### PR TITLE
22288-The-changes-in-21855-affect-old-extension-methods-that-are-not-case-equals

### DIFF
--- a/src/Monticello/MCPackageManager.class.st
+++ b/src/Monticello/MCPackageManager.class.st
@@ -47,7 +47,7 @@ MCPackageManager class >> bestMatchingManagerForCategory: aSystemCategory do: aB
 	self registry do: [ :mgr |
 		| candidatePackages bestMatchingPackage |
 		candidatePackages := mgr packageSet packages select: [ :package |
-			package name beginsWith: aSystemCategory ].
+			package name asUppercase beginsWith: aSystemCategory asUppercase ].
 		bestMatchingPackage := candidatePackages detectMin: [ :package |
 			package name size ].
 		bestMatchingPackage ifNotNil: [


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/22288/The-changes-in-21855-affect-old-extension-methods-that-are-not-case-equals

In 21855 the comparison of MCPackages was made case sensitive. This has problems when there are extension methods that are wrongly defined... For example, loading JSON 1.2

Metacello new
    configuration: 'JSON';
    repository: 'http://smalltalkhub.com/mc/PharoExtras/JSON/main/';
    version: '1.2';
    load.

will create two packages in latest pharo 7 (JSON, Json-printing). The second package is indeed wrong, it is created because the a method has "*Json-printing" as protocol, instead of "*JSON".

This PR introduces a case insensitive comparison of protocols when installing extension methods to be able to load old packages with wrong protocols.