### PR TITLE
2803-parseErrorNode-should-fill-value-for-the-case-of-expecting-a-

### DIFF
--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -438,12 +438,15 @@ RBParser >> parseCascadeMessage [
 
 { #category : #'error handling' }
 RBParser >> parseErrorNode: aMessageString [
-	| sourceString |
-	currentToken isError 
+	| sourceString errorPosition |
+	currentToken isError
 		ifTrue: [ ^ RBParseErrorNode errorMessage: currentToken cause value: currentToken value at: currentToken start ].
-	sourceString := source copyFrom: self errorPosition to: source size.
-	^ RBParseErrorNode
-		errorMessage: aMessageString value: sourceString at: self errorPosition
+	errorPosition := self errorPosition.
+	"the error at the end means in some cases that the start of the error is before"
+	aMessageString = ''')'' expected'
+		ifTrue: [ errorPosition := source findLastOccurrenceOfString: '(' startingAt: 1 ].
+	sourceString := source copyFrom: errorPosition to: source size.
+	^ RBParseErrorNode errorMessage: aMessageString value: sourceString at: self errorPosition
 ]
 
 { #category : #accessing }

--- a/src/AST-Tests-Core/RBFormatterTest.class.st
+++ b/src/AST-Tests-Core/RBFormatterTest.class.st
@@ -84,6 +84,16 @@ RBFormatterTest >> testParseError [
 ]
 
 { #category : #testing }
+RBFormatterTest >> testParseError2 [
+	| inputSource errorNode |
+	"parse error nodes should have the faulty code"
+	inputSource := '( 1 + 2'.
+   errorNode := RBParser parseFaultyExpression: inputSource.
+	self assert: errorNode source equals: errorNode formattedCode
+
+]
+
+{ #category : #testing }
 RBFormatterTest >> testPreserveLiteralArrayFormat [
 	| inputSource literalArrayNode |
 	"symbols within a literal array can omit the # character, if it is used that way,


### PR DESCRIPTION
fixes #2803