### PR TITLE
21891-PluggableButtonMorph-in-dark-theme-does-not-take-the-theme-into-account-for-the-border

### DIFF
--- a/src/Morphic-Widgets-Basic/PluggableButtonMorph.class.st
+++ b/src/Morphic-Widgets-Basic/PluggableButtonMorph.class.st
@@ -746,8 +746,9 @@ PluggableButtonMorph >> initialize [
 		layoutInset: (self theme buttonLabelInsetFor: self);
 		extent: 20 @ 15;
 		lastState: false;
-		cornerStyle: (self theme buttonCornerStyleIn: nil).
-	self theme buttonBorderStyleFor: self.
+		cornerStyle: (self theme buttonCornerStyleIn: nil);
+		borderStyle: (self theme buttonNormalBorderStyleFor: self).
+		
 	self clipSubmorphs: true
 ]
 

--- a/src/Morphic-Widgets-Taskbar/TaskbarItemMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarItemMorph.class.st
@@ -43,6 +43,12 @@ TaskbarItemMorph >> disabledFillStyle [
 ]
 
 { #category : #initialization }
+TaskbarItemMorph >> initialize [
+	super initialize.
+	self borderStyle: (self theme taskbarItemNormalBorderStyleFor: self)
+]
+
+{ #category : #initialization }
 TaskbarItemMorph >> initializeAnnouncements [
 	self 
 		on: #mouseEnter send: #taskbarButtonEntered:event:in: to: self model withValue: self;


### PR DESCRIPTION
PluggableButtonMorph should use the theme border style, even in the dark theme.Fix proposed by Henrik Nergaard. Thank you!

https://pharo.fogbugz.com/f/cases/21891/PluggableButtonMorph-in-dark-theme-does-not-take-the-theme-into-account-for-the-border