### PR TITLE
21426-RubSmalltalkEditor-class--compilerFor-is-dead-code

### DIFF
--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -110,13 +110,6 @@ RubSmalltalkEditor class >> buildShortcutsOn: aBuilder [
 		do: [ :target | target formatMethodCode ]
 ]
 
-{ #category : #accessing }
-RubSmalltalkEditor class >> compilerFor: aClass [
-	^ (aClass respondsTo: #compiler) 
-		ifTrue: [aClass compiler]
-		ifFalse: [ aClass class evaluatorClass new ]
-]
-
 { #category : #NOcompletion }
 RubSmalltalkEditor >> atCompletionPosition [
 	"Return true if the cursor is at a possible completion position"


### PR DESCRIPTION
RubSmalltalkEditor class >> #compilerFor: is dead code