### PR TITLE
2680-Cleanup-and-streamline-semantics-of-WriteStream-and-putOn-

### DIFF
--- a/src/Collections-Abstract/SequenceableCollection.class.st
+++ b/src/Collections-Abstract/SequenceableCollection.class.st
@@ -1576,6 +1576,10 @@ SequenceableCollection >> polynomialEval: thisX [
 
 { #category : #streaming }
 SequenceableCollection >> putOn: aStream [
+	"Write the receiver onto aStream by iterating over its elements.
+	In general we assume aStream accepts the receiver's elements as element type.
+	Return self."
+
 	self do: [ :each | each putOn: aStream ]
 ]
 

--- a/src/Collections-Native/ByteArray.class.st
+++ b/src/Collections-Native/ByteArray.class.st
@@ -282,6 +282,16 @@ ByteArray >> printOn: aStream [
 	aStream nextPut: $]
 ]
 
+{ #category : #streaming }
+ByteArray >> putOn: aStream [
+	"Write the receiver onto aStream by iterating over its elements.
+	In general we assume aStream accepts the receiver's elements as element type.
+	This is an optimisation.
+	Return self."
+
+	aStream nextPutAll: self
+]
+
 { #category : #initialization }
 ByteArray >> readHexFrom: aStream [
 	"Initialize the receiver from a hexadecimal string representation"

--- a/src/Collections-Streams/Stream.class.st
+++ b/src/Collections-Streams/Stream.class.st
@@ -15,8 +15,11 @@ Stream class >> new [
 
 { #category : #accessing }
 Stream >> << anObject [
-	"A more readable, shorter alternative to #nextPutAll: that also
-	accepts non-Collection arguments"
+	"Write anObject to the receiver, dispatching using #putOn:
+	This is a shortcut for both nextPut: and nextPutAll: since anObject can be both
+	the element type of the receiver as well as a collection of those elements.
+	No further conversions of anObject are applied.
+	Return self to accomodate chaining."
 
  	anObject putOn: self
 ]

--- a/src/Collections-Streams/WriteStream.class.st
+++ b/src/Collections-Streams/WriteStream.class.st
@@ -32,10 +32,14 @@ WriteStream class >> with: aCollection from: firstIndex to: lastIndex [
 
 { #category : #accessing }
 WriteStream >> << anObject [
-	"A more readable, shorter alternative to #nextPutAll: that also
-	accepts non-Collection arguments"
+	"Write anObject to the receiver, dispatching using #putOn:
+	This is a shortcut for both nextPut: and nextPutAll: since anObject can be both
+	the element type of the receiver as well as a collection of those elements.
+	No further conversions of anObject are applied.
+	This is an optimisation.
+	Return self to accomodate chaining."
 
-	anObject class == collection class
+ 	anObject class == collection class
 		ifTrue: [ self nextPutAll: anObject ]
 		ifFalse: [ anObject putOn: self ]
 ]

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2135,6 +2135,11 @@ String >> printOn: aStream [
 
 { #category : #streaming }
 String >> putOn: aStream [
+	"Write the receiver onto aStream by iterating over its elements.
+	In general we assume aStream accepts the receiver's elements as element type.
+	This is an optimisation.
+	Return self."
+
 	aStream nextPutAll: self
 ]
 

--- a/src/Collections-Tests/WriteStreamTest.class.st
+++ b/src/Collections-Tests/WriteStreamTest.class.st
@@ -128,6 +128,24 @@ WriteStreamTest >> testIsEmpty [
 ]
 
 { #category : #tests }
+WriteStreamTest >> testLessThanLessThan [
+	"Tests for #<< output operator shortcut on WriteStreams"
+	
+	self 
+		assert: (String streamContents: [ :out | out << $a << 'bcd' << $e ])
+		equals: 'abcde'.
+	self 
+		assert: (ByteArray streamContents: [ :out | out << 1 << #[2 3 4] << 5 ])
+		equals: #[1 2 3 4 5].
+	self 
+		assert: (Array streamContents: [ :out | out << 1 << #(2 3 4) asOrderedCollection << 5 ])
+		equals: #(1 2 3 4 5).
+	"no conversions, wrong element type"
+	self should: [ String streamContents: [ :out | out << 1234 ] ] raise: Error.
+	self should: [ ByteArray streamContents: [ :out | out << 1234 ] ] raise: Error
+]
+
+{ #category : #tests }
 WriteStreamTest >> testNew [
 
 	self should: [self streamClass new] raise: Error. 

--- a/src/Kernel/Integer.class.st
+++ b/src/Kernel/Integer.class.st
@@ -1347,13 +1347,6 @@ Integer >> printWithCommasSignedOn: aStream [
 	^ self printSeparatedBy: $, every: 3 signed: true on: aStream
 ]
 
-{ #category : #streaming }
-Integer >> putOn: aStream [
-	aStream isBinary
-		ifTrue: [ self asByteArray do: [ :each | aStream nextPut: each ] ]
-		ifFalse: [ self asString putOn: aStream ]
-]
-
 { #category : #arithmetic }
 Integer >> quo: aNumber [ 
 	"Refer to the comment in Number quo: "

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1787,6 +1787,10 @@ Object >> printStringLimitedTo: limit using: printBlock [
 
 { #category : #streaming }
 Object >> putOn: aStream [
+	"Write the receiver onto aStream.
+	In general we assume aStream accepts the receiver as element type.
+	Return self."
+	
 	aStream nextPut: self
 ]
 

--- a/src/Network-Kernel/SocketStream.class.st
+++ b/src/Network-Kernel/SocketStream.class.st
@@ -119,11 +119,14 @@ SocketStream class >> openConnectionToHostNamed: hostName port: portNumber [
 ]
 
 { #category : #private }
-SocketStream >> << items [
+SocketStream >> << anObject [
+	"Write anObject to the receiver, dispatching using #putOn:
+	This is a shortcut for both nextPut: and nextPutAll: since anObject can be both
+	the element type of the receiver as well as a collection of those elements.
+	No further conversions of anObject are applied.
+	Return self to accomodate chaining."
 
- 	items putOn: self.
-	
-	^ self
+ 	anObject putOn: self
 ]
 
 { #category : #private }

--- a/src/Transcript-Core-Traits/TTranscript.trait.st
+++ b/src/Transcript-Core-Traits/TTranscript.trait.st
@@ -18,9 +18,13 @@ Trait {
 
 { #category : #streaming }
 TTranscript >> << anObject [
-	"Output anObject asString on the receiver and show the output"
-	
-	self show: anObject
+	"Write anObject to the receiver, dispatching using #putOn:
+	This is a shortcut for both nextPut: and nextPutAll: since anObject can be both
+	the element type of the receiver as well as a collection of those elements.
+	No further conversions of anObject are applied.
+	Return self to accomodate chaining."
+
+ 	anObject putOn: self
 ]
 
 { #category : #streaming }

--- a/src/Transcript-Core/ThreadSafeTranscript.class.st
+++ b/src/Transcript-Core/ThreadSafeTranscript.class.st
@@ -53,9 +53,13 @@ ThreadSafeTranscript class >> taskbarIconName [
 
 { #category : #streaming }
 ThreadSafeTranscript >> << anObject [
-	"Output anObject asString on the receiver and show the output"
-	
-	self show: anObject
+	"Write anObject to the receiver, dispatching using #putOn:
+	This is a shortcut for both nextPut: and nextPutAll: since anObject can be both
+	the element type of the receiver as well as a collection of those elements.
+	No further conversions of anObject are applied.
+	Return self to accomodate chaining."
+
+ 	anObject putOn: self
 ]
 
 { #category : #accessing }

--- a/src/Transcript-NonInteractive/NonInteractiveTranscript.class.st
+++ b/src/Transcript-NonInteractive/NonInteractiveTranscript.class.st
@@ -87,9 +87,13 @@ NonInteractiveTranscript class >> stdout [
 
 { #category : #streaming }
 NonInteractiveTranscript >> << anObject [
-	"Output anObject asString on the receiver and show the output"
-	
-	self show: anObject
+	"Write anObject to the receiver, dispatching using #putOn:
+	This is a shortcut for both nextPut: and nextPutAll: since anObject can be both
+	the element type of the receiver as well as a collection of those elements.
+	No further conversions of anObject are applied.
+	Return self to accomodate chaining."
+
+ 	anObject putOn: self
 ]
 
 { #category : #streaming }

--- a/src/Zinc-Character-Encoding-Core/ZnEncodedWriteStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnEncodedWriteStream.class.st
@@ -10,8 +10,14 @@ Class {
 }
 
 { #category : #accessing }
-ZnEncodedWriteStream >> << collection [
-	^ self nextPutAll: collection
+ZnEncodedWriteStream >> << anObject [
+	"Write anObject to the receiver, dispatching using #putOn:
+	This is a shortcut for both nextPut: and nextPutAll: since anObject can be both
+	the element type of the receiver as well as a collection of those elements.
+	No further conversions of anObject are applied.
+	Return self to accomodate chaining."
+
+ 	anObject putOn: self
 ]
 
 { #category : #accessing }

--- a/src/Zinc-HTTP/ZnDefaultServerDelegate.class.st
+++ b/src/Zinc-HTTP/ZnDefaultServerDelegate.class.st
@@ -217,7 +217,7 @@ ZnDefaultServerDelegate >> generateSessionRequest: session [
 		html page: 'Session' do: [ 
 			html tag: #p do: [ html << 'I am using '; str: session asString ].
 			html tag: #p do: [ html << 'Current session id is ' << session id ].
-			html tag: #p do: [ html << 'Session hit count ' << (session attributeAt: #hitCount) ] ] ]
+			html tag: #p do: [ html << 'Session hit count ' << (session attributeAt: #hitCount) asString ] ] ]
 ]
 
 { #category : #private }

--- a/src/Zinc-HTTP/ZnHtmlOutputStream.class.st
+++ b/src/Zinc-HTTP/ZnHtmlOutputStream.class.st
@@ -56,8 +56,14 @@ ZnHtmlOutputStream class >> streamContents: block [
 ]
 
 { #category : #streaming }
-ZnHtmlOutputStream >> << collection [
-	^ self nextPutAll: collection asString
+ZnHtmlOutputStream >> << anObject [
+	"Write anObject to the receiver, dispatching using #putOn:
+	This is a shortcut for both nextPut: and nextPutAll: since anObject can be both
+	the element type of the receiver as well as a collection of those elements.
+	No further conversions of anObject are applied.
+	Return self to accomodate chaining."
+
+ 	anObject putOn: self
 ]
 
 { #category : #'initialize-release' }


### PR DESCRIPTION
Cleanup & streamline the semantics & implementation of [Write]Stream>>#<< and Object>>#putOn:

Add an explicit test and better documentation.

Several Stream and Transcript classes were modified.

https://github.com/pharo-project/pharo/issues/2680