### PR TITLE
20019-Spotter-While-searching-for-a-Trait-method-we-get-the-users-of-the-trait-in-the-results

### DIFF
--- a/src/GT-SpotterExtensions-Core.package/GTFilterImplementor.class/instance/applyFilterWithQuery.st
+++ b/src/GT-SpotterExtensions-Core.package/GTFilterImplementor.class/instance/applyFilterWithQuery.st
@@ -1,0 +1,4 @@
+private
+applyFilterWithQuery 
+	super applyFilterWithQuery.
+	self filteredItems: (self filteredItems reject: [:each | each isFromTrait]).

--- a/src/GT-SpotterExtensions-Core.package/GTSpotter.extension/instance/spotterImplementorsFor..st
+++ b/src/GT-SpotterExtensions-Core.package/GTSpotter.extension/instance/spotterImplementorsFor..st
@@ -5,6 +5,6 @@ spotterImplementorsFor: aStep
 	aStep listProcessor
 		title: 'Implementors';
 		filter: GTFilterImplementor item: [ :filter :context | 
-			SystemNavigation default allBehaviorsDo: [ :class | class methodsDo: filter ] ];
+			SystemNavigation default allBehaviorsDo: [ :class | class localMethods do: filter ] ];
 		keyBinding: $m meta;
 		wantsToDisplayOnEmptyQuery: false


### PR DESCRIPTION
Ading the filtering of the local  methods only. 
Previously was showing methods defined in traits.