### PR TITLE
Correct a typo in ZnDefaultServerDelegate class

### DIFF
--- a/src/Zinc-HTTP/ZnDefaultServerDelegate.class.st
+++ b/src/Zinc-HTTP/ZnDefaultServerDelegate.class.st
@@ -84,7 +84,7 @@ ZnDefaultServerDelegate >> errorResponse: request [
 	optionally with a user defined message."
 	
 	| message |
-	message := request uri queryAt: 'message' ifAbsent: [ 'An artifical error' ].
+	message := request uri queryAt: 'message' ifAbsent: [ 'An artificial error' ].
 	Error signal: message
 ]
 


### PR DESCRIPTION
Correct a typo artifical => artificial