### PR TITLE
22199-in-windows-freetype-library-can-be-named-libfreetype-6dll

### DIFF
--- a/src/FreeType/FT2FFILibrary.class.st
+++ b/src/FreeType/FT2FFILibrary.class.st
@@ -148,5 +148,9 @@ FT2FFILibrary >> unixModuleName [
 
 { #category : #'accessing platform' }
 FT2FFILibrary >> win32ModuleName [
-	^ 'libfreetype.dll'
+	#('libfreetype.dll' 'libfreetype-6.dll') 
+		detect: [ :each | (FileLocator vmDirectory / each) exists ]
+		ifFound: [ :each | ^ each ].
+	
+	self error: 'freetyle library not found!'
 ]


### PR DESCRIPTION
https://pharo.manuscript.com/f/cases/22199/in-windows-freetype-library-can-be-named-libfreetype-6-dll