### PR TITLE
Revert "2813-Failing-tests-in-MorphicTextInputFieldAdapterTest"

### DIFF
--- a/src/Spec-MorphicBackendTests/MorphicTextInputFieldAdapterTest.class.st
+++ b/src/Spec-MorphicBackendTests/MorphicTextInputFieldAdapterTest.class.st
@@ -11,7 +11,7 @@ MorphicTextInputFieldAdapterTest >> classToTest [
 
 { #category : #tests }
 MorphicTextInputFieldAdapterTest >> testChangeWidgetTextUpdatesPresenter [
-	self skipOnPharoCITestingEnvironment
+
 	self widget setTextAndAccept: 'some text'.
 	
 	self assert: presenter text equals: 'some text'
@@ -26,7 +26,7 @@ MorphicTextInputFieldAdapterTest >> testInvisibilityIsSetInWidget [
 
 { #category : #tests }
 MorphicTextInputFieldAdapterTest >> testMaxLengthIsSetInWidget [
-	self skipOnPharoCITestingEnvironment
+
 	presenter maxLength: 10.
 	self assert: self widget maxLength equals: 10
 ]


### PR DESCRIPTION
Reverts pharo-project/pharo#3003

People convinced me that failing tests should fail. 