### PR TITLE
19972-Implementers-code-pane-undo-goes-too-far

### DIFF
--- a/src/Rubric/RubPluggableTextMorph.class.st
+++ b/src/Rubric/RubPluggableTextMorph.class.st
@@ -42,6 +42,11 @@ RubPluggableTextMorph >> askBeforeDiscardingEdits: aBoolean [
 	askBeforeDiscardingEdits := aBoolean
 ]
 
+{ #category : #undo-redo }
+RubPluggableTextMorph >> clearUndoManager [
+	self textArea editingState clearUndoManager: nil
+]
+
 { #category : #accessing }
 RubPluggableTextMorph >> getEnabledSelector [
 	"Answer the value of getEnabledSelector"

--- a/src/Spec-Core/TextPresenter.class.st
+++ b/src/Spec-Core/TextPresenter.class.st
@@ -240,6 +240,11 @@ TextPresenter >> clearSelection [
 	self setSelection: (0 to: 0)
 ]
 
+{ #category : #undo-redo }
+TextPresenter >> clearUndoManager [
+	self widget ifNotNil: #clearUndoManager
+]
+
 { #category : #api }
 TextPresenter >> codePaneMenu: aMenu shifted: shifted [ 
 	"Note that unless we override perform:orSendTo:, 

--- a/src/Spec-MorphicAdapters/MorphicTextAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTextAdapter.class.st
@@ -97,6 +97,11 @@ MorphicTextAdapter >> classOrMetaClass: aClass [
 	self setEditingModeFor: self widget withBehavior: aClass
 ]
 
+{ #category : #undo-redo }
+MorphicTextAdapter >> clearUndoManager [
+	self widget clearUndoManager
+]
+
 { #category : #'widget API' }
 MorphicTextAdapter >> clearUserEditFlag [
 

--- a/src/Spec-Tools/MessageBrowser.class.st
+++ b/src/Spec-Tools/MessageBrowser.class.st
@@ -471,6 +471,7 @@ MessageBrowser >> initializePresenter [
 			textModel behavior: (item ifNil: [ nil ] ifNotNil: [ item methodClass ]).
 			textModel doItReceiver: textModel behavior.
 			textModel text: (self textConverter method: item; getText).
+			textModel clearUndoManager.
 			self installIconStylerFor: item].
 	listModel whenListChanged: [ self updateTitle ].
 		


### PR DESCRIPTION
Clearing the undo history when changing the selected method in the list.
Also adding a way of clearing this history from the TextPresenter