### PR TITLE
22608-Deprecate-FileDialog-methods-that-open-streams

### DIFF
--- a/src/Morphic-Base/Morph.extension.st
+++ b/src/Morphic-Base/Morph.extension.st
@@ -249,13 +249,10 @@ Morph >> dispatchKeystrokeForEvent: evt [
 Morph >> exportAs: anExtension using: aWriter [
 	
 	| reference |
-	
-	reference := UIManager default 
-		fileSave: 'Save Morph as ', anExtension asUppercase 
-		initialAnswer: (self externalName, '.' , anExtension)
-		extensions: { anExtension } 
-		path: Smalltalk imageDirectory.
-		
+	reference := UIManager default
+		chooseForSaveFileReference: 'Save Morph as ', anExtension asUppercase
+		extensions: { anExtension }
+		path: (self externalName, '.' , anExtension).
 	reference ifNotNil: [ aWriter putForm: self imageForm onFileNamed: reference ]
 	
 ]

--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -213,12 +213,11 @@ WorldState class >> saveAndQuit [
 { #category : #'world menu items' }
 WorldState class >> saveAs [
 	| reference |
-	reference := UIManager default 
-		fileSave: 'Save Image as?' 
-		initialAnswer: (Smalltalk imageFile nextVersion basename copyUpToLast: Path extensionDelimiter)
+	reference := UIManager default
+		chooseForSaveFileReference: 'Save Image as?'
 		extensions: #('image') 
-		path: Smalltalk imageDirectory.
-		
+		path: Smalltalk imageFile nextVersion.
+
 	reference ifNotNil: [ Smalltalk saveAs: reference parent / (reference basenameWithoutExtension: 'image') ]
 ]
 

--- a/src/Polymorph-Widgets/TEasilyThemed.trait.st
+++ b/src/Polymorph-Widgets/TEasilyThemed.trait.st
@@ -134,10 +134,35 @@ TEasilyThemed >> chooseDropList: aStringOrText title: aString list: aList [
 ]
 
 { #category : #services }
-TEasilyThemed >> chooseFileName: title extensions: exts path: path preview: preview [
+TEasilyThemed >> chooseExistingFileReference: title extensions: exts path: path [
 	"Answer the result of a file name chooser dialog with the given title, extensions
 	to show, path and preview type."
 
+	^self
+		chooseExistingFileReference: title
+		extensions: exts
+		path: path
+		preview: nil
+]
+
+{ #category : #services }
+TEasilyThemed >> chooseExistingFileReference: title extensions: exts path: path preview: preview [
+	"Answer the result of a file name chooser dialog with the given title, extensions
+	to show, path and preview type."
+
+	^self theme
+		chooseExistingFileReferenceIn: self
+		title: title
+		extensions: exts
+		path: path
+		preview: preview
+]
+
+{ #category : #services }
+TEasilyThemed >> chooseFileName: title extensions: exts path: path preview: preview [
+	"Answer the result of a file name chooser dialog with the given title, extensions
+	to show, path and preview type."
+	self deprecated: 'Use UIManager default chooseFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
 	^self theme
 		chooseFileNameIn: self
 		title: title
@@ -164,6 +189,31 @@ TEasilyThemed >> chooseFont: aFont [
 ]
 
 { #category : #services }
+TEasilyThemed >> chooseForSaveFileReference: title extensions: exts path: path [
+	"Answer the result of a file name chooser dialog with the given title, extensions
+	to show, path and preview type."
+
+	^self
+		chooseForSaveFileReference: title
+		extensions: exts
+		path: path
+		preview: nil
+]
+
+{ #category : #services }
+TEasilyThemed >> chooseForSaveFileReference: title extensions: exts path: path preview: preview [
+	"Answer the result of a file name chooser dialog with the given title, extensions
+	to show, path and preview type."
+
+	^self theme
+		chooseForSaveFileReferenceIn: self
+		title: title
+		extensions: exts
+		path: path
+		preview: preview
+]
+
+{ #category : #services }
 TEasilyThemed >> deny: aStringOrText [
 	"Open a denial dialog."
 
@@ -183,7 +233,7 @@ TEasilyThemed >> deny: aStringOrText title: aString [
 { #category : #services }
 TEasilyThemed >> fileOpen: title [
 	"Answer the result of a file open dialog with the given title."
-
+	self deprecated: 'Use UIManager default chooseExistingFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
 	^self
 		fileOpen: title
 		extensions: nil
@@ -192,7 +242,7 @@ TEasilyThemed >> fileOpen: title [
 { #category : #services }
 TEasilyThemed >> fileOpen: title extensions: exts [
 	"Answer the result of a file open dialog with the given title and extensions to show."
-
+	self deprecated: 'Use UIManager default chooseExistingFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
 	^self
 		fileOpen: title
 		extensions: exts
@@ -202,7 +252,7 @@ TEasilyThemed >> fileOpen: title extensions: exts [
 { #category : #services }
 TEasilyThemed >> fileOpen: title extensions: exts path: path [
 	"Answer the result of a file open dialog with the given title, extensions to show and path."
-
+	self deprecated: 'Use UIManager default chooseExistingFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
 	^self 
 		fileOpen: title
 		extensions: exts
@@ -213,7 +263,7 @@ TEasilyThemed >> fileOpen: title extensions: exts path: path [
 { #category : #services }
 TEasilyThemed >> fileOpen: title extensions: exts path: path preview: preview [
 	"Answer the result of a file open dialog with the given title, extensions to show, path and preview type."
-
+	self deprecated: 'Use UIManager default chooseExistingFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
 	^self theme
 		fileOpenIn: self
 		title: title
@@ -225,7 +275,7 @@ TEasilyThemed >> fileOpen: title extensions: exts path: path preview: preview [
 { #category : #services }
 TEasilyThemed >> fileSave: title [
 	"Answer the result of a file save dialog with the given title."
-
+	self deprecated: 'Use UIManager default chooseForSaveFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
 	^self
 		fileSave: title
 		extensions: nil
@@ -235,7 +285,7 @@ TEasilyThemed >> fileSave: title [
 { #category : #services }
 TEasilyThemed >> fileSave: title extensions: exts [
 	"Answer the result of a file save dialog with the given title."
-
+	self deprecated: 'Use UIManager default chooseForSaveFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
 	^self
 		fileSave: title
 		extensions: exts
@@ -245,7 +295,7 @@ TEasilyThemed >> fileSave: title extensions: exts [
 { #category : #services }
 TEasilyThemed >> fileSave: title extensions: exts path: path [
 	"Answer the result of a file save dialog with the given title, extensions to show and path."
-
+	self deprecated: 'Use UIManager default chooseForSaveFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
 	^self theme
 		fileSaveIn: self
 		title: title
@@ -255,7 +305,7 @@ TEasilyThemed >> fileSave: title extensions: exts path: path [
 
 { #category : #services }
 TEasilyThemed >> fileSave: title initialAnswer: aFileName extensions: exts path: path [
-
+	self deprecated: 'Use UIManager default chooseForSaveFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
 	^self theme
 		fileSaveIn: self
 		title: title
@@ -267,7 +317,7 @@ TEasilyThemed >> fileSave: title initialAnswer: aFileName extensions: exts path:
 { #category : #services }
 TEasilyThemed >> fileSave: title path: path [
 	"Answer the result of a file save open dialog with the given title."
-
+	self deprecated: 'Use UIManager default chooseForSaveFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
 	^self
 		fileSave: title
 		extensions: nil

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -995,6 +995,26 @@ UITheme >> chooseDropListIn: aThemedMorph text: aStringOrText title: aString lis
 ]
 
 { #category : #services }
+UITheme >> chooseExistingFileReferenceIn: aThemedMorph title: title extensions: exts path: path preview: preview [
+	"Answer the result of a file name chooser dialog with the given title, extensions
+	path and preview type.
+	Answer nil or a filename."
+
+	| fd pathFileReference |
+	pathFileReference := path asFileReference.
+	fd := FileDialogWindow basicNew
+		basicTheme: aThemedMorph theme;
+		previewType: preview;
+		fileNameText: pathFileReference basename;
+		initialize;
+		title: title;
+		answerFileName.	
+	exts ifNotNil: [ fd validExtensions: exts ].
+	path ifNotNil: [ fd selectPath: pathFileReference pathString ].
+	^ (aThemedMorph openModal: fd) answer ifNotNil: #asFileReference
+]
+
+{ #category : #services }
 UITheme >> chooseFileIn: aThemedMorph title: title extensions: exts path: path preview: preview [
 	"Answer the result of a file open dialog with the given title, extensions path and preview type.
 	Answer nil or a filename."
@@ -1016,8 +1036,8 @@ UITheme >> chooseFileNameIn: aThemedMorph title: title extensions: exts path: pa
 	"Answer the result of a file name chooser dialog with the given title, extensions
 	path and preview type.
 	Answer nil or a filename."
-
 	| fd |
+	self deprecated: 'Use UIManager default chooseExistingFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
 	fd := FileDialogWindow basicNew
 		basicTheme: aThemedMorph theme;
 		previewType: preview;
@@ -1045,12 +1065,30 @@ UITheme >> chooseFontIn: aThemedMorph title: aString font: aFont [
 ]
 
 { #category : #services }
+UITheme >> chooseForSaveFileReferenceIn: aThemedMorph title: title extensions: exts path: path preview: preview [
+	"Answer the result of a file name chooser dialog with the given title, extensions
+	path and preview type.
+	Answer nil or a filename."
+
+	| fd pathFileReference |
+	pathFileReference := path asFileReference.
+	fd := (FileDialogWindow newWithTheme: aThemedMorph theme)
+		title: title;
+		fileNameText: pathFileReference basename;
+		answerSaveFile.
+	exts ifNotNil: [ fd validExtensions: exts ].
+	path ifNotNil: [ fd selectPath: path ].
+	^ (aThemedMorph openModal: fd) answer
+]
+
+{ #category : #services }
 UITheme >> chooseFullFileNameIn: aThemedMorph title: title extensions: exts path: path preview: preview [
 	"Answer the result of a file name chooser dialog with the given title, extensions
 	path and preview type.
 	Answer nil or a full filename."
 
 	| fd |
+	self deprecated: 'Use UIManager default chooseExistingFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
 	fd := FileDialogWindow basicNew
 		basicTheme: aThemedMorph theme;
 		previewType: preview;
@@ -2169,6 +2207,7 @@ UITheme >> fileOpenIn: aThemedMorph title: title extensions: exts path: path pre
 	"Answer the result of a file open dialog with the given title, extensions path and preview type."
 
 	| fd |
+	self deprecated: 'Use UIManager default chooseExistingFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
 	fd := FileDialogWindow basicNew
 		basicTheme: aThemedMorph theme;
 		previewType: preview;
@@ -2184,6 +2223,7 @@ UITheme >> fileOpenIn: aThemedMorph title: title extensions: exts path: path pre
 UITheme >> fileSaveIn: aThemedMorph title: title extensions: exts path: path [
 	"Answer the result of a file save dialog with the given title, extensions and path."
 
+	self deprecated: 'Use UIManager default chooseForSaveFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
 	^self fileSaveIn: aThemedMorph title: title initialAnswer: '' extensions: exts path: path
 ]
 
@@ -2192,6 +2232,7 @@ UITheme >> fileSaveIn: aThemedMorph title: title initialAnswer: aFileName extens
 	"Answer the result of a file save dialog with the given title, extensions and path."
 
 	| fd |
+	self deprecated: 'Use UIManager default chooseForSaveFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
 	fd := (FileDialogWindow newWithTheme: aThemedMorph theme)
 		title: title;
 		fileNameText: aFileName;


### PR DESCRIPTION
Fix https://pharo.fogbugz.com/f/cases/22608/Deprecate-FileDialog-methods-that-open-streams

- Deprecate stream based API in UIManager
- Propose FileReference based methods
- Rewrote clientes saveAs and exportAs:using: