### PR TITLE
22290 MimeConverter mimeEncode: aCollectionOrStream should return Stream and not String

### DIFF
--- a/src/Network-MIME/MimeConverter.class.st
+++ b/src/Network-MIME/MimeConverter.class.st
@@ -40,8 +40,8 @@ MimeConverter class >> mimeDecode: aStringOrStream to: outStream [
 
 { #category : #convenience }
 MimeConverter class >> mimeEncode: aCollectionOrStream [
-	^ String streamContents: [:out |
-		self mimeEncode: aCollectionOrStream to: out]
+	^ (String streamContents: [:out |
+		self mimeEncode: aCollectionOrStream to: out]) readStream
 ]
 
 { #category : #convenience }

--- a/src/Network-Tests/MailMessageTest.class.st
+++ b/src/Network-Tests/MailMessageTest.class.st
@@ -28,13 +28,13 @@ Mike
 
 	message := MailMessage fromRfc822: text.
 
-	self assert: message text = text.
-	self assert: message subject = 'RE: Windows 2000 on your laptop'.
-	self assert: message from = 'mdr@scn.rg (Me Ru)'.
-	self assert: message date = '2/20/01'.
-	self assert: message time = 667133573.
-	self assert: message to = '"Greg Y" <to1@mail.com>, to2@no.scn.org, to2also@op.org'.
-	self assert: message cc = 'cc1@scn.org, cc1also@test.org, cc2@scn.org'.
+	self assert: message text equals: text.
+	self assert: message subject equals: 'RE: Windows 2000 on your laptop'.
+	self assert: message from equals: 'mdr@scn.rg (Me Ru)'.
+	self assert: message date equals: '2/20/01'.
+	self assert: message time equals: 667133573.
+	self assert: message to equals: '"Greg Y" <to1@mail.com>, to2@no.scn.org, to2also@op.org'.
+	self assert: message cc equals: 'cc1@scn.org, cc1also@test.org, cc2@scn.org'.
 ]
 
 { #category : #tests }
@@ -48,18 +48,49 @@ MailMessageTest >> testMultiPartAlternative [
 	m addAlternativePart: txt contentType: 'text/plain'. 
 	m addAlternativePart: html contentType: 'text/html'.
 
-	self assert: (((m fields at: 'content-type') at: 1) mainValue asLowercase = 'multipart/alternative'). 
-	self assert: (m parts size = 2).
+	self assert: ((m fields at: 'content-type') at: 1) mainValue asLowercase equals: 'multipart/alternative'. 
+	self assert: m parts size equals: 2.
 
 	part1 := m parts at: 1.
 	part2 := m parts at: 2.
 
-	self assert: (((part1 fields at: 'content-type') at: 1) mainValue asLowercase = 'text/plain').
-	self assert: ((part1 body content) = txt).
+	self assert: ((part1 fields at: 'content-type') at: 1) mainValue asLowercase equals: 'text/plain'.
+	self assert: part1 body content equals: txt.
 	
-	self assert: (((part2 fields at: 'content-type') at: 1) mainValue asLowercase = 'text/html').
-	self assert: ((part2 body content) = html).
+	self assert: ((part2 fields at: 'content-type') at: 1) mainValue asLowercase equals: 'text/html'.
+	self assert: part2 body content equals: html.
 
+]
+
+{ #category : #tests }
+MailMessageTest >> testMultiPartComplex [
+
+	 | message newPartText newPartHtml part1 part2 |
+    message := MailMessage empty.
+    message setField: 'subject' toString: ('test').
+    newPartText := MailMessage empty.
+    newPartText setField: 'content-type' toString: MIMEDocument contentTypePlainText.
+    newPartText body: (MIMEDocument contentType: MIMEDocument contentTypePlainText content: 'a simple text').
+    message addAlternativePart: newPartText.
+    newPartHtml := MailMessage empty.
+    newPartHtml setField: 'content-type' toString: 'text/html; charset="utf-8"'.
+    newPartHtml setField: 'content-transfer-encoding' toString: 'quoted-printable'.
+    newPartHtml body: (MIMEDocument contentType: 'text/html; charset="utf-8"' content: ('<div><i>this is html and german Umlaute ÄÜÖ </i></div>' convertToEncoding: 'utf8')).
+    message addAlternativePart: newPartHtml.
+	
+    self assert: message text notNil.
+	part1 := message parts at: 1. 
+	
+	self assert: part1 text equals: 'Content-type: text/plain
+
+a simple text'.
+
+	part2 := message parts at: 2.
+	
+	self assert: part2 text equals: 'Content-transfer-encoding: quoted-printable
+Content-type: text/html;charset="utf-8"
+
+<div><i>this is html and german Umlaute =C3=84=C3=9C=C3=96 </i></div>'
 ]
 
 { #category : #tests }
@@ -73,17 +104,17 @@ MailMessageTest >> testMultiPartMixed [
 	m addMixedPart: txt contentType: 'text/plain'. 
 	m addMixedPart: html contentType: 'text/html'.
 
-	self assert: (((m fields at: 'content-type') at: 1) mainValue asLowercase = 'multipart/mixed'). 
-	self assert: (m parts size = 2).
+	self assert: ((m fields at: 'content-type') at: 1) mainValue asLowercase equals: 'multipart/mixed'. 
+	self assert: m parts size equals: 2.
 
 	part1 := m parts at: 1.
 	part2 := m parts at: 2.
 
-	self assert: (((part1 fields at: 'content-type') at: 1) mainValue asLowercase = 'text/plain').
-	self assert: ((part1 body content) = txt).
+	self assert: ((part1 fields at: 'content-type') at: 1) mainValue asLowercase equals: 'text/plain'.
+	self assert: part1 body content equals: txt.
 	
-	self assert: (((part2 fields at: 'content-type') at: 1) mainValue asLowercase = 'text/html').
-	self assert: ((part2 body content) = html).
+	self assert: ((part2 fields at: 'content-type') at: 1) mainValue asLowercase equals: 'text/html'.
+	self assert: part2 body content equals: html.
 
 ]
 
@@ -93,9 +124,9 @@ MailMessageTest >> testRecipientList [
 	| message |
 	message := MailMessage fromRfc822: 'To: pharo-project@lists.gforge.inria.fr, pharo-users@lists.gforge.inria.fr'.
 	
-	self assert: (message recipientList size = 2).
-	self assert: (message recipientList first = 'pharo-project@lists.gforge.inria.fr').	
-	self assert: (message recipientList second = 'pharo-users@lists.gforge.inria.fr').
+	self assert: message recipientList size equals: 2.
+	self assert: message recipientList first equals: 'pharo-project@lists.gforge.inria.fr'.	
+	self assert: message recipientList second equals: 'pharo-users@lists.gforge.inria.fr'.
 ]
 
 { #category : #tests }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/22290/MimeConverter-mimeEncode-aCollectionOrStream-should-return-Stream-and-not-String

- return a (read) stream now
- add a test
- cleanup assert:equals: in tests