### PR TITLE
21406 NumberParserTest should use "utilities" method protocol instead of utility

### DIFF
--- a/src/AST-Tests-Core/NumberParserTest.class.st
+++ b/src/AST-Tests-Core/NumberParserTest.class.st
@@ -9,7 +9,7 @@ Class {
 	#category : #'AST-Tests-Core'
 }
 
-{ #category : #utility }
+{ #category : #utilities }
 NumberParserTest >> areLowercaseDigitsAllowed [
 	"Answer true if lowercase letter are allowed digits."
 	


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21406/NumberParserTest-should-use-utilities-method-protocol-instead-utility