### PR TITLE
21821-Integrate-Iceberg-075

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -914,7 +914,7 @@ BaselineOfIDE >> loadCalypso [
 BaselineOfIDE >> loadIceberg [
 	Metacello new
 		baseline: 'Iceberg';
-		repository: 'github://pharo-vcs/iceberg:v0.7.4';
+		repository: 'github://pharo-vcs/iceberg:v0.7.5';
 		load.
 	(Smalltalk classNamed: #Iceberg) enableMetacelloIntegration: true.
 


### PR DESCRIPTION
Time for the weekly Iceberg update.
Thanks to all brave users, issue reporters and contributors :).

Key changes: 
 - Several improvements in metacello integration. (see #625, #664, #688 + more tests)

Infrastructure changes:
 - In 0.7.4 we introduced in the build tests againt pharo 6.1 and 64 bits
   * https://travis-ci.org/pharo-vcs/iceberg/builds/372408795
 - In 0.7.5 all iceberg tests run green on Pharo 6.1 32 bits
   * https://travis-ci.org/pharo-vcs/iceberg/builds/374433920
 - In the next release we plan to do a pass on 64 bits

Pharo 6.1 backport
 - Cyril has been using the development version of Iceberg on Pharo 6.1 for a couple of weeks now.
 - This plus the green CI encourages us to backport to Pharo 6.1

Detailed ChangesLog:

#625 Non explicit error while loading a project
#758 [Regression] Repair action clone is not setting pharo repository
#756 Iceberg dev-0.7 is broken in Pharo6.1 (Instance of IceTipURLLabelMorph did not understand #addEmphasis:)
#749 Adding repair actions to the code subdirectory missing problem
#655 Rename extension method buildToolbarItem of CommandActivator
#755 Extracting the URL label behavior as a component that we can reuse
#468 Commiting via Iceberg does not commit package removal
#750 Add possibility to see current commit in Repositories/Package view
#754 Showing and coping the Commit ID
#753 Create branch dialog layout is broken
#664 Package wrongly shown with "uncommited changes" status
#752 Add "invalid ssh"
#747 Cloning a Git repository should change the path with the project name.
#738 Remove "pharo" Repository with "also remove from filesystem" gives error
#746 Make tests run on pharo 6
#735 Issue while registering a new project on Pharo 6.1
#733 Add license file
#740 Fogbugz panel: Improve label, focus order and layout
#549 IceRestoreRepositoryModel should have a class comment
#688 Duplicated project error when loading in a fresh image