### PR TITLE
22490-It-seems-that-openFileStreamwritable-is-dead-code

### DIFF
--- a/src/FileSystem-Core/FileSystem.class.st
+++ b/src/FileSystem-Core/FileSystem.class.st
@@ -506,13 +506,6 @@ FileSystem >> open: aResolvable writable: aBoolean [
 		
 ]
 
-{ #category : #delegated }
-FileSystem >> openFileStream: aResolvable writable: aBoolean [
-	^ store 
-		openFileStream: (self resolve: aResolvable) 
-		writable: aBoolean
-]
-
 { #category : #private }
 FileSystem >> openStreamDescription: aResolvable writable: aBoolean [
 	"I am  a helper method to delegate basicOpen:writable: to the store.

--- a/src/FileSystem-Core/FileSystemStore.class.st
+++ b/src/FileSystem-Core/FileSystemStore.class.st
@@ -319,11 +319,6 @@ FileSystemStore >> open [
 	"Some kinds of filesystems need to open connections to external resources"
 ]
 
-{ #category : #public }
-FileSystemStore >> openFileStream: path writable: writable [
-	self subclassResponsibility
-]
-
 { #category : #converting }
 FileSystemStore >> pathFromString: aString [
 	"Use the unix convention by default, since many filesystems are based on it."

--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -363,16 +363,6 @@ DiskStore >> nodeAt: aPath ifPresent: presentBlock ifAbsent: absentBlock [
 ]
 
 { #category : #public }
-DiskStore >> openFileStream: path writable: writable [
-	| fullPath |
-	fullPath := self stringFromPath: path.
-	"redirect over the default implementation"
-	^ writable 
-		ifFalse: [ FileStream readOnlyFileNamed: fullPath ]
-		ifTrue: [ FileStream fileNamed: fullPath ]
-]
-
-{ #category : #public }
 DiskStore >> rename: sourcePath to: destinationPath [
 
 	| sourcePathString encodedSourcePathString targetPathString encodedTargetPathString |

--- a/src/FileSystem-Memory/MemoryStore.class.st
+++ b/src/FileSystem-Memory/MemoryStore.class.st
@@ -224,15 +224,6 @@ MemoryStore >> nodeAt: aPath ifPresent: presentBlock ifAbsent: absentBlock [
 ]
 
 { #category : #public }
-MemoryStore >> openFileStream: path writable: isWriteStream [
-	| entry |
-	entry := self basicOpen: path writable: isWriteStream.
-	^ isWriteStream 
-		ifTrue: [ entry writeStream ]
-		ifFalse: [ entry readStream ]
-]
-
-{ #category : #public }
 MemoryStore >> rename: sourcePath to: destinationPath [
 	| sourceEntry destinationParentEntry newName |
 	


### PR DESCRIPTION
Looking at how DiskStore>>#openFileStream:writable: is still using the deprecated FileStream class, I conclude that #openFileStream:writable: seems dead code and could be removed (4 implementers).

https://pharo.manuscript.com/f/cases/22490/It-seems-that-openFileStream-writable-is-dead-code