### PR TITLE
Improving the script to detect the version of the build.

### DIFF
--- a/bootstrap/scripts/upload_to_files.pharo.org.sh
+++ b/bootstrap/scripts/upload_to_files.pharo.org.sh
@@ -4,7 +4,7 @@ set -ex
 
 # I will use the name of the image to determine the vm version (because file name is in the format Pharo7.0.0-rc1)
 #
-PHARO_NAME_PREFIX=$(find . -name "Pharo*.zip" | head -n 1 | cut -d'/' -f 2 | cut -d'-' -f 1-2)
+PHARO_NAME_PREFIX=$(find . -name "Pharo*-bootstrap*.zip" | head -n 1 | cut -d'/' -f 2 | cut -d'-' -f 1-2)
 PHARO_SHORT_VERSION=$(echo "${PHARO_NAME_PREFIX}" | cut -d'-' -f 1 | cut -c 6- | cut -d'.' -f 1-2 | sed 's/\.//')
 
 destDir="/appli/files.pharo.org/image/${PHARO_SHORT_VERSION}/"


### PR DESCRIPTION
Find returns different results if the files are stored differently in the filesystem.
As one of the files that might be found does not have a proper format for the regular expression, I have to filter better the files to find. 