### PR TITLE
21420-The-XML-Test-reports-should-have-independent-filenames-for-each-CI-Node

### DIFF
--- a/src/JenkinsTools-Core/HDTestReport.class.st
+++ b/src/JenkinsTools-Core/HDTestReport.class.st
@@ -213,12 +213,15 @@ HDTestReport >> serializeError: error of: aTestCase [
 { #category : #running }
 HDTestReport >> setUp [
 
-	| aFile |
+	| aFile fileName |
 	
 	progressFile nextPutAll: 'running suite: ';
 		nextPutAll: suite name ; crlf; flush.
+
+	fileName := nodeName isEmptyOrNil ifTrue: [ '' ] ifFalse: [ nodeName ].
+	fileName := fileName , suite name , '-Test.xml'.
 		
-	aFile := File named: suite name , '-Test.xml'.
+	aFile := File named: fileName .
 	aFile delete.
 	stream := ZnCharacterWriteStream
 			on: (aFile writeStream setToEnd; yourself)


### PR DESCRIPTION
If we are running in the CI infrastructure the files produced by running the tests need to have the node name. So they are no overriden.