### PR TITLE
21878-deprecate-isTranslucentColor-using-deprecated-transformWith

### DIFF
--- a/src/Deprecated70/Color.extension.st
+++ b/src/Deprecated70/Color.extension.st
@@ -2,7 +2,8 @@ Extension { #name : #Color }
 
 { #category : #'*Deprecated70' }
 Color >> isTranslucentColor [
-	"This means: self isTranslucent, but isTransparent not"
-	self deprecated: 'To be removed without replacement'.
-	^ false
+	self
+		deprecated: 'use isTranslucentButNotTransparent or isTranslucent'
+		transformWith: '`@receiver isTranslucentColor' -> '`@receiver isTranslucentButNotTransparent'.
+	^ self isTranslucentButNotTransparent
 ]


### PR DESCRIPTION
deprecate isTranslucentColor using deprecated: transformWith:
https://pharo.fogbugz.com/f/cases/21878/deprecate-isTranslucentColor-using-deprecated-transformWith