### PR TITLE
21204-Help--Pharo-Environment-Help--Keyboard-Shortcuts--Browser-Shortcuts-says-Windows--ALT

### DIFF
--- a/src/Pharo-Help/PharoEnvironmentHelp.class.st
+++ b/src/Pharo-Help/PharoEnvironmentHelp.class.st
@@ -16,7 +16,7 @@ KMDescription new categories: #(NautilusGlobalShortcuts); openWithSpec.
 - Shortcuts are typically multi-key combinations, where you hold a modifier key and press the listed secondary key. For example if something is listed as CMD-F, CMD-C you would press and hold the CMD key while typing  F and then C
 
 - The modifier key varies between platforms:
- - Windows = ALT
+ - Windows = CTRL
  - Mac/OSX = CMD
  - Linux = CTRL
 


### PR DESCRIPTION
Change the help description from ALT to CTRL for Windows. Fixex case https://pharo.manuscript.com/f/cases/21204/Help-Pharo-Environment-Help-Keyboard-Shortcuts-Browser-Shortcuts-says-Windows-ALT