### PR TITLE
21761-change-asDoItIn-to-asDoItForContext

### DIFF
--- a/src/AST-Core/RBValueNode.class.st
+++ b/src/AST-Core/RBValueNode.class.st
@@ -45,12 +45,8 @@ RBValueNode >> evaluate [
 { #category : #evaluating }
 RBValueNode >> evaluateForContext: aContext [
 	"evaluate the AST taking variables from the context"
-	| methodNode |
-	
-	methodNode := self asDoitIn.
-	methodNode methodClass: aContext receiver class.
-	methodNode rewriteTempsForContext: aContext.
-	^methodNode generateWithSource valueWithReceiver: aContext receiver arguments: {aContext}.
+	^(self asDoitForContext: aContext) 
+		generateWithSource valueWithReceiver: aContext receiver arguments: {aContext}.
 
 
 ]

--- a/src/Kernel-Tests-WithCompiler/AssociationTest.extension.st
+++ b/src/Kernel-Tests-WithCompiler/AssociationTest.extension.st
@@ -7,7 +7,7 @@ AssociationTest >> testStoreOnNegativeIntegerRoundtrip [
 	
 	storeString := String streamContents: [ :s | association storeOn: s ].
 	
-	evaluated := Compiler evaluate: storeString.
+	evaluated := Smalltalk compiler evaluate: storeString.
 	
 	self assert: association equals: evaluated
 ]
@@ -18,7 +18,7 @@ AssociationTest >> testStoreOnPositiveIntegerRoundtrip [
 	association := 'a'-> 1.
 	storeString := String streamContents: [ :s | association storeOn: s ].
 	
-	evaluated := Compiler evaluate: storeString.
+	evaluated := Smalltalk compiler evaluate: storeString.
 	
 	self assert: association equals: evaluated
 ]

--- a/src/Kernel-Tests-WithCompiler/SmallDictionaryTest.extension.st
+++ b/src/Kernel-Tests-WithCompiler/SmallDictionaryTest.extension.st
@@ -10,6 +10,6 @@ SmallDictionaryTest >> testStoreOnRoundTrip [
 		add: #c -> 1;
 		add: #d -> -2.
 	storeString := String streamContents: [ :s | dictionary storeOn: s ].
-	evalutated := Compiler evaluate: storeString.
+	evalutated := Smalltalk compiler evaluate: storeString.
 	self assert: dictionary equals: evalutated
 ]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -633,7 +633,7 @@ CompiledMethod >> isReturnSpecial [
 { #category : #printing }
 CompiledMethod >> isSelfEvaluating [
 
-	^self methodClass notNil and: [self selector isDoIt not]
+	^self methodClass notNil and: [self isDoIt not]
 ]
 
 { #category : #testing }

--- a/src/Monticello-Tests/MCStWriterTest.class.st
+++ b/src/Monticello-Tests/MCStWriterTest.class.st
@@ -21,7 +21,7 @@ MCStWriterTest >> assertChunkIsWellFormed: chunk [
 		class: UndefinedObject;
 		noPattern: true;
 		failBlock:  [self assert: false];
-		translate.
+		compile.
 ]
 
 { #category : #asserting }
@@ -38,7 +38,7 @@ MCStWriterTest >> assertMethodChunkIsWellFormed: chunk [
 		source: chunk readStream;
 		class: UndefinedObject;
 		failBlock: [self assert: false];
-		translate.
+		compile.
 	
 ]
 

--- a/src/NautilusRefactoring/RBAddMethodChange.extension.st
+++ b/src/NautilusRefactoring/RBAddMethodChange.extension.st
@@ -14,7 +14,7 @@ RBAddMethodChange >> accept: aText notifying: aController [
 		class:  self changeClass;
 		requestor: aController;
 		failBlock: [ ^ false ];
-		translate.
+		compile.
 	
 		
 	self 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -324,19 +324,9 @@ OpalCompiler >> options: anOptionsArray [
 
 { #category : #'public access' }
 OpalCompiler >> parse [
-	| expression selector arguments method |
-	self compilationContext noPattern ifFalse: [ ^ self parseMethod ].
-	expression := self parseExpression asSequenceNode transformLastToReturn.
-	context
-		ifNil: [ 
-			selector := #DoIt.
-			arguments := #() ] 
-		ifNotNil: [ 
-			selector := #DoItIn:.
-			arguments := { RBVariableNode named: 'ThisContext' } ].
-	method := RBMethodNode selector: selector arguments: arguments body: expression.
-	context ifNotNil: [ method rewriteTempsForContext: context ].
-	^ method
+	^self compilationContext noPattern 
+		ifTrue: [ self parseExpression ]
+		ifFalse: [ self parseMethod ].
 ]
 
 { #category : #'public access' }
@@ -349,13 +339,18 @@ OpalCompiler >> parse: textOrString [
 
 { #category : #private }
 OpalCompiler >> parseExpression [
-	| parseClass |
+	| parseClass expression |
 	
 	parseClass := self compilationContext parserClass.
 
-	^self compilationContext optionParseErrors 
+	expression := self compilationContext optionParseErrors 
 		ifTrue: [parseClass parseFaultyExpression: source contents]
-		ifFalse: [parseClass parseExpression: source contents]
+		ifFalse: [parseClass parseExpression: source contents].
+		
+	^context 
+		ifNil: [expression asDoit] 
+		ifNotNil: [expression asDoitForContext: context].
+
 ]
 
 { #category : #'public access' }
@@ -368,7 +363,7 @@ OpalCompiler >> parseMethod [
 	| parseClass |
 	
 	parseClass := self compilationContext parserClass.
-
+	
 	^self compilationContext optionParseErrors 
 		ifTrue: [parseClass parseFaultyMethod: source contents]
 		ifFalse: [parseClass parseMethod: source contents]

--- a/src/OpalCompiler-Core/RBProgramNode.extension.st
+++ b/src/OpalCompiler-Core/RBProgramNode.extension.st
@@ -9,12 +9,20 @@ RBProgramNode >> asDoit [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-RBProgramNode >> asDoitIn [
+RBProgramNode >> asDoitForContext: aContext [
 	"The VM can only evaluate methods. wrap this ast in a doitIn MethodNode to evaluate in a context"
-	^RBMethodNode 
+	| methodNode |
+	
+	methodNode := RBMethodNode 
 		selector: #DoItIn:
 		arguments: { RBVariableNode named: 'ThisContext' } 
 		body: self asSequenceNode transformLastToReturn.
+	
+	methodNode methodClass: aContext receiver class.
+	methodNode rewriteTempsForContext: aContext.
+	^methodNode
+		
+	
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -26,7 +26,7 @@ OCCompilerTest >> compileWithFailBlock: aBlock [
 		class: MockForCompilation;
 		requestor: self;
 		failBlock: aBlock;
-		translate.
+		compile.
 
 ]
 
@@ -104,11 +104,7 @@ OCCompilerTest >> testAssignmentOfGlobalVarBinding [
 		requestor: self;
 		failBlock: [ self fail.
 			^ nil ];
-		translate
-]
-
-{ #category : #'test shadowing' }
-OCCompilerTest >> testEmptyCharacterFail [
+		compile
 ]
 
 { #category : #'test shadowing' }
@@ -222,7 +218,7 @@ OCCompilerTest >> testNotInteractiveInBlockArgumentInstanceVariableShadowing [
 			OpalCompiler new 
 				source: 'temp [:var1 | ]';
 				class: MockForCompilation;
-				translate.
+				compile.
 		] 
 		raise: OCShadowVariableWarning 
 		withExceptionDo: [ :ex |
@@ -244,7 +240,7 @@ OCCompilerTest >> testNotInteractiveInBlockTempArgumentShadowing [
 				source: 'temp [:temp | |temp|]';
 				class: MockForCompilation;
 				requestor: self;
-				translate.
+				compile.
 		] 
 		raise: OCShadowVariableWarning 
 		withExceptionDo: [ :ex |
@@ -266,7 +262,7 @@ OCCompilerTest >> testNotInteractiveInBlockTempInstanceVariableShadowing [
 				class: MockForCompilation;
 				requestor: self;
 				failBlock: [self fail. ^ nil];
-				translate.
+				compile.
 		] 
 		raise: OCShadowVariableWarning 
 		withExceptionDo: [ :ex |
@@ -289,7 +285,7 @@ OCCompilerTest >> testNotInteractiveInBlockTempShadowing [
 				class: MockForCompilation;
 				requestor: self;
 				failBlock: [self fail];
-				translate.
+				compile.
 		] 
 		raise: OCShadowVariableWarning 
 		withExceptionDo: [ :ex |
@@ -313,7 +309,7 @@ OCCompilerTest >> testNotInteractiveNoShadowing [
 			class: MockForCompilation;
 			requestor: self;
 			failBlock: [self fail. ^ nil ];
-			translate.
+			compile.
 	] raise: OCShadowVariableWarning.
 	
 
@@ -332,7 +328,7 @@ OCCompilerTest >> testNotInteractiveShadowingOfTemp [
 				source: 'temp |temp1 temp1| ';
 				class: MockForCompilation;
 				requestor: self;
-				translate.
+				compile.
 		] 
 		raise: OCShadowVariableWarning 
 		withExceptionDo: [ :ex |
@@ -355,7 +351,7 @@ OCCompilerTest >> testNotInteractiveSiblingBlocksInstanceVariableShadowing [
 				class:  MockForCompilation;
 				requestor: self; 
 				failBlock: [self fail. ^ nil ];
-				translate.
+				compile.
 		] 
 		raise: OCShadowVariableWarning 
 		withExceptionDo: [ :ex |
@@ -380,7 +376,7 @@ OCCompilerTest >> testNotInteractiveSiblingBlocksTempShadowing [
 			class: MockForCompilation;
 			requestor: self;
 			failBlock: [self fail. ^nil];
-			translate
+			compile
 	] raise: OCShadowVariableWarning.
 
 
@@ -404,7 +400,7 @@ OCCompilerTest >> testReservedNameAsBlockArgumentShadowing [
 				class: MockForCompilation;
 				requestor: self;
 				failBlock: [ exit value ];
-				translate.
+				compile.
 			self fail ] valueWithExit.
 		self assert: ((errorMessage = 'Variable name expected ->' )or: [ errorMessage =  'Name already defined ->' ]).
 		self assert: errorLocation = 11 ]
@@ -422,7 +418,7 @@ OCCompilerTest >> testReservedNameAsMethodArgumentShadowing [
 				class:  MockForCompilation;
 				requestor: self;
 				failBlock: [ exit value ];
-				translate.
+				compile.
 			self fail ] valueWithExit.
 		self assert: ((errorMessage = 'Variable name expected ->' )or: [ errorMessage =  'Name already defined ->' ]).
 		self assert: errorLocation = 7 ]
@@ -454,7 +450,7 @@ OCCompilerTest >> testSiblingBlocksInstanceVariableShadowing [
 				self assert: (errorMessage = 'Name already defined ->').
 				self assert: (errorLocation = 27).
 				^nil];
-		translate.
+		compile.
 	self fail.
 
 
@@ -471,7 +467,7 @@ OCCompilerTest >> testSiblingBlocksTempShadowing [
 		source: 'temp [:temp | ]. [:temp | ]';
 		class: MockForCompilation;
 		failBlock: [self fail. ^ nil ];
-		translate.
+		compile.
 				
 
 
@@ -496,7 +492,7 @@ OCCompilerTest >> testTraitTempShadowing [
 				source: self tempTraitShadowingString;
 				class: ArrayTest;
 				failBlock: [self fail.];
-				translate.
+				compile.
 	] 
 	on: OCShadowVariableWarning 
 	do: [ :ex | 


### PR DESCRIPTION
- change asDoItIn to asDoItForContext:
- simplify CM>>#isSelfevaluating even more
- remove two references to Compiler
- remove calls of #translate (as we should only have parse and compile)
- simplify OpalCompiler>>#parse

https://pharo.fogbugz.com/f/cases/21761/change-asDoItIn-to-asDoItForContext