### PR TITLE
22291-Deprecation-of-OSEnvironment-default-should-have-a-rewrite-tool

### DIFF
--- a/src/Deprecated70/OSEnvironment.extension.st
+++ b/src/Deprecated70/OSEnvironment.extension.st
@@ -3,6 +3,10 @@ Extension { #name : #OSEnvironment }
 { #category : #'*Deprecated70' }
 OSEnvironment class >> default [
 
-	self deprecated: 'Use #current'.
+	self
+		deprecated: 'Please use #current instead'
+		transformWith: '`@receiver default' 
+						-> '`@receiver current'.
+
 	^ self current
 ]


### PR DESCRIPTION
Adding rewrite rule to the deprecation of #default in OSEnvironment.Issue: https://pharo.manuscript.com/f/cases/22291/Deprecation-of-OSEnvironment-default-should-have-a-rewrite-tool