### PR TITLE
22561-uFFI-should-not-require-decompilation-to-extract-sender-selector

### DIFF
--- a/src/UnifiedFFI/FFICalloutAPI.class.st
+++ b/src/UnifiedFFI/FFICalloutAPI.class.st
@@ -66,8 +66,9 @@ FFICalloutAPI >> convention: aCallingConvention [
 
 { #category : #action }
 FFICalloutAPI >> function: functionSignature module: moduleNameOrLibrary [
-	| sender ffiMethod |
+	| sender ffiMethod ffiMethodSelector |
 	sender := context ifNil: [ thisContext sender sender ].
+	ffiMethodSelector := thisContext sender method selector.
 
 	"Build new method"
 	ffiMethod := self newBuilder
@@ -82,7 +83,7 @@ FFICalloutAPI >> function: functionSignature module: moduleNameOrLibrary [
 	"Replace with generated ffi method, but save old one for future use"
 	ffiMethod propertyValueAt: #ffiNonCompiledMethod put: (sender methodClass methodDict at: sender selector).
 	"For senders search, one need to keep the selector in the properties"
-	ffiMethod propertyValueAt: #ffiMethodSelector put: sender method sendNodes first selector.
+	ffiMethod propertyValueAt: #ffiMethodSelector put: ffiMethodSelector.
 	sender methodClass methodDict at: sender selector put: ffiMethod.
 	"Register current method as compiled for ffi"
 	FFIMethodRegistry uniqueInstance registerMethod: ffiMethod.


### PR DESCRIPTION
Fix for issue https://pharo.fogbugz.com/f/cases/22561/uFFI-should-not-require-decompilation-to-extract-sender-selectorExtract ffiMethod selector from direct sender