### PR TITLE
21042-file-out-does-not-work-from-browser

### DIFF
--- a/src/CodeExport/CodeExporter.class.st
+++ b/src/CodeExport/CodeExporter.class.st
@@ -10,19 +10,11 @@ Class {
 { #category : #'file-out' }
 CodeExporter class >> writeSourceCodeFrom: aStream baseName: baseName isSt: stOrCsFlag [
 
-	| extension fileName  outputStream |
-	extension := stOrCsFlag ifTrue: ['.st']  ifFalse: ['.cs'].
-	fileName := baseName, extension.
-	fileName := FileSystem disk checkName: fileName fixErrors: true.
-	outputStream := (File named: fileName) writeStream.
-	
-	(ZnCrPortableWriteStream on: (ZnCharacterWriteStream
-		on: outputStream
-		encoding: 'utf8')) nextPutAll: aStream contents.
+	| extension targetFile |
+	extension := stOrCsFlag ifTrue: ['st']  ifFalse: ['cs'].
+	targetFile := FileLocator imageDirectory / baseName asFileName, extension.
 
-	outputStream close.
-
-	self inform: 'Filed out to: ', String cr, fileName.
+	self writeSourceCodeFrom: aStream toFileReference: targetFile
 ]
 
 { #category : #'file-out' }
@@ -35,5 +27,5 @@ CodeExporter class >> writeSourceCodeFrom: aStream toFileReference: aFileReferen
 			encoding: 'utf8')) nextPutAll: aStream contents.
 	].
 
-	self inform: 'Filed out to: ', String cr, aFileReference basename
+	self inform: 'Filed out to: ', String cr, aFileReference pathString
 ]


### PR DESCRIPTION
Now CodeExporter uses imageDirectory to fileOut code.https://pharo.fogbugz.com/f/cases/21042/file-out-does-not-work-from-browser