### PR TITLE
21313 Remove unnecessary "self run:" in DelayTest

### DIFF
--- a/src/Kernel-Tests/DelayTest.class.st
+++ b/src/Kernel-Tests/DelayTest.class.st
@@ -9,7 +9,6 @@ Class {
 
 { #category : #tests }
 DelayTest >> testBounds [
-	"self run: #testBounds"
 
 	self should: [ Delay forMilliseconds: -1 ] raise: Error.
 	Delay forMilliseconds: SmallInteger maxVal // 2 + 1.
@@ -64,8 +63,6 @@ DelayTest >> testSemaphoreNoTimeout [
 DelayTest >> testSemaphoreTimeout [
 	"When we provide our own semaphore for a Delay, it should be used"
 	"See http://bugs.squeak.org/view.php?id=6834"
-
-	"self run: #testSemaphoreTimeout"
 	
 	| sem |
 	sem := Semaphore new.


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21313/Remove-unnecessary-self-run-in-DelayTest