### PR TITLE
21522-Better-support-for-write-barrier-in-MirrorPrimitives

### DIFF
--- a/src/Kernel-Tests/ContextTest.class.st
+++ b/src/Kernel-Tests/ContextTest.class.st
@@ -215,7 +215,7 @@ ContextTest >> verifyJumpWithSelector: selector [
 	guineaPig beReadOnlyObject.
 	[ readOnlyStackp := (guineaPig perform: selector) stackPtr ]
 		on: ModificationForbidden 
-		do: [ :ex | ex resume ].
+		do: [ :ex | ex resumeUnchecked: nil ].
 	self assert: normalStackp = readOnlyStackp.
 	
 ]

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -537,7 +537,7 @@ Context >> completeCallee: aContext [
 		whileTrue: [
 			current := context.
 			nextContext := context quickStep.
-			nextContext ifNil: [ self error: 'Should not happens!' ].
+			nextContext ifNil: [ self error: 'Should not happen!' ].
 			context := nextContext ].
 	^ self stepToSendOrReturn
 ]

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -537,7 +537,7 @@ Context >> completeCallee: aContext [
 		whileTrue: [
 			current := context.
 			nextContext := context quickStep.
-			nextContext ifNil: [ self halt ].
+			nextContext ifNil: [ self error: 'Should not happens!' ].
 			context := nextContext ].
 	^ self stepToSendOrReturn
 ]
@@ -1329,7 +1329,7 @@ Context >> object: anObject perform: selector withArguments: argArray inClass: l
 	self primitiveFailed
 ]
 
