### PR TITLE
21495 Remove unnecessary #test0CopyTest as this is inherited by TCopyTest

### DIFF
--- a/src/Collections-Tests/ArrayTest.class.st
+++ b/src/Collections-Tests/ArrayTest.class.st
@@ -523,17 +523,6 @@ ArrayTest >> subCollectionNotIn [
 ]
 
 { #category : #'tests - fixture' }
-ArrayTest >> test0CopyTest [
-	self empty.
-	self assert: self empty size = 0.
-	self nonEmpty.
-	self assert: (self nonEmpty size = 0) not.
-	self collectionWithElementsToRemove.
-	self assert: (self collectionWithElementsToRemove size = 0) not.
-	self elementToAdd
-]
-
-{ #category : #'tests - fixture' }
 ArrayTest >> test0FixtureIncludeTest [
 	| anElementIn |
 	self nonEmpty.

--- a/src/Collections-Tests/BagTest.class.st
+++ b/src/Collections-Tests/BagTest.class.st
@@ -323,17 +323,6 @@ BagTest >> speciesClass [
 	^ Bag
 ]
 
-{ #category : #'tests - fixture' }
-BagTest >> test0CopyTest [
-	self empty.
-	self assert: self empty size = 0.
-	self nonEmpty.
-	self assert: (self nonEmpty size = 0) not.
-	self collectionWithElementsToRemove.
-	self assert: (self collectionWithElementsToRemove size = 0) not.
-	self elementToAdd
-]
-
 { #category : #'basic tests' }
 BagTest >> testAdd [
 

--- a/src/Collections-Tests/IntervalTest.class.st
+++ b/src/Collections-Tests/IntervalTest.class.st
@@ -306,19 +306,6 @@ IntervalTest >> subCollectionNotIn [
 ]
 
 { #category : #'tests - fixture' }
-IntervalTest >> test0CopyTest [
-	self empty.
-	self assert: self empty size = 0.
-	self nonEmpty.
-	self assert: (self nonEmpty size = 0) not.
-	self collectionWithElementsToRemove.
-	self assert: (self collectionWithElementsToRemove size = 0) not.
-	self elementToAdd.
-	self collectionNotIncluded.
-	self collectionNotIncluded do: [ :each | self deny: (self nonEmpty includes: each) ]
-]
-
-{ #category : #'tests - fixture' }
 IntervalTest >> test0IndexAccessingTest [
 	self accessCollection.
 	self assert: self accessCollection size = 5.

--- a/src/Collections-Tests/StringTest.class.st
+++ b/src/Collections-Tests/StringTest.class.st
@@ -89,7 +89,7 @@ StringTest >> collectionMoreThan5Elements [
 { #category : #requirements }
 StringTest >> collectionNotIncluded [
 " return a collection for wich each element is not included in 'nonEmpty' "
-	^ notIn 
+	^ collectionNotIncluded  
 ]
 
 { #category : #requirements }
@@ -366,17 +366,6 @@ StringTest >> sortedInAscendingOrderCollection [
 StringTest >> subCollectionNotIn [
 " return a collection for which at least one element is not included in 'moreThan4Elements' "
 	^ collectionNotIncluded 
-]
-
-{ #category : #'tests - fixture' }
-StringTest >> test0CopyTest [
-	self empty.
-	self assert: self empty size = 0.
-	self nonEmpty.
-	self assert: (self nonEmpty size = 0) not.
-	self collectionWithElementsToRemove.
-	self assert: (self collectionWithElementsToRemove size = 0) not.
-	self elementToAdd
 ]
 
 { #category : #tests }

--- a/src/Collections-Tests/TCopyTest.trait.st
+++ b/src/Collections-Tests/TCopyTest.trait.st
@@ -49,7 +49,6 @@ TCopyTest >> test0CopyTest [
 	self collectionWithElementsToRemove do: [ :each | self assert: (self nonEmpty includes: each) ].
 	self elementToAdd.
 	self deny: (self nonEmpty includes: self elementToAdd).
-	self collectionNotIncluded.
 	self collectionNotIncluded do: [ :each | self deny: (self nonEmpty includes: each) ]
 ]
 


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21495/Remove-unnecessary-test0CopyTest-as-this-is-inherited-by-TCopyTest

While inheriting the common tests from Traits is nice it adds additional complexity of its own. 
I guess delegation would have solved this better ...