### PR TITLE
2573-SortedCollection-slow-when-sorting-collections-with-many-equal-elements

### DIFF
--- a/src/Collections-Sequenceable/SortedCollection.class.st
+++ b/src/Collections-Sequenceable/SortedCollection.class.st
@@ -177,7 +177,7 @@ SortedCollection >> defaultSort: i to: j [
 				 l := j.
 				 [[l := l - 1.  k <= l and: [dij <= (array at: l)]]
 				   whileTrue.  "i.e. while dl succeeds dij"
-				  [k := k + 1.  k <= l and: [(array at: k) <= dij]]
+				  [k := k + 1.  k < j and: [(array at: k) <= dij]]
 				   whileTrue.  "i.e. while dij succeeds dk"
 				  k <= l]
 				   whileTrue:
@@ -290,7 +290,7 @@ SortedCollection >> sort: i to: j [
 				 l := j.
 				 [[l := l - 1.  k <= l and: [sortBlock value: dij value: (array at: l)]]
 				   whileTrue.  "i.e. while dl succeeds dij"
-				  [k := k + 1.  k <= l and: [sortBlock value: (array at: k) value: dij]]
+				  [k := k + 1.  k < j and: [sortBlock value: (array at: k) value: dij]]
 				   whileTrue.  "i.e. while dij succeeds dk"
 				  k <= l]
 				   whileTrue:


### PR DESCRIPTION
change the quick sort implementation to skip over equal elements before recursively sorting partitions -- changes the running time of "sorting" a collection of equal values from O(n^2) to be O(n)fixes case #2573