### PR TITLE
20570-Move-LayoutFrame-out-of-Morphic-Base-and-put-it-close-to-Margin

### DIFF
--- a/src/Kernel/LayoutFrame.class.st
+++ b/src/Kernel/LayoutFrame.class.st
@@ -40,7 +40,7 @@ Class {
 		'bottomFraction',
 		'bottomOffset'
 	],
-	#category : #'Morphic-Base-Layouts'
+	#category : #'Kernel-BasicObjects'
 }
 
 { #category : #'instance creation' }

--- a/src/Kernel/LayoutProperties.class.st
+++ b/src/Kernel/LayoutProperties.class.st
@@ -9,7 +9,7 @@ Class {
 		'vResizing',
 		'disableLayout'
 	],
-	#category : #'Morphic-Base-Layouts'
+	#category : #'Kernel-BasicObjects'
 }
 
 { #category : #converting }

--- a/src/Kernel/TableLayoutProperties.class.st
+++ b/src/Kernel/TableLayoutProperties.class.st
@@ -16,7 +16,7 @@ Class {
 		'minCellSize',
 		'maxCellSize'
 	],
-	#category : #'Morphic-Base-Layouts'
+	#category : #'Kernel-BasicObjects'
 }
 
 { #category : #'table defaults' }


### PR DESCRIPTION
Fix issue 20570.
- Move LayoutFrame, LayoutProperties, and sub from Morphic-Base to Kernel-BasicObjects