### PR TITLE
21245-SmalltalkImage current imageDirectory should give a fileReference instead of a path

### DIFF
--- a/src/FileSystem-Tests-Core/DirectoryEntryTest.class.st
+++ b/src/FileSystem-Tests-Core/DirectoryEntryTest.class.st
@@ -27,7 +27,8 @@ DirectoryEntryTest >> testIsDirectory [
 	| ref entry |
 	ref := FileLocator imageDirectory resolve.
 	entry := ref entry.
-	self assert: entry isDirectory
+	self assert: entry isDirectory.
+	self assert: FileLocator imageDirectory resolve equals: Smalltalk imageDirectory
 ]
 
 { #category : #tests }

--- a/src/FileSystem-Tests-Core/FileLocatorTest.class.st
+++ b/src/FileSystem-Tests-Core/FileLocatorTest.class.st
@@ -85,7 +85,7 @@ FileLocatorTest >> testFileSystem [
 { #category : #'resolution tests' }
 FileLocatorTest >> testImageDirectory [
 	locator := FileLocator image.
-	self assert: locator resolve = FileLocator image resolve
+	self assert: locator resolve equals: FileLocator image resolve
 ]
 
 { #category : #'compatibility tests' }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -777,7 +777,7 @@ SmalltalkImage >> image [
 SmalltalkImage >> imageDirectory [
 	"Answer the directory containing the current image."
 
-	^ (Path from: self primImagePath) parent
+	^ self primImagePath asFileReference parent
 ]
 
 { #category : #'image, changes name' }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -258,7 +258,7 @@ SmalltalkImage >> backupImageInFileNamed: aFileReference [
 { #category : #saving }
 SmalltalkImage >> backupTo: newNameWithoutSuffix [
 	"Create a new backup of this image. 
-	Unlike #saveAs: do not transfer the default execution to the new image. 
+	Unlike #saveAs:, I do not transfer the default execution to the new image. 
 	Results:
 		true  when continuing in the new session
 		false for the current session"


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21245/SmalltalkImage-current-imageDirectory-should-give-a-fileReference-instead-of-a-path