### PR TITLE
20869-Add-tooltips-to-world-menu-entries

### DIFF
--- a/src/EmergencyEvaluator/Transcripter.class.st
+++ b/src/EmergencyEvaluator/Transcripter.class.st
@@ -69,7 +69,7 @@ Transcripter class >> emergencyEvaluatorMenuOn: aBuilder [
 		action: [self emergencyEvaluator. World restoreMorphicDisplay];
 		parent: #Tools;
 		order: 0.57;	
-		help: 'Invoke the emergency evaluator';
+		help: 'Invoke the emergency evaluator.';
 		icon: self icon
 	
 ]

--- a/src/EpiceaBrowsers/EpUnifiedBrowserModel.class.st
+++ b/src/EpiceaBrowsers/EpUnifiedBrowserModel.class.st
@@ -57,6 +57,7 @@ EpUnifiedBrowserModel class >> worldMenuItemOn: aBuilder [
 		parent: #Tools;
 		action: [ self open ]; 
 		icon: self taskbarIcon;
+		help: 'Browse recorded change logs during from Pharo coding sessions and replay changes.';
 		order: 0.5
 ]
 

--- a/src/GT-Playground/GTPlayground.class.st
+++ b/src/GT-Playground/GTPlayground.class.st
@@ -113,6 +113,7 @@ GTPlayground class >> menuCommandOn: aBuilder [
 		action: [ Smalltalk tools openWorkspace ];
 		order: 0.3;
 		keyText: 'o, w';
+		help: 'A window used as a scratchpad area where fragments of Pharo code can be entered, stored, edited, and evaluated.';
 		icon: Smalltalk tools workspace taskbarIcon
 ]
 

--- a/src/GT-Spotter/GTSpotter.class.st
+++ b/src/GT-Spotter/GTSpotter.class.st
@@ -133,6 +133,7 @@ GTSpotter class >> menuCommandOn: aBuilder [
 		keyText: 'Shift + Enter';
 		order: 0.7;
 		parent: #MostUsedTools;
+		help: 'Search tool to explore Pharo system effectively.';
 		iconName: #smallFindIcon
 ]
 

--- a/src/Glamour-Examples/GLMExamplesBrowser.class.st
+++ b/src/Glamour-Examples/GLMExamplesBrowser.class.st
@@ -16,7 +16,7 @@ GLMExamplesBrowser class >> menuExamplesOn: aBuilder [
 		iconName: #glamorousHelp;
 		parent: #Help;
 		order: 4.0;
-		help: 'Open Glamour Example Browser';
+		help: 'Open Glamour Example Browser.';
 		action: [ self open ]
 ]
 

--- a/src/HelpSystem-Core/HelpBrowser.class.st
+++ b/src/HelpSystem-Core/HelpBrowser.class.st
@@ -59,6 +59,7 @@ HelpBrowser class >> menuCommandOn: aBuilder [
 		order: 1.0;
 		action: [ self open ];
 		iconName: #smallHelpIcon;
+		help: 'Explore a list of help topics to learn to use Pharo tools.';
 		withSeparatorAfter 
 ]
 

