### PR TITLE
3091-ExternalDataprintOn-not-as-extension

### DIFF
--- a/src/FFI-Kernel/ExternalData.class.st
+++ b/src/FFI-Kernel/ExternalData.class.st
@@ -81,6 +81,16 @@ ExternalData >> fromCStrings [
 	^strings
 ]
 
+{ #category : #printing }
+ExternalData >> printOn: stream [
+
+	stream 
+		nextPut: $(;
+		print: type; 
+		nextPut: $). 
+	self getHandle printOn: stream.
+]
+
 { #category : #private }
 ExternalData >> setHandle: aHandle type: aType [
 	handle := aHandle.

--- a/src/UnifiedFFI/ExternalData.extension.st
+++ b/src/UnifiedFFI/ExternalData.extension.st
@@ -27,16 +27,6 @@ ExternalData >> copyFrom: start to: stop [
 ]
 
 { #category : #'*UnifiedFFI' }
-ExternalData >> printOn: stream [
-
-	stream 
-		nextPut: $(;
-		print: type; 
-		nextPut: $). 
-	self getHandle printOn: stream.
-]
-
-{ #category : #'*UnifiedFFI' }
 ExternalData >> readString [
 	self isNull ifTrue: [ ^ nil ].
 	^ self fromCString


### PR DESCRIPTION
#3091 moved extension from UnifiedFFI to FFI-Kernel