### PR TITLE
Use the stable VM instead of Latest for bootstrap

### DIFF
--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -33,7 +33,7 @@ then
     # Downloads a SPUR vm for the configured architecture
     mkdir ${BOOTSTRAP_CACHE}/vmtarget
     cd ${BOOTSTRAP_CACHE}/vmtarget
-    ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/getPharoVM.sh 70 vmLatest $BOOTSTRAP_ARCH
+    ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/getPharoVM.sh 70 vm $BOOTSTRAP_ARCH
     cd -
 fi
 echo "Target VM: $(${VM} --version | grep Hash)"


### PR DESCRIPTION
In support of #2459

As described in #2459, the bootstrap process is failing quite often with
VM crashes.  This will allow us to get an idea of whether it is due to a
recent change in the VM, or something else (which may or may not be part
of the VM).