### PR TITLE
2740-do-not-zap-method-dict-when-making-classes-obsolete

### DIFF
--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -342,7 +342,7 @@ CompiledMethodTest >> testIsInstalled [
 	method := (self class)>>#returnTrue.
 	self assert: method isInstalled.
 
-	"now make an orphaned method by just deleting the class."
+	
 
 	Smalltalk removeClassNamed: #TUTU.
 
@@ -353,9 +353,12 @@ CompiledMethodTest >> testIsInstalled [
 		category: self categoryNameForTemporaryClasses.
 	cls compile: 'foo ^ 10'.
 	method := cls >> #foo.
-	Smalltalk removeClassNamed: #TUTU.
 
+	"now make an orphaned method by just deleting the method."
+	cls removeSelector: #foo.
+	
 	self deny: method isInstalled. 
+	Smalltalk removeClassNamed: #TUTU.
 ]
 
 { #category : #'tests - testing' }

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1482,11 +1482,7 @@ Behavior >> numberOfInstanceVariables [
 
 { #category : #initialization }
 Behavior >> obsolete [
-	"Invalidate and recycle local methods,
-	e.g., zap the method dictionary if can be done safely."
-	self canZapMethodDictionary
-		ifTrue: [self methodDict: self emptyMethodDictionary].
-
+	"nothing to be done"
 ]
 
 { #category : #'obsolete subclasses' }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -958,7 +958,6 @@ ClassDescription >> numberOfMethods [
 ClassDescription >> obsolete [
 	"Make the receiver obsolete."
 	self superclass removeSubclass: self.
-	self organization: nil.
 	super obsolete.
 ]
 

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -81,15 +81,6 @@ Metaclass >> bindingOf: varName [
 	^self instanceSide classBindingOf: varName
 ]
 
-{ #category : #testing }
-Metaclass >> canZapMethodDictionary [
-	"Return true if it is safe to zap the method dictionary on #obsolete"
-
-	self soleInstance
-		ifNil: [ ^ true ]
-		ifNotNil: [ ^ self soleInstance canZapMethodDictionary ]
-]
-
 { #category : #accessing }
 Metaclass >> category [
 	^ self instanceSide category

--- a/src/TraitsV2-Tests/T2ObsoleteClassTest.class.st
+++ b/src/TraitsV2-Tests/T2ObsoleteClassTest.class.st
@@ -47,69 +47,6 @@ T2ObsoleteClassTest >> testObsoleteClassIsRemovedFromUsersClassSide [
 ]
 
 { #category : #tests }
-T2ObsoleteClassTest >> testObsoleteClassRemovesMethods [
-	| t1 t2 c1 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t1 compile: 'm1 ^ 1'.
-
-	t2 := self newTrait: #T2 with: #() uses: {}.
-	t2 compile: 'm2 ^ 1'.
-
-	c1 := self newClass: #C1 with: #() uses: t1 + t2.
-
-	c1 compile: 'localM1 ^ 1'.
-
-	self assert: (c1 methodDict includesKey: #m1).
-	self assert: (c1 methodDict includesKey: #m2).
-	self deny: (c1 localMethodDict includesKey: #m1).
-	self deny: (c1 localMethodDict includesKey: #m2).
-	self assert: (c1 localMethodDict includesKey: #localM1).
-
-	c1 removeFromSystem.
-	createdClasses remove: c1.
-
-	self deny: (c1 methodDict includesKey: #m1).
-	self deny: (c1 methodDict includesKey: #m2).
-
-	"Accessing directly because there is no more accesor method"
-	self assertEmpty: (c1 class instVarNamed: #baseLocalMethods).
-	self deny: ((c1 class instVarNamed: #baseLocalMethods) includesKey: #m1).
-	self deny: ((c1 class instVarNamed: #baseLocalMethods) includesKey: #m2).
-	self deny: ((c1 class instVarNamed: #baseLocalMethods) includesKey: #localM1)
-]
-
-{ #category : #tests }
-T2ObsoleteClassTest >> testObsoleteClassRemovesMethodsClassSide [
-	| t1 t2 c1 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t1 compile: 'm1 ^ 1'.
-
-	t2 := self newTrait: #T2 with: #() uses: {}.
-	t2 compile: 'm2 ^ 1'.
-
-	c1 := self newClass: #C1 with: #()  uses: {}.
-	c1 class setTraitComposition: t1 + t2. 
-
-	c1 class compile: 'localM1 ^ 1'.
-
-	self assert: (c1 class methodDict includesKey: #m1).
-	self assert: (c1 class methodDict includesKey: #m2).
-	self deny: (c1 class localMethodDict includesKey: #m1).
-	self deny: (c1 class localMethodDict includesKey: #m2).
-	self assert: (c1 class localMethodDict includesKey: #localM1).
-	
-	c1 removeFromSystem.
-	createdClasses remove: c1.
-	
-	self deny: (c1 class methodDict includesKey: #m1).
-	self deny: (c1 class methodDict includesKey: #m2).
-	self deny: (c1 class localMethodDict includesKey: #m1).
-	self deny: (c1 class localMethodDict includesKey: #m2).
-	self deny: (c1 class localMethodDict includesKey: #localM1).
-
-]
-
-{ #category : #tests }
 T2ObsoleteClassTest >> testObsoleteTraitIsRemovedFromUsers [
 	| t1 t2 t3 |
 	t1 := self newTrait: #T1 with: #() uses: {}.

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -258,18 +258,6 @@ TraitedMetaclass >> localSelectors [
 ]
 
 { #category : #initialization }
-TraitedMetaclass >> obsolete [
-
-	super obsolete.
-	self canZapMethodDictionary
-		ifTrue: [
-			localMethods := self emptyMethodDictionary.
-			baseLocalMethods := self emptyMethodDictionary].
-	
-
-]
-
-{ #category : #initialization }
 TraitedMetaclass >> rebuildMethodDictionary [
 	| selectors removedSelectors modified |
 	


### PR DESCRIPTION
do not zap method dict when making classes obsolete

fixes #2740