### PR TITLE
2486-Class-builder-should-call-initializeSlot-on-instance-migration

### DIFF
--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -63,6 +63,21 @@ ShClassInstallerTest >> testChangingHierarchy [
 ]
 
 { #category : #tests }
+ShClassInstallerTest >> testChangingSlotCallsInitializeSlotOnInstanceMigration [
+
+	| className someInstance |
+	className := #ShClassWithNormalSlots.
+	newClass := self newClass: className slots:#( someSlot ).
+	someInstance := newClass	new.
+
+	"Migrate the class changing the slot definition"
+	self newClass: className slots: { #someSlot => ShTestSlot }.
+	
+	"The slot should have initialized the value"
+	self assert: (someInstance readSlotNamed: #someSlot) equals: 'initialized'
+]
+
+{ #category : #tests }
 ShClassInstallerTest >> testChangingSuperclassInTheHierarchy [
 
 	superClass := self newClass:#ShCITestClass slots:#(var1 var2).
@@ -113,6 +128,30 @@ ShClassInstallerTest >> testClassWithComment [
 	
 	self assert: newClass comment equals: 'I have a comment'.
 	self assert: newClass organization commentStamp equals: 'anStamp'.
+]
+
+{ #category : #tests }
+ShClassInstallerTest >> testClassWithSlotCallsInitializeSlotOnInstanceCreation [
+
+	| className someInstance |
+	className := #ShClassWithNormalSlots.
+	newClass := self newClass: className slots: { #someSlot => ShTestSlot }.
+
+	someInstance := newClass	new.
+	
+	"The slot should have initialized the value"
+	self assert: (someInstance readSlotNamed: #someSlot) equals: 'initialized'
+]
+
+{ #category : #tests }
+ShClassInstallerTest >> testClassWithSlotHasInitializeMethodWithInitializeSlots [
+
+	| className |
+	className := #ShClassWithNormalSlots.
+	newClass := self newClass: className slots: { #someSlot => ShTestSlot }.
+	
+	self assert: ((newClass >> #initialize) ast statements
+		includes: (RBParser parseExpression: 'self class initializeSlots: self')).
 ]
 
 { #category : #tests }

--- a/src/Shift-ClassInstaller-Tests/ShTestSlot.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShTestSlot.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : #ShTestSlot,
+	#superclass : #IndexedSlot,
+	#category : #'Shift-ClassInstaller-Tests'
+}
+
+{ #category : #initialization }
+ShTestSlot >> initialize: anObject [
+
+	super write: 'initialized' to: anObject.
+]
+
+{ #category : #initialization }
+ShTestSlot >> wantsInitalization [
+
+	^ true
+]
+
+{ #category : #initialization }
+ShTestSlot >> write: aValue to: anObject [
+
+	^(self read: anObject)
+		ifNil: [ super write: aValue to: anObject ]
+]

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -76,6 +76,7 @@ ShiftClassInstaller >> copyObject: oldObject to: newClass [
 		ifFalse: [ newClass basicNew ].
 
 	newClass allSlots do: [ :newSlot | oldObject class slotNamed: newSlot name ifFound: [ :oldSlot | 
+			newSlot initialize: newObject.
 			newSlot write: (oldSlot read: oldObject) to: newObject ] ].
 
 	newClass isVariable


### PR DESCRIPTION
Fix #2486
- fix copyObject:to: to initialize slots on class migration
- add tests for slot initialization and migration