### PR TITLE
22497-MIMEDocumentsaveToFile-should-not-use-FileStream

### DIFF
--- a/src/Network-MIME/MIMEDocument.class.st
+++ b/src/Network-MIME/MIMEDocument.class.st
@@ -299,11 +299,10 @@ MIMEDocument >> privateContent: aString [
 ]
 
 { #category : #files }
-MIMEDocument >> saveToFile: anAbsolutePathString [
-
-	FileStream forceNewFileNamed: anAbsolutePathString do: [ :str |
-		str binary.
-		str nextPutAll: (self contents) ].
+MIMEDocument >> saveToFile: pathString [
+	pathString asFileReference 
+		binaryWriteStreamDo: [ :out | 
+			out nextPutAll: self contents ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
MIMEDocument>>#saveToFile: should not use FileStream

https://pharo.manuscript.com/f/cases/22497/MIMEDocument-saveToFile-should-not-use-FileStream