### PR TITLE
21613-DebugActions-should-have-meaningful-tooltips

### DIFF
--- a/src/DebuggerActions/BrowseDebugAction.class.st
+++ b/src/DebuggerActions/BrowseDebugAction.class.st
@@ -19,33 +19,40 @@ BrowseDebugAction class >> debugActionsFor: aDebugger [
 			id: #browseSendersOfMessages;
 			order: initilOrder;
 			keymap: PharoShortcuts current browseSendersShortcut;
+			help: 'Browse the senders of the current message.';
 			label: 'Senders of...'.
 		self new
 			id: #browseMessages;
 			order: initilOrder + 5;
 			keymap: PharoShortcuts current browseImplementorsShortcut;
+			help: 'Browse the implementors of the current message.';
 			label: 'Implementors of...'.
 		self new
 			id: #methodHierarchy;
 			order: initilOrder + 10;
 			keymap: PharoShortcuts new browseMethodHierarchyShortcut;
+			help: 'Browser a hierarchy of the implementors of the current mnethod.';
 			label: 'Inheritance'.
 		self new
 			id: #browseVersions;
 			order: initilOrder + 15;
 			keymap: PharoShortcuts current browseVersionsShortcut;
+			help: 'Open the historic of the message.';
 			label: 'Versions'.
 		self new
 			id: #browseInstVarRefs;
 			order: initilOrder + 20;
+			help: 'Browse the references to the instance variable.';
 			label: 'Inst var refs...'.
 		self new
 			id: #browseClassVarRefs;
 			order: initilOrder + 25;
+			help: 'Browse the references to the class variable.';
 			label: 'Class var refs...'.
 		self new
 			id: #browseClassVariables;
 			order: initilOrder + 30;
+			help: 'Browse the class variables.';
 			label: 'Class variables';
 			withSeparatorAfter.
 			
@@ -53,30 +60,36 @@ BrowseDebugAction class >> debugActionsFor: aDebugger [
 			id: #browseClassRefs;
 			order: initilOrder + 35;
 			keymap: PharoShortcuts current browseClassReferencesShortcut;
+			help: 'Browse the references to the class.';
 			label: 'Class refs'.
 		self new
 			id: #browseMethodFull;
 			order: initilOrder + 40;
 			keymap: PharoShortcuts current browseShortcut;
+			help: 'Open a system browser on the method sent.';
 			label: 'Browse full'.
 		self new
 			id: #browseReceiver;
 			order: initilOrder + 41;
+			help: 'Open a system browser on the class of the object receiving the method.';
 			"keymap: PharoShortcuts current browseShortcut;"
 			label: 'Browse receiver'.
 		
 		self new
 			id: #fileOutMessage;
 			order: initilOrder + 45;
+			help: 'Export the code of the current method to a file.';
 			label: 'File out'.
 		self new
 			id: #inspectInstances;
 			order: initilOrder + 50;
+			help: 'Open an inspector on a collection containing all the instances of the receiver class.';
 			label: 'Inspect instances'.
 		self new
 			id: #inspectSubInstances;
 			order: initilOrder + 55;
-			label: 'Inspect subinstances';
+			help: 'Open an inspector on a collection containing all the instances and sub instances of the receiver class.';
+			label: 'Inspect sub instances';
 			withSeparatorAfter
 	 }
 ]

