### PR TITLE
21423-Improve-even-more-the-Test-reports

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,8 +23,8 @@ def runTests(architecture, prefix=''){
 		try {
 			cleanWs()
 			unstash "bootstrap${architecture}"
-			shell "bash -c 'bootstrap/scripts/run${prefix}Tests.sh ${architecture}'"
-			junit allowEmptyResults: true, testResults: '*.xml'
+			shell "bash -c 'bootstrap/scripts/run${prefix}Tests.sh ${architecture} ${env.STAGE_NAME}'"
+			junit allowEmptyResults: true, testResults: "${env.STAGE_NAME}*.xml"
 			success = !(currentBuild.result == 'UNSTABLE')
 			echo "Tests run with result ${currentBuild.result}"
 		} catch(e) {
@@ -40,7 +40,7 @@ def runTests(architecture, prefix=''){
 		}
 		return success || (tries == retryTimes)
 	}
-	archiveArtifacts allowEmptyArchive: true, artifacts: '*.xml', fingerprint: true
+	archiveArtifacts allowEmptyArchive: true, artifacts: "${env.STAGE_NAME}*.xml", fingerprint: true
 	cleanWs()
 }
 

--- a/bootstrap/scripts/runKernelTests.sh
+++ b/bootstrap/scripts/runKernelTests.sh
@@ -6,6 +6,9 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 
+# The first parameter is the architecture
+# The second parameter is the stage name
+
 ARCHFLAG=""
 if [ ${1} = "64" ]; then
     ARCHFLAG="64/"
@@ -35,4 +38,4 @@ export PHARO_CI_TESTING_ENVIRONMENT=1
 ./pharo bootstrap.image initializePackages --packages=packagesKernel.txt --protocols=protocolsKernel.txt --save
 ./pharo bootstrap.image loadHermes Hermes-Extensions.hermes --save
 ./pharo bootstrap.image loadHermes SUnit-Core.hermes JenkinsTools-Core.hermes JenkinsTools-Core.hermes SUnit-Tests.hermes --save --no-fail-on-undeclared --on-duplication=ignore
-./pharo bootstrap.image test --junit-xml-output SUnit-Core SUnit-Tests	
+./pharo bootstrap.image test --junit-xml-output --stage-name=${2} SUnit-Core SUnit-Tests	

--- a/bootstrap/scripts/runTests.sh
+++ b/bootstrap/scripts/runTests.sh
@@ -6,6 +6,9 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 
+# The first parameter is the architecture
+# The second parameter is the stage name
+
 ARCHFLAG=""
 if [ ${1} = "64" ]; then
     ARCHFLAG="64/"
@@ -28,4 +31,4 @@ mv $CHANGES_FILE Pharo.changes
 
 export PHARO_CI_TESTING_ENVIRONMENT=1
 					
-./pharo Pharo.image test --junit-xml-output '.*'
+./pharo Pharo.image test --junit-xml-output --stage-name=${2} '.*'

--- a/src/JenkinsTools-Core/HDTestReport.class.st
+++ b/src/JenkinsTools-Core/HDTestReport.class.st
@@ -12,10 +12,19 @@ Class {
 		'suiteFailures',
 		'suiteErrors',
 		'progressFile',
-		'nodeName'
+		'nodeName',
+		'stageName'
+	],
+	#classVars : [
+		'CurrentStageName'
 	],
 	#category : #'JenkinsTools-Core'
 }
+
+{ #category : #running }
+HDTestReport class >> currentStageName: aStageName [
+	CurrentStageName := aStageName
+]
 
 { #category : #running }
 HDTestReport class >> runClasses: aCollectionOfClasses named: aString [
@@ -39,7 +48,8 @@ HDTestReport class >> runPackage: aString [
 { #category : #running }
 HDTestReport class >> runSuite: aTestSuite [
 	^ self new
-		initializeOn: aTestSuite; 
+		initializeOn: aTestSuite;
+		stageName: CurrentStageName;
 		run;
 		done
 ]
@@ -138,6 +148,7 @@ HDTestReport >> initialize [
 			encoding: 'utf8'.
 			
 	nodeName := self calculateNodeName.
+	stageName := ''
 ]
 
 { #category : #initialization }
@@ -218,7 +229,7 @@ HDTestReport >> setUp [
 	progressFile nextPutAll: 'running suite: ';
 		nextPutAll: suite name ; crlf; flush.
 
-	fileName := nodeName isEmptyOrNil ifTrue: [ '' ] ifFalse: [ nodeName ].
+	fileName := stageName isEmpty ifTrue: [ '' ] ifFalse: [ stageName , '-' ].
 	fileName := fileName , suite name , '-Test.xml'.
 		
 	aFile := File named: fileName .
@@ -249,6 +260,17 @@ HDTestReport >> stackTraceString: err of: aTestCase [
 		[ context isNil or: [ context receiver == aTestCase and: [ context methodSelector == #runCase ] ] ] whileFalse: [
 			[str print: context; lf.] ifError: [ str nextPutAll: 'PRINTING ERROR'; lf].
 			context := context sender ] ] 
+]
+
+{ #category : #accessing }
+HDTestReport >> stageName [
+	"The stage name is used by the CI to name the report files"
+	^ stageName
+]
+
+{ #category : #accessing }
+HDTestReport >> stageName: anObject [
+	stageName := anObject
 ]
 
 { #category : #accessing }

--- a/src/JenkinsTools-Core/TestCommandLineHandler.class.st
+++ b/src/JenkinsTools-Core/TestCommandLineHandler.class.st
@@ -4,6 +4,9 @@ Usage: test [--junit-xml-output] [--fail-on-failure] [<package> ...]
 	--fail-on-failure     if there is a test error or failure, it will exit with error code 1
 	--fail-on-error       if there is a test error it will exit with error code 1
 	--save                save after executing tests
+	--stage-name=aName	
+					it adds a prefix to the xml generated, this is useful 
+					when running in the CI infrastructure
 	 <package>            a String matching a package name
 	
 Examples:
@@ -123,7 +126,10 @@ TestCommandLineHandler >> runPackages [
 
 { #category : #private }
 TestCommandLineHandler >> testRunner [
-	(self hasOption: 'junit-xml-output') ifTrue: [ ^ HDTestReport ].
+	
+	(self hasOption: 'junit-xml-output') ifTrue: [ 
+		HDTestReport currentStageName: ((self hasOption: 'stage-name') ifTrue: [ self optionAt: 'stage-name' ] ifFalse: [ '' ]). 	
+		^ HDTestReport ].
 	
 	self class environment at: #CommandLineTestRunner ifPresent: [ :commandLineTestRunner |
 		(self hasOption: 'no-xterm') ifTrue: [ ^ commandLineTestRunner ].


### PR DESCRIPTION
Adding a additional option to TestCommandLineHandler to handle a prefix when running in the CI.
The prefix is added to all the result xmls. This allows us to filter them, so they are handled properly by Jenkins.