### PR TITLE
22620-Move-zippedunzipped-from-String-to-ByteArray

### DIFF
--- a/src/Compression-Tests/ZipExtensionTests.class.st
+++ b/src/Compression-Tests/ZipExtensionTests.class.st
@@ -8,8 +8,24 @@ Class {
 }
 
 { #category : #tests }
-ZipExtensionTests >> testZipped [
-	| compressed |
-	compressed := 'hello' zipped.
-	self assert: compressed unzipped equals: 'hello'
+ZipExtensionTests >> testUnzippedError [
+	self should: [ #[ 1 2 3 ] unzipped ] raise: Error
+]
+
+{ #category : #tests }
+ZipExtensionTests >> testZippedUnzipped [
+	| data |
+	data := #[ 1 2 3 4 5 6 1 2 3 4 5 6 1 2 3 4 5 6 1 2 3 4 5 6 1 2 3 4 5 6 ].
+	self assert: data zipped size < data size.
+	self assert: data zipped unzipped equals: data.
+	
+  self assert: #[ ] zipped unzipped equals: #[ ]
+]
+
+{ #category : #tests }
+ZipExtensionTests >> testZippedUnzippedString [
+	| string |
+	string := 'abcded abcded abcded abcded abcded abcded - 10 €'.
+	self assert: string utf8Encoded zipped size < string size.
+	self assert: string utf8Encoded zipped unzipped utf8Decoded equals: string
 ]

--- a/src/Compression-Tests/ZipWriteStreamTests.class.st
+++ b/src/Compression-Tests/ZipWriteStreamTests.class.st
@@ -11,24 +11,16 @@ Class {
 ZipWriteStreamTests >> testEmptyStrings [
 	| aStream zipStream |
 
-	aStream := ByteArray new writeStream binary.
+	aStream := ByteArray new writeStream.
 	zipStream := ZipWriteStream on: aStream.
 	zipStream nextStringPut: ''. 
 	zipStream nextStringPut: ''.
 	zipStream close.
 	aStream close.
-	aStream := aStream contents readStream binary.
+	aStream := aStream contents readStream.
 	zipStream := ZipReadStream on: aStream.
 	self assert: zipStream nextString isEmpty. 
 	self assert: zipStream nextString isEmpty.
 	zipStream close.
 	aStream close
-]
-
-{ #category : #tests }
-ZipWriteStreamTests >> testZipped [
-	| compressed |
-	
-	compressed := 'hello' zipped.
-	self assert: compressed unzipped equals: 'hello'
 ]

--- a/src/Compression/ByteArray.extension.st
+++ b/src/Compression/ByteArray.extension.st
@@ -17,3 +17,21 @@ ByteArray >> lastIndexOfPKSignature: aSignature [
 	].
 	^0
 ]
+
+{ #category : #'*Compression' }
+ByteArray >> unzipped [
+	"Decompress the receiver using GZip and return the resulting byte array.
+	This will fail when the receiver does not contain GZip compressed data."
+	
+	^ (GZipReadStream on: self) upToEnd
+]
+
+{ #category : #'*Compression' }
+ByteArray >> zipped [
+	"Compress the receiver using GZip and return the resulting byte array"
+	
+	^ self class streamContents: [ :out |
+		(GZipWriteStream on: out) 
+			nextPutAll: self; 
+			close ]
+]

--- a/src/Compression/String.extension.st
+++ b/src/Compression/String.extension.st
@@ -23,27 +23,3 @@ String >> lastIndexOfPKSignature: aSignature [
 	].
 	^0
 ]
-
-{ #category : #'*compression' }
-String >> unzipped [
-	| magic1 magic2 |
-	magic1 := (self at: 1) asInteger.
-	magic2 := (self at: 2) asInteger.
-	(magic1 = 16r1F and:[magic2 = 16r8B]) ifFalse:[^self].
-	^(GZipReadStream on: self) upToEnd
-]
-
-{ #category : #'*Compression' }
-String >> zipped [
-	| stream gzstream |
-
-	stream := RWBinaryOrTextStream on: String new.
-
-	gzstream := GZipWriteStream on: stream.
-	gzstream nextPutAll: self.
-	gzstream close.
-	stream reset.
-
-	^ stream contents
-
-]


### PR DESCRIPTION
Add #zipped and #unzipped to ByteArray as an extension from Compression
Remove #zipped and #unzipped from String
Adjust and extend unit tests

https://pharo.fogbugz.com/f/cases/22620/Move-zipped-unzipped-from-String-to-ByteArray