### PR TITLE
21232-BenchmarkResultprintFrequencyOn-can-be-confusing

### DIFF
--- a/src/Kernel/BenchmarkResult.class.st
+++ b/src/Kernel/BenchmarkResult.class.st
@@ -85,9 +85,7 @@ BenchmarkResult >> period [
 
 { #category : #printing }
 BenchmarkResult >> printFrequenceOn: stream [
-	self frequency > 999
-		ifTrue: [ self frequency rounded printWithCommasOn: stream ]
-		ifFalse: [ self frequency printOn: stream showingDecimalPlaces: 3 ].
+	self frequency printOn: stream showingDecimalPlaces: 3.
 	stream << ' per second'
 ]
 


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21232/BenchmarkResult-printFrequencyOn-can-be-confusingThe result of BlockClosure>>#bench and BlockClosure>>#benchFor: can be confusing because they both use BenchmarkResult>>#printFrequencyOn: which (in the spirit of backward compatibility) tried to be clever by sometimes using a $, thousands separator (for large numbers) and a $. decimal point for smaller numbers.

Let's pick one format, the plain float with 3 decimals of precision.