### PR TITLE
21814-ShiftClassBuilder-sharedVariablesFromString-should-support-an-array-of-symbols

### DIFF
--- a/src/Shift-ClassBuilder-Tests/ShAbstractClassBuilderTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShAbstractClassBuilderTest.class.st
@@ -8,7 +8,7 @@ Class {
 		'result',
 		'builder'
 	],
-	#category : 'Shift-ClassBuilder-Tests'
+	#category : #'Shift-ClassBuilder-Tests'
 }
 
 { #category : #validation }

--- a/src/Shift-ClassBuilder-Tests/ShCBClassWithInstanceVariables.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShCBClassWithInstanceVariables.class.st
@@ -7,5 +7,5 @@ Class {
 	#instVars : [
 		'inheritedSlot'
 	],
-	#category : 'Shift-ClassBuilder-Tests-TestClasses'
+	#category : #'Shift-ClassBuilder-Tests-TestClasses'
 }

--- a/src/Shift-ClassBuilder-Tests/ShCBEmptyClass.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShCBEmptyClass.class.st
@@ -4,5 +4,5 @@ I am a test class.
 Class {
 	#name : #ShCBEmptyClass,
 	#superclass : #Object,
-	#category : 'Shift-ClassBuilder-Tests-TestClasses'
+	#category : #'Shift-ClassBuilder-Tests-TestClasses'
 }

--- a/src/Shift-ClassBuilder-Tests/ShCBEmptyClassWithMethods.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShCBEmptyClassWithMethods.class.st
@@ -4,7 +4,7 @@ I am a test class.
 Class {
 	#name : #ShCBEmptyClassWithMethods,
 	#superclass : #Object,
-	#category : 'Shift-ClassBuilder-Tests-TestClasses'
+	#category : #'Shift-ClassBuilder-Tests-TestClasses'
 }
 
 { #category : #'test methods' }

--- a/src/Shift-ClassBuilder-Tests/ShCreateClassTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShCreateClassTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ShCreateClassTest,
 	#superclass : #ShAbstractClassBuilderTest,
-	#category : 'Shift-ClassBuilder-Tests'
+	#category : #'Shift-ClassBuilder-Tests'
 }
 
 { #category : #tests }
@@ -91,6 +91,36 @@ ShCreateClassTest >> testSharedVariables [
 	self validateResult.
 	self validateSuperclass: Object.
 	self validateSharedVariables: #(aSharedVariable)
+]
+
+{ #category : #tests }
+ShCreateClassTest >> testSharedVariablesAsArray [
+	builder name: #SHClassWithSharedVariable.
+	result := builder
+		sharedVariablesFromString: #(aSharedVariable);
+		build.
+
+	self validateResult.
+	self validateSuperclass: Object.
+	self validateSharedVariables: #(aSharedVariable)
+]
+
+{ #category : #tests }
+ShCreateClassTest >> testSharedVariablesAsString [
+	builder name: #SHClassWithSharedVariable.
+	result := builder
+		sharedVariablesFromString: 'aSharedVariable';
+		build.
+
+	self validateResult.
+	self validateSuperclass: Object.
+	self validateSharedVariables: #(aSharedVariable)
+]
+
+{ #category : #tests }
+ShCreateClassTest >> testSharedVariablesWithSlot [
+	builder name: #SHClassWithSharedVariable.
+	self should: [ builder sharedVariablesFromString: {#aSharedVariable asSlot} ] raise: Error.
 ]
 
 { #category : #tests }

--- a/src/Shift-ClassBuilder-Tests/ShModifyClassTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShModifyClassTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ShModifyClassTest,
 	#superclass : #ShAbstractClassBuilderTest,
-	#category : 'Shift-ClassBuilder-Tests'
+	#category : #'Shift-ClassBuilder-Tests'
 }
 
 { #category : #tests }

--- a/src/Shift-ClassBuilder-Tests/ShTestSharedPool.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShTestSharedPool.class.st
@@ -7,5 +7,5 @@ Class {
 	#classVars : [
 		'FooValue1'
 	],
-	#category : 'Shift-ClassBuilder-Tests-TestClasses'
+	#category : #'Shift-ClassBuilder-Tests-TestClasses'
 }

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -432,8 +432,13 @@ ShiftClassBuilder >> sharedVariables: aCollection [
 ]
 
 { #category : #accessing }
-ShiftClassBuilder >> sharedVariablesFromString: aString [ 
-	layoutDefinition sharedVariables:((aString substrings: ' ') collect: [:x | x asSymbol => ClassVariable]). 
+ShiftClassBuilder >> sharedVariablesFromString: aStringOrArray [
+	layoutDefinition sharedVariables: (aStringOrArray isString
+        ifTrue: [ (aStringOrArray substrings: ' ') collect: [ :x | x asSymbol => ClassVariable ] ]
+        ifFalse: [ aStringOrArray collect: [ :x | 
+                x isSymbol
+                    ifTrue: [ x => ClassVariable ]
+                    ifFalse: [ self error: 'Shared variables can only be String or an array of Symbols' ] ] ])
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
#sharedVariablesFromString: should allow to receive an array of symbols. Also it should validate if it receives only Strings or symbols, slots cannot be used as class variables.

Issue: https://pharo.manuscript.com/f/cases/21814/ShiftClassBuilder-sharedVariablesFromString-should-support-an-array-of-symbols