### PR TITLE
21306 Remove unnecessary "self run:" in FractionTest

### DIFF
--- a/src/Kernel-Tests/FractionTest.class.st
+++ b/src/Kernel-Tests/FractionTest.class.st
@@ -136,7 +136,6 @@ FractionTest >> testCeiling [
 
 { #category : #'tests - mathematical functions' }
 FractionTest >> testDegreeCos [
-	"self run: #testDegreeCos"
 
 	(4 / 3) degreeCos.
 	-361 / 3 to: 359 / 3 do: [ :i | self assert: (i degreeCos closeTo: i degreesToRadians cos) ]
@@ -144,7 +143,6 @@ FractionTest >> testDegreeCos [
 
 { #category : #'tests - mathematical functions' }
 FractionTest >> testDegreeSin [
-	"self run: #testDegreeSin"
 
 	(4 / 3) degreeSin.
 	-361 / 3 to: 359 / 3 do: [ :i | self assert: (i degreeSin closeTo: i degreesToRadians sin) ]


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21306/Remove-unnecessary-self-run-in-FractionTest