### PR TITLE
21654-MetaLink-should-have-announceChange-for-all-SystemAnnouncer-related-change-announcing

### DIFF
--- a/src/Reflectivity-Tools/Watchpoint.class.st
+++ b/src/Reflectivity-Tools/Watchpoint.class.st
@@ -151,13 +151,13 @@ Watchpoint >> printOn: aStream [
 { #category : #recording }
 Watchpoint >> start [
 	recording := true.
-	SystemAnnouncer uniqueInstance announce: (MetalinkChanged new link: link)
+	link announceChanged
 ]
 
 { #category : #recording }
 Watchpoint >> stop [
 	recording := false.
-	SystemAnnouncer uniqueInstance announce: (MetalinkChanged new link: link)
+	link announceChanged
 ]
 
 { #category : #accessing }

--- a/src/Reflectivity/BlockClosure.extension.st
+++ b/src/Reflectivity/BlockClosure.extension.st
@@ -1,19 +1,28 @@
 Extension { #name : #BlockClosure }
 
 { #category : #'*Reflectivity' }
-BlockClosure >> ctxtEnsure: aBlock [
-	"Evaluate a termination block after evaluating the receiver, regardless of whether the receiver's evaluation completes."
+BlockClosure >> rfEnsure: aBlock [
+	"same as #esure, carefully written to never have active meta-links as it is called in the code path that checks for recursion"
 
 	<primitive: 198>
+	<metaLinkOptions: #( + optionDisabledLink)>
 	| returnValue b |
-	returnValue := self value.
+	returnValue := self rfvalue.
 	aBlock isNil
 		ifFalse: [ 
 			"nil out aBlock temp before evaluating aBlock so it is not executed again if aBlock remote returns"
 			b := aBlock.
-			thisContext tempAt: 1 put: nil.
-			b value ].
+			thisContext rftempAt: 1 put: nil.
+			b rfvalue ].
 	^ returnValue
+]
+
+{ #category : #'*Reflectivity' }
+BlockClosure >> rfvalue [
+	"same as value, for recursion stopping metalinks"
+	<primitive: 201>
+	<metaLinkOptions: #( + optionDisabledLink)>
+	^self primitiveFailed
 ]
 
 { #category : #'*Reflectivity' }

--- a/src/Reflectivity/CompiledMethod.extension.st
+++ b/src/Reflectivity/CompiledMethod.extension.st
@@ -38,7 +38,7 @@ CompiledMethod >> installLink: aMetaLink [
 	(aMetaLink optionCompileOnLinkInstallation or: [ self isRealPrimitive ])
 		ifTrue: [ self reflectiveMethod compileAndInstallCompiledMethod ]
 		ifFalse: [ self invalidate ].
-	SystemAnnouncer uniqueInstance announce: (MetalinkChanged new link: aMetaLink)	
+	aMetaLink announceChanged.
 	
 ]
 

--- a/src/Reflectivity/Context.extension.st
+++ b/src/Reflectivity/Context.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #Context }
+
+{ #category : #'*Reflectivity' }
+Context >> rftempAt: index put: value [ 
+	"same as #tempAt:put:, for recursion stopping metalinks"
+	<primitive: 211>
+	<metaLinkOptions: #( + optionDisabledLink)>
+	"should never reach here, so no rfat:put: needed"
+	^self at: index put: value
+]

--- a/src/Reflectivity/MetaLink.class.st
+++ b/src/Reflectivity/MetaLink.class.st
@@ -76,6 +76,11 @@ MetaLink >> allReifications [
 	^reifications
 ]
 
+{ #category : #installing }
+MetaLink >> announceChanged [
+	SystemAnnouncer uniqueInstance announce: (MetalinkChanged new link: self)	
+]
+
 { #category : #accessing }
 MetaLink >> arguments [
 	^arguments
@@ -405,10 +410,11 @@ MetaLink >> uninstall [
 { #category : #ast }
 MetaLink >> valueInContext: aBlock [
 	| process |
+	"We need to take care that all code called here can not have active metalinks. We use copies of methods if we call system methods"
 	process := Processor rfactiveProcess.
 	(process isActive: self level)
 		ifFalse: [ ^ self ].
 	process shiftLevelUp.
-	aBlock value.
-	process shiftLevelDown.
+	[aBlock value] rfEnsure: [process shiftLevelDown]
+	
 ]

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -159,7 +159,7 @@ ReflectiveMethod >> installLink: aMetaLink [
 	self increaseLinkCount.
 	(self ast hasOption: #optionCompileOnLinkInstallation for: aMetaLink) 
 		ifTrue: [ self compileAndInstallCompiledMethod ].
-	SystemAnnouncer uniqueInstance announce: (MetalinkChanged new link: aMetaLink)	
+	aMetaLink announceChanged	
 ]
 
 { #category : #invalidate }
@@ -259,7 +259,7 @@ ReflectiveMethod >> removeLink: aMetaLink [
 		ifFalse: [ compiledMethod invalidate ].
 	self decreaseLinkCount.
 	self linkCount = 0 ifTrue: [ self destroyTwin ].
-	SystemAnnouncer uniqueInstance announce: (MetalinkChanged new link: aMetaLink).
+	aMetaLink announceChanged
 		
 ]
 


### PR DESCRIPTION
MetaLink should have #announceChange for all SystemAnnouncer related change announcing
	https://pharo.fogbugz.com/f/cases/21654/MetaLink-should-have-announceChange-for-all-SystemAnnouncer-related-change-announcing