### PR TITLE
21438-There-is-code-in-_UnpackagedPackage-in-Pharo-7

### DIFF
--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -203,6 +203,9 @@ RPackageOrganizer >> addMethod: method [
 	
 	protocol := method protocol ifNil: [ Error signal: 'Should not happen' ].
 	
+	"If the class is not packaged yet, ignore the situation. This method is created during the creation of the class or on an anonymous class"
+	(method methodClass package name = RPackage defaultPackageName) ifTrue: [ ^ self ].
+	
 	rPackage := (self hasPackageForProtocol: protocol inClass: method methodClass)
 		ifTrue: [ self packageForProtocol: protocol inClass: method methodClass ]
 		ifFalse: [ self registerPackage: (self packageClass named: (protocol copyWithout: $*)) ].

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -260,6 +260,14 @@ ReleaseTest >> testUnpackagedClasses [
 
 ]
 
+{ #category : #'testing - rpackage' }
+ReleaseTest >> testUnpackagedPackageShouldBeEmpty [
+	| unpackagePackage |
+	unpackagePackage := RPackageOrganizer default packageNamed: (RPackage defaultPackageName ).
+	"The unpackage package should not have any defined class or extended classes"
+	self assert: unpackagePackage classes isEmpty.
+]
+
 { #category : #testing }
 ReleaseTest >> testWorldMenuHasHelpForAllEntries [
 	"In this test we check that at least every terminal menu entry of the world menu has an help."


### PR DESCRIPTION
Fixing the creation of methods of when a class is not installed. 
If a method is added in a class that is not installed, the method is not put in a package.
This happens during the creation of method in anonymous and still not installed classes.

Issue: https://pharo.fogbugz.com/f/cases/21438/There-is-code-in-_UnpackagedPackage-in-Pharo-7