### PR TITLE
21322 LayoutFrameTest testIdentity should not use deprecated method fraction:

### DIFF
--- a/src/Morphic-Tests/LayoutFrameTest.class.st
+++ b/src/Morphic-Tests/LayoutFrameTest.class.st
@@ -27,7 +27,7 @@ LayoutFrameTest >> testAsLayoutFrame [
 
 { #category : #'tests - conversion' }
 LayoutFrameTest >> testIdentity [
-	self assert: (LayoutFrame fractions: (0 @ 0 corner: 1 @ 1)) = LayoutFrame identity
+	self assert: LayoutFrame new equals: LayoutFrame identity
 ]
 
 { #category : #tests }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21322/LayoutFrameTest-testIdentity-should-not-use-deprecated-method-fraction