### PR TITLE
21998 Cleanup Keymapping-Tests

### DIFF
--- a/src/Keymapping-Tests/AbstractKeymappingTest.class.st
+++ b/src/Keymapping-Tests/AbstractKeymappingTest.class.st
@@ -15,7 +15,7 @@ Class {
 		'default'
 	],
 	#category : #'Keymapping-Tests'
-} 
+}
 
 { #category : #testing }
 AbstractKeymappingTest class >> isAbstract [

--- a/src/Keymapping-Tests/KMCategoryTest.class.st
+++ b/src/Keymapping-Tests/KMCategoryTest.class.st
@@ -1,3 +1,6 @@
+"
+SUnit tests for key mapping categories
+"
 Class {
 	#name : #KMCategoryTest,
 	#superclass : #AbstractKeymappingTest,
@@ -18,9 +21,9 @@ KMCategoryTest >> testAddKeymapToCategory [
 	categoryToAdd := KMCategory named: #TestCategory.
 	entry := KMKeymap named: #Foo shortcut: $a asKeyCombination, $b asKeyCombination, $c asKeyCombination action: [ "nothing" ].
 
-	self assert: (categoryToAdd allEntries) size = 0.
+	self assert: (categoryToAdd allEntries) size equals: 0.
 	categoryToAdd addKeymapEntry: entry.
-	self assert: (categoryToAdd allEntries) size = 1.
+	self assert: (categoryToAdd allEntries) size equals: 1
 ]
 
 { #category : #tests }
@@ -28,10 +31,10 @@ KMCategoryTest >> testCreateExistentCategoryFails [
 	| categoryToAdd |
 	categoryToAdd := KMCategory named: #TestCategory.
 	
-	self assert: self categoryContainer categories size = 0.
+	self assert: self categoryContainer categories size equals: 0.
 	self categoryContainer addCategory: categoryToAdd.
-	self assert: self categoryContainer categories size = 1.
-	self should: [self categoryContainer addCategory: categoryToAdd] raise: Error.
+	self assert: self categoryContainer categories size equals: 1.
+	self should: [self categoryContainer addCategory: categoryToAdd] raise: Error
 ]
 
 { #category : #tests }
@@ -39,8 +42,8 @@ KMCategoryTest >> testCreateUnexistentCategory [
 	| categoryToAdd |
 	categoryToAdd := KMCategory named: #TestCategory.
 	
-	self assert: self categoryContainer categories size = 0.
+	self assert: self categoryContainer categories size equals: 0.
 	self categoryContainer addCategory: categoryToAdd.
-	self assert: self categoryContainer categories size = 1.
-	self assert: (self categoryContainer includesCategory: categoryToAdd).
+	self assert: self categoryContainer categories size equals: 1.
+	self assert: (self categoryContainer includesCategory: categoryToAdd)
 ]

--- a/src/Keymapping-Tests/KMCombinationTests.class.st
+++ b/src/Keymapping-Tests/KMCombinationTests.class.st
@@ -1,3 +1,6 @@
+"
+SUnit tests for key combinations
+"
 Class {
 	#name : #KMCombinationTests,
 	#superclass : #AbstractKeymappingTest,
@@ -15,7 +18,7 @@ KMCombinationTests >> testCombinationOfSimpleShortcuts [
 	self assert: (combination includes: shortcut).
 	self assert: (combination includes: otherShortcut).
 	
-	self assert: ((combination collect: #platform) allSatisfy: [ :p | p = #all ]).
+	self assert: ((combination collect: #platform) allSatisfy: [ :p | p = #all ])
 ]
 
 { #category : #tests }
@@ -28,7 +31,7 @@ KMCombinationTests >> testCombinationSeveralShortcuts [
 	self assert: (platforms includes: #MacOSX).
 	self assert: (platforms includes: #Windows).
 	self assert: (platforms includes: #Unix).
-	self assert: (platforms includes: #all).
+	self assert: (platforms includes: #all)
 ]
 
 { #category : #tests }
@@ -36,9 +39,9 @@ KMCombinationTests >> testMacDependentShortcut [
 	| shortcut |
 	shortcut := $a ctrl mac.
 	
-	self assert: (shortcut shortcut = $a ctrl).
+	self assert: shortcut shortcut equals: $a ctrl.
 	
-	self assert: shortcut platform equals: #MacOSX.
+	self assert: shortcut platform equals: #MacOSX
 ]
 
 { #category : #tests }
@@ -55,9 +58,9 @@ KMCombinationTests >> testPlatformDependentShortcut [
 	| shortcut |
 	shortcut := $a ctrl win.
 	
-	self assert: (shortcut shortcut = $a ctrl).
+	self assert: shortcut shortcut equals: $a ctrl.
 	
-	self assert: shortcut platform equals: #Windows.
+	self assert: shortcut platform equals: #Windows
 ]
 
 { #category : #tests }
@@ -65,7 +68,7 @@ KMCombinationTests >> testShortcutIsSimpleCombination [
 	| shortcut |
 	shortcut := $a command.
 	self assert: (shortcut includes: shortcut).
-	self assert: shortcut shortcut equals: shortcut.
+	self assert: shortcut shortcut equals: shortcut
 ]
 
 { #category : #tests }
@@ -73,9 +76,9 @@ KMCombinationTests >> testUnixDependentShortcut [
 	| shortcut |
 	shortcut := $a ctrl unix.
 	
-	self assert: (shortcut shortcut = $a ctrl).
+	self assert: shortcut shortcut equals: $a ctrl.
 	
-	self assert: shortcut platform equals: #Unix.
+	self assert: shortcut platform equals: #Unix
 ]
 
 { #category : #tests }
@@ -92,7 +95,7 @@ KMCombinationTests >> testWindowsDependentShortcut [
 	| shortcut |
 	shortcut := $a ctrl win.
 	
-	self assert: (shortcut shortcut = $a ctrl).
+	self assert: shortcut shortcut equals: $a ctrl.
 	
-	self assert: shortcut platform equals: #Windows.
+	self assert: shortcut platform equals: #Windows
 ]

--- a/src/Keymapping-Tests/KMDispatchChainTest.class.st
+++ b/src/Keymapping-Tests/KMDispatchChainTest.class.st
@@ -1,3 +1,6 @@
+"
+SUnit tests for testing the dispatch chain
+"
 Class {
 	#name : #KMDispatchChainTest,
 	#superclass : #AbstractKeymappingTest,
@@ -10,7 +13,7 @@ KMDispatchChainTest >> testGlobalIsFirst [
 	first := nil.
 	chain := KMDispatchChain from: (KmGlobalDispatcher new) andDispatcher: (KMDispatcher new).
 	chain do: [ :target | first ifNil: [ first := target ] ].
-	self assert: first isGlobalDispatcher.
+	self assert: first isGlobalDispatcher
 ]
 
 { #category : #tests }
@@ -27,5 +30,5 @@ KMDispatchChainTest >> testPassesOnTheTarget [
 KMDispatchChainTest >> testTargetDoesNotIterateTheNil [
 	| chain |
 	chain := KMDispatchChain from: (KmGlobalDispatcher new) andDispatcher: (KMDispatcher new).
-	chain do: [ :target | self assert: target notNil ].
+	chain do: [ :target | self assert: target notNil ]
 ]

--- a/src/Keymapping-Tests/KMDispatcherTestCase.class.st
+++ b/src/Keymapping-Tests/KMDispatcherTestCase.class.st
@@ -1,3 +1,6 @@
+"
+SUnit tests for the key mapping dispatcher
+"
 Class {
 	#name : #KMDispatcherTestCase,
 	#superclass : #AbstractKeymappingTest,
@@ -32,16 +35,16 @@ KMDispatcherTestCase >> testBuffering [
 	event2 := self eventKey: $b.
 	morph kmDispatcher
 		dispatchKeystroke: event2.
-	self assert: morph kmDispatcher buffer size = 2.
-	self assert: morph kmDispatcher buffer first = event1.
-	self assert: morph kmDispatcher buffer second = event2.
+	self assert: morph kmDispatcher buffer size equals: 2.
+	self assert: morph kmDispatcher buffer first equals: event1.
+	self assert: morph kmDispatcher buffer second equals: event2.
 	
 	event3 := self eventKey: $c.
 	morph kmDispatcher
 		dispatchKeystroke: event3.
 	self assert: morph kmDispatcher buffer isEmpty.
 	
-	self assert: flag.
+	self assert: flag
 ]
 
 { #category : #tests }
@@ -62,7 +65,7 @@ KMDispatcherTestCase >> testDetach [
 	attachedCategories := morph kmDispatcher targets collect: [ :e | e category name ].
 	self assert: attachedCategories asArray equals: { #TestAnother }.
 
-	self should: [ morph detachKeymapCategory: #NonExistent ] raise: Error.
+	self should: [ morph detachKeymapCategory: #NonExistent ] raise: Error
 ]
 
 { #category : #tests }
@@ -89,7 +92,7 @@ KMDispatcherTestCase >> testNoMultiTrigger [
 	{self eventKey: $a. self eventKey: $b. self eventKey: $c}
 		do: [:e | bm2 dispatchKeystrokeForEvent: e].
 	self deny: flag1.
-	self assert: flag2.
+	self assert: flag2
 ]
 
 { #category : #tests }
@@ -121,5 +124,5 @@ KMDispatcherTestCase >> testNoStaggeredTrigger [
 		do: [:e | bm2 dispatchKeystrokeForEvent: e].
 	flag1 ifTrue: [ bufferBefore inspect ].
 	self deny: flag1.
-	self assert: flag2.
+	self assert: flag2
 ]

--- a/src/Keymapping-Tests/KMKeymapBuilderTest.class.st
+++ b/src/Keymapping-Tests/KMKeymapBuilderTest.class.st
@@ -1,11 +1,14 @@
+"
+SUnit tests for key map builder
+"
 Class {
-	#name : #KeymapBuilderTest,
+	#name : #KMKeymapBuilderTest,
 	#superclass : #AbstractKeymappingTest,
 	#category : #'Keymapping-Tests'
 }
 
 { #category : #tests }
-KeymapBuilderTest >> testAddKeymapCreatesCategory [
+KMKeymapBuilderTest >> testAddKeymapCreatesCategory [
 	self assert: KMRepository default categories isEmpty.
 	
 	KMRepository default
@@ -16,11 +19,11 @@ KeymapBuilderTest >> testAddKeymapCreatesCategory [
 		platform: #all.
 	
 	self assert: (KMRepository default includesCategoryNamed: #Testing).
-	self assert: KMRepository default categories size = 1.
+	self assert: KMRepository default categories size equals: 1
 ]
 
 { #category : #tests }
-KeymapBuilderTest >> testAddKeymapCreatesShortcut [
+KMKeymapBuilderTest >> testAddKeymapCreatesShortcut [
 	KMRepository default
 		initializeKeymap: #test
 		executingOn: $r ctrl, $r asKeyCombination, $r asKeyCombination
@@ -28,11 +31,11 @@ KeymapBuilderTest >> testAddKeymapCreatesShortcut [
 		inCategory: #Testing
 		platform: #all.
 	
-	self assert: (KMRepository default categoryForName: #Testing ) allEntries size = 1.
+	self assert: (KMRepository default categoryForName: #Testing) allEntries size equals: 1
 ]
 
 { #category : #tests }
-KeymapBuilderTest >> testAttachKeymapAndExecuteExecutes [
+KMKeymapBuilderTest >> testAttachKeymapAndExecuteExecutes [
 	| executed morphToTest |
 	executed := false.
 	
@@ -43,7 +46,7 @@ KeymapBuilderTest >> testAttachKeymapAndExecuteExecutes [
 		inCategory: #Testing
 		platform: #all.
 
-"	KMFactory keymapContainer attachCategoryName: #Testing to: Morph."
+	"KMFactory keymapContainer attachCategoryName: #Testing to: Morph."
 	
 	morphToTest := Morph new.
 	morphToTest attachKeymapCategory: #Testing.
@@ -51,5 +54,5 @@ KeymapBuilderTest >> testAttachKeymapAndExecuteExecutes [
 	{self eventKey: $a. self eventKey: $a. self eventKey: $a}
 		do: [:e | morphToTest dispatchKeystrokeForEvent: e].
 		
-	self assert: executed.
+	self assert: executed
 ]

--- a/src/Keymapping-Tests/KMKeymapTest.class.st
+++ b/src/Keymapping-Tests/KMKeymapTest.class.st
@@ -1,3 +1,6 @@
+"
+SUnit tests for the key map
+"
 Class {
 	#name : #KMKeymapTest,
 	#superclass : #AbstractKeymappingTest,
@@ -49,5 +52,5 @@ KMKeymapTest >> testMatching [
 	self assert: (category matches: {p}).
 	self assert: (category matchesCompletely: {p. p.}).
 	self deny: (category matches: {a. p. p}).
-	self deny: (category matches: {self eventKey: $l. self eventKey: $m. self eventKey: $n. self eventKey: $o}).
+	self deny: (category matches: {self eventKey: $l. self eventKey: $m. self eventKey: $n. self eventKey: $o})
 ]

--- a/src/Keymapping-Tests/KMPerInstanceTests.class.st
+++ b/src/Keymapping-Tests/KMPerInstanceTests.class.st
@@ -1,3 +1,6 @@
+"
+SUnit tests for key mapping per instance
+"
 Class {
 	#name : #KMPerInstanceTests,
 	#superclass : #AbstractKeymappingTest,
@@ -13,5 +16,5 @@ KMPerInstanceTests >> testAddMoreThanOneHandler [
 	morph on: $j do: [ flag := flag + 6 ].
 	{ self eventKey: $i. self eventKey: $j }
 		do: [:e | morph dispatchKeystrokeForEvent: e].
-	self assert: flag equals: 7.
+	self assert: flag equals: 7
 ]

--- a/src/Keymapping-Tests/KMShortcutTest.class.st
+++ b/src/Keymapping-Tests/KMShortcutTest.class.st
@@ -1,3 +1,6 @@
+"
+SUnit tests for key mapping shortcuts
+"
 Class {
 	#name : #KMShortcutTest,
 	#superclass : #AbstractKeymappingTest,
@@ -6,14 +9,14 @@ Class {
 
 { #category : #tests }
 KMShortcutTest >> testAsString [
-	self assert: $a asShortcut asString = 'a'.
-	self assert: $A asShortcut asString = 'A'.
-	self assert: $a ctrl asString = 'Ctrl + a'.
-	self assert: $A ctrl asString = 'Ctrl + A'.
-	self assert: $b command asString = 'Cmd + b'.
-	self assert: $c shift asString = 'Shift + c'.
-	self assert: $d alt asString = 'Alt + d'.
-	self assert: $e ctrl command asString =  (KMCtrlModifier new asString ,' + ' , KMCommandModifier new asString,' + e').
+	self assert: $a asShortcut asString equals: 'a'.
+	self assert: $A asShortcut asString equals: 'A'.
+	self assert: $a ctrl asString equals: 'Ctrl + a'.
+	self assert: $A ctrl asString equals: 'Ctrl + A'.
+	self assert: $b command asString equals: 'Cmd + b'.
+	self assert: $c shift asString equals: 'Shift + c'.
+	self assert: $d alt asString equals: 'Alt + d'.
+	self assert: $e ctrl command asString equals: (KMCtrlModifier new asString ,' + ' , KMCommandModifier new asString,' + e')
 	
 	
 
@@ -26,27 +29,27 @@ KMShortcutTest >> testBadComposedCmdShortcutFails [
 
 { #category : #tests }
 KMShortcutTest >> testChainIntegerSucceds [
-	^ self assert: ($e ctrl , 1) = ($e ctrl , 1)
+	^ self assert: ($e ctrl , 1) equals: ($e ctrl , 1)
 ]
 
 { #category : #tests }
 KMShortcutTest >> testChainShortcutSucceds [
-	^ self assert: ($e ctrl , $e ctrl) = ($e ctrl , $e ctrl)
+	^ self assert: ($e ctrl , $e ctrl) equals: ($e ctrl , $e ctrl)
 ]
 
 { #category : #tests }
 KMShortcutTest >> testChainSimpleCharsSucceds [
-	^ self assert: ($e ctrl , $e) = ($e ctrl , $e)
+	^ self assert: ($e ctrl , $e) equals: ($e ctrl , $e)
 ]
 
 { #category : #tests }
 KMShortcutTest >> testCmdIntegerSucceds [
-	^ self assert: 1 ctrl = 1 ctrl
+	^ self assert: 1 ctrl equals: 1 ctrl
 ]
 
 { #category : #tests }
 KMShortcutTest >> testCmdKeySucceds [
-	^ self assert: $e ctrl = $e ctrl
+	^ self assert: $e ctrl equals: $e ctrl
 ]
 
 { #category : #tests }
@@ -68,7 +71,7 @@ KMShortcutTest >> testComplexChainMatches [
 
 	self deny: (($e ctrl, $e shift, $f) matchesCompletely: {eCtrl}).
 	self deny: (($e ctrl, $e shift, $f) matchesCompletely: {eCtrl. eShift}).
-	self assert: (($e ctrl, $e shift, $f) matchesCompletely: {eCtrl. eShift. f}).
+	self assert: (($e ctrl, $e shift, $f) matchesCompletely: {eCtrl. eShift. f})
 ]
 
 { #category : #tests }
@@ -81,7 +84,7 @@ KMShortcutTest >> testCreation [
 { #category : #tests }
 KMShortcutTest >> testEventCodes [
 	self assert: $s meta modifier eventCode 
-		 equals: OSPlatform current defaultModifier eventCode 
+		  equals: OSPlatform current defaultModifier eventCode 
 ]
 
 { #category : #tests }
@@ -107,12 +110,12 @@ KMShortcutTest >> testModifiedShortcutsMatch [
 	self assert: ($a ctrl matchesCompletely: {a}).
 	self assert: ($1 shift matchesCompletely: {oneShift}).
 	self assert: ($1 command matchesCompletely: {oneCommand}).
-	self assert: ($1 command shift matchesCompletely: {oneCommandShift}).
+	self assert: ($1 command shift matchesCompletely: {oneCommandShift})
 ]
 
 { #category : #tests }
 KMShortcutTest >> testShiftKeySucceds [
-	^ self assert: $e shift = $e shift
+	^ self assert: $e shift equals: $e shift
 ]
 
 { #category : #tests }
@@ -125,7 +128,7 @@ KMShortcutTest >> testSimpleChainMatches [
 	self assert: ($e ctrl matches: {eCtrl. e}).
 	
 	self deny: (($e ctrl, $e) matches: {eCtrl. self eventKey: $a}).
-	self deny: ($e ctrl matches: {e}).
+	self deny: ($e ctrl matches: {e})
 ]
 
 { #category : #tests }
@@ -142,10 +145,10 @@ KMShortcutTest >> testSingleShortcutsMatch [
 	self deny: ($b asKeyCombination matches: {a}).
 	
 	self assert: ($a asKeyCombination matchesCompletely: {a}).
-	self assert: (1 asKeyCombination matchesCompletely: {one}).
+	self assert: (1 asKeyCombination matchesCompletely: {one})
 ]
 
 { #category : #tests }
 KMShortcutTest >> testTripleChainShortcutSucceds [
-	^ self assert: ($e ctrl , $e ctrl , $d ctrl) = ($e ctrl , $e ctrl , $d ctrl)
+	^ self assert: ($e ctrl , $e ctrl , $d ctrl) equals: ($e ctrl , $e ctrl , $d ctrl)
 ]


### PR DESCRIPTION
- comment the classes
- follow the prefix KM for all tests
- use assert:equals:
- remove unnecessary dots

https://pharo.fogbugz.com/f/cases/21998/Cleanup-Keymapping-Tests