### PR TITLE
21044-InspectorNavigatordefaultWindowModelClass-has-unused-tem

### DIFF
--- a/src/Spec-Inspector/InspectorNavigator.class.st
+++ b/src/Spec-Inspector/InspectorNavigator.class.st
@@ -107,7 +107,6 @@ InspectorNavigator >> customMenuActions [
 
 { #category : #accessing }
 InspectorNavigator >> defaultWindowModelClass [
-	| stdout |
 	Stdio stdout wantsLineEndConversion: true; converter.
 	Stdio stdout << self class name ; cr.
 	^ TickingWindowPresenter


### PR DESCRIPTION
InspectorNavigator>>#defaultWindowModelClass has unused tem

https://pharo.fogbugz.com/f/cases/21044/InspectorNavigator-defaultWindowModelClass-has-unused-tem