### PR TITLE
Fix Case 17626 - FS: #, should not resolve

### DIFF
--- a/src/FileSystem-Core/AbstractFileReference.class.st
+++ b/src/FileSystem-Core/AbstractFileReference.class.st
@@ -8,8 +8,8 @@ Class {
 }
 
 { #category : #copying }
-AbstractFileReference >> , extension [
-	^ self resolve, extension
+AbstractFileReference >> , extensionString [
+	^ self withExtension: extensionString
 ]
 
 { #category : #navigating }

--- a/src/FileSystem-Core/AbstractFileReference.class.st
+++ b/src/FileSystem-Core/AbstractFileReference.class.st
@@ -7,9 +7,9 @@ Class {
 	#category : #'FileSystem-Core-Public'
 }
 
-{ #category : #copying }
-AbstractFileReference >> , extensionString [
-	^ self withExtension: extensionString
+{ #category : #navigating }
+AbstractFileReference >> , extension [
+	^ self withPath: self path, extension
 ]
 
 { #category : #navigating }

--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -44,11 +44,6 @@ FileReference class >> newTempFilePrefix: prefix suffix: suffix [
 	^ tmpDir / fileName
 ]
 
-{ #category : #navigating }
-FileReference >> , extension [
-	^ self withPath: self path, extension
-]
-
 { #category : #comparing }
 FileReference >> = other [
 	"Two FileReferences are considered equal if they refer to the same file / directory.


### PR DESCRIPTION
`aFileLocator, 'jpg'` currently returns aFileReference, but should return aFileLocator with extension appended. 

In the case, some philosophical issues have been raised about FS in general, but they don't seem to have to do with this issue per se. There is a fix which provides "better" behavior. Let's not let "best" be its enemy and discuss these higher level points either in a new issue or on the ML.