### PR TITLE
21409 NECTestClass should use utilities categories

### DIFF
--- a/src/NECompletion-Tests/NECTestClass.class.st
+++ b/src/NECompletion-Tests/NECTestClass.class.st
@@ -57,7 +57,7 @@ NECTestClass >> initialize: aRectangle [
 	complexInit2 := Dictionary new: aRectangle origin x. 
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 NECTestClass >> lowPriorityOverrides: aRectangle [ 
 	messageSend := aRectangle.
 	typeSuggestingParameter2 := aRectangle. 


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21409/NECTestClass-should-use-utilities-categories