### PR TITLE
21700-When-closing-a-method-explorer-window-with-tabs-the-changes-are-discarded-without-warning

### DIFF
--- a/src/Morphic-Widgets-Windows/GroupWindowMorph.class.st
+++ b/src/Morphic-Widgets-Windows/GroupWindowMorph.class.st
@@ -154,6 +154,12 @@ GroupWindowMorph >> offerWindowMenu [
 	aMenu popUpEvent: self currentEvent in: self world
 ]
 
+{ #category : #'model - updating' }
+GroupWindowMorph >> okToChange [
+
+    ^self tabGroup pages allSatisfy: [ :each | each model okToChange ]
+]
+
 { #category : #windows }
 GroupWindowMorph >> onWindowLabelChanged: ann [
 	self tabGroup relabelPage: ann window with: (self tabLabelFor: ann window)  
@@ -163,13 +169,14 @@ GroupWindowMorph >> onWindowLabelChanged: ann [
 GroupWindowMorph >> removeWindow: aSystemWindow [
 	"Remove a window from the pages."
 
+	aSystemWindow isCloseable
+		ifFalse: [ ^ self ].
 	aSystemWindow announcer unsubscribe: self.
 	self tabGroup removePage: aSystemWindow.
 	aSystemWindow configureForUnembedding.
 	"self world addMorph: aSystemWindow"
-	aSystemWindow delete.
-	self tabGroup pages size = 0 
-		ifTrue: [ self owner delete ]
+	aSystemWindow deleteDiscardingChanges.
+	self tabGroup pages ifEmpty: [ self owner delete ]
 ]
 
 { #category : #accessing }

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -564,17 +564,15 @@ SystemWindow >> createBox [
 
 { #category : #'menu actions' }
 SystemWindow >> createWindowGroup [
-
-  | group pos ext |
-  
-  pos := self position.
-  ext := self extent.
-  group := GroupWindowMorph new.
-  group addWindow: self.
-  (group openInWindowLabeled: 'Group: ' translated, self label) 
-    extent: ext;
-    position: pos.
-  
+	| group pos ext |
+	pos := self position.
+	ext := self extent.
+	group := GroupWindowMorph new.
+	group addWindow: self.
+	(group openInWindowLabeled: 'Group: ' translated , self label)
+		extent: ext;
+		position: pos;
+		model: group
 ]
 
 { #category : #initialization }
@@ -600,34 +598,11 @@ SystemWindow >> delete [
 	"Should activate window before asking model if okToChange
 	since likely that a confirmation dialog will be requested.
 	Don't if not owned by the world though."
-	
-	| thisWorld animateClose announcement |
-	self mustNotClose ifTrue: [^ self].
-	"(self owner notNil and: [self owner isWorldMorph])
-		ifTrue: [self activate]."
-		
-	model ifNotNil: [ model okToChange ifFalse: [ ^ self ] ].
-	animateClose := (self visible and: [self world notNil and: [
-		self theme settings animationSettings useAnimation and: [
-		self theme settings animationSettings animateClosing]]]).
-	self removePaneSplitters. "in case we add some panes and reopen!"
-	thisWorld := self world.
-	self isFlexed
-		ifTrue: [owner delete]
-		ifFalse: [super delete].
-	model ifNotNil: [ 
-		model 
-			windowIsClosing; 
-			releaseActionMap ].
-	model := nil.
-	animateClose ifTrue: [self animateClose].	
-	SystemWindow noteTopWindowIn: thisWorld.
-	announcement := (WindowClosed new 
-						window: self; 
-						yourself).
-	self announce: announcement.
-	World announcer announce: announcement
 
+	"in case we add some panes and reopen!"
+	self isCloseable
+		ifFalse: [ ^ self ].
+	self deleteDiscardingChanges
 ]
 
 { #category : #'menu actions' }
@@ -635,6 +610,33 @@ SystemWindow >> deleteCloseBox [
 	closeBox ifNotNil:
 		[closeBox delete.
 		closeBox := nil]
+]
+
+{ #category : #'open/close' }
+SystemWindow >> deleteDiscardingChanges [
+	| thisWorld announcement animateClose |
+	animateClose := self visible
+		and: [ self world notNil
+				and: [ self theme settings animationSettings useAnimation
+						and: [ self theme settings animationSettings animateClosing ] ] ].
+	self removePaneSplitters.	"in case we add some panes and reopen!"
+	thisWorld := self world.
+	self isFlexed
+		ifTrue: [ owner delete ]
+		ifFalse: [ super delete ].
+	model
+		ifNotNil: [ model
+				windowIsClosing;
+				releaseActionMap ].
+	model := nil.
+	animateClose
+		ifTrue: [ self animateClose ].
+	SystemWindow noteTopWindowIn: thisWorld.
+	announcement := WindowClosed new
+		window: self;
+		yourself.
+	self announce: announcement.
+	World announcer announce: announcement
 ]
 
 { #category : #'menu building' }
@@ -893,6 +895,11 @@ SystemWindow >> initializeShortcuts: aKMDispatcher [
 
 	super initializeShortcuts: aKMDispatcher.
 	aKMDispatcher attachCategory: #WindowShortcuts	
+]
+
+{ #category : #testing }
+SystemWindow >> isCloseable [
+	^ self mustNotClose not and: [ model ifNotNil: [ model okToChange ] ifNil: [ true ] ]
 ]
 
 { #category : #'resize/collapse' }


### PR DESCRIPTION
Solve https://pharo.fogbugz.com/f/cases/21700/When-closing-a-method-explorer-window-with-tabs-the-changes-are-discarded-without-warning