### PR TITLE
22063-OSSDL2Driver-needs-to-clean-handlers-on-shutdown

### DIFF
--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -308,6 +308,15 @@ OSSDL2Driver >> setupEventLoop [
 		resume
 ]
 
+{ #category : #'system startup' }
+OSSDL2Driver >> shutDown [
+	"Reset WindowMap and JoystickMap when shuting down (otherwise there will be handlers 
+	 remaining on restart)"
+
+	WindowMap := nil.
+	JoystickMap := nil
+]
+
 { #category : #'global events' }
 OSSDL2Driver >> unregisterGlobalListener: globalListener [
 	"This method registers a global event listener.


### PR DESCRIPTION
https://pharo.manuscript.com/f/cases/22063/OSSDL2Driver-needs-to-clean-handlers-on-shutdown

fix issue #22063