### PR TITLE
3300-Could-we-have-better-comment-for-SlotemitStore-

### DIFF
--- a/src/Slot-Core/InstanceVariableSlot.class.st
+++ b/src/Slot-Core/InstanceVariableSlot.class.st
@@ -42,13 +42,13 @@ InstanceVariableSlot >> definitionString [
 
 { #category : #'code generation' }
 InstanceVariableSlot >> emitStore: methodBuilder [
-
+	"generate store bytecodode"
 	methodBuilder storeInstVar: index
 ]
 
 { #category : #'code generation' }
 InstanceVariableSlot >> emitValue: methodBuilder [
-
+	"emit the bytecode to push ivar"
 	methodBuilder pushInstVar: index.
 
 ]
@@ -66,7 +66,8 @@ InstanceVariableSlot >> isReadIn: aCompiledCode [
 { #category : #testing }
 InstanceVariableSlot >> isSpecial [
 	"I am just a backward compatible ivar slot. Note: my subclasses are special"
-	^(self class = InstanceVariableSlot) not
+
+	^ self class ~= InstanceVariableSlot
 ]
 
 { #category : #testing }

--- a/src/Slot-Core/Slot.class.st
+++ b/src/Slot-Core/Slot.class.st
@@ -140,8 +140,9 @@ Slot >> definitionString [
 
 { #category : #'code generation' }
 Slot >> emitStore: aMethodBuilder [
+	"generate bytecode to call the reflective write method of the Slot"
 	| tempName |
-	tempName := Object new.
+	tempName := Object new.  "we need a unique Object as a temp name"
 	aMethodBuilder
 		addTemp: tempName;
 		storeTemp: tempName;

--- a/src/Slot-Examples/AbstractInitializedSlot.class.st
+++ b/src/Slot-Examples/AbstractInitializedSlot.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : #AbstractInitializedSlot,
+	#superclass : #InstanceVariableSlot,
+	#instVars : [
+		'default'
+	],
+	#category : #'Slot-Examples-Base'
+}
+
+{ #category : #comparing }
+AbstractInitializedSlot >> = other [
+	^ super = other and: [default = other default]
+]
+
+{ #category : #accessing }
+AbstractInitializedSlot >> default [
+	^ default
+]
+
+{ #category : #accessing }
+AbstractInitializedSlot >> default: anObject [
+	default := anObject
+]
+
+{ #category : #comparing }
+AbstractInitializedSlot >> hasSameDefinitionAs: otherSlot [
+
+	^ (super hasSameDefinitionAs: otherSlot) 
+		and: [ default = otherSlot default ]
+
+]
+
+{ #category : #comparing }
+AbstractInitializedSlot >> hash [
+	^super hash bitXor: default hash
+]
+
+{ #category : #printing }
+AbstractInitializedSlot >> printOn: aStream [
+	aStream 
+		store: self name;
+		nextPutAll: ' => ';
+		nextPutAll: self class name;
+		nextPutAll: ' default: ';
+		store: default
+]

--- a/src/Slot-Examples/BooleanSlot.class.st
+++ b/src/Slot-Examples/BooleanSlot.class.st
@@ -22,9 +22,9 @@ BooleanSlot >> baseSlotRead: anObject [
 
 { #category : #'code generation' }
 BooleanSlot >> emitStore: methodBuilder [
+	"generate bytecode for 'baseSlot bitAt: index put: <stackTop>'"
 	| tempName |
-
-	tempName := Object new.
+	tempName := Object new.  "we need a unique Object as a temp name"
 	methodBuilder
 		send: #asBit;
 		addTemp: tempName;
@@ -40,13 +40,13 @@ BooleanSlot >> emitStore: methodBuilder [
 
 { #category : #'code generation' }
 BooleanSlot >> emitValue: methodBuilder [
-
-		methodBuilder
-			pushInstVar: baseSlot index;
-			pushLiteral: offset;
-			send: #bitAt:;
-			pushLiteral: 1;
-			send: #==.
+	"generate bytecode for '(<baseSlot> bitAt: offset) == 1'"
+	methodBuilder
+		pushInstVar: baseSlot index;
+		pushLiteral: offset;
+		send: #bitAt:;
+		pushLiteral: 1;
+		send: #==.
 	
 	
 ]

--- a/src/Slot-Examples/ComputedSlot.class.st
+++ b/src/Slot-Examples/ComputedSlot.class.st
@@ -25,18 +25,13 @@ ComputedSlot >> = other [
 	^ super = other and: [block = other block]
 ]
 
-{ #category : #accessing }
-ComputedSlot >> block [
-	^block
-]
-
 { #category : #'code generation' }
 ComputedSlot >> emitValue: methodBuilder [
-
-		methodBuilder
-			pushLiteral: block;
-			pushReceiver;
-			send: #cull:.
+	"generate the bytcode for 'block cull: self'"
+	methodBuilder
+		pushLiteral: block;
+		pushReceiver;
+		send: #cull:.
 ]
 
 { #category : #comparing }
@@ -64,6 +59,7 @@ ComputedSlot >> printOn: aStream [
 
 { #category : #'meta-object-protocol' }
 ComputedSlot >> read: anObject [
+	"we use #cull to support both 0-arg and 1-arg blocks"
 	^block cull: anObject
 	
 ]
@@ -75,5 +71,5 @@ ComputedSlot >> with: aBlock [
 
 { #category : #'meta-object-protocol' }
 ComputedSlot >> write: aValue to: anObject [
-	"ignored"
+	"ignored, as the slot returns the computed value on read"
 ]

--- a/src/Slot-Examples/ExampleSlotWithDefaultValue.class.st
+++ b/src/Slot-Examples/ExampleSlotWithDefaultValue.class.st
@@ -7,55 +7,14 @@ I am showing how a slot can initialize itself on object creation.
 "
 Class {
 	#name : #ExampleSlotWithDefaultValue,
-	#superclass : #InstanceVariableSlot,
-	#instVars : [
-		'default'
-	],
+	#superclass : #AbstractInitializedSlot,
 	#category : #'Slot-Examples-Base'
 }
-
-{ #category : #comparing }
-ExampleSlotWithDefaultValue >> = other [
-	^ super = other and: [default = other default]
-]
-
-{ #category : #accessing }
-ExampleSlotWithDefaultValue >> default [
-	^ default
-]
-
-{ #category : #accessing }
-ExampleSlotWithDefaultValue >> default: anObject [
-	default := anObject
-]
-
-{ #category : #comparing }
-ExampleSlotWithDefaultValue >> hasSameDefinitionAs: otherSlot [
-
-	^ (super hasSameDefinitionAs: otherSlot) 
-		and: [ default = otherSlot default ]
-
-]
-
-{ #category : #comparing }
-ExampleSlotWithDefaultValue >> hash [
-	^super hash bitXor: default hash
-]
 
 { #category : #initialization }
 ExampleSlotWithDefaultValue >> initialize: anObject [
 	self write: default to: anObject. 
 	
-]
-
-{ #category : #printing }
-ExampleSlotWithDefaultValue >> printOn: aStream [
-	aStream 
-		store: self name;
-		nextPutAll: ' => ';
-		nextPutAll: self class name;
-		nextPutAll: ' default: ';
-		store: default
 ]
 
 { #category : #'meta-object-protocol' }

--- a/src/Slot-Examples/LazySlot.class.st
+++ b/src/Slot-Examples/LazySlot.class.st
@@ -8,25 +8,13 @@ The slot instead does the nil check as part of the slot read operation
 "
 Class {
 	#name : #LazySlot,
-	#superclass : #InstanceVariableSlot,
-	#instVars : [
-		'default'
-	],
+	#superclass : #AbstractInitializedSlot,
 	#category : #'Slot-Examples-Base'
 }
 
-{ #category : #comparing }
-LazySlot >> = other [
-	^ super = other and: [default = other default]
-]
-
-{ #category : #accessing }
-LazySlot >> default: anObject [
-	default := anObject
-]
-
 { #category : #'code generation' }
 LazySlot >> emitValue: aMethodBuilder [
+	"generate bytecode for '<varname> ifNil: [default]'"
 	aMethodBuilder
 		pushInstVar: index;
 		pushDup;
@@ -36,27 +24,6 @@ LazySlot >> emitValue: aMethodBuilder [
 		popTop;
 		pushLiteral: default;
 		jumpAheadTarget: #target
-]
-
-{ #category : #comparing }
-LazySlot >> hasSameDefinitionAs: otherSlot [
-	^ (super hasSameDefinitionAs: otherSlot) 
-		and: [ default = otherSlot default ]
-]
-
-{ #category : #comparing }
-LazySlot >> hash [
-	^super hash bitXor: default hash
-]
-
-{ #category : #printing }
-LazySlot >> printOn: aStream [
-	aStream 
-		store: self name;
-		nextPutAll: ' => ';
-		nextPutAll: self class name;
-		nextPutAll: ' default: ';
-		store: default
 ]
 
 { #category : #'meta-object-protocol' }

--- a/src/Slot-Examples/ProcessLocalSlot.class.st
+++ b/src/Slot-Examples/ProcessLocalSlot.class.st
@@ -31,8 +31,9 @@ Class {
 
 { #category : #'code generation' }
 ProcessLocalSlot >> emitStore: aMethodBuilder [
+	"generate bytecode for 'varname value: <stackTop>'"
 	| temp |
-	temp := Object new.
+	temp := Object new.  "we need a unique Object as a temp name"
 	"We pop the value from the stack into a temp to push it back in the right order"
 	aMethodBuilder addTemp: temp.
 	aMethodBuilder storeTemp: temp.

--- a/src/Slot-Examples/PropertySlot.class.st
+++ b/src/Slot-Examples/PropertySlot.class.st
@@ -13,9 +13,9 @@ Class {
 
 { #category : #'code generation' }
 PropertySlot >> emitStore: methodBuilder [
+	"generate bytecode for 'baseSlot at: 1 put: <stackTop>'"
 	| tempName |
-
-	tempName := Object new.
+	tempName := Object new.  "we need a unique Object as a temp name"
 	methodBuilder
 		addTemp: tempName;
 		storeTemp: tempName;
@@ -29,12 +29,12 @@ PropertySlot >> emitStore: methodBuilder [
 
 { #category : #'code generation' }
 PropertySlot >> emitValue: methodBuilder [
-
-		methodBuilder
-			pushInstVar: baseSlot index;
-			pushLiteral: self name;
-			pushLiteral: nil;
-			send: #at:ifAbsent:
+	"generate bytecode for '<baseSlot> at: name ifAbsent: nil'"
+	methodBuilder
+		pushInstVar: baseSlot index;
+		pushLiteral: self name;
+		pushLiteral: nil;
+		send: #at:ifAbsent:
 	
 	
 ]

--- a/src/Slot-Examples/RelationSlot.class.st
+++ b/src/Slot-Examples/RelationSlot.class.st
@@ -71,8 +71,9 @@ RelationSlot >> checkValue: aValue [
 
 { #category : #'code generation' }
 RelationSlot >> emitStore: aMethodBuilder [
+	"copy of #emitStore from Slot as my superclass has overriden it"
 	| tempName |
-	tempName := Object new.
+	tempName := Object new.  "we need a unique Object as a temp name"
 	aMethodBuilder
 		addTemp: tempName;
 		storeTemp: tempName;

--- a/src/Slot-Examples/UnlimitedInstanceVariableSlot.class.st
+++ b/src/Slot-Examples/UnlimitedInstanceVariableSlot.class.st
@@ -12,9 +12,9 @@ Class {
 
 { #category : #'code generation' }
 UnlimitedInstanceVariableSlot >> emitStore: methodBuilder [
+	"generate bytecode for 'baseSlot at: index put: <stackTop>'"
 	| tempName |
-
-	tempName := Object new.
+	tempName := Object new.  "we need a unique Object as a temp name"
 	methodBuilder
 		addTemp: tempName;
 		storeTemp: tempName;
@@ -27,11 +27,11 @@ UnlimitedInstanceVariableSlot >> emitStore: methodBuilder [
 
 { #category : #'code generation' }
 UnlimitedInstanceVariableSlot >> emitValue: methodBuilder [
-
-		methodBuilder
-			pushInstVar: baseSlot index;
-			pushLiteral: offset;
-			send: #at:
+	"generate bytecode for '<baseSlot> at: offset'"
+	methodBuilder
+		pushInstVar: baseSlot index;
+		pushLiteral: offset;
+		send: #at:
 			
 ]
 

--- a/src/Slot-Examples/WeakSlot.class.st
+++ b/src/Slot-Examples/WeakSlot.class.st
@@ -19,8 +19,9 @@ Class {
 
 { #category : #'code generation' }
 WeakSlot >> emitStore: aMethodBuilder [
+	"generate bytecode for 'varname at: 1 put: <stackTop>'"
 	| temp |
-	temp := Object new.
+	temp := Object new. "we need a unique Object as a temp name"
 	"Pop the value to store into a temp to push it back in the right order"
 	aMethodBuilder addTemp: temp.
 	aMethodBuilder storeTemp: temp.
@@ -34,7 +35,7 @@ WeakSlot >> emitStore: aMethodBuilder [
 
 { #category : #'code generation' }
 WeakSlot >> emitValue: aMethodBuilder [
-	"Push the weak array into the stack"
+	"Push the weak array at: 1 on the stack"
 	aMethodBuilder pushInstVar: index.
 	aMethodBuilder pushLiteral: 1.
 	aMethodBuilder send: #at:

--- a/src/Slot-Tests/BooleanSlotTest.class.st
+++ b/src/Slot-Tests/BooleanSlotTest.class.st
@@ -18,7 +18,7 @@ BooleanSlotTest >> testExampleBooleanSlot [
 	self assert: (slot instVarNamed: 'baseSlot') isNotNil.
 
 	object := aClass new. 
-	"test refletive write and read"
+	"test reflective write and read"
 	slot write: true to: object.
 	self assert: (slot read: object).
 	

--- a/src/Slot-Tests/ExampleSlotWithDefaultValueTest.class.st
+++ b/src/Slot-Tests/ExampleSlotWithDefaultValueTest.class.st
@@ -15,7 +15,7 @@ ExampleSlotWithDefaultValueTest >> testExampleSlotWithDefaultValue [
 
 	self assert: (aClass hasSlotNamed: #slot1).
 	
-	"test refletive write and read"
+	"test reflective write and read"
 	slot := aClass slotNamed: #slot1.
 	object := aClass new.
 

--- a/src/Slot-Tests/ExampleSlotWithStateTest.class.st
+++ b/src/Slot-Tests/ExampleSlotWithStateTest.class.st
@@ -19,12 +19,10 @@ ExampleSlotWithStateTest >> testExampleClassSide [
 { #category : #tests }
 ExampleSlotWithStateTest >> testExampleSlotWithState [
 	| slot |
-	aClass := self
-		make:
-			[ :builder | builder slots: {(#slot1 => ExampleSlotWithState)} ].
+	aClass := self make: [ :builder | builder slots: {(#slot1 => ExampleSlotWithState)} ].
 	self assert: (aClass hasSlotNamed: #slot1).
 
-	"test refletive write and read"
+	"test reflective write and read"
 	slot := aClass slotNamed: #slot1.
 	slot write: 5 to: aClass new.
 	self assert: (slot read: aClass new) equals: 5.

--- a/src/Slot-Tests/LazySlotTest.class.st
+++ b/src/Slot-Tests/LazySlotTest.class.st
@@ -25,7 +25,7 @@ LazySlotTest >> testLazySlotReadReflective [
 	slot := #slot1 => LazySlot default: 5 .
 	aClass := self make: [ :builder | builder slots: {slot } ].
 	
-	"test refletive write and read"
+	"test reflective write and read"
 	object := aClass new.
 
 	self assert: (slot read: object) equals: 5.

--- a/src/Slot-Tests/UnlimitedInstanceVariableSlotTest.class.st
+++ b/src/Slot-Tests/UnlimitedInstanceVariableSlotTest.class.st
@@ -15,7 +15,7 @@ UnlimitedInstanceVariableSlotTest >> testExampleIvarSlot [
 	self assert: (slot instVarNamed: 'baseSlot') isNotNil.
 
 	object := aClass new. 
-	"test refletive write and read"
+	"test reflective write and read"
 	slot write: 5 to: object.
 	self assert: (slot read: object) == 5.
 	

--- a/src/Spec-Core/SpecObservableSlot.class.st
+++ b/src/Spec-Core/SpecObservableSlot.class.st
@@ -6,8 +6,9 @@ Class {
 
 { #category : #'code generation' }
 SpecObservableSlot >> emitStore: aMethodBuilder [
+	"generate bytecode for 'varName value: <stackTop>'"
 	| temp |
-	temp := Object new.
+	temp := Object new.  "we need a unique Object as a temp name"
 	"We pop the value from the stack into a temp to push it back in the right order"
 	aMethodBuilder addTemp: temp.
 	aMethodBuilder storeTemp: temp.


### PR DESCRIPTION
- add comment to all #emitValue: methods
- add comments to all emitStore: methods
- add comment for 'Object new' in #emitStore:
- fix type: refletive -> reflective
- move all the duplicated code from ExampleSlotWithDefaultValue and LazySlot to AbstractInitializedSlot (class names needs to be improved)

fixes #3300