--- a/src/Komitter/Komitter.class.st
+++ b/src/Komitter/Komitter.class.st
@@ -33,7 +33,7 @@ Komitter class >> komitterMenuOn: aBuilder [
 		action: [ self openAndCommitToMonticello ];
 		order: 0.29;
 		parent: #Tools;
-		help: 'Cherry pick what you commit';
+		help: 'Cherry pick what you commit.';
 		keyText: 'o, k';
 		icon: self taskbarIcon.
 	aBuilder withSeparatorAfter

--- a/src/MonticelloGUI/MCWorkingCopyBrowser.class.st
+++ b/src/MonticelloGUI/MCWorkingCopyBrowser.class.st
@@ -36,6 +36,7 @@ MCWorkingCopyBrowser class >> menuCommandOn: aBuilder [
 		action: [ Smalltalk tools openMonticelloBrowser ];
 		order: 0.9;
 		keyText: 'o, p';
+		help: 'Source code versionning system to manage Smalltalk code.';
 		icon: Smalltalk tools monticelloBrowser taskbarIcon
 ]
 

--- a/src/Morphic-Base/WorldState.extension.st
+++ b/src/Morphic-Base/WorldState.extension.st
@@ -19,12 +19,15 @@ WorldState class >> debugOn: aBuilder [
 		iconName: #smallDebug;
 		with: [ (aBuilder item: #'Remove all Breakpoints')
 				order: 0;
+				help: 'Remove all the breakpoints of the image.';
 				action: [ Breakpoint removeAll ].
 			(aBuilder item: #'Enable all break/inspect once')
 				order: 0;
+				help: 'Reset the break/inspect once. Once restarted, the first break once encountered will stop the execution.';
 				action: [ Halt resetOnce ].
 			(aBuilder item: #'Reset Counters')
 				order: 0;
+				help: 'Reset the counters on the executions counters.';
 				action: [ ExecutionCounter resetAll ] ]
 ]
 
@@ -81,22 +84,30 @@ WorldState class >> systemOn: aBuilder [
 		with: [ (aBuilder item: #'About...')
 				order: 0;
 				iconName: #smallLanguageIcon;
+				help: 'Informations about this version of Pharo.';
 				action: [ Smalltalk aboutThisSystem ].
 			(aBuilder item: #'Start profiling all Processes')
+				help: 'Profile all Pharo processes.';
 				action: [ self startMessageTally ].
 			(aBuilder item: #'Start profiling UI ')
+				help: 'Profile the UI process of Pharo.';
 				action: [ self startThenBrowseMessageTally ].
 			(aBuilder item: #'Space left')
+				help: 'Do a garbage collection, and report results about the to the user.';
 				action: [ Smalltalk informSpaceLeftAfterGarbageCollection ].
 			(aBuilder item: #'Do Image Cleanup')
+				help: 'Clean out any caches and other state that should be flushed when trying to get an image into a pristine state.';
 				action: [ Smalltalk cleanUp: true ];
 				withSeparatorAfter.
 			(aBuilder item: #'Start drawing again')
+				help: 'Resume the drawing after a draw error of the world.';
 				action: [ World resumeAfterDrawError ].
 			(aBuilder item: #'Start stepping again')
+				help: 'Resume stepping of Morph after an error has occured.';
 				action: [ World resumeAfterStepError ];
 				withSeparatorAfter.
-			(aBuilder item: #'Restore display (r)')
+			(aBuilder item: #'Restore display')
+				help: 'Restore Morphic display.';
 				action: [ World restoreMorphicDisplay ] ]
 ]
 
@@ -109,9 +120,7 @@ WorldState class >> windowsOn: aBuilder [
 		iconName: #smallWindowIcon;
 		with: [ (aBuilder item: #'Collapse all windows')
 				action: [ World collapseAll ];
-				help:
-					'Reduce all open windows to collapsed forms that only show titles'
-						translated.
+				help: 'Reduce all open windows to collapsed forms that only show titles' translated.
 			(aBuilder item: #'Expand all windows')
 				iconName: #expandBoxIcon;
 				action: [ World expandAll ];
@@ -120,12 +129,11 @@ WorldState class >> windowsOn: aBuilder [
 				action: [ World fitAllVisibleWindows ];
 				help: 'Fit all open windows as visible in World' translated.
 			(aBuilder item: #'Close all debuggers')
+				help: 'Close all opened debugger in the image.';
 				action: [ Smalltalk tools debugger closeAllDebuggers ].
 			(aBuilder item: #'Send top window to back (\)')
 				action: [ SystemWindow sendTopWindowToBack ];
-				help:
-					'Make the topmost window become the backmost one, and activate the window just beneath it.'
-						translated.
+				help: 'Make the topmost window become the backmost one, and activate the window just beneath it.' translated.
 			(aBuilder item: #'Move windows onscreen')
 				action: [ World bringWindowsFullOnscreen ];
 				help: 'Make all windows fully visible on the screen' translated.
@@ -137,7 +145,5 @@ WorldState class >> windowsOn: aBuilder [
 				help: 'Deletes all windows even if they have unsaved text edits.' translated.
 			(aBuilder item: #'Toggle full screen mode')
 				action: [ Display toggleFullscreen ];
-				help:
-					'Turn full screen mode on when it is off, off when it is on.'
-						translated ]
+				help: 'Turn full screen mode on when it is off, off when it is on.' translated ]
 ]

--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -126,6 +126,7 @@ WorldState class >> helpOn: aBuilder [
 	(aBuilder item: #Help)
 		order: 4.0;
 		iconName: #smallHelpIcon;
+		help: 'Some help tools on Pharo.';
 		withSeparatorAfter
 ]
 
@@ -159,23 +160,23 @@ WorldState class >> quitItemsOn: aBuilder [
 		with: [ (aBuilder item: #Save)
 				target: self;
 				selector: #saveSession;
-				help: 'save the current version of the image on disk';
+				help: 'Save the current version of the image on disk.';
 				keyText: 'S';
 				iconName: #smallSaveIcon.
 			(aBuilder item: #'Save as...')
 				target: self;
 				selector: #saveAs;
-				help: 'save the current version of the image on disk under a new name.';
+				help: 'Save the current version of the image on disk under a new name.';
 				iconName: #smallSaveAsIcon.
 			(aBuilder item: #'Save and quit')
 				target: self;
 				selector: #saveAndQuit;
-				help: 'save the current image on disk, and quit Pharo.';
+				help: 'Save the current image on disk, and quit Pharo.';
 				iconName: #smallQuitIcon.
 			(aBuilder item: #Quit)
 				target: self;
 				selector: #quitSession;
-				help: 'quit Pharo.';
+				help: 'Quit Pharo without saving the image on disk.';
 				iconName: #smallQuitIcon ]
 ]
 
@@ -226,6 +227,7 @@ WorldState class >> screenShotCommandOn: aBuilder [
 		order: 0.59;
 		selector: #makeAScreenshot;
 		label: 'Screenshot';
+		help: 'Take a screenshot of your Pharo image.';
 		iconName: #smallScreenshotIcon
 ]
 

--- a/src/Nautilus/Nautilus.class.st
+++ b/src/Nautilus/Nautilus.class.st
@@ -164,6 +164,7 @@ Nautilus class >> menuCommandOn: aBuilder [
 		action: [ Smalltalk tools openClassBrowser ];
 		order: 0.1;
 		keyText: 'o, b';
+		help: 'System browser to browse and edit code.';
 		icon: Smalltalk tools browser taskbarIcon
 ]
 

--- a/src/ProfStef-Core/ProfStef.class.st
+++ b/src/ProfStef-Core/ProfStef.class.st
@@ -125,6 +125,7 @@ ProfStef class >> menuCommandOn: aBuilder [
 		order: 3.0;
 		action: [ self openPharoZenWorkspace ];
 		icon: ((self iconNamed: #pharoIcon) scaledToSize: 16@16);
+		help: 'Pharo values.';
 		withSeparatorAfter 
 ]
 

--- a/src/ProfStef-Help/PharoTutorialsHelp.class.st
+++ b/src/ProfStef-Help/PharoTutorialsHelp.class.st
@@ -25,5 +25,5 @@ PharoTutorialsHelp class >> menuCommandOn: aBuilder [
 			order: 2.0;
 			action:[ HelpBrowser openOn: self ]; 
 			icon: ((self iconNamed: #pharoIcon) scaledToSize: 16@16);
-			help: 'Browse and create Pharo tutorials'.
+			help: 'Browse and create Pharo tutorials.'.
 ]

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -259,3 +259,17 @@ ReleaseTest >> testUnpackagedClasses [
 				separatedBy: [ s cr ]])
 
 ]
+
+{ #category : #testing }
+ReleaseTest >> testWorldMenuHasHelpForAllEntries [
+	"In this test we check that at least every terminal menu entry of the world menu has an help."
+
+	| menuElements |
+	menuElements := WorldState new menuBuilder itemList.
+
+	"Here we have the roots of the menu. We want the terminal menu entries."
+	[ menuElements allSatisfy: [ :each | each itemList isNil ] ]
+		whileFalse: [ menuElements := menuElements inject: OrderedCollection new into: [ :coll :each | each itemList ifNil: [ coll add: each ] ifNotNil: [ :items | coll addAll: items ]. coll ] ].
+			
+	menuElements collect: #spec thenDo: [ :item | self assert: item help isNotNil description: item label , ' menu entry in world menu should have an help.' ]
+]

--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -46,6 +46,7 @@ TestRunner class >> menuCommandOn: aBuilder [
 		action: [ Smalltalk tools openTestRunner ];
 		order: 0.5;
 		keyText: 'o, u';
+		help: 'Let you run and debug SUnit tests.';
 		icon: self taskbarIcon
 ]
 

--- a/src/Spec-Tools/DualChangeSorterApplication.class.st
+++ b/src/Spec-Tools/DualChangeSorterApplication.class.st
@@ -77,16 +77,16 @@ DualChangeSorterApplication class >> defaultSpec [
 ]
 
 { #category : #menu }
-DualChangeSorterApplication class >> menuCommandOn: aBuilder [ 
-	<worldMenu> 
+DualChangeSorterApplication class >> menuCommandOn: aBuilder [
+	<worldMenu>
 	(aBuilder group: #SystemChanges)
-		parent: #Tools;  
+		parent: #Tools;
 		order: 0.51;
-		with: [
-			(aBuilder item: #'Change Sorter')
-				action:[self open]; 
-				icon: self taskbarIcon].			
-	aBuilder withSeparatorAfter.		
+		with: [ (aBuilder item: #'Change Sorter')
+				action: [ self open ];
+				help: 'Examine the different change set of the image.';
+				icon: self taskbarIcon ].
+	aBuilder withSeparatorAfter
 ]
 
 { #category : #menu }

--- a/src/Spec-Tools/KeymapBrowser.class.st
+++ b/src/Spec-Tools/KeymapBrowser.class.st
@@ -36,7 +36,7 @@ KeymapBrowser class >> keymapBrowserMenuOn: aBuilder [
 		order: 4;
 		icon: self taskbarIcon;
 		action: [ self new openWithSpec ];
-		help: 'List all know shortcuts and Keymapping categories'.
+		help: 'List all know shortcuts and Keymapping categories.'.
 ]
 
 { #category : #accessing }

--- a/src/System-Settings/SettingBrowser.class.st
+++ b/src/System-Settings/SettingBrowser.class.st
@@ -245,7 +245,7 @@ SettingBrowser class >> menuCommandOn: aBuilder [
 		action: [ SettingBrowser open ];
 		keyText: 'o, s';
 		help:
-			'Opens a SystemSettingBrowser which allows you to alter many system settings'
+			'Opens a SystemSettingBrowser which allows you to alter many system settings.'
 ]
 
 { #category : #opening }

--- a/src/System-Settings/StartupPreferencesLoader.extension.st
+++ b/src/System-Settings/StartupPreferencesLoader.extension.st
@@ -8,7 +8,7 @@ StartupPreferencesLoader class >> startupGeneralPrefererencesFolderMenuOn: aBuil
 		label: 'General Preferences folder';
 		parent: #SystemStartup;
 		order: 3;
-		help: 'Open the folder with general preferences';
+		help: 'Open the folder with general preferences.';
 		iconName: #smallOpenIcon
 ]
 
@@ -20,7 +20,7 @@ StartupPreferencesLoader class >> startupLoaderMenuOn: aBuilder [
 		label: 'Run startup scripts';
 		parent: #SystemStartup;
 		order: 1;
-		help: 'Run startup "scripts';
+		help: 'Run startup scripts.';
 		iconName: #scriptManagerIcon.
 	aBuilder withSeparatorAfter
 ]
@@ -35,7 +35,7 @@ StartupPreferencesLoader class >> startupPreferencesVersionFolderMenuOn: aBuilde
 		label: 'Version Preferences folder';
 		parent: #SystemStartup;
 		order: 2;
-		help: 'Open the preferences per version folder';
+		help: 'Open the preferences per version folder.';
 		iconName: #smallOpenIcon
 ]
 
@@ -46,6 +46,6 @@ StartupPreferencesLoader class >> systemStartupMenuOn: aBuilder [
 		label: 'Startup';
 		parent: #System;
 		order: 2;
-		help: 'System startup related';
+		help: 'System startup related.';
 		iconName: #scriptManagerIcon
 ]

--- a/src/Tool-Base/AbstractTool.class.st
+++ b/src/Tool-Base/AbstractTool.class.st
@@ -28,6 +28,7 @@ AbstractTool class >> menuCommandOn: aBuilder [
 	(aBuilder item: #Tools)
 		order: 1.0;
 		target: self;
+		help: 'Set of tools to get a better Pharo experience.';
 		iconName: #toolsIcon
 ]
 

--- a/src/Tool-Catalog/CatalogBrowser.class.st
+++ b/src/Tool-Catalog/CatalogBrowser.class.st
@@ -35,6 +35,7 @@ CatalogBrowser class >> menuCommandOn: aBuilder [
 		order: 0.19;
 		iconName: #catalogIcon;
 		parent: #Tools;
+		help: 'Project catalog from pharo official repositories.';
 		action: [ self open ]
 ]
 

--- a/src/Tool-CriticBrowser/CriticBrowser.class.st
+++ b/src/Tool-CriticBrowser/CriticBrowser.class.st
@@ -35,7 +35,7 @@ CriticBrowser class >> criticsBrowserMenuOn: aBuilder [
 		action: [ self openOnCurrentWorkingConfiguration];
 		order: 0.41;
 		parent: #Tools;
-		help: 'To manage rule checks';
+		help: 'To manage rule checks.';
 		icon: self icon
 ]
 

--- a/src/Tool-DependencyAnalyser-UI/DAPackageDependenciesWelcome.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageDependenciesWelcome.class.st
@@ -58,6 +58,7 @@ DAPackageDependenciesWelcome class >> menuCommandOn: aBuilder [
 		parent: #Tools;
 		label: 'Dependency Analyser';
 		icon: (self iconNamed: #packageIcon);
+		help: 'Analyze dependencies between different packages in the image.';
 		action: [ self new open ]
 ]
 

--- a/src/Tool-FileList/FileList.class.st
+++ b/src/Tool-FileList/FileList.class.st
@@ -131,14 +131,15 @@ FileList class >> itemsForFile: file [
 ]
 
 { #category : #'world menu' }
-FileList class >> menuCommandOn: aBuilder [ 
-	<worldMenu> 
+FileList class >> menuCommandOn: aBuilder [
+	<worldMenu>
 	(aBuilder item: #'File Browser')
 		parent: #Tools;
 		order: 0.43;
-		action:[self open]; 
+		action: [ self open ];
+		help: 'Browse the files present on your system.';
 		icon: self taskbarIcon.
-	aBuilder withSeparatorAfter.		
+	aBuilder withSeparatorAfter
 ]
 
 { #category : #'morphic ui' }

--- a/src/Tool-ProcessBrowser/ProcessBrowser.class.st
+++ b/src/Tool-ProcessBrowser/ProcessBrowser.class.st
@@ -157,7 +157,8 @@ ProcessBrowser class >> menuCommandOn: aBuilder [
 	(aBuilder item: #'Process Browser')
 		parent: #Tools;
 		order: 0.42;
-		action:[self open]; 
+		action:[ self open ];
+		help: 'Provides a view of all of the processes (threads) executing in Smalltalk.';
 		icon: self taskbarIcon.
 ]
 

--- a/src/Tool-Profilers/TimeProfiler.class.st
+++ b/src/Tool-Profilers/TimeProfiler.class.st
@@ -63,6 +63,7 @@ TimeProfiler class >> menuCommandOn: aBuilder [
 		parent: #Tools;  
 		order: 0.40;
 		icon: self taskbarIcon;
+		help: 'Profile the execution of a piece of code and navigate into the result.';
 		action: [TimeProfiler new open]
 ]
 

--- a/src/Tool-SystemReporter/SystemReporter.class.st
+++ b/src/Tool-SystemReporter/SystemReporter.class.st
@@ -37,7 +37,7 @@ SystemReporter class >> systemReporterMenuOn: aBuilder [
 	(aBuilder item: #'System Reporter')
 		parent: #System;
 		action: [ self open ];
-		help: 'If you have a bug, use this tool to provide information about your system'.
+		help: 'If you have a bug, use this tool to provide information about your system.'.
 ]
 
 { #category : #operations }

--- a/src/Transcript-Tool/ThreadSafeTranscript.extension.st
+++ b/src/Transcript-Tool/ThreadSafeTranscript.extension.st
@@ -15,6 +15,7 @@ ThreadSafeTranscript class >> menuCommandOn: aBuilder [
 		parent: #Tools;
 		help: 'Transcript';
 		keyText: 'o, t';
+		help: 'Window on the Transcript output stream, which is useful for writing log messages.';
 		icon: self taskbarIcon.
 	aBuilder withSeparatorAfter
 

--- a/src/Versionner-Spec-Browser/VersionnerSpecBrowser.class.st
+++ b/src/Versionner-Spec-Browser/VersionnerSpecBrowser.class.st
@@ -63,6 +63,7 @@ VersionnerSpecBrowser class >> menuCommandOn: aBuilder [
 		parent: #Tools;
 		label: 'Versionner';
 		iconName: #databaseIcon;
+		help: 'Create and edit project configurations for code versionned via Monticello.';
 		action: [ VersionnerSpecBrowser open ]
 ]
 


### PR DESCRIPTION
- Add help to every menu entry of the world menu- Be sur every help begin with an uppercase and end with a dot- Add a release test to be sure we do not integrate a tool without help menu laterCase 20869 : https://pharo.fogbugz.com/f/cases/20869/Add-tooltips-to-world-menu-entries/!\/!\/!\ To integrate after https://github.com/pharo-vcs/iceberg/pull/538 for the release test /!\/!\/!\