### PR TITLE
20390 - Enforce Proper method categorization - Part 1 - SUnit

### DIFF
--- a/src/AST-Tests-Core.package/RBParseTreeRewriterTest.class/instance/setUp.st
+++ b/src/AST-Tests-Core.package/RBParseTreeRewriterTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 
 	rewriter := RBParseTreeRewriter new.

--- a/src/AST-Tests-Core.package/RBParseTreeSearcherTest.class/instance/setUp.st
+++ b/src/AST-Tests-Core.package/RBParseTreeSearcherTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-tests
+running
 setUp
 	searcher := RBParseTreeSearcher new.
 	

--- a/src/Collections-Tests.package/ArrayTest.class/instance/setUp.st
+++ b/src/Collections-Tests.package/ArrayTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 
 	

--- a/src/Collections-Tests.package/AssociationTest.class/instance/setUp.st
+++ b/src/Collections-Tests.package/AssociationTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 
 	a := 1 -> 'one'.

--- a/src/Collections-Tests.package/BagTest.class/instance/setUp.st
+++ b/src/Collections-Tests.package/BagTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 	empty := self speciesClass new.
 	nonEmpty := self speciesClass new

--- a/src/Collections-Tests.package/DictionaryTest.class/instance/setUp.st
+++ b/src/Collections-Tests.package/DictionaryTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 	emptyDict := self classToBeTested new.
 	nonEmptyDict := self classToBeTested new.

--- a/src/Collections-Tests.package/IntervalTest.class/instance/setUp.st
+++ b/src/Collections-Tests.package/IntervalTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 
 	empty := (1 to: 0).

--- a/src/Collections-Tests.package/MatrixTest.class/instance/setUp.st
+++ b/src/Collections-Tests.package/MatrixTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 	matrix1 := Matrix new: 2.
 	matrix1 at:1 at:1 put: 1.

--- a/src/Collections-Tests.package/OrderedCollectionTest.class/instance/setUp.st
+++ b/src/Collections-Tests.package/OrderedCollectionTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 
 	

--- a/src/Collections-Tests.package/SetTest.class/instance/setUp.st
+++ b/src/Collections-Tests.package/SetTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialize
+running
 setUp
 	empty := self classToBeTested  new.
 	full := self classToBeTested  with: 1 with: 2 with: 3 with: 4.

--- a/src/Collections-Tests.package/SortedCollectionTest.class/instance/setUp.st
+++ b/src/Collections-Tests.package/SortedCollectionTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 
 	nonEmpty := SortedCollection new.

--- a/src/Collections-Tests.package/StackTest.class/instance/setUp.st
+++ b/src/Collections-Tests.package/StackTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 
 	empty := Stack new.

--- a/src/Collections-Tests.package/StringTest.class/instance/setUp.st
+++ b/src/Collections-Tests.package/StringTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 	string := 'Hi, I am a String'.
 	emptyString := ''.

--- a/src/Collections-Tests.package/SymbolTest.class/instance/setUp.st
+++ b/src/Collections-Tests.package/SymbolTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 	emptySymbol := #''.
 	collectionSize4 := #abcd.

--- a/src/Collections-Tests.package/WeakKeyDictionaryTest.class/instance/setUp.st
+++ b/src/Collections-Tests.package/WeakKeyDictionaryTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 	keys := (1 to: 1000) collect:[:n| 'key', n asString].
 	dict := WeakKeyDictionary new.

--- a/src/Compression-Tests.package/ZipArchiveTest.class/instance/setUp.st
+++ b/src/Compression-Tests.package/ZipArchiveTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-tests
+running
 setUp
 
 	| now |

--- a/src/Compression-Tests.package/ZipArchiveTest.class/instance/tearDown.st
+++ b/src/Compression-Tests.package/ZipArchiveTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-tests
+running
 tearDown
 
 	fileToZip ensureDelete.

--- a/src/Compression-Tests.package/monticello.meta/categories.st
+++ b/src/Compression-Tests.package/monticello.meta/categories.st
@@ -1,3 +1,3 @@
 SystemOrganization addCategory: #'Compression-Tests'!
-SystemOrganization addCategory: 'Compression-Tests-Archive'!
-SystemOrganization addCategory: 'Compression-Tests-Streams'!
+SystemOrganization addCategory: #'Compression-Tests-Archive'!
+SystemOrganization addCategory: #'Compression-Tests-Streams'!

--- a/src/FileSystem-Tests-Core.package/AbstractEnumerationVisitorTest.class/instance/setUp.st
+++ b/src/FileSystem-Tests-Core.package/AbstractEnumerationVisitorTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-as yet unclassified
+running
 setUp
 	super setUp.
 	self setUpGreek.

--- a/src/FileSystem-Tests-Core.package/FileSystemTest.class/instance/setUp.st
+++ b/src/FileSystem-Tests-Core.package/FileSystemTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialize-release
+running
 setUp
 	filesystem := self createFileSystem.
 	toDelete := OrderedCollection new.

--- a/src/FileSystem-Tests-Core.package/FileSystemTest.class/instance/tearDown.st
+++ b/src/FileSystem-Tests-Core.package/FileSystemTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-initialize-release
+running
 tearDown
 	toDelete
 		select: [ :path | filesystem exists: path ]

--- a/src/GT-SUnitDebugger.package/GTSUnitExampleWithProblematicSetUpTest.class/instance/setUp.st
+++ b/src/GT-SUnitDebugger.package/GTSUnitExampleWithProblematicSetUpTest.class/instance/setUp.st
@@ -1,3 +1,3 @@
-setup
+running
 setUp
 	42 messageThatIsNotUnderstood

--- a/src/GT-SUnitDebugger.package/GTSUnitExampleWithSetUpAndNoTearDownTest.class/instance/setUp.st
+++ b/src/GT-SUnitDebugger.package/GTSUnitExampleWithSetUpAndNoTearDownTest.class/instance/setUp.st
@@ -1,3 +1,3 @@
-setup
+running
 setUp
 	a := 42.

