### PR TITLE
21658 monticello initializers are not enabled by default

### DIFF
--- a/src/BaselineOfDisplay/BaselineOfDisplay.class.st
+++ b/src/BaselineOfDisplay/BaselineOfDisplay.class.st
@@ -83,6 +83,9 @@ BaselineOfDisplay >> postload: loader package: packageSpec [
 { #category : #actions }
 BaselineOfDisplay >> preload: loader package: packageSpec [
 
+	"Ignore pre and post loads if already executed"
+	Initialized = true ifTrue: [ ^ self ].
+
 	initializersEnabled := MCMethodDefinition initializersEnabled.
 	MCMethodDefinition initializersEnabled: false.
 	

--- a/src/BaselineOfUnifiedFFI/BaselineOfUnifiedFFI.class.st
+++ b/src/BaselineOfUnifiedFFI/BaselineOfUnifiedFFI.class.st
@@ -16,6 +16,9 @@ Class {
 	#instVars : [
 		'initializersEnabled'
 	],
+	#classVars : [
+		'Initialized'
+	],
 	#category : #BaselineOfUnifiedFFI
 }
 
@@ -43,6 +46,9 @@ BaselineOfUnifiedFFI >> baseline: spec [
 { #category : #actions }
 BaselineOfUnifiedFFI >> postload: loader package: packageSpec [
 
+	"Ignore pre and post loads if already executed"
+	Initialized = true ifTrue: [ ^ self ].
+
 	MCMethodDefinition initializersEnabled: initializersEnabled.
 	
 	
@@ -50,6 +56,9 @@ BaselineOfUnifiedFFI >> postload: loader package: packageSpec [
 
 { #category : #actions }
 BaselineOfUnifiedFFI >> preload: loader package: packageSpec [
+
+	"Ignore pre and post loads if already executed"
+	Initialized = true ifTrue: [ ^ self ].
 
 	initializersEnabled := MCMethodDefinition initializersEnabled.
 	MCMethodDefinition initializersEnabled: true.

--- a/src/Monticello-Tests/MCReleaseTest.class.st
+++ b/src/Monticello-Tests/MCReleaseTest.class.st
@@ -1,0 +1,14 @@
+Class {
+	#name : #MCReleaseTest,
+	#superclass : #MCTestCase,
+	#category : #'Monticello-Tests-Base'
+}
+
+{ #category : #tests }
+MCReleaseTest >> testMonticelloInitializersAreEnabledByDefault [
+
+	"Monticello should by default have this option enabled.
+	If this is not the case, the image cannot be released, as it will break users that expect class initializations to be run automatically"
+
+	self assert: MCMethodDefinition initializersEnabled.
+]


### PR DESCRIPTION
- Add a test to avoid releasing again an image with this problem
- guard all pharo baselines with postloads from double execution (and hopefully fix the bug)