### PR TITLE
22064-Suggestions-menu-should-be-not-shown-in-Calypso-code-menu

### DIFF
--- a/src/SmartSuggestions/RubSmalltalkEditor.extension.st
+++ b/src/SmartSuggestions/RubSmalltalkEditor.extension.st
@@ -6,16 +6,3 @@ RubSmalltalkEditor >> smartSuggestions [
 
 	SugsMenuBuilder showMenuFor: self
 ]
-
-{ #category : #'*SmartSuggestions' }
-RubSmalltalkEditor class >> suggestionsMenuOn: aBuilder [
-	<RubSmalltalkCodeMenu>
-	aBuilder
-		item: 'Suggestions...';
-		selector: #value;
-		target: [ SugsMenuBuilder showMenuFor: aBuilder model ];
-		keyText: 't ';
-		order: 0;
-		iconName: #smallAuthoringTools;
-		with: [ SugsMenuBuilder buildContextMenuOn: aBuilder ]
-]


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/22064/Suggestions-menu-should-be-not-shown-in-Calypso-code-menuremove obsolete code suggestions