### PR TITLE
2423-Rename-selection-methods-of-FastTable-to-remove-the-row-in-names

### DIFF
--- a/src/Glamour-FastTable/GLMFastListDataSource.class.st
+++ b/src/Glamour-FastTable/GLMFastListDataSource.class.st
@@ -133,7 +133,7 @@ GLMFastListDataSource >> rowMorphForElement: element [
 
 { #category : #selecting }
 GLMFastListDataSource >> selectTable: aTable element: anObject [ 
-	aTable selectRowIndex: (self elements indexOf: anObject)
+	aTable selectIndex: (self elements indexOf: anObject)
 ]
 
 { #category : #accessing }

--- a/src/Glamour-FastTable/GLMFastTreeDataSource.class.st
+++ b/src/Glamour-FastTable/GLMFastTreeDataSource.class.st
@@ -85,7 +85,7 @@ GLMFastTreeDataSource >> dataCache [
 
 { #category : #selecting }
 GLMFastTreeDataSource >> explicitSelection: anObject [
-	self table selectRowIndexes: (self searchText: anObject asString)
+	self table selectIndexes: (self searchText: anObject asString)
 ]
 
 { #category : #accessing }
@@ -188,7 +188,7 @@ GLMFastTreeDataSource >> strongSelection: ann [
 	self announcer
 		announce:
 			(GLMTreeMorphStrongSelectionChanged new
-				strongSelectionValue: (self elementAt: ann selectedRowIndex) data;
+				strongSelectionValue: (self elementAt: ann selectedIndex) data;
 				yourself)
 ]
 

--- a/src/Glamour-FastTable/TGLMFastTable.trait.st
+++ b/src/Glamour-FastTable/TGLMFastTable.trait.st
@@ -95,7 +95,7 @@ TGLMFastTable >> executeMenuAction: anAction [
 
 { #category : #selecting }
 TGLMFastTable >> explicitSelection: anObject [ 
-	self table selectRowIndex: (self elements indexOf: anObject)
+	self table selectIndex: (self elements indexOf: anObject)
 ]
 
 { #category : #'accessing - cache' }
@@ -192,7 +192,7 @@ TGLMFastTable >> shouldUseCache [
 { #category : #selecting }
 TGLMFastTable >> strongSelection: ann [
 	self announcer announce: (GLMTreeMorphStrongSelectionChanged new 
-		strongSelectionValue: (self elementAt: ann selectedRowIndex);
+		strongSelectionValue: (self elementAt: ann selectedIndex);
 		yourself)
 ]
 

--- a/src/Morphic-Widgets-FastTable/FTAllItemsStrategy.class.st
+++ b/src/Morphic-Widgets-FastTable/FTAllItemsStrategy.class.st
@@ -53,7 +53,7 @@ FTAllItemsStrategy >> filter [
 	| items |
 	items := OrderedCollection new.
 	dataSource rootsItems do: [ :item | (self matchingFilter: item) ifNotNil: [ :itemNew | items add: itemNew ] ] displayingProgress: [ :each | 'Looking inside ' , each printString ].
-	dataSource table selectRowIndex: 1.
+	dataSource table selectIndex: 1.
 	^ dataSource class
 		root:
 			(FTRootItem new

--- a/src/Morphic-Widgets-FastTable/FTExamples.class.st
+++ b/src/Morphic-Widgets-FastTable/FTExamples.class.st
@@ -255,29 +255,36 @@ FTExamples class >> exampleEasyList3 [
 FTExamples class >> exampleEditableList1 [
 	<sampleInstance>
 	<example>
-	| list data|
+	| list data |
 	data := OrderedCollection with: 'A' with: 'B' with: 'C'.
 	list := FTTableMorph new
-		extent: 300@550;
+		extent: 300 @ 550;
 		dataSource: (FTExampleDropDataSource new elements: data);
-		selectRowIndex: 1;
+		selectIndex: 1;
 		showFirstRowSelection;
-		onAnnouncement: FTStrongSelectionChanged 
-			do: [ :ann | |index morph ed |
-				index := ann selectedRowIndex.
-				morph := list visibleRowMorphAtIndex: index.
-				ed := RubFloatingEditorBuilder new
-					customizeEditorWith: [ :editor | 
-						editor scrollbarsShowNever.
-						editor bounds: (morph bounds insetBy: (Margin left: -2 top: 0 right: 0 bottom: 0  ))
-					];
+		onAnnouncement: FTStrongSelectionChanged
+			do: [ :ann | 
+			| index morph ed |
+			index := ann selectedIndex.
+			morph := list visibleRowMorphAtIndex: index.
+			ed := RubFloatingEditorBuilder new
+				customizeEditorWith: [ :editor | 
+					editor scrollbarsShowNever.
+					editor
+						bounds:
+							(morph bounds
+								insetBy:
+									(Margin
+										left: -2
+										top: 0
+										right: 0
+										bottom: 0)) ];
 				withEditedContentsDo: [ :editedContents | 
 					data at: index put: editedContents asString.
-					list refresh].
-				ed openEditorWithContents: (data at: index) 
-		];
+					list refresh ].
+			ed openEditorWithContents: (data at: index) ];
 		yourself.
-		
+
 	^ list openInWindow
 ]
 
@@ -313,20 +320,19 @@ FTExamples class >> exampleList1 [
 { #category : #examples }
 FTExamples class >> exampleList2 [
 	"Show a list with all Object methods and preselects one item"
+
 	<example>
 	<sampleInstance>
 	| list |
-
 	list := FTTableMorph new
-		extent: 300@550;
+		extent: 300 @ 550;
 		dataSource: (FTExampleMethodListDataSource for: Object);
-		selectRowIndex: 42;
+		selectIndex: 42;
 		showFirstRowSelection;
 		allowDeselection;
 		yourself.
 
 	^ list openInWindow
-
 ]
 
 { #category : #examples }
@@ -334,19 +340,18 @@ FTExamples class >> exampleList3 [
 	"Show a list with all Object methods, 
 		- preselects one element
 	 	- responds to selection changes"
+
 	<example>
 	<sampleInstance>
 	| list |
-
 	list := FTTableMorph new
-		extent: 300@550;
+		extent: 300 @ 550;
 		dataSource: (FTExampleMethodListDataSource for: Object);
-		selectRowIndex: 42;
+		selectIndex: 42;
 		showFirstRowSelection;
-		onAnnouncement: FTSelectionChanged 
-			do: [ :ann | ('row selected: ', (ann newSelectedRowIndexes asString)) crLog ];
+		onAnnouncement: FTSelectionChanged do: [ :ann | ('row selected: ' , ann newSelectedRowIndexes asString) crLog ];
 		yourself.
-		
+
 	^ list openInWindow
 ]
 
@@ -356,21 +361,19 @@ FTExamples class >> exampleList4 [
 		- preselects one element 
 		- respond to selection changes
 		- respond to strong selections (double click)"
+
 	<sampleInstance>
 	<example>
 	| list |
-
 	list := FTTableMorph new
-		extent: 300@550;
+		extent: 300 @ 550;
 		dataSource: (FTExampleMethodListDataSource for: Object);
-		selectRowIndex: 42;
+		selectIndex: 42;
 		showFirstRowSelection;
-		onAnnouncement: FTSelectionChanged 
-			do: [ :ann | ('row selected: ', (ann newSelectedRowIndexes asString)) crLog ];
-		onAnnouncement: FTStrongSelectionChanged 
-			do: [ :ann | ('double-click on row: ', (ann selectedRowIndex asString)) crLog ];
+		onAnnouncement: FTSelectionChanged do: [ :ann | ('row selected: ' , ann newSelectedRowIndexes asString) crLog ];
+		onAnnouncement: FTStrongSelectionChanged do: [ :ann | ('double-click on row: ' , ann selectedIndex asString) crLog ];
 		yourself.
-		
+
 	^ list openInWindow
 ]
 
@@ -381,22 +384,20 @@ FTExamples class >> exampleList5 [
 		- respond to selection changes
 		- respond to strong selections (double click)
 		- allows multiple selection"
+
 	<sampleInstance>
 	<example>
 	| list |
-
 	list := FTTableMorph new
-		extent: 300@550;
+		extent: 300 @ 550;
 		dataSource: (FTExampleMethodListDataSource for: Object);
-		selectRowIndexes: #(42 43);
+		selectIndexes: #(42 43);
 		showFirstRowSelection;
-		onAnnouncement: FTSelectionChanged 
-			do: [ :ann | ('rows selected: ', (ann newSelectedRowIndexes asString)) crLog ];
-		onAnnouncement: FTStrongSelectionChanged 
-			do: [ :ann | ('double-click on row: ', (ann selectedRowIndex asString)) crLog ];
+		onAnnouncement: FTSelectionChanged do: [ :ann | ('rows selected: ' , ann newSelectedRowIndexes asString) crLog ];
+		onAnnouncement: FTStrongSelectionChanged do: [ :ann | ('double-click on row: ' , ann selectedIndex asString) crLog ];
 		beMultipleSelection;
 		yourself.
-		
+
 	^ list openInWindow
 ]
 
@@ -484,110 +485,102 @@ FTExamples class >> exampleOutline2 [
 { #category : #examples }
 FTExamples class >> exampleTable1 [
 	"Show a table with all Object methods"
+
 	<sampleInstance>
 	<example>
 	| table |
-
 	table := FTTableMorph new
-		extent: 650@500;
+		extent: 650 @ 500;
 		addColumn: (FTColumn id: 'Name');
 		addColumn: (FTColumn id: 'Protocol');
 		addColumn: (FTColumn id: 'Origin');
 		dataSource: (FTExampleMethodTableDataSource for: Object);
-		selectRowIndex: 1;
+		selectIndex: 1;
 		showFirstRowSelection;
-		onAnnouncement: FTSelectionChanged 
-			do: [ :ann | ('rows selected: ', (ann newSelectedRowIndexes asString)) crLog ];
-		onAnnouncement: FTStrongSelectionChanged 
-			do: [ :ann | ('double-click on row: ', (ann selectedRowIndex asString)) crLog ];
+		onAnnouncement: FTSelectionChanged do: [ :ann | ('rows selected: ' , ann newSelectedRowIndexes asString) crLog ];
+		onAnnouncement: FTStrongSelectionChanged do: [ :ann | ('double-click on row: ' , ann selectedIndex asString) crLog ];
 		beMultipleSelection;
 		beResizable;
 		yourself.
-		
+
 	^ table openInWindow
 ]
 
 { #category : #examples }
 FTExamples class >> exampleTable2 [
 	"Show a table with all Object methods, with a fixed width"
+
 	<sampleInstance>
 	<example>
 	| table |
-
 	table := FTTableMorph new
-		extent: 650@500;
+		extent: 650 @ 500;
 		addColumn: ((FTColumn id: 'Name') width: 350);
 		addColumn: (FTColumn id: 'Protocol');
 		addColumn: (FTColumn id: 'Origin');
 		dataSource: (FTExampleMethodTableDataSource for: Morph);
-		selectRowIndex: 1;
+		selectIndex: 1;
 		showFirstRowSelection;
-		onAnnouncement: FTSelectionChanged 
-			do: [ :ann | ('rows selected: ', (ann newSelectedRowIndexes asString)) crLog ];
-		onAnnouncement: FTStrongSelectionChanged 
-			do: [ :ann | ('double-click on row: ', (ann selectedRowIndex asString)) crLog ];
+		onAnnouncement: FTSelectionChanged do: [ :ann | ('rows selected: ' , ann newSelectedRowIndexes asString) crLog ];
+		onAnnouncement: FTStrongSelectionChanged do: [ :ann | ('double-click on row: ' , ann selectedIndex asString) crLog ];
 		beMultipleSelection;
 		beResizable;
 		yourself.
-		
+
 	^ table openInWindow
 ]
 
 { #category : #examples }
 FTExamples class >> exampleTable3 [
 	"Show a table with all Object methods, with a header"
+
 	<sampleInstance>
 	<example>
 	| table |
-
 	table := FTTableMorph new
-		extent: 650@500;
+		extent: 650 @ 500;
 		addColumn: ((FTColumn id: '#') width: 40);
 		addColumn: ((FTColumn id: 'Name') width: 350);
 		addColumn: (FTColumn id: 'Protocol');
 		addColumn: (FTColumn id: 'Origin');
 		intercellSpacing: 1;
 		dataSource: (FTExampleMethodTableDataSource for: Morph);
-		selectRowIndex: 1;
+		selectIndex: 1;
 		showFirstRowSelection;
-		onAnnouncement: FTSelectionChanged 
-			do: [ :ann | ('rows selected: ', (ann newSelectedRowIndexes asString)) crLog ];
-		onAnnouncement: FTStrongSelectionChanged 
-			do: [ :ann | ('double-click on row: ', (ann selectedRowIndex asString)) crLog ];
+		onAnnouncement: FTSelectionChanged do: [ :ann | ('rows selected: ' , ann newSelectedRowIndexes asString) crLog ];
+		onAnnouncement: FTStrongSelectionChanged do: [ :ann | ('double-click on row: ' , ann selectedIndex asString) crLog ];
 		beMultipleSelection;
 		beResizable;
 		yourself.
-		
+
 	^ table openInWindow
 ]
 
 { #category : #examples }
 FTExamples class >> exampleTable4 [
 	"Show a table with all Object methods, with a resizable header"
+
 	<sampleInstance>
 	<example>
 	| table |
-
 	table := FTTableMorph new
-		extent: 650@500;
+		extent: 650 @ 500;
 		addColumn: ((FTColumn id: '#') width: 40);
 		addColumn: ((FTColumn id: 'Name') width: 350);
 		addColumn: (FTColumn id: 'Protocol');
 		addColumn: (FTColumn id: 'Origin');
 		hideColumnHeaders;
 		beResizable;
-		intercellSpacing: 8@1;
+		intercellSpacing: 8 @ 1;
 		dataSource: (FTExampleMethodTableDataSource for: Morph);
-		selectRowIndex: 1;
+		selectIndex: 1;
 		showFirstRowSelection;
-		onAnnouncement: FTSelectionChanged 
-			do: [ :ann | ('rows selected: ', (ann newSelectedRowIndexes asString)) crLog ];
-		onAnnouncement: FTStrongSelectionChanged 
-			do: [ :ann | ('double-click on row: ', (ann selectedRowIndex asString)) crLog ];
+		onAnnouncement: FTSelectionChanged do: [ :ann | ('rows selected: ' , ann newSelectedRowIndexes asString) crLog ];
+		onAnnouncement: FTStrongSelectionChanged do: [ :ann | ('double-click on row: ' , ann selectedIndex asString) crLog ];
 		beMultipleSelection;
 		beResizable;
 		yourself.
-		
+
 	^ table openInWindow
 ]
 
@@ -595,28 +588,27 @@ FTExamples class >> exampleTable4 [
 FTExamples class >> exampleTableHorizontalScroll [
 	"Show a table with all Object methods, with a header,
 	 all fixed width columns as horizontal scroll."
-	<example>
+
 	"self exampleTableHorizontalScroll"
+
+	<example>
 	| table |
-	
 	table := FTTableMorph newTrialHorizontalScrollBar
-		extent: 650@500;
+		extent: 650 @ 500;
 		addColumn: ((FTColumn id: '#') width: 40);
 		addColumn: ((FTColumn id: 'Name') width: 350);
 		addColumn: ((FTColumn id: 'Protocol') width: 200);
 		addColumn: ((FTColumn id: 'Origin') width: 200);
 		intercellSpacing: 1;
 		dataSource: (FTExampleMethodTableDataSource for: Morph);
-		selectRowIndex: 1;
+		selectIndex: 1;
 		showFirstRowSelection;
-		onAnnouncement: FTSelectionChanged 
-			do: [ :ann | ('rows selected: ', (ann newSelectedRowIndexes asString)) crLog ];
-		onAnnouncement: FTStrongSelectionChanged 
-			do: [ :ann | ('double-click on row: ', (ann selectedRowIndex asString)) crLog ];
+		onAnnouncement: FTSelectionChanged do: [ :ann | ('rows selected: ' , ann newSelectedRowIndexes asString) crLog ];
+		onAnnouncement: FTStrongSelectionChanged do: [ :ann | ('double-click on row: ' , ann selectedIndex asString) crLog ];
 		beMultipleSelection;
 		yourself.
-		
-	^table openInWindow.
+
+	^ table openInWindow
 ]
 
 { #category : #'tree examples' }

--- a/src/Morphic-Widgets-FastTable/FTExamples.class.st
+++ b/src/Morphic-Widgets-FastTable/FTExamples.class.st
@@ -261,7 +261,7 @@ FTExamples class >> exampleEditableList1 [
 		extent: 300 @ 550;
 		dataSource: (FTExampleDropDataSource new elements: data);
 		selectIndex: 1;
-		showFirstRowSelection;
+		showFirstSelection;
 		onAnnouncement: FTStrongSelectionChanged
 			do: [ :ann | 
 			| index morph ed |
@@ -328,7 +328,7 @@ FTExamples class >> exampleList2 [
 		extent: 300 @ 550;
 		dataSource: (FTExampleMethodListDataSource for: Object);
 		selectIndex: 42;
-		showFirstRowSelection;
+		showFirstSelection;
 		allowDeselection;
 		yourself.
 
@@ -348,7 +348,7 @@ FTExamples class >> exampleList3 [
 		extent: 300 @ 550;
 		dataSource: (FTExampleMethodListDataSource for: Object);
 		selectIndex: 42;
-		showFirstRowSelection;
+		showFirstSelection;
 		onAnnouncement: FTSelectionChanged do: [ :ann | ('row selected: ' , ann newSelectedRowIndexes asString) crLog ];
 		yourself.
 
@@ -369,7 +369,7 @@ FTExamples class >> exampleList4 [
 		extent: 300 @ 550;
 		dataSource: (FTExampleMethodListDataSource for: Object);
 		selectIndex: 42;
-		showFirstRowSelection;
+		showFirstSelection;
 		onAnnouncement: FTSelectionChanged do: [ :ann | ('row selected: ' , ann newSelectedRowIndexes asString) crLog ];
 		onAnnouncement: FTStrongSelectionChanged do: [ :ann | ('double-click on row: ' , ann selectedIndex asString) crLog ];
 		yourself.
@@ -392,7 +392,7 @@ FTExamples class >> exampleList5 [
 		extent: 300 @ 550;
 		dataSource: (FTExampleMethodListDataSource for: Object);
 		selectIndexes: #(42 43);
-		showFirstRowSelection;
+		showFirstSelection;
 		onAnnouncement: FTSelectionChanged do: [ :ann | ('rows selected: ' , ann newSelectedRowIndexes asString) crLog ];
 		onAnnouncement: FTStrongSelectionChanged do: [ :ann | ('double-click on row: ' , ann selectedIndex asString) crLog ];
 		beMultipleSelection;
@@ -496,7 +496,7 @@ FTExamples class >> exampleTable1 [
 		addColumn: (FTColumn id: 'Origin');
 		dataSource: (FTExampleMethodTableDataSource for: Object);
 		selectIndex: 1;
-		showFirstRowSelection;
+		showFirstSelection;
 		onAnnouncement: FTSelectionChanged do: [ :ann | ('rows selected: ' , ann newSelectedRowIndexes asString) crLog ];
 		onAnnouncement: FTStrongSelectionChanged do: [ :ann | ('double-click on row: ' , ann selectedIndex asString) crLog ];
 		beMultipleSelection;
@@ -520,7 +520,7 @@ FTExamples class >> exampleTable2 [
 		addColumn: (FTColumn id: 'Origin');
 		dataSource: (FTExampleMethodTableDataSource for: Morph);
 		selectIndex: 1;
-		showFirstRowSelection;
+		showFirstSelection;
 		onAnnouncement: FTSelectionChanged do: [ :ann | ('rows selected: ' , ann newSelectedRowIndexes asString) crLog ];
 		onAnnouncement: FTStrongSelectionChanged do: [ :ann | ('double-click on row: ' , ann selectedIndex asString) crLog ];
 		beMultipleSelection;
@@ -546,7 +546,7 @@ FTExamples class >> exampleTable3 [
 		intercellSpacing: 1;
 		dataSource: (FTExampleMethodTableDataSource for: Morph);
 		selectIndex: 1;
-		showFirstRowSelection;
+		showFirstSelection;
 		onAnnouncement: FTSelectionChanged do: [ :ann | ('rows selected: ' , ann newSelectedRowIndexes asString) crLog ];
 		onAnnouncement: FTStrongSelectionChanged do: [ :ann | ('double-click on row: ' , ann selectedIndex asString) crLog ];
 		beMultipleSelection;
@@ -574,7 +574,7 @@ FTExamples class >> exampleTable4 [
 		intercellSpacing: 8 @ 1;
 		dataSource: (FTExampleMethodTableDataSource for: Morph);
 		selectIndex: 1;
-		showFirstRowSelection;
+		showFirstSelection;
 		onAnnouncement: FTSelectionChanged do: [ :ann | ('rows selected: ' , ann newSelectedRowIndexes asString) crLog ];
 		onAnnouncement: FTStrongSelectionChanged do: [ :ann | ('double-click on row: ' , ann selectedIndex asString) crLog ];
 		beMultipleSelection;
@@ -602,7 +602,7 @@ FTExamples class >> exampleTableHorizontalScroll [
 		intercellSpacing: 1;
 		dataSource: (FTExampleMethodTableDataSource for: Morph);
 		selectIndex: 1;
-		showFirstRowSelection;
+		showFirstSelection;
 		onAnnouncement: FTSelectionChanged do: [ :ann | ('rows selected: ' , ann newSelectedRowIndexes asString) crLog ];
 		onAnnouncement: FTStrongSelectionChanged do: [ :ann | ('double-click on row: ' , ann selectedIndex asString) crLog ];
 		beMultipleSelection;

--- a/src/Morphic-Widgets-FastTable/FTFilterFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTFilterFunction.class.st
@@ -36,7 +36,7 @@ FTFilterFunction >> filter [
 
 	table dataSource: (pattern ifEmpty: [ initialDataSource ] ifNotEmpty: [ initialDataSource newDataSourceMatching: (filterClass pattern: pattern) ]).
 	table refresh.
-	table selectRowIndexes: #().
+	table selectIndexes: #().
 		
 	self isExplicite
 		ifTrue: [ self resizeWidget ]

--- a/src/Morphic-Widgets-FastTable/FTFilterFunctionWithAction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTFilterFunctionWithAction.class.st
@@ -51,8 +51,8 @@ FTFilterFunctionWithAction >> action: aBlockClosure named: aString [
 FTFilterFunctionWithAction >> beExplicite [
 	super beExplicite.
 	table addMorph: actionButton.
-	table selectedRowIndex = 0
-		ifTrue: [ table selectRowIndex: 1 ]
+	table selectedIndex = 0
+		ifTrue: [ table selectIndex: 1 ]
 ]
 
 { #category : #execute }
@@ -61,8 +61,8 @@ FTFilterFunctionWithAction >> execute [
 		cull: table dataSource
 		cull: field getTextFromModel asString
 		cull:
-			(table selectedRowIndex = 0
-				ifFalse: [ table dataSource realElementAt: table selectedRowIndex ]
+			(table selectedIndex = 0
+				ifFalse: [ table dataSource realElementAt: table selectedIndex ]
 				ifTrue: [ nil ])
 ]
 
@@ -104,6 +104,5 @@ FTFilterFunctionWithAction >> resizeWidget [
 FTFilterFunctionWithAction >> showWidget [
 	super showWidget.
 	table addMorph: actionButton.
-	table selectedRowIndex = 0
-		ifTrue: [ table selectRowIndex: 1 ]
+	table selectedIndex = 0 ifTrue: [ table selectIndex: 1 ]
 ]

--- a/src/Morphic-Widgets-FastTable/FTMultipleSelection.class.st
+++ b/src/Morphic-Widgets-FastTable/FTMultipleSelection.class.st
@@ -16,13 +16,13 @@ FTMultipleSelection >> isMultiple [
 { #category : #private }
 FTMultipleSelection >> selectAppendingRowIndex: rowIndex [
 	| currentSelection newSelection |
-	currentSelection := self table selectedRowIndexes.
+	currentSelection := self table selectedIndexes.
 	
 	newSelection := (currentSelection includes: rowIndex)
 		ifTrue: [ currentSelection copyWithout: rowIndex ]
 		ifFalse: [ currentSelection copyWithFirst: rowIndex].
 		
-	self table selectRowIndexes: newSelection
+	self table selectIndexes: newSelection
 ]
 
 { #category : #accessing }
@@ -38,7 +38,7 @@ FTMultipleSelection >> selectRowIndexes: rowIndex previous: oldSelection [
 	"I ensure the selected row index is the first in selection range so I can handle it better. 
 	 I do not like to assume and probably I will need the concept of 'selection', but for now 
 	 let's not abuse :)"
-	self table selectRowIndexes: (((oldSelection includes: rowIndex)
+	self table selectIndexes: (((oldSelection includes: rowIndex)
 		ifTrue: [ oldSelection copyWithout: rowIndex ]
 		ifFalse: [ oldSelection] )
 		copyWithFirst: rowIndex)
@@ -50,7 +50,7 @@ FTMultipleSelection >> selectRowIndexesUpTo: endIndex [
 	 This is used in case of multiple selections (when holding shift)"
 	| oldSelected firstIndex step |
 
-	oldSelected := self table selectedRowIndexes.
+	oldSelected := self table selectedIndexes.
 	firstIndex :=  oldSelected 
 		ifNotEmpty: [ oldSelected first ]
 		ifEmpty: [ endIndex ].

--- a/src/Morphic-Widgets-FastTable/FTPluggableIconListMorphAdaptor.class.st
+++ b/src/Morphic-Widgets-FastTable/FTPluggableIconListMorphAdaptor.class.st
@@ -411,7 +411,7 @@ FTPluggableIconListMorphAdaptor >> scrollValue [
 
 { #category : #ignored }
 FTPluggableIconListMorphAdaptor >> searchedElement: index [
-	self highlightRowIndex: index
+	self highlightIndex: index
 ]
 
 { #category : #private }

--- a/src/Morphic-Widgets-FastTable/FTPluggableIconListMorphAdaptor.class.st
+++ b/src/Morphic-Widgets-FastTable/FTPluggableIconListMorphAdaptor.class.st
@@ -497,10 +497,10 @@ FTPluggableIconListMorphAdaptor >> update: symbol [
 
 { #category : #updating }
 FTPluggableIconListMorphAdaptor >> updateList [
-	(showIndex < self dataSource numberOfRows and: [ self isRowIndexVisible: showIndex ])
+	(showIndex < self dataSource numberOfRows and: [ self isIndexVisible: showIndex ])
 		ifFalse: [ self resetPosition ].
 	self basicUpdateSelectionIndex.
-	(self hasSelection and: [ (self isRowIndexVisible: self selectedIndex) ])
+	(self hasSelection and: [ (self isIndexVisible: self selectedIndex) ])
 		ifFalse: [ self resetPosition.
 			self ensureVisibleFirstSelection ].
 	self refresh

--- a/src/Morphic-Widgets-FastTable/FTPluggableIconListMorphAdaptor.class.st
+++ b/src/Morphic-Widgets-FastTable/FTPluggableIconListMorphAdaptor.class.st
@@ -152,10 +152,10 @@ FTPluggableIconListMorphAdaptor >> basicUpdateSelectionIndex [
 	self getIndexSelector ifNil: [ ^ self ].
 	
 	rowIndex := self model perform: self getIndexSelector.
-	rowIndex = self selectedRowIndex ifTrue: [ ^ self ].
+	rowIndex = self selectedIndex ifTrue: [ ^ self ].
 	rowIndex = 0
-		ifTrue: [ self basicSelectRowIndexes: #() ]
-		ifFalse: [ self basicSelectRowIndexes: { rowIndex } ]
+		ifTrue: [ self basicSelectIndexes: #() ]
+		ifFalse: [ self basicSelectIndexes: { rowIndex } ]
 ]
 
 { #category : #'accessing selectors' }
@@ -277,7 +277,7 @@ FTPluggableIconListMorphAdaptor >> interactWithSelection [
 	
 	self hasSelection ifFalse: [ ^ self ].
 	"this is a horrible hack, but well... that's how it is implemented :("
-	cell := (self container exposedRows at: self selectedRowIndex) submorphs first. "the cell is there"
+	cell := (self container exposedRows at: self selectedIndex) submorphs first. "the cell is there"
 	cell submorphsDo: [ :each | each update: #interact ]
 ]
 
@@ -500,7 +500,7 @@ FTPluggableIconListMorphAdaptor >> updateList [
 	(showIndex < self dataSource numberOfRows and: [ self isRowIndexVisible: showIndex ])
 		ifFalse: [ self resetPosition ].
 	self basicUpdateSelectionIndex.
-	(self hasSelection and: [ (self isRowIndexVisible: self selectedRowIndex) ])
+	(self hasSelection and: [ (self isRowIndexVisible: self selectedIndex) ])
 		ifFalse: [ self resetPosition.
 			self ensureVisibleFirstSelection ].
 	self refresh

--- a/src/Morphic-Widgets-FastTable/FTSearchFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTSearchFunction.class.st
@@ -27,7 +27,7 @@ FTSearchFunction >> keyStroke: anEvent [
 	(anEvent anyModifierKeyPressed
 		or: [ anEvent keyCharacter isAlphaNumeric not ])
 		ifTrue: [ ^ false ].
-	currentSelIndex := self table selectedRowIndex.
+	currentSelIndex := self table selectedIndex.
 	currentHighlightedIndexes := self table highlightedRowIndexes.
 	self showSearchFieldFromKeystrokeEvent: anEvent.
 	^ true
@@ -38,7 +38,7 @@ FTSearchFunction >> realSearch [
 	| founds |
 	founds := self table dataSource searchText: pattern.
 
-	founds ifNotEmpty: [ self table selectRowIndex: founds first ].
+	founds ifNotEmpty: [ self table selectIndex: founds first ].
 	self table highlightRowIndexes: founds.
 	
 	^ founds notEmpty
@@ -65,7 +65,7 @@ FTSearchFunction >> showSearchFieldFromKeystrokeEvent: anEvent [
 		withEditedContentsDo:
 				[ :contents :editor | 
 			contents
-				ifEmpty: [ founds ifTrue: [self table selectRowIndex: currentSelIndex]. 
+				ifEmpty: [ founds ifTrue: [self table selectIndex: currentSelIndex]. 
 					self table highlightRowIndexes: currentHighlightedIndexes ]
 				ifNotEmpty:
 					[ founds := self searchFor: contents.
@@ -80,7 +80,7 @@ FTSearchFunction >> showSearchFieldFromKeystrokeEvent: anEvent [
 									(contents
 										addAttribute: (TextColor new color: Color red);
 										yourself) ] ] ];
-		whenEditorEscapedDo: [ founds ifTrue: [self table selectRowIndex: currentSelIndex].
+		whenEditorEscapedDo: [ founds ifTrue: [self table selectIndex: currentSelIndex].
 			self table highlightRowIndexes: currentHighlightedIndexes ].
 	ed autoAccept: true.
 	founds

--- a/src/Morphic-Widgets-FastTable/FTSearchFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTSearchFunction.class.st
@@ -28,7 +28,7 @@ FTSearchFunction >> keyStroke: anEvent [
 		or: [ anEvent keyCharacter isAlphaNumeric not ])
 		ifTrue: [ ^ false ].
 	currentSelIndex := self table selectedIndex.
-	currentHighlightedIndexes := self table highlightedRowIndexes.
+	currentHighlightedIndexes := self table highlightedIndexes.
 	self showSearchFieldFromKeystrokeEvent: anEvent.
 	^ true
 ]
@@ -39,7 +39,7 @@ FTSearchFunction >> realSearch [
 	founds := self table dataSource searchText: pattern.
 
 	founds ifNotEmpty: [ self table selectIndex: founds first ].
-	self table highlightRowIndexes: founds.
+	self table highlightIndexes: founds.
 	
 	^ founds notEmpty
 ]
@@ -66,7 +66,7 @@ FTSearchFunction >> showSearchFieldFromKeystrokeEvent: anEvent [
 				[ :contents :editor | 
 			contents
 				ifEmpty: [ founds ifTrue: [self table selectIndex: currentSelIndex]. 
-					self table highlightRowIndexes: currentHighlightedIndexes ]
+					self table highlightIndexes: currentHighlightedIndexes ]
 				ifNotEmpty:
 					[ founds := self searchFor: contents.
 					founds
@@ -81,7 +81,7 @@ FTSearchFunction >> showSearchFieldFromKeystrokeEvent: anEvent [
 										addAttribute: (TextColor new color: Color red);
 										yourself) ] ] ];
 		whenEditorEscapedDo: [ founds ifTrue: [self table selectIndex: currentSelIndex].
-			self table highlightRowIndexes: currentHighlightedIndexes ].
+			self table highlightIndexes: currentHighlightedIndexes ].
 	ed autoAccept: true.
 	founds
 		ifFalse: [ s addAttribute: (TextColor new color: Color red) ]

--- a/src/Morphic-Widgets-FastTable/FTSelectionStrategy.class.st
+++ b/src/Morphic-Widgets-FastTable/FTSelectionStrategy.class.st
@@ -51,10 +51,7 @@ FTSelectionStrategy >> table [
 
 { #category : #private }
 FTSelectionStrategy >> toggleRowIndex: rowIndex [
-	((self table selectedRowIndexes includes: rowIndex) 
-		and: [ self table selectedRowIndexes size = 1 "just one selected"
-		and: [ self table allowsDeselection ] ])
-			ifTrue: [  self table selectRowIndexes: #() ]
-			ifFalse: [
-				self table selectRowIndex: rowIndex ]
+	((self table selectedIndexes includes: rowIndex) and: [ self table selectedIndexes size = 1 and: [ self table allowsDeselection ]	"just one selected" ])
+		ifTrue: [ self table selectIndexes: #() ]
+		ifFalse: [ self table selectIndex: rowIndex ]
 ]

--- a/src/Morphic-Widgets-FastTable/FTTableContainerMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableContainerMorph.class.st
@@ -178,19 +178,16 @@ FTTableContainerMorph >> defaultColor [
 { #category : #drawing }
 FTTableContainerMorph >> drawOn: canvas [
 	| x y cellWidth cellHeight rowsToDisplay rowSubviews highligtedRowIndexes primarySelectionIndex |
-	
 	super drawOn: canvas.
-	self canRefreshValues ifFalse: [ ^ self ]. "Nothing to update yet"
+	self canRefreshValues ifFalse: [ ^ self ].	"Nothing to update yet"
 
 	x := self left + self class rowLeftMargin.
-	y := self top.	
+	y := self top.
 	cellWidth := self width - self class rowLeftMargin.
-	cellHeight := self table rowHeight rounded. 
-	highligtedRowIndexes := 
-		self table selectedRowIndexes, 
-		self table highlightedRowIndexes.
-	primarySelectionIndex := self table selectedRowIndex.
-	
+	cellHeight := self table rowHeight rounded.
+	highligtedRowIndexes := self table selectedIndexes , self table highlightedRowIndexes.
+	primarySelectionIndex := self table selectedIndex.
+
 	"For some superweird reason, calling #calculateExposedRows here instead in #changed (where
 	 it should be called) is 10x faster. Since the whole purpose of this component is speed, for 
 	 now I'm calling it here and adding the #setNeedRecalculateRows mechanism. 
@@ -199,30 +196,33 @@ FTTableContainerMorph >> drawOn: canvas [
 
 	rowsToDisplay := self exposedRows.
 	rowSubviews := OrderedCollection new: rowsToDisplay size + 1.
-	headerRow ifNotNil: [ 
-		headerRow bounds: (self left@y extent: self width@cellHeight).
-		y := y + cellHeight + self table intercellSpacing y.		
-		rowSubviews add: headerRow ].
-	
-	rowsToDisplay keysAndValuesDo: [ :rowIndex :row | | visibleHeight |
-		visibleHeight := cellHeight min: (self bottom - y). 
-		row bounds: (x@y extent: cellWidth@visibleHeight).
-		y := y + visibleHeight + self table intercellSpacing y.
-		
-		(highligtedRowIndexes includes: rowIndex) ifTrue: [ 
-			row selectionColor: (self table colorForSelection: primarySelectionIndex = rowIndex) ].
-		rowSubviews add: row ].
+	headerRow
+		ifNotNil: [ headerRow bounds: (self left @ y extent: self width @ cellHeight).
+			y := y + cellHeight + self table intercellSpacing y.
+			rowSubviews add: headerRow ].
+
+	rowsToDisplay
+		keysAndValuesDo: [ :rowIndex :row | 
+			| visibleHeight |
+			visibleHeight := cellHeight min: self bottom - y.
+			row bounds: (x @ y extent: cellWidth @ visibleHeight).
+			y := y + visibleHeight + self table intercellSpacing y.
+
+			(highligtedRowIndexes includes: rowIndex) ifTrue: [ row selectionColor: (self table colorForSelection: primarySelectionIndex = rowIndex) ].
+			rowSubviews add: row ].
 
 	"We should notify existing rows about deletion and new rows about insertion. 
-	It is required to correctly manage stepping animation of cells"						
-	submorphs do: [:each | 
-		each privateOwner: nil; outOfWorld: self world].
+	It is required to correctly manage stepping animation of cells"
+	submorphs
+		do: [ :each | 
+			each
+				privateOwner: nil;
+				outOfWorld: self world ].
 	submorphs := rowSubviews asArray.
-	submorphs do: [:each | each intoWorld: self world].
-	
-	self table isResizable 
-		ifTrue: [ self addResizeSplitters ].
-	
+	submorphs do: [ :each | each intoWorld: self world ].
+
+	self table isResizable ifTrue: [ self addResizeSplitters ].
+
 
 	needsRefreshExposedRows := false
 ]

--- a/src/Morphic-Widgets-FastTable/FTTableContainerMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableContainerMorph.class.st
@@ -185,7 +185,7 @@ FTTableContainerMorph >> drawOn: canvas [
 	y := self top.
 	cellWidth := self width - self class rowLeftMargin.
 	cellHeight := self table rowHeight rounded.
-	highligtedRowIndexes := self table selectedIndexes , self table highlightedRowIndexes.
+	highligtedRowIndexes := self table selectedIndexes , self table highlightedIndexes.
 	primarySelectionIndex := self table selectedIndex.
 
 	"For some superweird reason, calling #calculateExposedRows here instead in #changed (where

--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -30,7 +30,6 @@ Class {
 		'dataSource',
 		'intercellSpacing',
 		'rowHeight',
-		'selectedRowIndexes',
 		'highlightedRowIndexes',
 		'selectionStrategy',
 		'columns',
@@ -41,7 +40,8 @@ Class {
 		'needToggleAtMouseUp',
 		'function',
 		'resizable',
-		'trialHSB'
+		'trialHSB',
+		'selectedIndexes'
 	],
 	#category : #'Morphic-Widgets-FastTable'
 }
@@ -142,9 +142,14 @@ FTTableMorph >> basicMoveShowIndexTo: aNumber [
 ]
 
 { #category : #private }
-FTTableMorph >> basicSelectRowIndexes: anArray [
-	selectedRowIndexes := anArray asArray.
+FTTableMorph >> basicSelectIndexes: anArray [
+	selectedIndexes := anArray asArray
+]
 
+{ #category : #private }
+FTTableMorph >> basicSelectRowIndexes: anArray [
+	self deprecated: 'Use #basicSelectIndexes: instead' transformWith: '`@receiver basicSelectRowIndexes: `@statements' -> '`@receiver basicSelectIndexes: `@statements'.
+	self basicSelectIndexes: anArray
 ]
 
 { #category : #accessing }
@@ -305,11 +310,9 @@ FTTableMorph >> ensureAtLeastOneColumn [
 FTTableMorph >> ensureVisibleFirstSelection [
 	| rowIndex |
 	self hasSelection ifFalse: [ ^ self ].
-	rowIndex := self selectedRowIndex.
-	(self container isRowIndexFullyVisible: rowIndex) ifFalse: [ 
-		rowIndex < self showIndex 
-			ifTrue: [ self moveShowIndexTo: rowIndex ]
-			ifFalse: [ self moveShowIndexTo: (rowIndex - self container calculateMinVisibleRows + 1) ] ]
+	rowIndex := self selectedIndex.
+	(self container isRowIndexFullyVisible: rowIndex)
+		ifFalse: [ rowIndex < self showIndex ifTrue: [ self moveShowIndexTo: rowIndex ] ifFalse: [ self moveShowIndexTo: rowIndex - self container calculateMinVisibleRows + 1 ] ]
 ]
 
 { #category : #accessing }
@@ -368,7 +371,7 @@ FTTableMorph >> hasHighlighted [
 
 { #category : #testing }
 FTTableMorph >> hasSelection [
-	^ self selectedRowIndexes notEmpty
+	^ self selectedIndexes notEmpty
 ]
 
 { #category : #'accessing colors' }
@@ -396,20 +399,18 @@ FTTableMorph >> highlightRowIndex: aNumber [
 { #category : #'accessing selection' }
 FTTableMorph >> highlightRowIndexes: anArray [
 	anArray = highlightedRowIndexes ifTrue: [ ^ self ].
-	
-	self basicHighlightRowIndexes: anArray. 
-	
-	(self hasHighlighted and: [ (self isRowIndexVisible: self highlightedRowIndex) not ]) 
-		ifTrue: [ 
-			self moveShowIndexTo: self highlightedRowIndexes first.
+
+	self basicHighlightRowIndexes: anArray.
+
+	(self hasHighlighted and: [ (self isRowIndexVisible: self highlightedRowIndex) not ])
+		ifTrue: [ self moveShowIndexTo: self highlightedRowIndexes first.
 			^ self ].
-	
-	(self hasSelection and: [ (self isRowIndexVisible: self selectedRowIndex) not  ])
-		ifTrue: [ 
-			self moveShowIndexTo: self selectedRowIndex.
+
+	(self hasSelection and: [ (self isRowIndexVisible: self selectedIndex) not ])
+		ifTrue: [ self moveShowIndexTo: self selectedIndex.
 			^ self ].
-	
-	self refresh.
+
+	self refresh
 ]
 
 { #category : #'accessing selection' }
@@ -452,7 +453,7 @@ FTTableMorph >> initialize [
 	super initialize.
 	showIndex := 0.
 	showColumnHeaders := true.
-	selectedRowIndexes := #().
+	selectedIndexes := #().
 	highlightedRowIndexes := #().
 	columns := #().
 	needToggleAtMouseUp := false.
@@ -483,13 +484,13 @@ FTTableMorph >> initializeKeyBindings [
 		toAction: [ :target :morph :event | self keyStrokeArrowDown: event ].
 	self 
 		bindKeyCombination: Character home asKeyCombination
-		toAction: [ self selectRowIndex: 1 ].
+		toAction: [ self selectIndex: 1 ].
 	self 
 		bindKeyCombination: Character end asKeyCombination
-		toAction: [ self selectRowIndex: self numberOfRows ].
+		toAction: [ self selectIndex: self numberOfRows ].
 	self 
 		bindKeyCombination: $a meta  
-		toAction: [ self selectAllRowIndexes ]
+		toAction: [ self selectAllIndexes ]
 ]
 
 { #category : #initialization }
@@ -549,7 +550,7 @@ FTTableMorph >> isResizable [
 
 { #category : #testing }
 FTTableMorph >> isRowIndexSelected: rowIndex [
-	^ self selectedRowIndexes includes: rowIndex
+	^ self selectedIndexes includes: rowIndex
 ]
 
 { #category : #testing }
@@ -592,7 +593,7 @@ FTTableMorph >> keyStroke: event [
 { #category : #'event handling' }
 FTTableMorph >> keyStrokeArrowDown: event [
 	| rowIndex |
-	rowIndex := self selectedRowIndex.
+	rowIndex := self selectedIndex.
 	rowIndex < self numberOfRows
 		ifFalse: [ ^ self ].
 	self resetFunction.
@@ -602,7 +603,7 @@ FTTableMorph >> keyStrokeArrowDown: event [
 { #category : #'event handling' }
 FTTableMorph >> keyStrokeArrowUp: event [
 	| rowIndex |
-	rowIndex := self selectedRowIndex.
+	rowIndex := self selectedIndex.
 	rowIndex > 1
 		ifFalse: [ ^ self ].
 	self resetFunction.
@@ -640,15 +641,11 @@ FTTableMorph >> minWidth [
 FTTableMorph >> mouseDown: event [
 	| rowIndex |
 	"perform the click"
-	
 	needToggleAtMouseUp ifTrue: [ ^ self ].
-	
+
 	rowIndex := self container rowIndexContainingPoint: event cursorPoint.
-	(self selectedRowIndexes includes: rowIndex)
-		ifFalse: [ self selectRowIndex: rowIndex event: event ]
-		ifTrue: [ needToggleAtMouseUp := true ].	"If the cell is selected we let the mouse up toggle to avoid any problem with the drag and drop"
-	self wantsKeyboardFocus
-		ifTrue: [ self takeKeyboardFocus ].
+	(self selectedIndexes includes: rowIndex) ifFalse: [ self selectRowIndex: rowIndex event: event ] ifTrue: [ needToggleAtMouseUp := true ].	"If the cell is selected we let the mouse up toggle to avoid any problem with the drag and drop"
+	self wantsKeyboardFocus ifTrue: [ self takeKeyboardFocus ].
 	event hand waitForClicksOrDrag: self event: event
 ]
 
@@ -894,54 +891,89 @@ FTTableMorph >> secondarySelectionColor: aColor [
 ]
 
 { #category : #'accessing selection' }
-FTTableMorph >> selectAllRowIndexes [
+FTTableMorph >> selectAllIndexes [
 	self isMultipleSelection ifFalse: [ ^ self ].
-	self selectRowIndexes: (1 to: self numberOfRows) asArray 
+	self selectIndexes: (1 to: self numberOfRows) asArray 
+]
+
+{ #category : #'accessing selection' }
+FTTableMorph >> selectAllRowIndexes [
+	self deprecated: 'Use #selectAllIndexes instead' transformWith: '`@receiver selectAllRowIndexes' -> '`@receiver selectAllIndexes'.
+	^ self selectAllIndexes
+]
+
+{ #category : #'accessing selection' }
+FTTableMorph >> selectIndex: anArray [
+	self selectIndexes: {anArray}
+]
+
+{ #category : #'accessing selection' }
+FTTableMorph >> selectIndexes: anArray [
+	self selectIndexes: anArray andMakeVisibleIf: true
+]
+
+{ #category : #'accessing selection' }
+FTTableMorph >> selectIndexes: anArray andMakeVisibleIf: shouldEnsureVisibleSelection [
+	| oldSelectedIndexes |
+	anArray = selectedIndexes ifTrue: [ ^ self ].
+	oldSelectedIndexes := selectedIndexes.
+	self basicSelectIndexes: anArray.
+	shouldEnsureVisibleSelection ifTrue: [ self ensureVisibleFirstSelection ].
+	self refresh.
+	self
+		doAnnounce:
+			((FTSelectionChanged from: oldSelectedIndexes to: selectedIndexes)
+				fastTable: self;
+				yourself)
 ]
 
 { #category : #'accessing selection' }
 FTTableMorph >> selectRowIndex: aNumber [
-	self selectRowIndexes: { aNumber }
+	self deprecated: 'Use #selectIndex: instead' transformWith: '`@receiver selectRowIndex: `@statements1' -> '`@receiver selectIndex: `@statements1'.
+	self selectIndex: aNumber
 ]
 
 { #category : #private }
 FTTableMorph >> selectRowIndex: rowIndex event: event [
 	rowIndex
 		ifNotNil: [ selectionStrategy selectRowIndex: rowIndex event: event ]
-		ifNil: [ self selectRowIndexes: #() ].
+		ifNil: [ self selectIndexes: #() ].
 ]
 
 { #category : #'accessing selection' }
 FTTableMorph >> selectRowIndexes: anArray [
-	self selectRowIndexes: anArray andMakeVisibleIf: true
+	self deprecated: 'Use #selectIndexes: instead' transformWith: '`@receiver selectRowIndexes: `@statements1' -> '`@receiver selectIndexes: `@statements1'.
+	self selectIndexes: anArray
 ]
 
 { #category : #'accessing selection' }
 FTTableMorph >> selectRowIndexes: anArray andMakeVisibleIf: shouldEnsureVisibleSelection [
-	| oldSelectedRowIndexes |
-	anArray = selectedRowIndexes
-		ifTrue: [ ^ self ].
-	oldSelectedRowIndexes := selectedRowIndexes.
-	self basicSelectRowIndexes: anArray.
-	shouldEnsureVisibleSelection ifTrue: [ self ensureVisibleFirstSelection ].
-	self refresh.
 	self
-		doAnnounce:
-			((FTSelectionChanged from: oldSelectedRowIndexes to: selectedRowIndexes)
-				fastTable: self;
-				yourself)
+		deprecated: 'Use #selectIndexes:andMakeVisibleIf: instead'
+		transformWith: '`@receiver selectRowIndexes: `@statements1 andMakeVisibleIf: `@statements2' -> '`@receiver selectIndexes: `@statements1 andMakeVisibleIf: `@statements2'.
+	self selectIndexes: anArray andMakeVisibleIf: shouldEnsureVisibleSelection
+]
+
+{ #category : #'accessing selection' }
+FTTableMorph >> selectedIndex [
+	^ self selectedIndexes ifNotEmpty: #first ifEmpty: [ 0 ]
+]
+
+{ #category : #'accessing selection' }
+FTTableMorph >> selectedIndexes [
+	^ selectedIndexes
 ]
 
 { #category : #'accessing selection' }
 FTTableMorph >> selectedRowIndex [
-	^ self selectedRowIndexes 
-		ifNotEmpty: [ :indexes | indexes first ]
-		ifEmpty: [ 0 ] 
+	self deprecated: 'Use #selectedIndex instead' transformWith: '`@receiver selectedRowIndex' -> '`@receiver selectedIndex'.
+	^ self selectedIndex
 ]
 
 { #category : #'accessing selection' }
 FTTableMorph >> selectedRowIndexes [
-	^ selectedRowIndexes
+	self deprecated: 'Use #selectedIndexes instead' transformWith: '`@receiver selectedRowIndexes' -> '`@receiver selectedIndexes'.
+	^ self selectedIndexes
 ]
 
 { #category : #'accessing colors' }
@@ -979,7 +1011,7 @@ FTTableMorph >> showColumnHeaders [
 { #category : #accessing }
 FTTableMorph >> showFirstRowSelection [
 	self hasSelection ifFalse: [ ^ self ].
-	self moveShowIndexTo: self selectedRowIndex
+	self moveShowIndexTo: self selectedIndex
 ]
 
 { #category : #private }
@@ -1002,7 +1034,7 @@ FTTableMorph >> showMenuForRowIndex: rowIndex columnIndex: columnIndex [
 	| menu |
 
 	(rowIndex notNil and: [ (self isRowIndexSelected: rowIndex) not ]) ifTrue: [ 
-		self selectRowIndex: rowIndex ].
+		self selectIndex: rowIndex ].
 
 	menu := self dataSource 
 		menuColumn: (columnIndex ifNotNil: [self columns at: columnIndex])
@@ -1026,7 +1058,7 @@ FTTableMorph >> startDrag: event [
 	event hand anyButtonPressed ifFalse: [ ^self ].
 	self hasSelection ifFalse: [ ^ self ].
 			
-	passengers := self selectedRowIndexes collect: [ :each | self dataSource passengerAt: each ].
+	passengers := self selectedIndexes collect: [ :each | self dataSource passengerAt: each ].
 	transferMorph := self dataSource transferFor: passengers from: self.
 	transferMorph align: transferMorph draggedMorph topLeft with: event position.
 	transferMorph dragTransferType: self dataSource dragTransferType.

--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -26,11 +26,12 @@ Class {
 		'verticalScrollBar',
 		'horizontalScrollBar',
 		'selectionColor',
+		'selectedIndexes',
+		'highlightedIndexes',
 		'showIndex',
 		'dataSource',
 		'intercellSpacing',
 		'rowHeight',
-		'highlightedRowIndexes',
 		'selectionStrategy',
 		'columns',
 		'secondarySelectionColor',
@@ -40,8 +41,7 @@ Class {
 		'needToggleAtMouseUp',
 		'function',
 		'resizable',
-		'trialHSB',
-		'selectedIndexes'
+		'trialHSB'
 	],
 	#category : #'Morphic-Widgets-FastTable'
 }
@@ -131,8 +131,14 @@ FTTableMorph >> autoScrollHeightLimit [
 ]
 
 { #category : #private }
+FTTableMorph >> basicHighlightIndexes: anArray [
+	highlightedIndexes := anArray asArray
+]
+
+{ #category : #private }
 FTTableMorph >> basicHighlightRowIndexes: anArray [
-	highlightedRowIndexes := anArray asArray
+	self deprecated: 'Use #basicHighlightIndexes: instead' transformWith: '`@receiver basicHighlightRowIndexes: `@statements' -> '`@receiver basicHighlightIndexes: `@statements'.
+	^ self basicHighlightIndexes: anArray
 ]
 
 { #category : #private }
@@ -366,7 +372,7 @@ FTTableMorph >> hasDataSource [
 
 { #category : #testing }
 FTTableMorph >> hasHighlighted [
-	^ self highlightedRowIndexes notEmpty
+	^ self highlightedIndexes notEmpty
 ]
 
 { #category : #testing }
@@ -392,18 +398,18 @@ FTTableMorph >> hideColumnHeaders [
 ]
 
 { #category : #'accessing selection' }
-FTTableMorph >> highlightRowIndex: aNumber [
-	self highlightRowIndexes: { aNumber }
+FTTableMorph >> highlightIndex: aNumber [
+	self highlightIndexes: { aNumber }
 ]
 
 { #category : #'accessing selection' }
-FTTableMorph >> highlightRowIndexes: anArray [
-	anArray = highlightedRowIndexes ifTrue: [ ^ self ].
+FTTableMorph >> highlightIndexes: anArray [
+	anArray = highlightedIndexes ifTrue: [ ^ self ].
 
-	self basicHighlightRowIndexes: anArray.
+	self basicHighlightIndexes: anArray.
 
-	(self hasHighlighted and: [ (self isIndexVisible: self highlightedRowIndex) not ])
-		ifTrue: [ self moveShowIndexTo: self highlightedRowIndexes first.
+	(self hasHighlighted and: [ (self isIndexVisible: self highlightedIndex) not ])
+		ifTrue: [ self moveShowIndexTo: self highlightedIndexes first.
 			^ self ].
 
 	(self hasSelection and: [ (self isIndexVisible: self selectedIndex) not ])
@@ -414,15 +420,37 @@ FTTableMorph >> highlightRowIndexes: anArray [
 ]
 
 { #category : #'accessing selection' }
+FTTableMorph >> highlightRowIndex: aNumber [
+	self deprecated: 'Use #highlightIndex: instead' transformWith: '`@receiver highlightRowIndex: `@statements1' -> '`@receiver highlightIndex: `@statements1'.
+	self highlightIndex: aNumber
+]
+
+{ #category : #'accessing selection' }
+FTTableMorph >> highlightRowIndexes: anArray [
+	self deprecated: 'Use #highlightIndexes: instead' transformWith: '`@receiver highlightRowIndexes: `@statements1' -> '`@receiver highlightIndexes: `@statements1'.
+	self highlightIndexes: anArray
+]
+
+{ #category : #'accessing selection' }
+FTTableMorph >> highlightedIndex [
+	^ self highlightedIndexes ifNotEmpty: #first ifEmpty: [ 0 ]
+]
+
+{ #category : #'accessing selection' }
+FTTableMorph >> highlightedIndexes [
+	^ highlightedIndexes
+]
+
+{ #category : #'accessing selection' }
 FTTableMorph >> highlightedRowIndex [
-	^ self highlightedRowIndexes 
-		ifNotEmpty: [ :indexes | indexes first ]
-		ifEmpty: [ 0 ] 
+	self deprecated: 'Use #highlightedIndex instead' transformWith: '`@receiver highlightedRowIndex' -> '`@receiver highlightedIndex'.
+	^ self highlightedIndex
 ]
 
 { #category : #'accessing selection' }
 FTTableMorph >> highlightedRowIndexes [
-	^ highlightedRowIndexes
+	self deprecated: 'Use #highlightedIndexes instead' transformWith: '`@receiver highlightedRowIndexes' -> '`@receiver highlightedIndexes'.
+	^ self highlightedIndexes
 ]
 
 { #category : #private }
@@ -454,7 +482,7 @@ FTTableMorph >> initialize [
 	showIndex := 0.
 	showColumnHeaders := true.
 	selectedIndexes := #().
-	highlightedRowIndexes := #().
+	highlightedIndexes := #().
 	columns := #().
 	needToggleAtMouseUp := false.
 	self beNotResizable.

--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -402,11 +402,11 @@ FTTableMorph >> highlightRowIndexes: anArray [
 
 	self basicHighlightRowIndexes: anArray.
 
-	(self hasHighlighted and: [ (self isRowIndexVisible: self highlightedRowIndex) not ])
+	(self hasHighlighted and: [ (self isIndexVisible: self highlightedRowIndex) not ])
 		ifTrue: [ self moveShowIndexTo: self highlightedRowIndexes first.
 			^ self ].
 
-	(self hasSelection and: [ (self isRowIndexVisible: self selectedIndex) not ])
+	(self hasSelection and: [ (self isIndexVisible: self selectedIndex) not ])
 		ifTrue: [ self moveShowIndexTo: self selectedIndex.
 			^ self ].
 
@@ -539,6 +539,16 @@ FTTableMorph >> isHorizontalScrollBarVisible [
 ]
 
 { #category : #testing }
+FTTableMorph >> isIndexSelected: rowIndex [
+	^ self selectedIndexes includes: rowIndex
+]
+
+{ #category : #testing }
+FTTableMorph >> isIndexVisible: anIndex [
+	^ self container isRowIndexVisible: anIndex
+]
+
+{ #category : #testing }
 FTTableMorph >> isMultipleSelection [
 	^ selectionStrategy isMultiple
 ]
@@ -549,13 +559,15 @@ FTTableMorph >> isResizable [
 ]
 
 { #category : #testing }
-FTTableMorph >> isRowIndexSelected: rowIndex [
-	^ self selectedIndexes includes: rowIndex
+FTTableMorph >> isRowIndexSelected: anIndex [
+	self deprecated: 'Use #isIndexSelected: instead' transformWith: '`@receiver isRowIndexSelected: `@statements1' -> '`@receiver isIndexSelected: `@statements1'.
+	^ self isIndexSelected: anIndex
 ]
 
 { #category : #testing }
 FTTableMorph >> isRowIndexVisible: rowIndex [
-	^ self container isRowIndexVisible: rowIndex
+	self deprecated: 'Use #isIndexVisible: instead' transformWith: '`@receiver isRowIndexVisible: `@statements1' -> '`@receiver isIndexVisible: `@statements1'.
+	^ self isIndexVisible: rowIndex
 ]
 
 { #category : #testing }
@@ -1010,6 +1022,12 @@ FTTableMorph >> showColumnHeaders [
 
 { #category : #accessing }
 FTTableMorph >> showFirstRowSelection [
+	self deprecated: 'Use #showFirstSelection instead' transformWith: '`@receiver showFirstRowSelection' -> '`@receiver showFirstSelection'.
+	^ self showFirstSelection
+]
+
+{ #category : #accessing }
+FTTableMorph >> showFirstSelection [
 	self hasSelection ifFalse: [ ^ self ].
 	self moveShowIndexTo: self selectedIndex
 ]
@@ -1033,7 +1051,7 @@ FTTableMorph >> showMenuForPosition: aPoint [
 FTTableMorph >> showMenuForRowIndex: rowIndex columnIndex: columnIndex [
 	| menu |
 
-	(rowIndex notNil and: [ (self isRowIndexSelected: rowIndex) not ]) ifTrue: [ 
+	(rowIndex notNil and: [ (self isIndexSelected: rowIndex) not ]) ifTrue: [ 
 		self selectIndex: rowIndex ].
 
 	menu := self dataSource 

--- a/src/Morphic-Widgets-FastTable/FTTreeDataSource.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTreeDataSource.class.st
@@ -295,11 +295,11 @@ FTTreeDataSource >> updateSelectionWithCollectBlock: aBlock [
 	newly selected elements are visible. Use #ensureVisibleFirstSelection for that."
 
 	| index |
-	self table selectedRowIndexes ifEmpty: [ ^ self ].
+	self table selectedIndexes ifEmpty: [ ^ self ].
 	
 	index := self indexOfChangedItem.
 	self table 
-		selectRowIndexes: ((self table selectedRowIndexes collect: [ :ind | 
+		selectIndexes: ((self table selectedIndexes collect: [ :ind | 
 			aBlock value: ind value: index ]) asSet) asArray 
 		andMakeVisibleIf: false
 ]

--- a/src/Morphic-Widgets-FastTable/FTTreeItem.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTreeItem.class.st
@@ -132,8 +132,8 @@ FTTreeItem >> selectedRowsIndexesFrom: anInteger [
 	| index selfSelection |
 	index := anInteger.
 	self recentlyChanged
-		ifTrue: [ ^ (self dataSource table selectedRowIndexes select: [ :each | each between: index and: index + self numberOfVisibleChildren ]) ifEmpty: [ {} ] ifNotEmpty: [ {index} ] ].
-	selfSelection := (self dataSource table selectedRowIndexes includes: index)
+		ifTrue: [ ^ (self dataSource table selectedIndexes select: [ :each | each between: index and: index + self numberOfVisibleChildren ]) ifEmpty: [ {} ] ifNotEmpty: [ {index} ] ].
+	selfSelection := (self dataSource table selectedIndexes includes: index)
 		ifTrue: [ {index} ]
 		ifFalse: [ {} ].
 	self isExpanded

--- a/src/Morphic-Widgets-FastTable/FTVisibleItemsStrategy.class.st
+++ b/src/Morphic-Widgets-FastTable/FTVisibleItemsStrategy.class.st
@@ -40,7 +40,7 @@ FTVisibleItemsStrategy >> filter [
 	| items |
 	items := OrderedCollection new.
 	dataSource rootsItems do: [ :item | (self matchingFilter: item) ifNotNil: [ :itemNew | items add: itemNew ] ] displayingProgress: [ :each | 'Looking inside ' , each printString ].
-	dataSource table selectRowIndex: 1.
+	dataSource table selectIndex: 1.
 	^ dataSource class
 		root:
 			(FTRootItem new

--- a/src/Spec-MorphicAdapters/MorphicFastTableAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicFastTableAdapter.class.st
@@ -9,33 +9,32 @@ Class {
 
 { #category : #factory }
 MorphicFastTableAdapter >> buildWidget [
-
 	^ FTPluggableIconListMorphAdaptor new
-		   model: self model;
-			hideColumnHeaders;
-			beResizable;
-			columns: self model columns;
-			getListSizeSelector: #listSize ;
-			getListElementSelector: #listElementAt: ;
-			getIndexSelector: #getIndex ;
-			setIndexSelector: #setIndex: ;
-			getSelectionListSelector:	#getSelectionStateFor: ;
-			setSelectionListSelector:	#setSelectionStateFor:at: ;
-			getIconSelector: #getIconFor: ;
-			resetListSelector:	#resetListSelection ; 
-			getMenuSelector:	#menu:shifted: ;
-			setMultipleSelection: self multiSelection;
-			doubleClickSelector: #doubleClick: ;
-			basicWrapSelector: #wrapItem: ;
-			dragEnabled:	self dragEnabled ;
-			dropEnabled:	self dropEnabled ; 	
-			setBalloonText: self help; 
-			hResizing: 	#spaceFill;
-			vResizing: 	#spaceFill;
-			selectRowIndex: 1;
-			enableFilter: FTSubstringFilter;			
-			explicitFunction;
-			yourself
+		model: self model;
+		hideColumnHeaders;
+		beResizable;
+		columns: self model columns;
+		getListSizeSelector: #listSize;
+		getListElementSelector: #listElementAt:;
+		getIndexSelector: #getIndex;
+		setIndexSelector: #setIndex:;
+		getSelectionListSelector: #getSelectionStateFor:;
+		setSelectionListSelector: #setSelectionStateFor:at:;
+		getIconSelector: #getIconFor:;
+		resetListSelector: #resetListSelection;
+		getMenuSelector: #menu:shifted:;
+		setMultipleSelection: self multiSelection;
+		doubleClickSelector: #doubleClick:;
+		basicWrapSelector: #wrapItem:;
+		dragEnabled: self dragEnabled;
+		dropEnabled: self dropEnabled;
+		setBalloonText: self help;
+		hResizing: #spaceFill;
+		vResizing: #spaceFill;
+		selectIndex: 1;
+		enableFilter: FTSubstringFilter;
+		explicitFunction;
+		yourself
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
First pass to rename selection methods of FastTable.

Fixes #2423