### PR TITLE
22066-Menubar-should-be-able-to-add-separators

### DIFF
--- a/src/Morphic-Base/WorldState.extension.st
+++ b/src/Morphic-Base/WorldState.extension.st
@@ -110,7 +110,6 @@ WorldState class >> windowsOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #Windows)
 		order: 4.0;
-		withSeparatorAfter;
 		with: [ (aBuilder item: #'Collapse all windows')
 				action: [ World collapseAll ];
 				help: 'Reduce all open windows to collapsed forms that only show titles' translated.

--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -161,7 +161,7 @@ WorldState class >> pharoItemsOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #Pharo)
 		label: 'Pharo';
-		icon: (#pharo asIcon scaledToSize: 20 @ 20);
+		icon: ((self iconNamed: #pharo) scaledToSize: 20 @ 20);
 		order: 0;
 		with: [ (aBuilder item: #Save)
 				target: self;

--- a/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
+++ b/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
@@ -55,6 +55,11 @@ MenubarMorph class >> reset [
 	self open.
 ]
 
+{ #category : #construction }
+MenubarMorph >> addSeparator [
+	self addMorphBack: MenubarSeparatorMorph new
+]
+
 { #category : #adding }
 MenubarMorph >> drawSubmenuMarkerOn: aCanvas [
 
@@ -98,7 +103,8 @@ MenubarMorph >> open [
 			add: each label
 			icon: each icon
 			help: each help
-			subMenu: (each subMenu ifNotNil: #asMenuMorph) ].
+			subMenu: (each subMenu ifNotNil: #asMenuMorph).
+			each separator ifTrue: [ self addSeparator ] ].
 		
 	self
 		adhereToTop;

--- a/src/Morphic-Widgets-Menubar/MenubarSeparatorMorph.class.st
+++ b/src/Morphic-Widgets-Menubar/MenubarSeparatorMorph.class.st
@@ -1,0 +1,36 @@
+Class {
+	#name : #MenubarSeparatorMorph,
+	#superclass : #SimpleButtonMorph,
+	#category : #'Morphic-Widgets-Menubar'
+}
+
+{ #category : #initialization }
+MenubarSeparatorMorph >> defaultBorderWidth [
+	^ 0
+]
+
+{ #category : #initialization }
+MenubarSeparatorMorph >> defaultColor [
+	^ Color transparent
+]
+
+{ #category : #initialization }
+MenubarSeparatorMorph >> defaultLabel [
+	^ '|'
+]
+
+{ #category : #initialization }
+MenubarSeparatorMorph >> initialize [
+	super initialize.
+	self
+		color: self defaultColor;
+		borderWidth: self defaultBorderWidth
+]
+
+{ #category : #theme }
+MenubarSeparatorMorph >> themeChanged [
+	super themeChanged.
+	self
+		color: self defaultColor;
+		borderWidth: self defaultBorderWidth
+]


### PR DESCRIPTION
Menubar should manage the separators of its item. 

Fixes https://pharo.fogbugz.com/f/cases/22066/Menubar-should-be-able-to-add-separators