### PR TITLE
22679-Metacello-attributes-should-be-based-on-SystemVersion-instead-of-hardcoding

### DIFF
--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1130,8 +1130,6 @@ SmalltalkImage >> memoryHogs [
 SmalltalkImage >> metacelloPlatformAttributes [
 	"Returns the tags for the conditional platform loading in Metacello. Pay attention the order is important: from most  to least general."
 
-	"For release integrators, we should not have #'pharo1.3x' **and** #'pharo1.4.x'"
-
 	| attributes systemeVersion |
 	attributes := OrderedCollection withAll: #(#squeakCommon #pharo).
 	systemeVersion := SystemVersion current.

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1132,9 +1132,9 @@ SmalltalkImage >> metacelloPlatformAttributes [
 
 	| attributes systemeVersion |
 	attributes := OrderedCollection withAll: #(#squeakCommon #pharo).
-	systemeVersion := SystemVersion current.
-	attributes add: (String streamContents: [ :stream | stream << 'pharo' << systemeVersion major << '.x' ]) asSymbol.
-	attributes add: (String streamContents: [ :stream | stream << 'pharo' << systemeVersion major << $. << systemeVersion minor << '.x' ]) asSymbol.
+	systemVersion := SystemVersion current.
+	attributes add: (String streamContents: [ :stream | stream << 'pharo' << systemVersion major << '.x' ]) asSymbol.
+	attributes add: (String streamContents: [ :stream | stream << 'pharo' << systemVersion major << $. << systemVersion minor << '.x' ]) asSymbol.
 	^ attributes asArray
 ]
 

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1128,9 +1128,16 @@ SmalltalkImage >> memoryHogs [
 
 { #category : #miscellaneous }
 SmalltalkImage >> metacelloPlatformAttributes [
-    "Returns the tags for the conditional platform loading in Metacello. Pay attention the order is important: from most  to least general." 
-    "For release integrators, we should not have #'pharo1.3x' **and** #'pharo1.4.x'"
-   ^ #(#squeakCommon #pharo #'pharo7.x' #'pharo7.0.x')
+	"Returns the tags for the conditional platform loading in Metacello. Pay attention the order is important: from most  to least general."
+
+	"For release integrators, we should not have #'pharo1.3x' **and** #'pharo1.4.x'"
+
+	| attributes systemeVersion |
+	attributes := OrderedCollection withAll: #(#squeakCommon #pharo).
+	systemeVersion := SystemVersion current.
+	attributes add: (String streamContents: [ :stream | stream << 'pharo' << systemeVersion major << '.x' ]) asSymbol.
+	attributes add: (String streamContents: [ :stream | stream << 'pharo' << systemeVersion major << $. << systemeVersion minor << '.x' ]) asSymbol.
+	^ attributes asArray
 ]
 
 { #category : #'special objects' }


### PR DESCRIPTION
Do not hardcode platform attributes of Metacello.