### PR TITLE
22423 Correctly deprecate MatrixTest

### DIFF
--- a/src/Deprecated70/MatrixTest.class.st
+++ b/src/Deprecated70/MatrixTest.class.st
@@ -13,6 +13,11 @@ Class {
 	#category : #Deprecated70
 }
 
+{ #category : #testing }
+MatrixTest class >> isDeprecated [
+	^true
+]
+
 { #category : #running }
 MatrixTest >> setUp [
 	super setUp.


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/22423/Correctly-deprecate-MatrixTest

Matrix already returns #isDeprecated true, but MatrixText not (yet).
Usually no one calls a test - but for completeness we should deprecate it too