### PR TITLE
21726-add-a-first-version-of-evaluate-and-evaluateInContext-to-RBValueNode-and-use-it-in-RBBlockPatternNode

### DIFF
--- a/src/AST-Core/RBPatternBlockNode.class.st
+++ b/src/AST-Core/RBPatternBlockNode.class.st
@@ -74,7 +74,7 @@ RBPatternBlockNode >> createReplacingBlock [
 	newBlock := RBBlockNode arguments: arguments body: body.
 	self arguments isEmpty 
 		ifTrue: [self addArgumentWithNameBasedOn: 'aDictionary' to: newBlock].
-	^newBlock evaluate
+	^newBlock evaluateForReceiver: self.
 ]
 
 { #category : #'testing-matching' }

--- a/src/AST-Core/RBPatternBlockNode.class.st
+++ b/src/AST-Core/RBPatternBlockNode.class.st
@@ -61,7 +61,7 @@ RBPatternBlockNode >> createMatchingBlock [
 		ifTrue: [self addArgumentWithNameBasedOn: 'aNode' to: newBlock].
 	newBlock arguments size = 1 
 		ifTrue: [self addArgumentWithNameBasedOn: 'aDictionary' to: newBlock].
-	^newBlock evaluate.
+	^newBlock evaluateForReceiver: self.
 ]
 
 { #category : #matching }

--- a/src/AST-Core/RBPatternBlockNode.class.st
+++ b/src/AST-Core/RBPatternBlockNode.class.st
@@ -50,16 +50,6 @@ RBPatternBlockNode >> copyInContext: aDictionary [
 ]
 
 { #category : #matching }
-RBPatternBlockNode >> createBlockFor: aRBBlockNode [ 
-	aRBBlockNode left: self left; right:self right.
-	self replacePatternNodesIn: aRBBlockNode.
-	^Smalltalk compiler 
-		source: aRBBlockNode formattedCode;
-		receiver: self;
-		evaluate
-]
-
-{ #category : #matching }
 RBPatternBlockNode >> createMatchingBlock [
 	| newBlock |
 	self arguments size > 2 
@@ -71,7 +61,7 @@ RBPatternBlockNode >> createMatchingBlock [
 		ifTrue: [self addArgumentWithNameBasedOn: 'aNode' to: newBlock].
 	newBlock arguments size = 1 
 		ifTrue: [self addArgumentWithNameBasedOn: 'aDictionary' to: newBlock].
-	^self createBlockFor: newBlock
+	^newBlock evaluate.
 ]
 
 { #category : #matching }
@@ -84,7 +74,7 @@ RBPatternBlockNode >> createReplacingBlock [
 	newBlock := RBBlockNode arguments: arguments body: body.
 	self arguments isEmpty 
 		ifTrue: [self addArgumentWithNameBasedOn: 'aDictionary' to: newBlock].
-	^self createBlockFor: newBlock
+	^newBlock evaluate
 ]
 
 { #category : #'testing-matching' }

--- a/src/AST-Core/RBValueNode.class.st
+++ b/src/AST-Core/RBValueNode.class.st
@@ -63,6 +63,7 @@ RBValueNode >> evaluateForContext: aContext [
 		arguments: { RBVariableNode named: 'ThisContext' } 
 		body: (RBReturnNode value: self) asSequenceNode.
 
+	methodNode methodClass: aContext receiver class.
 	methodNode rewriteTempsForContext: aContext.
 	^methodNode generate valueWithReceiver: aContext receiver arguments: {aContext}.
 

--- a/src/AST-Core/RBValueNode.class.st
+++ b/src/AST-Core/RBValueNode.class.st
@@ -65,7 +65,7 @@ RBValueNode >> evaluateForContext: aContext [
 
 	methodNode methodClass: aContext receiver class.
 	methodNode rewriteTempsForContext: aContext.
-	^methodNode generate valueWithReceiver: aContext receiver arguments: {aContext}.
+	^methodNode generateWithSource valueWithReceiver: aContext receiver arguments: {aContext}.
 
 
 ]
@@ -80,7 +80,6 @@ RBValueNode >> evaluateForReceiver: aReceicer [
 		body: (RBReturnNode value: self) asSequenceNode.
 	
 	methodNode methodClass: aReceicer class.
-	
 	^methodNode generateWithSource valueWithReceiver: aReceicer arguments: #().
 
 

--- a/src/AST-Core/RBValueNode.class.st
+++ b/src/AST-Core/RBValueNode.class.st
@@ -39,6 +39,36 @@ RBValueNode >> containedBy: anInterval [
 		and: [anInterval last >= self stopWithoutParentheses]
 ]
 
+{ #category : #evaluating }
+RBValueNode >> evaluate [
+	"evaluate the AST without taking variables into account"
+	| methodNode |
+	
+	methodNode := RBMethodNode 
+		selector: #DoIt
+		body: (RBReturnNode value: self) asSequenceNode.
+	
+	^methodNode generateWithSource valueWithReceiver: nil arguments: #().
+
+
+]
+
+{ #category : #evaluating }
+RBValueNode >> evaluateForContext: aContext [
+	"evaluate the AST taking variables from the context"
+	| methodNode |
+	
+	methodNode := RBMethodNode 
+		selector: #DoItIn:
+		arguments: { RBVariableNode named: 'ThisContext' } 
+		body: (RBReturnNode value: self) asSequenceNode.
+
+	methodNode rewriteTempsForContext: aContext.
+	^methodNode generate valueWithReceiver: aContext receiver arguments: {aContext}.
+
+
+]
+
 { #category : #testing }
 RBValueNode >> hasParentheses [
 	^self parentheses notEmpty

--- a/src/AST-Core/RBValueNode.class.st
+++ b/src/AST-Core/RBValueNode.class.st
@@ -69,6 +69,22 @@ RBValueNode >> evaluateForContext: aContext [
 
 ]
 
+{ #category : #evaluating }
+RBValueNode >> evaluateForReceiver: aReceicer [
+	"evaluate the AST without taking variables into account"
+	| methodNode |
+	
+	methodNode := RBMethodNode 
+		selector: #DoIt
+		body: (RBReturnNode value: self) asSequenceNode.
+	
+	methodNode methodClass: aReceicer class.
+	
+	^methodNode generateWithSource valueWithReceiver: aReceicer arguments: #().
+
+
+]
+
 { #category : #testing }
 RBValueNode >> hasParentheses [
 	^self parentheses notEmpty

--- a/src/AST-Tests-Core/ASTEvaluationTest.class.st
+++ b/src/AST-Tests-Core/ASTEvaluationTest.class.st
@@ -1,3 +1,6 @@
+"
+I am testing AST evaluation 
+"
 Class {
 	#name : #ASTEvaluationTest,
 	#superclass : #TestCase,
@@ -15,6 +18,10 @@ ASTEvaluationTest >> testeEvaluateForContext [
 	varForTesting := 4@5.
 	node := thisContext method variableNodes first.
 	self assert: (node evaluateForContext: thisContext) equals: varForTesting.
+	node := RBVariableNode named: 'self'.
+	self assert: (node evaluateForContext: thisContext) equals: thisContext receiver.
+	node := RBVariableNode named: 'testSelector'.
+	self assert: (node evaluateForContext: thisContext) equals: #testeEvaluateForContext.
 ]
 
 { #category : #tests }
@@ -23,20 +30,6 @@ ASTEvaluationTest >> testeEvaluateForReceiver [
 	receiver := 4@5.
 	node := (receiver class>>#x) variableNodes first.
 	self assert: (node evaluateForReceiver: receiver) equals: 4.
-]
-
-{ #category : #tests }
-ASTEvaluationTest >> testeEvaluateForReceiverSelf [
-	| receiver node |
-	receiver := 4@5.
-	node := RBVariableNode named: 'self'.
-	self assert: (node evaluateForReceiver: receiver) equals: receiver.
-]
-
-{ #category : #tests }
-ASTEvaluationTest >> testeEvaluateForReceiverSelfSuper [
-	| receiver node |
-	receiver := 4@5.
 	node := RBVariableNode named: 'self'.
 	self assert: (node evaluateForReceiver: receiver) equals: receiver.
 	node := RBVariableNode named: 'super'.

--- a/src/AST-Tests-Core/ASTEvaluationTest.class.st
+++ b/src/AST-Tests-Core/ASTEvaluationTest.class.st
@@ -8,24 +8,36 @@ Class {
 }
 
 { #category : #tests }
-ASTEvaluationTest >> testeEvaluate [
+ASTEvaluationTest >> testEvaluate [
 	self assert: (RBLiteralNode value: 5) evaluate equals: 5
 ]
 
 { #category : #tests }
-ASTEvaluationTest >> testeEvaluateForContext [
+ASTEvaluationTest >> testEvaluateForContext [
 	| varForTesting node |
 	varForTesting := 4@5.
+
+	"first we test if we can read the temp varForTesting"
 	node := thisContext method variableNodes first.
 	self assert: (node evaluateForContext: thisContext) equals: varForTesting.
+
+	"lets check self, super"
 	node := RBVariableNode named: 'self'.
 	self assert: (node evaluateForContext: thisContext) equals: thisContext receiver.
+	node := RBVariableNode named: 'super'.
+	self assert: (node evaluateForContext: thisContext) equals: thisContext receiver.
+
+	"thisContext is not the thisContext of this method though... it is the context of the evaluating doit"
+	node := RBVariableNode named: 'thisContext'.
+	self deny: (node evaluateForContext: thisContext) equals: thisContext.	
+
+	"reading ivars works, too"
 	node := RBVariableNode named: 'testSelector'.
-	self assert: (node evaluateForContext: thisContext) equals: #testeEvaluateForContext.
+	self assert: (node evaluateForContext: thisContext) equals: #testEvaluateForContext.
 ]
 
 { #category : #tests }
-ASTEvaluationTest >> testeEvaluateForReceiver [
+ASTEvaluationTest >> testEvaluateForReceiver [
 	| receiver node |
 	receiver := 4@5.
 	node := (receiver class>>#x) variableNodes first.

--- a/src/AST-Tests-Core/ASTEvaluationTest.class.st
+++ b/src/AST-Tests-Core/ASTEvaluationTest.class.st
@@ -1,0 +1,44 @@
+Class {
+	#name : #ASTEvaluationTest,
+	#superclass : #TestCase,
+	#category : #'AST-Tests-Core'
+}
+
+{ #category : #tests }
+ASTEvaluationTest >> testeEvaluate [
+	self assert: (RBLiteralNode value: 5) evaluate equals: 5
+]
+
+{ #category : #tests }
+ASTEvaluationTest >> testeEvaluateForContext [
+	| varForTesting node |
+	varForTesting := 4@5.
+	node := thisContext method variableNodes first.
+	self assert: (node evaluateForContext: thisContext) equals: varForTesting.
+]
+
+{ #category : #tests }
+ASTEvaluationTest >> testeEvaluateForReceiver [
+	| receiver node |
+	receiver := 4@5.
+	node := (receiver class>>#x) variableNodes first.
+	self assert: (node evaluateForReceiver: receiver) equals: 4.
+]
+
+{ #category : #tests }
+ASTEvaluationTest >> testeEvaluateForReceiverSelf [
+	| receiver node |
+	receiver := 4@5.
+	node := RBVariableNode named: 'self'.
+	self assert: (node evaluateForReceiver: receiver) equals: receiver.
+]
+
+{ #category : #tests }
+ASTEvaluationTest >> testeEvaluateForReceiverSelfSuper [
+	| receiver node |
+	receiver := 4@5.
+	node := RBVariableNode named: 'self'.
+	self assert: (node evaluateForReceiver: receiver) equals: receiver.
+	node := RBVariableNode named: 'super'.
+	self assert: (node evaluateForReceiver: receiver) equals: receiver.
+]


### PR DESCRIPTION
add a first version of #evaluate and #evaluateInContext to RBValueNode and use it in RBBlockPatternNode
	https://pharo.fogbugz.com/f/cases/21726/add-a-first-version-of-evaluate-and-evaluateInContext-to-RBValueNode-and-use-it-in-RBBlockPatternNode