### PR TITLE
2554 Epicea: EpApplyPreviewer sourceEntries and logBrowserModel ivars not used

### DIFF
--- a/src/EpiceaBrowsers/EpApplyPreviewer.class.st
+++ b/src/EpiceaBrowsers/EpApplyPreviewer.class.st
@@ -7,9 +7,7 @@ Class {
 	#traits : 'EpTCodeChangeVisitor',
 	#classTraits : 'EpTCodeChangeVisitor classTrait',
 	#instVars : [
-		'environment',
-		'logBrowserModel',
-		'sourceEntries'
+		'environment'
 	],
 	#category : #'EpiceaBrowsers-Visitors'
 }


### PR DESCRIPTION
https://github.com/pharo-project/pharo/issues/2554