### PR TITLE
21468 Remove invalid comment in parseCompositionMappingFrom:

### DIFF
--- a/src/Kernel/CombinedChar.class.st
+++ b/src/Kernel/CombinedChar.class.st
@@ -37,9 +37,7 @@ CombinedChar class >> isDiacriticals: unicode [
 
 { #category : #initialization }
 CombinedChar class >> parseCompositionMappingFrom: stream [
-"
-	self parseCompositionMapping
-"
+ 
 	| line fieldEnd point fieldStart compositions toNumber diacritical result |
 
 	toNumber := [:quad | ('16r', quad) asNumber].


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21468/Remove-invalid-comment-in-parseCompositionMappingFrom

remove comment as the called method does not exist anymore