### PR TITLE
21045-debugging-code-left-in-method-should-not-highlight-the-whole-method

### DIFF
--- a/src/GeneralRules/RBCodeCruftLeftInMethodsRule.class.st
+++ b/src/GeneralRules/RBCodeCruftLeftInMethodsRule.class.st
@@ -28,6 +28,14 @@ RBCodeCruftLeftInMethodsRule >> addRuleRemoving: patternString [
 	self replace: findString with: replaceString
 ]
 
+{ #category : #helpers }
+RBCodeCruftLeftInMethodsRule >> anchorFor: aNode [
+	"we do not use the method of the superclass as it hightlights far too much"
+    ^ ReIntervalSourceAnchor
+            entity: aNode
+            interval: (1 to: aNode methodNode selector size).
+]
+
 { #category : #private }
 RBCodeCruftLeftInMethodsRule >> debuggingPatterns [
 	| result |


### PR DESCRIPTION
"debugging code left in method" should not highlight the whole method

https://pharo.fogbugz.com/f/cases/21045/debugging-code-left-in-method-should-not-highlight-the-whole-method