### PR TITLE
Fixed issue 22688.

### DIFF
--- a/src/AST-Core/BISimpleFormatter.class.st
+++ b/src/AST-Core/BISimpleFormatter.class.st
@@ -82,11 +82,6 @@ BISimpleFormatter >> codeStream: anObject [
 ]
 
 { #category : #'public interface' }
-BISimpleFormatter >> containerWidth: anInteger [
-	"nothing done on purpose"
-]
-
-{ #category : #'public interface' }
 BISimpleFormatter >> format: aParseTree [
 	originalSource := aParseTree source.
 	self visitNode: aParseTree.

--- a/src/AST-Core/RBNullFormatter.class.st
+++ b/src/AST-Core/RBNullFormatter.class.st
@@ -31,11 +31,6 @@ RBNullFormatter class >> formatAsYouReadPolicy: aBoolean [
 ]
 
 { #category : #'public interface' }
-RBNullFormatter >> containerWidth: anInteger [
-	"doing nothing on purpose"
-]
-
-{ #category : #'public interface' }
 RBNullFormatter >> format: aParseTree [ 
 	^ aParseTree source
 		ifNil: [	self visitNode: aParseTree.

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -333,14 +333,7 @@ RBProgramNode >> evaluatedFirst: aNode [
 
 { #category : #accessing }
 RBProgramNode >> formattedCode [
-	^ self formattedCodeWithMaxLineLength: 70
-]
-
-{ #category : #accessing }
-RBProgramNode >> formattedCodeWithMaxLineLength: anInteger [
-	^ self formatterClass new
-		containerWidth: anInteger;
-		format: self
+	^ self formatterClass new format: self
 ]
 
 { #category : #accessing }

--- a/src/BlueInk-Core/BIConfigurableFormatter.class.st
+++ b/src/BlueInk-Core/BIConfigurableFormatter.class.st
@@ -490,11 +490,6 @@ BIConfigurableFormatter >> codeStream: anObject [
 	codeStream := anObject
 ]
 
-{ #category : #'public interface' }
-BIConfigurableFormatter >> containerWidth: anInteger [
-	self installNewValueInContext: {(#maxLineLength: -> anInteger)}
-]
-
 { #category : #private }
 BIConfigurableFormatter >> currentLineLength [
 	^ codeStream position - lineStart

--- a/src/BlueInk-Extras/BISettingPreviewer.class.st
+++ b/src/BlueInk-Extras/BISettingPreviewer.class.st
@@ -179,8 +179,7 @@ BISettingPreviewer >> formatSourceCode [
 	| source tree formatted |
 	source := self compiledMethodFromSearchFields sourceCode.
 	tree := RBParser parseMethod: source onError: [ :msg :pos | ^ self ].
-	formatted := tree
-		formattedCodeWithMaxLineLength: (self window value window value width / 9) integerPart asInteger.	"It is a bit tricky but I get the width of the sourceCodePane like this..."
+	formatted := tree formattedCode.
 	sourceCodePane text: formatted
 ]
 

--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -138,7 +138,7 @@ RubSmalltalkCodeMode >> formatMethodCode [
 	| source tree formatted |
 	source := self textArea text asString.
 	tree := RBParser parseMethod: source onError: [ :msg :pos | ^ self ].
-	formatted := tree formattedCodeWithMaxLineLength: self maxFormatterLineLength.
+	formatted := tree formattedCode.
 	formatted = source
 		ifTrue: [ ^ self ].
 	self textArea updateTextWith: formatted
@@ -154,13 +154,6 @@ RubSmalltalkCodeMode >> hasBindingOf: aString [
 RubSmalltalkCodeMode >> hasBindingThatBeginsWith: aString [ 
 	" For the shout styler "
 	^ self model notNil and: [ self model hasBindingThatBeginsWith: aString ]
-]
-
-{ #category : #formatting }
-RubSmalltalkCodeMode >> maxFormatterLineLength [
-	^ self textArea wrapped
-		ifTrue: [ (self textArea innerBounds width / 9) integerPart ]
-		ifFalse: [ 70 ]
 ]
 
 { #category : #parsing }


### PR DESCRIPTION
The only formatter using the provided value was the configurable one, and it's overriding the configured value with the window size.
Just removed all this, and use the value configured in the formatter settings for max line length.