### PR TITLE
22370-RF-tests-related-to-level

### DIFF
--- a/src/Reflectivity-Tests/ReflectivityControlTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityControlTest.class.st
@@ -12,6 +12,11 @@ Class {
 }
 
 { #category : #tagging }
+ReflectivityControlTest >> recordLevel [
+	tag := Processor activeProcess level
+]
+
+{ #category : #tagging }
 ReflectivityControlTest >> return3 [
 	^3
 ]
@@ -188,6 +193,24 @@ ReflectivityControlTest >> testAfterMethod [
 	self assert: tag isNil.
 	self assert: ReflectivityExamples new exampleMethod equals: 5.
 	self assert: tag equals: #yes.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: CompiledMethod
+]
+
+{ #category : #'tests - level' }
+ReflectivityControlTest >> testAfterMethodLevel [
+	| methodNode |
+	"check that level is correct in #after on methodNode"
+	methodNode := (ReflectivityExamples >> #exampleMethod) ast.
+	link := MetaLink new
+		metaObject: self;
+		selector: #recordLevel;
+		control: #after;
+		level: 0.
+	methodNode link: link.
+	self assert: methodNode hasMetalink.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
+	self assert: ReflectivityExamples new exampleMethod equals: 5.
+	self assert: tag equals: 1.
 	self assert: (ReflectivityExamples >> #exampleMethod) class equals: CompiledMethod
 ]
 
@@ -651,6 +674,24 @@ ReflectivityControlTest >> testConditionDisableEnableWithArguments [
 	ReflectivityExamples new exampleMethod.
 	self assert: tag class equals: RBMessageNode.
 
+]
+
+{ #category : #'tests - level' }
+ReflectivityControlTest >> testConditionMetaLevel [
+	"check that the condition is evaluated on the same meta level as the link"
+	| sendNode |
+	sendNode := (ReflectivityExamples >> #exampleMethod) sendNodes first.
+	link := MetaLink new
+		metaObject: self;
+		selector: #tagExec:;
+		condition: [ self assert: Processor activeProcess level == 1. true ];
+		level: 0;
+		arguments: #(#node).
+	sendNode link: link.
+	self assert: sendNode hasMetalinkBefore.
+	self assert: tag isNil.
+	ReflectivityExamples new exampleMethod.
+	self assert: tag class equals: RBMessageNode.
 ]
 
 { #category : #'tests - conditions' }


### PR DESCRIPTION
RF: tests related to level

testConditionMetaLevel
    "check that the condition is evaluated on the same meta level as the link"

 

testAfterMethodLevel
    "check that level is correct in #after on methodNode"

https://pharo.fogbugz.com/f/cases/22370/RF-tests-related-to-level