### PR TITLE
22346-mustBeBooleanDeOptimizeIn-needs-to-clean-semantic-annotation-before-recompile

### DIFF
--- a/src/OpalCompiler-Core/Object.extension.st
+++ b/src/OpalCompiler-Core/Object.extension.st
@@ -20,6 +20,7 @@ Object >> mustBeBooleanDeOptimizeIn: context [
 	"Disable inlining so the message send will be unoptimized"
 	methodNode compilationContext compilerOptions: #(- optionInlineIf optionInlineAndOr optionInlineWhile).
 	"Generate the method"	
+	OCASTSemanticCleaner clean: methodNode.
 	method := methodNode generate.
 	"Execute the generated method with the pc still at the optimzized block so that the lookUp can read variables defined in the optimized block"
 	ret := context receiver withArgs: {context} executeMethod: method.

--- a/src/OpalCompiler-Tests/MustBeBooleanTests.class.st
+++ b/src/OpalCompiler-Tests/MustBeBooleanTests.class.st
@@ -65,6 +65,14 @@ MustBeBooleanTests >> testOr [
 ]
 
 { #category : #tests }
+MustBeBooleanTests >> testSemanticAnalysisCleaned [
+	"this used to fail as we did not clean semantic analysis data before recompiling"
+	
+	self should: [self shouldnt: [1 ifTrue:  [[:dir :path|
+                        [ path]]]] raise: KeyNotFound ] raise: MessageNotUnderstood.
+]
+
+{ #category : #tests }
 MustBeBooleanTests >> testWhile [
 	| myFlag |
 	self should: [[ nil ] whileFalse: [myFlag := true ]] raise: MessageNotUnderstood.


### PR DESCRIPTION
#mustBeBooleanDeOptimizeIn: needs to clean semantic annotation before recompile
       https://pharo.fogbugz.com/f/cases/22346/mustBeBooleanDeOptimizeIn-needs-to-clean-semantic-annotation-before-recompile