-{ #category : #accessing }
+{ #category : #'mirror primitives' }
 Context >> objectClass: aReceiver [
 	<primitive: 111>
 	self primitiveFailed

--- a/src/Kernel/ModificationForbidden.class.st
+++ b/src/Kernel/ModificationForbidden.class.st
@@ -10,7 +10,7 @@ selector <Symbol> selector that can be used to reproduce the mutation (typically
 "
 Class {
 	#name : #ModificationForbidden,
-	#superclass : #Exception,
+	#superclass : #Error,
 	#instVars : [
 		'object',
 		'fieldIndex',
@@ -20,19 +20,14 @@ Class {
 	#category : #'Kernel-Exceptions'
 }
 
-{ #category : #'as yet unclassified' }
-ModificationForbidden class >> for: anObject atInstVar: fieldIndex with: newValue retrySelector: selector [
+{ #category : #'instance creation' }
+ModificationForbidden class >> for: anObject at: fieldIndex with: newValue retrySelector: selector [
 
 	^self new 
 		object: anObject;
 		fieldIndex: fieldIndex;
 		newValue: newValue;
 		retrySelector: selector
-]
-
-{ #category : #accessing }
-ModificationForbidden >> defaultAction [
-	UnhandledError signalForException: self
 ]
 
 { #category : #accessing }
@@ -104,7 +99,7 @@ ModificationForbidden >> retryModification [
 	fieldIndex notNil
 		ifTrue: [ object perform: retrySelector with: fieldIndex with: newValue ]
 		ifFalse: [object perform: retrySelector with: newValue ].
-	self resume: newValue
+	self resumeUnchecked: newValue
 ]
 
 { #category : #accessing }

--- a/src/Kernel/ProtoObject.class.st
+++ b/src/Kernel/ProtoObject.class.st
@@ -182,7 +182,7 @@ ProtoObject >> isNil [
 ProtoObject >> modificationForbiddenFor: selector index: index value: value [
 	^ (ModificationForbidden 
 		for: self
-		atInstVar: index
+		at: index
 		with: value
 		retrySelector: selector) signal
 ]

--- a/src/ReflectionMirrors-Primitives-Tests/MirrorPrimitivesTests.class.st
+++ b/src/ReflectionMirrors-Primitives-Tests/MirrorPrimitivesTests.class.st
@@ -38,6 +38,16 @@ MirrorPrimitivesTests >> testChangingFixedFieldOfFixedObject [
 	self should: [MirrorPrimitives fixedFieldOf: object at: 3 put: 500] raise: PrimitiveFailed
 ]
 
+{ #category : #'tests-write barrier' }
+MirrorPrimitivesTests >> testChangingFixedFieldOfReadOnlyObject [
+
+	| object |
+	object := 10@20.
+	object beReadOnlyObject.
+	
+	self should: [MirrorPrimitives fixedFieldOf: object at: 1 put: 500] raise: ModificationForbidden
+]
+
 { #category : #'tests-fields accessing' }
 MirrorPrimitivesTests >> testChangingFixedFieldOfWeakMessageSend [
 
@@ -126,6 +136,16 @@ MirrorPrimitivesTests >> testChangingIndexableFieldOfArray [
 MirrorPrimitivesTests >> testChangingIndexableFieldOfFixedObject [
 	
 	self should: [MirrorPrimitives indexableFieldOf: 10@20 at: 1 put: 10] raise: Error
+]
+
+{ #category : #'tests-write barrier' }
+MirrorPrimitivesTests >> testChangingIndexableFieldOfReadOnlyArray [
+	
+	| array |
+	array := {10. 20}.
+	array beReadOnlyObject.
+	
+	self should: [MirrorPrimitives indexableFieldOf: array at: 1 put: 5] raise: ModificationForbidden
 ]
 
 { #category : #'tests-fields accessing' }
@@ -389,6 +409,16 @@ MirrorPrimitivesTests >> testGettingIndexibleSizeOfWeakMessageSend [
 	self assert: actual equals: 1 "receiver of weak message send is stored as first array item"
 ]
 
+{ #category : #'tests-comparison' }
+MirrorPrimitivesTests >> testIdenticalEquality [
+
+	| object |
+	object := 0@0.
+	
+	self assert: (MirrorPrimitives check: object identicalTo: object).
+	self deny: (MirrorPrimitives check: object identicalTo: 0@0)
+]
+
 { #category : #'tests-write barrier' }
 MirrorPrimitivesTests >> testMakingObjectReadOnly [
 	| point |
@@ -397,7 +427,8 @@ MirrorPrimitivesTests >> testMakingObjectReadOnly [
 	self assert: (MirrorPrimitives isObjectReadOnly: point).
 	
 	[MirrorPrimitives fieldOf: point at: 1 put: 100.
-	self assert: false description: 'should raise modification error'] on: ModificationForbidden do: [].
+	self assert: false description: 'should raise modification error'] 
+		on: ModificationForbidden do: [].
 	self assert: point equals: 10@20.
 
 	MirrorPrimitives makeObject: point readOnly: false.
@@ -432,4 +463,19 @@ MirrorPrimitivesTests >> testPrintingObject [
 	actual := MirrorPrimitives print: 0@0.
 	
 	self assert: actual equals: 'a Point'
+]
+
+{ #category : #'tests-write barrier' }
+MirrorPrimitivesTests >> testRetryingFixedFieldModificationOfReadOnlyObject [
+
+	| array actual |
+	array := {10. 20}.
+	array beReadOnlyObject.
+	
+	actual := [MirrorPrimitives indexableFieldOf: array at: 1 put: 5. #done] 
+		on: ModificationForbidden do: [ :err | 
+			array beWritableObject.
+			err retryModification ].
+	self assert: actual equals: #done.
+	self assert: array equals: #(5 20)
 ]

--- a/src/ReflectionMirrors-Primitives/MirrorModificationForbidden.class.st
+++ b/src/ReflectionMirrors-Primitives/MirrorModificationForbidden.class.st
@@ -1,0 +1,18 @@
+"
+This exception is raised when mutating a read-only object using mirror primitives.
+
+I am signaled from MirrorPrimitive methods.
+"
+Class {
+	#name : #MirrorModificationForbidden,
+	#superclass : #ModificationForbidden,
+	#category : #'ReflectionMirrors-Primitives'
+}
+
+{ #category : #retrying }
+MirrorModificationForbidden >> retryModification [
+	fieldIndex notNil
+		ifTrue: [ MirrorPrimitives perform: retrySelector withArguments: {object. fieldIndex. newValue}]
+		ifFalse: [MirrorPrimitives perform: retrySelector withArguments: {object. newValue}].
+	self resumeUnchecked: newValue
+]

--- a/src/ReflectionMirrors-Primitives/MirrorPrimitives.class.st
+++ b/src/ReflectionMirrors-Primitives/MirrorPrimitives.class.st
@@ -12,6 +12,18 @@ Class {
 	#category : #'ReflectionMirrors-Primitives'
 }
 
+{ #category : #comparison }
+MirrorPrimitives class >> check: anObject identicalTo: anotherObject [
+	"Answer whether the first and second arguments are the same object (have the
+	 same object pointer) without sending a message to the first argument.  This
+	 mimics the action of the VM when it compares two object pointers.  Used to
+	 simulate the execution machinery by, for example, the debugger.
+	 Primitive.  See Object documentation whatIsAPrimitive."
+
+	<primitive: 110>
+	self primitiveFailed
+]
+
 { #category : #'class relationship' }
 MirrorPrimitives class >> classOf: anObject [
 	"Primitive. Answer the object which is the receiver's class"
@@ -24,7 +36,7 @@ MirrorPrimitives class >> classOf: anObject [
 MirrorPrimitives class >> errorNotIndexableFor: anObject [
 	"Create an error notification that the receiver is not indexable."
 
-	self error: ('Instances of {1} are not indexable' translated format: {(self classOf: anObject) name})
+	self error: ('Instances of {1} are not indexable' format: {(self classOf: anObject) name})
 ]
 
 { #category : #'fields accessing' }
@@ -75,21 +87,24 @@ MirrorPrimitives class >> fixedFieldOf: anObject at: anIndex [
 ]
 
 { #category : #'fields accessing' }
-MirrorPrimitives class >> fixedFieldOf: anObject at: index put: value [ 
+MirrorPrimitives class >> fixedFieldOf: anObject at: anIndex put: newValue [ 
 	"Primitive. Store a value into a fixed variable in the argument anObject.
 	 The numbering of the variables corresponds to the named instance
 	 variables.  Fail if the index is not an Integer or is not the index of a
 	 fixed variable.  Answer the value stored as the result"
 
 	<primitive: 74>
-	"Access beyond fixed fields"
-	(self isObjectReadOnly: anObject) 
-		ifTrue: [ ^ (ModificationForbidden 
-							for: anObject
-							atInstVar: index
-							with: value
-							retrySelector: #indexableFieldOf:at:put:) signal ].
-	^self primitiveFail 
+	anIndex isInteger ifTrue: [
+		(anIndex between: 1 and: (self fixedSizeOf: anObject)) 
+			ifTrue: [
+				(self isObjectReadOnly: anObject) ifTrue: [ 
+					^self 
+						modificationForbiddenFor: anObject 
+						at: anIndex 
+						with: newValue
+						selector: #fixedFieldOf:at:put:]].
+		^self primitiveFail].		
+	self errorNonIntegerIndex
 ]
 
 { #category : #'fields accessing' }
@@ -127,30 +142,28 @@ MirrorPrimitives class >> indexableFieldOf: anObject at: anIndex [
 ]
 
 { #category : #'fields accessing' }
-MirrorPrimitives class >> indexableFieldOf: anObject at: index put: value [
+MirrorPrimitives class >> indexableFieldOf: anObject at: anIndex put: newValue [
 	"Primitive. Assumes receiver is indexable. Store the argument value in 
 	the indexable element of the receiver indicated by index. Fail if the 
 	index is not an Integer or is out of bounds. Or fail if the value is not of 
 	the right type for this kind of collection. Answer the value that was 
 	stored"
-
 	<primitive: 61>
-	index isInteger 
-		ifTrue: [(self classOf: anObject) isVariable
-			ifTrue: [(index between: 1 and: (self indexableSizeOf: anObject))
-				ifFalse: [ ^ self errorSubscriptBounds: index]]
-			ifFalse: [ ^ self errorNotIndexable ]]
-		ifFalse: [  
-			^ index isNumber
-				ifTrue: [ self at: index asInteger put: value]
-				ifFalse: [ self errorNonIntegerIndex] ].
-	(self isObjectReadOnly: anObject) 
-		ifTrue: [ ^ (ModificationForbidden 
-							for: anObject
-							atInstVar: index
-							with: value
-							retrySelector: #indexableFieldOf:at:put:) signal ].
-	self errorImproperStore 
+	anIndex isInteger ifTrue:
+		[(self classOf: anObject) isVariable
+			ifTrue: [(anIndex between: 1 and: (self indexableSizeOf: anObject))
+					ifTrue: [
+						(self isObjectReadOnly: anObject) ifTrue: [
+							^self 
+								modificationForbiddenFor: anObject 
+								at: anIndex 
+								with: newValue
+								selector: #indexableFieldOf:at:put:].
+						^self errorImproperStore]
+					ifFalse: [self errorSubscriptBounds: anIndex]]
+			ifFalse: [self errorNotIndexableFor: anObject]].
+	
+	self errorNonIntegerIndex
 ]
 
 { #category : #'fields accessing' }
@@ -173,6 +186,16 @@ MirrorPrimitives class >> isObjectReadOnly: anObject [
 MirrorPrimitives class >> makeObject: anObject readOnly: aBoolean [
 	<primitive: 164 error: ec>
 	^ self primitiveFail
+]
+
+{ #category : #errors }
+MirrorPrimitives class >> modificationForbiddenFor: anObject at: fieldIndex with: newObject selector: selector [
+	
+	^(MirrorModificationForbidden 
+		for: anObject 
+		at: fieldIndex 
+		with: newObject 
+		retrySelector: selector) signal
 ]
 
 { #category : #printing }
@@ -199,7 +222,7 @@ MirrorPrimitives class >> setClass: classObject to: anObject [
 	(self isObjectReadOnly: anObject) 
 		ifTrue: [ ^ (ModificationForbidden 
 							for: anObject
-							atInstVar: nil
+							at: nil
 							with: classObject
 							retrySelector: #setClass:to:) signal ]. 
 	self primitiveFailed
@@ -240,6 +263,8 @@ MirrorPrimitives class >> withReceiver: receiver perform: selector withArguments
 	<primitive: 100 error: error>
 	(selector isSymbol)
 		ifFalse: [^ self error: 'selector argument must be a Symbol'].
+	((self classOf: argArray) == Array) ifFalse:
+		[^self error: 'argArray must be an Array'].
 	(selector numArgs = self indexableSizeOf: argArray)
 		ifFalse: [^ self error: 'incorrect number of arguments'].
 	((self classOf: receiver) == lookupClass or: [(self classOf: receiver) inheritsFrom: lookupClass])


### PR DESCRIPTION
MirrorModificationForbidden exception is added as subclass of MirrorModificationForbidden.
It overriddes #retryModificaiton method to use original mirror based selector.

In addition this fix makes MoridicationForbidden kind of Error instead of Exception.
Because many tools handle Error instead of general Exception (SUnit for example). And with previous version this failure was skipped by them which is wrong.
And generally this failure is kind of error.

Also better name for instance creation method:
	for: anObject at: fieldIndex with: newValue retrySelector:
	
And more tests to cover new behaviour.https://pharo.fogbugz.com/f/cases/21522/Better-support-for-write-barrier-in-MirrorPrimitives