### PR TITLE
21995-HeapTest-examples-should-use-String-streamContents-instead-of-Transcript

### DIFF
--- a/src/Collections-Sequenceable/Heap.class.st
+++ b/src/Collections-Sequenceable/Heap.class.st
@@ -67,6 +67,68 @@ Heap class >> defaultSortBlock [
 		sortBlock := [ :a :b | a <= b]]
 ]
 
+{ #category : #examples }
+Heap class >> heapExample [	
+	"self heapExample"
+	"Create a sorted collection of numbers, remove the elements
+	sequentially and add new objects randomly.
+	Note: This is the kind of benchmark a heap is designed for."
+	
+	^ String streamContents: [ :str | 
+		| n rnd array time sorted |
+		n := 5000. "# of elements to sort"
+		rnd := Random new.
+		array := (1 to: n) collect:[:i| rnd next].
+		"First, the heap version"
+		time := Time millisecondsToRun:[
+		sorted := self withAll: array.
+			1 to: n do:[:i| 
+				sorted removeFirst.
+				sorted add: rnd next].
+	].
+	str << 'Time for Heap: ' << time printString <<' msecs '; cr.
+	"The quicksort version"
+	time := Time millisecondsToRun:[
+		sorted := SortedCollection withAll: array.
+		1 to: n do:[:i| 
+			sorted removeFirst.
+			sorted add: rnd next].
+	].
+	str << 'Time for SortedCollection: '<< time printString << ' msecs'.]
+
+]
+
+{ #category : #examples }
+Heap class >> heapSortExample [	
+	"self heapSortExample"
+	"Sort a random collection of Floats and compare the results with
+	SortedCollection (using the quick-sort algorithm) and 
+	ArrayedCollection>>mergeSortFrom:to:by: (using the merge-sort algorithm)."
+	
+	^ String streamContents: [ :str | 
+		| n rnd array  time sorted |
+		n := 10000. "# of elements to sort"
+		rnd := Random new.
+		array := (1 to: n) collect:[:i| rnd next].
+		"First, the heap version"
+		time := Time millisecondsToRun:[
+			sorted := Heap withAll: array.
+			1 to: n do:[:i| sorted removeFirst].
+		].
+	str << 'Time for heap-sort: ' << time printString << ' msecs ';cr.
+	"The quicksort version"
+	time := Time millisecondsToRun:[
+		sorted := SortedCollection withAll: array.
+	].
+	str << 'Time for quick-sort: ' << time printString <<' msecs '; cr.
+	"The merge-sort version"
+	time := Time millisecondsToRun:[
+		array mergeSortFrom: 1 to: array size by: [:v1 :v2| v1 <= v2].
+	].
+	str << 'Time for merge-sort: ' << time printString  << ' msecs'; cr.
+	]
+]
+
 { #category : #'instance creation' }
 Heap class >> new [
 	^self new: 10

--- a/src/Collections-Tests/HeapTest.class.st
+++ b/src/Collections-Tests/HeapTest.class.st
@@ -261,62 +261,6 @@ HeapTest >> firstIndex [
 	^2
 ]
 
-{ #category : #examples }
-HeapTest >> heapExample [	"HeapTest new heapExample"
-	"Create a sorted collection of numbers, remove the elements
-	sequentially and add new objects randomly.
-	Note: This is the kind of benchmark a heap is designed for."
-	| n rnd array time sorted |
-	n := 5000. "# of elements to sort"
-	rnd := Random new.
-	array := (1 to: n) collect:[:i| rnd next].
-	"First, the heap version"
-	time := Time millisecondsToRun:[
-		sorted := Heap withAll: array.
-		1 to: n do:[:i| 
-			sorted removeFirst.
-			sorted add: rnd next].
-	].
-	Transcript cr; show:'Time for Heap: ', time printString,' msecs'.
-	"The quicksort version"
-	time := Time millisecondsToRun:[
-		sorted := SortedCollection withAll: array.
-		1 to: n do:[:i| 
-			sorted removeFirst.
-			sorted add: rnd next].
-	].
-	Transcript cr; show:'Time for SortedCollection: ', time printString,' msecs'.
-
-]
-
-{ #category : #examples }
-HeapTest >> heapSortExample [	"HeapTest new heapSortExample"
-	"Sort a random collection of Floats and compare the results with
-	SortedCollection (using the quick-sort algorithm) and 
-	ArrayedCollection>>mergeSortFrom:to:by: (using the merge-sort algorithm)."
-	| n rnd array  time sorted |
-	n := 10000. "# of elements to sort"
-	rnd := Random new.
-	array := (1 to: n) collect:[:i| rnd next].
-	"First, the heap version"
-	time := Time millisecondsToRun:[
-		sorted := Heap withAll: array.
-		1 to: n do:[:i| sorted removeFirst].
-	].
-	Transcript cr; show:'Time for heap-sort: ', time printString,' msecs'.
-	"The quicksort version"
-	time := Time millisecondsToRun:[
-		sorted := SortedCollection withAll: array.
-	].
-	Transcript cr; show:'Time for quick-sort: ', time printString,' msecs'.
-	"The merge-sort version"
-	time := Time millisecondsToRun:[
-		array mergeSortFrom: 1 to: array size by: [:v1 :v2| v1 <= v2].
-	].
-	Transcript cr; show:'Time for merge-sort: ', time printString,' msecs'.
-
-]
-
 { #category : #requirements }
 HeapTest >> indexArray [
 	" return a Collection including indexes between bounds of 'nonEmpty' "
@@ -561,8 +505,8 @@ HeapTest >> testDo [
 
 { #category : #tests }
 HeapTest >> testExamples [
-	self heapExample.
-	self heapSortExample
+	Heap heapExample.
+	Heap heapSortExample
 ]
 
 { #category : #'basic tests' }


### PR DESCRIPTION
Move heapExample to the class Heap and remove transcript references