### PR TITLE
21399 Use category "utilities" instead of "utils" in GTSUnitDebuggerSmokeTest, GoferOperationTest, MonticelloRepositoryBrowser and NativeArrayTest

### DIFF
--- a/src/Collections-Tests/NativeArrayTest.class.st
+++ b/src/Collections-Tests/NativeArrayTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'Collections-Tests-Arrayed'
 }
 
-{ #category : #utils }
+{ #category : #utilities }
 NativeArrayTest >> alignmentIndexesDo: aBlock [
 	| max |
 	max := self wordSize.
@@ -17,7 +17,7 @@ NativeArrayTest >> alignmentIndexesDo: aBlock [
 				aBlock value: i value: j value: k ] ] ] 
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 NativeArrayTest >> alignments [
 	"Arrays aligned differently on 8 bytes boundary (when turned into byteArrays)"
 	^ #( 
@@ -32,12 +32,12 @@ NativeArrayTest >> alignments [
 	)
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 NativeArrayTest >> guineaPigClasses [
 	^ { ByteArray . DoubleByteArray . WordArray . DoubleWordArray}
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 NativeArrayTest >> guineaPigHerd [
 	"Different alignment, different classes"
 	^ self guineaPigClasses flatCollect: [ :cls |
@@ -76,7 +76,7 @@ NativeArrayTest >> testReplaceFromToWithStartingAt [
 					self assert: (guineaPig at: j + 8) = (copy at: j + 8 - i + k) ] ]
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 NativeArrayTest >> wordSize [
 	^ Smalltalk wordSize
 ]

--- a/src/Collections-Tests/NativeArrayTest.class.st
+++ b/src/Collections-Tests/NativeArrayTest.class.st
@@ -1,6 +1,6 @@
 "
 SUnit tests for ByteArray, DoubleByteArray, WordArray and DoubleWordArray.
-"
+" 
 Class {
 	#name : #NativeArrayTest,
 	#superclass : #TestCase,

--- a/src/GT-Tests-Debugger/GTSUnitDebuggerSmokeTest.class.st
+++ b/src/GT-Tests-Debugger/GTSUnitDebuggerSmokeTest.class.st
@@ -10,7 +10,7 @@ GTSUnitDebuggerSmokeTest >> debuggerToTest [
 	^ GTSUnitDebugger
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 GTSUnitDebuggerSmokeTest >> stepBlockForTestArrays [
 
 	^ [ :aProcess |
@@ -29,7 +29,7 @@ GTSUnitDebuggerSmokeTest >> stepBlockForTestArrays [
 
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 GTSUnitDebuggerSmokeTest >> stepBlockForTestWithHalt [
 
 	^ [ :aProcess |

--- a/src/Gofer-Tests/GoferOperationTest.class.st
+++ b/src/Gofer-Tests/GoferOperationTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'Gofer-Tests-Tests'
 }
 
-{ #category : #utils }
+{ #category : #utilities }
 GoferOperationTest >> allManagers [
 
 	^ MCWorkingCopy allManagers 

--- a/src/Spec-Tools/MonticelloRepositoryBrowser.class.st
+++ b/src/Spec-Tools/MonticelloRepositoryBrowser.class.st
@@ -15,7 +15,7 @@ Class {
 	#category : #'Spec-Tools-Monticello'
 }
 
-{ #category : #utils }
+{ #category : #utilities }
 MonticelloRepositoryBrowser class >> allManagers [ 
 
 	^ MCWorkingCopy allManagers 
@@ -40,12 +40,12 @@ MonticelloRepositoryBrowser class >> example [
 		workingCopies: (self allManagers)
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 MonticelloRepositoryBrowser class >> order [
 	^ Order ifNil: [ Order := 1 ]
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 MonticelloRepositoryBrowser class >> order: anInteger [
 	Order := anInteger
 ]


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21399/Use-category-utilities-instead-of-utils-in-GTSUnitDebuggerSmokeTest-GoferOperationTest-MonticelloRepositoryBrowser-and-Nat