### PR TITLE
22872-NewMethodFinder-Tests-is-an-empty-package

### DIFF
--- a/src/NewMethodFinder-Tests/package.st
+++ b/src/NewMethodFinder-Tests/package.st
@@ -1,1 +1,0 @@
-Package { #name : #'NewMethodFinder-Tests' }


### PR DESCRIPTION
Remove empty package.

Fixes https://pharo.fogbugz.com/f/cases/22872/NewMethodFinder-Tests-is-an-empty-package