### PR TITLE
21488 Remove unnecessary debug output/debig code from #testPrintNameOn

### DIFF
--- a/src/Collections-Tests/TPrintOnSequencedTest.trait.st
+++ b/src/Collections-Tests/TPrintOnSequencedTest.trait.st
@@ -40,7 +40,7 @@ TPrintOnSequencedTest >> testPrintNameOn [
 	aStream := ReadWriteStream on: result.
 	
 	self nonEmpty printNameOn: aStream.
-	Transcript show: result asString.
+
 	self nonEmpty class name first isVowel
 		ifTrue:[ self assert: aStream contents equals: ('an ',self nonEmpty class name ) ]
 		ifFalse:[ self assert: aStream contents equals: ('a ',self nonEmpty class name)].


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21488/Remove-unnecessary-debug-output-debig-code-from-testPrintNameOn