### PR TITLE
22056-Morphic-has-an-unwanted-dependency-on-Menubar

### DIFF
--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -401,12 +401,6 @@ WorldMorph >> listOfSteppingMorphs [
 "self currentWorld listOfSteppingMorphs"
 ]
 
-{ #category : #accessing }
-WorldMorph >> menubar [
-
-	^ self submorphs detect: [ :morph | morph isKindOf: MenubarMorph  ]
-]
-
 { #category : #'dropping/grabbing' }
 WorldMorph >> mouseDown: evt [
 	super mouseDown: evt.

--- a/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
+++ b/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
@@ -69,6 +69,11 @@ MenubarMorph >> initialize [
 	self cellInset: 7.
 ]
 
+{ #category : #testing }
+MenubarMorph >> isMenubar [
+	^ true
+]
+
 { #category : #accessing }
 MenubarMorph >> menuBarItems [
 	^ menuBarItems

--- a/src/Morphic-Widgets-Menubar/Morph.extension.st
+++ b/src/Morphic-Widgets-Menubar/Morph.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #Morph }
+
+{ #category : #'*Morphic-Widgets-Menubar' }
+Morph >> isMenubar [
+	"Answer false in the general case."
+
+	^false
+]

--- a/src/Morphic-Widgets-Menubar/WorldMorph.extension.st
+++ b/src/Morphic-Widgets-Menubar/WorldMorph.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #WorldMorph }
+
+{ #category : #'*Morphic-Widgets-Menubar' }
+WorldMorph >> menubar [
+
+	^ self submorphs detect: #isMenubar
+]


### PR DESCRIPTION
Remove Morphic-Core dependency to Morphic-Widgets-Menubar

https://pharo.fogbugz.com/f/cases/22056/Morphic-has-an-unwanted-dependency-on-Menubar