### PR TITLE
22290 MimeConverter mimeEncode: aCollectionOrStream should return Stream and not String

### DIFF
--- a/src/Network-Mail/MailMessage.class.st
+++ b/src/Network-Mail/MailMessage.class.st
@@ -778,7 +778,7 @@ MailMessage >> regenerateText [
 		"put the body, being sure to encode it according to the header"
 		encodedBodyText := body content.
 		self decoderClass ifNotNil: 
-			[ encodedBodyText := (self decoderClass mimeEncode: encodedBodyText readStream) upToEnd ].
+			[ encodedBodyText := self decoderClass mimeEncode: encodedBodyText readStream ].
 		str nextPutAll: encodedBodyText ]
 ]
 


### PR DESCRIPTION
- remove #upToEnd as suggested by Sabine as second option in bug 

https://pharo.fogbugz.com/f/cases/22290/MimeConverter-mimeEncode-aCollectionOrStream-should-return-Stream-and-not-String

as returning a stream makes no sense (see old deprecated and closed PR https://github.com/pharo-project/pharo/pull/1812)