### PR TITLE
21653-ShiftClassInstaller-gives-error-when-changing-superclass-to-new-one-with-variables

### DIFF
--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -5,7 +5,8 @@ Class {
 		'newClass',
 		'superClass',
 		'subClass',
-		'newClass2'
+		'newClass2',
+		'superClass2'
 	],
 	#category : #'Shift-ClassInstaller-Tests'
 }
@@ -36,8 +37,25 @@ ShClassInstallerTest >> tearDown [
 
 	subClass ifNotNil: #removeFromSystem.
 	superClass ifNotNil: #removeFromSystem.
+	superClass2 ifNotNil: #removeFromSystem.
 	
 	super tearDown.
+]
+
+{ #category : #tests }
+ShClassInstallerTest >> testChangingSuperclassToOther [
+
+	superClass := self newClass:#ShCITestClass slots:#(var1).
+	superClass2 := self newClass:#ShCITestClass2 slots:#(var1).
+	subClass := self newClass:#ShCISubTestClass superclass: superClass2 slots:#().
+
+	subClass := 	self newClass:#ShCISubTestClass superclass: superClass slots:#().
+
+	self deny: superClass subclasses isEmpty.
+	self assert: superClass2 subclasses isEmpty.
+	self assertCollection: superClass subclasses equals: { subClass }. 
+	self assert: subClass superclass equals: superClass.
+
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Could not reproduce it. I have added the test to validate it is not happening.

ShClassInstallerTest >> #testChangingSuperclassToOther

Issue: https://pharo.fogbugz.com/f/cases/resolve/21653/ShiftClassInstaller-gives-error-when-changing-superclass-to-new-one-with-variables