### PR TITLE
By default a class should not be abstract

### DIFF
--- a/src/Kernel-Tests/BehaviorTest.class.st
+++ b/src/Kernel-Tests/BehaviorTest.class.st
@@ -141,9 +141,9 @@ BehaviorTest >> testIncludesMethod [
 { #category : #tests }
 BehaviorTest >> testIsAbstract [
 
-	self assert: Behavior isAbstract.	
+	self deny: Behavior isAbstract.	
 	self deny: Behavior class isAbstract.
-	self assert: ClassDescription isAbstract.
+	self deny: ClassDescription isAbstract.
 	self deny: ClassDescription class isAbstract.
 	
 	self deny: Class isAbstract.

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1090,11 +1090,8 @@ Behavior >> instancesSizeInMemory [
 { #category : #testing }
 Behavior >> isAbstract [
 	
-	self withAllSuperclassesDo: [ :eachClass | 
-		eachClass methodsDo: [ :eachMethod |
-			(eachMethod isAbstract and: [ (self lookupSelector: eachMethod selector) isAbstract ])
-				ifTrue: [ ^true ]]].
-	
+	"By default a class is not abstract.
+	Hook to mark your own subclasses as abstract."
 	^false
 ]
 


### PR DESCRIPTION
The current implementation of #isAbstract

```
isAbstract
    
    self withAllSuperclassesDo: [ :eachClass | 
        eachClass methodsDo: [ :eachMethod |
            (eachMethod isAbstract and: [ (self lookupSelector: eachMethod selector) isAbstract ])
                ifTrue: [ ^true ]]].
    
    ^false
```

leads to a lot of false positives.

A class is abstract by design, not by implementation. This should probably be replaced by something like #isFullyImplemented