### PR TITLE
21340-isReadOnlyObject-should-not-fail-when-VM-do-not-support-write-barrier

### DIFF
--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1243,7 +1243,7 @@ Object >> isReadOnlyObject [
 	 An attempt to modify a read-only object in a primitive will cause the
 	 primitive to fail with a #'no modification' error code."
 	<primitive: 163 error: ec>
-	^self primitiveFailed
+	^self class isImmediateClass 
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Instead of primitiveFailed the #isReadOnlyObject method returns "self class isImmediateClass" in case if error.

https://pharo.fogbugz.com/f/cases/21340/isReadOnlyObject-should-not-fail-when-VM-do-not-support-write-barrier