### PR TITLE
21856 Balloon and playground printIt colors for DarkTheme should be fixed

### DIFF
--- a/src/Polymorph-Widgets/PharoDarkTheme.class.st
+++ b/src/Polymorph-Widgets/PharoDarkTheme.class.st
@@ -76,13 +76,7 @@ PharoDarkTheme >> backgroundColor [
 { #category : #'accessing colors' }
 PharoDarkTheme >> balloonBackgroundColor [
 
-	^ (Color r: 1.0 g: 1.0 b: 0.71 alpha: 1.0)
-]
-
-{ #category : #'accessing colors' }
-PharoDarkTheme >> balloonTextColor [
-
-	^ Color black
+	^ self darkBaseColor lighter
 ]
 
 { #category : #'accessing colors' }


### PR DESCRIPTION
- not hardcoding the background color (by using a lighter versiono of the darkBaseColor for 
  balloonBackgroundColor)
- restore the actual color values of the dark theme as before the introduction of issue #21809 
- it is still possible to define a tooltips text color on the graphics theme as it was the goal in #21809

All details in https://pharo.fogbugz.com/f/cases/21856/