### PR TITLE
21833 Deprecate #isTranslucentColor in Color (and small package cleanups)

### DIFF
--- a/src/Colors/Color.class.st
+++ b/src/Colors/Color.class.st
@@ -74,7 +74,7 @@ Class {
 		'MaskingMap',
 		'RedShift'
 	],
-	#category : #Colors
+	#category : #'Colors-Base'
 }
 
 { #category : #colormaps }
@@ -1597,13 +1597,6 @@ Color >> isTranslucentButNotTransparent [
 	"Answer true if this any of this morph is translucent but not transparent."
 	
 	^ self isTranslucent and: [ self isTransparent not ]
-]
-
-{ #category : #queries }
-Color >> isTranslucentColor [
-	"This means: self isTranslucent, but isTransparent not"
-	self flag: #toremove.
-	^ false
 ]
 
 { #category : #queries }

--- a/src/Colors/ColorMap.class.st
+++ b/src/Colors/ColorMap.class.st
@@ -11,7 +11,7 @@ Class {
 		'masks',
 		'colors'
 	],
-	#category : #Colors
+	#category : #'Colors-Base'
 }
 
 { #category : #'instance creation' }

--- a/src/Colors/ManifestColors.class.st
+++ b/src/Colors/ManifestColors.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ManifestColors,
 	#superclass : #PackageManifest,
-	#category : #Colors
+	#category : #'Colors-Manifest'
 }
 
 { #category : #'meta-data - dependency analyser' }

--- a/src/Deprecated70/Color.extension.st
+++ b/src/Deprecated70/Color.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #Color }
+
+{ #category : #'*Deprecated70' }
+Color >> isTranslucentColor [
+	"This means: self isTranslucent, but isTransparent not"
+	self deprecated: 'To be removed without replacement'.
+	^ false
+]


### PR DESCRIPTION

https://pharo.fogbugz.com/f/cases/21833/Deprecate-isTranslucentColor-in-Color-and-small-package-cleanups
- deprecate #isTranslucentColor
- move #isTranslucentColor to Deprecated70
- put some classes into tags