### PR TITLE
OpalCompiler-Core spelling in class comment

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -1,12 +1,12 @@
 "
 I provide the API of the whole Compiler Package for the case that the input is sourcecode.
-(if there is alreay and AST, call #generate (to compile) or #evaluate directly on the node)
+(if there is already and AST, call #generate (to compile) or #evaluate directly on the node)
 
 a pre-configures compiler instance can be requested with: 
  - Smalltalk compiler
  - a Class compiler 
 
-The compiler instance (atually: the compilation context) needs to be setup. See #class: #source: #noPattern: #requestor: for the most important accessors (more are in the accessing protocol). 
+The compiler instance (actually: the compilation context) needs to be setup. See #class: #source: #noPattern: #requestor: for the most important accessors (more are in the accessing protocol). 
 
 See the class comment of CompilationContext for more information.
 


### PR DESCRIPTION
While reading source code on github I noticed these few spelling errors.  
I was *encouraged* to fix them since it was so very easy to do it in place by clicking the <Edit> icon.
While general policy is to require an Issue to go with each contribution, 
maybe this be stretched for documentation or at least simple spelling errors 
like these.  It could encourage others to do similar small fixes.

One thing to distinguish is that Github PRs provide a place to discuss contributions which the previous mcz process didn't.  
