### PR TITLE
Fix comment on OSWindow >> startTextInput

### DIFF
--- a/src/OSWindow-Core/OSWindow.class.st
+++ b/src/OSWindow-Core/OSWindow.class.st
@@ -375,7 +375,7 @@ OSWindow >> startTextInput [
 	"Start accepting Unicode text input events.
 	I will start accepting Unicode text input events in the focused window, and start emitting text input and text editing events.
 	Please use me in pair with stopTextInput.
-	On some platforms using I may activates the screen keyboard."
+	On some platforms I may activate the screen keyboard."
 
 	self validHandle startTextInput
 ]


### PR DESCRIPTION
I noticed a small problem in the comment on OSWindow's startTextInput method. I updated the comment to something I think should make it a little bit more clear.

I read the contributing guidelines but I'm still not certain I submitted this sort of change quite correctly. Specifically, I am not quite sure what the current development branch is.

If there's anything I can do on this or future PRs to make reviewing it is easier for the maintainers, please let me know.

Thanks much!