### PR TITLE
21547 TStructuralEqualityTest should use "tests" in protocol name instead of "test"

### DIFF
--- a/src/Collections-Tests/StringTest.class.st
+++ b/src/Collections-Tests/StringTest.class.st
@@ -4,7 +4,7 @@ This is the unit test for the class String. Unit tests are a good way to exercis
 	- there is a chapter in the PharoByExample book (http://pharobyexample.org/)
 	- the sunit class category
 "
-Class { 
+Class {
 	#name : #StringTest,
 	#superclass : #CollectionRootTest,
 	#traits : 'TIncludesTest + TCloneTest + TCopyTest + TSetArithmetic + TIterateSequencedReadableTest + TPrintOnSequencedTest + TAsStringCommaAndDelimiterSequenceableTest + TIndexAccess + TSequencedElementAccessTest + TSubCollectionAccess + TPutBasicTest + TCopySequenceableSameContents + TCopyPartOfSequenceable + TCopyPartOfSequenceableForMultipliness + TCopySequenceableWithOrWithoutSpecificElements + TCopySequenceableWithReplacement + TReplacementSequencedTest + (TConvertTest - {#testAsByteArray}) + TConvertAsSortedTest + TBeginsEndsWith + (TIndexAccessForMultipliness - {#testIdentityIndexOfIAbsentDuplicate. #testIdentityIndexOfDuplicate. #collectionWithNonIdentitySameAtEndAndBegining}) + TSequencedConcatenationTest + TPutTest + TConvertAsSetForMultiplinessTest + TSortTest + TSequencedStructuralEqualityTest + TOccurrencesForMultiplinessTest + TCreationWithTest',

--- a/src/Collections-Tests/TStructuralEqualityTest.trait.st
+++ b/src/Collections-Tests/TStructuralEqualityTest.trait.st
@@ -6,13 +6,13 @@ Trait {
 	#category : #'Collections-Tests-Abstract'
 }
 
-{ #category : #'test - equality' }
+{ #category : #'tests - equality' }
 TStructuralEqualityTest >> empty [
 	
 	^ self explicitRequirement
 ]
 
-{ #category : #'test - equality' }
+{ #category : #'tests - equality' }
 TStructuralEqualityTest >> nonEmpty [
 	
 	^ self explicitRequirement
@@ -26,13 +26,13 @@ TStructuralEqualityTest >> test0TStructuralEqualityTest [
 	self deny: self nonEmpty isEmpty
 ]
 
-{ #category : #'test - equality' }
+{ #category : #'tests - equality' }
 TStructuralEqualityTest >> testEqualSign [
  
 	self deny: (self empty = self nonEmpty)
 ]
 
-{ #category : #'test - equality' }
+{ #category : #'tests - equality' }
 TStructuralEqualityTest >> testEqualSignIsTrueForNonIdenticalButEqualCollections [
 		
 	self assert: self empty equals: self empty copy. 
@@ -44,7 +44,7 @@ TStructuralEqualityTest >> testEqualSignIsTrueForNonIdenticalButEqualCollections
 	self assert: self nonEmpty copy equals: self nonEmpty copy
 ]
 
-{ #category : #'test - equality' }
+{ #category : #'tests - equality' }
 TStructuralEqualityTest >> testEqualSignOfIdenticalCollectionObjects [
 	
 	self assert: self empty equals: self empty. 


### PR DESCRIPTION
 

https://pharo.fogbugz.com/f/cases/21547/TStructuralEqualityTest-should-use-tests-in-protocol-name-instead-of-test