### PR TITLE
2829-RPackagepackageManifestOrNil-should-be-directly-in-RPackage-Core

### DIFF
--- a/src/Manifest-Core/RPackage.extension.st
+++ b/src/Manifest-Core/RPackage.extension.st
@@ -39,10 +39,3 @@ RPackage >> packageManifest [
 		detect: [ :each | each isManifest ]
 		ifNone: [ TheManifestBuilder new createManifestNamed: name]
 ]
-
-{ #category : #'*Manifest-Core' }
-RPackage >> packageManifestOrNil [
-	^ self definedClasses
-		detect: [ :each | each isManifest ]
-		ifNone: [ nil ]
-]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1119,6 +1119,13 @@ RPackage >> organizer [
 ]
 
 { #category : #accessing }
+RPackage >> packageManifestOrNil [
+	^ self definedClasses
+		detect: [ :each | each isManifest ]
+		ifNone: [ nil ]
+]
+
+{ #category : #accessing }
 RPackage >> packageName [
 
 	^ name


### PR DESCRIPTION
move ownership of packageManifestOrNilfixes #2829