### PR TITLE
21384-Make-non-ensure-wrapped-after-the-default-for-message-sends

### DIFF
--- a/src/Reflectivity/LiteralVariable.extension.st
+++ b/src/Reflectivity/LiteralVariable.extension.st
@@ -94,7 +94,7 @@ LiteralVariable >> link: aMetaLink [
 	(aMetaLink checkForCompatibilityWith: self) ifFalse: [ self error: 'link requests reification that can not be provided by this node' ].
 	
 	methods := self usingMethods.
-	(self propertyAt: #links ifAbsentPut: [ IdentitySet new ]) add: aMetaLink.
+	(self propertyAt: #links ifAbsentPut: [ OrderedCollection new ]) add: aMetaLink.
 	aMetaLink installOnVariable: self.
 	methods
 		do: [ :method |  

--- a/src/Reflectivity/MetaLink.class.st
+++ b/src/Reflectivity/MetaLink.class.st
@@ -52,6 +52,7 @@ MetaLink class >> defaultOptions [
 	- optionOneShot                     "remove link after first activation"
 	- optionMetalevel                   "force level: 0 for the link"
 	- optionDisabledLink                "links are active by default"
+	+ optionWeakAfter 						  "do not use #ensure: for #after "
 	)
 ]
 

--- a/src/Reflectivity/RBProgramNode.extension.st
+++ b/src/Reflectivity/RBProgramNode.extension.st
@@ -13,6 +13,7 @@ RBProgramNode >> afterLinks [
 { #category : #'*Reflectivity' }
 RBProgramNode >> allAfterAreWeak [
 	self hasMetalink ifFalse: [^false].
+	self isMessage ifFalse:  [^false]. "only sends are weak"
 	^self afterLinks allSatisfy: [ :link | link hasOption: #optionWeakAfter ].
 ]
 
@@ -93,7 +94,7 @@ RBProgramNode >> invalidate [
 { #category : #'*Reflectivity' }
 RBProgramNode >> link: aMetaLink [
 	(aMetaLink checkForCompatibilityWith: self) ifFalse: [ self error: 'link requests reification that can not be provided by this node' ].
-	(self propertyAt: #links ifAbsentPut: [ IdentitySet new ]) add: aMetaLink.
+	(self propertyAt: #links ifAbsentPut: [ OrderedCollection new ]) add: aMetaLink.
 	aMetaLink installOn: self.
 	self clearReflectivityAnnotations.
 	self methodNode method installLink: aMetaLink. 

--- a/src/Reflectivity/Slot.extension.st
+++ b/src/Reflectivity/Slot.extension.st
@@ -84,7 +84,7 @@ Slot >> link: aMetaLink [
 	(aMetaLink checkForCompatibilityWith: self) ifFalse: [ self error: 'link requests reification that can not be provided by this node' ].
 	
 	methods := self usingMethods.
-	(self propertyAt: #links ifAbsentPut: [ IdentitySet new ]) add: aMetaLink.
+	(self propertyAt: #links ifAbsentPut: [ OrderedCollection new ]) add: aMetaLink.
 	aMetaLink installOnVariable: self.
 	methods
 		do: [ :method |  

--- a/src/Reflectivity/TemporaryVariable.extension.st
+++ b/src/Reflectivity/TemporaryVariable.extension.st
@@ -63,7 +63,7 @@ TemporaryVariable >> insteadLinks [
 TemporaryVariable >> link: aMetaLink [
 	(aMetaLink checkForCompatibilityWith: self) ifFalse: [ self error: 'link requests reification that can not be provided by this node' ].
 	
-	(self propertyAt: #links ifAbsentPut: [ IdentitySet new ]) add: aMetaLink.
+	(self propertyAt: #links ifAbsentPut: [ OrderedCollection new ]) add: aMetaLink.
 	aMetaLink installOnVariable: self.
 	method 
 		createTwin;


### PR DESCRIPTION
Make non-ensure wrapped #after the default for message sends

https://pharo.fogbugz.com/f/cases/21384/Make-non-ensure-wrapped-after-the-default-for-message-sends