### PR TITLE
22224-ZipArchiveMember-still-uses-deprecated-RWBinaryOrTextStream-and-MultiByteBinaryOrTextStream

### DIFF
--- a/src/Compression-Tests/ZipArchiveTest.class.st
+++ b/src/Compression-Tests/ZipArchiveTest.class.st
@@ -48,6 +48,12 @@ ZipArchiveTest >> testAddNonExistentFile [
 ]
 
 { #category : #tests }
+ZipArchiveTest >> testContents [
+	zip addFile: fileToZip fullName as: fileToZip basename.
+	self assert: zip members first contents equals: 'file contents'
+]
+
+{ #category : #tests }
 ZipArchiveTest >> testCreateWithRelativeNames [
 	"Test creating a zip with a relative tree of files, so that the tree will
 	be created whereever the ."

--- a/src/Compression/ZipArchiveMember.class.st
+++ b/src/Compression/ZipArchiveMember.class.st
@@ -205,33 +205,30 @@ ZipArchiveMember >> contentStreamFromEncoding: encodingName [
 	"Answer my contents as a text stream.
 	Interpret the raw bytes with given encodingName"
 
-	| s |
-	s := MultiByteBinaryOrTextStream on: (String new: self uncompressedSize).
-	s converter:  (TextConverter newForEncoding: encodingName).
-	self extractTo: s.
-	s reset.
-	^ s
-
+	| file |
+	file := MemoryFileSystemFile named: 'tempExtractFile'.
+	file writeStreamDo: [ :s | self extractTo: s ].
+	^ (ZnCharacterEncoder newForEncoding: encodingName) decodeBytes: file binaryReadStream
 ]
 
 { #category : #reading }
 ZipArchiveMember >> contents [
 	"Answer my contents as a string."
-	| s |
-	s := RWBinaryOrTextStream on: (String new: self uncompressedSize).
-	self extractTo: s.
-	s text.
-	^s contents
+
+	| file |
+	file := MemoryFileSystemFile named: 'tempExtractFile'.
+	file writeStreamDo: [ :s | self extractTo: s ].
+	^ file readStream contents
 ]
 
 { #category : #reading }
 ZipArchiveMember >> contentsFrom: start to: finish [
 	"Answer my contents as a string."
-	| s |
-	s := RWBinaryOrTextStream on: (String new: finish - start + 1).
-	self extractTo: s from: start to: finish.
-	s text.
-	^s contents
+
+	| file |
+	file := MemoryFileSystemFile named: 'tempExtractFile'.
+	file writeStreamDo: [ :s | self extractTo: s from: start to: finish ].
+	^ file readStream contents
 ]
 
 { #category : #'private-writing' }

--- a/src/System-Installers/MczInstaller.class.st
+++ b/src/System-Installers/MczInstaller.class.st
@@ -129,15 +129,18 @@ MczInstaller >> contentStreamForMember: member [
 
 { #category : #parsing }
 MczInstaller >> contentsForMember: member [
-	^[(member contentStreamFromEncoding: 'utf8') text contents] on: ZnInvalidUTF8
-		do: [:exc | 
+	^ [ (member contentStreamFromEncoding: 'utf8') contents ]
+		on: ZnInvalidUTF8
+		do: [ :exc | 
 			"Case of legacy encoding, presumably it is latin-1.
 			But if contents starts with a null character, it might be a case of WideString encoded in UTF-32BE"
 			| str |
-			str := (member contentStreamFromEncoding: 'latin1') text.
-			exc return: ((str peek = Character null and: [ str size \\ 4 = 0 ])
-				ifTrue: [WideString fromByteArray: str contents asByteArray]
-				ifFalse: [str contents])]
+			str := member contentStreamFromEncoding: 'latin1'.
+			exc
+				return:
+					((str peek = Character null and: [ str size \\ 4 = 0 ])
+						ifTrue: [ WideString fromByteArray: str contents asByteArray ]
+						ifFalse: [ str contents ]) ]
 ]
 
 { #category : #utilities }


### PR DESCRIPTION
Add tests + convert the deprecated streams to MemoryFileSystemFilehttps://pharo.fogbugz.com/f/cases/22224/ZipArchiveMember-still-uses-deprecated-RWBinaryOrTextStream-and-MultiByteBinaryOrTextStream