### PR TITLE
22235-unsafe-TextMorphForFieldViewminimumExtent

### DIFF
--- a/src/Morphic-Base/Paragraph.class.st
+++ b/src/Morphic-Base/Paragraph.class.st
@@ -622,7 +622,7 @@ Paragraph >> lineIndexOfCharacterIndex: characterIndex [
 
 { #category : #private }
 Paragraph >> lines [
-	^ lines
+	^ lines ifNil: [ ^ Array new ]
 ]
 
 { #category : #access }

--- a/src/Morphic-Widgets-Pluggable/TextMorphForFieldView.class.st
+++ b/src/Morphic-Widgets-Pluggable/TextMorphForFieldView.class.st
@@ -141,8 +141,11 @@ TextMorphForFieldView >> minimumExtent [
 	"Use the actual paragraph line to take font changes into account."
 	
 	| minExt |
-	textStyle ifNil: [^ 9@16].
-	borderWidth ifNil: [^ 9@16].
+	(textStyle isNil
+		or: [ borderWidth isNil 
+		or: [ self paragraph lines isEmpty ]])
+		ifTrue: [ ^ 9@16 ].
+		
 	minExt := (9@(self paragraph lines first lineHeight ceiling)) + (borderWidth*2).
 	^ ((0@0 extent: minExt) expandBy: margins) extent
 ]


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/22235/unsafe-TextMorphForFieldView-minimumExtentsafer TextMorphForFieldView>>#minimumExtent