### PR TITLE
22205-ByteArray-hex-dump-misses-characters

### DIFF
--- a/src/Collections-Native/ByteArray.class.st
+++ b/src/Collections-Native/ByteArray.class.st
@@ -186,9 +186,8 @@ ByteArray >> hexDumpOn: aStream max: maxBytes [
 			aStream
 				<< (ch printPaddedWith: $0 to: 2 base: 16);
 				<< ' '.
-			ch := Character value: ch.
-			ch isAlphaNumeric ifTrue: 
-				[ string nextPut: ch ]
+			(ch between: 32 and: 126) ifTrue: 
+				[ string nextPut: (Character value: ch) ]
 			ifFalse:
 				[ string nextPut: $. ].
 			remainder = 15 ifTrue: [ 
@@ -199,7 +198,7 @@ ByteArray >> hexDumpOn: aStream max: maxBytes [
 			ch := stream next.
 			i := i + 1 ].
 		remainder := i \\ 16.
-		(ch isNil and: [remainder between: 1 and: 14]) ifTrue: [ 
+		(ch isNil and: [remainder between: 1 and: 15]) ifTrue: [ 
 			(16 - remainder) timesRepeat: [ aStream nextPutAll: '   ' ].
 			aStream
 				<< '  |';

--- a/src/Collections-Native/WordArray.class.st
+++ b/src/Collections-Native/WordArray.class.st
@@ -22,7 +22,7 @@ WordArray >> atAllPut: value [
 	super atAllPut: value
 ]
 
-{ #category : #'accessing' }
+{ #category : #accessing }
 WordArray >> byteSize [
 	^self size * 4
 ]


### PR DESCRIPTION
22205 ByteArray hex dump misses characters

ByteArray>>hexDumpOn:max:

- is failing to print characters that are allowed, e.g. punctuation characters.
-- This is because the previous test was that the character is alpha-numeric, while any character between 32 and 126 is valid.
- failing to print the string representation of the last line if there are 15 bytes.
-- Due to an incorrect remainder comparison (14 instead of 15).

Fogbugz: https://pharo.fogbugz.com/f/cases/22205/ByteArray-hex-dump-misses-characters