### PR TITLE
21812-Trait-slots-are-ignored-when-added-to-an-existing-trait

### DIFF
--- a/src/Shift-ClassBuilder/ShLayoutDefinition.class.st
+++ b/src/Shift-ClassBuilder/ShLayoutDefinition.class.st
@@ -19,7 +19,7 @@ Class {
 ShLayoutDefinition >> allSlots [
 	| superclass | 
 	superclass := builder superclass.
-	^ (superclass ifNil: [ ^#() ] ifNotNil: [ superclass allSlots ]) , slots.
+	^ (superclass ifNil: [ #() ] ifNotNil: [ superclass allSlots ]) , slots.
 ]
 
 { #category : #accessing }

--- a/src/TraitsV2-Tests/T2TraitWithSlots.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithSlots.class.st
@@ -64,3 +64,16 @@ T2TraitWithSlots >> testOwningClass [
 
 
 ]
+
+{ #category : #tests }
+T2TraitWithSlots >> testRedefiningTrait [
+
+	| t1 |
+	
+	t1 := self newTrait: #T1 with: #().
+	t1 := self newTrait: #T1 with: #(aSlot).
+
+	self deny: t1 slots isEmpty.
+
+
+]


### PR DESCRIPTION
Fixing a problem when a trait is modified.
Adding tests.

Issue #21812
https://pharo.manuscript.com/f/cases/21812/Trait-slots-are-ignored-when-added-to-an-existing-trait

