### PR TITLE
[Partial Fix] Experiment to test FreeType Problem

### DIFF
--- a/src/FreeType-Tests/FreeTypeCacheTest.class.st
+++ b/src/FreeType-Tests/FreeTypeCacheTest.class.st
@@ -113,6 +113,47 @@ FreeTypeCacheTest >> testFreeTypeCacheEntry [
 ]
 
 { #category : #tests }
+FreeTypeCacheTest >> testGlyphAccessIsThreadSafe [
+
+	"This test is weak because it depends in the rendering of Morphic and Rubrik"
+	"This test breaks 95% of times"	
+
+	self timeLimit: 10 seconds.
+	
+	10 timesRepeat: [  
+		 | sem text canvases blocky |
+
+		sem := Semaphore new.
+		text := (String loremIpsum: 25*1024).
+		FreeTypeCache current removeAll.
+		canvases := OrderedCollection new.
+			
+		blocky := [  | canvas |
+			canvas := FormCanvas extent: 1000@1000.
+			canvases add: canvas.
+			(RubScrolledTextMorph new)
+					setText: text;
+					font: StandardFonts codeFont;
+					bounds: (0@0 corner: canvas form extent);
+					fullDrawOn: canvas.
+			sem signal ].
+			
+		blocky forkAt: 39.
+		blocky forkAt: 39.
+		blocky forkAt: 39.
+		
+		sem 
+			wait;
+			wait;
+			wait.	
+			
+		self assert: (((canvases at:1) form bits = (canvases at:2) form bits) and: [ ((canvases at:2) form bits = (canvases at:3) form bits) ]) 
+	].
+
+
+]
+
+{ #category : #tests }
 FreeTypeCacheTest >> testInstanceInitialization [
 	self assert: (cache instVarNamed: #maximumSize) = FreeTypeCache defaultMaximumSize.
 	self assert: (cache instVarNamed: #used) = 0.

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -14,7 +14,8 @@ Class {
 		'cachedAscent',
 		'cachedDescent',
 		'subPixelPositioned',
-		'symbolFont'
+		'symbolFont',
+		'mutex'
 	],
 	#pools : [
 		'FT2Constants',
@@ -383,12 +384,13 @@ FreeTypeFont >> glyphOf: aCharacter colorValue: aColorValue mono: monoBoolean su
 		charCode: aCharacter asUnicode asInteger
 		type: ((1+sub) << 32) + aColorValue
 		ifAbsentPut: [
-			FreeTypeGlyphRenderer current
-				glyphOf: aCharacter 
-				colorValue: aColorValue 
-				mono: monoBoolean 
-				subpixelPosition: sub 
-				font: self]
+			self mutex critical: [ 
+				FreeTypeGlyphRenderer current
+					glyphOf: aCharacter 
+					colorValue: aColorValue 
+					mono: monoBoolean 
+					subpixelPosition: sub 
+					font: self]]
 
 
 ]
@@ -664,14 +666,21 @@ FreeTypeFont >> mode41GlyphOf: aCharacter colorValue: aColorValue mono: monoBool
 		charCode: aCharacter asUnicode asInteger
 		type: (FreeTypeCacheGlyph + sub)
 		ifAbsentPut: [
-			FreeTypeGlyphRenderer current
-				mode41GlyphOf: aCharacter 
-				colorValue: aColorValue 
-				mono: monoBoolean 
-				subpixelPosition: sub 
-				font: self]
+			self mutex critical: [ 
+				FreeTypeGlyphRenderer current
+					mode41GlyphOf: aCharacter 
+					colorValue: aColorValue 
+					mono: monoBoolean 
+					subpixelPosition: sub 
+					font: self]]
 
 
+]
+
+{ #category : #accessing }
+FreeTypeFont >> mutex [
+
+	^ mutex ifNil: [ mutex := Semaphore forMutualExclusion ]
 ]
 
 { #category : #measuring }
@@ -790,12 +799,13 @@ FreeTypeFont >> subGlyphOf: aCharacter colorValue: aColorValue mono: monoBoolean
 		charCode: aCharacter asUnicode asInteger
 		type: FreeTypeCacheGlyphLCD + sub
 		ifAbsentPut: [
-			FreeTypeGlyphRenderer current
-				subGlyphOf: aCharacter 
-				colorValue: aColorValue 
-				mono: monoBoolean 
-				subpixelPosition: sub 
-				font: self]
+			self mutex critical: [ 
+				FreeTypeGlyphRenderer current
+					subGlyphOf: aCharacter 
+					colorValue: aColorValue 
+					mono: monoBoolean 
+					subpixelPosition: sub 
+					font: self]]
 
 
 ]


### PR DESCRIPTION
After checking the problem with Guille, we have the hypothesis of the source of the problem.
We have seen that accessing Free Type is not thread-safe.
Basically, the FTFace holds a structure that is filled up with the glyph and its information. 
As this structure is shared by the whole Font, only one request to a glyph can be executed at the time.

Also, we have seen that there many accesses to the glyphs outside the UI process. 
This problem started to appear as we starting to use Calypso (but it is not limited to it), as Calypso uses lazy tabs. The creation of these tabs is done outside the UI process.

This is only a hack to test our hypothesis. 
To fix it correctly we will have to rewrite the drawing of the glyphs and synchronize the access to the glyph data information. Also, we want to do it in a way that does not penalize the processing in the UI process. 

I have only patched the code that is used by the rendering of morphic, other renderings like Athens or any other user using FT should be correctly rewritten.