### PR TITLE
2777-classbuilder-copyClassSlotsFromExistingClass-needs-to-be-done-by-the-classInstaller-by-default

### DIFF
--- a/src/GT-Debugger/GTSpecPreDebugWindow.class.st
+++ b/src/GT-Debugger/GTSpecPreDebugWindow.class.st
@@ -191,14 +191,15 @@ GTSpecPreDebugWindow >> initializePresenter [
 
 { #category : #'initialization widgets' }
 GTSpecPreDebugWindow >> initializeStackPane [
+	
 	self stackPane
 		displayBlock: [ :aContext | self columnsFor: aContext ];
-		items: self filteredStack;
-		whenSelectionChangedDo: [ :selection | 
-			[ :aContext | 
+		items: self filteredStack ;
+		whenSelectedItemChanged: [ :aContext | 
 			"Set the selection before, as debugAction removes the link with the debugger. "
 			self debugger stackPresentation selection: aContext.
-			self openFullDebugger ] cull: selection selectedItem ]
+			self openFullDebugger ]
+		
 ]
 
 { #category : #accessing }

--- a/src/GT-Debugger/GTSpecPreDebugWindow.class.st
+++ b/src/GT-Debugger/GTSpecPreDebugWindow.class.st
@@ -191,15 +191,14 @@ GTSpecPreDebugWindow >> initializePresenter [
 
 { #category : #'initialization widgets' }
 GTSpecPreDebugWindow >> initializeStackPane [
-	
 	self stackPane
 		displayBlock: [ :aContext | self columnsFor: aContext ];
-		items: self filteredStack ;
-		whenSelectedItemChanged: [ :aContext | 
+		items: self filteredStack;
+		whenSelectionChangedDo: [ :selection | 
+			[ :aContext | 
 			"Set the selection before, as debugAction removes the link with the debugger. "
 			self debugger stackPresentation selection: aContext.
-			self openFullDebugger ]
-		
+			self openFullDebugger ] cull: selection selectedItem ]
 ]
 
 { #category : #accessing }

--- a/src/Hermes/HEInstaller.class.st
+++ b/src/Hermes/HEInstaller.class.st
@@ -70,8 +70,7 @@ HEInstaller >> build: aHEClass [
 		sharedVariables:  (self asClassVariables:aHEClass classVariables);
 		sharedPools: aHEClass sharedPools;
 		category: aHEClass category;
-		classSlots: (self asSlots: aHEClass classInstancevariables);
-		copyClassSlotsFromExistingClass ].
+		classSlots: (self asSlots: aHEClass classInstancevariables) ].
 	
 	self processTraitsFrom: aHEClass in: newClass.
 	

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -612,8 +612,7 @@ Class >> ephemeronSubclass: t instanceVariableNames: f
 			sharedVariablesFromString: d;
 			sharedPools: s;
 			category: cat;
-			environment: self environment;
-			copyClassSlotsFromExistingClass ].
+			environment: self environment ].
 ]
 
 { #category : #private }
@@ -703,8 +702,7 @@ Class >> immediateSubclass: t instanceVariableNames: f classVariableNames: d poo
 			sharedVariablesFromString: d;
 			sharedPools: s;
 			category: cat;
-			environment: self environment;
-			copyClassSlotsFromExistingClass ].
+			environment: self environment ].
 ]
 
 { #category : #compiling }
@@ -1137,8 +1135,7 @@ Class >> subclass: t instanceVariableNames: f classVariableNames: d poolDictiona
 				sharedVariablesFromString: d;
 				sharedPools: s;
 				category: cat;
-				environment: self environment;
-				copyClassSlotsFromExistingClass ]
+				environment: self environment ]
 ]
 
 { #category : #'subclass creation - slots' }
@@ -1161,8 +1158,7 @@ Class >> subclass: aSubclassSymbol  layout: layoutClass slots: slotDefinition cl
 		layoutClass: layoutClass;
 		slots: slotDefinition;
 		sharedVariables: classVarDefinition;
-		category: aCategorySymbol;
-		copyClassSlotsFromExistingClass ].
+		category: aCategorySymbol ].
 
 ]
 
@@ -1183,8 +1179,7 @@ Class >> subclass: aSubclassSymbol  layout: layoutClass  slots: slotDefinition c
 		slots: slotDefinition;
 		sharedVariables:  classVarDefinition;
 		sharedPools: someSharedPoolNames;
-		category: aCategorySymbol;
-		copyClassSlotsFromExistingClass ].
+		category: aCategorySymbol ].
 
 ]
 
