### PR TITLE
22324-Wrong-implementation-of-stop-in-RBMethodNode

### DIFF
--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -472,11 +472,9 @@ RBMethodNode >> reformatSource [
 					each stopPosition + 1 ])
 			to: source size).
 	newSource := stream contents.
-	newTree := RBParser 
-		parseMethod: newSource 
-		onError: [ :msg :pos | ^ self formattedCode ].
+	newTree :=  RBParser parseFaultyMethod: newSource.
 	self = newTree
-		ifFalse: [ ^ self formattedCode ].
+		ifFalse: [ ^ self formattedCode].
 	^ newSource
 ]
 

--- a/src/AST-Core/RBParseErrorNode.class.st
+++ b/src/AST-Core/RBParseErrorNode.class.st
@@ -31,6 +31,13 @@ RBParseErrorNode class >> errorMessage: aString value: aValue at: aPosition [
 		yourself
 ]
 
+{ #category : #comparing }
+RBParseErrorNode >> = anObject [ 
+	self == anObject ifTrue: [^true].
+	self class = anObject class ifFalse: [^false].
+	^anObject value = value and: [ anObject errorMessage = errorMessage ]
+]
+
 { #category : #visiting }
 RBParseErrorNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitParseErrorNode: self.
@@ -70,6 +77,11 @@ RBParseErrorNode >> errorMessage [
 { #category : #accessing }
 RBParseErrorNode >> errorMessage: anObject [
 	errorMessage := anObject
+]
+
+{ #category : #comparing }
+RBParseErrorNode >> hash [
+	^ (self value hash bitXor: self errorMessage hash)
 ]
 
 { #category : #testing }

--- a/src/AST-Tests-Core/RBParserTest.class.st
+++ b/src/AST-Tests-Core/RBParserTest.class.st
@@ -437,7 +437,7 @@ RBParserTest >> testParents [
 						self assert: each methodNode == root ] ] ] ] ]
 ]
 
-{ #category : #'tests parsing' }
+{ #category : #'tests parsing faulty' }
 RBParserTest >> testParseFaultyBlock [
 	| node blockNoArgButBar blockNoArgButColon unfinishedBlock |
 	"parsing block should mark this block as faulty, if it is unfinished no closing brace, or missing parts (colon but no arg, 
@@ -454,7 +454,7 @@ RBParserTest >> testParseFaultyBlock [
 			self assert: node isFaulty]
 ]
 
-{ #category : #'tests parsing' }
+{ #category : #'tests parsing faulty' }
 RBParserTest >> testParseFaultyLiteral [
 	| faultyLiteral faultyLiteralArray node |
 	"a literal or literal array object with an unknown character can be parse
@@ -472,7 +472,7 @@ RBParserTest >> testParseFaultyLiteral [
 	self assert: node contents first errorMessage equals: 'Unknown character'
 ]
 
-{ #category : #'tests parsing' }
+{ #category : #'tests parsing faulty' }
 RBParserTest >> testParseFaultyMethod [
 	| node strangeExpressions |
 	
@@ -500,7 +500,7 @@ RBParserTest >> testParseFaultyMethod [
 	
 ]
 
-{ #category : #'tests parsing' }
+{ #category : #'tests parsing faulty' }
 RBParserTest >> testParseFaultyMethodExpresionHasErrorNodeAsFinal [
 	| node strangeExpression |
 	
@@ -514,12 +514,27 @@ RBParserTest >> testParseFaultyMethodExpresionHasErrorNodeAsFinal [
 	
 ]
 
-{ #category : #'tests parsing' }
+{ #category : #'tests parsing faulty' }
 RBParserTest >> testParseFaultyMethodMessagePattern [
 	| node faultyMessagePattern |
 	faultyMessagePattern := '1'.
 	node := self parseFaultyMethod: faultyMessagePattern.
 	self assert: node isFaulty
+]
+
+{ #category : #'tests parsing faulty' }
+RBParserTest >> testParseFaultyMethodStop [
+	 | methodSource node |
+	
+	methodSource :=  'method: asd   self do      ('.
+	node := self parseFaultyMethod: methodSource.
+	
+	self assert: node isMethod.
+	self assert: node isFaulty.
+	self assert: node stop equals: 28.
+
+
+	
 ]
 
 { #category : #'tests parsing' }


### PR DESCRIPTION
- add equal and hash to RBParseErrorNode
- simplify- tests