### PR TITLE
22257-Uppercase-and-lowercase-entries-should-be-merged-in-the-FileDialogWindow-list-of-files-right-column

### DIFF
--- a/src/Tool-FileList/FileDialogWindow.class.st
+++ b/src/Tool-FileList/FileDialogWindow.class.st
@@ -175,12 +175,12 @@ FileDialogWindow >> defaultFileSortBlock [
 
 	^[:entry1 :entry2 |
 		entry1 isDirectory = entry2 isDirectory
-			ifTrue: [entry1 basename <= entry2 basename]
+			ifTrue: [entry1 basename caseInsensitiveLessOrEqual: entry2 basename]
 			ifFalse: [entry1 isDirectory
 						ifTrue: [true]
 						ifFalse: [entry2 isDirectory
 									ifTrue: [false]
-									ifFalse: [entry1 basename <= entry2 basename]]]]
+									ifFalse: [entry1 basename caseInsensitiveLessOrEqual: entry2 basename]]]]
 ]
 
 { #category : #actions }


### PR DESCRIPTION
Fix https://pharo.fogbugz.com/f/cases/22257 - change <= by caseInsensitiveLessOrEqual: