### PR TITLE
22891-Callbacks-with-more-than-4-parameters-in-Win64-is-not-working

### DIFF
--- a/src/Alien-Core/CallbackForWin64X64.class.st
+++ b/src/Alien-Core/CallbackForWin64X64.class.st
@@ -55,7 +55,7 @@ CallbackForWin64X64 >> valueInContext: callbackContext [ "<VMCallbackContext32|V
 	numEvaluatorArgs = 2 ifTrue:
 		[^self perform: evaluator
 			with: callbackContext
-			with: callbackContext intregargsp].
+			with: callbackContext stackp].
 	numEvaluatorArgs = 3 ifTrue:
 		[^self perform: evaluator
 			with: callbackContext

--- a/src/UnifiedFFI-Tests/FFICallbackParametersTests.class.st
+++ b/src/UnifiedFFI-Tests/FFICallbackParametersTests.class.st
@@ -16,7 +16,7 @@ FFICallbackParametersTests >> callCallback: aFFICallback withArgs: aCollection [
 	^ (ExternalLibraryFunction 
 			name: nil
 			module: nil
-			callType: (OSPlatform current ffiCallingConvention = #stdcall ifTrue: [ 0 ] ifFalse: [ 1 ])
+			callType: (OSPlatform current ffiCallingConvention = #stdcall ifTrue: [ 1 ] ifFalse: [ 0 ])
 			returnType: aFFICallback functionSpec returnType externalTypeWithArity
 			argumentTypes: (aFFICallback functionSpec arguments collect: #externalTypeWithArity))
 				setHandle: (ExternalAddress fromAddress: (aFFICallback thunk address)) ;	
@@ -33,7 +33,7 @@ FFICallbackParametersTests >> testCharacterParameters [
 	params := (1 to: 6) collect: [ :i | i asCharacter ].	
 	
 	callback := FFICallback 
-		signature: #(void (char, char, char, char, char, char))
+		signature: #(int (char, char, char, char, char, char))
 		block: [ :a :b :c :d :e :f  | 
 			self assert: a value equals: 1 asCharacter.
 			self assert: b value equals: 2 asCharacter.
@@ -41,16 +41,17 @@ FFICallbackParametersTests >> testCharacterParameters [
 			self assert: d value equals: 4 asCharacter.
 			self assert: e value equals: 5 asCharacter.
 			self assert: f value equals: 6 asCharacter.
+			$z asInteger
 		].
 
-	self callCallback: callback withArgs: params.
+	self assert: (self callCallback: callback withArgs: params) equals: $z asInteger.
 ]
 
 { #category : #running }
 FFICallbackParametersTests >> testFloatParameters [ 
 	
 	callback := FFICallback 
-		signature: #(void (double a, double b, float c, float d, double e, float f))
+		signature: #(double (double a, double b, float c, float d, double e, float f))
 		block: [ :a :b :c :d :e :f  | 
 			self assert: a value equals: 1.0.
 			self assert: b value equals: 2.0.
@@ -58,16 +59,50 @@ FFICallbackParametersTests >> testFloatParameters [
 			self assert: d value equals: 4.0.
 			self assert: e value equals: 5.0.
 			self assert: f value equals: 6.0.
+			7.0
 		].
 
-	self callCallback: callback withArgs: {1.0. 2.0. 3.0. 4.0. 5.0. 6.0}.
+	self assert: (self callCallback: callback withArgs: {1.0. 2.0. 3.0. 4.0. 5.0. 6.0}) equals: 7.0.
+]
+
+{ #category : #running }
+FFICallbackParametersTests >> testIdentityStruct [ 
+	
+	<expectedFailure>		
+	
+	| param |
+	callback := FFICallback 
+		signature: #(FFITestStructureSmallIntFloatStructure (FFITestStructureSmallIntFloatStructure a))
+		block: [ :a |
+			self assert: a x equals: 2.0. 
+			self assert: a y equals: 3. 
+			self assert: a w equals: 5.0. 
+			self assert: a z equals: 7.0. 
+
+			a x: 3.0.
+			a y: 4.
+			a w: 5.0.
+			a z: 7.0. 
+						
+			a
+		].
+
+	param := FFITestStructureSmallIntFloatStructure externalNew
+		x: 2.0;
+		y: 3;
+		w: 5.0;
+		z: 7;
+		autoRelease;
+		yourself.
+
+	self assert: (self callCallback: callback withArgs: { param }) equals: param.
 ]
 
 { #category : #running }
 FFICallbackParametersTests >> testIntegerParameters [ 
 	
 	callback := FFICallback 
-		signature: #(void (int, int, int, int, int, int))
+		signature: #(int (int, int, int, int, int, int))
 		block: [ :a :b :c :d :e :f  | 
 			self assert: a equals: 1.
 			self assert: b equals: 2.
@@ -75,9 +110,10 @@ FFICallbackParametersTests >> testIntegerParameters [
 			self assert: d equals: 4.
 			self assert: e equals: 5.
 			self assert: f equals: 6.
+			7
 		].
 
-	self callCallback: callback withArgs: #(1 2 3 4 5 6).
+	self assert: (self callCallback: callback withArgs: #(1 2 3 4 5 6)) equals: 7.
 
 
 ]
@@ -118,4 +154,66 @@ FFICallbackParametersTests >> testMixingParameters [
 		].
 
 	self callCallback: callback withArgs: {1. 2.0. $c. 4. 5.0. 6. $g}.
+]
+
+{ #category : #running }
+FFICallbackParametersTests >> testPassingDoubleStructureInTheStack [ 
+			
+	| param |
+	callback := FFICallback 
+		signature: #(int (FFITestStructureDoubleStructure a))
+		block: [ :a |
+			self assert: a x equals: 2.0. 
+			self assert: a y equals: 3.0. 
+			self assert: a w equals: 5.0. 
+			self assert: a z equals: 7.0. 
+
+			a x: 3.0.
+			a y: 4.0.
+			a w: 5.0.
+			a z: 7.0. 
+
+			99
+		].
+
+	param := FFITestStructureDoubleStructure externalNew
+		x: 2.0;
+		y: 3;
+		w: 5.0;
+		z: 7;
+		autoRelease;
+		yourself.
+
+	self assert: (self callCallback: callback withArgs: { param }) equals: 99.
+]
+
+{ #category : #running }
+FFICallbackParametersTests >> testPassingStructureInTheStack [ 
+	
+	| param expect |
+	callback := FFICallback 
+		signature: #(int (FFITestStructureSmallIntFloatStructure a))
+		block: [ :a |
+			self assert: a x equals: 2.0. 
+			self assert: a y equals: 3. 
+			self assert: a w equals: 5.0. 
+			self assert: a z equals: 7. 
+
+			a x: 3.0.
+			a y: 4.
+			a w: 5.0.
+			a z: 7. 
+
+			77 
+		].
+
+	param := FFITestStructureSmallIntFloatStructure externalNew
+		x: 2.0;
+		y: 3;
+		w: 5.0;
+		z: 7;
+		autoRelease;
+		yourself.
+		
+	self assert: (self callCallback: callback withArgs: { param }) equals: 77.
 ]

--- a/src/UnifiedFFI-Tests/FFICallbackParametersTests.class.st
+++ b/src/UnifiedFFI-Tests/FFICallbackParametersTests.class.st
@@ -1,0 +1,121 @@
+Class {
+	#name : #FFICallbackParametersTests,
+	#superclass : #TestCase,
+	#instVars : [
+		'callback'
+	],
+	#pools : [
+		'FFITestEnumeration'
+	],
+	#category : #'UnifiedFFI-Tests-Tests'
+}
+
+{ #category : #executing }
+FFICallbackParametersTests >> callCallback: aFFICallback withArgs: aCollection [ 
+
+	^ (ExternalLibraryFunction 
+			name: nil
+			module: nil
+			callType: (OSPlatform current ffiCallingConvention = #stdcall ifTrue: [ 0 ] ifFalse: [ 1 ])
+			returnType: aFFICallback functionSpec returnType externalTypeWithArity
+			argumentTypes: (aFFICallback functionSpec arguments collect: #externalTypeWithArity))
+				setHandle: (ExternalAddress fromAddress: (aFFICallback thunk address)) ;	
+					invokeWithArguments: aCollection
+	
+
+
+]
+
+{ #category : #running }
+FFICallbackParametersTests >> testCharacterParameters [
+	
+	| params |
+	params := (1 to: 6) collect: [ :i | i asCharacter ].	
+	
+	callback := FFICallback 
+		signature: #(void (char, char, char, char, char, char))
+		block: [ :a :b :c :d :e :f  | 
+			self assert: a value equals: 1 asCharacter.
+			self assert: b value equals: 2 asCharacter.
+			self assert: c value equals: 3 asCharacter.
+			self assert: d value equals: 4 asCharacter.
+			self assert: e value equals: 5 asCharacter.
+			self assert: f value equals: 6 asCharacter.
+		].
+
+	self callCallback: callback withArgs: params.
+]
+
+{ #category : #running }
+FFICallbackParametersTests >> testFloatParameters [ 
+	
+	callback := FFICallback 
+		signature: #(void (double a, double b, float c, float d, double e, float f))
+		block: [ :a :b :c :d :e :f  | 
+			self assert: a value equals: 1.0.
+			self assert: b value equals: 2.0.
+			self assert: c value equals: 3.0.
+			self assert: d value equals: 4.0.
+			self assert: e value equals: 5.0.
+			self assert: f value equals: 6.0.
+		].
+
+	self callCallback: callback withArgs: {1.0. 2.0. 3.0. 4.0. 5.0. 6.0}.
+]
+
+{ #category : #running }
+FFICallbackParametersTests >> testIntegerParameters [ 
+	
+	callback := FFICallback 
+		signature: #(void (int, int, int, int, int, int))
+		block: [ :a :b :c :d :e :f  | 
+			self assert: a equals: 1.
+			self assert: b equals: 2.
+			self assert: c equals: 3.
+			self assert: d equals: 4.
+			self assert: e equals: 5.
+			self assert: f equals: 6.
+		].
+
+	self callCallback: callback withArgs: #(1 2 3 4 5 6).
+
+
+]
+
+{ #category : #running }
+FFICallbackParametersTests >> testIntegerPointerParameters [ 
+	
+	| params |
+	params := (1 to: 6) collect: [ :i | ExternalAddress fromAddress: i ].	
+	
+	callback := FFICallback 
+		signature: #(void (void* a, void* b, int* c, int* d, char* e, float* f))
+		block: [ :a :b :c :d :e :f  | 
+			self assert: a value equals: 1.
+			self assert: b value equals: 2.
+			self assert: c value equals: 3.
+			self assert: d value equals: 4.
+			self assert: e value equals: 5.
+			self assert: f value equals: 6.
+		].
+
+	self callCallback: callback withArgs: params.
+]
+
+{ #category : #running }
+FFICallbackParametersTests >> testMixingParameters [ 
+	
+	callback := FFICallback 
+		signature: #(void (int a, float b, char c, int d, double e, int f, char g))
+		block: [ :a :b :c :d :e :f :g | 
+			self assert: a value equals: 1.
+			self assert: b value equals: 2.0.
+			self assert: c value equals: $c.
+			self assert: d value equals: 4.
+			self assert: e value equals: 5.0.
+			self assert: f value equals: 6.
+			self assert: g value equals: $g.
+		].
+
+	self callCallback: callback withArgs: {1. 2.0. $c. 4. 5.0. 6. $g}.
+]

--- a/src/UnifiedFFI-Tests/FFICallbackParametersTests.class.st
+++ b/src/UnifiedFFI-Tests/FFICallbackParametersTests.class.st
@@ -4,6 +4,9 @@ Class {
 	#instVars : [
 		'callback'
 	],
+	#classVars : [
+		'ARRAY'
+	],
 	#pools : [
 		'FFITestEnumeration'
 	],
@@ -157,7 +160,51 @@ FFICallbackParametersTests >> testMixingParameters [
 ]
 
 { #category : #running }
-FFICallbackParametersTests >> testPassingDoubleStructureInTheStack [ 
+FFICallbackParametersTests >> testPassing2DoubleStructureInTheStack [ 
+			
+	| param |
+	callback := FFICallback 
+		signature: #(int (FFITestStructure2DoubleStructure a))
+		block: [ :a |
+			self assert: a x equals: 2.0. 
+			self assert: a y equals: 3.0. 
+
+			99
+		].
+
+	param := FFITestStructure2DoubleStructure externalNew
+		x: 2.0;
+		y: 3.0;
+		autoRelease;
+		yourself.
+
+	self assert: (self callCallback: callback withArgs: { param }) equals: 99.
+]
+
+{ #category : #running }
+FFICallbackParametersTests >> testPassing2Int64StructureInTheStack [ 
+			
+	| param |
+	callback := FFICallback 
+		signature: #(int (FFITestStructure2Int64Structure a))
+		block: [ :a |
+			self assert: a x equals: 2. 
+			self assert: a y equals: 3. 
+
+			99
+		].
+
+	param := FFITestStructure2Int64Structure externalNew
+		x: 2;
+		y: 3;
+		autoRelease;
+		yourself.
+
+	self assert: (self callCallback: callback withArgs: { param }) equals: 99.
+]
+
+{ #category : #running }
+FFICallbackParametersTests >> testPassing4DoubleStructureInTheStack [ 
 			
 	| param |
 	callback := FFICallback 
@@ -180,6 +227,58 @@ FFICallbackParametersTests >> testPassingDoubleStructureInTheStack [
 		x: 2.0;
 		y: 3;
 		w: 5.0;
+		z: 7;
+		autoRelease;
+		yourself.
+
+	self assert: (self callCallback: callback withArgs: { param }) equals: 99.
+]
+
+{ #category : #running }
+FFICallbackParametersTests >> testPassing4Int64StructureInTheStack [ 
+			
+	| param |
+	callback := FFICallback 
+		signature: #(int (FFITestStructure4Int64Structure a))
+		block: [ :a |
+			self assert: a x equals: 2. 
+			self assert: a y equals: 3. 
+			self assert: a w equals: 5. 
+			self assert: a z equals: 7. 
+
+			99
+		].
+
+	param := FFITestStructure4Int64Structure externalNew
+		x: 2;
+		y: 3;
+		w: 5;
+		z: 7;
+		autoRelease;
+		yourself.
+
+	self assert: (self callCallback: callback withArgs: { param }) equals: 99.
+]
+
+{ #category : #running }
+FFICallbackParametersTests >> testPassing4IntStructureInTheStack [ 
+			
+	| param |
+	callback := FFICallback 
+		signature: #(int (FFITestStructureIntStructure a))
+		block: [ :a |
+			self assert: a x equals: 2. 
+			self assert: a y equals: 3. 
+			self assert: a w equals: 5. 
+			self assert: a z equals: 7. 
+
+			99
+		].
+
+	param := FFITestStructureIntStructure externalNew
+		x: 2;
+		y: 3;
+		w: 5;
 		z: 7;
 		autoRelease;
 		yourself.

--- a/src/UnifiedFFI-Tests/FFICallbackParametersTests.class.st
+++ b/src/UnifiedFFI-Tests/FFICallbackParametersTests.class.st
@@ -1,3 +1,6 @@
+"
+This TestSuite evaluates the correct implementation of the callback parameter extraction.
+"
 Class {
 	#name : #FFICallbackParametersTests,
 	#superclass : #TestCase,
@@ -289,7 +292,7 @@ FFICallbackParametersTests >> testPassing4IntStructureInTheStack [
 { #category : #running }
 FFICallbackParametersTests >> testPassingStructureInTheStack [ 
 	
-	| param expect |
+	| param |
 	callback := FFICallback 
 		signature: #(int (FFITestStructureSmallIntFloatStructure a))
 		block: [ :a |

--- a/src/UnifiedFFI-Tests/FFICallbackTests.class.st
+++ b/src/UnifiedFFI-Tests/FFICallbackTests.class.st
@@ -24,11 +24,6 @@ FFICallbackTests >> intregargsp [
 FFICallbackTests >> testCqsort [
 	| unsorted expected values callback results |
 	
-	self flag: #TODO. "TEMPORAL... I need to see why this is crashing on windows (but callbacks are 
-	working in general)"
-	OSPlatform current isWindows 
-		ifTrue: [ ^ self skip ].
-	
 	unsorted := (10.0 to: 1.0 by: -0.5) asArray.
 	expected := (1.0 to: 10.0 by: 0.5) asArray.
 	
@@ -53,11 +48,6 @@ FFICallbackTests >> testCqsort [
 FFICallbackTests >> testCqsortWithByteArray [
 	| unsorted expected values callback results |
 	
-	self flag: #TODO. "TEMPORAL... I need to see why this is crashing on windows (but callbacks are 
-	working in general)"
-	OSPlatform current isWindows 
-		ifTrue: [ ^ self skip ].
-
 	unsorted := (10.0 to: 1.0 by: -0.5) asArray.
 	expected := (1.0 to: 10.0 by: 0.5) asArray.
 	

--- a/src/UnifiedFFI-Tests/FFICallbackTests.class.st
+++ b/src/UnifiedFFI-Tests/FFICallbackTests.class.st
@@ -20,9 +20,19 @@ FFICallbackTests >> intregargsp [
 	^ nil
 ]
 
+{ #category : #running }
+FFICallbackTests >> runCaseManaged [
+	^ self runCase
+]
+
 { #category : #tests }
 FFICallbackTests >> testCqsort [
 	| unsorted expected values callback results |
+	
+	self flag: #TODO. "TEMPORAL... I need to see why this is crashing on windows (but callbacks are 
+	working in general)"
+	OSPlatform current isWindows 
+		ifTrue: [ ^ self skip ].
 	
 	unsorted := (10.0 to: 1.0 by: -0.5) asArray.
 	expected := (1.0 to: 10.0 by: 0.5) asArray.
@@ -48,6 +58,11 @@ FFICallbackTests >> testCqsort [
 FFICallbackTests >> testCqsortWithByteArray [
 	| unsorted expected values callback results |
 	
+	self flag: #TODO. "TEMPORAL... I need to see why this is crashing on windows (but callbacks are 
+	working in general)"
+	OSPlatform current isWindows 
+		ifTrue: [ ^ self skip ].
+
 	unsorted := (10.0 to: 1.0 by: -0.5) asArray.
 	expected := (1.0 to: 10.0 by: 0.5) asArray.
 	

--- a/src/UnifiedFFI-Tests/FFITestCallback.class.st
+++ b/src/UnifiedFFI-Tests/FFITestCallback.class.st
@@ -1,0 +1,14 @@
+Class {
+	#name : #FFITestCallback,
+	#superclass : #FFICallback,
+	#classVars : [
+		'ARRAY'
+	],
+	#category : #'UnifiedFFI-Tests'
+}
+
+{ #category : #'as yet unclassified' }
+FFITestCallback class >> arrayType: aType [
+
+	ARRAY := aType
+]

--- a/src/UnifiedFFI-Tests/FFITestStructure2DoubleStructure.class.st
+++ b/src/UnifiedFFI-Tests/FFITestStructure2DoubleStructure.class.st
@@ -1,0 +1,42 @@
+Class {
+	#name : #FFITestStructure2DoubleStructure,
+	#superclass : #FFIExternalStructure,
+	#classVars : [
+		'OFFSET_X',
+		'OFFSET_Y'
+	],
+	#category : #'UnifiedFFI-Tests-Test-Data'
+}
+
+{ #category : #'field definition' }
+FFITestStructure2DoubleStructure class >> fieldsDesc [
+	"self rebuildFieldAccessors"
+	^ #(
+	double x;
+	double y;
+	)
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructure2DoubleStructure >> x [
+	"This method was automatically generated"
+	^handle doubleAt: OFFSET_X
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructure2DoubleStructure >> x: anObject [
+	"This method was automatically generated"
+	handle doubleAt: OFFSET_X put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructure2DoubleStructure >> y [
+	"This method was automatically generated"
+	^handle doubleAt: OFFSET_Y
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructure2DoubleStructure >> y: anObject [
+	"This method was automatically generated"
+	handle doubleAt: OFFSET_Y put: anObject
+]

--- a/src/UnifiedFFI-Tests/FFITestStructure2Int64Structure.class.st
+++ b/src/UnifiedFFI-Tests/FFITestStructure2Int64Structure.class.st
@@ -1,0 +1,42 @@
+Class {
+	#name : #FFITestStructure2Int64Structure,
+	#superclass : #FFIExternalStructure,
+	#classVars : [
+		'OFFSET_X',
+		'OFFSET_Y'
+	],
+	#category : #'UnifiedFFI-Tests-Test-Data'
+}
+
+{ #category : #'field definition' }
+FFITestStructure2Int64Structure class >> fieldsDesc [
+	"self rebuildFieldAccessors"
+	^ #(
+	int64 x;
+	int64 y;
+	)
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructure2Int64Structure >> x [
+	"This method was automatically generated"
+	^handle signedLongLongAt: OFFSET_X
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructure2Int64Structure >> x: anObject [
+	"This method was automatically generated"
+	handle signedLongLongAt: OFFSET_X put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructure2Int64Structure >> y [
+	"This method was automatically generated"
+	^handle signedLongLongAt: OFFSET_Y
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructure2Int64Structure >> y: anObject [
+	"This method was automatically generated"
+	handle signedLongLongAt: OFFSET_Y put: anObject
+]

--- a/src/UnifiedFFI-Tests/FFITestStructure4Int64Structure.class.st
+++ b/src/UnifiedFFI-Tests/FFITestStructure4Int64Structure.class.st
@@ -1,8 +1,5 @@
-"
-I am a structure that in the AMD64 SystemV ABI is passed in 1 integer register, and in 1 float register.
-"
 Class {
-	#name : #FFITestStructureSmallIntFloatStructure,
+	#name : #FFITestStructure4Int64Structure,
 	#superclass : #FFIExternalStructure,
 	#classVars : [
 		'OFFSET_W',
@@ -14,60 +11,60 @@ Class {
 }
 
 { #category : #'field definition' }
-FFITestStructureSmallIntFloatStructure class >> fieldsDesc [
+FFITestStructure4Int64Structure class >> fieldsDesc [
 	"self rebuildFieldAccessors"
 	^ #(
-	float x;
-	int32 y;
-	float z;
-	float w;
+	int64 x;
+	int64 y;
+	int64 z;
+	int64 w;
 	)
 ]
 
 { #category : #'accessing structure variables' }
-FFITestStructureSmallIntFloatStructure >> w [
+FFITestStructure4Int64Structure >> w [
 	"This method was automatically generated"
-	^handle floatAt: OFFSET_W
+	^handle signedLongLongAt: OFFSET_W
 ]
 
 { #category : #'accessing structure variables' }
-FFITestStructureSmallIntFloatStructure >> w: anObject [
+FFITestStructure4Int64Structure >> w: anObject [
 	"This method was automatically generated"
-	handle floatAt: OFFSET_W put: anObject
+	handle signedLongLongAt: OFFSET_W put: anObject
 ]
 
 { #category : #'accessing structure variables' }
-FFITestStructureSmallIntFloatStructure >> x [
+FFITestStructure4Int64Structure >> x [
 	"This method was automatically generated"
-	^handle floatAt: OFFSET_X
+	^handle signedLongLongAt: OFFSET_X
 ]
 
 { #category : #'accessing structure variables' }
-FFITestStructureSmallIntFloatStructure >> x: anObject [
+FFITestStructure4Int64Structure >> x: anObject [
 	"This method was automatically generated"
-	handle floatAt: OFFSET_X put: anObject
+	handle signedLongLongAt: OFFSET_X put: anObject
 ]
 
 { #category : #'accessing structure variables' }
-FFITestStructureSmallIntFloatStructure >> y [
+FFITestStructure4Int64Structure >> y [
 	"This method was automatically generated"
-	^handle signedLongAt: OFFSET_Y
+	^handle signedLongLongAt: OFFSET_Y
 ]
 
 { #category : #'accessing structure variables' }
-FFITestStructureSmallIntFloatStructure >> y: anObject [
+FFITestStructure4Int64Structure >> y: anObject [
 	"This method was automatically generated"
-	handle signedLongAt: OFFSET_Y put: anObject
+	handle signedLongLongAt: OFFSET_Y put: anObject
 ]
 
 { #category : #'accessing structure variables' }
-FFITestStructureSmallIntFloatStructure >> z [
+FFITestStructure4Int64Structure >> z [
 	"This method was automatically generated"
-	^handle floatAt: OFFSET_Z
+	^handle signedLongLongAt: OFFSET_Z
 ]
 
 { #category : #'accessing structure variables' }
-FFITestStructureSmallIntFloatStructure >> z: anObject [
+FFITestStructure4Int64Structure >> z: anObject [
 	"This method was automatically generated"
-	handle floatAt: OFFSET_Z put: anObject
+	handle signedLongLongAt: OFFSET_Z put: anObject
 ]

--- a/src/UnifiedFFI-Tests/FFITestStructureDoubleStructure.class.st
+++ b/src/UnifiedFFI-Tests/FFITestStructureDoubleStructure.class.st
@@ -1,0 +1,70 @@
+Class {
+	#name : #FFITestStructureDoubleStructure,
+	#superclass : #FFIExternalStructure,
+	#classVars : [
+		'OFFSET_W',
+		'OFFSET_X',
+		'OFFSET_Y',
+		'OFFSET_Z'
+	],
+	#category : #'UnifiedFFI-Tests-Test-Data'
+}
+
+{ #category : #'field definition' }
+FFITestStructureDoubleStructure class >> fieldsDesc [
+	"self rebuildFieldAccessors"
+	^ #(
+	double x;
+	double y;
+	double z;
+	double w;
+	)
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructureDoubleStructure >> w [
+	"This method was automatically generated"
+	^handle doubleAt: OFFSET_W
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructureDoubleStructure >> w: anObject [
+	"This method was automatically generated"
+	handle doubleAt: OFFSET_W put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructureDoubleStructure >> x [
+	"This method was automatically generated"
+	^handle doubleAt: OFFSET_X
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructureDoubleStructure >> x: anObject [
+	"This method was automatically generated"
+	handle doubleAt: OFFSET_X put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructureDoubleStructure >> y [
+	"This method was automatically generated"
+	^handle doubleAt: OFFSET_Y
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructureDoubleStructure >> y: anObject [
+	"This method was automatically generated"
+	handle doubleAt: OFFSET_Y put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructureDoubleStructure >> z [
+	"This method was automatically generated"
+	^handle doubleAt: OFFSET_Z
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructureDoubleStructure >> z: anObject [
+	"This method was automatically generated"
+	handle doubleAt: OFFSET_Z put: anObject
+]

--- a/src/UnifiedFFI-Tests/FFITestStructureIntStructure.class.st
+++ b/src/UnifiedFFI-Tests/FFITestStructureIntStructure.class.st
@@ -1,8 +1,5 @@
-"
-I am a structure that in the AMD64 SystemV ABI is passed in 1 integer register, and in 1 float register.
-"
 Class {
-	#name : #FFITestStructureSmallIntFloatStructure,
+	#name : #FFITestStructureIntStructure,
 	#superclass : #FFIExternalStructure,
 	#classVars : [
 		'OFFSET_W',
@@ -14,60 +11,60 @@ Class {
 }
 
 { #category : #'field definition' }
-FFITestStructureSmallIntFloatStructure class >> fieldsDesc [
+FFITestStructureIntStructure class >> fieldsDesc [
 	"self rebuildFieldAccessors"
 	^ #(
-	float x;
+	int32 x;
 	int32 y;
-	float z;
-	float w;
+	int32 z;
+	int32 w;
 	)
 ]
 
 { #category : #'accessing structure variables' }
-FFITestStructureSmallIntFloatStructure >> w [
+FFITestStructureIntStructure >> w [
 	"This method was automatically generated"
-	^handle floatAt: OFFSET_W
+	^handle signedLongAt: OFFSET_W
 ]
 
 { #category : #'accessing structure variables' }
-FFITestStructureSmallIntFloatStructure >> w: anObject [
+FFITestStructureIntStructure >> w: anObject [
 	"This method was automatically generated"
-	handle floatAt: OFFSET_W put: anObject
+	handle signedLongAt: OFFSET_W put: anObject
 ]
 
 { #category : #'accessing structure variables' }
-FFITestStructureSmallIntFloatStructure >> x [
+FFITestStructureIntStructure >> x [
 	"This method was automatically generated"
-	^handle floatAt: OFFSET_X
+	^handle signedLongAt: OFFSET_X
 ]
 
 { #category : #'accessing structure variables' }
-FFITestStructureSmallIntFloatStructure >> x: anObject [
+FFITestStructureIntStructure >> x: anObject [
 	"This method was automatically generated"
-	handle floatAt: OFFSET_X put: anObject
+	handle signedLongAt: OFFSET_X put: anObject
 ]
 
 { #category : #'accessing structure variables' }
-FFITestStructureSmallIntFloatStructure >> y [
+FFITestStructureIntStructure >> y [
 	"This method was automatically generated"
 	^handle signedLongAt: OFFSET_Y
 ]
 
 { #category : #'accessing structure variables' }
-FFITestStructureSmallIntFloatStructure >> y: anObject [
+FFITestStructureIntStructure >> y: anObject [
 	"This method was automatically generated"
 	handle signedLongAt: OFFSET_Y put: anObject
 ]
 
 { #category : #'accessing structure variables' }
-FFITestStructureSmallIntFloatStructure >> z [
+FFITestStructureIntStructure >> z [
 	"This method was automatically generated"
-	^handle floatAt: OFFSET_Z
+	^handle signedLongAt: OFFSET_Z
 ]
 
 { #category : #'accessing structure variables' }
-FFITestStructureSmallIntFloatStructure >> z: anObject [
+FFITestStructureIntStructure >> z: anObject [
 	"This method was automatically generated"
-	handle floatAt: OFFSET_Z put: anObject
+	handle signedLongAt: OFFSET_Z put: anObject
 ]

--- a/src/UnifiedFFI/FFIAbstract64BitsArgumentReader.class.st
+++ b/src/UnifiedFFI/FFIAbstract64BitsArgumentReader.class.st
@@ -1,10 +1,17 @@
+"
+I implement the common behavior of the processing of arguments for 64 bits platforms.
+The 64 bits platforms uses the registers to pass parameters.
+The integer parameters are passed in the general purpose parameters (the address of the copy of them is in #integerRegisterPointer) and the float parameters are passed in the set of registers XMM0-XMM8. This float point registers are accessible through the #floatRegisterPointer.
+
+As the different calling conventions uses the registers in different ways and also they use different number of registers I only have limited reused code.
+"
 Class {
 	#name : #FFIAbstract64BitsArgumentReader,
 	#superclass : #FFICallbackArgumentReader,
 	#instVars : [
 		'currentRegisterIndex'
 	],
-	#category : #'UnifiedFFI-Architecture'
+	#category : #'UnifiedFFI-Callbacks'
 }
 
 { #category : #accessing }
@@ -13,7 +20,7 @@ FFIAbstract64BitsArgumentReader >> floatRegisterPointer [
 	^ callbackContext floatregargsp
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 FFIAbstract64BitsArgumentReader >> initialize [ 
 	super initialize.
 	currentRegisterIndex := 1.	

--- a/src/UnifiedFFI/FFIAbstract64BitsArgumentReader.class.st
+++ b/src/UnifiedFFI/FFIAbstract64BitsArgumentReader.class.st
@@ -1,0 +1,32 @@
+Class {
+	#name : #FFIAbstract64BitsArgumentReader,
+	#superclass : #FFICallbackArgumentReader,
+	#instVars : [
+		'currentRegisterIndex'
+	],
+	#category : #'UnifiedFFI-Architecture'
+}
+
+{ #category : #accessing }
+FFIAbstract64BitsArgumentReader >> floatRegisterPointer [
+	
+	^ callbackContext floatregargsp
+]
+
+{ #category : #accessing }
+FFIAbstract64BitsArgumentReader >> initialize [ 
+	super initialize.
+	currentRegisterIndex := 1.	
+]
+
+{ #category : #accessing }
+FFIAbstract64BitsArgumentReader >> integerRegisterPointer [
+	
+	^ callbackContext intregargsp
+]
+
+{ #category : #accessing }
+FFIAbstract64BitsArgumentReader >> numberOfRegisters [
+
+	^ self subclassResponsibility
+]

--- a/src/UnifiedFFI/FFIArchitecture.class.st
+++ b/src/UnifiedFFI/FFIArchitecture.class.st
@@ -33,17 +33,6 @@ FFIArchitecture class >> uniqueInstance [
 	^ uniqueInstance ifNil: [ uniqueInstance := self basicNew initialize ]
 ]
 
-{ #category : #'default abi' }
-FFIArchitecture >> areStructuresSplitIntoRegisters [
-	^ false
-]
-
-{ #category : #'default abi' }
-FFIArchitecture >> computeStructureRegisterPassingLayout: aStructureClass [
-	^ nil
-	
-]
-
 { #category : #types }
 FFIArchitecture >> externalLongType [
 	^ ExternalType long
@@ -59,39 +48,9 @@ FFIArchitecture >> externalULongType [
 	^ ExternalType ulong
 ]
 
-{ #category : #'default abi' }
-FFIArchitecture >> floatRegisterCountForParameterPassing [
-	^ 0
-]
-
-{ #category : #'default abi' }
-FFIArchitecture >> floatRegisterSize [
-	self subclassResponsibility
-]
-
-{ #category : #'default abi' }
-FFIArchitecture >> integerRegisterCountForParameterPassing [
-	^ 0
-]
-
-{ #category : #'default abi' }
-FFIArchitecture >> integerRegisterSize [
-	self subclassResponsibility
-]
-
-{ #category : #types }
-FFIArchitecture >> longType [
-	^ FFIInt32
-]
-
 { #category : #types }
 FFIArchitecture >> longTypeSize [
 	^ self externalLongType byteSize
-]
-
-{ #category : #'default abi' }
-FFIArchitecture >> maxStructureSizeToPassInRegisters [
-	^ 0
 ]
 
 { #category : #'default abi' }
@@ -99,17 +58,7 @@ FFIArchitecture >> returnSingleFloatsAsDoubles [
 	self subclassResponsibility
 ]
 
-{ #category : #'default abi' }
-FFIArchitecture >> shadowCallSpaceSize [
-	^ 0
-]
-
 { #category : #types }
 FFIArchitecture >> sizeTTypeSize [
 	^ self externalSizeTType byteSize
-]
-
-{ #category : #types }
-FFIArchitecture >> ulongType [
-	^ FFIUInt32
 ]

--- a/src/UnifiedFFI/FFICallback.class.st
+++ b/src/UnifiedFFI/FFICallback.class.st
@@ -71,62 +71,16 @@ FFICallback class >> signature: aSignature block: aBlock [
 
 { #category : #evaluation }
 FFICallback >> argumentsFor: stackPointer context: callbackContext [
-	| stackOffset architecture intRegisterCount intRegisterSize registerIndex floatRegisterCount floatRegisterSize floatRegisters intRegisters structureRegisterLayout |
-	self flag: 'TODO: Refactor and improve this code.'.
-	architecture := FFIArchitecture forCurrentArchitecture.
+
+	| callbackArgumentReader | 
 	
-	intRegisterCount := architecture integerRegisterCountForParameterPassing.
-	intRegisterSize := architecture integerRegisterSize.
-	registerIndex := 0.
+	callbackArgumentReader := FFIArchitecture forCurrentArchitecture newCallbackArgumentReaderForCallback: self inContext: callbackContext.
 	
-	floatRegisterCount := architecture floatRegisterCountForParameterPassing.
-	floatRegisterSize := architecture floatRegisterSize.
-	
-	floatRegisters := callbackContext floatregargsp.
-	intRegisters := callbackContext intregargsp.
-	
-	stackOffset := 1 + architecture shadowCallSpaceSize.
-	^ functionSpec arguments 
-		collect: [ :each | | value parameterClass |
-			parameterClass := each stackParameterClass.
-			(parameterClass == #integer and: [ registerIndex < intRegisterCount and: [each typeSize <= intRegisterSize ]]) ifTrue: [
-				value := each callbackValueFor: intRegisters at: registerIndex*intRegisterSize + 1.
-				registerIndex := registerIndex + 1
-			] ifFalse: [ 
-				(parameterClass == #float and: [ registerIndex < floatRegisterCount and: [each typeSize <= floatRegisterSize ]]) ifTrue: [
-					value := each callbackValueFor: floatRegisters at: registerIndex*floatRegisterSize + 1.
-					registerIndex := registerIndex + 1
-				] ifFalse: [
-					(parameterClass == #structure and:
-					[ (structureRegisterLayout := architecture computeStructureRegisterPassingLayout: each objectClass) isNotNil and:
-					[registerIndex + structureRegisterLayout integerRegisterCount <= intRegisterSize and:
-					[registerIndex + structureRegisterLayout floatRegisterCount <= floatRegisterSize]]]) ifTrue: [
-						"This is structure whose content was splitted in registers."
-						value := each objectClass new.
-						structureRegisterLayout fields do: [ :structureField |
-							structureField registerClass == #integer ifTrue: [
-								1 to: structureField size do: [ :i |
-									value getHandle byteAt: structureField offset + i put:
-										(intRegisters unsignedByteAt: registerIndex*intRegisterSize + i)
-								].
-							] ifFalse: [
-								self assert: structureField registerClass == #float.
-								1 to: structureField size do: [ :i |
-									value getHandle byteAt: structureField offset + i put:
-										(floatRegisters unsignedByteAt: registerIndex*floatRegisterSize + i)
-								].
-								registerIndex := registerIndex + 1
-							] 
-						]
-					] ifFalse: [ 
-						"Memory parameter"
-						value := each callbackValueFor: stackPointer at: stackOffset.
-						stackOffset := stackOffset + (parameterClass == #float ifTrue: [floatRegisterSize ] ifFalse: [intRegisterSize]).
-					]
-				].
-			].
-		
-			value ].	
+	functionSpec arguments do: [ :type | callbackArgumentReader extractNext: type ].
+
+	self assert: functionSpec arguments size = callbackArgumentReader arguments size.
+
+	^ callbackArgumentReader arguments.
 ]
 
 { #category : #evaluation }

--- a/src/UnifiedFFI/FFICallback.class.st
+++ b/src/UnifiedFFI/FFICallback.class.st
@@ -71,58 +71,57 @@ FFICallback class >> signature: aSignature block: aBlock [
 
 { #category : #evaluation }
 FFICallback >> argumentsFor: stackPointer context: callbackContext [
-	| index architecture intRegisterCount intRegisterSize intRegisterIndex floatRegisterCount floatRegisterSize floatRegisterIndex floatRegisters intRegisters structureRegisterLayout |
+	| stackOffset architecture intRegisterCount intRegisterSize registerIndex floatRegisterCount floatRegisterSize floatRegisters intRegisters structureRegisterLayout |
 	self flag: 'TODO: Refactor and improve this code.'.
 	architecture := FFIArchitecture forCurrentArchitecture.
 	
 	intRegisterCount := architecture integerRegisterCountForParameterPassing.
 	intRegisterSize := architecture integerRegisterSize.
-	intRegisterIndex := 0.
+	registerIndex := 0.
 	
 	floatRegisterCount := architecture floatRegisterCountForParameterPassing.
 	floatRegisterSize := architecture floatRegisterSize.
-	floatRegisterIndex := 0.
 	
 	floatRegisters := callbackContext floatregargsp.
 	intRegisters := callbackContext intregargsp.
 	
-	index := 1 + architecture shadowCallSpaceSize.
+	stackOffset := 1 + architecture shadowCallSpaceSize.
 	^ functionSpec arguments 
 		collect: [ :each | | value parameterClass |
 			parameterClass := each stackParameterClass.
-			(parameterClass == #integer and: [ intRegisterIndex < intRegisterCount and: [each typeSize <= intRegisterSize ]]) ifTrue: [
-				value := each callbackValueFor: intRegisters at: intRegisterIndex*intRegisterSize + 1.
-				intRegisterIndex := intRegisterIndex + 1
+			(parameterClass == #integer and: [ registerIndex < intRegisterCount and: [each typeSize <= intRegisterSize ]]) ifTrue: [
+				value := each callbackValueFor: intRegisters at: registerIndex*intRegisterSize + 1.
+				registerIndex := registerIndex + 1
 			] ifFalse: [ 
-				(parameterClass == #float and: [ floatRegisterIndex < floatRegisterCount and: [each typeSize <= floatRegisterSize ]]) ifTrue: [
-					value := each callbackValueFor: floatRegisters at: floatRegisterIndex*floatRegisterSize + 1.
-					floatRegisterIndex := floatRegisterIndex + 1
+				(parameterClass == #float and: [ registerIndex < floatRegisterCount and: [each typeSize <= floatRegisterSize ]]) ifTrue: [
+					value := each callbackValueFor: floatRegisters at: registerIndex*floatRegisterSize + 1.
+					registerIndex := registerIndex + 1
 				] ifFalse: [
 					(parameterClass == #structure and:
 					[ (structureRegisterLayout := architecture computeStructureRegisterPassingLayout: each objectClass) isNotNil and:
-					[intRegisterIndex + structureRegisterLayout integerRegisterCount <= intRegisterSize and:
-					[floatRegisterIndex + structureRegisterLayout floatRegisterCount <= floatRegisterSize]]]) ifTrue: [
+					[registerIndex + structureRegisterLayout integerRegisterCount <= intRegisterSize and:
+					[registerIndex + structureRegisterLayout floatRegisterCount <= floatRegisterSize]]]) ifTrue: [
 						"This is structure whose content was splitted in registers."
 						value := each objectClass new.
 						structureRegisterLayout fields do: [ :structureField |
 							structureField registerClass == #integer ifTrue: [
 								1 to: structureField size do: [ :i |
 									value getHandle byteAt: structureField offset + i put:
-										(intRegisters unsignedByteAt: intRegisterIndex*intRegisterSize + i)
+										(intRegisters unsignedByteAt: registerIndex*intRegisterSize + i)
 								].
 							] ifFalse: [
 								self assert: structureField registerClass == #float.
 								1 to: structureField size do: [ :i |
 									value getHandle byteAt: structureField offset + i put:
-										(floatRegisters unsignedByteAt: floatRegisterIndex*floatRegisterSize + i)
+										(floatRegisters unsignedByteAt: registerIndex*floatRegisterSize + i)
 								].
-								floatRegisterIndex := floatRegisterIndex + 1
+								registerIndex := registerIndex + 1
 							] 
 						]
 					] ifFalse: [ 
-						"Memory parameter" 
-						value := each callbackValueFor: stackPointer at: index.
-						index := index + each typeSize.
+						"Memory parameter"
+						value := each callbackValueFor: stackPointer at: stackOffset.
+						stackOffset := stackOffset + (parameterClass == #float ifTrue: [floatRegisterSize ] ifFalse: [intRegisterSize]).
 					]
 				].
 			].
@@ -151,6 +150,11 @@ FFICallback >> ffiInstVarArgument: argName generator: generator [
 	^ FFIInstVarArgument new 
 		argName: argName;
 		yourself
+]
+
+{ #category : #accessing }
+FFICallback >> functionSpec [
+	^ functionSpec
 ]
 
 { #category : #private }

--- a/src/UnifiedFFI/FFICallback.class.st
+++ b/src/UnifiedFFI/FFICallback.class.st
@@ -60,8 +60,7 @@ FFICallback class >> forAddress: address [
 { #category : #'private primitives' }
 FFICallback class >> primQsort: array with: count with: size with: compare [
 	self
-		ffiCall: #(void qsort (FFIExternalArray array, size_t count, size_t size, FFICallback compare)) 
-		module: LibC
+		ffiCall: #(void qsort (FFIExternalArray array, size_t count, size_t size, FFICallback compare)) 		module: LibC
 ]
 
 { #category : #'instance creation' }
@@ -75,9 +74,9 @@ FFICallback >> argumentsFor: stackPointer context: callbackContext [
 	| callbackArgumentReader | 
 	
 	callbackArgumentReader := FFIArchitecture forCurrentArchitecture newCallbackArgumentReaderForCallback: self inContext: callbackContext.
-	
-	functionSpec arguments do: [ :type | callbackArgumentReader extractNext: type ].
 
+	callbackArgumentReader extractArguments.
+	
 	self assert: functionSpec arguments size = callbackArgumentReader arguments size.
 
 	^ callbackArgumentReader arguments.

--- a/src/UnifiedFFI/FFICallbackArgumentReader.class.st
+++ b/src/UnifiedFFI/FFICallbackArgumentReader.class.st
@@ -1,3 +1,49 @@
+"
+I am an abstract class that is responsible for extracting the arguments of a callback.
+The callbacks provides the arguments in different forms depending of the architecture.
+Each of my subclasses implements special behavior for the given architectures.
+I have the common behavior for all the architectures.
+
+Basically, I am a stateful object that is used during the process of extraction.
+I am created with a callback and a callback context.
+A new instance of myself is created in each callback invocation, and it should not be reused.
+
+From the callback I extract the type of return of the callback and the type of the parameters.
+
+I am used in the method FFICallback >> #argumentsFor: stackPointer context: callbackContext.
+Each of the architectures is able to create the correct subclass of me.
+
+My users just use the #extractArguments method and then access teh arguments through #arguments.
+
+In the extractArguments, I take the arguments from the FFICallback and send my message extractNext: with the type of the arguments.
+
+The #extractNext: method checks if the type represents a pointer or a value type. 
+If it is a pointer the message #extractPointerOfType: is used. If it is a value,
+there is a double dispatch with the type. The message #extractFromCallbackOn: is sent to the type.
+
+Then the type use one of the following methods to indicate its type: 
+
+#extractCharacterType
+#extractDouble
+#extractFloat
+#extractIntegerType 
+#extractExternalString: 
+#extractStructType:
+
+Each of this methods calculates the base address and the correct offset to extract the value or the pointer. For this calculation the messages #nextBaseAddressFor: aType and #nextBaseAddressForStructure: aStructType are used.
+
+My base implementation extracts all the parameters from the stack. So the base address is always the stack pointer and the offset is updated according to the type.
+
+Once the base address is opteined, the type objects is used with the message #handle:at: to get the value from the stack.
+
+These methods all modify the collection of extracted elements.
+
+Note: 
+
+When a callback should return a struct by copy, the caller function allocates the returning struct. 
+The pointer to this struct is stored in a new first parameter to the callback. This hidden parameter is extracted in the #initialize if it is required.
+The callback can access to the pointer through the returnValueHolder instance variable.
+"
 Class {
 	#name : #FFICallbackArgumentReader,
 	#superclass : #Object,
@@ -8,7 +54,7 @@ Class {
 		'extractedArguments',
 		'returnValueHolder'
 	],
-	#category : #'UnifiedFFI-Architecture'
+	#category : #'UnifiedFFI-Callbacks'
 }
 
 { #category : #'as yet unclassified' }
@@ -81,6 +127,13 @@ FFICallbackArgumentReader >> callbackContext: anObject [
 ]
 
 { #category : #extracting }
+FFICallbackArgumentReader >> extractArguments [
+
+	callback functionSpec arguments do: [ :type | self extractNext: type ].
+
+]
+
+{ #category : #extracting }
 FFICallbackArgumentReader >> extractCharacterType [
 
 	extractedArguments add: self basicExtractUnsignedInteger asCharacter
@@ -132,7 +185,7 @@ FFICallbackArgumentReader >> extractIntegerType [
 FFICallbackArgumentReader >> extractNext: aFFIType [
 
 	aFFIType isPointer
-		ifTrue: [ aFFIType extractPointerFrom: self ]
+		ifTrue: [ self extractPointerOfType: aFFIType ]
 		ifFalse: [ aFFIType extractFromCallbackOn: self ]
 ]
 
@@ -181,6 +234,10 @@ FFICallbackArgumentReader >> initialize [
 { #category : #'calculating-offsets' }
 FFICallbackArgumentReader >> nextBaseAddressFor: type [
 
+	"I calculate the base address to read an argument from a callback context.
+	In my implementation all the arguments are read from the stack.
+	The space of each type depends of its own size."
+
 	| baseAddressToRead offsetOfBaseAddress typeSize |
 
 	typeSize := type isPointer ifTrue: [ Smalltalk wordSize ] ifFalse: [ type externalTypeSize ].
@@ -195,11 +252,19 @@ FFICallbackArgumentReader >> nextBaseAddressFor: type [
 { #category : #'calculating-offsets' }
 FFICallbackArgumentReader >> nextBaseAddressForStructure: type [
 
+	"I calculate the base address to read an struct argument.
+	The handling of structs is different in the subclases, but in myself the handle of 
+	structs is performed in the stack, so the calculation of addresses is perform in the same
+	way as non-struct arguments."
+
+
 	^ self nextBaseAddressFor: type
 ]
 
 { #category : #types }
 FFICallbackArgumentReader >> stackIntegerType [
+	
+	"Depending of the architecture there are different types used in the stack for the integers."
 	
 	^ self subclassResponsibility
 ]
@@ -212,5 +277,7 @@ FFICallbackArgumentReader >> stackPointer [
 { #category : #types }
 FFICallbackArgumentReader >> stackUnsignedIntegerType [
 	
+	"Depending of the architecture there are different types used in the stack for the unsigned integers."
+
 	^ self subclassResponsibility
 ]

--- a/src/UnifiedFFI/FFICallbackArgumentReader.class.st
+++ b/src/UnifiedFFI/FFICallbackArgumentReader.class.st
@@ -5,7 +5,8 @@ Class {
 		'callback',
 		'callbackContext',
 		'currentStackOffset',
-		'extractedArguments'
+		'extractedArguments',
+		'returnValueHolder'
 	],
 	#category : #'UnifiedFFI-Architecture'
 }
@@ -28,14 +29,28 @@ FFICallbackArgumentReader >> arguments [
 
 { #category : #extracting }
 FFICallbackArgumentReader >> basicExtractInteger [
-
-	^ self subclassResponsibility 
+	
+	| baseAddressToRead offsetOfBaseAddress type pair |
+	
+	type := self stackIntegerType.
+	pair := self nextBaseAddressFor: type.
+	baseAddressToRead := pair first.
+	offsetOfBaseAddress := pair second.
+	
+	^ type handle: baseAddressToRead at: offsetOfBaseAddress.
 ]
 
 { #category : #extracting }
 FFICallbackArgumentReader >> basicExtractUnsignedInteger [
-
-	^ self subclassResponsibility 
+	
+	| baseAddressToRead offsetOfBaseAddress type pair |
+	
+	type := self stackUnsignedIntegerType.
+	pair := self nextBaseAddressFor: type.
+	baseAddressToRead := pair first.
+	offsetOfBaseAddress := pair second.
+	
+	^ type handle: baseAddressToRead at: offsetOfBaseAddress.
 ]
 
 { #category : #accessing }
@@ -67,12 +82,38 @@ FFICallbackArgumentReader >> extractCharacterType [
 
 { #category : #extracting }
 FFICallbackArgumentReader >> extractDouble [
-	self subclassResponsibility 
+
+	| type pair baseAddressToRead offsetOfBaseAddress |
+	type := FFIFloat64 new.
+	pair := self nextBaseAddressFor: type.
+	baseAddressToRead := pair first.
+	offsetOfBaseAddress := pair second.
+
+	extractedArguments add: (type handle: baseAddressToRead at: offsetOfBaseAddress).
+
+]
+
+{ #category : #extracting }
+FFICallbackArgumentReader >> extractExternalString: type [ 
+	
+	| pair baseAddressToRead offsetOfBaseAddress |
+	pair := self nextBaseAddressFor: type.
+	baseAddressToRead := pair first.
+	offsetOfBaseAddress := pair second.
+
+	extractedArguments add: (type handle: baseAddressToRead at: offsetOfBaseAddress).
 ]
 
 { #category : #extracting }
 FFICallbackArgumentReader >> extractFloat [
-	self subclassResponsibility 
+
+	| type pair baseAddressToRead offsetOfBaseAddress |
+	type := FFIFloat32 new.
+	pair := self nextBaseAddressFor: type.
+	baseAddressToRead := pair first.
+	offsetOfBaseAddress := pair second.
+
+	extractedArguments add: (type handle: baseAddressToRead at: offsetOfBaseAddress).
 ]
 
 { #category : #extracting }
@@ -92,24 +133,75 @@ FFICallbackArgumentReader >> extractNext: aFFIType [
 { #category : #extracting }
 FFICallbackArgumentReader >> extractPointerOfType: aType [
 
-	extractedArguments add: (aType handle: self stackPointer at: currentStackOffset).
-	currentStackOffset := currentStackOffset + Smalltalk wordSize
+	| pair baseAddressToRead offsetOfBaseAddress |
+	pair := self nextBaseAddressFor: aType.
+	baseAddressToRead := pair first.
+	offsetOfBaseAddress := pair second.
+
+	extractedArguments add: (aType handle: baseAddressToRead at: offsetOfBaseAddress).
+
 ]
 
 { #category : #extracting }
-FFICallbackArgumentReader >> extractStructType: aFFIExternalStructureType [ 
+FFICallbackArgumentReader >> extractStructType: type [ 
 	
-	self subclassResponsibility 
+	| pair baseAddressToRead offsetOfBaseAddress |
+	pair := self nextBaseAddressForStructure: type.
+	baseAddressToRead := pair first.
+	offsetOfBaseAddress := pair second.
+
+	extractedArguments add: (type handle: baseAddressToRead at: offsetOfBaseAddress).
 ]
 
 { #category : #initialization }
 FFICallbackArgumentReader >> initialize [
+	
+	| returnType |
+
+	super initialize.
 
 	currentStackOffset := 1.
 	extractedArguments := OrderedCollection new.
+	
+	"If the function returns an struct by copy there is a hidden parameter with a pointer storing it".
+	returnType := callback functionSpec returnType.
+	(returnType isExternalStructure and: [ returnType isPointer not ]) ifTrue: [ 
+		returnValueHolder := self stackPointer pointerAt: 1.
+		currentStackOffset := currentStackOffset + Smalltalk wordSize.
+	]
+]
+
+{ #category : #'calculating-offsets' }
+FFICallbackArgumentReader >> nextBaseAddressFor: type [
+
+	| baseAddressToRead offsetOfBaseAddress |
+
+	baseAddressToRead := self stackPointer.
+	offsetOfBaseAddress := currentStackOffset.
+	currentStackOffset := currentStackOffset + type externalTypeSize.
+
+	^ {baseAddressToRead. offsetOfBaseAddress}
+]
+
+{ #category : #'calculating-offsets' }
+FFICallbackArgumentReader >> nextBaseAddressForStructure: type [
+
+	^ self nextBaseAddressFor: type
+]
+
+{ #category : #types }
+FFICallbackArgumentReader >> stackIntegerType [
+	
+	^ self subclassResponsibility
 ]
 
 { #category : #accessing }
 FFICallbackArgumentReader >> stackPointer [
 	^ callbackContext stackp
+]
+
+{ #category : #types }
+FFICallbackArgumentReader >> stackUnsignedIntegerType [
+	
+	^ self subclassResponsibility
 ]

--- a/src/UnifiedFFI/FFICallbackArgumentReader.class.st
+++ b/src/UnifiedFFI/FFICallbackArgumentReader.class.st
@@ -174,11 +174,13 @@ FFICallbackArgumentReader >> initialize [
 { #category : #'calculating-offsets' }
 FFICallbackArgumentReader >> nextBaseAddressFor: type [
 
-	| baseAddressToRead offsetOfBaseAddress |
+	| baseAddressToRead offsetOfBaseAddress typeSize |
+
+	typeSize := type isPointer ifTrue: [ Smalltalk wordSize ] ifFalse: [ type externalTypeSize ].
 
 	baseAddressToRead := self stackPointer.
 	offsetOfBaseAddress := currentStackOffset.
-	currentStackOffset := currentStackOffset + type externalTypeSize.
+	currentStackOffset := currentStackOffset + typeSize.
 
 	^ {baseAddressToRead. offsetOfBaseAddress}
 ]

--- a/src/UnifiedFFI/FFICallbackArgumentReader.class.st
+++ b/src/UnifiedFFI/FFICallbackArgumentReader.class.st
@@ -1,0 +1,115 @@
+Class {
+	#name : #FFICallbackArgumentReader,
+	#superclass : #Object,
+	#instVars : [
+		'callback',
+		'callbackContext',
+		'currentStackOffset',
+		'extractedArguments'
+	],
+	#category : #'UnifiedFFI-Architecture'
+}
+
+{ #category : #'as yet unclassified' }
+FFICallbackArgumentReader class >> forCallback: aCallback inContext: aCallbackContext [
+
+	^ self basicNew
+		callbackContext: aCallbackContext;
+		callback: aCallback;
+		initialize;
+		yourself.
+]
+
+{ #category : #accessing }
+FFICallbackArgumentReader >> arguments [
+	
+	^ extractedArguments
+]
+
+{ #category : #extracting }
+FFICallbackArgumentReader >> basicExtractInteger [
+
+	^ self subclassResponsibility 
+]
+
+{ #category : #extracting }
+FFICallbackArgumentReader >> basicExtractUnsignedInteger [
+
+	^ self subclassResponsibility 
+]
+
+{ #category : #accessing }
+FFICallbackArgumentReader >> callback [
+	^ callback
+]
+
+{ #category : #accessing }
+FFICallbackArgumentReader >> callback: anObject [
+	callback := anObject
+]
+
+{ #category : #accessing }
+FFICallbackArgumentReader >> callbackContext [
+	^ callbackContext
+]
+
+{ #category : #accessing }
+FFICallbackArgumentReader >> callbackContext: anObject [
+	callbackContext := anObject.
+
+]
+
+{ #category : #extracting }
+FFICallbackArgumentReader >> extractCharacterType [
+
+	extractedArguments add: self basicExtractUnsignedInteger asCharacter
+]
+
+{ #category : #extracting }
+FFICallbackArgumentReader >> extractDouble [
+	self subclassResponsibility 
+]
+
+{ #category : #extracting }
+FFICallbackArgumentReader >> extractFloat [
+	self subclassResponsibility 
+]
+
+{ #category : #extracting }
+FFICallbackArgumentReader >> extractIntegerType [
+
+	extractedArguments add: self basicExtractInteger
+]
+
+{ #category : #extracting }
+FFICallbackArgumentReader >> extractNext: aFFIType [
+
+	aFFIType isPointer
+		ifTrue: [ aFFIType extractPointerFrom: self ]
+		ifFalse: [ aFFIType extractFromCallbackOn: self ]
+]
+
+{ #category : #extracting }
+FFICallbackArgumentReader >> extractPointerOfType: aType [
+
+	extractedArguments add: (aType handle: self stackPointer at: currentStackOffset).
+	currentStackOffset := currentStackOffset + Smalltalk wordSize
+]
+
+{ #category : #extracting }
+FFICallbackArgumentReader >> extractStructType: aFFIExternalStructureType [ 
+	
+	self subclassResponsibility 
+]
+
+{ #category : #initialization }
+FFICallbackArgumentReader >> initialize [
+
+	currentStackOffset := 1.
+	extractedArguments := OrderedCollection new.
+]
+
+{ #category : #accessing }
+FFICallbackArgumentReader >> stackPointer [
+	^ callbackContext stackp
+]

--- a/src/UnifiedFFI/FFICallbackArgumentReader.class.st
+++ b/src/UnifiedFFI/FFICallbackArgumentReader.class.st
@@ -41,6 +41,12 @@ FFICallbackArgumentReader >> basicExtractInteger [
 ]
 
 { #category : #extracting }
+FFICallbackArgumentReader >> basicExtractPointer [
+	
+	^ ExternalAddress fromAddress: (self basicExtractUnsignedInteger)
+]
+
+{ #category : #extracting }
 FFICallbackArgumentReader >> basicExtractUnsignedInteger [
 	
 	| baseAddressToRead offsetOfBaseAddress type pair |
@@ -146,6 +152,7 @@ FFICallbackArgumentReader >> extractPointerOfType: aType [
 FFICallbackArgumentReader >> extractStructType: type [ 
 	
 	| pair baseAddressToRead offsetOfBaseAddress |
+	
 	pair := self nextBaseAddressForStructure: type.
 	baseAddressToRead := pair first.
 	offsetOfBaseAddress := pair second.

--- a/src/UnifiedFFI/FFICharacterType.class.st
+++ b/src/UnifiedFFI/FFICharacterType.class.st
@@ -39,6 +39,12 @@ FFICharacterType >> defaultReturnOnError [
 	^ Character null
 ]
 
+{ #category : #callbacks }
+FFICharacterType >> extractFromCallbackOn: aCallbackArgumentReader [ 
+
+	aCallbackArgumentReader extractCharacterType
+]
+
 { #category : #testing }
 FFICharacterType >> needsArityPacking [
 	">1 because it can be a 'char *', then just roll when is 'char**' or bigger"

--- a/src/UnifiedFFI/FFIExternalString.class.st
+++ b/src/UnifiedFFI/FFIExternalString.class.st
@@ -44,6 +44,12 @@ FFIExternalString >> externalTypeSize [
 	^ self pointerSize "i am live and die as a pointer (a char*)"
 ]
 
+{ #category : #callbacks }
+FFIExternalString >> extractFromCallbackOn: aFFICallbackArgumentReader [ 
+	
+	aFFICallbackArgumentReader extractExternalString: self
+]
+
 { #category : #'stack parameter classification' }
 FFIExternalString >> stackValueParameterClass [
 	^ #integer

--- a/src/UnifiedFFI/FFIExternalStructureType.class.st
+++ b/src/UnifiedFFI/FFIExternalStructureType.class.st
@@ -25,6 +25,7 @@ FFIExternalStructureType class >> objectClass: aClass [
 
 { #category : #private }
 FFIExternalStructureType >> basicHandle: aHandle at: index [
+
 	^ self objectClass fromHandle: (aHandle referenceStructAt: index length: self externalTypeSize)
 
 ]
@@ -32,6 +33,12 @@ FFIExternalStructureType >> basicHandle: aHandle at: index [
 { #category : #private }
 FFIExternalStructureType >> basicHandle: aHandle at: index put: value [
 	^ LibC memCopy: value getHandle to: aHandle + (index - 1) size: self externalTypeSize
+]
+
+{ #category : #callbacks }
+FFIExternalStructureType >> callbackReturnOn: callbackContext for: anObject [
+
+	^ self error: 'Cannot return an external structure by copy. It is not yet implemented'
 ]
 
 { #category : #accessing }
@@ -61,6 +68,12 @@ FFIExternalStructureType >> externalTypeAlignment [
 { #category : #accessing }
 FFIExternalStructureType >> externalTypeSize [ 
 	^ self objectClass structureSize
+]
+
+{ #category : #extracting }
+FFIExternalStructureType >> extractFromCallbackOn: aCallbackArgumentReader [ 
+
+	aCallbackArgumentReader extractStructType: self
 ]
 
 { #category : #initialization }

--- a/src/UnifiedFFI/FFIExternalType.class.st
+++ b/src/UnifiedFFI/FFIExternalType.class.st
@@ -235,6 +235,12 @@ FFIExternalType >> isExternalType [
 ]
 
 { #category : #testing }
+FFIExternalType >> isFloatType [
+
+	^ false
+]
+
+{ #category : #testing }
 FFIExternalType >> isPointer [
 	^ self pointerArity > 0
 ]

--- a/src/UnifiedFFI/FFIExternalType.class.st
+++ b/src/UnifiedFFI/FFIExternalType.class.st
@@ -116,13 +116,13 @@ FFIExternalType >> basicHandle: aHandle at: index put: value [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : #callbacks }
 FFIExternalType >> callbackReturnOn: callbackContext for: anObject [
 	"By default, I answer an integral return (not a float)"
 	^ callbackContext wordResult: anObject
 ]
 
-{ #category : #accessing }
+{ #category : #callbacks }
 FFIExternalType >> callbackValueFor: anObject at: index [
 	"This is the value for a callback. 
 	 The callback parameters came from an external adress who can be treated as a ByteArray, so it 
@@ -197,6 +197,12 @@ FFIExternalType >> externalTypeWithArity [
 	^ self pointerArity > 0 
 		ifTrue: [ self externalType asPointerType ]
 		ifFalse: [ self externalType ]
+]
+
+{ #category : #callbacks }
+FFIExternalType >> extractPointerFrom: aCallbackArgumentReader [ 
+
+	aCallbackArgumentReader extractPointerOfType: self
 ]
 
 { #category : #'accessing array' }

--- a/src/UnifiedFFI/FFIExternalType.class.st
+++ b/src/UnifiedFFI/FFIExternalType.class.st
@@ -199,12 +199,6 @@ FFIExternalType >> externalTypeWithArity [
 		ifFalse: [ self externalType ]
 ]
 
-{ #category : #callbacks }
-FFIExternalType >> extractPointerFrom: aCallbackArgumentReader [ 
-
-	aCallbackArgumentReader extractPointerOfType: self
-]
-
 { #category : #'accessing array' }
 FFIExternalType >> handle: aHandle at: index [ 
 	self isPointer ifTrue: [ ^ aHandle pointerAt: index ].

--- a/src/UnifiedFFI/FFIFloat32.class.st
+++ b/src/UnifiedFFI/FFIFloat32.class.st
@@ -48,3 +48,9 @@ FFIFloat32 >> emitPointerArityRoll: aBuilder context: aContext [
 		arity: self pointerArity
 		selector: #packAsFloatToArity:
 ]
+
+{ #category : #callbacks }
+FFIFloat32 >> extractFromCallbackOn: aCallbackArgumentReader [ 
+	
+	aCallbackArgumentReader extractFloat
+]

--- a/src/UnifiedFFI/FFIFloat64.class.st
+++ b/src/UnifiedFFI/FFIFloat64.class.st
@@ -41,3 +41,9 @@ FFIFloat64 >> emitPointerArityRoll: aBuilder context: aContext [
 		arity: self pointerArity
 		selector: #packAsDoubleToArity:
 ]
+
+{ #category : #callbacks }
+FFIFloat64 >> extractFromCallbackOn: aCallbackArgumentReader [ 
+	
+	aCallbackArgumentReader extractDouble
+]

--- a/src/UnifiedFFI/FFIFloatType.class.st
+++ b/src/UnifiedFFI/FFIFloatType.class.st
@@ -18,6 +18,12 @@ FFIFloatType >> defaultReturnOnError [
 	^ 0.0
 ]
 
+{ #category : #testing }
+FFIFloatType >> isFloatType [
+	
+	^ true
+]
+
 { #category : #'stack parameter classification' }
 FFIFloatType >> stackValueParameterClass [
 	^ #float

--- a/src/UnifiedFFI/FFIIntegerType.class.st
+++ b/src/UnifiedFFI/FFIIntegerType.class.st
@@ -13,6 +13,12 @@ FFIIntegerType >> defaultReturnOnError [
 	^ 0
 ]
 
+{ #category : #callbacks }
+FFIIntegerType >> extractFromCallbackOn: aCallbackArgumentReader [
+ 
+	^ aCallbackArgumentReader extractIntegerType
+]
+
 { #category : #'stack parameter classification' }
 FFIIntegerType >> stackValueParameterClass [
 	^ #integer

--- a/src/UnifiedFFI/FFISystemV64CallbackArgumentReader.class.st
+++ b/src/UnifiedFFI/FFISystemV64CallbackArgumentReader.class.st
@@ -1,9 +1,8 @@
 Class {
 	#name : #FFISystemV64CallbackArgumentReader,
-	#superclass : #FFICallbackArgumentReader,
+	#superclass : #FFIAbstract64BitsArgumentReader,
 	#instVars : [
-		'currentFloatRegisterIndex',
-		'currentIntegerRegisterIndex'
+		'currentFloatRegisterIndex'
 	],
 	#category : #'UnifiedFFI-Architecture'
 }
@@ -15,13 +14,7 @@ FFISystemV64CallbackArgumentReader >> currentFloatRegisterIndex [
 
 { #category : #accessing }
 FFISystemV64CallbackArgumentReader >> currentIntegerRegisterIndex [
-	^ currentIntegerRegisterIndex
-]
-
-{ #category : #accessing }
-FFISystemV64CallbackArgumentReader >> floatRegisterPointer [
-	
-	^ callbackContext floatregargsp
+	^ currentRegisterIndex
 ]
 
 { #category : #updating }
@@ -33,7 +26,7 @@ FFISystemV64CallbackArgumentReader >> increateFloatRegisterIndex [
 { #category : #updating }
 FFISystemV64CallbackArgumentReader >> increateIntegerRegisterIndex [
 	
-	currentIntegerRegisterIndex := currentIntegerRegisterIndex + 1
+	currentRegisterIndex := currentRegisterIndex + 1
 ]
 
 { #category : #initialization }
@@ -41,13 +34,7 @@ FFISystemV64CallbackArgumentReader >> initialize [
 
 	super initialize.
 	currentFloatRegisterIndex := 1.
-	currentIntegerRegisterIndex := 1.	
-]
 
-{ #category : #accessing }
-FFISystemV64CallbackArgumentReader >> integerRegisterPointer [
-	
-	^ callbackContext intregargsp
 ]
 
 { #category : #'calculating-offsets' }
@@ -84,9 +71,9 @@ FFISystemV64CallbackArgumentReader >> nextBaseAddressForStructure: type [
 	(type externalTypeSize > FFIArchitecture forCurrentArchitecture maxStructureSizeToPassInRegisters)
 		ifTrue: [ ^ super nextBaseAddressFor: type ].
 
-	baseOffset := (self currentIntegerRegisterIndex - 1) * Smalltalk wordSize + 1.
+	baseOffset := (currentRegisterIndex - 1) * Smalltalk wordSize + 1.
 	"We have to increase the current register index used"
-	currentIntegerRegisterIndex := currentIntegerRegisterIndex + (type externalTypeSize / Smalltalk wordSize) ceiling.
+	currentRegisterIndex := currentRegisterIndex + (type externalTypeSize / Smalltalk wordSize) ceiling.
 	 		
 	^ { self integerRegisterPointer.  baseOffset}
 	

--- a/src/UnifiedFFI/FFISystemV64CallbackArgumentReader.class.st
+++ b/src/UnifiedFFI/FFISystemV64CallbackArgumentReader.class.st
@@ -1,10 +1,31 @@
+"
+I represent the parsing of arguments in the SystemV 64 bits calling convention.
+In this convention the passing of the parameters is done in the registers for the first 6 integers and the first 6 floats.
+The count of the register used is indepent of the type. Ex: 
+
+int f(int a, int b, float x, float y, int c)
+
+a -> 1st int register.
+b -> 2nd int register.
+x -> 1st float register.
+y -> 2nd float register.
+c -> 3rd int register.
+
+If there are more that 6 parameters of a given type, the seventh goes in the stack.
+
+The structs in this calling convention are passed in the stack or in the registers.
+If a struct occupies #maxStructureSizeToPassInRegisters bytes or less it is passed in the registers. Using the two next registers available.
+If there are no available registers or the struct is bigger, the stack is used. 
+
+All the integer types are promoted to Int64 or UInt64.
+"
 Class {
 	#name : #FFISystemV64CallbackArgumentReader,
 	#superclass : #FFIAbstract64BitsArgumentReader,
 	#instVars : [
 		'currentFloatRegisterIndex'
 	],
-	#category : #'UnifiedFFI-Architecture'
+	#category : #'UnifiedFFI-Callbacks'
 }
 
 { #category : #accessing }
@@ -35,6 +56,14 @@ FFISystemV64CallbackArgumentReader >> initialize [
 	super initialize.
 	currentFloatRegisterIndex := 1.
 
+]
+
+{ #category : #'instance creation' }
+FFISystemV64CallbackArgumentReader >> maxStructureSizeToPassInRegisters [
+
+	"I am the max size of registers passed in the general purpouse registres.
+	The structures that are bigger are passed through the stack"
+	^ 16
 ]
 
 { #category : #'calculating-offsets' }
@@ -68,7 +97,7 @@ FFISystemV64CallbackArgumentReader >> nextBaseAddressForStructure: type [
 	| baseOffset |
 
 	"If the structure is maller than the max size, it is passed in the general purpouse registers."
-	(type externalTypeSize > FFIArchitecture forCurrentArchitecture maxStructureSizeToPassInRegisters)
+	(type externalTypeSize > self maxStructureSizeToPassInRegisters)
 		ifTrue: [ ^ super nextBaseAddressFor: type ].
 
 	baseOffset := (currentRegisterIndex - 1) * Smalltalk wordSize + 1.

--- a/src/UnifiedFFI/FFISystemV64CallbackArgumentReader.class.st
+++ b/src/UnifiedFFI/FFISystemV64CallbackArgumentReader.class.st
@@ -1,0 +1,111 @@
+Class {
+	#name : #FFISystemV64CallbackArgumentReader,
+	#superclass : #FFICallbackArgumentReader,
+	#instVars : [
+		'currentFloatRegisterIndex',
+		'currentIntegerRegisterIndex'
+	],
+	#category : #'UnifiedFFI-Architecture'
+}
+
+{ #category : #accessing }
+FFISystemV64CallbackArgumentReader >> currentFloatRegisterIndex [
+	^ currentFloatRegisterIndex
+]
+
+{ #category : #accessing }
+FFISystemV64CallbackArgumentReader >> currentIntegerRegisterIndex [
+	^ currentIntegerRegisterIndex
+]
+
+{ #category : #accessing }
+FFISystemV64CallbackArgumentReader >> floatRegisterPointer [
+	
+	^ callbackContext floatregargsp
+]
+
+{ #category : #updating }
+FFISystemV64CallbackArgumentReader >> increateFloatRegisterIndex [
+	
+	currentFloatRegisterIndex := currentFloatRegisterIndex + 1
+]
+
+{ #category : #updating }
+FFISystemV64CallbackArgumentReader >> increateIntegerRegisterIndex [
+	
+	currentIntegerRegisterIndex := currentIntegerRegisterIndex + 1
+]
+
+{ #category : #initialization }
+FFISystemV64CallbackArgumentReader >> initialize [
+
+	super initialize.
+	currentFloatRegisterIndex := 1.
+	currentIntegerRegisterIndex := 1.	
+]
+
+{ #category : #accessing }
+FFISystemV64CallbackArgumentReader >> integerRegisterPointer [
+	
+	^ callbackContext intregargsp
+]
+
+{ #category : #'calculating-offsets' }
+FFISystemV64CallbackArgumentReader >> nextBaseAddressFor: type [
+	
+	| baseAddressToRead offsetOfBaseAddress registerIndex |
+	
+	registerIndex := (type isFloatType and: [type isPointer not])  ifTrue: [ self currentFloatRegisterIndex ] ifFalse: [ self currentIntegerRegisterIndex ].
+	
+	^ registerIndex <= self numberOfRegisters 
+		ifTrue:[ 
+				"If the parameter is a floating point parameter it comes in the floating point set of registers, not in the general purpose ones."
+				(type isFloatType and: [type isPointer not]) 
+					ifTrue: [ 
+						baseAddressToRead := self floatRegisterPointer.
+						self increateFloatRegisterIndex ]
+					ifFalse: [
+						baseAddressToRead := self integerRegisterPointer.
+						self increateIntegerRegisterIndex].
+				
+				offsetOfBaseAddress := (registerIndex - 1) * Smalltalk wordSize + 1.
+				{ baseAddressToRead. offsetOfBaseAddress }] 
+		ifFalse:[ super nextBaseAddressFor: type ].
+
+
+]
+
+{ #category : #'calculating-offsets' }
+FFISystemV64CallbackArgumentReader >> nextBaseAddressForStructure: type [
+
+	| baseOffset |
+
+	"If the structure is maller than the max size, it is passed in the general purpouse registers."
+	(type externalTypeSize > FFIArchitecture forCurrentArchitecture maxStructureSizeToPassInRegisters)
+		ifTrue: [ ^ super nextBaseAddressFor: type ].
+
+	baseOffset := (self currentIntegerRegisterIndex - 1) * 8 + 1.
+	"We have to increase the current register index used"
+	currentIntegerRegisterIndex := currentIntegerRegisterIndex + (type externalTypeSize / 8) ceiling.
+	 		
+	^ { self integerRegisterPointer.  baseOffset}
+	
+]
+
+{ #category : #accessing }
+FFISystemV64CallbackArgumentReader >> numberOfRegisters [
+	
+	^ 6
+]
+
+{ #category : #types }
+FFISystemV64CallbackArgumentReader >> stackIntegerType [
+	
+	^ FFIInt64 new
+]
+
+{ #category : #types }
+FFISystemV64CallbackArgumentReader >> stackUnsignedIntegerType [
+	
+	^ FFIUInt64 new
+]

--- a/src/UnifiedFFI/FFISystemV64CallbackArgumentReader.class.st
+++ b/src/UnifiedFFI/FFISystemV64CallbackArgumentReader.class.st
@@ -84,9 +84,9 @@ FFISystemV64CallbackArgumentReader >> nextBaseAddressForStructure: type [
 	(type externalTypeSize > FFIArchitecture forCurrentArchitecture maxStructureSizeToPassInRegisters)
 		ifTrue: [ ^ super nextBaseAddressFor: type ].
 
-	baseOffset := (self currentIntegerRegisterIndex - 1) * 8 + 1.
+	baseOffset := (self currentIntegerRegisterIndex - 1) * Smalltalk wordSize + 1.
 	"We have to increase the current register index used"
-	currentIntegerRegisterIndex := currentIntegerRegisterIndex + (type externalTypeSize / 8) ceiling.
+	currentIntegerRegisterIndex := currentIntegerRegisterIndex + (type externalTypeSize / Smalltalk wordSize) ceiling.
 	 		
 	^ { self integerRegisterPointer.  baseOffset}
 	

--- a/src/UnifiedFFI/FFIWin64CallbackArgumentReader.class.st
+++ b/src/UnifiedFFI/FFIWin64CallbackArgumentReader.class.st
@@ -1,12 +1,31 @@
+"
+I am the responsible to parse the callback arguments in Win64.
+In Win64 the structures are always passed by reference. 
+The first 4 parameters are passed in the registry. 
+If the parameter is an integer, it is in the integer registers (general purpouse registers).
+If the parameter is a float, it is in the float registers (SSE registers).
+
+The first parameter is always in the first register of the set, the second always in the second register, etc. Following the type of arguments.
+
+Ex: 
+
+int f( int a, float b, char c)
+
+The parameter a is in the first integer register, the parameter b is in the second float register, and the parameter c is in the third integer register.
+
+The fifth and following parameters are passed in the stack.
+If any of the four first parameters does not fit in the registers are passed in the stack.
+"
 Class {
 	#name : #FFIWin64CallbackArgumentReader,
 	#superclass : #FFIAbstract64BitsArgumentReader,
-	#category : #'UnifiedFFI-Architecture'
+	#category : #'UnifiedFFI-Callbacks'
 }
 
 { #category : #accessing }
 FFIWin64CallbackArgumentReader >> currentParameterIndex [
 	
+	"As the current parameter index correspond with the number of extracted parameters I directly use it"
 	^ extractedArguments size + 1
 ]
 
@@ -14,6 +33,8 @@ FFIWin64CallbackArgumentReader >> currentParameterIndex [
 FFIWin64CallbackArgumentReader >> extractStructType: type [ 
 	
 	| pointer |
+	
+	"The struct are always preallocated by the caller and they pass as a pointer."
 	
 	pointer := self basicExtractPointer.
 	extractedArguments add: (type handle: pointer at: 1).
@@ -36,7 +57,7 @@ FFIWin64CallbackArgumentReader >> nextBaseAddressFor: type [
 	
 	| baseAddressToRead offsetOfBaseAddress |
 	
-	^ self currentParameterIndex <= self numberOfRegisters 
+	^ (self currentParameterIndex <= self numberOfRegisters and: [ type typeSize <= 8])
 		ifTrue:[ 
 				"If the parameter is a floating point parameter it comes in the floating point set of registers, not in the general purpose ones."
 				baseAddressToRead := type isFloatType ifTrue: [self floatRegisterPointer] ifFalse: [self integerRegisterPointer].
@@ -57,6 +78,7 @@ FFIWin64CallbackArgumentReader >> nextBaseAddressForStructure: type [
 { #category : #accessing }
 FFIWin64CallbackArgumentReader >> numberOfRegisters [
 	
+	"Win64 only uses 4 registers (integer or float), but never more"
 	^ 4
 ]
 

--- a/src/UnifiedFFI/FFIWin64CallbackArgumentReader.class.st
+++ b/src/UnifiedFFI/FFIWin64CallbackArgumentReader.class.st
@@ -1,0 +1,57 @@
+Class {
+	#name : #FFIWin64CallbackArgumentReader,
+	#superclass : #FFICallbackArgumentReader,
+	#category : #'UnifiedFFI-Architecture'
+}
+
+{ #category : #accessing }
+FFIWin64CallbackArgumentReader >> currentParameterIndex [
+	
+	^ extractedArguments size + 1
+]
+
+{ #category : #accessing }
+FFIWin64CallbackArgumentReader >> floatRegisterPointer [
+	
+	^ callbackContext floatregargsp
+]
+
+{ #category : #accessing }
+FFIWin64CallbackArgumentReader >> integerRegisterPointer [
+	
+	^ callbackContext intregargsp
+]
+
+{ #category : #extracting }
+FFIWin64CallbackArgumentReader >> nextBaseAddressFor: type [
+	
+	| baseAddressToRead offsetOfBaseAddress |
+	
+	^ self currentParameterIndex <= self numberOfRegisters 
+		ifTrue:[ 
+				"If the parameter is a floating point parameter it comes in the floating point set of registers, not in the general purpose ones."
+				baseAddressToRead := type isFloatType ifTrue: [self floatRegisterPointer] ifFalse: [self integerRegisterPointer].
+				offsetOfBaseAddress := (self currentParameterIndex - 1) * Smalltalk wordSize + 1.
+				{ baseAddressToRead. offsetOfBaseAddress }] 
+		ifFalse:[ super nextBaseAddressFor: type ].
+
+
+]
+
+{ #category : #accessing }
+FFIWin64CallbackArgumentReader >> numberOfRegisters [
+	
+	^ 6
+]
+
+{ #category : #types }
+FFIWin64CallbackArgumentReader >> stackIntegerType [
+	
+	^ FFIInt64 new
+]
+
+{ #category : #types }
+FFIWin64CallbackArgumentReader >> stackUnsignedIntegerType [
+	
+	^ FFIUInt64 new
+]

--- a/src/UnifiedFFI/FFIWin64CallbackArgumentReader.class.st
+++ b/src/UnifiedFFI/FFIWin64CallbackArgumentReader.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FFIWin64CallbackArgumentReader,
-	#superclass : #FFICallbackArgumentReader,
+	#superclass : #FFIAbstract64BitsArgumentReader,
 	#category : #'UnifiedFFI-Architecture'
 }
 
@@ -8,6 +8,15 @@ Class {
 FFIWin64CallbackArgumentReader >> currentParameterIndex [
 	
 	^ extractedArguments size + 1
+]
+
+{ #category : #extracting }
+FFIWin64CallbackArgumentReader >> extractStructType: type [ 
+	
+	| pointer |
+	
+	pointer := self basicExtractPointer.
+	extractedArguments add: (type handle: pointer at: 1).
 ]
 
 { #category : #accessing }
@@ -22,7 +31,7 @@ FFIWin64CallbackArgumentReader >> integerRegisterPointer [
 	^ callbackContext intregargsp
 ]
 
-{ #category : #extracting }
+{ #category : #'calculating-offsets' }
 FFIWin64CallbackArgumentReader >> nextBaseAddressFor: type [
 	
 	| baseAddressToRead offsetOfBaseAddress |
@@ -32,16 +41,23 @@ FFIWin64CallbackArgumentReader >> nextBaseAddressFor: type [
 				"If the parameter is a floating point parameter it comes in the floating point set of registers, not in the general purpose ones."
 				baseAddressToRead := type isFloatType ifTrue: [self floatRegisterPointer] ifFalse: [self integerRegisterPointer].
 				offsetOfBaseAddress := (self currentParameterIndex - 1) * Smalltalk wordSize + 1.
+				currentStackOffset := currentStackOffset + Smalltalk wordSize.
 				{ baseAddressToRead. offsetOfBaseAddress }] 
 		ifFalse:[ super nextBaseAddressFor: type ].
 
 
 ]
 
+{ #category : #'calculating-offsets' }
+FFIWin64CallbackArgumentReader >> nextBaseAddressForStructure: type [
+
+	self error: 'The structures all always pointers'
+]
+
 { #category : #accessing }
 FFIWin64CallbackArgumentReader >> numberOfRegisters [
 	
-	^ 6
+	^ 4
 ]
 
 { #category : #types }

--- a/src/UnifiedFFI/FFI_i386.class.st
+++ b/src/UnifiedFFI/FFI_i386.class.st
@@ -14,6 +14,7 @@ FFI_i386 class >> isActive [
 
 { #category : #callback }
 FFI_i386 >> newCallbackArgumentReaderForCallback: aCallback inContext: aCallbackContext [
+
 	^ FFIi386CallbackArgumentReader
 		forCallback: aCallback
 		inContext: aCallbackContext

--- a/src/UnifiedFFI/FFI_i386.class.st
+++ b/src/UnifiedFFI/FFI_i386.class.st
@@ -12,14 +12,11 @@ FFI_i386 class >> isActive [
 	^ Smalltalk vm wordSize = 4
 ]
 
-{ #category : #'default abi' }
-FFI_i386 >> floatRegisterSize [
-	^ 8
-]
-
-{ #category : #'default abi' }
-FFI_i386 >> integerRegisterSize [
-	^ 4
+{ #category : #callback }
+FFI_i386 >> newCallbackArgumentReaderForCallback: aCallback inContext: aCallbackContext [
+	^ FFIi386CallbackArgumentReader
+		forCallback: aCallback
+		inContext: aCallbackContext
 ]
 
 { #category : #'default abi' }

--- a/src/UnifiedFFI/FFI_x86_64.class.st
+++ b/src/UnifiedFFI/FFI_x86_64.class.st
@@ -30,26 +30,6 @@ FFI_x86_64 >> externalULongType [
 ]
 
 { #category : #'default abi' }
-FFI_x86_64 >> floatRegisterSize [
-	^ 8
-]
-
-{ #category : #'default abi' }
-FFI_x86_64 >> integerRegisterSize [
-	^ 8
-]
-
-{ #category : #types }
-FFI_x86_64 >> longType [
-	^ FFIInt64
-]
-
-{ #category : #'default abi' }
 FFI_x86_64 >> returnSingleFloatsAsDoubles [
 	^ false
-]
-
-{ #category : #types }
-FFI_x86_64 >> ulongType [
-	^ FFIUInt64
 ]

--- a/src/UnifiedFFI/FFI_x86_64_SystemV.class.st
+++ b/src/UnifiedFFI/FFI_x86_64_SystemV.class.st
@@ -31,3 +31,11 @@ FFI_x86_64_SystemV >> maxStructureSizeToPassInRegisters [
 	"Four eightbytes according to the ABI documentation."
 	^ 16
 ]
+
+{ #category : #callbacks }
+FFI_x86_64_SystemV >> newCallbackArgumentReaderForCallback: aCallback inContext: aCallbackContext [ 
+
+	^ FFISystemV64CallbackArgumentReader
+		forCallback: aCallback
+		inContext: aCallbackContext
+]

--- a/src/UnifiedFFI/FFI_x86_64_SystemV.class.st
+++ b/src/UnifiedFFI/FFI_x86_64_SystemV.class.st
@@ -19,26 +19,11 @@ FFI_x86_64_SystemV class >> isActive [
 ]
 
 { #category : #'default abi' }
-FFI_x86_64_SystemV >> areStructuresSplitIntoRegisters [
-	^ true
-]
-
-{ #category : #'default abi' }
 FFI_x86_64_SystemV >> computeStructureRegisterPassingLayout: aStructureClass [
 	| layout |
 	aStructureClass structureSize > self maxStructureSizeToPassInRegisters ifTrue: [ ^ nil ].
 	layout := aStructureClass flatStructureLayout sysVAMD64PostProcess.
 	^ layout isPassedInMemory ifTrue: [ nil ] ifFalse: [ layout ]
-]
-
-{ #category : #'default abi' }
-FFI_x86_64_SystemV >> floatRegisterCountForParameterPassing [
-	^ 8
-]
-
-{ #category : #'default abi' }
-FFI_x86_64_SystemV >> integerRegisterCountForParameterPassing [
-	^ 6
 ]
 
 { #category : #'default abi' }

--- a/src/UnifiedFFI/FFI_x86_64_Windows.class.st
+++ b/src/UnifiedFFI/FFI_x86_64_Windows.class.st
@@ -28,3 +28,17 @@ FFI_x86_64_Windows >> externalLongType [
 FFI_x86_64_Windows >> externalULongType [
 	^ ExternalType ulong
 ]
+
+{ #category : #'instance creation' }
+FFI_x86_64_Windows >> maxStructureSizeToPassInRegisters [
+
+	^ 16
+]
+
+{ #category : #'instance creation' }
+FFI_x86_64_Windows >> newCallbackArgumentReaderForCallback: aCallback inContext: aCallbackContext [ 
+
+	^ FFIWin64CallbackArgumentReader 
+		forCallback: aCallback
+		inContext: aCallbackContext
+]

--- a/src/UnifiedFFI/FFI_x86_64_Windows.class.st
+++ b/src/UnifiedFFI/FFI_x86_64_Windows.class.st
@@ -28,28 +28,3 @@ FFI_x86_64_Windows >> externalLongType [
 FFI_x86_64_Windows >> externalULongType [
 	^ ExternalType ulong
 ]
-
-{ #category : #'default abi' }
-FFI_x86_64_Windows >> floatRegisterCountForParameterPassing [
-	^ 4
-]
-
-{ #category : #'default abi' }
-FFI_x86_64_Windows >> integerRegisterCountForParameterPassing [
-	^ 4
-]
-
-{ #category : #types }
-FFI_x86_64_Windows >> longType [
-	^ FFIInt32
-]
-
-{ #category : #'default abi' }
-FFI_x86_64_Windows >> shadowCallSpaceSize [
-	^ 32
-]
-
-{ #category : #types }
-FFI_x86_64_Windows >> ulongType [
-	^ FFIUInt32
-]

--- a/src/UnifiedFFI/FFI_x86_64_Windows.class.st
+++ b/src/UnifiedFFI/FFI_x86_64_Windows.class.st
@@ -30,12 +30,6 @@ FFI_x86_64_Windows >> externalULongType [
 ]
 
 { #category : #'instance creation' }
-FFI_x86_64_Windows >> maxStructureSizeToPassInRegisters [
-
-	^ 16
-]
-
-{ #category : #'instance creation' }
 FFI_x86_64_Windows >> newCallbackArgumentReaderForCallback: aCallback inContext: aCallbackContext [ 
 
 	^ FFIWin64CallbackArgumentReader 

--- a/src/UnifiedFFI/FFIi386CallbackArgumentReader.class.st
+++ b/src/UnifiedFFI/FFIi386CallbackArgumentReader.class.st
@@ -1,7 +1,15 @@
+"
+I am the subclass responsible of handling i386 parameter passing.
+All the parameters in i386 are passed in the stack.
+The integer types are promoted to Int32 or UInt32 depending if they are signed or unsigned.
+The structs are always passed in the stack.
+
+I do not modify the behavior of my superclass.
+"
 Class {
 	#name : #FFIi386CallbackArgumentReader,
 	#superclass : #FFICallbackArgumentReader,
-	#category : #'UnifiedFFI-Architecture'
+	#category : #'UnifiedFFI-Callbacks'
 }
 
 { #category : #types }

--- a/src/UnifiedFFI/FFIi386CallbackArgumentReader.class.st
+++ b/src/UnifiedFFI/FFIi386CallbackArgumentReader.class.st
@@ -1,0 +1,64 @@
+Class {
+	#name : #FFIi386CallbackArgumentReader,
+	#superclass : #FFICallbackArgumentReader,
+	#instVars : [
+		'returnValueHolder'
+	],
+	#category : #'UnifiedFFI-Architecture'
+}
+
+{ #category : #extracting }
+FFIi386CallbackArgumentReader >> basicExtractInteger [
+	
+	^ [ FFIInt32 new handle: self stackPointer at: currentStackOffset ]
+		ensure: [ currentStackOffset := currentStackOffset + 4 ]
+]
+
+{ #category : #extracting }
+FFIi386CallbackArgumentReader >> basicExtractUnsignedInteger [
+	
+	^ [ FFIUInt32 new handle: self stackPointer at: currentStackOffset ]
+		ensure: [ currentStackOffset := currentStackOffset + 4 ]
+]
+
+{ #category : #extracting }
+FFIi386CallbackArgumentReader >> extractDouble [
+
+	extractedArguments add: (FFIFloat64 new handle: self stackPointer at: currentStackOffset).
+	currentStackOffset := currentStackOffset + 8.
+]
+
+{ #category : #extracting }
+FFIi386CallbackArgumentReader >> extractExternalString: aFFIExternalString [ 
+	
+	extractedArguments add: (aFFIExternalString basicHandle: self stackPointer at: currentStackOffset).
+	currentStackOffset := currentStackOffset + Smalltalk wordSize. 
+]
+
+{ #category : #extracting }
+FFIi386CallbackArgumentReader >> extractFloat [
+
+	extractedArguments add: (FFIFloat32 new handle: self stackPointer at: currentStackOffset).
+	currentStackOffset := currentStackOffset + 4.
+]
+
+{ #category : #extracting }
+FFIi386CallbackArgumentReader >> extractStructType: aFFIExternalStructureType [ 
+
+	extractedArguments add: (aFFIExternalStructureType handle: self stackPointer at: currentStackOffset).
+	currentStackOffset := currentStackOffset + aFFIExternalStructureType objectClass byteSize.
+]
+
+{ #category : #extracting }
+FFIi386CallbackArgumentReader >> initialize [
+
+	| returnType |
+	super initialize.
+
+	"If the function returns an struct by copy there is a hidden parameter with a pointer storing it".
+	returnType := callback functionSpec returnType.
+	(returnType isExternalStructure and: [ returnType isPointer not ]) ifTrue: [ 
+		returnValueHolder := self stackPointer pointerAt: 1.
+		currentStackOffset := currentStackOffset + Smalltalk wordSize.
+	]
+]

--- a/src/UnifiedFFI/FFIi386CallbackArgumentReader.class.st
+++ b/src/UnifiedFFI/FFIi386CallbackArgumentReader.class.st
@@ -1,64 +1,17 @@
 Class {
 	#name : #FFIi386CallbackArgumentReader,
 	#superclass : #FFICallbackArgumentReader,
-	#instVars : [
-		'returnValueHolder'
-	],
 	#category : #'UnifiedFFI-Architecture'
 }
 
-{ #category : #extracting }
-FFIi386CallbackArgumentReader >> basicExtractInteger [
+{ #category : #types }
+FFIi386CallbackArgumentReader >> stackIntegerType [
 	
-	^ [ FFIInt32 new handle: self stackPointer at: currentStackOffset ]
-		ensure: [ currentStackOffset := currentStackOffset + 4 ]
+	^ FFIInt32 new
 ]
 
-{ #category : #extracting }
-FFIi386CallbackArgumentReader >> basicExtractUnsignedInteger [
+{ #category : #types }
+FFIi386CallbackArgumentReader >> stackUnsignedIntegerType [
 	
-	^ [ FFIUInt32 new handle: self stackPointer at: currentStackOffset ]
-		ensure: [ currentStackOffset := currentStackOffset + 4 ]
-]
-
-{ #category : #extracting }
-FFIi386CallbackArgumentReader >> extractDouble [
-
-	extractedArguments add: (FFIFloat64 new handle: self stackPointer at: currentStackOffset).
-	currentStackOffset := currentStackOffset + 8.
-]
-
-{ #category : #extracting }
-FFIi386CallbackArgumentReader >> extractExternalString: aFFIExternalString [ 
-	
-	extractedArguments add: (aFFIExternalString basicHandle: self stackPointer at: currentStackOffset).
-	currentStackOffset := currentStackOffset + Smalltalk wordSize. 
-]
-
-{ #category : #extracting }
-FFIi386CallbackArgumentReader >> extractFloat [
-
-	extractedArguments add: (FFIFloat32 new handle: self stackPointer at: currentStackOffset).
-	currentStackOffset := currentStackOffset + 4.
-]
-
-{ #category : #extracting }
-FFIi386CallbackArgumentReader >> extractStructType: aFFIExternalStructureType [ 
-
-	extractedArguments add: (aFFIExternalStructureType handle: self stackPointer at: currentStackOffset).
-	currentStackOffset := currentStackOffset + aFFIExternalStructureType objectClass byteSize.
-]
-
-{ #category : #extracting }
-FFIi386CallbackArgumentReader >> initialize [
-
-	| returnType |
-	super initialize.
-
-	"If the function returns an struct by copy there is a hidden parameter with a pointer storing it".
-	returnType := callback functionSpec returnType.
-	(returnType isExternalStructure and: [ returnType isPointer not ]) ifTrue: [ 
-		returnValueHolder := self stackPointer pointerAt: 1.
-		currentStackOffset := currentStackOffset + Smalltalk wordSize.
-	]
+	^ FFIUInt32 new
 ]


### PR DESCRIPTION
Issue: https://pharo.manuscript.com/f/cases/22891/Callbacks-with-more-than-4-parameters-in-Win64-is-not-working