### PR TITLE
22556-Reverting-slots-to-return-the-set-of-installed-slots-in-the-class-

### DIFF
--- a/src/Shift-ClassInstaller/Class.extension.st
+++ b/src/Shift-ClassInstaller/Class.extension.st
@@ -22,7 +22,7 @@ Class >> addSlot: aSlot [
 	^self classInstaller update: self to: [ :builder |
 		builder
 			fillFor: self;
-			slots: (self slots copyWith: aSlot)].
+			slots: (self localSlots copyWith: aSlot)].
 ]
 
 { #category : #'*Shift-ClassInstaller' }

--- a/src/TraitsV2-Tests/T2TraitWithSlots.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithSlots.class.st
@@ -34,7 +34,7 @@ T2TraitWithSlots >> testClassUsingStatefulTraits [
 	t1 := self newTrait: #T1 with: #(aSlot).
 	c1 := self newClass: #C1 superclass: Object with: #() uses: { t1 }. 
 
-	self assert: c1 slots isEmpty
+	self assertCollection: c1 slots hasSameElements: { c1 slotNamed: #aSlot }.
 ]
 
 { #category : #tests }
@@ -45,7 +45,7 @@ T2TraitWithSlots >> testClassUsingStatefulTraitsAndLocalSlots [
 	t1 := self newTrait: #T1 with: #(aSlot).
 	c1 := self newClass: #C1 superclass: Object with: #(anotherSlot) uses: { t1 }. 
 
-	self assertCollection: c1 slots hasSameElements: { c1 slotNamed: #anotherSlot }
+	self assertCollection: c1 slots hasSameElements: { c1 slotNamed: #aSlot. c1 slotNamed: #anotherSlot }
 ]
 
 { #category : #tests }

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -315,16 +315,6 @@ TraitedClass >> removeSelector: aSelector [
 	TraitChange removeSelector: aSelector on: self.
 ]
 
-{ #category : #initialization }
-TraitedClass >> slots [
-	"I remove the slots comming from a traitComposition"
-
-	^ super slots reject:
-			[ :aSlot | 
-				self traitComposition slots anySatisfy: 
-					[ :existingSlots | aSlot name = existingSlots name ] ]
-]
-
 { #category : #'accessing tags' }
 TraitedClass >> tagsForMethods [
 	"Any method could be tagged with multiple symbols for user purpose. 


### PR DESCRIPTION
#slots should return the slots defined in the class and the ones in the traits.
These are the installed slots in the class. 
Represents the fisical representation of the class.