--- a/src/DebuggerActions/CopyToClipboardDebugAction.class.st
+++ b/src/DebuggerActions/CopyToClipboardDebugAction.class.st
@@ -33,6 +33,11 @@ CopyToClipboardDebugAction >> executeAction [
 ]
 
 { #category : #accessing }
+CopyToClipboardDebugAction >> help [
+	^ 'Copy a short debugging stack to the clipboard.'
+]
+
+{ #category : #accessing }
 CopyToClipboardDebugAction >> id [
 
 	^ #copyToClipboard

--- a/src/DebuggerActions/DebugAction.class.st
+++ b/src/DebuggerActions/DebugAction.class.st
@@ -121,12 +121,6 @@ DebugAction >> defaultCategory [
 ]
 
 { #category : #accessing }
-DebugAction >> defaultHelp [
-
-	^ 'No help, sorry.'
-]
-
-{ #category : #accessing }
 DebugAction >> defaultIcon [
 
 	^ self class defaultIcon
@@ -195,8 +189,7 @@ DebugAction >> forDebugger: aDebugger [
 
 { #category : #accessing }
 DebugAction >> help [
-
-	^ self defaultHelp
+	^ self subclassResponsibility
 ]
 
 { #category : #accessing }

--- a/src/DebuggerActions/DoesNotUnderstandDebugAction.class.st
+++ b/src/DebuggerActions/DoesNotUnderstandDebugAction.class.st
@@ -41,11 +41,6 @@ DoesNotUnderstandDebugAction >> askForSuperclassOf: aClass toImplement: aSelecto
 ]
 
 { #category : #accessing }
-DoesNotUnderstandDebugAction >> defaultHelp [
-    ^ 'Create the missing method in the user prompted class and restart the debugger at that location where it can be edited.'
-]
-
-{ #category : #accessing }
 DoesNotUnderstandDebugAction >> defaultLabel [
 
 	^  'Create'
@@ -77,6 +72,11 @@ DoesNotUnderstandDebugAction >> executeAction [
 		inClass: chosenClass 
 		forContext: self interruptedContext.
 	self debugger selectTopContext
+]
+
+{ #category : #accessing }
+DoesNotUnderstandDebugAction >> help [
+    ^ 'Create the missing method in the user prompted class and restart the debugger at that location where it can be edited.'
 ]
 
 { #category : #accessing }

--- a/src/DebuggerActions/FullStackDebugAction.class.st
+++ b/src/DebuggerActions/FullStackDebugAction.class.st
@@ -47,7 +47,7 @@ FullStackDebugAction >> expandedStackSize [
 
 { #category : #accessing }
 FullStackDebugAction >> help [
-	^ 'Open a full debuggeur to navigate in the full bugged stack.'
+	^ 'Open a full debugger to navigate in the full bugged stack.'
 ]
 
 { #category : #accessing }

--- a/src/DebuggerActions/FullStackDebugAction.class.st
+++ b/src/DebuggerActions/FullStackDebugAction.class.st
@@ -46,6 +46,11 @@ FullStackDebugAction >> expandedStackSize [
 ]
 
 { #category : #accessing }
+FullStackDebugAction >> help [
+	^ 'Open a full debuggeur to navigate in the full bugged stack.'
+]
+
+{ #category : #accessing }
 FullStackDebugAction >> id [
 
 	^ #fullStack

--- a/src/DebuggerActions/MessageSendDebugAction.class.st
+++ b/src/DebuggerActions/MessageSendDebugAction.class.st
@@ -20,7 +20,8 @@ Class {
 	#superclass : #DebugAction,
 	#instVars : [
 		'id',
-		'selector'
+		'selector',
+		'help'
 	],
 	#category : #'DebuggerActions-Actions'
 }
@@ -37,6 +38,16 @@ MessageSendDebugAction >> executeAction [
 	self receiver 
 		perform: self selector
 		withEnoughArguments: self arguments
+]
+
+{ #category : #accessing }
+MessageSendDebugAction >> help [
+	^ help
+]
+
+{ #category : #accessing }
+MessageSendDebugAction >> help: anObject [
+	help := anObject
 ]
 
 { #category : #accessing }

--- a/src/DebuggerActions/PeelToFirstDebugAction.class.st
+++ b/src/DebuggerActions/PeelToFirstDebugAction.class.st
@@ -32,6 +32,11 @@ PeelToFirstDebugAction >> executeAction [
 ]
 
 { #category : #accessing }
+PeelToFirstDebugAction >> help [
+	^ 'Peels the stack back to the second occurance of the currently selected message.'
+]
+
+{ #category : #accessing }
 PeelToFirstDebugAction >> id [
 
 	^ #peelToFirst

--- a/src/DebuggerActions/PreDebugAction.class.st
+++ b/src/DebuggerActions/PreDebugAction.class.st
@@ -20,13 +20,13 @@ PreDebugAction class >> debugActionsFor: aDebugger [
 			id: #abandonAction;
 			selector: #close;
 			order: 10;
-			help: 'Close the debuggeur and ignore the exception';
+			help: 'Close the debugger and ignore the exception';
 			label: 'Abandon'.
 		self new
 			id: #openFullDebuggerAction;
 			selector: #openFullDebugger;
 			order: 15;
-			help: 'Open a full debuggeur to navigate in the full bugged stack.';
+			help: 'Open a full debugger to navigate in the full bugged stack.';
 			label: 'Debug'
 	}
 ]

--- a/src/DebuggerActions/PreDebugAction.class.st
+++ b/src/DebuggerActions/PreDebugAction.class.st
@@ -20,11 +20,13 @@ PreDebugAction class >> debugActionsFor: aDebugger [
 			id: #abandonAction;
 			selector: #close;
 			order: 10;
+			help: 'Close the debuggeur and ignore the exception';
 			label: 'Abandon'.
 		self new
 			id: #openFullDebuggerAction;
 			selector: #openFullDebugger;
 			order: 15;
+			help: 'Open a full debuggeur to navigate in the full bugged stack.';
 			label: 'Debug'
 	}
 ]

--- a/src/DebuggerActions/RestartDebugAction.class.st
+++ b/src/DebuggerActions/RestartDebugAction.class.st
@@ -15,11 +15,6 @@ RestartDebugAction class >> actionType [
 ]
 
 { #category : #accessing }
-RestartDebugAction >> defaultHelp [
-	^ 'Go back the start of the current execution context, resetting all local variables and take debugger control.'
-]
-
-{ #category : #accessing }
 RestartDebugAction >> defaultKeymap [
 
 	^ PharoShortcuts current restartExecutionShortcut
@@ -41,6 +36,11 @@ RestartDebugAction >> defaultOrder [
 RestartDebugAction >> executeAction [
 
 	self session restart: self currentContext
+]
+
+{ #category : #accessing }
+RestartDebugAction >> help [
+	^ 'Go back the start of the current execution context, resetting all local variables and take debugger control.'
 ]
 
 { #category : #accessing }

--- a/src/DebuggerActions/ResumeDebugAction.class.st
+++ b/src/DebuggerActions/ResumeDebugAction.class.st
@@ -15,11 +15,6 @@ ResumeDebugAction class >> actionType [
 ]
 
 { #category : #accessing }
-ResumeDebugAction >> defaultHelp [
-	^ 'Relinquish debugger control and proceed execution from the current point of debugger control.'
-]
-
-{ #category : #accessing }
 ResumeDebugAction >> defaultKeymap [
 
 	^ PharoShortcuts current resumeExecutionShortcut
@@ -50,6 +45,11 @@ ResumeDebugAction >> executeAction [
 		resume;
 		clear.
 	self debugger close. 
+]
+
+{ #category : #accessing }
+ResumeDebugAction >> help [
+	^ 'Relinquish debugger control and proceed execution from the current point of debugger control.'
 ]
 
 { #category : #accessing }

--- a/src/DebuggerActions/ReturnValueDebugAction.class.st
+++ b/src/DebuggerActions/ReturnValueDebugAction.class.st
@@ -40,6 +40,11 @@ ReturnValueDebugAction >> executeAction [
 ]
 
 { #category : #accessing }
+ReturnValueDebugAction >> help [
+	^ 'Forces a return of a given value to the previous context.'
+]
+
+{ #category : #accessing }
 ReturnValueDebugAction >> id [
 
 	^ #returnValue

--- a/src/DebuggerActions/ReturnValueDebugAction.class.st
+++ b/src/DebuggerActions/ReturnValueDebugAction.class.st
@@ -41,7 +41,7 @@ ReturnValueDebugAction >> executeAction [
 
 { #category : #accessing }
 ReturnValueDebugAction >> help [
-	^ 'Forces a return of a given value to the previous context.'
+	^ 'Return of a given value to the previous context.'
 ]
 
 { #category : #accessing }

--- a/src/DebuggerActions/RunToSelectionDebugAction.class.st
+++ b/src/DebuggerActions/RunToSelectionDebugAction.class.st
@@ -14,12 +14,6 @@ RunToSelectionDebugAction class >> actionType [
 ]
 
 { #category : #accessing }
-RunToSelectionDebugAction >> defaultHelp [
-
-	^ 'Execute methods up to the text cursor position and return debugger control.'
-]
-
-{ #category : #accessing }
 RunToSelectionDebugAction >> defaultLabel [
 
 	^ 'Run to here'
@@ -37,6 +31,11 @@ RunToSelectionDebugAction >> executeAction [
 	self session 
 		runToSelection: self debugger code getSelection 
 		inContext: self currentContext
+]
+
+{ #category : #accessing }
+RunToSelectionDebugAction >> help [
+	^ 'Execute methods up to the text cursor position and return debugger control.'
 ]
 
 { #category : #accessing }

--- a/src/DebuggerActions/StepIntoDebugAction.class.st
+++ b/src/DebuggerActions/StepIntoDebugAction.class.st
@@ -15,11 +15,6 @@ StepIntoDebugAction class >> actionType [
 ]
 
 { #category : #accessing }
-StepIntoDebugAction >> defaultHelp [
-	^ 'Step in the highlighted message, i.e. follow the sent message, taking debugger control in the method invoked.'
-]
-
-{ #category : #accessing }
 StepIntoDebugAction >> defaultKeymap [
 
 	^ PharoShortcuts current stepIntoShortcut
@@ -41,6 +36,11 @@ StepIntoDebugAction >> defaultOrder [
 StepIntoDebugAction >> executeAction [
 
 	self session stepInto: self currentContext
+]
+
+{ #category : #accessing }
+StepIntoDebugAction >> help [
+	^ 'Step in the highlighted message, i.e. follow the sent message, taking debugger control in the method invoked.'
 ]
 
 { #category : #accessing }

--- a/src/DebuggerActions/StepOverDebugAction.class.st
+++ b/src/DebuggerActions/StepOverDebugAction.class.st
@@ -15,11 +15,6 @@ StepOverDebugAction class >> actionType [
 ]
 
 { #category : #accessing }
-StepOverDebugAction >> defaultHelp [
-	^ 'Step over the highlighted message, i.e. do not follow the sent message, taking debugger control after the method invoked returns.'
-]
-
-{ #category : #accessing }
 StepOverDebugAction >> defaultKeymap [
 
 	^ PharoShortcuts current stepOverShortcut
@@ -41,6 +36,11 @@ StepOverDebugAction >> defaultOrder [
 StepOverDebugAction >> executeAction [
 
 	self session stepOver: self currentContext
+]
+
+{ #category : #accessing }
+StepOverDebugAction >> help [
+	^ 'Step over the highlighted message, i.e. do not follow the sent message, taking debugger control after the method invoked returns.'
 ]
 
 { #category : #accessing }

--- a/src/DebuggerActions/StepThroughDebugAction.class.st
+++ b/src/DebuggerActions/StepThroughDebugAction.class.st
@@ -15,11 +15,6 @@ StepThroughDebugAction class >> actionType [
 ]
 
 { #category : #accessing }
-StepThroughDebugAction >> defaultHelp [
-	^ 'Step over the highlighted message, i.e. do not follow the sent message, taking debugger control after the method invoked returns or whenever execution should return inside a block used as an argument before that.'
-]
-
-{ #category : #accessing }
 StepThroughDebugAction >> defaultKeymap [
 
 	^ PharoShortcuts current stepThroughShortcut
@@ -41,6 +36,11 @@ StepThroughDebugAction >> defaultOrder [
 StepThroughDebugAction >> executeAction [
 
 	self session stepThrough: self currentContext
+]
+
+{ #category : #accessing }
+StepThroughDebugAction >> help [
+	^ 'Step over the highlighted message, i.e. do not follow the sent message, taking debugger control after the method invoked returns or whenever execution should return inside a block used as an argument before that.'
 ]
 
 { #category : #accessing }

--- a/src/DebuggerActions/SubclassResponsabilityDebugAction.class.st
+++ b/src/DebuggerActions/SubclassResponsabilityDebugAction.class.st
@@ -84,6 +84,11 @@ SubclassResponsabilityDebugAction >> executeAction [
 ]
 
 { #category : #accessing }
+SubclassResponsabilityDebugAction >> help [
+	^ 'Create a method in a class having the responsability to implement it.'
+]
+
+{ #category : #accessing }
 SubclassResponsabilityDebugAction >> id [
 
 	^ #subclassResponsability

--- a/src/DebuggerActions/WhereIsDebugAction.class.st
+++ b/src/DebuggerActions/WhereIsDebugAction.class.st
@@ -15,12 +15,6 @@ WhereIsDebugAction class >> actionType [
 ]
 
 { #category : #accessing }
-WhereIsDebugAction >> defaultHelp [
-
-	^ 'Highligh the next method to be executed (step) by the debugger.'
-]
-
-{ #category : #accessing }
 WhereIsDebugAction >> defaultLabel [
 
 	^ 'Where is?'
@@ -37,6 +31,11 @@ WhereIsDebugAction >> executeAction [
 
 	self debugger code setSelection: (self session 
 		pcRangeForContext:  self currentContext)	
+]
+
+{ #category : #accessing }
+WhereIsDebugAction >> help [
+	^ 'Highligh the next method to be executed (step) by the debugger.'
 ]
 
 { #category : #accessing }

--- a/src/FuelTools-Debugger/FuelOutStackDebugAction.class.st
+++ b/src/FuelTools-Debugger/FuelOutStackDebugAction.class.st
@@ -76,6 +76,11 @@ FuelOutStackDebugAction >> executeAction [
 ]
 
 { #category : #accessing }
+FuelOutStackDebugAction >> help [
+	^ 'Serialize a portion of the current stack trace using fuel.'
+]
+
+{ #category : #accessing }
 FuelOutStackDebugAction >> id [
 
 	^ #fuelOutStack

--- a/src/GT-BytecodeDebugger/GTGoAndInspectBytecodeDebugAction.class.st
+++ b/src/GT-BytecodeDebugger/GTGoAndInspectBytecodeDebugAction.class.st
@@ -1,5 +1,5 @@
 "
-I am a debugging action that inspects the currently selected bytecode.
+I am a debugging action that inspect the currently selected bytecode.
 
 "
 Class {
@@ -37,7 +37,7 @@ GTGoAndInspectBytecodeDebugAction >> executeAction [
 
 { #category : #accessing }
 GTGoAndInspectBytecodeDebugAction >> help [
-	^ 'Inspects the currently selected bytecode.'
+	^ 'Inspect the currently selected bytecode.'
 ]
 
 { #category : #accessing }

--- a/src/GT-BytecodeDebugger/GTGoAndInspectBytecodeDebugAction.class.st
+++ b/src/GT-BytecodeDebugger/GTGoAndInspectBytecodeDebugAction.class.st
@@ -36,6 +36,11 @@ GTGoAndInspectBytecodeDebugAction >> executeAction [
 ]
 
 { #category : #accessing }
+GTGoAndInspectBytecodeDebugAction >> help [
+	^ 'Inspects the currently selected bytecode.'
+]
+
+{ #category : #accessing }
 GTGoAndInspectBytecodeDebugAction >> id [
 
 	^ GTGoAndInspectBytecodeDebugAction name

--- a/src/GT-BytecodeDebugger/GTStepToBytecodeDebugAction.class.st
+++ b/src/GT-BytecodeDebugger/GTStepToBytecodeDebugAction.class.st
@@ -15,7 +15,7 @@ GTStepToBytecodeDebugAction class >> gtBytecodeDebuggerActionFor: aDebugger [
 			icon: GLMUIThemeExtraIcons glamorousPlay
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 GTStepToBytecodeDebugAction >> appliesToDebugger: aDebugger [
 
 	^ (aDebugger session isContextPostMortem: aDebugger currentContext) not and: [ 
@@ -40,6 +40,11 @@ GTStepToBytecodeDebugAction >> executeAction [
 	self session
 		runToBytecode: self debugger bytecodePresentation selection 
 		inContext: self currentContext
+]
+
+{ #category : #accessing }
+GTStepToBytecodeDebugAction >> help [
+	^ 'Step to a selected bytecode.'
 ]
 
 { #category : #accessing }

--- a/src/GT-Debugger/GTBrowseMethodDebuggerAction.class.st
+++ b/src/GT-Debugger/GTBrowseMethodDebuggerAction.class.st
@@ -35,6 +35,11 @@ GTBrowseMethodDebuggerAction >> executeAction [
 ]
 
 { #category : #accessing }
+GTBrowseMethodDebuggerAction >> help [
+	^ 'Open a sytem browser on the current method.'
+]
+
+{ #category : #accessing }
 GTBrowseMethodDebuggerAction >> id [
 
 	^ #gtBrowseMethodDebuggerAction

--- a/src/GT-Debugger/GTChangeDebuggerAction.class.st
+++ b/src/GT-Debugger/GTChangeDebuggerAction.class.st
@@ -65,6 +65,11 @@ GTChangeDebuggerAction >> executeAction [
 	 newDebugger := self debugger debug: self interruptedContext using: debuggerClass
 ]
 
+{ #category : #accessing }
+GTChangeDebuggerAction >> help [
+	^ 'Switch to another debugger'
+]
+
 { #category : #initialization }
 GTChangeDebuggerAction >> initialize [
 	super initialize.

--- a/src/GT-Debugger/GTClearEditorDebugAction.class.st
+++ b/src/GT-Debugger/GTClearEditorDebugAction.class.st
@@ -49,6 +49,11 @@ GTClearEditorDebugAction >> executeAction [
 ]
 
 { #category : #accessing }
+GTClearEditorDebugAction >> help [
+	^ 'Cancel editor changes.'
+]
+
+{ #category : #accessing }
 GTClearEditorDebugAction >> id [
 
 	^ #gtClearEditorDebugAction

--- a/src/GT-Debugger/GTDebugSelectionDebugAction.class.st
+++ b/src/GT-Debugger/GTDebugSelectionDebugAction.class.st
@@ -41,6 +41,11 @@ GTDebugSelectionDebugAction >> executeAction [
 ]
 
 { #category : #accessing }
+GTDebugSelectionDebugAction >> help [
+	^ 'Debug a selected piece of code from the code pane of the debugger.'
+]
+
+{ #category : #accessing }
 GTDebugSelectionDebugAction >> id [
 
 	^ #gTDebugSelectionDebugAction

--- a/src/GT-Debugger/GTExecuteSelectionDebugAction.class.st
+++ b/src/GT-Debugger/GTExecuteSelectionDebugAction.class.st
@@ -42,6 +42,11 @@ GTExecuteSelectionDebugAction >> executeAction [
 ]
 
 { #category : #accessing }
+GTExecuteSelectionDebugAction >> help [
+	^ 'Execute a selected piece of code from the code pane of the debugger.'
+]
+
+{ #category : #accessing }
 GTExecuteSelectionDebugAction >> id [
 
 	^ #gTExecuteSelectionDebugAction

--- a/src/GT-Debugger/GTHelpDebugAction.class.st
+++ b/src/GT-Debugger/GTHelpDebugAction.class.st
@@ -41,6 +41,11 @@ GTHelpDebugAction >> executeAction [
 				each title = 'Overview' ] ] ]
 ]
 
+{ #category : #accessing }
+GTHelpDebugAction >> help [
+	^ 'Open an help browser for the currently active debugger.'
+]
+
 { #category : #initialization }
 GTHelpDebugAction >> initialize [
 	super initialize.

--- a/src/GT-Debugger/GTInspectSelectionDebugAction.class.st
+++ b/src/GT-Debugger/GTInspectSelectionDebugAction.class.st
@@ -60,6 +60,11 @@ GTInspectSelectionDebugAction >> executeAction [
 ]
 
 { #category : #accessing }
+GTInspectSelectionDebugAction >> help [
+	^ 'Inspecte the result of a selected piece of code from the code pane of the debugger.'
+]
+
+{ #category : #accessing }
 GTInspectSelectionDebugAction >> id [
 
 	^ #gTInspectSelectionDebugAction

--- a/src/GT-Debugger/GTInspectSelectionDebugAction.class.st
+++ b/src/GT-Debugger/GTInspectSelectionDebugAction.class.st
@@ -61,7 +61,7 @@ GTInspectSelectionDebugAction >> executeAction [
 
 { #category : #accessing }
 GTInspectSelectionDebugAction >> help [
-	^ 'Inspecte the result of a selected piece of code from the code pane of the debugger.'
+	^ 'Inspect the result of a selected piece of code from the code pane of the debugger.'
 ]
 
 { #category : #accessing }

--- a/src/GT-Debugger/GTPrintSelectionDebugAction.class.st
+++ b/src/GT-Debugger/GTPrintSelectionDebugAction.class.st
@@ -42,6 +42,11 @@ GTPrintSelectionDebugAction >> executeAction [
 ]
 
 { #category : #accessing }
+GTPrintSelectionDebugAction >> help [
+	^ 'Print the result of a selected piece of code from the code pane of the debugger.'
+]
+
+{ #category : #accessing }
 GTPrintSelectionDebugAction >> id [
 
 	^ #gTPrintSelectionDebugAction

--- a/src/GT-Debugger/GTProfileSelectionDebugAction.class.st
+++ b/src/GT-Debugger/GTProfileSelectionDebugAction.class.st
@@ -35,6 +35,11 @@ GTProfileSelectionDebugAction >> executeAction [
 ]
 
 { #category : #accessing }
+GTProfileSelectionDebugAction >> help [
+	^ 'Profile the execution of a selected piece of code from the code pane of the debugger.'
+]
+
+{ #category : #accessing }
 GTProfileSelectionDebugAction >> id [
 
 	^ #gTProfileSelectionDebugAction

--- a/src/GT-Debugger/GTSaveDebugAction.class.st
+++ b/src/GT-Debugger/GTSaveDebugAction.class.st
@@ -15,7 +15,7 @@ GTSaveDebugAction class >> gtActionFor: aDebugger [
 			icon: GLMUIThemeExtraIcons glamorousAccept
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 GTSaveDebugAction >> defaultKeymap [
 
 	^ PharoShortcuts current acceptShortcut
@@ -44,6 +44,11 @@ GTSaveDebugAction >> executeAction [
 				from: self session 
 				andDo: [ self needsUpdate: true ] ].
 	self codePresentation flash
+]
+
+{ #category : #accessing }
+GTSaveDebugAction >> help [
+	^ 'Save the current method.'
 ]
 
 { #category : #accessing }

--- a/src/GT-Debugger/GTSelectionGoDebugAction.class.st
+++ b/src/GT-Debugger/GTSelectionGoDebugAction.class.st
@@ -42,6 +42,11 @@ GTSelectionGoDebugAction >> executeAction [
 ]
 
 { #category : #accessing }
+GTSelectionGoDebugAction >> help [
+	^ 'Evaluate the selection in a code pane of a debugger and push the result in the inspector of the debugger.'
+]
+
+{ #category : #accessing }
 GTSelectionGoDebugAction >> id [
 
 	^ #gTOpenSelectionDebugAction

--- a/src/GT-Debugger/GTTemporaryPreDebugChangeDebuggerAction.class.st
+++ b/src/GT-Debugger/GTTemporaryPreDebugChangeDebuggerAction.class.st
@@ -49,6 +49,11 @@ GTTemporaryPreDebugChangeDebuggerAction >> executeAction [
 ]
 
 { #category : #accessing }
+GTTemporaryPreDebugChangeDebuggerAction >> help [
+	^ 'Open a GTDebugger from the PreDebugWindow.'
+]
+
+{ #category : #accessing }
 GTTemporaryPreDebugChangeDebuggerAction >> id [
 
 	^ #gtChangeDebuggerPreDebug

--- a/src/GT-SUnitDebugger/GTSUnitDebuggerJumpToTestAction.class.st
+++ b/src/GT-SUnitDebugger/GTSUnitDebuggerJumpToTestAction.class.st
@@ -43,7 +43,7 @@ GTSUnitDebuggerJumpToTestAction >> executeAction [
 
 { #category : #accessing }
 GTSUnitDebuggerJumpToTestAction >> help [
-	^ 'Select in the stack the context containing the test  method.'
+	^ 'Select in the stack the context containing the test method.'
 ]
 
 { #category : #accessing }

--- a/src/GT-SUnitDebugger/GTSUnitDebuggerJumpToTestAction.class.st
+++ b/src/GT-SUnitDebugger/GTSUnitDebuggerJumpToTestAction.class.st
@@ -42,12 +42,17 @@ GTSUnitDebuggerJumpToTestAction >> executeAction [
 ]
 
 { #category : #accessing }
+GTSUnitDebuggerJumpToTestAction >> help [
+	^ 'Select in the stack the context containing the test  method.'
+]
+
+{ #category : #accessing }
 GTSUnitDebuggerJumpToTestAction >> id [
 
 	^ GTSUnitDebuggerJumpToTestAction name
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 GTSUnitDebuggerJumpToTestAction >> initialize [
 	super initialize.
 	self needsUpdate: false


### PR DESCRIPTION
Case 21613 : https://pharo.fogbugz.com/f/cases/21613/DebugActions-should-have-meaningful-tooltips

- Remove DebugAction>>defaultHelp which was really not useful...
- Make DebugAction>>help as subclassResponsibility
- Implement #help on all subclasses of DebugAction missing it
- Categorise some uncategorised methods

Working on this I also saw that the context menus do not display tooltips on hover :( This is another issue. (https://pharo.fogbugz.com/f/cases/21614/Debugger-menus-do-not-show-tooltips-of-the-debug-actions)