### PR TITLE
21256-Deprecated-glmSubscriptions-is-used-in-GLMBrickPropertiesTrait

### DIFF
--- a/src/Glamour-Morphic-Brick/GLMBrickPropertiesTrait.trait.st
+++ b/src/Glamour-Morphic-Brick/GLMBrickPropertiesTrait.trait.st
@@ -16,12 +16,13 @@ GLMBrickPropertiesTrait >> announce: anAnnouncement [
 
 { #category : #'brick-properties-events' }
 GLMBrickPropertiesTrait >> announce: aSymbol event: anEvent [
-
-	self announcer subscriptions glmSubscriptions do: [ :each |
-		each announcementClass = aSymbol ifTrue: [
-			(each handlesAnnouncement: aSymbol ) ifTrue: [
-				[ each action cull: anEvent cull: self ] 
-					on: UnhandledError fork: [:ex | ex pass ] ] ] ]
+	self announcer subscriptions subscriptions
+		do: [ :each | 
+			each announcementClass = aSymbol
+				ifTrue: [ (each handlesAnnouncement: aSymbol)
+						ifTrue: [ [ each action cull: anEvent cull: self ]
+								on: UnhandledError
+								fork: [ :ex | ex pass ] ] ] ]
 ]
 
 { #category : #'brick-properties' }


### PR DESCRIPTION
#glmSubscriptions was deprecated for #subscriptions. Remove its usage in GLMBrickPropertiesTrait.

Case 21256 : https://pharo.fogbugz.com/f/cases/21256/Deprecated-glmSubscriptions-is-used-in-GLMBrickPropertiesTrait