### PR TITLE
22132-Semantic-Analyser-do-not-pop-scope-in-methodNode

### DIFF
--- a/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
@@ -48,7 +48,6 @@ OCASTClosureAnalyzer >> visitMethodNode: aMethodNode [
 	scope := aMethodNode scope.	
 	self doRemotes; doCopying.
 	self visitNode: aMethodNode body.
-	scope := scope popScope.
 ]
 
 { #category : #visiting }

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -195,7 +195,6 @@ OCASTSemanticAnalyzer >> visitMethodNode: aMethodNode [
 	aMethodNode arguments do: [:node | self declareArgumentNode: node ].
 	aMethodNode pragmas do: [:each | self visitNode: each].
 	self visitNode: aMethodNode body.
-	scope := scope outerScope.
 
 ]
 

--- a/src/Reflectivity/RFASTClosureAnalyzer.class.st
+++ b/src/Reflectivity/RFASTClosureAnalyzer.class.st
@@ -8,16 +8,6 @@ Class {
 }
 
 { #category : #visiting }
-RFASTClosureAnalyzer >> visitMethodNode: aMethodNode [
-	"here look at the temps and make copying vars / tempVector out of them"
-	self visitArgumentNodes: aMethodNode arguments.
-	scope := aMethodNode scope.	
-	self doRemotes; doCopying.
-	self visitNode: aMethodNode body.
-	"scope := scope popScope."
-]
-
-{ #category : #visiting }
 RFASTClosureAnalyzer >> visitNode: aNode [
 	super visitNode: aNode.
 	

--- a/src/Reflectivity/RFSemanticAnalyzer.class.st
+++ b/src/Reflectivity/RFSemanticAnalyzer.class.st
@@ -96,7 +96,6 @@ RFSemanticAnalyzer >> visitMethodNode: aMethodNode [
 	aMethodNode pragmas do: [:each | self visitNode: each].
 	self analyseForLinksForNodes: aMethodNode.
 	self visitNode: aMethodNode body.
-	scope := scope outerScope.
 
 ]
 


### PR DESCRIPTION
Semantic Analyser: do not pop scope in methodNode
https://pharo.fogbugz.com/f/cases/22132/Semantic-Analyser-do-not-pop-scope-in-methodNode