### PR TITLE
22822-Debugger-opens-at-the-wrong-position-when-open-full-debuggeur-option-is-on

### DIFF
--- a/src/GT-Debugger/GTGenericStackDebugger.class.st
+++ b/src/GT-Debugger/GTGenericStackDebugger.class.st
@@ -239,6 +239,12 @@ GTGenericStackDebugger >> debuggingActionsPragmas [
 	^ #( debuggingAction )
 ]
 
+{ #category : #opening }
+GTGenericStackDebugger >> filteredStack [
+
+	^ (self session stackOfSize: 50 ) select: [ :aContext | (aContext method hasPragmaNamed: #debuggerCompleteToSender) not ]
+]
+
 { #category : #'printing/formatting' }
 GTGenericStackDebugger >> formatStackClassColumnForContext: aContext [
 
@@ -344,9 +350,11 @@ GTGenericStackDebugger >> methodCodeWidgetIn: composite forContext: aContext [
 
 { #category : #opening }
 GTGenericStackDebugger >> openWithFullView [
-	"Create and schedule a full debugger with the given label. Do not
-	terminate the current active process."
+	"Create and schedule a full debugger with the given label. Do not terminate the current active process.
 	
+	We also select the first non filtered context, this mean that we will ignore some methods like halts or debug method to select the first interesting line in the debugger."
+
+	self setDebuggerToFirstNonFilteredContext.
 	self open
 ]
 
@@ -485,6 +493,16 @@ GTGenericStackDebugger >> send [
 	self session stepInto: self currentContext.
 	self updateBrowser.
 
+]
+
+{ #category : #opening }
+GTGenericStackDebugger >> setDebuggerToFirstNonFilteredContext [
+	"I set the debugger to the first non filtered stack"
+
+	| selection |
+	selection := self stackPresentation selection.
+	(selection isNil or: [ selection method hasPragmaNamed: #debuggerCompleteToSender ])
+		ifTrue: [ self stackPresentation selection: self filteredStack first ]
 ]
 
 { #category : #accessing }

--- a/src/GT-Debugger/GTSpecPreDebugWindow.class.st
+++ b/src/GT-Debugger/GTSpecPreDebugWindow.class.st
@@ -143,15 +143,7 @@ GTSpecPreDebugWindow >> emptyLayout [
 
 { #category : #'initialization widgets' }
 GTSpecPreDebugWindow >> filteredStack [
-
-	^ (self debugger session stackOfSize: 50 ) select: [ :aContext | (aContext method hasPragmaNamed: #debuggerCompleteToSender) not ]
-]
-
-{ #category : #'initialization widgets' }
-GTSpecPreDebugWindow >> firstContextToOpen [
-
-	self filteredStack ifEmpty: [ ^ nil ].
-	^ self filteredStack first
+	^ self debugger filteredStack
 ]
 
 { #category : #api }
@@ -239,10 +231,9 @@ GTSpecPreDebugWindow >> notifierPaneWidgetId [
 GTSpecPreDebugWindow >> openFullDebugger [
 	| currentDebugger |
 	currentDebugger := self debugger.
-	self setDebuggerToFirstNonFilteredContext.
 	self debugger: nil.
 	self close.
-	currentDebugger open
+	currentDebugger openWithFullView
 ]
 
 { #category : #'actions lookup' }
@@ -282,19 +273,6 @@ GTSpecPreDebugWindow >> rebuildWidget [
 GTSpecPreDebugWindow >> session [
 
 	^ self debugger session
-]
-
-{ #category : #actions }
-GTSpecPreDebugWindow >> setDebuggerToFirstNonFilteredContext [
-	"I set the debugger to the first non filtered stack"
-	| currentDebugger |
-
-	currentDebugger := self debugger.
-
-	(currentDebugger stackPresentation selection isNil
-		or: [ currentDebugger stackPresentation selection method
-				hasPragmaNamed: #debuggerCompleteToSender ])
-		ifTrue: [ currentDebugger stackPresentation selection: self firstContextToOpen ]
 ]
 
 { #category : #'building widgets' }


### PR DESCRIPTION
Fix opening of full debugger to ignore halts.

Move code from PreDebugger to the debugger to centralize the behavior of openning the debugger.Fixes https://pharo.fogbugz.com/f/cases/22822/Debugger-opens-at-the-wrong-position-when-open-full-debuggeur-option-is-on