### PR TITLE
22558-FFICalloutresolveType-ignores-class-side-definition

### DIFF
--- a/src/UnifiedFFI/FFICallout.class.st
+++ b/src/UnifiedFFI/FFICallout.class.st
@@ -343,22 +343,28 @@ FFICallout >> resolveType: aTypeName [
 	
 	newName := aTypeName.
 	ptrArity := 0.
-	"resolve aliases and pointers"	
-	[
-		name := newName asString trimRight.  
+	"resolve aliases and pointers"
+	[ 
+		name := newName asString trimRight.
 		newName := self aliasForType: name.
-		newName last = $* ifTrue: [
+		newName last = $* ifTrue: [ 
 			ptrArity := ptrArity + 1.
 			newName := newName allButLast ].
-		name = newName ] whileFalse.
-	
-	resolver := requestor ifNil: [ self class ].
-	binding := resolver ffiBindingOf: name asSymbol.
-	
-	binding ifNotNil: [ 
-		^ (binding value asExternalTypeOn: self) pointerArity: ptrArity ] .
+		name = newName 
+	] whileFalse.
 
-	^ self error: 'Unable to resolve external type: ', aTypeName
+	resolver := requestor 
+		ifNotNil: [ 
+			requestor isClass
+				ifTrue: [ requestor instanceSide ]
+				ifFalse: [ requestor ] ]
+		ifNil: [ self class ].
+		
+	binding := resolver ffiBindingOf: name asSymbol.
+	binding ifNotNil: [ 
+		^ (binding value asExternalTypeOn: self) pointerArity: ptrArity ].
+
+	^ self error: 'Unable to resolve external type: ' , aTypeName
 ]
 
 { #category : #'spec parsing' }


### PR DESCRIPTION
https://pharo.manuscript.com/f/cases/22558/FFICallout-resolveType-ignores-class-side-definition