### PR TITLE
2205-OCASTTranslator-class-initialize-should-not-invoke-super

### DIFF
--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -32,8 +32,6 @@ Class {
 OCASTTranslator class >> initialize [
 	"OCASTTranslator initialize"
 	
-	super initialize.
-	
 	OptimizedMessages := { 
 	#caseOf: -> #emitCaseOf: .
 	#caseOf:otherwise: -> #emitCaseOfOtherwise: .


### PR DESCRIPTION
OCASTTranslator class initialize should not invoke super

fixes 2205