### PR TITLE
2651-CanvasencryptedParagraphboundscolor-has-no-senders-or-concrete-implementors

### DIFF
--- a/src/Graphics-Canvas/Canvas.class.st
+++ b/src/Graphics-Canvas/Canvas.class.st
@@ -184,12 +184,6 @@ Canvas >> drawString: s in: boundsRect font: fontOrNil color: c underline: under
 	^self drawString: s from: 1 to: s size in: boundsRect font: fontOrNil color: c underline: underline underlineColor: uc strikethrough: strikethrough strikethroughColor: sc
 ]
 
-{ #category : #drawing }
-Canvas >> encryptedParagraph: para bounds: bounds color: c [
-	"Draw the given paragraph"
-	^self subclassResponsibility
-]
-
 { #category : #accessing }
 Canvas >> extent [
 	"Return the physical extent of the output device"


### PR DESCRIPTION
Remove dead method.

Fixes #2651