### PR TITLE
Revert "22679-Metacello-attributes-should-be-based-on-SystemVersion-instead-of-hardcoding"

### DIFF
--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1128,14 +1128,9 @@ SmalltalkImage >> memoryHogs [
 
 { #category : #miscellaneous }
 SmalltalkImage >> metacelloPlatformAttributes [
-	"Returns the tags for the conditional platform loading in Metacello. Pay attention the order is important: from most  to least general."
-
-	| attributes systemeVersion |
-	attributes := OrderedCollection withAll: #(#squeakCommon #pharo).
-	systemVersion := SystemVersion current.
-	attributes add: (String streamContents: [ :stream | stream << 'pharo' << systemVersion major << '.x' ]) asSymbol.
-	attributes add: (String streamContents: [ :stream | stream << 'pharo' << systemVersion major << $. << systemVersion minor << '.x' ]) asSymbol.
-	^ attributes asArray
+    "Returns the tags for the conditional platform loading in Metacello. Pay attention the order is important: from most  to least general." 
+    "For release integrators, we should not have #'pharo1.3x' **and** #'pharo1.4.x'"
+   ^ #(#squeakCommon #pharo #'pharo7.x' #'pharo7.0.x')
 ]
 
 { #category : #'special objects' }


### PR DESCRIPTION
Reverts pharo-project/pharo#1999