### PR TITLE
22613-ZnNewLineWriterStreamclose-missing

### DIFF
--- a/src/Zinc-Character-Encoding-Core/ZnNewLineWriterStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnNewLineWriterStream.class.st
@@ -36,6 +36,12 @@ ZnNewLineWriterStream class >> on: aStream [
 		yourself
 ]
 
+{ #category : #'open/close' }
+ZnNewLineWriterStream >> close [ 
+
+	^stream close
+]
+
 { #category : #flushing }
 ZnNewLineWriterStream >> flush [
 	^ stream flush

--- a/src/Zinc-Character-Encoding-Tests/ZnNewLineWriterStreamTests.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnNewLineWriterStreamTests.class.st
@@ -5,6 +5,25 @@ Class {
 }
 
 { #category : #tests }
+ZnNewLineWriterStreamTests >> testClose [ 
+
+	| string fs fileReference znstream |
+
+	fs := FileSystem memory.
+	fileReference := fs / 'test.txt'.
+	string := String streamContents: [ :stream |
+		stream 
+			<< 'abcčřž';
+			cr ].
+	znstream := ZnNewLineWriterStream on: fileReference writeStream.
+	znstream forLf.
+	[ znstream nextPutAll: string ]
+		ensure: [ znstream close ].
+	string at: string size put: Character lf.
+	self assert: fileReference contents equals: string.
+]
+
+{ #category : #tests }
 ZnNewLineWriterStreamTests >> testNextPut [
 	"Ensure that the line ends are written correctly"
 


### PR DESCRIPTION
22613: ZnNewLineWriterStream>>close missing

ZnNewLineWriterStream inherits #close from Stream, which is a no-op.

If the wrapped stream is buffered the final buffer won't be written when the stream is closed, losing content.

See ZnNewLineWriterStreamTests>>testClose for code that triggers this issue.