### PR TITLE
21670-FileReference-GT-Contents-Inspector-causes-DNU-binary

### DIFF
--- a/src/FileSystem-Core/AbstractFileReference.class.st
+++ b/src/FileSystem-Core/AbstractFileReference.class.st
@@ -496,6 +496,51 @@ AbstractFileReference >> hash [
 	^ self path  hash
 ]
 
+{ #category : #private }
+AbstractFileReference >> hexDump: buffer on: aStream max: maxBytes [
+	"Print a hex dump of the receiver on the supplied stream, up to maxBytes long"
+
+	| ch i string remainder |
+
+	i := 0.
+	buffer readStreamDo: [ :stream |
+		ch := stream next.
+		[ch notNil and: [ i < maxBytes ]] whileTrue: [ 
+			remainder := i \\ 16.
+			remainder = 0 ifTrue: [ 
+				i = 0 ifFalse: [ aStream cr ].
+				aStream 
+					<< (i printPaddedWith: $0 to: 8 base: 16);
+					<< '  '.
+				string := String new writeStream ].
+			aStream
+				<< (ch printPaddedWith: $0 to: 2 base: 16);
+				<< ' '.
+			ch := Character value: ch.
+			ch isAlphaNumeric ifTrue: 
+				[ string nextPut: ch ]
+			ifFalse:
+				[ string nextPut: $. ].
+			remainder = 15 ifTrue: [ 
+				aStream
+					<< '  |';
+					<< string contents;
+					<< '|' ].
+			ch := stream next.
+			i := i + 1 ].
+		remainder := i \\ 16.
+		(ch isNil and: [remainder between: 1 and: 14]) ifTrue: [ 
+			(16 - remainder) timesRepeat: [ aStream nextPutAll: '   ' ].
+			aStream
+				<< '  |';
+				<< string contents.
+			(16 - remainder timesRepeat: [ aStream nextPut: Character space ]).
+			aStream
+				<< '|' ].
+		aStream cr ].
+
+]
+
 { #category : #accessing }
 AbstractFileReference >> humanReadableSize [
 	^ self size humanReadableSIByteSize

--- a/src/FileSystem-Tests-Core/AbstractFileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/AbstractFileReferenceTest.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #AbstractFileReferenceTest,
+	#superclass : #TestCase,
+	#type : #variable,
+	#category : #'FileSystem-Tests-Core'
+}
+
+{ #category : #tests }
+AbstractFileReferenceTest >> testHexDumponmax [
+
+	| source display expected |
+
+	source := '01234567890123456789'.
+	display := String streamContents: [ :stream |
+		'.' asFileReference hexDump: source asByteArray on: stream max: 1000 ].
+	expected := '00000000  30 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35   |0123456789012345|
+00000010  36 37 38 39                                       |6789            |
+'.
+	self assert: display equals: expected
+]

--- a/src/GT-InspectorExtensions-Core/AbstractFileReference.extension.st
+++ b/src/GT-InspectorExtensions-Core/AbstractFileReference.extension.st
@@ -18,15 +18,31 @@ AbstractFileReference >> gtInspectorContentsIn: composite [
 	<gtInspectorPresentationOrder: 5>
 	composite text
 			title: 'Contents';
-			display: [ 
-				self readStreamDo: [ :stream | 
-					| result |
-					result := [(stream next: 10000) asString]
-						on: Error 
-						do: [ (stream binary next: 10000) asString ].
-					stream size > 10000
-						ifTrue: [ result, '  ... truncated ...' ]
-						ifFalse: [ result ] ] ];
+			format: #asText;
+			display: [ | maxBytes buffer atEnd stringContents displayStream displayString |
+				maxBytes := 10000.
+				self binaryReadStreamDo: [ :stream | 
+					buffer := stream next: maxBytes.
+					atEnd := stream atEnd ].
+				"Separate out the utf8 decoding and error handling so we can use the hex dump stream to add the truncated message"
+				stringContents := [ ZnCharacterEncoder utf8 decodeBytes: buffer ]
+							on: Error 
+							do: [ nil ].
+				stringContents ifNotNil: [ 
+					displayString := atEnd ifTrue: 
+						[ stringContents ]
+					ifFalse:
+						[ stringContents, '  ... truncated ...' ] ]
+				ifNil: [ 
+					displayStream := (String new: maxBytes * 5) writeStream.
+					self hexDump: buffer on: displayStream max: maxBytes.
+					atEnd ifFalse: [ displayStream nextPutAll: '  ... truncated ...' ].
+					displayString := displayStream contents asText.
+					displayString addAttribute: (TextFontReference
+						toFont: (LogicalFont 
+							familyName: 'Source Code Pro' 
+							pointSize: StandardFonts defaultFont pointSize)) ].
+				displayString asText ];
 			withLineNumbers: true;
 			act: [ :text |
 				self ensureDelete; writeStreamDo: [ :s | s nextPutAll: text text asString ] ]


### PR DESCRIPTION
21670 FileReference GT Contents Inspector causes DNU #binary

Update AbstractFileReference>>gtInspectorContentsIn: to work with Zinc file streams and display a /usr/bin/hd style dump of binary files (i.e. not UTF-8 encoded).Fogbugz: https://pharo.fogbugz.com/f/cases/21670/