### PR TITLE
21258-Add-an-option-do-disable-WorldMorphs-drag-and-drop-for-deployment

### DIFF
--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -12,6 +12,7 @@ Class {
 		'session'
 	],
 	#classVars : [
+		'AllowDropFiles',
 		'CursorOwnerWorld',
 		'ExtraWorldList'
 	],
@@ -21,6 +22,18 @@ Class {
 { #category : #'extra worlds' }
 WorldMorph class >> addExtraWorld: aWorld [
 	ExtraWorldList := self extraWorldList copyWith: aWorld
+]
+
+{ #category : #accessing }
+WorldMorph class >> allowDropFiles [
+	"If this option is set to false, the world morph will no longer be able to receive droped files. This help to protect private code while deploying an application."
+	
+	^ AllowDropFiles ifNil: [ AllowDropFiles := true ]
+]
+
+{ #category : #accessing }
+WorldMorph class >> allowDropFiles: anObject [
+	AllowDropFiles := anObject
 ]
 
 { #category : #'system startup' }
@@ -535,7 +548,9 @@ WorldMorph >> wantsDirectionHandles [
 
 { #category : #'event handling' }
 WorldMorph >> wantsDropFiles: anEvent [
-	^ true
+	"We check if the WorldMorph is configured to be able to receive droped files. During the deployment of an application this option might be disabled."
+	
+	^ self class allowDropFiles
 ]
 
 { #category : #private }


### PR DESCRIPTION
Add an option to disable the drop of files in the WorldMorph. 

This option can be used when we deploy an application to protect the code.

Case 21258 : https://pharo.fogbugz.com/f/cases/21258/Add-an-option-do-disable-WorldMorph-s-drag-and-drop-for-deployment