### PR TITLE
21381 CodeExporter triggers errorImproperStore

### DIFF
--- a/src/CodeExport/CodeExporter.class.st
+++ b/src/CodeExport/CodeExporter.class.st
@@ -24,8 +24,9 @@ CodeExporter class >> writeSourceCodeFrom: aStream baseName: baseName isSt: stOr
 
 { #category : #'file-out' }
 CodeExporter class >> writeSourceCodeFrom: aStream toFileReference: aFileReference [
+	"Write the supplied changes to aFileReference"
 
-	aFileReference writeStreamDo: [ :outputStream |
+	aFileReference binaryWriteStreamDo: [ :outputStream |
 		(ZnCrPortableWriteStream on: (ZnCharacterWriteStream
 			on: outputStream
 			encoding: 'utf8')) nextPutAll: aStream contents.

--- a/src/FileSystem-Core/AbstractFileReference.class.st
+++ b/src/FileSystem-Core/AbstractFileReference.class.st
@@ -154,6 +154,24 @@ AbstractFileReference >> binaryReadStreamIfAbsent: absentBlock [
 		ifFalse: absentBlock
 ]
 
+{ #category : #'streams-compatibility' }
+AbstractFileReference >> binaryWriteStream [
+	"Answer a binary write stream on the receiver"
+
+	^ self subclassResponsibility
+]
+
+{ #category : #'streams-compatibility' }
+AbstractFileReference >> binaryWriteStreamDo: aBlock [
+	"Pass a binary write stream on the receiver to the supplied block, and ensure that the stream is closed after evaluation."
+
+	| stream |
+
+	stream := self binaryWriteStream.
+	^ [ aBlock value: stream ] 
+		ensure: [ stream close ]
+]
+
 { #category : #delegated }
 AbstractFileReference >> canonicalize [
 	"Answer the receiver with references to the current folder (.) and parent folder (..) removed"

--- a/src/FileSystem-Core/FileLocator.class.st
+++ b/src/FileSystem-Core/FileLocator.class.st
@@ -383,6 +383,13 @@ FileLocator >> binaryReadStream [
 	^ self resolve binaryReadStream
 ]
 
+{ #category : #'streams-compatibility' }
+FileLocator >> binaryWriteStream [
+	"Answer a binary write stream on the receiver"
+
+	^ self resolve binaryWriteStream
+]
+
 { #category : #copying }
 FileLocator >> copyWithPath: newPath [
 	^ self class origin: origin path: newPath

--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -87,6 +87,13 @@ FileReference >> binaryReadStream [
 	^ filesystem binaryReadStreamOn: self path
 ]
 
+{ #category : #'streams-compatibility' }
+FileReference >> binaryWriteStream [
+	"Answer a binary write stream on the receiver"
+
+	^ filesystem binaryWriteStreamOn: self path
+]
+
 { #category : #comparing }
 FileReference >> containsReference: aReference [
 	^  aReference fileSystem = filesystem and: [path contains: aReference path]

--- a/src/FileSystem-Core/FileSystem.class.st
+++ b/src/FileSystem-Core/FileSystem.class.st
@@ -67,6 +67,14 @@ FileSystem >> binaryReadStreamOn: aResolvable [
 ]
 
 { #category : #public }
+FileSystem >> binaryWriteStreamOn: aResolvable [
+	"Resolve the argument into an absolute path and open a file handle on the file
+	at that path. Ask the handle to give us a binary write stream for reading the file."
+
+	^ (self open: aResolvable writable: true) binaryWriteStream.
+]
+
+{ #category : #public }
 FileSystem >> checkName: aString fixErrors: fixErrors [
 	^ store checkName: aString fixErrors: fixErrors
 ]

--- a/src/FileSystem-Disk/FileHandle.class.st
+++ b/src/FileSystem-Disk/FileHandle.class.st
@@ -86,6 +86,18 @@ FileHandle >> binaryReadStream [
 				yourself ]
 ]
 
+{ #category : #'streams-compatibility' }
+FileHandle >> binaryWriteStream [
+	"Answer a binary write stream on the reciver"
+
+	^ (FileStream onHandle: self)
+		ifNil: [ self streamError ]
+		ifNotNil: [ :stream | 
+			stream
+				binary;
+				yourself ]
+]
+
 { #category : #public }
 FileHandle >> close [
 	Primitives close: id.


### PR DESCRIPTION
Update CodeExporter class>>writeSourceCodeFrom: aStream toFileReference: aFileReference to pass a binary write stream to the Zinc encoders.

Fogbugz: https://pharo.fogbugz.com/f/cases/21381/CodeExporter-triggers-errorImproperStore