### PR TITLE
21530-ComposablePresenteraboutText-doesnt-return-the-text-when-setting-a-default

### DIFF
--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -194,7 +194,7 @@ ComposablePresenter class >> toolbarHeight [
 { #category : #api }
 ComposablePresenter >> aboutText [
 
-	^ aboutText value ifNil: [ aboutText value: 'The about text for this window has not been set.']
+	^ aboutText value ifNil: [ aboutText value: 'The about text for this window has not been set.'; value]
 ]
 
 { #category : #api }


### PR DESCRIPTION
Ensure ComposablePresenter>>aboutText returns the default text instead of the aboutText value holder