### PR TITLE
21847-RBSmallLintContext-has-unused-ivars

### DIFF
--- a/src/Refactoring-Critics/RBSmalllintContext.class.st
+++ b/src/Refactoring-Critics/RBSmalllintContext.class.st
@@ -9,10 +9,7 @@ Class {
 		'literalSemaphore',
 		'literalProcess',
 		'selectors',
-		'compiledMethod',
-		'selfMessages',
-		'superMessages',
-		'messages'
+		'compiledMethod'
 	],
 	#category : #'Refactoring-Critics'
 }


### PR DESCRIPTION
RBSmallLintContext has unused ivars
https://pharo.fogbugz.com/f/cases/21847/RBSmallLintContext-has-unused-ivars