### PR TITLE
21715-When-asking-for-the-context-in-a-after-node-on-a-method-return-context-of-method-not-the-ensure-block

### DIFF
--- a/src/Reflectivity-Tests/ReflectivityControlTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityControlTest.class.st
@@ -35,24 +35,30 @@ ReflectivityControlTest >> tearDown [
 { #category : #'tests - after' }
 ReflectivityControlTest >> testAfterArray [
 	| arrayNode |
-	arrayNode := (ReflectivityExamples >> #exampleArray) ast statements first value.
+	arrayNode := (ReflectivityExamples >> #exampleArray) ast statements
+		first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec;
 		control: #after.
 	arrayNode link: link.
 	self assert: arrayNode hasMetalinkAfter.
-	self assert: (ReflectivityExamples >> #exampleArray) class = ReflectiveMethod.
+	self
+		assert: (ReflectivityExamples >> #exampleArray) class
+		equals: ReflectiveMethod.
 	self assert: tag isNil.
 	self assert: ReflectivityExamples new exampleArray isArray.
-	self assert: tag = 'yes'.
-	self assert: (ReflectivityExamples >> #exampleArray) class = CompiledMethod.
+	self assert: tag equals: 'yes'.
+	self
+		assert: (ReflectivityExamples >> #exampleArray) class
+		equals: CompiledMethod
 ]
 
 { #category : #'tests - after' }
 ReflectivityControlTest >> testAfterAssignment [
 	| assignmentNode |
-	assignmentNode := (ReflectivityExamples >> #exampleAssignment) assignmentNodes first.
+	assignmentNode := (ReflectivityExamples >> #exampleAssignment)
+		assignmentNodes first.
 	self assert: assignmentNode isAssignment.
 	link := MetaLink new
 		metaObject: self;
@@ -60,17 +66,22 @@ ReflectivityControlTest >> testAfterAssignment [
 		control: #after.
 	assignmentNode link: link.
 	self assert: assignmentNode hasMetalinkAfter.
-	self assert: (ReflectivityExamples >> #exampleAssignment) class = ReflectiveMethod.
+	self
+		assert: (ReflectivityExamples >> #exampleAssignment) class
+		equals: ReflectiveMethod.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleAssignment = 3.
-	self assert: tag = 'yes'.
-	self assert: (ReflectivityExamples >> #exampleAssignment) class = CompiledMethod.
+	self assert: ReflectivityExamples new exampleAssignment equals: 3.
+	self assert: tag equals: 'yes'.
+	self
+		assert: (ReflectivityExamples >> #exampleAssignment) class
+		equals: CompiledMethod
 ]
 
 { #category : #'tests - after' }
 ReflectivityControlTest >> testAfterBlock [
 	| blockNode |
-	blockNode := (ReflectivityExamples >> #exampleBlock) ast statements first value receiver.
+	blockNode := (ReflectivityExamples >> #exampleBlock) ast statements
+		first value receiver.
 	self assert: blockNode isBlock.
 	link := MetaLink new
 		metaObject: self;
@@ -78,11 +89,15 @@ ReflectivityControlTest >> testAfterBlock [
 		control: #after.
 	blockNode link: link.
 	self assert: blockNode hasMetalinkAfter.
-	self assert: (ReflectivityExamples >> #exampleBlock) class = ReflectiveMethod.
+	self
+		assert: (ReflectivityExamples >> #exampleBlock) class
+		equals: ReflectiveMethod.
 	self assert: tag isNil.
 	self assert: ReflectivityExamples new exampleBlock == 5.
-	self assert: tag = 'yes'.
-	self assert: (ReflectivityExamples >> #exampleBlock) class = CompiledMethod.
+	self assert: tag equals: 'yes'.
+	self
+		assert: (ReflectivityExamples >> #exampleBlock) class
+		equals: CompiledMethod
 ]
 
 { #category : #'tests - after' }
@@ -288,18 +303,20 @@ ReflectivityControlTest >> testAfterSequence [
 ReflectivityControlTest >> testAfterSlot [
 	| iVar instance |
 	iVar := ReflectivityExamples slotNamed: #ivar.
-	link := MetaLink new 
-		metaObject: self; 
+	link := MetaLink new
+		metaObject: self;
 		selector: #tagExec:;
 		control: #after;
 		arguments: #(name).
 	iVar link: link.
 	self assert: iVar hasMetalink.
-	self assert: (ReflectivityExamples >> #exampleIvarRead) class = ReflectiveMethod.
-	self assert: (tag isNil).
+	self
+		assert: (ReflectivityExamples >> #exampleIvarRead) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
 	instance := ReflectivityExamples new.
-	self assert: (instance exampleIvarRead = 33).
-	self assert: (tag = #ivar).
+	self assert: instance exampleIvarRead equals: 33.
+	self assert: tag equals: #ivar
 ]
 
 { #category : #'tests - after' }
@@ -782,12 +799,18 @@ ReflectivityControlTest >> testInsteadClassVariable [
 		control: #instead.
 	classVar link: link.
 	self assert: classVar hasMetalinkInstead.
-	self assert: (ReflectivityExamples >> #exampleClassVarRead) class = ReflectiveMethod.
+	self
+		assert:
+			(ReflectivityExamples >> #exampleClassVarRead) class
+				= ReflectiveMethod.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleClassVarRead  = #AClassVar.
+	self
+		assert: ReflectivityExamples new exampleClassVarRead = #AClassVar.
 	self assert: tag = 'yes'.
-	self assert: (ReflectivityExamples >> #exampleClassVarRead) class = CompiledMethod.
-	self deny: (ReflectivityExamples >> #exampleClassVarRead) isQuick.
+	self
+		assert: (ReflectivityExamples >> #exampleClassVarRead) class
+		equals: CompiledMethod.
+	self deny: (ReflectivityExamples >> #exampleClassVarRead) isQuick
 ]
 
 { #category : #'tests - instead' }

--- a/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
@@ -376,26 +376,6 @@ ReflectivityReificationTest >> testReifyMethodArgsAfter [
 ]
 
 { #category : #'tests - method' }
-ReflectivityReificationTest >> testReifyMethodArgsByNameBefore [
-	| methodNode instance |
-	methodNode := (ReflectivityExamples >> #exampleWithArg:) ast.
-	link := MetaLink new
-		metaObject: self;
-		selector: #tagExec:;
-		control: #before;
-		arguments: methodNode arguments.
-	methodNode link: link.
-	self assert: methodNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleWithArg:) class
-		equals: ReflectiveMethod.
-	self assert: tag isNil.
-	instance := ReflectivityExamples new.
-	self assert: (instance exampleWithArg: 3) equals: 5.
-	self assert: tag equals: 3
-]
-
-{ #category : #'tests - method' }
 ReflectivityReificationTest >> testReifyMethodReceiver [
 	| sendNode instance |
 	sendNode := (ReflectivityExamples >> #exampleMethod) ast.
@@ -450,6 +430,27 @@ ReflectivityReificationTest >> testReifyMethodThisContext [
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
 	self assert: tag class equals: Context
+]
+
+{ #category : #'tests - method' }
+ReflectivityReificationTest >> testReifyMethodThisContextAfter [
+	| sendNode instance |
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast.
+	link := MetaLink new
+		metaObject: self;
+		selector: #tagExec:;
+		control: #after;
+		arguments: #(context).
+	sendNode link: link.
+	self assert: sendNode hasMetalink.
+	self
+		assert: (ReflectivityExamples >> #exampleMethod) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+	instance := ReflectivityExamples new.
+	self assert: instance exampleMethod equals: 5.
+	self assert: tag class equals: Context.
+	self deny: tag isBlockContext.
 ]
 
 { #category : #'tests - assignment' }
@@ -760,6 +761,26 @@ ReflectivityReificationTest >> testReifySendSelector [
 ]
 
 { #category : #'tests - sends' }
+ReflectivityReificationTest >> testReifySendSender [
+	| sendNode instance |
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
+		statements first value.
+	link := MetaLink new
+		metaObject: self;
+		selector: #tagExec:;
+		arguments: #(sender).
+	sendNode link: link.
+	self assert: sendNode hasMetalink.
+	self
+		assert: (ReflectivityExamples >> #exampleMethod) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+	instance := ReflectivityExamples new.
+	self assert: instance exampleMethod equals: 5.
+	self assert: tag equals: instance
+]
+
+{ #category : #'tests - sends' }
 ReflectivityReificationTest >> testReifySendThisContext [
 	| sendNode instance |
 	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
@@ -776,7 +797,31 @@ ReflectivityReificationTest >> testReifySendThisContext [
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
-	self assert: tag class equals: Context
+	self assert: tag class equals: Context.
+	
+]
+
+{ #category : #'tests - sends' }
+ReflectivityReificationTest >> testReifySendThisContextAfter [
+	| sendNode instance |
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
+		statements first value.
+	link := MetaLink new
+		metaObject: self;
+		selector: #tagExec:;
+		control: #after;
+		arguments: #(context).
+	sendNode link: link.
+	self assert: sendNode hasMetalink.
+	self
+		assert: (ReflectivityExamples >> #exampleMethod) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+	instance := ReflectivityExamples new.
+	self assert: instance exampleMethod equals: 5.
+	self assert: tag class equals: Context.
+	self deny: tag isBlockContext.
+	
 ]
 
 { #category : #'tests - sends' }

--- a/src/Reflectivity/RFThisContextReification.class.st
+++ b/src/Reflectivity/RFThisContextReification.class.st
@@ -28,6 +28,15 @@ RFThisContextReification >> genForLiteralVariable [
 ]
 
 { #category : #generate }
+RFThisContextReification >> genForRBMethodNode [
+	"when in after the call to the meta is wrapped in a block"
+	^link control = #after
+		ifTrue: [ RBMessageNode receiver: (RBThisContextNode named: #thisContext) selector: #outerContext]
+		ifFalse: [ RBThisContextNode named: #thisContext ]
+
+]
+
+{ #category : #generate }
 RFThisContextReification >> genForRBProgramNode [
 	^RBThisContextNode named: #thisContext
 ]


### PR DESCRIPTION
When asking for the #context in a #after node on a method: return context of method, not the ensure: block
	https://pharo.fogbugz.com/f/cases/21715/When-asking-for-the-context-in-a-after-node-on-a-method-return-context-of-method-not-the-ensure-block