### PR TITLE
22292-MCTraitDefinition-should-correctly-support-stateful-traits

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,3 @@
+{
+	'srcDirectory' : 'src'
+}

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -183,6 +183,9 @@ MCClassDefinition >> classInstVarNames [
 
 { #category : #printing }
 MCClassDefinition >> classInstanceVariables [
+
+	variables ifNil: [ ^ #() ].
+
 	^self usesSpecialVariables 
 		ifTrue: [ self variablesOfType: #isClassInstanceVariable]
 		ifFalse: [self classInstanceVariablesString asSlotCollection]

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -50,7 +50,7 @@ MCTraitDefinition >> = aDefinition [
 		and: [(self isRevisionOf: aDefinition)
 		and: [self traitCompositionString = aDefinition traitCompositionString
 		and: [category = aDefinition category
-		and: [self instanceVariablesString = aDefinition instanceVariablesString
+		and: [self slotDefinitionString = aDefinition slotDefinitionString
 		and: [comment = aDefinition comment]]]]]
 ]
 

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -51,13 +51,28 @@ MCTraitDefinition >> = aDefinition [
 		and: [self traitCompositionString = aDefinition traitCompositionString
 		and: [category = aDefinition category
 		and: [self slotDefinitionString = aDefinition slotDefinitionString
-		and: [comment = aDefinition comment]]]]]
+		and: [self classInstVarNames  = aDefinition classInstVarNames  
+		and: [comment = aDefinition comment]]]]]]
 ]
 
 { #category : #visiting }
 MCTraitDefinition >> accept: aVisitor [
 	^ aVisitor visitTraitDefinition: self
 
+]
+
+{ #category : #printing }
+MCTraitDefinition >> classSlotDefinitionString [
+
+	^ self usesSpecialVariables 
+		ifTrue: [ self classInstanceVariables asString ]
+		ifFalse: [ 
+			String streamContents: [ :stream |
+				stream nextPutAll: '{ '.
+				self classInstanceVariables 
+					do: [ :each | stream print: each name ]
+					separatedBy: [ stream nextPutAll: '. ' ].
+				stream nextPutAll: ' }']]
 ]
 
 { #category : #installing }
@@ -68,7 +83,10 @@ MCTraitDefinition >> createClass [
 		uses: (Smalltalk compiler evaluate: self traitCompositionString)
 		slots: self instanceVariables
 		category: category.
-	trait ifNotNil: [trait classComment: comment stamp: commentStamp].
+	trait ifNotNil: [
+		trait classComment: comment stamp: commentStamp.
+		self classInstanceVariables ifNotEmpty: [
+			trait classSide slots: self classInstanceVariables ]].
 	^trait
 ]
 

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -185,6 +185,9 @@ MCTraitDefinition >> requirements [
 
 { #category : #printing }
 MCTraitDefinition >> slotDefinitionString [
+
+	variables ifNil: [ ^ '{ }' ].
+
 	^ self usesSpecialVariables 
 		ifTrue: [ self instanceVariables asString ]
 		ifFalse: [ 

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -50,7 +50,8 @@ MCTraitDefinition >> = aDefinition [
 		and: [(self isRevisionOf: aDefinition)
 		and: [self traitCompositionString = aDefinition traitCompositionString
 		and: [category = aDefinition category
-		and: [comment = aDefinition comment]]]]
+		and: [self instanceVariablesString = aDefinition instanceVariablesString
+		and: [comment = aDefinition comment]]]]]
 ]
 
 { #category : #visiting }
@@ -153,7 +154,16 @@ MCTraitDefinition >> printDefinitionOn: stream [
 		 tab;
 		 nextPutAll: 'uses: ';
 		 nextPutAll: self traitCompositionString;
-		 cr;
+		 cr.
+
+	self instanceVariablesString isEmpty ifFalse: [
+			stream 
+				tab;
+				nextPutAll: 'slots: ';
+		 		nextPutAll: self slotDefinitionString;
+				cr ].
+		
+	stream
 		 tab;
 		 nextPutAll: 'category: ';
 		 store: self category asString
@@ -171,4 +181,17 @@ MCTraitDefinition >> requirements [
 	tokens := traitComposition parseLiterals.
 	traitNames := tokens select: [:each | each first isUppercase].
 	^traitNames asArray
+]
+
+{ #category : #printing }
+MCTraitDefinition >> slotDefinitionString [
+	^ self usesSpecialVariables 
+		ifTrue: [ self instanceVariables asString ]
+		ifFalse: [ 
+			String streamContents: [ :stream |
+				stream nextPutAll: '{ '.
+				self instanceVariables 
+					do: [ :each | stream print: each name ]
+					separatedBy: [ stream nextPutAll: '. ' ].
+				stream nextPutAll: ' }']]
 ]

--- a/src/Monticello/Trait.extension.st
+++ b/src/Monticello/Trait.extension.st
@@ -8,6 +8,7 @@ Trait >> asClassDefinition [
 			traitComposition: self traitCompositionString
 			category: self category 
 			instVarNames: self instVarNames
+			classInstVarNames: self classSide slotNames
 			comment: self organization classComment asString
 			commentStamp: self organization commentStamp ].
 		
@@ -16,6 +17,7 @@ Trait >> asClassDefinition [
 			traitComposition: self traitCompositionString
 			category: self category 
 			instVarNames: (self localSlots collect: #definitionString)
+			classInstVarNames: (self classSide localSlots collect: #definitionString)
 			comment: self organization classComment asString
 			commentStamp: self organization commentStamp.
 		

--- a/src/Ring-Deprecated-Monticello/MCTraitDefinition.extension.st
+++ b/src/Ring-Deprecated-Monticello/MCTraitDefinition.extension.st
@@ -48,4 +48,12 @@ MCTraitDefinition >> printMetaDefinitionOn: stream [
 		 crtab;
 		 nextPutAll: 'uses: ';
 		 nextPutAll: self classTraitCompositionString.
+	
+	self classInstanceVariables ifNotEmpty: [  
+		stream
+			cr; tab;
+			nextPutAll: 'slots: '; 
+			nextPutAll: self classSlotDefinitionString
+	].	
+
 ]

--- a/src/TraitsV2-Tests/T2TraitInTraitClass.class.st
+++ b/src/TraitsV2-Tests/T2TraitInTraitClass.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : #T2TraitInTraitClass,
+	#superclass : #T2AbstractTest,
+	#category : #'TraitsV2-Tests-Tests'
+}
+
+{ #category : #tests }
+T2TraitInTraitClass >> testAddingSlotToClassSide [
+	
+	| t1 |
+	
+	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 classTrait uses: {} slots: #(aSlot).
+	
+	self assert: t1 classTrait slots size equals: 1.
+	self assert: t1 classTrait slots anyOne name equals: #aSlot.	
+]
+
+{ #category : #tests }
+T2TraitInTraitClass >> testAddingSpecialSlotToClassSide [
+	
+	| t1 |
+	
+	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 classTrait uses: {} slots: {#aSlot => WeakSlot}.
+	
+	self assert: t1 classTrait slots size equals: 1.
+	self assert: t1 classTrait slots anyOne name equals: #aSlot.	
+	self assert: t1 classTrait slots anyOne species equals: WeakSlot.		
+]

--- a/src/TraitsV2-Tests/T2TraitMCDefinitions.class.st
+++ b/src/TraitsV2-Tests/T2TraitMCDefinitions.class.st
@@ -8,6 +8,32 @@ Class {
 }
 
 { #category : #tests }
+T2TraitMCDefinitions >> testDefinitionHasCorrectString [
+	| t2 definition t1 definitionString |
+	t1 := self newTrait: #T1 with: {#x => PropertySlot. #y => PropertySlot }. 
+	t2 := self newTrait: #T2 with: {#a => PropertySlot. #b => PropertySlot } uses: t1.
+
+	definition := t2 asClassDefinition.				
+	definitionString := String streamContents: [ :s | definition printDefinitionOn: s ].
+ 	
+ 	self assert: (definitionString reject: [ :each | each isSeparator]) equals: (t2 definition reject: [ :each | each isSeparator ]).
+
+]
+
+{ #category : #tests }
+T2TraitMCDefinitions >> testDefinitionHasCorrectStringWithoutSlots [
+	| t2 definition t1 definitionString |
+	t1 := self newTrait: #T1 with: {}. 
+	t2 := self newTrait: #T2 with: {#a. #b } uses: t1.
+
+	definition := t2 asClassDefinition.				
+	definitionString := String streamContents: [ :s | definition printDefinitionOn: s ].
+		
+	self assert: (definitionString reject: [ :each | each isSeparator ]) equals: (t2 definition reject: [ :each | each isSeparator ]).
+
+]
+
+{ #category : #tests }
 T2TraitMCDefinitions >> testDefinitionOfNormalClass [
 	| c1 definition |
 	c1 := self newClass: #C1 with: #(a b c) uses: {}.
@@ -24,7 +50,7 @@ T2TraitMCDefinitions >> testDefinitionOfNormalClassWithSlots [
 	| c1 definition |
 	c1 := self newClass: #C1 with: { #a => PropertySlot. #b => PropertySlot } uses: {}.
 	definition := c1 asClassDefinition.
-	
+		
 	self assert: definition instanceVariablesString equals: '#a => PropertySlot #b => PropertySlot'.
 	self assert: definition instanceVariables size equals: 2.
 	self assert: definition traitComposition equals: '{}'.	
@@ -63,7 +89,7 @@ T2TraitMCDefinitions >> testDefinitionOfTraitUsingTraitWithSlots [
 	t2 := self newTrait: #T2 with: {#a => PropertySlot. #b => PropertySlot } uses: t1.
 
 	definition := t2 asClassDefinition.	
-		
+				
 	self assert: definition instanceVariablesString equals: '#a => PropertySlot #b => PropertySlot'.
 	self assert: definition instanceVariables size equals: 2.
 	self assert: definition traitComposition equals: 'T1'.	

--- a/src/TraitsV2-Tests/T2TraitMCDefinitions.class.st
+++ b/src/TraitsV2-Tests/T2TraitMCDefinitions.class.st
@@ -15,6 +15,7 @@ T2TraitMCDefinitions >> testDefinitionOfNormalClass [
 	
 	self assert: definition instanceVariablesString equals: 'a b c'.
 	self assert: definition instanceVariables size equals: 3.
+	self assert: definition traitComposition equals: '{}'.	
 	self assert: (definition instanceVariables allSatisfy: [ :e | e species = InstanceVariableSlot ])
 ]
 
@@ -26,6 +27,7 @@ T2TraitMCDefinitions >> testDefinitionOfNormalClassWithSlots [
 	
 	self assert: definition instanceVariablesString equals: '#a => PropertySlot #b => PropertySlot'.
 	self assert: definition instanceVariables size equals: 2.
+	self assert: definition traitComposition equals: '{}'.	
 	self assert: (definition instanceVariables allSatisfy: [ :e | e species = PropertySlot ])
 ]
 
@@ -37,6 +39,7 @@ T2TraitMCDefinitions >> testDefinitionOfTrait [
 	
 	self assert: definition instanceVariablesString equals: 'a b c'.
 	self assert: definition instanceVariables size equals: 3.
+	self assert: definition traitComposition equals: '{}'.
 	self assert: (definition instanceVariables allSatisfy: [ :e | e species = InstanceVariableSlot ])
 ]
 
@@ -44,11 +47,12 @@ T2TraitMCDefinitions >> testDefinitionOfTrait [
 T2TraitMCDefinitions >> testDefinitionOfTraitUsingTrait [
 	| t2 definition t1 |
 	t1 := self newTrait: #T1 with: #(x y z). 
-	t2 := self newClass: #T2 with: #(a b c) uses: t1.
+	t2 := self newTrait: #T2 with: #(a b c) uses: t1.
 	definition := t2 asClassDefinition.
 		
 	self assert: definition instanceVariablesString equals: 'a b c'.
 	self assert: definition instanceVariables size equals: 3.
+	self assert: definition traitComposition equals: 'T1'.
 	self assert: (definition instanceVariables allSatisfy: [ :e | e species = InstanceVariableSlot ])
 ]
 
@@ -59,9 +63,10 @@ T2TraitMCDefinitions >> testDefinitionOfTraitUsingTraitWithSlots [
 	t2 := self newTrait: #T2 with: {#a => PropertySlot. #b => PropertySlot } uses: t1.
 
 	definition := t2 asClassDefinition.	
-	
+		
 	self assert: definition instanceVariablesString equals: '#a => PropertySlot #b => PropertySlot'.
 	self assert: definition instanceVariables size equals: 2.
+	self assert: definition traitComposition equals: 'T1'.	
 	self assert: (definition instanceVariables allSatisfy: [ :e | e species = PropertySlot ])
 ]
 
@@ -69,6 +74,7 @@ T2TraitMCDefinitions >> testDefinitionOfTraitUsingTraitWithSlots [
 T2TraitMCDefinitions >> testDefinitionOfTraitWithSlots [
 	| t1  definition |
 	t1 := self newClass: #C1 with: { #a => PropertySlot. #b => PropertySlot } uses: {}.
+
 	definition := t1 asClassDefinition.
 	
 	self assert: definition instanceVariablesString equals: '#a => PropertySlot #b => PropertySlot'.
@@ -85,6 +91,7 @@ T2TraitMCDefinitions >> testDefinitionOfTraitedClass [
 	
 	self assert: definition instanceVariablesString equals: 'a b c'.
 	self assert: definition instanceVariables size equals: 3.
+	self assert: definition traitComposition equals: 'T1'.
 	self assert: (definition instanceVariables allSatisfy: [ :e | e species = InstanceVariableSlot ])
 ]
 
@@ -98,5 +105,44 @@ T2TraitMCDefinitions >> testDefinitionOfTraitedClassWithSlots [
 	
 	self assert: definition instanceVariablesString equals: '#a => PropertySlot #b => PropertySlot'.
 	self assert: definition instanceVariables size equals: 2.
+	self assert: definition traitComposition equals: 'T1'.	
 	self assert: (definition instanceVariables allSatisfy: [ :e | e species = PropertySlot ])
+]
+
+{ #category : #tests }
+T2TraitMCDefinitions >> testEqualityOfTraitDefinition [
+	| t1 definition1 definition2 |
+	t1 := self newTrait: #T1 with: #() uses: {}.
+	definition1 := t1 asClassDefinition.
+
+	t1 := self newTrait: #T1 with: #(a b c) uses: {}.
+	definition2 := t1 asClassDefinition.
+	
+	self deny: definition1 = definition2
+]
+
+{ #category : #tests }
+T2TraitMCDefinitions >> testEqualityOfTraitDefinitionInUses [
+	| t1 t2 definition1 definition2 |
+	t1 := self newTrait: #T1 with: #() uses: {}.
+	t2 := self newTrait: #T2 with: #() uses: {}.
+	
+	definition1 := t2 asClassDefinition.
+
+	t2 := self newTrait: #T2 with: #() uses: {t1}.
+	definition2 := t2 asClassDefinition.
+	
+	self deny: definition1 = definition2
+]
+
+{ #category : #tests }
+T2TraitMCDefinitions >> testEqualityOfTraitDefinitionWithDifferentSlotTypes [
+	| t1 definition1 definition2 |
+	t1 := self newTrait: #T1 with: #(a) uses: {}.
+	definition1 := t1 asClassDefinition.
+
+	t1 := self newTrait: #T1 with: { #a => PropertySlot } uses: {}.
+	definition2 := t1 asClassDefinition.
+	
+	self deny: definition1 = definition2
 ]

--- a/src/TraitsV2-Tests/T2TraitMCDefinitions.class.st
+++ b/src/TraitsV2-Tests/T2TraitMCDefinitions.class.st
@@ -34,6 +34,48 @@ T2TraitMCDefinitions >> testDefinitionHasCorrectStringWithoutSlots [
 ]
 
 { #category : #tests }
+T2TraitMCDefinitions >> testDefinitionOfClassSideTrait [
+	
+	| t1 definition |
+	
+	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 classTrait uses: {} slots: #(aSlot).
+
+	definition := t1 asClassDefinition.
+	
+	self assert: definition classInstanceVariables equals: {#aSlot => InstanceVariableSlot}.
+
+]
+
+{ #category : #tests }
+T2TraitMCDefinitions >> testDefinitionOfClassSideTraitHasCorrectString [
+	
+	| t1 definition |
+	
+	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 classTrait uses: {} slots: #(aSlot).
+
+	definition := t1 asClassDefinition.
+	
+	self assert: definition classDefinitionString equals: t1 class definition 
+
+]
+
+{ #category : #tests }
+T2TraitMCDefinitions >> testDefinitionOfClassSideTraitWithSpecialSlotHasCorrectString [
+	
+	| t1 definition |
+	
+	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 classTrait uses: {} slots: {#aSlot => WeakSlot.}.
+
+	definition := t1 asClassDefinition.
+	
+	self assert: (definition classDefinitionString reject: [ :each | each isSeparator ]) equals: (t1 class definition reject: [ :each | each isSeparator ])
+
+]
+
+{ #category : #tests }
 T2TraitMCDefinitions >> testDefinitionOfNormalClass [
 	| c1 definition |
 	c1 := self newClass: #C1 with: #(a b c) uses: {}.


### PR DESCRIPTION
Fixing the definition in MCTraitDefinition when using slots.
Also implementing the equals to take care of the slots.

Issue: https://pharo.manuscript.com/f/cases/22292/MCTraitDefinition-should-correctly-support-stateful-traits

Solves also:

https://pharo.fogbugz.com/f/cases/22262/MC-support-for-class-side-stateful-traits-instance-variables