--- a/src/GT-SUnitDebugger.package/GTSUnitExampleWithSetUpAndTearDownTest.class/instance/setUp.st
+++ b/src/GT-SUnitDebugger.package/GTSUnitExampleWithSetUpAndTearDownTest.class/instance/setUp.st
@@ -1,3 +1,3 @@
-setup
+running
 setUp
 	a := 42.

--- a/src/GT-SUnitDebugger.package/GTSUnitExampleWithSetUpAndTearDownTest.class/instance/tearDown.st
+++ b/src/GT-SUnitDebugger.package/GTSUnitExampleWithSetUpAndTearDownTest.class/instance/tearDown.st
@@ -1,3 +1,3 @@
-setup
+running
 tearDown
 	a := nil

--- a/src/GT-Tests-Spotter.package/GTSpotterSmokeTest.class/instance/tearDown.st
+++ b/src/GT-Tests-Spotter.package/GTSpotterSmokeTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-as yet unclassified
+running
 tearDown
 	super tearDown.
 	

--- a/src/GT-Tests-Spotter.package/monticello.meta/categories.st
+++ b/src/GT-Tests-Spotter.package/monticello.meta/categories.st
@@ -1,6 +1,6 @@
 SystemOrganization addCategory: #'GT-Tests-Spotter'!
-SystemOrganization addCategory: 'GT-Tests-Spotter-Exceptions'!
-SystemOrganization addCategory: 'GT-Tests-Spotter-Exceptions-Mocks'!
-SystemOrganization addCategory: 'GT-Tests-Spotter-Scripting'!
-SystemOrganization addCategory: 'GT-Tests-Spotter-Scripting-Mocks'!
-SystemOrganization addCategory: 'GT-Tests-Spotter-SettingBrowser'!
+SystemOrganization addCategory: #'GT-Tests-Spotter-Exceptions'!
+SystemOrganization addCategory: #'GT-Tests-Spotter-Exceptions-Mocks'!
+SystemOrganization addCategory: #'GT-Tests-Spotter-Scripting'!
+SystemOrganization addCategory: #'GT-Tests-Spotter-Scripting-Mocks'!
+SystemOrganization addCategory: #'GT-Tests-Spotter-SettingBrowser'!

--- a/src/Glamour-Tests-Core.package/GLMAnnouncementPropagationTest.class/instance/setUp.st
+++ b/src/Glamour-Tests-Core.package/GLMAnnouncementPropagationTest.class/instance/setUp.st
@@ -1,3 +1,3 @@
-setup
+running
 setUp
 	GLMLogger instance: GLMMemoryLogger new

--- a/src/Glamour-Tests-Core.package/GLMAnnouncementPropagationTest.class/instance/tearDown.st
+++ b/src/Glamour-Tests-Core.package/GLMAnnouncementPropagationTest.class/instance/tearDown.st
@@ -1,3 +1,3 @@
-setup
+running
 tearDown
 	GLMLogger reset

--- a/src/Glamour-Tests-Core.package/GLMExplicitBrowserCopyTest.class/instance/setUp.st
+++ b/src/Glamour-Tests-Core.package/GLMExplicitBrowserCopyTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-tests
+running
 setUp
 	| pane1 pane2 transmission1 transmission2 | 
 	browser := GLMExplicitBrowser new. 

--- a/src/Glamour-Tests-Core.package/GLMTreePresentationTest.class/instance/setUp.st
+++ b/src/Glamour-Tests-Core.package/GLMTreePresentationTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-tests
+running
 setUp
 	pane := GLMPane named: 'test'.
 	presentation := GLMTreePresentation new.

--- a/src/Glamour-Tests-Morphic.package/GLMMorphicTest.class/instance/tearDown.st
+++ b/src/Glamour-Tests-Morphic.package/GLMMorphicTest.class/instance/tearDown.st
@@ -1,3 +1,3 @@
-setup - tear down
+running
 tearDown
 	window ifNotNil: [window delete]

--- a/src/Glamour-Tests-Morphic.package/GLMUpdateMorphicTest.class/instance/setUp.st
+++ b/src/Glamour-Tests-Morphic.package/GLMUpdateMorphicTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-tests
+running
 setUp
 	announcer := Announcer new.
 	entity := OrderedCollection with: 1 with: 2 with: 3.

--- a/src/Glamour-Tests-Morphic.package/LazyTabGroupTest.class/instance/setUp.st
+++ b/src/Glamour-Tests-Morphic.package/LazyTabGroupTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup - tear down
+running
 setUp
 	tabs := LazyTabGroupMorph new.
 	tabs addLazyPage: (PanelMorph new fillStyle: (SolidFillStyle color: Color red)) label: 'one'.

--- a/src/Glamour-Tests-Morphic.package/LazyTabGroupTest.class/instance/tearDown.st
+++ b/src/Glamour-Tests-Morphic.package/LazyTabGroupTest.class/instance/tearDown.st
@@ -1,3 +1,3 @@
-setup - tear down
+running
 tearDown
 	window ifNotNil: [window delete]

--- a/src/Graphics-Tests.package/PNGReadWriterTest.class/instance/setUp.st
+++ b/src/Graphics-Tests.package/PNGReadWriterTest.class/instance/setUp.st
@@ -1,3 +1,3 @@
-helpers
+running
 setUp
 	fileName := nil.

--- a/src/Graphics-Tests.package/PNGReadWriterTest.class/instance/tearDown.st
+++ b/src/Graphics-Tests.package/PNGReadWriterTest.class/instance/tearDown.st
@@ -1,3 +1,3 @@
-helpers
+running
 tearDown
 	World changed.

