### PR TITLE
21745-Trait-new-should-raise-error-instead-of-VM-crash

### DIFF
--- a/src/Tests/TraitTest.class.st
+++ b/src/Tests/TraitTest.class.st
@@ -240,6 +240,16 @@ TraitTest >> testExplicitRequirementWithSuperclassImplementatiosAlwaysReturnsThe
 ]
 
 { #category : #testing }
+TraitTest >> testForbidInstantiation [
+
+   | tmpCategory trait |
+tmpCategory := 'TemporaryGeneratedClasses'.
+   trait := Trait named: #TMyTrait uses: {} category: tmpCategory.
+    
+	self should: [ trait basicNew ] raise: Error 
+]
+
+{ #category : #testing }
 TraitTest >> testIsRootInEnvironment [
 	self assert: self t1 isRootInEnvironment.
 	self assert: self t2 isRootInEnvironment

--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -136,6 +136,16 @@ Trait >> asTraitComposition [
 	^ TaCompositionElement for: self.
 ]
 
+{ #category : #'instance creation' }
+Trait >> basicNew [
+	"Traits should never be instantiated.
+	They are naked object: superclass = nil. 
+	They not understand any Object messages 
+	and any DNU crashes VM because there are no methods doesNotUnderstand: or cannotInterpret:"
+	
+	self error: 'Traits should not be instantiated!'
+]
+
 { #category : #'accessing parallel hierarchy' }
 Trait >> classTrait [
 


### PR DESCRIPTION
Now ATrait basicNew raises error.

https://pharo.fogbugz.com/f/cases/21745/Trait-new-should-raise-error-instead-of-VM-crash