### PR TITLE
22753-RBParseErrorNode-should-pretty-print-the-faulty-text-if-it-has-it

### DIFF
--- a/src/AST-Core/BISimpleFormatter.class.st
+++ b/src/AST-Core/BISimpleFormatter.class.st
@@ -312,20 +312,32 @@ BISimpleFormatter >> lineStart: anObject [
 
 { #category : #private }
 BISimpleFormatter >> needsParenthesisFor: aNode [
-  | parent |
-  aNode ifNil: [ ^false ].
-  aNode isValue ifFalse: [ ^false ].
-   parent := aNode parent ifNil: [ ^false ].
-   aNode precedence < parent precedence ifTrue: [ ^false ].
-   (aNode isAssignment and: [ parent isAssignment ]) ifTrue: [ ^false ].
-   (aNode isAssignment and: [ aNode isCascade ]) ifTrue: [ ^true ].
-   aNode precedence = 0 ifTrue: [ ^false ].
-   aNode isMessage ifFalse: [ ^true ].
-   aNode isUnary ifTrue: [ ^false ].
-   aNode isKeyword ifTrue: [ ^true ].
-   (parent isMessage and: [ parent receiver == aNode ]) ifFalse: [ ^true ].
-   aNode precedence = parent precedence ifFalse: [ ^true ].
-   ^self precedenceOf: parent selector greaterThan: aNode selector
+	| parent |
+	aNode ifNil: [ ^ false ].
+	aNode isValue
+		ifFalse: [ ^ false ].
+	aNode isParseError 
+		ifTrue: [ ^false ].
+	parent := aNode parent ifNil: [ ^ false ].
+	aNode precedence < parent precedence
+		ifTrue: [ ^ false ].
+	(aNode isAssignment and: [ parent isAssignment ])
+		ifTrue: [ ^ false ].
+	(aNode isAssignment and: [ aNode isCascade ])
+		ifTrue: [ ^ true ].
+	aNode precedence = 0
+		ifTrue: [ ^ false ].
+	aNode isMessage
+		ifFalse: [ ^ true ].
+	aNode isUnary
+		ifTrue: [ ^ false ].
+	aNode isKeyword
+		ifTrue: [ ^ true ].
+	(parent isMessage and: [ parent receiver == aNode ])
+		ifFalse: [ ^ true ].
+	aNode precedence = parent precedence
+		ifFalse: [ ^ true ].
+	^ self precedenceOf: parent selector greaterThan: aNode selector
 ]
 
 { #category : #private }
@@ -470,6 +482,11 @@ BISimpleFormatter >> visitNode: aNode [
 				ifTrue: [ '()' ]
 				ifFalse: [ '' ])
 		around: [ super visitNode: aNode ]
+]
+
+{ #category : #visiting }
+BISimpleFormatter >> visitParseErrorNode: aNode [
+		self writeString: aNode value
 ]
 
 { #category : #visiting }

--- a/src/AST-Core/RBParseErrorNode.class.st
+++ b/src/AST-Core/RBParseErrorNode.class.st
@@ -89,6 +89,11 @@ RBParseErrorNode >> isFaulty [
 	^true
 ]
 
+{ #category : #testing }
+RBParseErrorNode >> isParseError [
+	^true
+]
+
 { #category : #accessing }
 RBParseErrorNode >> name [
 	"be polymorphic with variable nodes"

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -472,6 +472,11 @@ RBProgramNode >> isMethod [
 	^false
 ]
 
+{ #category : #testing }
+RBProgramNode >> isParseError [
+	^false
+]
+
 { #category : #'testing-matching' }
 RBProgramNode >> isPatternNode [
 	^false

--- a/src/AST-Tests-Core/RBFormatterTest.class.st
+++ b/src/AST-Tests-Core/RBFormatterTest.class.st
@@ -74,6 +74,16 @@ RBFormatterTest >> testLiteralDynamicArray [
 ]
 
 { #category : #testing }
+RBFormatterTest >> testParseError [
+	| inputSource errorNode |
+	"parse error nodes should have the faulty code"
+	inputSource := ')'.
+   errorNode := RBParser parseFaultyExpression: inputSource.
+	self assert: errorNode source equals: errorNode formattedCode
+
+]
+
+{ #category : #testing }
 RBFormatterTest >> testPreserveLiteralArrayFormat [
 	| inputSource literalArrayNode |
 	"symbols within a literal array can omit the # character, if it is used that way,

--- a/src/BlueInk-Core/BIConfigurableFormatter.class.st
+++ b/src/BlueInk-Core/BIConfigurableFormatter.class.st
@@ -997,6 +997,7 @@ BIConfigurableFormatter >> needsParenthesisFor: aNode [
 	aNode ifNil: [ ^ false ].
 	aNode isValue
 		ifFalse: [ ^ false ].
+	aNode isParseError ifTrue: [ ^false ].
 	parent := aNode parent ifNil: [ ^ false ].
 	(aNode isMessage and: [ 
 		parent isMessage and: [ 
@@ -1479,6 +1480,11 @@ BIConfigurableFormatter >> visitNode: aNode [
 				ifFalse: [ self formatCommentsFor: aNode ].
 			needsParenthesis
 				ifTrue: [ codeStream nextPutAll: self stringInsideParentheses ] ]
+]
+
+{ #category : #visiting }
+BIConfigurableFormatter >> visitParseErrorNode: aNode [
+	self writeString: aNode value
 ]
 
 { #category : #visiting }


### PR DESCRIPTION
RBParseErrorNode should pretty print thttps://pharo.fogbugz.com/f/cases/22753/RBParseErrorNode-should-pretty-print-the-faulty-text-if-it-has-ithe faulty text (if it has it)