### PR TITLE
21899-MetacelloCommonPlatformcopyClassasinCategory-uses-old-Compiler-API

### DIFF
--- a/src/Metacello-PharoCommonPlatform/MetacelloPharoCommonPlatform.class.st
+++ b/src/Metacello-PharoCommonPlatform/MetacelloPharoCommonPlatform.class.st
@@ -38,13 +38,13 @@ MetacelloPharoCommonPlatform >> copyClass: oldClass as: newName inCategory: newC
 	copysName := newName asSymbol.
 	copysName = oldClass name
 		ifTrue: [ ^ oldClass ].
-	(Smalltalk includesKey: copysName)
+	(Smalltalk globals includesKey: copysName)
 		ifTrue: [ ^ self error: copysName , ' already exists' ].
 	newDefinition := oldClass definition copyReplaceAll: '#' , oldClass name asString with: '#' , copysName asString printString.
 	newDefinition := newDefinition
 		copyReplaceAll: 'category: ' , (SystemOrganization categoryOfElement: oldClass name) asString printString
 		with: 'category: ' , newCategoryName printString.
-	class := self compiler evaluate: newDefinition logged: true.
+	class := self compiler logged: true; evaluate: newDefinition.
 	class class instanceVariableNames: oldClass class instanceVariablesString.
 	class copyAllCategoriesFrom: oldClass.
 	class class copyAllCategoriesFrom: oldClass class.


### PR DESCRIPTION
MetacelloCommonPlatform>>#copyClass:as:inCategory uses old Compiler API
https://pharo.fogbugz.com/f/cases/21899/MetacelloCommonPlatform-copyClass-as-inCategory-uses-old-Compiler-API