### PR TITLE
2397-Use-theme-instead-of-referencing-Smalltalk-in-FastTable

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTBasicItem.class.st
+++ b/src/Morphic-Widgets-FastTable/FTBasicItem.class.st
@@ -51,12 +51,17 @@ Class {
 
 { #category : #'expanding-collapsing' }
 FTBasicItem class >> expandedForm [
-	^ Smalltalk ui theme treeExpandedForm
+	^ self theme treeExpandedForm
+]
+
+{ #category : #accessing }
+FTBasicItem class >> theme [
+	^ Smalltalk ui theme
 ]
 
 { #category : #'expanding-collapsing' }
 FTBasicItem class >> unexpandedForm [
-	^ Smalltalk ui theme treeUnexpandedForm
+	^ self theme treeUnexpandedForm
 ]
 
 { #category : #accessing }

--- a/src/Morphic-Widgets-FastTable/FTCellMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTCellMorph.class.st
@@ -65,7 +65,7 @@ FTCellMorph >> initialize [
 
 { #category : #drawing }
 FTCellMorph >> seperatorColor [
-	^ Smalltalk ui theme scrollbarColor
+	^ self theme scrollbarColor
 ]
 
 { #category : #accessing }

--- a/src/Morphic-Widgets-FastTable/FTColumnResizerMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTColumnResizerMorph.class.st
@@ -97,7 +97,7 @@ FTColumnResizerMorph >> mouseMove: anEvent [
 	anEvent hand temporaryCursor ifNil: [^ self].
 	traceMorph ifNil: [
 		traceMorph := Morph newBounds: (self bounds withHeight: container height).
-		traceMorph color: Smalltalk ui theme fastTableColumnResizingColor.
+		traceMorph color: self theme fastTableColumnResizingColor.
 		traceMorph borderWidth: 0.
 		container addMorph: traceMorph].
 	traceMorph position: (anEvent cursorPoint x - lastMouse second x) @ traceMorph position y
@@ -146,7 +146,7 @@ FTColumnResizerMorph >> resizeCursor [
 { #category : #private }
 FTColumnResizerMorph >> setGrabbedColor [
 	"Set the color of the receiver when it is grabbed."
-	self fillStyle: Smalltalk ui theme fastTableColumnSplitterSelectedColor
+	self fillStyle: self theme fastTableColumnSplitterSelectedColor
 ]
 
 { #category : #'Polymorph-Widgets' }

--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -53,7 +53,7 @@ FTTableMorph class >> defaultAllowsDeselection [
 
 { #category : #accessing }
 FTTableMorph class >> defaultBackgroundColor [
-	^ Smalltalk ui theme listBackgroundColor
+	^ self theme listBackgroundColor
 ]
 
 { #category : #accessing }
@@ -65,7 +65,7 @@ FTTableMorph class >> defaultColumn [
 FTTableMorph class >> defaultHeaderColor [
 	self flag: #todo. "I think we should deprecate all this headerColor stuff. This is 
 	responsibility of data source, after all"
-	^ Smalltalk ui theme fastTableHeaderColor
+	^ self theme fastTableHeaderColor
 ]
 
 { #category : #accessing }
@@ -80,12 +80,12 @@ FTTableMorph class >> defaultRowHeight [
 
 { #category : #accessing }
 FTTableMorph class >> defaultSecondarySelectionColor [
-	^ Smalltalk ui theme secondarySelectionColor
+	^ self theme secondarySelectionColor
 ]
 
 { #category : #accessing }
 FTTableMorph class >> defaultSelectionColor [
-	^ Smalltalk ui theme selectionColor
+	^ self theme selectionColor
 ]
 
 { #category : #temporary }

--- a/src/Morphic-Widgets-FastTable/FTTableRowMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableRowMorph.class.st
@@ -72,7 +72,7 @@ FTTableRowMorph >> mouseLeave: evt [
 
 { #category : #initialize }
 FTTableRowMorph >> mouseOverColor [
-	^ Smalltalk ui theme lightBackgroundColor
+	^ self theme lightBackgroundColor
 ]
 
 { #category : #initialize }


### PR DESCRIPTION
FastTable: Do not reference Smalltalk to acces theme in morphs.

Fixes  #2397