### PR TITLE
3080-Review-testIndexOfSubCollectionStartingAtIfAbsent-Pharo-8

### DIFF
--- a/src/Collections-Tests/DictionaryTest.class.st
+++ b/src/Collections-Tests/DictionaryTest.class.st
@@ -559,17 +559,6 @@ DictionaryTest >> testIsHealthy [
 ]
 
 { #category : #'tests - dictionary key access' }
-DictionaryTest >> testKeyAtIdentityValueIfAbsent [
-
-	| dict value result |
-	dict := self nonEmpty.
-	value := dict values anyOne.
-	result := dict keyAtIdentityValue: value ifAbsent: [ nil ].
-	self assert: (dict at: result) equals: value.
-	self assert: (dict keyAtIdentityValue: self valueNotIn ifAbsent: [ nil ]) isNil
-]
-
-{ #category : #'tests - dictionary key access' }
 DictionaryTest >> testKeyAtValueIfAbsent [
  
 	| dict value result |


### PR DESCRIPTION
#3080  This PR aims at removing testKeyAtIdentityValueIfAbsent method from DictionaryTest class (TDictionaryKeyAccessTest).
testIndexOfSubCollectionStartingAtIfAbsent and testIncludesKeyLocalyDefined methods are not duplicated in pharo-8. 