### PR TITLE
Use Calypso 0.16.3

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -868,7 +868,7 @@ BaselineOfIDE >> loadCalypso [
 
 	Metacello new
 		baseline: 'Calypso';
-		repository: 'github://pharo-ide/Calypso:v0.16.2/src';
+		repository: 'github://pharo-ide/Calypso:v0.16.3/src';
 		onConflict: [ :err | err useIncoming ];
 		onUpgrade: [ :err | err useIncoming ];
 		load: #('FullEnvironment' 'SystemBrowser' 'Tests').


### PR DESCRIPTION
- double click on tab header to expand it to full window- fixes for TelePharo in pharo 8