### PR TITLE
22058-TabMorph-should-handle-wheel-click-and-close-itself-like-in-most-software-as-web-browsers

### DIFF
--- a/src/Morphic-Widgets-Tabs/TabMorph.class.st
+++ b/src/Morphic-Widgets-Tabs/TabMorph.class.st
@@ -415,6 +415,11 @@ TabMorph >> backgroundColor [
 	^ state backgroundColor
 ]
 
+{ #category : #'meta-actions' }
+TabMorph >> blueButtonUp: anEvent [
+	self close
+]
+
 { #category : #'private-drawing' }
 TabMorph >> borderColor [
 	"I do not use #borderColor because I want a light border"
@@ -536,6 +541,13 @@ TabMorph >> extraSpaceForActions [
 		offsets := offsets +1 ].
 	
 	^ space + (offsets * self actionOffset)
+]
+
+{ #category : #'events-processing' }
+TabMorph >> handleMouseUp: anEvent [
+	anEvent blueButtonChanged
+		ifTrue: [ self blueButtonUp: anEvent ]
+		ifFalse: [ super handleMouseUp: anEvent ]
 ]
 
 { #category : #'event handling' }

--- a/src/Morphic-Widgets-Tabs/TabMorph.class.st
+++ b/src/Morphic-Widgets-Tabs/TabMorph.class.st
@@ -417,6 +417,7 @@ TabMorph >> backgroundColor [
 
 { #category : #'meta-actions' }
 TabMorph >> blueButtonUp: anEvent [
+	super blueButtonUp: anEvent.
 	self close
 ]
 


### PR DESCRIPTION
Close tabs on wheel click

https://pharo.fogbugz.com/f/cases/22058/TabMorph-should-handle-wheel-click-and-close-itself-like-in-most-software-as-web-browsers