### PR TITLE
Removing leftover halts

### DIFF
--- a/src/Debugger-Tests/FilterTest.class.st
+++ b/src/Debugger-Tests/FilterTest.class.st
@@ -18,7 +18,7 @@ Class {
 { #category : #running }
 FilterTest >> setUp [
 	super setUp.
-	context := [ (Set with: 1 with: 2) collect: [ :e | e * 2 ]. self halt ] asContext.
+	context := [ (Set with: 1 with: 2) collect: [ :e | e * 2 ]] asContext.
 	process := Process 
 		forContext: context 
 		priority: Processor userInterruptPriority.

--- a/src/GT-SUnitDebugger/GTSUnitExampleFailingTest.class.st
+++ b/src/GT-SUnitDebugger/GTSUnitExampleFailingTest.class.st
@@ -113,7 +113,7 @@ GTSUnitExampleFailingTest >> testSimpleFailingAssestion [
 
 { #category : #tests }
 GTSUnitExampleFailingTest >> testWithHalt [
-
+	<haltOrBreakpointForTesting>
 	self assert: true.
 	self halt
 ]

--- a/src/Kernel-Tests-Extended/CodeSimulationTests.class.st
+++ b/src/Kernel-Tests-Extended/CodeSimulationTests.class.st
@@ -25,6 +25,7 @@ CodeSimulationTests >> methodWithError [
 
 { #category : #tests }
 CodeSimulationTests >> methodWithHalt [
+	<haltOrBreakpointForTesting>
 	self halt
 ]
 

--- a/src/Kernel-Tests-Extended/ObjectTest.extension.st
+++ b/src/Kernel-Tests-Extended/ObjectTest.extension.st
@@ -2,6 +2,7 @@ Extension { #name : #ObjectTest }
 
 { #category : #'*Kernel-Tests-Extended' }
 ObjectTest >> testHaltOnce [
+	<haltOrBreakpointForTesting>
 	| anObject block |
 	anObject := Object new.
 	block :=  [ anObject haltOnce ]. 

--- a/src/Kernel-Tests-WithCompiler/ObjectTest.extension.st
+++ b/src/Kernel-Tests-WithCompiler/ObjectTest.extension.st
@@ -2,6 +2,7 @@ Extension { #name : #ObjectTest }
 
 { #category : #'*Kernel-Tests-WithCompiler' }
 ObjectTest >> testHaltOnCount [
+	<haltOrBreakpointForTesting>
 
 	| anObject |
 	anObject := Object new.

--- a/src/Kernel-Tests/ObjectTest.class.st
+++ b/src/Kernel-Tests/ObjectTest.class.st
@@ -19,11 +19,13 @@ ObjectTest >> a1 [
 
 { #category : #private }
 ObjectTest >> b [
+	<haltOrBreakpointForTesting>
 	self haltIf: #testHaltIf.
 ]
 
 { #category : #private }
 ObjectTest >> b1 [
+	<haltOrBreakpointForTesting>
 	self haltIf: #testasdasdfHaltIf.
 ]
 
@@ -98,6 +100,7 @@ ObjectTest >> testDisplayStringLimitedString [
 
 { #category : #'tests - debugging' }
 ObjectTest >> testHaltIf [
+	<haltOrBreakpointForTesting>
 
 	self shouldHaltWhen: [self haltIf: true].
 	self shouldntHaltWhen: [self haltIf: false].

--- a/src/Kernel-Tests/ProtoObjectTest.class.st
+++ b/src/Kernel-Tests/ProtoObjectTest.class.st
@@ -17,32 +17,53 @@ ProtoObjectTest >> testFlag [
 
 { #category : #'tests - testing' }
 ProtoObjectTest >> testIfNil [
-	| object block |
+	| object block reachabilityTest|
+	reachabilityTest := false.
 	object := ProtoObject new.
-	object ifNil: [ self halt ].
-	self assert: (object ifNil: [ nil ]) == object.	"Now the same without inlining."
-	block := [ self halt ].
+	object ifNil: [reachabilityTest := true ].
+	self assert: (object ifNil: [ nil ]) == object.
+	self assert: reachabilityTest equals: false.
+	"Now the same test without inlining."
+	reachabilityTest := false.
+	block := [ reachabilityTest := true].
 	object ifNil: block.
 	block := [ nil ].
-	self assert: (object ifNil: block) == object
+	self assert: (object ifNil: block) == object.
+	self assert: reachabilityTest equals: false.
 ]
 
 { #category : #'tests - testing' }
 ProtoObjectTest >> testIfNilIfNotNil [
 
-	| object returnValue block |
+	| object returnValue block notReached1 reached1 notReached2 reached2 reached3 notReached3 reached4 notReached4 |
+	notReached1 := false. reached1 := false. notReached2 := false. reached2 := false.
+	notReached3 := false. reached3 := false. notReached4 := false. reached4 := false.
 	object := ProtoObject new.
 	returnValue := Object new.
-	self should: [ object ifNil: [ self error ] ifNotNil: [ self halt ] ] raise: Halt.
-	self should: [ object ifNil: [ self error ] ifNotNil: [ :o | self halt ] ] raise: Halt.
+
+	object ifNil: [ notReached1 := true ] ifNotNil: [ reached1 := true ].
+	self assert: notReached1 equals: false.
+	self assert: reached1 equals: true.
+
+	object ifNil: [ notReached2 := true ] ifNotNil: [ :o | reached2 := true ].
+	self assert: notReached2 equals: false.
+	self assert: reached2 equals: true.
+
 	self assert: (object ifNil: [ false ] ifNotNil: [ :o | o == object ]).
 	self assert: (object ifNil: [ nil ] ifNotNil: [ returnValue ]) == returnValue.
 	self assert: (object ifNil: [ nil ] ifNotNil: [ :o | returnValue ]) == returnValue.
+	
 	"Now the same without inlining."
-	block := [ self halt ].
-	self should: [ object ifNil: [ self error ] ifNotNil: block ] raise: Halt.
-	block := [ :o | self halt ].
-	self should: [ object ifNil: [ self error ] ifNotNil: block ] raise: Halt.
+	block := [ reached3 := true ].
+	object ifNil: [ notReached3 := true ] ifNotNil: block.
+	self assert: notReached3 equals: false.
+	self assert: reached3 equals: true.
+
+	block := [ :o | reached4 := true ].
+	object ifNil: [ notReached4 := true ] ifNotNil: block.
+	self assert: notReached4 equals: false.
+	self assert: reached4 equals: true.
+	
 	block := [ :o | o == object ].
 	self assert: (object ifNil: [ false ] ifNotNil: block).
 	block := [ returnValue ].
@@ -54,19 +75,26 @@ ProtoObjectTest >> testIfNilIfNotNil [
 { #category : #'tests - testing' }
 ProtoObjectTest >> testIfNotNil [
 
-	| object returnValue block |
+	| object returnValue block reached|
 	object := ProtoObject new.
 	returnValue := Object new.
-	self should: [ object ifNotNil: [ self halt ] ] raise: Halt.
-	self should: [ object ifNotNil: [ :o | self halt ] ] raise: Halt.
+	reached := false.
+	object ifNotNil: [ reached := true ].
+	self assert: reached equals: true.
+	reached := false.
+	object ifNotNil: [ :o | reached := true ].
+	self assert: reached equals: true.
 	self assert: (object ifNotNil: [ :o | o == object ]).
 	self assert: (object ifNotNil: [ returnValue ]) == returnValue.
 	self assert: (object ifNotNil: [ :o | returnValue ]) == returnValue.	
 	"Now the same without inlining."
-	block := [ self halt ].
-	self should: [ object ifNotNil: block ] raise: Halt.
-	block := [ :o | self halt ].
-	self should: [ object ifNotNil: block ] raise: Halt.
+	block := [ reached := true ].
+	object ifNotNil: block.
+	self assert: reached equals: true.
+	reached := false.
+	block := [ :o | reached := true ].
+	object ifNotNil: block.
+	self assert: reached equals: true.
 	block := [ :o | o == object ].
 	self assert: (object ifNotNil: block).
 	block := [ returnValue ].
@@ -78,19 +106,38 @@ ProtoObjectTest >> testIfNotNil [
 { #category : #'tests - testing' }
 ProtoObjectTest >> testIfNotNilIfNil [
 
-	| object returnValue block |
+	| object returnValue block reached notReached|
 	object := ProtoObject new.
 	returnValue := Object new.
-	self should: [ object ifNotNil: [ self halt ] ifNil: [ self error ]  ] raise: Halt.
-	self should: [ object ifNotNil: [ :o | self halt ] ifNil: [ self error ] ] raise: Halt.
+	
+	reached := false. notReached := false.
+	object ifNotNil: [ reached := true ] ifNil: [ notReached := true ].
+	self assert: reached equals: true.
+	self assert: notReached equals: false.
+	
+	reached := false. notReached := false.
+	object ifNotNil: [ :o | reached := true ] ifNil: [ notReached := true ].
+	self assert: reached equals: true.
+	self assert: notReached equals: false.
+	
+	reached := false.
+	notReached := false.
 	self assert: (object ifNotNil: [ :o | o == object ] ifNil: [ false ]).
 	self assert: (object ifNotNil: [ returnValue ] ifNil: [ false ]) == returnValue.
 	self assert: (object ifNotNil: [ :o | returnValue ] ifNil: [ false ]) == returnValue.
 	"Now the same without inlining."
-	block := [ self halt ].
-	self should: [ object ifNotNil: block ifNil: [ self error ]  ] raise: Halt.
-	block := [ :o | self halt ].
-	self should: [ object ifNotNil: block ifNil: [ self error ] ] raise: Halt.
+	reached := false.	notReached := false.
+	block := [ reached := true ].
+	object ifNotNil: block ifNil: [ notReached := true ].
+	self assert: reached equals: true.
+	self assert: notReached equals: false.
+	
+	reached := false. notReached := false.	
+	block := [ :o | reached := true ].
+	object ifNotNil: block ifNil: [ notReached := true ].
+	self assert: reached equals: true.
+	self assert: notReached equals: false.
+	
 	block := [ :o | o == object ].
 	self assert: (object ifNotNil: block ifNil: [ false ]).
 	block := [ returnValue ].

--- a/src/Kernel-Tests/UndefinedObjectTest.class.st
+++ b/src/Kernel-Tests/UndefinedObjectTest.class.st
@@ -23,12 +23,14 @@ UndefinedObjectTest >> testDeepCopy [
 
 { #category : #'tests - testing' }
 UndefinedObjectTest >> testHaltIfNil [
+	<haltOrBreakpointForTesting>
 
 	self should: [ nil haltIfNil] raise: Halt.
 ]
 
 { #category : #'tests - testing' }
 UndefinedObjectTest >> testIfNil [
+	<haltOrBreakpointForTesting>
 
 	self should: [ nil ifNil: [self halt]] raise: Halt.
 
@@ -38,6 +40,7 @@ UndefinedObjectTest >> testIfNil [
 
 { #category : #'tests - testing' }
 UndefinedObjectTest >> testIfNilIfNotNil [
+	<haltOrBreakpointForTesting>
 
 	self should: [ nil ifNil: [self halt] ifNotNil: [self error] ] raise: Halt.
 
@@ -65,6 +68,7 @@ UndefinedObjectTest >> testIfNotNilDo [
 
 { #category : #'tests - testing' }
 UndefinedObjectTest >> testIfNotNilIfNil [
+	<haltOrBreakpointForTesting>
 
 	self should: [ nil ifNotNil: [self error] ifNil: [self halt] ] raise: Halt.
 

--- a/src/Kernel/DelayBasicScheduler.class.st
+++ b/src/Kernel/DelayBasicScheduler.class.st
@@ -175,6 +175,7 @@ DelayBasicScheduler >> runBackendLoopAtTimingPriority [
 	"Unit tests may run this at a lower priority" 
 
 	"Debug lines to help code review. Could be removed after a settling in period"
+	<haltOrBreakpointForTesting>
 
 	[  [runTimerEventLoop] whileTrue: 
 		[	|nowTick|
@@ -205,6 +206,7 @@ DelayBasicScheduler >> runBackendLoopAtTimingPriority [
 
 { #category : #'user-api' }
 DelayBasicScheduler >> schedule: aDelay [
+	<haltOrBreakpointForTesting>
 	"This is the front-half of scheduling a delay. Invoked from user processes. 
 	 For back-half see #scheduleAtTimingPriority"
 
@@ -326,6 +328,7 @@ DelayBasicScheduler >> suspend [
 
 { #category : #'private - timing priority process' }
 DelayBasicScheduler >> suspendAtTimingPriority [
+	<haltOrBreakpointForTesting>
 	"Private! This is the front-half for suspending the delay scheduler to prevent
 	 wake-up of delayed threads in the middle of snapshotting. For front-half see #suspend"
 	debug ifTrue: [ self halt ].
@@ -355,6 +358,7 @@ DelayBasicScheduler >> ticker [
 
 { #category : #'user-api' }
 DelayBasicScheduler >> unschedule: aDelay [
+	<haltOrBreakpointForTesting>
 	"This is the front-half of unscheduling a delay. Invoked from user processes. 
 	 For back-half see #unscheduleAtTimingPriority"
 

--- a/src/Manifest-Resources-Tests/MFClassA.class.st
+++ b/src/Manifest-Resources-Tests/MFClassA.class.st
@@ -9,4 +9,5 @@ Class {
 
 { #category : #'as yet unclassified' }
 MFClassA >> method [
+	"This instance variable is there to trigger the 'Temporary variable not read or written' critics rule for the test SmallintManifestCheckerTest>>testCriticsOf rule"
 ]

--- a/src/Manifest-Resources-Tests/MFClassA.class.st
+++ b/src/Manifest-Resources-Tests/MFClassA.class.st
@@ -10,5 +10,5 @@ Class {
 { #category : #'as yet unclassified' }
 MFClassA >> method [
 	|foo|
-	self halt.
+	1+1.
 ]

--- a/src/Manifest-Resources-Tests/MFClassA.class.st
+++ b/src/Manifest-Resources-Tests/MFClassA.class.st
@@ -9,6 +9,4 @@ Class {
 
 { #category : #'as yet unclassified' }
 MFClassA >> method [
-	|foo|
-	1+1.
 ]

--- a/src/Manifest-Resources-Tests/MFClassB.class.st
+++ b/src/Manifest-Resources-Tests/MFClassB.class.st
@@ -9,8 +9,14 @@ Class {
 
 { #category : #'as yet unclassified' }
 MFClassB >> method2 [
+	"This instance variable is there to trigger the 'Temporary variable not read or written' critics rule for the test SmallintManifestCheckerTest>>testCriticsOf rule"
+	|foo|
+	"Having a line of code (for example the following one) here is necessary not to fail the tests SmallintManifestCheckerTest>>testIsToDo and SmallintManifestCheckerTest>>testToDoOf"
+	1.
 ]
 
 { #category : #'as yet unclassified' }
 MFClassB >> method3 [
+	"This instance variable is there to trigger the 'Temporary variable not read or written' critics rule for the test SmallintManifestCheckerTest>>testCriticsOf rule"
+	|foo|
 ]

--- a/src/Manifest-Resources-Tests/MFClassB.class.st
+++ b/src/Manifest-Resources-Tests/MFClassB.class.st
@@ -9,11 +9,8 @@ Class {
 
 { #category : #'as yet unclassified' }
 MFClassB >> method2 [
-	|foo|
 ]
 
 { #category : #'as yet unclassified' }
 MFClassB >> method3 [
-	|foo|
-	1+1.
 ]

--- a/src/Manifest-Resources-Tests/MFClassB.class.st
+++ b/src/Manifest-Resources-Tests/MFClassB.class.st
@@ -15,5 +15,5 @@ MFClassB >> method2 [
 { #category : #'as yet unclassified' }
 MFClassB >> method3 [
 	|foo|
-	self halt.
+	1+1.
 ]

--- a/src/Metacello-Core/MetacelloVersionValidator.class.st
+++ b/src/Metacello-Core/MetacelloVersionValidator.class.st
@@ -221,6 +221,7 @@ MetacelloVersionValidator >> recordValidationCriticalWarning: aString callSite: 
 
 { #category : #accessing }
 MetacelloVersionValidator >> recordValidationCriticalWarning: aString versionString: versionString callSite: callSite reasonCode: aSymbol [
+	<haltOrBreakpointForTesting>
 	"reasonCodes:
 		#packageNameMismatch
 		#projectClassNameFileMismatch
@@ -253,6 +254,7 @@ MetacelloVersionValidator >> recordValidationError: aString callSite: callSite r
 
 { #category : #accessing }
 MetacelloVersionValidator >> recordValidationError: aString versionString: versionString callSite: callSite reasonCode: aSymbol [
+	<haltOrBreakpointForTesting>
 	"reasonCodes:
 		#noVersionForSymbolicVersion
 		#duplicateNames
@@ -293,6 +295,7 @@ MetacelloVersionValidator >> recordValidationWarning: aString callSite: callSite
 
 { #category : #accessing }
 MetacelloVersionValidator >> recordValidationWarning: aString versionString: versionString callSite: callSite reasonCode: aSymbol [
+	<haltOrBreakpointForTesting>
 	"reasonCodes:
 		#onlyBaselineVersion
 		#noVersionSpecified

--- a/src/Morphic-Examples/TabExample.class.st
+++ b/src/Morphic-Examples/TabExample.class.st
@@ -57,6 +57,7 @@ TabExample >> delete [
 
 { #category : #'tabs creation' }
 TabExample >> freshListTab [
+	<haltOrBreakpointForTesting>
 	^ (TabMorph
 		label: 'Fresh List'
 		icon: nil

--- a/src/Refactoring-Tests-Core/RBRefactoryTestDataApp.class.st
+++ b/src/Refactoring-Tests-Core/RBRefactoryTestDataApp.class.st
@@ -132,6 +132,7 @@ RBRefactoryTestDataApp >> contains [
 
 { #category : #lint }
 RBRefactoryTestDataApp >> cruft [
+	<haltOrBreakpointForTesting>
 	self halt
 ]
 

--- a/src/Refactoring-Tests-Critics/RBSmalllintTestObject.class.st
+++ b/src/Refactoring-Tests-Critics/RBSmalllintTestObject.class.st
@@ -64,6 +64,7 @@ RBSmalllintTestObject >> booleanPrecedence [
 
 { #category : #methods }
 RBSmalllintTestObject >> codeCruftLeftInMethods [
+	<haltOrBreakpointForTesting>
 	| a b c |
 	a := b := c := 2.
 	self halt.

--- a/src/Refactoring2-Transformations-Tests/RBDummyRefactoryTestDataApp.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBDummyRefactoryTestDataApp.class.st
@@ -132,6 +132,7 @@ RBDummyRefactoryTestDataApp >> contains [
 
 { #category : #lint }
 RBDummyRefactoryTestDataApp >> cruft [
+	<haltOrBreakpointForTesting>
 	self halt
 ]
 

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -658,6 +658,7 @@ TestCase >> onPharoCITestingEnvironment [
 
 { #category : #running }
 TestCase >> openDebuggerOnFailingTestMethod [
+	<haltOrBreakpointForTesting>
 	"SUnit has halted one step in front of the failing test method. Step over the 'self halt' and 
 	 send into 'self perform: testSelector' to see the failure from the beginning"
 

--- a/src/Spec-Core/TreePresenter.class.st
+++ b/src/Spec-Core/TreePresenter.class.st
@@ -95,6 +95,7 @@ TreePresenter class >> exampleOfAutoRefreshOnExpand [
 
 { #category : #examples }
 TreePresenter class >> exampleWithCustomColumnsAndNodes [
+	<haltOrBreakpointForTesting>
 	"self exampleWithCustomColumnsAndNodes"
 	| m col1 col2 |
 
@@ -138,6 +139,7 @@ TreePresenter class >> exampleWithCustomColumnsAndNodes [
 
 { #category : #examples }
 TreePresenter class >> exampleWithCustomColumnsAndNodesAndChildren [
+	<haltOrBreakpointForTesting>
 	"self exampleWithCustomColumnsAndNodesAndChildren"
 
 	| m col1 col2 |


### PR DESCRIPTION
Or adding the <haltOrBreakpointForTesting> to methods that are meant to contain halts in production. This way they won't appear in the breakpoint browser that got integrated into Pharo 7 with the new version of Calypso.