### PR TITLE
20111-Some-Collection-tests-fail-on-64-bit-because-they-assume-Floats-are-non-immediate

### DIFF
--- a/src/Collections-Tests/ArrayTest.class.st
+++ b/src/Collections-Tests/ArrayTest.class.st
@@ -41,14 +41,14 @@ Class {
 		'nonEmpty1Element',
 		'collectionOfCollection',
 		'collectionOfFloatWithEqualElements',
-		'floatCollectionWithSameBeginingAnEnd',
 		'collectionWithoutNil',
 		'duplicateElement',
 		'collection5Elements',
 		'collectionWith4Elements',
 		'collectionOfCollectionsOfStrings',
 		'collectionOfCollectionsOfInts',
-		'simpleCollection'
+		'simpleCollection',
+		'stringCollectionWithSameBeginingAnEnd'
 	],
 	#category : #'Collections-Tests-Arrayed'
 }
@@ -191,14 +191,14 @@ ArrayTest >> collectionWithEqualElements [
 ArrayTest >> collectionWithNonIdentitySameAtEndAndBegining [
 	" return a collection with elements at end and begining equals only with classic equality (they are not the same object).
 (others elements of the collection are not equal to those elements)"
-	^ floatCollectionWithSameBeginingAnEnd 
+	^ stringCollectionWithSameBeginingAnEnd 
 ]
 
 { #category : #requirements }
 ArrayTest >> collectionWithSameAtEndAndBegining [
 " return a collection with elements at end and begining equals .
 (others elements of the collection are not equal to those elements)"
-	^ floatCollectionWithSameBeginingAnEnd 
+	^ stringCollectionWithSameBeginingAnEnd 
 ]
 
 { #category : #requirements }
@@ -341,13 +341,6 @@ ArrayTest >> firstOdd [
 ]
 
 { #category : #requirements }
-ArrayTest >> floatCollectionWithSameAtEndAndBegining [
-" return a collection with elements at end and begining equals only with classic equality (they are not the same object).
-(others elements of the collection are not equal to those elements)"
-	^ floatCollectionWithSameBeginingAnEnd 
-]
-
-{ #category : #requirements }
 ArrayTest >> indexArray [
 	^ indexArray .
 ]
@@ -485,9 +478,9 @@ ArrayTest >> setUp [
 	replacementCollection:= {4. 3. 2. 1.}.
 	replacementCollectionSameSize := {5. 4. 3.}.	
 	nonEmpty1Element:={ 5.}.
-	collectionOfCollection:={1.5. 5.5. 6.5.}.
+	collectionOfCollection:={'a'. 'b'. 'c'.}.
 	collectionOfFloatWithEqualElements:={1.5. 5.5. 6.5. 1.5}.
-	floatCollectionWithSameBeginingAnEnd := {1.5. 5.5. 1.5 copy}.
+	stringCollectionWithSameBeginingAnEnd := {'c'. 's'. 'c' copy}.
 	collection5Elements := { 1. 2. 5. 3. 4.}.
 ]
 

--- a/src/Collections-Tests/ArrayTest.class.st
+++ b/src/Collections-Tests/ArrayTest.class.st
@@ -48,7 +48,8 @@ Class {
 		'collectionOfCollectionsOfStrings',
 		'collectionOfCollectionsOfInts',
 		'simpleCollection',
-		'stringCollectionWithSameBeginingAnEnd'
+		'stringCollectionWithSameBeginingAnEnd',
+		'collectionOfFloat'
 	],
 	#category : #'Collections-Tests-Arrayed'
 }
@@ -153,7 +154,7 @@ ArrayTest >> collectionOfCollectionsOfStrings [
 
 { #category : #requirements }
 ArrayTest >> collectionOfFloat [
-	^ collectionOfCollection
+	^ collectionOfFloat
 ]
 
 { #category : #requirements }
@@ -220,7 +221,7 @@ ArrayTest >> collectionWithoutNilElements [
 
 { #category : #requirements }
 ArrayTest >> elementInCollectionOfFloat [
-	^ collectionOfCollection atRandom
+	^ collectionOfFloat atRandom
 ]
 
 { #category : #requirements }
@@ -479,6 +480,7 @@ ArrayTest >> setUp [
 	replacementCollectionSameSize := {5. 4. 3.}.	
 	nonEmpty1Element:={ 5.}.
 	collectionOfCollection:={'a'. 'b'. 'c'.}.
+	collectionOfFloat:={1.5. 5.5. 6.5.}.
 	collectionOfFloatWithEqualElements:={1.5. 5.5. 6.5. 1.5}.
 	stringCollectionWithSameBeginingAnEnd := {'c'. 's'. 'c' copy}.
 	collection5Elements := { 1. 2. 5. 3. 4.}.
@@ -563,14 +565,12 @@ ArrayTest >> test0FixtureTConvertAsSetForMultiplinessTest [
 	self withEqualElements do: [ :each | self assert: each isFloat ].
 	res := true.
 	self withEqualElements detect: [ :each | (self withEqualElements occurrencesOf: each) > 1 ] ifNone: [ res := false ].
-	self assert: res = true.	"a collection of Float without equal elements:"
-	self elementsCopyNonIdenticalWithoutEqualElements.
-	self elementsCopyNonIdenticalWithoutEqualElements do: [ :each | self assert: each isFloat ].
+	self assert: res.	"a collection of Float without equal elements:"
 	res := true.
 	self elementsCopyNonIdenticalWithoutEqualElements
 		detect: [ :each | (self elementsCopyNonIdenticalWithoutEqualElements occurrencesOf: each) > 1 ]
 		ifNone: [ res := false ].
-	self assert: res = false
+	self deny: res
 ]
 
 { #category : #'tests - iterate' }
@@ -688,9 +688,9 @@ ArrayTest >> testIdentityIncludes [
 ArrayTest >> testIdentityIndexOf [
 	
 	| collection element |
-	element := self elementInCollectionOfFloat copy.
-	self deny: self elementInCollectionOfFloat == element.
-	collection := self collectionOfFloat copyWith: element.
+	element := self collectionWithCopyNonIdentical anyOne copy.
+	self deny: self collectionWithCopyNonIdentical anyOne == element.
+	collection := self collectionWithCopyNonIdentical copyWith: element.
 	self assert: (collection identityIndexOf: element) equals: collection size
 ]
 

--- a/src/Collections-Tests/BagTest.class.st
+++ b/src/Collections-Tests/BagTest.class.st
@@ -275,9 +275,9 @@ BagTest >> setUp [
 		add: 5;
 		yourself.
 	collectionOfString := self speciesClass new
-		add: 1.5;
-		add: 5.5;
-		add: 7.5;
+		add: 'a';
+		add: 'b';
+		add: 'c';
 		yourself.
 	otherCollectionWithoutEqualElements := self speciesClass new
 		add: 1;

--- a/src/Collections-Tests/DictionaryTest.class.st
+++ b/src/Collections-Tests/DictionaryTest.class.st
@@ -19,9 +19,9 @@ Class {
 		'valueNotIn',
 		'keyNotIn',
 		'dictionaryNotIncluded',
-		'nonEmptyWithFloat',
 		'dictionaryWithDuplicateValues',
-		'duplicateValue'
+		'duplicateValue',
+		'nonEmptyWithString'
 	],
 	#classInstVars : [
 		'testToto',
@@ -254,7 +254,7 @@ DictionaryTest >> nonEmptyDifferentFromNonEmptyDict [
 { #category : #requirements }
 DictionaryTest >> nonEmptyWithCopyNonIdentical [
 " return a collection including elements for wich copy is not identical to the initial element ( this is not the cas of Integer )"
-^nonEmptyWithFloat 
+^nonEmptyWithString 
 ]
 
 { #category : #requirements }
@@ -325,7 +325,7 @@ DictionaryTest >> setUp [
 		at: #a
 			put: 5;
 		yourself.
-	nonEmptyWithFloat := Dictionary new add: #A->2.5; add: #b->3.5 ; yourself.
+	nonEmptyWithString := Dictionary new add: #A->'foo'; add: #b->'bar' ; yourself.
 	duplicateValue := 2.5.
 	dictionaryWithDuplicateValues := 	Dictionary new add: #A->duplicateValue ; add: #b->3.5 ; add: #C->duplicateValue  ; yourself.
 

--- a/src/Collections-Tests/HeapTest.class.st
+++ b/src/Collections-Tests/HeapTest.class.st
@@ -23,12 +23,12 @@ Class {
 		'nonEmpty5ElementsWithoutDuplicate',
 		'sameAtEndAndBegining',
 		'nonEmpty1Element',
-		'floatCollection',
 		'indexArray',
 		'subCollection',
 		'duplicateElement',
 		'collectionWithDuplicateElement',
-		'collectionWith4Elements'
+		'collectionWith4Elements',
+		'stringCollection'
 	],
 	#category : #'Collections-Tests-Sequenceable'
 }
@@ -108,7 +108,7 @@ HeapTest >> collectionWith5Elements [
 { #category : #requirements }
 HeapTest >> collectionWithCopyNonIdentical [
 	" return a collection that include elements for which 'copy' return a different object (this is not the case of SmallInteger)"
-	^ floatCollection 
+	^ stringCollection 
 ]
 
 { #category : #requirements }
@@ -227,7 +227,7 @@ HeapTest >> elementTwiceInForOccurrences [
 HeapTest >> elementsCopyNonIdenticalWithoutEqualElements [
 	" return a collection that does niot incllude equal elements ( classic equality )
 	all elements included are elements for which copy is not identical to the element  "
-	^ floatCollection 
+	^ stringCollection 
 ]
 
 { #category : #requirements }
@@ -410,7 +410,7 @@ HeapTest >> setUp [
 	speciesClass := Heap.
 	sameAtEndAndBegining := Heap new add: 1.5 ;  add: 1.5 copy ; yourself.
 	nonEmpty1Element := Heap new add: 5 ; yourself.
-	floatCollection := Heap new add: 2.5 ; add: 5.5 ; add:4.2 ; yourself.
+	stringCollection := Heap new add: 'a' ; add: 'b' ; add: 'c' ; yourself.
 	indexArray := #( 1 3).
 	subCollection := Heap new.
 	duplicateElement := 1.

--- a/src/Collections-Tests/OrderedCollectionTest.class.st
+++ b/src/Collections-Tests/OrderedCollectionTest.class.st
@@ -21,7 +21,6 @@ Class {
 		'elementNotIn',
 		'indexArray',
 		'withoutEqualElements',
-		'floatCollectionWithSameBeginingEnd',
 		'duplicateElement',
 		'collectionWithDuplicateElement',
 		'collection5Elements',
@@ -30,7 +29,9 @@ Class {
 		'collectionOfCollectionsOfStrings',
 		'withCharacters',
 		'collectionNotIncluded',
-		'simpleCollection'
+		'simpleCollection',
+		'collectionOfString',
+		'collectionWithSameBeginingEnd'
 	],
 	#category : #'Collections-Tests-Sequenceable'
 }
@@ -123,11 +124,6 @@ OrderedCollectionTest >> collectionOfCollectionsOfStrings [
 ]
 
 { #category : #requirements }
-OrderedCollectionTest >> collectionOfFloat [
-	^ collectionOfFloat 
-]
-
-{ #category : #requirements }
 OrderedCollectionTest >> collectionWith1TimeSubcollection [
 " return a collection including 'oldSubCollection'  only one time "
 	^ ((OrderedCollection new add: elementNotIn; yourself),self oldSubCollection) add: elementNotIn;yourself   
@@ -153,7 +149,7 @@ OrderedCollectionTest >> collectionWithCharacters [
 { #category : #requirements }
 OrderedCollectionTest >> collectionWithCopyNonIdentical [
 	" return a collection that include elements for which 'copy' return a different object (this is not the case of SmallInteger)"
-	^ collectionOfFloat
+	^ collectionOfString
 ]
 
 { #category : #requirements }
@@ -178,14 +174,14 @@ OrderedCollectionTest >> collectionWithEqualElements [
 OrderedCollectionTest >> collectionWithNonIdentitySameAtEndAndBegining [
 	" return a collection with elements at end and begining equals only with classic equality (they are not the same object).
 (others elements of the collection are not equal to those elements)"
-	^ floatCollectionWithSameBeginingEnd 
+	^ collectionWithSameBeginingEnd 
 ]
 
 { #category : #requirements }
 OrderedCollectionTest >> collectionWithSameAtEndAndBegining [
 " return a collection with elements at end and begining equals .
 (others elements of the collection are not equal to those elements)"
-	^ floatCollectionWithSameBeginingEnd 
+	^ collectionWithSameBeginingEnd 
 ]
 
 { #category : #requirements }
@@ -277,7 +273,7 @@ OrderedCollectionTest >> elementTwiceInForOccurrences [
 { #category : #requirements }
 OrderedCollectionTest >> elementsCopyNonIdenticalWithoutEqualElements [
 	" return a collection that does niot incllude equal elements ( classic equality )"
-	^ collectionOfFloat
+	^ collectionOfString
 ]
 
 { #category : #setup }
@@ -307,13 +303,6 @@ OrderedCollectionTest >> firstCollection [
 OrderedCollectionTest >> firstIndex [
 " return an index between 'nonEmpty' bounds that is < to 'second index' "
 	^1
-]
-
-{ #category : #requirements }
-OrderedCollectionTest >> floatCollectionWithSameAtEndAndBegining [
-" return a collection with elements at end and begining equals only with classic equality (they are not the same object).
-(others elements of the collection are not equal to those elements)"
-	^ floatCollectionWithSameBeginingEnd 
 ]
 
 { #category : #requirements }
@@ -466,7 +455,8 @@ OrderedCollectionTest >> setUp [
 	emptyButAllocatedWith20 := OrderedCollection new: 20. 
 	collectionWithElement := OrderedCollection new add: self element; yourself.
 	collectionOfFloat := OrderedCollection new add: 4.1; add: 7.2; add: 2.5; yourself.
-	floatCollectionWithSameBeginingEnd := OrderedCollection new add: 4.1; add: 7.2; add: 4.1 copy ; yourself.
+	collectionOfString := OrderedCollection new add: 'a'; add: 'b'; add: 'c'; yourself.
+	collectionWithSameBeginingEnd := OrderedCollection new add: 'a'; add: 'b'; add: 'a' copy ; yourself.
 	duplicateElement := 2.
 	collectionWithDuplicateElement := OrderedCollection new add: duplicateElement ; add: duplicateElement ; add:4 ; yourself.	
 
@@ -519,8 +509,6 @@ OrderedCollectionTest >> test0FixtureTConvertAsSetForMultiplinessTest [
 	res := true.
 	self withEqualElements detect: [ :each | (self withEqualElements occurrencesOf: each) > 1 ] ifNone: [ res := false ].
 	self assert: res = true.	"a collection of Float without equal elements:"
-	self elementsCopyNonIdenticalWithoutEqualElements.
-	self elementsCopyNonIdenticalWithoutEqualElements do: [ :each | self assert: each isFloat ].
 	res := true.
 	self elementsCopyNonIdenticalWithoutEqualElements
 		detect: [ :each | (self elementsCopyNonIdenticalWithoutEqualElements occurrencesOf: each) > 1 ]

--- a/src/Collections-Tests/SetTest.class.st
+++ b/src/Collections-Tests/SetTest.class.st
@@ -20,7 +20,8 @@ Class {
 		'nonEmpty1element',
 		'withoutEqualElements',
 		'collection5Elements',
-		'collectionWith3Elements'
+		'collectionWith3Elements',
+		'collectionOfNonIdentical'
 	],
 	#category : #'Collections-Tests-Unordered'
 }
@@ -79,14 +80,9 @@ SetTest >> collectionNotIncluded [
 ]
 
 { #category : #requirements }
-SetTest >> collectionOfFloat [
-	^ collectionOfFloat 
-]
-
-{ #category : #requirements }
 SetTest >> collectionWithCopyNonIdentical [
 	" return a collection that include elements for which 'copy' return a different object (this is not the case of SmallInteger)"
-	^ collectionOfFloat
+	^ collectionOfNonIdentical
 ]
 
 { #category : #requirements }
@@ -227,6 +223,7 @@ SetTest >> setUp [
 	emptyButAllocatedWith20 := self classToBeTested  new: 20.
 	elementNotIn := 99.
 	collectionOfFloat := self classToBeTested  with: 2.5 with: 4.6 with: 4.2.
+	collectionOfNonIdentical := self classToBeTested  with: 'a' with: 'b' with: 'c'.
 	nonEmpty1element := self classToBeTested  with: 32.
 	withoutEqualElements := self classToBeTested  with: 4 with: 5 with: 2.
 	collection5Elements := self classToBeTested with: 1 with: 2 with: 3 with: 4 with: 5.

--- a/src/Collections-Tests/SortedCollectionTest.class.st
+++ b/src/Collections-Tests/SortedCollectionTest.class.st
@@ -16,7 +16,6 @@ Class {
 		'accessCollection',
 		'elementNoteIn',
 		'oldSubcollection',
-		'floatCollectionSameEndAndBegining',
 		'withoutEqualElements',
 		'collectionOfFloatWithDuplicate',
 		'collectionIncluded',
@@ -24,7 +23,9 @@ Class {
 		'collectionWithoutNil',
 		'duplicateFloat',
 		'nonEmpty5Elements',
-		'collectionWith4Elements'
+		'collectionWith4Elements',
+		'collectionOfString',
+		'stringCollectionSameEndAndBegining'
 	],
 	#category : #'Collections-Tests-Unordered'
 }
@@ -92,13 +93,6 @@ SortedCollectionTest >> collectionNotIncluded [
 ]
 
 { #category : #requirements }
-SortedCollectionTest >> collectionOfFloat [
- 	"Return a collection only includiing Float elements "
-	
-	^ collectionOfFloat 
-]
-
-{ #category : #requirements }
 SortedCollectionTest >> collectionOfSize5 [
 	"Return a collection of size 5"
 	
@@ -130,7 +124,7 @@ SortedCollectionTest >> collectionWith5Elements [
 SortedCollectionTest >> collectionWithCopyNonIdentical [
 	"Return a collection that include elements for which 'copy' return a different object (this is not the case of SmallInteger)"
 	
-	^ collectionOfFloat
+	^ collectionOfString
 ]
 
 { #category : #requirements }
@@ -159,21 +153,21 @@ SortedCollectionTest >> collectionWithNonIdentitySameAtEndAndBegining [
 	"Return a collection with elements at end and begining equals only with classic equality (they are not the same object).
 (others elements of the collection are not equal to those elements)"
 
-	^ floatCollectionSameEndAndBegining 
+	^ stringCollectionSameEndAndBegining 
 ]
 
 { #category : #requirements }
 SortedCollectionTest >> collectionWithSameAtEndAndBegining [
 	"Return a collection with elements at end and begining equals (others elements of the collection are not equal to those elements)"
 	
-	^ floatCollectionSameEndAndBegining 
+	^ stringCollectionSameEndAndBegining 
 ]
 
 { #category : #requirements }
 SortedCollectionTest >> collectionWithSortableElements [
 	"Return a collection elements that can be sorted ( understanding message ' < '  or ' > ')"
 	
-	^ collectionOfFloat 
+	^ collectionOfString 
 ]
 
 { #category : #requirements }
@@ -270,7 +264,7 @@ SortedCollectionTest >> elementTwiceInForOccurrences [
 SortedCollectionTest >> elementsCopyNonIdenticalWithoutEqualElements [
 	"Return a collection that does niot incllude equal elements ( classic equality )"
 	
-	^ collectionOfFloat
+	^ collectionOfString
 ]
 
 { #category : #requirements }
@@ -283,14 +277,6 @@ SortedCollectionTest >> empty [
 SortedCollectionTest >> expectedSizeAfterReject [
 
 	^ 1
-]
-
-{ #category : #requirements }
-SortedCollectionTest >> floatCollectionWithSameAtEndAndBegining [
-	"Return a collection with elements at end and begining equals only with classic equality (they are not the same object).
-(others elements of the collection are not equal to those elements)"
-
-	^ floatCollectionSameEndAndBegining 
 ]
 
 { #category : #requirements }
@@ -419,12 +405,13 @@ SortedCollectionTest >> setUp [
 	collectResult add: SmallInteger.
 	nonEmpty1Element := SortedCollection new add:5; yourself.
 	collectionOfFloat := SortedCollection new add:1.2 ; add: 5.6 ; add:4.4 ; add: 1.9 ; yourself.
+	collectionOfString := SortedCollection new add: 'a' ; add: 'b' ; add: 'c' ; add: 'd' ; yourself.
 	duplicateFloat := 1.2.
 	collectionOfFloatWithDuplicate := SortedCollection new add: duplicateFloat  ; add: 5.6 ; add:4.4 ; add: duplicateFloat  ; yourself.
 	accessCollection := SortedCollection new add:1 ; add: 5 ; add:4 ; add: 2 ; add:7 ; yourself.
 	elementNoteIn := 999.
 	oldSubcollection := SortedCollection new add: 2 ; add: 2 ; add: 2 ; yourself.
-	floatCollectionSameEndAndBegining := SortedCollection new add: 1.5 ; add: 1.5 copy ; yourself.
+	stringCollectionSameEndAndBegining := SortedCollection new add: 'a' ; add: 'a' copy ; yourself.
 	withoutEqualElements := SortedCollection new add: 1 ; add: 8 copy ; add: 4;yourself.
 	nonEmpty5Elements := SortedCollection new add: 1 ; add: 8 copy ; add: 4; add: 4; add: 4;yourself.
 ]
@@ -457,9 +444,7 @@ SortedCollectionTest >> test0FixtureTConvertAsSetForMultiplinessTest [
 	self withEqualElements do: [ :each | self assert: each isFloat ].
 	res := true.
 	self withEqualElements detect: [ :each | (self withEqualElements occurrencesOf: each) > 1 ] ifNone: [ res := false ].
-	self assert: res = true.	"a collection of Float without equal elements:"
-	self elementsCopyNonIdenticalWithoutEqualElements.
-	self elementsCopyNonIdenticalWithoutEqualElements do: [ :each | self assert: each isFloat ].
+	self assert: res.	"a collection of Float without equal elements:"
 	res := true.
 	self elementsCopyNonIdenticalWithoutEqualElements
 		detect: [ :each | (self elementsCopyNonIdenticalWithoutEqualElements occurrencesOf: each) > 1 ]


### PR DESCRIPTION
Changed collections enforcing not same idenity to use string literals instead of floats.