### PR TITLE
21981-RBBasicLintRuleTest-class--usesTrue-should-be-removed

### DIFF
--- a/src/Refactoring-Tests-Core/RBBasicLintRuleTest.class.st
+++ b/src/Refactoring-Tests-Core/RBBasicLintRuleTest.class.st
@@ -1044,24 +1044,6 @@ RBBasicLintRuleTest class >> usesAdd [
 	^detector
 ]
 
-{ #category : #bugs }
-RBBasicLintRuleTest class >> usesTrue [
-	| detector trueBinding falseBinding |
-	detector := self new.
-	trueBinding := Smalltalk associationAt: #True.
-	falseBinding := Smalltalk associationAt: #False.
-	detector name: 'Uses True/False instead of true/false'.
-	detector methodBlock: 
-			[:context :result | 
-			| method |
-			method := context compiledMethod.
-			((method referencesLiteral: trueBinding)
-				or: [method referencesLiteral: falseBinding]) ifTrue: 
-						[result addClass: context selectedClass selector: context selector.
-						result searchStrings: #('True' 'False')]].
-	^detector
-]
-
 { #category : #miscellaneous }
 RBBasicLintRuleTest class >> utilityMethods [
 	| detector |


### PR DESCRIPTION
Removed the method usesTrue.https://pharo.manuscript.com/f/cases/21981/RBBasicLintRuleTest-class-usesTrue-should-be-removed