--- a/src/Graphics-Tests.package/RectangleTest.class/instance/setUp.st
+++ b/src/Graphics-Tests.package/RectangleTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup-teardown
+running
 setUp
 	emptyRectangle := 0 @ 0 corner: 0 @ 0.
 	rectangle1 := 10@10 corner:20@20

--- a/src/Graphics-Tests.package/monticello.meta/categories.st
+++ b/src/Graphics-Tests.package/monticello.meta/categories.st
@@ -1,3 +1,3 @@
 SystemOrganization addCategory: #'Graphics-Tests'!
-SystemOrganization addCategory: 'Graphics-Tests-Files'!
-SystemOrganization addCategory: 'Graphics-Tests-Primitives'!
+SystemOrganization addCategory: #'Graphics-Tests-Files'!
+SystemOrganization addCategory: #'Graphics-Tests-Primitives'!

--- a/src/JobsTests.package/JobTest.class/instance/tearDown.st
+++ b/src/JobsTests.package/JobTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-tests
+running
 tearDown
 
 	Smalltalk globals at: #SystemProgressMorph ifPresent: [:spm | 

--- a/src/Kernel-Tests.package/BlockClosureTest.class/instance/setUp.st
+++ b/src/Kernel-Tests.package/BlockClosureTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 	super setUp.
 	aBlockContext := [100@100 corner: 200@200].

--- a/src/Kernel-Tests.package/ClassTest.class/instance/setUp.st
+++ b/src/Kernel-Tests.package/ClassTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 	className := #TUTU.
 	renamedName := #RenamedTUTU.

--- a/src/Kernel-Tests.package/ClassTest.class/instance/tearDown.st
+++ b/src/Kernel-Tests.package/ClassTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-setup
+running
 tearDown
 	self deleteClass.
 	self deleteRenamedClass.

--- a/src/Kernel-Tests.package/LocalRecursionStopperTest.class/instance/setUp.st
+++ b/src/Kernel-Tests.package/LocalRecursionStopperTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-as yet unclassified
+running
 setUp
 
 	value := 0

--- a/src/Kernel-Tests.package/LocalRecursionStopperTest.class/instance/tearDown.st
+++ b/src/Kernel-Tests.package/LocalRecursionStopperTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-as yet unclassified
+running
 tearDown
 
 	fork ifNotNil: [ fork terminate. fork := nil ].

--- a/src/Kernel-Tests.package/RecursionStopperTest.class/instance/setUp.st
+++ b/src/Kernel-Tests.package/RecursionStopperTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-as yet unclassified
+running
 setUp
 
 	value := 0

--- a/src/Kernel-Tests.package/RecursionStopperTest.class/instance/tearDown.st
+++ b/src/Kernel-Tests.package/RecursionStopperTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-as yet unclassified
+running
 tearDown
 
 	fork ifNotNil: [ fork terminate. fork := nil ].

--- a/src/Kernel-Tests.package/TimeTest.class/instance/setUp.st
+++ b/src/Kernel-Tests.package/TimeTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 
 	localTimeZoneToRestore := DateAndTime localTimeZone.

--- a/src/Kernel-Tests.package/TimeTest.class/instance/tearDown.st
+++ b/src/Kernel-Tests.package/TimeTest.class/instance/tearDown.st
@@ -1,3 +1,3 @@
-setup
+running
 tearDown
 	DateAndTime localTimeZone: localTimeZoneToRestore.

--- a/src/Monticello-Tests.package/MCMczInstallerTest.class/instance/setUp.st
+++ b/src/Monticello-Tests.package/MCMczInstallerTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-as yet unclassified
+running
 setUp
 	expected := self mockVersion.
 	self change: #one toReturn: 2.

--- a/src/Monticello-Tests.package/MCMczInstallerTest.class/instance/tearDown.st
+++ b/src/Monticello-Tests.package/MCMczInstallerTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-as yet unclassified
+running
 tearDown
 	expected snapshot updatePackage: self mockPackage.
 	self deleteFile.

--- a/src/Monticello-Tests.package/MCStWriterTest.class/instance/setUp.st
+++ b/src/Monticello-Tests.package/MCStWriterTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-testing
+running
 setUp
 	stream := String new writeStream.
 	writer := MCStWriter on: stream.

--- a/src/Multilingual-Tests.package/MultiByteFileStreamTest.class/instance/tearDown.st
+++ b/src/Multilingual-Tests.package/MultiByteFileStreamTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-testing
+running
 tearDown
 	'foobug6933' asFileReference ensureDelete.
 	self lineEndTestFile asFileReference ensureDelete.

--- a/src/Multilingual-Tests.package/monticello.meta/categories.st
+++ b/src/Multilingual-Tests.package/monticello.meta/categories.st
@@ -1,3 +1,3 @@
 SystemOrganization addCategory: #'Multilingual-Tests'!
-SystemOrganization addCategory: 'Multilingual-Tests-OtherLanguages'!
-SystemOrganization addCategory: 'Multilingual-Tests-TextConversion'!
+SystemOrganization addCategory: #'Multilingual-Tests-OtherLanguages'!
+SystemOrganization addCategory: #'Multilingual-Tests-TextConversion'!

--- a/src/NECompletion-Tests.package/NECControllerTest.class/instance/setUp.st
+++ b/src/NECompletion-Tests.package/NECControllerTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialize
+running
 setUp
 	"Setting up code for NECControllerTest"
 

--- a/src/NECompletion-Tests.package/NECControllerTest.class/instance/tearDown.st
+++ b/src/NECompletion-Tests.package/NECControllerTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-initialize
+running
 tearDown
 	"Tearing down code for NECControllerTest"
 

--- a/src/NECompletion-Tests.package/NECOverrideModelTest.class/instance/setUp.st
+++ b/src/NECompletion-Tests.package/NECOverrideModelTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-testing
+running
 setUp
 	model := NECOverrideModel class: NECTestClass.
 	model toggleExpand

