### PR TITLE
3033-TextMorphEditView-should-be-packaged-with-PluggableTextMorph

### DIFF
--- a/src/Morphic-Widgets-Pluggable/TextMorphForEditView.class.st
+++ b/src/Morphic-Widgets-Pluggable/TextMorphForEditView.class.st
@@ -35,7 +35,7 @@ Class {
 		'acceptOnFocusChange',
 		'selectionColor'
 	],
-	#category : #'Morphic-Base-Text Support'
+	#category : #'Morphic-Widgets-Pluggable-Text'
 }
 
 { #category : #editing }


### PR DESCRIPTION
Repackage TextMorphForEditView next to PluggableTextMorph.

Fixes #3033