### PR TITLE
2347 BaselineOfIDE references non-existant Iceberg 1.5.5

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -859,7 +859,7 @@ BaselineOfIDE >> loadCalypso [
 BaselineOfIDE >> loadIceberg [
 	Metacello new
 		baseline: 'Iceberg';
-		repository: 'github://pharo-vcs/iceberg:v1.5.5';
+		repository: 'github://pharo-vcs/iceberg:v1.5.6';
 		load.
 	(Smalltalk classNamed: #Iceberg) enableMetacelloIntegration: true.
 	(Smalltalk classNamed: #IcePharoPlugin) addPharoProjectToIceberg.


### PR DESCRIPTION
BaselineOfIDE currently tries to load Iceberg 1.5.5, which doesn't
exist.

Use V1.5.6 (previous available version is 1.5.3). See
https://github.com/pharo-vcs/iceberg/releases

Issue: https://github.com/pharo-project/pharo/issues/2347