### PR TITLE
22755-Reflectivity-cleanups-tests-unify-variable-Naming

### DIFF
--- a/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
+++ b/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
@@ -99,7 +99,7 @@ ReflectiveMethodTest >> testSetLink [
 	sendNode := (ReflectivityExamples >> #exampleMethod) ast body statements first value.
 	sendNode link: link.
 	self assert: (sendNode hasMetalink: link).
-	self assert: (ReflectivityExamples >> #exampleMethod) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	sendNode removeLink: link.
 	(ReflectivityExamples >> #exampleMethod) destroyTwin.
 	self assert: (ReflectivityExamples >> #exampleMethod) class equals: CompiledMethod.
@@ -131,7 +131,7 @@ ReflectiveMethodTest >> testSetLinkOnClassVariable [
 	classVar link: link.
 
 	self assert: (classVar links includes: link).
-	self assert: (ReflectivityExamples >> #exampleClassVarRead) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleClassVarRead) class equals: ReflectiveMethod.
 	classVar removeProperty: #links.
 ]
 
@@ -144,11 +144,11 @@ ReflectiveMethodTest >> testSetLinkOnClassVariableAndUninstall [
 	classVar link: link.
 
 	self assert: (classVar links includes: link).
-	self assert: (ReflectivityExamples >> #exampleClassVarRead) class = ReflectiveMethod.
-	self assert: (ReflectivityExamples >> #exampleClassVarRead) linkCount = 1.
+	self assert: (ReflectivityExamples >> #exampleClassVarRead) class equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleClassVarRead) linkCount equals: 1.
 	
 	link uninstall.
-	self assert: (ReflectivityExamples >> #exampleClassVarRead) class = CompiledMethod.
+	self assert: (ReflectivityExamples >> #exampleClassVarRead) class equals: CompiledMethod.
 
 ]
 
@@ -160,7 +160,7 @@ ReflectiveMethodTest >> testSetLinkOnGlobalVariable [
 	globalVar := (Smalltalk globals at: #GlobalForTesting) binding.
 	globalVar link: link. 
 	self assert: (globalVar links includes: link).
-	self assert: (ReflectivityExamples >> #exampleGlobalRead) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleGlobalRead) class equals: ReflectiveMethod.
 	link uninstall.
 	globalVar removeProperty: #links.
 	
@@ -174,10 +174,10 @@ ReflectiveMethodTest >> testSetLinkOnGlobalVariableAndUninstall [
 	global := (Smalltalk globals at: #GlobalForTesting) binding.
 	global link: link.
 	self assert: (global links includes: link). 
-	self assert: (ReflectivityExamples >> #exampleGlobalRead) class = ReflectiveMethod.
-	self assert: (ReflectivityExamples >> #exampleGlobalRead) linkCount = 1.
+	self assert: (ReflectivityExamples >> #exampleGlobalRead) class equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleGlobalRead) linkCount equals: 1.
 	link uninstall.
-	self assert: (ReflectivityExamples >> #exampleGlobalRead) class = CompiledMethod.
+	self assert: (ReflectivityExamples >> #exampleGlobalRead) class equals: CompiledMethod.
 	global removeProperty: #links.
 
 
@@ -191,7 +191,7 @@ ReflectiveMethodTest >> testSetLinkOnInstanceVariable [
 	ivar := ReflectivityExamples slotNamed: #ivar.
 	ivar link: link.
 	self assert: (ivar links includes: link).
-	self assert: (ReflectivityExamples >> #exampleIvarRead) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleIvarRead) class equals: ReflectiveMethod.
 	link uninstall.
 ]
 
@@ -203,10 +203,10 @@ ReflectiveMethodTest >> testSetLinkOnInstanceVariableAndUninstall [
 	ivar := ReflectivityExamples slotNamed: #ivar.
 	ivar link: link.
 	self assert: (ivar links includes: link).
-	self assert: (ReflectivityExamples >> #exampleIvarRead) class = ReflectiveMethod.
-	self assert: (ReflectivityExamples >> #exampleIvarRead) linkCount = 1.
+	self assert: (ReflectivityExamples >> #exampleIvarRead) class equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleIvarRead) linkCount equals: 1.
 	link uninstall.
-	self assert: (ReflectivityExamples >> #exampleIvarRead) class = CompiledMethod.
+	self assert: (ReflectivityExamples >> #exampleIvarRead) class equals: CompiledMethod.
 	self assert: (ivar links isEmpty).
 ]
 
@@ -219,11 +219,11 @@ ReflectiveMethodTest >> testSetLinkOnPrimitive [
 	self assert: (ReflectivityExamples>>#examplePrimitiveMethod) isRealPrimitive.
 	methodNode link: link.
 	self assert: (methodNode links includes: link).
-	self assert: (ReflectivityExamples>>#examplePrimitiveMethod) class = CompiledMethod.
+	self assert: (ReflectivityExamples>>#examplePrimitiveMethod) class equals: CompiledMethod.
 	self deny: (ReflectivityExamples>>#examplePrimitiveMethod) isRealPrimitive.
 	methodNode removeLink: link.
 	(ReflectivityExamples>>#examplePrimitiveMethod) destroyTwin.
-	self assert: (ReflectivityExamples>>#examplePrimitiveMethod) class = CompiledMethod.
+	self assert: (ReflectivityExamples>>#examplePrimitiveMethod) class equals: CompiledMethod.
 	self assert: (ReflectivityExamples>>#examplePrimitiveMethod) isRealPrimitive.
 	self assert: (ReflectivityExamples>>#examplePrimitiveMethod) reflectiveMethod isNil.
 	
@@ -237,10 +237,10 @@ ReflectiveMethodTest >> testSetLinkWithPragmaOptions [
 	sendNode := (ReflectivityExamples>>#exampleMethodWithMetaLinkOptions) ast body statements first value.
 	sendNode link: link.
 	self assert: (sendNode links includes: link).
-	self assert: (ReflectivityExamples>>#exampleMethodWithMetaLinkOptions) class = CompiledMethod.
+	self assert: (ReflectivityExamples>>#exampleMethodWithMetaLinkOptions) class equals: CompiledMethod.
 	sendNode removeLink: link.
 	(ReflectivityExamples>>#exampleMethodWithMetaLinkOptions) destroyTwin.
-	self assert: (ReflectivityExamples>>#exampleMethodWithMetaLinkOptions) class = CompiledMethod.
+	self assert: (ReflectivityExamples>>#exampleMethodWithMetaLinkOptions) class equals: CompiledMethod.
 	self assert: (ReflectivityExamples>>#exampleMethodWithMetaLinkOptions) reflectiveMethod isNil.
 	
 ]

--- a/src/Reflectivity-Tests/ReflectivityControlTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityControlTest.class.st
@@ -40,23 +40,18 @@ ReflectivityControlTest >> tearDown [
 { #category : #'tests - after' }
 ReflectivityControlTest >> testAfterArray [
 	| arrayNode |
-	arrayNode := (ReflectivityExamples >> #exampleArray) ast statements
-		first value.
+	arrayNode := (ReflectivityExamples >> #exampleArray) ast statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec;
 		control: #after.
 	arrayNode link: link.
 	self assert: arrayNode hasMetalinkAfter.
-	self
-		assert: (ReflectivityExamples >> #exampleArray) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleArray) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	self assert: ReflectivityExamples new exampleArray isArray.
 	self assert: tag equals: 'yes'.
-	self
-		assert: (ReflectivityExamples >> #exampleArray) class
-		equals: CompiledMethod
+	self assert: (ReflectivityExamples >> #exampleArray) class equals: CompiledMethod
 ]
 
 { #category : #'tests - after' }
@@ -753,11 +748,11 @@ ReflectivityControlTest >> testConditionWithArgument [
 	sendNode link: link.
 	self assert: sendNode hasMetalinkBefore.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleMethod = 5.
-	self assert: tag class = RBMessageNode.
+	self assert: ReflectivityExamples new exampleMethod equals: 5.
+	self assert: tag class equals: RBMessageNode.
 	link condition: [ :node | node == 5 ].
 	tag := nil.
-	self assert: ReflectivityExamples new exampleMethod = 5.
+	self assert: ReflectivityExamples new exampleMethod equals: 5.
 	self assert: tag isNil.
 ]
 
@@ -773,11 +768,11 @@ ReflectivityControlTest >> testConditionWithArgument2 [
 	sendNode link: link.
 	self assert: sendNode hasMetalinkBefore.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleMethod = 5.
-	self assert: tag class = RBMessageNode.
+	self assert: ReflectivityExamples new exampleMethod equals: 5.
+	self assert: tag class equals: RBMessageNode.
 	link condition: [ :node | node == 5 ].
 	tag := nil.
-	self assert: ReflectivityExamples new exampleMethod = 5.
+	self assert: ReflectivityExamples new exampleMethod equals: 5.
 	self assert: tag isNil.
 ]
 
@@ -850,9 +845,9 @@ ReflectivityControlTest >> testInsteadArray [
 		selector: #return3.
 	arrayNode link: link.
 	self assert: arrayNode hasMetalinkInstead.
-	self assert: (ReflectivityExamples >> #exampleArray) class = ReflectiveMethod.
-	self assert: ReflectivityExamples new exampleArray = 3.
-	self assert: (ReflectivityExamples >> #exampleArray) class = CompiledMethod.
+	self assert: (ReflectivityExamples >> #exampleArray) class equals: ReflectiveMethod.
+	self assert: ReflectivityExamples new exampleArray equals: 3.
+	self assert: (ReflectivityExamples >> #exampleArray) class equals: CompiledMethod.
 	self deny: (ReflectivityExamples >> #exampleArray) isQuick.
 ]
 
@@ -885,9 +880,9 @@ ReflectivityControlTest >> testInsteadBlock [
 	self assert: ReflectivityExamples new exampleBlock == 5.
 	blockNode link: link.
 	self assert: blockNode hasMetalinkInstead.
-	self assert: (ReflectivityExamples >> #exampleBlock) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleBlock) class equals: ReflectiveMethod.
 	self assert: ReflectivityExamples new exampleBlock == 3.
-	self assert: (ReflectivityExamples >> #exampleBlock) class = CompiledMethod.
+	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod.
 ]
 
 { #category : #'tests - instead' }
@@ -901,11 +896,11 @@ ReflectivityControlTest >> testInsteadBlockSequence [
 		control: #instead.
 	sequence link: link.
 	self assert: sequence hasMetalinkInstead.
-	self assert: (ReflectivityExamples >> #exampleBlock) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleBlock) class equals: ReflectiveMethod.
 	self assert: tag isNil.
  	ReflectivityExamples new exampleBlock.
-	self assert: tag = 'yes'.
-	self assert: (ReflectivityExamples >> #exampleBlock) class = CompiledMethod.
+	self assert: tag equals: 'yes'.
+	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod.
 ]
 
 { #category : #'tests - instead' }
@@ -939,11 +934,11 @@ ReflectivityControlTest >> testInsteadClassVariable [
 	self
 		assert:
 			(ReflectivityExamples >> #exampleClassVarRead) class
-				= ReflectiveMethod.
+				equals: ReflectiveMethod.
 	self assert: tag isNil.
 	self
-		assert: ReflectivityExamples new exampleClassVarRead = #AClassVar.
-	self assert: tag = 'yes'.
+		assert: ReflectivityExamples new exampleClassVarRead equals: #AClassVar.
+	self assert: tag equals: 'yes'.
 	self
 		assert: (ReflectivityExamples >> #exampleClassVarRead) class
 		equals: CompiledMethod.
@@ -961,9 +956,9 @@ ReflectivityControlTest >> testInsteadLiteral [
 		selector: #return3.
 	literalNode link: link.
 	self assert: literalNode hasMetalinkInstead.
-	self assert: (ReflectivityExamples >> #exampleLiteral) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleLiteral) class equals: ReflectiveMethod.
 	self assert: ReflectivityExamples new exampleLiteral == 3.
-	self assert: (ReflectivityExamples >> #exampleLiteral) class = CompiledMethod.
+	self assert: (ReflectivityExamples >> #exampleLiteral) class equals: CompiledMethod.
 	self deny: (ReflectivityExamples >> #exampleLiteral) isQuick.
 ]
 
@@ -978,9 +973,9 @@ ReflectivityControlTest >> testInsteadLiteralArray [
 		selector: #return3.
 	literalArray link: link.
 	self assert: literalArray hasMetalinkInstead.
-	self assert: (ReflectivityExamples >> #exampleLiteralArray) class = ReflectiveMethod.
-	self assert: ReflectivityExamples new exampleLiteralArray = 3.
-	self assert: (ReflectivityExamples >> #exampleLiteralArray) class = CompiledMethod.
+	self assert: (ReflectivityExamples >> #exampleLiteralArray) class equals: ReflectiveMethod.
+	self assert: ReflectivityExamples new exampleLiteralArray equals: 3.
+	self assert: (ReflectivityExamples >> #exampleLiteralArray) class equals: CompiledMethod.
 	self deny: (ReflectivityExamples >> #exampleLiteralArray) isQuick.
 ]
 
@@ -994,11 +989,11 @@ ReflectivityControlTest >> testInsteadMethod [
 		control: #instead.
 	node link: link.
 	self assert: node hasMetalink.
-	self assert: (ReflectivityExamples >> #exampleMethod) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	ReflectivityExamples new exampleMethod.
-	self assert: tag = #yes.
-	self assert: (ReflectivityExamples >> #exampleMethod) class = CompiledMethod.
+	self assert: tag equals: #yes.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: CompiledMethod.
 ]
 
 { #category : #'tests - instead' }
@@ -1012,11 +1007,11 @@ ReflectivityControlTest >> testInsteadPrimitiveMethod [
 		control: #instead.
 	node link: link.
 	self assert: node hasMetalink.
-	self assert: (ReflectivityExamples >> #examplePrimitiveMethod) class = CompiledMethod.
+	self assert: (ReflectivityExamples >> #examplePrimitiveMethod) class equals: CompiledMethod.
 	self assert: tag isNil.
 	ReflectivityExamples new examplePrimitiveMethod.
-	self assert: tag = #yes.
-	self assert: (ReflectivityExamples >> #examplePrimitiveMethod) class = CompiledMethod.
+	self assert: tag equals: #yes.
+	self assert: (ReflectivityExamples >> #examplePrimitiveMethod) class equals: CompiledMethod.
 ]
 
 { #category : #'tests - instead' }
@@ -1063,11 +1058,11 @@ ReflectivityControlTest >> testInsteadSequence [
 	self assert: (seqNode isKindOf: RBSequenceNode).
 	seqNode link: link.
 	self assert: seqNode hasMetalinkInstead.
-	self assert: (ReflectivityExamples >> #exampleAssignment) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleAssignment) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	ReflectivityExamples new exampleAssignment.
-	self assert: tag = 'yes'.
-	self assert: (ReflectivityExamples >> #exampleAssignment) class = CompiledMethod.
+	self assert: tag equals: 'yes'.
+	self assert: (ReflectivityExamples >> #exampleAssignment) class equals: CompiledMethod.
 ]
 
 { #category : #'tests - instead' }
@@ -1081,9 +1076,9 @@ ReflectivityControlTest >> testInsteadVariableReadGlobal [
 		arguments: #(#name).
 	varNode link: link.
 	self assert: varNode hasMetalink.
-	self assert: (ReflectivityExamples >> #exampleGlobalRead) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleGlobalRead) class equals: ReflectiveMethod.
 	instance := ReflectivityExamples new.
-	self assert: instance exampleGlobalRead value = GlobalForTesting.
+	self assert: instance exampleGlobalRead value equals: GlobalForTesting.
 ]
 
 { #category : #'tests - instead' }
@@ -1097,9 +1092,9 @@ ReflectivityControlTest >> testInsteadVariableReadIvar [
 		arguments: #(#name).
 	varNode link: link.
 	self assert: varNode hasMetalink.
-	self assert: (ReflectivityExamples >> #exampleIvarRead) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleIvarRead) class equals: ReflectiveMethod.
 	instance := ReflectivityExamples new.
-	self assert: instance exampleIvarRead value = 33.
+	self assert: instance exampleIvarRead value equals: 33.
 	self deny: (ReflectivityExamples >> #exampleIvarRead) isQuick.	"yes, we changed the method"
 ]
 
@@ -1114,9 +1109,9 @@ ReflectivityControlTest >> testInsteadVariableReadTemp [
 		arguments: #(#name).
 	varNode link: link.
 	self assert: varNode hasMetalink.
-	self assert: (ReflectivityExamples >> #exampleAssignment) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleAssignment) class equals: ReflectiveMethod.
 	instance := ReflectivityExamples new.
-	self assert: instance exampleAssignment value = 3.
+	self assert: instance exampleAssignment value equals: 3.
 ]
 
 { #category : #'tests - instead' }

--- a/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
@@ -27,8 +27,7 @@ ReflectivityReificationTest >> tearDown [
 { #category : #'tests - variablenodes' }
 ReflectivityReificationTest >> testAccessTemp [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleAssignment) ast body
-		statements second.
+	varNode := (ReflectivityExamples >> #exampleAssignment) ast body statements second.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -246,8 +245,7 @@ ReflectivityReificationTest >> testLiteralValueBefore [
 { #category : #'tests - sends' }
 ReflectivityReificationTest >> testReifyArguments2level [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleSendTwoArgs) ast body statements first
-		value.
+	sendNode := (ReflectivityExamples >> #exampleSendTwoArgs) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -255,20 +253,19 @@ ReflectivityReificationTest >> testReifyArguments2level [
 		level: 0.
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self assert: (ReflectivityExamples >> #exampleSendTwoArgs) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleSendTwoArgs) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self deny: (Processor activeProcess isMeta).
-	self assert: instance exampleSendTwoArgs = #(1 2).
+	self assert: instance exampleSendTwoArgs equals: #(1 2).
 	self deny: (Processor activeProcess isMeta).
-	self assert: tag = #(1 2)
+	self assert: tag equals: #(1 2)
 ]
 
 { #category : #'tests - misc' }
 ReflectivityReificationTest >> testReifyArrayOperationAfter [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleArray) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleArray) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -276,9 +273,7 @@ ReflectivityReificationTest >> testReifyArrayOperationAfter [
 		arguments: #(operation).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleArray) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleArray) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleArray equals: #(3).
@@ -288,8 +283,7 @@ ReflectivityReificationTest >> testReifyArrayOperationAfter [
 { #category : #'tests - misc' }
 ReflectivityReificationTest >> testReifyArrayOperationBefore [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleArray) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleArray) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -297,9 +291,7 @@ ReflectivityReificationTest >> testReifyArrayOperationBefore [
 		arguments: #(operation).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleArray) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleArray) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleArray equals: #(3).
@@ -310,8 +302,7 @@ ReflectivityReificationTest >> testReifyArrayOperationBefore [
 { #category : #'tests - misc' }
 ReflectivityReificationTest >> testReifyArrayOperationInstead [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleArray) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleArray) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -331,8 +322,7 @@ ReflectivityReificationTest >> testReifyArrayOperationInstead [
 { #category : #'tests - misc' }
 ReflectivityReificationTest >> testReifyArrayValue [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleArray) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleArray) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -340,9 +330,7 @@ ReflectivityReificationTest >> testReifyArrayValue [
 		arguments: #(value).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleArray) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleArray) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleArray equals: #(3).
@@ -352,8 +340,7 @@ ReflectivityReificationTest >> testReifyArrayValue [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyAssignmentClassVarOperationAfter [
 	| varNode instance reachHere |
-	varNode := (ReflectivityExamples >> #exampleAssignmentClassVar)
-		assignmentNodes first.
+	varNode := (ReflectivityExamples >> #exampleAssignmentClassVar) assignmentNodes first.
 	reachHere := false.
 	link := MetaLink new
 		metaObject: [:operation | reachHere := true. self assert: operation value equals: 3];
@@ -370,8 +357,7 @@ ReflectivityReificationTest >> testReifyAssignmentClassVarOperationAfter [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyAssignmentClassVarOperationBefore [
 	| varNode instance reachHere |
-	varNode := (ReflectivityExamples >> #exampleAssignmentClassVar)
-		assignmentNodes first.
+	varNode := (ReflectivityExamples >> #exampleAssignmentClassVar) assignmentNodes first.
 	reachHere := false.
 	link := MetaLink new
 		metaObject: [:operation | reachHere := true. self assert: operation value equals: 3];
@@ -388,8 +374,7 @@ ReflectivityReificationTest >> testReifyAssignmentClassVarOperationBefore [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyAssignmentClassVarOperationInstead [
 	| varNode instance reachHere |
-	varNode := (ReflectivityExamples >> #exampleAssignmentClassVar)
-		assignmentNodes first.
+	varNode := (ReflectivityExamples >> #exampleAssignmentClassVar) assignmentNodes first.
 	reachHere := false.
 	link := MetaLink new
 		metaObject: [:operation | reachHere := true. operation value];
@@ -406,8 +391,7 @@ ReflectivityReificationTest >> testReifyAssignmentClassVarOperationInstead [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyAssignmentSlotOperationAfter [
 	| varNode instance reachHere |
-	varNode := (ReflectivityExamples >> #exampleAssignmentIvar)
-		assignmentNodes first.
+	varNode := (ReflectivityExamples >> #exampleAssignmentIvar) assignmentNodes first.
 	reachHere := false.
 	link := MetaLink new
 		metaObject: [:operation | reachHere := true. self assert: operation value equals: 3];
@@ -424,8 +408,7 @@ ReflectivityReificationTest >> testReifyAssignmentSlotOperationAfter [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyAssignmentSlotOperationBefore [
 	| varNode instance reachHere |
-	varNode := (ReflectivityExamples >> #exampleAssignmentIvar)
-		assignmentNodes first.
+	varNode := (ReflectivityExamples >> #exampleAssignmentIvar) assignmentNodes first.
 	reachHere := false.
 	link := MetaLink new
 		metaObject: [:operation | reachHere := true. self assert: operation value equals: 3];
@@ -442,8 +425,7 @@ ReflectivityReificationTest >> testReifyAssignmentSlotOperationBefore [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyAssignmentSlotOperationInstead [
 	| varNode instance reachHere |
-	varNode := (ReflectivityExamples >> #exampleAssignmentIvar)
-		assignmentNodes first.
+	varNode := (ReflectivityExamples >> #exampleAssignmentIvar) assignmentNodes first.
 	reachHere := false.
 	link := MetaLink new
 		metaObject: [:operation | reachHere := true. operation value];
@@ -460,8 +442,7 @@ ReflectivityReificationTest >> testReifyAssignmentSlotOperationInstead [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyAssignmentTempOperationAfter [
 	| varNode instance reachHere |
-	varNode := (ReflectivityExamples >> #exampleAssignment)
-		assignmentNodes first.
+	varNode := (ReflectivityExamples >> #exampleAssignment) assignmentNodes first.
 	reachHere := false.
 	link := MetaLink new
 		metaObject: [:operation | reachHere := true. operation value];
@@ -478,8 +459,7 @@ ReflectivityReificationTest >> testReifyAssignmentTempOperationAfter [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyAssignmentTempOperationBefore [
 	| varNode instance reachHere |
-	varNode := (ReflectivityExamples >> #exampleAssignment)
-		assignmentNodes first.
+	varNode := (ReflectivityExamples >> #exampleAssignment) assignmentNodes first.
 	reachHere := false.
 	link := MetaLink new
 		metaObject: [:operation | reachHere := true. self assert: operation value equals: 3];
@@ -497,8 +477,7 @@ ReflectivityReificationTest >> testReifyAssignmentTempOperationBefore [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyAssignmentTempOperationInstead [
 	| varNode instance reachHere |
-	varNode := (ReflectivityExamples >> #exampleAssignment)
-		assignmentNodes first.
+	varNode := (ReflectivityExamples >> #exampleAssignment) assignmentNodes first.
 	reachHere := false.
 	link := MetaLink new
 		metaObject: [:operation | 	reachHere := true . operation value];
@@ -515,8 +494,7 @@ ReflectivityReificationTest >> testReifyAssignmentTempOperationInstead [
 { #category : #'tests - allnodes' }
 ReflectivityReificationTest >> testReifyByInstanceNotKey [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body statements last value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -550,8 +528,7 @@ ReflectivityReificationTest >> testReifyCascadeValue [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyClassVarOperation [
 	| node instance |
-	node := (ReflectivityExamples >> #exampleClassVarRead) ast
-		variableNodes first.
+	node := (ReflectivityExamples >> #exampleClassVarRead) ast variableNodes first.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -574,9 +551,7 @@ ReflectivityReificationTest >> testReifyClassVariableClass [
 		arguments: #(class).
 	classVar link: link.
 	self assert: classVar hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleClassVarRead) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleClassVarRead) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleClassVarRead equals: #AClassVar.
@@ -593,10 +568,10 @@ ReflectivityReificationTest >> testReifyClassVariableContext [
 		arguments: #(context).
 	classVar link: link.
 	self assert: classVar hasMetalink.
-	self assert: (ReflectivityExamples >> #exampleClassVarRead) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleClassVarRead) class equals: ReflectiveMethod.
 	self assert: (tag isNil).
 	instance := ReflectivityExamples new.
-	self assert: (instance exampleClassVarRead = #AClassVar).
+	self assert: instance exampleClassVarRead equals: #AClassVar.
 	self assert: (tag class == Context).
 ]
 
@@ -610,11 +585,11 @@ ReflectivityReificationTest >> testReifyClassVariableEntity [
 		arguments: #(entity).
 	classVar link: link.
 	self assert: classVar hasMetalink.
-	self assert: (ReflectivityExamples >> #exampleClassVarRead) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleClassVarRead) class equals: ReflectiveMethod.
 	self assert: (tag isNil).
 	instance := ReflectivityExamples new.
-	self assert: (instance exampleClassVarRead = #AClassVar).
-	self assert: (tag = classVar).
+	self assert: (instance exampleClassVarRead == #AClassVar).
+	self assert: tag equals: classVar.
 ]
 
 { #category : #'tests - variables' }
@@ -627,10 +602,10 @@ ReflectivityReificationTest >> testReifyClassVariableLink [
 		arguments: #(link).
 	classVar link: link.
 	self assert: classVar hasMetalink.
-	self assert: (ReflectivityExamples >> #exampleClassVarRead) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleClassVarRead) class equals: ReflectiveMethod.
 	self assert: (tag isNil).
 	instance := ReflectivityExamples new.
-	self assert: (instance exampleClassVarRead = #AClassVar).
+	self assert: instance exampleClassVarRead equals: #AClassVar.
 	self assert: (tag == link).
 ]
 
@@ -644,11 +619,11 @@ ReflectivityReificationTest >> testReifyClassVariableName [
 		arguments: #(name).
 	classVar link: link.
 	self assert: classVar hasMetalink.
-	self assert: (ReflectivityExamples >> #exampleClassVarRead) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleClassVarRead) class equals: ReflectiveMethod.
 	self assert: (tag isNil).
 	instance := ReflectivityExamples new.
-	self assert: (instance exampleClassVarRead = #AClassVar).
-	self assert: (tag = #ClassVar).
+	self assert: instance exampleClassVarRead equals: #AClassVar.
+	self assert: tag equals: #ClassVar.
 ]
 
 { #category : #'tests - variables' }
@@ -661,10 +636,10 @@ ReflectivityReificationTest >> testReifyClassVariableObject [
 		arguments: #(object).
 	classVar link: link.
 	self assert: classVar hasMetalink.
-	self assert: (ReflectivityExamples >> #exampleClassVarRead) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleClassVarRead) class equals: ReflectiveMethod.
 	self assert: (tag isNil).
 	instance := ReflectivityExamples new.
-	self assert: (instance exampleClassVarRead = #AClassVar).
+	self assert: instance exampleClassVarRead equals: #AClassVar.
 	self assert: (tag class == ReflectivityExamples).
 ]
 
@@ -678,11 +653,11 @@ ReflectivityReificationTest >> testReifyClassVariableValue [
 		arguments: #(value).
 	classVar link: link.
 	self assert: classVar hasMetalink.
-	self assert: (ReflectivityExamples >> #exampleClassVarRead) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleClassVarRead) class equals: ReflectiveMethod.
 	self assert: (tag isNil).
 	instance := ReflectivityExamples new.
-	self assert: (instance exampleClassVarRead = #AClassVar).
-	self assert: (tag = #AClassVar).
+	self assert: instance exampleClassVarRead equals: #AClassVar.
+	self assert: tag equals: #AClassVar.
 ]
 
 { #category : #'tests - variables' }
@@ -695,18 +670,17 @@ ReflectivityReificationTest >> testReifyClassVariableVariable [
 		arguments: #(variable).
 	classVar link: link.
 	self assert: classVar hasMetalink.
-	self assert: (ReflectivityExamples >> #exampleClassVarRead) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleClassVarRead) class equals: ReflectiveMethod.
 	self assert: (tag isNil).
 	instance := ReflectivityExamples new.
-	self assert: (instance exampleClassVarRead = #AClassVar).
-	self assert: (tag = classVar).
+	self assert: instance exampleClassVarRead equals: #AClassVar.
+	self assert: tag equals: classVar.
 ]
 
 { #category : #'tests - allnodes' }
 ReflectivityReificationTest >> testReifyEntity [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body statements last value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -722,8 +696,7 @@ ReflectivityReificationTest >> testReifyEntity [
 { #category : #'tests - variablenodes' }
 ReflectivityReificationTest >> testReifyGlobalName [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleGlobalRead) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleGlobalRead) ast body statements last value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -739,8 +712,7 @@ ReflectivityReificationTest >> testReifyGlobalName [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyGlobalOperation [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleGlobalRead) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleGlobalRead) ast body statements last value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -757,8 +729,7 @@ ReflectivityReificationTest >> testReifyGlobalOperation [
 { #category : #'tests - variablenodes' }
 ReflectivityReificationTest >> testReifyGlobalValue [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleGlobalRead) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleGlobalRead) ast body statements last value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -774,8 +745,7 @@ ReflectivityReificationTest >> testReifyGlobalValue [
 { #category : #'tests - variablenodes' }
 ReflectivityReificationTest >> testReifyGlobalVariable [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleGlobalRead) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleGlobalRead) ast body statements last value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -798,18 +768,17 @@ ReflectivityReificationTest >> testReifyGlobalVariableValue [
 		arguments: #(name).
 	globalVar link: link.
 	self assert: globalVar hasMetalink.
-	self assert: (ReflectivityExamples >> #exampleGlobalRead) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleGlobalRead) class equals: ReflectiveMethod.
 	self assert: (tag isNil).
 	instance := ReflectivityExamples new.
-	self assert: (instance exampleGlobalRead = GlobalForTesting).
-	self assert: (tag = #GlobalForTesting).
+	self assert: instance exampleGlobalRead equals: GlobalForTesting.
+	self assert: tag equals: #GlobalForTesting.
 ]
 
 { #category : #'tests - variablenodes' }
 ReflectivityReificationTest >> testReifyIvarName [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body statements last value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -825,8 +794,7 @@ ReflectivityReificationTest >> testReifyIvarName [
 { #category : #'tests - variablenodes' }
 ReflectivityReificationTest >> testReifyIvarValue [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body statements last value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -842,8 +810,7 @@ ReflectivityReificationTest >> testReifyIvarValue [
 { #category : #'tests - variablenodes' }
 ReflectivityReificationTest >> testReifyIvarVariable [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body statements last value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -859,8 +826,7 @@ ReflectivityReificationTest >> testReifyIvarVariable [
 { #category : #'tests - misc' }
 ReflectivityReificationTest >> testReifyLiteralArrayOperation [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleLiteralArray) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleLiteralArray) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -880,8 +846,7 @@ ReflectivityReificationTest >> testReifyLiteralArrayOperation [
 { #category : #'tests - misc' }
 ReflectivityReificationTest >> testReifyLiteralArrayValue [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleLiteralArray) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleLiteralArray) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -926,9 +891,7 @@ ReflectivityReificationTest >> testReifyMethodArgs [
 		arguments: #(arguments).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleWithArg:) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleWithArg:) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: (instance exampleWithArg: 3) equals: 5.
@@ -1043,9 +1006,7 @@ ReflectivityReificationTest >> testReifyMethodReceiver [
 		arguments: #(receiver).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
@@ -1062,9 +1023,7 @@ ReflectivityReificationTest >> testReifyMethodSelector [
 		arguments: #(selector).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
@@ -1081,9 +1040,7 @@ ReflectivityReificationTest >> testReifyMethodThisContext [
 		arguments: #(context).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
@@ -1101,9 +1058,7 @@ ReflectivityReificationTest >> testReifyMethodThisContextAfter [
 		arguments: #(context).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
@@ -1122,9 +1077,7 @@ ReflectivityReificationTest >> testReifyMethodValue [
 		arguments: #(value).
 	methodNode link: link.
 	self assert: methodNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
@@ -1152,8 +1105,7 @@ ReflectivityReificationTest >> testReifyNewValueAssignmentAfter [
 { #category : #'tests - assignment' }
 ReflectivityReificationTest >> testReifyNewValueAssignmentBefore [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleAssignment)
-		assignmentNodes first.
+	varNode := (ReflectivityExamples >> #exampleAssignment) assignmentNodes first.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -1169,8 +1121,7 @@ ReflectivityReificationTest >> testReifyNewValueAssignmentBefore [
 { #category : #'tests - allnodes' }
 ReflectivityReificationTest >> testReifyNode [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body statements last value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -1186,17 +1137,14 @@ ReflectivityReificationTest >> testReifyNode [
 { #category : #'tests - allnodes' }
 ReflectivityReificationTest >> testReifyObject [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
 		arguments: #(object).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
@@ -1265,8 +1213,7 @@ ReflectivityReificationTest >> testReifyOperationMethodInstead [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyOperationSend [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -1274,9 +1221,7 @@ ReflectivityReificationTest >> testReifyOperationSend [
 		arguments: #(operation).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
@@ -1286,8 +1231,7 @@ ReflectivityReificationTest >> testReifyOperationSend [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyOperationSendAfter [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -1295,9 +1239,7 @@ ReflectivityReificationTest >> testReifyOperationSendAfter [
 		arguments: #(operation).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
@@ -1307,8 +1249,7 @@ ReflectivityReificationTest >> testReifyOperationSendAfter [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyOperationSendInstead [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -1316,9 +1257,7 @@ ReflectivityReificationTest >> testReifyOperationSendInstead [
 		arguments: #(operation).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: self.
@@ -1431,8 +1370,7 @@ ReflectivityReificationTest >> testReifyReturnOperation [
 { #category : #'tests - return' }
 ReflectivityReificationTest >> testReifyReturnValue [
 	| returnNode instance |
-	returnNode := (ReflectivityExamples >> #exampleAssignment) ast body
-		statements last.
+	returnNode := (ReflectivityExamples >> #exampleAssignment) ast body statements last.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -1449,8 +1387,7 @@ ReflectivityReificationTest >> testReifyReturnValue [
 ReflectivityReificationTest >> testReifySendAfterMany [
 	"test to reify a lot after"
 	| sendNode instance executed |
-	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast body statements first value.
 	executed := false.
 		link := MetaLink new
 		metaObject: [ :s :r :a :v | self assert: v equals: 5. executed := true ];
@@ -1468,17 +1405,14 @@ ReflectivityReificationTest >> testReifySendAfterMany [
 { #category : #'tests - sends' }
 ReflectivityReificationTest >> testReifySendAll [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast body statements first value.
 	link := MetaLink new
 		metaObject: #receiver;
 		selector: #perform:withArguments:;
 		arguments: #(selector arguments).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5
 ]
@@ -1495,9 +1429,7 @@ ReflectivityReificationTest >> testReifySendArgsAsArray [
 		options: #(argsAsArray).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
@@ -1517,9 +1449,7 @@ ReflectivityReificationTest >> testReifySendArguments [
 		arguments: #(arguments).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
@@ -1537,9 +1467,7 @@ ReflectivityReificationTest >> testReifySendArguments2 [
 		arguments: #(arguments).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleSendTwoArgs) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleSendTwoArgs) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleSendTwoArgs equals: #(1 2).
@@ -1557,28 +1485,25 @@ ReflectivityReificationTest >> testReifySendArgumentsLevel [
 		level: 0.
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self assert: (ReflectivityExamples>>#exampleMethod) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples>>#exampleMethod) class equals: ReflectiveMethod.
 	self assert: (tag isNil).
 	instance := ReflectivityExamples new .
-	self assert: (instance exampleMethod = 5).
-	self assert: (tag = #(3)).
+	self assert: instance exampleMethod equals: 5.
+	self assert: tag equals: #(3).
 
 ]
 
 { #category : #'tests - sends' }
 ReflectivityReificationTest >> testReifySendReceiver [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
 		arguments: #(receiver).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
@@ -1588,17 +1513,14 @@ ReflectivityReificationTest >> testReifySendReceiver [
 { #category : #'tests - sends' }
 ReflectivityReificationTest >> testReifySendSelector [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
 		arguments: #(selector).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
@@ -1608,17 +1530,14 @@ ReflectivityReificationTest >> testReifySendSelector [
 { #category : #'tests - sends' }
 ReflectivityReificationTest >> testReifySendSender [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
 		arguments: #(sender).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
@@ -1628,17 +1547,14 @@ ReflectivityReificationTest >> testReifySendSender [
 { #category : #'tests - sends' }
 ReflectivityReificationTest >> testReifySendThisContext [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
 		arguments: #(context).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
@@ -1649,8 +1565,7 @@ ReflectivityReificationTest >> testReifySendThisContext [
 { #category : #'tests - sends' }
 ReflectivityReificationTest >> testReifySendThisContextAfter [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -1658,9 +1573,7 @@ ReflectivityReificationTest >> testReifySendThisContextAfter [
 		arguments: #(context).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
@@ -1672,8 +1585,7 @@ ReflectivityReificationTest >> testReifySendThisContextAfter [
 { #category : #'tests - sends' }
 ReflectivityReificationTest >> testReifySendValue [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -1681,9 +1593,7 @@ ReflectivityReificationTest >> testReifySendValue [
 		arguments: #(value).
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleMethod) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
@@ -1700,11 +1610,11 @@ ReflectivityReificationTest >> testReifySlotClass [
 		arguments: #(class).
 	iVar link: link.
 	self assert: iVar hasMetalink.
-	self assert: (ReflectivityExamples >> #exampleIvarRead) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleIvarRead) class equals: ReflectiveMethod.
 	self assert: (tag isNil).
 	instance := ReflectivityExamples new.
-	self assert: (instance exampleIvarRead = 33).
-	self assert: (tag = ReflectivityExamples).
+	self assert: instance exampleIvarRead equals: 33.
+	self assert: tag equals: ReflectivityExamples.
 ]
 
 { #category : #'tests - variables' }
@@ -1717,18 +1627,17 @@ ReflectivityReificationTest >> testReifySlotName [
 		arguments: #(name).
 	iVar link: link.
 	self assert: iVar hasMetalink.
-	self assert: (ReflectivityExamples >> #exampleIvarRead) class = ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleIvarRead) class equals: ReflectiveMethod.
 	self assert: (tag isNil).
 	instance := ReflectivityExamples new.
-	self assert: (instance exampleIvarRead = 33).
-	self assert: (tag = #ivar).
+	self assert: instance exampleIvarRead equals: 33.
+	self assert: tag equals: #ivar.
 ]
 
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifySlotOperation [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body statements last value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -1746,8 +1655,7 @@ ReflectivityReificationTest >> testReifySlotOperation [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifySlotOperationAfter [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body statements last value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -1766,8 +1674,7 @@ ReflectivityReificationTest >> testReifySlotOperationAfter [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifySlotOperationInstead [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleIvarRead) ast body statements last value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -1793,9 +1700,7 @@ ReflectivityReificationTest >> testReifySlotValue [
 		arguments: #(value).
 	iVar link: link.
 	self assert: iVar hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleIvarRead) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleIvarRead) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleIvarRead equals: 33.
@@ -1812,9 +1717,7 @@ ReflectivityReificationTest >> testReifySlotVariable [
 		arguments: #(variable).
 	iVar link: link.
 	self assert: iVar hasMetalink.
-	self
-		assert: (ReflectivityExamples >> #exampleIvarRead) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleIvarRead) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleIvarRead equals: 33.
@@ -1824,8 +1727,7 @@ ReflectivityReificationTest >> testReifySlotVariable [
 { #category : #'tests - variablenodes' }
 ReflectivityReificationTest >> testReifyTempName [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleAssignment) ast body
-		statements first variable.
+	varNode := (ReflectivityExamples >> #exampleAssignment) ast body statements first variable.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -1841,8 +1743,7 @@ ReflectivityReificationTest >> testReifyTempName [
 { #category : #'tests - variablenodes' }
 ReflectivityReificationTest >> testReifyTempNewValue [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleAssignment) ast body
-		statements first variable.
+	varNode := (ReflectivityExamples >> #exampleAssignment) ast body statements first variable.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -1858,8 +1759,7 @@ ReflectivityReificationTest >> testReifyTempNewValue [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyTempOperation [
 	| varNode instance executed |
-	varNode := (ReflectivityExamples >> #exampleAssignment) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleAssignment) ast body statements last value.
 	executed := false.
 	link := MetaLink new
 		metaObject: [:operation | executed := true. self assert: operation class == RFTempRead. self assert: operation value equals: 3. ];
@@ -1875,8 +1775,7 @@ ReflectivityReificationTest >> testReifyTempOperation [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyTempOperationAfter [
 	| varNode instance executed |
-	varNode := (ReflectivityExamples >> #exampleAssignment) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleAssignment) ast body statements last value.
 	executed := false.
 	link := MetaLink new
 		metaObject: [:operation | executed := true. self assert: operation class == RFTempRead. self assert: operation value equals: 3. ];
@@ -1893,8 +1792,7 @@ ReflectivityReificationTest >> testReifyTempOperationAfter [
 { #category : #'tests - operations' }
 ReflectivityReificationTest >> testReifyTempOperationInstead [
 	| varNode instance executed |
-	varNode := (ReflectivityExamples >> #exampleAssignment) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleAssignment) ast body statements last value.
 	executed := false.
 	link := MetaLink new
 		metaObject: [:operation | executed := true. self assert: operation class == RFTempRead. self assert: operation value equals: 3. operation value];
@@ -1911,8 +1809,7 @@ ReflectivityReificationTest >> testReifyTempOperationInstead [
 { #category : #'tests - variablenodes' }
 ReflectivityReificationTest >> testReifyTempValue [
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleAssignment) ast body
-		statements last value.
+	varNode := (ReflectivityExamples >> #exampleAssignment) ast body statements last value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -1929,8 +1826,7 @@ ReflectivityReificationTest >> testReifyTempValue [
 ReflectivityReificationTest >> testReifyValueAssignmentAfter [
 	"#value for Assignemnt is the new value when #after"
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleAssignment)
-		assignmentNodes first.
+	varNode := (ReflectivityExamples >> #exampleAssignment)assignmentNodes first.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -1948,8 +1844,7 @@ ReflectivityReificationTest >> testReifyValueAssignmentAfter [
 ReflectivityReificationTest >> testReifyValueAssignmentBefore [
 	"#value for Assignemnt is the old value, is that what we want?"
 	| varNode instance |
-	varNode := (ReflectivityExamples >> #exampleAssignment)
-		assignmentNodes first.
+	varNode := (ReflectivityExamples >> #exampleAssignment) assignmentNodes first.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -267,7 +267,7 @@ RFASTTranslator >> visitMethodNode: aMethodNode [
 	].
 	effectTranslator visitNode: aMethodNode body.
 	aMethodNode isPrimitive ifFalse: [self emitMetaLinkAfterNoEnsure: aMethodNode].
-	(aMethodNode hasProperty: #wrappedPrimitive) ifTrue: [methodBuilder pushTemp: #RFValueReificationVar; returnTop].
+	(aMethodNode hasProperty: #wrappedPrimitive) ifTrue: [methodBuilder pushTemp: #RFReifyValueVar; returnTop].
 	aMethodNode body lastIsReturn ifFalse:  [methodBuilder pushReceiver; returnTop].
 
 ]

--- a/src/Reflectivity/RFArgumentsReification.class.st
+++ b/src/Reflectivity/RFArgumentsReification.class.st
@@ -50,7 +50,7 @@ RFArgumentsReification >> preambleForMessage: aNode [
 			arguments add:  (RBTemporaryNode named: name).
 	].
 	preamble addAll: (RBArrayNode statements: arguments).
-	preamble add: (RFStorePopIntoTempNode named: 'RFArgumentsReificationVar').
+	preamble add: (RFStorePopIntoTempNode named: self varName).
 	preamble addAll: arguments.
 	^ preamble 
 ]
@@ -61,7 +61,7 @@ RFArgumentsReification >> preambleForMethod: aNode [
 	preamble := OrderedCollection new.
 	arguments := aNode argumentNames collect: [ :name | RBTemporaryNode named: name].
 	preamble addAll: (RBArrayNode statements: arguments).
-	preamble add: (RFStorePopIntoTempNode named: 'RFArgumentsReificationVar').
+	preamble add: (RFStorePopIntoTempNode named: self varName).
 	^ preamble 
 ]
 
@@ -71,7 +71,7 @@ RFArgumentsReification >> preambleSequence: aNode [
 	preamble := OrderedCollection new.
 	arguments := aNode parent argumentNames collect: [ :name | RBTemporaryNode named: name].
 	preamble addAll: (RBArrayNode statements: arguments).
-	preamble add: (RFStorePopIntoTempNode named: 'RFArgumentsReificationVar').
+	preamble add: (RFStorePopIntoTempNode named: self varName).
 	^ preamble 
 ]
 

--- a/src/Reflectivity/RFSemanticAnalyzer.class.st
+++ b/src/Reflectivity/RFSemanticAnalyzer.class.st
@@ -72,7 +72,7 @@ RFSemanticAnalyzer >> visitMethodNode: aMethodNode [
 	aMethodNode scope: scope.  scope node: aMethodNode.
 	aMethodNode arguments do: [:node | self declareArgumentNode: node ].
 	aMethodNode pragmas do: [:each | self visitNode: each].
-	self declareVariableNode: (RBVariableNode named: #RFValueReificationVar).
+	self declareVariableNode: (RBVariableNode named: #RFReifyValueVar).
 	self analyseForLinksForNodes: aMethodNode.
 	self visitNode: aMethodNode body.
 

--- a/src/Reflectivity/RFValueReification.class.st
+++ b/src/Reflectivity/RFValueReification.class.st
@@ -45,7 +45,7 @@ RFValueReification >> genForLiteralVariable [
 
 { #category : #generate }
 RFValueReification >> genForRBArrayNode [
-	^RBVariableNode named: #RFReifyValueVar
+	^RBVariableNode named: self varName
 ]
 
 { #category : #generate }
@@ -56,12 +56,12 @@ RFValueReification >> genForRBAssignmentNode [
 
 { #category : #generate }
 RFValueReification >> genForRBBlockNode [
-	^RBVariableNode named: #RFReifyValueVar
+	^RBVariableNode named: self varName
 ]
 
 { #category : #generate }
 RFValueReification >> genForRBCascadeNode [
-	^RBVariableNode named: #RFReifyValueVar
+	^RBVariableNode named: self varName
 ]
 
 { #category : #generate }
@@ -76,17 +76,17 @@ RFValueReification >> genForRBLiteralValueNode [
 
 { #category : #generate }
 RFValueReification >> genForRBMessageNode [
-	^RBVariableNode named: #RFReifyValueVar
+	^RBVariableNode named: self varName
 ]
 
 { #category : #generate }
 RFValueReification >> genForRBMethodNode [
-	^RBTemporaryNode named: #RFValueReificationVar
+	^RBTemporaryNode named: self varName
 ]
 
 { #category : #generate }
 RFValueReification >> genForRBReturnNode [
-	^RBVariableNode named: #RFReifyValueVar
+	^RBVariableNode named: self varName
 ]
 
 { #category : #generate }
@@ -98,9 +98,9 @@ RFValueReification >> genForRBVariableNode [
 { #category : #generate }
 RFValueReification >> postamble: aNode [
 	(aNode isKindOf: RBProgramNode) ifFalse: [ ^#() ].
-	aNode isMessage ifTrue: [^RFStoreIntoTempNode named: 'RFReifyValueVar'. ].
-	aNode isCascade ifTrue: [^RFStoreIntoTempNode named: 'RFReifyValueVar'. ].
-	aNode isBlock ifTrue: [^RFStoreIntoTempNode named: #RFReifyValueVar].
+	aNode isMessage ifTrue: [^RFStoreIntoTempNode named: self varName. ].
+	aNode isCascade ifTrue: [^RFStoreIntoTempNode named: self varName. ].
+	aNode isBlock ifTrue: [^RFStoreIntoTempNode named: self varName].
 	^super postamble: aNode.
 	 
 ]
@@ -124,7 +124,7 @@ RFValueReification >> preambleForArray: aNode [
 			arguments add:  (RBTemporaryNode named: name).
 	].
 	preamble addAll: (RBArrayNode statements: arguments).
-	preamble add: (RFStorePopIntoTempNode named: 'RFReifyValueVar').
+	preamble add: (RFStorePopIntoTempNode named: self varName).
 	preamble addAll: arguments.
 	^ preamble 
 	
@@ -132,5 +132,10 @@ RFValueReification >> preambleForArray: aNode [
 
 { #category : #preamble }
 RFValueReification >> preambleForReturn: aNode [
-	^ RFStoreIntoTempNode named: #RFReifyValueVar
+	^ RFStoreIntoTempNode named: self varName
+]
+
+{ #category : #generate }
+RFValueReification >> varName [
+	^#RFReifyValueVar
 ]

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -104,7 +104,7 @@ ReflectiveMethod >> generatePrimitiveWrapper [
 		arguments: {RBArrayNode statements: ast arguments . (RFLiteralVariableNode value: wrappedMethod)}.
 	
 	assignmentNode := RBAssignmentNode 
-		variable: (RBVariableNode named: #RFValueReificationVar)
+		variable: (RBVariableNode named: #RFReifyValueVar)
 		value: send.
 		
 	wrapperMethod := RBMethodNode


### PR DESCRIPTION
22755  Reflectivity: cleanups (tests, unify variable Naming)
https://pharo.fogbugz.com/f/cases/22755/Reflectivity-cleanups-tests-unify-variable-Naming

-  unify varName usage
- fix tests to use assert:equals: