### PR TITLE
19204-RBMissingSubclassResponsibilityRule-does-not-check-the-class-side

### DIFF
--- a/src/GeneralRules/RBMissingSubclassResponsibilityRule.class.st
+++ b/src/GeneralRules/RBMissingSubclassResponsibilityRule.class.st
@@ -24,7 +24,7 @@ RBMissingSubclassResponsibilityRule >> check: aClass forCritiquesDo: aCritiqueBl
 	
 	| subs |
 	subs := aClass subclasses.
-	(subs size > 1 and: [ aClass isMeta not ]) ifTrue: 
+	(subs size > 1) ifTrue: 
 		[ | sels noSuperSels |
 		sels := Bag new.
 		subs do: [ :each | sels addAll: each selectors ].


### PR DESCRIPTION
19204 RBMissingSubclassResponsibilityRule does not check the class side
	https://pharo.fogbugz.com/f/cases/19204/RBMissingSubclassResponsibilityRule-does-not-check-the-class-side