### PR TITLE
Fix for  issue 22516

### DIFF
--- a/src/TraitsV2-Tests/T2AbstractTest.class.st
+++ b/src/TraitsV2-Tests/T2AbstractTest.class.st
@@ -11,6 +11,11 @@ Class {
 }
 
 { #category : #'instance creation' }
+T2AbstractTest >> newClass: aName [ 
+	^self newClass: aName with: #() uses: #()
+]
+
+{ #category : #'instance creation' }
 T2AbstractTest >> newClass: aName superclass: aSuperclass with: slots uses: aComposition [
 	
 	^ self newClass: aName superclass: aSuperclass with: slots uses: aComposition category: 'TraitsV2-Tests-TestClasses' 

--- a/src/TraitsV2-Tests/T2TraitTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitTest.class.st
@@ -156,6 +156,32 @@ T2TraitTest >> testMethodsAddedInMetaclassPresentInSubclassesAfterRemovingSuperc
 ]
 
 { #category : #tests }
+T2TraitTest >> testSelectorsWithExplicitOrigin [
+	"Obtain the subset of selectors that are defined either locally or inherited from traits. But, exclude selectors of methods from implicit traits such as TraitedClass"
+	| t1 c1 |
+	
+	t1 := self newTrait: #T1 with: #().	
+	t1 compile: 'instanceSideMethod'.
+	t1 class compile: 'classSideMethod'.
+	c1 := self newClass: #C1 with: #() uses: t1.
+	self assertCollection: c1 selectorsWithExplicitOrigin hasSameElements: #(instanceSideMethod).
+	self assertCollection: c1 class selectorsWithExplicitOrigin hasSameElements: #(classSideMethod).
+
+]
+
+{ #category : #tests }
+T2TraitTest >> testSelectorsWithExplicitOriginNoTrait [
+	"Obtain the subset of selectors that are defined either locally or inherited from traits. But, exclude selectors of methods from implicit traits such as TraitedClass"
+	| c1 |	
+	c1 := self newClass: #C1.
+	c1 compile: 'instanceSideMethod'.
+	c1 class compile: 'classSideMethod'.
+	self assertCollection: c1 selectorsWithExplicitOrigin hasSameElements: #(instanceSideMethod).
+	self assertCollection: c1 class selectorsWithExplicitOrigin hasSameElements: #(classSideMethod).
+
+]
+
+{ #category : #tests }
 T2TraitTest >> testSequence [
 	| t1 t2 c1 obj |
 	

--- a/src/TraitsV2/ClassDescription.extension.st
+++ b/src/TraitsV2/ClassDescription.extension.st
@@ -17,6 +17,11 @@ ClassDescription >> baseComposition [
 ]
 
 { #category : #'*TraitsV2' }
+ClassDescription >> selectorsWithExplicitOrigin [
+	^self traitComposition selectors , self localSelectors
+]
+
+{ #category : #'*TraitsV2' }
 ClassDescription >> traitComposition [
 	^ TaEmptyComposition new
 ]


### PR DESCRIPTION
Message "selectors" on a class gives all selectors including one from the implicit trait TraitedClass. We need a way to obtain the subset of selectors that are defined either locally or inherited from traits. But, exclude selectors of methods from implicit traits such as TraitedClass