### PR TITLE
21617-Better-implementation-of-package-comments

### DIFF
--- a/src/AST-Core/ManifestASTCore.class.st
+++ b/src/AST-Core/ManifestASTCore.class.st
@@ -1,6 +1,3 @@
-"
-I stores metadata on true and false positive critics. These meta data are used by the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestASTCore,
 	#superclass : #PackageManifest,

--- a/src/Announcements-Core/ManifestAnnouncementsCore.class.st
+++ b/src/Announcements-Core/ManifestAnnouncementsCore.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestAnnouncementsCore,
 	#superclass : #PackageManifest,

--- a/src/CodeExport-Traits/ManifestCodeExportTraits.class.st
+++ b/src/CodeExport-Traits/ManifestCodeExportTraits.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestCodeExportTraits,
 	#superclass : #PackageManifest,

--- a/src/CodeExport/ManifestCodeExport.class.st
+++ b/src/CodeExport/ManifestCodeExport.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestCodeExport,
 	#superclass : #PackageManifest,

--- a/src/CodeImport/ManifestCodeImport.class.st
+++ b/src/CodeImport/ManifestCodeImport.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestCodeImport,
 	#superclass : #PackageManifest,

--- a/src/CodeImportCommandLineHandlers/ManifestCodeImportCommandLineHandlers.class.st
+++ b/src/CodeImportCommandLineHandlers/ManifestCodeImportCommandLineHandlers.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestCodeImportCommandLineHandlers,
 	#superclass : #PackageManifest,

--- a/src/Collections-Abstract/ManifestCollectionsAbstract.class.st
+++ b/src/Collections-Abstract/ManifestCollectionsAbstract.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestCollectionsAbstract,
 	#superclass : #PackageManifest,

