### PR TITLE
22050-Menubar-should-reject-event-that-are-not-on-the-menu-to-let-the-user-drag-its-windows

### DIFF
--- a/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
+++ b/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
@@ -100,6 +100,13 @@ MenubarMorph >> open [
 		openInWorld
 ]
 
+{ #category : #recategorized }
+MenubarMorph >> rejectsEvent: anEvent [
+	(anEvent isMouse and: [ anEvent isMouseDown ]) ifTrue: [ ^ (self submorphs anySatisfy: [ :each | each containsPoint: anEvent cursorPoint ]) not ].
+	
+	^ super rejectsEvent: anEvent
+]
+
 { #category : #accessing }
 MenubarMorph >> repelsMorph: aMorph event: ev [
 	^ true


### PR DESCRIPTION
Reject click evens in Menubar to be able to drag windows under it. (This does not reject click events on the Menubar items.

https://pharo.fogbugz.com/f/cases/22050/Menubar-should-reject-event-that-are-not-on-the-menu-to-let-the-user-drag-its-windows