### PR TITLE
21619-Integrate-new-Calypso-version-0110

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -902,25 +902,10 @@ BaselineOfIDE >> loadCalypso [
 
 	"Load Calypso without Iceberg Metacello integration"
 	(self class environment at: #Iceberg) enableMetacelloIntegration: false.
-
-	Metacello new
-		baseline: 'ClassAnnotation';
-		repository: 'github://dionisiydk/ClassAnnotation:v0.3.1';
-		load.
 		
 	Metacello new
-		baseline: 'Commander';
-		repository: 'github://dionisiydk/Commander:v0.5.3';
-		load: #(default #'Commander-SpecSupport' #'Commander-Examples').
-	
-	Metacello new
-		baseline: 'SystemCommands';
-		repository: 'github://dionisiydk/SystemCommands:v0.7.1';
-		load.
-			
-	Metacello new
 		baseline: 'Calypso';
-		repository: 'github://dionisiydk/Calypso:v0.10.3';
+		repository: 'github://dionisiydk/Calypso:v0.11.0';
 		load: #('FullEnvironment' 'SystemBrowser' 'Tests').
 
 	(self class environment at: #ClyBrowser) beAllDefault.


### PR DESCRIPTION
Now simple script to load Calypso: static version points to static versions of dependencies