### PR TITLE
21646  AbstractFileReference should use "utilities" protocol name

### DIFF
--- a/src/FileSystem-Core/AbstractFileReference.class.st
+++ b/src/FileSystem-Core/AbstractFileReference.class.st
@@ -605,7 +605,7 @@ AbstractFileReference >> moveTo: aReference [
 	^ self resolve moveTo: aReference
 ]
 
-{ #category : #utility }
+{ #category : #utilities }
 AbstractFileReference >> nextVersion [
 	^ self resolve nextVersion
 ]


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21646/AbstractFileReference-should-use-utilities-protocol-name