### PR TITLE
2824-unify-and-cleanup-compactAll-OrderedCollection

### DIFF
--- a/src/Collections-Abstract/HashedCollection.class.st
+++ b/src/Collections-Abstract/HashedCollection.class.st
@@ -35,14 +35,14 @@ HashedCollection class >> cleanUp: aggressive [
 
 ]
 
-{ #category : #initialization }
+{ #category : #cleanup }
 HashedCollection class >> compactAll [
-	"HashedCollection rehashAll"	
+	"HashedCollection compactAll"	
 		
 	self allSubclassesDo: #compactAllInstances
 ]
 
-{ #category : #initialization }
+{ #category : #cleanup }
 HashedCollection class >> compactAllInstances [
 	"Do not use #allInstancesDo: because rehash may create new instances."
 	
@@ -75,14 +75,14 @@ HashedCollection class >> newFrom: aCollection [
 	^self subclassResponsibility
 ]
 
-{ #category : #initialization }
+{ #category : #cleanup }
 HashedCollection class >> rehashAll [
 	"HashedCollection rehashAll"	
 		
 	self allSubclassesDo: #rehashAllInstances
 ]
 
-{ #category : #initialization }
+{ #category : #cleanup }
 HashedCollection class >> rehashAllInstances [
 	"Do not use #allInstancesDo: because rehash may create new instances."
 	

--- a/src/Collections-Sequenceable/OrderedCollection.class.st
+++ b/src/Collections-Sequenceable/OrderedCollection.class.st
@@ -87,7 +87,21 @@ OrderedCollection class >> arrayType [
 	^ Array
 ]
 
-{ #category : #initialization }
+{ #category : #cleanup }
+OrderedCollection class >> cleanUp: aggressive [
+	"Rehash all instances when cleaning aggressively"
+
+	aggressive ifTrue: [self compactAll].
+]
+
+{ #category : #cleanup }
+OrderedCollection class >> compactAll [
+	"OrderedCollection compactAll"	
+		
+	self allSubclassesDo: #compactAllInstances
+]
+
+{ #category : #cleanup }
 OrderedCollection class >> compactAllInstances [
 	self allInstances do: #compact
 ]

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -635,13 +635,6 @@ Behavior >> compiledMethodAt: selector ifPresent: anotherBlock ifAbsent: aBlock 
 	^ self methodDict at: selector ifPresent: anotherBlock ifAbsent: aBlock
 ]
 
-{ #category : #'accessing method dictionary' }
-Behavior >> compress [
-	"Compact the method dictionary of the receiver."
-
-	self methodDict rehash
-]
-
 { #category : #queries }
 Behavior >> copiedFromSuperclass: method [
 	"Returns the methods that the receiver copied with its ancestors"

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -82,7 +82,6 @@ ImageCleaner >> cleanUpForRelease [
 
 	Author fullName: 'MrCleaner'.
 	self cleanUpMethods.
-	OrderedCollection compactAllInstances.
 	self class environment at: #MetacelloProjectRegistration ifPresent: [ :class | class resetRegistry ].
 	SystemNavigation new
 		allObjectsDo: [ :each | 
@@ -100,7 +99,7 @@ ImageCleaner >> cleanUpForRelease [
 		cleanOutUndeclared; 
 		fixObsoleteReferences;
 		cleanUp: true except: #() confirming: false.	
-
+	HashedCollection rehashAll.		
 	Author reset
 ]
 


### PR DESCRIPTION
OrderedCollection had #compactInstances: add #compactAll and call it in cleanUp: just like HashedCollection
remove Behaviour >>compress (not called, can be called manually if needed (methodDict rehash_
#cleanUpForRelease
-- remove explicit call to #compactInstances, as this is now done with the #cleanup
-- add a final #rehash of all HashedCollections at the end