### PR TITLE
21781-trait-composition-should-not-copy-slots-everytime-it-is-asked

### DIFF
--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -229,6 +229,16 @@ TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing
 ]
 
 { #category : #copying }
+TaAbstractComposition >> copySlot: aSlot [
+	"This is a utitlity method to handle the copy of a slot. It is used for instance side and class side slots."
+	| newOne |
+	newOne := aSlot copy.
+	newOne isVirtual ifFalse: [ newOne index: nil ].
+	newOne definingClass: aSlot definingClass.
+	^ newOne
+]
+
+{ #category : #copying }
 TaAbstractComposition >> copyTraitExpression [
 	"I should copy all the elements in the traitComposition"
 	^ self subclassResponsibility 
@@ -387,6 +397,12 @@ TaAbstractComposition >> semanticallyEquals: another [
 { #category : #accessing }
 TaAbstractComposition >> slots [
 	self subclassResponsibility 
+]
+
+{ #category : #copying }
+TaAbstractComposition >> slotsCopy [
+
+	^ self slots collect: [ :each | self copySlot: each ]
 ]
 
 { #category : #accessing }

--- a/src/TraitsV2/TaClassCompositionElement.class.st
+++ b/src/TraitsV2/TaClassCompositionElement.class.st
@@ -22,9 +22,9 @@ TaClassCompositionElement >> selectors [
 
 { #category : #accessing }
 TaClassCompositionElement >> slots [
-	^ (innerClass slots
-		reject: [ :e | TraitedClass slots anySatisfy: [ :x | x name = e name ] ])
-		collect: [ :e | self copySlot: e ]
+	^ innerClass slots
+		reject: [ :e | TraitedClass slots anySatisfy: [ :x | x name = e name ] ]
+		
 ]
 
 { #category : #printing }

--- a/src/TraitsV2/TaCompositionElement.class.st
+++ b/src/TraitsV2/TaCompositionElement.class.st
@@ -65,16 +65,6 @@ TaCompositionElement >> compiledMethodAt: selector [
 ]
 
 { #category : #copying }
-TaCompositionElement >> copySlot: aSlot [
-	"This is a utitlity method to handle the copy of a slot. It is used for instance side and class side slots."
-	| newOne |
-	newOne := aSlot copy.
-	newOne isVirtual ifFalse: [ newOne index: nil ].
-	newOne definingClass: self innerClass.
-	^ newOne
-]
-
-{ #category : #copying }
 TaCompositionElement >> copyTraitExpression [
 	"I can be just shallowCopy, because I have only a reference to the real Trait"
 	^ self shallowCopy.
@@ -158,7 +148,7 @@ TaCompositionElement >> selectors [
 
 { #category : #accessing }
 TaCompositionElement >> slots [
-	^ innerClass slots collect: [ :e | self copySlot: e ]
+	^ innerClass slots 
 ]
 
 { #category : #printing }

--- a/src/TraitsV2/TraitBuilderEnhancer.class.st
+++ b/src/TraitsV2/TraitBuilderEnhancer.class.st
@@ -101,7 +101,7 @@ TraitBuilderEnhancer >> configureClass: newClass superclass: superclass withLayo
 	self validateTraitComposition: self traitComposition ofClass: builder oldClass.
 
 	resultingSlots := self
-		eliminateDuplicates: slots , self traitComposition slots
+		eliminateDuplicates: slots , self traitComposition slotsCopy
 		withSuperclassSlots: (superclass ifNil: [#()] ifNotNil:[ :x | x allSlots]).
 
 	newClass superclass: superclass withLayoutType: layoutType slots: resultingSlots
@@ -113,7 +113,7 @@ TraitBuilderEnhancer >> configureMetaclass: newMetaclass superclass: superclass 
 	self validateTraitComposition: self classTraitComposition ofClass: builder oldMetaclass.
 
 	resultingSlots := self
-		eliminateDuplicates: classSlots , self classTraitComposition slots
+		eliminateDuplicates: classSlots , self classTraitComposition slotsCopy
 		withSuperclassSlots: superclass allSlots.
 
 	newMetaclass superclass: superclass withLayoutType: aLayoutType slots: resultingSlots


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21781/trait-composition-should-not-copy-slots-everytime-it-is-askeddo not copy slots in trait composition element by default