### PR TITLE
21806-Document-Difference-between-ast-and-parseTree

### DIFF
--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -1,5 +1,19 @@
 "
 I am a simple cache for AST nodes corresponding to CompiledMethods in the image. The cache is emptied when the image is saved.
+
+The cached #ast is for one interesting for speed (that is, in situations where you ask for it often).
+
+The other use-case is if you want to annotate the AST and keep that annotation around (till the next image save, but you can subscribe to ASTCacheReset and re-install the AST in the cache after cleaning. (This is used by MetaLinks to make sure they survive image restart).
+
+The last thing that it provides is that we do have a quite powerful mapping between bytecode/text/context and the AST. Regardless how you navigate, you get the same object.
+
+e.g. even this one works:
+
+    [ 1+2 ] sourceNode == thisContext method ast blockNodes first
+
+**NOTE** due to the cached ast, Modification of the AST can be a problem.
+Code that wants to modify the AST without making sure the compiledMethod is in sync later should use #parseTree. 
+
 "
 Class {
 	#name : #ASTCache,

--- a/src/AST-Core/CompiledMethod.extension.st
+++ b/src/AST-Core/CompiledMethod.extension.st
@@ -2,11 +2,13 @@ Extension { #name : #CompiledMethod }
 
 { #category : #'*AST-Core' }
 CompiledMethod >> ast [
+	"return an AST for this method. The AST is cached. see class comment of ASTCache"
 	^ ASTCache at: self
 ]
 
 { #category : #'*AST-Core' }
 CompiledMethod >> parseTree [
+	"returns an AST for this method, do not cache it. (see #ast for the cached alternative)"
 	^(RBParser 
 		parseMethod: self sourceCode 
 		onError: [ :msg :pos | 


### PR DESCRIPTION
Document Difference between #ast and #parseTree
https://pharo.fogbugz.com/f/cases/21806/Document-Difference-between-ast-and-parseTree