### PR TITLE
21965-SmaltlalkImagecompiler--use-globals-as-default-environment-not-just-self

### DIFF
--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -449,7 +449,7 @@ SmalltalkImage >> compactClassesArray [
 { #category : #compiler }
 SmalltalkImage >> compiler [
 	^self compilerClass new
-		environment: self
+		environment: self globals
 ]
 
 { #category : #compiler }


### PR DESCRIPTION
Fix issue 21965
- SmalltalkImage>>compiler now use globals