### PR TITLE
21860-remove-all-senders-of-compiler--translate

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -267,7 +267,6 @@ OpalCompiler >> evaluate [
 	self noPattern: true.
 	self getSourceFromRequestorSelection.
 	self class: (context ifNil: [ receiver class ] ifNotNil: [ context method methodClass ]).
-	compilationContext parseOptions: #(+ #optionEmbeddSources).
 	value := receiver withArgs: (context ifNil: [ #() ] ifNotNil: [ {context} ]) executeMethod: self compile.
 	self logDoIt.
 	^ value
@@ -328,6 +327,8 @@ OpalCompiler >> logged: aBoolean [
 { #category : #accessing }
 OpalCompiler >> noPattern: aBoolean [
 	self compilationContext noPattern: aBoolean.
+	"when we compile an expression, embedd sources, as the resulting method will never be installed"
+	compilationContext parseOptions: #(+ #optionEmbeddSources).
 	
 ]
 

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -213,24 +213,22 @@ RubSmalltalkEditor >> click: anEvent [
 
 { #category : #'do-its' }
 RubSmalltalkEditor >> compile: aStream for: anObject in: evalContext [
-	| methodNode methodClass |
+	| methodClass |
 	methodClass := evalContext
 		ifNil: [ anObject class ]
 		ifNotNil: [ evalContext methodClass ].
-	methodNode := self class compiler
+	^self class compiler
 		source: aStream;
 		class: methodClass;
 		context: evalContext;
 		requestor: self morph;
 		noPattern: true;
 		failBlock: [ ^ nil ];
-		translate.
-	^ methodNode generateWithSource
+		compile
 ]
 
 { #category : #'do-its' }
 RubSmalltalkEditor >> compileSelectionFor: anObject in: evalContext [
-	
 	^ self compile: self selectionAsStream for: anObject in: evalContext
 ]
 

--- a/src/Text-Edition/SmalltalkEditor.class.st
+++ b/src/Text-Edition/SmalltalkEditor.class.st
@@ -315,19 +315,14 @@ SmalltalkEditor >> codeCompletionAround:  aBlock textMorph:  aTextMorph keyStrok
 
 { #category : #'do-its' }
 SmalltalkEditor >> compileSelectionFor: anObject in: evalContext [
-	| methodNode  |
-
-	methodNode :=  self class compiler
+	^self class compiler
 		source: self selectionAsStream;
 		class: anObject class;
 		context: evalContext;
 		requestor: self morph;
 		noPattern: true;
 		failBlock:  [ ^nil ];
-		translate.
-			
-	^methodNode generateWithSource.
-	
+		compile.
 ]
 
 { #category : #'do-its' }

--- a/src/Tool-Profilers/TimeProfiler.class.st
+++ b/src/Tool-Profilers/TimeProfiler.class.st
@@ -147,10 +147,14 @@ TimeProfiler >> blockCode: aString notifying: aRequestor [
 	"Treat the current selection as an expression; evaluate and tally it."
 	|  compiledMethod |
 	aString ifNil: [^ self].
-
 	blockSource := aString.
-	compiledMethod := self compile: aString for: nil in: self doItContext.
-	compiledMethod ifNil: [^ self].
+	compiledMethod := Smalltalk compiler
+		source: ('self runBlock: [', aString, ']');
+		context: self doItContext;
+		requestor: self;
+		noPattern: true;
+		failBlock: [^self];
+		compile.
 	self showResult: ( compiledMethod valueWithReceiver: self arguments: #()).
 	self changed: #blockCode.
 	self changed: #summaryText.
@@ -177,22 +181,6 @@ TimeProfiler >> codePaneMenu: aMenu shifted: shifted [
 	| donorMenu |
    donorMenu := (PragmaMenuBuilder pragmaKeyword: RubSmalltalkCodeMode menuKeyword model: codeTabPane) menu.
 	^ aMenu addAllFrom: donorMenu
-]
-
-{ #category : #compiling }
-TimeProfiler >> compile: codeString for: anObject in: evalContext [
-
-	| methodNode |
-	methodNode := Smalltalk compiler
-		source: ('self runBlock: [', codeString, ']');
-		class: anObject class;
-		context: evalContext;
-		requestor: self;
-		noPattern: true;
-		failBlock: [^nil];
-		translate.
-		
-	^ methodNode generateWithSource.
 ]
 
 { #category : #'UI specific' }

--- a/src/TraitsV2-Compatibility/TraitMethodDescription.class.st
+++ b/src/TraitsV2-Compatibility/TraitMethodDescription.class.st
@@ -108,7 +108,7 @@ TraitMethodDescription >> generateMethod: aSelector withMarker: aSymbol forArgs:
 		source: source;
 		class: self class;
 		failBlock: [];
-		translate.
+		parse.
 	^(node generateWithSource) selector: aSelector; yourself
 ]
 


### PR DESCRIPTION
remove all senders of compiler >> #translate
https://pharo.fogbugz.com/f/cases/21860/remove-all-senders-of-compiler-translate

#translate is not really needed. all clients just use it because the want to use #generateWithSources.
But if we make source embedding the default for all cases where we use #noPattern:, then we can just use #compile