### PR TITLE
21861-AbstractCompiler-move-all-non-abstract-methods-down

### DIFF
--- a/src/Compiler/Compiler.class.st
+++ b/src/Compiler/Compiler.class.st
@@ -97,6 +97,11 @@ Compiler class >> recompileAll [
 ]
 
 { #category : #'public - opal compatibility' }
+Compiler >> addPlugin: aClass [ 
+	"do nothing"
+]
+
+{ #category : #'public - opal compatibility' }
 Compiler >> class: aClass [
 	"This is used for compatibility with Opal"
 	class := aClass.
@@ -110,6 +115,11 @@ Compiler >> compilationContext [
 			requestor: requestor;
 			class: class ]
 			
+]
+
+{ #category : #'public - opal compatibility' }
+Compiler >> compilationContext: anObject [
+	compilationContext := anObject
 ]
 
 { #category : #'public - opal compatibility' }
@@ -184,6 +194,11 @@ Compiler >> context: aContext [
 Compiler >> decompileMethod: aCompiledMethod [
 	^Decompiler decompile: aCompiledMethod
 
+]
+
+{ #category : #'public - opal compatibility' }
+Compiler >> encoderClass: aClass [ 
+	self compilationContext encoderClass: aClass 
 ]
 
 { #category : #'public - opal compatibility' }
@@ -474,6 +489,12 @@ Compiler >> requestor: aRequestor [
 	requestor := aRequestor.
 	self compilationContext requestor: aRequestor.
 	self compilationContext interactive: self interactive.
+]
+
+{ #category : #'public - opal compatibility' }
+Compiler >> requestorScopeClass: aClass [ 
+	"clients can set their own subclass of OCRequestorScope if needed"
+	self compilationContext requestorScopeClass: aClass
 ]
 
 { #category : #'public - opal compatibility' }

--- a/src/OpalCompiler-Core/AbstractCompiler.class.st
+++ b/src/OpalCompiler-Core/AbstractCompiler.class.st
@@ -23,11 +23,6 @@ AbstractCompiler class >> compilerSettingsOn: aBuilder [
 					
 ]
 
-{ #category : #plugins }
-AbstractCompiler >> addPlugin: aClass [ 
-	"do nothing"
-]
-
 { #category : #accessing }
 AbstractCompiler >> class: aClass [
 	self subclassResponsibility
@@ -58,43 +53,6 @@ AbstractCompiler >> compile [
 	self subclassResponsibility
 ]
 
-{ #category : #'old - public' }
-AbstractCompiler >> compile: textOrStream in: aClass classified: aCategory notifying: aRequestor ifFail:  aFailBlock [ 
-
-	^self 
-		source: textOrStream;
-		class: aClass;
-		requestor: aRequestor;
-		failBlock: aFailBlock;
-		translate
-]
-
-{ #category : #'old - public' }
-AbstractCompiler >> compile: textOrStream in: aClass notifying: aRequestor ifFail: aFailBlock [ 
-
-	^self 
-		source: textOrStream;
-		class: aClass;
-		requestor: aRequestor;
-		failBlock: aFailBlock;
-		translate
-	
-
-]
-
-{ #category : #'old - public' }
-AbstractCompiler >> compileNoPattern: textOrStream in: aClass context: aContext notifying: aRequestor ifFail: aFailBlock [
-
-	^self 
-		source: textOrStream;
-		class: aClass;
-		context: aContext;
-		requestor: aRequestor;
-		noPattern: true;
-		failBlock: aFailBlock;
-		translate
-]
-
 { #category : #accessing }
 AbstractCompiler >> compiledMethodTrailer: aClass [
 	self subclassResponsibility
@@ -112,7 +70,7 @@ AbstractCompiler >> decompileMethod: aCompiledMethod [
 
 { #category : #accessing }
 AbstractCompiler >> encoderClass: aClass [ 
-	self compilationContext encoderClass: aClass 
+	self subclassResponsibility
 ]
 
 { #category : #accessing }
@@ -125,95 +83,6 @@ AbstractCompiler >> evaluate [
 	self subclassResponsibility
 ]
 
-{ #category : #'public access' }
-AbstractCompiler >> evaluate: textOrString [ 
-	
-	^self
-		source: textOrString;
-		evaluate
-]
-
-{ #category : #'old - public' }
-AbstractCompiler >> evaluate: textOrString for: anObject logged: logFlag [ 
-
-	^self
-		source: textOrString;
-		logged: logFlag;
-		receiver: anObject;
-		evaluate
-]
-
-{ #category : #'old - public' }
-AbstractCompiler >> evaluate: textOrString for: anObject notifying: aController logged: logFlag [
-
-	^ self 
-		source: textOrString;
-		logged: logFlag;
-		receiver: anObject;
-		requestor: aController;
-		evaluate
-	
-			
-]
-
-{ #category : #'old - public' }
-AbstractCompiler >> evaluate: aString in: aContext to: aReceiver [
-	
-	^self
-		source: aString;
-		context: aContext;
-		receiver: aReceiver;
-		failBlock: [^ #failedDoit];
-		evaluate
-]
-
-{ #category : #'old - public' }
-AbstractCompiler >> evaluate: textOrStream in: aContext to: aReceiver notifying: aRequestor ifFail: aFailBlock [ 
-	
-	^self
-		source: textOrStream;
-		context: aContext;
-		receiver: aReceiver;
-		requestor: aRequestor;
-		failBlock: aFailBlock;
-		evaluate
-]
-
-{ #category : #'old - public' }
-AbstractCompiler >> evaluate: textOrStream in: aContext to: aReceiver notifying: aRequestor ifFail: aFailBlock logged: logFlag [
-	
-	^self
-		source: textOrStream;
-		context: aContext;
-		receiver: aReceiver;
-		requestor: aRequestor;
-		failBlock: aFailBlock;
-		logged: logFlag;
-		evaluate
-]
-
-{ #category : #'old - public' }
-AbstractCompiler >> evaluate: textOrString logged: logFlag [ 
-
-	^ self
-		source: textOrString;
-		logged: logFlag;
-		evaluate
-	
-			
-]
-
-{ #category : #'old - public' }
-AbstractCompiler >> evaluate: textOrString notifying: aController logged: logFlag [ 
-
-	^ self
-		source: textOrString;
-		logged: logFlag;
-		requestor: aController;
-		evaluate
-	
-]
-
 { #category : #accessing }
 AbstractCompiler >> failBlock: aBlock [
 	self subclassResponsibility
@@ -222,16 +91,6 @@ AbstractCompiler >> failBlock: aBlock [
 { #category : #'public access' }
 AbstractCompiler >> format [
 	self subclassResponsibility
-]
-
-{ #category : #'old - public' }
-AbstractCompiler >> format: textOrStream in: aClass notifying: aRequestor [
-	^self
-		source: textOrStream;
-		class: aClass;
-		requestor: aRequestor;
-		format
-		
 ]
 
 { #category : #accessing }
@@ -252,38 +111,6 @@ AbstractCompiler >> options: anArray [
 { #category : #'public access' }
 AbstractCompiler >> parse [
 	self subclassResponsibility
-]
-
-{ #category : #'old - public' }
-AbstractCompiler >> parse: aString class: aClass [
-	^self 
-		source: aString;
-		class: aClass;
-		parse
-]
-
-{ #category : #'old - public' }
-AbstractCompiler >> parse: aString class: aClass noPattern: aBoolean context: aContext notifying: req ifFail: aBlock [
-	"Backwards compatibilty"
-	
-	^self 
-		source: aString;
-		class: aClass;
-		noPattern: aBoolean;
-		context: aContext;
-		requestor: req;
-		failBlock: aBlock;
-		translate.
-]
-
-{ #category : #'old - public' }
-AbstractCompiler >> parse: textOrStream in: aClass notifying: req [
-
-	^self 
-		source: textOrStream;
-		class: aClass;
-		requestor: req;
-		translate.
 ]
 
 { #category : #'public access' }
@@ -307,9 +134,8 @@ AbstractCompiler >> requestor: aRequestor [
 ]
 
 { #category : #accessing }
-AbstractCompiler >> requestorScopeClass: aClass [ 
-	"clients can set their own subclass of OCRequestorScope if needed"
-	self compilationContext requestorScopeClass: aClass 
+AbstractCompiler >> requestorScopeClass: aClass [
+	self subclassResponsibility
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -220,6 +220,43 @@ OpalCompiler >> compile: textOrString [
 		compile.
 ]
 
+{ #category : #'old - deprecated' }
+OpalCompiler >> compile: textOrStream in: aClass classified: aCategory notifying: aRequestor ifFail:  aFailBlock [ 
+
+	^self 
+		source: textOrStream;
+		class: aClass;
+		requestor: aRequestor;
+		failBlock: aFailBlock;
+		parse
+]
+
+{ #category : #'old - deprecated' }
+OpalCompiler >> compile: textOrStream in: aClass notifying: aRequestor ifFail: aFailBlock [ 
+
+	^self 
+		source: textOrStream;
+		class: aClass;
+		requestor: aRequestor;
+		failBlock: aFailBlock;
+		parse
+	
+
+]
+
+{ #category : #'old - deprecated' }
+OpalCompiler >> compileNoPattern: textOrStream in: aClass context: aContext notifying: aRequestor ifFail: aFailBlock [
+
+	^self 
+		source: textOrStream;
+		class: aClass;
+		context: aContext;
+		requestor: aRequestor;
+		noPattern: true;
+		failBlock: aFailBlock;
+		parse
+]
+
 { #category : #accessing }
 OpalCompiler >> compiledMethodTrailer: bytes [
 	self compilationContext compiledMethodTrailer: bytes
@@ -250,6 +287,11 @@ OpalCompiler >> doSemanticAnalysis [
 ]
 
 { #category : #accessing }
+OpalCompiler >> encoderClass: aClass [ 
+	self compilationContext encoderClass: aClass 
+]
+
+{ #category : #accessing }
 OpalCompiler >> environment: anSmallTalkImage [
 	self compilationContext environment: anSmallTalkImage 
 ]
@@ -272,6 +314,95 @@ OpalCompiler >> evaluate [
 	^ value
 ]
 
+{ #category : #'public access' }
+OpalCompiler >> evaluate: textOrString [ 
+	
+	^self
+		source: textOrString;
+		evaluate
+]
+
+{ #category : #'old - deprecated' }
+OpalCompiler >> evaluate: textOrString for: anObject logged: logFlag [ 
+
+	^self
+		source: textOrString;
+		logged: logFlag;
+		receiver: anObject;
+		evaluate
+]
+
+{ #category : #'old - deprecated' }
+OpalCompiler >> evaluate: textOrString for: anObject notifying: aController logged: logFlag [
+
+	^ self 
+		source: textOrString;
+		logged: logFlag;
+		receiver: anObject;
+		requestor: aController;
+		evaluate
+	
+			
+]
+
+{ #category : #'old - deprecated' }
+OpalCompiler >> evaluate: aString in: aContext to: aReceiver [
+	
+	^self
+		source: aString;
+		context: aContext;
+		receiver: aReceiver;
+		failBlock: [^ #failedDoit];
+		evaluate
+]
+
+{ #category : #'old - deprecated' }
+OpalCompiler >> evaluate: textOrStream in: aContext to: aReceiver notifying: aRequestor ifFail: aFailBlock [ 
+	
+	^self
+		source: textOrStream;
+		context: aContext;
+		receiver: aReceiver;
+		requestor: aRequestor;
+		failBlock: aFailBlock;
+		evaluate
+]
+
+{ #category : #'old - deprecated' }
+OpalCompiler >> evaluate: textOrStream in: aContext to: aReceiver notifying: aRequestor ifFail: aFailBlock logged: logFlag [
+	
+	^self
+		source: textOrStream;
+		context: aContext;
+		receiver: aReceiver;
+		requestor: aRequestor;
+		failBlock: aFailBlock;
+		logged: logFlag;
+		evaluate
+]
+
+{ #category : #'old - deprecated' }
+OpalCompiler >> evaluate: textOrString logged: logFlag [ 
+
+	^ self
+		source: textOrString;
+		logged: logFlag;
+		evaluate
+	
+			
+]
+
+{ #category : #'old - deprecated' }
+OpalCompiler >> evaluate: textOrString notifying: aController logged: logFlag [ 
+
+	^ self
+		source: textOrString;
+		logged: logFlag;
+		requestor: aController;
+		evaluate
+	
+]
+
 { #category : #accessing }
 OpalCompiler >> failBlock: aBlock [
 	self compilationContext failBlock: aBlock.
@@ -288,6 +419,16 @@ OpalCompiler >> format: textOrString [
 	^self
 		source: textOrString;
 		format
+]
+
+{ #category : #'old - deprecated' }
+OpalCompiler >> format: textOrStream in: aClass notifying: aRequestor [
+	^self
+		source: textOrStream;
+		class: aClass;
+		requestor: aRequestor;
+		format
+		
 ]
 
 { #category : #private }
@@ -352,6 +493,38 @@ OpalCompiler >> parse: textOrString [
 		parse
 ]
 
+{ #category : #'old - deprecated' }
+OpalCompiler >> parse: aString class: aClass [
+	^self 
+		source: aString;
+		class: aClass;
+		parse
+]
+
+{ #category : #'old - deprecated' }
+OpalCompiler >> parse: aString class: aClass noPattern: aBoolean context: aContext notifying: req ifFail: aBlock [
+	"Backwards compatibilty"
+	
+	^self 
+		source: aString;
+		class: aClass;
+		noPattern: aBoolean;
+		context: aContext;
+		requestor: req;
+		failBlock: aBlock;
+		parse.
+]
+
+{ #category : #'old - deprecated' }
+OpalCompiler >> parse: textOrStream in: aClass notifying: req [
+
+	^self 
+		source: textOrStream;
+		class: aClass;
+		requestor: req;
+		parse.
+]
+
 { #category : #private }
 OpalCompiler >> parseExpression [
 	| expression |
@@ -403,15 +576,19 @@ OpalCompiler >> requestor: aRequestor [
 ]
 
 { #category : #accessing }
+OpalCompiler >> requestorScopeClass: aClass [ 
+	"clients can set their own subclass of OCRequestorScope if needed"
+	self compilationContext requestorScopeClass: aClass
+]
+
+{ #category : #accessing }
 OpalCompiler >> source: aString [
 	source := aString readStream.
 ]
 
-{ #category : #'public access' }
+{ #category : #'old - deprecated' }
 OpalCompiler >> translate [
-	[ self compile ] on: ReparseAfterSourceEditing do: [ :ex |
-		self source: ex newSource readStream.
-		self compile
-	 ] .
-	^ ast
+	self
+		deprecated: 'Please use #parse instead'
+		transformWith: '`@receiver translate' -> '`@receiver parse'
 ]


### PR DESCRIPTION
AbstractCompiler: move all non-abstract methods down
https://pharo.fogbugz.com/f/cases/21861/AbstractCompiler-move-all-non-abstract-methods-down