### PR TITLE
22424 Correctly deprecate Ring-Deprecated-Tests-Containers and Ring-D…

### DIFF
--- a/src/Ring-Deprecated-Tests-Containers/ManifestRingTestsContainers.class.st
+++ b/src/Ring-Deprecated-Tests-Containers/ManifestRingTestsContainers.class.st
@@ -1,0 +1,14 @@
+"
+Manifest for DEPRECATED package for Ring containers tests
+"
+Class {
+	#name : #ManifestRingTestsContainers,
+	#superclass : #PackageManifest,
+	#category : #'Ring-Deprecated-Tests-Containers-Manifest'
+}
+
+{ #category : #testing }
+ManifestRingTestsContainers class >> isDeprecated [
+
+	^true
+]

--- a/src/Ring-Deprecated-Tests-Containers/RGContainerTest.class.st
+++ b/src/Ring-Deprecated-Tests-Containers/RGContainerTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for container
 Class {
 	#name : #RGContainerTest,
 	#superclass : #TestCase,
-	#category : #'Ring-Deprecated-Tests-Containers'
+	#category : #'Ring-Deprecated-Tests-Containers-Base'
 }
 
 { #category : #deprecation }

--- a/src/Ring-Deprecated-Tests-Containers/RGNamespaceTest.class.st
+++ b/src/Ring-Deprecated-Tests-Containers/RGNamespaceTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for namespaces
 Class {
 	#name : #RGNamespaceTest,
 	#superclass : #TestCase,
-	#category : #'Ring-Deprecated-Tests-Containers'
+	#category : #'Ring-Deprecated-Tests-Containers-Base'
 }
 
 { #category : #deprecation }

--- a/src/Ring-Deprecated-Tests-Containers/RGPackageTest.class.st
+++ b/src/Ring-Deprecated-Tests-Containers/RGPackageTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for packages
 Class {
 	#name : #RGPackageTest,
 	#superclass : #TestCase,
-	#category : #'Ring-Deprecated-Tests-Containers'
+	#category : #'Ring-Deprecated-Tests-Containers-Base'
 }
 
 { #category : #deprecation }

--- a/src/Ring-Deprecated-Tests-Containers/RGSliceTest.class.st
+++ b/src/Ring-Deprecated-Tests-Containers/RGSliceTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for slices
 Class {
 	#name : #RGSliceTest,
 	#superclass : #TestCase,
-	#category : #'Ring-Deprecated-Tests-Containers'
+	#category : #'Ring-Deprecated-Tests-Containers-Base'
 }
 
 { #category : #deprecation }

--- a/src/Ring-Deprecated-Tests-Monticello/ManifestRingTestsMonticello.class.st
+++ b/src/Ring-Deprecated-Tests-Monticello/ManifestRingTestsMonticello.class.st
@@ -1,0 +1,14 @@
+"
+Manifest for DEPRECATED package for Ring monticello tests
+"
+Class {
+	#name : #ManifestRingTestsMonticello,
+	#superclass : #PackageManifest,
+	#category : #'Ring-Deprecated-Tests-Monticello-Manifest'
+}
+
+{ #category : #testing }
+ManifestRingTestsMonticello class >> isDeprecated [
+
+	^true
+]

--- a/src/Ring-Deprecated-Tests-Monticello/RGMonticelloTest.class.st
+++ b/src/Ring-Deprecated-Tests-Monticello/RGMonticelloTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for monticello
 Class {
 	#name : #RGMonticelloTest,
 	#superclass : #TestCase,
-	#category : #'Ring-Deprecated-Tests-Monticello'
+	#category : #'Ring-Deprecated-Tests-Monticello-Base'
 }
 
 { #category : #deprecation }


### PR DESCRIPTION
…eprecated-Tests-Monticello-Manifest

Packages should be striked through as they have been deprecated. 
Therefore we apply a manifest and tag/categorize so the manifest is found more easily

https://pharo.fogbugz.com/f/cases/22424/Correctly-deprecate-Ring-Deprecated-Tests-Containers-and-Ring-Deprecated-Tests-Monticello-Manifest