### PR TITLE
21958-Metaclass-traitComposition-localSelectors-are-not-needed

### DIFF
--- a/src/Kernel-Tests/BehaviorTest.class.st
+++ b/src/Kernel-Tests/BehaviorTest.class.st
@@ -209,9 +209,9 @@ BehaviorTest >> testMethodsWritingSlot [
 
 { #category : #metrics }
 BehaviorTest >> testNumberOfInstanceVariables [
-	self assert: Object numberOfInstanceVariables = 0.
-	self assert: Point numberOfInstanceVariables = 2.
-	self assert: Metaclass numberOfInstanceVariables = 3
+	self assert: Object numberOfInstanceVariables equals: 0.
+	self assert: Point numberOfInstanceVariables equals: 2.
+	self assert: Metaclass numberOfInstanceVariables equals: 1
 ]
 
 { #category : #'tests - properties' }

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -14,9 +14,7 @@ Class {
 	#name : #Metaclass,
 	#superclass : #ClassDescription,
 	#instVars : [
-		'thisClass',
-		'traitComposition',
-		'localSelectors'
+		'thisClass'
 	],
 	#category : #'Kernel-Classes'
 }


### PR DESCRIPTION
Metaclass: traitComposition localSelectors are not needed
https://pharo.fogbugz.com/f/cases/21958/Metaclass-traitComposition-localSelectors-are-not-needed