### PR TITLE
22639-Clean-ComposablePresenter-icon-API

### DIFF
--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -129,6 +129,11 @@ ComposablePresenter class >> defaultSpec [
 ]
 
 { #category : #defaults }
+ComposablePresenter class >> iconNamed: aSymbol [
+	^ Smalltalk ui icons iconNamed: aSymbol
+]
+
+{ #category : #defaults }
 ComposablePresenter class >> inputTextHeight [
 
 	^ self defaultFont height + 12
@@ -523,11 +528,9 @@ ComposablePresenter >> hide [
 		(widget respondsTo: #hide) ifTrue: [ widget hide ]].
 ]
 
-{ #category : #icon }
-ComposablePresenter >> icon: aSymbol [
-	"Return the icon associated with the argument."
-	self flag: #remove.
-	^ self iconNamed: aSymbol
+{ #category : #accessing }
+ComposablePresenter >> iconNamed: aSymbol [
+	^ self class iconNamed: aSymbol
 ]
 
 { #category : #api }

--- a/src/Spec-Core/ManifestSpecCore.class.st
+++ b/src/Spec-Core/ManifestSpecCore.class.st
@@ -38,6 +38,11 @@ ManifestSpecCore class >> ruleLongMethodsRuleV1FalsePositive [
 ]
 
 { #category : #'code-critics' }
+ManifestSpecCore class >> ruleRBEquivalentSuperclassMethodsRuleV1FalsePositive [
+	^ #(#(#(#RGMethodDefinition #(#'ComposablePresenter class' #iconNamed: #true)) #'2018-11-07T14:51:01.186582+01:00') )
+]
+
+{ #category : #'code-critics' }
 ManifestSpecCore class >> ruleRBOverridesDeprecatedMethodRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#MenuItemPresenter #name #false)) #'2016-07-01T15:56:13.378417+02:00') )
 ]

--- a/src/Spec-Deprecated/ComposablePresenter.extension.st
+++ b/src/Spec-Deprecated/ComposablePresenter.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : #ComposablePresenter }
 
 { #category : #'*Spec-Deprecated' }
+ComposablePresenter >> icon: aSymbol [
+	self deprecated: 'Use #iconNamed: instead' transformWith: '`@receiver icon: `@statements' -> '`@receiver iconNamed: `@statements'.
+	^ self iconNamed: aSymbol
+]
+
+{ #category : #'*Spec-Deprecated' }
 ComposablePresenter >> instantiateModels: aCollectionOfPairs [
 	
 	"instantiateModels: is legacy code in ComposablePresenter and must not be used. It will be deprecated and removed."


### PR DESCRIPTION
Deprecate ComposablePresenter>>#icon: to use #iconNamed:

Fixes https://pharo.fogbugz.com/f/cases/22639/Clean-ComposablePresenter-icon-API