### PR TITLE
21926-PluggableButtonMorph-instance-valiable-lastColor-is-not-written

### DIFF
--- a/src/Morphic-Widgets-Basic/PluggableButtonMorph.class.st
+++ b/src/Morphic-Widgets-Basic/PluggableButtonMorph.class.st
@@ -51,7 +51,6 @@ Class {
 		'getColorSelector',
 		'getEnabledSelector',
 		'getFontSelector',
-		'lastColor',
 		'labelMorph',
 		'iconMorph',
 		'iconPosition',
@@ -389,12 +388,11 @@ PluggableButtonMorph >> changed [
 PluggableButtonMorph >> color: aColor [
 	"Check to avoid repeats of the same color."
 
-	aColor ifNil: [^self].
-	(lastColor = aColor and: [
-	self getModelState = (self lastState)])
-		ifTrue: [^self].
+	aColor ifNil: [ ^ self ].
+	(aColor = self color and: [ self getModelState = self lastState ]) ifTrue: [ ^ self ].
+	
 	super color: aColor.
-	self class gradientButtonLook ifTrue: [self adoptColor: aColor]
+	self class gradientButtonLook ifTrue: [ self adoptColor: aColor ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Remove PluggableButtonMorph lastColor instance variable and use #color instead

https://pharo.fogbugz.com/f/cases/21926/PluggableButtonMorph-instance-valiable-lastColor-is-not-written