### PR TITLE
backstop

### DIFF
--- a/src/Deprecated70/Key.class.st
+++ b/src/Deprecated70/Key.class.st
@@ -8,3 +8,8 @@ Class {
 	#superclass : #KeyboardKey,
 	#category : #Deprecated70
 }
+
+{ #category : #deprecation }
+Key class >> isDeprecated [
+	^true
+]

--- a/src/Deprecated70/PackageChecker.class.st
+++ b/src/Deprecated70/PackageChecker.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #Deprecated70
 }
 
+{ #category : #deprecation }
+PackageChecker class >> isDeprecated [
+	^true
+]
+
 { #category : #check }
 PackageChecker >> check [
 	"self new check"


### PR DESCRIPTION
In Deprecated70: classes Key and PackageChecker should be deprecated
https://pharo.fogbugz.com/f/cases/21908/In-Deprecated70-classes-Key-and-PackageChecker-should-be-deprecated