### PR TITLE
Fix https://pharo.fogbugz.com/f/cases/22241

### DIFF
--- a/src/UnifiedFFI/FFIExternalStructureType.class.st
+++ b/src/UnifiedFFI/FFIExternalStructureType.class.st
@@ -31,8 +31,7 @@ FFIExternalStructureType >> basicHandle: aHandle at: index [
 
 { #category : #private }
 FFIExternalStructureType >> basicHandle: aHandle at: index put: value [
-	^ LibC memCopy: value getHandle to: aHandle size: self externalTypeSize
-
+	^ LibC memCopy: value getHandle to: aHandle + (index - 1) size: self externalTypeSize
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fix https://pharo.fogbugz.com/f/cases/22241

Current implementation of :

```Smalltalk
FFIExternalStructureType>>basicHandle: aHandle at: index put: value
    ^ LibC memCopy: value getHandle to: aHandle size: self externalTypeSize
```

does not use index value, I propose to rewrite it like this :

```Smalltalk
FFIExternalStructureType>>basicHandle: aHandle at: index put: value
    ^ LibC memCopy: value getHandle to: aHandle + (index - 1) size: self externalTypeSize
```