### PR TITLE
22714 leftover halts in the system

### DIFF
--- a/src/Debugger-Tests/FilterTest.class.st
+++ b/src/Debugger-Tests/FilterTest.class.st
@@ -18,7 +18,7 @@ Class {
 { #category : #running }
 FilterTest >> setUp [
 	super setUp.
-	context := [ (Set with: 1 with: 2) collect: [ :e | e * 2 ]. self halt ] asContext.
+	context := [ (Set with: 1 with: 2) collect: [ :e | e * 2 ]] asContext.
 	process := Process 
 		forContext: context 
 		priority: Processor userInterruptPriority.

--- a/src/Kernel-Tests/ProtoObjectTest.class.st
+++ b/src/Kernel-Tests/ProtoObjectTest.class.st
@@ -17,32 +17,58 @@ ProtoObjectTest >> testFlag [
 
 { #category : #'tests - testing' }
 ProtoObjectTest >> testIfNil [
-	| object block |
+	| object block reachabilityTest1 reachabilityTest2|
+	reachabilityTest1 := false.
+	reachabilityTest2 := false.
 	object := ProtoObject new.
-	object ifNil: [ self halt ].
+	object ifNil: [reachabilityTest1 := true ].
 	self assert: (object ifNil: [ nil ]) == object.	"Now the same without inlining."
-	block := [ self halt ].
+	block := [ reachabilityTest2 := true].
 	object ifNil: block.
 	block := [ nil ].
-	self assert: (object ifNil: block) == object
+	self assert: (object ifNil: block) == object.
+	self assert: reachabilityTest1 equals: false.
+	self assert: reachabilityTest2 equals: false.
 ]
 
 { #category : #'tests - testing' }
 ProtoObjectTest >> testIfNilIfNotNil [
 
-	| object returnValue block |
+	| object returnValue block notReached1 reached1 notReached2 reached2 reached3 notReached3 reached4 notReached4 |
+	notReached1 := false.
+	reached1 := false.
+	notReached2 := false.
+	reached2 := false.
+	notReached3 := false.
+	reached3 := false.
+	notReached4 := false.
+	reached4 := false.
 	object := ProtoObject new.
 	returnValue := Object new.
-	self should: [ object ifNil: [ self error ] ifNotNil: [ self halt ] ] raise: Halt.
-	self should: [ object ifNil: [ self error ] ifNotNil: [ :o | self halt ] ] raise: Halt.
+	
+	object ifNil: [ notReached1 := true ] ifNotNil: [ reached1 := true ].
+	self assert: notReached1 equals: false.
+	self assert: reached1 equals: true.
+	
+	object ifNil: [ notReached2 := true ] ifNotNil: [ :o | reached2 := true ].
+	self assert: notReached2 equals: false.
+	self assert: reached2 equals: true.
+
 	self assert: (object ifNil: [ false ] ifNotNil: [ :o | o == object ]).
 	self assert: (object ifNil: [ nil ] ifNotNil: [ returnValue ]) == returnValue.
 	self assert: (object ifNil: [ nil ] ifNotNil: [ :o | returnValue ]) == returnValue.
+	
 	"Now the same without inlining."
-	block := [ self halt ].
-	self should: [ object ifNil: [ self error ] ifNotNil: block ] raise: Halt.
-	block := [ :o | self halt ].
-	self should: [ object ifNil: [ self error ] ifNotNil: block ] raise: Halt.
+	block := [ reached3 := true ].
+	object ifNil: [ notReached3 := true ] ifNotNil: block.
+	self assert: notReached3 equals: false.
+	self assert: reached3 equals: true.
+	
+	block := [ :o | reached4 := true ].
+	object ifNil: [ notReached4 := true ] ifNotNil: block.
+	self assert: notReached4 equals: false.
+	self assert: reached4 equals: true.
+	
 	block := [ :o | o == object ].
 	self assert: (object ifNil: [ false ] ifNotNil: block).
 	block := [ returnValue ].
@@ -54,19 +80,27 @@ ProtoObjectTest >> testIfNilIfNotNil [
 { #category : #'tests - testing' }
 ProtoObjectTest >> testIfNotNil [
 
-	| object returnValue block |
+	| object returnValue block reached|
+	reached := false.
 	object := ProtoObject new.
 	returnValue := Object new.
-	self should: [ object ifNotNil: [ self halt ] ] raise: Halt.
-	self should: [ object ifNotNil: [ :o | self halt ] ] raise: Halt.
+	object ifNotNil: [ reached := true ].
+	self assert: reached equals: true.
+	reached := false.
+	object ifNotNil: [ :o | reached := true ].
+	self assert: reached equals: true.
+	reached := false.
 	self assert: (object ifNotNil: [ :o | o == object ]).
 	self assert: (object ifNotNil: [ returnValue ]) == returnValue.
 	self assert: (object ifNotNil: [ :o | returnValue ]) == returnValue.	
 	"Now the same without inlining."
-	block := [ self halt ].
-	self should: [ object ifNotNil: block ] raise: Halt.
-	block := [ :o | self halt ].
-	self should: [ object ifNotNil: block ] raise: Halt.
+	block := [ reached := true ].
+	object ifNotNil: block.
+	self assert: reached equals: true.
+	reached := false.
+	block := [ :o | reached := true ].
+	object ifNotNil: block.
+	self assert: reached equals: true.
 	block := [ :o | o == object ].
 	self assert: (object ifNotNil: block).
 	block := [ returnValue ].
@@ -78,19 +112,37 @@ ProtoObjectTest >> testIfNotNil [
 { #category : #'tests - testing' }
 ProtoObjectTest >> testIfNotNilIfNil [
 
-	| object returnValue block |
+	| object returnValue block reached notReached|
+	reached := false.
+	notReached := false.
 	object := ProtoObject new.
 	returnValue := Object new.
-	self should: [ object ifNotNil: [ self halt ] ifNil: [ self error ]  ] raise: Halt.
-	self should: [ object ifNotNil: [ :o | self halt ] ifNil: [ self error ] ] raise: Halt.
+	object ifNotNil: [ reached := true ] ifNil: [ notReached := true ].
+	self assert: reached equals: true.
+	self assert: notReached equals: false.
+	reached := false.
+	notReached := false.
+	object ifNotNil: [ :o | reached := true ] ifNil: [ notReached := true ].
+	self assert: reached equals: true.
+	self assert: notReached equals: false.
+	reached := false.
+	notReached := false.
 	self assert: (object ifNotNil: [ :o | o == object ] ifNil: [ false ]).
 	self assert: (object ifNotNil: [ returnValue ] ifNil: [ false ]) == returnValue.
 	self assert: (object ifNotNil: [ :o | returnValue ] ifNil: [ false ]) == returnValue.
 	"Now the same without inlining."
-	block := [ self halt ].
-	self should: [ object ifNotNil: block ifNil: [ self error ]  ] raise: Halt.
-	block := [ :o | self halt ].
-	self should: [ object ifNotNil: block ifNil: [ self error ] ] raise: Halt.
+	block := [ reached := true ].
+	object ifNotNil: block ifNil: [ notReached := true ].
+	self assert: reached equals: true.
+	self assert: notReached equals: false.
+	reached := false.
+	notReached := false.	
+	block := [ :o | reached := true ].
+	object ifNotNil: block ifNil: [ notReached := true ].
+	self assert: reached equals: true.
+	self assert: notReached equals: false.
+	reached := false.
+	notReached := false.
 	block := [ :o | o == object ].
 	self assert: (object ifNotNil: block ifNil: [ false ]).
 	block := [ returnValue ].

--- a/src/Kernel/DelayBasicScheduler.class.st
+++ b/src/Kernel/DelayBasicScheduler.class.st
@@ -182,7 +182,7 @@ DelayBasicScheduler >> runBackendLoopAtTimingPriority [
 		 	ticker waitForUserSignalled: timingSemaphore orExpired: activeDelay. 
 
 			"When two debuggers appear, step/proceed through this higher priority one first."
-			debug ifTrue: [ self halt ].		
+			debug ifTrue: [ self openDebugger ].		
 
 			"Invoke the api back-ends, which set the transfer-variable to nil" 		
 			suspendSemaphore ifNotNil: [ self suspendAtTimingPriority    ].
@@ -197,7 +197,7 @@ DelayBasicScheduler >> runBackendLoopAtTimingPriority [
 						activeDelay := suspendedDelays removeFirstOrNil ].
 		]
 	] ensure: [ "When timer event loop exits, expire remaining delays."
-		debug ifTrue: [ self halt ].
+		debug ifTrue: [ self openDebugger ].
 		[activeDelay notNil] whileTrue: [
 				activeDelay timingPrioritySignalExpired.
 				activeDelay := suspendedDelays removeFirstOrNil ]].
@@ -209,7 +209,7 @@ DelayBasicScheduler >> schedule: aDelay [
 	 For back-half see #scheduleAtTimingPriority"
 
 	"Debug lines to help review. Could be removed after a settling in period"
-	debug ifTrue: [ self halt ].
+	debug ifTrue: [ self openDebugger ].
 	
 	"Only one signal is sent when delay expires, and if that is already spoken for"
 	aDelay beingWaitedOn ifTrue: [^self error: 'This Delay has already been scheduled.'].
@@ -222,7 +222,7 @@ DelayBasicScheduler >> schedule: aDelay [
 	delayToStart := aDelay.
 	timingSemaphore signal. "Transfer execution to back-end #scheduleAtTimingPriority"
 	
-	debug ifTrue: [ self halt. "If debugger appeared for timingPriority thread, step through that first" ]
+	debug ifTrue: [ self openDebugger. "If debugger appeared for timingPriority thread, step through that first" ]
 
 ]
 
@@ -328,14 +328,14 @@ DelayBasicScheduler >> suspend [
 DelayBasicScheduler >> suspendAtTimingPriority [
 	"Private! This is the front-half for suspending the delay scheduler to prevent
 	 wake-up of delayed threads in the middle of snapshotting. For front-half see #suspend"
-	debug ifTrue: [ self halt ].
+	debug ifTrue: [ self openDebugger ].
 	
 	ticker saveResumptionTimes: suspendedDelays asArray, {activeDelay}.
 	
 	"Warning! Stepping <Over> the following line may lock the Image. Use <Proceed>."
 	suspendSemaphore wait.
 	
-	debug ifTrue: [ self halt ].
+	debug ifTrue: [ self openDebugger ].
 	
 	ticker restoreResumptionTimes: suspendedDelays asArray, {activeDelay}.  
 	suspendSemaphore := nil
@@ -359,7 +359,7 @@ DelayBasicScheduler >> unschedule: aDelay [
 	 For back-half see #unscheduleAtTimingPriority"
 
 	"Debug lines to help review. Could be removed after a settling in period"
-	debug ifTrue: [ self halt ].
+	debug ifTrue: [ self openDebugger ].
 
 	"The basic scheduler is highly dependant on semantics of cooperative multitasking and 
 	 bytecode inlining such that interuption *cannot* occur between the assignment and the signal.
@@ -369,7 +369,7 @@ DelayBasicScheduler >> unschedule: aDelay [
 	delayToStop := aDelay.
 	timingSemaphore signal. "Transfer execution to #unscheduleAtTimingPriority"
 	
-	debug ifTrue: [ self halt. "If timingPriority thread debugger appears, step through it first" ]
+	debug ifTrue: [ self openDebugger. "If timingPriority thread debugger appears, step through it first" ]
 
 
 ]

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1584,6 +1584,12 @@ Object >> openDebugger [
 	self halt.
 ]
 
+{ #category : #'as yet unclassified' }
+Object >> openDebugger: aString [
+	"Used in debugging infrastructure that should stay in production, instead of leaving a halt in the code. This way it is not flagged as debugging code left in method"
+	self halt: aString.
+]
+
 { #category : #'message performing' }
 Object >> perform: aSymbol [ 
 	"Send the unary selector, aSymbol, to the receiver.

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1578,6 +1578,12 @@ Object >> okToChange [
 	^ true
 ]
 
+{ #category : #'as yet unclassified' }
+Object >> openDebugger [
+	"Used in debugging infrastructure that should stay in production, instead of leaving a halt in the code. This way it is not flagged as debugging code left in method"
+	self halt.
+]
+
 { #category : #'message performing' }
 Object >> perform: aSymbol [ 
 	"Send the unary selector, aSymbol, to the receiver.

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1578,13 +1578,13 @@ Object >> okToChange [
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #debugging }
 Object >> openDebugger [
 	"Used in debugging infrastructure that should stay in production, instead of leaving a halt in the code. This way it is not flagged as debugging code left in method"
 	self halt.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #debugging }
 Object >> openDebugger: aString [
 	"Used in debugging infrastructure that should stay in production, instead of leaving a halt in the code. This way it is not flagged as debugging code left in method"
 	self halt: aString.

--- a/src/Manifest-Resources-Tests/MFClassA.class.st
+++ b/src/Manifest-Resources-Tests/MFClassA.class.st
@@ -10,5 +10,5 @@ Class {
 { #category : #'as yet unclassified' }
 MFClassA >> method [
 	|foo|
-	self halt.
+	1+1.
 ]

--- a/src/Manifest-Resources-Tests/MFClassB.class.st
+++ b/src/Manifest-Resources-Tests/MFClassB.class.st
@@ -15,5 +15,5 @@ MFClassB >> method2 [
 { #category : #'as yet unclassified' }
 MFClassB >> method3 [
 	|foo|
-	self halt.
+	1+1.
 ]

--- a/src/Metacello-Core/MetacelloVersionValidator.class.st
+++ b/src/Metacello-Core/MetacelloVersionValidator.class.st
@@ -232,7 +232,7 @@ MetacelloVersionValidator >> recordValidationCriticalWarning: aString versionStr
 		ifFalse: [ self error: 'Unknown critical warning reason code' ].
 	((self exludededValidations at: versionString ifAbsent: [ #() ]) includes: aSymbol)
 		ifTrue: [ ^self ].
-	(self debug includes: #criticalWarning) ifTrue: [ self halt: 'Debug triggered for critical warning: ', aString ].
+	(self debug includes: #criticalWarning) ifTrue: [ self openDebugger: 'Debug triggered for critical warning: ', aString ].
 	self validationReport
 		add:
 			(MetacelloValidationCriticalWarning
@@ -271,7 +271,7 @@ MetacelloVersionValidator >> recordValidationError: aString versionString: versi
 		ifFalse: [ self error: 'Unknown error reason code' ].
 	((self exludededValidations at: versionString ifAbsent: [ #() ]) includes: aSymbol)
 		ifTrue: [ ^self ].
-	(self debug includes: #error) ifTrue: [ self halt: 'Debug triggered for error: ', aString ].
+	(self debug includes: #error) ifTrue: [ self openDebugger: 'Debug triggered for error: ', aString ].
 	self validationReport
 		add:
 			(MetacelloValidationError
@@ -302,7 +302,7 @@ MetacelloVersionValidator >> recordValidationWarning: aString versionString: ver
 		ifFalse: [ self error: 'Unknown warning reason code' ].
 	((self exludededValidations at: versionString ifAbsent: [ #() ]) includes: aSymbol)
 		ifTrue: [ ^self ].
-	(self debug includes: #warning) ifTrue: [ self halt: 'Debug triggered for critical warning: ', aString ].
+	(self debug includes: #warning) ifTrue: [ self openDebugger: 'Debug triggered for critical warning: ', aString ].
 	self validationReport
 		add:
 			(MetacelloValidationWarning

--- a/src/Morphic-Examples/TabExample.class.st
+++ b/src/Morphic-Examples/TabExample.class.st
@@ -66,7 +66,7 @@ TabExample >> freshListTab [
 				buildWithSpec ]
 		actions:
 		{(TabAction
-				action: [ self halt ]
+				action: [ self openDebugger ]
 				icon: (self iconNamed: #smallConfigurationIcon)
 				label: 'Halt!')})
 		menu: [ :menu | menu add: 'Fubu' target: self selector: #halt ];

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -662,7 +662,7 @@ TestCase >> openDebuggerOnFailingTestMethod [
 	 send into 'self perform: testSelector' to see the failure from the beginning"
 
 	self
-		halt;
+		openDebugger;
 		performTest
 ]
 

--- a/src/Spec-Core/TreePresenter.class.st
+++ b/src/Spec-Core/TreePresenter.class.st
@@ -120,7 +120,7 @@ TreePresenter class >> exampleWithCustomColumnsAndNodes [
 		columns: {col1. col2};
 		dragEnabled: true;
 		dropEnabled: true;
-		acceptDropBlock: [ :transfer :event :source :receiver | self halt ].
+		acceptDropBlock: [ :transfer :event :source :receiver | self openDebugger].
 		
 	col2 
 		headerLabel: 'Character +2';
@@ -161,7 +161,7 @@ TreePresenter class >> exampleWithCustomColumnsAndNodesAndChildren [
 			col2};
 		dragEnabled: true;
 		dropEnabled: true;
-		acceptDropBlock: [ :transfer :event :source :receiver | self halt ].
+		acceptDropBlock: [ :transfer :event :source :receiver | self openDebugger ].
 	col2
 		displayBlock: [ :node | (Character value: node content asString first asciiValue + 2) asString ]
 ]

--- a/src/Spec-Core/TreePresenter.class.st
+++ b/src/Spec-Core/TreePresenter.class.st
@@ -152,7 +152,7 @@ TreePresenter class >> exampleWithCustomColumnsAndNodesAndChildren [
 	m openWithSpec.
 	col1 := TreeColumnPresenter new
 		displayBlock: [ :node | node content asString ];
-		headerAction: [ self halt ].
+		headerAction: [ self openDebugger ].
 	col2 := TreeColumnPresenter new
 		displayBlock: [ :node | (Character value: node content asString first asciiValue + 1) asString ].
 	m


### PR DESCRIPTION
Removed a bunch of leftover `halt` in the image.
Left those that looked legitimate (for example in methods testing that `self halt` does indeed raise a Halt).
Replaced those that were used as debugging infrastructure (ex: `debug ifTrue: [self halt]`) with a new method: Object>>openDebugger (and its flavour Object>>openDebugger:). This new method just does `self halt`, but it clarifies that the halt it replaced was legitimate and not some leftover debugging code.