### PR TITLE
22273-When-there-is-a-duplicated-instance-variable-it-is-created-always

### DIFF
--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -143,12 +143,15 @@ ShClassInstallerTest >> testDuplicateClassPreserveSlots [
 
 { #category : #tests }
 ShClassInstallerTest >> testDuplicatedInstanceVariable [
+	superClass := self newClass: #ShCITestClass1 slots: #(aSlot).
+	newClass := self newClass: #ShCITestClass2 superclass: superClass slots: #().
 
-	superClass := self newClass:#ShCITestClass1 slots:#(aSlot).
-	newClass := self newClass:#ShCITestClass2 superclass: superClass slots:#().
-	
-	self should: [newClass := self newClass:#ShCITestClass2 superclass: superClass slots:#(aSlot)] raise: Error.
-	
+	"The DuplicatedSlotName should not be resumable. If it is resume, the process will generate
+   duplicated instance variables. The shadowing of IV is not possible in Pharo."
+	[ newClass := self newClass: #ShCITestClass2 superclass: superClass slots: #(aSlot).
+	self fail ]
+		on: DuplicatedSlotName
+		do: [ :ex | self deny: ex isResumable ]
 ]
 
 { #category : #tests }

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -142,6 +142,16 @@ ShClassInstallerTest >> testDuplicateClassPreserveSlots [
 ]
 
 { #category : #tests }
+ShClassInstallerTest >> testDuplicatedInstanceVariable [
+
+	superClass := self newClass:#ShCITestClass1 slots:#(aSlot).
+	newClass := self newClass:#ShCITestClass2 superclass: superClass slots:#().
+	
+	self should: [newClass := self newClass:#ShCITestClass2 superclass: superClass slots:#(aSlot)] raise: Error.
+	
+]
+
+{ #category : #tests }
 ShClassInstallerTest >> testModifyingClassKeepsOrganizationOfMethods [
 	newClass := self newClass: #ShCITestClass superclass: subClass slots: #().
 

--- a/src/Slot-Core/ClassBuilderWarning.class.st
+++ b/src/Slot-Core/ClassBuilderWarning.class.st
@@ -1,8 +1,0 @@
-"
-I represent a warning signaled while building a class.
-"
-Class {
-	#name : #ClassBuilderWarning,
-	#superclass : #Warning,
-	#category : #'Slot-Core-Exception'
-}

--- a/src/Slot-Core/DuplicatedSlotName.class.st
+++ b/src/Slot-Core/DuplicatedSlotName.class.st
@@ -3,7 +3,7 @@ I am signaled when trying to build a class with a duplicated slot.
 "
 Class {
 	#name : #DuplicatedSlotName,
-	#superclass : #ClassBuilderWarning,
+	#superclass : #ClassBuilderError,
 	#instVars : [
 		'newSlot',
 		'oldSlot',

--- a/src/Slot-Core/InvalidGlobalName.class.st
+++ b/src/Slot-Core/InvalidGlobalName.class.st
@@ -3,7 +3,7 @@ I am a warning signaled when trying to build a class with invalid name.
 "
 Class {
 	#name : #InvalidGlobalName,
-	#superclass : #ClassBuilderWarning,
+	#superclass : #ClassBuilderError,
 	#category : #'Slot-Core-Exception'
 }
 

--- a/src/Slot-Core/InvalidSlotName.class.st
+++ b/src/Slot-Core/InvalidSlotName.class.st
@@ -3,7 +3,7 @@ I am signaled when the name of a Slot is an invalid variable name.
 "
 Class {
 	#name : #InvalidSlotName,
-	#superclass : #ClassBuilderWarning,
+	#superclass : #ClassBuilderError,
 	#category : #'Slot-Core-Exception'
 }
 


### PR DESCRIPTION
The warnings in the class building process should produce an exception, not a warning. The warning is resumedIssue: https://pharo.manuscript.com/f/cases/22273/When-there-is-a-duplicated-instance-variable-it-is-created-always