### PR TITLE
22412-Typo-closeclosed-in-AbstractBinaryFileStream--nextputAll

### DIFF
--- a/src/Files/AbstractBinaryFileStream.class.st
+++ b/src/Files/AbstractBinaryFileStream.class.st
@@ -177,7 +177,7 @@ AbstractBinaryFileStream >> next: amount putAll: aByteArray [
 		on: PrimitiveFailed
 		do: [ (FileWriteError fileName: self name)
 				signal:
-					(self close
+					(self closed
 						ifTrue: [ 'File ' , self name , ' is closed' ]
 						ifFalse: [ 'File ' , self name , ' write failed' ]) ].
 	^ aByteArray


### PR DESCRIPTION
In `AbstractBinaryFileStream >> next:putAll:`…

`self close ifTrue:…` closes the stream and then causes a MustBeBoolean; I'm pretty sure `closed` is what was intended there ;-)
