### PR TITLE
21993-ExternalBrowser-reference-to-Transcript-does-not-make-sense

### DIFF
--- a/src/Tool-ExternalBrowser/ExternalBrowser.class.st
+++ b/src/Tool-ExternalBrowser/ExternalBrowser.class.st
@@ -224,7 +224,7 @@ ExternalBrowser >> refreshClasses: pack [
 	pack 
 		ifNil: [ classes items: #() ] 
 		ifNotNil: [ classes items: (self classesOfPackage: pack)]. 
-	Transcript show: pack printString;cr
+
 ]
 
 { #category : #'selection operation' }


### PR DESCRIPTION
trace left over