### PR TITLE
18180-whichSelectorsAccess-cannot-find-some-of-the-variables-using-slots

### DIFF
--- a/src/Kernel-Tests/BehaviorTest.class.st
+++ b/src/Kernel-Tests/BehaviorTest.class.st
@@ -239,6 +239,26 @@ BehaviorTest >> testWhichSelectorsAccess [
 ]
 
 { #category : #tests }
+BehaviorTest >> testWhichSelectorsAccessFindSlots [
+	| cls |
+	cls := Object newAnonymousSubclass.
+	cls := cls addSlot: #regularIvar.
+	cls := cls addSlot: #slotIvar => PropertySlot.
+	cls
+		compile:
+			'initialize 
+		super initialize.
+	
+		regularIvar := 4.
+		slotIvar := 2.
+	'.
+	self
+		assert: (cls whichSelectorsAccess: #regularIvar) size equals: 1;
+		assert: (cls whichSelectorsAccess: #slotIvar) size equals: 1;
+		assert: (cls whichSelectorsAccess: #notAnIvar) equals: #()
+]
+
+{ #category : #tests }
 BehaviorTest >> testallSuperclassesIncluding [
 		
 	|cls |


### PR DESCRIPTION
#whichSelectorsAccess: cannot find some of the variables using slots
https://pharo.fogbugz.com/f/cases/18180/whichSelectorsAccess-cannot-find-some-of-the-variables-using-slots
-> just add test, it it green