### PR TITLE
21291 Remove unnecessary "self run:" in PathTest

### DIFF
--- a/src/FileSystem-Tests-Core/PathTest.class.st
+++ b/src/FileSystem-Tests-Core/PathTest.class.st
@@ -322,7 +322,6 @@ PathTest >> testIsRoot [
 
 { #category : #tests }
 PathTest >> testMakeRelative [
-	"self run: #testMakeRelative"
 	
 	| parent child relative |
 	parent := Path / 'griffle' / 'bibb'.
@@ -385,8 +384,7 @@ PathTest >> testParentUpTo [
 
 { #category : #tests }
 PathTest >> testParse [
-	"self run: #testParse"
-	
+
 	| path |
 	path := Path from: 'parent/child/grandChild' delimiter: $/.
 	self assert: path size equals: 3.
@@ -399,7 +397,6 @@ PathTest >> testParse [
 
 { #category : #tests }
 PathTest >> testParseBogus [
-	"self run: #testParseBogus"
 	
 	| path |
 	path := Path from: 'parent?<>~ \child/grandChild' delimiter: $/.
@@ -420,7 +417,6 @@ PathTest >> testParseTrailingSlash [
 
 { #category : #tests }
 PathTest >> testParseWindowsPathWithUnixDelimiters [
-	"self run: #testParse"
 	
 	| path |
 	path := WindowsStore new pathFromString: 'C:\a/b/c'.
@@ -580,7 +576,6 @@ PathTest >> testRelativePrintString [
 
 { #category : #tests }
 PathTest >> testRelativeTo [
-	"self run: #testRelativeTo"
 	"aPath relativeTo: aParent returns a new path relative to the parent"
 	
 	| parent child relative |

--- a/src/FileSystem-Tests-Core/PathTest.class.st
+++ b/src/FileSystem-Tests-Core/PathTest.class.st
@@ -30,6 +30,7 @@ PathTest >> testAbsolutePath [
 
 { #category : #tests }
 PathTest >> testAbsolutePrintString [
+	
 	| path actual |
 	path := Path / 'plonk' / 'griffle'.
 	actual := path printString.


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21291/Remove-unnecessary-self-run-in-PathTest