### PR TITLE
Fix `Week>>year:week:` to return a correct ISO week (starting on Monday)

### DIFF
--- a/src/Kernel-Chronology-Extras/Week.class.st
+++ b/src/Kernel-Chronology-Extras/Week.class.st
@@ -69,9 +69,13 @@ Week class >> week: weekNumber [
 
 { #category : #'instance creation' }
 Week class >> year: aYear week: weekNumber [
-	"Return the ISO week for the given week number and the given year.
-	Week 1 contains the year's first Thursday (weekday = 5)"
-	^ self starting: aYear asYear firstThursday + (weekNumber * 7 - 5"adjust for firstThursday") days
+	"Return the ISO week for the given week number and the given year. ISO 8601
+	specifies that weeks start on a Monday, therefore the returned week will start
+	on a Monday no matter what Week >> startDay is set to."
+
+	"Note: we have to call starting:duration: from the superclass Timespan to make this work,
+	 because the Week class enforces weeks to start on Week >> startDay."
+	^ super starting: aYear asYear firstThursday + (weekNumber * 7 - 10) days duration: 1 week
 ]
 
 { #category : #conversion }

--- a/src/Kernel-Tests-Extended/WeekTest.class.st
+++ b/src/Kernel-Tests-Extended/WeekTest.class.st
@@ -50,18 +50,24 @@ WeekTest >> tearDown [
 
 { #category : #tests }
 WeekTest >> testByWeekNumber [
-	"Check some week dates, assuming that the week starts on Sunday"
+	"Check some week dates, and check that the week starts on Monday
+	 even though Week >> startDay is set to Sunday in setUp."
 	week := Week year: 2013 week: 1.
-	self assert: week start equals: (DateAndTime year: 2012 month: 12 day: 30).
-	
+	self assert: week start equals: (DateAndTime year: 2012 month: 12 day: 31).
+	self assert: week start dayOfWeek equals: 2.
+
 	week := Week year: 2013 week: 32.
-	self assert: week start equals: (DateAndTime year: 2013 month: 8 day: 4).
+	self assert: week start equals: (DateAndTime year: 2013 month: 8 day: 5).
+	self assert: week start dayOfWeek equals: 2.
 	
 	week := Week year: 2013 week: 52.
-	self assert: week start equals: (DateAndTime year: 2013 month: 12 day: 22).
+	self assert: week start equals: (DateAndTime year: 2013 month: 12 day: 23).
+	self assert: week start dayOfWeek equals: 2.
 	
 	week := Week year: 2014 week: 1.
-	self assert: week start equals: (DateAndTime year: 2013 month: 12 day: 29).
+	self assert: week start equals: (DateAndTime year: 2013 month: 12 day: 30).
+	self assert: week start dayOfWeek equals: 2.
+
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Test included.
Fixes #2455