### PR TITLE
21751-isSelfEvaluating-on-CompiledMethod-should-use-isDoit

### DIFF
--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -633,7 +633,7 @@ CompiledMethod >> isReturnSpecial [
 { #category : #printing }
 CompiledMethod >> isSelfEvaluating [
 
-	^self methodClass notNil and: [(#(#DoIt #DoItIn: nil) includes: self selector) not]
+	^self methodClass notNil and: [self selector isDoIt not]
 ]
 
 { #category : #testing }

--- a/src/SUnit-Core/ClassTestCase.class.st
+++ b/src/SUnit-Core/ClassTestCase.class.st
@@ -95,7 +95,7 @@ ClassTestCase >> selectorsTested [
 
 { #category : #coverage }
 ClassTestCase >> selectorsToBeIgnored [
-	^ #(#DoIt #DoItIn:)
+	^ #()
 ]
 
 { #category : #coverage }


### PR DESCRIPTION
isSelfEvaluating on CompiledMethod should use #isDoit
	https://pharo.fogbugz.com/f/cases/21751/isSelfEvaluating-on-CompiledMethod-should-use-isDoit