### PR TITLE
21708-Epicea-should-not-offer-to-recover-changes-if-the-ombu-file-does-not-exists

### DIFF
--- a/src/EpiceaBrowsers-Tests/EpLostChangesDetectorTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpLostChangesDetectorTest.class.st
@@ -50,3 +50,22 @@ EpLostChangesDetectorTest >> testDetectOneChange [
 
 	self assert: monitor log entriesCount > 1. "Just to ensure assumptions of this test"
 ]
+
+{ #category : #tests }
+EpLostChangesDetectorTest >> testDetectOneChangeButFileDeleted [
+
+	| logWithALostChange |
+	"Build a fake log with a lost change"
+	classFactory newClass.
+	logWithALostChange := EpLog newWithStore: monitor sessionStore store flush copyReopened refresh.
+	classFactory newClass.
+	monitor sessionStore flush.
+
+	"Delete the file"
+	monitor sessionStore store ensureDeleteFile.
+
+	detector := EpLostChangesDetector newWithLog: logWithALostChange.
+	self deny: detector hasLostChanges.
+	self assert: detector lostChanges isEmpty.
+
+]

--- a/src/Ombu-Tests/OmFileStoreTest.class.st
+++ b/src/Ombu-Tests/OmFileStoreTest.class.st
@@ -56,11 +56,19 @@ OmFileStoreTest >> testEnsureDeleteFile [
 { #category : #tests }
 OmFileStoreTest >> testIsOutdated [
 
+	| copy |
 	self deny: store isOutdated.
 	store newEntry: (OmEntry content: 42).
 	self deny: store isOutdated.
 	store flush.
 	self deny: store isOutdated.
+	copy := store copyReopened refresh.
+	store newEntry: (OmEntry content: 43).
+	store flush.
+	"A store is outdated if the file exists and has greater size than in memory."
+	self assert: copy isOutdated.
+	store ensureDeleteFile.
+	self deny: copy isOutdated.
 
 ]
 

--- a/src/Ombu/OmFileStore.class.st
+++ b/src/Ombu/OmFileStore.class.st
@@ -295,12 +295,9 @@ OmFileStore >> initializeWithGlobalName: aName fileReference: aFileReference [
 
 { #category : #testing }
 OmFileStore >> isOutdated [
-	"Answer if #refresh is needed. To that end, I check if the file has different size than last time I wrote."
+	"Answer if #refresh is needed. A store is outdated if the file exists and has greater size than last time I wrote."
 
-	^ self fileReference exists
-		ifTrue: [ self fileReference size ~= lastStreamPosition ]
-		ifFalse: [ lastStreamPosition isNotNil ]
-
+	^ self fileReference exists and: [ self fileReference size ~= lastStreamPosition ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
An ombu store should answer false to #isOutdated if the file doesn't exist in fily system. This will make, in the case of a missing ombu file, the EpLostChangesDetector avoid asking if you want to recover lost changes and after do nothing.