### PR TITLE
assert:equal: cleanups in FileSystem-Tests-Core

### DIFF
--- a/src/FileSystem-Tests-Core/AbstractEnumerationVisitorTest.class.st
+++ b/src/FileSystem-Tests-Core/AbstractEnumerationVisitorTest.class.st
@@ -29,5 +29,5 @@ AbstractEnumerationVisitorTest >> root [
 { #category : #running }
 AbstractEnumerationVisitorTest >> setUp [
 	super setUp.
-	self setUpGreek.
+	self setUpGreek
 ]

--- a/src/FileSystem-Tests-Core/CopyVisitorTest.class.st
+++ b/src/FileSystem-Tests-Core/CopyVisitorTest.class.st
@@ -35,5 +35,5 @@ CopyVisitorTest >> testAll [
 		copy: (source / 'alpha') 
 		to: (dest / 'alpha').
 	self assert: (dest isDirectory: '/alpha').
-	self assert: (dest isFile: '/alpha/beta/gamma').
+	self assert: (dest isFile: '/alpha/beta/gamma')
 ]

--- a/src/FileSystem-Tests-Core/DeleteVisitorTest.class.st
+++ b/src/FileSystem-Tests-Core/DeleteVisitorTest.class.st
@@ -13,6 +13,6 @@ DeleteVisitorTest >> testBeta [
 	DeleteVisitor delete: (filesystem / 'alpha' / 'beta').
 	self assert: (filesystem isDirectory: '/alpha').
 	self assert: (filesystem isDirectory: '/alpha/epsilon').
-	self deny: (filesystem exists: '/alpha/beta').
+	self deny: (filesystem exists: '/alpha/beta')
 	
 ]

--- a/src/FileSystem-Tests-Core/FileLocatorTest.class.st
+++ b/src/FileSystem-Tests-Core/FileLocatorTest.class.st
@@ -13,13 +13,13 @@ Class {
 { #category : #'compatibility tests' }
 FileLocatorTest >> testAsAbsolute [
 	locator := FileLocator image.
-	self assert: locator asAbsolute = locator
+	self assert: locator asAbsolute equals: locator
 ]
 
 { #category : #'compatibility tests' }
 FileLocatorTest >> testBasename [
 	locator := FileLocator image / 'griffle'.
-	self assert: locator basename = 'griffle'
+	self assert: locator basename equals: 'griffle'
 ]
 
 { #category : #tests }
@@ -27,38 +27,42 @@ FileLocatorTest >> testCPath [
 	| ref |
 	ref := FileLocator C / 'WINDOWS'.
 	self assert: (ref fileSystem isKindOf: FileSystem).
-	self assert: ref path = (Path / 'C:' / 'WINDOWS')
+	self assert: ref path equals: (Path / 'C:' / 'WINDOWS')
 ]
 
 { #category : #'compatibility tests' }
 FileLocatorTest >> testCommaAddsExtension [
+
 	locator := FileLocator image / 'griffle'.
-	self assert: (locator , 'plonk') basename = 'griffle.plonk'
+	self assert: (locator , 'plonk') basename equals: 'griffle.plonk'
 ]
 
 { #category : #'compatibility tests' }
 FileLocatorTest >> testCommaAddsExtensionAgain [
+
 	locator := FileLocator image / 'griffle.plonk'.
-	self assert: (locator , 'nurp') basename = 'griffle.plonk.nurp'
+	self assert: (locator , 'nurp') basename equals: 'griffle.plonk.nurp'
 ]
 
 { #category : #'compatibility tests' }
 FileLocatorTest >> testContainsLocator [
+
 	locator := FileLocator image.
-	self assert: (locator contains: locator / 'griffle').
+	self assert: (locator contains: locator / 'griffle')
 ]
 
 { #category : #'compatibility tests' }
 FileLocatorTest >> testContainsPath [
 	
 	locator := FileLocator image.
-	self assert: (locator contains: (locator resolve / 'griffle') path).
+	self assert: (locator contains: (locator resolve / 'griffle') path)
 ]
 
 { #category : #'compatibility tests' }
 FileLocatorTest >> testContainsReference [
+
 	locator := FileLocator image.
-	self assert: (locator contains: (locator resolve / 'griffle')).
+	self assert: (locator contains: (locator resolve / 'griffle'))
 ]
 
 { #category : #'compatibility tests' }
@@ -109,7 +113,7 @@ FileLocatorTest >> testIsRelative [
 { #category : #'compatibility tests' }
 FileLocatorTest >> testIsRoot [
 	locator := FileLocator image.
-	(locator resolve path size) timesRepeat: [locator := locator / '..'].
+	(locator resolve path size) timesRepeat: [ locator := locator / '..' ].
 	self assert: locator canonicalize isRoot
 ]
 
@@ -140,13 +144,13 @@ FileLocatorTest >> testMoveTo [
 { #category : #'compatibility tests' }
 FileLocatorTest >> testOriginBasename [
 	locator := FileLocator image.
-	self assert: locator basename = FileLocator image resolve basename
+	self assert: locator basename equals: FileLocator image resolve basename
 ]
 
 { #category : #'compatibility tests' }
 FileLocatorTest >> testParent [
 	locator := FileLocator image.
-	self assert: locator parent resolve = FileLocator imageDirectory resolve
+	self assert: locator parent resolve equals: FileLocator imageDirectory resolve
 ]
 
 { #category : #'resolution tests' }
@@ -164,9 +168,9 @@ FileLocatorTest >> testResolveCompoundString [
 	locator := FileLocator image / 'plonk'.
 	compound := 'griffle', locator fileSystem delimiter asString, 'nurp'.
 	result := locator resolve: compound.
-	self assert: result class = locator class.
-	self assert: result origin = locator origin.
-	self assert: result path = ((Path * 'plonk') / 'griffle' / 'nurp')
+	self assert: result class equals: locator class.
+	self assert: result origin equals: locator origin.
+	self assert: result path equals: ((Path * 'plonk') / 'griffle' / 'nurp')
 ]
 
 { #category : #'resolution tests' }
@@ -175,9 +179,9 @@ FileLocatorTest >> testResolvePath [
 	locator := FileLocator image / 'plonk'.
 	result := locator resolve: (Path * 'griffle').
 	path := (Path * 'plonk') / 'griffle'.
-	self assert: result class = locator class.
-	self assert: result origin = locator origin.
-	self assert: result path = path.
+	self assert: result class equals: locator class.
+	self assert: result origin equals: locator origin.
+	self assert: result path equals: path
 ]
 
 { #category : #'resolution tests' }
@@ -198,25 +202,25 @@ FileLocatorTest >> testResolveString [
 	locator := FileLocator image / 'plonk'.
 	result := locator resolve: 'griffle'.
 	path := (Path * 'plonk') / 'griffle'.
-	self assert: result class = locator class.
-	self assert: result origin = locator origin.
-	self assert: result path = path.
+	self assert: result class equals: locator class.
+	self assert: result origin equals: locator origin.
+	self assert: result path equals: path
 ]
 
 { #category : #'compatibility tests' }
 FileLocatorTest >> testSlash [
 	locator := FileLocator image / 'griffle'.
-	self assert: locator = (FileLocator image / 'griffle')
+	self assert: locator equals: (FileLocator image / 'griffle')
 ]
 
 { #category : #'compatibility tests' }
 FileLocatorTest >> testWithExtensionAddsExtension [
 	locator := FileLocator image / 'griffle'.
-	self assert: (locator withExtension: 'plonk') basename = 'griffle.plonk'
+	self assert: (locator withExtension: 'plonk') basename equals: 'griffle.plonk'
 ]
 
 { #category : #'compatibility tests' }
 FileLocatorTest >> testWithExtensionReplacesExtension [
 	locator := FileLocator image / 'griffle.nurp'.
-	self assert: (locator withExtension: 'plonk') basename = 'griffle.plonk'
+	self assert: (locator withExtension: 'plonk') basename equals: 'griffle.plonk'
 ]

--- a/src/FileSystem-Tests-Core/FileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/FileReferenceTest.class.st
@@ -78,7 +78,7 @@ FileReferenceTest >> testAllEntries [
 	entries := ref allEntries.
 	self assert: entries size equals: 4.
 	entries do: [:entry |
-		self assert: entry class = MemoryDirectoryEntry.
+		self assert: entry class equals: MemoryDirectoryEntry.
 		self assert: (ref = entry reference or: [ref contains: entry reference])].
 	self assert: (entries collect: [ :ea | ea basename ]) equals: #('alpha' 'beta' 'gamma' 'delta') ]
 		ensure: [ (filesystem / 'alpha') ensureDeleteAll ]
@@ -238,7 +238,7 @@ FileReferenceTest >> testChildOfPath [
 	parent := Path / 'griffle'.
 	child := filesystem / 'griffle' / 'nurb'.
 	self deny: (child isChildOf: parent).
-	self deny: (parent isChildOf: child).
+	self deny: (parent isChildOf: child)
 ]
 
 { #category : #tests }
@@ -247,7 +247,7 @@ FileReferenceTest >> testChildOfReference [
 	parent := filesystem / 'griffle'.
 	child := filesystem / 'griffle' / 'nurb'.
 	self assert: (child isChildOf: parent).
-	self deny: (parent isChildOf: child).
+	self deny: (parent isChildOf: child)
 ]
 
 { #category : #tests }
@@ -456,7 +456,7 @@ FileReferenceTest >> testEntries [
 	entries := ref entries.
 	self assert: entries size equals: 2.
 	entries do: [:entry |
-		self assert: entry class = MemoryDirectoryEntry.
+		self assert: entry class equals: MemoryDirectoryEntry.
 		self assert: (entry reference isChildOf: ref).
 		self assert: (#('beta' 'gamma') includes: entry reference basename)] ]
 		ensure: [ (filesystem / 'alpha') ensureDeleteAll ]
@@ -515,7 +515,7 @@ FileReferenceTest >> testGrandchildOfReference [
 	griffle := filesystem / 'griffle'.
 	nurb := filesystem / 'griffle' / 'plonk' / 'nurb'.
 	self deny: (griffle isChildOf: nurb).
-	self deny: (nurb isChildOf: griffle).
+	self deny: (nurb isChildOf: griffle)
 ]
 
 { #category : #tests }
@@ -796,8 +796,8 @@ FileReferenceTest >> testParent [
 	| ref parent |
 	ref := filesystem * 'plonk' / 'griffle'.
 	parent := ref parent.
-	self assert: parent class = ref class.
-	self assert: (parent path at: 1) = 'plonk'
+	self assert: parent class equals: ref class.
+	self assert: (parent path at: 1) equals: 'plonk'
 ]
 
 { #category : #tests }
@@ -869,7 +869,7 @@ FileReferenceTest >> testPathRelativeTo [
 	parent := filesystem / 'griffle'.
 	childPath := Path / 'griffle' / 'plonk' / 'nurb'.
 	relative := childPath relativeTo: parent.
-	self assert: relative = (Path * 'plonk' / 'nurb')
+	self assert: relative equals: (Path * 'plonk' / 'nurb')
 ]
 
 { #category : #tests }
@@ -949,7 +949,7 @@ FileReferenceTest >> testRelativeToPath [
 	parentPath := Path / 'griffle'.
 	child := filesystem / 'griffle' / 'plonk' / 'nurb'.
 	relative := child relativeTo: parentPath.
-	self assert: relative = (Path * 'plonk' / 'nurb')
+	self assert: relative equals: (Path * 'plonk' / 'nurb')
 ]
 
 { #category : #tests }
@@ -958,7 +958,7 @@ FileReferenceTest >> testRelativeToReference [
 	parent := filesystem / 'griffle'.
 	child := filesystem  / 'griffle' / 'plonk' / 'nurb'.
 	relative := child relativeTo: parent.
-	self assert: relative = (Path * 'plonk' / 'nurb')
+	self assert: relative equals: (Path * 'plonk' / 'nurb')
 ]
 
 { #category : #tests }
@@ -1018,9 +1018,9 @@ FileReferenceTest >> testSimpleResolution [
 	relative := (Path * 'griffle') / 'zonk'.
 	absolute := base resolve: relative.
 	self assert: absolute isAbsolute.
-	self assert: (absolute path at: 1) = 'plonk'.
-	self assert: (absolute path at: 2) = 'griffle'.
-	self assert: (absolute path at: 3) = 'zonk'.
+	self assert: (absolute path at: 1) equals: 'plonk'.
+	self assert: (absolute path at: 2) equals: 'griffle'.
+	self assert: (absolute path at: 3) equals: 'zonk'.
 	
 	
 ]
@@ -1030,10 +1030,10 @@ FileReferenceTest >> testSlash [
 	| ref result |
 	ref := filesystem * 'plonk'.
 	result := ref / 'griffle'.
-	self assert: result class = ref class.
+	self assert: result class equals: ref class.
 	self assert: result  isRelative.
-	self assert: (result path at: 1) = 'plonk'.
-	self assert: (result path at: 2) = 'griffle'.
+	self assert: (result path at: 1) equals: 'plonk'.
+	self assert: (result path at: 2) equals: 'griffle'.
 
 ]
 
@@ -1136,7 +1136,7 @@ FileReferenceTest >> testWithExtentionAddsExtension [
 	ref := filesystem * 'plonk'.
 	result := ref withExtension: 'griffle'.
 	self assert: result isRelative.
-	self assert: result basename = 'plonk.griffle'
+	self assert: result basename equals: 'plonk.griffle'
 ]
 
 { #category : #tests }
@@ -1161,8 +1161,8 @@ FileReferenceTest >> testWithoutExtension [
 FileReferenceTest >> testWorkingDirectoryParent [
 	| wd |
 	wd := filesystem referenceTo: Path workingDirectory.
-	self assert: wd parent path size = 1.
-	self assert: (wd parent path at: 1) = '..'.
+	self assert: wd parent path size equals: 1.
+	self assert: (wd parent path at: 1) equals: '..'.
 ]
 
 { #category : #tests }

--- a/src/FileSystem-Tests-Core/FileSystemHandleTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemHandleTest.class.st
@@ -45,7 +45,7 @@ FileSystemHandleTest >> tearDown [
 { #category : #tests }
 FileSystemHandleTest >> testAt [
 	handle at: 1 write: (ByteArray with: 3) startingAt: 1 count: 1.
-	self assert: (handle at: 1) = 3
+	self assert: (handle at: 1) equals: 3
 ]
 
 { #category : #tests }
@@ -54,7 +54,7 @@ FileSystemHandleTest >> testAtPut [
 	handle at: 1 put: 3.
 	in := ByteArray new: 1.
 	handle at: 1 read: in startingAt: 1 count: 1.
-	self assert: in first = 3
+	self assert: in first equals: 3
 ]
 
 { #category : #tests }
@@ -113,7 +113,7 @@ FileSystemHandleTest >> testIO [
 	in := ByteArray new: 3.
 	handle at: 1 write: out startingAt: 1 count: 3.
 	handle at: 1 read: in startingAt: 1 count: 3.
-	self assert: out = in.
+	self assert: out equals: in
 ]
 
 { #category : #tests }
@@ -124,8 +124,8 @@ FileSystemHandleTest >> testReadBufferTooLarge [
 	in atAllPut: 9.
 	handle at: 1 write: out startingAt: 1 count: 3.
 	result := handle at: 1 read: in startingAt: 2 count: 4.
-	self assert: result = 3.
-	self assert: in = #(9 1 2 3 9) asByteArray.
+	self assert: result equals: 3.
+	self assert: in equals: #(9 1 2 3 9) asByteArray
 ]
 
 { #category : #tests }
@@ -144,7 +144,7 @@ FileSystemHandleTest >> testReadOnly [
 
 { #category : #tests }
 FileSystemHandleTest >> testReference [
-	self assert: handle reference = reference asAbsolute
+	self assert: handle reference equals: reference asAbsolute
 ]
 
 { #category : #tests }
@@ -152,7 +152,7 @@ FileSystemHandleTest >> testSizeAfterGrow [
 	| out |
 	out := #(1 2 3) asByteArray.
 	handle at: 1 write: out startingAt: 1 count: 3.
-	self assert: handle size = 3
+	self assert: handle size equals: 3
 ]
 
 { #category : #tests }
@@ -161,7 +161,7 @@ FileSystemHandleTest >> testSizeNoGrow [
 	bytes := #(1 2 3 4) asByteArray.
 	handle at: 1 write: bytes startingAt: 1 count: 3.
 	handle at: 4 write: bytes startingAt: 4 count: 1.
-	self assert: handle size = 4
+	self assert: handle size equals: 4
 ]
 
 { #category : #tests }
@@ -170,7 +170,7 @@ FileSystemHandleTest >> testTruncate [
 	out := #(1 2 3 4 5) asByteArray.
 	handle at: 1 write: out startingAt: 1 count: 5.
 	handle truncateTo: 3.
-	self assert: handle size = 3
+	self assert: handle size equals: 3
 ]
 
 { #category : #tests }

--- a/src/FileSystem-Tests-Core/FileSystemResolverTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemResolverTest.class.st
@@ -33,5 +33,5 @@ FileSystemResolverTest >> createResolver [
 { #category : #running }
 FileSystemResolverTest >> setUp [
 	super setUp.
-	resolver := self createResolver.
+	resolver := self createResolver
 ]

--- a/src/FileSystem-Tests-Core/FileSystemTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemTest.class.st
@@ -49,7 +49,7 @@ FileSystemTest >> markForCleanup: anObject [
 FileSystemTest >> setUp [
 	super setUp.
 	filesystem := self createFileSystem.
-	toDelete := OrderedCollection new.
+	toDelete := OrderedCollection new
 ]
 
 { #category : #running }
@@ -79,8 +79,9 @@ FileSystemTest >> testBinaryReadStreamDo [
 		should: [ reference binaryReadStreamDo: [ :stream | self assert: false ] ] 
 		raise: FileDoesNotExistException.
 	reference writeStreamDo: [ :ws | ws nextPutAll: 'griffle' ].
-	self assert: (reference readStreamDo: [ :stream | stream contents asString ]) 
-		= 'griffle'
+	self 
+		assert: (reference readStreamDo: [ :stream | stream contents asString ]) 
+		equals: 'griffle'
 ]
 
 { #category : #'tests-streams-compatibility' }
@@ -103,7 +104,7 @@ FileSystemTest >> testBinaryReadStreamIfAbsent [
 	self assert: (reference binaryReadStreamIfAbsent: [ true ]).
 	reference writeStreamDo: [ :ws | ws nextPutAll: 'griffle' ].
 	stream := reference binaryReadStreamIfAbsent: [ false ].
-	self assert: stream contents asString = 'griffle'.
+	self assert: stream contents asString equals: 'griffle'.
 	stream close
 ]
 
@@ -122,10 +123,10 @@ FileSystemTest >> testChildrenAt [
 	
 	entries := filesystem childrenAt: directory.
 	
-	self assert: entries size = 2.
+	self assert: entries size equals: 2.
 	entries do: [ :ea | 
 		self assert: (ea isKindOf: Path).
-		self assert: ea parent = (filesystem resolve: directory).
+		self assert: ea parent equals: (filesystem resolve: directory).
 		self assert: (#('griffle' 'bint' ) includes: ea basename) ]
 ]
 
@@ -144,9 +145,9 @@ FileSystemTest >> testChildrenSorting [
 	self markForCleanup: directory.
 	
 	sorted := (filesystem childrenAt: directory) sorted.
-	self assert: sorted size = 2.
-	self assert: (sorted at: 1) basename = 'alfa'.
-	self assert: (sorted at: 2) basename = 'beta'.
+	self assert: sorted size equals: 2.
+	self assert: (sorted at: 1) basename equals: 'alfa'.
+	self assert: (sorted at: 2) basename equals: 'beta'
 ]
 
 { #category : #tests }
@@ -163,7 +164,9 @@ FileSystemTest >> testChildrenSortingRoot [
 	self markForCleanup: directory1.
 	self markForCleanup: directory2.
 	
-	self assert: filesystem workingDirectory children sorted size = filesystem workingDirectory children size
+	self 
+		assert: filesystem workingDirectory children sorted size 
+		equals: filesystem workingDirectory children size
 ]
 
 { #category : #tests }
@@ -235,15 +238,16 @@ FileSystemTest >> testCopySourceDoesntExist [
 
 { #category : #tests }
 FileSystemTest >> testCopyWithCorrectBasename [
-        | directory |
-        self
-                markForCleanup: 'gooly';
-                markForCleanup: 'plonk'.
-        directory := filesystem workingDirectory.
-        (directory / 'gooly') ensureCreateFile.
-        directory / 'gooly' copyTo: directory / 'plonk'.
-        self assert: (directory / 'plonk') exists.
-        self assert: (directory childNames includes: 'plonk')
+	| directory |
+ 	self
+        markForCleanup: 'gooly';
+        markForCleanup: 'plonk'.
+	directory := filesystem workingDirectory.
+ 	(directory / 'gooly') ensureCreateFile.
+	directory / 'gooly' copyTo: directory / 'plonk'.
+ 
+	self assert: (directory / 'plonk') exists.
+ 	self assert: (directory childNames includes: 'plonk')
 ]
 
 { #category : #tests }
@@ -291,7 +295,7 @@ FileSystemTest >> testCreateDirectoryNotCreateParent [
 	| path |
 	path := filesystem workingDirectory / 'plonk' / 'griffle'.
 	self should:[path createDirectory] raise: DirectoryDoesNotExist.
-	self assert: path exists not.
+	self assert: path exists not
 ]
 
 { #category : #tests }
@@ -309,7 +313,7 @@ FileSystemTest >> testCreateFileNotCreateParent [
 	| path |
 	path := '/plonk/griffles' asFileReference.
 	self should:[path createFile] raise: DirectoryDoesNotExist .
-	self assert: path exists not.
+	self assert: path exists not
 ]
 
 { #category : #tests }
@@ -333,7 +337,7 @@ FileSystemTest >> testDelete [
 	reference := ( filesystem workingDirectory / 'file') ensureCreateFile.
 	reference delete.
 	
-	self deny: reference exists. 
+	self deny: reference exists
 		
 
 ]
@@ -406,10 +410,10 @@ FileSystemTest >> testEntriesAt [
 		markForCleanup: directory.
 	
 	entries := filesystem entriesAt: directory.
-	self assert: entries size = 2.
+	self assert: entries size equals: 2.
 	entries do: [ :ea | 
 		self assert: (ea isKindOf: FileSystemDirectoryEntry).
-		self assert: ea reference parent path = (filesystem resolve: directory).
+		self assert: ea reference parent path equals: (filesystem resolve: directory).
 		self assert: (#('griffle' 'bint' ) includes: ea reference basename).
 		self assert: ea isDirectory ]
 ]
@@ -432,8 +436,8 @@ FileSystemTest >> testEntryAt [
 	
 	self assert: entry1 isDirectory.
 	self assert: entry2 isDirectory.
-	self assert: entry1 reference = (filesystem referenceTo: path1) asAbsolute.
-	self assert: entry2 reference = (filesystem referenceTo: path2) asAbsolute.
+	self assert: entry1 reference equals: (filesystem referenceTo: path1) asAbsolute.
+	self assert: entry2 reference equals: (filesystem referenceTo: path2) asAbsolute.
 
 	self assert: entry1 creationTime < entry2 creationTime.
 	self assert: entry1 modificationTime < entry2 modificationTime.
@@ -516,13 +520,13 @@ FileSystemTest >> testMoveToFailingExistingDestination [
 	"Cleanup after running"
 	self 
 		markForCleanup: (base / 'folder' / 'newFile');
-		markForCleanup: (base / 'folder') ;
+		markForCleanup: (base / 'folder');
 		markForCleanup: (base / 'file').	
 	
 	"Destination exists already"
 	self should: [ file moveTo: (folder / 'newFile') ] raise: Error.
 	self assert: (base / 'file') exists.
-	self assert: (folder / 'newFile') exists.
+	self assert: (folder / 'newFile') exists
 ]
 
 { #category : #tests }
@@ -543,7 +547,7 @@ FileSystemTest >> testMoveToFailingMissingDestination [
 	self deny: (base / 'folder') exists.
 	self should: [ file moveTo: (base / 'folder' / 'newFile') ] raise: Error.
 	self assert: (base / 'file') exists.
-	self deny: (base / 'folder' / 'newFile') exists.
+	self deny: (base / 'folder' / 'newFile') exists
 ]
 
 { #category : #tests }
@@ -563,7 +567,7 @@ FileSystemTest >> testMoveToFailingMissingSource [
 	"Destination exists already"
 	self should: [ (base / 'file') moveTo: (folder / 'newFile') ] raise: Error.
 	self deny: (base / 'file') exists.
-	self deny: (folder / 'newFile') exists.
+	self deny: (folder / 'newFile') exists
 ]
 
 { #category : #tests }
@@ -610,8 +614,9 @@ FileSystemTest >> testReadStreamDo [
 		should: [ reference readStreamDo: [ :stream | self assert: false ] ] 
 		raise: FileDoesNotExistException.
 	reference writeStreamDo: [ :ws | ws nextPutAll: 'griffle' ].
-	self assert: (reference readStreamDo: [ :stream | stream contents asString ]) 
-		= 'griffle'
+	self 
+		assert: (reference readStreamDo: [ :stream | stream contents asString ]) 
+		equals: 'griffle'
 ]
 
 { #category : #'tests-streams' }
@@ -634,7 +639,7 @@ FileSystemTest >> testReadStreamIfAbsent [
 	self assert: (reference readStreamIfAbsent: [ true ]).
 	reference writeStreamDo: [ :ws | ws nextPutAll: 'griffle' ].
 	stream := reference readStreamIfAbsent: [ false ].
-	self assert: stream contents asString = 'griffle'.
+	self assert: stream contents asString equals: 'griffle'.
 	stream close
 ]
 
@@ -659,8 +664,8 @@ FileSystemTest >> testReferenceTo [
 
 { #category : #tests }
 FileSystemTest >> testRoot [
-	self assert: filesystem root fileSystem = filesystem.
-	self assert: filesystem root path = Path root.
+	self assert: filesystem root fileSystem equals: filesystem.
+	self assert: filesystem root path equals: Path root.
 	self assert: filesystem root isRoot.
 ]
 
@@ -681,8 +686,8 @@ FileSystemTest >> testRootIsNotAFile [
 
 { #category : #tests }
 FileSystemTest >> testWorking [
-	self assert: filesystem workingDirectory fileSystem = filesystem.
-	self assert: filesystem workingDirectory path = filesystem workingDirectoryPath
+	self assert: filesystem workingDirectory fileSystem equals: filesystem.
+	self assert: filesystem workingDirectory path equals: filesystem workingDirectoryPath
 ]
 
 { #category : #'tests-streams' }

--- a/src/FileSystem-Tests-Core/GuideTest.class.st
+++ b/src/FileSystem-Tests-Core/GuideTest.class.st
@@ -20,7 +20,7 @@ GuideTest class >> isAbstract [
 GuideTest >> assertVisitedIs: anArray [
 	visited with: anArray do:
 		[:entry :basename | 
-		self assert: entry reference basename = basename]
+		self assert: entry reference basename equals: basename]
 ]
 
 { #category : #running }
@@ -33,10 +33,10 @@ GuideTest >> setUp [
 
 { #category : #visitor }
 GuideTest >> visitDirectory: aReference [
-	visited add: aReference.
+	visited add: aReference
 ]
 
 { #category : #visitor }
 GuideTest >> visitFile: aReference [
-	visited add: aReference.
+	visited add: aReference
 ]

--- a/src/FileSystem-Tests-Core/PathTest.class.st
+++ b/src/FileSystem-Tests-Core/PathTest.class.st
@@ -23,7 +23,7 @@ PathTest >> testAbsolutePath [
 	self assert: (path at: 3) equals: 'grandChild'.
 	
 	path := AbsolutePath from: '/' delimiter: $/.
-	self assert: path equals: Path root.
+	self assert: path equals: Path root
 	
 
 ]
@@ -178,7 +178,7 @@ PathTest >> testEqual [
 	a := Path * 'plonk'.
 	b := Path * 'plonk'.
 	self deny: a == b.
-	self assert: a equals: b.
+	self assert: a equals: b
 ]
 
 { #category : #tests }
@@ -205,10 +205,10 @@ PathTest >> testExtendingPath [
 	self assert: ref segments equals: #('a' 'b' 'c' 'd' '..' 'e').
 
 	ref := '/a/b/c' asPath / './d'.
-	self assert: (ref segments = #('a' 'b' 'c' 'd')).
+	self assert: (ref segments equals: #('a' 'b' 'c' 'd')).
 
 	ref := '/a/b/c' asPath / 'd/.'.
-	self assert: (ref segments = #('a' 'b' 'c' 'd')).
+	self assert: (ref segments equals: #('a' 'b' 'c' 'd')).
 
 	ref := '/a/b/c' asPath / 'd/./e'.
 	self assert: ref segments equals: #('a' 'b' 'c' 'd' 'e').
@@ -262,7 +262,7 @@ PathTest >> testIsAbsoluteWindowsPathReturnsFalseWhenNoWindowsAbsolutePathProvid
   
 	self deny: (Path isAbsoluteWindowsPath: 'tmp').
 	self deny: (Path isAbsoluteWindowsPath: '/tmp').
-	self deny: (Path isAbsoluteWindowsPath: '/tmp/test').
+	self deny: (Path isAbsoluteWindowsPath: '/tmp/test')
 ]
 
 { #category : #tests }
@@ -357,7 +357,7 @@ PathTest >> testParentParent [
 	path := (Path * '..') parent.
 	self assert: path size equals: 2.
 	self assert: (path at: 1) equals: '..'.
-	self assert: (path at: 2) equals: '..'.
+	self assert: (path at: 2) equals: '..'
 ]
 
 { #category : #tests }
@@ -367,7 +367,7 @@ PathTest >> testParentResolution [
 	relative := Path parent / 'griffle' / 'zonk'.
 	absolute := base resolve: relative.
 	self assert: absolute isAbsolute.
-	self assert: absolute segments equals: #('plonk' 'pinto' '..' 'griffle' 'zonk').
+	self assert: absolute segments equals: #('plonk' 'pinto' '..' 'griffle' 'zonk')
 
 ]
 
@@ -391,7 +391,7 @@ PathTest >> testParse [
 	self assert: path size equals: 3.
 	self assert: (path at: 1) equals: 'parent'.
 	self assert: (path at: 2) equals: 'child'.
-	self assert: (path at: 3) equals: 'grandChild'.
+	self assert: (path at: 3) equals: 'grandChild'
 	
 
 ]
@@ -403,7 +403,7 @@ PathTest >> testParseBogus [
 	path := Path from: 'parent?<>~ \child/grandChild' delimiter: $/.
 	self assert: path size equals: 2.
 	self assert: (path at: 1) equals: 'parent?<>~ \child'.
-	self assert: (path at: 2) equals: 'grandChild'.
+	self assert: (path at: 2) equals: 'grandChild'
 	
 
 ]
@@ -527,7 +527,7 @@ PathTest >> testRelativeFromString [
 	self assert: path isRelative.
 	self assert: path size equals: 2.
 	self assert: (path at: 1) equals: 'plonk'.
-	self assert: (path at: 2) equals: 'griffle'.
+	self assert: (path at: 2) equals: 'griffle'
 ]
 
 { #category : #tests }
@@ -539,7 +539,7 @@ PathTest >> testRelativeFromStringNormalization [
 	
 	self assert: path isRelative.
 	self assert: path size equals: 3.
-	self assert: path segments equals: #('plonk' '..' 'griffle').
+	self assert: path segments equals: #('plonk' '..' 'griffle')
 ]
 
 { #category : #tests }
@@ -564,7 +564,7 @@ PathTest >> testRelativeFromStringParent [
 	self assert: path isRelative.
 	self assert: path size equals: 2.
 	self assert: (path at: 1) equals: '..'.
-	self assert: (path at: 2) equals: '..'.
+	self assert: (path at: 2) equals: '..'
 ]
 
 { #category : #tests }
@@ -666,7 +666,7 @@ PathTest >> testResolveString [
 	self assert: result class equals: path class.
 	self assert: result size equals: 2.
 	self assert: (result at: 1) equals: 'plonk'.
-	self assert: (result at: 2) equals: 'griffle'.
+	self assert: (result at: 2) equals: 'griffle'
 ]
 
 { #category : #tests }

--- a/src/FileSystem-Tests-Core/PathTest.class.st
+++ b/src/FileSystem-Tests-Core/PathTest.class.st
@@ -205,10 +205,10 @@ PathTest >> testExtendingPath [
 	self assert: ref segments equals: #('a' 'b' 'c' 'd' '..' 'e').
 
 	ref := '/a/b/c' asPath / './d'.
-	self assert: (ref segments equals: #('a' 'b' 'c' 'd')).
+	self assert: ref segments equals: #('a' 'b' 'c' 'd').
 
 	ref := '/a/b/c' asPath / 'd/.'.
-	self assert: (ref segments equals: #('a' 'b' 'c' 'd')).
+	self assert: ref segments equals: #('a' 'b' 'c' 'd').
 
 	ref := '/a/b/c' asPath / 'd/./e'.
 	self assert: ref segments equals: #('a' 'b' 'c' 'd' 'e').


### PR DESCRIPTION
- use assert:equals:
- some unnecessary dots removed
- format one method

fixes #3069