### PR TITLE
2579-Update-deleteAll-comments

### DIFF
--- a/src/FileSystem-Core/AbstractFileReference.class.st
+++ b/src/FileSystem-Core/AbstractFileReference.class.st
@@ -311,13 +311,15 @@ AbstractFileReference >> delete [
 
 { #category : #operations }
 AbstractFileReference >> deleteAll [
-	"Delete this directory and all children of it, raise an error if the file does not exist."
+	"Delete this directory and all children of it, raise an error if the file does not exist.
+	Don't follow symbolic links (so files outside the receiver's tree will not be deleted)."
 	DeleteVisitor delete: self resolve
 ]
 
 { #category : #operations }
 AbstractFileReference >> deleteAllChildren [
-	"delete all children of the receiver, raise an error if the receiver does not exist"
+	"Delete all children of the receiver, raise an error if the receiver does not exist.
+	Don't follow symbolic links (so files outside the receiver's tree will not be deleted)."
 	
 	self children do: [:aReference | aReference deleteAll ]
 ]

--- a/src/FileSystem-Core/DeleteVisitor.class.st
+++ b/src/FileSystem-Core/DeleteVisitor.class.st
@@ -1,5 +1,7 @@
 "
 I delete the directory tree that I visit. I use the PostorderGuide so that I can delete files before deleting their containing directories.
+
+I don't follow symbolic links (so files outside the receiver's tree will not be deleted).
 "
 Class {
 	#name : #DeleteVisitor,
@@ -14,6 +16,9 @@ DeleteVisitor class >> delete: aReference [
 
 { #category : #visiting }
 DeleteVisitor >> visit: aReference [
+	"Don't follow symbolic links:
+	- We shouldn't delete files outside the root's tree.
+	- Symbolic links that point to the containing directory create an infinite loop"
 	PostorderGuide 
 		show: aReference 
 		to: self 


### PR DESCRIPTION
Update #deleteAll comments

Update comments to reflect that DeleteVisitor no longer follows symbolic links.

Fixes #2579