### PR TITLE
21903-GT-tools-still-uses-old-compiler-API-evaluateforlogged

### DIFF
--- a/src/GT-Inspector/GTSimpleMethodsBrowser.class.st
+++ b/src/GT-Inspector/GTSimpleMethodsBrowser.class.st
@@ -3,7 +3,7 @@ This browser is used to browse the class structure of every object in the inspec
 
 Example:
 self openOn: World
-" 
+"
 Class {
 	#name : #GTSimpleMethodsBrowser,
 	#superclass : #GLMCompositePresentation,
@@ -117,7 +117,7 @@ GTSimpleMethodsBrowser >> sourceOf: method for: object in: composite [
 		selectionPopulate: #evaluatedObject
 			on: $g
 			entitled: 'Do it and go'
-			with: [ :text | Smalltalk compiler evaluate: text selectedText for: object logged: false ];
+			with: [ :text | Smalltalk compiler receiver: object; evaluate: text selectedText ];
 		installDefaultSelectionActions;
 		selectionAct: [ :text | self updateOuterPaneFrom: text for: method ]
 			icon: GLMUIThemeExtraIcons glamorousAccept

--- a/src/GT-InspectorExtensions-Core/Announcer.extension.st
+++ b/src/GT-InspectorExtensions-Core/Announcer.extension.st
@@ -20,7 +20,7 @@ Announcer >> gtInspectorAnnouncementsIn: composite context: aGTContext [
 		send: #value;
 		showOnly: 50;
 		format: #gtDisplayString;
-		filterOn: [:text :each | Smalltalk compiler evaluate: '| date each | date := self key. each := self value. ', text for: each logged: false ];
+		filterOn: [:text :each | Smalltalk compiler receiver: each; evaluate: '| date each | date := self key. each := self value. ', text ];
 		updateOn: Announcement from: recordedAnnouncements gtAnnouncer;
 		act: [ :table | 
 			recordedAnnouncements removeAll.

--- a/src/Glamour-Examples/GLMBasicExamples.class.st
+++ b/src/Glamour-Examples/GLMBasicExamples.class.st
@@ -664,12 +664,12 @@ GLMBasicExamples >> multipleFinderWithFilter [
 			title: 'List';
 			beMultiple;
 			dynamicActions: [:list | self actionsFor: list];
-			filterOn: [:text :each | Smalltalk compiler evaluate: '| each | each := self. ', text for: each logged: false ];
+			filterOn: [:text :each | Smalltalk compiler receiver: each; evaluate: '| each | each := self. ', text ];
 			helpMessage:  'Enter a filtering request (e.g., "each > $f")'. 
 		a tree
 			title: 'Tree';
 			dynamicActions: [:list | self actionsFor: list];
-			filterOn: [:text :each | Smalltalk compiler evaluate: '| each | each := self. ', text for: each logged: false ];
+			filterOn: [:text :each | Smalltalk compiler receiver: each; evaluate: '| each | each := self. ', text ];
 			helpMessage:  'Enter a filtering request (e.g., "each > $f")' ].
 	^ finder 
 ]

--- a/src/Glamour-Presentations/GLMListingPresentation.class.st
+++ b/src/Glamour-Presentations/GLMListingPresentation.class.st
@@ -343,6 +343,6 @@ GLMListingPresentation >> whiteRectangledTags [
 GLMListingPresentation >> withSmalltalkSearch [
 	self
 		searchOn: [:text :each | 
-			Smalltalk compiler evaluate: ' | entity each | each := self. entity := each.', text for: each logged: false];
+			Smalltalk compiler receiver: each; evaluate: ' | entity each | each := self. entity := each.', text];
 		helpMessage: 'Quick selection field. Given your INPUT, it executes: self select: [:each | INPUT ]'
 ]


### PR DESCRIPTION
GT tools still uses old compiler API #evaluate:for:logged:
https://pharo.fogbugz.com/f/cases/21903/GT-tools-still-uses-old-compiler-API-evaluate-for-logged