### PR TITLE
22422 Correctly deprecate Ring- Core-Kernel and Ring Tests Kernel

### DIFF
--- a/src/Ring-Deprecated-Core-Kernel/ManifestRingCoreKernel.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/ManifestRingCoreKernel.class.st
@@ -1,7 +1,10 @@
+"
+Manifest for DEPRECATED package of Ring
+"
 Class {
 	#name : #ManifestRingCoreKernel,
 	#superclass : #PackageManifest,
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Manifest'
 }
 
 { #category : #deprecation }

--- a/src/Ring-Deprecated-Core-Kernel/RGBehaviorDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGBehaviorDefinition.class.st
@@ -14,7 +14,7 @@ Class {
 		'methods',
 		'protocols'
 	],
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #'class-annotations' }

--- a/src/Ring-Deprecated-Core-Kernel/RGClassDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGClassDefinition.class.st
@@ -12,7 +12,7 @@ Class {
 		'package',
 		'sharedPools'
 	],
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #'instance creation' }

--- a/src/Ring-Deprecated-Core-Kernel/RGClassDescriptionDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGClassDescriptionDefinition.class.st
@@ -8,7 +8,7 @@ Class {
 		'instanceVariables',
 		'organization'
 	],
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #comparing }

--- a/src/Ring-Deprecated-Core-Kernel/RGClassInstanceVariableDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGClassInstanceVariableDefinition.class.st
@@ -4,7 +4,7 @@ A class instance variable definition
 Class {
 	#name : #RGClassInstanceVariableDefinition,
 	#superclass : #RGVariableDefinition,
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #initialization }

--- a/src/Ring-Deprecated-Core-Kernel/RGClassVariableDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGClassVariableDefinition.class.st
@@ -4,7 +4,7 @@ A class variable definition
 Class {
 	#name : #RGClassVariableDefinition,
 	#superclass : #RGVariableDefinition,
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #testing }

--- a/src/Ring-Deprecated-Core-Kernel/RGCommentDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGCommentDefinition.class.st
@@ -8,7 +8,7 @@ Class {
 		'content',
 		'stamp'
 	],
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #'instance creation' }

--- a/src/Ring-Deprecated-Core-Kernel/RGDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGDefinition.class.st
@@ -9,7 +9,7 @@ Class {
 		'annotations',
 		'name'
 	],
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #annotations }

--- a/src/Ring-Deprecated-Core-Kernel/RGElementDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGElementDefinition.class.st
@@ -81,7 +81,7 @@ Class {
 	#instVars : [
 		'parent'
 	],
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #'parsing stamp' }

--- a/src/Ring-Deprecated-Core-Kernel/RGGlobalDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGGlobalDefinition.class.st
@@ -5,7 +5,7 @@ An RGGlobalDefinition is an abstract superclass for representing classes, global
 Class {
 	#name : #RGGlobalDefinition,
 	#superclass : #RGDefinition,
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #comparing }

--- a/src/Ring-Deprecated-Core-Kernel/RGGlobalVariableDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGGlobalVariableDefinition.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'value'
 	],
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #'managing container' }

--- a/src/Ring-Deprecated-Core-Kernel/RGInstanceVariableDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGInstanceVariableDefinition.class.st
@@ -4,7 +4,7 @@ An instance variable definition
 Class {
 	#name : #RGInstanceVariableDefinition,
 	#superclass : #RGVariableDefinition,
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #testing }

--- a/src/Ring-Deprecated-Core-Kernel/RGMetaclassDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGMetaclassDefinition.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'baseClass'
 	],
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #'class initialization' }

--- a/src/Ring-Deprecated-Core-Kernel/RGMetatraitDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGMetatraitDefinition.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'baseClass'
 	],
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #'class initialization' }

--- a/src/Ring-Deprecated-Core-Kernel/RGMethodDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGMethodDefinition.class.st
@@ -82,7 +82,7 @@ Class {
 		'stamp',
 		'package'
 	],
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #'instance creation' }

--- a/src/Ring-Deprecated-Core-Kernel/RGPoolVariableDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGPoolVariableDefinition.class.st
@@ -4,7 +4,7 @@ A pool variable definition
 Class {
 	#name : #RGPoolVariableDefinition,
 	#superclass : #RGVariableDefinition,
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #testing }

--- a/src/Ring-Deprecated-Core-Kernel/RGTraitDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGTraitDefinition.class.st
@@ -10,7 +10,7 @@ Class {
 		'category',
 		'package'
 	],
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #accessing }

--- a/src/Ring-Deprecated-Core-Kernel/RGTraitDescriptionDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGTraitDescriptionDefinition.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'users'
 	],
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #'adding/removing users' }

--- a/src/Ring-Deprecated-Core-Kernel/RGVariableDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGVariableDefinition.class.st
@@ -4,7 +4,7 @@ A variable definition
 Class {
 	#name : #RGVariableDefinition,
 	#superclass : #RGElementDefinition,
-	#category : #'Ring-Deprecated-Core-Kernel'
+	#category : #'Ring-Deprecated-Core-Kernel-Base'
 }
 
 { #category : #comparing }

--- a/src/Ring-Deprecated-Tests-Kernel/ManifestRingCoreTestsKernel.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/ManifestRingCoreTestsKernel.class.st
@@ -1,0 +1,13 @@
+"
+Manifest for DEPRECATED package of Ring tests
+"
+Class {
+	#name : #ManifestRingCoreTestsKernel,
+	#superclass : #PackageManifest,
+	#category : #'Ring-Deprecated-Tests-Kernel-Manifest'
+}
+
+{ #category : #testing }
+ManifestRingCoreTestsKernel class >> isDeprecated [
+	^true
+]

--- a/src/Ring-Deprecated-Tests-Kernel/RGClassDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGClassDefinitionTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for class definitions
 Class {
 	#name : #RGClassDefinitionTest,
 	#superclass : #TestCase,
-	#category : #'Ring-Deprecated-Tests-Kernel'
+	#category : #'Ring-Deprecated-Tests-Kernel-Base'
 }
 
 { #category : #deprecation }

--- a/src/Ring-Deprecated-Tests-Kernel/RGCommentDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGCommentDefinitionTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for comment definitions
 Class {
 	#name : #RGCommentDefinitionTest,
 	#superclass : #TestCase,
-	#category : #'Ring-Deprecated-Tests-Kernel'
+	#category : #'Ring-Deprecated-Tests-Kernel-Base'
 }
 
 { #category : #deprecation }

--- a/src/Ring-Deprecated-Tests-Kernel/RGGlobalDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGGlobalDefinitionTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for global definitions (pools, global variables)
 Class {
 	#name : #RGGlobalDefinitionTest,
 	#superclass : #TestCase,
-	#category : #'Ring-Deprecated-Tests-Kernel'
+	#category : #'Ring-Deprecated-Tests-Kernel-Base'
 }
 
 { #category : #deprecation }

--- a/src/Ring-Deprecated-Tests-Kernel/RGMetaclassDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGMetaclassDefinitionTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for Ring metaclass definitions
 Class {
 	#name : #RGMetaclassDefinitionTest,
 	#superclass : #TestCase,
-	#category : #'Ring-Deprecated-Tests-Kernel'
+	#category : #'Ring-Deprecated-Tests-Kernel-Base'
 }
 
 { #category : #deprecation }

--- a/src/Ring-Deprecated-Tests-Kernel/RGMetatraitDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGMetatraitDefinitionTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for Ring classtrait definitions
 Class {
 	#name : #RGMetatraitDefinitionTest,
 	#superclass : #TestCase,
-	#category : #'Ring-Deprecated-Tests-Kernel'
+	#category : #'Ring-Deprecated-Tests-Kernel-Base'
 }
 
 { #category : #deprecation }

--- a/src/Ring-Deprecated-Tests-Kernel/RGMethodDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGMethodDefinitionTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for method definitions
 Class {
 	#name : #RGMethodDefinitionTest,
 	#superclass : #TestCase,
-	#category : #'Ring-Deprecated-Tests-Kernel'
+	#category : #'Ring-Deprecated-Tests-Kernel-Base'
 }
 
 { #category : #deprecation }

--- a/src/Ring-Deprecated-Tests-Kernel/RGTraitDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGTraitDefinitionTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for trait definitions
 Class {
 	#name : #RGTraitDefinitionTest,
 	#superclass : #TestCase,
-	#category : #'Ring-Deprecated-Tests-Kernel'
+	#category : #'Ring-Deprecated-Tests-Kernel-Base'
 }
 
 { #category : #deprecation }

--- a/src/Ring-Deprecated-Tests-Kernel/RGVariableDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGVariableDefinitionTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for variable definitions
 Class {
 	#name : #RGVariableDefinitionTest,
 	#superclass : #TestCase,
-	#category : #'Ring-Deprecated-Tests-Kernel'
+	#category : #'Ring-Deprecated-Tests-Kernel-Base'
 }
 
 { #category : #deprecation }


### PR DESCRIPTION
The package is already called "Ring-Deprecated-Tests-Kernel-Manifest" but not strike through to signal deprecation as it is in Ring-Deprecated-Core-Kernel.

Therefore we add a Manifest returning #isDeprecated with true

also categorize so the manifest is easier found