### PR TITLE
20793-During-Bootstrap-if-a-baseline-installation-fails-it-should-cancel-the-process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,99 +127,99 @@ Check for latest built images in http://files.pharo.org:
 }
 
 try{
-
-if( env.BRANCH_NAME == "development" ) {
-    properties([disableConcurrentBuilds()])
-}
+  timeout(60){
+    if( env.BRANCH_NAME == "development" ) {
+        properties([disableConcurrentBuilds()])
+    }
 	
-node('unix') {
- 	cleanWs()
-	def builders = [:]
-	def architectures = ['32']//, '64']
-	for (arch in architectures) {
-    // Need to bind the label variable before the closure - can't do 'for (label in labels)'
-    def architecture = arch
+    node('unix') {
+     	cleanWs()
+    	def builders = [:]
+    	def architectures = ['32']//, '64']
+    	for (arch in architectures) {
+        // Need to bind the label variable before the closure - can't do 'for (label in labels)'
+        def architecture = arch
 
-	builders[architecture] = {
-		dir(architecture) {
+    	builders[architecture] = {
+    		dir(architecture) {
 			
-		try{
-		stage ("Fetch Requirements-${architecture}") {	
-			checkout scm
-			shell 'wget -O - get.pharo.org/vm60 | bash	'
-			shell 'wget https://github.com/guillep/PharoBootstrap/releases/download/v1.2/bootstrapImage.zip'
-			shell 'unzip bootstrapImage.zip'
-			shell './pharo Pharo.image bootstrap/scripts/prepare_image.st --save --quit'
-	    }
+    		try{
+    		stage ("Fetch Requirements-${architecture}") {	
+    			checkout scm
+    			shell 'wget -O - get.pharo.org/vm60 | bash	'
+    			shell 'wget https://github.com/guillep/PharoBootstrap/releases/download/v1.2/bootstrapImage.zip'
+    			shell 'unzip bootstrapImage.zip'
+    			shell './pharo Pharo.image bootstrap/scripts/prepare_image.st --save --quit'
+    	    }
 
-		stage ("Bootstrap-${architecture}") {
-			shell "mkdir -p bootstrap-cache #required to generate hermes files"
-			shell "./pharo Pharo.image ./bootstrap/scripts/generateKernelHermesFiles.st --quit"
-			shell "./pharo Pharo.image ./bootstrap/scripts/generateSUnitHermesFiles.st --quit"
-			shell "./pharo ./Pharo.image bootstrap/scripts/bootstrap.st --ARCH=${architecture} --BUILD_NUMBER=${env.BUILD_ID} --quit"
-	    }
+    		stage ("Bootstrap-${architecture}") {
+    			shell "mkdir -p bootstrap-cache #required to generate hermes files"
+    			shell "./pharo Pharo.image ./bootstrap/scripts/generateKernelHermesFiles.st --quit"
+    			shell "./pharo Pharo.image ./bootstrap/scripts/generateSUnitHermesFiles.st --quit"
+    			shell "./pharo ./Pharo.image bootstrap/scripts/bootstrap.st --ARCH=${architecture} --BUILD_NUMBER=${env.BUILD_ID} --quit"
+    	    }
 
-		stage ("Full Image-${architecture}") {
-			shell "BUILD_NUMBER=${BUILD_NUMBER} BOOTSTRAP_ARCH=${architecture} bash ./bootstrap/scripts/build.sh -a ${architecture}"
-			stash includes: "bootstrap-cache/*.zip,bootstrap-cache/*.sources,bootstrap/scripts/**", name: "bootstrap${architecture}"
-	    }
+    		stage ("Full Image-${architecture}") {
+    			shell "BUILD_NUMBER=${BUILD_NUMBER} BOOTSTRAP_ARCH=${architecture} bash ./bootstrap/scripts/build.sh -a ${architecture}"
+    			stash includes: "bootstrap-cache/*.zip,bootstrap-cache/*.sources,bootstrap/scripts/**", name: "bootstrap${architecture}"
+    	    }
 		
-	    if (architecture == "32") {
-			stage ("Convert Image - 32->64") {
-				dir("conversion") {
-					shell "cp ../bootstrap-cache/*.zip ."
-					shell "bash ../bootstrap/scripts/transform_32_into_64.sh"
-					shell "mv *-64bit-*.zip ../bootstrap-cache"
-				}
-			}
-		}
+    	    if (architecture == "32") {
+    			stage ("Convert Image - 32->64") {
+    				dir("conversion") {
+    					shell "cp ../bootstrap-cache/*.zip ."
+    					shell "bash ../bootstrap/scripts/transform_32_into_64.sh"
+    					shell "mv *-64bit-*.zip ../bootstrap-cache"
+    				}
+    			}
+    		}
 		
-		if( env.BRANCH_NAME == "development" ) {
-			stage("Upload to files.pharo.org") {
-				dir("bootstrap-cache") {
-				    shell "BUILD_NUMBER=${env.BUILD_ID} bash ../bootstrap/scripts/prepare_for_upload.sh"
-					sshagent (credentials: ['b5248b59-a193-4457-8459-e28e9eb29ed7']) {
-						shell "bash ../bootstrap/scripts/upload_to_files.pharo.org.sh"
-					}
-				}
-			}
-		}
+    		if( env.BRANCH_NAME == "development" ) {
+    			stage("Upload to files.pharo.org") {
+    				dir("bootstrap-cache") {
+    				    shell "BUILD_NUMBER=${env.BUILD_ID} bash ../bootstrap/scripts/prepare_for_upload.sh"
+    					sshagent (credentials: ['b5248b59-a193-4457-8459-e28e9eb29ed7']) {
+    						shell "bash ../bootstrap/scripts/upload_to_files.pharo.org.sh"
+    					}
+    				}
+    			}
+    		}
 
-		} finally {
-			archiveArtifacts artifacts: 'bootstrap-cache/*.zip,bootstrap-cache/*.sources', fingerprint: true
-			cleanWs()
-		}
-		}
-	}
-	}
+    		} finally {
+    			archiveArtifacts artifacts: 'bootstrap-cache/*.zip,bootstrap-cache/*.sources', fingerprint: true
+    			cleanWs()
+    		}
+    		}
+    	}
+    	}
 	
-	parallel builders
-}
+    	parallel builders
+    }
 
-//Testing step
-def testers = [:]
-def architectures = ['32']//, '64']
-def platforms = ['unix', 'osx', 'windows']
-for (arch in architectures) {
-	// Need to bind the label variable before the closure - can't do 'for (label in labels)'
-	def architecture = arch
-	for (platf in platforms) {
-		// Need to bind the label variable before the closure - can't do 'for (label in labels)'
-		def platform = platf
-		testers["${platform}-${architecture}"] = {
-			node(platform) { stage("Tests-${platform}-${architecture}") {
-				runTests(architecture)
-			}}
-		}
-		testers["kernel-${platform}-${architecture}"] = {
-			node(platform) { stage("Kernel-tests-${platform}-${architecture}") {
-				runTests(architecture, "Kernel")
-			}}
-		}
-	}
-}
-parallel testers
-
+    //Testing step
+    def testers = [:]
+    def architectures = ['32']//, '64']
+    def platforms = ['unix', 'osx', 'windows']
+    for (arch in architectures) {
+    	// Need to bind the label variable before the closure - can't do 'for (label in labels)'
+    	def architecture = arch
+    	for (platf in platforms) {
+    		// Need to bind the label variable before the closure - can't do 'for (label in labels)'
+    		def platform = platf
+    		testers["${platform}-${architecture}"] = {
+    			node(platform) { stage("Tests-${platform}-${architecture}") {
+    				runTests(architecture)
+    			}}
+    		}
+    		testers["kernel-${platform}-${architecture}"] = {
+    			node(platform) { stage("Kernel-tests-${platform}-${architecture}") {
+    				runTests(architecture, "Kernel")
+    			}}
+    		}
+    	}
+    }
+    parallel testers
+  }
 	notifyBuild("SUCCESS")
 } catch (e) {
 	notifyBuild("FAILURE")

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -309,6 +309,8 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 	UIManager default: MorphicUIManager new.
 
 	World displayWorldSafely.
+	World assuredCanvas.
+
 	UIManager default uiProcess resume.
 	PharoLightTheme beCurrent.
 	(World windowsSatisfying: [:w | w model canDiscardEdits]) do: [:w | w delete].
@@ -318,7 +320,7 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 
 	"Install the right UIManager"
 	UIManager default: UIManager forCurrentSystemConfiguration.
-	Stdio stdout nextPutAll: 'UIManager changed:' , UIManager default class name ; lf.
+	Stdio stdout nextPutAll: 'UIManager changed:' ; nextPutAll: UIManager default class name ; lf.
 
 	TextEditor initialize.
 	SmalltalkEditor initialize.

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -307,6 +307,7 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 	Display newDepth: 32.
 	World displayWorldSafely.
 	UIManager default: MorphicUIManager new.
+
 	World displayWorldSafely.
 	UIManager default uiProcess resume.
 	PharoLightTheme beCurrent.
@@ -315,8 +316,14 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 
 	GraphicFontSettings setFontsToStyleNamed: #small.
 
+	"Install the right UIManager"
+	UIManager default: UIManager forCurrentSystemConfiguration.
+	Stdio stdout nextPutAll: 'UIManager changed:' , UIManager default class name ; lf.
+
 	TextEditor initialize.
 	SmalltalkEditor initialize.
+
+	Stdio stdout nextPutAll: 'SmalltalkEditor initialized.'; lf.
 
 	PolymorphSystemSettings showDesktopLogo: false.
 	PolymorphSystemSettings showDesktopLogo: true.


### PR DESCRIPTION
This PR introduces two changes to handle the errors during the bootstrap:

1. The Whole process now has a timeout of 60 minutes.
2. After initializing the world in BaselineOfMorphic the UIManager is restored to the correct UIManager depending the system state. If it is headless then the NonInteractiveManager is used, otherwise the MorphicUIManager.