### PR TITLE
 Adding class OCCompilerDynamicASTPlugin (and its test class), allowi…

### DIFF
--- a/src/OpalCompiler-Core/OCCompilerASTPlugin.class.st
+++ b/src/OpalCompiler-Core/OCCompilerASTPlugin.class.st
@@ -1,5 +1,5 @@
 "
-I am an abtract superclass for compiler plugings.
+I am an abtract superclass for compiler plugins.
 
 The compiler consists of multiple passes:
 

--- a/src/OpalCompiler-Core/OCCompilerDynamicASTPlugin.class.st
+++ b/src/OpalCompiler-Core/OCCompilerDynamicASTPlugin.class.st
@@ -1,0 +1,52 @@
+"
+Look at the OCCompilerASTPlugin class comment for information about compiler plugins.
+
+I allow the dynamic creation of compiler plugins.
+
+Instanciate me using """"newFromTransformBlock: aBlock andPriority: aPriority"""" to get a compiler plugin you can add to an OpalCompiler instance with OpalCompiler>>addPlugin:.
+- aBlock must be a block of the form [ :ast | do something to ast ] that returns the modified ast.
+- aPriority is the priority the created plugin should have
+
+Check out my test class (OCCompilerDynamicASTPluginTest) for a usage example.
+"
+Class {
+	#name : #OCCompilerDynamicASTPlugin,
+	#superclass : #Object,
+	#instVars : [
+		'priority',
+		'transformBlock'
+	],
+	#category : #'OpalCompiler-Core-Translator'
+}
+
+{ #category : #'instance creation' }
+OCCompilerDynamicASTPlugin class >> newFromTransformBlock: aBlock andPriority: aPriority [
+	^ self new
+		transformBlock: aBlock;
+		priority: aPriority.
+]
+
+{ #category : #accessing }
+OCCompilerDynamicASTPlugin >> priority [
+	^ priority
+]
+
+{ #category : #accessing }
+OCCompilerDynamicASTPlugin >> priority: anObject [
+	priority := anObject
+]
+
+{ #category : #accessing }
+OCCompilerDynamicASTPlugin >> transform: ast [
+	^ transformBlock value: ast.
+]
+
+{ #category : #accessing }
+OCCompilerDynamicASTPlugin >> transformBlock [
+	^ transformBlock
+]
+
+{ #category : #accessing }
+OCCompilerDynamicASTPlugin >> transformBlock: anObject [
+	transformBlock := anObject
+]

--- a/src/OpalCompiler-Tests/OCCompilerDynamicASTPluginTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerDynamicASTPluginTest.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : #OCCompilerDynamicASTPluginTest,
+	#superclass : #TestCase,
+	#category : #'OpalCompiler-Tests-Plugins'
+}
+
+{ #category : #tests }
+OCCompilerDynamicASTPluginTest >> testCreatingAndUsingDynamicCompilerPlugin [
+	| result |
+	result :=
+	Object compiler
+		addPlugin: 
+			(OCCompilerDynamicASTPlugin 
+				newFromTransformBlock: [ :ast | (RBParseTreeRewriter replaceLiteral: 42 with: 'meaning of life') executeTree: ast. ast. ]
+				andPriority: 0
+			);
+		evaluate: '42'.
+	self assert: result equals: 'meaning of life'.
+]


### PR DESCRIPTION
…ng the dynamic creation of compiler plugins

Usage example:
```
Object compiler
	addPlugin: 
		(OCCompilerDynamicASTPlugin 
			newFromTransformBlock: [ :ast | (RBParseTreeRewriter replaceLiteral: 42 with: 'meaning of life') executeTree: ast. ast. ]
			andPriority: 0
		);
	evaluate: '42'.
```
The above yields 'meaning of life'