--- a/src/NECompletion-Tests.package/NECUntypedModelTest.class/instance/setUp.st
+++ b/src/NECompletion-Tests.package/NECUntypedModelTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-tests
+running
 setUp
 	prefValueCase := NECPreferences caseSensitive.
 	NECPreferences caseSensitive: true

--- a/src/NECompletion-Tests.package/NECUntypedModelTest.class/instance/tearDown.st
+++ b/src/NECompletion-Tests.package/NECUntypedModelTest.class/instance/tearDown.st
@@ -1,3 +1,3 @@
-tests
+running
 tearDown
 	NECPreferences caseSensitive: prefValueCase

--- a/src/Nautilus-Tests.package/AbstractNautilusUITest.class/instance/setUp.st
+++ b/src/Nautilus-Tests.package/AbstractNautilusUITest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 	"Setting up code for AbstractNautilusUITest"
 

--- a/src/Nautilus-Tests.package/NautilusUITest.class/instance/setUp.st
+++ b/src/Nautilus-Tests.package/NautilusUITest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 	"Setting up code for NautilusUITest"
 

--- a/src/Nautilus-Tests.package/NautilusUITest.class/instance/tearDown.st
+++ b/src/Nautilus-Tests.package/NautilusUITest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-initialization
+running
 tearDown
 	"Tearing down code for NautilusUITest"
 

