### PR TITLE
22112-Remove-code-related-to-HostSystemMenus

### DIFF
--- a/src/System-VMEvents/InputEventSensor.class.st
+++ b/src/System-VMEvents/InputEventSensor.class.st
@@ -414,10 +414,7 @@ InputEventSensor >> processEvent: evt [
 	type := evt at: 1.
 
 	"Treat menu events first"
-	type = EventTypeMenu
-		ifTrue: [
-			self processMenuEvent: evt.
-			^nil].
+	type = EventTypeMenu ifTrue: [ "Do we still have EventTypeMenu? All the code handling this was removed from Pharo. I keep this guard just in case." ^nil].
 
 	"Tackle mouse events first"
 	type = EventTypeMouse
@@ -445,18 +442,6 @@ InputEventSensor >> processEvent: evt [
 	"Handle all events other than Keyborad or Mouse."
 	^evt.
 	
-]
-
-{ #category : #'private events' }
-InputEventSensor >> processMenuEvent: evt [
-	| handler localCopyOfEvt |
-
-	Smalltalk globals at: #HostSystemMenus ifPresent: [ :menus |		
-		localCopyOfEvt := evt shallowCopy.
-		handler := (menus
-			defaultMenuBarForWindowIndex: (localCopyOfEvt at: 8))
-			getHandlerForMenu: (localCopyOfEvt at: 3) item: (localCopyOfEvt at: 4).
-		handler handler value: localCopyOfEvt ]
 ]
 
 { #category : #'private events' }

--- a/src/System-VMEvents/ManifestSystemVMEvents.class.st
+++ b/src/System-VMEvents/ManifestSystemVMEvents.class.st
@@ -6,5 +6,5 @@ Class {
 
 { #category : #'meta-data - dependency analyser' }
 ManifestSystemVMEvents class >> manuallyResolvedDependencies [
-	^ #(#'System-Support' #'Morphic-Core' #'Collections-Abstract' #'System-Platforms')
+	^ #(#'System-Support' #'Collections-Abstract' #'System-Platforms')
 ]


### PR DESCRIPTION
Remove code related to HostSystemMenus. This also remove a dependency from  System-VMEvents to Morphic-Core. 

https://pharo.fogbugz.com/f/cases/22112/Remove-code-related-to-HostSystemMenus