### PR TITLE
22255-Either-Pragma-should-compare-methodSelector-or-PragmaCollector-should-account-for-bad-comparison

### DIFF
--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -103,6 +103,7 @@ Pragma >> = aPragma [
 	self species == aPragma species ifFalse: [^false].
 
 	self method = aPragma method ifFalse: [^false].
+	self method selector = aPragma method selector ifFalse: [ ^false ].
 	self keyword = aPragma keyword ifFalse: [^false].
 	self arguments = aPragma arguments ifFalse: [^false].
 


### PR DESCRIPTION
CompiledMethod>>#= now compares selectors, too.