### PR TITLE
2972-MailAddressTokenizer-doesnt-handle-non-ascii-characters

### DIFF
--- a/src/Network-Mail/MailAddressTokenizer.class.st
+++ b/src/Network-Mail/MailAddressTokenizer.class.st
@@ -44,6 +44,8 @@ MailAddressTokenizer class >> initialize [
 	atomChars addAll: ($a to: $z).
 	atomChars addAll: ($0 to: $9).
 	atomChars addAll: '!#$%&''*+-/=?^_`{|}~'.
+	"RFC 6531 allows characters with value > 127 encoded as UTF-8, which means values between 128 and 255 may appear as part of atoms."
+	atomChars addAll: ((Character value: 128) to: (Character value: 255)).
 
 	CSNonAtom :=  atomChars complement.
 ]
@@ -62,6 +64,31 @@ MailAddressTokenizer >> atEnd [
 { #category : #tokenizing }
 MailAddressTokenizer >> atEndOfChars [
 	^pos > text size
+]
+
+{ #category : #tokenizing }
+MailAddressTokenizer >> indexOfNextNonAtomIn: aString startingAt: startIndex ifAbsent: absentBlock [
+	"Answer the index of the next non-atom character after startIndex in aString.
+	If not found, answer absentBlock value"
+
+	| index indexChar stringSize |
+
+	stringSize := aString size.
+	"First try the primitive (which only handles code points < 256)"
+	index := aString indexOfAnyOf: CSNonAtom startingAt: startIndex ifAbsent: absentBlock.
+	(index > stringSize or: [ (aString at: index) codePoint < 256 ]) ifTrue: 
+		[ ^index ].
+
+	"#indexOfAnyOf:startingAt:ifAbsent: has stopped at a character with a code point above 255.
+	Manually step forward until we find a non-atom character or the end of the string"
+	indexChar := aString at: index.
+	[ index <= stringSize and: 
+		[ (CSNonAtom includes: indexChar) not or: 
+		[ indexChar codePoint > 255 ] ] ] whileTrue:
+			[ index := index + 1.
+			index <= stringSize ifTrue:
+				[ indexChar := aString at: index ] ].
+	^index
 ]
 
 { #category : #initialization }
@@ -83,7 +110,7 @@ MailAddressTokenizer >> next [
 MailAddressTokenizer >> nextAtom [
 	| start end |
 	start := pos.
-	pos := text indexOfAnyOf: CSNonAtom startingAt: start ifAbsent: [ text size + 1].
+	pos := self indexOfNextNonAtomIn: text startingAt: start ifAbsent: [ text size + 1].
 	end := pos - 1.
 	^MailAddressToken
 		type: #Atom

--- a/src/Network-Tests/MailAddressTokenizerTest.class.st
+++ b/src/Network-Tests/MailAddressTokenizerTest.class.st
@@ -1,0 +1,83 @@
+Class {
+	#name : #MailAddressTokenizerTest,
+	#superclass : #TestCase,
+	#category : #'Network-Tests-Mail'
+}
+
+{ #category : #tests }
+MailAddressTokenizerTest >> testTokensInAscii [
+	"Basic test that the tokenizer returns the correct values"
+
+	| tokens tokensCollection |
+
+	tokens := MailAddressTokenizer tokensIn: 'first last <person@company.com>'.
+	tokensCollection := tokens collect: [ :each |
+		each type -> each text ] as: Array.
+	self 
+		assert: tokensCollection
+		equals: {#Atom->'first'. #Atom->'last'. $<->'<'. #Atom->'person'. $@->'@'. #Atom->'company'. $.->'.'. #Atom->'com'. $>->'>'}.
+]
+
+{ #category : #tests }
+MailAddressTokenizerTest >> testTokensInLatin [
+	"RFC6531 (February 2012) allows character values > 127.
+	Check that the parser handles values between 128 and 255 (which can be correctly represented with single byte encoding)"
+
+	| email tokens tokensCollection |
+
+	email := 'first last <person@company.com>'.
+	email
+		at: 2 put: 237 asCharacter;
+		at: 14 put: 233 asCharacter.
+	tokens := MailAddressTokenizer tokensIn: email.
+	tokensCollection := tokens collect: [ :each |
+		each type -> each text ] as: Array.
+	self 
+		assert: tokensCollection
+		equals: {
+			#Atom->('first'
+				at: 2 put: 237 asCharacter;
+				yourself). 
+			#Atom->'last'. 
+			$<->'<'. 
+			#Atom->('person'
+				at: 2 put: 233 asCharacter;
+				yourself). 
+			$@->'@'. 
+			#Atom->'company'. 
+			$.->'.'. 
+			#Atom->'com'. 
+			$>->'>'}.
+]
+
+{ #category : #tests }
+MailAddressTokenizerTest >> testTokensInUnicode [
+	"RFC6531 (February 2012) allows character values > 127.
+	Check that the parser handles values greater than 255 (which require multi-byte encoding)"
+
+	| email tokens tokensCollection |
+
+	email := 'first last <person@company.com>'.
+	email
+		at: 3 put: 345 asCharacter;
+		at: 15 put: 345 asCharacter.
+	tokens := MailAddressTokenizer tokensIn: email.
+	tokensCollection := tokens collect: [ :each |
+		each type -> each text ] as: Array.
+	self 
+		assert: tokensCollection
+		equals: {
+			#Atom->('first'
+				at: 3 put: 345 asCharacter;
+				yourself). 
+			#Atom->'last'. 
+			$<->'<'. 
+			#Atom->('person'
+				at: 3 put: 345 asCharacter;
+				yourself). 
+			$@->'@'. 
+			#Atom->'company'. 
+			$.->'.'. 
+			#Atom->'com'. 
+			$>->'>'}.
+]


### PR DESCRIPTION
RFC 6531 allows mail addresses to include characters outside the normal ascii character set.

Extend MailAddressTokenizer to handle these characters (codePoint > 127) and add automated tests.

Thanks to Levente Uzonyi for identifying the issue, appropriate RFC and changes to CSNonAtom in Squeak.

Fixes: #2972