### PR TITLE
Fix Pharo home URL in WebBrowser example method

### DIFF
--- a/src/WebBrowser-Core/WebBrowser.class.st
+++ b/src/WebBrowser-Core/WebBrowser.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #examples }
 WebBrowser class >> example [
 
-	self openOn: 'http://www.pharo.org'
+	self openOn: 'http://pharo.org'
 ]
 
 { #category : #testing }


### PR DESCRIPTION
`WebBrowser example` method was opening a browser on
<http://www.pharo.org>, (which currently displays a directory with a
`springer.png` file through Apache by the way).

It now opens a browser on <http://pharo.org>, which is the URL shown in
the github description.