### PR TITLE
2776-Hitting-an-undefined-class-gives-a-debugger-with-misleading-message-new-was-sent-to-nil-2

### DIFF
--- a/src/DebuggerActions/DoesNotUnderstandDebugAction.class.st
+++ b/src/DebuggerActions/DoesNotUnderstandDebugAction.class.st
@@ -51,22 +51,14 @@ DoesNotUnderstandDebugAction >> closeWindow [
 ]
 
 { #category : #private }
-DoesNotUnderstandDebugAction >> createMissingClassIn: aContext [
-	| senderContext variableNode previousContext errorMsgNode |
-	
-	variableNode := nil.
-	
-	[ senderContext := aContext sender.
-	errorMsgNode := senderContext method sourceNodeExecutedForPC: senderContext pc.
-	variableNode := self findUndeclaredVariableIn: errorMsgNode ]
-		on: Error
-		do: [ ^self ].
+DoesNotUnderstandDebugAction >> createMissingClassWith: variableNode in: aContext [
+	|  previousContext  |
 		
 	OCUndeclaredVariableWarning new
 		node: variableNode;
 		defineClass: variableNode name.
 		
-	previousContext := aContext stack second.
+	previousContext := aContext sender.
 	
 	self closeWindow.
 	
@@ -91,11 +83,13 @@ DoesNotUnderstandDebugAction >> executeAction [
 	MessageNotUnderstood exception. Create a stub for the method that was
 	missing and proceed into it, or create a class if it was missing instead"
 	
-	| msg msgCategory chosenClass |
+	| msg msgCategory chosenClass exception |
 	
 	msg := self interruptedContext tempAt: 1.
-	(msg lookupClass == UndefinedObject ) ifTrue: [ 
-		self createMissingClassIn: self interruptedContext ].
+	exception := self interruptedContext tempAt: 2.
+	
+	(exception class == VariableNotDeclared) ifTrue: [ 
+		self createMissingClassWith: exception variableNode in: self interruptedContext ].
 	
 	chosenClass := self 
 		askForSuperclassOf: self interruptedContext receiver class
@@ -108,14 +102,6 @@ DoesNotUnderstandDebugAction >> executeAction [
 		inClass: chosenClass 
 		forContext: self interruptedContext.
 	self debugger selectTopContext
-]
-
-{ #category : #private }
-DoesNotUnderstandDebugAction >> findUndeclaredVariableIn: errorMsgNode [
-	^ errorMsgNode allChildren
-		detect: [ :n | n isVariable and: [ n isUndeclared ] ]
-		ifNone: [ errorMsgNode parent allChildren
-				detect: [ :n | n isVariable and: [ n isUndeclared ] ] ]
 ]
 
 { #category : #accessing }

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -77,11 +77,46 @@ UndefinedObject >> deepCopy [
 	with self."
 ]
 
+{ #category : #'reflective operations' }
+UndefinedObject >> doesNotUnderstand: aMessage [
+	<debuggerCompleteToSender>
+	"Handle the fact that there was an attempt to send the given message to an Undeclared variable (nil), hence the receiver does not understand this message (typically #new)."
+	"Testing: (3 activeProcess)"
+
+	| exception resumeValue node |
+	
+	(node := self findUndeclaredVariableIn: thisContext sender sourceNodeExecuted) ifNil: [ 
+		 ^super doesNotUnderstand: aMessage ].
+				
+	(exception := VariableNotDeclared new)
+			message: aMessage;
+			variableNode: node;
+			receiver: self.
+			
+	resumeValue := exception signal.
+	^ exception reachedDefaultHandler
+			ifTrue: [ aMessage sentTo: self ]
+			ifFalse: [ resumeValue ] .
+			
+	
+]
+
 { #category : #'class hierarchy' }
 UndefinedObject >> environment [
 	"Necessary to support disjoint class hierarchies."
 
 	^self class environment
+]
+
+{ #category : #'reflective operations' }
+UndefinedObject >> findUndeclaredVariableIn: ast [
+	"Walk the ast of the current statment and find the undeclared variable node, or nil (if none).
+	Assumes there is only one such variable in an executing statement"
+	
+	ast nodesDo: [:node |
+		(node isVariable and: [ node isUndeclared]) ifTrue: [ ^node ]].
+
+	^nil
 ]
 
 { #category : #testing }

--- a/src/Kernel/VariableNotDeclared.class.st
+++ b/src/Kernel/VariableNotDeclared.class.st
@@ -1,0 +1,35 @@
+"
+This exception is provided to support doesNotUnderstand: on missing classes (Undeclared variables)
+"
+Class {
+	#name : #VariableNotDeclared,
+	#superclass : #MessageNotUnderstood,
+	#instVars : [
+		'variableNode'
+	],
+	#category : #'Kernel-Exceptions'
+}
+
+{ #category : #accessing }
+VariableNotDeclared >> classSymbol [
+	^ self variableNode name
+]
+
+{ #category : #accessing }
+VariableNotDeclared >> smartDescription [
+	
+	message ifNil: [^self description].
+
+	^self classSymbol printString
+		, ' is missing, and does not understand ', message selector printString
+]
+
+{ #category : #accessing }
+VariableNotDeclared >> variableNode [
+	^ variableNode
+]
+
+{ #category : #accessing }
+VariableNotDeclared >> variableNode: anObject [
+	variableNode := anObject
+]


### PR DESCRIPTION
This re-applies the fix, which re-works what was done in Pharo 6 to let the debugger create a missing class, the code is cleaner and crucially it gives a better title in the debugger that you've hit a missing Class/Variable.

see: https://github.com/pharo-project/pharo/pull/2783

This applies the feedback from @guillep to use a better name for the exception raised to identify a missing variable/class that the debugger can then detec.