### PR TITLE
22843-Cannot-select-all-in-windows

### DIFF
--- a/src/Morphic-Core/KeyboardEvent.class.st
+++ b/src/Morphic-Core/KeyboardEvent.class.st
@@ -109,7 +109,7 @@ KeyboardEvent >> keyValue [
 KeyboardEvent >> modifiedCharacter [
 	self flag: #hack.
 	"Hack me.  When Ctrl is pressed, the key ascii value is not right and we have to do something ugly"
-	^(self hasSpecialCTRLKeyValue and: [ (#(MacOSX Windows) includes: Smalltalk os current platformFamily) ])
+	^(self hasSpecialCTRLKeyValue and: [ (#(MacOSX Windows) includes: Smalltalk os platformFamily) ])
     	ifTrue: [ (self keyValue + $a asciiValue - 1) asCharacter ]    
 		ifFalse: [ 
 			Smalltalk os isWindows 

--- a/src/Morphic-Core/KeyboardEvent.class.st
+++ b/src/Morphic-Core/KeyboardEvent.class.st
@@ -107,11 +107,14 @@ KeyboardEvent >> keyValue [
 
 { #category : #keymapping }
 KeyboardEvent >> modifiedCharacter [
-    self flag: #hack.
-    "Hack me.  When Ctrl is pressed, the key ascii value is not right and we have to do something ugly"
-    ^(self hasSpecialCTRLKeyValue and: [ (#(MacOSX Windows) includes: Smalltalk os current platformFamily) ])
-        ifTrue: [ (self keyValue + $a asciiValue - 1) asCharacter ]    
-        ifFalse: [ self keyCharacter ]
+	self flag: #hack.
+	"Hack me.  When Ctrl is pressed, the key ascii value is not right and we have to do something ugly"
+	^(self hasSpecialCTRLKeyValue and: [ (#(MacOSX Windows) includes: Smalltalk os current platformFamily) ])
+    	ifTrue: [ (self keyValue + $a asciiValue - 1) asCharacter ]    
+		ifFalse: [ 
+			Smalltalk os isWindows 
+				ifTrue: [ self keyCharacter asLowercase ]
+				ifFalse: [ self keyCharacter ] ]
 ]
 
 { #category : #printing }


### PR DESCRIPTION
do an image patch for Windows VM inconsistency with other platforms. This OS returns keyCharacters as uppercase