### PR TITLE
21307 Remove unnecessary "self run:" in LargePositiveIntegerTest

### DIFF
--- a/src/Kernel-Tests/LargePositiveIntegerTest.class.st
+++ b/src/Kernel-Tests/LargePositiveIntegerTest.class.st
@@ -41,23 +41,21 @@ LargePositiveIntegerTest >> testLargeSqrtFloor [
 
 { #category : #tests }
 LargePositiveIntegerTest >> testMultDicAddSub [
-	"self run: #testMultDicAddSub"
 
 	| n f f1 |	
 	n := 100.
 	f := 100 factorial.
 	f1 := f*(n+1).
 	n timesRepeat: [f1 := f1 - f].
-	self assert: (f1 = f). 
+	self assert: f1 equals: f. 
 
 	n timesRepeat: [f1 := f1 + f].
-	self assert: (f1 // f = (n+1)). 
-	self assert: (f1 negated = (Number readFrom: '-' , f1 printString)).
+	self assert: f1 // f equals: n+1. 
+	self assert: f1 negated equals: (Number readFrom: '-' , f1 printString)
 ]
 
 { #category : #tests }
 LargePositiveIntegerTest >> testNormalize [
-	"self run: #testNormalize"
 	"Check normalization and conversion to/from SmallInts"
 
 	self assert: ((SmallInteger maxVal + 1 - 1) == SmallInteger maxVal).

--- a/src/Kernel-Tests/LargePositiveIntegerTest.class.st
+++ b/src/Kernel-Tests/LargePositiveIntegerTest.class.st
@@ -5,7 +5,7 @@ Class {
 	#name : #LargePositiveIntegerTest,
 	#superclass : #ClassTestCase,
 	#category : #'Kernel-Tests-Numbers'
-}
+} 
 
 { #category : #tests }
 LargePositiveIntegerTest >> testBitShift [


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21307/Remove-unnecessary-self-run-in-LargePositiveIntegerTest