### PR TITLE
Bug fix for bindings to inherited pool dictionaries (issue 22470)

### DIFF
--- a/src/Kernel-Tests/SharedPoolTest.class.st
+++ b/src/Kernel-Tests/SharedPoolTest.class.st
@@ -8,6 +8,13 @@ Class {
 }
 
 { #category : #tests }
+SharedPoolTest >> testIncludesKey [
+
+	self assert: (ChronologyConstants includesKey: #DayNames).
+	self deny: (ChronologyConstants includesKey: #DependentsFields)
+]
+
+{ #category : #tests }
 SharedPoolTest >> testPoolUsers [
 	| result |
 	result := ChronologyConstants poolUsers.

--- a/src/Kernel/SharedPool.class.st
+++ b/src/Kernel/SharedPool.class.st
@@ -22,9 +22,9 @@ SharedPool class >> bindingOf: varName [
 		binding := pool bindingOf: aSymbol.
 		binding ifNotNil:[^binding].
 	].
+ 
+	^self superclass bindingOf: varName.
 
-	"subclassing and environment are not preserved"
-	^nil
 ]
 
 { #category : #'name lookup' }

--- a/src/Kernel/SharedPool.class.st
+++ b/src/Kernel/SharedPool.class.st
@@ -10,20 +10,10 @@ Class {
 { #category : #'name lookup' }
 SharedPool class >> bindingOf: varName [
 	"Answer the binding of some variable resolved in the scope of the receiver"
-	| aSymbol binding |
-	aSymbol := varName asSymbol.
 
-	"First look in classVar dictionary."
-	binding := self classPool bindingOf: aSymbol.
-	binding ifNotNil:[^binding].
-
-	"Next look in shared pools."
-	self sharedPools do:[:pool | 
-		binding := pool bindingOf: aSymbol.
-		binding ifNotNil:[^binding].
-	].
+	^ (self localBindingOf: varName) ifNil: [ self superclass bindingOf: varName ]
  
-	^self superclass bindingOf: varName.
+	
 
 ]
 
@@ -50,15 +40,35 @@ SharedPool class >> hasBindingThatBeginsWith: aString [
 	^false
 ]
 
-{ #category : #'name lookup' }
+{ #category : #testing }
 SharedPool class >> includesKey: aName [
 	"does this pool include aName"
-	^(self bindingOf: aName) notNil
+	^(self localBindingOf: aName) notNil
 ]
 
 { #category : #testing }
 SharedPool class >> isUsed [
 	^super isUsed or: [self poolUsers isNotEmpty]
+]
+
+{ #category : #'name lookup' }
+SharedPool class >> localBindingOf: varName [
+	"Answer the binding of some variable resolved in the scope of the receiver without accessing the superclass"
+	| aSymbol binding |
+	aSymbol := varName asSymbol.
+
+	"First look in classVar dictionary."
+	binding := self classPool bindingOf: aSymbol.
+	binding ifNotNil:[^binding].
+
+	"Next look in shared pools."
+	self sharedPools do:[:pool | 
+		binding := pool bindingOf: aSymbol.
+		binding ifNotNil:[^binding].
+	].
+
+	"subclassing and environment are not preserved"
+	^nil
 ]
 
 { #category : #pools }

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -304,7 +304,7 @@ SystemNavigation >> allReferencesToPool: aPool [
 			cls
 				selectorsAndMethodsDo: [ :sel :meth | 
 					meth literals
-						detect: [ :lit | (lit isVariableBinding and: [ lit key notNil ]) and: [ (aPool bindingOf: lit key) notNil ] ]
+						detect: [ :lit | (lit isVariableBinding and: [ lit key notNil ]) and: [ aPool includesKey: lit key ] ]
 						ifFound: [ list add: (self createMethodNamed: sel realParent: cls) ] ] ].
 	^ list
 ]


### PR DESCRIPTION
Fix to issue 22470
Bug fix for bindings to inherited pool dictionaries
https://pharo.fogbugz.com/f/cases/22470/Bug-in-the-opal-compiler-Shared-Pools-inheritance-is-ignored