### PR TITLE
2718-Rubric-should-not-depend-on-TextEditor

### DIFF
--- a/src/Rubric-Tests/RubFindReplaceServiceTest.class.st
+++ b/src/Rubric-Tests/RubFindReplaceServiceTest.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #RubFindReplaceServiceTest,
+	#superclass : #TestCase,
+	#category : #'Rubric-Tests'
+}
+
+{ #category : #tests }
+RubFindReplaceServiceTest >> testCaseSensitive [ 
+	
+	self deny: RubFindReplaceService new caseSensitive
+]

--- a/src/Rubric/RubFindReplaceService.class.st
+++ b/src/Rubric/RubFindReplaceService.class.st
@@ -42,7 +42,7 @@ RubFindReplaceService class >> dialog [
 
 { #category : #accessing }
 RubFindReplaceService >> caseSensitive [
-	^ caseSensitive ifNil: [caseSensitive := TextEditor caseSensitiveFinds]
+	^ caseSensitive ifNil: [caseSensitive := RubAbstractTextArea caseSensitiveFinds]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fixing dependencies from Rubric to editor