### PR TITLE
22496-ButtonPresenter-should-be-initialized-with-default-theme-color

### DIFF
--- a/src/Spec-Core/ButtonPresenter.class.st
+++ b/src/Spec-Core/ButtonPresenter.class.st
@@ -191,6 +191,8 @@ ButtonPresenter >> initialize [
 		(aMenuModel isNil or: [ aMenuModel isBlock ]) ifFalse: [ aMenuModel applyTo: self ] ].
 		
 	self bindKeyCombination: Character space toAction: [ self action ].
+	
+	self color: nil.
 ]
 
 { #category : #morphic }

--- a/src/Spec-MorphicAdapters/MorphicButtonAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicButtonAdapter.class.st
@@ -39,7 +39,7 @@ MorphicButtonAdapter >> buildLabel: text withIcon: icon [
 { #category : #factory }
 MorphicButtonAdapter >> buildWidget [
 	
-	| button normalColorBlock clickedColorBlock | 
+	| button | 
 	button := PluggableButtonMorph
 				on: self 
 				getState: #state 
@@ -57,16 +57,7 @@ MorphicButtonAdapter >> buildWidget [
 		dropEnabled: self dropEnabled ;	
 		eventHandler: (MorphicEventHandler new on: #keyStroke send: #keyStroke:fromMorph: to: self).
 	
-	normalColorBlock := [ :aButton |
-							(aButton valueOfProperty: #noFill ifAbsent: [false]) 
-								ifTrue: [ SolidFillStyle color: Color transparent ]
-								ifFalse: [ SolidFillStyle color: self color ] ].
-	clickedColorBlock := [ :aButton | SolidFillStyle color: self color muchDarker ].
-	button theme: ((UIThemeDecorator theme: button theme)
-							property: #buttonNormalFillStyleFor: returnsValueOf: normalColorBlock;
-							property: #buttonMouseOverFillStyleFor: returnsValueOf: normalColorBlock;
-							property: #buttonPressedFillStyleFor: returnsValueOf: clickedColorBlock;
-							yourself).
+	self color ifNotNil: [ self setWidgetColor: button ].
 	^ button
 ]
 
@@ -92,6 +83,25 @@ MorphicButtonAdapter >> menu: aMenu [
 	menuModel := self model menu.
 	menuModel isBlock ifTrue: [ menuModel := menuModel value ].
 	^ menuModel buildWithSpec
+]
+
+{ #category : #factory }
+MorphicButtonAdapter >> setWidgetColor: button [
+
+		| normalColorBlock clickedColorBlock |
+
+		normalColorBlock := [ :aButton |
+							(aButton valueOfProperty: #noFill ifAbsent: [false]) 
+								ifTrue: [ SolidFillStyle color: Color transparent ]
+								ifFalse: [ SolidFillStyle color: self color ] ].
+	
+		clickedColorBlock := [ :aButton | SolidFillStyle color: self color muchDarker ].
+		button theme: ((UIThemeDecorator theme: button theme)
+							property: #buttonNormalFillStyleFor: returnsValueOf: normalColorBlock;
+							property: #buttonMouseOverFillStyleFor: returnsValueOf: normalColorBlock;
+							property: #buttonPressedFillStyleFor: returnsValueOf: clickedColorBlock;
+							yourself).
+
 ]
 
 { #category : #'widget API' }


### PR DESCRIPTION
The button presenter should not have a color initialized. If there is no color it should use the default by the theme.Issue https://pharo.manuscript.com/f/cases/22496/ButtonPresenter-should-be-initialized-with-default-theme-color