### PR TITLE
22398-speed-up-NECSymbolCache-interestingSymbolsDo

### DIFF
--- a/src/NECompletion/NECSymbolCache.class.st
+++ b/src/NECompletion/NECSymbolCache.class.st
@@ -48,35 +48,11 @@ NECSymbolCache class >> contains: aString caseSensitive: aBoolean do: aBlock [
 
 { #category : #private }
 NECSymbolCache class >> interestingSymbolsDo: aBlock [
-
-	Symbol allSymbolTablesDo:[:symbol |
-		symbol isEmpty
-			ifFalse: [
-				(symbol first isUppercase and:[ Smalltalk globals includesKey: symbol ])
-					ifTrue:[ aBlock value: symbol ]
-					ifFalse: [ symbol isSelectorSymbol ifTrue: [ aBlock value: symbol ]]]].
+	 Symbol selectorTable do: [:symbol | aBlock value: symbol ].
+    Smalltalk globals keysDo: [:symbol | aBlock value: symbol ].
 ]
 
 { #category : #accessing }
 NECSymbolCache class >> resetCachedSymbols [
 	cachedSymbols := nil
-]
-
-{ #category : #query }
-NECSymbolCache class >> startsWith: aChar caseSensitive: aBoolean do: aBlock [ 
-	| char caseInSensitive firstChar |
-	caseInSensitive := aBoolean not.
-	firstChar := caseInSensitive 
-		ifTrue: [ aChar asLowercase ]
-		ifFalse: [ aChar ].
-	Symbol allSymbolTablesDo: 
-		[ :each | 
-		| size |
-		size := each size.
-		char := size > 0 ifTrue: [ each first ].
-		(char notNil 
-			and: [ (char == firstChar or: [ caseInSensitive and: [ char asLowercase == firstChar ] ])
-			and: [ (each 
-				findAnySubstring: '- '
-				startingAt: 2) > size ] ]) ifTrue: [ aBlock value: each ] ]
 ]

--- a/src/NECompletion/NECUntypedModel.class.st
+++ b/src/NECompletion/NECUntypedModel.class.st
@@ -104,7 +104,7 @@ NECUntypedModel >> initializeSelectors [
 	self resetSelectors.
 	
 	includeSelectors ifFalse: 
-		[ Smalltalk globals keysAndValuesDo: [ :each :class |
+		[ Smalltalk globals keysDo: [ :each |
 			(each includesSubstring: narrowString caseSensitive: NECPreferences caseSensitive) ifTrue: [
 			selectors add: (NECGlobalEntry contents: each)] ].
 		^ self ].


### PR DESCRIPTION
- use keysDo: in initializeSelectors
- delete a unsent method
- speed up interestingSymbolsDo: by a factor of >10. (Cache is not needed after... so we can clean that up next)