### PR TITLE
21521-File-out-and-file-in-code-leads-to-wrong-line-ending-in-the-image2

### DIFF
--- a/src/CodeExport/CodeExporter.class.st
+++ b/src/CodeExport/CodeExporter.class.st
@@ -22,9 +22,8 @@ CodeExporter class >> writeSourceCodeFrom: aStream toFileReference: aFileReferen
 	"Write the supplied changes to aFileReference"
 
 	aFileReference binaryWriteStreamDo: [ :outputStream |
-		(ZnCrPortableWriteStream on: (ZnCharacterWriteStream
-			on: outputStream
-			encoding: 'utf8')) nextPutAll: aStream contents.
+		(ZnCharacterWriteStream on: outputStream encoding: 'utf8')
+			nextPutAll: aStream contents.
 	].
 
 	self inform: 'Filed out to: ', String cr, aFileReference pathString


### PR DESCRIPTION
Avoid using portable stream to not modify in image file ending.https://pharo.fogbugz.com/f/cases/21521/File-out-and-file-in-code-leads-to-wrong-line-ending-in-the-image