### PR TITLE
21460-ShiftClassInstaller-do-not-correctly-add-class-side-variables-into-the-hierarchy

### DIFF
--- a/src/Shift-Changes/ShAbstractChange.class.st
+++ b/src/Shift-Changes/ShAbstractChange.class.st
@@ -57,7 +57,7 @@ ShAbstractChange >> hash [
 ]
 
 { #category : #migration }
-ShAbstractChange >> migrateInstancesOf: anObject to: newClass using: aClassInstaller [
+ShAbstractChange >> migrateInstancesOf: anOldClass to: newClass using: aClassInstaller [
 	"Concrete change can require class instances migration"
 ]
 

--- a/src/Shift-Changes/ShAbstractChange.class.st
+++ b/src/Shift-Changes/ShAbstractChange.class.st
@@ -56,6 +56,11 @@ ShAbstractChange >> hash [
 	^ builder hash.
 ]
 
+{ #category : #migration }
+ShAbstractChange >> migrateInstancesOf: anObject to: newClass using: aClassInstaller [
+	"Concrete change can require class instances migration"
+]
+
 { #category : #accessing }
 ShAbstractChange >> oldClass [
 	^ oldClass

--- a/src/Shift-Changes/ShInstanceShapeChanged.class.st
+++ b/src/Shift-Changes/ShInstanceShapeChanged.class.st
@@ -11,7 +11,13 @@ Class {
 
 { #category : #testing }
 ShInstanceShapeChanged >> hasToMigrateInstances [
-	^ true.
+	^ true
+]
+
+{ #category : #migration }
+ShInstanceShapeChanged >> migrateInstancesOf: anOldClass to: newClass using: aClassInstaller [
+
+	aClassInstaller migrateInstancesOf: anOldClass to: newClass
 ]
 
 { #category : #testing }

--- a/src/Shift-Changes/ShInstanceShapeChanged.class.st
+++ b/src/Shift-Changes/ShInstanceShapeChanged.class.st
@@ -17,7 +17,7 @@ ShInstanceShapeChanged >> hasToMigrateInstances [
 { #category : #migration }
 ShInstanceShapeChanged >> migrateInstancesOf: anOldClass to: newClass using: aClassInstaller [
 
-	aClassInstaller migrateInstancesOf: anOldClass to: newClass
+	aClassInstaller migrateInstances: anOldClass allInstances to: newClass
 ]
 
 { #category : #testing }

--- a/src/Shift-Changes/ShMetaclassChanged.class.st
+++ b/src/Shift-Changes/ShMetaclassChanged.class.st
@@ -27,8 +27,8 @@ ShMetaclassChanged >> hasToMigrateInstances [
 
 { #category : #migration }
 ShMetaclassChanged >> migrateInstancesOf: anOldClass to: newClass using: aClassInstaller [
-	
-	aClassInstaller migrateInstancesOf: anOldClass classSide to: newClass classSide
+
+	aClassInstaller migrateInstances: { anOldClass } to: newClass classSide
 ]
 
 { #category : #propagating }

--- a/src/Shift-Changes/ShMetaclassChanged.class.st
+++ b/src/Shift-Changes/ShMetaclassChanged.class.st
@@ -19,3 +19,19 @@ ShMetaclassChanged >> builder: anObject [
 	super builder: anObject.
 	oldClass := builder oldClass copy.
 ]
+
+{ #category : #testing }
+ShMetaclassChanged >> hasToMigrateInstances [
+	^ true
+]
+
+{ #category : #migration }
+ShMetaclassChanged >> migrateInstancesOf: anOldClass to: newClass using: aClassInstaller [
+	
+	aClassInstaller migrateInstancesOf: anOldClass classSide to: newClass classSide
+]
+
+{ #category : #propagating }
+ShMetaclassChanged >> propagateToSubclasses: anotherBuilder [
+	anotherBuilder changes add: self.
+]

--- a/src/Shift-ClassInstaller/Class.extension.st
+++ b/src/Shift-ClassInstaller/Class.extension.st
@@ -3,7 +3,12 @@ Extension { #name : #Class }
 { #category : #'*Shift-ClassInstaller' }
 Class >> addClassSlot: aSlot [
 
-	^ self classInstaller update: self to: [ :builder |
+ 	<localClassMethod> 
+   "This method is supposed to be local in Class because of a good reason.
+   We use this pragma to test if Class does not contain some accidental 
+   local selectors."
+
+	^self classInstaller update: self to: [ :builder |
 		builder
 			superclass: self superclass;
 			name: self name;
@@ -13,13 +18,18 @@ Class >> addClassSlot: aSlot [
 			sharedVariablesFromString: self classVariablesString;
 			sharedPools: self sharedPoolsString;
 			category: self category;
-			environment: self environment]
+			environment: self environment].
 ]
 
 { #category : #'*Shift-ClassInstaller' }
 Class >> addSlot: aSlot [
 
-	^ self classInstaller update: self to: [ :builder |
+	<localClassMethod> 
+    "This method is supposed to be local in Class because of a good reason.
+    We use this pragma to test if Class does not contain some accidental 
+    local selectors."
+
+	^self classInstaller update: self to: [ :builder |
 		builder
 			superclass: self superclass;
 			name: self getName;
@@ -29,7 +39,7 @@ Class >> addSlot: aSlot [
 			sharedVariablesFromString: self classVariablesString;
 			sharedPools: self sharedPoolsString;
 			category: self category;
-			environment: self environment]
+			environment: self environment].
 ]
 
 { #category : #'*Shift-ClassInstaller' }

--- a/src/Shift-ClassInstaller/Metaclass.extension.st
+++ b/src/Shift-ClassInstaller/Metaclass.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #Metaclass }
 Metaclass >> instanceVariableNames: instVarString [ 
 	"Declare additional named variables for my instance."
 	| theClass |
-	theClass := self instanceSide.
+	theClass := self theNonMetaClass.
 	
 	theClass := theClass classInstaller update: theClass to: [ :builder |
 		builder
@@ -17,5 +17,5 @@ Metaclass >> instanceVariableNames: instVarString [
 			traitComposition: theClass traitComposition;
 			category: theClass category asString;
 			classSlots: instVarString asSlotCollection ].
-	^ theClass classSide
+	^ theClass theMetaClass
 ]

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -191,9 +191,8 @@ ShiftClassInstaller >> migrateClassTo: newClass [
 ]
 
 { #category : #migrating }
-ShiftClassInstaller >> migrateInstancesOf: anOldClass to: aNewClass [
-	| oldObjects newObjects |
-	oldObjects := anOldClass allInstances.
+ShiftClassInstaller >> migrateInstances: oldObjects to: aNewClass [
+	| newObjects |
 	newObjects := oldObjects collect: [ :e | self copyObject: e to: aNewClass ].
 
 	oldObjects elementsForwardIdentityTo: newObjects copyHash: true

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -31,7 +31,6 @@ Class {
 
 { #category : #examples }
 ShiftClassInstaller class >> example [
-	<sampleInstance>
 	^ Smalltalk classInstaller make: [ :aSlotClassBuilder |
 		aSlotClassBuilder
 			superclass: Object;
@@ -184,21 +183,26 @@ ShiftClassInstaller >> migrateClassTo: newClass [
 	].
 	
 	[ 	
-		(self builder hasToMigrateInstances) 
-			ifTrue: [self migrateInstancesTo: newClass].
-
+		self migrateInstancesTo: newClass.
+		
 		{ oldClass. builder oldMetaclass } elementsForwardIdentityTo: { newClass. builder newMetaclass }.	
 	] valueUninterruptably.
 
 ]
 
 { #category : #migrating }
-ShiftClassInstaller >> migrateInstancesTo: newClass [
+ShiftClassInstaller >> migrateInstancesOf: anOldClass to: aNewClass [
 	| oldObjects newObjects |
-	oldObjects := oldClass allInstances.
-	newObjects := oldObjects collect: [ :e | self copyObject: e to: newClass ].
+	oldObjects := anOldClass allInstances.
+	newObjects := oldObjects collect: [ :e | self copyObject: e to: aNewClass ].
 
 	oldObjects elementsForwardIdentityTo: newObjects copyHash: true
+]
+
+{ #category : #migrating }
+ShiftClassInstaller >> migrateInstancesTo: newClass [
+	builder changes
+		do: [ :each | each migrateInstancesOf: oldClass to: newClass using: self ]
 ]
 
 { #category : #notifications }


### PR DESCRIPTION
migration instances is moved to change itself.
MEtaclass change is propagated into the subclasses builder as instance change