--- a/src/Nautilus-Tests.package/PackageTreeNautilusTest.class/instance/setUp.st
+++ b/src/Nautilus-Tests.package/PackageTreeNautilusTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-tests
+running
 setUp
 	super setUp.
 	self compiledMethod: (NautilusUI>>#addClassIn:).

--- a/src/Nautilus-Tests.package/SortHierarchicallyTests.class/instance/setUp.st
+++ b/src/Nautilus-Tests.package/SortHierarchicallyTests.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 
 	completeTree := {String . ByteString . Symbol . ByteSymbol . WideSymbol . WideString} .

--- a/src/Network-Tests.package/Base64MimeConverterTest.class/instance/setUp.st
+++ b/src/Network-Tests.package/Base64MimeConverterTest.class/instance/setUp.st
@@ -1,3 +1,3 @@
-setup
+running
 setUp
 	message := 'Hi There!' readStream.

--- a/src/Network-Tests.package/SocketStreamTest.class/instance/setUp.st
+++ b/src/Network-Tests.package/SocketStreamTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 	| listener clientSocket serverSocket |
 	listener := Socket newTCP.

--- a/src/Network-Tests.package/SocketStreamTest.class/instance/tearDown.st
+++ b/src/Network-Tests.package/SocketStreamTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-setup
+running
 tearDown
 	clientStream ifNotNil:[clientStream destroy].
 	serverStream ifNotNil:[serverStream destroy].

--- a/src/Network-Tests.package/SocketTest.class/instance/setUp.st
+++ b/src/Network-Tests.package/SocketTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 
 	listenerSocket := Socket newTCP listenOn: self listenerPort backlogSize: 4 interface: self listenerAddress.

--- a/src/Network-Tests.package/SocketTest.class/instance/tearDown.st
+++ b/src/Network-Tests.package/SocketTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-setup
+running
 tearDown
 
 	listenerSocket ifNotNil:[listenerSocket destroy].

--- a/src/Network-Tests.package/UUIDGeneratorTests.class/instance/setUp.st
+++ b/src/Network-Tests.package/UUIDGeneratorTests.class/instance/setUp.st
@@ -1,3 +1,3 @@
-setup
+running
 setUp
 	generator := UUIDGenerator new

--- a/src/OmbuTests.package/OmSessionStoreNameStrategyTest.class/instance/setUp.st
+++ b/src/OmbuTests.package/OmSessionStoreNameStrategyTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 
 	strategy := self strategyClass new

--- a/src/OmbuTests.package/OmSessionStoreNameStrategyTest.class/instance/tearDown.st
+++ b/src/OmbuTests.package/OmSessionStoreNameStrategyTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-initialization
+running
 tearDown
 
 	self directory ensureDeleteAll 

--- a/src/OpalCompiler-Tests.package/OCArrayLiteralTest.class/instance/tearDown.st
+++ b/src/OpalCompiler-Tests.package/OCArrayLiteralTest.class/instance/tearDown.st
@@ -1,3 +1,3 @@
-initialization
+running
 tearDown
 	self class removeSelector: #array

--- a/src/OpalCompiler-Tests.package/OCBytecodeDecompilerTest.class/instance/setUp.st
+++ b/src/OpalCompiler-Tests.package/OCBytecodeDecompilerTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setUp - tearDown
+running
 setUp
 	currentCompiler := SmalltalkImage compilerClass.
 	SmalltalkImage compilerClass: OpalCompiler.

--- a/src/OpalCompiler-Tests.package/OCBytecodeDecompilerTest.class/instance/tearDown.st
+++ b/src/OpalCompiler-Tests.package/OCBytecodeDecompilerTest.class/instance/tearDown.st
@@ -1,3 +1,3 @@
-setUp - tearDown
+running
 tearDown
 	SmalltalkImage compilerClass: currentCompiler.

--- a/src/OpalCompiler-Tests.package/OCCompilerExceptionsTest.class/instance/setUp.st
+++ b/src/OpalCompiler-Tests.package/OCCompilerExceptionsTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setUp
+running
 setUp
 
 	currentCompiler := SmalltalkImage compilerClass.

--- a/src/OpalCompiler-Tests.package/OCCompilerExceptionsTest.class/instance/tearDown.st
+++ b/src/OpalCompiler-Tests.package/OCCompilerExceptionsTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-setUp
+running
 tearDown
 	self removeGeneratedMethods.
 	SmalltalkImage compilerClass: currentCompiler.

--- a/src/OpalCompiler-Tests.package/OCCompilerNotifyingTest.class/instance/setUp.st
+++ b/src/OpalCompiler-Tests.package/OCCompilerNotifyingTest.class/instance/setUp.st
@@ -1,3 +1,3 @@
-initialize-release
+running
 setUp
 	failure := Object new.

--- a/src/OpalCompiler-Tests.package/monticello.meta/categories.st
+++ b/src/OpalCompiler-Tests.package/monticello.meta/categories.st
@@ -1,8 +1,8 @@
 SystemOrganization addCategory: #'OpalCompiler-Tests'!
-SystemOrganization addCategory: 'OpalCompiler-Tests-AST'!
-SystemOrganization addCategory: 'OpalCompiler-Tests-Bytecode'!
-SystemOrganization addCategory: 'OpalCompiler-Tests-FromOld'!
-SystemOrganization addCategory: 'OpalCompiler-Tests-IR'!
-SystemOrganization addCategory: 'OpalCompiler-Tests-Misc'!
-SystemOrganization addCategory: 'OpalCompiler-Tests-Plugins'!
-SystemOrganization addCategory: 'OpalCompiler-Tests-Source'!
+SystemOrganization addCategory: #'OpalCompiler-Tests-AST'!
+SystemOrganization addCategory: #'OpalCompiler-Tests-Bytecode'!
+SystemOrganization addCategory: #'OpalCompiler-Tests-FromOld'!
+SystemOrganization addCategory: #'OpalCompiler-Tests-IR'!
+SystemOrganization addCategory: #'OpalCompiler-Tests-Misc'!
+SystemOrganization addCategory: #'OpalCompiler-Tests-Plugins'!
+SystemOrganization addCategory: #'OpalCompiler-Tests-Source'!

--- a/src/RPackage-Tests.package/RPackageCompleteSetupButForModificationTest.class/instance/setUp.st
+++ b/src/RPackage-Tests.package/RPackageCompleteSetupButForModificationTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 	super setUp.
 	p1 := self createNewPackageNamed: self p1Name.

--- a/src/RPackage-Tests.package/RPackageIncrementalTest.class/instance/setUp.st
+++ b/src/RPackage-Tests.package/RPackageIncrementalTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 	super setUp.
 	Author fullName ifNil: [Author fullName: 'RPackage'].

--- a/src/RPackage-Tests.package/RPackageIncrementalTest.class/instance/tearDown.st
+++ b/src/RPackage-Tests.package/RPackageIncrementalTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-setup
+running
 tearDown
 	
 	| logging |

--- a/src/RPackage-Tests.package/RPackageMCSynchronisationTest.class/instance/setUp.st
+++ b/src/RPackage-Tests.package/RPackageMCSynchronisationTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp 
 	super setUp.
 	

--- a/src/RPackage-Tests.package/RPackageMCSynchronisationTest.class/instance/tearDown.st
+++ b/src/RPackage-Tests.package/RPackageMCSynchronisationTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-setup
+running
 tearDown
 	MCWorkingCopy removeDependent: self emptyOrganizer.
 	self cleanClassesPackagesAndCategories.

--- a/src/RPackage-Tests.package/RPackageOrganizerTest.class/instance/setUp.st
+++ b/src/RPackage-Tests.package/RPackageOrganizerTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 	super setUp.
 	createdClasses := OrderedCollection new.

--- a/src/RPackage-Tests.package/RPackageOrganizerTest.class/instance/tearDown.st
+++ b/src/RPackage-Tests.package/RPackageOrganizerTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-setup
+running
 tearDown 
 	
 	Author fullName: previousAuthor.

--- a/src/RPackage-Tests.package/RPackageReadOnlyCompleteSetupTest.class/instance/setUp.st
+++ b/src/RPackage-Tests.package/RPackageReadOnlyCompleteSetupTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 
 	super setUp.

--- a/src/RPackage-Tests.package/RPackageTraitTest.class/instance/setUp.st
+++ b/src/RPackage-Tests.package/RPackageTraitTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setup
+running
 setUp
 
 	super setUp.

--- a/src/Refactoring-Tests-Core.package/RBAbstractClassVariableTest.class/instance/setUp.st
+++ b/src/Refactoring-Tests-Core.package/RBAbstractClassVariableTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-set up
+running
 setUp
 	super setUp.
 	model := self abstractVariableTestData.

--- a/src/Refactoring-Tests-Core.package/RBAbstractInstanceVariableTest.class/instance/setUp.st
+++ b/src/Refactoring-Tests-Core.package/RBAbstractInstanceVariableTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-set up
+running
 setUp
 	super setUp.
 	model := self abstractVariableTestData.

--- a/src/Refactoring-Tests-Core.package/RBAddClassTest.class/instance/setUp.st
+++ b/src/Refactoring-Tests-Core.package/RBAddClassTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-set up
+running
 setUp
 	super setUp.
 	model := self abstractVariableTestData.

--- a/src/Refactoring-Tests-Core.package/RBAddClassVariableTest.class/instance/setUp.st
+++ b/src/Refactoring-Tests-Core.package/RBAddClassVariableTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-set up
+running
 setUp
 	super setUp.
 	model := self abstractVariableTestData.

--- a/src/Refactoring-Tests-Core.package/RBAddInstanceVariableTest.class/instance/setUp.st
+++ b/src/Refactoring-Tests-Core.package/RBAddInstanceVariableTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-set up
+running
 setUp
 	super setUp.
 	model := self abstractVariableTestData.

--- a/src/Refactoring-Tests-Core.package/RBAddMethodTest.class/instance/setUp.st
+++ b/src/Refactoring-Tests-Core.package/RBAddMethodTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-set up
+running
 setUp
 	super setUp.
 	model := self abstractVariableTestData.

--- a/src/Refactoring-Tests-Core.package/RBAddParameterTest.class/instance/setUp.st
+++ b/src/Refactoring-Tests-Core.package/RBAddParameterTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-set up
+running
 setUp
 	super setUp.
 	model := self abstractVariableTestData.

--- a/src/Refactoring-Tests-Core.package/RBChildrenToSiblingsTest.class/instance/setUp.st
+++ b/src/Refactoring-Tests-Core.package/RBChildrenToSiblingsTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-set up
+running
 setUp
 	super setUp.
 	model := Smalltalk compiler evaluate: self childrenToSiblingTestData

--- a/src/Refactoring-Tests-Core.package/RBClassTest.class/instance/setUp.st
+++ b/src/Refactoring-Tests-Core.package/RBClassTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-set up
+running
 setUp
 	| st |
 	super setUp.

--- a/src/Refactoring-Tests-Core.package/RBCreateAccessorsForVariableTest.class/instance/setUp.st
+++ b/src/Refactoring-Tests-Core.package/RBCreateAccessorsForVariableTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-set up
+running
 setUp
 	super setUp.
 	model := self abstractVariableTestData.

--- a/src/Refactoring-Tests-Core.package/RBRefactoringTest.class/instance/setUp.st
+++ b/src/Refactoring-Tests-Core.package/RBRefactoringTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-set up
+running
 setUp
 	super setUp.
 	manager := RBRefactoringManager classVarNamed: #Instance.

--- a/src/Refactoring-Tests-Core.package/RBRefactoringTest.class/instance/tearDown.st
+++ b/src/Refactoring-Tests-Core.package/RBRefactoringTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-set up
+running
 tearDown
 	super tearDown.
 	RBRefactoringManager instance release.

--- a/src/Refactoring-Tests-Core.package/RBSearchTest.class/instance/setUp.st
+++ b/src/Refactoring-Tests-Core.package/RBSearchTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-accessing
+running
 setUp
 	super setUp.
 	classSearches := Dictionary new.

--- a/src/Refactoring-Tests-Core.package/RBTemporaryToInstanceVariableTest.class/instance/setUp.st
+++ b/src/Refactoring-Tests-Core.package/RBTemporaryToInstanceVariableTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-set up
+running
 setUp
 	super setUp.
 	model := self abstractVariableTestData.

--- a/src/Refactoring-Tests-Core.package/monticello.meta/categories.st
+++ b/src/Refactoring-Tests-Core.package/monticello.meta/categories.st
@@ -1,2 +1,2 @@
 SystemOrganization addCategory: #'Refactoring-Tests-Core'!
-SystemOrganization addCategory: 'Refactoring-Tests-Core-Data'!
+SystemOrganization addCategory: #'Refactoring-Tests-Core-Data'!

--- a/src/Reflectivity-Tools-Tests.package/BreakpointTest.class/instance/setUp.st
+++ b/src/Reflectivity-Tools-Tests.package/BreakpointTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 	super setUp.
 	cls := self newDummyClass.

--- a/src/Reflectivity-Tools-Tests.package/BreakpointTest.class/instance/tearDown.st
+++ b/src/Reflectivity-Tools-Tests.package/BreakpointTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-initialization
+running
 tearDown
 	| pkg |
 	super tearDown.

--- a/src/ReleaseTests.package/ProperMethodCategorizationTest.class/README.md
+++ b/src/ReleaseTests.package/ProperMethodCategorizationTest.class/README.md
@@ -1,0 +1,1 @@
+Tests to enforce proper categorization

--- a/src/ReleaseTests.package/ProperMethodCategorizationTest.class/instance/assureAll.areCategorizedIn.whenSubclassOf..st
+++ b/src/ReleaseTests.package/ProperMethodCategorizationTest.class/instance/assureAll.areCategorizedIn.whenSubclassOf..st
@@ -1,0 +1,10 @@
+utilities
+assureAll: selector areCategorizedIn: category whenSubclassOf: aClass
+	| violating |
+	violating := OrderedCollection new.
+	aClass allSubclassesDo: [:cls | cls methods do: [:m |
+			(m selector = selector and: [ m category ~= category ])
+				ifTrue: [ violating add: m -> m category ]
+			]
+		 ].
+	self assert: violating isEmpty description: ('Subclasses of {1} should have #{2} methods in category {3}' format: { aClass asString. selector. category })

--- a/src/ReleaseTests.package/ProperMethodCategorizationTest.class/instance/testRunCaseMethodInSUnitTestsNeedsToBeInRunningProtocol.st
+++ b/src/ReleaseTests.package/ProperMethodCategorizationTest.class/instance/testRunCaseMethodInSUnitTestsNeedsToBeInRunningProtocol.st
@@ -1,0 +1,5 @@
+tests - sunit
+testRunCaseMethodInSUnitTestsNeedsToBeInRunningProtocol
+	"The #tearDown method in SUnit test classes should be in method protocol 'running'"
+	
+	self assureAll: #runCase areCategorizedIn: #running  whenSubclassOf: TestCase

--- a/src/ReleaseTests.package/ProperMethodCategorizationTest.class/instance/testSetUpMethodInSUnitTestsNeedsToBeInRunningProtocol.st
+++ b/src/ReleaseTests.package/ProperMethodCategorizationTest.class/instance/testSetUpMethodInSUnitTestsNeedsToBeInRunningProtocol.st
@@ -1,0 +1,5 @@
+tests - sunit
+testSetUpMethodInSUnitTestsNeedsToBeInRunningProtocol
+	"The #setUp method in SUnit test classes should be in method protocol 'running'"
+
+	self assureAll: #setUp areCategorizedIn: #running  whenSubclassOf: TestCase

--- a/src/ReleaseTests.package/ProperMethodCategorizationTest.class/instance/testTearDownMethodInSUnitTestsNeedsToBeInRunningProtocol.st
+++ b/src/ReleaseTests.package/ProperMethodCategorizationTest.class/instance/testTearDownMethodInSUnitTestsNeedsToBeInRunningProtocol.st
@@ -1,0 +1,5 @@
+tests - sunit
+testTearDownMethodInSUnitTestsNeedsToBeInRunningProtocol
+	"The #tearDown method in SUnit test classes should be in method protocol 'running'"
+	
+	self assureAll: #tearDown areCategorizedIn: #running  whenSubclassOf: TestCase

--- a/src/ReleaseTests.package/ProperMethodCategorizationTest.class/properties.json
+++ b/src/ReleaseTests.package/ProperMethodCategorizationTest.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "TorstenBergmann 9/7/2017 12:10",
+	"super" : "TestCase",
+	"category" : "ReleaseTests-Categorization",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "ProperMethodCategorizationTest",
+	"type" : "normal"
+}

