### PR TITLE
22890-IconListModelbackgroundColorBlock-does-not-work

### DIFF
--- a/src/Spec-MorphicAdapters/MorphicIconListAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicIconListAdapter.class.st
@@ -28,6 +28,7 @@ MorphicIconListAdapter >> buildWidget [
 			setBalloonText: self help; 
 			hResizing: 	#spaceFill;
 			vResizing: 	#spaceFill;
+			backgroundColoringBlockOrSelector: #backgroundColorFor:at: ;
 			yourself
 ]
 


### PR DESCRIPTION
Now takes into account the background color set by user.