### PR TITLE
22575-GZipReadStream-classunzipto-results-in-an-Invalid-utf8-input-detected-error

### DIFF
--- a/src/Compression/GZipReadStream.class.st
+++ b/src/Compression/GZipReadStream.class.st
@@ -82,8 +82,7 @@ GZipReadStream class >> unzip: fullFileName to: pathName [
 	GZipReadStream unzip:'zip.gz' to: '/aPath'
 	GZipReadStream unzip:'/aPath/zip.gz' asFileReference to: '/aPath' asFileReference
 	
-	To unzip a .zip go to the class ZipArchive
-	"
+	To unzip a .zip go to the class ZipArchive"
 
 	| buffer newName |
 	newName := fullFileName asFileReference basename copyUpToLast: FileSystem disk extensionDelimiter.

--- a/src/Compression/GZipReadStream.class.st
+++ b/src/Compression/GZipReadStream.class.st
@@ -82,22 +82,16 @@ GZipReadStream class >> unzip: fullFileName to: pathName [
 	GZipReadStream unzip:'zip.gz' to: '/aPath'
 	GZipReadStream unzip:'/aPath/zip.gz' asFileReference to: '/aPath' asFileReference
 	
-	To unzip a .zip go to the class ZipArchive
-	"
-	
-	| zipped buffer unzipped newName path|
+	To unzip a .zip go to the class ZipArchive"
+
+	| buffer newName |
 	newName := fullFileName asFileReference basename copyUpToLast: FileSystem disk extensionDelimiter.
-	path := pathName asFileReference.
-	path ensureCreateDirectory.
-	unzipped := FileStream newFileNamed: (path / newName) fullName.
-	unzipped ifNil: [self error: pathName, ' looks incorrect'].
-	[ unzipped binary. 
-	zipped := self on: (FileStream readOnlyFileNamed: fullFileName).
-	buffer := ByteArray new: 50000.
-	[zipped atEnd] whileFalse: [unzipped nextPutAll: (zipped nextInto: buffer)]]
-		ensure: [
-			zipped close.
-			unzipped close].
+	pathName asFileReference ensureCreateDirectory / newName
+		binaryWriteStreamDo: [ :unzipped | 
+			self with: fullFileName asFileReference binaryReadStream
+				do: [ :zipped | 
+					buffer := ByteArray new: 50000.
+					[ zipped atEnd ] whileFalse: [ unzipped nextPutAll: (zipped nextInto: buffer) ] ] ].
 	^ newName
 ]
 

--- a/src/Compression/GZipReadStream.class.st
+++ b/src/Compression/GZipReadStream.class.st
@@ -82,7 +82,8 @@ GZipReadStream class >> unzip: fullFileName to: pathName [
 	GZipReadStream unzip:'zip.gz' to: '/aPath'
 	GZipReadStream unzip:'/aPath/zip.gz' asFileReference to: '/aPath' asFileReference
 	
-	To unzip a .zip go to the class ZipArchive"
+	To unzip a .zip go to the class ZipArchive
+	"
 
 	| buffer newName |
 	newName := fullFileName asFileReference basename copyUpToLast: FileSystem disk extensionDelimiter.


### PR DESCRIPTION
Updated unzip:to: method to work with Pharo 7 streams.https://pharo.fogbugz.com/f/cases/22575/GZipReadStream-class-unzip-to-results-in-an-Invalid-utf8-input-detected-error