### PR TITLE
21682-DropListPresenter-ignores-disable-before-it-is-built

### DIFF
--- a/src/Spec-Examples/DropListExample.class.st
+++ b/src/Spec-Examples/DropListExample.class.st
@@ -12,20 +12,22 @@ Class {
 		'morph2',
 		'morph3',
 		'uniformDropList',
-		'heterogeneousDropList'
+		'heterogeneousDropList',
+		'disabledDropList'
 	],
 	#category : #'Spec-Examples-Morphic'
 }
 
 { #category : #specs }
 DropListExample class >> defaultSpec [
-
-	^ { #ContainerPresenter.
-			#add:.	{ self topSpec . #layout: . #(#SpecLayoutFrame
-													bottomFraction: 0
-													bottomOffset: 30) }.
-			#add:.	{{#model . #container } . #layout: .  #(#SpecLayoutFrame
-													topOffset: 42). }}
+	^ SpecColumnLayout composed
+		newRow: [ :r | 
+			r
+				add: #uniformDropList;
+				add: #heterogeneousDropList ]
+			height: self toolbarHeight;
+		newRow: [ :r | r add: #disabledDropList ] height: self toolbarHeight;
+		newRow: [ :r | r add: #container ] yourself
 ]
 
 { #category : #example }
@@ -41,21 +43,16 @@ DropListExample class >> title [
 	^ 'Drop list'
 ]
 
-{ #category : #specs }
-DropListExample class >> topSpec [
-
-	^ SpecLayout composed
-		newRow: [ :r |
-			r 
-				add: #uniformDropList;
-				add: #heterogeneousDropList ];
-		yourself
-]
-
 { #category : #accessing }
 DropListExample >> container [
 
 	^ container asSpecAdapter
+]
+
+{ #category : #accessing }
+DropListExample >> disabledDropList [
+
+	^ disabledDropList
 ]
 
 { #category : #accessing }
@@ -81,6 +78,10 @@ DropListExample >> initialize [
 DropListExample >> initializeWidgets [
 	uniformDropList := self newDropList.
 	heterogeneousDropList := self newDropList.
+	(disabledDropList := self newDropList)
+		items: #('Disabled' 'Two' 'Three');
+		displayBlock: [ :each | each ];
+		disable.
 	uniformDropList
 		items:
 			{morph1.
@@ -129,7 +130,8 @@ DropListExample >> setFocus [
 	
 	self focusOrder
 		add: uniformDropList;
-		add: heterogeneousDropList.
+		add: heterogeneousDropList;
+		add: disabledDropList.
 	
 ]
 

--- a/src/Spec-MorphicAdapters/MorphicDropListAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicDropListAdapter.class.st
@@ -9,14 +9,14 @@ Class {
 
 { #category : #factory }
 MorphicDropListAdapter >> buildWidget [
-
 	^ SpecDropListMorph new
-		wrapSelector:	 #wrap:withIndex:; 
-	    	on: self list: #getList selected: #getIndex changeSelected: #setIndex:;
-		hResizing: #spaceFill ;
-		vResizing: #spaceFill ;
+		wrapSelector: #wrap:withIndex:;
+		on: self list: #getList selected: #getIndex 	changeSelected: #setIndex:;
+		hResizing: #spaceFill;
+		vResizing: #spaceFill;
 		dragEnabled: self dragEnabled;
-		dropEnabled: self dropEnabled;	
+		dropEnabled: self dropEnabled;
+		enabled: self enabled;
 		setBalloonText: self help;
 		yourself
 ]


### PR DESCRIPTION
Provide #enabled information to DropListMorph during initial spec building.
Added disabled DropListExample and simplified the layout.