### PR TITLE
22726 pharo icon in menus is larger than other icons 20 pix instead of 16 making its row height different

### DIFF
--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -168,7 +168,7 @@ WorldState class >> pharoItemsOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #Pharo)
 		label: 'Pharo';
-		icon: ((self iconNamed: #pharo) scaledToSize: 20 @ 20);
+		icon: ((self iconNamed: #pharo) scaledToSize: 16 @ 16);
 		order: 0;
 		with: [ (aBuilder item: #Save)
 				target: self;

--- a/src/Morphic-Widgets-Menubar/MenubarItemMorph.class.st
+++ b/src/Morphic-Widgets-Menubar/MenubarItemMorph.class.st
@@ -19,7 +19,7 @@ MenubarItemMorph >> drawIconOn: aCanvas [
 	x := (self menuStringBounds left - iconForm width - 5 ).
 	y := (self top + ((self height - iconForm height) // 2)).
 	
-	self shouldBeHighlighted ifTrue: [ y := y + 2 ].
+	"self shouldBeHighlighted ifTrue: [ y := y + 2 ]." "Stop moving"
 	
 	aCanvas translucentImage: iconForm at: x @ y
 ]
@@ -35,22 +35,23 @@ MenubarItemMorph >> menuStringBounds [
 
 	| oldBounds |
 	oldBounds := super menuStringBounds.
-	self shouldBeHighlighted ifTrue: [ oldBounds := oldBounds top: oldBounds top + 2 ].
+	"Stop shifting elements.
+	self shouldBeHighlighted ifTrue: [ oldBounds := oldBounds top: oldBounds top + 2 ]".
 	^ oldBounds left: (oldBounds left + oldBounds right - self measureContents x) // 2
 ]
 
 { #category : #drawing }
 MenubarItemMorph >> minHeight [
 
-	^ super minHeight + 6
+	^ super minHeight
 ]
 
 { #category : #private }
 MenubarItemMorph >> selectionFillStyle [
-	^ self theme menubarItemSelectionFillStyleFor: self
+	^ self theme settings menuSelectionColor.
 ]
 
 { #category : #private }
 MenubarItemMorph >> selectionTextColor [
-	^ self theme menubarItemSelectionTextColorFor: self
+	^ self theme settings menuSelectionTextColor.
 ]

--- a/src/Morphic-Widgets-Menubar/PluggableMenuSpec.extension.st
+++ b/src/Morphic-Widgets-Menubar/PluggableMenuSpec.extension.st
@@ -2,5 +2,8 @@ Extension { #name : #PluggableMenuSpec }
 
 { #category : #'*Morphic-Widgets-Menubar' }
 PluggableMenuSpec >> asMenubarMenuMorph [
-	^ self asMenuMorphOfKind: MenubarMenuMorph
+^ (self asMenuMorphOfKind: MenubarMenuMorph)
+			layoutItems; 
+			yourself
+
 ]


### PR DESCRIPTION
No more mismatched icon and line height in menus.

![image](https://user-images.githubusercontent.com/2128441/49345434-0af96580-f685-11e8-9b73-e8699111a6a3.png)
