### PR TITLE
21394-Debugger-does-not-scroll-to-the-first-line

### DIFF
--- a/src/GT-Debugger/GTSpecPreDebugWindow.class.st
+++ b/src/GT-Debugger/GTSpecPreDebugWindow.class.st
@@ -33,15 +33,10 @@ GTSpecPreDebugWindow >> initialExtent [
 
 { #category : #'initialization widgets' }
 GTSpecPreDebugWindow >> initializeStackPane [
-	
 	self stackPane
 		displayBlock: [ :aContext | self columnsFor: aContext ];
-		items: (self debugger session stackOfSize: 50 ) ;
-		whenSelectedItemChanged: [ :aContext | 
-			"Set the selection before, as debugAction removes the link with the debugger. "
-			self debugger stackPresentation selection: aContext.
-			self openFullDebugger ]
-		
+		items: (self debugger session stackOfSize: 50);
+		whenSelectedItemChanged: [ :aContext | self openFullDebugger ]
 ]
 
 { #category : #actions }


### PR DESCRIPTION
When clicking in the stack pane of the pre debugging window it was opening the debugger in the selected item.

This was not clear, as you only want to open the debugger, so I have changed it to just open the debugger in the first stack.
Issue https://pharo.fogbugz.com/f/cases/resolve/21394/Debugger-does-not-scroll-to-the-first-line.
