### PR TITLE
22863-Improve-Stability-of-Glamour-Tests

### DIFF
--- a/src/Glamour-Tests-Morphic/AbstractMorphicUITest.class.st
+++ b/src/Glamour-Tests-Morphic/AbstractMorphicUITest.class.st
@@ -1,0 +1,44 @@
+Class {
+	#name : #AbstractMorphicUITest,
+	#superclass : #TestCase,
+	#instVars : [
+		'uiWaitingSemaphore'
+	],
+	#category : #'Glamour-Tests-Morphic'
+}
+
+{ #category : #running }
+AbstractMorphicUITest >> defaultWaitDuration [
+
+	^ 500 milliSecond
+]
+
+{ #category : #running }
+AbstractMorphicUITest >> isRunningInUIProcess [
+
+	^ UIManager default uiProcess == Processor activeProcess
+]
+
+{ #category : #running }
+AbstractMorphicUITest >> setUp [
+	super setUp.
+	uiWaitingSemaphore := Semaphore new
+]
+
+{ #category : #running }
+AbstractMorphicUITest >> waitUntilUIRedrawed [
+
+	"I wait until the UI has been redrawn. 
+	I take care of selecting how to do it. 
+	If I am in the CI I should defer a semaphore signal. 
+	If I am running in the UI process I can directly execute a doOneCycle on the World.
+	If I am in the CI the tests and the UI run in different process. So I should not do a #doOneCycle.
+	If I do it, I am in a race condition!"
+	self isRunningInUIProcess ifTrue: [ 
+		World doOneCycle.
+		^ self.	
+	]. 
+
+	World defer: [ uiWaitingSemaphore ifNotNil: #signal ].	
+	uiWaitingSemaphore wait: self defaultWaitDuration.
+]

--- a/src/Glamour-Tests-Morphic/GLMFinderMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMFinderMorphicTest.class.st
@@ -171,6 +171,8 @@ GLMFinderMorphicTest >> testSpawnFinder [
 	| browser |
 	browser := GLMFinder new.
 	window := browser openOn: ($a to: $d).
-	self repeatAssert: [window submorphs last class] equals: GLMPaneScroller.
+	
+	self waitUntilUIRedrawed.
+	self assert: window submorphs last class equals: GLMPaneScroller.
 
 ]

--- a/src/Glamour-Tests-Morphic/GLMListMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMListMorphicTest.class.st
@@ -96,7 +96,9 @@ GLMListMorphicTest >> testOnlyOneMorphPerRowInList [
 		to: #one;
 		andShow: [ :a | a list display: [ :x | x ] ].
 	window := browser openOn: (1 to: 100).
-	World doOneCycle.
+
+	self waitUntilUIRedrawed.
+
 	listMorph := self find: MorphTreeMorph in: window.
 	nodeMorphs := (self find: MorphTreeTransformMorph in: listMorph) submorphs.
 	self assert: nodeMorphs size equals: 100.

--- a/src/Glamour-Tests-Morphic/GLMMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMMorphicTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #GLMMorphicTest,
-	#superclass : #TestCase,
+	#superclass : #AbstractMorphicUITest,
 	#instVars : [
 		'window'
 	],
@@ -43,12 +43,6 @@ GLMMorphicTest >> findWherePresentationIs: aPresentation in: aMorph [
 					and: [(morph model respondsTo: #glamourPresentation) 
 					and: [morph model glamourPresentation == aPresentation]] ]
 			in: aMorph  
-]
-
-{ #category : #private }
-GLMMorphicTest >> repeatAssert: aBlock equals: aResult [
-
-	self assert: (self wait: 0.5 until: aBlock evaluatesTo: aResult)
 ]
 
 { #category : #private }
@@ -99,20 +93,4 @@ GLMMorphicTest >> send: treeMorph mouseUpWithShift: aBoolean onItem: treeNodeMor
 GLMMorphicTest >> tearDown [
 	window ifNotNil: [ window delete ].
 	super tearDown
-]
-
-{ #category : #private }
-GLMMorphicTest >> wait: maxWaitSeconds until: validateBlock evaluatesTo: expectedResult [
-	"Evaluate validateBlock until it returns expectedResult or 
-maxWaitSeconds have passed,
-	 pausing between evaluations.  Return the last result of validateBlock 
-value"
-
-	| startTime result |
-	startTime := Time millisecondClockValue.
-	[result := validateBlock value = expectedResult] whileFalse:
-			[(Time millisecondClockValue - startTime > (maxWaitSeconds * 1000)) ifTrue: [^result].
-			(Delay forMilliseconds: 50) wait].
-	^ result
-
 ]

--- a/src/Glamour-Tests-Morphic/GLMTableMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMTableMorphicTest.class.st
@@ -13,8 +13,9 @@ GLMTableMorphicTest >> testColumnBlockTakesEntity [
 	browser show: [:a | a table
 		column: 'Even' evaluated: [:each :entity | receivedEntity := entity. 'x']].
 	window := browser openOn: (1 to: 5).
-	World doOneCycle.
-	self repeatAssert: [receivedEntity] equals: (1 to: 5).
+
+	self waitUntilUIRedrawed.
+	self assert: receivedEntity equals: (1 to: 5).
 
 ]
 

--- a/src/Glamour-Tests-Morphic/GLMTabulatorMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMTabulatorMorphicTest.class.st
@@ -37,7 +37,8 @@ GLMTabulatorMorphicTest >> testSizeAndSpan [
 	window := browser openOn: #('Should be scaled at 2/3' 'Should be fixed' 'Should be scaled at 1/3').
 	{200@500. 100@300} do: [:ext |
 		window extent: ext.
-		World doOneCycle.
+		self waitUntilUIRedrawed.
+
 		panes := window submorphs last submorphs last: 3.
 		heights := panes collect: [ :each | each height+2 ].
 		self assert: panes first owner height equals: heights sum.
@@ -54,11 +55,14 @@ GLMTabulatorMorphicTest >> testSpawnTabulator [
 	browser := GLMTabulator new.
 	window := browser openOn: ($a to: $d).
 	self assert: window model == browser.
-	self repeatAssert: [
-		window submorphs last 
+	
+	self waitUntilUIRedrawed.
+
+	self assert: 
+		(window submorphs last 
 					submorphs last 
 						submorphs last 
-							submorphs last class] equals: GLMPaginatedMorphTreeMorph
+							submorphs last class) equals: GLMPaginatedMorphTreeMorph
 
 ]
 
@@ -71,7 +75,9 @@ GLMTabulatorMorphicTest >> testStatusbar [
 	browser transmit to: #one; andShow: [:a | a list display: #(1 2 3)].
 	window := browser openOn: 42.
 	((browser paneNamed: #one) port: #status) value: 2.
-	World doOneCycle.
+
+	self waitUntilUIRedrawed.
+
 	statusMorph := (window submorphs last: 2) first submorphs first.	
 	self assert: (statusMorph isKindOf: LabelMorph)
 ]

--- a/src/Glamour-Tests-Morphic/GLMTreeMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMTreeMorphicTest.class.st
@@ -14,8 +14,9 @@ GLMTreeMorphicTest >> testChildrenBlock [
 			check := true.
 			#() ]].
 	window := browser openOn: ($a to: $d).
-	World doOneCycle.
-	self repeatAssert: [ check ] equals: true
+
+	self waitUntilUIRedrawed.
+	self assert: check equals: true
 ]
 
 { #category : #tests }
@@ -26,9 +27,10 @@ GLMTreeMorphicTest >> testChildrenBlockTakesEntity [
 	browser show: [:a | a tree
 		children: [:each :entity | receivedEntity := entity. #()]].
 	window := browser openOn: ($a to: $d).
-	World doOneCycle.
-	self repeatAssert: [receivedEntity] equals: ($a to: $d).
 
+	self waitUntilUIRedrawed.
+
+	self assert: receivedEntity equals: ($a to: $d).
 ]
 
 { #category : #tests }
@@ -163,18 +165,24 @@ GLMTreeMorphicTest >> testTreeWithTags [
 												ifFalse: [ #('odd') ] ]
 										ifFalse: [ #() ] ] ].
 	window := browser openOn: model.
-	World doOneCycle.
+
+	self waitUntilUIRedrawed.
+
 	oddNode := self treeVisibleItems second.	
 	
 	oddNode toggleExpandedState. "Simulate a click on the node's arrow to expand the node and make sub nodes visible"
 
-	World doOneCycle.
+	self waitUntilUIRedrawed.
+
 	lineWithNumber3 := self treeVisibleItems third.
 	(self find: SimpleButtonMorph in: lineWithNumber3) doButtonAction. "Simulate a click on the 'odd' tag to make even numbers disappear"
-	World doOneCycle.
+	self waitUntilUIRedrawed.
+
 	someNode := self treeVisibleItems fifth.
 	someNode toggleExpandedState.
-	World doOneCycle.
+
+	self waitUntilUIRedrawed.
+
 	secondSome := self find: TextMorph in: self treeVisibleItems seventh.
 	self assert: secondSome text asString equals: '3'
 ]

--- a/src/Glamour-Tests-Morphic/GLMUpdateInterdependentPanesTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMUpdateInterdependentPanesTest.class.st
@@ -166,7 +166,7 @@ GLMUpdateInterdependentPanesTest >> testTwoInterdependentPanesShouldUpdateTheRen
 	self assert: ((browser paneNamed: #one) port: #selection) value equals: 5.
 	self assert: ((browser paneNamed: #two) port: #selection) value equals: 5.
 
-	World doOneCycle.
+	self waitUntilUIRedrawed.
 
 	morphOne := self findWherePresentationIs: (browser paneNamed: #one) presentations first in: window.
 	self assert: morphOne notNil.


### PR DESCRIPTION
Adding a superclass to the Glamour tests to handle the waiting for UI redrawn in a more tidy way.

Glamour Tests are using directly World >> #doOneCycle.
This produces a problem when executing in the CI.
As the tests in the CI are run in another process different than the UI process, if we do #doOneCycle there is the risk of race conditions.

This will improve the stability of the build in the CI.

Issue: https://pharo.manuscript.com/f/cases/22863/Improve-Stability-of-Glamour-Tests