### PR TITLE
21462-Open-a-FileStream-based-on-fd-or-FILE

### DIFF
--- a/src/FileSystem-Disk/FilePluginPrims.class.st
+++ b/src/FileSystem-Disk/FilePluginPrims.class.st
@@ -177,6 +177,38 @@ FilePluginPrims >> open: fileName writable: writableFlag [
 ]
 
 { #category : #'file primitives' }
+FilePluginPrims >> openFileDescriptor: fileDescriptor writable: writableFlag [
+	"Open the file with fileDescriptor number, and return the file ID obtained"
+
+	<primitive: 'primitiveFileOpenUseFileDescriptor' module: 'FilePlugin' error: error>
+	error = #'bad argument' ifTrue: [ 
+		fileDescriptor isInteger ifFalse: 
+			[ ^self error: 'openFileDescriptor:writable: fileDescriptor must be an integer' ].
+		(writableFlag isKindOf: Boolean) ifFalse: 
+			[ ^self error: 'openFileDescriptor:writable: writableFlag must be a boolean' ] ].
+	OSPlatform current isWindows ifTrue: 
+			[ ^self error: 'openFileDescriptor:writable: not supported on Windows' ].
+	^ self primitiveFailed 
+
+]
+
+{ #category : #'file primitives' }
+FilePluginPrims >> openFileFile: filePointer writable: writableFlag [
+	"Open the file with the supplied FILE* pointer, and return the file ID obtained"
+
+	<primitive: 'primitiveFileOpenUseFile' module: 'FilePlugin' error: error>
+	error = #'bad argument' ifTrue: [ 
+		filePointer isBytes ifFalse: 
+			[ ^self error: 'openFileFile:writable: filePointer must be bytes with size void*' ].
+		(writableFlag isKindOf: Boolean) ifFalse: 
+			[ ^self error: 'openFileFile:writable: writableFlag must be a boolean' ] ].
+	OSPlatform current isWindows ifTrue: 
+			[ ^self error: 'openFileFile:writable: not supported on Windows' ].
+	^ self primitiveFailed 
+
+]
+
+{ #category : #'file primitives' }
 FilePluginPrims >> read: id into: byteArray startingAt: startIndex count: count [
 	"Read up to count bytes of data from this file into the given string or byte array starting at the given index. Answer the number of bytes actually read."
 

--- a/src/FileSystem-Disk/FilePluginPrims.class.st
+++ b/src/FileSystem-Disk/FilePluginPrims.class.st
@@ -34,7 +34,7 @@ FilePluginPrims >> connectToFile: filePointer writable: writableFlag [
 	<primitive: 'primitiveConnectToFile' module: 'FilePlugin' error: error>
 	error = #'bad argument' ifTrue: [ 
 		(filePointer isKindOf: ByteArray) ifFalse: 
-			[ ^self error: 'openFileFile:writable: filePointer must be a ByteArray' ].
+			[ ^self error: 'filePointer must be a ByteArray' ].
 		(writableFlag isKindOf: Boolean) ifFalse: 
 			[ ^self error: 'writableFlag must be a boolean' ] ].
 	^ self primitiveFailed 
@@ -50,7 +50,7 @@ FilePluginPrims >> connectToFileDescriptor: fileDescriptor writable: writableFla
 	<primitive: 'primitiveConnectToFileDescriptor' module: 'FilePlugin' error: error>
 	error = #'bad argument' ifTrue: [ 
 		fileDescriptor isInteger ifFalse: 
-			[ ^self error: 'openFileDescriptor:writable: fileDescriptor must be an integer' ].
+			[ ^self error: 'fileDescriptor must be an integer' ].
 		(writableFlag isKindOf: Boolean) ifFalse: 
 			[ ^self error: 'writableFlag must be a boolean' ] ].
 	^ self primitiveFailed 

--- a/src/FileSystem-Disk/FilePluginPrims.class.st
+++ b/src/FileSystem-Disk/FilePluginPrims.class.st
@@ -33,10 +33,10 @@ FilePluginPrims >> connectToFile: filePointer writable: writableFlag [
 
 	<primitive: 'primitiveConnectToFile' module: 'FilePlugin' error: error>
 	error = #'bad argument' ifTrue: [ 
-		filePointer isBytes ifFalse: 
-			[ ^self error: 'openFileFile:writable: filePointer must be bytes' ].
+		(filePointer isKindOf: ByteArray) ifFalse: 
+			[ ^self error: 'openFileFile:writable: filePointer must be a ByteArray' ].
 		(writableFlag isKindOf: Boolean) ifFalse: 
-			[ ^self error: 'openFileFile:writable: writableFlag must be a boolean' ] ].
+			[ ^self error: 'writableFlag must be a boolean' ] ].
 	^ self primitiveFailed 
 
 ]
