### PR TITLE
21940-bindings-assignment-return-value-is-wrong

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -352,7 +352,7 @@ CompilationContext >> bindings [
 CompilationContext >> bindings: aDictionay [
 	"binding are LiteralVariables, not simple Associations"
 	bindings := (aDictionay associations
-		collect: [ :each | LiteralVariable key: each key value: each value ]) asDictionary
+		collect: [ :each | AdditionalBinding key: each key value: each value ]) asDictionary
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Tests/OpalCompilerTests.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTests.class.st
@@ -18,7 +18,7 @@ OpalCompilerTests >> testBindingsWriteGlobals [
 	| result |
 	result := Smalltalk compiler
 		 bindings: {(#Object -> Point)} asDictionary;
-       evaluate: 'Object := 42. Object'.
+       evaluate: 'Object := 42'.
 	self assert: result equals: 42.
 ]
 

--- a/src/Slot-Core/AdditionalBinding.class.st
+++ b/src/Slot-Core/AdditionalBinding.class.st
@@ -1,0 +1,28 @@
+"
+When handing over a dictionary with additonal binding to the compiler:
+
+	 Smalltalk compiler
+        bindings: {(#test -> Point)} asDictionary;
+        evaluate: 'test := 42'.
+
+all associations are changed to be AdditionaBinding.
+"
+Class {
+	#name : #AdditionalBinding,
+	#superclass : #LiteralVariable,
+	#category : #'Slot-Core-Variables'
+}
+
+{ #category : #'code generation' }
+AdditionalBinding >> emitStore: methodBuilder [
+
+	methodBuilder storeIntoLiteralVariable: self.
+
+
+]
+
+{ #category : #'code generation' }
+AdditionalBinding >> emitValue: methodBuilder [
+
+	methodBuilder pushLiteralVariable: self.
+]

--- a/src/Slot-Core/DangerousClassNotifier.class.st
+++ b/src/Slot-Core/DangerousClassNotifier.class.st
@@ -26,7 +26,7 @@ Class {
 	#classInstVars : [
 		'enabled'
 	],
-	#category : #'Slot-Core'
+	#category : #'Slot-Core-Exception'
 }
 
 { #category : #validation }

--- a/src/Slot-Core/LiteralVariable.class.st
+++ b/src/Slot-Core/LiteralVariable.class.st
@@ -214,5 +214,6 @@ LiteralVariable >> usingMethods [
 
 { #category : #'meta-object-protocol' }
 LiteralVariable >> write: anObject [
-	^self value: anObject
+	self value: anObject.
+	^anObject
 ]

--- a/src/Slot-Core/ManifestSlot.class.st
+++ b/src/Slot-Core/ManifestSlot.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ManifestSlot,
 	#superclass : #PackageManifest,
-	#category : #'Slot-Core'
+	#category : #'Slot-Core-Manifest'
 }
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
21940 #bindings: assignment return value is wrong
https://pharo.fogbugz.com/f/cases/21940/bindings-assignment-return-value-is-wrong
- add class AdditionalBinding as LiteralVariable uses reflective read and write
- fix LiteralVariable write:
- fix test to test the assignment
- some recategorisation in Slot package