### PR TITLE
22659-generated-artifacts-should-have-the-version-tag (V3)

### DIFF
--- a/bootstrap/scripts/prepare_for_upload.sh
+++ b/bootstrap/scripts/prepare_for_upload.sh
@@ -7,7 +7,7 @@ set -o xtrace
 
 #Get the hash of the built image
 
-#ESTEBAN: This is maybe wrong
+PHARO_NAME_PREFIX=$(find . -name Pharo*.zip | head -n 1 | cut -d'/' -f 2 | cut -d'-' -f 1-2)
 HASH=$(find ${PHARO_NAME_PREFIX}-32bit-*.zip | head -n 1 | cut -d '-' -f 3 | cut -d '.' -f 1)
 FULL_IMAGE_NAME32="${PHARO_NAME_PREFIX}-32bit-${HASH}.zip"
 FULL_IMAGE_NAME64="${PHARO_NAME_PREFIX}-64bit-${HASH}.zip"


### PR DESCRIPTION
fix prepare for upload