### PR TITLE
22718-argumentNames-should-not-use-propertyValueAt

### DIFF
--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -96,7 +96,7 @@ CompiledCode >> allLiterals [
 { #category : #'source code management' }
 CompiledCode >> argumentNames [
 	^self 
-		propertyValueAt: #argumentNames 
+		propertyAt: #argumentNames 
 		ifAbsent: [ self ast argumentNames ]
 
 ]


### PR DESCRIPTION
argumentNames should not use propertyValueAt
https://pharo.fogbugz.com/f/cases/22718/argumentNames-should-not-use-propertyValueAt