### PR TITLE
3013-RegressionDropListMorph-content-is-now-selectable

### DIFF
--- a/src/Polymorph-Widgets/DropListMorph.class.st
+++ b/src/Polymorph-Widgets/DropListMorph.class.st
@@ -557,6 +557,7 @@ DropListMorph >> newContentMorph [
 		vResizing: #shrinkWrap;
 		hResizing: #spaceFill;
 		beReadOnly;
+		lock;
 		yourself
 		
 		


### PR DESCRIPTION
DropListMorph text area should be locked so it is not selectable. 

Fixes #3013