### PR TITLE
20981-SessionManager-references-Nautilus-by-symbol

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -103,7 +103,10 @@ BaselineOfBasicTools >> baseline: spec [
 { #category : #actions }
 BaselineOfBasicTools >> postload: loader package: packageSpec [
 
+	"Registering Nautilus"
  	Nautilus registerToolsOn: Smalltalk tools.
+	SessionManager default registerToolClassNamed: #Nautilus.
+	
 	Smalltalk tools register: TestRunner as: #testRunner.
 	Smalltalk tools register: MCWorkingCopyBrowser as: #monticelloBrowser.
 	

--- a/src/System-SessionManager/SessionManager.class.st
+++ b/src/System-SessionManager/SessionManager.class.st
@@ -120,68 +120,6 @@ SessionManager class >> default: aSessionManager [
 ]
 
 { #category : #'compatibility - startupList' }
-SessionManager class >> forCompatibility [
-	^ SessionManager new
-		registerSystemClassNamed: #SmallInteger; "system - 10"
-		registerSystemClassNamed: #Delay; "System - 20"
-		registerSystemClassNamed: #Stdio; "System"
-		registerSystemClassNamed: #OSPlatform; "System - 50"
-		registerSystemClassNamed: #DisplayScreen; "GUI - 10"
-		registerSystemClassNamed: #Cursor; "GUI"
-		registerSystemClassNamed: #InputEventFetcher; "System - 40" "WARNING: should not be in the list if InputEventSensor is already there"
-	
-		registerSystemClassNamed: #Form; "GUI"
-		registerSystemClassNamed: #StrikeFont; "GUI"
-		registerSystemClassNamed: #Color; "GUI"
-		
-		registerSystemClassNamed: #ProcessorScheduler; "System - 30"
-		registerSystemClassNamed: #LanguageEnvironment	; "System"
-
-		registerSystemClassNamed: #NaturalLanguageTranslator; "Does nothing - will not be in the list"
-
-		registerSystemClassNamed: #ShortIntegerArray; "System"
-		registerSystemClassNamed: #DiskStore;
-		registerSystemClassNamed: #InputEventSensor; "Need to create initialize/release methods?"
-		registerSystemClassNamed: #SmalltalkImage; "System"
-		registerSystemClassNamed: #WeakFinalizationList; "System"
-		registerSystemClassNamed: #CPUWatcher; "Tools"
-		registerSystemClassNamed: #Clipboard; "System"
-	
-		registerSystemClassNamed: #FreeTypeCache; "GUI"
-	
-		registerSystemClassNamed: #InternetConfiguration; "Network"
-	
-		registerSystemClassNamed: #LogicalFont; "GUI"
-		registerSystemClassNamed: #MCMethodDefinition; "System"
-		registerSystemClassNamed: #Symbol; "System"
-		
-		registerSystemClassNamed: #Locale; "System"
-		registerSystemClassNamed: #UUIDGenerator; "Network"
-		registerSystemClassNamed: #WeakArray; "System"
-		registerSystemClassNamed: #MacOSClipboard; "nothing to do - will not be in  the list"
-		registerSystemClassNamed: #ZnServer; "Network"
-		registerSystemClassNamed: #FileStream; "System"
-		registerSystemClassNamed: #FileLocator; "System"
-		registerSystemClassNamed: #BasicCommandLineHandler; "System"
-		registerSystemClassNamed: #FT2Handle; "GUI"
-		registerSystemClassNamed: #FreeTypeSettings; "GUI"
-	
-		registerSystemClassNamed: #NonInteractiveTranscript; "System"
-		registerSystemClassNamed: #ASTCache; "System"
-		registerSystemClassNamed: #NOCCompletionTable; "Tool"
-		registerSystemClassNamed: #Nautilus; "Tool"
-		registerSystemClassNamed: #PharoCommonTools; "Tool"
-		registerSystemClassNamed: #OSEnvironment; "System"
-		
-		registerSystemClassNamed: #WorldMorph; "GUI"
-		registerSystemClassNamed: #MCGitHubRepository; "Network"
-		registerSystemClassNamed: #ZnLogEvent; "Network"
-		registerSystemClassNamed: #GTPlayBook; "Tools"
-		registerSystemClassNamed: #EndianDetector; "System"
-		yourself
-]
-
-{ #category : #'compatibility - startupList' }
 SessionManager class >> initializedSessionManager [
 	| manager |
 	manager := SessionManager new.
@@ -240,7 +178,6 @@ SessionManager class >> initializedSessionManager [
 
 		registerToolClassNamed: #CPUWatcher; "Tools"
 		registerToolClassNamed: #NOCCompletionTable; "Tool"
-		registerToolClassNamed: #Nautilus; "Tool"
 		registerToolClassNamed: #PharoCommonTools; "Tool"
 		registerToolClassNamed: #GTPlayBook; "Tools"
 


### PR DESCRIPTION
Removing Nautilus from the initialization of the SessionManager to the postload action of BaselineOfBasicTools, as this is the place where  the Nautilus package is installed.

Issue: https://pharo.fogbugz.com/f/cases/20981/SessionManager-references-Nautilus-by-symbol