### PR TITLE
21668-Mark-deprecated-classes-as-deprecated

### DIFF
--- a/src/DeprecatedFileStream/FileExistsException.class.st
+++ b/src/DeprecatedFileStream/FileExistsException.class.st
@@ -17,6 +17,11 @@ FileExistsException class >> fileName: aFileName fileClass: aClass [
 		fileClass: aClass
 ]
 
+{ #category : #deprecation }
+FileExistsException class >> isDeprecated [
+	^true
+]
+
 { #category : #exceptiondescription }
 FileExistsException >> defaultAction [
 	"The default action taken if the exception is signaled."

--- a/src/DeprecatedFileStream/FileStream.class.st
+++ b/src/DeprecatedFileStream/FileStream.class.st
@@ -146,6 +146,11 @@ FileStream class >> isChangesFileSuffix: suffix [
 
 ]
 
+{ #category : #deprecation }
+FileStream class >> isDeprecated [
+	^true
+]
+
 { #category : #'file reader services' }
 FileStream class >> isSourceFileSuffix: suffix [
 

--- a/src/DeprecatedFileStream/LimitingLineStreamWrapper.class.st
+++ b/src/DeprecatedFileStream/LimitingLineStreamWrapper.class.st
@@ -75,6 +75,11 @@ okay
 ' readStream
 ]
 
+{ #category : #deprecation }
+LimitingLineStreamWrapper class >> isDeprecated [
+	^true
+]
+
 { #category : #'instance creation' }
 LimitingLineStreamWrapper class >> on: aStream delimiter: aString [
 

--- a/src/DeprecatedFileStream/ManifestDeprecatedFileStream.class.st
+++ b/src/DeprecatedFileStream/ManifestDeprecatedFileStream.class.st
@@ -3,3 +3,8 @@ Class {
 	#superclass : #PackageManifest,
 	#category : #DeprecatedFileStream
 }
+
+{ #category : #deprecation }
+ManifestDeprecatedFileStream class >> isDeprecated [
+	^true
+]

--- a/src/DeprecatedFileStream/MultiByteBinaryOrTextStream.class.st
+++ b/src/DeprecatedFileStream/MultiByteBinaryOrTextStream.class.st
@@ -17,6 +17,11 @@ MultiByteBinaryOrTextStream class >> defaultConverter [
 
 ]
 
+{ #category : #deprecation }
+MultiByteBinaryOrTextStream class >> isDeprecated [
+	^true
+]
+
 { #category : #'instance creation' }
 MultiByteBinaryOrTextStream class >> on: aCollection encoding: encodingName [ 
 	| aTextConverter |

--- a/src/DeprecatedFileStream/RWBinaryOrTextStream.class.st
+++ b/src/DeprecatedFileStream/RWBinaryOrTextStream.class.st
@@ -12,6 +12,11 @@ Class {
 	#category : #DeprecatedFileStream
 }
 
+{ #category : #deprecation }
+RWBinaryOrTextStream class >> isDeprecated [
+	^true
+]
+
 { #category : #converting }
 RWBinaryOrTextStream >> asBinaryOrTextStream [
 

--- a/src/Ring-Deprecated-ChunkImporter/ManifestRingChunkImporter.class.st
+++ b/src/Ring-Deprecated-ChunkImporter/ManifestRingChunkImporter.class.st
@@ -4,6 +4,11 @@ Class {
 	#category : #'Ring-Deprecated-ChunkImporter'
 }
 
+{ #category : #deprecation }
+ManifestRingChunkImporter class >> isDeprecated [
+	^true
+]
+
 { #category : #'meta-data - dependency analyser' }
 ManifestRingChunkImporter class >> manuallyResolvedDependencies [
 	^ #(#'OpalCompiler-Core' #'FileSystem-Core' #'Collections-Abstract' #'Collections-Strings' #'System-Support')

--- a/src/Ring-Deprecated-ChunkImporter/RingChunkImporter.class.st
+++ b/src/Ring-Deprecated-ChunkImporter/RingChunkImporter.class.st
@@ -32,6 +32,11 @@ RingChunkImporter class >> fromStream: aStream [
 	^ self new fileInFrom: aStream; yourself
 ]
 
+{ #category : #deprecation }
+RingChunkImporter class >> isDeprecated [
+	^true
+]
+
 { #category : #private }
 RingChunkImporter >> classDefinition: aString with: chgRec [
 	| tokens theClass |

--- a/src/Ring-Deprecated-Core-Containers/ManifestRingCoreContainers.class.st
+++ b/src/Ring-Deprecated-Core-Containers/ManifestRingCoreContainers.class.st
@@ -4,6 +4,11 @@ Class {
 	#category : #'Ring-Deprecated-Core-Containers'
 }
 
+{ #category : #deprecation }
+ManifestRingCoreContainers class >> isDeprecated [
+	^true
+]
+
 { #category : #'meta-data - dependency analyser' }
 ManifestRingCoreContainers class >> manuallyResolvedDependencies [
 	^ #(#'Collections-Streams' #'Collections-Abstract' #'Collections-Strings' #'System-Support')

--- a/src/Ring-Deprecated-Core-Kernel/ManifestRingCoreKernel.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/ManifestRingCoreKernel.class.st
@@ -4,6 +4,11 @@ Class {
 	#category : #'Ring-Deprecated-Core-Kernel'
 }
 
+{ #category : #deprecation }
+ManifestRingCoreKernel class >> isDeprecated [
+	^true
+]
+
 { #category : #'meta-data - dependency analyser' }
 ManifestRingCoreKernel class >> manuallyResolvedDependencies [
 	^ #(#'Collections-Abstract' #'Collections-Strings' #'Collections-Streams' #'System-Sources')

--- a/src/Ring-Deprecated-Core-Kernel/RGDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGDefinition.class.st
@@ -24,6 +24,11 @@ RGDefinition class >> fullNameKey [
 	^#fullName
 ]
 
+{ #category : #deprecation }
+RGDefinition class >> isDeprecated [
+	^true
+]
+
 { #category : #'class initialization' }
 RGDefinition class >> named: aName [
 

--- a/src/Ring-Deprecated-Monticello/ManifestRingMonticello.class.st
+++ b/src/Ring-Deprecated-Monticello/ManifestRingMonticello.class.st
@@ -4,6 +4,11 @@ Class {
 	#category : #'Ring-Deprecated-Monticello'
 }
 
+{ #category : #deprecation }
+ManifestRingMonticello class >> isDeprecated [
+	^true
+]
+
 { #category : #'meta-data - dependency analyser' }
 ManifestRingMonticello class >> manuallyResolvedDependencies [
 	^ #(#'Collections-Streams' #'Collections-Abstract')

--- a/src/Ring-Deprecated-Tests-Containers/RGContainerTest.class.st
+++ b/src/Ring-Deprecated-Tests-Containers/RGContainerTest.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #TestCase,
 	#category : #'Ring-Deprecated-Tests-Containers'
 }
+
+{ #category : #deprecation }
+RGContainerTest class >> isDeprecated [
+	^true
+]

--- a/src/Ring-Deprecated-Tests-Containers/RGNamespaceTest.class.st
+++ b/src/Ring-Deprecated-Tests-Containers/RGNamespaceTest.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Ring-Deprecated-Tests-Containers'
 }
 
+{ #category : #deprecation }
+RGNamespaceTest class >> isDeprecated [
+	^true
+]
+
 { #category : #testing }
 RGNamespaceTest >> testCreatingNamespace [
 	| newNamespace newPackage newClass |

--- a/src/Ring-Deprecated-Tests-Containers/RGPackageTest.class.st
+++ b/src/Ring-Deprecated-Tests-Containers/RGPackageTest.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Ring-Deprecated-Tests-Containers'
 }
 
+{ #category : #deprecation }
+RGPackageTest class >> isDeprecated [
+	^true
+]
+
 { #category : #testing }
 RGPackageTest >> testAddingClass [
 	| newPackage newClass |

--- a/src/Ring-Deprecated-Tests-Containers/RGSliceTest.class.st
+++ b/src/Ring-Deprecated-Tests-Containers/RGSliceTest.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Ring-Deprecated-Tests-Containers'
 }
 
+{ #category : #deprecation }
+RGSliceTest class >> isDeprecated [
+	^true
+]
+
 { #category : #testing }
 RGSliceTest >> testAddingClasses [
 	| newSlice newClass newTrait  |

--- a/src/Ring-Deprecated-Tests-Kernel/RGClassDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGClassDefinitionTest.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Ring-Deprecated-Tests-Kernel'
 }
 
+{ #category : #deprecation }
+RGClassDefinitionTest class >> isDeprecated [
+	^true
+]
+
 { #category : #testing }
 RGClassDefinitionTest >> testAddingMethods [
 	| newMethod newClass |

--- a/src/Ring-Deprecated-Tests-Kernel/RGCommentDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGCommentDefinitionTest.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Ring-Deprecated-Tests-Kernel'
 }
 
+{ #category : #deprecation }
+RGCommentDefinitionTest class >> isDeprecated [
+	^true
+]
+
 { #category : #testing }
 RGCommentDefinitionTest >> testActiveComment [
 

--- a/src/Ring-Deprecated-Tests-Kernel/RGGlobalDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGGlobalDefinitionTest.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Ring-Deprecated-Tests-Kernel'
 }
 
+{ #category : #deprecation }
+RGGlobalDefinitionTest class >> isDeprecated [
+	^true
+]
+
 { #category : #testing }
 RGGlobalDefinitionTest >> testEquality [
 	| global1 global2 |

--- a/src/Ring-Deprecated-Tests-Kernel/RGMetaclassDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGMetaclassDefinitionTest.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Ring-Deprecated-Tests-Kernel'
 }
 
+{ #category : #deprecation }
+RGMetaclassDefinitionTest class >> isDeprecated [
+	^true
+]
+
 { #category : #testing }
 RGMetaclassDefinitionTest >> testAsMetaclassDefinition [
 	| rgClass class |

--- a/src/Ring-Deprecated-Tests-Kernel/RGMetatraitDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGMetatraitDefinitionTest.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Ring-Deprecated-Tests-Kernel'
 }
 
+{ #category : #deprecation }
+RGMetatraitDefinitionTest class >> isDeprecated [
+	^true
+]
+
 { #category : #testing }
 RGMetatraitDefinitionTest >> testAsClassTraitfinition [
 	| rgCTrait cTrait |

--- a/src/Ring-Deprecated-Tests-Kernel/RGMethodDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGMethodDefinitionTest.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Ring-Deprecated-Tests-Kernel'
 }
 
+{ #category : #deprecation }
+RGMethodDefinitionTest class >> isDeprecated [
+	^true
+]
+
 { #category : #running }
 RGMethodDefinitionTest >> runCase [
 

--- a/src/Ring-Deprecated-Tests-Kernel/RGTraitDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGTraitDefinitionTest.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Ring-Deprecated-Tests-Kernel'
 }
 
+{ #category : #deprecation }
+RGTraitDefinitionTest class >> isDeprecated [
+	^true
+]
+
 { #category : #testing }
 RGTraitDefinitionTest >> testAddingMethods [
 	| newMethod newClass |

--- a/src/Ring-Deprecated-Tests-Kernel/RGVariableDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGVariableDefinitionTest.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Ring-Deprecated-Tests-Kernel'
 }
 
+{ #category : #deprecation }
+RGVariableDefinitionTest class >> isDeprecated [
+	^true
+]
+
 { #category : #testing }
 RGVariableDefinitionTest >> testClassInstanceVariable [
 	| instVar newClass metaClass |

--- a/src/Ring-Deprecated-Tests-Monticello/RGMonticelloTest.class.st
+++ b/src/Ring-Deprecated-Tests-Monticello/RGMonticelloTest.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Ring-Deprecated-Tests-Monticello'
 }
 
+{ #category : #deprecation }
+RGMonticelloTest class >> isDeprecated [
+	^true
+]
+
 { #category : #testing }
 RGMonticelloTest >> testAsMCMethodDefinition [
 	

--- a/src/Spec-Deprecated/AbstractFormButtonModel.class.st
+++ b/src/Spec-Deprecated/AbstractFormButtonModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #AbstractFormButtonPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+AbstractFormButtonModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/AbstractWidgetModel.class.st
+++ b/src/Spec-Deprecated/AbstractWidgetModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #AbstractWidgetPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+AbstractWidgetModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/ButtonModel.class.st
+++ b/src/Spec-Deprecated/ButtonModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #ButtonPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+ButtonModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/CheckBoxModel.class.st
+++ b/src/Spec-Deprecated/CheckBoxModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #CheckBoxPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+CheckBoxModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/ComposableModel.class.st
+++ b/src/Spec-Deprecated/ComposableModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #ComposablePresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+ComposableModel class >> isDeprecated [
+	^self name = 'ComposableModel' "to avoid referencing itself"
+]

--- a/src/Spec-Deprecated/ContainerModel.class.st
+++ b/src/Spec-Deprecated/ContainerModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #ContainerPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+ContainerModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/DateModel.class.st
+++ b/src/Spec-Deprecated/DateModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #DatePresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+DateModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/DialogWindowModel.class.st
+++ b/src/Spec-Deprecated/DialogWindowModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #DialogWindowPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+DialogWindowModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/DiffModel.class.st
+++ b/src/Spec-Deprecated/DiffModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #DiffPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+DiffModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/DropListModel.class.st
+++ b/src/Spec-Deprecated/DropListModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #DropListPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+DropListModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/DynamicComposableModel.class.st
+++ b/src/Spec-Deprecated/DynamicComposableModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #DynamicComposablePresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+DynamicComposableModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/FastTableModel.class.st
+++ b/src/Spec-Deprecated/FastTableModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #FastTablePresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+FastTableModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/IconListModel.class.st
+++ b/src/Spec-Deprecated/IconListModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #IconListPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+IconListModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/ImageModel.class.st
+++ b/src/Spec-Deprecated/ImageModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #ImagePresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+ImageModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/LabelModel.class.st
+++ b/src/Spec-Deprecated/LabelModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #LabelPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+LabelModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/ListModel.class.st
+++ b/src/Spec-Deprecated/ListModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #ListPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+ListModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/MenuGroupModel.class.st
+++ b/src/Spec-Deprecated/MenuGroupModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #MenuGroupPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+MenuGroupModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/MenuItemModel.class.st
+++ b/src/Spec-Deprecated/MenuItemModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #MenuItemPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+MenuItemModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/MenuModel.class.st
+++ b/src/Spec-Deprecated/MenuModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #MenuPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+MenuModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/MultiColumnListModel.class.st
+++ b/src/Spec-Deprecated/MultiColumnListModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #MultiColumnListPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+MultiColumnListModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/PickListModel.class.st
+++ b/src/Spec-Deprecated/PickListModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #PickListPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+PickListModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/RadioButtonGroupModel.class.st
+++ b/src/Spec-Deprecated/RadioButtonGroupModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #RadioButtonGroupPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+RadioButtonGroupModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/RadioButtonModel.class.st
+++ b/src/Spec-Deprecated/RadioButtonModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #RadioButtonPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+RadioButtonModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/SliderModel.class.st
+++ b/src/Spec-Deprecated/SliderModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #SliderPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+SliderModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/TabManagerModel.class.st
+++ b/src/Spec-Deprecated/TabManagerModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #TabManagerPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+TabManagerModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/TabModel.class.st
+++ b/src/Spec-Deprecated/TabModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #TabPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+TabModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/TableContainerModel.class.st
+++ b/src/Spec-Deprecated/TableContainerModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #TableContainerPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+TableContainerModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/TextInputFieldModel.class.st
+++ b/src/Spec-Deprecated/TextInputFieldModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #TextInputFieldPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+TextInputFieldModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/TextModel.class.st
+++ b/src/Spec-Deprecated/TextModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #TextPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+TextModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/TickingWindowModel.class.st
+++ b/src/Spec-Deprecated/TickingWindowModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #TickingWindowPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+TickingWindowModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/TransferModel.class.st
+++ b/src/Spec-Deprecated/TransferModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #TransferPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+TransferModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/TreeColumnModel.class.st
+++ b/src/Spec-Deprecated/TreeColumnModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #TreeColumnPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+TreeColumnModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/TreeModel.class.st
+++ b/src/Spec-Deprecated/TreeModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #TreePresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+TreeModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/TreeNodeModel.class.st
+++ b/src/Spec-Deprecated/TreeNodeModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #TreeNodePresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+TreeNodeModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/WindowModel.class.st
+++ b/src/Spec-Deprecated/WindowModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #WindowPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+WindowModel class >> isDeprecated [
+	^true
+]

--- a/src/Spec-Deprecated/WorldModel.class.st
+++ b/src/Spec-Deprecated/WorldModel.class.st
@@ -6,3 +6,8 @@ Class {
 	#superclass : #WorldPresenter,
 	#category : #'Spec-Deprecated'
 }
+
+{ #category : #deprecation }
+WorldModel class >> isDeprecated [
+	^true
+]


### PR DESCRIPTION
isDeprecated is added to all classes in deprecated packages.
For ring it is just in base class by returning true.
For the rest which are not supposed to be subclasses it is also simple true.
For ComposableModel it returing self name = 'ComposableModel' to prevent referencing class itself which will complecates deprecation refactoring.https://pharo.fogbugz.com/f/cases/21668/Mark-deprecated-classes-as-deprecated