### PR TITLE
3168-pharoversion-file-is-hardcoding-wrong-version

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -222,7 +222,7 @@ ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "FFIMethodRegistr
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" clean --release
 
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" save "Pharo"
-echo "70" > pharo.version
+echo "${PHARO_SHORT_VERSION}" > pharo.version
 
 # clean bak sources files
 rm -f *.bak

--- a/bootstrap/scripts/transform_32_into_64.sh
+++ b/bootstrap/scripts/transform_32_into_64.sh
@@ -59,7 +59,6 @@ for f in  ${PHARO_NAME_PREFIX}-32bit-*.zip; do
 	printf "\231\002\320\003" > displaySize.bin
 	dd if="displaySize.bin" of="${PHARO_NAME_PREFIX}-64bit-$HASH.image" bs=1 seek=40 count=4 conv=notrunc
 	
-	echo "${PHARO_SHORT_VERSION}" > pharo.version
 	PHARO_SOURCES_PREFIX=$(echo "${PHARO_NAME_PREFIX}" | cut -d'-' -f 1 | cut -d'.' -f 1-2)
 	zip ${PHARO_NAME_PREFIX}-64bit-$HASH.zip ${PHARO_NAME_PREFIX}-64bit-$HASH.* ${PHARO_SOURCES_PREFIX}*.sources pharo.version
 	rm -f *.image *.changes *.sources

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -162,6 +162,20 @@ ReleaseTest >> testObsoleteClasses [
 					print: obsoleteClasses ]]
 ]
 
+{ #category : #testing }
+ReleaseTest >> testPharoVersionFileExists [
+
+	"Test there is a pharo.version file next to this image containing the short version of this pharo image.
+	This file is required by the Pharo launcher to correctly detect the Pharo version we are running on."
+	
+	| pharoVersionFile |
+	pharoVersionFile := FileLocator imageDirectory / 'pharo.version'.
+	self assert: pharoVersionFile exists.
+	self
+		assert: pharoVersionFile readStream contents trimBoth
+		equals: SystemVersion current major asString,  SystemVersion current minor asString
+]
+
 { #category : #'testing - rpackage' }
 ReleaseTest >> testRPackageOrganizer [
 	"Ensure other tests temporary created organizers are collected"


### PR DESCRIPTION
Fix #3168
 - use pharo short version in pharo.version
 - create pharo.version in single place
 - add release test