### PR TITLE
21543-IdentityNewValueHoldervalue-doesnt-follow-contract-of-NewValueHoldervalue

### DIFF
--- a/src/NewValueHolder/IdentityNewValueHolder.class.st
+++ b/src/NewValueHolder/IdentityNewValueHolder.class.st
@@ -10,6 +10,5 @@ Class {
 { #category : #accessing }
 IdentityNewValueHolder >> value: anObject [
 
-	self value == anObject ifTrue: [ ^ anObject ].
-	super value: anObject
+	self value == anObject ifFalse: [	super value: anObject ].
 ]


### PR DESCRIPTION
Make IdentitfyNewValueHolder>>value: return a consistent value