### PR TITLE
22131-Begin-to-add-requirement-in-Athens-baseline

### DIFF
--- a/src/Athens-Cairo/AthensCairoDefs.class.st
+++ b/src/Athens-Cairo/AthensCairoDefs.class.st
@@ -129,7 +129,7 @@ Class {
 		'cairo_t',
 		'cairo_text_extents_t'
 	],
-	#category : #'Athens-CairoPools'
+	#category : #'Athens-Cairo-Pools'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Athens-Cairo/StrikeFont.extension.st
+++ b/src/Athens-Cairo/StrikeFont.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #StrikeFont }
+
+{ #category : #'*Athens-Cairo' }
+StrikeFont >> asAthensFontDescription [
+	^ AthensFontDescription new family: self familyName; fontSize: self pointSize.
+
+]

--- a/src/Athens-CairoPools/package.st
+++ b/src/Athens-CairoPools/package.st
@@ -1,1 +1,0 @@
-Package { #name : #'Athens-CairoPools' }

--- a/src/Athens-Examples/AthensTextRenderTest.class.st
+++ b/src/Athens-Examples/AthensTextRenderTest.class.st
@@ -4,16 +4,18 @@ Visual tests for correct rendering of text using Athens
 Class {
 	#name : #AthensTextRenderTest,
 	#superclass : #Object,
-	#category : #'Athens-Text'
+	#category : #'Athens-Examples-Demos'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #utilities }
 AthensTextRenderTest class >> surfaceClass [
 	^ AthensCairoSurface
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 AthensTextRenderTest class >> test1 [
+	<example>
+	
 	|  t  c  |
 
 t := '
@@ -52,8 +54,10 @@ asText .
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 AthensTextRenderTest class >> test2 [
+	<example>
+	
 	|  t  c surf |
 	t := self testText. 
 	t addAttribute: (AthensTextBackground new color: (Color green alpha: 0.3 )) from: 1 to: 267.
@@ -80,8 +84,10 @@ AthensTextRenderTest class >> test2 [
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 AthensTextRenderTest class >> test3 [
+	<example>
+	
 	|  t  c surf |
 
 "t := '12345 pi kl mn op gj the text must flow' "
@@ -122,8 +128,10 @@ LogicalFont
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 AthensTextRenderTest class >> test4 [
+	<example>
+	
 	|  t  c surf |
 
 "t := '12345 pi kl mn op gj the text must flow' "
@@ -158,8 +166,10 @@ LogicalFont
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 AthensTextRenderTest class >> test5 [
+	<example>
+	
 	|  t  c surf |
 
 "t := '12345 pi kl mn op gj the text must flow' "
@@ -190,8 +200,10 @@ LogicalFont
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 AthensTextRenderTest class >> testBlitting [
+	<example>
+	
 	| fnt form blt |
 
 	fnt := LogicalFont
@@ -233,8 +245,10 @@ AthensTextRenderTest class >> testBlitting [
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 AthensTextRenderTest class >> testText [
+	<example>
+	
 	|  t  |
 
 t := 'The safety Dconstraint is that the garbage collector 
@@ -271,8 +285,9 @@ LogicalFont
 	^ t
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 AthensTextRenderTest class >> testWindow [
+	<example>
 
 	^ (AthensPluggableTextMorph
 		on: self
@@ -281,8 +296,10 @@ AthensTextRenderTest class >> testWindow [
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 AthensTextRenderTest class >> testWindowRender [
+	<example>
+	
 	| surf |
 	surf := self surfaceClass extent: Display extent.
 

--- a/src/Athens-Text/StrikeFont.extension.st
+++ b/src/Athens-Text/StrikeFont.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : #StrikeFont }
 
 { #category : #'*Athens-Text' }
-StrikeFont >> asAthensFontDescription [
-	^ AthensFontDescription new family: self familyName; fontSize: self pointSize.
-
-]
-
-{ #category : #'*Athens-Text' }
 StrikeFont >> asFreetypeFont [
 
 		self error: 'not supported yet. and ever'

--- a/src/BaselineOfAthens/BaselineOfAthens.class.st
+++ b/src/BaselineOfAthens/BaselineOfAthens.class.st
@@ -15,23 +15,46 @@ BaselineOfAthens >> baseline: spec [
 	<baseline>
 	spec
 		for: #common
-		do: [ 
-			self flag: #todo. "We need to cut cyclic dependencies and add requirements to the packages."
-			
+		do: [ self flag: #todo.	"Inter packages dependencies are now added but it is missing some dependencies on other projects such as Morphic for Athens-Morphic"
+
+			"Dependencies"
+			self
+				display: spec;
+				unifiedFFI: spec.
+
 			"Packages"
-			spec package: 'Athens-Core'. "There is a cyclic dependency between Core and Morphic"
-			spec package: 'Athens-Text'.
-			spec package: 'Athens-Balloon'.
-			spec package: 'Athens-Morphic'.
-			spec package: 'Athens-CairoPools'.
-			spec package: 'Athens-Cairo'.
-			spec package: 'Athens-Examples'.
-			spec package: 'Athens-Tests-Cairo'.
-			
+			spec
+				package: 'Athens-Core' with: [ spec requires: 'Display' ];
+				package: 'Athens-Text' with: [ spec requires: 'Athens-Core' ];
+				package: 'Athens-Balloon' with: [ spec requires: #('Athens-Core' 'Athens-Text') ];
+				package: 'Athens-Morphic' with: [ spec requires: #('Athens-Core' 'Athens-Text' 'Athens-Balloon' 'Athens-Cairo') ];
+				package: 'Athens-Cairo' with: [ spec requires: #('Athens-Core' 'UnifiedFFI') ];
+				package: 'Athens-Examples' with: [ spec requires: #('Athens-Morphic' 'Athens-Text' 'Athens-Balloon' 'Athens-Cairo') ];
+				package: 'Athens-Tests-Cairo' with: [ spec requires: 'Athens-Cairo' ].
+
 			"Groups"
 			spec
-				group: 'Core' with: #('Basic' 'Athens-Text' 'Athens-Balloon' 'Athens-Morphic');
-				group: 'Basic' with: #('Athens-Core' 'Athens-CairoPools' 'Athens-Cairo');
-				group: 'Examples' with: #('Athens-Examples'); "Test and Examples are not yet working. We need to add the requirements between packages to get them working"
+				group: 'Core' with: #('Cairo-core' 'Athens-Text' 'Athens-Balloon' 'Athens-Morphic');
+				group: 'Cairo-core' with: #('Athens-Core' 'Athens-Cairo');
+				group: 'Examples' with: #('Athens-Examples');
 				group: 'Tests' with: #('Athens-Tests-Cairo') ]
+]
+
+{ #category : #baseline }
+BaselineOfAthens >> display: spec [
+	spec baseline: 'Display' with: [ spec repository: self repository ]
+]
+
+{ #category : #accessing }
+BaselineOfAthens >> repository [
+	^ self packageRepositoryURL
+]
+
+{ #category : #baseline }
+BaselineOfAthens >> unifiedFFI: spec [
+	spec
+		baseline: 'UnifiedFFI'
+		with: [ spec
+				loads: 'minimal';
+				repository: self repository ]
 ]

--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -45,7 +45,7 @@ BaselineOfBasicTools >> baseline: spec [
 		
 		spec baseline: 'Athens' with: [ 
 			spec
-				loads: 'Basic';
+				loads: 'Cairo-core';
 				repository: repository ].
 
 		spec package: 'JenkinsTools-Core'.

--- a/src/BaselineOfDisplay/BaselineOfDisplay.class.st
+++ b/src/BaselineOfDisplay/BaselineOfDisplay.class.st
@@ -33,9 +33,9 @@ BaselineOfDisplay >> baseline: spec [
 		spec 
 			package: 'Graphics-Display Objects';
 			package: 'Graphics-Primitives' with: [ spec requires: 'Graphics-Display Objects' ];
-			package: 'Graphics-Transformations'.
-		spec 
-			group: 'default' with: #('Graphics-Display Objects' 'Graphics-Primitives' 'Graphics-Transformations'). ].		
+			package: 'Graphics-Transformations'
+		
+		 ].		
 
 ]
 

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -44,6 +44,7 @@ BaselineOfIDE >> addPharoProjectToIceberg [
 	
 	"extract package names from baselines"
 	packageNames := (#(
+		BaselineOfAthens
 		BaselineOfBasicTools
 		BaselineOfDisplay
 		BaselineOfIDE  

--- a/src/BaselineOfUnifiedFFI/BaselineOfUnifiedFFI.class.st
+++ b/src/BaselineOfUnifiedFFI/BaselineOfUnifiedFFI.class.st
@@ -39,7 +39,8 @@ BaselineOfUnifiedFFI >> baseline: spec [
 			
 		spec 
 			group: 'default' with: #('core' 'legacy');
-			group: 'core' with: #('UnifiedFFI' 'UnifiedFFI-Tests');
+			group: 'minimal' with: #('UnifiedFFI');
+			group: 'core' with: #('minimal' 'UnifiedFFI-Tests');
 			group: 'legacy' with: #('UnifiedFFI-Legacy') ]
 ]
 


### PR DESCRIPTION
Begin to add Athens requirements and some cleaning. (detail bellow)

Full log:
- Add inter packages requirements to Athens baseline
- Begin to add requirements on other projects
- Add a "minimal" group to UFFI to not get the tests
- Remove useless "default" group from display since it loads everything by default
- Move Athens-text examples to Athens-Examples package (This cut dependencies on Athens-Morphic and Athens-Cairo)
- Merge Athens-Cairo and Athens-CairoPools packages
- Rename a group of Athens to be more explicit

https://pharo.fogbugz.com/f/cases/22131/Begin-to-add-requirement-in-Athens-baseline