### PR TITLE
22669-UFFI-structures-are-not-recalculated-on-system-startup

### DIFF
--- a/src/UnifiedFFI/FFIExternalStructure.class.st
+++ b/src/UnifiedFFI/FFIExternalStructure.class.st
@@ -9,6 +9,9 @@ I extend my parent functionality by adding:
 Class {
 	#name : #FFIExternalStructure,
 	#superclass : #ExternalStructure,
+	#classVars : [
+		'LastCompilationPlatform'
+	],
 	#classInstVars : [
 		'externalStructureAlignment'
 	],
@@ -180,6 +183,15 @@ FFIExternalStructure class >> isNormalAlignedStructure [
 	^ true
 ]
 
+{ #category : #accessing }
+FFIExternalStructure class >> nestedStructures [
+
+	"Retuns the direct nested structures of this structure"
+	^ self fieldSpec types
+		select: [ :each | each isExternalStructure and: [ each isPointer not ] ]
+		thenCollect: [ :each | each objectClass ]
+]
+
 { #category : #private }
 FFIExternalStructure class >> offsetFieldPrefix [
 	^ 'OFFSET'
@@ -219,6 +231,39 @@ FFIExternalStructure class >> removeAllOffsetVariables [
 
 { #category : #'class management' }
 FFIExternalStructure class >> reset [
+	"Reset this structure and all its nested structures"
+	self resetStructureIfNotIn: Set new
+]
+
+{ #category : #'class management' }
+FFIExternalStructure class >> resetAllStructures [
+	"Reset the offsets of all structures.
+	This is required when there is a platform change since type sizes and padding rules change.
+	
+	Manage nested structures with a recursive approach.
+	Stop recursing using a tracking collection of already reset structures."
+	
+	| alreadyReset currentCompilationPlatform |
+	currentCompilationPlatform := { OSPlatform current family . Smalltalk vm wordSize }.
+	LastCompilationPlatform = currentCompilationPlatform
+		ifTrue: [ ^ self ].
+	
+	LastCompilationPlatform := currentCompilationPlatform.
+	alreadyReset := IdentitySet new.
+	self allSubclassesDo: [ :each | each resetStructureIfNotIn: alreadyReset ].
+]
+
+{ #category : #'class management' }
+FFIExternalStructure class >> resetStructureIfNotIn: alreadyReset [
+	"Reset myself by recompiling all my fields.
+	
+	Reset all my nested structures recursively if any.
+	Stop recursing using a tracking collection of already reset structures."
+	(alreadyReset includes: self)
+		ifTrue: [ ^ self ].
+
+	alreadyReset add: self.
+	self nestedStructures do: [ :each | each resetStructureIfNotIn: alreadyReset ].
 	self compileFields.
 ]
 

--- a/src/UnifiedFFI/FFIExternalStructure.class.st
+++ b/src/UnifiedFFI/FFIExternalStructure.class.st
@@ -218,8 +218,8 @@ FFIExternalStructure class >> removeAllOffsetVariables [
 ]
 
 { #category : #'class management' }
-FFIExternalStructure class >> reset [ 
-	compiledSpec := nil
+FFIExternalStructure class >> reset [
+	self compileFields.
 ]
 
 { #category : #accessing }

--- a/src/UnifiedFFI/FFIExternalStructureFieldSpec.class.st
+++ b/src/UnifiedFFI/FFIExternalStructureFieldSpec.class.st
@@ -43,3 +43,8 @@ FFIExternalStructureFieldSpec >> initialize [
 FFIExternalStructureFieldSpec >> typeFor: aString [ 
 	^ fields at: aString
 ]
+
+{ #category : #accessing }
+FFIExternalStructureFieldSpec >> types [
+	^ fields values
+]

--- a/src/UnifiedFFI/FFIExternalStructureType.class.st
+++ b/src/UnifiedFFI/FFIExternalStructureType.class.st
@@ -69,6 +69,12 @@ FFIExternalStructureType >> initializeObjectClass: aClass [
 	self initialize
 ]
 
+{ #category : #testing }
+FFIExternalStructureType >> isExternalStructure [
+
+	^ true
+]
+
 { #category : #accessing }
 FFIExternalStructureType >> objectClass [
 	^ objectClass

--- a/src/UnifiedFFI/FFIExternalType.class.st
+++ b/src/UnifiedFFI/FFIExternalType.class.st
@@ -207,6 +207,12 @@ FFIExternalType >> initialize [
 ]
 
 { #category : #testing }
+FFIExternalType >> isExternalStructure [
+
+	^ false
+]
+
+{ #category : #testing }
 FFIExternalType >> isExternalType [
 	^ true
 ]

--- a/src/UnifiedFFI/FFIMethodRegistry.class.st
+++ b/src/UnifiedFFI/FFIMethodRegistry.class.st
@@ -44,7 +44,7 @@ FFIMethodRegistry class >> resetAll [
 	I am not supposed to be performed when image is just saved to avoid possible problem which can happen when we reset all caches and continue to work"
 	self uniqueInstance reset.
 	FFICallbackFunctionResolution reset.
-	FFIExternalStructure allSubclassesDo: #reset.
+	FFIExternalStructure resetAllStructures.
 	uniqueInstance := nil.
 ]
 


### PR DESCRIPTION
Reset should compile fields, because the compiledSpec field is not then lazily initialized by the instance side.Issue: https://pharo.fogbugz.com/f/cases/22669/UFFI-structures-are-not-recalculated-on-system-startup