### PR TITLE
21279 WatchPointWindow should have consistent menu

### DIFF
--- a/src/Reflectivity-Tools/WatchpointWindow.class.st
+++ b/src/Reflectivity-Tools/WatchpointWindow.class.st
@@ -79,7 +79,7 @@ WatchpointWindow >> initializeWidgets [
 	numItems := 7.
 	self refreshItems.
 	
-	inspectIt label: 'Inspect ...'.
+	inspectIt label: 'Inspect...'.
 	inspectIt enabled: false.
 ]
 


### PR DESCRIPTION
'Inspect...' instead of 'Inspect ...' (without space) to be consistent

https://pharo.fogbugz.com/f/cases/21279/WatchPointWindow-should-have-consistent-menu