### PR TITLE
22140-Raise-warning-if-read-only-literals-option-is-enable-with-a-VM-that-cannot-manage-it

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -275,6 +275,8 @@ CompilationContext class >> optionReadOnlyLiterals [
 
 { #category : #'options - settings API' }
 CompilationContext class >> optionReadOnlyLiterals: aBoolean [
+	(aBoolean and: [ Smalltalk vm supportsWriteBarrier ]) ifFalse: [ ^ OCReadOnlyVMWarning signal ].
+	
 	^ self writeDefaultOption: #optionReadOnlyLiterals value: aBoolean
 ]
 


### PR DESCRIPTION
Raise a warning if we enable read only literals with a vm that cannot manage them.

https://pharo.fogbugz.com/f/cases/22140/Raise-warning-if-read-only-literals-option-is-enable-with-a-VM-that-cannot-manage-it