### PR TITLE
22864-SessionErrorHandlingTest-should-run-using-the-NonInteractiveUIManager

### DIFF
--- a/src/System-SessionManager-Tests/SessionErrorHandlingTest.class.st
+++ b/src/System-SessionManager-Tests/SessionErrorHandlingTest.class.st
@@ -28,18 +28,19 @@ SessionErrorHandlingTest >> setUp [
 
 { #category : #tests }
 SessionErrorHandlingTest >> testErrorCaughtAndDefferedIfExceptionSignaledAtStartupWhenStartupUiManagerActive [
-	manager register: (TestSessionHandler onStartup: [ Halt now ]).	
-	session errorHandler: 
-		(TestStartupUIManager new
-			sessionManager: manager;
-			yourself).
-	
-	self 
-		shouldnt: [ session start: false ]
-		raise: Halt.
-	self
-		assert: (session instVarNamed: 'deferredStartupActions') size 
-		equals: 1
+
+	UIManager nonInteractiveDuring: [	manager register: (TestSessionHandler onStartup: [ Halt now ]).	
+		session errorHandler: 
+			(TestStartupUIManager new
+				sessionManager: manager;
+				yourself).
+		
+		self 
+			shouldnt: [ session start: false ]
+			raise: Halt.
+		self
+			assert: (session instVarNamed: 'deferredStartupActions') size 
+			equals: 1]
 ]
 
 { #category : #tests }


### PR DESCRIPTION
The test SessionErrorHandlingTest>>testErrorHandledIfExceptionSignaledAtShutdownWhenStartupUiManagerActive runs correct if it is using the non interactive UIManager when it runs in the CI. This should be the default, but there are some execution patterns that produce that another UIManager is in use. If another UIManager is in use and an error occurs the image quits.

Adding a guard to guarantee that the correct UIManager is used as expected.
This should improve the stability of the tests (I hope).

Issue: https://pharo.manuscript.com/f/cases/22864/SessionErrorHandlingTest-should-run-using-the-NonInteractiveUIManager