### PR TITLE
22402 TabPresenter>>#model: should be renamed to TabPresenter>>#presenter:

### DIFF
--- a/src/Deprecated70/TabPresenter.extension.st
+++ b/src/Deprecated70/TabPresenter.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #TabPresenter }
+
+{ #category : #'*Deprecated70' }
+TabPresenter >> model: aComposablePresenter [
+	self
+		deprecated: 'Use #presenter: instead.'
+		transformWith: '`@receiver model: `@statements' -> '`@receiver presenter: `@statements'.
+	
+	self presenter: aComposablePresenter.
+]

--- a/src/Spec-Core/TabPresenter.class.st
+++ b/src/Spec-Core/TabPresenter.class.st
@@ -177,16 +177,16 @@ TabPresenter >> menuHolder [
 	^ menuHolder
 ]
 
-{ #category : #api }
-TabPresenter >> model: aComposablePresenter [
-	aComposablePresenter owner: self.
-	self retrievingBlock: [ aComposablePresenter buildWithSpec asWidget ]
-]
-
 { #category : #'api-valueHolder' }
 TabPresenter >> morphHolder [
 
 	^ morphHolder
+]
+
+{ #category : #api }
+TabPresenter >> presenter: aComposablePresenter [
+	aComposablePresenter owner: self.
+	self retrievingBlock: [ aComposablePresenter buildWithSpec asWidget ]
 ]
 
 { #category : #api }

--- a/src/Spec-Examples/SpecDemoPage.class.st
+++ b/src/Spec-Examples/SpecDemoPage.class.st
@@ -45,13 +45,12 @@ SpecDemoPage >> commentFor: aClass [
 
 { #category : #initialization }
 SpecDemoPage >> commentTab [
-	| tab commentInput|
+	| tab commentInput |
 	tab := self newTab.
 	tab
 		label: 'Comment';
 		icon: (tab iconNamed: #helpIcon);
-		model: (commentInput := self newText).
-		
+		presenter: (commentInput := self newText).
 	commentInput text: (self commentFor: self pageClass).
 	^ tab
 ]
@@ -63,7 +62,7 @@ SpecDemoPage >> exampleTab [
 	tab
 		label: 'Example';
 		icon: (tab iconNamed: #smallPaint);
-		model: (self instantiate: self pageClass).
+		presenter: (self instantiate: self pageClass).
 	^ tab
 ]
 

--- a/src/Spec-Examples/TabsExample.class.st
+++ b/src/Spec-Examples/TabsExample.class.st
@@ -39,7 +39,7 @@ TabsExample >> browserTab [
 	tab
 		label: 'Browser';
 		icon: (tab iconNamed: #nautilusIcon);
-		model:
+		presenter:
 			(ClassMethodBrowser new
 				classes: Smalltalk allClasses;
 				yourself).
@@ -48,13 +48,13 @@ TabsExample >> browserTab [
 
 { #category : #private }
 TabsExample >> dynamicTab [
-      | tab |
-      tab := self newTab.
-      tab
-          label: 'Dynamic';
-          icon: (tab iconNamed: #nautilusIcon);
-          model: (DynamicWidgetChange  new).
-      ^ tab 
+	| tab |
+	tab := self newTab.
+	tab
+		label: 'Dynamic';
+		icon: (tab iconNamed: #nautilusIcon);
+		presenter: DynamicWidgetChange new.
+	^ tab
 ]
 
 { #category : #initialization }
@@ -78,7 +78,7 @@ TabsExample >> objectClassTab [
 	tab
 		label: 'Object class';
 		icon: (tab iconNamed: #nautilusIcon);
-		model: (MessageBrowser new messages: Object methods).
+		presenter: (MessageBrowser new messages: Object methods).
 	^ tab
 ]
 

--- a/src/Spec-Tests/TabPresenterTest.class.st
+++ b/src/Spec-Tests/TabPresenterTest.class.st
@@ -49,6 +49,6 @@ TabPresenterTest >> testSetOwner [
 	| button |
 	button := ButtonPresenter new.
 	self assert: button owner equals: nil.
-	testedInstance model: button.
+	testedInstance presenter: button.
 	self assert: button owner equals: testedInstance
 ]


### PR DESCRIPTION
Introduced #presenter: method and deprecated #model: method. Additionally, provided a rewrite rule for automatic transformation of the source code using #model:.