### PR TITLE
21737-NullStream-sends-self-positionError-but-does-not-implement-it

### DIFF
--- a/src/Collections-Streams/NullStream.class.st
+++ b/src/Collections-Streams/NullStream.class.st
@@ -218,6 +218,14 @@ NullStream >> position: anInteger [
 		ifFalse: [self positionError]
 ]
 
+{ #category : #positioning }
+NullStream >> positionError [
+	"Since I am not necessarily writable, it is up to my subclasses to override 
+	position: if expanding the collection is preferrable to giving this error."
+
+	self error: 'Attempt to set the position of a PositionableStream out of bounds'
+]
+
 { #category : #printing }
 NullStream >> printOn: aStream [
 	aStream nextPutAll: 'a '; nextPutAll: self class name.


### PR DESCRIPTION
NullStream sends self positionError but does not implement it
	https://pharo.fogbugz.com/f/cases/21737/NullStream-sends-self-positionError-but-does-not-implement-it