### PR TITLE
21866-Remove-Compiler-from-ignored-dependencies-of-OpalCompiler

### DIFF
--- a/src/OpalCompiler-Core/ManifestOpalCompilerCore.class.st
+++ b/src/OpalCompiler-Core/ManifestOpalCompilerCore.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #'meta-data - dependency analyser' }
 ManifestOpalCompilerCore class >> ignoredDependencies [
-	^ #(#Compiler #'Morphic-Base' #'System-Settings')
+	^ #(#'Morphic-Base' #'System-Settings')
 ]
 
 { #category : #'meta-data - dependency analyser' }


### PR DESCRIPTION
Remove Compiler from ignored dependencies of OpalCompilerFixes https://pharo.fogbugz.com/f/cases/21866/Remove-Compiler-from-ignored-dependencies-of-OpalCompiler