--- a/src/Collections-Arithmetic/ManifestCollectionsArithmetic.class.st
+++ b/src/Collections-Arithmetic/ManifestCollectionsArithmetic.class.st
@@ -1,5 +1,6 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+This package only makes extensions to existing collection classes by adding the arithmetic protocols. 
+Such protocols allow one to perform in particular vector-operations on collection
 "
 Class {
 	#name : #ManifestCollectionsArithmetic,
@@ -10,12 +11,6 @@ Class {
 { #category : #'meta-data' }
 ManifestCollectionsArithmetic class >> dependencies [
 	^ #(#'Collections-Native' #'Collections-Unordered' #'Collections-Sequenceable' #Kernel #'Collections-Abstract')
-]
-
-{ #category : #'meta-data' }
-ManifestCollectionsArithmetic class >> description [
-	^ 'This package only makes extensions to existing collection classes by adding the arithmetic protocols. 
-Such protocols allow one to perform in particular vector-operations on collection'
 ]
 
 { #category : #'meta-data' }

--- a/src/Collections-Atomic/ManifestCollectionsAtomic.class.st
+++ b/src/Collections-Atomic/ManifestCollectionsAtomic.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestCollectionsAtomic,
 	#superclass : #PackageManifest,

--- a/src/Collections-Native/ManifestCollectionsNative.class.st
+++ b/src/Collections-Native/ManifestCollectionsNative.class.st
@@ -1,5 +1,5 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+Arrays of native types: byte, word, float and integer
 "
 Class {
 	#name : #ManifestCollectionsNative,
@@ -10,11 +10,6 @@ Class {
 { #category : #'meta-data' }
 ManifestCollectionsNative class >> dependencies [
 	^ #(#'Collections-Abstract' #Kernel #'Collections-Strings')
-]
-
-{ #category : #'meta-data' }
-ManifestCollectionsNative class >> description [
-	^ 'Arrays of native types: byte, word, float and integer'
 ]
 
 { #category : #'meta-data - dependency analyser' }

--- a/src/Collections-Sequenceable/ManifestCollectionsSequenceable.class.st
+++ b/src/Collections-Sequenceable/ManifestCollectionsSequenceable.class.st
@@ -1,5 +1,5 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+Sequenceable collections: arrays, intervals, ordered collections and dictionaries, etc.
 "
 Class {
 	#name : #ManifestCollectionsSequenceable,
@@ -10,11 +10,6 @@ Class {
 { #category : #'meta-data' }
 ManifestCollectionsSequenceable class >> dependencies [
 	^ #(#'Collections-Strings' #'Collections-Streams' #'Collections-Unordered' #Kernel #'Collections-Abstract')
-]
-
-{ #category : #'meta-data' }
-ManifestCollectionsSequenceable class >> description [
-	^ 'Sequenceable collections: arrays, intervals, ordered collections and dictionaries, etc.'
 ]
 
 { #category : #'meta-data - dependency analyser' }

--- a/src/Collections-Stack/ManifestCollectionsStack.class.st
+++ b/src/Collections-Stack/ManifestCollectionsStack.class.st
@@ -1,5 +1,5 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+I only contain a Stack implementation.
 "
 Class {
 	#name : #ManifestCollectionsStack,
@@ -10,11 +10,6 @@ Class {
 { #category : #'meta-data' }
 ManifestCollectionsStack class >> dependencies [
 	^ #(#'Collections-Sequenceable')
-]
-
-{ #category : #'meta-data' }
-ManifestCollectionsStack class >> description [
-	^ 'I only contain a Stack implementation.'
 ]
 
 { #category : #'meta-data' }

--- a/src/Collections-Streams/ManifestCollectionsStreams.class.st
+++ b/src/Collections-Streams/ManifestCollectionsStreams.class.st
@@ -1,5 +1,5 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+All Stream hierarchy: read/write stream
 "
 Class {
 	#name : #ManifestCollectionsStreams,
@@ -10,11 +10,6 @@ Class {
 { #category : #'meta-data' }
 ManifestCollectionsStreams class >> dependencies [
 	^ #(#'Collections-Strings' #'Multilingual-TextConversion' #'Collections-Support' #'Collections-Sequenceable' #Kernel #'Collections-Native')
-]
-
-{ #category : #'meta-data' }
-ManifestCollectionsStreams class >> description [
-	^ 'All Stream hierarchy: read/write stream'
 ]
 
 { #category : #'meta-data - dependency analyser' }

--- a/src/Collections-Strings/ManifestCollectionsStrings.class.st
+++ b/src/Collections-Strings/ManifestCollectionsStrings.class.st
@@ -1,5 +1,5 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+Contains String, ByteString, Symbol, ByteSymbol, WideSymbol and WideString
 "
 Class {
 	#name : #ManifestCollectionsStrings,
@@ -10,11 +10,6 @@ Class {
 { #category : #'meta-data' }
 ManifestCollectionsStrings class >> dependencies [
 	^ #(#'Collections-Streams' #'Collections-Weak' #'Collections-Native' #'Collections-Support' #Kernel #'Collections-Sequenceable' #'Multilingual-Encodings' #'Collections-Abstract')
-]
-
-{ #category : #'meta-data' }
-ManifestCollectionsStrings class >> description [
-	^ 'Contains String, ByteString, Symbol, ByteSymbol, WideSymbol and WideString'
 ]
 
 { #category : #'meta-data - dependency analyser' }

--- a/src/Collections-Support/ManifestCollectionsSupport.class.st
+++ b/src/Collections-Support/ManifestCollectionsSupport.class.st
@@ -1,5 +1,5 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+Some basic classes used in collections: Link, Associtation, Weak*, CharacterSet, SetElement, etc.
 "
 Class {
 	#name : #ManifestCollectionsSupport,
@@ -10,11 +10,6 @@ Class {
 { #category : #'meta-data' }
 ManifestCollectionsSupport class >> dependencies [
 	^ #(#'Collections-Strings' #'Collections-Native' #'Collections-Unordered' #Kernel #'Collections-Abstract')
-]
-
-{ #category : #'meta-data' }
-ManifestCollectionsSupport class >> description [
-	^ 'Some basic classes used in collections: Link, Associtation, Weak*, CharacterSet, SetElement, etc.'
 ]
 
 { #category : #'meta-data - dependency analyser' }

--- a/src/Collections-Tests/ManifestCollectionsTests.class.st
+++ b/src/Collections-Tests/ManifestCollectionsTests.class.st
@@ -1,5 +1,5 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+I contain tests for collections
 "
 Class {
 	#name : #ManifestCollectionsTests,
@@ -10,11 +10,6 @@ Class {
 { #category : #'meta-data' }
 ManifestCollectionsTests class >> dependencies [
 	^ #(#'Collections-Streams' #'System-Finalization' #'Collections-Native' #'Collections-Abstract' #'Collections-Weak' #'Collections-Stack' #'Collections-Strings' #Compiler #'Collections-Sequenceable' #'SUnit-Core' #Kernel #'Graphics-Primitives' #'Collections-Support' #'Collections-Unordered' #'System-Support' #'Collections-Atomic' #'Multilingual-Encodings')
-]
-
-{ #category : #'meta-data' }
-ManifestCollectionsTests class >> description [
-	^ 'I contain tests for collections'
 ]
 
 { #category : #'meta-data - dependency analyser' }

--- a/src/Collections-Unordered/ManifestCollectionsUnordered.class.st
+++ b/src/Collections-Unordered/ManifestCollectionsUnordered.class.st
@@ -1,5 +1,6 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+I contain collections that do not care about the order of the elements they contain.
+Main classes: Bag, Dictionary, Matrix, Set
 "
 Class {
 	#name : #ManifestCollectionsUnordered,
@@ -10,12 +11,6 @@ Class {
 { #category : #'meta-data' }
 ManifestCollectionsUnordered class >> dependencies [
 	^ #(#'Collections-Strings' #'Collections-Support' #Kernel #'Collections-Sequenceable' #'Collections-Abstract')
-]
-
-{ #category : #'meta-data' }
-ManifestCollectionsUnordered class >> description [
-	^ 'I contain collections that do not care about the order of the elements they contain.
-Main classes: Bag, Dictionary, Matrix, Set'
 ]
 
 { #category : #'meta-data - dependency analyser' }

--- a/src/Collections-Weak/ManifestCollectionsWeak.class.st
+++ b/src/Collections-Weak/ManifestCollectionsWeak.class.st
@@ -1,5 +1,5 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+All weak collections
 "
 Class {
 	#name : #ManifestCollectionsWeak,
@@ -10,11 +10,6 @@ Class {
 { #category : #'meta-data' }
 ManifestCollectionsWeak class >> dependencies [
 	^ #(#'System-Finalization' #'Collections-Support' #'Collections-Sequenceable' #'Collections-Unordered' #'Collections-Abstract' #Kernel)
-]
-
-{ #category : #'meta-data' }
-ManifestCollectionsWeak class >> description [
-	^ 'All weak collections'
 ]
 
 { #category : #'meta-data - dependency analyser' }

--- a/src/Colors/ManifestColors.class.st
+++ b/src/Colors/ManifestColors.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestColors,
 	#superclass : #PackageManifest,

--- a/src/Compression/ManifestCompression.class.st
+++ b/src/Compression/ManifestCompression.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestCompression,
 	#superclass : #PackageManifest,

--- a/src/DeprecatedFileStream/ManifestDeprecatedFileStream.class.st
+++ b/src/DeprecatedFileStream/ManifestDeprecatedFileStream.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestDeprecatedFileStream,
 	#superclass : #PackageManifest,

--- a/src/FileSystem-Core/ManifestFileSystemCore.class.st
+++ b/src/FileSystem-Core/ManifestFileSystemCore.class.st
@@ -1,19 +1,15 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+This package contains the core of Pharo's FileSystem manager. 
+
+It offers an expressive and elegant object-oriented design. 
+
+A documentation of this library is available in the Deep Into Pharo book, «Chapter 3: Files with FileSystem».
 "
 Class {
 	#name : #ManifestFileSystemCore,
 	#superclass : #PackageManifest,
 	#category : #'FileSystem-Core'
 }
-
-{ #category : #'meta-data' }
-ManifestFileSystemCore class >> description [ ^ 'This package contains the core of Pharo''s FileSystem manager. 
-
-It offers an expressive and elegant object-oriented design. 
-
-A documentation of this library is available in the Deep Into Pharo book, «Chapter 3: Files with FileSystem».'
-]
 
 { #category : #'meta-data - dependency analyser' }
 ManifestFileSystemCore class >> manuallyResolvedDependencies [

--- a/src/FileSystem-Disk/ManifestFileSystemDisk.class.st
+++ b/src/FileSystem-Disk/ManifestFileSystemDisk.class.st
@@ -1,19 +1,15 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+This package contains the disk management of Pharo's FileSystem manager. 
+
+Its responsibility is to provid a common API for the different OS's disks. 
+
+A documentation of this library is available in the Deep Into Pharo book, «Chapter 3: Files with FileSystem».
 "
 Class {
 	#name : #ManifestFileSystemDisk,
 	#superclass : #PackageManifest,
 	#category : #'FileSystem-Disk'
 }
-
-{ #category : #'meta-data' }
-ManifestFileSystemDisk class >> description [ ^ 'This package contains the disk management of Pharo''s FileSystem manager. 
-
-Its responsibility is to provid a common API for the different OS''s disks. 
-
-A documentation of this library is available in the Deep Into Pharo book, «Chapter 3: Files with FileSystem».'
-]
 
 { #category : #'meta-data - dependency analyser' }
 ManifestFileSystemDisk class >> manuallyResolvedDependencies [

--- a/src/FileSystem-Memory/ManifestFileSystemMemory.class.st
+++ b/src/FileSystem-Memory/ManifestFileSystemMemory.class.st
@@ -1,18 +1,14 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+This package contains a memory file system part of Pharo's FileSystem manager. 
+
+It allow to emulate a file system directly into the memory of the computer. This memory file system can be used during tests for two reasons:
+- To avoid to write temporary files (it will also help when Pharo is stored in a read only environment)
+- To speed up the tests executions
+
+A documentation of this library is available in the Deep Into Pharo book, «Chapter 3: Files with FileSystem».
 "
 Class {
 	#name : #ManifestFileSystemMemory,
 	#superclass : #PackageManifest,
 	#category : #'FileSystem-Memory'
 }
-
-{ #category : #'meta-data' }
-ManifestFileSystemMemory class >> description [ ^ 'This package contains a memory file system part of Pharo''s FileSystem manager. 
-
-It allow to emulate a file system directly into the memory of the computer. This memory file system can be used during tests for two reasons:
-- To avoid to write temporary files (it will also help when Pharo is stored in a read only environment)
-- To speed up the tests executions
-
-A documentation of this library is available in the Deep Into Pharo book, «Chapter 3: Files with FileSystem».'
-]

--- a/src/FileSystem-Path/ManifestFileSystemPath.class.st
+++ b/src/FileSystem-Path/ManifestFileSystemPath.class.st
@@ -1,19 +1,15 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+This package contains the path management of Pharo's FileSystem manager. 
+
+It is responsible for the modelisation of absolute and relative paths in the file system.
+
+A documentation of this library is available in the Deep Into Pharo book, «Chapter 3: Files with FileSystem».
 "
 Class {
 	#name : #ManifestFileSystemPath,
 	#superclass : #PackageManifest,
 	#category : #'FileSystem-Path'
 }
-
-{ #category : #'meta-data' }
-ManifestFileSystemPath class >> description [ ^ 'This package contains the path management of Pharo''s FileSystem manager. 
-
-It is responsible for the modelisation of absolute and relative paths in the file system.
-
-A documentation of this library is available in the Deep Into Pharo book, «Chapter 3: Files with FileSystem».'
-]
 
 { #category : #'meta-data - dependency analyser' }
 ManifestFileSystemPath class >> manuallyResolvedDependencies [

--- a/src/FileSystem-Tests-Core/ManifestFileSystemTestsCore.class.st
+++ b/src/FileSystem-Tests-Core/ManifestFileSystemTestsCore.class.st
@@ -1,14 +1,10 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+This package contains the core tests of Pharo's FileSystem manager. 
+
+A documentation of this library is available in the Deep Into Pharo book, «Chapter 3: Files with FileSystem».
 "
 Class {
 	#name : #ManifestFileSystemTestsCore,
 	#superclass : #PackageManifest,
 	#category : #'FileSystem-Tests-Core'
 }
-
-{ #category : #'meta-data' }
-ManifestFileSystemTestsCore class >> description [ ^ 'This package contains the core tests of Pharo''s FileSystem manager. 
-
-A documentation of this library is available in the Deep Into Pharo book, «Chapter 3: Files with FileSystem».'
-]

--- a/src/FileSystem-Tests-Disk/ManifestFileSystemTestsDisk.class.st
+++ b/src/FileSystem-Tests-Disk/ManifestFileSystemTestsDisk.class.st
@@ -1,14 +1,10 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+This package contains the disk tests of Pharo's FileSystem manager.
+
+A documentation of this library is available in the Deep Into Pharo book, «Chapter 3: Files with FileSystem».
 "
 Class {
 	#name : #ManifestFileSystemTestsDisk,
 	#superclass : #PackageManifest,
 	#category : #'FileSystem-Tests-Disk'
 }
-
-{ #category : #'meta-data' }
-ManifestFileSystemTestsDisk class >> description [ ^ 'This package contains the disk tests of Pharo''s FileSystem manager.
-
-A documentation of this library is available in the Deep Into Pharo book, «Chapter 3: Files with FileSystem».'
-]

--- a/src/FileSystem-Tests-Memory/ManifestFileSystemTestsMemory.class.st
+++ b/src/FileSystem-Tests-Memory/ManifestFileSystemTestsMemory.class.st
@@ -1,14 +1,10 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+This package contains the memory tests of Pharo's FileSystem manager. 
+
+A documentation of this library is available in the Deep Into Pharo book, «Chapter 3: Files with FileSystem».
 "
 Class {
 	#name : #ManifestFileSystemTestsMemory,
 	#superclass : #PackageManifest,
 	#category : #'FileSystem-Tests-Memory'
 }
-
-{ #category : #'meta-data' }
-ManifestFileSystemTestsMemory class >> description [ ^ 'This package contains the memory tests of Pharo''s FileSystem manager. 
-
-A documentation of this library is available in the Deep Into Pharo book, «Chapter 3: Files with FileSystem».'
-]

--- a/src/FileSystem-Zip/ManifestFileSystemZip.class.st
+++ b/src/FileSystem-Zip/ManifestFileSystemZip.class.st
@@ -1,16 +1,12 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+This package contains the zip implementation of Pharo's FileSystem manager. 
+
+It make it possible to look over zip archives.
+
+A documentation of this library is available in the Deep Into Pharo book, «Chapter 3: Files with FileSystem».
 "
 Class {
 	#name : #ManifestFileSystemZip,
 	#superclass : #PackageManifest,
 	#category : #'FileSystem-Zip'
 }
-
-{ #category : #'meta-data' }
-ManifestFileSystemZip class >> description [ ^ 'This package contains the zip implementation of Pharo''s FileSystem manager. 
-
-It make it possible to look over zip archives.
-
-A documentation of this library is available in the Deep Into Pharo book, «Chapter 3: Files with FileSystem».'
-]

--- a/src/Files/ManifestFiles.class.st
+++ b/src/Files/ManifestFiles.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestFiles,
 	#superclass : #PackageManifest,

--- a/src/Fuel/ManifestFuel.class.st
+++ b/src/Fuel/ManifestFuel.class.st
@@ -1,6 +1,3 @@
-"
-Manifest for Fuel package
-"
 Class {
 	#name : #ManifestFuel,
 	#superclass : #PackageManifest,

--- a/src/GT-Debugger/ManifestGTDebugger.class.st
+++ b/src/GT-Debugger/ManifestGTDebugger.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestGTDebugger,
 	#superclass : #PackageManifest,

--- a/src/GT-Spotter/ManifestGTSpotter.class.st
+++ b/src/GT-Spotter/ManifestGTSpotter.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestGTSpotter,
 	#superclass : #PackageManifest,

--- a/src/Graphics-Display Objects/ManifestGraphicsDisplayObjects.class.st
+++ b/src/Graphics-Display Objects/ManifestGraphicsDisplayObjects.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestGraphicsDisplayObjects,
 	#superclass : #PackageManifest,

--- a/src/Graphics-Primitives/ManifestGraphicsPrimitives.class.st
+++ b/src/Graphics-Primitives/ManifestGraphicsPrimitives.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestGraphicsPrimitives,
 	#superclass : #PackageManifest,

--- a/src/IssueTracking-Tests/ManifestIssueTrackingTests.class.st
+++ b/src/IssueTracking-Tests/ManifestIssueTrackingTests.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestIssueTrackingTests,
 	#superclass : #PackageManifest,

--- a/src/IssueTracking/ManifestIssueTracking.class.st
+++ b/src/IssueTracking/ManifestIssueTracking.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestIssueTracking,
 	#superclass : #PackageManifest,

--- a/src/Jobs/ManifestJobs.class.st
+++ b/src/Jobs/ManifestJobs.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestJobs,
 	#superclass : #PackageManifest,

--- a/src/Kernel-Tests/ManifestKernelTests.class.st
+++ b/src/Kernel-Tests/ManifestKernelTests.class.st
@@ -1,5 +1,5 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+I contain tests for the Kernel package.
 "
 Class {
 	#name : #ManifestKernelTests,
@@ -10,11 +10,6 @@ Class {
 { #category : #metadata }
 ManifestKernelTests class >> dependencies [
 	^ #(#'Graphics-Primitives' #'RPackage-Core' #'System-Announcements' #'Morphic-Core' #'Morphic-Base' #'System-Changes' #'Collections-Strings' #'Collections-Unordered' #'Slot-Core' #Jobs #'Collections-Streams' #'FileSystem-Disk' #'System-Support' #'Text-Core' #'Collections-Abstract' #CollectionsTests #'Collections-Support' #'Collections-Sequenceable' #'SUnit-Core' #Tests #'OpalCompiler-Core' #Traits #Kernel #'Collections-Weak' #UIManager)
-]
-
-{ #category : #metadata }
-ManifestKernelTests class >> description [
-	^ 'I contain tests for the Kernel package.'
 ]
 
 { #category : #metadata }

--- a/src/Kernel/ManifestKernel.class.st
+++ b/src/Kernel/ManifestKernel.class.st
@@ -1,5 +1,5 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+Core classes of Pharo Smalltalk including basic objects, types, exceptions, process, etc.
 "
 Class {
 	#name : #ManifestKernel,
@@ -10,11 +10,6 @@ Class {
 { #category : #'meta-data' }
 ManifestKernel class >> dependencies [
 	^ #(#'System-Announcements' #'System-CommandLine' #'Collections-Strings' #'System-Localization' #'Slot-Core' #'Collections-Unordered' #'Collections-Streams' #Files #'System-Object Events' #'Collections-Abstract' #'Collections-Native' #'Collections-Support' #'System-Support' #'Multilingual-Encodings' #'Collections-Sequenceable' #NewValueHolder #'System-Sources' #Compiler #'OpalCompiler-Core' #'System-Finalization' #Traits #'Collections-Weak' #UIManager)
-]
-
-{ #category : #'meta-data' }
-ManifestKernel class >> description [
-	^ 'Core classes of Pharo Smalltalk including basic objects, types, exceptions, process, etc.'
 ]
 
 { #category : #'meta-data - dependency analyser' }

--- a/src/Kernel/PackageManifest.class.st
+++ b/src/Kernel/PackageManifest.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #Kernel
 }
 
+{ #category : #'accessing comment' }
+PackageManifest class >> classCommentBlank [
+
+	^'No description for this package available. Please add a description for this package here'
+]
+
 { #category : #'meta-data' }
 PackageManifest class >> description [
 	^ 'No description for this package manifest available. Please add a description for this package here.'

--- a/src/Manifest-Core/ManifestManifestCore.class.st
+++ b/src/Manifest-Core/ManifestManifestCore.class.st
@@ -1,6 +1,3 @@
-"
-I stores metadata on true and false positive critics. These meta data are used by the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestManifestCore,
 	#superclass : #PackageManifest,

--- a/src/Manifest-Core/RPackage.extension.st
+++ b/src/Manifest-Core/RPackage.extension.st
@@ -15,8 +15,27 @@ RPackage >> manifestBuilderForRuleChecker: aRuleChecker [
 ]
 
 { #category : #'*Manifest-Core' }
+RPackage >> packageComment [
+	^ self packageManifestOrNil ifNil: [ '' ] ifNotNil: [ :manifest | manifest comment ]
+]
+
+{ #category : #'*Manifest-Core' }
+RPackage >> packageComment: aDescription [
+	^ self packageManifest
+		ifNil: [ '' ]
+		ifNotNil: [ :manifest | manifest comment: aDescription stamp: Author changeStamp]
+]
+
+{ #category : #'*Manifest-Core' }
 RPackage >> packageManifest [
 	^ self definedClasses
 		detect: [ :each | each isManifest ]
 		ifNone: [ TheManifestBuilder new createManifestNamed: name]
+]
+
+{ #category : #'*Manifest-Core' }
+RPackage >> packageManifestOrNil [
+	^ self definedClasses
+		detect: [ :each | each isManifest ]
+		ifNone: [ nil ]
 ]

--- a/src/Manifest-Tests/ManifestManifestTests.class.st
+++ b/src/Manifest-Tests/ManifestManifestTests.class.st
@@ -1,6 +1,3 @@
-"
-The manifest for Manifest-Tests package
-"
 Class {
 	#name : #ManifestManifestTests,
 	#superclass : #PackageManifest,

--- a/src/Math-Operations-Extensions/ManifestMathOperationsExtensions.class.st
+++ b/src/Math-Operations-Extensions/ManifestMathOperationsExtensions.class.st
@@ -1,6 +1,3 @@
-"
-I am the manifest of the Numbers-Extensions package
-"
 Class {
 	#name : #ManifestMathOperationsExtensions,
 	#superclass : #PackageManifest,

--- a/src/Monticello-OldDataStreamCompatibility/ManifestMonticelloOldDataStreamCompatibility.class.st
+++ b/src/Monticello-OldDataStreamCompatibility/ManifestMonticelloOldDataStreamCompatibility.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestMonticelloOldDataStreamCompatibility,
 	#superclass : #PackageManifest,

--- a/src/Monticello/MCMczReader.class.st
+++ b/src/Monticello/MCMczReader.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'zip',
 		'infoCache',
-    'filename'
+		'filename'
 	],
 	#category : #'Monticello-Storing'
 }

--- a/src/Monticello/ManifestMonticello.class.st
+++ b/src/Monticello/ManifestMonticello.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestMonticello,
 	#superclass : #PackageManifest,

--- a/src/MonticelloGUI/ManifestMonticelloGUI.class.st
+++ b/src/MonticelloGUI/ManifestMonticelloGUI.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestMonticelloGUI,
 	#superclass : #PackageManifest,

--- a/src/Morphic-Base/ManifestMorphicBase.class.st
+++ b/src/Morphic-Base/ManifestMorphicBase.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestMorphicBase,
 	#superclass : #PackageManifest,

--- a/src/Morphic-Widgets-Pluggable/ManifestMorphicWidgetsPluggable.class.st
+++ b/src/Morphic-Widgets-Pluggable/ManifestMorphicWidgetsPluggable.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestMorphicWidgetsPluggable,
 	#superclass : #PackageManifest,

--- a/src/Multilingual-Encodings/ManifestMultilingualEncodings.class.st
+++ b/src/Multilingual-Encodings/ManifestMultilingualEncodings.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestMultilingualEncodings,
 	#superclass : #PackageManifest,

--- a/src/Multilingual-Languages/ManifestMultilingualLanguages.class.st
+++ b/src/Multilingual-Languages/ManifestMultilingualLanguages.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestMultilingualLanguages,
 	#superclass : #PackageManifest,

--- a/src/Multilingual-TextConversion/ManifestMultilingualTextConversion.class.st
+++ b/src/Multilingual-TextConversion/ManifestMultilingualTextConversion.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestMultilingualTextConversion,
 	#superclass : #PackageManifest,

--- a/src/Multilingual-TextConverterOtherLanguages/ManifestMultilingualTextConverterOtherLanguages.class.st
+++ b/src/Multilingual-TextConverterOtherLanguages/ManifestMultilingualTextConverterOtherLanguages.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestMultilingualTextConverterOtherLanguages,
 	#superclass : #PackageManifest,

--- a/src/Network-UUID/ManifestNetworkUUID.class.st
+++ b/src/Network-UUID/ManifestNetworkUUID.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestNetworkUUID,
 	#superclass : #PackageManifest,

--- a/src/NewValueHolder/ManifestNewValueHolder.class.st
+++ b/src/NewValueHolder/ManifestNewValueHolder.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestNewValueHolder,
 	#superclass : #PackageManifest,

--- a/src/OpalCompiler-Core/ManifestOpalCompilerCore.class.st
+++ b/src/OpalCompiler-Core/ManifestOpalCompilerCore.class.st
@@ -1,6 +1,3 @@
-"
-This is the Manifest for Opal for recording false positive of the code critique tool
-"
 Class {
 	#name : #ManifestOpalCompilerCore,
 	#superclass : #PackageManifest,

--- a/src/OpalCompiler-Tests/ManifestOpalCompilerTests.class.st
+++ b/src/OpalCompiler-Tests/ManifestOpalCompilerTests.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestOpalCompilerTests,
 	#superclass : #PackageManifest,

--- a/src/OpalCompiler-Tests/OCBytecodeDecompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeDecompilerTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'currentCompiler'
 	],
 	#category : #'OpalCompiler-Tests-Bytecode'
-} 
+}
 
 { #category : #examples }
 OCBytecodeDecompilerTest >> pushClosureCopyNoCopied [

--- a/src/OpalCompiler-Traits/ManifestOpalCompilerTraits.class.st
+++ b/src/OpalCompiler-Traits/ManifestOpalCompilerTraits.class.st
@@ -1,6 +1,3 @@
-"
-I store meta-data for a package. I'm the common superclass of all package Manifest.
-"
 Class {
 	#name : #ManifestOpalCompilerTraits,
 	#superclass : #PackageManifest,

--- a/src/PharoBootstrap-Initialization/ManifestPharoBootstrapInitialization.class.st
+++ b/src/PharoBootstrap-Initialization/ManifestPharoBootstrapInitialization.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestPharoBootstrapInitialization,
 	#superclass : #PackageManifest,

--- a/src/PharoDocComment/ManifestPharoDocComment.class.st
+++ b/src/PharoDocComment/ManifestPharoDocComment.class.st
@@ -1,20 +1,11 @@
 "
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
-Class {
-	#name : #ManifestPharoDocComment,
-	#superclass : #PackageManifest,
-	#category : #PharoDocComment
-}
-
-{ #category : #'meta-data' }
-ManifestPharoDocComment class >> description [ ^ 'This package supports the handling (synatx highlighting and first class manipulation of small executable examples inline in method comment. 
+This package supports the handling (synatx highlighting and first class manipulation of small executable examples inline in method comment. 
 
 Assuming the following method is defined
 
 AbstractFileReference >> basename
-            "Returns the basename, i.e. /foo/gloops.taz basename is ''gloops.taz''"
-            "''/foo/gloops.taz'' asFileReference basename >>> ''gloops.taz''"
+            ""Returns the basename, i.e. /foo/gloops.taz basename is 'gloops.taz'""
+            ""'/foo/gloops.taz' asFileReference basename >>> 'gloops.taz'""
             ^ self fullPath basename
 
 The following expression allows one to access to the expression and its expected result. 
@@ -23,9 +14,9 @@ The following expression allows one to access to the expression and its expected
 | doc |
 doc := (AbstractFileReference >> #basename) ast pharoDocCommentNodes
 doc expression 
-> ''/foo/gloops.taz'' asFileReference basename
+> '/foo/gloops.taz' asFileReference basename
 doc result
->  ''gloops.taz''
+>  'gloops.taz'
 ]]]
 
 The code browser will show a little icon with the executed examples.  In that case you will get the original expression, its returned result and the expected result. 
@@ -40,5 +31,10 @@ Implementation Notes
 	it would be nice to address 
 		example expression expressionCode 
 - I renamed expression and result into expressionNode, resultNode. To be able to make the difference between an expression, its expected value and its effective value. 		
-	'
-]
+	
+"
+Class {
+	#name : #ManifestPharoDocComment,
+	#superclass : #PackageManifest,
+	#category : #PharoDocComment
+}

--- a/src/QualityAssistantRecording/ManifestQualityAssistantRecording.class.st
+++ b/src/QualityAssistantRecording/ManifestQualityAssistantRecording.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestQualityAssistantRecording,
 	#superclass : #PackageManifest,

--- a/src/RPackage-Core/ManifestRPackageCore.class.st
+++ b/src/RPackage-Core/ManifestRPackageCore.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestRPackageCore,
 	#superclass : #PackageManifest,

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1158,25 +1158,6 @@ RPackage >> overrideCategoriesForClass: aClass do: aBlock [
 ]
 
 { #category : #accessing }
-RPackage >> packageComment [
-	^ self packageManifestOrNil ifNil: [ '' ] ifNotNil: [ :manifest | manifest description ]
-]
-
-{ #category : #accessing }
-RPackage >> packageComment: aDescription [
-	^ self packageManifest classSide
-		ifNil: [ '' ]
-		ifNotNil: [ :manifest | manifest compile: 'description ^ ' , aDescription classified: 'meta-data' ]
-]
-
-{ #category : #accessing }
-RPackage >> packageManifestOrNil [
-	^ self definedClasses
-		detect: [ :each | each isManifest ]
-		ifNone: [ nil ]
-]
-
-{ #category : #accessing }
 RPackage >> packageName [
 
 	^ name

--- a/src/RPackage-Traits/ManifestRPackageTraits.class.st
+++ b/src/RPackage-Traits/ManifestRPackageTraits.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestRPackageTraits,
 	#superclass : #PackageManifest,

--- a/src/Random-Core/ManifestRandomCore.class.st
+++ b/src/Random-Core/ManifestRandomCore.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestRandomCore,
 	#superclass : #PackageManifest,

--- a/src/Reflectivity/ManifestReflectivity.class.st
+++ b/src/Reflectivity/ManifestReflectivity.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestReflectivity,
 	#superclass : #PackageManifest,

--- a/src/Regex-Core/ManifestRegexCore.class.st
+++ b/src/Regex-Core/ManifestRegexCore.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestRegexCore,
 	#superclass : #PackageManifest,

--- a/src/Renraku/ManifestRenraku.class.st
+++ b/src/Renraku/ManifestRenraku.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestRenraku,
 	#superclass : #PackageManifest,

--- a/src/Ring-Core-Containers/ManifestRingCoreContainers.class.st
+++ b/src/Ring-Core-Containers/ManifestRingCoreContainers.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestRingCoreContainers,
 	#superclass : #PackageManifest,

--- a/src/Ring-Core-Kernel/ManifestRingCoreKernel.class.st
+++ b/src/Ring-Core-Kernel/ManifestRingCoreKernel.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestRingCoreKernel,
 	#superclass : #PackageManifest,

--- a/src/Ring-Monticello/ManifestRingMonticello.class.st
+++ b/src/Ring-Monticello/ManifestRingMonticello.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestRingMonticello,
 	#superclass : #PackageManifest,

--- a/src/RingChunkImporter/ManifestRingChunkImporter.class.st
+++ b/src/RingChunkImporter/ManifestRingChunkImporter.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestRingChunkImporter,
 	#superclass : #PackageManifest,

--- a/src/SUnit-Core/ManifestSUnitCore.class.st
+++ b/src/SUnit-Core/ManifestSUnitCore.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSUnitCore,
 	#superclass : #PackageManifest,

--- a/src/Shift-ClassInstaller/ManifestShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ManifestShiftClassInstaller.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestShiftClassInstaller,
 	#superclass : #PackageManifest,

--- a/src/Slot-Core/ManifestSlot.class.st
+++ b/src/Slot-Core/ManifestSlot.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSlot,
 	#superclass : #PackageManifest,

--- a/src/Slot-Traits/ManifestSlotTraits.class.st
+++ b/src/Slot-Traits/ManifestSlotTraits.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSlotTraits,
 	#superclass : #PackageManifest,

--- a/src/Spec-Core/ManifestSpecCore.class.st
+++ b/src/Spec-Core/ManifestSpecCore.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSpecCore,
 	#superclass : #PackageManifest,

--- a/src/Spec-Help/ManifestSpecHelp.class.st
+++ b/src/Spec-Help/ManifestSpecHelp.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSpecHelp,
 	#superclass : #PackageManifest,

--- a/src/Spec-Inspector/ManifestSpecInspector.class.st
+++ b/src/Spec-Inspector/ManifestSpecInspector.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSpecInspector,
 	#superclass : #PackageManifest,

--- a/src/Spec-Layout/ManifestSpecLayout.class.st
+++ b/src/Spec-Layout/ManifestSpecLayout.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSpecLayout,
 	#superclass : #PackageManifest,

--- a/src/Spec-MorphicAdapters/ManifestSpecMorphicAdapters.class.st
+++ b/src/Spec-MorphicAdapters/ManifestSpecMorphicAdapters.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSpecMorphicAdapters,
 	#superclass : #PackageManifest,

--- a/src/Spec-Tests/ManifestSpecTests.class.st
+++ b/src/Spec-Tests/ManifestSpecTests.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSpecTests,
 	#superclass : #PackageManifest,

--- a/src/Spec-Tools/ManifestSpecTools.class.st
+++ b/src/Spec-Tools/ManifestSpecTools.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSpecTools,
 	#superclass : #PackageManifest,

--- a/src/System-Announcements/ManifestSystemAnnouncements.class.st
+++ b/src/System-Announcements/ManifestSystemAnnouncements.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemAnnouncements,
 	#superclass : #PackageManifest,

--- a/src/System-BasicCommandLineHandler/ManifestSystemBasicCommandLineHandler.class.st
+++ b/src/System-BasicCommandLineHandler/ManifestSystemBasicCommandLineHandler.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemBasicCommandLineHandler,
 	#superclass : #PackageManifest,

--- a/src/System-Changes/ManifestSystemChanges.class.st
+++ b/src/System-Changes/ManifestSystemChanges.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemChanges,
 	#superclass : #PackageManifest,

--- a/src/System-CommandLine/ManifestSystemCommandLine.class.st
+++ b/src/System-CommandLine/ManifestSystemCommandLine.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemCommandLine,
 	#superclass : #PackageManifest,

--- a/src/System-CommandLineHandler/ManifestSystemCommandLineHandler.class.st
+++ b/src/System-CommandLineHandler/ManifestSystemCommandLineHandler.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemCommandLineHandler,
 	#superclass : #PackageManifest,

--- a/src/System-FileRegistry/FileServices.class.st
+++ b/src/System-FileRegistry/FileServices.class.st
@@ -9,7 +9,7 @@ MyClass class>>fileReaderServicesForFile: fullName suffix: suffix
 	^ (FileStream isSourceFileSuffix: suffix)
 		ifTrue: [ { self mySimpleServiceEntry1 . self mySimpleServiceEntry2 }]
 		ifFalse: [#()]
-" 
+"
 Class {
 	#name : #FileServices,
 	#superclass : #Object,

--- a/src/System-FileRegistry/ManifestSystemFileRegistry.class.st
+++ b/src/System-FileRegistry/ManifestSystemFileRegistry.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemFileRegistry,
 	#superclass : #PackageManifest,

--- a/src/System-Finalization/ManifestSystemFinalization.class.st
+++ b/src/System-Finalization/ManifestSystemFinalization.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemFinalization,
 	#superclass : #PackageManifest,

--- a/src/System-Hashing/ManifestSystemHashing.class.st
+++ b/src/System-Hashing/ManifestSystemHashing.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemHashing,
 	#superclass : #PackageManifest,

--- a/src/System-Localization/ManifestSystemLocalization.class.st
+++ b/src/System-Localization/ManifestSystemLocalization.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemLocalization,
 	#superclass : #PackageManifest,

--- a/src/System-Model/ManifestSystemModel.class.st
+++ b/src/System-Model/ManifestSystemModel.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemModel,
 	#superclass : #PackageManifest,

--- a/src/System-Object Events/ManifestSystemObjectEvents.class.st
+++ b/src/System-Object Events/ManifestSystemObjectEvents.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemObjectEvents,
 	#superclass : #PackageManifest,

--- a/src/System-Platforms/ManifestSystemPlatforms.class.st
+++ b/src/System-Platforms/ManifestSystemPlatforms.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemPlatforms,
 	#superclass : #PackageManifest,

--- a/src/System-SessionManager/ManifestSystemSessionManager.class.st
+++ b/src/System-SessionManager/ManifestSystemSessionManager.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemSessionManager,
 	#superclass : #PackageManifest,

--- a/src/System-Sources-Traits/ManifestSystemSourcesTraits.class.st
+++ b/src/System-Sources-Traits/ManifestSystemSourcesTraits.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemSourcesTraits,
 	#superclass : #PackageManifest,

--- a/src/System-Sources/ManifestSystemSources.class.st
+++ b/src/System-Sources/ManifestSystemSources.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemSources,
 	#superclass : #PackageManifest,

--- a/src/System-Support-Traits/ManifestSystemSupportTraits.class.st
+++ b/src/System-Support-Traits/ManifestSystemSupportTraits.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemSupportTraits,
 	#superclass : #PackageManifest,

--- a/src/System-Support/ManifestSystemSupport.class.st
+++ b/src/System-Support/ManifestSystemSupport.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemSupport,
 	#superclass : #PackageManifest,

--- a/src/System-VMEvents/ManifestSystemVMEvents.class.st
+++ b/src/System-VMEvents/ManifestSystemVMEvents.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestSystemVMEvents,
 	#superclass : #PackageManifest,

--- a/src/Text-Core/ManifestTextCore.class.st
+++ b/src/Text-Core/ManifestTextCore.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestTextCore,
 	#superclass : #PackageManifest,

--- a/src/Text-Scanning/ManifestTextScanning.class.st
+++ b/src/Text-Scanning/ManifestTextScanning.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestTextScanning,
 	#superclass : #PackageManifest,

--- a/src/Tool-Base/ManifestToolBase.class.st
+++ b/src/Tool-Base/ManifestToolBase.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestToolBase,
 	#superclass : #PackageManifest,

--- a/src/Tool-DependencyAnalyser/ManifestToolDependencyAnalyser.class.st
+++ b/src/Tool-DependencyAnalyser/ManifestToolDependencyAnalyser.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestToolDependencyAnalyser,
 	#superclass : #PackageManifest,

--- a/src/Tool-Diff/ManifestToolDiff.class.st
+++ b/src/Tool-Diff/ManifestToolDiff.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestToolDiff,
 	#superclass : #PackageManifest,

--- a/src/Tool-ExternalBrowser/ManifestToolExternalBrowser.class.st
+++ b/src/Tool-ExternalBrowser/ManifestToolExternalBrowser.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestToolExternalBrowser,
 	#superclass : #PackageManifest,

--- a/src/Transcript-Core/ManifestTranscript.class.st
+++ b/src/Transcript-Core/ManifestTranscript.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestTranscript,
 	#superclass : #PackageManifest,

--- a/src/Transcript-NonInteractive/ManifestNonInteractiveTranscript.class.st
+++ b/src/Transcript-NonInteractive/ManifestNonInteractiveTranscript.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestNonInteractiveTranscript,
 	#superclass : #PackageManifest,

--- a/src/Transcript-Tool/ManifestToolTranscript.class.st
+++ b/src/Transcript-Tool/ManifestToolTranscript.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestToolTranscript,
 	#superclass : #PackageManifest,

--- a/src/UIManager/CommandLineUIManager.class.st
+++ b/src/UIManager/CommandLineUIManager.class.st
@@ -1,7 +1,7 @@
 "
 I am UI manager for a headless setup.
 I block all UI manager API that uses Morphs and will trow an error instead.
-" 
+"
 Class {
 	#name : #CommandLineUIManager,
 	#superclass : #UIManager,

--- a/src/UIManager/ManifestUIManager.class.st
+++ b/src/UIManager/ManifestUIManager.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestUIManager,
 	#superclass : #PackageManifest,

--- a/src/Unicode-Initialization/ManifestUnicodeInitialization.class.st
+++ b/src/Unicode-Initialization/ManifestUnicodeInitialization.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestUnicodeInitialization,
 	#superclass : #PackageManifest,

--- a/src/Versionner-Spec-Browser/ManifestVersionnerSpecBrowser.class.st
+++ b/src/Versionner-Spec-Browser/ManifestVersionnerSpecBrowser.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestVersionnerSpecBrowser,
 	#superclass : #PackageManifest,

--- a/src/WriteBarrier-Tests/ManifestWriteBarrierTests.class.st
+++ b/src/WriteBarrier-Tests/ManifestWriteBarrierTests.class.st
@@ -1,6 +1,3 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
 	#name : #ManifestWriteBarrierTests,
 	#superclass : #PackageManifest,


### PR DESCRIPTION
Manifest classes of uncommented packages are reset their dummy class comment. So now uncommented manifests indicate uncommented packages. And duplicated comment stubs are removed.
For commented packages the description method string is moved to manifest comment.

#packageComment and #packageComment: methods are changed to use class comment logic.
And they are moved to Manifest package.

In addition #classCommentBlank is overriden by PackageManifest with: 
	No description for this package available. Please add a description for this package here
	
https://pharo.fogbugz.com/f/cases/21617/Better-implementation-of-package-comments