### PR TITLE
22432 New Release test: NoUnusedTemporaryVariablesLeftTest

### DIFF
--- a/src/ReleaseTests/NoUnusedTemporaryVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedTemporaryVariablesLeftTest.class.st
@@ -1,0 +1,37 @@
+"
+Test to check if there are methods who have unused temporary variables in the image
+"
+Class {
+	#name : #NoUnusedTemporaryVariablesLeftTest,
+	#superclass : #TestCase,
+	#category : #'ReleaseTests-CleanCode'
+}
+
+{ #category : #accessing }
+NoUnusedTemporaryVariablesLeftTest class >> defaultTimeLimit [
+
+	^ 1 minute
+]
+
+{ #category : #running }
+NoUnusedTemporaryVariablesLeftTest >> tearDown [
+	ASTCache reset.
+	super tearDown
+]
+
+{ #category : #testing }
+NoUnusedTemporaryVariablesLeftTest >> testNoUnusedTemporaryVariablesLeft [
+	"Fail if there are methods who have unused temporary variables"
+	| found validExceptions remaining |
+	found := CompiledMethod allInstances
+		select: [ :m | m ast temporaries anySatisfy: [ :x | x binding isUnused ] ].
+	
+	"No other exceptions beside the ones mentioned here should be allowed"	
+	validExceptions := { MFClassA>>#method. MFClassB>>#method3. MFClassB>>#method2}.	
+	
+	remaining := found asOrderedCollection 
+								removeAll: validExceptions;
+								yourself.
+								
+	self assert: remaining isEmpty description: ('the following methods have unused temporary variables and should be cleaned: ', remaining asString)
+]


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/edit/22432/New-Release-test-NoUnusedTemporaryVariablesLeftTest

A new test to check that there are no methods with unused variables introduced 
into the image again.

See discussion on http://lists.pharo.org/pipermail/pharo-dev_lists.pharo.org/2018-September/272927.html