### PR TITLE
2518-DiskStoreentryFromNodepathfor-doesnt-use-existing-attributes

### DIFF
--- a/src/FileSystem-Core/DiskDirectoryEntry.class.st
+++ b/src/FileSystem-Core/DiskDirectoryEntry.class.st
@@ -1,3 +1,28 @@
+"
+DiskDirectoryEntry holds attributes for a single file / directory on the disk.
+
+The actual attributes are held in two arrays which are returned directly from the #fileAttributes:mask: primitive.  See statAttributes and accessAttributes, below.
+
+DiskDirectoryEntry's are not normally created directly, but are returned as a result of sending the #entry or #entries messages to a FileReference.
+
+If the receiver's file is a symbolic link, the information contained in the receiver is for the target file, not the symbolic link.  See also DiskSymlinkDirectoryEntry.
+
+ 
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	accessAttributes:		<Array>  An array of booleans indicating whether the image has read, write and execute access to the file.
+	statAttributes:		<Array>  See File class>>primFileAttributes:mask: for the list of attributes.
+
+
+    Implementation Points
+
+- statAttributes mostly corresponds with the information returned by the posix stat() call, thus its name.
+- accessAttributes mostly corresponds with the information returned by the posix array() call, thus its name.
+
+accessAttributes is relatively expensive to retrieve, so is loaded lazily only if requested.
+
+"
 Class {
 	#name : #DiskDirectoryEntry,
 	#superclass : #FileSystemDirectoryEntry,
@@ -23,6 +48,13 @@ DiskDirectoryEntry class >> fileSystem: aFilesystem path: aPath [
 	"Create a directory entry given a filesystem and a path in such filesystem."
 
 	^ self reference: (aFilesystem referenceTo: aPath)
+]
+
+{ #category : #'instance creation' }
+DiskDirectoryEntry class >> reference: aFileReference statAttributes: anArray [
+	"Answer an instance of the receiver pre-loaded with the supplied attributes"
+
+	^self new initializeWithReference: aFileReference statAttributes: anArray
 ]
 
 { #category : #'instance creation' }
@@ -189,6 +221,14 @@ DiskDirectoryEntry >> hasCreationTime [
 	"Answer a boolean indicating whether the receiver has a creation timestamp, or is just using the change timestamp."
 
 	^(self statAttributes at: 12) isNotNil
+]
+
+{ #category : #'initialize-release' }
+DiskDirectoryEntry >> initializeWithReference: aFileReference statAttributes: anArray [
+
+	super initialize.	
+	reference := aFileReference.
+	statAttributes := anArray
 ]
 
 { #category : #accessing }

--- a/src/FileSystem-Core/DiskSymlinkDirectoryEntry.class.st
+++ b/src/FileSystem-Core/DiskSymlinkDirectoryEntry.class.st
@@ -1,3 +1,8 @@
+"
+DiskSymlinkDirectoryEntry provides the same information as DiskDirectoryEntry, but for the symbolic link (and not the target file).
+
+See DiskDirectoryEntry for more information.
+"
 Class {
 	#name : #DiskSymlinkDirectoryEntry,
 	#superclass : #DiskDirectoryEntry,

--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -353,7 +353,9 @@ DiskStore >> entryFromNode: node path: path for: aFileSystem [
 
 	| entryPath |
 	entryPath := path / (self basenameFromEntry: node).
-	^DiskDirectoryEntry reference: (FileReference fileSystem: aFileSystem path: entryPath).
+	^DiskDirectoryEntry 
+		reference: (FileReference fileSystem: aFileSystem path: entryPath)
+		statAttributes: (node at: 2).
 
 ]
 

--- a/src/FileSystem-Tests-Disk/DiskFileSystemTest.class.st
+++ b/src/FileSystem-Tests-Disk/DiskFileSystemTest.class.st
@@ -20,6 +20,19 @@ DiskFileSystemTest >> testDefaultWorkingDirectory [
 ]
 
 { #category : #tests }
+DiskFileSystemTest >> testEntriesHaveAttributes [
+	"Disk entries returned by FileReference>>entries should be pre-loaded with statAttributes"
+
+	| entries |
+
+	entries := FileLocator imageDirectory resolve entries.
+	"Ensure that we are actually checking entries"
+	self assert: entries isNotEmpty.
+	"We can't use the accessor method to get the statAttributes since does lazy initialisation"
+	self assert: (entries select: [ :each | (each instVarNamed: 'statAttributes') isNil ]) isEmpty.
+]
+
+{ #category : #tests }
 DiskFileSystemTest >> testEqual [
 	| other |
 	other := self createFileSystem.


### PR DESCRIPTION
DiskStore>>entryFromNode:path:for: doesn't pass on the attribute information that it has, causing the information to be unnecessarily retrieved a second time when the entry is used.

An example of this is sending FileReference>>entries to a directory.

See also http://forum.world.st/File-problems-in-Pharo-8-tp5095111p5095176.html

- Initialise DiskDirectoryEntry with the stat attributes
- Add automated test to ensure the attributes are loaded

Fixes #2518