### PR TITLE
22785 Refactor FFICompilerPlugin

### DIFF
--- a/src/Deprecated70/FFICompilerPlugin.extension.st
+++ b/src/Deprecated70/FFICompilerPlugin.extension.st
@@ -1,0 +1,61 @@
+Extension { #name : #FFICompilerPlugin }
+
+{ #category : #'*Deprecated70' }
+FFICompilerPlugin class >> addAFfiCalloutSelectorEvent: aPragmaAdded [
+
+	self
+		deprecated: 'Please use #addFFICalloutSelectorEvent: instead'
+		transformWith: '`@receiver addAFfiCalloutSelectorEvent: `@statements' -> '`@receiver addFFICalloutSelectorEvent: `@statements'.
+		
+	self addFFICalloutSelectorEvent: aPragmaAdded
+]
+
+{ #category : #'*Deprecated70' }
+FFICompilerPlugin class >> addAFfiCalloutSelectorFromPragma: aPragma [
+
+	self
+		deprecated: 'Please use #addFFICalloutSelectorFromPragma: instead'
+		transformWith: '`@receiver addAFfiCalloutSelectorFromPragma: `@statements' -> '`@receiver addFFICalloutSelectorFromPragma: `@statements'.
+		
+	self addFFICalloutSelectorFromPragma: aPragma
+]
+
+{ #category : #'*Deprecated70' }
+FFICompilerPlugin class >> addFfiCalloutSelector: aString [
+
+	self
+		deprecated: 'Please use #addFFICalloutSelector: instead'
+		transformWith: '`@receiver addFfiCalloutSelector: `@statements' -> '`@receiver addFFICalloutSelector: `@statements'.
+		
+	self addFFICalloutSelector: aString
+]
+
+{ #category : #'*Deprecated70' }
+FFICompilerPlugin class >> defaultFfiCalloutSelectors [
+
+	self
+		deprecated: 'Please use #defaultFFICalloutSelectors instead'
+		transformWith: '`@receiver defaultFfiCalloutSelectors' -> '`@receiver defaultFFICalloutSelectors'.
+		
+	^self defaultFFICalloutSelectors 
+]
+
+{ #category : #'*Deprecated70' }
+FFICompilerPlugin class >> removeAFfiCalloutSelectorEvent: aPragmaRemoved [
+
+	self
+		deprecated: 'Please use #removeFFICalloutSelectorEvent: instead'
+		transformWith: '`@receiver removeAFfiCalloutSelectorEvent: `@statements' -> '`@receiver removeFFICalloutSelectorEvent: `@statements'.
+		
+	self removeFFICalloutSelectorEvent: aPragmaRemoved 
+]
+
+{ #category : #'*Deprecated70' }
+FFICompilerPlugin class >> removeFfiCalloutSelector: aString [
+
+	self
+		deprecated: 'Please use #removeFFICalloutSelector: instead'
+		transformWith: '`@receiver removeFfiCalloutSelector: `@statements' -> '`@receiver removeFFICalloutSelector: `@statements'.
+		
+	self removeFFICalloutSelector: aString 
+]

--- a/src/Deprecated70/FFICompilerPlugin.extension.st
+++ b/src/Deprecated70/FFICompilerPlugin.extension.st
@@ -17,7 +17,7 @@ FFICompilerPlugin class >> addAFfiCalloutSelectorFromPragma: aPragma [
 		deprecated: 'Please use #addFFICalloutSelectorFromPragma: instead'
 		transformWith: '`@receiver addAFfiCalloutSelectorFromPragma: `@statements' -> '`@receiver addFFICalloutSelectorFromPragma: `@statements'.
 		
-	self addFFICalloutSelectorFromPragma: aPragma
+	^self addFFICalloutSelectorFromPragma: aPragma
 ]
 
 { #category : #'*Deprecated70' }
@@ -27,7 +27,7 @@ FFICompilerPlugin class >> addFfiCalloutSelector: aString [
 		deprecated: 'Please use #addFFICalloutSelector: instead'
 		transformWith: '`@receiver addFfiCalloutSelector: `@statements' -> '`@receiver addFFICalloutSelector: `@statements'.
 		
-	self addFFICalloutSelector: aString
+	^self addFFICalloutSelector: aString
 ]
 
 { #category : #'*Deprecated70' }
@@ -47,7 +47,7 @@ FFICompilerPlugin class >> removeAFfiCalloutSelectorEvent: aPragmaRemoved [
 		deprecated: 'Please use #removeFFICalloutSelectorEvent: instead'
 		transformWith: '`@receiver removeAFfiCalloutSelectorEvent: `@statements' -> '`@receiver removeFFICalloutSelectorEvent: `@statements'.
 		
-	self removeFFICalloutSelectorEvent: aPragmaRemoved 
+	^self removeFFICalloutSelectorEvent: aPragmaRemoved 
 ]
 
 { #category : #'*Deprecated70' }
@@ -57,5 +57,5 @@ FFICompilerPlugin class >> removeFfiCalloutSelector: aString [
 		deprecated: 'Please use #removeFFICalloutSelector: instead'
 		transformWith: '`@receiver removeFfiCalloutSelector: `@statements' -> '`@receiver removeFFICalloutSelector: `@statements'.
 		
-	self removeFFICalloutSelector: aString 
+	^self removeFFICalloutSelector: aString 
 ]

--- a/src/UnifiedFFI/FFICompilerPlugin.class.st
+++ b/src/UnifiedFFI/FFICompilerPlugin.class.st
@@ -84,7 +84,7 @@ FFICompilerPlugin class >> defaultUFFICalloutSelectors [
 FFICompilerPlugin class >> ffiCalloutSelectors [
 	<script: 'self ffiCalloutSelectors inspect'>
 	
-	^FFICalloutSelectors ifNil: [ FFICalloutSelectors := self class initializeFFICalloutSelectors ]
+	^FFICalloutSelectors ifNil: [ self class initializeFFICalloutSelectors ]
 ]
 
 { #category : #'class initialization' }

--- a/src/UnifiedFFI/FFICompilerPlugin.class.st
+++ b/src/UnifiedFFI/FFICompilerPlugin.class.st
@@ -154,10 +154,10 @@ FFICompilerPlugin class >> uninstall [
 	self recompileSenders
 ]
 
-{ #category : #api }
-FFICompilerPlugin >> initializeFFICalloutSelectors [
+{ #category : #'private - accessing' }
+FFICompilerPlugin >> ffiCalloutSelectors [
 
-	^FFICalloutSelectors ifNil: [ FFICalloutSelectors := self class initializeFFICalloutSelectors ]
+	^self class ffiCalloutSelectors
 ]
 
 { #category : #api }
@@ -177,6 +177,6 @@ FFICompilerPlugin >> transformsFFIMethod [
  
   ast nodesDo: [:each | 
       each isMessage ifTrue: [    
-    		(self class ffiCalloutSelectors includes: each selector) ifTrue: [^true]]].
+    		(self ffiCalloutSelectors includes: each selector) ifTrue: [^true]]].
   ^false
 ]

--- a/src/UnifiedFFI/FFICompilerPlugin.class.st
+++ b/src/UnifiedFFI/FFICompilerPlugin.class.st
@@ -60,8 +60,7 @@ FFICompilerPlugin class >> addFFICalloutSelectorFromPragma: aPragma [
 FFICompilerPlugin class >> defaultFFICalloutSelectors [
 	"FFI uses UFFI and NB for the time being"
 	
-	^ self defaultUFFICalloutSelectors 
-		join: self defaultNativeBoostCalloutSelectors 
+	^ self defaultUFFICalloutSelectors, self defaultNativeBoostCalloutSelectors 
 ]
 
 { #category : #'private - defaults' }

--- a/src/UnifiedFFI/FFICompilerPlugin.class.st
+++ b/src/UnifiedFFI/FFICompilerPlugin.class.st
@@ -1,7 +1,9 @@
 "
-I am a FFICompilerPlugin. I am a plugin for the OpalCompiler for the compiler that makes the compiled method store the arguments names 
-to be used for FFI when the sources are not loaded or unloaded.
-I can be activated with the command FFICompilerPlugin install.
+I am a FFICompilerPlugin - a compiler plugin for the OpalCompiler that makes the compiled method store the arguments names to be used for FFI when the sources are not loaded or unloaded.
+I can be activated with the command 
+
+  FFICompilerPlugin install
+
 I am pragma-based to detect the methods where the arguments names should be remembered.
 The pragma should be added in the FFI API methods, i.e., the methods that are called by the FFI methods where the arguments have to be remembered.
 Example:
@@ -22,11 +24,9 @@ call: fnSpec options: options
 		options: options;
 		function: fnSpec module: self ffiLibraryName
 
-To remove to be able to remove the sources (.changes and .sources), you only have to activate the plugin, 
-no recompilation is necessary. You can even import new FFI methods or change the FFI API.
+To remove to be able to remove the sources (.changes and .sources), you only have to activate the plugin, no recompilation is necessary. You can even import new FFI methods or change the FFI API.
 
-N.B: Users that redefine the FFI API (like TLGitCalloutTrait >> call:options:) also have to wear the pragma.
-See also FFIAdditionalFFIMethodState and FDBDecompiler>>createNArgs:
+N.B: Users that redefine the FFI API (like TLGitCalloutTrait >> call:options:) also have to wear the pragma. See also FFIAdditionalFFIMethodState and FDBDecompiler>>createNArgs:
 "
 Class {
 	#name : #FFICompilerPlugin,
@@ -41,40 +41,75 @@ Class {
 }
 
 { #category : #adding }
-FFICompilerPlugin class >> addAFfiCalloutSelectorEvent: aPragmaAdded [
-	self addAFfiCalloutSelectorFromPragma: aPragmaAdded pragma
-]
-
-{ #category : #adding }
-FFICompilerPlugin class >> addAFfiCalloutSelectorFromPragma: aPragma [
-	self addFfiCalloutSelector: aPragma methodSelector.
-	self recompileSendersOf: aPragma method
-]
-
-{ #category : #adding }
-FFICompilerPlugin class >> addFfiCalloutSelector: aString [ 
+FFICompilerPlugin class >> addFFICalloutSelector: aString [ 
 	FFICalloutSelectors add: aString
 ]
 
+{ #category : #adding }
+FFICompilerPlugin class >> addFFICalloutSelectorEvent: aPragmaAdded [
+	self addFFICalloutSelectorFromPragma: aPragmaAdded pragma
+]
+
+{ #category : #adding }
+FFICompilerPlugin class >> addFFICalloutSelectorFromPragma: aPragma [
+	self addFFICalloutSelector: aPragma methodSelector.
+	self recompileSendersOf: aPragma method
+]
+
+{ #category : #'private - defaults' }
+FFICompilerPlugin class >> defaultFFICalloutSelectors [
+	"FFI uses UFFI and NB for the time being"
+	
+	^ self defaultUFFICalloutSelectors 
+		join: self defaultNativeBoostCalloutSelectors 
+]
+
+{ #category : #'private - defaults' }
+FFICompilerPlugin class >> defaultNativeBoostCalloutSelectors [
+	"Return the default callout selectors used by old NativeBoost"
+
+	^ #(nbCall: #nbCall:module: #nbCall:options: #nbCall:module:options:)
+]
+
+{ #category : #'private - defaults' }
+FFICompilerPlugin class >> defaultUFFICalloutSelectors [
+	"Return the default callout selectors used by UFFI"
+	
+	^ #(ffiCall: 
+		 ffiCall:module: 
+		 ffiCall:options: 
+		 ffiCall:module:options:)
+]
+
 { #category : #accessing }
-FFICompilerPlugin class >> defaultFfiCalloutSelectors [
-	^ #(ffiCall: #ffiCall:module: #ffiCall:options: #ffiCall:module:options: nbCall: #nbCall:module: #nbCall:options: #nbCall:module:options:)
+FFICompilerPlugin class >> ffiCalloutSelectors [
+	<script: 'self ffiCalloutSelectors inspect'>
+	
+	^FFICalloutSelectors ifNil: [ FFICalloutSelectors := self class initializeFFICalloutSelectors ]
 ]
 
 { #category : #'class initialization' }
 FFICompilerPlugin class >> initialize [
-	FFICalloutSelectors := IdentitySet
-		withAll: self defaultFfiCalloutSelectors.
-	self initializeFfiCalloutSelectorsListUpdate.
-	self install
+
+	self 
+		initializeFFICalloutSelectors;
+		initializeFFICalloutSelectorsListUpdate;
+		install
 ]
 
-{ #category : #initialization }
-FFICompilerPlugin class >> initializeFfiCalloutSelectorsListUpdate [
+{ #category : #'private - initialization' }
+FFICompilerPlugin class >> initializeFFICalloutSelectors [
+
+	FFICalloutSelectors := IdentitySet withAll: self defaultFFICalloutSelectors
+]
+
+{ #category : #'private - initialization' }
+FFICompilerPlugin class >> initializeFFICalloutSelectorsListUpdate [
+
 	collector := PragmaCollector filter: [ :pragma | pragma keyword = #ffiCalloutTranslator ].
-	collector reset do: [ :pragma | self addAFfiCalloutSelectorFromPragma: pragma ].
-	collector when: PragmaAdded send: #addAFfiCalloutSelectorEvent: to: self.
-	collector when: PragmaRemoved send: #removeAFfiCalloutSelectorEvent: to: self
+	collector reset do: [ :pragma | self addFFICalloutSelectorFromPragma: pragma ].
+	collector when: PragmaAdded send: #addFFICalloutSelectorEvent: to: self.
+	collector when: PragmaRemoved send: #removeFFICalloutSelectorEvent: to: self
 ]
 
 { #category : #installation }
@@ -91,7 +126,7 @@ FFICompilerPlugin class >> priority [
 	^ 2
 ]
 
-{ #category : #installation }
+{ #category : #private }
 FFICompilerPlugin class >> recompileSenders [
 	collector reset do: [ :pragma | self recompileSendersOf: pragma method ]
 ]
@@ -102,14 +137,14 @@ FFICompilerPlugin class >> recompileSendersOf: aCompiledMethod [
 ]
 
 { #category : #removing }
-FFICompilerPlugin class >> removeAFfiCalloutSelectorEvent: aPragmaRemoved [
-	self removeFfiCalloutSelector: aPragmaRemoved pragma methodSelector.
-	self recompileSendersOf: aPragmaRemoved pragma method
+FFICompilerPlugin class >> removeFFICalloutSelector: aString [
+	FFICalloutSelectors remove: aString ifAbsent: [  ]
 ]
 
 { #category : #removing }
-FFICompilerPlugin class >> removeFfiCalloutSelector: aString [
-	FFICalloutSelectors remove: aString ifAbsent: [  ]
+FFICompilerPlugin class >> removeFFICalloutSelectorEvent: aPragmaRemoved [
+	self removeFFICalloutSelector: aPragmaRemoved pragma methodSelector.
+	self recompileSendersOf: aPragmaRemoved pragma method
 ]
 
 { #category : #installation }
@@ -119,11 +154,10 @@ FFICompilerPlugin class >> uninstall [
 	self recompileSenders
 ]
 
-{ #category : #accessing }
-FFICompilerPlugin >> ffiCalloutSelectors [
-	^FFICalloutSelectors ifNil: [ FFICalloutSelectors := IdentitySet withAll: #( 
-        ffiCall: ffiCall:module: ffiCall:options: ffiCall:module:options: 
-        nbCall: nbCall:module: nbCall:options: nbCall:module:options:)]
+{ #category : #api }
+FFICompilerPlugin >> initializeFFICalloutSelectors [
+
+	^FFICalloutSelectors ifNil: [ FFICalloutSelectors := self class initializeFFICalloutSelectors ]
 ]
 
 { #category : #api }
@@ -140,9 +174,9 @@ FFICompilerPlugin >> transform [
 
 { #category : #api }
 FFICompilerPlugin >> transformsFFIMethod [
-
- 	ast nodesDo: [:each | 
+ 
+  ast nodesDo: [:each | 
       each isMessage ifTrue: [    
-    		(self ffiCalloutSelectors includes: each selector) ifTrue: [^true]]].
+    		(self class ffiCalloutSelectors includes: each selector) ifTrue: [^true]]].
   ^false
 ]


### PR DESCRIPTION
- Refactor FFICompilerPlugin>>ffiCalloutSelectors to be available from class side so it could be reused in other methods like CompiledMethod>>isFFICall from Calypso later
- Use FFI instead of "Ffi" in method names
- Separate into UFFI and NativeBoost selectors
- refactor initialization
- use proper categorization (like "private - initialization" for initialization methods)
- rework class comment

https://pharo.fogbugz.com/f/cases/22785/