### PR TITLE
feature/sunit-test-pragma

### DIFF
--- a/src/Ring-Deprecated-Core-Kernel/RGMethodDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGMethodDefinition.class.st
@@ -446,7 +446,7 @@ RGMethodDefinition >> isTestMethod [
 		ifFalse: [ ^ false ].
 	selectorString := self selector asString.
 	"unary selectors starting with 'should' are supposed to be treated as test methods too"
-	((selectorString beginsWith: 'test') or: [ selectorString beginsWith: 'should' ])
+	(((selectorString beginsWith: 'test') or: [ selectorString beginsWith: 'should' ]) or: [ (self pragmaAt: #test) isNotNil ])
 		ifFalse: [ ^ false ].
 	"Is the receiver a TestCase test method?"
 	self methodClass isTestCase

--- a/src/SUnit-Core/CompiledMethod.extension.st
+++ b/src/SUnit-Core/CompiledMethod.extension.st
@@ -30,7 +30,7 @@ CompiledMethod >> isTestMethod [
 	self numArgs isZero
 		ifFalse: [ ^ false ].
 	"unary selectors starting with 'should' are supposed to be treated as test methods too"
-	((self selector beginsWith: 'test') or: [ self selector beginsWith: 'should' ])
+	(((self selector beginsWith: 'test') or: [ self selector beginsWith: 'should' ]) or: [(self pragmaAt: #test) isNotNil ])
 		ifFalse: [ ^ false ].
 	"Is the receiver a TestCase test method?"
 	self methodClass isTestCase

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -551,7 +551,9 @@ TestCase class >> sunitVersion [
 
 { #category : #accessing }
 TestCase class >> testSelectors [
-	^(self selectors select: [ :each | (each beginsWith: 'test') and: [each numArgs isZero]])
+	^self selectors select: [ :each |
+		each numArgs isZero and: [
+			(each beginsWith: 'test') or: [ (self >> each pragmaAt: #test) isNotNil ]]]
 ]
 
 { #category : #dependencies }

--- a/src/SUnit-Tests/SUnitTest.class.st
+++ b/src/SUnit-Tests/SUnitTest.class.st
@@ -645,3 +645,9 @@ SUnitTest >> testWithExceptionDo [
 		]
 			
 ]
+
+{ #category : #testing }
+SUnitTest >> this_is_a_test [
+	<test>
+	self assert: true
+]


### PR DESCRIPTION
Allow to mark a test with a pragma

Make it possible to mark a test with a pragma and get it treated as test. This allows to name a test as "selector_state_expectedOutcome" as proposed  in some style guides.