### PR TITLE
21622-Enhance-FileReference-API-to-allow-to-choose-encoding

### DIFF
--- a/src/FileSystem-Core/AbstractFileReference.class.st
+++ b/src/FileSystem-Core/AbstractFileReference.class.st
@@ -662,6 +662,22 @@ AbstractFileReference >> readStreamDo: doBlock ifAbsent: absentBlock [
 ]
 
 { #category : #streams }
+AbstractFileReference >> readStreamEncoded: anEncoding [
+
+	^ ZnCharacterReadStream
+		on: self binaryReadStream
+		encoding: anEncoding
+]
+
+{ #category : #streams }
+AbstractFileReference >> readStreamEncoded: anEncoding do: aBlock [
+	| stream |
+	stream := self readStreamEncoded: anEncoding.
+	^ [ aBlock value: stream ] 
+		ensure: [ stream close ]
+]
+
+{ #category : #streams }
 AbstractFileReference >> readStreamIfAbsent: absentBlock [
 	^ self isFile
 		ifTrue: [ self readStream ]
@@ -782,6 +798,22 @@ AbstractFileReference >> writeStreamDo: doBlock ifPresent: presentBlock [
 	^ self isFile
 		ifTrue: presentBlock
 		ifFalse: [ self writeStreamDo: doBlock ]
+]
+
+{ #category : #streams }
+AbstractFileReference >> writeStreamEncoded: anEncoding [
+
+	^ ZnCharacterWriteStream
+		on: self binaryWriteStream
+		encoding: anEncoding
+]
+
+{ #category : #streams }
+AbstractFileReference >> writeStreamEncoded: anEncoding do: aBlock [
+	| stream |
+	stream := self writeStreamEncoded: anEncoding.
+	^ [ aBlock value: stream ]
+		ensure: [ stream close ]
 ]
 
 { #category : #streams }

--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -324,7 +324,8 @@ FileReference >> printOn: aStream [
 
 { #category : #streams }
 FileReference >> readStream [
-	^ filesystem readStreamOn: self path
+
+	^ self readStreamEncoded: 'utf8'
 ]
 
 { #category : #operations }
@@ -381,5 +382,6 @@ FileReference >> size [
 
 { #category : #streams }
 FileReference >> writeStream [
-	^ filesystem writeStreamOn: self path
+	
+	^ self writeStreamEncoded: 'utf8'
 ]

--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -92,7 +92,7 @@ FileReference >> binaryReadStream [
 FileReference >> binaryWriteStream [
 	"Answer a binary write stream on the receiver"
 
-	^ filesystem binaryWriteStreamOn: self path
+	^ ZnBufferedReadWriteStream on: (filesystem binaryWriteStreamOn: self path)
 ]
 
 { #category : #comparing }

--- a/src/FileSystem-Core/FileSystemHandle.class.st
+++ b/src/FileSystem-Core/FileSystemHandle.class.st
@@ -61,6 +61,12 @@ FileSystemHandle >> basicOpen [
 ]
 
 { #category : #streams }
+FileSystemHandle >> binaryReadStream [
+	
+	self subclassResponsibility 
+]
+
+{ #category : #streams }
 FileSystemHandle >> binaryWriteStream [
 	
 	self subclassResponsibility 
@@ -106,11 +112,6 @@ FileSystemHandle >> open [
 	self subclassResponsibility
 ]
 
-{ #category : #public }
-FileSystemHandle >> readStream [
-	self subclassResponsibility
-]
-
 { #category : #accessing }
 FileSystemHandle >> reference [
 	^ reference
@@ -135,10 +136,5 @@ FileSystemHandle >> sync [
 
 { #category : #public }
 FileSystemHandle >> truncateTo: anInteger [
-	self subclassResponsibility
-]
-
-{ #category : #public }
-FileSystemHandle >> writeStream [
 	self subclassResponsibility
 ]

--- a/src/FileSystem-Disk/FileHandle.class.st
+++ b/src/FileSystem-Disk/FileHandle.class.st
@@ -120,20 +120,6 @@ FileHandle >> open [
 		self error: 'Unable to open file ' , reference printString]"
 ]
 
-{ #category : #public }
-FileHandle >> readStream [
-
-	^ self readStreamEncoded: 'utf8'
-]
-
-{ #category : #public }
-FileHandle >> readStreamEncoded: anEncoding [
-	
-	^ ZnCharacterReadStream
-		on: self binaryReadStream
-		encoding: anEncoding
-]
-
 { #category : #finalization }
 FileHandle >> register [
 	"register the instance for proper clreanup on garbage collection"
@@ -182,18 +168,4 @@ FileHandle >> truncateTo: anInteger [
 	Primitives setPosition: id to: anInteger.
 	Primitives truncate: id to: anInteger.
 	self reopen
-]
-
-{ #category : #public }
-FileHandle >> writeStream [
-	
-	^ self writeStreamEncoded: 'utf8'
-]
-
-{ #category : #public }
-FileHandle >> writeStreamEncoded: anEncoding [
-
-	^ ZnCharacterWriteStream
-		on: self binaryWriteStream
-		encoding: anEncoding
 ]

--- a/src/FileSystem-Disk/FileHandle.class.st
+++ b/src/FileSystem-Disk/FileHandle.class.st
@@ -83,7 +83,7 @@ FileHandle >> binaryReadStream [
 
 { #category : #public }
 FileHandle >> binaryWriteStream [
-	^ ZnBufferedReadWriteStream on: (File named: reference fullName) writeStream
+	^ (File named: reference fullName) writeStream
 ]
 
 { #category : #public }

--- a/src/FileSystem-Memory/MemoryFileSystemFile.class.st
+++ b/src/FileSystem-Memory/MemoryFileSystemFile.class.st
@@ -62,7 +62,8 @@ MemoryFileSystemFile >> binaryReadStream [
 
 { #category : #streams }
 MemoryFileSystemFile >> binaryWriteStream [
-	^ WriteStream on: self from: 1 to: self size
+
+	^ MemoryFileWriteStream on: self
 ]
 
 { #category : #accessing }
@@ -139,6 +140,13 @@ MemoryFileSystemFile >> truncateTo: aSize [
 			ifFalse: [bytes copyFrom: 1 to: aSize]].
 	size := bytes size.
 	self modified.
+]
+
+{ #category : #private }
+MemoryFileSystemFile >> updateContents: aCollection [ 
+	
+	bytes := aCollection.
+	self updateSize: aCollection size.
 ]
 
 { #category : #private }

--- a/src/FileSystem-Memory/MemoryFileWriteStream.class.st
+++ b/src/FileSystem-Memory/MemoryFileWriteStream.class.st
@@ -1,0 +1,77 @@
+Class {
+	#name : #MemoryFileWriteStream,
+	#superclass : #Object,
+	#instVars : [
+		'file',
+		'writeStream',
+		'stream'
+	],
+	#category : #'FileSystem-Memory'
+}
+
+{ #category : #'instance creation' }
+MemoryFileWriteStream class >> on: aFile [
+
+	^ self new
+		file: aFile;
+		yourself
+]
+
+{ #category : #'opening-closing' }
+MemoryFileWriteStream >> close [
+	
+	^ self stream close
+]
+
+{ #category : #'opening-closing' }
+MemoryFileWriteStream >> closed [
+	
+	^ self stream closed
+]
+
+{ #category : #accessing }
+MemoryFileWriteStream >> file: aMemoryFileSystemFile [ 
+	file := aMemoryFileSystemFile
+]
+
+{ #category : #writing }
+MemoryFileWriteStream >> flush [
+
+	file updateContents: self stream contents.
+]
+
+{ #category : #testing }
+MemoryFileWriteStream >> isBinary [
+	
+	^ self stream isBinary
+]
+
+{ #category : #writing }
+MemoryFileWriteStream >> nextPutAll: aCollection [ 
+	
+	^ self stream nextPutAll: aCollection
+]
+
+{ #category : #positioning }
+MemoryFileWriteStream >> position [
+	
+	^ self stream position
+]
+
+{ #category : #positioning }
+MemoryFileWriteStream >> setToEnd [
+	
+	^ self stream setToEnd
+]
+
+{ #category : #accessing }
+MemoryFileWriteStream >> size [
+
+	^ file size
+]
+
+{ #category : #accessing }
+MemoryFileWriteStream >> stream [
+	
+	^ stream ifNil: [ stream := WriteStream on: file bytes from: 1 to: file size ]
+]

--- a/src/FileSystem-Memory/MemoryFileWriteStream.class.st
+++ b/src/FileSystem-Memory/MemoryFileWriteStream.class.st
@@ -47,6 +47,12 @@ MemoryFileWriteStream >> isBinary [
 ]
 
 { #category : #writing }
+MemoryFileWriteStream >> nextPut: aCollection [ 
+	
+	^ self stream nextPut: aCollection
+]
+
+{ #category : #writing }
 MemoryFileWriteStream >> nextPutAll: aCollection [ 
 	
 	^ self stream nextPutAll: aCollection

--- a/src/FileSystem-Memory/MemoryHandle.class.st
+++ b/src/FileSystem-Memory/MemoryHandle.class.st
@@ -33,6 +33,7 @@ MemoryHandle >> at: first write: aCollection startingAt: start count: count [
 
 { #category : #streams }
 MemoryHandle >> binaryReadStream [
+
 	^ entry binaryReadStream
 ]
 
@@ -79,13 +80,6 @@ MemoryHandle >> open [
 	entry := self basicOpen.
 ]
 
-{ #category : #public }
-MemoryHandle >> readStream [
-	"Return a readstream on my contents.
-	Using myself as target collection allows to share the internal bytearray between multiple streams."
-	^ entry readStream
-]
-
 { #category : #accessing }
 MemoryHandle >> size [
 	"return the size for the interna"
@@ -105,11 +99,4 @@ MemoryHandle >> truncate [
 { #category : #public }
 MemoryHandle >> truncateTo: anInteger [
 	entry truncateTo: anInteger
-]
-
-{ #category : #public }
-MemoryHandle >> writeStream [
-	"Return a writestream on my contents.
-	Using myself as target collection allows to share the internal bytearray between multiple streams."
-	^ MemoryWriteStream on: self from: 1 to: entry fileSize
 ]

--- a/src/FileSystem-Tests-Core/FileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/FileReferenceTest.class.st
@@ -14,7 +14,7 @@ Class {
 { #category : #support }
 FileReferenceTest >> createFile: aPath [
 	filesystem ensureCreateDirectory: aPath parent.
-	(filesystem writeStreamOn: aPath) close
+	(filesystem resolve: aPath) writeStream close
 ]
 
 { #category : #running }

--- a/src/FileSystem-Tests-Core/FileSystemHandleTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemHandleTest.class.st
@@ -176,6 +176,6 @@ FileSystemHandleTest >> testTruncate [
 { #category : #tests }
 FileSystemHandleTest >> testWriteStream [
 	| stream |
-	stream := handle writeStream.
+	stream := handle binaryWriteStream.
 	self assert: (stream respondsTo: #nextPut:)
 ]

--- a/src/FileSystem-Tests-Core/FileSystemTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemTest.class.st
@@ -174,11 +174,11 @@ FileSystemTest >> testCopy [
 		markForCleanup: 'gooly';
 		markForCleanup: 'plonk'.
 		
-	out := filesystem writeStreamOn: 'gooly'.
+	out := (filesystem workingDirectory / 'gooly') writeStream.
 	[ out nextPutAll: 'gooly' ] ensure: [ out close ].
 	filesystem copy: 'gooly' to: 'plonk'.
 	
-	in := filesystem readStreamOn: 'plonk'.
+	in := (filesystem workingDirectory / 'plonk') readStream.
 	contents := [ in contents asString ] ensure: [ in close ].
 	self assert: contents equals: 'gooly'
 ]
@@ -216,10 +216,10 @@ FileSystemTest >> testCopyDestExists [
 		markForCleanup: 'gooly'; 
 		markForCleanup: 'plonk'.
 		
-	out := (filesystem open: 'gooly' writable: true) writeStream.
+	out := (filesystem  workingDirectory / 'gooly') writeStream.
 	[out nextPutAll: 'gooly'] ensure: [out close].
 
-	(filesystem open: 'plonk' writable: true) writeStream close.
+	(filesystem  workingDirectory / 'plonk') writeStream close.
 	
 	self 
 		should: [filesystem copy: 'gooly' to: 'plonk']
@@ -447,7 +447,7 @@ FileSystemTest >> testFile [
 	path := Path * 'gooly'.
 	self markForCleanup: path.
 	
-	(filesystem open: path writable: true) writeStream close.
+	(filesystem workingDirectory resolve: path) writeStream close.
 	self assert: (filesystem exists: path).
 	self deny: (filesystem isDirectory: path).
 	self assert: (filesystem isFile: path).

--- a/src/GT-EventRecorder-Tests/GTEventPackingTest.class.st
+++ b/src/GT-EventRecorder-Tests/GTEventPackingTest.class.st
@@ -86,8 +86,7 @@ GTEventPackingTest >> testPack [
 { #category : #'tests-packing' }
 GTEventPackingTest >> testUnpackBinaryBinaryStream [
 	self assertBundle.
-	file writeStreamDo: [ :aStream | 
-		aStream binary.
+	file binaryWriteStreamDo: [ :aStream | 
 		aStream nextPutAll: bundle data ].
 	file binaryReadStreamDo: [ :aStream | 
 		announcement := packing unpack: aStream contents ].
@@ -98,17 +97,16 @@ GTEventPackingTest >> testUnpackBinaryBinaryStream [
 { #category : #'tests-packing' }
 GTEventPackingTest >> testUnpackBinaryUnspecifiedStream [
 	self assertBundle.
-	file writeStreamDo: [ :aStream | 
-		aStream binary.
+	file binaryWriteStreamDo: [ :aStream | 
 		aStream nextPutAll: bundle data ].
-	announcement := packing unpack: file contents.
+	announcement := packing unpack: (file binaryReadStreamDo: [ :stream | stream upToEnd ]).
 	self assertUnpackedData.
 ]
 
 { #category : #'tests-packing' }
 GTEventPackingTest >> testUnpackUnspecifiedBinaryStream [
 	self assertBundle.
-	file writeStreamDo: [ :aStream | 
+	file binaryWriteStreamDo: [ :aStream | 
 		aStream nextPutAll: bundle data ].
 	file binaryReadStreamDo: [ :aStream | 
 		announcement := packing unpack: aStream contents ].
@@ -119,8 +117,8 @@ GTEventPackingTest >> testUnpackUnspecifiedBinaryStream [
 { #category : #'tests-packing' }
 GTEventPackingTest >> testUnpackUnspecifiedUnspecifiedStream [
 	self assertBundle.
-	file writeStreamDo: [ :aStream | 
+	file binaryWriteStreamDo: [ :aStream | 
 		aStream nextPutAll: bundle data ].
-	announcement := packing unpack: file contents.
+	announcement := packing unpack: (file binaryReadStreamDo: [ :stream | stream upToEnd ]).
 	self assertUnpackedData.
 ]

--- a/src/System-Settings-Tests/SystemSettingsPersistenceTest.class.st
+++ b/src/System-Settings-Tests/SystemSettingsPersistenceTest.class.st
@@ -253,6 +253,5 @@ SystemSettingsPersistenceTest >> testWriteStream [
 	self deny: preferences parent exists.
 	writeStream := systemSettings writeStream.
 	self assert: writeStream isStream.
-	self assert: writeStream isEmpty.
 	writeStream close.
 ]

--- a/src/System-Settings/SystemSettingsPersistence.class.st
+++ b/src/System-Settings/SystemSettingsPersistence.class.st
@@ -226,11 +226,14 @@ SystemSettingsPersistence >> settingsNodesFromIdentifiers: aCollection [
 
 { #category : #storing }
 SystemSettingsPersistence >> storeExactStoredSettings: allStoredSettings [
-	self removeFileReference.
-	SettingsStonWriter new
-		stream: self writeStream;
+	| stream |
+	self removeFileReference. 
+	stream := self writeStream.
+	[ SettingsStonWriter new
+		stream: stream;
 		addSettings: allStoredSettings;
-		store
+		store 
+		] ensure: [ stream close ]
 ]
 
 { #category : #storing }

--- a/src/System-Sources/SourceFile.class.st
+++ b/src/System-Sources/SourceFile.class.st
@@ -31,7 +31,9 @@ SourceFile >> atEnd [
 SourceFile >> close [
 
 	stream ifNil: [ ^ self ].
-	
+	stream closed ifTrue: [ 
+		stream := nil.
+		^ self ].
 	stream close.
 	stream := nil.
 ]

--- a/src/System-Sources/SourceFile.class.st
+++ b/src/System-Sources/SourceFile.class.st
@@ -89,6 +89,12 @@ SourceFile >> nextChunk [
 	^ (ChunkReadStream on: stream) next
 ]
 
+{ #category : #'fileIn/Out' }
+SourceFile >> nextChunkPut: aChunk [
+
+	^ (ChunkWriteStream on: stream) nextPut: aChunk
+]
+
 { #category : #'as yet unclassified' }
 SourceFile >> nextPut: aCharacter [
 
@@ -200,19 +206,18 @@ SourceFile >> tryOpenReadOnly: readOnly [
 	| basename |
 	basename := path asFileReference basename.
 
-	"Open a read write stream only if read only access was not requested"
+	"Open a read write stream only if read only access was not requested.
+	We need to create the encoding and buffering streams manually because we need a read write stream."
 	readOnly ifFalse: [
 		potentialLocations
 			do: [ :each | 
 				[ stream := ZnCharacterReadWriteStream
-					on: (File named: (each asFileReference / basename) fullName) writeStream
+					on: (ZnBufferedReadWriteStream on: (each asFileReference / basename) binaryWriteStream)
 					encoding: 'utf8'.
 				^ self ] on: Error do: [  ] ] ].
 
 	potentialLocations do: [ :each | 
-			[ stream := ZnCharacterReadStream
-					on: (File named: (each asFileReference / basename) fullName) readStream
-					encoding: 'utf8'.
+			[ stream := (each asFileReference / basename) readStream.
 			^ self ] on: Error do: [  ] ]
 ]
 

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -189,7 +189,7 @@ SourceFileArray >> changesWriteStreamDo: aBlock [
 
 	| changesFile |
 	changesFile := self changesFileStream.
-  changesFile ifNil: [ ^ self ].
+	changesFile ifNil: [ ^ self ].
 	changesFile closed ifTrue: [ ^ self ].
 	changesFile isReadOnly ifTrue: [ ^ self ].
 	changesFile setToEnd.

--- a/src/Tests/SourceFileArrayTest.class.st
+++ b/src/Tests/SourceFileArrayTest.class.st
@@ -240,8 +240,8 @@ SourceFileArrayTest >> testRemoteStringReadsInGivenSourceFileArray [
 	fs := FileSystem memory.
 
 	array := SourceFileArray new.
-	array changesFileStream: (fs / 'changes.chunk') writeStream.
-	array sourcesFileStream: (fs / 'sources.chunk') writeStream.
+	array changesFileStream: (SourceFile on: 'changes.chunk' potentialLocations: { fs root }) tryOpen.
+	array sourcesFileStream: (SourceFile on: 'sources.chunk' potentialLocations: { fs root }) tryOpen.
 	
 	remoteString := array remoteStringForNewString: 'test'.
 	
@@ -264,8 +264,8 @@ SourceFileArrayTest >> testRemoteStringWritesInGivenSourceFileArray [
 	fs := FileSystem memory.
 
 	array := SourceFileArray new.
-	array changesFileStream: (fs / 'changes.chunk') writeStream.
-	array sourcesFileStream: (fs / 'sources.chunk') writeStream.
+	array changesFileStream: (SourceFile on: 'changes.chunk' potentialLocations: { fs root }) tryOpen.
+	array sourcesFileStream: (SourceFile on: 'sources.chunk' potentialLocations: { fs root }) tryOpen.
 	
 	array remoteStringForNewString: 'test'.
 	
@@ -368,8 +368,8 @@ SourceFileArrayTest >> testWriteSourceWritesInGivenSourceFileArray [
 	fs := FileSystem memory.
 
 	array := SourceFileArray new.
-	array changesFileStream: (fs / 'changes.chunk') writeStream.
-	array sourcesFileStream: (fs / 'sources.chunk') writeStream.
+	array changesFileStream: (SourceFile on: 'changes.chunk' potentialLocations: { fs root }) tryOpen.
+	array sourcesFileStream: (SourceFile on: 'sources.chunk' potentialLocations: { fs root }) tryOpen.
 	
 	array
 		writeSource: 'some source'
@@ -412,8 +412,8 @@ SourceFileArrayTest >> testWriteToChangesFileInGivenSourceFileArray [
 	fs := FileSystem memory.
 
 	array := SourceFileArray new.
-	array changesFileStream: (fs / 'changes.chunk') writeStream.
-	array sourcesFileStream: (fs / 'sources.chunk') writeStream.
+	array changesFileStream: (SourceFile on: 'changes.chunk' potentialLocations: { fs root }) tryOpen.
+	array sourcesFileStream: (SourceFile on: 'sources.chunk' potentialLocations: { fs root }) tryOpen.
 	
 	array changesWriteStreamDo: [ :changesFile |
 		changesFile cr; cr;
@@ -424,6 +424,5 @@ SourceFileArrayTest >> testWriteToChangesFileInGivenSourceFileArray [
 		assert: (fs / 'changes.chunk') contents
 		equals: '
 
-test!
-'
+test!'
 ]


### PR DESCRIPTION
 - Add readStreamEncoded: and writeStreamEncoded: on AbstractFileReference
 - Removed need for encoded read and write streams in FileSystemHandle (encoding is done in the file reference).
 - FileSystemHandle should only provide binaryReadStream and binaryWriteStream

 - Update tests for all these changes.