### PR TITLE
3006-When-a-test-fails-open-the-debugger-on-the-test-instead-of-on-Objectassert

### DIFF
--- a/src/Kernel/BlockClosure.class.st
+++ b/src/Kernel/BlockClosure.class.st
@@ -144,7 +144,7 @@ BlockClosure >> cull: anArg [
 	"([:x | x + 12] cull: 3)
 	>>> 15
 	"
-	
+	<debuggerCompleteToSender>
 	^numArgs = 0 
 		ifTrue: [self value]
 		ifFalse: [self value: anArg]
@@ -324,6 +324,7 @@ BlockClosure >> ifCurtailed: aBlock [
 	 primitive.  Primitive 198 always fails.  The VM uses prim 198 in a
 	 context's method as the mark for an ensure:/ifCurtailed: activation."
 	| complete result |
+	<debuggerCompleteToSender>
 	<primitive: 198>
 	result := self valueNoContextSwitch.
 	complete := true.
@@ -925,7 +926,7 @@ BlockClosure >> valueWithPossibleArgument: anArg [
 BlockClosure >> valueWithin: aDuration onTimeout: timeoutBlock [
 	"Evaluate the receiver.
 	If the evaluation does not complete in less than aDuration evaluate the timeoutBlock instead"
-
+	<debuggerCompleteToSender>
 	| theProcess delay watchdog tag |
 
 	aDuration <= Duration zero ifTrue: [^ timeoutBlock value ].

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -716,6 +716,7 @@ Context >> evaluateSignal: exception [
 	See MethodContext>>#isHandlerOrSignalingContext. "
 
 	<primitive: 199>
+	<debuggerCompleteToSender>
 	| value |
 	exception privHandlerContext: self contextTag.
 	value := self exceptionHandlerBlock cull: exception.	
@@ -842,7 +843,7 @@ Context >> findSimilarSender [
 { #category : #'private-exceptions' }
 Context >> handleSignal: exception [
 	"Sent to handler (on:do:) contexts only.  If my exception class (first arg) handles exception then execute my handle block (second arg), otherwise forward this message to the next handler context.  If none left, execute exception's defaultAction (see nil>>handleSignal:)."
-
+	<debuggerCompleteToSender>
 	(self exceptionClass handles: exception)
 		ifFalse: [ ^ self nextHandlerContext handleSignal: exception ].
 	self evaluateSignal: exception

--- a/src/Kernel/Delay.class.st
+++ b/src/Kernel/Delay.class.st
@@ -365,7 +365,7 @@ Delay >> unschedule [
 { #category : #delaying }
 Delay >> wait [
 	"Schedule this Delay, then wait on its semaphore. The current process will be suspended for the amount of time specified when this Delay was created."
-
+	<debuggerCompleteToSender>
 	self schedule.
 	[delaySemaphore wait] ifCurtailed:[self unschedule].
 

--- a/src/Kernel/Exception.class.st
+++ b/src/Kernel/Exception.class.st
@@ -281,7 +281,7 @@ Exception >> searchFrom: aContext [
 { #category : #signaling }
 Exception >> signal [
 	"Ask ContextHandlers in the sender chain to handle this signal.  The default is to execute and return my defaultAction."
-
+	<debuggerCompleteToSender>
 	signalContext := thisContext contextTag.
 	signaler ifNil: [ signaler := self receiver ].
 	^ signalContext nextHandlerContext handleSignal: self

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -365,13 +365,14 @@ Object >> asString [
 Object >> assert: aBlock [
 	"Throw an assertion error if aBlock does not evaluates to true.
 	We check for true explicitly to make the assertion fail for non booleans"
+	<debuggerCompleteToSender>
 	self assert: aBlock description: 'Assertion failed'.
 ]
 
 { #category : #asserting }
 Object >> assert: aBlock description: aStringOrBlock [
 	"Throw an assertion error if aBlock does not evaluates to true."
-	
+	<debuggerCompleteToSender>
 	aBlock value 
 		ifFalse: [ AssertionFailure signal: aStringOrBlock value ]
 ]

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -455,7 +455,7 @@ Process >> pvtSignal: anException list: aList [
 	"Since this method is not called in a normal way, we need to take care
 	that it doesn't directly return to the caller (because I believe that could
 	have the potential to push an unwanted object on the caller's stack)."
-
+	<debuggerCompleteToSender>
 	| blocker |
 	self isActiveProcess ifFalse: [^self].
 	anException signal.

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -66,7 +66,7 @@ TestAsserter class >> suiteClass [
 { #category : #asserting }
 TestAsserter >> assert: actualNumber closeTo: expectedNumber [
 	"Tell whether the actualNumber and expectedNumber are close from each with a margin of 0.0001"
-
+	<debuggerCompleteToSender>
 	^ self
 		assert: (actualNumber closeTo: expectedNumber)
 		description: [ self comparingStringBetween: actualNumber and: expectedNumber ]
@@ -75,7 +75,7 @@ TestAsserter >> assert: actualNumber closeTo: expectedNumber [
 { #category : #asserting }
 TestAsserter >> assert: aBooleanOrBlock description: aStringOrBlock [
 	"Take a second argument wich is a message string that describes the reason for the failure, this string will be displayed by the Test Runner"
-
+	<debuggerCompleteToSender>
 	aBooleanOrBlock value
 		ifFalse: [ | aString |
 			aString := aStringOrBlock value.
@@ -107,7 +107,7 @@ TestAsserter >> assert: aBooleanOrBlock description: aStringOrBlock resumable: r
 { #category : #asserting }
 TestAsserter >> assert: actual equals: expected [
 	"Validate whether or not the actual value is equal than the expected, if the assertion fails it provides a description that show both the actual and the expected value"
-	
+	<debuggerCompleteToSender>
 	^ self
 		assert: actual = expected
 		description: [self comparingStringBetween: actual and: expected]
@@ -277,7 +277,7 @@ TestAsserter >> defaultTestFailure [
 { #category : #asserting }
 TestAsserter >> deny: aBooleanOrBlock [
 	"to assert something that should not be true"
-
+	<debuggerCompleteToSender>
 	self assert: aBooleanOrBlock value not
 ]
 
@@ -371,7 +371,7 @@ TestAsserter >> logFailure: aString [
 { #category : #asserting }
 TestAsserter >> should: aBlock [
 	"Evaluate the Block first then execute the assertion"
-
+	<debuggerCompleteToSender>
 	self assert: aBlock value
 ]
 
@@ -385,7 +385,7 @@ TestAsserter >> should: aBlock description: aString [
 TestAsserter >> should: aBlock notTakeMoreThan: aDuration [
     "Evaluate aBlock and if it takes more than given duration
     to run we report a test failure. "
-
+	<debuggerCompleteToSender>
 	^ aBlock valueWithin: aDuration onTimeout: [
 		self 
 			assert: false 
@@ -405,7 +405,7 @@ TestAsserter >> should: aBlock notTakeMoreThanMilliseconds: anInteger [
 { #category : #asserting }
 TestAsserter >> should: aBlock raise: anExceptionalEvent [
 	"To test that a particular exception is raised during the execution of a Block"
-
+	<debuggerCompleteToSender>
 	^ self assert: (self executeShould: aBlock inScopeOf: anExceptionalEvent)
 ]
 
@@ -432,19 +432,20 @@ TestAsserter >> should: aBlock raise: anExceptionalEvent whoseDescriptionInclude
 
 { #category : #asserting }
 TestAsserter >> should: aBlock raise: anException withExceptionDo: anotherBlock [ 
-
+	<debuggerCompleteToSender>
 	^self assert: (self executeShould: aBlock inScopeOf: anException withExceptionDo: anotherBlock)
 ]
 
 { #category : #asserting }
 TestAsserter >> shouldFix: aBlock [
 	"Run the block expecting an Exception. Throw an assertion failure if the block does NOT throw an exception."
-
+	<debuggerCompleteToSender>
 	^ self should: aBlock raise: Exception
 ]
 
 { #category : #asserting }
 TestAsserter >> shouldnt: aBlock [
+	<debuggerCompleteToSender>
 	self deny: aBlock value
 			
 ]
@@ -457,7 +458,7 @@ TestAsserter >> shouldnt: aBlock description: aString [
 
 { #category : #asserting }
 TestAsserter >> shouldnt: aBlock raise: anExceptionalEvent [  
-	 
+	<debuggerCompleteToSender>
 	^self assert: (self executeShould: aBlock inScopeOf: anExceptionalEvent) not
 			
 ]


### PR DESCRIPTION
I have added <debuggerCompleteToSender> pragma to TestAsserter methods in the protocol #asserting