### PR TITLE
2858-GRVariableAssignedLiteralRule-raises-exception-on-slots-not-inherited-from-IndexedSlot

### DIFF
--- a/src/GeneralRules/GRVariableAssignedLiteralRule.class.st
+++ b/src/GeneralRules/GRVariableAssignedLiteralRule.class.st
@@ -31,7 +31,7 @@ GRVariableAssignedLiteralRule >> check: aSlot of: aClass forCritiquesDo: aCritic
 
 	aClass withAllSubclassesDo: [ :class |
 		class methods do: [ :method |
-			(method writesField: aSlot index) ifTrue: [ 
+			(method writesSlot: aSlot) ifTrue: [ 
 				theMethod
 					ifNotNil: [ ^ self ]
 					ifNil: [theMethod := method ] ] ] ].


### PR DESCRIPTION
GRVariableAssignedLiteralRule raises exception on slots not inherited from IndexedSlot
- use #writeSlot:

fixes #2858