### PR TITLE
21834 Cleanups in FileSystem-Tests-Core

### DIFF
--- a/src/FileSystem-Tests-Core/AbstractEnumerationVisitorTest.class.st
+++ b/src/FileSystem-Tests-Core/AbstractEnumerationVisitorTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for AbstractEnumerationVisitor
 Class {
 	#name : #AbstractEnumerationVisitorTest,
 	#superclass : #SingleTreeTest,
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Visitors'
 }
 
 { #category : #'as yet unclassified' }
@@ -12,16 +12,16 @@ AbstractEnumerationVisitorTest class >> isAbstract [
 	^ self name = #AbstractEnumerationVisitorTest
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #utilities }
 AbstractEnumerationVisitorTest >> assertEntries: references are: expected [
 	| strings |
 	self assert: references isArray.
-	references do: [ :ea | self assert: ea class = FileSystemDirectoryEntry ].
+	references do: [ :ea | self assert: ea class equals: FileSystemDirectoryEntry ].
 	strings := references collect: [ :ea | ea reference pathString ].
 	self assert: strings equals: expected
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 AbstractEnumerationVisitorTest >> root [
 	^ filesystem / 'alpha'
 ]

--- a/src/FileSystem-Tests-Core/BreadthFirstGuideTest.class.st
+++ b/src/FileSystem-Tests-Core/BreadthFirstGuideTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for class BreadthFirstGuide
 Class {
 	#name : #BreadthFirstGuideTest,
 	#superclass : #GuideTest,
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Guide'
 }
 
 { #category : #tests }

--- a/src/FileSystem-Tests-Core/CollectVisitorTest.class.st
+++ b/src/FileSystem-Tests-Core/CollectVisitorTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for class CollectVisitor
 Class {
 	#name : #CollectVisitorTest,
 	#superclass : #AbstractEnumerationVisitorTest,
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Visitors'
 }
 
 { #category : #tests }

--- a/src/FileSystem-Tests-Core/CopyVisitorTest.class.st
+++ b/src/FileSystem-Tests-Core/CopyVisitorTest.class.st
@@ -8,7 +8,7 @@ Class {
 		'source',
 		'dest'
 	],
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Visitors'
 }
 
 { #category : #running }

--- a/src/FileSystem-Tests-Core/DeleteVisitorTest.class.st
+++ b/src/FileSystem-Tests-Core/DeleteVisitorTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for class DeleteVisitor
 Class {
 	#name : #DeleteVisitorTest,
 	#superclass : #SingleTreeTest,
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Visitors'
 }
 
 { #category : #tests }

--- a/src/FileSystem-Tests-Core/DirectoryEntryTest.class.st
+++ b/src/FileSystem-Tests-Core/DirectoryEntryTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for FileSystemDirectoryEntry
 Class {
 	#name : #DirectoryEntryTest,
 	#superclass : #TestCase,
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Base'
 }
 
 { #category : #accessing }

--- a/src/FileSystem-Tests-Core/FileLocatorTest.class.st
+++ b/src/FileSystem-Tests-Core/FileLocatorTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'locator'
 	],
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Base'
 }
 
 { #category : #'compatibility tests' }

--- a/src/FileSystem-Tests-Core/FileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/FileReferenceTest.class.st
@@ -8,7 +8,7 @@ Class {
 	#instVars : [
 		'filesystem'
 	],
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Base'
 }
 
 { #category : #support }

--- a/src/FileSystem-Tests-Core/FileSystemHandleTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemHandleTest.class.st
@@ -9,7 +9,7 @@ Class {
 		'handle',
 		'reference'
 	],
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Base'
 }
 
 { #category : #testing }

--- a/src/FileSystem-Tests-Core/FileSystemResolverTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemResolverTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'resolver'
 	],
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Resolver'
 }
 
 { #category : #testing }

--- a/src/FileSystem-Tests-Core/FileSystemTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemTest.class.st
@@ -11,7 +11,7 @@ Class {
 		'filesystem',
 		'toDelete'
 	],
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Base'
 }
 
 { #category : #accessing }

--- a/src/FileSystem-Tests-Core/FileSystemTreeTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemTreeTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for a file system tree
 Class {
 	#name : #FileSystemTreeTest,
 	#superclass : #TestCase,
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Base'
 }
 
 { #category : #testing }

--- a/src/FileSystem-Tests-Core/GuideTest.class.st
+++ b/src/FileSystem-Tests-Core/GuideTest.class.st
@@ -8,7 +8,7 @@ Class {
 		'guide',
 		'visited'
 	],
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Guide'
 }
 
 { #category : #testing }

--- a/src/FileSystem-Tests-Core/InteractiveResolverTest.class.st
+++ b/src/FileSystem-Tests-Core/InteractiveResolverTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for InteractiveResolver
 Class {
 	#name : #InteractiveResolverTest,
 	#superclass : #FileSystemResolverTest,
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Resolver'
 }
 
 { #category : #running }

--- a/src/FileSystem-Tests-Core/ManifestFileSystemTestsCore.class.st
+++ b/src/FileSystem-Tests-Core/ManifestFileSystemTestsCore.class.st
@@ -6,5 +6,5 @@ A documentation of this library is available in the Deep Into Pharo book, «Chap
 Class {
 	#name : #ManifestFileSystemTestsCore,
 	#superclass : #PackageManifest,
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Manifest'
 }

--- a/src/FileSystem-Tests-Core/PathTest.class.st
+++ b/src/FileSystem-Tests-Core/PathTest.class.st
@@ -5,7 +5,7 @@ Class {
 	#name : #PathTest,
 	#superclass : #TestCase,
 	#type : #variable,
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Base'
 }
 
 { #category : #tests }

--- a/src/FileSystem-Tests-Core/PlatformResolverTest.class.st
+++ b/src/FileSystem-Tests-Core/PlatformResolverTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for PlatformResolver
 Class {
 	#name : #PlatformResolverTest,
 	#superclass : #FileSystemResolverTest,
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Resolver'
 }
 
 { #category : #running }

--- a/src/FileSystem-Tests-Core/PostorderGuideTest.class.st
+++ b/src/FileSystem-Tests-Core/PostorderGuideTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for class PostorderGuide
 Class {
 	#name : #PostorderGuideTest,
 	#superclass : #GuideTest,
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Guide'
 }
 
 { #category : #tests }

--- a/src/FileSystem-Tests-Core/PreorderGuideTest.class.st
+++ b/src/FileSystem-Tests-Core/PreorderGuideTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for class PreorderGuide
 Class {
 	#name : #PreorderGuideTest,
 	#superclass : #GuideTest,
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Guide'
 }
 
 { #category : #tests }

--- a/src/FileSystem-Tests-Core/SelectVisitorTest.class.st
+++ b/src/FileSystem-Tests-Core/SelectVisitorTest.class.st
@@ -5,7 +5,7 @@ SUnit tests for class SelectVistor
 Class {
 	#name : #SelectVisitorTest,
 	#superclass : #AbstractEnumerationVisitorTest,
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Visitors'
 }
 
 { #category : #tests }

--- a/src/FileSystem-Tests-Core/SingleTreeTest.class.st
+++ b/src/FileSystem-Tests-Core/SingleTreeTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'filesystem'
 	],
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Base'
 }
 
 { #category : #testing }

--- a/src/FileSystem-Tests-Core/SystemResolverTest.class.st
+++ b/src/FileSystem-Tests-Core/SystemResolverTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for SystemResolver
 Class {
 	#name : #SystemResolverTest,
 	#superclass : #FileSystemResolverTest,
-	#category : #'FileSystem-Tests-Core'
+	#category : #'FileSystem-Tests-Core-Resolver'
 }
 
 { #category : #running }


### PR DESCRIPTION
- tagging of classes
- use assert:equals:
- categorize uncategorized methods
 

https://pharo.fogbugz.com/f/cases/21834/Cleanups-in-FileSystem-Tests-Core