### PR TITLE
2516-FastTable-add-example-of-list-with-header

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTExamples.class.st
+++ b/src/Morphic-Widgets-FastTable/FTExamples.class.st
@@ -452,6 +452,22 @@ FTExamples class >> exampleListWithExplicitSearch [
 ]
 
 { #category : #examples }
+FTExamples class >> exampleListWithHeader [
+	"Show a list with all Object methods"
+
+	<example>
+	<sampleInstance>
+	| list |
+	list := FTTableMorph new
+		extent: 300 @ 550;
+		addColumn: (FTColumn id: 'Name');
+		dataSource: (FTExampleMethodListDataSource for: Object);
+		yourself.
+
+	^ list openInWindow
+]
+
+{ #category : #examples }
 FTExamples class >> exampleOutline1 [
 	<example>
 	| list |

--- a/src/Morphic-Widgets-FastTable/FTExamples.class.st
+++ b/src/Morphic-Widgets-FastTable/FTExamples.class.st
@@ -453,14 +453,14 @@ FTExamples class >> exampleListWithExplicitSearch [
 
 { #category : #examples }
 FTExamples class >> exampleListWithHeader [
-	"Show a list with all Object methods"
+	"Show a list with all Object methods with a header"
 
 	<example>
 	<sampleInstance>
 	| list |
 	list := FTTableMorph new
 		extent: 300 @ 550;
-		addColumn: (FTColumn id: 'Name');
+		addColumn: (FTColumn id: 'Method name');
 		dataSource: (FTExampleMethodListDataSource for: Object);
 		yourself.
 


### PR DESCRIPTION
Add example of list with header.

Fixes #2516