### PR TITLE
20309 - Startup should run always in a fresh process

### DIFF
--- a/src/System-BasicCommandLineHandler.package/BasicCommandLineHandler.class/instance/activate.st
+++ b/src/System-BasicCommandLineHandler.package/BasicCommandLineHandler.class/instance/activate.st
@@ -1,8 +1,10 @@
 activation
 activate
 	
-	[ self handleArgument: (self arguments 
+	[ [ self handleArgument: (self arguments 
 			ifEmpty: [ '' ] 
 			ifNotEmpty: [ :arguments| arguments first ])] 
 		on: Exit 
-		do: [ :exit | ^ self handleExit: exit ]
+		do: [ :exit | ^ self handleExit: exit ] ]
+			forkAt: Processor userSchedulingPriority
+			named: 'CommandLine handler process'

--- a/src/System-SessionManager.package/SessionManager.class/instance/launchSnapshot.andQuit..st
+++ b/src/System-SessionManager.package/SessionManager.class/instance/launchSnapshot.andQuit..st
@@ -1,0 +1,25 @@
+snapshot and quit
+launchSnapshot: save andQuit: quit
+	| isImageStarting snapshotResult |
+	ChangesLog default logSnapshot: save andQuit: quit.
+	
+	self currentSession stop: quit.	"Image not usable from here until the session is restarted!"
+	save
+		ifTrue: [
+					snapshotResult := Smalltalk snapshotPrimitive.	"<-- PC frozen here on image file"
+					isImageStarting := snapshotResult == true. ]
+		ifFalse: [ isImageStarting := false ].
+	(quit and: [ isImageStarting not ])
+		ifTrue: [ Smalltalk quitPrimitive ].
+
+	"create a new session object if we're booting"
+	isImageStarting ifTrue: [ self installNewSession ].
+
+	self currentSession start: isImageStarting.
+	snapshotResult 
+		ifNil: [ self error: 'Failed to write image file (disk full?)' ]
+		ifNotNil: [ 
+			SystemAnnouncer uniqueInstance snapshotDone: isImageStarting ].
+	
+	"We return the resuming state, which may be useful for users to know the state of the image"
+	^ isImageStarting

--- a/src/System-SessionManager.package/SessionManager.class/instance/snapshot.andQuit..st
+++ b/src/System-SessionManager.package/SessionManager.class/instance/snapshot.andQuit..st
@@ -1,25 +1,13 @@
 snapshot and quit
 snapshot: save andQuit: quit
-	| isImageStarting snapshotResult |
-	ChangesLog default logSnapshot: save andQuit: quit.
-	
-	self currentSession stop: quit.	"Image not usable from here until the session is restarted!"
-	save
-		ifTrue: [
-					snapshotResult := Smalltalk snapshotPrimitive.	"<-- PC frozen here on image file"
-					isImageStarting := snapshotResult == true. ]
-		ifFalse: [ isImageStarting := false ].
-	(quit and: [ isImageStarting not ])
-		ifTrue: [ Smalltalk quitPrimitive ].
-
-	"create a new session object if we're booting"
-	isImageStarting ifTrue: [ self installNewSession ].
-
-	self currentSession start: isImageStarting.
-	snapshotResult 
-		ifNil: [ self error: 'Failed to write image file (disk full?)' ]
-		ifNotNil: [ 
-			SystemAnnouncer uniqueInstance snapshotDone: isImageStarting ].
-	
-	"We return the resuming state, which may be useful for users to know the state of the image"
+	| isImageStarting wait |
+	"We do the snapshot in a separate process in maximum priority to have always a clean startup.
+	This process will be interrupted by the fork, and will be resumed as soon as the snapshot finishes.
+	We synchronize these processes in case both are in the same priority"
+	wait := Semaphore new.
+	[
+		isImageStarting := self launchSnapshot: save andQuit: quit.
+		wait signal
+	] forkAt: Processor highestPriority.
+	wait wait.
 	^ isImageStarting


### PR DESCRIPTION
Pharo starts right now each time in an old saved process. This means that executing a series of snapshot:andQuit: makes the stack grow.

A workaround to clean it is to save the image from a new process. But we should do that on each snapshot so we always start from a fresh clean process.

https://pharo.fogbugz.com/f/cases/20309/Startup-should-run-always-in-a-fresh-process

Retry of the PR: #196