### PR TITLE
22896-Creating-methods-in-a-subclass-with-a-class-using-a-trait

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -28,7 +28,7 @@ ClassDescription >> acceptsLoggingOfCompilation [
 { #category : #'accessing method dictionary' }
 ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: category [
 	| priorMethodOrNil priorOriginOrNil oldProtocol newProtocol |
-	
+
 	priorMethodOrNil := self 
 		compiledMethodAt: selector 
 		ifAbsent: [ nil ].

--- a/src/Shift-Changes/ShClassChanged.class.st
+++ b/src/Shift-Changes/ShClassChanged.class.st
@@ -22,5 +22,10 @@ ShClassChanged >> builder: anObject [
 
 { #category : #propagating }
 ShClassChanged >> propagateToSubclasses: anotherBuilder [
-	anotherBuilder changes add: self.
+
+	anotherBuilder changes add: (ShSuperclassChanged new
+		builder: builder;
+		oldClass: oldClass;
+		yourself
+	).
 ]

--- a/src/Shift-Changes/ShClassChanged.class.st
+++ b/src/Shift-Changes/ShClassChanged.class.st
@@ -19,3 +19,8 @@ ShClassChanged >> builder: anObject [
 	builder := anObject.
 	oldClass := builder oldClass copyForAnnouncement.
 ]
+
+{ #category : #propagating }
+ShClassChanged >> propagateToSubclasses: anotherBuilder [
+	anotherBuilder changes add: self.
+]

--- a/src/Shift-Changes/ShSuperclassChanged.class.st
+++ b/src/Shift-Changes/ShSuperclassChanged.class.st
@@ -1,0 +1,18 @@
+"
+I model the change in a superclass that should be propagated to the subclasses.
+"
+Class {
+	#name : #ShSuperclassChanged,
+	#superclass : #ShAbstractChange,
+	#category : #'Shift-Changes'
+}
+
+{ #category : #testing }
+ShSuperclassChanged >> hasToMigrateInstances [
+	^ true.
+]
+
+{ #category : #testing }
+ShSuperclassChanged >> propagateToSubclasses: anotherBuilder [
+	anotherBuilder changes add: self
+]

--- a/src/TraitsV2-Tests/T2SubclassingTraitedClassTest.class.st
+++ b/src/TraitsV2-Tests/T2SubclassingTraitedClassTest.class.st
@@ -1,0 +1,36 @@
+Class {
+	#name : #T2SubclassingTraitedClassTest,
+	#superclass : #T2AbstractTest,
+	#category : #'TraitsV2-Tests-Tests'
+}
+
+{ #category : #tests }
+T2SubclassingTraitedClassTest >> testCreatingMethodInSubclass [
+	| t1 c1 c2 |
+	t1 := self newTrait: #T1 with: #() uses: {}.
+	c1 := self newClass: #C1 with: #()  uses: t1.
+
+	c2 := self newClass: #C2 superclass: c1 with: #() uses: {}.
+
+	c2 compile: 'asd'.
+
+	self shouldnt: [c2 >> #asd] raise: Error.
+	self assert: (c2 >> #asd) package name equals: 'TraitsV2-Tests'.
+	self assert: (c2 >> #asd) package equals: c2 package.
+]
+
+{ #category : #tests }
+T2SubclassingTraitedClassTest >> testCreatingMethodInSubclass2 [
+	| t1 c1 c2 |
+	c1 := self newClass: #C1 with: #() uses: {}.
+	c2 := self newClass: #C2 superclass: c1 with: #() uses: {}.
+
+	t1 := self newTrait: #T1 with: #() uses: {}.
+	c1 := self newClass: #C1 with: #() uses: t1.
+
+	c2 compile: 'asd'.
+
+	self shouldnt: [c2 >> #asd] raise: Error.
+	self assert: (c2 >> #asd) package name equals: 'TraitsV2-Tests'.
+	self assert: (c2 >> #asd) package equals: c2 package.
+]

--- a/src/TraitsV2-Tests/T2TraitTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitTest.class.st
@@ -155,32 +155,6 @@ T2TraitTest >> testMethodsAddedInMetaclassPresentInSubclassesAfterRemovingSuperc
 ]
 
 { #category : #tests }
-T2TraitTest >> testSelectorsWithExplicitOrigin [
-	"Obtain the subset of selectors that are defined either locally or inherited from traits. But, exclude selectors of methods from implicit traits such as TraitedClass"
-	| t1 c1 |
-	
-	t1 := self newTrait: #T1 with: #().	
-	t1 compile: 'instanceSideMethod'.
-	t1 class compile: 'classSideMethod'.
-	c1 := self newClass: #C1 with: #() uses: t1.
-	self assertCollection: c1 selectorsWithExplicitOrigin hasSameElements: #(instanceSideMethod).
-	self assertCollection: c1 class selectorsWithExplicitOrigin hasSameElements: #(classSideMethod).
-
-]
-
-{ #category : #tests }
-T2TraitTest >> testSelectorsWithExplicitOriginNoTrait [
-	"Obtain the subset of selectors that are defined either locally or inherited from traits. But, exclude selectors of methods from implicit traits such as TraitedClass"
-	| c1 |	
-	c1 := self newClass: #C1.
-	c1 compile: 'instanceSideMethod'.
-	c1 class compile: 'classSideMethod'.
-	self assertCollection: c1 selectorsWithExplicitOrigin hasSameElements: #(instanceSideMethod).
-	self assertCollection: c1 class selectorsWithExplicitOrigin hasSameElements: #(classSideMethod).
-
-]
-
-{ #category : #tests }
 T2TraitTest >> testRemovingTraitsRemoveTraitedClassMethods [
 	| t1 t2 c1 |
 	
@@ -212,6 +186,32 @@ T2TraitTest >> testRemovingTraitsRemoveTraitedClassMethodsWithSubclasses [
 	self deny: (c1 class includesSelector: #traits).
 	self assert: (c2 class includesSelector: #traits).
 	
+]
+
+{ #category : #tests }
+T2TraitTest >> testSelectorsWithExplicitOrigin [
+	"Obtain the subset of selectors that are defined either locally or inherited from traits. But, exclude selectors of methods from implicit traits such as TraitedClass"
+	| t1 c1 |
+	
+	t1 := self newTrait: #T1 with: #().	
+	t1 compile: 'instanceSideMethod'.
+	t1 class compile: 'classSideMethod'.
+	c1 := self newClass: #C1 with: #() uses: t1.
+	self assertCollection: c1 selectorsWithExplicitOrigin hasSameElements: #(instanceSideMethod).
+	self assertCollection: c1 class selectorsWithExplicitOrigin hasSameElements: #(classSideMethod).
+
+]
+
+{ #category : #tests }
+T2TraitTest >> testSelectorsWithExplicitOriginNoTrait [
+	"Obtain the subset of selectors that are defined either locally or inherited from traits. But, exclude selectors of methods from implicit traits such as TraitedClass"
+	| c1 |	
+	c1 := self newClass: #C1.
+	c1 compile: 'instanceSideMethod'.
+	c1 class compile: 'classSideMethod'.
+	self assertCollection: c1 selectorsWithExplicitOrigin hasSameElements: #(instanceSideMethod).
+	self assertCollection: c1 class selectorsWithExplicitOrigin hasSameElements: #(classSideMethod).
+
 ]
 
 { #category : #tests }

--- a/src/TraitsV2/TraitBuilderEnhancer.class.st
+++ b/src/TraitsV2/TraitBuilderEnhancer.class.st
@@ -178,7 +178,7 @@ TraitBuilderEnhancer >> isTraitedMetaclass: aBuilder [
 { #category : #'class modifications' }
 TraitBuilderEnhancer >> newMetaclass: aBuilder [
 
-	(aBuilder traitComposition asTraitComposition isNotEmpty or: [ aBuilder classTraitComposition asTraitComposition isNotEmpty ])
+	(aBuilder traitComposition asTraitComposition isNotEmpty or: [ aBuilder classTraitComposition asTraitComposition isNotEmpty or: [ aBuilder superclass class class = TraitedMetaclass]])
 		ifTrue: [ aBuilder metaclassClass: TraitedMetaclass ].
 				
 	aBuilder metaSuperclass = Trait


### PR DESCRIPTION
The subclasses of a traited metaclass should be a traited metaclass.Issue: https://pharo.manuscript.com/f/cases/22896/Creating-methods-in-a-subclass-with-a-class-using-a-trait