### PR TITLE
22886 Zinc should allow custom server string

### DIFF
--- a/src/Zinc-HTTP/ZnConstants.class.st
+++ b/src/Zinc-HTTP/ZnConstants.class.st
@@ -21,6 +21,7 @@ ZnConstants class >> defaultHTTPVersion [
 
 { #category : #accessing }
 ZnConstants class >> defaultServerString [ 
+	
 	^DefaultServerString ifNil: [ DefaultServerString := self frameworkNameAndVersion , ' (' , self systemVersion , ')' ]
 
 ]

--- a/src/Zinc-HTTP/ZnConstants.class.st
+++ b/src/Zinc-HTTP/ZnConstants.class.st
@@ -8,6 +8,7 @@ Class {
 	#superclass : #Object,
 	#classVars : [
 		'DefaultMaximumEntitySize',
+		'DefaultServerString',
 		'HTTPStatusCodes'
 	],
 	#category : #'Zinc-HTTP-Support'
@@ -20,7 +21,15 @@ ZnConstants class >> defaultHTTPVersion [
 
 { #category : #accessing }
 ZnConstants class >> defaultServerString [ 
-	^ self frameworkNameAndVersion , ' (' , self systemVersion , ')'
+	^DefaultServerString ifNil: [ DefaultServerString := self frameworkNameAndVersion , ' (' , self systemVersion , ')' ]
+
+]
+
+{ #category : #accessing }
+ZnConstants class >> defaultServerString: aString [ 
+
+	DefaultServerString := aString
+
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Allow to customize the server string for deployment scenarios relying on security. Here the server should not tell the 
outside world about its version or technology and not expose such confidential data to an attacker.

    ZnConstants defaultServerString: 'SecureServer'