### PR TITLE
22281-ReadWriteStream-broken

### DIFF
--- a/src/Collections-Streams/ReadWriteStream.class.st
+++ b/src/Collections-Streams/ReadWriteStream.class.st
@@ -15,6 +15,13 @@ ReadWriteStream >> = other [
 	^ self position = other position and: [self contents = other contents]
 ]
 
+{ #category : #accessing }
+ReadWriteStream >> contents [
+
+	readLimit := readLimit max: position.
+	^ collection copyFrom: 1 to: readLimit
+]
+
 { #category : #comparing }
 ReadWriteStream >> hash [
 
@@ -53,13 +60,6 @@ ReadWriteStream >> next: anInteger [
 	position := endPosition.
 	^ans
 
-]
-
-{ #category : #initialization }
-ReadWriteStream >> on: aCollection [
-
-	super on: aCollection.
-	readLimit := aCollection size
 ]
 
 { #category : #accessing }

--- a/src/Collections-Tests/ReadStreamTest.class.st
+++ b/src/Collections-Tests/ReadStreamTest.class.st
@@ -35,23 +35,38 @@ ReadStreamTest >> streamOnString [
 	^ ReadStream on: 'abcde'.
 ]
 
+{ #category : #'tests - testing' }
+ReadStreamTest >> testAtEnd [
+	self assert: self emptyStream atEnd.
+	self deny: self streamOnString atEnd
+]
+
 { #category : #tests }
 ReadStreamTest >> testBack [
-	|stream|
+	| stream |
 	stream := 'abc' readStream.
 	stream setToEnd.
-	self assert: stream back = $c.
+	self assert: stream back equals: $c.
 
 ]
 
 { #category : #tests }
 ReadStreamTest >> testBackOnPosition1 [
 	"Test the new implementation of the method back."
-	|stream|
+	| stream |
 	stream := 'abc' readStream.
 	stream next.
-	self assert: stream back = $a.
+	self assert: stream back equals: $a.
 
+]
+
+{ #category : #'tests - accessing' }
+ReadStreamTest >> testContents [
+	| stream |
+	stream := self streamOnString.
+	self assert: stream contents equals: 'abcde'.
+	stream next: 2.
+	self assert: stream contents equals: 'abcde'
 ]
 
 { #category : #'tests - testing' }
@@ -75,10 +90,10 @@ ReadStreamTest >> testIsEmpty [
 { #category : #tests }
 ReadStreamTest >> testOldBack [
 	"Test the old behavior of the method back. The method #oldBack is a misconception about what a stream is. A stream contains a pointer *between* elements with past and future elements. The method #oldBack considers that the pointer is *on* an element. (Damien Cassou - 1 August 2007)"
-	|stream|
+	| stream |
 	stream := 'abc' readStream.
 	stream setToEnd.
-	self assert: stream oldBack = $b.
+	self assert: stream oldBack equals: $b.
 
 ]
 
@@ -95,31 +110,31 @@ ReadStreamTest >> testOldBackOnPosition1 [
 { #category : #tests }
 ReadStreamTest >> testOldPeekBack [
 	"Test the old behavior of the method peekBack. The method #oldBack is a misconception about what a stream is. A stream contains a pointer *between* elements with past and future elements. The method #oldBack considers that the pointer is *on* an element. (Damien Cassou - 1 August 2007)"
-	|stream|
+	| stream |
 	stream := 'abc' readStream.
 	stream setToEnd.
-	self assert: stream oldPeekBack = $b.
+	self assert: stream oldPeekBack equals: $b.
 
 ]
 
 { #category : #tests }
 ReadStreamTest >> testPeekBack [
 	"Test the new implementation of the method peekBack due to changing #back."
-	|stream|
+	| stream |
 	stream := 'abc' readStream.
 	stream setToEnd.
-	self assert: stream peekBack = $c.
+	self assert: stream peekBack equals: $c.
 
 ]
 
 { #category : #tests }
 ReadStreamTest >> testPositionOfSubCollection [
 	
-	self assert: ('xyz' readStream positionOfSubCollection: 'q' ) = 0.
-	self assert: ('xyz' readStream positionOfSubCollection: 'x' ) = 1.
+	self assert: ('xyz' readStream positionOfSubCollection: 'q' ) equals: 0.
+	self assert: ('xyz' readStream positionOfSubCollection: 'x' ) equals: 1.
 
-	self assert: ('xyz' readStream positionOfSubCollection: 'y' ) = 2.
-	self assert: ('xyz' readStream positionOfSubCollection: 'z' ) = 3.
+	self assert: ('xyz' readStream positionOfSubCollection: 'y' ) equals: 2.
+	self assert: ('xyz' readStream positionOfSubCollection: 'z' ) equals: 3.
 ]
 
 { #category : #'tests - accessing' }
@@ -127,11 +142,11 @@ ReadStreamTest >> testUpTo3 [
 	| stream string |
 	string := 'XYZabcdUVW'.
 	stream := ReadStream on: string from: (string indexOf: $a) to: (string indexOf: $d).
-	self assert: stream upToEnd = 'abcd'.
+	self assert: stream upToEnd equals: 'abcd'.
 	self assert: stream atEnd.
 	stream := ReadStream on: string from: (string indexOf: $a) to: (string indexOf: $d).
-	self assert: (stream upTo: $c) = 'ab'.
-	self assert: stream next = $d.
+	self assert: (stream upTo: $c) equals: 'ab'.
+	self assert: stream next equals: $d.
 	stream := ReadStream on: string from: (string indexOf: $a) to: (string indexOf: $d).
 	self assert: (stream upTo: $e) = 'abcd'.
 	self assert: stream atEnd.
@@ -139,29 +154,23 @@ ReadStreamTest >> testUpTo3 [
 
 { #category : #tests }
 ReadStreamTest >> testUpToAll [
-
-	self assert: (self streamOn: 'abcdefgh' upToAll: 'cd') = 'ab'.
-	self assert: (self streamOn: 'abcdefgh' upToAll: 'cd' upToAll: 'gh') = 'ef'.
-
-	self assert: (self streamOn: '' upToAll: '') = ''.
-
-	self assert: (self streamOn: 'a' upToAll: '') = ''.
-	self assert: (self streamOn: 'a' upToAll: 'a') = ''.
-	self assert: (self streamOn: 'a' upToAll: 'b') = 'a'.
-
-	self assert: (self streamOn: 'ab' upToAll: '') = ''.
-	self assert: (self streamOn: 'ab' upToAll: 'a') = ''.
-	self assert: (self streamOn: 'ab' upToAll: 'b') = 'a'.
-	self assert: (self streamOn: 'ab' upToAll: 'c') = 'ab'.
-	self assert: (self streamOn: 'ab' upToAll: 'ab') = ''.
-
-	self assert: (self streamOn: 'abc' upToAll: '') = ''.
-	self assert: (self streamOn: 'abc' upToAll: 'a') = ''.
-	self assert: (self streamOn: 'abc' upToAll: 'b') = 'a'.
-	self assert: (self streamOn: 'abc' upToAll: 'c') = 'ab'.
-	self assert: (self streamOn: 'abc' upToAll: 'd') = 'abc'.
-	self assert: (self streamOn: 'abc' upToAll: 'ab') = ''.
-	self assert: (self streamOn: 'abc' upToAll: 'bc') = 'a'.
-	self assert: (self streamOn: 'abc' upToAll: 'cd') = 'abc'.
-
+	self assert: (self streamOn: 'abcdefgh' upToAll: 'cd') equals: 'ab'.
+	self assert: (self streamOn: 'abcdefgh' upToAll: 'cd' upToAll: 'gh') equals: 'ef'.
+	self assert: (self streamOn: '' upToAll: '') equals: ''.
+	self assert: (self streamOn: 'a' upToAll: '') equals: ''.
+	self assert: (self streamOn: 'a' upToAll: 'a') equals: ''.
+	self assert: (self streamOn: 'a' upToAll: 'b') equals: 'a'.
+	self assert: (self streamOn: 'ab' upToAll: '') equals: ''.
+	self assert: (self streamOn: 'ab' upToAll: 'a') equals: ''.
+	self assert: (self streamOn: 'ab' upToAll: 'b') equals: 'a'.
+	self assert: (self streamOn: 'ab' upToAll: 'c') equals: 'ab'.
+	self assert: (self streamOn: 'ab' upToAll: 'ab') equals: ''.
+	self assert: (self streamOn: 'abc' upToAll: '') equals: ''.
+	self assert: (self streamOn: 'abc' upToAll: 'a') equals: ''.
+	self assert: (self streamOn: 'abc' upToAll: 'b') equals: 'a'.
+	self assert: (self streamOn: 'abc' upToAll: 'c') equals: 'ab'.
+	self assert: (self streamOn: 'abc' upToAll: 'd') equals: 'abc'.
+	self assert: (self streamOn: 'abc' upToAll: 'ab') equals: ''.
+	self assert: (self streamOn: 'abc' upToAll: 'bc') equals: 'a'.
+	self assert: (self streamOn: 'abc' upToAll: 'cd') equals: 'abc'
 ]

--- a/src/Collections-Tests/ReadWriteStreamTest.class.st
+++ b/src/Collections-Tests/ReadWriteStreamTest.class.st
@@ -15,6 +15,38 @@ Class {
 	#category : #'Collections-Tests-Streams'
 }
 
+{ #category : #coverage }
+ReadWriteStreamTest >> classToBeTested [
+	
+	^ ReadWriteStream
+]
+
+{ #category : #'accessing - defaults' }
+ReadWriteStreamTest >> emptyByteStream [
+	^ ReadWriteStream on: (ByteArray new: 4096).
+]
+
+{ #category : #'accessing - defaults' }
+ReadWriteStreamTest >> emptyStream [
+	^ ReadWriteStream on: (String new: 4096).
+]
+
+{ #category : #'accessing - defaults' }
+ReadWriteStreamTest >> streamOnString [
+	^ ReadWriteStream with: 'abcde'.
+]
+
+{ #category : #'tests - testing' }
+ReadWriteStreamTest >> testAtEnd [
+	| stream |
+	stream := self emptyStream.
+	self assert: stream atEnd.
+	stream
+		nextPut: $a;
+		reset.
+	self deny: stream atEnd
+]
+
 { #category : #tests }
 ReadWriteStreamTest >> testConstructionUsingWith [
 	"Use the with: constructor."
@@ -24,10 +56,29 @@ ReadWriteStreamTest >> testConstructionUsingWith [
 	self assert: (aStream contents = #(1 2)) description: 'Ensure correct initialization.'
 ]
 
+{ #category : #tests }
+ReadWriteStreamTest >> testContents [
+	| stream |
+	stream := self emptyStream.
+	stream
+		nextPutAll: 'abc';
+		reset.
+	self assert: stream contents equals: 'abc'.
+	stream next: 2.
+	self assert: stream contents equals: 'abc'.
+	stream := self emptyByteStream.
+	stream
+		nextPutAll: 'abc' asByteArray;
+		reset.
+	self assert: stream contents equals: 'abc' asByteArray.
+	stream next: 2.
+	self assert: stream contents equals: 'abc' asByteArray
+]
+
 { #category : #'tests - testing' }
 ReadWriteStreamTest >> testIsEmpty [
 	| stream |
-	stream := ReadWriteStream on: String new.
+	stream := self emptyStream.
 	self assert: stream isEmpty.
 	stream nextPut: $a.
 	self deny: stream isEmpty.
@@ -40,5 +91,217 @@ ReadWriteStreamTest >> testIsEmpty [
 { #category : #tests }
 ReadWriteStreamTest >> testNew [
 
-	self should: [ReadWriteStream new] raise: Error.
+	self should: [ ReadWriteStream new ] raise: Error.
+]
+
+{ #category : #tests }
+ReadWriteStreamTest >> testNext [
+	| stream |
+	stream := self emptyStream.
+	stream
+		nextPutAll: 'abcd';
+		reset.
+	self assert: stream next equals: $a.
+	self assert: (stream next: 0) equals: ''.
+	self assert: (stream next: 1) equals: 'b'.
+	self assert: (stream next: 2) equals: 'cd'.
+	stream := self emptyByteStream.
+	stream
+		nextPutAll: 'abcd' asByteArray;
+		reset.
+	self assert: stream next equals: 97.
+	self assert: (stream next: 0) equals: '' asByteArray.
+	self assert: (stream next: 1) equals: 'b' asByteArray.
+	self assert: (stream next: 2) equals: 'cd' asByteArray
+]
+
+{ #category : #tests }
+ReadWriteStreamTest >> testNextPut [
+	| stream |
+	stream := self emptyStream.
+	stream nextPut: $a.
+	self assert: stream contents equals: 'a'.
+	stream := self emptyByteStream.
+	stream nextPut: 97.
+	self assert: stream contents equals: 'a' asByteArray
+]
+
+{ #category : #tests }
+ReadWriteStreamTest >> testNextPutAll [
+	| stream |
+	stream := self emptyStream.
+	stream nextPutAll: 'abc'.
+	self assert: stream contents equals: 'abc'.
+	stream := self emptyStream.
+	stream nextPutAll: #($a $b $c).
+	self assert: stream contents equals: 'abc'.
+	stream := self emptyByteStream.
+	stream nextPutAll: #(97 98 99 ) asByteArray.
+	self assert: stream contents equals: 'abc' asByteArray
+]
+
+{ #category : #tests }
+ReadWriteStreamTest >> testPeek [
+	| stream |
+	stream := self emptyStream.
+	self assert: stream peek isNil.
+	stream := self emptyStream.
+	stream
+		nextPutAll: 'abcd';
+		reset.
+	self assert: stream peek equals: $a.
+	stream := self emptyByteStream.
+	stream
+		nextPutAll: 'abcd' asByteArray;
+		reset.
+	self assert: stream peek equals: 97
+]
+
+{ #category : #tests }
+ReadWriteStreamTest >> testPosition [
+	| stream |
+	stream := self emptyStream.
+	stream
+		nextPutAll: 'abc';
+		reset.
+	self assert: stream position equals: 0.
+	stream next.
+	self assert: stream position equals: 1.
+	stream next.
+	self assert: stream position equals: 2.
+	stream next.
+	self assert: stream position equals: 3.
+	stream position: 1.
+	self assert: stream position equals: 1.
+	self assert: stream next equals: $b.
+	stream position: 0.
+	self assert: stream position equals: 0.
+	self assert: stream next equals: $a.
+	stream position: 3.
+	self assert: stream atEnd.
+	stream := self emptyByteStream.
+	stream
+		nextPutAll: 'abc' asByteArray;
+		reset.
+	self assert: stream position equals: 0.
+	stream next.
+	self assert: stream position equals: 1.
+	stream next.
+	self assert: stream position equals: 2.
+	stream next.
+	self assert: stream position equals: 3.
+	stream position: 1.
+	self assert: stream position equals: 1.
+	self assert: stream next equals: 98.
+	stream position: 0.
+	self assert: stream position equals: 0.
+	self assert: stream next equals: 97.
+	stream position: 3.
+	self assert: stream atEnd
+]
+
+{ #category : #tests }
+ReadWriteStreamTest >> testReset [
+	| stream |
+	stream := self emptyStream.
+	stream
+		nextPutAll: 'abc';
+		reset.
+	stream next: 2.
+	stream reset.
+	self assert: stream next equals: $a.
+	stream := self emptyStream.
+	stream 
+		nextPutAll: 'abc';
+		reset.
+	stream nextPutAll: 'def'.
+	self assert: stream contents equals: 'def'.
+	stream := self emptyByteStream.
+	stream
+		nextPutAll: 'abc' asByteArray;
+		reset.
+	stream next: 2.
+	stream reset.
+	self assert: stream next equals: 97
+]
+
+{ #category : #tests }
+ReadWriteStreamTest >> testSkip [
+	| stream |
+	stream := self emptyStream.
+	stream
+		nextPutAll: 'abcd';
+		reset.
+	self assert: (stream skip: 2; peek) equals: $c.
+	stream := self emptyByteStream.
+	stream
+		nextPutAll: 'abcd' asByteArray;
+		reset.
+	self assert: (stream skip: 2; peek) equals: 99
+]
+
+{ #category : #tests }
+ReadWriteStreamTest >> testTab [
+	| stream |
+	stream := self emptyStream.
+	stream tab.
+	self assert: stream contents first equals: Character tab
+]
+
+{ #category : #tests }
+ReadWriteStreamTest >> testUpTo [
+	| stream |
+	stream := self emptyStream.
+	stream
+		nextPutAll: 'abcd';
+		reset.
+	self assert: (stream upTo: $c) equals: 'ab'.
+	self assert: stream next equals: $d.
+	stream := self emptyStream.
+	stream
+		nextPutAll: 'abcd';
+		reset.
+	self assert: (stream upTo: $x) equals: 'abcd'.
+	self assert: stream atEnd.
+	stream := self emptyByteStream.
+	stream
+		nextPutAll: 'abcd' asByteArray;
+		reset.
+	self assert: (stream upTo: 99) equals: #(97 98) asByteArray.
+	self assert: stream next equals: 100.
+	stream := self emptyByteStream.
+	stream
+		nextPutAll: 'abcd' asByteArray;
+		reset.
+	self assert: (stream upTo: 120) equals: #(97 98 99 100) asByteArray.
+	self assert: stream atEnd
+]
+
+{ #category : #tests }
+ReadWriteStreamTest >> testUpToEnd [
+	| stream |
+	stream := self emptyStream.
+	stream
+		nextPutAll: 'abcd';
+		reset.
+	self assert: stream upToEnd equals: 'abcd'.
+	self assert: stream atEnd.
+	self assert: stream upToEnd equals: ''.
+	self assert: stream atEnd.
+	stream reset.
+	stream upTo: $b.
+	self assert: stream upToEnd equals: 'cd'.
+	self assert: stream atEnd.
+	stream := self emptyByteStream.
+	stream
+		nextPutAll: 'abcd' asByteArray;
+		reset.
+	self assert: stream upToEnd equals: #(97 98 99 100) asByteArray.
+	self assert: stream atEnd.
+	self assert: stream upToEnd equals: #() asByteArray.
+	self assert: stream atEnd.
+	stream reset.
+	stream upTo: 98.
+	self assert: stream upToEnd equals: #(99 100) asByteArray.
+	self assert: stream atEnd
 ]

--- a/src/Zinc-Character-Encoding-Tests/ZnBufferedReadWriteStreamTests.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnBufferedReadWriteStreamTests.class.st
@@ -77,7 +77,8 @@ ZnBufferedReadWriteStreamTests >> testReadThenWrite [
 	((SystemVersion current major < 7) or: [ SystemVersion current build < 690 ])
 		ifTrue: [ ^ self skip ].
 
-	stringStream := ReadWriteStream on: '0123456789'.
+	stringStream := ReadWriteStream with: '0123456789'.
+	stringStream reset.
 	stream := ZnBufferedReadWriteStream on: stringStream.
 	stream sizeBuffer: 8.
 	
@@ -121,7 +122,8 @@ ZnBufferedReadWriteStreamTests >> testWriteThenRead [
 	((SystemVersion current major < 7) or: [ SystemVersion current build < 690 ])
 		ifTrue: [ ^ self skip ].
 
-	stringStream := ReadWriteStream on: '0123456789'.
+	stringStream := ReadWriteStream with: '0123456789'.
+	stringStream reset.
 	stream := ZnBufferedReadWriteStream on: stringStream.
 	stream sizeBuffer: 8.
 	


### PR DESCRIPTION
Fix broken ReadWriteStream behavior, add more unit tests for ReadWriteStream (and also a bit for ReadStream) and fix the broken ZnBufferedReadWriteTests accordingly.These fixes are required to make Grease:master (and hence also Seaside3) work correctly on Pharo7 (see https://travis-ci.org/SeasideSt/Grease/jobs/406668036)