### PR TITLE
22677-Renaming-a-class-variable-in-a-SharedPool-does-not-rename-the-places-where-its-used

### DIFF
--- a/src/Refactoring-Core/RBClass.class.st
+++ b/src/Refactoring-Core/RBClass.class.st
@@ -182,6 +182,21 @@ RBClass >> isMeta [
 	^false
 ]
 
+{ #category : #testing }
+RBClass >> isSharedPool [
+	
+	^ (self allSuperclasses collect: #name) includes: #SharedPool
+]
+
+{ #category : #querying }
+RBClass >> methodsUsingClassVariableNamed: aClassVariableName [
+ 
+	^ (self realClass classVariableNamed: aClassVariableName) usingMethods collect: [ :aMethod | |modelClass|
+			modelClass := self model classNamed: aMethod methodClass name.
+			modelClass methodFor: aMethod selector
+		]
+]
+
 { #category : #accessing }
 RBClass >> poolDictionaryNames: aCollectionOfStrings [ 
 	poolDictionaryNames := (aCollectionOfStrings 

--- a/src/Refactoring-Core/RBRenameClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameClassVariableRefactoring.class.st
@@ -59,18 +59,16 @@ RBRenameClassVariableRefactoring >> rename: aVarName to: aName in: aClass [
 
 { #category : #transforming }
 RBRenameClassVariableRefactoring >> renameReferences [
-	| replacer subclasses |
+	| replacer methods |
 	replacer := RBParseTreeRewriter 
 		rename: variableName
 		to: newName
 		handler: 
 			[ self refactoringError: ('<1s> is already defined as a method or block temporary <n> variable in this class or one of its subclasses' expandMacrosWith: newName) ].
-	subclasses := class withAllSubclasses asSet.
-	subclasses addAll: class classSide withAllSubclasses.
-	self 
-		convertClasses: subclasses
-		select: [ :aClass | aClass whichSelectorsReferToClassVariable: variableName ]
-		using: replacer
+
+	methods := class methodsUsingClassVariableNamed: variableName.	
+	methods do: [ :method | self convertMethod: method selector for: method modelClass using: replacer ]
+
 ]
 
 { #category : #printing }

--- a/src/Refactoring-Tests-Core/RBClassUsingSharedPoolForTest.class.st
+++ b/src/Refactoring-Tests-Core/RBClassUsingSharedPoolForTest.class.st
@@ -1,0 +1,14 @@
+Class {
+	#name : #RBClassUsingSharedPoolForTest,
+	#superclass : #Object,
+	#pools : [
+		'RBSharedPoolForTest'
+	],
+	#category : #'Refactoring-Tests-Core-Data'
+}
+
+{ #category : #'as yet unclassified' }
+RBClassUsingSharedPoolForTest >> msg3 [
+
+	^ Var1
+]

--- a/src/Refactoring-Tests-Core/RBRenameClassVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenameClassVariableTest.class.st
@@ -55,3 +55,21 @@ RBRenameClassVariableTest >> testRenameClassVar [
 													in: class
 													classified: aSmalllintContext protocols]]')
 ]
+
+{ #category : #tests }
+RBRenameClassVariableTest >> testRenameClassVarInSharedPool [
+	| refactoring class userClass |
+	refactoring := RBRenameClassVariableRefactoring 
+		rename: #Var1
+		to: #VarOne
+		in: RBSharedPoolForTest.
+	self executeRefactoring: refactoring.
+	
+	class := refactoring model classNamed: #RBSharedPoolForTest.
+	userClass := refactoring model classNamed: #RBClassUsingSharedPoolForTest.
+	
+	self assert: (class parseTreeFor: #msg1) = (RBParser parseMethod: 'msg1 ^ VarOne').	
+	self assert: (class parseTreeFor: #msg2) = (RBParser parseMethod: 'msg2 ^ VarOne').	
+	self assert: (userClass parseTreeFor: #msg3) = (RBParser parseMethod: 'msg3 ^ VarOne').	
+
+]

--- a/src/Refactoring-Tests-Core/RBSharedPoolForTest.class.st
+++ b/src/Refactoring-Tests-Core/RBSharedPoolForTest.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #RBSharedPoolForTest,
+	#superclass : #SharedPool,
+	#classVars : [
+		'Var1'
+	],
+	#category : #'Refactoring-Tests-Core-Data'
+}
+
+{ #category : #accessing }
+RBSharedPoolForTest >> msg1 [
+	
+	^ Var1
+]
+
+{ #category : #accessing }
+RBSharedPoolForTest >> msg2 [
+	
+	^ Var1
+]


### PR DESCRIPTION
Renaming a class variable in a SharedPool renames the places where it's used.
Issue: https://pharo.manuscript.com/f/cases/22677/Renaming-a-class-variable-in-a-SharedPool-does-not-rename-the-places-where-it-s-used