### PR TITLE
21350 Enhance LibC with piping and the platform with running commands

### DIFF
--- a/src/UnifiedFFI/LibC.class.st
+++ b/src/UnifiedFFI/LibC.class.st
@@ -8,7 +8,14 @@ Class {
 	#category : #'UnifiedFFI-Libraries'
 }
 
-{ #category : #misc }
+{ #category : #'api - accessing' }
+LibC class >> fgetc: aCStream [
+	"Get character from the given C stream."
+	
+	^self uniqueInstance fgetc: aCStream
+]
+
+{ #category : #'api - misc' }
 LibC class >> memCopy: from to: to size: size [
 	^ self uniqueInstance  
 		memCopy: from 
@@ -16,32 +23,113 @@ LibC class >> memCopy: from to: to size: size [
 		size: size
 ]
 
-{ #category : #misc }
+{ #category : #'api - piping' }
+LibC class >> pipe: command mode: mode [
+	"Initiate pipe streams to or from a process."
+	
+	^ self uniqueInstance pipe: command mode: mode
+]
+
+{ #category : #'api - piping' }
+LibC class >> pipeClose: stream [
+	"Close the given pipe stream."
+	
+	^ self uniqueInstance pipeClose: stream
+]
+
+{ #category : #'process actions' }
+LibC class >> resultOfCommand: aCommand [
+
+	^self uniqueInstance resultOfCommand: aCommand  
+]
+
+{ #category : #'process actions' }
+LibC class >> runCommand: aCommand [
+
+	^self uniqueInstance system: aCommand  
+]
+
+{ #category : #'api - misc' }
 LibC class >> system: command [
 	^ self uniqueInstance system: command
 ]
 
-{ #category : #'accessing platform' }
+{ #category : #'api - processes' }
+LibC >> currentProcessId [
+	"Returns the process identifier (PID) of the calling process."
+ 
+	 ^self ffiCall: #(int getpid(void)) 
+]
+
+{ #category : #'api - accessing' }
+LibC >> fgetc: stream [
+	"Get character from stream."
+	 
+	 ^self ffiCall: #(int* fgetc(ExternalAddress* stream))
+]
+
+{ #category : #'private - accessing' }
 LibC >> macModuleName [
 	^ 'libc.dylib'
 ]
 
-{ #category : #misc }
+{ #category : #'api - misc' }
 LibC >> memCopy: src to: dest size: n [
 	^ self ffiCall: #(void *memcpy(void *dest, const void *src, size_t n))
 ]
 
-{ #category : #misc }
+{ #category : #'api - processes' }
+LibC >> parentProcessId [
+	"Returns the process ID of the parent of the calling process."
+	 
+	 ^self ffiCall: #(int getppid(void))
+]
+
+{ #category : #'api - piping' }
+LibC >> pipe: command mode: mode [
+	"Initiate pipe streams to or from a process."
+	 
+	 ^self ffiCall: #(ExternalAddress* popen(char* command, char* mode))			
+			 
+]
+
+{ #category : #'api - piping' }
+LibC >> pipeClose: stream [
+	"Close the given pipe stream."
+	 
+	 ^self ffiCall: #(int* pclose(ExternalAddress* stream))
+]
+
+{ #category : #'process actions' }
+LibC >> resultOfCommand: cmd [
+	|file last s |
+	file := self pipe: cmd mode: 'r'.
+	s := String new writeStream.
+	[ last := (self fgetc: file) value.
+	  last = 16rFFFFFFFF ] whileFalse: [ 	 
+			s nextPut: (Character value: last)
+	].
+	self pipeClose: file.
+	^s contents
+]
+
+{ #category : #'process actions' }
+LibC >> runCommand: cmd [
+
+	^self system: cmd
+]
+
+{ #category : #'api - misc' }
 LibC >> system: command [
 	^ self ffiCall: #(int system #(char * command))
 ]
 
-{ #category : #'accessing platform' }
+{ #category : #'private - accessing' }
 LibC >> unixModuleName [
 	^ 'libc.so.6'
 ]
 
-{ #category : #'accessing platform' }
+{ #category : #'private - accessing' }
 LibC >> win32ModuleName [
 	"While this is not a 'libc' properly, msvcrt has the functions we are defining here"
 	^ 'msvcrt.dll'

--- a/src/UnifiedFFI/LibC.class.st
+++ b/src/UnifiedFFI/LibC.class.st
@@ -108,8 +108,7 @@ LibC >> resultOfCommand: cmd [
 	[ last := (self fgetc: file) value.
 	  last = 16rFFFFFFFF ] whileFalse: [ 	 
 			s nextPut: (Character value: last)
-	].
-	self pipeClose: file.
+	] ensure: [ self pipeClose: file ].
 	^s contents
 ]
 

--- a/src/UnifiedFFI/OSPlatform.extension.st
+++ b/src/UnifiedFFI/OSPlatform.extension.st
@@ -33,3 +33,17 @@ OSPlatform >> ffiPointerAlignment [
 	"By default is 4, windows and maybe others can use other"
 	^ Smalltalk wordSize
 ]
+
+{ #category : #'*UnifiedFFI' }
+OSPlatform >> resultOfCommand: aCommand [
+	"Run the given operating system command and return the piped command line result."
+	
+	^LibC resultOfCommand: aCommand
+]
+
+{ #category : #'*UnifiedFFI' }
+OSPlatform >> runCommand: aCommand [
+	"Run the given operating system command."
+	
+	^LibC runCommand: aCommand
+]


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21350/Enhance-LibC-with-piping-and-the-platform-with-running-commands


you can now write:

on Unix:

Smalltalk os runCommand: 'nautilus'.
Smalltalk os resultOfCommand: 'uname -s'

or on Windows

Smalltalk os runCommand: 'explorer'

or on Mac:

 Smalltalk os runCommand: 'open .'

