### PR TITLE
Log the Target VM date and CommitHash during bootstrap

### DIFF
--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -36,4 +36,5 @@ then
     ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/getPharoVM.sh 70 vmLatest $BOOTSTRAP_ARCH
     cd -
 fi
+echo "Target VM: $(${VM} --version | grep Hash)"
 


### PR DESCRIPTION
At the moment it is difficult to be sure exactly which VM is being used
to bootstrap Pharo.  This will assist in tracking down VM issues during
the bootstrap process.

In support of #2459