### PR TITLE
21818-RBPatternBlockNode-fix-problems-introduced-by-ast-Eval-use

### DIFF
--- a/src/AST-Core/RBPatternBlockNode.class.st
+++ b/src/AST-Core/RBPatternBlockNode.class.st
@@ -41,7 +41,7 @@ RBPatternBlockNode >> constructLookupNodeFor: aString in: aRBBlockNode [
 	^RBMessageNode 
 		receiver: (RBVariableNode named: 'self')
 		selector: #lookupMatchFor:in:
-		arguments: (Array with: argumentNode with: aRBBlockNode arguments last)
+		arguments: (Array with: argumentNode with: aRBBlockNode arguments last copy)
 ]
 
 { #category : #matching }
@@ -61,6 +61,7 @@ RBPatternBlockNode >> createMatchingBlock [
 		ifTrue: [self addArgumentWithNameBasedOn: 'aNode' to: newBlock].
 	newBlock arguments size = 1 
 		ifTrue: [self addArgumentWithNameBasedOn: 'aDictionary' to: newBlock].
+	self replacePatternNodesIn: newBlock.
 	^newBlock evaluateForReceiver: self.
 ]
 
@@ -74,6 +75,7 @@ RBPatternBlockNode >> createReplacingBlock [
 	newBlock := RBBlockNode arguments: arguments body: body.
 	self arguments isEmpty 
 		ifTrue: [self addArgumentWithNameBasedOn: 'aDictionary' to: newBlock].
+	self replacePatternNodesIn: newBlock.
 	^newBlock evaluateForReceiver: self.
 ]
 

--- a/src/AST-Tests-Core/RBPatternParserTest.class.st
+++ b/src/AST-Tests-Core/RBPatternParserTest.class.st
@@ -29,3 +29,21 @@ RBPatternParserTest >> testParseFaultyPatternBlock [
 			self assert: node isBlock.
 			self assert: node isFaulty]
 ]
+
+{ #category : #'tests parsing' }
+RBPatternParserTest >> testPatternBlockNode1 [
+	| searchPattern tree |
+	searchPattern := RBPatternParser
+		parseExpression: '(`a = `b) `{`a name size = `b name size}'.
+	tree := RBParser parseExpression: 'a = c'.
+	self assert: (searchPattern match: tree inContext: Dictionary new)
+]
+
+{ #category : #'tests parsing' }
+RBPatternParserTest >> testPatternBlockNode2 [
+	| searchPattern tree |
+	searchPattern := RBPatternParser
+		parseExpression: '(`a = `b) `{`a name anySatisfy: [ :e | `b name includes: e]}'.
+	tree := RBParser parseExpression: 'a = a1'.
+	self assert: (searchPattern match: tree inContext: Dictionary new)
+]


### PR DESCRIPTION
RBPatternBlockNode: fix problems introduced by ast Eval use
	https://pharo.fogbugz.com/f/cases/21818/RBPatternBlockNode-fix-problems-introduced-by-ast-Eval-use