### PR TITLE
20228-Checking if the directory is empty before delete.

### DIFF
--- a/src/FileSystem-Core.package/AbstractFileReference.class/instance/ensureDelete.st
+++ b/src/FileSystem-Core.package/AbstractFileReference.class/instance/ensureDelete.st
@@ -1,5 +1,7 @@
 operations
 ensureDelete
-	"Delete the file and does not raise exception if it does not exist contrary to delete"
+	"Delete the file and does not raise exception if it does not exist contrary to delete.
+	However if it is a directory and it has children an error is signaled. If it is required to 
+	delete even with children, use #ensureDeleteAll."
 	
 	self deleteIfAbsent: [].

--- a/src/FileSystem-Core.package/DirectoryIsNotEmpty.class/README.md
+++ b/src/FileSystem-Core.package/DirectoryIsNotEmpty.class/README.md
@@ -1,0 +1,1 @@
+I am raised on an attempt to delete a directory when is not empty.

--- a/src/FileSystem-Core.package/DirectoryIsNotEmpty.class/properties.json
+++ b/src/FileSystem-Core.package/DirectoryIsNotEmpty.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "PabloTesone 10/18/2017 11:14",
+	"super" : "FileSystemError",
+	"category" : "FileSystem-Core-Kernel",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "DirectoryIsNotEmpty",
+	"type" : "normal"
+}

--- a/src/FileSystem-Core.package/FileReference.class/instance/delete.st
+++ b/src/FileSystem-Core.package/FileReference.class/instance/delete.st
@@ -1,3 +1,8 @@
 operations
 delete
+	"Deletes the referenced file or directory. If the directory is not empty, 
+	raises an error. Use #deleteAll to delete with the children."
+
+	(self isDirectory and:[self hasChildren]) 
+		ifTrue:[DirectoryIsNotEmpty signalWith: self].
 	filesystem delete: path

--- a/src/FileSystem-Tests-Core.package/FileReferenceTest.class/instance/testEnsureDeleteAll.st
+++ b/src/FileSystem-Tests-Core.package/FileReferenceTest.class/instance/testEnsureDeleteAll.st
@@ -1,0 +1,15 @@
+tests
+testEnsureDeleteAll
+	| reference childReference |
+	reference := filesystem / 'plonk'.	"Deletes the file if it exists"
+	reference ensureCreateDirectory.
+	self assert: reference exists.
+	
+	childReference := reference / 'child'.
+	childReference ensureCreateFile.
+	self assert: childReference exists.
+		
+	reference ensureDeleteAll.
+	
+	self deny: childReference exists.
+	self deny: reference exists.

--- a/src/FileSystem-Tests-Core.package/FileReferenceTest.class/instance/testEnsureDeleteNonEmptyDirectory.st
+++ b/src/FileSystem-Tests-Core.package/FileReferenceTest.class/instance/testEnsureDeleteNonEmptyDirectory.st
@@ -1,0 +1,14 @@
+tests
+testEnsureDeleteNonEmptyDirectory
+	| reference childReference |
+	reference := filesystem / 'plonk'.	"Deletes the file if it exists"
+	reference ensureCreateDirectory.
+	self assert: reference exists.
+	
+	childReference := reference / 'child'.
+	childReference ensureCreateFile.
+	self assert: childReference exists.
+		
+	self should: [reference ensureDelete] raise: DirectoryIsNotEmpty.
+
+	reference ensureDeleteAll.


### PR DESCRIPTION
Doing it in the image side to affect all the filesystems. 
The FilePlugin fails if the directory is not empty, 
however it does with a generic primitive fail error.