### PR TITLE
21721-FastTable-filtering-produces-ByteString-DNU-matchesIn-in-some-examples

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTTreeDataSource.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTreeDataSource.class.st
@@ -230,9 +230,12 @@ FTTreeDataSource >> menuColumn: column row: rowIndex [
 
 { #category : #accessing }
 FTTreeDataSource >> newDataSourceMatching: aFTFilter [
-	"I delegate the filter to a FTTreeFunctionStrategy."
 
-	^ (self class searchStrategies at: self searchStrategy ifAbsent: [ self class searchStrategies at: #default ]) filterWith: aFTFilter pattern dataSource: self
+	^ (self class searchStrategies
+		at: self searchStrategy
+		ifAbsent: [ self class searchStrategies at: #default ])
+		filterWith: (RxMatcher forString: aFTFilter pattern)
+		dataSource: self
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21721/FastTable-filtering-produces-ByteString-DNU-matchesIn-in-some-examplesThe pattern is passed to the search strategy as a RxMatcher