### PR TITLE
22442 Tag and comment Manifests in all Spec related packages

### DIFF
--- a/src/Spec-Core/AbstractAdapter.class.st
+++ b/src/Spec-Core/AbstractAdapter.class.st
@@ -15,7 +15,7 @@ Class {
 		'widget',
 		'selector'
 	],
-	#category : #'Spec-Core'
+	#category : #'Spec-Core-Base'
 }
 
 { #category : #'instance creation' }

--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -101,7 +101,7 @@ Class {
 		'askOkToClose',
 		'titleHolder'
 	],
-	#category : #'Spec-Core'
+	#category : #'Spec-Core-Base'
 }
 
 { #category : #defaults }

--- a/src/Spec-Core/ComposablePresenterWithModel.class.st
+++ b/src/Spec-Core/ComposablePresenterWithModel.class.st
@@ -12,7 +12,7 @@ Class {
 	#instVars : [
 		'announcingObject'
 	],
-	#category : #'Spec-Core'
+	#category : #'Spec-Core-Base'
 }
 
 { #category : #'accessing - private' }

--- a/src/Spec-Core/CurrentSpecDefaultBindings.class.st
+++ b/src/Spec-Core/CurrentSpecDefaultBindings.class.st
@@ -1,3 +1,6 @@
+"
+Dynamic variable for Spec on which of the bindings (Morphic or other) should be used as default
+"
 Class {
 	#name : #CurrentSpecDefaultBindings,
 	#superclass : #DynamicVariable,

--- a/src/Spec-Core/DynamicComposablePresenter.class.st
+++ b/src/Spec-Core/DynamicComposablePresenter.class.st
@@ -28,7 +28,7 @@ Class {
 		'widgets',
 		'layout'
 	],
-	#category : #'Spec-Core'
+	#category : #'Spec-Core-Base'
 }
 
 { #category : #'instance creation' }

--- a/src/Spec-Core/ManifestSpecCore.class.st
+++ b/src/Spec-Core/ManifestSpecCore.class.st
@@ -1,7 +1,10 @@
+"
+Core package for the Spec UI Framework
+"
 Class {
 	#name : #ManifestSpecCore,
 	#superclass : #PackageManifest,
-	#category : #'Spec-Core'
+	#category : #'Spec-Core-Manifest'
 }
 
 { #category : #'code-critics' }

--- a/src/Spec-Core/ManifestSpecCore.class.st
+++ b/src/Spec-Core/ManifestSpecCore.class.st
@@ -1,5 +1,5 @@
 "
-Core package for the Spec UI Framework
+Core package for the Spec UI framework
 "
 Class {
 	#name : #ManifestSpecCore,

--- a/src/Spec-Core/SpecAdapterBindings.class.st
+++ b/src/Spec-Core/SpecAdapterBindings.class.st
@@ -9,8 +9,14 @@ Class {
 	#instVars : [
 		'bindings'
 	],
-	#category : #'Spec-Core'
+	#category : #'Spec-Core-Base'
 }
+
+{ #category : #testing }
+SpecAdapterBindings class >> isAbstract [ 
+
+	^ self name = #SpecAdapterBindings
+]
 
 { #category : #initialize }
 SpecAdapterBindings >> initialize [

--- a/src/Spec-Core/SpecFTColumn.class.st
+++ b/src/Spec-Core/SpecFTColumn.class.st
@@ -1,3 +1,6 @@
+"
+A column for Fast table
+"
 Class {
 	#name : #SpecFTColumn,
 	#superclass : #Object,

--- a/src/Spec-Core/SpecInterpreter.class.st
+++ b/src/Spec-Core/SpecInterpreter.class.st
@@ -13,7 +13,7 @@ Class {
 	#classInstVars : [
 		'bindings'
 	],
-	#category : #'Spec-Core'
+	#category : #'Spec-Core-Utilities'
 }
 
 { #category : #accessing }

--- a/src/Spec-Core/SpecWrapper.class.st
+++ b/src/Spec-Core/SpecWrapper.class.st
@@ -8,7 +8,7 @@ Class {
 		'instance',
 		'selector'
 	],
-	#category : #'Spec-Core'
+	#category : #'Spec-Core-Utilities'
 }
 
 { #category : #'instance creation' }

--- a/src/Spec-Help/ManifestSpecHelp.class.st
+++ b/src/Spec-Help/ManifestSpecHelp.class.st
@@ -1,5 +1,8 @@
+"
+Help descriptions for Spec UI framework
+"
 Class {
 	#name : #ManifestSpecHelp,
 	#superclass : #PackageManifest,
-	#category : #'Spec-Help'
+	#category : #'Spec-Help-Manifest'
 }

--- a/src/Spec-Help/SpecExamples.class.st
+++ b/src/Spec-Help/SpecExamples.class.st
@@ -6,7 +6,7 @@ See class side for selectors.
 Class {
 	#name : #SpecExamples,
 	#superclass : #SpecHelpTopics,
-	#category : #'Spec-Help'
+	#category : #'Spec-Help-Topics'
 }
 
 { #category : #accessing }

--- a/src/Spec-Help/SpecHelpTopics.class.st
+++ b/src/Spec-Help/SpecHelpTopics.class.st
@@ -6,7 +6,7 @@ See class side for selectors.
 Class {
 	#name : #SpecHelpTopics,
 	#superclass : #CustomHelp,
-	#category : #'Spec-Help'
+	#category : #'Spec-Help-Topics'
 }
 
 { #category : #accessing }

--- a/src/Spec-Help/SpecLayouts.class.st
+++ b/src/Spec-Help/SpecLayouts.class.st
@@ -6,7 +6,7 @@ See class side for selectors.
 Class {
 	#name : #SpecLayouts,
 	#superclass : #SpecHelpTopics,
-	#category : #'Spec-Help'
+	#category : #'Spec-Help-Topics'
 }
 
 { #category : #accessing }

--- a/src/Spec-Help/TheHeartOfSpec.class.st
+++ b/src/Spec-Help/TheHeartOfSpec.class.st
@@ -6,7 +6,7 @@ See class side for selectors.
 Class {
 	#name : #TheHeartOfSpec,
 	#superclass : #SpecHelpTopics,
-	#category : #'Spec-Help'
+	#category : #'Spec-Help-Topics'
 }
 
 { #category : #accessing }

--- a/src/Spec-Inspector/EyeAbstractInspector.class.st
+++ b/src/Spec-Inspector/EyeAbstractInspector.class.st
@@ -11,7 +11,7 @@ Class {
 		'customMenuActions',
 		'text'
 	],
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #spec }

--- a/src/Spec-Inspector/EyeBagInspector.class.st
+++ b/src/Spec-Inspector/EyeBagInspector.class.st
@@ -4,7 +4,7 @@ Specialized version of inspector showing occurrences of items of the bag
 Class {
 	#name : #EyeBagInspector,
 	#superclass : #EyeCollectionInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #list }

--- a/src/Spec-Inspector/EyeBasicInspector.class.st
+++ b/src/Spec-Inspector/EyeBasicInspector.class.st
@@ -4,7 +4,7 @@ I am a special inspector that only lists the real fields of an object. I have ex
 Class {
 	#name : #EyeBasicInspector,
 	#superclass : #EyeInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #accessing }

--- a/src/Spec-Inspector/EyeByteArrayInspector.class.st
+++ b/src/Spec-Inspector/EyeByteArrayInspector.class.st
@@ -5,7 +5,7 @@ Specialized version of inspector showing the hex and string representation of th
 Class {
 	#name : #EyeByteArrayInspector,
 	#superclass : #EyeCollectionInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #list }

--- a/src/Spec-Inspector/EyeCharacterInspector.class.st
+++ b/src/Spec-Inspector/EyeCharacterInspector.class.st
@@ -10,7 +10,7 @@ I show the Unicode code point in standard notation, like U+0041 for $A.
 Class {
 	#name : #EyeCharacterInspector,
 	#superclass : #EyeInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #list }

--- a/src/Spec-Inspector/EyeCollectionInspector.class.st
+++ b/src/Spec-Inspector/EyeCollectionInspector.class.st
@@ -4,7 +4,7 @@ Specialized version of inspector showing the size of the inspected collection in
 Class {
 	#name : #EyeCollectionInspector,
 	#superclass : #EyeInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #accessing }

--- a/src/Spec-Inspector/EyeCompiledMethodInspector.class.st
+++ b/src/Spec-Inspector/EyeCompiledMethodInspector.class.st
@@ -4,7 +4,7 @@ Specialized version of inspector showing bytecodes symbolic representation, ast,
 Class {
 	#name : #EyeCompiledMethodInspector,
 	#superclass : #EyeInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #accessing }

--- a/src/Spec-Inspector/EyeDateAndTimeInspector.class.st
+++ b/src/Spec-Inspector/EyeDateAndTimeInspector.class.st
@@ -8,7 +8,7 @@ I show  all individual elements by name, as well as a UTC representation.
 Class {
 	#name : #EyeDateAndTimeInspector,
 	#superclass : #EyeInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #list }

--- a/src/Spec-Inspector/EyeDictionaryInspector.class.st
+++ b/src/Spec-Inspector/EyeDictionaryInspector.class.st
@@ -4,7 +4,7 @@ Specialized version of inspector showing keys on left panel and values on descri
 Class {
 	#name : #EyeDictionaryInspector,
 	#superclass : #EyeCollectionInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #list }

--- a/src/Spec-Inspector/EyeEditor.class.st
+++ b/src/Spec-Inspector/EyeEditor.class.st
@@ -4,7 +4,7 @@ I am an abstract view model for editors displayed in the inspector
 Class {
 	#name : #EyeEditor,
 	#superclass : #EyeAbstractInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #accessing }

--- a/src/Spec-Inspector/EyeFileSystemInspector.class.st
+++ b/src/Spec-Inspector/EyeFileSystemInspector.class.st
@@ -4,7 +4,7 @@ I am an inspector dedicated to the visualization of file systems
 Class {
 	#name : #EyeFileSystemInspector,
 	#superclass : #EyeTreeInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #accessing }

--- a/src/Spec-Inspector/EyeFloatInspector.class.st
+++ b/src/Spec-Inspector/EyeFloatInspector.class.st
@@ -12,7 +12,7 @@ sign * significand * (2 raisedToInteger: exponent)
 Class {
 	#name : #EyeFloatInspector,
 	#superclass : #EyeInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #list }

--- a/src/Spec-Inspector/EyeInspector.class.st
+++ b/src/Spec-Inspector/EyeInspector.class.st
@@ -14,7 +14,7 @@ Class {
 	#classInstVars : [
 		'useAutoRefresh'
 	],
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #inspecting }

--- a/src/Spec-Inspector/EyeInspectorToolBar.class.st
+++ b/src/Spec-Inspector/EyeInspectorToolBar.class.st
@@ -10,7 +10,7 @@ Class {
 		'inspectorChoice',
 		'isUpdating'
 	],
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Widgets'
 }
 
 { #category : #specs }

--- a/src/Spec-Inspector/EyeIntegerInspector.class.st
+++ b/src/Spec-Inspector/EyeIntegerInspector.class.st
@@ -6,7 +6,7 @@ If within Unicode range, show a Character having using the Integer value as code
 Class {
 	#name : #EyeIntegerInspector,
 	#superclass : #EyeInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #list }

--- a/src/Spec-Inspector/EyeMethodContextInspector.class.st
+++ b/src/Spec-Inspector/EyeMethodContextInspector.class.st
@@ -4,7 +4,7 @@ I am an eye inspector specified for MethodContext
 Class {
 	#name : #EyeMethodContextInspector,
 	#superclass : #EyeInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #accessing }

--- a/src/Spec-Inspector/EyeMethodEditor.class.st
+++ b/src/Spec-Inspector/EyeMethodEditor.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'toolbar'
 	],
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #spec }

--- a/src/Spec-Inspector/EyeMorphViewer.class.st
+++ b/src/Spec-Inspector/EyeMorphViewer.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'container'
 	],
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #spec }

--- a/src/Spec-Inspector/EyePointerExplorer.class.st
+++ b/src/Spec-Inspector/EyePointerExplorer.class.st
@@ -17,7 +17,7 @@ Class {
 	#instVars : [
 		'onlyStrong'
 	],
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #accessing }

--- a/src/Spec-Inspector/EyeSetInspector.class.st
+++ b/src/Spec-Inspector/EyeSetInspector.class.st
@@ -4,7 +4,7 @@ Specialized version of inspector showing values only
 Class {
 	#name : #EyeSetInspector,
 	#superclass : #EyeCollectionInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #list }

--- a/src/Spec-Inspector/EyeStringInspector.class.st
+++ b/src/Spec-Inspector/EyeStringInspector.class.st
@@ -6,7 +6,7 @@ Right now, the only difference is that the list of elements for the tree is over
 Class {
 	#name : #EyeStringInspector,
 	#superclass : #EyeCollectionInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #accessing }

--- a/src/Spec-Inspector/EyeSyntaxTreeInspector.class.st
+++ b/src/Spec-Inspector/EyeSyntaxTreeInspector.class.st
@@ -10,7 +10,7 @@ As an example, inspect
 Class {
 	#name : #EyeSyntaxTreeInspector,
 	#superclass : #EyeTreeInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #accessing }

--- a/src/Spec-Inspector/EyeTreeInspector.class.st
+++ b/src/Spec-Inspector/EyeTreeInspector.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'tree'
 	],
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #spec }

--- a/src/Spec-Inspector/EyeViewHierarchyInspector.class.st
+++ b/src/Spec-Inspector/EyeViewHierarchyInspector.class.st
@@ -4,7 +4,7 @@ A special tree inspector that displays the submorph hierarchy of the inspected m
 Class {
 	#name : #EyeViewHierarchyInspector,
 	#superclass : #EyeTreeInspector,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Base'
 }
 
 { #category : #accessing }

--- a/src/Spec-Inspector/InspectorNavigator.class.st
+++ b/src/Spec-Inspector/InspectorNavigator.class.st
@@ -11,7 +11,7 @@ Class {
 		'listOfOpenedInspectors',
 		'toolbar'
 	],
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Widgets'
 }
 
 { #category : #specs }

--- a/src/Spec-Inspector/ManifestSpecInspector.class.st
+++ b/src/Spec-Inspector/ManifestSpecInspector.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #ManifestSpecInspector,
 	#superclass : #PackageManifest,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Manifest'
 }

--- a/src/Spec-Inspector/TInspectorActions.trait.st
+++ b/src/Spec-Inspector/TInspectorActions.trait.st
@@ -3,7 +3,7 @@ I contain common actions for inspectors and inspector elements/wrappers
 "
 Trait {
 	#name : #TInspectorActions,
-	#category : #'Spec-Inspector'
+	#category : #'Spec-Inspector-Traits'
 }
 
 { #category : #actions }

--- a/src/Spec-MorphicAdapters/AbstractMorphicAdapter.class.st
+++ b/src/Spec-MorphicAdapters/AbstractMorphicAdapter.class.st
@@ -4,7 +4,7 @@ I am an abstract class providing all the properties shared amongs all the morphi
 Class {
 	#name : #AbstractMorphicAdapter,
 	#superclass : #AbstractAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #specs }

--- a/src/Spec-MorphicAdapters/ManifestSpecMorphicAdapters.class.st
+++ b/src/Spec-MorphicAdapters/ManifestSpecMorphicAdapters.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ManifestSpecMorphicAdapters,
 	#superclass : #PackageManifest,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Manifest'
 }
 
 { #category : #'code-critics' }

--- a/src/Spec-MorphicAdapters/MorphicButtonAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicButtonAdapter.class.st
@@ -7,7 +7,7 @@ SpecInterpreter
 Class {
 	#name : #MorphicButtonAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #'widget API' }

--- a/src/Spec-MorphicAdapters/MorphicCheckBoxAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicCheckBoxAdapter.class.st
@@ -4,7 +4,7 @@ I am an adapter to ease the bridge a CheckBoxPresenter and a CheckboxMorph
 Class {
 	#name : #MorphicCheckBoxAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #factory }

--- a/src/Spec-MorphicAdapters/MorphicContainerAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicContainerAdapter.class.st
@@ -4,7 +4,7 @@ I am the adapter providing the correct container class: PanelMorph
 Class {
 	#name : #MorphicContainerAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #factory }

--- a/src/Spec-MorphicAdapters/MorphicDialogWindowAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicDialogWindowAdapter.class.st
@@ -4,7 +4,7 @@ I am the adapter used to bridge a DialogWindowPresenter and a DialogWindow
 Class {
 	#name : #MorphicDialogWindowAdapter,
 	#superclass : #MorphicWindowAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #factory }

--- a/src/Spec-MorphicAdapters/MorphicDiffAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicDiffAdapter.class.st
@@ -4,7 +4,7 @@ I am an adpater to bridge a DiffPresenter and a DiffMorph
 Class {
 	#name : #MorphicDiffAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #factory }

--- a/src/Spec-MorphicAdapters/MorphicDropListAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicDropListAdapter.class.st
@@ -4,7 +4,7 @@ I am the adapter used to bridget a DropListPresenter and a DropListMorph
 Class {
 	#name : #MorphicDropListAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #factory }

--- a/src/Spec-MorphicAdapters/MorphicFastTableAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicFastTableAdapter.class.st
@@ -4,7 +4,7 @@ I am the adapter used to bridge an FastTablePresenter and a FTPluggableIconListM
 Class {
 	#name : #MorphicFastTableAdapter,
 	#superclass : #MorphicListAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #factory }

--- a/src/Spec-MorphicAdapters/MorphicGenericAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicGenericAdapter.class.st
@@ -6,7 +6,7 @@ Be aware that when you use this, you broke Spec plateform independency and force
 Class {
 	#name : #MorphicGenericAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #'instance creation' }

--- a/src/Spec-MorphicAdapters/MorphicIconListAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicIconListAdapter.class.st
@@ -4,7 +4,7 @@ I am the adapter used to bridge an IconListPresenter and a PluggableIconListMorp
 Class {
 	#name : #MorphicIconListAdapter,
 	#superclass : #MorphicListAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #factory }

--- a/src/Spec-MorphicAdapters/MorphicImageAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicImageAdapter.class.st
@@ -4,7 +4,7 @@ I am the bridge between an ImagePresenter and a AlphaImageMorph
 Class {
 	#name : #MorphicImageAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #initialization }

--- a/src/Spec-MorphicAdapters/MorphicLabelAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicLabelAdapter.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'emphasisOptions'
 	],
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #factory }

--- a/src/Spec-MorphicAdapters/MorphicListAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicListAdapter.class.st
@@ -4,7 +4,7 @@ I am the adapter used to bridge a ListPresenter and a PluggableListMorph
 Class {
 	#name : #MorphicListAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #'widget API' }

--- a/src/Spec-MorphicAdapters/MorphicMenuAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicMenuAdapter.class.st
@@ -4,7 +4,7 @@ I am the adapter used to build a MenuMorph from a MenuPresenter
 Class {
 	#name : #MorphicMenuAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #'instance creation' }

--- a/src/Spec-MorphicAdapters/MorphicMenuGroupAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicMenuGroupAdapter.class.st
@@ -5,7 +5,7 @@ There is not Morphic represenation of a MenuGroup, that is why I do not have a c
 Class {
 	#name : #MorphicMenuGroupAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #private }

--- a/src/Spec-MorphicAdapters/MorphicMenuItemAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicMenuItemAdapter.class.st
@@ -4,7 +4,7 @@ I am the bridge between a MenuItemPresenter and a ToggleMenuItemMorph
 Class {
 	#name : #MorphicMenuItemAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #'widget API' }

--- a/src/Spec-MorphicAdapters/MorphicMultiColumnListAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicMultiColumnListAdapter.class.st
@@ -4,7 +4,7 @@ I am the adapter used to bridge a MultiColumnListPresenter and a PluggableMultiC
 Class {
 	#name : #MorphicMultiColumnListAdapter,
 	#superclass : #MorphicListAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #factory }

--- a/src/Spec-MorphicAdapters/MorphicRadioButtonAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicRadioButtonAdapter.class.st
@@ -4,7 +4,7 @@ I am the adapter used to link a RadioButtonPresenter with a CheckboxMorph (which
 Class {
 	#name : #MorphicRadioButtonAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #factory }

--- a/src/Spec-MorphicAdapters/MorphicSliderAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicSliderAdapter.class.st
@@ -4,7 +4,7 @@ I am the adapter used to bridget a SliderPresenter and a PluggableSliderMorph
 Class {
 	#name : #MorphicSliderAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #'widget API' }

--- a/src/Spec-MorphicAdapters/MorphicTabAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTabAdapter.class.st
@@ -4,7 +4,7 @@ I am the adapter used to bridge a TabPresenter and a Tab
 Class {
 	#name : #MorphicTabAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #initialization }

--- a/src/Spec-MorphicAdapters/MorphicTabManagerAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTabManagerAdapter.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'isClosedHolder'
 	],
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #'spec protocol' }

--- a/src/Spec-MorphicAdapters/MorphicTableContainerAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTableContainerAdapter.class.st
@@ -5,7 +5,7 @@ I am the adapter providing container with table layout
 Class {
 	#name : #MorphicTableContainerAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #factory }

--- a/src/Spec-MorphicAdapters/MorphicTextAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTextAdapter.class.st
@@ -6,7 +6,7 @@ Class {
 	#superclass : #AbstractMorphicAdapter,
 	#traits : 'TViewModel',
 	#classTraits : 'TViewModel classTrait',
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #'spec protocol' }

--- a/src/Spec-MorphicAdapters/MorphicTextInputFieldAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTextInputFieldAdapter.class.st
@@ -4,7 +4,7 @@ I am the adapter used to bridge a TextInputFieldPresenter and a PluggableTextFie
 Class {
 	#name : #MorphicTextInputFieldAdapter,
 	#superclass : #MorphicTextAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #'widget API' }

--- a/src/Spec-MorphicAdapters/MorphicTickingWindowAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTickingWindowAdapter.class.st
@@ -4,7 +4,7 @@ I am the adapter used to bridge a TickingWindowPresenter and a TickingSpecWindow
 Class {
 	#name : #MorphicTickingWindowAdapter,
 	#superclass : #MorphicWindowAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #factory }

--- a/src/Spec-MorphicAdapters/MorphicTransferAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTransferAdapter.class.st
@@ -4,7 +4,7 @@ I am a morphic specific adapter used to build a transfer object during a drang a
 Class {
 	#name : #MorphicTransferAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #factory }

--- a/src/Spec-MorphicAdapters/MorphicTreeAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTreeAdapter.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'treeModel'
 	],
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #'drag and drop - private' }

--- a/src/Spec-MorphicAdapters/MorphicTreeColumnAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTreeColumnAdapter.class.st
@@ -6,7 +6,7 @@ Ialso add support for on the fly refresh
 Class {
 	#name : #MorphicTreeColumnAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #'widget API' }

--- a/src/Spec-MorphicAdapters/MorphicTreeNodeAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTreeNodeAdapter.class.st
@@ -4,7 +4,7 @@ I am the bridget between a TreeNodePresenter and a SpecTreeNodeModel
 Class {
 	#name : #MorphicTreeNodeAdapter,
 	#superclass : #AbstractMorphicAdapter,
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #factory }

--- a/src/Spec-MorphicAdapters/MorphicWindowAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicWindowAdapter.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'isClosedHolder'
 	],
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #'widget API' }

--- a/src/Spec-MorphicAdapters/WorldPresenter.class.st
+++ b/src/Spec-MorphicAdapters/WorldPresenter.class.st
@@ -9,7 +9,7 @@ Class {
 	#instVars : [
 		'widget'
 	],
-	#category : #'Spec-MorphicAdapters'
+	#category : #'Spec-MorphicAdapters-Base'
 }
 
 { #category : #specs }

--- a/src/Spec-Tests/ManifestSpecTests.class.st
+++ b/src/Spec-Tests/ManifestSpecTests.class.st
@@ -1,5 +1,8 @@
+"
+Package for SUnit tests related to Spec UI framework
+"
 Class {
 	#name : #ManifestSpecTests,
 	#superclass : #PackageManifest,
-	#category : #'Spec-Tests'
+	#category : #'Spec-Tests-Manifest'
 }

--- a/src/Spec-Tests/MorphicLabelAdapterTest.class.st
+++ b/src/Spec-Tests/MorphicLabelAdapterTest.class.st
@@ -1,10 +1,13 @@
+"
+SUnit tests for MorphicLabelAdapter
+"
 Class {
 	#name : #MorphicLabelAdapterTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'label'
 	],
-	#category : #'Spec-Tests'
+	#category : #'Spec-Tests-Base'
 }
 
 { #category : #accessing }

--- a/src/Spec-Tests/MorphicTreeAdapterTest.class.st
+++ b/src/Spec-Tests/MorphicTreeAdapterTest.class.st
@@ -1,10 +1,13 @@
+"
+SUnit tests for MorphicTreeAdapter
+"
 Class {
 	#name : #MorphicTreeAdapterTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'treeWithItems'
 	],
-	#category : #'Spec-Tests'
+	#category : #'Spec-Tests-Base'
 }
 
 { #category : #accessing }

--- a/src/Spec-Tests/SpecFocusOrderTest.class.st
+++ b/src/Spec-Tests/SpecFocusOrderTest.class.st
@@ -1,3 +1,6 @@
+"
+SUnit tests for SpecFocusOrder
+"
 Class {
 	#name : #SpecFocusOrderTest,
 	#superclass : #TestCase,

--- a/src/Spec-Tests/SpecInterpreterTest.class.st
+++ b/src/Spec-Tests/SpecInterpreterTest.class.st
@@ -8,7 +8,7 @@ Class {
 		'specInterpreter',
 		'specInterpreterClass'
 	],
-	#category : #'Spec-Tests'
+	#category : #'Spec-Tests-Utilities'
 }
 
 { #category : #running }

--- a/src/Spec-Tests/SpecWindowTest.class.st
+++ b/src/Spec-Tests/SpecWindowTest.class.st
@@ -1,7 +1,10 @@
+"
+SUnit tests for SpecWindow
+"
 Class {
 	#name : #SpecWindowTest,
 	#superclass : #TestCase,
-	#category : #'Spec-Tests'
+	#category : #'Spec-Tests-Core-Support'
 }
 
 { #category : #tests }

--- a/src/Spec-Tools/ManifestSpecTools.class.st
+++ b/src/Spec-Tools/ManifestSpecTools.class.st
@@ -1,5 +1,8 @@
+"
+System Tools based on Spec UI framework
+"
 Class {
 	#name : #ManifestSpecTools,
 	#superclass : #PackageManifest,
-	#category : #'Spec-Tools'
+	#category : #'Spec-Tools-Manifest'
 }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/22442/Tag-and-comment-Manifests-in-all-Spec-related-packages

ManifestSpecCore
ManifestSpecInspector
ManifestSpecMorphicAdapters
ManifestSpecTools
ManifestSpecTests
ManifestSpecHelp

tag manifests and classes to structure related packages

ONLY TAGGING OF CLASSES AND COMMENTS, NO CHANGE IN BEHAVIOR
SHOULD BE SAFE TO INTEGRATE