### PR TITLE
20579-Ring-Core-Containers-seems-to-be-loaded-twice

### DIFF
--- a/src/BaselineOfMetacello/BaselineOfMetacello.class.st
+++ b/src/BaselineOfMetacello/BaselineOfMetacello.class.st
@@ -15,7 +15,6 @@ BaselineOfMetacello >> baseline: spec [
 			package: 'System-FileRegistry';
 			package: 'FileSystem-Memory';
 			package: 'Regex-Core';
-			package: 'Ring-Deprecated-Core-Containers';
 			package: 'StartupPreferences';
 			package: 'ConfigurationCommandLineHandler-Core';
 			package: 'PragmaCollector';


### PR DESCRIPTION
Remove Ring-Deprecated-Core-COntainers from Metacello baseline