### PR TITLE
Make size_t work inside a nested structure

### DIFF
--- a/src/UnifiedFFI-Tests/FFIExternalStructureFieldParserTests.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalStructureFieldParserTests.class.st
@@ -30,7 +30,7 @@ FFIExternalStructureFieldParserTests >> testParseFieldsStructure [
 		structure: FFITestStructure.
 		
 	self assert: fieldSpec notNil. 
-	self assert: fieldSpec fieldNames equals: #(byte short long float double int64 ulong).
+	self assert: fieldSpec fieldNames equals: #(byte short long float double int64 ulong size_t).
 	self assert: (fieldSpec typeFor: #byte) class equals: FFIUInt8.
 	self assert: (fieldSpec typeFor: #short) class equals: FFIInt16.
 	self assert: (fieldSpec typeFor: #long) class equals: FFILong.
@@ -38,5 +38,6 @@ FFIExternalStructureFieldParserTests >> testParseFieldsStructure [
 	self assert: (fieldSpec typeFor: #double) class equals: FFIFloat64.
 	self assert: (fieldSpec typeFor: #int64) class equals: FFIInt64.
 	self assert: (fieldSpec typeFor: #ulong) class equals: FFIULong.
+	self assert: (fieldSpec typeFor: #size_t) class equals: FFISizeT.
 	
 ]

--- a/src/UnifiedFFI-Tests/FFIExternalStructureTests.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalStructureTests.class.st
@@ -127,6 +127,7 @@ FFIExternalStructureTests >> testNestedStructure [
 	s1 nested byte: 42.
 	s1 nested float: 4.0.
 	s1 nested double: 42.0.
+	s1 nested size_t: 23.
 
 	s1 nested long: -123456.
 	s1 nested ulong: 123456.
@@ -136,6 +137,7 @@ FFIExternalStructureTests >> testNestedStructure [
 	self assert: s1 nested double equals: 42.0.	
 	self assert: s1 nested long equals: -123456.
 	self assert: s1 nested ulong equals: 123456.
+	self assert: s1 nested size_t equals: 23.
 
 ]
 

--- a/src/UnifiedFFI-Tests/FFITestNestingStructure.class.st
+++ b/src/UnifiedFFI-Tests/FFITestNestingStructure.class.st
@@ -30,13 +30,13 @@ FFITestNestingStructure class >> initialize [
 { #category : #'accessing structure variables' }
 FFITestNestingStructure >> nested [
 	"This method was automatically generated"
-	^FFITestStructure fromHandle: (handle referenceStructAt: OFFSET_NESTED length: 28)
+	^ FFITestStructure fromHandle: (handle referenceStructAt: OFFSET_NESTED length: FFITestStructure byteSize)
 ]
 
 { #category : #'accessing structure variables' }
 FFITestNestingStructure >> nested: anObject [
 	"This method was automatically generated"
-	handle structAt: OFFSET_NESTED put: anObject getHandle length: 28.
+	handle structAt: OFFSET_NESTED put: anObject getHandle length: FFITestStructure byteSize
 ]
 
 { #category : #'accessing structure variables' }

--- a/src/UnifiedFFI-Tests/FFITestStructure.class.st
+++ b/src/UnifiedFFI-Tests/FFITestStructure.class.st
@@ -11,6 +11,7 @@ Class {
 		'OFFSET_INT64',
 		'OFFSET_LONG',
 		'OFFSET_SHORT',
+		'OFFSET_SIZE_T',
 		'OFFSET_ULONG'
 	],
 	#category : #'UnifiedFFI-Tests-Test-Data'
@@ -27,6 +28,7 @@ FFITestStructure class >> fieldsDesc [
 		double double;
 		int64 int64;
 		ulong ulong;
+		size_t size_t;
 		)
 ]
 
@@ -105,6 +107,18 @@ FFITestStructure >> short [
 FFITestStructure >> short: anObject [
 	"This method was automatically generated"
 	handle signedShortAt: OFFSET_SHORT put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructure >> size_t [
+	"This method was automatically generated"
+	^handle platformSizeTAt: OFFSET_SIZE_T
+]
+
+{ #category : #'accessing structure variables' }
+FFITestStructure >> size_t: anObject [
+	"This method was automatically generated"
+	^handle platformSizeTAt: OFFSET_SIZE_T put: anObject
 ]
 
 { #category : #'accessing structure variables' }

--- a/src/UnifiedFFI/FFIExternalStructureReferenceHandle.class.st
+++ b/src/UnifiedFFI/FFIExternalStructureReferenceHandle.class.st
@@ -143,6 +143,16 @@ FFIExternalStructureReferenceHandle >> platformLongAt: byteOffset put: value [
 ]
 
 { #category : #accessing }
+FFIExternalStructureReferenceHandle >> platformSizeTAt: byteOffset [ 
+	^ handle platformSizeTAt: startOffset + byteOffset
+]
+
+{ #category : #accessing }
+FFIExternalStructureReferenceHandle >> platformSizeTAt: byteOffset put: aValue [ 
+	^ handle platformSizeTAt: startOffset + byteOffset put: aValue
+]
+
+{ #category : #accessing }
 FFIExternalStructureReferenceHandle >> platformUnsignedLongAt: byteOffset [
 	^ handle platformUnsignedLongAt: startOffset + byteOffset
 ]


### PR DESCRIPTION
Add the missing selectors to forward the get/set to the bytearray at the right offset.