### PR TITLE
2959-Epicea-doesnt-reload-events-in-the-correct-order

### DIFF
--- a/src/EpiceaBrowsers-Tests/EpLostChangesDetectorTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpLostChangesDetectorTest.class.st
@@ -5,7 +5,8 @@ Class {
 	#name : #EpLostChangesDetectorTest,
 	#superclass : #EpEnabledIntegrationTest,
 	#instVars : [
-		'detector'
+		'detector',
+		'detectedLostChanges'
 	],
 	#category : #'EpiceaBrowsers-Tests-Integration'
 }
@@ -31,24 +32,7 @@ EpLostChangesDetectorTest >> testDetectNoChange [
 ]
 
 { #category : #tests }
-EpLostChangesDetectorTest >> testDetectOneChange [
-
-	| logWithALostChange |
-	"Build a fake log with a lost change"
-	classFactory newClass.
-	logWithALostChange := EpLog newWithStore: monitor sessionStore store flush copyReopened refresh.
-	classFactory newClass.
-	monitor sessionStore flush.
-
-	detector := EpLostChangesDetector newWithLog: logWithALostChange.
-	self assert: detector hasLostChanges.
-	self assert: detector lostChanges size equals: 1.
-
-	self assert: monitor log entriesCount > 1. "Just to ensure assumptions of this test"
-]
-
-{ #category : #tests }
-EpLostChangesDetectorTest >> testDetectOneChangeButFileDeleted [
+EpLostChangesDetectorTest >> testDetectNoChangeBecauseLogFileWasDeleted [
 
 	| logWithALostChange |
 	"Build a fake log with a lost change"
@@ -63,5 +47,50 @@ EpLostChangesDetectorTest >> testDetectOneChangeButFileDeleted [
 	detector := EpLostChangesDetector newWithLog: logWithALostChange.
 	self deny: detector hasLostChanges.
 	self assertEmpty: detector lostChanges.
+
+]
+
+{ #category : #tests }
+EpLostChangesDetectorTest >> testDetectOneChangeDetectedAndOneIgnored [
+
+	| logWithALostChange |
+	"Create an initial change that will be ignored by the detector (read below)"
+	classFactory newClass.
+	
+	"Simulate the image session starts here (then previous change shouldn't be detected as lost... that's how it works)."
+	logWithALostChange := EpLog newWithStore: monitor sessionStore store flush copyReopened refresh.
+	classFactory newClass.
+	monitor sessionStore flush.
+	
+	"At this moment, the log meets the conditions of opening an image after a crash."
+	detector := EpLostChangesDetector newWithLog: logWithALostChange.
+
+	self assert: detector hasLostChanges.
+	self assert: detector lostChanges size equals: 1.
+	self assert: monitor log entriesCount > 1. "Just to ensure assumptions of this test"
+
+]
+
+{ #category : #tests }
+EpLostChangesDetectorTest >> testDetectThreeChanges [
+
+	| logWithLostChanges numberOfLostChanges expectedLostClassNames |
+
+	"Build a log with several lost changes (class additions)"
+	numberOfLostChanges := 3.
+	logWithLostChanges := EpLog newWithStore: monitor sessionStore store flush copyReopened refresh.
+	expectedLostClassNames := (1 to: numberOfLostChanges) collect: [ :each | classFactory newClass name ] as: Array.
+	monitor sessionStore flush.
+
+	"At this moment, the log meets the conditions of opening an image after a crash."
+	detector := EpLostChangesDetector newWithLog: logWithLostChanges.
+
+	detectedLostChanges := detector lostChanges.
+	detectedLostChanges do: [ :each | self assert: each content isEpClassChange ].
+
+	self assert: detectedLostChanges size equals: numberOfLostChanges.
+	self
+		assert: (detectedLostChanges collect: [ :each | each content behaviorAffectedName ]) asArray
+		equals: expectedLostClassNames.
 
 ]

--- a/src/EpiceaBrowsers-Tests/EpLostChangesDetectorTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpLostChangesDetectorTest.class.st
@@ -5,8 +5,7 @@ Class {
 	#name : #EpLostChangesDetectorTest,
 	#superclass : #EpEnabledIntegrationTest,
 	#instVars : [
-		'detector',
-		'detectedLostChanges'
+		'detector'
 	],
 	#category : #'EpiceaBrowsers-Tests-Integration'
 }
@@ -74,7 +73,7 @@ EpLostChangesDetectorTest >> testDetectOneChangeDetectedAndOneIgnored [
 { #category : #tests }
 EpLostChangesDetectorTest >> testDetectThreeChanges [
 
-	| logWithLostChanges numberOfLostChanges expectedLostClassNames |
+	| logWithLostChanges numberOfLostChanges expectedLostClassNames detectedLostChanges |
 
 	"Build a log with several lost changes (class additions)"
 	numberOfLostChanges := 3.

--- a/src/EpiceaBrowsers/EpLostChangesDetector.class.st
+++ b/src/EpiceaBrowsers/EpLostChangesDetector.class.st
@@ -101,7 +101,7 @@ EpLostChangesDetector >> lostChanges [
 	"Then, there are lost events"
 	entries := freshLog priorEntriesFrom: freshLog headReference upTo: lastSessionHeadReference.
 
-	^ entries ifNotEmpty: [ entries allButLast "reject lastSessionHeadReference's change"]
+	^ entries ifNotEmpty: [ entries allButLast reversed ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fixed "lost changes detector" and added a test. Also refactored a bit the already present tests.