### PR TITLE
22665-NECContextTesttestReceiverTempVar-is-failing-in-64-bit-image

### DIFF
--- a/src/NECompletion-Tests/NECTestClass.class.st
+++ b/src/NECompletion-Tests/NECTestClass.class.st
@@ -38,7 +38,7 @@ NECTestClass class >> initialize [
 { #category : #initialization }
 NECTestClass >> initialize: aRectangle [ 
 	constantInteger := 15.
-	constantLargeInteger := 1073741824.
+	constantLargeInteger := 1152921504606846976. "(SmallInteger maxVal + 1) on 64-bit"
 	constantString := 'Ruben'.
 	constantSymbol := #Symbol.
 	constantArray := #(15 16 17 28 ).


### PR DESCRIPTION
use bigger constant for the large integer in NECTestClass

https://pharo.fogbugz.com/f/cases/22665/NECContextTest-testReceiverTempVar-is-failing-in-64-bit-image