### PR TITLE
22107-DockingBarMorph-should-have-its-own-entry-in-the-theme-to-define-the-border-width

### DIFF
--- a/src/Morphic-Widgets-Extra/DockingBarMorph.class.st
+++ b/src/Morphic-Widgets-Extra/DockingBarMorph.class.st
@@ -303,7 +303,7 @@ DockingBarMorph >> defaultBorderColor [
 
 { #category : #initialization }
 DockingBarMorph >> defaultBorderWidth [
-	^ self theme menuBorderWidth
+	^ self theme dockingBarBorderWidth
 ]
 
 { #category : #initialization }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -1846,6 +1846,11 @@ UITheme >> disabledTextColor [
 	^ self disabledColor
 ]
 
+{ #category : #accessing }
+UITheme >> dockingBarBorderWidth [ 
+	^ 0
+]
+
 { #category : #'fill-styles' }
 UITheme >> dockingBarNormalFillStyleFor: aToolDockingBar [
 	^ SolidFillStyle color: Color transparent


### PR DESCRIPTION
Add a theme setting for docking bar morph border width.

https://pharo.fogbugz.com/f/cases/22107/DockingBarMorph-should-have-its-own-entry-in-the-theme-to-define-the-border-width