### PR TITLE
21315 Remove unnecessary "self run:" in ChangeSetClassChangesTest

### DIFF
--- a/src/Tests/ChangeSetClassChangesTest.class.st
+++ b/src/Tests/ChangeSetClassChangesTest.class.st
@@ -17,7 +17,7 @@ ChangeSetClassChangesTest >> categoryNameForTemporaryClasses [
 	"Answer the category where to classify temporarily created classes"
 
 	^'Dummy-Tests-Class' 
-]
+] 
 
 { #category : #support }
 ChangeSetClassChangesTest >> deleteClass [

--- a/src/Tests/ChangeSetClassChangesTest.class.st
+++ b/src/Tests/ChangeSetClassChangesTest.class.st
@@ -235,17 +235,12 @@ ChangeSetClassChangesTest >> testChangeClassCategoryAddsNewChangeRecord [
 { #category : #testing }
 ChangeSetClassChangesTest >> testInitialChangeSet [
 	"Run this to assure the initial changeset is named. Checks bug found in 3.9 7052."
-	"self new testInitialChangeSet"
-	"self run:  #testInitialChangeSet"
 
-	self deny: (ChangeSet current printString = 'a ChangeSet named <no name -- garbage?>') .
-	
-^true
+	self deny: (ChangeSet current printString = 'a ChangeSet named <no name -- garbage?>')
 ]
 
 { #category : #support }
 ChangeSetClassChangesTest >> testRenaming [
-	"self run: #testRenaming"
 
 	| oldName newMetaclassName class |
 	oldName := className.
@@ -253,7 +248,7 @@ ChangeSetClassChangesTest >> testRenaming [
 	class := Smalltalk globals at: oldName.
 	class class compile: 'dummyMeth'.
 	class rename: renamedName.
-	self assert: class name = renamedName.
+	self assert: class name equals: renamedName.
 	self assert: (ChangeSet current changedClassNames includes: renamedName).
 	self assert: (ChangeSet current changedClassNames includes: newMetaclassName)
 ]


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21315/Remove-unnecessary-self-run-in-ChangeSetClassChangesTest


- also use assert:equals
- also cleanup #testInitialChangeSet to not have a return value