### PR TITLE
22735-ZipArchive-classisZipArchive-is-broken-in-P7

### DIFF
--- a/src/Compression-Tests/ZipArchiveTest.class.st
+++ b/src/Compression-Tests/ZipArchiveTest.class.st
@@ -329,25 +329,17 @@ ZipArchiveTest >> testZip [
 ]
 
 { #category : #tests }
-ZipArchiveTest >> testisFileAZipArchive [
-	| nonArchive |
-	zip addFile: fileToZip fullName as: fileToZip basename.
-	zip writeToFileNamed: zipFile fullName.
-	self assert: (ZipArchive isFileAZipArchive: zipFile).
-	nonArchive := 'non_archive_file_for_test.txt' asFileReference.
-	nonArchive ensureCreateFile.
-	[ self deny: (ZipArchive isFileAZipArchive: nonArchive) ]
-		ensure: [ nonArchive ensureDelete ]
-]
-
-{ #category : #tests }
 ZipArchiveTest >> testisZipArchive [
 	| nonArchive |
 	zip addFile: fileToZip fullName as: fileToZip basename.
 	zip writeToFileNamed: zipFile fullName.
 	self assert: (ZipArchive isZipArchive: zipFile fullName).
+	self assert: (ZipArchive isZipArchive: zipFile).
+	self assert: (zipFile binaryReadStreamDo: [ :s | ZipArchive isZipArchive: s ]).
 	nonArchive := 'non_archive_file_for_test.txt' asFileReference.
 	nonArchive ensureCreateFile.
-	[ self deny: (ZipArchive isZipArchive: nonArchive fullName) ]
+	[ self deny: (ZipArchive isZipArchive: nonArchive fullName).
+	self deny: (ZipArchive isZipArchive: nonArchive).
+	self deny: (nonArchive binaryReadStreamDo: [ :s | ZipArchive isZipArchive: s ]) ]
 		ensure: [ nonArchive ensureDelete ]
 ]

--- a/src/Compression-Tests/ZipArchiveTest.class.st
+++ b/src/Compression-Tests/ZipArchiveTest.class.st
@@ -327,3 +327,27 @@ ZipArchiveTest >> testZip [
 		self assert: (endianStream nextLittleEndianNumber: 2) equals: 0 "zip comment length".
 		self assert: str atEnd ].
 ]
+
+{ #category : #tests }
+ZipArchiveTest >> testisFileAZipArchive [
+	| nonArchive |
+	zip addFile: fileToZip fullName as: fileToZip basename.
+	zip writeToFileNamed: zipFile fullName.
+	self assert: (ZipArchive isFileAZipArchive: zipFile).
+	nonArchive := 'non_archive_file_for_test.txt' asFileReference.
+	nonArchive ensureCreateFile.
+	[ self deny: (ZipArchive isFileAZipArchive: nonArchive) ]
+		ensure: [ nonArchive ensureDelete ]
+]
+
+{ #category : #tests }
+ZipArchiveTest >> testisZipArchive [
+	| nonArchive |
+	zip addFile: fileToZip fullName as: fileToZip basename.
+	zip writeToFileNamed: zipFile fullName.
+	self assert: (ZipArchive isZipArchive: zipFile fullName).
+	nonArchive := 'non_archive_file_for_test.txt' asFileReference.
+	nonArchive ensureCreateFile.
+	[ self deny: (ZipArchive isZipArchive: nonArchive fullName) ]
+		ensure: [ nonArchive ensureDelete ]
+]

--- a/src/Compression/ZipArchive.class.st
+++ b/src/Compression/ZipArchive.class.st
@@ -82,10 +82,19 @@ ZipArchive class >> findEndOfCentralDirectoryFrom: stream [
 ]
 
 { #category : #'file format' }
+ZipArchive class >> isFileAZipArchive: aFile [
+	"Answer whether the given file represents a valid zip file."
+	
+	^ self isZipArchive: aFile fullName
+]
+
+{ #category : #'file format' }
 ZipArchive class >> isZipArchive: aStreamOrFileName [
 	"Answer whether the given filename represents a valid zip file."
 
 	| stream eocdPosition |
+	self flag: #clean. "This assert is here to help the transition between Pharo 6.1 and 7. In Pharo "
+	self assert: (aStreamOrFileName isStream or: [ aStreamOrFileName isString]) description: 'In Pharo 6 this method worked on FileReferences. Now it does not. If you want to make it work on a file reference, use #isFileAZipArchive:'. 
 	stream := aStreamOrFileName isStream
 		ifTrue: [aStreamOrFileName]
 		ifFalse: [File openForReadFileNamed: aStreamOrFileName].

--- a/src/Compression/ZipArchive.class.st
+++ b/src/Compression/ZipArchive.class.st
@@ -82,27 +82,21 @@ ZipArchive class >> findEndOfCentralDirectoryFrom: stream [
 ]
 
 { #category : #'file format' }
-ZipArchive class >> isFileAZipArchive: aFile [
-	"Answer whether the given file represents a valid zip file."
+ZipArchive class >> isZipArchive: file [
+	"Answer whether the given file represents a valid zip file. The argument file can be a String, FileReference or an open binary read stream.
 	
-	^ self isZipArchive: aFile fullName
-]
-
-{ #category : #'file format' }
-ZipArchive class >> isZipArchive: aStreamOrFileName [
-	"Answer whether the given filename represents a valid zip file."
+	See ZipArchiveTest>>testisZipArchive for examples."
 
 	| stream eocdPosition |
-	self flag: #clean. "This assert is here to help the transition between Pharo 6.1 and 7. In Pharo "
-	self assert: (aStreamOrFileName isStream or: [ aStreamOrFileName isString]) description: 'In Pharo 6 this method worked on FileReferences. Now it does not. If you want to make it work on a file reference, use #isFileAZipArchive:'. 
-	stream := aStreamOrFileName isStream
-		ifTrue: [aStreamOrFileName]
-		ifFalse: [File openForReadFileNamed: aStreamOrFileName].
-	stream ifNil: [^ false].
-	"nil happens sometimes somehow"
-	stream size < 22 ifTrue: [^ false].
+	stream := file isStream
+		ifTrue: [ file ]
+		ifFalse: [ file asFileReference binaryReadStream ].
+		
+	stream size < 22 ifTrue: [ ^ false ].
+	
 	eocdPosition := self findEndOfCentralDirectoryFrom: stream.
-	stream ~= aStreamOrFileName ifTrue: [stream close].
+	stream ~= file ifTrue: [ stream close ].
+	
 	^ eocdPosition > 0
 ]
 


### PR DESCRIPTION
Work on migration form pharo 6 to 7 + non regression tests

Fixes https://pharo.fogbugz.com/f/cases/22735/ZipArchive-class-isZipArchive-is-broken-in-P7