### PR TITLE
2309-Add-assertIsEmpty

### DIFF
--- a/src/AST-Tests-Core/RBParserTest.class.st
+++ b/src/AST-Tests-Core/RBParserTest.class.st
@@ -304,18 +304,12 @@ RBParserTest >> testIsA [
 	| nodes types |
 	nodes := Bag new.
 	types := Set new.
-	#(#(#isAssignment 1) #(#isBlock 1) #(#isCascade 1) #(#isLiteralNode 2) #(#isMessage 3) #(#isMethod 1) #(#isReturn 1) #(#isSequence 2) #(#isValue 15) #(#isVariable 7) #(#isUsed 10) #(#isDirectlyUsed 9) #(#hasParentheses 1) #(#isBinary 0) #(#isPrimitive 0) #(#isImmediateNode 10) #(#isWrite 1) #(#isRead 3)) 
-		do: 
-			[:each | 
-			each last timesRepeat: [nodes add: each first].
-			types add: each first].
-	self treeWithEverything nodesDo: 
-			[:each | 
-			types do: 
-					[:sel | 
-					((each respondsTo: sel) and: [each perform: sel]) 
-						ifTrue: [nodes remove: sel]]].
-	self assert: nodes isEmpty
+	#(#(#isAssignment 1) #(#isBlock 1) #(#isCascade 1) #(#isLiteralNode 2) #(#isMessage 3) #(#isMethod 1) #(#isReturn 1) #(#isSequence 2) #(#isValue 15) #(#isVariable 7) #(#isUsed 10) #(#isDirectlyUsed 9) #(#hasParentheses 1) #(#isBinary 0) #(#isPrimitive 0) #(#isImmediateNode 10) #(#isWrite 1) #(#isRead 3))
+		do: [ :each | 
+			each last timesRepeat: [ nodes add: each first ].
+			types add: each first ].
+	self treeWithEverything nodesDo: [ :each | types do: [ :sel | ((each respondsTo: sel) and: [ each perform: sel ]) ifTrue: [ nodes remove: sel ] ] ].
+	self assertEmpty: nodes
 ]
 
 { #category : #'tests parsing' }
@@ -360,8 +354,7 @@ RBParserTest >> testMethodPatterns [
 { #category : #tests }
 RBParserTest >> testModifying [
 	| tree |
-	tree := self parserClass  
-				parseMethod: 'foo: a bar: b | c | self first. self second. a + b + c'.
+	tree := self parserClass parseMethod: 'foo: a bar: b | c | self first. self second. a + b + c'.
 	self deny: tree lastIsReturn.
 	self deny: (tree body statements at: 2) isUsed.
 	self assert: tree body statements last arguments first isUsed.
@@ -374,23 +367,23 @@ RBParserTest >> testModifying [
 	tree
 		addReturn;
 		selector: #bar:foo:.
-	(tree body)
+	tree body
 		addTemporaryNamed: 'd';
 		removeTemporaryNamed: 'c'.
-	self compare: tree
-		to: (self parserClass  
-				parseMethod: 'bar: a foo: b | d | self first. self second. ^a + b + c').
-	self 
-		assert: ((tree argumentNames asSet)
+	self compare: tree to: (self parserClass parseMethod: 'bar: a foo: b | d | self first. self second. ^a + b + c').
+	self
+		assertEmpty:
+			(tree argumentNames asSet
 				removeAll: #('a' 'b');
-				yourself) isEmpty.
-	self 
-		assert: ((tree allDefinedVariables asSet)
+				yourself).
+	self
+		assertEmpty:
+			(tree allDefinedVariables asSet
 				removeAll: #('a' 'b' 'd');
-				yourself) isEmpty.
-	tree := self parserClass  parseExpression: 'self foo: 0'.
+				yourself).
+	tree := self parserClass parseExpression: 'self foo: 0'.
 	tree selector: #+.
-	self compare: tree to: (self parserClass  parseExpression: 'self + 0').
+	self compare: tree to: (self parserClass parseExpression: 'self + 0')
 ]
 
 { #category : #'tests parsing' }
@@ -540,7 +533,6 @@ RBParserTest >> testParseFaultyMethodStop [
 { #category : #'tests parsing' }
 RBParserTest >> testParseMethodWithErrorTokenIsWellFormed [
 	| node strangeMethod body statement message errorNode |
-	
 	strangeMethod := '
 	selector  
 		|temp| 
@@ -550,7 +542,7 @@ RBParserTest >> testParseMethodWithErrorTokenIsWellFormed [
 
 	self assert: node isMethod.
 	self assert: node isFaulty.
-	self assert: node arguments isEmpty.
+	self assertEmpty: node arguments.
 
 	body := node body.
 	self assert: body isSequence.
@@ -559,20 +551,20 @@ RBParserTest >> testParseMethodWithErrorTokenIsWellFormed [
 
 	statement := body statements first.
 	self assert: statement isFaulty.
-	self assert: statement isAssignment .
-	
+	self assert: statement isAssignment.
+
 	message := statement value.
 	self assert: message isFaulty.
 	self assert: message arguments size equals: 1.
 
 	errorNode := message arguments at: 1.
 	self assert: errorNode isFaulty.
-	self assert: errorNode value equals: 'wrong because no end.
+	self
+		assert: errorNode value
+		equals:
+			'wrong because no end.
 		^temp'.
 	self assert: errorNode errorMessage equals: 'Unmatched '' in string literal.' translated
-	
-	
-	
 ]
 
 { #category : #'tests parsing' }

--- a/src/AST-Tests-Core/RBReadBeforeWrittenTesterTest.class.st
+++ b/src/AST-Tests-Core/RBReadBeforeWrittenTesterTest.class.st
@@ -38,9 +38,13 @@ RBReadBeforeWrittenTesterTest >> testReadBeforeWritten [
 
 { #category : #tests }
 RBReadBeforeWrittenTesterTest >> testReadBeforeWritten1 [
-	self 
-		assert: (RBReadBeforeWrittenTester variablesReadBeforeWrittenIn: (RBParser 
-						parseMethod: 'addAll: aCollection 
+	self
+		assertEmpty:
+			(RBReadBeforeWrittenTester
+				variablesReadBeforeWrittenIn:
+					(RBParser
+						parseMethod:
+							'addAll: aCollection 
 	"Answer aCollection, having added all elements
 	 of aCollection to the receiver.
 
@@ -68,6 +72,5 @@ RBReadBeforeWrittenTesterTest >> testReadBeforeWritten1 [
 						ifFalse: [element == newObject]]
 							whileFalse: 
 								[(hashIndex := hashIndex + 1) > elementsSize ifTrue: [hashIndex := 1]]]].
-	^aCollection')) 
-				isEmpty
+	^aCollection'))
 ]

--- a/src/Collections-DoubleLinkedList-Tests/DoubleLinkedListTests.class.st
+++ b/src/Collections-DoubleLinkedList-Tests/DoubleLinkedListTests.class.st
@@ -74,11 +74,10 @@ DoubleLinkedListTests >> testDo [
 DoubleLinkedListTests >> testEmpty [
 	| list |
 	list := DoubleLinkedList new.
-	self assert: list isEmpty.
+	self assertEmpty: list.
 	self should: [ list first ] raise: CollectionIsEmpty.
 	self should: [ list last ] raise: CollectionIsEmpty.
 	list do: [ :each | self fail ]
-	
 ]
 
 { #category : #testing }
@@ -145,10 +144,10 @@ DoubleLinkedListTests >> testOneRemoveFirst [
 	list := DoubleLinkedList new.
 	list add: #one.
 	list removeFirst.
-	self assert: list isEmpty.
+	self assertEmpty: list.
 	list add: #one.
 	list removeLast.
-	self assert: list isEmpty
+	self assertEmpty: list
 ]
 
 { #category : #testing }
@@ -157,10 +156,10 @@ DoubleLinkedListTests >> testOneRemoveLast [
 	list := DoubleLinkedList new.
 	list add: #one.
 	list removeLast.
-	self assert: list isEmpty.
+	self assertEmpty: list.
 	list add: #one.
 	list removeLast.
-	self assert: list isEmpty
+	self assertEmpty: list
 ]
 
 { #category : #testing }

--- a/src/Collections-Tests/ArrayTest.class.st
+++ b/src/Collections-Tests/ArrayTest.class.st
@@ -524,7 +524,7 @@ ArrayTest >> subCollectionNotIn [
 ArrayTest >> test0FixtureIncludeTest [
 	| anElementIn |
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self elementNotIn.
 	anElementIn := true.
 	self nonEmpty detect: [ :each | each = self elementNotIn ] ifNone: [ anElementIn := false ].
@@ -532,24 +532,24 @@ ArrayTest >> test0FixtureIncludeTest [
 	self anotherElementNotIn.
 	anElementIn := true.
 	self nonEmpty detect: [ :each | each = self anotherElementNotIn ] ifNone: [ anElementIn := false ].
-	self assert: anElementIn equals: false.
+	self deny: anElementIn.
 	self collection.
 	self empty.
-	self assert: self empty isEmpty.
+	self assertEmpty: self empty.
 	self collectionOfFloat.
 	self collectionOfFloat do: [ :each | self assert: each isFloat ].
 	self elementInForIncludesTest.
 	anElementIn := true.
 	self nonEmpty detect: [ :each | each = self elementInForIncludesTest ] ifNone: [ anElementIn := false ].
-	self assert: anElementIn equals: true
+	self assert: anElementIn
 ]
 
 { #category : #'tests - fixture' }
 ArrayTest >> test0FixtureOccurrencesTest [
 	self empty.
-	self assert: self empty isEmpty.
+	self assertEmpty: self empty.
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self elementInForOccurrences.
 	self assert: (self nonEmpty includes: self elementInForOccurrences).
 	self elementNotInForOccurrences.

--- a/src/Collections-Tests/BagTest.class.st
+++ b/src/Collections-Tests/BagTest.class.st
@@ -404,8 +404,8 @@ BagTest >> testCopyNonEmptyWithoutAllNotIncluded [
 BagTest >> testCreation [
 	| bag |
 	bag := Bag new.
-	self assert: (bag size) equals: 0.
-	self assert: (bag isEmpty)
+	self assert: bag size equals: 0.
+	self assertEmpty: bag
 ]
 
 { #category : #tests }
@@ -450,12 +450,12 @@ BagTest >> testEqual [
 BagTest >> testFlatCollect [
 	| bag |
 	bag := Bag new.
-	bag add: { 1. 2. 3 }.
-	bag add: { 4. 5. 6 }.
+	bag add: {1 . 2 . 3}.
+	bag add: {4 . 5 . 6}.
 
 	self assert: (bag flatCollect: [ :x | x ]) equals: #(1 2 3 4 5 6) asBag.
 	self assert: (bag flatCollect: [ :x | x ]) class == Bag.
-	self assert: (#() asBag flatCollect: [:x | 1 to: 4 ]) isEmpty
+	self assertEmpty: (#() asBag flatCollect: [ :x | 1 to: 4 ])
 ]
 
 { #category : #'tests - includes' }
@@ -501,19 +501,19 @@ BagTest >> testOccurrencesOf [
 BagTest >> testRemove [
 	| bag item |
 	item := 'test item'.
-	bag := Bag new. 
-	
+	bag := Bag new.
+
 	bag add: item.
-	self assert: (bag size) equals: 1.
+	self assert: bag size equals: 1.
 	bag remove: item.
-	self assert: bag isEmpty.
-	
+	self assertEmpty: bag.
+
 	bag add: item withOccurrences: 2.
 	bag remove: item.
 	bag remove: item.
-	self assert: (bag size) equals: 0.
-	
-	self should: [bag remove: item.] raise: Error
+	self assert: bag size equals: 0.
+
+	self should: [ bag remove: item ] raise: Error
 ]
 
 { #category : #tests }

--- a/src/Collections-Tests/HeapTest.class.st
+++ b/src/Collections-Tests/HeapTest.class.st
@@ -443,8 +443,8 @@ HeapTest >> test0FixtureRequirementsOfTGrowableTest [
 	self nonEmpty.
 	self element.
 	self elementNotInForOccurrences.
-	self assert: self empty isEmpty.
-	self deny: self nonEmpty isEmpty.
+	self assertEmpty: self empty.
+	self denyEmpty: self nonEmpty.
 	self assert: (self nonEmpty includes: self element).
 	self deny: (self nonEmpty includes: self elementNotInForOccurrences)
 ]
@@ -523,14 +523,13 @@ HeapTest >> testFirst [
 
 { #category : #'basic tests' }
 HeapTest >> testHeap [
-	| heap | 
+	| heap |
 	heap := Heap new.
 	self assert: heap isHeap.
-	
-	self assert: heap isEmpty.
-	heap add: 1.
-	self deny: heap isEmpty
 
+	self assertEmpty: heap.
+	heap add: 1.
+	self denyEmpty: heap
 ]
 
 { #category : #tests }

--- a/src/Collections-Tests/LinkedListTest.class.st
+++ b/src/Collections-Tests/LinkedListTest.class.st
@@ -328,22 +328,22 @@ LinkedListTest >> tearDown [
 
 { #category : #tests }
 LinkedListTest >> test01add [
-	self assert: list isEmpty.
+	self assertEmpty: list.
 	list add: link1.
 	self assert: list size = 1.
 	self assert: list first = link1.
-	
+
 	list add: link2.
 	self assert: list size = 2.
 	self assert: list first = link1.
 	self assert: list second = link2.
-	
+
 	list add: link3.
 	self assert: list size = 3.
 	self assert: list first = link1.
 	self assert: list second = link2.
 	self assert: list third = link3.
-	
+
 	list add: link4.
 	self assert: list size = 4.
 	self assert: list first = link1.
@@ -354,23 +354,23 @@ LinkedListTest >> test01add [
 
 { #category : #tests }
 LinkedListTest >> test02addLast [
-	self assert: list isEmpty.
-	
+	self assertEmpty: list.
+
 	list addLast: link1.
 	self assert: list size = 1.
 	self assert: list first = link1.
-	
+
 	list addLast: link2.
 	self assert: list size = 2.
 	self assert: list first = link1.
 	self assert: list second = link2.
-	
+
 	list addLast: link3.
 	self assert: list size = 3.
 	self assert: list first = link1.
 	self assert: list second = link2.
 	self assert: list third = link3.
-	
+
 	list addLast: link4.
 	self assert: list size = 4.
 	self assert: list first = link1.
@@ -381,23 +381,23 @@ LinkedListTest >> test02addLast [
 
 { #category : #tests }
 LinkedListTest >> test03addFirst [
-	self assert: list isEmpty.
-	
+	self assertEmpty: list.
+
 	list addFirst: link1.
 	self assert: list size = 1.
 	self assert: list first = link1.
-	
+
 	list addFirst: link2.
 	self assert: list size = 2.
 	self assert: list first = link2.
 	self assert: list second = link1.
-	
+
 	list addFirst: link3.
 	self assert: list size = 3.
 	self assert: list first = link3.
 	self assert: list second = link2.
 	self assert: list third = link1.
-	
+
 	list addFirst: link4.
 	self assert: list size = 4.
 	self assert: list first = link4.
@@ -408,23 +408,23 @@ LinkedListTest >> test03addFirst [
 
 { #category : #tests }
 LinkedListTest >> test04addBefore [
-	self assert: list isEmpty.
-	
+	self assertEmpty: list.
+
 	list add: link1.
 	self assert: list size = 1.
 	self assert: list first == link1.
-	
+
 	list add: link2 before: link1.
 	self assert: list size = 2.
 	self assert: list first == link2.
 	self assert: list second == link1.
-	
+
 	list add: link3 before: link1.
 	self assert: list size = 3.
 	self assert: list first == link2.
 	self assert: list second == link3.
 	self assert: list third == link1.
-	
+
 	list add: link4 before: link1.
 	self assert: list size = 4.
 	self assert: list first == link2.
@@ -435,7 +435,7 @@ LinkedListTest >> test04addBefore [
 
 { #category : #tests }
 LinkedListTest >> test05addBefore [
-	self assert: list isEmpty.
+	self assertEmpty: list.
 	
 	list add: link1.
 	self assert: list size = 1.
@@ -462,7 +462,7 @@ LinkedListTest >> test05addBefore [
 
 { #category : #tests }
 LinkedListTest >> test06addAfter [
-	self assert: list isEmpty.
+	self assertEmpty: list.
 	
 	list add: link1.
 	self assert: list size = 1.
@@ -489,7 +489,7 @@ LinkedListTest >> test06addAfter [
 
 { #category : #tests }
 LinkedListTest >> test07addAfter [
-	self assert: list isEmpty.
+	self assertEmpty: list.
 	
 	list add: link1.
 	self assert: list size = 1.
@@ -590,7 +590,7 @@ LinkedListTest >> test10removeFirst [
 	self assert: list first == link4.
 	
 	list removeFirst.
-	self assert: list isEmpty
+	self assertEmpty: list
 ]
 
 { #category : #tests }
@@ -622,7 +622,7 @@ LinkedListTest >> test11removeLast [
 	self assert: list first == link1.
 	
 	list removeFirst.
-	self assert: list isEmpty
+	self assertEmpty: list
 ]
 
 { #category : #tests }
@@ -654,7 +654,7 @@ LinkedListTest >> test12remove [
 	self assert: list first == link4.
 	
 	list remove: link4.
-	self assert: list isEmpty
+	self assertEmpty: list
 ]
 
 { #category : #tests }
@@ -663,48 +663,48 @@ LinkedListTest >> test13remove [
 	list add: link2.
 	list add: link3.
 	list add: link4.
-	
+
 	self assert: list size = 4.
 	self assert: list first == link1.
 	self assert: list second == link2.
 	self assert: list third == link3.
 	self assert: list fourth == link4.
-	
+
 	list remove: link1.
 	self assert: list size = 3.
 	self assert: list first == link2.
 	self assert: list second == link3.
 	self assert: list third == link4.
-	
+
 	list remove: link4.
 	self assert: list size = 2.
 	self assert: list first == link2.
 	self assert: list second == link3.
-	
+
 	list remove: link2.
 	self assert: list size = 1.
 	self assert: list first == link3.
-	
+
 	list remove: link3.
-	self assert: list isEmpty
+	self assertEmpty: list
 ]
 
 { #category : #tests }
 LinkedListTest >> test14removeIfAbsent [
 	list add: link1.
-	
+
 	self assert: list size = 1.
 	self assert: list first == link1.
-	
+
 	list remove: link1.
-	self assert: list isEmpty.
-	
-	[list remove: link1]
+	self assertEmpty: list.
+
+	[ list remove: link1 ]
 		on: Error
-		do: [^ self].
-		
+		do: [ ^ self ].
+
 	"The execution should not get here. If yes, something went wrong."
-	self assert: false
+	self fail
 ]
 
 { #category : #tests }

--- a/src/Collections-Tests/OrderedCollectionTest.class.st
+++ b/src/Collections-Tests/OrderedCollectionTest.class.st
@@ -835,24 +835,24 @@ OrderedCollectionTest >> testCollectFromTo [
 OrderedCollectionTest >> testCompact [
 	| collection |
 	collection := OrderedCollection new.
-	self assert: collection isEmpty.
+	self assertEmpty: collection.
 	self assert: collection capacity equals: 10.
 	collection compact.
 	self assert: collection capacity equals: 0.
-	
+
 	collection := OrderedCollection new.
 	collection add: 1.
 	collection compact.
 	self assert: collection capacity equals: 1.
-	
+
 	collection growAtLast.
 	collection compact.
 	self assert: collection capacity equals: 1.
-	
+
 	"we do not shrink the start for now"
 	collection growAtFirst.
 	collection compact.
-	self assert: collection capacity equals: 2.
+	self assert: collection capacity equals: 2
 ]
 
 { #category : #'tests - copying' }
@@ -868,21 +868,17 @@ OrderedCollectionTest >> testCopyEmptyOld [
 { #category : #'tests - copying' }
 OrderedCollectionTest >> testCopyFromTo [
 	"Allows one to create a copy of the receiver that contains elements from position start to end"
-	
-	| c1 c2 c3 | 
-	c1 := #(1 2 3 4) asOrderedCollection.
-	c2 := (c1 copyFrom: 1 to: 2).
-	self assert: c2 equals: #(1 2) asOrderedCollection.
-	self should: [c1 copyFrom: 10 to: 20] raise: Error.
-	
-	c3 := c1 copyFrom: 4 to: 2.
-	self assert: c3 isEmpty.
-	
-	self should: [c1 copyFrom: 4 to: 5 ] raise: Error.
-	
-	
-	
 
+	| c1 c2 c3 |
+	c1 := #(1 2 3 4) asOrderedCollection.
+	c2 := c1 copyFrom: 1 to: 2.
+	self assert: c2 equals: #(1 2) asOrderedCollection.
+	self should: [ c1 copyFrom: 10 to: 20 ] raise: Error.
+
+	c3 := c1 copyFrom: 4 to: 2.
+	self assertEmpty: c3.
+
+	self should: [ c1 copyFrom: 4 to: 5 ] raise: Error
 ]
 
 { #category : #'tests - copy' }

--- a/src/Collections-Tests/OrderedDictionaryTest.class.st
+++ b/src/Collections-Tests/OrderedDictionaryTest.class.st
@@ -691,28 +691,17 @@ OrderedDictionaryTest >> testCopyEmpty [
 { #category : #tests }
 OrderedDictionaryTest >> testDeclareFrom [
 	| dictionary otherDictionary |
-
 	dictionary := self emptyDictionary.
 	otherDictionary := self dictionaryWithOrderedAssociations.
-	self orderedKeys do: [:each |
-		self assert:
-			(dictionary
-				declare: each
-				from: otherDictionary) == dictionary].
-	self
-		assertIsDictionary: dictionary
-		withOrderedAssociations: self orderedAssociations.
-	self assert: otherDictionary isEmpty.
+	self orderedKeys do: [ :each | self assert: (dictionary declare: each from: otherDictionary) == dictionary ].
+	self assertIsDictionary: dictionary withOrderedAssociations: self orderedAssociations.
+	self assertEmpty: otherDictionary.
 
-	self orderedKeys do: [:each |
-		otherDictionary add: (each -> self newValue).
-		self assert:
-			(dictionary
-				declare: each
-				from: otherDictionary) == dictionary].
-	self
-		assertIsDictionary: dictionary
-		withOrderedAssociations: self orderedAssociations.
+	self orderedKeys
+		do: [ :each | 
+			otherDictionary add: each -> self newValue.
+			self assert: (dictionary declare: each from: otherDictionary) == dictionary ].
+	self assertIsDictionary: dictionary withOrderedAssociations: self orderedAssociations
 ]
 
 { #category : #tests }
@@ -1123,31 +1112,24 @@ OrderedDictionaryTest >> testKeysAndValuesDo [
 { #category : #tests }
 OrderedDictionaryTest >> testKeysAndValuesRemove [
 	| dictionary |
-
 	dictionary := self dictionaryWithOrderedAssociations.
-	self orderedAssociations withIndexDo: [:removedAssociation :i |
-		| unremovedAssociations |
-		unremovedAssociations :=
-			(self orderedAssociationsAllButFirst: i) asOrderedCollection.
-		dictionary keysAndValuesRemove: [:key :value |
-			(self isTestingIdentityDictionary
-				ifTrue: [key == removedAssociation key]
-				ifFalse: [key = removedAssociation key])
-				ifTrue: [
-					self assert: value equals: removedAssociation value.
-					true]
-				ifFalse: [| unremovedAssociation |
-					unremovedAssociation := unremovedAssociations removeFirst.
-					self isTestingIdentityDictionary
-						ifTrue: [self assert: key == unremovedAssociation key]
-						ifFalse: [self assert: key equals: unremovedAssociation key].
-					self assert: value equals: unremovedAssociation value.
-					false]].
-		self assert: unremovedAssociations isEmpty.
-		self
-			assertKey: removedAssociation key
-			wasRemovedfrom: dictionary].
-	self assert: dictionary isEmpty.
+	self orderedAssociations
+		withIndexDo: [ :removedAssociation :i | 
+			| unremovedAssociations |
+			unremovedAssociations := (self orderedAssociationsAllButFirst: i) asOrderedCollection.
+			dictionary
+				keysAndValuesRemove: [ :key :value | 
+					(self isTestingIdentityDictionary ifTrue: [ key == removedAssociation key ] ifFalse: [ key = removedAssociation key ])
+						ifTrue: [ self assert: value equals: removedAssociation value.
+							true ]
+						ifFalse: [ | unremovedAssociation |
+							unremovedAssociation := unremovedAssociations removeFirst.
+							self isTestingIdentityDictionary ifTrue: [ self assert: key == unremovedAssociation key ] ifFalse: [ self assert: key equals: unremovedAssociation key ].
+							self assert: value equals: unremovedAssociation value.
+							false ] ].
+			self assertEmpty: unremovedAssociations.
+			self assertKey: removedAssociation key wasRemovedfrom: dictionary ].
+	self assertEmpty: dictionary
 ]
 
 { #category : #tests }
@@ -1246,17 +1228,13 @@ OrderedDictionaryTest >> testOccurancesOf [
 { #category : #tests }
 OrderedDictionaryTest >> testRemoveAll [
 	| dictionary removedKeys |
-
 	dictionary := self dictionaryWithOrderedAssociations.
 	removedKeys := dictionary keys.
 	self
-		deny: dictionary isEmpty;
+		denyEmpty: dictionary;
 		assert: dictionary removeAll == dictionary;
-		assert: dictionary isEmpty.
-	removedKeys do: [:each |
-		self
-			assertKey: each
-			wasRemovedfrom: dictionary].
+		assertEmpty: dictionary.
+	removedKeys do: [ :each | self assertKey: each wasRemovedfrom: dictionary ]
 ]
 
 { #category : #tests }

--- a/src/Collections-Tests/ReadWriteStreamTest.class.st
+++ b/src/Collections-Tests/ReadWriteStreamTest.class.st
@@ -79,7 +79,7 @@ ReadWriteStreamTest >> testContents [
 ReadWriteStreamTest >> testIsEmpty [
 	| stream |
 	stream := self emptyStream.
-	self assert: stream isEmpty.
+	self assertEmpty: stream.
 	stream nextPut: $a.
 	self deny: stream isEmpty.
 	stream reset.

--- a/src/Collections-Tests/SetTest.class.st
+++ b/src/Collections-Tests/SetTest.class.st
@@ -325,9 +325,9 @@ SetTest >> testCopy [
 	full add: 3.
 	full add: 2.
 	newFull := full copy.
-	self assert: (full size = newFull size).
-	self assert: ((full select: [:each | (newFull includes: each) not]) isEmpty).
-	self assert: ((newFull select: [:each | (full includes: each) not]) isEmpty).
+	self assert: full size = newFull size.
+	self assertEmpty: (full select: [ :each | (newFull includes: each) not ]).
+	self assertEmpty: (newFull select: [ :each | (full includes: each) not ])
 ]
 
 { #category : #'tests - copy' }
@@ -337,15 +337,14 @@ SetTest >> testCopyNonEmptyWithoutAllNotIncluded [
 
 { #category : #'tests - some' }
 SetTest >> testCopyWithout [
-	| newFull | 
+	| newFull |
 	full add: 3.
 	full add: 2.
 	newFull := full copyWithout: 3.
-	self assert: (newFull size = (full size - 1)).
+	self assert: newFull size = (full size - 1).
 	self deny: (newFull includes: 3).
-	self assert: ((newFull select: [:each | (full includes: each) not]) isEmpty).
-	self assert: ((full select: [:each | (newFull includes: each) not]) = (Set with: 3)).
-	
+	self assertEmpty: (newFull select: [ :each | (full includes: each) not ]).
+	self assert: (full select: [ :each | (newFull includes: each) not ]) = (Set with: 3)
 ]
 
 { #category : #'tests - some' }
@@ -368,8 +367,8 @@ SetTest >> testDoWithoutNoDuplicates [
 
 { #category : #'tests - enumerating' }
 SetTest >> testFlatCollect [
-	self assert: (#(1 2) asSet flatCollect: [ :x | 1 to: (2 * x) ]) = #(1 2 3 4) asSet.
-	self assert: (#() asSet flatCollect: [:x | 1 to: 4 ]) isEmpty
+	self assert: (#(1 2) asSet flatCollect: [ :x | 1 to: 2 * x ]) = #(1 2 3 4) asSet.
+	self assertEmpty: (#() asSet flatCollect: [ :x | 1 to: 4 ])
 ]
 
 { #category : #'tests - enumerating' }
@@ -421,22 +420,24 @@ SetTest >> testIncludesElementIsNotThere [
 ]
 
 { #category : #'tests - some' }
-SetTest >> testIntersection [ 
+SetTest >> testIntersection [
 	| newFull col |
-	full add: 3; add: 2.
+	full
+		add: 3;
+		add: 2.
 	col := full intersection: full.
-	self assert: (full = col).
+	self assert: full = col.
 
 	newFull := Set with: 8 with: 9 with: #z.
 	col := newFull intersection: full.
-	self assert: (col isEmpty).
-	
-	newFull add: 5; add: #abc; add: 7.
+	self assertEmpty: col.
+
+	newFull
+		add: 5;
+		add: #abc;
+		add: 7.
 	col := newFull intersection: full.
-	self assert: ((full select: [:each | (newFull includes: each)]) = col).
-	
-	
-	
+	self assert: (full select: [ :each | newFull includes: each ]) = col
 ]
 
 { #category : #'tests - integrity' }

--- a/src/Collections-Tests/StackTest.class.st
+++ b/src/Collections-Tests/StackTest.class.st
@@ -55,23 +55,20 @@ StackTest >> testEmptyError [
 
 { #category : #tests }
 StackTest >> testPop [
-
 	| aStack res elem |
-	elem := 'anElement'.	
+	elem := 'anElement'.
 	aStack := Stack new.
-	self assert: aStack isEmpty.
-	
+	self assertEmpty: aStack.
+
 	aStack push: 'a'.
 	aStack push: elem.
-	res := aStack pop.	
+	res := aStack pop.
 	self assert: res = elem.
 	self assert: res == elem.
-	
+
 	self assert: aStack size = 1.
 	aStack pop.
-	self assert: aStack isEmpty.
-
-
+	self assertEmpty: aStack
 ]
 
 { #category : #tests }
@@ -110,13 +107,12 @@ StackTest >> testSize [
 
 { #category : #tests }
 StackTest >> testTop [
-
 	| aStack |
 	aStack := Stack new.
-	self assert: aStack isEmpty.
+	self assertEmpty: aStack.
 	aStack push: 'a'.
 	aStack push: 'b'.
 	self assert: aStack top = 'b'.
 	self assert: aStack top = 'b'.
-	self assert: aStack size = 2.
+	self assert: aStack size = 2
 ]

--- a/src/Collections-Tests/StringTest.class.st
+++ b/src/Collections-Tests/StringTest.class.st
@@ -488,35 +488,23 @@ StringTest >> testAsSignedInteger [
 
 { #category : #'tests - converting' }
 StringTest >> testAsSmalltalkComment [
-
-	| exampleStrings  |
-	exampleStrings := #(
-		''
-		' '
-		'"'
-		'""'
-		'"""'
-		'abc"abc'
-		'abc""abc'
-		'abc"hello"abc'
-		'abc"'
-		'"abc' ).
+	| exampleStrings |
+	exampleStrings := #('' ' ' '"' '""' '"""' 'abc"abc' 'abc""abc' 'abc"hello"abc' 'abc"' '"abc').
 
 	"check that the result of scanning the comment is empty"
-	exampleStrings do: [ :s |
-		| tokens  |
-		tokens := s asComment parseLiterals.
-		self assert: (tokens isEmpty) ].
+	exampleStrings
+		do: [ :s | 
+			| tokens |
+			tokens := s asComment parseLiterals.
+			self assertEmpty: tokens ].
 
 	"check that the result has the same non-quote characters as the original"
-	exampleStrings do: [ :s |
-		self assert: (s copyWithout: $") equals: (s asComment copyWithout: $")].
+	exampleStrings do: [ :s | self assert: (s copyWithout: $") equals: (s asComment copyWithout: $") ].
 
 	"finnaly, test for some common kinds of inputs"
 	self assert: 'abc' asComment equals: '"abc"'.
 	self assert: 'abc"abc' asComment equals: '"abc""abc"'.
-	self assert: 'abc""abc' asComment equals: '"abc""abc"'.
-		
+	self assert: 'abc""abc' asComment equals: '"abc""abc"'
 ]
 
 { #category : #tests }
@@ -979,11 +967,10 @@ StringTest >> testFindTokensEscapedBy01 [
 
 { #category : #'tests - tokenizing' }
 StringTest >> testFindTokensEscapedBy02 [
-
 	| tokens |
 	string := ''.
 	tokens := string findTokens: ',' escapedBy: '"'.
-	self assert: tokens isEmpty
+	self assertEmpty: tokens
 ]
 
 { #category : #'tests - tokenizing' }
@@ -1578,7 +1565,7 @@ StringTest >> testLinesDoWithCrLfBetween [
 StringTest >> testLoremIpsum [
 	| fillerText |
 	fillerText := String loremIpsum.
-	self deny: fillerText isEmpty.
+	self denyEmpty: fillerText.
 	self assert: (fillerText beginsWith: 'Lorem ipsum').
 	self assert: (fillerText endsWith: 'laborum.').
 	self assert: fillerText lines first equals: fillerText.

--- a/src/Collections-Tests/TAsStringCommaAndDelimiterSequenceableTest.trait.st
+++ b/src/Collections-Tests/TAsStringCommaAndDelimiterSequenceableTest.trait.st
@@ -28,11 +28,10 @@ TAsStringCommaAndDelimiterSequenceableTest >> nonEmpty1Element [
 
 { #category : #'tests - fixture' }
 TAsStringCommaAndDelimiterSequenceableTest >> test0FixtureAsStringCommaAndDelimiterTest [
-
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self empty.
-	self assert: self empty isEmpty.
+	self assertEmpty: self empty.
 	self nonEmpty1Element.
 	self assert: self nonEmpty1Element size = 1
 ]

--- a/src/Collections-Tests/TAsStringCommaAndDelimiterTest.trait.st
+++ b/src/Collections-Tests/TAsStringCommaAndDelimiterTest.trait.st
@@ -27,9 +27,9 @@ TAsStringCommaAndDelimiterTest >> nonEmpty1Element [
 { #category : #'tests - fixture' }
 TAsStringCommaAndDelimiterTest >> test0FixtureAsStringCommaAndDelimiterTest [
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self empty.
-	self assert: self empty isEmpty.
+	self assertEmpty: self empty.
 	self nonEmpty1Element.
 	self assert: self nonEmpty1Element size = 1
 ]

--- a/src/Collections-Tests/TBeginsEndsWith.trait.st
+++ b/src/Collections-Tests/TBeginsEndsWith.trait.st
@@ -18,12 +18,11 @@ TBeginsEndsWith >> nonEmpty [
 
 { #category : #'tests - fixture' }
 TBeginsEndsWith >> test0FixtureBeginsEndsWithTest [
-
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self assert: self nonEmpty size > 1.
 	self empty.
-	self assert: self empty isEmpty
+	self assertEmpty: self empty
 ]
 
 { #category : #'tests - begins ends with' }

--- a/src/Collections-Tests/TCloneTest.trait.st
+++ b/src/Collections-Tests/TCloneTest.trait.st
@@ -21,9 +21,9 @@ TCloneTest >> nonEmpty [
 { #category : #'tests - fixture' }
 TCloneTest >> test0FixtureCloneTest [
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self empty.
-	self assert: self empty isEmpty
+	self assertEmpty: self empty
 ]
 
 { #category : #'tests - copy - clone' }
@@ -38,19 +38,14 @@ TCloneTest >> testCopyCreatesNewObject [
 
 { #category : #'tests - copy - clone' }
 TCloneTest >> testCopyEmpty [
-	
-	| copy | 
-	copy := self empty copy.
-	self assert: copy isEmpty.
+	self assertEmpty: self empty copy
 ]
 
 { #category : #'tests - copy - clone' }
 TCloneTest >> testCopyNonEmpty [
-	
-	| copy | 
+	| copy |
 	copy := self nonEmpty copy.
-	self deny: copy isEmpty.
+	self denyEmpty: copy.
 	self assert: copy size = self nonEmpty size.
-	self nonEmpty do: 
-		[:each | copy includes: each]
+	self nonEmpty do: [ :each | copy includes: each ]
 ]

--- a/src/Collections-Tests/TConcatenationEqualElementsRemovedTest.trait.st
+++ b/src/Collections-Tests/TConcatenationEqualElementsRemovedTest.trait.st
@@ -28,11 +28,11 @@ TConcatenationEqualElementsRemovedTest >> secondCollection [
 { #category : #'tests - fixture' }
 TConcatenationEqualElementsRemovedTest >> test0FixtureConcatenationTest [
 	self firstCollection.
-	self deny: self firstCollection isEmpty.
+	self denyEmpty: self firstCollection.
 	self firstCollection.
-	self deny: self firstCollection isEmpty.
+	self denyEmpty: self firstCollection.
 	self empty.
-	self assert: self empty isEmpty
+	self assertEmpty: self empty
 ]
 
 { #category : #'tests - concatenation' }

--- a/src/Collections-Tests/TConcatenationTest.trait.st
+++ b/src/Collections-Tests/TConcatenationTest.trait.st
@@ -26,11 +26,11 @@ TConcatenationTest >> secondCollection [
 { #category : #'tests - fixture' }
 TConcatenationTest >> test0FixtureConcatenationTest [
 	self firstCollection.
-	self deny: self firstCollection isEmpty.
+	self denyEmpty: self firstCollection.
 	self firstCollection.
-	self deny: self firstCollection isEmpty.
+	self denyEmpty: self firstCollection.
 	self empty.
-	self assert: self empty isEmpty
+	self assertEmpty: self empty
 ]
 
 { #category : #'tests - concatenation' }

--- a/src/Collections-Tests/TConvertAsSortedTest.trait.st
+++ b/src/Collections-Tests/TConvertAsSortedTest.trait.st
@@ -14,9 +14,8 @@ TConvertAsSortedTest >> collectionWithSortableElements [
 
 { #category : #'tests - fixture' }
 TConvertAsSortedTest >> test0FixtureConverAsSortedTest [
-
 	self collectionWithSortableElements.
-	self deny: self collectionWithSortableElements isEmpty
+	self denyEmpty: self collectionWithSortableElements
 ]
 
 { #category : #'tests - as sorted collection' }

--- a/src/Collections-Tests/TCopyPartOfSequenceable.trait.st
+++ b/src/Collections-Tests/TCopyPartOfSequenceable.trait.st
@@ -26,17 +26,12 @@ TCopyPartOfSequenceable >> indexInForCollectionWithoutDuplicates [
 
 { #category : #'tests - fixture' }
 TCopyPartOfSequenceable >> test0FixtureCopyPartOfSequenceableTest [
-
 	self collectionWithoutEqualElements.
-	self collectionWithoutEqualElements
-		do: [ :each | self assert: (self collectionWithoutEqualElements occurrencesOf: each) = 1 ].
+	self collectionWithoutEqualElements do: [ :each | self assert: (self collectionWithoutEqualElements occurrencesOf: each) = 1 ].
 	self indexInForCollectionWithoutDuplicates.
-	self
-		assert:
-			(self indexInForCollectionWithoutDuplicates > 0 & self indexInForCollectionWithoutDuplicates)
-				< self collectionWithoutEqualElements size.
+	self assert: (self indexInForCollectionWithoutDuplicates > 0 & self indexInForCollectionWithoutDuplicates) < self collectionWithoutEqualElements size.
 	self empty.
-	self assert: self empty isEmpty
+	self assertEmpty: self empty
 ]
 
 { #category : #'tests - copying part of sequenceable' }
@@ -56,11 +51,9 @@ TCopyPartOfSequenceable >> testCopyAfter [
 
 { #category : #'tests - copying part of sequenceable' }
 TCopyPartOfSequenceable >> testCopyAfterEmpty [
-
 	| result |
 	result := self empty copyAfter: self collectionWithoutEqualElements first.
-	self assert: result isEmpty
-	
+	self assertEmpty: result
 ]
 
 { #category : #'tests - copying part of sequenceable' }
@@ -81,19 +74,17 @@ TCopyPartOfSequenceable >> testCopyAfterLast [
 
 { #category : #'tests - copying part of sequenceable' }
 TCopyPartOfSequenceable >> testCopyAfterLastEmpty [
-
 	| result |
 	result := self empty copyAfterLast: self collectionWithoutEqualElements first.
-	self assert: result isEmpty
+	self assertEmpty: result
 ]
 
 { #category : #'tests - copying part of sequenceable' }
 TCopyPartOfSequenceable >> testCopyEmptyMethod [
-
 	| result |
-	result := self collectionWithoutEqualElements  copyEmpty .
-	self assert: result isEmpty .
-	self assert: result class equals: self nonEmpty class.
+	result := self collectionWithoutEqualElements copyEmpty.
+	self assertEmpty: result.
+	self assert: result class equals: self nonEmpty class
 ]
 
 { #category : #'tests - copying part of sequenceable' }
@@ -129,11 +120,9 @@ TCopyPartOfSequenceable >> testCopyUpTo [
 
 { #category : #'tests - copying part of sequenceable' }
 TCopyPartOfSequenceable >> testCopyUpToEmpty [
-
 	| result |
 	result := self empty copyUpTo: self collectionWithoutEqualElements first.
-	self assert: result isEmpty
-	
+	self assertEmpty: result
 ]
 
 { #category : #'tests - copying part of sequenceable' }
@@ -153,8 +142,7 @@ TCopyPartOfSequenceable >> testCopyUpToLast [
 
 { #category : #'tests - copying part of sequenceable' }
 TCopyPartOfSequenceable >> testCopyUpToLastEmpty [
-
 	| result |
 	result := self empty copyUpToLast: self collectionWithoutEqualElements first.
-	self assert: result isEmpty
+	self assertEmpty: result
 ]

--- a/src/Collections-Tests/TCopyPartOfSequenceableForMultipliness.trait.st
+++ b/src/Collections-Tests/TCopyPartOfSequenceableForMultipliness.trait.st
@@ -26,19 +26,16 @@ TCopyPartOfSequenceableForMultipliness >> test0FixtureCopyPartOfForMultipliness 
 
 { #category : #'tests - copying part of sequenceable for multipliness' }
 TCopyPartOfSequenceableForMultipliness >> testCopyAfterLastWithDuplicate [
-
-	| result element  collection |
+	| result element collection |
 	collection := self collectionWithSameAtEndAndBegining.
 	element := collection first.
-	
+
 	"collectionWithSameAtEndAndBegining first and last elements are equals.
 	'copyAfter:' should copy after the last occurence of element :"
-	result := collection copyAfterLast: (element ).
-	
+	result := collection copyAfterLast: element.
+
 	"Verify content"
-	self assert: result isEmpty
-
-
+	self assertEmpty: result
 ]
 
 { #category : #'tests - copying part of sequenceable for multipliness' }
@@ -82,17 +79,14 @@ TCopyPartOfSequenceableForMultipliness >> testCopyUpToLastWithDuplicate [
 
 { #category : #'tests - copying part of sequenceable for multipliness' }
 TCopyPartOfSequenceableForMultipliness >> testCopyUpToWithDuplicate [
-
-	| result element  collection |
+	| result element collection |
 	collection := self collectionWithSameAtEndAndBegining.
 	element := collection last.
-	
+
 	"collectionWithSameAtEndAndBegining first and last elements are equals.
  	 'copyUpTo:' should copy until the first occurence"
-	result := collection copyUpTo: (element ).
-	
+	result := collection copyUpTo: element.
+
 	"Verify content"
-	self assert: result isEmpty
-
-
+	self assertEmpty: result
 ]

--- a/src/Collections-Tests/TCopySequenceableSameContents.trait.st
+++ b/src/Collections-Tests/TCopySequenceableSameContents.trait.st
@@ -24,11 +24,10 @@ TCopySequenceableSameContents >> nonEmpty [
 
 { #category : #'tests - fixture' }
 TCopySequenceableSameContents >> test0FixtureCopySameContentsTest [
-
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self empty.
-	self assert: self empty isEmpty
+	self assertEmpty: self empty
 ]
 
 { #category : #'tests - copying same contents' }
@@ -74,10 +73,9 @@ TCopySequenceableSameContents >> testShallowCopy [
 
 { #category : #'tests - copying same contents' }
 TCopySequenceableSameContents >> testShallowCopyEmpty [
-
 	| result |
 	result := self empty shallowCopy.
-	self assert: result isEmpty
+	self assertEmpty: result
 ]
 
 { #category : #'tests - copying same contents' }

--- a/src/Collections-Tests/TCopySequenceableWithOrWithoutSpecificElements.trait.st
+++ b/src/Collections-Tests/TCopySequenceableWithOrWithoutSpecificElements.trait.st
@@ -22,7 +22,7 @@ TCopySequenceableWithOrWithoutSpecificElements >> nonEmpty [
 TCopySequenceableWithOrWithoutSpecificElements >> test0FixtureCopyWithOrWithoutSpecificElementsTest [
 
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self indexInNonEmpty.
 	self assert: self indexInNonEmpty > 0.
 	self assert: self indexInNonEmpty <= self nonEmpty size

--- a/src/Collections-Tests/TCopySequenceableWithReplacementForSorted.trait.st
+++ b/src/Collections-Tests/TCopySequenceableWithReplacementForSorted.trait.st
@@ -25,51 +25,42 @@ self explicitRequirement
 
 { #category : #'tests - fixture' }
 TCopySequenceableWithReplacementForSorted >> test0FixtureCopyWithReplacementForSorted [
-
 	self collectionOfSize5.
 	self assert: self collectionOfSize5 size = 5.
 	self replacementCollection.
-	self deny: self replacementCollection isEmpty.
+	self denyEmpty: self replacementCollection.
 	self empty.
-	self assert: self empty isEmpty
+	self assertEmpty: self empty
 ]
 
 { #category : #'tests - copying with replacement for sorted' }
 TCopySequenceableWithReplacementForSorted >> testCopyFromToWithForSorted [
-
 	| collection result |
-	collection := self collectionOfSize5 .
+	collection := self collectionOfSize5.
 
 	"Testing that elements to be replaced are removed from the copy :"
-	result := collection copyReplaceFrom: 1 to: collection size with: self empty .
-	self assert: result isEmpty.
+	result := collection copyReplaceFrom: 1 to: collection size with: self empty.
+	self assertEmpty: result.
 
 	"Testing that replacement elements  are all put into the copy :"
-	result := collection copyReplaceFrom: 1 to: collection size with: self replacementCollection .
- 	self replacementCollection do:
-			[:each | self assert: (result occurrencesOf: each) equals: ( self replacementCollection occurrencesOf: each )].
+	result := collection copyReplaceFrom: 1 to: collection size with: self replacementCollection.
+	self replacementCollection do: [ :each | self assert: (result occurrencesOf: each) equals: (self replacementCollection occurrencesOf: each) ].
 
 	self assert: result size equals: self replacementCollection size
-
-
 ]
 
 { #category : #'tests - copying with replacement for sorted' }
 TCopySequenceableWithReplacementForSorted >> testCopyReplaceAllWithForSorted [
-
 	| collection result |
-	collection := self collectionOfSize5 .
+	collection := self collectionOfSize5.
 
 	"Testing that elements to be replaced are removed from the copy :"
 	result := collection copyReplaceAll: collection with: self empty.
-	self assert: result isEmpty.
+	self assertEmpty: result.
 
 	"Testing that replacement elements  are all put into the copy :"
 	result := collection copyReplaceAll: collection with: self replacementCollection.
- 	self replacementCollection do:
-			[:each | self assert: (result occurrencesOf: each) equals: (self replacementCollection occurrencesOf: each)].
+	self replacementCollection do: [ :each | self assert: (result occurrencesOf: each) equals: (self replacementCollection occurrencesOf: each) ].
 
 	self assert: result size equals: self replacementCollection size
-
-
 ]

--- a/src/Collections-Tests/TCopyTest.trait.st
+++ b/src/Collections-Tests/TCopyTest.trait.st
@@ -42,9 +42,9 @@ TCopyTest >> test0CopyTest [
 	self empty.
 	self assertEmpty: self empty.
 	self nonEmpty.
-	self denyEmpty: self nonEmpty notEmpty.
+	self denyEmpty: self nonEmpty.
 	self collectionWithElementsToRemove.
-	self denyEmpty: self collectionWithElementsToRemove notEmpty.
+	self denyEmpty: self collectionWithElementsToRemove.
 	self collectionWithElementsToRemove do: [ :each | self assert: (self nonEmpty includes: each) ].
 	self elementToAdd.
 	self deny: (self nonEmpty includes: self elementToAdd).

--- a/src/Collections-Tests/TCopyTest.trait.st
+++ b/src/Collections-Tests/TCopyTest.trait.st
@@ -39,13 +39,12 @@ TCopyTest >> nonEmpty [
 
 { #category : #'tests - fixture' }
 TCopyTest >> test0CopyTest [
-
 	self empty.
-	self assert: self empty isEmpty.
+	self assertEmpty: self empty.
 	self nonEmpty.
-	self assert: self nonEmpty notEmpty.
+	self denyEmpty: self nonEmpty notEmpty.
 	self collectionWithElementsToRemove.
-	self assert: self collectionWithElementsToRemove notEmpty.
+	self denyEmpty: self collectionWithElementsToRemove notEmpty.
 	self collectionWithElementsToRemove do: [ :each | self assert: (self nonEmpty includes: each) ].
 	self elementToAdd.
 	self deny: (self nonEmpty includes: self elementToAdd).

--- a/src/Collections-Tests/TDictionaryAddingTest.trait.st
+++ b/src/Collections-Tests/TDictionaryAddingTest.trait.st
@@ -26,7 +26,7 @@ TDictionaryAddingTest >> nonEmptyDict [
 { #category : #'tests - fixture' }
 TDictionaryAddingTest >> test0FixtureDictionaryAddingTest [
 	self nonEmptyDict.
-	self deny: self nonEmptyDict isEmpty.
+	self denyEmpty: self nonEmptyDict.
 	self associationWithKeyNotInToAdd.
 	self deny: (self nonEmptyDict keys includes: self associationWithKeyNotInToAdd key).
 	self associationWithKeyAlreadyInToAdd.
@@ -58,12 +58,12 @@ TDictionaryAddingTest >> testAddWithKeyAlreadyIn [
 	| dictionary result association oldSize |
 	dictionary := self nonEmptyDict.
 	oldSize := dictionary size.
-	association := self associationWithKeyAlreadyInToAdd .
+	association := self associationWithKeyAlreadyInToAdd.
 	result := dictionary add: association.
-	
+
 	self assert: result = association.
 	self assert: (dictionary at: association key) = association value.
-	self assert: dictionary size = oldSize .
+	self assert: dictionary size equals: oldSize
 ]
 
 { #category : #'tests - adding' }
@@ -73,10 +73,10 @@ TDictionaryAddingTest >> testAddWithKeyNotIn [
 	oldSize := dictionary size.
 	association := self associationWithKeyNotInToAdd.
 	result := dictionary add: association.
-	
-	self assert: result = association.
-	self assert: (dictionary at: association key) = association value.
-	self assert: dictionary size = oldSize  + 1.
+
+	self assert: result equals: association.
+	self assert: (dictionary at: association key) equals: association value.
+	self assert: dictionary size equals: oldSize + 1
 ]
 
 { #category : #'tests - adding' }
@@ -84,18 +84,18 @@ TDictionaryAddingTest >> testDeclareFrom [
 	| newDict v dictionary keyIn associationKeyNotIn |
 	dictionary := self nonEmptyDict.
 	keyIn := dictionary keys anyOne.
-	associationKeyNotIn := self associationWithKeyNotInToAdd .
-	newDict := self collectionClass new add: associationKeyNotIn; yourself.
-	
-	
-	
+	associationKeyNotIn := self associationWithKeyNotInToAdd.
+	newDict := self collectionClass new
+		add: associationKeyNotIn;
+		yourself.
+
 	"if the key already exist, nothing changes"
-	v := dictionary  at: keyIn.
-	dictionary  declare: keyIn  from: newDict.
-	self assert: (dictionary  at: keyIn ) = v.
-	
+	v := dictionary at: keyIn.
+	dictionary declare: keyIn from: newDict.
+	self assert: (dictionary at: keyIn) equals: v.
+
 	"if the key does not exist, then it gets removed from newDict and is added to the receiver"
 	self nonEmptyDict declare: associationKeyNotIn key from: newDict.
-	self assert: (dictionary  at: associationKeyNotIn key) = associationKeyNotIn value.
-	self assert: (newDict size = 0)
+	self assert: (dictionary at: associationKeyNotIn key) equals: associationKeyNotIn value.
+	self assert: newDict size equals: 0
 ]

--- a/src/Collections-Tests/TDictionaryAssociationAccessTest.trait.st
+++ b/src/Collections-Tests/TDictionaryAssociationAccessTest.trait.st
@@ -20,22 +20,21 @@ TDictionaryAssociationAccessTest >> nonEmpty [
 { #category : #'tests - fixture' }
 TDictionaryAssociationAccessTest >> test0FixtureDictionaryAssocitionAccess [
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self keyNotIn.
 	self deny: (self nonEmpty keys includes: self keyNotIn)
 ]
 
 { #category : #'tests - dictionary assocition access' }
 TDictionaryAssociationAccessTest >> testAssociationAt [
-
 	| collection keyIn result |
 	collection := self nonEmpty.
 	keyIn := collection keys anyOne.
 
-	result := collection associationAt: keyIn. 
+	result := collection associationAt: keyIn.
 
-	self assert: (result key) = keyIn.
-	self assert: (result value ) = (collection at: keyIn ).
+	self assert: result key equals: keyIn.
+	self assert: result value equals: (collection at: keyIn)
 ]
 
 { #category : #'tests - dictionary assocition access' }

--- a/src/Collections-Tests/TDictionaryCopyingTest.trait.st
+++ b/src/Collections-Tests/TDictionaryCopyingTest.trait.st
@@ -44,23 +44,21 @@ self explicitRequirement.
 { #category : #'tests - fixture' }
 TDictionaryCopyingTest >> test0FixtureCloneTest [
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self empty.
-	self assert: self empty isEmpty
+	self assertEmpty: self empty
 ]
 
 { #category : #'tests - fixture' }
 TDictionaryCopyingTest >> test0FixtureDictionaryCopyingTest [
 	| duplicateKey |
 	self nonEmptyDict.
-	self deny: self nonEmptyDict isEmpty.
+	self denyEmpty: self nonEmptyDict.
 	self nonEmptyDifferentFromNonEmptyDict.
-	self deny: self nonEmptyDifferentFromNonEmptyDict isEmpty.
+	self denyEmpty: self nonEmptyDifferentFromNonEmptyDict.
 	duplicateKey := true.
-	self nonEmptyDict keys
-		detect: [ :key | self nonEmptyDifferentFromNonEmptyDict includes: key ]
-		ifNone: [ duplicateKey := false ].
-	self assert: duplicateKey = false
+	self nonEmptyDict keys detect: [ :key | self nonEmptyDifferentFromNonEmptyDict includes: key ] ifNone: [ duplicateKey := false ].
+	self deny: duplicateKey
 ]
 
 { #category : #'tests - copy - clone' }
@@ -74,21 +72,16 @@ TDictionaryCopyingTest >> testCopyCreatesNewObject [
 
 { #category : #'tests - copy - clone' }
 TDictionaryCopyingTest >> testCopyEmpty [
-	
-	| copy | 
-	copy := self empty copy.
-	self assert: copy isEmpty.
+	self assertEmpty: self empty copy
 ]
 
 { #category : #'tests - copy - clone' }
 TDictionaryCopyingTest >> testCopyNonEmpty [
-	
-	| copy | 
+	| copy |
 	copy := self nonEmpty copy.
-	self deny: copy isEmpty.
+	self denyEmpty: copy.
 	self assert: copy size = self nonEmpty size.
-	self nonEmpty do: 
-		[:each | copy includes: each]
+	self nonEmpty do: [ :each | copy includes: each ]
 ]
 
 { #category : #'tests - copying' }

--- a/src/Collections-Tests/TDictionaryEnumeratingTest.trait.st
+++ b/src/Collections-Tests/TDictionaryEnumeratingTest.trait.st
@@ -24,7 +24,7 @@ TDictionaryEnumeratingTest >> nonEmptyDict [
 { #category : #'tests - fixture' }
 TDictionaryEnumeratingTest >> test0FixtureDictionaryEnumeratingTest [
 	self nonEmptyDict.
-	self deny: self nonEmptyDict isEmpty
+	self denyEmpty: self nonEmptyDict
 ]
 
 { #category : #'tests - dictionnary enumerating' }

--- a/src/Collections-Tests/TDictionaryIncludesTest.trait.st
+++ b/src/Collections-Tests/TDictionaryIncludesTest.trait.st
@@ -22,21 +22,15 @@ TDictionaryIncludesTest >> nonEmpty [
 TDictionaryIncludesTest >> test0FixtureDictionaryIncludes [
 	| in |
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self valueNotInNonEmpty.
 	in := false.
-	self nonEmpty
-		valuesDo: [ :assoc | 
-			assoc = self valueNotInNonEmpty
-				ifTrue: [ in := true ] ].
-	self assert: in = false.
+	self nonEmpty valuesDo: [ :assoc | assoc = self valueNotInNonEmpty ifTrue: [ in := true ] ].
+	self deny: in.
 	self keyNotInNonEmpty.
 	in := false.
-	self nonEmpty
-		keysDo: [ :assoc | 
-			assoc = self keyNotInNonEmpty
-				ifTrue: [ in := true ] ].
-	self assert: in = false
+	self nonEmpty keysDo: [ :assoc | assoc = self keyNotInNonEmpty ifTrue: [ in := true ] ].
+	self deny: in
 ]
 
 { #category : #'tests - dictionary including' }

--- a/src/Collections-Tests/TDictionaryIncludesWithIdentityCheckTest.trait.st
+++ b/src/Collections-Tests/TDictionaryIncludesWithIdentityCheckTest.trait.st
@@ -30,27 +30,21 @@ TDictionaryIncludesWithIdentityCheckTest >> nonEmptyWithCopyNonIdentical [
 TDictionaryIncludesWithIdentityCheckTest >> test0FixtureDictionaryIncludes [
 	| in |
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self valueNotInNonEmpty.
 	in := false.
-	self nonEmpty
-		valuesDo: [ :assoc | 
-			assoc = self valueNotInNonEmpty
-				ifTrue: [ in := true ] ].
-	self assert: in = false.
+	self nonEmpty valuesDo: [ :assoc | assoc = self valueNotInNonEmpty ifTrue: [ in := true ] ].
+	self deny: in.
 	self keyNotInNonEmpty.
 	in := false.
-	self nonEmpty
-		keysDo: [ :assoc | 
-			assoc = self keyNotInNonEmpty
-				ifTrue: [ in := true ] ].
-	self assert: in = false
+	self nonEmpty keysDo: [ :assoc | assoc = self keyNotInNonEmpty ifTrue: [ in := true ] ].
+	self deny: in
 ]
 
 { #category : #'tests - fixture' }
 TDictionaryIncludesWithIdentityCheckTest >> test0FixtureDictionaryIncludesIdentity [
 	self nonEmptyWithCopyNonIdentical.
-	self deny: self nonEmptyWithCopyNonIdentical isEmpty.
+	self denyEmpty: self nonEmptyWithCopyNonIdentical.
 	self nonEmptyWithCopyNonIdentical do: [ :each | self deny: each == each copy ]
 ]
 

--- a/src/Collections-Tests/TDictionaryKeyAccessTest.trait.st
+++ b/src/Collections-Tests/TDictionaryKeyAccessTest.trait.st
@@ -16,11 +16,11 @@ TDictionaryKeyAccessTest >> nonEmptyWithoutEqualsValues [
 TDictionaryKeyAccessTest >> test0FixtureDictionaryKeyAccess [
 	| collection equals |
 	self nonEmptyWithoutEqualsValues.
-	self deny: self nonEmptyWithoutEqualsValues isEmpty.
+	self denyEmpty: self nonEmptyWithoutEqualsValues.
 	equals := true.
 	collection := self nonEmptyWithoutEqualsValues values.
 	collection detect: [ :each | (collection occurrencesOf: each) > 1 ] ifNone: [ equals := false ].
-	self assert: equals = false.
+	self deny: equals.
 	self valueNotIn.
 	self deny: (self nonEmptyWithoutEqualsValues values includes: self valueNotIn)
 ]

--- a/src/Collections-Tests/TDictionaryKeysValuesAssociationsAccess.trait.st
+++ b/src/Collections-Tests/TDictionaryKeysValuesAssociationsAccess.trait.st
@@ -15,7 +15,7 @@ self explicitRequirement.
 { #category : #'tests - fixture' }
 TDictionaryKeysValuesAssociationsAccess >> test0FixtureDictionaryKeysValuesAssociationsAccess [
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty
+	self denyEmpty: self nonEmpty
 ]
 
 { #category : #'tests - dictionary keys values associations access' }

--- a/src/Collections-Tests/TDictionaryRemovingTest.trait.st
+++ b/src/Collections-Tests/TDictionaryRemovingTest.trait.st
@@ -30,7 +30,7 @@ TDictionaryRemovingTest >> nonEmptyDict [
 { #category : #'tests - fixture' }
 TDictionaryRemovingTest >> test0FixtureDictionaryRemovingTest [
 	self nonEmptyDict.
-	self deny: self nonEmptyDict isEmpty.
+	self denyEmpty: self nonEmptyDict.
 	self keyNotInNonEmptyDict.
 	self deny: (self nonEmptyDict keys includes: self keyNotInNonEmptyDict)
 ]

--- a/src/Collections-Tests/TDictionaryValueAccessTest.trait.st
+++ b/src/Collections-Tests/TDictionaryValueAccessTest.trait.st
@@ -27,11 +27,11 @@ TDictionaryValueAccessTest >> supportsNilKey [
 TDictionaryValueAccessTest >> test0FixtureDictionaryElementAccess [
 	| in |
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self keyNotIn.
 	in := true.
 	self nonEmpty keys detect: [ :key | key = self keyNotIn ] ifNone: [ in := false ].
-	self assert: in = false
+	self deny: in
 ]
 
 { #category : #'tests - DictionaryIndexAccessing' }

--- a/src/Collections-Tests/TEmptySequenceableTest.trait.st
+++ b/src/Collections-Tests/TEmptySequenceableTest.trait.st
@@ -43,9 +43,9 @@ TEmptySequenceableTest >> selectorToAccessValuePutIn [
 { #category : #'tests - fixture' }
 TEmptySequenceableTest >> test0FixtureEmptySequenceableTest [
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self empty.
-	self assert: self empty isEmpty
+	self assertEmpty: self empty
 ]
 
 { #category : #'tests - sequence isempty' }

--- a/src/Collections-Tests/TEmptyTest.trait.st
+++ b/src/Collections-Tests/TEmptyTest.trait.st
@@ -24,63 +24,50 @@ TEmptyTest >> nonEmpty [
 { #category : #'tests - fixture' }
 TEmptyTest >> test0FixtureEmptyTest [
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self empty.
-	self assert: self empty isEmpty
+	self assertEmpty: self empty
 ]
 
 { #category : #'tests - empty' }
 TEmptyTest >> testIfEmpty [
-
-	self nonEmpty ifEmpty: [ self assert: false] .
-	self empty ifEmpty: [ self assert: true] .
-	
-
-	
+	self nonEmpty ifEmpty: [ self assert: false ].
+	self empty ifEmpty: [ self assert: true ]
 ]
 
 { #category : #'tests - empty' }
 TEmptyTest >> testIfEmptyifNotEmpty [
-
-	self assert: (self empty ifEmpty: [true] ifNotEmpty: [false]).
-	self assert: (self nonEmpty ifEmpty: [false] ifNotEmpty: [true]).
-	
+	self assert: (self empty ifEmpty: [ true ] ifNotEmpty: [ false ]).
+	self assert: (self nonEmpty ifEmpty: [ false ] ifNotEmpty: [ true ])
 ]
 
 { #category : #'tests - empty' }
 TEmptyTest >> testIfNotEmpty [
-
-	self empty ifNotEmpty: [self assert: false].
-	self nonEmpty ifNotEmpty: [self assert: true].
-	self assert: (self nonEmpty ifNotEmpty: [:s | s ]) = self nonEmpty
-	
+	self empty ifNotEmpty: [ self assert: false ].
+	self nonEmpty ifNotEmpty: [ self assert: true ].
+	self assert: (self nonEmpty ifNotEmpty: [ :s | s ]) = self nonEmpty
 ]
 
 { #category : #'tests - empty' }
 TEmptyTest >> testIfNotEmptyifEmpty [
-
-	self assert: (self empty ifNotEmpty: [false] ifEmpty: [true]).
-	self assert: (self nonEmpty ifNotEmpty: [true] ifEmpty: [false]).
-	
+	self assert: (self empty ifNotEmpty: [ false ] ifEmpty: [ true ]).
+	self assert: (self nonEmpty ifNotEmpty: [ true ] ifEmpty: [ false ])
 ]
 
 { #category : #'tests - empty' }
 TEmptyTest >> testIsEmpty [
-
-	self assert: (self empty isEmpty).
-	self deny: (self nonEmpty isEmpty).
+	self assert: self empty isEmpty.
+	self deny: self nonEmpty isEmpty
 ]
 
 { #category : #'tests - empty' }
 TEmptyTest >> testIsEmptyOrNil [
-
-	self assert: (self empty isEmptyOrNil).
-	self deny: (self nonEmpty isEmptyOrNil).
+	self assert: self empty isEmptyOrNil.
+	self deny: self nonEmpty isEmptyOrNil
 ]
 
 { #category : #'tests - empty' }
 TEmptyTest >> testNotEmpty [
-
-	self assert: (self nonEmpty  notEmpty).
-	self deny: (self empty notEmpty).
+	self assert: self nonEmpty notEmpty.
+	self deny: self empty notEmpty
 ]

--- a/src/Collections-Tests/TGrowableTest.trait.st
+++ b/src/Collections-Tests/TGrowableTest.trait.st
@@ -36,8 +36,8 @@ TGrowableTest >> test0FixtureRequirementsOfTGrowableTest [
 	self nonEmpty.
 	self element.
 	self elementNotIn.
-	self assert: self empty isEmpty.
-	self deny: self nonEmpty isEmpty.
+	self assertEmpty: self empty.
+	self denyEmpty: self nonEmpty.
 	self assert: (self nonEmpty includes: self element).
 	self deny: (self nonEmpty includes: self elementNotIn)
 ]

--- a/src/Collections-Tests/TIncludesTest.trait.st
+++ b/src/Collections-Tests/TIncludesTest.trait.st
@@ -33,17 +33,17 @@ TIncludesTest >> nonEmpty [
 TIncludesTest >> test0FixtureIncludeTest [
 	| anElementIn |
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self elementNotIn.
 	anElementIn := true.
 	self nonEmpty detect: [ :each | each = self elementNotIn ] ifNone: [ anElementIn := false ].
-	self assert: anElementIn equals: false.
+	self deny: anElementIn.
 	self anotherElementNotIn.
 	anElementIn := true.
 	self nonEmpty detect: [ :each | each = self anotherElementNotIn ] ifNone: [ anElementIn := false ].
-	self assert: anElementIn equals: false.
+	self deny: anElementIn.
 	self empty.
-	self assert: self empty isEmpty
+	self assertEmpty: self empty
 ]
 
 { #category : #'tests - includes' }

--- a/src/Collections-Tests/TIncludesWithIdentityCheckTest.trait.st
+++ b/src/Collections-Tests/TIncludesWithIdentityCheckTest.trait.st
@@ -39,20 +39,19 @@ TIncludesWithIdentityCheckTest >> nonEmpty [
 
 { #category : #'tests - fixture' }
 TIncludesWithIdentityCheckTest >> test0FixtureIncludeTest [
-
 	| anElementIn |
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self elementNotIn.
 	anElementIn := true.
 	self nonEmpty detect: [ :each | each = self elementNotIn ] ifNone: [ anElementIn := false ].
-	self assert: anElementIn equals: false.
+	self deny: anElementIn.
 	self anotherElementNotIn.
 	anElementIn := true.
 	self nonEmpty detect: [ :each | each = self anotherElementNotIn ] ifNone: [ anElementIn := false ].
-	self assert: anElementIn equals: false.
+	self deny: anElementIn.
 	self empty.
-	self assert: self empty isEmpty
+	self assertEmpty: self empty
 ]
 
 { #category : #'tests - fixture' }

--- a/src/Collections-Tests/TIterateSequencedReadableTest.trait.st
+++ b/src/Collections-Tests/TIterateSequencedReadableTest.trait.st
@@ -19,19 +19,16 @@ TIterateSequencedReadableTest >> nonEmptyMoreThan1Element [
 
 { #category : #'tests - fixture' }
 TIterateSequencedReadableTest >> test0FixtureIterateSequencedReadableTest [
-
-	| res |	
+	| res |
 	self nonEmptyMoreThan1Element.
 	self assert: self nonEmptyMoreThan1Element size > 1.
-		
+
 	self empty.
-	self assert: self empty isEmpty.
-	
+	self assertEmpty: self empty.
+
 	res := true.
-	self nonEmptyMoreThan1Element    
-	detect: [ :each | (self nonEmptyMoreThan1Element occurrencesOf: each) > 1 ]
-	ifNone: [ res := false ].
-	self assert: res = false
+	self nonEmptyMoreThan1Element detect: [ :each | (self nonEmptyMoreThan1Element occurrencesOf: each) > 1 ] ifNone: [ res := false ].
+	self deny: res
 ]
 
 { #category : #'tests - iterate on sequenced reable collections' }
@@ -179,31 +176,25 @@ TIterateSequencedReadableTest >> testKeysAndValuesDo [
 
 { #category : #'tests - iterate on sequenced reable collections' }
 TIterateSequencedReadableTest >> testKeysAndValuesDoEmpty [
-
 	| result |
-	result:= OrderedCollection new.
-	
-	self empty keysAndValuesDo: 
-		[:i :value| result add: (value+i) ].
-	
-	self assert: result isEmpty
+	result := OrderedCollection new.
+
+	self empty keysAndValuesDo: [ :i :value | result add: value + i ].
+
+	self assertEmpty: result
 ]
 
 { #category : #'tests - iterate on sequenced reable collections' }
 TIterateSequencedReadableTest >> testPairsCollect [
-	
 	| index result |
 	index := 0.
-	
-	result := self nonEmptyMoreThan1Element pairsCollect: 
-		[:each1 :each2 | 
-			self assert: (self nonEmptyMoreThan1Element indexOf: each2 ) equals: (index := index + 2).
-			(self nonEmptyMoreThan1Element indexOf: each2) = ((self nonEmptyMoreThan1Element indexOf: each1) + 1)].
-	
-	result do: 
-		[:each | self assert: each equals: true ]
-	
 
+	result := self nonEmptyMoreThan1Element
+		pairsCollect: [ :each1 :each2 | 
+			self assert: (self nonEmptyMoreThan1Element indexOf: each2) equals: (index := index + 2).
+			(self nonEmptyMoreThan1Element indexOf: each2) = ((self nonEmptyMoreThan1Element indexOf: each1) + 1) ].
+
+	result do: [ :each | self assert: each ]
 ]
 
 { #category : #'tests - iterate on sequenced reable collections' }
@@ -238,9 +229,9 @@ TIterateSequencedReadableTest >> testReverseDo [
 TIterateSequencedReadableTest >> testReverseDoEmpty [
 	| result |
 	result := OrderedCollection new.
-	self empty reverseDo: [: each | result add: each ].
-	
-	self assert: result isEmpty
+	self empty reverseDo: [ :each | result add: each ].
+
+	self assertEmpty: result
 ]
 
 { #category : #'tests - iterate on sequenced reable collections' }

--- a/src/Collections-Tests/TIterateTest.trait.st
+++ b/src/Collections-Tests/TIterateTest.trait.st
@@ -31,10 +31,8 @@ TIterateTest >> test0FixtureIterateTest [
 	self collectionWithoutNilElements.
 	self assert: (self collectionWithoutNilElements occurrencesOf: nil) = 0.
 	res := true.
-	self collectionWithoutNilElements
-		detect: [ :each | (self collectionWithoutNilElements occurrencesOf: each) > 1 ]
-		ifNone: [ res := false ].
-	self assert: res = false
+	self collectionWithoutNilElements detect: [ :each | (self collectionWithoutNilElements occurrencesOf: each) > 1 ] ifNone: [ res := false ].
+	self deny: res
 ]
 
 { #category : #'tests - iterating' }
@@ -92,11 +90,9 @@ TIterateTest >> testBasicCollect [
 
 { #category : #'tests - iterating' }
 TIterateTest >> testBasicCollectEmpty [
-
 	| res |
-	res := self empty collect: [:each | each class].
-	self assert: res isEmpty
-	
+	res := self empty collect: [ :each | each class ].
+	self assertEmpty: res
 ]
 
 { #category : #'tests - iterating' }
@@ -117,19 +113,17 @@ TIterateTest >> testBasicCollectThenDo [
 
 { #category : #'tests - iterating' }
 TIterateTest >> testCollectOnEmpty [
-	self assert: (self empty collect: [:e | self fail]) isEmpty
+	self assertEmpty: (self empty collect: [ :e | self fail ])
 ]
 
 { #category : #'tests - iterating' }
 TIterateTest >> testCollectThenDoOnEmpty [
-
-	self assert: (self empty collect: [:e | self fail] thenDo: [ self fail ]) isEmpty
+	self assertEmpty: (self empty collect: [ :e | self fail ] thenDo: [ self fail ])
 ]
 
 { #category : #'tests - iterating' }
 TIterateTest >> testCollectThenSelectOnEmpty [
-
-	self assert: (self empty collect: [:e | self fail] thenSelect: [:e | self fail ]) isEmpty
+	self assertEmpty: (self empty collect: [ :e | self fail ] thenSelect: [ :e | self fail ])
 ]
 
 { #category : #'tests - iterating' }
@@ -263,12 +257,9 @@ TIterateTest >> testReject [
 { #category : #'tests - iterating' }
 TIterateTest >> testRejectAllThenCollect [
 	| result |
-	
-	result := self collectionWithoutNilElements 
-		reject: [ :each | each notNil ] 
-		thenCollect: [ :each| self fail ].
-	
-	self assert: result isEmpty
+	result := self collectionWithoutNilElements reject: [ :each | each notNil ] thenCollect: [ :each | self fail ].
+
+	self assertEmpty: result
 ]
 
 { #category : #'tests - iterating' }
@@ -331,8 +322,7 @@ TIterateTest >> testRejectThenCollect [
 
 { #category : #'tests - iterating' }
 TIterateTest >> testRejectThenCollectEmpty [
-
-	self assert: (self empty reject: [:e | self fail ] thenCollect: [ :each| self fail ]) isEmpty
+	self assertEmpty: (self empty reject: [ :e | self fail ] thenCollect: [ :each | self fail ])
 ]
 
 { #category : #'tests - iterating' }
@@ -360,8 +350,7 @@ TIterateTest >> testRejectThenDo [
 
 { #category : #'tests - iterating' }
 TIterateTest >> testRejectThenDoOnEmpty [
-
-	self assert: (self empty reject: [:e | self fail ] thenDo: [ self fail ]) isEmpty
+	self assertEmpty: (self empty reject: [ :e | self fail ] thenDo: [ self fail ])
 ]
 
 { #category : #'tests - iterating' }
@@ -380,12 +369,9 @@ TIterateTest >> testSelect [
 { #category : #'tests - iterating' }
 TIterateTest >> testSelectNoneThenCollect [
 	| result |
-	
-	result := self collectionWithoutNilElements 
-		select: [ :each | each isNil ] 
-		thenCollect: [ :each| self fail ].
-	
-	self assert: result isEmpty
+	result := self collectionWithoutNilElements select: [ :each | each isNil ] thenCollect: [ :each | self fail ].
+
+	self assertEmpty: result
 ]
 
 { #category : #'tests - iterating' }
@@ -401,9 +387,7 @@ TIterateTest >> testSelectNoneThenDo [
 
 { #category : #'tests - iterating' }
 TIterateTest >> testSelectOnEmpty [
-
-	self assert: (self empty select: [:e | self fail]) isEmpty
-	
+	self assertEmpty: (self empty select: [ :e | self fail ])
 ]
 
 { #category : #'tests - iterating' }
@@ -437,8 +421,7 @@ TIterateTest >> testSelectThenCollect [
 
 { #category : #'tests - iterating' }
 TIterateTest >> testSelectThenCollectOnEmpty [
-
-	self assert: (self empty select: [:e | self fail ] thenCollect: [ self fail ]) isEmpty
+	self assertEmpty: (self empty select: [ :e | self fail ] thenCollect: [ self fail ])
 ]
 
 { #category : #'tests - iterating' }
@@ -466,8 +449,7 @@ TIterateTest >> testSelectThenDo [
 
 { #category : #'tests - iterating' }
 TIterateTest >> testSelectThenDoOnEmpty [
-
-	self assert: (self empty select: [:e | self fail ] thenDo: [ self fail ]) isEmpty
+	self assertEmpty: (self empty select: [ :e | self fail ] thenDo: [ self fail ])
 ]
 
 { #category : #'tests - iterating' }

--- a/src/Collections-Tests/TOccurrencesForMultiplinessTest.trait.st
+++ b/src/Collections-Tests/TOccurrencesForMultiplinessTest.trait.st
@@ -56,12 +56,11 @@ TOccurrencesForMultiplinessTest >> test0FixtureOccurrencesForMultiplinessTest [
 
 { #category : #'tests - fixture' }
 TOccurrencesForMultiplinessTest >> test0FixtureOccurrencesTest [
-
 	| tmp |
 	self empty.
-	self assert: self empty isEmpty.
+	self assertEmpty: self empty.
 	self collectionWithoutEqualElements.
-	self deny: self collectionWithoutEqualElements isEmpty.
+	self denyEmpty: self collectionWithoutEqualElements.
 	tmp := OrderedCollection new.
 	self collectionWithoutEqualElements
 		do: [ :each | 

--- a/src/Collections-Tests/TOccurrencesTest.trait.st
+++ b/src/Collections-Tests/TOccurrencesTest.trait.st
@@ -26,9 +26,9 @@ TOccurrencesTest >> empty [
 TOccurrencesTest >> test0FixtureOccurrencesTest [
 	| tmp |
 	self empty.
-	self assert: self empty isEmpty.
+	self assertEmpty: self empty.
 	self collectionWithoutEqualElements.
-	self deny: self collectionWithoutEqualElements isEmpty.
+	self denyEmpty: self collectionWithoutEqualElements.
 	tmp := OrderedCollection new.
 	self collectionWithoutEqualElements
 		do: [ :each | 
@@ -49,8 +49,8 @@ TOccurrencesTest >> testOccurrencesOf [
 { #category : #'tests - occurrencesOf' }
 TOccurrencesTest >> testOccurrencesOfEmpty [
 	| result |
-	result := self empty occurrencesOf: (self collectionWithoutEqualElements anyOne).
-	self assert: result = 0
+	result := self empty occurrencesOf: self collectionWithoutEqualElements anyOne.
+	self assert: result equals: 0
 ]
 
 { #category : #'tests - occurrencesOf' }

--- a/src/Collections-Tests/TPrintTest.trait.st
+++ b/src/Collections-Tests/TPrintTest.trait.st
@@ -14,7 +14,7 @@ TPrintTest >> nonEmpty [
 { #category : #'tests - fixture' }
 TPrintTest >> test0FixturePrintTest [
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty
+	self denyEmpty: self nonEmpty
 ]
 
 { #category : #'tests - printing' }

--- a/src/Collections-Tests/TPutBasicTest.trait.st
+++ b/src/Collections-Tests/TPutBasicTest.trait.st
@@ -39,16 +39,15 @@ TPutBasicTest >> nonEmpty [
 TPutBasicTest >> test0FixturePutTest [
 	self aValue.
 	self anotherValue.
-	
+
 	self anIndex.
-	self nonEmpty isDictionary 
-		ifFalse:[self assert: (self anIndex >=1 & self anIndex <= self nonEmpty size).].
-	
+	self nonEmpty isDictionary ifFalse: [ self assert: (self anIndex >= 1 & self anIndex) <= self nonEmpty size ].
+
 	self empty.
-	self assert: self empty isEmpty .
-	
+	self assertEmpty: self empty.
+
 	self nonEmpty.
-	self deny: self nonEmpty  isEmpty.
+	self denyEmpty: self nonEmpty
 ]
 
 { #category : #'tests - at put' }

--- a/src/Collections-Tests/TPutTest.trait.st
+++ b/src/Collections-Tests/TPutTest.trait.st
@@ -29,21 +29,20 @@ TPutTest >> nonEmpty [
 TPutTest >> test0FixturePutOneOrMoreElementsTest [
 	self aValue.
 
-	
+
 	self indexArray.
-	self indexArray do: [
-		:each| 
-		self assert: each class = SmallInteger. 
-		self assert: (each>=1 & each<= self nonEmpty size).
-		].
-	
+	self indexArray
+		do: [ :each | 
+			self assert: each class = SmallInteger.
+			self assert: (each >= 1 & each) <= self nonEmpty size ].
+
 	self assert: self indexArray size = self valueArray size.
-	
+
 	self empty.
-	self assert: self empty isEmpty .
-	
+	self assertEmpty: self empty.
+
 	self nonEmpty.
-	self deny: self nonEmpty  isEmpty.
+	self denyEmpty: self nonEmpty
 ]
 
 { #category : #'tests - puting with indexes' }

--- a/src/Collections-Tests/TRemoveForMultiplenessTest.trait.st
+++ b/src/Collections-Tests/TRemoveForMultiplenessTest.trait.st
@@ -35,15 +35,13 @@ TRemoveForMultiplenessTest >> test0FixtureTRemoveTest [
 	| duplicate |
 	self empty.
 	self nonEmptyWithoutEqualElements.
-	self deny: self nonEmptyWithoutEqualElements isEmpty.
+	self denyEmpty: self nonEmptyWithoutEqualElements.
 	duplicate := true.
-	self nonEmptyWithoutEqualElements
-		detect: [ :each | (self nonEmptyWithoutEqualElements occurrencesOf: each) > 1 ]
-		ifNone: [ duplicate := false ].
+	self nonEmptyWithoutEqualElements detect: [ :each | (self nonEmptyWithoutEqualElements occurrencesOf: each) > 1 ] ifNone: [ duplicate := false ].
 	self assert: duplicate = false.
 	self elementNotIn.
-	self assert: self empty isEmpty.
-	self deny: self nonEmptyWithoutEqualElements isEmpty.
+	self assertEmpty: self empty.
+	self denyEmpty: self nonEmptyWithoutEqualElements.
 	self deny: (self nonEmptyWithoutEqualElements includes: self elementNotIn)
 ]
 
@@ -134,9 +132,7 @@ TRemoveForMultiplenessTest >> testRemoveElementThatExistsTwice [
 
 { #category : #'tests - remove' }
 TRemoveForMultiplenessTest >> testRemoveIfAbsent [
-
-	| el res |
-	el := self elementNotIn.
-	res := self nonEmptyWithoutEqualElements remove: el ifAbsent: [ 33 ].
-	self assert: res = 33
+	| res |
+	res := self nonEmptyWithoutEqualElements remove: self elementNotIn ifAbsent: [ 33 ].
+	self assert: res equals: 33
 ]

--- a/src/Collections-Tests/TRemoveTest.trait.st
+++ b/src/Collections-Tests/TRemoveTest.trait.st
@@ -31,7 +31,7 @@ TRemoveTest >> test0FixtureTRemoveTest [
 	self denyEmpty: self nonEmptyWithoutEqualElements.
 	duplicate := true.
 	self nonEmptyWithoutEqualElements detect: [ :each | (self nonEmptyWithoutEqualElements occurrencesOf: each) > 1 ] ifNone: [ duplicate := false ].
-	self deny: duplicate equals: false.
+	self deny: duplicate.
 	self elementNotIn.
 	self assertEmpty: self empty.
 	self denyEmpty: self nonEmptyWithoutEqualElements.

--- a/src/Collections-Tests/TRemoveTest.trait.st
+++ b/src/Collections-Tests/TRemoveTest.trait.st
@@ -25,19 +25,16 @@ TRemoveTest >> nonEmptyWithoutEqualElements [
 
 { #category : #'tests - fixture' }
 TRemoveTest >> test0FixtureTRemoveTest [
-
 	| duplicate |
 	self empty.
 	self nonEmptyWithoutEqualElements.
-	self deny: self nonEmptyWithoutEqualElements isEmpty.
+	self denyEmpty: self nonEmptyWithoutEqualElements.
 	duplicate := true.
-	self nonEmptyWithoutEqualElements
-		detect: [ :each | (self nonEmptyWithoutEqualElements occurrencesOf: each) > 1 ]
-		ifNone: [ duplicate := false ].
-	self assert: duplicate = false.
+	self nonEmptyWithoutEqualElements detect: [ :each | (self nonEmptyWithoutEqualElements occurrencesOf: each) > 1 ] ifNone: [ duplicate := false ].
+	self deny: duplicate equals: false.
 	self elementNotIn.
-	self assert: self empty isEmpty.
-	self deny: self nonEmptyWithoutEqualElements isEmpty.
+	self assertEmpty: self empty.
+	self denyEmpty: self nonEmptyWithoutEqualElements.
 	self deny: (self nonEmptyWithoutEqualElements includes: self elementNotIn)
 ]
 

--- a/src/Collections-Tests/TReplacementSequencedTest.trait.st
+++ b/src/Collections-Tests/TReplacementSequencedTest.trait.st
@@ -56,28 +56,26 @@ TReplacementSequencedTest >> secondIndex [
 
 { #category : #'tests - fixture' }
 TReplacementSequencedTest >> testOFixtureReplacementSequencedTest [
-
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
-	
+	self denyEmpty: self nonEmpty.
+
 	self elementInForReplacement.
 	self assert: (self nonEmpty includes: self elementInForReplacement).
-	
+
 	self newElement.
-	
+
 	self firstIndex.
-	self assert: (self firstIndex >= 1 & self firstIndex <= self nonEmpty size).
-	
+	self assert: (self firstIndex >= 1 & self firstIndex) <= self nonEmpty size.
+
 	self secondIndex.
-	self assert: (self secondIndex >= 1 & self secondIndex <= self nonEmpty size).
-	
+	self assert: (self secondIndex >= 1 & self secondIndex) <= self nonEmpty size.
+
 	self assert: self firstIndex <= self secondIndex.
-	
+
 	self replacementCollection.
-	
+
 	self replacementCollectionSameSize.
-	self assert: (self secondIndex  - self firstIndex +1) equals: self replacementCollectionSameSize size
-	
+	self assert: self secondIndex - self firstIndex + 1 equals: self replacementCollectionSameSize size
 ]
 
 { #category : #'tests - replacing' }

--- a/src/Collections-Tests/TSequencedConcatenationTest.trait.st
+++ b/src/Collections-Tests/TSequencedConcatenationTest.trait.st
@@ -26,7 +26,7 @@ TSequencedConcatenationTest >> secondCollection [
 { #category : #'tests - fixture' }
 TSequencedConcatenationTest >> test0FixtureSequencedConcatenationTest [
 	self empty.
-	self assert: self empty isEmpty.
+	self assertEmpty: self empty.
 	self firstCollection.
 	self secondCollection
 ]

--- a/src/Collections-Tests/TSequencedStructuralEqualityTest.trait.st
+++ b/src/Collections-Tests/TSequencedStructuralEqualityTest.trait.st
@@ -28,11 +28,10 @@ TSequencedStructuralEqualityTest >> test0TSequencedStructuralEqualityTest [
 
 { #category : #'tests - fixture' }
 TSequencedStructuralEqualityTest >> test0TStructuralEqualityTest [
-
 	self empty.
 	self nonEmpty.
-	self assert: self empty isEmpty.
-	self deny: self nonEmpty isEmpty
+	self assertEmpty: self empty.
+	self denyEmpty: self nonEmpty
 ]
 
 { #category : #'tests - equality' }

--- a/src/Collections-Tests/TSetArithmetic.trait.st
+++ b/src/Collections-Tests/TSetArithmetic.trait.st
@@ -52,11 +52,10 @@ TSetArithmetic >> numberOfSimilarElementsInIntersection [
 
 { #category : #'tests - fixture' }
 TSetArithmetic >> test0FixtureSetAritmeticTest [
-
 	self collection.
-	self deny: self collection isEmpty.
+	self denyEmpty: self collection.
 	self nonEmpty.
-	self deny: self nonEmpty isEmpty.
+	self denyEmpty: self nonEmpty.
 	self anotherElementOrAssociationNotIn.
 	self collection isDictionary
 		ifTrue: [ self deny: (self collection associations includes: self anotherElementOrAssociationNotIn key) ]
@@ -67,15 +66,13 @@ TSetArithmetic >> test0FixtureSetAritmeticTest [
 { #category : #'tests - set arithmetic' }
 TSetArithmetic >> testDifference [
 	"Answer the set theoretic difference of two collections."
-	
-	| difference |
-	self assert: (self collectionWithoutEqualElements difference: self collectionWithoutEqualElements) isEmpty.
-	self assert: (self empty difference: self collectionWithoutEqualElements) isEmpty.
-	difference := (self collectionWithoutEqualElements difference: self empty).
-	self assert: difference size = self collectionWithoutEqualElements size.
-	self collectionWithoutEqualElements do: [ :each |
-		self assert: (difference includes: each) ].
 
+	| difference |
+	self assertEmpty: (self collectionWithoutEqualElements difference: self collectionWithoutEqualElements).
+	self assertEmpty: (self empty difference: self collectionWithoutEqualElements).
+	difference := self collectionWithoutEqualElements difference: self empty.
+	self assert: difference size = self collectionWithoutEqualElements size.
+	self collectionWithoutEqualElements do: [ :each | self assert: (difference includes: each) ]
 ]
 
 { #category : #'tests - set arithmetic' }
@@ -113,22 +110,19 @@ TSetArithmetic >> testDifferenceWithSeparateCollection [
 
 { #category : #'tests - set arithmetic' }
 TSetArithmetic >> testIntersectionBasic [
-
 	| inter |
 	inter := self collection intersection: (self collectionClass with: self anotherElementOrAssociationIn).
-	self deny: inter isEmpty.
+	self denyEmpty: inter.
 	self assert: (inter includes: self anotherElementOrAssociationIn value)
 ]
 
 { #category : #'tests - set arithmetic' }
 TSetArithmetic >> testIntersectionEmpty [
-	
 	| inter |
 	inter := self empty intersection: self empty.
-	self assert: inter isEmpty. 
+	self assertEmpty: inter.
 	inter := self empty intersection: self collection.
 	self assert: inter equals: self empty
-	
 ]
 
 { #category : #'tests - set arithmetic' }
@@ -165,8 +159,5 @@ TSetArithmetic >> testUnion [
 
 { #category : #'tests - set arithmetic' }
 TSetArithmetic >> testUnionOfEmpties [
-	
-	self assert:  (self empty union: self empty) isEmpty.
-	
-	
+	self assertEmpty: (self empty union: self empty)
 ]

--- a/src/Collections-Tests/TSizeTest.trait.st
+++ b/src/Collections-Tests/TSizeTest.trait.st
@@ -22,8 +22,8 @@ TSizeTest >> sizeCollection [
 TSizeTest >> test0TSizeTest [
 	self empty.
 	self sizeCollection.
-	self assert: self empty isEmpty.
-	self deny: self sizeCollection isEmpty
+	self assertEmpty: self empty.
+	self denyEmpty: self sizeCollection
 ]
 
 { #category : #'tests - size capacity' }

--- a/src/Collections-Tests/TSortTest.trait.st
+++ b/src/Collections-Tests/TSortTest.trait.st
@@ -21,7 +21,7 @@ TSortTest >> test0SortingArrayedTest [
 	self unsortedCollection do: [ :each | each isNumber ].
 	sorted := true.
 	self unsortedCollection pairsDo: [ :each1 :each2 | each2 < each1 ifTrue: [ sorted := false ] ].
-	self deny: sorted equals: false.	" a collection of number sorted in an ascending order"
+	self deny: sorted.	" a collection of number sorted in an ascending order"
 	self sortedInAscendingOrderCollection.
 	self sortedInAscendingOrderCollection do: [ :each | each isNumber ].
 	tmp := self sortedInAscendingOrderCollection at: 1.

--- a/src/Collections-Tests/TSortTest.trait.st
+++ b/src/Collections-Tests/TSortTest.trait.st
@@ -20,11 +20,8 @@ TSortTest >> test0SortingArrayedTest [
 	self unsortedCollection.
 	self unsortedCollection do: [ :each | each isNumber ].
 	sorted := true.
-	self unsortedCollection
-		pairsDo: [ :each1 :each2 | 
-			each2 < each1
-				ifTrue: [ sorted := false ] ].
-	self assert: sorted = false.	" a collection of number sorted in an ascending order"
+	self unsortedCollection pairsDo: [ :each1 :each2 | each2 < each1 ifTrue: [ sorted := false ] ].
+	self deny: sorted equals: false.	" a collection of number sorted in an ascending order"
 	self sortedInAscendingOrderCollection.
 	self sortedInAscendingOrderCollection do: [ :each | each isNumber ].
 	tmp := self sortedInAscendingOrderCollection at: 1.

--- a/src/Collections-Tests/TStructuralEqualityTest.trait.st
+++ b/src/Collections-Tests/TStructuralEqualityTest.trait.st
@@ -22,8 +22,8 @@ TStructuralEqualityTest >> nonEmpty [
 TStructuralEqualityTest >> test0TStructuralEqualityTest [
 	self empty.
 	self nonEmpty.
-	self assert: self empty isEmpty.
-	self deny: self nonEmpty isEmpty
+	self assertEmpty: self empty.
+	self denyEmpty: self nonEmpty
 ]
 
 { #category : #'tests - equality' }

--- a/src/Collections-Tests/WeakOrderedCollectionTest.class.st
+++ b/src/Collections-Tests/WeakOrderedCollectionTest.class.st
@@ -38,28 +38,25 @@ WeakOrderedCollectionTest >> testWeakOrderedCollectionAllGarbageCollected [
 { #category : #tests }
 WeakOrderedCollectionTest >> testWeakOrderedCollectionSomeGarbageCollected [
 	| anArray anotherObject weakOrderedCollection |
-	
 	anArray := OrderedCollection new.
-	anotherObject := Time new. 
+	anotherObject := Time new.
 	anotherObject seconds: 40.
 	anArray add: Duration new.
 	anArray add: anotherObject.
 
 	weakOrderedCollection := WeakOrderedCollection new.
-	weakOrderedCollection 
+	weakOrderedCollection
 		add: anArray;
 		add: anotherObject.
-		
+
 	"Let's add lot of stuff to be sure #grow is send."
-	(1 to: 1000) do: [:index | weakOrderedCollection add: Date today ].
-	
+	(1 to: 1000) do: [ :index | weakOrderedCollection add: Date today ].
+
 	anArray := nil.
-	
-	3 timesRepeat: [Smalltalk garbageCollect].
+
+	3 timesRepeat: [ Smalltalk garbageCollect ].
 	self assert: weakOrderedCollection asSet size equals: 2.
 	self assert: (weakOrderedCollection asSet includes: anotherObject).
-	self assert: ((weakOrderedCollection asSet select: [:each | each class = Duration]) isEmpty).
-	self assert: ((weakOrderedCollection asSet select: [:each | each class = OrderedCollection]) isEmpty).
-
-
+	self assertEmpty: (weakOrderedCollection asSet select: [ :each | each class = Duration ]).
+	self assertEmpty: (weakOrderedCollection asSet select: [ :each | each class = OrderedCollection ])
 ]

--- a/src/Collections-Tests/WeakRegistryTest.class.st
+++ b/src/Collections-Tests/WeakRegistryTest.class.st
@@ -19,18 +19,14 @@ WeakRegistryTest >> signalMockException [
 
 { #category : #tests }
 WeakRegistryTest >> testFinalization [
-
 	| w finalized block object |
 	w := WeakRegistry new: 1.
 	finalized := false.
 	block := [ :v | finalized := v ].
-	object := ObjectFinalizer "an object that responds to #finalize"
-		receiver: block
-		selector: #value:
-		argument: true.
+	object := ObjectFinalizer receiver: block selector: #value: argument: true.	"an object that responds to #finalize"
 	w add: object.
-	object := nil. "let it go"
-	Smalltalk garbageCollect. "finalize it"
+	object := nil.	"let it go"
+	Smalltalk garbageCollect.	"finalize it"
 
 	"This is an odd issue. It seems that in some situations the finalization
 	process doesn't run 'in time' for the isEmpty assertion below to succeed.
@@ -40,7 +36,7 @@ WeakRegistryTest >> testFinalization [
 	just wait a little to ensure that the finalization process has been run."
 	(Delay forMilliseconds: 100) wait.
 
-	self assert: w isEmpty.
+	self assertEmpty: w.
 	self assert: finalized
 ]
 
@@ -76,22 +72,17 @@ WeakRegistryTest >> testFinalizationWithBadFinalizer [
 
 { #category : #tests }
 WeakRegistryTest >> testFinalizationWithMultipleFinalizersPerObject [
-
 	| object registry counter |
 	registry := WeakRegistry new.
 	object := Object new.
 	counter := 0.
-	5 timesRepeat: [
-		registry add: object executor: (ObjectFinalizer
-			receiver: [ counter := counter + 1 ]
-			selector: #value) ].
+	5 timesRepeat: [ registry add: object executor: (ObjectFinalizer receiver: [ counter := counter + 1 ] selector: #value) ].
 	self assert: registry size = 1.
-	object := nil. 
+	object := nil.
 	Smalltalk garbageCollect.
 	registry finalizeValues.
-	self assert: registry isEmpty.
+	self assertEmpty: registry.
 	self assert: counter = 5
-
 ]
 
 { #category : #tests }
@@ -178,50 +169,40 @@ WeakRegistryTest >> testGrowingDoesntLeak [
 
 { #category : #tests }
 WeakRegistryTest >> testRemovingByAHighPriorityProcessDoesntLeak [
-
 	| w finalized block hash object executor semaphore |
 	w := WeakRegistry new: 1.
 	finalized := false.
 	block := [ :v | finalized := v ].
 	object := Object new.
-	executor := ObjectFinalizer
-		receiver: block
-		selector: #value:
-		argument: true.
+	executor := ObjectFinalizer receiver: block selector: #value: argument: true.
 	hash := object hash.
 	w add: hash.
 	w add: object executor: executor.
 	semaphore := Semaphore new.
-	[ 
-		object := nil. "let it go"
-		w remove: hash.
-		semaphore signal ] 
-			forkAt: WeakArray runningFinalizationProcess priority + 1.
+	[ object := nil.	"let it go"
+	w remove: hash.
+	semaphore signal ] forkAt: WeakArray runningFinalizationProcess priority + 1.
 	semaphore wait.
-	Smalltalk garbageCollect. "finalize it"
-	self assert: w isEmpty.
+	Smalltalk garbageCollect.	"finalize it"
+	self assertEmpty: w.
 	self assert: finalized
 ]
 
 { #category : #tests }
 WeakRegistryTest >> testRemovingDoesntLeak [
-
 	| w finalized block hash object executor |
 	w := WeakRegistry new: 1.
 	finalized := false.
 	block := [ :v | finalized := v ].
 	object := Object new.
-	executor := ObjectFinalizer
-		receiver: block
-		selector: #value:
-		argument: true.
+	executor := ObjectFinalizer receiver: block selector: #value: argument: true.
 	hash := object hash.
 	w add: hash.
 	w add: object executor: executor.
-	object := nil. "let it go"
+	object := nil.	"let it go"
 	w remove: hash.
-	Smalltalk garbageCollect. "finalize it"
-	self assert: w isEmpty.
+	Smalltalk garbageCollect.	"finalize it"
+	self assertEmpty: w.
 	self assert: finalized
 ]
 

--- a/src/Collections-Tests/WeakValueDictionaryTest.class.st
+++ b/src/Collections-Tests/WeakValueDictionaryTest.class.st
@@ -38,9 +38,7 @@ WeakValueDictionaryTest >> keyWithGarbageCollectedValue [
 
 { #category : #tests }
 WeakValueDictionaryTest >> testAssociationsWithGarbageCollectedValue [
-
-	self assert: self dictionaryWithGarbageCollectedValue associations isEmpty
-
+	self assertEmpty: self dictionaryWithGarbageCollectedValue associations
 ]
 
 { #category : #tests }

--- a/src/Compression-Tests/ZipWriteStreamTests.class.st
+++ b/src/Compression-Tests/ZipWriteStreamTests.class.st
@@ -10,17 +10,16 @@ Class {
 { #category : #tests }
 ZipWriteStreamTests >> testEmptyStrings [
 	| aStream zipStream |
-
 	aStream := ByteArray new writeStream binary.
 	zipStream := ZipWriteStream on: aStream.
-	zipStream nextStringPut: ''. 
+	zipStream nextStringPut: ''.
 	zipStream nextStringPut: ''.
 	zipStream close.
 	aStream close.
 	aStream := aStream contents readStream binary.
 	zipStream := ZipReadStream on: aStream.
-	self assert: zipStream nextString isEmpty. 
-	self assert: zipStream nextString isEmpty.
+	self assertEmpty: zipStream nextString.
+	self assertEmpty: zipStream nextString.
 	zipStream close.
 	aStream close
 ]

--- a/src/Epicea-Tests/EpLogTest.class.st
+++ b/src/Epicea-Tests/EpLogTest.class.st
@@ -128,7 +128,7 @@ EpLogTest >> testHeadReference [
 EpLogTest >> testPriorEntriesFromNullReferenceIsEmpty [
 	| priorEntries |
 	priorEntries := log priorEntriesFrom: log nullReference.
-	self assert: priorEntries isEmpty
+	self assertEmpty: priorEntries
 ]
 
 { #category : #tests }

--- a/src/EpiceaBrowsers-Tests/EpLostChangesDetectorTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpLostChangesDetectorTest.class.st
@@ -12,26 +12,22 @@ Class {
 
 { #category : #tests }
 EpLostChangesDetectorTest >> testDetectInEmptyLog [
-
 	detector := EpLostChangesDetector newWithLog: monitor log.
 	self deny: detector hasLostChanges.
-	self assert: detector lostChanges isEmpty.
+	self assertEmpty: detector lostChanges.
 
-	self assert: monitor log entries isEmpty. "Just to be sure of the assumed precondition"
-
+	self assertEmpty: monitor log entries	"Just to be sure of the assumed precondition"
 ]
 
 { #category : #tests }
 EpLostChangesDetectorTest >> testDetectNoChange [
-
 	classFactory newClass.
 	monitor log store flush.
 	detector := EpLostChangesDetector newWithLog: monitor log.
 	self deny: detector hasLostChanges.
-	self assert: detector lostChanges isEmpty.
+	self assertEmpty: detector lostChanges.
 
-	self assert: monitor log entriesCount equals: 2. "Just to be sure of the assumed precondition: category and only one class created"
-
+	self assert: monitor log entriesCount equals: 2	"Just to be sure of the assumed precondition: category and only one class created"
 ]
 
 { #category : #tests }
@@ -66,6 +62,6 @@ EpLostChangesDetectorTest >> testDetectOneChangeButFileDeleted [
 
 	detector := EpLostChangesDetector newWithLog: logWithALostChange.
 	self deny: detector hasLostChanges.
-	self assert: detector lostChanges isEmpty.
+	self assertEmpty: detector lostChanges.
 
 ]

--- a/src/FileSystem-Tests-Core/PathTest.class.st
+++ b/src/FileSystem-Tests-Core/PathTest.class.st
@@ -293,7 +293,7 @@ PathTest >> testIsChildOfReference [
 
 { #category : #tests }
 PathTest >> testIsEmpty [
-	self assert: (Path workingDirectory) isEmpty
+	self assertEmpty: Path workingDirectory
 ]
 
 { #category : #tests }

--- a/src/FreeType-Tests/FreeTypeCacheTest.class.st
+++ b/src/FreeType-Tests/FreeTypeCacheTest.class.st
@@ -91,15 +91,10 @@ FreeTypeCacheTest >> testEntriesRemovedFIFO [
 
 { #category : #tests }
 FreeTypeCacheTest >> testFailedGet [
-	| |
-
-	self 
-		should: [cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph] 
-		raise: Error.
-	self assert: (cache instVarNamed: #fontTable) isEmpty. 
-	self assert: (cache instVarNamed: #used) = 0.
+	self should: [ cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph ] raise: Error.
+	self assertEmpty: (cache instVarNamed: #fontTable).
+	self assert: (cache instVarNamed: #used) equals: 0.
 	self validateSizes: cache
-	
 ]
 
 { #category : #tests }
@@ -123,10 +118,9 @@ FreeTypeCacheTest >> testInstanceInitialization [
 	self assert: (cache instVarNamed: #maximumSize) = FreeTypeCache defaultMaximumSize.
 	self assert: (cache instVarNamed: #used) = 0.
 	self assert: (cache instVarNamed: #fontTable) class = cache dictionaryClass.
-	self assert: (cache instVarNamed: #fontTable) isEmpty.
+	self assertEmpty: (cache instVarNamed: #fontTable).
 	self assert: (cache instVarNamed: #fifo) class = cache fifoClass.
-	self assert: (cache instVarNamed: #fifo) isEmpty.
-	
+	self assertEmpty: (cache instVarNamed: #fifo)
 ]
 
 { #category : #tests }
@@ -328,12 +322,12 @@ FreeTypeCacheTest >> testRemoveAll [
 	fifo := fullCache instVarNamed: #fifo.
 	fontTable := fullCache instVarNamed: #fontTable.
 	fullCache removeAll.
-	self assert: (fullCache instVarNamed: #fifo) isEmpty.
-	self assert: (fullCache instVarNamed: #fontTable) isEmpty.
+	self assertEmpty: (fullCache instVarNamed: #fifo).
+	self assertEmpty: (fullCache instVarNamed: #fontTable).
 	self assert: (fullCache instVarNamed: #used) = 0.
 	self assert: m = (fullCache instVarNamed: #maximumSize).
 	self assert: fifo class = (fullCache instVarNamed: #fifo) class.
-	self assert: fontTable class = (fullCache instVarNamed: #fontTable) class.	
+	self assert: fontTable class = (fullCache instVarNamed: #fontTable) class
 ]
 
 { #category : #tests }

--- a/src/Fuel-Tests-Core/FLBasicSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLBasicSerializationTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'currentTimeZone'
 	],
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #failures }

--- a/src/Fuel-Tests-Core/FLBinaryFileStreamSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLBinaryFileStreamSerializationTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FLBinaryFileStreamSerializationTest,
 	#superclass : #FLBasicSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #running }

--- a/src/Fuel-Tests-Core/FLBinaryFileStreamStrategy.class.st
+++ b/src/Fuel-Tests-Core/FLBinaryFileStreamStrategy.class.st
@@ -4,7 +4,7 @@ Specific to BinaryFileStream
 Class {
 	#name : #FLBinaryFileStreamStrategy,
 	#superclass : #FLFileStreamStrategy,
-	#category : 'Fuel-Tests-Core-StreamStrategies'
+	#category : #'Fuel-Tests-Core-StreamStrategies'
 }
 
 { #category : #reading }

--- a/src/Fuel-Tests-Core/FLBlockClosureSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLBlockClosureSerializationTest.class.st
@@ -10,7 +10,7 @@ Class {
 	#classInstVars : [
 		'interval'
 	],
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #'closures for testing' }

--- a/src/Fuel-Tests-Core/FLByteArrayStreamStrategy.class.st
+++ b/src/Fuel-Tests-Core/FLByteArrayStreamStrategy.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'inMemoryStream'
 	],
-	#category : 'Fuel-Tests-Core-StreamStrategies'
+	#category : #'Fuel-Tests-Core-StreamStrategies'
 }
 
 { #category : #reading }

--- a/src/Fuel-Tests-Core/FLClassSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLClassSerializationTest.class.st
@@ -4,7 +4,7 @@ I have the common behavior for testing class serialization.
 Class {
 	#name : #FLClassSerializationTest,
 	#superclass : #FLSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #tests }

--- a/src/Fuel-Tests-Core/FLClassWithRecursiveSubstitution.class.st
+++ b/src/Fuel-Tests-Core/FLClassWithRecursiveSubstitution.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'index'
 	],
-	#category : 'Fuel-Tests-Core-Mocks'
+	#category : #'Fuel-Tests-Core-Mocks'
 }
 
 { #category : #serialization }

--- a/src/Fuel-Tests-Core/FLCompiledMethodSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLCompiledMethodSerializationTest.class.st
@@ -20,23 +20,23 @@ FLCompiledMethodSerializationTest >> testDoIt [
 	"Since Pharo 3.0 decompilation of compiled methods is no longer possible.
 	That means we have to store the source too."
 	self useDoIt.
-	
+
 	theCompiledMethod selector: #DoIt.
 	self assert: theCompiledMethod isDoIt.
 	self assert: theCompiledMethod isInstalled.
 	self deny: theCompiledMethod trailer hasSource.
-	self assert: theCompiledMethod trailer isEmpty.
+	self assertEmpty: theCompiledMethod trailer.
 	self deny: theCompiledMethod trailer hasSourcePointer.
-	
+
 	materialized := self resultOfSerializeAndMaterialize: theCompiledMethod.
 	"not possible since it's a different instance"
 	self deny: materialized isInstalled.
 	self assert: materialized isDoIt.
 	"we serialized the source"
 	self assert: materialized trailer hasSource.
-	self deny: materialized trailer isEmpty.
+	self denyEmpty: materialized trailer.
 	self deny: materialized trailer hasSourcePointer.
-	
+
 	self assert: (materialized isEqualRegardlessTrailerTo: theCompiledMethod)
 ]
 
@@ -50,7 +50,7 @@ FLCompiledMethodSerializationTest >> testInstalled [
 	self assert: theCompiledMethod isInstalled.
 	self deny: theCompiledMethod isDoIt.
 	self deny: theCompiledMethod trailer hasSource.
-	self deny: theCompiledMethod trailer isEmpty.
+	self denyEmpty: theCompiledMethod trailer.
 	self assert: theCompiledMethod trailer hasSourcePointer.
 	
 	"if installed but not different, the installed instance will be answered"
@@ -68,7 +68,7 @@ FLCompiledMethodSerializationTest >> testInstalledModified [
 	self assert: theCompiledMethod isInstalled.
 	self deny: theCompiledMethod isDoIt.
 	self deny: theCompiledMethod trailer hasSource.
-	self deny: theCompiledMethod trailer isEmpty.
+	self denyEmpty: theCompiledMethod trailer.
 	self assert: theCompiledMethod trailer hasSourcePointer.
 	
 	copy := theCompiledMethod copy.
@@ -76,7 +76,7 @@ FLCompiledMethodSerializationTest >> testInstalledModified [
 	self deny: copy isInstalled.
 	self deny: copy isDoIt.
 	self deny: copy trailer hasSource.
-	self deny: copy trailer isEmpty.
+	self denyEmpty: copy trailer.
 	self assert: copy trailer hasSourcePointer.
 	
 	"if installed but not different, the installed instance will be answered"
@@ -87,7 +87,7 @@ FLCompiledMethodSerializationTest >> testInstalledModified [
 	self deny: materialized isDoIt.
 	"we serialized the source"
 	self assert: materialized trailer hasSource.
-	self deny: materialized trailer isEmpty.
+	self denyEmpty: materialized trailer.
 	self deny: materialized trailer hasSourcePointer
 ]
 
@@ -101,7 +101,7 @@ FLCompiledMethodSerializationTest >> testNotInstalled [
 	self deny: theCompiledMethod isInstalled.
 	self deny: theCompiledMethod isDoIt.
 	self deny: theCompiledMethod trailer hasSource.
-	self assert: theCompiledMethod trailer isEmpty.
+	self assertEmpty: theCompiledMethod trailer.
 	self deny: theCompiledMethod trailer hasSourcePointer.
 	
 	materialized := self resultOfSerializeAndMaterialize: theCompiledMethod.
@@ -109,7 +109,7 @@ FLCompiledMethodSerializationTest >> testNotInstalled [
 	self deny: materialized isDoIt.
 	"we serialized the source"
 	self assert: materialized trailer hasSource.
-	self deny: materialized trailer isEmpty.
+	self denyEmpty: materialized trailer.
 	self deny: materialized trailer hasSourcePointer.
 	
 	self assert: (materialized isEqualRegardlessTrailerTo: theCompiledMethod)

--- a/src/Fuel-Tests-Core/FLCompiledMethodSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLCompiledMethodSerializationTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'theCompiledMethod',
 		'theClass'
 	],
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #running }
@@ -34,7 +34,7 @@ FLCompiledMethodSerializationTest >> testDoIt [
 	self assert: materialized isDoIt.
 	"we serialized the source"
 	self assert: materialized trailer hasSource.
-	self denyEmpty: materialized trailer.
+	self deny: materialized trailer isEmpty.
 	self deny: materialized trailer hasSourcePointer.
 
 	self assert: (materialized isEqualRegardlessTrailerTo: theCompiledMethod)
@@ -50,7 +50,7 @@ FLCompiledMethodSerializationTest >> testInstalled [
 	self assert: theCompiledMethod isInstalled.
 	self deny: theCompiledMethod isDoIt.
 	self deny: theCompiledMethod trailer hasSource.
-	self denyEmpty: theCompiledMethod trailer.
+	self deny: theCompiledMethod trailer isEmpty.
 	self assert: theCompiledMethod trailer hasSourcePointer.
 	
 	"if installed but not different, the installed instance will be answered"
@@ -68,7 +68,7 @@ FLCompiledMethodSerializationTest >> testInstalledModified [
 	self assert: theCompiledMethod isInstalled.
 	self deny: theCompiledMethod isDoIt.
 	self deny: theCompiledMethod trailer hasSource.
-	self denyEmpty: theCompiledMethod trailer.
+	self deny: theCompiledMethod trailer isEmpty.
 	self assert: theCompiledMethod trailer hasSourcePointer.
 	
 	copy := theCompiledMethod copy.
@@ -76,7 +76,7 @@ FLCompiledMethodSerializationTest >> testInstalledModified [
 	self deny: copy isInstalled.
 	self deny: copy isDoIt.
 	self deny: copy trailer hasSource.
-	self denyEmpty: copy trailer.
+	self deny: copy trailer isEmpty.
 	self assert: copy trailer hasSourcePointer.
 	
 	"if installed but not different, the installed instance will be answered"
@@ -87,7 +87,7 @@ FLCompiledMethodSerializationTest >> testInstalledModified [
 	self deny: materialized isDoIt.
 	"we serialized the source"
 	self assert: materialized trailer hasSource.
-	self denyEmpty: materialized trailer.
+	self deny: materialized trailer isEmpty.
 	self deny: materialized trailer hasSourcePointer
 ]
 
@@ -109,7 +109,7 @@ FLCompiledMethodSerializationTest >> testNotInstalled [
 	self deny: materialized isDoIt.
 	"we serialized the source"
 	self assert: materialized trailer hasSource.
-	self denyEmpty: materialized trailer.
+	self deny: materialized trailer isEmpty.
 	self deny: materialized trailer hasSourcePointer.
 	
 	self assert: (materialized isEqualRegardlessTrailerTo: theCompiledMethod)

--- a/src/Fuel-Tests-Core/FLDelayedSerializationMock.class.st
+++ b/src/Fuel-Tests-Core/FLDelayedSerializationMock.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FLDelayedSerializationMock,
 	#superclass : #FLSerialization,
-	#category : 'Fuel-Tests-Core-Mocks'
+	#category : #'Fuel-Tests-Core-Mocks'
 }
 
 { #category : #serializing }

--- a/src/Fuel-Tests-Core/FLDelayedSerializerMock.class.st
+++ b/src/Fuel-Tests-Core/FLDelayedSerializerMock.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FLDelayedSerializerMock,
 	#superclass : #FLSerializer,
-	#category : 'Fuel-Tests-Core-Mocks'
+	#category : #'Fuel-Tests-Core-Mocks'
 }
 
 { #category : #protected }

--- a/src/Fuel-Tests-Core/FLFileStreamStrategy.class.st
+++ b/src/Fuel-Tests-Core/FLFileStreamStrategy.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'fileStreamClass'
 	],
-	#category : 'Fuel-Tests-Core-StreamStrategies'
+	#category : #'Fuel-Tests-Core-StreamStrategies'
 }
 
 { #category : #'instance creation' }

--- a/src/Fuel-Tests-Core/FLGZipStrategy.class.st
+++ b/src/Fuel-Tests-Core/FLGZipStrategy.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'targetStrategy'
 	],
-	#category : 'Fuel-Tests-Core-StreamStrategies'
+	#category : #'Fuel-Tests-Core-StreamStrategies'
 }
 
 { #category : #'instance creation' }

--- a/src/Fuel-Tests-Core/FLGZippedBasicSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLGZippedBasicSerializationTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for basic serialization that is zipped
 Class {
 	#name : #FLGZippedBasicSerializationTest,
 	#superclass : #FLBasicSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #testing }

--- a/src/Fuel-Tests-Core/FLGlobalClassSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLGlobalClassSerializationTest.class.st
@@ -6,7 +6,7 @@ Class {
 	#superclass : #FLClassSerializationTest,
 	#traits : 'FLTGlobalClassOrTraitSerializationTest',
 	#classTraits : 'FLTGlobalClassOrTraitSerializationTest classTrait',
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #tests }

--- a/src/Fuel-Tests-Core/FLGlobalEnvironmentTest.class.st
+++ b/src/Fuel-Tests-Core/FLGlobalEnvironmentTest.class.st
@@ -8,7 +8,7 @@ Class {
 		'serializationEnvironment',
 		'materializationEnvironment'
 	],
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #running }

--- a/src/Fuel-Tests-Core/FLGlobalSendMock.class.st
+++ b/src/Fuel-Tests-Core/FLGlobalSendMock.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'contents'
 	],
-	#category : 'Fuel-Tests-Core-Mocks'
+	#category : #'Fuel-Tests-Core-Mocks'
 }
 
 { #category : #'instance creation' }

--- a/src/Fuel-Tests-Core/FLGlobalSendNotPresentMock.class.st
+++ b/src/Fuel-Tests-Core/FLGlobalSendNotPresentMock.class.st
@@ -4,7 +4,7 @@ A test mock where a global send is not present
 Class {
 	#name : #FLGlobalSendNotPresentMock,
 	#superclass : #Object,
-	#category : 'Fuel-Tests-Core-Mocks'
+	#category : #'Fuel-Tests-Core-Mocks'
 }
 
 { #category : #serialization }

--- a/src/Fuel-Tests-Core/FLGlobalSendSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLGlobalSendSerializationTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for fuel serialization of global sends
 Class {
 	#name : #FLGlobalSendSerializationTest,
 	#superclass : #FLSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #tests }

--- a/src/Fuel-Tests-Core/FLGlobalTraitSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLGlobalTraitSerializationTest.class.st
@@ -6,5 +6,5 @@ Class {
 	#superclass : #FLTraitSerializationTest,
 	#traits : 'FLTGlobalClassOrTraitSerializationTest',
 	#classTraits : 'FLTGlobalClassOrTraitSerializationTest classTrait',
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }

--- a/src/Fuel-Tests-Core/FLHashedCollectionSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLHashedCollectionSerializationTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for fuel serialization of hashed collections
 Class {
 	#name : #FLHashedCollectionSerializationTest,
 	#superclass : #FLSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #tests }

--- a/src/Fuel-Tests-Core/FLHeaderSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLHeaderSerializationTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for header serialization in fuel
 Class {
 	#name : #FLHeaderSerializationTest,
 	#superclass : #FLSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #tests }

--- a/src/Fuel-Tests-Core/FLHookedSubstitutionTest.class.st
+++ b/src/Fuel-Tests-Core/FLHookedSubstitutionTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for hooked serialization using fuel
 Class {
 	#name : #FLHookedSubstitutionTest,
 	#superclass : #FLSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #tests }

--- a/src/Fuel-Tests-Core/FLIgnoredVariablesTest.class.st
+++ b/src/Fuel-Tests-Core/FLIgnoredVariablesTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for serialization with ignored variables
 Class {
 	#name : #FLIgnoredVariablesTest,
 	#superclass : #FLClassSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #tests }

--- a/src/Fuel-Tests-Core/FLInMemoryBasicSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLInMemoryBasicSerializationTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'byteArray'
 	],
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #testing }

--- a/src/Fuel-Tests-Core/FLIndexStreamTest.class.st
+++ b/src/Fuel-Tests-Core/FLIndexStreamTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for index streams
 Class {
 	#name : #FLIndexStreamTest,
 	#superclass : #TestCase,
-	#category : 'Fuel-Tests-Core-Streams'
+	#category : #'Fuel-Tests-Core-Streams'
 }
 
 { #category : #running }

--- a/src/Fuel-Tests-Core/FLMigrationTest.class.st
+++ b/src/Fuel-Tests-Core/FLMigrationTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for migrations
 Class {
 	#name : #FLMigrationTest,
 	#superclass : #FLClassSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #running }

--- a/src/Fuel-Tests-Core/FLMultiByteStreamStrategy.class.st
+++ b/src/Fuel-Tests-Core/FLMultiByteStreamStrategy.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'inMemoryStream'
 	],
-	#category : 'Fuel-Tests-Core-StreamStrategies'
+	#category : #'Fuel-Tests-Core-StreamStrategies'
 }
 
 { #category : #reading }

--- a/src/Fuel-Tests-Core/FLNotSerializableMock.class.st
+++ b/src/Fuel-Tests-Core/FLNotSerializableMock.class.st
@@ -4,7 +4,7 @@ A test mock which is not serializable
 Class {
 	#name : #FLNotSerializableMock,
 	#superclass : #Object,
-	#category : 'Fuel-Tests-Core-Mocks'
+	#category : #'Fuel-Tests-Core-Mocks'
 }
 
 { #category : #hooks }

--- a/src/Fuel-Tests-Core/FLPair.class.st
+++ b/src/Fuel-Tests-Core/FLPair.class.st
@@ -8,7 +8,7 @@ Class {
 		'left',
 		'right'
 	],
-	#category : 'Fuel-Tests-Core-Mocks'
+	#category : #'Fuel-Tests-Core-Mocks'
 }
 
 { #category : #comparing }

--- a/src/Fuel-Tests-Core/FLPerson.class.st
+++ b/src/Fuel-Tests-Core/FLPerson.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'id'
 	],
-	#category : 'Fuel-Tests-Core-Mocks'
+	#category : #'Fuel-Tests-Core-Mocks'
 }
 
 { #category : #comparing }

--- a/src/Fuel-Tests-Core/FLPluggableSubstitutionTest.class.st
+++ b/src/Fuel-Tests-Core/FLPluggableSubstitutionTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for fuels pluggable substitutions
 Class {
 	#name : #FLPluggableSubstitutionTest,
 	#superclass : #FLSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #tests }

--- a/src/Fuel-Tests-Core/FLProcessSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLProcessSerializationTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FLProcessSerializationTest,
 	#superclass : #FLBasicSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #running }

--- a/src/Fuel-Tests-Core/FLProxyThatBecomesItsContent.class.st
+++ b/src/Fuel-Tests-Core/FLProxyThatBecomesItsContent.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'contents'
 	],
-	#category : 'Fuel-Tests-Core-Mocks'
+	#category : #'Fuel-Tests-Core-Mocks'
 }
 
 { #category : #'instance creation' }

--- a/src/Fuel-Tests-Core/FLReplacementClassMock.class.st
+++ b/src/Fuel-Tests-Core/FLReplacementClassMock.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FLReplacementClassMock,
 	#superclass : #FLReplacementMock,
-	#category : 'Fuel-Tests-Core-Mocks'
+	#category : #'Fuel-Tests-Core-Mocks'
 }
 
 { #category : #accessing }

--- a/src/Fuel-Tests-Core/FLReplacementMock.class.st
+++ b/src/Fuel-Tests-Core/FLReplacementMock.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'ignoreMe'
 	],
-	#category : 'Fuel-Tests-Core-Mocks'
+	#category : #'Fuel-Tests-Core-Mocks'
 }
 
 { #category : #comparing }

--- a/src/Fuel-Tests-Core/FLSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLSerializationTest.class.st
@@ -11,7 +11,7 @@ Class {
 		'streamFactory',
 		'traits'
 	],
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #accessing }

--- a/src/Fuel-Tests-Core/FLSignatureTest.class.st
+++ b/src/Fuel-Tests-Core/FLSignatureTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for fuel serializations, here signatures
 Class {
 	#name : #FLSignatureTest,
 	#superclass : #FLSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #tests }

--- a/src/Fuel-Tests-Core/FLSimpleStackTest.class.st
+++ b/src/Fuel-Tests-Core/FLSimpleStackTest.class.st
@@ -27,20 +27,16 @@ FLSimpleStackTest >> testGrow [
 
 { #category : #testing }
 FLSimpleStackTest >> testIsEmpty [
-
-	| stack |
-	stack := FLSimpleStack new.
-	self assert: stack isEmpty.
+	self assertEmpty: FLSimpleStack new
 ]
 
 { #category : #testing }
 FLSimpleStackTest >> testPop [
-
 	| stack |
 	stack := FLSimpleStack new.
 	stack push: 1.
 	stack pop.
-	self assert: stack isEmpty.
+	self assertEmpty: stack
 ]
 
 { #category : #testing }

--- a/src/Fuel-Tests-Core/FLSimpleStackTest.class.st
+++ b/src/Fuel-Tests-Core/FLSimpleStackTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FLSimpleStackTest,
 	#superclass : #TestCase,
-	#category : 'Fuel-Tests-Core-Collections'
+	#category : #'Fuel-Tests-Core-Collections'
 }
 
 { #category : #testing }

--- a/src/Fuel-Tests-Core/FLSingletonMock.class.st
+++ b/src/Fuel-Tests-Core/FLSingletonMock.class.st
@@ -10,7 +10,7 @@ Class {
 	#classVars : [
 		'Instance'
 	],
-	#category : 'Fuel-Tests-Core-Mocks'
+	#category : #'Fuel-Tests-Core-Mocks'
 }
 
 { #category : #accessing }

--- a/src/Fuel-Tests-Core/FLSingletonMockEnforced.class.st
+++ b/src/Fuel-Tests-Core/FLSingletonMockEnforced.class.st
@@ -4,7 +4,7 @@ A test mock where a new instance is enforced
 Class {
 	#name : #FLSingletonMockEnforced,
 	#superclass : #FLSingletonMock,
-	#category : 'Fuel-Tests-Core-Mocks'
+	#category : #'Fuel-Tests-Core-Mocks'
 }
 
 { #category : #fuel }

--- a/src/Fuel-Tests-Core/FLSingletonTest.class.st
+++ b/src/Fuel-Tests-Core/FLSingletonTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for fuel serialization of singletons
 Class {
 	#name : #FLSingletonTest,
 	#superclass : #FLSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #running }

--- a/src/Fuel-Tests-Core/FLSortedCollectionSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLSortedCollectionSerializationTest.class.st
@@ -10,7 +10,7 @@ Class {
 	#classVars : [
 		'ClassVariableForTesting'
 	],
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #'sorted collections for testing' }

--- a/src/Fuel-Tests-Core/FLStandardFileStreamSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLStandardFileStreamSerializationTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FLStandardFileStreamSerializationTest,
 	#superclass : #FLBasicSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #running }

--- a/src/Fuel-Tests-Core/FLStreamStrategy.class.st
+++ b/src/Fuel-Tests-Core/FLStreamStrategy.class.st
@@ -4,7 +4,7 @@ I am a strategy that help tests for writing (and then reading) on streams.
 Class {
 	#name : #FLStreamStrategy,
 	#superclass : #Object,
-	#category : 'Fuel-Tests-Core-StreamStrategies'
+	#category : #'Fuel-Tests-Core-StreamStrategies'
 }
 
 { #category : #serializing }

--- a/src/Fuel-Tests-Core/FLTGlobalClassOrTraitSerializationTest.trait.st
+++ b/src/Fuel-Tests-Core/FLTGlobalClassOrTraitSerializationTest.trait.st
@@ -3,7 +3,7 @@ I test the serialization of classes and traits as *external* objects, i.e. the c
 "
 Trait {
 	#name : #FLTGlobalClassOrTraitSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #tests }

--- a/src/Fuel-Tests-Core/FLTraitSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLTraitSerializationTest.class.st
@@ -4,7 +4,7 @@ I have the common behavior for testing trait serialization.
 Class {
 	#name : #FLTraitSerializationTest,
 	#superclass : #FLSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #running }

--- a/src/Fuel-Tests-Core/FLUserGuidesTest.class.st
+++ b/src/Fuel-Tests-Core/FLUserGuidesTest.class.st
@@ -4,7 +4,7 @@ SUnit tests to guide users with fuel serialization
 Class {
 	#name : #FLUserGuidesTest,
 	#superclass : #FLSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #running }

--- a/src/Fuel-Tests-Core/FLVersionTest.class.st
+++ b/src/Fuel-Tests-Core/FLVersionTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for fuel versioning
 Class {
 	#name : #FLVersionTest,
 	#superclass : #FLSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #tests }

--- a/src/Fuel-Tests-Core/FLWeakClassMock.class.st
+++ b/src/Fuel-Tests-Core/FLWeakClassMock.class.st
@@ -8,7 +8,7 @@ Class {
 	#instVars : [
 		'instVar1'
 	],
-	#category : 'Fuel-Tests-Core-Mocks'
+	#category : #'Fuel-Tests-Core-Mocks'
 }
 
 { #category : #accessing }

--- a/src/Fuel-Tests-Core/FLWeakObjectsTest.class.st
+++ b/src/Fuel-Tests-Core/FLWeakObjectsTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for fuel serialization of weak objects
 Class {
 	#name : #FLWeakObjectsTest,
 	#superclass : #FLSerializationTest,
-	#category : 'Fuel-Tests-Core-Base'
+	#category : #'Fuel-Tests-Core-Base'
 }
 
 { #category : #tests }

--- a/src/FuzzyMatcher-Tests/FuzzyMatcherTests.class.st
+++ b/src/FuzzyMatcher-Tests/FuzzyMatcherTests.class.st
@@ -87,21 +87,14 @@ FuzzyMatcherTests >> testClassSideAPI [
 
 { #category : #tests }
 FuzzyMatcherTests >> testEmptyPattern [
-
 	| matcher |
-	
 	matcher := self newMatcher.
-	
+
 	self
-	
-		assert: matcher pattern isEmpty; 
-		
-		assert: matcher scoreFor: '' 		equals: 0;
-		assert: matcher scoreFor: 'abc' 	equals: 0;
-		assert: matcher scoreFor: '   ' 	equals: 0.
-			
-			
-	
+		assertEmpty: matcher pattern;
+		assert: matcher scoreFor: '' equals: 0;
+		assert: matcher scoreFor: 'abc' equals: 0;
+		assert: matcher scoreFor: '   ' equals: 0
 ]
 
 { #category : #tests }

--- a/src/GT-EventRecorder-Tests/GTEventCollectorTest.class.st
+++ b/src/GT-EventRecorder-Tests/GTEventCollectorTest.class.st
@@ -18,7 +18,7 @@ GTEventCollectorTest >> setUp [
 
 { #category : #tests }
 GTEventCollectorTest >> testBundle [
-	self assert: collector bundle isEmpty
+	self assertEmpty: collector bundle
 ]
 
 { #category : #tests }
@@ -26,7 +26,7 @@ GTEventCollectorTest >> testBundle2 [
 	collector add: GTDummyEvent new.
 	collector add: GTDummyEvent new.
 	self assert: collector bundle size equals: 2.
-	self assert: collector bundle isEmpty.
+	self assertEmpty: collector bundle
 ]
 
 { #category : #tests }

--- a/src/GT-EventRecorder-Tests/GTEventMultiBundleTest.class.st
+++ b/src/GT-EventRecorder-Tests/GTEventMultiBundleTest.class.st
@@ -29,7 +29,7 @@ GTEventMultiBundleTest >> setUp [
 
 { #category : #tests }
 GTEventMultiBundleTest >> testEntity [
-	self assert: multiBundle entity isEmpty
+	self assertEmpty: multiBundle entity
 ]
 
 { #category : #tests }

--- a/src/GT-Spotter-EventRecorder/GTSpotterEventCollectorBackwardCompatibilityTest.class.st
+++ b/src/GT-Spotter-EventRecorder/GTSpotterEventCollectorBackwardCompatibilityTest.class.st
@@ -128,19 +128,16 @@ GTSpotterEventCollectorBackwardCompatibilityTest >> testMaterializeVersions [
 	| versions notMaterializedEvents |
 	checkedEvents := Set new.
 	versions := self allPragmaVersions.
-	self assert: versions notEmpty.
-	versions
-		do: [ :eachPragma | self assertVersion: eachPragma methodSelector ].
+	self denyEmpty: versions.
+	versions do: [ :eachPragma | self assertVersion: eachPragma methodSelector ].
 	self assert: checkedEvents notEmpty.
 	notMaterializedEvents := GTSpotterRecorderEvent allSubclasses
 		removeAll: checkedEvents;
 		yourself.
 	self
 		assert: notMaterializedEvents isEmpty
-		description: [ 'Some events are not tested for backward compatibility.' , String cr
-				,
-					'You should create new version using method #storeSerializedAnnouncementIntoMethod:.'
-				, String cr , 'Do not override the existing serialized versions!' ]
+		description: [ 'Some events are not tested for backward compatibility.' , String cr , 'You should create new version using method #storeSerializedAnnouncementIntoMethod:.' , String cr
+				, 'Do not override the existing serialized versions!' ]
 ]
 
 { #category : #'serialized data' }

--- a/src/GT-Spotter-EventRecorder/GTSpotterEventCollectorTest.class.st
+++ b/src/GT-Spotter-EventRecorder/GTSpotterEventCollectorTest.class.st
@@ -21,7 +21,7 @@ GTSpotterEventCollectorTest >> testBundle [
 	| events bundle |
 	"collecting data"
 	events := OrderedCollection new.
-	events 
+	events
 		add: GTSpotterRecorderOpenEvent new;
 		add: GTSpotterRecorderShowPreviewEvent new;
 		add: GTSpotterRecorderExitAnnouncementEvent new;
@@ -34,17 +34,14 @@ GTSpotterEventCollectorTest >> testBundle [
 	"first delivery"
 	bundle := collector bundle.
 	self assert: collector postponedEvents size equals: 2.
-	7 to: 8 do: [ :index |
-		self assert: (events at: index) == (collector postponedEvents at: index - 6) ].
+	7 to: 8 do: [ :index | self assert: (events at: index) == (collector postponedEvents at: index - 6) ].
 	self assert: bundle size equals: 6.
-	bundle withIndexDo: [ :eachEvent :index |
-		self assert: (events at: index) class = eachEvent class ].
+	bundle withIndexDo: [ :eachEvent :index | self assert: (events at: index) class = eachEvent class ].
 	"second delivery"
 	bundle := collector bundle.
 	self assert: collector postponedEvents size equals: 2.
-	7 to: 8 do: [ :index |
-		self assert: (events at: index) == (collector postponedEvents at: index - 6) ].
-	self assert: bundle isEmpty.
+	7 to: 8 do: [ :index | self assert: (events at: index) == (collector postponedEvents at: index - 6) ].
+	self assertEmpty: bundle.
 	"third delivery"
 	collector add: GTSpotterRecorderExitAnnouncementEvent new.
 	bundle := collector bundle.
@@ -52,7 +49,7 @@ GTSpotterEventCollectorTest >> testBundle [
 	self assert: bundle size equals: 3.
 	self assert: bundle first class equals: (events at: 7) class.
 	self assert: bundle second class equals: (events at: 8) class.
-	self assert: bundle third class equals: GTSpotterRecorderExitAnnouncementEvent.
+	self assert: bundle third class equals: GTSpotterRecorderExitAnnouncementEvent
 ]
 
 { #category : #tests }

--- a/src/GT-Tests-Debugger/GTGenericStackDebuggerUITest.class.st
+++ b/src/GT-Tests-Debugger/GTGenericStackDebuggerUITest.class.st
@@ -6,20 +6,14 @@ Class {
 
 { #category : #testing }
 GTGenericStackDebuggerUITest >> testNoOverlappingCodeEditorKeyBindings [
-
 	| context process codeEditor keymaps doubleKeymaps |
-	
-		self skip.
+	self skip.
 	context := [ 20 factorial ] asContext.
-	process := Process
-		forContext: context
-		priority: Processor userInterruptPriority.
+	process := Process forContext: context priority: Processor userInterruptPriority.
 	window := GTGenericStackDebugger openOn: (process newDebugSessionNamed: 'test debugging' startedAt: context).
-	codeEditor := self findSatisfying: [ :morph | 
-		morph model isKindOf: GLMRubricSmalltalkTextModel ] in: window.
+	codeEditor := self findSatisfying: [ :morph | morph model isKindOf: GLMRubricSmalltalkTextModel ] in: window.
 	keymaps := OrderedCollection new.
-	codeEditor withAllOwnersDo: [:morph | 
-		keymaps addAll: morph kmDispatcher directKeymaps allEntries keymaps ].
-	doubleKeymaps := (keymaps groupedBy: [:each | each shortcut ]) select: [ :each | each value size > 1 ].
-	self assert: doubleKeymaps isEmpty
+	codeEditor withAllOwnersDo: [ :morph | keymaps addAll: morph kmDispatcher directKeymaps allEntries keymaps ].
+	doubleKeymaps := (keymaps groupedBy: [ :each | each shortcut ]) select: [ :each | each value size > 1 ].
+	self assertEmpty: doubleKeymaps
 ]

--- a/src/GT-Tests-Spotter/GTSpotterExceptionsTest.class.st
+++ b/src/GT-Tests-Spotter/GTSpotterExceptionsTest.class.st
@@ -29,15 +29,15 @@ GTSpotterExceptionsTest class >> reset [
 
 { #category : #private }
 GTSpotterExceptionsTest >> assertException: anErrorClass [
-	self deny: self class exceptions isEmpty.
+	self denyEmpty: self class exceptions.
 	self assert: (self class exceptions anySatisfy: [ :e | e class == anErrorClass ]).
-	self assert: self class fatals isEmpty.
+	self assertEmpty: self class fatals
 ]
 
 { #category : #private }
 GTSpotterExceptionsTest >> assertNoExceptions [
-	self assert: self class exceptions isEmpty.
-	self assert: self class fatals isEmpty.
+	self assertEmpty: self class exceptions.
+	self assertEmpty: self class fatals
 ]
 
 { #category : #private }

--- a/src/GT-Tests-Spotter/GTSpotterStepTest.class.st
+++ b/src/GT-Tests-Spotter/GTSpotterStepTest.class.st
@@ -133,7 +133,7 @@ GTSpotterStepTest >> assertProcessorMatching: aBlock [
 { #category : #convenience }
 GTSpotterStepTest >> assertProcessorNotEmpty [
 	self assert: currentProcessor notNil.
-	self denyEmpty: currentProcessor allFilteredCandidates
+	self deny: currentProcessor allFilteredCandidates isEmpty
 ]
 
 { #category : #convenience }

--- a/src/GT-Tests-Spotter/GTSpotterStepTest.class.st
+++ b/src/GT-Tests-Spotter/GTSpotterStepTest.class.st
@@ -17,15 +17,15 @@ Class {
 GTSpotterStepTest >> assertCandidateMatching: aBlock [
 	| candidates |
 	self assert: currentProcessor notNil.
-	
+
 	candidates := currentProcessor allFilteredCandidates select: [ :each | aBlock value: each ].
-	
-	self deny: candidates isEmpty.
+
+	self denyEmpty: candidates.
 	self assert: candidates size = 1.
-	
+
 	currentCandidate := candidates anyOne.
 	self assert: currentCandidate notNil.
-	
+
 	^ currentCandidate
 ]
 
@@ -43,7 +43,7 @@ GTSpotterStepTest >> assertDiveIn: aSelector [
 
 	" get and validate the link "
 	link := spotter currentStep candidates getCandidateLink: currentCandidate in: currentProcessor.
-	
+
 	self assert: link notNil.
 	self assert: link candidate == currentCandidate.
 	self assert: link processor == currentProcessor.
@@ -51,19 +51,19 @@ GTSpotterStepTest >> assertDiveIn: aSelector [
 	" set the selection - like the UI would do "
 	self shouldnt: [ spotter currentStep select: link ] raise: Error.
 	self assert: spotter currentStep selected == link.
-	
+
 	" perform the dive operation - like the UI would do "
 	self shouldnt: [ spotter currentStep perform: aSelector ] raise: Error.
 	currentStep := spotter currentStep.
 	currentProcessor := currentCandidate := previousContext := currentContext := nil.
-	
-	self deny: spotter steps isEmpty .
+
+	self denyEmpty: spotter steps.
 	self assert: spotter steps size > previousStepsSize.
 	self assert: spotter steps size = (previousStepsSize + 1).
-	
+
 	self deny: previousStep = currentStep.
 	self deny: previousStep = spotter currentStep.
-	self assert: currentStep = spotter currentStep.
+	self assert: currentStep = spotter currentStep
 ]
 
 { #category : #convenience }
@@ -133,7 +133,7 @@ GTSpotterStepTest >> assertProcessorMatching: aBlock [
 { #category : #convenience }
 GTSpotterStepTest >> assertProcessorNotEmpty [
 	self assert: currentProcessor notNil.
-	self deny: currentProcessor allFilteredCandidates isEmpty.
+	self denyEmpty: currentProcessor allFilteredCandidates
 ]
 
 { #category : #convenience }

--- a/src/GT-Tests-Spotter/GTSpotterTest.class.st
+++ b/src/GT-Tests-Spotter/GTSpotterTest.class.st
@@ -16,15 +16,13 @@ GTSpotterTest >> assertText: aTextualObject [
 GTSpotterTest >> assertText: aTextualObject do: aBlock [
 	| result |
 	" self: emulate a view. Forget about a separate GTSpotterMockView. kiss :) "
-	self shouldnt: [ result := spotter setText: aTextualObject from: self. ] raise: Error.
-	
+	self shouldnt: [ result := spotter setText: aTextualObject from: self ] raise: Error.
+
 	self assert: result.
 	self deny: spotter hasSteps not.
-	self deny: spotter steps isEmpty.
-	
-	self shouldnt: [ aBlock value ] raise: Error.
-	
-	
+	self denyEmpty: spotter steps.
+
+	self shouldnt: [ aBlock value ] raise: Error
 ]
 
 { #category : #tests }
@@ -69,13 +67,14 @@ GTSpotterTest >> testInitialText [
 { #category : #tests }
 GTSpotterTest >> testInstanceCreation [
 	self shouldnt: [ spotter := GTMockSpotter new ] raise: Error.
-	self shouldnt: [ 
-		spotter := GTMockSpotter new
-			exceptionHandler: GTSpotterDebuggingExceptionHandler new;
-			yourself ] raise: Error.
-	
+	self
+		shouldnt: [ spotter := GTMockSpotter new
+				exceptionHandler: GTSpotterDebuggingExceptionHandler new;
+				yourself ]
+		raise: Error.
+
 	self assert: spotter notNil.
-	self assert: spotter steps isEmpty.
+	self assertEmpty: spotter steps.
 	self deny: spotter hasMultipleSteps
 ]
 
@@ -83,18 +82,20 @@ GTSpotterTest >> testInstanceCreation [
 GTSpotterTest >> testNewSpotter [
 	| step1 |
 	self testInstanceCreation.
-	
+
 	self assert: spotter notNil.
 	self assert: spotter hasSteps not.
-	self assert: spotter steps isEmpty.
+	self assertEmpty: spotter steps.
 	self deny: spotter hasMultipleSteps.
-	
+
 	self shouldnt: [ step1 := spotter currentStep ] raise: Error.
-	
-	self flag: '#currentStep is not always cached in spotter - especially when it is a new/empty spotter. In that case #currentStep will always return a new instance of a step. The implementation would be more polymorphic, oo-style, simpler and with much less ifTrue/ifFalse if the initial-state were regarded as a step as well (as an inst-var not in the inst-var-list of #steps). Maybe use a separate type to distinguish? GTSpotterInitialStep ... '.
+
+	self
+		flag:
+			'#currentStep is not always cached in spotter - especially when it is a new/empty spotter. In that case #currentStep will always return a new instance of a step. The implementation would be more polymorphic, oo-style, simpler and with much less ifTrue/ifFalse if the initial-state were regarded as a step as well (as an inst-var not in the inst-var-list of #steps). Maybe use a separate type to distinguish? GTSpotterInitialStep ... '.
 	"self assert: step1 == spotter currentStep"
-	
+
 	self assert: step1 notNil.
 	self assert: spotter hasSteps not.
-	self assert: spotter steps isEmpty.
+	self assertEmpty: spotter steps
 ]

--- a/src/GeneralRules-Tests/RBSmalllintTest.class.st
+++ b/src/GeneralRules-Tests/RBSmalllintTest.class.st
@@ -410,26 +410,41 @@ RBSmalllintTest >> testPrecedence [
 RBSmalllintTest >> testRBMissingSubclassResponsibilityRule [
 	| sup sub1 sub2 rule |
 	rule := RBMissingSubclassResponsibilityRule new.
-	sup := Object subclass: 'MySuperclass' instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: self class category.
-	sub1 := sup subclass: 'MySubclass1' instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: self class category.
-	sub2 := sup subclass: 'MySubclass2' instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: self class category.
-	
+	sup := Object
+		subclass: 'MySuperclass'
+		instanceVariableNames: ''
+		classVariableNames: ''
+		poolDictionaries: ''
+		category: self class category.
+	sub1 := sup
+		subclass: 'MySubclass1'
+		instanceVariableNames: ''
+		classVariableNames: ''
+		poolDictionaries: ''
+		category: self class category.
+	sub2 := sup
+		subclass: 'MySubclass2'
+		instanceVariableNames: ''
+		classVariableNames: ''
+		poolDictionaries: ''
+		category: self class category.
+
 	sub1 compile: 'method ^ 3'.
 	sub2 compile: 'method ^ 5'.
-	
-	self deny: (rule check: sup) isEmpty.
-	
-	sup  compile: 'method ^ 2'.
-		
-	self assert: (rule check: sup) isEmpty.
-		
-	sup  compile: 'method ^self subclassResponsibility'.
-		
-	self assert: (rule check: sup) isEmpty.
-		
+
+	self denyEmpty: (rule check: sup).
+
+	sup compile: 'method ^ 2'.
+
+	self assertEmpty: (rule check: sup).
+
+	sup compile: 'method ^self subclassResponsibility'.
+
+	self assertEmpty: (rule check: sup).
+
 	sub1 removeFromSystem.
 	sub2 removeFromSystem.
-	sup  removeFromSystem
+	sup removeFromSystem
 ]
 
 { #category : #tests }

--- a/src/Glamour-Tests-Core/GLMActionTest.class.st
+++ b/src/Glamour-Tests-Core/GLMActionTest.class.st
@@ -21,21 +21,19 @@ GLMActionTest >> testCondition [
 { #category : #tests }
 GLMActionTest >> testShortcutAsString [
 	| action modifier |
-	
 	modifier := Smalltalk os menuShortcutModifierString.
 	action := GLMAction new.
 	action shortcut: $i.
-	self assert: action shortcutAsString equals: modifier, '+i'.
+	self assert: action shortcutAsString equals: modifier , '+i'.
 	action shortcut: $I.
-	self assert: action shortcutAsString equals: modifier, '+shift+i'.
+	self assert: action shortcutAsString equals: modifier , '+shift+i'.
 	action shortcut: nil.
-	self assert: action shortcutAsString isEmpty
+	self assertEmpty: action shortcutAsString
 ]
 
 { #category : #tests }
 GLMActionTest >> testShortcutFromKeymap [
 	| action modifier |
-	
 	modifier := Smalltalk os defaultModifier.
 	action := GLMAction new.
 	action keymap: modifier + $i asShortcut.
@@ -43,5 +41,5 @@ GLMActionTest >> testShortcutFromKeymap [
 	action keymap: modifier + $i shift.
 	self assert: action keymap equals: modifier + $i shift.
 	action keymap: nil.
-	self assert: action shortcutAsString isEmpty
+	self assertEmpty: action shortcutAsString
 ]

--- a/src/Glamour-Tests-Core/GLMAnnouncementPropagationTest.class.st
+++ b/src/Glamour-Tests-Core/GLMAnnouncementPropagationTest.class.st
@@ -52,7 +52,7 @@ GLMAnnouncementPropagationTest >> testEntityPropogationAnnouncements [
 	(browser2 transmit)
 		to: #'b2-pane';
 		andShow: [ :a | a text ].
-	self assert: GLMLogger instance announcements copy isEmpty.
+	self assertEmpty: GLMLogger instance announcements copy.
 	browser1 startOn: 42.
 	self assert: GLMLogger instance announcements copy size equals: 12.	"1. The outer browser's outer pane changes its value."
 	self assert: ((GLMLogger instance announcements copy at: 1) isKindOf: GLMContextChanged).
@@ -61,7 +61,7 @@ GLMAnnouncementPropagationTest >> testEntityPropogationAnnouncements [
 	self assert: (GLMLogger instance announcements copy at: 1) value equals: 42.	"2. The jumpstart transmission of the outer browser is triggered, updating the presentations..."
 	self assert: ((GLMLogger instance announcements copy at: 2) isKindOf: GLMPresentationsChanged).
 	self assert: (GLMLogger instance announcements copy at: 2) pane == browser1 panes first.
-	self assert: (GLMLogger instance announcements copy at: 2) oldPresentations isEmpty.
+	self assertEmpty: (GLMLogger instance announcements copy at: 2) oldPresentations.
 	self assert: (GLMLogger instance announcements copy at: 2) presentations size equals: 1.
 	self assert: (GLMLogger instance announcements copy at: 2) presentations first equals: browser2.	"3. ...and then the context."
 	self assert: ((GLMLogger instance announcements copy at: 3) isKindOf: GLMContextChanged).
@@ -70,7 +70,7 @@ GLMAnnouncementPropagationTest >> testEntityPropogationAnnouncements [
 	self assert: (GLMLogger instance announcements at: 3) value equals: 42.	"4. The jumpstart transmission of the inner browser is triggered, updating the presentations..."
 	self assert: ((GLMLogger instance announcements at: 4) isKindOf: GLMPresentationsChanged).
 	self assert: (GLMLogger instance announcements at: 4) pane == browser2 panes first.
-	self assert: (GLMLogger instance announcements at: 4) oldPresentations isEmpty.
+	self assertEmpty: (GLMLogger instance announcements at: 4) oldPresentations.
 	self assert: (GLMLogger instance announcements at: 4) presentations size equals: 1.
 	self assert: (GLMLogger instance announcements at: 4) presentations first isNil.	"5. ...and then the context."
 	self assert: ((GLMLogger instance announcements at: 5) isKindOf: GLMContextChanged).
@@ -79,17 +79,17 @@ GLMAnnouncementPropagationTest >> testEntityPropogationAnnouncements [
 	self assert: (GLMLogger instance announcements at: 5) value equals: 42.	"6. Due to the context change of 5, the innermost presentation now matches."
 	self assert: ((GLMLogger instance announcements at: 6) isKindOf: GLMMatchingPresentationsChanged).
 	self assert: (GLMLogger instance announcements at: 6) pane == browser2 panes first.
-	self assert: (GLMLogger instance announcements at: 6) oldMatchingPresentations isEmpty.
+	self assertEmpty: (GLMLogger instance announcements at: 6) oldMatchingPresentations.
 	self assert: (GLMLogger instance announcements at: 6) matchingPresentations size equals: 1.
 	self assert: (GLMLogger instance announcements at: 6) matchingPresentations first isNil.	"7. Due to the context change of 3, the inner browser now matches."
 	self assert: ((GLMLogger instance announcements at: 7) isKindOf: GLMMatchingPresentationsChanged).
 	self assert: (GLMLogger instance announcements at: 7) pane == browser1 panes first.
-	self assert: (GLMLogger instance announcements at: 7) oldMatchingPresentations isEmpty.
+	self assertEmpty: (GLMLogger instance announcements at: 7) oldMatchingPresentations.
 	self assert: (GLMLogger instance announcements at: 7) matchingPresentations size equals: 1.
 	self assert: (GLMLogger instance announcements at: 7) matchingPresentations first == browser2.	"8. Due to the context change of 1, the outer browser now matches."
 	self assert: ((GLMLogger instance announcements at: 8) isKindOf: GLMMatchingPresentationsChanged).
 	self assert: (GLMLogger instance announcements at: 8) pane == browser1 pane.
-	self assert: (GLMLogger instance announcements at: 8) oldMatchingPresentations isEmpty.
+	self assertEmpty: (GLMLogger instance announcements at: 8) oldMatchingPresentations.
 	self assert: (GLMLogger instance announcements at: 8) matchingPresentations size equals: 1.
 	self assert: (GLMLogger instance announcements at: 8) matchingPresentations first == browser1
 ]

--- a/src/Glamour-Tests-Core/GLMBrowserTest.class.st
+++ b/src/Glamour-Tests-Core/GLMBrowserTest.class.st
@@ -8,7 +8,7 @@ Class {
 GLMBrowserTest >> testAddPane [
 	| browser pane |
 	browser := GLMBrowser new.
-	self assert: browser panes isEmpty.
+	self assertEmpty: browser panes.
 	pane := GLMPane new.
 	browser addPane: pane.
 	self assert: pane browser equals: browser
@@ -18,7 +18,7 @@ GLMBrowserTest >> testAddPane [
 GLMBrowserTest >> testAddTransmissions [
 	| browser transmission |
 	browser := GLMBrowser new.
-	self assert: browser transmissions isEmpty.
+	self assertEmpty: browser transmissions.
 	transmission := GLMTransmission new.
 	browser addTransmission: transmission.
 	self assert: transmission browser equals: browser
@@ -91,7 +91,7 @@ GLMBrowserTest >> testTransmissionTriggeredAnnounced [
 	browser
 		when: GLMTransmissionTriggered
 		do: [ :ann | announcements add: ann ].
-	self assert: announcements isEmpty.
+	self assertEmpty: announcements.
 	transmission transmit.
 	self assert: announcements size equals: 1
 ]

--- a/src/Glamour-Tests-Core/GLMCompositePresentationTest.class.st
+++ b/src/Glamour-Tests-Core/GLMCompositePresentationTest.class.st
@@ -9,7 +9,7 @@ GLMCompositePresentationTest >> testAdd [
 	| composite |
 	composite := GLMCompositePresentation new.
 	composite add: GLMPresentation new.
-	self denyEmpty: composite.
+	self deny: composite isEmpty.
 	self assert: composite presentations size equals: 1
 ]
 

--- a/src/Glamour-Tests-Core/GLMCompositePresentationTest.class.st
+++ b/src/Glamour-Tests-Core/GLMCompositePresentationTest.class.st
@@ -9,7 +9,7 @@ GLMCompositePresentationTest >> testAdd [
 	| composite |
 	composite := GLMCompositePresentation new.
 	composite add: GLMPresentation new.
-	self assert: composite isEmpty not.
+	self denyEmpty: composite.
 	self assert: composite presentations size equals: 1
 ]
 
@@ -103,9 +103,7 @@ GLMCompositePresentationTest >> testCreateTabulator [
 
 { #category : #tests }
 GLMCompositePresentationTest >> testCreation [
-	| composite |
-	composite := GLMCompositePresentation new.
-	self assert: composite isEmpty
+	self assertEmpty: GLMCompositePresentation new
 ]
 
 { #category : #tests }

--- a/src/Glamour-Tests-Core/GLMExpanderTest.class.st
+++ b/src/Glamour-Tests-Core/GLMExpanderTest.class.st
@@ -43,7 +43,7 @@ GLMExpanderTest >> testConditionWhenEmbedded [
 
 { #category : #tests }
 GLMExpanderTest >> testCreation [
-	self assert: GLMExpander new panes isEmpty
+	self assertEmpty: GLMExpander new panes
 ]
 
 { #category : #tests }

--- a/src/Glamour-Tests-Core/GLMExplicitBrowserTest.class.st
+++ b/src/Glamour-Tests-Core/GLMExplicitBrowserTest.class.st
@@ -26,7 +26,7 @@ GLMExplicitBrowserTest >> testJumpstartTransmission [
 				addPresentation: presentation;
 				yourself).
 	self assert: (browser panes first port: #entity) value isNil.
-	self assert: browser panes first presentations isEmpty.
+	self assertEmpty: browser panes first presentations.
 	(browser pane port: #entity) value: #foo.
 	self assert: (browser panes first port: #entity) value equals: #foo.
 	self assert: browser panes first presentations size equals: 1.
@@ -198,17 +198,17 @@ GLMExplicitBrowserTest >> testTriggeringConditions [
 	browser addPane: pane1.
 	browser addPane: pane2.
 	browser addTransmission: transmission.
-	self assert: (pane1 port: #selection) seenTransmissions isEmpty.
-	self assert: (pane2 port: #entity) seenTransmissions isEmpty.
+	self assertEmpty: (pane1 port: #selection) seenTransmissions.
+	self assertEmpty: (pane2 port: #entity) seenTransmissions.
 	(pane1 port: #selection) value: 12.
-	self assert: (pane1 port: #selection) seenTransmissions size equals: 0.	"self 
+	self assertEmpty: (pane1 port: #selection) seenTransmissions.	"self 
 		assert: 
 			((pane1 port: #selection) seenTransmissions first isKindOf: 
 					GLMSimpleTransmission). "
 	self assert: (pane2 port: #entity) seenTransmissions size equals: 1.
 	self assert: (pane2 port: #entity) seenTransmissions first == transmission.	"Setting the same value should re-publish but not trigger inner transmissions."
 	(pane1 port: #selection) value: 12.
-	self assert: (pane1 port: #selection) seenTransmissions size equals: 0.	"self 
+	self assertEmpty: (pane1 port: #selection) seenTransmissions.	"self 
 		assert: 
 			((pane1 port: #selection) seenTransmissions first isKindOf: 
 					GLMSimpleTransmission). "	"self 

--- a/src/Glamour-Tests-Core/GLMFinderTest.class.st
+++ b/src/Glamour-Tests-Core/GLMFinderTest.class.st
@@ -8,8 +8,8 @@ Class {
 GLMFinderTest >> testEmptyPanes [
 	| browser | 
 	browser := GLMFinder new. 
-	self assert: browser panes isEmpty. 
-	self assert: browser transmissions isEmpty.
+	self assertEmpty: browser panes. 
+	self assertEmpty: browser transmissions.
 ]
 
 { #category : #tests }
@@ -162,7 +162,7 @@ GLMFinderTest >> testPanesHaveDifferentRegistries [
 	| browser |
 	browser := GLMFinder new.
 	browser addPresentation: (GLMPresentation new title: 'presentation1').
-	self assert: browser panes isEmpty.	"Outer entity changed."
+	self assertEmpty: browser panes.	"Outer entity changed."
 	(browser pane port: #entity) value: #value1.
 	self assert: browser panes size equals: 1.
 	(browser panes first port: #selection) value: #value2.
@@ -245,7 +245,7 @@ GLMFinderTest >> testValidSubscriptionsInComplexBrowser [
 	 
 	browser := GLMFinder new. 
 	browser show: [:a | a custom: navigator].
-	self assert: browser panes isEmpty.
+	self assertEmpty: browser panes.
 	(browser pane port: #entity) value: String. 
 	self assert: browser panes size equals: 1. 
 	pane1 := browser panes first.

--- a/src/Glamour-Tests-Core/GLMNestedBrowserTest.class.st
+++ b/src/Glamour-Tests-Core/GLMNestedBrowserTest.class.st
@@ -84,12 +84,12 @@ GLMNestedBrowserTest >> testCondition [
 				yourself).
 	self assert: (browser1 pane port: #entity) value isNil.
 	self assert: (browser1 panes first port: #entity) value isNil.
-	self assert: browser1 panes first presentations isEmpty.
+	self assertEmpty: browser1 panes first presentations.
 	(browser1 pane port: #entity) value: 41.
 	self assert: (browser1 pane port: #entity) value equals: 41.
 	self assert: (browser1 panes first port: #entity) value equals: 41.
 	self assert: browser1 panes first presentations size equals: 1.
-	self assert: browser1 panes first matchingPresentations size equals: 0.
+	self assertEmpty: browser1 panes first matchingPresentations.
 	(browser1 pane port: #entity) value: 42.
 	self assert: (browser1 pane port: #entity) value equals: 42.	"	self assert: (browser1 panes first port: #entity) presentations value = 84.
 "
@@ -137,10 +137,10 @@ GLMNestedBrowserTest >> testEntityPropogation [
 	self assert: (browser1 pane port: #entity) value isNil.
 	self assert: browser1 panes size equals: 1.
 	self assert: (browser1 panes first port: #entity) value isNil.
-	self assert: browser1 panes first presentations isEmpty.
+	self assertEmpty: browser1 panes first presentations.
 	self assert: browser2 panes size equals: 1.
 	self assert: (browser2 panes first port: #entity) value isNil.
-	self assert: browser2 panes first presentations isEmpty.
+	self assertEmpty: browser2 panes first presentations.
 	(browser1 pane port: #entity) value: 42.
 	self assert: (browser1 pane port: #entity) value equals: 42.
 	self assert: browser1 panes size equals: 1.

--- a/src/Glamour-Tests-Core/GLMPaneTest.class.st
+++ b/src/Glamour-Tests-Core/GLMPaneTest.class.st
@@ -118,7 +118,7 @@ GLMPaneTest >> testNamed [
 	self assert: aPane name equals: 1.
 	self assert: aPane browser equals: GLMNoBrowser new.
 	self assertEmpty: aPane ports.
-	self assertEmpty: aPane presentations
+	self assert: aPane presentations isEmpty
 ]
 
 { #category : #tests }
@@ -128,7 +128,7 @@ GLMPaneTest >> testNamedIn [
 	self assert: aPane name equals: 1.
 	self assert: aPane browser equals: 2.
 	self assertEmpty: aPane ports.
-	self assertEmpty: aPane presentations
+	self assert: aPane presentations isEmpty
 ]
 
 { #category : #tests }

--- a/src/Glamour-Tests-Core/GLMPaneTest.class.st
+++ b/src/Glamour-Tests-Core/GLMPaneTest.class.st
@@ -107,8 +107,8 @@ GLMPaneTest >> testIn [
 	aPane := GLMPane in: 1.
 	self assert: aPane name equals: aPane defaultName.
 	self assert: aPane browser equals: 1.
-	self assert: aPane ports isEmpty.
-	self assert: aPane presentations isEmpty
+	self assertEmpty: aPane ports.
+	self assertEmpty: aPane presentations
 ]
 
 { #category : #tests }
@@ -117,8 +117,8 @@ GLMPaneTest >> testNamed [
 	aPane := GLMPane named: 1.
 	self assert: aPane name equals: 1.
 	self assert: aPane browser equals: GLMNoBrowser new.
-	self assert: aPane ports isEmpty.
-	self assert: aPane presentations isEmpty
+	self assertEmpty: aPane ports.
+	self assertEmpty: aPane presentations
 ]
 
 { #category : #tests }
@@ -127,15 +127,15 @@ GLMPaneTest >> testNamedIn [
 	aPane := GLMPane named: 1 in: 2.
 	self assert: aPane name equals: 1.
 	self assert: aPane browser equals: 2.
-	self assert: aPane ports isEmpty.
-	self assert: aPane presentations isEmpty
+	self assertEmpty: aPane ports.
+	self assertEmpty: aPane presentations
 ]
 
 { #category : #tests }
 GLMPaneTest >> testPorts [
 	| pane port |
 	pane := GLMPane named: 'test'.
-	self assert: pane ports isEmpty.
+	self assertEmpty: pane ports.
 	port := pane port: #foo.
 	self assert: pane ports size equals: 1.
 	self assert: pane ports first == port.
@@ -146,11 +146,11 @@ GLMPaneTest >> testPorts [
 GLMPaneTest >> testPortsInmmutability [
 	| aPane ports |
 	aPane := GLMPane in: 1.
-	self assert: aPane ports isEmpty.
+	self assertEmpty: aPane ports.
 	ports := aPane ports.
 	ports add: 1.
 	self assert: ports size equals: 1.
-	self assert: aPane ports isEmpty
+	self assertEmpty: aPane ports
 ]
 
 { #category : #tests }
@@ -202,7 +202,7 @@ GLMPaneTest >> testPresentations [
 	| pane presentation announcement |
 	pane := GLMPane named: 'test'.
 	presentation := GLMPresentation new.
-	self assert: pane presentations isEmpty.
+	self assertEmpty: pane presentations.
 	announcement := nil.
 	pane when: GLMPresentationsChanged do: [ :ann | announcement := ann ].
 	pane addPresentation: presentation.
@@ -216,11 +216,11 @@ GLMPaneTest >> testPresentations [
 GLMPaneTest >> testPresentationsInmmutability [
 	| aPane presentations |
 	aPane := GLMPane in: 1.
-	self assert: aPane presentations isEmpty.
+	self assertEmpty: aPane presentations.
 	presentations := aPane presentations.
 	presentations add: 1.
 	self assert: presentations size equals: 1.
-	self assert: aPane presentations isEmpty
+	self assertEmpty: aPane presentations
 ]
 
 { #category : #tests }
@@ -228,7 +228,7 @@ GLMPaneTest >> testSimplePresentations [
 	| pane presentation announcement |
 	pane := GLMPane named: 'test'.
 	presentation := GLMPresentation new.
-	self assert: pane presentations isEmpty.
+	self assertEmpty: pane presentations.
 	announcement := nil.
 	pane when: GLMPresentationsChanged do: [ :ann | announcement := ann ].
 	pane addPresentation: presentation.

--- a/src/Glamour-Tests-Core/GLMPortEventTest.class.st
+++ b/src/Glamour-Tests-Core/GLMPortEventTest.class.st
@@ -7,12 +7,16 @@ Class {
 { #category : #tests }
 GLMPortEventTest >> testCreation [
 	| anEvent portOne portTwo |
-	portOne := (GLMSimplePort new) name: #portOne; value: 1.
-	portTwo := (GLMSimplePort new) name: #portTwo; value: 2.
+	portOne := GLMSimplePort new
+		name: #portOne;
+		value: 1.
+	portTwo := GLMSimplePort new
+		name: #portTwo;
+		value: 2.
 	anEvent := GLMPortEvent on: portOne previouslyValued: portTwo.
 	self assert: anEvent port equals: portOne.
 	self assert: anEvent oldValue equals: portTwo.
-	self assert: anEvent transmissionContext isEmpty
+	self assertEmpty: anEvent transmissionContext
 ]
 
 { #category : #tests }

--- a/src/Glamour-Tests-Core/GLMPortTest.class.st
+++ b/src/Glamour-Tests-Core/GLMPortTest.class.st
@@ -9,7 +9,7 @@ GLMPortTest >> testPanePortTransmissionCallingReceiveIn [
 	| originPort destinationPort transmission |
 	originPort := GLMTestPane new port: #originPort.
 	destinationPort := GLMTestPane new port: #destinationPort.
-	self assert: destinationPort seenTransmissions isEmpty.
+	self assertEmpty: destinationPort seenTransmissions.
 	transmission := (GLMTransmission new)
 		addActiveOrigin: originPort;
 		destination: destinationPort;

--- a/src/Glamour-Tests-Core/GLMScriptingTest.class.st
+++ b/src/Glamour-Tests-Core/GLMScriptingTest.class.st
@@ -390,15 +390,15 @@ GLMScriptingTest >> testStartTransmission [
 	browser
 		column: #one;
 		column: #two.
-	browser
-		transmit to: #one;
+	browser transmit
+		to: #one;
 		andShow: [ :a | a list ].
 	self assert: browser transmissions size equals: 1.
-	self assert: (browser paneNamed: #one) presentations isEmpty.
-	self assert: (browser paneNamed: #two) presentations isEmpty.
+	self assertEmpty: (browser paneNamed: #one) presentations.
+	self assertEmpty: (browser paneNamed: #two) presentations.
 	browser startOn: 15.
 	self assert: (browser paneNamed: #one) presentations size equals: 1.
-	self assert: (browser paneNamed: #two) presentations isEmpty
+	self assertEmpty: (browser paneNamed: #two) presentations
 ]
 
 { #category : #tests }
@@ -408,19 +408,15 @@ GLMScriptingTest >> testStartTransmissionFromInitializationBlock [
 	browser
 		column: #one;
 		column: #two.
-	browser
-		transmit to: #one;
-		andShow: [ :a | 
-			a list
-				initialize: [ :pres | pres selection: 4 ] ].
-	browser 
-		transmit 
-		from:#one port: #selection;
-		to:#two port: #entity;
-		andShow: [ :a |
-			a text ].
-	self assert: (browser paneNamed: #one) presentations isEmpty.
-	self assert: (browser paneNamed: #two) presentations isEmpty.
+	browser transmit
+		to: #one;
+		andShow: [ :a | a list initialize: [ :pres | pres selection: 4 ] ].
+	browser transmit
+		from: #one port: #selection;
+		to: #two port: #entity;
+		andShow: [ :a | a text ].
+	self assertEmpty: (browser paneNamed: #one) presentations.
+	self assertEmpty: (browser paneNamed: #two) presentations.
 	browser startOn: 42.
 	self assert: (browser paneNamed: #one) presentations size equals: 1.
 	self assert: (browser paneNamed: #one) presentations first selection equals: 4.
@@ -434,21 +430,21 @@ GLMScriptingTest >> testStartWithOnlyJumpStart [
 	browser
 		column: #one;
 		column: #two.
-	browser
-		transmit to: #one;
+	browser transmit
+		to: #one;
 		andShow: [ :a | a list ].
-	browser
-		transmit to: #two;
+	browser transmit
+		to: #two;
 		from: #one;
 		andShow: [ :a | a text ].
 	self assert: browser transmissions size equals: 2.
-	self assert: (browser paneNamed: #one) presentations isEmpty.
-	self assert: (browser paneNamed: #two) presentations isEmpty.
+	self assertEmpty: (browser paneNamed: #one) presentations.
+	self assertEmpty: (browser paneNamed: #two) presentations.
 	browser startOn: #(15 25 35).
 	self assert: (browser paneNamed: #one) presentations size equals: 1.
 	self assert: (browser paneNamed: #one) matchingPresentations size equals: 1.
-	self assert: (browser paneNamed: #two) presentations isEmpty.
-	self assert: (browser paneNamed: #two) matchingPresentations isEmpty
+	self assertEmpty: (browser paneNamed: #two) presentations.
+	self assertEmpty: (browser paneNamed: #two) matchingPresentations
 ]
 
 { #category : #tests }
@@ -508,25 +504,25 @@ GLMScriptingTest >> testTwoTransmissionsWithOnlyOneEvent [
 		column: #one;
 		column: #two;
 		column: #three.
-	browser
-		transmit to: #two;
+	browser transmit
+		to: #two;
 		from: #one;
 		andShow: [ :a | a list ].
-	browser
-		transmit to: #three;
+	browser transmit
+		to: #three;
 		from: #two;
 		andShow: [ :a | a text ].
 	self assert: browser transmissions size equals: 2.
-	self assert: (browser paneNamed: #one) presentations isEmpty.
-	self assert: (browser paneNamed: #two) presentations isEmpty.
-	self assert: (browser paneNamed: #three) presentations isEmpty.
+	self assertEmpty: (browser paneNamed: #one) presentations.
+	self assertEmpty: (browser paneNamed: #two) presentations.
+	self assertEmpty: (browser paneNamed: #three) presentations.
 	((browser paneNamed: #one) port: #selection) value: 42.
 	self assert: ((browser paneNamed: #two) port: #entity) value equals: 42.
-	self assert: (browser paneNamed: #one) presentations isEmpty.
+	self assertEmpty: (browser paneNamed: #one) presentations.
 	self assert: (browser paneNamed: #two) presentations size equals: 1.
 	self assert: (browser paneNamed: #two) matchingPresentations size equals: 1.
-	self assert: (browser paneNamed: #three) presentations isEmpty.
-	self assert: (browser paneNamed: #three) matchingPresentations isEmpty
+	self assertEmpty: (browser paneNamed: #three) presentations.
+	self assertEmpty: (browser paneNamed: #three) matchingPresentations
 ]
 
 { #category : #tests }
@@ -536,16 +532,16 @@ GLMScriptingTest >> testUpdateAction [
 	browser
 		column: #one;
 		column: #two.
-	(browser transmit)
+	browser transmit
 		to: #one;
 		andShow: [ :a | a list populate: #foo on: $m with: [ :list :input | 42 ] ].
-	(browser transmit)
+	browser transmit
 		to: #two;
 		from: #one port: #foo;
 		andShow: [ :a | a text ].
 	browser startOn: #(1 2 3).
 	self assert: browser panes first presentations size equals: 1.
-	self assert: browser panes last presentations isEmpty.
+	self assertEmpty: browser panes last presentations.
 	browser panes first presentations first actions first actOn: browser panes first presentations first.
 	self assert: browser panes second presentations size equals: 1.
 	self assert: browser panes second presentations first entity equals: 42

--- a/src/Glamour-Tests-Morphic/GLMAccumulatorMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMAccumulatorMorphicTest.class.st
@@ -83,7 +83,7 @@ GLMAccumulatorMorphicTest >> testPaneRemoval [
 	self assert: self tabGroup tabSelectorMorph tabs size equals: 1.
 	self assert: browser activeEntity equals: $c.
 	self tabGroup removePageIndex: 1.
-	self assert: self tabGroup tabSelectorMorph tabs isEmpty.
+	self assertEmpty: self tabGroup tabSelectorMorph tabs.
 	self assert: browser activeEntity isNil.
 	browser entity: $c.
 	self assert: self tabGroup tabSelectorMorph tabs size equals: 1

--- a/src/Glamour-Tests-Morphic/GLMCompositePresentationMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMCompositePresentationMorphicTest.class.st
@@ -207,17 +207,17 @@ GLMCompositePresentationMorphicTest >> testTabsWithActions [
 	| browser |
 	browser := GLMTabulator new.
 	browser column: #one.
-	(browser transmit)
+	browser transmit
 		to: #one;
 		andShow: [ :a | 
-					a list act: #inspect entitled: 'Inspect'.
-					a text ].
+			a list act: #inspect entitled: 'Inspect'.
+			a text ].
 	window := browser openOn: 42.
-	self assert: self compositeTabGroup toolbarMorph submorphs notEmpty.
+	self denyEmpty: self compositeTabGroup toolbarMorph submorphs.
 	self compositeTabGroup selectedPageIndex: 2.
-	self assert: self compositeTabGroup toolbarMorph submorphs isEmpty.
+	self assertEmpty: self compositeTabGroup toolbarMorph submorphs.
 	self compositeTabGroup selectedPageIndex: 1.
-	self assert: self compositeTabGroup toolbarMorph submorphs notEmpty
+	self denyEmpty: self compositeTabGroup toolbarMorph submorphs
 ]
 
 { #category : #tests }

--- a/src/Glamour-Tests-Morphic/GLMListMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMListMorphicTest.class.st
@@ -231,7 +231,7 @@ GLMListMorphicTest >> testUpdateFromModel [
 	treeMorphOne2 := self find: MorphTreeMorph in: window.
 	self assert: (treeMorphOne2 model roots collect: #item) equals: #(5 6 7 8) asOrderedCollection.
 	self assert: treeMorphOne1 ~= treeMorphOne2.
-	self assert: window submorphs last submorphs last submorphs first submorphs isEmpty.
+	self assertEmpty: window submorphs last submorphs last submorphs first submorphs.
 	((browser paneNamed: #one) port: #selection) value: 5.
 	treeMorphTwo2 := self findLast: MorphTreeMorph in: window.
 	self assert: (treeMorphTwo2 model roots collect: #item) equals: #(50 51 52) asOrderedCollection.

--- a/src/Glamour-Tests-Morphic/GLMTextMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMTextMorphicTest.class.st
@@ -41,7 +41,7 @@ GLMTextMorphicTest >> testMultipleSelectionWithChange [
 	composite := GLMCompositePresentation new with: [ :a | a text display: '123456789' ].
 	window := composite openOn: 4.
 	textMorph := self find: RubScrolledTextMorph in: window.
-	self assert: textMorph selectionInterval isEmpty.
+	self assertEmpty: textMorph selectionInterval.
 	textPresentation := composite presentations first.
 	textPresentation selectionInterval: (2 to: 5).
 	self assert: textMorph textArea editor selection asString equals: '2345'.

--- a/src/Glamour-Tests-Morphic/LazyTabGroupTest.class.st
+++ b/src/Glamour-Tests-Morphic/LazyTabGroupTest.class.st
@@ -60,8 +60,8 @@ LazyTabGroupTest >> testPageRemovedAnnouncement [
 LazyTabGroupTest >> testRemoveAllPages [
 	tabs removePage: tabs pages first.
 	tabs removePage: tabs pages first.
-	self assert: tabs pages isEmpty.
-	self assert: tabs contentMorph submorphs isEmpty
+	self assertEmpty: tabs pages.
+	self assertEmpty: tabs contentMorph submorphs
 ]
 
 { #category : #tests }

--- a/src/Glamour-Tests-Rubric/GLMRubricTextMorphicTest.class.st
+++ b/src/Glamour-Tests-Rubric/GLMRubricTextMorphicTest.class.st
@@ -135,7 +135,7 @@ GLMRubricTextMorphicTest >> testMultipleSelectionWithChange [
 	composite := GLMCompositePresentation new with: [ :a | a text display: '123456789' ].
 	window := composite openOn: 4.
 	textMorph := self find: RubScrolledTextMorph in: window.
-	self assert: textMorph selectionInterval isEmpty.
+	self assertEmpty: textMorph selectionInterval.
 	textPresentation := composite presentations first.
 	textPresentation selectionInterval: (2 to: 5).
 	self assert: textMorph textArea selection asString equals: '2345'.

--- a/src/Gofer-Tests/GoferApiTest.class.st
+++ b/src/Gofer-Tests/GoferApiTest.class.st
@@ -125,7 +125,7 @@ GoferApiTest >> testImpara [
 
 { #category : #tests }
 GoferApiTest >> testInitialReferences [
-	self assert: gofer references isEmpty
+	self assertEmpty: gofer references
 ]
 
 { #category : #tests }
@@ -150,19 +150,19 @@ GoferApiTest >> testPackageCache [
 
 { #category : #'tests - references' }
 GoferApiTest >> testPackageReference [
-	|reference|
-	gofer 
+	| reference |
+	gofer
 		repository: self monticelloRepository;
 		package: 'GoferFoo'.
 
 	self assert: gofer resolved size equals: 1.
 
 	reference := gofer resolved first.
-	
+
 	self assert: (reference isKindOf: GoferResolvedReference).
 	self assert: reference packageName equals: 'GoferFoo'.
 	self assert: reference author equals: 'lr'.
-	self assert: reference branch isEmpty.
+	self assertEmpty: reference branch.
 	self assert: reference versionNumber equals: 4.
 	self assert: reference repository equals: self monticelloRepository
 ]
@@ -227,7 +227,7 @@ GoferApiTest >> testVersionReference [
 	self assert: (reference isKindOf: GoferResolvedReference).
 	self assert: reference packageName equals: 'GoferFoo'.
 	self assert: reference author equals: 'lr'.
-	self assert: reference branch isEmpty.
+	self assertEmpty: reference branch.
 	self assert: reference versionNumber equals: 2.
 	self assert: reference repository equals: self monticelloRepository
 ]

--- a/src/Gofer-Tests/GoferReferenceTest.class.st
+++ b/src/Gofer-Tests/GoferReferenceTest.class.st
@@ -19,42 +19,37 @@ GoferReferenceTest >> testBranchAfterAuthorIsNotABranch [
 	queryReference := GoferVersionReference name: 'Seaside-Core-jf.configcleanup.3'.
 	self assert: queryReference packageName equals: 'Seaside-Core'.
 	self assert: queryReference author equals: 'jf.configcleanup'.
-	self assert: queryReference branch isEmpty.
+	self assertEmpty: queryReference branch.
 	self assert: queryReference versionNumber equals: 3.
-	
+
 	queryReference := GoferVersionReference name: 'Seaside-Core-lr.configcleanup.extraspeedup.69'.
 	self assert: queryReference packageName equals: 'Seaside-Core'.
 	self assert: queryReference author equals: 'lr.configcleanup.extraspeedup'.
-	self assert: queryReference branch isEmpty.
+	self assertEmpty: queryReference branch.
 	self assert: queryReference versionNumber equals: 69.
 
 	queryReference := GoferVersionReference name: 'Seaside-Core-lr.configcleanup42.extraspeedup.69'.
 	self assert: queryReference packageName equals: 'Seaside-Core'.
 	self assert: queryReference author equals: 'lr.configcleanup42.extraspeedup'.
-	self assert: queryReference branch isEmpty.
+	self assertEmpty: queryReference branch.
 	self assert: queryReference versionNumber equals: 69
-
 ]
 
 { #category : #'tests - reference' }
 GoferReferenceTest >> testContraintShouldFindLatestVersion [
 	| constraintReference reference |
-	constraintReference := GoferConstraintReference 
-		name: 'GoferBar'
-		constraint: [ :ref | true ].
+	constraintReference := GoferConstraintReference name: 'GoferBar' constraint: [ :ref | true ].
 	self assert: (constraintReference resolveAllWith: gofer) size equals: 4.
-	
+
 	reference := constraintReference resolveWith: gofer.
-		
+
 	self assert: reference packageName equals: 'GoferBar'.
 	self assert: reference author equals: 'lr'.
-	self assert: reference branch isEmpty.
+	self assertEmpty: reference branch.
 	self assert: reference versionNumber equals: 1.
 	self assert: reference repository equals: self monticelloRepository.
-	
-	constraintReference := GoferConstraintReference 
-									name: 'GoferBar'
-									constraint: [ :ref | ref branch = 'branch' ].
+
+	constraintReference := GoferConstraintReference name: 'GoferBar' constraint: [ :ref | ref branch = 'branch' ].
 
 	self assert: (constraintReference resolveAllWith: gofer) size equals: 2.
 
@@ -65,10 +60,8 @@ GoferReferenceTest >> testContraintShouldFindLatestVersion [
 	self assert: reference branch equals: 'branch'.
 	self assert: reference versionNumber equals: 2.
 	self assert: reference repository equals: self monticelloRepository.
-	
-	constraintReference := GoferConstraintReference 
-									name: 'GoferBar'
-									constraint: [ :ref | ref author = 'jf' ].
+
+	constraintReference := GoferConstraintReference name: 'GoferBar' constraint: [ :ref | ref author = 'jf' ].
 
 	self assert: (constraintReference resolveAllWith: gofer) size equals: 1.
 
@@ -76,16 +69,14 @@ GoferReferenceTest >> testContraintShouldFindLatestVersion [
 
 	self assert: reference packageName equals: 'GoferBar'.
 	self assert: reference author equals: 'jf'.
-	self assert: reference branch isEmpty.
+	self assertEmpty: reference branch.
 	self assert: reference versionNumber equals: 1.
 	self assert: reference repository equals: self monticelloRepository.
-	
-	constraintReference := GoferConstraintReference 
-										name: 'GoferBar'
-										constraint: [ :ref | false ].
-										
-	self assert: (constraintReference resolveAllWith: gofer) isEmpty.
-	self should: [ constraintReference resolveWith: gofer ] raise: Error.
+
+	constraintReference := GoferConstraintReference name: 'GoferBar' constraint: [ :ref | false ].
+
+	self assertEmpty: (constraintReference resolveAllWith: gofer).
+	self should: [ constraintReference resolveWith: gofer ] raise: Error
 ]
 
 { #category : #'tests - working' }
@@ -119,7 +110,7 @@ GoferReferenceTest >> testPackageShouldFindLatestVersion [
 
 	self assert: reference packageName equals: 'GoferFoo'.
 	self assert: reference author equals: 'lr'.
-	self assert: reference branch isEmpty.
+	self assertEmpty: reference branch.
 	self assert: reference versionNumber equals: 4.
 	self assert: reference repository equals: self monticelloRepository
 ]
@@ -137,10 +128,10 @@ GoferReferenceTest >> testResolvedShouldFindLatestVersion [
 	| versionReference reference |
 	versionReference := GoferResolvedReference name: 'GoferFoo-lr.2' repository: self monticelloRepository.
 	reference := versionReference resolveWith: gofer.
-	
+
 	self assert: reference packageName equals: 'GoferFoo'.
 	self assert: reference author equals: 'lr'.
-	self assert: reference branch isEmpty.
+	self assertEmpty: reference branch.
 	self assert: reference versionNumber equals: 2.
 	self assert: reference repository equals: self monticelloRepository
 ]
@@ -158,13 +149,13 @@ GoferReferenceTest >> testVersionShouldFindLatestVersion [
 	| versionReference reference |
 	versionReference := GoferVersionReference name: 'GoferFoo-lr.2'.
 	reference := versionReference resolveWith: gofer.
-	
+
 	self assert: reference packageName equals: 'GoferFoo'.
 	self assert: reference author equals: 'lr'.
 	self assert: reference versionNumber equals: 2.
-	self assert: reference branch isEmpty.
+	self assertEmpty: reference branch.
 	self assert: reference repository equals: self monticelloRepository.
-	
+
 	versionReference := GoferVersionReference name: 'GoferFoo-lr.3'.
 	self should: [ versionReference resolveWith: gofer ] raise: Error
 ]
@@ -181,31 +172,30 @@ GoferReferenceTest >> testVersionShouldFindWorkingCopy [
 { #category : #tests }
 GoferReferenceTest >> testVersionShouldParseComplexName [
 	| queryReference |
-	
 	queryReference := GoferVersionReference name: 'Seaside2.8b5'.
 	self assert: queryReference packageName equals: 'Seaside2'.
-	self assert: queryReference author isEmpty.
+	self assertEmpty: queryReference author.
 	self assert: queryReference branch equals: '8b5'.
 	self assert: queryReference versionNumber equals: 0.
-	
+
 	queryReference := GoferVersionReference name: 'Seaside2.8b5-avi.1'.
 	self assert: queryReference packageName equals: 'Seaside2'.
 	self assert: queryReference author equals: 'avi'.
 	self assert: queryReference branch equals: '8b5'.
 	self assert: queryReference versionNumber equals: 1.
-	
+
 	queryReference := GoferVersionReference name: 'Seaside-Core-pmm.2'.
 	self assert: queryReference packageName equals: 'Seaside-Core'.
 	self assert: queryReference author equals: 'pmm'.
-	self assert: queryReference branch isEmpty.
+	self assertEmpty: queryReference branch.
 	self assert: queryReference versionNumber equals: 2.
-	
+
 	queryReference := GoferVersionReference name: 'Seaside-Core.configcleanup-jf.3'.
 	self assert: queryReference packageName equals: 'Seaside-Core'.
 	self assert: queryReference author equals: 'jf'.
 	self assert: queryReference branch equals: 'configcleanup'.
 	self assert: queryReference versionNumber equals: 3.
-	
+
 	queryReference := GoferVersionReference name: 'Seaside-Core.configcleanup.extraspeedup-lr.69'.
 	self assert: queryReference packageName equals: 'Seaside-Core'.
 	self assert: queryReference author equals: 'lr'.
@@ -217,5 +207,4 @@ GoferReferenceTest >> testVersionShouldParseComplexName [
 	self assert: queryReference author equals: 'lr'.
 	self assert: queryReference branch equals: 'configcleanup42.extraspeedup'.
 	self assert: queryReference versionNumber equals: 69
-
 ]

--- a/src/Graphics-Tests/PointTest.class.st
+++ b/src/Graphics-Tests/PointTest.class.st
@@ -110,25 +110,18 @@ PointTest >> testAsPoint [
 { #category : #'tests - testing' }
 PointTest >> testBasicFourDirections [
 	"fourDirections returns the four rotation of the receiver in counter clockwise order with the receiver appearing last."
-	
+
 	| samples results rejects |
-	self assert:  (0@0) fourDirections = {(0@0). (0@0). (0@0). (0@0)}.
-	self assert: (0@0) eightNeighbors =  {(1@0). (1@1). (0@1). (-1@1). (-1@0). (-1@ -1). (0@ -1). (1@ -1)}.
+	self assert: (0 @ 0) fourDirections = {(0 @ 0) . (0 @ 0) . (0 @ 0) . (0 @ 0)}.
+	self assert: (0 @ 0) eightNeighbors = {(1 @ 0) . (1 @ 1) . (0 @ 1) . (-1 @ 1) . (-1 @ 0) . (-1 @ -1) . (0 @ -1) . (1 @ -1)}.
 
-	samples :=  {(1@0). (1@1). (0@1). (-1@1). (-1@0). (-1@ -1). (0@ -1). (1@ -1)}.
-	results :=  { {0@ -1 . -1@0 . 0@1 . 1@0} 
- 				. {1@ -1 . -1@ -1 . -1@1 . 1@1}  
- 				. {1@0 . 0@ -1 . -1@0 . 0@1}  
- 				. {1@1 . 1@ -1 . -1@ -1 . -1@1}  
- 				. {0@1 . 1@0 . 0@ -1 . -1@0}  
- 				. {-1@1 . 1@1 . 1@ -1 . -1@ -1}  
- 				. {-1@0 . 0@1 . 1@0 . 0@ -1}  
- 				. {-1@ -1 . -1@1 . 1@1 . 1@ -1} } .
+	samples := {(1 @ 0) . (1 @ 1) . (0 @ 1) . (-1 @ 1) . (-1 @ 0) . (-1 @ -1) . (0 @ -1) . (1 @ -1)}.
+	results := {{(0 @ -1) . (-1 @ 0) . (0 @ 1) . (1 @ 0)} . {(1 @ -1) . (-1 @ -1) . (-1 @ 1) . (1 @ 1)} . {(1 @ 0) . (0 @ -1) . (-1 @ 0) . (0 @ 1)} . {(1 @ 1) . (1 @ -1) . (-1 @ -1).
+	(-1 @ 1)} . {(0 @ 1) . (1 @ 0) . (0 @ -1) . (-1 @ 0)} . {(-1 @ 1) . (1 @ 1) . (1 @ -1) . (-1 @ -1)} . {(-1 @ 0) . (0 @ 1) . (1 @ 0) . (0 @ -1)} . {(-1 @ -1) . (-1 @ 1) . (1 @ 1).
+	(1 @ -1)}}.
 
-	rejects := (1 to: samples size ) reject: [ :each |
-											 (samples at: each) fourDirections = (results at: each) ].
-	self assert: ( rejects isEmpty).
-
+	rejects := (1 to: samples size) reject: [ :each | (samples at: each) fourDirections = (results at: each) ].
+	self assertEmpty: rejects
 ]
 
 { #category : #'tests - testing' }

--- a/src/HelpSystem-Tests/HelpTopicTest.class.st
+++ b/src/HelpSystem-Tests/HelpTopicTest.class.st
@@ -33,10 +33,9 @@ HelpTopicTest >> testAddingSubtopic [
 
 { #category : #testing }
 HelpTopicTest >> testInitialization [
-
 	self assert: topic title = 'Unnamed Topic'.
-	self assert: topic key isEmpty.
-	self assert: topic contents isEmpty 
+	self assertEmpty: topic key.
+	self assertEmpty: topic contents
 ]
 
 { #category : #testing }

--- a/src/Jobs-Tests/JobTest.class.st
+++ b/src/Jobs-Tests/JobTest.class.st
@@ -17,19 +17,17 @@ JobTest >> tearDown [
 
 { #category : #tests }
 JobTest >> testChildJob [
-	
 	| wasRun |
-	
 	wasRun := false.
-	
-	[ :job | 	
-		[ :job2 | 
-			self assert: job children size equals: 1.
-			self assert: job children first equals: job2.
-			wasRun := true ] asJob run.
-	
-		self assert: job children isEmpty ] asJob run.
-	
+
+	[ :job | 
+	[ :job2 | 
+	self assert: job children size equals: 1.
+	self assert: job children first equals: job2.
+	wasRun := true ] asJob run.
+
+	self assertEmpty: job children ] asJob run.
+
 	self assert: wasRun
 ]
 
@@ -48,7 +46,6 @@ JobTest >> testCurrentJob [
 
 { #category : #tests }
 JobTest >> testJobAnnouncements [
-	
 	| announcements |
 	announcements := OrderedCollection new.
 
@@ -56,13 +53,11 @@ JobTest >> testJobAnnouncements [
 	Job jobAnnouncer weak when: JobEnd send: #add: to: announcements.
 	Job jobAnnouncer weak when: JobChange send: #add: to: announcements.
 
-	self assert: announcements isEmpty.
+	self assertEmpty: announcements.
 
-	[ :job | job currentValue: 1 ] asJob run.	
-	
-	self 
-		assert: (announcements collect: #class as: Array)
-		equals: {JobStart. JobChange. JobEnd}.
+	[ :job | job currentValue: 1 ] asJob run.
+
+	self assert: (announcements collect: #class as: Array) equals: {JobStart . JobChange . JobEnd}.
 
 	Job jobAnnouncer unsubscribe: announcements
 ]
@@ -130,11 +125,10 @@ JobTest >> testProgressChangeByCurrentValue [
 
 { #category : #tests }
 JobTest >> testSingleJob [
-
 	| wasRun |
 	wasRun := false.
 	[ :job | 
-		self assert: job children isEmpty.
-		wasRun := true ] asJob run.	
+	self assertEmpty: job children.
+	wasRun := true ] asJob run.
 	self assert: wasRun
 ]

--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -118,14 +118,13 @@ ClassTest >> testAddSlotAnonymous [
 
 { #category : #'tests - access' }
 ClassTest >> testAllSharedPools [
-
 	self assert: Point allSharedPools equals: OrderedCollection new.
 	self assert: Date sharedPools first equals: ChronologyConstants.
 	self assert: Date sharedPools size equals: 1.	"a metaclass does not have shared pools since only classes have shared pools"
 
 	self assert: RootClassPoolUser sharedPools size equals: 1.
 	self assert: ClassMultiplePoolUser sharedPools size equals: 2.	"has shared pools does not take into account the fact that a superclass may use some shared pools"
-	self assert: SubclassPoolUser sharedPools isEmpty
+	self assertEmpty: SubclassPoolUser sharedPools
 ]
 
 { #category : #'as yet unclassified' }
@@ -218,12 +217,9 @@ ClassTest >> testIsInstanceSide [
 ClassTest >> testMethodsReferencingClass [
 	self assert: (ClassTest methodsReferencingClass: (Smalltalk classNamed: #ExampleForTest111)) equals: {(ClassTest >> #testOrdersACollectionOfClassesBySuperclass)}.
 	self
-		assert: ((ClassTest methodsReferencingClass: (Smalltalk classNamed: #ExampleForTest1)) sort: [ :a :b | a name <= b name]) asArray
-		equals:
-			{ClassTest>>#referencingMethod1. 
-			ClassTest>>#referencingMethod2. 
-			ClassTest>>#testOrdersACollectionOfClassesBySuperclass}.
-	self assert: (ClassTest methodsReferencingClass: (Smalltalk classNamed: #BehaviorTest)) isEmpty
+		assert: ((ClassTest methodsReferencingClass: (Smalltalk classNamed: #ExampleForTest1)) sort: [ :a :b | a name <= b name ]) asArray
+		equals: {(ClassTest >> #referencingMethod1) . (ClassTest >> #referencingMethod2) . (ClassTest >> #testOrdersACollectionOfClassesBySuperclass)}.
+	self assertEmpty: (ClassTest methodsReferencingClass: (Smalltalk classNamed: #BehaviorTest))
 ]
 
 { #category : #'tests - navigation' }
@@ -342,14 +338,13 @@ ClassTest >> testSharedPoolOfVarNamed [
 
 { #category : #'tests - access' }
 ClassTest >> testSharedPools [
-
 	self assert: Point sharedPools equals: OrderedCollection new.
 	self assert: Date sharedPools first equals: ChronologyConstants.
 	self assert: Date sharedPools size equals: 1.	"a metaclass does not have shared pools since only classes have shared pools"
 	Date class sharedPools.
 	self assert: RootClassPoolUser sharedPools size equals: 1.
 	self assert: ClassMultiplePoolUser sharedPools size equals: 2.	"has shared pools does not take into account the fact that a superclass may use some shared pools"
-	self assert: SubclassPoolUser sharedPools isEmpty
+	self assertEmpty: SubclassPoolUser sharedPools
 ]
 
 { #category : #'tests - class creation' }

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -376,9 +376,9 @@ CompiledMethodTest >> testLiterals [
 	"#literals should not expose implementation hack that the last two literals are 
 	used for name of method and class"
 
-	self assert: (Object >> #yourself) literals isEmpty.
+	self assertEmpty: (Object >> #yourself) literals.
 	self assert: (Object >> #yourself) allLiterals size equals: 2.
-	self deny: ((Object >> #yourself) hasLiteral: #yourself).
+	self deny: (Object >> #yourself hasLiteral: #yourself)
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Kernel-Tests-Extended/MonthTest.class.st
+++ b/src/Kernel-Tests-Extended/MonthTest.class.st
@@ -53,8 +53,8 @@ MonthTest >> testEnumerating [
 	| weeks |
 	weeks := OrderedCollection new.
 	month weeksDo: [ :w | weeks add: w start ].
-	0 to: 4 do: [ :i | weeks remove: (Week starting:  ('29 June 1998' asDate addDays: i * 7)) start ].
-	self assert: weeks isEmpty
+	0 to: 4 do: [ :i | weeks remove: (Week starting: ('29 June 1998' asDate addDays: i * 7)) start ].
+	self assertEmpty: weeks
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests-Extended/StopwatchTest.class.st
+++ b/src/Kernel-Tests-Extended/StopwatchTest.class.st
@@ -81,17 +81,14 @@ StopwatchTest >> testMultipleTimings [
 
 { #category : #tests }
 StopwatchTest >> testNew [
-
 	| sw |
 	sw := Stopwatch new.
-	
-	self 
-		assert: (sw isSuspended);
-		assert: (sw state = #suspended);
-		deny: (sw isActive);
-		assert: (sw timespans isEmpty)
 
-
+	self
+		assert: sw isSuspended;
+		assert: sw state = #suspended;
+		deny: sw isActive;
+		assertEmpty: sw timespans
 ]
 
 { #category : #tests }
@@ -116,16 +113,14 @@ StopwatchTest >> testReActivate [
 
 { #category : #tests }
 StopwatchTest >> testReset [
-
 	| sw |
 	sw := Stopwatch new.
 	sw activate.
-	
-	sw reset.
-	self 
-		assert: (sw isSuspended);
-		assert: (sw timespans isEmpty)
 
+	sw reset.
+	self
+		assert: sw isSuspended;
+		assertEmpty: sw timespans
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests-Extended/WeekTest.class.st
+++ b/src/Kernel-Tests-Extended/WeekTest.class.st
@@ -77,15 +77,13 @@ WeekTest >> testDayNames [
 
 { #category : #tests }
 WeekTest >> testEnumerating [
-
 	| days |
 	days := OrderedCollection new.
 	0 to: 6 do: [ :i | days add: ('28 June 1998' asDate addDays: i) ].
 
 	week datesDo: [ :d | days remove: d ].
-	
-	self assert: days isEmpty.
 
+	self assertEmpty: days
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests-Rules/OverridesDeprecatedMethodRuleTest.class.st
+++ b/src/Kernel-Tests-Rules/OverridesDeprecatedMethodRuleTest.class.st
@@ -43,10 +43,7 @@ OverridesDeprecatedMethodRuleTest >> testBasicCheck [
 
 { #category : #tests }
 OverridesDeprecatedMethodRuleTest >> testBasicCheck1 [
-
 	| testMethod |
-	testMethod := testSubclass >> (
-		testSubclass compile: self methodName, '1').
-		
-	self assert: (OverridesDeprecatedMethodRule new check: testMethod) isEmpty
+	testMethod := testSubclass >> (testSubclass compile: self methodName , '1').
+	self assertEmpty: (OverridesDeprecatedMethodRule new check: testMethod)
 ]

--- a/src/Kernel-Tests-Rules/PharoBootstrapRuleTest.class.st
+++ b/src/Kernel-Tests-Rules/PharoBootstrapRuleTest.class.st
@@ -26,26 +26,22 @@ PharoBootstrapRuleTest >> tearDown [
 PharoBootstrapRuleTest >> testRuleDoesNotFailIfAppliedOnNonBootstrapPackage [
 	| rule critiques |
 	rule := PharoBootstrapRule new.
-	rule class 
-		classVarNamed: 'DependencyChecker'
-		put: PharoBootstrapAnalyzerStubWithNoNewDependency.
+	rule class classVarNamed: 'DependencyChecker' put: PharoBootstrapAnalyzerStubWithNoNewDependency.
 
 	critiques := rule check: (RPackage named: #P1).
 
-	self assert: critiques isEmpty
+	self assertEmpty: critiques
 ]
 
 { #category : #tests }
 PharoBootstrapRuleTest >> testRuleDoesNotFailIfNoNewExternalDependency [
 	| rule critiques |
 	rule := PharoBootstrapRule new.
-	rule class 
-		classVarNamed: 'DependencyChecker'
-		put: PharoBootstrapAnalyzerStubWithNoNewDependency.
+	rule class classVarNamed: 'DependencyChecker' put: PharoBootstrapAnalyzerStubWithNoNewDependency.
 
 	critiques := rule check: (RPackage named: #Kernel).
 
-	self assert: critiques isEmpty
+	self assertEmpty: critiques
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -58,13 +58,12 @@ ClassOrganizationTest >> testCategories [
 { #category : #tests }
 ClassOrganizationTest >> testListAtCategoryNamed [
 	| methods |
-
 	methods := self organization listAtCategoryNamed: 'empty'.
-	self assert: methods isEmpty.
-		
+	self assertEmpty: methods.
+
 	methods := self organization listAtCategoryNamed: 'one'.
 	self assert: methods size = 1.
-	self assert: methods first = #one.
+	self assert: methods first = #one
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ProtoObjectTest.class.st
+++ b/src/Kernel-Tests/ProtoObjectTest.class.st
@@ -166,8 +166,7 @@ ProtoObjectTest >> testNotTheSame [
 ProtoObjectTest >> testPointersTo [
 	| myObject myArray |
 	myObject := Object new.
-   self assert: myObject pointersTo isEmpty.
-	myArray := {myObject. myObject}.
-	self assert: myObject pointersTo asArray equals: {myArray}.
-
+	self assertEmpty: myObject pointersTo.
+	myArray := {myObject . myObject}.
+	self assert: myObject pointersTo asArray equals: {myArray}
 ]

--- a/src/Keymapping-Tests/KMKeymapBuilderTest.class.st
+++ b/src/Keymapping-Tests/KMKeymapBuilderTest.class.st
@@ -9,15 +9,15 @@ Class {
 
 { #category : #tests }
 KMKeymapBuilderTest >> testAddKeymapCreatesCategory [
-	self assert: KMRepository default categories isEmpty.
-	
+	self assertEmpty: KMRepository default categories.
+
 	KMRepository default
 		initializeKeymap: #test
-		executingOn: $r ctrl, $r asKeyCombination, $r asKeyCombination
+		executingOn: $r ctrl , $r asKeyCombination , $r asKeyCombination
 		doing: [ :receiver | "nothing" ]
 		inCategory: #Testing
 		platform: #all.
-	
+
 	self assert: (KMRepository default includesCategoryNamed: #Testing).
 	self assert: KMRepository default categories size equals: 1
 ]

--- a/src/Metacello-Gitlab-Tests/MCGitlabRepositoryTest.class.st
+++ b/src/Metacello-Gitlab-Tests/MCGitlabRepositoryTest.class.st
@@ -23,7 +23,7 @@ MCGitlabRepositoryTest >> testLocation [
 		assert: repository hostname equals: 'gitlab.com';
 		assert: repository projectPath equals: 'pharo-project/pharo';
 		assert: repository projectVersion equals: 'master';
-		assert: repository repoPath isEmpty;
+		assertEmpty: repository repoPath;
 		assert: repository sshPort isNil.
 
 	repository := MCGitlabRepository location: 'gitlab://pharo-project/pharo'.
@@ -31,7 +31,7 @@ MCGitlabRepositoryTest >> testLocation [
 		assert: repository hostname equals: 'gitlab.com';
 		assert: repository projectPath equals: 'pharo-project/pharo';
 		assert: repository projectVersion equals: 'master';
-		assert: repository repoPath isEmpty;
+		assertEmpty: repository repoPath;
 		assert: repository sshPort isNil
 ]
 
@@ -62,7 +62,7 @@ MCGitlabRepositoryTest >> testSelfHostedLocation [
 		assert: repository hostname equals: 'git.pharo.org';
 		assert: repository projectPath equals: 'pharo-project/pharo';
 		assert: repository projectVersion equals: 'master';
-		assert: repository repoPath isEmpty;
+		assertEmpty: repository repoPath;
 		assert: repository sshPort isNil.
 
 	repository := MCGitlabRepository location: 'gitlab://git.pharo.org:pharo-project/pharo'.
@@ -70,7 +70,7 @@ MCGitlabRepositoryTest >> testSelfHostedLocation [
 		assert: repository hostname equals: 'git.pharo.org';
 		assert: repository projectPath equals: 'pharo-project/pharo';
 		assert: repository projectVersion equals: 'master';
-		assert: repository repoPath isEmpty;
+		assertEmpty: repository repoPath;
 		assert: repository sshPort isNil
 ]
 
@@ -90,7 +90,7 @@ MCGitlabRepositoryTest >> testSelfHostedLocationWithNonDefaultSSHPort [
 		assert: repository hostname equals: 'git.pharo.org';
 		assert: repository projectPath equals: 'pharo-project/pharo';
 		assert: repository projectVersion equals: 'master';
-		assert: repository repoPath isEmpty;
+		assertEmpty: repository repoPath;
 		assert: repository sshPort equals: '1234'.
 
 	repository := MCGitlabRepository location: 'gitlab://git.pharo.org:1234:pharo-project/pharo'.
@@ -98,6 +98,6 @@ MCGitlabRepositoryTest >> testSelfHostedLocationWithNonDefaultSSHPort [
 		assert: repository hostname equals: 'git.pharo.org';
 		assert: repository projectPath equals: 'pharo-project/pharo';
 		assert: repository projectVersion equals: 'master';
-		assert: repository repoPath isEmpty;
+		assertEmpty: repository repoPath;
 		assert: repository sshPort equals: '1234'
 ]

--- a/src/Metacello-TestsMC/MetacelloDictionaryRepositoryTest.class.st
+++ b/src/Metacello-TestsMC/MetacelloDictionaryRepositoryTest.class.st
@@ -122,30 +122,24 @@ MetacelloDictionaryRepositoryTest >> setUp [
 
 { #category : #running }
 MetacelloDictionaryRepositoryTest >> tearDown [
-  | aGofer finalWorkingCopyList diff |
-  aGofer := Gofer new.
-  self tearDownPackages: aGofer.
-  aGofer references notEmpty
-    ifTrue: [ aGofer metacelloUnload ].
-  Smalltalk globals removeKey: #'Metacello_Gofer_Test_Repository' ifAbsent: [  ].
-  Smalltalk globals removeKey: #'Metacello_Configuration_Test_Repository' ifAbsent: [  ].
-  Smalltalk globals
-    removeKey: #'Metacello_Configuration_Test_Alternate_Repository'
-    ifAbsent: [  ].
-  self tempRepositories
-    do: [ :repo | MCRepositoryGroup default removeIdenticalRepository: repo ].
-  MetacelloPlatform current reenableUndefinedSybolUpdates: undefinedSymbols.
-  finalWorkingCopyList := MCWorkingCopy allManagers
-    collect: [ :each | each packageName ].
-  diff := finalWorkingCopyList difference: initialWorkingCopyList.
-  diff
-    do: [ :leak | 
-      Transcript
-        cr;
-        show:
-            'leaked package from ' , self printString , ' -> ' , leak printString ].
-  self assert: diff isEmpty.
-  super tearDown
+	| aGofer finalWorkingCopyList diff |
+	aGofer := Gofer new.
+	self tearDownPackages: aGofer.
+	aGofer references notEmpty ifTrue: [ aGofer metacelloUnload ].
+	Smalltalk globals removeKey: #Metacello_Gofer_Test_Repository ifAbsent: [  ].
+	Smalltalk globals removeKey: #Metacello_Configuration_Test_Repository ifAbsent: [  ].
+	Smalltalk globals removeKey: #Metacello_Configuration_Test_Alternate_Repository ifAbsent: [  ].
+	self tempRepositories do: [ :repo | MCRepositoryGroup default removeIdenticalRepository: repo ].
+	MetacelloPlatform current reenableUndefinedSybolUpdates: undefinedSymbols.
+	finalWorkingCopyList := MCWorkingCopy allManagers collect: [ :each | each packageName ].
+	diff := finalWorkingCopyList difference: initialWorkingCopyList.
+	diff
+		do: [ :leak | 
+			Transcript
+				cr;
+				show: 'leaked package from ' , self printString , ' -> ' , leak printString ].
+	self assertEmpty: diff.
+	super tearDown
 ]
 
 { #category : #running }

--- a/src/Monticello-Tests/MCAncestryTest.class.st
+++ b/src/Monticello-Tests/MCAncestryTest.class.st
@@ -83,7 +83,7 @@ MCAncestryTest >> testLinearPath [
 
 { #category : #tests }
 MCAncestryTest >> testPathToMissingAncestor [
-	self assert: (self tree allAncestorsOnPathTo: MCVersionInfo new) isEmpty
+	self assertEmpty: (self tree allAncestorsOnPathTo: MCVersionInfo new)
 ]
 
 { #category : #building }

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -145,9 +145,9 @@ MCClassDefinitionTest >> testLoadAndUnload [
 	c := Smalltalk globals classNamed: 'MCMockClassC'.
 	self assert: (c isKindOf: Class).
 	self assert: c superclass equals: Object.
-	self assert: c instVarNames isEmpty.
-	self assert: c classVarNames isEmpty.
-	self assert: c sharedPools isEmpty.
+	self assertEmpty: c instVarNames.
+	self assertEmpty: c classVarNames.
+	self assertEmpty: c sharedPools.
 	self assert: c category equals: self mockCategoryName.
 	self assert: c organization classComment equals: (self commentForClass: 'MCMockClassC').
 	self assert: c organization commentStamp equals: (self commentStampForClass: 'MCMockClassC').

--- a/src/Monticello-Tests/MCFileInTest.class.st
+++ b/src/Monticello-Tests/MCFileInTest.class.st
@@ -45,7 +45,7 @@ MCFileInTest >> assertNoChange [
 	| actual |
 	actual := MCSnapshotResource takeSnapshot.
 	diff := actual patchRelativeToBase: expected.
-	self assert: diff isEmpty
+	self assertEmpty: diff
 ]
 
 { #category : #testing }

--- a/src/Monticello-Tests/MCMczInstallerTest.class.st
+++ b/src/Monticello-Tests/MCMczInstallerTest.class.st
@@ -35,7 +35,7 @@ MCMczInstallerTest >> assertNoChange [
 	| actual |
 	actual := MCSnapshotResource takeSnapshot.
 	diff := actual patchRelativeToBase: expected snapshot.
-	self assert: diff isEmpty
+	self assertEmpty: diff
 ]
 
 { #category : #assertions }

--- a/src/Monticello-Tests/MCMergingTest.class.st
+++ b/src/Monticello-Tests/MCMergingTest.class.st
@@ -126,7 +126,7 @@ MCMergingTest >> testMultiPackageMerge [
 	merger applyPatch: ((self snapshotWithElements: #(a2 b1)) patchRelativeToBase: (self snapshotWithElements: #(b1))).
 	merger conflicts do: [:ea | self handleConflict: ea].
 	self assert: merger mergedSnapshot definitions hasElements: #(a2 b1).
-	self assert: conflicts isEmpty
+	self assertEmpty: conflicts
 ]
 
 { #category : #tests }
@@ -139,7 +139,7 @@ MCMergingTest >> testMultiPackageMerge2 [
 	merger applyPatch: ((self snapshotWithElements: #(a1 b1)) patchRelativeToBase: (self snapshotWithElements: #(b1))).
 	merger conflicts do: [:ea | self handleConflict: ea].
 	self assert: merger mergedSnapshot definitions hasElements: #(a1 b1).
-	self assert: conflicts isEmpty
+	self assertEmpty: conflicts
 ]
 
 { #category : #tests }
@@ -152,7 +152,7 @@ MCMergingTest >> testMultiPackageMerge3 [
 	merger applyPatch: ((self snapshotWithElements: #()) patchRelativeToBase: (self snapshotWithElements: #(a1))).
 	merger conflicts do: [:ea | self handleConflict: ea].
 	self assert: merger mergedSnapshot definitions hasElements: #(a1 b1).
-	self assert: conflicts isEmpty
+	self assertEmpty: conflicts
 ]
 
 { #category : #tests }

--- a/src/Monticello-Tests/MCMethodDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCMethodDefinitionTest.class.st
@@ -52,9 +52,13 @@ MCMethodDefinitionTest >> tearDown [
 { #category : #testing }
 MCMethodDefinitionTest >> testCannotLoad [
 	| definition |
-	definition := self mockMethod: #kjahs87 class: 'NoSuchClass' source: 'kjahs87 ^self' meta: false.
-	self should: [definition load] raise: Error.
-	self assert: (navigation allImplementorsOf: #kjahs87) isEmpty
+	definition := self
+		mockMethod: #kjahs87
+		class: 'NoSuchClass'
+		source: 'kjahs87 ^self'
+		meta: false.
+	self should: [ definition load ] raise: Error.
+	self assertEmpty: (navigation allImplementorsOf: #kjahs87)
 ]
 
 { #category : #testing }

--- a/src/Monticello-Tests/RPackageTraitSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageTraitSynchronisationTest.class.st
@@ -11,22 +11,21 @@ Class {
 { #category : #'tests - operations on methods' }
 RPackageTraitSynchronisationTest >> testAddMethodByUsingATraitDoesNotAddTheMethodToThePackage [
 	"test that when a method is added to a class bu using a trait, this method is not imported in the parent package of the class"
-		
-	|XPackage YPackage class trait|
+
+	| XPackage YPackage class trait |
 	self addXCategory.
 	self addYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
 	trait := self createNewTraitNamed: 'NewTrait' inCategory: 'YYYYY'.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass:  trait inCategory: 'trait category'.
-	
-	self assert: (XPackage methods isEmpty ).
-	self deny: (YPackage methods isEmpty ).
+	self createMethodNamed: 'stubMethod' inClass: trait inCategory: 'trait category'.
+
+	self assertEmpty: XPackage methods.
+	self denyEmpty: YPackage methods.
 	class addToComposition: trait.
 	self assert: (YPackage includesDefinedSelector: #stubMethod ofClass: trait).
-	self assert: (XPackage methods isEmpty).
-		
+	self assertEmpty: XPackage methods
 ]
 
 { #category : #'tests - operations on traits' }

--- a/src/Morphic-Tests/WindowAnnouncementTest.class.st
+++ b/src/Morphic-Tests/WindowAnnouncementTest.class.st
@@ -77,25 +77,24 @@ WindowAnnouncementTest >> testResizing [
 { #category : #'tests - window creation and deletion' }
 WindowAnnouncementTest >> testResizingClosing [
 	| coll |
-
 	window := SystemWindow labelled: 'foo'.
 	coll := OrderedCollection new.
 	window openInWorld.
-	window announcer when: WindowAnnouncement do: [:ann | coll add: ann].
-	self assert: (coll isEmpty).
+	window announcer when: WindowAnnouncement do: [ :ann | coll add: ann ].
+	self assertEmpty: coll.
 	window minimizeOrRestore.
-	
+
 	"Resizing, moving, deActivation, collapsing "
-	self assert: (coll size = 4).
-	self assert: (coll first isResized).
-	self assert: (coll second isMoved).
-	self assert: (coll third isDeActivated).
-	self assert: (coll fourth isCollapsed).
+	self assert: coll size = 4.
+	self assert: coll first isResized.
+	self assert: coll second isMoved.
+	self assert: coll third isDeActivated.
+	self assert: coll fourth isCollapsed.
 
 	window delete.
 
-	self assert: (coll size = 5).
-	self assert: (coll fifth isClosed).
+	self assert: coll size = 5.
+	self assert: coll fifth isClosed.
 	window := nil
 ]
 

--- a/src/NECompletion-Tests/NECContextTest.class.st
+++ b/src/NECompletion-Tests/NECContextTest.class.st
@@ -5,18 +5,16 @@ Class {
 }
 
 { #category : #private }
-NECContextTest >> checkUntypedVariablesOnly: aString [ 
+NECContextTest >> checkUntypedVariablesOnly: aString [
 	| context model |
-	context := self 
-		createContextFor: aString
-		at: aString size.
+	context := self createContextFor: aString at: aString size.
 	self assert: context isVariablesOnly.
 	model := context model.
 	model loadEntries.
 	self assert: model hasMessage not.
-	self assert: (model entriesOfType: #instVar) notEmpty.
+	self denyEmpty: (model entriesOfType: #instVar).
 	context narrowWith: 'a'.
-	self assert: (model entriesOfType: #selector) isEmpty
+	self assertEmpty: (model entriesOfType: #selector)
 ]
 
 { #category : #private }
@@ -437,16 +435,14 @@ NECContextTest >> testUntypedSelectorsOnly [
 	text := 'testIt: aRectangle
 	| ab bc bd |
 	ab '.
-	context := self 
-		createContextFor: text
-		at: text size.
+	context := self createContextFor: text at: text size.
 	model := context model.
 	self assert: model hasMessage.
 	self assert: model message = 'press key for selectors'.
 	context narrowWith: 'ab'.
-	self assert: (model entriesOfType: #selector) notEmpty.
-	self assert: (model entriesOfType: #local) isEmpty.
-	self assert: (model entriesOfType: #instance) isEmpty
+	self denyEmpty: (model entriesOfType: #selector).
+	self assertEmpty: (model entriesOfType: #local).
+	self assertEmpty: (model entriesOfType: #instance)
 ]
 
 { #category : #tests }

--- a/src/NECompletion-Tests/NECUntypedModelTest.class.st
+++ b/src/NECompletion-Tests/NECUntypedModelTest.class.st
@@ -64,20 +64,18 @@ NECUntypedModelTest >> testCaseSensitive [
 NECUntypedModelTest >> testCaseSensitivity [
 	| model instances |
 	self assert: NECPreferences caseSensitive.
-	model := NECUntypedModel 
-		class: NECTestClass
-		temporaries: OrderedCollection new.
+	model := NECUntypedModel class: NECTestClass temporaries: OrderedCollection new.
 	model narrowWith: 'typesugg'.
-	self assert: model isEmpty.
-	
+	self assertEmpty: model.
+
 	NECPreferences caseSensitive: false.
 	model narrowWith: 'typesugg'.
 	instances := model entriesOfType: #instVar.
 	self assert: instances size == 2.
 	self assert: (instances includes: 'typeSuggestingParameter').
-	
+
 	model narrowWith: 'dict'.
-	self assert: model notEmpty.
+	self deny: model isEmpty.
 	self assert: ((model entriesOfType: #globalVar) includes: 'Dictionary')
 ]
 
@@ -85,8 +83,8 @@ NECUntypedModelTest >> testCaseSensitivity [
 NECUntypedModelTest >> testEmpty [
 	| model |
 	model := NECUntypedModel new.
-	self assert: model isEmpty.
-	self assert: model entries isEmpty.
+	self assertEmpty: model.
+	self assertEmpty: model entries.
 	self assert: model entryCount == 0
 ]
 
@@ -177,34 +175,34 @@ NECUntypedModelTest >> testMessage [
 NECUntypedModelTest >> testNarrowWith [
 	| count model |
 	model := NECUntypedModel new.
-	self assert: model isEmpty.
-	
+	self assertEmpty: model.
+
 	model narrowWith: 'ba'.
 	count := model entryCount.
 	self assert: count == model entries size.
-	self assert: model isEmpty not.
-	
+	self deny: model isEmpty.
+
 	model narrowWith: 'bar'.
 	self assert: count > model entryCount.
-	
+
 	model narrowWith: 'barXXXX'.
 	self assert: model isEmpty.
-	
+
 	model narrowWith: 'ba'.
 	self assert: count == model entryCount.
-	
+
 	model narrowWith: 'save'.
-	self assert: model isEmpty not.
-	
+	self deny: model isEmpty.
+
 	model narrowWith: ''.
-	self assert: model isEmpty
+	self assertEmpty: model
 ]
 
 { #category : #tests }
 NECUntypedModelTest >> testNoEntriesWithSpace [
 	| model separatorEntry |
 	model := NECUntypedModel new.
-	self assert: model isEmpty.
+	self assertEmpty: model.
 	model narrowWith: 'b'.
 	separatorEntry := model entries detect: 
 					[:each | 

--- a/src/NautilusRefactoring-Tests/ChangesBrowserTest.class.st
+++ b/src/NautilusRefactoring-Tests/ChangesBrowserTest.class.st
@@ -42,5 +42,5 @@ ChangesBrowserTest >> testInitializeWidgets [
 
 { #category : #tests }
 ChangesBrowserTest >> testPickedChanges [
-	self assert: browser pickedChanges isEmpty
+	self assertEmpty: browser pickedChanges
 ]

--- a/src/Ombu-Tests/OmStoreFactoryTest.class.st
+++ b/src/Ombu-Tests/OmStoreFactoryTest.class.st
@@ -15,11 +15,10 @@ OmStoreFactoryTest >> aStoreName [
 
 { #category : #tests }
 OmStoreFactoryTest >> testNullStore [
-
 	| factory store |
 	factory := OmStoreFactory new.
 	store := factory null.
-	self assert: store entries isEmpty.
+	self assertEmpty: store entries.
 	self assert: factory null == store description: 'Singleton'
 ]
 

--- a/src/Ombu-Tests/OmStoreTest.class.st
+++ b/src/Ombu-Tests/OmStoreTest.class.st
@@ -61,7 +61,7 @@ OmStoreTest >> tearDown [
 
 { #category : #tests }
 OmStoreTest >> testEntries [
-	self assert: store entries isEmpty.
+	self assertEmpty: store entries
 ]
 
 { #category : #tests }
@@ -238,8 +238,8 @@ OmStoreTest >> testReferenceTo [
 { #category : #tests }
 OmStoreTest >> testRefreshEmpty [
 	store refresh.
-	
-	self assert: store entries isEmpty.
+
+	self assertEmpty: store entries
 ]
 
 { #category : #tests }

--- a/src/OpalCompiler-Tests/MethodPragmaTest.class.st
+++ b/src/OpalCompiler-Tests/MethodPragmaTest.class.st
@@ -61,9 +61,9 @@ MethodPragmaTest >> testAllNamedFromTo [
 	pragmasCompiled := self pragma: #foo: selector: #bar times: 5.
 	pragmasDetected := Pragma allNamed: #foo: from: self class to: Object.
 	self assert: pragmasDetected = pragmasCompiled.
-	
+
 	pragmasDetected := Pragma allNamed: #foo: from: Object to: Object.
-	self assert: pragmasDetected isEmpty.
+	self assertEmpty: pragmasDetected
 ]
 
 { #category : #'testing-finding' }
@@ -92,9 +92,9 @@ MethodPragmaTest >> testAllNamedIn [
 	pragmasCompiled := self pragma: #foo: selector: #bar times: 5.
 	pragmasDetected := Pragma allNamed: #foo: in: self class.
 	self assert: pragmasDetected = pragmasCompiled.
-	
+
 	pragmasDetected := Pragma allNamed: #foo: in: Object.
-	self assert: pragmasDetected isEmpty.
+	self assertEmpty: pragmasDetected
 ]
 
 { #category : #'testing-finding' }

--- a/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
@@ -133,16 +133,16 @@ OCASTCheckerTest >> testExampleToDoArgument [
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testInstanceVar [
 	| ast assignment |
-	ast := (OCOpalExamples>>#exampleiVar) parseTree.
+	ast := (OCOpalExamples >> #exampleiVar) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars isEmpty.
-	
+	self assertEmpty: ast scope tempVars.
+
 	self assert: ast scope outerScope isInstanceScope.
 	self assert: (ast scope outerScope lookupVar: 'iVar') isInstance.
-	
-	assignment := RBParseTreeSearcher treeMatching: '`var := ``@anything' in: ast. 
-	self assert: assignment variable isInstance.
+
+	assignment := RBParseTreeSearcher treeMatching: '`var := ``@anything' in: ast.
+	self assert: assignment variable isInstance
 ]
 
 { #category : #'testing - variables' }
@@ -267,10 +267,10 @@ OCASTCheckerTest >> testOptimizedBlocksAndSameNameTemps [
 { #category : #'testing - simple' }
 OCASTCheckerTest >> testReturn1 [
 	| ast |
-	ast := (OCOpalExamples>>#exampleReturn1) parseTree.
+	ast := (OCOpalExamples >> #exampleReturn1) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars isEmpty.
+	self assertEmpty: ast scope tempVars
 ]
 
 { #category : #'testing - simple' }

--- a/src/OpalCompiler-Tests/OCArrayLiteralTest.class.st
+++ b/src/OpalCompiler-Tests/OCArrayLiteralTest.class.st
@@ -34,7 +34,7 @@ OCArrayLiteralTest >> testByteArrayBase [
 OCArrayLiteralTest >> testByteArrayEmpty [
 	self class compile: 'array ^ #[]'.
 	self assert: (self array isKindOf: ByteArray).
-	self assert: (self array isEmpty)
+	self assertEmpty: self array
 ]
 
 { #category : #tests }

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -376,14 +376,11 @@ RPackageOrganizerTest >> testRegisteredNumberOfPackageIsOk [
 { #category : #'tests extending' }
 RPackageOrganizerTest >> testRegistrationExtendingPackages [
 	| p |
-	self assert: (self packageOrganizer extendingPackagesOf: self quadrangleClass) isEmpty.
+	self assertEmpty: (self packageOrganizer extendingPackagesOf: self quadrangleClass).
 	p := self pointRectangleInGraphElement.
-	(self packageOrganizer
-					registerExtendingPackage:  p
-					forClass: self quadrangleClass).
-	self deny: (self packageOrganizer extendingPackagesOf: self quadrangleClass) isEmpty.
-	self assert: (self packageOrganizer extendingPackagesOf: self quadrangleClass) anyOne name equals: #GraphElement.
-	
+	self packageOrganizer registerExtendingPackage: p forClass: self quadrangleClass.
+	self denyEmpty: (self packageOrganizer extendingPackagesOf: self quadrangleClass).
+	self assert: (self packageOrganizer extendingPackagesOf: self quadrangleClass) anyOne name equals: #GraphElement
 ]
 
 { #category : #'tests extensions' }
@@ -420,16 +417,11 @@ RPackageOrganizerTest >> testUnregisterBasedOnNames [
 
 { #category : #'tests extending' }
 RPackageOrganizerTest >> testUnregistrationExtendingPackages [
-	| p |	
+	| p |
 	p := self pointRectangleInGraphElement.
-	self packageOrganizer
-		registerExtendingPackage: p
-		forClass: self quadrangleClass.
-	self deny: (self packageOrganizer extendingPackagesOf: self quadrangleClass) isEmpty.
+	self packageOrganizer registerExtendingPackage: p forClass: self quadrangleClass.
+	self denyEmpty: (self packageOrganizer extendingPackagesOf: self quadrangleClass).
 	self assert: (self packageOrganizer extendingPackagesOf: self quadrangleClass) anyOne name equals: #GraphElement.
-	self packageOrganizer
-					unregisterExtendingPackage:  p
-					forClass: self quadrangleClass.
-	self assert: (self packageOrganizer extendingPackagesOf: self quadrangleClass) isEmpty.
-	
+	self packageOrganizer unregisterExtendingPackage: p forClass: self quadrangleClass.
+	self assertEmpty: (self packageOrganizer extendingPackagesOf: self quadrangleClass)
 ]

--- a/src/RPackage-Tests/RPackagePrequisitesTest.class.st
+++ b/src/RPackage-Tests/RPackagePrequisitesTest.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #tests }
 RPackagePrequisitesTest >> testNoPackagesOverride [
-"Class side packages should not be overridden"
-	self assert: (Object allSubclasses select: [: each | (each class compiledMethodAt: #packages ifAbsent: [nil]) isNotNil]) isEmpty.
+	"Class side packages should not be overridden"
 
+	self assertEmpty: (Object allSubclasses select: [ :each | (each class compiledMethodAt: #packages ifAbsent: [ nil ]) isNotNil ])
 ]

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -70,11 +70,11 @@ RPackageReadOnlyCompleteSetupTest >> setUp [
 
 { #category : #'test tag class' }
 RPackageReadOnlyCompleteSetupTest >> testAddTag [
-	self assert: p1 classTags isEmpty.
-	p1 addClassTag: #baz. 
+	self assertEmpty: p1 classTags.
+	p1 addClassTag: #baz.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
 	self assert: p1 classTags size equals: 1.
-	
+
 	p1 addClassDefinitionName: #A1DefinedInP1 toClassTag: #foo.
 	p1 addClassDefinitionName: #B1DefinedInP1 toClassTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
@@ -82,23 +82,22 @@ RPackageReadOnlyCompleteSetupTest >> testAddTag [
 	self assert: (((p1 classesForClassTag: #foo) collect: #name) includes: #A1DefinedInP1).
 	self assert: (((p1 classesForClassTag: #foo) collect: #name) includes: #B1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 2.
-	
-	p1 addClassTag: #foo. 
+
+	p1 addClassTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
 	self assert: (((p1 classesForClassTag: #foo) collect: #name) includes: #A1DefinedInP1).
 	self assert: (((p1 classesForClassTag: #foo) collect: #name) includes: #B1DefinedInP1).
-	self assert: (p1 classesForClassTag: #foo) size equals: 2.
+	self assert: (p1 classesForClassTag: #foo) size equals: 2
 ]
 
 { #category : #'test tag class' }
 RPackageReadOnlyCompleteSetupTest >> testAddTagNames [
-	
-	self assert: p1 classTags isEmpty.
-	p1 addClassTag: #baz. 
+	self assertEmpty: p1 classTags.
+	p1 addClassTag: #baz.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
 	self assert: p1 classTags size equals: 1.
-	
+
 	p1 addClassDefinitionName: #A1DefinedInP1 toClassTag: #foo.
 	p1 addClassDefinitionName: #B1DefinedInP1 toClassTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
@@ -106,18 +105,18 @@ RPackageReadOnlyCompleteSetupTest >> testAddTagNames [
 	self assert: ((p1 classNamesForClassTag: #foo) includes: #A1DefinedInP1).
 	self assert: ((p1 classNamesForClassTag: #foo) includes: #B1DefinedInP1).
 	self assert: (p1 classNamesForClassTag: #foo) size equals: 2.
-	
-	p1 addClassTag: #foo. 
+
+	p1 addClassTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
 	self assert: ((p1 classNamesForClassTag: #foo) includes: #A1DefinedInP1).
 	self assert: ((p1 classNamesForClassTag: #foo) includes: #B1DefinedInP1).
-	self assert: (p1 classNamesForClassTag: #foo) size equals: 2.
+	self assert: (p1 classNamesForClassTag: #foo) size equals: 2
 ]
 
 { #category : #'test tag class' }
 RPackageReadOnlyCompleteSetupTest >> testAddTagsToAClass [
-	self assert: p1 classTags isEmpty.
+	self assertEmpty: p1 classTags.
 	p1 addClassDefinitionName: #A1DefinedInP1 toClassTag: #foo.
 	self assert: (((p1 classesForClassTag: #foo) collect: #name) includes: #A1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 1.
@@ -128,7 +127,7 @@ RPackageReadOnlyCompleteSetupTest >> testAddTagsToAClass [
 	p1 addClassDefinitionName: #B1DefinedInP1 toClassTag: #zork.
 	self assert: (((p1 classesForClassTag: #zork) collect: #name) includes: #B1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 2.
-	self assert: (p1 classesForClassTag: #zork) size equals: 1.
+	self assert: (p1 classesForClassTag: #zork) size equals: 1
 ]
 
 { #category : #'test compiled method' }
@@ -211,39 +210,35 @@ RPackageReadOnlyCompleteSetupTest >> testDefinedSelectors [
 
 { #category : #'test situation' }
 RPackageReadOnlyCompleteSetupTest >> testDefinedSelectorsForClass [
-
-	self assert: (p1 definedSelectorsForClass: a1) size equals: 2. 
-	self assert: (p1 definedMethodsForClass: a1) size equals: 2. 
+	self assert: (p1 definedSelectorsForClass: a1) size equals: 2.
+	self assert: (p1 definedMethodsForClass: a1) size equals: 2.
 	self assert: ((p1 definedSelectorsForClass: a1) includes: #methodDefinedInP1).
 	self assert: ((p1 definedSelectorsForClass: a1) includes: #anotherMethodDefinedInP1).
-	self assert: ((p1 definedMethodsForClass: a1) includes: ((Smalltalk at: #A1DefinedInP1)>>#methodDefinedInP1)).
-	self assert: (p1 definedSelectorsForClass: Object) isEmpty. 
-	self assert: (p1 definedSelectorsForClass: Object class) isEmpty. 
-
+	self assert: ((p1 definedMethodsForClass: a1) includes: (Smalltalk at: #A1DefinedInP1) >> #methodDefinedInP1).
+	self assertEmpty: (p1 definedSelectorsForClass: Object).
+	self assertEmpty: (p1 definedSelectorsForClass: Object class)
 ]
 
 { #category : #'test tag class' }
 RPackageReadOnlyCompleteSetupTest >> testEmpty [
-		
-	self assert: p1 classTags isEmpty.
-	
+	self assertEmpty: p1 classTags
 ]
 
 { #category : #'test accessing' }
 RPackageReadOnlyCompleteSetupTest >> testExtendingPackagesOfClass [
 	"since a class can be extended by several packages, we want the list of packages that extend
 	the class"
-	
+
 	| packages |
 	packages := a2 extendingPackages.
 	"a2 is extended by p1 and p3"
-	self assert: packages size equals: 2. 
+	self assert: packages size equals: 2.
 	self assert: (packages includes: p1).
 	self deny: (packages includes: p2).
 	self assert: (packages includes: p3).
-	
+
 	packages := a1 extendingPackages.
-	self assert: packages isEmpty. 
+	self assertEmpty: packages
 ]
 
 { #category : #'test accessing' }
@@ -271,22 +266,20 @@ RPackageReadOnlyCompleteSetupTest >> testExtensionMethods [
 
 { #category : #'test situation' }
 RPackageReadOnlyCompleteSetupTest >> testExtensionSelectors [
-	
-	self assert: a1 extensionSelectors isEmpty.
+	self assertEmpty: a1 extensionSelectors.
 
 	self assert: a2 extensionSelectors size equals: 2.
 	self assert: (a2 extensionSelectors includes: #methodDefinedInP1).
-	self assert: (a2 extensionSelectors includes: #methodDefinedInP3).
+	self assert: (a2 extensionSelectors includes: #methodDefinedInP3)
 ]
 
 { #category : #'test situation' }
 RPackageReadOnlyCompleteSetupTest >> testExtensionSelectorsForClass [
-	
-	self assert: (p1 extensionSelectorsForClass: a2) size equals: 1. 
+	self assert: (p1 extensionSelectorsForClass: a2) size equals: 1.
 	self assert: ((p1 extensionSelectorsForClass: a2) includes: #methodDefinedInP1).
 	self assert: ((p1 extensionMethodsForClass: a2) includes: (Smalltalk at: #A2DefinedInP2) >> #methodDefinedInP1).
-	self assert: (p1 extensionSelectorsForClass: Object) isEmpty.
-	self assert: (p1 extensionSelectorsForClass: Object class) isEmpty
+	self assertEmpty: (p1 extensionSelectorsForClass: Object).
+	self assertEmpty: (p1 extensionSelectorsForClass: Object class)
 ]
 
 { #category : #'test situation' }
@@ -317,18 +310,17 @@ RPackageReadOnlyCompleteSetupTest >> testMethods [
 
 { #category : #'test situation' }
 RPackageReadOnlyCompleteSetupTest >> testMethodsForClass [
-
-	self assert: (p1 methodsForClass: a1) size equals: 2. 
-	self assert: ((p1 methodsForClass: a1) includes: ((Smalltalk at: #A1DefinedInP1)>>#methodDefinedInP1)).
-	self assert: ((p1 methodsForClass: a1) includes: ((Smalltalk at: #A1DefinedInP1)>>#anotherMethodDefinedInP1)).
-	self assert: (p1 methodsForClass: b1) isEmpty. 
-	self assert: (p1 methodsForClass: Object) isEmpty. 
-	self assert: (p1 methodsForClass: Object class) isEmpty. 
+	self assert: (p1 methodsForClass: a1) size equals: 2.
+	self assert: ((p1 methodsForClass: a1) includes: (Smalltalk at: #A1DefinedInP1) >> #methodDefinedInP1).
+	self assert: ((p1 methodsForClass: a1) includes: (Smalltalk at: #A1DefinedInP1) >> #anotherMethodDefinedInP1).
+	self assertEmpty: (p1 methodsForClass: b1).
+	self assertEmpty: (p1 methodsForClass: Object).
+	self assertEmpty: (p1 methodsForClass: Object class).
 
 	self assert: (p3 methodsForClass: a2) size equals: 1.
-	self assert: ((p3 methodsForClass: a2) includes: ((Smalltalk at: #A2DefinedInP2)>>#methodDefinedInP3)).
+	self assert: ((p3 methodsForClass: a2) includes: (Smalltalk at: #A2DefinedInP2) >> #methodDefinedInP3).
 	self assert: (p3 methodsForClass: a2 class) size equals: 1.
-	self assert:  ((p3 methodsForClass: a2 class) includes: ((Smalltalk at: #A2DefinedInP2) class>>#classSideMethodDefinedInP3))	
+	self assert: ((p3 methodsForClass: a2 class) includes: (Smalltalk at: #A2DefinedInP2) class >> #classSideMethodDefinedInP3)
 ]
 
 { #category : #'test accessing' }
@@ -359,8 +351,7 @@ RPackageReadOnlyCompleteSetupTest >> testPackagesOfClass [
 
 { #category : #'test tag class' }
 RPackageReadOnlyCompleteSetupTest >> testRemoveTag [
-	
-	self assert: p1 classTags isEmpty.
+	self assertEmpty: p1 classTags.
 	p1 addClassDefinitionName: #A1DefinedInP1 toClassTag: #foo.
 	self assert: (((p1 classesForClassTag: #foo) collect: #name) includes: #A1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 1.
@@ -413,18 +404,17 @@ RPackageReadOnlyCompleteSetupTest >> testSelectors [
 
 { #category : #'test situation' }
 RPackageReadOnlyCompleteSetupTest >> testSelectorsForClass [
-		
-	self assert: (p1 selectorsForClass: a1) size equals:2. 
+	self assert: (p1 selectorsForClass: a1) size equals: 2.
 	self assert: ((p1 selectorsForClass: a1) includes: #methodDefinedInP1).
 	self assert: ((p1 selectorsForClass: a1) includes: #anotherMethodDefinedInP1).
-	self assert: (p1 selectorsForClass: b1) isEmpty. 
-	self assert: (p1 selectorsForClass: Object) isEmpty. 
-	self assert: (p1 selectorsForClass: Object class) isEmpty. 
+	self assertEmpty: (p1 selectorsForClass: b1).
+	self assertEmpty: (p1 selectorsForClass: Object).
+	self assertEmpty: (p1 selectorsForClass: Object class).
 
 	self assert: (p3 selectorsForClass: a2) size equals: 1.
 	self assert: ((p3 selectorsForClass: a2) includes: #methodDefinedInP3).
 	self assert: (p3 selectorsForClass: a2 class) size equals: 1.
-	self assert:  ((p3 selectorsForClass: a2 class) includes: #classSideMethodDefinedInP3)	
+	self assert: ((p3 selectorsForClass: a2 class) includes: #classSideMethodDefinedInP3)
 ]
 
 { #category : #'test situation' }

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -80,20 +80,19 @@ RPackageTagTest >> testAsRPackage [
 
 { #category : #tests }
 RPackageTagTest >> testAsRPackageWithExtensionMethods [
-	| package1 convertedTag class  |
-
+	| package1 convertedTag class |
 	package1 := (self packageClass named: #Test1) register.
 	package1 addClassTag: #TAG1.
-	
+
 	(self packageClass named: #Test2) register.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test2'.
-	
+
 	class compile: 'foo ^42' classified: '*Test1-TAG1'.
-	
+
 	convertedTag := (package1 classTagNamed: #TAG1) asRPackage.
-	
-	self assert: (convertedTag definedClasses isEmpty).
-	self assert: (convertedTag includesExtensionSelector: 'foo' ofClass:  class).
+
+	self assertEmpty: convertedTag definedClasses.
+	self assert: (convertedTag includesExtensionSelector: 'foo' ofClass: class)
 ]
 
 { #category : #tests }

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -18,12 +18,11 @@ RPackageTest >> tearDown [
 
 { #category : #tests }
 RPackageTest >> testActualClassTags [
-
 	| packageWithoutClassTags packageWithClassTags |
 	packageWithoutClassTags := RPackageOrganizer default packageOf: StartupAction.
-	self deny: packageWithoutClassTags classTags isEmpty.
-	self assert: packageWithoutClassTags actualClassTags isEmpty.
-	
+	self denyEmpty: packageWithoutClassTags classTags.
+	self assertEmpty: packageWithoutClassTags actualClassTags.
+
 	packageWithClassTags := RPackageOrganizer default packageOf: Object.
 	self assert: packageWithClassTags actualClassTags equals: packageWithClassTags classTags
 ]

--- a/src/Refactoring-Tests-Changes/RBRefactoringChangeTests.class.st
+++ b/src/Refactoring-Tests-Changes/RBRefactoringChangeTests.class.st
@@ -392,16 +392,21 @@ RBRefactoringChangeTests >> testPerformAddRemoveMethodInteractively [
 { #category : #'tests-perform' }
 RBRefactoringChangeTests >> testPerformChangeClass [
 	| change |
-	change := changes defineClass: self class name , ' subclass: #' , self changeMock name , '
+	change := changes
+		defineClass:
+			self class name , ' subclass: #' , self changeMock name
+				,
+					'
 	instanceVariableNames: ''''
 	classVariableNames: ''''
 	poolDictionaries: ''''
 	category: ''' , self class category , ''''.
-	self perform: change do: [ 
-		self assert: change changeClass superclass equals: self class.
-		self assert: change changeClass instVarNames isEmpty ].
+	self
+		perform: change
+		do: [ self assert: change changeClass superclass equals: self class.
+			self assertEmpty: change changeClass instVarNames ].
 	self assert: change changeClass superclass equals: Object.
-	self assert: change changeClass instVarNames notEmpty.
+	self denyEmpty: change changeClass instVarNames.
 	self assert: change definedClass equals: self changeMock
 ]
 
@@ -417,10 +422,14 @@ RBRefactoringChangeTests >> testPerformChangeComment [
 { #category : #'tests-perform' }
 RBRefactoringChangeTests >> testPerformChangeMetaclass [
 	| change |
-	change := changes defineClass: self changeMock name , ' class 
+	change := changes
+		defineClass:
+			self changeMock name
+				,
+					' class 
 	instanceVariableNames: '''''.
-	self perform: change do: [ self assert: change changeClass class instVarNames isEmpty ].
-	self assert: change changeClass class instVarNames notEmpty.
+	self perform: change do: [ self assertEmpty: change changeClass class instVarNames ].
+	self denyEmpty: change changeClass class instVarNames.
 	self assert: change definedClass equals: self changeMock class
 ]
 

--- a/src/Refactoring-Tests-Core/RBCreateAccessorsForVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBCreateAccessorsForVariableTest.class.st
@@ -18,7 +18,7 @@ RBCreateAccessorsForVariableTest >> testExistingInstanceVariableAccessors [
 		class: RBLintRuleTest
 		classVariable: false.
 	self executeRefactoring: ref.
-	self assert: ref changes changes isEmpty.
+	self assertEmpty: ref changes changes.
 	self assert: ref setterMethod == #name:.
 	self assert: ref getterMethod == #name
 ]
@@ -32,7 +32,7 @@ RBCreateAccessorsForVariableTest >> testNewClassVariableAccessors [
 		classVariable: true.
 	self executeRefactoring: ref.
 	class := ref model metaclassNamed: #RBLintRuleTest.
-	self deny: ref changes changes isEmpty.
+	self denyEmpty: ref changes changes.
 	self assert: ref setterMethod == #foo1:.
 	self assert: ref getterMethod == #foo1.
 	self assert: (class parseTreeFor: #foo1) = (RBParser parseMethod: 'foo1 ^Foo1').
@@ -42,13 +42,10 @@ RBCreateAccessorsForVariableTest >> testNewClassVariableAccessors [
 { #category : #tests }
 RBCreateAccessorsForVariableTest >> testNewInstanceVariableAccessors [
 	| ref class |
-	ref := RBCreateAccessorsForVariableRefactoring 
-		variable: 'foo1'
-		class: RBLintRuleTest
-		classVariable: false.
+	ref := RBCreateAccessorsForVariableRefactoring variable: 'foo1' class: RBLintRuleTest classVariable: false.
 	self executeRefactoring: ref.
 	class := ref model classNamed: #RBLintRuleTest.
-	self deny: ref changes changes isEmpty.
+	self denyEmpty: ref changes changes.
 	self assert: ref setterMethod == #foo1:.
 	self assert: ref getterMethod == #foo1.
 	self assert: (class parseTreeFor: #foo1) = (RBParser parseMethod: 'foo1 ^foo1').

--- a/src/Refactoring-Tests-Core/RBSearchTest.class.st
+++ b/src/Refactoring-Tests-Core/RBSearchTest.class.st
@@ -171,13 +171,11 @@ RBSearchTest >> setUp [
 
 { #category : #tests }
 RBSearchTest >> testAllSearches [
-	classSearches keysAndValuesDo: 
-			[:class :searches | 
-			class selectors do: 
-					[:sel | 
+	classSearches
+		keysAndValuesDo: [ :class :searches | 
+			class selectors
+				do: [ :sel | 
 					currentSelector := sel.
-					searches 
-						do: [:each | each executeTree: (class parseTreeFor: sel) initialAnswer: each answer]]].
-	classSearches 
-		do: [:searches | searches do: [:each | self assert: each answer isEmpty]]
+					searches do: [ :each | each executeTree: (class parseTreeFor: sel) initialAnswer: each answer ] ] ].
+	classSearches do: [ :searches | searches do: [ :each | self assertEmpty: each answer ] ]
 ]

--- a/src/Refactoring-Tests-Core/RBVariableTypeTest.class.st
+++ b/src/Refactoring-Tests-Core/RBVariableTypeTest.class.st
@@ -34,7 +34,7 @@ RBVariableTypeTest >> testCompositeLintRuleTypes [
 	self assert: (types includes: (typer model classFor: Collection)).
 	types := typer typesFor: '-rules-'.
 	self assert: (types includes: (typer model classFor: RBLintRuleTest)).
-	self assert: (typer guessTypesFor: 'asdf') isEmpty.
+	self assertEmpty: (typer guessTypesFor: 'asdf').
 	typer printString
 ]
 

--- a/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
+++ b/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
@@ -518,7 +518,7 @@ RBBrowserEnvironmentTest >> uniqueClassesIn: aBrowserEnvironment [
 ]
 
 { #category : #private }
-RBBrowserEnvironmentTest >> universalTestFor: aBrowserEnvironment [
+RBBrowserEnvironmentTest >> universalTestFor: aBrowserEnvironment [ 
 	self labelFor: aBrowserEnvironment.
 	self uniqueClassesIn: aBrowserEnvironment.
 	self numberSelectorsFor: aBrowserEnvironment.
@@ -529,6 +529,5 @@ RBBrowserEnvironmentTest >> universalTestFor: aBrowserEnvironment [
 	self protocolsFor: aBrowserEnvironment.
 	self classesFor: aBrowserEnvironment.
 	self keysFor: aBrowserEnvironment.
-	self assert: aBrowserEnvironment problemCount = 0.
-	self assertEmpty: aBrowserEnvironment
+	self assert: aBrowserEnvironment problemCount = 0 = aBrowserEnvironment isEmpty
 ]

--- a/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
+++ b/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
@@ -27,26 +27,24 @@ RBBrowserEnvironmentTest class >> packageNamesUnderTest [
 ]
 
 { #category : #private }
-RBBrowserEnvironmentTest >> categoriesFor: anEnvironment [ 
+RBBrowserEnvironmentTest >> categoriesFor: anEnvironment [
 	| allCategories |
 	allCategories := IdentitySet withAll: universalEnvironment categories.
 	allCategories removeAll: anEnvironment categories.
-	anEnvironment not categories 
-		do: [ :each | allCategories remove: each ifAbsent: [ ] ].
-	allCategories 
-		do: [ :each | self assert: (universalEnvironment classNamesFor: each) isEmpty ]
+	anEnvironment not categories do: [ :each | allCategories remove: each ifAbsent: [  ] ].
+	allCategories do: [ :each | self assertEmpty: (universalEnvironment classNamesFor: each) ]
 ]
 
 { #category : #private }
-RBBrowserEnvironmentTest >> classNamesFor: anEnvironment [ 
+RBBrowserEnvironmentTest >> classNamesFor: anEnvironment [
 	| classNames allClassNames |
 	classNames := IdentitySet new
 		addAll: anEnvironment classNames asSet;
 		addAll: anEnvironment not classNames;
 		yourself.
 	allClassNames := universalEnvironment classNames asSortedCollection.
-	self assert: classNames asSortedCollection 	= allClassNames.
-	self assert: (anEnvironment & anEnvironment not) classNames isEmpty.
+	self assert: classNames asSortedCollection = allClassNames.
+	self assertEmpty: (anEnvironment & anEnvironment not) classNames.
 	self assert: (anEnvironment | anEnvironment not) classNames asSortedCollection = allClassNames
 ]
 
@@ -61,12 +59,12 @@ RBBrowserEnvironmentTest >> classVariableWriter [
 ]
 
 { #category : #private }
-RBBrowserEnvironmentTest >> classesFor: aBrowserEnvironment [ 
+RBBrowserEnvironmentTest >> classesFor: aBrowserEnvironment [
 	| allClasses |
 	allClasses := aBrowserEnvironment classes asSet.
 	allClasses addAll: aBrowserEnvironment not classes.
-	RBBrowserEnvironment new allClassesDo: [:each | allClasses remove: each].
-	self assert: allClasses isEmpty
+	RBBrowserEnvironment new allClassesDo: [ :each | allClasses remove: each ].
+	self assertEmpty: allClasses
 ]
 
 { #category : #private }
@@ -78,12 +76,12 @@ RBBrowserEnvironmentTest >> copyFor: aBrowserEnvironment [
 ]
 
 { #category : #private }
-RBBrowserEnvironmentTest >> keysFor: aBrowserEnvironment [ 
+RBBrowserEnvironmentTest >> keysFor: aBrowserEnvironment [
 	| allKeys |
 	allKeys := IdentitySet withAll: aBrowserEnvironment keys.
 	allKeys addAll: aBrowserEnvironment not keys.
 	allKeys removeAll: Smalltalk globals keys.
-	self assert: allKeys isEmpty
+	self assertEmpty: allKeys
 ]
 
 { #category : #private }
@@ -296,31 +294,29 @@ RBBrowserEnvironmentTest >> testMatches [
 
 { #category : #'testing-environments' }
 RBBrowserEnvironmentTest >> testNotEnvironment [
-	| notPrintStringEnvironment printStringEnvironment kernelEnvironment notKernelEnvironment|
+	| notPrintStringEnvironment printStringEnvironment kernelEnvironment notKernelEnvironment |
 	printStringEnvironment := universalEnvironment referencesTo: #printString.
 	notPrintStringEnvironment := printStringEnvironment not.
-	kernelEnvironment := (RBPackageEnvironment packageName: 'Kernel').
+	kernelEnvironment := RBPackageEnvironment packageName: 'Kernel'.
 	notKernelEnvironment := kernelEnvironment not.
 
 	self universalTestFor: notPrintStringEnvironment.
-	self assert: (notPrintStringEnvironment referencesTo: #printString) isEmpty.
+	self assertEmpty: (notPrintStringEnvironment referencesTo: #printString).
 	self assert: (notPrintStringEnvironment not includesClass: RBBrowserEnvironmentTest).
-	self assert: (notPrintStringEnvironment not 
-			includesSelector: #testNotEnvironment
-			in: RBBrowserEnvironmentTest).
+	self assert: (notPrintStringEnvironment not includesSelector: #testNotEnvironment in: RBBrowserEnvironmentTest).
 	self assert: (notKernelEnvironment includesPackage: 'Kernel' asPackage) not.
-	self assert: (notKernelEnvironment & kernelEnvironment) packages isEmpty
+	self assertEmpty: (notKernelEnvironment & kernelEnvironment) packages
 ]
 
 { #category : #'testing-environments' }
 RBBrowserEnvironmentTest >> testNotEnvironmentWithClassEnvironments [
 	| numberEnvironment notNumberEnvironment |
-	numberEnvironment := (RBBrowserEnvironment new) forClasses: Number withAllSubclasses.
+	numberEnvironment := RBBrowserEnvironment new forClasses: Number withAllSubclasses.
 	notNumberEnvironment := numberEnvironment not.
 
 	self universalTestFor: notNumberEnvironment.
 	self deny: (notNumberEnvironment includesClass: Number).
-	self assert: (notNumberEnvironment & numberEnvironment) classes isEmpty.
+	self assertEmpty: (notNumberEnvironment & numberEnvironment) classes.
 	self assert: (notNumberEnvironment not includesClass: Number)
 ]
 
@@ -465,14 +461,12 @@ RBBrowserEnvironmentTest >> testVariableEnvironmentAddRemove [
 
 { #category : #testing }
 RBBrowserEnvironmentTest >> testVariableEnvironmentClassVars [
-"test variable environment for class vars, refered on the class side only"
-	| classRefs |
-	classRefs := RBVariableEnvironment
-		referencesToClassVariable: 'ClassSideOnlyVariable'
-		in: self class.
-	self universalTestFor: classRefs.
-	self assert: classRefs methods isEmpty not.
+	"test variable environment for class vars, refered on the class side only"
 
+	| classRefs |
+	classRefs := RBVariableEnvironment referencesToClassVariable: 'ClassSideOnlyVariable' in: self class.
+	self universalTestFor: classRefs.
+	self denyEmpty: classRefs methods
 ]
 
 { #category : #testing }
@@ -524,7 +518,7 @@ RBBrowserEnvironmentTest >> uniqueClassesIn: aBrowserEnvironment [
 ]
 
 { #category : #private }
-RBBrowserEnvironmentTest >> universalTestFor: aBrowserEnvironment [ 
+RBBrowserEnvironmentTest >> universalTestFor: aBrowserEnvironment [
 	self labelFor: aBrowserEnvironment.
 	self uniqueClassesIn: aBrowserEnvironment.
 	self numberSelectorsFor: aBrowserEnvironment.
@@ -535,5 +529,6 @@ RBBrowserEnvironmentTest >> universalTestFor: aBrowserEnvironment [
 	self protocolsFor: aBrowserEnvironment.
 	self classesFor: aBrowserEnvironment.
 	self keysFor: aBrowserEnvironment.
-	self assert: aBrowserEnvironment problemCount = 0 = aBrowserEnvironment isEmpty
+	self assert: aBrowserEnvironment problemCount = 0.
+	self assertEmpty: aBrowserEnvironment
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddSubtreeTransformationTest.class.st
@@ -6,30 +6,26 @@ Class {
 
 { #category : #testing }
 RBAddSubtreeTransformationTest >> testMethodDoesNotExist [
-
 	| transformation |
 	transformation := (RBAddSubtreeTransformation
 		interval: (0 to: 1)
 		with: 'self printString'
 		from: #two
-		in: self changeMock name)
-		transform. 
-	
-	self assert: transformation model changes changes isEmpty
+		in: self changeMock name) transform.
+
+	self assertEmpty: transformation model changes changes
 ]
 
 { #category : #testing }
 RBAddSubtreeTransformationTest >> testParseFailure [
-
 	| transformation |
 	transformation := (RBAddSubtreeTransformation
 		interval: (0 to: 1)
 		with: ':= 123'
 		from: #one
-		in: self changeMock name)
-		transform. 
-	
-	self assert: transformation model changes changes isEmpty
+		in: self changeMock name) transform.
+
+	self assertEmpty: transformation model changes changes
 ]
 
 { #category : #testing }

--- a/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorTransformationTest.class.st
@@ -6,42 +6,29 @@ Class {
 
 { #category : #testing }
 RBAddVariableAccessorTransformationTest >> testExistingInstanceVariableAccessors [
-
 	| refactoring |
-	refactoring := (RBAddVariableAccessorTransformation 
-						instanceVariable: 'name'
-						class: #RBDummyLintRuleTest)
-						asRefactoring transform.
-		
-	self assert: refactoring changes changes isEmpty
+	refactoring := (RBAddVariableAccessorTransformation instanceVariable: 'name' class: #RBDummyLintRuleTest) asRefactoring transform.
+	self assertEmpty: refactoring changes changes
 ]
 
 { #category : #testing }
 RBAddVariableAccessorTransformationTest >> testNewClassVariableAccessors [
-
 	| refactoring class |
-	refactoring := (RBAddVariableAccessorTransformation 
-						classVariable: 'Foo1'
-						class: #RBDummyLintRuleTest)
-						asRefactoring transform.
-	
+	refactoring := (RBAddVariableAccessorTransformation classVariable: 'Foo1' class: #RBDummyLintRuleTest) asRefactoring transform.
+
 	class := refactoring model metaclassNamed: #RBDummyLintRuleTest.
-	self deny: refactoring changes changes isEmpty.
-	self assert: (class parseTreeFor: #foo1) = (RBParser parseMethod: 'foo1 ^Foo1').
-	self assert: (class parseTreeFor: #foo1:) = (RBParser parseMethod: 'foo1: anObject Foo1 := anObject')
+	self denyEmpty: refactoring changes changes.
+	self assert: (class parseTreeFor: #foo1) equals: (RBParser parseMethod: 'foo1 ^Foo1').
+	self assert: (class parseTreeFor: #foo1:) equals: (RBParser parseMethod: 'foo1: anObject Foo1 := anObject')
 ]
 
 { #category : #testing }
 RBAddVariableAccessorTransformationTest >> testNewInstanceVariableAccessors [
-
 	| refactoring class |
-	refactoring := (RBAddVariableAccessorTransformation
-						instanceVariable: 'foo1'
-						class: #RBDummyLintRuleTest)
-						asRefactoring transform.
-		
+	refactoring := (RBAddVariableAccessorTransformation instanceVariable: 'foo1' class: #RBDummyLintRuleTest) asRefactoring transform.
+
 	class := refactoring model classNamed: #RBDummyLintRuleTest.
-	self deny: refactoring changes changes isEmpty.
+	self denyEmpty: refactoring changes changes.
 	self assert: (class parseTreeFor: #foo1) = (RBParser parseMethod: 'foo1 ^foo1').
 	self assert: (class parseTreeFor: #foo1:) = (RBParser parseMethod: 'foo1: anObject foo1 := anObject')
 ]
@@ -62,15 +49,11 @@ RBAddVariableAccessorTransformationTest >> testNonExistantName [
 
 { #category : #testing }
 RBAddVariableAccessorTransformationTest >> testRefactoring [
-
 	| refactoring class |
-	refactoring := (RBAddVariableAccessorTransformation 
-						instanceVariable: 'foo1'
-						class: #RBDummyLintRuleTest)
-						asRefactoring transform.
-		
+	refactoring := (RBAddVariableAccessorTransformation instanceVariable: 'foo1' class: #RBDummyLintRuleTest) asRefactoring transform.
+
 	class := refactoring model classNamed: #RBDummyLintRuleTest.
-	self deny: refactoring changes changes isEmpty.
+	self denyEmpty: refactoring changes changes.
 	self assert: (class parseTreeFor: #foo1) = (RBParser parseMethod: 'foo1 ^foo1').
 	self assert: (class parseTreeFor: #foo1:) = (RBParser parseMethod: 'foo1: anObject foo1 := anObject')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBMethodProtocolTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMethodProtocolTransformationTest.class.st
@@ -26,33 +26,18 @@ RBMethodProtocolTransformationTest >> testMethodDoesNotExist [
 
 { #category : #testing }
 RBMethodProtocolTransformationTest >> testRefactoring [
-
 	| refactoring |
-	self assert: ( RBDummyEmptyClass
-		organization protocolOrganizer
-		protocolNamed: 'empty protocol 2' ) isEmpty.
-	
-	refactoring := (RBMethodProtocolTransformation
-						protocol: 'empty protocol 2'
-						inMethod: #someMethod
-						inClass: #RBDummyEmptyClass)
-						asRefactoring transform.
+	self assert: (RBDummyEmptyClass organization protocolOrganizer protocolNamed: 'empty protocol 2') isEmpty.
+
+	refactoring := (RBMethodProtocolTransformation protocol: 'empty protocol 2' inMethod: #someMethod inClass: #RBDummyEmptyClass) asRefactoring transform.
 	RBRefactoringManager instance addRefactoring: refactoring.
 
-	self assert: ( RBDummyEmptyClass
-		organization protocolOrganizer
-		protocolNamed: 'empty protocol 2' ) isEmpty not.
-	
-	refactoring := (RBMethodProtocolTransformation 
-						protocol: 'empty protocol 1'
-						inMethod: #someMethod
-						inClass: #RBDummyEmptyClass)
-						asRefactoring transform.
+	self deny: (RBDummyEmptyClass organization protocolOrganizer protocolNamed: 'empty protocol 2') isEmpty.
+
+	refactoring := (RBMethodProtocolTransformation protocol: 'empty protocol 1' inMethod: #someMethod inClass: #RBDummyEmptyClass) asRefactoring transform.
 	RBRefactoringManager instance addRefactoring: refactoring.
-		
-	self assert: ( RBDummyEmptyClass
-		organization protocolOrganizer
-		protocolNamed: 'empty protocol 2' ) isEmpty.
+
+	self assert: (RBDummyEmptyClass organization protocolOrganizer protocolNamed: 'empty protocol 2') isEmpty
 ]
 
 { #category : #testing }

--- a/src/Refactoring2-Transformations-Tests/RBRemoveSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveSubtreeTransformationTest.class.st
@@ -6,56 +6,29 @@ Class {
 
 { #category : #testing }
 RBRemoveSubtreeTransformationTest >> testEmptyCode [
-
 	| transformation |
-	transformation := (RBRemoveSubtreeTransformation
-							code: ''
-							from: #one
-							in: self changeMock name)
-							transform. 
-	self assert: transformation model changes changes isEmpty.
-	
-	self shouldFail: (RBRemoveSubtreeTransformation 
-							code: ''
-							from: #selector:from:
-							in: #RBRemoveMethodTransformation)
-							asRefactoring 
+	transformation := (RBRemoveSubtreeTransformation code: '' from: #one in: self changeMock name) transform.
+	self assertEmpty: transformation model changes changes.
+
+	self shouldFail: (RBRemoveSubtreeTransformation code: '' from: #selector:from: in: #RBRemoveMethodTransformation) asRefactoring
 ]
 
 { #category : #testing }
 RBRemoveSubtreeTransformationTest >> testExtractFailure [
-
 	| transformation |
-	transformation := (RBRemoveSubtreeTransformation
-							code: ':= anInterval'
-							from: #one
-							in: self changeMock name)
-							transform. 
-	self assert: transformation model changes changes isEmpty.
-	
-	self shouldFail: (RBRemoveSubtreeTransformation
-							code: ':= aSelector' 
-							from: #selector:from:
-							in: #RBRemoveMethodTransformation)
-							asRefactoring 
+	transformation := (RBRemoveSubtreeTransformation code: ':= anInterval' from: #one in: self changeMock name) transform.
+	self assertEmpty: transformation model changes changes.
+
+	self shouldFail: (RBRemoveSubtreeTransformation code: ':= aSelector' from: #selector:from: in: #RBRemoveMethodTransformation) asRefactoring
 ]
 
 { #category : #testing }
 RBRemoveSubtreeTransformationTest >> testMethodDoesNotExist [
-
 	| transformation |
-	transformation := (RBRemoveSubtreeTransformation
-							code: 'selector := aSelector'
-							from: #two
-							in: self changeMock name)
-							transform. 
-	self assert: transformation model changes changes isEmpty.
-	
-	self shouldFail: (RBRemoveSubtreeTransformation 
-							code: 'selector := aSelector'
-							from: #selector:for:
-							in: #RBRemoveMethodTransformation)
-							asRefactoring
+	transformation := (RBRemoveSubtreeTransformation code: 'selector := aSelector' from: #two in: self changeMock name) transform.
+	self assertEmpty: transformation model changes changes.
+
+	self shouldFail: (RBRemoveSubtreeTransformation code: 'selector := aSelector' from: #selector:for: in: #RBRemoveMethodTransformation) asRefactoring
 ]
 
 { #category : #testing }
@@ -77,40 +50,29 @@ RBRemoveSubtreeTransformationTest >> testRefactoring [
 
 { #category : #testing }
 RBRemoveSubtreeTransformationTest >> testTransform [
-
 	| transformation class |
-	transformation := (RBRemoveSubtreeTransformation
-		code: '^ 1'
-		from: #one
-		in: self changeMock name)
-		transform. 
-	
+	transformation := (RBRemoveSubtreeTransformation code: '^ 1' from: #one in: self changeMock name) transform.
+
 	self assert: transformation model changes changes size equals: 1.
-	
+
 	class := transformation model classNamed: self changeMock name asSymbol.
 	self assert: (class directlyDefinesMethod: #one).
-	self assert: (class parseTreeFor: #one) body statements isEmpty
+	self assertEmpty: (class parseTreeFor: #one) body statements
 ]
 
 { #category : #testing }
 RBRemoveSubtreeTransformationTest >> testTransformNotSequenceNode [
-
 	| transformation class |
 	transformation := RBCompositeTransformation new
-		transformations: (OrderedCollection
-		with: (RBAddMethodTransformation
-				sourceCode: 'printString1 super printString'
-				in: self changeMock name
-				withProtocol: #accessing)
-		with: (RBRemoveSubtreeTransformation
-				code: 'super printString'
-				from: #printString1
-				in: self changeMock name)).
+		transformations:
+			(OrderedCollection
+				with: (RBAddMethodTransformation sourceCode: 'printString1 super printString' in: self changeMock name withProtocol: #accessing)
+				with: (RBRemoveSubtreeTransformation code: 'super printString' from: #printString1 in: self changeMock name)).
 	transformation transform.
-	
+
 	self assert: transformation model changes changes size equals: 2.
-	
+
 	class := transformation model classNamed: self changeMock name asSymbol.
 	self assert: (class directlyDefinesMethod: #printString1).
-	self assert: (class parseTreeFor: #printString1) body statements isEmpty
+	self assertEmpty: (class parseTreeFor: #printString1) body statements
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRenameAndDeprecateClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameAndDeprecateClassTransformationTest.class.st
@@ -6,27 +6,23 @@ Class {
 
 { #category : #testing }
 RBRenameAndDeprecateClassTransformationTest >> testTransform [
-
 	| transformation class |
-	transformation := (RBRenameAndDeprecateClassTransformation 
-							rename: self changeMock name
-							to: #RBRefactoringChangeMock2)
-							transform. 
+	transformation := (RBRenameAndDeprecateClassTransformation rename: self changeMock name to: #RBRefactoringChangeMock2) transform.
 
 	self assert: transformation model changes changes size equals: 7.
-	
+
 	"old class"
 	class := transformation model classNamed: self changeMock name asSymbol.
 	self deny: class isNil.
-	self assert: class selectors isEmpty.
+	self assertEmpty: class selectors.
 	self assert: class superclass name equals: #RBRefactoringChangeMock2.
 	self assert: class comment equals: 'Deprecated!!! Use superclass'.
-	
+
 	"new class as a superclass"
 	class := transformation model classNamed: #RBRefactoringChangeMock2.
-	self deny: class selectors isEmpty.
-	
+	self denyEmpty: class selectors.
+
 	"temporary class, should not exist"
-	class := transformation model classNamed: (#TmpSubclass, self changeMock name asSymbol).
-	self assert: class isNil.
+	class := transformation model classNamed: #TmpSubclass , self changeMock name asSymbol.
+	self assert: class isNil
 ]

--- a/src/Refactoring2-Transformations-Tests/RBTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBTransformationTest.class.st
@@ -157,24 +157,21 @@ RBTransformationTest >> tearDown [
 { #category : #testing }
 RBTransformationTest >> testAPI [
 	"all classes must implement #storeOn: and #transform"
-	
+
 	| incompleteTransformations |
 	incompleteTransformations := RBTransformation allSubclasses
 		select: [ :each | 
 			| selectors |
 			selectors := each methods collect: #selector.
-	
-			each subclasses isEmpty
-				and: [ (selectors includes: #privateTransform) not
-				and: [ (selectors includes: #storeOn:) not ] ] ].
-	self assert: incompleteTransformations isEmpty.
-	
+
+			each subclasses isEmpty and: [ (selectors includes: #privateTransform) not and: [ (selectors includes: #storeOn:) not ] ] ].
+	self assertEmpty: incompleteTransformations.
+
 	incompleteTransformations := RBCompositeTransformation allSubclasses
 		select: [ :each | 
 			| selectors |
 			selectors := each methods collect: #selector.
-	
-			each subclasses isEmpty
-				and: [ (selectors includes: #buildTransformations) not ] ].
-	self assert: incompleteTransformations isEmpty.
+
+			each subclasses isEmpty and: [ (selectors includes: #buildTransformations) not ] ].
+	self assertEmpty: incompleteTransformations
 ]

--- a/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
+++ b/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
@@ -207,7 +207,7 @@ ReflectiveMethodTest >> testSetLinkOnInstanceVariableAndUninstall [
 	self assert: (ReflectivityExamples >> #exampleIvarRead) linkCount equals: 1.
 	link uninstall.
 	self assert: (ReflectivityExamples >> #exampleIvarRead) class equals: CompiledMethod.
-	self assert: (ivar links isEmpty).
+	self assertEmpty: ivar links
 ]
 
 { #category : #'tests - links' }

--- a/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
@@ -41,33 +41,33 @@ BreakpointTest >> tearDown [
 { #category : #tests }
 BreakpointTest >> testModifyMethodWithBreakpoint [
 	cls compile: 'dummy ^42'.
-	self assert: Breakpoint all isEmpty.
+	self assertEmpty: Breakpoint all.
 	Breakpoint new
 		node: (cls >> #dummy) ast;
 		once;
 		install.
 	self assert: (cls >> #dummy) hasBreakpoint.
 	cls compile: 'dummy ^43'.
-	self assert: Breakpoint all isEmpty
+	self assertEmpty: Breakpoint all
 ]
 
 { #category : #tests }
 BreakpointTest >> testRemoveClassWithBreakpoint [
 	cls compile: 'dummy ^42'.
-	self assert: Breakpoint all isEmpty.
+	self assertEmpty: Breakpoint all.
 	Breakpoint new
 		node: (cls >> #dummy) ast;
 		once;
 		install.
 	self assert: (cls >> #dummy) hasBreakpoint.
 	cls removeFromSystem.
-	self assert: Breakpoint all isEmpty
+	self assertEmpty: Breakpoint all
 ]
 
 { #category : #tests }
 BreakpointTest >> testRemoveMethodWithBreakpoint [
 	cls compile: 'dummy ^42'.
-	self assert: Breakpoint all isEmpty.
+	self assertEmpty: Breakpoint all.
 	Breakpoint new
 		node: (cls >> #dummy) ast;
 		once;
@@ -75,6 +75,6 @@ BreakpointTest >> testRemoveMethodWithBreakpoint [
 	self assert: (cls >> #dummy) hasBreakpoint.
 	cls removeSelector: #dummy.
 	self
-		assert: cls methods isEmpty;
-		assert: Breakpoint all isEmpty
+		assertEmpty: cls methods;
+		assertEmpty: Breakpoint all
 ]

--- a/src/Reflectivity-Tools-Tests/WatchpointTests.class.st
+++ b/src/Reflectivity-Tools-Tests/WatchpointTests.class.st
@@ -54,65 +54,59 @@ WatchpointTests >> testAddWatchpointsSameNode [
 
 { #category : #'deleting history' }
 WatchpointTests >> testDeleteAllHistory [
-	|node1 node2 watchpoint1 watchpoint2|
-	
-	node1 := (WPDummy>>#exampleAssignment:) ast body children first.
+	| node1 node2 watchpoint1 watchpoint2 |
+	node1 := (WPDummy >> #exampleAssignment:) ast body children first.
 	watchpoint1 := Watchpoint in: node1.
-	node2 := (WPDummy>>#exampleAssignment) ast body children first.
+	node2 := (WPDummy >> #exampleAssignment) ast body children first.
 	watchpoint2 := Watchpoint in: node2.
-	
+
 	WPDummy new exampleAssignment: 2.
 	WPDummy new exampleAssignment.
-		
-	self assert: (watchpoint1 values first value = 2).
-	self assert: (watchpoint2 values first value = 1).
-	
+
+	self assert: watchpoint1 values first value = 2.
+	self assert: watchpoint2 values first value = 1.
+
 	Watchpoint deleteAllHistory.
-	
-	self assert: watchpoint1 values isEmpty.
-	self assert: watchpoint2 values isEmpty.
-	
+
+	self assertEmpty: watchpoint1 values.
+	self assertEmpty: watchpoint2 values.
+
 	watchpoint1 uninstall.
-	watchpoint2 uninstall.
-	
+	watchpoint2 uninstall
 ]
 
 { #category : #'deleting history' }
 WatchpointTests >> testDeleteHistory [
-	|node watchpoint|
-	
-	node := (WPDummy>>#exampleAssignment:) ast body children first.
+	| node watchpoint |
+	node := (WPDummy >> #exampleAssignment:) ast body children first.
 	watchpoint := Watchpoint in: node.
 	WPDummy new exampleAssignment: 1.
 	WPDummy new exampleAssignment: 2.
-	
-	self assert: (watchpoint values first value = 1).
-	self assert: (watchpoint values second value = 2).
-	
+
+	self assert: watchpoint values first value = 1.
+	self assert: watchpoint values second value = 2.
+
 	watchpoint deleteHistory.
-	self assert: watchpoint values isEmpty.
-	
-	watchpoint uninstall.
-	
+	self assertEmpty: watchpoint values.
+
+	watchpoint uninstall
 ]
 
 { #category : #'deleting history' }
 WatchpointTests >> testDeleteHistoryFromNode [
-	|node watchpoint|
-	
-	node := (WPDummy>>#exampleAssignment:) ast body children first.
+	| node watchpoint |
+	node := (WPDummy >> #exampleAssignment:) ast body children first.
 	watchpoint := Watchpoint in: node.
 	WPDummy new exampleAssignment: 1.
 	WPDummy new exampleAssignment: 2.
-	
-	self assert: (watchpoint values first value = 1).
-	self assert: (watchpoint values second value = 2).
-	
+
+	self assert: watchpoint values first value = 1.
+	self assert: watchpoint values second value = 2.
+
 	Watchpoint deleteHistoryFrom: node.
-	self assert: watchpoint values isEmpty.
-	
-	watchpoint uninstall.
-	
+	self assertEmpty: watchpoint values.
+
+	watchpoint uninstall
 ]
 
 { #category : #values }

--- a/src/Regex-Tests-Core/RxMatcherTest.class.st
+++ b/src/Regex-Tests-Core/RxMatcherTest.class.st
@@ -1082,10 +1082,8 @@ RxMatcherTest >> testMatchesInDo [
 	| matcher expected |
 	matcher := self matcherClass forString: '\w+'.
 	expected := #('now' 'is' 'the' 'time') asOrderedCollection.
-	matcher 
-		matchesIn: 'now is the time'
-		do: [ :each | self assert: each = expected removeFirst ].
-	self assert: expected isEmpty
+	matcher matchesIn: 'now is the time' do: [ :each | self assert: each = expected removeFirst ].
+	self assertEmpty: expected
 ]
 
 { #category : #'testing-protocol' }
@@ -1111,10 +1109,8 @@ RxMatcherTest >> testMatchesOnStreamDo [
 	| matcher expected |
 	matcher := self matcherClass forString: '\w+'.
 	expected := #('now' 'is' 'the' 'time') asOrderedCollection.
-	matcher 
-		matchesOnStream: 'now is the time' readStream
-		do: [ :each | self assert: each = expected removeFirst ].
-	self assert: expected isEmpty
+	matcher matchesOnStream: 'now is the time' readStream do: [ :each | self assert: each = expected removeFirst ].
+	self assertEmpty: expected
 ]
 
 { #category : #'testing-protocol' }
@@ -1130,10 +1126,11 @@ RxMatcherTest >> testMatchingRangesIn [
 	| matcher expected |
 	matcher := self matcherClass forString: '\w+'.
 	expected := #(1 3 5 6 8 10 12 15) asOrderedCollection.
-	(matcher matchingRangesIn: 'now is the time') do: [ :range |
-		self assert: range first = expected removeFirst.
-		self assert: range last = expected removeFirst ].
-	self assert: expected isEmpty
+	(matcher matchingRangesIn: 'now is the time')
+		do: [ :range | 
+			self assert: range first = expected removeFirst.
+			self assert: range last = expected removeFirst ].
+	self assertEmpty: expected
 ]
 
 { #category : #testing }

--- a/src/ReleaseTests/ObsoleteTest.class.st
+++ b/src/ReleaseTests/ObsoleteTest.class.st
@@ -40,31 +40,31 @@ ObsoleteTest >> testClassObsolete [
 { #category : #tests }
 ObsoleteTest >> testFixObsoleteSharedPools [
 	| poolClass obsoletePoolName testClass preFixObsoleteClassNames postFixObsoleteClassNames |
-	poolClass := classFactory newClass. "provides unique name over time via class variable counter"
-	testClass := classFactory  
-		newSubclassOf: classFactory defaultSuperclass 
-		uses: { }
+	poolClass := classFactory newClass.	"provides unique name over time via class variable counter"
+	testClass := classFactory
+		newSubclassOf: classFactory defaultSuperclass
+		uses: {}
 		instanceVariableNames: ''
 		classVariableNames: ''
 		poolDictionaries: poolClass name asString
-		category: classFactory defaultCategory.		
+		category: classFactory defaultCategory.
 	classFactory deleteClass: poolClass.
-	obsoletePoolName := poolClass name. 
+	obsoletePoolName := poolClass name.
 	poolClass := nil.
 	3 timesRepeat: [ Smalltalk garbageCollect ].
-	
+
 	preFixObsoleteClassNames := SystemNavigation default obsoleteClasses collect: #name.
 	self assert: (preFixObsoleteClassNames includes: obsoletePoolName).
 	self assert: testClass sharedPoolNames size equals: 1.
-	self assert: (testClass sharedPoolNames includes: obsoletePoolName ).
+	self assert: (testClass sharedPoolNames includes: obsoletePoolName).
 	self assert: (testClass sharedPoolsString beginsWith: 'AnObsolete').
-	
+
 	Smalltalk fixObsoleteSharedPools.
-	
+
 	postFixObsoleteClassNames := SystemNavigation default obsoleteClasses collect: #name.
 	self deny: (postFixObsoleteClassNames includes: obsoletePoolName).
-	self assert: testClass sharedPoolNames isEmpty.
-	self assert: testClass sharedPoolsString isEmpty
+	self assertEmpty: testClass sharedPoolNames.
+	self assertEmpty: testClass sharedPoolsString
 ]
 
 { #category : #tests }

--- a/src/ReleaseTests/ProperMethodCategorizationTest.class.st
+++ b/src/ReleaseTests/ProperMethodCategorizationTest.class.st
@@ -79,16 +79,15 @@ ProperMethodCategorizationTest >> testHashMethodNeedsToBeInComparingProtocol [
 { #category : #tests }
 ProperMethodCategorizationTest >> testNoEmptyProtocols [
 	"Check that we have no protocols left without methods"
-	
+
 	| violating protocolsWithoutMethods |
 	violating := Dictionary new.
 	ProtoObject withAllSubclasses
 		do: [ :cls | 
 			protocolsWithoutMethods := cls organization protocolOrganizer protocols select: [ :e | e isEmpty and: [ e canBeRemoved ] ].
-			protocolsWithoutMethods notEmpty
-				ifTrue: [ violating at: cls put: protocolsWithoutMethods ] ].
-			
-	self assert: violating isEmpty
+			protocolsWithoutMethods notEmpty ifTrue: [ violating at: cls put: protocolsWithoutMethods ] ].
+
+	self assertEmpty: violating
 ]
 
 { #category : #'tests - object' }

--- a/src/ReleaseTests/ProperlyImplementedSUnitClassesTest.class.st
+++ b/src/ReleaseTests/ProperlyImplementedSUnitClassesTest.class.st
@@ -11,27 +11,23 @@ Class {
 ProperlyImplementedSUnitClassesTest >> testAndMakeSureSuperSetupIsCalledAsFirstMessageInSetupMethodsOfTestCases [
 	"Verify that each setUp method in a unit test starts with a call to super setUp as first message sent"
 
-	|violating|	
+	| violating |
 	violating := OrderedCollection new.
-	TestCase allSubclassesDo: [:each |	
- 		each compiledMethodAt: #setUp ifPresent: [:method |
-				(ShouldSendSuperSetUpAsFirstMessage superSetUpNotCalledFirstIn: method) 
-					ifTrue: [ violating add: method ]
-			] ifAbsent: nil ].
-	
-	self assert: violating isEmpty	
+	TestCase
+		allSubclassesDo:
+			[ :each | each compiledMethodAt: #setUp ifPresent: [ :method | (ShouldSendSuperSetUpAsFirstMessage superSetUpNotCalledFirstIn: method) ifTrue: [ violating add: method ] ] ifAbsent: nil ].
+
+	self assertEmpty: violating
 ]
 
 { #category : #tests }
 ProperlyImplementedSUnitClassesTest >> testAndMakeSureSuperTearDownIsCalledAsLastMessageInTearDownMethodsOfTestCases [
 	"Verify that each tearDown method in a unit test ends with a call to super tearDown as last message sent"
-	
-	|violating|	
+
+	| violating |
 	violating := OrderedCollection new.
-	TestCase allSubclassesDo: [:each |	
- 		each compiledMethodAt: #tearDown ifPresent: [:method |
-				(ShouldSendSuperTearDownAsLastMessage superTearDownNotCalledLastIn: method) 
-					ifTrue: [ violating add: method ]
-			] ifAbsent: nil ].
-	self assert: violating isEmpty 
+	TestCase
+		allSubclassesDo:
+			[ :each | each compiledMethodAt: #tearDown ifPresent: [ :method | (ShouldSendSuperTearDownAsLastMessage superTearDownNotCalledLastIn: method) ifTrue: [ violating add: method ] ] ifAbsent: nil ].
+	self assertEmpty: violating
 ]

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -56,17 +56,15 @@ ReleaseTest >> knownProcesses [
 ReleaseTest >> testAllClassPoolBindingAreClassVariables [
 	| wrong |
 	wrong := OrderedCollection new.
-	Smalltalk globals allClasses do: [:class | 
-		 wrong addAll: (class classVariables reject: [ :each | each isKindOf:  ClassVariable]).
-		].
-	self assert: wrong isEmpty.
+	Smalltalk globals allClasses do: [ :class | wrong addAll: (class classVariables reject: [ :each | each isKindOf: ClassVariable ]) ].
+	self assertEmpty: wrong
 ]
 
 { #category : #testing }
 ReleaseTest >> testAllGlobalBindingAreGlobalVariables [
 	| wrong |
-	wrong := Smalltalk globals associations reject: [ :each | each isKindOf:  GlobalVariable].
-	self assert: wrong isEmpty.
+	wrong := Smalltalk globals associations reject: [ :each | each isKindOf: GlobalVariable ].
+	self assertEmpty: wrong
 ]
 
 { #category : #testing }
@@ -143,7 +141,7 @@ ReleaseTest >> testNoEmptyPackages [
 
 	| violating |
 	violating := RPackageOrganizer default packages select: #isEmpty.
-	self assert: violating isEmpty	
+	self assertEmpty: violating
 ]
 
 { #category : #testing }
@@ -205,13 +203,13 @@ ReleaseTest >> testShouldWorldMorphBeAfterFontClassesInStartupList [
 
 { #category : #'testing - rpackage' }
 ReleaseTest >> testThatAllMethodsArePackaged [
-    | classes instanceMethods classMethods allMethods methodsWithoutPackageInfo|
-    classes := Smalltalk allClassesAndTraits.
-    instanceMethods := classes flatCollect: #methods.
-    classMethods := classes flatCollect: [ :class | class classSide methods ].
-    allMethods := instanceMethods , classMethods.
-    methodsWithoutPackageInfo := allMethods select: [ :method | method package isNil ].
-    self assert: methodsWithoutPackageInfo isEmpty.
+	| classes instanceMethods classMethods allMethods methodsWithoutPackageInfo |
+	classes := Smalltalk allClassesAndTraits.
+	instanceMethods := classes flatCollect: #methods.
+	classMethods := classes flatCollect: [ :class | class classSide methods ].
+	allMethods := instanceMethods , classMethods.
+	methodsWithoutPackageInfo := allMethods select: [ :method | method package isNil ].
+	self assertEmpty: methodsWithoutPackageInfo
 ]
 
 { #category : #testing }
@@ -263,9 +261,9 @@ ReleaseTest >> testUnpackagedClasses [
 { #category : #'testing - rpackage' }
 ReleaseTest >> testUnpackagedPackageShouldBeEmpty [
 	| unpackagePackage |
-	unpackagePackage := RPackageOrganizer default packageNamed: (RPackage defaultPackageName ).
+	unpackagePackage := RPackageOrganizer default packageNamed: RPackage defaultPackageName.
 	"The unpackage package should not have any defined class or extended classes"
-	self assert: unpackagePackage classes isEmpty.
+	self assertEmpty: unpackagePackage classes
 ]
 
 { #category : #testing }

--- a/src/Renraku-Test/ReBasicScenarioExceptionStrategyTest.class.st
+++ b/src/Renraku-Test/ReBasicScenarioExceptionStrategyTest.class.st
@@ -7,15 +7,11 @@ Class {
 { #category : #tests }
 ReBasicScenarioExceptionStrategyTest >> testIgnore [
 	| critiques |
-
 	ReExceptionStrategy current: ReIgnoreExceptionStrategy.
-	
-	self
-		shouldnt: [
-			critiques := self validationScenario  ]
-		raise: MyTestError.
-		
-	self assert: critiques isEmpty
+
+	self shouldnt: [ critiques := self validationScenario ] raise: MyTestError.
+
+	self assertEmpty: critiques
 ]
 
 { #category : #tests }

--- a/src/Ring-Deprecated-Tests-Containers/RGNamespaceTest.class.st
+++ b/src/Ring-Deprecated-Tests-Containers/RGNamespaceTest.class.st
@@ -15,22 +15,22 @@ RGNamespaceTest class >> isDeprecated [
 { #category : #testing }
 RGNamespaceTest >> testCreatingNamespace [
 	| newNamespace newPackage newClass |
-	
-	newNamespace := RGNamespace named: #'RingNamespace'.
-	newPackage := RGPackage named:  #'Collections-Sequenceable'.
-	newClass:= RGClassDefinition named: #OrderedCollection.
+	newNamespace := RGNamespace named: #RingNamespace.
+	newPackage := RGPackage named: #'Collections-Sequenceable'.
+	newClass := RGClassDefinition named: #OrderedCollection.
 	newPackage addClass: newClass.
-	newNamespace addPackage: newPackage;
+	newNamespace
+		addPackage: newPackage;
 		addClass: newClass.
-	
-	self assert: (newNamespace isNamespace).
-	self assert: ((newNamespace packageNamed: #'Collections-Sequenceable') == newPackage).
-	self assert: ((newNamespace classNamed: #OrderedCollection) == newClass).
-	self assert: (newNamespace methods isEmpty).
-	self assert: (newNamespace pools isEmpty).
-	self assert: (newNamespace globalVariables isEmpty).
-	
+
+	self assert: newNamespace isNamespace.
+	self assert: (newNamespace packageNamed: #'Collections-Sequenceable') == newPackage.
+	self assert: (newNamespace classNamed: #OrderedCollection) == newClass.
+	self assertEmpty: newNamespace methods.
+	self assertEmpty: newNamespace pools.
+	self assertEmpty: newNamespace globalVariables.
+
 	newNamespace removeClass: newClass.
-	self assert: ((newNamespace classNamed: #OrderedCollection) isNil).
-	self assert: ((newPackage classNamed: #OrderedCollection) notNil).
+	self assert: (newNamespace classNamed: #OrderedCollection) isNil.
+	self assert: (newPackage classNamed: #OrderedCollection) notNil
 ]

--- a/src/Ring-Deprecated-Tests-Containers/RGPackageTest.class.st
+++ b/src/Ring-Deprecated-Tests-Containers/RGPackageTest.class.st
@@ -43,14 +43,13 @@ RGPackageTest >> testAddingPackage [
 { #category : #testing }
 RGPackageTest >> testNewPackage [
 	| newPackage |
-	
-	newPackage:= RGPackage named: 'Collections-Sequenceable'.
-	
-	self assert: (newPackage isPackage).
-	self assert: (newPackage name = 'Collections-Sequenceable').
-	self assert: (newPackage classes isEmpty).
-	self assert: (newPackage traits isEmpty).
-	self assert: (newPackage packages isEmpty).
-	self assert: (newPackage package isNil).
-	self assert: (newPackage parent == Smalltalk globals).
+	newPackage := RGPackage named: 'Collections-Sequenceable'.
+
+	self assert: newPackage isPackage.
+	self assert: newPackage name = 'Collections-Sequenceable'.
+	self assertEmpty: newPackage classes.
+	self assertEmpty: newPackage traits.
+	self assertEmpty: newPackage packages.
+	self assert: newPackage package isNil.
+	self assert: newPackage parent == Smalltalk globals
 ]

--- a/src/Ring-Deprecated-Tests-Containers/RGSliceTest.class.st
+++ b/src/Ring-Deprecated-Tests-Containers/RGSliceTest.class.st
@@ -61,10 +61,9 @@ RGSliceTest >> testNestingContainers [
 { #category : #testing }
 RGSliceTest >> testNewSlice [
 	| newSlice |
-	
-	newSlice:= RGSlice named: 'Foo'.
-	
-	self assert: (newSlice isSlice).
-	self assert: (newSlice classes isEmpty).
-	self assert: (newSlice environment == Smalltalk globals)
+	newSlice := RGSlice named: 'Foo'.
+
+	self assert: newSlice isSlice.
+	self assertEmpty: newSlice classes.
+	self assert: newSlice environment == Smalltalk globals
 ]

--- a/src/Ring-Deprecated-Tests-Kernel/RGClassDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGClassDefinitionTest.class.st
@@ -138,25 +138,22 @@ RGClassDefinitionTest >> testExistingClass [
 { #category : #testing }
 RGClassDefinitionTest >> testNonExistingClass [
 	| newClass |
-	
-	newClass:= RGClassDefinition named:  #Connection.
-	self assert: (newClass isClass).
-	self assert: (newClass instanceVariables isEmpty).
-	self assert: (newClass classVariables isEmpty).
-	self assert: (newClass sharedPools isEmpty).
-	self assert: (newClass hasMetaclass not).
-	self assert: (newClass hasComment not).
-	self assert: (newClass hasStamp not).
-	self assert: (newClass parent = Smalltalk globals).
-	self assert: (newClass package isNil).
-	self assert: (newClass category isNil).
-	self assert: (newClass hasMethods not).
-	self assert: (newClass hasSuperclass not).
-	self assert: (newClass hasTraitComposition not).
-	self assert: (newClass isDefined not).
-	self assert: (newClass hasProtocols not).
-	
-	
+	newClass := RGClassDefinition named: #Connection.
+	self assert: newClass isClass.
+	self assertEmpty: newClass instanceVariables.
+	self assertEmpty: newClass classVariables.
+	self assertEmpty: newClass sharedPools.
+	self assert: newClass hasMetaclass not.
+	self assert: newClass hasComment not.
+	self assert: newClass hasStamp not.
+	self assert: newClass parent = Smalltalk globals.
+	self assert: newClass package isNil.
+	self assert: newClass category isNil.
+	self assert: newClass hasMethods not.
+	self assert: newClass hasSuperclass not.
+	self assert: newClass hasTraitComposition not.
+	self assert: newClass isDefined not.
+	self assert: newClass hasProtocols not
 ]
 
 { #category : #testing }
@@ -233,28 +230,26 @@ RGClassDefinitionTest >> testWithCategory [
 { #category : #testing }
 RGClassDefinitionTest >> testWithClassInstanceVariables [
 	| newClass metaClass classInstVar |
-	
-	newClass:= RGClassDefinition named:  #HashTableSizes.
+	newClass := RGClassDefinition named: #HashTableSizes.
 	newClass withMetaclass.
-	metaClass:= newClass classSide.
+	metaClass := newClass classSide.
 	metaClass addInstanceVariables: #(sizes).
-	
-	self assert: (metaClass instanceVariables size = 1).
-	self assert: (metaClass instVarNames size = 1).
-	self assert: (metaClass allInstVarNames size = 1).
-	
-	classInstVar:= metaClass instanceVariableNamed: #sizes.
-	self assert: (classInstVar notNil).
-	self assert: (classInstVar parent = metaClass).
-	self assert: (classInstVar isClassInstanceVariable).
-	self assert: (classInstVar isVariable).
-	self assert: (classInstVar parentName = metaClass name).
-	self assert: (classInstVar realClass = HashTableSizes class).
-	
+
+	self assert: metaClass instanceVariables size equals: 1.
+	self assert: metaClass instVarNames size equals: 1.
+	self assert: metaClass allInstVarNames size equals: 1.
+
+	classInstVar := metaClass instanceVariableNamed: #sizes.
+	self assert: classInstVar notNil.
+	self assert: classInstVar parent = metaClass.
+	self assert: classInstVar isClassInstanceVariable.
+	self assert: classInstVar isVariable.
+	self assert: classInstVar parentName = metaClass name.
+	self assert: classInstVar realClass = HashTableSizes class.
+
 	metaClass removeInstVarNamed: #sizes.
-	self assert: (metaClass instanceVariables isEmpty).
-	self assert: ((metaClass instanceVariableNamed: #sizes) isNil).
-	
+	self assertEmpty: metaClass instanceVariables.
+	self assert: (metaClass instanceVariableNamed: #sizes) isNil
 ]
 
 { #category : #testing }
@@ -353,50 +348,49 @@ RGClassDefinitionTest >> testWithInstanceVariables [
 { #category : #testing }
 RGClassDefinitionTest >> testWithPoolDictionaries [
 	| newClass poolVar |
-	
-	newClass:= (RGClassDefinition named:  #Text)
-						addSharedPoolNamed: #TextConstants;
-						yourself.
+	newClass := (RGClassDefinition named: #Text)
+		addSharedPoolNamed: #TextConstants;
+		yourself.
 
-	self assert: (newClass sharedPools size = 1).
-	self assert: (newClass sharedPoolNames size = 1).
-	self assert: (newClass allSharedPools size = 1).  "no hierarchy"
-	self assert: (newClass allSharedPoolNames size = 1).
-	
-	poolVar:= newClass sharedPoolNamed: #TextConstants.
-	self assert: (poolVar notNil).
-	self assert: (poolVar isPoolVariable).
-	self assert: (poolVar isVariable).
-	self assert: (poolVar parent = newClass).
-	self assert: (poolVar parentName == newClass name).
-	self assert: (poolVar realClass = Text).
-	
+	self assert: newClass sharedPools size = 1.
+	self assert: newClass sharedPoolNames size = 1.
+	self assert: newClass allSharedPools size = 1.	"no hierarchy"
+	self assert: newClass allSharedPoolNames size = 1.
+
+	poolVar := newClass sharedPoolNamed: #TextConstants.
+	self assert: poolVar notNil.
+	self assert: poolVar isPoolVariable.
+	self assert: poolVar isVariable.
+	self assert: poolVar parent = newClass.
+	self assert: poolVar parentName == newClass name.
+	self assert: poolVar realClass = Text.
+
 	newClass withMetaclass.
-	self assert: (newClass classSide allSharedPoolNames size = 1).
-	
+	self assert: newClass classSide allSharedPoolNames size = 1.
+
 	newClass removeSharedPoolNamed: #TextConstants.
-	self assert: (newClass sharedPools isEmpty).
+	self assertEmpty: newClass sharedPools
 ]
 
 { #category : #testing }
 RGClassDefinitionTest >> testWithProtocols [
 	| newMethod newClass |
-	
-	newClass:= RGClassDefinition named: #OrderedCollection.
-	newMethod:= (RGMethodDefinition named: #add:)
-					 parent: newClass;
-					protocol: 'adding'; 
-					sourceCode: 'add: newObject
+	newClass := RGClassDefinition named: #OrderedCollection.
+	newMethod := (RGMethodDefinition named: #add:)
+		parent: newClass;
+		protocol: 'adding';
+		sourceCode:
+			'add: newObject
 									^self addLast: newObject'.
-	
+
 	newClass addMethod: newMethod.
 	newClass addProtocol: 'accessing'.
-	
-	self assert: (newClass hasProtocols).
-	self assert: (newClass protocols size = 2).
+
+	self assert: newClass hasProtocols.
+	self assert: newClass protocols size = 2.
 	self assert: (newClass includesProtocol: 'accessing').
-	self assert: ((newClass methodsInProtocol: 'adding') size = 1).
-	self assert: ((newClass methodsInProtocol: 'accessing') isEmpty)
+	self assert: (newClass methodsInProtocol: 'adding') size = 1.
+	self assertEmpty: (newClass methodsInProtocol: 'accessing')
 ]
 
 { #category : #testing }

--- a/src/Ring-Deprecated-Tests-Kernel/RGGlobalDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGGlobalDefinitionTest.class.st
@@ -38,7 +38,7 @@ RGGlobalDefinitionTest >> testPoolDefinition [
 	| pool newClass |
 	pool := RGClassDefinition createSharedPoolNamed: #TextConstants.
 	self assert: pool isPool.
-	self assert: pool users isEmpty.
+	self assertEmpty: pool users.
 	self assert: pool parent equals: Smalltalk globals.
 	newClass := RGClassDefinition named: #OrderedCollection.
 	pool addUser: newClass.
@@ -48,5 +48,5 @@ RGGlobalDefinitionTest >> testPoolDefinition [
 	pool := RGClassDefinition named: #TextConstants.
 	pool superclassName: #SharedPool.
 	self assert: pool isPool.
-	self assert: pool users isEmpty
+	self assertEmpty: pool users
 ]

--- a/src/Ring-Deprecated-Tests-Kernel/RGTraitDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGTraitDefinitionTest.class.st
@@ -65,20 +65,27 @@ RGTraitDefinitionTest >> testAsTraitDefinition [
 
 { #category : #testing }
 RGTraitDefinitionTest >> testAsTraitDefinition2 [
-
 	| newTrait newClass newSlice |
-	newClass := MOPTestClassC asRingDefinitionWithMethods: false withSuperclasses: false withSubclasses: true withPackages: false.
+	newClass := MOPTestClassC
+		asRingDefinitionWithMethods: false
+		withSuperclasses: false
+		withSubclasses: true
+		withPackages: false.
 	newSlice := newClass environment.
-	self assert: (newClass allSubclasses size = 0).
+	self assert: newClass allSubclasses size = 0.
 	self assert: newClass traitNames size = 1.
 	self assert: newClass traits first = (newSlice traitNamed: #Trait2).
-	
-	newTrait := MOPTestClassA asRingDefinitionWithMethods: true withSuperclasses: true withSubclasses: false withPackages: true.
+
+	newTrait := MOPTestClassA
+		asRingDefinitionWithMethods: true
+		withSuperclasses: true
+		withSubclasses: false
+		withPackages: true.
 	newSlice := newTrait environment.
 	self assert: newTrait superclass = (newSlice classNamed: #Object).
 	self assert: newTrait methods size < newSlice methods size.
 	self assert: newTrait category = #'Tests-Traits-MOP'.
-	self assert: newTrait subclasses isEmpty.
+	self assertEmpty: newTrait subclasses
 ]
 
 { #category : #testing }

--- a/src/Ring-Deprecated-Tests-Kernel/RGVariableDefinitionTest.class.st
+++ b/src/Ring-Deprecated-Tests-Kernel/RGVariableDefinitionTest.class.st
@@ -35,23 +35,22 @@ RGVariableDefinitionTest >> testClassInstanceVariable [
 { #category : #testing }
 RGVariableDefinitionTest >> testClassVariable [
 	| instVar newClass |
-	
-	instVar:= RGClassVariableDefinition named: 'DependentsFields'.
-	
-	self assert: (instVar isClassVariable).
-	self assert: (instVar isVariable).
-	self assert: (instVar name = 'DependentsFields').
-	self assert: (instVar parent isNil).
-	self assert: (instVar isMetaSide not).   
-	
-	newClass:= RGClassDefinition named: #Object.
-	instVar:= (RGClassVariableDefinition named: 'DependentsFields') parent: newClass.
-	
-	self assert: (instVar parent = newClass).
-	self assert: (newClass classVariables isEmpty).
-	
+	instVar := RGClassVariableDefinition named: 'DependentsFields'.
+
+	self assert: instVar isClassVariable.
+	self assert: instVar isVariable.
+	self assert: instVar name = 'DependentsFields'.
+	self assert: instVar parent isNil.
+	self assert: instVar isMetaSide not.
+
+	newClass := RGClassDefinition named: #Object.
+	instVar := (RGClassVariableDefinition named: 'DependentsFields') parent: newClass.
+
+	self assert: instVar parent = newClass.
+	self assertEmpty: newClass classVariables.
+
 	newClass classVariables add: instVar.
-	self assert: (newClass classVariables size = 1).
+	self assert: newClass classVariables size = 1
 ]
 
 { #category : #testing }
@@ -75,22 +74,21 @@ RGVariableDefinitionTest >> testInstanceVariable [
 { #category : #testing }
 RGVariableDefinitionTest >> testPoolVariable [
 	| poolVar newClass |
-	
-	poolVar:= RGPoolVariableDefinition named: 'TextConstants'.
-	
-	self assert: (poolVar isPoolVariable).
-	self assert: (poolVar isVariable).
-	self assert: (poolVar name = 'TextConstants').
-	self assert: (poolVar parent isNil).
-	self assert: (poolVar isMetaSide not).
-	
-	newClass:= RGClassDefinition named: #OrderedCollection.
-	poolVar:= (RGPoolVariableDefinition named:  'TextConstants' ) parent: newClass.
-	self assert: (poolVar parent = newClass).
-	self assert: (newClass sharedPools isEmpty).
-	
+	poolVar := RGPoolVariableDefinition named: 'TextConstants'.
+
+	self assert: poolVar isPoolVariable.
+	self assert: poolVar isVariable.
+	self assert: poolVar name = 'TextConstants'.
+	self assert: poolVar parent isNil.
+	self assert: poolVar isMetaSide not.
+
+	newClass := RGClassDefinition named: #OrderedCollection.
+	poolVar := (RGPoolVariableDefinition named: 'TextConstants') parent: newClass.
+	self assert: poolVar parent = newClass.
+	self assertEmpty: newClass sharedPools.
+
 	newClass sharedPools add: poolVar.
-	self assert: (newClass sharedPools size = 1).
+	self assert: newClass sharedPools size = 1
 ]
 
 { #category : #testing }

--- a/src/Ring-Deprecated-Tests-Monticello/RGClassDefinitionTest.extension.st
+++ b/src/Ring-Deprecated-Tests-Monticello/RGClassDefinitionTest.extension.st
@@ -42,30 +42,29 @@ RGClassDefinitionTest >> testAsClassDefinition3 [
 
 { #category : #'*Ring-Deprecated-Tests-Monticello' }
 RGClassDefinitionTest >> testAsFullClassDefinition [
-	
 	| rgClass |
 	rgClass := Class asRingDefinition.
-	self assert: rgClass methods isEmpty.
+	self assertEmpty: rgClass methods.
 	self assert: rgClass superclass isNil.
-	self assert: rgClass subclasses isEmpty.
+	self assertEmpty: rgClass subclasses.
 	self assert: rgClass package name equals: #Kernel.
 
 	rgClass := Class asFullRingDefinition.
-	self assert: rgClass methods notEmpty.
+	self denyEmpty: rgClass methods.
 	self assert: (rgClass methodNamed: #asRingDefinition) package name = #'Ring-Deprecated-Core-Kernel'.
 	self assert: rgClass superclass notNil.
 	self assert: rgClass superclass name = #ClassDescription.
-	self assert: rgClass subclasses notEmpty.
+	self denyEmpty: rgClass subclasses.
 	self assert: rgClass package notNil.
 	self assert: rgClass package = rgClass instanceSide package.
 	self assert: rgClass package name = #Kernel.
 	self assert: rgClass category = #'Kernel-Classes'.
-	self assert: rgClass extensionMethods notEmpty.
-	
+	self denyEmpty: rgClass extensionMethods.
+
 	self assert: rgClass superclass superclass isNil.
 	self assert: rgClass superclass package name equals: #Kernel.
 	self assert: rgClass subclasses first package name equals: #Kernel.
-	
+
 	rgClass := RGClassDefinition classSide asFullRingDefinition.
-	self assert: rgClass package = rgClass instanceSide package.
+	self assert: rgClass package = rgClass instanceSide package
 ]

--- a/src/Ring-Deprecated-Tests-Monticello/RGTraitDefinitionTest.extension.st
+++ b/src/Ring-Deprecated-Tests-Monticello/RGTraitDefinitionTest.extension.st
@@ -2,12 +2,11 @@ Extension { #name : #RGTraitDefinitionTest }
 
 { #category : #'*Ring-Deprecated-Tests-Monticello' }
 RGTraitDefinitionTest >> testAsFullTraitDefinition [
-	
 	| rgClass |
 	rgClass := TSortable asRingDefinition.
-	self assert: rgClass methods isEmpty.
+	self assertEmpty: rgClass methods.
 	self assert: rgClass superclass isNil.
-	self assert: rgClass subclasses isEmpty.
+	self assertEmpty: rgClass subclasses.
 	self assert: rgClass package isNil.
 
 	rgClass := TSortable asFullRingDefinition.
@@ -15,15 +14,15 @@ RGTraitDefinitionTest >> testAsFullTraitDefinition [
 	self assert: (rgClass methodNamed: #isSorted) package notNil.
 	self assert: rgClass superclass notNil.
 	self assert: rgClass superclass name = #Trait.
-	self assert: rgClass subclasses isEmpty.
+	self assertEmpty: rgClass subclasses.
 	self assert: rgClass package notNil.
 	self assert: rgClass package = rgClass instanceSide package.
 	self assert: rgClass package name = #'Collections-Abstract-Traits'.
 	self assert: rgClass category = #'Collections-Abstract-Traits'.
-	
+
 	self assert: rgClass superclass superclass isNil.
 	self assert: rgClass superclass package name equals: #TraitsV2.
-	
+
 	rgClass := TBehavior classSide asFullRingDefinition.
-	self assert: rgClass package = rgClass classSide package.
+	self assert: rgClass package = rgClass classSide package
 ]

--- a/src/SUnit-Core-Traits/TAssertable.trait.st
+++ b/src/SUnit-Core-Traits/TAssertable.trait.st
@@ -79,6 +79,11 @@ TAssertable >> assertCollection: actual hasSameElements: expected [
 ]
 
 { #category : #asserting }
+TAssertable >> assertEmpty: aCollection [
+	^ self assert: aCollection isEmpty description: aCollection asString , ' should have been empty'
+]
+
+{ #category : #asserting }
 TAssertable >> classForTestResult [
 	"Returns the class of the test result"
 	^ TestResult
@@ -187,6 +192,11 @@ TAssertable >> denyCollection: actual equals: expected [
 	^ self
 		deny: expected = actual
 		description: [ self unexpectedEqualityStringBetween: actual and: expected ]
+]
+
+{ #category : #asserting }
+TAssertable >> denyEmpty: aCollection [
+	^ self assert: aCollection isNotEmpty description: aCollection asString , ' should not have been empty'
 ]
 
 { #category : #asserting }

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -161,6 +161,11 @@ TestAsserter >> assertCollection: actual includesAll: subcollection [
 		description: [ actual asString , ' does not include all in ' , subcollection asString ]
 ]
 
+{ #category : #asserting }
+TestAsserter >> assertEmpty: aCollection [
+	^ self assert: aCollection isEmpty description: aCollection asString , ' should have been empty'
+]
+
 { #category : #factory }
 TestAsserter >> classForTestResource [
 	^ TestResource
@@ -308,6 +313,11 @@ TestAsserter >> denyCollection: actual equals: expected [
 	^ self
 		deny: expected = actual
 		description: [ self unexpectedEqualityStringBetween: actual and: expected ]
+]
+
+{ #category : #asserting }
+TestAsserter >> denyEmpty: aCollection [
+	^ self assert: aCollection isNotEmpty description: aCollection asString , ' should not have been empty'
 ]
 
 { #category : #asserting }

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -113,19 +113,15 @@ ClassFactoryForTestCaseTest >> testMultipleClassCreation [
 { #category : #testing }
 ClassFactoryForTestCaseTest >> testPackageCleanUp [
 	| createdClassNames allClasses |
-	3 timesRepeat: [
-		factory newClassInCategory: #One].
-	2 timesRepeat: [
-		factory newClassInCategory: #Two].
+	3 timesRepeat: [ factory newClassInCategory: #One ].
+	2 timesRepeat: [ factory newClassInCategory: #Two ].
 	createdClassNames := factory createdClassNames.
-	factory cleanUp.	
-	self assert: (factory createdClasses allSatisfy: [:class| class isObsolete]). 
+	factory cleanUp.
+	self assert: (factory createdClasses allSatisfy: [ :class | class isObsolete ]).
 	allClasses := SystemNavigation new allClasses.
-	self assert: (factory createdClasses noneSatisfy: [:class| allClasses includes: class]).
-	self assert: (SystemOrganization categoriesMatching: factory packageName, '*') isEmpty. 
-	self class environment at: #ChangeSet ifPresent: [:changeSet |
-		self deny: (changeSet current changedClassNames includesAnyOf: createdClassNames) ].
-
+	self assert: (factory createdClasses noneSatisfy: [ :class | allClasses includes: class ]).
+	self assertEmpty: (SystemOrganization categoriesMatching: factory packageName , '*').
+	self class environment at: #ChangeSet ifPresent: [ :changeSet | self deny: (changeSet current changedClassNames includesAnyOf: createdClassNames) ]
 ]
 
 { #category : #testing }
@@ -144,13 +140,13 @@ ClassFactoryForTestCaseTest >> testSingleClassCreation [
 
 { #category : #testing }
 ClassFactoryForTestCaseTest >> testSingleClassFastCreation [
-	|class elementsInCategoryForTest |
+	| class elementsInCategoryForTest |
 	class := factory newClass.
 	self assert: (SystemNavigation new allClasses includes: class).
-	elementsInCategoryForTest := SystemOrganization listAtCategoryNamed: factory defaultCategory. 
+	elementsInCategoryForTest := SystemOrganization listAtCategoryNamed: factory defaultCategory.
 	self assert: elementsInCategoryForTest = {class name}.
-	self assert: class instVarNames isEmpty.
-	self assert: class classPool isEmpty
+	self assertEmpty: class instVarNames.
+	self assertEmpty: class classPool
 ]
 
 { #category : #testing }

--- a/src/SUnit-Tests/ClassFactoryWithOrganizationTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryWithOrganizationTest.class.st
@@ -89,19 +89,15 @@ ClassFactoryWithOrganizationTest >> testMultipleClassCreation [
 { #category : #testing }
 ClassFactoryWithOrganizationTest >> testPackageCleanUp [
 	| createdClassNames allClasses |
-	3 timesRepeat: [
-		factory newClassInCategory: #One].
-	2 timesRepeat: [
-		factory newClassInCategory: #Two].
+	3 timesRepeat: [ factory newClassInCategory: #One ].
+	2 timesRepeat: [ factory newClassInCategory: #Two ].
 	createdClassNames := factory createdClassNames.
-	factory cleanUp.	
-	self assert: (factory createdClasses allSatisfy: [:class| class isObsolete]). 
+	factory cleanUp.
+	self assert: (factory createdClasses allSatisfy: [ :class | class isObsolete ]).
 	allClasses := self testedEnvironment allClasses.
-	self assert: (factory createdClasses noneSatisfy: [:class| allClasses includes: class]).
-	self assert: (self testedOrganization categoriesMatching: factory packageName, '*') isEmpty. 
-	self class environment at: #ChangeSet ifPresent: [:changeSet |
-		self deny: (changeSet current changedClassNames includesAnyOf: createdClassNames) ].
-
+	self assert: (factory createdClasses noneSatisfy: [ :class | allClasses includes: class ]).
+	self assertEmpty: (self testedOrganization categoriesMatching: factory packageName , '*').
+	self class environment at: #ChangeSet ifPresent: [ :changeSet | self deny: (changeSet current changedClassNames includesAnyOf: createdClassNames) ]
 ]
 
 { #category : #testing }
@@ -122,15 +118,14 @@ ClassFactoryWithOrganizationTest >> testSingleClassCreation [
 
 { #category : #testing }
 ClassFactoryWithOrganizationTest >> testSingleClassFastCreation [
-	|class elementsInCategoryForTest |
+	| class elementsInCategoryForTest |
 	class := factory newClass.
 	self assert: (self testedEnvironment allClasses includes: class).
-	elementsInCategoryForTest := self testedOrganization listAtCategoryNamed: factory defaultCategory. 
-	factory createdClasses do: [ :aClass |
-		self assertEnvironmentOf: aClass ].
+	elementsInCategoryForTest := self testedOrganization listAtCategoryNamed: factory defaultCategory.
+	factory createdClasses do: [ :aClass | self assertEnvironmentOf: aClass ].
 	self assert: elementsInCategoryForTest = {class name}.
-	self assert: class instVarNames isEmpty.
-	self assert: class classPool isEmpty
+	self assertEmpty: class instVarNames.
+	self assertEmpty: class classPool
 ]
 
 { #category : #accessing }

--- a/src/SUnit-Tests/SUnitExtensionsTest.class.st
+++ b/src/SUnit-Tests/SUnitExtensionsTest.class.st
@@ -107,18 +107,14 @@ SUnitExtensionsTest >> stream [
 
 { #category : #test }
 SUnitExtensionsTest >> testAssertionFailedInRaiseWithExceptionDo [
-
-	| testCase testResult  |
-	
+	| testCase testResult |
 	testCase := self class selector: #assertionFailedInRaiseWithExceptionDoTest.
 	testResult := testCase run.
-	
+
 	self assert: (testResult failures includes: testCase).
-	self assert: testResult failures size=1.
-	self assert: testResult passed isEmpty.
-	self assert: testResult errors isEmpty.
-	
-	
+	self assert: testResult failures size = 1.
+	self assertEmpty: testResult passed.
+	self assertEmpty: testResult errors
 ]
 
 { #category : #test }
@@ -153,32 +149,26 @@ SUnitExtensionsTest >> testAutoDenyTrue [
 
 { #category : #test }
 SUnitExtensionsTest >> testDifferentExceptionInShouldRaiseWithExceptionDo [
-
-	| testCase testResult  |
-	
+	| testCase testResult |
 	testCase := self class selector: #differentExceptionInShouldRaiseWithExceptionDoTest.
 	testResult := testCase run.
-	
+
 	self assert: (testResult passed includes: testCase).
-	self assert: testResult errors isEmpty.
-	self assert: testResult failures isEmpty.
-	self assert: testResult passed size=1
+	self assertEmpty: testResult errors.
+	self assertEmpty: testResult failures.
+	self assert: testResult passed size = 1
 ]
 
 { #category : #test }
 SUnitExtensionsTest >> testErrorInRaiseWithExceptionDo [
-
-	| testCase testResult  |
-	
+	| testCase testResult |
 	testCase := self class selector: #errorInRaiseWithExceptionDoTest.
 	testResult := testCase run.
-		
+
 	self assert: (testResult errors includes: testCase).
-	self assert: testResult errors size=1.
-	self assert: testResult failures isEmpty.
-	self assert: testResult passed isEmpty.
-	
-	
+	self assert: testResult errors size = 1.
+	self assertEmpty: testResult failures.
+	self assertEmpty: testResult passed
 ]
 
 { #category : #tests }
@@ -197,50 +187,38 @@ SUnitExtensionsTest >> testExceptionWithoutMatchingString [
 
 { #category : #test }
 SUnitExtensionsTest >> testInvalidShouldNotTakeMoreThan [
-
 	| testCase testResult |
-
 	testCase := self class selector: #invalidShouldNotTakeMoreThan.
 	testResult := testCase run.
 
-	self assert: testResult passed isEmpty.
+	self assertEmpty: testResult passed.
 	self assert: testResult failures size = 1.
 	self assert: (testResult failures includes: testCase).
-	self assert: testResult errors isEmpty
-
-
+	self assertEmpty: testResult errors
 ]
 
 { #category : #test }
 SUnitExtensionsTest >> testInvalidShouldNotTakeMoreThanMilliseconds [
-
 	| testCase testResult |
-
 	testCase := self class selector: #invalidShouldNotTakeMoreThanMilliseconds.
 	testResult := testCase run.
 
-	self assert: testResult passed isEmpty.
+	self assertEmpty: testResult passed.
 	self assert: testResult failures size = 1.
 	self assert: (testResult failures includes: testCase).
-	self assert: testResult errors isEmpty
-
-
+	self assertEmpty: testResult errors
 ]
 
 { #category : #test }
 SUnitExtensionsTest >> testNoExceptionInShouldRaiseWithExceptionDo [
-
-	| testCase testResult  |
-	
+	| testCase testResult |
 	testCase := self class selector: #noExceptionInShouldRaiseWithExceptionDoTest.
 	testResult := testCase run.
-	
+
 	self assert: (testResult failures includes: testCase).
-	self assert: testResult failures size=1.
-	self assert: testResult passed isEmpty.
-	self assert: testResult errors isEmpty.
-	
-	
+	self assert: testResult failures size = 1.
+	self assertEmpty: testResult passed.
+	self assertEmpty: testResult errors
 ]
 
 { #category : #tests }
@@ -263,65 +241,50 @@ SUnitExtensionsTest >> testNoExceptionWithNoMatchingString [
 
 { #category : #test }
 SUnitExtensionsTest >> testShouldFix [
-
-	| testCase testResult  |
-	
+	| testCase testResult |
 	testCase := self class selector: #shouldFixTest.
 	testResult := testCase run.
-	
+
 	self assert: (testResult passed includes: testCase).
-	self assert: testResult passed size=1.
-	self assert: testResult failures isEmpty.
-	self assert: testResult errors isEmpty.
-	
-	
+	self assert: testResult passed size = 1.
+	self assertEmpty: testResult failures.
+	self assertEmpty: testResult errors
 ]
 
 { #category : #test }
 SUnitExtensionsTest >> testShouldRaiseWithExceptionDo [
-
-	| testCase testResult  |
-	
+	| testCase testResult |
 	testCase := self class selector: #shouldRaiseWithExceptionDoTest.
 	testResult := testCase run.
-	
+
 	self assert: (testResult passed includes: testCase).
-	self assert: testResult passed size=1.
-	self assert: testResult failures isEmpty.
-	self assert: testResult errors isEmpty.
-	
-	
+	self assert: testResult passed size = 1.
+	self assertEmpty: testResult failures.
+	self assertEmpty: testResult errors
 ]
 
 { #category : #test }
 SUnitExtensionsTest >> testValidShouldNotTakeMoreThan [
 	| testCase testResult |
-
 	testCase := self class selector: #validShouldNotTakeMoreThan.
 	testResult := testCase run.
 
 	self assert: (testResult passed includes: testCase).
 	self assert: testResult passed size = 1.
-	self assert: testResult failures isEmpty.
-	self assert: testResult errors isEmpty
-
-
+	self assertEmpty: testResult failures.
+	self assertEmpty: testResult errors
 ]
 
 { #category : #test }
 SUnitExtensionsTest >> testValidShouldNotTakeMoreThanMilliseconds [
-
 	| testCase testResult |
-
 	testCase := self class selector: #validShouldNotTakeMoreThanMilliseconds.
 	testResult := testCase run.
 
 	self assert: (testResult passed includes: testCase).
 	self assert: testResult passed size = 1.
-	self assert: testResult failures isEmpty.
-	self assert: testResult errors isEmpty
-
-
+	self assertEmpty: testResult failures.
+	self assertEmpty: testResult errors
 ]
 
 { #category : #'real tests' }

--- a/src/SUnit-Tests/SUnitTest.class.st
+++ b/src/SUnit-Tests/SUnitTest.class.st
@@ -628,11 +628,10 @@ SUnitTest >> testSuite [
 
 { #category : #testing }
 SUnitTest >> testWatchDogProcessShouldNotBeCatchedAsForkedProcess [
-
 	| env |
 	env := CurrentExecutionEnvironment value.
-	
-	self assert: env forkedProcesses isEmpty
+
+	self assertEmpty: env forkedProcesses
 ]
 
 { #category : #testing }

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -81,21 +81,19 @@ ShClassInstallerTest >> testChangingSuperclassInTheHierarchy [
 
 { #category : #tests }
 ShClassInstallerTest >> testChangingSuperclassToOther [
+	superClass := self newClass: #ShCITestClass slots: #(var1).
+	superClass2 := self newClass: #ShCITestClass2 slots: #().
+	subClass := self newClass: #ShCISubTestClass superclass: superClass2 slots: #().
 
-	superClass := self newClass:#ShCITestClass slots:#(var1).
-	superClass2 := self newClass:#ShCITestClass2 slots:#().
-	subClass := self newClass:#ShCISubTestClass superclass: superClass2 slots:#().
+	subClass := self newClass: #ShCISubTestClass superclass: superClass slots: #().
 
-	subClass := 	self newClass:#ShCISubTestClass superclass: superClass slots:#().
+	superClass2 := self newClass: #ShCITestClass2 superclass: superClass slots: #().
 
-   superClass2 := self newClass:#ShCITestClass2 superclass: superClass slots:#().
-
-	self deny: superClass subclasses isEmpty.
-	self assert: superClass2 subclasses isEmpty.
-	self assertCollection: superClass subclasses equals: { subClass. superClass2 }. 
+	self denyEmpty: superClass subclasses.
+	self assertEmpty: superClass2 subclasses.
+	self assertCollection: superClass subclasses equals: {subClass . superClass2}.
 	self assert: subClass superclass equals: superClass.
-	self assert: superClass2 superclass equals: superClass.
-
+	self assert: superClass2 superclass equals: superClass
 ]
 
 { #category : #tests }

--- a/src/Slot-Tests/SlotAnnouncementsTest.class.st
+++ b/src/Slot-Tests/SlotAnnouncementsTest.class.st
@@ -220,19 +220,17 @@ SlotAnnouncementsTest >> testCreateAndChangeWithCommentDoesAnnounceBoth [
 
 { #category : #'tests-comments' }
 SlotAnnouncementsTest >> testCreateAndChangeWithoutCommentDoesNotAnnounce [
-
 	self subscribeOn: ClassCommented.
-	
-	self make: [ :builder |
-		builder 
-			name: self aClassName ].
-	
-	self make: [ :builder | 
-		builder 
-			name: self aClassName;
-			sharedPools: 'TestSharedPool' ].
 
-	self assert: self collectedAnnouncements isEmpty.
+	self make: [ :builder | builder name: self aClassName ].
+
+	self
+		make: [ :builder | 
+			builder
+				name: self aClassName;
+				sharedPools: 'TestSharedPool' ].
+
+	self assertEmpty: self collectedAnnouncements
 ]
 
 { #category : #'tests-comments' }
@@ -259,21 +257,22 @@ SlotAnnouncementsTest >> testCreateWithCommentDoesAnnounce [
 
 { #category : #'tests-comments' }
 SlotAnnouncementsTest >> testEmptyCommentDoesNotAnnounce [
-
 	self subscribeOn: ClassCommented.
-	
-	self make: [ :builder |
-		builder 
-			name: self aClassName;
-			comment: '' ].
 
-	self make: [ :builder |
-		builder 
-			name: self aClassName;
-			comment: '';
-			sharedPools: 'TestSharedPool' ].
+	self
+		make: [ :builder | 
+			builder
+				name: self aClassName;
+				comment: '' ].
 
-	self assert: self collectedAnnouncements isEmpty.
+	self
+		make: [ :builder | 
+			builder
+				name: self aClassName;
+				comment: '';
+				sharedPools: 'TestSharedPool' ].
+
+	self assertEmpty: self collectedAnnouncements
 ]
 
 { #category : #'tests-integration' }

--- a/src/Slot-Tests/SlotBasicTest.class.st
+++ b/src/Slot-Tests/SlotBasicTest.class.st
@@ -101,11 +101,10 @@ SlotBasicTest >> testNewCompiledMethodClass [
 
 { #category : #'tests-basic' }
 SlotBasicTest >> testNewPointerClass [
-
 	aClass := self makeWithLayout: FixedLayout.
 	self assert: aClass isPointers.
 	self assert: aClass isFixed.
-	self assert: aClass instVarNames isEmpty.
+	self assertEmpty: aClass instVarNames
 ]
 
 { #category : #'tests-basic' }
@@ -170,27 +169,20 @@ SlotBasicTest >> testRemoveClassSlotAndMigrate [
 
 { #category : #'tests-shared pools' }
 SlotBasicTest >> testRemoveSharedPool [
+	self make: [ :builder | builder sharedPools: 'TestSharedPool' ].
 
-	self make: [ :builder | 
-		builder sharedPools: 'TestSharedPool' ].
+	aClass := self make: [ :builder | builder sharedPools: '' ].
 
-	aClass := self make: [ :builder | 
-		builder sharedPools: '' ].
-	
-	self assert: aClass sharedPools isEmpty
-
+	self assertEmpty: aClass sharedPools
 ]
 
 { #category : #'tests-shared variables' }
 SlotBasicTest >> testRemoveSharedVariable [
+	self make: [ :builder | builder sharedVariablesFromString: 'Var' ].
 
-	self make: [ :builder | 
-		builder sharedVariablesFromString: 'Var' ].
+	aClass := self make: [ :builder | builder sharedVariablesFromString: '' ].
 
-	aClass := self make: [ :builder | 
-		builder sharedVariablesFromString: '' ].
-	
-	self assert: aClass classVarNames isEmpty
+	self assertEmpty: aClass classVarNames
 ]
 
 { #category : #'tests-class slots' }
@@ -264,27 +256,21 @@ SlotBasicTest >> testWithSharedVariable [
 
 { #category : #'tests-class slots' }
 SlotBasicTest >> testWithoutClassSlots [
+	aClass := self make: [ :builder | builder classSlots: #() ].
 
-	aClass := self make: [ :builder | 
-		builder classSlots: #() ].
-	
-	self assert: aClass classVarNames isEmpty
+	self assertEmpty: aClass classVarNames
 ]
 
 { #category : #'tests-shared pools' }
 SlotBasicTest >> testWithoutSharedPools [
+	aClass := self make: [ :builder | builder sharedPools: '' ].
 
-	aClass := self make: [ :builder | 
-		builder sharedPools: '' ].
-	
-	self assert: aClass sharedPools isEmpty
+	self assertEmpty: aClass sharedPools
 ]
 
 { #category : #'tests-shared variables' }
 SlotBasicTest >> testWithoutSharedVariables [
+	aClass := self make: [ :builder | builder sharedVariablesFromString: '' ].
 
-	aClass := self make: [ :builder | 
-		builder sharedVariablesFromString: '' ].
-	
-	self assert: aClass classVarNames isEmpty
+	self assertEmpty: aClass classVarNames
 ]

--- a/src/Slot-Tests/SlotExampleMovieAndPersonTest.class.st
+++ b/src/Slot-Tests/SlotExampleMovieAndPersonTest.class.st
@@ -27,22 +27,22 @@ SlotExampleMovieAndPersonTest >> testAddActors [
 
 { #category : #tests }
 SlotExampleMovieAndPersonTest >> testAddAndRemoveActors [
-
 	| m1 m2 p1 p2 |
-	
 	m1 := SlotExampleMovie named: 'M1'.
 	m2 := SlotExampleMovie named: 'M2'.
 	p1 := SlotExamplePerson named: 'P1'.
 	p2 := SlotExamplePerson named: 'P2'.
-	
-	m1 addActor: p1; addActor: p2.
+
+	m1
+		addActor: p1;
+		addActor: p2.
 	m2 addActor: p2.
 
 	m1 removeActor: p2.
 	self assert: p2 actedInMovies size equals: 1.
 	m2 removeActor: p2.
-	self assert: p2 actedInMovies isEmpty.
-	
+	self assertEmpty: p2 actedInMovies.
+
 	self should: [ m2 removeActor: p2 ] raise: Error
 ]
 
@@ -86,79 +86,69 @@ SlotExampleMovieAndPersonTest >> testAddMovieDirectorTwice [
 
 { #category : #tests }
 SlotExampleMovieAndPersonTest >> testChangeMovieDirector [
-
 	| movie p1 p2 |
-	
 	movie := SlotExampleMovie named: 'Jaws'.
 	p1 := SlotExamplePerson named: 'P1'.
 	p2 := SlotExamplePerson named: 'P2'.
-	
+
 	movie director: p1.
 	self assert: movie director equals: p1.
 	self assert: p1 directedMovies anyOne equals: movie.
-	self assert: p2 directedMovies isEmpty.
-	
+	self assertEmpty: p2 directedMovies.
+
 	movie director: p2.
 	self assert: movie director equals: p2.
-	self assert: p1 directedMovies isEmpty.
-	self assert: p2 directedMovies anyOne equals: movie.
+	self assertEmpty: p1 directedMovies.
+	self assert: p2 directedMovies anyOne equals: movie
 ]
 
 { #category : #tests }
 SlotExampleMovieAndPersonTest >> testNewMovie [
-
 	| movie |
-	
 	movie := SlotExampleMovie new.
 	self assert: movie name isNil.
 	self assert: movie director isNil.
 	self assert: movie actors isCollection.
-	self assert: movie actors isEmpty.
+	self assertEmpty: movie actors
 ]
 
 { #category : #tests }
 SlotExampleMovieAndPersonTest >> testNewPerson [
-
 	| person |
-	
 	person := SlotExamplePerson new.
 	self assert: person name isNil.
 	self assert: person directedMovies isCollection.
-	self assert: person directedMovies isEmpty.
+	self assertEmpty: person directedMovies
 ]
 
 { #category : #tests }
 SlotExampleMovieAndPersonTest >> testSetAndRemoveMovieDirector [
-
 	| movie person |
-	
 	movie := SlotExampleMovie named: 'Jaws'.
 	person := SlotExamplePerson named: 'Peter'.
-	
+
 	movie director: person.
 	self assert: movie director equals: person.
 	self assert: person directedMovies anyOne equals: movie.
-	
+
 	person directedMovies remove: movie.
 	self assert: movie director isNil.
-	self assert: person directedMovies isEmpty.	
+	self assertEmpty: person directedMovies
 ]
 
 { #category : #tests }
 SlotExampleMovieAndPersonTest >> testSetAndUnsetMovieDirector [
-
 	| movie person |
-	
 	movie := SlotExampleMovie named: 'Jaws'.
 	person := SlotExamplePerson named: 'Peter'.
-	
+
 	movie director: person.
 	self assert: movie director equals: person.
 	self assert: person directedMovies anyOne equals: movie.
-	
+
 	movie director: nil.
 	self assert: movie director isNil.
-	self assert: person directedMovies isEmpty.
+	self assertEmpty: person directedMovies
 ]
 
 { #category : #tests }

--- a/src/Slot-Tests/SlotIntegrationTest.class.st
+++ b/src/Slot-Tests/SlotIntegrationTest.class.st
@@ -243,86 +243,87 @@ SlotIntegrationTest >> testRemoveInstVarNamedClassInterface [
 { #category : #tests }
 SlotIntegrationTest >> testRemoveInstVarNamedWithTrait2 [
 	"Add instance variables using the builder interface"
-	
-	aClass := self make: [ :builder |
-		builder 
-			name: self aClassName;
-			traitComposition: TOne;
-			slots: #( x )
-		].
+
+	aClass := self
+		make: [ :builder | 
+			builder
+				name: self aClassName;
+				traitComposition: TOne;
+				slots: #(x) ].
 
 	self assert: aClass instVarNames equals: #(x).
-	
-	self assert: TOne traitUsers asArray equals: { aClass }.
-	
+
+	self assert: TOne traitUsers asArray equals: {aClass}.
+
 	self assert: (aClass canUnderstand: #one).
 	self assert: aClass new one equals: 1.
 
 	aClass removeInstVarNamed: #x.
-	
-	self assert: aClass instVarNames isEmpty.
-	
-	self assert: TOne traitUsers asArray equals: { aClass }.
-	
+
+	self assertEmpty: aClass instVarNames.
+
+	self assert: TOne traitUsers asArray equals: {aClass}.
+
 	self assert: (aClass canUnderstand: #one).
-	self assert: aClass new one equals: 1.
+	self assert: aClass new one equals: 1
 ]
 
 { #category : #tests }
 SlotIntegrationTest >> testReshapeClassPropagatesToDeepHierarchyClassInterface [
 	"Test reshaping a class which is head of a hierarchy of 4 levels"
-	
+
 	"level 1"
+
 	aClass := Object
-		subclass: self aClassName 
-		instanceVariableNames: '' 
-		classVariableNames: '' 
-		poolDictionaries: '' 
+		subclass: self aClassName
+		instanceVariableNames: ''
+		classVariableNames: ''
+		poolDictionaries: ''
 		category: self aCategory.
 
-	self assert: aClass subclasses isEmpty.
+	self assertEmpty: aClass subclasses.
 	aClass classLayout checkIntegrity.
 
 	"level 2"
 	anotherClass := aClass
-		subclass: self anotherClassName 
-		instanceVariableNames: '' 
-		classVariableNames: '' 
-		poolDictionaries: '' 
+		subclass: self anotherClassName
+		instanceVariableNames: ''
+		classVariableNames: ''
+		poolDictionaries: ''
 		category: self aCategory.
-	
-	self assert: aClass subclasses equals: { anotherClass }.
-	self assert: anotherClass subclasses isEmpty.
+
+	self assert: aClass subclasses equals: {anotherClass}.
+	self assertEmpty: anotherClass subclasses.
 	aClass classLayout checkIntegrity.
 	anotherClass classLayout checkIntegrity.
 
 	"level 3"
 	yetAnotherClass := anotherClass
-		subclass: self yetAnotherClassName 
-		instanceVariableNames: '' 
-		classVariableNames: '' 
-		poolDictionaries: '' 
+		subclass: self yetAnotherClassName
+		instanceVariableNames: ''
+		classVariableNames: ''
+		poolDictionaries: ''
 		category: self aCategory.
 
-	self assert: aClass subclasses equals: { anotherClass }.
-	self assert: anotherClass subclasses equals: { yetAnotherClass }.
-	self assert: yetAnotherClass subclasses isEmpty.
+	self assert: aClass subclasses equals: {anotherClass}.
+	self assert: anotherClass subclasses equals: {yetAnotherClass}.
+	self assertEmpty: yetAnotherClass subclasses.
 	aClass classLayout checkIntegrity.
 	anotherClass classLayout checkIntegrity.
 	yetAnotherClass classLayout checkIntegrity.
 
 	"level 4"
 	yetYetAnotherClass := yetAnotherClass
-		subclass: self yetYetAnotherClassName 
-		instanceVariableNames: '' 
-		classVariableNames: '' 
-		poolDictionaries: '' 
+		subclass: self yetYetAnotherClassName
+		instanceVariableNames: ''
+		classVariableNames: ''
+		poolDictionaries: ''
 		category: self aCategory.
 
-	self assert: aClass subclasses equals: { anotherClass }.
-	self assert: anotherClass subclasses equals: { yetAnotherClass }.
-	self assert: yetAnotherClass subclasses equals: { yetYetAnotherClass }.
-	self assert: yetYetAnotherClass subclasses isEmpty.
+	self assert: aClass subclasses equals: {anotherClass}.
+	self assert: anotherClass subclasses equals: {yetAnotherClass}.
+	self assert: yetAnotherClass subclasses equals: {yetYetAnotherClass}.
+	self assertEmpty: yetYetAnotherClass subclasses.
 	aClass classLayout checkIntegrity.
 	anotherClass classLayout checkIntegrity.
 	yetAnotherClass classLayout checkIntegrity.
@@ -330,17 +331,17 @@ SlotIntegrationTest >> testReshapeClassPropagatesToDeepHierarchyClassInterface [
 
 	"reshape level 1"
 	aClass := Object
-		subclass: self aClassName 
-		instanceVariableNames: 'x' 
-		classVariableNames: '' 
-		poolDictionaries: '' 
+		subclass: self aClassName
+		instanceVariableNames: 'x'
+		classVariableNames: ''
+		poolDictionaries: ''
 		category: self aCategory.
 
 	self assert: aClass instVarNames equals: #(x).
 	aClass classLayout checkIntegrity.
 	anotherClass classLayout checkIntegrity.
 	yetAnotherClass classLayout checkIntegrity.
-	yetYetAnotherClass classLayout checkIntegrity.
+	yetYetAnotherClass classLayout checkIntegrity
 ]
 
 { #category : #tests }

--- a/src/Slot-Tests/SlotMigrationTest.class.st
+++ b/src/Slot-Tests/SlotMigrationTest.class.st
@@ -108,52 +108,53 @@ SlotMigrationTest >> testChangeLayoutTypeFromByte [
 
 { #category : #tests }
 SlotMigrationTest >> testChangeLayoutTypeToByte [
-	aClass := self 
-		makeWithLayout: FixedLayout
-		andSlots: { #id. #name }.
+	aClass := self makeWithLayout: FixedLayout andSlots: {#id . #name}.
 	"Change the layout of the class from pointer to bytes"
 	aClass := self makeWithLayout: ByteLayout.
-	
+
 	aClass classLayout checkIntegrity.
-	
+
 	self assert: aClass classLayout isBits.
-	self assert: aClass instVarNames isEmpty.
+	self assertEmpty: aClass instVarNames
 ]
 
 { #category : #tests }
 SlotMigrationTest >> testChangeSuperclass [
-
 	"Define original hierarchy"
-	aClass := self make: [ :builder |
-		builder 
-			name: self aClassName;
-			superclass: Object ]. 
 
-	anotherClass := self make: [ :builder |
-		builder 
-			name: self anotherClassName;
-			superclass: aClass ].
+	aClass := self
+		make: [ :builder | 
+			builder
+				name: self aClassName;
+				superclass: Object ].
+
+	anotherClass := self
+		make: [ :builder | 
+			builder
+				name: self anotherClassName;
+				superclass: aClass ].
 
 	self assert: aClass subclasses size equals: 1.
 	self assert: aClass subclasses anyOne == anotherClass.
 	self assert: anotherClass superclass == aClass.
 
 	"Change to a new superclass"
-	yetAnotherClass := self make: [ :builder |
-		builder 
-			name: self yetAnotherClassName;
-			superclass: Object ]. 
+	yetAnotherClass := self
+		make: [ :builder | 
+			builder
+				name: self yetAnotherClassName;
+				superclass: Object ].
 
-	anotherClass := self make: [ :builder |
-		builder 
-			name: self anotherClassName;
-			superclass: yetAnotherClass ]. 
-	
-	self assert: aClass subclasses isEmpty.
+	anotherClass := self
+		make: [ :builder | 
+			builder
+				name: self anotherClassName;
+				superclass: yetAnotherClass ].
+
+	self assertEmpty: aClass subclasses.
 	self assert: yetAnotherClass subclasses size equals: 1.
 	self assert: yetAnotherClass subclasses anyOne == anotherClass.
-	self assert: anotherClass superclass == yetAnotherClass.
-
+	self assert: anotherClass superclass == yetAnotherClass
 ]
 
 { #category : #tests }
@@ -296,64 +297,68 @@ SlotMigrationTest >> testReshapeByteVariableToPointerPropagatesToDeepHierarchy [
 { #category : #tests }
 SlotMigrationTest >> testReshapeClassPropagatesToDeepHierarchy [
 	"Test reshaping a class which is head of a hierarchy of 4 levels"
-	
-	"level 1"
-	aClass := self make: [ :builder |
-		builder name: self aClassName ].
 
-	self assert: aClass subclasses isEmpty.
+	"level 1"
+
+	aClass := self make: [ :builder | builder name: self aClassName ].
+
+	self assertEmpty: aClass subclasses.
 	aClass classLayout checkIntegrity.
 
 	"level 2"
-	anotherClass := self make: [ :builder |
-		builder 
-			superclass: aClass;
-			name: self anotherClassName ].
-	
-	self assert: aClass subclasses equals: { anotherClass }.
-	self assert: anotherClass subclasses isEmpty.
+	anotherClass := self
+		make: [ :builder | 
+			builder
+				superclass: aClass;
+				name: self anotherClassName ].
+
+	self assert: aClass subclasses equals: {anotherClass}.
+	self assertEmpty: anotherClass subclasses.
 	aClass classLayout checkIntegrity.
 	anotherClass classLayout checkIntegrity.
 
 	"level 3"
-	yetAnotherClass := self make: [ :builder |
-		builder 
-			superclass: anotherClass;
-			name: self yetAnotherClassName ].
+	yetAnotherClass := self
+		make: [ :builder | 
+			builder
+				superclass: anotherClass;
+				name: self yetAnotherClassName ].
 
-	self assert: aClass subclasses equals: { anotherClass }.
-	self assert: anotherClass subclasses equals: { yetAnotherClass }.
-	self assert: yetAnotherClass subclasses isEmpty.
+	self assert: aClass subclasses equals: {anotherClass}.
+	self assert: anotherClass subclasses equals: {yetAnotherClass}.
+	self assertEmpty: yetAnotherClass subclasses.
 	aClass classLayout checkIntegrity.
 	anotherClass classLayout checkIntegrity.
 	yetAnotherClass classLayout checkIntegrity.
 
 	"level 4"
-	yetYetAnotherClass := self make: [ :builder |
-		builder 
-			superclass: yetAnotherClass;
-			name: self yetYetAnotherClassName ].
+	yetYetAnotherClass := self
+		make: [ :builder | 
+			builder
+				superclass: yetAnotherClass;
+				name: self yetYetAnotherClassName ].
 
 
-	self assert: aClass subclasses equals: { anotherClass }.
-	self assert: anotherClass subclasses equals: { yetAnotherClass }.
-	self assert: yetAnotherClass subclasses equals: { yetYetAnotherClass }.
-	self assert: yetYetAnotherClass subclasses isEmpty.
+	self assert: aClass subclasses equals: {anotherClass}.
+	self assert: anotherClass subclasses equals: {yetAnotherClass}.
+	self assert: yetAnotherClass subclasses equals: {yetYetAnotherClass}.
+	self assertEmpty: yetYetAnotherClass subclasses.
 	aClass classLayout checkIntegrity.
 	anotherClass classLayout checkIntegrity.
 	yetAnotherClass classLayout checkIntegrity.
 	yetYetAnotherClass classLayout checkIntegrity.
 
 	"reshape level 1"
-	aClass := self make: [ :builder |
-		builder 
-			name: self aClassName;
-			slots:#(x) ].
+	aClass := self
+		make: [ :builder | 
+			builder
+				name: self aClassName;
+				slots: #(x) ].
 
 	aClass classLayout checkIntegrity.
 	anotherClass classLayout checkIntegrity.
 	yetAnotherClass classLayout checkIntegrity.
-	yetYetAnotherClass classLayout checkIntegrity.
+	yetYetAnotherClass classLayout checkIntegrity
 ]
 
 { #category : #tests }
@@ -406,58 +411,56 @@ SlotMigrationTest >> testReshapePointerToByteVariablePropagatesToDeepHierarchy [
 
 { #category : #tests }
 SlotMigrationTest >> testReshapeSuperSuperClass [
-
 	| supersuperclass superclass subclass |
+	supersuperclass := self
+		make: [ :builder | 
+			builder
+				superclass: Object;
+				name: self aClassName;
+				slots: #(a b) ].
 
-	supersuperclass := self make: [ :builder |
-		builder 
-			superclass: Object;
-			name: self aClassName;
-			slots: #(a b).
-		 ].
-
-	self assert: supersuperclass subclasses isEmpty.
+	self assertEmpty: supersuperclass subclasses.
 	supersuperclass classLayout checkIntegrity.
-	
-	superclass := self make: [ :builder |
-		builder 
-			superclass: supersuperclass;
-			name: self anotherClassName.
-		 ].
 
-	self assert: supersuperclass subclasses equals: { superclass }.
-	self assert: superclass subclasses isEmpty.
+	superclass := self
+		make: [ :builder | 
+			builder
+				superclass: supersuperclass;
+				name: self anotherClassName ].
+
+	self assert: supersuperclass subclasses equals: {superclass}.
+	self assertEmpty: superclass subclasses.
 	superclass classLayout checkIntegrity.
 	supersuperclass classLayout checkIntegrity.
-	
-	subclass := self make: [ :builder |
-		builder 
-			superclass: superclass;
-			name: self yetAnotherClassName;
-			slots:#(c d).
-		 ].
 
-	self assert: supersuperclass subclasses equals: { superclass }.
-	self assert: superclass subclasses equals: { subclass }.
-	self assert: subclass subclasses isEmpty.
+	subclass := self
+		make: [ :builder | 
+			builder
+				superclass: superclass;
+				name: self yetAnotherClassName;
+				slots: #(c d) ].
+
+	self assert: supersuperclass subclasses equals: {superclass}.
+	self assert: superclass subclasses equals: {subclass}.
+	self assertEmpty: subclass subclasses.
 	subclass classLayout checkIntegrity.
 	superclass classLayout checkIntegrity.
 	supersuperclass classLayout checkIntegrity.
 
 	"reshape the super super class"
-	supersuperclass := self make: [ :builder |
-		builder 
-			superclass: Object;
-			name: self aClassName;
-			slots: #(a b a2).
-		 ].
-	
-	self assert: supersuperclass subclasses equals: { superclass }.
-	self assert: superclass subclasses equals: { subclass }.
-	self assert: subclass subclasses isEmpty.	
+	supersuperclass := self
+		make: [ :builder | 
+			builder
+				superclass: Object;
+				name: self aClassName;
+				slots: #(a b a2) ].
+
+	self assert: supersuperclass subclasses equals: {superclass}.
+	self assert: superclass subclasses equals: {subclass}.
+	self assertEmpty: subclass subclasses.
 	subclass classLayout checkIntegrity.
 	superclass classLayout checkIntegrity.
-	supersuperclass classLayout checkIntegrity.
+	supersuperclass classLayout checkIntegrity
 ]
 
 { #category : #tests }

--- a/src/Slot-Tests/SlotTraitsTest.class.st
+++ b/src/Slot-Tests/SlotTraitsTest.class.st
@@ -6,138 +6,120 @@ Class {
 
 { #category : #tests }
 SlotTraitsTest >> testClassWithClassTrait [
+	self assertEmpty: TOne traitUsers.
+	self assertEmpty: TOne classTrait traitUsers.
 
-	self assert: TOne traitUsers isEmpty.
-	self assert: TOne classTrait traitUsers isEmpty.
-	
-	aClass := self make: [ :builder | ].
+	aClass := self make: [ :builder |  ].
 	aClass class setTraitComposition: TOne.
-	
-	self assert: TOne traitUsers asArray equals: { aClass class }.
-	self assert: TOne classTrait traitUsers isEmpty.
-	
+
+	self assert: TOne traitUsers asArray equals: {aClass class}.
+	self assertEmpty: TOne classTrait traitUsers.
+
 	self assert: (aClass class canUnderstand: #one).
-	self assert: aClass one equals: 1.
+	self assert: aClass one equals: 1
 ]
 
 { #category : #tests }
 SlotTraitsTest >> testClassWithTrait [
+	self assertEmpty: TOne traitUsers.
+	self assertEmpty: TOne classTrait traitUsers.
 
-	self assert: TOne traitUsers isEmpty.
-	self assert: TOne classTrait traitUsers isEmpty.
-	
-	aClass := self make: [ :builder | ]. 
+	aClass := self make: [ :builder |  ].
 	aClass setTraitComposition: TOne.
-	
-	self assert: TOne traitUsers asArray equals: { aClass }.
-	self assert: TOne classTrait traitUsers asArray equals: { aClass class }.
-	
+
+	self assert: TOne traitUsers asArray equals: {aClass}.
+	self assert: TOne classTrait traitUsers asArray equals: {aClass class}.
+
 	self assert: (aClass canUnderstand: #one).
-	self assert: aClass new one equals: 1.
+	self assert: aClass new one equals: 1
 ]
 
 { #category : #tests }
 SlotTraitsTest >> testModifyClassTraitComposition [
 	"Tests that when modifing the trait composition on class-side, the old methods are removed from the method dictionary, and the new ones are added."
 
-	self make: [ :builder | 
-		builder classTraitComposition: TOne ].
+	self make: [ :builder | builder classTraitComposition: TOne ].
 
-	aClass := self make: [ :builder | 
-		builder classTraitComposition: TTwo ].
-	
-	self assert: TOne traitUsers isEmpty.
-	self assert: TOne classTrait traitUsers isEmpty.
-	self assert: TTwo traitUsers asArray equals: { aClass class }.
-	self assert: TTwo classTrait traitUsers isEmpty.
-	
+	aClass := self make: [ :builder | builder classTraitComposition: TTwo ].
+
+	self assertEmpty: TOne traitUsers.
+	self assertEmpty: TOne classTrait traitUsers.
+	self assert: TTwo traitUsers asArray equals: {aClass class}.
+	self assertEmpty: TTwo classTrait traitUsers.
+
 	self deny: (aClass class canUnderstand: #one).
 	self deny: (aClass class canUnderstand: #classOne).
 	self assert: (aClass class canUnderstand: #two).
 	aClass classLayout checkIntegrity.
 
+	aClass := self make: [ :builder | builder classTraitComposition: {} ].
 
-	aClass := self make: [ :builder | 
-		builder classTraitComposition: { } ].
-	
-	self assert: TOne traitUsers isEmpty.
-	self assert: TOne classTrait traitUsers isEmpty.
-	self assert: TTwo traitUsers isEmpty.
-	self assert: TTwo classTrait traitUsers isEmpty.
+	self assertEmpty: TOne traitUsers.
+	self assertEmpty: TOne classTrait traitUsers.
+	self assertEmpty: TTwo traitUsers.
+	self assertEmpty: TTwo classTrait traitUsers.
 	aClass classLayout checkIntegrity.
-	
+
 	self deny: (aClass canUnderstand: #one).
 	self deny: (aClass class canUnderstand: #classOne).
-	self deny: (aClass canUnderstand: #two).
+	self deny: (aClass canUnderstand: #two)
 ]
 
 { #category : #tests }
 SlotTraitsTest >> testModifyTraitComposition [
 	"Tests that when modifing the trait composition, the old methods are removed from the method dictionary, and the new ones are added."
-	
-	self make: [ :builder | 
-		builder traitComposition: TOne ].
 
-	aClass := self make: [ :builder | 
-		builder traitComposition: TTwo ].
-	
-	self assert: TOne traitUsers isEmpty.
-	self assert: TOne classTrait traitUsers isEmpty.
-	self assert: TTwo traitUsers asArray equals: { aClass }.
-	"self assert: TTwo classTrait traitUsers isEmpty."
+	self make: [ :builder | builder traitComposition: TOne ].
+
+	aClass := self make: [ :builder | builder traitComposition: TTwo ].
+
+	self assertEmpty: TOne traitUsers.
+	self assertEmpty: TOne classTrait traitUsers.
+	self assert: TTwo traitUsers asArray equals: {aClass}.
+	"self assertEmpty: TTwo classTrait traitUsers ."
 	aClass classLayout checkIntegrity.
-	
+
 	self deny: (aClass canUnderstand: #one).
 	self deny: (aClass class canUnderstand: #classOne).
 	self assert: (aClass canUnderstand: #two).
-	
-	
-	aClass := self make: [ :builder | 
-		builder traitComposition: { } ].
-	
-	self assert: TOne traitUsers isEmpty.
-	self assert: TOne classTrait traitUsers isEmpty.
-	self assert: TTwo traitUsers isEmpty.
-	self assert: TTwo classTrait traitUsers isEmpty.
+
+	aClass := self make: [ :builder | builder traitComposition: {} ].
+
+	self assertEmpty: TOne traitUsers.
+	self assertEmpty: TOne classTrait traitUsers.
+	self assertEmpty: TTwo traitUsers.
+	self assertEmpty: TTwo classTrait traitUsers.
 	aClass classLayout checkIntegrity.
-	
+
 	self deny: (aClass canUnderstand: #one).
 	self deny: (aClass class canUnderstand: #classOne).
-	self deny: (aClass canUnderstand: #two).
-	
-
+	self deny: (aClass canUnderstand: #two)
 ]
 
 { #category : #tests }
 SlotTraitsTest >> testRemoveClassTrait [
 	"Tests that when removing a trait from class-side, its methods are removed from the method dictionary."
 
-	aClass := self make: [ :builder | 
-		builder classTraitComposition: TOne ].
+	aClass := self make: [ :builder | builder classTraitComposition: TOne ].
 
-	aClass := self make: [ :builder | 
-		builder classTraitComposition: {} ].
-	
+	aClass := self make: [ :builder | builder classTraitComposition: {} ].
+
 	self deny: (aClass class canUnderstand: #one).
-	self assert: TOne traitUsers isEmpty.
-	self assert: TOne classTrait traitUsers isEmpty.
-
+	self assertEmpty: TOne traitUsers.
+	self assertEmpty: TOne classTrait traitUsers
 ]
 
 { #category : #tests }
 SlotTraitsTest >> testRemoveTrait [
 	"Tests that when removing a trait from a class, its methods are removed from the method dictionary."
-	
-	self make: [ :builder | 
-		builder traitComposition: TOne ].
-	
-	aClass := self make: [ :builder | 
-		builder traitComposition: {} ].
-	
-	self assert: TOne traitUsers isEmpty.
-	self assert: TOne classTrait traitUsers isEmpty.
-	self deny: (aClass canUnderstand: #one).
 
+	self make: [ :builder | builder traitComposition: TOne ].
+
+	aClass := self make: [ :builder | builder traitComposition: {} ].
+
+	self assertEmpty: TOne traitUsers.
+	self assertEmpty: TOne classTrait traitUsers.
+	self deny: (aClass canUnderstand: #one)
 ]
 
 { #category : #tests }

--- a/src/Spec-Tests/SpecFocusOrderTest.class.st
+++ b/src/Spec-Tests/SpecFocusOrderTest.class.st
@@ -23,55 +23,47 @@ SpecFocusOrderTest >> setUp [
 { #category : #tests }
 SpecFocusOrderTest >> testAdd [
 	self
-		assert: specFocusOrder presenters isEmpty;
+		assertEmpty: specFocusOrder presenters;
 		shouldnt: [ specFocusOrder
 				add: button1;
 				add: button2;
 				add: button1;
 				add: button1 ]
 			raise: Error;
-		assert: specFocusOrder presenters
-			equals:
-			{button1.
-			button2.
-			button1.
-			button1} asOrderedCollection
+		assert: specFocusOrder presenters equals: {button1 . button2 . button1 . button1} asOrderedCollection
 ]
 
 { #category : #tests }
 SpecFocusOrderTest >> testAddLast [
 	self
-		assert: specFocusOrder presenters isEmpty;
+		assertEmpty: specFocusOrder presenters;
 		shouldnt: [ specFocusOrder
 				addLast: button1;
-				addLast: button2]
+				addLast: button2 ]
 			raise: Error;
-		assert: specFocusOrder presenters
-			equals:
-			{button1.
-			button2} asOrderedCollection
+		assert: specFocusOrder presenters equals: {button1 . button2} asOrderedCollection
 ]
 
 { #category : #tests }
 SpecFocusOrderTest >> testGiveFocusToNextFrom [
 	self
-		assert: specFocusOrder presenters isEmpty;
+		assertEmpty: specFocusOrder presenters;
 		shouldnt: [ specFocusOrder
 				add: button1;
 				add: button2 ]
 			raise: Error;
-			assert: (specFocusOrder giveFocusToNextFrom:button1 for: nil).
+		assert: (specFocusOrder giveFocusToNextFrom: button1 for: nil)
 ]
 
 { #category : #tests }
 SpecFocusOrderTest >> testRemoveAll [
 	self
-		assert: specFocusOrder presenters isEmpty;
+		assertEmpty: specFocusOrder presenters;
 		shouldnt: [ specFocusOrder
 				add: button1;
 				add: button2 ]
 			raise: Error;
 		assert: specFocusOrder presenters size == 2;
 		shouldnt: [ specFocusOrder removeAll ] raise: Error;
-		assert: specFocusOrder presenters isEmpty
+		assertEmpty: specFocusOrder presenters
 ]

--- a/src/Spec-Tests/TextPresenterTest.class.st
+++ b/src/Spec-Tests/TextPresenterTest.class.st
@@ -21,5 +21,5 @@ TextPresenterTest >> testSelectAll [
 	testedInstance selectAll.
 	self assert: testedInstance getSelection equals: (1 to: 15).
 	testedInstance clearSelection.
-	self assert: testedInstance getSelection isEmpty
+	self assertEmpty: testedInstance getSelection
 ]

--- a/src/System-BasicCommandLineHandler-Tests/CommandLineArgumentsTest.class.st
+++ b/src/System-BasicCommandLineHandler-Tests/CommandLineArgumentsTest.class.st
@@ -28,8 +28,8 @@ CommandLineArgumentsTest >> setUp [
 
 { #category : #tests }
 CommandLineArgumentsTest >> testAllFileTyped [
-	self assert: (self commandLine allFilesWithExtension: #txt) = #('noOpt2.txt' 'opt12.txt').
-	self assert: (self commandLine allFilesWithExtension: #foo) isEmpty.
+	self assert: (self commandLine allFilesWithExtension: #txt) equals: #('noOpt2.txt' 'opt12.txt').
+	self assertEmpty: (self commandLine allFilesWithExtension: #foo)
 ]
 
 { #category : #tests }

--- a/src/System-Caching-Tests/LRUCacheTests.class.st
+++ b/src/System-Caching-Tests/LRUCacheTests.class.st
@@ -207,7 +207,7 @@ LRUCacheTests >> testOne [
 	cache := self newCache.
 	cache at: #foo ifAbsentPut: [ 100 ].
 	self assert: (cache includesKey: #foo).
-	self denyEmpty: cache.
+	self deny: cache isEmpty.
 	self assert: cache size equals: 1.
 	self assert: cache totalWeight equals: 1.
 	self assert: cache hits isZero.

--- a/src/System-Caching-Tests/LRUCacheTests.class.st
+++ b/src/System-Caching-Tests/LRUCacheTests.class.st
@@ -92,7 +92,7 @@ LRUCacheTests >> testCustomWeight [
 LRUCacheTests >> testEmpty [
 	| emptyCache |
 	emptyCache := self newCache.
-	self assert: emptyCache isEmpty.
+	self assertEmpty: emptyCache.
 	self assert: emptyCache size isZero.
 	self assert: emptyCache hits isZero.
 	self assert: emptyCache misses isZero.
@@ -207,7 +207,7 @@ LRUCacheTests >> testOne [
 	cache := self newCache.
 	cache at: #foo ifAbsentPut: [ 100 ].
 	self assert: (cache includesKey: #foo).
-	self deny: cache isEmpty.
+	self denyEmpty: cache.
 	self assert: cache size equals: 1.
 	self assert: cache totalWeight equals: 1.
 	self assert: cache hits isZero.
@@ -311,10 +311,9 @@ LRUCacheTests >> testRandomAccess [
 LRUCacheTests >> testRemoveAll [
 	| cache |
 	cache := self newCache.
-	1 to: 10 do: [ :each | 
-		cache at: each ifAbsentPut: [ each ] ].
+	1 to: 10 do: [ :each | cache at: each ifAbsentPut: [ each ] ].
 	cache removeAll.
-	self assert: cache isEmpty.
+	self assertEmpty: cache.
 	self assert: cache size isZero.
 	self assert: cache totalWeight isZero.
 	self assert: cache misses equals: 10.
@@ -330,7 +329,7 @@ LRUCacheTests >> testRemoveOne [
 	cache := self newCache.
 	cache at: #foo ifAbsentPut: [ 100 ].
 	cache removeKey: #foo.
-	self assert: cache isEmpty.
+	self assertEmpty: cache.
 	self assert: cache size isZero.
 	self assert: cache totalWeight isZero.
 	self deny: (cache includesKey: #foo).

--- a/src/System-Caching-Tests/TTLCacheTests.class.st
+++ b/src/System-Caching-Tests/TTLCacheTests.class.st
@@ -44,8 +44,7 @@ TTLCacheTests >> testRemoveStaleValues [
 	self deny: cache isEmpty.
 	1 second asDelay wait.
 	keys := cache removeStaleValues.
-	self assert: cache isEmpty.
+	self assertEmpty: cache.
 	self assert: keys asArray sorted equals: #(bar foo).
-	cache validateInvariantWith: self 
-	
+	cache validateInvariantWith: self
 ]

--- a/src/System-History-Tests/HistoryIteratorTest.class.st
+++ b/src/System-History-Tests/HistoryIteratorTest.class.st
@@ -73,14 +73,8 @@ HistoryIteratorTest >> testGrouping [
 	self assert: historyList size equals: 1.
 	self assert: (historyList at: 1) isComposite.
 	self assert: (historyList at: 1) opened.
-	historyList doAndAddRecord: (
-		UndoRedoRecord
-			do: (MessageSend receiver: aCollection selector: #addLast: argument: 1)
-			undo: (MessageSend receiver: aCollection selector: #removeLast)).
-	historyList doAndAddRecord: (
-		UndoRedoRecord
-			do: (MessageSend receiver: aCollection selector: #addLast: argument: 2)
-			undo: (MessageSend receiver: aCollection selector: #removeLast)).
+	historyList doAndAddRecord: (UndoRedoRecord do: (MessageSend receiver: aCollection selector: #addLast: argument: 1) undo: (MessageSend receiver: aCollection selector: #removeLast)).
+	historyList doAndAddRecord: (UndoRedoRecord do: (MessageSend receiver: aCollection selector: #addLast: argument: 2) undo: (MessageSend receiver: aCollection selector: #removeLast)).
 	self assert: historyList size equals: 1.
 	self assert: (historyList at: 1) size equals: 2.
 	historyList closeGroup.
@@ -89,7 +83,7 @@ HistoryIteratorTest >> testGrouping [
 	self assert: aCollection first equals: 1.
 	self assert: aCollection last equals: 2.
 	historyList undo.
-	self assert: aCollection isEmpty
+	self assertEmpty: aCollection
 ]
 
 { #category : #testing }

--- a/src/System-History-Tests/HistoryNodeTest.class.st
+++ b/src/System-History-Tests/HistoryNodeTest.class.st
@@ -41,7 +41,7 @@ HistoryNodeTest >> testGroup [
 
 { #category : #tests }
 HistoryNodeTest >> testOneGroup [
-	| h i c i2 i3 i4 | 
+	| h i c i2 i3 i4 |
 	h := HistoryNode new.
 	h addItem: (i := HistoryLeaf new).
 	self assert: h size equals: 1.
@@ -50,7 +50,7 @@ HistoryNodeTest >> testOneGroup [
 	self assert: h size equals: 2.
 	self assert: (h at: 1) equals: i.
 	self assert: (c := h at: 2) isComposite.
-	self assert: c isEmpty.
+	self assertEmpty: c.
 	h addItem: (i2 := HistoryLeaf new).
 	self assert: h size equals: 2.
 	self assert: c size equals: 1.
@@ -62,9 +62,6 @@ HistoryNodeTest >> testOneGroup [
 	h closeGroup.
 	h addItem: (i4 := HistoryLeaf new).
 	self assert: h size equals: 3
-	
-	
-
 ]
 
 { #category : #tests }

--- a/src/System-Identification-Tests/GlobalIdentifierPersistenceTest.class.st
+++ b/src/System-Identification-Tests/GlobalIdentifierPersistenceTest.class.st
@@ -118,6 +118,7 @@ GlobalIdentifierPersistenceTest >> testLoad2 [
 { #category : #tests }
 GlobalIdentifierPersistenceTest >> testLoad3 [
 	"Load stored values."
+
 	| values loaded |
 	persistence checker: self newFalseChecker.
 	values := Dictionary new.
@@ -125,7 +126,7 @@ GlobalIdentifierPersistenceTest >> testLoad3 [
 	persistence save: values.
 	loaded := Dictionary new.
 	persistence load: loaded.
-	self assert: loaded isEmpty.
+	self assertEmpty: loaded
 ]
 
 { #category : #tests }

--- a/src/System-SessionManager-Tests/SessionErrorHandlingTest.class.st
+++ b/src/System-SessionManager-Tests/SessionErrorHandlingTest.class.st
@@ -46,19 +46,15 @@ SessionErrorHandlingTest >> testErrorCaughtAndDefferedIfExceptionSignaledAtStart
 { #category : #tests }
 SessionErrorHandlingTest >> testErrorCaughtIfExceptionSignaledAtShutdownWhenDefaultUiManagerActive [
 	"session errorHandler will be TestWorkingSession that will register caught errors"
+
 	manager register: (TestSessionHandler onShutdown: [ Halt now ]).
 
 	"ensure error handled"
-	self 
-		shouldnt: [ session stop: false ]
-		raise: Halt.
-	self
-		assert: session errorHandler errors size
-		equals: 1.
-	
+	self shouldnt: [ session stop: false ] raise: Halt.
+	self assert: session errorHandler errors size equals: 1.
+
 	"ensure no defered actions"
-	self assert:
-		(session instVarNamed: 'deferredStartupActions') isEmpty
+	self assertEmpty: (session instVarNamed: 'deferredStartupActions')
 ]
 
 { #category : #tests }
@@ -80,17 +76,13 @@ SessionErrorHandlingTest >> testErrorHandledIfExceptionSignaledAtShutdownWhenSta
 { #category : #tests }
 SessionErrorHandlingTest >> testErrorHandledIfExceptionSignaledAtStartupWhenDefaultUiManagerActive [
 	"session errorHandler will be TestWorkingSession that will register caught errors"
+
 	manager register: (TestSessionHandler onStartup: [ Halt now ]).
 
 	"ensure error handled"
-	self 
-		shouldnt: [ session start: false ]
-		raise: Halt.
-	self
-		assert: session errorHandler errors size
-		equals: 1.
-	
+	self shouldnt: [ session start: false ] raise: Halt.
+	self assert: session errorHandler errors size equals: 1.
+
 	"ensure no defered actions"
-	self assert:
-		(session instVarNamed: 'deferredStartupActions') isEmpty
+	self assertEmpty: (session instVarNamed: 'deferredStartupActions')
 ]

--- a/src/System-Settings-Tests/SettingsStonReaderTest.class.st
+++ b/src/System-Settings-Tests/SettingsStonReaderTest.class.st
@@ -26,7 +26,7 @@ SettingsStonReaderTest >> testBasic [
 
 { #category : #tests }
 SettingsStonReaderTest >> testEmptyStream [
-	self assert: reader stream contents isEmpty
+	self assertEmpty: reader stream contents
 ]
 
 { #category : #tests }

--- a/src/System-Settings-Tests/SettingsStonWriterTest.class.st
+++ b/src/System-Settings-Tests/SettingsStonWriterTest.class.st
@@ -37,7 +37,7 @@ SettingsStonWriterTest >> testBasic [
 { #category : #tests }
 SettingsStonWriterTest >> testEmptyStream [
 	fileStream flush.
-	self assert: fileReference contents isEmpty
+	self assertEmpty: fileReference contents
 ]
 
 { #category : #tests }

--- a/src/System-Settings-Tests/StoredSettingsMergerTest.class.st
+++ b/src/System-Settings-Tests/StoredSettingsMergerTest.class.st
@@ -18,7 +18,7 @@ StoredSettingsMergerTest >> setUp [
 
 { #category : #tests }
 StoredSettingsMergerTest >> testEmpty [
-	self assert: merger storedSettings isEmpty.
+	self assertEmpty: merger storedSettings
 ]
 
 { #category : #tests }

--- a/src/System-Settings-Tests/SystemSettingsPersistenceTest.class.st
+++ b/src/System-Settings-Tests/SystemSettingsPersistenceTest.class.st
@@ -64,11 +64,13 @@ SystemSettingsPersistenceTest >> testAccessibleRealValues [
 { #category : #tests }
 SystemSettingsPersistenceTest >> testAllStoredSettings [
 	"There is no preference file. It should not generate an error."
-	self assert: systemSettings allStoredSettings isEmpty.
-	systemSettings writeStream nextPutAll: 'random string'; close.
-	self assert: systemSettings fileReference contents equals: 'random string'.
-	self assert: systemSettings allStoredSettings isEmpty.
 
+	self assertEmpty: systemSettings allStoredSettings.
+	systemSettings writeStream
+		nextPutAll: 'random string';
+		close.
+	self assert: systemSettings fileReference contents equals: 'random string'.
+	self assertEmpty: systemSettings allStoredSettings
 ]
 
 { #category : #tests }

--- a/src/System-Support-Tests/MethodQueryTest.class.st
+++ b/src/System-Support-Tests/MethodQueryTest.class.st
@@ -10,12 +10,9 @@ Class {
 { #category : #tests }
 MethodQueryTest >> testReferencedClasses [
 	| refs |
-	
-	refs := (CompiledMethod>>#referencedClasses) referencedClasses.
-	self assert: refs isEmpty.
-	
+	refs := (CompiledMethod >> #referencedClasses) referencedClasses.
+	self assertEmpty: refs.
+
 	refs := thisContext method referencedClasses.
-	self assert: refs equals: { CompiledMethod }.
-	
-	
+	self assert: refs equals: {CompiledMethod}
 ]

--- a/src/System-Support-Tests/SmalltalkImageTest.class.st
+++ b/src/System-Support-Tests/SmalltalkImageTest.class.st
@@ -20,7 +20,7 @@ SmalltalkImageTest >> testExtractAllKinds [
 	self assert: (keys at: 3) equals: #ArgWithMinus2.
 	self assert: (extract at: #*) equals: (Array with: 'ArgWithoutMinus1').
 	self assert: (extract at: #ArgWithMinus1) equals: #('ArgWithoutMinus2' 'ArgWithoutMinus3').
-	self assert: (extract at: #ArgWithMinus2) isEmpty
+	self assertEmpty: (extract at: #ArgWithMinus2)
 ]
 
 { #category : #'tests-arguments' }
@@ -29,7 +29,7 @@ SmalltalkImageTest >> testExtractEmpty [
 	args := #().
 	extract := SmalltalkImage current extractMinusParametersFrom: args.
 	self assert: extract class equals: Dictionary.
-	self assert: extract isEmpty
+	self assertEmpty: extract
 ]
 
 { #category : #'tests-arguments' }
@@ -38,7 +38,7 @@ SmalltalkImageTest >> testExtractNil [
 	args := nil.
 	extract := SmalltalkImage current extractMinusParametersFrom: args.
 	self assert: extract class equals: Dictionary.
-	self assert: extract isEmpty
+	self assertEmpty: extract
 ]
 
 { #category : #'tests-arguments' }
@@ -60,7 +60,7 @@ SmalltalkImageTest >> testExtractOneArgWithMinus [
 	self assert: extract isDictionary.
 	self assert: extract size equals: 1.
 	self assert: (extract keys at: 1) equals: #ArgWithMinus.
-	self assert: (extract at: #ArgWithMinus) isEmpty
+	self assertEmpty: (extract at: #ArgWithMinus)
 ]
 
 { #category : #'tests-arguments' }
@@ -85,7 +85,7 @@ SmalltalkImageTest >> testExtractTwoArgsWithAndWithoutMinus [
 	self assert: (keys at: 1) equals: #*.
 	self assert: (keys at: 2) equals: #ArgWithMinus.
 	self assert: (extract at: #*) equals: (Array with: 'ArgWithoutMinus').
-	self assert: (extract at: #ArgWithMinus) isEmpty
+	self assertEmpty: (extract at: #ArgWithMinus)
 ]
 
 { #category : #testing }

--- a/src/System-Support-Tests/SystemDictionaryTest.class.st
+++ b/src/System-Support-Tests/SystemDictionaryTest.class.st
@@ -102,7 +102,8 @@ SystemDictionaryTest >> testSmalltalkSelfEvaluating [
 
 { #category : #tests }
 SystemDictionaryTest >> testUnCategorizedMethods [
-	| categories slips  |	categories := self categoriesForClass: self targetClass.
-	slips := categories select: [:each | each = #'as yet unclassified'].
-	self assert: slips isEmpty	
+	| categories slips |
+	categories := self categoriesForClass: self targetClass.
+	slips := categories select: [ :each | each = #'as yet unclassified' ].
+	self assertEmpty: slips
 ]

--- a/src/System-Support-Tests/SystemNavigationOnNewlyCreatedEnvironmentTest.class.st
+++ b/src/System-Support-Tests/SystemNavigationOnNewlyCreatedEnvironmentTest.class.st
@@ -26,36 +26,36 @@ SystemNavigationOnNewlyCreatedEnvironmentTest >> createSystemNavigationToTest [
 { #category : #tests }
 SystemNavigationOnNewlyCreatedEnvironmentTest >> testAllExistingProtocolsFor [
 	"refined from the superclass. Because in a created environment there is no existing protocols."
-	
-	| instSideProtocols classSideProtocols |
-	instSideProtocols := self systemNavigationToTest allExistingProtocolsFor: true. 
-	classSideProtocols := self systemNavigationToTest allExistingProtocolsFor: false.
-	self assert: instSideProtocols isEmpty.	
-	self assert: classSideProtocols isEmpty.
 
+	| instSideProtocols classSideProtocols |
+	instSideProtocols := self systemNavigationToTest allExistingProtocolsFor: true.
+	classSideProtocols := self systemNavigationToTest allExistingProtocolsFor: false.
+	self assertEmpty: instSideProtocols.
+	self assertEmpty: classSideProtocols
 ]
 
 { #category : #tests }
 SystemNavigationOnNewlyCreatedEnvironmentTest >> testAllReferencesToPool [
 	| result |
-	
 	result := self systemNavigationToTest allReferencesToPool: FooSharedPool.
-	self assert: result isEmpty. "FooSharedPool is not in this environment"
+	self assertEmpty: result	"FooSharedPool is not in this environment"
 ]
 
 { #category : #tests }
 SystemNavigationOnNewlyCreatedEnvironmentTest >> testEnsureDefaultEnvironmentNotUsed [
-	
 	| allClasses originalProtoObjectClass originalObjectClass anotherObjectClass |
 	allClasses := self systemNavigationToTest allClasses.
-	self assert: allClasses isEmpty.
-	originalProtoObjectClass := Smalltalk globals at: #ProtoObject.		
+	self assertEmpty: allClasses.
+	originalProtoObjectClass := Smalltalk globals at: #ProtoObject.
 	originalObjectClass := Smalltalk globals at: #Object.
-	
-	DangerousClassNotifier disableDuring: [
-		anotherObjectClass := self classFactory newClassNamed: #Object subclassOf: originalProtoObjectClass instanceVariableNames: '' classVariableNames:  'DependentsFields'].
-	
-	self assert: ((self environmentToTest at: #Object) = anotherObjectClass).
-	self assert: ((Smalltalk globals at: #Object) = originalObjectClass).
-	
+
+	DangerousClassNotifier
+		disableDuring: [ anotherObjectClass := self classFactory
+				newClassNamed: #Object
+				subclassOf: originalProtoObjectClass
+				instanceVariableNames: ''
+				classVariableNames: 'DependentsFields' ].
+
+	self assert: (self environmentToTest at: #Object) = anotherObjectClass.
+	self assert: (Smalltalk globals at: #Object) = originalObjectClass
 ]

--- a/src/System-Support-Tests/SystemNavigationTest.class.st
+++ b/src/System-Support-Tests/SystemNavigationTest.class.st
@@ -185,16 +185,12 @@ SystemNavigationTest >> testIsUnsentMessage [
 { #category : #testing }
 SystemNavigationTest >> testRetrievingCategoriesInAPackage [
 	| retrievedCategories |
-	
-	#(#CategoryForTest #'CategoryForTest-Core' #'CategoryForTest-Tests' #CategoryForTest #ForTestCategory #'ForTestCategory-Core') do: [ :catName | 
-		self classFactory newClassInCategory: catName].
-	
+	#(#CategoryForTest #'CategoryForTest-Core' #'CategoryForTest-Tests' #CategoryForTest #ForTestCategory #'ForTestCategory-Core') do: [ :catName | self classFactory newClassInCategory: catName ].
+
 	retrievedCategories := self systemNavigationToTest categoriesInPackageNamed: 'CategoryForTest'.
-	self
-		assert: (retrievedCategories includesAll: #(#CategoryForTest #'CategoryForTest-Core' #'CategoryForTest-Tests' )).
+	self assert: (retrievedCategories includesAll: #(#CategoryForTest #'CategoryForTest-Core' #'CategoryForTest-Tests')).
 	retrievedCategories := self systemNavigationToTest categoriesInPackageNamed: 'CategoryForTest-Core'.
-	self
-		assert: (retrievedCategories includesAll: #(#'CategoryForTest-Core')). 
+	self assert: (retrievedCategories includesAll: #(#'CategoryForTest-Core')).
 	retrievedCategories := self systemNavigationToTest categoriesInPackageNamed: 'CategoryFor'.
-	self assert: retrievedCategories isEmpty.
+	self assertEmpty: retrievedCategories
 ]

--- a/src/System-Support-Tests/SystemVersionTest.class.st
+++ b/src/System-Support-Tests/SystemVersionTest.class.st
@@ -54,72 +54,77 @@ SystemVersionTest >> testDottedMajorMinorPatch [
 
 { #category : #'tests - instance creation' }
 SystemVersionTest >> testInstanceCreation [
-
 	| version |
-	version := (SystemVersion new).
-	self 
+	version := SystemVersion new.
+	self
 		assert: version type equals: 'Pharo';
 		assert: version major equals: 0;
 		assert: version minor equals: 0;
-		assert: version suffix isEmpty;
-		assert: version build equals: SystemVersion invalidBuildNumber;	
-		assert: version commitHash isEmpty;
-		assert: version commitHashShort isEmpty;
-		assert: version commitHashShort isEmpty;		
+		assertEmpty: version suffix;
+		assert: version build equals: SystemVersion invalidBuildNumber;
+		assertEmpty: version commitHash;
+		assertEmpty: version commitHashShort;
+		assertEmpty: version commitHashShort;
 		assert: version date notNil;
 		assert: (version printString beginsWith: 'Pharo-0.0')
 ]
 
 { #category : #'tests - instance creation' }
 SystemVersionTest >> testInstanceCreationMajorMinor [
-
 	| version |
-	version := (SystemVersion major: 6 minor: 1 patch: 199).
-	self 
+	version := SystemVersion major: 6 minor: 1 patch: 199.
+	self
 		assert: version type equals: 'Pharo';
 		assert: version major equals: 6;
 		assert: version minor equals: 1;
 		assert: version patch equals: 199;
-		assert: version suffix isEmpty;
+		assertEmpty: version suffix;
 		assert: version build equals: SystemVersion invalidBuildNumber;
-		assert: version commitHash isEmpty;
-		assert: version commitHashShort isEmpty;		
+		assertEmpty: version commitHash;
+		assertEmpty: version commitHashShort;
 		assert: version date notNil;
 		assert: (version printString beginsWith: 'Pharo-6.1.199')
 ]
 
 { #category : #'tests - instance creation' }
 SystemVersionTest >> testInstanceCreationMajorMinorSuffix [
-
 	| version |
-	version := (SystemVersion major: 7 minor: 0 patch: 199 suffix: 'alpha').
-	self 
+	version := SystemVersion
+		major: 7
+		minor: 0
+		patch: 199
+		suffix: 'alpha'.
+	self
 		assert: version type equals: 'Pharo';
 		assert: version major equals: 7;
 		assert: version minor equals: 0;
 		assert: version patch equals: 199;
 		assert: version suffix equals: 'alpha';
 		assert: version build equals: SystemVersion invalidBuildNumber;
-		assert: version commitHash isEmpty;
-		assert: version commitHashShort isEmpty;		
+		assertEmpty: version commitHash;
+		assertEmpty: version commitHashShort;
 		assert: version date notNil;
 		assert: (version printString beginsWith: 'Pharo-7.0.199+alpha')
 ]
 
 { #category : #'tests - instance creation' }
 SystemVersionTest >> testInstanceCreationMajorMinorSuffixBuild [
-
 	| version |
-	version := (SystemVersion major: 7 minor: 0 patch: 199 suffix: 'alpha' build: 142).
-	self 
-		assert: version type equals: 'Pharo';	
+	version := SystemVersion
+		major: 7
+		minor: 0
+		patch: 199
+		suffix: 'alpha'
+		build: 142.
+	self
+		assert: version type equals: 'Pharo';
 		assert: version major equals: 7;
 		assert: version minor equals: 0;
 		assert: version patch equals: 199;
 		assert: version suffix equals: 'alpha';
 		assert: version build equals: 142;
-		assert: version commitHash isEmpty;
-		assert: version commitHashShort isEmpty;		
+		assertEmpty: version commitHash;
+		assertEmpty: version commitHashShort;
 		assert: version date notNil;
 		assert: (version printString beginsWith: 'Pharo-7.0.199+alpha.build.142')
 ]
@@ -144,19 +149,23 @@ SystemVersionTest >> testInstanceCreationMajorMinorSuffixBuildCommitHash [
 
 { #category : #'tests - instance creation' }
 SystemVersionTest >> testInstanceCreationMajorMinorSuffixBuildWithoutSuffix [
-
 	| version |
-	version := (SystemVersion major: 7 minor: 0 patch: 199 suffix: '' build: 142).
-	self 
-		assert: version type equals: 'Pharo';	
+	version := SystemVersion
+		major: 7
+		minor: 0
+		patch: 199
+		suffix: ''
+		build: 142.
+	self
+		assert: version type equals: 'Pharo';
 		assert: version major equals: 7;
 		assert: version minor equals: 0;
 		assert: version patch equals: 199;
-		assert: version suffix isEmpty;
+		assertEmpty: version suffix;
 		assert: version build equals: 142;
-		assert: version commitHash isEmpty;
-		assert: version commitHashShort isEmpty;
-		assert: version date notNil;		
+		assertEmpty: version commitHash;
+		assertEmpty: version commitHashShort;
+		assert: version date notNil;
 		assert: (version printString beginsWith: 'Pharo-7.0.199+build.142')
 ]
 

--- a/src/Tests/ClassTraitTest.class.st
+++ b/src/Tests/ClassTraitTest.class.st
@@ -94,5 +94,5 @@ ClassTraitTest >> testUsers [
 	self assert: self t5 classSide traitUsers size = 1.
 	self assert: self t5 classSide traitUsers anyOne = self c2 class.
 	self c2 setTraitComposition: self t2 asTraitComposition.
-	self assert: self t5 classSide traitUsers isEmpty
+	self assertEmpty: self t5 classSide traitUsers
 ]

--- a/src/Tests/EphemeronTests.class.st
+++ b/src/Tests/EphemeronTests.class.st
@@ -42,21 +42,20 @@ EphemeronTests >> testEphemeronIsNotRemovedFromRegistryUponFinalizationIfKeyIsRe
 
 { #category : #tests }
 EphemeronTests >> testEphemeronIsRemovedFromRegistryUponFinalization [
-
 	| finalized theKey registry |
 	Smalltalk supportsQueueingFinalization ifFalse: [ ^ self skip ].
 
 	finalized := false.
 	theKey := ObjectFinalizer receiver: [ finalized := true ] selector: #value.
-	
+
 	registry := EphemeronRegistry new.
 	registry at: theKey put: nil.
-		
+
 	"Nil theKey to remove all strong references to it. Then Garbage collect to force mourning"
 	theKey := nil.
 	Smalltalk garbageCollect.
-	
-	self assert: registry isEmpty.
+
+	self assertEmpty: registry
 ]
 
 { #category : #tests }

--- a/src/Tests/EventManagerTest.class.st
+++ b/src/Tests/EventManagerTest.class.st
@@ -94,8 +94,8 @@ EventManagerTest >> testCopy [
 	you make a copy of anEventManager"
 
 	eventSource when: #blah send: #yourself to: eventListener.
-	self assert: eventSource actionMap keys isEmpty not.
-	self assert: eventSource copy actionMap keys isEmpty
+	self denyEmpty: eventSource actionMap keys.
+	self assertEmpty: eventSource copy actionMap keys
 ]
 
 { #category : #'running-broadcast query' }

--- a/src/Tests/OSEnvironmentTest.class.st
+++ b/src/Tests/OSEnvironmentTest.class.st
@@ -21,9 +21,9 @@ OSEnvironmentTest >> testAsDictionary [
 OSEnvironmentTest >> testAssociations [
 	| associations |
 	associations := self instance associations.
-	self deny: associations isEmpty.
+	self denyEmpty: associations.
 	self assert: associations anyOne key isString.
-	self assert: associations anyOne value isString.
+	self assert: associations anyOne value isString
 ]
 
 { #category : #tests }
@@ -67,11 +67,10 @@ OSEnvironmentTest >> testEnvironmentFor [
 { #category : #tests }
 OSEnvironmentTest >> testKeys [
 	| env keys |
-	
 	env := self instance.
 	keys := env keys.
-	
-	self deny: keys isEmpty.
+
+	self denyEmpty: keys.
 	self assert: keys anyOne isString.
 	self assert: (env includesKey: keys anyOne)
 ]
@@ -79,11 +78,10 @@ OSEnvironmentTest >> testKeys [
 { #category : #tests }
 OSEnvironmentTest >> testValues [
 	| env values |
-	
 	env := self instance.
 	values := env values.
-	
-	self deny: values isEmpty.
+
+	self denyEmpty: values.
 	self assert: values anyOne isString.
 	self assert: (env includes: values anyOne)
 ]

--- a/src/Tests/TraitCompositionTest.class.st
+++ b/src/Tests/TraitCompositionTest.class.st
@@ -79,9 +79,9 @@ TraitCompositionTest >> testCompositionFromArray [
 TraitCompositionTest >> testEmptyTrait [
 	| composition |
 	composition := {} asTraitComposition.
-	
-	self assert: composition isEmpty.
-	self assert: composition traits isEmpty
+
+	self assertEmpty: composition.
+	self assertEmpty: composition traits
 ]
 
 { #category : #'testing-basic' }

--- a/src/Tests/TraitPureBehaviorTest.class.st
+++ b/src/Tests/TraitPureBehaviorTest.class.st
@@ -344,8 +344,7 @@ TraitPureBehaviorTest >> testTraitCompositionWithCycles [
 
 { #category : #testing }
 TraitPureBehaviorTest >> testTraitsAccessor [
-	
-	self assert: self c1 traits isEmpty.
+	self assertEmpty: self c1 traits.
 	self assert: (self c2 traits hasEqualElements: (Array with: self t5))
 ]
 

--- a/src/Tests/TraitTest.class.st
+++ b/src/Tests/TraitTest.class.st
@@ -52,9 +52,8 @@ TraitTest >> testAddAndRemoveMethodsInClassOrTrait [
 ]
 
 { #category : #testing }
-TraitTest >> testAllClassVarNames [	
-	
-	self assert: self t1 allClassVarNames isEmpty
+TraitTest >> testAllClassVarNames [
+	self assertEmpty: self t1 allClassVarNames
 ]
 
 { #category : #testing }
@@ -388,19 +387,16 @@ TraitTest >> testTraitCompositionRespectsParenthesis [
 TraitTest >> testTraitRemoval [
 	self flag: #fix.	"It has to be refactored when Mariano's ClassBuilder for testCase is integrated :)"
 	SystemAnnouncer uniqueInstance
-		suspendAllWhile: [ 
-			| aClass aTrait |
-			[ 
-			aTrait := self createTrait.
+		suspendAllWhile: [ | aClass aTrait |
+			[ aTrait := self createTrait.
 			aClass := self createClassUsing: aTrait.
-			self assert: aClass localSelectors isEmpty.
+			self assertEmpty: aClass localSelectors.
 			aClass removeFromComposition: aTrait.
-			self assert: aClass localSelectors isEmpty.
-			self assert: aClass organization allMethodSelectors isEmpty.
+			self assertEmpty: aClass localSelectors.
+			self assertEmpty: aClass organization allMethodSelectors.
 			self deny: aClass hasTraitComposition.
-			self deny: (aTrait traitUsers includes: aClass). ]
-				ensure: [ 
-					aClass removeFromSystem: false.
+			self deny: (aTrait traitUsers includes: aClass) ]
+				ensure: [ aClass removeFromSystem: false.
 					aTrait removeFromSystem: false ] ]
 ]
 
@@ -426,15 +422,15 @@ TraitTest >> testTraitsUsersSanity [
 { #category : #testing }
 TraitTest >> testUsers [
 	self assert: self t1 traitUsers size = 3.
-	self assert: (self t1 traitUsers includesAll: {self t4. self t5. self t6 }).
-	self assert: self t3 traitUsers isEmpty.
+	self assert: (self t1 traitUsers includesAll: {self t4 . self t5 . self t6}).
+	self assertEmpty: self t3 traitUsers.
 	self assert: self t5 traitUsers size = 1.
 	self assert: self t5 traitUsers anyOne = self c2.
 	self c2 setTraitComposition: self t1 + self t5.
 	self assert: self t5 traitUsers size = 1.
 	self assert: self t5 traitUsers anyOne = self c2.
 	self c2 setTraitComposition: self t2 asTraitComposition.
-	self assert: self t5 traitUsers isEmpty
+	self assertEmpty: self t5 traitUsers
 ]
 
 { #category : #testing }

--- a/src/Text-Tests/RunArrayTest.class.st
+++ b/src/Text-Tests/RunArrayTest.class.st
@@ -9,11 +9,7 @@ Class {
 
 { #category : #'tests - instance creation' }
 RunArrayTest >> testANewRunArrayIsEmpty [
-
-	| t |
-	t := RunArray new.
-	self assert: t isEmpty 
-
+	self assertEmpty: RunArray new
 ]
 
 { #category : #'tests - accessing' }

--- a/src/Tool-DependencyAnalyser-Tests/DAPackageCycleDetectorTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAPackageCycleDetectorTest.class.st
@@ -152,8 +152,8 @@ DAPackageCycleDetectorTest >> testDequeue [
 	| dequeue |
 	aPackageCycleDetection initializeQueueWith: packageA.
 	dequeue := aPackageCycleDetection dequeue.
-	self assert: (dequeue = packageA).
-	self assert: self queue isEmpty
+	self assert: dequeue equals: packageA.
+	self assertEmpty: self queue
 ]
 
 { #category : #tests }
@@ -218,7 +218,7 @@ DAPackageCycleDetectorTest >> testReset [
 	aPackageCycleDetection findCycles: aPDPackageRelation.
 	self assert: aPackageCycleDetection cycles size = 3.
 	aPackageCycleDetection reset.
-	self assert: aPackageCycleDetection cycles isEmpty
+	self assertEmpty: aPackageCycleDetection cycles
 ]
 
 { #category : #tests }

--- a/src/Tool-DependencyAnalyser-Tests/DAPackageRelationGraphDiffTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAPackageRelationGraphDiffTest.class.st
@@ -60,9 +60,7 @@ DAPackageRelationGraphDiffTest >> testHasChangedForPackageItemDiffOnOneDependent
 { #category : #running }
 DAPackageRelationGraphDiffTest >> testMakeDependentPackagesDiffOnSameGraph [
 	packageRelationGraphDiff makePackagesDiff.
-		
-	self assert: packageRelationGraphDiff dependentPackagesDiff isEmpty
-	
+	self assertEmpty: packageRelationGraphDiff dependentPackagesDiff
 ]
 
 { #category : #running }
@@ -122,11 +120,8 @@ DAPackageRelationGraphDiffTest >> testPackagesDiffToDisplayBis [
 
 { #category : #running }
 DAPackageRelationGraphDiffTest >> testPackagesDiffToDisplayOnSameGraph [
-	
 	packageRelationGraphDiff make.
-			
-	self assert: (packageRelationGraphDiff packagesDiffToDisplay isEmpty).
-
+	self assertEmpty: packageRelationGraphDiff packagesDiffToDisplay
 ]
 
 { #category : #running }

--- a/src/Tool-DependencyAnalyser-Tests/DAPackageRelationGraphTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAPackageRelationGraphTest.class.st
@@ -163,8 +163,8 @@ DAPackageRelationGraphTest >> testDependenciesFrom [
 	(aCollection at: 1) add: (DAPackageDependency from: packageA to: packageC).
 	(aCollection at: 2) add: (DAPackageDependency from: packageB to: packageC).
 	aCollection do: [ :package | aPackageRelationGraph addPackage: package ].
-	self assert: ((aPackageRelationGraph dependenciesFrom: 'A') size equals: 2).
-	self assert: ((aPackageRelationGraph dependenciesFrom: 'B') size equals: 1).
+	self assert: (aPackageRelationGraph dependenciesFrom: 'A') size equals: 2.
+	self assert: (aPackageRelationGraph dependenciesFrom: 'B') size equals: 1.
 	self assertEmpty: (aPackageRelationGraph dependenciesFrom: 'C')
 ]
 
@@ -194,7 +194,7 @@ DAPackageRelationGraphTest >> testPackages [
 	aCollection add: packagePackageDependencies.
 	aCollection add: packageKernel.
 	aCollection do: [ :each | aPackageRelationGraph addPackage: each ].
-	self assert: (aPackageRelationGraph packages size equals: 2)
+	self assert: aPackageRelationGraph packages size equals: 2
 ]
 
 { #category : #tests }
@@ -218,10 +218,10 @@ DAPackageRelationGraphTest >> testPredecessors [
 	packageB add: (DAPackageDependency from: packageB to: packageC).
 	packageB add: (DAPackageDependency from: packageB to: packageD).
 	aCollection do: [ :package | aPackageRelationGraph addPackage: package ].
-	self assert: ((aPackageRelationGraph predecessors: packageC) size equals: 2).
+	self assert: (aPackageRelationGraph predecessors: packageC) size equals: 2.
 	self assertEmpty: (aPackageRelationGraph predecessors: (aCollection at: 1)).
-	self assert: ((aPackageRelationGraph predecessors: packageB) size equals: 1).
-	self assert: ((aPackageRelationGraph predecessors: packageD) size equals: 2)
+	self assert: (aPackageRelationGraph predecessors: packageB) size equals: 1.
+	self assert: (aPackageRelationGraph predecessors: packageD) size equals: 2
 ]
 
 { #category : #tests }
@@ -263,7 +263,7 @@ DAPackageRelationGraphTest >> testSeenPackages [
 	aPackageRelationGraph addPackage: packageCollectionAbstract.
 	self assertEmpty: aPackageRelationGraph seenPackages.
 	aPackageRelationGraph computeStaticDependencies.
-	self assert: (aPackageRelationGraph seenPackages size equals: 2)
+	self assert: aPackageRelationGraph seenPackages size equals: 2
 ]
 
 { #category : #tests }
@@ -289,9 +289,9 @@ DAPackageRelationGraphTest >> testSuccessors [
 	packageB add: (DAPackageDependency from: packageB to: packageC).
 	packageB add: (DAPackageDependency from: packageB to: packageD).
 	aCollection do: [ :package | aPackageRelationGraph addPackage: package ].
-	self assert: ((aPackageRelationGraph successors: (aCollection at: 1)) size equals: 3).
+	self assert: (aPackageRelationGraph successors: (aCollection at: 1)) size equals: 3.
 	self assertEmpty: (aPackageRelationGraph successors: (aCollection at: 4)).
-	self assert: ((aPackageRelationGraph successors: (aCollection at: 2)) size equals: 2).
+	self assert: (aPackageRelationGraph successors: (aCollection at: 2)) size equals: 2.
 	self assertEmpty: (aPackageRelationGraph successors: (aCollection at: 3))
 ]
 

--- a/src/Tool-DependencyAnalyser-Tests/DAPackageRelationGraphTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAPackageRelationGraphTest.class.st
@@ -59,20 +59,20 @@ DAPackageRelationGraphTest >> testAddInheritanceDependencies [
 
 { #category : #tests }
 DAPackageRelationGraphTest >> testAddPackage [
-	self assert: aPackageRelationGraph packages isEmpty.
+	self assertEmpty: aPackageRelationGraph packages.
 	aPackageRelationGraph addPackage: packageCollectionAbstract.
 	self assert: aPackageRelationGraph packages size = 1.
 	aPackageRelationGraph addPackage: packageCollectionsSequenceable.
-	self assert: aPackageRelationGraph packages size = 2.
+	self assert: aPackageRelationGraph packages size = 2
 ]
 
 { #category : #tests }
 DAPackageRelationGraphTest >> testAddPackages [
 	| array |
-	self assert: aPackageRelationGraph packages isEmpty.
+	self assertEmpty: aPackageRelationGraph packages.
 	array := Array with: packageCollectionAbstract with: packageCollectionsSequenceable with: packageKernel.
 	aPackageRelationGraph addPackages: array.
-	self assert: aPackageRelationGraph packages size = 3
+	self assert: aPackageRelationGraph packages size equals: 3
 ]
 
 { #category : #tests }
@@ -159,13 +159,13 @@ DAPackageRelationGraphTest >> testDependenciesFrom [
 	aCollection add: packageA.
 	aCollection add: packageB.
 	aCollection add: packageC.
-	(aCollection at:1) add: (DAPackageDependency from: packageA to: packageB).
-	(aCollection at:1) add: (DAPackageDependency from:packageA to: packageC).
-	(aCollection at:2) add: (DAPackageDependency from: packageB to: packageC).
+	(aCollection at: 1) add: (DAPackageDependency from: packageA to: packageB).
+	(aCollection at: 1) add: (DAPackageDependency from: packageA to: packageC).
+	(aCollection at: 2) add: (DAPackageDependency from: packageB to: packageC).
 	aCollection do: [ :package | aPackageRelationGraph addPackage: package ].
-	self assert: ((aPackageRelationGraph dependenciesFrom:'A') size = 2).
-	self assert: ((aPackageRelationGraph dependenciesFrom:'B') size = 1).
-	self assert: ((aPackageRelationGraph dependenciesFrom:'C') isEmpty).
+	self assert: ((aPackageRelationGraph dependenciesFrom: 'A') size equals: 2).
+	self assert: ((aPackageRelationGraph dependenciesFrom: 'B') size equals: 1).
+	self assertEmpty: (aPackageRelationGraph dependenciesFrom: 'C')
 ]
 
 { #category : #tests }
@@ -189,12 +189,12 @@ DAPackageRelationGraphTest >> testPackageAt [
 { #category : #tests }
 DAPackageRelationGraphTest >> testPackages [
 	| aCollection |
-	self assert: aPackageRelationGraph packages isEmpty.
+	self assertEmpty: aPackageRelationGraph packages.
 	aCollection := Bag new.
 	aCollection add: packagePackageDependencies.
 	aCollection add: packageKernel.
-	aCollection do: [ :each | aPackageRelationGraph addPackage: each].
-	self assert: (aPackageRelationGraph packages size = 2)
+	aCollection do: [ :each | aPackageRelationGraph addPackage: each ].
+	self assert: (aPackageRelationGraph packages size equals: 2)
 ]
 
 { #category : #tests }
@@ -212,16 +212,16 @@ DAPackageRelationGraphTest >> testPredecessors [
 	aCollection add: packageB.
 	aCollection add: packageC.
 	aCollection add: packageD.
-	packageA add: (DAPackageDependency from:packageA to: packageB).
-	packageA add: (DAPackageDependency from:packageA to: packageC).
-	packageA add: (DAPackageDependency from:packageA to: packageD).
-	packageB add: (DAPackageDependency from:packageB to: packageC).
-	packageB add: (DAPackageDependency from:packageB to: packageD).
+	packageA add: (DAPackageDependency from: packageA to: packageB).
+	packageA add: (DAPackageDependency from: packageA to: packageC).
+	packageA add: (DAPackageDependency from: packageA to: packageD).
+	packageB add: (DAPackageDependency from: packageB to: packageC).
+	packageB add: (DAPackageDependency from: packageB to: packageD).
 	aCollection do: [ :package | aPackageRelationGraph addPackage: package ].
-	self assert: ((aPackageRelationGraph predecessors: packageC) size = 2).
-	self assert: ((aPackageRelationGraph predecessors: (aCollection at: 1)) isEmpty).
-	self assert: ((aPackageRelationGraph predecessors: packageB) size = 1).
-	self assert: ((aPackageRelationGraph predecessors: packageD) size = 2).
+	self assert: ((aPackageRelationGraph predecessors: packageC) size equals: 2).
+	self assertEmpty: (aPackageRelationGraph predecessors: (aCollection at: 1)).
+	self assert: ((aPackageRelationGraph predecessors: packageB) size equals: 1).
+	self assert: ((aPackageRelationGraph predecessors: packageD) size equals: 2)
 ]
 
 { #category : #tests }
@@ -250,20 +250,20 @@ DAPackageRelationGraphTest >> testRemoveOutgoingDependencies [
 
 { #category : #tests }
 DAPackageRelationGraphTest >> testRemovePackage [
-	self assert: aPackageRelationGraph packages isEmpty.
+	self assertEmpty: aPackageRelationGraph packages.
 	aPackageRelationGraph addPackage: packageCollectionAbstract.
-	self assert: aPackageRelationGraph packages size = 1.
+	self assert: aPackageRelationGraph packages size equals: 1.
 	aPackageRelationGraph removePackage: packageCollectionAbstract packageName.
-	self assert: aPackageRelationGraph packages isEmpty
+	self assertEmpty: aPackageRelationGraph packages
 ]
 
 { #category : #tests }
 DAPackageRelationGraphTest >> testSeenPackages [
 	aPackageRelationGraph addPackage: packageKernel.
 	aPackageRelationGraph addPackage: packageCollectionAbstract.
-	self assert: (aPackageRelationGraph seenPackages isEmpty).
+	self assertEmpty: aPackageRelationGraph seenPackages.
 	aPackageRelationGraph computeStaticDependencies.
-	self assert: (aPackageRelationGraph seenPackages size = 2).
+	self assert: (aPackageRelationGraph seenPackages size equals: 2)
 ]
 
 { #category : #tests }
@@ -283,16 +283,16 @@ DAPackageRelationGraphTest >> testSuccessors [
 	aCollection add: packageB.
 	aCollection add: packageC.
 	aCollection add: packageD.
-	packageA add: (DAPackageDependency from:packageA to: packageB).
-	packageA add: (DAPackageDependency from:packageA to: packageC).
-	packageA add: (DAPackageDependency from:packageA to: packageD).
-	packageB add: (DAPackageDependency from:packageB to: packageC).
-	packageB add: (DAPackageDependency from:packageB to: packageD).
+	packageA add: (DAPackageDependency from: packageA to: packageB).
+	packageA add: (DAPackageDependency from: packageA to: packageC).
+	packageA add: (DAPackageDependency from: packageA to: packageD).
+	packageB add: (DAPackageDependency from: packageB to: packageC).
+	packageB add: (DAPackageDependency from: packageB to: packageD).
 	aCollection do: [ :package | aPackageRelationGraph addPackage: package ].
-	self assert: ((aPackageRelationGraph successors: (aCollection at: 1)) size = 3).
-	self assert: ((aPackageRelationGraph successors: (aCollection at: 4)) isEmpty).
-	self assert: ((aPackageRelationGraph successors: (aCollection at: 2)) size = 2).
-	self assert: ((aPackageRelationGraph successors: (aCollection at: 3)) isEmpty).
+	self assert: ((aPackageRelationGraph successors: (aCollection at: 1)) size equals: 3).
+	self assertEmpty: (aPackageRelationGraph successors: (aCollection at: 4)).
+	self assert: ((aPackageRelationGraph successors: (aCollection at: 2)) size equals: 2).
+	self assertEmpty: (aPackageRelationGraph successors: (aCollection at: 3))
 ]
 
 { #category : #tests }

--- a/src/Tool-DependencyAnalyser-Tests/DAPackageTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAPackageTest.class.st
@@ -41,7 +41,7 @@ DAPackageTest >> testBeIncluded [
 { #category : #tests }
 DAPackageTest >> testCleardependencies [
 	aPackage clearDependencies.
-	self assert: (aPackage dependencies isEmpty)
+	self assertEmpty: aPackage dependencies
 ]
 
 { #category : #tests }
@@ -101,15 +101,15 @@ DAPackageTest >> testDependenciesSizeTo [
 
 { #category : #tests }
 DAPackageTest >> testDependenciesTo [
-	self assert: (aPackage dependenciesTo: aSecondPackage packageName) size = 1.
-	self assert: (aPackage dependenciesTo: 'Test') isEmpty
+	self assert: (aPackage dependenciesTo: aSecondPackage packageName) size equals: 1.
+	self assertEmpty: (aPackage dependenciesTo: 'Test')
 ]
 
 { #category : #tests }
 DAPackageTest >> testDependentPackages [
-	self assert: (aPackage dependentPackages size = 1).
+	self assert: aPackage dependentPackages size equals: 1.
 	self assert: (aPackage dependentPackages anySatisfy: [ :package | package = aSecondPackage ]).
-	self assert: (aSecondPackage dependentPackages isEmpty)
+	self assertEmpty: aSecondPackage dependentPackages
 ]
 
 { #category : #tests }
@@ -153,8 +153,8 @@ DAPackageTest >> testReferenceDependenciesFrom [
 { #category : #tests }
 DAPackageTest >> testRemoveAllInternal [
 	aPackage clearDependencies.
-	aPackage add: (DAPackageDependency from:aPackage to:aPackage).
-	aPackage add: (DAPackageDependency from:aSecondPackage to:aSecondPackage).
+	aPackage add: (DAPackageDependency from: aPackage to: aPackage).
+	aPackage add: (DAPackageDependency from: aSecondPackage to: aSecondPackage).
 	aPackage removeAllInternal.
-	self assert: (aPackage dependencies isEmpty)
+	self assertEmpty: aPackage dependencies
 ]

--- a/src/Tools-Test/AndreasSystemProfilerTest.class.st
+++ b/src/Tools-Test/AndreasSystemProfilerTest.class.st
@@ -81,7 +81,7 @@ AndreasSystemProfilerTest >> testTallyTreePrint [
 		orThreshold: 1.
 	
 	"Nothing is printed since there is no tab"
-	self assert: stream contents isEmpty
+	self assertEmpty: stream contents
 ]
 
 { #category : #'tests tally' }

--- a/src/Tools-Test/TextDiffBuilderTest.class.st
+++ b/src/Tools-Test/TextDiffBuilderTest.class.st
@@ -55,10 +55,9 @@ TextDiffBuilderTest >> testEmptyLcs3 [
 
 { #category : #tests }
 TextDiffBuilderTest >> testEmptySequences [
-
 	| patch |
 	patch := self patchSequenceFor: #() and: #().
-	self assert: patch isEmpty
+	self assertEmpty: patch
 ]
 
 { #category : #tests }

--- a/src/Tools-Test/WorkspaceTest.class.st
+++ b/src/Tools-Test/WorkspaceTest.class.st
@@ -9,6 +9,5 @@ Class {
 
 { #category : #tests }
 WorkspaceTest >> testEmptyContent [
-
-	self assert: (Workspace new contents isEmpty)
+	self assertEmpty: Workspace new contents
 ]

--- a/src/TraitsV2-Tests/T2ObsoleteClassTest.class.st
+++ b/src/TraitsV2-Tests/T2ObsoleteClassTest.class.st
@@ -55,7 +55,7 @@ T2ObsoleteClassTest >> testObsoleteClassRemovesMethods [
 	t2 := self newTrait: #T2 with: #() uses: {}.
 	t2 compile: 'm2 ^ 1'.
 
-	c1 := self newClass: #C1 with: #()  uses:  t1 + t2.
+	c1 := self newClass: #C1 with: #() uses: t1 + t2.
 
 	c1 compile: 'localM1 ^ 1'.
 
@@ -64,19 +64,18 @@ T2ObsoleteClassTest >> testObsoleteClassRemovesMethods [
 	self deny: (c1 localMethodDict includesKey: #m1).
 	self deny: (c1 localMethodDict includesKey: #m2).
 	self assert: (c1 localMethodDict includesKey: #localM1).
-	
+
 	c1 removeFromSystem.
 	createdClasses remove: c1.
-	
+
 	self deny: (c1 methodDict includesKey: #m1).
 	self deny: (c1 methodDict includesKey: #m2).
-	
+
 	"Accessing directly because there is no more accesor method"
-	self assert: (c1 class instVarNamed: #baseLocalMethods) isEmpty.
+	self assertEmpty: (c1 class instVarNamed: #baseLocalMethods).
 	self deny: ((c1 class instVarNamed: #baseLocalMethods) includesKey: #m1).
 	self deny: ((c1 class instVarNamed: #baseLocalMethods) includesKey: #m2).
-	self deny: ((c1 class instVarNamed: #baseLocalMethods) includesKey: #localM1).
-
+	self deny: ((c1 class instVarNamed: #baseLocalMethods) includesKey: #localM1)
 ]
 
 { #category : #tests }

--- a/src/TraitsV2-Tests/T2UsingTraitsWithSlotsTest.class.st
+++ b/src/TraitsV2-Tests/T2UsingTraitsWithSlotsTest.class.st
@@ -6,19 +6,16 @@ Class {
 
 { #category : #tests }
 T2UsingTraitsWithSlotsTest >> testRedefinitionKeepsSlots [
-
 	| t1 c1 |
-	
-	t1 := self newTrait: #T1 with:  #(a b c).
+	t1 := self newTrait: #T1 with: #(a b c).
 	t1 classTrait slots: #(aSlot).
-	c1 := self newClass: #C1 with: { } uses: { t1 }.
-	
-	self assert: c1 localSlots isEmpty.	
-	self assert: c1 class localSlots isEmpty.
+	c1 := self newClass: #C1 with: {} uses: {t1}.
+
+	self assertEmpty: c1 localSlots.
+	self assertEmpty: c1 class localSlots.
 
 	c1 addSlot: #d.
 
-	self assertCollection: (c1 localSlots collect: #name) hasSameElements: { #d }.	
-	self assert: c1 class localSlots isEmpty.
-	
+	self assertCollection: (c1 localSlots collect: #name) hasSameElements: {#d}.
+	self assertEmpty: c1 class localSlots
 ]

--- a/src/Zinc-Resource-Meta-Tests/ZnUrlTests.class.st
+++ b/src/Zinc-Resource-Meta-Tests/ZnUrlTests.class.st
@@ -255,13 +255,13 @@ ZnUrlTests >> testParsePathOnly [
 ZnUrlTests >> testParsingEmpty [
 	| url |
 	url := ZnUrl fromString: ''.
-	self assertEmpty: url.
+	self assert: url isEmpty.
 	url := ZnUrl fromString: '/'.
-	self assertEmpty: url.
+	self assert: url isEmpty.
 	url := ZnUrl fromString: '/./foo/../'.
-	self assertEmpty: url.
+	self assert: url isEmpty.
 	url := ZnUrl fromString: '//'.
-	self denyEmpty: url
+	self deny: url isEmpty
 ]
 
 { #category : #testing }
@@ -331,9 +331,11 @@ ZnUrlTests >> testPathRemoval [
 
 { #category : #testing }
 ZnUrlTests >> testPathSegments [
-	self assert: 'http://foo.com/x/y/z' asZnUrl pathSegments equals: #('x' 'y' 'z') asOrderedCollection.
-	self assertEmpty: 'http://foo.com/' asZnUrl pathSegments.
-	self assertEmpty: 'http://foo.com' asZnUrl pathSegments
+	self 
+		assert: 'http://foo.com/x/y/z' asZnUrl pathSegments 
+		equals: #('x' 'y' 'z') asOrderedCollection.
+	self assert: 'http://foo.com/' asZnUrl pathSegments isEmpty.
+	self assert: 'http://foo.com' asZnUrl pathSegments isEmpty
 ]
 
 { #category : #testing }
@@ -487,36 +489,72 @@ ZnUrlTests >> testQueryRemoveAll [
 			self deny: url = each asZnUrl.
 			url queryRemoveAll.
 			self
-				assertEmpty: url query;
+				assert: url query isEmpty;
 				assert: url = each asZnUrl ]
 ]
 
 { #category : #testing }
 ZnUrlTests >> testReferenceResolution [
 	"RFC 3986 Section 5"
-
+	
 	| baseUri specification result succeeded failed |
 	baseUri := 'http://a/b/c/d;p?q' asZnUrl.
-	specification := {('mailto:john@acme.com' -> 'mailto:john@acme.com') . ('g' -> 'http://a/b/c/g') . ('./g' -> 'http://a/b/c/g') . ('g/' -> 'http://a/b/c/g/') . ('/g' -> 'http://a/g').
-	('//g' -> 'http://g/') . ('//a.com/assets/img.jpg' -> 'http://a.com/assets/img.jpg') . ('?y' -> 'http://a/b/c/d;p?y') . ('g?y' -> 'http://a/b/c/g?y') . ('#s' -> 'http://a/b/c/d;p?q#s').
-	('g#s' -> 'http://a/b/c/g#s') . ('g?y#s' -> 'http://a/b/c/g?y#s') . (';x' -> 'http://a/b/c/;x') . ('g;x' -> 'http://a/b/c/g;x') . ('g;x?y#s' -> 'http://a/b/c/g;x?y#s').
-	('' -> 'http://a/b/c/d;p?q') . ('.' -> 'http://a/b/c/') . ('./' -> 'http://a/b/c/') . ('..' -> 'http://a/b/') . ('../' -> 'http://a/b/') . ('../g' -> 'http://a/b/g').
-	('../..' -> 'http://a/') . ('../../' -> 'http://a/') . ('../../g' -> 'http://a/g') . ('../../../g' -> 'http://a/g') . ('../../../../g' -> 'http://a/g').
-	('/./g' -> 'http://a/g') . ('/../g' -> 'http://a/g') . ('g.' -> 'http://a/b/c/g.') . ('.g' -> 'http://a/b/c/.g') . ('g..' -> 'http://a/b/c/g..') . ('..g' -> 'http://a/b/c/..g').
-	('./../g' -> 'http://a/b/g') . ('./g/.' -> 'http://a/b/c/g/') . ('g/./h' -> 'http://a/b/c/g/h') . ('g/../h' -> 'http://a/b/c/h') . ('g;x1/./y' -> 'http://a/b/c/g;x1/y').
-	('g;x1/../y' -> 'http://a/b/c/y') . ('g?y/./x' -> 'http://a/b/c/g?y/./x') . ('g?y/../x' -> 'http://a/b/c/g?y/../x') . ('g#s/./x' -> 'http://a/b/c/g#s/./x').
-	('g#s/../x' -> 'http://a/b/c/g#s/../x') . ('http://g' -> 'http://g/')}.
-	"Examples 5.4.1 - Normal"
-	" 'g:h' -> 'g:h'. "	"we do not support unknown schemes without //"
-	result := specification
-		withIndexCollect: [ :spec :index | 
-			| resolved success |
-			resolved := baseUri withRelativeReference: spec key.
-			success := resolved asString = spec value.
-			{(#input -> spec key) . (#expected -> spec value) . (#index -> index) . (#resolved -> resolved) . (#result -> success)} asDictionary ].
+	specification := {
+		"Examples 5.4.1 - Normal" 
+		" 'g:h' -> 'g:h'. " "we do not support unknown schemes without //"
+		'mailto:john@acme.com' -> 'mailto:john@acme.com'. "this we can do"
+		'g' -> 'http://a/b/c/g'.
+		'./g' -> 'http://a/b/c/g'.
+		'g/' -> 'http://a/b/c/g/'.
+		'/g' -> 'http://a/g'.
+		'//g' -> 'http://g/'.  "a trailing slash is added automatically"
+		'//a.com/assets/img.jpg' -> 'http://a.com/assets/img.jpg'.
+		'?y' -> 'http://a/b/c/d;p?y'.
+		'g?y' -> 'http://a/b/c/g?y'.
+		'#s' -> 'http://a/b/c/d;p?q#s'.
+		'g#s' -> 'http://a/b/c/g#s'.
+		'g?y#s' -> 'http://a/b/c/g?y#s'.
+		';x' -> 'http://a/b/c/;x'.
+		'g;x' -> 'http://a/b/c/g;x'.
+		'g;x?y#s' -> 'http://a/b/c/g;x?y#s'.
+		'' -> 'http://a/b/c/d;p?q'.
+		'.' -> 'http://a/b/c/'.
+		'./' -> 'http://a/b/c/'.
+		'..' -> 'http://a/b/'.
+		'../' -> 'http://a/b/'.
+		'../g' -> 'http://a/b/g'.
+		'../..' -> 'http://a/'.
+		'../../' -> 'http://a/'.
+		'../../g' -> 'http://a/g'.
+		"Examples 5.4.2 - Abnormal" 
+		'../../../g' -> 'http://a/g'.
+		'../../../../g' -> 'http://a/g'.
+		'/./g' -> 'http://a/g'.
+		'/../g' -> 'http://a/g'.
+		'g.' -> 'http://a/b/c/g.'.
+		'.g' -> 'http://a/b/c/.g'.
+		'g..' -> 'http://a/b/c/g..'.
+		'..g' -> 'http://a/b/c/..g'.
+		'./../g' -> 'http://a/b/g'.
+		'./g/.' -> 'http://a/b/c/g/'.
+		'g/./h' -> 'http://a/b/c/g/h'.
+		'g/../h' -> 'http://a/b/c/h'.
+		'g;x1/./y' -> 'http://a/b/c/g;x1/y'.
+		'g;x1/../y' -> 'http://a/b/c/y'.
+		'g?y/./x' -> 'http://a/b/c/g?y/./x'.
+		'g?y/../x' -> 'http://a/b/c/g?y/../x'.
+		'g#s/./x' -> 'http://a/b/c/g#s/./x'.
+		'g#s/../x' -> 'http://a/b/c/g#s/../x'.
+		'http://g' -> 'http://g/' "a trailing slash is added automatically"
+	}.
+	result := specification withIndexCollect: [ :spec :index | | resolved success |
+		resolved := baseUri withRelativeReference: spec key.
+		success := resolved asString = spec value.
+		{ #input -> spec key. #expected -> spec value. #index -> index.
+		#resolved -> resolved. #result -> success } asDictionary ].
 	succeeded := result select: [ :each | each at: #result ].
 	failed := result reject: [ :each | each at: #result ].
-	self assertEmpty: failed
+	self assert: failed isEmpty
 ]
 
 { #category : #testing }

--- a/src/Zinc-Resource-Meta-Tests/ZnUrlTests.class.st
+++ b/src/Zinc-Resource-Meta-Tests/ZnUrlTests.class.st
@@ -255,13 +255,13 @@ ZnUrlTests >> testParsePathOnly [
 ZnUrlTests >> testParsingEmpty [
 	| url |
 	url := ZnUrl fromString: ''.
-	self assert: url isEmpty.
+	self assertEmpty: url.
 	url := ZnUrl fromString: '/'.
-	self assert: url isEmpty.
+	self assertEmpty: url.
 	url := ZnUrl fromString: '/./foo/../'.
-	self assert: url isEmpty.
+	self assertEmpty: url.
 	url := ZnUrl fromString: '//'.
-	self deny: url isEmpty
+	self denyEmpty: url
 ]
 
 { #category : #testing }
@@ -331,11 +331,9 @@ ZnUrlTests >> testPathRemoval [
 
 { #category : #testing }
 ZnUrlTests >> testPathSegments [
-	self 
-		assert: 'http://foo.com/x/y/z' asZnUrl pathSegments 
-		equals: #('x' 'y' 'z') asOrderedCollection.
-	self assert: 'http://foo.com/' asZnUrl pathSegments isEmpty.
-	self assert: 'http://foo.com' asZnUrl pathSegments isEmpty
+	self assert: 'http://foo.com/x/y/z' asZnUrl pathSegments equals: #('x' 'y' 'z') asOrderedCollection.
+	self assertEmpty: 'http://foo.com/' asZnUrl pathSegments.
+	self assertEmpty: 'http://foo.com' asZnUrl pathSegments
 ]
 
 { #category : #testing }
@@ -489,72 +487,36 @@ ZnUrlTests >> testQueryRemoveAll [
 			self deny: url = each asZnUrl.
 			url queryRemoveAll.
 			self
-				assert: url query isEmpty;
+				assertEmpty: url query;
 				assert: url = each asZnUrl ]
 ]
 
 { #category : #testing }
 ZnUrlTests >> testReferenceResolution [
 	"RFC 3986 Section 5"
-	
+
 	| baseUri specification result succeeded failed |
 	baseUri := 'http://a/b/c/d;p?q' asZnUrl.
-	specification := {
-		"Examples 5.4.1 - Normal" 
-		" 'g:h' -> 'g:h'. " "we do not support unknown schemes without //"
-		'mailto:john@acme.com' -> 'mailto:john@acme.com'. "this we can do"
-		'g' -> 'http://a/b/c/g'.
-		'./g' -> 'http://a/b/c/g'.
-		'g/' -> 'http://a/b/c/g/'.
-		'/g' -> 'http://a/g'.
-		'//g' -> 'http://g/'.  "a trailing slash is added automatically"
-		'//a.com/assets/img.jpg' -> 'http://a.com/assets/img.jpg'.
-		'?y' -> 'http://a/b/c/d;p?y'.
-		'g?y' -> 'http://a/b/c/g?y'.
-		'#s' -> 'http://a/b/c/d;p?q#s'.
-		'g#s' -> 'http://a/b/c/g#s'.
-		'g?y#s' -> 'http://a/b/c/g?y#s'.
-		';x' -> 'http://a/b/c/;x'.
-		'g;x' -> 'http://a/b/c/g;x'.
-		'g;x?y#s' -> 'http://a/b/c/g;x?y#s'.
-		'' -> 'http://a/b/c/d;p?q'.
-		'.' -> 'http://a/b/c/'.
-		'./' -> 'http://a/b/c/'.
-		'..' -> 'http://a/b/'.
-		'../' -> 'http://a/b/'.
-		'../g' -> 'http://a/b/g'.
-		'../..' -> 'http://a/'.
-		'../../' -> 'http://a/'.
-		'../../g' -> 'http://a/g'.
-		"Examples 5.4.2 - Abnormal" 
-		'../../../g' -> 'http://a/g'.
-		'../../../../g' -> 'http://a/g'.
-		'/./g' -> 'http://a/g'.
-		'/../g' -> 'http://a/g'.
-		'g.' -> 'http://a/b/c/g.'.
-		'.g' -> 'http://a/b/c/.g'.
-		'g..' -> 'http://a/b/c/g..'.
-		'..g' -> 'http://a/b/c/..g'.
-		'./../g' -> 'http://a/b/g'.
-		'./g/.' -> 'http://a/b/c/g/'.
-		'g/./h' -> 'http://a/b/c/g/h'.
-		'g/../h' -> 'http://a/b/c/h'.
-		'g;x1/./y' -> 'http://a/b/c/g;x1/y'.
-		'g;x1/../y' -> 'http://a/b/c/y'.
-		'g?y/./x' -> 'http://a/b/c/g?y/./x'.
-		'g?y/../x' -> 'http://a/b/c/g?y/../x'.
-		'g#s/./x' -> 'http://a/b/c/g#s/./x'.
-		'g#s/../x' -> 'http://a/b/c/g#s/../x'.
-		'http://g' -> 'http://g/' "a trailing slash is added automatically"
-	}.
-	result := specification withIndexCollect: [ :spec :index | | resolved success |
-		resolved := baseUri withRelativeReference: spec key.
-		success := resolved asString = spec value.
-		{ #input -> spec key. #expected -> spec value. #index -> index.
-		#resolved -> resolved. #result -> success } asDictionary ].
+	specification := {('mailto:john@acme.com' -> 'mailto:john@acme.com') . ('g' -> 'http://a/b/c/g') . ('./g' -> 'http://a/b/c/g') . ('g/' -> 'http://a/b/c/g/') . ('/g' -> 'http://a/g').
+	('//g' -> 'http://g/') . ('//a.com/assets/img.jpg' -> 'http://a.com/assets/img.jpg') . ('?y' -> 'http://a/b/c/d;p?y') . ('g?y' -> 'http://a/b/c/g?y') . ('#s' -> 'http://a/b/c/d;p?q#s').
+	('g#s' -> 'http://a/b/c/g#s') . ('g?y#s' -> 'http://a/b/c/g?y#s') . (';x' -> 'http://a/b/c/;x') . ('g;x' -> 'http://a/b/c/g;x') . ('g;x?y#s' -> 'http://a/b/c/g;x?y#s').
+	('' -> 'http://a/b/c/d;p?q') . ('.' -> 'http://a/b/c/') . ('./' -> 'http://a/b/c/') . ('..' -> 'http://a/b/') . ('../' -> 'http://a/b/') . ('../g' -> 'http://a/b/g').
+	('../..' -> 'http://a/') . ('../../' -> 'http://a/') . ('../../g' -> 'http://a/g') . ('../../../g' -> 'http://a/g') . ('../../../../g' -> 'http://a/g').
+	('/./g' -> 'http://a/g') . ('/../g' -> 'http://a/g') . ('g.' -> 'http://a/b/c/g.') . ('.g' -> 'http://a/b/c/.g') . ('g..' -> 'http://a/b/c/g..') . ('..g' -> 'http://a/b/c/..g').
+	('./../g' -> 'http://a/b/g') . ('./g/.' -> 'http://a/b/c/g/') . ('g/./h' -> 'http://a/b/c/g/h') . ('g/../h' -> 'http://a/b/c/h') . ('g;x1/./y' -> 'http://a/b/c/g;x1/y').
+	('g;x1/../y' -> 'http://a/b/c/y') . ('g?y/./x' -> 'http://a/b/c/g?y/./x') . ('g?y/../x' -> 'http://a/b/c/g?y/../x') . ('g#s/./x' -> 'http://a/b/c/g#s/./x').
+	('g#s/../x' -> 'http://a/b/c/g#s/../x') . ('http://g' -> 'http://g/')}.
+	"Examples 5.4.1 - Normal"
+	" 'g:h' -> 'g:h'. "	"we do not support unknown schemes without //"
+	result := specification
+		withIndexCollect: [ :spec :index | 
+			| resolved success |
+			resolved := baseUri withRelativeReference: spec key.
+			success := resolved asString = spec value.
+			{(#input -> spec key) . (#expected -> spec value) . (#index -> index) . (#resolved -> resolved) . (#result -> success)} asDictionary ].
 	succeeded := result select: [ :each | each at: #result ].
 	failed := result reject: [ :each | each at: #result ].
-	self assert: failed isEmpty
+	self assertEmpty: failed
 ]
 
 { #category : #testing }

--- a/src/Zinc-Tests/ZnEntityTests.class.st
+++ b/src/Zinc-Tests/ZnEntityTests.class.st
@@ -93,7 +93,7 @@ ZnEntityTests >> testReadingApplicationFormUrlEncoding [
 	input := #(111 97 117 116 104 95 116 111 107 101 110 95 115 101 99 114 101 116 61 98 121 112 104 57 99 109 104 106 49 53 101 108 121 56 38 111 97 117 116 104 95 116 111 107 101 110 61 56 54 101 112 106 51 116 118 100 49 107 115 120 111 57)
 		asByteArray.
 	entity := ZnEntity readFrom: input readStream usingType: ZnMimeType applicationFormUrlEncoded andLength: input size.
-	self deny: entity isEmpty.
+	self denyEmpty: entity.
 	self assert: (entity includesField: 'oauth_token_secret').
 	self assert: (entity includesField: 'oauth_token').
 	self assert: (entity at: 'oauth_token_secret') equals: 'byph9cmhj15ely8'.
@@ -106,7 +106,7 @@ ZnEntityTests >> testReadingApplicationFormUrlEncodingNoLength [
 	input := #(111 97 117 116 104 95 116 111 107 101 110 95 115 101 99 114 101 116 61 98 121 112 104 57 99 109 104 106 49 53 101 108 121 56 38 111 97 117 116 104 95 116 111 107 101 110 61 56 54 101 112 106 51 116 118 100 49 107 115 120 111 57)
 		asByteArray.
 	entity := ZnEntity readFrom: input readStream usingType: ZnMimeType applicationFormUrlEncoded andLength: nil.
-	self deny: entity isEmpty.
+	self denyEmpty: entity.
 	self assert: (entity includesField: 'oauth_token_secret').
 	self assert: (entity includesField: 'oauth_token').
 	self assert: (entity at: 'oauth_token_secret') equals: 'byph9cmhj15ely8'.

--- a/src/Zinc-Tests/ZnEntityTests.class.st
+++ b/src/Zinc-Tests/ZnEntityTests.class.st
@@ -93,7 +93,7 @@ ZnEntityTests >> testReadingApplicationFormUrlEncoding [
 	input := #(111 97 117 116 104 95 116 111 107 101 110 95 115 101 99 114 101 116 61 98 121 112 104 57 99 109 104 106 49 53 101 108 121 56 38 111 97 117 116 104 95 116 111 107 101 110 61 56 54 101 112 106 51 116 118 100 49 107 115 120 111 57)
 		asByteArray.
 	entity := ZnEntity readFrom: input readStream usingType: ZnMimeType applicationFormUrlEncoded andLength: input size.
-	self denyEmpty: entity.
+	self deny: entity isEmpty.
 	self assert: (entity includesField: 'oauth_token_secret').
 	self assert: (entity includesField: 'oauth_token').
 	self assert: (entity at: 'oauth_token_secret') equals: 'byph9cmhj15ely8'.
@@ -106,7 +106,7 @@ ZnEntityTests >> testReadingApplicationFormUrlEncodingNoLength [
 	input := #(111 97 117 116 104 95 116 111 107 101 110 95 115 101 99 114 101 116 61 98 121 112 104 57 99 109 104 106 49 53 101 108 121 56 38 111 97 117 116 104 95 116 111 107 101 110 61 56 54 101 112 106 51 116 118 100 49 107 115 120 111 57)
 		asByteArray.
 	entity := ZnEntity readFrom: input readStream usingType: ZnMimeType applicationFormUrlEncoded andLength: nil.
-	self denyEmpty: entity.
+	self deny: entity isEmpty.
 	self assert: (entity includesField: 'oauth_token_secret').
 	self assert: (entity includesField: 'oauth_token').
 	self assert: (entity at: 'oauth_token_secret') equals: 'byph9cmhj15ely8'.

--- a/src/Zinc-Tests/ZnLineReaderTests.class.st
+++ b/src/Zinc-Tests/ZnLineReaderTests.class.st
@@ -7,11 +7,11 @@ Class {
 { #category : #testing }
 ZnLineReaderTests >> testBinary [
 	| input reader |
-	input := ('Foo', String crlf, 'Bar', String crlf) asByteArray.
+	input := ('Foo' , String crlf , 'Bar' , String crlf) asByteArray.
 	reader := ZnLineReader on: input readStream.
 	self assert: reader nextLine = 'Foo'.
 	self assert: reader nextLine = 'Bar'.
-	self assert: reader nextLine isEmpty
+	self assertEmpty: reader nextLine
 ]
 
 { #category : #testing }
@@ -33,9 +33,9 @@ ZnLineReaderTests >> testLineTooLongDefault [
 { #category : #testing }
 ZnLineReaderTests >> testSimple [
 	| input reader |
-	input := 'Foo', String crlf, 'Bar', String crlf.
+	input := 'Foo' , String crlf , 'Bar' , String crlf.
 	reader := ZnLineReader on: input readStream.
 	self assert: reader nextLine = 'Foo'.
 	self assert: reader nextLine = 'Bar'.
-	self assert: reader nextLine isEmpty
+	self assertEmpty: reader nextLine
 ]

--- a/src/Zinc-Tests/ZnLineReaderTests.class.st
+++ b/src/Zinc-Tests/ZnLineReaderTests.class.st
@@ -7,11 +7,11 @@ Class {
 { #category : #testing }
 ZnLineReaderTests >> testBinary [
 	| input reader |
-	input := ('Foo' , String crlf , 'Bar' , String crlf) asByteArray.
+	input := ('Foo', String crlf, 'Bar', String crlf) asByteArray.
 	reader := ZnLineReader on: input readStream.
 	self assert: reader nextLine = 'Foo'.
 	self assert: reader nextLine = 'Bar'.
-	self assertEmpty: reader nextLine
+	self assert: reader nextLine isEmpty
 ]
 
 { #category : #testing }
@@ -33,9 +33,9 @@ ZnLineReaderTests >> testLineTooLongDefault [
 { #category : #testing }
 ZnLineReaderTests >> testSimple [
 	| input reader |
-	input := 'Foo' , String crlf , 'Bar' , String crlf.
+	input := 'Foo', String crlf, 'Bar', String crlf.
 	reader := ZnLineReader on: input readStream.
 	self assert: reader nextLine = 'Foo'.
 	self assert: reader nextLine = 'Bar'.
-	self assertEmpty: reader nextLine
+	self assert: reader nextLine isEmpty
 ]

--- a/src/Zinc-Tests/ZnServerTests.class.st
+++ b/src/Zinc-Tests/ZnServerTests.class.st
@@ -420,61 +420,70 @@ ZnServerTests >> testRespond [
 
 { #category : #testing }
 ZnServerTests >> testSession [
-	self withServerDo: [ :server | | client sessionId |
-		client := ZnClient new url: (server localUrl addPathSegment: #session); yourself.
-		self assert: client session cookieJar cookies isEmpty.
-		client get.
-		self assert: client isSuccess.
-		self assert: client session cookieJar cookies size = 1.
-		sessionId := client session cookieJar cookies anyOne value.
-		self assert: (client contents includesSubstring: sessionId).
-		client get.
-		self assert: client isSuccess.
-		self assert: client session cookieJar cookies size = 1.
-		self assert: client session cookieJar cookies anyOne value equals: sessionId.
-		self assert: (client contents includesSubstring: sessionId) ]
-
+	self
+		withServerDo: [ :server | 
+			| client sessionId |
+			client := ZnClient new
+				url: (server localUrl addPathSegment: #session);
+				yourself.
+			self assertEmpty: client session cookieJar cookies.
+			client get.
+			self assert: client isSuccess.
+			self assert: client session cookieJar cookies size = 1.
+			sessionId := client session cookieJar cookies anyOne value.
+			self assert: (client contents includesSubstring: sessionId).
+			client get.
+			self assert: client isSuccess.
+			self assert: client session cookieJar cookies size = 1.
+			self assert: client session cookieJar cookies anyOne value equals: sessionId.
+			self assert: (client contents includesSubstring: sessionId) ]
 ]
 
 { #category : #testing }
 ZnServerTests >> testSessionExpired [
-	self withServerDo: [ :server | | client sessionId |
-		client := ZnClient new url: (server localUrl addPathSegment: #session); yourself.
-		self assert: client session cookieJar cookies isEmpty.
-		client get.
-		self assert: client isSuccess.
-		self assert: client session cookieJar cookies size = 1.
-		sessionId := client session cookieJar cookies anyOne value.
-		self assert: (client contents includesSubstring: sessionId).
-		"Kill the server session as if it was expired"
-		server sessionManager removeSessionWithId: sessionId.
-		"The client still presents the old session id but should get a new one"
-		client get.
-		self assert: client isSuccess.
-		self assert: client session cookieJar cookies size = 1.
-		self deny: client session cookieJar cookies anyOne value = sessionId ]
-
+	self
+		withServerDo: [ :server | 
+			| client sessionId |
+			client := ZnClient new
+				url: (server localUrl addPathSegment: #session);
+				yourself.
+			self assertEmpty: client session cookieJar cookies.
+			client get.
+			self assert: client isSuccess.
+			self assert: client session cookieJar cookies size = 1.
+			sessionId := client session cookieJar cookies anyOne value.
+			self assert: (client contents includesSubstring: sessionId).
+			"Kill the server session as if it was expired"
+			server sessionManager removeSessionWithId: sessionId.
+			"The client still presents the old session id but should get a new one"
+			client get.
+			self assert: client isSuccess.
+			self assert: client session cookieJar cookies size = 1.
+			self deny: client session cookieJar cookies anyOne value = sessionId ]
 ]
 
 { #category : #testing }
 ZnServerTests >> testSessionRoute [
-	self withServerDo: [ :server | | client sessionId |
-		server route: 'r1'.
-		self assert: server route equals: 'r1'.
-		client := ZnClient new url: (server localUrl addPathSegment: #session); yourself.
-		self assert: client session cookieJar cookies isEmpty.
-		client get.
-		self assert: client isSuccess.
-		self assert: client session cookieJar cookies size = 1.
-		sessionId := client session cookieJar cookies anyOne value.
-		self assert: (client contents includesSubstring: sessionId).
-		self assert: (sessionId endsWith: '.r1').
-		client get.
-		self assert: client isSuccess.
-		self assert: client session cookieJar cookies size = 1.
-		self assert: client session cookieJar cookies anyOne value equals: sessionId.
-		self assert: (client contents includesSubstring: sessionId) ]
-
+	self
+		withServerDo: [ :server | 
+			| client sessionId |
+			server route: 'r1'.
+			self assert: server route equals: 'r1'.
+			client := ZnClient new
+				url: (server localUrl addPathSegment: #session);
+				yourself.
+			self assertEmpty: client session cookieJar cookies.
+			client get.
+			self assert: client isSuccess.
+			self assert: client session cookieJar cookies size = 1.
+			sessionId := client session cookieJar cookies anyOne value.
+			self assert: (client contents includesSubstring: sessionId).
+			self assert: (sessionId endsWith: '.r1').
+			client get.
+			self assert: client isSuccess.
+			self assert: client session cookieJar cookies size = 1.
+			self assert: client session cookieJar cookies anyOne value equals: sessionId.
+			self assert: (client contents includesSubstring: sessionId) ]
 ]
 
 { #category : #testing }

--- a/src/Zinc-Tests/ZnServerTests.class.st
+++ b/src/Zinc-Tests/ZnServerTests.class.st
@@ -420,70 +420,61 @@ ZnServerTests >> testRespond [
 
 { #category : #testing }
 ZnServerTests >> testSession [
-	self
-		withServerDo: [ :server | 
-			| client sessionId |
-			client := ZnClient new
-				url: (server localUrl addPathSegment: #session);
-				yourself.
-			self assertEmpty: client session cookieJar cookies.
-			client get.
-			self assert: client isSuccess.
-			self assert: client session cookieJar cookies size = 1.
-			sessionId := client session cookieJar cookies anyOne value.
-			self assert: (client contents includesSubstring: sessionId).
-			client get.
-			self assert: client isSuccess.
-			self assert: client session cookieJar cookies size = 1.
-			self assert: client session cookieJar cookies anyOne value equals: sessionId.
-			self assert: (client contents includesSubstring: sessionId) ]
+	self withServerDo: [ :server | | client sessionId |
+		client := ZnClient new url: (server localUrl addPathSegment: #session); yourself.
+		self assert: client session cookieJar cookies isEmpty.
+		client get.
+		self assert: client isSuccess.
+		self assert: client session cookieJar cookies size = 1.
+		sessionId := client session cookieJar cookies anyOne value.
+		self assert: (client contents includesSubstring: sessionId).
+		client get.
+		self assert: client isSuccess.
+		self assert: client session cookieJar cookies size = 1.
+		self assert: client session cookieJar cookies anyOne value equals: sessionId.
+		self assert: (client contents includesSubstring: sessionId) ]
+
 ]
 
 { #category : #testing }
 ZnServerTests >> testSessionExpired [
-	self
-		withServerDo: [ :server | 
-			| client sessionId |
-			client := ZnClient new
-				url: (server localUrl addPathSegment: #session);
-				yourself.
-			self assertEmpty: client session cookieJar cookies.
-			client get.
-			self assert: client isSuccess.
-			self assert: client session cookieJar cookies size = 1.
-			sessionId := client session cookieJar cookies anyOne value.
-			self assert: (client contents includesSubstring: sessionId).
-			"Kill the server session as if it was expired"
-			server sessionManager removeSessionWithId: sessionId.
-			"The client still presents the old session id but should get a new one"
-			client get.
-			self assert: client isSuccess.
-			self assert: client session cookieJar cookies size = 1.
-			self deny: client session cookieJar cookies anyOne value = sessionId ]
+	self withServerDo: [ :server | | client sessionId |
+		client := ZnClient new url: (server localUrl addPathSegment: #session); yourself.
+		self assert: client session cookieJar cookies isEmpty.
+		client get.
+		self assert: client isSuccess.
+		self assert: client session cookieJar cookies size = 1.
+		sessionId := client session cookieJar cookies anyOne value.
+		self assert: (client contents includesSubstring: sessionId).
+		"Kill the server session as if it was expired"
+		server sessionManager removeSessionWithId: sessionId.
+		"The client still presents the old session id but should get a new one"
+		client get.
+		self assert: client isSuccess.
+		self assert: client session cookieJar cookies size = 1.
+		self deny: client session cookieJar cookies anyOne value = sessionId ]
+
 ]
 
 { #category : #testing }
 ZnServerTests >> testSessionRoute [
-	self
-		withServerDo: [ :server | 
-			| client sessionId |
-			server route: 'r1'.
-			self assert: server route equals: 'r1'.
-			client := ZnClient new
-				url: (server localUrl addPathSegment: #session);
-				yourself.
-			self assertEmpty: client session cookieJar cookies.
-			client get.
-			self assert: client isSuccess.
-			self assert: client session cookieJar cookies size = 1.
-			sessionId := client session cookieJar cookies anyOne value.
-			self assert: (client contents includesSubstring: sessionId).
-			self assert: (sessionId endsWith: '.r1').
-			client get.
-			self assert: client isSuccess.
-			self assert: client session cookieJar cookies size = 1.
-			self assert: client session cookieJar cookies anyOne value equals: sessionId.
-			self assert: (client contents includesSubstring: sessionId) ]
+	self withServerDo: [ :server | | client sessionId |
+		server route: 'r1'.
+		self assert: server route equals: 'r1'.
+		client := ZnClient new url: (server localUrl addPathSegment: #session); yourself.
+		self assert: client session cookieJar cookies isEmpty.
+		client get.
+		self assert: client isSuccess.
+		self assert: client session cookieJar cookies size = 1.
+		sessionId := client session cookieJar cookies anyOne value.
+		self assert: (client contents includesSubstring: sessionId).
+		self assert: (sessionId endsWith: '.r1').
+		client get.
+		self assert: client isSuccess.
+		self assert: client session cookieJar cookies size = 1.
+		self assert: client session cookieJar cookies anyOne value equals: sessionId.
+		self assert: (client contents includesSubstring: sessionId) ]
+
 ]
 
 { #category : #testing }

--- a/src/Zinc-Zodiac/ZnHTTPSTests.class.st
+++ b/src/Zinc-Zodiac/ZnHTTPSTests.class.st
@@ -140,7 +140,7 @@ ZnHTTPSTests >> testGetPharoVersion [
 	self assert: lastBuildVersion isString.
 	self assert: lastBuildVersion size > 0.
 	version := (lastBuildVersion copyAfter: $>) copyUpTo: $<.
-	self denyEmpty: version
+	self deny: version isEmpty
 ]
 
 { #category : #testing }

--- a/src/Zinc-Zodiac/ZnHTTPSTests.class.st
+++ b/src/Zinc-Zodiac/ZnHTTPSTests.class.st
@@ -140,7 +140,7 @@ ZnHTTPSTests >> testGetPharoVersion [
 	self assert: lastBuildVersion isString.
 	self assert: lastBuildVersion size > 0.
 	version := (lastBuildVersion copyAfter: $>) copyUpTo: $<.
-	self deny: version isEmpty
+	self denyEmpty: version
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Introduce #assertEmpty: and #denyEmpty: + use them

The commit also contains some cleanings such as replacing some `assert: something = true` by `assert:` etc.

Fixes #2309