### PR TITLE
22566-Add-a-Details-pane-to-Colors-GT-Inspector

### DIFF
--- a/src/GT-InspectorExtensions-Core/Color.extension.st
+++ b/src/GT-InspectorExtensions-Core/Color.extension.st
@@ -7,3 +7,26 @@ Color >> gtInspectorColorIn: composite [
 		title: 'Color';
 		display: [ BorderedMorph new color: self ]
 ]
+
+{ #category : #'*GT-InspectorExtensions-Core' }
+Color >> gtInspectorDetailsIn: composite [
+	<gtInspectorPresentationOrder: 32>
+	^ composite table
+		title: 'Details';
+		display: [ 
+					{'name' -> self name.
+					'RGB red' -> self red.
+					'RGB green' -> self green.
+					'RGB blue' -> self blue.
+					'alpha' -> self alpha.
+					'HSL hue' -> self hue.
+					'HSL saturation' -> self hslSaturation.
+					'HSL lightness' -> self lightness.
+					'HSV hue' -> self hue.
+					'HSV saturation' -> self hsvSaturation.
+					'HSV value' -> self brightness.
+					'hex' -> self asHexString } ];
+		column: 'Key' evaluated: #key;
+		column: 'Value' evaluated: #value;
+		send: #value
+]


### PR DESCRIPTION
Add a Details pane to Color's GT Inspector to show RGB, HSL, HSV, alpha, name and hex.