### PR TITLE
Provide Bag compatibility with asDictionary and don't throw a walkback error

### DIFF
--- a/src/Collections-Tests/BagTest.class.st
+++ b/src/Collections-Tests/BagTest.class.st
@@ -369,6 +369,22 @@ BagTest >> testAsBag [
 ]
 
 { #category : #'basic tests' }
+BagTest >> testAsDictionary [
+
+	| aBag aDictonary |
+	aBag := Bag new.	
+	aBag add:'a' withOccurrences: 4.
+	aBag add:'b' withOccurrences: 2.
+	aDictonary := aBag asDictionary.
+	self assert: aDictonary size equals: 2.
+	self assert: (aDictonary at: 'a') equals: 4.
+	self assert: aBag asDictionary equals: aBag valuesAndCounts.
+	self deny: aBag asDictionary == aBag valuesAndCounts.
+	
+	
+]
+
+{ #category : #'basic tests' }
 BagTest >> testAsSet [
 
 	| aBag aSet |

--- a/src/Collections-Tests/BagTest.class.st
+++ b/src/Collections-Tests/BagTest.class.st
@@ -377,6 +377,7 @@ BagTest >> testAsDictionary [
 	aBag add:'b' withOccurrences: 2.
 	aDictonary := aBag asDictionary.
 	self assert: aDictonary size equals: 2.
+	self assert: (aBag as: Dictionary) equals: aDictonary.
 	self assert: (aDictonary at: 'a') equals: 4.
 	self assert: aBag asDictionary equals: aBag valuesAndCounts.
 	self deny: aBag asDictionary == aBag valuesAndCounts.

--- a/src/Collections-Unordered/Bag.class.st
+++ b/src/Collections-Unordered/Bag.class.st
@@ -89,7 +89,7 @@ Bag >> associationsDo: aBlock [
 	"Evaluate aBlock for each of the receiver's elements (key/value 
 	associations).  Provided for compatibility with Dictionaries"
 
-	self doWithOccurrences: [ :key :occurence | aBlock value: key->occurence ]
+	contents associationsDo: aBlock
 ]
 
 { #category : #accessing }

--- a/src/Collections-Unordered/Bag.class.st
+++ b/src/Collections-Unordered/Bag.class.st
@@ -77,6 +77,13 @@ Bag >> asBag [
 ]
 
 { #category : #converting }
+Bag >> asDictionary [
+	"Answer a Dictionary with values and counts (a copy)"
+ 
+	^self valuesAndCounts copy
+]
+
+{ #category : #converting }
 Bag >> asSet [
 	"Answer a set with the elements of the receiver."
 	"#(1 2 2 3 1 1 1) asBag asSet >>> #(1 2 2 3 1 1 1) asSet"

--- a/src/Collections-Unordered/Bag.class.st
+++ b/src/Collections-Unordered/Bag.class.st
@@ -79,6 +79,7 @@ Bag >> asBag [
 { #category : #converting }
 Bag >> asDictionary [
 	"Answer a Dictionary with values and counts (a copy)"
+	"(Bag newFrom: 'aabbbc') asDictionary >>> { 'a'->2. 'b'->3. 'c'->1 }"
  
 	^self valuesAndCounts copy
 ]

--- a/src/Collections-Unordered/Bag.class.st
+++ b/src/Collections-Unordered/Bag.class.st
@@ -77,19 +77,19 @@ Bag >> asBag [
 ]
 
 { #category : #converting }
-Bag >> asDictionary [
-	"Answer a Dictionary with values and counts (a copy)"
-	"(Bag newFrom: 'aabbbc') asDictionary >>> { 'a'->2. 'b'->3. 'c'->1 }"
- 
-	^self valuesAndCounts copy
-]
-
-{ #category : #converting }
 Bag >> asSet [
 	"Answer a set with the elements of the receiver."
 	"#(1 2 2 3 1 1 1) asBag asSet >>> #(1 2 2 3 1 1 1) asSet"
 	
 	^ contents keys asSet
+]
+
+{ #category : #enumerating }
+Bag >> associationsDo: aBlock [
+	"Evaluate aBlock for each of the receiver's elements (key/value 
+	associations).  Provided for compatibility with Dictionaries"
+
+	self doWithOccurrences: [ :key :occurence | aBlock value: key->occurence ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
There is still some discussion about this on the mailing list - as would you expect the inverse -

 { #foo->2. #bar->3 } asDictionary asBag.

to give a bag the same (currently it gives stats on the values).

This is what I expected to work when I hit this - however could be convinced that asDictionary throws an exception (and tells you about #valuesAndCounts)