### PR TITLE
Exporting MCZ from the BaselineOfMetacello

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -217,8 +217,9 @@ ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "Smalltalk vm par
 env 2>&1 > env.log
 
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "Metacello new baseline: 'Tonel';repository: 'github://pharo-vcs/tonel:v1.0.13';onWarning: [ :e | Error signal: e messageText in: e signalerContext ]; load: 'core'"
+${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "MCCacheRepository uniqueInstance disable"
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "Metacello new baseline: 'Pharo';repository: 'tonel://${BOOTSTRAP_REPOSITORY}/src';onWarning: [ :e | Error signal: e messageText in: e signalerContext ]; load"
-${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "FFIMethodRegistry resetAll. PharoSourcesCondenser condenseNewSources. Smalltalk garbageCollect"
+${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "MCCacheRepository uniqueInstance enable. FFIMethodRegistry resetAll. PharoSourcesCondenser condenseNewSources. Smalltalk garbageCollect"
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" clean --release
 
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" save "Pharo"

--- a/bootstrap/src/Pharo30Bootstrap.package/PBBootstrap.class/instance/ensureBaselineOfPharoBootstrap.st
+++ b/bootstrap/src/Pharo30Bootstrap.package/PBBootstrap.class/instance/ensureBaselineOfPharoBootstrap.st
@@ -3,3 +3,4 @@ ensureBaselineOfPharoBootstrap
 	(self originRepository versionWithInfo: (self originRepository versionInfoFromVersionNamed: 'Metacello-PharoExtensions')) load.
 	(self originRepository versionWithInfo: (self originRepository versionInfoFromVersionNamed: 'BaselineOfPharoBootstrap')) load.
 	(self originRepository versionWithInfo: (self originRepository versionInfoFromVersionNamed: 'BaselineOfTraits')) load.
+	(self originRepository versionWithInfo: (self originRepository versionInfoFromVersionNamed: 'BaselineOfMetacello')) load.	

--- a/bootstrap/src/Pharo30Bootstrap.package/PBBootstrap.class/instance/exportAllPackagesIntoMcz.st
+++ b/bootstrap/src/Pharo30Bootstrap.package/PBBootstrap.class/instance/exportAllPackagesIntoMcz.st
@@ -2,5 +2,5 @@ preparation
 exportAllPackagesIntoMcz
 
 	self mczCache directory ensureDeleteAll; ensureCreateDirectory.
-	self originRepository allFileNames do: [ :packageName |
+	self packagesToExportAsMCZ do: [ :packageName |
 		self exportIntoMcz: packageName ].

--- a/bootstrap/src/Pharo30Bootstrap.package/PBBootstrap.class/instance/exportMonticelloInStFile.st
+++ b/bootstrap/src/Pharo30Bootstrap.package/PBBootstrap.class/instance/exportMonticelloInStFile.st
@@ -2,7 +2,7 @@ preparation
 exportMonticelloInStFile
 
 	self
-		exportPackages: #('System-Model' 'Ring-Deprecated-ChunkImporter' 'Zinc-Resource-Meta-Core' 'System-Changes' 'Ring-Deprecated-Core-Kernel' 'Ring-Deprecated-Core-Containers' 'Ring-Deprecated-ChunkImporter'  'Compression' 'Monticello' 'Ring-Deprecated-Monticello' )
+		exportPackages: self monticelloPackageNames
 		usingInitializeScript: '
 		ChangeSet initialize.
 		

--- a/bootstrap/src/Pharo30Bootstrap.package/PBBootstrap.class/instance/monticelloNetworkPackageNames.st
+++ b/bootstrap/src/Pharo30Bootstrap.package/PBBootstrap.class/instance/monticelloNetworkPackageNames.st
@@ -1,0 +1,12 @@
+package-names
+monticelloNetworkPackageNames
+
+	^ #('Network-Kernel'
+		 'Network-MIME'
+		 'Network-Protocols'
+
+		 'MonticelloRemoteRepositories'
+
+		 'Zinc-HTTP'
+		 'Zinc-FileSystem'
+		 'Zodiac-Core')

--- a/bootstrap/src/Pharo30Bootstrap.package/PBBootstrap.class/instance/monticelloPackageNames.st
+++ b/bootstrap/src/Pharo30Bootstrap.package/PBBootstrap.class/instance/monticelloPackageNames.st
@@ -1,0 +1,4 @@
+package-names
+monticelloPackageNames
+
+	^ #('System-Model' 'Ring-Deprecated-ChunkImporter' 'Zinc-Resource-Meta-Core' 'System-Changes' 'Ring-Deprecated-Core-Kernel' 'Ring-Deprecated-Core-Containers' 'Ring-Deprecated-ChunkImporter'  'Compression' 'Monticello' 'Ring-Deprecated-Monticello' )

--- a/bootstrap/src/Pharo30Bootstrap.package/PBBootstrap.class/instance/packagesToExportAsMCZ.st
+++ b/bootstrap/src/Pharo30Bootstrap.package/PBBootstrap.class/instance/packagesToExportAsMCZ.st
@@ -1,0 +1,4 @@
+package-names
+packagesToExportAsMCZ
+
+	^ #(BaselineOfMetacello) , (#BaselineOfMetacello asClass allPackageNames)  , self monticelloPackageNames , self hermesPackageNames, self kernelPackageNames , self monticelloNetworkPackageNames


### PR DESCRIPTION
During the bootstrap some packages are loaded using Monticello.
It should use the list of packages to import Metacello from the Baseline of Metacello.

This is important as Monticello does not support stateful traits. 
The number of packages exported with it should be minimized to the only required.
Also, as Gofer is used by Metacello, it tries to generate an entry in the package-cache, that cannot be done in this scenario. So, the cache should be disabled also.