### PR TITLE
22000-Click-on-the-taskbar-empty-space-should-open-the-world-menu

### DIFF
--- a/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
@@ -282,6 +282,13 @@ TaskbarMorph >> preferredButtonCornerStyle [
 	^#square
 ]
 
+{ #category : #recategorized }
+TaskbarMorph >> rejectsEvent: anEvent [
+	(anEvent isMouse and: [ anEvent isMouseDown ]) ifTrue: [ ^ (self submorphs anySatisfy: [ :each | each containsPoint: anEvent cursorPoint ]) not ].
+	
+	^ super rejectsEvent: anEvent
+]
+
 { #category : #taskbar }
 TaskbarMorph >> removeFromWorld [
 	"Delete the receiver from its world after restoring minimized tasks.


### PR DESCRIPTION
Taskbar should not handle click event if it does not happen on a taskbar item.

Fix from Henrik Nergaard
https://pharo.fogbugz.com/f/cases/22000/Click-on-the-taskbar-empty-space-should-open-the-world-menu