### PR TITLE
2636-Error-while-browsing-the-versions-of-code-that-is-not-a-method-during-debugging

### DIFF
--- a/src/Spec-Tools/VersionBrowser.class.st
+++ b/src/Spec-Tools/VersionBrowser.class.st
@@ -12,13 +12,16 @@ Class {
 }
 
 { #category : #api }
-VersionBrowser class >> browseVersionsForClass: aClass selector: aSelector [ 
-	| method |
-	method := (aClass compiledMethodAt: aSelector) ifNil: [ ^self ].
-	
-	^ self new
-		browseVersionsOf: method
-		
+VersionBrowser class >> browseVersionsForClass: aClass selector: aSelector [
+	^ aClass
+		compiledMethodAt: aSelector
+		ifPresent: [ :method | self new browseVersionsOf: method ]
+		ifAbsent: [ self
+				inform:
+					('No method {1} in class {2}'
+						format:
+							{aSelector.
+							aClass printString}) ]
 ]
 
 { #category : #api }


### PR DESCRIPTION
Inform the user if he tries to retrive the history of a non existing method.

Fixes #2636