### PR TITLE
22651-URL-color-is-hardcoded-in-welcome-window

### DIFF
--- a/src/HelpSystem-Core/CustomHelp.class.st
+++ b/src/HelpSystem-Core/CustomHelp.class.st
@@ -267,6 +267,11 @@ CustomHelp class >> subheading: aString [
 
 ]
 
+{ #category : #accessing }
+CustomHelp class >> theme [
+	^ Smalltalk ui theme
+]
+
 { #category : #formatting }
 CustomHelp class >> underlined: aString [
 	"Return Text object with underlined emphasis."
@@ -279,17 +284,15 @@ CustomHelp class >> underlined: aString [
 { #category : #formatting }
 CustomHelp class >> url: aString [
 	"Return Text object with copy aString to the clipboard after mouse click."
-	| color clickBlock |
+	| clickBlock |
 	
 	aString ifEmpty: [ self errorEmptyString ].
-	
-	color := Color fromHexString: '3196D3'.
 	
 	clickBlock := [ WebBrowser openOn: aString ].
 
 	^ aString asText 
 		addAttribute: (	TextAction new actOnClickBlock: clickBlock);
-		addAttribute: (TextColor new color: color);
+		addAttribute: (TextColor new color: self theme urlColor);
 		yourself
 
 ]

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -5898,6 +5898,11 @@ UITheme >> updateWorldDockingBars [
 			borderStyle: (self worldMainDockingBarBorderStyleFor: d)]
 ]
 
+{ #category : #'accessing colors' }
+UITheme >> urlColor [
+	^ Color fromHexString: '03A9F4'
+]
+
 { #category : #'fill-styles-scrollbars' }
 UITheme >> useScrollbarThumbShadow [
 	"Answer whether a shadow morph should be displayed when


### PR DESCRIPTION
Do not hardcode URL color but use theme instead.

I need that for a new Spec presenter.

Fixes https://pharo.fogbugz.com/f/cases/22651/URL-color-is-hardcoded-in-welcome-window