### PR TITLE
22092-Add-part-of-the-keyboard-suport-for-the-menubar

### DIFF
--- a/src/Morphic-Base/MenuMorph.class.st
+++ b/src/Morphic-Base/MenuMorph.class.st
@@ -196,7 +196,16 @@ MenuMorph class >> pushPinImage [
 { #category : #events }
 MenuMorph >> activate: evt [
 	"Receiver should be activated; e.g., so that control passes correctly."
+	evt hand newMouseFocus: self
+]
+
+{ #category : #events }
+MenuMorph >> activateFromKeyboard: evt [
+	"Receiver should be activated; e.g., so that control passes correctly."
 	evt hand newMouseFocus: self.
+	self activate: evt.
+	self takeKeyboardFocus.
+	self moveSelectionDown: 1 event: evt
 ]
 
 { #category : #control }

--- a/src/Morphic-Base/MenuMorph.class.st
+++ b/src/Morphic-Base/MenuMorph.class.st
@@ -965,94 +965,77 @@ MenuMorph >> justDroppedInto: aMorph event: evt [
 { #category : #events }
 MenuMorph >> keyStroke: evt [
 	"Handle keboard item matching."
-	
+
 	| matchString char asc selectable help |
-	help := self theme builder newBalloonHelp: 'Enter text to\narrow selection down\to matching items ' withCRs for: self corner: #topLeft.
+	help := self theme builder
+		newBalloonHelp: 'Enter text to\narrow selection down\to matching items ' withCRs
+		for: self
+		corner: #topLeft.
 	help popUpForHand: self activeHand.
-	(self rootMenu hasProperty: #hasUsedKeyboard) 
-		ifFalse: 
-			[self rootMenu setProperty: #hasUsedKeyboard toValue: true.
-			self changed].
-	(evt commandKeyPressed and: [self commandKeyHandler notNil]) 
-		ifTrue: 
-			[self commandKeyHandler commandKeyTypedIntoMenu: evt.
-			^self deleteIfPopUp: evt].
+	(self rootMenu hasProperty: #hasUsedKeyboard)
+		ifFalse: [ self rootMenu setProperty: #hasUsedKeyboard toValue: true.
+			self changed ].
+	(evt commandKeyPressed and: [ self commandKeyHandler notNil ])
+		ifTrue: [ self commandKeyHandler commandKeyTypedIntoMenu: evt.
+			^ self deleteIfPopUp: evt ].
 	char := evt keyCharacter.
 	asc := char asciiValue.
-	char = Character cr 
-		ifTrue: 
-			[selectedItem ifNotNil: 
-					[selectedItem hasSubMenu 
-						ifTrue: 
-							[evt hand newMouseFocus: selectedItem subMenu.
-							^evt hand newKeyboardFocus: selectedItem subMenu]
-						ifFalse: 
-							["self delete."
-
-							^selectedItem invokeWithEvent: evt]].
-			(selectable := self items) size = 1 
-				ifTrue: [^selectable first invokeWithEvent: evt].
-			^self].
-	asc = 27 
-		ifTrue: 
-			["escape key"
-
-			self valueOfProperty: #matchString
-				ifPresentDo: 
-					[:str | 
-					str isEmpty 
-						ifFalse: 
-							["If filtered, first ESC removes filter"
-
+	char = Character cr
+		ifTrue: [ selectedItem
+				ifNotNil: [ selectedItem hasSubMenu
+						ifTrue: [ evt hand newMouseFocus: selectedItem subMenu.
+							^ evt hand newKeyboardFocus: selectedItem subMenu ]
+						ifFalse: [ "self delete." ^ selectedItem invokeWithEvent: evt ] ].
+			(selectable := self items) size = 1
+				ifTrue: [ ^ selectable first invokeWithEvent: evt ].
+			^ self ].
+	asc = 27
+		ifTrue: [ "escape key"
+			self
+				valueOfProperty: #matchString
+				ifPresentDo: [ :str | 
+					str isEmpty
+						ifFalse: [ "If filtered, first ESC removes filter"
 							self setProperty: #matchString toValue: String new.
 							self selectItem: nil event: evt.
-							^self displayFiltered: evt]].
+							^ self displayFiltered: evt ] ].
 			"If a stand-alone menu, just delete it"
-			popUpOwner ifNil: [^self delete].
+			popUpOwner ifNil: [ ^ self delete ].
 			"If a sub-menu, then deselect, and return focus to outer menu"
-			^ self deselectAndFocusOutermenuOn: evt].
-		
+			^ self deselectAndFocusOutermenuOn: evt ].
+
 	"Left arrow key - If we are in a submenu, then we remove myself (i.e., the current morph) and move the focus to the owner popup"
-	(asc = 28)
-		ifTrue: [ 			
-				"If a stand-alone menu, do nothing"
-				popUpOwner ifNil: [^self].
-				"If a sub-menu, then deselect, and return focus to outer menu"
-				^ self deselectAndFocusOutermenuOn: evt].
-	
+	asc = 28 ifTrue: [ ^ self leftArrowStroked: evt ].
+
 	"Right arrow key - If the selected menu item has a submenu, then we move the focus to the submenu "
-	(asc = 29) 
-		ifTrue: 
-			["right arrow key"
-			(selectedItem notNil and: [selectedItem hasSubMenu]) 
-				ifTrue: 
-					[evt hand newMouseFocus: selectedItem subMenu.
-					selectedItem subMenu moveSelectionDown: 1 event: evt.
-					^evt hand newKeyboardFocus: selectedItem subMenu]].
-			
-	asc = 30 ifTrue: [^self moveSelectionDown: -1 event: evt].	"up arrow key"
-	asc = 31 ifTrue: [^self moveSelectionDown: 1 event: evt].	"down arrow key"
-	asc = 11 ifTrue: [^self moveSelectionDown: -5 event: evt].	"page up key"
-	asc = 12 ifTrue: [^self moveSelectionDown: 5 event: evt].	"page down key"
-		
+	asc = 29 ifTrue: [ (self rightArrowStroked: evt) ifTrue: [ ^ self ] ].
+	asc = 30
+		ifTrue: [ ^ self moveSelectionDown: -1 event: evt ].	"up arrow key"
+	asc = 31
+		ifTrue: [ ^ self moveSelectionDown: 1 event: evt ].	"down arrow key"
+	asc = 11
+		ifTrue: [ ^ self moveSelectionDown: -5 event: evt ].	"page up key"
+	asc = 12
+		ifTrue: [ ^ self moveSelectionDown: 5 event: evt ].	"page down key"
+
 	"If we reach this point, it means that we are editing the filter associated to each menu. "
 	"In case ther eis no filter associated to the menu, we simply create one"
-	matchString := self valueOfProperty: #matchString ifAbsentPut: [ String new ].
+	matchString := self
+		valueOfProperty: #matchString
+		ifAbsentPut: [ String new ].
 
 	"If we press the backspace, then we simply remove the last character from matchString"
 	(char = Character backspace and: [ matchString notEmpty ])
-		ifTrue: [ matchString := matchString allButLast. 
-				   self recordFiltering: matchString.
-				   self displayFiltered: evt. ].
-	
+		ifTrue: [ matchString := matchString allButLast.
+			self recordFiltering: matchString.
+			self displayFiltered: evt ].
+
 	"No need to go further if the character is not alphanumeric, i.e., not useful for filtering"
-	char isAlphaNumeric ifFalse: [ ^ self ].
-	matchString := matchString, char asString.
-		
+	char isAlphaNumeric
+		ifFalse: [ ^ self ].
+	matchString := matchString , char asString.
 	self recordFiltering: matchString.
-	self displayFiltered: evt.
-
-
+	self displayFiltered: evt
 ]
 
 { #category : #'keyboard control' }
@@ -1089,6 +1072,14 @@ MenuMorph >> layoutItems [
 	maxIconWidth isZero 
 		ifFalse: [self addBlankIconsIfNecessary: (Smalltalk ui icons blankIconOfWidth: maxIconWidth)].
 
+]
+
+{ #category : #events }
+MenuMorph >> leftArrowStroked: evt [
+	"If a stand-alone menu, do nothing"
+	popUpOwner ifNil: [ ^ self ].
+	"If a sub-menu, then deselect, and return focus to outer menu"
+	^ self deselectAndFocusOutermenuOn: evt
 ]
 
 { #category : #accessing }
@@ -1360,6 +1351,19 @@ MenuMorph >> restoreFocus: originalFocusHolder in: aWorld [
 
 	aWorld primaryHand keyboardFocus ifNotNil: [ ^ self ].
 	originalFocusHolder ifNotNil: [ aWorld primaryHand newKeyboardFocus: originalFocusHolder ]
+]
+
+{ #category : #events }
+MenuMorph >> rightArrowStroked: evt [
+	"right arrow key"
+
+	(selectedItem notNil and: [ selectedItem hasSubMenu ])
+		ifTrue: [ evt hand newMouseFocus: selectedItem subMenu.
+			selectedItem subMenu moveSelectionDown: 1 event: evt.
+			evt hand newKeyboardFocus: selectedItem subMenu.
+			^ true ].
+		
+	^ false
 ]
 
 { #category : #accessing }

--- a/src/Morphic-Base/PluggableMenuItemSpec.extension.st
+++ b/src/Morphic-Base/PluggableMenuItemSpec.extension.st
@@ -19,7 +19,7 @@ PluggableMenuItemSpec >> asMenuItemMorphFrom: parentMenu isLast: aBoolean [
 					target: act receiver;
 					selector: act selector;
 					arguments: act arguments ].
-	(menu := self subMenu) ifNotNil: [ self enabled ifTrue: [ it subMenu: (menu asMenuMorph) ]].
+	(menu := self subMenu) ifNotNil: [ self enabled ifTrue: [ it subMenu: (menu asMenuMorphOfKind: parentMenu class) ]].
 		
 	parentMenu ifNotNil: [ parentMenu addMorphBack: it ].
 	aBoolean ifFalse: [ self separator ifTrue: [ parentMenu addLine ] ].

--- a/src/Morphic-Base/PluggableMenuSpec.extension.st
+++ b/src/Morphic-Base/PluggableMenuSpec.extension.st
@@ -2,9 +2,14 @@ Extension { #name : #PluggableMenuSpec }
 
 { #category : #'*Morphic-Base' }
 PluggableMenuSpec >> asMenuMorph [
+	^ self asMenuMorphOfKind: self morphClass
+]
+
+{ #category : #'*Morphic-Base' }
+PluggableMenuSpec >> asMenuMorphOfKind: aMorphClass [
 	| prior menu myitems |
 	prior := parentMenu.
-	parentMenu := menu := self morphClass new.
+	parentMenu := menu := aMorphClass new.
 	self label ifNotNil: [ 
 		parentMenu buildTitle: [ :titleMorph | 
 			titleMorph bigTitle: self label 

--- a/src/Morphic-Widgets-Extra/DockingBarMorph.class.st
+++ b/src/Morphic-Widgets-Extra/DockingBarMorph.class.st
@@ -87,7 +87,8 @@ DockingBarMorph >> aboutToBeGrabbedBy: aHand [
 DockingBarMorph >> activate: evt [ 
 	"Receiver should be activated; e.g., so that control passes  
 	correctly."
-	evt hand newMouseFocus: self
+	evt hand newMouseFocus: self.
+	self takeKeyboardFocus
 ]
 
 { #category : #control }
@@ -402,6 +403,11 @@ DockingBarMorph >> handleFocusEvent: evt [
 ]
 
 { #category : #'events-processing' }
+DockingBarMorph >> handlesKeyboard: evt [
+	^ true
+]
+
+{ #category : #'events-processing' }
 DockingBarMorph >> handlesMouseDown: evt [
 	^ true
 ]
@@ -505,6 +511,19 @@ DockingBarMorph >> justDroppedInto: aMorph event: anEvent [
 	self beFloating
 ]
 
+{ #category : #'events-processing' }
+DockingBarMorph >> keyStroke: anEvent [
+	"Handle menu navigation"
+	
+	"Left arrow key"
+	anEvent keyValue = 28 ifTrue: [ self moveSelectionRight: -1 event: anEvent ].
+	"Right arrow key"
+	anEvent keyValue = 29 ifTrue: [ self moveSelectionRight: 1 event: anEvent ].
+	"Bottom key"
+	anEvent keyValue = 31 ifTrue: [ (selectedItem ifNotNil: [ selectedItem subMenu ifNotNil: [ :subMenu | subMenu activateFromKeyboard: anEvent ] ] )].
+	^ super keyStroke: anEvent
+]
+
 { #category : #'wiw support' }
 DockingBarMorph >> morphicLayerNumber [
 	"helpful for insuring some morphs always appear in front of or 
@@ -519,6 +538,25 @@ DockingBarMorph >> mouseDown: anEvent [
 	(self fullContainsPoint: anEvent position)
 		ifFalse: [anEvent hand releaseMouseFocus: self].
 	^super mouseDown: anEvent
+]
+
+{ #category : #'events-processing' }
+DockingBarMorph >> moveSelectionRight: direction event: anEvent [
+	"Move the current selection left or right by one, presumably under keyboard control.
+	direction = +/-1"
+
+	| index |
+	index := (submorphs indexOf: selectedItem ifAbsent: [ 1 - direction ]) + direction.
+	submorphs
+		do: [ :unused | 
+			"Ensure finite"
+			| m |
+			m := submorphs atWrap: index.
+			(m isMenuItemMorph and: [ m isEnabled ])
+				ifTrue: [ ^ self selectItem: m event: anEvent ].
+			"Keep looking for an enabled item"
+			index := index + direction sign ].
+	^ self selectItem: nil event: anEvent
 ]
 
 { #category : #construction }

--- a/src/Morphic-Widgets-Menubar/MenubarMenuMorph.class.st
+++ b/src/Morphic-Widgets-Menubar/MenubarMenuMorph.class.st
@@ -1,0 +1,37 @@
+Class {
+	#name : #MenubarMenuMorph,
+	#superclass : #MenuMorph,
+	#category : #'Morphic-Widgets-Menubar'
+}
+
+{ #category : #events }
+MenubarMenuMorph >> leftArrowStroked: evt [
+	| keyboardFocus |
+	super leftArrowStroked: evt.
+	
+	"If the menu is a submenu of a MenubarItemMorph then we need to give back the focus but also move the MenubarItemMorph selected one left."
+	keyboardFocus := evt hand keyboardFocus.
+	keyboardFocus isMenubar ifTrue: [ keyboardFocus keyStroke: evt ]
+]
+
+{ #category : #events }
+MenubarMenuMorph >> rightArrowStroked: evt [
+	"If the super return false it's probably because we need to give back the focus to the menubar and move to the right."
+
+	(super rightArrowStroked: evt)
+		ifTrue: [ ^ true ].
+	popUpOwner
+		ifNotNil: [ self deselectAndFocusOutermenuOn: evt.
+			self sendRightArrowPressedToMenubarOwner: evt.
+			^ true ].
+	^ false
+]
+
+{ #category : #events }
+MenubarMenuMorph >> sendRightArrowPressedToMenubarOwner: evt [
+	popUpOwner owner isMenubar
+		ifTrue:
+			[ "This is a submenu of a MenubarItemMorph, we give back the focus and move one right." popUpOwner owner keyStroke: evt ]
+		ifFalse:
+			[ "In that case we have submenus in submenus, we delegate the action to our parent menu" popUpOwner owner sendRightArrowPressedToMenubarOwner: evt ]
+]

--- a/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
+++ b/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
@@ -137,7 +137,7 @@ MenubarMorph >> open [
 			add: each label
 			icon: each icon
 			help: each help
-			subMenu: (each subMenu ifNotNil: #asMenuMorph).
+			subMenu: (each subMenu ifNotNil: #asMenubarMenuMorph).
 			each separator ifTrue: [ self addSeparator ] ].
 		
 	self

--- a/src/Morphic-Widgets-Menubar/PluggableMenuSpec.extension.st
+++ b/src/Morphic-Widgets-Menubar/PluggableMenuSpec.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #PluggableMenuSpec }
+
+{ #category : #'*Morphic-Widgets-Menubar' }
+PluggableMenuSpec >> asMenubarMenuMorph [
+	^ self asMenuMorphOfKind: MenubarMenuMorph
+]


### PR DESCRIPTION
Add first part of menubar keyboard management. (Left/right/bottom key management)

https://pharo.fogbugz.com/f/cases/22092/Add-part-of-the-keyboard-suport-for-the-menubar