### PR TITLE
2975-Problem-when-you-read-an-mcz-pharo7

### DIFF
--- a/src/Compression/ZipArchiveMember.class.st
+++ b/src/Compression/ZipArchiveMember.class.st
@@ -205,8 +205,10 @@ ZipArchiveMember >> contentStreamFromEncoding: encodingName [
 	"Answer my contents as a text stream.
 	Interpret the raw bytes with given encodingName"
 
-	^ (ByteArray new: self uncompressedSize streamContents: [ :stream |
-		self extractTo: stream ]) decodeWith: encodingName
+	^ ((ByteArray new: self uncompressedSize streamContents: [ :stream |
+		self extractTo: stream ])
+			decodeWith: encodingName)
+				readStream
 ]
 
 { #category : #reading }


### PR DESCRIPTION
Fix #2975contentStreamFromEncoding: should return a steam and not a string.Fix for Pharo7