### PR TITLE
3170-PreDebugger-should-work-with-Spec2

### DIFF
--- a/src/GT-Debugger/GTGenericStackDebugger.class.st
+++ b/src/GT-Debugger/GTGenericStackDebugger.class.st
@@ -368,9 +368,9 @@ GTGenericStackDebugger >> openWithNotification: notificationString [
 	"NOTE: When this method returns, a new process has been scheduled to
 	run the windows, and thus this notifier, but the previous active porcess
 	has not been suspended. The sender will do this."
-	
-	GTSpecPreDebugWindow new 
-		setTitle: self title;
+
+	GTSpecPreDebugWindow new
+		title: self title;
 		message: notificationString;
 		openWithSpec;
 		debugger: self

--- a/src/GT-Debugger/GTSpecPreDebugWindow.class.st
+++ b/src/GT-Debugger/GTSpecPreDebugWindow.class.st
@@ -9,17 +9,14 @@ Class {
 	#superclass : #DynamicComposablePresenter,
 	#instVars : [
 		'debugger',
-		'title',
 		'message'
 	],
 	#category : #'GT-Debugger-UI'
 }
 
 { #category : #specs }
-GTSpecPreDebugWindow class >> spec [
-	<spec: #default>
-		^ SpecLayout composed
-			yourself
+GTSpecPreDebugWindow class >> defaultSpec [
+	^ SpecLayout composed
 ]
 
 { #category : #'actions lookup' }
@@ -44,28 +41,15 @@ GTSpecPreDebugWindow >> buildButtonWidgetsSpecForActions: aCollection [
 
 { #category : #'building widgets' }
 GTSpecPreDebugWindow >> buildNotifierPaneWidgetsSpec [
-	
-	^ self message 
-		ifNil: [ {#stackPane. #MultiColumnListPresenter} ] 
-		ifNotNil: [ {#codePane. #TextPresenter} ]
+	^ self message
+		ifNil: [ {#stackPane . #TablePresenter} ]
+		ifNotNil: [ {#codePane . #TextPresenter} ]
 ]
 
 { #category : #actions }
 GTSpecPreDebugWindow >> clear [
 
 	self debugger ifNotNil: [ :aDebugger | aDebugger windowIsClosing ]
-]
-
-{ #category : #'building widgets' }
-GTSpecPreDebugWindow >> clearWidget [
-
-	self widgets removeAll.
-	
-	self needFullRebuild: true.
-	self needRebuild: false.
-	
- 	self buildWithSpecLayout: self emptyLayout	
-
 ]
 
 { #category : #actions }
@@ -179,26 +163,24 @@ GTSpecPreDebugWindow >> initializeCodePane [
 
 { #category : #initialization }
 GTSpecPreDebugWindow >> initializePresenter [
-
 	super initializePresenter.
-	
-	debugger whenChangedDo: [ :aDebugger |
-		aDebugger 
-			ifNil: [ self clearWidget ] 
-			ifNotNil:  [ self rebuildWidget ]	 ]
 
+	debugger whenChangedDo: [ :aDebugger | aDebugger ifNotNil: [ self rebuildWidget ] ]
 ]
 
 { #category : #'initialization widgets' }
 GTSpecPreDebugWindow >> initializeStackPane [
 	self stackPane
-		displayBlock: [ :aContext | self columnsFor: aContext ];
+		addColumn: (StringTableColumn title: 'Class' evaluated: [ :aContext | self debugger formatStackClassColumnForContext: aContext ]);
+		addColumn: (StringTableColumn title: 'Method' evaluated: [ :aContext | self debugger formatStackMethodColumnForContext: aContext ]);
+		addColumn: (StringTableColumn title: 'Extra' evaluated: [ :aContext | self debugger formatStackExtraColumnForContext: aContext ]);
 		items: self filteredStack;
 		whenSelectionChangedDo: [ :selection | 
-			[ :aContext | 
-			"Set the selection before, as debugAction removes the link with the debugger. "
-			self debugger stackPresentation selection: aContext.
-			self openFullDebugger ] cull: selection selectedItem ]
+			selection selectedItem
+				in: [ :aContext | 
+					"Set the selection before, as debugAction removes the link with the debugger. "
+					self debugger stackPresentation selection: aContext.
+					self openFullDebugger ] ]
 ]
 
 { #category : #accessing }
@@ -285,18 +267,11 @@ GTSpecPreDebugWindow >> setFocusOrderForActions: aCollection [
 
 { #category : #api }
 GTSpecPreDebugWindow >> setTitle: aString [
-
-	title := aString.
-	self updateTitle 
+	self deprecated: 'Use #title:' transformWith: '`@receiver setTitle: `@argument' -> '`@receiver title: `@argument'.
+	self title: aString
 ]
 
 { #category : #accessing }
 GTSpecPreDebugWindow >> stackPane [
-	^widgets at: #stackPane
-]
-
-{ #category : #api }
-GTSpecPreDebugWindow >> title [
-
-	^ title 
+	^ self widgets at: #stackPane
 ]


### PR DESCRIPTION
Make GTSpecPreDebugger work with Spec 2.

WARNING: This will break the possibility to open the full debugger by clicking on the stack for now. This will be fixed by the next Spec2 integration. The full debugger can still be opened by clicking on the "Debug" button. 
I propose the change because it'll make it easier to work on Spec2 like this (currently we get an emergency debugger at each error...) and will already be done for the next Spec2 integration.

Fixes #3170