### PR TITLE
21895 Cleanup of SUnit

### DIFF
--- a/src/SUnit-Core/ManifestSUnitCore.class.st
+++ b/src/SUnit-Core/ManifestSUnitCore.class.st
@@ -1,5 +1,8 @@
+"
+Core package for the SUnit unit testing framework
+"
 Class {
 	#name : #ManifestSUnitCore,
 	#superclass : #PackageManifest,
-	#category : #'SUnit-Core'
+	#category : #'SUnit-Core-Manifest'
 }

--- a/src/SUnit-Support-UITesting-Tests/SimulateKeystrokesTest.class.st
+++ b/src/SUnit-Support-UITesting-Tests/SimulateKeystrokesTest.class.st
@@ -1,22 +1,25 @@
+"
+SUnit tests to simulate and test key strokes
+"
 Class {
-	#name : #SimulateKeystrokesSpecification,
+	#name : #SimulateKeystrokesTest,
 	#superclass : #UITestCase,
 	#category : #'SUnit-Support-UITesting-Tests'
 }
 
 { #category : #tests }
-SimulateKeystrokesSpecification >> testSimulateCmdKeystroke [
+SimulateKeystrokesTest >> testSimulateCmdKeystroke [
 
 	| ws |
 	ws := Smalltalk tools workspace open.
 	self simulateKeyStrokes: 'var := 3.'.
 	self simulateKeyStroke: $s meta.
-	self assert: ws hasUnacceptedEdits = false.
+	self assert: ws hasUnacceptedEdits equals:false.
 	ws delete.
 ]
 
 { #category : #tests }
-SimulateKeystrokesSpecification >> testSimulateKeystroke [
+SimulateKeystrokesTest >> testSimulateKeystroke [
 
 	| textMorph |
 	textMorph := TextMorph new contents: ''; openInWorld.
@@ -28,7 +31,7 @@ SimulateKeystrokesSpecification >> testSimulateKeystroke [
 ]
 
 { #category : #tests }
-SimulateKeystrokesSpecification >> testSimulateKeystrokes [
+SimulateKeystrokesTest >> testSimulateKeystrokes [
 
 	| textMorph |
 	textMorph := TextMorph new contents: ''; openInWorld.

--- a/src/SUnit-Support-UITesting-Tests/SimulateMouseTest.class.st
+++ b/src/SUnit-Support-UITesting-Tests/SimulateMouseTest.class.st
@@ -1,5 +1,8 @@
+"
+SUnit tests to simulate and test mouse behavior
+"
 Class {
-	#name : #SimulateMouseSpecification,
+	#name : #SimulateMouseTest,
 	#superclass : #UITestCase,
 	#instVars : [
 		'morph'
@@ -8,7 +11,7 @@ Class {
 }
 
 { #category : #helpers }
-SimulateMouseSpecification >> menuOpenedDuring: aBlock [
+SimulateMouseTest >> menuOpenedDuring: aBlock [
 
 	| jailor |
 	jailor := MenuCapturingMorph new openInWorld.
@@ -17,14 +20,14 @@ SimulateMouseSpecification >> menuOpenedDuring: aBlock [
 ]
 
 { #category : #running }
-SimulateMouseSpecification >> tearDown [
+SimulateMouseTest >> tearDown [
 
 	morph delete.
 	super tearDown 
 ]
 
 { #category : #tests }
-SimulateMouseSpecification >> testSimulateClick [
+SimulateMouseTest >> testSimulateClick [
 
 	morph := TextMorph new contents: ''; openInWorld.	
 	morph simulateClick.
@@ -32,7 +35,7 @@ SimulateMouseSpecification >> testSimulateClick [
 ]
 
 { #category : #tests }
-SimulateMouseSpecification >> testSimulateMiddleClick [
+SimulateMouseTest >> testSimulateMiddleClick [
 	
 	morph := MorphHandlingMiddleButton new openInWorld.
 	morph simulateMiddleClick.
@@ -41,7 +44,7 @@ SimulateMouseSpecification >> testSimulateMiddleClick [
 ]
 
 { #category : #tests }
-SimulateMouseSpecification >> testSimulateRightClick [
+SimulateMouseTest >> testSimulateRightClick [
 	
 	| menu |
 	morph := Smalltalk tools workspace open.
@@ -50,7 +53,7 @@ SimulateMouseSpecification >> testSimulateRightClick [
 ]
 
 { #category : #helpers }
-SimulateMouseSpecification >> timeoutAfter: aDuration ifNot: aBlock [
+SimulateMouseTest >> timeoutAfter: aDuration ifNot: aBlock [
 
 	| timer |
 	timer := Stopwatch new activate.
@@ -58,7 +61,7 @@ SimulateMouseSpecification >> timeoutAfter: aDuration ifNot: aBlock [
 ]
 
 { #category : #helpers }
-SimulateMouseSpecification >> waitForMorphThat: aBlock [
+SimulateMouseTest >> waitForMorphThat: aBlock [
 
 	self timeoutAfter: 2 seconds ifNot: [
 		morph := World submorphThat: aBlock ifNone: [ nil ].

--- a/src/SUnit-Tests/SimpleTestResource.class.st
+++ b/src/SUnit-Tests/SimpleTestResource.class.st
@@ -12,7 +12,7 @@ Class {
 	#classInstVars : [
 		'preventAvailability'
 	],
-	#category : #'SUnit-Tests-Core'
+	#category : #'SUnit-Tests-Resources'
 }
 
 { #category : #accessing }

--- a/src/SUnit-Tests/SimpleTestResourceA.class.st
+++ b/src/SUnit-Tests/SimpleTestResourceA.class.st
@@ -4,7 +4,7 @@ I'm a simple test ressource for test purposes
 Class {
 	#name : #SimpleTestResourceA,
 	#superclass : #SimpleTestResource,
-	#category : #'SUnit-Tests-Core'
+	#category : #'SUnit-Tests-Resources'
 }
 
 { #category : #accessing }

--- a/src/SUnit-Tests/SimpleTestResourceA1.class.st
+++ b/src/SUnit-Tests/SimpleTestResourceA1.class.st
@@ -4,5 +4,5 @@ I'm a simple test ressource for test purposes
 Class {
 	#name : #SimpleTestResourceA1,
 	#superclass : #SimpleTestResource,
-	#category : #'SUnit-Tests-Core'
+	#category : #'SUnit-Tests-Resources'
 }

--- a/src/SUnit-Tests/SimpleTestResourceA2.class.st
+++ b/src/SUnit-Tests/SimpleTestResourceA2.class.st
@@ -4,5 +4,5 @@ I'm a simple test ressource for test purposes
 Class {
 	#name : #SimpleTestResourceA2,
 	#superclass : #SimpleTestResource,
-	#category : #'SUnit-Tests-Core'
+	#category : #'SUnit-Tests-Resources'
 }

--- a/src/SUnit-Tests/SimpleTestResourceB.class.st
+++ b/src/SUnit-Tests/SimpleTestResourceB.class.st
@@ -4,7 +4,7 @@ I'm a simple test ressource for test purposes
 Class {
 	#name : #SimpleTestResourceB,
 	#superclass : #SimpleTestResource,
-	#category : #'SUnit-Tests-Core'
+	#category : #'SUnit-Tests-Resources'
 }
 
 { #category : #accessing }

--- a/src/SUnit-Tests/SimpleTestResourceB1.class.st
+++ b/src/SUnit-Tests/SimpleTestResourceB1.class.st
@@ -4,5 +4,5 @@ I'm a simple test ressource for test purposes
 Class {
 	#name : #SimpleTestResourceB1,
 	#superclass : #SimpleTestResource,
-	#category : #'SUnit-Tests-Core'
+	#category : #'SUnit-Tests-Resources'
 }

--- a/src/SUnit-Tests/SimpleTestResourceCircular.class.st
+++ b/src/SUnit-Tests/SimpleTestResourceCircular.class.st
@@ -4,7 +4,7 @@ I'm a simple test ressource for test purposes
 Class {
 	#name : #SimpleTestResourceCircular,
 	#superclass : #SimpleTestResource,
-	#category : #'SUnit-Tests-Core'
+	#category : #'SUnit-Tests-Resources'
 }
 
 { #category : #accessing }

--- a/src/SUnit-Tests/SimpleTestResourceCircular1.class.st
+++ b/src/SUnit-Tests/SimpleTestResourceCircular1.class.st
@@ -4,7 +4,7 @@ I'm a simple test ressource for test purposes
 Class {
 	#name : #SimpleTestResourceCircular1,
 	#superclass : #SimpleTestResource,
-	#category : #'SUnit-Tests-Core'
+	#category : #'SUnit-Tests-Resources'
 }
 
 { #category : #accessing }

--- a/src/SUnit-UI/CommandLineTestRunner.class.st
+++ b/src/SUnit-UI/CommandLineTestRunner.class.st
@@ -11,7 +11,7 @@ Class {
 		'maxTest',
 		'shouldSerializeError'
 	],
-	#category : #'SUnit-UI'
+	#category : #'SUnit-UI-Headless'
 }
 
 { #category : #private }

--- a/src/SUnit-UI/TestReviver.class.st
+++ b/src/SUnit-UI/TestReviver.class.st
@@ -19,7 +19,7 @@ Class {
 		'imageVersion',
 		'imageVersionLabel'
 	],
-	#category : #'SUnit-UI'
+	#category : #'SUnit-UI-Tools'
 }
 
 { #category : #opening }

--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -35,7 +35,7 @@ Class {
 		'packagePattern',
 		'packageIndex'
 	],
-	#category : #'SUnit-UI'
+	#category : #'SUnit-UI-Tools'
 }
 
 { #category : #'world menu' }
@@ -52,6 +52,8 @@ TestRunner class >> menuCommandOn: aBuilder [
 
 { #category : #'instance creation' }
 TestRunner class >> open [
+	<script>
+	
 	^ self new open
 ]
 
@@ -706,7 +708,8 @@ TestRunner >> label: aString forSuite: aTestSuite [
 
 { #category : #building }
 TestRunner >> open [
-
+	<script: 'self new open'>
+	 
 	^ self build openInWorld
 	
 

--- a/src/SUnit-UI/VTermTestRunner.class.st
+++ b/src/SUnit-UI/VTermTestRunner.class.st
@@ -5,7 +5,7 @@ I run a TestSuite and outpout the progress in a terminal friendly way with XTerm
 Class {
 	#name : #VTermTestRunner,
 	#superclass : #CommandLineTestRunner,
-	#category : #'SUnit-UI'
+	#category : #'SUnit-UI-Headless'
 }
 
 { #category : #private }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21895/Cleanup-of-SUnit

- Rename SimulateKeystrokesSpecification into SimulateKeystrokesTest
- Rename SimulateMouseSpecification into SimulateMouseTest
- tag and comment ManifestSUnitCore
- SimpleTestResource and subclasses should be in "Resources" protocol as
  they are SUnit test resources
- categorize classes in SUnit-UI
- put a <script> pragma on TestRunner(class)>>#open