### PR TITLE
21516-Move-packages-from-the-bootstrap-to-be-loaded-with-Hermes

### DIFF
--- a/bootstrap/scripts/build.sh
+++ b/bootstrap/scripts/build.sh
@@ -150,6 +150,8 @@ echo "[Compiler] Adding more Kernel packages"
 ${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Hermes-Extensions.hermes --save
 ${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Multilingual-Encodings.hermes Multilingual-TextConversion.hermes Multilingual-Languages.hermes --save --no-fail-on-undeclared
 
+${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes InitializePackagesCommandLineHandler.hermes System-Model.hermes --save
+
 ${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Collections-Atomic.hermes AST-Core.hermes Collections-Arithmetic.hermes Jobs.hermes --save --no-fail-on-undeclared
 
 echo "[Compiler] Initializing the packages in the Kernel"

--- a/bootstrap/scripts/build.sh
+++ b/bootstrap/scripts/build.sh
@@ -150,7 +150,7 @@ echo "[Compiler] Adding more Kernel packages"
 ${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Hermes-Extensions.hermes --save
 ${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Multilingual-Encodings.hermes Multilingual-TextConversion.hermes Multilingual-Languages.hermes --save --no-fail-on-undeclared
 
-${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes InitializePackagesCommandLineHandler.hermes System-Model.hermes --save
+${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes InitializePackagesCommandLineHandler.hermes --save
 
 ${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Collections-Atomic.hermes AST-Core.hermes Collections-Arithmetic.hermes Jobs.hermes --save --no-fail-on-undeclared
 

--- a/bootstrap/scripts/generateKernelHermesFiles.st
+++ b/bootstrap/scripts/generateKernelHermesFiles.st
@@ -12,7 +12,7 @@ repository := TonelRepository new
 
 Transcript nextPutAll: '[Hermes] - Generating Environment from repository'; cr.
 
-toExport := #BaselineOfPharoBootstrap asClass compilerPackageNames, {'Hermes-Extensions'}, #BaselineOfPharoBootstrap asClass multilingualPackageNames.
+toExport := #BaselineOfPharoBootstrap asClass compilerPackageNames, {'Hermes-Extensions'}, #BaselineOfPharoBootstrap asClass multilingualPackageNames, #BaselineOfPharoBootstrap asClass kernelAdditionalPackagesNames.
 	
 packageNames := #BaselineOfPharoBootstrap asClass kernelPackageNames, toExport.
 environment := repository asRing2EnvironmentWith: packageNames.		

--- a/bootstrap/scripts/runKernelTests.sh
+++ b/bootstrap/scripts/runKernelTests.sh
@@ -38,7 +38,7 @@ export PHARO_CI_TESTING_ENVIRONMENT=1
 ./pharo bootstrap.image
 #Adding packages removed from the bootstrap
 ./pharo bootstrap.image loadHermes Hermes-Extensions.hermes --save
-./pharo bootstrap.image loadHermes Collections-Atomic.hermes AST-Core.hermes Collections-Arithmetic.hermes Jobs.hermes --save --no-fail-on-undeclared --on-duplication=ignore
+./pharo bootstrap.image loadHermes Collections-Atomic.hermes AST-Core.hermes Collections-Arithmetic.hermes Jobs.hermes InitializePackagesCommandLineHandler.hermes --save --no-fail-on-undeclared --on-duplication=ignore
 
 #Initializing the package manager
 ./pharo bootstrap.image initializePackages --packages=packagesKernel.txt --protocols=protocolsKernel.txt --save

--- a/bootstrap/src/Pharo30Bootstrap.package/PBBootstrap.class/instance/exportMonticelloInStFile.st
+++ b/bootstrap/src/Pharo30Bootstrap.package/PBBootstrap.class/instance/exportMonticelloInStFile.st
@@ -2,7 +2,7 @@ preparation
 exportMonticelloInStFile
 
 	self
-		exportPackages: #( 'RingChunkImporter' 'Zinc-Resource-Meta-Core' 'System-Changes' 'Ring-Core-Kernel' 'Ring-Core-Containers' 'RingChunkImporter'  'Compression' 'Monticello' 'Ring-Monticello' )
+		exportPackages: #('System-Model' 'RingChunkImporter' 'Zinc-Resource-Meta-Core' 'System-Changes' 'Ring-Core-Kernel' 'Ring-Core-Containers' 'RingChunkImporter'  'Compression' 'Monticello' 'Ring-Monticello' )
 		usingInitializeScript: '
 		ChangeSet initialize.
 		

--- a/src/BaselineOfMonticello/BaselineOfMonticello.class.st
+++ b/src/BaselineOfMonticello/BaselineOfMonticello.class.st
@@ -34,6 +34,7 @@ BaselineOfMonticello >> baseline: spec [
 			package: 'Compression';
 			package: 'Monticello';
 			package: 'Ring-Monticello';
+			package: 'System-Model';
 			
 			package: 'Network-Kernel';
 			package: 'Network-MIME';
@@ -43,7 +44,7 @@ BaselineOfMonticello >> baseline: spec [
 			package: 'Zinc-FileSystem';
 			package: 'Zodiac-Core'.
 		spec 
-			group: 'Core' with: #('RingChunkImporter' 'Zinc-Resource-Meta-Core' 'System-Changes' 'Ring-Core-Kernel' 'Ring-Core-Containers' 'RingChunkImporter' 'Compression' 'Monticello' 'Ring-Monticello');
+			group: 'Core' with: #('RingChunkImporter' 'Zinc-Resource-Meta-Core' 'System-Changes' 'Ring-Core-Kernel' 'Ring-Core-Containers' 'RingChunkImporter' 'Compression' 'Monticello' 'Ring-Monticello' 'System-Model');
 			group: 'RemoteRepositories' with: #( 'Network-Kernel' 'Network-MIME' 'Network-Protocols' 'MonticelloRemoteRepositories' 'Zinc-HTTP' 'Zinc-FileSystem' 'Zodiac-Core' );
 
 			group: 'default' with: #('Core' 'RemoteRepositories' ). ].		

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -24,6 +24,12 @@ BaselineOfPharoBootstrap class >> fileSystemPackageNames [
 ]
 
 { #category : #accessing }
+BaselineOfPharoBootstrap class >> kernelAdditionalPackagesNames [
+
+	^ self packagesOfGroupNamed: #AdditionalPackages
+]
+
+{ #category : #accessing }
 BaselineOfPharoBootstrap class >> kernelPackageNames [
 
 	^ self packagesOfGroupNamed: #KernelGroup
@@ -142,17 +148,26 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'System-CommandLineHandler'.
 			'System-Finalization'.
 			'System-Hashing'.
-			'System-Model'.
 			'System-Platforms'.
 			'System-SessionManager'.
 			'System-Sources'.
 			'System-Support'.
 
 			'UIManager'.
-			'Zinc-Character-Encoding-Core'.
-			'InitializePackagesCommandLineHandler' }.
+			'Zinc-Character-Encoding-Core' }.
 
 		"These packages are added using hermes after bootstrap"
+
+		spec group: 'AdditionalPackages' with: {
+			'InitializePackagesCommandLineHandler'.
+			'System-Model'.
+		}.
+
+		spec group: 'MultilingualGroup' with: {
+			'Multilingual-Languages'.
+			'Multilingual-Encodings'.
+			'Multilingual-TextConversion'}.
+
 		spec group: 'CompilerGroup' with: {
 			'AST-Core'.
 			'Collections-Arithmetic'.
@@ -174,9 +189,6 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'SUnit-Tests'.
 			'JenkinsTools-Core'}.
 
-		spec group: 'MultilingualGroup' with: {
-			'Multilingual-Languages'.
-			'Multilingual-Encodings'.
-			'Multilingual-TextConversion'}.	]
+	]
 
 ]

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -87,7 +87,6 @@ BaselineOfPharoBootstrap >> baseline: spec [
 		spec package: 'System-CommandLineHandler'.
 		spec package: 'System-Finalization'.
 		spec package: 'System-Hashing'.
-		spec package: 'System-Model'.
 		spec package: 'System-Platforms'.
 		spec package: 'System-SessionManager'.
 		spec package: 'System-Sources'.
@@ -160,7 +159,6 @@ BaselineOfPharoBootstrap >> baseline: spec [
 
 		spec group: 'AdditionalPackages' with: {
 			'InitializePackagesCommandLineHandler'.
-			'System-Model'.
 		}.
 
 		spec group: 'MultilingualGroup' with: {

--- a/src/SUnit-Core/TestSuite.class.st
+++ b/src/SUnit-Core/TestSuite.class.st
@@ -5,11 +5,12 @@ then ensures that any TestResources made available during the run are reset.  Th
 "
 Class {
 	#name : #TestSuite,
-	#superclass : #Model,
+	#superclass : #Object,
 	#instVars : [
 		'tests',
 		'resources',
-		'name'
+		'name',
+		'announcer'
 	],
 	#category : #'SUnit-Core-Kernel'
 }
@@ -159,7 +160,7 @@ TestSuite >> tearDown [
 
 { #category : #announcements }
 TestSuite >> testSuiteAnnouncer [
-	^ self announcer
+	^ announcer ifNil: [ announcer := Announcer new. ]
 ]
 
 { #category : #accessing }

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -190,6 +190,7 @@ SystemDependenciesTest >> metacelloPackageNames [
 	  BaselineOfPharoBootstrap compilerPackageNames,
 	  BaselineOfPharoBootstrap fileSystemPackageNames,
 	  BaselineOfPharoBootstrap multilingualPackageNames,
+	  BaselineOfPharoBootstrap kernelAdditionalPackagesNames,
 	  BaselineOfMonticello corePackageNames,
 	  BaselineOfMonticello remoteRepositoriesPackageNames,
 	  BaselineOfMetacello allPackageNames
@@ -321,6 +322,7 @@ SystemDependenciesTest >> testExternalLocalMonticelloDependencies [
 		BaselineOfPharoBootstrap compilerPackageNames,
 		BaselineOfPharoBootstrap multilingualPackageNames,
 		BaselineOfPharoBootstrap fileSystemPackageNames,
+		BaselineOfPharoBootstrap kernelAdditionalPackagesNames,
 		BaselineOfMonticello corePackageNames).
 	
 	self assertCollection: dependencies equals: self knownLocalMonticelloDependencies.
@@ -351,6 +353,7 @@ SystemDependenciesTest >> testExternalMonticelloDependencies [
 		BaselineOfPharoBootstrap multilingualPackageNames,
 		BaselineOfPharoBootstrap compilerPackageNames,
 		BaselineOfPharoBootstrap fileSystemPackageNames,
+		BaselineOfPharoBootstrap kernelAdditionalPackagesNames,
 		BaselineOfMonticello corePackageNames,
 		BaselineOfMonticello remoteRepositoriesPackageNames).
 	
@@ -422,7 +425,8 @@ SystemDependenciesTest >> testExternalSUnitKernelDependencies [
 	dependencies := self externalDependendiesOf: (
 		BaselineOfTraits allPackageNames,
 		BaselineOfPharoBootstrap kernelPackageNames,
-		BaselineOfPharoBootstrap multilingualPackageNames,		
+		BaselineOfPharoBootstrap multilingualPackageNames,
+		BaselineOfPharoBootstrap kernelAdditionalPackagesNames,
 		BaselineOfPharoBootstrap sUnitPackageNames).
 	
 	self assertCollection: dependencies equals: self knownSUnitKernelDependencies.


### PR DESCRIPTION
Moving the packages:
'InitializePackagesCommandLineHandler'
'System-Model'

This improves the modularity and speeds up the whole process.

Issue: https://pharo.manuscript.com/f/cases/21516/Move-packages-from-the-bootstrap-to-be-loaded-with-Hermes