### PR TITLE
22691-Adopt-file-names-following-branch-tag-convention

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,20 @@ def isWindows(){
     return env.NODE_LABELS.toLowerCase().contains('windows')
 }
 
+// Answers if we are in a development branch (we assume is a development branch if it starts with "Pharo")
+def isDevelopmentBranch() {
+	def branchName =  env.BRANCH_NAME 
+	def baseName = branchName.substring(1, 5)
+	
+	return baseName == "Pharo"
+}
+
+// Extracts Pharo version from the development branch (if it is "Pharo7.0" it will answer "7.0")
+def getPharoVersionFromBranch() {
+	def branchName =  env.BRANCH_NAME 
+	return branchName.substring(6)
+}
+
 def shell(params){
     if(isWindows()) bat(params) 
     else sh(params)
@@ -38,9 +52,9 @@ def notifyBuild(status){
   if (env.CHANGE_ID != null){
     buildKind = "PR ${env.CHANGE_ID}"
   }
-  if( env.BRANCH_NAME == "development" ) {
+  if( isDevelopmentBranch() ) {
     toMail = "pharo-dev@lists.pharo.org"
-    buildKind = "7.0-dev"
+    buildKind = getPharoVersionFromBranch()
   }
   
   //We checkout scm to have access to the log information
@@ -89,13 +103,17 @@ Build Url: ${env.BUILD_URL}
 """
 
   // If we are building development, add information about the uploads
-  if( env.BRANCH_NAME == "development" ) {
+  /* ESTEBAN: Let this out for now (I don't know how to get tag version)
+  if( isDevelopmentBranch() ) {
+  	//def pharoVersion = 
+	//def pharoShortVersion = 
+  
   """"
 Check for latest built images in http://files.pharo.org:
- - http://files.pharo.org/images/70/Pharo-7.0.0-alpha.build.${env.BUILD_NUMBER}.sha.${logSHA}.arch.32bit.zip
- - http://files.pharo.org/images/70/Pharo-7.0.0-alpha.build.${env.BUILD_NUMBER}.sha.${logSHA}.arch.64bit.zip
+ - http://files.pharo.org/images/${pharoShortVersion}/${pharoVersion}.build.${env.BUILD_NUMBER}.sha.${logSHA}.arch.32bit.zip
+ - http://files.pharo.org/images/${pharoShortVersion}/${pharoVersion}.build.${env.BUILD_NUMBER}.sha.${logSHA}.arch.64bit.zip
 """
-  }
+  } */
   mail to: toMail, cc: 'guillermopolito@gmail.com', subject: "[Pharo ${buildKind}] Build #${env.BUILD_NUMBER}: ${title}", body: body
   } catch (e) {
     //If there is an error during mail send, just print it and continue
@@ -142,7 +160,7 @@ def bootstrapImage(){
         }
       }
   
-      if( env.BRANCH_NAME == "development" ) {
+      if( isDevelopmentBranch() ) {
         stage("Upload to files.pharo.org") {
           dir("bootstrap-cache") {
               shell "BUILD_NUMBER=${env.BUILD_ID} bash ../bootstrap/scripts/prepare_for_upload.sh"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,18 +102,6 @@ ${mailMessage}
 Build Url: ${env.BUILD_URL}
 """
 
-  // If we are building development, add information about the uploads
-  /* ESTEBAN: Let this out for now (I don't know how to get tag version)
-  if( isDevelopmentBranch() ) {
-  	//def pharoVersion = 
-	//def pharoShortVersion = 
-  
-  """"
-Check for latest built images in http://files.pharo.org:
- - http://files.pharo.org/images/${pharoShortVersion}/${pharoVersion}.build.${env.BUILD_NUMBER}.sha.${logSHA}.arch.32bit.zip
- - http://files.pharo.org/images/${pharoShortVersion}/${pharoVersion}.build.${env.BUILD_NUMBER}.sha.${logSHA}.arch.64bit.zip
-"""
-  } */
   mail to: toMail, cc: 'guillermopolito@gmail.com', subject: "[Pharo ${buildKind}] Build #${env.BUILD_NUMBER}: ${title}", body: body
   } catch (e) {
     //If there is an error during mail send, just print it and continue

--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -8,11 +8,7 @@ set -e
 SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 . ${SCRIPTS}/envvars.sh
 
-if [ $(is_version) == 1 ]; then
-    PHARO_NAME_PREFIX=${PHARO_VERSION_PREFIX}
-else
-    PHARO_NAME_PREFIX=${PHARO_SNAPSHOT_PREFIX}
-fi
+set_version_variables
 
 # A POSIX variable
 OPTIND=1         # Reset in case getopts has been used previously in the shell.

--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -8,6 +8,12 @@ set -e
 SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 . ${SCRIPTS}/envvars.sh
 
+if [ $(is_version) == 1 ]; then
+    PHARO_NAME_PREFIX=${PHARO_VERSION_PREFIX}
+else
+    PHARO_NAME_PREFIX=${PHARO_SNAPSHOT_PREFIX}
+fi
+
 # A POSIX variable
 OPTIND=1         # Reset in case getopts has been used previously in the shell.
 

--- a/bootstrap/scripts/envversion.sh
+++ b/bootstrap/scripts/envversion.sh
@@ -5,8 +5,22 @@
 # - current image version prefix, e.g. "Pharo7.0.0-rc1"
 # - vm version for the current image, to be used to download the correct vm, e.g. "70"
 
+# Versions are taken from tags. Tag should have a format like vMAJOR.MINOR.PATCH[-EXTRA], e.g. v7.0.0-rc1
+PHARO_VERSION_PREFIX="Pharo`git describe --long --tags | cut -d'-' -f 1-2 | cut -c 2-`"
+# Snapshots are taken from branchs. Branchs should be named dev-MAJOR.MINOR (example: dev-7.0)
+PHARO_SNAPSHOT_PREFIX="Pharo`git branch | grep \* | cut -d' ' -f 2 | cut -d'-' -f 2`-SNAPSHOT"
 
-PHARO_NAME_PREFIX="Pharo`git describe --long --tags | cut -d'-' -f 1-2 | cut -c 2-`"
-PHARO_SHORT_VERSION=`git describe --long --tags | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-2 | sed 's/\.//'`
+PHARO_SHORT_VERSION=`git branch | grep \* | cut -d' ' -f 2 | cut -d'-' -f 2 | sed 's/\.//'`
 # this is just to make things clear (and because they could change in the future, who knows :P)
 PHARO_VM_VERSION="${PHARO_SHORT_VERSION}"
+
+# use this to know if we are in a version or a SNAPSHOT
+function is_version() {
+	set -f
+	local versionTag=$(git tag --list --points-at HEAD | grep -E "^v[0-9]+\.[0-9]+.[0-9]+(\-[a-zA-Z0-9_]+)?$")
+    if [ "${versionTag}" == "" ]; then
+        echo 0
+    else
+        echo 1
+    fi
+}

--- a/bootstrap/scripts/envversion.sh
+++ b/bootstrap/scripts/envversion.sh
@@ -46,7 +46,7 @@ function set_version_variables() {
 	else
 		# I'm not development build, I should be a PR
 		# HACK: Since this is a PR branch, I do not have all information I need. I assume I will have a tag indicating Pharo version.
-		PHARO_NAME_PREFIX="Pharo$(git describe --long --tags | cut -d'-' -f 1 | cut -c 2-)-PR"
+		PHARO_NAME_PREFIX="Pharo$(git describe --long --tags | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-2)-PR"
 		PHARO_SHORT_VERSION="$(git describe --long --tags | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-2 | sed 's/\.//')"
 	fi
 	

--- a/bootstrap/scripts/envversion.sh
+++ b/bootstrap/scripts/envversion.sh
@@ -50,10 +50,10 @@ function set_version_snapshot_variables() {
 function set_version_pull_request_variables() {
 	# I'm not development build, I should be a PR
 	# HACK: Since this is a PR branch, I do not have all information I need. I assume I will have a tag indicating Pharo version.
-	# This is same as with 'set_version_release_variables' so I use the function.
-	set_version_release_variables
-	# And I modify name to substract any -EXTRA info we have and to reflect the fact we are in a Pull request
-	PHARO_NAME_PREFIX="$(echo ${PHARO_NAME_PREFIX} | cut -d'-' -f 1)-PR"
+	# This will answer "Pharo7.0-PR"
+	PHARO_NAME_PREFIX="Pharo$(git describe --long --tags | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-2)-PR"
+	# This will answer "70"
+	PHARO_SHORT_VERSION="$(git describe --long --tags | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-2 | sed 's/\.//')"
 }
 
 # sets all variables

--- a/bootstrap/scripts/envversion.sh
+++ b/bootstrap/scripts/envversion.sh
@@ -6,11 +6,11 @@
 # - vm version for the current image, to be used to download the correct vm, e.g. "70"
 
 # Versions are taken from tags. Tag should have a format like vMAJOR.MINOR.PATCH[-EXTRA], e.g. v7.0.0-rc1
-PHARO_VERSION_PREFIX="Pharo`git describe --long --tags | cut -d'-' -f 1-2 | cut -c 2-`"
+PHARO_VERSION_PREFIX="Pharo$(git describe --long --tags | cut -d'-' -f 1-2 | cut -c 2-)"
 # Snapshots are taken from branchs. Branchs should be named dev-MAJOR.MINOR (example: dev-7.0)
-PHARO_SNAPSHOT_PREFIX="Pharo`git branch | grep \* | cut -d' ' -f 2 | cut -d'-' -f 2`-SNAPSHOT"
+PHARO_SNAPSHOT_PREFIX="Pharo$(git branch | grep \* | cut -d' ' -f 2 | cut -d'-' -f 2)-SNAPSHOT"
 
-PHARO_SHORT_VERSION=`git branch | grep \* | cut -d' ' -f 2 | cut -d'-' -f 2 | sed 's/\.//'`
+PHARO_SHORT_VERSION=$(git branch | grep \* | cut -d' ' -f 2 | cut -d'-' -f 2 | sed 's/\.//')
 # this is just to make things clear (and because they could change in the future, who knows :P)
 PHARO_VM_VERSION="${PHARO_SHORT_VERSION}"
 

--- a/bootstrap/scripts/envversion.sh
+++ b/bootstrap/scripts/envversion.sh
@@ -5,17 +5,8 @@
 # - current image version prefix, e.g. "Pharo7.0.0-rc1"
 # - vm version for the current image, to be used to download the correct vm, e.g. "70"
 
-# Versions are taken from tags. Tag should have a format like vMAJOR.MINOR.PATCH[-EXTRA], e.g. v7.0.0-rc1
-PHARO_VERSION_PREFIX="Pharo$(git describe --long --tags | cut -d'-' -f 1-2 | cut -c 2-)"
-# Snapshots are taken from branchs. Branchs should be named dev-MAJOR.MINOR (example: dev-7.0)
-PHARO_SNAPSHOT_PREFIX="Pharo$(git branch | grep \* | cut -d' ' -f 2 | cut -d'-' -f 2)-SNAPSHOT"
-
-PHARO_SHORT_VERSION=$(git branch | grep \* | cut -d' ' -f 2 | cut -d'-' -f 2 | sed 's/\.//')
-# this is just to make things clear (and because they could change in the future, who knows :P)
-PHARO_VM_VERSION="${PHARO_SHORT_VERSION}"
-
-# use this to know if we are in a version or a SNAPSHOT
-function is_version() {
+# answers if we are in a release commit (tagged with vMAJOR.MINOR.PATCH[-EXTRA])
+function is_release_build() {
 	set -f
 	local versionTag=$(git tag --list --points-at HEAD | grep -E "^v[0-9]+\.[0-9]+.[0-9]+(\-[a-zA-Z0-9_]+)?$")
     if [ "${versionTag}" == "" ]; then
@@ -24,3 +15,41 @@ function is_version() {
         echo 1
     fi
 }
+
+# answers if we are in development branch
+function is_development_build() {
+	set -f 
+	local branchName=$(git branch | grep \* | cut -d' ' -f 2 | grep -E "^dev-[0-9]+\.[0-9]+\$")
+	if [ "${branchName}" == "" ]; then
+		echo 0
+	else
+		echo 1
+	fi
+}
+
+# sets all variables
+# PHARO_NAME_PREFIX -> Prefix to name the buids (Pharo7.0.0-rc1, Pharo7.0-SNAPSHOT, Pharo7.0.0-PR)
+# PHARO_SHORT_VERSION -> Short version of the image (70, 80, etc.)
+# PHARO_VM_VERSION -> VM version (equivallent to PHARO_SHORT_VERSION)
+function set_version_variables() {
+	
+	if [ $(is_development_build) == 1 ]; then
+		if [ $(is_release_build) == 1 ]; then
+			# I'm a release, I have all values needed in a TAG
+			PHARO_NAME_PREFIX="Pharo$(git describe --long --tags | cut -d'-' -f 1-2 | cut -c 2-)"
+			PHARO_SHORT_VERSION="$(git describe --long --tags | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-2 | sed 's/\.//')"
+		else
+			# I'm not a release, but I'm in development branch. I'm a SNAPSHOT
+			PHARO_NAME_PREFIX="Pharo$(git branch | grep \* | cut -d' ' -f 2 | cut -d'-' -f 2)-SNAPSHOT"
+			PHARO_SHORT_VERSION="$(git branch | grep \* | cut -d' ' -f 2 | cut -d'-' -f 2 | sed 's/\.//')"
+		fi
+	else
+		# I'm not development build, I should be a PR
+		# HACK: Since this is a PR branch, I do not have all information I need. I assume I will have a tag indicating Pharo version.
+		PHARO_NAME_PREFIX="Pharo$(git describe --long --tags | cut -d'-' -f 1 | cut -c 2-)-PR"
+		PHARO_SHORT_VERSION="$(git describe --long --tags | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-2 | sed 's/\.//')"
+	fi
+	
+	# this is just to make things clear (and because they could change in the future, who knows :P)
+	PHARO_VM_VERSION="${PHARO_SHORT_VERSION}"
+} 

--- a/bootstrap/scripts/envversion.sh
+++ b/bootstrap/scripts/envversion.sh
@@ -52,8 +52,8 @@ function set_version_pull_request_variables() {
 	# HACK: Since this is a PR branch, I do not have all information I need. I assume I will have a tag indicating Pharo version.
 	# This is same as with 'set_version_release_variables' so I use the function.
 	set_version_release_variables
-	# And I modify name to refleact the fact we are in a Pull request
-	PHARO_NAME_PREFIX="${PHARO_NAME_PREFIX}-PR"
+	# And I modify name to substract any -EXTRA info we have and to reflect the fact we are in a Pull request
+	PHARO_NAME_PREFIX="$(echo ${PHARO_NAME_PREFIX} | cut -d'-' -f 1)-PR"
 }
 
 # sets all variables

--- a/bootstrap/scripts/transform_32_into_64.sh
+++ b/bootstrap/scripts/transform_32_into_64.sh
@@ -7,6 +7,8 @@ set -o xtrace
 SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 . ${SCRIPTS}/envversion.sh
 
+set_version_variables
+
 #Load VMMaker, used to convert images from 32 to 64 bits
 mkdir -p vmmaker && cd vmmaker
 wget https://github.com/pharo-project/pharo-32to64-converter/releases/download/v1.0.0/vmmaker-image.zip


### PR DESCRIPTION
https://pharo.manuscript.com/f/cases/22691/Adopt-file-names-following-branch-tag-convention

using branch approach to calculate version when not directly tagged.

Then, it will be something like this:
- tagged versions will be called: Pharo7.0.0-rc2* (for example)
- non tagger versions will be called: Pharo7.0-SNAPSHOT* (for example)

