### PR TITLE
22673-OCNewCompilerWithChangesFunctionalTeststestBlockReturning-is-failing

### DIFF
--- a/src/OpalCompiler-Tests/OCNewCompilerWithChangesFunctionalTests.class.st
+++ b/src/OpalCompiler-Tests/OCNewCompilerWithChangesFunctionalTests.class.st
@@ -19,7 +19,7 @@ OCNewCompilerWithChangesFunctionalTests >> testBlockReturning [
 	bytecode := aCompiledMethod symbolic asString substrings: String cr.
 
 	expected := 	Smalltalk vm 
-		for32bit: '29 <70> self.
+		for32bit: '29 <70> self
 30 <D0> send: announcements
 31 <70> self
 32 <D1> send: index


### PR DESCRIPTION
fix typo in OCNewCompilerWithChangesFunctionalTests>>#testBlockReturninghttps://pharo.fogbugz.com/f/cases/22673/OCNewCompilerWithChangesFunctionalTests-testBlockReturning-is-failing