### PR TITLE
21634-add-AST-and-Bytecode-view-to-RGMethodDefinition-inspector

### DIFF
--- a/src/GT-InspectorExtensions-Core/RGMethodDefinition.extension.st
+++ b/src/GT-InspectorExtensions-Core/RGMethodDefinition.extension.st
@@ -1,6 +1,21 @@
 Extension { #name : #RGMethodDefinition }
 
 { #category : #'*GT-InspectorExtensions-Core' }
+RGMethodDefinition >> gtInspectorASTIn: composite [
+	<gtInspectorPresentationOrder: 35> 
+	(GTSimpleRBTreeBrowser new treeIn: composite)
+		title: 'AST';
+		display: [ :anObject | {anObject ast} ]
+]
+
+{ #category : #'*GT-InspectorExtensions-Core' }
+RGMethodDefinition >> gtInspectorBytecodeIn: composite [
+	<gtInspectorPresentationOrder: 30> 
+	^ (GTBytecodeBrowser new treeIn: composite)
+		title: 'Bytecode'
+]
+
+{ #category : #'*GT-InspectorExtensions-Core' }
 RGMethodDefinition >> gtInspectorImplementorsIn: composite [
 	<gtInspectorPresentationOrder: 4>
 	composite list 

--- a/src/Ring-Core-Kernel/RGMethodDefinition.class.st
+++ b/src/Ring-Core-Kernel/RGMethodDefinition.class.st
@@ -656,6 +656,11 @@ RGMethodDefinition >> symbolic [
 	^ self method symbolic
 ]
 
+{ #category : #accessing }
+RGMethodDefinition >> symbolicBytecodes [
+	^self compiledMethod symbolicBytecodes
+]
+
 { #category : #'stamp values' }
 RGMethodDefinition >> timeStamp [ 
 


### PR DESCRIPTION
add AST and Bytecode view to RGMethodDefinition inspector
	https://pharo.fogbugz.com/f/cases/21634/add-AST-and-Bytecode-view-to-RGMethodDefinition-inspector