### PR TITLE
21615-Separate-bootstrap-process-in-to-distinct-stages

### DIFF
--- a/bootstrap/scripts/1-clean.sh
+++ b/bootstrap/scripts/1-clean.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Remove any artifacts from previous bootstrap runs
+#
+set -x
+set -e
+
+source bootstrap/scripts/envvars.sh
+
+pushd "${REPOSITORY}"
+rm -f bootstrapImage.zip
+rm -f Pharo.image Pharo.changes pharo pharo-ui
+rm -rf pharo-vm
+rm -rf pharo-local
+rm -rf vmtarget
+rm -rf "${CACHE}"
+popd

--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Download resources required for bootstrap process
+#
+set -x
+set -e
+
+source bootstrap/scripts/envvars.sh
+
+mkdir -p "${CACHE}" #required to generate hermes files
+
+wget -O - get.pharo.org/vm61 | bash
+wget https://github.com/guillep/PharoBootstrap/releases/download/v1.4/bootstrapImage.zip
+unzip bootstrapImage.zip
+
+pushd "${CACHE}"
+#We need the old sources file next to the image because of sources condensation step
+wget http://files.pharo.org/sources/PharoV60.sources
+echo "Prepare icons"
+mkdir icon-packs
+pushd icon-packs
+# update the commit hash as soon as you need a new version of the icons to be loaded
+wget http://github.com/pharo-project/pharo-icon-packs/archive/57fba57a02ef3b96c453fb9feba7b71c6a3e618e.zip -O idea11.zip
+popd
+popd
+
+
+# Downloads a SPUR vm for the configured architecture
+mkdir vmtarget
+pushd vmtarget
+if [ ${BOOTSTRAP_ARCH} = "64" ]; then
+	ARCHFLAG=64/
+fi
+wget -O- get.pharo.org/${ARCHFLAG}vm70 | bash
+popd
+

--- a/bootstrap/scripts/3-prepare.sh
+++ b/bootstrap/scripts/3-prepare.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Prepare the image used for bootstrapping
+#
+set -x
+set -e
+
+source bootstrap/scripts/envvars.sh
+
+./pharo Pharo.image ${REPOSITORY}/bootstrap/scripts/prepare_image.st --save --quit
+./pharo Pharo.image ${REPOSITORY}/bootstrap/scripts/bootstrap.st --ARCH=${BOOTSTRAP_ARCH} --BUILD_NUMBER=${BUILD_NUMBER} --quit
+

