### PR TITLE
21611-Adapt-ImageReadWriter-hierarchy-to-need-only-pure-binary-streams

### DIFF
--- a/src/Graphics-Files/BMPReadWriter.class.st
+++ b/src/Graphics-Files/BMPReadWriter.class.st
@@ -67,7 +67,6 @@ BMPReadWriter class >> typicalFileExtensions [
 { #category : #reading }
 BMPReadWriter >> nextImage [
 	| colors |
-	stream binary.
 	self readHeader.
 	biBitCount = 24 ifTrue:[^self read24BmpFile].
 	"read the color map"
@@ -92,25 +91,23 @@ BMPReadWriter >> nextPutImage: aForm [
 	biSizeImage := biHeight * rowBytes.
 
 	"Write the file header"
-	stream position: 0.
-	stream nextLittleEndianNumber: 2 put: 19778.  "bfType = BM"
-	stream nextLittleEndianNumber: 4 put: bfOffBits + biSizeImage.  "Entire file size in bytes"
-	stream nextLittleEndianNumber: 4 put: 0.  "bfReserved"
-	stream nextLittleEndianNumber: 4 put: bfOffBits.  "Offset of bitmap data from start of hdr (and file)"
+	self nextLittleEndianNumber: 2 put: 19778.  "bfType = BM"
+	self nextLittleEndianNumber: 4 put: bfOffBits + biSizeImage.  "Entire file size in bytes"
+	self nextLittleEndianNumber: 4 put: 0.  "bfReserved"
+	self nextLittleEndianNumber: 4 put: bfOffBits.  "Offset of bitmap data from start of hdr (and file)"
 
 	"Write the bitmap info header"
-	stream position: bhSize.
-	stream nextLittleEndianNumber: 4 put: biSize.  "info header size in bytes"
-	stream nextLittleEndianNumber: 4 put: image width.  "biWidth"
-	stream nextLittleEndianNumber: 4 put: image height.  "biHeight"
-	stream nextLittleEndianNumber: 2 put: 1.  "biPlanes"
-	stream nextLittleEndianNumber: 2 put: (depth min: 24).  "biBitCount"
-	stream nextLittleEndianNumber: 4 put: 0.  "biCompression"
-	stream nextLittleEndianNumber: 4 put: biSizeImage.  "size of image section in bytes"
-	stream nextLittleEndianNumber: 4 put: 2800.  "biXPelsPerMeter"
-	stream nextLittleEndianNumber: 4 put: 2800.  "biYPelsPerMeter"
-	stream nextLittleEndianNumber: 4 put: biClrUsed.
-	stream nextLittleEndianNumber: 4 put: 0.  "biClrImportant"
+	self nextLittleEndianNumber: 4 put: biSize.  "info header size in bytes"
+	self nextLittleEndianNumber: 4 put: image width.  "biWidth"
+	self nextLittleEndianNumber: 4 put: image height.  "biHeight"
+	self nextLittleEndianNumber: 2 put: 1.  "biPlanes"
+	self nextLittleEndianNumber: 2 put: (depth min: 24).  "biBitCount"
+	self nextLittleEndianNumber: 4 put: 0.  "biCompression"
+	self nextLittleEndianNumber: 4 put: biSizeImage.  "size of image section in bytes"
+	self nextLittleEndianNumber: 4 put: 2800.  "biXPelsPerMeter"
+	self nextLittleEndianNumber: 4 put: 2800.  "biYPelsPerMeter"
+	self nextLittleEndianNumber: 4 put: biClrUsed.
+	self nextLittleEndianNumber: 4 put: 0.  "biClrImportant"
 	biClrUsed > 0 ifTrue: [
 		"write color map; this works for ColorForms, too"
 		colorValues := image colormapIfNeededForDepth: 32.
@@ -133,9 +130,7 @@ BMPReadWriter >> nextPutImage: aForm [
 			self store24BitBmpLine: pixline from: data startingAt: (biHeight-i)*biWidth+1 width: biWidth.
 			stream nextPutAll: pixline.
 		].
-	].
-	stream position = (bfOffBits + biSizeImage) ifFalse: [self error:'Write failure'].
-	stream close.
+	]
 ]
 
 { #category : #reading }
@@ -223,21 +218,21 @@ BMPReadWriter >> readColorMap [
 { #category : #reading }
 BMPReadWriter >> readHeader [
 	| reserved |
-	bfType := stream nextLittleEndianNumber: 2.
-	bfSize := stream nextLittleEndianNumber: 4.
-	reserved := stream nextLittleEndianNumber: 4.
-	bfOffBits := stream nextLittleEndianNumber: 4.
-	biSize := stream nextLittleEndianNumber: 4.
-	biWidth := stream nextLittleEndianNumber: 4.
-	biHeight := stream nextLittleEndianNumber: 4.
-	biPlanes := stream nextLittleEndianNumber: 2.
-	biBitCount := stream nextLittleEndianNumber: 2.
-	biCompression := stream nextLittleEndianNumber: 4.
-	biSizeImage := stream nextLittleEndianNumber: 4.
-	biXPelsPerMeter := stream nextLittleEndianNumber: 4.
-	biYPelsPerMeter := stream nextLittleEndianNumber: 4.
-	biClrUsed := stream nextLittleEndianNumber: 4.
-	biClrImportant := stream nextLittleEndianNumber: 4
+	bfType := self nextLittleEndianNumber: 2.
+	bfSize := self nextLittleEndianNumber: 4.
+	reserved := self nextLittleEndianNumber: 4.
+	bfOffBits := self nextLittleEndianNumber: 4.
+	biSize := self nextLittleEndianNumber: 4.
+	biWidth := self nextLittleEndianNumber: 4.
+	biHeight := self nextLittleEndianNumber: 4.
+	biPlanes := self nextLittleEndianNumber: 2.
+	biBitCount := self nextLittleEndianNumber: 2.
+	biCompression := self nextLittleEndianNumber: 4.
+	biSizeImage := self nextLittleEndianNumber: 4.
+	biXPelsPerMeter := self nextLittleEndianNumber: 4.
+	biYPelsPerMeter := self nextLittleEndianNumber: 4.
+	biClrUsed := self nextLittleEndianNumber: 4.
+	biClrImportant := self nextLittleEndianNumber: 4
 ]
 
 { #category : #reading }
@@ -312,12 +307,10 @@ BMPReadWriter >> store24BitBmpLine: pixelLine from: formBits startingAt: formBit
 
 { #category : #testing }
 BMPReadWriter >> understandsImageFormat [
-	stream size < 54 ifTrue:[^false]. "min size = BITMAPFILEHEADER+BITMAPINFOHEADER"
 	self readHeader.
 	bfType = 19778 "BM" ifFalse:[^false].
 	biSize = 40 ifFalse:[^false].
 	biPlanes = 1 ifFalse:[^false].
-	bfSize <= stream size ifFalse:[^false].
 	biCompression = 0 ifFalse:[^false].
 	^true
 ]

--- a/src/Graphics-Files/GIFReadWriter.class.st
+++ b/src/Graphics-Files/GIFReadWriter.class.st
@@ -221,17 +221,12 @@ GIFReadWriter >> nextBytePut: aByte [
 
 { #category : #accessing }
 GIFReadWriter >> nextImage [
-	"Read in the next GIF image from the stream. Read it all into
-memory first for speed."
+	"Read in the next GIF image from the stream."
 	| f thisImageColorTable |
-	stream class == ReadWriteStream ifFalse: 
-		[ stream binary.
-		self on: (ReadWriteStream with: stream contentsOfEntireFile) ].
 	localColorTable := nil.
 	self readHeader.
 	f := self readBody.
-	self close.
-	f == nil ifTrue: [ ^ self error: 'corrupt GIF file' ].
+	f ifNil: [ ^ self error: 'corrupt GIF file' ].
 	thisImageColorTable := localColorTable ifNil: [ colorPalette ].
 	transparentIndex ifNotNil: 
 		[ transparentIndex + 1 > thisImageColorTable size ifTrue: 
@@ -470,11 +465,12 @@ GIFReadWriter >> readColorTable: numberOfEntries [
 
 { #category : #'private-decoding' }
 GIFReadWriter >> readHeader [
-	| is89 byte hasColorMap |
-	(self hasMagicNumber: 'GIF87a' asByteArray) 
+	| magic is89 byte hasColorMap |
+	magic := stream next: 6.
+	(magic = 'GIF87a' asByteArray) 
 		ifTrue: [ is89 := false ]
 		ifFalse: 
-			[ (self hasMagicNumber: 'GIF89a' asByteArray) 
+			[ (magic = 'GIF89a' asByteArray) 
 				ifTrue: [ is89 := true ]
 				ifFalse: [ ^ self error: 'This does not appear to be a GIF file' ] ].
 	self readWord.	"skip Screen Width"

--- a/src/Graphics-Files/ImageReadWriter.class.st
+++ b/src/Graphics-Files/ImageReadWriter.class.st
@@ -43,19 +43,20 @@ ImageReadWriter class >> allTypicalFileExtensions [
 { #category : #'image reading/writing' }
 ImageReadWriter class >> formFromFileNamed: fileName [ 
 	"Answer a ColorForm stored on the file with the given name."
-	| stream |
-	stream := FileStream readOnlyFileNamed: fileName.
-	^ self formFromStream: stream
+	
+	^ fileName asFileReference 
+		binaryReadStreamDo: [ :in | self formFromStream: in ]
 ]
 
 { #category : #'image reading/writing' }
 ImageReadWriter class >> formFromStream: aBinaryStream [ 
 	"Answer a ColorForm stored on the given stream.  closes the stream"
-	| reader readerClass form |
-	readerClass := self readerClassFromStream: aBinaryStream.
-	reader := readerClass new on: aBinaryStream.
+	| positionableReadStream reader readerClass form |
+	positionableReadStream := ZnPositionableReadStream on: aBinaryStream.
+	readerClass := self readerClassFromStream: positionableReadStream.
+	reader := readerClass new on: positionableReadStream.
 	form := reader nextImage.
-	reader close.
+	aBinaryStream close.
 	^ form
 ]
 
@@ -70,30 +71,30 @@ ImageReadWriter class >> on: aStream [
 { #category : #'image reading/writing' }
 ImageReadWriter class >> putForm: aForm onFileNamed: fileName [ 
 	"Store the given form on a file of the given name."
-	| writer |
-	writer := self on: (FileStream newFileNamed: fileName) binary.
-	Cursor write showWhile: [ writer nextPutImage: aForm ].
-	writer close
+	
+	fileName asFileReference 
+		binaryWriteStreamDo: [ :out | (self on: out) nextPutImage: aForm ]
 ]
 
 { #category : #'image reading/writing' }
 ImageReadWriter class >> putForm: aForm onStream: aWriteStream [ 
-	"Store the given form on a file of the given name."
+	"Store the given form on a file of the given name. closes the stream"
+	
 	| writer |
-	writer := self on: aWriteStream.
-	Cursor write showWhile: [ writer nextPutImage: aForm ].
+	writer := (self on: aWriteStream).
+	writer nextPutImage: aForm.
 	writer close
 ]
 
 { #category : #'image reading/writing' }
-ImageReadWriter class >> readerClassFromStream: aBinaryStream [
+ImageReadWriter class >> readerClassFromStream: positionableReadStream [
 	| readerClass |
 	readerClass := self withAllSubclasses
-		detect: [ :subclass | subclass understandsImageFormat: aBinaryStream ]
+		detect: [ :subclass | 
+			positionableReadStream savingPositionDo: [ subclass understandsImageFormat: positionableReadStream ] ]
 		ifNone: [ 
-			aBinaryStream close.
+			positionableReadStream close.
 			^ self error: 'image format not recognized' ].
-	aBinaryStream reset.
 	^ readerClass
 ]
 
@@ -194,6 +195,62 @@ ImageReadWriter >> nextImage [
 ]
 
 { #category : #'stream access' }
+ImageReadWriter >> nextIntegerOfSize: numberOfBytes signed: signed bigEndian: bigEndian [
+	"Assuming the receiver is a stream of bytes, read the next integer of size numberOfBytes.
+	If bigEndian is true, use network byte order, most significant byte first, 
+	else use little endian order, least significant byte first.
+	If signed is true, interpret as a two-complement signed value, 
+	else interpret as a plain unsigned value."
+	
+	| value |
+	value := 0.
+	bigEndian
+		ifTrue: [ 
+			(numberOfBytes - 1) * 8 to: 0 by: -8 do: [ :shift |
+				value := value + (self next bitShift: shift) ] ]
+		ifFalse: [ 
+			0 to: (numberOfBytes - 1) * 8 by: 8 do: [ :shift |
+				value := value + (self next bitShift: shift) ] ].
+	^ (signed and: [ (value bitAt: numberOfBytes * 8) = 1 ])
+		ifTrue: [ value - (1 << (numberOfBytes * 8)) ]
+		ifFalse: [ value ]
+]
+
+{ #category : #'stream access' }
+ImageReadWriter >> nextIntegerOfSize: numberOfBytes signed: signed bigEndian: bigEndian put: value [
+	"Assuming the receiver is a stream of bytes, write value as the next integer of size numberOfBytes.
+	If bigEndian is true, use network byte order, most significant byte first, 
+	else use little endian order, least significant byte first.
+	If signed is true, encode as a two-complement signed value, 
+	else encode as a plain unsigned value."
+	
+	| unsignedValue |
+	unsignedValue := (signed and: [ value negative ])
+		ifTrue: [ (1 << (numberOfBytes * 8)) + value ] 
+		ifFalse: [ value ].
+	(unsignedValue between: 0 and: (2 ** (numberOfBytes * 8)) - 1)
+		ifFalse: [ DomainError signalFrom: 0 to: (2 ** (numberOfBytes * 8)) - 1 ].
+	bigEndian
+		ifTrue: [ 
+			numberOfBytes to: 1 by: -1 do: [ :index |
+				self nextPut: (unsignedValue digitAt: index) ] ]
+		ifFalse: [ 
+			1 to: numberOfBytes do: [ :index |
+				self nextPut: (unsignedValue digitAt: index) ] ].
+	^ value
+]
+
+{ #category : #'stream access' }
+ImageReadWriter >> nextLittleEndianNumber: numberOfBytes [
+	^ self nextIntegerOfSize: numberOfBytes signed: false bigEndian: false
+]
+
+{ #category : #'stream access' }
+ImageReadWriter >> nextLittleEndianNumber: numberOfBytes put: integer [
+	^ self nextIntegerOfSize: numberOfBytes signed: false bigEndian: false put: integer
+]
+
+{ #category : #'stream access' }
 ImageReadWriter >> nextLong [
 	"Read a 32-bit quantity from the input stream."
 
@@ -248,10 +305,8 @@ ImageReadWriter >> nextWordPut: a16BitW [
 ]
 
 { #category : #private }
-ImageReadWriter >> on: aStream [ 
-	(stream := aStream) reset.
-	stream binary
-	"Note that 'reset' makes a file be text.  Must do this after."
+ImageReadWriter >> on: binaryStream [ 
+	stream := binaryStream
 ]
 
 { #category : #'stream access' }

--- a/src/Graphics-Files/JPEGReadWriter.class.st
+++ b/src/Graphics-Files/JPEGReadWriter.class.st
@@ -233,7 +233,6 @@ JPEGReadWriter class >> typicalFileExtensions [
 { #category : #'image reading/writing' }
 JPEGReadWriter class >> understandsImageFormat: aStream [
 	(PluginBasedJPEGReadWriter understandsImageFormat: aStream) ifTrue:[^false].
-	aStream reset.
 	aStream next = 16rFF ifFalse: [^ false].
 	aStream next = 16rD8 ifFalse: [^ false].
 	^true

--- a/src/Graphics-Files/PNGReadWriter.class.st
+++ b/src/Graphics-Files/PNGReadWriter.class.st
@@ -776,8 +776,6 @@ PNGReadWriter >> nextImage [
 	idatChunkStream := nil.
 	transparentPixelValue := nil.
 	unknownChunks := Set new.
-	stream reset.
-	stream binary.
 	stream skip: 8.
 	[stream atEnd] whileFalse: [self processNextChunk].
 	"Set up our form"
@@ -1251,16 +1249,12 @@ PNGReadWriter >> writeChunk: crcStream [
 			print: length;
 			nextPutAll: ' crc=0x';
 			nextPutAll: crc printStringHex ].
-	stream 
-		nextNumber: 4
-		put: length - 4.	"exclude chunk name"
+	self nextLongPut: length - 4.	"exclude chunk name"
 	stream 
 		next: length
 		putAll: bytes
 		startingAt: 1.
-	stream 
-		nextNumber: 4
-		put: crc.
+	self nextLongPut: crc.
 	debug ifTrue: 
 		[ Transcript
 			nextPutAll: ' afterPos=';

--- a/src/Graphics-Files/PluginBasedJPEGReadWriter.class.st
+++ b/src/Graphics-Files/PluginBasedJPEGReadWriter.class.st
@@ -34,12 +34,11 @@ PluginBasedJPEGReadWriter class >> putForm: aForm quality: quality progressiveJP
 	"Store the given Form as a JPEG file of the given name, overwriting any existing file of that name. Quality goes from 0 (low) to 100 (high), where -1 means default. If progressiveFlag is true, encode as a progressive JPEG."
 	| writer |
 	fileName asFileReference ensureDelete.
-	writer := self on: (FileStream newFileNamed: fileName) binary.
-	Cursor write showWhile: 
-		[ writer 
-			nextPutImage: aForm
-			quality: quality
-			progressiveJPEG: progressiveFlag ].
+	writer := self on: fileName asFileReference binaryWriteStream.
+	writer 
+		nextPutImage: aForm
+		quality: quality
+		progressiveJPEG: progressiveFlag.
 	writer close
 ]
 

--- a/src/Graphics-Tests/ImageReadWriterTests.class.st
+++ b/src/Graphics-Tests/ImageReadWriterTests.class.st
@@ -1,0 +1,171 @@
+"
+Functional tests for image IO to binary streams and files for the major formats (JPEG,PNG,GIF,BMP)
+"
+Class {
+	#name : #ImageReadWriterTests,
+	#superclass : #TestCase,
+	#category : #'Graphics-Tests-Files'
+}
+
+{ #category : #accessing }
+ImageReadWriterTests >> pharoLogoForm [
+	^ (PNGReadWriter on: (ZnBase64Encoder new decode: PolymorphSystemSettings pharoLogoContents) readStream) nextImage
+]
+
+{ #category : #accessing }
+ImageReadWriterTests >> pharoLogoFormDepth8 [
+	^ self pharoLogoFormNonTransparent asFormOfDepth: 8
+]
+
+{ #category : #accessing }
+ImageReadWriterTests >> pharoLogoFormNonTransparent [
+	^ self pharoLogoForm 
+		mapColor: Color transparent to: Color white;
+		yourself
+]
+
+{ #category : #tests }
+ImageReadWriterTests >> testBmpWriteReadInMemory [
+	| form bytes result |
+	form := self pharoLogoFormNonTransparent.
+	bytes := ByteArray streamContents: [ :out | BMPReadWriter putForm: form onStream: out ].
+	"Without format detection"
+	result := (BMPReadWriter on: bytes readStream) nextImage.
+	self assert: form bits equals: result bits.
+	"With format detection"
+	result := ImageReadWriter formFromStream: bytes readStream.
+	self assert: form bits equals: result bits
+]
+
+{ #category : #tests }
+ImageReadWriterTests >> testBmpWriteReadUsingFiles [
+	| form file result |
+	form := self pharoLogoFormNonTransparent.
+	file := (self class name asString , '-pharo-logo.bmp') asFileReference.
+	file ensureDelete.
+	file binaryWriteStreamDo: [ :out | (BMPReadWriter on: out) nextPutImage: form ].
+	"Without format detection"
+	result := file binaryReadStreamDo: [ :in | (BMPReadWriter on: in) nextImage ].
+	self assert: form bits equals: result bits.
+	"With format detection"
+	result := file binaryReadStreamDo: [ :in | ImageReadWriter formFromStream: in ].
+	"result := ImageReadWriter formFromFileNamed: file fullPath."
+	self assert: form bits equals: result bits.
+	file delete
+]
+
+{ #category : #tests }
+ImageReadWriterTests >> testGifWriteReadInMemory [
+	| form bytes result |
+	form := self pharoLogoFormDepth8.
+	bytes := ByteArray streamContents: [ :out | GIFReadWriter putForm: form onStream: out ].
+	"Without format detection"
+	result := (GIFReadWriter on: bytes readStream) nextImage.
+	self assert: form bits equals: result bits.
+	"With format detection"
+	result := ImageReadWriter formFromStream: bytes readStream.
+	self assert: form bits equals: result bits
+]
+
+{ #category : #tests }
+ImageReadWriterTests >> testGifWriteReadUsingFiles [
+	| form file result |
+	form := self pharoLogoFormDepth8.
+	file := (self class name asString , '-pharo-logo.gif') asFileReference.
+	file ensureDelete.
+	file binaryWriteStreamDo: [ :out | (GIFReadWriter on: out) nextPutImage: form ].
+	"Without format detection"
+	result := file binaryReadStreamDo: [ :in | (GIFReadWriter on: in) nextImage ].
+	self assert: form bits equals: result bits.
+	"With format detection"
+	result := file binaryReadStreamDo: [ :in | ImageReadWriter formFromStream: in ].
+	self assert: form bits equals: result bits.
+	file delete
+]
+
+{ #category : #tests }
+ImageReadWriterTests >> testJpegWriteReadInMemory [
+	| form bytes result |
+	form := self pharoLogoFormNonTransparent.
+	bytes := ByteArray streamContents: [ :out | PluginBasedJPEGReadWriter putForm: form onStream: out ].
+	"Without format detection"
+	result := (JPEGReadWriter on: bytes readStream) nextImage.
+	self assert: form bits size equals: result bits size.
+	"With format detection"
+	result := ImageReadWriter formFromStream: bytes readStream.
+	self assert: form bits size equals: result bits size
+]
+
+{ #category : #tests }
+ImageReadWriterTests >> testJpegWriteReadUsingFiles [
+	| form file result |
+	form := self pharoLogoFormNonTransparent.
+	file := (self class name asString , '-pharo-logo.jpeg') asFileReference.
+	file ensureDelete.
+	(PluginBasedJPEGReadWriter on: file binaryWriteStream) nextPutImage: form. "gets closed ?!"
+	"Without format detection"
+	result := file binaryReadStreamDo: [ :in | (JPEGReadWriter on: in) nextImage ].
+	self assert: form bits size equals: result bits size.
+	"With format detection"
+	result := file binaryReadStreamDo: [ :in | ImageReadWriter formFromStream: in ].
+	self assert: form bits size equals: result bits size.
+	file delete
+]
+
+{ #category : #tests }
+ImageReadWriterTests >> testPluginBasedJpegWriteReadInMemory [
+	| form bytes result |
+	form := self pharoLogoFormNonTransparent.
+	bytes := ByteArray streamContents: [ :out | PluginBasedJPEGReadWriter putForm: form onStream: out ].
+	"Without format detection"
+	result := (PluginBasedJPEGReadWriter on: bytes readStream) nextImage.
+	self assert: form bits size equals: result bits size.
+	"With format detection"
+	result := ImageReadWriter formFromStream: bytes readStream.
+	self assert: form bits size equals: result bits size
+]
+
+{ #category : #tests }
+ImageReadWriterTests >> testPluginBasedJpegWriteReadUsingFiles [
+	| form file result |
+	form := self pharoLogoFormNonTransparent.
+	file := (self class name asString , '-pharo-logo.jpeg') asFileReference.
+	file ensureDelete.
+	(PluginBasedJPEGReadWriter on: file binaryWriteStream) nextPutImage: form. "gets closed ?!"
+	"Without format detection"
+	result := file binaryReadStreamDo: [ :in | (PluginBasedJPEGReadWriter on: in) nextImage ].
+	self assert: form bits size equals: result bits size.
+	"With format detection"
+	result := file binaryReadStreamDo: [ :in | ImageReadWriter formFromStream: in ].
+	self assert: form bits size equals: result bits size.
+	file delete
+]
+
+{ #category : #tests }
+ImageReadWriterTests >> testPngWriteReadInMemory [
+	| form bytes result |
+	form := self pharoLogoForm.
+	bytes := ByteArray streamContents: [ :out | PNGReadWriter putForm: form onStream: out ].
+	"Without format detection"
+	result := (PNGReadWriter on: bytes readStream) nextImage.
+	self assert: form bits equals: result bits.
+	"With format detection"
+	result := ImageReadWriter formFromStream: bytes readStream.
+	self assert: form bits equals: result bits
+]
+
+{ #category : #tests }
+ImageReadWriterTests >> testPngWriteReadUsingFiles [
+	| form file result |
+	form := self pharoLogoForm.
+	file := (self class name asString , '-pharo-logo.png') asFileReference.
+	file ensureDelete.
+	file binaryWriteStreamDo: [ :out | (PNGReadWriter on: out) nextPutImage: form ].
+	"Without format detection"
+	result := file binaryReadStreamDo: [ :in | (PNGReadWriter on: in) nextImage ].
+	self assert: form bits equals: result bits.
+	"With format detection"
+	result := file binaryReadStreamDo: [ :in | ImageReadWriter formFromStream: in ].
+	self assert: form bits equals: result bits.
+	file delete
+]

--- a/src/Graphics-Tests/PNGReadWriterTest.class.st
+++ b/src/Graphics-Tests/PNGReadWriterTest.class.st
@@ -164,8 +164,8 @@ PNGReadWriterTest >> decodeColors: colorsAndFiles depth: requiredDepth [
 	
 	colorsAndFiles do:[:assoc| | bytes color form |
 		color := assoc key.
-		bytes := Base64MimeConverter mimeDecodeToBytes: assoc value readStream.
-		form := PNGReadWriter formFromStream: bytes.
+		bytes := (Base64MimeConverter mimeDecodeToBytes: assoc value readStream) reset; upToEnd.
+		form := PNGReadWriter formFromStream: bytes readStream.
 		self assert: form depth = requiredDepth.
 		self assert: (form pixelValueAt: 1@1) = (color pixelValueForDepth: requiredDepth).
 	].


### PR DESCRIPTION
A set of changes that refactors the ImageReadWriter hierarchy to work with simple binary streams (need for Pharo 7 new stream/file implementation)

https://pharo.manuscript.com/f/cases/21611/Adapt-ImageReadWriter-hierarchy-to-need-only-pure-binary-streams