### PR TITLE
Adding an "Inspect Debugger" command to the debugger UI.

### DIFF
--- a/src/DebuggerActions/InspectDebuggerDebugAction.class.st
+++ b/src/DebuggerActions/InspectDebuggerDebugAction.class.st
@@ -1,0 +1,35 @@
+Class {
+	#name : #InspectDebuggerDebugAction,
+	#superclass : #DebugAction,
+	#category : #'DebuggerActions-Actions'
+}
+
+{ #category : #registration }
+InspectDebuggerDebugAction class >> actionType [
+	<contextMenuDebuggingAction>
+]
+
+{ #category : #accessing }
+InspectDebuggerDebugAction >> defaultLabel [
+	^ 'Inspect debugger'
+]
+
+{ #category : #accessing }
+InspectDebuggerDebugAction >> defaultOrder [
+	^ 130
+]
+
+{ #category : #accessing }
+InspectDebuggerDebugAction >> executeAction [ 
+	self debugger inspect.
+]
+
+{ #category : #accessing }
+InspectDebuggerDebugAction >> help [
+	^ 'Opens an inspector on the underlying debugger object'
+]
+
+{ #category : #accessing }
+InspectDebuggerDebugAction >> id [
+	^ #inspectDebugger
+]

--- a/src/GT-Debugger/InspectDebuggerDebugAction.extension.st
+++ b/src/GT-Debugger/InspectDebuggerDebugAction.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #InspectDebuggerDebugAction }
+
+{ #category : #'*GT-Debugger' }
+InspectDebuggerDebugAction class >> gtActionFor: aDebugger [
+	<gtStackDebuggingAction>
+
+	^ (self forDebugger: aDebugger)
+			order: 60
+]


### PR DESCRIPTION
To inspect the underlying debugger object.