### PR TITLE
21508-Integrate-Calypso-0103

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -914,11 +914,11 @@ BaselineOfIDE >> loadCalypso [
 		onLock: [ :ex | ex honor ];
 		lock.
 			
-	[Metacello new
+	Metacello new
 		baseline: 'Calypso';
 		repository: 'github://dionisiydk/Calypso:v0.10.3';
-		load: #('FullEnvironment' 'SystemBrowser' 'Tests') ]
-	on: MetacelloAllowLockedProjectChange do: [ :err |  err honor ].
+		onLock: [ :ex | ex honor ];
+		load: #('FullEnvironment' 'SystemBrowser' 'Tests') ].
 
 	(self class environment at: #ClyBrowser) beAllDefault.
 	

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -901,24 +901,22 @@ BaselineOfIDE >> loadCalypso [
 	Metacello new
 		baseline: 'ClassAnnotation';
 		repository: 'github://dionisiydk/ClassAnnotation:v0.3.1';
-		lock.
+		load.
 		
 	Metacello new
 		baseline: 'Commander';
 		repository: 'github://dionisiydk/Commander:v0.5.3';
-		lock.
+		load: #(default #'Commander-SpecSupport' #'Commander-Examples').
 	
 	Metacello new
 		baseline: 'SystemCommands';
 		repository: 'github://dionisiydk/SystemCommands:v0.7.1';
-		onLock: [ :ex | ex honor ];
-		lock.
+		load.
 			
 	Metacello new
 		baseline: 'Calypso';
 		repository: 'github://dionisiydk/Calypso:v0.10.3';
-		onLock: [ :ex | ex honor ];
-		load: #('FullEnvironment' 'SystemBrowser' 'Tests') ].
+		load: #('FullEnvironment' 'SystemBrowser' 'Tests').
 
 	(self class environment at: #ClyBrowser) beAllDefault.
 	

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -899,8 +899,24 @@ BaselineOfIDE >> loadCalypso [
 	(self class environment at: #Iceberg) enableMetacelloIntegration: false.
 
 	Metacello new
+		baseline: 'ClassAnnotation';
+		repository: 'github://dionisiydk/ClassAnnotation:v0.3.1';
+		lock.
+		
+	Metacello new
+		baseline: 'Commander';
+		repository: 'github://dionisiydk/Commander:v0.5.3';
+		lock.
+	
+	Metacello new
+		baseline: 'SystemCommands';
+		repository: 'github://dionisiydk/SystemCommands:v0.7.1';
+		lock.
+			
+	Metacello new
 		baseline: 'Calypso';
-		repository: 'github://dionisiydk/Calypso:v0.10.2';
+		repository: 'github://dionisiydk/Calypso:v0.10.3';
+		onLock: [ :ex | ex honor ];
 		load: #('FullEnvironment' 'SystemBrowser' 'Tests').
 
 	(self class environment at: #ClyBrowser) beAllDefault.

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -911,13 +911,14 @@ BaselineOfIDE >> loadCalypso [
 	Metacello new
 		baseline: 'SystemCommands';
 		repository: 'github://dionisiydk/SystemCommands:v0.7.1';
+		onLock: [ :ex | ex honor ];
 		lock.
 			
-	Metacello new
+	[Metacello new
 		baseline: 'Calypso';
 		repository: 'github://dionisiydk/Calypso:v0.10.3';
-		onLock: [ :ex | ex honor ];
-		load: #('FullEnvironment' 'SystemBrowser' 'Tests').
+		load: #('FullEnvironment' 'SystemBrowser' 'Tests') ]
+	on: MetacelloAllowLockedProjectChange do: [ :err |  err honor ].
 
 	(self class environment at: #ClyBrowser) beAllDefault.
 	


### PR DESCRIPTION
#loadCalypso script is now uses Metacello locking mechanizm to force explicit version for all dependencies.
Calypso version is now 0.10.3.https://pharo.fogbugz.com/f/cases/21508/Integrate-Calypso-0-10-3