### PR TITLE
21683-Text-layout-for-ti-broken-in-browser-NautilusCalypso

### DIFF
--- a/src/EmbeddedFreeType/EmbeddedFreeTypeFontInstaller.class.st
+++ b/src/EmbeddedFreeType/EmbeddedFreeTypeFontInstaller.class.st
@@ -80,7 +80,7 @@ EmbeddedFreeTypeFontInstaller >> addFromFileContents: bytes baseName:  originalF
 	[ "we use the primNewFaceFromFile:index: method because we want to do this as fast as possible and we don't need the face registered because it will be explicitly destroyed later"
 	face newFaceFromExternalMemory: externalMem index: i.
 	face loadFields] 
-		on: FT2Error 
+		on: FT2Error, PrimitiveFailed 
 		do:[:e | 
 			self failedToOpen:face index: i.
 			^ self].

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -321,7 +321,7 @@ FreeTypeFont >> getLinearWidthOf: aCharacter [
 	face validate.
 	face setPixelWidth: em height: em.
 	[face loadCharacter: charCode flags: (LoadNoBitmap bitOr: (LoadIgnoreTransform bitOr: "FreeTypeSettings current hintingFlags" 2 "no hinting"))]
-		on: FT2Error do:[:e |
+		on: FT2Error , PrimitiveFailed do:[:e |
 			face loadGlyph: 0 flags: (LoadNoBitmap bitOr: (LoadIgnoreTransform bitOr: FreeTypeSettings current hintingFlags "no hinting")) ].
 	glyph := face glyph.
 	la := glyph linearHorizontalAdvance.
@@ -363,7 +363,7 @@ FreeTypeFont >> getWidthOf: aCharacter [
 	hintingFlags := FreeTypeSettings current hintingFlags.
 	flags :=  LoadNoBitmap bitOr:( LoadIgnoreTransform bitOr: hintingFlags). 
 	[face loadCharacter: charCode flags: flags.
-	] on:FT2Error do:[:e | "character not in map?"^0]. 
+	] on:FT2Error, PrimitiveFailed do:[:e | "character not in map?"^0]. 
 	glyph := face glyph.
 	"When not hinting FreeType sets the advance to the truncated linearAdvance.
 	The characters appear squashed together. Rounding is probably better, so we 

--- a/src/FreeType/FreeTypeFontProvider.class.st
+++ b/src/FreeType/FreeTypeFontProvider.class.st
@@ -380,12 +380,10 @@ FreeTypeFontProvider >> platformImageRelativeDirectories [
 
 { #category : #'file paths' }
 FreeTypeFontProvider >> platformVMRelativeDirectories [
-	
-	| directory |
-	directory :=  Smalltalk vm path asFileReference / 'Fonts'.
-	directory exists
-		ifTrue: [ ^ { directory } ].
-	^ #()
+  | directory |
+  directory := Smalltalk vm directory asFileReference / 'Fonts'.
+  directory exists ifTrue: [ ^{directory} ].
+  ^#()
 ]
 
 { #category : #'loading and updating' }
@@ -503,7 +501,7 @@ FreeTypeFontProvider >> updateFromFile: aFile [
 	["we use the primNewFaceFromFile:index: method because we want to do this as fast as possible and we don't need the face registered because it will be explicitly destroyed later"
 	face newFaceFromFile: path index: i.
 	face loadFields]
-		on: FT2Error
+		on: FT2Error, PrimitiveFailed
 		do: [:e | ^self failedToOpen: face from: path index: i ].
 	(face height notNil  and:[face hasFamilyName and:[face hasStyleName and:[face isValid]]])
 		ifFalse: [ ^self failedToOpen:face from: path index: i ]

--- a/src/FreeType/FreeTypeGlyphRenderer.class.st
+++ b/src/FreeType/FreeTypeGlyphRenderer.class.st
@@ -177,12 +177,13 @@ FreeTypeGlyphRenderer >> renderGlyph: aCharacter depth: depth subpixelPosition: 
 	hintingFlags := FreeTypeSettings current hintingFlags.
 	flags :=  LoadNoBitmap bitOr:( LoadIgnoreTransform bitOr: hintingFlags). 
 	face loadCharacter:charCode flags: flags]
-	on: FT2Error do:[:e | 
+	on: FT2Error, PrimitiveFailed do:[:e | 
 		^(GlyphForm extent: 0@0 depth: depth)
 			advance: 0@0;
 			linearAdvance: 0@0;
 			offset:0@0;
-			yourself]. 
+			yourself].
+		 
 	glyph := face glyph. 
 	slant := aFreeTypeFont simulatedItalicSlant.
 	extraWidth := (glyph height * slant) abs ceiling.

--- a/src/FreeType/FreeTypeSubPixelAntiAliasedGlyphRenderer.class.st
+++ b/src/FreeType/FreeTypeSubPixelAntiAliasedGlyphRenderer.class.st
@@ -128,7 +128,7 @@ FreeTypeSubPixelAntiAliasedGlyphRenderer >> renderStretchedGlyph: aCharacter dep
 	hintingFlags := FreeTypeSettings current hintingFlags.
 	flags :=  LoadNoBitmap bitOr:( LoadIgnoreTransform bitOr: hintingFlags). 
 	face loadCharacter:charCode flags: flags. 
-	] on: FT2Error do:[:e | 
+	] on: FT2Error, PrimitiveFailed do:[:e | 
 		^(GlyphForm extent: 0@0 depth: depth)
 			advance: 0@0;
 			linearAdvance: 0@0;


### PR DESCRIPTION
Improving the error handling when calling to the FT bindings.
Also it fixes the recursive execution when there is an error.
Also it will be great to have the new version of the library, as it fixes many related issues.
Issue: https://pharo.manuscript.com/f/cases/21683/Text-layout-for-ti-broken-in-browser-Nautilus-Calypso