### PR TITLE
22621-FileReferencemoveTo-doesnt-work-with-directories

### DIFF
--- a/src/FileSystem-Core/AbstractFileReference.class.st
+++ b/src/FileSystem-Core/AbstractFileReference.class.st
@@ -608,7 +608,9 @@ AbstractFileReference >> moveTo: aReference [
 	(FileSystem disk workingDirectory / 'paf' ) ensureCreateFile.
 	(FileSystem disk workingDirectory / 'fooFolder') ensureCreateDirectory. 
 	(FileSystem disk workingDirectory / 'paf' ) moveTo: (FileSystem disk workingDirectory / 'fooFolder' / 'paf')
-	"
+	
+	Note that the receiver is modified to point to the new location."
+
 	^ self resolve moveTo: aReference
 ]
 

--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -314,6 +314,13 @@ FileReference >> modificationTime [
 
 { #category : #operations }
 FileReference >> moveTo: aReference [
+	"Move the receiver in the location passed as argument.
+	
+	(FileSystem disk workingDirectory / 'paf' ) ensureCreateFile.
+	(FileSystem disk workingDirectory / 'fooFolder') ensureCreateDirectory. 
+	(FileSystem disk workingDirectory / 'paf' ) moveTo: (FileSystem disk workingDirectory / 'fooFolder' / 'paf')
+	
+	Note that the receiver is modified to point to the new location."
 	
 	| result |
 	result := self fileSystem 

--- a/src/FileSystem-Core/FileSystem.class.st
+++ b/src/FileSystem-Core/FileSystem.class.st
@@ -169,14 +169,69 @@ FileSystem >> copyAndDelete: sourcePath to: destination [
 	If there is no file at sourcePath, raise FileDoesNotExist.
 	If destPath is a file, raise FileExists.
 	If an error occurs during the operation, try and roll back to the original state."
-	
-	[
-		self copy: sourcePath toReference: destination.
-		self delete: sourcePath.
-	] on: Error do: [ :error |
-		destination delete.
-		error signal.
-	]
+
+	^(self isDirectory: sourcePath) ifTrue: 
+		[ self copyDirectoryAndDelete: sourcePath to: destination ]
+	ifFalse:
+		[ self copyFileAndDelete: sourcePath to: destination ].
+
+]
+
+{ #category : #private }
+FileSystem >> copyDirectory: sourcePath toReference: destination [
+	"Copy the source directory to the (yet to be created) destination"
+
+	destination createDirectory.
+	store directoryAt: sourcePath nodesDo:
+		[ :entry | | basename |
+			basename := store basenameFromEntry: entry.
+			(store basicIsDirectory: entry) ifTrue: 
+				[ self copyDirectory: sourcePath / basename toReference: destination / basename ]
+			ifFalse:
+				[ self copy: sourcePath / basename toReference: destination / basename ] ]
+]
+
+{ #category : #private }
+FileSystem >> copyDirectoryAndDelete: sourcePath to: destination [
+	"Copy the directory sourcePath to the destination referred as destPath.
+	If destination exists (and is a directory), add sourcePath basename to it,
+	otherwise create destination as a directory a copy the contents of sourcePath in to it.
+	If there is no file at sourcePath, raise FileDoesNotExist.
+	If destPath is a file, raise FileExists.
+	If an error occurs during the operation, try and roll back to the original state."
+
+	"The source must be a directory"
+	(self isDirectory: sourcePath) ifFalse: 
+		[ (FileException fileName: sourcePath pathString)
+				message: 'not a directory';
+				signal ].
+	"The destination musn't exist yet"
+	destination exists ifTrue: 
+		[ FileAlreadyExistsException signalWith: destination ].
+
+	[self copyDirectory: sourcePath toReference: destination] 
+		on: Error 
+		do: [ :error |
+			destination delete.
+			error signal].
+	(FileReference fileSystem: self path: sourcePath) deleteAll.
+	^destination
+]
+
+{ #category : #private }
+FileSystem >> copyFileAndDelete: sourcePath to: destination [
+	"Copy the file referenced as sourcePath to the destination referred as destPath.  
+	If there is no file at sourcePath, raise FileDoesNotExist.
+	If destPath is a file, raise FileExists.
+	If an error occurs during the operation, try and roll back to the original state."
+
+	[self copy: sourcePath toReference: destination] 
+		on: Error 
+		do: [ :error |
+			destination delete.
+			error signal].
+	self delete: sourcePath.
+	^destination
 ]
 
 { #category : #private }

--- a/src/FileSystem-Core/FileSystemStore.class.st
+++ b/src/FileSystem-Core/FileSystemStore.class.st
@@ -199,6 +199,15 @@ FileSystemStore >> directoryAt: aPath ifAbsent: absentBlock nodesDo: aBlock [
 ]
 
 { #category : #public }
+FileSystemStore >> directoryAt: path nodesDo: aBlock [
+
+	^self
+		directoryAt: path
+		ifAbsent: [ self signalDirectoryDoesNotExist: path ]
+		nodesDo: aBlock
+]
+
+{ #category : #public }
 FileSystemStore >> ensureCreateDirectory: aPath [
 	(self isDirectory: aPath) ifTrue: [ ^ self ].
 	self ensureCreateDirectory: aPath parent.

--- a/src/FileSystem-Tests-Memory/MemoryFileSystemTest.class.st
+++ b/src/FileSystem-Tests-Memory/MemoryFileSystemTest.class.st
@@ -12,6 +12,21 @@ MemoryFileSystemTest >> createFileSystem [
 	^ FileSystem memory
 ]
 
+{ #category : #private }
+MemoryFileSystemTest >> createFilesIn: root from: anArray [
+	"Helper method to create a directory hierarchy with files."
+
+	| dir path |
+
+	dir := (root / anArray first) createDirectory.
+	anArray allButFirstDo: [ :each |
+		each isArray ifTrue: 
+			[ self createFilesIn: dir from: each ]
+		ifFalse: 
+			[ (path := dir / each) writeStreamDo: [ :stream |
+				stream nextPutAll: path pathString ] ] ]
+]
+
 { #category : #tests }
 MemoryFileSystemTest >> lastModificationTimeOf: fileReference [
 	"DateAndTime primUTCMicrosecondsClock is not precise across all OS so put in slight delay between calling modificationTime"
@@ -39,6 +54,83 @@ MemoryFileSystemTest >> testCurrentEqual [
 	another := FileSystem currentMemoryFileSystem.
 	other := FileSystem currentMemoryFileSystem.
 	self assert: other equals: another
+]
+
+{ #category : #tests }
+MemoryFileSystemTest >> testDirectoryMoveTo [
+	"Test the scenario where the source is a directory, the destination is an existing directory and they are on separate file systems."
+	| srcFS destFS src dest count f33 |
+
+	srcFS := filesystem workingDirectory.
+	destFS := FileSystem memory workingDirectory.
+	self createFilesIn: srcFS from: #(
+		src
+		f11
+		f12
+		#(
+			d11
+			f21
+			f22
+			#(
+				d21
+				f31
+				f32)
+			#(
+				d22
+				f33
+				f34))).
+
+	[src := srcFS / 'src'.
+	count := src allChildren size.
+	dest := destFS / 'dest'.
+	dest ensureCreateDirectory.
+	f33 := dest / 'src/d11/d22/f33'.
+	src copy moveTo: dest.
+	self deny: src exists.
+	self assert: (dest / 'src') allChildren size equals: count.
+	self assert: f33 exists.
+	self assert: f33 contents equals: '/src/d11/d22/f33']
+		ensure: 
+			[ src exists ifTrue: [ src deleteAll ].
+			dest exists ifTrue: [ dest deleteAll ] ].
+]
+
+{ #category : #tests }
+MemoryFileSystemTest >> testDirectoryMoveToRename [
+	"Test the scenario where the source is a directory, the destination doesn't exist (its parent does) and they are on separate file systems, i.e. move and rename the source to the destination."
+	| srcFS destFS src dest count f33 |
+
+	srcFS := filesystem workingDirectory.
+	destFS := FileSystem memory workingDirectory.
+	self createFilesIn: srcFS from: #(
+		src
+		f11
+		f12
+		#(
+			d11
+			f21
+			f22
+			#(
+				d21
+				f31
+				f32)
+			#(
+				d22
+				f33
+				f34))).
+
+	[src := srcFS / 'src'.
+	count := src allChildren size.
+	dest := (destFS / 'dest') ensureCreateDirectory / 'renamed'.
+	f33 := dest / 'd11/d22/f33'.
+	src copy moveTo: dest.
+	self deny: src exists.
+	self assert: dest allChildren size equals: count.
+	self assert: f33 exists.
+	self assert: f33 contents equals: '/src/d11/d22/f33']
+		ensure: 
+			[ src exists ifTrue: [ src deleteAll ].
+			dest exists ifTrue: [ dest deleteAll ] ].
 ]
 
 { #category : #tests }


### PR DESCRIPTION
22621 FileReference>>moveTo: doesn't work with directories

Fogbugz: https://pharo.fogbugz.com/f/cases/22621/

FileReference>>moveTo: calls FileSystem>>move:to: which states:

"Move the file /directory referenced as sourcePath to the destination referred as destPath."

However it fails if the source is a directory.

- Add the missing functionality
- Update #moveTo: comments to notify the user that the receiver is modified to point to the destination
- Add unit tests for the new functionality
-- Only in the memory file system so the test time isn't increased too much.