### PR TITLE
19571 zip archive api should let the user extract an archive and overriting files without carring about display

### DIFF
--- a/src/Compression-Tests/ZipArchiveTest.class.st
+++ b/src/Compression-Tests/ZipArchiveTest.class.st
@@ -224,8 +224,6 @@ ZipArchiveTest >> testSetLastModification [
 { #category : #tests }
 ZipArchiveTest >> testShouldUnzipAndOverwriteWithoutInforming [
 	| nestedFileToZip fileModificationTime fileModificationTimeBlock |
-	Smalltalk os isWindows
-		ifTrue: [ "Occassionally trying to delete an existing file fails in Windows due to a file open lock" ^ self skip ].
 	fileModificationTimeBlock := [ (subdir / '_test-zip-file.txt') modificationTime ].
 	nestedFileToZip := (subdir / '_test-zip-file.txt')
 		writeStreamDo: [ :stream | stream nextPutAll: 'file contents' ];
@@ -233,21 +231,25 @@ ZipArchiveTest >> testShouldUnzipAndOverwriteWithoutInforming [
 	zip
 		addDirectory: subdir fullName as: subdir basename;
 		addFile: nestedFileToZip fullName as: nestedFileToZip basename;
-		writeToFileNamed: zipFile fullName.
+		writeToFileNamed: zipFile fullName;
+		close.
 	ZipArchive new
 		readFrom: zipFile;
-		extractAllTo: subdir overwrite: true.
+		extractAllTo: subdir overwrite: true;
+		close.
 	fileModificationTime := fileModificationTimeBlock value.
 	1 second wait.
 	ZipArchive new
 		readFrom: zipFile;
-		extractAllTo: subdir overwrite: true.
+		extractAllTo: subdir overwrite: true;
+		close.
 	self assert: fileModificationTime ~= fileModificationTimeBlock value.
 	fileModificationTime := fileModificationTimeBlock value.
 	1 second wait.
 	ZipArchive new
 		readFrom: zipFile;
-		extractAllTo: subdir overwrite: false.
+		extractAllTo: subdir overwrite: false;
+		close.
 	self deny: fileModificationTime ~= fileModificationTimeBlock value
 ]
 

--- a/src/Compression-Tests/ZipArchiveTest.class.st
+++ b/src/Compression-Tests/ZipArchiveTest.class.st
@@ -224,6 +224,8 @@ ZipArchiveTest >> testSetLastModification [
 { #category : #tests }
 ZipArchiveTest >> testShouldUnzipAndOverwriteWithoutInforming [
 	| nestedFileToZip fileModificationTime fileModificationTimeBlock |
+	Smalltalk os isWindows
+		ifTrue: [ "Occassionally trying to delete an existing file fails in Windows due to a file open lock" ^ self skip ].
 	fileModificationTimeBlock := [ (subdir / '_test-zip-file.txt') modificationTime ].
 	nestedFileToZip := (subdir / '_test-zip-file.txt')
 		writeStreamDo: [ :stream | stream nextPutAll: 'file contents' ];

--- a/src/Compression-Tests/ZipArchiveTest.class.st
+++ b/src/Compression-Tests/ZipArchiveTest.class.st
@@ -31,15 +31,14 @@ ZipArchiveTest >> setUp [
 
 { #category : #running }
 ZipArchiveTest >> tearDown [
-
 	"Must close the zipfile before deleting all files.
 	Otherwise in windows the file will not be deleted as long as the file is open."
-	zip close.
-	
-	fileToZip ensureDelete.
-	subdir ensureDeleteAll.
-	zipFile ensureDelete.
-	super tearDown 
+
+	[ zip close ]
+		ensure: [ fileToZip ensureDelete.
+			subdir ensureDeleteAll.
+			zipFile ensureDelete ].
+	super tearDown
 ]
 
 { #category : #tests }
@@ -220,6 +219,34 @@ ZipArchiveTest >> testSetLastModification [
 	member := zip addDeflateString: 'foo' as: 'bar'.
 	member modifiedAt: aDateAndTime.
 	self assert: member lastModTime equals: aDateAndTime.
+]
+
+{ #category : #tests }
+ZipArchiveTest >> testShouldUnzipAndOverwriteWithoutInforming [
+	| nestedFileToZip fileModificationTime fileModificationTimeBlock |
+	fileModificationTimeBlock := [ (subdir / '_test-zip-file.txt') modificationTime ].
+	nestedFileToZip := (subdir / '_test-zip-file.txt')
+		writeStreamDo: [ :stream | stream nextPutAll: 'file contents' ];
+		yourself.
+	zip
+		addDirectory: subdir fullName as: subdir basename;
+		addFile: nestedFileToZip fullName as: nestedFileToZip basename;
+		writeToFileNamed: zipFile fullName.
+	ZipArchive new
+		readFrom: zipFile;
+		extractAllTo: subdir overwrite: true.
+	fileModificationTime := fileModificationTimeBlock value.
+	1 second wait.
+	ZipArchive new
+		readFrom: zipFile;
+		extractAllTo: subdir overwrite: true.
+	self assert: fileModificationTime ~= fileModificationTimeBlock value.
+	fileModificationTime := fileModificationTimeBlock value.
+	1 second wait.
+	ZipArchive new
+		readFrom: zipFile;
+		extractAllTo: subdir overwrite: false.
+	self deny: fileModificationTime ~= fileModificationTimeBlock value
 ]
 
 { #category : #tests }

--- a/src/Compression/Archive.class.st
+++ b/src/Compression/Archive.class.st
@@ -110,10 +110,11 @@ Archive >> contentsOf: aMemberOrName [
 Archive >> extractMember: aMemberOrName [
 	| member |
 	member := self member: aMemberOrName.
-	member ifNil: [ ^nil ].
-	member 
-		extractToFileNamed: member localFileName 
-		inDirectory: FileSystem workingDirectory.
+	member ifNil: [ ^ nil ].
+	member
+		extractToFileNamed: member localFileName
+		inDirectory: FileSystem workingDirectory
+		overwrite: true
 ]
 
 { #category : #'archive operations' }
@@ -135,8 +136,8 @@ Archive >> extractMemberWithoutPath: aMemberOrName [
 Archive >> extractMemberWithoutPath: aMemberOrName inDirectory: dir [
 	| member |
 	member := self member: aMemberOrName.
-	member ifNil: [ ^nil ].
-	member extractToFileNamed: (member asFileReference basename) inDirectory: dir
+	member ifNil: [ ^ nil ].
+	member extractToFileNamed: member asFileReference basename inDirectory: dir overwrite: true
 ]
 
 { #category : #initialization }

--- a/src/Compression/ZipArchive.class.st
+++ b/src/Compression/ZipArchive.class.st
@@ -109,10 +109,11 @@ ZipArchive class >> validSignatures [
 { #category : #'archive operations' }
 ZipArchive >> addDeflateString: aString as: aFileName [
 	"Add a verbatim string under the given file name"
+
 	| mbr |
 	mbr := self addString: aString as: aFileName.
 	mbr desiredCompressionMethod: CompressionDeflated.
-	^mbr
+	^ mbr
 ]
 
 { #category : #initialization }
@@ -126,14 +127,15 @@ ZipArchive >> extractAllTo: aDirectory [
 
 	UIManager default
 		informUserDuring: [ :bar | 
-			bar max: self members size.
+			bar max: self numberOfMembers.
 			self extractAllTo: aDirectory informing: bar ]
 ]
 
 { #category : #'archive operations' }
 ZipArchive >> extractAllTo: aDirectory informing: bar [
 	"Extract all elements to the given directory"
-	^self extractAllTo: aDirectory informing: bar overwrite: false
+
+	^ self extractAllTo: aDirectory informing: bar overwrite: false
 ]
 
 { #category : #'archive operations' }
@@ -178,6 +180,13 @@ ZipArchive >> extractAllTo: aDirectory informing: bar overwrite: allOverwrite [
 			bar isNotNil & shouldUpdateInfos
 				ifTrue: [ bar value: barValue.
 					lastUpdate := Time millisecondClockValue ] ]
+]
+
+{ #category : #'archive operations' }
+ZipArchive >> extractAllTo: aDirectory overwrite: overwriteAll [
+	"Extracts all elements to the given directory, overwriting existing entries if necessary. Does not use UI for confirmation"
+
+	self members do: [ :entry | entry extractInDirectory: aDirectory withoutInformingOverwrite: overwriteAll ]
 ]
 
 { #category : #accessing }

--- a/src/Compression/ZipArchive.class.st
+++ b/src/Compression/ZipArchive.class.st
@@ -185,7 +185,7 @@ ZipArchive >> extractAllTo: aDirectory informing: aBar overwrite: allOverwrite [
 
 { #category : #'archive operations' }
 ZipArchive >> extractAllTo: aDirectory overwrite: overwriteAll [
-	"Extracts all elements to the given directory, overwriting existing entries if necessary. Does not use UI for confirmation"
+	"Extracts all elements to the given directory, overwriting existing entries if necessary. Does not use the UI for confirmation"
 
 	self members do: [ :entry | entry extractInDirectory: aDirectory withoutInformingOverwrite: overwriteAll ]
 ]

--- a/src/Compression/ZipArchive.class.st
+++ b/src/Compression/ZipArchive.class.st
@@ -139,45 +139,46 @@ ZipArchive >> extractAllTo: aDirectory informing: bar [
 ]
 
 { #category : #'archive operations' }
-ZipArchive >> extractAllTo: aDirectory informing: bar overwrite: allOverwrite [
-	"Extract all elements to the given directory"
+ZipArchive >> extractAllTo: aDirectory informing: aBar overwrite: allOverwrite [
+	"Extract all elements to the given directory. Informs user when a file exists and set to overwrite"
 
-	| overwriteAll lastUpdate barValue shouldUpdateInfos |
+	| bar overwriteAll barValue |
+	bar := aBar ifNil: [ DummySystemProgressItem new ].
 	overwriteAll := allOverwrite.
-	lastUpdate := 0.
 	barValue := 0.
 	self members
 		select: #isDirectory
 		thenDo: [ :entry | 
-			| dir |
+			| dir shouldUpdateInfos lastUpdate |
+			lastUpdate := 0.
 			(shouldUpdateInfos := (Time millisecondsSince: lastUpdate) >= 100)
-				ifTrue: [ lastUpdate := Time millisecondClockValue ].
-			bar isNotNil & shouldUpdateInfos
-				ifTrue: [ bar label: 'Creating ' , entry fileName ].
-			dir := (entry fileName findTokens: '/') inject: aDirectory into: [ :base :part | base / part ].
+				ifTrue: [ lastUpdate := Time millisecondClockValue.
+					bar label: 'Creating ' , entry fileName ].
+			dir := (entry fileName findTokens: '/')
+				inject: aDirectory
+				into: [ :base :part | base / part ].
 			dir ensureCreateDirectory.
 			barValue := barValue + 1.
-			bar isNotNil & shouldUpdateInfos
+			shouldUpdateInfos
 				ifTrue: [ bar value: barValue ] ].
 	self members
-		select: [ :entry | entry isDirectory not ]
+		reject: #isDirectory
 		thenDo: [ :entry | 
-			| response |
+			| shouldUpdateInfos lastUpdate |
+			lastUpdate := 0.
 			(shouldUpdateInfos := (Time millisecondsSince: lastUpdate) >= 100)
-				ifTrue: [ lastUpdate := Time millisecondClockValue ].
-			bar isNotNil & shouldUpdateInfos
-				ifTrue: [ bar label: 'Extracting ' , entry fileName ].
-			response := entry extractInDirectory: aDirectory overwrite: overwriteAll.
-			response == #retryWithOverwrite
-				ifTrue: [ overwriteAll := true.
-					response := entry extractInDirectory: aDirectory overwrite: overwriteAll ].
-			response == #abort
-				ifTrue: [ ^ self ].
-			response == #failed
-				ifTrue: [ (self confirm: 'Failed to extract ' , entry fileName , '. Proceed?')
-						ifFalse: [ ^ self ] ].
+				ifTrue: [ lastUpdate := Time millisecondClockValue.
+					bar label: 'Extracting ' , entry fileName ].
+			entry
+				extractInDirectory: aDirectory
+				informingOverwrite: overwriteAll
+				onSuccess: [  ]
+				onRetryWithOverwrite: [ overwriteAll := true ]
+				onFailedOverwrite: [ (self confirm: 'Failed to extract ' , entry fileName , '. Proceed?')
+						ifFalse: [ ^ self ] ]
+				onAbortOverwrite: [ ^ self ].
 			barValue := barValue + 1.
-			bar isNotNil & shouldUpdateInfos
+			shouldUpdateInfos
 				ifTrue: [ bar value: barValue.
 					lastUpdate := Time millisecondClockValue ] ]
 ]

--- a/src/Compression/ZipArchive.class.st
+++ b/src/Compression/ZipArchive.class.st
@@ -123,7 +123,7 @@ ZipArchive >> close [
 
 { #category : #'archive operations' }
 ZipArchive >> extractAllTo: aDirectory [
-	"Extract all elements to the given directory"
+	"Extract all elements to the given directory; notifying user via UI on progress and if existing files exist"
 
 	UIManager default
 		informUserDuring: [ :bar | 
@@ -133,7 +133,7 @@ ZipArchive >> extractAllTo: aDirectory [
 
 { #category : #'archive operations' }
 ZipArchive >> extractAllTo: aDirectory informing: bar [
-	"Extract all elements to the given directory"
+	"Extract all elements to the given directory; notifying user via UI on progress and if existing files exist"
 
 	^ self extractAllTo: aDirectory informing: bar overwrite: false
 ]

--- a/src/Compression/ZipArchiveMember.class.st
+++ b/src/Compression/ZipArchiveMember.class.st
@@ -63,6 +63,21 @@ ZipArchiveMember >> asDirectory [
 	^ZipDirectoryMember new copyFrom: self
 ]
 
+{ #category : #'extraction-ui' }
+ZipArchiveMember >> askOverwriteOptionsUsing: aUIManager onYes: yesBlock onNo: noBlock onRetryWithOverwrite: retryWithOverwriteBlock onCancel: cancelBlock [
+	| index |
+	[ index := aUIManager chooseFrom: {'Yes, overwrite' . 'No, don''t overwrite' . 'Overwrite ALL files' . 'Cancel operation'} lines: #(2) title: fileName , ' already exists. Overwrite?'.
+	index isNil ] whileTrue.
+	index = 1
+		ifTrue: [ yesBlock value ].
+	index = 2
+		ifTrue: [ noBlock value ].
+	index = 3
+		ifTrue: [ retryWithOverwriteBlock value ].
+	index = 4
+		ifTrue: [ cancelBlock value ]
+]
+
 { #category : #'accessing - spec fields' }
 ZipArchiveMember >> bitFlag [
 	"Per .ZIP File Format Specification Version: 6.3.2:
@@ -351,37 +366,46 @@ ZipArchiveMember >> endRead [
 
 { #category : #extraction }
 ZipArchiveMember >> extractInDirectory: dir [
-	self extractToFileNamed: self localFileName inDirectory: dir
-
+	self extractToFileNamed: self localFileName inDirectory: dir overwrite: true
 ]
 
-{ #category : #extraction }
-ZipArchiveMember >> extractInDirectory: aDirectory overwrite: overwriteAll [
-	"Extract this entry into the given directory. Answer #okay, #failed, #abort, or #retryWithOverwrite."
-	| path fileDir file index localName |
+{ #category : #'extraction-ui' }
+ZipArchiveMember >> extractInDirectory: aDirectory informingOverwrite: shouldOverwrite onSuccess: successBlock onRetryWithOverwrite: retryWithOverwriteBlock onFailedOverwrite: failedBlock onAbortOverwrite: abortBlock [
+	"Extract this entry into the given directory. Answer successBlock or call one of the other action blocks."
+
+	| path fileDir file localName |
 	path := fileName findTokens: '/'.
 	localName := path last.
 	fileDir := path allButLast inject: aDirectory into: [ :base :part | base / part ].
 	fileDir ensureCreateDirectory.
 	file := fileDir / localName.
-	file exists ifTrue: [
-		overwriteAll ifFalse:[
-			[index := UIManager default chooseFrom: {
-						'Yes, overwrite'. 
-						'No, don''t overwrite'. 
-						'Overwrite ALL files'.
-						'Cancel operation'
-					} lines: #(2) title: fileName, ' already exists. Overwrite?'.
-			index == nil] whileTrue.
-			index = 4 ifTrue:[^#abort].
-			index = 3 ifTrue:[^#retryWithOverwrite].
-			index = 2 ifTrue:[^#okay].
-		].
-		file ensureDelete.
-		file := [file ensureCreateFile] on: Error do:[:ex| ^#failed].
-	].
-	file binaryWriteStreamDo: [ :str | self extractTo: str ].
-	^#okay
+	^ self
+		extractToFile: file
+		informingOverwrite: shouldOverwrite
+		onSuccess: successBlock
+		onRetryWithOverwrite: retryWithOverwriteBlock
+		onFailedOverwrite: failedBlock
+		onAbortOverwrite: abortBlock
+]
+
+{ #category : #'extraction-ui' }
+ZipArchiveMember >> extractInDirectory: aDirectory overwrite: shouldOverwrite [
+	"Extract this entry into the given directory. Answer #okay, #failed, #abort, or #retryWithOverwrite."
+
+	^ self
+		extractInDirectory: aDirectory
+		informingOverwrite: shouldOverwrite
+		onSuccess: [ ^ #okay ]
+		onRetryWithOverwrite: [ ^ #retryWithOverwrite ]
+		onFailedOverwrite: [ ^ #failed ]
+		onAbortOverwrite: [ ^ #abort ]
+]
+
+{ #category : #extraction }
+ZipArchiveMember >> extractInDirectory: dir withoutInformingOverwrite: overwrite [
+	"Extract myself to dir without informing user whether to overwrite existing file"
+
+	self extractToFileNamed: self localFileName inDirectory: dir overwrite: overwrite
 ]
 
 { #category : #extraction }
@@ -407,27 +431,59 @@ ZipArchiveMember >> extractTo: aStream from: start to: finish [
 	self endRead.
 ]
 
-{ #category : #extraction }
-ZipArchiveMember >> extractToFileNamed: aFileName [
-	self 
-		extractToFileNamed: aFileName 
-		inDirectory: FileSystem workingDirectory.
+{ #category : #'extraction-private' }
+ZipArchiveMember >> extractToFile: aFile informingOverwrite: shouldOverwrite onSuccess: successBlock onRetryWithOverwrite: retryWithOverwriteBlock onFailedOverwrite: failedBlock onAbortOverwrite: abortBlock [
+	"Extract this entry into the given file. Answer successBlock or call one of the other action blocks."
+
+	| file |
+	file := aFile.
+	(file exists and: [ shouldOverwrite not ])
+		ifTrue: [ | overwriteBlock |
+			overwriteBlock := [ file := [ file
+				ensureDelete;
+				ensureCreateFile ]
+				on: Error
+				do: [ :ex | 
+					failedBlock cull: ex.
+					^ self ] ].
+			self
+				askOverwriteOptionsUsing: UIManager default
+				onYes: overwriteBlock
+				onNo: [ ^ #okay ]
+				onRetryWithOverwrite: [ retryWithOverwriteBlock value.
+					overwriteBlock value ]
+				onCancel: abortBlock ].
+	file binaryWriteStreamDo: [ :str | self extractTo: str ].
+	^ successBlock value
 ]
 
-{ #category : #accessing }
-ZipArchiveMember >> extractToFileNamed: aLocalFileName inDirectory: dir [
-	| file fullDir |
-	self isEncrypted
-		ifTrue: [ ^self error: 'encryption unsupported' ].
-	file := dir / aLocalFileName.
-	file parent ensureCreateDirectory.
-	self isDirectory 
-		ifFalse: [
-			fullDir 
-				forceNewFileNamed: file basename 
-				do: [:stream |  self extractTo: stream]]
-		ifTrue: [ fullDir ensureCreateDirectory ]
+{ #category : #extraction }
+ZipArchiveMember >> extractToFileNamed: aFileName [
+	self extractToFileNamed: aFileName inDirectory: FileSystem workingDirectory overwrite: true
+]
 
+{ #category : #extraction }
+ZipArchiveMember >> extractToFileNamed: aLocalFileName inDirectory: dir [
+	self extractToFileNamed: aLocalFileName inDirectory: dir overwrite: true
+]
+
+{ #category : #extraction }
+ZipArchiveMember >> extractToFileNamed: aLocalFileName inDirectory: dir overwrite: overwrite [
+	| file |
+	self isEncrypted
+		ifTrue: [ ^ self error: 'encryption unsupported' ].
+	file := dir / aLocalFileName.
+	self isDirectory
+		ifTrue: [ file ensureCreateDirectory ]
+		ifFalse: [ (file isFile and: [ file exists ])
+				ifTrue: [ overwrite
+						ifTrue: [ file
+								ensureDelete;
+								ensureCreateFile;
+								binaryWriteStreamDo: [ :stream | self extractTo: stream ] ] ]
+				ifFalse: [ file
+						ensureCreateFile;
+						binaryWriteStreamDo: [ :stream | self extractTo: stream ] ] ]
 ]
 
 { #category : #accessing }

--- a/src/Compression/ZipArchiveMember.class.st
+++ b/src/Compression/ZipArchiveMember.class.st
@@ -431,7 +431,7 @@ ZipArchiveMember >> extractTo: aStream from: start to: finish [
 	self endRead.
 ]
 
-{ #category : #'extraction-private' }
+{ #category : #'private-extraction' }
 ZipArchiveMember >> extractToFile: aFile informingOverwrite: shouldOverwrite onSuccess: successBlock onRetryWithOverwrite: retryWithOverwriteBlock onFailedOverwrite: failedBlock onAbortOverwrite: abortBlock [
 	"Extract this entry into the given file. Answer successBlock or call one of the other action blocks."
 


### PR DESCRIPTION
 19571 - ZipArchive API should let the user extract an archive and overriting files without carring about display.
    Add message selector ZipArchive>>extractAllTo:overwrite: which does not inform or use UI when asked to overwrite an existing file.
    Moved UI related methods to different package to differentiate from non-ui methods.

    Fix for https://pharo.fogbugz.com/f/cases/19571/ZipArchive-API-should-let-the-user-extract-an-archive-and-overriting-files-without-carring-about-display