### PR TITLE
22126-allInstVarNames-returns-wrong-results-for-classes-with-stateful-traits

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -138,8 +138,8 @@ Behavior >> allInstVarNames [
 
 	| vars |
 	self superclass == nil
-		ifTrue: [vars := self instVarNames copy]	"Guarantee a copy is answered."
-		ifFalse: [vars := self superclass allInstVarNames , self instVarNames].
+		ifTrue: [vars := self slots collect: #name]	"Guarantee a copy is answered."
+		ifFalse: [vars := self superclass allInstVarNames , (self slots collect: #name)].
 	^vars
 ]
 

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1735,6 +1735,11 @@ Behavior >> shutDown: quitting [
 	^self shutDown.
 ]
 
+{ #category : #accessing }
+Behavior >> slots [
+	^#()
+]
+
 { #category : #'accessing instances and variables' }
 Behavior >> someInstance [
 	"Primitive. Answer the first instance in the enumeration of all instances 

--- a/src/TraitsV2-Compatibility/TBehavior.trait.st
+++ b/src/TraitsV2-Compatibility/TBehavior.trait.st
@@ -116,8 +116,8 @@ TBehavior >> allInstVarNames [
 
 	| vars |
 	self superclass == nil
-		ifTrue: [vars := self instVarNames copy]	"Guarantee a copy is answered."
-		ifFalse: [vars := self superclass allInstVarNames , self instVarNames].
+		ifTrue: [vars := self slots collect: #name]	"Guarantee a copy is answered."
+		ifFalse: [vars := self superclass allInstVarNames , (self slots collect: #name)].
 	^vars
 ]
 


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/22126/use slot names instead of instVarNames