### PR TITLE
21952-FileSystemStoresignalFileDoesNotExist-creates-bad-exception

### DIFF
--- a/src/FileSystem-Core/FileSystemStore.class.st
+++ b/src/FileSystem-Core/FileSystemStore.class.st
@@ -381,7 +381,7 @@ FileSystemStore >> signalDirectoryExists: aPath [
 { #category : #'error signalling' }
 FileSystemStore >> signalFileDoesNotExist: aPath [
 	^ FileDoesNotExistException
-		signalWithFile: (File named: aPath asString)
+		signalWithFile: (File named: aPath asPath pathString)
 		writeMode: false
 ]
 

--- a/src/FileSystem-Path/Path.class.st
+++ b/src/FileSystem-Path/Path.class.st
@@ -231,6 +231,11 @@ Path >> = other [
 ]
 
 { #category : #converting }
+Path >> asPath [
+	^ self
+]
+
+{ #category : #converting }
 Path >> asPathWith: anObject [
 	^ self
 ]


### PR DESCRIPTION
21952 FileSystemStore>>signalFileDoesNotExist: creates bad exception

FileSystemStore>>signalFileDoesNotExist: currently creates a badly formed FileDoesNotExistException as it passes a File in with a human readable path string, e.g. "Path / 'path' / 'to / 'file'", as the fileName.  This causes problems later on when the fileName attempts to be used.