### PR TITLE
21448-Integrate-Calypso-v0102

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -905,7 +905,7 @@ BaselineOfIDE >> loadCalypso [
 
 	Metacello new
 		baseline: 'Calypso';
-		repository: 'github://dionisiydk/Calypso:v0.10.1';
+		repository: 'github://dionisiydk/Calypso:v0.10.2';
 		load: #('FullEnvironment' 'SystemBrowser' 'Tests').
 
 	(self class environment at: #ClyBrowser) beAllDefault.


### PR DESCRIPTION
New version v0.10.2 is ready.

https://pharo.fogbugz.com/f/cases/21448/Integrate-Calypso-v0-10-2