### PR TITLE
21930-Display-the-progress-of-zip-downloads-in-Metacello

### DIFF
--- a/src/Metacello-Platform/MetacelloPharoPlatform.class.st
+++ b/src/Metacello-Platform/MetacelloPharoPlatform.class.st
@@ -61,15 +61,21 @@ MetacelloPharoPlatform >> downloadJSON: url username: username pass: pass [
 
 { #category : #'github support' }
 MetacelloPharoPlatform >> downloadZipArchive: url to: outputFileName [
-  "download zip archive from <url> into <outputFileName>"
+	"download zip archive from <url> into <outputFileName>"
 
 	outputFileName asFileReference ensureDelete.
-	ZnClient new
+	[ :bar | 
+	bar title: 'Download: ' , url asString , ' to ' , outputFileName.
+	[ ZnClient new
 		url: url;
-		downloadTo: outputFileName.
-    ^ ZipArchive new 
-		readFrom: outputFileName asFileReference
-
+		signalProgress: true;
+		downloadTo: outputFileName ]
+		on: HTTPProgress
+		do: [ :progress | 
+			progress isEmpty
+				ifFalse: [ bar current: progress percentage ].
+			progress resume ] ] asJob run.
+	^ ZipArchive new readFrom: outputFileName asFileReference
 ]
 
 { #category : #'file system' }


### PR DESCRIPTION
Show progress bar for zip downloading in Metacello.

https://pharo.fogbugz.com/f/cases/21930/Display-the-progress-of-zip-downloads-in-Metacello

Port of https://github.com/Metacello/metacello/pull/489