### PR TITLE
22388-Ecompletion-enable-Use-navigation-keys-for-extended-completion-functionality

### DIFF
--- a/src/NECompletion/NECPreferences.class.st
+++ b/src/NECompletion/NECPreferences.class.st
@@ -130,7 +130,7 @@ NECPreferences class >> initialize [
 	caseSensitive := true.
 	smartCharacters := true.
 	expandPrefixes := true.
-	captureNavigationKeys := false.
+	captureNavigationKeys := true.
 	useEnterToAccept := true.
 	smartCharactersMapping := Dictionary new.
 	smartCharactersMapping


### PR DESCRIPTION
22388 Ecompletion: enable "Use navigation keys for extended completion functionality"
https://pharo.fogbugz.com/f/cases/22388/Ecompletion-enable-Use-navigation-keys-for-extended-completion-functionality