### PR TITLE
21707-revert-for-now-the-change-that-made-evaluate-doit-to-loose-variable-names

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -275,7 +275,7 @@ OpalCompiler >> evaluate [
 		ifTrue: [ itsSelectionString ]
 		ifFalse: [ source ].
 	self source: selectedSource.
-	value := receiver withArgs: (context ifNil: [ #() ] ifNotNil: [ {context} ]) executeMethod:  self translate generate.
+	value := receiver withArgs: (context ifNil: [ #() ] ifNotNil: [ {context} ]) executeMethod:  self translate generateWithSource.
 	self compilationContext logged
 		ifTrue: [ Smalltalk globals 
 			at: #SystemAnnouncer 


### PR DESCRIPTION
revert for now the change that made #evaluate doit to loose variable names
	https://pharo.fogbugz.com/f/cases/21707/revert-for-now-the-change-that-made-evaluate-doit-to-loose-variable-names