### PR TITLE
Revert "3289-beForText-is-deprecated-but-there-are-two-senders"

### DIFF
--- a/src/GT-Debugger/GTSpecPreDebugWindow.class.st
+++ b/src/GT-Debugger/GTSpecPreDebugWindow.class.st
@@ -95,6 +95,9 @@ GTSpecPreDebugWindow >> createButtonWidgetsForActions: aCollection [
 GTSpecPreDebugWindow >> createNotifierPaneWidgets [
 
 	self instantiatePresenters: self buildNotifierPaneWidgetsSpec.
+	(self widgets keys includes: #codePane) ifTrue: [ 
+		(self widgets at: #codePane) beForText.
+	].
 	self widgets keysDo: [ :key | 
 		(self perform: ('initialize', key asString capitalized) asSymbol) ]
 ]

--- a/src/ProfStef-Core/ProfStef.class.st
+++ b/src/ProfStef-Core/ProfStef.class.st
@@ -152,6 +152,7 @@ ProfStef class >> openPharoZenWorkspace [
 		text: self pharoZenValuesContents;
 		title: 'Pharo Zen' translated;
 		aboutText: self aboutPharoZen;
+		beForText;
 		openWithSpec
 ]
 


### PR DESCRIPTION
Removing the calls is not magically going to result in working code

Reverts pharo-project/pharo#3290