### PR TITLE
22727-NonInteractiveTranscript-is-broken-with-files

### DIFF
--- a/src/Transcript-NonInteractive-Tests/NonInteractiveTranscriptTests.class.st
+++ b/src/Transcript-NonInteractive-Tests/NonInteractiveTranscriptTests.class.st
@@ -1,0 +1,51 @@
+"
+I am NonInteractiveTranscriptTests
+"
+Class {
+	#name : #NonInteractiveTranscriptTests,
+	#superclass : #TestCase,
+	#category : #'Transcript-NonInteractive-Tests'
+}
+
+{ #category : #tests }
+NonInteractiveTranscriptTests >> testAppend [
+	| log transcript |
+	log := 'test.log' asFileReference.
+	log ensureDelete.
+	transcript := NonInteractiveTranscript onFileNamed: log basename.
+	transcript
+		show: 'One'; cr; 
+		show: 'Two'; cr; 
+		close.
+	transcript := NonInteractiveTranscript onFileNamed: log basename.
+	transcript
+		show: 'Three'; cr; 
+		close.
+	self assert: log contents lines equals: #('One' 'Two' 'Three').
+	log ensureDelete
+]
+
+{ #category : #tests }
+NonInteractiveTranscriptTests >> testSimple [
+	| log transcript |
+	log := 'test.log' asFileReference.
+	log ensureDelete.
+	transcript := NonInteractiveTranscript onFileNamed: log basename.
+	transcript
+		show: 'One'; cr; 
+		show: 'Two'; cr; 
+		show: 'Three'; cr; 
+		close.
+	self assert: log contents lines equals: #('One' 'Two' 'Three').
+	log ensureDelete
+]
+
+{ #category : #tests }
+NonInteractiveTranscriptTests >> testStderr [
+	NonInteractiveTranscript stderr << 'Pharo writing to the standard error'; cr; flush
+]
+
+{ #category : #tests }
+NonInteractiveTranscriptTests >> testStdout [
+	NonInteractiveTranscript stdout << 'Pharo writing to the standard output'; cr; flush
+]

--- a/src/Transcript-NonInteractive-Tests/package.st
+++ b/src/Transcript-NonInteractive-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Transcript-NonInteractive-Tests' }

--- a/src/Transcript-NonInteractive/DailyNonInteractiveTranscript.class.st
+++ b/src/Transcript-NonInteractive/DailyNonInteractiveTranscript.class.st
@@ -39,17 +39,17 @@ DailyNonInteractiveTranscript >> initialize [
 
 { #category : #private }
 DailyNonInteractiveTranscript >> initializeStream [
-	"Open the file stream that I write to or connect to #stdout.
-	I use the proper line end convention.
+	"Open the file stream that I write to or connect to #stdout/#stderr.
+	I will use the platform line end convention.
 	I will append to regular files.
 	Overwrtitten to use #fileNameWithDate"
 	
-	stream := self isStdout 
+	^ stream := self isStdout 
 		ifTrue: [ Stdio stdout ]
-		ifFalse: [ File named: self fileNameWithDate ].
-	self isStdout
-		ifFalse: [ stream setToEnd ].
-	^ stream
+		ifFalse: [ 
+			self isStderr
+				ifTrue: [ Stdio stderr ]
+				ifFalse: [ (File named: self fileNameWithDate) openForAppend ] ]
 ]
 
 { #category : #accessing }

--- a/src/Transcript-NonInteractive/NonInteractiveTranscript.class.st
+++ b/src/Transcript-NonInteractive/NonInteractiveTranscript.class.st
@@ -172,19 +172,16 @@ NonInteractiveTranscript >> initialize [
 
 { #category : #private }
 NonInteractiveTranscript >> initializeStream [
-	"Open the file stream that I write to or connect to #stdout.
-	I use the proper line end convention.
+	"Open the file stream that I write to or connect to #stdout/#stderr.
+	I will use the platform line end convention.
 	I will append to regular files."
 	
-	stream := self isStdout 
+	^ stream := self isStdout 
 		ifTrue: [ Stdio stdout ]
 		ifFalse: [ 
 			self isStderr
 				ifTrue: [ Stdio stderr ]
-				ifFalse: [ File named: self fileName ]].
-	(self isStdout or: [ self isStderr ])
-		ifFalse: [ stream setToEnd ].
-	^ stream
+				ifFalse: [ (File named: self fileName) openForAppend ] ]
 ]
 
 { #category : #installation }


### PR DESCRIPTION
Fix the issue with NonInteractiveTranscript when using files as output
Add some elementary unit tests in package Transcript-NonInteractive-Testshttps://pharo.manuscript.com/f/cases/22727/NonInteractiveTranscript-is-broken-with-files