### PR TITLE
21824-Remove-test-retries-in-CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,32 +14,10 @@ def shell(params){
 }
 
 def runTests(architecture, prefix=''){
-	def retryTimes = 3
-	def tries = 0
-	def success = false
-	waitUntil {
-		tries += 1
-		echo "Try #${tries}"
-		try {
-			cleanWs()
-			unstash "bootstrap${architecture}"
-			shell "bash -c 'bootstrap/scripts/run${prefix}Tests.sh ${architecture} ${env.STAGE_NAME}'"
-			junit allowEmptyResults: true, testResults: "${env.STAGE_NAME}*.xml"
-			success = !(currentBuild.result == 'UNSTABLE')
-			echo "Tests run with result ${currentBuild.result}"
-		} catch(e) {
-			//If there is an exception ignore.
-			//success will be false and we will retry thanks to waitUntil
-			echo "Tests couldn't complete to run due to an exception"
-		}
-		if (!success && tries == retryTimes) {
-			echo "Out of retries"
-      //If the problem is with an exception I have to raise it because if not the test is marked as success.
-			if(currentBuild.result != 'UNSTABLE')
-        error("Out of retries running " + prefix + " tests")
-		}
-		return success || (tries == retryTimes)
-	}
+	cleanWs()
+	unstash "bootstrap${architecture}"
+	shell "bash -c 'bootstrap/scripts/run${prefix}Tests.sh ${architecture} ${env.STAGE_NAME}'"
+	junit allowEmptyResults: true, testResults: "${env.STAGE_NAME}*.xml"
 	archiveArtifacts allowEmptyArchive: true, artifacts: "${env.STAGE_NAME}*.xml", fingerprint: true
 	cleanWs()
 }


### PR DESCRIPTION
Initially the pharo build had tests that were failing randomly.
To cope with that, we introduced a retry of the tests.

Nowadays, this situation is actually very rare. Tests that fail, fail always, and randomly failing tests are not seen so often... This means however, that in the case that a test is persistently failing, we are (uselessly) retrying it, and making jobs take 10-15 minutes longer for nothing.

I propose that we remove the retries.

 - This will speed up the builds that are green and only penalize those that are not green.
 - Remove stress from our servers (that we can use to have a higher ratio builds/hour :))
 - Randomly failing tests will just need to manually retry the build. But since green builds take now ~15-20 minutes, which is in the same order of magnitude of the retries, we only penalize the one that found the hiccup.