### PR TITLE
22228-Class-copy-and-duplicateClassWithNewName-should-be-correctly-implemented

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -120,7 +120,7 @@ Class >> addClassVariable: aGlobal [
 	Signal an error if the first character of aString is not capitalized,
 	or if it is already a variable named in the class."
 	| symbol oldState |
-	oldState := self copy.
+	oldState := self copyForAnnouncement.
 	symbol := aGlobal name asSymbol.
 	self withAllSubclasses do: 
 		[:subclass | 
@@ -396,8 +396,22 @@ Class >> compileAllFrom: oldClass [
 
 { #category : #copying }
 Class >> copy [ 
-	"Answer a copy of the receiver without a list of subclasses"
+	
+	self error: 'You should not copy a class.'.
+	
+	"If you want to copy a class just to check the differences before a change, as done in the announcements, use #copyForAnnouncement.
+	Copying a class should be done using #duplicateClassWithNewName:
+	Any other copy operation should be used using the class builder and class installer. 
+	They guarantee that the state of the system is consistent."
+]
+
+{ #category : #copying }
+Class >> copyForAnnouncement [
+	"Answer a copy of the receiver to be used in the announcement of changes.
+	You should not use this class for anything else, it is invalid."
 	| newClass |
+	
+	
 	newClass := self class copy new
 		superclass: superclass;
 		methodDict: self methodDict copy;
@@ -565,19 +579,18 @@ Class >> deprecationRefactorings [
 { #category : #copying }
 Class >> duplicateClassWithNewName: aSymbol [
 	| copysName class |
+			
 	copysName := aSymbol asSymbol.
 	copysName = self name
 		ifTrue: [ ^ self ].
 	(self environment includesKey: copysName)
 		ifTrue: [ ^ self error: copysName , ' already exists' ].
-	class := self superclass
-		subclass: copysName
-		instanceVariableNames: self instanceVariablesString
-		classVariableNames: self classVariablesString
-		poolDictionaries: self sharedPoolsString
-		package: self category.
-	class classSide
-		instanceVariableNames: self classSide instanceVariablesString.
+
+	class := self classInstaller make: [ :builder | 
+		builder 
+			fillFor: self;
+			name: copysName].
+		
 	class copyAllCategoriesFrom: self.
 	class class copyAllCategoriesFrom: self class.
 	^ class

--- a/src/Shift-Changes/ShClassChanged.class.st
+++ b/src/Shift-Changes/ShClassChanged.class.st
@@ -17,5 +17,5 @@ ShClassChanged >> announceChanges [
 { #category : #announcing }
 ShClassChanged >> builder: anObject [
 	builder := anObject.
-	oldClass := builder oldClass copy.
+	oldClass := builder oldClass copyForAnnouncement.
 ]

--- a/src/Shift-Changes/ShMetaclassChanged.class.st
+++ b/src/Shift-Changes/ShMetaclassChanged.class.st
@@ -17,7 +17,7 @@ ShMetaclassChanged >> announceChanges [
 { #category : #accessing }
 ShMetaclassChanged >> builder: anObject [
 	super builder: anObject.
-	oldClass := builder oldClass copy.
+	oldClass := builder oldClass copyForAnnouncement.
 ]
 
 { #category : #propagating }

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -118,6 +118,30 @@ ShClassInstallerTest >> testClassWithComment [
 ]
 
 { #category : #tests }
+ShClassInstallerTest >> testDuplicateClassPreserveMethods [
+	
+	newClass := self newClass: #ShCITestClass slots: {#anInstanceVariable => BooleanSlot}.
+	newClass compile: 'm1 ^ 42'.
+	newClass class compile: 'm2 ^ 42'.
+	
+	newClass2 := newClass duplicateClassWithNewName: #ShCITestClass2.
+	
+	self assert: (newClass2 includesSelector: #m1).
+	self assert: (newClass2 class includesSelector: #m2)	
+]
+
+{ #category : #tests }
+ShClassInstallerTest >> testDuplicateClassPreserveSlots [
+	
+	newClass := self newClass: #ShCITestClass slots: {#anInstanceVariable => BooleanSlot}.
+	newClass2 := newClass duplicateClassWithNewName: #ShCITestClass2.
+	
+	self assert: (newClass2 hasSlotNamed: #anInstanceVariable).
+	self assert: (newClass2 slotNamed: #anInstanceVariable) class equals: BooleanSlot.
+	
+]
+
+{ #category : #tests }
 ShClassInstallerTest >> testModifyingClassKeepsOrganizationOfMethods [
 	newClass := self newClass: #ShCITestClass superclass: subClass slots: #().
 

--- a/src/Slot-Tests/SlotIntegrationTest.class.st
+++ b/src/Slot-Tests/SlotIntegrationTest.class.st
@@ -201,16 +201,6 @@ SlotIntegrationTest >> testCompiledMethodLayout [
 ]
 
 { #category : #tests }
-SlotIntegrationTest >> testCopyPreservesLayout [
-	aClass := self makeWithLayout: FixedLayout.
-	anotherClass := aClass copy.
-	self deny: anotherClass classLayout isNil.
-	self deny: anotherClass classLayout == aClass classLayout.
-	self assert: aClass classLayout host == aClass.
-	self assert: anotherClass classLayout host == anotherClass
-]
-
-{ #category : #tests }
 SlotIntegrationTest >> testRemoveInstVarNamed [
 
 	| answer |


### PR DESCRIPTION
Changing the implementation of copy in the class.
You should not copy a class, only duplicate it with a new name. 
The only possible case to copy a class is to register changes and compare it with a new one, for that the #copyForAnnouncement should be used.Fix Issue:  https://pharo.manuscript.com/f/cases/22228/Class-copy-and-duplicateClassWithNewName-should-be-correctly-implemented