### PR TITLE
21750-ClassTestCase-do-not-need-to-ignore-DoIt-DoItIn-as-they-are-never-installed

### DIFF
--- a/src/SUnit-Core/ClassTestCase.class.st
+++ b/src/SUnit-Core/ClassTestCase.class.st
@@ -95,7 +95,7 @@ ClassTestCase >> selectorsTested [
 
 { #category : #coverage }
 ClassTestCase >> selectorsToBeIgnored [
-	^ #(#DoIt #DoItIn:)
+	^ #()
 ]
 
 { #category : #coverage }


### PR DESCRIPTION
ClassTestCase: do not need to ignore #DoIt #DoItIn: as they are never installed
	https://pharo.fogbugz.com/f/cases/21750/ClassTestCase-do-not-need-to-ignore-DoIt-DoItIn-as-they-are-never-installed