### PR TITLE
21414 Cleanup OSWindow-Tests package

### DIFF
--- a/src/OSWindow-Tests/OSWindowAttributesTest.class.st
+++ b/src/OSWindow-Tests/OSWindowAttributesTest.class.st
@@ -4,15 +4,16 @@ An OSWindowAttributesTest is a test class for testing the behavior of OSWindowAt
 Class {
 	#name : #OSWindowAttributesTest,
 	#superclass : #TestCase,
-	#category : #'OSWindow-Tests'
+	#category : #'OSWindow-Tests-Tests'
 }
 
 { #category : #tests }
 OSWindowAttributesTest >> testDefaults [
+
 	| attributes |
-	attributes := OSWindowAttributes new.
+	attributes := OSWindowAttributes new.	
 	self assert: attributes position = attributes class defaultPosition.
 	self assert: attributes extent = attributes class defaultExtent.
 	self assert: attributes fullscreen  = attributes class defaultFullscreen.
-	self assert: attributes title = attributes class defaultTitle.
+	self assert: attributes title = attributes class defaultTitle
 ]

--- a/src/OSWindow-Tests/OSWindowAttributesTest.class.st
+++ b/src/OSWindow-Tests/OSWindowAttributesTest.class.st
@@ -6,7 +6,7 @@ Class {
 	#superclass : #TestCase,
 	#category : #'OSWindow-Tests-Tests'
 }
-
+ 
 { #category : #tests }
 OSWindowAttributesTest >> testDefaults [
 

--- a/src/OSWindow-Tests/OSWindowBench.class.st
+++ b/src/OSWindow-Tests/OSWindowBench.class.st
@@ -1,35 +1,35 @@
+"
+Benchmark for window processing
+"
 Class {
 	#name : #OSWindowBench,
 	#superclass : #TestCase,
-	#category : #'OSWindow-Tests'
+	#category : #'OSWindow-Tests-Benchmarks'
 }
 
 { #category : #benchmarking }
 OSWindowBench >> benchEventProcessing [
-	"self new benchEventProcessing"
+	<script: 'self new benchEventProcessing'>
+	
 	| window sema |
 	
 	window := World osWindow.
 	sema := Semaphore new.
 	[ 
-"		TimeProfiler spyAllOn:[ sema wait ]. 
-"		AndreasSystemProfiler spyOn: [ sema wait ].
+		"TimeProfiler spyAllOn:[ sema wait ]"		
+		AndreasSystemProfiler spyOn: [ sema wait ].
 	] forkAt: Processor userInterruptPriority.
 	
-	[  
-		20 timesRepeat: [  
-		1 to: 500 do: [ :i | | event |
-		
-		
-			event := OSMouseMoveEvent for: window.
-			event position: i @ 100;
-				delta: 1 @ 0.
-
-			event deliver.
-		].
-	(Delay forMilliseconds: 20) wait.
-	].
-		sema signal.
+	[ 20 timesRepeat: [  
+			1 to: 500 do: [ :i | 
+				| event |
+				event := OSMouseMoveEvent for: window.
+				event 
+					position: i @ 100;
+					delta: 1 @ 0.
+				event deliver ].
+			(Delay forMilliseconds: 20) wait ].
+		sema signal
 	] forkAt: 60.
 
 	

--- a/src/OSWindow-Tests/OSWindowTest.class.st
+++ b/src/OSWindow-Tests/OSWindowTest.class.st
@@ -4,7 +4,7 @@ An OSWindowTest is a test class for testing the behavior of OSWindow
 Class {
 	#name : #OSWindowTest,
 	#superclass : #TestCase,
-	#category : #'OSWindow-Tests'
+	#category : #'OSWindow-Tests-Tests'
 }
 
 { #category : #tests }
@@ -15,7 +15,7 @@ OSWindowTest >> testCreatingWindow [
 	attributes preferableDriver: OSNullWindowDriver new.
 	window := OSWindow createWithAttributes: attributes.
 
-	self assert: (window isValid).
+	self assert: (window isValid)
 
 ]
 
@@ -26,9 +26,8 @@ OSWindowTest >> testNewWindowDefaults [
 	
 	window := OSWindow newWithNullDriver.
 
-	[
-		self assert: (window isValid).
-		self assert: window extent = OSWindowAttributes defaultExtent.
+	[	self assert: (window isValid).
+		self assert: window extent = OSWindowAttributes defaultExtent
 	] ensure: [ window destroy ]
 		
 	
@@ -41,10 +40,10 @@ OSWindowTest >> testSettingUpWindow [
 	
 	window := OSWindow newWithNullDriver.
 	
-	[
-		window extent: 150@150.
-		self assert: (window extent = (150@150)).	
-		self assert: (window isValid).
+	[ window extent: 150@150.
+	  self assert: window extent equals: (150@150).	
+	  self assert: (window isValid) 
 	] ensure: [ window destroy ].
-	self assert: (window isValid not)
+
+	self deny: window isValid 
 ]


### PR DESCRIPTION
- remove unnecessary dots
- add tags to package to separate tests from benchmarks
- use #assert:equals:
- formatting

https://pharo.fogbugz.com/f/cases/21414/Cleanup-OSWindow-Tests-package