### PR TITLE
21618-Saving-code-as-file-tree-is-broken

### DIFF
--- a/src/MonticelloFileTree-Core/MCFileTreeAbstractStWriter.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeAbstractStWriter.class.st
@@ -157,9 +157,8 @@ MCFileTreeAbstractStWriter >> writeInDirectoryName: directoryNameOrPath fileName
     self fileUtils
         writeStreamFor: fileName , ext
         in: directory
-        do: [ :fileStream | 
-            fileStream lineEndConvention: #'lf'.
-            self setFileStream: fileStream.
+        do: [ :fileStream |
+            self setFileStream: (ZnNewLineWriterStream on: fileStream) forLf.
             visitBlock value ]
 ]
 


### PR DESCRIPTION
 - Should use new ZnNewLineWriterStream