### PR TITLE
20057-Autocomplete-crashes-for-trait-methods

### DIFF
--- a/src/NECompletion/NECOverrideModel.class.st
+++ b/src/NECompletion/NECOverrideModel.class.st
@@ -37,5 +37,6 @@ NECOverrideModel >> methodAt: aNumber [
 
 { #category : #action }
 NECOverrideModel >> title [
-	^ '(override) ' , clazz superclass name
+	^ '(override) ' , 
+            (clazz superclass ifNotNil: #name ifNil: [ clazz name ])
 ]


### PR DESCRIPTION
Autocomplete crashes for trait methods

https://pharo.fogbugz.com/f/cases/20057/Autocomplete-crashes-for-trait-methods