### PR TITLE
2342-memory-leak-through-GTSnippets-instance-cache

### DIFF
--- a/src/GT-Inspector/GTSnippets.class.st
+++ b/src/GT-Inspector/GTSnippets.class.st
@@ -57,5 +57,5 @@ GTSnippets >> snippetAtOrEmpty: anObject [
 
 { #category : #accessing }
 GTSnippets >> snippets [ 
-	^ snippets ifNil: [ snippets := IdentityDictionary new ]
+	^ snippets ifNil: [ snippets := WeakIdentityKeyDictionary new ]
 ]


### PR DESCRIPTION
making the snippets cache use a WeakIdentityKeyDictionary (2342)