### PR TITLE
22887-TonelWritercreateDefaultOrganizationFrom-can-return-string

### DIFF
--- a/bootstrap/src/BaselineOfPharoBootstrapProcess.package/BaselineOfPharoBootstrapProcess.class/instance/baseline..st
+++ b/bootstrap/src/BaselineOfPharoBootstrapProcess.package/BaselineOfPharoBootstrapProcess.class/instance/baseline..st
@@ -5,7 +5,7 @@ baseline: spec
 	spec for: #common do: [
 		spec blessing: #baseline.
 		spec baseline: 'Tonel' with: [ spec
-			repository: 'github://pharo-vcs/tonel:v1.0.12' ].
+			repository: 'github://pharo-vcs/tonel:v1.0.13' ].
 		spec baseline: 'Hermes' with: [ spec
 			repository: 'github://tesonep/hermes:v2.4.1';
   			loads: 'core' ].

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -859,7 +859,7 @@ BaselineOfIDE >> loadCalypso [
 BaselineOfIDE >> loadIceberg [
 	Metacello new
 		baseline: 'Iceberg';
-		repository: 'github://pharo-vcs/iceberg:v1.5.4';
+		repository: 'github://pharo-vcs/iceberg:v1.5.5';
 		load.
 	(Smalltalk classNamed: #Iceberg) enableMetacelloIntegration: true.
 	(Smalltalk classNamed: #IcePharoPlugin) addPharoProjectToIceberg.


### PR DESCRIPTION
update iceberg to 1.5.5

https://pharo.manuscript.com/f/cases/22887/TonelWriter-createDefaultOrganizationFrom-can-return-string