### PR TITLE
21363-coreMethodsForClass-send-but-not-implemented

### DIFF
--- a/src/JenkinsTools-ExtraReports/HDCoverageReport.class.st
+++ b/src/JenkinsTools-ExtraReports/HDCoverageReport.class.st
@@ -76,7 +76,7 @@ HDCoverageReport >> generatePackage: aPackage class: aClass on: aStream [
 		on: aStream.
 	self
 		generateType: 'method' indent: 5
-		total: (items := aPackage coreMethodsForClass: aClass) size
+		total: (items := aPackage definedMethodsForClass: aClass) size
 		actual: (covered count: [ :each | items includes: each ])
 		on: aStream.
 	items do: [ :each | self generatePackage: each method: each on: aStream ].	


### PR DESCRIPTION
coreMethodsForClass: send but not implemented

https://pharo.fogbugz.com/f/cases/21363/coreMethodsForClass-send-but-not-implemented