### PR TITLE
3064-Each-assert-like-method-in-TestRunner-should-have-the-dual-deny-method

### DIFF
--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -71,12 +71,15 @@ TestAsserter class >> suiteClass [
 
 { #category : #asserting }
 TestAsserter >> assert: actualNumber closeTo: expectedNumber [
+	"Tell whether the actualNumber and expectedNumber ARE close to each others with a margin of
+	 the default precision (see class-side method #defaultPrecisionsForCloseToComparison).
+	"
 	self assert: actualNumber closeTo: expectedNumber precision: self class defaultPrecisionsForCloseToComparison
 ]
 
 { #category : #asserting }
 TestAsserter >> assert: actualNumber closeTo: expectedNumber precision: epsilon [
-	"Tell whether the actualNumber and expectedNumber are close from each with a margin of epsilon"
+	"Tell whether the actualNumber and expectedNumber ARE close to each others with a margin of epsilon."
 
 	^ self
 		assert: (actualNumber closeTo: expectedNumber precision: epsilon)
@@ -85,7 +88,9 @@ TestAsserter >> assert: actualNumber closeTo: expectedNumber precision: epsilon 
 
 { #category : #asserting }
 TestAsserter >> assert: aBooleanOrBlock description: aStringOrBlock [
-	"Take a second argument wich is a message string that describes the reason for the failure, this string will be displayed by the Test Runner"
+	"This method raises an AssertionFailure with aString as #messageText if
+	 aBooleanOrBlock evaluates to false.
+	"
 
 	self assert: aBooleanOrBlock description: aStringOrBlock resumable: false
 ]
@@ -109,7 +114,9 @@ TestAsserter >> assert: aBooleanOrBlock description: aStringOrBlock resumable: r
 
 { #category : #asserting }
 TestAsserter >> assert: actual equals: expected [
-	"Validate whether or not the actual value is equal than the expected, if the assertion fails it provides a description that show both the actual and the expected value"
+	"This method raises an AssertionFailure if actual is different (using #= message) from expected.
+	 Else it does nothing and execution continues.
+	"
 	
 	^ self
 		assert: actual = expected
@@ -118,7 +125,7 @@ TestAsserter >> assert: actual equals: expected [
 
 { #category : #asserting }
 TestAsserter >> assert: actual identicalTo: expected [
-	"Verify whether the actual and the expected are the same object (have the same object pointer)"
+	"Verify whether the actual and the expected are the same object (have the same object pointer so #== returns true)."
 	
 	^ self
 		assert: expected == actual
@@ -126,12 +133,14 @@ TestAsserter >> assert: actual identicalTo: expected [
 ]
 
 { #category : #asserting }
-TestAsserter >> assertCollection: actual equals: expected [
-	"Specialized test method that generates a proper error message for collection"
+TestAsserter >> assertCollection: actualCollection equals: expectedCollection [
+	"Raises an AssertionFailure if actualCollection is not equal to expectedCollection (using #= message).
+	 I also provide a specialized message for the AssertionFailure in case I fail.
+	"
 
 	^ self
-		assert: expected = actual
-		description: [ self comparingCollectionBetween: actual and: expected ]
+		assert: actualCollection = expectedCollection
+		description: [ self comparingCollectionBetween: actualCollection and: expectedCollection ]
 ]
 
 { #category : #asserting }
@@ -161,7 +170,9 @@ TestAsserter >> assertCollection: actual hasSameElements: expected [
 
 { #category : #asserting }
 TestAsserter >> assertCollection: actual includesAll: subcollection [
-	"Specialized test method that generates a proper error message for collection"
+	"Raises an AssertionFailure if actualCollection does not include all the elements of expectedCollection (using #includesAll: message).
+	 I also provide a specialized message for the AssertionFailure in case I fail.
+	"
 
 	^ self
 		assert: (actual includesAll: subcollection)
@@ -285,12 +296,15 @@ TestAsserter >> deny: aBooleanOrBlock [
 
 { #category : #asserting }
 TestAsserter >> deny: actualNumber closeTo: expectedNumber [
+	"Tell whether the actualNumber and expectedNumber are NOT close to each others with a margin of
+	 the default precision (see class-side method #defaultPrecisionsForCloseToComparison).
+	"
 	self deny: actualNumber closeTo: expectedNumber precision: self class defaultPrecisionsForCloseToComparison
 ]
 
 { #category : #asserting }
 TestAsserter >> deny: actualNumber closeTo: expectedNumber precision: epsilon [
-	"Tell whether the actualNumber and expectedNumber are NOT close from each with a margin of epsilon"
+	"Tell whether the actualNumber and expectedNumber are NOT close to each others with a margin of epsilon."
 
 	^ self
 		assert: (actualNumber closeTo: expectedNumber precision: epsilon) not
@@ -305,16 +319,23 @@ TestAsserter >> deny: aBooleanOrBlock description: aString [
 ]
 
 { #category : #asserting }
-TestAsserter >> deny: aBooleanOrBlock description: aString resumable: resumableBoolean [ 
+TestAsserter >> deny: aBooleanOrBlock description: aStringOrBlock resumable: resumableBoolean [
+	"Checks if aBooleanOrBlock evaluates to false (by sending #value message to it).
+	 aStringOrBlock and resumableBoolean parameters are used similarly as in
+	 TestAsserter>>#assert:description:resumable:.
+	"
 	self
 		assert: aBooleanOrBlock value not
-		description: aString
+		description: aStringOrBlock
 		resumable: resumableBoolean
 			
 ]
 
 { #category : #asserting }
 TestAsserter >> deny: actual equals: expected [
+	"This method raises an AssertionFailure if actual is equals (using #= message) to expected.
+	 Else it does nothing and execution continues.
+	"
 	^ self
 		deny: expected = actual
 		description: [self unexpectedEqualityStringBetween: actual and: expected]
@@ -322,23 +343,29 @@ TestAsserter >> deny: actual equals: expected [
 
 { #category : #asserting }
 TestAsserter >> deny: actual identicalTo: expected [
+	"Verify whether the actual and the expected are NOT the same object (have the same object pointer so #== returns false)."
 	^ self
 		deny: expected == actual
 		description: [self unexpectedIdentityEqualityStringBetween: actual and: expected]
 ]
 
 { #category : #asserting }
-TestAsserter >> denyCollection: actual equals: expected [
-	"Specialized test method that generates a proper error message for collection"
+TestAsserter >> denyCollection: actualCollection equals: expectedCollection [
+	"Raises an AssertionFailure if actualCollection IS EQUAL to expectedCollection (using #= message).
+	 I also provide a specialized message for the AssertionFailure in case I fail.
+	"
 
 	^ self
-		deny: expected = actual
-		description: [ self unexpectedEqualityStringBetween: actual and: expected ]
+		deny: actualCollection = expectedCollection
+		description: [ self unexpectedEqualityStringBetween: actualCollection and: expectedCollection ]
 ]
 
 { #category : #asserting }
 TestAsserter >> denyCollection: actual includesAll: subcollection [
-
+	"Raises an AssertionFailure if actualCollection INCLUDES all the elements of expectedCollection (by negating result of #includesAll: message).
+	 I also provide a specialized message for the AssertionFailure in case I fail.
+	"
+	
 	^ self
 		assert: (actual includesAll: subcollection) not
 		description: [ actual asString , ' does not include all in ' , subcollection asString ]

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -76,11 +76,7 @@ TestAsserter >> assert: actualNumber closeTo: expectedNumber [
 TestAsserter >> assert: aBooleanOrBlock description: aStringOrBlock [
 	"Take a second argument wich is a message string that describes the reason for the failure, this string will be displayed by the Test Runner"
 
-	aBooleanOrBlock value
-		ifFalse: [ | aString |
-			aString := aStringOrBlock value.
-			self logFailure: aString.
-			self classForTestResult failure signal: aString ]
+	self assert: aBooleanOrBlock description: aStringOrBlock resumable: false
 ]
 
 { #category : #asserting }

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -274,8 +274,7 @@ TestAsserter >> deny: aBooleanOrBlock [
 
 { #category : #asserting }
 TestAsserter >> deny: aBooleanOrBlock description: aString [
-	self assert: aBooleanOrBlock value not description: aString
-			
+	self deny: aBooleanOrBlock description: aString resumable: false
 ]
 
 { #category : #asserting }

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -34,6 +34,12 @@ TestAsserter class >> classForTestSuite [
 	^ TestSuite
 ]
 
+{ #category : #accessing }
+TestAsserter class >> defaultPrecisionsForCloseToComparison [
+	"This number comes from the one used in Float>>#closeTo: implementation."
+	^ 0.0001
+]
+
 { #category : #logging }
 TestAsserter class >> failureLog [
 	^Transcript
@@ -65,10 +71,15 @@ TestAsserter class >> suiteClass [
 
 { #category : #asserting }
 TestAsserter >> assert: actualNumber closeTo: expectedNumber [
-	"Tell whether the actualNumber and expectedNumber are close from each with a margin of 0.0001"
+	self assert: actualNumber closeTo: expectedNumber precision: self class defaultPrecisionsForCloseToComparison
+]
+
+{ #category : #asserting }
+TestAsserter >> assert: actualNumber closeTo: expectedNumber precision: epsilon [
+	"Tell whether the actualNumber and expectedNumber are close from each with a margin of epsilon"
 
 	^ self
-		assert: (actualNumber closeTo: expectedNumber)
+		assert: (actualNumber closeTo: expectedNumber precision: epsilon)
 		description: [ self comparingStringBetween: actualNumber and: expectedNumber ]
 ]
 

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -284,6 +284,20 @@ TestAsserter >> deny: aBooleanOrBlock [
 ]
 
 { #category : #asserting }
+TestAsserter >> deny: actualNumber closeTo: expectedNumber [
+	self deny: actualNumber closeTo: expectedNumber precision: self class defaultPrecisionsForCloseToComparison
+]
+
+{ #category : #asserting }
+TestAsserter >> deny: actualNumber closeTo: expectedNumber precision: epsilon [
+	"Tell whether the actualNumber and expectedNumber are NOT close from each with a margin of epsilon"
+
+	^ self
+		assert: (actualNumber closeTo: expectedNumber precision: epsilon) not
+		description: [ self comparingStringBetween: actualNumber and: expectedNumber ]
+]
+
+{ #category : #asserting }
 TestAsserter >> deny: aBooleanOrBlock description: aString [
 	self deny: aBooleanOrBlock description: aString resumable: false
 ]

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -144,12 +144,12 @@ TestAsserter >> assertCollection: actualCollection equals: expectedCollection [
 ]
 
 { #category : #asserting }
-TestAsserter >> assertCollection: actual hasSameElements: expected [
+TestAsserter >> assertCollection: actualCollection hasSameElements: expected [
 	"Assert that a collection contains the same elements as the given collection. Order is not checked, only the presence/absence of elements."
 
 	| missingElements additionalElements |
-	additionalElements := actual difference: expected.
-	missingElements := expected difference: (actual intersection: expected).
+	additionalElements := actualCollection difference: expected.
+	missingElements := expected difference: (actualCollection intersection: expected).
 	self
 		assert: (additionalElements isEmpty and: [ missingElements isEmpty ])
 		description:
@@ -169,14 +169,14 @@ TestAsserter >> assertCollection: actual hasSameElements: expected [
 ]
 
 { #category : #asserting }
-TestAsserter >> assertCollection: actual includesAll: subcollection [
+TestAsserter >> assertCollection: actualCollection includesAll: subcollection [
 	"Raises an AssertionFailure if actualCollection does not include all the elements of expectedCollection (using #includesAll: message).
 	 I also provide a specialized message for the AssertionFailure in case I fail.
 	"
 
 	^ self
-		assert: (actual includesAll: subcollection)
-		description: [ actual asString , ' does not include all in ' , subcollection asString ]
+		assert: (actualCollection includesAll: subcollection)
+		description: [ actualCollection asString , ' does not include all in ' , subcollection asString ]
 ]
 
 { #category : #asserting }
@@ -361,14 +361,14 @@ TestAsserter >> denyCollection: actualCollection equals: expectedCollection [
 ]
 
 { #category : #asserting }
-TestAsserter >> denyCollection: actual includesAll: subcollection [
+TestAsserter >> denyCollection: actualCollection includesAll: subcollection [
 	"Raises an AssertionFailure if actualCollection INCLUDES all the elements of expectedCollection (by negating result of #includesAll: message).
 	 I also provide a specialized message for the AssertionFailure in case I fail.
 	"
 	
 	^ self
-		assert: (actual includesAll: subcollection) not
-		description: [ actual asString , ' does not include all in ' , subcollection asString ]
+		assert: (actualCollection includesAll: subcollection) not
+		description: [ actualCollection asString , ' does not include all in ' , subcollection asString ]
 ]
 
 { #category : #asserting }

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -335,6 +335,14 @@ TestAsserter >> denyCollection: actual equals: expected [
 ]
 
 { #category : #asserting }
+TestAsserter >> denyCollection: actual includesAll: subcollection [
+
+	^ self
+		assert: (actual includesAll: subcollection) not
+		description: [ actual asString , ' does not include all in ' , subcollection asString ]
+]
+
+{ #category : #asserting }
 TestAsserter >> denyEmpty: aCollection [
 	^ self assert: aCollection isNotEmpty description: aCollection asString , ' should not have been empty'
 ]

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -279,7 +279,7 @@ TestAsserter >> defaultTestFailure [
 
 { #category : #asserting }
 TestAsserter >> deny: aBooleanOrBlock [
-	"to assert something that should not be true"
+	"This method raises an AssertionFailure if aBooleanOrBlock evaluates to true."
 	self deny: aBooleanOrBlock description: 'Denial failed'
 ]
 
@@ -299,6 +299,8 @@ TestAsserter >> deny: actualNumber closeTo: expectedNumber precision: epsilon [
 
 { #category : #asserting }
 TestAsserter >> deny: aBooleanOrBlock description: aString [
+	"This method raises an AssertionFailure with aString as #messageText if
+	 aBooleanOrBlock evaluates to true."
 	self deny: aBooleanOrBlock description: aString resumable: false
 ]
 

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -269,8 +269,7 @@ TestAsserter >> defaultTestFailure [
 { #category : #asserting }
 TestAsserter >> deny: aBooleanOrBlock [
 	"to assert something that should not be true"
-
-	self assert: aBooleanOrBlock value not
+	self deny: aBooleanOrBlock description: 'Denial failed'
 ]
 
 { #category : #asserting }


### PR DESCRIPTION
Fix 3064