### PR TITLE
22880-GTPlaygroundBasicTest-leaves-empty-protocols

### DIFF
--- a/src/GT-Tests-Playground/GTPlaygroundBasicTest.class.st
+++ b/src/GT-Tests-Playground/GTPlaygroundBasicTest.class.st
@@ -54,13 +54,12 @@ GTPlaygroundBasicTest >> testPageActionsIn [
 		title: ''A mock page action'''
 		classified: '*GTMockTests'.
 		
-	[ self assert: selector notNil.
+	self assert: selector notNil.
 	window := playground openOn: (GTPlayPage new saveContent: 'a:=1. b:=a+1').
 	actions := playground pageActions.
 	self deny: actions size isZero.
 	action := actions detect: [ :eachAction | eachAction title = 'A mock page action' ].
-	self deny: action isNil ]
-		ensure: [ playground class removeSelector: selector ]
+	self deny: action isNil
 ]
 
 { #category : #running }
@@ -76,13 +75,12 @@ GTPlaygroundBasicTest >> testPlaygroundActionsIn [
 		title: ''A mock playground action'''
 		classified: '*GTMockTests'.
 		
-	[ self assert: selector notNil.
+	self assert: selector notNil.
 	window := playground openOn: (GTPlayPage new saveContent: 'a:=1. b:=a+1').
 	actions := playground playgroundActions.
 	self deny: actions size isZero.
 	action := actions detect: [ :eachAction | eachAction title = 'A mock playground action' ].
-	self deny: action isNil ]
-		ensure: [ playground class removeSelector: selector ]
+	self deny: action isNil
 ]
 
 { #category : #running }


### PR DESCRIPTION
Let the package removal in tearDown remove the methods and clean protocols.

In the previous version, tests removed in an #ensure:Â some created methods. This way do not remove empty protocols.  Now we let the #removeFromSystem in the tearDown do the action because this way clean also empty protocols.

Fixes https://pharo.fogbugz.com/f/cases/22880/GTPlaygroundBasicTest-leaves-empty-protocols