### PR TITLE
[IGNORE]22068-BaselineOfBasicTools-should-not-manage-the-TestRunner-whith-is-managed-in-SUnit

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -100,7 +100,6 @@ BaselineOfBasicTools >> postload: loader package: packageSpec [
 	"Ignore pre and post loads if already executed"
 	Initialized = true ifTrue: [ ^ self ].
 	
-	Smalltalk tools register: TestRunner as: #testRunner.
 	Smalltalk tools register: MCWorkingCopyBrowser as: #monticelloBrowser.
 	
 	BIConfigurableFormatter initialize.


### PR DESCRIPTION
Remove registery of TestRunner from BasicTools

https://pharo.fogbugz.com/f/cases/22068/BaselineOfBasicTools-should-not-manage-the-TestRunner-whith-is-managed-in-SUnit