### PR TITLE
2504-FTTable-does-not-hide-headers-dynamically

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTTableContainerMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableContainerMorph.class.st
@@ -244,6 +244,12 @@ FTTableContainerMorph >> exposedRows [
 	^ exposedRows
 ]
 
+{ #category : #accessing }
+FTTableContainerMorph >> headerRow [
+
+	^ headerRow
+]
+
 { #category : #initialization }
 FTTableContainerMorph >> initialize [ 
 	super initialize.
@@ -319,7 +325,8 @@ FTTableContainerMorph >> table [
 { #category : #updating }
 FTTableContainerMorph >> updateAllRows [
 	self table isShowColumnHeaders 
-		ifTrue: [ self updateHeaderRow ].
+		ifTrue: [ self updateHeaderRow ]
+		ifFalse: [ headerRow := nil ].
 	self updateExposedRows.
 	
 ]


### PR DESCRIPTION
Fix #2504
 - reset headerRow variable in case no column headers should be shown
 - add headerRow getter for testing in spec