### PR TITLE
22862-RubScrolledTextMorph-should-be-able-to-manage-a-ghost-text

### DIFF
--- a/src/Rubric/RubScrolledTextMorph.class.st
+++ b/src/Rubric/RubScrolledTextMorph.class.st
@@ -508,6 +508,11 @@ RubScrolledTextMorph >> getTextSelector: aSymbol [
 ]
 
 { #category : #'accessing rulers' }
+RubScrolledTextMorph >> ghostText: aText [
+	self withGhostText: aText
+]
+
+{ #category : #'accessing rulers' }
 RubScrolledTextMorph >> ghostTextRuler [
 	^ self rulerNamed: #ghostText
 ]
@@ -1205,6 +1210,7 @@ RubScrolledTextMorph >> withFocusBorder [
 
 { #category : #'accessing rulers' }
 RubScrolledTextMorph >> withGhostText: aText [
+	aText ifNil: [ ^ self withoutRulerNamed: #ghostText ].
 	self withRulerNamed: #ghostText.
 	self ghostTextRuler updateTextWith: aText asText.
 	self ghostTextRuler comeToFront


### PR DESCRIPTION
Add #ghostText: to RubScrolledTextMorph

Fixes https://pharo.fogbugz.com/f/cases/22862/RubScrolledTextMorph-should-be-able-to-manage-a-ghost-text