### PR TITLE
Fix the layout of Glamour tabulator rows and columns in the presence …

### DIFF
--- a/src/Glamour-Morphic-Renderer/GLMMorphicTabulatorRenderer.class.st
+++ b/src/Glamour-Morphic-Renderer/GLMMorphicTabulatorRenderer.class.st
@@ -32,8 +32,9 @@ GLMMorphicTabulatorRenderer >> render: aBrowser [
 
 { #category : #private }
 GLMMorphicTabulatorRenderer >> renderCustomColumn: aCell ofPane: aPane inUI: aMorph inBrowser: aBrowser [
-	| pane totalSpans currentSpanPosition currentOffset |
+	| pane totalSpans totalSizes currentSpanPosition currentOffset |
 	totalSpans := aCell children inject: 0 into: [ :sum :each | sum + each span ].
+	totalSizes := aCell children inject: 0 into: [ :sum :each | sum + each size ].
 	currentSpanPosition := 0.
 	currentOffset := 0.
 	aCell children
@@ -51,9 +52,11 @@ GLMMorphicTabulatorRenderer >> renderCustomColumn: aCell ofPane: aPane inUI: aMo
 			pane
 				layoutFrame:
 					(LayoutFrame new
-						topFraction: currentSpanPosition / totalSpans offset: currentOffset + self margin;
+						topFraction: currentSpanPosition / totalSpans
+							offset: currentOffset - (totalSizes * currentSpanPosition / totalSpans) rounded + self margin;
 						leftFraction: 0 offset: 0;
-						bottomFraction: (currentSpanPosition + each span) / totalSpans offset: currentOffset + each size - self margin;
+						bottomFraction: (currentSpanPosition + each span) / totalSpans
+							offset: currentOffset + each size - (totalSizes * (currentSpanPosition + each span) / totalSpans) rounded - self margin;
 						rightFraction: 1 offset: 0;
 						yourself).
 			aMorph addMorphBack: pane.
@@ -71,8 +74,9 @@ GLMMorphicTabulatorRenderer >> renderCustomColumn: aCell ofPane: aPane inUI: aMo
 
 { #category : #private }
 GLMMorphicTabulatorRenderer >> renderCustomRow: aCell ofPane: aPane inUI: aMorph inBrowser: aBrowser [ 
-	| pane totalSpans currentSpanPosition currentOffset |
+	| pane totalSpans totalSizes currentSpanPosition currentOffset |
 	totalSpans := aCell children inject: 0 into: [ :sum :each | sum + each span ].
+	totalSizes := aCell children inject: 0 into: [ :sum :each | sum + each size ].
 	currentSpanPosition := 0.
 	currentOffset := 0.
 	aCell children keysAndValuesDo: [ :index :each | 
@@ -88,9 +92,11 @@ GLMMorphicTabulatorRenderer >> renderCustomRow: aCell ofPane: aPane inUI: aMorph
 				pane addPaneSplitters ].
 		pane layoutFrame: (LayoutFrame new
 				topFraction: 0 offset: 0;
-				leftFraction: currentSpanPosition / totalSpans offset: currentOffset + self margin;
+				leftFraction: currentSpanPosition / totalSpans
+					offset: currentOffset - (totalSizes * currentSpanPosition / totalSpans) rounded + self margin;
 				bottomFraction: 1 offset: 0;
-				rightFraction: (currentSpanPosition + each span) / totalSpans offset: currentOffset + each size - self margin;
+				rightFraction: (currentSpanPosition + each span) / totalSpans
+					offset: currentOffset + each size - (totalSizes * (currentSpanPosition + each span) / totalSpans) rounded - self margin;
 				yourself).
 		aMorph addMorphBack: pane.
 		currentSpanPosition := currentSpanPosition + each span.

--- a/src/Glamour-Tests-Morphic/GLMTabulatorMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMTabulatorMorphicTest.class.st
@@ -26,7 +26,7 @@ GLMTabulatorMorphicTest >> testMultipleInitialSelection [
 GLMTabulatorMorphicTest >> testSizeAndSpan [
 	"combining span (=fractional width/height) and size (=fixed width/height) did not work correctly before.
 	2 is added in height comparisons because the layout code leaves one pixel offset on top and bottom."
-	| browser panes |
+	| browser panes heights |
 	browser := GLMTabulator new.
 	browser row: #top span: 2.
 	browser row: #middle size: 80.
@@ -35,16 +35,16 @@ GLMTabulatorMorphicTest >> testSizeAndSpan [
 	browser transmit to: #middle; transformation: #second; andShow: [ :p | p text ].
 	browser transmit to: #bottom; transformation: #last; andShow: [ :p | p text ].
 	window := browser openOn: #('Should be scaled at 2/3' 'Should be fixed' 'Should be scaled at 1/3').
-	World doOneCycle.
-	panes := window submorphs last submorphs last: 3.
-	self assert: panes second height + 2 equals: 80.
-	self assert: ((panes last height + 2) / (panes first height + 2) - 0.5) abs < 0.01.
-	self assert: panes last bottom < panes last owner bottom.
-	window extent: 100@300.
-	self assert: panes second height + 2 equals: 80.
-	self assert: ((panes last height + 2) / (panes first height + 2) - 0.5) abs < 0.01.
-	self assert: panes last bottom < panes last owner bottom
-	
+	{window extent. 100@400} do: [:ext |
+		window extent: ext.
+		World doOneCycle.
+		panes := window submorphs last submorphs last: 3.
+		heights := panes collect: [ :each | each height+2 ].
+		self assert: panes first owner height equals: heights sum.
+		self assert: panes last bottom + 1 equals: panes first owner bottom.
+		self assert: heights second equals: 80.
+		self assert: (heights first - (heights sum - 80 / 3 * 2)) abs <= 1.
+		self assert: (heights last - (heights sum - 80 / 3)) abs <= 1]
 ]
 
 { #category : #tests }

--- a/src/Glamour-Tests-Morphic/GLMTabulatorMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMTabulatorMorphicTest.class.st
@@ -35,7 +35,7 @@ GLMTabulatorMorphicTest >> testSizeAndSpan [
 	browser transmit to: #middle; transformation: #second; andShow: [ :p | p text ].
 	browser transmit to: #bottom; transformation: #last; andShow: [ :p | p text ].
 	window := browser openOn: #('Should be scaled at 2/3' 'Should be fixed' 'Should be scaled at 1/3').
-	{window extent. 100@400} do: [:ext |
+	{200@500. 100@300} do: [:ext |
 		window extent: ext.
 		World doOneCycle.
 		panes := window submorphs last submorphs last: 3.

--- a/src/Glamour-Tests-Morphic/GLMTabulatorMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMTabulatorMorphicTest.class.st
@@ -23,6 +23,31 @@ GLMTabulatorMorphicTest >> testMultipleInitialSelection [
 ]
 
 { #category : #tests }
+GLMTabulatorMorphicTest >> testSizeAndSpan [
+	"combining span (=fractional width/height) and size (=fixed width/height) did not work correctly before.
+	2 is added in height comparisons because the layout code leaves one pixel offset on top and bottom."
+	| browser panes |
+	browser := GLMTabulator new.
+	browser row: #top span: 2.
+	browser row: #middle size: 80.
+	browser row: #bottom.
+	browser transmit to: #top; transformation: #first; andShow: [ :p | p text ].
+	browser transmit to: #middle; transformation: #second; andShow: [ :p | p text ].
+	browser transmit to: #bottom; transformation: #last; andShow: [ :p | p text ].
+	window := browser openOn: #('Should be scaled at 2/3' 'Should be fixed' 'Should be scaled at 1/3').
+	World doOneCycle.
+	panes := window submorphs last submorphs last: 3.
+	self assert: panes second height + 2 equals: 80.
+	self assert: ((panes last height + 2) / (panes first height + 2) - 0.5) abs < 0.01.
+	self assert: panes last bottom < panes last owner bottom.
+	window extent: 100@300.
+	self assert: panes second height + 2 equals: 80.
+	self assert: ((panes last height + 2) / (panes first height + 2) - 0.5) abs < 0.01.
+	self assert: panes last bottom < panes last owner bottom
+	
+]
+
+{ #category : #tests }
 GLMTabulatorMorphicTest >> testSpawnTabulator [
 
 	| browser |


### PR DESCRIPTION
…of fixed-size panes.

Note: resizing with splitter still does not work correctly, there's more work to be done there.