### PR TITLE
21822-Fix-Zn-Tests-due-to-encryptedgooglecom-moving

### DIFF
--- a/src/Zinc-Zodiac/ZnHTTPSTests.class.st
+++ b/src/Zinc-Zodiac/ZnHTTPSTests.class.st
@@ -175,9 +175,9 @@ ZnHTTPSTests >> testRequestResponse [
 	self ensureSocketStreamFactory.
 	self isNativeSSLPluginPresent ifFalse: [ ^ self ].
 	query := 'Smalltalk'.
-	stream := ZdcSecureSocketStream openConnectionToHostNamed: 'encrypted.google.com' port: 443.
+	stream := ZdcSecureSocketStream openConnectionToHostNamed: 'www.google.com' port: 443.
 	[
-		request := ZnRequest get: 'https://encrypted.google.com/search?q=', query.
+		request := ZnRequest get: 'https://www.google.com/search?q=', query.
 		stream connect.
 		request writeOn: stream.
 		stream flush.

--- a/src/Zodiac-Tests/ZdcSecureSocketStreamTests.class.st
+++ b/src/Zodiac-Tests/ZdcSecureSocketStreamTests.class.st
@@ -30,11 +30,11 @@ ZdcSecureSocketStreamTests >> testPlain [
 	| query stream request response |
 	self isNativeSSLPluginPresent ifFalse: [ ^ self ].
 	query := 'Smalltalk'.
-	stream := ZdcSecureSocketStream openConnectionToHostNamed: 'encrypted.google.com' port: 443.
+	stream := ZdcSecureSocketStream openConnectionToHostNamed: 'www.google.com' port: 443.
 	[
 		request := String streamContents: [ :out |
 			out << 'GET /search?q=' << query << ' HTTP/1.1' << String crlf.
-			out << 'Host: encrypted.google.com' << String crlf.
+			out << 'Host: www.google.com' << String crlf.
 			out << 'Connection: close' << String crlf.
 			out << String crlf ].
 		stream connect.


### PR DESCRIPTION
Fix test outdated due to 301 response
- use www.google.com instead of encrypted.google.com