### PR TITLE
22563-GTInspector-can-loop-on-WindowPresenter

### DIFF
--- a/src/GT-InspectorExtensions-Core/ComposablePresenter.extension.st
+++ b/src/GT-InspectorExtensions-Core/ComposablePresenter.extension.st
@@ -19,6 +19,7 @@ ComposablePresenter >> gtInspectorModelNestingIn: composite [
 { #category : #'*GT-InspectorExtensions-Core' }
 ComposablePresenter >> gtInspectorPreviewIn: composite [
 	<gtInspectorPresentationOrder: 30>
+	self widget = self ifTrue: [ ^ self ].
 	
 	self widget ifNotNil: [ :w | w gtInspectorPreviewIn: composite ]
 ]


### PR DESCRIPTION
In some case GTInspector can loop on WindowPresenter. 

Fixes https://pharo.fogbugz.com/f/cases/22563/GTInspector-can-loop-on-WindowPresenter