### PR TITLE
20322-name-sent-to-a-class-SHOULD-NOT-automatically-rename-and-destroy-the-class

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -798,12 +798,6 @@ Class >> name [
 	^ name ifNil: [ super name ]
 ]
 
-{ #category : #private }
-Class >> name: aSymbol [
-	"for compatibile API with trais"
-	self setName: aSymbol
-]
-
 { #category : #'subclass creation' }
 Class >> newAnonymousSubclass [
 

--- a/src/STON-Tests/STONReaderTests.class.st
+++ b/src/STON-Tests/STONReaderTests.class.st
@@ -59,7 +59,7 @@ STONReaderTests >> testClassWithUnderscore [
 	| cls data reader |
 
 	cls := Object newAnonymousSubclass.
-	cls name: #A_B_C123AnonClass.
+	cls setName: #A_B_C123AnonClass.
 
 	data := STON toString: cls new.
 	reader := STONReader on: data readStream.


### PR DESCRIPTION
name: sent to a class SHOULD NOT automatically rename and destroy the class
https://pharo.fogbugz.com/f/cases/20322/name-sent-to-a-class-SHOULD-NOT-automatically-rename-and-destroy-the-class

name: was just ther to make Class api compatine to Trait.. but the old trait model. The new trait model does not implement #name: