### PR TITLE
21982-Store-Settings-on-Setting-Browser-fails-with-PrimitiveFailed-primitive-flush-in-File-class-failed

### DIFF
--- a/src/System-Settings/SettingsStonWriter.class.st
+++ b/src/System-Settings/SettingsStonWriter.class.st
@@ -45,15 +45,14 @@ SettingsStonWriter >> initialize [
 SettingsStonWriter >> store [
 	"Write the stored setting in the stream"
 
+	| writer |
 	stream ifNil: [ ^ self ].
-	[ | writer |
 	writer := STON writer
 		on: stream;
 		prettyPrint: true;
 		asciiOnly: true;
 		yourself.
-	writer nextPut: storedSettings asArray ]
-		ensure: [ stream close ]
+	writer nextPut: storedSettings asArray
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
fix double close issue https://pharo.fogbugz.com/f/cases/21982/Store-Settings-on-Setting-Browser-fails-with-PrimitiveFailed-primitive-flush-in-File-class-failed