### PR TITLE
21960-Move-DangerousClassNotifier-to-ClassBuilder-package

### DIFF
--- a/src/Shift-ClassBuilder/DangerousClassNotifier.class.st
+++ b/src/Shift-ClassBuilder/DangerousClassNotifier.class.st
@@ -26,7 +26,7 @@ Class {
 	#classInstVars : [
 		'enabled'
 	],
-	#category : #'Slot-Core-Exception'
+	#category : #'Shift-ClassBuilder'
 }
 
 { #category : #validation }


### PR DESCRIPTION
Fix issue 21960.
- Move DangerousClassNotifier to Shift-ClassBuilder package