### PR TITLE
2578-Test-result-notification-uses-wrong-plural-forms

### DIFF
--- a/src/SUnit-Core/TestResult.class.st
+++ b/src/SUnit-Core/TestResult.class.st
@@ -321,21 +321,25 @@ TestResult >> passedCount [
 
 { #category : #printing }
 TestResult >> printOn: aStream [
+	self runCount isZero ifTrue: [ ^ aStream nextPutAll: 'No tests ran' ].
 	aStream
-		nextPutAll: self runCount printString;
-		nextPutAll: ' run, ';
-		nextPutAll: self expectedPassCount printString;
-		nextPutAll: ' passes, ';
-		nextPutAll: self skippedCount printString;
+		print: self runCount;
+		nextPutAll: ' ran, ';
+		print: self expectedPassCount;
+		nextPutAll: ' passed, ';
+		print: self skippedCount;
 		nextPutAll: ' skipped, ';
-		nextPutAll: self expectedDefectCount printString;
-		nextPutAll:' expected failures, ';
-		nextPutAll: self unexpectedFailureCount printString;
-		nextPutAll: ' failures, ';
-		nextPutAll: self unexpectedErrorCount printString;
-		nextPutAll:' errors, ';
-		nextPutAll: self unexpectedPassCount printString;
-		nextPutAll:' unexpected passes'.
+		print: self expectedDefectCount;
+		nextPutAll: (' expected failure' asPluralBasedOn: self expectedDefectCount); 
+		nextPutAll: ', ';
+		print: self unexpectedFailureCount;
+		nextPutAll: (' failure' asPluralBasedOn: self unexpectedFailureCount);
+		nextPutAll: ', ';
+		print: self unexpectedErrorCount;
+		nextPutAll: (' error' asPluralBasedOn: self unexpectedErrorCount);
+		nextPutAll: ', ';
+		print: self unexpectedPassCount;
+		nextPutAll: ' passed unexpected'
 ]
 
 { #category : #running }

--- a/src/SUnit-Tests/SUnitTest.class.st
+++ b/src/SUnit-Tests/SUnitTest.class.st
@@ -396,7 +396,7 @@ SUnitTest >> testFileOutResult [
 	self
 		assert: fileout
 		equals:
-			'3 run, 1 passes, 0 skipped, 0 expected failures, 1 failures, 1 errors, 0 unexpected passes
+			'3 ran, 1 passed, 0 skipped, 0 expected failures, 1 failure, 1 error, 0 passed unexpected
 Failures:
 SUnitTest(TestAsserter)>>#fail
 

--- a/src/SUnit-Tests/SimpleTestResourceTestCase.class.st
+++ b/src/SUnit-Tests/SimpleTestResourceTestCase.class.st
@@ -114,7 +114,7 @@ SimpleTestResourceTestCase >> testRunSuiteWithResource [
 	suite addTest: (self class selector: #dummy).
 	self clearOuterResourceStateDuring:
 		[self
-			assert: suite run printString = '3 run, 1 passes, 0 skipped, 0 expected failures, 1 failures, 1 errors, 0 unexpected passes'
+			assert: suite run printString = '3 ran, 1 passed, 0 skipped, 0 expected failures, 1 failure, 1 error, 0 passed unexpected'
 			description: 'A suite of tests needing SimpleTestResource did not run as expected'].
 ]
 
@@ -123,6 +123,6 @@ SimpleTestResourceTestCase >> testRunTestWithResource [
 	self clearOuterResourceStateDuring:
 		[self
 			assert: (self class selector: #dummy) run printString =
-							'1 run, 1 passes, 0 skipped, 0 expected failures, 0 failures, 0 errors, 0 unexpected passes'
+							'1 ran, 1 passed, 0 skipped, 0 expected failures, 0 failures, 0 errors, 0 passed unexpected'
 			description: 'A dummy test that needed a resource did not pass']
 ]


### PR DESCRIPTION
Improve TestResult>>#printOn: to better take singular/plural forms into account

https://github.com/pharo-project/pharo/issues/2578