### PR TITLE
22044-Old-compiler-API-deprecation-rule-is-incorrect

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -420,7 +420,7 @@ OpalCompiler >> evaluate: textOrString for: anObject logged: logFlag [
 		transformWith:
 			'`@receiver evaluate: `@statements1 for: `@statements2 logged: `@statements3'
 				->
-					'`@receiver source: `@statements1; logged: `@statements2; receiver: `@statements3; evaluate'.
+					'`@receiver source: `@statements1; logged: `@statements3; receiver: `@statements2; evaluate'.
 	^ self
 		source: textOrString;
 		logged: logFlag;

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -190,7 +190,12 @@ OCCompilerTest >> testInstanceVariableShadowing [
 
 { #category : #literals }
 OCCompilerTest >> testNegativeZero [
-	self assert: (OpalCompiler evaluate: '-0.0') hex = Float negativeZero hex.
+	self
+		assert:
+			(OpalCompiler new
+				source: '-0.0';
+				evaluate) hex
+		equals: Float negativeZero hex
 ]
 
 { #category : #'test shadowing' }


### PR DESCRIPTION
The method OpalCompiler class>>#evaluate: called from OCCompilerTest>>#testNegativeZero
https://pharo.fogbugz.com/f/cases/22044/Old-compiler-API-deprecation-rule-is-incorrect