### PR TITLE
22553-Instances-are-not-indexable-after-double-clicking-item-in-Collection-Inspector

### DIFF
--- a/src/GT-InspectorExtensions-Core/Collection.extension.st
+++ b/src/GT-InspectorExtensions-Core/Collection.extension.st
@@ -34,13 +34,5 @@ Collection >> gtInspectorItemsIn: composite [
 			implemented in the renderer."
 			self asOrderedCollection ];
 		beMultiple;	
-		format: [ :each | GTObjectPrinter asTruncatedTextFrom: each ];
-		send: [ :result | result isNil 
-			ifTrue:[nil]
-			ifFalse:[ (result size = 1) 
-				ifTrue: [result anyOne] 
-				ifFalse: [self species withAll: result]]]
-		"withSmalltalkSearch;	
-		showOnly: 50;
-		helpMessage: 'Quick selection field. Given your INPUT, it executes: self select: [:each | INPUT ]'."
+		format: [ :each | GTObjectPrinter asTruncatedTextFrom: each ]
 ]

--- a/src/GT-InspectorExtensions-Core/SequenceableCollection.extension.st
+++ b/src/GT-InspectorExtensions-Core/SequenceableCollection.extension.st
@@ -9,14 +9,5 @@ SequenceableCollection >> gtInspectorItemsIn: composite [
 		enableElementIndex;
 		wantsAutomaticRefresh: true;
 		column: 'Index' evaluated: [ :value :idex | idex asString ] width: 50;
-		column: 'Item' evaluated: [ :value | GTObjectPrinter asTruncatedTextFrom: value ];
-		send: [ :result | 
-			result isNil
-				ifTrue: [ nil ]
-				ifFalse: [ result size = 1 
-					ifTrue: [result anyOne ]  
-					ifFalse: [self species withAll: result]]]
-		"withSmalltalkSearch;
-		showOnly: 50;
-		helpMessage: 'Quick selection field. Given your INPUT, it executes: self select: [:each | INPUT ]'."
+		column: 'Item' evaluated: [ :value | GTObjectPrinter asTruncatedTextFrom: value ]
 ]


### PR DESCRIPTION
remove the broken actionhttps://pharo.fogbugz.com/f/cases/22553/Instances-are-not-indexable-after-double-clicking-item-in-Collection-Inspector