### PR TITLE
22008-Move-GTPlaygroundBasicTest-cleaning-to-tearDown

### DIFF
--- a/src/GT-Tests-Playground/GTPlaygroundBasicTest.class.st
+++ b/src/GT-Tests-Playground/GTPlaygroundBasicTest.class.st
@@ -16,9 +16,9 @@ GTPlaygroundBasicTest >> setUp [
 
 { #category : #running }
 GTPlaygroundBasicTest >> tearDown [
-
 	window ifNotNil: [ window delete ].
 	window := nil.
+	(RPackageOrganizer default packageNamed: 'GTMockTests' ifAbsent: [ "No package to delete" ]) ifNotNil: #removeFromSystem.
 	playground := nil.
 	super tearDown
 ]
@@ -43,48 +43,46 @@ GTPlaygroundBasicTest >> testAccessBindings [
 
 { #category : #running }
 GTPlaygroundBasicTest >> testPageActionsIn [
-
 	| actions selector action |
-	selector := playground class 
-		compile: 'mockMethodPageAction
+	selector := playground class
+		compile:
+			'mockMethodPageAction
 	<pageActionOrder: 10>
 	^ GLMGenericAction new
 		action: [ :presentation | self inform: ''page action works'' ];
 		iconNamed: #abstract;
-		title: ''A mock page action''' 
+		title: ''A mock page action'''
 		classified: '*GTMockTests'.
 		
-	self assert: selector notNil.
+	[ self assert: selector notNil.
 	window := playground openOn: (GTPlayPage new saveContent: 'a:=1. b:=a+1').
 	actions := playground pageActions.
 	self deny: actions size isZero.
 	action := actions detect: [ :eachAction | eachAction title = 'A mock page action' ].
-	self deny: action isNil.
-	playground class removeSelector: selector.
-	'GTMockTests' asPackage removeFromSystem.
+	self deny: action isNil ]
+		ensure: [ playground class removeSelector: selector ]
 ]
 
 { #category : #running }
 GTPlaygroundBasicTest >> testPlaygroundActionsIn [
-
 	| actions selector action |
-	selector := playground class 
-		compile: 'mockMethodPlaygrounAction
+	selector := playground class
+		compile:
+			'mockMethodPlaygrounAction
 	<playgroundActionOrder: 100>
 	^ GLMGenericAction new
 		action: [ :presentation | self inform: ''playground action works'' ];
 		iconNamed: #abstract;
-		title: ''A mock playground action''' 
+		title: ''A mock playground action'''
 		classified: '*GTMockTests'.
 		
-	self assert: selector notNil.
+	[ self assert: selector notNil.
 	window := playground openOn: (GTPlayPage new saveContent: 'a:=1. b:=a+1').
 	actions := playground playgroundActions.
 	self deny: actions size isZero.
 	action := actions detect: [ :eachAction | eachAction title = 'A mock playground action' ].
-	self deny: action isNil.
-	playground class removeSelector: selector.
-	'GTMockTests' asPackage removeFromSystem.
+	self deny: action isNil ]
+		ensure: [ playground class removeSelector: selector ]
 ]
 
 { #category : #running }


### PR DESCRIPTION
GTPlaygroundBasicTest: Move package removal to tearDown and add #ensure: block for cleaning.

https://pharo.fogbugz.com/f/cases/22008/Move-GTPlaygroundBasicTest-cleaning-to-tearDown