### PR TITLE
21904-TextDoIt-TextPrintIt-uses-old-compiler-API

### DIFF
--- a/src/Text-Edition/TextDoIt.extension.st
+++ b/src/Text-Edition/TextDoIt.extension.st
@@ -5,6 +5,6 @@ TextDoIt >> actOnClick: anEvent for: anObject in: paragraph editor: editor [
 
 	"Note: evalString gets evaluated IN THE CONTEXT OF anObject
 	 -- meaning that self and all instVars are accessible"
-	Smalltalk compiler evaluate: evalString for: anObject logged: false.
+	Smalltalk compiler receiver: anObject; evaluate: evalString.
 	^ true 
 ]

--- a/src/Text-Edition/TextPrintIt.extension.st
+++ b/src/Text-Edition/TextPrintIt.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #TextPrintIt }
 TextPrintIt >> actOnClick: anEvent for: anObject in: paragraph editor: editor [
 
 	| result |
-	result := Smalltalk compiler evaluate: evalString for: anObject logged: false.
+	result := Smalltalk compiler receiver: anObject; evaluate: evalString.
 	UIManager inform: result printString.
 	^ true 
 ]


### PR DESCRIPTION
TextDoIt TextPrintIt uses old compiler API
https://pharo.fogbugz.com/f/cases/21904/TextDoIt-TextPrintIt-uses-old-compiler-API