### PR TITLE
21359-Random-Crashes-during-loading-baselines-in-the-bootstrap

### DIFF
--- a/bootstrap/scripts/build.sh
+++ b/bootstrap/scripts/build.sh
@@ -196,6 +196,13 @@ else
 fi
 dd if="displaySize.bin" of="${PHARO_IMAGE_NAME}.image" bs=1 seek=$SEEK count=4 conv=notrunc
 
+#Terrible HACK!!!! 
+#I am increasing the size of the eden space.
+#This allows to load the big baselines.
+#However, this is only needed because the VM has a bug when extending the space itself. It is corrupting the objects, this produces random crashes
+${VM} "${PHARO_IMAGE_NAME}.image" eval --save "Smalltalk vm parameterAt: 45 put: (Smalltalk vm parameterAt: 44) * 4"
+
+
 ${VM} "${PHARO_IMAGE_NAME}.image" eval --save "Metacello new baseline: 'Tonel';repository: 'github://pharo-vcs/tonel:v1.0.5'; load: 'core'"
 ${VM} "${PHARO_IMAGE_NAME}.image" eval --save "Metacello new baseline: 'IDE';repository: 'tonel://${REPOSITORY}/src'; load"
 ${VM} "${PHARO_IMAGE_NAME}.image" eval --save "FFIMethodRegistry resetAll. PharoSourcesCondenser condenseNewSources"


### PR DESCRIPTION
Terrible HACK!!!! but....

I am increasing the size of the eden space.
This allows to load the big baselines.
However, this is only needed because the VM has a bug when extending the space itself. It is corrupting the objects, this produces random crashes

I have detected that the problem is that the GC is corrupting the the objects when it has to enlarge the Eden.

This problem also was detected some months ago by Pavel when he tried to load a big baseline in the minimal image (Seaside in that moment). I have solved it in a similar way, increasing the Eden size before loading BaselineOfIDE.

Issue: https://pharo.fogbugz.com/f/cases/21359/Random-Crashes-during-loading-baselines-in-the-bootstrap