--- a/src/ReleaseTests.package/ReleaseTest.class/properties.json
+++ b/src/ReleaseTests.package/ReleaseTest.class/properties.json
@@ -1,7 +1,7 @@
 {
 	"commentStamp" : "<historical>",
 	"super" : "TestCase",
-	"category" : "ReleaseTests",
+	"category" : "ReleaseTests-Release",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],

--- a/src/ReleaseTests.package/monticello.meta/categories.st
+++ b/src/ReleaseTests.package/monticello.meta/categories.st
@@ -1,1 +1,3 @@
 SystemOrganization addCategory: #ReleaseTests!
+SystemOrganization addCategory: #'ReleaseTests-Categorization'!
+SystemOrganization addCategory: #'ReleaseTests-Release'!

--- a/src/Renraku-Test.package/ReSmokeExceptionStrategyTest.class/instance/setUp.st
+++ b/src/Renraku-Test.package/ReSmokeExceptionStrategyTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 	super setUp.
 

--- a/src/Renraku-Test.package/ReSmokeExceptionStrategyTest.class/instance/tearDown.st
+++ b/src/Renraku-Test.package/ReSmokeExceptionStrategyTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-initialization
+running
 tearDown
 
 	brokenRule removeFromSystem.

--- a/src/Renraku-Test.package/RenrakuGlobalBanningTest.class/instance/setUp.st
+++ b/src/Renraku-Test.package/RenrakuGlobalBanningTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 	super setUp.
 	oldRulesSettings := Dictionary new.

