### PR TITLE
21799 Move UUIDPrimitivesTest and UUIDTest to package "Network-Tests" tag UUID

### DIFF
--- a/src/Network-Tests/Base64MimeConverterTest.class.st
+++ b/src/Network-Tests/Base64MimeConverterTest.class.st
@@ -3,7 +3,7 @@ This is the unit test for the class Base64MimeConverter. Unit tests are a good w
 	- http://www.c2.com/cgi/wiki?UnitTest
 	- there is a chapter in the PharoByExample book (http://pharobyexample.org/)
 	- the sunit class category
-" 
+"
 Class {
 	#name : #Base64MimeConverterTest,
 	#superclass : #TestCase,

--- a/src/Network-Tests/UUIDPrimitivesTest.class.st
+++ b/src/Network-Tests/UUIDPrimitivesTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for UUIDPrimitives
 Class {
 	#name : #UUIDPrimitivesTest,
 	#superclass : #TestCase,
-	#category : #'Tests-UUID'
+	#category : #'Network-Tests-UUID'
 }
 
 { #category : #tests }

--- a/src/Network-Tests/UUIDTest.class.st
+++ b/src/Network-Tests/UUIDTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for UUID
 Class {
 	#name : #UUIDTest,
 	#superclass : #TestCase,
-	#category : #'Tests-UUID'
+	#category : #'Network-Tests-UUID'
 }
 
 { #category : #testing }


### PR DESCRIPTION
Further breakup of the bloated "Tests" package:
 
 - Move UUIDPrimitivesTest and UUIDTest to package "Network-Tests" tag UUID
  where we already have UUIDGeneratorTests

https://pharo.fogbugz.com/f/cases/21799/Move-UUIDPrimitivesTest-and-UUIDTest-to-package-Network-Tests-tag-UUID