### PR TITLE
22399-packagesAffected-in-class-renames-does-not-honor-extension-methods

### DIFF
--- a/src/System-Announcements/ClassRenamed.class.st
+++ b/src/System-Announcements/ClassRenamed.class.st
@@ -76,3 +76,10 @@ ClassRenamed >> oldName: anObject [
 	
 	oldName := anObject
 ]
+
+{ #category : #accessing }
+ClassRenamed >> packagesAffected [
+	^ (super packageAffected,
+		(self classAffected methods asArray , self classAffected classSide methods asArray
+			collect: #package)) asSet asArray
+]

--- a/src/System-Announcements/ClassRenamed.class.st
+++ b/src/System-Announcements/ClassRenamed.class.st
@@ -79,7 +79,5 @@ ClassRenamed >> oldName: anObject [
 
 { #category : #accessing }
 ClassRenamed >> packagesAffected [
-	^ (super packageAffected,
-		(self classAffected methods asArray , self classAffected classSide methods asArray
-			collect: #package)) asSet asArray
+	^ self classAffected packages
 ]


### PR DESCRIPTION
Fix #22399

Renaming a class should affect also the packages containing its extension methods