### PR TITLE
22287-size-t-type-does-not-have-right-size-in-windows-64bit

### DIFF
--- a/src/UnifiedFFI/ByteArray.extension.st
+++ b/src/UnifiedFFI/ByteArray.extension.st
@@ -62,6 +62,23 @@ ByteArray >> platformLongAt: byteOffset put: value [
 ]
 
 { #category : #'*UnifiedFFI' }
+ByteArray >> platformSizeTAt: byteOffset [
+	^ self 
+		integerAt: byteOffset 
+		size: FFIArchitecture forCurrentArchitecture sizeTTypeSize
+		signed: false
+]
+
+{ #category : #'*UnifiedFFI' }
+ByteArray >> platformSizeTAt: byteOffset put: value [
+	self 
+		integerAt: byteOffset
+		put: value
+		size: FFIArchitecture forCurrentArchitecture sizeTTypeSize
+		signed: false
+]
+
+{ #category : #'*UnifiedFFI' }
 ByteArray >> platformUnsignedLongAt: byteOffset [
 	^ self 
 		integerAt: byteOffset 

--- a/src/UnifiedFFI/FFIArchitecture.class.st
+++ b/src/UnifiedFFI/FFIArchitecture.class.st
@@ -50,6 +50,11 @@ FFIArchitecture >> externalLongType [
 ]
 
 { #category : #types }
+FFIArchitecture >> externalSizeTType [
+	^ ExternalType ulong
+]
+
+{ #category : #types }
 FFIArchitecture >> externalULongType [
 	^ ExternalType ulong
 ]
@@ -97,6 +102,11 @@ FFIArchitecture >> returnSingleFloatsAsDoubles [
 { #category : #'default abi' }
 FFIArchitecture >> shadowCallSpaceSize [
 	^ 0
+]
+
+{ #category : #types }
+FFIArchitecture >> sizeTTypeSize [
+	^ self externalSizeTType byteSize
 ]
 
 { #category : #types }

--- a/src/UnifiedFFI/FFISizeT.class.st
+++ b/src/UnifiedFFI/FFISizeT.class.st
@@ -10,15 +10,9 @@ Class {
 	#category : #'UnifiedFFI-Types'
 }
 
-{ #category : #converting }
-FFISizeT class >> asExternalTypeOn: generator [
-	"We resolve size_t to a uint/ulong which may be not the case always"
-	^ generator resolveType: #ulong
-]
-
 { #category : #accessing }
 FFISizeT class >> externalType [ 
-	^ ExternalType long
+	^ FFIArchitecture forCurrentArchitecture externalSizeTType
 ]
 
 { #category : #accessing }
@@ -33,26 +27,71 @@ FFISizeT class >> externalTypeSize [
 
 { #category : #private }
 FFISizeT >> basicHandle: aHandle at: index [
-	^ aHandle platformUnsignedLongAt: index
+	^ aHandle platformSizeTAt: index
 ]
 
 { #category : #private }
 FFISizeT >> basicHandle: aHandle at: index put: value [
-	^ aHandle platformUnsignedLongAt: index put: value
+	^ aHandle platformSizeTAt: index put: value
 ]
 
-{ #category : #'emitting code' }
+{ #category : #'private emitting code' }
+FFISizeT >> emitSelector [
+	^ 'platformSizeTAt'
+]
+
+{ #category : #accessing }
+FFISizeT >> offsetPointerReadFieldAt: offsetVariableName [
+	^ '^ExternalData 
+		fromHandle: (handle {1}: {2})
+		type: FFIArchitecture forCurrentArchitecture externalSizeTType asPointerType'
+	format: { 
+		self emitSelector.
+		offsetVariableName }
+]
+
+{ #category : #accessing }
+FFISizeT >> offsetReadFieldAt: offsetVariableName [
+	self isPointer ifTrue: [ 
+		^ self offsetPointerReadFieldAt: offsetVariableName ].
+	
+	^ String streamContents: [ :stream |
+		stream << '^handle ' << self emitSelector << ': ' << offsetVariableName ]
+]
+
+{ #category : #accessing }
+FFISizeT >> offsetWriteFieldAt: offsetVariableName with: valueName [
+	self isPointer ifTrue: [ 
+		^ self externalTypeWithArity 
+			offsetWriteFieldAt: offsetVariableName 
+			with: valueName ].
+
+	^ String streamContents: [ :stream |
+		stream 
+			<< '^handle ' << self emitSelector << ': ' << offsetVariableName 
+			<< ' put: ' << valueName ]
+]
+
+{ #category : #accessing }
+FFISizeT >> pointerReadFieldAt: byteOffset [
+	"since offsetPointerReadFieldAt: receives a variable no matter what we use the trick of 
+	 just passing the offset as a string... it will work :)"
+	^ self offsetPointerReadFieldAt: byteOffset asString
+]
+
+{ #category : #accessing }
 FFISizeT >> readFieldAt: byteOffset [
 	self isPointer ifTrue: [ 
 		^ self pointerReadFieldAt: byteOffset ].
 
 	^ String streamContents: [ :stream |
-		stream << '^handle platformUnsignedLongAt: ' << byteOffset asString ].
+		stream << '^handle ' << self emitSelector << ': ' << byteOffset asString ].
 
 ]
 
-{ #category : #'emitting code' }
+{ #category : #accessing }
 FFISizeT >> writeFieldAt: byteOffset with: valueName [
+
 	self isPointer ifTrue: [ 
 		^ self externalTypeWithArity 
 			writeFieldAt: byteOffset
@@ -60,7 +99,7 @@ FFISizeT >> writeFieldAt: byteOffset with: valueName [
 
 	^ String streamContents: [ :stream |
 		stream 
-			<< '^handle platformUnsignedLongAt: ' << byteOffset asString
+			<< '^handle ' << self emitSelector << ': ' << byteOffset asString
 			<< ' put: ' << valueName ]
 
 ]

--- a/src/UnifiedFFI/FFISizeT.class.st
+++ b/src/UnifiedFFI/FFISizeT.class.st
@@ -2,7 +2,6 @@
 I'm a size_t type. 
 I can change in different architectures (32/64bits)
 
-WARNING: I'm just implemented 32bits!
 "
 Class {
 	#name : #FFISizeT,

--- a/src/UnifiedFFI/FFI_x86_64.class.st
+++ b/src/UnifiedFFI/FFI_x86_64.class.st
@@ -20,6 +20,11 @@ FFI_x86_64 >> externalLongType [
 ]
 
 { #category : #types }
+FFI_x86_64 >> externalSizeTType [
+	^ ExternalType unsignedLongLong
+]
+
+{ #category : #types }
 FFI_x86_64 >> externalULongType [
 	^ ExternalType unsignedLongLong
 ]


### PR DESCRIPTION
https://pharo.manuscript.com/f/cases/22287/size_t-type-does-not-have-right-size-in-windows-64bitsize_t needs to be resolved depending platform, otherwise we will  crash when using it in win64 context, where sizeof(ulong) ~= sizeof(size_t)