### PR TITLE
21249-Pharo-should-includes-Metacello-Cypress

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -66,8 +66,9 @@ BaselineOfBasicTools >> baseline: spec [
 		spec package: 'Nautilus-GroupManagerUI'.
 		spec package: 'Komitter'.
 		
-		spec package: 'Announcements-Help'.	
+		spec package: 'Announcements-Help'.
 		spec package: 'Metacello-FileTree'.
+		spec package: 'Metacello-Cypress'.
 		spec package: 'Metacello-ProfStef'.
 		spec package: 'Metacello-Reference'.
 		spec package: 'Metacello-Tutorial'.

--- a/src/Metacello-Cypress/MetacelloCypressBaselineProject.class.st
+++ b/src/Metacello-Cypress/MetacelloCypressBaselineProject.class.st
@@ -1,0 +1,53 @@
+"
+The **MetacelloCypressBaselineProject**  is a wrapper for the **BaselineOf** version specification for file-based repositories specific to metadataless export format. (Filetree/Tonel)
+
+It should be used by metadataless repositories (FileTree/Tonel). To use it the **BaselineOf** needs to redefine this method:
+
+```Smalltalk
+	projectClass
+	    ^ MetacelloMCBaselineProject
+```
+
+Metacello has an internal rule to not load Monticello packages of the same version, since they are already loaded. However, when using metadataless repositories the filetree/tonel Monticello package readers typically generate a package name using the author/version `-cypress.1`, which make Metacello think that the versions are the same and the package is not loaded. By including the above method in your baselineof, Metacello will know to ignore the Monticello author/version of the package and always load it.
+"
+Class {
+	#name : #MetacelloCypressBaselineProject,
+	#superclass : #MetacelloMCBaselineProject,
+	#classVars : [
+		'UseCypressPackagesForAllBaselines'
+	],
+	#category : #'Metacello-Cypress'
+}
+
+{ #category : #accessing }
+MetacelloCypressBaselineProject class >> singletonVersionName [
+    ^ 'baseline'
+]
+
+{ #category : #accessing }
+MetacelloCypressBaselineProject class >> useCypressPackagesForAllBaselines [
+  UseCypressPackagesForAllBaselines ifNil: [ ^ false ].
+  ^ UseCypressPackagesForAllBaselines
+]
+
+{ #category : #accessing }
+MetacelloCypressBaselineProject class >> useCypressPackagesForAllBaselines: aBool [
+	"self useCypressPackagesForAllBaselines: true"
+
+	UseCypressPackagesForAllBaselines := aBool
+]
+
+{ #category : #accessing }
+MetacelloCypressBaselineProject class >> versionConstructorClass [
+    ^ MetacelloBaselineConstructor
+]
+
+{ #category : #'spec classes' }
+MetacelloCypressBaselineProject >> baselineOfProjectSpecClass [
+    ^ MetacelloCypressBaselineProjectSpec
+]
+
+{ #category : #'spec classes' }
+MetacelloCypressBaselineProject >> packageSpecClass [
+  ^ MetacelloCypressPackageSpec
+]

--- a/src/Metacello-Cypress/MetacelloCypressBaselineProjectSpec.class.st
+++ b/src/Metacello-Cypress/MetacelloCypressBaselineProjectSpec.class.st
@@ -1,0 +1,8 @@
+"
+I am a project spec specific to metadataless projects (filetree/tonel).
+"
+Class {
+	#name : #MetacelloCypressBaselineProjectSpec,
+	#superclass : #MetacelloMCBaselineOfProjectSpec,
+	#category : #'Metacello-Cypress-Specs'
+}

--- a/src/Metacello-Cypress/MetacelloCypressPackageSpec.class.st
+++ b/src/Metacello-Cypress/MetacelloCypressPackageSpec.class.st
@@ -1,0 +1,35 @@
+"
+I am a package spec specific to metadataless projects (filetree/tonel).
+"
+Class {
+	#name : #MetacelloCypressPackageSpec,
+	#superclass : #MetacelloPackageSpec,
+	#category : #'Metacello-Cypress-Specs'
+}
+
+{ #category : #querying }
+MetacelloCypressPackageSpec >> ancestors [
+  ^ nil
+]
+
+{ #category : #testing }
+MetacelloCypressPackageSpec >> compareCurrentVersion: anOperator targetVersionStatus: statusIgnored using: anMCLoader [
+  ^ false
+]
+
+{ #category : #querying }
+MetacelloCypressPackageSpec >> isPackageLoaded: aLoader [
+  MCWorkingCopy allManagers
+    detect: [ :wc | wc packageName = self file ]
+    ifNone: [ ^ false ].
+  ^ true
+]
+
+{ #category : #fetching }
+MetacelloCypressPackageSpec >> searchCacheRepositoryForPackage: searchBlock [
+  "evaluate the <searchBlock> if you want to search for the package in a local package cache"
+
+  "for Cypress packages the answer is NO!"
+
+
+]

--- a/src/Metacello-Cypress/MetacelloMCBaselineProject.extension.st
+++ b/src/Metacello-Cypress/MetacelloMCBaselineProject.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #MetacelloMCBaselineProject }
+
+{ #category : #'*metacello-cypress' }
+MetacelloMCBaselineProject >> packageSpecClass [
+  "One could argue that Baselines should have done this from the very beginning ... the cost is that every package is fetched (from disk) and the snapshots for every package are created ... the advantage is that you will properly downgrade packages when switching git versions ... for now a class variable is sufficient"
+
+  MetacelloCypressBaselineProject useCypressPackagesForAllBaselines
+    ifTrue: [ ^ MetacelloCypressPackageSpec ].
+  ^ super packageSpecClass
+]

--- a/src/Metacello-Cypress/package.st
+++ b/src/Metacello-Cypress/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Metacello-Cypress' }


### PR DESCRIPTION
Add package Metacello-Cypress. 

This package bring a new kind of project type: MetacelloCypressBaselineProject. This project kind can be used in the baseline of metadataless projects (filetree/tonel) and helps Metacello to execute some features such has a project updates. 

References:
http://forum.world.st/ANN-Metacello-support-for-GitFileTree-metadata-less-mode-td4906662.html
http://forum.world.st/unsolicited-package-cache-use-td5060335.html

Close 21249 : https://pharo.fogbugz.com/f/cases/21249/Pharo-should-includes-Metacello-Cypress