### PR TITLE
Implement ZnNewLineWriterStream >> #flush

### DIFF
--- a/src/Zinc-Character-Encoding-Core/ZnEncodedStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnEncodedStream.class.st
@@ -58,11 +58,6 @@ ZnEncodedStream >> encoding: encoding [
 	encoder := encoding asZnCharacterEncoder
 ]
 
-{ #category : #accessing }
-ZnEncodedStream >> flush [
-	^ stream flush
-]
-
 { #category : #testing }
 ZnEncodedStream >> isStream [
   ^ true

--- a/src/Zinc-Character-Encoding-Core/ZnNewLineWriterStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnNewLineWriterStream.class.st
@@ -1,12 +1,13 @@
 "
 I am a write stream wrapping a second stream. Whenever they ask me to write a cr, a lf, or a crlf I'll instead print a new line depending on a configured convention. By default I use the current platform convention. 
 
+| stream converter |
 stream := '' writeStream.
-converter := ZnCrPortableWriteStream on: stream.
+converter := ZnNewLineWriterStream on: stream.
 converter cr; cr; lf; nextPut: $a.
 stream contents
 
-A ZnCrPortableWriteStream can be configured with the desired line ending convention using the methods 
+A ZnNewLineWriterStream can be configured with the desired line ending convention using the methods 
 
 converter forCr.
 converter forLf.
@@ -33,6 +34,11 @@ ZnNewLineWriterStream class >> on: aStream [
 		initialize;
 		stream: aStream;
 		yourself
+]
+
+{ #category : #flushing }
+ZnNewLineWriterStream >> flush [
+	^ stream flush
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
…and cleanup its comment and a duplicate method in ZnEncodedStream