### PR TITLE
20596-Zinc-should-not-use-asBytesDescription-as-it-is-deprecated

### DIFF
--- a/src/Zinc-HTTP.package/ZnUtils.class/class/signalProgress.total..st
+++ b/src/Zinc-HTTP.package/ZnUtils.class/class/signalProgress.total..st
@@ -5,7 +5,7 @@ signalProgress: amount total: total
 			total 
 				ifNil: [ 
 					HTTPProgress new 
-						signal: ('Transferred {1} bytes ...' format: { amount asBytesDescription }) ]
+						signal: ('Transferred {1} bytes ...' format: { amount humanReadableSIByteSize }) ]
 				ifNotNil: [ 
 					HTTPProgress new 
 						total: total; 

--- a/src/Zinc-HTTP.package/monticello.meta/categories.st
+++ b/src/Zinc-HTTP.package/monticello.meta/categories.st
@@ -1,8 +1,8 @@
 SystemOrganization addCategory: #'Zinc-HTTP'!
-SystemOrganization addCategory: 'Zinc-HTTP-Client-Server'!
-SystemOrganization addCategory: 'Zinc-HTTP-Core'!
-SystemOrganization addCategory: 'Zinc-HTTP-Exceptions'!
-SystemOrganization addCategory: 'Zinc-HTTP-Logging'!
-SystemOrganization addCategory: 'Zinc-HTTP-Streaming'!
-SystemOrganization addCategory: 'Zinc-HTTP-Support'!
-SystemOrganization addCategory: 'Zinc-HTTP-Variables'!
+SystemOrganization addCategory: #'Zinc-HTTP-Client-Server'!
+SystemOrganization addCategory: #'Zinc-HTTP-Core'!
+SystemOrganization addCategory: #'Zinc-HTTP-Exceptions'!
+SystemOrganization addCategory: #'Zinc-HTTP-Logging'!
+SystemOrganization addCategory: #'Zinc-HTTP-Streaming'!
+SystemOrganization addCategory: #'Zinc-HTTP-Support'!
+SystemOrganization addCategory: #'Zinc-HTTP-Variables'!


### PR DESCRIPTION
Zinc is using #asBytesDescription. It should not be used as it is deprecated.
This error is affecting all the users of Zinc. Ex: Smalltalk CI