### PR TITLE
21723-Opal-compiler-instances-are-created-in-huge-amount-during-a-method-compilation-from-the-browser

### DIFF
--- a/src/GeneralRules/RBUnaryAccessingMethodWithoutReturnRule.class.st
+++ b/src/GeneralRules/RBUnaryAccessingMethodWithoutReturnRule.class.st
@@ -25,7 +25,7 @@ RBUnaryAccessingMethodWithoutReturnRule >> check: aMethod forCritiquesDo: aCriti
 	((aMethod methodClass organization categoryOfElement: aMethod selector) asString
 		beginsWith: 'accessing')
 		ifFalse: [ ^ self ].
-	aMethod parseTree
+	aMethod ast
 		nodesDo: [ :each | 
 			each isReturn
 				ifTrue: [ ^ self ] ].

--- a/src/Refactoring-Critics/CompiledMethod.extension.st
+++ b/src/Refactoring-Critics/CompiledMethod.extension.st
@@ -2,30 +2,11 @@ Extension { #name : #CompiledMethod }
 
 { #category : #'*Refactoring-Critics' }
 CompiledMethod >> selfMessages [
-
-	|  selfMessages searcher |
-	selfMessages := Set new.
-	searcher := RBParseTreeSearcher new.
-	searcher
-		matches: 'self `@message: ``@args'
-			do: [:aNode :answer | selfMessages add: aNode selector].
-
-	searcher executeTree: self parseTree initialAnswer: nil.
-	
-	^ selfMessages
+	^self ast sendNodes select: [ :node | node isSelfSend ] thenCollect: [ :node | node selector ] 
 ]
 
 { #category : #'*Refactoring-Critics' }
 CompiledMethod >> superMessages [
 
-	|  superMessages searcher |
-	superMessages := Set new.
-	searcher := RBParseTreeSearcher new.
-	searcher
-		matches: 'super `@message: ``@args'
-			do: [:aNode :answer | superMessages add: aNode selector].
-
-	searcher executeTree: self parseTree initialAnswer: nil.
-	
-	^ superMessages
+	^self ast sendNodes select: [ :node | node isSuperSend ] thenCollect: [ :node | node selector ] 
 ]

--- a/src/Refactoring-Critics/CompiledMethod.extension.st
+++ b/src/Refactoring-Critics/CompiledMethod.extension.st
@@ -2,11 +2,11 @@ Extension { #name : #CompiledMethod }
 
 { #category : #'*Refactoring-Critics' }
 CompiledMethod >> selfMessages [
-	^self ast sendNodes select: [ :node | node isSelfSend ] thenCollect: [ :node | node selector ] 
+	^(self ast sendNodes select: [ :node | node isSelfSend ] thenCollect: [ :node | node selector ]) asSet
+	
 ]
 
 { #category : #'*Refactoring-Critics' }
 CompiledMethod >> superMessages [
-
-	^self ast sendNodes select: [ :node | node isSuperSend ] thenCollect: [ :node | node selector ] 
+	^(self ast sendNodes select: [ :node | node isSuperSend ] thenCollect: [ :node | node selector ]) asSet
 ]


### PR DESCRIPTION
Opal compiler instances are created in huge amount during a method compilation from the browser
	https://pharo.fogbugz.com/f/cases/21723/Opal-compiler-instances-are-created-in-huge-amount-during-a-method-compilation-from-the-browser$