### PR TITLE
20938-Add-PrimitiveError-to-Pharo

### DIFF
--- a/src/System-Support/Object.extension.st
+++ b/src/System-Support/Object.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : #Object }
 
 { #category : #'*System-Support' }
+Object >> isPrimitiveError [
+	"Answer a boolean indicating if the receiver is an error object returned by a primitive"
+	^false
+]
+
+{ #category : #'*System-Support' }
 Object class >> registerToolsOn: aToolRegistry [
 
 	" Override to register any tools for Smalltalk tools registry. " 

--- a/src/System-Support/PrimitiveError.class.st
+++ b/src/System-Support/PrimitiveError.class.st
@@ -1,0 +1,60 @@
+"
+A PrimitiveError is used to answer a primitive failure code that has an associated operating system/library error.
+
+Instance Variables
+	errorName:		<Symbol>
+	errorCode:		<Integer>
+
+errorName
+	- typically #'operating system error'
+
+errorCode
+	- the value of the error, a signed 64-bit value, a representation imposed by the VM; specific clients must map this error value into an unsigned value as appropriate if required
+
+Typical usage is shown in the ficticious method below:
+
+primitiveOperation
+	<primitive: 'primitiveOperation' module: 'APlugin' error: error>
+	^(error isPrimitiveError)
+		ifTrue: [ self processErrorCode: error errorCode ]
+		ifFalse: [ self primitiveFailed ].
+"
+Class {
+	#name : #PrimitiveError,
+	#superclass : #Object,
+	#instVars : [
+		'errorName',
+		'errorCode'
+	],
+	#category : #'System-Support'
+}
+
+{ #category : #accessing }
+PrimitiveError >> errorCode [
+	
+	^errorCode
+]
+
+{ #category : #accessing }
+PrimitiveError >> errorCode: anInteger [
+	
+	errorCode := anInteger
+]
+
+{ #category : #accessing }
+PrimitiveError >> errorName [
+	
+	^errorName
+]
+
+{ #category : #accessing }
+PrimitiveError >> errorName: aSymbol [
+	
+	errorName := aSymbol
+]
+
+{ #category : #testing }
+PrimitiveError >> isPrimitiveError [
+	"Answer a boolean indicating if the receiver is an error object returned by a primitive"
+	^true
+]

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1282,7 +1282,8 @@ SmalltalkImage >> newSpecialObjectsArray [
 							#'internal error in named primitive machinery'
 							#'object may move' #'resource limit exceeded'
 							#'object is pinned' #'primitive write beyond end of object'
-							#'object moved' #'object not pinned' #'callback error').
+							#'object moved' #'object not pinned' #'callback error'),
+							{PrimitiveError new errorName: #'operating system error'; yourself}.
 	"53 to 55 are for Alien"
 	newArray at: 53 put: (self at: #Alien ifAbsent: []).
 	newArray at: 54 put: #invokeCallbackContext:. "use invokeCallback:stack:registers:jmpbuf: for old Alien callbacks."


### PR DESCRIPTION
20938-Add-PrimitiveError-to-Pharo

Add PrimitiveError and update the SmalltalkImage special objects array to point to it.See: https://pharo.fogbugz.com/f/cases/20938/