### PR TITLE
22643-Image-not-opening---portability-

### DIFF
--- a/src/System-SessionManager/SessionManager.class.st
+++ b/src/System-SessionManager/SessionManager.class.st
@@ -174,8 +174,9 @@ SessionManager class >> initializedSessionManager [
 		registerGuiClassNamed: #FT2Handle; "GUI"
 		registerGuiClassNamed: #FreeTypeSettings; "GUI"
 		registerGuiClassNamed: #WorldMorph atPriority: 110; "GUI"
+		"It Should run at the end of everything to correctly handle the errors"
 		registerLast: UIManagerSessionHandler uniqueInstance
-			inCategory: manager guiCategory; "GUi - last"
+			inCategory: manager userCategory; 
 
 		registerToolClassNamed: #CPUWatcher; "Tools"
 		registerToolClassNamed: #NOCCompletionTable; "Tool"
@@ -441,8 +442,12 @@ SessionManager >> snapshot: save andQuit: quit [
 		ifFalse: [ ^ false ].
 	wait := Semaphore new.
 	[ isImageStarting := self launchSnapshot: save andQuit: quit.
-	wait signal ] forkAt: Processor timingPriority - 1.
+	  wait signal. ] forkAt: Processor timingPriority - 1.
 	wait wait.
+	
+	"The execution of the deferred startup actions are executed in the caller thread."
+	self currentSession executeDeferredStartupActions: isImageStarting.
+	
 	^ isImageStarting
 ]
 

--- a/src/System-SessionManager/UIManagerSessionHandler.class.st
+++ b/src/System-SessionManager/UIManagerSessionHandler.class.st
@@ -16,10 +16,10 @@ Class {
 
 { #category : #'initialize-release' }
 UIManagerSessionHandler class >> initialize [
-	"has to be executed at the end of the GUI category"
+	"has to be executed at the end of the user category"
 	SessionManager default 
 		register: self uniqueInstance
-		inCategory: SessionManager default guiCategory 
+		inCategory: SessionManager default userCategory  
 		atPriority: SmallInteger maxVal
 ]
 

--- a/src/System-SessionManager/WorkingSession.class.st
+++ b/src/System-SessionManager/WorkingSession.class.st
@@ -88,7 +88,6 @@ WorkingSession >> runStartup: isImageStarting [
 	self
 		runList: manager startupList
 		do: [ :each | each startup: isImageStarting ].
-	self executeDeferredStartupActions: isImageStarting
 	
 ]
 


### PR DESCRIPTION
Fixing the issue 22643
 - Moving the deferred startup actions after all the startup is done. It also runs in the caller process.
 - Moving the UIManagerSessionHandler, who starts up and shutdowns the UIManager to the end of the startup list.