### PR TITLE
2701-Remove-StreamCollectionwrite

### DIFF
--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -1290,11 +1290,6 @@ Collection >> union: aCollection [
 	^ self species withAll: set asArray
 ]
 
-{ #category : #'filter streaming' }
-Collection >> write: anObject [ 
-	^ self add: anObject
-]
-
 { #category : #enumerating }
 Collection >> | aCollection [
 	^ self union: aCollection

--- a/src/Collections-Streams/Stream.class.st
+++ b/src/Collections-Streams/Stream.class.st
@@ -224,11 +224,3 @@ Stream >> upToEnd [
 		elements add: self next ].
 	^elements
 ]
-
-{ #category : #accessing }
-Stream >> write: anObject [
-	"Like <<, but returns the object putOn the receiver."
-
-	anObject putOn: self.
-	^ anObject.
-]

--- a/src/Collections-Tests/TAddTest.trait.st
+++ b/src/Collections-Tests/TAddTest.trait.st
@@ -116,32 +116,3 @@ TAddTest >> testTAddWithOccurences [
 	self assert: (collection includes: anElement).
 	self assert: collection size equals: (oldSize + 5)
 ]
-
-{ #category : #'tests - adding' }
-TAddTest >> testTWrite [
-
-	| added collection elem |
-	collection := self otherCollection.
-	elem := self element.
-	added := collection write: elem.
-	
-	self assert: added == elem.	"test for identiy because #add: has not reason to copy its parameter."
-	self assert: (collection includes: elem).
-	self assert: (collection includes: elem)
-	
-	
-]
-
-{ #category : #'tests - adding' }
-TAddTest >> testTWriteTwice [
-	| added oldSize collection elem |
-	collection := self collectionWithElement.
-	elem := self element.
-	oldSize := collection size.
-	added := collection 
-		write: elem;
-		write: elem.
-	self assert: added == elem .	"test for identiy because #add: has not reason to copy its parameter."
-	self assert: (collection  includes: elem ).
-	self assert: collection size equals: (oldSize + 2)
-]


### PR DESCRIPTION
Remove Stream and Collection  #write: (as an alias to #<< and #add: respectively) 

This selector is not used for these 2 receiver types in the standard image (except for one unit test), I never saw it being used in actual code.

These are just aliases that add nothing but cognitive load.

They make the API's of two important hierarchies (and especially the interface for non-inheriting classes) heavier than needed for no functional benefit.

Fixes #2701