### PR TITLE
20592-SizeInMemory-is-not-updated-to-handle-32-and-64-bits-for-WordLayout

### DIFF
--- a/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/align64Bits..st
+++ b/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/align64Bits..st
@@ -1,0 +1,5 @@
+utils
+align64Bits: size
+	size % 8 = 0
+		ifTrue: [ ^ size ]
+		ifFalse:[ ^ size + 8 - (size % 8) ].

--- a/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/headerSize.st
+++ b/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/headerSize.st
@@ -1,0 +1,4 @@
+utils
+headerSize
+	" The header is 64 bits"
+	^ 8

--- a/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/paddedByteStringSize..st
+++ b/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/paddedByteStringSize..st
@@ -2,6 +2,6 @@ utils
 paddedByteStringSize: numberOfChars 
 	"64 bits for the header"
 	| originalSize  |
-	originalSize := (2 * Smalltalk wordSize) + (numberOfChars = 0 ifTrue:[1] ifFalse:[numberOfChars]).
+	originalSize := self headerSize + (numberOfChars = 0 ifTrue:[1] ifFalse:[numberOfChars]).
 		
 	^ self align64Bits: originalSize.

--- a/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/paddedByteStringSize..st
+++ b/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/paddedByteStringSize..st
@@ -1,8 +1,7 @@
 utils
 paddedByteStringSize: numberOfChars 
-	"2 words for the header"
-	| originalSize |
-	originalSize := (2 * Smalltalk wordSize) + numberOfChars.
-	^ ((originalSize % Smalltalk wordSize) = 0) ifTrue:[ ^ originalSize] ifFalse:[
-		originalSize + Smalltalk wordSize - (originalSize % Smalltalk wordSize)
-	]. 
+	"64 bits for the header"
+	| originalSize  |
+	originalSize := (2 * Smalltalk wordSize) + (numberOfChars = 0 ifTrue:[1] ifFalse:[numberOfChars]).
+		
+	^ self align64Bits: originalSize.

--- a/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/paddedByteStringSize..st
+++ b/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/paddedByteStringSize..st
@@ -1,0 +1,8 @@
+utils
+paddedByteStringSize: numberOfChars 
+	"2 words for the header"
+	| originalSize |
+	originalSize := (2 * Smalltalk wordSize) + numberOfChars.
+	^ ((originalSize % Smalltalk wordSize) = 0) ifTrue:[ ^ originalSize] ifFalse:[
+		originalSize + Smalltalk wordSize - (originalSize % Smalltalk wordSize)
+	]. 

--- a/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/testSizeInMemoryLargeInstances.st
+++ b/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/testSizeInMemoryLargeInstances.st
@@ -1,8 +1,9 @@
 tests
+"protocol: tests"
 testSizeInMemoryLargeInstances
 	"Two words for the object header + a world per instance variable"
 
-	self assert: Smalltalk allClasses sizeInMemory = 20.
+	self assert: Smalltalk allClasses sizeInMemory = (5 * Smalltalk wordSize).
 	self
 		assert:
 			Smalltalk allClasses asArray sizeInMemory

--- a/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/testSizeInMemoryLargeInstances.st
+++ b/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/testSizeInMemoryLargeInstances.st
@@ -1,10 +1,12 @@
 tests
-"protocol: tests"
 testSizeInMemoryLargeInstances
+
 	"Two words for the object header + a world per instance variable"
 
-	self assert: Smalltalk allClasses sizeInMemory = (5 * Smalltalk wordSize).
 	self
+		assert: Smalltalk allClasses sizeInMemory = (self align64Bits: (self headerSize + (3 * Smalltalk wordSize)));
 		assert:
 			Smalltalk allClasses asArray sizeInMemory
-				= (Smalltalk wordSize * 3 + (Smalltalk allClasses asArray size * Smalltalk wordSize))
+				=
+					(self align64Bits:(self headerSize + (Smalltalk allClasses asArray size * Smalltalk wordSize)
+						+ self headerSize))

--- a/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/testSizeInMemoryLargeInstances.st
+++ b/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/testSizeInMemoryLargeInstances.st
@@ -1,7 +1,7 @@
 tests
 "protocol: tests"
 testSizeInMemoryLargeInstances
-	"Two words for the object header + a world per instance variable"
+	"Two words for the object header + a word per instance variable"
 
 	self assert: Smalltalk allClasses sizeInMemory = (5 * Smalltalk wordSize).
 	self

--- a/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/testSizeInMemoryNormalClasses.st
+++ b/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/testSizeInMemoryNormalClasses.st
@@ -1,11 +1,10 @@
 tests
-"protocol: tests"
 testSizeInMemoryNormalClasses
 	"Two word for the header + one word per instance variable"
