### PR TITLE
22129-haltIfInsideTest-should-be-removed-leftover-now-called-haltIfTest

### DIFF
--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -955,13 +955,6 @@ Object >> haltIf: condition [
 	Halt if: condition.
 ]
 
-{ #category : #halting }
-Object >> haltIfInsideTest [
-	"This is the typical message to use for inserting breakpoints during debugging."
-	<debuggerCompleteToSender>
-	Halt ifInsideTest
-]
-
 { #category : #testing }
 Object >> haltIfNil [
 ]


### PR DESCRIPTION
haltIfInsideTest should be removed (leftover, now called haltIfTest)
https://pharo.fogbugz.com/f/cases/22129/haltIfInsideTest-should-be-removed-leftover-now-called-haltIfTest