### PR TITLE
21762-The-System-browser-world-menu-registration-should-be-done-in-Tool-Base-package

### DIFF
--- a/src/Tool-Base/PharoCommonTools.class.st
+++ b/src/Tool-Base/PharoCommonTools.class.st
@@ -102,6 +102,18 @@ PharoCommonTools class >> shutDown: aboutToQuit [
 	self allInstancesDo: #cleanUp
 ]
 
+{ #category : #'world menu' }
+PharoCommonTools class >> worldMenuOn: aBuilder [
+	<worldMenu>
+	(aBuilder item: #'System Browser')
+		parent: #MostUsedTools;
+		action: [ Smalltalk tools openClassBrowser ];
+		order: 0.1;
+		keyText: 'o, b';
+		help: 'System browser to browse and edit code.';
+		icon: Smalltalk tools browser taskbarIcon
+]
+
 { #category : #'registry access' }
 PharoCommonTools >> basicInspector [
 


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21762/The-System-browser-world-menu-registration-should-be-done-in-Tool-Base-packageadd world menu registration of the System browser