### PR TITLE
22617-MemoryFileWriteStreamclose-doesnt-flush

### DIFF
--- a/src/FileSystem-Memory/MemoryFileWriteStream.class.st
+++ b/src/FileSystem-Memory/MemoryFileWriteStream.class.st
@@ -6,7 +6,6 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'file',
-		'writeStream',
 		'stream'
 	],
 	#category : #'FileSystem-Memory-Streams'
@@ -22,6 +21,7 @@ MemoryFileWriteStream class >> on: aFile [
 
 { #category : #'opening-closing' }
 MemoryFileWriteStream >> close [
+	self flush.
 	self stream close.
 	file close
 ]

--- a/src/FileSystem-Tests-Memory/MemoryFileSystemTest.class.st
+++ b/src/FileSystem-Tests-Memory/MemoryFileSystemTest.class.st
@@ -21,6 +21,19 @@ MemoryFileSystemTest >> lastModificationTimeOf: fileReference [
 ]
 
 { #category : #tests }
+MemoryFileSystemTest >> testCopyFromto [
+
+	| fileReference buffer |
+
+	fileReference := filesystem root / 'test.file'.
+	buffer := 'test data'.
+	filesystem
+		copyFrom: buffer readStream 
+		to: fileReference path.
+	self assert: fileReference contents equals: buffer.
+]
+
+{ #category : #tests }
 MemoryFileSystemTest >> testCurrentEqual [
 	| other another |
 	another := FileSystem currentMemoryFileSystem.


### PR DESCRIPTION
22617: MemoryFileWriteStream>>close doesn't flush the stream, and thus doesn't write the updated contents back to the file.

Also remove unused instance variable 'writeStream'.