### PR TITLE
22409-ProperMethodCategorizationTesttestTearDownMethodInSUnitTestsNeedsToBeInRunningProtocol

### DIFF
--- a/src/Renraku-Test/ReTestBasedTestCase.class.st
+++ b/src/Renraku-Test/ReTestBasedTestCase.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'Renraku-Test'
 }
 
-{ #category : #tests }
+{ #category : #running }
 ReTestBasedTestCase >> setUp [
 	super setUp.
 	
@@ -22,7 +22,7 @@ ReTestBasedTestCase >> setUp [
 		package: testPackage name.
 ]
 
-{ #category : #tests }
+{ #category : #running }
 ReTestBasedTestCase >> tearDown [
 
 	validTestPackage methods do: #removeFromSystem.


### PR DESCRIPTION
22409 ProperMethodCategorizationTest.testTearDownM
https://pharo.fogbugz.com/f/cases/22409/ProperMethodCategorizationTest-testTearDownMethodInSUnitTestsNeedsToBeInRunningProtocol