### PR TITLE
21655-MetaLinks-should-by-default-not-announce-a-MetaLinkChanged-only-when-option-is-set

### DIFF
--- a/src/Reflectivity-Tools/Breakpoint.class.st
+++ b/src/Reflectivity-Tools/Breakpoint.class.st
@@ -150,7 +150,7 @@ Breakpoint >> condition: aCondition [
 
 { #category : #initialization }
 Breakpoint >> initialize [
-	options := #(+ optionCompileOnLinkInstallation)
+	options := #(+ optionCompileOnLinkInstallation + optionAnnounce)
 ]
 
 { #category : #install }

--- a/src/Reflectivity-Tools/ExecutionCounter.class.st
+++ b/src/Reflectivity-Tools/ExecutionCounter.class.st
@@ -71,7 +71,8 @@ ExecutionCounter >> install [
 
 	link := MetaLink new 
 				metaObject: self;
-				selector: #increase.
+				selector: #increase;
+				optionAnnounce: true.
 	node link: link.
 	self class allCounters at: node put: self.
 ]

--- a/src/Reflectivity-Tools/Watchpoint.class.st
+++ b/src/Reflectivity-Tools/Watchpoint.class.st
@@ -110,7 +110,7 @@ Watchpoint >> install [
 				arguments: #(value);
 				control: #after;
 				condition: [ recording ];
-				option: #(+ optionWeakAfter).
+				option: #(+ optionWeakAfter +optionAnnounce).
 	node link: link.
 	self class allWatchpoints at: node put: self.
 ]
@@ -151,13 +151,13 @@ Watchpoint >> printOn: aStream [
 { #category : #recording }
 Watchpoint >> start [
 	recording := true.
-	link announceChanged
+	link announceChange
 ]
 
 { #category : #recording }
 Watchpoint >> stop [
 	recording := false.
-	link announceChanged
+	link announceChange
 ]
 
 { #category : #accessing }

--- a/src/Reflectivity/CompiledMethod.extension.st
+++ b/src/Reflectivity/CompiledMethod.extension.st
@@ -38,7 +38,7 @@ CompiledMethod >> installLink: aMetaLink [
 	(aMetaLink optionCompileOnLinkInstallation or: [ self isRealPrimitive ])
 		ifTrue: [ self reflectiveMethod compileAndInstallCompiledMethod ]
 		ifFalse: [ self invalidate ].
-	aMetaLink announceChanged.
+	aMetaLink announceChange.
 	
 ]
 

--- a/src/Reflectivity/MetaLink.class.st
+++ b/src/Reflectivity/MetaLink.class.st
@@ -53,6 +53,7 @@ MetaLink class >> defaultOptions [
 	- optionMetalevel                   "force level: 0 for the link"
 	- optionDisabledLink                "links are active by default"
 	+ optionWeakAfter 						  "do not use #ensure: for #after "
+	- optionAnnounce                    "do we announce adding / removing links? Slow!"
 	)
 ]
 
@@ -77,8 +78,8 @@ MetaLink >> allReifications [
 ]
 
 { #category : #installing }
-MetaLink >> announceChanged [
-	SystemAnnouncer uniqueInstance announce: (MetalinkChanged new link: self)	
+MetaLink >> announceChange [
+	self optionAnnounce ifTrue: [SystemAnnouncer uniqueInstance announce: (MetalinkChanged new link: self)]
 ]
 
 { #category : #accessing }
@@ -292,6 +293,18 @@ MetaLink >> methods [
 { #category : #accessing }
 MetaLink >> option: anArray [ 
 	self parseOptions: anArray
+]
+
+{ #category : #options }
+MetaLink >> optionAnnounce [
+	^ options includes: #optionAnnounce
+]
+
+{ #category : #options }
+MetaLink >> optionAnnounce: aBoolean [
+	aBoolean
+		ifTrue: [ options add: #optionAnnounce ] 
+		ifFalse: [ options remove: #optionAnnounce ifAbsent:[] ]
 ]
 
 { #category : #options }

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -159,7 +159,7 @@ ReflectiveMethod >> installLink: aMetaLink [
 	self increaseLinkCount.
 	(self ast hasOption: #optionCompileOnLinkInstallation for: aMetaLink) 
 		ifTrue: [ self compileAndInstallCompiledMethod ].
-	aMetaLink announceChanged	
+	aMetaLink announceChange
 ]
 
 { #category : #invalidate }
@@ -259,8 +259,7 @@ ReflectiveMethod >> removeLink: aMetaLink [
 		ifFalse: [ compiledMethod invalidate ].
 	self decreaseLinkCount.
 	self linkCount = 0 ifTrue: [ self destroyTwin ].
-	aMetaLink announceChanged
-		
+	aMetaLink announceChange		
 ]
 
 { #category : #evaluation }


### PR DESCRIPTION
MetaLinks should by default not announce a MetaLinkChanged (only when option is set)
	https://pharo.fogbugz.com/f/cases/21655/MetaLinks-should-by-default-not-announce-a-MetaLinkChanged-only-when-option-is-set