### PR TITLE
Adding <debuggerCompleteToSender> pragma to some assert methods so th…

### DIFF
--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -365,6 +365,7 @@ Object >> asString [
 Object >> assert: aBlock [
 	"Throw an assertion error if aBlock does not evaluates to true.
 	We check for true explicitly to make the assertion fail for non booleans"
+	<debuggerCompleteToSender>
 	self assert: aBlock description: 'Assertion failed'.
 ]
 

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -75,6 +75,7 @@ TestAsserter >> assert: actualNumber closeTo: expectedNumber [
 { #category : #asserting }
 TestAsserter >> assert: aBooleanOrBlock description: aStringOrBlock [
 	"Take a second argument wich is a message string that describes the reason for the failure, this string will be displayed by the Test Runner"
+	<debuggerCompleteToSender>
 
 	aBooleanOrBlock value
 		ifFalse: [ | aString |


### PR DESCRIPTION
…at the debugger opens directly on the failing test method when a test fails.

Fixes #3006 