### PR TITLE
2645-Duplication-wrappingPolicyLabel-and-lineNumbersDisplayLabel-is-defined-4-times

### DIFF
--- a/src/Rubric/RubAnnotationDisplayer.class.st
+++ b/src/Rubric/RubAnnotationDisplayer.class.st
@@ -4,6 +4,8 @@ I represent a bar with annotations for the text area, like editing mode, line nu
 Class {
 	#name : #RubAnnotationDisplayer,
 	#superclass : #RubScrolledTextSideRuler,
+	#traits : 'TRubWithWrapPolicy + TRubWithLineNumber',
+	#classTraits : 'TRubWithWrapPolicy classTrait + TRubWithLineNumber classTrait',
 	#instVars : [
 		'lineAnnotation',
 		'row',
@@ -42,24 +44,6 @@ RubAnnotationDisplayer >> changeColumnDisplay [
 		ifNotNil: [ self paragraphProvider withoutColumns ].
 	self textArea changed.
 	self updateContents
-]
-
-{ #category : #'submorphs-accessing' }
-RubAnnotationDisplayer >> changeLineNumbersDisplay [
-	self paragraphProvider lineNumbersRuler 
-		ifNil: [ self paragraphProvider withLineNumbers ]
-		ifNotNil: [ self paragraphProvider withoutLineNumbers ].
-	self paragraphProvider manageLayout.
-	self updateContents
-]
-
-{ #category : #'submorphs-accessing' }
-RubAnnotationDisplayer >> changeWrappingPolicy [
-	self paragraphProvider wrapped 
-		ifTrue: [ self paragraphProvider beNotWrapped  ]
-		ifFalse: [ self paragraphProvider beWrapped ].
-	self updateContents.
-	self paragraphProvider changed
 ]
 
 { #category : #'submorphs-accessing' }
@@ -115,11 +99,6 @@ RubAnnotationDisplayer >> editingModeLabelMorph [
 		font: self fontToUse
 ]
 
-{ #category : #accessing }
-RubAnnotationDisplayer >> fontToUse [
-	^ RubAbstractTextArea lineNumbersFont 
-]
-
 { #category : #initialization }
 RubAnnotationDisplayer >> initialize [
 	super initialize.
@@ -130,20 +109,6 @@ RubAnnotationDisplayer >> initialize [
 { #category : #accessing }
 RubAnnotationDisplayer >> level [
 	^ 1
-]
-
-{ #category : #'submorphs-accessing' }
-RubAnnotationDisplayer >> lineNumbersDisplayLabel [
-	^ self paragraphProvider lineNumbersRuler  
-		ifNil: [ '+L' ]
-		ifNotNil: [ 'L' ]
-]
-
-{ #category : #'submorphs-accessing' }
-RubAnnotationDisplayer >> lineNumbersDisplayLabelMorph [
-	^ StringMorph
-		contents: self lineNumbersDisplayLabel
-		font: self fontToUse
 ]
 
 { #category : #geometry }
@@ -283,18 +248,4 @@ RubAnnotationDisplayer >> updateContents [
 	lineNumbersDisplayMorph contents: self lineNumbersDisplayLabel.
 	row position: self innerBounds topLeft.
 	row width: self innerBounds width
-]
-
-{ #category : #'submorphs-accessing' }
-RubAnnotationDisplayer >> wrappingPolicyLabel [
-	^ self paragraphProvider wrapped
-				ifTrue: [ 'W' ]
-				ifFalse: [ 'NW' ]
-]
-
-{ #category : #'submorphs-accessing' }
-RubAnnotationDisplayer >> wrappingPolicyLabelMorph [
-	^ StringMorph
-		contents: self wrappingPolicyLabel
-		font: self fontToUse
 ]

--- a/src/Rubric/TRubWithLineNumber.trait.st
+++ b/src/Rubric/TRubWithLineNumber.trait.st
@@ -1,0 +1,38 @@
+"
+I am a Trait that can be used by subclasses of RubScrolledTextExtra wanting to display or not line numbers.
+"
+Trait {
+	#name : #TRubWithLineNumber,
+	#category : #'Rubric-Traits'
+}
+
+{ #category : #'managing line numbers' }
+TRubWithLineNumber >> changeLineNumbersDisplay [
+	self paragraphProvider lineNumbersRuler 
+		ifNil: [ self paragraphProvider withLineNumbers ]
+		ifNotNil: [ self paragraphProvider withoutLineNumbers ].
+	self paragraphProvider manageLayout.
+	self updateContents
+]
+
+{ #category : #accessing }
+TRubWithLineNumber >> fontToUse [
+	^ RubAbstractTextArea lineNumbersFont 
+]
+
+{ #category : #'managing line numbers' }
+TRubWithLineNumber >> lineNumbersDisplayLabel [
+	^ self paragraphProvider lineNumbersRuler  
+		ifNil: [ '+L' ]
+		ifNotNil: [ 'L' ]
+]
+
+{ #category : #'managing line numbers' }
+TRubWithLineNumber >> lineNumbersDisplayLabelMorph [
+	^ StringMorph contents: self lineNumbersDisplayLabel font: self fontToUse
+]
+
+{ #category : #'event handling' }
+TRubWithLineNumber >> updateContents [
+	self explicitRequirement
+]

--- a/src/Rubric/TRubWithWrapPolicy.trait.st
+++ b/src/Rubric/TRubWithWrapPolicy.trait.st
@@ -1,0 +1,38 @@
+"
+I am a Trait that can be used by subclasses of RubScrolledTextExtra wanting a WrapPolicy.
+"
+Trait {
+	#name : #TRubWithWrapPolicy,
+	#category : #'Rubric-Traits'
+}
+
+{ #category : #'managing wrapping policy' }
+TRubWithWrapPolicy >> changeWrappingPolicy [
+	self paragraphProvider wrapped
+		ifTrue: [ self paragraphProvider beNotWrapped ]
+		ifFalse: [ self paragraphProvider beWrapped ].
+	self updateContents.
+	self paragraphProvider changed
+]
+
+{ #category : #accessing }
+TRubWithWrapPolicy >> fontToUse [
+	^ RubAbstractTextArea lineNumbersFont 
+]
+
+{ #category : #'event handling' }
+TRubWithWrapPolicy >> updateContents [
+	self explicitRequirement
+]
+
+{ #category : #'managing wrapping policy' }
+TRubWithWrapPolicy >> wrappingPolicyLabel [
+	^ self paragraphProvider wrapped
+		ifTrue: [ 'W' ]
+		ifFalse: [ 'NW' ]
+]
+
+{ #category : #'managing wrapping policy' }
+TRubWithWrapPolicy >> wrappingPolicyLabelMorph [
+	^ StringMorph contents: self wrappingPolicyLabel font: self fontToUse
+]

--- a/src/Tool-Workspace/RubWorkspaceBar.class.st
+++ b/src/Tool-Workspace/RubWorkspaceBar.class.st
@@ -4,6 +4,8 @@ A bottom bar to change the editing mode, switch with/without line numbers and sw
 Class {
 	#name : #RubWorkspaceBar,
 	#superclass : #RubScrolledTextSideRuler,
+	#traits : 'TRubWithWrapPolicy + TRubWithLineNumber',
+	#classTraits : 'TRubWithWrapPolicy classTrait + TRubWithLineNumber classTrait',
 	#instVars : [
 		'row',
 		'wrappingPolicyMorph',
@@ -21,24 +23,6 @@ RubWorkspaceBar class >> key [
 { #category : #accessing }
 RubWorkspaceBar >> backgroundColor [
 	^ self paragraphProvider backgroundColor darker
-]
-
-{ #category : #'managing line numbers' }
-RubWorkspaceBar >> changeLineNumbersDisplay [
-	self paragraphProvider lineNumbersRuler 
-		ifNil: [ self paragraphProvider withLineNumbers ]
-		ifNotNil: [ self paragraphProvider withoutLineNumbers ].
-	self paragraphProvider manageLayout.
-	self updateContents
-]
-
-{ #category : #'managing wrapping policy' }
-RubWorkspaceBar >> changeWrappingPolicy [
-	self paragraphProvider wrapped 
-		ifTrue: [ self paragraphProvider beNotWrapped  ]
-		ifFalse: [ self paragraphProvider beWrapped ].
-	self updateContents.
-	self paragraphProvider changed
 ]
 
 { #category : #'managing editing mode' }
@@ -69,35 +53,15 @@ RubWorkspaceBar >> editingModeLabelMorph [
 		font: self fontToUse
 ]
 
-{ #category : #accessing }
-RubWorkspaceBar >> fontToUse [
-	^ RubAbstractTextArea lineNumbersFont 
-]
-
 { #category : #initialization }
 RubWorkspaceBar >> initialize [
 	super initialize.
-	self side: #bottom.
-
+	self side: #bottom
 ]
 
 { #category : #accessing }
 RubWorkspaceBar >> level [
 	^ 1
-]
-
-{ #category : #'managing line numbers' }
-RubWorkspaceBar >> lineNumbersDisplayLabel [
-	^ self paragraphProvider lineNumbersRuler  
-		ifNil: [ '+L' ]
-		ifNotNil: [ 'L' ]
-]
-
-{ #category : #'managing line numbers' }
-RubWorkspaceBar >> lineNumbersDisplayLabelMorph [
-	^ StringMorph
-		contents: self lineNumbersDisplayLabel
-		font: self fontToUse
 ]
 
 { #category : #geometry }
@@ -176,18 +140,4 @@ RubWorkspaceBar >> updateContents [
 	editingModeMorph contents: self editingModeLabel.
 	lineNumbersDisplayMorph contents: self lineNumbersDisplayLabel.
 	row bounds: self innerBounds
-]
-
-{ #category : #'managing wrapping policy' }
-RubWorkspaceBar >> wrappingPolicyLabel [
-	^ self paragraphProvider wrapped
-				ifTrue: [ 'W' ]
-				ifFalse: [ 'NW' ]
-]
-
-{ #category : #'managing wrapping policy' }
-RubWorkspaceBar >> wrappingPolicyLabelMorph [
-	^ StringMorph
-		contents: self wrappingPolicyLabel
-		font: self fontToUse
 ]


### PR DESCRIPTION
Use Traits to remove duplication in Rubric.

Fixes #2645