### PR TITLE
2525-DiskStoredelete-UTF8-encodes-twice

### DIFF
--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -268,17 +268,17 @@ DiskStore >> defaultWorkingDirectory [
 { #category : #public }
 DiskStore >> delete: path [
 	| pathString encodedPathString |
-	
+
 	((self exists: path) or: [ self isSymlink: path ])
 		ifFalse: [ ^ FileDoesNotExistException signalWith: path ].
-		
+
 	pathString := self stringFromPath: path.
-	encodedPathString := File encodePathString: pathString.
-	
-	(self isDirectory: path)
-		ifTrue: [ File deleteDirectory: encodedPathString ]
-		ifFalse: [ 
-			(File named: pathString) delete ]
+
+	(self isDirectory: path) ifTrue: 
+		[ encodedPathString := File encodePathString: pathString.
+		File deleteDirectory: encodedPathString ]
+	ifFalse: 
+		[ File deleteFile: pathString ]
 ]
 
 { #category : #accessing }

--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -267,7 +267,7 @@ DiskStore >> defaultWorkingDirectory [
 
 { #category : #public }
 DiskStore >> delete: path [
-	| pathString encodedPathString |
+	| pathString |
 
 	((self exists: path) or: [ self isSymlink: path ])
 		ifFalse: [ ^ FileDoesNotExistException signalWith: path ].
@@ -275,8 +275,7 @@ DiskStore >> delete: path [
 	pathString := self stringFromPath: path.
 
 	(self isDirectory: path) ifTrue: 
-		[ encodedPathString := File encodePathString: pathString.
-		File deleteDirectory: encodedPathString ]
+		[ File deleteDirectory: (File encodePathString: pathString) ]
 	ifFalse: 
 		[ File deleteFile: pathString ]
 ]

--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -170,13 +170,19 @@ File class >> deleteDirectory: fullPath [
 ]
 
 { #category : #'primitives-path' }
-File class >> deleteFile: aFileName [
-	"Delete the file of the given name. 
-	Return self if the primitive succeeds, nil otherwise."
+File class >> deleteFile: fullPathString [
+	"Delete the supplied UTF8 encoded path.  Answer nil on failure."
 
-	<primitive: 'primitiveFileDelete' module: 'FilePlugin'>
-	^ nil
+	| utf8Path |
 
+	utf8Path := fullPathString utf8Encoded.
+	self
+		retryWithGC: [ self primDeleteFile: utf8Path ]
+		until: [ :result | result notNil ]
+		forFileNamed: fullPathString.
+	(self primExists: utf8Path) ifTrue: 
+		[ (CannotDeleteFileException new messageText: 'Could not delete file ' , name,
+			'. Check the file is not open.') signal ].
 ]
 
 { #category : #'primitives-path' }
@@ -607,6 +613,16 @@ File class >> primClosedir: directoryPointerBytes [
 
 	<primitive: 'primitiveClosedir' module: 'FileAttributesPlugin' error: error>
 	^self signalError: error for: 'primClosedir'
+]
+
+{ #category : #'primitives-path' }
+File class >> primDeleteFile: aFileName [
+	"Delete the file of the given name. 
+	Return self if the primitive succeeds, nil otherwise."
+
+	<primitive: 'primitiveFileDelete' module: 'FilePlugin'>
+	^ nil
+
 ]
 
 { #category : #'primitives-file attributes' }
@@ -1098,13 +1114,10 @@ File >> checkDoesNotExist [
 
 { #category : #'open/close' }
 File >> delete [
-	"We retries with GC because in some platforms open files cannot be open"
-	self class
-		retryWithGC: [ self class deleteFile: name utf8Encoded ]
-		until: [ :result | result notNil ]
-		forFileNamed: name.
-	self exists
-		ifTrue: [ (CannotDeleteFileException new messageText: 'Could not delete file ' , name,'. Check the file is not open.') signal ].
+	"Delete the receiver"
+
+	^self class deleteFile: name.
+
 ]
 
 { #category : #testing }


### PR DESCRIPTION
When deleting files (as opposed to directories) DiskStore>>delete: UTF8 encodes the file name twice, wasting time and memory.

Fixes: https://github.com/pharo-project/pharo/issues/2525