### PR TITLE
More reasonable timespan arithmetic

### DIFF
--- a/src/Kernel-Chronology-Extras/Month.class.st
+++ b/src/Kernel-Chronology-Extras/Month.class.st
@@ -199,3 +199,9 @@ Month >> printOn: aStream [
 
 	aStream nextPutAll: self monthName, ' ', self year printString.
 ]
+
+{ #category : #private }
+Month >> species [
+
+	^Timespan
+]

--- a/src/Kernel-Chronology-Extras/Timespan.extension.st
+++ b/src/Kernel-Chronology-Extras/Timespan.extension.st
@@ -183,10 +183,11 @@ Timespan >> intersection: aTimespan [
 
 	 | aBegin anEnd |
 	 aBegin := self start max: aTimespan start.
-	 anEnd := self end min: aTimespan end.
-	 anEnd < aBegin ifTrue: [^nil].
+	"Use start + duration rather than end, because the latter subtracts clockPrecision."
+	 anEnd := (self start + self duration) min: (aTimespan start + aTimespan duration).
+	 anEnd <= aBegin ifTrue: [^nil].
 
-	 ^ self class starting: aBegin ending: anEnd.
+	 ^ self species starting: aBegin ending: anEnd.
 
 ]
 

--- a/src/Kernel-Chronology-Extras/Week.class.st
+++ b/src/Kernel-Chronology-Extras/Week.class.st
@@ -93,3 +93,9 @@ Week >> printOn: aStream [
 	aStream nextPutAll: 'a Week starting: '.
 	self start printOn: aStream. 
 ]
+
+{ #category : #private }
+Week >> species [
+
+	^Timespan
+]

--- a/src/Kernel-Chronology-Extras/Year.class.st
+++ b/src/Kernel-Chronology-Extras/Year.class.st
@@ -103,3 +103,9 @@ Year >> printOn: aStream [
 	aStream nextPutAll: ')'.
 
 ]
+
+{ #category : #private }
+Year >> species [
+
+	^Timespan
+]

--- a/src/Kernel-Tests/TimespanTest.class.st
+++ b/src/Kernel-Tests/TimespanTest.class.st
@@ -335,17 +335,8 @@ TimespanTest >> testIntersectionWithDisjoint [
 TimespanTest >> testIntersectionWithIncluded [
 	self
 		assert: (aTimespan intersection: anIncludedTimespan)
-		equals:
-			(Timespan
-				starting: jan01
-				duration:
-					(Duration
-						days: 0
-						hours: 23
-						minutes: 59
-						seconds: 59
-						nanoSeconds: 999999999)).
-	self deny: (aTimespan intersection: anIncludedTimespan) equals: anIncludedTimespan
+		equals: anIncludedTimespan
+
 ]
 
 { #category : #tests }
@@ -357,27 +348,14 @@ TimespanTest >> testIntersectionWithOverlapping [
 				starting: jan01
 				duration:
 					(Duration
-						days: 5
-						hours: 23
-						minutes: 59
-						seconds: 59
-						nanoSeconds: 999999999))
+						days: 6))
 ]
 
 { #category : #tests }
 TimespanTest >> testIntersectionWithSelf [
 	self
 		assert: (aTimespan intersection: aTimespan)
-		equals:
-			(Timespan
-				starting: jan01
-				duration:
-					(Duration
-						days: 6
-						hours: 23
-						minutes: 59
-						seconds: 59
-						nanoSeconds: 999999999)).
+		equals: aTimespan.
 	self deny: (aTimespan intersection: anIncludedTimespan) equals: aTimespan
 ]
 
@@ -385,19 +363,7 @@ TimespanTest >> testIntersectionWithSelf [
 TimespanTest >> testIntersectionWithSeparate [
 	self assert: (aTimespan intersection: aDisjointTimespan) isNil.
 	self deny: (aTimespan intersection: anOverlappingTimespan) isNil.
-	self
-		assert: (aTimespan intersection: anIncludedTimespan)
-		equals:
-			(Timespan
-				starting: jan01
-				duration:
-					(Duration
-						days: 0
-						hours: 23
-						minutes: 59
-						seconds: 59
-						nanoSeconds: 999999999)).
-	self deny: (aTimespan intersection: anIncludedTimespan) equals: anIncludedTimespan
+	self assert: (aTimespan intersection: anIncludedTimespan) equals: anIncludedTimespan
 ]
 
 { #category : #tests }
@@ -480,6 +446,29 @@ TimespanTest >> testStart [
 { #category : #tests }
 TimespanTest >> testStartingEnding [
 	self assert: aTimespan equals: (Timespan starting: jan01 ending: jan08)
+]
+
+{ #category : #tests }
+TimespanTest >> testSubclassArithmetic [
+
+	| timespans |
+	timespans := { Year currentYear.
+					 	Month current.
+						(Week starting: DateAndTime now).
+						Date today.
+						Timespan starting: (DateAndTime now) duration: 1 hour }.
+	timespans do:
+		[ :ts |
+			self assert: ts + aDay - ts equals: aDay.
+			self assert: ts - aDay - ts equals: aDay negated.
+			timespans do:
+				[ :otherTs |
+					self assert: (ts intersection: otherTs) equals: (otherTs intersection: ts) ] ].
+
+	self assert: (timespans first intersection: timespans second) equals: timespans second.
+	self assert: (timespans first intersection: timespans fourth) equals: timespans fourth.
+	self assert: (timespans second intersection: timespans fourth) equals: timespans fourth.
+
 ]
 
 { #category : #tests }

--- a/src/Kernel/Date.class.st
+++ b/src/Kernel/Date.class.st
@@ -120,3 +120,9 @@ Date >> printOn: aStream format: formatArray [
 	
 	BasicDatePrinter default printDate: self format: formatArray on: aStream
 ]
+
+{ #category : #private }
+Date >> species [
+
+	^Timespan
+]

--- a/src/Kernel/Timespan.class.st
+++ b/src/Kernel/Timespan.class.st
@@ -53,7 +53,7 @@ Timespan class >> starting: startDateAndTime ending: endDateAndTime [
 Timespan >> + operand [
 	"operand conforms to protocol Duration" 	
 
-	^ self class starting: (self start + operand) duration: self duration
+	^ self species starting: (self start + operand) duration: self duration
 
 ]
 


### PR DESCRIPTION
- Subclasses of fixed duration (Year, Month, Week, Date) behave like plain Timespans under arithmetic (+ - intersection:) (see `testSubclassArithmetic` for illustration)
- `Timespan >> intersection:` does not return results shortened by `clockPrecision` (see `testIntersectionWithSelf` to understand why this is more reasonable)

Fixes #2458