### PR TITLE
3119-Failing-test-on-CI-MorphicTextInputFieldAdapterTesttestMaxLengthIsSetInWidget

### DIFF
--- a/src/Rubric/RubTextFieldMorph.class.st
+++ b/src/Rubric/RubTextFieldMorph.class.st
@@ -7,7 +7,8 @@ Class {
 	#instVars : [
 		'hasValidText',
 		'acceptOnCR',
-		'entryCompletion'
+		'entryCompletion',
+		'maxLength'
 	],
 	#category : #'Rubric-Editing-Widgets'
 }
@@ -149,6 +150,7 @@ RubTextFieldMorph >> initialize [
 	self scrollbarsShowNever.
 	self extent: self extent.
 	acceptOnCR := true.
+	maxLength := 0.
 	self beDecrypted
 ]
 
@@ -163,6 +165,26 @@ RubTextFieldMorph >> keyboardFocusChange: aBoolean [
 RubTextFieldMorph >> manageLayoutInBounds: aRectangle [
 	super manageLayoutInBounds: aRectangle.
 	self closeChooser 
+]
+
+{ #category : #accessing }
+RubTextFieldMorph >> maxLength [
+	
+	"Returns the max length of this text field.
+	0 meaning unlimited"
+	^ maxLength
+]
+
+{ #category : #accessing }
+RubTextFieldMorph >> maxLength: anInteger [
+	"Sets the max length of the text field.
+	0 means unlimited"
+	maxLength := anInteger.
+	maxLength = 0 ifTrue: [ ^ self ].
+	
+	"If the contents of this textfield exceed the max length, contents are truncated"
+	self getText size > maxLength
+		ifTrue: [ self setText: (self getText first: maxLength) ]
 ]
 
 { #category : #'model protocol' }

--- a/src/Spec-MorphicAdapters/MorphicTextInputFieldAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTextInputFieldAdapter.class.st
@@ -47,14 +47,12 @@ MorphicTextInputFieldAdapter >> buildWidget [
 		dropEnabled: self dropEnabled;
 		hResizing: #spaceFill;
 		vResizing: #spaceFill;
-		acceptOnCR: self acceptOnCR.
-		"maxLength: self presenter maxLength."
-		"comment for now."
+		acceptOnCR: self acceptOnCR;
+		maxLength: self presenter maxLength.
 	self presenter whenTextChangedDo: [ :text | plu setText: text ].
 	self presenter whenPlaceholderChangedDo: [ :text | plu ghostText: text ].
 	self presenter whenVisibilityChangedDo: [ :isVisible | plu encrypted: isVisible not ].	
-	"self presenter whenMaxLengthChangedDo: [ :length | plu maxLength: length ]."
-	"comment for now."
+	self presenter whenMaxLengthChangedDo: [ :length | plu maxLength: length ].
 	^ plu
 ]
 


### PR DESCRIPTION
Fix #3119 - make Rubric text field accept max length - make rubric truncate when max length is set - this fixes (the existing) spec tests (and should help getting the CI green)However, rubric does not yet prevent typing when maxLength is set (see issue https://github.com/pharo-project/pharo/issues/3128)