### PR TITLE
21846-basicAddSelectorwithMethod-has-unused-temp

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -379,8 +379,6 @@ Behavior >> basicAddSelector: selector withMethod: compiledMethod [
 	receiver's method dictionary.
 	Do this without sending system change notifications"
 
-	| oldMethodOrNil |	
-	oldMethodOrNil := self lookupSelector: selector.
 	self methodDict at: selector put: compiledMethod.
 	compiledMethod methodClass: self.
 	compiledMethod selector: selector.

--- a/src/TraitsV2-Compatibility/TBehavior.trait.st
+++ b/src/TraitsV2-Compatibility/TBehavior.trait.st
@@ -374,8 +374,6 @@ TBehavior >> basicAddSelector: selector withMethod: compiledMethod [
 	receiver's method dictionary.
 	Do this without sending system change notifications"
 
-	| oldMethodOrNil |	
-	oldMethodOrNil := self lookupSelector: selector.
 	self methodDict at: selector put: compiledMethod.
 	compiledMethod methodClass: self.
 	compiledMethod selector: selector.


### PR DESCRIPTION
21846   basicAddSelector:withMethod: has unused temp
https://pharo.fogbugz.com/f/cases/21846/basicAddSelector-withMethod-has-unused-temp