### PR TITLE
Issue 2345 envversion.sh causes out-of-repository bootstrap to fail

### DIFF
--- a/bootstrap/scripts/envversion.sh
+++ b/bootstrap/scripts/envversion.sh
@@ -81,8 +81,12 @@ function set_version_pull_request_variables() {
 #  PHARO_NAME_PREFIX -> Prefix to name the buids (Pharo7.0.0-rc1, Pharo7.0-SNAPSHOT, Pharo7.0.0-PR)
 #  PHARO_SHORT_VERSION -> Short version of the image (70, 80, etc.)
 #  PHARO_VM_VERSION -> VM version (equivallent to PHARO_SHORT_VERSION)
+#
+# Input environment variables:
+#  BOOTSTRAP_REPOSITORY - the root directory of the git repository
 function set_version_variables() {
-	
+
+	pushd "$BOOTSTRAP_REPOSITORY" > /dev/null
 	if [ $(is_development_build) == 1 ]; then
 		if [ $(is_release_build) == 1 ]; then
 			set_version_release_variables
@@ -97,4 +101,6 @@ function set_version_variables() {
 	#PHARO_VM_VERSION="${PHARO_SHORT_VERSION}"
 	PHARO_VM_VERSION="70"
 	PHARO_COMMIT_HASH="$(git rev-parse --verify HEAD)"
+	popd > /dev/null
 } 
+


### PR DESCRIPTION
Recent changes to envversion.sh assume that the bootstrap is being run
from within the repository, which is not required (BOOTSTRAP_REPOSITORY
can be set to point to the repository).

The solution is to change directory to BOOTSTRAP_REPOSITORY before
issuing the git commands, and then change back.

Issue: https://github.com/pharo-project/pharo/issues/2345