### PR TITLE
21227-MBCommandrepositoryOfPackageNamed-sends-MCCacheRepository-default

### DIFF
--- a/src/Versionner-Core-Commands/MBCommand.class.st
+++ b/src/Versionner-Core-Commands/MBCommand.class.st
@@ -289,7 +289,7 @@ MBCommand >> repositoryOfPackageNamed: packageName [
 	| mcPackage workingCopy repositories repository repositoryIndex username password |
 	mcPackage := MCPackage named: packageName.
 	workingCopy := mcPackage workingCopy.
-	repositories := workingCopy repositoryGroup repositories reject: [ :rep | rep == MCCacheRepository default ].
+	repositories := workingCopy repositoryGroup repositories reject: [ :rep | rep == MCCacheRepository uniqueInstance ].
 	repositories
 		ifEmpty: [ 
 			| projectName answer squeakSourceURL |


### PR DESCRIPTION
MBCommand>>#repositoryOfPackageNamed: sends MCCacheRepository default

https://pharo.fogbugz.com/f/cases/21227/MBCommand-repositoryOfPackageNamed-sends-MCCacheRepository-default