### PR TITLE
21267 NECTestSuperClass should use utilities category

### DIFF
--- a/src/NECompletion-Tests/NECTestSuperClass.class.st
+++ b/src/NECompletion-Tests/NECTestSuperClass.class.st
@@ -28,13 +28,13 @@ NECTestSuperClass >> testIt: aString [
 	self subclassResponsibility 
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 NECTestSuperClass >> toBeOverriden: anArgument [ 
 	15 > 16
 		ifTrue: [self sample * anArgument ]
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 NECTestSuperClass >> toBeOverridenWithReturn [
 	^ 'saga'
 ]


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21267/NECTestSuperClass-should-use-utilities-category