### PR TITLE
Fixes: #3245 to ensure that we cannot create an empty protocol.

### DIFF
--- a/src/Monticello-Tests/MCMethodDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCMethodDefinitionTest.class.st
@@ -83,11 +83,26 @@ MCMethodDefinitionTest >> testComparison [
 MCMethodDefinitionTest >> testLoadAndUnload [
 	|definition|
 	definition := self mockMethod: #one class: 'MCMockClassA' source: 'one ^2' meta: false.
-	self assert: self mockInstanceA one = 1.
+	self assert: self mockInstanceA one equals: 1.
 	definition load.
-	self assert: self mockInstanceA one = 2.
+	self assert: self mockInstanceA one equals: 2.
 	definition unload.
 	self deny: (self mockInstanceA respondsTo: #one)
+]
+
+{ #category : #testing }
+MCMethodDefinitionTest >> testMethodDefinitionWithEmptyProtocolIsClassifiedAsAsYetUnclassified [
+
+	| methodDef |
+	methodDef := (MCMethodDefinition
+			className: #Object
+			classIsMeta: false
+			selector: #name
+			category: '' 
+			timeStamp: nil
+			source: 'name
+	^ self printString').
+	self assert: methodDef category equals: #'as yet unclassified'.
 ]
 
 { #category : #testing }

--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -219,7 +219,7 @@ timeStamp: timeString
 source: sourceString [
 	className := classString asSymbol.
 	selector := selectorString asSymbol.
-	category := catString asSymbol.
+	category := (catString asSymbol) ifEmpty: [#'as yet unclassified'].
 	timeStamp := timeString.
 	classIsMeta := metaBoolean.
 	source := sourceString withSqueakLineEndings.


### PR DESCRIPTION
Added a test and when a category is empty turn it into a 'as yet unclassified'.
Fixes: #3245