### PR TITLE
22615-Random-Core-can-be-removed-form-the-manual-dependencies-list-of-Collections-String

### DIFF
--- a/src/Collections-Strings/ManifestCollectionsStrings.class.st
+++ b/src/Collections-Strings/ManifestCollectionsStrings.class.st
@@ -14,7 +14,7 @@ ManifestCollectionsStrings class >> dependencies [
 
 { #category : #'meta-data - dependency analyser' }
 ManifestCollectionsStrings class >> manuallyResolvedDependencies [
-	^ #(#'System-Support' #'AST-Core' #'Random-Core' #'OpalCompiler-Core')
+	^ #(#'System-Support' #'AST-Core' #'OpalCompiler-Core')
 ]
 
 { #category : #'meta-data' }


### PR DESCRIPTION
Remove Random-Core from manually resolved dependencies of Collections-String.

Fixes https://pharo.fogbugz.com/f/cases/22615/Random-Core-can-be-removed-form-the-manual-dependencies-list-of-Collections-String