### PR TITLE
21515-Update-bootstrap-to-bootstrapImage-1.4-and-7.0-VM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -141,7 +141,7 @@ def bootstrapImage(){
     		stage ("Fetch Requirements-${architecture}") {	
     			checkout scm
     			shell 'wget -O - get.pharo.org/vm61 | bash	'
-    			shell 'wget https://github.com/guillep/PharoBootstrap/releases/download/v1.3/bootstrapImage.zip'
+    			shell 'wget https://github.com/guillep/PharoBootstrap/releases/download/v1.4/bootstrapImage.zip'
     			shell 'unzip bootstrapImage.zip'
     			shell './pharo Pharo.image bootstrap/scripts/prepare_image.st --save --quit'
     	    }


### PR DESCRIPTION
Update bootstrapImage from 1.3 to 1.4 in Jenkinsfile

The previous PR only updated bootstrap.sh.   It appears that Jenkinsfile duplicates the code in bootstrap.sh.