### PR TITLE
2301-Metacello-attributes-in-Pharo-8should-return-pharo8xx-instead-of-pharo7xx

### DIFF
--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1130,7 +1130,7 @@ SmalltalkImage >> memoryHogs [
 SmalltalkImage >> metacelloPlatformAttributes [
     "Returns the tags for the conditional platform loading in Metacello. Pay attention the order is important: from most  to least general." 
     "For release integrators, we should not have #'pharo1.3x' **and** #'pharo1.4.x'"
-   ^ #(#squeakCommon #pharo #'pharo8.x' #'pharo78.0.x')
+   ^ #(#squeakCommon #pharo #'pharo8.x' #'pharo8.0.x')
 ]
 
 { #category : #'special objects' }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1130,7 +1130,7 @@ SmalltalkImage >> memoryHogs [
 SmalltalkImage >> metacelloPlatformAttributes [
     "Returns the tags for the conditional platform loading in Metacello. Pay attention the order is important: from most  to least general." 
     "For release integrators, we should not have #'pharo1.3x' **and** #'pharo1.4.x'"
-   ^ #(#squeakCommon #pharo #'pharo7.x' #'pharo7.0.x')
+   ^ #(#squeakCommon #pharo #'pharo8.x' #'pharo78.0.x')
 ]
 
 { #category : #'special objects' }


### PR DESCRIPTION
Update Metacello tags for P8

FIxes #2301