@@ -1207,8 +1202,7 @@ Class >> subclass: aSubclassSymbol slots: slotDefinition classVariables: classVa
 				superclass: self;
 				slots: slotDefinition;
 				sharedVariables: classVarDefinition;
-				category: aCategorySymbol;
-				copyClassSlotsFromExistingClass ]
+				category: aCategorySymbol ]
 ]
 
 { #category : #'subclass creation - slots' }
@@ -1227,8 +1221,7 @@ Class >> subclass: aSubclassSymbol slots: slotDefinition classVariables: classVa
 		slots: slotDefinition;
 		sharedVariables:  classVarDefinition;
 		sharedPools: someSharedPoolNames;
-		category: aCategorySymbol;
-		copyClassSlotsFromExistingClass ]
+		category: aCategorySymbol ]
 ]
 
 { #category : #'accessing class hierarchy' }
@@ -1330,8 +1323,7 @@ Class >> variableByteSubclass: t instanceVariableNames: f
 			sharedVariablesFromString: d;
 			sharedPools: s;
 			category: cat;
-			environment: self  environment;
-			copyClassSlotsFromExistingClass ].
+			environment: self  environment ].
 ]
 
 { #category : #'subclass creation - variable' }
@@ -1366,8 +1358,7 @@ Class >> variableSubclass: t instanceVariableNames: f classVariableNames: d pool
 			sharedVariablesFromString: d;
 			sharedPools: s;
 			category: cat;
-			environment: self environment;
-			copyClassSlotsFromExistingClass ].
+			environment: self environment ].
 ]
 
 { #category : #'subclass creation - variable' }
@@ -1428,8 +1419,7 @@ Class >> variableWordSubclass: t instanceVariableNames: f
 			sharedVariablesFromString: d;
 			sharedPools: s;
 			category: cat;
-			environment: self environment;
-			copyClassSlotsFromExistingClass ].
+			environment: self environment ].
 ]
 
 { #category : #'subclass creation - weak' }
@@ -1470,8 +1460,7 @@ Class >> weakSubclass: t instanceVariableNames: f
 			sharedVariablesFromString: d;
 			sharedPools: s;
 			category: cat;
-			environment: self environment;
-			copyClassSlotsFromExistingClass ].
+			environment: self environment ].
 ]
 
 { #category : #'subclass creation - weak' }

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -268,8 +268,7 @@ MCClassDefinition >> createClass [
 				classTraitComposition: self classTraitCompositionCompiled;
 				comment: comment stamp: commentStamp;
 				category: category;
-				environment: superClass environment;
-				copyClassSlotsFromExistingClass ] ]
+				environment: superClass environment ] ]
 		on: Warning , DuplicatedVariableError
 		do: [ :ex | ex resume ]
 ]

--- a/src/SUnit-Core/ClassFactoryWithOrganization.class.st
+++ b/src/SUnit-Core/ClassFactoryWithOrganization.class.st
@@ -51,8 +51,7 @@ ClassFactoryWithOrganization >> newClassNamed: aString subclassOf: aClass instan
 				sharedVariablesFromString: classVarsString;
 				sharedPools: '';
 				category: category asSymbol;
-				environment: self organization environment;
-				copyClassSlotsFromExistingClass ].
+				environment: self organization environment ].
 	self createdClasses add: newClass.
 	^ newClass
 ]
@@ -79,8 +78,7 @@ ClassFactoryWithOrganization >> newSubclassOf: aClass instanceVariableNames: ivN
 				sharedVariablesFromString: classVarsString;
 				sharedPools: '';
 				category: category asSymbol;
-				environment: self organization environment;
-				copyClassSlotsFromExistingClass ].
+				environment: self organization environment ].
 	self createdClasses add: newClass.
 	^ newClass
 ]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -191,19 +191,6 @@ ShiftClassBuilder >> compileMethods [
 
 ]
 
