### PR TITLE
22901-Image-crash-on-commit-and-push-in-windows-64bit

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -859,7 +859,7 @@ BaselineOfIDE >> loadCalypso [
 BaselineOfIDE >> loadIceberg [
 	Metacello new
 		baseline: 'Iceberg';
-		repository: 'github://pharo-vcs/iceberg:v1.5.5';
+		repository: 'github://pharo-vcs/iceberg:v1.5.6';
 		load.
 	(Smalltalk classNamed: #Iceberg) enableMetacelloIntegration: true.
 	(Smalltalk classNamed: #IcePharoPlugin) addPharoProjectToIceberg.


### PR DESCRIPTION
Update iceberg version to restore fixes for win64 and tonel