### PR TITLE
22054-FreeType-FFI-Implementation-should-handle-errors-on-startup

### DIFF
--- a/src/FreeType/FT2Library.class.st
+++ b/src/FreeType/FT2Library.class.st
@@ -92,8 +92,7 @@ FT2Library >> getBitmap: ftBitmap fromOutline: outline [
 
 { #category : #testing }
 FT2Library >> isAvailable [
-	self checkLibrary.
-	"^ false."
+	[self checkLibrary] on:Error do: [^ false].
 	^ self isNull not
 ]
 


### PR DESCRIPTION
Handling the errors when it is not possible to use the library through FFI.

Issue: https://pharo.manuscript.com/f/cases/resolve/22054/FreeType-FFI-Implementation-should-handle-errors-on-startup