### PR TITLE
This patches MorphTreeNodeMorph to avoid the walkback described

### DIFF
--- a/src/Morphic-Widgets-Tree/MorphTreeNodeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeNodeMorph.class.st
@@ -894,6 +894,7 @@ MorphTreeNodeMorph >> selected [
 MorphTreeNodeMorph >> selected: aBoolean [
 	selected = aBoolean
 		ifTrue: [^ self].
+	container ifNil: [^ self].
 	aBoolean
 		ifTrue: [container selectedMorphList add: self]
 		ifFalse: [selected 


### PR DESCRIPTION
This patches Issue 20811.  In the normal case where container is not nil, it has no effect.