### PR TITLE
21314 Remove unnecessary "self run:" in IntervalTest and IdentityBagTest

### DIFF
--- a/src/Collections-Tests/IdentityBagTest.class.st
+++ b/src/Collections-Tests/IdentityBagTest.class.st
@@ -48,30 +48,29 @@ IdentityBagTest >> testAsSetWithEqualsElements [
 
 { #category : #tests }
 IdentityBagTest >> testIdentity [
-	"self run:#testIdentity" 
  
 	| bag identityBag aString anOtherString |
 	
 	aString := 'hello'.
 	anOtherString := aString copy.
 	
-	self assert: (aString = anOtherString).
+	self assert: aString equals: anOtherString.
 	self assert: (aString == anOtherString) not.
 
 	bag := Bag new.
 	bag add: aString.
 	bag add: aString.
 	bag add: anOtherString.
-	self assert: (bag occurrencesOf: aString) = 3.
-	self assert: (bag occurrencesOf: anOtherString) = 3.
+	self assert: (bag occurrencesOf: aString) equals: 3.
+	self assert: (bag occurrencesOf: anOtherString) equals: 3.
 	
 	identityBag := IdentityBag new.
 	identityBag add: aString.
 	identityBag add: aString.
 	identityBag add: anOtherString.
 	
-	self assert: (identityBag occurrencesOf: aString) = 2.
-	self assert: (identityBag occurrencesOf: anOtherString) = 1.
+	self assert: (identityBag occurrencesOf: aString) equals: 2.
+	self assert: (identityBag occurrencesOf: anOtherString) equals: 1.
 
 
 

--- a/src/Collections-Tests/IntervalTest.class.st
+++ b/src/Collections-Tests/IntervalTest.class.st
@@ -366,10 +366,10 @@ IntervalTest >> testAllButLastElements [
 { #category : #tests }
 IntervalTest >> testAsInterval [
 	"This is the same as newFrom:"
-	"self run: #testAsIntervaltestAsInterval"
-	self assert: (#(1 2 3) as: Interval) = (1 to: 3).
-	self assert: (#(33 5 -23) as: Interval) = (33 to: -23 by: -28).
-	self assert: (#[2 4 6] as: Interval) = (2 to: 6 by: 2).
+
+	self assert: (#(1 2 3) as: Interval) equals: (1 to: 3).
+	self assert: (#(33 5 -23) as: Interval) equals: (33 to: -23 by: -28).
+	self assert: (#[2 4 6] as: Interval) equals: (2 to: 6 by: 2).
 
 	self should: [#(33 5 -22) as: Interval]
 		raise: Error


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21314/Remove-unnecessary-self-run-in-IntervalTest-and-IdentityBagTest

- also use assert:equals: in test methods