### PR TITLE
21231-tabmorph-close-icon-is-not-well-aligned

### DIFF
--- a/src/Morphic-Widgets-Tabs/TabMorph.class.st
+++ b/src/Morphic-Widgets-Tabs/TabMorph.class.st
@@ -370,10 +370,10 @@ TabMorph >> addIcon [
 		fullFrame: (LayoutFrame identity
 			bottomFraction: 0;
 			leftFraction: 1;
-			topOffset: 8; "tab height : 26px, icon height: 12 px -> (26 - 12 / 4) + 1"
+			topOffset: 6; 
 			leftOffset: self iconRightOffset negated - 12;
 			rightOffset: self iconRightOffset negated;
-			bottomOffset: 20; "8 + 12"
+			bottomOffset: 18; 
 			yourself)
 ]
 


### PR DESCRIPTION
fix alignment

fixes issue #21231