### PR TITLE
2806-test-and-fix-for-PropertySlot-remove-propertySlot-when-instances-are-present

### DIFF
--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -74,15 +74,22 @@ ShiftClassInstaller >> copyClassSlotsFromExistingClass [
 
 { #category : #copying }
 ShiftClassInstaller >> copyObject: oldObject to: newClass [
-	| newObject |
+	| newObject hiddenSlots |
 	
 	newObject := newClass isVariable
 		ifTrue: [ newClass basicNew: oldObject size ]
 		ifFalse: [ newClass basicNew ].
 
+	"first initalize all hidden slots"
+	hiddenSlots := newClass classLayout allSlots reject: [:each | each isVisible].
+	hiddenSlots do: [ :newSlot | oldObject class slotNamed: newSlot name ifFound: [ :oldSlot | 
+			newSlot initialize: newObject.
+			newSlot write: (oldSlot read: oldObject) to: newObject ]  ].
+
+	"the initalize all visible slots"
 	newClass allSlots do: [ :newSlot | oldObject class slotNamed: newSlot name ifFound: [ :oldSlot | 
 			newSlot initialize: newObject.
-			newSlot write: (oldSlot read: oldObject) to: newObject ] ].
+		   newSlot write: (oldSlot read: oldObject) to: newObject ] ].
 
 	newClass isVariable
 		ifTrue: [ 1 to: oldObject basicSize do: [ :offset | newObject basicAt: offset put: (oldObject basicAt: offset) ] ].

--- a/src/Slot-Tests/PropertySlotTest.class.st
+++ b/src/Slot-Tests/PropertySlotTest.class.st
@@ -143,6 +143,36 @@ PropertySlotTest >> testRemovePropertySlot2 [
 ]
 
 { #category : #tests }
+PropertySlotTest >> testRemovePropertySlotWithInstance [
+	"add two property slots, remove one"
+	
+	| propertySlot1 propertySlot2 instance |
+	
+	propertySlot1 := #prop1 => PropertySlot.
+	propertySlot2 := #prop2 => PropertySlot.
+	
+	aClass := self make: [ :builder |
+		builder 
+			slots: {propertySlot1 . propertySlot2 }
+		].
+
+	instance := aClass new.
+
+	propertySlot1 write: 41 to: instance.
+	propertySlot2 write: 42 to: instance.
+
+	self assert: (propertySlot1 read: instance) equals: 41.
+	self assert: (propertySlot2 read: instance) equals: 42.
+
+	aClass removeSlot: propertySlot1.
+	
+	self assert:	(aClass hasSlot: propertySlot2).
+	self deny: 	(aClass hasSlot: propertySlot1).
+	
+	
+]
+
+{ #category : #tests }
 PropertySlotTest >> testWhichSelectorsAccessFindSlots [
 	| cls |
 	cls := Object newAnonymousSubclass.


### PR DESCRIPTION
add test and fix that allows removal of propertyslots when instances are present.