### PR TITLE
Collection of fixes to some failures from TestRunner

### DIFF
--- a/src/FileSystem-Path/AbsolutePath.class.st
+++ b/src/FileSystem-Path/AbsolutePath.class.st
@@ -39,9 +39,9 @@ AbsolutePath >> printOn: aStream [
 			[1 to: self size do:
 				[:i |
 				aStream 
-					nextPutAll: ' / ''';
-				 	nextPutAll: (self at: i);
-					nextPut: $']]
+					nextPutAll: ' / ';
+				 	print: (self at: i) ]]
+
 ]
 
 { #category : #printing }

--- a/src/FileSystem-Path/RelativePath.class.st
+++ b/src/FileSystem-Path/RelativePath.class.st
@@ -34,16 +34,14 @@ RelativePath >> printOn: aStream [
 		ifTrue: [ aStream nextPutAll: 'workingDirectory' ]
 		ifFalse: 
 			[ aStream 
-				nextPutAll: '* ''';
-				print: (self at: 1);
-				nextPut: $'.
+				nextPutAll: '* ';
+				print: (self at: 1).
 			2 to: self size do:
 				[:i |
 				aStream
-					nextPutAll: ' / ''';
-					print: (self at: i);
-					nextPut: $' ]]
-			
+					nextPutAll: ' / ';
+					print: (self at: i) ]]
+
 ]
 
 { #category : #printing }

--- a/src/NECompletion-Tests/NECEntryTest.class.st
+++ b/src/NECompletion-Tests/NECEntryTest.class.st
@@ -37,5 +37,6 @@ NECEntryTest >> testPrintOn [
 	entry := NECSelectorEntry 
 		contents: 'compute'
 		type: #unary:.
-	self assert: 'NECSelectorEntry(compute,unary:)' = entry printString
+	self assert: 'NECSelectorEntry(''compute'',unary:)' equals: entry printString
+
 ]

--- a/src/Refactoring-Core/RBCondition.class.st
+++ b/src/Refactoring-Core/RBCondition.class.st
@@ -402,7 +402,7 @@ RBCondition >> errorBlockFor: aBoolean [
 
 { #category : #printing }
 RBCondition >> printOn: aStream [ 
-	aStream print: type
+	aStream nextPutAll: type
 ]
 
 { #category : #'initialize-release' }

--- a/src/Tool-ExternalBrowser/ExternalBrowserTest.class.st
+++ b/src/Tool-ExternalBrowser/ExternalBrowserTest.class.st
@@ -63,11 +63,12 @@ ExternalBrowserTest >> setUp [
 { #category : #running }
 ExternalBrowserTest >> tearDown [ 
 	| newWindows |
-	super tearDown.
 	file deleteIfAbsent: [ ].
 	Smalltalk at: self classNameForTest  ifPresent: [ : cl | cl removeFromSystem ].
 	newWindows := World windowsSatisfying: [ : each | (initialWindows includes: each) not ].
 	newWindows do: #delete.
+	super tearDown.
+
 ]
 
 { #category : #running }


### PR DESCRIPTION
Mostly related to printing.
ExternalBrowserTest >> tearDown is corrected so tests from ProperlyImplementedSUnitClassesTest are passing.
