### PR TITLE
21694-Package-OpalCompiler-Traits-is-empty---remove

### DIFF
--- a/src/BaselineOfTraits/BaselineOfTraits.class.st
+++ b/src/BaselineOfTraits/BaselineOfTraits.class.st
@@ -57,7 +57,6 @@ BaselineOfTraits >> baseline: spec [
 					'Collections-Abstract-Traits'
 					'Transcript-Core-Traits'
 					'CodeImport-Traits'
-					'OpalCompiler-Traits'
 					'Slot-Traits'
 					'CodeExport-Traits'
 					'System-Sources-Traits'


### PR DESCRIPTION
Package OpalCompiler-Traits is empty -> remove
	https://pharo.fogbugz.com/f/cases/21694/Package-OpalCompiler-Traits-is-empty-remove