### PR TITLE
21929-Metacello-has-problem-with-archive-deletion-on-windows

### DIFF
--- a/src/Metacello-GitBasedRepository/MCGitBasedNetworkRepository.class.st
+++ b/src/Metacello-GitBasedRepository/MCGitBasedNetworkRepository.class.st
@@ -234,21 +234,22 @@ MCGitBasedNetworkRepository class >> projectDirectoryFrom: projectPath version: 
 			url := self
 				projectZipUrlFor: projectPath
 				versionString: versionString.
-			pid := MetacelloPlatform current processPID.
-			zipFileName := MetacelloPlatform current
+			pid := mcPlatform processPID.
+			zipFileName := mcPlatform
 				tempFileFor:
 					self basicDescription , '-' , pid , '-'
 						, (downloadCacheKey select: [ :c | c isAlphaNumeric ])
 				suffix: '.zip'.
-			archive := MetacelloPlatform current
+			archive := mcPlatform
 				downloadZipArchive: url
 				to: zipFileName.
 			directory := mcPlatform
 				directoryFromPath: (cachePath := archive members first fileName)
 				relativeTo: theCacheDirectory.
+			archive close.
 			directory exists
-				ifTrue: [ MetacelloPlatform current deleteFileNamed: zipFileName ]
-				ifFalse: [ MetacelloPlatform current
+				ifTrue: [ mcPlatform deleteFileNamed: zipFileName ]
+				ifFalse: [ mcPlatform
 						extractRepositoryFrom: zipFileName
 						to: theCacheDirectory fullName ].
 			self downloadCache at: downloadCacheKey put: cachePath.


### PR DESCRIPTION
Close the archive before deleting it in MCGitBasedNetworkRepository class>>projectDirectoryFrom:version:

Also, there is a small cleaning of the code.

See: https://pharo.fogbugz.com/f/cases/21929/Metacello-has-problem-with-archive-deletion-on-windows

Equivalent is proposed to Metacello repository via https://github.com/Metacello/metacello/pull/488