### PR TITLE
22428-Code-in-TimeProfiler-is-no-longer-highlighted

### DIFF
--- a/src/Tool-Profilers/TimeProfiler.class.st
+++ b/src/Tool-Profilers/TimeProfiler.class.st
@@ -342,6 +342,8 @@ TimeProfiler >> open [
 		getText: #selectedMethodCode
 		setText: #selectedMethodCode:notifying:
 		getEnabled: nil.
+	"The next line is a fix for https://pharo.fogbugz.com/f/cases/22428/Code-in-TimeProfiler-is-no-longer-highlighted but I have the impression that the problem comes from the constructor used before. Since we are close to the release I'll just fix it here but later we should check the constructor method."
+	codePane styler: (SHRBTextStyler new view: codePane; yourself).
 	codePane getMenuSelector: #codePaneMenu:shifted:.
 	codePane font: StandardFonts codeFont.
 	self withToolBar


### PR DESCRIPTION
Enable once again the syntax highlight in TimeProfiler.

Fixes https://pharo.fogbugz.com/f/cases/22428/Code-in-TimeProfiler-is-no-longer-highlighted