### PR TITLE
21653 - ShiftClassInstaller gives error when changing superclass to new one with variables

### DIFF
--- a/src/Shift-Changes/ShSlotChangeDetector.class.st
+++ b/src/Shift-Changes/ShSlotChangeDetector.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #initialization }
 ShSlotChangeDetector >> initialize [
 	super initialize.
-	builderAccessor := [ :e | e layoutDefinition slots asArray ].
-	classAccessor := [ :e | e slots asArray].
+	builderAccessor := [ :e | e layoutDefinition allSlots asArray ].
+	classAccessor := [ :e | e allSlots asArray].
 	comparer := [ :a :b |  self compareSlotCollection: a with: b ]
 ]

--- a/src/Shift-ClassBuilder/ShLayoutDefinition.class.st
+++ b/src/Shift-ClassBuilder/ShLayoutDefinition.class.st
@@ -16,6 +16,13 @@ Class {
 }
 
 { #category : #accessing }
+ShLayoutDefinition >> allSlots [
+	| superclass | 
+	superclass := builder superclass.
+	^ (superclass ifNil: [ ^#() ] ifNotNil: [ superclass allSlots ]) , slots.
+]
+
+{ #category : #accessing }
 ShLayoutDefinition >> builder: anObject [
 	builder := anObject
 ]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -308,11 +308,6 @@ ShiftClassBuilder >> hasToMigrateInstances [
 	^ self changes anySatisfy: [ :e | e hasToMigrateInstances ]
 ]
 
-{ #category : #testing }
-ShiftClassBuilder >> hasToMigrateInstances [
-	^ self changes anySatisfy: [ :e | e hasToMigrateInstances ]
-]
-
 { #category : #initialization }
 ShiftClassBuilder >> initialize [
 	super initialize.

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -43,18 +43,38 @@ ShClassInstallerTest >> tearDown [
 ]
 
 { #category : #tests }
+ShClassInstallerTest >> testChangingSuperclassInTheHierarchy [
+
+	superClass := self newClass:#ShCITestClass slots:#(var1 var2).
+	superClass2 := self newClass:#ShCITestClass2 slots:#().
+	subClass := self newClass:#ShCISubTestClass superclass: superClass2 slots:#().
+
+   superClass2 := self newClass:#ShCITestClass2 superclass: superClass slots:#().
+
+	self deny: superClass subclasses isEmpty.
+	self assertCollection: superClass2 subclasses equals: { subClass }. 
+	self assertCollection: superClass subclasses equals: { superClass2 }. 
+	self assert: subClass superclass equals: superClass2.
+	self assert: superClass2 superclass equals: superClass.
+
+]
+
+{ #category : #tests }
 ShClassInstallerTest >> testChangingSuperclassToOther [
 
 	superClass := self newClass:#ShCITestClass slots:#(var1).
-	superClass2 := self newClass:#ShCITestClass2 slots:#(var1).
+	superClass2 := self newClass:#ShCITestClass2 slots:#().
 	subClass := self newClass:#ShCISubTestClass superclass: superClass2 slots:#().
 
 	subClass := 	self newClass:#ShCISubTestClass superclass: superClass slots:#().
 
+   superClass2 := self newClass:#ShCITestClass2 superclass: superClass slots:#().
+
 	self deny: superClass subclasses isEmpty.
 	self assert: superClass2 subclasses isEmpty.
-	self assertCollection: superClass subclasses equals: { subClass }. 
+	self assertCollection: superClass subclasses equals: { subClass. superClass2 }. 
 	self assert: subClass superclass equals: superClass.
+	self assert: superClass2 superclass equals: superClass.
 
 ]
 

--- a/src/Slot-Tests/SlotAnnouncementsTest.class.st
+++ b/src/Slot-Tests/SlotAnnouncementsTest.class.st
@@ -132,8 +132,9 @@ SlotAnnouncementsTest >> testChangeInSuperclassShouldNotAnnounceSubclassModified
 			name: self aClassName;
 			slots: #(a b c) ].
 
-	self assert: self collectedAnnouncements size equals: 1.
-	self assert: self collectedAnnouncements first newClassDefinition equals: aClass.
+	self assert: self collectedAnnouncements size equals: 2.
+	self assert: self collectedAnnouncements second newClassDefinition equals: aClass.
+	self assert: self collectedAnnouncements first newClassDefinition equals: anotherClass.	
 ]
 
 { #category : #'tests-integration' }


### PR DESCRIPTION
Fixing the propagation of changes in all the hierarchy.