### PR TITLE
21966-bindings-ok-to-use-array-of-associations

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -349,9 +349,10 @@ CompilationContext >> bindings [
 ]
 
 { #category : #accessing }
-CompilationContext >> bindings: aDictionay [
-	"binding are LiteralVariables, not simple Associations"
-	bindings := (aDictionay associations
+CompilationContext >> bindings: aCollectionOfAssociations [
+	"bindings are LiteralVariables, not simple Associations.
+	This method receives any collection with bindings inside and converts it to a dictionary of AdditionalBindings"
+	bindings := (aCollectionOfAssociations asDictionary associations
 		collect: [ :each | AdditionalBinding key: each key value: each value ]) asDictionary
 ]
 

--- a/src/OpalCompiler-Tests/OpalCompilerTests.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTests.class.st
@@ -5,6 +5,42 @@ Class {
 }
 
 { #category : #'tests - bindings' }
+OpalCompilerTests >> testArrayBindingsWithUppercaseNameDoOverwriteGlobals [
+	| result |
+	result := Smalltalk compiler
+		bindings: {(#UndefinedObject -> Object)};
+		evaluate: 'UndefinedObject class'.
+	self assert: result equals: Object class
+]
+
+{ #category : #'tests - bindings' }
+OpalCompilerTests >> testArrayBindingsWriteGlobals [
+	| result |
+	result := Smalltalk compiler
+		 bindings: {(#Object -> Point)};
+       evaluate: 'Object := 42'.
+	self assert: result equals: 42.
+]
+
+{ #category : #'tests - bindings' }
+OpalCompilerTests >> testArrayEvaluateWithBindings [
+	| result |
+	result := Smalltalk compiler
+		bindings: {(#a -> 3)};
+		evaluate: '1+a'.
+	self assert: result equals: 4
+]
+
+{ #category : #'tests - bindings' }
+OpalCompilerTests >> testArrayEvaluateWithBindingsWithUppercaseName [
+	| result |
+	result := Smalltalk compiler
+		bindings: {(#MyVar -> 3)};
+		evaluate: '1+MyVar'.
+	self assert: result equals: 4
+]
+
+{ #category : #'tests - bindings' }
 OpalCompilerTests >> testBindingsWithUppercaseNameDoOverwriteGlobals [
 	| result |
 	result := Smalltalk compiler


### PR DESCRIPTION
Fix issue 21966.
- bindings: can now receive any collection
- added tests for arrays