### PR TITLE
Move AuthorTest, SmalltalkImageTest, SystemDictionaryTest and other to package "System-Support-Tests"

### DIFF
--- a/src/System-Support-Tests/AuthorTest.class.st
+++ b/src/System-Support-Tests/AuthorTest.class.st
@@ -1,10 +1,13 @@
+"
+SUnit tests for Author
+"
 Class {
 	#name : #AuthorTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'author'
 	],
-	#category : #'Tests-System'
+	#category : #'System-Support-Tests'
 }
 
 { #category : #tests }

--- a/src/System-Support-Tests/AuthorTest.class.st
+++ b/src/System-Support-Tests/AuthorTest.class.st
@@ -12,5 +12,5 @@ Class {
 
 { #category : #tests }
 AuthorTest >> testUniqueness [
-	self should: [ Author new ] raise: Error.
+	self should: [ Author new ] raise: Error
 ]

--- a/src/System-Support-Tests/SmalltalkImageTest.class.st
+++ b/src/System-Support-Tests/SmalltalkImageTest.class.st
@@ -1,7 +1,10 @@
+"
+Tests for SmalltalkImage
+"
 Class {
 	#name : #SmalltalkImageTest,
 	#superclass : #TestCase,
-	#category : #'Tests-System'
+	#category : #'System-Support-Tests'
 }
 
 { #category : #'tests-arguments' }

--- a/src/System-Support-Tests/SystemDictionaryTest.class.st
+++ b/src/System-Support-Tests/SystemDictionaryTest.class.st
@@ -1,7 +1,10 @@
+"
+SUnit tests for SystemDictionary
+"
 Class {
 	#name : #SystemDictionaryTest,
 	#superclass : #DictionaryTest,
-	#category : #'Tests-System'
+	#category : #'System-Support-Tests'
 }
 
 { #category : #'building suites' }
@@ -22,9 +25,9 @@ SystemDictionaryTest >> classToBeTested [
 	^ SystemDictionary
 ]
 
-{ #category : #problems }
+{ #category : #tests }
 SystemDictionaryTest >> testClassComment [
-	self should: [self targetClass organization hasComment].
+	self assert: self targetClass organization hasComment
 ]
 
 { #category : #tests }
@@ -102,9 +105,9 @@ SystemDictionaryTest >> testSmalltalkSelfEvaluating [
 	self assert: Smalltalk isSelfEvaluating
 ]
 
-{ #category : #problems }
+{ #category : #tests }
 SystemDictionaryTest >> testUnCategorizedMethods [
 	| categories slips  |	categories := self categoriesForClass: self targetClass.
 	slips := categories select: [:each | each = #'as yet unclassified'].
-	self should: [slips isEmpty].	
+	self assert: slips isEmpty	
 ]

--- a/src/System-Support-Tests/SystemNavigationOnNewlyCreatedEnvironmentTest.class.st
+++ b/src/System-Support-Tests/SystemNavigationOnNewlyCreatedEnvironmentTest.class.st
@@ -1,7 +1,10 @@
+"
+SUnit tests for SystemNavigation on newly created environments
+"
 Class {
 	#name : #SystemNavigationOnNewlyCreatedEnvironmentTest,
 	#superclass : #SystemNavigationTest,
-	#category : #'Tests-System'
+	#category : #'System-Support-Tests'
 }
 
 { #category : #'building suites' }

--- a/src/System-Support-Tests/SystemNavigationTest.class.st
+++ b/src/System-Support-Tests/SystemNavigationTest.class.st
@@ -11,7 +11,7 @@ Class {
 		'navigator',
 		'oldSystemAnnouncer'
 	],
-	#category : #'Tests-System'
+	#category : #'System-Support-Tests'
 }
 
 { #category : #testing }

--- a/src/System-Support-Tests/SystemOrganizerTest.class.st
+++ b/src/System-Support-Tests/SystemOrganizerTest.class.st
@@ -1,7 +1,10 @@
+"
+SUnit tests for SystemOrganizer
+"
 Class {
 	#name : #SystemOrganizerTest,
 	#superclass : #TestCase,
-	#category : #'Tests-System'
+	#category : #'System-Support-Tests'
 }
 
 { #category : #tests }


### PR DESCRIPTION
- AuthorTest
- SmalltalkImageTest
- SystemDictionaryTest
- SystemNavigationTest
- SystemNavigationOnNewlyCreatedEnvironmentTest

to "System-Support-Tests" and add some class comments

https://pharo.fogbugz.com/f/cases/21797/AuthorTest-SmalltalkImageTest-SystemDictionaryTest-and-other-should-be-in-package-System-Support-Tests