### PR TITLE
Adding BreakpointBrowser to Pharo

### DIFF
--- a/src/BreakpointBrowser/BreakpointBrowser.class.st
+++ b/src/BreakpointBrowser/BreakpointBrowser.class.st
@@ -1,0 +1,83 @@
+"
+My class method ""open"" opens a Calypso method browser showing all the methods of the image that have halts or breakpoints in them. The different flavours of halts and breakpoints are also covered (break once, break on condition, haltIf: haltOnCount:, haltOnce...).
+
+By default, I do not show methods from my own package, nor methods registered on my ""blacklist"" class method. Blacklisted methods are meant to be methods from the core of Pharo that include halts for legitimate reasons (testing for example) and would probably pollute the experience of users if they were shown in the BreakpointBrowser.
+If you want to see all methods containing halts and breakpoints without any filtering, you can call my ""openUnfiltered"" class method. 
+"
+Class {
+	#name : #BreakpointBrowser,
+	#superclass : #Object,
+	#category : #BreakpointBrowser
+}
+
+{ #category : #filtering }
+BreakpointBrowser class >> blacklist [
+	"These methods will not be shown by BreakpointBrowser by default. They contain halts but are meant to contain them (for example, they can be testing that executing self halt does indeed raise a halt)
+	Format: Array of {class name symbol. method name symbol} arrays"
+	^ { 
+	{#ClyClassWithHalts. #methodWithHalts2}.
+	{#ClyClassWithHalts. #methodWithHalts1}.
+	{#ClyClassWithProblemMethods. #methodWithHalt}.
+	{#ClyClassWithProblemMethods. #methodWithHalt2}.
+	{#GTSUnitExampleFailingTest. #testWithHalt}.
+	{#Object. #openDebugger}.
+	{#Object. #openDebugger:}.
+	{#ObjectTest. #b}.
+	{#ObjectTest. #b1}.
+	{#ObjectTest. #testHaltIf}.
+	{#ObjectTest. #testHaltOnce}.
+	{#ObjectTest. #testHaltOnCount}.
+	{#UndefinedObjectTest. #testHaltIfNil}.
+	{#UndefinedObjectTest. #testIfNil}.
+	{#UndefinedObjectTest. #testIfNilIfNotNil}.
+	{#UndefinedObjectTest. #testIfNotNilIfNil}.
+	{#CodeSimulationTests. #methodWithHalt}.
+	{#RBRefactoryTestDataApp. #cruft}.
+	{#RBSmalllintTestObject. #codeCruftLeftInMethods}.
+	{#RBDummyRefactoryTestDataApp. #cruft}.
+	 }
+]
+
+{ #category : #filtering }
+BreakpointBrowser class >> filterOutMethodsFromBlacklist: anOrderedCollectionOfRBMethodDefinition [
+	^ anOrderedCollectionOfRBMethodDefinition select: [ :anRGMethodDef | (self methodIsOnBlacklist: anRGMethodDef) not]
+]
+
+{ #category : #filtering }
+BreakpointBrowser class >> filterOutMethodsFromThisPackage: anOrderedCollectionOfRBMethodDefinition [
+	^ anOrderedCollectionOfRBMethodDefinition select: [ :anRGMethodDef |(anRGMethodDef package realPackage == self package) not ]
+]
+
+{ #category : #filtering }
+BreakpointBrowser class >> methodIsOnBlacklist: anRGMethodDef [
+	^ self blacklist anySatisfy: [:classNameSymbolAndMethodNameSymbol |
+			((anRGMethodDef realClass) = (self environment at: (classNameSymbolAndMethodNameSymbol at: 1) ifAbsent: [^false])) and: 
+			[ anRGMethodDef name = (classNameSymbolAndMethodNameSymbol at: 2) ]
+	].
+]
+
+{ #category : #filtering }
+BreakpointBrowser class >> methodsToDisplay [
+	^ SystemNavigation default allMethodsSelect: [ :aMethod | 
+		aMethod hasBreakpoint or: [
+		aMethod containsHalt]].
+]
+
+{ #category : #filtering }
+BreakpointBrowser class >> open [
+	<script>
+	"Opens a method browser showing all methods containing breakpoints (and its flavours like break once), halts (and its flavours like haltOnce), inactive breakpoints (and flavours) and inactive halts (and flavours). Filter out such methods that belong to the HaltManager package."
+	| b |
+	b := ClyQueryBrowser browseMethods: (self filterOutMethodsFromBlacklist: (self filterOutMethodsFromThisPackage: (self methodsToDisplay))) withTitle: 'Breakpoint Browser'.
+	b switchResultTo: (ClySortedQueryResult using: SortMethodsByPackageFunction new )
+	
+]
+
+{ #category : #filtering }
+BreakpointBrowser class >> openUnfiltered [
+	<script>
+	"Does the same as the openHaltManager method, without filtering out the methods from the HaltManager package"
+	| b |
+	b := ClyQueryBrowser browseMethods: (self methodsToDisplay) withTitle: 'Breakpoint Browser (unfiltered)'.
+	b switchResultTo: (ClySortedQueryResult using: SortMethodsByPackageFunction new )
+]

--- a/src/BreakpointBrowser/BreakpointBrowserTests.class.st
+++ b/src/BreakpointBrowser/BreakpointBrowserTests.class.st
@@ -1,0 +1,120 @@
+Class {
+	#name : #BreakpointBrowserTests,
+	#superclass : #TestCase,
+	#instVars : [
+		'breakpointsAddedDuringSetupAndTests'
+	],
+	#category : #BreakpointBrowser
+}
+
+{ #category : #adding }
+BreakpointBrowserTests >> addBreakpointConditionalOnSetupHere [
+"Dummy method to indicate a position to put a conditional breakpoint at in the setUp of this test class"
+]
+
+{ #category : #adding }
+BreakpointBrowserTests >> addBreakpointOnSetupHere [
+"Dummy method to indicate a position to put a breakpoint at in the setUp of this test class"
+]
+
+{ #category : #adding }
+BreakpointBrowserTests >> addBreakpointOnceOnSetupHere [
+"Dummy method to indicate a position to put a once breakpoint at in the setUp of this test class"
+]
+
+{ #category : #'halts and breakpoints' }
+BreakpointBrowserTests >> methodWithBreakpoint [
+	self addBreakpointOnSetupHere "Breakpoint will be added during setup and removed during teardown"
+]
+
+{ #category : #'halts and breakpoints' }
+BreakpointBrowserTests >> methodWithBreakpointConditional [
+	self addBreakpointConditionalOnSetupHere "Breakpoint will be added during setup and removed during teardown"
+]
+
+{ #category : #'halts and breakpoints' }
+BreakpointBrowserTests >> methodWithBreakpointOnce [
+	self addBreakpointOnceOnSetupHere "Breakpoint will be added during setup and removed during teardown"
+]
+
+{ #category : #'halts and breakpoints' }
+BreakpointBrowserTests >> methodWithHalt [
+	self halt
+]
+
+{ #category : #'halts and breakpoints' }
+BreakpointBrowserTests >> methodWithHaltColon [
+	self halt: 'Hey'
+]
+
+{ #category : #'halts and breakpoints' }
+BreakpointBrowserTests >> methodWithHaltIf [
+	self haltIf: [ true ]
+]
+
+{ #category : #'halts and breakpoints' }
+BreakpointBrowserTests >> methodWithHaltIfNil [
+	self haltIfNil
+]
+
+{ #category : #'halts and breakpoints' }
+BreakpointBrowserTests >> methodWithHaltOnCount [
+	self haltOnCount: 4
+]
+
+{ #category : #'halts and breakpoints' }
+BreakpointBrowserTests >> methodWithHaltOnce [
+	self haltOnce
+]
+
+{ #category : #'halts and breakpoints' }
+BreakpointBrowserTests >> methodWithHaltSentToOne [
+	1halt
+]
+
+{ #category : #running }
+BreakpointBrowserTests >> setUp [
+	breakpointsAddedDuringSetupAndTests := LinkedList new.
+
+	"Adding breakpoints to the message node of selector addBreakpointOnSetupHere in method methodWithBreakpoint"
+	(MessageNodeFinder findMessageNodesSatisfying: [ :msgNode | msgNode selector == #addBreakpointOnSetupHere ] inNode: (self class >>#methodWithBreakpoint) ast) do: [
+		 :node |
+		|brkpt| 
+		brkpt := Breakpoint new node: node; always; install.
+		breakpointsAddedDuringSetupAndTests add: brkpt.
+	].
+
+	"Adding once breakpoints to the message node of selector addBreakpointOnceOnSetupHere in method methodWithBreakpointOnce"
+	(MessageNodeFinder findMessageNodesSatisfying: [ :msgNode | msgNode selector == #addBreakpointOnceOnSetupHere ] inNode: (self class >>#methodWithBreakpointOnce) ast) do: [
+		 :node |
+		|brkpt| 
+		brkpt := Breakpoint new node: node; once; install.
+		breakpointsAddedDuringSetupAndTests add: brkpt.
+	].
+
+	"Adding conditional breakpoints to the message node of selector addBreakpointConditionalOnSetupHere in method methodWithBreakpointConditional"
+	(MessageNodeFinder findMessageNodesSatisfying: [ :msgNode | msgNode selector == #addBreakpointConditionalOnSetupHere ] inNode: (self class >>#methodWithBreakpointConditional) ast) do: [
+		 :node |
+		|brkpt| 
+		brkpt := Breakpoint new node: node; condition: (Smalltalk compiler evaluate: 'true'); install.
+		breakpointsAddedDuringSetupAndTests add: brkpt.
+	].
+]
+
+{ #category : #tests }
+BreakpointBrowserTests >> testMethodsToDisplay [
+	| methodsToDisplay methodContainmentAssertionBlock |
+	methodsToDisplay := BreakpointBrowser methodsToDisplay collect: [:anRGMethodDefinition| anRGMethodDefinition method].
+	methodContainmentAssertionBlock := [ :selector | 	self assert: (methodsToDisplay contains: [:aCompiledMethod | aCompiledMethod == (self class >>selector)]) ].
+
+	methodContainmentAssertionBlock value: #methodWithBreakpoint.
+	methodContainmentAssertionBlock value: #methodWithBreakpointConditional.
+	methodContainmentAssertionBlock value: #methodWithBreakpointOnce.
+	methodContainmentAssertionBlock value: #methodWithHalt.
+	methodContainmentAssertionBlock value: #methodWithHaltColon.
+	methodContainmentAssertionBlock value: #methodWithHaltIf.
+	methodContainmentAssertionBlock value: #methodWithHaltIfNil.
+	methodContainmentAssertionBlock value: #methodWithHaltOnCount.
+	methodContainmentAssertionBlock value: #methodWithHaltOnce.
+	methodContainmentAssertionBlock value: #methodWithHaltSentToOne.
+]

--- a/src/BreakpointBrowser/package.st
+++ b/src/BreakpointBrowser/package.st
@@ -1,0 +1,1 @@
+Package { #name : #BreakpointBrowser }

--- a/src/Morphic-Base/WorldState.extension.st
+++ b/src/Morphic-Base/WorldState.extension.st
@@ -16,7 +16,16 @@ WorldState class >> debugOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #Debugging)
 		order: 3.5;
-		with: [ (aBuilder item: #'Remove all Breakpoints')
+		with: [
+			(aBuilder item: #'Open Breakpoint Browser')
+				order: 1;
+				help: 'Lists all breakpoints and halts in the image.';
+				action: [ BreakpointBrowser open ].
+			(aBuilder item: #'Open Breakpoint Browser (unfiltered)')
+				order: 2;
+				help: 'Lists all breakpoints and halts in the image, even those from system tests.';
+				action: [ BreakpointBrowser openUnfiltered ].
+			(aBuilder item: #'Remove all Breakpoints')
 				order: 0;
 				help: 'Remove all the breakpoints of the image.';
 				action: [ Breakpoint removeAll ].


### PR DESCRIPTION
BreakpointBrowser is accessible via the "Debugging" menu of the image and shows a list of the methods that contain halts or breakpoints in the image as a Calypso method browser.