### PR TITLE
22483-CollectiongroupedBy---preserve-key-order-in-final-grouped-dictionary

### DIFF
--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -736,7 +736,7 @@ Collection >> groupedBy: aBlock [
 	"Answer a dictionary whose keys are the result of evaluating aBlock for all my elements, and the value for each key is the selection of my elements that evaluated to that key. Uses species."
 	
 	| groups |
-	groups := PluggableDictionary integerDictionary.
+	groups := OrderedDictionary new.
 	self do: [ :each |
 		(groups at: (aBlock value: each) ifAbsentPut: [ OrderedCollection new ]) add: each ].
 	self species ~~ OrderedCollection ifTrue: [

--- a/src/Collections-Tests/CollectionTest.class.st
+++ b/src/Collections-Tests/CollectionTest.class.st
@@ -1,0 +1,69 @@
+"
+Basic Collection tests
+"
+Class {
+	#name : #CollectionTest,
+	#superclass : #TestCase,
+	#category : #'Collections-Tests-Support'
+}
+
+{ #category : #tests }
+CollectionTest >> testGroupedByGroupsOrderSimple [
+	| dataCollection grouped keys |
+	"test of preserving groups order according to source collection order"
+	dataCollection := OrderedCollection new
+		add: #('ZZZ' '1');
+		add: #('ZZZ' '2');
+		add: #('ZZZ' '3');
+		add: #('SSS' '4');
+		add: #('SSS' '5');
+		add: #('SSS' '6');
+		add: #('BFLM' 'X');
+		add: #('AAA' '1');
+		add: #('AAA' '2');
+		yourself.
+	
+	grouped := dataCollection groupedBy: [ :arrItem | arrItem at: 1 ].
+	keys := grouped keys.
+	self assert: (keys at: 1) equals: 'ZZZ'.
+	self assert: (keys at: 2) equals: 'SSS'.
+	self assert: (keys at: 3) equals: 'BFLM'.
+	self assert: (keys at: 4) equals: 'AAA'.
+	
+	"---"
+	
+	dataCollection := OrderedCollection new
+		add: #('k' 1);
+		add: #('f' 2);
+		add: #('k' 3);
+		add: #('k' 4);
+		add: #('k' 5);
+		add: #('f' 6);
+		add: #('f' 7);
+		add: #('k' 8);
+		yourself.
+	grouped := dataCollection groupedBy: [ :arrItem | arrItem at: 1 ].
+	keys := grouped keys.
+	self assert: (keys at: 1) equals: 'k'.
+	self assert: (keys at: 2) equals: 'f'.
+	self assert: (grouped at: 'k') asArray equals: #(#('k' 1) #('k' 3) #('k' 4) #('k' 5) #('k' 8)).
+	self assert: (grouped at: 'f') asArray equals: #(#('f' 2) #('f' 6) #('f' 7)).
+]
+
+{ #category : #tests }
+CollectionTest >> testGroupedByGroupsOrderWithSortedCollectionOfDates [
+	| dataCollection grouped keys |
+	"data collection full of Date instances is sorted ascending"
+	dataCollection := OrderedCollection new.
+	0 to: 10 do: [ :i | 0 to: 5 do: [ :j | dataCollection add: (Date year: 2000 month: 1 day: 1) + i years + j weeks ] ].
+	
+	"group dates collection by year"
+	grouped := dataCollection groupedBy: [ :dateItem | dateItem year ].
+
+	"test if groups (Years) order is preserved after groupedBy"	
+	keys := grouped keys.
+	1 to: grouped size do: [ :i |
+		self assert: (keys at: i) equals: 2000 + i - 1.
+		].
+
+]


### PR DESCRIPTION
groupedBy: fixed + testshttps://pharo.manuscript.com/f/cases/22483/Collection-groupedBy-preserve-key-order-in-final-grouped-dictionary