### PR TITLE
2975-Problem-when-you-read-an-mcz

### DIFF
--- a/src/Compression/ZipArchiveMember.class.st
+++ b/src/Compression/ZipArchiveMember.class.st
@@ -205,8 +205,9 @@ ZipArchiveMember >> contentStreamFromEncoding: encodingName [
 	"Answer my contents as a text stream.
 	Interpret the raw bytes with given encodingName"
 
-	^ (ByteArray new: self uncompressedSize streamContents: [ :stream |
-		self extractTo: stream ]) decodeWith: encodingName
+	^ ((ByteArray new: self uncompressedSize streamContents: [ :stream |
+		self extractTo: stream ]) decodeWith: encodingName)
+			readStream
 ]
 
 { #category : #reading }

--- a/src/UnifiedFFI/LibC.class.st
+++ b/src/UnifiedFFI/LibC.class.st
@@ -75,7 +75,8 @@ LibC >> macModuleName [
 
 { #category : #'api - misc' }
 LibC >> memCopy: src to: dest size: n [
-	^ self ffiCall: #(void *memcpy(void *dest, const void *src, size_t n))
+	^ self
+		ffiCall: #(#void #* #memcpy #(#void #* #dest #, #const #void #* #src #, #size_t #n))
 ]
 
 { #category : #'api - processes' }


### PR DESCRIPTION
Fix for #2975

contentStreamFromEncoding: should return a steam and not a string.

Fix for Pharo8. Should be backported for Pharo7.