### PR TITLE
21917 No abbreviation for combined utilities category (no utils)

### DIFF
--- a/src/Glamour-Morphic-Widgets/GLMMorphic.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMMorphic.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'Glamour-Morphic-Widgets'
 }
 
-{ #category : #'utils - morph creation' }
+{ #category : #'utilities - morph creation' }
 GLMMorphic class >> alignmentMorph: aCollectionOfMorphs [
 	"Answer a row-oriented AlignmentMorph holding the given collection"
 	| morph |
@@ -22,7 +22,7 @@ GLMMorphic class >> alignmentMorph: aCollectionOfMorphs [
 	^morph
 ]
 
-{ #category : #'utils - morph creation' }
+{ #category : #'utilities - morph creation' }
 GLMMorphic class >> containerMorph [
 	^ GLMPanelMorph new
 		layoutPolicy: ProportionalLayout new;
@@ -32,7 +32,7 @@ GLMMorphic class >> containerMorph [
 		yourself
 ]
 
-{ #category : #'utils - morph creation' }
+{ #category : #'utilities - morph creation' }
 GLMMorphic class >> emptyMorph [
 	^ self containerMorph
 		fillStyle: (SolidFillStyle color: Color transparent );
@@ -84,7 +84,7 @@ GLMMorphic class >> isWhiteRectangledButton: aSymbol [
 	^aSymbol = #whiteRectangledButton
 ]
 
-{ #category : #'utils - morph creation' }
+{ #category : #'utilities - morph creation' }
 GLMMorphic class >> morphElement: anObject [
 
 	anObject isString
@@ -115,7 +115,7 @@ GLMMorphic class >> styleButton: button morph: m pressed: aBoolean style: aSymbo
 		ifTrue:[ self whiteRectangledButtonStyle: button morph: m pressed: aBoolean ]
 ]
 
-{ #category : #'utils - morph creation' }
+{ #category : #'utilities - morph creation' }
 GLMMorphic class >> togglingButtonLabelled: anObject pressed: aBoolean style: aSymbol [
 	| button oldLabel m |
 	button := SimpleButtonMorph new.

--- a/src/Morphic-Widgets-FastTable/FTTreeDataSource.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTreeDataSource.class.st
@@ -83,7 +83,7 @@ FTTreeDataSource class >> defaultSearchStrategies [
 		yourself
 ]
 
-{ #category : #'utils - morph creation' }
+{ #category : #'utilities - morph creation' }
 FTTreeDataSource class >> emptyMorph [
 	| icon |
 	icon := (Smalltalk ui icons iconNamed: #emptyIcon) asMorph.


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21917/No-abbreviation-for-combined-utilities-category-no-utils

Fix the two classes GLMMorphic and FTTreeDataSource using "utils - ..." instead of "utilities - ..."

JUST RECATGEORIZATION - NO CHANGE IN BEHAVIOR