### PR TITLE
22690-32-vs-64-bits-and-large-integer-hash

### DIFF
--- a/src/Kernel/LargeInteger.class.st
+++ b/src/Kernel/LargeInteger.class.st
@@ -238,10 +238,9 @@ LargeInteger >> digitLength [
 
 { #category : #comparing }
 LargeInteger >> hash [
-
-	^ByteArray
-		hashBytes: self
-		startingWith: self species hash
+	^ self digitLength <= 8
+		ifTrue: [ self ]
+		ifFalse: [ ByteArray hashBytes: self startingWith: self species hash ]
 ]
 
 { #category : #'bit manipulation' }


### PR DESCRIPTION
32 vs 64 bits and large integer hash
https://pharo.fogbugz.com/f/cases/22690/32-vs-64-bits-and-large-integer-hash