### PR TITLE
21884-Dont-use-ZnUtils-for-Base64-encodingdecoding-outside-of-Zn

### DIFF
--- a/src/MonticelloRemoteRepositories/MCHttpRepository.class.st
+++ b/src/MonticelloRemoteRepositories/MCHttpRepository.class.st
@@ -373,7 +373,7 @@ MCHttpRepository >> userAndPasswordFromSettingsDo: aBlock [
 				(entry first match: self location) ifTrue: [
 					userAndPassword := entry second.
 					(userAndPassword includes: $:) ifFalse: [
-						userAndPassword := ZnUtils decodeBase64: userAndPassword].
+						userAndPassword := userAndPassword base64Decoded decodeWith: #null].
 					userAndPassword := userAndPassword findTokens: $:.
 					^aBlock value: userAndPassword first 
 						value: userAndPassword second 

--- a/src/Network-Kernel/NetworkSystemSettings.class.st
+++ b/src/Network-Kernel/NetworkSystemSettings.class.st
@@ -173,14 +173,14 @@ NetworkSystemSettings class >> proxyPassword [
 
 	^ ProxyPassword 
 		ifNil: [ '' ]
-		ifNotNil: [ ZnUtils decodeBase64: ProxyPassword ]
+		ifNotNil: [ ProxyPassword base64Decoded utf8Decoded ]
 ]
 
 { #category : #settings }
 NetworkSystemSettings class >> proxyPassword: aPassword [
 	"Set the HTTP proxy password. Can be empty or nil to reset"
 	
-	ProxyPassword := aPassword ifNotNil: [ ZnUtils encodeBase64: aPassword ]
+	ProxyPassword := aPassword ifNotNil: [ aPassword utf8Encoded base64Encoded ]
 
 ]
 
@@ -190,14 +190,14 @@ NetworkSystemSettings class >> proxyUser [
 
 	^ ProxyUser
 		ifNil: [ '' ]
-		ifNotNil: [ ZnUtils decodeBase64: ProxyUser ]
+		ifNotNil: [ ProxyUser base64Decoded utf8Decoded ]
 ]
 
 { #category : #settings }
 NetworkSystemSettings class >> proxyUser: aUser [
 	"Set the HTTP proxy user. Can be empty or nil to reset"
 	
-	ProxyUser := aUser ifNotNil: [ ZnUtils encodeBase64: aUser ]
+	ProxyUser := aUser ifNotNil: [ aUser utf8Encoded base64Encoded ]
 
 
 ]

--- a/src/Network-MIME/ByteArray.extension.st
+++ b/src/Network-MIME/ByteArray.extension.st
@@ -3,7 +3,8 @@ Extension { #name : #ByteArray }
 { #category : #'*Network-MIME' }
 ByteArray >> base64Encoded [
 	"Encode the receiver using Base64, returning a String.
-	Base64 encoding is a technique to represent binary data as ASCII text"
+	Base64 encoding is a technique to represent binary data as ASCII text.
+	The inverse operation is String>>#base64Decoded"
 	
 	"(0 to: 255) asByteArray base64Encoded"
 	"(Integer primesUpTo: 255) asByteArray base64Encoded"

--- a/src/Network-MIME/String.extension.st
+++ b/src/Network-MIME/String.extension.st
@@ -8,9 +8,11 @@ String >> asMIMEType [
 { #category : #'*Network-MIME' }
 String >> base64Decoded [
 	"Decode the receiver assuming it was encoded using Base64, returning a ByteArray.
-	Base64 encoding is a technique to represent binary data as ASCII text"
+	Base64 encoding is a technique to represent binary data as ASCII text.
+	The inverse operation is ByteArray>>#base64Encoded"
 	
 	"'AgMFBwsNERMXHR8lKSsvNTs9Q0dJT1NZYWVna21xf4OJi5WXnaOnrbO1v8HFx9Pf4+Xp7/H7' base64Decoded"
+	"'SGVsbG8gV29ybGQh' base64Decoded utf8Decoded"
 	
 	^ ZnBase64Encoder new decode: self
 ]

--- a/src/Network-Protocols/SMTPClient.class.st
+++ b/src/Network-Protocols/SMTPClient.class.st
@@ -114,7 +114,7 @@ SMTPClient >> data: messageData [
 
 { #category : #utility }
 SMTPClient >> encodeString: aString [ 
-	^ ZnUtils encodeBase64: aString
+	^ (aString encodeWith: #null) base64Encoded
 ]
 
 { #category : #'private protocol' }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21884/Don-t-use-ZnUtils-for-Base64-encoding-decoding-outside-of-Zn

In the latest Base64 changes, some code outside Zn referred to ZnUtils for Base64 encoding.

This is not needed and util classes are not the best coding style, reimplement in place.

For Zn itself, this can not (yet) be done as older Pharo versions must still be supported.