### PR TITLE
21689-displayString-for-String-should-return-self

### DIFF
--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1014,6 +1014,13 @@ String >> deepCopy [
 	^self shallowCopy
 ]
 
+{ #category : #displaying }
+String >> displayStringOn: aStream [
+	
+	aStream nextPutAll: self
+	
+]
+
 { #category : #printing }
 String >> encodeDoublingQuoteOn: aStream [ 
 	"Print inside string quotes, doubling inbedded quotes."

--- a/src/Collections-Tests/StringTest.class.st
+++ b/src/Collections-Tests/StringTest.class.st
@@ -723,6 +723,14 @@ StringTest >> testCorrectAgainst [
 	self assert: ('test' correctAgainst: coll) asArray equals: #().
 ]
 
+{ #category : #'tests - printing' }
+StringTest >> testDisplayString [
+
+	| actual |
+	actual := 'some string' displayString.
+	self assert: actual equals: 'some string'
+]
+
 { #category : #tests }
 StringTest >> testEndsWith [ 
 

--- a/src/Collections-Tests/SymbolTest.class.st
+++ b/src/Collections-Tests/SymbolTest.class.st
@@ -339,6 +339,14 @@ SymbolTest >> testCopyNotSame [
 	self assert: copy  == self nonEmpty.
 ]
 
+{ #category : #tests }
+SymbolTest >> testDisplayString [
+
+	| actual |
+	actual := #'some symbol' displayString.
+	self assert: actual equals: 'some symbol'
+]
+
 { #category : #'tests - testing' }
 SymbolTest >> testEndsWithAColon [
 	 

--- a/src/Kernel-Tests/ObjectTest.class.st
+++ b/src/Kernel-Tests/ObjectTest.class.st
@@ -82,6 +82,20 @@ ObjectTest >> testBecomeForward [
 	self assert: pt1 = (100@100)
 ]
 
+{ #category : #'tests-printing' }
+ObjectTest >> testDisplayString [
+
+	self assert: Object new displayString equals: 'an Object'
+]
+
+{ #category : #'tests-printing' }
+ObjectTest >> testDisplayStringLimitedString [
+
+	| actual |
+	actual := Object new displayStringLimitedTo: 4.
+	self assert: actual equals: 'an O...etc...'
+]
+
 { #category : #'tests - debugging' }
 ObjectTest >> testHaltIf [
 
@@ -137,6 +151,20 @@ ObjectTest >> testInstVarNamedPut [
 	self assert: (obj instVarNamed: 'variable') equals: 1.
 	self shouldnt: [ obj instVarNamed: 'variable' put: 1 ] raise: InstanceVariableNotFound.
 	self should: [ obj instVarNamed: 'timoleon' put: 1 ] raise: InstanceVariableNotFound
+]
+
+{ #category : #'tests-printing' }
+ObjectTest >> testPrintLimitedString [
+
+	| actual |
+	actual := Object new printStringLimitedTo: 4.
+	self assert: actual equals: 'an O...etc...'
+]
+
+{ #category : #'tests-printing' }
+ObjectTest >> testPrintString [
+
+	self assert: Object new printString equals: 'an Object'
 ]
 
 { #category : #'tests - introspection' }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -778,11 +778,26 @@ Object >> deprecated: anExplanationString transformWith: aRule [
 
 { #category : #displaying }
 Object >> displayString [
-	"While printString is about to give a detailled information about an object, displayString is a message that should return a short string-based representation to be used by list and related UI frameworks. By default, simply return printString."
-	"asString should not be implemented in Object, and kept for conversion between strings, symbols, text and characters."
+	"While printString is about to give a detailled information about an object, displayString is a message that should return a short string-based representation to be used by list and related UI frameworks. By default, simply return printString.
+	Subclasses should not override this method 
+	but instead stream based method #displayStringOn:"
 	
-	^ self printString
+	^ self displayStringLimitedTo: 50000
+]
 
+{ #category : #displaying }
+Object >> displayStringLimitedTo: limit [
+	"Answer a String whose characters are a description of the receiver.
+	If you want to print without a character limit, use fullDisplayString."
+	^self printStringLimitedTo: limit using: [:s | self displayStringOn: s]
+]
+
+{ #category : #displaying }
+Object >> displayStringOn: aStream [
+	"While #printOn: is about to give a detailled information about an object, #displayStringOn: is a message that should return a string-based representation to be used by list and related UI frameworks. By default, simply use printOn: method.
+	Subclasses should override this method instead of #displayString"
+
+	self printOn: aStream
 ]
 
 { #category : #'reflective operations' }
@@ -896,6 +911,13 @@ Object >> finalizationRegistry [
 { #category : #finalization }
 Object >> finalize [
 	"Finalize the resource associated with the receiver. This message should only be sent during the finalization process. There is NO garantuee that the resource associated with the receiver hasn't been free'd before so take care that you don't run into trouble - this all may happen with interrupt priority."
+]
+
+{ #category : #displaying }
+Object >> fullDisplayString [
+	"Answer a String whose characters are a description of the receiver suitable for UI"
+
+	^ String streamContents: [:s | self displayStringOn: s]
 ]
 
 { #category : #printing }
@@ -1711,8 +1733,15 @@ Object >> printString [
 Object >> printStringLimitedTo: limit [
 	"Answer a String whose characters are a description of the receiver.
 	If you want to print without a character limit, use fullPrintString."
+	^self printStringLimitedTo: limit using: [:s | self printOn: s]
+]
+
+{ #category : #printing }
+Object >> printStringLimitedTo: limit using: printBlock [
+	"Answer a String whose characters are a description of the receiver
+	produced by given printBlock. It ensures the result will be not bigger than given limit"
 	| limitedString |
-	limitedString := String streamContents: [:s | self printOn: s] limitedTo: limit.
+	limitedString := String streamContents: printBlock limitedTo: limit.
 	limitedString size < limit ifTrue: [^ limitedString].
 	^ limitedString , '...etc...'
 ]


### PR DESCRIPTION
It introduce several displayString methods to be consistent with printString logic:
- displayString calls limited version of displayStringOn:
- displayStringOn: , which is supposed to be overriten by classes
- displayStringLimitedTo:, ir applyes limit on possible string
- fullDisplayString returns full string built by displayStringOn:

And Now String implements displayStringOn: by printing own characters on stream.

https://pharo.fogbugz.com/f/cases/21689/displayString-for-String-should-return-self