### PR TITLE
20946-Modifying-a-class-with-read-only-instances-should-raise-a-proper-error

### DIFF
--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -274,6 +274,11 @@ ShiftClassBuilder >> fillFor: aClass [
 		copyClassSlotsFromExistingClass
 ]
 
+{ #category : #testing }
+ShiftClassBuilder >> hasToMigrateInstances [
+	^ self changes anySatisfy: [ :e | e hasToMigrateInstances ]
+]
+
 { #category : #initialization }
 ShiftClassBuilder >> initialize [
 	super initialize.

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -113,3 +113,38 @@ ShClassInstallerTest >> testModifyingSuperclassInOtherOrder [
 	self assert: (obj instVarNamed: #anSubInstanceVariable) equals: 17
 
 ]
+
+{ #category : #tests }
+ShClassInstallerTest >> testTryingToModifyReadOnlyInstances [
+	| obj obj2 |
+	newClass := self newClass: #ShCITestClass slots: #(anInstanceVariable).
+	
+	obj := newClass new.	
+	obj instVarNamed: #anInstanceVariable put: 7.
+	obj beReadOnlyObject.
+			
+	obj2 := newClass new.	
+	obj2 instVarNamed: #anInstanceVariable put: 17.
+
+	self should: [self newClass:#ShCITestClass slots:#(otherVariable anInstanceVariable)] raise: Error.
+
+]
+
+{ #category : #tests }
+ShClassInstallerTest >> testTryingToModifyReadOnlySubInstances [
+	| obj obj2 |
+	superClass := self newClass: #ShCITestSuperClass slots: #(aSuperVariable).
+	newClass := self newClass: #ShCITestClass superclass: superClass slots: #(anInstanceVariable).
+	
+	obj := newClass new.	
+	obj instVarNamed: #aSuperVariable put: 1.
+	obj instVarNamed: #anInstanceVariable put: 7.
+	obj beReadOnlyObject.
+			
+	obj2 := newClass new.	
+	obj2 instVarNamed: #aSuperVariable put: 11.
+	obj2 instVarNamed: #anInstanceVariable put: 17.
+
+	self should: [self newClass:#ShCITestClass slots:#(otherVariable anInstanceVariable)] raise: Error.
+
+]

--- a/src/Shift-ClassInstaller/ManifestShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ManifestShiftClassInstaller.class.st
@@ -4,5 +4,5 @@ I store metadata for this package. These meta data are used by other tools such 
 Class {
 	#name : #ManifestShiftClassInstaller,
 	#superclass : #PackageManifest,
-	#category : #'Shift-ClassInstaller'
+	#category : 'Shift-ClassInstaller'
 }

--- a/src/Shift-ClassInstaller/ShiftAnonymousClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftAnonymousClassInstaller.class.st
@@ -7,7 +7,7 @@ I have exactly the same interface than the main class installer.
 Class {
 	#name : #ShiftAnonymousClassInstaller,
 	#superclass : #ShiftClassInstaller,
-	#category : #'Shift-ClassInstaller'
+	#category : 'Shift-ClassInstaller'
 }
 
 { #category : #accessing }

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -139,6 +139,8 @@ ShiftClassInstaller >> make: aBlock [
 		builder oldClass: oldClass.
 		newClass := builder build.
 
+		self validateReadOnlyInstancesOf: oldClass.
+
 		self installInEnvironment: newClass.
 
 		self installSubclassInSuperclass: newClass.
@@ -168,7 +170,7 @@ ShiftClassInstaller >> migrateClassTo: newClass [
 	| slotsToMigrate |
 	oldClass ifNil:[^ self].
 	self assert: newClass isNotNil.
-	
+		
 	oldClass 	superclass removeSubclass: oldClass.
 
 	newClass subclasses: oldClass subclasses.
@@ -181,7 +183,7 @@ ShiftClassInstaller >> migrateClassTo: newClass [
 	].
 	
 	[ 	
-		(self builder changes anySatisfy: [ :e | e hasToMigrateInstances ]) 
+		(self builder hasToMigrateInstances) 
 			ifTrue: [self migrateInstancesTo: newClass].
 
 		{ oldClass. builder oldMetaclass } elementsForwardIdentityTo: { newClass. builder newMetaclass }.	
@@ -243,4 +245,14 @@ ShiftClassInstaller >> remake: aClass [
 { #category : #building }
 ShiftClassInstaller >> updateBindings: aBinding of: newClass [
 	newClass methods do: [ :e | e classBinding: aBinding ]
+]
+
+{ #category : #validating }
+ShiftClassInstaller >> validateReadOnlyInstancesOf: aClass [
+	
+	builder hasToMigrateInstances ifFalse: [ ^ self ].
+	
+	(aClass allSubInstances anySatisfy: [ :anInstance | anInstance isReadOnlyObject ]) ifTrue:[
+		self error: 'There are read only instances of the class to modify. Aborting the creation of classes'
+	]
 ]


### PR DESCRIPTION
Modifying a class with read only instances should raise a proper error.
When a class is modified and it has read-only instances the migration process is not possible. 
The class installer should report a proper error.
Also all the subinstances should be checked.

Issue: https://pharo.fogbugz.com/f/cases/20946/Modifying-a-class-with-read-only-instances-should-raise-a-proper-error