### PR TITLE
22684-testNoUnusedTemporaryVariablesLeft-uses-all-CompiledMethod-instances

### DIFF
--- a/src/ReleaseTests/NoUnusedTemporaryVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedTemporaryVariablesLeftTest.class.st
@@ -23,7 +23,7 @@ NoUnusedTemporaryVariablesLeftTest >> tearDown [
 NoUnusedTemporaryVariablesLeftTest >> testNoUnusedTemporaryVariablesLeft [
 	"Fail if there are methods who have unused temporary variables"
 	| found validExceptions remaining |
-	found := CompiledMethod allInstances
+	found := (SystemNavigation default allBehaviors flatCollect: #localMethods)
 		select: [ :m | m ast temporaries anySatisfy: [ :x | x binding isUnused ] ].
 	
 	"No other exceptions beside the ones mentioned here should be allowed"	


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/22684/testNoUnusedTemporaryVariablesLeft-uses-all-CompiledMethod-instancesuse all installed localMethods instead of all compiled method instances