@@ -52,7 +52,7 @@ FilePluginPrims >> connectToFileDescriptor: fileDescriptor writable: writableFla
 		fileDescriptor isInteger ifFalse: 
 			[ ^self error: 'openFileDescriptor:writable: fileDescriptor must be an integer' ].
 		(writableFlag isKindOf: Boolean) ifFalse: 
-			[ ^self error: 'openFileDescriptor:writable: writableFlag must be a boolean' ] ].
+			[ ^self error: 'writableFlag must be a boolean' ] ].
 	^ self primitiveFailed 
 
 ]

--- a/src/FileSystem-Disk/FilePluginPrims.class.st
+++ b/src/FileSystem-Disk/FilePluginPrims.class.st
@@ -25,6 +25,38 @@ FilePluginPrims >> close: id [
 	
 ]
 
+{ #category : #'file primitives' }
+FilePluginPrims >> connectToFile: filePointer writable: writableFlag [
+	"Open the file with the supplied FILE* pointer, and return the file ID obtained.
+	writeableFlag indicates whether to allow write operations and must be compatible with the way the file was opened.
+	It is the responsibility of the caller to coordinate closing the file."
+
+	<primitive: 'primitiveConnectToFile' module: 'FilePlugin' error: error>
+	error = #'bad argument' ifTrue: [ 
+		filePointer isBytes ifFalse: 
+			[ ^self error: 'openFileFile:writable: filePointer must be bytes' ].
+		(writableFlag isKindOf: Boolean) ifFalse: 
+			[ ^self error: 'openFileFile:writable: writableFlag must be a boolean' ] ].
+	^ self primitiveFailed 
+
+]
+
+{ #category : #'file primitives' }
+FilePluginPrims >> connectToFileDescriptor: fileDescriptor writable: writableFlag [
+	"Connect to the file with fileDescriptor number, and return the file ID obtained.
+	writeableFlag indicates whether to allow write operations and must be compatible with the way the file was opened.
+	It is the responsibility of the caller to coordinate closing the file."
+
+	<primitive: 'primitiveConnectToFileDescriptor' module: 'FilePlugin' error: error>
+	error = #'bad argument' ifTrue: [ 
+		fileDescriptor isInteger ifFalse: 
+			[ ^self error: 'openFileDescriptor:writable: fileDescriptor must be an integer' ].
+		(writableFlag isKindOf: Boolean) ifFalse: 
+			[ ^self error: 'openFileDescriptor:writable: writableFlag must be a boolean' ] ].
+	^ self primitiveFailed 
+
+]
+
 { #category : #'path primitives' }
 FilePluginPrims >> createDirectory: fullPath [
 	"Create a directory named by the given path. 
@@ -173,38 +205,6 @@ FilePluginPrims >> open: fileName writable: writableFlag [
 
 	<primitive: 'primitiveFileOpen' module: 'FilePlugin'>
 	^ nil
-
-]
-
-{ #category : #'file primitives' }
-FilePluginPrims >> openFileDescriptor: fileDescriptor writable: writableFlag [
-	"Open the file with fileDescriptor number, and return the file ID obtained"
-
-	<primitive: 'primitiveFileOpenUseFileDescriptor' module: 'FilePlugin' error: error>
-	error = #'bad argument' ifTrue: [ 
-		fileDescriptor isInteger ifFalse: 
-			[ ^self error: 'openFileDescriptor:writable: fileDescriptor must be an integer' ].
-		(writableFlag isKindOf: Boolean) ifFalse: 
-			[ ^self error: 'openFileDescriptor:writable: writableFlag must be a boolean' ] ].
-	OSPlatform current isWindows ifTrue: 
-			[ ^self error: 'openFileDescriptor:writable: not supported on Windows' ].
-	^ self primitiveFailed 
-
-]
-
-{ #category : #'file primitives' }
-FilePluginPrims >> openFileFile: filePointer writable: writableFlag [
-	"Open the file with the supplied FILE* pointer, and return the file ID obtained"
-
-	<primitive: 'primitiveFileOpenUseFile' module: 'FilePlugin' error: error>
-	error = #'bad argument' ifTrue: [ 
-		filePointer isBytes ifFalse: 
-			[ ^self error: 'openFileFile:writable: filePointer must be bytes with size void*' ].
-		(writableFlag isKindOf: Boolean) ifFalse: 
-			[ ^self error: 'openFileFile:writable: writableFlag must be a boolean' ] ].
-	OSPlatform current isWindows ifTrue: 
-			[ ^self error: 'openFileFile:writable: not supported on Windows' ].
-	^ self primitiveFailed 
 
 ]
 


### PR DESCRIPTION
Add:

- FilePluginPrims>>openFileFile:writable:
- FilePluginPrims>>openFileDescriptor:writable:

which enables files to be opened based on file descriptor or FILE*.

See also: 

- https://pharo.fogbugz.com/f/cases/21462/
- https://github.com/OpenSmalltalk/opensmalltalk-vm/pull/222