--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+#
+# Bootstrap the new image
+#
+set -x
+set -e
+
+source bootstrap/scripts/envvars.sh
+
+
+# A POSIX variable
+OPTIND=1         # Reset in case getopts has been used previously in the shell.
+
+function show_help {
+  echo
+  "Pharo Build Script
+  ==================
+  This script assumes the existence of a new uninitialized image. Then it proceeds to its initialization and \"growing\".
+  * Step 1:
+    - Initialize the image
+    - output: core.image
+  * Step 2:
+    - Bootstrap Monticello local repositories
+    - output: monticello_bootstrap.image and changes file
+  * Step 3:
+    - Load Monticello remote repositories
+    - output: monticello.image and changes file
+  * Step 4:
+    - Load Metacello
+    - output: metacello.image and changes file
+  * Step 5:
+    - Load the rest of the image using BaselineOfIDE
+    - output: Pharo.image and changes file
+
+  Script arguments
+  ================
+  -a
+    Architecture of the image. Indicates wether the image will be a 32 bit or 64 bit artifact.
+    Expected values: 32, 64
+  -h -?
+    Prints this help message
+  "
+  exit 0
+}
+
+# Initialize our own variables:
+ARCH_DESCRIPTION=${BOOTSTRAP_ARCH}
+
+# Use -gt 1 to consume two arguments per pass in the loop (e.g. each
+# argument has a corresponding value to go with it).
+# Use -gt 0 to consume one or more arguments per pass in the loop (e.g.
+# some arguments don't have a corresponding value to go with it such
+# as in the --default example).
+# note: if this is set to -gt 0 the /etc/hosts part is not recognized ( may be a bug )
+while getopts "h?a:d" opt; do
+    case "${opt}" in
+    a)
+        if [[ "${OPTARG}" -ne "32"  &&  "${OPTARG}" -ne "64" ]]; then
+          echo "Invalid Option ${OPTARG}: expected architecture values are 32 or 64";
+          exit 1;
+        fi
+        ARCH_DESCRIPTION=${OPTARG};
+        ;;
+    d)
+        DESCRIBE=1;
+        ;;
+    h|\?)
+        show_help;
+        exit 0;
+        ;;
+  esac
+done
+
+shift $((OPTIND-1))
+[ "$1" = "--" ] && shift
+
+if [ -z "${ARCH_DESCRIPTION}" ]; then
+  echo "No architecture specified. Please set the BOOTSTRAP_ARCH environment variable or use the -a argument";
+  exit 1;
+fi
+
+# Script directory
+__this_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PREFIX=Pharo7.0
+
+if [[ -z "${BOOTSTRAP_REPOSITORY}" ]]; then
+  GIT_COMMIT_HASH=$(git show -s --format=%h)
+else
+  GIT_COMMIT_HASH=$(git -C ${REPOSITORY} show -s --format=%h)
+fi
+
+SUFFIX=${ARCH_DESCRIPTION}bit-${GIT_COMMIT_HASH}
+
+if [[ ${DESCRIBE} -eq "1" ]]; then
+  echo "${SUFFIX}"
+  exit 0
+fi
+
+BOOTSTRAP_IMAGE_NAME=bootstrap
+BOOTSTRAP_ARCHIVE_IMAGE_NAME=${PREFIX}-bootstrap-${SUFFIX}
+
+HERMES_ARCHIVE_NAME=${PREFIX}-hermesPackages-${SUFFIX}
+RPACKAGE_ARCHIVE_NAME=${PREFIX}-rpackage-${SUFFIX}
+
+CORE_IMAGE_NAME=${PREFIX}-core-${SUFFIX}
+COMPILER_IMAGE_NAME=${PREFIX}-compiler-${SUFFIX}
+TRAITS_IMAGE_NAME=${PREFIX}-traits-${SUFFIX}
+MC_BOOTSTRAP_IMAGE_NAME=${PREFIX}-monticello_bootstrap-${SUFFIX}
+MC_IMAGE_NAME=${PREFIX}-monticello-${SUFFIX}
+METACELLO_IMAGE_NAME=${PREFIX}-metacello-${SUFFIX}
+PHARO_IMAGE_NAME=${PREFIX}-${SUFFIX}
+
+#Get inside the bootstrap-cache folder. Pharo interprets relatives as relatives to the image and not the 'working directory'
+cd "${CACHE}"
+
+
+#Prepare
+echo "Prepare Bootstrap files"
+cp "${BOOTSTRAP_IMAGE_NAME}.image" "${COMPILER_IMAGE_NAME}.image"
+
+# Archive bootstrap image
+cp "${BOOTSTRAP_IMAGE_NAME}.image" "${BOOTSTRAP_ARCHIVE_IMAGE_NAME}.image"
+zip "${BOOTSTRAP_ARCHIVE_IMAGE_NAME}.zip" "${BOOTSTRAP_ARCHIVE_IMAGE_NAME}.image"
+
+# Archive binary Hermes packages
+zip "${HERMES_ARCHIVE_NAME}.zip" *.hermes
+
+# Archive RPackage definitions
+zip "${RPACKAGE_ARCHIVE_NAME}.zip" protocolsKernel.txt packagesKernel.txt
+
+# Find st-cache path
+[[ -z "${BOOTSTRAP_CACHE}" ]] && ST_CACHE='st-cache' || ST_CACHE="${BOOTSTRAP_CACHE}/st-cache"
+
+# Installing RPackage
+echo "[Compiler] Initializing Bootstraped Image"
+${VM} "${COMPILER_IMAGE_NAME}.image" # I have to run once the image so the next time it starts the CommandLineHandler.
+
+echo "[Compiler] Adding more Kernel packages"
+${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Hermes-Extensions.hermes --save
+${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Math-Operations-Extensions.hermes Debugging-Core.hermes Kernel-Chronology-Extras.hermes Multilingual-Encodings.hermes Multilingual-TextConversion.hermes Multilingual-Languages.hermes --save --no-fail-on-undeclared
+
+${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes InitializePackagesCommandLineHandler.hermes --save
+
+${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Collections-Atomic.hermes AST-Core.hermes Collections-Arithmetic.hermes Jobs.hermes --save --no-fail-on-undeclared
+
+echo "[Compiler] Initializing the packages in the Kernel"
+${VM} "${COMPILER_IMAGE_NAME}.image" initializePackages --protocols=protocolsKernel.txt --packages=packagesKernel.txt --save
+
+# Installing compiler through Hermes 
+echo "[Compiler] Installing compiler through Hermes"
+${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes OpalCompiler-Core.hermes CodeExport.hermes CodeImport.hermes CodeImportCommandLineHandlers.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" eval --save "CompilationContext initialize. OCASTTranslator initialize." 
+${VM} "${COMPILER_IMAGE_NAME}.image" st ${REPOSITORY}/bootstrap/scripts/01-initialization/01-init.st --no-source --save --quit
+
+echo "[Compiler] Initializing Unicode"
+${VM} "${COMPILER_IMAGE_NAME}.image" st ${REPOSITORY}/bootstrap/scripts/01-initialization/03-initUnicode.st --no-source --save --quit "${REPOSITORY}/resources/unicode/"
+
+${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes DeprecatedFileStream.hermes FileSystem-Core.hermes FileSystem-Disk.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" eval --save "PharoBootstrapInitialization initializeFileSystem"
+${VM} "${COMPILER_IMAGE_NAME}.image" eval --save "SourceFileArray initialize"
+zip "${COMPILER_IMAGE_NAME}.zip" "${COMPILER_IMAGE_NAME}.image"
+
+# Installing Traits through Hermes 
+echo "[Compiler] Installing Traits through Hermes"
+
+${VM} "${COMPILER_IMAGE_NAME}.image" save ${TRAITS_IMAGE_NAME}
+${VM} "${TRAITS_IMAGE_NAME}.image" loadHermes TraitsV2.hermes --save
+${VM} "${TRAITS_IMAGE_NAME}.image" loadHermes Kernel-Traits.hermes AST-Core-Traits.hermes Collections-Abstract-Traits.hermes Transcript-Core-Traits.hermes SUnit-Core-Traits.hermes CodeImport-Traits.hermes RPackage-Traits.hermes OpalCompiler-Traits.hermes Slot-Traits.hermes CodeExport-Traits.hermes System-Sources-Traits.hermes System-Support-Traits.hermes TraitsV2-Compatibility.hermes --save
+zip "${TRAITS_IMAGE_NAME}.zip" "${TRAITS_IMAGE_NAME}.image"
+
+#Bootstrap Initialization: Class and RPackage initialization
+echo "[Core] Class and RPackage initialization"
+${VM} "${TRAITS_IMAGE_NAME}.image" save ${CORE_IMAGE_NAME}
+zip "${CORE_IMAGE_NAME}.zip" "${CORE_IMAGE_NAME}.image"
+
+#Bootstrap Monticello Part 1: Core and Local repositories
+echo "[Monticello] Bootstrap Monticello Core and Local repositories"
+
+${VM} "${CORE_IMAGE_NAME}.image" save ${MC_BOOTSTRAP_IMAGE_NAME}
+#cp "${CORE_IMAGE_NAME}.image" "${MC_BOOTSTRAP_IMAGE_NAME}.image"
+${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" st ${ST_CACHE}/Monticello.st --save --quit
+${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" st ${REPOSITORY}/bootstrap/scripts/02-monticello-bootstrap/01-fixLocalMonticello.st --save --quit
+${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" st ${REPOSITORY}/bootstrap/scripts/02-monticello-bootstrap/02-bootstrapMonticello.st --save --quit
+${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" eval --save "TraitsBootstrap fixSourceCodeOfTraits "
+zip "${MC_BOOTSTRAP_IMAGE_NAME}.zip" ${MC_BOOTSTRAP_IMAGE_NAME}.*
+
+#Bootstrap Monticello Part 2: Networking Packages and Remote Repositories
+echo "[Monticello] Loading Networking Packages and Remote Repositories"
+${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" save $MC_IMAGE_NAME
+${VM} "${MC_IMAGE_NAME}.image" st ${REPOSITORY}/bootstrap/scripts/02-monticello-bootstrap/03-bootstrapMonticelloRemote.st --save --quit
+zip "${MC_IMAGE_NAME}.zip" ${MC_IMAGE_NAME}.*
+
+#Bootstrap Metacello
+echo "[Metacello] Bootstrapping Metacello"
+${VM} "${MC_IMAGE_NAME}.image" save ${METACELLO_IMAGE_NAME}
+${VM} "${METACELLO_IMAGE_NAME}.image" st ${REPOSITORY}/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st --save --quit
+zip "${METACELLO_IMAGE_NAME}.zip" ${METACELLO_IMAGE_NAME}.*
+
+echo "[Pharo] Reloading rest of packages"
+${VM} "${METACELLO_IMAGE_NAME}.image" save "${PHARO_IMAGE_NAME}"
+
+# fix the display size in the image header (position 40 [zero based], 24 for 32-bit image)
+# in older versions we must use octal representation
+printf "\231\002\320\003" > displaySize.bin
+if [[ ${ARCH_DESCRIPTION} -eq "32" ]]; then
+  SEEK=24
+else
+  SEEK=40
+fi
+dd if="displaySize.bin" of="${PHARO_IMAGE_NAME}.image" bs=1 seek=$SEEK count=4 conv=notrunc
+
+#Terrible HACK!!!! 
+#I am increasing the size of the eden space.
+#This allows to load the big baselines.
+#However, this is only needed because the VM has a bug when extending the space itself. It is corrupting the objects, this produces random crashes
+${VM} "${PHARO_IMAGE_NAME}.image" eval --save "Smalltalk vm parameterAt: 45 put: (Smalltalk vm parameterAt: 44) * 4"
+
+env 2>&1 > env.log
+
+${VM} "${PHARO_IMAGE_NAME}.image" eval --save "Metacello new baseline: 'Tonel';repository: 'github://pharo-vcs/tonel:v1.0.5';onWarning: [ :e | Error signal: e messageText in: e signalerContext ]; load: 'core'"
+${VM} "${PHARO_IMAGE_NAME}.image" eval --save "Metacello new baseline: 'IDE';repository: 'tonel://${REPOSITORY}/src';onWarning: [ :e | Error signal: e messageText in: e signalerContext ]; load"
+${VM} "${PHARO_IMAGE_NAME}.image" eval --save "FFIMethodRegistry resetAll. PharoSourcesCondenser condenseNewSources. Smalltalk garbageCollect"
+${VM} "${PHARO_IMAGE_NAME}.image" clean --release
+
+echo "[Pharo] Configure resulting image"
+${VM} "${PHARO_IMAGE_NAME}.image" st ${REPOSITORY}/bootstrap/scripts/04-configure-resulting-image/fixPackageVersions.st --save --quit
+
+${VM} "${PHARO_IMAGE_NAME}.image" save "Pharo"
+
+# clean bak sources files
+rm -f *.bak
+
+zip "${PHARO_IMAGE_NAME}.zip" ${PHARO_IMAGE_NAME}.*

--- a/bootstrap/scripts/bootstrap.sh
+++ b/bootstrap/scripts/bootstrap.sh
@@ -1,15 +1,47 @@
+#!/bin/bash
+#
+# Perform the entire bootstrap process.
+#
+# For a list of required and optional input environment variables
+# please see envvars.sh
+#
+# The current working directory must be the pharo project git
+# root directory
+#
+# The goal of breaking the process in to the 4 stages below is to facilitate
+# manual development, e.g. when testing a new VM:
+#
+# 1. bootstrap/scripts/1-clean.sh
+# 2. bootstrap/scripts/2-download.sh
+# 3. Replace default target VM with dev version
+# 4. bootstrap/scripts/3-prepare.sh
+# 5. bootstrap/scripts/backup.sh
+# 6. bootstrap/scripts/4-build.sh
+# 7. on error:
+#       bootstrap/scripts/restore.sh
+#       goto 6
+#
 set -x
 set -e
 
-wget -O - get.pharo.org/vm61 | bash
-wget https://github.com/guillep/PharoBootstrap/releases/download/v1.4/bootstrapImage.zip
-unzip bootstrapImage.zip
+source bootstrap/scripts/envvars.sh
 
-CACHE="${BOOTSTRAP_CACHE:-bootstrap-cache}"
-REPOSITORY="${BOOTSTRAP_REPOSITORY:-.}"
+SCRIPTS=${REPOSITORY}/bootstrap/scripts
 
-./pharo Pharo.image ${REPOSITORY}/bootstrap/scripts/prepare_image.st --save --quit
-mkdir -p "${CACHE}" #required to generate hermes files
-./pharo Pharo.image eval "PBBootstrap fromCommandLine bootstrap" --quit
+#
+# Remove any artifacts from previous runs
+#
+${SCRIPTS}/1-clean.sh
+#
+# Fetch all prerequisites
+#
+${SCRIPTS}/2-download.sh
+#
+# Prepare the bootstrap environment
+#
+${SCRIPTS}/3-prepare.sh
+#
+# Build the new image
+#
+${SCRIPTS}/4-build.sh
 
-bash ${REPOSITORY}/bootstrap/scripts/build.sh

--- a/bootstrap/scripts/envvars.sh
+++ b/bootstrap/scripts/envvars.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Set up environment variables used by the various
+# bootstrap stages
+#
+# Required Input environment variables:
+#
+# - BUILD_NUMBER
+# - BOOTSTRAP_ARCH
+#
+# Optional input environment variables:
+#
+# - BOOTSTRAP_CACHE
+# - BOOTSTRAP_REPOSITORY
+#
+if [ -z "${BUILD_NUMBER}" ]
+then
+    echo "BUILD_NUMBER not specified, exiting"
+    exit 1
+fi
+
+if [ -z "${BOOTSTRAP_ARCH}" ]
+then
+    echo "BOOTSTRAP_ARCH not specified, existing"
+    exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+CACHE="${BOOTSTRAP_CACHE:-${ROOT_DIR}/bootstrap-cache}"
+REPOSITORY="${BOOTSTRAP_REPOSITORY:-${ROOT_DIR}}"
+# Ensure that BOOTSTRAP_REPOSITORY is propagated
+export BOOTSTRAP_REPOSITORY="${REPOSITORY}"
+# This is the VM used to bootstrap, i.e. the target VM
+VM="${REPOSITORY}/vmtarget/pharo --headless"

--- a/bootstrap/scripts/restore.sh
+++ b/bootstrap/scripts/restore.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Restore the bootstrap snapshot.
+#
+# Only works if bootstrap-cache is in the default location
+#
+set -x
+set -e
+
+source bootstrap/scripts/envvars.sh
+
+pushd "${REPOSITORY}"
+bootstrap/scripts/1-clean.sh
+tar xzf "${REPOSITORY}/snapshot.tar.gz"
+popd

--- a/bootstrap/scripts/snapshot.sh
+++ b/bootstrap/scripts/snapshot.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Make a snapshot of the current bootstrap state.
+#
+# Only works if bootstrap-cache is in the default location
+#
+# The snapshot can then be restored with restore.sh
+#
+set -x
+set -e
+
+source bootstrap/scripts/envvars.sh
+
+pushd "${REPOSITORY}"
+tar czf "${REPOSITORY}/snapshot.tar.gz" Pharo.image Pharo.changes pharo pharo-ui pharo-vm pharo-local vmtarget bootstrap-cache
+popd


### PR DESCRIPTION
The current bootstrap process has scope for improvement :-):

- Downloads occur at various stages during the process, which makes it
  difficult to test new code in a personal environment, e.g. choosing a
  specific VM to bootstrap with.
- Code is duplicated in Jenkinsfile and the various shell scripts
- It isn't easy to snapshot the process and resume bootstrapping from
  that point (related to the first item).

The proposed patch is a first step that will restructure the shell
scripts in to the following phases:

1. Clean up (remove any artefacts from previous runs)
2. Download all required files
3. Prepare the image for bootstrap
4. Build the new image

This work is intended to complement the existing effort by Pablo and
others to move more of the code from shell scripts to Pharo.

A second PR will refactor Jenkinsfile to call the new scripts, removing
the code duplication.

Fogbugz: https://pharo.fogbugz.com/f/cases/21615/Separate-bootstrap-process-in-to-distinct-stages