### PR TITLE
22451 Unselecting example from SpecDemo's left list raises an exception

### DIFF
--- a/src/Spec-Examples/SpecDemo.class.st
+++ b/src/Spec-Examples/SpecDemo.class.st
@@ -97,15 +97,19 @@ SpecDemo >> initializePresenter [
 
 	list setSelectedItem: self selectedPage.
 	
-	list whenSelectedItemChanged: [ :newPageClass | 
-		newPageClass = self selectedPage
-			ifFalse: [
-				self selectedPage: newPageClass. 
-				page := self instantiate: newPageClass.
+	list whenSelectedItemChanged: [ :newPageClass |
+		newPageClass
+			ifNotNil: [
+			newPageClass = self selectedPage
+				ifFalse: [
+					self selectedPage: newPageClass. 
+					page := self instantiate: newPageClass.
 				
-				self needRebuild: false.
-				self buildWithSpec.
-				list setSelectedItem: self selectedPage ]].
+					self needRebuild: false.
+					self buildWithSpec.
+					list setSelectedItem: self selectedPage ] ]
+			ifNil: [ "Avoid the user to have no page selected at all."
+				list setSelectedItem: self selectedPage ] ].
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Fixed the behaviour handling page selection in the list in order to handle when nil is passed as argument.