### PR TITLE
22492-Self-Hosted Gitlab support

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -565,7 +565,8 @@ spec group: 'Metacello-Tests-Group' with: #(
 	'Metacello-TestsMC'	
 	'Metacello-TestsMCCore'	
 	'Metacello-TestsPlatform'	
-	'Metacello-TestsReference'	
+	'Metacello-TestsReference'
+	'Metacello-Gitlab-Tests'
 ).
 
 spec group: 'Refactoring-Rules-Group' with: #(

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -195,6 +195,7 @@ BaselineOfIDE >> baseline: spec [
 		spec package: 'Metacello-TestsMCCore'.	"standalone"
 		spec package: 'Metacello-TestsPlatform'.	"standalone"
 		spec package: 'Metacello-TestsReference'.	"standalone"
+		spec package: 'Metacello-Gitlab-Tests'.
 
 		spec package: 'RPackage-Tests'.
 		spec package: 'Monticello-Tests'.

--- a/src/Metacello-Bitbucket/MCBitbucketRepository.class.st
+++ b/src/Metacello-Bitbucket/MCBitbucketRepository.class.st
@@ -33,11 +33,6 @@ MCBitbucketRepository class >> isEnabled [
 ]
 
 { #category : #private }
-MCBitbucketRepository class >> projectTagsUrlFor: projectPath [
-  ^ 'https://bitbucket.org/api/1.0/repositories/' , projectPath , '/tags'
-]
-
-{ #category : #private }
 MCBitbucketRepository class >> projectZipUrlFor: projectPath versionString: versionString [
   ^ 'https://bitbucket.org/' , projectPath , '/get/' , versionString , '.zip'
 ]
@@ -65,4 +60,9 @@ MCBitbucketRepository >> normalizeTagsData: jsonObject [
       sha := tagObject at: 'node'.
       tagDict at: tag put: sha ].
   ^ tagDict
+]
+
+{ #category : #private }
+MCBitbucketRepository >> projectTagsUrlFor: projectPath [
+  ^ 'https://bitbucket.org/api/1.0/repositories/' , projectPath , '/tags'
 ]

--- a/src/Metacello-GitBasedRepository/MCGitBasedNetworkRepository.class.st
+++ b/src/Metacello-GitBasedRepository/MCGitBasedNetworkRepository.class.st
@@ -14,7 +14,7 @@ Class {
 		'siteUsername',
 		'sitePassword'
 	],
-	#category : 'Metacello-GitBasedRepository'
+	#category : #'Metacello-GitBasedRepository'
 }
 
 { #category : #accessing }
@@ -259,11 +259,6 @@ MCGitBasedNetworkRepository class >> projectDirectoryFrom: projectPath version: 
 				directoryFromPath: cachePath
 				relativeTo: theCacheDirectory ].
 	^ projectDirectory
-]
-
-{ #category : #private }
-MCGitBasedNetworkRepository class >> projectTagsUrlFor: aProjectPath [
-  self subclassResponsibility
 ]
 
 { #category : #'version patterns' }
@@ -522,7 +517,7 @@ MCGitBasedNetworkRepository >> projectPath: aProjectPath projectVersion: aProjec
 
 { #category : #private }
 MCGitBasedNetworkRepository >> projectTagsUrlFor: aProjectPath [
-  ^ self class projectTagsUrlFor: aProjectPath
+	self subclassResponsibility
 ]
 
 { #category : #accessing }

--- a/src/Metacello-GitHub/MCGitHubRepository.class.st
+++ b/src/Metacello-GitHub/MCGitHubRepository.class.st
@@ -88,11 +88,6 @@ MCGitHubRepository class >> isEnabled [
 ]
 
 { #category : #private }
-MCGitHubRepository class >> projectTagsUrlFor: projectPath [
-  ^ 'https://api.github.com/repos/' , projectPath , '/tags'
-]
-
-{ #category : #private }
 MCGitHubRepository class >> projectZipUrlFor: projectPath versionString: versionString [
   ^ 'https://github.com/' , projectPath , '/zipball/' , versionString
 ]
@@ -144,4 +139,9 @@ MCGitHubRepository >> normalizeTagsData: jsonObject [
       commit := tagObject at: 'commit'.
       tagDict at: tag put: (commit at: 'sha') ].
   ^ tagDict
+]
+
+{ #category : #private }
+MCGitHubRepository >> projectTagsUrlFor: projectPath [
+  ^ 'https://api.github.com/repos/' , projectPath , '/tags'
 ]

--- a/src/Metacello-Gitlab-Tests/MCGitlabRepositoryTest.class.st
+++ b/src/Metacello-Gitlab-Tests/MCGitlabRepositoryTest.class.st
@@ -1,0 +1,69 @@
+Class {
+	#name : #MCGitlabRepositoryTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'hostname'
+	],
+	#category : #'Metacello-Gitlab-Tests'
+}
+
+{ #category : #tests }
+MCGitlabRepositoryTest >> testLocation [
+	| repository |
+	repository := MCGitlabRepository location: 'gitlab://pharo-project/pharo:master/src'.
+	self
+		assert: repository hostname equals: 'gitlab.com';
+		assert: repository projectPath equals: 'pharo-project/pharo';
+		assert: repository projectVersion equals: 'master';
+		assert: repository repoPath equals: 'src'.
+
+	repository := MCGitlabRepository location: 'gitlab://pharo-project/pharo:master'.
+	self
+		assert: repository hostname equals: 'gitlab.com';
+		assert: repository projectPath equals: 'pharo-project/pharo';
+		assert: repository projectVersion equals: 'master';
+		assert: repository repoPath isEmpty.
+
+	repository := MCGitlabRepository location: 'gitlab://pharo-project/pharo'.
+	self
+		assert: repository hostname equals: 'gitlab.com';
+		assert: repository projectPath equals: 'pharo-project/pharo';
+		assert: repository projectVersion equals: 'master';
+		assert: repository repoPath isEmpty
+]
+
+{ #category : #tests }
+MCGitlabRepositoryTest >> testProjectTagsUrlFor [
+	| repository |
+	repository := MCGitlabRepository location: 'gitlab://pharo-project/pharo:master/src'.
+	self assert: (repository projectTagsUrlFor: 'pharo-project/pharo') equals: 'https://gitlab.com/api/v4/projects/pharo-project/pharo/repository/tags'.
+
+	"Self-hosted instance"
+	repository := MCGitlabRepository location: 'gitlab://git.pharo.org:pharo-project/pharo:master/src'.
+	self assert: (repository projectTagsUrlFor: 'pharo-project/pharo') equals: 'https://git.pharo.org/api/v4/projects/pharo-project/pharo/repository/tags'
+]
+
+{ #category : #tests }
+MCGitlabRepositoryTest >> testSelfHostedLocation [
+	| repository |
+	repository := MCGitlabRepository location: 'gitlab://git.pharo.org:pharo-project/pharo:master/src'.
+	self
+		assert: repository hostname equals: 'git.pharo.org';
+		assert: repository projectPath equals: 'pharo-project/pharo';
+		assert: repository projectVersion equals: 'master';
+		assert: repository repoPath equals: 'src'.
+
+	repository := MCGitlabRepository location: 'gitlab://git.pharo.org:pharo-project/pharo:master'.
+	self
+		assert: repository hostname equals: 'git.pharo.org';
+		assert: repository projectPath equals: 'pharo-project/pharo';
+		assert: repository projectVersion equals: 'master';
+		assert: repository repoPath isEmpty.
+
+	repository := MCGitlabRepository location: 'gitlab://git.pharo.org:pharo-project/pharo'.
+	self
+		assert: repository hostname equals: 'git.pharo.org';
+		assert: repository projectPath equals: 'pharo-project/pharo';
+		assert: repository projectVersion equals: 'master';
+		assert: repository repoPath isEmpty
+]

--- a/src/Metacello-Gitlab-Tests/package.st
+++ b/src/Metacello-Gitlab-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Metacello-Gitlab-Tests' }

--- a/src/Metacello-Gitlab/MCGitlabRepository.class.st
+++ b/src/Metacello-Gitlab/MCGitlabRepository.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #MCGitlabRepository,
 	#superclass : #MCGitBasedNetworkRepository,
+	#instVars : [
+		'hostname'
+	],
 	#category : #'Metacello-Gitlab'
 }
 
@@ -16,6 +19,11 @@ MCGitlabRepository class >> cacheDirectoryPath [
   ^ super cacheDirectoryPath
 ]
 
+{ #category : #private }
+MCGitlabRepository class >> defaultHostname [
+	^ 'gitlab.com'
+]
+
 { #category : #testing }
 MCGitlabRepository class >> isEnabled [
 
@@ -23,6 +31,44 @@ MCGitlabRepository class >> isEnabled [
 ]
 
 { #category : #private }
-MCGitlabRepository class >> projectTagsUrlFor: projectPath [
-  ^ 'https://gitlab.com/api/v4/projects/' , projectPath , '/repository/tags'
+MCGitlabRepository class >> parseLocation: locationUrl version: versionString [
+	"Gitlab can be self hosted, so we need some way to tell in the location the service url and not use gitlab.com in 
+	a hardcoded way.
+	This parsing extensions supports adding the hostname before the project owner name:
+	Eg. gitlab://selfhostedgitlab.com:owner/project
+	If no hostname is specified default to the old behavior (using gitlab.com)
+	"
+
+	| location hostnameAndOwner |
+	"Remove gitlab:// prefix"
+	location := locationUrl copyFrom: self description size + 1 to: locationUrl size.
+	"Take the next chunk up to the first / and split it to get the hostname and owner"
+	hostnameAndOwner := (location copyFrom: 1 to: (location indexOf: $/)) splitOn: $:.
+	^ hostnameAndOwner size = 1
+		ifTrue: [ "No hostname specified, so use the default one"
+			(super parseLocation: locationUrl version: versionString)
+				hostname: self defaultHostname;
+				yourself ]
+		ifFalse: [ | newLocationUrl hostname |
+			hostname := hostnameAndOwner first.
+			newLocationUrl := self description , (location copyFrom: hostname size + 2 to: location size).
+			"Reuse the parsing omitting the hostname"
+			(super parseLocation: newLocationUrl version: versionString)
+				hostname: hostname;
+				yourself ]
+]
+
+{ #category : #accessing }
+MCGitlabRepository >> hostname [
+	^ hostname
+]
+
+{ #category : #'initialize-release' }
+MCGitlabRepository >> hostname: aString [ 
+	hostname := aString
+]
+
+{ #category : #private }
+MCGitlabRepository >> projectTagsUrlFor: aProjectPath [
+	^ 'https://<1s>/api/v4/projects/<2s>/repository/tags' expandMacrosWith: self hostname with: aProjectPath
 ]


### PR DESCRIPTION
First step to support self-hosted Gitlab instances as dependencies in the baselines. 
This is really needed for some companies hosting it's own code.

Changelog:
- MCGitlabRepository now supports providing (optionally) the hostname info for the self-hosted Gitlab 
- Move projectTagsUrlFor: to the instance side because now the hostname is not hardcoded for Gitlab.
- Added some tests in the Metacello-Gitlab-Tests package b.

Next steps requires changes in Iceberg because some extensions have a hardcoded `gitlab.com` hostname, but first this changes must be present in Pharo.