### PR TITLE
22564-Spec-tests-has-a-class-that-need-to-be-moved-to-deprecated-pacakage

### DIFF
--- a/src/Spec-Deprecated/TestAutoFractionComputation.class.st
+++ b/src/Spec-Deprecated/TestAutoFractionComputation.class.st
@@ -1,5 +1,5 @@
 "
-I am a widget used to verify that the mechanism used to compute rows and columns are still working.
+I am deprecated
 "
 Class {
 	#name : #TestAutoFractionComputation,
@@ -9,7 +9,7 @@ Class {
 		'list',
 		'text'
 	],
-	#category : #'Spec-Tests-Utils'
+	#category : #'Spec-Deprecated-Obsolete'
 }
 
 { #category : #spec }
@@ -25,6 +25,11 @@ TestAutoFractionComputation class >> defaultSpec [
 						add: #button bottom: 0.7;
 						add: #text top: 0.3 ] right: 0.2 ];
 		yourself
+]
+
+{ #category : #deprecation }
+TestAutoFractionComputation class >> isDeprecated [
+	^ true
 ]
 
 { #category : #accessing }

--- a/src/Spec-Deprecated/TestingComposableModel.class.st
+++ b/src/Spec-Deprecated/TestingComposableModel.class.st
@@ -4,5 +4,10 @@ This is deprecated class because the original class TestingComposableModel was r
 Class {
 	#name : #TestingComposableModel,
 	#superclass : #TestingComposablePresenter,
-	#category : #'Spec-Tests-Deprecated'
+	#category : #'Spec-Deprecated-Obsolete'
 }
+
+{ #category : #deprecation }
+TestingComposableModel class >> isDeprecated [
+	^ true
+]


### PR DESCRIPTION
Deprecate some Spec classes to be able to remove them in P8

Fixes https://pharo.fogbugz.com/f/cases/22564/Spec-tests-has-a-class-that-need-to-be-moved-to-deprecated-pacakage