### PR TITLE
21825-Improve-Catalog-loading

### DIFF
--- a/src/Tool-Catalog/CatalogProject.class.st
+++ b/src/Tool-Catalog/CatalogProject.class.st
@@ -153,21 +153,20 @@ CatalogProject >> gtInspectorDetailsIn: composite [
 ]
 
 { #category : #installing }
-CatalogProject >> installStableVersion [ 
-	  Metacello new
-		repository: self repositoryUrl, '/',self name;
-		configuration: self name;
-		version: #'stable';
-		load
+CatalogProject >> installStableVersion [
+	
+	self installVersion: #stable
 ]
 
 { #category : #installing }
 CatalogProject >> installVersion: aStringOrSymbol [ 
-	[ Gofer it 
-			url: self repositoryUrl;
-			configurationOf: self name;
-			loadVersion: aStringOrSymbol ]
-	on: Warning do: [ :w | w resume: true ]
+
+	Metacello new
+		repository: self repositoryUrl , '/' , self name;
+		configuration: self name;
+		version: aStringOrSymbol;
+		onWarningLog;
+		load
 ]
 
 { #category : #testing }


### PR DESCRIPTION
The catalog is sometimes using the old Gofer load instead of the new Metacello scripting interface.