### PR TITLE
3233-Windows-file-references-broken-in-P8

### DIFF
--- a/src/FileSystem-Core/DiskDirectoryEntry.class.st
+++ b/src/FileSystem-Core/DiskDirectoryEntry.class.st
@@ -204,15 +204,15 @@ DiskDirectoryEntry >> gtInspectAttributesIn: composite [
 	| attrDictionary |
 
 	attrDictionary := Dictionary new.
-	[self class methodsDo: [ :method |
+	self class methodsDo: [ :method |
 		method methodNode arguments size = 0 ifTrue:
 			[ attrDictionary at: method selector put:
-				(method selector value: self) ] ]]
-		on: FileDoesNotExistException
-		do: [ nil ].
+				([ (method selector value: self) ]
+					on: Error
+					do: [ 'N/A' translated ]) ] ].
 	^(attrDictionary gtInspectorItemsIn: composite)
 		when: [ attrDictionary isNotEmpty ];
-		title: 'Attributes';
+		title: 'Attributes' translated;
 		yourself.
 ]
 
@@ -311,6 +311,7 @@ DiskDirectoryEntry >> isSocket [
 DiskDirectoryEntry >> isSymlink [
 	"Answer true if the receiver is a symbolic link"
 
+	reference path isRoot ifTrue: [ ^false ].
 	"Don't use cached information as the values might reflect a target file accessed from a symlink."
 	^self primitives isSymlink: self pathString
 ]

--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -573,7 +573,7 @@ FileReference >> symlinkEntry [
 	^ filesystem symlinkEntryAt: path
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 FileReference >> symlinkUid: uid gid: gid [
 	"Set the owner and group of the receiver by numeric id.
 	An id of nil leaves it unchanged."
@@ -593,7 +593,7 @@ FileReference >> uid [
 	^ filesystem uidOf: path
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 FileReference >> uid: uid gid: gid [
 	"Set the owner and group of the receiver by numeric id.
 	An id of nil leaves it unchanged."

--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -444,6 +444,7 @@ DiskStore >> isDiskFileSystem [
 
 { #category : #testing }
 DiskStore >> isExecutable: aPath [
+	"Answer a boolean indicating whether the supplied path is executable"
 
 	^File isExecutable: (self stringFromPath: aPath)
 ]
@@ -536,6 +537,17 @@ DiskStore >> rename: sourcePath to: destinationPath [
 	targetPathString := self stringFromPath: destinationPath.
 	encodedTargetPathString := File encodePathString: targetPathString.
 	^ File rename: encodedSourcePathString to: encodedTargetPathString.
+]
+
+{ #category : #private }
+DiskStore >> rootEntry [
+	"Answer a pseudo Directory Entry for the root directory"
+
+	^(DiskDirectoryEntry
+		reference: (FileReference fileSystem: FileSystem disk path: Path root)
+		statAttributes: #(nil 8r40775 0 0 0 0 0 0 0 0 nil 0 22))
+			accessAttributes: #(true false true);
+			yourself
 ]
 
 { #category : #private }

--- a/src/FileSystem-Disk/WindowsStore.class.st
+++ b/src/FileSystem-Disk/WindowsStore.class.st
@@ -34,6 +34,22 @@ WindowsStore class >> separator [
 	^ $\
 ]
 
+{ #category : #accessing }
+WindowsStore >> accessTimeOf: aPath [
+	"Answer the access time of aPath."
+
+	aPath isRoot ifTrue: [ ^self rootEntry accessTime ].
+	^super accessTimeOf: aPath
+]
+
+{ #category : #accessing }
+WindowsStore >> changeTimeOf: aPath [
+	"Answer the change time of aPath."
+
+	aPath isRoot ifTrue: [ ^self rootEntry changeTime ].
+	^super changeTimeOf: aPath
+]
+
 { #category : #public }
 WindowsStore >> checkName: aFileName fixErrors: fixing [
 	"Check if the file name contains any invalid characters"
@@ -53,9 +69,25 @@ WindowsStore >> checkName: aFileName fixErrors: fixing [
 				ifFalse: [char]]
 ]
 
+{ #category : #accessing }
+WindowsStore >> creationTimeOf: aPath [
+	"Answer the creation time of aPath.  If the platform doesn't support creation time, use change time"
+
+	aPath isRoot ifTrue: [ ^self rootEntry creationTime ].
+	^super creationTimeOf: aPath
+]
+
 { #category : #converting }
 WindowsStore >> currentDisk [
 	^ disk ifNil: [  disk := FileSystem workingDirectory path segments first ]
+]
+
+{ #category : #accessing }
+WindowsStore >> deviceIdOf: aPath [
+	"Return the device id of the file at aPath"
+
+	aPath isRoot ifTrue: [ ^self rootEntry deviceId ].
+	^super deviceIdOf: aPath
 ]
 
 { #category : #private }
@@ -77,6 +109,109 @@ WindowsStore >> directoryAt: aPath nodesDo: aBlock [
 		]
 ]
 
+{ #category : #private }
+WindowsStore >> entryAt: aPath fileSystem: aFilesystem [
+
+	aPath isRoot ifTrue: [ ^aFilesystem store rootEntry ].
+	^super entryAt: aPath fileSystem: aFilesystem
+]
+
+{ #category : #accessing }
+WindowsStore >> gidOf: aPath [
+	"Return the gid of the file at aPath"
+
+	aPath isRoot ifTrue: [ ^self rootEntry gid ].
+	^super gidOf: aPath
+]
+
+{ #category : #accessing }
+WindowsStore >> inodeOf: aPath [
+	"Return the inode of the file at aPath"
+
+	aPath isRoot ifTrue: [ ^self rootEntry inode ].
+	^super inodeOf: aPath
+]
+
+{ #category : #accessing }
+WindowsStore >> isBlock: aPath [
+	"Answer a boolean indicating whether the supplied path is a Block file"
+
+	aPath isRoot ifTrue: [ ^self rootEntry isBlock ].
+	^super isBlock: aPath
+]
+
+{ #category : #accessing }
+WindowsStore >> isCharacter: aPath [
+	"Answer a boolean indicating whether the supplied path is a Character file"
+
+	aPath isRoot ifTrue: [ ^self rootEntry isCharacter ].
+	^super isCharacter: aPath
+]
+
+{ #category : #accessing }
+WindowsStore >> isExecutable: aPath [
+	"Answer a boolean indicating whether the supplied path is executable"
+
+	aPath isRoot ifTrue: [ ^self rootEntry isExecutable ].
+	^super isExecutable: aPath
+]
+
+{ #category : #testing }
+WindowsStore >> isFIFO: aPath [
+	"Answer a boolean indicating whether the supplied path is a FIFO file (pipe)"
+
+	aPath isRoot ifTrue: [ ^self rootEntry isFIFO ].
+	^super isFIFO: aPath
+]
+
+{ #category : #testing }
+WindowsStore >> isReadable: aPath [
+	"Answer a boolean indicating whether the supplied path is readable"
+
+	aPath isRoot ifTrue: [ ^self rootEntry isReadable ].
+	^super isReadable: aPath
+]
+
+{ #category : #testing }
+WindowsStore >> isRegular: aPath [
+	"Answer a boolean indicating whether the supplied path is a Regular file"
+
+	aPath isRoot ifTrue: [ ^self rootEntry isRegular ].
+	^super isRegular: aPath
+]
+
+{ #category : #testing }
+WindowsStore >> isSocket: aPath [
+	"Answer a boolean indicating whether the supplied path is a Socket file"
+
+	aPath isRoot ifTrue: [ ^self rootEntry isSocket ].
+	^super isSocket: aPath
+]
+
+{ #category : #testing }
+WindowsStore >> isWritable: aPath [
+	"Answer a boolean indicating whether the supplied path can be written to"
+
+	aPath isRoot ifTrue: [ ^self rootEntry isWritable ].
+	^super isWritable: aPath
+]
+
+{ #category : #accessing }
+WindowsStore >> modificationTimeOf: aPath [
+	"Answer the modification time of aPath."
+
+	aPath isRoot ifTrue: [ ^self rootEntry modificationTime ].
+	^super modificationTimeOf: aPath
+]
+
+{ #category : #accessing }
+WindowsStore >> numberOfHardLinks: aPath [
+	"Return the number of hard links for the File described by aPath"
+
+	aPath isRoot ifTrue: [ ^self rootEntry numberOfHardLinks ].
+	^super numberOfHardLinks: aPath
+]
+
 { #category : #converting }
 WindowsStore >> pathFromString: aString [
 	"Need to distinguish '' and '/' , so tag latter with invalid character ':'  "
@@ -89,6 +224,14 @@ WindowsStore >> pathFromString: aString [
 		ifFalse: [ self stripDrive: pathElements.
 			RelativePath ].
 	^pathClass withAll: pathElements
+]
+
+{ #category : #accessing }
+WindowsStore >> permissions: aPath [
+	"Answer the FileSystemPermissions for the supplied path"
+
+	aPath isRoot ifTrue: [ ^self rootEntry permissions ].
+	^super permissions: aPath
 ]
 
 { #category : #converting }
@@ -110,7 +253,21 @@ WindowsStore >> printPath: aPath on: aStream [
 		ifTrue: [ aStream nextPut: self delimiter ]
 ]
 
+{ #category : #accessing }
+WindowsStore >> sizeOf: aPath [
+	"Return the size of the File described by aPath"
+	aPath isRoot ifTrue: [ ^self rootEntry size ].
+	^super sizeOf: aPath.
+]
+
 { #category : #converting }
 WindowsStore >> stripDrive: pathElements [
 	pathElements ifNotEmpty: [ pathElements at: 1 put: ( ($: split: pathElements first) last)  ]
+]
+
+{ #category : #accessing }
+WindowsStore >> uidOf: aPath [
+	"Return the uid of the File described by aPath"
+	aPath isRoot ifTrue: [ ^self rootEntry uid ].
+	^super uidOf: aPath.
 ]

--- a/src/FileSystem-Tests-Core/DirectoryEntryTest.class.st
+++ b/src/FileSystem-Tests-Core/DirectoryEntryTest.class.st
@@ -68,6 +68,24 @@ DirectoryEntryTest >> testReference [
 ]
 
 { #category : #tests }
+DirectoryEntryTest >> testRootEntry [
+	"Check that the root entry contains sensible values.
+	On Windows this requires a pseudo entry to be available."
+
+	| rootEntry |
+
+	rootEntry := (FileReference fileSystem: FileSystem disk path: Path root) entry.
+
+	self assert: rootEntry isDirectory.
+	self deny: rootEntry isFile.
+	self assert: rootEntry size equals: 0.
+	self assert: rootEntry isReadable.
+	self assert: rootEntry isExecutable.
+	self deny: rootEntry isWritable.
+
+]
+
+{ #category : #tests }
 DirectoryEntryTest >> testSize [
 	self assert: self entry size isInteger
 ]

--- a/src/FileSystem-Tests-Core/FileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/FileReferenceTest.class.st
@@ -992,6 +992,24 @@ FileReferenceTest >> testRootParent [
 ]
 
 { #category : #tests }
+FileReferenceTest >> testRootReference [
+	"Check that the root entry contains sensible values.
+	On Windows this requires a pseudo entry to be available."
+
+	| rootReference |
+
+	rootReference := FileReference fileSystem: FileSystem disk path: Path root.
+
+	self assert: rootReference isDirectory.
+	self deny: rootReference isFile.
+	self assert: rootReference size equals: 0.
+	self assert: rootReference isReadable.
+	self assert: rootReference isExecutable.
+	self deny: rootReference isWritable.
+
+]
+
+{ #category : #tests }
 FileReferenceTest >> testSiblingOfReference [
 	| griffle  nurb |
 	griffle := filesystem / 'griffle'.

--- a/src/GT-InspectorExtensions-Core/AbstractFileReference.extension.st
+++ b/src/GT-InspectorExtensions-Core/AbstractFileReference.extension.st
@@ -96,12 +96,16 @@ AbstractFileReference >> gtInspectorItemsIn: composite [
 		column: 'Name' evaluated: [:each | (self isChildOf: each) 
 								ifTrue: [ '..' ] 
 								ifFalse: [ each basename ]] width: 400;
-		column: 'Size' evaluated: [:each | each humanReadableSize] width: 100;
+		column: 'Size' evaluated: [:each | [each humanReadableSize]
+							on: Error 
+							do: [ 'N/A' translated ]] width: 100;
 		column: 'Creation' evaluated: [ :each | 
-			String streamContents: [:s | 
+			[String streamContents: [:s | 
 				each creationTime printYMDOn: s.
 				s nextPut: Character space.
-				each creationTime printHMSOn: s ]];
+				each creationTime printHMSOn: s ]]
+					on: Error 
+					do: [ 'N/A' translated ]];
 		icon: [ :each | 
 			each isDirectory 
 				ifTrue: [ GLMUIThemeExtraIcons glamorousFolder ] 


### PR DESCRIPTION
Handle the root directory entry ('\') on Windows.

Unix file systems have a common root which is handled by the OS file system.  Windows doesn't have this, so the Pharo FileSystem needs to have a pseudo-root entry to be consistent across platforms.

Fixes: #3233