### PR TITLE
21788 Cleanup Athens-Examples

### DIFF
--- a/src/Athens-Examples/AthensBalloonSurfaceExamples.class.st
+++ b/src/Athens-Examples/AthensBalloonSurfaceExamples.class.st
@@ -6,10 +6,10 @@ Athens example using Ballon as surface
 Class {
 	#name : #AthensBalloonSurfaceExamples,
 	#superclass : #AthensSurfaceExamples,
-	#category : #'Athens-Examples'
+	#category : #'Athens-Examples-Demos'
 }
 
-{ #category : #'instance creation' }
+{ #category : #utilities }
 AthensBalloonSurfaceExamples class >> newSurface: extent [
 	
 	^ AthensBalloonSurface extent: extent

--- a/src/Athens-Examples/AthensCairoSurfaceExamples.class.st
+++ b/src/Athens-Examples/AthensCairoSurfaceExamples.class.st
@@ -4,10 +4,10 @@ self example1
 Class {
 	#name : #AthensCairoSurfaceExamples,
 	#superclass : #AthensSurfaceExamples,
-	#category : #'Athens-Examples'
+	#category : #'Athens-Examples-Demos'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #examples }
 AthensCairoSurfaceExamples class >> exampleInterop [
 
 "
@@ -36,7 +36,7 @@ A cairo image surface bits are exposed to bitblt operations via surface plugin.
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #utilities }
 AthensCairoSurfaceExamples class >> newSurface: extent [
 	
 	^ AthensCairoSurface extent: extent

--- a/src/Athens-Examples/AthensDemoMorph.class.st
+++ b/src/Athens-Examples/AthensDemoMorph.class.st
@@ -19,28 +19,54 @@ Class {
 		'pharoLogo',
 		'esugBallon'
 	],
-	#category : #'Athens-Examples'
+	#category : #'Athens-Examples-Demos'
 }
 
 { #category : #examples }
 AthensDemoMorph class >> example [
-	"self example"
-	
+
 	| demo model window |
-	demo := AthensDemoMorph new openInWorld. 
+	demo := self new openInWorld.
 	(model := DynamicComposablePresenter new)
 		instantiatePresenters: #(backButton ButtonPresenter forwardButton ButtonPresenter).
-	model backButton label: 'Previous Figure'; action: [ demo prevFigure ].
-	model forwardButton label: 'Next Figure'; action: [ demo nextFigure ].
-	window := model openWithSpecLayout: (SpecLayout composed
- 				   newColumn: [: c | c add: #backButton. c add: #forwardButton ];
-    				   yourself).
-	window title: 'Athens demos'
+	model backButton
+		label: 'Previous Figure';
+		action: [ demo prevFigure ].
+	model forwardButton
+		label: 'Next Figure';
+		action: [ demo nextFigure ].
+	window := model
+		openWithSpecLayout:
+			(SpecLayout composed
+				newColumn: [ :c | 
+					c add: #backButton.
+					c add: #forwardButton ];
+				yourself).
+	window title: 'Athens demos' translated
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #utilities }
+AthensDemoMorph class >> roundedRectanglePathOn: aCanvas [
+
+	^ aCanvas createPath: [:builder |
+		builder
+			absolute;
+			moveTo: 70@100;
+			lineTo: 330@100;
+			cwArcTo: 350@120 angle: 90 degreesToRadians;
+			lineTo: 350@280;
+			cwArcTo: 330@300 angle: 90 degreesToRadians;
+			lineTo: 70@300;
+			cwArcTo: 50@280 angle: 90 degreesToRadians;
+			lineTo: 50@120;
+			cwArcTo: 70@100 angle: 90 degreesToRadians ]
+
+
+]
+
+{ #category : #accessing }
 AthensDemoMorph >> backColor [
-	^ Color white.
+	^ Color white
 ]
 
 { #category : #accessing }
@@ -70,14 +96,17 @@ AthensDemoMorph >> defaultExtent [
 
 { #category : #drawing }
 AthensDemoMorph >> drawBackgroundOn: aCanvas [
-	aCanvas setPaint: Color veryLightGray; drawShape: (0@0 extent: 1@1)
+	aCanvas
+		setPaint: Color veryLightGray;
+		drawShape: (0 @ 0 extent: 1 @ 1)
 ]
 
 { #category : #drawing }
 AthensDemoMorph >> drawCarOn: aCanvas [
-	"chasis -----------------------------------------------------------------------"
-		| p stroke wheel decorator |
-	p := aCanvas createPath:[:b|
+
+	| p stroke wheel decorator |
+	"chasis"
+	p := aCanvas createPath: [:b |		
 			b 
 				moveTo: 0.3@0.3 ;
 				lineTo: 0.4@0;
@@ -95,7 +124,7 @@ AthensDemoMorph >> drawCarOn: aCanvas [
 		stroke width: 0.01.
 		aCanvas draw.
 		
-		"wheels-----------------------------------------------------------------------"
+		"wheels"
 		wheel := aCanvas createPath:[:b|
 			b
 				moveTo: 	0.3@0.3;		
@@ -110,7 +139,7 @@ AthensDemoMorph >> drawCarOn: aCanvas [
 			setPaint: self wheelColor;
 			drawShape: wheel.
 		
-		"chasis decorator-----------------------------------------------------------------------"
+		"chasis decorator"
 		decorator  := aCanvas createPath:[:b|
 			b
 				moveTo: 	0.2@0.45;	
@@ -126,9 +155,7 @@ AthensDemoMorph >> drawCarOn: aCanvas [
 		stroke width: 0.01.	
 		aCanvas drawShape: decorator.
 		aCanvas setPaint: self chasisLineColor.
-		aCanvas draw.		
-			
-			
+		aCanvas draw
 ]
 
 { #category : #drawing }
@@ -146,16 +173,15 @@ AthensDemoMorph >> figure10: aCanvas [
 	ellipsePath := aCanvas createPath: [ :builder |
 		builder
 			moveTo: 0@200;
-			cwArcTo: 240@0  angle: Float pi ;
-			 cwArcTo: -240@0 angle: Float pi ].
+			cwArcTo:  240@0 angle: Float pi;
+			cwArcTo: -240@0 angle: Float pi ].
 	aCanvas setPaint: Color black.
 	aCanvas drawShape: ellipsePath.
 	rectangle := 250@40 extent: 140@300.
 	aCanvas drawShape: rectangle.
 
-
 	aCanvas paintTransform loadIdentity.
-	aCanvas paintTransform scaleBy: ((frame/100) sin abs)*5.
+	aCanvas paintTransform scaleBy: ((frame/100) sin abs) * 5.
 	aCanvas paintTransform rotateByDegrees: (frame/100) sin * 360.
 	
 	patternPaint := aCanvas setPaint: pharoLogo.
@@ -164,8 +190,7 @@ AthensDemoMorph >> figure10: aCanvas [
 	
 	aCanvas setPaint: patternPaint.
 	patternPaint setExtend: #Reflect.
-	aCanvas drawShape: rectangle.
-
+	aCanvas drawShape: rectangle
 ]
 
 { #category : #figures }
@@ -178,8 +203,7 @@ AthensDemoMorph >> figure1: aCanvas [
 
 { #category : #figures }
 AthensDemoMorph >> figure2: aCanvas [
-	| path |
-	
+	| path |	
 	path := aCanvas createPath: [:builder |
 		builder
 			absolute;
@@ -191,19 +215,16 @@ AthensDemoMorph >> figure2: aCanvas [
 			lineTo: 70@300;
 			cwArcTo: 50@280 angle: 90 degreesToRadians;
 			lineTo: 50@120;
-			cwArcTo: 70@100 angle: 90 degreesToRadians
-	].
+			cwArcTo: 70@100 angle: 90 degreesToRadians ].
 
 	aCanvas
 		setPaint: self carColor;
-		drawShape: path 
-
+		drawShape: path
 ]
 
 { #category : #figures }
 AthensDemoMorph >> figure3: aCanvas [
-	| path |
-	
+	| path |	
 	path := aCanvas createPath: [:builder |
 		builder
 			relative;
@@ -220,15 +241,14 @@ AthensDemoMorph >> figure3: aCanvas [
 	aCanvas pathTransform scaleBy: self extent.
 	aCanvas
 		setPaint: self carColor;
-		drawShape: path 
-
+		drawShape: path
 ]
 
 { #category : #figures }
 AthensDemoMorph >> figure4: aCanvas [
 	| path stroke |
 	
-	path := self roundedRectanglePathOn: aCanvas.
+	path := self class roundedRectanglePathOn: aCanvas.
 	
 	aCanvas setShape: path.
 	
@@ -238,7 +258,7 @@ AthensDemoMorph >> figure4: aCanvas [
 	stroke := aCanvas setStrokePaint: Color black.
 	stroke width: 3.
 	
-	aCanvas draw. 
+	aCanvas draw
 ]
 
 { #category : #figures }
@@ -279,12 +299,11 @@ AthensDemoMorph >> figure6: aCanvas [
 		start:  0@100  
 		stop: 0@300.
 	
-	aCanvas setShape: (self roundedRectanglePathOn: aCanvas).
+	aCanvas setShape: (self class roundedRectanglePathOn: aCanvas).
 	
 	aCanvas setPaint: linearGradient.
 	
-	aCanvas draw.
-		
+	aCanvas draw
 ]
 
 { #category : #figures }
@@ -296,7 +315,6 @@ AthensDemoMorph >> figure7: aCanvas [
 	pt := aCanvas pathTransform.
 
 	pt restoreAfter:[
-
 		pt scaleBy: self extent .
 		self drawCarOn: aCanvas.
 
@@ -304,8 +322,7 @@ AthensDemoMorph >> figure7: aCanvas [
 		self drawCarOn: aCanvas.
 	
 		pt  translateBy: 2@0; rotateByDegrees: 35.
-		self drawCarOn: aCanvas.
-	].
+		self drawCarOn: aCanvas ]
 		
 ]
 
@@ -313,9 +330,8 @@ AthensDemoMorph >> figure7: aCanvas [
 AthensDemoMorph >> figure8: aCanvas [
 	| pt |
 	pt := aCanvas pathTransform.
-	pt restoreAfter:[
-		| stroke p  wheel decorator |
-		pt scaleBy: self extent .
+	pt restoreAfter:[	
+		pt scaleBy: self extent.
 		self drawBackgroundOn: aCanvas.
 
 		pt scaleBy: (frame/100) sin abs.
@@ -324,9 +340,7 @@ AthensDemoMorph >> figure8: aCanvas [
 		self drawCarOn: aCanvas.
 	
 		pt  translateBy: 2@0; rotateByDegrees: 35.
-		self drawCarOn: aCanvas.
-	
-	  ].
+		self drawCarOn: aCanvas ]
 		
 ]
 
@@ -350,10 +364,10 @@ AthensDemoMorph >> figure9: aCanvas [
 	
 	patternPaint := aCanvas setPaint: esugBallon .
 	patternPaint setExtend: #None.
-	aCanvas draw.
+	aCanvas draw
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #accessing }
 AthensDemoMorph >> figures [
 	^ #(
 	figure1:
@@ -366,12 +380,12 @@ AthensDemoMorph >> figures [
 	figure8:
 	figure9:
 	figure10:
-	).
+	)
 	
 	
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #initialization }
 AthensDemoMorph >> initialize [ 
 	| ref loadFileFailBlock|
 	super initialize.
@@ -381,14 +395,13 @@ AthensDemoMorph >> initialize [
 	current := 1.
 	frame := 0.
       loadFileFailBlock:= AthensCairoSurface fromForm:(Form fromDisplay: (0@0 extent:(300@150))).
-	ref := 	'Pharo.png' asFileReference.
+	ref := 'Pharo.png' asFileReference.
 	pharoLogo := AthensCairoSurface createFromFile:  ref fullName ifFailed:  [ loadFileFailBlock ].
 
 	ref := 'esug-balloon.png' asFileReference.
 	esugBallon := AthensCairoSurface createFromFile:  ref fullName ifFailed:  [ loadFileFailBlock ].
-
 	
-	self startStepping.
+	self startStepping
 	
 ]
 
@@ -421,33 +434,13 @@ AthensDemoMorph >> render [
 
 ]
 
-{ #category : #figures }
-AthensDemoMorph >> roundedRectanglePathOn: aCanvas [
-
-	^ aCanvas createPath: [:builder |
-		builder
-			absolute;
-			moveTo: 70@100;
-			lineTo: 330@100;
-			cwArcTo: 350@120 angle: 90 degreesToRadians;
-			lineTo: 350@280;
-			cwArcTo: 330@300 angle: 90 degreesToRadians;
-			lineTo: 70@300;
-			cwArcTo: 50@280 angle: 90 degreesToRadians;
-			lineTo: 50@120;
-			cwArcTo: 70@100 angle: 90 degreesToRadians
-	].
-
-
-]
-
-{ #category : #accessing }
+{ #category : #'stepping and presenter' }
 AthensDemoMorph >> step [
 	frame := frame + 1.
 	self changed
 ]
 
-{ #category : #accessing }
+{ #category : #'model - stepping' }
 AthensDemoMorph >> stepTime [
 	^ 0
 ]

--- a/src/Athens-Examples/AthensFlakeDemo.class.st
+++ b/src/Athens-Examples/AthensFlakeDemo.class.st
@@ -11,20 +11,20 @@ Class {
 		'frame',
 		'spike'
 	],
-	#category : #'Athens-Examples'
+	#category : #'Athens-Examples-Demos'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AthensFlakeDemo >> circle [
 	^ circle 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #defaults }
 AthensFlakeDemo >> defaultExtent [
 	^ 800@800
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #drawing }
 AthensFlakeDemo >> drawCircles: canvas [
 
 	canvas pathTransform restoreAfter: [
@@ -49,7 +49,7 @@ AthensFlakeDemo >> drawCircles: canvas [
 	]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #drawing }
 AthensFlakeDemo >> drawOn: aCanvas [
 
 	self render.
@@ -57,7 +57,7 @@ AthensFlakeDemo >> drawOn: aCanvas [
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #drawing }
 AthensFlakeDemo >> drawSpike: canvas [
 
 
@@ -90,7 +90,7 @@ AthensFlakeDemo >> drawSpike: canvas [
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 AthensFlakeDemo >> initialize [ 
 
 	super initialize.
@@ -124,7 +124,7 @@ AthensFlakeDemo >> initialize [
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #rendering }
 AthensFlakeDemo >> render [ 
 
 	surface drawDuring: [:canvas | 
@@ -149,14 +149,14 @@ AthensFlakeDemo >> render [
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'stepping and presenter' }
 AthensFlakeDemo >> step [
 	frame := Time millisecondClockValue / 100.
 	
 	self changed
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'model - stepping' }
 AthensFlakeDemo >> stepTime [
 	^ 0
 ]

--- a/src/Athens-Examples/AthensMorphScene.class.st
+++ b/src/Athens-Examples/AthensMorphScene.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'morph'
 	],
-	#category : #'Athens-Examples'
+	#category : #'Athens-Examples-Utilities'
 }
 
 { #category : #accessing }
@@ -22,7 +22,7 @@ AthensMorphScene >> morph: anObject [
 	morph := anObject
 ]
 
-{ #category : #accessing }
+{ #category : #rendering }
 AthensMorphScene >> renderOn:aCanvas [
 	morph fullDrawOnAthensCanvas: aCanvas
 ]

--- a/src/Athens-Examples/AthensSimpleTreeNode.class.st
+++ b/src/Athens-Examples/AthensSimpleTreeNode.class.st
@@ -15,7 +15,7 @@ Class {
 		'originY',
 		'color'
 	],
-	#category : #'Athens-Examples'
+	#category : #'Athens-Examples-Utilities'
 }
 
 { #category : #accessing }
@@ -30,12 +30,12 @@ AthensSimpleTreeNode >> box: anObject [
 	box := anObject
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AthensSimpleTreeNode >> children [
 	^ children
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AthensSimpleTreeNode >> children: aCollection [
 
 	children := aCollection
@@ -70,7 +70,7 @@ AthensSimpleTreeNode >> height [
 	^ extent y
 ]
 
-{ #category : #accessing }
+{ #category : #private }
 AthensSimpleTreeNode >> layoutHorizontally: center [
 	| pos |
 	"position ourselves in the middle X"
@@ -102,12 +102,12 @@ AthensSimpleTreeNode >> layoutWidth [
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AthensSimpleTreeNode >> midBottom [
 	^ originX +(extent x *0.5) @ (originY + extent y)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AthensSimpleTreeNode >> midTop [
 	^ originX +(extent x *0.5) @ originY 
 ]
@@ -127,7 +127,7 @@ AthensSimpleTreeNode >> originY: aNumber [
 	originY := aNumber
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #rendering }
 AthensSimpleTreeNode >> renderOn: aCanvas [
 
 	aCanvas setPaint: color.
@@ -161,7 +161,7 @@ AthensSimpleTreeNode >> renderOn: aCanvas [
 	]
 ]
 
-{ #category : #accessing }
+{ #category : #defaults }
 AthensSimpleTreeNode >> spacingBetweenChilds [
 	^ 10
 ]

--- a/src/Athens-Examples/AthensSurfaceExamples.class.st
+++ b/src/Athens-Examples/AthensSurfaceExamples.class.st
@@ -1,8 +1,5 @@
 "
-AthensCairoSurfaceExamples example1.
-AthensCairoSurfaceExamples example2.
-
-AthensBalloonSurfaceExamples example6.
+See examples on the class side and on class side of subclasses
 "
 Class {
 	#name : #AthensSurfaceExamples,
@@ -10,15 +7,13 @@ Class {
 	#instVars : [
 		'renderBlock'
 	],
-	#category : #'Athens-Examples'
+	#category : #'Athens-Examples-Demos'
 }
 
 { #category : #examples }
 AthensSurfaceExamples class >> draw2Strings [
-"
-self subclasses anyOne exampleDrawText
-"
-	| surf  font1 font2 ascent advance |
+ 	<example>
+	| surf font1 font2 ascent advance |
 	
 	font1 := LogicalFont familyName: 'Arial' pointSize: 10.
 	font2 := LogicalFont familyName: 'Tahoma' pointSize: 20.
@@ -48,21 +43,15 @@ self subclasses anyOne exampleDrawText
 		advance := can drawString: 'IT'.
 		can setFont: font1.
 		can pathTransform translateBy: advance.
-		can drawString: 'in mind.'.
-		
-	].
+		can drawString: 'in mind.'].
+	
 	Display getCanvas drawImage: 	surf asForm  at: 0@0
-
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> drawFontMetrics [
-"
-self  drawFontMetrics
-"
-	|   font |
-	
-	
+ 	<example>
+	| font |
 	font := LogicalFont familyName: 'Arial' pointSize: 10.
 	self openViewOn: [ :can |
 
@@ -96,23 +85,19 @@ self  drawFontMetrics
 			builder 
 				moveTo: 0@font getPreciseAscent;
 				lineTo: 400@0
-			 ] ).
+			 ]).
 				
 		can setFont: font.
 		can setPaint: (Color black).
 		can pathTransform translateX: 0 Y: (font getPreciseAscent).
 		can drawString: 'yh'.
-		] ]
+		]]
 
- 
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> example1 [
 
-"
-self  example1
-"
 	self openViewOn: [ :can |
 		can pathTransform restoreAfter: [ 
 
@@ -129,13 +114,9 @@ self  example1
 
 { #category : #examples }
 AthensSurfaceExamples class >> example10 [ 
-" draw a rounded rectangle, using the arc segments
+	"Draw a rounded rectangle, using the arc segments"
 
-AthensCairoSurfaceExamples example10.
-"
-
-	| surf |
-	
+	| surf |	
 	surf := self newSurface: 440@440.
 	
 	surf drawDuring: [:can |
@@ -170,13 +151,8 @@ AthensCairoSurfaceExamples example10.
 
 { #category : #examples }
 AthensSurfaceExamples class >> example2 [
-"
-Draw a path on surface.
-
-self example2.
-
-
-"
+	"Draw a path on surface."
+	
 	self openViewOn: [ :can |
 		can setPaint: Color blue.
 		
@@ -187,25 +163,19 @@ self example2.
 					lineTo: 50@0;
 					lineTo: 50@50;
 					lineTo: 0@100
-			])
-	
-	].
+			])	
+	]
  
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> example3 [
-" 
-Draw simple filled path, changing the transformation and colors to get some animated effects.
-
- self example3 
-"
-	| surf |
+	"Draw simple filled path, changing the transformation and colors to get some animated effects."
 	
+	| surf |	
 	surf := self newSurface: 800@800.
 	
-	surf drawDuring: [:can | | transform path |
-	
+	surf drawDuring: [:can | | path |	
 		can setPaint: Color blue.
 
 		can pathTransform translateX: 200 Y: 200.	
@@ -219,36 +189,28 @@ Draw simple filled path, changing the transformation and colors to get some anim
 				curveVia: -25@25 to: -25@ -25
 		].
 		
-		
-			1 to: 1000 do: [:i |
-				can setPaint: Color random.
+		1 to: 1000 do: [:i |
+			can setPaint: Color random.
 
-				can pathTransform restoreAfter: [
-
-					can pathTransform rotateByDegrees: i*5.
-					can pathTransform scaleBy: (1- ( i/2000)).
-					can drawShape: path.
-				].
-				Display getCanvas drawImage: 	surf asForm  at: 0@0. 
+			can pathTransform restoreAfter: [
+				can pathTransform rotateByDegrees: i*5.
+				can pathTransform scaleBy: (1 - (i/2000)).
+				can drawShape: path ].
+			
+			Display getCanvas drawImage: surf asForm  at: 0@0. 
 		]	
-	].
+	]
 
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> example3stroke [
-" 
-Draw simple stroke  path, changing the transformation and colors to get some animated effects.
-
- self  example3stroke 
-"
+	"Draw simple stroke  path, changing the transformation and colors to get some animated effects."
 
 	| surf |
-	
 	surf := self newSurface: 400@400.
 	
 	surf drawDuring: [:can | |  path |
-	
 		(can setStrokePaint: Color blue) width: 1.
 
 		can pathTransform translateX: 200 Y: 200.	
@@ -259,20 +221,18 @@ Draw simple stroke  path, changing the transformation and colors to get some ani
 					absolute;
 					moveTo: -25 @ -25;
 					curveVia: 25@ -25 to: 25@25;
-					curveVia: -25@25 to: -25@ -25
-			].
+					curveVia: -25@25 to: -25@ -25 ].
 		
 		1 to: 1000 do: [:i |
-		
 			(can setStrokePaint: Color random) width: 1.
 			can pathTransform restoreAfter: [
 				can pathTransform rotateByDegrees: i*5.
 				can pathTransform scaleBy: (1- ( i/2000)).
 				can drawShape: path.
 			].
-			Display getCanvas drawImage: 	surf asForm  at: 0@0. 
+			Display getCanvas drawImage: surf asForm  at: 0@0 
 		]	
-	].
+	]
 
 ]
 
@@ -280,9 +240,7 @@ Draw simple stroke  path, changing the transformation and colors to get some ani
 AthensSurfaceExamples class >> example4 [
 	" 
 	This example demostrates that same path could be reused multiple times when drawing.
-	First, we creating a path, and later we can use it in #drawShape: command.
-	self example4
-	"
+	First, we creating a path, and later we can use it in #drawShape: command."
 
 	| surf path |
 	
@@ -301,20 +259,17 @@ AthensSurfaceExamples class >> example4 [
 		can drawShape: path.
 	].
 	Display getCanvas drawImage: 	surf asForm  at: 0@0
-
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> example5 [
-" draw a hollow rectangle (frame) using lineTo/moveTo commands,
- with path, consisting of two contours: outer and inner one.
+	"Draw a hollow rectangle (frame) using lineTo/moveTo commands,
+ 	 with path, consisting of two contours: outer and inner one.
 
-Note how #moveTo: command implicitly starts new contour
-when inssued in the middle of command chain.
-self example5
-"
-	| surf |
+	 Note how #moveTo: command implicitly starts new contour
+	 when inssued in the middle of command chain."
 	
+	| surf |	
 	surf := self newSurface: 100@100.
 	
 	surf drawDuring: [:can |
@@ -334,30 +289,23 @@ self example5
 					lineTo: 40@40;
 					lineTo: 40@10
 			])
-	
 	].
 
 	Display getCanvas drawImage: 	surf asForm  at: 0@0
-
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> example6 [
-"Draw two rectangles, filled by linear gradient. 
-
-Note that it should produce same rectangles with exact same fills, because gradient paint 
-coordinates are affected by pathTransform matrix.
-
-
-self example6
-"
+	"Draw two rectangles, filled by linear gradient. 
+	 
+	 Note that it should produce same rectangles with exact same fills, because gradient paint 
+	 coordinates are affected by pathTransform matrix."
 
 	| surf paint |
-	
 	surf := self newSurface: 100@200.
 	
 	paint := surf 
-		createLinearGradient: { 0->Color red .  1->Color green } 
+		createLinearGradient: { 0->Color red. 1->Color green } 
 		start: 0@0 
 		stop: 50@50.
 	
@@ -369,31 +317,24 @@ self example6
 		can drawShape: (0@0 corner: 50@50).
 		
 		can pathTransform translateX: 50 Y: 50; rotateByDegrees: 30.
-		can drawShape: (0@0 corner: 50@50).
-		
-	].
+		can drawShape: (0@0 corner: 50@50) ].
 
-	Display getCanvas drawImage: 	surf asForm  at: 0@0
+	Display getCanvas drawImage: surf asForm  at: 0@0
 
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> example6point1 [
-"Draw two rectangles, filled by linear gradient. 
+	"Draw two rectangles, filled by linear gradient. 
 
-Note that it should produce same rectangles with exact same fills, because gradient paint 
-coordinates are affected by pathTransform matrix.
-
-
-self example6point1
-"
+	Note that it should produce same rectangles with exact same fills, because gradient paint 
+	coordinates are affected by pathTransform matrix."
 
 	| surf paint |
-	
 	surf := self newSurface: 100@200.
 	
 	paint := surf 
-		createLinearGradient: { 0->Color red .  1->Color green } 
+		createLinearGradient: { 0->Color red. 1->Color green } 
 		start: 0@0 
 		stop: 30@30.
 	
@@ -402,30 +343,23 @@ self example6point1
 		
 		can setPaint: paint.
 
-		can drawShape: (0@0 corner: 50@50).
-	].
+		can drawShape: (0@0 corner: 50@50) ].
 
-	Display getCanvas drawImage: 	surf asForm  at: 0@0
-
+	Display getCanvas drawImage: surf asForm at: 0@0
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> example6stroke [
-"
-self example6stroke
+	"Draw two rectangles, stoked by linear gradient. 
 
-
-Draw two rectangles, stoked by linear gradient. 
-
-Note that it should produce same rectangles with exact same fills, because gradient paint 
-coordinates are affected by pathTransform matrix.
-"
-	| surf paint |
+	 Note that it should produce same rectangles with exact same fills, because gradient paint 
+	 coordinates are affected by pathTransform matrix."
 	
+	| surf paint |	
 	surf := self newSurface: 100@100.
 	
 	paint := surf 
-		createLinearGradient: { 0->Color red .  1->Color green } 
+		createLinearGradient: { 0->Color red. 1->Color green } 
 		start: 0@0 
 		stop: 50@50.
 	
@@ -437,31 +371,24 @@ coordinates are affected by pathTransform matrix.
 		can drawShape: (0@0 corner: 50@50).
 		
 		can pathTransform translateX: 50 Y: 50.
-		can drawShape: (0@0 corner: 50@50).
-		
-	].
+		can drawShape: (0@0 corner: 50@50) ].
 
 	Display getCanvas drawImage: 	surf asForm  at: 0@0
-
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> example7 [
-"Draw two rectangles, filled by linear gradient. 
-Rotate the gradient in a loop.
+	"Draw two rectangles, filled by linear gradient. 
+	 Rotate the gradient in a loop.
 
-Note that it should produce same rectangles with exact same fills, because gradient paint 
-coordinates are affected by pathTransform matrix.
+	 Note that it should produce same rectangles with exact same fills, because gradient paint 
+	 coordinates are affected by pathTransform matrix."
 
-self example7
-"
-
-	| surf paint |
-	
+	| surf paint |	
 	surf := self newSurface: 100@100.
 	
 	paint := surf 
-		createLinearGradient: { 0->Color red .  1->Color green } 
+		createLinearGradient: { 0->Color red. 1->Color green } 
 		start: 0@0 
 		stop: 50@50.
 	
@@ -480,24 +407,19 @@ self example7
 			can pathTransform translateX: 50 Y: 50.
 			can drawShape: (0@0 corner: 50@50).
 
-			Display getCanvas drawImage: 	surf asForm  at: 0@0
+			Display getCanvas drawImage: surf asForm at: 0@0
 		].		
-	].
-
-
+	]
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> example8 [
-"Draw a rectangle filled by radial gradient. 
-self example8
-"
+	"Draw a rectangle filled by radial gradient."
 	| surf paint |
 	
-	surf := self newSurface: 200@200.
-	
+	surf := self newSurface: 200@200.	
 	paint := surf 
-		createRadialGradient: { 0->Color red . 1->Color green } 
+		createRadialGradient: { 0->Color red. 1->Color green } 
 		center: 100@100
 		radius: 100.
 	
@@ -509,22 +431,15 @@ self example8
 
 			can drawShape: (0@0 corner: 200@200).
 		
-			Display getCanvas drawImage: 	surf asForm  at: 0@0
-	].
-
-
+			Display getCanvas drawImage: surf asForm  at: 0@0 ]
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> example9 [
-"
-Fill the rectangle using image paint.
-self example9
-"
-	| surf paint f  |
+	"Fill the rectangle using image paint."
 	
-	surf := self newSurface: 200@200.
-	
+	| surf paint f  |	
+	surf := self newSurface: 200@200.	
 	surf asForm getCanvas fillRectangle: surf asForm boundingBox color: Color white.
 	
 	f := Form extent: 10@10 depth: 32.
@@ -535,24 +450,18 @@ self example9
 	
 	surf drawDuring: [:can |
 
-			can setPaint: paint.
-
-			can drawShape: (0@0 corner: 100@200).
+		can 
+			setPaint: paint;
+			drawShape: (0@0 corner: 100@200).
 		
-			Display getCanvas drawImage: 	surf asForm  at: 0@0
-	].
-
+		Display getCanvas drawImage: surf asForm  at: 0@0 ]
 
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> exampleClip [
 
-"
-self exampleClip
-"
 	| surf |
-	
 	surf := self newSurface: 100@100.
 	
 	surf drawDuring: [:can |
@@ -568,15 +477,13 @@ self exampleClip
 			can drawShape: (0@0 corner: 100@ 100).
 		]
 	].
-	Display getCanvas drawImage: 	surf asForm  at: 0@0
-
+	Display getCanvas drawImage: surf asForm at: 0@0
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> exampleDrawForm [
-"self exampleDrawForm"
+ 
 	| surf surf2   |
-
 	surf2 := self newSurface: 100@100.
 	surf2 drawDuring: [:c |
 		c setPaint: (Color red alpha: 0.5) .
@@ -597,20 +504,16 @@ AthensSurfaceExamples class >> exampleDrawForm [
 		can draw.
 
 		can pathTransform translateX: 30 Y: 30. 
-		can draw.
-
-	].
+		can draw ].
 	Display getCanvas drawImage: surf asForm  at: 0@0
-
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> exampleDrawForm2 [
-"self exampleDrawForm2"
-	| surf  |
-		
+ 
+	| surf  |		
 	surf := self newSurface: 300@300.
-	
+		
 	surf drawDuring: [:can |
 		surf clear.
 		can pathTransform loadIdentity.
@@ -622,19 +525,15 @@ AthensSurfaceExamples class >> exampleDrawForm2 [
 		 translateX: 60 Y: 60. 
 		(can setPaint: (self iconNamed: #helpIcon)) repeat.
 		can paintTransform scaleBy: 3; rotateByDegrees: 30.
-		can draw.
-	].
+		can draw ].
+	
 	Display getCanvas drawImage: surf asForm  at: 0@0
-
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> exampleDrawText [
-"
-self subclasses anyOne exampleDrawText
-"
+ 
 	| surf  font |
-	
 	font := LogicalFont familyName: 'Arial' pointSize: 20.
 
 	surf := self newSurface: 300@100.
@@ -650,31 +549,24 @@ self subclasses anyOne exampleDrawText
 		"translate an origin by font's ascent, otherwise 
 		we will see only things below baseline"
 		can pathTransform translateX: 0 Y: (font getPreciseAscent).
-		can drawString: 'Hello Athens!'.
-	].
-	Display getCanvas drawImage: 	surf asForm  at: 0@0
+		can drawString: 'Hello Athens!' ].
+	
+	Display getCanvas drawImage: surf asForm at: 0@0
 
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> exampleStrokeRect [
-" 
-Draw a frame rectangle, rotate & transform it in a loop
-
- self exampleStrokeRect
-"
+	"Draw a frame rectangle, rotate & transform it in a loop"
 
 	| surf |
-	
 	surf := self newSurface: 400@400.
 	
-	surf drawDuring: [:can | | path |
-	
+	surf drawDuring: [:can | 	
 		can pathTransform translateX: 200 Y: 200.	
 		can pathTransform scaleBy: 8.
 		
 		1 to: 1000 do: [:i |
-		
 			(can setStrokePaint: Color random) width: 1.
 			can pathTransform restoreAfter: [
 				can pathTransform rotateByDegrees: i*5.
@@ -683,15 +575,13 @@ Draw a frame rectangle, rotate & transform it in a loop
 				can drawShape: (0@0 corner: 25@25) ].
 			Display getCanvas drawImage: 	surf asForm  at: 0@0. 
 		]	
-	].
-
+	]
 ]
 
 { #category : #examples }
 AthensSurfaceExamples class >> exampleUseForm [
-" self exampleUseForm"
+
 	| surf  form |
-	
 	form := Form extent: 100@100 depth: 32.
 	form getCanvas fillRectangle: (0@0 corner: 30@30)  color: (Color red).
 	form getCanvas fillRectangle: (10@10 corner: 40@40)  color: (Color green).
@@ -704,10 +594,12 @@ AthensSurfaceExamples class >> exampleUseForm [
 
 { #category : #'instance creation' }
 AthensSurfaceExamples class >> newAsSceneFrom: aBlock [
-	^ self new renderBlock: aBlock; yourself
+	^ self new
+		renderBlock: aBlock;
+		yourself
 ]
 
-{ #category : #'instance initialization' }
+{ #category : #utilities }
 AthensSurfaceExamples class >> newSurface:  extent [
 	^ AthensCairoSurfaceExamples newSurface: extent
 ]
@@ -745,7 +637,7 @@ AthensSurfaceExamples >> renderBlock: anObject [
 	renderBlock := anObject
 ]
 
-{ #category : #drawing }
+{ #category : #rendering }
 AthensSurfaceExamples >> renderOn: aCanvas [
 	renderBlock value: aCanvas
 ]

--- a/src/Athens-Examples/AthensTigerShape.class.st
+++ b/src/Athens-Examples/AthensTigerShape.class.st
@@ -17,55 +17,55 @@ Class {
 		'fillPaint',
 		'stroke'
 	],
-	#category : #'Athens-Examples'
+	#category : #'Athens-Examples-Utilities'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AthensTigerShape >> addFill [
 	fill := true.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AthensTigerShape >> addStroke [
 	stroke := true.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AthensTigerShape >> capStyle: cap [
 	capStyle := cap.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AthensTigerShape >> fillPaint: aColor [ 
 	fillPaint := aColor
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AthensTigerShape >> fillRule [
 	^ fillRule
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AthensTigerShape >> fillRule: rule [ 
 	fillRule := rule.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 AthensTigerShape >> initialize [ 
 	fill := stroke := false.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AthensTigerShape >> joinStyle: join [
 	joinStyle := join.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AthensTigerShape >> miterLimit: lim [
 	miterLimit := lim.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #rendering }
 AthensTigerShape >> prepareFor: surface [
 	fill ifTrue: [
 		fillPaint := surface createSolidColorPaint: fillPaint.
@@ -79,7 +79,7 @@ AthensTigerShape >> prepareFor: surface [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #rendering }
 AthensTigerShape >> renderOn: can [
 
 	fill ifTrue: [ 
@@ -93,17 +93,17 @@ AthensTigerShape >> renderOn: can [
 	]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AthensTigerShape >> setPath: anAthensCairoPath [
 		path := anAthensCairoPath
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AthensTigerShape >> strokePaint: aColor [ 
 	strokePaint := aColor
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AthensTigerShape >> strokeWidth: w [
 	strokeWidth := w
 ]

--- a/src/Athens-Examples/AthensTreeView.class.st
+++ b/src/Athens-Examples/AthensTreeView.class.st
@@ -10,13 +10,15 @@ Class {
 		'root',
 		'rows'
 	],
-	#category : #'Athens-Examples'
+	#category : #'Athens-Examples-Demos'
 }
 
 { #category : #examples }
 AthensTreeView class >> example1 [
-
-	AthensTreeView openOn: Collection extentBlock: [ :each | (5 + each instVarNames size)@(5 + each methodDict size)  ] childsBlock: [:el | el subclasses ] 
+	AthensTreeView
+		openOn: Collection
+		extentBlock: [ :each | (5 + each instVarNames size) @ (5 + each methodDict size) ]
+		childsBlock: [ :el | el subclasses ]
 ]
 
 { #category : #'instance creation' }

--- a/src/Athens-Examples/CurveWorkshop.class.st
+++ b/src/Athens-Examples/CurveWorkshop.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'surface'
 	],
-	#category : #'Athens-Examples'
+	#category : #'Athens-Examples-Workshop'
 }
 
 { #category : #colors }

--- a/src/Athens-Examples/VGTigerDemo.class.st
+++ b/src/Athens-Examples/VGTigerDemo.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'surface'
 	],
-	#category : #'Athens-Examples'
+	#category : #'Athens-Examples-Demos'
 }
 
 { #category : #private }
@@ -265,7 +265,7 @@ VGTigerDemo class >> tigerCommands [
 'CEFNRMMCCCCEFNRMMCCC'
 'EFNRMMCCCEFNRMMCCCEF'
 'NRMMLCLNSRMMLNSRMMCN'
-'SRMMCNSRMMC' ).
+'SRMMCNSRMMC' )
 ]
 
 { #category : #private }


### PR DESCRIPTION
- Fix uncategorized methods
- tag classes
- format some code
- unnecessary temps in methods like #figure8
- cleanup inconsistent method classifications
- remove unnecessary dots at end of expressions
- ...

https://pharo.fogbugz.com/f/cases/21788/