### PR TITLE
21747-BlockClosure-sourceCode-tab-should-provide-self-binding

### DIFF
--- a/src/GT-InspectorExtensions-Core/BlockClosure.extension.st
+++ b/src/GT-InspectorExtensions-Core/BlockClosure.extension.st
@@ -3,5 +3,7 @@ Extension { #name : #BlockClosure }
 { #category : #'*GT-InspectorExtensions-Core' }
 BlockClosure >> gtInspectorSourceCodeIn: composite [ 
 	<gtInspectorPresentationOrder: 40>
-	self sourceNode gtInspectorSourceCodeIn: composite
+	^(self sourceNode gtInspectorSourceCodeIn: composite)
+		doItReceiver: [ self receiver ];
+		doItContext: [ self outerContext ]
 ]


### PR DESCRIPTION
It just adds doItReceiver and doItContext (outerContext) to the source code presentation.

https://pharo.fogbugz.com/f/cases/21747/BlockClosure-sourceCode-tab-should-provide-self-binding