### PR TITLE
20734-Nested-Structures-using-Platform-longs-fails

### DIFF
--- a/src/UnifiedFFI-Tests/FFIExternalStructureFieldParserTests.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalStructureFieldParserTests.class.st
@@ -26,12 +26,13 @@ FFIExternalStructureFieldParserTests >> testParseFieldsStructure [
 		structure: FFITestStructure.
 		
 	self assert: fieldSpec notNil. 
-	self assert: fieldSpec fieldNames equals: #(byte short long float double int64).
+	self assert: fieldSpec fieldNames equals: #(byte short long float double int64 ulong).
 	self assert: (fieldSpec typeFor: #byte) class equals: FFIUInt8.
 	self assert: (fieldSpec typeFor: #short) class equals: FFIInt16.
 	self assert: (fieldSpec typeFor: #long) class equals: FFILong.
 	self assert: (fieldSpec typeFor: #float) class equals: FFIFloat32.
 	self assert: (fieldSpec typeFor: #double) class equals: FFIFloat64.
 	self assert: (fieldSpec typeFor: #int64) class equals: FFIInt64.
+	self assert: (fieldSpec typeFor: #ulong) class equals: FFIULong.
 	
 ]

--- a/src/UnifiedFFI-Tests/FFIExternalStructureTests.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalStructureTests.class.st
@@ -122,7 +122,18 @@ FFIExternalStructureTests >> testNestedStructure [
 
 	s1 := FFITestNestingStructure new.
 	s1 nested byte: 42.
-	self assert: s1 nested byte = 42
+	s1 nested float: 4.0.
+	s1 nested double: 42.0.
+
+	s1 nested long: -123456.
+	s1 nested ulong: 123456.
+
+	self assert: s1 nested byte equals: 42.	
+	self assert: s1 nested float equals: 4.0.	
+	self assert: s1 nested double equals: 42.0.	
+	self assert: s1 nested long equals: -123456.
+	self assert: s1 nested ulong equals: 123456.
+
 ]
 
 { #category : #tests }

--- a/src/UnifiedFFI-Tests/FFITestStructure.class.st
+++ b/src/UnifiedFFI-Tests/FFITestStructure.class.st
@@ -7,7 +7,8 @@ Class {
 		'OFFSET_FLOAT',
 		'OFFSET_INT64',
 		'OFFSET_LONG',
-		'OFFSET_SHORT'
+		'OFFSET_SHORT',
+		'OFFSET_ULONG'
 	],
 	#category : #UnifiedFFI-Tests
 }
@@ -22,6 +23,7 @@ FFITestStructure class >> fieldsDesc [
 		float float;
 		double double;
 		int64 int64;
+		ulong ulong;
 		)
 ]
 
@@ -100,4 +102,16 @@ FFITestStructure >> short [
 FFITestStructure >> short: anObject [
 	"This method was automatically generated"
 	handle signedShortAt: OFFSET_SHORT put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructure >> ulong [
+	"This method was automatically generated"
+	^handle platformUnsignedLongAt: OFFSET_ULONG
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructure >> ulong: anObject [
+	"This method was automatically generated"
+	^handle platformUnsignedLongAt: OFFSET_ULONG put: anObject
 ]

--- a/src/UnifiedFFI/FFIExternalStructureReferenceHandle.class.st
+++ b/src/UnifiedFFI/FFIExternalStructureReferenceHandle.class.st
@@ -133,6 +133,26 @@ FFIExternalStructureReferenceHandle >> isNull [
 ]
 
 { #category : #accessing }
+FFIExternalStructureReferenceHandle >> platformLongAt: byteOffset [
+	^ handle platformLongAt: startOffset + byteOffset
+]
+
+{ #category : #accessing }
+FFIExternalStructureReferenceHandle >> platformLongAt: byteOffset put: value [
+	^ handle platformLongAt: startOffset + byteOffset put: value
+]
+
+{ #category : #accessing }
+FFIExternalStructureReferenceHandle >> platformUnsignedLongAt: byteOffset [
+	^ handle platformUnsignedLongAt: startOffset + byteOffset
+]
+
+{ #category : #accessing }
+FFIExternalStructureReferenceHandle >> platformUnsignedLongAt: byteOffset put: value [
+	^ handle platformUnsignedLongAt: startOffset + byteOffset put: value
+]
+
+{ #category : #accessing }
 FFIExternalStructureReferenceHandle >> pointerAt: byteOffset [
 	^ handle pointerAt: startOffset + byteOffset
 ]


### PR DESCRIPTION
Adding implementation of platform dependent longs in FFIExternalStructureReferenceHandle.

Fixes https://pharo.fogbugz.com/f/cases/20734/Nested-Structures-using-Platform-longs-fails