### PR TITLE
2688-Remove-GLMBrowser-and-GLMExamples

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -207,7 +207,6 @@ BaselineOfIDE >> baseline: spec [
 		spec package: 'Glamour-PagerModel'.
 		spec package: 'Glamour-Presentations'.
 		spec package: 'Glamour-Browsers'.
-		spec package: 'Glamour-Examples'.
 		spec package: 'Glamour-Morphic-Brick'.
 		spec package: 'Glamour-Tests-Core'.
 		spec package: 'Glamour-Tests-Resources'.
@@ -658,7 +657,6 @@ spec group: 'Glamour-Core-Group' with: #(
 	'Glamour-PagerModel'
 	'Glamour-Presentations'
 	'Glamour-Browsers'
-	'Glamour-Examples'
 	'Glamour-Morphic-Brick'
 	'Glamour-Morphic-Theme'
 	'Glamour-Morphic-Widgets'


### PR DESCRIPTION
Fixes #2692  https://github.com/pharo-project/pharo/issues/2692 
We will have to remove the package manually from the repo because iceberg does not handle correclty the removal of packages.