### PR TITLE
21994-Generator-class-example-method-should-use-streamContents-instead-of-Transcript

### DIFF
--- a/src/Collections-Streams/Generator.class.st
+++ b/src/Collections-Streams/Generator.class.st
@@ -79,17 +79,19 @@ Class {
 	#category : #'Collections-Streams'
 }
 
-{ #category : #examples }
-Generator class >> examplePrimes [
-	| generator |
-	Transcript open.
-	generator := Generator on: [:g| Integer primesUpTo: 100 do:[:prime| g yield: prime]].
-	[generator atEnd] whileFalse:[Transcript show: generator next; cr].
-]
-
 { #category : #'instance creation' }
 Generator class >> on: aBlock [
 	^ self basicNew initializeOn: aBlock
+]
+
+{ #category : #examples }
+Generator class >> somePrimes [
+	"self somePrimes" 
+	
+	^ String streamContents: [ :str | 
+		| generator |
+		generator := Generator on: [:g| Integer primesUpTo: 100 do:[:prime| g yield: prime]].
+		[generator atEnd] whileFalse:[ str nextPutAll: generator next printString; cr]]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
use a stream instead of Transcript