### PR TITLE
20645-Windows-rebuildFieldAccessors-problem

### DIFF
--- a/src/UnifiedFFI/FFITypeArrayType.class.st
+++ b/src/UnifiedFFI/FFITypeArrayType.class.st
@@ -14,7 +14,7 @@ FFITypeArrayType >> annonymousClassCreator [
 			nextPutAll: '(FFITypeArray ofType: ';
 			print: (self objectClass type isPointer
 				ifTrue: [ self externalTypeWithArity printString ]
-				ifFalse: [ '#' , self objectClass type class ]);
+				ifFalse: [ self objectClass type class name ]);
 			nextPutAll: ' size: ';
 			print: self objectClass numberOfElements;
 			nextPutAll: ')' ]


### PR DESCRIPTION
Fixing the creation of annonymous classes for FFITypeArray. It was affecting all the platforms.Issue: https://pharo.fogbugz.com/f/cases/20645/Windows-rebuildFieldAccessors-problem