### PR TITLE
21741-subclasslayoutslotsclassVariablespoolDictionaries-should-receive-a-collection-of-symbols

### DIFF
--- a/src/TraitsV2-Tests/T2AbstractTest.class.st
+++ b/src/TraitsV2-Tests/T2AbstractTest.class.st
@@ -19,7 +19,7 @@ T2AbstractTest >> newClass: aName superclass: aSuperclass with: slots uses: aCom
 { #category : #'instance creation' }
 T2AbstractTest >> newClass: aName superclass: aSuperclass with: slots uses: aComposition category: category [
 	| class |
-	class := aSuperclass subclass: aName uses: aComposition slots: slots classVariables: '' poolDictionaries: '' category: category. 
+	class := aSuperclass subclass: aName uses: aComposition slots: slots classVariables: #() poolDictionaries: '' category: category. 
 	createdClasses add:class.
 	
 	^class.

--- a/src/TraitsV2-Tests/T2TraitSlotScopeTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitSlotScopeTest.class.st
@@ -186,7 +186,7 @@ T2TraitSlotScopeTest >> testSubClassWithTraitsAfterModificationOfParentSharedPoo
 
 	x1 := SharedPool subclass: #X1.
 
-	c1 := Object subclass: #C1 uses: t1 slots: #(aSlot) classVariables: '' poolDictionaries: 'X1' category: 'TraitsV2-Tests-TestClasses' . 
+	c1 := Object subclass: #C1 uses: t1 slots: #(aSlot) classVariables: #() poolDictionaries: 'X1' category: 'TraitsV2-Tests-TestClasses' . 
 
 	
 	self assert: c2 classLayout slotScope parentScope == c2 superclass classLayout slotScope. 
@@ -204,7 +204,7 @@ T2TraitSlotScopeTest >> testSubClassWithTraitsAfterModificationOfParentSharedvar
 	c1 := self newClass: #C1 with: #(aSlot) uses: t1.
 	c2 := self newClass: #C2 superclass: c1 with: #(otherSlot)  uses: t2.
 
-	c1 := Object subclass: #C1 uses: t1 slots: #(aSlot) classVariables: 'ClassVar' poolDictionaries: '' category: 'TraitsV2-Tests-TestClasses' . 
+	c1 := Object subclass: #C1 uses: t1 slots: #(aSlot) classVariables: #(ClassVar) poolDictionaries: '' category: 'TraitsV2-Tests-TestClasses' . 
 
 	self assert: c2 classLayout slotScope parentScope == c2 superclass classLayout slotScope. 
 	self assert: c2 class classLayout slotScope parentScope == c2 class superclass classLayout slotScope. 	

--- a/src/TraitsV2/Class.extension.st
+++ b/src/TraitsV2/Class.extension.st
@@ -21,7 +21,7 @@ Class >> immediateSubclass: aName uses: aTraitComposition instanceVariableNames:
 		uses: aTraitComposition
 		layout: ImmediateLayout
 		slots: someInstanceVariableNames asSlotCollection 
-		classVariables: someClassVariableNames
+		classVariablesNames: someClassVariableNames
 		poolDictionaries: someSharedPoolNames
 		category: aCategory
 ]
@@ -80,7 +80,7 @@ Class >> subclass: aName uses: aTraitCompositionOrArray instanceVariableNames: s
 		uses: aTraitCompositionOrArray
 		layout: self classLayout class
 		slots: someInstanceVariableNames asSlotCollection
-		classVariables: someClassVariableNames
+		classVariablesNames: someClassVariableNames
 		poolDictionaries: someSharedPoolNames
 		category: aCategory
 ]
@@ -93,7 +93,7 @@ Class >> subclass: aName uses: aTraitCompositionOrArray instanceVariableNames: s
 		uses: aTraitCompositionOrArray
 		layout: self classLayout class
 		slots: someInstanceVariableNames asSlotCollection
-		classVariables: someClassVariableNames
+		classVariablesNames: someClassVariableNames
 		poolDictionaries: someSharedPoolNames
 		category: aCategory
 ]
@@ -122,6 +122,24 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 				slots: someSlots;
 				layoutClass: aLayout;
 				sharedVariables: someClassVariables;
+				sharedPools: somePoolDictionaries;
+				traitComposition: aTraitComposition asTraitComposition;
+				classTraitComposition: aTraitComposition asTraitComposition classComposition;
+				category: aCategory;
+				copyClassSlotsFromExistingClass ]
+]
+
+{ #category : #'*TraitsV2' }
+Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: someSlots classVariablesNames: someClassVariablesNames poolDictionaries: somePoolDictionaries category: aCategory [
+	
+	^ self classInstaller
+		make: [ :builder | 
+			builder
+				name: subclassName;
+				superclass: self;
+				slots: someSlots;
+				layoutClass: aLayout;
+				sharedVariablesFromString: someClassVariablesNames;
 				sharedPools: somePoolDictionaries;
 				traitComposition: aTraitComposition asTraitComposition;
 				classTraitComposition: aTraitComposition asTraitComposition classComposition;
@@ -180,7 +198,7 @@ Class >> variableByteSubclass: aName uses: aTraitComposition instanceVariableNam
 		uses: aTraitComposition
 		layout: actualLayoutClass
 		slots: someInstanceVariableNames asSlotCollection
-		classVariables: someClassVariableNames
+		classVariablesNames: someClassVariableNames
 		poolDictionaries: someSharedPoolNames
 		category: aCategory
 ]
@@ -216,7 +234,7 @@ Class >> variableSubclass: aName uses: aTraitComposition instanceVariableNames: 
 		uses: aTraitComposition
 		layout: VariableLayout
 		slots: someInstanceVariableNames asSlotCollection
-		classVariables: someClassVariableNames
+		classVariablesNames: someClassVariableNames
 		poolDictionaries: someSharedPoolNames
 		category: aCategory
 ]
@@ -275,7 +293,7 @@ Class >> variableWordSubclass: aName uses: aTraitComposition instanceVariableNam
 		uses: aTraitComposition
 		layout: WordLayout
 		slots: someInstanceVariableNames asSlotCollection
-		classVariables: someClassVariableNames
+		classVariablesNames: someClassVariableNames
 		poolDictionaries: someSharedPoolNames
 		category: aCategory
 ]
@@ -311,7 +329,7 @@ Class >> weakSubclass: aName uses: aTraitComposition instanceVariableNames: some
 		uses: aTraitComposition
 		layout: WeakLayout
 		slots: someInstanceVariableNames asSlotCollection
-		classVariables: someClassVariableNames
+		classVariablesNames: someClassVariableNames
 		poolDictionaries: someSharedPoolNames
 		category: aCategory
 ]

--- a/src/TraitsV2/Class.extension.st
+++ b/src/TraitsV2/Class.extension.st
@@ -121,7 +121,7 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 				superclass: self;
 				slots: someSlots;
 				layoutClass: aLayout;
-				sharedVariablesFromString: someClassVariables;
+				sharedVariables: someClassVariables;
 				sharedPools: somePoolDictionaries;
 				traitComposition: aTraitComposition asTraitComposition;
 				classTraitComposition: aTraitComposition asTraitComposition classComposition;


### PR DESCRIPTION
Changing #subclass:uses:layout:slots:classVariablesNames:poolDictionaries:category: to receive a collection of symbols instead that an String with the names.Updating the tests.