### PR TITLE
19913-Nautilus-Class-pane-have-a-weird-behavior-when-we-hold-shift-while-clicking-on-classes

### DIFF
--- a/src/Nautilus/ClassWidget.class.st
+++ b/src/Nautilus/ClassWidget.class.st
@@ -27,22 +27,21 @@ ClassWidget >> abstractColorAdjust: aColor [
 
 { #category : #'item creation' }
 ClassWidget >> buildClassesList [
-	classesList := self class listClass new
+	^ classesList := self class listClass new
 				basicWrapSelector: #classWrapper:;
-				keystrokeSelector: #keyPressedOnList:shifted:;
-				getIconSelector: #classIconFor:;
-				getListSizeSelector: #classListSize;
-				
 				resetListSelector: #resetClassSelection;
+				keystrokeSelector: #keyPressedOnList:shifted:;
 				autoDeselect: true;
-				dropEnabled: true;
+				getListSizeSelector: #classListSize;
+
 				dropItemSelector: #dropInClass:inARow:;
-				doubleClickSelector: #doubleClick:;
-				dragEnabled: true;
+				dragEnabled: true; dropEnabled: true;
 				hResizing: #spaceFill;
 				vResizing: #spaceFill;
-				
-				model: self;
+
+				getIconSelector: #classIconFor:;
+				model: self;								
+				doubleClickSelector: #doubleClick:;
 				getIndexSelector: #selectedClassIndex;
 				setIndexSelector: #selectedClassIndex:;
 				getSelectionListSelector: #classSelectionAt:;
@@ -50,9 +49,12 @@ ClassWidget >> buildClassesList [
 				getMenuSelector: #classesMenu:shifted:;
 				beMultipleSelection;
 				
-				getListElementSelector: #getClassItem:.
-						
-	^ classesList
+				getListElementSelector: #getClassItem: ;
+				
+				changed;
+				
+				yourself					
+
 ]
 
 { #category : #private }
@@ -122,7 +124,8 @@ ClassWidget >> classSelectionAt: anIndex put: aBoolean [
 	aBoolean ifNil: [ ^ self ].
 	elt := self getClassesList at: anIndex ifAbsent: [ ^ self ].
 	self classesSelection at: elt put: aBoolean.
-	self model changed: #hasSelectedSelections
+			
+	^ aBoolean
 ]
 
 { #category : #'private list model' }
@@ -337,13 +340,11 @@ ClassWidget >> selectedClassIndex [
 { #category : #'private list model' }
 ClassWidget >> selectedClassIndex: anInteger [
 	| selection |
-	
 	selection := self getClassesList at: anInteger ifAbsent: [nil].
 	
 	self model showInstance ifFalse: [selection ifNotNil: [selection := selection theMetaClass]].
 	self model selectedClassWithoutChangingSelection: selection.
 	
-	self changed: #selectedClassIndex.
 	self model changed: #currentHistoryIndex.
 ]
 


### PR DESCRIPTION

Fixing the nautilus class selection to work properly in both scenarios, when selecting only one or multiple.

https://pharo.fogbugz.com/f/cases/19913