### PR TITLE
22788  AthensCairoSurface class should not use nbCall:module: anymore

### DIFF
--- a/src/Athens-Cairo/AthensCairoSurface.class.st
+++ b/src/Athens-Cairo/AthensCairoSurface.class.st
@@ -284,7 +284,7 @@ AthensCairoSurface class >> ioFindSurface: id dispatch: dispPtr handle: handlePt
 		(e.g., the surface has been found), false otherwise.
 "
 
-	self nbCall: #( bool ioFindSurface(int id, void * dispPtr, int *handlePtr) ) module: #SurfacePlugin
+	self ffiCall: #( bool ioFindSurface(int id, void * dispPtr, int *handlePtr) ) module: #SurfacePlugin
 ]
 
 { #category : #private }
@@ -296,7 +296,7 @@ AthensCairoSurface class >> ioFindSurface: id handle: handlePtr [
 		(e.g., the surface has been found), false otherwise.
 "
 
-	self nbCall: #( bool ioFindSurface(int id, 0 , int *handlePtr) ) module: #SurfacePlugin
+	self ffiCall: #( bool ioFindSurface(int id, 0 , int *handlePtr) ) module: #SurfacePlugin
 ]
 
 { #category : #private }
@@ -310,7 +310,7 @@ AthensCairoSurface class >> ioRegisterSurface: aCairoSurfaceHandle dispatch: sqS
 	otherwise.
 
 "
-	self nbCall: #(bool ioRegisterSurface(int aCairoSurfaceHandle, void *sqSurfaceDispatchPtr, void *idHolder)) module: #SurfacePlugin
+	self ffiCall: #(bool ioRegisterSurface(int aCairoSurfaceHandle, void *sqSurfaceDispatchPtr, void *idHolder)) module: #SurfacePlugin
 ]
 
 { #category : #private }
@@ -322,7 +322,7 @@ AthensCairoSurface class >> ioUnregisterSurface: aCairoSurfaceId [
 
 "
 	
-	self nbCall: #( int ioUnregisterSurface(ulong aCairoSurfaceId) ) module: #SurfacePlugin
+	self ffiCall: #( int ioUnregisterSurface(ulong aCairoSurfaceId) ) module: #SurfacePlugin
 ]
 
 { #category : #private }


### PR DESCRIPTION
- use ffiCall:module: from UFFI instead of old NativeBoost nbCall:module:

https://pharo.fogbugz.com/f/cases/22788