### PR TITLE
22174-Remove-FileDoesNotExistExceptiondefaultAction

### DIFF
--- a/src/Deprecated70/MorphicUIManager.extension.st
+++ b/src/Deprecated70/MorphicUIManager.extension.st
@@ -1,0 +1,85 @@
+Extension { #name : #MorphicUIManager }
+
+{ #category : #'*Deprecated70' }
+MorphicUIManager >> fileDoesNotExistUserHandling: anException [
+	| selection newName filename |
+
+	self 
+		deprecated: 'Deprecated since file exceptions should not rely on a UI being present' 
+		on: '20 Jun 2018' 
+		in: 'Pharo70'.
+	filename := anException fileName.
+	selection := self
+		chooseFrom:
+			{('Force recursive file creation' translated).
+			('Choose another file name' translated).
+			('Cancel' translated)}
+		title: filename, ' does not exist.'.
+		
+	"If user presses escape, selection will be 0.
+	If user selects cancel, selection will be the last choice"
+	(#( 0 3 ) includes: selection) ifTrue:[
+		Abort signal: 'Please close this to abort file opening' ].
+	
+	"Create a new file.
+	We depend on FileSystem here to recursively create the directory for the file."
+	selection = 1
+		ifTrue: [
+			filename asFileReference ensureCreateFile.
+			^ File openForWriteFileNamed: filename ].
+		
+	"Create a new file"
+	newName := self request: 'Enter a new file name' initialAnswer: filename.
+	^ File openForWriteFileNamed: newName
+]
+
+{ #category : #'*Deprecated70' }
+MorphicUIManager >> fileDoesNotExistsDefaultAction: anException [
+
+	self 
+		deprecated: 'Deprecated since file exceptions should not rely on a UI being present' 
+		on: '20 Jun 2018' 
+		in: 'Pharo70'.
+	^ anException readOnly
+		ifTrue: [ self readOnlyFileDoesNotExistUserHandling: anException]
+		ifFalse: [self fileDoesNotExistUserHandling: anException]
+
+]
+
+{ #category : #'*Deprecated70' }
+MorphicUIManager >> readOnlyFileDoesNotExistUserHandling: anException [
+
+	| files choices selection newName directory filename |
+
+	self 
+		deprecated: 'Deprecated since file exceptions should not rely on a UI being present' 
+		on: '20 Jun 2018' 
+		in: 'Pharo70'.
+	filename := anException fileName.	
+	directory := filename asFileReference parent.
+	files := directory fileNames.
+	
+	choices := filename correctAgainst: files.
+	choices add: 'Choose another file name'.
+	choices add: 'Cancel'.
+	
+	selection := self chooseFrom: choices lines: (Array with: 5)
+		title: filename, ' does not exist.'.
+	
+	"If user presses escape, selection will be 0.
+	If user selects cancel, selection will be the last choice"
+	(selection = 0 or: [selection = choices size]) ifTrue:[
+		Abort signal: 'Please close this to abort file opening' ].
+	
+	selection < (choices size - 1) ifTrue: [
+		newName := directory / (choices at: selection)].
+	
+	selection = (choices size - 1) ifTrue: [
+		newName := directory / (self
+				request: 'Enter a new file name' 
+				initialAnswer: filename) ].
+
+	newName ifNotNil: [ ^ newName readStream ].
+	
+	^ self error: 'Could not open a file'
+]

--- a/src/Files-Prompt/FileDoesNotExistException.extension.st
+++ b/src/Files-Prompt/FileDoesNotExistException.extension.st
@@ -1,9 +1,0 @@
-Extension { #name : #FileDoesNotExistException }
-
-{ #category : #'*Files-Prompt' }
-FileDoesNotExistException >> defaultAction [
-	"The default action taken if the exception is signaled."
-
-	^ UIManager default fileDoesNotExistsDefaultAction: self
-
-]

--- a/src/Files-Prompt/MorphicUIManager.extension.st
+++ b/src/Files-Prompt/MorphicUIManager.extension.st
@@ -4,6 +4,10 @@ Extension { #name : #MorphicUIManager }
 MorphicUIManager >> fileDoesNotExistUserHandling: anException [
 	| selection newName filename |
 
+	self 
+		deprecated: 'Deprecated since file exceptions should not rely on a UI being present' 
+		on: '20 Jun 2018' 
+		in: 'Pharo70'.
 	filename := anException fileName.
 	selection := self
 		chooseFrom:
@@ -32,6 +36,10 @@ MorphicUIManager >> fileDoesNotExistUserHandling: anException [
 { #category : #'*Files-Prompt' }
 MorphicUIManager >> fileDoesNotExistsDefaultAction: anException [
 
+	self 
+		deprecated: 'Deprecated since file exceptions should not rely on a UI being present' 
+		on: '20 Jun 2018' 
+		in: 'Pharo70'.
 	^ anException readOnly
 		ifTrue: [ self readOnlyFileDoesNotExistUserHandling: anException]
 		ifFalse: [self fileDoesNotExistUserHandling: anException]
@@ -68,6 +76,10 @@ MorphicUIManager >> readOnlyFileDoesNotExistUserHandling: anException [
 
 	| files choices selection newName directory filename |
 
+	self 
+		deprecated: 'Deprecated since file exceptions should not rely on a UI being present' 
+		on: '20 Jun 2018' 
+		in: 'Pharo70'.
 	filename := anException fileName.	
 	directory := filename asFileReference parent.
 	files := directory fileNames.

--- a/src/Files-Prompt/MorphicUIManager.extension.st
+++ b/src/Files-Prompt/MorphicUIManager.extension.st
@@ -1,52 +1,6 @@
 Extension { #name : #MorphicUIManager }
 
 { #category : #'*Files-Prompt' }
-MorphicUIManager >> fileDoesNotExistUserHandling: anException [
-	| selection newName filename |
-
-	self 
-		deprecated: 'Deprecated since file exceptions should not rely on a UI being present' 
-		on: '20 Jun 2018' 
-		in: 'Pharo70'.
-	filename := anException fileName.
-	selection := self
-		chooseFrom:
-			{('Force recursive file creation' translated).
-			('Choose another file name' translated).
-			('Cancel' translated)}
-		title: filename, ' does not exist.'.
-		
-	"If user presses escape, selection will be 0.
-	If user selects cancel, selection will be the last choice"
-	(#( 0 3 ) includes: selection) ifTrue:[
-		Abort signal: 'Please close this to abort file opening' ].
-	
-	"Create a new file.
-	We depend on FileSystem here to recursively create the directory for the file."
-	selection = 1
-		ifTrue: [
-			filename asFileReference ensureCreateFile.
-			^ File openForWriteFileNamed: filename ].
-		
-	"Create a new file"
-	newName := self request: 'Enter a new file name' initialAnswer: filename.
-	^ File openForWriteFileNamed: newName
-]
-
-{ #category : #'*Files-Prompt' }
-MorphicUIManager >> fileDoesNotExistsDefaultAction: anException [
-
-	self 
-		deprecated: 'Deprecated since file exceptions should not rely on a UI being present' 
-		on: '20 Jun 2018' 
-		in: 'Pharo70'.
-	^ anException readOnly
-		ifTrue: [ self readOnlyFileDoesNotExistUserHandling: anException]
-		ifFalse: [self fileDoesNotExistUserHandling: anException]
-
-]
-
-{ #category : #'*Files-Prompt' }
 MorphicUIManager >> fileExistsDefaultAction: anException [
 	| file choice |
 	
@@ -69,42 +23,4 @@ MorphicUIManager >> fileExistsDefaultAction: anException [
 		^ newFile checkDoesNotExist ].
 
 	Abort signal: 'Please close this to abort file opening'
-]
-
-{ #category : #'*Files-Prompt' }
-MorphicUIManager >> readOnlyFileDoesNotExistUserHandling: anException [
-
-	| files choices selection newName directory filename |
-
-	self 
-		deprecated: 'Deprecated since file exceptions should not rely on a UI being present' 
-		on: '20 Jun 2018' 
-		in: 'Pharo70'.
-	filename := anException fileName.	
-	directory := filename asFileReference parent.
-	files := directory fileNames.
-	
-	choices := filename correctAgainst: files.
-	choices add: 'Choose another file name'.
-	choices add: 'Cancel'.
-	
-	selection := self chooseFrom: choices lines: (Array with: 5)
-		title: filename, ' does not exist.'.
-	
-	"If user presses escape, selection will be 0.
-	If user selects cancel, selection will be the last choice"
-	(selection = 0 or: [selection = choices size]) ifTrue:[
-		Abort signal: 'Please close this to abort file opening' ].
-	
-	selection < (choices size - 1) ifTrue: [
-		newName := directory / (choices at: selection)].
-	
-	selection = (choices size - 1) ifTrue: [
-		newName := directory / (self
-				request: 'Enter a new file name' 
-				initialAnswer: filename) ].
-
-	newName ifNotNil: [ ^ newName readStream ].
-	
-	^ self error: 'Could not open a file'
 ]

--- a/src/Files/FileDoesNotExistException.class.st
+++ b/src/Files/FileDoesNotExistException.class.st
@@ -1,5 +1,17 @@
 "
-Notify when fie does not exist
+I am raised when an operation is attempted on a file that does not exist.
+
+The method used to signal the exception depends on the form the file name exists in:
+
+- For strings: (FileDoesNotExistException file fileName: aString) signal 
+- For Files: FileDoesNotExistException signalOnFile: aFile
+- For FileReferences: FileDoesNotExistException signalWith: aFileReference
+
+
+Applications that want to offer the user the opportunity to select a different file can use:
+
+	UIManager default fileDoesNotExistsDefaultAction: exception
+
 "
 Class {
 	#name : #FileDoesNotExistException,


### PR DESCRIPTION
22174 Remove FileDoesNotExistException>>defaultAction

FileDoesNotExist and FileDoesNotExistException were recently merged into FileDoesNotExistException.

FileDoesNotExistException has an interactive pop-up as its default action, while FileDoesNotExist didn't.  This causes problems as experienced recently in PR 1572 [1].

Core classes, such as the file system, shouldn't be relying on an interactive environment being present, so...

Remove the #defaultAction over-ride and update the class comment to suggest the interactive action that can be taken by applications if appropriate.
Fogbugz: https://pharo.fogbugz.com/f/cases/22174/Remove-FileDoesNotExistException-defaultAction
[1] https://github.com/pharo-project/pharo/pull/1572