### PR TITLE
22676-Cannot-extract-method-with-a-name-matching-the-one-in-a-superclass-being-a-subclassResponsibility

### DIFF
--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -234,7 +234,7 @@ RBExtractMethodRefactoring >> getNewMethodName [
 		ifFalse: 
 			[self refactoringWarning: newSelector , ' is not a valid selector name.'.
 			newSelector := nil].
-	(class hierarchyDefinesMethod: newSelector asSymbol) 
+	(class directlyDefinesMethod: newSelector) 
 		ifTrue: 
 			[(self shouldOverride: newSelector in: class) ifFalse: [newSelector := nil]].
 	newSelector isNil] 


### PR DESCRIPTION
changed the validation for launching an #alreadyDefined error. Now the selector name is searched directly in the class instead of its  hierarchy