### PR TITLE
21980-When-debugging-a-DNU-the-create-method-button-should-be-available

### DIFF
--- a/src/GT-Debugger/GTSpecPreDebugWindow.class.st
+++ b/src/GT-Debugger/GTSpecPreDebugWindow.class.st
@@ -141,6 +141,19 @@ GTSpecPreDebugWindow >> emptyLayout [
 
 ]
 
+{ #category : #'initialization widgets' }
+GTSpecPreDebugWindow >> filteredStack [
+
+	^ (self debugger session stackOfSize: 50 ) select: [ :aContext | (aContext method hasPragmaNamed: #debuggerCompleteToSender) not ]
+]
+
+{ #category : #'initialization widgets' }
+GTSpecPreDebugWindow >> firstContextToOpen [
+
+	self filteredStack ifEmpty: [ ^ nil ].
+	^ self filteredStack first
+]
+
 { #category : #api }
 GTSpecPreDebugWindow >> initialExtent [
 
@@ -189,7 +202,7 @@ GTSpecPreDebugWindow >> initializeStackPane [
 	
 	self stackPane
 		displayBlock: [ :aContext | self columnsFor: aContext ];
-		items: (self debugger session stackOfSize: 50 ) ;
+		items: self filteredStack ;
 		whenSelectedItemChanged: [ :aContext | 
 			"Set the selection before, as debugAction removes the link with the debugger. "
 			self debugger stackPresentation selection: aContext.
@@ -225,12 +238,11 @@ GTSpecPreDebugWindow >> notifierPaneWidgetId [
 { #category : #actions }
 GTSpecPreDebugWindow >> openFullDebugger [
 	| currentDebugger |
-	
 	currentDebugger := self debugger.
+	self setDebuggerToFirstNonFilteredContext.
 	self debugger: nil.
 	self close.
-	currentDebugger 
-		open
+	currentDebugger open
 ]
 
 { #category : #'actions lookup' }
@@ -270,6 +282,19 @@ GTSpecPreDebugWindow >> rebuildWidget [
 GTSpecPreDebugWindow >> session [
 
 	^ self debugger session
+]
+
+{ #category : #actions }
+GTSpecPreDebugWindow >> setDebuggerToFirstNonFilteredContext [
+	"I set the debugger to the first non filtered stack"
+	| currentDebugger |
+
+	currentDebugger := self debugger.
+
+	(currentDebugger stackPresentation selection isNil
+		or: [ currentDebugger stackPresentation selection method
+				hasPragmaNamed: #debuggerCompleteToSender ])
+		ifTrue: [ currentDebugger stackPresentation selection: self firstContextToOpen ]
 ]
 
 { #category : #'building widgets' }

--- a/src/Kernel/Halt.class.st
+++ b/src/Kernel/Halt.class.st
@@ -201,13 +201,3 @@ Halt >> defaultAction [
 	^ UIManager default unhandledErrorDefaultAction: self
 	"^ UnhandledError signalForException: self" 
 ]
-
-{ #category : #accessing }
-Halt >> signalerContext [
-	"specialized version to find the proper context to open the debugger on.
-	This will find the first context whose method is no longer on Halt or Halt class nor is #halt method iteself."
-	^ signalContext findContextSuchThat: [ :context |
-		(context receiver == self 
-		or: [ (context receiver == self class) 
-		or: [ context method hasPragmaNamed: #debuggerCompleteToSender ]]) not ]
-]

--- a/src/Kernel/MessageNotUnderstood.class.st
+++ b/src/Kernel/MessageNotUnderstood.class.st
@@ -16,7 +16,7 @@ Class {
 MessageNotUnderstood >> debug [
 	"open a debugger on myself"
 	Processor activeProcess 
-		debug: self signalerContext sender
+		debug: self signalerContext
 		title: self smartDescription
 ]
 

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -798,6 +798,7 @@ Object >> displayStringOn: aStream [
 
 { #category : #'reflective operations' }
 Object >> doesNotUnderstand: aMessage [ 
+	<debuggerCompleteToSender>
 	 "Handle the fact that there was an attempt to send the given message to the receiver but the receiver does not understand this message (typically sent from the machine when a message is sent to the receiver and no method is defined for that selector)."
 	"Testing: (3 activeProcess)"
 		

--- a/src/Kernel/ProtoObject.class.st
+++ b/src/Kernel/ProtoObject.class.st
@@ -84,6 +84,8 @@ ProtoObject >> doOnlyOnce: aBlock [
 { #category : #'reflective operations' }
 ProtoObject >> doesNotUnderstand: aMessage [
 
+	<debuggerCompleteToSender>
+
 	^ MessageNotUnderstood new 
 		message: aMessage;
 		receiver: self;


### PR DESCRIPTION
I have implemented the filtering of the debug stack using the debuggerCompleteToSender pragma.

This filtering is done in the UI, the debug session does not care about the real context.
The debugger is always open in a filtered stack, it opens on a context that does not have the pragma.

Issue: https://pharo.manuscript.com/f/cases/21980/When-debugging-a-DNU-the-create-method-button-should-be-available