### PR TITLE
21460-ShiftClassInstaller-do-not-correctly-add-class-side-variables-into-the-hierarchy

### DIFF
--- a/src/Shift-Changes/ShMetaclassChanged.class.st
+++ b/src/Shift-Changes/ShMetaclassChanged.class.st
@@ -19,3 +19,8 @@ ShMetaclassChanged >> builder: anObject [
 	super builder: anObject.
 	oldClass := builder oldClass copy.
 ]
+
+{ #category : #propagating }
+ShMetaclassChanged >> propagateToSubclasses: anotherBuilder [
+		anotherBuilder changes add: self.
+]

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -77,6 +77,17 @@ ShClassInstallerTest >> testModifyingClassKeepsOrganizationOfMethods [
 ]
 
 { #category : #tests }
+ShClassInstallerTest >> testModifyingClassSideInstances [
+	superClass := self newClass:#ShCITestClass slots:#(anInstanceVariable).
+	newClass := self newClass: #ShCITestSubClass superclass: superClass slots: #().
+	
+	superClass class addInstVarNamed: #aVariable.
+
+	self assert: (superClass class hasSlotNamed: #aVariable).
+	self assert: (newClass class hasSlotNamed: #aVariable)
+]
+
+{ #category : #tests }
 ShClassInstallerTest >> testModifyingSuperclass [
 	superClass := self newClass:#ShCITestClass slots:#(anInstanceVariable).
 	newClass := self newClass: #ShCITestSubClass superclass: superClass slots: #().


### PR DESCRIPTION
Propagating the modifications when a change is performed in the metaclass of the superclass.

Issue #21460

https://pharo.fogbugz.com/f/cases/21460/ShiftClassInstaller-do-not-correctly-add-class-side-variables-into-the-hierarchy