### PR TITLE
2670-Update-the-checkVMVersion-date

### DIFF
--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -27,7 +27,7 @@ DiskStore class >> checkVMVersion [
 	"Display a warning if the VM is too old"
 	| displayError |
 	displayError := [ ^ self inform: 'Your VM is too old for this image. Please download the latest VM.' ].
-	[(Smalltalk vm interpreterSourceDate > '2012-07-08+2:00' asDate)
+	[(Smalltalk vm interpreterSourceDate >= '2019-01-05' asDate)
 		ifFalse: displayError
 	] on: Error do: [ :e| displayError value ].
 ]


### PR DESCRIPTION
Date class>>checkVMVersion currently checks that the VM is newer than 2012-07-08. Pharo 8 requires the FileAttributesPlugin from the 2019-01-05 VM.

This results in users getting a rather uninformative #'not found' error if they user an older VM.

Update the date to match the earliest supported VM for Pharo 8.0.

Fixes #2670