### PR TITLE
UndefinedObject should not implement at:put: (or inherit it). This is…

### DIFF
--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -50,6 +50,11 @@ UndefinedObject >> asSetElement [
 	^ SetElement withNil
 ]
 
+{ #category : #accessing }
+UndefinedObject >> at: index put: anObject [ 
+	self shouldNotImplement 
+]
+
 { #category : #'bottom context' }
 UndefinedObject >> canHandleSignal: exception [
 	"When no more handler (on:do:) context left in sender chain this gets called"


### PR DESCRIPTION
… the minimal fix

Lots of discussion on the ML about this - but no real decisions. The bare minimum is that nil should throw an error, but a future fix could be to remove at:put: from object.

fixes #2795