### PR TITLE
22387 Allow dynamic spec builder to specify a different presenter for each model object.

### DIFF
--- a/src/Spec-Core/DynamicPresentersListBuilder.class.st
+++ b/src/Spec-Core/DynamicPresentersListBuilder.class.st
@@ -12,13 +12,13 @@ Class {
 	#name : #DynamicPresentersListBuilder,
 	#superclass : #Object,
 	#instVars : [
-		'presenterClass',
 		'configurationBlock',
 		'instVarCount',
 		'dynamicPresenter',
 		'nullPresentersInstVarNames',
 		'layoutBuilder',
-		'instVarToModelObject'
+		'instVarToModelObject',
+		'presenterBlock'
 	],
 	#category : #'Spec-Core-Dynamic-Builder'
 }
@@ -34,6 +34,26 @@ DynamicPresentersListBuilder class >> example [
 				label: modelObject asString;
 				whenActivatedDo: [ UIManager default inform: modelObject asString , ' activated.' ];
 				whenDeactivatedDo: [ UIManager default inform: modelObject asString , ' deactivated.' ] ];
+		layoutBuilder: (DynamicTopToBottomColumnsLayout columns: 2);
+		build.
+	
+	^ dynamicPresenter
+		openWithSpec;
+		yourself
+]
+
+{ #category : #example }
+DynamicPresentersListBuilder class >> example2 [
+	| dynamicPresenter |
+	dynamicPresenter := DynamicPresentersListBuilder new
+		modelObjects: {1 . 2 . 3 . 4 . 5};
+		presenterProvidedBy: [ :integer |
+			integer odd "In your real code, avoid conditionals, use dispatch."
+				ifTrue: [ CheckBoxPresenter ]
+				ifFalse: [ LabelPresenter ] ]
+			configuredAs: [ :presenter :modelObject | 
+			presenter
+				label: modelObject asString ];
 		layoutBuilder: (DynamicTopToBottomColumnsLayout columns: 2);
 		build.
 	
@@ -109,12 +129,12 @@ DynamicPresentersListBuilder >> instVarNames [
 
 { #category : #private }
 DynamicPresentersListBuilder >> instVarNamesAndPresenterNamesArray [
-	^ (self instVarNames
+	^ (self instVarToModelObject
 		inject: OrderedCollection new
-		into: [ :col :instVar |
+		into: [ :col :instVarToModelObjectAssoc |
 			col
-				add: instVar;
-				add: self presenterClass name;
+				add: instVarToModelObjectAssoc key;
+				add: (self presenterBlock value: instVarToModelObjectAssoc value) name;
 				yourself ]) asArray
 ]
 
@@ -169,17 +189,23 @@ DynamicPresentersListBuilder >> nullPresentersInstVarNamesAndPresenterNamesArray
 
 { #category : #api }
 DynamicPresentersListBuilder >> presenter: aPresenterClass configuredAs: twoArgumentsBlock [
+	self presenterProvidedBy: [ :modelObject | aPresenterClass ] configuredAs: twoArgumentsBlock
+]
+
+{ #category : #accessing }
+DynamicPresentersListBuilder >> presenterBlock [
+	^ presenterBlock
+]
+
+{ #category : #accessing }
+DynamicPresentersListBuilder >> presenterBlock: anObject [
+	presenterBlock := anObject
+]
+
+{ #category : #api }
+DynamicPresentersListBuilder >> presenterProvidedBy: blockReturningPresenter configuredAs: blockConfiguringThePresenter [
 	self
-		presenterClass: aPresenterClass;
-		configurationBlock: twoArgumentsBlock
-]
-
-{ #category : #accessing }
-DynamicPresentersListBuilder >> presenterClass [
-	^ presenterClass
-]
-
-{ #category : #accessing }
-DynamicPresentersListBuilder >> presenterClass: anObject [
-	presenterClass := anObject
+		presenterBlock: blockReturningPresenter;
+		configurationBlock: blockConfiguringThePresenter
+	
 ]

--- a/src/Spec-Tests/DynamicPresentersListBuilderTest.class.st
+++ b/src/Spec-Tests/DynamicPresentersListBuilderTest.class.st
@@ -45,7 +45,7 @@ DynamicPresentersListBuilderTest >> testInstVarNames [
 DynamicPresentersListBuilderTest >> testInstVarNamesAndPresenterNamesArray [
 	builder
 		modelObjects: { 3 . 2 . 1 };
-		presenterClass: ButtonPresenter.
+		presenterBlock: [ :o | ButtonPresenter ].
 		
 	self
 		assertCollection: builder instVarNamesAndPresenterNamesArray hasSameElements: #(var1 ButtonPresenter var2 ButtonPresenter var3 ButtonPresenter)
@@ -76,7 +76,7 @@ DynamicPresentersListBuilderTest >> testNullPresentersInstVarNamesAndPresenterNa
 DynamicPresentersListBuilderTest >> testPresenterConfiguredAs [
 	| block |
 	self
-		assert: builder presenterClass isNil;
+		assert: builder presenterBlock isNil;
 		assert: builder configurationBlock isNil.
 	
 	block := [ :p :m | ].
@@ -84,6 +84,26 @@ DynamicPresentersListBuilderTest >> testPresenterConfiguredAs [
 		presenter: ButtonPresenter configuredAs: block.
 		
 	self
-		assert: builder presenterClass equals: ButtonPresenter;
+		assert: (builder presenterBlock value: nil) equals: ButtonPresenter; "Any value can be provided to the block in this case, always the same presenter is returned."
+		assert: builder configurationBlock equals: block
+]
+
+{ #category : #tests }
+DynamicPresentersListBuilderTest >> testPresenterProvidedByConfiguredAs [
+	| block |
+	self
+		assert: builder presenterBlock isNil;
+		assert: builder configurationBlock isNil.
+	
+	block := [ :p :m | ].
+	builder
+		presenterProvidedBy: [ :integer |
+			integer even
+				ifTrue: [ ButtonPresenter ]
+				ifFalse: [ LabelPresenter ] ] configuredAs: block.
+		
+	self
+		assert: (builder presenterBlock value: 1) equals: LabelPresenter;
+		assert: (builder presenterBlock value: 2) equals: ButtonPresenter;
 		assert: builder configurationBlock equals: block
 ]


### PR DESCRIPTION
Added possibility to have a different presenter for each model object depending on the result of a Block evaluation.