### PR TITLE
2511 Tag in Slot-Examples should be uppercase

### DIFF
--- a/src/Slot-Examples/AccessorInstanceVariableSlot.class.st
+++ b/src/Slot-Examples/AccessorInstanceVariableSlot.class.st
@@ -8,7 +8,7 @@ This example shows how Slots can change the class that they are part of.
 Class {
 	#name : #AccessorInstanceVariableSlot,
 	#superclass : #InstanceVariableSlot,
-	#category : #'Slot-Examples-base'
+	#category : #'Slot-Examples-Base'
 }
 
 { #category : #'class building' }

--- a/src/Slot-Examples/BaseSlot.class.st
+++ b/src/Slot-Examples/BaseSlot.class.st
@@ -9,7 +9,7 @@ Class {
 	#instVars : [
 		'default'
 	],
-	#category : #'Slot-Examples-base'
+	#category : #'Slot-Examples-Base'
 }
 
 { #category : #comparing }

--- a/src/Slot-Examples/BooleanSlot.class.st
+++ b/src/Slot-Examples/BooleanSlot.class.st
@@ -12,7 +12,7 @@ Class {
 		'baseSlot',
 		'offset'
 	],
-	#category : #'Slot-Examples-base'
+	#category : #'Slot-Examples-Base'
 }
 
 { #category : #accessing }

--- a/src/Slot-Examples/ComputedSlot.class.st
+++ b/src/Slot-Examples/ComputedSlot.class.st
@@ -17,7 +17,7 @@ Class {
 	#instVars : [
 		'block'
 	],
-	#category : #'Slot-Examples-base'
+	#category : #'Slot-Examples-Base'
 }
 
 { #category : #comparing }

--- a/src/Slot-Examples/ExampleClassVariable.class.st
+++ b/src/Slot-Examples/ExampleClassVariable.class.st
@@ -8,7 +8,7 @@ Class {
 	#instVars : [
 		'state'
 	],
-	#category : #'Slot-Examples-base'
+	#category : #'Slot-Examples-Base'
 }
 
 { #category : #'meta-object-protocol' }

--- a/src/Slot-Examples/ExampleSlotWithDefaultValue.class.st
+++ b/src/Slot-Examples/ExampleSlotWithDefaultValue.class.st
@@ -11,7 +11,7 @@ Class {
 	#instVars : [
 		'default'
 	],
-	#category : #'Slot-Examples-base'
+	#category : #'Slot-Examples-Base'
 }
 
 { #category : #comparing }

--- a/src/Slot-Examples/ExampleSlotWithState.class.st
+++ b/src/Slot-Examples/ExampleSlotWithState.class.st
@@ -46,7 +46,7 @@ Class {
 	#instVars : [
 		'value'
 	],
-	#category : #'Slot-Examples-base'
+	#category : #'Slot-Examples-Base'
 }
 
 { #category : #'meta-object-protocol' }

--- a/src/Slot-Examples/HiddenInstanceVariableSlot.class.st
+++ b/src/Slot-Examples/HiddenInstanceVariableSlot.class.st
@@ -8,7 +8,7 @@ The idea is that virtual slots can use hidden non-virtual slots to store their s
 Class {
 	#name : #HiddenInstanceVariableSlot,
 	#superclass : #InstanceVariableSlot,
-	#category : #'Slot-Examples-base'
+	#category : #'Slot-Examples-Base'
 }
 
 { #category : #testing }

--- a/src/Slot-Examples/MorphSlot.class.st
+++ b/src/Slot-Examples/MorphSlot.class.st
@@ -11,7 +11,7 @@ setIvar: aMorph
 Class {
 	#name : #MorphSlot,
 	#superclass : #IndexedSlot,
-	#category : #'Slot-Examples-base'
+	#category : #'Slot-Examples-Base'
 }
 
 { #category : #'meta-object-protocol' }

--- a/src/Slot-Examples/ProcessLocalSlot.class.st
+++ b/src/Slot-Examples/ProcessLocalSlot.class.st
@@ -26,7 +26,7 @@ obj local. “nil” <—— Now we don’t
 Class {
 	#name : #ProcessLocalSlot,
 	#superclass : #IndexedSlot,
-	#category : #'Slot-Examples-base'
+	#category : #'Slot-Examples-Base'
 }
 
 { #category : #'code generation' }

--- a/src/Slot-Examples/PropertySlot.class.st
+++ b/src/Slot-Examples/PropertySlot.class.st
@@ -11,7 +11,7 @@ Class {
 	#instVars : [
 		'baseSlot'
 	],
-	#category : #'Slot-Examples-base'
+	#category : #'Slot-Examples-Base'
 }
 
 { #category : #'code generation' }

--- a/src/Slot-Examples/UnlimitedInstanceVariableSlot.class.st
+++ b/src/Slot-Examples/UnlimitedInstanceVariableSlot.class.st
@@ -8,7 +8,7 @@ Class {
 		'baseSlot',
 		'offset'
 	],
-	#category : #'Slot-Examples-base'
+	#category : #'Slot-Examples-Base'
 }
 
 { #category : #'class building' }

--- a/src/Slot-Examples/WeakSlot.class.st
+++ b/src/Slot-Examples/WeakSlot.class.st
@@ -14,7 +14,7 @@ This slot inherits from IndexedSlot to guarantee that this slot has a real field
 Class {
 	#name : #WeakSlot,
 	#superclass : #IndexedSlot,
-	#category : #'Slot-Examples-base'
+	#category : #'Slot-Examples-Base'
 }
 
 { #category : #'code generation' }


### PR DESCRIPTION
solving https://github.com/pharo-project/pharo/issues/2511
- use "Base" instead of "base" for class tag