### PR TITLE
2704-Improve-as-when-the-class-is-already-of-the-right-kind

### DIFF
--- a/src/Kernel-Tests/ObjectTest.class.st
+++ b/src/Kernel-Tests/ObjectTest.class.st
@@ -54,6 +54,20 @@ ObjectTest >> shouldntHaltWhen: aBlock [
 ]
 
 { #category : #tests }
+ObjectTest >> testAs [
+	| coll1 coll2 |
+	coll1 := { 1 . 2 . 3 }.
+	coll2 := coll1 as: OrderedCollection.
+	
+	self assert: coll2 equals: (OrderedCollection with: 1 with: 2 with: 3).
+	self deny: coll1 == coll2.
+	
+	"If the object has the right type, do nothing."
+	coll2 := coll1 as: Array.
+	self assert: coll1 == coll2
+]
+
+{ #category : #tests }
 ObjectTest >> testBecome [	
 	"this test should that all the variables pointing to an object are pointing now to another one, and all
       object pointing to the other are pointing to the object"

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -325,7 +325,9 @@ Object >> addDependent: anObject [
 
 { #category : #converting }
 Object >> as: aSimilarClass [
-	"Create an object of class aSimilarClass that has similar contents to the receiver."
+	"Create an object of class aSimilarClass that has similar contents to the receiver if the object is not already an instance of this class."
+
+	aSimilarClass == self class ifTrue: [ ^ self ].
 
 	^ aSimilarClass newFrom: self
 ]


### PR DESCRIPTION
Do not create a new instance in #as: if we already have the right kind.

+ add a test.

Fixes #2704