### PR TITLE
2317-Tree-filtering-in-FastTable-is-broken

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTRegexFilter.class.st
+++ b/src/Morphic-Widgets-FastTable/FTRegexFilter.class.st
@@ -23,6 +23,15 @@ FTRegexFilter >> matches: aString [
 { #category : #accessing }
 FTRegexFilter >> pattern: aString [
 	super pattern: aString.
-	
-	regex := aString asRegexIgnoringCase
+
+	regex := self patternFromString: aString
+]
+
+{ #category : #accessing }
+FTRegexFilter >> patternFromString: aString [
+	" do not throw an error if the pattern is bad - important in case of auto-accepting"
+
+	^ [ aString asRegexIgnoringCase ]
+		on: RegexSyntaxError
+		do: [ :ex |  ]
 ]

--- a/src/Morphic-Widgets-FastTable/FTTreeFunctionStrategy.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTreeFunctionStrategy.class.st
@@ -43,11 +43,20 @@ Class {
 }
 
 { #category : #'instance creation' }
-FTTreeFunctionStrategy class >> filterWith: aRegex dataSource: aDataSource [
+FTTreeFunctionStrategy class >> filterWith: aString dataSource: aDataSource [
 	^ self new
-		pattern: aRegex;
+		pattern: (self patternFromString: aString);
 		dataSource: aDataSource;
 		filter
+]
+
+{ #category : #updating }
+FTTreeFunctionStrategy class >> patternFromString: aString [
+	" do not throw an error if the pattern is bad - important in case of auto-accepting"
+
+	^ [ aString asRegexIgnoringCase ]
+		on: RegexSyntaxError
+		do: [ :ex | '' asRegexIgnoringCase ]
 ]
 
 { #category : #'instance creation' }


### PR DESCRIPTION
Fix bug on tree filters introduced in Pharo 6.

Fixes #2317