### PR TITLE
22073-BaselineOfIDE-rely-on-deprecated-classes

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -960,9 +960,13 @@ BaselineOfIDE >> postload: loader package: packageSpec [
 
 	Smalltalk cleanOutUndeclared. 
 
-	FileStream stdout nextPutAll: ' ------------ Obsolete ------------'; lf.
-	FileStream stdout nextPutAll: SystemNavigation default obsoleteClasses asString; lf.
-	FileStream stdout nextPutAll: ' ............ Obsolete ............'; lf.
+	Stdio stdout 
+		nextPutAll: ' ------------ Obsolete ------------';
+		lf;
+		nextPutAll: SystemNavigation default obsoleteClasses asString;
+		lf;
+		nextPutAll: ' ............ Obsolete ............';
+		lf.
 
 	Smalltalk fixObsoleteReferences.
 	


### PR DESCRIPTION
Use Stdio instead of FileStream

https://pharo.fogbugz.com/f/cases/22073/BaselineOfIDE-rely-on-deprecated-classes