### PR TITLE
22668-Contextual-menu-does-not-show-up-when-pressing-Ctrlleft-click-on-Pharo-7

### DIFF
--- a/src/System-VMEvents/InputEventSensor.class.st
+++ b/src/System-VMEvents/InputEventSensor.class.st
@@ -270,10 +270,10 @@ InputEventSensor >> keyboardPressed [
 { #category : #'private events' }
 InputEventSensor >> mapButtons: buttons modifiers: anInteger [
 	"Map the buttons to yellow or blue based on the given modifiers.
-    If only the red button is pressed, then map
-        Ctrl-RedButton -> YellowButtonBit.
-        Cmd-RedButton -> BlueButtonBit.
-    "
+	 If only the red button is pressed, then map
+		Ctrl-RedButton -> YellowButtonBit.
+		Cmd-RedButton -> BlueButtonBit.
+	"
 
 	buttons = RedButtonBit
 		ifFalse: [ ^ buttons ].

--- a/src/System-VMEvents/InputEventSensor.class.st
+++ b/src/System-VMEvents/InputEventSensor.class.st
@@ -270,17 +270,18 @@ InputEventSensor >> keyboardPressed [
 { #category : #'private events' }
 InputEventSensor >> mapButtons: buttons modifiers: anInteger [
 	"Map the buttons to yellow or blue based on the given modifiers.
-	If only the red button is pressed, then map
-		Ctrl-RedButton -> BlueButton.
-		Cmd-RedButton -> YellowButton.
-	"
-	(buttons = RedButtonBit)
-		ifFalse:[^buttons].
-	(anInteger allMask: CtrlKeyBit) 
-		ifTrue:[^BlueButtonBit].
-	(anInteger allMask: CommandKeyBit) 
-		ifTrue:[^YellowButtonBit].
-	^buttons
+    If only the red button is pressed, then map
+        Ctrl-RedButton -> YellowButtonBit.
+        Cmd-RedButton -> BlueButtonBit.
+    "
+
+	buttons = RedButtonBit
+		ifFalse: [ ^ buttons ].
+	(anInteger allMask: CtrlKeyBit)
+		ifTrue: [ ^ YellowButtonBit ].
+	(anInteger allMask: CommandKeyBit)
+		ifTrue: [ ^ BlueButtonBit ].
+	^ buttons
 ]
 
 { #category : #'private events' }


### PR DESCRIPTION
Fixed the regression highlighted by @SergeStinckwich thanks to him.

This was caused by the recent cleanup I did in https://github.com/pharo-project/pharo/pull/1896

Now it works as it was before and I checked the other references to these variables in the shared poll they are all fine.