### PR TITLE
21358-Renraku-evaluator-creates-the-AST-of-the-methods-even-if-they-are-not-used-at-all

### DIFF
--- a/src/Refactoring-Critics/ReleaseTest.extension.st
+++ b/src/Refactoring-Critics/ReleaseTest.extension.st
@@ -4,8 +4,6 @@ Extension { #name : #ReleaseTest }
 ReleaseTest >> testExplicitRequirementMethodsShouldBeImplementedInTheirUsers [
 	"If a class is using a trait with an explicit requirement method, this class should implement the method"
 	
-	self timeLimit: 300 seconds.
-
 	self assertValidLintRule: RBExplicitRequirementMethodsRule new
 	
 ]

--- a/src/Renraku/ReSmalllintChecker.class.st
+++ b/src/Renraku/ReSmalllintChecker.class.st
@@ -30,18 +30,21 @@ ReSmalllintChecker >> checkClass: aClass [
 
 { #category : #private }
 ReSmalllintChecker >> checkMethodsForClass: aClass [
+	
 	environment
 		selectorsForClass: aClass
 		do: [ :selector | | method |
 			method := aClass>>selector.
 			self getCritiquesAbout: method by: methodRules.
-			method ast nodesDo: [ :node |
-				nodeRules do: [ :r |
-					r
-						check: node
-						forCritiquesDo: [ :crit |
-							crit sourceAnchor initializeEnitity: method.
-							self addCritique: crit ] ] ] ]
+			
+			nodeRules ifNotEmpty: 
+				[	method ast nodesDo: [ :node |
+					nodeRules do: [ :r |
+						r
+							check: node
+							forCritiquesDo: [ :crit |
+								crit sourceAnchor initializeEnitity: method.
+								self addCritique: crit ] ] ]] ]
 ]
 
 { #category : #private }


### PR DESCRIPTION
Even if there is no node rule to apply the SmallLint of renraku generates the AST of the tested methods in the class.

This is affecting the release tests where all the classes are tested for some rules. The rules are not using the AST but they are created for all the classes in the image.

Issue: https://pharo.fogbugz.com/f/cases/21358/Renraku-evaluator-creates-the-AST-of-the-methods-even-if-they-are-not-used-at-all