### PR TITLE
22294-MCTraitDefinition-is-not-correctly-initialised-in-all-the-constructors

### DIFF
--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -118,6 +118,7 @@ MCTraitDefinition >> initializeWithName: classNameString
 		traitComposition := traitCompositionString.
 	     category := categoryString.
 		comment := commentString withSqueakLineEndings.
+		variables := OrderedCollection  new.
 		commentStamp :=  commentStampString ifNil: [self defaultCommentStamp]
 
 ]


### PR DESCRIPTION
Initializing the MCTraitDefinition in all the initialization methods.
Fixes Issue https://pharo.manuscript.com/f/cases/22294/MCTraitDefinition-is-not-correctly-initialised-in-all-the-constructors