### PR TITLE
21828-Slot-defined-a-trait-used-by-a-superclass-does-not-invoke-slot-accessing-method-when-used

### DIFF
--- a/src/Shift-ClassBuilder/ShDefaultBuilderEnhancer.class.st
+++ b/src/Shift-ClassBuilder/ShDefaultBuilderEnhancer.class.st
@@ -80,3 +80,10 @@ ShDefaultBuilderEnhancer >> on: newClass declareClassVariables: sharedVariables 
 		declareClassVariables: sharedVariables;
 		sharing: sharedPoolsString
 ]
+
+{ #category : #'class modifications' }
+ShDefaultBuilderEnhancer >> propagateChangesToRelatedClasses: newClass installer: installer [
+	
+	newClass subclasses do: [ :e | installer remake: e ].
+
+]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -291,7 +291,7 @@ ShiftClassBuilder >> fillFor: aClass [
 		superclass: aClass superclass;
 		name: aClass getName;
 		layoutClass: aClass classLayout class;
-		slots: aClass slots ;
+		slots: aClass localSlots ;
 		sharedVariablesFromString: aClass classVariablesString;
 		sharedPools: aClass sharedPoolsString;
 		category: aClass category;

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -166,7 +166,7 @@ ShiftClassInstaller >> make: aBlock [
 
 		builder builderEnhancer afterMigratingClass: builder installer: self.	
 
-		newClass subclasses do: [ :e | self remake: e ].
+		builder builderEnhancer propagateChangesToRelatedClasses: newClass installer: self.
 	] on: ShNoChangesInClass do:[
 		"If there are no changes in the building, I am not building or replacing nothing"
 		newClass := oldClass.

--- a/src/TraitsV2-Tests/T2TraitPropagatingSlotChangesTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitPropagatingSlotChangesTest.class.st
@@ -1,0 +1,42 @@
+Class {
+	#name : #T2TraitPropagatingSlotChangesTest,
+	#superclass : #T2AbstractTest,
+	#category : #'TraitsV2-Tests'
+}
+
+{ #category : #tests }
+T2TraitPropagatingSlotChangesTest >> testAddingSlotToTrait [
+	| t1 c1 |
+
+	t1 := self newTrait: #T1 with: #() uses: {}.
+	c1 := self newClass: #C1 with: #() uses: t1.
+
+	self assert: c1 classLayout slotScope parentScope == c1 superclass classLayout slotScope.
+	self assert: c1 class classLayout slotScope parentScope == c1 class superclass classLayout slotScope.
+	self assertCollection: c1 slots equals: #()	.
+			
+	t1 := self newTrait: #T1 with: #(aSlot) uses: {}.
+
+	self assert: c1 classLayout slotScope parentScope == c1 superclass classLayout slotScope.
+	self assert: c1 class classLayout slotScope parentScope == c1 class superclass classLayout slotScope. 		 
+	self assertCollection: (c1 slots collect: #name)  hasSameElements: #(aSlot).
+]
+
+{ #category : #tests }
+T2TraitPropagatingSlotChangesTest >> testRemovingSlotToTrait [
+	| t1 c1 |
+
+	t1 := self newTrait: #T1 with: #(aSlot) uses: {}.
+	c1 := self newClass: #C1 with: #() uses: t1.
+
+	self assert: c1 classLayout slotScope parentScope == c1 superclass classLayout slotScope.
+	self assert: c1 class classLayout slotScope parentScope == c1 class superclass classLayout slotScope.
+	self assertCollection: (c1 slots collect: #name)  hasSameElements: #(aSlot).
+			
+	t1 := self newTrait: #T1 with: #() uses: {}.
+
+	self assert: c1 classLayout slotScope parentScope == c1 superclass classLayout slotScope.
+	self assert: c1 class classLayout slotScope parentScope == c1 class superclass classLayout slotScope. 		 
+	self assertCollection: c1 slots equals: #()	.
+
+]

--- a/src/TraitsV2-Tests/T2TraitWithComplexSlots.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithComplexSlots.class.st
@@ -63,6 +63,29 @@ T2TraitWithComplexSlots >> testTraitWithComplexSlot [
 ]
 
 { #category : #'instance creation' }
+T2TraitWithComplexSlots >> testTraitWithComplexSlotAfter [
+	| t1 c1 obj |
+	
+	self createSlotClass.
+	t1 := self newTrait: #T1 with: {}. 
+	c1 := self newClass: #C1 with: { #aSlot. } uses: {t1}.
+
+	c1 compile: 'initialize
+		aSlot := 0'.
+
+	t1 := self newTrait: #T1 with: { #otherSlot => (slotClass associatedSlotName: #aSlot) }. 
+
+	c1 compile: 'doSomething
+		otherSlot := ''a'''.
+	
+	obj := c1 new.
+	self assert: (obj instVarNamed: #aSlot) equals: 0.
+	obj doSomething.
+	self assert: (obj instVarNamed: #aSlot) equals: 1.
+
+]
+
+{ #category : #'instance creation' }
 T2TraitWithComplexSlots >> testTraitWithComplexSlotInSuperclass [
 	| t1 c1 c2 obj |
 	
@@ -77,6 +100,28 @@ T2TraitWithComplexSlots >> testTraitWithComplexSlotInSuperclass [
 		otherSlot := ''a'''.
 	
 	obj := c2 new.
+	self assert: (obj instVarNamed: #aSlot) equals: 0.
+	obj doSomething.
+	self assert: (obj instVarNamed: #aSlot) equals: 1.
+
+]
+
+{ #category : #'instance creation' }
+T2TraitWithComplexSlots >> testTraitWithComplexSlotUpdatedAfter [
+	| t1 c1 obj |
+	
+	self createSlotClass.
+	t1 := self newTrait: #T1 with: {}. 
+	c1 := self newClass: #C1 with: { #aSlot. } uses: {t1}.
+
+	t1 := self newTrait: #T1 with: { #otherSlot => (slotClass associatedSlotName: #aSlot) }. 
+
+	c1 compile: 'initialize
+		aSlot := 0'.
+	c1 compile: 'doSomething
+		otherSlot := ''a'''.
+	
+	obj := c1 new.
 	self assert: (obj instVarNamed: #aSlot) equals: 0.
 	obj doSomething.
 	self assert: (obj instVarNamed: #aSlot) equals: 1.

--- a/src/TraitsV2-Tests/T2TraitWithComplexSlots.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithComplexSlots.class.st
@@ -1,0 +1,130 @@
+Class {
+	#name : #T2TraitWithComplexSlots,
+	#superclass : #T2AbstractTest,
+	#instVars : [
+		'slotClass'
+	],
+	#category : #'TraitsV2-Tests'
+}
+
+{ #category : #'instance creation' }
+T2TraitWithComplexSlots >> createSlotClass [
+	slotClass := self newClass: #TestSlot superclass: IndexedSlot with: #(associatedSlotName) uses: #().
+	slotClass class compile: 'associatedSlotName: aName
+		^ self new
+			associatedSlotName: aName;
+			yourself'.
+			
+	slotClass compile: 'associatedSlotName: aName
+		associatedSlotName:=aName'.
+	
+	slotClass compile: 'write: aValue to: anObject
+		super write: aValue to: anObject.
+		anObject instVarNamed: associatedSlotName put: (anObject instVarNamed: associatedSlotName) + 1.
+		'
+]
+
+{ #category : #'instance creation' }
+T2TraitWithComplexSlots >> testNormalClassWithComplexSlot [
+	| c1 obj |
+	
+	self createSlotClass.
+	c1 := self newClass: #C1 with: { #aSlot. #otherSlot => (slotClass associatedSlotName: #aSlot) } uses: #().
+	c1 compile: 'initialize
+		aSlot := 0'.
+	c1 compile: 'doSomething
+		otherSlot := ''a'''.
+	
+	obj := c1 new.
+	self assert: (obj instVarNamed: #aSlot) equals: 0.
+	obj doSomething.
+	self assert: (obj instVarNamed: #aSlot) equals: 1.
+
+]
+
+{ #category : #'instance creation' }
+T2TraitWithComplexSlots >> testTraitWithComplexSlot [
+	| t1 c1 obj |
+	
+	self createSlotClass.
+	t1 := self newTrait: #T1 with: { #otherSlot => (slotClass associatedSlotName: #aSlot) }. 
+	c1 := self newClass: #C1 with: { #aSlot. } uses: {t1}.
+
+	c1 compile: 'initialize
+		aSlot := 0'.
+	c1 compile: 'doSomething
+		otherSlot := ''a'''.
+	
+	obj := c1 new.
+	self assert: (obj instVarNamed: #aSlot) equals: 0.
+	obj doSomething.
+	self assert: (obj instVarNamed: #aSlot) equals: 1.
+
+]
+
+{ #category : #'instance creation' }
+T2TraitWithComplexSlots >> testTraitWithComplexSlotInSuperclass [
+	| t1 c1 c2 obj |
+	
+	self createSlotClass.
+	t1 := self newTrait: #T1 with: { #otherSlot => (slotClass associatedSlotName: #aSlot) }. 
+	c1 := self newClass: #C1 with: { #aSlot. } uses: {t1}.
+	c2 := self newClass: #C2 superclass: c1 with: #() uses: #().
+
+	c1 compile: 'initialize
+		aSlot := 0'.
+	t1 compile: 'doSomething
+		otherSlot := ''a'''.
+	
+	obj := c2 new.
+	self assert: (obj instVarNamed: #aSlot) equals: 0.
+	obj doSomething.
+	self assert: (obj instVarNamed: #aSlot) equals: 1.
+
+]
+
+{ #category : #'instance creation' }
+T2TraitWithComplexSlots >> testTraitWithComplexSlotUsedInOtherSlot [
+	| t1 t2 c1 obj |
+	
+	self createSlotClass.
+	t1 := self newTrait: #T1 with: { #otherSlot => (slotClass associatedSlotName: #aSlot) }. 
+	t2 := self newTrait: #T2 with: { #otherSlot }.
+	c1 := self newClass: #C1 with: { #aSlot. } uses: {t1. t2 asTraitComposition -- #otherSlot}.
+
+	c1 compile: 'initialize
+		aSlot := 0'.
+	
+	t2 compile: 'doSomething
+		otherSlot := ''a'''.
+	
+	obj := c1 new.
+	self assert: (obj instVarNamed: #aSlot) equals: 0.
+	obj doSomething.
+	self assert: (obj instVarNamed: #aSlot) equals: 1.
+
+]
+
+{ #category : #'instance creation' }
+T2TraitWithComplexSlots >> testTraitWithComplexSlotUsedInOtherSlotInSuperclass [
+	| t1 t2 c1 c2 obj |
+	
+	self createSlotClass.
+	t1 := self newTrait: #T1 with: { #otherSlot => (slotClass associatedSlotName: #aSlot) }. 
+	t2 := self newTrait: #T2 with: { #otherSlot }.
+	c1 := self newClass: #C1 with: { #aSlot. } uses: {t1. t2 asTraitComposition -- #otherSlot}.
+
+	c1 compile: 'initialize
+		aSlot := 0'.
+	
+	t2 compile: 'doSomething
+		otherSlot := ''a'''.
+	
+	c2 := self newClass: #C2 superclass: c1 with: #() uses: #().
+	
+	obj := c2 new.
+	self assert: (obj instVarNamed: #aSlot) equals: 0.
+	obj doSomething.
+	self assert: (obj instVarNamed: #aSlot) equals: 1.
+
+]

--- a/src/TraitsV2/TraitBuilderEnhancer.class.st
+++ b/src/TraitsV2/TraitBuilderEnhancer.class.st
@@ -161,6 +161,16 @@ TraitBuilderEnhancer >> initializeBuilder: aBuilder [
 		ifFalse: [ aBuilder metaclassClass: TraitedMetaclass ]
 ]
 
+{ #category : #'class modifications' }
+TraitBuilderEnhancer >> propagateChangesToRelatedClasses: newClass installer: installer [
+
+	super propagateChangesToRelatedClasses: newClass installer: installer.
+
+	"If the newClass is a trait I have to remake the users of it"
+	newClass isTrait ifFalse: [ ^ self ].
+	newClass users do: [ :each | installer remake: each ]
+]
+
 { #category : #accessing }
 TraitBuilderEnhancer >> traitComposition [
 	^ builder traitComposition asTraitComposition


### PR DESCRIPTION
Fixing problems when propagating changes in the slots of traits. 

Fixes issue https://pharo.manuscript.com/f/cases/21828/Slot-defined-a-trait-used-by-a-superclass-does-not-invoke-slot-accessing-method-when-used