### PR TITLE
22609-When-we-separate-a-tab-from-the-Welcome-window-you-can-not-close-it

### DIFF
--- a/src/Spec-MorphicAdapters/SpecWindow.class.st
+++ b/src/Spec-MorphicAdapters/SpecWindow.class.st
@@ -18,8 +18,9 @@ SpecWindow >> aboutText [
 { #category : #controls }
 SpecWindow >> close [
 
-	self model askOkToClose
-		ifTrue: [ self okToChange ifFalse: [ ^ self ] ].
+	self model ifNotNil: [ :aModel |
+		aModel askOkToClose
+			ifTrue: [ self okToChange ifFalse: [ ^ self ] ] ].
 		
 	super close
 ]


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/22609/When-we-separate-a-tab-from-the-Welcome-window-you-can-not-close-itsafer access to the SpecWindow model