### PR TITLE
21868-Compiler-wrongly-defined-as-a-dependency-of-Collections-Tests

### DIFF
--- a/src/Collections-Tests/ManifestCollectionsTests.class.st
+++ b/src/Collections-Tests/ManifestCollectionsTests.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #'meta-data' }
 ManifestCollectionsTests class >> dependencies [
-	^ #(#'Collections-Streams' #'System-Finalization' #'Collections-Native' #'Collections-Abstract' #'Collections-Weak' #'Collections-Stack' #'Collections-Strings' #Compiler #'Collections-Sequenceable' #'SUnit-Core' #Kernel #'Graphics-Primitives' #'Collections-Support' #'Collections-Unordered' #'System-Support' #'Collections-Atomic' #'Multilingual-Encodings')
+	^ #(#'Collections-Streams' #'System-Finalization' #'Collections-Native' #'Collections-Abstract' #'Collections-Weak' #'Collections-Stack' #'Collections-Strings' #'Collections-Sequenceable' #'SUnit-Core' #Kernel #'Graphics-Primitives' #'Collections-Support' #'Collections-Unordered' #'System-Support' #'Collections-Atomic' #'Multilingual-Encodings')
 ]
 
 { #category : #'meta-data - dependency analyser' }


### PR DESCRIPTION
Remove Compiler from Collections-Tests dependencies.

https://pharo.fogbugz.com/f/cases/21868/Compiler-wrongly-defined-as-a-dependency-of-Collections-Tests