### PR TITLE
21517-New-traits-copy-all-class-side-methods-of-TraitedClass-to-all-subclasses-of-trait-users

### DIFF
--- a/src/TraitsV2-Tests/T2TraitTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitTest.class.st
@@ -95,6 +95,64 @@ T2TraitTest >> testIndirectSequence [
 ]
 
 { #category : #tests }
+T2TraitTest >> testMethodsAddedInMetaclass [
+	| t1 c1 |
+	
+	t1 := self createT1.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: t1.
+	
+	self assertCollection: c1 class selectors sorted equals: TraitedClass selectors sorted.
+
+]
+
+{ #category : #tests }
+T2TraitTest >> testMethodsAddedInMetaclassNotPresentInSubclasses [
+	| t1 c1 c2 |
+	
+	t1 := self createT1.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: t1.
+	c2 := self newClass: #C2 superclass: c1 with: #() uses: {}.
+	
+	self assertCollection: c2 class selectors sorted equals: #().
+
+]
+
+{ #category : #tests }
+T2TraitTest >> testMethodsAddedInMetaclassPresentInSubclassesAfterChangingSuperclass [
+	| t1 c1 c2 t2 |
+	
+	t1 := self createT1.
+	t2 := self createT2.
+	
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: t1.
+	c2 := self newClass: #C2 superclass: c1 with: #() uses: {t2}.
+	
+	self assertCollection: c2 class selectors sorted equals: #().
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: {}.
+
+	"When a class that uses traits has a empty traitComposition it still keeps being a TraitedClass"
+	self assertCollection: c2 class selectors sorted equals: #().
+
+]
+
+{ #category : #tests }
+T2TraitTest >> testMethodsAddedInMetaclassPresentInSubclassesAfterRemovingSuperclass [
+	| t1 c1 c2 t2 |
+	
+	t1 := self createT1.
+	t2 := self createT2.
+	
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: t1.
+	c2 := self newClass: #C2 superclass: c1 with: #() uses: {t2}.
+	
+	self assertCollection: c2 class selectors sorted equals: #().
+	c1 removeFromSystem.
+
+	self assertCollection: c2 class selectors sorted equals: TraitedClass selectors sorted.
+
+]
+
+{ #category : #tests }
 T2TraitTest >> testSequence [
 	| t1 t2 c1 obj |
 	

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -281,12 +281,20 @@ TraitedClass >> removeFromComposition: aTrait [
 TraitedClass >> removeFromSystem: logged [
 	
 	"When a traited class is removed the traits it is using should be updated"
+	| mySubclasses |
 	self traitComposition removeUser: self.
 	self class traitComposition removeUser: self class.
 
 	TraitedClass removeUser: self class.
-
+	
+	mySubclasses := self subclasses.
+	
 	super removeFromSystem: logged.
+	
+	"As I am a traited class my subclasses does not have the basic traited class 
+	methods, so I add them."
+	mySubclasses do: [ :each | each class initializeBasicMethods ].
+
 ]
 
 { #category : #removing }

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -210,12 +210,25 @@ TraitedMetaclass >> isLocalSelector: aSelector [
 TraitedMetaclass >> isRejectedMethod: aSelector [
 	"The method is not installed in method dictionary if:
 	 - It is in the localMethods.
-	 - It is from Class (we already have them) and are not overriden in TraitedClass.
+	 - It is from Class (we already have them) and they are not overriden in TraitedClass.
+	 - If it is in TraitedClass and it is in my superclass.
 	"
 
-	^ (self isLocalSelector: aSelector)
-		or: [ (Class canUnderstand: aSelector)
-				and: [ (TraitedClass methodDict includesKey: aSelector) not ] ]
+	| isFromClass isFromTraitedClass isMySuperclassTraitedClass |
+	(self isLocalSelector: aSelector)
+		ifTrue: [ ^ true ].
+
+	isFromClass := Class canUnderstand: aSelector.
+	isFromTraitedClass := TraitedClass methodDict includesKey: aSelector.
+	isMySuperclassTraitedClass := (superclass isKindOf: TraitedMetaclass) and: [superclass isObsolete not].
+
+	(isFromClass and: [ isFromTraitedClass not ])
+		ifTrue: [ ^ true ].
+
+	(isFromTraitedClass and: isMySuperclassTraitedClass)
+		ifTrue: [ ^ true ].
+
+	^ false
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Minimizing the copy of methods from TraitedClass in the subclasses that already have them from the subclass.

Issue: https://pharo.manuscript.com/f/cases/resolve/21516/Move-packages-from-the-bootstrap-to-be-loaded-with-Hermes