### PR TITLE
Pharo8.0-ffi

### DIFF
--- a/src/FreeType/FFIExternalStructureReferenceHandle.extension.st
+++ b/src/FreeType/FFIExternalStructureReferenceHandle.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #FFIExternalStructureReferenceHandle }
-
-{ #category : #'*FreeType' }
-FFIExternalStructureReferenceHandle >> asExternalAddress [
-	^ handle + startOffset
-]

--- a/src/UnifiedFFI-Tests/FFICallbackParametersTests.class.st
+++ b/src/UnifiedFFI-Tests/FFICallbackParametersTests.class.st
@@ -290,6 +290,37 @@ FFICallbackParametersTests >> testPassing4IntStructureInTheStack [
 ]
 
 { #category : #running }
+FFICallbackParametersTests >> testPassingPassableStruct [
+	"Tests that a large struct passed by value can be passed to another callback."
+			
+	| param handleWasExternalAddress |
+
+	handleWasExternalAddress := false.
+	callback := FFICallback 
+		signature: #(int (FFITestStructure4Int64Structure a))
+		block: [ :a |
+			self assert: a x equals: 2. 
+			self assert: a y equals: 3. 
+			self assert: a w equals: 5. 
+			self assert: a z equals: 7. 
+
+			handleWasExternalAddress := a getHandle isExternalAddress.
+			99		
+		].
+
+	param := FFITestStructure4Int64Structure externalNew
+		x: 2;
+		y: 3;
+		w: 5;
+		z: 7;
+		autoRelease;
+		yourself.
+
+	self assert: (self callCallback: callback withArgs: { param }) equals: 99.
+	self assert: handleWasExternalAddress description: 'The handle of "a" was an ExternalAddress'.
+]
+
+{ #category : #running }
 FFICallbackParametersTests >> testPassingStructureInTheStack [ 
 	
 	| param |

--- a/src/UnifiedFFI/ExternalAddress.extension.st
+++ b/src/UnifiedFFI/ExternalAddress.extension.st
@@ -8,6 +8,11 @@ ExternalAddress >> adoptAddress: anExternalAddress [
 ]
 
 { #category : #'*UnifiedFFI' }
+ExternalAddress >> asExternalAddress [
+	^self
+]
+
+{ #category : #'*UnifiedFFI' }
 ExternalAddress >> autoRelease [
 	^ self class finalizationRegistry add: self
 ]
@@ -132,6 +137,11 @@ ExternalAddress >> pointer [
 ExternalAddress >> pointerAutoRelease [
 	"Same as #pointer (see its comment for detals), but contents are garbage collected automatically"
 	^ self pointer autoRelease
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> referenceStructAt: byteOffset length: length [
+	^self + (byteOffset - 1)
 ]
 
 { #category : #'*UnifiedFFI-Deprecated50' }

--- a/src/UnifiedFFI/FFICallbackArgumentReader.class.st
+++ b/src/UnifiedFFI/FFICallbackArgumentReader.class.st
@@ -194,7 +194,7 @@ FFICallbackArgumentReader >> extractPointerOfType: aType [
 
 	| pair baseAddressToRead offsetOfBaseAddress |
 	pair := self nextBaseAddressFor: aType.
-	baseAddressToRead := pair first.
+	baseAddressToRead := ExternalAddress fromAddress: pair first address.
 	offsetOfBaseAddress := pair second.
 
 	extractedArguments add: (aType handle: baseAddressToRead at: offsetOfBaseAddress).
@@ -207,7 +207,7 @@ FFICallbackArgumentReader >> extractStructType: type [
 	| pair baseAddressToRead offsetOfBaseAddress |
 	
 	pair := self nextBaseAddressForStructure: type.
-	baseAddressToRead := pair first.
+	baseAddressToRead := ExternalAddress fromAddress: pair first address.
 	offsetOfBaseAddress := pair second.
 
 	extractedArguments add: (type handle: baseAddressToRead at: offsetOfBaseAddress).

--- a/src/UnifiedFFI/FFIExternalStructureReferenceHandle.class.st
+++ b/src/UnifiedFFI/FFIExternalStructureReferenceHandle.class.st
@@ -42,6 +42,11 @@ FFIExternalStructureReferenceHandle class >> new [
 ]
 
 { #category : #converting }
+FFIExternalStructureReferenceHandle >> asExternalAddress [
+	^ handle + startOffset
+]
+
+{ #category : #converting }
 FFIExternalStructureReferenceHandle >> asExternalPointer [
 	"Convert the receiver assuming that it describes a pointer to an object."
 	^(ExternalAddress new)


### PR DESCRIPTION
Add testcase for the internal structure of the read FFIExternalStructure

Any idea how to make this more than a change detector? I want to asses that "a" is a valid object and can be used for future FFI. I tried to call another callback from within the callback but that seemed to deadlock.