### PR TITLE
22657-The-closing-of-a-window-using-a-keyboard-can-close-a-window-without-focus

### DIFF
--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -53,7 +53,7 @@ SystemWindow class >> buildShortcutsOn: aBuilder [
 	(aBuilder shortcut: #close)
 		category: #WindowShortcuts
 		default: PharoShortcuts current closeWindowShortcut
-		do: [ :target | target closeWindowAction ]
+		do: [ :target | SystemWindow closeTopWindow ]
 		description: 'Close this window'.
 ]
 


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/22657/The-closing-of-a-window-using-a-keyboard-can-close-a-window-without-focususe different mechanism to close top windows