### PR TITLE
2474-Cleaning-printing-protocols

### DIFF
--- a/src/GT-SpotterExtensions-Core/PragmaType.class.st
+++ b/src/GT-SpotterExtensions-Core/PragmaType.class.st
@@ -82,7 +82,7 @@ PragmaType >> pragmas: aCollection [
 	pragmas := aCollection
 ]
 
-{ #category : #ui }
+{ #category : #printing }
 PragmaType >> printOn: stream [
 	stream nextPutAll: self keyword
 ]

--- a/src/Glamour-Core/GLMPanePort.class.st
+++ b/src/Glamour-Core/GLMPanePort.class.st
@@ -49,7 +49,7 @@ GLMPanePort >> pane: aPane [
 	pane := aPane
 ]
 
-{ #category : #accessing }
+{ #category : #printing }
 GLMPanePort >> printOn: aStream [ 
 	 
 	aStream 

--- a/src/Glamour-Core/GLMTransmission.class.st
+++ b/src/Glamour-Core/GLMTransmission.class.st
@@ -291,7 +291,7 @@ GLMTransmission >> presentations: aCompositePresentation [
 	self transmissionStrategy presentations: aCompositePresentation
 ]
 
-{ #category : #transmitting }
+{ #category : #printing }
 GLMTransmission >> printOn: aStream [ 
 	 
 	aStream 

--- a/src/Kernel/FullBlockClosure.class.st
+++ b/src/Kernel/FullBlockClosure.class.st
@@ -83,7 +83,7 @@ FullBlockClosure >> outerContext: ctxt [
 	outerContext := ctxt
 ]
 
-{ #category : #private }
+{ #category : #printing }
 FullBlockClosure >> printOn: s [
 	[ super printOn: s ] on: Error do: [ :ex | s << '![' << ex messageText << ']!' ]
 ]

--- a/src/Metacello-Core/MetacelloVersionMethodSection.class.st
+++ b/src/Metacello-Core/MetacelloVersionMethodSection.class.st
@@ -63,7 +63,7 @@ MetacelloVersionMethodSection >> parent: anObject [
 	parent := anObject
 ]
 
-{ #category : #accessing }
+{ #category : #printing }
 MetacelloVersionMethodSection >> printOn: aStream [
   aStream
     nextPutAll: self class name asString;

--- a/src/Moose-Algos-Graph/MalGraphEdge.class.st
+++ b/src/Moose-Algos-Graph/MalGraphEdge.class.st
@@ -52,7 +52,7 @@ MalGraphEdge >> model: aModel [
 	model := aModel
 ]
 
-{ #category : #accessing }
+{ #category : #printing }
 MalGraphEdge >> printOn: aStream [
 	self from printOn: aStream.
 	aStream << ' -> '.

--- a/src/Renraku/ReAbstractCritique.class.st
+++ b/src/Renraku/ReAbstractCritique.class.st
@@ -167,7 +167,7 @@ ReAbstractCritique >> popDescriptionUp [
 	UIManager default longMessage: self description title: self title
 ]
 
-{ #category : #initialization }
+{ #category : #printing }
 ReAbstractCritique >> printOn: aStream [
 
 	super printOn: aStream.

--- a/src/Tool-DependencyAnalyser/DAPackageDependencyWrapper.class.st
+++ b/src/Tool-DependencyAnalyser/DAPackageDependencyWrapper.class.st
@@ -41,7 +41,7 @@ DAPackageDependencyWrapper >> packageName [
 	^ daPackage packageName
 ]
 
-{ #category : #accessing }
+{ #category : #printing }
 DAPackageDependencyWrapper >> printOn: aStream [
 	aStream nextPutAll: self packageName
 ]


### PR DESCRIPTION
https://github.com/pharo-project/pharo/issues/2474 

Cleaned using ProtocolAnalyser

ProtocolAnalyzer new statisticFor: #printOn: 
>>> {412->#printing. 4->#accessing. 1->#ui. 1->#private. 1->#initialization. 1->#transmitting}

ProtocolAnalyzer new findInconsistenciesForASelector: #printOn: thatIsNotInProtocol: 'printing' 

ProtocolAnalyzer new fixInconsistenciesOf: #printOn: toBeInProtocol: 'printing'