### PR TITLE
21225-Unknown-message-nonBlockTempsIn-sent-in-RBBasicLintRuleTestclasstempsReadBeforeWritten

### DIFF
--- a/src/Refactoring-Tests-Core/RBBasicLintRuleTest.class.st
+++ b/src/Refactoring-Tests-Core/RBBasicLintRuleTest.class.st
@@ -944,25 +944,6 @@ RBBasicLintRuleTest class >> tempVarOverridesInstVar [
 ]
 
 { #category : #'possible bugs' }
-RBBasicLintRuleTest class >> tempsReadBeforeWritten [
-	| detector |
-	detector := self new.
-	detector name: 'Temporaries read before written'.
-	detector methodBlock: 
-			[:context :result | 
-			| variables |
-			variables := RBParseTreeSearcher nonBlockTempsIn: context parseTree.
-			variables isEmpty 
-				ifFalse: 
-					[(RBReadBeforeWrittenTester variablesReadBeforeWrittenIn: context parseTree) 
-						do: 
-							[:each | 
-							result addClass: context selectedClass selector: context selector.
-							result addSearchString: each]]].
-	^detector
-]
-
-{ #category : #'possible bugs' }
 RBBasicLintRuleTest class >> threeElementPoint [
 	| detector matcher |
 	detector := self new.


### PR DESCRIPTION
Unknown message nonBlockTempsIn: sent in RBBasicLintRuleTest(class)>>#tempsReadBeforeWritten
https://pharo.fogbugz.com/f/cases/21225/Unknown-message-nonBlockTempsIn-sent-in-RBBasicLintRuleTest-class-tempsReadBeforeWritten