### PR TITLE
3023-Some-cleanups-in-Slots

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -1379,11 +1379,12 @@ ClassDescription >> whichSelectorsAccess: instVarName [
 	"Answer a set of selectors whose methods access the argument, 
 	instVarName, as a named instance variable."
 
-	| slot |
-	(self hasSlotNamed: instVarName) ifFalse: [ ^#() ].
-	slot := self slotNamed: instVarName.
-	^ self selectors select:  [:sel |
-		slot isAccessedIn: (self compiledMethodAt: sel)]
+	^self
+		slotNamed: instVarName
+		ifFound: [ :slot | 
+			self selectors
+				select: [ :sel | slot isAccessedIn: self>>sel ] ]
+		ifNone: [  #() ]
 ]
 
 { #category : #queries }
@@ -1396,26 +1397,27 @@ ClassDescription >> whichSelectorsAssign: instVarName [
 ]
 
 { #category : #queries }
-ClassDescription >> whichSelectorsRead: aString [
-	
-	| slot |
-	(self hasSlotNamed: aString) ifFalse: [ ^#() ].
-	slot := self slotNamed: aString.
-	^ self selectors select:  [:sel |
-		slot isReadIn: (self compiledMethodAt: sel)]
+ClassDescription >> whichSelectorsRead: instVarName [
+	"Answer a Set of selectors whose methods read the argument, 
+	instVarName, as a named instance variable."
+
+	^ self
+		slotNamed: instVarName
+		ifFound:
+			[ :slot | self selectors select: [ :sel | slot isReadIn: self >> sel ] ]
+		ifNone: [ #() ]
 ]
 
 { #category : #queries }
-ClassDescription >> whichSelectorsStoreInto: instVarName [ 
+ClassDescription >> whichSelectorsStoreInto: instVarName [
 	"Answer a Set of selectors whose methods access the argument, 
 	instVarName, as a named instance variable."
-	| slot |
-	(self hasSlotNamed: instVarName) ifFalse: [ ^#() ].
-	slot := self slotNamed: instVarName.
-	^ self selectors select:  [:sel |
-		slot isWrittenIn: (self compiledMethodAt: sel)]
 
-	"Point whichSelectorsStoreInto: 'x'."
+	^ self
+		slotNamed: instVarName
+		ifFound:
+			[ :slot | self selectors select: [ :sel | slot isWrittenIn: self >> sel ] ]
+		ifNone: [ #() ]
 ]
 
 { #category : #organization }

--- a/src/Slot-Core/AbstractLayout.class.st
+++ b/src/Slot-Core/AbstractLayout.class.st
@@ -133,6 +133,11 @@ AbstractLayout >> resolveSlot: aName [
 	self error: 'No slots found'
 ]
 
+{ #category : #api }
+AbstractLayout >> resolveSlot: aName ifFound: foundBlock ifNone: exceptionBlock [
+	^exceptionBlock value
+]
+
 { #category : #accessing }
 AbstractLayout >> slotScope [
 	^ LayoutEmptyScope instance

--- a/src/Slot-Core/BitsLayout.class.st
+++ b/src/Slot-Core/BitsLayout.class.st
@@ -63,10 +63,6 @@ BitsLayout >> extendWord [
 		signal
 ]
 
-{ #category : #initialization }
-BitsLayout >> initializeInstance: anInstance [
-]
-
 { #category : #testing }
 BitsLayout >> isBits [
 	^ true

--- a/src/Slot-Core/ObjectLayout.class.st
+++ b/src/Slot-Core/ObjectLayout.class.st
@@ -145,7 +145,7 @@ ObjectLayout >> initialize [
 
 { #category : #initialization }
 ObjectLayout >> initializeInstance: anInstance [
-	self subclassResponsibility
+	"do nothing by default, overriden by PointerLayout"
 ]
 
 { #category : #format }

--- a/src/Slot-Core/Slot.class.st
+++ b/src/Slot-Core/Slot.class.st
@@ -365,11 +365,6 @@ Slot >> removeProperty: propName ifAbsent: aBlock [
 	^ property
 ]
 
-{ #category : #'class building' }
-Slot >> removingFrom: aClass [
-	"I am called by the class builder. This way a Slot can change the class it is installed in"
-]
-
 { #category : #accessing }
 Slot >> scope: aScope [
 	"ignored, subclasses can override to analyze the scope they are to be installed in"

--- a/src/Slot-Examples/AccessorInstanceVariableSlot.class.st
+++ b/src/Slot-Examples/AccessorInstanceVariableSlot.class.st
@@ -1,7 +1,7 @@
 "
 NOTE: this is an example of what can be done with Slots. It is *not* an example of what *should* be done with Slots.
 
-I am a slot that compiles accessor methods in the Class that it is installes in.  When the slot is removed, the accessors are removed, too.
+I am a slot that compiles accessor methods in the Class that it is installes in.
 
 This example shows how Slots can change the class that they are part of.
 "
@@ -32,12 +32,4 @@ AccessorInstanceVariableSlot >> installingIn: aClass [
 		].
 	aClass compile: reader classified: 'accessing'.
 	aClass compile: writer classified: 'accessing'.
-]
-
-{ #category : #'class building' }
-AccessorInstanceVariableSlot >> removingFrom: aClass [
-	
-	aClass removeSelector: self name.
-	aClass removeSelector: self name asMutator.
-	
 ]

--- a/src/Slot-Tests/ExampleClassVariableTest.class.st
+++ b/src/Slot-Tests/ExampleClassVariableTest.class.st
@@ -61,7 +61,7 @@ ExampleClassVariableTest >> testMigrateClassVar [
 		].
 	
 	self assert: (aClass hasClassVarNamed: 'ClassVar').
-	self assert: (aClass classVariableNamed: #ClassVar) class = ClassVariable.
+	self assert: (aClass classVariableNamed: #ClassVar) class equals: ClassVariable.
 	
 	aClass classVarNamed: 'ClassVar' put: 5.
 	
@@ -71,6 +71,6 @@ ExampleClassVariableTest >> testMigrateClassVar [
 		].
 	
 	self assert: (aClass hasClassVarNamed: 'ClassVar').
-	self assert: (aClass classVariableNamed: #ClassVar) class = ExampleClassVariable.
-	self assert: (aClass classVariableNamed: #ClassVar) read = 5.
+	self assert: (aClass classVariableNamed: #ClassVar) class equals: ExampleClassVariable.
+	self assert: (aClass classVariableNamed: #ClassVar) read equals: 5.
 ]

--- a/src/Slot-Tests/SlotErrorsTest.class.st
+++ b/src/Slot-Tests/SlotErrorsTest.class.st
@@ -19,16 +19,10 @@ SlotErrorsTest >> assertInvalidClassName: aName [
 		raise: InvalidGlobalName
 ]
 
-{ #category : #running }
-SlotErrorsTest >> expectedFailures [ 
-
-	^ #(testCannotBeRecompiled)
-]
-
 { #category : #tests }
 SlotErrorsTest >> testCannotBeRecompiled [
-
 	| superclass |
+	<expectedFailure>
 	superclass := self make: [ :builder | 
 		builder 
 			superclass: Object;

--- a/src/Slot-Tests/SlotExampleTest.class.st
+++ b/src/Slot-Tests/SlotExampleTest.class.st
@@ -11,28 +11,22 @@ Class {
 { #category : #tests }
 SlotExampleTest >> testAccessorInstanceVariableSlot [
 	| slot object |
-	
-	aClass := self make: [ :builder |
-		builder 
-			slots: {#slot1 =>AccessorInstanceVariableSlot  }
-		].
-
+	aClass := self
+		make:
+			[ :builder | builder slots: {(#slot1 => AccessorInstanceVariableSlot)} ].
 	self assert: (aClass hasSlotNamed: #slot1).
-	
+
 	"test refletive write and read"
 	slot := aClass slotNamed: #slot1.
 	object := aClass new.
 	slot write: 5 to: object.
-	self assert: (slot read: object) = 5.
-	
-	"test generated accessors"
+	self assert: (slot read: object) equals: 5.
 	object slot1: 10.
-	self assert: object slot1 = 10.
+	self assert: object slot1 equals: 10.
 	
-	
-	
-	
-	
+	"did we create accessors?"
+	self assert: (aClass includesSelector: #slot1).
+	self assert: (aClass includesSelector: #slot1:).
 ]
 
 { #category : #tests }
@@ -44,7 +38,7 @@ SlotExampleTest >> testExampleClassSide [
 		].
 
 	self assert: (aClass class hasSlotNamed: #slot1).
-	self assert: aClass class slotDefinitionString =  '{ #slot1 => ExampleSlotWithState }'.
+	self assert: aClass class slotDefinitionString equals:  '{ #slot1 => ExampleSlotWithState }'.
 ]
 
 { #category : #'test - unlimited ivars' }
@@ -104,9 +98,9 @@ SlotExampleTest >> testExampleSlotWithDefaultValue [
 	slot := aClass slotNamed: #slot1.
 	object := aClass new.
 
-	self assert: (slot read: object) = 5.
+	self assert: (slot read: object) equals: 5.
 	slot write: 10 to: object.
-	self assert: (slot read: object) = 10.
+	self assert: (slot read: object) equals: 10.
 	
 	
 	
@@ -117,45 +111,36 @@ SlotExampleTest >> testExampleSlotWithDefaultValue [
 { #category : #tests }
 SlotExampleTest >> testExampleSlotWithState [
 	| slot reader writer |
-	
-	aClass := self make: [ :builder |
-		builder 
-			slots: {#slot1 =>ExampleSlotWithState  }
-		].
-
+	aClass := self
+		make:
+			[ :builder | builder slots: {(#slot1 => ExampleSlotWithState)} ].
 	self assert: (aClass hasSlotNamed: #slot1).
-	
+
 	"test refletive write and read"
 	slot := aClass slotNamed: #slot1.
 	slot write: 5 to: aClass new.
-	self assert: (slot read: aClass new) = 5.
-	
-	"compiled accessors to test code gen"
-	reader := String streamContents: [ :str |
-		str 
-			nextPutAll: slot name;
-			cr;tab;
-			nextPutAll: ' ^';
-			nextPutAll: slot name.
-		 ].
-	writer := String streamContents: [ :str |
-		str 
-			nextPutAll: slot name;
-			nextPutAll: ': anObject';
-			cr;tab;
-			nextPutAll: slot name;
-			nextPutAll: ':= anObject.'.
-		].
+	self assert: (slot read: aClass new) equals: 5.
+	reader := String
+		streamContents: [ :str | 
+			str
+				nextPutAll: slot name;
+				cr;
+				tab;
+				nextPutAll: ' ^';
+				nextPutAll: slot name ].
+	writer := String
+		streamContents: [ :str | 
+			str
+				nextPutAll: slot name;
+				nextPutAll: ': anObject';
+				cr;
+				tab;
+				nextPutAll: slot name;
+				nextPutAll: ':= anObject.' ].
 	aClass compile: reader classified: 'accessing'.
 	aClass compile: writer classified: 'accessing'.
-	
 	aClass new slot1: 10.
-	self assert: aClass new slot1 = 10.
-	
-	
-	
-	
-	
+	self assert: aClass new slot1 equals: 10
 ]
 
 { #category : #'test - unlimited ivars' }


### PR DESCRIPTION
- move expected failure to use pragama
- simplify whichSelectorsAccess:, whichSelectorsRead: whichSelectorsStoreInto:
- simplify #initializeInstance: default implementation in ObjectLayout
- improve test AccessorInstanceVariableSlot
- some assert:equals: cleans in tests

fixes #3023