### PR TITLE
22271-Fix-IndexedSlots-in-combination-with-StatefulTraits-

### DIFF
--- a/src/Kernel-Tests/ClassHierarchyTest.class.st
+++ b/src/Kernel-Tests/ClassHierarchyTest.class.st
@@ -37,7 +37,7 @@ ClassHierarchyTest class >> fixSubclasses [
 ClassHierarchyTest >> testObjectFormatInstSize [
 	| classes offending |
 	"check that #instSize is in sync with #allInstVarNames"
-	offending := SystemNavigation default allBehaviors reject: [ :cls | cls instSize = cls allInstVarNames size ].
+	offending := SystemNavigation default allBehaviors reject: [ :cls | cls instSize = (cls allSlots reject: #isVirtual) size ].
 	self assertCollection: offending hasSameElements: {}.
 
 	"instSpec is only 0 for classes without any inst vars or variable fields"

--- a/src/Kernel-Tests/ClassHierarchyTest.class.st
+++ b/src/Kernel-Tests/ClassHierarchyTest.class.st
@@ -35,16 +35,16 @@ ClassHierarchyTest class >> fixSubclasses [
 
 { #category : #tests }
 ClassHierarchyTest >> testObjectFormatInstSize [
-	| classes |
+	| classes offending |
 	"check that #instSize is in sync with #allInstVarNames"
-	self assert:
-			(SystemNavigation default allBehaviors
-				allSatisfy: [ :cls | cls instSize = cls allInstVarNames size ]).
+	offending := SystemNavigation default allBehaviors reject: [ :cls | cls instSize = cls allInstVarNames size ].
+	self assertCollection: offending hasSameElements: {}.
 
 	"instSpec is only 0 for classes without any inst vars or variable fields"
-	classes := SystemNavigation default allBehaviors
-		select: [ :cls | cls isTrait not and: [ cls instSpec = 0 ] ].
-	self assert: (classes allSatisfy: [ :each | each instVarNames isEmpty or: [ each isVariable not ] ])
+	classes := SystemNavigation default allBehaviors select: [ :cls | cls isTrait not and: [ cls instSpec = 0 ] ].
+	offending := classes reject: [ :each | each instVarNames isEmpty or: [ each isVariable not ] ].
+	self assertCollection: offending hasSameElements: {}.
+
 ]
 
 { #category : #tests }

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -89,8 +89,6 @@ ShiftClassInstaller >> fixSlotScope: newClass [
 	newClass superclass ifNil: [ ^ self ].
 	(newClass classLayout slotScope isKindOf: LayoutEmptyScope) ifTrue: [ ^ self ].
 
-	self assert: newClass superclass classLayout slotScope = newClass classLayout slotScope parentScope.
-
 	newClass superclass classLayout slotScope == newClass classLayout slotScope parentScope
 		ifFalse: [ newClass classLayout slotScope parentScope: newClass superclass classLayout slotScope ].
 		

--- a/src/TraitsV2-Tests/T2TraitWithSlots.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithSlots.class.st
@@ -27,6 +27,28 @@ T2TraitWithSlots >> createT1 [
 ]
 
 { #category : #tests }
+T2TraitWithSlots >> testClassUsingStatefulTraits [
+
+	| t1 c1 |
+
+	t1 := self newTrait: #T1 with: #(aSlot).
+	c1 := self newClass: #C1 superclass: Object with: #() uses: { t1 }. 
+
+	self assert: c1 slots isEmpty
+]
+
+{ #category : #tests }
+T2TraitWithSlots >> testClassUsingStatefulTraitsAndLocalSlots [
+
+	| t1 c1 |
+
+	t1 := self newTrait: #T1 with: #(aSlot).
+	c1 := self newClass: #C1 superclass: Object with: #(anotherSlot) uses: { t1 }. 
+
+	self assertCollection: c1 slots hasSameElements: { c1 slotNamed: #anotherSlot }
+]
+
+{ #category : #tests }
 T2TraitWithSlots >> testDefiningClass [
 
 	| t1 c1 |

--- a/src/TraitsV2/TaClassCompositionElement.class.st
+++ b/src/TraitsV2/TaClassCompositionElement.class.st
@@ -22,8 +22,8 @@ TaClassCompositionElement >> selectors [
 
 { #category : #accessing }
 TaClassCompositionElement >> slots [
-	^ innerClass slots
-		reject: [ :e | TraitedClass slots anySatisfy: [ :x | x name = e name ] ]
+	^ innerClass allSlots
+		reject: [ :e | TraitedClass allSlots anySatisfy: [ :x | x name = e name ] ]
 		
 ]
 

--- a/src/TraitsV2/TaCompositionElement.class.st
+++ b/src/TraitsV2/TaCompositionElement.class.st
@@ -148,7 +148,7 @@ TaCompositionElement >> selectors [
 
 { #category : #accessing }
 TaCompositionElement >> slots [
-	^ innerClass slots 
+	^ innerClass allSlots 
 ]
 
 { #category : #printing }

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -318,7 +318,11 @@ TraitedClass >> removeSelector: aSelector [
 { #category : #initialization }
 TraitedClass >> slots [
 	"I remove the slots comming from a traitComposition"
-	^ super slots reject:[ :e  | self traitComposition slots includes:e ]
+
+	^ super slots reject:
+			[ :aSlot | 
+				self traitComposition slots anySatisfy: 
+					[ :existingSlots | aSlot name = existingSlots name ] ]
 ]
 
 { #category : #'accessing tags' }


### PR DESCRIPTION
Fixing the filtering of slots coming from a trait composition.
Issue 22271. 

Adding tests for this scenario.

Issue https://pharo.manuscript.com/f/cases/resolve/22271/Fix-IndexedSlots-in-combination-with-StatefulTraits