### PR TITLE
21793-Removing-of-a-class-side-method-that-overrides-a-trait-implementation-does-not-update-the-RPackage

### DIFF
--- a/src/TraitsV2-Tests/T2TraitAnnouncements.class.st
+++ b/src/TraitsV2-Tests/T2TraitAnnouncements.class.st
@@ -1,0 +1,44 @@
+Class {
+	#name : #T2TraitAnnouncements,
+	#superclass : #T2AbstractTest,
+	#category : #'TraitsV2-Tests'
+}
+
+{ #category : #tests }
+T2TraitAnnouncements >> packageName [
+	^ 'TestPackage'
+]
+
+{ #category : #tests }
+T2TraitAnnouncements >> testRPackageIsUpdatedInClassSide [
+	
+	| c1 t1 |
+	
+	t1 := self newTrait: #T1 with: #() uses: #() category: self packageName.
+	t1 class compile: 'msg ^ 1'.
+
+	c1 := self newClass: #C1 superclass: Object with: #() uses: t1 category: self packageName.
+	c1 class compile: 'msg ^ 12'.
+	
+	self assert: self packageName asPackage methods size equals: 2.
+	(c1 class >> #msg) removeFromSystem.
+	self assert: self packageName asPackage methods size equals: 1.
+]
+
+{ #category : #tests }
+T2TraitAnnouncements >> testRPackageIsUpdatedInInstanceSide [
+	
+	| c1 t1 |
+	
+	t1 := self newTrait: #T1 with: #() uses: #() category: self packageName.
+	t1 compile: 'msg ^ 1'.
+
+	c1 := self newClass: #C1 superclass: Object with: #() uses: t1 category: self packageName.
+	c1 compile: 'msg ^ 12'.
+	
+	self assert: (c1 >> #msg) origin equals: c1.
+	
+	self assert: self packageName asPackage methods size equals: 2.
+	(c1 >> #msg) removeFromSystem.
+	self assert: self packageName asPackage methods size equals: 1.
+]

--- a/src/TraitsV2-Tests/T2TraitAnnouncementsTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitAnnouncementsTest.class.st
@@ -1,16 +1,16 @@
 Class {
-	#name : #T2TraitAnnouncements,
+	#name : #T2TraitAnnouncementsTest,
 	#superclass : #T2AbstractTest,
 	#category : #'TraitsV2-Tests'
 }
 
 { #category : #tests }
-T2TraitAnnouncements >> packageName [
+T2TraitAnnouncementsTest >> packageName [
 	^ 'TestPackage'
 ]
 
 { #category : #tests }
-T2TraitAnnouncements >> testRPackageIsUpdatedInClassSide [
+T2TraitAnnouncementsTest >> testRPackageIsUpdatedInClassSide [
 	
 	| c1 t1 |
 	
@@ -26,7 +26,7 @@ T2TraitAnnouncements >> testRPackageIsUpdatedInClassSide [
 ]
 
 { #category : #tests }
-T2TraitAnnouncements >> testRPackageIsUpdatedInInstanceSide [
+T2TraitAnnouncementsTest >> testRPackageIsUpdatedInInstanceSide [
 	
 	| c1 t1 |
 	

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -129,7 +129,7 @@ TraitedMetaclass >> findOriginMethodOf: aMethod [
 	If it is an aliased or conflicting method, the method is look up in the whole trait composition"
 
 	(self isLocalSelector: aMethod selector)
-		ifTrue: [ ^ self compiledMethodAt: aMethod selector].
+		ifTrue: [ ^ aMethod].
 
 	(aMethod hasProperty: #traitSource)
 		ifTrue: [ |newSelector|
@@ -324,9 +324,9 @@ TraitedMetaclass >> removeSelector: aSelector [
 
 	"When a selector is removed it should be notified to my users.
 	Check the class TraitChange for more details"
-
-	self localMethodDict removeKey: aSelector ifAbsent: [  ].
 	super removeSelector: aSelector.
+	self localMethodDict removeKey: aSelector ifAbsent: [  ].
+
 	TraitChange removeSelector: aSelector on: self.
 ]
 


### PR DESCRIPTION
Fixing issue 21793

https://pharo.fogbugz.com/f/cases/21793/Removing-of-a-class-side-method-that-overrides-a-trait-implementation-does-not-update-the-RPackage

The propagation of RPackage announcement was wrong in the class side.