--- a/src/Renraku-Test.package/RenrakuGlobalBanningTest.class/instance/tearDown.st
+++ b/src/Renraku-Test.package/RenrakuGlobalBanningTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-initialization
+running
 tearDown
 	oldRulesSettings keysAndValuesDo: [ :rule :setting |
 		rule enabled: setting ].

--- a/src/SUnit-Tests.package/ClassFactoryForTestCaseTest.class/instance/setUp.st
+++ b/src/SUnit-Tests.package/ClassFactoryForTestCaseTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setUp-tearDown
+running
 setUp
 	super setUp.
 	factory := ClassFactoryForTestCase new

--- a/src/SUnit-Tests.package/ClassFactoryForTestCaseTest.class/instance/tearDown.st
+++ b/src/SUnit-Tests.package/ClassFactoryForTestCaseTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-setUp-tearDown
+running
 tearDown
 	super tearDown.
 	factory cleanUp

--- a/src/SUnit-Tests.package/ClassFactoryWithOrganizationTest.class/instance/setUp.st
+++ b/src/SUnit-Tests.package/ClassFactoryWithOrganizationTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setUp-tearDown
+running
 setUp
 	| environment |
 	super setUp.

--- a/src/SUnit-Tests.package/monticello.meta/categories.st
+++ b/src/SUnit-Tests.package/monticello.meta/categories.st
@@ -1,2 +1,2 @@
 SystemOrganization addCategory: #'SUnit-Tests'!
-SystemOrganization addCategory: 'SUnit-Tests-Core'!
+SystemOrganization addCategory: #'SUnit-Tests-Core'!

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionTest.class/instance/setUp.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialize-release
+running
 setUp
 	super setUp.
 	emptyClass  := self createClass: #TestWithAccessors.

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionTest.class/instance/tearDown.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-initialize-release
+running
 tearDown
 	super tearDown.
 	self removeClass: emptyClass .

--- a/src/Spec-Tests.package/SpecInterpreterTest.class/instance/setUp.st
+++ b/src/Spec-Tests.package/SpecInterpreterTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 	"Setting up code for SpecInterpreterTest"
 

--- a/src/Spec-Tests.package/SpecInterpreterTest.class/instance/tearDown.st
+++ b/src/Spec-Tests.package/SpecInterpreterTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-initialization
+running
 tearDown
 	"Tearing down code for SpecInterpreterTest"
 

--- a/src/System-SessionManager-Tests.package/SessionErrorHandlingTest.class/instance/setUp.st
+++ b/src/System-SessionManager-Tests.package/SessionErrorHandlingTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-tests
+running
 setUp
 	manager := SessionManager new.
 	session := self newTestSessionfor: manager.

--- a/src/System-SessionManager-Tests.package/SessionManagerRegistrationOrderTest.class/instance/setUp.st
+++ b/src/System-SessionManager-Tests.package/SessionManagerRegistrationOrderTest.class/instance/setUp.st
@@ -1,3 +1,3 @@
-tests
+running
 setUp
 	manager := SessionManager new

--- a/src/Tests.package/SystemNavigationTest.class/instance/setUp.st
+++ b/src/Tests.package/SystemNavigationTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-setUp-tearDown
+running
 setUp
 	super setUp. 
 	

--- a/src/Tests.package/SystemNavigationTest.class/instance/tearDown.st
+++ b/src/Tests.package/SystemNavigationTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-setUp-tearDown
+running
 tearDown
 	super tearDown.
 	self classFactory cleanUp. 

