### PR TITLE
2172-Color-classfromHexString-should-remove-possible-

### DIFF
--- a/src/Colors/Color.class.st
+++ b/src/Colors/Color.class.st
@@ -286,11 +286,17 @@ Color class >> fromHexString: aColorHex [
 
 	"(Color fromHexString: 'FFFFFF')>>> (Color white) "
 
-	| green red blue |
-	red := (Integer readFrom: (aColorHex first: 2) base: 16) / 255.
-	green := (Integer readFrom: (aColorHex copyFrom: 3 to: 4) base: 16) / 255.
-	blue := (Integer readFrom: (aColorHex last: 2) base: 16) / 255.
-	^ self r: red g: green b: blue
+	| green red blue alpha hexString |
+	hexString := aColorHex withoutPrefix: '#'.
+	red := (Integer readFrom: (hexString first: 2) base: 16) / 255.
+	green := (Integer readFrom: (hexString copyFrom: 3 to: 4) base: 16) / 255.
+	blue := (Integer readFrom: (hexString copyFrom: 5 to: 6) base: 16) / 255.
+	
+	alpha := hexString size = 8 
+		ifFalse: [ 1.0 ]
+		ifTrue: [ (Integer readFrom: (hexString copyFrom: 7 to: 8) base: 16) / 255 ].
+	
+	^ self r: red g: green b: blue alpha: alpha
 ]
 
 { #category : #'instance creation' }

--- a/src/Graphics-Tests/ColorTest.class.st
+++ b/src/Graphics-Tests/ColorTest.class.st
@@ -102,13 +102,13 @@ ColorTest >> testFromHexString [
 	color := 	Color fromHexString: 'FFFFFF'.
 	self assert: color equals: Color white.
 
-	color := 	Color fromHexString: 'ff0000'.
+	color := Color fromHexString: 'ff0000'.
 	self assert: color equals: Color red.
 
-	color := 	Color fromHexString: '#ff0000'.
+	color := Color fromHexString: '#ff0000'.
 	self assert: color equals: Color red.
 
-	color := 	Color fromHexString: '#FF00FFFF'.
+	color := Color fromHexString: '#FF00FFFF'.
 	self assert: color equals: Color magenta.
 
 	color := 	Color fromHexString: '#FF00FF55'.

--- a/src/Graphics-Tests/ColorTest.class.st
+++ b/src/Graphics-Tests/ColorTest.class.st
@@ -99,7 +99,7 @@ ColorTest >> testFromHexString [
 
 	| color |
 	
-	color := 	Color fromHexString: 'FFFFFF'.
+	color := Color fromHexString: 'FFFFFF'.
 	self assert: color equals: Color white.
 
 	color := Color fromHexString: 'ff0000'.
@@ -111,7 +111,7 @@ ColorTest >> testFromHexString [
 	color := Color fromHexString: '#FF00FFFF'.
 	self assert: color equals: Color magenta.
 
-	color := 	Color fromHexString: '#FF00FF55'.
+	color := Color fromHexString: '#FF00FF55'.
 	self assert: (color alpha > 0.3 and: [color alpha < 0.4])
 
 ]

--- a/src/Graphics-Tests/ColorTest.class.st
+++ b/src/Graphics-Tests/ColorTest.class.st
@@ -95,6 +95,28 @@ ColorTest >> testColorFrom [
 ]
 
 { #category : #tests }
+ColorTest >> testFromHexString [
+
+	| color |
+	
+	color := 	Color fromHexString: 'FFFFFF'.
+	self assert: color equals: Color white.
+
+	color := 	Color fromHexString: 'ff0000'.
+	self assert: color equals: Color red.
+
+	color := 	Color fromHexString: '#ff0000'.
+	self assert: color equals: Color red.
+
+	color := 	Color fromHexString: '#FF00FFFF'.
+	self assert: color equals: Color magenta.
+
+	color := 	Color fromHexString: '#FF00FF55'.
+	self assert: (color alpha > 0.3 and: [color alpha < 0.4])
+
+]
+
+{ #category : #tests }
 ColorTest >> testFromString [
 	self assert: ((Color fromString: '#FF8800') asHexString sameAs: 'ff8800');
 		assert: ((Color fromString: 'FF8800') asHexString sameAs: 'ff8800');


### PR DESCRIPTION
may fromHexString independent on '#' prefix and add possibility to specify alphaFixes #2172