### PR TITLE
22314-Stdio-doesnt-handle-cygwin-terminals-correctly

### DIFF
--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -158,6 +158,14 @@ File class >> encodePathString: aString [
 ]
 
 { #category : #'primitives-file' }
+File class >> fileDescriptorIsAvailable: anInteger [
+	"Answer a boolean indicating whether the supplied file descriptor (anInteger) is available.
+	A file descriptor is considered available if it is connected to a console / terminal, pipe or a file.  cygwin terminals are currently not supported (the pipe is created, but nothing appears in the terminal)"
+
+	^ (self fileDescriptorType: anInteger) between: 1 and: 3
+]
+
+{ #category : #'primitives-file' }
 File class >> fileDescriptorType: fdNum [
 	"Allow to test if the standard input/output files are from a console or not
 	Return values:
@@ -385,9 +393,7 @@ File class >> stdioIsAvailable [
 	stdio is considered available if any one of the three files (stdin, stdout, stderr) is available."
 
 	^ (0 to: 2)
-		anySatisfy: [ :fdNum | | res |
-			res := self fileDescriptorType: fdNum.
-			res between: 1 and: 3 ]
+		anySatisfy: [ :fdNum | self fileDescriptorIsAvailable: fdNum ]
 ]
 
 { #category : #'primitives-file' }

--- a/src/Files/Stdio.class.st
+++ b/src/Files/Stdio.class.st
@@ -81,19 +81,11 @@ Stdio class >> standardIOStreamNamed: moniker forWrite: forWrite [
 	"Create the requested stdio (#stdin, #stdout, #stderr) if possible.
 	On Windows, if stdio is not available, create a regular file instead."
 
-	| handle |
+	| handle streamIndex |
 
-	"The VM should return nil if stdio is not available, but there's a bug in the VM on Windows.
-	See: https://github.com/OpenSmalltalk/opensmalltalk-vm/issues/274.
-	This section of code can be removed once the issue is resolved"
-	Smalltalk os isWindows ifTrue: [ 
-		([ File stdioIsAvailable not ]
-			on: PrimitiveFailed
-			do: [ :ex | true ]) ifTrue: 
-				[ ^ self createStdioFileFor: moniker ] ].
-
-	handle := File stdioHandles at: (#(stdin stdout stderr) identityIndexOf: moniker).
-	handle ifNil: [ 
+	streamIndex := #(stdin stdout stderr) identityIndexOf: moniker.
+	handle := File stdioHandles at: streamIndex.
+	(handle isNil or: [ (File fileDescriptorIsAvailable: streamIndex-1) not ]) ifTrue: [ 
 		"On windows, create a file for stdio, error on other platforms"
 		Smalltalk os isWindows 
 			ifTrue: [ ^ self createStdioFileFor: moniker ]


### PR DESCRIPTION
22314-Stdio-doesnt-handle-cygwin-terminals-correctly

Stdio class>>standardIOStreamNamed:forWrite: assumes that the VM will will return a nil handle for cygwin terminals, however an actual handle to the cygwin pipe is returned.  We aren't able to use the pipe since the VM uses the windows Read/WriteConsole() routines.

Modify Stdio class>>standardIOStreamNamed:forWrite: so that cygwin terminals are ignored, i.e. the stream is redirected to a file (on windows).

Fogbugz: https://pharo.fogbugz.com/f/cases/22314/Stdio-doesn-t-handle-cygwin-terminals-correctly