### PR TITLE
22692-Improve-after-operation-for-Array

### DIFF
--- a/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
@@ -130,8 +130,7 @@ ReflectivityReificationTest >> testReifyArrayOperationAfter [
 
 { #category : #'tests - misc' }
 ReflectivityReificationTest >> testReifyArrayOperationBefore [
-
-	"
+	| sendNode instance |
 	sendNode := (ReflectivityExamples >> #exampleArray) ast body
 		statements first value.
 	link := MetaLink new
@@ -147,13 +146,14 @@ ReflectivityReificationTest >> testReifyArrayOperationBefore [
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleArray equals: #(3).
-	self assert: tag value equals: #(3)"
+	self assert: tag class equals: Array.
+	self assert: tag value equals: #(3)
 ]
 
 { #category : #'tests - misc' }
 ReflectivityReificationTest >> testReifyArrayOperationInstead [
-
-	"sendNode := (ReflectivityExamples >> #exampleArray) ast body
+	| sendNode instance |
+	sendNode := (ReflectivityExamples >> #exampleArray) ast body
 		statements first value.
 	link := MetaLink new
 		metaObject: self;
@@ -168,7 +168,7 @@ ReflectivityReificationTest >> testReifyArrayOperationInstead [
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleArray equals: self.
-	self assert: tag value equals: #(3)"
+	self assert: tag value equals: #(3)
 ]
 
 { #category : #'tests - misc' }
@@ -870,6 +870,28 @@ ReflectivityReificationTest >> testReifyMethodThisContextAfter [
 	self deny: tag isBlockContext.
 ]
 
+{ #category : #'tests - method' }
+ReflectivityReificationTest >> testReifyMethodValue [
+	| sendNode instance |
+	"not working yet. Need to somehow access return value of whole method"
+	self skip.
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast.
+	link := MetaLink new
+		metaObject: self;
+		selector: #tagExec:;
+		control: #after;
+		arguments: #(value).
+	sendNode link: link.
+	self assert: sendNode hasMetalink.
+	self
+		assert: (ReflectivityExamples >> #exampleMethod) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+	instance := ReflectivityExamples new.
+	self assert: instance exampleMethod equals: 5.
+	self assert: tag equals: #exampleMethod
+]
+
 { #category : #'tests - assignment' }
 ReflectivityReificationTest >> testReifyNewValueAssignmentAfter [
 	| varNode instance |
@@ -1047,6 +1069,27 @@ ReflectivityReificationTest >> testReifyOperationSend [
 		metaObject: self;
 		selector: #tagExec:;
 		control: #before;
+		arguments: #(operation).
+	sendNode link: link.
+	self assert: sendNode hasMetalink.
+	self
+		assert: (ReflectivityExamples >> #exampleMethod) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+	instance := ReflectivityExamples new.
+	self assert: instance exampleMethod equals: 5.
+	self assert: tag value equals: 5
+]
+
+{ #category : #'tests - operations' }
+ReflectivityReificationTest >> testReifyOperationSendAfter [
+	| sendNode instance |
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
+		statements first value.
+	link := MetaLink new
+		metaObject: self;
+		selector: #tagExec:;
+		control: #after;
 		arguments: #(operation).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
@@ -1413,7 +1456,6 @@ ReflectivityReificationTest >> testReifySendValue [
 		metaObject: self;
 		selector: #tagExec:;
 		control: #after;
-		option: #(+ optionWeakAfter);
 		arguments: #(value).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.

--- a/src/Reflectivity-Tools-Tests/WPDummy.class.st
+++ b/src/Reflectivity-Tools-Tests/WPDummy.class.st
@@ -12,14 +12,14 @@ Class {
 
 { #category : #examples }
 WPDummy >> exampleAssignment [
-	foo := 1.
+	foo := 1
 	
 	
 ]
 
 { #category : #examples }
 WPDummy >> exampleAssignment: anObject [
-	foo := anObject.
+	foo := anObject
 	
 	
 ]
@@ -27,8 +27,6 @@ WPDummy >> exampleAssignment: anObject [
 { #category : #examples }
 WPDummy >> exampleMessageSend [
 	self exampleOperation
-	
-	
 ]
 
 { #category : #examples }

--- a/src/Reflectivity/HookGenerator.class.st
+++ b/src/Reflectivity/HookGenerator.class.st
@@ -28,12 +28,9 @@ HookGenerator class >> node: aNode [
 
 { #category : #results }
 HookGenerator >> afterHooks [
-	| statements |
-	statements := links 
+	^ links 
 			select: [ :each | each control = #after ] 
 			thenCollect:  [ :link | (self hookFor: link) parent: node].
-			
-	^(RBBlockNode body: (RBSequenceNode statements: statements flattened)) parent: node.
 ]
 
 { #category : #results }
@@ -141,6 +138,18 @@ HookGenerator >> links [
 { #category : #accessing }
 HookGenerator >> plugins [
 	^ plugins
+]
+
+{ #category : #results }
+HookGenerator >> postamble [
+	| postamble |
+	"This is code executed just before the #after link"
+	
+	postamble := OrderedCollection new.
+	links do: [:link |  
+		plugins do: [ :plugin | (link allReifications includes: plugin key) ifTrue: [postamble addAll: ((plugin entity: entity link: link) postamble: entity)]]].
+		
+	^postamble
 ]
 
 { #category : #results }

--- a/src/Reflectivity/LiteralVariable.extension.st
+++ b/src/Reflectivity/LiteralVariable.extension.st
@@ -116,6 +116,11 @@ LiteralVariable >> methodNode [
 ]
 
 { #category : #'*Reflectivity' }
+LiteralVariable >> postambles [
+	^ self propertyAt: #postambles ifAbsent: #()
+]
+
+{ #category : #'*Reflectivity' }
 LiteralVariable >> preambles [
 	^ self propertyAt: #preambles ifAbsent: #()
 ]

--- a/src/Reflectivity/RBProgramNode.extension.st
+++ b/src/Reflectivity/RBProgramNode.extension.st
@@ -111,6 +111,11 @@ RBProgramNode >> nodesWithLinks [
 ]
 
 { #category : #'*Reflectivity' }
+RBProgramNode >> postambles [
+	^self propertyAt: #postambles ifAbsent: #()
+]
+
+{ #category : #'*Reflectivity' }
 RBProgramNode >> preambles [
 	^self propertyAt: #preambles ifAbsent: #()
 ]

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -23,6 +23,7 @@ RFASTTranslator >> emitMessageNode: aMessageNode [
 	aMessageNode isCascaded
 		ifFalse: [ valueTranslator visitNode: aMessageNode receiver ].
 	aMessageNode arguments do: [ :each | valueTranslator visitNode: each ].
+	self emitPreamble: aMessageNode.
 	self emitPrepareLinkAfter: aMessageNode.
 	self emitMetaLinkBefore: aMessageNode.
 	aMessageNode hasMetalinkInstead
@@ -40,8 +41,9 @@ RFASTTranslator >> emitMetaLinkAfter: aNode [
 	aNode allAfterAreWeak ifTrue: [ ^self emitMetaLinkAfterNoEnsure: aNode ].
 	
 	methodBuilder blockReturnTop.
-	methodBuilder jumpAheadTarget: #block.		
-	valueTranslator visitNode: aNode afterHooks.
+	methodBuilder jumpAheadTarget: #block.
+	aNode postambles do: [:each | valueTranslator visitNode: each].
+	aNode afterHooks do: [:each | valueTranslator visitNode: each].
 	methodBuilder send: #ensure:.
 ]
 
@@ -49,20 +51,18 @@ RFASTTranslator >> emitMetaLinkAfter: aNode [
 RFASTTranslator >> emitMetaLinkAfterNoEnsure: aNode [
 
 	aNode hasMetalinkAfter ifFalse: [ ^self ].
-	self emitPreamble: aNode.
-	aNode afterHooks do: [ :each | effectTranslator visitNode: each body ].
+	aNode postambles do: [:each | valueTranslator visitNode: each].
+	aNode afterHooks do: [ :each | effectTranslator visitNode: each ].
 ]
 
 { #category : #reflectivity }
 RFASTTranslator >> emitMetaLinkBefore: aNode [
 	aNode hasMetalinkBefore ifFalse: [ ^self ].
-	self emitPreamble: aNode.
 	aNode beforeHooks do: [ :hook | effectTranslator visitNode: hook ].
 ]
 
 { #category : #reflectivity }
 RFASTTranslator >> emitMetaLinkInstead: aNode [
-	self emitPreamble: aNode.
 	valueTranslator visitNode: aNode insteadHooks.
 ]
 
@@ -77,7 +77,6 @@ RFASTTranslator >> emitPrepareLinkAfter: aNode [
 	| copied |
 	copied := #().
 	aNode hasMetalinkAfter ifFalse: [^self].
-	self emitPreamble: aNode.
 	aNode allAfterAreWeak ifTrue: [ ^self ].
 	aNode isMethod ifTrue: [ copied := aNode argumentNames, aNode tempNames ].
 	methodBuilder
@@ -95,6 +94,7 @@ RFASTTranslator >> visitArrayNode: anArrayNode [
 	
 	elementNodes := anArrayNode children.
 	elementNodes do: [:node | valueTranslator visitNode: node].
+	self emitPreamble: anArrayNode.
 	self emitMetaLinkBefore: anArrayNode.
 	anArrayNode hasMetalinkInstead
 		ifTrue: [ self emitMetaLinkInstead: anArrayNode ]
@@ -106,10 +106,11 @@ RFASTTranslator >> visitArrayNode: anArrayNode [
 { #category : #'visitor-double dispatching' }
 RFASTTranslator >> visitAssignmentNode: anAssignmentNode [ 
 	valueTranslator visitNode: anAssignmentNode value.
+	self emitPreamble: anAssignmentNode.
 	self emitMetaLinkBefore: anAssignmentNode.
+	self emitPreamble: anAssignmentNode variable.
 	self emitMetaLinkBefore: anAssignmentNode variable.
 	
-
 	anAssignmentNode hasMetalinkInstead
 				ifTrue: [ self emitMetaLinkInstead: anAssignmentNode ]
 				ifFalse: [
@@ -144,6 +145,7 @@ RFASTTranslator >> visitBlockNode: aBlockNode [
 			withVars: (aBlockNode scope tempVector collect: [:each| each name]) asArray.
 	].
 	methodBuilder addTemps: tempNames.
+	self emitPreamble: aBlockNode.
 	self emitMetaLinkBefore: aBlockNode.
 	valueTranslator visitNode: aBlockNode body.
 	methodBuilder addBlockReturnTopIfRequired.
@@ -186,12 +188,14 @@ RFASTTranslator >> visitInlinedBlockNode: anOptimizedBlockNode [
 			methodBuilder storeTemp: tempName.
 			methodBuilder popTop.
 		 ]].
+	self emitPreamble: anOptimizedBlockNode.
 	self emitMetaLinkBefore: anOptimizedBlockNode.
 	self visitNode: anOptimizedBlockNode body.
 ]
 
 { #category : #'visitor-double dispatching' }
 RFASTTranslator >> visitLiteralArrayNode: aRBLiteralArrayNode [
+	self emitPreamble: aRBLiteralArrayNode.
 	self emitMetaLinkBefore: aRBLiteralArrayNode.
 	aRBLiteralArrayNode hasMetalinkInstead
 		ifTrue: [ self emitMetaLinkInstead: aRBLiteralArrayNode ]
@@ -203,6 +207,7 @@ RFASTTranslator >> visitLiteralArrayNode: aRBLiteralArrayNode [
 
 { #category : #'visitor-double dispatching' }
 RFASTTranslator >> visitLiteralNode: aLiteralNode [
+	self emitPreamble: aLiteralNode.
 	self emitMetaLinkBefore: aLiteralNode.
 	aLiteralNode hasMetalinkInstead
 		ifTrue: [ self emitMetaLinkInstead: aLiteralNode ]
@@ -227,7 +232,7 @@ RFASTTranslator >> visitMethodNode: aMethodNode [
 	methodBuilder compilationContext: aMethodNode compilationContext.
 	methodBuilder addTemps: aMethodNode scope tempVarNames.
 	
-	aMethodNode isPrimitive ifFalse: [self emitMetaLinkBefore: aMethodNode].
+	aMethodNode isPrimitive ifFalse: [self emitPreamble: aMethodNode. self emitMetaLinkBefore: aMethodNode].
 
 	methodBuilder properties: aMethodNode methodProperties.
 	methodBuilder irPrimitive: aMethodNode primitiveFromPragma.
@@ -256,6 +261,7 @@ RFASTTranslator >> visitMethodNode: aMethodNode [
 RFASTTranslator >> visitReturnNode: aReturnNode [ 
 
 	valueTranslator visitNode: aReturnNode value.
+	self emitPreamble: aReturnNode.
 	self emitMetaLinkBefore: aReturnNode.
 	aReturnNode hasMetalinkInstead
 		ifTrue: [ self emitMetaLinkInstead: aReturnNode ]
@@ -283,6 +289,7 @@ RFASTTranslator >> visitStorePopIntoTempNode: aNode [
 
 { #category : #'visitor-double dispatching' }
 RFASTTranslator >> visitVariableNode: aVariableNode [
+	self emitPreamble: aVariableNode.
 	self emitMetaLinkBefore: aVariableNode.
 	aVariableNode hasMetalinkInstead
 				ifTrue: [ self emitMetaLinkInstead: aVariableNode ]
@@ -295,7 +302,7 @@ RFASTTranslator >> visitVariableNode: aVariableNode [
 { #category : #reflectivity }
 RFASTTranslator >> visitVariableValue: aVariable [
 	self flag: #TBD. "needs to be extendend to other kinds of variables and cleaned"
-	((aVariable isKindOf: LiteralVariable) or: [ (aVariable isKindOf: Slot) ]) ifTrue: [ self emitMetaLinkBefore: aVariable. ].
+	((aVariable isKindOf: LiteralVariable) or: [ (aVariable isKindOf: Slot) ]) ifTrue: [ self emitPreamble: aVariable. self emitMetaLinkBefore: aVariable. ].
 	aVariable emitValue: methodBuilder.
 	((aVariable isKindOf: LiteralVariable) or: [ (aVariable isKindOf: Slot) ]) ifTrue: [self emitMetaLinkAfterNoEnsure: aVariable].
 ]

--- a/src/Reflectivity/RFASTTranslatorForEffect.class.st
+++ b/src/Reflectivity/RFASTTranslatorForEffect.class.st
@@ -109,6 +109,7 @@ RFASTTranslatorForEffect >> visitParseErrorNode: anErrorNode [
 
 { #category : #'visitor-double dispatching' }
 RFASTTranslatorForEffect >> visitSequenceNode: aSequenceNode [
+	self emitPreamble: aSequenceNode.
 	self emitMetaLinkBefore: aSequenceNode.
 	self emitPrepareLinkAfter: aSequenceNode.
 	
@@ -126,6 +127,7 @@ RFASTTranslatorForEffect >> visitVariableNode: aVariableNode [
 	
 	| binding |
 	
+	self emitPreamble: aVariableNode.
 	self emitMetaLinkBefore: aVariableNode.
 	self emitPrepareLinkAfter: aVariableNode.
 	

--- a/src/Reflectivity/RFASTTranslatorForValue.class.st
+++ b/src/Reflectivity/RFASTTranslatorForValue.class.st
@@ -67,6 +67,7 @@ RFASTTranslatorForValue >> emitWhileTrue: aMessageNode [
 { #category : #'visitor-double dispatching' }
 RFASTTranslatorForValue >> visitSequenceNode: aSequenceNode [ 
 	| statements |
+	self emitPreamble: aSequenceNode.
 	self emitMetaLinkBefore: aSequenceNode.
 	self emitPrepareLinkAfter: aSequenceNode.
 	

--- a/src/Reflectivity/RFOldValueReification.class.st
+++ b/src/Reflectivity/RFOldValueReification.class.st
@@ -23,7 +23,6 @@ RFOldValueReification class >> key [
 RFOldValueReification >> genForRBAssignmentNode [
 	| varNode |
 	varNode := entity variable.
-	
 	varNode isGlobal ifTrue: [^RFLiteralVariableNode value: entity binding value]. 
 	^RBVariableNode named: varNode name.
 ]
@@ -33,9 +32,4 @@ RFOldValueReification >> genForRBVariableNode [
 	"same as #value for variableNodes"
 	entity isGlobal ifTrue: [^RFLiteralVariableNode value: entity binding value]. 
 	^RBVariableNode named: entity name.
-]
-
-{ #category : #generate }
-RFOldValueReification >> preamble: aNode [
-		^{}
 ]

--- a/src/Reflectivity/RFOperationReification.class.st
+++ b/src/Reflectivity/RFOperationReification.class.st
@@ -124,19 +124,32 @@ RFOperationReification >> preamble: aNode [
 
 { #category : #generate }
 RFOperationReification >> preambleForArray: aNode [
-	"balance stack for instead"
-	self flag: #TBD. "need to pop of the complete stack for instead, need to create the array for #before?"
-	link control= #instead
-		ifTrue: [ ^RFStorePopIntoTempNode named: #RFReifyValueVar  ]
-		ifFalse: [^RFStoreIntoTempNode named: #RFReifyValueVar  ]
+	| preamble arguments |
+	preamble := OrderedCollection new.
+	arguments := OrderedCollection new.
+
+	(1 to: aNode size) reverseWithIndexDo: [:each :index |  
+			| name |
+			name := 'RFArg', index asString, 'RFReification'.
+			preamble add:  (RFStorePopIntoTempNode named: name).
+	].
+	
+	self flag: #TBD. "for #instead we do not need to build the stack up again as the array creation bytecode is missing"
+	(1 to: aNode size) withIndexDo: [:each :index |  
+			| name |
+			name := 'RFArg', index asString, 'RFReification'.
+			arguments add:  (RBTemporaryNode named: name).
+	].
+	preamble addAll: (RBArrayNode statements: arguments).
+	preamble add: (RFStorePopIntoTempNode named: 'RFReifyValueVar').
+	preamble addAll: arguments.
+	^ preamble 
+	
 ]
 
 { #category : #generate }
 RFOperationReification >> preambleForAssignment: aNode [
-	"balance stack for instead"
-	link control= #instead
-		ifTrue: [ ^RFStorePopIntoTempNode named: #RFNewValueReificationVar  ]
-		ifFalse: [^RFStoreIntoTempNode named: #RFNewValueReificationVar  ]
+	^RFStoreIntoTempNode named: #RFNewValueReificationVar
 ]
 
 { #category : #generate }

--- a/src/Reflectivity/RFReification.class.st
+++ b/src/Reflectivity/RFReification.class.st
@@ -159,6 +159,11 @@ RFReification >> link: anUndefinedObject [
 ]
 
 { #category : #generate }
+RFReification >> postamble: aNode [
+	^#()
+]
+
+{ #category : #generate }
 RFReification >> preamble: aNode [
 	^#()
 ]

--- a/src/Reflectivity/RFSemanticAnalyzer.class.st
+++ b/src/Reflectivity/RFSemanticAnalyzer.class.st
@@ -10,30 +10,6 @@ Class {
 }
 
 { #category : #visiting }
-RFSemanticAnalyzer >> analyseForLinks: aNode [
-	| generator |
-	aNode hasMetalink
-		ifFalse: [ ^ self ].
-	generator := HookGenerator node: aNode.
-
-	aNode propertyAt: #preambles put: generator preamble.
-	aNode preambles do: [:each | self visitNode: each].
-	
-	aNode hasMetalinkBefore ifTrue: [  
-		aNode propertyAt: #beforeHooks put: generator beforeHooks.
- 		aNode beforeHooks do: [:each | self visitNode: each]].
-	
-	aNode hasMetalinkAfter ifTrue: [  
-		aNode propertyAt: #afterHooks put: generator afterHooks.
-		self visitNode: aNode afterHooks].
-	
-	aNode hasMetalinkInstead ifTrue: [  
-		aNode propertyAt: #insteadHooks put: generator insteadHooks.
- 		aNode insteadHooks do: [:each | self visitNode: each]].	
-
-]
-
-{ #category : #visiting }
 RFSemanticAnalyzer >> analyseForLinks: aNode generator: aGenerator [
 
 	aNode propertyAt: #preambles put: aGenerator preamble.
@@ -43,9 +19,11 @@ RFSemanticAnalyzer >> analyseForLinks: aNode generator: aGenerator [
 		aNode propertyAt: #beforeHooks put: aGenerator beforeHooks.
  		aNode beforeHooks do: [:each | self visitNode: each]].
 	
-	aNode hasMetalinkAfter ifTrue: [  
+	aNode hasMetalinkAfter ifTrue: [    
+		aNode propertyAt: #postambles put: aGenerator postamble.
+		aNode postambles do: [:each | self visitNode: each].
 		aNode propertyAt: #afterHooks put: aGenerator afterHooks.
-		self visitNode: aNode afterHooks].
+		aNode afterHooks do: [:each | self visitNode: each]].
 	
 	aNode hasMetalinkInstead ifTrue: [  
 		aNode propertyAt: #insteadHooks put: aGenerator insteadHooks.

--- a/src/Reflectivity/RFThisContextReification.class.st
+++ b/src/Reflectivity/RFThisContextReification.class.st
@@ -28,15 +28,6 @@ RFThisContextReification >> genForLiteralVariable [
 ]
 
 { #category : #generate }
-RFThisContextReification >> genForRBMethodNode [
-	"when in after the call to the meta is wrapped in a block"
-	^link control = #after
-		ifTrue: [ RBMessageNode receiver: (RBThisContextNode named: #thisContext) selector: #outerContext]
-		ifFalse: [ RBThisContextNode named: #thisContext ]
-
-]
-
-{ #category : #generate }
 RFThisContextReification >> genForRBProgramNode [
 	^RBThisContextNode named: #thisContext
 ]

--- a/src/Reflectivity/RFValueReification.class.st
+++ b/src/Reflectivity/RFValueReification.class.st
@@ -19,7 +19,7 @@ Class {
 
 { #category : #'plugin interface' }
 RFValueReification class >> entities [
-	^{RBVariableNode. RBAssignmentNode. RBReturnNode. RBMessageNode . RBLiteralValueNode . RBLiteralArrayNode. RBArrayNode . LiteralVariable . Slot}
+	^{RBVariableNode. RBAssignmentNode. RBReturnNode. RBMessageNode . RBLiteralValueNode . RBLiteralArrayNode. RBArrayNode . RBMethodNode . LiteralVariable . Slot} 
 ]
 
 { #category : #'plugin interface' }
@@ -70,6 +70,11 @@ RFValueReification >> genForRBMessageNode [
 ]
 
 { #category : #generate }
+RFValueReification >> genForRBMethodNode [
+	^RBVariableNode named: #RFReifyValueVar
+]
+
+{ #category : #generate }
 RFValueReification >> genForRBReturnNode [
 	^RBVariableNode named: #RFReifyValueVar
 ]
@@ -81,9 +86,44 @@ RFValueReification >> genForRBVariableNode [
 ]
 
 { #category : #generate }
+RFValueReification >> postamble: aNode [
+	(aNode isKindOf: RBProgramNode) ifFalse: [ ^#() ].
+	aNode isMethod ifTrue: [^RFStoreIntoTempNode named: 'RFReifyValueVar'. ].
+	aNode isMessage ifTrue: [^RFStoreIntoTempNode named: 'RFReifyValueVar'. ].
+	^super postamble: aNode.
+	 
+]
+
+{ #category : #generate }
 RFValueReification >> preamble: aNode [
 	(aNode isKindOf: RBProgramNode) ifFalse: [ ^#() ].
-	^(aNode isReturn or: [ aNode isMessage or: [aNode isDynamicArray]])
-		ifTrue: [RFStoreIntoTempNode named: #RFReifyValueVar]
-		ifFalse: [ #() ]. 
+	aNode isReturn ifTrue: [^RFStoreIntoTempNode named: #RFReifyValueVar].
+	aNode isDynamicArray ifTrue: [ ^self preambleForArray: aNode ].
+	^#().
+	 
+]
+
+{ #category : #generate }
+RFValueReification >> preambleForArray: aNode [
+	| preamble arguments |
+	preamble := OrderedCollection new.
+	arguments := OrderedCollection new.
+
+	(1 to: aNode size) reverseWithIndexDo: [:each :index |  
+			| name |
+			name := 'RFArg', index asString, 'RFReification'.
+			preamble add:  (RFStorePopIntoTempNode named: name).
+	].
+	
+	self flag: #TBD. "for #instead we do not need to build the stack up again as the array creation bytecode is missing"
+	(1 to: aNode size) withIndexDo: [:each :index |  
+			| name |
+			name := 'RFArg', index asString, 'RFReification'.
+			arguments add:  (RBTemporaryNode named: name).
+	].
+	preamble addAll: (RBArrayNode statements: arguments).
+	preamble add: (RFStorePopIntoTempNode named: 'RFReifyValueVar').
+	preamble addAll: arguments.
+	^ preamble 
+	
 ]

--- a/src/Reflectivity/Slot.extension.st
+++ b/src/Reflectivity/Slot.extension.st
@@ -100,6 +100,11 @@ Slot >> links [
 ]
 
 { #category : #'*Reflectivity' }
+Slot >> postambles [
+	^ self propertyAt: #postambles ifAbsent: #()
+]
+
+{ #category : #'*Reflectivity' }
 Slot >> preambles [
 	^ self propertyAt: #preambles ifAbsent: #()
 ]

--- a/src/Reflectivity/TemporaryVariable.extension.st
+++ b/src/Reflectivity/TemporaryVariable.extension.st
@@ -77,6 +77,11 @@ TemporaryVariable >> links [
 ]
 
 { #category : #'*Reflectivity' }
+TemporaryVariable >> postambles [
+	^ self propertyAt: #postambles ifAbsent: #()
+]
+
+{ #category : #'*Reflectivity' }
 TemporaryVariable >> preambles [
 	^ self propertyAt: #preambles ifAbsent: #()
 ]


### PR DESCRIPTION
- #operation for send after
- #operation and value for {} arrays
- #after hooks: preamble now executed *before* the operation
- #after hooks: added concept of postamble, executed just before hook

https://pharo.fogbugz.com/f/cases/22692/Improve-after-operation-for-Array