### PR TITLE
22831-Methods-compiled-in-classes-from--UnpackagedPackage-does-no-have-package

### DIFF
--- a/src/RPackage-Core/CompiledMethod.extension.st
+++ b/src/RPackage-Core/CompiledMethod.extension.st
@@ -34,5 +34,5 @@ CompiledMethod >> packageFromOrganizer: anRPackageOrganizer [
 			self origin isMeta
 				ifFalse: [ each includesSelector: originSelector ofClassName: self origin instanceSide originalName]
 				ifTrue: [ each includesSelector: originSelector ofMetaclassName: self origin instanceSide originalName]] 
-		ifNone: [ nil ]
+		ifNone: [ anRPackageOrganizer defaultPackage ]
 ]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -335,6 +335,12 @@ RPackageOrganizer >> debuggingName: aString [
 	debuggingName := aString
 ]
 
+{ #category : #accessing }
+RPackageOrganizer >> defaultPackage [
+
+	^ self packageNamed: RPackage defaultPackageName
+]
+
 { #category : #initialization }
 RPackageOrganizer >> defineUnpackagedClassesPackage [
 	^ self ensureExistAndRegisterPackageNamed: self packageClass defaultPackageName

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -402,6 +402,20 @@ RPackageOrganizerTest >> testSilentlyRenameCategoryToBe [
 ]
 
 { #category : #tests }
+RPackageOrganizerTest >> testUnpackagedClassesWithMethods [
+
+	| aClass |
+	aClass := self createNewClassNamed: 'RTestClass' inCategory: RPackage defaultPackageName.
+	
+	self assert: aClass package name equals: RPackage defaultPackageName.
+	
+	aClass compile: 'm1'.
+	
+	self assert: (aClass >> #m1) package name equals: RPackage defaultPackageName.
+
+]
+
+{ #category : #tests }
 RPackageOrganizerTest >> testUnregisterBasedOnNames [
 	| p1 p2 p3 |
 	p1 := self createNewPackageNamed: 'P1'.


### PR DESCRIPTION
An unpackaged method should return the default package.Issue: https://pharo.manuscript.com/f/cases/22831/Methods-compiled-in-classes-from-_UnpackagedPackage-does-no-have-package