### PR TITLE
22772-chooseExistingFileReferenceextensionspathpreview-returning-wrong-FileReference

### DIFF
--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -1007,7 +1007,7 @@ UITheme >> chooseExistingFileReferenceIn: aThemedMorph title: title extensions: 
 		fileNameText: pathFileReference basename;
 		initialize;
 		title: title;
-		answerFileName.	
+		answerPathName.	
 	exts ifNotNil: [ fd validExtensions: exts ].
 	path ifNotNil: [ fd selectPath: pathFileReference pathString ].
 	^ (aThemedMorph openModal: fd) answer ifNotNil: #asFileReference


### PR DESCRIPTION
Fix issue https://pharo.fogbugz.com/f/cases/22772/chooseExistingFileReference-extensions-path-preview-returning-wrong-FileReference.

The solution is to ask the file dialog to return a path and not a file name.