### PR TITLE
22151 Separator in help menu between Example browser and About

### DIFF
--- a/src/Glamour-Examples/GLMExamplesBrowser.class.st
+++ b/src/Glamour-Examples/GLMExamplesBrowser.class.st
@@ -17,7 +17,8 @@ GLMExamplesBrowser class >> menuExamplesOn: aBuilder [
 		parent: #Help;
 		order: 4.0;
 		help: 'Open Glamour Example Browser.';
-		action: [ self open ]
+		action: [ self open ].
+	aBuilder withSeparatorAfter	
 ]
 
 { #category : #'user interface' }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/22151/Separator-in-help-menu-between-Example-browser-and-About