### PR TITLE
22504-OSPlatformcurrentWorkingDirectoryPathWithBuffer-fails

### DIFF
--- a/src/System-Platforms/OSPlatform.class.st
+++ b/src/System-Platforms/OSPlatform.class.st
@@ -91,17 +91,21 @@ OSPlatform >> current [
 
 { #category : #accessing }
 OSPlatform >> currentWorkingDirectoryPath [
-	"This method calls the method getPwdViaFFI with arugement of a buffer size. By default it uses the defaultMaximumPathLength of each subclass as the buffer size."
-	^ self currentWorkingDirectoryPathWithBufferSize: self defaultMaximumPathLength
+	"Answer the current working directory (string).
+	First attempt to retrieve it with the named primitve, if that fails, try FFI."
+
+	^[ self primCurrentWorkingDirectoryPath ]
+		on: PrimitiveFailed 
+		do: [ self currentWorkingDirectoryPathWithBufferSize: self defaultMaximumPathLength ]
 
 ]
 
 { #category : #accessing }
 OSPlatform >> currentWorkingDirectoryPathWithBuffer: aByteString [
-	<primitive: 'primitiveGetCurrentWorkingDirectory' module: '' error: ec>
-	
-	^ (self getPwdViaFFI: aByteString size: aByteString size) 
-		ifNil:[ self error:'Insufficient buffer size to read current working directory: ' , aByteString size asString]
+	"This method calls the method getPwdViaFFI with arugement of a buffer size."
+
+	^ (self getPwdViaFFI: aByteString size: aByteString size) ifNil:
+		[ self error: 'Unable to read current working directory with buffer size: ', aByteString size asString]
 ]
 
 { #category : #accessing }
@@ -204,6 +208,14 @@ OSPlatform >> platformFamily [
 { #category : #compatbility }
 OSPlatform >> platformName [
 	^ self name
+]
+
+{ #category : #accessing }
+OSPlatform >> primCurrentWorkingDirectoryPath [
+	"Answer the current working directory of the process"
+
+	<primitive: 'primitiveGetCurrentWorkingDirectory' module: 'UnixOSProcessPlugin' error: ec>	
+	^self primitiveFailed: ec printString
 ]
 
 { #category : #initialize }

--- a/src/Tests/OSPlatformTest.class.st
+++ b/src/Tests/OSPlatformTest.class.st
@@ -53,3 +53,13 @@ OSPlatformTest >> testStartUpList [
 	
 	self should: [ (startupList indexOf: #OSPlatform) < (startupList indexOf: #InputEventSensor) ]
 ]
+
+{ #category : #tests }
+OSPlatformTest >> testWorkingDirectory [
+	"There are currently two implementations to retrieve the working directory.
+	Check that they are the same."
+
+	self
+		assert: OSPlatform current primCurrentWorkingDirectoryPath
+		equals: (OSPlatform current currentWorkingDirectoryPathWithBufferSize: 4096)
+]


### PR DESCRIPTION
22504 OSPlatform>>currentWorkingDirectoryPathWithBuffer: fails

OSPlatform>>currentWorkingDirectoryPathWithBuffer: has a number of issues:

1. It doesn't find the primitive because the module isn't specified.
2. The primitive call fails because the primitive expects 0 arguments while the method passes one (which is unrelated to the primitive).

I'm not sure why the FFI fallback is required.  If the primitive is failing, it should be fixed (I don't see how the primitive can fail under normal circumstances, it is effectively just getcwd()).  Replacing the primitive with the FFI call is problematic at the moment as it fails sometimes, depending on which VM is used.

For now I'll just fix the code leaving the functionality as intended, and we can revisit it later if desired.