### PR TITLE
2587-Cannot-remove-a-Trait

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -665,7 +665,7 @@ Class >> hasSharedPools [
 
 { #category : #'accessing class hierarchy' }
 Class >> hasSubclasses [
-	^subclasses notNil
+	^ self subclasses isEmpty not
 ]
 
 { #category : #'subclass creation - immediate' }

--- a/src/Refactoring-Changes/RBAddTraitChange.class.st
+++ b/src/Refactoring-Changes/RBAddTraitChange.class.st
@@ -14,7 +14,7 @@ Class {
 
 { #category : #private }
 RBAddTraitChange class >> definitionPatterns [
-	^ #('Trait named: `#traitName uses: `@traitComposition category: `#category')
+	^ #('Trait named: `#traitName uses: `@traitComposition category: `#category' 'Trait named: `#traitName uses: `@traitComposition slots: `@slotDefinition category: `#category' )
 ]
 
 { #category : #converting }

--- a/src/TraitsV2-Tests/T2TraitTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitTest.class.st
@@ -232,3 +232,22 @@ T2TraitTest >> testSequence [
 	self assert: obj getValues equals: 6.
 	self assert: obj getValues2 equals: 12
 ]
+
+{ #category : #tests }
+T2TraitTest >> testSubclasses [
+	| t1 t2 |
+		
+	t1 := self createT1.
+	t2 := self newTrait: #T2 with: #(aa bb) uses: t1.
+
+	self deny: t1 hasSubclasses.
+	self deny: t2 hasSubclasses.	
+
+	self assert: t1 subclasses isEmpty.
+	self assert: t2 subclasses isEmpty.	
+		
+	self deny: t1 hasSubclasses.
+	self deny: t2 hasSubclasses.	
+
+
+]


### PR DESCRIPTION
When Calypso removes a Trait it uses the refactoring browser. As RB is not prepared for stateful traits I have to extend it. 
Also I have improved the detection of subclasses.