### PR TITLE
2445-Morph-subclasses-should-not-equally-redefine-theme

### DIFF
--- a/src/Keymapping-Settings/KMCatcherMorph.class.st
+++ b/src/Keymapping-Settings/KMCatcherMorph.class.st
@@ -62,7 +62,7 @@ KMCatcherMorph >> drawOn: aCanvas [
 
 	super drawOn: aCanvas. 
 	focused ifTrue: [
-		Smalltalk ui theme drawTextAdornmentFor: self color: Color orange on: aCanvas]
+		self theme drawTextAdornmentFor: self color: Color orange on: aCanvas]
 ]
 
 { #category : #'event handling' }
@@ -89,12 +89,10 @@ KMCatcherMorph >> initialize [
 	self listCentering: #center.
 	self width: 300.
 	self height: 25.
-	self color: (Smalltalk ui theme textEditorDisabledFillStyleFor: self).
-	self borderStyle: (Smalltalk ui theme textEditorDisabledBorderStyleFor: self).
-	
+	self color: (self theme textEditorDisabledFillStyleFor: self).
+	self borderStyle: (self theme textEditorDisabledBorderStyleFor: self).
 	labelMorph := StringMorph contents: ''.
-	self addMorph: (labelMorph).
-	
+	self addMorph: labelMorph.
 	edited := false.
 	focused := false.
 	self initializeKeystrokes.
@@ -118,8 +116,8 @@ KMCatcherMorph >> keyboardFocusChange: aBoolean [
 	super keyboardFocusChange: aBoolean.
 	focused := aBoolean.
 	focused
-		ifTrue: [ self color: (Smalltalk ui theme textEditorNormalFillStyleFor: self) ]
-		ifFalse: [ self color: (Smalltalk ui theme textEditorDisabledFillStyleFor: self) ].
+		ifTrue: [ self color: (self theme textEditorNormalFillStyleFor: self) ]
+		ifFalse: [ self color: (self theme textEditorDisabledFillStyleFor: self) ].
 	^ true
 ]
 

--- a/src/Morphic-Base/TransferMorph.class.st
+++ b/src/Morphic-Base/TransferMorph.class.st
@@ -103,7 +103,7 @@ TransferMorph >> animationForMoveSuccess: success [
 { #category : #initialization }
 TransferMorph >> defaultColor [
 	"answer the default color/fill style for the receiver"
-	^ Smalltalk ui theme selectionColor
+	^ self theme selectionColor
 ]
 
 { #category : #'submorphs-add/remove' }

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -1198,6 +1198,14 @@ Morph >> balloonText [
 				text asString withNoLineLongerThan: self theme settings maxBalloonHelpLineLength]
 ]
 
+{ #category : #theme }
+Morph >> basicTheme: aUITheme [
+	"Set the current theme for the receiver without notification of change."
+
+	self theme = aUITheme ifFalse: [
+		self setProperty: #theme toValue: aUITheme]
+]
+
 { #category : #accessing }
 Morph >> beSticky [
 	"make the receiver sticky"
@@ -1221,7 +1229,7 @@ Morph >> becomeModal [
 		ifNotNil: [self currentWorld modalWindow: self]
 ]
 
-{ #category : #'Morphic-Base-Widgets' }
+{ #category : #'base-widgets' }
 Morph >> beginsWith: aString fromList: aMorph [
 	| string |
 	string := self userString ifNil: [(self submorphs collect: [:m | m userString]) detect: [:us | us notNil] ifNone: ['']].
@@ -1778,7 +1786,7 @@ Morph >> changed: anAspect with: anObject [
 		arguments: anObject)
 ]
 
-{ #category : #'Morphic-Base-Worlds' }
+{ #category : #'base-worlds' }
 Morph >> clearArea [
 	"Answer the clear area of the receiver. It means the area free  
 	of docking bars."
@@ -2046,8 +2054,7 @@ Morph >> deepCopy [
 Morph >> defaultBackgroundColor [
 	"Answer the color to be used as the base window color for a window whose model is an object of the receiver's class"
 	
-	"I don't want to do a self theme  because otherwise I will need to implement it on Object"
-	^  Smalltalk ui theme windowColorFor: self
+	^  self theme windowColorFor: self
 ]
 
 { #category : #initialize }
@@ -3352,7 +3359,7 @@ Morph >> height: aNumber [
 
 ]
 
-{ #category : #'Morphic-Base-Widgets' }
+{ #category : #'base-widgets' }
 Morph >> heightToDisplayInList: aList [
 
 	^ self minExtent y
@@ -3973,7 +3980,7 @@ Morph >> listDirectionString: aSymbol [
 	^self layoutMenuPropertyString: aSymbol from: self listDirection
 ]
 
-{ #category : #'Morphic-Base-Widgets' }
+{ #category : #'base-widgets' }
 Morph >> listRenderOn: aCanvas atRow: aRow bounds: drawBounds color: drawColor backgroundColor: backgroundColor from: aMorph [
 
 	self bounds: drawBounds.
@@ -4625,13 +4632,13 @@ Morph >> ownerThatIsA: aClass [
 	^ self firstOwnerSuchThat: [:m | m isKindOf: aClass]
 ]
 
-{ #category : #'Morphic-Base-Worlds' }
+{ #category : #'base-worlds' }
 Morph >> pasteUpMorph [
 	"Answer the closest containing morph that is a PasteUp morph"
 	^ self ownerThatIsA: PasteUpMorph
 ]
 
-{ #category : #'Morphic-Base-Worlds' }
+{ #category : #'base-worlds' }
 Morph >> pasteUpMorphHandlingTabAmongFields [
 	"Answer the nearest PasteUpMorph in my owner chain that has the tabAmongFields property, or nil if none"
 
@@ -6051,6 +6058,33 @@ Morph >> textAnchorType: aSymbol [
 		ifFalse:[^self setProperty: #textAnchorType toValue: aSymbol].
 ]
 
+{ #category : #theme }
+Morph >> theme [
+	"Answer the current theme for the receiver."
+
+	(self valueOfProperty: #theme) ifNotNil: [:t | ^ t].
+	^(self owner ifNil: [self class]) theme
+]
+
+{ #category : #theme }
+Morph >> theme: aUITheme [
+	"Set the current theme for the receiver and propagate theme changed to submorphs."
+
+	self theme = aUITheme ifFalse: [
+		self setProperty: #theme toValue: aUITheme.
+		"we do not invoke basicTheme: to avoid checking twice if the theme changed or not"
+		self themeChanged]
+]
+
+{ #category : #theme }
+Morph >> themeChanged [
+	"The current theme has changed.
+	Update any dependent visual aspects."
+
+	self submorphsDo: [:m | m themeChanged].
+	self changed
+]
+
 { #category : #rounding }
 Morph >> toggleCornerRounding [
 	self cornerStyle == #rounded
@@ -6132,7 +6166,7 @@ Morph >> topLeft: aPoint [
 
 ]
 
-{ #category : #'Morphic-Base-Worlds' }
+{ #category : #'base-worlds' }
 Morph >> topPasteUp [
 	"If the receiver is in a world, return that; otherwise return the outermost pasteup morph"
 	^ self outermostMorphThat: [:m | m isKindOf: PasteUpMorph]
@@ -6447,7 +6481,7 @@ Morph >> veryDeepInner: deepCopier [
 	extension := (extension veryDeepCopyWith: deepCopier)
 ]
 
-{ #category : #'Morphic-Base-Worlds' }
+{ #category : #'base-worlds' }
 Morph >> viewBox [
 	^ self pasteUpMorph viewBox
 ]
@@ -6617,7 +6651,7 @@ Morph >> width: aNumber [
 
 ]
 
-{ #category : #'Morphic-Base-Widgets' }
+{ #category : #'base-widgets' }
 Morph >> widthToDisplayInList: aList [
 
 	^ self minExtent x

--- a/src/Morphic-Widgets-Tabs/TabActionButtonMorph.class.st
+++ b/src/Morphic-Widgets-Tabs/TabActionButtonMorph.class.st
@@ -35,7 +35,7 @@ TabActionButtonMorph >> drawOn: aCanvas [
 TabActionButtonMorph >> forAction: anAction [
 	| baseColor |
 	
-	baseColor := Smalltalk ui theme baseColor.
+	baseColor := self theme baseColor.
 	self extent: anAction icon extent.
 	
 	self activeEnabledNotOverUpFillStyle: baseColor.

--- a/src/Morphic-Widgets-Tabs/TabBarMorph.class.st
+++ b/src/Morphic-Widgets-Tabs/TabBarMorph.class.st
@@ -126,7 +126,7 @@ TabBarMorph >> adjustLayout [
 { #category : #drawing }
 TabBarMorph >> borderColor [
 	"I do not use #borderColor because I want a light border"
-	^ Smalltalk ui theme lightBackgroundColor
+	^ self theme lightBackgroundColor
 ]
 
 { #category : #accessing }
@@ -175,23 +175,23 @@ TabBarMorph >> createMenuButton [
 	"Answer a button for the window menu."
 	| form msb |
 	
-	form := Smalltalk ui theme windowMenuForm.
+	form := self theme windowMenuForm.
 	msb := MultistateButtonMorph new extent: form extent.
 	msb activeEnabledNotOverUpFillStyle: (ImageFillStyle form: form).
 	
-	form := Smalltalk ui theme windowMenuPassiveForm.
+	form := self theme windowMenuPassiveForm.
 	msb extent: form extent.
 	msb activeDisabledNotOverUpFillStyle: (ImageFillStyle form: form).
 	msb passiveEnabledNotOverUpFillStyle: (ImageFillStyle form: form).
 	msb passiveDisabledNotOverUpFillStyle: (ImageFillStyle form: form).
 	
-	form := Smalltalk ui theme windowMenuForm.
+	form := self theme windowMenuForm.
 	msb extent: form extent.
 	msb
 		activeEnabledOverUpFillStyle: (ImageFillStyle form: form);
 		passiveEnabledOverUpFillStyle: (ImageFillStyle form: form).
 	
-	form := Smalltalk ui theme windowMenuPassiveForm.
+	form := self theme windowMenuPassiveForm.
 	msb
 		extent: form extent;
 		activeEnabledOverDownFillStyle: (ImageFillStyle form: form);
@@ -415,7 +415,7 @@ TabBarMorph >> selectTabAt: index ifAbsent: aBlock [
 
 { #category : #drawing }
 TabBarMorph >> selectedColor [
-	^ Smalltalk ui theme selectionColor
+	^ self theme selectionColor
 ]
 
 { #category : #accessing }

--- a/src/Morphic-Widgets-Tabs/TabManagerMorph.class.st
+++ b/src/Morphic-Widgets-Tabs/TabManagerMorph.class.st
@@ -133,7 +133,7 @@ TabManagerMorph >> barDeleted: aBar [
 
 { #category : #'private-drawing' }
 TabManagerMorph >> borderColor [
-	^ Smalltalk ui theme borderColor
+	^ self theme borderColor
 ]
 
 { #category : #protocol }
@@ -162,7 +162,7 @@ TabManagerMorph >> closeAllTabs [
 
 { #category : #'private-drawing' }
 TabManagerMorph >> containerColor [
-	^ Smalltalk ui theme lightBaseColor
+	^ self theme lightBaseColor
 ]
 
 { #category : #protocol }
@@ -405,10 +405,10 @@ TabManagerMorph >> themeChanged [
 	toolbar themeChanged.
 	
 	container
-		color: Smalltalk ui theme lightBaseColor;
+		color: self theme lightBaseColor;
 		changed.
 	contentsWrapper
-		color: Smalltalk ui theme lightBaseColor;
+		color: self theme lightBaseColor;
 		changed
 ]
 

--- a/src/Morphic-Widgets-Tabs/TabMorph.class.st
+++ b/src/Morphic-Widgets-Tabs/TabMorph.class.st
@@ -139,7 +139,7 @@ TabMorph class >> label: label icon: icon retrievingBlock: morph actions: aColle
 { #category : #icons }
 TabMorph class >> menuIcon [
 
-	^ Smalltalk ui theme windowMenuForm
+	^ self theme windowMenuForm
 ]
 
 { #category : #icons }
@@ -424,7 +424,7 @@ TabMorph >> blueButtonUp: anEvent [
 { #category : #'private-drawing' }
 TabMorph >> borderColor [
 	"I do not use #borderColor because I want a light border"
-	^ Smalltalk ui theme lightBackgroundColor
+	^ self theme lightBackgroundColor
 ]
 
 { #category : #'private-drawing' }

--- a/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
@@ -417,7 +417,7 @@ MorphTreeMorph >> adoptPaneColor: paneColor [
 	
 	super adoptPaneColor: paneColor.
 	paneColor ifNil: [^self].
-	self color: (self preferedPaneColor ifNil: [ Smalltalk ui theme backgroundColor ] ).
+	self color: (self preferedPaneColor ifNil: [ self theme backgroundColor ] ).
 
 ]
 
@@ -888,7 +888,7 @@ MorphTreeMorph >> expandedForm [
 MorphTreeMorph >> expandedFormForMorph: aMorph [
 	"Answer the form to use for expanded items."
 	
-	^ ((aMorph selected) and: [self selectionColor luminance < 0.7])
+	^ (aMorph selected and: [self selectionColor luminance < 0.7])
 		ifTrue: [self theme whiteTreeExpandedForm]
 		ifFalse: [self theme treeExpandedForm]
 ]

--- a/src/Morphic-Widgets-Tree/MorphTreeNodeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeNodeMorph.class.st
@@ -959,15 +959,6 @@ MorphTreeNodeMorph >> takeHighlight [
 	container selectionChanged
 ]
 
-{ #category : #accessing }
-MorphTreeNodeMorph >> theme [
-	"Answer the ui theme that provides controls.
-	Done directly here to avoid performance hit of
-	looking up in window."
-
-	^ Smalltalk ui theme
-]
-
 { #category : #updating }
 MorphTreeNodeMorph >> themeChanged [
  
@@ -1019,7 +1010,7 @@ MorphTreeNodeMorph >> unhighlight [
 				ifTrue: [m 
 						color: (m
 								valueOfProperty: #originalColor
-								ifAbsent: [ Smalltalk ui theme textColor ])]].
+								ifAbsent: [ self theme textColor ])]].
 
 ]
 

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1448,7 +1448,7 @@ SystemWindow >> openInWorldExtent: extent [
 SystemWindow >> openModal [
 
 	self openInWorld.
-	Smalltalk ui theme runModal: self.
+	self theme runModal: self.
 ]
 
 { #category : #panes }

--- a/src/NECompletion/NECMenuMorph.class.st
+++ b/src/NECompletion/NECMenuMorph.class.st
@@ -179,7 +179,7 @@ NECMenuMorph class >> scrollArrowSize [
 
 { #category : #'preferences-colors' }
 NECMenuMorph class >> scrollColor [
-	^ Smalltalk ui theme selectionColor
+	^ self theme selectionColor
 ]
 
 { #category : #'help text' }

--- a/src/Polymorph-Widgets/IdentifierChooserMorph.class.st
+++ b/src/Polymorph-Widgets/IdentifierChooserMorph.class.st
@@ -555,8 +555,3 @@ IdentifierChooserMorph >> switchToPreviousColumn [
 			ifFalse: [prevIdx - 1]]
 
 ]
-
-{ #category : #accessing }
-IdentifierChooserMorph >> theme [
-		^ Smalltalk ui theme 
-]

--- a/src/Polymorph-Widgets/IndentingListItemMorph.extension.st
+++ b/src/Polymorph-Widgets/IndentingListItemMorph.extension.st
@@ -95,12 +95,3 @@ IndentingListItemMorph >> selectionFrame [
 		from: container.
 	^frame
 ]
-
-{ #category : #'*Polymorph-Widgets' }
-IndentingListItemMorph >> theme [
-	"Answer the ui theme that provides controls.
-	Done directly here to avoid performance hit of
-	looking up in window."
-
-	^ Smalltalk ui theme 
-]

--- a/src/Polymorph-Widgets/Morph.extension.st
+++ b/src/Polymorph-Widgets/Morph.extension.st
@@ -8,14 +8,6 @@ Morph >> adoptPaneColor [
 ]
 
 { #category : #'*Polymorph-Widgets' }
-Morph >> basicTheme: aUITheme [
-	"Set the current theme for the receiver."
-
-	self theme = aUITheme ifFalse: [
-		self setProperty: #theme toValue: aUITheme]
-]
-
-{ #category : #'*Polymorph-Widgets' }
 Morph >> boundsWithinCorners [
  	"Changed to be more realistic..."
 	
@@ -314,7 +306,7 @@ Morph >> showBalloon: msgString hand: aHand [
 	|w h|
 	(w := self world) ifNil: [^self].
 	h := aHand ifNil: [w activeHand].
-	( self theme   builder newBalloonHelp: msgString for: self balloonHelpAligner)
+	( self theme builder newBalloonHelp: msgString for: self balloonHelpAligner)
 		popUpFor: self hand: h
 ]
 
@@ -356,32 +348,6 @@ Morph class >> theme [
 	"Answer the ui theme that provides controls."
 
 	^ Smalltalk ui theme
-]
-
-{ #category : #'*Polymorph-Widgets' }
-Morph >> theme [
-	"Answer the current theme for the receiver."
-
-	(self valueOfProperty: #theme) ifNotNil: [:t | ^ t].
-	^(self owner ifNil: [self class]) theme
-]
-
-{ #category : #'*Polymorph-Widgets' }
-Morph >> theme: aUITheme [
-	"Set the current theme for the receiver."
-
-	self theme = aUITheme ifFalse: [
-		self basicTheme: aUITheme.
-		self themeChanged]
-]
-
-{ #category : #'*Polymorph-Widgets' }
-Morph >> themeChanged [
-	"The current theme has changed.
-	Update any dependent visual aspects."
-
-	self submorphsDo: [:m | m themeChanged].
-	self changed
 ]
 
 { #category : #'*Polymorph-Widgets' }

--- a/src/Reflectivity-Examples/ReflectivityCodeMorph.class.st
+++ b/src/Reflectivity-Examples/ReflectivityCodeMorph.class.st
@@ -62,7 +62,7 @@ ReflectivityCodeMorph >> drawTitleOn: aCanvas [
 	aCanvas drawString: self compiledMethod methodClass asString 
 		in: (self bounds insetBy: (Margin left: 10 top: 10 right: 2 bottom: 10)) 
 		font: (LogicalFont familyName: self familyName pointSize: 11)
-		color: Smalltalk ui theme textColor. 
+		color: self theme textColor. 
 ]
 
 { #category : #accessing }

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -296,7 +296,7 @@ RubAbstractTextArea class >> highlightMessageSend: aBoolean [
 
 { #category : #settings }
 RubAbstractTextArea class >> lineNumbersBackgroundColor [
-	^ LineNumbersBackgroundColor ifNil: [ LineNumbersBackgroundColor := Smalltalk ui theme backgroundColor darker] 
+	^ LineNumbersBackgroundColor ifNil: [ LineNumbersBackgroundColor := self theme backgroundColor darker] 
 ]
 
 { #category : #settings }
@@ -316,7 +316,7 @@ RubAbstractTextArea class >> lineNumbersFont: aFont [
 
 { #category : #settings }
 RubAbstractTextArea class >> lineNumbersTextColor [
-	^ LineNumbersTextColor ifNil: [ LineNumbersTextColor := Smalltalk ui theme lineNumberColor ]
+	^ LineNumbersTextColor ifNil: [ LineNumbersTextColor := self theme lineNumberColor ]
 ]
 
 { #category : #settings }

--- a/src/Rubric/RubCodeSizeFeedback.class.st
+++ b/src/Rubric/RubCodeSizeFeedback.class.st
@@ -23,7 +23,7 @@ RubCodeSizeFeedback >> backgroundColor [
 	"Return the current fillStyle of the receiver."
 
 	| basicColor size |
-	basicColor := Smalltalk ui theme backgroundColor.
+	basicColor := self theme backgroundColor.
 	self paragraph ifNil: [ ^Color transparent ].
 	size := self textSize.
 	size >= self warningLimit

--- a/src/Rubric/RubHoverHighlightSegmentMorph.class.st
+++ b/src/Rubric/RubHoverHighlightSegmentMorph.class.st
@@ -17,7 +17,7 @@ RubHoverHighlightSegmentMorph >> defaultBorderColor [
 
 { #category : #initialization }
 RubHoverHighlightSegmentMorph >> defaultColor [
-	^ Smalltalk ui theme secondarySelectionColor
+	^ self theme secondarySelectionColor
 ]
 
 { #category : #initialization }

--- a/src/Rubric/RubScrolledTextMorph.class.st
+++ b/src/Rubric/RubScrolledTextMorph.class.st
@@ -277,7 +277,7 @@ RubScrolledTextMorph >> cursor [
 
 { #category : #defaults }
 RubScrolledTextMorph >> defaultBackgroundColor [ 
-	^ Smalltalk ui theme backgroundColor
+	^ self theme backgroundColor
 ]
 
 { #category : #defaults }

--- a/src/Rubric/RubSelectorChooserMorph.class.st
+++ b/src/Rubric/RubSelectorChooserMorph.class.st
@@ -73,7 +73,7 @@ RubSelectorChooserMorph >> comeToFront [
 
 { #category : #accessing }
 RubSelectorChooserMorph >> defaultBaseColor [
-	^  (self theme menuColorFor: self) muchLighter
+	^ (self theme menuColorFor: self) muchLighter
 ]
 
 { #category : #drawing }

--- a/src/Spec-MorphicAdapters/ToolDockingBarMorph.extension.st
+++ b/src/Spec-MorphicAdapters/ToolDockingBarMorph.extension.st
@@ -25,7 +25,7 @@ ToolDockingBarMorph >> adoptMenuItemModel: item accumulator: controls [
 			controls add: button ]
 		ifNotNil: [ 
 			self emptyAccumulator: controls.
-			self addMorphBack: (Smalltalk ui theme newToolSpacerIn: self).
+			self addMorphBack: (self theme newToolSpacerIn: self).
 			self 
 				add: item name
 				font: Smalltalk ui theme menuBarFont

--- a/src/Tool-Diff/PSMCPatchMorph.class.st
+++ b/src/Tool-Diff/PSMCPatchMorph.class.st
@@ -163,7 +163,7 @@ PSMCPatchMorph >> changesMenu: m [
 		enablementSelector: #selectionHasActualClass.
 	menu lastItem
 		font: self theme menuFont;
-		icon: Smalltalk tools browser taskbarIcon;
+		icon: (self iconNamed: #smallWindowIcon);
 		keyText: 'Cmd+b'.
 	menu addLine.
 	menu


### PR DESCRIPTION
Removing all the plague Smalltalk ui theme in Morphic hierarchy by self theme.
Moved theme:, theme, basicTheme from polymorph to Morphic-Core. 
Make sure that theme: does not check twice that a theme changed.
Check 569 senders of theme!!! #2445https://github.com/pharo-project/pharo/issues/2445