### PR TITLE
22881-successTextColor-is-not-readable-in-light-theme

### DIFF
--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -5423,12 +5423,12 @@ UITheme >> subgroupColorFrom: paneColor [
 
 { #category : #'accessing colors' }
 UITheme >> successBackgroundColor [
-	^ self successTextColor darker darker
+	^ self successTextColor lighter lighter
 ]
 
 { #category : #'accessing colors' }
 UITheme >> successTextColor [
-	^ Color green
+	^ Color r: 0 g: 0.5 b: 0
 ]
 
 { #category : #'border-styles' }


### PR DESCRIPTION
Use a more readable color for success color in light theme.

Fixes https://pharo.fogbugz.com/f/cases/22881/successTextColor-is-not-readable-in-light-theme