### PR TITLE
21900-GTExamplesBrowser-uses-old-Compiler-API

### DIFF
--- a/src/Glamour-Examples/GLMExamplesBrowser.class.st
+++ b/src/Glamour-Examples/GLMExamplesBrowser.class.st
@@ -57,7 +57,7 @@ GLMExamplesBrowser >> exampleBrowserForPragma: each in: aClass [
 		to: #theOuterPane;
 		andShow: [ :a | a custom: exampleBrowser ].
 	^ wrapperBrowser
-		startOn: (Smalltalk compiler evaluate: (each argumentAt: 2) logged: false)
+		startOn: (Smalltalk compiler evaluate: (each argumentAt: 2))
 ]
 
 { #category : #building }


### PR DESCRIPTION
GTExamplesBrowser uses old Compiler API
https://pharo.fogbugz.com/f/cases/21900/GTExamplesBrowser-uses-old-Compiler-API