### PR TITLE
21179-sendersOfCritic-should-not-use-AbstractTool

### DIFF
--- a/src/Tool-CriticBrowser/SingleCodeCriticResultList.class.st
+++ b/src/Tool-CriticBrowser/SingleCodeCriticResultList.class.st
@@ -429,14 +429,11 @@ SingleCodeCriticResultList >> selectionIntervalFor: aString [
 
 { #category : #menu }
 SingleCodeCriticResultList >> sendersOfCritic [
-
-	| abstractTool |
-	abstractTool := AbstractTool new. 	
 	criticsModel selectedItem
 		ifNotNil: [ :elem | 
-			elem isBehavior 
-				ifTrue: [ abstractTool browseClassRefsOf: elem ]
-				ifFalse: [ abstractTool browseSendersOfMessagesFrom: elem selector ] ] 
+			elem isBehavior
+				ifTrue: [ self systemNavigation browseAllCallsOnClass: elem ]
+				ifFalse: [ self systemNavigation browseAllSendersOf: elem selector ] ]
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
#sendersOfCritic should not use AbstractTool

https://pharo.fogbugz.com/f/cases/21179/sendersOfCritic-should-not-use-AbstractTool