-	self assert: Date today sizeInMemory = ( (2+2) * Smalltalk wordSize ).
+	self assert: Date today sizeInMemory = (self align64Bits:( 2 * Smalltalk wordSize + self headerSize)).
 
 	"Two word for the header + one word per instance variable"
-	self assert: TestCase new sizeInMemory = ( (2+2) * Smalltalk wordSize ).
+	self assert: TestCase new sizeInMemory = (self align64Bits:( 2 * Smalltalk wordSize + self headerSize)).
 
 
 

--- a/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/testSizeInMemoryNormalClasses.st
+++ b/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/testSizeInMemoryNormalClasses.st
@@ -1,10 +1,11 @@
 tests
+"protocol: tests"
 testSizeInMemoryNormalClasses
 	"Two word for the header + one word per instance variable"
-	self assert: Date today sizeInMemory = 16.
+	self assert: Date today sizeInMemory = ( (2+2) * Smalltalk wordSize ).
 
 	"Two word for the header + one word per instance variable"
-	self assert: TestCase new sizeInMemory = 16.
+	self assert: TestCase new sizeInMemory = ( (2+2) * Smalltalk wordSize ).
 
 
 

--- a/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/testSizeInMemoryOfByteObjects.st
+++ b/src/Kernel-Tests.package/SizeInMemoryTest.class/instance/testSizeInMemoryOfByteObjects.st
@@ -1,8 +1,8 @@
 tests
 testSizeInMemoryOfByteObjects
 	"Byte objects should be padded to words"
-	self assert: 'a' sizeInMemory equals: 12.
-	self assert: 'abcd' sizeInMemory equals: 12.
-	self assert: '' sizeInMemory equals: 8.
-	self assert: 'abcde' sizeInMemory equals: 16.
-	self assert: 'abcdefghi' sizeInMemory equals: 20.
+	self assert: 'a' sizeInMemory equals: (self paddedByteStringSize: 1).
+	self assert: 'abcd' sizeInMemory equals: (self paddedByteStringSize: 4).
+	self assert: '' sizeInMemory equals: (self paddedByteStringSize: 0).
+	self assert: 'abcde' sizeInMemory equals: (self paddedByteStringSize: 5).
+	self assert: 'abcdefghi' sizeInMemory equals: (self paddedByteStringSize: 9).

--- a/src/Kernel.package/Object.class/instance/sizeInMemory.st
+++ b/src/Kernel.package/Object.class/instance/sizeInMemory.st
@@ -12,7 +12,7 @@ sizeInMemory
 			"indexed elements"
 			bytesPerElement := self class isBytes
 				ifTrue: [ 1 ]
-				ifFalse: [ 4 ].
+				ifFalse: [ Smalltalk wordSize ]. "If it is a word layout"
 			contentBytes := contentBytes + (self basicSize * bytesPerElement).
 			"If we are not filling an ammount of bytes multiple of the wordSize, we do it"
 			contentBytes \\ Smalltalk wordSize = 0

--- a/src/Kernel.package/Object.class/instance/sizeInMemory.st
+++ b/src/Kernel.package/Object.class/instance/sizeInMemory.st
@@ -1,25 +1,7 @@
 memory usage
 sizeInMemory
-	"Answer the number of bytes consumed by this instance including object header."
-
-	| contentBytes |
 	self class isImmediateClass
 		ifTrue: [ ^ 0 ].
-	contentBytes := Smalltalk wordSize.	"base header"
-	contentBytes := contentBytes + (self class instSize * Smalltalk wordSize).	"instance vars"
-	self class isVariable
-		ifTrue: [ | bytesPerElement |
-			"indexed elements"
-			bytesPerElement := self class isBytes
-				ifTrue: [ 1 ]
-				ifFalse: [ Smalltalk wordSize ]. "If it is a word layout"
-			contentBytes := contentBytes + (self basicSize * bytesPerElement).
-			"If we are not filling an ammount of bytes multiple of the wordSize, we do it"
-			contentBytes \\ Smalltalk wordSize = 0
-				ifFalse: [ | extraBytesToFillAWord |
-					extraBytesToFillAWord := Smalltalk wordSize - (contentBytes \\ Smalltalk wordSize).
-					contentBytes := contentBytes + extraBytesToFillAWord ] ].
-	contentBytes > 255
-		ifTrue: [ contentBytes := contentBytes + (2 * Smalltalk wordSize) ]
-		ifFalse: [ contentBytes := contentBytes + Smalltalk wordSize ].
-	^ contentBytes
+	^ self class isVariable
+		ifTrue: [ self class byteSizeOfInstanceOfSize: self basicSize ]
+		ifFalse: [ self class byteSizeOfInstance ]


### PR DESCRIPTION
Fixing sizeInMemory to handle properly WordLayout objects.
Also fixing the tests to handle both 32 and 64 bits.