### PR TITLE
21925-SharedPool-subclasses-should-not-trigger-class-not-referenced--QA-Rule-if-they-are-used

### DIFF
--- a/src/Kernel-Tests/SharedPoolTest.class.st
+++ b/src/Kernel-Tests/SharedPoolTest.class.st
@@ -8,9 +8,9 @@ Class {
 }
 
 { #category : #tests }
-SharedPoolTest >> testUsers [
+SharedPoolTest >> testPoolUsers [
 	| result |
-	result := ChronologyConstants users.
+	result := ChronologyConstants poolusers.
 	self assert: result asSet equals: {Date. DateAndTime. Duration. Month. Time. TimeZone. Week. LocalTimeZone . AbstractTimeZone } asSet.
 		 
 ]

--- a/src/Kernel-Tests/SharedPoolTest.class.st
+++ b/src/Kernel-Tests/SharedPoolTest.class.st
@@ -1,0 +1,16 @@
+"
+Tests related to SharedPool
+"
+Class {
+	#name : #SharedPoolTest,
+	#superclass : #TestCase,
+	#category : #'Kernel-Tests-Classes'
+}
+
+{ #category : #tests }
+SharedPoolTest >> testUsers [
+	| result |
+	result := ChronologyConstants users.
+	self assert: result asSet equals: {Date. DateAndTime. Duration. Month. Time. TimeZone. Week. LocalTimeZone . AbstractTimeZone } asSet.
+		 
+]

--- a/src/Kernel/SharedPool.class.st
+++ b/src/Kernel/SharedPool.class.st
@@ -55,3 +55,18 @@ SharedPool class >> includesKey: aName [
 	"does this pool include aName"
 	^(self bindingOf: aName) notNil
 ]
+
+{ #category : #testing }
+SharedPool class >> isUsed [
+	^self users isNotEmpty
+]
+
+{ #category : #pools }
+SharedPool class >> users [
+	"Answer an Array of all classes that uses the shared pool"
+
+	| aCollection |
+	aCollection := ReadWriteStream on: Array new.
+	self environment allClassesDo: [:class | (class includesSharedPoolNamed: self name) ifTrue: [aCollection nextPut: class]].
+	^ aCollection contents
+]

--- a/src/Kernel/SharedPool.class.st
+++ b/src/Kernel/SharedPool.class.st
@@ -58,7 +58,7 @@ SharedPool class >> includesKey: aName [
 
 { #category : #testing }
 SharedPool class >> isUsed [
-	^self poolUsers isNotEmpty
+	^super isUsed or: [self poolUsers isNotEmpty]
 ]
 
 { #category : #pools }

--- a/src/Kernel/SharedPool.class.st
+++ b/src/Kernel/SharedPool.class.st
@@ -58,11 +58,11 @@ SharedPool class >> includesKey: aName [
 
 { #category : #testing }
 SharedPool class >> isUsed [
-	^self users isNotEmpty
+	^self poolUsers isNotEmpty
 ]
 
 { #category : #pools }
-SharedPool class >> users [
+SharedPool class >> poolUsers [
 	"Answer an Array of all classes that uses the shared pool"
 
 	| aCollection |

--- a/src/System-Support-Tests/SystemNavigationTest.class.st
+++ b/src/System-Support-Tests/SystemNavigationTest.class.st
@@ -79,14 +79,6 @@ SystemNavigationTest >> tearDown [
 ]
 
 { #category : #testing }
-SystemNavigationTest >> testAllClassesUsingSharedPool [
-
-	| res |
-	res := SystemNavigation new allClassesUsingSharedPool: 'ChronologyConstants'.
-	self assert: ({Date. DateAndTime. Duration. Month. Time. TimeZone. Week} difference: res) isEmpty
-]
-
-{ #category : #testing }
 SystemNavigationTest >> testAllExistingProtocolsFor [
 
 	| instSideProtocols classSideProtocols |

--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -352,7 +352,7 @@ SystemNavigation >> browseSharedPoolUsersOf: aClass [
 
 	| pattern list | 
 	self okToChange ifFalse: [^ self ].
-	list := aClass users.
+	list := aClass poolUsers.
 	list isEmpty
 		ifTrue: [ ^ self ]
 		ifFalse: [pattern := UIManager default 

--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -352,7 +352,7 @@ SystemNavigation >> browseSharedPoolUsersOf: aClass [
 
 	| pattern list | 
 	self okToChange ifFalse: [^ self ].
-	list := self allClassesUsingSharedPool: aClass name.
+	list := aClass users.
 	list isEmpty
 		ifTrue: [ ^ self ]
 		ifFalse: [pattern := UIManager default 


### PR DESCRIPTION
SharedPool subclasses should not trigger âclass not referencedâ QA Rule if they are used
https://pharo.fogbugz.com/f/cases/21925/SharedPool-subclasses-should-not-trigger-class-not-referenced-QA-Rule-if-they-are-used