### PR TITLE
transform_32_into_64.sh: call envvars.sh

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,7 +154,7 @@ def bootstrapImage(){
         stage ("Convert Image - 32->64") {
           dir("conversion") {
             shell "cp ../bootstrap-cache/*.zip ."
-            shell "bash ../bootstrap/scripts/transform_32_into_64.sh"
+            shell "BUILD_NUMBER=${BUILD_NUMBER} BOOTSTRAP_ARCH=${architecture} bash ../bootstrap/scripts/transform_32_into_64.sh"
             shell "mv *-64bit-*.zip ../bootstrap-cache"
           }
         }

--- a/bootstrap/scripts/envvars.sh
+++ b/bootstrap/scripts/envvars.sh
@@ -13,19 +13,19 @@
 # - BOOTSTRAP_CACHE
 # - BOOTSTRAP_REPOSITORY
 #
-if [ -z "${BUILD_NUMBER}" ]
+if [ -z ${BUILD_NUMBER+x} ]
 then
     echo "BUILD_NUMBER not specified, exiting"
     exit 1
 fi
 
-if [ -z "${BOOTSTRAP_ARCH}" ]
+if [ -z ${BOOTSTRAP_ARCH+x} ]
 then
     echo "BOOTSTRAP_ARCH not specified, exiting"
     exit 1
 fi
 
-if [ -z "${BOOTSTRAP_REPOSITORY}" ]
+if [ -z ${BOOTSTRAP_REPOSITORY+x} ]
 then
   ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." ; pwd -P)"
   export BOOTSTRAP_REPOSITORY="${ROOT_DIR}"
@@ -33,7 +33,7 @@ else
   ROOT_DIR="$(pwd -P)"
 fi
 
-if [ -z "${BOOTSTRAP_CACHE}" ]
+if [ -z ${BOOTSTRAP_CACHE+x} ]
 then
   BOOTSTRAP_CACHE=${ROOT_DIR}/bootstrap-cache
 fi

--- a/bootstrap/scripts/transform_32_into_64.sh
+++ b/bootstrap/scripts/transform_32_into_64.sh
@@ -5,6 +5,7 @@ set -o nounset
 set -o xtrace
 
 SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
+. ${SCRIPTS}/envvars.sh
 . ${SCRIPTS}/envversion.sh
 
 set_version_variables

--- a/bootstrap/scripts/transform_32_into_64.sh
+++ b/bootstrap/scripts/transform_32_into_64.sh
@@ -6,7 +6,6 @@ set -o xtrace
 
 SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 . ${SCRIPTS}/envvars.sh
-. ${SCRIPTS}/envversion.sh
 
 set_version_variables
 


### PR DESCRIPTION
envvars.sh is required to set up environment variables such as
BOOTSTRAP_REPOSITORY.