### PR TITLE
21687-make-a-deprecated-Key-as-subclass-of-KeyboardKey

### DIFF
--- a/src/Deprecated70/InputEventHandler.extension.st
+++ b/src/Deprecated70/InputEventHandler.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #InputEventHandler }
 
-{ #category : #'*Deprecated70' } 
+{ #category : #'*Deprecated70' }
 InputEventHandler >> isKbdEvent: bufEvt [
 	
 	self

--- a/src/Deprecated70/Key.class.st
+++ b/src/Deprecated70/Key.class.st
@@ -1,0 +1,10 @@
+"
+This class is deprecated. Use the class KeyboardKey instead of me.
+
+I represent a keyboard Key. I am mapped from the platform specific keycodes into a common keycode base, by using my class side methods.
+"
+Class {
+	#name : #Key,
+	#superclass : #KeyboardKey,
+	#category : #Deprecated70
+}


### PR DESCRIPTION
make Key as deprecated subclass of KeyboardKeyhttps://pharo.fogbugz.com/f/cases/21687/make-a-deprecated-Key-as-subclass-of-KeyboardKey