### PR TITLE
20797-Exception-class-missing-a-method

### DIFF
--- a/src/Kernel-Tests/ExceptionTests.class.st
+++ b/src/Kernel-Tests/ExceptionTests.class.st
@@ -243,6 +243,20 @@ ExceptionTests >> testSignalFromHandlerActionTest [
 ]
 
 { #category : #'tests - exceptiontester' }
+ExceptionTests >> testSignalWithTag [
+	| aTag |
+	aTag := Object new.
+	
+	[ 
+		DomainError signal: 'aMessage' withTag: aTag.
+		self fail: 'The exception was not signaled'. 
+	] on: DomainError do: [ :e | 
+		self assert: e messageText equals: 'aMessage'.
+		self assert: e tag equals: aTag.
+	]
+]
+
+{ #category : #'tests - exceptiontester' }
 ExceptionTests >> testSimpleEnsure [
 	self assertSuccess: (ExceptionTester new runTest: #simpleEnsureTest ) 
 ]

--- a/src/Kernel/Exception.class.st
+++ b/src/Kernel/Exception.class.st
@@ -82,6 +82,16 @@ Exception class >> signal: message in: context [
 ]
 
 { #category : #exceptioninstantiator }
+Exception class >> signal: message withTag: aTag [
+	"Signal the occurrence of an exceptional condition with a specified textual description including a tag for the exception."
+
+	^ self new 
+		messageText: message;
+		tag: aTag; 
+		signal
+]
+
+{ #category : #exceptioninstantiator }
 Exception class >> signalIn: context [
 	"Signal the occurrence of an exceptional condition in the given context."
 


### PR DESCRIPTION
Adding  a new constructor to exception to include the tag. 
And adding a test for it.