### PR TITLE
Add AST dump from an existing AST

### DIFF
--- a/src/AST-Core/RBArrayNode.class.st
+++ b/src/AST-Core/RBArrayNode.class.st
@@ -104,6 +104,18 @@ RBArrayNode >> copyInContext: aDictionary [
 	^ self class statements: (self copyList: self statements inContext: aDictionary)
 ]
 
+{ #category : #generation }
+RBArrayNode >> dumpOn: aStream [
+	aStream
+		nextPutAll: self class name;
+		nextPutAll: ' statements: { '.
+	self statements
+		do: [ :each | 
+			each dumpOn: aStream.
+			aStream nextPutAll: '. ' ].
+	aStream nextPut: $}
+]
+
 { #category : #comparing }
 RBArrayNode >> equalTo: anObject withMapping: aDictionary [ 
 	self class = anObject class 

--- a/src/AST-Core/RBAssignmentNode.class.st
+++ b/src/AST-Core/RBAssignmentNode.class.st
@@ -106,6 +106,17 @@ RBAssignmentNode >> directlyUses: aNode [
 	^aNode = value ifTrue: [true] ifFalse: [self isDirectlyUsed]
 ]
 
+{ #category : #generation }
+RBAssignmentNode >> dumpOn: aStream [
+	aStream
+		nextPutAll: self class name;
+		nextPutAll: ' variable: ('.
+	self variable dumpOn: aStream.
+	aStream nextPutAll: ') value: ('.
+	self value dumpOn: aStream.
+	aStream nextPut: $)
+]
+
 { #category : #comparing }
 RBAssignmentNode >> equalTo: anObject withMapping: aDictionary [ 
 	^self class = anObject class and: 

--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -149,6 +149,21 @@ RBBlockNode >> directlyUses: aNode [
 	^false
 ]
 
+{ #category : #generation }
+RBBlockNode >> dumpOn: aStream [
+	aStream nextPutAll: self class name.
+	self arguments
+		ifNotEmpty: [ aStream nextPutAll: ' arguments: {'.
+			self arguments
+				do: [ :each | 
+					each dumpOn: aStream.
+					aStream nextPutAll: '. ' ].
+			aStream nextPutAll: '}' ].
+	aStream nextPutAll: ' body: ('.
+	self body dumpOn: aStream.
+	aStream nextPut: $)
+]
+
 { #category : #comparing }
 RBBlockNode >> equalTo: anObject withMapping: aDictionary [ 
 	self class = anObject class ifFalse: [^false].

--- a/src/AST-Core/RBCascadeNode.class.st
+++ b/src/AST-Core/RBCascadeNode.class.st
@@ -71,6 +71,18 @@ RBCascadeNode >> directlyUses: aNode [
 	^messages last = aNode and: [self isDirectlyUsed]
 ]
 
+{ #category : #generation }
+RBCascadeNode >> dumpOn: aStream [
+	aStream
+		nextPutAll: self class name;
+		nextPutAll: ' messages: {'.
+	self messages
+		do: [ :each | 
+			each dumpOn: aStream.
+			aStream nextPutAll: '. ' ].
+	aStream nextPut: $}
+]
+
 { #category : #comparing }
 RBCascadeNode >> equalTo: anObject withMapping: aDictionary [ 
 	self class = anObject class ifFalse: [^false].

--- a/src/AST-Core/RBLiteralArrayNode.class.st
+++ b/src/AST-Core/RBLiteralArrayNode.class.st
@@ -77,6 +77,15 @@ RBLiteralArrayNode >> copyInContext: aDictionary [
 		isByteArray: isByteArray
 ]
 
+{ #category : #generation }
+RBLiteralArrayNode >> dumpOn: aStream [
+	aStream
+		nextPutAll: self class name;
+		nextPutAll: ' value: #('.
+	(self contents collect: [ :each | each value ]) printOn: aStream delimiter: ' '.
+	aStream nextPutAll: ')'
+]
+
 { #category : #comparing }
 RBLiteralArrayNode >> equalTo: anObject withMapping: aDictionary [ 
 	self class = anObject class ifFalse: [^false].

--- a/src/AST-Core/RBLiteralValueNode.class.st
+++ b/src/AST-Core/RBLiteralValueNode.class.st
@@ -60,10 +60,6 @@ RBLiteralValueNode >> dumpOn: aStream [
 		nextPutAll: self class name;
 		nextPutAll: ' value: '.
 	self value printOn: aStream
-	"aStream nextPutAll: ' start: '.
-	self start printOn: aStream.
-	aStream nextPutAll: ' stop: '.
-	self stop printOn: aStream"
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBLiteralValueNode.class.st
+++ b/src/AST-Core/RBLiteralValueNode.class.st
@@ -54,6 +54,18 @@ RBLiteralValueNode >> copyInContext: aDictionary [
 	^ self class value: self value
 ]
 
+{ #category : #generation }
+RBLiteralValueNode >> dumpOn: aStream [
+	aStream
+		nextPutAll: self class name;
+		nextPutAll: ' value: '.
+	self value printOn: aStream
+	"aStream nextPutAll: ' start: '.
+	self start printOn: aStream.
+	aStream nextPutAll: ' stop: '.
+	self stop printOn: aStream"
+]
+
 { #category : #testing }
 RBLiteralValueNode >> isFaulty [
 	^false

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -119,6 +119,23 @@ RBMessageNode >> debugHighlightStop [
 	^ self stopWithoutParentheses
 ]
 
+{ #category : #generation }
+RBMessageNode >> dumpOn: aStream [
+	aStream
+		nextPutAll: self class name;
+		nextPutAll: ' receiver: ('.
+	self receiver dumpOn: aStream.
+	aStream nextPutAll: ') selector: '.
+	self selector printOn: aStream.
+	self arguments
+		ifNotEmpty: [ aStream nextPutAll: ' arguments: {'.
+			self arguments
+				do: [ :each | 
+					each dumpOn: aStream.
+					aStream nextPutAll: '. ' ].
+			aStream nextPut: $} ]
+]
+
 { #category : #comparing }
 RBMessageNode >> equalTo: anObject withMapping: aDictionary [ 
 	self class = anObject class ifFalse: [^false].

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -235,6 +235,37 @@ RBMethodNode >> defines: aName [
 		or: [ self pragmas anySatisfy: [ :pragma | pragma defines: aName ] ]
 ]
 
+{ #category : #generation }
+RBMethodNode >> dumpOn: aStream [
+	| hasPragmas |
+	hasPragmas := self pragmas isNotEmpty.
+	hasPragmas
+		ifTrue: [ aStream nextPut: $( ].
+	aStream
+		nextPutAll: self class name;
+		nextPutAll: ' selector: '.
+	self selector printOn: aStream.
+	self arguments
+		ifNotEmpty: [ aStream nextPutAll: ' arguments: {'.
+			self arguments
+				do: [ :each | 
+					each dumpOn: aStream.
+					aStream nextPutAll: '. ' ].
+			aStream nextPut: $} ].
+	self body
+		ifNotNil: [ aStream nextPutAll: ' body: ('.
+			self body dumpOn: aStream.
+			aStream nextPut: $) ].
+	hasPragmas
+		ifFalse: [ ^ self ].
+	aStream nextPutAll: ') pragmas: {'.
+	self pragmas
+		do: [ :each | 
+			each dumpOn: aStream.
+			aStream nextPutAll: '. ' ].
+	aStream nextPut: $}
+]
+
 { #category : #comparing }
 RBMethodNode >> equalTo: anObject withMapping: aDictionary [ 
 	self class = anObject class ifFalse: [ ^ false ].

--- a/src/AST-Core/RBPragmaNode.class.st
+++ b/src/AST-Core/RBPragmaNode.class.st
@@ -94,6 +94,20 @@ RBPragmaNode >> defines: aName [
 	^ self isPrimitive and: [ arguments anySatisfy: [ :each | each value = aName ] ]
 ]
 
+{ #category : #accessing }
+RBPragmaNode >> dumpOn: aStream [
+	aStream
+		nextPutAll: self class name;
+		nextPutAll: ' selector: '.
+	self selector printOn: aStream.
+	aStream nextPutAll: ' arguments: {'.
+	self arguments
+		do: [ :each | 
+			each dumpOn: aStream.
+			aStream nextPutAll: '. ' ].
+	aStream nextPut: $}
+]
+
 { #category : #comparing }
 RBPragmaNode >> equalTo: anObject withMapping: aDictionary [ 
 	self class = anObject class ifFalse: [ ^ false ].

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -296,6 +296,16 @@ RBProgramNode >> do: aBlock [
 	aBlock value: self
 ]
 
+{ #category : #generation }
+RBProgramNode >> dump [
+	^  String streamContents: [:s | self dumpOn: s]
+]
+
+{ #category : #generation }
+RBProgramNode >> dumpOn: aStream [
+	self subclassResponsibility 
+]
+
 { #category : #comparing }
 RBProgramNode >> equalTo: aNode exceptForVariables: variableNameCollection [ 
 	| dictionary |

--- a/src/AST-Core/RBReturnNode.class.st
+++ b/src/AST-Core/RBReturnNode.class.st
@@ -56,6 +56,15 @@ RBReturnNode >> copyInContext: aDictionary [
 		yourself
 ]
 
+{ #category : #accessing }
+RBReturnNode >> dumpOn: aStream [
+	aStream
+		nextPutAll: self class name;
+		nextPutAll: ' value: ('.
+	self value dumpOn: aStream.
+	aStream nextPut: $)
+]
+
 { #category : #comparing }
 RBReturnNode >> equalTo: anObject withMapping: aDictionary [ 
 	^self class = anObject class 

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -228,6 +228,24 @@ RBSequenceNode >> directlyUses: aNode [
 	^false
 ]
 
+{ #category : #generation }
+RBSequenceNode >> dumpOn: aStream [
+	aStream nextPutAll: self class name.
+	self temporaries
+		ifNotEmpty: [ aStream nextPutAll: ' temporaries: {'.
+			self temporaries
+				do: [ :each | 
+					each dumpOn: aStream.
+					aStream nextPutAll: '. ' ].
+			aStream nextPut: $} ].
+	aStream nextPutAll: ' statements: {'.
+	self statements
+		do: [ :each | 
+			each dumpOn: aStream.
+			aStream nextPutAll: '. ' ].
+	aStream nextPut: $}
+]
+
 { #category : #comparing }
 RBSequenceNode >> equalTo: anObject withMapping: aDictionary [ 
 	self class = anObject class ifFalse: [^false].

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -68,6 +68,14 @@ RBVariableNode >> copyInContext: aDictionary [
 	^ self class named: name.
 ]
 
+{ #category : #generation }
+RBVariableNode >> dumpOn: aStream [
+	aStream
+		nextPutAll: self class name;
+		nextPutAll: ' named: '.
+	self name printOn: aStream
+]
+
 { #category : #comparing }
 RBVariableNode >> equalTo: anObject withMapping: aDictionary [ 
 	^self class = anObject class and: 

--- a/src/AST-Tests-Core/RBDumpNodeTest.class.st
+++ b/src/AST-Tests-Core/RBDumpNodeTest.class.st
@@ -1,0 +1,330 @@
+"
+SUnit tests for the #dump and #dumpOn: methods on RBProgramNodes
+"
+Class {
+	#name : #RBDumpNodeTest,
+	#superclass : #TestCase,
+	#category : #'AST-Tests-Core'
+}
+
+{ #category : #tests }
+RBDumpNodeTest >> testArrayNodeDump [
+	| node dumpedNode |
+	"Empty Array"
+	node := RBParser parseExpression: '{}'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBArrayNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	"non-empty Array"
+	node := RBParser parseExpression: '{1 + 1. true. Object new}'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBArrayNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testAssignmentNodeDump [
+	| node dumpedNode |
+	node := RBParser parseExpression: 'a := 3.'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBAssignmentNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testBlockNodeDump [
+	| node dumpedNode |
+	"Simple block"
+	node := RBParser parseExpression: '[self]'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBBlockNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	"Block with argument"
+	node := RBParser parseExpression: '[:each | each]'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBBlockNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	"Block with arguments and temps"
+	node := RBParser parseExpression: '[:each :i | |a b| a := each. b := i.]'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBBlockNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testCascadeNodeDump [
+	| node dumpedNode |
+	node := RBParser parseExpression: 'self foo; bar'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBCascadeNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testDumpOnObjectMethod [
+	| node dumpedNode |
+	node := (Object>>#readSlot:) ast.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBMethodNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	
+	
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testDumpOnSelfClassMethods [
+	| methods node dumpedNode |
+	methods := {(self class >> #testAssignmentNodeDump).
+	(self class >> #uselessMethod).
+	(self class >> #testVariableNodeDump).
+	(self class >> #testThisContextNodeDump).
+	(self class >> #testReturnNodeDump)}.
+	methods
+		do: [ :each | 
+			node := each ast.
+			dumpedNode := Smalltalk compiler evaluate: node dump.
+			self assert: dumpedNode class equals: RBMethodNode.
+			self assert: node class equals: dumpedNode class.
+			self assert: node formattedCode equals: dumpedNode printString ]
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testGlobalNodeDump [
+	| node dumpedNode |
+	"Global nodes are only generated when a semantic analysis is triggered on a method"
+	node := RBParser parseMethod: 'foo ^ Object'.
+	dumpedNode := Smalltalk compiler evaluate: node doSemanticAnalysis dump.
+	
+	self assert: dumpedNode statements first value class equals: RBGlobalNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testLiteralArrayNodeDump [
+	| node dumpedNode |
+	node := RBParser parseExpression: '#(1 $a true ''a'')'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBLiteralArrayNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testLiteralValueNodeDump [
+	| node dumpedNode |
+	"Numeric are literals"
+	node := RBParser parseExpression: '1'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBLiteralValueNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	"Symbol are literals"
+	node := RBParser parseExpression: '#foo'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBLiteralValueNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	"Booleans are literals"
+	node := RBParser parseExpression: 'true'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBLiteralValueNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	"char are literals"
+	node := RBParser parseExpression: '$a'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBLiteralValueNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	"String are literals"
+	node := RBParser parseExpression: '''a'''.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBLiteralValueNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testMessageNodeDump [
+	| node dumpedNode |
+	"Simple selector"
+	node := RBParser parseExpression: 'self foo'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBMessageNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	"With an argument"
+	node := RBParser parseExpression: 'self foo: 1'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBMessageNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	"With many arguments"
+	node := RBParser parseExpression: 'self foo: 1 bar: 2'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBMessageNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	"Binary message"
+	node := RBParser parseExpression: '1 + 2'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBMessageNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testMethodNodeDump [
+	| node dumpedNode |
+	node := RBParser parseMethod: 'foo <useless>'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBMethodNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	
+	
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testPragmaNodeDump [
+	| node dumpedNode |
+	node := RBParser parseMethod: 'foo <useless>'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode pragmas first class equals: RBPragmaNode. 
+	self assert: node pragmas first class equals: dumpedNode pragmas first class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	
+	
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testReturnNodeDump [
+	| node dumpedNode |
+	node := RBParser parseExpression: '^ 1 + 1'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBReturnNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	
+	
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testSelfNodeDump [
+	| node dumpedNode |
+	node := RBParser parseExpression: 'self'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBSelfNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testSequenceNodeDump [
+	| node dumpedNode |
+	node := RBParser parseExpression: 'foo. bar.'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBSequenceNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+	
+	
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testSuperNodeDump [
+	| node dumpedNode |
+	node := RBParser parseExpression: 'super'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBSuperNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testThisContextNodeDump [
+	| node dumpedNode |
+	node := RBParser parseExpression: 'thisContext'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBThisContextNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> testVariableNodeDump [
+	| node dumpedNode |
+	node := RBParser parseExpression: 'a'.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	
+	self assert: dumpedNode class equals: RBVariableNode. 
+	self assert: node class equals: dumpedNode class.
+	self assert: node printString equals: dumpedNode printString.
+	
+]
+
+{ #category : #tests }
+RBDumpNodeTest >> uselessMethod [
+	<useless>
+	
+]

--- a/src/GT-InspectorExtensions-Core/RBProgramNode.extension.st
+++ b/src/GT-InspectorExtensions-Core/RBProgramNode.extension.st
@@ -1,6 +1,15 @@
 Extension { #name : #RBProgramNode }
 
 { #category : #'*GT-InspectorExtensions-Core' }
+RBProgramNode >> gtInspectorASTDumpIn: composite [
+	<gtInspectorPresentationOrder: 50>
+	
+	^ composite pharoMethod
+		title: [ 'AST Dump' translated ];
+		display: [ (RBParser parseExpression: self dump) formattedCode ]
+]
+
+{ #category : #'*GT-InspectorExtensions-Core' }
 RBProgramNode >> gtInspectorSourceCodeIn: composite [
 	<gtInspectorPresentationOrder: 30> 
 


### PR DESCRIPTION
The AST dump gives the set of constructors required in order to programmatically create an existing AST.  This dump can be asked to any AST node:

```smalltalk
(RBParser parseExpression: '[ 1 + 1 ] value') dump.
```
returns:

```smalltalk
RBMessageNode
    receiver:
        (RBBlockNode
            body:
                (RBSequenceNode
                    statements:
                         {(RBMessageNode
                             receiver: (RBLiteralValueNode value: 1)
                             selector: #+
                            arguments: {(RBLiteralValueNode value: 1)})}))
    selector: #value
```
	
An inspector view for AST nodes is also provided.