### PR TITLE
21923-ShiftClassInstaller-trigger-assertion-failure-when-changing-superclass-in-deep-hierarchy

### DIFF
--- a/src/Shift-Changes/ShSuperclassChangedDetector.class.st
+++ b/src/Shift-Changes/ShSuperclassChangedDetector.class.st
@@ -3,7 +3,7 @@ I detect if there is a change in the superclass
 "
 Class {
 	#name : #ShSuperclassChangedDetector,
-	#superclass : #ShAbstractClassChangeDetector,
+	#superclass : #ShAbstractInstanceSideClassChangeDetector,
 	#category : #'Shift-Changes'
 }
 

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -43,6 +43,26 @@ ShClassInstallerTest >> tearDown [
 ]
 
 { #category : #tests }
+ShClassInstallerTest >> testChangingHierarchy [
+
+	"Testing that the changes in the superclasses are propagated to the subclasses"
+
+	superClass := self newClass:#ShCITestClass1 slots:#().
+	newClass := self newClass:#ShCITestClass2 superclass: superClass slots:#(aSlot).
+
+	self assert: newClass classLayout slotScope parentScope equals: superClass classLayout slotScope.
+
+	superClass2 := self newClass:#ShCITestClass0 slots:#(anotherSlot).
+	superClass := self newClass:#ShCITestClass1 superclass: superClass2 slots:#().
+	
+	self assert: newClass classLayout slotScope parentScope equals: superClass classLayout slotScope.
+	self assert: superClass classLayout slotScope parentScope equals: superClass2 classLayout slotScope.
+	
+	self assertCollection: (newClass allSlots collect: #name) hasSameElements: #(aSlot anotherSlot)
+
+]
+
+{ #category : #tests }
 ShClassInstallerTest >> testChangingSuperclassInTheHierarchy [
 
 	superClass := self newClass:#ShCITestClass slots:#(var1 var2).


### PR DESCRIPTION
Fixing a problem with the propagation of changes in the SlotLayout when changing the hierarchy.

It fixes Issue #21923

https://pharo.manuscript.com/f/cases/21923/ShiftClassInstaller-trigger-assertion-failure-when-changing-superclass-in-deep-hierarchy