### PR TITLE
2690-22595-Median-is-not-calculated-correctly-for-even-sizes

### DIFF
--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -937,6 +937,9 @@ Collection >> isSequenceable [
 
 { #category : #'math functions' }
 Collection >> median [
+	"Return the middle element, or as close as we can get."
+	"{1 . 2 . 3 . 4 . 5} median >>> 3"
+	
 	^ self asSortedCollection median
 ]
 

--- a/src/Collections-Sequenceable/SortedCollection.class.st
+++ b/src/Collections-Sequenceable/SortedCollection.class.st
@@ -235,7 +235,12 @@ SortedCollection >> median [
 	"Return the middle element, or as close as we can get."
 	"{1 . 2 . 3 . 4 . 5} asSortedCollection  median >>> 3"
 	
-	^ self at: self size + 1 // 2
+	| size middle |
+ 	size := self size.
+ 	middle := (size + 1) // 2.
+ 	^ size even
+			ifTrue: [ ((self at: middle) + (self at: middle + 1)) / 2 ]
+			ifFalse: [ self at: middle ]
 ]
 
 { #category : #private }

--- a/src/Collections-Sequenceable/SortedCollection.class.st
+++ b/src/Collections-Sequenceable/SortedCollection.class.st
@@ -233,7 +233,8 @@ SortedCollection >> join: aCollection [
 { #category : #'math functions' }
 SortedCollection >> median [
 	"Return the middle element, or as close as we can get."
-
+	"{1 . 2 . 3 . 4 . 5} asSortedCollection  median >>> 3"
+	
 	^ self at: self size + 1 // 2
 ]
 

--- a/src/Collections-Tests/SortedCollectionTest.class.st
+++ b/src/Collections-Tests/SortedCollectionTest.class.st
@@ -719,11 +719,21 @@ SortedCollectionTest >> testLastIndexOfStartingAt [
 ]
 
 { #category : #'tests - basic' }
-SortedCollectionTest >> testMedian [
+SortedCollectionTest >> testMedianForEvenSizeCollection [
 	
 	|aSortedCollection|
-	aSortedCollection := (1 to: 10) asSortedCollection.
-	self assert: aSortedCollection median equals: 5.
+	aSortedCollection := {1 .2 . 3 . 4 . 5 . 6 } asSortedCollection.
+	self assert: aSortedCollection median equals: 3.5
+	
+	
+]
+
+{ #category : #'tests - basic' }
+SortedCollectionTest >> testMedianForOddSizeCollection [
+	
+	|aSortedCollection|
+	aSortedCollection := {1 .2 . 3 . 4 . 5 . 6 .7} asSortedCollection.
+	self assert: aSortedCollection median equals: 4.
 	
 	aSortedCollection := SortedCollection new.
 	aSortedCollection 
@@ -733,6 +743,14 @@ SortedCollectionTest >> testMedian [
 
 	self assert: aSortedCollection median equals: 'porcinet'
 	
+]
+
+{ #category : #'tests - basic' }
+SortedCollectionTest >> testMedianWithNumbers [
+
+	| aSortedCollection |
+	aSortedCollection := (1 to: 10) asSortedCollection.
+ 	self assert: aSortedCollection median equals: 5.5
 ]
 
 { #category : #'tests - basic' }


### PR DESCRIPTION
Fix: #2690 Added some tests. Changed logic about testing if elements are integer. We can only compute a mean on objects that can be added.