### PR TITLE
21397 Use category "utilities" instead of "utils" in AtomicCollection, BreakpointTest, ClassTestCase, UIManager, TraitTest. ThemeIcons

### DIFF
--- a/src/Collections-Atomic/AtomicCollection.class.st
+++ b/src/Collections-Atomic/AtomicCollection.class.st
@@ -30,7 +30,7 @@ AtomicCollection >> interrupt [
 	Processor yield
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 AtomicCollection >> newItem [
 	"override in subclass, if you need to instantiate queue items of different class or initialize them in some specific way"
 	^ AtomicQueueItem new

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -215,7 +215,7 @@ ThemeIcons >> blankIcon [
 	^ self blankIconOfWidth: 16
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 ThemeIcons >> blankIconOfWidth: aNumber [ 
 	^ self icons
 		at: ('blank-' , aNumber asString) asSymbol
@@ -249,7 +249,7 @@ ThemeIcons >> downloadFromUrl [
 	^ zipArchive
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 ThemeIcons >> form16x16FromContents: aByteArray [ 
 	^ Form
 	extent: 16@16

--- a/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
@@ -11,7 +11,7 @@ Class {
 	#category : #'Reflectivity-Tools-Tests'
 }
 
-{ #category : #utils }
+{ #category : #utilities }
 BreakpointTest >> newDummyClass [
 	^ Object
 		subclass: #DummyClassForBreakpoint

--- a/src/SUnit-Core/ClassTestCase.class.st
+++ b/src/SUnit-Core/ClassTestCase.class.st
@@ -48,7 +48,7 @@ ClassTestCase >> classToBeTested [
 	self subclassResponsibility
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 ClassTestCase >> differentMethodsWithSameSelectorBetween: firstClass and: secondClass [
 	| repeatedSelectors differentMethodsWithSameSelector |
 	
@@ -62,7 +62,7 @@ ClassTestCase >> differentMethodsWithSameSelectorBetween: firstClass and: second
 	^differentMethodsWithSameSelector.
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 ClassTestCase >> repeatedMethodsThatDoNotAccessInstanceVariablesBetween: firstClass and: secondClass [
 	| repeatedSelectors repeatedMethodsThatDoNotAccessInstanceVariables |
 	

--- a/src/Tests/TraitTest.class.st
+++ b/src/Tests/TraitTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'Tests-Traits'
 }
 
-{ #category : #utils }
+{ #category : #utilities }
 TraitTest >> createClassUsing: aTrait [
 	^ Object
 		subclass: #AClassForTests
@@ -15,7 +15,7 @@ TraitTest >> createClassUsing: aTrait [
 		category: 'AAA'
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 TraitTest >> createTrait [
 	| trait |
 	trait := Trait named: #ATraitForTests uses: {} category: 'AAA'.

--- a/src/UIManager/UIManager.class.st
+++ b/src/UIManager/UIManager.class.st
@@ -49,7 +49,7 @@ UIManager class >> isValidForCurrentSystemConfiguration [
 	^ false
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 UIManager class >> nonInteractiveDuring: aBlock [
 	| currentManager |
 	currentManager := self default.


### PR DESCRIPTION

https://pharo.fogbugz.com/f/cases/21397/Use-category-utilities-instead-of-utils-in-AtomicCollection-BreakpointTest-ClassTestCase-UIManager-TraitTest-ThemeIcons