### PR TITLE
21518-New-Traits-brings-wrong-behaviour-to-tagsForMethods

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -777,6 +777,19 @@ ClassDescription >> isInstanceSide [
 	^ self isClassSide not
 ]
 
+{ #category : #testing }
+ClassDescription >> isLocalMethodsProtocol: aProtocol [
+	aProtocol methods ifEmpty: [ ^true ].
+	
+	^aProtocol methods anySatisfy: [ :each | self isLocalSelector: each]
+]
+
+{ #category : #testing }
+ClassDescription >> isLocalSelector: aSelector [
+	
+	^ self methodDict includesKey: aSelector
+]
+
 { #category : #'accessing - deprecated parallel hierarchy ' }
 ClassDescription >> isMeta [
 	^self isClassSide

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -1184,14 +1184,10 @@ ClassDescription >> tagsForMethods [
 	It supposed to not include any method tags inherited from Traits 
 	which is opposite to current Protocol implementation.
 	And extension protocol is not treated as tag"
-	| allProtocols tags |
-	allProtocols := self organization protocols 
-		reject: [ :each | each name = Protocol unclassified | each isExtensionProtocol ].
+	| allProtocols |
+	allProtocols := self organization protocols reject: [ :each | each name = Protocol unclassified | each isExtensionProtocol ].
 		
-	tags := OrderedCollection new.
-	allProtocols do: [ :each | tags add: each name ].
-
-	^tags
+	^ allProtocols select: [ :each | self isLocalMethodsProtocol: each ] thenCollect: #name
 ]
 
 { #category : #'accessing - deprecated parallel hierarchy ' }

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -329,15 +329,10 @@ TraitedClass >> tagsForMethods [
 	It supposed to not include any method tags inherited from Traits 
 	which is opposite to current Protocol implementation.
 	And extension protocol is not treated as tag"
-	| allProtocols tags |
-	allProtocols := self organization protocols 
-		reject: [ :each | each name = Protocol unclassified | each isExtensionProtocol ].
+	| allProtocols |
+	allProtocols := self organization protocols reject: [ :each | each name = Protocol unclassified | each isExtensionProtocol ].
 		
-	tags := OrderedCollection new.
-	allProtocols do: [ :each | 
-		(self isLocalMethodsProtocol: each) ifTrue: [ tags add: each name ]].
-
-	^tags
+	^ allProtocols select: [ :each | self isLocalMethodsProtocol: each ] thenCollect: #name
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Synch ClassDescription and TraitedClass implementation of #tagsForMethods.

https://pharo.fogbugz.com/f/cases/21518/New-Traits-brings-wrong-behaviour-to-tagsForMethods