### PR TITLE
2901-ClassBuilder-fillFor-should-not-use-classVariablesString

### DIFF
--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -285,7 +285,7 @@ ShiftClassBuilder >> fillFor: aClass [
 		name: aClass getName;
 		layoutClass: aClass classLayout class;
 		slots: aClass localSlots ;
-		sharedVariablesFromString: aClass classVariablesString;
+		sharedVariables: aClass classVariables;
 		sharedPools: aClass sharedPoolsString;
 		category: aClass category;
 		environment: aClass environment;


### PR DESCRIPTION
fixes #2901