### PR TITLE
2753-FileReference-version-number-issues

### DIFF
--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -357,15 +357,15 @@ FileReference >> lastFileFor: baseFileName extension: extension [
 
 	"FileSystem workingDirectory lastFileFor: 'games' extension: 'ston'"
 
-	| files |
-	files := self childrenMatching: baseFileName , '.*.' , extension.
-	files ifEmpty: [ ^ self error: 'No file with number pattern' ].
-	"splitting twice but for now a simple '*.*.*' does not work since it selects: name.45.677.mcz"
-	files := files select: [ :each | (each basename splitOn: $.) size = 3].
-	^ (files
-		asSortedCollection:
-			[ :a :b | ((a basename splitOn: $.) at: 2) asNumber < ((b basename splitOn: $.) at: 2) asNumber ])
-		last
+	| version |
+
+	version := self versionNumberFor: baseFileName extension: extension.
+	^(version
+		ifNil: [ self error: 'No file with number pattern' ]
+		ifNotNil: [ version = 0
+			ifTrue: [ baseFileName, '.', extension ]
+			ifFalse: [ baseFileName , '.' , version asString , '.' , extension ] ]) asFileReference 
+
 ]
 
 { #category : #accessing }
@@ -407,17 +407,12 @@ FileReference >> nextNameFor: baseFileName extension: extension [
 
 	"(FileSystem workingDirectory nextNameFor: 'games' extension: 'ston') asFileReference ensureCreateFile"
 
-	| files splits version |
-	files := self childrenMatching: baseFileName , '.*.' , extension.
-	files ifEmpty: [ ^ baseFileName , '.1.' , extension ].
-	splits := files
-		collect: [ :filename | filename basename splitOn: $. ]
-		thenSelect: [ :split | (split at: 1) = baseFileName and: [ split size = 3 ] ].
-	splits := splits asSortedCollection: [ :a :b | (a at: 2) asNumber < (b at: 2) asNumber ].
-	version := splits isEmpty
-		ifTrue: [ 1 ]
-		ifFalse: [ (splits last at: 2) asNumber + 1 ].
-	^ baseFileName , '.' , version asString , '.' , extension
+	| version |
+
+	version := self versionNumberFor: baseFileName extension: extension.
+	^version
+		ifNil: [ baseFileName, '.1.', extension ]
+		ifNotNil: [ baseFileName , '.' , (version+1) asString , '.' , extension ]
 ]
 
 { #category : #utilities }
@@ -426,24 +421,24 @@ FileReference >> nextVersion [
 	preceding the file extension.  Increment the version number and answer the new file name.
 	If a version number is not found, return just the file"
 
-	| parent version versionNumbers nameWithoutExtension |
-	
+	| parent basename nameWithoutExtension extension max index |
+
 	self exists
 		ifFalse: [ ^ self ].
-	
+
 	parent := self parent.
-	nameWithoutExtension := self basename copyUpTo: $..
-	
-	versionNumbers := parent children 
-				select: [ :f| 
-					(f basename beginsWith: nameWithoutExtension) ]
-				thenCollect: [ :f| 
-					Number squeezeNumberOutOfString: (f basename last: (f basename size - nameWithoutExtension size - 1))   ifFail: [ 0 ]].
-	
-	versionNumbers ifEmpty: [ ^self ].
-	
-	version := versionNumbers max + 1.
-	^ parent / (nameWithoutExtension , '.', version asString) , self extension
+	extension := self extension.
+	basename := self basename.
+	nameWithoutExtension := basename copyFrom: 1 to: (basename size - extension size - 1).
+	"At this stage nameWithoutExtension may still include a version number.  Remove it if necessary"
+	index := nameWithoutExtension size.
+	[ index > 0 and: [ (nameWithoutExtension at: index) isDigit ] ] whileTrue:
+		[ index := index - 1 ].
+	((index between: 1 and: nameWithoutExtension size - 1) and: [ (nameWithoutExtension at: index) = $. ]) ifTrue: 
+		[ nameWithoutExtension := nameWithoutExtension copyFrom: 1 to: index-1 ].
+
+	max := parent versionNumberFor: nameWithoutExtension extension: extension.
+	^ parent / (nameWithoutExtension, '.', (max+1) asString) , self extension
 ]
 
 { #category : #accessing }
@@ -578,6 +573,26 @@ FileReference >> uid: uid gid: gid [
 	An id of nil leaves it unchanged."
 
 	^filesystem file: self path uid: uid gid: gid
+]
+
+{ #category : #versions }
+FileReference >> versionNumberFor: basename extension: extension [
+	"Answer the latest (largest) version number for the specified file.
+	0 = basename.extension exists, but nothing later.
+	nil = no file exists"
+
+	| regex maxVersion |
+
+	regex := (basename, '.(\d+).', extension) asRegex.
+	maxVersion := 0.
+	self fileSystem childNamesAt: self path do: [ :child |
+		(regex matches: child) ifTrue: 
+			[ maxVersion := maxVersion max: (regex subexpression: 2) asNumber ] ].
+	^maxVersion = 0
+		ifTrue: [ (self / (basename, '.', extension)) asFileReference exists 
+			ifTrue: [ 0 ]
+			ifFalse: [ nil ] ]
+		ifFalse: [ maxVersion ]
 ]
 
 { #category : #streams }

--- a/src/FileSystem-Tests-Core/FileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/FileReferenceTest.class.st
@@ -684,23 +684,39 @@ FileReferenceTest >> testMakeRelative [
 { #category : #'tests - handy utils' }
 FileReferenceTest >> testNextNameForExtension [
 	
-	| childFiles |
-	[ filesystem createDirectory: 'dir'.
-	filesystem / 'dir' / 'games.51.ston' writeStreamDo: [ :stream | stream nextPutAll: '51' ].
-	filesystem / 'dir' / 'games.3.ston' writeStreamDo: [ :stream | stream nextPutAll: '3' ].
-	filesystem / 'dir' / 'games.33.ston' writeStreamDo: [ :stream | stream nextPutAll: '33' ].
-	filesystem / 'dir' / 'games.4.ston' writeStreamDo: [ :stream | stream nextPutAll: '4' ].
-	filesystem / 'dir' / 'games.101.ston' writeStreamDo: [ :stream | stream nextPutAll: '101' ].
-	filesystem / 'dir' / 'games.49.ston' writeStreamDo: [ :stream | stream nextPutAll: '49' ].
-	filesystem / 'dir' / 'games.5.ston' writeStreamDo: [ :stream | stream nextPutAll: '5' ].
-	
-	childFiles := (filesystem root / 'dir') files.
-	self assert: childFiles size equals: 7.
-	self assert: ((filesystem root / 'dir') nextNameFor: 'games' extension: 'ston') equals: 'games.102.ston'.
+	| childFiles dir |
 
+	[ filesystem createDirectory: 'dir'.
+	dir := filesystem / 'dir'.
+	dir / 'games.51.ston' writeStreamDo: [ :stream | stream nextPutAll: '51' ].
+	dir / 'games.3.ston' writeStreamDo: [ :stream | stream nextPutAll: '3' ].
+	dir / 'games.33.ston' writeStreamDo: [ :stream | stream nextPutAll: '33' ].
+	dir / 'games.4.ston' writeStreamDo: [ :stream | stream nextPutAll: '4' ].
+	dir / 'games.101.ston' writeStreamDo: [ :stream | stream nextPutAll: '101' ].
+	dir / 'games.49.ston' writeStreamDo: [ :stream | stream nextPutAll: '49' ].
+	dir / 'games.5.ston' writeStreamDo: [ :stream | stream nextPutAll: '5' ].
 	
-			]
-			ensure: [ (filesystem / 'dir') ensureDeleteAll ]
+	childFiles := dir files.
+	self assert: childFiles size equals: 7.
+	self assert: (dir nextNameFor: 'games' extension: 'ston') equals: 'games.102.ston' ]
+		ensure: [ (filesystem / 'dir') ensureDeleteAll ].
+
+
+	[ filesystem createDirectory: 'dir'.
+	dir := filesystem / 'dir'.
+	dir / 'foo.bar.51.ston' writeStreamDo: [ :stream | stream nextPutAll: '51' ].
+	dir / 'foo.bar.3.ston' writeStreamDo: [ :stream | stream nextPutAll: '3' ].
+	dir / 'foo.bar.33.ston' writeStreamDo: [ :stream | stream nextPutAll: '33' ].
+	dir / 'foo.bar.4.ston' writeStreamDo: [ :stream | stream nextPutAll: '4' ].
+	dir / 'foo.bar.101.ston' writeStreamDo: [ :stream | stream nextPutAll: '101' ].
+	dir / 'foo.bar.49.ston' writeStreamDo: [ :stream | stream nextPutAll: '49' ].
+	dir / 'foo.bar.5.ston' writeStreamDo: [ :stream | stream nextPutAll: '5' ].
+	
+	childFiles := dir files.
+	self assert: childFiles size equals: 7.
+	self assert: (dir nextNameFor: 'foo.bar' extension: 'ston') equals: 'foo.bar.102.ston' ]
+		ensure: [ (filesystem / 'dir') ensureDeleteAll ].
+
 ]
 
 { #category : #'tests - handy utils' }
@@ -754,6 +770,25 @@ FileReferenceTest >> testNextVersion [
 			stream nextPut: file basename.
 			file := file nextVersion. ] ].
 	self assert: versions equals: #('file.name' 'file.1.name' 'file.2.name' 'file.3.name' 'file.4.name').
+
+	fs := FileSystem memory.
+	file := fs / 'file123.name.ext'.
+	versions := Array streamContents: [ :stream |
+		5 timesRepeat: [ 
+			file createFile.
+			stream nextPut: file basename.
+			file := file nextVersion. ] ].
+	self assert: versions equals: #('file123.name.ext' 'file123.name.1.ext' 'file123.name.2.ext' 'file123.name.3.ext' 'file123.name.4.ext').
+
+	fs := FileSystem memory.
+	file := fs / '123.ext'.
+	versions := Array streamContents: [ :stream |
+		5 timesRepeat: [ 
+			file createFile.
+			stream nextPut: file basename.
+			file := file nextVersion. ] ].
+	self assert: versions equals: #('123.ext' '123.1.ext' '123.2.ext' '123.3.ext' '123.4.ext').
+
 ]
 
 { #category : #tests }
@@ -1042,6 +1077,44 @@ FileReferenceTest >> testUpToAll [
 			self assert: (stream upToAll: 'e') equals: 'ß'.
 		] ]
 	ensure: [ filename asFileReference ensureDelete ] 
+]
+
+{ #category : #'tests - handy utils' }
+FileReferenceTest >> testVersionNumberForExtension [
+	
+	| childFiles dir |
+
+	[ filesystem createDirectory: 'dir'.
+	dir := filesystem / 'dir'.
+	dir / 'games.51.ston' writeStreamDo: [ :stream | stream nextPutAll: '51' ].
+	dir / 'games.3.ston' writeStreamDo: [ :stream | stream nextPutAll: '3' ].
+	dir / 'games.33.ston' writeStreamDo: [ :stream | stream nextPutAll: '33' ].
+	dir / 'games.4.ston' writeStreamDo: [ :stream | stream nextPutAll: '4' ].
+	dir / 'games.101.ston' writeStreamDo: [ :stream | stream nextPutAll: '101' ].
+	dir / 'games.49.ston' writeStreamDo: [ :stream | stream nextPutAll: '49' ].
+	dir / 'games.5.ston' writeStreamDo: [ :stream | stream nextPutAll: '5' ].
+	
+	childFiles := dir files.
+	self assert: childFiles size equals: 7.
+	self assert: (dir versionNumberFor: 'games' extension: 'ston') equals: 101 ]
+		ensure: [ (filesystem / 'dir') ensureDeleteAll ].
+
+
+	[ filesystem createDirectory: 'dir'.
+	dir := filesystem / 'dir'.
+	dir / 'foo.bar.51.ston' writeStreamDo: [ :stream | stream nextPutAll: '51' ].
+	dir / 'foo.bar.3.ston' writeStreamDo: [ :stream | stream nextPutAll: '3' ].
+	dir / 'foo.bar.33.ston' writeStreamDo: [ :stream | stream nextPutAll: '33' ].
+	dir / 'foo.bar.4.ston' writeStreamDo: [ :stream | stream nextPutAll: '4' ].
+	dir / 'foo.bar.101.ston' writeStreamDo: [ :stream | stream nextPutAll: '101' ].
+	dir / 'foo.bar.49.ston' writeStreamDo: [ :stream | stream nextPutAll: '49' ].
+	dir / 'foo.bar.5.ston' writeStreamDo: [ :stream | stream nextPutAll: '5' ].
+	
+	childFiles := dir files.
+	self assert: childFiles size equals: 7.
+	self assert: (dir versionNumberFor: 'foo.bar' extension: 'ston') equals: 101 ]
+		ensure: [ (filesystem / 'dir') ensureDeleteAll ].
+
 ]
 
 { #category : #tests }


### PR DESCRIPTION
FileReference>>versionNumber has a number of issues:

- '/dev/shm/foo.bar.txt' asFileReference ensureCreateFile; nextVersion -> "File @ /dev/shm/foo.1.txt" incorrectly changing the base file name.
- '/dev/shm/foo.bar' asFileReference nextVersion will cause a primitiveFailure if there is a directory /dev/shm/foo.
- The method is quite inefficient as it requests a collection of all children of the parent directory, which can be quite large.


There is also an issue that associated methods:

- #nextVersion
- #lastFileFor:extension:
- #nextNameFor:extension:

all do their own parsing of file names, resulting in duplicated code and possible inconsistencies.

- Refactor the code to provide a single implementation of parsing the file name for the version number and fix the three issues listed above.
- Extend automated tests to cover the issues listed above.

Fixes: #2753