### PR TITLE
21263-WorldState--displayWorldsubmorphs--canvas--finish---canvas-can-be-nil-at-startup-of-the-image

### DIFF
--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -425,32 +425,38 @@ WorldState >> displayWorld: aWorld submorphs: submorphs [
 	"Update this world's display."
 
 	| deferredUpdateMode handsToDraw allDamage |
-
-	submorphs do: [:m | m fullBounds].  "force re-layout if needed"
-	self checkIfUpdateNeeded ifFalse: [^ self].  "display is already up-to-date"
-
+	submorphs do: [ :m | m fullBounds ].	"force re-layout if needed"
+	self checkIfUpdateNeeded
+		ifFalse: [ ^ self ].	"display is already up-to-date"
 	deferredUpdateMode := self doDeferredUpdatingFor: aWorld.
-	deferredUpdateMode ifFalse: [self assuredCanvas].
-	canvas roundCornersOf: aWorld during:[ | worldDamageRects handDamageRects |
-		worldDamageRects := self drawWorld: aWorld submorphs: submorphs invalidAreasOn: canvas.  "repair world's damage on canvas"
-		"self handsDo:[:h| h noticeDamageRects: worldDamageRects]."
-		handsToDraw := self selectHandsToDrawForDamage: worldDamageRects.
-		handDamageRects := handsToDraw collect: [:h | h savePatchFrom: canvas].
-		allDamage := worldDamageRects, handDamageRects.
-
-		handsToDraw reverseDo: [:h | canvas fullDrawMorph: h].  "draw hands onto world canvas"
-	].
+	deferredUpdateMode
+		ifFalse: [ self assuredCanvas ].
+	canvas
+		roundCornersOf: aWorld
+		during: [ | worldDamageRects handDamageRects |
+			worldDamageRects := self
+				drawWorld: aWorld
+				submorphs: submorphs
+				invalidAreasOn: canvas.	"repair world's damage on canvas"
+			"self handsDo:[:h| h noticeDamageRects: worldDamageRects]."
+			handsToDraw := self selectHandsToDrawForDamage: worldDamageRects.
+			handDamageRects := handsToDraw
+				collect: [ :h | h savePatchFrom: canvas ].
+			allDamage := worldDamageRects , handDamageRects.
+			handsToDraw reverseDo: [ :h | canvas fullDrawMorph: h ]	"draw hands onto world canvas" ].
 	"*make this true to flash damaged areas for testing*"
-	self class debugShowDamage ifTrue: [aWorld flashRects: allDamage color: Color black].
-
-	canvas finish.
+	self class debugShowDamage
+		ifTrue: [ aWorld flashRects: allDamage color: Color black ].
+	"Check that the canvas is not already freed when we want to finish it"
+	canvas ifNotNil: [ :c | c finish ].
 	"quickly copy altered rects of canvas to Display:"
 	deferredUpdateMode
-		ifTrue: [self forceDamageToScreen: allDamage]
-		ifFalse: [canvas showAt: aWorld viewBox origin invalidRects: allDamage].
-	handsToDraw do: [:h | h restoreSavedPatchOn: canvas].  "restore world canvas under hands"
-	Display deferUpdates: false; forceDisplayUpdate.
-
+		ifTrue: [ self forceDamageToScreen: allDamage ]
+		ifFalse: [ canvas showAt: aWorld viewBox origin invalidRects: allDamage ].
+	handsToDraw do: [ :h | h restoreSavedPatchOn: canvas ].	"restore world canvas under hands"
+	Display
+		deferUpdates: false;
+		forceDisplayUpdate
 ]
 
 { #category : #'update cycle' }

--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -432,18 +432,16 @@ WorldState >> displayWorld: aWorld submorphs: submorphs [
 	deferredUpdateMode
 		ifFalse: [ self assuredCanvas ].
 	canvas
-		roundCornersOf: aWorld
-		during: [ | worldDamageRects handDamageRects |
-			worldDamageRects := self
-				drawWorld: aWorld
-				submorphs: submorphs
-				invalidAreasOn: canvas.	"repair world's damage on canvas"
-			"self handsDo:[:h| h noticeDamageRects: worldDamageRects]."
-			handsToDraw := self selectHandsToDrawForDamage: worldDamageRects.
-			handDamageRects := handsToDraw
-				collect: [ :h | h savePatchFrom: canvas ].
-			allDamage := worldDamageRects , handDamageRects.
-			handsToDraw reverseDo: [ :h | canvas fullDrawMorph: h ]	"draw hands onto world canvas" ].
+		ifNotNil: [ :c | 
+			c
+				roundCornersOf: aWorld
+				during: [ | worldDamageRects handDamageRects |
+					worldDamageRects := self drawWorld: aWorld submorphs: submorphs invalidAreasOn: canvas.	"repair world's damage on canvas"
+					"self handsDo:[:h| h noticeDamageRects: worldDamageRects]."
+					handsToDraw := self selectHandsToDrawForDamage: worldDamageRects.
+					handDamageRects := handsToDraw collect: [ :h | h savePatchFrom: canvas ].
+					allDamage := worldDamageRects , handDamageRects.
+					handsToDraw reverseDo: [ :h | "draw hands onto world canvas" canvas fullDrawMorph: h ] ] ].
 	"*make this true to flash damaged areas for testing*"
 	self class debugShowDamage
 		ifTrue: [ aWorld flashRects: allDamage color: Color black ].


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21263/WorldState-displayWorld-submorphs-canvas-finish-canvas-can-be-nil-at-startup-of-the-image