### PR TITLE
Add pattern to #expandMacros supporting line feeds

### DIFF
--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1138,6 +1138,7 @@ String >> expandMacrosWithArguments: anArray [
 	"'<t>' expandMacros >>> String tab"
 	"'<r>' expandMacros >>> String cr"
 	"'<n>' expandMacros >>> OSPlatform current lineEnding"
+	"'<l>' expandMacros >>> String lf"
 	
 	"Writing '<' character:
 	To write '<', prepend it with a percent sign."
@@ -1166,6 +1167,8 @@ String >> expandMacrosWithArguments: anArray [
 							nextChar := readStream next asUppercase.
 							nextChar == $R
 								ifTrue: [ newStream cr ].
+							nextChar == $L
+								ifTrue: [ newStream lf ].
 							nextChar == $T
 								ifTrue: [ newStream tab ].
 							nextChar == $N

--- a/src/Collections-Tests/StringTest.class.st
+++ b/src/Collections-Tests/StringTest.class.st
@@ -789,14 +789,15 @@ StringTest >> testEquality [
 StringTest >> testExpandMacros [
 
 	self
-		assert: '<t><n><r>' expandMacros
+		assert: '<t><n><r><l>' expandMacros
 		equals:
 			(String
 				streamContents: [ :stream | 
 					stream
 						nextPut: Character tab;
 						nextPutAll: OSPlatform current lineEnding;
-						nextPut: Character cr ])
+						nextPut: Character cr;
+						nextPut: Character lf ])
 ]
 
 { #category : #'tests - formatting' }


### PR DESCRIPTION
Fixes: 
https://pharo.fogbugz.com/f/cases/22674/String-expandMacros-does-not-support-pattern-for-line-feed

Add pattern to #expandMacros supporting line feeds