### PR TITLE
Fix #21602. Choose line ending convention in ZnCrPortableWriteStream.

### DIFF
--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -563,7 +563,7 @@ TestRunner >> fileOutResults [
 		request: 'Enter the file name' 
 		initialAnswer: defaultFilename.
 	fileName ifNil: [^ self].
-	stream := ZnCrPortableWriteStream on: (ZnCharacterWriteStream
+	stream := ZnNewLineWriterStream on: (ZnCharacterWriteStream
 			on: (File openForWriteFileNamed: fileName)
 			encoding: 'utf8').
 	[result fileOutOn: stream]

--- a/src/System-CommandLine/VTermOutputDriver.class.st
+++ b/src/System-CommandLine/VTermOutputDriver.class.st
@@ -35,7 +35,7 @@ Class {
 { #category : #'instance-creation' }
 VTermOutputDriver class >> on: anOutputStream [
 	^ self new
-		outStream: (ZnCrPortableWriteStream on:
+		outStream: (ZnNewLineWriterStream on:
 			(ZnCharacterWriteStream on: anOutputStream encoding: 'utf8'));
 		yourself
 ]

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1111,7 +1111,7 @@ SmalltalkImage >> logStdErrorDuring: aBlock [
 	| stderr |
 	[
 		"install the line end conversion and force initialize the converter"
-		stderr := ZnCrPortableWriteStream on: (ZnCharacterWriteStream
+		stderr := ZnNewLineWriterStream on: (ZnCharacterWriteStream
 			on: Stdio stderr
 			encoding: 'utf8').
 		
@@ -1332,7 +1332,7 @@ SmalltalkImage >> openLog [
 	Because it really belongs to logging facility,
 	we should delegate to it at some point "
 
-	^ [ZnCrPortableWriteStream on: (ZnCharacterWriteStream
+	^ [ZnNewLineWriterStream on: (ZnCharacterWriteStream
 		on:
 			((File named: Smalltalk logFileName) writeStream
 				setToEnd;

--- a/src/Tests/TimeMeasuringTest.class.st
+++ b/src/Tests/TimeMeasuringTest.class.st
@@ -38,7 +38,7 @@ TimeMeasuringTest >> openDebuggerOnFailingTestMethod [
 { #category : #performance }
 TimeMeasuringTest >> reportPerformance [
 	| str |
-	str := ZnCrPortableWriteStream on: (ZnCharacterWriteStream
+	str := ZnNewLineWriterStream on: (ZnCharacterWriteStream
 			on: (File openForWriteFileNamed: 'performanceReports.txt')
 			encoding: 'utf8').
 	

--- a/src/Zinc-Character-Encoding-Core/ZnCrPortableWriteStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnCrPortableWriteStream.class.st
@@ -1,10 +1,17 @@
 "
-I am a write stream wrapping a second stream. Whenever they ask me to write a cr, a lf, or a crlf I'll instead print a portable new line depending on the platform I'm on.
+I am a write stream wrapping a second stream. Whenever they ask me to write a cr, a lf, or a crlf I'll instead print a new line depending on a configured convention. By default I use the current platform convention. 
 
 stream := '' writeStream.
 converter := ZnCrPortableWriteStream on: stream.
 converter cr; cr; lf; nextPut: $a.
 stream contents
+
+A ZnCrPortableWriteStream can be configured with the desired line ending convention using the methods 
+
+converter forCr.
+converter forLf.
+converter forCrLf.
+converter forPlatformLineEnding.
 "
 Class {
 	#name : #ZnCrPortableWriteStream,
@@ -13,7 +20,8 @@ Class {
 		'stream',
 		'cr',
 		'lf',
-		'previous'
+		'previous',
+		'lineEnding'
 	],
 	#category : #'Zinc-Character-Encoding-Core'
 }
@@ -27,18 +35,43 @@ ZnCrPortableWriteStream class >> on: aStream [
 		yourself
 ]
 
+{ #category : #accessing }
+ZnCrPortableWriteStream >> forCr [
+
+	lineEnding := String cr
+]
+
+{ #category : #accessing }
+ZnCrPortableWriteStream >> forCrLf [
+
+	lineEnding := String crlf
+]
+
+{ #category : #accessing }
+ZnCrPortableWriteStream >> forLf [
+
+	lineEnding := String lf
+]
+
+{ #category : #accessing }
+ZnCrPortableWriteStream >> forPlatformLineEnding [
+
+	lineEnding := OSPlatform current lineEnding
+]
+
 { #category : #initialize }
 ZnCrPortableWriteStream >> initialize [
 
 	super initialize.
 	cr := Character cr.
 	lf := Character lf.
+	self forPlatformLineEnding.
 ]
 
 { #category : #accessing }
 ZnCrPortableWriteStream >> newLine [
 	previous := nil.
-	stream nextPutAll: OSPlatform current lineEnding
+	stream nextPutAll: lineEnding
 ]
 
 { #category : #accessing }

--- a/src/Zinc-Character-Encoding-Core/ZnNewLineWriterStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnNewLineWriterStream.class.st
@@ -14,7 +14,7 @@ converter forCrLf.
 converter forPlatformLineEnding.
 "
 Class {
-	#name : #ZnCrPortableWriteStream,
+	#name : #ZnNewLineWriterStream,
 	#superclass : #WriteStream,
 	#instVars : [
 		'stream',
@@ -27,7 +27,7 @@ Class {
 }
 
 { #category : #'instance creation' }
-ZnCrPortableWriteStream class >> on: aStream [
+ZnNewLineWriterStream class >> on: aStream [
 
 	^ self basicNew
 		initialize;
@@ -36,31 +36,31 @@ ZnCrPortableWriteStream class >> on: aStream [
 ]
 
 { #category : #accessing }
-ZnCrPortableWriteStream >> forCr [
+ZnNewLineWriterStream >> forCr [
 
 	lineEnding := String cr
 ]
 
 { #category : #accessing }
-ZnCrPortableWriteStream >> forCrLf [
+ZnNewLineWriterStream >> forCrLf [
 
 	lineEnding := String crlf
 ]
 
 { #category : #accessing }
-ZnCrPortableWriteStream >> forLf [
+ZnNewLineWriterStream >> forLf [
 
 	lineEnding := String lf
 ]
 
 { #category : #accessing }
-ZnCrPortableWriteStream >> forPlatformLineEnding [
+ZnNewLineWriterStream >> forPlatformLineEnding [
 
 	lineEnding := OSPlatform current lineEnding
 ]
 
 { #category : #initialize }
-ZnCrPortableWriteStream >> initialize [
+ZnNewLineWriterStream >> initialize [
 
 	super initialize.
 	cr := Character cr.
@@ -69,13 +69,13 @@ ZnCrPortableWriteStream >> initialize [
 ]
 
 { #category : #accessing }
-ZnCrPortableWriteStream >> newLine [
+ZnNewLineWriterStream >> newLine [
 	previous := nil.
 	stream nextPutAll: lineEnding
 ]
 
 { #category : #accessing }
-ZnCrPortableWriteStream >> nextPut: aCharacter [
+ZnNewLineWriterStream >> nextPut: aCharacter [
 	"Write aCharacter to the receivers stream.
 	Convert all line end combinations, i.e cr, lf, crlf, to the platform convention"
 
@@ -89,6 +89,6 @@ ZnCrPortableWriteStream >> nextPut: aCharacter [
 ]
 
 { #category : #accessing }
-ZnCrPortableWriteStream >> stream: aWriteStream [ 
+ZnNewLineWriterStream >> stream: aWriteStream [ 
 	stream := aWriteStream
 ]

--- a/src/Zinc-Character-Encoding-Tests/ZnCrPortableWriteStreamTests.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnCrPortableWriteStreamTests.class.st
@@ -15,7 +15,7 @@ ZnCrPortableWriteStreamTests >> testNextPut [
 		String lf.
 		String crlf. } do: [ :lineEnd |
 			stream := String new writeStream.
-			crStream := ZnCrPortableWriteStream on: stream.
+			crStream := ZnNewLineWriterStream on: stream.
 			crStream
 				<< 'a';
 				<< lineEnd;


### PR DESCRIPTION
A ZnCrPortableWriteStream can be configured with the desired line ending convention using the methods 

converter forCr.
converter forLf.
converter forCrLf.
converter forPlatformLineEnding.