### PR TITLE
22356-CompiledMethod-methodNode-should-reuse-parseTree

### DIFF
--- a/src/OpalCompiler-Core/CompiledMethod.extension.st
+++ b/src/OpalCompiler-Core/CompiledMethod.extension.st
@@ -31,17 +31,10 @@ CompiledMethod >> irPrimitive [
 	^ primNode
 ]
 
-{ #category : #'*opalcompiler-core' }
+{ #category : #'*OpalCompiler-Core' }
 CompiledMethod >> methodNode [
-	"Return the parse tree that represents self"
-	| aClass source methodNode |
-	
-	aClass := self methodClass.
-	source := self sourceCode.
-	methodNode := aClass compiler parse: source.
-	methodNode source: source.
-	^methodNode.
-			
+	"returns an AST for this method, do not cache it. (see #ast for the cached alternative)"
+	^self parseTree
 ]
 
 { #category : #'*opalcompiler-core' }


### PR DESCRIPTION
22356 CompiledMethod: #methodNode should reuse #parseTree
https://pharo.fogbugz.com/f/cases/22356/CompiledMethod-methodNode-should-reuse-parseTree