### PR TITLE
2488-ZipArchive-should-use-FileReferences-and-not-path-strings

### DIFF
--- a/src/Compression-Tests/ZipArchiveTest.class.st
+++ b/src/Compression-Tests/ZipArchiveTest.class.st
@@ -44,7 +44,7 @@ ZipArchiveTest >> tearDown [
 { #category : #tests }
 ZipArchiveTest >> testAddNonExistentFile [
 	
-	self should: [ zip addFile: 'it_would_be_crazy_if_this_file_existed.ext' ] raise: FileDoesNotExistException.
+	self should: [ zip addFile: 'it_would_be_crazy_if_this_file_existed.ext' asFileReference ] raise: FileDoesNotExistException.
 ]
 
 { #category : #tests }
@@ -58,10 +58,10 @@ ZipArchiveTest >> testCreateWithRelativeNames [
 	fileModified := nestedFileToZip entry modification.
 	folderModified := subdir entry modification.
 	zip
-		addDirectory: subdir fullName
+		addDirectory: subdir
 		as: subdir basename.
 	zip	
-		addFile: nestedFileToZip fullName
+		addFile: nestedFileToZip
 		as: nestedFileToZip basename.
 		
 	zip writeToFileNamed: zipFile fullName.
@@ -189,10 +189,10 @@ ZipArchiveTest >> testFilePermissions [
 	fileModified := nestedFileToZip entry modification asTime.
 	folderModified := subdir entry modification asTime.
 	folderMember := zip
-		addDirectory: subdir fullName
+		addDirectory: subdir
 		as: subdir basename.
 	fileMember := zip	
-		addFile: nestedFileToZip fullName
+		addFile: nestedFileToZip
 		as: nestedFileToZip basename.
 	zip writeToFileNamed: zipFile fullName.
 	
@@ -229,8 +229,8 @@ ZipArchiveTest >> testShouldUnzipAndOverwriteWithoutInforming [
 		writeStreamDo: [ :stream | stream nextPutAll: 'file contents' ];
 		yourself.
 	zip
-		addDirectory: subdir fullName as: subdir basename;
-		addFile: nestedFileToZip fullName as: nestedFileToZip basename;
+		addDirectory: subdir as: subdir basename;
+		addFile: nestedFileToZip as: nestedFileToZip basename;
 		writeToFileNamed: zipFile fullName;
 		close.
 	ZipArchive new
@@ -260,7 +260,7 @@ ZipArchiveTest >> testZip [
 	
 	realModificationStamp := fileToZip entry modification.
 	zip	
-		addFile: fileToZip fullName
+		addFile: fileToZip
 		as: fileToZip basename.
 	
 	zip writeToFileNamed: zipFile fullName.
@@ -331,7 +331,7 @@ ZipArchiveTest >> testZip [
 { #category : #tests }
 ZipArchiveTest >> testisZipArchive [
 	| nonArchive |
-	zip addFile: fileToZip fullName as: fileToZip basename.
+	zip addFile: fileToZip as: fileToZip basename.
 	zip writeToFileNamed: zipFile fullName.
 	self assert: (ZipArchive isZipArchive: zipFile fullName).
 	self assert: (ZipArchive isZipArchive: zipFile).

--- a/src/Compression/Archive.class.st
+++ b/src/Compression/Archive.class.st
@@ -11,29 +11,29 @@ Class {
 }
 
 { #category : #'archive operations' }
-Archive >> addDirectory: aFileName [
-	^self addDirectory: aFileName as: aFileName
+Archive >> addDirectory: aFileReference [
+	^self addDirectory: aFileReference as: aFileReference path pathString
 
 ]
 
 { #category : #'archive operations' }
-Archive >> addDirectory: aFileName as: anotherFileName [
+Archive >> addDirectory: aFileReference as: anotherFileName [
 	| newMember |
-	newMember := self memberClass newFromDirectory: aFileName.
+	newMember := self memberClass newFromDirectory: aFileReference.
 	self addMember: newMember.
 	newMember localFileName: anotherFileName.
 	^newMember
 ]
 
 { #category : #'archive operations' }
-Archive >> addFile: aFileName [
-	^self addFile: aFileName as: aFileName
+Archive >> addFile: aFileReference [
+	^self addFile: aFileReference as: aFileReference path pathString
 ]
 
 { #category : #'archive operations' }
-Archive >> addFile: aFileName as: anotherFileName [
+Archive >> addFile: aFileReference as: anotherFileName [
 	| newMember |
-	newMember := self memberClass newFromFile: aFileName.
+	newMember := self memberClass newFromFile: aFileReference.
 	newMember localFileName: anotherFileName.
 	self addMember: newMember.
 	^newMember

--- a/src/Compression/ZipArchiveMember.class.st
+++ b/src/Compression/ZipArchiveMember.class.st
@@ -39,13 +39,13 @@ Class {
 }
 
 { #category : #'instance creation' }
-ZipArchiveMember class >> newFromDirectory: aFileName [
-	^ZipDirectoryMember newNamed: aFileName
+ZipArchiveMember class >> newFromDirectory: aFileReference [
+	^ZipDirectoryMember newFromDirectory: aFileReference
 ]
 
 { #category : #'instance creation' }
-ZipArchiveMember class >> newFromFile: aFileName [
-	^ZipNewFileMember newNamed: aFileName
+ZipArchiveMember class >> newFromFile: aFileReference [
+	^ZipNewFileMember newFromFile: aFileReference
 ]
 
 { #category : #'instance creation' }

--- a/src/Compression/ZipDirectoryMember.class.st
+++ b/src/Compression/ZipDirectoryMember.class.st
@@ -11,8 +11,8 @@ Class {
 }
 
 { #category : #'instance creation' }
-ZipDirectoryMember class >> newNamed: aFileName [
-	^(self new) localFileName: aFileName; yourself
+ZipDirectoryMember class >> newFromDirectory: aFileReference [
+	^(self new) localFileNameFrom: aFileReference; yourself
 ]
 
 { #category : #private }
@@ -39,11 +39,15 @@ ZipDirectoryMember >> isDirectory [
 { #category : #accessing }
 ZipDirectoryMember >> localFileName: aString [
 
-	| file |
-	file := aString asFileReference.	
-	super localFileName: (file basename copyWith: $/).
-	file exists ifFalse: [ ^ self ].
-	self modifiedAt: file entry modificationTime.
+	self localFileNameFrom: aString asFileReference
+]
+
+{ #category : #accessing }
+ZipDirectoryMember >> localFileNameFrom: aFileReference [
+
+	super localFileName: (aFileReference basename copyWith: $/).
+	aFileReference exists ifFalse: [ ^ self ].
+	self modifiedAt: aFileReference entry modificationTime.
 ]
 
 { #category : #private }

--- a/src/Compression/ZipNewFileMember.class.st
+++ b/src/Compression/ZipNewFileMember.class.st
@@ -13,8 +13,8 @@ Class {
 }
 
 { #category : #'instance creation' }
-ZipNewFileMember class >> newNamed: aFileName [
-	^(self new) from: aFileName
+ZipNewFileMember class >> newFromFile: aFileReference [
+	^(self new) from: aFileReference
 ]
 
 { #category : #initialization }
@@ -23,13 +23,13 @@ ZipNewFileMember >> close [
 ]
 
 { #category : #initialization }
-ZipNewFileMember >> from: aFileName [
+ZipNewFileMember >> from: aFileReference [
 
 	| entry |
 	"Now get the size, attributes, and timestamps, and see if the file exists"
-	stream := File openForReadFileNamed: aFileName.
-	self localFileName: (externalFileName := aFileName).
-	entry := aFileName asFileReference entry.
+	stream := aFileReference binaryReadStream.
+	self localFileName: (externalFileName := aFileReference path pathString).
+	entry := aFileReference entry.
 	compressedSize := uncompressedSize := entry size.
 	desiredCompressionMethod := compressedSize > 0 ifTrue: [ CompressionDeflated ] ifFalse: [ CompressionStored ].
 	self flag: 'When we replace Files with FileSystem, the following line won''t have to jump throught hoops (FS returns aDateAndTime)'.


### PR DESCRIPTION
fixes #2488