### PR TITLE
ClassParser: methods polymorphic to RB-nodes for Calypso integration

### DIFF
--- a/src/ClassParser-Tests/CDBehaviorParserTest.class.st
+++ b/src/ClassParser-Tests/CDBehaviorParserTest.class.st
@@ -116,3 +116,25 @@ CDBehaviorParserTest >> testClassDefFromLegacyStringHasSlots [
 	self assert: classDefinition slotNodes first name equals: self firstInstanceVariableName.
 	self assert: classDefinition slotNodes second name equals: self secondInstanceVariableName.
 ]
+
+{ #category : #tests }
+CDBehaviorParserTest >> testClassNameNodeHaveParentReference [
+
+	| nameNode |
+	nameNode := classDefinition classNameNode.
+	
+	self assert: nameNode parent identicalTo: classDefinition.
+	self assert: nameNode classDefinitionNode identicalTo: classDefinition.
+	self assert: (classDefinition children includes: nameNode)
+]
+
+{ #category : #tests }
+CDBehaviorParserTest >> testSlotNodesHaveParentReference [
+
+	| slotNode |
+	slotNode := classDefinition slotNodes first.
+	
+	self assert: slotNode parent identicalTo: classDefinition.
+	self assert: slotNode classDefinitionNode identicalTo: classDefinition.
+	self assert: (classDefinition children includes: slotNode)
+]

--- a/src/ClassParser-Tests/CDClassWithFullDefinitionExample.class.st
+++ b/src/ClassParser-Tests/CDClassWithFullDefinitionExample.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #CDClassWithFullDefinitionExample,
+	#superclass : #Object,
+	#instVars : [
+		'instVar1',
+		'instVar2'
+	],
+	#classVars : [
+		'ClassVar1',
+		'ClassVar2'
+	],
+	#classInstVars : [
+		'classSideVar1',
+		'classSideVar2'
+	],
+	#category : #'ClassParser-Tests'
+}

