### PR TITLE
22313-Packages-are-created-for-extension-methods-that-does-not-are-exactly-the-package-name

### DIFF
--- a/src/Monticello-Tests/MCWorkingCopyForExtensions.class.st
+++ b/src/Monticello-Tests/MCWorkingCopyForExtensions.class.st
@@ -1,0 +1,43 @@
+Class {
+	#name : #MCWorkingCopyForExtensions,
+	#superclass : #MCTestCase,
+	#category : #'Monticello-Tests-Base'
+}
+
+{ #category : #tests }
+MCWorkingCopyForExtensions >> tearDown [
+	super tearDown.
+	'ATestPackage' asPackage removeFromSystem.
+	'AnotherTestPackage' asPackage removeFromSystem.
+	
+	Object
+		compiledMethodAt: #testingMethod
+		ifPresent: [ Object removeSelector: #testingMethod ]
+		ifAbsent: [  ].
+
+	('Atestpackage-something-else' asPackageIfAbsent: [ nil ]) ifNotNil: #removeFromSystem.
+
+	MCWorkingCopy registry
+		at: (MCPackage named: 'atestpackage-something-else')
+		ifPresent: [ :aWC | aWC unload ]
+]
+
+{ #category : #tests }
+MCWorkingCopyForExtensions >> testAddingExtensionMethodNotMatchingPackage [
+
+	| aClass |
+	RPackageOrganizer default createPackageNamed: 'ATestPackage'.
+	RPackageOrganizer default createPackageNamed: 'AnotherTestPackage'.
+
+	aClass := Object subclass: #ATestClass  
+		instanceVariableNames:''
+		classVariableNames: ''
+		package: 'AnotherTestPackage'.  
+
+	aClass compile: 'testingMethod ^ 42 ' classified: '*atestpackage-something-else'.
+	
+	self deny: (RPackageOrganizer default includesPackageNamed: 'Atestpackage-something-else').
+	self assert: ('ATestPackage' asPackage extendedClasses includes: aClass).
+
+	MCWorkingCopy registry at: (MCPackage named: 'atestpackage-something-else') ifPresent: [ self fail ].	
+]

--- a/src/Monticello/MCPackageManager.class.st
+++ b/src/Monticello/MCPackageManager.class.st
@@ -131,10 +131,11 @@ MCPackageManager class >> managersForCategory: aSystemCategory do: aBlock [
 
    foundOne ifTrue: [^self].
 	["Loop over categories until we found a matching one"
-	self registry at: (MCPackage named: cat) ifPresent:[:mgr|
-		aBlock value: mgr.
-		foundOne := true.
-	].
+
+	self registry keys detect: [ :aPackage | aPackage name sameAs: cat ] ifFound: [:aPackage | |mgr| 
+		mgr := self registry at: aPackage.
+		aBlock value: mgr. foundOne := true ].
+
 	index := cat lastIndexOf: $-.
 	index > 0]whileTrue:[
 		"Step up to next level package"

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -164,6 +164,25 @@ RPackageOrganizerTest >> testEmpty [
 ]
 
 { #category : #tests }
+RPackageOrganizerTest >> testExtensionMethodNotExacltyTheName [
+	| p1 p2 c1 |
+	p1 := self createNewPackageNamed: 'P1'.
+	p2 := self createNewPackageNamed: 'P2'.
+
+	self packageOrganizer basicRegisterPackage: p1.
+	self packageOrganizer basicRegisterPackage: p2.
+
+	c1 := self createNewClassNamed: #C1 inPackage: p2.
+	
+	c1 compileSilently: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*p1-something'.
+	packageOrganizer addMethod: (c1 >> #methodPackagedInP1).
+
+	self deny: (packageOrganizer includesPackageNamed: #'p1-something').
+	self assert: (p1 extensionClasses includes: c1)
+
+]
+
+{ #category : #tests }
 RPackageOrganizerTest >> testFullRegistration [	
 
 	| p1 p2 p3 a1 a2 b1 b2 a3 |


### PR DESCRIPTION
Fixing the lookup of extension packages that are not named exactly as the package.