### PR TITLE
[WIP]3246-Compiling-a-class-does-not-reset-the-cache-of-compiled-method-using-it

### DIFF
--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -45,6 +45,11 @@ ASTCache class >> initialize [
 	SessionManager default registerSystemClassNamed: self name
 ]
 
+{ #category : #accessing }
+ASTCache class >> remove: aCompiledMethod [
+	default removeKey: aCompiledMethod
+]
+
 { #category : #'initialization-release' }
 ASTCache class >> reset [
 	default reset.

--- a/src/AST-Core/CompiledMethod.extension.st
+++ b/src/AST-Core/CompiledMethod.extension.st
@@ -28,3 +28,10 @@ CompiledMethod >> parseTree [
 		onError: [ :msg :pos | 
 			^ self decompile ]) methodClass: self methodClass.
 ]
+
+{ #category : #'*AST-Core' }
+CompiledMethod >> resetASTCache [
+	"Reset the ast cache for this method"
+
+	ASTCache remove: self
+]

--- a/src/Slot-Core/SystemDictionary.extension.st
+++ b/src/Slot-Core/SystemDictionary.extension.st
@@ -10,7 +10,10 @@ SystemDictionary >> declare: key from: aDictionary [
 	(self includesKey: key) ifTrue: [^ self].
 	(aDictionary includesKey: key)
 		ifTrue: 
-			[self add: ((aDictionary associationAt: key) primitiveChangeClassTo: GlobalVariable new).
+			[ |undeclared |
+			undeclared := (aDictionary associationAt: key).
+			self add: (undeclared primitiveChangeClassTo: GlobalVariable new).
+			undeclared usingMethods collect: #compiledMethod thenDo: #resetASTCache.
 			aDictionary removeKey: key]
 		ifFalse: 
 			[self add: (GlobalVariable key: key)]


### PR DESCRIPTION
When changing undefine classes to a defined one, reset the AST cache of the compiled methods using it.Result of a Sprint with Theo.

Fixes #3246