### PR TITLE
21324-Missing-Browse-receiver-feature-in-the-debugger

### DIFF
--- a/src/DebuggerActions/BrowseDebugAction.class.st
+++ b/src/DebuggerActions/BrowseDebugAction.class.st
@@ -60,6 +60,12 @@ BrowseDebugAction class >> debugActionsFor: aDebugger [
 			keymap: PharoShortcuts current browseShortcut;
 			label: 'Browse full'.
 		self new
+			id: #browseReceiver;
+			order: initilOrder + 41;
+			"keymap: PharoShortcuts current browseShortcut;"
+			label: 'Browse receiver'.
+		
+		self new
 			id: #fileOutMessage;
 			order: initilOrder + 45;
 			label: 'File out'.

--- a/src/GT-Debugger/GTBrowsingActions.trait.st
+++ b/src/GT-Debugger/GTBrowsingActions.trait.st
@@ -63,6 +63,14 @@ GTBrowsingActions >> browseMethodFull [
 ]
 
 { #category : #actions }
+GTBrowsingActions >> browseReceiver [
+	"Create and schedule a full Browser and then select the current class and message."
+	self currentContext receiver class ifNotNil: [ :instance |
+		Smalltalk tools browser 
+			openOnClass: instance ]
+]
+
+{ #category : #actions }
 GTBrowsingActions >> browseSendersOfMessages [
 	"Present a menu of the current message, as well as all messages sent by it.  Open a message set browser of all senders of the selector chosen."
 


### PR DESCRIPTION
Browser receiver command is added to debugger menu
(code from pharo 6 inbox).https://pharo.fogbugz.com/f/cases/21324/Missing-Browse-receiver-feature-in-the-debugger