### PR TITLE
21675-Zinc-uses-atEnd-incorrectly-still

### DIFF
--- a/src/Zinc-Character-Encoding-Core/ZnCharacterEncoder.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnCharacterEncoder.class.st
@@ -258,8 +258,10 @@ ZnCharacterEncoder >> nextFromStream: stream [
 	"Read and return the next character from stream"
 	
 	"We should use #codePoint: but #value: is faster"
-	
-	^ Character value: (self nextCodePointFromStream: stream)
+
+	| codePoint |
+	codePoint := self nextCodePointFromStream: stream.
+	^ codePoint ifNotNil: [ Character value: codePoint ]
 ]
 
 { #category : #converting }

--- a/src/Zinc-Character-Encoding-Core/ZnEncodedReadStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnEncodedReadStream.class.st
@@ -38,8 +38,7 @@ ZnEncodedReadStream >> isReadOnly [
 { #category : #accessing }
 ZnEncodedReadStream >> next [
 	^ peeked
-		ifNil: [ 
-			stream atEnd ifFalse: [ self nextElement ] ]
+		ifNil: [ self nextElement ]
 		ifNotNil: [ | character |
 			character := peeked.
 			peeked := nil.
@@ -153,6 +152,8 @@ ZnEncodedReadStream >> upTo: anObject [
 { #category : #accessing }
 ZnEncodedReadStream >> upToEnd [
 	^ self collectionSpecies
-		streamContents: [ :collectionStream | 
-			[ self atEnd ] whileFalse: [ collectionStream nextPut: self next ] ]
+		streamContents: [ :collectionStream | | element |
+			[ (element := self next) ] whileNotNil: 
+				[ collectionStream nextPut: element ].
+			self atEnd ifFalse: [ self error: 'Error while reading stream' ] ]
 ]

--- a/src/Zinc-Character-Encoding-Core/ZnSimplifiedByteEncoder.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnSimplifiedByteEncoder.class.st
@@ -232,7 +232,8 @@ ZnSimplifiedByteEncoder >> nextCodePointFromStream: stream [
 	"In non-strict mode, we let byte values for holes in our mapping pass through"
 
 	| byteValue |
-	^ (byteValue := stream next) < 128
+	(byteValue := stream next) ifNil: [ ^nil ].
+	^byteValue < 128
 		ifTrue: [ byteValue ]
 		ifFalse: [ 
 			(byteToUnicode at: byteValue - 127 ifAbsent: [ nil ])

--- a/src/Zinc-Character-Encoding-Core/ZnUTF16Encoder.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnUTF16Encoder.class.st
@@ -71,6 +71,7 @@ ZnUTF16Encoder >> nextCodePointFromStream: stream [
 
 	| word leadSurrogate trailSurrogate code |
 	word := self read16BitWordFromStream: stream.
+	word ifNil: [ ^nil ].
 	(self processByteOrderMark: word)
 		ifTrue: [ word := self read16BitWordFromStream: stream ].
 	^ (word < 16rD800 or: [ word > 16rDBFF ])
@@ -117,9 +118,9 @@ ZnUTF16Encoder >> processByteOrderMark: word [
 ZnUTF16Encoder >> read16BitWordFromStream: stream [
 	| firstByte secondByte |
 	firstByte := stream next.
+	firstByte ifNil: [ ^nil ].
 	secondByte := stream next.
-	(firstByte isNil or: [ secondByte isNil ])
-		ifTrue: [ self errorIncomplete ].
+	secondByte ifNil: [ self errorIncomplete ].
 	^ self isBigEndian 
 		ifTrue: [ secondByte + (firstByte << 8) ]
 		ifFalse: [ firstByte + (secondByte << 8) ]

--- a/src/Zinc-Character-Encoding-Core/ZnUTF32Encoder.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnUTF32Encoder.class.st
@@ -59,6 +59,7 @@ ZnUTF32Encoder >> nextCodePointFromStream: stream [
 
 	| codePoint |
 	codePoint := self readCodePointFrom: stream.
+	codePoint ifNil: [ ^nil ].
 	(self processByteOrderMark: codePoint)
 		ifTrue: [ codePoint := self readCodePointFrom: stream ].
 	((self isSurrogateCodePoint: codePoint) or: [ codePoint > self maximumUTFCode ]) 
@@ -93,10 +94,11 @@ ZnUTF32Encoder >> processByteOrderMark: codePoint [
 ZnUTF32Encoder >> readCodePointFrom: stream [
 	| byte1 byte2 byte3 byte4 |
 	byte1 := stream next.
+	byte1 ifNil: [ ^nil ].
 	byte2 := stream next.
 	byte3 := stream next.
 	byte4 := stream next.
-	(byte1 isNil or: [ byte2 isNil or: [ byte3 isNil or: [ byte4 isNil ] ] ])
+	(byte2 isNil or: [ byte3 isNil or: [ byte4 isNil ] ])
 		ifTrue: [ self errorIncomplete ].
 	^ self isBigEndian
 		ifTrue: [ 

--- a/src/Zinc-Character-Encoding-Core/ZnUTF8Encoder.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnUTF8Encoder.class.st
@@ -171,7 +171,7 @@ ZnUTF8Encoder >> nextCodePointFromStream: stream [
 	"Read and return the next integer code point from stream"
 
 	| code byte next |
-	(byte := stream next) < 128
+	((byte := stream next) isNil or: [ byte < 128 ])
 		ifTrue: [ ^ byte ].
 	(byte bitAnd: 2r11100000) == 2r11000000
 		ifTrue: [ 


### PR DESCRIPTION
21675-Zinc-uses-atEnd-incorrectly-still

Update the Zinc libraries to check that the end of a stream has been reached by reading from the stream, not using #atEnd.

Fogbugz: https://pharo.fogbugz.com/f/cases/21675/Zinc-uses-atEnd-incorrectly-still