-{ #category : #copying }
-ShiftClassBuilder >> copyClassSlotsFromExistingClass [
-	"Ugly helper method: I copy over the class slots of the class in my builder environment."
-
-	| anOldClass oldSlots |
-	
-	anOldClass := self environment at: name ifAbsent: [ ^ self ].
-	oldSlots := anOldClass class classLayout slotScope visibleSlots.
-	
-	self layoutDefinition copyClassSlotsIfNeeded: oldSlots
-
-]
-
 { #category : #building }
 ShiftClassBuilder >> copyOrganization [
 	newClass organization copyFrom: oldClass organization.
@@ -302,7 +289,6 @@ ShiftClassBuilder >> fillFor: aClass [
 		sharedPools: aClass sharedPoolsString;
 		category: aClass category;
 		environment: aClass environment;
-		copyClassSlotsFromExistingClass;
 		oldClass: aClass.
 		
 	self builderEnhancer fillBuilder: self from: aClass.

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -26,8 +26,7 @@ ShClassInstallerTest >> newClass: className superclass: aSuperclass slots: slots
 				slots: slots;
 				sharedVariables: '';
 				sharedPools: '';
-				category: 'Shift-ClassInstaller-Tests';
-				copyClassSlotsFromExistingClass ]
+				category: 'Shift-ClassInstaller-Tests' ]
 ]
 
 { #category : #running }
@@ -123,8 +122,7 @@ ShClassInstallerTest >> testClassWithComment [
 				sharedPools: '';
 				category: 'Shift-ClassInstaller-Tests';
 				comment: 'I have a comment'; 
-				commentStamp: 'anStamp';				
-				copyClassSlotsFromExistingClass ].
+				commentStamp: 'anStamp' ].
 	
 	self assert: newClass comment equals: 'I have a comment'.
 	self assert: newClass organization commentStamp equals: 'anStamp'.

--- a/src/Shift-ClassInstaller/Class.extension.st
+++ b/src/Shift-ClassInstaller/Class.extension.st
@@ -13,8 +13,7 @@ Class >> addClassSlot: aSlot [
 			sharedVariablesFromString: self classVariablesString;
 			sharedPools: self sharedPoolsString;
 			category: self category;
-			environment: self environment;
-			copyClassSlotsFromExistingClass ]
+			environment: self environment ]
 ]
 
 { #category : #'*Shift-ClassInstaller' }

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -69,7 +69,6 @@ ShiftClassInstaller >> comment: newClass [
 
 { #category : #building }
 ShiftClassInstaller >> copyClassSlotsFromExistingClass [
-	oldClass class ifNil: [ ^self ]. "happens in the boostrap"
 	self builder layoutDefinition copyClassSlotsIfNeeded: oldClass class slots
 ]
 

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -69,9 +69,7 @@ ShiftClassInstaller >> comment: newClass [
 
 { #category : #building }
 ShiftClassInstaller >> copyClassSlotsFromExistingClass [
-	| oldSlots |
-	oldSlots := oldClass class classLayout slotScope visibleSlots.
-	self builder layoutDefinition copyClassSlotsIfNeeded: oldSlots
+	self builder layoutDefinition copyClassSlotsIfNeeded: oldClass class slots
 ]
 
 { #category : #copying }

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -69,10 +69,8 @@ ShiftClassInstaller >> comment: newClass [
 
 { #category : #building }
 ShiftClassInstaller >> copyClassSlotsFromExistingClass [
-	| anOldClass oldSlots |
-	builder name ifNil: [ ^ self ].
-	anOldClass := self installingEnvironment classNamed: builder name.
-	oldSlots := anOldClass class classLayout slotScope visibleSlots.
+	| oldSlots |
+	oldSlots := oldClass class classLayout slotScope visibleSlots.
 	self builder layoutDefinition copyClassSlotsIfNeeded: oldSlots
 ]
 

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -67,6 +67,15 @@ ShiftClassInstaller >> comment: newClass [
 	builder comment ifNotNil: [ newClass classComment: builder comment stamp: builder commentStamp ]
 ]
 
+{ #category : #building }
+ShiftClassInstaller >> copyClassSlotsFromExistingClass [
+	| anOldClass oldSlots |
+	builder name ifNil: [ ^ self ].
+	anOldClass := self installingEnvironment classNamed: builder name.
+	oldSlots := anOldClass class classLayout slotScope visibleSlots.
+	self builder layoutDefinition copyClassSlotsIfNeeded: oldSlots
+]
+
 { #category : #copying }
 ShiftClassInstaller >> copyObject: oldObject to: newClass [
 	| newObject |
@@ -151,6 +160,9 @@ ShiftClassInstaller >> make: aBlock [
 
 	[	
 		builder oldClass: oldClass.
+		
+		self copyClassSlotsFromExistingClass.
+		
 		newClass := builder build.
 
 		self validateReadOnlyInstancesOf: oldClass.

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -69,6 +69,7 @@ ShiftClassInstaller >> comment: newClass [
 
 { #category : #building }
 ShiftClassInstaller >> copyClassSlotsFromExistingClass [
+	oldClass class ifNil: [ ^self ]. "happens in the boostrap"
 	self builder layoutDefinition copyClassSlotsIfNeeded: oldClass class slots
 ]
 

--- a/src/Slot-Core/Behavior.extension.st
+++ b/src/Slot-Core/Behavior.extension.st
@@ -5,6 +5,7 @@ Behavior >> classLayout [
 	^ layout
 		ifNil: [ 
 			| superLayout scope |
+			superclass ifNil: [ ^ EmptyLayout instance ].
 			superLayout := superclass classLayout.
 			scope := superLayout slotScope extend.
 			layout := superLayout class extending: superLayout scope: scope host: self ]

--- a/src/Slot-Core/Behavior.extension.st
+++ b/src/Slot-Core/Behavior.extension.st
@@ -6,7 +6,7 @@ Behavior >> classLayout [
 		ifNil: [ 
 			| superLayout scope |
 			superLayout := superclass 
-				ifNil: [ FixedLayout new ] "happend in the bootrap"
+				ifNil: [ FixedLayout new slotScope: LayoutEmptyScope instance] "happend in the bootrap"
 				ifNotNil: [:sl | sl classLayout].
 			scope := superLayout slotScope extend.
 			layout := superLayout class extending: superLayout scope: scope host: self ]

--- a/src/Slot-Core/Behavior.extension.st
+++ b/src/Slot-Core/Behavior.extension.st
@@ -6,7 +6,7 @@ Behavior >> classLayout [
 		ifNil: [ 
 			| superLayout scope |
 			superLayout := superclass 
-				ifNil: [ EmptyLayout instance ]
+				ifNil: [ FixedLayout new ] "happend in the bootrap"
 				ifNotNil: [:sl | sl classLayout].
 			scope := superLayout slotScope extend.
 			layout := superLayout class extending: superLayout scope: scope host: self ]

--- a/src/Slot-Core/Behavior.extension.st
+++ b/src/Slot-Core/Behavior.extension.st
@@ -5,8 +5,9 @@ Behavior >> classLayout [
 	^ layout
 		ifNil: [ 
 			| superLayout scope |
-			superclass ifNil: [ ^ EmptyLayout instance ].
-			superLayout := superclass classLayout.
+			superLayout := superclass 
+				ifNil: [ EmptyLayout instance ]
+				ifNotNil: [:sl | sl classLayout].
 			scope := superLayout slotScope extend.
 			layout := superLayout class extending: superLayout scope: scope host: self ]
 ]

--- a/src/Slot-Tests/SlotClassVariableTest.class.st
+++ b/src/Slot-Tests/SlotClassVariableTest.class.st
@@ -62,8 +62,7 @@ SlotClassVariableTest >> testSlotIsPersistedAfterRebuildOfClass [
 	class1 := self make: [ :builder | 
 		builder
 			name: self aClassName;
-			superclass: Object;
-			copyClassSlotsFromExistingClass ].
+			superclass: Object ].
 
 	self assert: class1 class slots size equals: 1.
 	self assert: (class1 class slots at:1) name equals: #Foo.

--- a/src/TraitsV2/Class.extension.st
+++ b/src/TraitsV2/Class.extension.st
@@ -138,8 +138,7 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 				sharedPools: somePoolDictionaries;
 				traitComposition: aTraitComposition asTraitComposition;
 				classTraitComposition: aTraitComposition asTraitComposition classComposition;
-				category: aCategory;
-				copyClassSlotsFromExistingClass ]
+				category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
@@ -156,8 +155,7 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 				sharedPools: somePoolDictionaries;
 				traitComposition: aTraitComposition asTraitComposition;
 				classTraitComposition: aTraitComposition asTraitComposition classComposition;
-				category: aCategory;
-				copyClassSlotsFromExistingClass ]
+				category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
@@ -174,8 +172,7 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 				sharedPools: somePoolDictionaries;
 				traitComposition: aTraitComposition asTraitComposition;
 				classTraitComposition: aTraitComposition asTraitComposition classComposition;
-				category: aCategory;
-				copyClassSlotsFromExistingClass ]
+				category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
@@ -192,8 +189,7 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 				sharedPools: somePoolDictionaries;
 				traitComposition: aTraitComposition asTraitComposition;
 				classTraitComposition: aTraitComposition asTraitComposition classComposition;
-				category: aCategory;
-				copyClassSlotsFromExistingClass ]
+				category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }

--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -92,8 +92,7 @@ Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots
 				category: aCategory;
 				traitComposition: aTraitCompositionOrCollection asTraitComposition;
 				classTraitComposition: aTraitCompositionOrCollection asTraitComposition classComposition;
-				classSlots: #();
-				copyClassSlotsFromExistingClass ].
+				classSlots: #() ].
 			
 	self assert: [ trait class class = MetaclassForTraits ].
 	self assert: [ trait class superclass = Trait ].


### PR DESCRIPTION
move copyClassSlotsFromExistingClass to the classbuilder. remove lots of calls outside.

fixes #2777