### PR TITLE
Few fix on the AST

### DIFF
--- a/src/AST-Core-Traits/TRBProgramNodeVisitor.trait.st
+++ b/src/AST-Core-Traits/TRBProgramNodeVisitor.trait.st
@@ -130,7 +130,11 @@ TRBProgramNodeVisitor >> visitSuperNode: aSuperNode [
 
 { #category : #visiting }
 TRBProgramNodeVisitor >> visitTemporaryDeclarationNode: aTemporaryDeclarationNode [
-	^self visitArgumentNode: aTemporaryDeclarationNode 
+	"| temp |
+	temp is a temporary node as we can find in the body of methods, but it can't be visited the same way.
+	Redirect the message on argumentNodeVisitor as a way to keep retrocompatibility"
+
+	^ self visitArgumentNode: aTemporaryDeclarationNode
 ]
 
 { #category : #visiting }
@@ -140,9 +144,11 @@ TRBProgramNodeVisitor >> visitTemporaryNode: aNode [
 ]
 
 { #category : #visiting }
-TRBProgramNodeVisitor >> visitTemporaryNodes: aNodeCollection [ 
+TRBProgramNodeVisitor >> visitTemporaryNodes: aNodeCollection [
 	"This is triggered when defining the temporaries between the pipes"
-	^aNodeCollection do: [ :each | self visitTemporaryDeclarationNode: each ]
+
+	^ aNodeCollection
+		do: [ :each | self visitTemporaryDeclarationNode: each ]
 ]
 
 { #category : #visiting }

--- a/src/AST-Core-Traits/TRBProgramNodeVisitor.trait.st
+++ b/src/AST-Core-Traits/TRBProgramNodeVisitor.trait.st
@@ -41,7 +41,7 @@ TRBProgramNodeVisitor >> visitBlockNode: aBlockNode [
 
 { #category : #visiting }
 TRBProgramNodeVisitor >> visitCascadeNode: aCascadeNode [ 
-	aCascadeNode messages do: [:each | self visitNode: each]
+	aCascadeNode messages do: [:aMessage | self visitNode: aMessage]
 ]
 
 { #category : #visiting }
@@ -132,7 +132,7 @@ TRBProgramNodeVisitor >> visitSuperNode: aSuperNode [
 TRBProgramNodeVisitor >> visitTemporaryDeclarationNode: aTemporaryDeclarationNode [
 	"| temp |
 	temp is a temporary node as we can find in the body of methods, but it can't be visited the same way.
-	Redirect the message on argumentNodeVisitor as a way to keep retrocompatibility"
+	IT redirects the message on argumentNodeVisitor as a way to keep retrocompatibility"
 
 	^ self visitArgumentNode: aTemporaryDeclarationNode
 ]

--- a/src/AST-Core-Traits/TRBProgramNodeVisitor.trait.st
+++ b/src/AST-Core-Traits/TRBProgramNodeVisitor.trait.st
@@ -129,6 +129,11 @@ TRBProgramNodeVisitor >> visitSuperNode: aSuperNode [
 ]
 
 { #category : #visiting }
+TRBProgramNodeVisitor >> visitTemporaryDeclarationNode: aTemporaryDeclarationNode [
+	^self visitArgumentNode: aTemporaryDeclarationNode 
+]
+
+{ #category : #visiting }
 TRBProgramNodeVisitor >> visitTemporaryNode: aNode [ 
 	"Sent *each time* a temporary node is found"
 	^ self visitVariableNode: aNode
@@ -137,7 +142,7 @@ TRBProgramNodeVisitor >> visitTemporaryNode: aNode [
 { #category : #visiting }
 TRBProgramNodeVisitor >> visitTemporaryNodes: aNodeCollection [ 
 	"This is triggered when defining the temporaries between the pipes"
-	^self visitArgumentNodes: aNodeCollection
+	^aNodeCollection do: [ :each | self visitTemporaryDeclarationNode: each ]
 ]
 
 { #category : #visiting }

--- a/src/AST-Core-Traits/TRBProgramNodeVisitor.trait.st
+++ b/src/AST-Core-Traits/TRBProgramNodeVisitor.trait.st
@@ -1,5 +1,5 @@
 "
-A TRBProgramNodeVisitor is a simple  that define visitor methods. 
+A TRBProgramNodeVisitor is a simple Trait that define visitor methods. 
 "
 Trait {
 	#name : #TRBProgramNodeVisitor,

--- a/src/AST-Core/RBArgumentNode.class.st
+++ b/src/AST-Core/RBArgumentNode.class.st
@@ -10,8 +10,8 @@ Class {
 }
 
 { #category : #visiting }
-RBArgumentNode >> acceptVisitor: aProgramNodeVisitor [ 
-	^aProgramNodeVisitor visitArgumentNode: self
+RBArgumentNode >> acceptVisitor: aProgramNodeVisitor [
+	^ aProgramNodeVisitor visitArgumentNode: self
 ]
 
 { #category : #converting }

--- a/src/AST-Core/RBArrayNode.class.st
+++ b/src/AST-Core/RBArrayNode.class.st
@@ -104,18 +104,6 @@ RBArrayNode >> copyInContext: aDictionary [
 	^ self class statements: (self copyList: self statements inContext: aDictionary)
 ]
 
-{ #category : #generation }
-RBArrayNode >> dumpOn: aStream [
-	aStream
-		nextPutAll: self class name;
-		nextPutAll: ' statements: { '.
-	self statements
-		do: [ :each | 
-			each dumpOn: aStream.
-			aStream nextPutAll: '. ' ].
-	aStream nextPut: $}
-]
-
 { #category : #comparing }
 RBArrayNode >> equalTo: anObject withMapping: aDictionary [ 
 	self class = anObject class 

--- a/src/AST-Core/RBAssignmentNode.class.st
+++ b/src/AST-Core/RBAssignmentNode.class.st
@@ -106,17 +106,6 @@ RBAssignmentNode >> directlyUses: aNode [
 	^aNode = value ifTrue: [true] ifFalse: [self isDirectlyUsed]
 ]
 
-{ #category : #generation }
-RBAssignmentNode >> dumpOn: aStream [
-	aStream
-		nextPutAll: self class name;
-		nextPutAll: ' variable: ('.
-	self variable dumpOn: aStream.
-	aStream nextPutAll: ') value: ('.
-	self value dumpOn: aStream.
-	aStream nextPut: $)
-]
-
 { #category : #comparing }
 RBAssignmentNode >> equalTo: anObject withMapping: aDictionary [ 
 	^self class = anObject class and: 

--- a/src/AST-Core/RBAssignmentNode.class.st
+++ b/src/AST-Core/RBAssignmentNode.class.st
@@ -44,8 +44,8 @@ RBAssignmentNode >> = anObject [
 ]
 
 { #category : #visiting }
-RBAssignmentNode >> acceptVisitor: aProgramNodeVisitor [ 
-	^aProgramNodeVisitor visitAssignmentNode: self
+RBAssignmentNode >> acceptVisitor: aProgramNodeVisitor [
+	^ aProgramNodeVisitor visitAssignmentNode: self
 ]
 
 { #category : #'accessing-token' }

--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -53,8 +53,8 @@ RBBlockNode >> = anObject [
 ]
 
 { #category : #visiting }
-RBBlockNode >> acceptVisitor: aProgramNodeVisitor [ 
-	^aProgramNodeVisitor visitBlockNode: self
+RBBlockNode >> acceptVisitor: aProgramNodeVisitor [
+	^ aProgramNodeVisitor visitBlockNode: self
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -149,21 +149,6 @@ RBBlockNode >> directlyUses: aNode [
 	^false
 ]
 
-{ #category : #generation }
-RBBlockNode >> dumpOn: aStream [
-	aStream nextPutAll: self class name.
-	self arguments
-		ifNotEmpty: [ aStream nextPutAll: ' arguments: {'.
-			self arguments
-				do: [ :each | 
-					each dumpOn: aStream.
-					aStream nextPutAll: '. ' ].
-			aStream nextPutAll: '}' ].
-	aStream nextPutAll: ' body: ('.
-	self body dumpOn: aStream.
-	aStream nextPut: $)
-]
-
 { #category : #comparing }
 RBBlockNode >> equalTo: anObject withMapping: aDictionary [ 
 	self class = anObject class ifFalse: [^false].

--- a/src/AST-Core/RBCascadeNode.class.st
+++ b/src/AST-Core/RBCascadeNode.class.st
@@ -37,8 +37,8 @@ RBCascadeNode >> = anObject [
 ]
 
 { #category : #visiting }
-RBCascadeNode >> acceptVisitor: aProgramNodeVisitor [ 
-	^aProgramNodeVisitor visitCascadeNode: self
+RBCascadeNode >> acceptVisitor: aProgramNodeVisitor [
+	^ aProgramNodeVisitor visitCascadeNode: self
 ]
 
 { #category : #querying }

--- a/src/AST-Core/RBCascadeNode.class.st
+++ b/src/AST-Core/RBCascadeNode.class.st
@@ -71,18 +71,6 @@ RBCascadeNode >> directlyUses: aNode [
 	^messages last = aNode and: [self isDirectlyUsed]
 ]
 
-{ #category : #generation }
-RBCascadeNode >> dumpOn: aStream [
-	aStream
-		nextPutAll: self class name;
-		nextPutAll: ' messages: {'.
-	self messages
-		do: [ :each | 
-			each dumpOn: aStream.
-			aStream nextPutAll: '. ' ].
-	aStream nextPut: $}
-]
-
 { #category : #comparing }
 RBCascadeNode >> equalTo: anObject withMapping: aDictionary [ 
 	self class = anObject class ifFalse: [^false].

--- a/src/AST-Core/RBComment.class.st
+++ b/src/AST-Core/RBComment.class.st
@@ -42,11 +42,13 @@ RBComment class >> with: aString at: startPosition [
 ]
 
 { #category : #visiting }
-RBComment >> acceptVisitor: aProgramNodeVisitor [ 
+RBComment >> acceptVisitor: aProgramNodeVisitor [
 	"At some point we will have to think what we do to visit comment. 
 	It may have an impact on visitors so this should be done carefully.
 	Since by default previously comment node were not subclass of ProgramNode 
 	we do nothing by default."
+
+	
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBDumpVisitor.class.st
+++ b/src/AST-Core/RBDumpVisitor.class.st
@@ -1,7 +1,6 @@
 "
-I represent a visitor that generates Pharo code
-
-I visit an Pharo AST, and generate corresponding valid Pharo Code.
+I'm a visitor that generates code whose execution will recreate the visited node (similarly to storeOn: protocol).
+This is handy because we can simply serialize the object in a textual form without requiring a separate parser.
 
 I'm used by reflexivity.
 
@@ -24,12 +23,12 @@ Class {
 
 { #category : #initialization }
 RBDumpVisitor >> initialize [
-	stream := String new writeStream.
+	stream := String new writeStream
 ]
 
 { #category : #initialization }
 RBDumpVisitor >> stream [
-	^stream
+	^ stream
 ]
 
 { #category : #visiting }

--- a/src/AST-Core/RBDumpVisitor.class.st
+++ b/src/AST-Core/RBDumpVisitor.class.st
@@ -92,6 +92,11 @@ RBDumpVisitor >> visitLiteralArrayNode: aLiteralArrayNode [
 ]
 
 { #category : #visiting }
+RBDumpVisitor >> visitLiteralNode: aLiteralNode [
+	self visitLiteralValueNode: aLiteralNode
+]
+
+{ #category : #visiting }
 RBDumpVisitor >> visitLiteralValueNode: aLiteralValueNode [
 	stream
 		nextPutAll: aLiteralValueNode class name;

--- a/src/AST-Core/RBDumpVisitor.class.st
+++ b/src/AST-Core/RBDumpVisitor.class.st
@@ -1,0 +1,203 @@
+Class {
+	#name : #RBDumpVisitor,
+	#superclass : #RBProgramNodeVisitor,
+	#instVars : [
+		'stream'
+	],
+	#category : #'AST-Core-Visitors'
+}
+
+{ #category : #initialization }
+RBDumpVisitor >> initialize [
+	stream := String new writeStream.
+]
+
+{ #category : #initialization }
+RBDumpVisitor >> stream [
+	^stream
+]
+
+{ #category : #visiting }
+RBDumpVisitor >> visitArrayNode: anArrayNode [
+	stream
+		nextPutAll: anArrayNode class name;
+		nextPutAll: ' statements: { '.
+	anArrayNode statements
+		do: [ :each | 
+			each acceptVisitor: self.
+			stream nextPutAll: '. ' ].
+	stream nextPut: $}
+]
+
+{ #category : #visiting }
+RBDumpVisitor >> visitAssignmentNode: anAssignmentNode [
+	stream
+		nextPutAll: anAssignmentNode class name;
+		nextPutAll: ' variable: ('.
+	anAssignmentNode variable acceptVisitor: self.
+	stream nextPutAll: ') value: ('.
+	anAssignmentNode value acceptVisitor: self.
+	stream nextPut: $)
+]
+
+{ #category : #visiting }
+RBDumpVisitor >> visitBlockNode: aBlockNode [
+	stream nextPutAll: aBlockNode class name.
+	aBlockNode arguments
+		ifNotEmpty: [ stream nextPutAll: ' arguments: {'.
+			aBlockNode arguments
+				do: [ :each | 
+					each acceptVisitor: self.
+					stream nextPutAll: '. ' ].
+			stream nextPutAll: '}' ].
+	stream nextPutAll: ' body: ('.
+	aBlockNode body acceptVisitor: self.
+	stream nextPut: $)
+]
+
+{ #category : #visiting }
+RBDumpVisitor >> visitCascadeNode:aCascadeNode [
+	stream
+		nextPutAll: aCascadeNode class name;
+		nextPutAll: ' messages: {'.
+	aCascadeNode messages
+		do: [ :each | 
+			each acceptVisitor: self.
+			stream nextPutAll: '. ' ].
+	stream nextPut: $}
+]
+
+{ #category : #visiting }
+RBDumpVisitor >> visitLiteralArrayNode: aLiteralArrayNode [
+	stream
+		nextPutAll: aLiteralArrayNode class name;
+		nextPutAll: ' value: #('.
+	(aLiteralArrayNode contents collect: [ :each | each value ]) printOn: stream delimiter: ' '.
+	stream nextPutAll: ')'
+]
+
+{ #category : #visiting }
+RBDumpVisitor >> visitLiteralNode: aLiteralNode [
+	stream
+		nextPutAll: aLiteralNode class name;
+		nextPutAll: ' value: #('.
+	(aLiteralNode contents collect: [ :each | each value ]) printOn: stream delimiter: ' '.
+	stream nextPutAll: ')'
+]
+
+{ #category : #visiting }
+RBDumpVisitor >> visitLiteralValueNode: aLiteralValueNode [
+	stream
+		nextPutAll: aLiteralValueNode class name;
+		nextPutAll: ' value: '.
+	aLiteralValueNode value printOn: stream
+]
+
+{ #category : #visiting }
+RBDumpVisitor >> visitMessageNode: aMessageNode [
+	stream
+		nextPutAll: aMessageNode class name;
+		nextPutAll: ' receiver: ('.
+	aMessageNode receiver acceptVisitor: self.
+	stream nextPutAll: ') selector: '.
+	aMessageNode selector printOn: stream.
+	aMessageNode arguments
+		ifNotEmpty: [ stream nextPutAll: ' arguments: {'.
+			aMessageNode arguments
+				do: [ :each | 
+					each acceptVisitor: self.
+					stream nextPutAll: '. ' ].
+			stream nextPut: $} ]
+]
+
+{ #category : #visiting }
+RBDumpVisitor >> visitMethodNode: aMethodNode [
+	| hasPragmas |
+	hasPragmas := aMethodNode pragmas isNotEmpty.
+	hasPragmas
+		ifTrue: [ stream nextPut: $( ].
+	stream
+		nextPutAll: aMethodNode class name;
+		nextPutAll: ' selector: '.
+	aMethodNode selector printOn: stream.
+	aMethodNode arguments
+		ifNotEmpty: [ stream nextPutAll: ' arguments: {'.
+			aMethodNode arguments
+				do: [ :each | 
+					each acceptVisitor:self.
+					stream nextPutAll: '. ' ].
+			stream nextPut: $} ].
+	aMethodNode body
+		ifNotNil: [ stream nextPutAll: ' body: ('.
+			aMethodNode body acceptVisitor:self.
+			stream nextPut: $) ].
+	hasPragmas
+		ifFalse: [ ^ aMethodNode ].
+	stream nextPutAll: ') pragmas: {'.
+	aMethodNode pragmas
+		do: [ :each | 
+			each acceptVisitor: self.
+			stream nextPutAll: '. ' ].
+	stream nextPut: $}
+]
+
+{ #category : #visiting }
+RBDumpVisitor >> visitParseErrorNode: aParseErrorNode [
+	stream
+		nextPutAll: aParseErrorNode class name;
+		nextPutAll: ' errorMessage: '.
+	aParseErrorNode errorMessage printOn: stream.
+	stream nextPutAll: ' value: '.
+	aParseErrorNode value printOn: stream.
+	stream nextPutAll: ' at: '.
+	aParseErrorNode start printOn: stream
+]
+
+{ #category : #visiting }
+RBDumpVisitor >> visitPragmaNode: aPragmaNode [
+	stream
+		nextPutAll: aPragmaNode class name;
+		nextPutAll: ' selector: '.
+	aPragmaNode selector printOn: stream.
+	stream nextPutAll: ' arguments: {'.
+	aPragmaNode arguments
+		do: [ :each | 
+			each acceptVisitor: self.
+			stream nextPutAll: '. ' ].
+	stream nextPut: $}
+]
+
+{ #category : #visiting }
+RBDumpVisitor >> visitReturnNode: aReturnNode [
+	stream
+		nextPutAll: aReturnNode class name;
+		nextPutAll: ' value: ('.
+	aReturnNode value acceptVisitor:self.
+	stream nextPut: $)
+]
+
+{ #category : #visiting }
+RBDumpVisitor >> visitSequenceNode: aSequenceNode [
+	stream nextPutAll: aSequenceNode class name.
+	aSequenceNode temporaries
+		ifNotEmpty: [ stream nextPutAll: ' temporaries: {'.
+			aSequenceNode temporaries
+				do: [ :each | 
+					each acceptVisitor: self.
+					stream nextPutAll: '. ' ].
+			stream nextPut: $} ].
+	stream nextPutAll: ' statements: {'.
+	aSequenceNode statements
+		do: [ :each | 
+			each acceptVisitor: self.
+			stream nextPutAll: '. ' ].
+	stream nextPut: $}
+]
+
+{ #category : #visiting }
+RBDumpVisitor >> visitVariableNode: aVariableNode [
+	stream
+		nextPutAll: aVariableNode class name;
+		nextPutAll: ' named: '.
+	aVariableNode name printOn: stream
+]

--- a/src/AST-Core/RBDumpVisitor.class.st
+++ b/src/AST-Core/RBDumpVisitor.class.st
@@ -1,3 +1,18 @@
+"
+I represent a visitor that generates Pharo code
+
+I visit an Pharo AST, and generate corresponding valid Pharo Code.
+
+I'm used by reflexivity.
+
+try me! 
+(RBDumpVisitor >> #stream) ast dump
+
+Instance Variables
+	stream:		<Object>		The stream holding the output. Filled up throughout the visit.
+
+
+"
 Class {
 	#name : #RBDumpVisitor,
 	#superclass : #RBProgramNodeVisitor,
@@ -73,15 +88,6 @@ RBDumpVisitor >> visitLiteralArrayNode: aLiteralArrayNode [
 		nextPutAll: aLiteralArrayNode class name;
 		nextPutAll: ' value: #('.
 	(aLiteralArrayNode contents collect: [ :each | each value ]) printOn: stream delimiter: ' '.
-	stream nextPutAll: ')'
-]
-
-{ #category : #visiting }
-RBDumpVisitor >> visitLiteralNode: aLiteralNode [
-	stream
-		nextPutAll: aLiteralNode class name;
-		nextPutAll: ' value: #('.
-	(aLiteralNode contents collect: [ :each | each value ]) printOn: stream delimiter: ' '.
 	stream nextPutAll: ')'
 ]
 

--- a/src/AST-Core/RBGlobalNode.class.st
+++ b/src/AST-Core/RBGlobalNode.class.st
@@ -16,7 +16,7 @@ Class {
 }
 
 { #category : #visiting }
-RBGlobalNode >> acceptVisitor: aProgramNodeVisitor [ 
+RBGlobalNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitGlobalNode: self
 ]
 

--- a/src/AST-Core/RBInstanceVariableNode.class.st
+++ b/src/AST-Core/RBInstanceVariableNode.class.st
@@ -10,7 +10,7 @@ Class {
 }
 
 { #category : #visting }
-RBInstanceVariableNode >> acceptVisitor: aProgramNodeVisitor [ 
+RBInstanceVariableNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitInstanceVariableNode: self
 ]
 

--- a/src/AST-Core/RBLiteralArrayNode.class.st
+++ b/src/AST-Core/RBLiteralArrayNode.class.st
@@ -48,8 +48,8 @@ RBLiteralArrayNode >> = anObject [
 ]
 
 { #category : #visiting }
-RBLiteralArrayNode >> acceptVisitor: aProgramNodeVisitor [ 
-	^aProgramNodeVisitor visitLiteralArrayNode: self
+RBLiteralArrayNode >> acceptVisitor: aProgramNodeVisitor [
+	^ aProgramNodeVisitor visitLiteralArrayNode: self
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBLiteralArrayNode.class.st
+++ b/src/AST-Core/RBLiteralArrayNode.class.st
@@ -77,15 +77,6 @@ RBLiteralArrayNode >> copyInContext: aDictionary [
 		isByteArray: isByteArray
 ]
 
-{ #category : #generation }
-RBLiteralArrayNode >> dumpOn: aStream [
-	aStream
-		nextPutAll: self class name;
-		nextPutAll: ' value: #('.
-	(self contents collect: [ :each | each value ]) printOn: aStream delimiter: ' '.
-	aStream nextPutAll: ')'
-]
-
 { #category : #comparing }
 RBLiteralArrayNode >> equalTo: anObject withMapping: aDictionary [ 
 	self class = anObject class ifFalse: [^false].

--- a/src/AST-Core/RBLiteralNode.class.st
+++ b/src/AST-Core/RBLiteralNode.class.st
@@ -28,6 +28,11 @@ RBLiteralNode >> = anObject [
 	^self class = anObject class
 ]
 
+{ #category : #visiting }
+RBLiteralNode >> acceptVisitor: aProgramNodeVisitor [
+	^aProgramNodeVisitor visitLiteralNode:self
+]
+
 { #category : #comparing }
 RBLiteralNode >> hash [
 	^self value hash

--- a/src/AST-Core/RBLiteralNode.class.st
+++ b/src/AST-Core/RBLiteralNode.class.st
@@ -30,7 +30,7 @@ RBLiteralNode >> = anObject [
 
 { #category : #visiting }
 RBLiteralNode >> acceptVisitor: aProgramNodeVisitor [
-	^aProgramNodeVisitor visitLiteralNode:self
+	^ aProgramNodeVisitor visitLiteralNode: self
 ]
 
 { #category : #comparing }

--- a/src/AST-Core/RBLiteralValueNode.class.st
+++ b/src/AST-Core/RBLiteralValueNode.class.st
@@ -46,20 +46,12 @@ RBLiteralValueNode >> = anObject [
 
 { #category : #visiting }
 RBLiteralValueNode >> acceptVisitor: aProgramNodeVisitor [ 
-	^aProgramNodeVisitor visitLiteralNode: self
+	^aProgramNodeVisitor visitLiteralValueNode: self
 ]
 
 { #category : #matching }
 RBLiteralValueNode >> copyInContext: aDictionary [
 	^ self class value: self value
-]
-
-{ #category : #generation }
-RBLiteralValueNode >> dumpOn: aStream [
-	aStream
-		nextPutAll: self class name;
-		nextPutAll: ' value: '.
-	self value printOn: aStream
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBLiteralValueNode.class.st
+++ b/src/AST-Core/RBLiteralValueNode.class.st
@@ -45,8 +45,8 @@ RBLiteralValueNode >> = anObject [
 ]
 
 { #category : #visiting }
-RBLiteralValueNode >> acceptVisitor: aProgramNodeVisitor [ 
-	^aProgramNodeVisitor visitLiteralValueNode: self
+RBLiteralValueNode >> acceptVisitor: aProgramNodeVisitor [
+	^ aProgramNodeVisitor visitLiteralValueNode: self
 ]
 
 { #category : #matching }

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -119,23 +119,6 @@ RBMessageNode >> debugHighlightStop [
 	^ self stopWithoutParentheses
 ]
 
-{ #category : #generation }
-RBMessageNode >> dumpOn: aStream [
-	aStream
-		nextPutAll: self class name;
-		nextPutAll: ' receiver: ('.
-	self receiver dumpOn: aStream.
-	aStream nextPutAll: ') selector: '.
-	self selector printOn: aStream.
-	self arguments
-		ifNotEmpty: [ aStream nextPutAll: ' arguments: {'.
-			self arguments
-				do: [ :each | 
-					each dumpOn: aStream.
-					aStream nextPutAll: '. ' ].
-			aStream nextPut: $} ]
-]
-
 { #category : #comparing }
 RBMessageNode >> equalTo: anObject withMapping: aDictionary [ 
 	self class = anObject class ifFalse: [^false].

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -61,8 +61,8 @@ RBMessageNode >> = anObject [
 ]
 
 { #category : #visiting }
-RBMessageNode >> acceptVisitor: aProgramNodeVisitor [ 
-	^aProgramNodeVisitor visitMessageNode: self
+RBMessageNode >> acceptVisitor: aProgramNodeVisitor [
+	^ aProgramNodeVisitor visitMessageNode: self
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -87,8 +87,8 @@ RBMethodNode >> = anObject [
 ]
 
 { #category : #visiting }
-RBMethodNode >> acceptVisitor: aProgramNodeVisitor [ 
-	^aProgramNodeVisitor visitMethodNode: self
+RBMethodNode >> acceptVisitor: aProgramNodeVisitor [
+	^ aProgramNodeVisitor visitMethodNode: self
 ]
 
 { #category : #'adding/removing' }

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -255,37 +255,6 @@ RBMethodNode >> defines: aName [
 		or: [ self pragmas anySatisfy: [ :pragma | pragma defines: aName ] ]
 ]
 
-{ #category : #generation }
-RBMethodNode >> dumpOn: aStream [
-	| hasPragmas |
-	hasPragmas := self pragmas isNotEmpty.
-	hasPragmas
-		ifTrue: [ aStream nextPut: $( ].
-	aStream
-		nextPutAll: self class name;
-		nextPutAll: ' selector: '.
-	self selector printOn: aStream.
-	self arguments
-		ifNotEmpty: [ aStream nextPutAll: ' arguments: {'.
-			self arguments
-				do: [ :each | 
-					each dumpOn: aStream.
-					aStream nextPutAll: '. ' ].
-			aStream nextPut: $} ].
-	self body
-		ifNotNil: [ aStream nextPutAll: ' body: ('.
-			self body dumpOn: aStream.
-			aStream nextPut: $) ].
-	hasPragmas
-		ifFalse: [ ^ self ].
-	aStream nextPutAll: ') pragmas: {'.
-	self pragmas
-		do: [ :each | 
-			each dumpOn: aStream.
-			aStream nextPutAll: '. ' ].
-	aStream nextPut: $}
-]
-
 { #category : #comparing }
 RBMethodNode >> equalTo: anObject withMapping: aDictionary [ 
 	self class = anObject class ifFalse: [ ^ false ].

--- a/src/AST-Core/RBParseErrorNode.class.st
+++ b/src/AST-Core/RBParseErrorNode.class.st
@@ -40,7 +40,7 @@ RBParseErrorNode >> = anObject [
 
 { #category : #visiting }
 RBParseErrorNode >> acceptVisitor: aProgramNodeVisitor [
-	^ aProgramNodeVisitor visitParseErrorNode: self.
+	^ aProgramNodeVisitor visitParseErrorNode: self
 ]
 
 { #category : #converting }

--- a/src/AST-Core/RBParseErrorNode.class.st
+++ b/src/AST-Core/RBParseErrorNode.class.st
@@ -69,18 +69,6 @@ RBParseErrorNode >> body: aSequenceNode [
 	"I am not a valid MethodNode, but go one with parsing"
 ]
 
-{ #category : #generation }
-RBParseErrorNode >> dumpOn: aStream [
-	aStream
-		nextPutAll: self class name;
-		nextPutAll: ' errorMessage: '.
-	self errorMessage printOn: aStream.
-	aStream nextPutAll: ' value: '.
-	self value printOn: aStream.
-	aStream nextPutAll: ' at: '.
-	self start printOn: aStream
-]
-
 { #category : #accessing }
 RBParseErrorNode >> errorMessage [
 	^ errorMessage

--- a/src/AST-Core/RBParseTreeRewriter.class.st
+++ b/src/AST-Core/RBParseTreeRewriter.class.st
@@ -379,3 +379,8 @@ RBParseTreeRewriter >> visitSequenceNode: aSequenceNode [
 	aSequenceNode temporaries: (self visitTemporaryNodes: aSequenceNode temporaries).
 	aSequenceNode statements: (aSequenceNode statements collect: [ :each | self visitNode: each ])
 ]
+
+{ #category : #visiting }
+RBParseTreeRewriter >> visitTemporaryNodes: aNodeCollection [ 
+	^aNodeCollection collect: [:each | self visitTemporaryDeclarationNode: each]
+]

--- a/src/AST-Core/RBPragmaNode.class.st
+++ b/src/AST-Core/RBPragmaNode.class.st
@@ -47,7 +47,7 @@ RBPragmaNode >> = anObject [
 ]
 
 { #category : #visiting }
-RBPragmaNode >> acceptVisitor: aProgramNodeVisitor [ 
+RBPragmaNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitPragmaNode: self
 ]
 

--- a/src/AST-Core/RBPragmaNode.class.st
+++ b/src/AST-Core/RBPragmaNode.class.st
@@ -94,20 +94,6 @@ RBPragmaNode >> defines: aName [
 	^ self isPrimitive and: [ arguments anySatisfy: [ :each | each value = aName ] ]
 ]
 
-{ #category : #accessing }
-RBPragmaNode >> dumpOn: aStream [
-	aStream
-		nextPutAll: self class name;
-		nextPutAll: ' selector: '.
-	self selector printOn: aStream.
-	aStream nextPutAll: ' arguments: {'.
-	self arguments
-		do: [ :each | 
-			each dumpOn: aStream.
-			aStream nextPutAll: '. ' ].
-	aStream nextPut: $}
-]
-
 { #category : #comparing }
 RBPragmaNode >> equalTo: anObject withMapping: aDictionary [ 
 	self class = anObject class ifFalse: [ ^ false ].

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -293,11 +293,12 @@ RBProgramNode >> do: aBlock [
 
 { #category : #generation }
 RBProgramNode >> dump [
-	"Generate the Pharo code from self"
+	"Generate a literal expression that recreates the receiver"
+
 	| visitor |
 	visitor := RBDumpVisitor new.
 	self acceptVisitor: visitor.
-	^visitor stream contents
+	^ visitor stream contents
 ]
 
 { #category : #comparing }

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -293,12 +293,10 @@ RBProgramNode >> do: aBlock [
 
 { #category : #generation }
 RBProgramNode >> dump [
-	^  String streamContents: [:s | self dumpOn: s]
-]
-
-{ #category : #generation }
-RBProgramNode >> dumpOn: aStream [
-	self subclassResponsibility 
+	| visitor |
+	visitor := RBDumpVisitor new.
+	self acceptVisitor: visitor.
+	^visitor stream contents
 ]
 
 { #category : #comparing }

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -293,6 +293,7 @@ RBProgramNode >> do: aBlock [
 
 { #category : #generation }
 RBProgramNode >> dump [
+	"Generate the Pharo code from self"
 	| visitor |
 	visitor := RBDumpVisitor new.
 	self acceptVisitor: visitor.

--- a/src/AST-Core/RBProgramNodeVisitor.class.st
+++ b/src/AST-Core/RBProgramNodeVisitor.class.st
@@ -67,7 +67,9 @@ RBProgramNodeVisitor >> visitLiteralNode: aLiteralNode [
 
 { #category : #visiting }
 RBProgramNodeVisitor >> visitLiteralValueNode: aRBLiteralValueNode [
-	self visitLiteralNode: aRBLiteralValueNode
+	"Redirect the message by default to #visitLiteralNode: for retrocompatibility (pharo 8)"
+
+	^ self visitLiteralNode: aRBLiteralValueNode
 ]
 
 { #category : #visiting }

--- a/src/AST-Core/RBProgramNodeVisitor.class.st
+++ b/src/AST-Core/RBProgramNodeVisitor.class.st
@@ -12,37 +12,37 @@ Class {
 { #category : #visiting }
 RBProgramNodeVisitor >> visitArgumentNode: anArgumentNode [
 	"Sent *each time* an argument node is found"
+
 	^ self visitVariableNode: anArgumentNode
 ]
 
 { #category : #visiting }
-RBProgramNodeVisitor >> visitArgumentNodes: aNodeCollection [ 
+RBProgramNodeVisitor >> visitArgumentNodes: aNodeCollection [
 	"Sent *once* when visiting method and block nodes"
-	^aNodeCollection do: [ :each | self visitArgumentNode: each ]
+
+	^ aNodeCollection do: [ :each | self visitArgumentNode: each ]
 ]
 
 { #category : #visiting }
-RBProgramNodeVisitor >> visitArrayNode: anArrayNode [ 
-
-	anArrayNode children do: [:each | self visitNode: each]
+RBProgramNodeVisitor >> visitArrayNode: anArrayNode [
+	anArrayNode children do: [ :each | self visitNode: each ]
 ]
 
 { #category : #visiting }
 RBProgramNodeVisitor >> visitAssignmentNode: anAssignmentNode [
-
 	self visitNode: anAssignmentNode variable.
 	self visitNode: anAssignmentNode value
 ]
 
 { #category : #visiting }
-RBProgramNodeVisitor >> visitBlockNode: aBlockNode [ 
+RBProgramNodeVisitor >> visitBlockNode: aBlockNode [
 	self visitArgumentNodes: aBlockNode arguments.
 	self visitNode: aBlockNode body
 ]
 
 { #category : #visiting }
-RBProgramNodeVisitor >> visitCascadeNode: aCascadeNode [ 
-	aCascadeNode messages do: [:each | self visitNode: each]
+RBProgramNodeVisitor >> visitCascadeNode: aCascadeNode [
+	aCascadeNode messages do: [ :each | self visitNode: each ]
 ]
 
 { #category : #visiting }
@@ -56,47 +56,52 @@ RBProgramNodeVisitor >> visitInstanceVariableNode: aSelfNode [
 ]
 
 { #category : #visiting }
-RBProgramNodeVisitor >> visitLiteralArrayNode: aRBLiteralArrayNode [ 
-	aRBLiteralArrayNode contents do: [:each | self visitNode: each]
+RBProgramNodeVisitor >> visitLiteralArrayNode: aRBLiteralArrayNode [
+	aRBLiteralArrayNode contents do: [ :each | self visitNode: each ]
 ]
 
 { #category : #visiting }
 RBProgramNodeVisitor >> visitLiteralNode: aLiteralNode [
+	
 ]
 
 { #category : #visiting }
-RBProgramNodeVisitor >> visitMessageNode: aMessageNode [ 
-	(aMessageNode isCascaded not or: [aMessageNode isFirstCascaded]) 
-		ifTrue: [self visitNode: aMessageNode receiver].
-	aMessageNode arguments do: [:each | self visitNode: each]
+RBProgramNodeVisitor >> visitLiteralValueNode: aRBLiteralValueNode [
+	self visitLiteralNode: aRBLiteralValueNode
 ]
 
 { #category : #visiting }
-RBProgramNodeVisitor >> visitMethodNode: aMethodNode [ 
+RBProgramNodeVisitor >> visitMessageNode: aMessageNode [
+	(aMessageNode isCascaded not or: [ aMessageNode isFirstCascaded ])
+		ifTrue: [ self visitNode: aMessageNode receiver ].
+	aMessageNode arguments do: [ :each | self visitNode: each ]
+]
+
+{ #category : #visiting }
+RBProgramNodeVisitor >> visitMethodNode: aMethodNode [
 	self visitArgumentNodes: aMethodNode arguments.
-	aMethodNode pragmas
-		do: [ :each | self visitNode: each ].
+	aMethodNode pragmas do: [ :each | self visitNode: each ].
 	self visitNode: aMethodNode body
-
 ]
 
 { #category : #visiting }
-RBProgramNodeVisitor >> visitNode: aNode [ 
-	^aNode acceptVisitor: self
+RBProgramNodeVisitor >> visitNode: aNode [
+	^ aNode acceptVisitor: self
 ]
 
 { #category : #visiting }
 RBProgramNodeVisitor >> visitParseErrorNode: anErrorNode [
+	
 ]
 
 { #category : #visiting }
-RBProgramNodeVisitor >> visitPatternBlockNode: aRBPatternBlockNode [ 
+RBProgramNodeVisitor >> visitPatternBlockNode: aRBPatternBlockNode [
 	self visitArgumentNodes: aRBPatternBlockNode arguments.
 	self visitNode: aRBPatternBlockNode body
 ]
 
 { #category : #visiting }
-RBProgramNodeVisitor >> visitPatternWrapperBlockNode: aRBPatternWrapperBlockNode [ 
+RBProgramNodeVisitor >> visitPatternWrapperBlockNode: aRBPatternWrapperBlockNode [
 	self visitNode: aRBPatternWrapperBlockNode wrappedNode.
 	self visitArgumentNodes: aRBPatternWrapperBlockNode arguments.
 	self visitNode: aRBPatternWrapperBlockNode body
@@ -108,7 +113,7 @@ RBProgramNodeVisitor >> visitPragmaNode: aPragmaNode [
 ]
 
 { #category : #visiting }
-RBProgramNodeVisitor >> visitReturnNode: aReturnNode [ 
+RBProgramNodeVisitor >> visitReturnNode: aReturnNode [
 	^ self visitNode: aReturnNode value
 ]
 
@@ -118,9 +123,9 @@ RBProgramNodeVisitor >> visitSelfNode: aSelfNode [
 ]
 
 { #category : #visiting }
-RBProgramNodeVisitor >> visitSequenceNode: aSequenceNode [ 
+RBProgramNodeVisitor >> visitSequenceNode: aSequenceNode [
 	self visitTemporaryNodes: aSequenceNode temporaries.
-	aSequenceNode statements do: [:each | self visitNode: each]
+	aSequenceNode statements do: [ :each | self visitNode: each ]
 ]
 
 { #category : #visiting }
@@ -129,23 +134,27 @@ RBProgramNodeVisitor >> visitSuperNode: aSuperNode [
 ]
 
 { #category : #visiting }
-RBProgramNodeVisitor >> visitTemporaryDeclarationNode: aTemporaryDeclarationNode [ 
-	"| temp |"
-	"temp is a temporary node as we can find in the body of methods, but it can't be visited the same way."
-	"Redirect the message on argumentNodeVisitor as a way to keep retrocompatibility"
-	^self visitArgumentNode: aTemporaryDeclarationNode 
+RBProgramNodeVisitor >> visitTemporaryDeclarationNode: aTemporaryDeclarationNode [
+	"| temp |
+	temp is a temporary node as we can find in the body of methods, but it can't be visited the same way.
+	Redirect the message on argumentNodeVisitor as a way to keep retrocompatibility"
+
+	^ self visitArgumentNode: aTemporaryDeclarationNode
 ]
 
 { #category : #visiting }
-RBProgramNodeVisitor >> visitTemporaryNode: aNode [ 
+RBProgramNodeVisitor >> visitTemporaryNode: aNode [
 	"Sent *each time* a temporary node is found"
+
 	^ self visitVariableNode: aNode
 ]
 
 { #category : #visiting }
-RBProgramNodeVisitor >> visitTemporaryNodes: aNodeCollection [ 
+RBProgramNodeVisitor >> visitTemporaryNodes: aNodeCollection [
 	"This is triggered when defining the temporaries between the pipes"
-	^aNodeCollection do: [ :each | self visitTemporaryDeclarationNode: each ]
+
+	^ aNodeCollection
+		do: [ :each | self visitTemporaryDeclarationNode: each ]
 ]
 
 { #category : #visiting }

--- a/src/AST-Core/RBProgramNodeVisitor.class.st
+++ b/src/AST-Core/RBProgramNodeVisitor.class.st
@@ -77,6 +77,7 @@ RBProgramNodeVisitor >> visitMethodNode: aMethodNode [
 	aMethodNode pragmas
 		do: [ :each | self visitNode: each ].
 	self visitNode: aMethodNode body
+
 ]
 
 { #category : #visiting }
@@ -128,6 +129,14 @@ RBProgramNodeVisitor >> visitSuperNode: aSuperNode [
 ]
 
 { #category : #visiting }
+RBProgramNodeVisitor >> visitTemporaryDeclarationNode: aTemporaryDeclarationNode [ 
+	"| temp |"
+	"temp is a temporary node as we can find in the body of methods, but it can't be visited the same way."
+	"Redirect the message on argumentNodeVisitor as a way to keep retrocompatibility"
+	^self visitArgumentNode: aTemporaryDeclarationNode 
+]
+
+{ #category : #visiting }
 RBProgramNodeVisitor >> visitTemporaryNode: aNode [ 
 	"Sent *each time* a temporary node is found"
 	^ self visitVariableNode: aNode
@@ -136,7 +145,7 @@ RBProgramNodeVisitor >> visitTemporaryNode: aNode [
 { #category : #visiting }
 RBProgramNodeVisitor >> visitTemporaryNodes: aNodeCollection [ 
 	"This is triggered when defining the temporaries between the pipes"
-	^self visitArgumentNodes: aNodeCollection
+	^aNodeCollection do: [ :each | self visitTemporaryDeclarationNode: each ]
 ]
 
 { #category : #visiting }

--- a/src/AST-Core/RBReturnNode.class.st
+++ b/src/AST-Core/RBReturnNode.class.st
@@ -37,7 +37,7 @@ RBReturnNode >> = anObject [
 ]
 
 { #category : #visiting }
-RBReturnNode >> acceptVisitor: aProgramNodeVisitor [ 
+RBReturnNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitReturnNode: self
 ]
 

--- a/src/AST-Core/RBReturnNode.class.st
+++ b/src/AST-Core/RBReturnNode.class.st
@@ -58,15 +58,6 @@ RBReturnNode >> copyInContext: aDictionary [
 		yourself
 ]
 
-{ #category : #accessing }
-RBReturnNode >> dumpOn: aStream [
-	aStream
-		nextPutAll: self class name;
-		nextPutAll: ' value: ('.
-	self value dumpOn: aStream.
-	aStream nextPut: $)
-]
-
 { #category : #comparing }
 RBReturnNode >> equalTo: anObject withMapping: aDictionary [ 
 	^self class = anObject class 

--- a/src/AST-Core/RBSelfNode.class.st
+++ b/src/AST-Core/RBSelfNode.class.st
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #visiting }
-RBSelfNode >> acceptVisitor: aProgramNodeVisitor [ 
+RBSelfNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitSelfNode: self
 ]
 

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -250,24 +250,6 @@ RBSequenceNode >> directlyUses: aNode [
 	^false
 ]
 
-{ #category : #generation }
-RBSequenceNode >> dumpOn: aStream [
-	aStream nextPutAll: self class name.
-	self temporaries
-		ifNotEmpty: [ aStream nextPutAll: ' temporaries: {'.
-			self temporaries
-				do: [ :each | 
-					each dumpOn: aStream.
-					aStream nextPutAll: '. ' ].
-			aStream nextPut: $} ].
-	aStream nextPutAll: ' statements: {'.
-	self statements
-		do: [ :each | 
-			each dumpOn: aStream.
-			aStream nextPutAll: '. ' ].
-	aStream nextPut: $}
-]
-
 { #category : #comparing }
 RBSequenceNode >> equalTo: anObject withMapping: aDictionary [ 
 	self class = anObject class ifFalse: [^false].

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -63,8 +63,8 @@ RBSequenceNode >> = anObject [
 ]
 
 { #category : #visiting }
-RBSequenceNode >> acceptVisitor: aProgramNodeVisitor [ 
-	^aProgramNodeVisitor visitSequenceNode: self
+RBSequenceNode >> acceptVisitor: aProgramNodeVisitor [
+	^ aProgramNodeVisitor visitSequenceNode: self
 ]
 
 { #category : #'adding nodes' }

--- a/src/AST-Core/RBSuperNode.class.st
+++ b/src/AST-Core/RBSuperNode.class.st
@@ -8,8 +8,8 @@ Class {
 }
 
 { #category : #visiting }
-RBSuperNode >> acceptVisitor: aProgramNodeVisitor [ 
-	^aProgramNodeVisitor visitSuperNode: self
+RBSuperNode >> acceptVisitor: aProgramNodeVisitor [
+	^ aProgramNodeVisitor visitSuperNode: self
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBTemporaryNode.class.st
+++ b/src/AST-Core/RBTemporaryNode.class.st
@@ -10,8 +10,8 @@ Class {
 }
 
 { #category : #visiting }
-RBTemporaryNode >> acceptVisitor: aProgramNodeVisitor [ 
-	^aProgramNodeVisitor visitTemporaryNode: self
+RBTemporaryNode >> acceptVisitor: aProgramNodeVisitor [
+	^ aProgramNodeVisitor visitTemporaryNode: self
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBThisContextNode.class.st
+++ b/src/AST-Core/RBThisContextNode.class.st
@@ -8,6 +8,6 @@ Class {
 }
 
 { #category : #visiting }
-RBThisContextNode >> acceptVisitor: aProgramNodeVisitor [ 
-	^aProgramNodeVisitor visitThisContextNode: self
+RBThisContextNode >> acceptVisitor: aProgramNodeVisitor [
+	^ aProgramNodeVisitor visitThisContextNode: self
 ]

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -68,14 +68,6 @@ RBVariableNode >> copyInContext: aDictionary [
 	^ self class named: name.
 ]
 
-{ #category : #generation }
-RBVariableNode >> dumpOn: aStream [
-	aStream
-		nextPutAll: self class name;
-		nextPutAll: ' named: '.
-	self name printOn: aStream
-]
-
 { #category : #comparing }
 RBVariableNode >> equalTo: anObject withMapping: aDictionary [ 
 	^self class = anObject class and: 

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -53,8 +53,8 @@ RBVariableNode >> = anObject [
 ]
 
 { #category : #visiting }
-RBVariableNode >> acceptVisitor: aProgramNodeVisitor [ 
-	^aProgramNodeVisitor visitVariableNode: self
+RBVariableNode >> acceptVisitor: aProgramNodeVisitor [
+	^ aProgramNodeVisitor visitVariableNode: self
 ]
 
 { #category : #converting }

--- a/src/AST-Tests-Core/RBDumpNodeTest.class.st
+++ b/src/AST-Tests-Core/RBDumpNodeTest.class.st
@@ -1,5 +1,5 @@
 "
-SUnit tests for the #dump and #dumpOn: methods on RBProgramNodes
+SUnit tests for the RBDumpVisitor visit, called by the #dump method on RBProgramNodes.
 "
 Class {
 	#name : #RBDumpNodeTest,

--- a/src/Reflectivity/RBProgramNodeVisitor.extension.st
+++ b/src/Reflectivity/RBProgramNodeVisitor.extension.st
@@ -2,6 +2,7 @@ Extension { #name : #RBProgramNodeVisitor }
 
 { #category : #'*Reflectivity' }
 RBProgramNodeVisitor >> visitLiteralVariableNode: aNode [
+	
 ]
 
 { #category : #'*Reflectivity' }

--- a/src/Reflectivity/RBProgramNodeVisitor.extension.st
+++ b/src/Reflectivity/RBProgramNodeVisitor.extension.st
@@ -2,7 +2,6 @@ Extension { #name : #RBProgramNodeVisitor }
 
 { #category : #'*Reflectivity' }
 RBProgramNodeVisitor >> visitLiteralVariableNode: aNode [
-	
 ]
 
 { #category : #'*Reflectivity' }

--- a/src/Reflectivity/RFMessageNode.class.st
+++ b/src/Reflectivity/RFMessageNode.class.st
@@ -9,5 +9,5 @@ Class {
 
 { #category : #debugging }
 RFMessageNode >> debugHighlightRange [
-	^parent debugHighlightRange 
+	^ parent debugHighlightRange 
 ]

--- a/src/Reflectivity/TRBProgramNodeVisitor.extension.st
+++ b/src/Reflectivity/TRBProgramNodeVisitor.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #TRBProgramNodeVisitor }
 
 { #category : #'*Reflectivity' }
+TRBProgramNodeVisitor >> visitLiteralValueNode: aNode [
+	"Redirect the message by default to #visitLiteralNode: for retrocompatibility (pharo 8)"
+
+	^ self visitLiteralNode: aNode
+]
+
+{ #category : #'*Reflectivity' }
 TRBProgramNodeVisitor >> visitLiteralVariableNode: aNode [
 ]
 

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1152,13 +1152,13 @@ at once, but for ordinary literal arrays, style every node"
 ]
 
 { #category : #visiting }
-SHRBTextStyler >> visitLiteralNode: aLiteralNode [
+SHRBTextStyler >> visitLiteralValueNode: aLiteralValueNode [
 	| value |
-	value := aLiteralNode value.
+	value := aLiteralValueNode value.
 	self 
 		addStyle: (self literalStyleSymbol: value)
 		attribute: (TextClassLink class: value class)
-		forNode: aLiteralNode
+		forNode: aLiteralValueNode
 ]
 
 { #category : #visiting }


### PR DESCRIPTION
hope I didn't forget to commit something (working on compiler related stuff crashes a bit !)

Fix for: #3250. Added an intermediary hook that retains retro compatibility. There still may be retro compatibility problems for people that overrode the #visitTemporaryNodes: in a way that mimic the previous behavior.

added fix for #3262 as well. retro compatibility should be fine, by default behavior.
This should disappear at some point, given that it might be miss used by user.

fix for: #3237 Moved the code out in a visitor. Retains both the #dump selector & the GT hook in RBProgramNode though.
I didn't rename it either because I didn't follow all the conversation between steph' and vince.
Added some small comments, that @aranega should at least check :)

For a separation of the concern in the issues, added a #visitLiteralNode: AND a #visitLiteralValueNode: so it work with both version. (see issue #3262)
