### PR TITLE
22678-Update-calypso-to-v0130

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -841,7 +841,7 @@ BaselineOfIDE >> loadCalypso [
 
 	Metacello new
 		baseline: 'Calypso';
-		repository: 'github://pharo-ide/Calypso:v0.12.0/src';
+		repository: 'github://pharo-ide/Calypso:v0.13.0/src';
 		onConflict: [ :err | err useIncoming ];
 		onUpgrade: [ :err | err useIncoming ];
 		load: #('FullEnvironment' 'SystemBrowser' 'Tests').


### PR DESCRIPTION
update calypso version to v0.13.0https://pharo.manuscript.com/f/cases/22678/Update-calypso-to-v0-13-0