### PR TITLE
2766-RubScrolledTextMorphcanDiscardEdits-need-to-use-accessor-as-var-can-be-nil

### DIFF
--- a/src/Rubric/RubScrolledTextMorph.class.st
+++ b/src/Rubric/RubScrolledTextMorph.class.st
@@ -241,7 +241,7 @@ RubScrolledTextMorph >> borderWidth: anInteger [
 
 { #category : #'model protocol' }
 RubScrolledTextMorph >> canDiscardEdits [
-	^ (hasUnacceptedEdits and: [askBeforeDiscardingEdits]) not
+	^ (self hasUnacceptedEdits and: [askBeforeDiscardingEdits]) not
 
 ]
 


### PR DESCRIPTION
use accessor
fixes #2766