### PR TITLE
21644-RBRefersToClassRule-gives-misleading-advice-for-class-methods

### DIFF
--- a/src/GeneralRules/RBRefersToClassRule.class.st
+++ b/src/GeneralRules/RBRefersToClassRule.class.st
@@ -1,6 +1,6 @@
 "
-This smell arises when a class has its class name directly in the source instead of ""self class"". The self class variant allows you to create subclasses without needing to redefine that method.
-However we cannot systematically replace Class reference by self class or self because a Class reference is static and a self expression is dynamic. So the programmer may want to send messages to root of an hierarchy and not to the leaf classes. 
+This smell arises when a class has its class name directly in the source instead of ""self class"" (or just ""self"" when on the class side). The self class / self variant allows you to create subclasses without needing to redefine that method.
+However we cannot systematically replace Class reference by self class or self because a Class reference is static and a self expression is dynamic. So the programmer may want to send messages to root of an hierarchy and not to the leaf classes. Therefore this rule generates false positives, please double check when fixing!
 "
 Class {
 	#name : #RBRefersToClassRule,


### PR DESCRIPTION
RBRefersToClassRule gives misleading advice for class methods
https://pharo.fogbugz.com/f/cases/21644/RBRefersToClassRule-gives-misleading-advice-for-class-methods