### PR TITLE
22629-Secondary-selection-is-too-bright-when-switching-to-the-dark-theme

### DIFF
--- a/src/Athens-Morphic/LazyListMorph.extension.st
+++ b/src/Athens-Morphic/LazyListMorph.extension.st
@@ -34,7 +34,7 @@ LazyListMorph >> athensDrawBackgroundForRow: row on: aCanvas color: aColor [
 { #category : #'*Athens-Morphic' }
 LazyListMorph >> athensDrawBackgroundForSearchedRow: row on: aCanvas [ 
 
-	aCanvas setPaint: listSource  secondarySelectionColor.
+	aCanvas setPaint: listSource secondarySelectionColor.
 	aCanvas drawShape: (self selectionFrameForRow: row)
 ]
 

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -92,8 +92,6 @@ BaselineOfIDE >> additionalInitialization [
 	
 	PharoLightTheme beCurrent.
 	
-	Smalltalk ui theme settings secondarySelectionColor: (Color r: 0.927 g: 0.962 b: 0.995 alpha: 1.0).
-	
 	SDL_Event initialize.
 	
 	3 timesRepeat: [

--- a/src/Polymorph-Widgets/PharoDarkTheme.class.st
+++ b/src/Polymorph-Widgets/PharoDarkTheme.class.st
@@ -414,7 +414,7 @@ PharoDarkTheme >> scrollbarPressedThumbFillStyleFor: aScrollbar [
 
 { #category : #'accessing colors' }
 PharoDarkTheme >> secondarySelectionColor [
-	^ Color r: 0.31 g: 0.31 b: 0.36
+	^ Color r: 0.31 g: 0.31 b: 0.36 alpha: 1.0
 ]
 
 { #category : #'accessing colors' }

--- a/src/Polymorph-Widgets/ThemeSettings.class.st
+++ b/src/Polymorph-Widgets/ThemeSettings.class.st
@@ -508,23 +508,11 @@ ThemeSettings >> scrollbarColor: anObject [
 ]
 
 { #category : #accessing }
-ThemeSettings >> secondarySelectionColor [
-	"Answer the value of selectionColor"
-
-	^ secondarySelectionColor ifNil: [secondarySelectionColor :=   (Color r: 0.351 g: 0.939 b: 0.46 alpha: 0.35)]
-]
-
-{ #category : #accessing }
-ThemeSettings >> secondarySelectionColor: anColor [
-	secondarySelectionColor := anColor
-]
-
-{ #category : #accessing }
 ThemeSettings >> secondarySelectionTextColor [
 	"Answer the value of selectionTextColor"
 
 	^ secondarySelectionTextColor 
-		ifNil: [ self secondarySelectionColor contrastingColor ]
+		ifNil: [ Smalltalk ui theme secondarySelectionColor contrastingColor ]
 ]
 
 { #category : #accessing }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -180,7 +180,6 @@ UITheme class >> newDefaultSettings [
 		autoSelectionColor: false;
 		preferRoundCorner: false;
 		fadedBackgroundWindows: false;
-		secondarySelectionColor: self veryLightSelectionColor;
 		flatMenu: true
 ]
 
@@ -5269,7 +5268,7 @@ UITheme >> scrollbarThumbVerticalMiddleForm [
 
 { #category : #'accessing colors' }
 UITheme >> secondarySelectionColor [
-	^ self settings secondarySelectionColor
+	^ Color r: 0.927 g: 0.962 b: 0.995 alpha: 1.0
 ]
 
 { #category : #'accessing colors' }

--- a/src/Rubric/RubTextSelectionColor.class.st
+++ b/src/Rubric/RubTextSelectionColor.class.st
@@ -34,7 +34,7 @@ RubTextSelectionColor class >> oppositeDelimiterSelection [
 		ifNil: [ 
 			OppositeDelimiterSelection := self new
 				colorBlock: [ self theme currentSettings selectionTextColor ];
-				backgroundColorBlock: [ self theme currentSettings secondarySelectionColor ];
+				backgroundColorBlock: [ self theme secondarySelectionColor ];
 				yourself ]
 ]
 
@@ -57,7 +57,7 @@ RubTextSelectionColor class >> secondarySelection [
 							self theme currentSettings haveSecondarySelectionTextColor
 								ifTrue: [ self theme currentSettings secondarySelectionTextColor ]
 								ifFalse: [  ] ];
-				backgroundColorBlock: [ self theme currentSettings secondarySelectionColor ];
+				backgroundColorBlock: [ self theme secondarySelectionColor ];
 				yourself ]
 ]
 

--- a/src/Text-Edition/Editor.class.st
+++ b/src/Text-Edition/Editor.class.st
@@ -83,10 +83,6 @@ Editor class >> editingSettingsOn: aBuilder [
 				target: TextEditor;
 				label: 'Use the secondary selection';
 				with: [
-					(aBuilder setting: #secondarySelectionColor)
-						target: UITheme;
-						targetSelector: #currentSettings;
-						label: 'Secondary selection color'.
 					(aBuilder setting: #secondarySelectionTextColor)
 						target: UITheme;
 						targetSelector: #currentSettings;


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/22629/Secondary-selection-is-too-bright-when-switching-to-the-dark-themeremove secondary selection color theme setting and use theme value directly