### PR TITLE
2598-isSpecial-is-not-an-explicit-name-for-a-method

### DIFF
--- a/src/Collections-Support/Association.class.st
+++ b/src/Collections-Support/Association.class.st
@@ -40,13 +40,6 @@ Association >> isSelfEvaluating [
 	^ self class == Association and: [self key isSelfEvaluating and: [self value isSelfEvaluating]]
 ]
 
-{ #category : #testing }
-Association >> isSpecial [
-	"Implemented here so we can use simple Assocications as Bindings instead of LiteralVariable
-	subclasses"
-	^false
-]
-
 { #category : #accessing }
 Association >> key: aKey value: anObject [ 
 	"Store the arguments as the variables of the receiver."
@@ -79,6 +72,13 @@ Association >> storeOn: aStream [
 	aStream nextPutAll: '->'.
 	value storeOn: aStream.
 	aStream nextPut: $)
+]
+
+{ #category : #testing }
+Association >> useFullDefinition [
+	"Implemented here so we can use simple Assocications as Bindings instead of LiteralVariable
+	subclasses"
+	^false
 ]
 
 { #category : #evaluating }

--- a/src/GT-SpotterExtensions-Core/Behavior.extension.st
+++ b/src/GT-SpotterExtensions-Core/Behavior.extension.st
@@ -69,8 +69,8 @@ Behavior >> spotterTraitUsersFor: aStep [
 Behavior >> spotterUsedSlotsFor: aStep [
 	<spotterOrder: 70>
 	aStep listProcessor
-			title: 'Special Slots';
-			allCandidates: [ self slots select: [ :slot | slot isSpecial ] ];
+			title: 'Full Defintion Slots';
+			allCandidates: [ self slots select: [ :slot | slot useFullDefinition ] ];
 			itemName: [ :item | item definitionString ];
 			filter: GTFilterSubstring
 ]

--- a/src/GT-SpotterExtensions-Core/Behavior.extension.st
+++ b/src/GT-SpotterExtensions-Core/Behavior.extension.st
@@ -69,7 +69,7 @@ Behavior >> spotterTraitUsersFor: aStep [
 Behavior >> spotterUsedSlotsFor: aStep [
 	<spotterOrder: 70>
 	aStep listProcessor
-			title: 'Full Defintion Slots';
+			title: 'Full Definition Slots';
 			allCandidates: [ self slots select: [ :slot | slot useFullDefinition ] ];
 			itemName: [ :item | item definitionString ];
 			filter: GTFilterSubstring

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -348,14 +348,14 @@ Class >> classVarNames [
 Class >> classVariableDefinitionString [
 	"Answer a string that evaluates to the definition of the class Variables"
 	
-	^String streamContents: [ :str | | special |
+	^String streamContents: [ :str | | fullDef |
 		str nextPutAll: '{ '.
 		self classVariables do: [:global |
 				str nextPutAll: global definitionString.
-				special := global isSpecial]				
+				fullDef := global useFullDefinition]				
 			separatedBy: [ 
 				str nextPutAll: '. '.  
-				special ifTrue: [ str cr;tab;tab;tab;tab ]].
+				fullDef ifTrue: [ str cr;tab;tab;tab;tab ]].
 		str nextPutAll: ' }'. ]
 ]
 

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -1121,14 +1121,14 @@ ClassDescription >> slotDefinitionString [
 
 	"^self slots ifNotEmpty: [self slots asString] ifEmpty: ['{}']"
 	
-	^String streamContents: [ :str | | special |
+	^String streamContents: [ :str | | useFull |
 		str nextPutAll: '{ '.
 		self localSlots do: [:slot |
 				str nextPutAll: slot definitionString.
-				special := slot isSpecial]				
+				useFull := slot useFullDefinition]				
 			separatedBy: [ 
 				str nextPutAll: '. '.  
-				special ifTrue: [ str cr;tab;tab;tab;tab ]].
+				useFull ifTrue: [ str cr;tab;tab;tab;tab ]].
 		str nextPutAll: ' }'. ]
 
 ]
@@ -1331,13 +1331,13 @@ ClassDescription >> usesPoolVarNamed: aString [
 { #category : #slots }
 ClassDescription >> usesSpecialClassVariables [
 
-	^self classVariables anySatisfy: [ :each | each isSpecial ]
+	^self classVariables anySatisfy: [ :each | each useFullDefinition ]
 ]
 
 { #category : #slots }
 ClassDescription >> usesSpecialSlot [
 	"return true if we define something else than InstanceVariableSlots"
-	^self slots anySatisfy: [ :each | each isSpecial ]
+	^self slots anySatisfy: [ :each | each useFullDefinition ]
 ]
 
 { #category : #slots }

--- a/src/NautilusRefactoring/ChangesBrowser.class.st
+++ b/src/NautilusRefactoring/ChangesBrowser.class.st
@@ -113,7 +113,9 @@ ChangesBrowser >> initializeChangesTree [
 
 { #category : #initialization }
 ChangesBrowser >> initializePresenter [
-	changesTree whenHighlightedItemChanged: [ :item | item ifNotNil: [ textArea text: (self buildDiffFor: item content) ] ]
+	changesTree
+		whenHighlightedItemChangedDo:
+			[ :item | item ifNotNil: [ textArea text: (self buildDiffFor: item content) ] ]
 ]
 
 { #category : #initialization }

--- a/src/Slot-Core/ClassVariable.class.st
+++ b/src/Slot-Core/ClassVariable.class.st
@@ -15,7 +15,7 @@ Class {
 { #category : #printing }
 ClassVariable >> definitionString [
 	"non special globals are defined by the symbol"
-	^self isSpecial
+	^self useFullDefinition
 		ifTrue: [super definitionString]
 		ifFalse: [self name printString]
 
@@ -38,10 +38,4 @@ ClassVariable >> emitValue: methodBuilder [
 { #category : #testing }
 ClassVariable >> isClassVariable [
 	^true
-]
-
-{ #category : #testing }
-ClassVariable >> isSpecial [
-	"I just a class var Note: my subclasses are special"
-	^(self class = ClassVariable) not
 ]

--- a/src/Slot-Core/IndexedSlot.class.st
+++ b/src/Slot-Core/IndexedSlot.class.st
@@ -22,6 +22,12 @@ IndexedSlot >> = other [
 ]
 
 { #category : #comparing }
+IndexedSlot >> hasSameDefinitionAs: other [
+	"Definiton does not contain index"
+	^super = other
+]
+
+{ #category : #comparing }
 IndexedSlot >> hash [
 	^ (self species hash bitXor: self name hash) bitXor: (self index ifNil: [ 0 ])
 ]

--- a/src/Slot-Core/InstanceVariableSlot.class.st
+++ b/src/Slot-Core/InstanceVariableSlot.class.st
@@ -38,7 +38,7 @@ InstanceVariableSlot class >> resetIvarSlots [
 { #category : #printing }
 InstanceVariableSlot >> definitionString [
 	"non special globals are defined by the symbol"
-	^self isSpecial
+	^self useFullDefinition
 		ifTrue: [super definitionString]
 		ifFalse: [self name printString]
 
@@ -68,15 +68,16 @@ InstanceVariableSlot >> isReadIn: aCompiledCode [
 ]
 
 { #category : #testing }
-InstanceVariableSlot >> isSpecial [
-	"I am just a backward compatible ivar slot. Note: my subclasses are special"
-
-	^ self class ~= InstanceVariableSlot
+InstanceVariableSlot >> isWrittenIn: aCompiledCode [
+	^aCompiledCode writesField: index
 ]
 
 { #category : #testing }
-InstanceVariableSlot >> isWrittenIn: aCompiledCode [
-	^aCompiledCode writesField: index
+InstanceVariableSlot >> useFullDefinition [
+	"I am just a backward compatible ivar slot and can use simple definitons.
+	 Note: my subclasses need full definitons"
+
+	^ self class ~= InstanceVariableSlot
 ]
 
 { #category : #queries }

--- a/src/Slot-Core/LiteralVariable.class.st
+++ b/src/Slot-Core/LiteralVariable.class.st
@@ -118,12 +118,6 @@ LiteralVariable >> isSelfEvaluating [
 ]
 
 { #category : #testing }
-LiteralVariable >> isSpecial [
-	"I am more than just a backward compatible Global"
-	^true
-]
-
-{ #category : #testing }
 LiteralVariable >> isWrittenIn: aCompiledCode [
 	^aCompiledCode writesRef: self
 ]
@@ -197,6 +191,13 @@ LiteralVariable >> removeProperty: propName ifAbsent: aBlock [
 		ifAbsent: aBlock.
 	self removePropertiesIfEmpty.
 	^ property
+]
+
+{ #category : #testing }
+LiteralVariable >> useFullDefinition [
+	"only ClassVariable can used a simplified definition"
+
+	^ self class ~= ClassVariable
 ]
 
 { #category : #queries }

--- a/src/Slot-Core/Slot.class.st
+++ b/src/Slot-Core/Slot.class.st
@@ -12,7 +12,13 @@ For customizing a subclass can override the meta-object-protocol methods. See su
 
 Vocabulary:
 - Field: space occupied in an object, used to hold values accessed via Slots
-- Slot: class-side meta-object, mapping of names to values using a MOP to fields
+- Slot: class-side meta-object, implements readind and writing.
+
+My state:
+name: I have a name (a symbol).
+owningClass: the class (or Trait) I am installed in
+definingClass: When I get installed via a Trait, owningClass will be the class and
+the Trait I am coming from (that defined me) is stored here.
 
 
 "
@@ -126,13 +132,12 @@ Slot >> baseSlot [
 
 { #category : #accessing }
 Slot >> definingClass [
-	
+	"if a Slot from a Trait is installed in a class, we store the orginal class of the trait here"
 	^ definingClass ifNil: [ self owningClass ]
 ]
 
 { #category : #accessing }
 Slot >> definingClass: aClass [
-
 	definingClass := aClass
 ]
 
@@ -201,11 +206,11 @@ Slot >> hasProperty: aKey [
 { #category : #comparing }
 Slot >> hasSameDefinitionAs: otherSlot [
 
-	"similar to #= but does not take a slot index into count"
-	self == otherSlot
-		ifTrue: [ ^ true ].
-	^ (self species == otherSlot species) 
-			and: [ name = otherSlot name ]
+	"equal definition. Slots an have additional state that is not part of the definitoon
+	(e.g. the index in IndexSlot).
+	This method then is overriden to not take thtat state into account"
+	^self = otherSlot
+	
 
 ]
 
@@ -255,12 +260,6 @@ Slot >> isSelfEvaluating [
 ]
 
 { #category : #testing }
-Slot >> isSpecial [
-	"I am more than just a backward compatible ivar slot"
-	^true
-]
-
-{ #category : #testing }
 Slot >> isVirtual [
 	"virtual slots do not take up space in the object and have size = 0"
 	^true
@@ -289,6 +288,7 @@ Slot >> name: aSymbol [
 
 { #category : #accessing }
 Slot >> owningClass [
+	"the class that the slot is installed in"
 	^owningClass
 ]
 
@@ -401,6 +401,12 @@ Slot >> size [
 { #category : #printing }
 Slot >> storeOn: aStream [
 	^self printOn: aStream
+]
+
+{ #category : #testing }
+Slot >> useFullDefinition [
+	"I am more than just a backward compatible ivar slot, I need a full definition "
+	^true
 ]
 
 { #category : #queries }

--- a/src/Slot-Core/Slot.class.st
+++ b/src/Slot-Core/Slot.class.st
@@ -12,7 +12,7 @@ For customizing a subclass can override the meta-object-protocol methods. See su
 
 Vocabulary:
 - Field: space occupied in an object, used to hold values accessed via Slots
-- Slot: class-side meta-object, implements readind and writing.
+- Slot: class-side meta-object, implements reading and writing.
 
 My state:
 name: I have a name (a symbol).

--- a/src/Slot-Core/Slot.class.st
+++ b/src/Slot-Core/Slot.class.st
@@ -208,7 +208,7 @@ Slot >> hasSameDefinitionAs: otherSlot [
 
 	"equal definition. Slots an have additional state that is not part of the definitoon
 	(e.g. the index in IndexSlot).
-	This method then is overriden to not take thtat state into account"
+	This method then is overriden to not take that state into account"
 	^self = otherSlot
 	
 

--- a/src/Slot-Examples/AbstractInitializedSlot.class.st
+++ b/src/Slot-Examples/AbstractInitializedSlot.class.st
@@ -33,14 +33,6 @@ AbstractInitializedSlot >> defaultBlock: aBlock [
 ]
 
 { #category : #comparing }
-AbstractInitializedSlot >> hasSameDefinitionAs: otherSlot [
-
-	^ (super hasSameDefinitionAs: otherSlot) 
-		and: [ default = otherSlot default ]
-
-]
-
-{ #category : #comparing }
 AbstractInitializedSlot >> hash [
 	^super hash bitXor: default hash
 ]

--- a/src/Slot-Examples/BaseSlot.class.st
+++ b/src/Slot-Examples/BaseSlot.class.st
@@ -28,14 +28,6 @@ BaseSlot >> default: anObject [
 ]
 
 { #category : #comparing }
-BaseSlot >> hasSameDefinitionAs: otherSlot [
-
-	^ (super hasSameDefinitionAs: otherSlot) 
-		and: [ default = otherSlot default ]
-
-]
-
-{ #category : #comparing }
 BaseSlot >> hash [
 	^super hash bitXor: default hash
 ]

--- a/src/Slot-Examples/ComputedSlot.class.st
+++ b/src/Slot-Examples/ComputedSlot.class.st
@@ -36,7 +36,7 @@ ComputedSlot >> emitValue: methodBuilder [
 
 { #category : #comparing }
 ComputedSlot >> hasSameDefinitionAs: otherSlot [
-
+	"other then #=, we use string comparition for the blocks here"
 	^ (super hasSameDefinitionAs: otherSlot) 
 		and: [ block printString = otherSlot block printString ]
 

--- a/src/Slot-Examples/RelationSlot.class.st
+++ b/src/Slot-Examples/RelationSlot.class.st
@@ -92,7 +92,7 @@ RelationSlot >> hasInverse [
 
 { #category : #comparing }
 RelationSlot >> hasSameDefinitionAs: otherSlot [
-
+	"need to implement as superclass implements it"
 	^ (super hasSameDefinitionAs: otherSlot) 
 		and: [ self targetClassName = otherSlot targetClassName 
 		and: [ inverseName = otherSlot inverseName ] ]


### PR DESCRIPTION
- simplfy #hasSameDefinitonAs:
- Improve comment Slot 
- describe owningClass and definingClass 
- isSpecial -> useFullDefinition
- improvement of #usesSpecialSlot and #usesSpecialClassVariables is in the backlog.

fixes #2598