### PR TITLE
22268-MCFileTreeFileSystemUtils-classwriteSteamForindo-should-delete-the-file-if-it-exists

### DIFF
--- a/src/MonticelloFileTree-FileSystem-Utilities/MCFileTreeFileSystemUtils.class.st
+++ b/src/MonticelloFileTree-FileSystem-Utilities/MCFileTreeFileSystemUtils.class.st
@@ -95,5 +95,7 @@ MCFileTreeFileSystemUtils class >> resolvePath: path in: aDirectory [
 
 { #category : #utilities }
 MCFileTreeFileSystemUtils class >> writeStreamFor: filePath in: aDirectory do: aBlock [
-    (aDirectory resolveString: filePath) writeStreamDo: aBlock
+    (aDirectory resolveString: filePath) 
+		ensureDelete;
+		writeStreamDo: aBlock
 ]


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/22268/MCFileTreeFileSystemUtils-class-writeSteamFor-in-do-should-delete-the-file-if-it-existsensure file deletion in MCFileTreeFileSystemUtils