### PR TITLE
21249-Pharo-should-includes-Metacello-Cypress

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -66,8 +66,9 @@ BaselineOfBasicTools >> baseline: spec [
 		spec package: 'Nautilus-GroupManagerUI'.
 		spec package: 'Komitter'.
 		
-		spec package: 'Announcements-Help'.	
+		spec package: 'Announcements-Help'.
 		spec package: 'Metacello-FileTree'.
+		spec package: 'Metacello-Cypress'.
 		spec package: 'Metacello-ProfStef'.
 		spec package: 'Metacello-Reference'.
 		spec package: 'Metacello-Tutorial'.


### PR DESCRIPTION
Add Cypress support to Metacello. (Already in Pharo 6.1)

Case 21249 : https://pharo.fogbugz.com/f/cases/21249/Pharo-should-includes-Metacello-Cypress