### PR TITLE
22187-Alien-should-have-a-polymorphic-API-that-allow-portable-number-sizes

### DIFF
--- a/src/UnifiedFFI/Alien.extension.st
+++ b/src/UnifiedFFI/Alien.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Alien }
+
+{ #category : #'*UnifiedFFI' }
+Alien >> integerAt: byteOffset size: size signed: signed [
+
+	^ (ExternalAddress fromAddress: self address) integerAt: byteOffset size: size signed: signed
+]


### PR DESCRIPTION
Alien should have the message #integerAt:size:signed: to have portable callbacks in different architectures.

Fixes Issue 22187

https://pharo.manuscript.com/f/cases/22187/Alien-should-have-a-polymorphic-API-that-allow-portable-number-sizes