### PR TITLE
2291-Resizing-a-FastTable-mess-with-column-width

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTExamples.class.st
+++ b/src/Morphic-Widgets-FastTable/FTExamples.class.st
@@ -501,6 +501,7 @@ FTExamples class >> exampleTable1 [
 		onAnnouncement: FTStrongSelectionChanged 
 			do: [ :ann | ('double-click on row: ', (ann selectedRowIndex asString)) crLog ];
 		beMultipleSelection;
+		beResizable;
 		yourself.
 		
 	^ table openInWindow
@@ -526,6 +527,7 @@ FTExamples class >> exampleTable2 [
 		onAnnouncement: FTStrongSelectionChanged 
 			do: [ :ann | ('double-click on row: ', (ann selectedRowIndex asString)) crLog ];
 		beMultipleSelection;
+		beResizable;
 		yourself.
 		
 	^ table openInWindow
@@ -553,6 +555,7 @@ FTExamples class >> exampleTable3 [
 		onAnnouncement: FTStrongSelectionChanged 
 			do: [ :ann | ('double-click on row: ', (ann selectedRowIndex asString)) crLog ];
 		beMultipleSelection;
+		beResizable;
 		yourself.
 		
 	^ table openInWindow
@@ -582,6 +585,7 @@ FTExamples class >> exampleTable4 [
 		onAnnouncement: FTStrongSelectionChanged 
 			do: [ :ann | ('double-click on row: ', (ann selectedRowIndex asString)) crLog ];
 		beMultipleSelection;
+		beResizable;
 		yourself.
 		
 	^ table openInWindow

--- a/src/Morphic-Widgets-FastTable/FTTableContainerMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableContainerMorph.class.st
@@ -67,24 +67,25 @@ FTTableContainerMorph >> calculateColumnWidths [
 	- collect remaining undefined columnwidth 
 	- return if all fit 
 	  or collect and distribute remaining width"
-	| undefinedColumnWidths widths remainingWidth |
 
+	| undefinedColumnWidths widths remainingWidth |
 	remainingWidth := self owner bounds width.
 
 	widths := self owner columns
-		collect: [ :c | | columnWidth | 
-			columnWidth := c acquireWidth: remainingWidth. 
-			remainingWidth := remainingWidth - columnWidth. 
+		collect: [ :c | 
+			| columnWidth |
+			columnWidth := c acquireWidth: remainingWidth.
+			remainingWidth := remainingWidth - columnWidth.
 			columnWidth ].
-   "all fit - finish"		
-	undefinedColumnWidths := widths count: #isZero.
-   undefinedColumnWidths isZero ifTrue:[^ widths].
 
-   "collect and distribute remaining space"
-	^ widths collect: [ :c | 
-		c = 0
-			ifTrue: [ remainingWidth / undefinedColumnWidths]
-			ifFalse: [ c ] ]
+	"all fit - finish"
+	undefinedColumnWidths := widths count: #isZero.
+	undefinedColumnWidths isZero
+		ifTrue: [ widths size > 1 ifTrue: [ "Set the remaining space to the last column" widths at: widths size put: widths last + remainingWidth ].
+			^ widths ].
+
+	"collect and distribute remaining space"
+	^ widths collect: [ :c | c = 0 ifTrue: [ remainingWidth / undefinedColumnWidths ] ifFalse: [ c ] ]
 ]
 
 { #category : #private }

--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -815,22 +815,11 @@ FTTableMorph >> resizeAllSubviews [
 	 can be toggled, shown items can change, etc.)"
 	self recalculateVerticalScrollBar.
 	self resizeContainer.
-	self resizeColumns.
 	self container setNeedsRefreshExposedRows.
 	self container updateExposedRows.
 	self verticalScrollBar value: (self rowIndexToVerticalScrollBarValue: showIndex).
 	function isExplicite
 		ifTrue: [ function resizeWidget ]
-]
-
-{ #category : #private }
-FTTableMorph >> resizeColumns [
-	"Resize columns just has sense if there is more than one column, otherwise it will be resized 
-	 to row size, so I can safely skip the resize part if I have just one (and then I avoid 
-	 redundancy)"
-	self columns size > 1 ifFalse: [ ^ self ].
-	self columns last 
-		width: (self width - (self columns allButLast sum: [ :each | each width ifNil: [0]]))
 ]
 
 { #category : #private }


### PR DESCRIPTION
FTTableMorph should not resize column. It should be managed on redraw. 

I also added resizers to examples.

Fixes #2291