### PR TITLE
21325 FileServices class itemsForDirectory: should not use #selector

### DIFF
--- a/src/System-FileRegistry/FileServices.class.st
+++ b/src/System-FileRegistry/FileServices.class.st
@@ -23,7 +23,7 @@ FileServices class >> itemsForDirectory: aFileDirectory [
 	| services |
 	services := OrderedCollection new.
 	(PragmaCollector filter: [ :pragma | pragma keyword = 'directoryService' ]) reset
-		do: [ :each | services addAll: (each methodClass soleInstance perform: each selector with: aFileDirectory) ].
+		do: [ :each | services addAll: (each methodClass soleInstance perform: each methodSelector with: aFileDirectory) ].
 	^ services
 ]
 

--- a/src/System-FileRegistry/FileServices.class.st
+++ b/src/System-FileRegistry/FileServices.class.st
@@ -9,7 +9,7 @@ MyClass class>>fileReaderServicesForFile: fullName suffix: suffix
 	^ (FileStream isSourceFileSuffix: suffix)
 		ifTrue: [ { self mySimpleServiceEntry1 . self mySimpleServiceEntry2 }]
 		ifFalse: [#()]
-"
+" 
 Class {
 	#name : #FileServices,
 	#superclass : #Object,


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21325/FileServices-class-itemsForDirectory-should-not-use-selector