### PR TITLE
20020-Collectionaverage-throw-a-ZeroDivide-when-the-collection-is-empty

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -276,6 +276,7 @@ BaselineOfIDE >> baseline: spec [
 		spec package: 'BlueInk-Extras'.
 		spec package: 'BlueInk-Tests'.
 		spec package: 'Collections-DoubleLinkedList-Tests'.
+		spec package: 'Collections-Arithmetic-Tests'.
 		spec package: 'Compression-Tests'.
 		spec package: 'ConfigurationCommandLineHandler-Tests'.
 		spec package: 'MetacelloCommandLineHandler-Tests'.

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -430,6 +430,7 @@ spec group: 'General-Tests-Group' with: #(
 	'Fuel-Tests-Core'
 	'Balloon-Tests'
 	'Collections-DoubleLinkedList-Tests'
+	'Collections-Arithmetic-Tests'
 	'ConfigurationCommandLineHandler-Tests'
 	'MetacelloCommandLineHandler-Tests'
 	'Debugger-Tests'

--- a/src/Collections-Arithmetic-Tests/CollectionArithmeticTests.class.st
+++ b/src/Collections-Arithmetic-Tests/CollectionArithmeticTests.class.st
@@ -1,0 +1,44 @@
+Class {
+	#name : #CollectionArithmeticTests,
+	#superclass : #TestCase,
+	#category : #'Collections-Arithmetic-Tests'
+}
+
+{ #category : #tests }
+CollectionArithmeticTests >> testAverage [
+	| collection |
+	collection := #(1 2 3).
+	self assert: collection average equals: 2
+]
+
+{ #category : #tests }
+CollectionArithmeticTests >> testAverageIfEmpty [
+	| collection |
+	collection := #(1 2 3 4).
+	self assert: (collection averageIfEmpty: [ 0 ]) equals: 2.5
+]
+
+{ #category : #tests }
+CollectionArithmeticTests >> testAverageIfEmptyWithEmptyCollection [
+	self should: [#() averageIfEmpty: [ CollectionIsEmpty signal: 'Collection empty' ]] raise: CollectionIsEmpty
+]
+
+{ #category : #tests }
+CollectionArithmeticTests >> testAverageWithEmptyArray [
+	self should: [ #() average ] raise: CollectionIsEmpty
+]
+
+{ #category : #tests }
+CollectionArithmeticTests >> testAverageWithEmptyDictionary [
+	self should: [ Dictionary new average ] raise: CollectionIsEmpty
+]
+
+{ #category : #tests }
+CollectionArithmeticTests >> testAverageWithEmptyOrderedCollection [
+	self should: [ OrderedCollection new average ] raise: CollectionIsEmpty
+]
+
+{ #category : #tests }
+CollectionArithmeticTests >> testAverageWithEmptySet [
+	self should: [ Set new average ] raise: CollectionIsEmpty
+]

--- a/src/Collections-Arithmetic-Tests/CollectionArithmeticTests.class.st
+++ b/src/Collections-Arithmetic-Tests/CollectionArithmeticTests.class.st
@@ -19,12 +19,22 @@ CollectionArithmeticTests >> testAverageIfEmpty [
 ]
 
 { #category : #tests }
+CollectionArithmeticTests >> testAverageIfEmptyWithEmptyArray [
+	self assert: (#() averageIfEmpty: [ 0 ]) equals: 0
+]
+
+{ #category : #tests }
 CollectionArithmeticTests >> testAverageIfEmptyWithEmptyCollection [
 	self should: [#() averageIfEmpty: [ CollectionIsEmpty signal: 'Collection empty' ]] raise: CollectionIsEmpty
 ]
 
 { #category : #tests }
 CollectionArithmeticTests >> testAverageWithEmptyArray [
+	self should: [ #() average ] raise: CollectionIsEmpty
+]
+
+{ #category : #tests }
+CollectionArithmeticTests >> testAverageWithEmptyArrayShouldRaiseExecption [
 	self should: [ #() average ] raise: CollectionIsEmpty
 ]
 

--- a/src/Collections-Arithmetic-Tests/package.st
+++ b/src/Collections-Arithmetic-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Collections-Arithmetic-Tests' }

--- a/src/Collections-Arithmetic/Collection.extension.st
+++ b/src/Collections-Arithmetic/Collection.extension.st
@@ -57,14 +57,24 @@ Collection >> arcTan [
 	^self collect: [:each | each arcTan]
 ]
 
-{ #category : #'*Collections-arithmetic' }
+{ #category : #'*Collections-Arithmetic' }
 Collection >> average [
 	"
+	Calculate the average of a collection, return a CollectionIsEmpty exception if the collection is empty.
+	Look averageIfEmpty: aBlock
 	#(3 5 7) average 
 	>>> 5
 	"
 
 	^ self sum / self size
+]
+
+{ #category : #'*Collections-Arithmetic' }
+Collection >> averageIfEmpty: aBlock [ 
+	"This method return the average of the collection if it is not empty. In the other case,
+	it return the value of the block. It means the user the user of this method decide of the return value. #() averageIfEmpty: [ 0 ]"
+	self ifEmpty: [ ^ aBlock value ].
+	^ self average
 ]
 
 { #category : #'*Collections-arithmetic-collectors' }
@@ -178,6 +188,8 @@ Collection >> sum [
 	Consider a collection of measurement objects, 0 would be the unitless 
 	value and would not be appropriate to add with the unit-ed objects."
 	| sum sample |
+	
+	self emptyCheck.
 	sample := self anyOne.
 	sum := self inject: sample into: [:accum :each | accum + each].
 	^ sum - sample


### PR DESCRIPTION
- average exception set to CollectionIsEmpty for empty collections
- sum corected too for empty collections
- averageIfEmpty: added
- tests for those methods are green