--- a/src/ClassParser-Tests/CDExistingClassDefinitionTest.class.st
+++ b/src/ClassParser-Tests/CDExistingClassDefinitionTest.class.st
@@ -1,0 +1,93 @@
+Class {
+	#name : #CDExistingClassDefinitionTest,
+	#superclass : #CDBehaviorParserTest,
+	#category : #'ClassParser-Tests'
+}
+
+{ #category : #helpers }
+CDExistingClassDefinitionTest >> classDefinitionString [
+
+	^CDClassWithFullDefinitionExample definitionForNautilus 
+]
+
+{ #category : #helpers }
+CDExistingClassDefinitionTest >> className [
+
+	^ CDClassWithFullDefinitionExample name
+]
+
+{ #category : #helpers }
+CDExistingClassDefinitionTest >> firstInstanceVariableName [
+	
+	^ 'instVar1' 
+]
+
+{ #category : #helpers }
+CDExistingClassDefinitionTest >> secondInstanceVariableName [
+
+	^ 'instVar2'
+]
+
+{ #category : #helpers }
+CDExistingClassDefinitionTest >> testClassNameNodeIsPolymorphicToRBVariableNode [
+	
+	| nameNode |
+	nameNode := classDefinition classNameNode.
+	self assert: nameNode isVariable. "It is polymorphic to class reference nodes in method sources"
+	self deny: nameNode isTemp
+]
+
+{ #category : #helpers }
+CDExistingClassDefinitionTest >> testGettingExistingClass [
+	
+	| class |
+	class := classDefinition existingClassIfAbsent: [].
+	self assert: class equals: CDClassWithFullDefinitionExample 
+]
+
+{ #category : #helpers }
+CDExistingClassDefinitionTest >> testGettingExistingClassNameBinding [
+	
+	| binding |
+	binding := classDefinition classNameNode binding.
+	
+	self assert: binding class equals: OCLiteralVariable. "to be compatible to bindings in RB nodes".
+	self assert: binding assoc equals: CDClassWithFullDefinitionExample binding
+]
+
+{ #category : #helpers }
+CDExistingClassDefinitionTest >> testSharedSlotNodeArePolymorphicToRBVariableNodes [
+	
+	| classVarNode |
+	classVarNode := classDefinition sharedSlotNodes first.
+	
+	self assert: classVarNode isVariable.
+	self deny: classVarNode isTemp.
+	self deny: classVarNode isGlobalVariable.
+	self assert: classVarNode isClassVariable.
+	self deny: classVarNode isInstance.
+	self deny: classVarNode isLiteralVariable.
+	self deny: classVarNode isUndeclared.
+]
+
+{ #category : #helpers }
+CDExistingClassDefinitionTest >> testSlotNodeArePolymorphicToRBVariableNodes [
+	
+	| slotNode |
+	slotNode := classDefinition slotNodes first.
+	self assert: slotNode isVariable.
+	self deny: slotNode isTemp.
+	self deny: slotNode isGlobalVariable.
+	self deny: slotNode isClassVariable.
+	self assert: slotNode isInstance.
+	self deny: slotNode isLiteralVariable.
+	self deny: slotNode isUndeclared.
+]
+
+{ #category : #helpers }
+CDExistingClassDefinitionTest >> testSlotNodeBinding [
+	
+	| slotNode |
+	slotNode := classDefinition slotNodes first.
+	self assert: slotNode binding identicalTo: slotNode
+]

--- a/src/ClassParser-Tests/CDExistingClassSideDefinitionTest.class.st
+++ b/src/ClassParser-Tests/CDExistingClassSideDefinitionTest.class.st
@@ -1,0 +1,31 @@
+Class {
+	#name : #CDExistingClassSideDefinitionTest,
+	#superclass : #CDExistingClassDefinitionTest,
+	#category : #'ClassParser-Tests'
+}
+
+{ #category : #helpers }
+CDExistingClassSideDefinitionTest >> classDefinitionString [
+
+	^CDClassWithFullDefinitionExample class definitionForNautilus 
+]
+
+{ #category : #helpers }
+CDExistingClassSideDefinitionTest >> firstInstanceVariableName [
+	
+	^ 'classSideVar1' 
+]
+
+{ #category : #helpers }
+CDExistingClassSideDefinitionTest >> secondInstanceVariableName [
+
+	^ 'classSideVar2'
+]
+
+{ #category : #helpers }
+CDExistingClassSideDefinitionTest >> testGettingExistingClass [
+	
+	| class |
+	class := classDefinition existingClassIfAbsent: [].
+	self assert: class equals: CDClassWithFullDefinitionExample class
+]

--- a/src/ClassParser-Tests/CDVariableClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDVariableClassParserTest.class.st
@@ -23,5 +23,5 @@ CDVariableClassParserTest >> classDefinitionString [
 { #category : #helpers }
 CDVariableClassParserTest >> testVariableClassIsVariable [
 
-	self assert: (classDefinition isVariable)
+	self assert: classDefinition isVariableClass
 ]

--- a/src/ClassParser/CDBehaviorDefinitionNode.class.st
+++ b/src/ClassParser/CDBehaviorDefinitionNode.class.st
@@ -18,7 +18,12 @@ Class {
 CDBehaviorDefinitionNode >> addSlot: aCDSlotNode [
 	
 	slotNodes add: aCDSlotNode.
-	children add: aCDSlotNode
+	self addChild: aCDSlotNode
+]
+
+{ #category : #'as yet unclassified' }
+CDBehaviorDefinitionNode >> classDefinitionNode [
+	^self
 ]
 
 { #category : #accessing }
@@ -42,7 +47,7 @@ CDBehaviorDefinitionNode >> className: aName astNode: astNode [
 
 	className := aName.
 	classNameNode := astNode.
-	children add: astNode
+	self addChild: astNode
 ]
 
 { #category : #accessing }
@@ -60,7 +65,13 @@ CDBehaviorDefinitionNode >> classNameNode: aClassNameNode [
 CDBehaviorDefinitionNode >> classNameNode: aNode astNode: astNode [
 
 	classNameNode := aNode.
-	children add: aNode
+	self addChild: aNode
+]
+
+{ #category : #accessing }
+CDBehaviorDefinitionNode >> existingClassIfAbsent: aBlock [
+
+	^self classNameNode existingClassIfAbsent: aBlock
 ]
 
 { #category : #'initialize-release' }
@@ -94,7 +105,7 @@ CDBehaviorDefinitionNode >> isNormal [
 ]
 
 { #category : #testing }
-CDBehaviorDefinitionNode >> isVariable [
+CDBehaviorDefinitionNode >> isVariableClass [
 	
 	^ classKind = #variableSubclass:
 ]
@@ -127,7 +138,7 @@ CDBehaviorDefinitionNode >> slots [
 CDBehaviorDefinitionNode >> slots: aCollection [ 
 	
 	slotNodes := aCollection.
-	children addAll: aCollection
+	aCollection do: [ :each | self addChild: each ]
 	
 ]
 
@@ -141,5 +152,5 @@ CDBehaviorDefinitionNode >> traitDefinition [
 CDBehaviorDefinitionNode >> traitDefinition: aNode [
 
 	traitDefinition := aNode.
-	children add: aNode.
+	self addChild: aNode.
 ]

--- a/src/ClassParser/CDClassDefinitionNode.class.st
+++ b/src/ClassParser/CDClassDefinitionNode.class.st
@@ -1,6 +1,3 @@
-"
-I am the Class Definition as a Node, i represent a class and contains all the information for class creation.
-"
 Class {
 	#name : #CDClassDefinitionNode,
 	#superclass : #CDBehaviorDefinitionNode,
@@ -51,7 +48,7 @@ CDClassDefinitionNode >> packageNameNode [
 CDClassDefinitionNode >> packageNameNode: aNode astNode: astNode [
 
 	packageNameNode := aNode.
-	children add: aNode.
+	self addChild: aNode.
 ]
 
 { #category : #accessing }
@@ -63,7 +60,7 @@ CDClassDefinitionNode >> sharedPools [
 { #category : #accessing }
 CDClassDefinitionNode >> sharedPools: aCollection [ 
 	sharedPools := aCollection.
-	children addAll: aCollection
+	aCollection do: [ :each | self addChild: each ]
 ]
 
 { #category : #accessing }
@@ -83,7 +80,7 @@ CDClassDefinitionNode >> sharedSlots [
 { #category : #accessing }
 CDClassDefinitionNode >> sharedSlots: aCollection [ 
 	sharedSlotNodes := aCollection.
-	children addAll: aCollection
+	aCollection do: [ :each | self addChild: each ]
 ]
 
 { #category : #accessing }
@@ -102,7 +99,7 @@ CDClassDefinitionNode >> superclassName: aName astNode: astNode [
 	
 	superclassName := aName.
 	superclassNameNode := astNode.
-	children add: astNode.
+	self addChild: astNode.
 ]
 
 { #category : #accessing }

--- a/src/ClassParser/CDClassNameNode.class.st
+++ b/src/ClassParser/CDClassNameNode.class.st
@@ -1,6 +1,3 @@
-"
-I represent the name of classs, i may be removed in the future if i don't serve another purpose.
-"
 Class {
 	#name : #CDClassNameNode,
 	#superclass : #CDNode,
@@ -9,6 +6,15 @@ Class {
 	],
 	#category : #'ClassParser-Model'
 }
+
+{ #category : #accessing }
+CDClassNameNode >> binding [
+	| classBinding |
+	classBinding := self existingBindingIfAbsent: [className -> nil].
+	^OCLiteralVariable new 
+		scope: originalNode scope;
+		assoc: classBinding
+]
 
 { #category : #accessing }
 CDClassNameNode >> className [
@@ -20,6 +26,37 @@ CDClassNameNode >> className [
 CDClassNameNode >> className: aString [ 
 	
 	className := aString
+]
+
+{ #category : #accessing }
+CDClassNameNode >> existingBindingIfAbsent: aBlock [
+
+	| binding |
+	binding := originalNode methodNode compilationContext environment bindingOf: className.
+	^binding ifNil: aBlock
+]
+
+{ #category : #accessing }
+CDClassNameNode >> existingClassIfAbsent: aBlock [
+
+	| binding |
+	binding := self existingBindingIfAbsent: aBlock.
+	^binding value
+]
+
+{ #category : #testing }
+CDClassNameNode >> isTemp [
+	"To be polymorphic to RB method nodes"
+	^false
+]
+
+{ #category : #testing }
+CDClassNameNode >> isVariable [
+	"Existing class name is a variable 
+	to be polymorphic to method literal nodes which encode class reference"
+	
+	self existingBindingIfAbsent: [ ^false ].
+	^true
 ]
 
 { #category : #accessing }

--- a/src/ClassParser/CDMetaclassDefinitionNode.class.st
+++ b/src/ClassParser/CDMetaclassDefinitionNode.class.st
@@ -1,8 +1,12 @@
-"
-I am the meta class definition as a node, i come in pair with a class definition.
-"
 Class {
 	#name : #CDMetaclassDefinitionNode,
 	#superclass : #CDBehaviorDefinitionNode,
 	#category : #'ClassParser-Model'
 }
+
+{ #category : #accessing }
+CDMetaclassDefinitionNode >> existingClassIfAbsent: aBlock [
+	| existingClass |
+	existingClass := super existingClassIfAbsent: aBlock.	
+	^existingClass classSide
+]

--- a/src/ClassParser/CDNode.class.st
+++ b/src/ClassParser/CDNode.class.st
@@ -1,15 +1,16 @@
 "
-I'm the common superclass of all the class definition nodes. 
-A class definition is an object that is built out of the message sent to a class by the class definition parser. 
+I'm the common superclass of all the class definition nodes.
+A class definition is an object that is built out of the message sent to a class by the class definition parser.
 
-I keep a reference to the original method node (originalNode) I'm created from. 
+I keep a reference to the original method node (originalNode) I'm created from.
 
-Please note the vocabulary, we use the term class definition and class definition parser to refer to the class definition only and not the class with its methods. 
+Please note the vocabulary, we use the term class definition and class definition parser to refer to the class definition only and not the class with its methods.
 "
 Class {
 	#name : #CDNode,
 	#superclass : #Object,
 	#instVars : [
+		'parent',
 		'originalNode',
 		'children'
 	],
@@ -26,8 +27,9 @@ CDNode class >> on: aRBMessageNode [
 
 { #category : #accessing }
 CDNode >> addChild: aChild [
-	
-	children add: aChild
+
+	children add: aChild.
+	aChild parent: self
 ]
 
 { #category : #compatibility }
@@ -52,6 +54,11 @@ CDNode >> bestNodeFor: anInterval [
 CDNode >> children [
 
 	^ children
+]
+
+{ #category : #accessing }
+CDNode >> classDefinitionNode [
+	^parent classDefinitionNode
 ]
 
 { #category : #selection }
@@ -90,6 +97,24 @@ CDNode >> intersectsInterval: anInterval [
 		or: [self start between: anInterval first and: anInterval last]
 ]
 
+{ #category : #testing }
+CDNode >> isMessage [
+	"To be polymorphic to RB method nodes"
+	^false
+]
+
+{ #category : #testing }
+CDNode >> isMethod [
+	"To be polymorphic to RB method nodes"
+	^false
+]
+
+{ #category : #testing }
+CDNode >> isVariable [
+	"To be polymorphic to RB method nodes"
+	^false
+]
+
 { #category : #'as yet unclassified' }
 CDNode >> originalNode [
 
@@ -108,6 +133,21 @@ CDNode >> originalNodeSource [
 
 	^originalNode source.
 	
+]
+
+{ #category : #'' }
+CDNode >> parent [
+	^ parent
+]
+
+{ #category : #accessing }
+CDNode >> parent: anObject [
+	parent := anObject
+]
+
+{ #category : #accessing }
+CDNode >> sourceInterval [
+	^originalNode sourceInterval
 ]
 
 { #category : #selection }

--- a/src/ClassParser/CDSharedVariableNode.class.st
+++ b/src/ClassParser/CDSharedVariableNode.class.st
@@ -39,9 +39,3 @@ CDSharedVariableNode >> isVariable [
 		^false ].
 	^existingClass hasClassVarNamed: name asSymbol
 ]
-
-{ #category : #suggestions }
-CDSharedVariableNode >> specialCommands [
-
-	^ SugsSuggestionFactory commandsForClassVariable
-]

--- a/src/ClassParser/CDSharedVariableNode.class.st
+++ b/src/ClassParser/CDSharedVariableNode.class.st
@@ -1,6 +1,3 @@
-"
-I represent a variable shared by instances of my class. (class variable)
-"
 Class {
 	#name : #CDSharedVariableNode,
 	#superclass : #CDSlotNode,
@@ -19,4 +16,32 @@ CDSharedVariableNode class >> slot: aSlot node: aNode [
 { #category : #transforming }
 CDSharedVariableNode >> asClassVariable [
 	^ ClassVariable named: self name.
+]
+
+{ #category : #testing }
+CDSharedVariableNode >> isClassVariable [
+	"To be polymorphic to RB method nodes"
+	^true
+]
+
+{ #category : #testing }
+CDSharedVariableNode >> isInstance [
+	"To be polymorphic to RB method nodes"
+	^false
+]
+
+{ #category : #testing }
+CDSharedVariableNode >> isVariable [
+	"To be polymorphic to RB method nodes"
+	| existingClass |
+	existingClass := self classDefinitionNode existingClassIfAbsent: [
+		"Until class will be created the variables does not exist yet"
+		^false ].
+	^existingClass hasClassVarNamed: name asSymbol
+]
+
+{ #category : #suggestions }
+CDSharedVariableNode >> specialCommands [
+
+	^ SugsSuggestionFactory commandsForClassVariable
 ]

--- a/src/ClassParser/CDSlotNode.class.st
+++ b/src/ClassParser/CDSlotNode.class.st
@@ -1,6 +1,3 @@
-"
-I represent a slot contain in a class. An instance variable for example.
-"
 Class {
 	#name : #CDSlotNode,
 	#superclass : #CDNode,
@@ -34,9 +31,66 @@ CDSlotNode >> asSlot [
 ]
 
 { #category : #accessing }
+CDSlotNode >> binding [
+	"To be polymorphic to RB method nodes"
+	^self
+]
+
+{ #category : #accessing }
 CDSlotNode >> index: anInteger [ 
 	
 	index := anInteger
+]
+
+{ #category : #testing }
+CDSlotNode >> isClassVariable [
+	"To be polymorphic to RB method nodes"
+	^false
+]
+
+{ #category : #testing }
+CDSlotNode >> isGlobalVariable [
+	"To be polymorphic to RB method nodes"
+	^false
+]
+
+{ #category : #testing }
+CDSlotNode >> isInstance [
+	"To be polymorphic to RB method nodes"
+	^true
+]
+
+{ #category : #testing }
+CDSlotNode >> isLiteralVariable [
+	"To be polymorphic to RB method nodes"
+	^false
+]
+
+{ #category : #testing }
+CDSlotNode >> isTemp [
+	"To be polymorphic to RB method nodes"
+	^false
+]
+
+{ #category : #testing }
+CDSlotNode >> isUndeclared [
+	"To be polymorphic to RB method nodes"
+	^false
+]
+
+{ #category : #testing }
+CDSlotNode >> isVariable [
+	"To be polymorphic to RB method nodes"
+	| existingClass |
+	existingClass := self classDefinitionNode existingClassIfAbsent: [   
+		"Until class will be created the variables does not exist yet" 
+		^false ].
+	^existingClass 
+		slotNamed: name asSymbol 
+		ifFound: [true] 
+		ifNone: [
+			"Until class will be compiled with new slot the new slot does not exist yet"
+			false]
 ]
 
 { #category : #accessing }
@@ -66,6 +120,11 @@ CDSlotNode >> printOn: aStream [
 		nextPutAll: ' => ';
 		nextPutAll: typeName;
 		nextPutAll: ')'
+]
+
+{ #category : #accessing }
+CDSlotNode >> sourceInterval [
+	^start to: stop
 ]
 
 { #category : #selection }

--- a/src/ClassParser/ShiftClassBuilder.extension.st
+++ b/src/ClassParser/ShiftClassBuilder.extension.st
@@ -22,7 +22,7 @@ ShiftClassBuilder >> buildFromAST: aCDClassDefinitionNode [
 		ifTrue: [ self layoutClass: WeakLayout ].
 	aCDClassDefinitionNode isImmediate
 		ifTrue: [ self layoutClass: ImmediateLayout ].
-	aCDClassDefinitionNode isVariable
+	aCDClassDefinitionNode isVariableClass
 		ifTrue: [ self layoutClass: VariableLayout ].
 	aCDClassDefinitionNode isWords
 		ifTrue: [ self layoutClass: WordLayout ].


### PR DESCRIPTION
- parent field is added to CD nodes
- methods polymorphic to RB-nodes which are required for Calypso integration (isLiteralVariable, isVariable, isGlobalVariable, etc)