### PR TITLE
21287-Fix-lint-problems-in-testIndexOfSubCollectionStartingAtIfAbsent

### DIFF
--- a/src/Collections-Tests/SortedCollectionTest.class.st
+++ b/src/Collections-Tests/SortedCollectionTest.class.st
@@ -635,17 +635,17 @@ SortedCollectionTest >> testIndexOfSubCollectionStartingAt [
 { #category : #'tests - index access' }
 SortedCollectionTest >> testIndexOfSubCollectionStartingAtIfAbsent [
 	 
-	| index absent subcollection collection |
+	| absent subcollection collection |
 	collection := self collectionMoreThan1NoDuplicates.
 	subcollection := self collectionMoreThan1NoDuplicates.
 	absent := false.
-	index := collection 
+	collection 
 		indexOfSubCollection: subcollection
 		startingAt: 1
 		ifAbsent: [ absent := true ].
 	self assert: absent equals: false.
 	absent := false.
-	index := collection 
+	collection 
 		indexOfSubCollection: subcollection
 		startingAt: 2
 		ifAbsent: [ absent := true ].

--- a/src/Collections-Tests/StringTest.class.st
+++ b/src/Collections-Tests/StringTest.class.st
@@ -3,7 +3,7 @@ This is the unit test for the class String. Unit tests are a good way to exercis
 	- http://www.c2.com/cgi/wiki?UnitTest
 	- there is a chapter in the PharoByExample book (http://pharobyexample.org/)
 	- the sunit class category
-" 
+"
 Class {
 	#name : #StringTest,
 	#superclass : #CollectionRootTest,

--- a/src/Collections-Tests/TIndexAccess.trait.st
+++ b/src/Collections-Tests/TIndexAccess.trait.st
@@ -147,22 +147,15 @@ TIndexAccess >> testIndexOfSubCollectionStartingAt [
 
 { #category : #'tests - index access' }
 TIndexAccess >> testIndexOfSubCollectionStartingAtIfAbsent [
-
-	| index absent subcollection collection |
+	| absent subcollection collection |
 	collection := self collectionMoreThan1NoDuplicates.
 	subcollection := self collectionMoreThan1NoDuplicates.
 	absent := false.
-	index := collection 
-		indexOfSubCollection: subcollection
-		startingAt: 1
-		ifAbsent: [ absent := true ].
-	self assert: absent = false.
+	collection indexOfSubCollection: subcollection startingAt: 1 ifAbsent: [ absent := true ].
+	self deny: absent.
 	absent := false.
-	index := collection 
-		indexOfSubCollection: subcollection
-		startingAt: 2
-		ifAbsent: [ absent := true ].
-	self assert: absent = true
+	collection indexOfSubCollection: subcollection startingAt: 2 ifAbsent: [ absent := true ].
+	self assert: absent
 ]
 
 { #category : #'tests - index access' }


### PR DESCRIPTION
Fix lint problems in testIndexOfSubCollectionStartingAtIfAbsent

https://pharo.fogbugz.com/f/cases/21287/Fix-lint-problems-in-testIndexOfSubCollectionStartingAtIfAbsent