### PR TITLE
21794 Correctly deprecate #displayProgressAt:from:to:during: and clea…

### DIFF
--- a/src/Deprecated70/DiffChangeMorph.extension.st
+++ b/src/Deprecated70/DiffChangeMorph.extension.st
@@ -1,5 +1,5 @@
 Extension { #name : #DiffChangeMorph }
- 
+
 { #category : #'*Deprecated70' }
 DiffChangeMorph >> initialColorInSystemWindow: aSystemWindow [
 	"Answer the colour the receiver should be when added to a SystemWindow."

--- a/src/Deprecated70/String.extension.st
+++ b/src/Deprecated70/String.extension.st
@@ -1,0 +1,30 @@
+Extension { #name : #String }
+
+{ #category : #'*Deprecated70' }
+String >> displayProgressAt: aPoint from: minVal to: maxVal during: workBlock [ 
+	"Deprecated! - Display this string as a caption over a progress bar while workBlock is evaluated.
+
+EXAMPLE (Select next 6 lines and Do It)
+'Now here''s some Real Progress'
+	displayProgressAt: Sensor cursorPoint
+	from: 0 to: 10
+	during: [:bar |
+	1 to: 10 do: [:x | bar value: x.
+			(Delay forMilliseconds: 500) wait]].
+
+HOW IT WORKS (Try this in any other language :-)
+Since your code (the last 2 lines in the above example) is in a block,
+this method gets control to display its heading before, and clean up 
+the screen after, its execution.
+The key, though, is that the block is supplied with an argument,
+named 'bar' in the example, which will update the bar image every 
+it is sent the message value: x, where x is in the from:to: range.
+"
+	self deprecated: 'Use displayProgressFrom: minVal to: maxVal during: workBlock'.
+
+	^UIManager default 
+		displayProgress: self
+		from: minVal 
+		to: maxVal 
+		during: workBlock
+]

--- a/src/UIManager/Collection.extension.st
+++ b/src/UIManager/Collection.extension.st
@@ -3,8 +3,9 @@ Extension { #name : #Collection }
 { #category : #'*UIManager' }
 Collection >> do: aBlock displayingProgress: aStringOrBlock [
 	"Enumerate aBlock displaying progress information. 
-	If the argument is a string, use a static label for the process. 
-	If the argument is a block, evaluate it with the element to retrieve the label.
+ 	 If the argument is a string, use a static label for the process. 
+	 If the argument is a block, evaluate it with the element to retrieve the label.
+	
 		Smalltalk allClasses 
 			do:[:aClass| (Delay forMilliseconds: 1) wait]
 			displayingProgress: 'Processing...'.
@@ -17,10 +18,10 @@ Collection >> do: aBlock displayingProgress: aStringOrBlock [
 
 { #category : #'*UIManager' }
 Collection >> do: aBlock displayingProgress: aStringOrBlock every: msecs [
-       "Enumerate aBlock displaying progress information.
-       If the argument is a string, use a static label for the process.
-       If the argument is a block, evaluate it with the element to retrieve the label.
-       The msecs argument ensures that updates happen at most every msecs.
+	"Enumerate aBlock displaying progress information.
+ 	 If the argument is a string, use a static label for the process.
+	 If the argument is a block, evaluate it with the element to retrieve the label.
+ 	 The msecs argument ensures that updates happen at most every msecs.
        Example:
                Smalltalk allClasses
                        do:[:aClass| (Delay forMilliseconds: 1) wait]

--- a/src/UIManager/CommandLineUIManager.class.st
+++ b/src/UIManager/CommandLineUIManager.class.st
@@ -12,7 +12,7 @@ Class {
 	#classVars : [
 		'SnapshotErrorImage'
 	],
-	#category : #UIManager
+	#category : #'UIManager-Base'
 }
 
 { #category : #testing }

--- a/src/UIManager/DummyUIManager.class.st
+++ b/src/UIManager/DummyUIManager.class.st
@@ -7,7 +7,7 @@ Class {
 	#classVars : [
 		'ProgressBarEnabled'
 	],
-	#category : #UIManager
+	#category : #'UIManager-Base'
 }
 
 { #category : #'ui requests' }

--- a/src/UIManager/ErrorNonInteractive.class.st
+++ b/src/UIManager/ErrorNonInteractive.class.st
@@ -9,7 +9,7 @@ Class {
 	#instVars : [
 		'exception'
 	],
-	#category : #UIManager
+	#category : #'UIManager-Errors'
 }
 
 { #category : #signalling }

--- a/src/UIManager/ManifestUIManager.class.st
+++ b/src/UIManager/ManifestUIManager.class.st
@@ -1,7 +1,10 @@
+"
+Package for the UI Manager and related classes
+"
 Class {
 	#name : #ManifestUIManager,
 	#superclass : #PackageManifest,
-	#category : #UIManager
+	#category : #'UIManager-Manifest'
 }
 
 { #category : #'meta-data - dependency analyser' }

--- a/src/UIManager/NonInteractiveUIManager.class.st
+++ b/src/UIManager/NonInteractiveUIManager.class.st
@@ -14,7 +14,7 @@ You can replace the default UI Manager with my instance in cases, when you need 
 Class {
 	#name : #NonInteractiveUIManager,
 	#superclass : #CommandLineUIManager,
-	#category : #UIManager
+	#category : #'UIManager-Base'
 }
 
 { #category : #testing }

--- a/src/UIManager/Object.extension.st
+++ b/src/UIManager/Object.extension.st
@@ -15,7 +15,8 @@ Object >> confirm: queryString [
 Object >> inform: aString [
 	"Display a message for the user to read and then dismiss."
 
-	aString isEmptyOrNil ifFalse: [UIManager default inform: aString]
+	aString isEmptyOrNil
+		ifFalse: [ UIManager default inform: aString ]
 ]
 
 { #category : #'*UIManager' }
@@ -23,5 +24,5 @@ Object >> primitiveError: aString [
 	"This method is called when the error handling results in a recursion in 
 	calling on error: or halt or halt:."
 
-	UIManager default onPrimitiveError: aString.
+	UIManager default onPrimitiveError: aString
 ]

--- a/src/UIManager/String.extension.st
+++ b/src/UIManager/String.extension.st
@@ -1,40 +1,11 @@
 Extension { #name : #String }
 
-{ #category : #'*UIManager-Support' }
-String >> displayProgressAt: aPoint from: minVal to: maxVal during: workBlock [ 
-	"Deprecated! - Display this string as a caption over a progress bar while workBlock is evaluated.
-
-EXAMPLE (Select next 6 lines and Do It)
-'Now here''s some Real Progress'
-	displayProgressAt: Sensor cursorPoint
-	from: 0 to: 10
-	during: [:bar |
-	1 to: 10 do: [:x | bar value: x.
-			(Delay forMilliseconds: 500) wait]].
-
-HOW IT WORKS (Try this in any other language :-)
-Since your code (the last 2 lines in the above example) is in a block,
-this method gets control to display its heading before, and clean up 
-the screen after, its execution.
-The key, though, is that the block is supplied with an argument,
-named 'bar' in the example, which will update the bar image every 
-it is sent the message value: x, where x is in the from:to: range.
-"
-	"deprecated use displayProgressFrom: minVal to: maxVal during: workBlock "
-
-	^UIManager default 
-		displayProgress: self
-		from: minVal 
-		to: maxVal 
-		during: workBlock
-]
-
-{ #category : #'*UIManager-Support' }
+{ #category : #'*UIManager' }
 String >> displayProgressFrom: minVal to: maxVal during: workBlock [ 
 	"Display this string as a caption over a progress bar while workBlock is evaluated.
 
 EXAMPLE (Select next 6 lines and Do It)
-'Now here''s some Real Progress'
+'Now here''s some real progress'
 	displayProgressFrom: 0 to: 10
 	during: [:bar |
 	1 to: 10 do: [:x | bar value: x.

--- a/src/UIManager/UIManager.class.st
+++ b/src/UIManager/UIManager.class.st
@@ -7,7 +7,7 @@ Class {
 	#classVars : [
 		'Default'
 	],
-	#category : #UIManager
+	#category : #'UIManager-Base'
 }
 
 { #category : #initialization }


### PR DESCRIPTION
…nups in UIManager package

- correctly deprecate displayProgressAt:from:to:during: and move it to deprecated package
- add package/manifest comment
- categorized classes that were not categorized
- formatting cleanups

https://pharo.fogbugz.com/f/cases/21794/Correctly-deprecate-displayProgressAt-from-to-during-and-cleanups-in-UIManager-package