### PR TITLE
16196-Move-Zinc-Examples-to-a-different-package

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -354,6 +354,7 @@ BaselineOfIDE >> baseline: spec [
 		spec package: 'Tools-Test'.	
 		spec package: 'Zinc-Character-Encoding-Tests'.
 		spec package: 'Zinc-Resource-Meta-FileSystem'.	
+		spec package: 'Zinc-HTTP-Examples'.			
 		spec package: 'Zinc-Tests'.
 		spec package: 'System-Identification-Tests'.
 

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -353,8 +353,8 @@ BaselineOfIDE >> baseline: spec [
 		spec package: 'Tool-FileList-Tests'.
 		spec package: 'Tools-Test'.	
 		spec package: 'Zinc-Character-Encoding-Tests'.
-		spec package: 'Zinc-Resource-Meta-FileSystem'.	
-		spec package: 'Zinc-HTTP-Examples'.			
+		spec package: 'Zinc-Resource-Meta-FileSystem'.			
+		spec package: 'Zinc-HTTP-Examples'.
 		spec package: 'Zinc-Tests'.
 		spec package: 'System-Identification-Tests'.
 
@@ -468,6 +468,7 @@ spec group: 'General-Tests-Group' with: #(
 	'Tools-Test'
 	'Zinc-Resource-Meta-FileSystem'	
 	'Zinc-Resource-Meta-Tests'
+	'Zinc-HTTP-Examples'
 	'Zinc-Tests'	"requires Zinc-Resource-Meta-Tests"
 	'System-Identification-Tests'		
 	'System-DependenciesTests'

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -123,7 +123,7 @@ SystemDependenciesTest >> knownMonticelloDependencies [
 
 	"ideally this list should be empty"	
 
-	^ #(#'Graphics-Files' #'Network-Mail' #'SUnit-Core' #'System-Localization' #'Transcript-Core')
+	^ #(#'Graphics-Files' #'Network-Mail' #'System-Localization' #'Transcript-Core')
 ]
 
 { #category : #'known dependencies' }

--- a/src/Zinc-HTTP-Examples/ZnImageExampleDelegate.class.st
+++ b/src/Zinc-HTTP-Examples/ZnImageExampleDelegate.class.st
@@ -22,7 +22,7 @@ Class {
 	#instVars : [
 		'image'
 	],
-	#category : #'Zinc-HTTP-Client-Server'
+	#category : #'Zinc-HTTP-Examples'
 }
 
 { #category : #public }

--- a/src/Zinc-HTTP-Examples/ZnReadEvalPrintDelegate.class.st
+++ b/src/Zinc-HTTP-Examples/ZnReadEvalPrintDelegate.class.st
@@ -60,7 +60,7 @@ Part of Zinc HTTP Components.
 Class {
 	#name : #ZnReadEvalPrintDelegate,
 	#superclass : #Object,
-	#category : #'Zinc-HTTP-Client-Server'
+	#category : #'Zinc-HTTP-Examples'
 }
 
 { #category : #public }

--- a/src/Zinc-HTTP-Examples/ZnTestRunnerDelegate.class.st
+++ b/src/Zinc-HTTP-Examples/ZnTestRunnerDelegate.class.st
@@ -16,7 +16,7 @@ Part of Zinc HTTP Components
 Class {
 	#name : #ZnTestRunnerDelegate,
 	#superclass : #Object,
-	#category : #'Zinc-HTTP-Client-Server'
+	#category : #'Zinc-HTTP-Examples'
 }
 
 { #category : #public }

--- a/src/Zinc-HTTP-Examples/package.st
+++ b/src/Zinc-HTTP-Examples/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Zinc-HTTP-Examples' }


### PR DESCRIPTION
Move ZnImageExampleDelegate ZnReadEvalPrintDelegate ZnTestRunnerDelegate to Zinc-HTTP-Examples