### PR TITLE
21669-Style-deprecated-classes-in-source-code

### DIFF
--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -173,6 +173,18 @@ SHRBTextStyler >> resolveTextLinkFor: aVariableNode [
 ]
 
 { #category : #private }
+SHRBTextStyler >> resolveVariableAttributesFor: aVariableNode [
+	| textLink global |
+	textLink := self resolveTextLinkFor: aVariableNode.
+	aVariableNode binding isGlobalVariable ifFalse: [ ^{textLink}] .
+	
+	global :=	aVariableNode binding value.
+	(global isClass and: [ global isDeprecated ]) ifFalse: [ ^{textLink} ].
+	
+	^{textLink. TextEmphasis struckOut}
+]
+
+{ #category : #private }
 SHRBTextStyler >> style: aText ast: ast [
 	text := aText.	
 	charAttr := Array new: aText size withAll: (self attributesFor: #default).
@@ -427,7 +439,7 @@ SHRBTextStyler >> visitThisContextNode: aThisContextNode [
 SHRBTextStyler >> visitVariableNode: aVariableNode [
 	self 
 		addStyle: (self resolveStyleFor: aVariableNode) 
-		attribute: (self resolveTextLinkFor:aVariableNode)
+		attributes: (self resolveVariableAttributesFor: aVariableNode)
 		forNode: aVariableNode.
 	
 	


### PR DESCRIPTION
visitVariableNode: is modified to apply moltiple additional attributes.
Before it was only text link for variable. Not it also analyses deprecated class it is class reference and style it with struckOut emphasis.https://pharo.fogbugz.com/f/cases/21669/Style-deprecated-classes-in-source-code