### PR TITLE
Fixed mc writing

### DIFF
--- a/src/MonticelloRemoteRepositories/MCHttpRepository.class.st
+++ b/src/MonticelloRemoteRepositories/MCHttpRepository.class.st
@@ -184,7 +184,7 @@ MCHttpRepository >> entityStreamContents: aBlock [
 	"Generate output in a buffer because we need the length"
 	
 	| stream |
-	stream := RWBinaryOrTextStream on: String new.
+	stream := ReadWriteStream on: ByteArray new.
 	aBlock value: stream.
 	stream reset.
 	^ (ZnStreamingEntity type: ZnMimeType applicationOctetStream)


### PR DESCRIPTION
- extend CrPortableWriteStream to provide the line ending convention
- use a binary stream to write mc zip file