### PR TITLE
2879-removeInstVarNamed-on-MetaClass-needs-to-use-removeSlot-like-the-implementation-on-Class

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -940,13 +940,6 @@ Class >> removeFromSystemUnlogged [
 	^self removeFromSystem: false
 ]
 
-{ #category : #'instance variables' }
-Class >> removeInstVarNamed: aString [ 
-	"Remove the argument, aString, as one of the receiver's instance variables."
-
-	^self removeSlot: (self slotNamed: aString)
-]
-
 { #category : #'pool variables' }
 Class >> removeSharedPool: aDictionary [ 
 	"Remove the pool dictionary, aDictionary, as one of the receiver's pool 

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -1023,10 +1023,9 @@ ClassDescription >> reformatAll [
 
 { #category : #'instance variables' }
 ClassDescription >> removeInstVarNamed: aString [ 
-	"Remove the argument, aString, as one of the receiver's instance 
-	variables. Create an error notification if the argument is not found."
+	"Remove the argument, aString, as one of the receiver's instance variables."
 
-	^self subclassResponsibility
+	^self removeSlot: (self slotNamed: aString)
 ]
 
 { #category : #'accessing tags' }

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -258,19 +258,6 @@ Metaclass >> postCopy [
 ]
 
 { #category : #'instance variables' }
-Metaclass >> removeInstVarNamed: aString [ 
-	"Remove the argument, aString, as one of the receiver's instance variables."
-
-	| newArray newString |
-	(self instVarNames includes: aString)
-		ifFalse: [self error: aString , ' is not one of my instance variables'].
-	newArray := self instVarNames copyWithout: aString.
-	newString := ''.
-	newArray do: [:aString2 | newString := aString2 , ' ' , newString].
-	self instanceVariableNames: newString
-]
-
-{ #category : #'instance variables' }
 Metaclass >> removeSlot: aClassSlot [
 
 	^self instanceSide removeClassSlot: aClassSlot


### PR DESCRIPTION
fixes #2879