### PR TITLE
Adds a new exception for a missing class error (ClassNotUnderstood) and…

### DIFF
--- a/src/DebuggerActions/DoesNotUnderstandDebugAction.class.st
+++ b/src/DebuggerActions/DoesNotUnderstandDebugAction.class.st
@@ -51,22 +51,14 @@ DoesNotUnderstandDebugAction >> closeWindow [
 ]
 
 { #category : #private }
-DoesNotUnderstandDebugAction >> createMissingClassIn: aContext [
-	| senderContext variableNode previousContext errorMsgNode |
-	
-	variableNode := nil.
-	
-	[ senderContext := aContext sender.
-	errorMsgNode := senderContext method sourceNodeExecutedForPC: senderContext pc.
-	variableNode := self findUndeclaredVariableIn: errorMsgNode ]
-		on: Error
-		do: [ ^self ].
+DoesNotUnderstandDebugAction >> createMissingClassWith: variableNode in: aContext [
+	|  previousContext  |
 		
 	OCUndeclaredVariableWarning new
 		node: variableNode;
 		defineClass: variableNode name.
 		
-	previousContext := aContext stack second.
+	previousContext := aContext sender.
 	
 	self closeWindow.
 	
@@ -91,11 +83,13 @@ DoesNotUnderstandDebugAction >> executeAction [
 	MessageNotUnderstood exception. Create a stub for the method that was
 	missing and proceed into it, or create a class if it was missing instead"
 	
-	| msg msgCategory chosenClass |
+	| msg msgCategory chosenClass exception |
 	
 	msg := self interruptedContext tempAt: 1.
-	(msg lookupClass == UndefinedObject ) ifTrue: [ 
-		self createMissingClassIn: self interruptedContext ].
+	exception := self interruptedContext tempAt: 2.
+	
+	(exception class == ClassNotUnderstood) ifTrue: [ 
+		self createMissingClassWith: exception variableNode in: self interruptedContext ].
 	
 	chosenClass := self 
 		askForSuperclassOf: self interruptedContext receiver class
@@ -108,14 +102,6 @@ DoesNotUnderstandDebugAction >> executeAction [
 		inClass: chosenClass 
 		forContext: self interruptedContext.
 	self debugger selectTopContext
-]
-
-{ #category : #private }
-DoesNotUnderstandDebugAction >> findUndeclaredVariableIn: errorMsgNode [
-	^ errorMsgNode allChildren
-		detect: [ :n | n isVariable and: [ n isUndeclared ] ]
-		ifNone: [ errorMsgNode parent allChildren
-				detect: [ :n | n isVariable and: [ n isUndeclared ] ] ]
 ]
 
 { #category : #accessing }

--- a/src/Kernel-Tests/UndefinedObjectTest.class.st
+++ b/src/Kernel-Tests/UndefinedObjectTest.class.st
@@ -21,6 +21,22 @@ UndefinedObjectTest >> testDeepCopy [
 	self assert: nil deepCopy isNil
 ]
 
+{ #category : #test }
+UndefinedObjectTest >> testFindUndeclaredVariableIn [
+
+	
+	| ast missingClass |
+	
+	missingClass := #MissingTestClass.
+	ast := RBParser parseExpression: missingClass, ' new'.
+	
+	ast receiver binding: OCUndeclaredVariable new.
+	self assert: (nil findUndeclaredVariableIn: ast) name equals: missingClass.
+	
+	ast receiver binding: OCLiteralVariable new.
+	self assert: (nil findUndeclaredVariableIn: ast) equals: nil
+]
+
 { #category : #'tests - testing' }
 UndefinedObjectTest >> testHaltIfNil [
 	<haltOrBreakpointForTesting>

--- a/src/Kernel/ClassNotUnderstood.class.st
+++ b/src/Kernel/ClassNotUnderstood.class.st
@@ -1,0 +1,35 @@
+"
+This exception is provided to support doesNotUnderstand: on missing classes (Undeclared variables)
+"
+Class {
+	#name : #ClassNotUnderstood,
+	#superclass : #MessageNotUnderstood,
+	#instVars : [
+		'variableNode'
+	],
+	#category : #'Kernel-Exceptions'
+}
+
+{ #category : #accessing }
+ClassNotUnderstood >> classSymbol [
+	^ self variableNode name
+]
+
+{ #category : #accessing }
+ClassNotUnderstood >> smartDescription [
+	
+	message ifNil: [^self description].
+
+	^self classSymbol printString
+		, ' is missing, and does not understand ', message selector printString
+]
+
+{ #category : #accessing }
+ClassNotUnderstood >> variableNode [
+	^ variableNode
+]
+
+{ #category : #accessing }
+ClassNotUnderstood >> variableNode: anObject [
+	variableNode := anObject
+]

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -77,11 +77,46 @@ UndefinedObject >> deepCopy [
 	with self."
 ]
 
+{ #category : #'reflective operations' }
+UndefinedObject >> doesNotUnderstand: aMessage [
+	<debuggerCompleteToSender>
+	"Handle the fact that there was an attempt to send the given message to an Undeclared variable (nil), hence the receiver does not understand this message (typically #new)."
+	"Testing: (3 activeProcess)"
+
+	| exception resumeValue node |
+	
+	(node := self findUndeclaredVariableIn: thisContext sender sourceNodeExecuted) ifNil: [ 
+		 ^super doesNotUnderstand: aMessage ].
+				
+	(exception := ClassNotUnderstood new)
+			message: aMessage;
+			variableNode: node;
+			receiver: self.
+			
+	resumeValue := exception signal.
+	^ exception reachedDefaultHandler
+			ifTrue: [ aMessage sentTo: self ]
+			ifFalse: [ resumeValue ] .
+			
+	
+]
+
 { #category : #'class hierarchy' }
 UndefinedObject >> environment [
 	"Necessary to support disjoint class hierarchies."
 
 	^self class environment
+]
+
+{ #category : #'reflective operations' }
+UndefinedObject >> findUndeclaredVariableIn: ast [
+	"Walk the ast of the current statment and find the undeclared variable node, or nil (if none).
+	Assumes there is only one such variable in an executing statement"
+	
+	ast nodesDo: [:node |
+		(node isVariable and: [ node isUndeclared]) ifTrue: [ ^node ]].
+
+	^nil
 ]
 
 { #category : #testing }


### PR DESCRIPTION
… handles this in the debugger

This finishes the work that was done in Pharo 6 to support creating a missing class in the debugger. However in fixing #2776 to show a better message, a better solution came about by properly signalling a new ClassNotUnderstood exception, and then using that in the pre debugger to create the class (this latter part seems much cleaner).

I have tested this manually (but written a unit test for the detection of the missing variable node) as this is tricky to automate. You need to save a method with a MissingClass and choose the new save as undeclared menu item. Then executing the method will trigger the code in this change (and let you create a new class in the debugger).

Some questions for the reviewer:

1. Is the message I am using (generated by ClassNoUnderstood) a good one; e.g. the title bar now shows something like: #MissingClassYouEncountered is missing, and does not understand #new
1. #doesNotUnderstand has been overriden in UndefinedObject to support this behaviour (I think this is the cleanest way to do this), but is it safe to do this (I think so) - and is there a better way to not repeat the #dnu signalling code (copied from object and changed to use a different class. I was wondering if that signalling code should be extracted to a new method in object so it can be called from subclasses - but then I'm nervous adding new methods to Object?
