### PR TITLE
22319-Extracting-an-already-existing-method-should-not-raise-an-error-

### DIFF
--- a/src/NautilusRefactoring/NautilusRefactoring.class.st
+++ b/src/NautilusRefactoring/NautilusRefactoring.class.st
@@ -90,6 +90,14 @@ NautilusRefactoring class >> model: model [
 		yourself
 ]
 
+{ #category : #'instance creation' }
+NautilusRefactoring class >> onEnvironment: anEnvironment [
+
+	^ self new
+		environment: anEnvironment;
+		yourself
+]
+
 { #category : #accessing }
 NautilusRefactoring class >> promptOnRefactoring [
 
@@ -282,6 +290,14 @@ NautilusRefactoring >> createCascadeBetween: anInterval from: aMethod [
 { #category : #method }
 NautilusRefactoring >> deprecateMethodFor: aMethod [
 	self performRefactoringFor: #privateDeprecateMethodFor: with: aMethod
+]
+
+{ #category : #accessing }
+NautilusRefactoring >> environment: anEnvironment [
+
+	environment := (RBClassModelFactory rbNamespace onEnvironment: anEnvironment)
+						name: self printString;
+						yourself
 ]
 
 { #category : #source }


### PR DESCRIPTION
Add a way to instanciate NautilusRefacoring without having a Nautilus instance.
By the way, NautilusRefacoring should be renamed.