### PR TITLE
21317  remove unnecessary self run in diverse classes

### DIFF
--- a/src/Announcements-Tests-Core/AnnouncerTest.class.st
+++ b/src/Announcements-Tests-Core/AnnouncerTest.class.st
@@ -47,11 +47,9 @@ AnnouncerTest >> testAnnounceInstance [
 
 { #category : #tests }
 AnnouncerTest >> testAnnouncingReentrant [
-	" Test that it is safe to announce when handling announcement,
-	so announcer are reentrant "
-
-	" self run: #testAnnouncingReentrant "
-
+	"Test that it is safe to announce when handling announcement,
+	so announcer are reentrant"
+ 
 	| bool ok |
 
 	ok := bool := false.

--- a/src/Deprecated70/MultiByteFileStreamTest.class.st
+++ b/src/Deprecated70/MultiByteFileStreamTest.class.st
@@ -61,7 +61,6 @@ MultiByteFileStreamTest >> testBasicChunk [
 { #category : #testing }
 MultiByteFileStreamTest >> testBinaryUpTo [
 	"This is a non regression test for bug http://bugs.squeak.org/view.php?id=6933"
-	"self run: #testBinaryUpTo"
 	
 	| foo fileName |
 	

--- a/src/FileSystem-Tests-Core/FileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/FileReferenceTest.class.st
@@ -633,13 +633,12 @@ FileReferenceTest >> testIsRoot [
 
 { #category : #tests }
 FileReferenceTest >> testMakeRelative [
-	"self run: #testMakeRelative"
 
 	| parent child relative |
 	parent := filesystem / 'griffle'.
 	child := filesystem / 'griffle' / 'plonk' / 'nurb'.
 	relative := parent makeRelative: child.
-	self assert: relative = (Path * 'plonk' / 'nurb')
+	self assert: relative equals: (Path * 'plonk' / 'nurb')
 ]
 
 { #category : #tests }

--- a/src/Graphics-Tests/FormTest.class.st
+++ b/src/Graphics-Tests/FormTest.class.st
@@ -25,7 +25,7 @@ FormTest >> test32BitTranslucentBlackIsBlack [
 ]
 
 { #category : #tests }
-FormTest >> testIsAllWhite [	"self run: #testIsAllWhite"
+FormTest >> testIsAllWhite [
 	"Make sure #isAllWhite works for all bit depths"
 	
 	#(-32 -16 -8 -4 -2 -1 1 2 4 8 16 32) do:[:d| | form |

--- a/src/Morphic-Tests/StickynessBugsTest.class.st
+++ b/src/Morphic-Tests/StickynessBugsTest.class.st
@@ -12,9 +12,6 @@ Class {
 
 { #category : #tests }
 StickynessBugsTest >> testForTiltedStickyness [
-	"self new testForTiltedStickyness"
-
-	"self run: #testForTiltedStickyness"
 
 	| m |
 	m := Morph new openCenteredInWorld.

--- a/src/System-Caching-Tests/LRUCacheTests.class.st
+++ b/src/System-Caching-Tests/LRUCacheTests.class.st
@@ -270,8 +270,7 @@ LRUCacheTests >> testPopulate [
 
 { #category : #testing }
 LRUCacheTests >> testPrimeFactors [
-	"[ self run: #testPrimeFactors ] bench."
-	
+
 	| cache data |
 	cache := self newCache.
 	cache maximumWeight: 512.

--- a/src/System-Hashing-Tests/SHA1Test.class.st
+++ b/src/System-Hashing-Tests/SHA1Test.class.st
@@ -15,7 +15,6 @@ Class {
 
 { #category : #'testing - examples' }
 SHA1Test >> testEmptyInput [
-	"self run: #testEmptyInput"
 
 	self assert: ((SHA1 new hashMessage: '') asInteger radix: 16) equals: 'DA39A3EE5E6B4B0D3255BFEF95601890AFD80709'
 ]

--- a/src/Tests/ChangeSetClassChangesTest.class.st
+++ b/src/Tests/ChangeSetClassChangesTest.class.st
@@ -17,7 +17,7 @@ ChangeSetClassChangesTest >> categoryNameForTemporaryClasses [
 	"Answer the category where to classify temporarily created classes"
 
 	^'Dummy-Tests-Class' 
-] 
+]
 
 { #category : #support }
 ChangeSetClassChangesTest >> deleteClass [

--- a/src/Tests/ClassRenameFixTest.class.st
+++ b/src/Tests/ClassRenameFixTest.class.st
@@ -84,7 +84,6 @@ ClassRenameFixTest >> tearDown [
 
 { #category : #tests }
 ClassRenameFixTest >> testRenameClassUsingClass [
-	"self run: #testRenameClassUsingClass"
 
 	self renameClassUsing: [:class :newName | class rename: newName].
 ]

--- a/src/Text-Tests/RunArrayTest.class.st
+++ b/src/Text-Tests/RunArrayTest.class.st
@@ -145,7 +145,7 @@ RunArrayTest >> testRunsValues [
 
 { #category : #'tests - instance creation' }
 RunArrayTest >> testScanFromANSICompatibility [
-	"self run: #testScanFromANSICompatibility"
+ 
 	RunArray scanFrom: '()f1dNumber new;;' readStream.
 	RunArray scanFrom: '()a1death;;' readStream.
 	RunArray scanFrom: '()F1death;;' readStream

--- a/src/Text-Tests/TextAndTextStreamTest.class.st
+++ b/src/Text-Tests/TextAndTextStreamTest.class.st
@@ -109,8 +109,7 @@ TextAndTextStreamTest >> testAddingAttributesPastTheEnd [
 
 { #category : #tests }
 TextAndTextStreamTest >> testExampleText1 [
-	"self run: #testExampleText1"
-	"inspired by a bug report from Tim Olson.
+	"Inspired by a bug report from Tim Olson.
 	Text attributes are lost when the stream collection is expanded.
 	Documented BUG!!!"
 
@@ -120,7 +119,7 @@ TextAndTextStreamTest >> testExampleText1 [
 	atts1 := text1 runs copyFrom: 6 to: 10. 
 	atts2 := text2 runs copyFrom: 6 to: 10. 
 
-	self assert: atts1 = atts2.
+	self assert: atts1 equals: atts2.
       
 ]
 

--- a/src/Text-Tests/TextEmphasisTest.class.st
+++ b/src/Text-Tests/TextEmphasisTest.class.st
@@ -28,8 +28,7 @@ TextEmphasisTest >> testAdd [
 
 { #category : #tests }
 TextEmphasisTest >> testAppendString [
-	"tests the Text>>prepend: method when appending a String " 
-	"self run: # testAppendString"
+	"Tests the Text>>prepend: method when appending a String" 
 
 	| receiver argument result expectedResult |
 


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21317/Remove-unnecessary-self-run-in-diverse-classes

FormTest>>#testIsAllWhite
SHA1Test>>#testEmptyInput
TextEmphasisTest>>#testAppendString
MultiByteFileStreamTest>>#testBinaryUpTo
RunArrayTest>>#testScanFromANSICompatibility
TextAndTextStreamTest>>#testExampleText1
ClassRenameFixTest>>#testRenameClassUsingClass
FileReferenceTest>>#testMakeRelative
AnnouncerTest>>#testAnnouncingReentrant
StickynessBugsTest>>#testForTiltedStickyness
LRUCacheTests>>#testPrimeFactors