### PR TITLE
2414-failing-testAndMakeSureSuperSetupIsCalledAsFirstMessageInSetupMethodsOfTestCases

### DIFF
--- a/src/GT-Tests-Spotter/GTSpotterTest.class.st
+++ b/src/GT-Tests-Spotter/GTSpotterTest.class.st
@@ -27,6 +27,8 @@ GTSpotterTest >> assertText: aTextualObject do: aBlock [
 
 { #category : #running }
 GTSpotterTest >> setUp [ 
+
+	super setUp.
 	
 	spotter := GTMockSpotter new
 		exceptionHandler: GTSpotterDebuggingExceptionHandler new;


### PR DESCRIPTION
fix failing testfixes  #2414