### PR TITLE
22426 Cleanup LzwGifEncoder and GIFReadWriter

### DIFF
--- a/src/Graphics-Files/GIFReadWriter.class.st
+++ b/src/Graphics-Files/GIFReadWriter.class.st
@@ -430,7 +430,7 @@ GIFReadWriter >> readBitDataOnFrame: aFrame [
 { #category : #'private-decoding' }
 GIFReadWriter >> readBody [
 	"Read the GIF blocks. Modified to return a frame."
-	| form extype block blocksize packedFields delay1 disposal frame |
+	| block frame |
 	frame := nil.
 	frames := OrderedCollection new.
 	[ stream atEnd ] whileFalse: [ 

--- a/src/Graphics-Files/LzwGifEncoder.class.st
+++ b/src/Graphics-Files/LzwGifEncoder.class.st
@@ -56,7 +56,7 @@ LzwGifEncoder >> checkCodeSize [
 			maxCode := (1 bitShift: codeSize) - 1 ].
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #private }
 LzwGifEncoder >> checkSettings [
 	"Ensure that the appropriate variables
 	that are needed for proper encoding
@@ -260,19 +260,6 @@ LzwGifEncoder >> readPixelFrom: bits [
 { #category : #accessing }
 LzwGifEncoder >> rowByteSize: anInteger [
 	rowByteSize := anInteger
-]
-
-{ #category : #'as yet unclassified' }
-LzwGifEncoder >> tablesInclude: aValue withIndexBuffer: aCollection [
-	"Answer true if we are able to find the given value
-	in the prefix/suffix tables by tracing the values
-	in the given collection. False otherwise."
-	| lookupIndex |
-	aCollection ifEmpty: [ 
-		^ prefixTable includes: aValue ].
-	aCollection do: [ :val |
-		 ]
-	
 ]
 
 { #category : #private }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/22426/

This change
- categorizes what is uncategorized
- delete what is unsent
- removes what is unused 
to fix what was introduced in https://github.com/pharo-project/pharo/pull/1666

to get back to the situation with an image that had not unused temps

 