### PR TITLE
Moved the "create" button of the debugger when a SubclassResponsibili…

### DIFF
--- a/src/DebuggerActions/DoesNotUnderstandDebugAction.class.st
+++ b/src/DebuggerActions/DoesNotUnderstandDebugAction.class.st
@@ -82,7 +82,7 @@ DoesNotUnderstandDebugAction >> defaultLabel [
 { #category : #accessing }
 DoesNotUnderstandDebugAction >> defaultOrder [
 
-	^ 45
+	^ 1
 ]
 
 { #category : #actions }

--- a/src/DebuggerActions/SubclassResponsabilityDebugAction.class.st
+++ b/src/DebuggerActions/SubclassResponsabilityDebugAction.class.st
@@ -57,7 +57,7 @@ SubclassResponsabilityDebugAction >> defaultLabel [
 { #category : #accessing }
 SubclassResponsabilityDebugAction >> defaultOrder [
 
-	^ 45
+	^ 1
 ]
 
 { #category : #actions }


### PR DESCRIPTION
…ty error is raised to the left of the other debug action buttons, to be at the same place as the "create" button when a MessageNotUnderstood exception is raised
Solves #2624 