--- a/src/Text-Tests.package/TextAlignmentTest.class/instance/setUp.st
+++ b/src/Text-Tests.package/TextAlignmentTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 	super setUp.
 	prototypes add: TextAlignment centered;

--- a/src/Text-Tests.package/TextEmphasisTest.class/instance/setUp.st
+++ b/src/Text-Tests.package/TextEmphasisTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 	super setUp.
 	prototypes add: TextEmphasis bold;

--- a/src/Text-Tests.package/TextFontChangeTest.class/instance/setUp.st
+++ b/src/Text-Tests.package/TextFontChangeTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 	"create the prototypes for testing"
 	super setUp.

--- a/src/Text-Tests.package/TextFontReferenceTest.class/instance/setUp.st
+++ b/src/Text-Tests.package/TextFontReferenceTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-tests
+running
 setUp
 	super setUp.
 	prototypes

--- a/src/Text-Tests.package/TextKernTest.class/instance/setUp.st
+++ b/src/Text-Tests.package/TextKernTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-tests
+running
 setUp
 	super setUp.
 	prototypes

--- a/src/Text-Tests.package/monticello.meta/categories.st
+++ b/src/Text-Tests.package/monticello.meta/categories.st
@@ -1,2 +1,2 @@
 SystemOrganization addCategory: #'Text-Tests'!
-SystemOrganization addCategory: 'Text-Tests-Fonts'!
+SystemOrganization addCategory: #'Text-Tests-Fonts'!

--- a/src/Tools-Test.package/AndreasSystemProfilerTest.class/instance/setUp.st
+++ b/src/Tools-Test.package/AndreasSystemProfilerTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-tests tally
+running
 setUp
 	tally := QSystemTally new.
 	tally class: self class method: self class >> #testPrintingTally	

--- a/src/Tools-Test.package/monticello.meta/categories.st
+++ b/src/Tools-Test.package/monticello.meta/categories.st
@@ -1,7 +1,7 @@
 SystemOrganization addCategory: #'Tools-Test'!
-SystemOrganization addCategory: 'Tools-Test-Base'!
-SystemOrganization addCategory: 'Tools-Test-Debugger'!
-SystemOrganization addCategory: 'Tools-Test-DiffBuilder'!
-SystemOrganization addCategory: 'Tools-Test-Finder'!
-SystemOrganization addCategory: 'Tools-Test-PointerFinder'!
-SystemOrganization addCategory: 'Tools-Test-Profilers'!
+SystemOrganization addCategory: #'Tools-Test-Base'!
+SystemOrganization addCategory: #'Tools-Test-Debugger'!
+SystemOrganization addCategory: #'Tools-Test-DiffBuilder'!
+SystemOrganization addCategory: #'Tools-Test-Finder'!
+SystemOrganization addCategory: #'Tools-Test-PointerFinder'!
+SystemOrganization addCategory: #'Tools-Test-Profilers'!

--- a/src/UnifiedFFI-Tests.package/FFICalloutMethodBuilderTest.class/instance/setUp.st
+++ b/src/UnifiedFFI-Tests.package/FFICalloutMethodBuilderTest.class/instance/setUp.st
@@ -1,3 +1,3 @@
-initialization
+running
 setUp
 	architecture := FFIArchitecture forCurrentArchitecture

--- a/src/UnifiedFFI-Tests.package/FFICalloutTests.class/instance/setUp.st
+++ b/src/UnifiedFFI-Tests.package/FFICalloutTests.class/instance/setUp.st
@@ -1,3 +1,3 @@
-initialization
+running
 setUp
 	architecture := FFIArchitecture forCurrentArchitecture

--- a/src/UnifiedFFI-Tests.package/FFIExternalStructureFieldParserTests.class/instance/setUp.st
+++ b/src/UnifiedFFI-Tests.package/FFIExternalStructureFieldParserTests.class/instance/setUp.st
@@ -1,3 +1,3 @@
-initialization
+running
 setUp
 	architecture := FFIArchitecture forCurrentArchitecture

--- a/src/Versionner-Tests-Core-DependenciesModel.package/MCModel2MTModelVisitorTest.class/instance/setUp.st
+++ b/src/Versionner-Tests-Core-DependenciesModel.package/MCModel2MTModelVisitorTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-tests
+running
 setUp
 	super setUp.
 	classFactory := ClassFactoryForTestCase new.

--- a/src/Versionner-Tests-Core-DependenciesModel.package/MCModel2MTModelVisitorTest.class/instance/tearDown.st
+++ b/src/Versionner-Tests-Core-DependenciesModel.package/MCModel2MTModelVisitorTest.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-tests
+running
 tearDown
 	super tearDown.
 	classFactory cleanUp.

--- a/src/Versionner-Tests-Core-DependenciesModel.package/MTDependencyTest.class/instance/setUp.st
+++ b/src/Versionner-Tests-Core-DependenciesModel.package/MTDependencyTest.class/instance/setUp.st
@@ -1,4 +1,4 @@
-as yet unclassified
+running
 setUp
 	| visitor |
 	

--- a/src/Zodiac-Tests.package/ZdcPluginSSLSessionTests.class/instance/setUp.st
+++ b/src/Zodiac-Tests.package/ZdcPluginSSLSessionTests.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 
 	session := ZdcPluginSSLSession new

--- a/src/Zodiac-Tests.package/ZdcPluginSSLSessionTests.class/instance/tearDown.st
+++ b/src/Zodiac-Tests.package/ZdcPluginSSLSessionTests.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-initialization
+running
 tearDown
 
 	session destroy.


### PR DESCRIPTION
- properly categorize all #setUp methods in test case in category running 
- properly categorize all #tearDown methods in test case in category running

Add ProperMethodCategorizationTest as release test to ensure the methods
#setUp, #tearDown and #runCase from SUnit are properly categorized also in the future.

We should raise the bar on quality and consistency!