### PR TITLE
22296-Stdio-file-creation-fixes

### DIFF
--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -374,18 +374,20 @@ File class >> sizeOrNil: id [
 ]
 
 { #category : #'primitives-file' }
-File class >> stdioDescriptorIsATTY [
-	^ (0 to: 2)
-		anySatisfy: [ :fdNum | 
-			| res |
-			res := self fileDescriptorType: fdNum.
-			#(1 4) includes: res ]
-]
-
-{ #category : #'primitives-file' }
 File class >> stdioHandles [
 	<primitive: 'primitiveFileStdioHandles' module: 'FilePlugin' error: ec>
 	self primitiveFailed
+]
+
+{ #category : #'primitives-file' }
+File class >> stdioIsAvailable [
+	"Answer a boolean indicating whether stdio is available on the current platform.
+	stdio is considered available if any one of the three files (stdin, stdout, stderr) is available."
+
+	^ (0 to: 2)
+		anySatisfy: [ :fdNum | | res |
+			res := self fileDescriptorType: fdNum.
+			res between: 1 and: 3 ]
 ]
 
 { #category : #'primitives-file' }

--- a/src/Files/Stdio.class.st
+++ b/src/Files/Stdio.class.st
@@ -78,15 +78,26 @@ Stdio class >> initialize [
 
 { #category : #stdio }
 Stdio class >> standardIOStreamNamed: moniker forWrite: forWrite [
-	"Create if necessary and store default stdin, stdout and other files based on the their names"
+	"Create the requested stdio (#stdin, #stdout, #stderr) if possible.
+	On Windows, if stdio is not available, create a regular file instead."
 
 	| handle |
-	([ File stdioDescriptorIsATTY not ]
-		on: PrimitiveFailed
-		do: [ :ex | "HACK kept for retrocompatibility" Smalltalk os isWin32 ])
-		ifTrue: [ ^ self createStdioFileFor: moniker ].
+
+	"The VM should return nil if stdio is not available, but there's a bug in the VM on Windows.
+	See: https://github.com/OpenSmalltalk/opensmalltalk-vm/issues/274.
+	This section of code can be removed once the issue is resolved"
+	Smalltalk os isWindows ifTrue: [ 
+		([ File stdioIsAvailable not ]
+			on: PrimitiveFailed
+			do: [ :ex | true ]) ifTrue: 
+				[ ^ self createStdioFileFor: moniker ] ].
+
 	handle := File stdioHandles at: (#(stdin stdout stderr) identityIndexOf: moniker).
-	handle ifNil: [ self error: moniker , ' is unavailable' ].
+	handle ifNil: [ 
+		"On windows, create a file for stdio, error on other platforms"
+		Smalltalk os isWindows 
+			ifTrue: [ ^ self createStdioFileFor: moniker ]
+			ifFalse: [ self error: moniker , ' is unavailable' ] ].
 	^ StdioStream handle: handle file: (File named: moniker) forWrite: forWrite
 ]
 


### PR DESCRIPTION
22296 Stdio file creation fixes

Address the following issues with stdio file creation:

1. If all three streams are redirected on non-Windows platforms it creates files instead of connecting to the streams.
Replace #stdioDescriptorIsATTY with #stdioIsAvailable and correct file type comparisons

2. The test on whether stdio streams should be available (#stdioDescriptorIsATTY) is incorrect - tests for a console, not for all valid stream types (console / terminal, file, pipe).
As above, replace #stdioDescriptorIsATTY with #stdioIsAvailable and correct file type comparisons

3. The #stdioDescriptorIsATTY shouldn't be necessary in the first place - the VM should flag that no stream is available by returning nil instead of a sqFile handle.  This will be fixed separately, see https://github.com/OpenSmalltalk/opensmalltalk-vm/issues/274
While waiting for the VM fix, and for backward compatibilty, leave the #isWindows block in to create files if no stdio is available.

4. The windows test incorrectly uses #isWin32 instead of #isWindows.

Fogbugz: https://pharo.fogbugz.com/f/cases/22296/Stdio-file-creation-fixes