### PR TITLE
21777 Some assert:equal: and formatting cleanups in UFFI

### DIFF
--- a/src/UnifiedFFI-Tests/FFICalloutMethodBuilderTest.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutMethodBuilderTest.class.st
@@ -38,9 +38,9 @@ FFICalloutMethodBuilderTest >> testAllAtomicTypesCall [
 	
 	self assert: result notNil.
 	self assert: result isCompiledMethod.
-	self assert: result primitive = 0.
-	self assert: result literals first name = 'method1'.
-	self assert: result literals first argTypes = { 
+	self assert: result primitive equals: 0.
+	self assert: result literals first name equals: 'method1'.
+	self assert: result literals first argTypes equals: { 
 		ExternalType void. 
 		ExternalType bool. 
 		ExternalType byte. 
@@ -74,9 +74,9 @@ FFICalloutMethodBuilderTest >> testCallCreateObject [
 
 	self assert: result notNil.
 	self assert: result isCompiledMethod.
-	self assert: result primitive = 0.
-	self assert: result literals first name = 'method1'.
-	self assert: result literals first argTypes first = ExternalType void asPointerType. 
+	self assert: result primitive equals: 0.
+	self assert: result literals first name equals: 'method1'.
+	self assert: result literals first argTypes first equals: ExternalType void asPointerType
 ]
 
 { #category : #tests }
@@ -95,9 +95,9 @@ FFICalloutMethodBuilderTest >> testCallReturningEnumeration [
 
 	self assert: result notNil.
 	self assert: result isCompiledMethod.
-	self assert: result primitive = 0.
-	self assert: result literals first name = 'method1'.
-	self assert: result literals first argTypes first = ExternalType ulong.
+	self assert: result primitive equals: 0.
+	self assert: result literals first name equals: 'method1'.
+	self assert: result literals first argTypes first equals: ExternalType ulong
 ]
 
 { #category : #tests }
@@ -115,9 +115,9 @@ FFICalloutMethodBuilderTest >> testCallSimple [
 	
 	self assert: result notNil.
 	self assert: result isCompiledMethod.
-	self assert: result primitive = 0.
-	self assert: result literals first name = 'method1'.
-	self assert: result literals first argTypes = { ExternalType void. ExternalType long }
+	self assert: result primitive equals: 0.
+	self assert: result literals first name equals: 'method1'.
+	self assert: result literals first argTypes equals: { ExternalType void. ExternalType long }
 ]
 
 { #category : #tests }
@@ -135,8 +135,8 @@ FFICalloutMethodBuilderTest >> testCallWithConstant [
 
 	self assert: result notNil.
 	self assert: result isCompiledMethod.
-	self assert: result primitive = 0.
-	self assert: result literals first name = 'method1'.
+	self assert: result primitive equals: 0.
+	self assert: result literals first name equals: 'method1'
 ]
 
 { #category : #tests }
@@ -155,9 +155,9 @@ FFICalloutMethodBuilderTest >> testCallWithObject [
 
 	self assert: result notNil.
 	self assert: result isCompiledMethod.
-	self assert: result primitive = 0.
-	self assert: result literals first name = 'method1'.
-	self assert: result literals first argTypes last = ExternalType long asPointerType. 
+	self assert: result primitive equals: 0.
+	self assert: result literals first name equals: 'method1'.
+	self assert: result literals first argTypes last equals: ExternalType long asPointerType
 ]
 
 { #category : #tests }
@@ -175,9 +175,9 @@ FFICalloutMethodBuilderTest >> testCallWithPointer [
 
 	self assert: result notNil.
 	self assert: result isCompiledMethod.
-	self assert: result primitive = 0.
-	self assert: result literals first name = 'method1'.
-	self assert: result literals first argTypes last = ExternalType long asPointerType. 
+	self assert: result primitive equals: 0.
+	self assert: result literals first name equals: 'method1'.
+	self assert: result literals first argTypes last equals: ExternalType long asPointerType 
 ]
 
 { #category : #tests }
@@ -195,9 +195,9 @@ FFICalloutMethodBuilderTest >> testCallWithPointerPointer [
 
 	self assert: result notNil.
 	self assert: result isCompiledMethod.
-	self assert: result primitive = 0.
-	self assert: result literals first name = 'method1'.
-	self assert: result literals first argTypes last = architecture externalLongType asPointerType. 
+	self assert: result primitive equals: 0.
+	self assert: result literals first name equals: 'method1'.
+	self assert: result literals first argTypes last equals: architecture externalLongType asPointerType
 ]
 
 { #category : #tests }
@@ -216,7 +216,7 @@ FFICalloutMethodBuilderTest >> testCallWithSelf [
 
 	self assert: result notNil.
 	self assert: result isCompiledMethod.
-	self assert: result primitive = 0.
-	self assert: result literals first name = 'method1'.
-	self assert: result literals first argTypes last = ExternalType long asPointerType. 
+	self assert: result primitive equals: 0.
+	self assert: result literals first name equals: 'method1'.
+	self assert: result literals first argTypes last equals: ExternalType long asPointerType
 ]

--- a/src/UnifiedFFI-Tests/FFICalloutTests.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutTests.class.st
@@ -4,9 +4,6 @@ Tests for FFICallout
 Class {
 	#name : #FFICalloutTests,
 	#superclass : #TestCase,
-	#instVars : [
-		'architecture'
-	],
 	#classVars : [
 		'CLASSVAR',
 		'TYPEVAR'
@@ -26,26 +23,20 @@ FFICalloutTests >> checkType: type class: typeClass arity: ptrArity argument: ar
 { #category : #private }
 FFICalloutTests >> checkType: type class: typeClass value: const [
 	self assert: type class == typeClass.
-	self assert: type value = const
+	self assert: type value equals: const
 ]
 
 { #category : #private }
 FFICalloutTests >> checkTypeSelf: type class: typeClass arity: ptrArity [ 
 
-	self assert: type class = typeClass.
-	self assert: type pointerArity = ptrArity.
-	self assert: type loader class = FFISelfArgument.
+	self assert: type class equals: typeClass.
+	self assert: type pointerArity equals: ptrArity.
+	self assert: type loader class equals: FFISelfArgument.
 ]
 
 { #category : #binding }
 FFICalloutTests >> ffiBindingOf: aName [
 	^ self class ffiBindingOf: aName
-]
-
-{ #category : #running }
-FFICalloutTests >> setUp [
-	super setUp.
-	architecture := FFIArchitecture forCurrentArchitecture
 ]
 
 { #category : #tests }

--- a/src/UnifiedFFI-Tests/FFIExternalEnumerationTests.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalEnumerationTests.class.st
@@ -38,8 +38,8 @@ FFIExternalEnumerationTests >> testCall [
 
 { #category : #tests }
 FFIExternalEnumerationTests >> testEnumIdents [
-	self assert: self enumClass AAA value = 1.
-	self assert: self enumClass DDD value = 2400
+	self assert: self enumClass AAA value equals: 1.
+	self assert: self enumClass DDD value equals: 2400
 ]
 
 { #category : #tests }
@@ -50,10 +50,10 @@ FFIExternalEnumerationTests >> testEnumIncludes [
 
 { #category : #tests }
 FFIExternalEnumerationTests >> testFromInteger [
-	self assert: (self enumClass fromInteger:  1) value = 1 .
-	self assert: (self enumClass fromInteger: 2) value = 2.
-	self assert: (self enumClass fromInteger: 3) value = 3.
-	self assert: (self enumClass fromInteger: 2400) value = 2400.
+	self assert: (self enumClass fromInteger: 1) value equals: 1.
+	self assert: (self enumClass fromInteger: 2) value equals: 2.
+	self assert: (self enumClass fromInteger: 3) value equals: 3.
+	self assert: (self enumClass fromInteger: 2400) value equals: 2400.
 	self should: [ self enumClass fromInteger: 234 ] raise: Error
 ]
 

--- a/src/UnifiedFFI-Tests/FFIExternalPackedStructureTests.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalPackedStructureTests.class.st
@@ -24,11 +24,11 @@ FFIExternalPackedStructureTests >> testExternallyAllocatedStructure [
 	
 		struct2 := FFITestPackedStructure fromHandle: struct getHandle.
 	
-		self assert: (struct2 byte = 10).
-		self assert: (struct2 short = -20).	
-		self assert: (struct2 long = 100).	
-		self assert: (struct2 float = 1.0).	
-		self assert: (struct2 double = 2.0).	
+		self assert: struct2 byte equals: 10.
+		self assert: struct2 short equals: -20.	
+		self assert: struct2 long equals: 100.	
+		self assert: struct2 float equals: 1.0.	
+		self assert: struct2 double equals: 2.0.	
 		self flag: #todo. "This is not yet implemented"
 		"self assert: (struct2 int64 = 123456789101112)."	 ] 
 	ensure: [  struct free ]
@@ -51,11 +51,11 @@ FFIExternalPackedStructureTests >> testStructAccess [
 		self flag: #todo. "This is not yet implemented"
 	"struct int64: 123456789101112."
 	
-	self assert: (struct byte = 10).
-	self assert: (struct short = -20).	
-	self assert: (struct long = 100).	
-	self assert: (struct float = 1.0).	
-	self assert: (struct double = 2.0).	
+	self assert: struct byte equals: 10.
+	self assert: struct short equals: -20.	
+	self assert: struct long equals: 100.	
+	self assert: struct float equals: 1.0.	
+	self assert: struct double equals: 2.0.	
 	"self assert: (struct int64 = 123456789101112).	"
 	
 ]


### PR DESCRIPTION
- use assert:equals:
- remove unnecessary dots at end of methods
- formatting
- also remove unnecessary "architecture" ivar in FFICalloutTest

https://pharo.fogbugz.com/f/cases/21777/Some-assert-equal-and-formatting-cleanups-in-UFFI