### PR TITLE
21951-Deprecate-FileDoesNotExist

### DIFF
--- a/src/FileSystem-Core/AbstractFileReference.class.st
+++ b/src/FileSystem-Core/AbstractFileReference.class.st
@@ -85,6 +85,13 @@ AbstractFileReference >> asFileReference [
 	self subclassResponsibility 
 ]
 
+{ #category : #converting }
+AbstractFileReference >> asPath [
+	"Answer the receiver's path"
+
+	self subclassResponsibility 
+]
+
 { #category : #delegated }
 AbstractFileReference >> asPathWith: anObject [
 	^ self resolve asPathWith: anObject

--- a/src/FileSystem-Core/FileDoesNotExist.class.st
+++ b/src/FileSystem-Core/FileDoesNotExist.class.st
@@ -6,3 +6,10 @@ Class {
 	#superclass : #FileSystemError,
 	#category : #'FileSystem-Core-Kernel-Errors'
 }
+
+{ #category : #deprecation }
+FileDoesNotExist class >> isDeprecated [
+	"Use FileDoesNotExistException instead"
+
+	^true
+]

--- a/src/FileSystem-Core/FileLocator.class.st
+++ b/src/FileSystem-Core/FileLocator.class.st
@@ -378,6 +378,13 @@ FileLocator >> asFileReference [
 	^ self resolve
 ]
 
+{ #category : #converting }
+FileLocator >> asPath [
+	"Answer the receiver's path"
+
+	^self resolve asPath
+]
+
 { #category : #'streams-compatibility' }
 FileLocator >> binaryReadStream [
 	^ self resolve binaryReadStream

--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -82,6 +82,13 @@ FileReference >> asFileReference [
 	^ self
 ]
 
+{ #category : #converting }
+FileReference >> asPath [
+	"Answer the receivers path"
+
+	^path
+]
+
 { #category : #streams }
 FileReference >> binaryReadStream [
 	

--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -240,7 +240,7 @@ DiskStore >> delete: path [
 	| pathString encodedPathString |
 	
 	(self exists: path)
-		ifFalse: [ ^ FileDoesNotExist signalWith: path ].
+		ifFalse: [ ^ FileDoesNotExistException signalWith: path ].
 		
 	pathString := self stringFromPath: path.
 	encodedPathString := File encodePathString: pathString.

--- a/src/FileSystem-Disk/FileHandle.class.st
+++ b/src/FileSystem-Disk/FileHandle.class.st
@@ -139,7 +139,7 @@ FileHandle >> startUp [
 { #category : #public }
 FileHandle >> streamError [
 	reference exists
-		ifFalse: [FileDoesNotExist signalWith: reference].
+		ifFalse: [FileDoesNotExistException signalWith: reference].
 	self error: 'Unable to open file ' , reference printString
 ]
 

--- a/src/FileSystem-Memory/MemoryFileSystemDirectory.class.st
+++ b/src/FileSystem-Memory/MemoryFileSystemDirectory.class.st
@@ -67,7 +67,7 @@ MemoryFileSystemDirectory >> fileEntryAt: aFileName put: anEntry [
 
 { #category : #accessing }
 MemoryFileSystemDirectory >> fileEntryRemove: aFileName [
-	^ self fileEntryRemove: aFileName ifAbsent: [ FileDoesNotExist signalWith: aFileName ]
+	^ self fileEntryRemove: aFileName ifAbsent: [ FileDoesNotExistException signalWith: aFileName ]
 ]
 
 { #category : #accessing }

--- a/src/FileSystem-Memory/MemoryStore.class.st
+++ b/src/FileSystem-Memory/MemoryStore.class.st
@@ -158,7 +158,7 @@ MemoryStore >> delete: path [
 	self 
 		nodeAt: path parent
 		ifPresent: [ :dict | 
-			dict fileEntryRemove: path basename ifAbsent: [ FileDoesNotExist signalWith: path ]] 
+			dict fileEntryRemove: path basename ifAbsent: [ FileDoesNotExistException signalWith: path ]] 
 		ifAbsent: [ DirectoryDoesNotExist signalWith: path parent ]
 ]
 

--- a/src/FileSystem-Tests-Core/FileSystemTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemTest.class.st
@@ -327,7 +327,7 @@ FileSystemTest >> testDelete [
 	
 	self 
 		should: [ reference delete ]
-		raise: FileDoesNotExist.
+		raise: FileDoesNotExistException.
 		
 		
 	reference := ( filesystem workingDirectory / 'file') ensureCreateFile.

--- a/src/Files/FileException.class.st
+++ b/src/Files/FileException.class.st
@@ -21,6 +21,14 @@ FileException class >> signalOnFile: aFile [
 	(self fileName: aFile name) signal
 ]
 
+{ #category : #'instance creation' }
+FileException class >> signalWith: aReference [
+	"Signal a new instance of the receiver with the supplied reference.
+	aReference is something that can be converted to a path, e.g. a String, Path or FileReference"
+
+	^(self fileName: aReference asPath pathString) signal
+]
+
 { #category : #exceptiondescription }
 FileException >> fileName [
 	^fileName

--- a/src/Zinc-FileSystem/ZnFileSystemUtils.class.st
+++ b/src/Zinc-FileSystem/ZnFileSystemUtils.class.st
@@ -128,11 +128,11 @@ ZnFileSystemUtils class >> newFileNamed: fileName do: block [
 ZnFileSystemUtils class >> oldFileNamed: fileName do: block [
 	^ fileName asFileReference 
 		readStreamDo: block
-		ifAbsent: [ FileDoesNotExist signalWith: fileName asFileReference ]
+		ifAbsent: [ FileDoesNotExistException signalWith: fileName asFileReference ]
 ]
 
 { #category : #streams }
 ZnFileSystemUtils class >> oldFileStreamFor: fileName [
 	^ fileName asFileReference 
-		readStreamIfAbsent: [ FileDoesNotExist signalWith: fileName asFileReference ]
+		readStreamIfAbsent: [ FileDoesNotExistException signalWith: fileName asFileReference ]
 ]


### PR DESCRIPTION
21951 Deprecate FileDoesNotExist

https://pharo.fogbugz.com/f/cases/21951/Deprecate-FileDoesNotExist

In #18414 [1] most references to FileDoesNotExist were replaced with
FileDoesNotExistException, there were 7 left behind:

- DiskStore>>delete:
- FileHandle>>streamError
- FileSystemTest>>testDelete
- MemoryFileSystemDirectory>>fileEntryRemove:
- MemoryStore>>delete:
- ZnFileSystemUtils class>>oldFileNamed:do:
- ZnFileSystemUtils class>>oldFileStreamFor:

This leaves the image with the inconsistent behaviour where:

'doesnt.exist' asFileReference creationTime

and most other operations raises a FileDoesNotExistException.  
While:

'doesnt.exist' asFileReference delete

raises FileDoesNotExist.

Additional changes to be made include removing the 'Exception' suffix from the class names and consolodating the remaining exceptions.