### PR TITLE
Added Interval>>sort: method that raises a "you can not sort an inter…

### DIFF
--- a/src/Collections-Sequenceable/Interval.class.st
+++ b/src/Collections-Sequenceable/Interval.class.st
@@ -373,7 +373,7 @@ Interval >> size [
 Interval >> sort: aBlock [
 	"What sorting an Interval means is not clear."
 
-	self error: 'You can not sort an interval.'
+	self shouldNotImplement.
 ]
 
 { #category : #sorting }

--- a/src/Collections-Sequenceable/Interval.class.st
+++ b/src/Collections-Sequenceable/Interval.class.st
@@ -369,6 +369,13 @@ Interval >> size [
 				ifFalse: [^ stop - start // step + 1]]
 ]
 
+{ #category : #accessing }
+Interval >> sort: aBlock [
+	"What sorting an Interval means is not clear."
+
+	self error: 'you can not sort an interval'
+]
+
 { #category : #sorting }
 Interval >> sorted [
 	^ self increment >= 0

--- a/src/Collections-Sequenceable/Interval.class.st
+++ b/src/Collections-Sequenceable/Interval.class.st
@@ -369,11 +369,11 @@ Interval >> size [
 				ifFalse: [^ stop - start // step + 1]]
 ]
 
-{ #category : #accessing }
+{ #category : #sorting }
 Interval >> sort: aBlock [
 	"What sorting an Interval means is not clear."
 
-	self error: 'you can not sort an interval'
+	self error: 'You can not sort an interval.'
 ]
 
 { #category : #sorting }


### PR DESCRIPTION
…val" error

From fogbuz issue:
Interval new sort raises an "#< was sent to nil" exception
(1 to: 5)  sort raises an "you can not store into an interval" exception

The Interval class inherits the default #sort: method of SequenceableCollection, which does not work for intervals. I am not sure the concept of sorting an Interval makes sense in the general case. I suggest implementing Interval>>sort: so that it raises an explicit exception: "you can not sort an interval" akin to what Interval>>at:put: does (it raises "you can not store into an interval"). Unless someone has an idea for what "sorting an Interval" could mean. 