### PR TITLE
21575-Method-classCommentBlank-should-not-return-actual-class-comment

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -260,11 +260,7 @@ ClassDescription >> classComment: aString stamp: aStamp [
 { #category : #'accessing comment' }
 ClassDescription >> classCommentBlank [
 
-	| existingComment stream |
-	existingComment := self instanceSide organization classComment.
-	existingComment isEmpty
-		ifFalse: [^existingComment].
-
+	| stream |
 	stream := (String new: 100) writeStream.
 	
 	stream nextPutAll: 'Please comment me using the following template inspired by Class Responsibility Collaborator (CRC) design:


### PR DESCRIPTION
It simply removes following code:
```Smalltalk
classCommentBlank

	| existingComment stream |
	existingComment := self instanceSide organization classComment.
	existingComment isEmpty
		ifFalse: [^existingComment].
```https://pharo.fogbugz.com/f/cases/21575/Method-classCommentBlank-should-not-return-actual-class-comment