### PR TITLE
3009-CharacterSetComplement-size-causes-GT-inspector-to-crash

### DIFF
--- a/src/Collections-Support/CharacterSet.class.st
+++ b/src/Collections-Support/CharacterSet.class.st
@@ -1,5 +1,11 @@
 "
-A set of characters.  Lookups for inclusion are very fast.
+A set of characters: 
+
+- Lookups for inclusion are very fast.
+- CharacterSet will automatically convert itself to a WideCharacterSet if a character with value > 255 is added.
+- Tests for inclusion can be done on any Character value (up to Character maxVal).
+
+See the package comments for a description of how each of the classes in Collections-Support-CharacterSets is used.
 "
 Class {
 	#name : #CharacterSet,

--- a/src/Collections-Support/CharacterSetComplement.class.st
+++ b/src/Collections-Support/CharacterSetComplement.class.st
@@ -1,7 +1,7 @@
 "
 CharacterSetComplement is a space efficient implementation of (CharacterSet complement) taking care of WideCharacter (code > 255)
 
-However, it will maintain a byteArrayMap for character <= 255 in a cache keeping 
+However, it will maintain a byteArrayMap for character <= 255 in a cache for performance
 
 instance variables:
 	absent <CharacterSet> contains character that are not in the set (i.e. my complement)
@@ -69,10 +69,11 @@ CharacterSetComplement >> complement: aCharacterSet [
 
 { #category : #enumerating }
 CharacterSetComplement >> do: aBlock [
-	"evaluate aBlock with each character in the set.
-	don't do it, there are too many..."
+	"evaluate aBlock with each character in the set"
 
-	self shouldNotImplement
+	0 to: self size - 1 do: [ :codePoint | | ch |
+		ch := Character value: codePoint.
+		(self includes: ch) ifTrue: [ aBlock value: ch ] ]
 ]
 
 { #category : #enumerating }
@@ -82,6 +83,25 @@ CharacterSetComplement >> findFirstInByteString: aByteString startingAt: startIn
 		findFirstInString: aByteString
 		inSet: self byteArrayMap
 		startingAt: startIndex
+]
+
+{ #category : #'gt-inspector-extension' }
+CharacterSetComplement >> gtInspectorItemsIn: composite [
+	"The default set is huge, inspect the Absent list, which is typically a manageable size"
+
+	^ (composite fastList)
+		title: 'Absent';
+		display: [ absent asArray ];
+		beMultiple;
+		format: [ :each | GTObjectPrinter asTruncatedTextFrom: each ];
+		send: [ :result | result isNil 
+			ifTrue:[nil]
+			ifFalse:[ (result size = 1) 
+				ifTrue: [result anyOne] 
+				ifFalse: [self species withAll: result]]]
+		"withSmalltalkSearch;	
+		showOnly: 50;
+		helpMessage: 'Quick selection field. Given your INPUT, it executes: self select: [:each | INPUT ]'."
 ]
 
 { #category : #testing }
@@ -153,9 +173,10 @@ CharacterSetComplement >> select: aBlock [
 
 { #category : #accessing }
 CharacterSetComplement >> size [
-	"Is this 2**32-absent size ?"
-	
-	^self shouldNotImplement
+	"The size is all characters minus those explicitly excluded"
+
+	"Character values include 0, so we need to add 1."
+	^Character maxVal + 1 - absent size
 ]
 
 { #category : #printing }

--- a/src/Collections-Support/CharacterSetComplement.class.st
+++ b/src/Collections-Support/CharacterSetComplement.class.st
@@ -85,25 +85,6 @@ CharacterSetComplement >> findFirstInByteString: aByteString startingAt: startIn
 		startingAt: startIndex
 ]
 
-{ #category : #'gt-inspector-extension' }
-CharacterSetComplement >> gtInspectorItemsIn: composite [
-	"The default set is huge, inspect the Absent list, which is typically a manageable size"
-
-	^ (composite fastList)
-		title: 'Absent';
-		display: [ absent asArray ];
-		beMultiple;
-		format: [ :each | GTObjectPrinter asTruncatedTextFrom: each ];
-		send: [ :result | result isNil 
-			ifTrue:[nil]
-			ifFalse:[ (result size = 1) 
-				ifTrue: [result anyOne] 
-				ifFalse: [self species withAll: result]]]
-		"withSmalltalkSearch;	
-		showOnly: 50;
-		helpMessage: 'Quick selection field. Given your INPUT, it executes: self select: [:each | INPUT ]'."
-]
-
 { #category : #testing }
 CharacterSetComplement >> hasWideCharacters [
 	"This is a guess that absent is not holding each and every possible wideCharacter..."

--- a/src/Collections-Support/ManifestCollectionsSupport.class.st
+++ b/src/Collections-Support/ManifestCollectionsSupport.class.st
@@ -1,5 +1,16 @@
 "
 Some basic classes used in collections: Link, Associtation, Weak*, CharacterSet, SetElement, etc.
+
+
+
+!!Character Sets
+
+There are a number of options for holding sets of characters:
+
+Set, CharacterSet and WideCharacterSet can all be used where the set is empty by default and characters are explicitly added.
+
+CharacterSetComplement is used where all characters are in the set by default and characters are explicitly excluded.
+
 "
 Class {
 	#name : #ManifestCollectionsSupport,

--- a/src/Collections-Tests/CharacterTest.class.st
+++ b/src/Collections-Tests/CharacterTest.class.st
@@ -86,6 +86,18 @@ CharacterTest >> testIsSeparator [
     Character alphabet do: [ :each | self deny: each isSeparator ]
 ]
 
+{ #category : #tests }
+CharacterTest >> testMaxVal [
+	"Check that Character class>>maxVal is returning the correct value:
+	- A character created with the value has the same code point
+	- Attempting to create a character with maxVal+1 fails"
+
+	self assert: (Character value: Character maxVal) codePoint 
+			equals: Character maxVal.
+	self should: [ Character value: Character maxVal + 1 ]
+			raise: PrimitiveFailed
+]
+
 { #category : #'tests - instance creation' }
 CharacterTest >> testNew [
 

--- a/src/GT-InspectorExtensions-Core/CharacterSetComplement.extension.st
+++ b/src/GT-InspectorExtensions-Core/CharacterSetComplement.extension.st
@@ -1,0 +1,20 @@
+Extension { #name : #CharacterSetComplement }
+
+{ #category : #'*GT-InspectorExtensions-Core' }
+CharacterSetComplement >> gtInspectorItemsIn: composite [
+	"The default set is huge, inspect the Absent list, which is typically a manageable size"
+
+	^ (composite fastList)
+		title: 'Absent';
+		display: [ absent asArray ];
+		beMultiple;
+		format: [ :each | GTObjectPrinter asTruncatedTextFrom: each ];
+		send: [ :result | result isNil 
+			ifTrue:[nil]
+			ifFalse:[ (result size = 1) 
+				ifTrue: [result anyOne] 
+				ifFalse: [self species withAll: result]]]
+		"withSmalltalkSearch;	
+		showOnly: 50;
+		helpMessage: 'Quick selection field. Given your INPUT, it executes: self select: [:each | INPUT ]'."
+]

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -209,6 +209,13 @@ Character class >> linefeed [
 	^self value: 10
 ]
 
+{ #category : #constants }
+Character class >> maxVal [
+	"Answer the maximum value (code point) for a Character."
+
+	^ (2 ** 30) - 1
+]
+
 { #category : #'accessing untypeable characters' }
 Character class >> nbsp [
 	"non-breakable space. Latin1 encoding common usage."


### PR DESCRIPTION
CharacterSetComplement>>size is currently implemented as #shouldNotImplement, which causes GT inspector to crash (amongst other problems).

Given that files can already be larger than the maximum character value (2 ** 30 - 1) it doesn't make sense to artificially restrict iteration over the character set.

This commit:

- Updates CharacterSetComplement>>size to return the correct value.
- Reimplements CharacterSetComplement>>do: to do the expected thing.
- Adds CharacterSetComplement>>gtInspectorItemsIn: to view the absent list (which will be a manageable size)
- Updates the class and package comments to provide more information

Fixes: #3009