### PR TITLE
22569-add-two-more-inspector-views-for-MetaLink-nodes-and-methods

### DIFF
--- a/src/GT-InspectorExtensions-Core/MetaLink.extension.st
+++ b/src/GT-InspectorExtensions-Core/MetaLink.extension.st
@@ -7,3 +7,23 @@ MetaLink >> gtInspectorDefinitonIn: composite [
  		title: ['Definition' translated];
  		display: [self definitionString]
 ]
+
+{ #category : #'*GT-InspectorExtensions-Core' }
+MetaLink >> gtInspectorMethodsIn: composite [
+	<gtInspectorPresentationOrder: 30>
+	composite list
+		title: [ 'Methods' translated ];
+		display:
+				[ (self methods collect: #asRingDefinition) sorted: [ :x :y | x selector < y selector ] ];
+		showOnly: 30
+]
+
+{ #category : #'*GT-InspectorExtensions-Core' }
+MetaLink >> gtInspectorNodesIn: composite [
+	<gtInspectorPresentationOrder: 30>
+
+	composite list 
+		title: ['Nodes' translated];
+		display: [ self nodes ];
+		showOnly: 30
+]

--- a/src/Reflectivity/MetaLink.class.st
+++ b/src/Reflectivity/MetaLink.class.st
@@ -292,6 +292,11 @@ MetaLink >> methods [
 ]
 
 { #category : #accessing }
+MetaLink >> nodes [
+	^nodes
+]
+
+{ #category : #accessing }
 MetaLink >> option: anArray [ 
 	self parseOptions: anArray
 ]


### PR DESCRIPTION
22569 add two more inspector views for MetaLink: nodes and methods
https://pharo.fogbugz.com/f/cases/22569/add-two-more-inspector-views-for-MetaLink-nodes-and-methods