### PR TITLE
22625-FileReferencenextVersion-gets-stuck-at-11

### DIFF
--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -363,7 +363,7 @@ FileReference >> nextVersion [
 				select: [ :f| 
 					(f basename beginsWith: nameWithoutExtension) ]
 				thenCollect: [ :f| 
-					Number squeezeNumberOutOfString: (f basename last: (f basename size - nameWithoutExtension size))   ifFail: [ 0 ]].
+					Number squeezeNumberOutOfString: (f basename last: (f basename size - nameWithoutExtension size - 1))   ifFail: [ 0 ]].
 	
 	versionNumbers ifEmpty: [ ^self ].
 	

--- a/src/FileSystem-Tests-Core/FileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/FileReferenceTest.class.st
@@ -744,6 +744,21 @@ FileReferenceTest >> testNextNameForExtensionNegativeTesting [
 ]
 
 { #category : #tests }
+FileReferenceTest >> testNextVersion [
+
+	| fs file versions |
+
+	fs := FileSystem memory.
+	file := fs / 'file.name'.
+	versions := Array streamContents: [ :stream |
+		5 timesRepeat: [ 
+			file createFile.
+			stream nextPut: file basename.
+			file := file nextVersion. ] ].
+	self assert: versions equals: #('file.name' 'file.1.name' 'file.2.name' 'file.3.name' 'file.4.name').
+]
+
+{ #category : #tests }
 FileReferenceTest >> testParent [
 	| ref parent |
 	ref := filesystem * 'plonk' / 'griffle'.


### PR DESCRIPTION
22625: FileReference>>nextVersion gets stuck at 1.1

Calling FileReference>>nextVersion repeatedly results in the following sequence:

file.name
file.1.name
file.1.1.name
file.1.1.name
file.1.1.name
etc.

This is because when determining the current version number it leaves the leading '.' in the string before converting it to an integer.

Fogbugz: https://pharo.fogbugz.com/f/cases/22625/FileReference-nextVersion-gets-stuck-at-1-1