### PR TITLE
22218 Cleanup System-OSEnvironments and deprecate OSEnvironment(class)>>default

### DIFF
--- a/src/Deprecated70/OSEnvironment.extension.st
+++ b/src/Deprecated70/OSEnvironment.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #OSEnvironment }
+
+{ #category : #'*Deprecated70' }
+OSEnvironment class >> default [
+
+	self deprecated: 'Use #current'.
+	^ self current
+]

--- a/src/System-OSEnvironments/OSEnvironment.class.st
+++ b/src/System-OSEnvironments/OSEnvironment.class.st
@@ -1,6 +1,8 @@
 "
-I represent the user environment variables.
-See  `man environ` for more details.
+I represent the user environment variables. See  `man environ` for more details.
+Get access using: 
+
+	Smalltalk os environment
 "
 Class {
 	#name : #OSEnvironment,
@@ -11,7 +13,7 @@ Class {
 	#classVars : [
 		'Current'
 	],
-	#category : #'System-OSEnvironments'
+	#category : #'System-OSEnvironments-Base'
 }
 
 { #category : #'instance creation' }
@@ -19,12 +21,7 @@ OSEnvironment class >> current [
 	^ Current ifNil: [ Current := self environmentFor: OSPlatform current ]
 ]
 
-{ #category : #'instance creation' }
-OSEnvironment class >> default [
-	^ self current.
-]
-
-{ #category : #accessing }
+{ #category : #'private - accessing' }
 OSEnvironment class >> environmentFor: aPlatform [
 	| environmentClass |
 	
@@ -35,6 +32,12 @@ OSEnvironment class >> environmentFor: aPlatform [
 	^ (environmentClass notNil and: [ environmentClass isAvailable  ])  
 		ifTrue: [ environmentClass platform: aPlatform ]
 		ifFalse: [ PlatformIndependentEnvironment platform: aPlatform ]
+]
+
+{ #category : #examples }
+OSEnvironment class >> example [
+
+	Smalltalk os environment asDictionary inspect
 ]
 
 { #category : #'initialize-release' }

--- a/src/System-OSEnvironments/PlatformIndependentEnvironment.class.st
+++ b/src/System-OSEnvironments/PlatformIndependentEnvironment.class.st
@@ -6,7 +6,7 @@ Specially, I'm intended to work as a replacement for environments when there is 
 Class {
 	#name : #PlatformIndependentEnvironment,
 	#superclass : #OSEnvironment,
-	#category : #'System-OSEnvironments'
+	#category : #'System-OSEnvironments-Platforms'
 }
 
 { #category : #testing }

--- a/src/System-OSEnvironments/UnixEnvironment.class.st
+++ b/src/System-OSEnvironments/UnixEnvironment.class.st
@@ -4,7 +4,7 @@ I am a specialized OSEnvironment version for *nix systems (Linux, OSX).
 Class {
 	#name : #UnixEnvironment,
 	#superclass : #OSEnvironment,
-	#category : #'System-OSEnvironments'
+	#category : #'System-OSEnvironments-Platforms'
 }
 
 { #category : #testing }

--- a/src/System-OSEnvironments/Win32Environment.class.st
+++ b/src/System-OSEnvironments/Win32Environment.class.st
@@ -4,7 +4,7 @@ I am a specialized OSEnvironment for Windows
 Class {
 	#name : #Win32Environment,
 	#superclass : #OSEnvironment,
-	#category : #'System-OSEnvironments'
+	#category : #'System-OSEnvironments-Platforms'
 }
 
 { #category : #testing }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/22218/Cleanup-System-OSEnvironments-and-deprecate-OSEnvironment-class-default


 categorize and care on some formatting
- the method OSEnvironment(class)>>default is not used and points to OSEnvironment(class)>>current
  => therefore we should deprecate #default and move it to Deprecated70 package