### PR TITLE
22778 Tag Monticello-OldDataStreamCompatibility in Manifest

### DIFF
--- a/src/Monticello-OldDataStreamCompatibility/MCOldDataStreamExtensions.class.st
+++ b/src/Monticello-OldDataStreamCompatibility/MCOldDataStreamExtensions.class.st
@@ -6,7 +6,7 @@ This package is unloadeable.
 Class {
 	#name : #MCOldDataStreamExtensions,
 	#superclass : #Object,
-	#category : #'Monticello-OldDataStreamCompatibility'
+	#category : #'Monticello-OldDataStreamCompatibility-Base'
 }
 
 { #category : #'class initialization' }

--- a/src/Monticello-OldDataStreamCompatibility/ManifestMonticelloOldDataStreamCompatibility.class.st
+++ b/src/Monticello-OldDataStreamCompatibility/ManifestMonticelloOldDataStreamCompatibility.class.st
@@ -1,5 +1,8 @@
+"
+Compatibility package for old data streams
+"
 Class {
 	#name : #ManifestMonticelloOldDataStreamCompatibility,
 	#superclass : #PackageManifest,
-	#category : #'Monticello-OldDataStreamCompatibility'
+	#category : #'Monticello-OldDataStreamCompatibility-Manifest'
 }


### PR DESCRIPTION
tag
  - manifest class into "Manifest" tag
 - the rest into "Base" as it is base functionality of the package

https://pharo.fogbugz.com/f/cases/22778