### PR TITLE
21945 Cleanup Tool-ExternalBrowser and deprecate CurrentImage

### DIFF
--- a/src/Deprecated70/CurrentImage.class.st
+++ b/src/Deprecated70/CurrentImage.class.st
@@ -3,15 +3,28 @@ I am an object representing the current image to get all sorted packages for bro
 
 CurrentImage new packages
 	=> all packages in the image sorted
+	
+
+THIS CLASS IS NOW DEPRECATED AND BSOLETE - please use 
+
+  Smalltalk image packages 
+
+to receive all packages in the image sorted
 "
 Class {
 	#name : #CurrentImage,
 	#superclass : #Object,
-	#category : #'Tool-ExternalBrowser'
+	#category : #Deprecated70
 }
+
+{ #category : #testing }
+CurrentImage class >> isDeprecated [
+
+	^true
+]
 
 { #category : #accessing }
 CurrentImage >> packages [
-
+	self deprecated: 'Use Smalltalk image packages'.
 	^ (RPackageOrganizer default packages) sorted
 ]

--- a/src/Deprecated70/CurrentImage.class.st
+++ b/src/Deprecated70/CurrentImage.class.st
@@ -5,7 +5,7 @@ CurrentImage new packages
 	=> all packages in the image sorted
 	
 
-THIS CLASS IS NOW DEPRECATED AND BSOLETE - please use 
+THIS CLASS IS NOW DEPRECATED AND OBSOLETE - please use 
 
   Smalltalk image packages 
 

--- a/src/RPackage-Core/SmalltalkImage.extension.st
+++ b/src/RPackage-Core/SmalltalkImage.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #SmalltalkImage }
+
+{ #category : #'*RPackage-Core' }
+SmalltalkImage >> packages [
+
+	^ (RPackageOrganizer default packages) sorted
+]

--- a/src/Tool-ExternalBrowser/ExternalBrowser.class.st
+++ b/src/Tool-ExternalBrowser/ExternalBrowser.class.st
@@ -24,7 +24,7 @@ Class {
 		'showClassSide',
 		'model'
 	],
-	#category : #'Tool-ExternalBrowser'
+	#category : #'Tool-ExternalBrowser-Browsers'
 }
 
 { #category : #'public access' }
@@ -52,16 +52,23 @@ ExternalBrowser class >> defaultSpec [
 		yourself
 ]
 
+{ #category : #examples }
+ExternalBrowser class >> example [
+	<example>
+
+	self openOn: Smalltalk image
+]
+
 { #category : #'System-FileRegistry' }
 ExternalBrowser class >> fileReaderServicesForFile: fullName suffix: suffix [
 	<fileService>
 
-	^ (#('st' 'cs') includes: suffix)
+	^ (self sourceFileSuffixes includes: suffix)
 		ifTrue: [ Array with: self serviceBrowseCode]
-		ifFalse: [ #() ].
+		ifFalse: [ #() ]
 ]
 
-{ #category : #specs }
+{ #category : #'instance creation' }
 ExternalBrowser class >> openOn: model [
 
 	self basicNew
@@ -88,6 +95,14 @@ ExternalBrowser class >> services [
 	"Answer potential file services associated with this class"
 
 	^ {self serviceBrowseCode}.
+]
+
+{ #category : #'System-FileRegistry' }
+ExternalBrowser class >> sourceFileSuffixes [
+
+	^#('st' 'cs')
+
+
 ]
 
 { #category : #accessing }

--- a/src/Tool-ExternalBrowser/ExternalChangesBrowser.class.st
+++ b/src/Tool-ExternalBrowser/ExternalChangesBrowser.class.st
@@ -20,12 +20,13 @@ Class {
 		'deselectAllButton',
 		'fileInSelectedButton'
 	],
-	#category : #'Tool-ExternalBrowser'
+	#category : #'Tool-ExternalBrowser-Browsers'
 }
 
-{ #category : #browsing }
+{ #category : #examples }
 ExternalChangesBrowser class >> browseRecentLog [
 	<example>
+	
 	^ self openOnStream: SourceFiles changesFileStream
 ]
 
@@ -44,6 +45,21 @@ ExternalChangesBrowser class >> defaultSpec [
 						add: #fileInSelectedButton ] height: 32;
 				add: #codePane ]; 
 		yourself
+]
+
+{ #category : #examples }
+ExternalChangesBrowser class >> example1 [
+	<example>
+	
+	self new openWithSpec
+
+]
+
+{ #category : #examples }
+ExternalChangesBrowser class >> example2 [
+	<example>
+	
+	self openOn: Smalltalk changesFile fullName
 ]
 
 { #category : #'file service' }

--- a/src/Tool-ExternalBrowser/ManifestToolExternalBrowser.class.st
+++ b/src/Tool-ExternalBrowser/ManifestToolExternalBrowser.class.st
@@ -1,5 +1,8 @@
+"
+Package for hosting browsers to acces external infos (like *.cs files and other)
+"
 Class {
 	#name : #ManifestToolExternalBrowser,
 	#superclass : #PackageManifest,
-	#category : #'Tool-ExternalBrowser'
+	#category : #'Tool-ExternalBrowser-Manifest'
 }


### PR DESCRIPTION
- Categorize Manifest and classes
- Formatting issues
- provide examples
- do not hardcode file extensions (sourceFileSuffixes)
- use "Smalltalk image packages" instead of "CurrentImage new packages" by moving the #packages method and moving CurrentImage to deprecated package

https://pharo.fogbugz.com/f/cases/21945/Cleanup-Tool-ExternalBrowser-and-deprecate-CurrentImage