### PR TITLE
21360-Kernel-Tests-Methods-CompiledMethodTest-testSelector-produces-a-DNU

### DIFF
--- a/src/Kernel-Tests-WithCompiler/CompiledMethodTest.extension.st
+++ b/src/Kernel-Tests-WithCompiler/CompiledMethodTest.extension.st
@@ -111,7 +111,7 @@ CompiledMethodTest >> testSelector [
 		|  method cls |
 		
 		method := (self class)>>#returnTrue.
-		self assert: (method selector equals: #returnTrue).
+		self assert: method selector equals: #returnTrue.
 		
 		"now make an orphaned method. new semantics: return corrent name"	
 		Smalltalk removeClassNamed: #TUTU.


### PR DESCRIPTION
Kernel.Tests.Methods.CompiledMethodTest.testSelector test is failing in the CI because of a simple error with parenthesis. 

It should be fixed because having a simple test error makes the CI to retry ALL THE TESTS. If we have problems with the infrastructure, expending a lot of time running a broken is useless. I know nobody does it on purpose but please run the tests locally before commiting.