### PR TITLE
22163-Memory-Leak-GLMHintableActionButtonBrick

### DIFF
--- a/src/Glamour-Morphic-Brick/GLMActionButtonBrick.class.st
+++ b/src/Glamour-Morphic-Brick/GLMActionButtonBrick.class.st
@@ -96,6 +96,12 @@ GLMActionButtonBrick >> hShrinkWrap [
 							ifNotNil: [ self icon width max: self hoverIcon width ] ] ]) ]
 ]
 
+{ #category : #'brick-morph-mouse-events' }
+GLMActionButtonBrick >> handlesMouseDown: evt [
+
+	^ clickAction notNil
+]
+
 { #category : #'action-button-actions' }
 GLMActionButtonBrick >> hoverAction: anObject [
 

--- a/src/Glamour-Morphic-Brick/GLMHintableActionButtonBrick.class.st
+++ b/src/Glamour-Morphic-Brick/GLMHintableActionButtonBrick.class.st
@@ -5,65 +5,11 @@ Class {
 		'hintTitle',
 		'hintText',
 		'hintDelay',
-		'hintModifier'
-	],
-	#classInstVars : [
-		'asyncTask',
+		'hintModifier',
 		'hintBrick'
 	],
 	#category : #'Glamour-Morphic-Brick-Widgets-UI'
 }
-
-{ #category : #converting }
-GLMHintableActionButtonBrick class >> asyncTaskUniqueInstance [
-
-	^ asyncTask ifNil: [ asyncTask := GLMAsyncTask new ]
-]
-
-{ #category : #cleanup }
-GLMHintableActionButtonBrick class >> cleanUp [
-
-	self closeHint.
-	self reset.
-]
-
-{ #category : #actions }
-GLMHintableActionButtonBrick class >> closeHint [
-
-	self asyncTaskUniqueInstance ifNotNil: #terminate.
-	self hintBrickUniqueInstance ifNotNil: #close
-]
-
-{ #category : #accessing }
-GLMHintableActionButtonBrick class >> hintBrickUniqueInstance [
-
-	^ hintBrick
-]
-
-{ #category : #actions }
-GLMHintableActionButtonBrick class >> openHint: aHintString title: aTitleString type: aTypeSymbol for: aBrick [
-	|brick|
-	
-	self closeHint.
-	brick :=  GLMPopupBrick new
-		beUpward;
-		hintText: aHintString;
-		titleText: aTitleString;
-		perform: aTypeSymbol withEnoughArguments: {  };
-		openOn: aBrick.
-		
-	hintBrick := brick
-		
-	
-]
-
-{ #category : #actions }
-GLMHintableActionButtonBrick class >> reset [
-
-	self closeHint.
-	asyncTask := nil.
-	hintBrick := nil.
-]
 
 { #category : #initialization }
 GLMHintableActionButtonBrick >> beError [
@@ -80,10 +26,17 @@ GLMHintableActionButtonBrick >> beHelp [
 { #category : #initialization }
 GLMHintableActionButtonBrick >> beMode: aMode [
 
-	self hoverAction: [ :aBrick :evt |
-			self class asyncTaskUniqueInstance
-				perform: [ self isInWorld ifTrue: [ self class openHint: self hintText title: self hintTitle type: aMode for: self ] ]
-				delay: ((self isModifierPressed: evt) ifTrue: [ 0 ] ifFalse: [ self hintDelay ]) ]
+	self hoverAction: [ :aBrick :evt | | delay |
+		
+		delay := (self isModifierPressed: evt) 
+			ifTrue: [ 0 ]
+			ifFalse: [ self hintDelay ].
+		
+		self startStepping: #openHintPopup: 
+			at: Time millisecondClockValue + delay
+			arguments: {aMode}
+			stepTime: 3000 
+	]
 ]
 
 { #category : #initialization }
@@ -100,11 +53,24 @@ GLMHintableActionButtonBrick >> beSuccess [
 
 { #category : #'brick-interactable-actions' }
 GLMHintableActionButtonBrick >> click: evt [
+
 	|result|
+	
 	result := super click: evt.
-	self class asyncTaskUniqueInstance terminate.
-	self class reset.
+	result ifTrue: [ self closePopup ].
+	
 	^ result
+]
+
+{ #category : #'brick-interactable-actions' }
+GLMHintableActionButtonBrick >> closePopup [
+
+	self stopSteppingSelector: #openHintPopup:.
+
+	hintBrick ifNotNil: [ 	
+		hintBrick close.
+		hintBrick := nil.
+	]
 ]
 
 { #category : #accessing }
@@ -153,17 +119,16 @@ GLMHintableActionButtonBrick >> hintTitle: anObject [
 	hintTitle := anObject
 ]
 
-{ #category : #initialization }
+{ #category : #'brick-interactable-actions' }
 GLMHintableActionButtonBrick >> initialize [
 	super initialize.
 	
 	self beHelp.
 	self unhoverAction: [ :aBrick :anEvent |
-		self class asyncTaskUniqueInstance terminate.
-		(aBrick globalBounds containsPoint: anEvent position)
-			ifFalse: [ self class 
-				closeHint;
-				reset ] ]
+		(aBrick globalBounds containsPoint: anEvent position) ifFalse: [ 
+			self closePopup 
+		] 
+	]
 ]
 
 { #category : #testing }
@@ -179,9 +144,21 @@ GLMHintableActionButtonBrick >> isModifierPressed: anEvent [
 ]
 
 { #category : #'brick-interactable-actions' }
+GLMHintableActionButtonBrick >> openHintPopup: aMode [
+	
+	self closePopup.
+	
+	hintBrick := GLMPopupBrick new
+		beUpward;
+		hintText: self hintText;
+		titleText: self hintTitle;
+		perform: aMode withEnoughArguments: {  };
+		openOn: self.
+]
+
+{ #category : #'brick-interactable-actions' }
 GLMHintableActionButtonBrick >> press [
 	super press.
 	
-	self class asyncTaskUniqueInstance terminate.
-	self class reset.
+	self closePopup.
 ]

--- a/src/Glamour-Morphic-Brick/GLMPopupBrick.class.st
+++ b/src/Glamour-Morphic-Brick/GLMPopupBrick.class.st
@@ -73,6 +73,12 @@ GLMPopupBrick >> beSuccess [
 	self themer: self themer popupSuccessThemer themer
 ]
 
+{ #category : #'brick-morph-mouse-events' }
+GLMPopupBrick >> handlesMouseDown: evt [
+
+	^ true
+]
+
 { #category : #accessing }
 GLMPopupBrick >> hintBrick [
 	^ hintBrick
@@ -99,6 +105,15 @@ GLMPopupBrick >> hintText: aBrick [
 	hintText := aBrick.
 
 	self hintBrick ifNotNil: [ self hintBrick text: self hintText ]
+]
+
+{ #category : #'brick-morph-mouse-events' }
+GLMPopupBrick >> mouseDown: evt [
+	
+	(anchorBrick containsPoint: evt cursorPoint)
+		ifTrue: [ anchorBrick mouseDown: evt ]
+		ifFalse: [ super mouseDown: evt ]
+
 ]
 
 { #category : #'instance creation' }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/22163/Memory-Leak-GLMHintableActionButtonBrickConverted issue fix by Henrik:

===============

Name: Glamour-Morphic-Brick-HenrikNergaard.450
Author: HenrikNergaard
Time: 16 June 2018, 9:41:13.023184 am
UUID: d0529431-1f2b-0d00-ae6c-945d0cda09ca
Ancestors: Glamour-Morphic-Brick-MarcusDenker.449, Glamour-Morphic-Brick-AliakseiSyrel.448

Remove usage of asynctask, use stepping selector instead.

=================

Buttons need to be double clicked not sure if it is that way thay should behave, but the async stuff is gone.