### PR TITLE
[fix] Weird semantic on #propertyAt:ifPresent:IfAbsent: in RBProgramNode

### DIFF
--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -683,7 +683,7 @@ RBProgramNode >> propertyAt: aKey ifAbsent: aBlock [
 	"Answer the property value associated with aKey or, if aKey isn't found, answer the result of evaluating aBlock."
 	
 	^ properties 
-		ifNil: [ aBlock value ]
+		ifNil: aBlock
 		ifNotNil: [ properties at: aKey ifAbsent: aBlock ]
 ]
 
@@ -698,7 +698,7 @@ RBProgramNode >> propertyAt: aKey ifAbsentPut: aBlock [
 RBProgramNode >> propertyAt: aKey ifPresent: aPresentBlock ifAbsent: anAbsentBlock [
 	"Answer the property value associated with aKey or, if aKey is found, answer the result of evaluating aPresentBlock, else evaluates anAbsentBlock."
 
-	^ properties ifNil: [ anAbsentBlock ] ifNotNil: [ properties at: aKey ifPresent: aPresentBlock ifAbsent: anAbsentBlock ]
+	^ properties ifNil: anAbsentBlock ifNotNil: [ properties at: aKey ifPresent: aPresentBlock ifAbsent: anAbsentBlock ]
 ]
 
 { #category : #properties }


### PR DESCRIPTION
AbsentBlock has to be valued manually by the caller (or it won't be evaluated).  Changed #propertyAt:ifAbsent: to avoid creating a useless new block object.