### PR TITLE
Fix incorrect cascade in DomainError>>signalFrom:to:

### DIFF
--- a/src/Kernel/DomainError.class.st
+++ b/src/Kernel/DomainError.class.st
@@ -42,7 +42,7 @@ DomainError class >> signalFrom: start to: end [
 	msgStart := (start isFloat and: [start isFinite not]) ifTrue: ['(-infinity'] ifFalse: ['[', start printString].
 	msgEnd := (end isFloat and: [end isFinite not]) ifTrue: ['infinity)'] ifFalse: [end printString, ']'].
 	^ self signal: 'Value outside ', msgStart, ' , ' , msgEnd
-		from: start;
+		from: start
 		to: end
 ]
 


### PR DESCRIPTION
An easy one… instead of delegating to the canonical `signal:from:to:`, it was signalling first (`signal:from:`) and then cascading `to:`, which is not implemented on class-side.