### PR TITLE
22481-NetNameResolver-classlocalHostAddress---error-check-with-default

### DIFF
--- a/src/Network-Kernel/NetNameResolver.class.st
+++ b/src/Network-Kernel/NetNameResolver.class.st
@@ -160,7 +160,7 @@ NetNameResolver class >> localHostAddress [
 	| primAddress |
 
 	self initializeNetwork.
-	primAddress := self primLocalAddress.
+	[ primAddress := self primLocalAddress ] on: Error do: [ :err | primAddress := #[0 0 0 0] ].
 	^ (primAddress = #[0 0 0 0] ifTrue: [ #[127 0 0 1] ] ifFalse: [ primAddress ]) asSocketAddress
 ]
 

--- a/src/Network-Kernel/NetNameResolver.class.st
+++ b/src/Network-Kernel/NetNameResolver.class.st
@@ -160,7 +160,7 @@ NetNameResolver class >> localHostAddress [
 	| primAddress |
 
 	self initializeNetwork.
-	[ primAddress := self primLocalAddress ] on: Error do: [ :err | primAddress := #[0 0 0 0] ].
+	[ primAddress := self primLocalAddress ] on: PrimitiveFailed do: [ :err | primAddress := #[0 0 0 0] ].
 	^ (primAddress = #[0 0 0 0] ifTrue: [ #[127 0 0 1] ] ifFalse: [ primAddress ]) asSocketAddress
 ]
 


### PR DESCRIPTION
additional error check in localHostAddresshttps://pharo.manuscript.com/f/cases/22481/NetNameResolver-class-localHostAddress-error-check-with-default