### PR TITLE
21351 Remove unnecessary "self run:" in BagTest (last remaining)

### DIFF
--- a/src/Collections-Tests/BagTest.class.st
+++ b/src/Collections-Tests/BagTest.class.st
@@ -395,7 +395,6 @@ BagTest >> testAsSet [
 
 { #category : #'basic tests' }
 BagTest >> testCopy [
-	"self run: #testCopy"
 	
 	| aBag newBag |
 	aBag := Bag new.


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21352/FFICompilerPluginTests-setUp-needs-to-call-super-setUp