### PR TITLE
2751-rename-RBBLintRuleTests-to-RBBLintRuleTestData-and-add-comment

### DIFF
--- a/src/GT-Debugger/GTSpecPreDebugWindow.class.st
+++ b/src/GT-Debugger/GTSpecPreDebugWindow.class.st
@@ -191,15 +191,14 @@ GTSpecPreDebugWindow >> initializePresenter [
 
 { #category : #'initialization widgets' }
 GTSpecPreDebugWindow >> initializeStackPane [
-	
 	self stackPane
 		displayBlock: [ :aContext | self columnsFor: aContext ];
-		items: self filteredStack ;
-		whenSelectedItemChanged: [ :aContext | 
+		items: self filteredStack;
+		whenSelectionChangedDo: [ :selection | 
+			[ :aContext | 
 			"Set the selection before, as debugAction removes the link with the debugger. "
 			self debugger stackPresentation selection: aContext.
-			self openFullDebugger ]
-		
+			self openFullDebugger ] cull: selection selectedItem ]
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Tests-Core/RBAbstractClassVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBAbstractClassVariableTest.class.st
@@ -15,9 +15,9 @@ RBAbstractClassVariableTest >> testAbstractClassVariable [
 	| refactoring meta class |
 	refactoring := RBAbstractClassVariableRefactoring 
 		variable: 'RecursiveSelfRule'
-		class: RBTransformationRuleTest.
+		class: RBTransformationRuleTestData.
 	self executeRefactoring: refactoring.
-	class := refactoring model classNamed: #RBTransformationRuleTest.
+	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	meta := class classSide.
 	self assert: (meta parseTreeFor: #recursiveSelfRule) = (RBParser parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
 	self assert: (meta parseTreeFor: #recursiveSelfRule:) = (RBParser parseMethod: 'recursiveSelfRule: anObject RecursiveSelfRule := anObject').
@@ -42,14 +42,14 @@ RBAbstractClassVariableTest >> testAbstractClassVariable [
 RBAbstractClassVariableTest >> testInheritedName [
 	self shouldFail: (RBAbstractClassVariableRefactoring 
 			variable: #DependentsFields
-			class: RBBasicLintRuleTest)
+			class: RBBasicLintRuleTestData)
 ]
 
 { #category : #'failure tests' }
 RBAbstractClassVariableTest >> testMetaClassFailure [
 	self shouldFail: (RBAbstractClassVariableRefactoring 
 			variable: #RecursiveSelfRule
-			class: RBTransformationRuleTest class)
+			class: RBTransformationRuleTestData class)
 ]
 
 { #category : #tests }
@@ -96,5 +96,5 @@ RBAbstractClassVariableTest >> testModelAbstractClassVariableOverridenMethodsInS
 RBAbstractClassVariableTest >> testNonExistantName [
 	self shouldFail: (RBAbstractClassVariableRefactoring 
 			variable: #Foo
-			class: RBBasicLintRuleTest)
+			class: RBBasicLintRuleTestData)
 ]

--- a/src/Refactoring-Tests-Core/RBAbstractInstanceVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBAbstractInstanceVariableTest.class.st
@@ -15,9 +15,9 @@ RBAbstractInstanceVariableTest >> testAbstractInstanceVariable [
 	| refactoring class |
 	refactoring := RBAbstractInstanceVariableRefactoring 
 		variable: 'class'
-		class: RBTransformationRuleTest.
+		class: RBTransformationRuleTestData.
 	self executeRefactoring: refactoring.
-	class := refactoring model classNamed: #RBTransformationRuleTest.
+	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	self assert: (class parseTreeFor: #class1) = (RBParser parseMethod: 'class1 ^class').
 	self assert: (class parseTreeFor: #class:) = (RBParser parseMethod: 'class: anObject
 	class := anObject').
@@ -105,7 +105,7 @@ RBAbstractInstanceVariableTest >> testAbstractWithDefaultNamesUsed [
 RBAbstractInstanceVariableTest >> testInheritedName [
 	self shouldFail: (RBAbstractInstanceVariableRefactoring 
 			variable: 'name'
-			class: RBBasicLintRuleTest)
+			class: RBBasicLintRuleTestData)
 ]
 
 { #category : #tests }
@@ -133,5 +133,5 @@ RBAbstractInstanceVariableTest >> testMetaclassInstanceVariables [
 RBAbstractInstanceVariableTest >> testNonExistantName [
 	self shouldFail: (RBAbstractInstanceVariableRefactoring 
 			variable: 'foo'
-			class: RBBasicLintRuleTest)
+			class: RBBasicLintRuleTestData)
 ]

--- a/src/Refactoring-Tests-Core/RBAddClassTest.class.st
+++ b/src/Refactoring-Tests-Core/RBAddClassTest.class.st
@@ -45,8 +45,8 @@ RBAddClassTest >> testExistingName [
 RBAddClassTest >> testInvalidSubclass [
 	self shouldFail: (RBAddClassRefactoring 
 			addClass: #Foo
-			superclass: RBCompositeLintRuleTest
-			subclasses: (Array with: RBBasicLintRuleTest)
+			superclass: RBCompositeLintRuleTestData
+			subclasses: (Array with: RBBasicLintRuleTestData)
 			category: #'Refactory-Tesing')
 ]
 

--- a/src/Refactoring-Tests-Core/RBAddClassVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBAddClassVariableTest.class.st
@@ -15,9 +15,9 @@ RBAddClassVariableTest >> testAddClassVariable [
 	| refactoring |
 	refactoring := RBAddClassVariableRefactoring 
 		variable: 'Asdf'
-		class: RBTransformationRuleTest.
+		class: RBTransformationRuleTestData.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBTransformationRuleTest) directlyDefinesClassVariable: #Asdf)
+	self assert: ((refactoring model classNamed: #RBTransformationRuleTestData) directlyDefinesClassVariable: #Asdf)
 ]
 
 { #category : #'failure tests' }
@@ -25,17 +25,17 @@ RBAddClassVariableTest >> testAlreadyExistingName [
 	self
 		shouldFail: (RBAddClassVariableRefactoring 
 				variable: #RecursiveSelfRule
-				class: RBTransformationRuleTest);
+				class: RBTransformationRuleTestData);
 		shouldFail: (RBAddClassVariableRefactoring 
 				variable: self objectClassVariable
-				class: RBTransformationRuleTest)
+				class: RBTransformationRuleTestData)
 ]
 
 { #category : #'failure tests' }
 RBAddClassVariableTest >> testMetaClassFailure [
 	self shouldFail: (RBAddClassVariableRefactoring 
 			variable: #VariableName
-			class: RBTransformationRuleTest class)
+			class: RBTransformationRuleTestData class)
 ]
 
 { #category : #'failure tests' }

--- a/src/Refactoring-Tests-Core/RBAddInstanceVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBAddInstanceVariableTest.class.st
@@ -15,9 +15,9 @@ RBAddInstanceVariableTest >> testAddInstanceVariable [
 	| refactoring |
 	refactoring := RBAddInstanceVariableRefactoring 
 		variable: 'asdf'
-		class: RBTransformationRuleTest.
+		class: RBTransformationRuleTestData.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBTransformationRuleTest) directlyDefinesInstanceVariable: 'asdf')
+	self assert: ((refactoring model classNamed: #RBTransformationRuleTestData) directlyDefinesInstanceVariable: 'asdf')
 ]
 
 { #category : #tests }
@@ -45,10 +45,10 @@ RBAddInstanceVariableTest >> testAlreadyExistingName [
 	self
 		shouldFail: (RBAddInstanceVariableRefactoring 
 				variable: 'class'
-				class: RBTransformationRuleTest);
+				class: RBTransformationRuleTestData);
 		shouldFail: (RBAddInstanceVariableRefactoring 
 				variable: 'name'
-				class: RBTransformationRuleTest)
+				class: RBTransformationRuleTestData)
 ]
 
 { #category : #'failure tests' }

--- a/src/Refactoring-Tests-Core/RBAddMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBAddMethodTest.class.st
@@ -15,17 +15,17 @@ RBAddMethodTest >> testAddMethod [
 	| refactoring |
 	refactoring := RBAddMethodRefactoring 
 		addMethod: 'printString1 ^super printString'
-		toClass: RBBasicLintRuleTest
+		toClass: RBBasicLintRuleTestData
 		inProtocols: #(#accessing ).
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBBasicLintRuleTest) parseTreeFor: #printString1) = (RBParser parseMethod: 'printString1 ^super printString')
+	self assert: ((refactoring model classNamed: #RBBasicLintRuleTestData) parseTreeFor: #printString1) = (RBParser parseMethod: 'printString1 ^super printString')
 ]
 
 { #category : #'failure tests' }
 RBAddMethodTest >> testBadMethod [
 	self shouldFail: (RBAddMethodRefactoring 
 			addMethod: 'asdf ^super ^printString'
-			toClass: RBBasicLintRuleTest
+			toClass: RBBasicLintRuleTestData
 			inProtocols: #(#accessing ))
 ]
 
@@ -33,7 +33,7 @@ RBAddMethodTest >> testBadMethod [
 RBAddMethodTest >> testExistingSelector [
 	self shouldFail: (RBAddMethodRefactoring 
 			addMethod: 'printString ^super printString'
-			toClass: RBBasicLintRuleTest
+			toClass: RBBasicLintRuleTestData
 			inProtocols: #(#accessing ))
 ]
 

--- a/src/Refactoring-Tests-Core/RBAddParameterTest.class.st
+++ b/src/Refactoring-Tests-Core/RBAddParameterTest.class.st
@@ -88,12 +88,12 @@ RBAddParameterTest >> testBadInitializationCode [
 	self
 		shouldFail: (RBAddParameterRefactoring 
 				addParameterToMethod: #name
-				in: RBLintRuleTest
+				in: RBLintRuleTestData
 				newSelector: #name:
 				initializer: 'foo:');
 		shouldFail: (RBAddParameterRefactoring 
 				addParameterToMethod: #name
-				in: RBLintRuleTest
+				in: RBLintRuleTestData
 				newSelector: #name:
 				initializer: 'foo')
 ]
@@ -105,7 +105,7 @@ RBAddParameterTest >> testModelBadInitializationCode [
 	refactoring := RBAddParameterRefactoring 
 		model: model
 		addParameterToMethod: #name1
-		in: RBLintRuleTest
+		in: RBLintRuleTestData
 		newSelector: #name1:
 		initializer: 'AddParameterRefactoring new'.
 	self shouldFail: refactoring
@@ -114,11 +114,11 @@ RBAddParameterTest >> testModelBadInitializationCode [
 { #category : #'failure tests' }
 RBAddParameterTest >> testModelNonExistantName [
 	| refactoring |
-	(model classNamed: #RBLintRuleTest) removeMethod: #name.
+	(model classNamed: #RBLintRuleTestData) removeMethod: #name.
 	refactoring := RBAddParameterRefactoring 
 		model: model
 		addParameterToMethod: #name
-		in: RBLintRuleTest
+		in: RBLintRuleTestData
 		newSelector: #nameNew:
 		initializer: 'nil'.
 	self shouldFail: refactoring
@@ -128,7 +128,7 @@ RBAddParameterTest >> testModelNonExistantName [
 RBAddParameterTest >> testNonExistantName [
 	self shouldFail: (RBAddParameterRefactoring 
 			addParameterToMethod: #name1
-			in: RBLintRuleTest
+			in: RBLintRuleTestData
 			newSelector: #name1:
 			initializer: 'nil')
 ]

--- a/src/Refactoring-Tests-Core/RBApplyClassDeprecationRefactoringTest.class.st
+++ b/src/Refactoring-Tests-Core/RBApplyClassDeprecationRefactoringTest.class.st
@@ -8,10 +8,10 @@ Class {
 RBApplyClassDeprecationRefactoringTest >> testBadName [
 	self
 		shouldFail: (RBApplyClassDeprecationRefactoring 
-				rename: RBLintRuleTest
+				rename: RBLintRuleTestData
 				to: self objectClassVariable);
 		shouldFail: (RBApplyClassDeprecationRefactoring 
-				rename: RBLintRuleTest
+				rename: RBLintRuleTestData
 				to: #'Ob ject')
 ]
 

--- a/src/Refactoring-Tests-Core/RBBasicLintRuleTestData.class.st
+++ b/src/Refactoring-Tests-Core/RBBasicLintRuleTestData.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #RBBasicLintRuleTest,
-	#superclass : #RBLintRuleTest,
+	#name : #RBBasicLintRuleTestData,
+	#superclass : #RBLintRuleTestData,
 	#instVars : [
 		'methodBlock',
 		'result',
@@ -11,7 +11,7 @@ Class {
 }
 
 { #category : #private }
-RBBasicLintRuleTest class >> canCall: aSelector in: aClass from: anApplication [
+RBBasicLintRuleTestData class >> canCall: aSelector in: aClass from: anApplication [
 	"This method contains on purpose not implemented messages, such as rootApplication "
 	| methodApp root |
 	(aClass canUnderstand: aSelector) ifFalse: [^false].
@@ -22,12 +22,12 @@ RBBasicLintRuleTest class >> canCall: aSelector in: aClass from: anApplication [
 ]
 
 { #category : #private }
-RBBasicLintRuleTest class >> classShouldNotOverride [
+RBBasicLintRuleTestData class >> classShouldNotOverride [
 	^#(#== #class)
 ]
 
 { #category : #private }
-RBBasicLintRuleTest class >> createMatcherFor: codeStrings method: aBoolean [ 
+RBBasicLintRuleTestData class >> createMatcherFor: codeStrings method: aBoolean [ 
 	| matcher |
 	matcher := RBParseTreeSearcher new.
 	aBoolean
@@ -37,7 +37,7 @@ RBBasicLintRuleTest class >> createMatcherFor: codeStrings method: aBoolean [
 ]
 
 { #category : #'instance creation' }
-RBBasicLintRuleTest class >> createParseTreeRule: codeStrings method: aBoolean name: aName [ 
+RBBasicLintRuleTestData class >> createParseTreeRule: codeStrings method: aBoolean name: aName [ 
 	| detector matcher |
 	detector := self new.
 	detector name: aName.
@@ -50,14 +50,14 @@ RBBasicLintRuleTest class >> createParseTreeRule: codeStrings method: aBoolean n
 ]
 
 { #category : #'instance creation' }
-RBBasicLintRuleTest class >> createParseTreeRule: codeStrings name: aName [ 
+RBBasicLintRuleTestData class >> createParseTreeRule: codeStrings name: aName [ 
 	^self createParseTreeRule: codeStrings
 		method: false
 		name: aName
 ]
 
 { #category : #'unnecessary code' }
-RBBasicLintRuleTest class >> justSendsSuper [
+RBBasicLintRuleTestData class >> justSendsSuper [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Method just sends super message'.
@@ -71,21 +71,21 @@ RBBasicLintRuleTest class >> justSendsSuper [
 ]
 
 { #category : #private }
-RBBasicLintRuleTest class >> longMethodSize [
+RBBasicLintRuleTestData class >> longMethodSize [
 	^10
 ]
 
 { #category : #private }
-RBBasicLintRuleTest class >> metaclassShouldNotOverride [
+RBBasicLintRuleTestData class >> metaclassShouldNotOverride [
 	^#(#name #comment)
 ]
 
 { #category : #'possible bugs' }
-RBBasicLintRuleTest class >> modifiesCollection [
+RBBasicLintRuleTestData class >> modifiesCollection [
 	| detector addSearcher |
 	detector := self new.
 	detector name: 'Modifies collection while iterating over it'.
-	addSearcher := RBBasicLintRuleTest modifiesCollection.
+	addSearcher := RBBasicLintRuleTestData modifiesCollection.
 	detector methodBlock: 
 			[:context :result | 
 			addSearcher executeTree: context parseTree initialAnswer: false.
@@ -95,12 +95,12 @@ RBBasicLintRuleTest class >> modifiesCollection [
 ]
 
 { #category : #private }
-RBBasicLintRuleTest class >> new [
+RBBasicLintRuleTestData class >> new [
 	^super new
 ]
 
 { #category : #miscellaneous }
-RBBasicLintRuleTest class >> precedence [
+RBBasicLintRuleTestData class >> precedence [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Inspect instances of "A + B * C" might be "A + (B * C)"'.
@@ -115,12 +115,12 @@ RBBasicLintRuleTest class >> precedence [
 ]
 
 { #category : #accessing }
-RBBasicLintRuleTest class >> protocolsToCheck [
+RBBasicLintRuleTestData class >> protocolsToCheck [
 	^#('bugs' 'possible bugs' 'unnecessary code' 'intention revealing' 'miscellaneous')
 ]
 
 { #category : #'possible bugs' }
-RBBasicLintRuleTest class >> sentNotImplementedInApplication [
+RBBasicLintRuleTestData class >> sentNotImplementedInApplication [
 	| detector |
 	detector := self new.
 	detector name: 'Messages sent but not implemented in application'.
@@ -152,7 +152,7 @@ RBBasicLintRuleTest class >> sentNotImplementedInApplication [
 ]
 
 { #category : #private }
-RBBasicLintRuleTest class >> subclassOf: aClass overrides: aSelector [ 
+RBBasicLintRuleTestData class >> subclassOf: aClass overrides: aSelector [ 
 	| subs |
 	subs := aClass subclasses.
 	1 to: subs size
@@ -166,7 +166,7 @@ RBBasicLintRuleTest class >> subclassOf: aClass overrides: aSelector [
 ]
 
 { #category : #bugs }
-RBBasicLintRuleTest class >> subclassResponsibilityNotDefined [
+RBBasicLintRuleTestData class >> subclassResponsibilityNotDefined [
 	| detector subclassResponsibilitySymbol |
 	detector := self new.
 	subclassResponsibilitySymbol := 'subclassResponsibility' asSymbol.
@@ -186,12 +186,12 @@ RBBasicLintRuleTest class >> subclassResponsibilityNotDefined [
 ]
 
 { #category : #private }
-RBBasicLintRuleTest class >> superMessages [
+RBBasicLintRuleTestData class >> superMessages [
 	^#(#release #postCopy #postBuildWith: #preBuildWith: #postOpenWith: #noticeOfWindowClose: #initialize)
 ]
 
 { #category : #'possible bugs' }
-RBBasicLintRuleTest class >> superSends [
+RBBasicLintRuleTestData class >> superSends [
 	| detector |
 	detector := self new.
 	detector name: 'Missing super sends'.
@@ -208,7 +208,7 @@ RBBasicLintRuleTest class >> superSends [
 ]
 
 { #category : #'intention revealing' }
-RBBasicLintRuleTest class >> toDo [
+RBBasicLintRuleTestData class >> toDo [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Uses to:do: instead of do:, with:do: or timesRepeat:'.
@@ -231,7 +231,7 @@ RBBasicLintRuleTest class >> toDo [
 ]
 
 { #category : #miscellaneous }
-RBBasicLintRuleTest class >> utilityMethods [
+RBBasicLintRuleTestData class >> utilityMethods [
 	| detector |
 	detector := self new.
 	detector name: 'Utility methods'.
@@ -256,50 +256,50 @@ RBBasicLintRuleTest class >> utilityMethods [
 ]
 
 { #category : #private }
-RBBasicLintRuleTest class >> utilityProtocols [
+RBBasicLintRuleTestData class >> utilityProtocols [
 	"If a method is defined in one of these protocols, then don't check if its a utility method."
 
 	^#('*utilit*')
 ]
 
 { #category : #initialization }
-RBBasicLintRuleTest >> anInstVar [
+RBBasicLintRuleTestData >> anInstVar [
 	^ anInstVar
 ]
 
 { #category : #'initialize-release' }
-RBBasicLintRuleTest >> anInstVar: anObject [
+RBBasicLintRuleTestData >> anInstVar: anObject [
 	anInstVar := anObject
 ]
 
 { #category : #accessing }
-RBBasicLintRuleTest >> checkClass: aSmalllintContext [ 
+RBBasicLintRuleTestData >> checkClass: aSmalllintContext [ 
 	^classBlock value: aSmalllintContext value: result
 ]
 
 { #category : #accessing }
-RBBasicLintRuleTest >> checkMethod: aSmalllintContext [ 
+RBBasicLintRuleTestData >> checkMethod: aSmalllintContext [ 
 	^methodBlock value: aSmalllintContext value: result
 ]
 
 { #category : #initialization }
-RBBasicLintRuleTest >> classBlock [
+RBBasicLintRuleTestData >> classBlock [
 	^ self anInstVar + 5
 ]
 
 { #category : #initialization }
-RBBasicLintRuleTest >> classBlock: aBlock [
+RBBasicLintRuleTestData >> classBlock: aBlock [
 	classBlock := aBlock testMethod1
 ]
 
 { #category : #accessing }
-RBBasicLintRuleTest >> foobar [
+RBBasicLintRuleTestData >> foobar [
 
 	^#( true false )
 ]
 
 { #category : #initialization }
-RBBasicLintRuleTest >> initialize [
+RBBasicLintRuleTestData >> initialize [
 	super initialize.
 	self anInstVar: 1.
 	classBlock := [:context :aResult | ].
@@ -308,58 +308,58 @@ RBBasicLintRuleTest >> initialize [
 ]
 
 { #category : #testing }
-RBBasicLintRuleTest >> isEmpty [
+RBBasicLintRuleTestData >> isEmpty [
 	^result isEmpty
 ]
 
 { #category : #private }
-RBBasicLintRuleTest >> method: anObject1 with: anObject2 lots: anObject3 of: anObject4 arguments: anObject5 [
+RBBasicLintRuleTestData >> method: anObject1 with: anObject2 lots: anObject3 of: anObject4 arguments: anObject5 [
 	^ anObject5 + anObject1 > (anObject4 - anObject2 + anObject3)
 ]
 
 { #category : #initialization }
-RBBasicLintRuleTest >> methodBlock: aBlock [
+RBBasicLintRuleTestData >> methodBlock: aBlock [
 	methodBlock := aBlock
 ]
 
 { #category : #initialization }
-RBBasicLintRuleTest >> newResultClass: aClass [ 
+RBBasicLintRuleTestData >> newResultClass: aClass [ 
 "New one:)"
 	result := aClass new
 ]
 
 { #category : #accessing }
-RBBasicLintRuleTest >> problemCount [
+RBBasicLintRuleTestData >> problemCount [
 	^result problemCount
 ]
 
 { #category : #'initialize-release' }
-RBBasicLintRuleTest >> resetResult [
+RBBasicLintRuleTestData >> resetResult [
 	result := result copyEmpty.
 	result label: name
 ]
 
 { #category : #accessing }
-RBBasicLintRuleTest >> result [
+RBBasicLintRuleTestData >> result [
 	^result
 ]
 
 { #category : #'initialize-release' }
-RBBasicLintRuleTest >> result: aResult [ 
+RBBasicLintRuleTestData >> result: aResult [ 
 	result := aResult copyEmpty
 ]
 
 { #category : #initialization }
-RBBasicLintRuleTest >> resultClass: aClass [ 
+RBBasicLintRuleTestData >> resultClass: aClass [ 
 	result := aClass new
 ]
 
 { #category : #accessing }
-RBBasicLintRuleTest >> someDemoMethod [
+RBBasicLintRuleTestData >> someDemoMethod [
 	^ self junk
 ]
 
 { #category : #private }
-RBBasicLintRuleTest >> viewResults [
+RBBasicLintRuleTestData >> viewResults [
 	result openEditor
 ]

--- a/src/Refactoring-Tests-Core/RBChildrenToSiblingsTest.class.st
+++ b/src/Refactoring-Tests-Core/RBChildrenToSiblingsTest.class.st
@@ -14,10 +14,10 @@ RBChildrenToSiblingsTest >> setUp [
 RBChildrenToSiblingsTest >> testBadName [
 	self shouldFail: (RBChildrenToSiblingsRefactoring 
 			name: #'Obje ct'
-			class: RBLintRuleTest
+			class: RBLintRuleTestData
 			subclasses: (Array 
-					with: RBBasicLintRuleTest
-					with: RBCompositeLintRuleTest))
+					with: RBBasicLintRuleTestData
+					with: RBCompositeLintRuleTestData))
 ]
 
 { #category : #'failure tests' }
@@ -25,16 +25,16 @@ RBChildrenToSiblingsTest >> testExistingName [
 	self
 		shouldFail: (RBChildrenToSiblingsRefactoring 
 				name: #Object
-				class: RBLintRuleTest
+				class: RBLintRuleTestData
 				subclasses: (Array 
-						with: RBBasicLintRuleTest
-						with: RBCompositeLintRuleTest));
+						with: RBBasicLintRuleTestData
+						with: RBCompositeLintRuleTestData));
 		shouldFail: (RBChildrenToSiblingsRefactoring 
 				name: #Processor
-				class: RBLintRuleTest
+				class: RBLintRuleTestData
 				subclasses: (Array 
-						with: RBBasicLintRuleTest
-						with: RBCompositeLintRuleTest))
+						with: RBBasicLintRuleTestData
+						with: RBCompositeLintRuleTestData))
 ]
 
 { #category : #'failure tests' }
@@ -43,18 +43,18 @@ RBChildrenToSiblingsTest >> testInvalidSubclass [
 			name: #Foo
 			class: RBRefactoringTest
 			subclasses: (Array 
-					with: RBBasicLintRuleTest
-					with: RBCompositeLintRuleTest))
+					with: RBBasicLintRuleTestData
+					with: RBCompositeLintRuleTestData))
 ]
 
 { #category : #'failure tests' }
 RBChildrenToSiblingsTest >> testMetaClassFailure [
 	self shouldFail: (RBChildrenToSiblingsRefactoring 
 			name: #Foo
-			class: RBLintRuleTest class
+			class: RBLintRuleTestData class
 			subclasses: (Array 
-					with: RBBasicLintRuleTest class
-					with: RBCompositeLintRuleTest class))
+					with: RBBasicLintRuleTestData class
+					with: RBCompositeLintRuleTestData class))
 ]
 
 { #category : #tests }

--- a/src/Refactoring-Tests-Core/RBClassUsingSharedPoolForTestData.class.st
+++ b/src/Refactoring-Tests-Core/RBClassUsingSharedPoolForTestData.class.st
@@ -1,14 +1,14 @@
 Class {
-	#name : #RBClassUsingSharedPoolForTest,
+	#name : #RBClassUsingSharedPoolForTestData,
 	#superclass : #Object,
 	#pools : [
-		'RBSharedPoolForTest'
+		'RBSharedPoolForTestData'
 	],
 	#category : #'Refactoring-Tests-Core-Data'
 }
 
 { #category : #'as yet unclassified' }
-RBClassUsingSharedPoolForTest >> msg3 [
+RBClassUsingSharedPoolForTestData >> msg3 [
 
 	^ Var1
 ]

--- a/src/Refactoring-Tests-Core/RBCompositeLintRuleTestData.class.st
+++ b/src/Refactoring-Tests-Core/RBCompositeLintRuleTestData.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #RBCompositeLintRuleTest,
-	#superclass : #RBLintRuleTest,
+	#name : #RBCompositeLintRuleTestData,
+	#superclass : #RBLintRuleTestData,
 	#instVars : [
 		'rules'
 	],
@@ -8,23 +8,23 @@ Class {
 }
 
 { #category : #'instance creation' }
-RBCompositeLintRuleTest class >> allRules [
+RBCompositeLintRuleTestData class >> allRules [
 	^self ruleFor: self protocol: 'all checks'
 ]
 
 { #category : #'all checks' }
-RBCompositeLintRuleTest class >> lintChecks [
+RBCompositeLintRuleTestData class >> lintChecks [
 	^ self 
-		rules: (RBBasicLintRuleTest protocolsToCheck collect: 
+		rules: (RBBasicLintRuleTestData protocolsToCheck collect: 
 			[ :each | 
 			self 
-				ruleFor: RBBasicLintRuleTest
+				ruleFor: RBBasicLintRuleTestData
 				protocol: each ])
 		name: 'Lint checks'
 ]
 
 { #category : #'instance creation' }
-RBCompositeLintRuleTest class >> ruleFor: aClass protocol: aProtocol [ 
+RBCompositeLintRuleTestData class >> ruleFor: aClass protocol: aProtocol [ 
 	^self
 		rules: (((RBBrowserEnvironment new selectorsFor: aProtocol asSymbol in: aClass class)
 				collect: [:selector | aClass perform: selector])
@@ -34,26 +34,26 @@ RBCompositeLintRuleTest class >> ruleFor: aClass protocol: aProtocol [
 ]
 
 { #category : #'instance creation' }
-RBCompositeLintRuleTest class >> rules: aCollection [ 
+RBCompositeLintRuleTestData class >> rules: aCollection [ 
 	^self new rules: aCollection
 ]
 
 { #category : #'instance creation' }
-RBCompositeLintRuleTest class >> rules: aCollection name: aString [ 
+RBCompositeLintRuleTestData class >> rules: aCollection name: aString [ 
 	^(self new) rules: aCollection;
 		name: aString;
 		yourself
 ]
 
 { #category : #'all checks' }
-RBCompositeLintRuleTest class >> transformations [
+RBCompositeLintRuleTestData class >> transformations [
 	^ self 
-		ruleFor: RBTransformationRuleTest
+		ruleFor: RBTransformationRuleTestData
 		protocol: 'transformations'
 ]
 
 { #category : #accessing }
-RBCompositeLintRuleTest >> checkClass: aSmalllintContext [ 
+RBCompositeLintRuleTestData >> checkClass: aSmalllintContext [ 
 	rules do: 
 			[:each | 
 			each checkClass: aSmalllintContext.
@@ -61,7 +61,7 @@ RBCompositeLintRuleTest >> checkClass: aSmalllintContext [
 ]
 
 { #category : #accessing }
-RBCompositeLintRuleTest >> checkMethod: aSmalllintContext [ 
+RBCompositeLintRuleTestData >> checkMethod: aSmalllintContext [ 
 	rules do: 
 			[:each | 
 			each checkMethod: aSmalllintContext.
@@ -69,46 +69,46 @@ RBCompositeLintRuleTest >> checkMethod: aSmalllintContext [
 ]
 
 { #category : #accessing }
-RBCompositeLintRuleTest >> failedRules [
+RBCompositeLintRuleTestData >> failedRules [
 	^rules inject: OrderedCollection new into: [:oc :each | oc addAll: each failedRules; yourself]
 ]
 
 { #category : #testing }
-RBCompositeLintRuleTest >> hasConflicts [
+RBCompositeLintRuleTestData >> hasConflicts [
 	^(rules detect: [:each | each hasConflicts] ifNone: [nil]) notNil
 ]
 
 { #category : #testing }
-RBCompositeLintRuleTest >> isComposite [
+RBCompositeLintRuleTestData >> isComposite [
 	^true
 ]
 
 { #category : #testing }
-RBCompositeLintRuleTest >> isEmpty [
+RBCompositeLintRuleTestData >> isEmpty [
 	^(rules detect: [:each | each isEmpty not] ifNone: [nil]) isNil
 ]
 
 { #category : #accessing }
-RBCompositeLintRuleTest >> problemCount [
+RBCompositeLintRuleTestData >> problemCount [
 	^rules inject: 0 into: [:count :each | count + each problemCount]
 ]
 
 { #category : #initialization }
-RBCompositeLintRuleTest >> resetResult [
+RBCompositeLintRuleTestData >> resetResult [
 	rules do: [:each | each resetResult]
 ]
 
 { #category : #accessing }
-RBCompositeLintRuleTest >> rules [
+RBCompositeLintRuleTestData >> rules [
 	^rules
 ]
 
 { #category : #initialization }
-RBCompositeLintRuleTest >> rules: aCollection [
+RBCompositeLintRuleTestData >> rules: aCollection [
 	rules := aCollection
 ]
 
 { #category : #private }
-RBCompositeLintRuleTest >> viewResults [
+RBCompositeLintRuleTestData >> viewResults [
 	rules do: [:each | each viewResults]
 ]

--- a/src/Refactoring-Tests-Core/RBCreateAccessorsForVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBCreateAccessorsForVariableTest.class.st
@@ -15,7 +15,7 @@ RBCreateAccessorsForVariableTest >> testExistingInstanceVariableAccessors [
 	| ref |
 	ref := RBCreateAccessorsForVariableRefactoring 
 		variable: 'name'
-		class: RBLintRuleTest
+		class: RBLintRuleTestData
 		classVariable: false.
 	self executeRefactoring: ref.
 	self assertEmpty: ref changes changes.
@@ -28,10 +28,10 @@ RBCreateAccessorsForVariableTest >> testNewClassVariableAccessors [
 	| ref class |
 	ref := RBCreateAccessorsForVariableRefactoring 
 		variable: 'Foo1'
-		class: RBLintRuleTest
+		class: RBLintRuleTestData
 		classVariable: true.
 	self executeRefactoring: ref.
-	class := ref model metaclassNamed: #RBLintRuleTest.
+	class := ref model metaclassNamed: #RBLintRuleTestData.
 	self denyEmpty: ref changes changes.
 	self assert: ref setterMethod == #foo1:.
 	self assert: ref getterMethod == #foo1.
@@ -42,9 +42,9 @@ RBCreateAccessorsForVariableTest >> testNewClassVariableAccessors [
 { #category : #tests }
 RBCreateAccessorsForVariableTest >> testNewInstanceVariableAccessors [
 	| ref class |
-	ref := RBCreateAccessorsForVariableRefactoring variable: 'foo1' class: RBLintRuleTest classVariable: false.
+	ref := RBCreateAccessorsForVariableRefactoring variable: 'foo1' class: RBLintRuleTestData classVariable: false.
 	self executeRefactoring: ref.
-	class := ref model classNamed: #RBLintRuleTest.
+	class := ref model classNamed: #RBLintRuleTestData.
 	self denyEmpty: ref changes changes.
 	self assert: ref setterMethod == #foo1:.
 	self assert: ref getterMethod == #foo1.
@@ -57,10 +57,10 @@ RBCreateAccessorsForVariableTest >> testNonExistantName [
 	self
 		shouldFail: (RBCreateAccessorsForVariableRefactoring 
 				variable: #Foo
-				class: RBBasicLintRuleTest
+				class: RBBasicLintRuleTestData
 				classVariable: true);
 		shouldFail: (RBCreateAccessorsForVariableRefactoring 
 				variable: 'foo'
-				class: RBBasicLintRuleTest
+				class: RBBasicLintRuleTestData
 				classVariable: true)
 ]

--- a/src/Refactoring-Tests-Core/RBExtractMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBExtractMethodTest.class.st
@@ -16,9 +16,9 @@ RBExtractMethodTest >> testBadInterval [
 		shouldFail: (RBExtractMethodRefactoring 
 				extract: (self 
 						convertInterval: (80 to: 147)
-						for: (RBBasicLintRuleTest class sourceCodeAt: #subclassOf:overrides:))
+						for: (RBBasicLintRuleTestData class sourceCodeAt: #subclassOf:overrides:))
 				from: #subclassOf:overrides:
-				in: RBBasicLintRuleTest class)
+				in: RBBasicLintRuleTestData class)
 ]
 
 { #category : #'failure tests' }
@@ -27,21 +27,21 @@ RBExtractMethodTest >> testExtractFailure [
 		shouldFail: (RBExtractMethodRefactoring 
 				extract: (self 
 						convertInterval: (80 to: 269)
-						for: (RBBasicLintRuleTest class sourceCodeAt: #subclassOf:overrides:))
+						for: (RBBasicLintRuleTestData class sourceCodeAt: #subclassOf:overrides:))
 				from: #subclassOf:overrides:
-				in: RBBasicLintRuleTest class);
+				in: RBBasicLintRuleTestData class);
 		shouldFail: (RBExtractMethodRefactoring 
 				extract: (self 
 						convertInterval: (53 to: 56)
-						for: (RBBasicLintRuleTest class sourceCodeAt: #subclassOf:overrides:))
+						for: (RBBasicLintRuleTestData class sourceCodeAt: #subclassOf:overrides:))
 				from: #subclassOf:overrides:
-				in: RBBasicLintRuleTest class);
+				in: RBBasicLintRuleTestData class);
 		shouldFail: (RBExtractMethodRefactoring 
 				extract: (self 
 						convertInterval: (77 to: 222)
-						for: (RBBasicLintRuleTest class sourceCodeAt: #subclassResponsibilityNotDefined))
+						for: (RBBasicLintRuleTestData class sourceCodeAt: #subclassResponsibilityNotDefined))
 				from: #subclassResponsibilityNotDefined
-				in: RBBasicLintRuleTest class)
+				in: RBBasicLintRuleTestData class)
 ]
 
 { #category : #tests }
@@ -50,14 +50,14 @@ RBExtractMethodTest >> testExtractMethodAtEndOfMethodThatNeedsReturn [
 	refactoring := RBExtractMethodRefactoring 
 		extract: (self 
 				convertInterval: (52 to: 133)
-				for: (RBLintRuleTest sourceCodeAt: #openEditor))
+				for: (RBLintRuleTestData sourceCodeAt: #openEditor))
 		from: #openEditor
-		in: RBLintRuleTest.
+		in: RBLintRuleTestData.
 	self 
 		setupMethodNameFor: refactoring
 		toReturn: #foo:.
 	self executeRefactoring: refactoring.
-	class := refactoring model classNamed: #RBLintRuleTest.
+	class := refactoring model classNamed: #RBLintRuleTestData.
 	self assert: (class parseTreeFor: #openEditor) = (RBParser parseMethod: 'openEditor
 	| rules |
 	rules := self failedRules.
@@ -73,14 +73,14 @@ RBExtractMethodTest >> testExtractMethodThatMovesTemporaryVariable [
 	refactoring := RBExtractMethodRefactoring 
 		extract: (self 
 				convertInterval: (22 to: 280)
-				for: (RBTransformationRuleTest sourceCodeAt: #superSends))
+				for: (RBTransformationRuleTestData sourceCodeAt: #superSends))
 		from: #superSends
-		in: RBTransformationRuleTest.
+		in: RBTransformationRuleTestData.
 	self 
 		setupMethodNameFor: refactoring
 		toReturn: #foo1.
 	self executeRefactoring: refactoring.
-	class := refactoring model classNamed: #RBTransformationRuleTest.
+	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	self assert: (class parseTreeFor: #superSends) = (RBParser parseMethod: 'superSends
 	| rule |
 	rule := self foo1.
@@ -102,14 +102,14 @@ RBExtractMethodTest >> testExtractMethodThatNeedsArgument [
 	refactoring := RBExtractMethodRefactoring 
 		extract: (self 
 				convertInterval: (145 to: 343)
-				for: (RBTransformationRuleTest sourceCodeAt: #checkMethod:))
+				for: (RBTransformationRuleTestData sourceCodeAt: #checkMethod:))
 		from: #checkMethod:
-		in: RBTransformationRuleTest.
+		in: RBTransformationRuleTestData.
 	self 
 		setupMethodNameFor: refactoring
 		toReturn: #foo:.
 	self executeRefactoring: refactoring.
-	class := refactoring model classNamed: #RBTransformationRuleTest.
+	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	self assert: (class parseTreeFor: #checkMethod:) = (RBParser parseMethod: 'checkMethod: aSmalllintContext 
 	class := aSmalllintContext selectedClass.
 	(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
@@ -127,14 +127,14 @@ RBExtractMethodTest >> testExtractMethodThatNeedsTemporaryVariable [
 	refactoring := RBExtractMethodRefactoring 
 		extract: (self 
 				convertInterval: (78 to: 197)
-				for: (RBLintRuleTest sourceCodeAt: #displayName))
+				for: (RBLintRuleTestData sourceCodeAt: #displayName))
 		from: #displayName
-		in: RBLintRuleTest.
+		in: RBLintRuleTestData.
 	self 
 		setupMethodNameFor: refactoring
 		toReturn: #foo:.
 	self executeRefactoring: refactoring.
-	class := refactoring model classNamed: #RBLintRuleTest.
+	class := refactoring model classNamed: #RBLintRuleTestData.
 	self assert: (class parseTreeFor: #displayName) = (RBParser parseMethod: 'displayName
 	| nameStream |
 	nameStream := WriteStream on: (String new: 64).
@@ -195,5 +195,5 @@ RBExtractMethodTest >> testNonExistantSelector [
 	self shouldFail: (RBExtractMethodRefactoring 
 			extract: (10 to: 20)
 			from: #checkClass1:
-			in: RBBasicLintRuleTest)
+			in: RBBasicLintRuleTestData)
 ]

--- a/src/Refactoring-Tests-Core/RBExtractMethodToComponentTest.class.st
+++ b/src/Refactoring-Tests-Core/RBExtractMethodToComponentTest.class.st
@@ -16,9 +16,9 @@ RBExtractMethodToComponentTest >> testBadInterval [
 		shouldFail: (RBExtractMethodToComponentRefactoring 
 				extract: (self 
 						convertInterval: (80 to: 147)
-						for: (RBBasicLintRuleTest class sourceCodeAt: #subclassOf:overrides:))
+						for: (RBBasicLintRuleTestData class sourceCodeAt: #subclassOf:overrides:))
 				from: #subclassOf:overrides:
-				in: RBBasicLintRuleTest class)
+				in: RBBasicLintRuleTestData class)
 ]
 
 { #category : #'failure tests' }
@@ -27,21 +27,21 @@ RBExtractMethodToComponentTest >> testExtractFailure [
 		shouldFail: (RBExtractMethodToComponentRefactoring 
 				extract: (self 
 						convertInterval: (80 to: 269)
-						for: (RBBasicLintRuleTest class sourceCodeAt: #subclassOf:overrides:))
+						for: (RBBasicLintRuleTestData class sourceCodeAt: #subclassOf:overrides:))
 				from: #subclassOf:overrides:
-				in: RBBasicLintRuleTest class);
+				in: RBBasicLintRuleTestData class);
 		shouldFail: (RBExtractMethodToComponentRefactoring 
 				extract: (self 
 						convertInterval: (53 to: 56)
-						for: (RBBasicLintRuleTest class sourceCodeAt: #subclassOf:overrides:))
+						for: (RBBasicLintRuleTestData class sourceCodeAt: #subclassOf:overrides:))
 				from: #subclassOf:overrides:
-				in: RBBasicLintRuleTest class);
+				in: RBBasicLintRuleTestData class);
 		shouldFail: (RBExtractMethodToComponentRefactoring 
 				extract: (self 
 						convertInterval: (77 to: 222)
-						for: (RBBasicLintRuleTest class sourceCodeAt: #subclassResponsibilityNotDefined))
+						for: (RBBasicLintRuleTestData class sourceCodeAt: #subclassResponsibilityNotDefined))
 				from: #subclassResponsibilityNotDefined
-				in: RBBasicLintRuleTest class)
+				in: RBBasicLintRuleTestData class)
 ]
 
 { #category : #tests }
@@ -50,9 +50,9 @@ RBExtractMethodToComponentTest >> testExtractMethodAtEndOfMethodThatNeedsReturn 
 	refactoring := RBExtractMethodToComponentRefactoring 
 		extract: (self 
 				convertInterval: (52 to: 133)
-				for: (RBLintRuleTest sourceCodeAt: #openEditor))
+				for: (RBLintRuleTestData sourceCodeAt: #openEditor))
 		from: #openEditor
-		in: RBLintRuleTest.
+		in: RBLintRuleTestData.
 	self 
 		setupMethodNameFor: refactoring
 		toReturn: #foo:.
@@ -65,7 +65,7 @@ RBExtractMethodToComponentTest >> testExtractMethodAtEndOfMethodThatNeedsReturn 
 	self 
 		setupVariableTypesFor: refactoring
 		toReturn: (Array with: (refactoring model classNamed: #Collection)).
-	class := refactoring model classNamed: #RBLintRuleTest.
+	class := refactoring model classNamed: #RBLintRuleTestData.
 	selectorsSize := class selectors size.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	self assert: (class parseTreeFor: #openEditor) = (RBParser parseMethod: 'openEditor
@@ -114,5 +114,5 @@ RBExtractMethodToComponentTest >> testNonExistantSelector [
 	self shouldFail: (RBExtractMethodToComponentRefactoring 
 			extract: (10 to: 20)
 			from: #checkClass1:
-			in: RBBasicLintRuleTest)
+			in: RBBasicLintRuleTestData)
 ]

--- a/src/Refactoring-Tests-Core/RBFooLintRuleTest1.class.st
+++ b/src/Refactoring-Tests-Core/RBFooLintRuleTest1.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #RBFooLintRuleTest1,
-	#superclass : #RBLintRuleTest,
-	#category : #'Refactoring-Tests-Core-Data'
-}

--- a/src/Refactoring-Tests-Core/RBFooLintRuleTestData.class.st
+++ b/src/Refactoring-Tests-Core/RBFooLintRuleTestData.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #RBFooLintRuleTest,
-	#superclass : #RBLintRuleTest,
+	#name : #RBFooLintRuleTestData,
+	#superclass : #RBLintRuleTestData,
 	#instVars : [
 		'result'
 	],
@@ -8,6 +8,6 @@ Class {
 }
 
 { #category : #'as yet unclassified' }
-RBFooLintRuleTest >> foo [
+RBFooLintRuleTestData >> foo [
 	^ 6
 ]

--- a/src/Refactoring-Tests-Core/RBFooLintRuleTestData1.class.st
+++ b/src/Refactoring-Tests-Core/RBFooLintRuleTestData1.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #RBFooLintRuleTestData1,
+	#superclass : #RBLintRuleTestData,
+	#category : #'Refactoring-Tests-Core-Data'
+}

--- a/src/Refactoring-Tests-Core/RBInlineMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBInlineMethodTest.class.st
@@ -39,11 +39,11 @@ RBInlineMethodTest >> testInlineMethod [
 	refactoring := RBInlineMethodRefactoring 
 		inline: (self 
 				convertInterval: (455 to: 504)
-				for: (RBBasicLintRuleTest class sourceCodeAt: #sentNotImplementedInApplication))
+				for: (RBBasicLintRuleTestData class sourceCodeAt: #sentNotImplementedInApplication))
 		inMethod: #sentNotImplementedInApplication
-		forClass: RBBasicLintRuleTest class.
+		forClass: RBBasicLintRuleTestData class.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model metaclassNamed: #RBBasicLintRuleTest) parseTreeFor: #sentNotImplementedInApplication) = (RBParser parseMethod: 'sentNotImplementedInApplication
+	self assert: ((refactoring model metaclassNamed: #RBBasicLintRuleTestData) parseTreeFor: #sentNotImplementedInApplication) = (RBParser parseMethod: 'sentNotImplementedInApplication
 									| detector |
 									detector := self new.
 									detector name: ''Messages sent but not implemented in application''.
@@ -277,9 +277,9 @@ RBInlineMethodTest >> testOverriden [
 	self shouldWarn: (RBInlineMethodRefactoring 
 			inline: (self 
 					convertInterval: (15 to: 26)
-					for: (RBLintRuleTest sourceCodeAt: #failedRules))
+					for: (RBLintRuleTestData sourceCodeAt: #failedRules))
 			inMethod: #failedRules
-			forClass: RBLintRuleTest)
+			forClass: RBLintRuleTestData)
 ]
 
 { #category : #'failure tests' }
@@ -297,7 +297,7 @@ RBInlineMethodTest >> testReturn [
 	self shouldFail: (RBInlineMethodRefactoring 
 			inline: (self 
 					convertInterval: (418 to: 485)
-					for: (RBBasicLintRuleTest class sourceCodeAt: #utilityMethods))
+					for: (RBBasicLintRuleTestData class sourceCodeAt: #utilityMethods))
 			inMethod: #utilityMethods
-			forClass: RBBasicLintRuleTest class)
+			forClass: RBBasicLintRuleTestData class)
 ]

--- a/src/Refactoring-Tests-Core/RBLintRuleTestData.class.st
+++ b/src/Refactoring-Tests-Core/RBLintRuleTestData.class.st
@@ -1,5 +1,9 @@
+"
+This hierarchy is code that is used as test data to test the refactoring engine. As such the code might make
+no sense or have lots of easy possible improvements... but as it is used for testing, they should not be fixed.
+"
 Class {
-	#name : #RBLintRuleTest,
+	#name : #RBLintRuleTestData,
 	#superclass : #Object,
 	#instVars : [
 		'name',
@@ -15,25 +19,25 @@ Class {
 }
 
 { #category : #foo }
-RBLintRuleTest class >> someFooMethod [
+RBLintRuleTestData class >> someFooMethod [
 	^ 'does nothing here:)'
 ]
 
 { #category : #foo }
-RBLintRuleTest class >> someOtherFooMethod [
+RBLintRuleTestData class >> someOtherFooMethod [
 	^ 'does nothing here even better:)'
 ]
 
 { #category : #accessing }
-RBLintRuleTest >> checkClass: aSmalllintContext [
+RBLintRuleTestData >> checkClass: aSmalllintContext [
 ]
 
 { #category : #accessing }
-RBLintRuleTest >> checkMethod: aSmalllintContext [
+RBLintRuleTestData >> checkMethod: aSmalllintContext [
 ]
 
 { #category : #accessing }
-RBLintRuleTest >> displayName [
+RBLintRuleTestData >> displayName [
 	| nameStream |
 	nameStream := WriteStream on: (String new: 64).
 	nameStream nextPutAll: self name;
@@ -44,51 +48,51 @@ RBLintRuleTest >> displayName [
 ]
 
 { #category : #private }
-RBLintRuleTest >> failedRules [
+RBLintRuleTestData >> failedRules [
 	^self isEmpty
 		ifTrue: [#()]
 		ifFalse: [Array with: self]
 ]
 
 { #category : #testing }
-RBLintRuleTest >> hasConflicts [
+RBLintRuleTestData >> hasConflicts [
 	^false
 ]
 
 { #category : #initialization }
-RBLintRuleTest >> initialize [
+RBLintRuleTestData >> initialize [
 	name := ''
 ]
 
 { #category : #testing }
-RBLintRuleTest >> isComposite [
+RBLintRuleTestData >> isComposite [
 	^false
 ]
 
 { #category : #testing }
-RBLintRuleTest >> isEmpty [
+RBLintRuleTestData >> isEmpty [
 	self subclassResponsibility
 ]
 
 { #category : #testing }
-RBLintRuleTest >> junk [
+RBLintRuleTestData >> junk [
 	^ RBRefactoryTestDataApp printString 
 		copyFrom: 1
 		to: CR
 ]
 
 { #category : #accessing }
-RBLintRuleTest >> name [
+RBLintRuleTestData >> name [
 	^name
 ]
 
 { #category : #accessing }
-RBLintRuleTest >> name: aString [ 
+RBLintRuleTestData >> name: aString [ 
 	name := aString
 ]
 
 { #category : #accessing }
-RBLintRuleTest >> openEditor [
+RBLintRuleTestData >> openEditor [
 	| rules |
 	rules := self failedRules.
 	rules isEmpty ifTrue: [^self].
@@ -96,39 +100,39 @@ RBLintRuleTest >> openEditor [
 ]
 
 { #category : #printing }
-RBLintRuleTest >> printOn: aStream [ 
+RBLintRuleTestData >> printOn: aStream [ 
 	name isNil
 		ifTrue: [super printOn: aStream]
 		ifFalse: [aStream nextPutAll: name]
 ]
 
 { #category : #accessing }
-RBLintRuleTest >> problemCount [
+RBLintRuleTestData >> problemCount [
 	^self subclassResponsibility
 ]
 
 { #category : #initialization }
-RBLintRuleTest >> resetResult [
+RBLintRuleTestData >> resetResult [
 ]
 
 { #category : #accessing }
-RBLintRuleTest >> run [
+RBLintRuleTestData >> run [
 	^Object printOn: self
 ]
 
 { #category : #accessing }
-RBLintRuleTest >> runOnEnvironment: anEnvironment [ 
+RBLintRuleTestData >> runOnEnvironment: anEnvironment [ 
 	^Object printOn: self onEnvironment: anEnvironment
 ]
 
 { #category : #accessing }
-RBLintRuleTest >> someOtherDemoMethod [
+RBLintRuleTestData >> someOtherDemoMethod [
 	| temp |
 	temp := self new.
 	^ temp junk
 ]
 
 { #category : #private }
-RBLintRuleTest >> viewResults [
+RBLintRuleTestData >> viewResults [
 	self subclassResponsibility
 ]

--- a/src/Refactoring-Tests-Core/RBMoveInstVarToClassTest.class.st
+++ b/src/Refactoring-Tests-Core/RBMoveInstVarToClassTest.class.st
@@ -11,6 +11,6 @@ RBMoveInstVarToClassTest >> testMoveInstVarToClassAlreadyDefined [
 			(RBMoveInstVarToClassRefactoring
 				model: model
 				variable: 'result'
-				class: RBBasicLintRuleTest
-				oldClass: RBFooLintRuleTest)
+				class: RBBasicLintRuleTestData
+				oldClass: RBFooLintRuleTestData)
 ]

--- a/src/Refactoring-Tests-Core/RBMoveMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBMoveMethodTest.class.st
@@ -10,7 +10,7 @@ RBMoveMethodTest >> testMoveMethodIntoArgument [
 	self proceedThroughWarning: 
 		[ refactoring := RBMoveMethodRefactoring 
 			selector: #checkMethod:
-			class: RBTransformationRuleTest
+			class: RBTransformationRuleTestData
 			variable: 'aSmalllintContext'.
 		self 
 			setupSelfArgumentNameFor: refactoring
@@ -22,7 +22,7 @@ RBMoveMethodTest >> testMoveMethodIntoArgument [
 			setupMethodNameFor: refactoring
 			toReturn: #foo:.
 		self executeRefactoring: refactoring ].
-	class := refactoring model classNamed: #RBTransformationRuleTest.
+	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	self assert: (class parseTreeFor: #checkMethod:) = (RBParser parseMethod: 'checkMethod: aSmalllintContext aSmalllintContext foo: self').
 	self assert: ((refactoring model classNamed: #RBSmalllintContext) parseTreeFor: #foo:) = (RBParser parseMethod: 'foo: transformationRule
 	transformationRule class: self selectedClass.
@@ -48,7 +48,7 @@ RBMoveMethodTest >> testMoveMethodIntoClassVariable [
 	self proceedThroughWarning: 
 		[ refactoring := RBMoveMethodRefactoring 
 			selector: #checkMethod:
-			class: RBTransformationRuleTest
+			class: RBTransformationRuleTestData
 			variable: 'RecursiveSelfRule'.
 		self 
 			setupSelfArgumentNameFor: refactoring
@@ -61,7 +61,7 @@ RBMoveMethodTest >> testMoveMethodIntoClassVariable [
 			toReturn: #foo:foo:
 			withArguments: #('transformationRule' 'aSmalllintContext' ).
 		self executeRefactoring: refactoring ].
-	class := refactoring model classNamed: #RBTransformationRuleTest.
+	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	self assert: (class parseTreeFor: #checkMethod:) = (RBParser parseMethod: 'checkMethod: aSmalllintContext RecursiveSelfRule foo: self foo: aSmalllintContext').
 	self assert: ((refactoring model classNamed: #RBParseTreeSearcher) parseTreeFor: #foo:foo:) = (RBParser parseMethod: 'foo: transformationRule foo: aSmalllintContext
 	transformationRule class: aSmalllintContext selectedClass.
@@ -85,7 +85,7 @@ RBMoveMethodTest >> testMoveMethodIntoInstanceVariable [
 	self proceedThroughWarning: 
 		[ refactoring := RBMoveMethodRefactoring 
 			selector: #checkMethod:
-			class: RBTransformationRuleTest
+			class: RBTransformationRuleTestData
 			variable: 'rewriteRule'.
 		self 
 			setupSelfArgumentNameFor: refactoring
@@ -98,7 +98,7 @@ RBMoveMethodTest >> testMoveMethodIntoInstanceVariable [
 			toReturn: #foo:foo:
 			withArguments: #('transformationRule' 'aSmalllintContext' ).
 		self executeRefactoring: refactoring ].
-	class := refactoring model classNamed: #RBTransformationRuleTest.
+	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	self assert: (class parseTreeFor: #checkMethod:) = (RBParser parseMethod: 'checkMethod: aSmalllintContext rewriteRule foo: self foo: aSmalllintContext').
 	self assert: ((refactoring model classNamed: #RBParseTreeRewriter) parseTreeFor: #foo:foo:) = (RBParser parseMethod: 'foo: transformationRule foo: aSmalllintContext
 	transformationRule class: aSmalllintContext selectedClass.
@@ -122,7 +122,7 @@ RBMoveMethodTest >> testMoveMethodThatReferencesPoolDictionary [
 	self proceedThroughWarning: 
 		[ refactoring := RBMoveMethodRefactoring 
 			selector: #junk
-			class: RBLintRuleTest
+			class: RBLintRuleTestData
 			variable: 'RefactoryTestDataApp'.
 		self 
 			setupSelfArgumentNameFor: refactoring
@@ -134,7 +134,7 @@ RBMoveMethodTest >> testMoveMethodThatReferencesPoolDictionary [
 			setupMethodNameFor: refactoring
 			toReturn: #junk1.
 		self executeRefactoring: refactoring ].
-	class := refactoring model classNamed: #RBLintRuleTest.
+	class := refactoring model classNamed: #RBLintRuleTestData.
 	self assert: (class parseTreeFor: #junk) = (RBParser parseMethod: 'junk ^RefactoryTestDataApp junk1').
 	self assert: ((refactoring model metaclassNamed: #RBRefactoryTestDataApp) parseTreeFor: #junk1) = (RBParser parseMethod: 'junk1
 	^RBRefactoryTestDataApp printString copyFrom: 1 to: CR').

--- a/src/Refactoring-Tests-Core/RBMoveMethodToClassTest.class.st
+++ b/src/Refactoring-Tests-Core/RBMoveMethodToClassTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #'failure tests' }
 RBMoveMethodToClassTest >> testMethodAlreadyDefined [
 	| method someClass |
-	someClass := model classNamed: #RBFooLintRuleTest.
+	someClass := model classNamed: #RBFooLintRuleTestData.
 	method := RBClassModelFactory rbMethod for: someClass source: 'foo' , String cr , String tab , '^ 6' selector: #foo.
 	self shouldFail: (RBMoveMethodToClassRefactoring method: method class: someClass)
 ]

--- a/src/Refactoring-Tests-Core/RBMoveVariableDefinitionTest.class.st
+++ b/src/Refactoring-Tests-Core/RBMoveVariableDefinitionTest.class.st
@@ -65,18 +65,18 @@ RBMoveVariableDefinitionTest >> testNonExistantName [
 	self
 		shouldFail: (RBMoveVariableDefinitionRefactoring 
 				bindTight: (1 to: 10)
-				in: RBLintRuleTest
+				in: RBLintRuleTestData
 				selector: #name1);
 		shouldFail: (RBMoveVariableDefinitionRefactoring 
 				bindTight: (self 
 						convertInterval: (44 to: 54)
-						for: (RBLintRuleTest sourceCodeAt: #displayName))
-				in: RBLintRuleTest
+						for: (RBLintRuleTestData sourceCodeAt: #displayName))
+				in: RBLintRuleTestData
 				selector: #displayName);
 		shouldFail: (RBMoveVariableDefinitionRefactoring 
 				bindTight: (self 
 						convertInterval: (16 to: 25)
-						for: (RBLintRuleTest sourceCodeAt: #displayName))
-				in: RBLintRuleTest
+						for: (RBLintRuleTestData sourceCodeAt: #displayName))
+				in: RBLintRuleTestData
 				selector: #displayName)
 ]

--- a/src/Refactoring-Tests-Core/RBPullUpClassVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBPullUpClassVariableTest.class.st
@@ -8,14 +8,14 @@ Class {
 RBPullUpClassVariableTest >> testMetaClassFailure [
 	self shouldFail: (RBPullUpClassVariableRefactoring 
 			variable: #RecursiveSelfRule
-			class: RBLintRuleTest class)
+			class: RBLintRuleTestData class)
 ]
 
 { #category : #'failure tests' }
 RBPullUpClassVariableTest >> testNonExistantName [
 	self shouldFail: (RBPullUpClassVariableRefactoring 
 			variable: #Foo
-			class: RBLintRuleTest)
+			class: RBLintRuleTestData)
 ]
 
 { #category : #tests }
@@ -23,8 +23,8 @@ RBPullUpClassVariableTest >> testPullUpClassVariable [
 	| refactoring |
 	refactoring := RBPullUpClassVariableRefactoring 
 		variable: #RecursiveSelfRule
-		class: RBLintRuleTest.
+		class: RBLintRuleTestData.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBLintRuleTest) directlyDefinesClassVariable: #RecursiveSelfRule).
-	self deny: ((refactoring model classNamed: #RBTransformationRuleTest) directlyDefinesClassVariable: #RecursiveSelfRule)
+	self assert: ((refactoring model classNamed: #RBLintRuleTestData) directlyDefinesClassVariable: #RecursiveSelfRule).
+	self deny: ((refactoring model classNamed: #RBTransformationRuleTestData) directlyDefinesClassVariable: #RecursiveSelfRule)
 ]

--- a/src/Refactoring-Tests-Core/RBPullUpInstanceVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBPullUpInstanceVariableTest.class.st
@@ -10,15 +10,15 @@ RBPullUpInstanceVariableTest >> testPullUpInstVar [
 	self proceedThroughWarning: 
 		[ refactoring := RBPullUpInstanceVariableRefactoring 
 			variable: 'result'
-			class: RBLintRuleTest.
+			class: RBLintRuleTestData.
 		self executeRefactoring: refactoring ].
-	self assert: ((refactoring model classNamed: #RBLintRuleTest) directlyDefinesInstanceVariable: 'result').
-	self deny: ((refactoring model classNamed: #RBBasicLintRuleTest) directlyDefinesInstanceVariable: 'result')
+	self assert: ((refactoring model classNamed: #RBLintRuleTestData) directlyDefinesInstanceVariable: 'result').
+	self deny: ((refactoring model classNamed: #RBBasicLintRuleTestData) directlyDefinesInstanceVariable: 'result')
 ]
 
 { #category : #'failure tests' }
 RBPullUpInstanceVariableTest >> testPullUpVariableNotDefined [
 	self shouldFail: (RBPullUpInstanceVariableRefactoring 
 			variable: 'notDefinedVariable'
-			class: RBLintRuleTest)
+			class: RBLintRuleTestData)
 ]

--- a/src/Refactoring-Tests-Core/RBPullUpMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBPullUpMethodTest.class.st
@@ -50,19 +50,19 @@ RBPullUpMethodTest >> testPullUpMethodWithCopyOverriddenMethodsDown [
 	self proceedThroughWarning: 
 		[ refactoring := RBPullUpMethodRefactoring 
 			pullUp: #(#isComposite )
-			from: RBCompositeLintRuleTest.
+			from: RBCompositeLintRuleTestData.
 		self executeRefactoring: refactoring ].
-	self assert: ((refactoring model classNamed: #RBBasicLintRuleTest) parseTreeFor: #isComposite) = (RBParser parseMethod: 'isComposite ^false').
-	self assert: ((refactoring model classNamed: ('RBFoo' , 'LintRuleTest') asSymbol) parseTreeFor: #isComposite) = (RBParser parseMethod: 'isComposite ^false').
-	self assert: ((refactoring model classNamed: #RBLintRuleTest) parseTreeFor: #isComposite) = (RBParser parseMethod: 'isComposite ^true').
-	self deny: ((refactoring model classNamed: #RBCompositeLintRuleTest) directlyDefinesMethod: #isComposite)
+	self assert: ((refactoring model classNamed: #RBBasicLintRuleTestData) parseTreeFor: #isComposite) = (RBParser parseMethod: 'isComposite ^false').
+	self assert: ((refactoring model classNamed: ('RBFoo' , 'LintRuleTestData') asSymbol) parseTreeFor: #isComposite) = (RBParser parseMethod: 'isComposite ^false').
+	self assert: ((refactoring model classNamed: #RBLintRuleTestData) parseTreeFor: #isComposite) = (RBParser parseMethod: 'isComposite ^true').
+	self deny: ((refactoring model classNamed: #RBCompositeLintRuleTestData) directlyDefinesMethod: #isComposite)
 ]
 
 { #category : #'failure tests' }
 RBPullUpMethodTest >> testPullUpReferencesInstVar [
 	self shouldFail: (RBPullUpMethodRefactoring 
 			pullUp: #(#checkClass: )
-			from: RBBasicLintRuleTest)
+			from: RBBasicLintRuleTestData)
 ]
 
 { #category : #'failure tests' }

--- a/src/Refactoring-Tests-Core/RBPushDownClassVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBPushDownClassVariableTest.class.st
@@ -109,7 +109,7 @@ RBPushDownClassVariableTest >> testModelRemoveUnusedVariable [
 RBPushDownClassVariableTest >> testNonExistantName [
 	self shouldFail: (RBPushDownClassVariableRefactoring 
 			variable: #Foo
-			class: RBBasicLintRuleTest)
+			class: RBBasicLintRuleTestData)
 ]
 
 { #category : #tests }
@@ -117,8 +117,8 @@ RBPushDownClassVariableTest >> testPushDownClassVariable [
 	| refactoring |
 	refactoring := RBPushDownClassVariableRefactoring 
 		variable: #Foo1
-		class: RBLintRuleTest.
-	self assert: ((refactoring model classNamed: #RBLintRuleTest) directlyDefinesClassVariable: #Foo1).
+		class: RBLintRuleTestData.
+	self assert: ((refactoring model classNamed: #RBLintRuleTestData) directlyDefinesClassVariable: #Foo1).
 	self executeRefactoring: refactoring.
-	(refactoring model classNamed: #RBLintRuleTest) withAllSubclasses do: [ :each | self deny: (each directlyDefinesClassVariable: #Foo1) ]
+	(refactoring model classNamed: #RBLintRuleTestData) withAllSubclasses do: [ :each | self deny: (each directlyDefinesClassVariable: #Foo1) ]
 ]

--- a/src/Refactoring-Tests-Core/RBPushDownInstanceVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBPushDownInstanceVariableTest.class.st
@@ -63,7 +63,7 @@ RBPushDownInstanceVariableTest >> testModelRemoveUnusedVariable [
 RBPushDownInstanceVariableTest >> testNonExistantName [
 	self shouldFail: (RBPushDownInstanceVariableRefactoring 
 			variable: 'foo'
-			class: RBBasicLintRuleTest)
+			class: RBBasicLintRuleTestData)
 ]
 
 { #category : #tests }
@@ -71,7 +71,7 @@ RBPushDownInstanceVariableTest >> testPushDownInstanceVariable [
 	| refactoring |
 	refactoring := RBPushDownInstanceVariableRefactoring 
 		variable: 'foo1'
-		class: RBLintRuleTest.
+		class: RBLintRuleTestData.
 	self executeRefactoring: refactoring.
-	(refactoring model classNamed: #RBLintRuleTest) subclasses do: [ :each | self assert: (each directlyDefinesInstanceVariable: 'foo1') ]
+	(refactoring model classNamed: #RBLintRuleTestData) subclasses do: [ :each | self assert: (each directlyDefinesInstanceVariable: 'foo1') ]
 ]

--- a/src/Refactoring-Tests-Core/RBPushDownMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBPushDownMethodTest.class.st
@@ -9,9 +9,9 @@ RBPushDownMethodTest >> testPushDownMethod [
 	| refactoring class |
 	refactoring := RBPushDownMethodRefactoring 
 		pushDown: #(#name: )
-		from: RBLintRuleTest.
+		from: RBLintRuleTestData.
 	self executeRefactoring: refactoring.
-	class := refactoring model classNamed: #RBLintRuleTest.
+	class := refactoring model classNamed: #RBLintRuleTestData.
 	self deny: (class directlyDefinesMethod: #name:).
 	class subclasses do: 
 		[ :each | 
@@ -28,13 +28,13 @@ RBPushDownMethodTest >> testPushDownMethodOnNonAbstractClass [
 { #category : #tests }
 RBPushDownMethodTest >> testPushDownMethodThatReferencesPoolDictionary [
 	| refactoring class parseTree |
-	parseTree := RBLintRuleTest parseTreeFor: #junk.
+	parseTree := RBLintRuleTestData parseTreeFor: #junk.
 	self proceedThroughWarning: 
 		[ refactoring := RBPushDownMethodRefactoring 
 			pushDown: #(#junk )
-			from: RBLintRuleTest.
+			from: RBLintRuleTestData.
 		self executeRefactoring: refactoring ].
-	class := refactoring model classNamed: #RBLintRuleTest.
+	class := refactoring model classNamed: #RBLintRuleTestData.
 	self deny: (class directlyDefinesMethod: #junk).
 	class subclasses do: 
 		[ :each | 
@@ -47,6 +47,6 @@ RBPushDownMethodTest >> testPushDownNonExistantMenu [
 	| refactoring |
 	refactoring := RBPushDownMethodRefactoring 
 		pushDown: #(#someMethodThatDoesNotExist )
-		from: RBLintRuleTest.
+		from: RBLintRuleTestData.
 	self shouldFail: refactoring
 ]

--- a/src/Refactoring-Tests-Core/RBRemoveClassTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRemoveClassTest.class.st
@@ -23,14 +23,14 @@ RBRemoveClassTest >> testRemoveClassWithBadNameRaisesRBRefactoringError [
 
 { #category : #'failure tests' }
 RBRemoveClassTest >> testRemoveClassWithReferencesRaisesRBRefactoringError [
-	self shouldFail: (RBRemoveClassRefactoring classNames: #(#RBBasicLintRuleTest ))
+	self shouldFail: (RBRemoveClassRefactoring classNames: #(#RBBasicLintRuleTestData ))
 ]
 
 { #category : #tests }
 RBRemoveClassTest >> testRemoveEmptySuperclass [
 	| refactoring |
-	refactoring := RBRemoveClassRefactoring classNames: (Array with: ('RBFoo' , 'LintRuleTest1') asSymbol).
+	refactoring := RBRemoveClassRefactoring classNames: (Array with: ('RBFoo' , 'LintRuleTestData1') asSymbol).
 	self executeRefactoring: refactoring.
-	self assert: (refactoring model classNamed: ('RBFoo' , 'LintRuleTest1') asSymbol) isNil.
-	self assert: (refactoring model classNamed: #RBTransformationRuleTest1) superclass = (refactoring model classNamed: #RBLintRuleTest)
+	self assert: (refactoring model classNamed: ('RBFoo' , 'LintRuleTestData1') asSymbol) isNil.
+	self assert: (refactoring model classNamed: #RBTransformationRuleTestData1) superclass = (refactoring model classNamed: #RBLintRuleTestData)
 ]

--- a/src/Refactoring-Tests-Core/RBRemoveClassVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRemoveClassVariableTest.class.st
@@ -8,14 +8,14 @@ Class {
 RBRemoveClassVariableTest >> testNonExistantName [
 	self shouldFail: (RBRemoveClassVariableRefactoring 
 			variable: #RecursiveSelfRule1
-			class: RBTransformationRuleTest)
+			class: RBTransformationRuleTestData)
 ]
 
 { #category : #'failure tests' }
 RBRemoveClassVariableTest >> testReferencedVariable [
 	self shouldFail: (RBRemoveClassVariableRefactoring 
 			variable: #RecursiveSelfRule
-			class: RBTransformationRuleTest)
+			class: RBTransformationRuleTestData)
 ]
 
 { #category : #tests }
@@ -23,8 +23,8 @@ RBRemoveClassVariableTest >> testRemoveClassVar [
 	| refactoring class |
 	refactoring := RBRemoveClassVariableRefactoring 
 		variable: 'Foo1'
-		class: RBLintRuleTest.
-	class := refactoring model classNamed: #RBLintRuleTest.
+		class: RBLintRuleTestData.
+	class := refactoring model classNamed: #RBLintRuleTestData.
 	self assert: (class definesClassVariable: 'Foo1').
 	self executeRefactoring: refactoring.
 	self deny: (class definesClassVariable: 'Foo1')

--- a/src/Refactoring-Tests-Core/RBRemoveInstanceVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRemoveInstanceVariableTest.class.st
@@ -22,14 +22,14 @@ RBRemoveInstanceVariableTest >> testModelRemoveInstanceVariable [
 RBRemoveInstanceVariableTest >> testNonExistantName [
 	self shouldFail: (RBRemoveInstanceVariableRefactoring 
 			variable: 'name1'
-			class: RBLintRuleTest)
+			class: RBLintRuleTestData)
 ]
 
 { #category : #'failure tests' }
 RBRemoveInstanceVariableTest >> testReferencedVariable [
 	self shouldFail: (RBRemoveInstanceVariableRefactoring 
 			variable: 'name'
-			class: RBLintRuleTest)
+			class: RBLintRuleTestData)
 ]
 
 { #category : #tests }
@@ -37,8 +37,8 @@ RBRemoveInstanceVariableTest >> testRemoveInstVar [
 	| refactoring class |
 	refactoring := RBRemoveInstanceVariableRefactoring 
 		variable: 'foo1'
-		class: RBLintRuleTest.
-	class := refactoring model classNamed: #RBLintRuleTest.
+		class: RBLintRuleTestData.
+	class := refactoring model classNamed: #RBLintRuleTestData.
 	self assert: (class definesInstanceVariable: 'foo1').
 	self executeRefactoring: refactoring.
 	self deny: (class definesInstanceVariable: 'foo1')

--- a/src/Refactoring-Tests-Core/RBRemoveMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRemoveMethodTest.class.st
@@ -43,12 +43,12 @@ RBRemoveMethodTest >> testRemoveMethod [
 RBRemoveMethodTest >> testRemoveReferenced [
 	self shouldFail: (RBRemoveMethodRefactoring 
 			removeMethods: #(#checkClass: )
-			from: RBBasicLintRuleTest)
+			from: RBBasicLintRuleTestData)
 ]
 
 { #category : #'failure tests' }
 RBRemoveMethodTest >> testRemoveSameMethodButSendsSuper [
 	self shouldWarn: (RBRemoveMethodRefactoring 
 			removeMethods: #(#new )
-			from: RBBasicLintRuleTest class)
+			from: RBBasicLintRuleTestData class)
 ]

--- a/src/Refactoring-Tests-Core/RBRemoveParameterTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRemoveParameterTest.class.st
@@ -9,11 +9,11 @@ RBRemoveParameterTest >> testNonExistantName [
 	self
 		shouldFail: (RBRemoveParameterRefactoring 
 				removeParameter: 'asdf'
-				in: RBBasicLintRuleTest
+				in: RBBasicLintRuleTestData
 				selector: #checkClass:);
 		shouldFail: (RBRemoveParameterRefactoring 
 				removeParameter: 'aSmalllintContext'
-				in: RBBasicLintRuleTest
+				in: RBBasicLintRuleTestData
 				selector: #checkClass1:)
 ]
 

--- a/src/Refactoring-Tests-Core/RBRenameClassTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenameClassTest.class.st
@@ -8,10 +8,10 @@ Class {
 RBRenameClassTest >> testBadName [
 	self
 		shouldFail: (RBRenameClassRefactoring 
-				rename: RBLintRuleTest
+				rename: RBLintRuleTestData
 				to: self objectClassVariable);
 		shouldFail: (RBRenameClassRefactoring 
-				rename: RBLintRuleTest
+				rename: RBLintRuleTestData
 				to: #'Ob ject')
 ]
 

--- a/src/Refactoring-Tests-Core/RBRenameClassVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenameClassVariableTest.class.st
@@ -9,7 +9,7 @@ RBRenameClassVariableTest >> testAlreadyExistingName [
 	self shouldFail: (RBRenameClassVariableRefactoring 
 			rename: #RecursiveSelfRule
 			to: self objectClassVariable
-			in: RBTransformationRuleTest)
+			in: RBTransformationRuleTestData)
 ]
 
 { #category : #'failure tests' }
@@ -17,7 +17,7 @@ RBRenameClassVariableTest >> testMetaClassFailure [
 	self shouldFail: (RBRenameClassVariableRefactoring 
 			rename: #RecursiveSelfRule
 			to: #Foo
-			in: RBTransformationRuleTest class)
+			in: RBTransformationRuleTestData class)
 ]
 
 { #category : #'failure tests' }
@@ -25,7 +25,7 @@ RBRenameClassVariableTest >> testNonExistantName [
 	self shouldFail: (RBRenameClassVariableRefactoring 
 			rename: #foo
 			to: #newFoo
-			in: RBBasicLintRuleTest)
+			in: RBBasicLintRuleTestData)
 ]
 
 { #category : #tests }
@@ -34,9 +34,9 @@ RBRenameClassVariableTest >> testRenameClassVar [
 	refactoring := RBRenameClassVariableRefactoring 
 		rename: #RecursiveSelfRule
 		to: #RSR
-		in: RBTransformationRuleTest.
+		in: RBTransformationRuleTestData.
 	self executeRefactoring: refactoring.
-	class := refactoring model classNamed: #RBTransformationRuleTest.
+	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	self assert: (class directlyDefinesClassVariable: #RSR).
 	self deny: (class directlyDefinesClassVariable: #RecursiveSelfRule).
 	self assert: (class classSide parseTreeFor: #initializeAfterLoad1) = (RBParser parseMethod: 'initializeAfterLoad1
@@ -62,11 +62,11 @@ RBRenameClassVariableTest >> testRenameClassVarInSharedPool [
 	refactoring := RBRenameClassVariableRefactoring 
 		rename: #Var1
 		to: #VarOne
-		in: RBSharedPoolForTest.
+		in: RBSharedPoolForTestData.
 	self executeRefactoring: refactoring.
 	
-	class := refactoring model classNamed: #RBSharedPoolForTest.
-	userClass := refactoring model classNamed: #RBClassUsingSharedPoolForTest.
+	class := refactoring model classNamed: #RBSharedPoolForTestData.
+	userClass := refactoring model classNamed: #RBClassUsingSharedPoolForTestData.
 	
 	self assert: (class parseTreeFor: #msg1) = (RBParser parseMethod: 'msg1 ^ VarOne').	
 	self assert: (class parseTreeFor: #msg2) = (RBParser parseMethod: 'msg2 ^ VarOne').	

--- a/src/Refactoring-Tests-Core/RBRenameInstanceVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenameInstanceVariableTest.class.st
@@ -9,7 +9,7 @@ RBRenameInstanceVariableTest >> testAlreadyExistingName [
 	self shouldFail: (RBRenameInstanceVariableRefactoring 
 			rename: 'classBlock'
 			to: 'name'
-			in: RBBasicLintRuleTest)
+			in: RBBasicLintRuleTestData)
 ]
 
 { #category : #'failure tests' }
@@ -17,15 +17,15 @@ RBRenameInstanceVariableTest >> testNonExistantName [
 	self shouldFail: (RBRenameInstanceVariableRefactoring 
 			rename: 'foo'
 			to: 'newFoo'
-			in: RBBasicLintRuleTest)
+			in: RBBasicLintRuleTestData)
 ]
 
 { #category : #tests }
 RBRenameInstanceVariableTest >> testRenameInstVar [
 	| refactoring class |
-	refactoring := RBRenameInstanceVariableRefactoring rename: 'classBlock' to: 'asdf' in: RBBasicLintRuleTest.
+	refactoring := RBRenameInstanceVariableRefactoring rename: 'classBlock' to: 'asdf' in: RBBasicLintRuleTestData.
 	self executeRefactoring: refactoring.
-	class := refactoring model classNamed: #RBBasicLintRuleTest.
+	class := refactoring model classNamed: #RBBasicLintRuleTestData.
 	self assert: (class directlyDefinesInstanceVariable: 'asdf').
 	self deny: (class directlyDefinesInstanceVariable: 'classBlock').
 	self
@@ -53,9 +53,9 @@ RBRenameInstanceVariableTest >> testRenameInstVar [
 { #category : #tests }
 RBRenameInstanceVariableTest >> testRenameInstVarNotAccessors [
 	| refactoring class |
-	refactoring := RBRenameInstanceVariableRefactoring rename: 'result' to: 'whatever' in: RBBasicLintRuleTest renameAccessors: false.
+	refactoring := RBRenameInstanceVariableRefactoring rename: 'result' to: 'whatever' in: RBBasicLintRuleTestData renameAccessors: false.
 	self executeRefactoring: refactoring.
-	class := refactoring model classNamed: #RBBasicLintRuleTest.
+	class := refactoring model classNamed: #RBBasicLintRuleTestData.
 	self assert: (class directlyDefinesInstanceVariable: 'whatever').
 	self deny: (class directlyDefinesInstanceVariable: 'result').
 	

--- a/src/Refactoring-Tests-Core/RBRenameMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenameMethodTest.class.st
@@ -8,7 +8,7 @@ Class {
 RBRenameMethodTest >> testExistingSelector [
 	self shouldFail: (RBRenameMethodRefactoring 
 			renameMethod: #checkClass:
-			in: RBBasicLintRuleTest
+			in: RBBasicLintRuleTestData
 			to: #runOnEnvironment:
 			permutation: (1 to: 1))
 ]
@@ -17,7 +17,7 @@ RBRenameMethodTest >> testExistingSelector [
 RBRenameMethodTest >> testMultipleSelectors [
 	self shouldWarn: (RBRenameMethodRefactoring 
 			renameMethod: #checkClass:
-			in: RBBasicLintRuleTest
+			in: RBBasicLintRuleTestData
 			to: #foo:
 			permutation: (1 to: 1))
 ]
@@ -114,7 +114,7 @@ RBRenameMethodTest >> testRenameTestMethod1 [
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
 	self assert: (class parseTreeFor: #testMethod2) = (RBParser parseMethod: 'testMethod2
 	^self testMethod2 , ([:each | each testMethod2] value: #(#(#testMethod2) 2 #testMethod2))').
-	self assert: ((refactoring model classNamed: #RBBasicLintRuleTest) parseTreeFor: #classBlock:) = (RBParser parseMethod: 'classBlock: aBlock
+	self assert: ((refactoring model classNamed: #RBBasicLintRuleTestData) parseTreeFor: #classBlock:) = (RBParser parseMethod: 'classBlock: aBlock
 	classBlock := aBlock testMethod2').
 	self deny: (class directlyDefinesMethod: ('test' , 'Method1') asSymbol)
 ]

--- a/src/Refactoring-Tests-Core/RBRenameTemporaryTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenameTemporaryTest.class.st
@@ -21,30 +21,30 @@ RBRenameTemporaryTest >> testBadName [
 		shouldFail: (RBRenameTemporaryRefactoring 
 				renameTemporaryFrom: (self 
 						convertInterval: (15 to: 19)
-						for: (RBLintRuleTest sourceCodeAt: #openEditor))
+						for: (RBLintRuleTestData sourceCodeAt: #openEditor))
 				to: 'name'
-				in: RBLintRuleTest
+				in: RBLintRuleTestData
 				selector: #openEditor);
 		shouldFail: (RBRenameTemporaryRefactoring 
 				renameTemporaryFrom: (self 
 						convertInterval: (15 to: 19)
-						for: (RBLintRuleTest sourceCodeAt: #openEditor))
+						for: (RBLintRuleTestData sourceCodeAt: #openEditor))
 				to: 'rules'
-				in: RBLintRuleTest
+				in: RBLintRuleTestData
 				selector: #openEditor);
 		shouldFail: (RBRenameTemporaryRefactoring 
 				renameTemporaryFrom: (self 
 						convertInterval: (15 to: 19)
-						for: (RBLintRuleTest sourceCodeAt: #openEditor))
+						for: (RBLintRuleTestData sourceCodeAt: #openEditor))
 				to: 'DependentFields'
-				in: RBLintRuleTest
+				in: RBLintRuleTestData
 				selector: #openEditor);
 		shouldFail: (RBRenameTemporaryRefactoring 
 				renameTemporaryFrom: (self 
 						convertInterval: (15 to: 19)
-						for: (RBLintRuleTest sourceCodeAt: #openEditor))
+						for: (RBLintRuleTestData sourceCodeAt: #openEditor))
 				to: 'a b'
-				in: RBLintRuleTest
+				in: RBLintRuleTestData
 				selector: #openEditor)
 ]
 
@@ -75,12 +75,12 @@ RBRenameTemporaryTest >> testRenameTemporary [
 	refactoring := RBRenameTemporaryRefactoring 
 		renameTemporaryFrom: (self 
 				convertInterval: (15 to: 19)
-				for: (RBLintRuleTest sourceCodeAt: #openEditor))
+				for: (RBLintRuleTestData sourceCodeAt: #openEditor))
 		to: 'asdf'
-		in: RBLintRuleTest
+		in: RBLintRuleTestData
 		selector: #openEditor.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBLintRuleTest) parseTreeFor: #openEditor) = (RBParser parseMethod: 'openEditor
+	self assert: ((refactoring model classNamed: #RBLintRuleTestData) parseTreeFor: #openEditor) = (RBParser parseMethod: 'openEditor
 								| asdf |
 								asdf := self failedRules.
 								asdf isEmpty ifTrue: [^self].

--- a/src/Refactoring-Tests-Core/RBSearchTest.class.st
+++ b/src/Refactoring-Tests-Core/RBSearchTest.class.st
@@ -13,7 +13,7 @@ RBSearchTest >> buildArgumentSearch [
 	self 
 		createArgumentSearchWith: 'aSmalllintContext'
 		selectors: #(#checkMethod: #checkClass: )
-		inClass: RBBasicLintRuleTest
+		inClass: RBBasicLintRuleTestData
 ]
 
 { #category : #accessing }
@@ -21,7 +21,7 @@ RBSearchTest >> buildMessageSearch [
 	self 
 		createSearchWith: '``@receiver -> ``@arg'
 		selectors: #(#superSends #superSends )
-		inClass: RBTransformationRuleTest
+		inClass: RBTransformationRuleTestData
 ]
 
 { #category : #accessing }
@@ -34,7 +34,7 @@ RBSearchTest >> buildMethodArgumentSearch [
 				#createMatcherFor:method:
 				#createParseTreeRule:name:
 			)
-		inClass: RBBasicLintRuleTest class
+		inClass: RBBasicLintRuleTestData class
 ]
 
 { #category : #accessing }
@@ -43,7 +43,7 @@ RBSearchTest >> buildMethodSearch [
 	self 
 		createMethodSearchWith: '`@methodName: `@args ^`@object `@methodName: `@args'
 		selectors: #(#problemCount #isEmpty )
-		inClass: RBTransformationRuleTest
+		inClass: RBTransformationRuleTestData
 ]
 
 { #category : #accessing }
@@ -51,7 +51,7 @@ RBSearchTest >> buildMethodTitleSearch [
 	self 
 		createMethodSearchWith: 'initialize | `@temps | `@.Stmts'
 		selectors: #(#initialize )
-		inClass: RBBasicLintRuleTest
+		inClass: RBBasicLintRuleTestData
 ]
 
 { #category : #accessing }
@@ -68,7 +68,7 @@ RBSearchTest >> buildSimpleLiteralSearch [
 				yourself ].
 	search answer: #(#protocolsToCheck ) asBag.
 	(classSearches 
-		at: RBBasicLintRuleTest class
+		at: RBBasicLintRuleTestData class
 		ifAbsentPut: [ Set new ]) add: search
 ]
 
@@ -90,7 +90,7 @@ RBSearchTest >> buildSimpleVariableSearch [
 				#newResultClass:
 				#viewResults
 			)
-		inClass: RBBasicLintRuleTest
+		inClass: RBBasicLintRuleTestData
 ]
 
 { #category : #accessing }
@@ -104,7 +104,7 @@ RBSearchTest >> buildStatementSearch [
 				#viewResults
 				#superSends
 			)
-		inClass: RBTransformationRuleTest
+		inClass: RBTransformationRuleTestData
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Tests-Core/RBSharedPoolForTestData.class.st
+++ b/src/Refactoring-Tests-Core/RBSharedPoolForTestData.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #RBSharedPoolForTest,
+	#name : #RBSharedPoolForTestData,
 	#superclass : #SharedPool,
 	#classVars : [
 		'Var1'
@@ -8,13 +8,13 @@ Class {
 }
 
 { #category : #accessing }
-RBSharedPoolForTest >> msg1 [
+RBSharedPoolForTestData >> msg1 [
 	
 	^ Var1
 ]
 
 { #category : #accessing }
-RBSharedPoolForTest >> msg2 [
+RBSharedPoolForTestData >> msg2 [
 	
 	^ Var1
 ]

--- a/src/Refactoring-Tests-Core/RBTemporaryToInstanceVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBTemporaryToInstanceVariableTest.class.st
@@ -14,11 +14,11 @@ RBTemporaryToInstanceVariableTest >> setUp [
 RBTemporaryToInstanceVariableTest >> testNonExistantName [
 	self
 		shouldFail: (RBTemporaryToInstanceVariableRefactoring 
-				class: RBBasicLintRuleTest
+				class: RBBasicLintRuleTestData
 				selector: #checkClass:
 				variable: 'asdf');
 		shouldFail: (RBTemporaryToInstanceVariableRefactoring 
-				class: RBBasicLintRuleTest
+				class: RBBasicLintRuleTestData
 				selector: #checkClass1:
 				variable: 'aSmalllintContext')
 ]
@@ -40,11 +40,11 @@ RBTemporaryToInstanceVariableTest >> testRedefinedTemporary [
 RBTemporaryToInstanceVariableTest >> testTemporaryToInstanceVariable [
 	| refactoring class |
 	refactoring := RBTemporaryToInstanceVariableRefactoring 
-		class: RBLintRuleTest
+		class: RBLintRuleTestData
 		selector: #displayName
 		variable: 'nameStream'.
 	self executeRefactoring: refactoring.
-	class := refactoring model classNamed: #RBLintRuleTest.
+	class := refactoring model classNamed: #RBLintRuleTestData.
 	self assert: (class parseTreeFor: #displayName) = (RBParser parseMethod: 'displayName
 								nameStream := WriteStream on: (String new: 64).
 								nameStream

--- a/src/Refactoring-Tests-Core/RBTransformationRuleTest1.class.st
+++ b/src/Refactoring-Tests-Core/RBTransformationRuleTest1.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #RBTransformationRuleTest1,
-	#superclass : #RBFooLintRuleTest1,
-	#category : #'Refactoring-Tests-Core-Data'
-}

--- a/src/Refactoring-Tests-Core/RBTransformationRuleTestData.class.st
+++ b/src/Refactoring-Tests-Core/RBTransformationRuleTestData.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #RBTransformationRuleTest,
-	#superclass : #RBFooLintRuleTest,
+	#name : #RBTransformationRuleTestData,
+	#superclass : #RBFooLintRuleTestData,
 	#instVars : [
 		'rewriteRule',
 		'builder',
@@ -13,7 +13,7 @@ Class {
 }
 
 { #category : #transformations }
-RBTransformationRuleTest class >> assignmentInIfTrue [
+RBTransformationRuleTestData class >> assignmentInIfTrue [
 	^self rewrite: #(
 			#('``@Boolean ifTrue: [`variable := ``@true] ifFalse: [`variable := ``@false]'
 			"->"
@@ -26,7 +26,7 @@ RBTransformationRuleTest class >> assignmentInIfTrue [
 ]
 
 { #category : #transformations }
-RBTransformationRuleTest class >> atIfAbsent [
+RBTransformationRuleTestData class >> atIfAbsent [
 	^self rewrite: #(
 			#('``@dictionary at: ``@key 
 					ifAbsent: [| `@temps | 
@@ -54,7 +54,7 @@ RBTransformationRuleTest class >> atIfAbsent [
 ]
 
 { #category : #transformations }
-RBTransformationRuleTest class >> betweenAnd [
+RBTransformationRuleTestData class >> betweenAnd [
 	^self rewrite: #(
 			#('``@a >= ``@b and: [``@a <= ``@c]' "->" '``@a between: ``@b and: ``@c')
 			#('``@a >= ``@b & (``@a <= ``@c)' "->" '``@a between: ``@b and: ``@c')
@@ -77,12 +77,12 @@ RBTransformationRuleTest class >> betweenAnd [
 ]
 
 { #category : #cleanup }
-RBTransformationRuleTest class >> cleanUp [
+RBTransformationRuleTestData class >> cleanUp [
 	self nuke
 ]
 
 { #category : #transformations }
-RBTransformationRuleTest class >> detectIfNone [
+RBTransformationRuleTestData class >> detectIfNone [
 	^self rewrite: #(
 			#('(``@collection detect: [:`each | | `@temps | ``@.Statements] ifNone: [nil]) isNil'
 				"->"	'(``@collection contains: [:`each | | `@temps | ``@.Statements]) not')
@@ -101,7 +101,7 @@ RBTransformationRuleTest class >> detectIfNone [
 ]
 
 { #category : #transformations }
-RBTransformationRuleTest class >> equalNil [
+RBTransformationRuleTestData class >> equalNil [
 	^self
 		rewrite: #(
 			#('``@object = nil'	"->"	'``@object isNil') 
@@ -113,7 +113,7 @@ RBTransformationRuleTest class >> equalNil [
 ]
 
 { #category : #transformations }
-RBTransformationRuleTest class >> guardClause [
+RBTransformationRuleTestData class >> guardClause [
 	^self
 		rewrite: #(
 			#('`@methodName: `@args 
@@ -145,7 +145,7 @@ RBTransformationRuleTest class >> guardClause [
 ]
 
 { #category : #'class initialization' }
-RBTransformationRuleTest class >> initializeAfterLoad1 [
+RBTransformationRuleTestData class >> initializeAfterLoad1 [
 	RecursiveSelfRule := RBParseTreeSearcher new.
 	RecursiveSelfRule
 		addMethodSearches: #('`@methodName: `@args | `@temps | self `@methodName: `@args' '`@methodName: `@args | `@temps | ^self `@methodName: `@args')
@@ -153,7 +153,7 @@ RBTransformationRuleTest class >> initializeAfterLoad1 [
 ]
 
 { #category : #transformations }
-RBTransformationRuleTest class >> minMax [
+RBTransformationRuleTestData class >> minMax [
 	^self rewrite: #(
 			#('``@a < ``@b ifTrue: [``@a] ifFalse: [``@b]'	"->"	'``@a min: ``@b')
 			#('``@a <= ``@b ifTrue: [``@a] ifFalse: [``@b]'	"->"	'``@a min: ``@b')
@@ -184,7 +184,7 @@ RBTransformationRuleTest class >> minMax [
 ]
 
 { #category : #transformations }
-RBTransformationRuleTest class >> notElimination [
+RBTransformationRuleTestData class >> notElimination [
 	^self
 		rewrite: #(
 			#('``@object not not'	"->"	'``@object') 
@@ -215,12 +215,12 @@ RBTransformationRuleTest class >> notElimination [
 ]
 
 { #category : #'class initialization' }
-RBTransformationRuleTest class >> nuke [
+RBTransformationRuleTestData class >> nuke [
 	RecursiveSelfRule := nil
 ]
 
 { #category : #'instance creation' }
-RBTransformationRuleTest class >> rewrite: stringArrays methods: aBoolean name: aName [ 
+RBTransformationRuleTestData class >> rewrite: stringArrays methods: aBoolean name: aName [ 
 	| rewriteRule |
 	rewriteRule := RBParseTreeRewriter new.
 	stringArrays do: 
@@ -234,7 +234,7 @@ RBTransformationRuleTest class >> rewrite: stringArrays methods: aBoolean name: 
 ]
 
 { #category : #transformations }
-RBTransformationRuleTest class >> showWhileBlocks [
+RBTransformationRuleTestData class >> showWhileBlocks [
 	^self
 		rewrite: #(
 			#('``@cursor showWhile: [| `@temps | ``@.Statements. `var := ``@object]'
@@ -246,7 +246,7 @@ RBTransformationRuleTest class >> showWhileBlocks [
 ]
 
 { #category : #transformations }
-RBTransformationRuleTest class >> superSends [
+RBTransformationRuleTestData class >> superSends [
 	^(self new)
 		name: 'Rewrite super messages to self messages when both refer to same method';
 		superSends;
@@ -254,7 +254,7 @@ RBTransformationRuleTest class >> superSends [
 ]
 
 { #category : #transformations }
-RBTransformationRuleTest class >> unwindBlocks [
+RBTransformationRuleTestData class >> unwindBlocks [
 	^self
 		rewrite: #(
 			#('[| `@temps | ``@.Statements. `var := ``@object] ensure: ``@block'
@@ -270,7 +270,7 @@ RBTransformationRuleTest class >> unwindBlocks [
 ]
 
 { #category : #accessing }
-RBTransformationRuleTest >> checkMethod: aSmalllintContext [ 
+RBTransformationRuleTestData >> checkMethod: aSmalllintContext [ 
 	class := aSmalllintContext selectedClass.
 	(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
 			[(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
@@ -281,33 +281,33 @@ RBTransformationRuleTest >> checkMethod: aSmalllintContext [
 ]
 
 { #category : #testing }
-RBTransformationRuleTest >> hasConflicts [
+RBTransformationRuleTestData >> hasConflicts [
 	^true
 ]
 
 { #category : #testing }
-RBTransformationRuleTest >> isEmpty [
+RBTransformationRuleTestData >> isEmpty [
 	^builder changes isEmpty
 ]
 
 { #category : #accessing }
-RBTransformationRuleTest >> problemCount [
+RBTransformationRuleTestData >> problemCount [
 	^builder problemCount
 ]
 
 { #category : #accessing }
-RBTransformationRuleTest >> resetResult [
+RBTransformationRuleTestData >> resetResult [
 	builder := RBRefactoryChangeManager changeFactory compositeRefactoryChange
 ]
 
 { #category : #initialization }
-RBTransformationRuleTest >> rewriteUsing: searchReplacer [ 
+RBTransformationRuleTestData >> rewriteUsing: searchReplacer [ 
 	rewriteRule := searchReplacer.
 	self resetResult
 ]
 
 { #category : #rules }
-RBTransformationRuleTest >> superSends [
+RBTransformationRuleTestData >> superSends [
 	| rule |
 	rule := RBParseTreeRewriter new.
 	rule addSearch: 'super `@message: ``@args'
@@ -321,7 +321,7 @@ RBTransformationRuleTest >> superSends [
 ]
 
 { #category : #private }
-RBTransformationRuleTest >> viewResults [
+RBTransformationRuleTestData >> viewResults [
 	"I reset the result so that we don't fill up memory with methods to compile in the builder."
 
 	builder inspect.

--- a/src/Refactoring-Tests-Core/RBTransformationRuleTestData1.class.st
+++ b/src/Refactoring-Tests-Core/RBTransformationRuleTestData1.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #RBTransformationRuleTestData1,
+	#superclass : #RBFooLintRuleTestData1,
+	#category : #'Refactoring-Tests-Core-Data'
+}

--- a/src/Refactoring-Tests-Core/RBVariableTypeTest.class.st
+++ b/src/Refactoring-Tests-Core/RBVariableTypeTest.class.st
@@ -10,14 +10,14 @@ RBVariableTypeTest >> testBasicLintRuleTypes [
 	typer := RBRefactoryTyper new.
 	types := typer 
 		guessTypesFor: 'classBlock'
-		in: RBBasicLintRuleTest.
+		in: RBBasicLintRuleTestData.
 	"self assert: types size = 1."
 	self assert: ([  ] class withAllSuperclasses 
 			detect: [ :each | types includes: (typer model classFor: each) ]
 			ifNone: [ nil ]) notNil.
 	types := typer 
 		typesFor: 'methodBlock'
-		in: (typer model classFor: RBBasicLintRuleTest).
+		in: (typer model classFor: RBBasicLintRuleTestData).
 	"self should: [types size = 2]."
 	self assert: ([  ] class withAllSuperclasses 
 			detect: [ :each | types includes: (typer model classFor: each) ]
@@ -29,11 +29,11 @@ RBVariableTypeTest >> testBasicLintRuleTypes [
 { #category : #tests }
 RBVariableTypeTest >> testCompositeLintRuleTypes [
 	| typer types |
-	typer := RBRefactoryTyper new runOn: RBCompositeLintRuleTest.
+	typer := RBRefactoryTyper new runOn: RBCompositeLintRuleTestData.
 	types := typer guessTypesFor: 'rules'.
 	self assert: (types includes: (typer model classFor: Collection)).
 	types := typer typesFor: '-rules-'.
-	self assert: (types includes: (typer model classFor: RBLintRuleTest)).
+	self assert: (types includes: (typer model classFor: RBLintRuleTestData)).
 	self assertEmpty: (typer guessTypesFor: 'asdf').
 	typer printString
 ]
@@ -44,7 +44,7 @@ RBVariableTypeTest >> testLintRuleTypes [
 	typer := RBRefactoryTyper new.
 	types := typer 
 		guessTypesFor: 'name'
-		in: RBLintRuleTest.
+		in: RBLintRuleTestData.
 	self assert: types size = 1.
 	self assert: (types includes: (typer model classFor: String))
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddClassTransformationTest.class.st
@@ -54,8 +54,8 @@ RBAddClassTransformationTest >> testInvalidSubclass [
 	self shouldFail: (
 		RBAddClassTransformation
 			addClass: #Foo
-			superclass: #RBCompositeLintRuleTest
-			subclasses: (Array with: RBBasicLintRuleTest)
+			superclass: #RBCompositeLintRuleTestData
+			subclasses: (Array with: RBBasicLintRuleTestData)
 			category: #'Refactory-Tesing')
 			asRefactoring
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddMethodTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddMethodTransformationTest.class.st
@@ -16,7 +16,7 @@ RBAddMethodTransformationTest >> testBadSourceCode [
 
 	self shouldFail: (RBAddMethodTransformation
 							sourceCode: 'asdf ^super ^printString'
-							in: RBBasicLintRuleTest
+							in: RBBasicLintRuleTestData
 							withProtocol: #accessing)
 							asRefactoring
 ]
@@ -27,7 +27,7 @@ RBAddMethodTransformationTest >> testMethodAlreadyExists [
 	self 
 		shouldFail: (RBAddMethodTransformation
 			sourceCode: 'printString ^super printString'
-			in: #RBBasicLintRuleTest
+			in: #RBBasicLintRuleTestData
 			withProtocol: #accessing)
 			asRefactoring;
 		shouldFail: (RBAddMethodTransformation 

--- a/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorTransformationTest.class.st
@@ -39,11 +39,11 @@ RBAddVariableAccessorTransformationTest >> testNonExistantName [
 	self
 		shouldFail: (RBAddVariableAccessorTransformation 
 						classVariable: #Foo
-						class: #RBBasicLintRuleTest)
+						class: #RBBasicLintRuleTestData)
 						asRefactoring;
 		shouldFail: (RBAddVariableAccessorTransformation 
 						instanceVariable: 'foo'
-						class: #RBBasicLintRuleTest)
+						class: #RBBasicLintRuleTestData)
 						asRefactoring
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBAddVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddVariableTransformationTest.class.st
@@ -17,11 +17,11 @@ RBAddVariableTransformationTest >> testAddClassVariable [
 	| refactoring |
 	refactoring := (RBAddVariableTransformation 
 						classVariable: 'Asdf'
-						class: #RBTransformationRuleTest)
+						class: #RBTransformationRuleTestData)
 						asRefactoring transform.
 	
 	self assert: ((refactoring model
-		classNamed: #RBTransformationRuleTest)
+		classNamed: #RBTransformationRuleTestData)
 		directlyDefinesClassVariable: #Asdf)
 ]
 
@@ -31,11 +31,11 @@ RBAddVariableTransformationTest >> testAddInstanceVariable [
 	| refactoring |
 	refactoring := (RBAddVariableTransformation 
 						instanceVariable: 'asdf'
-						class: #RBTransformationRuleTest)
+						class: #RBTransformationRuleTestData)
 						asRefactoring transform.
 		
 	self assert: ((refactoring model
-		classNamed: #RBTransformationRuleTest)
+		classNamed: #RBTransformationRuleTestData)
 		directlyDefinesInstanceVariable: 'asdf')
 ]
 
@@ -45,19 +45,19 @@ RBAddVariableTransformationTest >> testAlreadyExistingName [
 	self
 		shouldFail: (RBAddVariableTransformation 
 						instanceVariable: 'class'
-						class: #RBTransformationRuleTest)
+						class: #RBTransformationRuleTestData)
 						asRefactoring;
 		shouldFail: (RBAddVariableTransformation 
 						instanceVariable: 'name'
-						class: #RBTransformationRuleTest)
+						class: #RBTransformationRuleTestData)
 						asRefactoring;
 		shouldFail: (RBAddVariableTransformation 
 						classVariable: #RecursiveSelfRule
-						class: #RBTransformationRuleTest)
+						class: #RBTransformationRuleTestData)
 						asRefactoring;
 		shouldFail: (RBAddVariableTransformation 
 						classVariable: self objectClassVariable
-						class: #RBTransformationRuleTest)
+						class: #RBTransformationRuleTestData)
 						asRefactoring 
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBBasicDummyLintRuleTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBBasicDummyLintRuleTest.class.st
@@ -625,7 +625,7 @@ RBBasicDummyLintRuleTest class >> modifiesCollection [
 	| detector addSearcher |
 	detector := self new.
 	detector name: 'Modifies collection while iterating over it'.
-	addSearcher := RBBasicLintRuleTest modifiesCollection.
+	addSearcher := RBBasicLintRuleTestData modifiesCollection.
 	detector methodBlock: 
 			[:context :result | 
 			addSearcher executeTree: context parseTree initialAnswer: false.

--- a/src/Refactoring2-Transformations-Tests/RBDummyCompositeLintRuleTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBDummyCompositeLintRuleTest.class.st
@@ -15,10 +15,10 @@ RBDummyCompositeLintRuleTest class >> allRules [
 { #category : #'all checks' }
 RBDummyCompositeLintRuleTest class >> lintChecks [
 	^ self 
-		rules: (RBBasicLintRuleTest protocolsToCheck collect: 
+		rules: (RBBasicLintRuleTestData protocolsToCheck collect: 
 			[ :each | 
 			self 
-				ruleFor: RBBasicLintRuleTest
+				ruleFor: RBBasicLintRuleTestData
 				protocol: each ])
 		name: 'Lint checks'
 ]
@@ -48,7 +48,7 @@ RBDummyCompositeLintRuleTest class >> rules: aCollection name: aString [
 { #category : #'all checks' }
 RBDummyCompositeLintRuleTest class >> transformations [
 	^ self 
-		ruleFor: RBTransformationRuleTest
+		ruleFor: RBTransformationRuleTestData
 		protocol: 'transformations'
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -24,7 +24,7 @@ RBExtractMethodTransformationTest >> testBadInterval [
 							extract: (self sourceCodeAt: (80 to: 147)
 								forMethod: #subclassOf:overrides: in: RBBasicLintRuleTestData class)
 							from: #subclassOf:overrides: to: #bla
-							in: #'RBBasicLintRuleTest class')
+							in: #'RBBasicLintRuleTestData class')
 							asRefactoring
 	
 ]
@@ -36,21 +36,21 @@ RBExtractMethodTransformationTest >> testExtractFailure [
 			extract: (self sourceCodeAt: (80 to: 269)
 						forMethod: #subclassOf:overrides: in: RBBasicLintRuleTestData class)
 			from: #subclassOf:overrides:
-			to: #foo in: #'RBBasicLintRuleTest class')
+			to: #foo in: #'RBBasicLintRuleTestData class')
 			asRefactoring.
 	
 	self shouldFail: (RBExtractMethodTransformation
 			extract: (self sourceCodeAt: (53 to: 56)
 						forMethod: #subclassOf:overrides: in: RBBasicLintRuleTestData class)
 			from: #subclassOf:overrides:
-			to: #foo in: #'RBBasicLintRuleTest class')
+			to: #foo in: #'RBBasicLintRuleTestData class')
 			asRefactoring.
 	
 	self shouldFail: (RBExtractMethodTransformation
 			extract: (self sourceCodeAt: (77 to: 222)
 						forMethod: #subclassResponsibilityNotDefined in: RBBasicLintRuleTestData class)
 			from: #subclassResponsibilityNotDefined
-			to: #foo in: #'RBBasicLintRuleTest class')
+			to: #foo in: #'RBBasicLintRuleTestData class')
 			asRefactoring
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -22,7 +22,7 @@ RBExtractMethodTransformationTest >> testBadInterval [
 				
 	self shouldFail: (RBExtractMethodTransformation
 							extract: (self sourceCodeAt: (80 to: 147)
-								forMethod: #subclassOf:overrides: in: RBBasicLintRuleTest class)
+								forMethod: #subclassOf:overrides: in: RBBasicLintRuleTestData class)
 							from: #subclassOf:overrides: to: #bla
 							in: #'RBBasicLintRuleTest class')
 							asRefactoring
@@ -34,21 +34,21 @@ RBExtractMethodTransformationTest >> testExtractFailure [
 
 	self shouldFail: (RBExtractMethodTransformation
 			extract: (self sourceCodeAt: (80 to: 269)
-						forMethod: #subclassOf:overrides: in: RBBasicLintRuleTest class)
+						forMethod: #subclassOf:overrides: in: RBBasicLintRuleTestData class)
 			from: #subclassOf:overrides:
 			to: #foo in: #'RBBasicLintRuleTest class')
 			asRefactoring.
 	
 	self shouldFail: (RBExtractMethodTransformation
 			extract: (self sourceCodeAt: (53 to: 56)
-						forMethod: #subclassOf:overrides: in: RBBasicLintRuleTest class)
+						forMethod: #subclassOf:overrides: in: RBBasicLintRuleTestData class)
 			from: #subclassOf:overrides:
 			to: #foo in: #'RBBasicLintRuleTest class')
 			asRefactoring.
 	
 	self shouldFail: (RBExtractMethodTransformation
 			extract: (self sourceCodeAt: (77 to: 222)
-						forMethod: #subclassResponsibilityNotDefined in: RBBasicLintRuleTest class)
+						forMethod: #subclassResponsibilityNotDefined in: RBBasicLintRuleTestData class)
 			from: #subclassResponsibilityNotDefined
 			to: #foo in: #'RBBasicLintRuleTest class')
 			asRefactoring
@@ -61,7 +61,7 @@ RBExtractMethodTransformationTest >> testMethodDoesNotExist [
 			extract: 'bla'
 			from: #checkClass1:
 			to: #bla
-			in: #RBBasicLintRuleTest)
+			in: #RBBasicLintRuleTestData)
 			asRefactoring
 ]
 
@@ -102,12 +102,12 @@ RBExtractMethodTransformationTest >> testRefactoring [
 						classified: aSmalllintContext protocols]'
 		from: #checkMethod:
 		to: #foo:
-		in: #RBTransformationRuleTest)
+		in: #RBTransformationRuleTestData)
 		asRefactoring transform.
 		
 	self assert: transformation model changes changes size equals: 2.
 	
-	class := transformation model classNamed: #RBTransformationRuleTest.
+	class := transformation model classNamed: #RBTransformationRuleTestData.
 	self assert: (class parseTreeFor: #checkMethod:) 
 		  equals: (RBParser parseMethod: 'checkMethod: aSmalllintContext 
 			class := aSmalllintContext selectedClass.
@@ -170,15 +170,15 @@ RBExtractMethodTransformationTest >> testWithArgument [
 	| refactoring class |
 	refactoring := (RBExtractMethodTransformation
 		extract: (self sourceCodeAt: (145 to: 343)
-					 forMethod: #checkMethod: in: RBTransformationRuleTest)
+					 forMethod: #checkMethod: in: RBTransformationRuleTestData)
 		from: #checkMethod:
 		to: #foo:
-		in: #RBTransformationRuleTest)
+		in: #RBTransformationRuleTestData)
 		asRefactoring transform.
 		
 	self assert: refactoring model changes changes size equals: 2.
 		
-	class := refactoring model classNamed: #RBTransformationRuleTest.
+	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	self assert: (class parseTreeFor: #checkMethod:) 
 		  equals: (RBParser parseMethod: 'checkMethod: aSmalllintContext 
 					class := aSmalllintContext selectedClass.
@@ -253,14 +253,14 @@ RBExtractMethodTransformationTest >> testWithTemporaryVariable [
 	refactoring := (RBExtractMethodTransformation
 		extract: (self
 			sourceCodeAt: (22 to: 280)
-			forMethod: #superSends in: RBTransformationRuleTest)
+			forMethod: #superSends in: RBTransformationRuleTestData)
 		from: #superSends
-		to: #foo1 in: #RBTransformationRuleTest)
+		to: #foo1 in: #RBTransformationRuleTestData)
 		asRefactoring transform.
 	
 	self assert: refactoring model changes changes size equals: 2.
 	
-	class := refactoring model classNamed: #RBTransformationRuleTest.
+	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	self assert: (class parseTreeFor: #superSends)
 		  equals: (RBParser parseMethod: 'superSends
 				| rule |

--- a/src/Refactoring2-Transformations-Tests/RBMoveInstanceVariableToClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveInstanceVariableToClassTransformationTest.class.st
@@ -11,20 +11,20 @@ RBMoveInstanceVariableToClassTransformationTest >> testRefactoring [
 	refactoring := (RBMoveInstanceVariableToClassTransformation
 						model: model
 						variable: 'methodBlock'
-						fromClass: #RBBasicLintRuleTest
-						toClass: #RBFooLintRuleTest)
+						fromClass: #RBBasicLintRuleTestData
+						toClass: #RBFooLintRuleTestData)
 						asRefactoring.
 				
-	oldClass := refactoring model classNamed: #RBBasicLintRuleTest.
-	newClass := refactoring model classNamed: #RBFooLintRuleTest.
+	oldClass := refactoring model classNamed: #RBBasicLintRuleTestData.
+	newClass := refactoring model classNamed: #RBFooLintRuleTestData.
 	self assert: (oldClass directlyDefinesInstanceVariable: 'methodBlock').
 	self deny: (newClass directlyDefinesInstanceVariable: 'methodBlock').
 	
 	[ refactoring transform ] on: RBRefactoringError do: [ :e | e resume ].
 	self assert: refactoring model changes changes size equals: 2.
 
-	oldClass := refactoring model classNamed: #RBBasicLintRuleTest.
-	newClass := refactoring model classNamed: #RBFooLintRuleTest.
+	oldClass := refactoring model classNamed: #RBBasicLintRuleTestData.
+	newClass := refactoring model classNamed: #RBFooLintRuleTestData.
 	self deny: (oldClass directlyDefinesInstanceVariable: 'methodBlock').
 	self assert: (newClass directlyDefinesInstanceVariable: 'methodBlock').
 	
@@ -68,8 +68,8 @@ RBMoveInstanceVariableToClassTransformationTest >> testVariableAlreadyExists [
 	self shouldFail: (RBMoveInstanceVariableToClassTransformation
 							model: model
 							variable: 'result'
-							fromClass: #RBFooLintRuleTest
-							toClass: #RBBasicLintRuleTest)
+							fromClass: #RBFooLintRuleTestData
+							toClass: #RBBasicLintRuleTestData)
 							asRefactoring
 ]
 
@@ -79,7 +79,7 @@ RBMoveInstanceVariableToClassTransformationTest >> testVariableDoesNotExistInOld
 	self shouldFail: (RBMoveInstanceVariableToClassTransformation
 							model: model
 							variable: 'abc'
-							fromClass: #RBFooLintRuleTest
-							toClass: #RBBasicLintRuleTest)
+							fromClass: #RBFooLintRuleTestData
+							toClass: #RBBasicLintRuleTestData)
 							asRefactoring
 ]

--- a/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
@@ -43,10 +43,10 @@ RBProtectVariableTransformationTest >> testClassVariable [
 	| refactoring class |
 	refactoring := (RBProtectVariableTransformation 
 						classVariable: 'RecursiveSelfRule'
-						class: #RBTransformationRuleTest)
+						class: #RBTransformationRuleTestData)
 						asRefactoring transform.
 	
-	class := (refactoring model classNamed: #RBTransformationRuleTest) theMetaClass.
+	class := (refactoring model classNamed: #RBTransformationRuleTestData) theMetaClass.
 	self assert: (class parseTreeFor: #recursiveSelfRule)
 			equals: (RBParser parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
 	self assert: (class parseTreeFor: #recursiveSelfRule:) 
@@ -60,7 +60,7 @@ RBProtectVariableTransformationTest >> testClassVariable [
 				self recursiveSelfRule
 					addMethodSearches: #(''`@methodName: `@args | `@temps | self `@methodName: `@args'' ''`@methodName: `@args | `@temps | ^self `@methodName: `@args'')
 					-> [:aNode :answer | true]').
-	self assert: ((refactoring model classNamed: #RBTransformationRuleTest) parseTreeFor: #checkMethod:) 
+	self assert: ((refactoring model classNamed: #RBTransformationRuleTestData) parseTreeFor: #checkMethod:) 
 			equals: (RBParser parseMethod: 'checkMethod: aSmalllintContext 
 				class := aSmalllintContext selectedClass.
 				(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
@@ -136,7 +136,7 @@ RBProtectVariableTransformationTest >> testMetaclassFailure [
 
 	self shouldFail: (RBProtectVariableTransformation 
 							classVariable: #RecursiveSelfRule
-							class: RBTransformationRuleTest class)
+							class: RBTransformationRuleTestData class)
 							asRefactoring
 ]
 
@@ -146,10 +146,10 @@ RBProtectVariableTransformationTest >> testRefactoring [
 	| refactoring class |
 	refactoring := (RBProtectVariableTransformation
 						instanceVariable: 'builder'
-						class: #RBTransformationRuleTest)
+						class: #RBTransformationRuleTestData)
 						asRefactoring transform.
 	
-	class := refactoring model classNamed: #RBTransformationRuleTest.
+	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	self assert: (class parseTreeFor: #builder) equals: (RBParser parseMethod: 'builder ^builder').
 	self assert: (class parseTreeFor: #builder:) equals: (RBParser parseMethod: 'builder: anObject
 	builder := anObject').
@@ -174,10 +174,10 @@ RBProtectVariableTransformationTest >> testTransform [
 	| transformation class |
 	transformation := (RBProtectVariableTransformation
 							instanceVariable: 'class'
-							class: #RBTransformationRuleTest)
+							class: #RBTransformationRuleTestData)
 							transform.
 		
-	class := transformation model classNamed: #RBTransformationRuleTest.
+	class := transformation model classNamed: #RBTransformationRuleTestData.
 	self assert: (class directlyDefinesLocalMethod: #class1).
 	self assert: (class directlyDefinesLocalMethod: #class:).
 	
@@ -211,11 +211,11 @@ RBProtectVariableTransformationTest >> testVariableDoesNotExist [
 	self
 		shouldFail: (RBProtectVariableTransformation 
 						instanceVariable: 'foo'
-						class: #RBBasicLintRuleTest)
+						class: #RBBasicLintRuleTestData)
 						asRefactoring;
 		shouldFail: (RBProtectVariableTransformation 
 						classVariable: #Foo
-						class: #RBBasicLintRuleTest)
+						class: #RBBasicLintRuleTestData)
 						asRefactoring
 ]
 
@@ -243,11 +243,11 @@ RBProtectVariableTransformationTest >> testVariableNotDirectlyDefined [
 	self 
 		shouldFail: (RBProtectVariableTransformation 
 						instanceVariable: 'name'
-						class: #RBBasicLintRuleTest)
+						class: #RBBasicLintRuleTestData)
 						asRefactoring;
 		shouldFail: (RBProtectVariableTransformation 
 						classVariable: #DependentsFields
-						class: #RBBasicLintRuleTest)
+						class: #RBBasicLintRuleTestData)
 						asRefactoring;
 		shouldFail: (RBProtectVariableTransformation 
 						model: model

--- a/src/Refactoring2-Transformations-Tests/RBPushDownVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBPushDownVariableTransformationTest.class.st
@@ -288,7 +288,7 @@ RBPushDownVariableTransformationTest >> testVariableDoesNotExist [
 	self
 		shouldFail: (RBPushDownVariableTransformation
 						instanceVariable: 'foo'
-						class: #RBBasicLintRuleTest)
+						class: #RBBasicLintRuleTestData)
 						asRefactoring;
 		shouldFail: (RBPushDownVariableTransformation
 						model: model
@@ -297,6 +297,6 @@ RBPushDownVariableTransformationTest >> testVariableDoesNotExist [
 						asRefactoring;
 		shouldFail: (RBPushDownVariableTransformation 
 						classVariable: #Foo
-						class: #RBBasicLintRuleTest)
+						class: #RBBasicLintRuleTestData)
 						asRefactoring
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveClassTransformationTest.class.st
@@ -41,7 +41,7 @@ RBRemoveClassTransformationTest >> testRemoveClassWithBadName [
 RBRemoveClassTransformationTest >> testRemoveClassWithReferences [
 
 	self shouldFail: (RBRemoveClassTransformation
-							className: #RBBasicLintRuleTest)
+							className: #RBBasicLintRuleTestData)
 							asRefactoring 
 ]
 
@@ -49,7 +49,7 @@ RBRemoveClassTransformationTest >> testRemoveClassWithReferences [
 RBRemoveClassTransformationTest >> testRemoveClassWithSubclasses [
 
 	self shouldFail: (RBRemoveClassTransformation
-							className: #RBFooLintRuleTest1)
+							className: #RBFooLintRuleTestData1)
 							asRefactoring
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
@@ -44,7 +44,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testDoesNotDefineVariable [
 						asRefactoring;
 		shouldFail: (RBRemoveDirectAccessToVariableTransformation 
 						classVariable: 'Foo1'
-						class: #RBFooLintRuleTest)
+						class: #RBFooLintRuleTestData)
 						asRefactoring 
 ]
 
@@ -59,7 +59,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testDoesNotUnderstandAccesso
 						asRefactoring;
 		shouldFail: (RBRemoveDirectAccessToVariableTransformation 
 						classVariable: 'RecursiveSelfRule'
-						class: #RBTransformationRuleTest)
+						class: #RBTransformationRuleTestData)
 						asRefactoring 
 ]
 
@@ -69,11 +69,11 @@ RBRemoveDirectAccessToVariableTransformationTest >> testInheritedName [
 	self
 		shouldFail: (RBRemoveDirectAccessToVariableTransformation 
 						instanceVariable: 'name'
-						class: #RBBasicLintRuleTest)
+						class: #RBBasicLintRuleTestData)
 						asRefactoring;
 		shouldFail: (RBRemoveDirectAccessToVariableTransformation 
 						classVariable: #DependentsFields
-						class: #RBBasicLintRuleTest)
+						class: #RBBasicLintRuleTestData)
 						asRefactoring 
 ]
 
@@ -97,7 +97,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testMetaclassFailure [
 
 	self shouldFail: (RBRemoveDirectAccessToVariableTransformation 
 							classVariable: #RecursiveSelfRule
-							class: RBTransformationRuleTest class)
+							class: RBTransformationRuleTestData class)
 							asRefactoring 
 ]
 
@@ -107,11 +107,11 @@ RBRemoveDirectAccessToVariableTransformationTest >> testNonExistantName [
 	self
 		shouldFail: (RBRemoveDirectAccessToVariableTransformation 
 						instanceVariable: 'foo'
-						class: #RBBasicLintRuleTest)
+						class: #RBBasicLintRuleTestData)
 						asRefactoring;
 		shouldFail: (RBRemoveDirectAccessToVariableTransformation 
 						classVariable: #Foo
-						class: #RBBasicLintRuleTest)
+						class: #RBBasicLintRuleTestData)
 						asRefactoring 
 ]
 
@@ -150,10 +150,10 @@ RBRemoveDirectAccessToVariableTransformationTest >> testTransform [
 	| transformation class |
 	transformation := (RBRemoveDirectAccessToVariableTransformation
 							instanceVariable: 'class'
-							class: #RBTransformationRuleTest)
+							class: #RBTransformationRuleTestData)
 							transform.
 	
-	class := transformation model classNamed: #RBTransformationRuleTest.
+	class := transformation model classNamed: #RBTransformationRuleTestData.
 	self assert: (class parseTreeFor: #superSends)
 		  equals: (RBParser parseMethod: 
 	'superSends

--- a/src/Refactoring2-Transformations-Tests/RBRemoveMethodTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveMethodTransformationTest.class.st
@@ -15,7 +15,7 @@ RBRemoveMethodTransformationTest >> testMethodIsReferenced [
 
 	self shouldFail: (RBRemoveMethodTransformation
 							selector: #checkClass:
-							from: #RBBasicLintRuleTest)
+							from: #RBBasicLintRuleTestData)
 							asRefactoring 
 ]
 
@@ -24,7 +24,7 @@ RBRemoveMethodTransformationTest >> testMethodSendsSuper [
 
 	self shouldFail: (RBRemoveMethodTransformation
 							selector: #new
-							from: RBBasicLintRuleTest class)
+							from: RBBasicLintRuleTestData class)
 							asRefactoring
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBRenameTemporaryVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameTemporaryVariableTransformationTest.class.st
@@ -62,11 +62,11 @@ RBRenameTemporaryVariableTransformationTest >> testRename [
 	| transformation |
 	transformation := (RBRenameTemporaryVariableTransformation 
 							rename: #rules to: #asdf
-							in: #RBLintRuleTest
+							in: #RBLintRuleTestData
 							selector: #openEditor)
 							transform.
 							
-	self assert: ((transformation model classNamed: #RBLintRuleTest) parseTreeFor: #openEditor)
+	self assert: ((transformation model classNamed: #RBLintRuleTestData) parseTreeFor: #openEditor)
 		  equals: (RBParser parseMethod: 'openEditor
 								| asdf |
 								asdf := self failedRules.
@@ -110,6 +110,6 @@ RBRenameTemporaryVariableTransformationTest >> testVariableDoesNotExist [
 	self shouldFail: (RBRenameTemporaryVariableTransformation 
 							rename: #rule
 							to: #name
-							in: #RBLintRuleTest
+							in: #RBLintRuleTestData
 							selector: #openEditor)
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRenameVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameVariableTransformationTest.class.st
@@ -10,11 +10,11 @@ RBRenameVariableTransformationTest >> testClassVariable [
 	| refactoring class |
 	refactoring := (RBRenameVariableTransformation
 						rename: #RecursiveSelfRule to: #RSR
-						in: #RBTransformationRuleTest
+						in: #RBTransformationRuleTestData
 						classVariable: true)
 						asRefactoring transform.
 	
-	class := refactoring model classNamed: #RBTransformationRuleTest.
+	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	self assert: (class directlyDefinesClassVariable: #RSR).
 	self deny: (class directlyDefinesClassVariable: #RecursiveSelfRule).
 	self assert: (class theMetaClass parseTreeFor: #initializeAfterLoad1) 
@@ -41,7 +41,7 @@ RBRenameVariableTransformationTest >> testMetaclassFailure [
 
 	self shouldFail: (RBRenameVariableTransformation
 							rename: #RecursiveSelfRule to: #Foo
-							in: RBTransformationRuleTest class
+							in: RBTransformationRuleTestData class
 							classVariable: true)
 							asRefactoring
 ]
@@ -52,11 +52,11 @@ RBRenameVariableTransformationTest >> testRefactoring [
 	| refactoring class |
 	refactoring := (RBRenameVariableTransformation 
 						rename: 'classBlock' to: 'asdf'
-						in: #RBBasicLintRuleTest
+						in: #RBBasicLintRuleTestData
 						classVariable: false)
 						asRefactoring transform.
 			
-	class := refactoring model classNamed: #RBBasicLintRuleTest.
+	class := refactoring model classNamed: #RBBasicLintRuleTestData.
 	self assert: (class directlyDefinesInstanceVariable: 'asdf').
 	self deny: (class directlyDefinesInstanceVariable: 'classBlock').
 	self assert: (class parseTreeFor: #checkClass:)
@@ -79,11 +79,11 @@ RBRenameVariableTransformationTest >> testTransform [
 	| transformation class |
 	transformation := (RBRenameVariableTransformation
 							rename: 'classBlock' to: 'asdf'
-							in: #RBBasicLintRuleTest
+							in: #RBBasicLintRuleTestData
 							classVariable: false)
 							transform.
 	
-	class := transformation model classNamed: #RBBasicLintRuleTest.
+	class := transformation model classNamed: #RBBasicLintRuleTestData.
 	self assert: (class directlyDefinesInstanceVariable: 'asdf').
 	self deny: (class directlyDefinesInstanceVariable: 'classBlock').
 	self assert: (class parseTreeFor: #checkClass:)
@@ -106,12 +106,12 @@ RBRenameVariableTransformationTest >> testVariableAlreadyExists [
 	self
 		shouldFail: (RBRenameVariableTransformation 
 						rename: 'classBlock' to: 'name'
-						in: #RBBasicLintRuleTest
+						in: #RBBasicLintRuleTestData
 						classVariable: false)
 						asRefactoring;
 		shouldFail: (RBRenameVariableTransformation 
 						rename: #RecursiveSelfRule to: self objectClassVariable
-						in: #RBTransformationRuleTest
+						in: #RBTransformationRuleTestData
 						classVariable: true)
 						asRefactoring
 ]
@@ -122,12 +122,12 @@ RBRenameVariableTransformationTest >> testVariableDoesNotExist [
 	self
 		shouldFail: (RBRenameVariableTransformation 
 						rename: 'foo' to: 'newFoo'
-						in: #RBBasicLintRuleTest
+						in: #RBBasicLintRuleTestData
 						classVariable: false)
 						asRefactoring;
 		shouldFail: (RBRenameVariableTransformation 
 						rename: #foo to: #newFoo
-						in: #RBBasicLintRuleTest
+						in: #RBBasicLintRuleTestData
 						classVariable: true)
 						asRefactoring
 ]


### PR DESCRIPTION
add *Data prefix as *Test makes people want to clean these classes. I added a comment, too.fixes #2751