### PR TITLE
21692-StdioStream-incorrectly-delegates-atEnd-and-position-to-file

### DIFF
--- a/src/Files-Tests/StdioStreamTest.class.st
+++ b/src/Files-Tests/StdioStreamTest.class.st
@@ -1,0 +1,145 @@
+"
+Automated tests for StdioStream
+
+
+Public API and Key Messages
+
+- StdioStreamTest is a subclass of TestCase and has the same public api
+ 
+Internal Representation and Key Implementation Points.
+
+StdioStreamTest relies on a test stream constructed by StdioStreamTestResource.
+"
+Class {
+	#name : #StdioStreamTest,
+	#superclass : #TestCase,
+	#category : #'Files-Tests'
+}
+
+{ #category : #'tests-manual' }
+StdioStreamTest class >> manualStdinTest [
+	"This test can be run headless to manually to check actual stdin.
+	It reads the input and confirms that #atEnd answers as expected and the number of characters read.
+	
+	Example execution (from the shell prompt):
+
+		echo 'hello world' | pharo --headless Pharo.image eval 'StdioStreamTest manualStdinTest'
+		
+		pharo --headless Pharo.image eval 'StdioStreamTest manualStdinTest' < /proc/cpuinfo
+		
+		pharo --headless Pharo.image eval 'StdioStreamTest manualStdinTest'
+		# Type some text, enter and Ctrl-D"
+
+	| stdin stdout atEndBefore atEndAfter contents |
+
+	stdin := Stdio stdin.
+	stdout := ZnNewLineWriterStream on: Stdio stdout.
+	atEndBefore := stdin atEnd.
+	contents := stdin upToEnd.
+	atEndAfter := stdin atEnd.
+	stdout
+		<< '#atEnd (before): ';
+		<< atEndBefore displayString;
+		cr;
+		<< '#atEnd (after): ';
+		<< atEndAfter displayString;
+		cr;
+		<< 'Size: ';
+		<< contents size displayString;
+		cr;
+		<< 'Contents:';
+		cr; cr.
+	contents hexDumpOn: stdout max: 128.
+	stdout cr.
+	SmalltalkImage current snapshot: false andQuit: true.
+]
+
+{ #category : #accessing }
+StdioStreamTest class >> resources [
+
+	^{ StdioStreamTestResource }.
+]
+
+{ #category : #accessing }
+StdioStreamTest >> resource [
+	"Answer the receiver's resource object"
+
+	^StdioStreamTestResource current
+]
+
+{ #category : #running }
+StdioStreamTest >> setUp [
+	"A stream is shared amongst all the tests to reduce file create, write, delete cycles.
+	Ensure the stream is in the expected state."
+
+	super setUp.
+	self resource stdioStream position: 0.
+]
+
+{ #category : #accessing }
+StdioStreamTest >> stdioStream [
+
+	^self resource stdioStream
+]
+
+{ #category : #tests }
+StdioStreamTest >> testAtEnd [
+	"Test that #atEnd isn't incorrectly answering true"
+
+	self deny: self stdioStream atEnd
+]
+
+{ #category : #tests }
+StdioStreamTest >> testChangePosition [
+	"The shared stream should be put back to the start for each test"
+
+	| stream |
+	
+	stream := self stdioStream.
+	stream position: 5.
+	self assert: stream position equals: 5.
+	self assert: stream next equals: $5 asciiValue.
+]
+
+{ #category : #tests }
+StdioStreamTest >> testContents [
+
+	self assert: self stdioStream contents equals: self resource contents asByteArray
+]
+
+{ #category : #tests }
+StdioStreamTest >> testPeek [
+
+	| stream |
+
+	stream := self stdioStream.
+	self assert: stream peek equals: $0 asciiValue.
+	self assert: stream peek equals: stream next.
+]
+
+{ #category : #tests }
+StdioStreamTest >> testPosition [
+	"The shared stream should be put back to the start for each test"
+	
+	self assert: self stdioStream position equals: 0.
+]
+
+{ #category : #tests }
+StdioStreamTest >> testSize [
+
+	self assert: self stdioStream size equals: self resource contents size
+]
+
+{ #category : #tests }
+StdioStreamTest >> testUpToEnd [
+
+	| stream contents |
+
+	stream := self stdioStream.
+	contents := self resource contents.
+	"Position stream (zero based)"
+	stream position: 5.
+	"Copy from contents (one based)"
+	self assert: stream upToEnd 
+		equals: (contents copyFrom: 6 to: contents size) asByteArray
+]

--- a/src/Files-Tests/StdioStreamTestResource.class.st
+++ b/src/Files-Tests/StdioStreamTestResource.class.st
@@ -1,0 +1,85 @@
+"
+StdioStreamTestResource provides a StdioStream to test for StdioStreamTest.
+
+As redirecting stdio during testing isn't practical a normal file is opened and an instance StdioStream attached to it.  This provides the same result as: 
+
+	pharo test.image < tmpfile.binary 
+	pharo test.image > tmpfile.binary
+
+StdioStreams normally cannot be both read and written, and the tests must take that into account.
+
+Public API and Key Messages
+
+- message one   
+- message two 
+- (for bonus points) how to create instances.
+
+   One simple example is simply gorgeous.
+ 
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	fileReference:		<Object>
+	stdioStream:		<Object>
+
+
+    Implementation Points
+"
+Class {
+	#name : #StdioStreamTestResource,
+	#superclass : #TestResource,
+	#instVars : [
+		'fileReference',
+		'contents',
+		'fileStream',
+		'stdioStream'
+	],
+	#category : #'Files-Tests'
+}
+
+{ #category : #accessing }
+StdioStreamTestResource >> contents [
+	^ contents
+]
+
+{ #category : #accessing }
+StdioStreamTestResource >> fileReference [
+	^ fileReference
+]
+
+{ #category : #accessing }
+StdioStreamTestResource >> fileStream [
+	^ fileStream
+]
+
+{ #category : #running }
+StdioStreamTestResource >> setUp [
+	"Create the temporary file and StdioStream"
+
+	| handle |
+
+	fileReference := FileReference newTempFilePrefix: 'StdioStreamTest.' suffix: '.bin'.
+	contents := '01234567890123456789'.
+	fileStream := fileReference binaryWriteStream wrappedStream.
+	fileStream
+		nextPutAll: contents;
+		position: 0.
+	"NOTE: This makes assumptions about the internal structure of BinaryFileStream.
+	This shouldn't be done in general."
+	handle := fileStream instVarNamed: 'handle'.
+	stdioStream := StdioStream handle: handle file: (File named: #stdio) forWrite: true.
+]
+
+{ #category : #accessing }
+StdioStreamTestResource >> stdioStream [
+	^ stdioStream
+]
+
+{ #category : #running }
+StdioStreamTestResource >> tearDown [
+	"Close the receiver's resources"
+	
+	stdioStream := nil.
+	fileStream close.
+	fileReference ensureDelete.
+]

--- a/src/Files/AbstractBinaryFileStream.class.st
+++ b/src/Files/AbstractBinaryFileStream.class.st
@@ -50,6 +50,27 @@ AbstractBinaryFileStream class >> handle: aCollection file: aFile forWrite: aTru
 		yourself
 ]
 
+{ #category : #testing }
+AbstractBinaryFileStream >> atEnd [
+
+	^ self primAtEnd: handle
+]
+
+{ #category : #accessing }
+AbstractBinaryFileStream >> contents [
+	"Answer the contents of the receiver while leaving the position unchanged.
+	Fail if the receiver doesn't support positioning.
+	#upToEnd provides an alternative that doesn't rely on stream positioning."
+
+	| savedPosition contents |
+
+	savedPosition := self position.
+	self position: 0.
+	contents := self upToEnd.
+	self position: savedPosition.
+	^contents
+]
+
 { #category : #'character writing' }
 AbstractBinaryFileStream >> cr [
 	
@@ -71,6 +92,15 @@ AbstractBinaryFileStream >> file [
 AbstractBinaryFileStream >> file: aFile [ 
 	
 	file := aFile
+]
+
+{ #category : #flushing }
+AbstractBinaryFileStream >> flush [
+	"When writing, this flushes the write buffer the stream uses to reduce
+	the number of write() system calls it makes. This should generally be
+	used before #sync, but on Windows they do the same thing."
+	
+	self primFlush: handle
 ]
 
 { #category : #initialization }
@@ -193,7 +223,22 @@ AbstractBinaryFileStream >> peek [
 { #category : #positioning }
 AbstractBinaryFileStream >> position [
 
-	self subclassResponsibility
+	^ self primGetPosition: handle
+]
+
+{ #category : #positioning }
+AbstractBinaryFileStream >> position: aPosition [
+	
+	self primSetPosition: handle to: aPosition
+]
+
+{ #category : #private }
+AbstractBinaryFileStream >> primAtEnd: id [
+	"Answer true if the file position is at the end of the file."
+
+	<primitive: 'primitiveFileAtEnd' module: 'FilePlugin'>
+	self primitiveFailed
+
 ]
 
 { #category : #private }
@@ -210,12 +255,48 @@ AbstractBinaryFileStream >> primFlush: id [
 ]
 
 { #category : #private }
+AbstractBinaryFileStream >> primGetPosition: id [
+	"Get this files current position."
+
+	<primitive: 'primitiveFileGetPosition' module: 'FilePlugin'>
+	self primitiveFailed
+
+]
+
+{ #category : #private }
 AbstractBinaryFileStream >> primRead: id into: byteArray startingAt: startIndex count: count [
 	"Read up to count bytes of data from this file into the given string or byte array starting at the given index. Answer the number of bytes actually read."
 
 	<primitive: 'primitiveFileRead' module: 'FilePlugin'>
 	self closed ifTrue: [^ self error: 'File is closed'].
 	self error: 'File read failed'.
+
+]
+
+{ #category : #private }
+AbstractBinaryFileStream >> primSetPosition: id to: anInteger [
+	"Set this file to the given position."
+
+	<primitive: 'primitiveFileSetPosition' module: 'FilePlugin'>
+	self primitiveFailed
+
+]
+
+{ #category : #private }
+AbstractBinaryFileStream >> primSize: id [
+	"Answer the size of this file."
+
+	<primitive: 'primitiveFileSize' module: 'FilePlugin'>
+	self primitiveFailed
+
+]
+
+{ #category : #private }
+AbstractBinaryFileStream >> primSizeNoError: id [
+	"Answer the size of this file. Answer nil if the primitive fails; this indicates that the file handle has become stale."
+
+	<primitive: 'primitiveFileSize' module: 'FilePlugin'>
+	^ nil
 
 ]
 
@@ -267,11 +348,37 @@ AbstractBinaryFileStream >> readInto: readBuffer startingAt: startIndex count: c
 ]
 
 { #category : #positioning }
+AbstractBinaryFileStream >> reset [
+	self position: 0
+]
+
+{ #category : #positioning }
+AbstractBinaryFileStream >> setToEnd [
+	
+	self position: self size
+]
+
+{ #category : #accessing }
+AbstractBinaryFileStream >> size [
+
+	^ self primSize: handle
+]
+
+{ #category : #positioning }
 AbstractBinaryFileStream >> skip: n [
 	"Set the character position to n characters from the current position.
 	Error if not enough characters left in the file.
 	By default we read n characters and we avoid reading the output"
 	self next: n
+]
+
+{ #category : #flushing }
+AbstractBinaryFileStream >> sync [	
+	"When writing, this syncs any written/flushed data still in the kernel
+	file system buffers to disk. This should generally be used after #flush,
+	but on Windows they do the same thing."
+
+	self primSync: handle
 ]
 
 { #category : #accessing }
@@ -286,4 +393,14 @@ AbstractBinaryFileStream >> upToAnyOf: delimiters [
 	^ ByteArray new: 1000 streamContents: [ :stream | | ch |
 		[ (ch := self next) isNil or: [ delimiters includes: ch] ] 
 			whileFalse: [ stream nextPut: ch ] ]
+]
+
+{ #category : #accessing }
+AbstractBinaryFileStream >> upToEnd [
+	"Answer a subcollection from the current access position through the last element of the receiver."
+
+	^ByteArray streamContents: [ :newStream |
+		| next |
+		[ (next := self next) isNil ] whileFalse: [
+			newStream nextPut: next ] ]
 ]

--- a/src/Files/BinaryFileStream.class.st
+++ b/src/Files/BinaryFileStream.class.st
@@ -12,12 +12,6 @@ Class {
 	#category : #'Files-Streams'
 }
 
-{ #category : #testing }
-BinaryFileStream >> atEnd [
-
-	^ self primAtEnd: handle
-]
-
 { #category : #'open/close' }
 BinaryFileStream >> close [
 	self closed
@@ -38,15 +32,6 @@ BinaryFileStream >> finalize [
 	^ self close
 ]
 
-{ #category : #flushing }
-BinaryFileStream >> flush [
-	"When writing, this flushes the write buffer the stream uses to reduce
-	the number of write() system calls it makes. This should generally be
-	used before #sync, but on Windows they do the same thing."
-	
-	self primFlush: handle
-]
-
 { #category : #accessing }
 BinaryFileStream >> peek [
 	"Answer what would be returned if the message next were sent to the receiver. If the receiver is at the end, answer nil.  "
@@ -57,68 +42,11 @@ BinaryFileStream >> peek [
 	^ next
 ]
 
-{ #category : #positioning }
-BinaryFileStream >> position [
-
-	^ self primGetPosition: handle
-]
-
-{ #category : #positioning }
-BinaryFileStream >> position: aPosition [
-	
-	self primSetPosition: handle to: aPosition
-]
-
-{ #category : #private }
-BinaryFileStream >> primAtEnd: id [
-	"Answer true if the file position is at the end of the file."
-
-	<primitive: 'primitiveFileAtEnd' module: 'FilePlugin'>
-	self primitiveFailed
-
-]
-
 { #category : #private }
 BinaryFileStream >> primCloseNoError: id [
 	"Close this file. Don't raise an error if the primitive fails."
 
 	<primitive: 'primitiveFileClose' module: 'FilePlugin'>
-
-]
-
-{ #category : #private }
-BinaryFileStream >> primGetPosition: id [
-	"Get this files current position."
-
-	<primitive: 'primitiveFileGetPosition' module: 'FilePlugin'>
-	self primitiveFailed
-
-]
-
-{ #category : #private }
-BinaryFileStream >> primSetPosition: id to: anInteger [
-	"Set this file to the given position."
-
-	<primitive: 'primitiveFileSetPosition' module: 'FilePlugin'>
-	self primitiveFailed
-
-]
-
-{ #category : #private }
-BinaryFileStream >> primSize: id [
-	"Answer the size of this file."
-
-	<primitive: 'primitiveFileSize' module: 'FilePlugin'>
-	self primitiveFailed
-
-]
-
-{ #category : #private }
-BinaryFileStream >> primSizeNoError: id [
-	"Answer the size of this file. Answer nil if the primitive fails; this indicates that the file handle has become stale."
-
-	<primitive: 'primitiveFileSize' module: 'FilePlugin'>
-	^ nil
 
 ]
 
@@ -129,35 +57,9 @@ BinaryFileStream >> register [
 ]
 
 { #category : #positioning }
-BinaryFileStream >> reset [
-	self position: 0
-]
-
-{ #category : #positioning }
-BinaryFileStream >> setToEnd [
-	
-	self position: self size
-]
-
-{ #category : #accessing }
-BinaryFileStream >> size [
-
-	^ self primSize: handle
-]
-
-{ #category : #positioning }
 BinaryFileStream >> skip: n [
 	"Set the character position to n characters from the current position."
 	self position: self position + n
-]
-
-{ #category : #flushing }
-BinaryFileStream >> sync [	
-	"When writing, this syncs any written/flushed data still in the kernel
-	file system buffers to disk. This should generally be used after #flush,
-	but on Windows they do the same thing."
-
-	self primSync: handle
 ]
 
 { #category : #positioning }
@@ -177,14 +79,4 @@ BinaryFileStream >> truncate: pos [
 BinaryFileStream >> unregister [
 
 	File unregister: self
-]
-
-{ #category : #accessing }
-BinaryFileStream >> upToEnd [
-	"Answer a subcollection from the current access position through the last element of the receiver."
-
-	^ByteArray streamContents: [ :newStream |
-		| next |
-		[ (next := self next) isNil ] whileFalse: [
-			newStream nextPut: next ] ]
 ]

--- a/src/Files/StdioStream.class.st
+++ b/src/Files/StdioStream.class.st
@@ -1,11 +1,29 @@
 "
-I am a concrete subclass of AbstractBinaryFileStream for stdio streams. I cannot modify the position of the underlying file.
+I am a concrete subclass of AbstractBinaryFileStream for stdio streams.
 
-Warning: Do not use me! You can access stdio streams through Stdio interface:
+StdioStreams map to one of three types of underlying file: 
+
+- Terminal input/output.
+- Piped input/output and named pipes (FIFO files) such as created with the shell pipe character ""|"".
+- A file mounted on the file system.
+  This includes all the files that can be opened with a FileReference, including sysfs files such as /proc/cpuinfo and character devices such as /dev/urandom.
+
+The operations that can be performed on these vary, e.g. it is possible to position the stream for a regular file, but not for piped input.  Currently it is up to the user of StdioStream to know which type of input they are dealing with.
+
+As pipes can't be positioned and FilePlugin doesn't provide a peek primitive, simulate #peek by reading the next character and holding on to it until it is consumed.
+
+Despite providing both input and output methods, StdioStreams are either read-only or write-only.  Currently it is up to the user to know which type of stream they are dealing with.
+
+Normally instances of StdioStream are not created directly but via Stdio, e.g: 
 
 Stdio stdin.
 Stdio stdout.
 Stdio stderr.
+
+
+Instance Variables:
+
+- peekBuffer     <SmallInteger or nil> The next character to be read from the stream or nil.
 "
 Class {
 	#name : #StdioStream,
@@ -15,12 +33,6 @@ Class {
 	],
 	#category : #'Files-Streams'
 }
-
-{ #category : #testing }
-StdioStream >> atEnd [
-
-	^ file atEnd
-]
 
 { #category : #accessing }
 StdioStream >> next: n [
@@ -40,16 +52,10 @@ StdioStream >> next: n [
 
 { #category : #accessing }
 StdioStream >> peek [
-	"Answer what would be returned if the message next were sent to the receiver. If the receiver is at the end, answer nil.  "
-	self atEnd ifTrue: [^ nil ].
+	"Answer the next element of the stream, but do not advance the stream pointer. 
+	If the receiver is at the end, answer nil."
 
+	self atEnd ifTrue: [ ^ nil ].
 	peekBuffer ifNotNil: [ ^ peekBuffer ].
-
-	^ peekBuffer := self next.
-]
-
-{ #category : #positioning }
-StdioStream >> position [
-
-	^ file position
+	^ peekBuffer := self next
 ]


### PR DESCRIPTION
21692 StdioStream incorrectly delegates atEnd and position to file

This has turned in to a general tidy up of AbstractBinaryFileStream, BinaryFileStream and StdioStream

- Push methods up from BinaryFileStream to AbstractBinaryFileStream that also apply to StdioStream:
-- atEnd, contents, flush, position[:], size and associated primitives
-- reset, setToEnd, sync, upToEnd
- Fix original bug of StdioStream trying to ask File for atEnd and position
- Add automated tests for StdioStream- Update class comments for StdioStream