### PR TITLE
21265 SizeInMemoryTest should use utilities category

### DIFF
--- a/src/Kernel-Tests/SizeInMemoryTest.class.st
+++ b/src/Kernel-Tests/SizeInMemoryTest.class.st
@@ -7,20 +7,20 @@ Class {
 	#category : #'Kernel-Tests-Objects'
 }
 
-{ #category : #utils }
+{ #category : #utilities }
 SizeInMemoryTest >> align64Bits: size [
 	size % 8 = 0
 		ifTrue: [ ^ size ]
 		ifFalse:[ ^ size + 8 - (size % 8) ].
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 SizeInMemoryTest >> headerSize [
 	" The header is 64 bits"
 	^ 8
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 SizeInMemoryTest >> paddedByteStringSize: numberOfChars [ 
 	"64 bits for the header"
 	| originalSize  |


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21265/SizeInMemoryTest-should-use-utilities-category


only recategorization - no change in behavior