### PR TITLE
21398 Use category "utilities" instead of "utils" in MBConfigurationInfo MBInfo MBPackageInfo MBProjectInfo

### DIFF
--- a/src/Versionner-Core-Model/MBConfigurationInfo.class.st
+++ b/src/Versionner-Core-Model/MBConfigurationInfo.class.st
@@ -265,7 +265,7 @@ MBConfigurationInfo >> currentVersionMismatch [
 		or: [ self packages anySatisfy: [ :each | each currentVersionMismatch ] ]
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 MBConfigurationInfo >> extractBranchFrom: aWorkingCopy [
 	| ref |
 	(aWorkingCopy isNil or: [ aWorkingCopy ancestors isEmpty ])

--- a/src/Versionner-Core-Model/MBInfo.class.st
+++ b/src/Versionner-Core-Model/MBInfo.class.st
@@ -83,7 +83,7 @@ MBInfo >> configurationRoot [
 	^self configurationInfo configurationRoot
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 MBInfo >> extractPackageSignatureFrom: aWorkingCopy [
 	| ref |
 	(aWorkingCopy isNil or: [ aWorkingCopy ancestors isEmpty ])
@@ -126,7 +126,7 @@ MBInfo >> project [
 	^nil
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 MBInfo >> repositories [
 	"Return the repositories associated with the receiver."
 

--- a/src/Versionner-Core-Model/MBPackageInfo.class.st
+++ b/src/Versionner-Core-Model/MBPackageInfo.class.st
@@ -148,7 +148,7 @@ MBPackageInfo >> printOn: aStream [
 								nextPutAll: refString ] ] ]
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 MBPackageInfo >> repositories [
 	"Return the repositories associated with the package."
 

--- a/src/Versionner-Core-Model/MBProjectInfo.class.st
+++ b/src/Versionner-Core-Model/MBProjectInfo.class.st
@@ -118,7 +118,7 @@ MBProjectInfo >> printOn: aStream [
 						ifFalse: [ aStream nextPutAll: ' [' , cv , ']' ] ] ]
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 MBProjectInfo >> repositories [
 	"Return the repositories associated with the configuration for the project."
 


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21398/Use-category-utilities-instead-of-utils-in-MBConfigurationInfo-MBInfo-MBPackageInfo-MBProjectInfo