### PR TITLE
2918-accessesSlot: should use #isAccessedIn: method

### DIFF
--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -357,6 +357,11 @@ RBProgramNode >> hashForCollection: aCollection [
 ]
 
 { #category : #querying }
+RBProgramNode >> instanceVariableNodes [
+		^self variableNodes select: [:each | each isInstance]
+]
+
+{ #category : #querying }
 RBProgramNode >> instanceVariableReadNodes [
 		^self variableReadNodes select: [:each | each isInstance]
 ]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -1382,9 +1382,8 @@ ClassDescription >> whichSelectorsAccess: instVarName [
 	| slot |
 	(self hasSlotNamed: instVarName) ifFalse: [ ^#() ].
 	slot := self slotNamed: instVarName.
-	^ self selectors select:  [:sel | | method |
-		method := self compiledMethodAt: sel.
-		(method readsSlot: slot) or: [method writesSlot: slot]]
+	^ self selectors select:  [:sel |
+		slot isAccessedIn: (self compiledMethodAt: sel)]
 ]
 
 { #category : #queries }
@@ -1400,8 +1399,8 @@ ClassDescription >> whichSelectorsRead: aString [
 	| slot |
 	(self hasSlotNamed: aString) ifFalse: [ ^#() ].
 	slot := self slotNamed: aString.
-	^ self selectors select: [ :each |
-		(self compiledMethodAt: each) readsSlot: slot ]
+	^ self selectors select:  [:sel |
+		slot isReadIn: (self compiledMethodAt: sel)]
 ]
 
 { #category : #queries }
@@ -1411,7 +1410,8 @@ ClassDescription >> whichSelectorsStoreInto: instVarName [
 	| slot |
 	(self hasSlotNamed: instVarName) ifFalse: [ ^#() ].
 	slot := self slotNamed: instVarName.
-	^ self selectors select: [:sel | (self compiledMethodAt: sel) writesSlot: slot]
+	^ self selectors select:  [:sel |
+		slot isWrittenIn: (self compiledMethodAt: sel)]
 
 	"Point whichSelectorsStoreInto: 'x'."
 ]

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -73,12 +73,7 @@ CompiledCode >> = aCompiledMethod [
 
 { #category : #scanning }
 CompiledCode >> accessesSlot: aSlot [
-	self ast nodesDo: [ :node | 
-		node isVariable and: [
-			node isInstance and: [ 
-				(node binding slot ==  aSlot)
-					 ifTrue: [^true]]]]. 
-	^false
+	^aSlot isAccessedIn: self
 	
 ]
 

--- a/src/Slot-Core/InstanceVariableSlot.class.st
+++ b/src/Slot-Core/InstanceVariableSlot.class.st
@@ -54,6 +54,11 @@ InstanceVariableSlot >> emitValue: methodBuilder [
 ]
 
 { #category : #testing }
+InstanceVariableSlot >> isAccessedIn: aCompiledCode [
+	^(aCompiledCode readsField: index) or: [aCompiledCode writesField: index]
+]
+
+{ #category : #testing }
 InstanceVariableSlot >> isReadIn: aCompiledCode [
 	^aCompiledCode readsField: index
 ]

--- a/src/Slot-Core/Slot.class.st
+++ b/src/Slot-Core/Slot.class.st
@@ -217,6 +217,12 @@ Slot >> installingIn: aClass [
 ]
 
 { #category : #testing }
+Slot >> isAccessedIn: aCompiledCode [
+	^aCompiledCode ast instanceVariableNodes
+		anySatisfy: [ :node | node binding slot == self ]
+]
+
+{ #category : #testing }
 Slot >> isGlobal [
 	^false
 ]


### PR DESCRIPTION
fixes #2918

continue the changes from #2880

add #isAccessedIn: for Slot (with fast version for instance vars)
use in accessesSlot:
use in whichSelectorsAccess:
whichSelectorsRead: and whichSelectorsStoreInto: changed to call the tests on the slot
Now we need to unify with the isReferencedIn: that is used on Globals and in Calypso