### PR TITLE
22728-Add-enough-informations-to-Metacello-to-load-a-project-from-a-gitlab-deployed-with-non-default-ssh-port

### DIFF
--- a/src/Metacello-Gitlab-Tests/MCGitlabRepositoryTest.class.st
+++ b/src/Metacello-Gitlab-Tests/MCGitlabRepositoryTest.class.st
@@ -15,21 +15,24 @@ MCGitlabRepositoryTest >> testLocation [
 		assert: repository hostname equals: 'gitlab.com';
 		assert: repository projectPath equals: 'pharo-project/pharo';
 		assert: repository projectVersion equals: 'master';
-		assert: repository repoPath equals: 'src'.
+		assert: repository repoPath equals: 'src';
+		assert: repository sshPort isNil.
 
 	repository := MCGitlabRepository location: 'gitlab://pharo-project/pharo:master'.
 	self
 		assert: repository hostname equals: 'gitlab.com';
 		assert: repository projectPath equals: 'pharo-project/pharo';
 		assert: repository projectVersion equals: 'master';
-		assert: repository repoPath isEmpty.
+		assert: repository repoPath isEmpty;
+		assert: repository sshPort isNil.
 
 	repository := MCGitlabRepository location: 'gitlab://pharo-project/pharo'.
 	self
 		assert: repository hostname equals: 'gitlab.com';
 		assert: repository projectPath equals: 'pharo-project/pharo';
 		assert: repository projectVersion equals: 'master';
-		assert: repository repoPath isEmpty
+		assert: repository repoPath isEmpty;
+		assert: repository sshPort isNil
 ]
 
 { #category : #tests }
@@ -51,19 +54,50 @@ MCGitlabRepositoryTest >> testSelfHostedLocation [
 		assert: repository hostname equals: 'git.pharo.org';
 		assert: repository projectPath equals: 'pharo-project/pharo';
 		assert: repository projectVersion equals: 'master';
-		assert: repository repoPath equals: 'src'.
+		assert: repository repoPath equals: 'src';
+		assert: repository sshPort isNil.
 
 	repository := MCGitlabRepository location: 'gitlab://git.pharo.org:pharo-project/pharo:master'.
 	self
 		assert: repository hostname equals: 'git.pharo.org';
 		assert: repository projectPath equals: 'pharo-project/pharo';
 		assert: repository projectVersion equals: 'master';
-		assert: repository repoPath isEmpty.
+		assert: repository repoPath isEmpty;
+		assert: repository sshPort isNil.
 
 	repository := MCGitlabRepository location: 'gitlab://git.pharo.org:pharo-project/pharo'.
 	self
 		assert: repository hostname equals: 'git.pharo.org';
 		assert: repository projectPath equals: 'pharo-project/pharo';
 		assert: repository projectVersion equals: 'master';
-		assert: repository repoPath isEmpty
+		assert: repository repoPath isEmpty;
+		assert: repository sshPort isNil
+]
+
+{ #category : #tests }
+MCGitlabRepositoryTest >> testSelfHostedLocationWithNonDefaultSSHPort [
+	| repository |
+	repository := MCGitlabRepository location: 'gitlab://git.pharo.org:1234:pharo-project/pharo:master/src'.
+	self
+		assert: repository hostname equals: 'git.pharo.org';
+		assert: repository projectPath equals: 'pharo-project/pharo';
+		assert: repository projectVersion equals: 'master';
+		assert: repository repoPath equals: 'src';
+		assert: repository sshPort equals: '1234'.
+
+	repository := MCGitlabRepository location: 'gitlab://git.pharo.org:1234:pharo-project/pharo:master'.
+	self
+		assert: repository hostname equals: 'git.pharo.org';
+		assert: repository projectPath equals: 'pharo-project/pharo';
+		assert: repository projectVersion equals: 'master';
+		assert: repository repoPath isEmpty;
+		assert: repository sshPort equals: '1234'.
+
+	repository := MCGitlabRepository location: 'gitlab://git.pharo.org:1234:pharo-project/pharo'.
+	self
+		assert: repository hostname equals: 'git.pharo.org';
+		assert: repository projectPath equals: 'pharo-project/pharo';
+		assert: repository projectVersion equals: 'master';
+		assert: repository repoPath isEmpty;
+		assert: repository sshPort equals: '1234'
 ]

--- a/src/Metacello-Gitlab/MCGitlabRepository.class.st
+++ b/src/Metacello-Gitlab/MCGitlabRepository.class.st
@@ -1,8 +1,37 @@
+"
+Description
+--------------------
+
+I am a repository managing projects hosted on gitlab.com or a self hosted gitlab.
+
+I am able to manage schemes such has:
+
+- gitlab://pharo-project/pharo:master/src
+- gitlab://pharo-project/pharo:master
+- gitlab://pharo-project/pharo
+- gitlab://git.pharo.org:pharo-project/pharo:master/src
+- gitlab://git.pharo.org:pharo-project/pharo:master
+- gitlab://git.pharo.org:pharo-project/pharo
+- gitlab://git.pharo.org:1234:pharo-project/pharo:master/src
+- gitlab://git.pharo.org:1234:pharo-project/pharo:master
+- gitlab://git.pharo.org:1234:pharo-project/pharo
+
+	
+ 
+Internal Representation and Key Implementation Points.
+--------------------
+
+    Instance Variables
+	hostname:		<aString>			The hostname of the repository. By default gitlab.com. Can also be the URL of the self hosted gitlab.
+	sshPort:		<aString>			Non default SSH port.
+
+"
 Class {
 	#name : #MCGitlabRepository,
 	#superclass : #MCGitBasedNetworkRepository,
 	#instVars : [
-		'hostname'
+		'hostname',
+		'sshPort'
 	],
 	#category : #'Metacello-Gitlab'
 }
@@ -39,22 +68,28 @@ MCGitlabRepository class >> parseLocation: locationUrl version: versionString [
 	If no hostname is specified default to the old behavior (using gitlab.com)
 	"
 
-	| location hostnameAndOwner |
+	| location hostAndOwner |
 	"Remove gitlab:// prefix"
 	location := locationUrl copyFrom: self description size + 1 to: locationUrl size.
 	"Take the next chunk up to the first / and split it to get the hostname and owner"
-	hostnameAndOwner := (location copyFrom: 1 to: (location indexOf: $/)) splitOn: $:.
-	^ hostnameAndOwner size = 1
+	hostAndOwner := (location copyFrom: 1 to: (location indexOf: $/)) splitOn: $:.
+	^ hostAndOwner size = 1
 		ifTrue: [ "No hostname specified, so use the default one"
 			(super parseLocation: locationUrl version: versionString)
 				hostname: self defaultHostname;
 				yourself ]
-		ifFalse: [ | newLocationUrl hostname |
-			hostname := hostnameAndOwner first.
-			newLocationUrl := self description , (location copyFrom: hostname size + 2 to: location size).
+		ifFalse: [ | newLocationUrl hostname sshPort numberOfCharactersToRemoveFromLocation |
+			hostname := hostAndOwner first.
+			numberOfCharactersToRemoveFromLocation := hostname size + 2.
+			"If the hostAndOwner array has 3 parts, we have a ssh port"
+			hostAndOwner size > 2
+				ifTrue: [ sshPort := hostAndOwner second.
+					numberOfCharactersToRemoveFromLocation := numberOfCharactersToRemoveFromLocation + sshPort size + 1 ].	
+			newLocationUrl := self description , (location copyFrom: numberOfCharactersToRemoveFromLocation to: location size).
 			"Reuse the parsing omitting the hostname"
 			(super parseLocation: newLocationUrl version: versionString)
 				hostname: hostname;
+				sshPort: sshPort;
 				yourself ]
 ]
 
@@ -71,4 +106,14 @@ MCGitlabRepository >> hostname: aString [
 { #category : #private }
 MCGitlabRepository >> projectTagsUrlFor: aProjectPath [
 	^ 'https://<1s>/api/v4/projects/<2s>/repository/tags' expandMacrosWith: self hostname with: aProjectPath
+]
+
+{ #category : #accessing }
+MCGitlabRepository >> sshPort [
+	^ sshPort
+]
+
+{ #category : #accessing }
+MCGitlabRepository >> sshPort: anObject [
+	sshPort := anObject
 ]


### PR DESCRIPTION
Add info about non default ssh port for gitlab.

Fixes https://pharo.fogbugz.com/f/cases/22728/Add-enough-informations-to-Metacello-to-load-a-project-from-a-gitlab-deployed-with-non-default-ssh-port