### PR TITLE
Add trait TSingleton and modify existing singleton classes to use it

### DIFF
--- a/src/Glamour-Morphic-Brick/GLMBrickHeightTraverser.class.st
+++ b/src/Glamour-Morphic-Brick/GLMBrickHeightTraverser.class.st
@@ -1,21 +1,15 @@
 Class {
 	#name : #GLMBrickHeightTraverser,
 	#superclass : #GLMBrickLayoutTraverser,
-	#classInstVars : [
-		'uniqueInstance'
-	],
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#category : #'Glamour-Morphic-Brick-Layouts-Utils'
 }
 
 { #category : #cleanup }
 GLMBrickHeightTraverser class >> cleanUp [
+	self reset
 
-	uniqueInstance := nil
-]
-
-{ #category : #accessing }
-GLMBrickHeightTraverser class >> uniqueInstance [
-	^ uniqueInstance ifNil: [ uniqueInstance := self new ]
 ]
 
 { #category : #private }

--- a/src/Glamour-Morphic-Brick/GLMBrickLayouter.class.st
+++ b/src/Glamour-Morphic-Brick/GLMBrickLayouter.class.st
@@ -31,9 +31,8 @@ rootWidthNode
 Class {
 	#name : #GLMBrickLayouter,
 	#superclass : #Object,
-	#classInstVars : [
-		'uniqueInstance'
-	],
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#category : #'Glamour-Morphic-Brick-Layouts-Utils'
 }
 
@@ -125,11 +124,6 @@ GLMBrickLayouter class >> example [
 	^ bricks
 	
 	
-]
-
-{ #category : #accessing }
-GLMBrickLayouter class >> uniqueInstance [
-	^ uniqueInstance ifNil: [ uniqueInstance := self new ]
 ]
 
 { #category : #accessing }

--- a/src/Glamour-Morphic-Brick/GLMBrickWidthTraverser.class.st
+++ b/src/Glamour-Morphic-Brick/GLMBrickWidthTraverser.class.st
@@ -1,21 +1,15 @@
 Class {
 	#name : #GLMBrickWidthTraverser,
 	#superclass : #GLMBrickLayoutTraverser,
-	#classInstVars : [
-		'uniqueInstance'
-	],
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#category : #'Glamour-Morphic-Brick-Layouts-Utils'
 }
 
 { #category : #cleanup }
 GLMBrickWidthTraverser class >> cleanUp [
 
-	uniqueInstance := nil
-]
-
-{ #category : #accessing }
-GLMBrickWidthTraverser class >> uniqueInstance [
-	^ uniqueInstance ifNil: [ uniqueInstance := self new ]
+	self reset
 ]
 
 { #category : #private }

--- a/src/Glamour-Morphic-Brick/GLMDirection.class.st
+++ b/src/Glamour-Morphic-Brick/GLMDirection.class.st
@@ -1,9 +1,8 @@
 Class {
 	#name : #GLMDirection,
 	#superclass : #Object,
-	#classInstVars : [
-		'uniqueInstance'
-	],
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#category : #'Glamour-Morphic-Brick-Utils-Geometry'
 }
 
@@ -11,12 +10,7 @@ Class {
 GLMDirection class >> cleanUp [
 	super cleanUp.
 	
-	uniqueInstance := nil
-]
-
-{ #category : #accessing }
-GLMDirection class >> uniqueInstance [
-	^ uniqueInstance ifNil: [ uniqueInstance := self new ]
+	self reset
 ]
 
 { #category : #arithmetic }

--- a/src/Glamour-Morphic-Brick/GLMHorizontalLinearLayout.class.st
+++ b/src/Glamour-Morphic-Brick/GLMHorizontalLinearLayout.class.st
@@ -1,9 +1,8 @@
 Class {
 	#name : #GLMHorizontalLinearLayout,
 	#superclass : #GLMLinearLayout,
-	#classInstVars : [
-		'uniqueInstance'
-	],
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#category : #'Glamour-Morphic-Brick-Layouts'
 }
 
@@ -11,19 +10,6 @@ Class {
 GLMHorizontalLinearLayout class >> cleanUp [
 
 	self reset
-]
-
-{ #category : #accessing }
-GLMHorizontalLinearLayout class >> reset [
-	"
-	self reset
-	"
-	uniqueInstance := nil
-]
-
-{ #category : #accessing }
-GLMHorizontalLinearLayout class >> uniqueInstance [
-	^ uniqueInstance ifNil: [ uniqueInstance := self new ]
 ]
 
 { #category : #layout }

--- a/src/Glamour-Morphic-Brick/GLMVerticalLinearLayout.class.st
+++ b/src/Glamour-Morphic-Brick/GLMVerticalLinearLayout.class.st
@@ -1,9 +1,8 @@
 Class {
 	#name : #GLMVerticalLinearLayout,
 	#superclass : #GLMLinearLayout,
-	#classInstVars : [
-		'uniqueInstance'
-	],
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#category : #'Glamour-Morphic-Brick-Layouts'
 }
 
@@ -11,19 +10,6 @@ Class {
 GLMVerticalLinearLayout class >> cleanUp [
 
 	self reset
-]
-
-{ #category : #accessing }
-GLMVerticalLinearLayout class >> reset [
-	"
-	self reset
-	"
-	uniqueInstance := nil
-]
-
-{ #category : #accessing }
-GLMVerticalLinearLayout class >> uniqueInstance [
-	^ uniqueInstance ifNil: [ uniqueInstance := self new ]
 ]
 
 { #category : #layout }

--- a/src/Glamour-Morphic-Pager/GLMPagerPanePreviewMorph.class.st
+++ b/src/Glamour-Morphic-Pager/GLMPagerPanePreviewMorph.class.st
@@ -4,12 +4,11 @@ I am a morph showing a preview image of another morph.  I should be used like a 
 Class {
 	#name : #GLMPagerPanePreviewMorph,
 	#superclass : #ImageMorph,
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#instVars : [
 		'thumbnail',
 		'position'
-	],
-	#classInstVars : [
-		'uniqueInstance'
 	],
 	#category : #'Glamour-Morphic-Pager-Morphic'
 }
@@ -17,19 +16,14 @@ Class {
 { #category : #cleanup }
 GLMPagerPanePreviewMorph class >> cleanUp [
 	super cleanUp.
-	uniqueInstance := nil
+	self reset
 ]
 
 { #category : #actions }
 GLMPagerPanePreviewMorph class >> remove [
 
 	self uniqueInstance delete.	
-	uniqueInstance := nil.
-]
-
-{ #category : #accessing }
-GLMPagerPanePreviewMorph class >> uniqueInstance [
-	^ uniqueInstance ifNil: [ uniqueInstance := GLMPagerPanePreviewMorph new ].
+	self reset.
 ]
 
 { #category : #actions }

--- a/src/Glamour-Morphic-Widgets/GLMWatcherWindow.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMWatcherWindow.class.st
@@ -7,13 +7,12 @@ GLMWatcherWindow reset.
 Class {
 	#name : #GLMWatcherWindow,
 	#superclass : #SystemWindow,
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#instVars : [
 		'isOpen',
 		'contentsMorph',
 		'process'
-	],
-	#classInstVars : [
-		'uniqueInstance'
 	],
 	#category : #'Glamour-Morphic-Widgets'
 }
@@ -28,17 +27,6 @@ GLMWatcherWindow class >> buildKeymapsOn: aBuilder [
 		do: [ :morph | self uniqueInstance toggleOpen ].
 
 	aBuilder attachShortcutCategory: #Glamour to: Morph.
-]
-
-{ #category : #'instance creation' }
-GLMWatcherWindow class >> reset [ 
-	"self reset"
-	uniqueInstance := nil
-]
-
-{ #category : #'instance creation' }
-GLMWatcherWindow class >> uniqueInstance [ 
-	^ uniqueInstance ifNil: [uniqueInstance := self new]
 ]
 
 { #category : #settings }

--- a/src/Keymapping-Core/KMBuffer.class.st
+++ b/src/Keymapping-Core/KMBuffer.class.st
@@ -6,24 +6,18 @@ I am cleared when the current morph loses focus or when a full match announcemen
 Class {
 	#name : #KMBuffer,
 	#superclass : #Object,
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#instVars : [
 		'buffer',
 		'currentEvent'
-	],
-	#classInstVars : [
-		'uniqueInstance'
 	],
 	#category : #'Keymapping-Core'
 }
 
 { #category : #'initialize-release' }
 KMBuffer class >> resetUniqueInstance [
-	uniqueInstance := nil 
-]
-
-{ #category : #accessing }
-KMBuffer class >> uniqueInstance [
-	^uniqueInstance ifNil: [ uniqueInstance := self new ].
+	self reset
 ]
 
 { #category : #accessing }

--- a/src/MonticelloRemoteRepositories/MCServerRegistry.class.st
+++ b/src/MonticelloRemoteRepositories/MCServerRegistry.class.st
@@ -4,20 +4,13 @@ Registry for metacello servers
 Class {
 	#name : #MCServerRegistry,
 	#superclass : #Object,
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#instVars : [
 		'registry'
 	],
-	#classInstVars : [
-		'uniqueInstance'
-	],
 	#category : #MonticelloRemoteRepositories
 }
-
-{ #category : #'instance creation' }
-MCServerRegistry class >> uniqueInstance [
-
-	^ uniqueInstance ifNil: [ uniqueInstance := self new ].
-]
 
 { #category : #initialization }
 MCServerRegistry >> initialize [

--- a/src/NECompletion/NECController.class.st
+++ b/src/NECompletion/NECController.class.st
@@ -11,6 +11,8 @@ The completion occurs in specific character position. The editor is responsible 
 Class {
 	#name : #NECController,
 	#superclass : #Object,
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#instVars : [
 		'model',
 		'menuMorph',
@@ -21,9 +23,6 @@ Class {
 	],
 	#classVars : [
 		'ContextClass'
-	],
-	#classInstVars : [
-		'uniqueInstance'
 	],
 	#category : #'NECompletion-View'
 }
@@ -85,17 +84,6 @@ NECController class >> registerToolsOn: registry [
 	"self registerToolsOn: Smalltalk tools" 
 	registry register: self as: #codeCompletion
 
-]
-
-{ #category : #'instance creation' }
-NECController class >> reset [
-	uniqueInstance := nil
-	
-]
-
-{ #category : #'instance creation' }
-NECController class >> uniqueInstance [
-	^uniqueInstance ifNil: [ uniqueInstance := self new ]
 ]
 
 { #category : #accessing }

--- a/src/Ombu/OmNullReference.class.st
+++ b/src/Ombu/OmNullReference.class.st
@@ -4,9 +4,8 @@ I represent the no-reference. I implement the null object design pattern.
 Class {
 	#name : #OmNullReference,
 	#superclass : #OmAbstractReference,
-	#classInstVars : [
-		'uniqueInstance'
-	],
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#category : #'Ombu-Entries'
 }
 
@@ -16,11 +15,6 @@ OmNullReference class >> fromSton: stonReader [
 	stonReader parseListDo: [ :each :index | "nothing to read" ].
 
 	^ self uniqueInstance
-]
-
-{ #category : #'instance creation' }
-OmNullReference class >> uniqueInstance [
-	^ uniqueInstance ifNil: [ uniqueInstance := self new ]
 ]
 
 { #category : #testing }

--- a/src/Renraku/ReCriticEngine.class.st
+++ b/src/Renraku/ReCriticEngine.class.st
@@ -4,9 +4,8 @@ I contain some functionality shared between code entities
 Class {
 	#name : #ReCriticEngine,
 	#superclass : #Object,
-	#classInstVars : [
-		'uniqueInstance'
-	],
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#category : #'Renraku-Utility'
 }
 
@@ -26,12 +25,6 @@ ReCriticEngine class >> guidedBy: anEntity ban: aCritique [
 ReCriticEngine class >> nodeCritiquesOf: anEntity [
 
 	^ self uniqueInstance nodeCritiquesOf: anEntity
-]
-
-{ #category : #accessing }
-ReCriticEngine class >> uniqueInstance [
-
-	^ uniqueInstance ifNil: [ uniqueInstance := self new ]
 ]
 
 { #category : #running }

--- a/src/Renraku/ReSettings.class.st
+++ b/src/Renraku/ReSettings.class.st
@@ -4,12 +4,11 @@ i have settings for QA recording functions
 Class {
 	#name : #ReSettings,
 	#superclass : #Object,
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#instVars : [
 		'inspectorPlugin',
 		'spotterPlugin'
-	],
-	#classInstVars : [
-		'uniqueInstance'
 	],
 	#category : #'Renraku-Utility'
 }
@@ -18,7 +17,7 @@ Class {
 ReSettings class >> cleanUp [
 	
 	
-	uniqueInstance := nil
+	self reset
 ]
 
 { #category : #'settings-accessing' }
@@ -120,12 +119,6 @@ ReSettings class >> spotterPluginSettingsOn: aBuilder [
 		description: 'Enable GTSpotter plugin which shows a group with critiques and allows to preview them.';
 		default: false;
 		parent: #qualityAssistant.
-]
-
-{ #category : #accessing }
-ReSettings class >> uniqueInstance [
-	
-	^ uniqueInstance ifNil: [ uniqueInstance := self new ]
 ]
 
 { #category : #initialization }

--- a/src/Renraku/ReSystemAnnouncer.class.st
+++ b/src/Renraku/ReSystemAnnouncer.class.st
@@ -10,18 +10,10 @@ ReSystemAnnouncer uniqueInstance week ...
 Class {
 	#name : #ReSystemAnnouncer,
 	#superclass : #Announcer,
-	#classInstVars : [
-		'uniqueInstance'
-	],
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#category : #'Renraku-Announcements'
 }
-
-{ #category : #'instance creation' }
-ReSystemAnnouncer class >> uniqueInstance [
-	"I'm a singleton…"
-	
-	^ uniqueInstance ifNil: [ uniqueInstance := self new ]
-]
 
 { #category : #announce }
 ReSystemAnnouncer >> notifyCritique: aCritique descriptionViewedFor: anEntity [

--- a/src/SingletonTrait/TSingleton.trait.st
+++ b/src/SingletonTrait/TSingleton.trait.st
@@ -1,0 +1,27 @@
+"
+I am a trait that makes a class into a singleton whose unique instance is accessed via the method TSingleton>>uniqueInstance.
+"
+Trait {
+	#name : #TSingleton,
+	#classInstVars : [
+		'uniqueInstance'
+	],
+	#category : #SingletonTrait
+}
+
+{ #category : #'instance creation' }
+TSingleton classSide >> new [
+	self error: 'Use #uniqueInstance'
+]
+
+{ #category : #'instance creation' }
+TSingleton classSide >> reset [
+	<script>
+	uniqueInstance := nil.
+
+]
+
+{ #category : #accessing }
+TSingleton classSide >> uniqueInstance [
+	^ uniqueInstance ifNil: [ uniqueInstance := super new ]
+]

--- a/src/SingletonTrait/package.st
+++ b/src/SingletonTrait/package.st
@@ -1,0 +1,1 @@
+Package { #name : #SingletonTrait }

--- a/src/UnifiedFFI/FFIExternalResourceManager.class.st
+++ b/src/UnifiedFFI/FFIExternalResourceManager.class.st
@@ -62,11 +62,10 @@ Note that in #finalizeResourceData: you cannot access any other properties of yo
 Class {
 	#name : #FFIExternalResourceManager,
 	#superclass : #Object,
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#instVars : [
 		'registry'
-	],
-	#classInstVars : [
-		'uniqueInstance'
 	],
 	#category : #'UnifiedFFI-External-Resources'
 }
@@ -84,16 +83,6 @@ FFIExternalResourceManager class >> addResource: anObject data: aData [
 { #category : #'resource management' }
 FFIExternalResourceManager class >> addResource: anObject executor: anExecutor [
 	self uniqueInstance addResource: anObject executor: anExecutor
-]
-
-{ #category : #'instance creation' }
-FFIExternalResourceManager class >> reset [
-	uniqueInstance := nil
-]
-
-{ #category : #accessing }
-FFIExternalResourceManager class >> uniqueInstance [ 
-	^ uniqueInstance ifNil: [ uniqueInstance  := super new ]
 ]
 
 { #category : #'external resource management' }

--- a/src/UnifiedFFI/FFIMethodRegistry.class.st
+++ b/src/UnifiedFFI/FFIMethodRegistry.class.st
@@ -5,11 +5,10 @@ Registry is used to know exactly which methods are executing FFI-NB calls and th
 Class {
 	#name : #FFIMethodRegistry,
 	#superclass : #Object,
+	#traits : 'TSingleton',
+	#classTraits : 'TSingleton classTrait',
 	#instVars : [
 		'compiledMethods'
-	],
-	#classInstVars : [
-		'uniqueInstance'
 	],
 	#category : #'UnifiedFFI-Base'
 }
@@ -18,7 +17,7 @@ Class {
 FFIMethodRegistry class >> cleanUp: aggressive [
 	"Only delete change sets when being aggressive"
 	self uniqueInstance reset.
-	uniqueInstance := nil
+	self reset
 	
 ]
 
@@ -27,11 +26,6 @@ FFIMethodRegistry class >> initialize [
 	SessionManager default
 		registerSystemClassNamed: self name
 		atPriority: 60
-]
-
-{ #category : #'instance creation' }
-FFIMethodRegistry class >> new [
-	self error: 'Use #uniqueInstance'
 ]
 
 { #category : #'system startup' }
@@ -45,7 +39,7 @@ FFIMethodRegistry class >> resetAll [
 	self uniqueInstance reset.
 	FFICallbackFunctionResolution reset.
 	FFIExternalStructure resetAllStructures.
-	uniqueInstance := nil.
+	self reset.
 ]
 
 { #category : #'system startup' }
@@ -60,11 +54,6 @@ FFIMethodRegistry class >> startUp: isImageStarting [
 	isImageStarting ifFalse: [ ^ self ].
 	
 	self resetAll
-]
-
-{ #category : #'instance creation' }
-FFIMethodRegistry class >> uniqueInstance [
-	^ uniqueInstance ifNil: [ uniqueInstance := super new ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Following a comment by @MarcusDenker on the pharo-users mailing list, I packaged the singleton trait discussed there with modifications to existing singleton classes for inclusion in Pharo 8. I believe this is useful both as a kind of code cleanup operation and to provide a simple example for the use of traits.

I modified only singleton classes that followed the standard pattern. The remaining ones have different behavior in the `uniqueInstance`, `new`, or `reset` methods. A particularly frequent variant stores the unique instance in a class variable rather than an instance variable of the class. I have no idea why this choice was made, so I preferred not to touch them.
