### PR TITLE
3320-Improve-HistorySlot-and-other-small-fixes

### DIFF
--- a/src/Collections-Support/Association.class.st
+++ b/src/Collections-Support/Association.class.st
@@ -56,6 +56,13 @@ Association >> literalEqual: otherLiteral [
 	^self == otherLiteral
 ]
 
+{ #category : #testing }
+Association >> needsFullDefinition [
+	"Implemented here so we can use simple Assocications as Bindings instead of LiteralVariable
+	subclasses"
+	^false
+]
+
 { #category : #printing }
 Association >> printOn: aStream [
 
@@ -72,13 +79,6 @@ Association >> storeOn: aStream [
 	aStream nextPutAll: '->'.
 	value storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #testing }
-Association >> useFullDefinition [
-	"Implemented here so we can use simple Assocications as Bindings instead of LiteralVariable
-	subclasses"
-	^false
 ]
 
 { #category : #evaluating }

--- a/src/Collections-Support/Association.class.st
+++ b/src/Collections-Support/Association.class.st
@@ -58,7 +58,7 @@ Association >> literalEqual: otherLiteral [
 
 { #category : #testing }
 Association >> needsFullDefinition [
-	"Implemented here so we can use simple Assocications as Bindings instead of LiteralVariable
+	"Implemented here so we can use simple Associations as Bindings instead of LiteralVariable
 	subclasses"
 	^false
 ]

--- a/src/GT-SpotterExtensions-Core/Behavior.extension.st
+++ b/src/GT-SpotterExtensions-Core/Behavior.extension.st
@@ -70,7 +70,7 @@ Behavior >> spotterUsedSlotsFor: aStep [
 	<spotterOrder: 70>
 	aStep listProcessor
 			title: 'Full Definition Slots';
-			allCandidates: [ self slots select: [ :slot | slot useFullDefinition ] ];
+			allCandidates: [ self slots select: [ :slot | slot needsFullDefinition ] ];
 			itemName: [ :item | item definitionString ];
 			filter: GTFilterSubstring
 ]

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -352,7 +352,7 @@ Class >> classVariableDefinitionString [
 		str nextPutAll: '{ '.
 		self classVariables do: [:global |
 				str nextPutAll: global definitionString.
-				fullDef := global useFullDefinition]				
+				fullDef := global needsFullDefinition]				
 			separatedBy: [ 
 				str nextPutAll: '. '.  
 				fullDef ifTrue: [ str cr;tab;tab;tab;tab ]].
@@ -447,9 +447,7 @@ Class >> definitionForNautilus [
 	"Answer a String that defines the receiver."
 
 	| aStream poolString |
-	((self usesSpecialSlot 
-		or: [ self usesSpecialClassVariables ])
-		or: [ Slot showSlotClassDefinition ])
+	(self usesSpecialVariables or: [ Slot showSlotClassDefinition ])
 		ifTrue: [ ^ self definitionForNautilusWithSlots ].
 	poolString := self sharedPoolsString.
 	aStream := (String new: 800) writeStream.

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -1125,7 +1125,7 @@ ClassDescription >> slotDefinitionString [
 		str nextPutAll: '{ '.
 		self localSlots do: [:slot |
 				str nextPutAll: slot definitionString.
-				useFull := slot useFullDefinition]				
+				useFull := slot needsFullDefinition]				
 			separatedBy: [ 
 				str nextPutAll: '. '.  
 				useFull ifTrue: [ str cr;tab;tab;tab;tab ]].
@@ -1331,21 +1331,19 @@ ClassDescription >> usesPoolVarNamed: aString [
 { #category : #slots }
 ClassDescription >> usesSpecialClassVariables [
 
-	^self classVariables anySatisfy: [ :each | each useFullDefinition ]
+	^self classVariables anySatisfy: [ :each | each needsFullDefinition ]
 ]
 
 { #category : #slots }
 ClassDescription >> usesSpecialSlot [
 	"return true if we define something else than InstanceVariableSlots"
-	^self slots anySatisfy: [ :each | each useFullDefinition ]
+	^self slots anySatisfy: [ :each | each needsFullDefinition ]
 ]
 
 { #category : #slots }
 ClassDescription >> usesSpecialVariables [
     "return true if we define something else than InstanceVariableSlots"
-    ^(self usesSpecialSlot 
-        or: [ self class usesSpecialSlot ])
-        or: [self usesSpecialClassVariables ]
+    ^self usesSpecialSlot or: [ self class usesSpecialSlot or: [self usesSpecialClassVariables ]]
 ]
 
 { #category : #compiling }

--- a/src/Slot-Core/ClassVariable.class.st
+++ b/src/Slot-Core/ClassVariable.class.st
@@ -15,7 +15,7 @@ Class {
 { #category : #printing }
 ClassVariable >> definitionString [
 	"non special globals are defined by the symbol"
-	^self useFullDefinition
+	^self needsFullDefinition
 		ifTrue: [super definitionString]
 		ifFalse: [self name printString]
 

--- a/src/Slot-Core/InstanceVariableSlot.class.st
+++ b/src/Slot-Core/InstanceVariableSlot.class.st
@@ -38,7 +38,7 @@ InstanceVariableSlot class >> resetIvarSlots [
 { #category : #printing }
 InstanceVariableSlot >> definitionString [
 	"non special globals are defined by the symbol"
-	^self useFullDefinition
+	^self needsFullDefinition
 		ifTrue: [super definitionString]
 		ifFalse: [self name printString]
 
@@ -73,7 +73,7 @@ InstanceVariableSlot >> isWrittenIn: aCompiledCode [
 ]
 
 { #category : #testing }
-InstanceVariableSlot >> useFullDefinition [
+InstanceVariableSlot >> needsFullDefinition [
 	"I am just a backward compatible ivar slot and can use simple definitons.
 	 Note: my subclasses need full definitons"
 

--- a/src/Slot-Core/LiteralVariable.class.st
+++ b/src/Slot-Core/LiteralVariable.class.st
@@ -127,6 +127,13 @@ LiteralVariable >> name: aString [
 	self key: aString asSymbol
 ]
 
+{ #category : #testing }
+LiteralVariable >> needsFullDefinition [
+	"only ClassVariable can used a simplified definition"
+
+	^ self class ~= ClassVariable
+]
+
 { #category : #properties }
 LiteralVariable >> properties [
 	^ Properties at: self ifAbsent: nil
@@ -191,13 +198,6 @@ LiteralVariable >> removeProperty: propName ifAbsent: aBlock [
 		ifAbsent: aBlock.
 	self removePropertiesIfEmpty.
 	^ property
-]
-
-{ #category : #testing }
-LiteralVariable >> useFullDefinition [
-	"only ClassVariable can used a simplified definition"
-
-	^ self class ~= ClassVariable
 ]
 
 { #category : #queries }

--- a/src/Slot-Core/LiteralVariable.class.st
+++ b/src/Slot-Core/LiteralVariable.class.st
@@ -129,7 +129,7 @@ LiteralVariable >> name: aString [
 
 { #category : #testing }
 LiteralVariable >> needsFullDefinition [
-	"only ClassVariable can used a simplified definition"
+	"only ClassVariable can use a simplified definition"
 
 	^ self class ~= ClassVariable
 ]

--- a/src/Slot-Core/Slot.class.st
+++ b/src/Slot-Core/Slot.class.st
@@ -286,6 +286,12 @@ Slot >> name: aSymbol [
 	name := aSymbol
 ]
 
+{ #category : #testing }
+Slot >> needsFullDefinition [
+	"I am more than just a backward compatible ivar slot, I need a full definition "
+	^true
+]
+
 { #category : #accessing }
 Slot >> owningClass [
 	"the class that the slot is installed in"
@@ -401,12 +407,6 @@ Slot >> size [
 { #category : #printing }
 Slot >> storeOn: aStream [
 	^self printOn: aStream
-]
-
-{ #category : #testing }
-Slot >> useFullDefinition [
-	"I am more than just a backward compatible ivar slot, I need a full definition "
-	^true
 ]
 
 { #category : #queries }

--- a/src/Slot-Examples/HistorySlot.class.st
+++ b/src/Slot-Examples/HistorySlot.class.st
@@ -11,6 +11,13 @@ Class {
 	#category : #'Slot-Examples-Base'
 }
 
+{ #category : #'code generation' }
+HistorySlot >> emitValue: aMethodBuilder [
+	"for speed, we inline the #last send instead of calling the #read: method"
+	aMethodBuilder pushInstVar: index.
+	aMethodBuilder send: #last
+]
+
 { #category : #initialization }
 HistorySlot >> initialize [
 	size := 5
@@ -34,14 +41,21 @@ HistorySlot >> printOn: aStream [
 ]
 
 { #category : #'meta-object-protocol' }
-HistorySlot >> read: anObject [
+HistorySlot >> rawRead: anObject [
+	"return the wrapper (the collection) used to store the value"
+	^super read: anObject
+]
 
-	^ (super read: anObject) last
+{ #category : #'meta-object-protocol' }
+HistorySlot >> read: anObject [
+	"we return the last value from the collection"
+	^ (self rawRead: anObject) last
 ]
 
 { #category : #'meta-object-protocol' }
 HistorySlot >> readHistory: anObject [
-	^ (super read: anObject)
+	"return the complete history"
+	^ self rawRead: anObject
 ]
 
 { #category : #accessing }
@@ -63,7 +77,7 @@ HistorySlot >> wantsInitalization [
 { #category : #'meta-object-protocol' }
 HistorySlot >> write: aDictionary to: anObject [
 	| history |
-	history := super read: anObject.
+	history := self rawRead: anObject.
 	history size >= size
 		ifTrue: [ history removeFirst ].
 	^ history addLast: aDictionary

--- a/src/Slot-Tests/HistorySlotTest.class.st
+++ b/src/Slot-Tests/HistorySlotTest.class.st
@@ -18,6 +18,21 @@ HistorySlotTest >> testAddOneElement [
 ]
 
 { #category : #tests }
+HistorySlotTest >> testAddOneElementAndModifyClass [
+	| slot instance |
+	slot := #slot1 => HistorySlot.
+	aClass := self make: [ :builder | builder slots: {slot} ].
+
+	self compileAccessorsFor: slot.
+
+	instance := aClass new.
+	instance slot1: 25.
+	
+	aClass addInstVarNamed: 'x'.
+	self assert: instance slot1 equals: 25
+]
+
+{ #category : #tests }
 HistorySlotTest >> testAddTwoElements [
 	| slot instance |
 	slot := #slot1 => HistorySlot.
@@ -76,4 +91,23 @@ HistorySlotTest >> testIsFirstElementNil [
 	instance := aClass new.
 
   	self assert: (instance slot1)  equals:  nil.
+]
+
+{ #category : #tests }
+HistorySlotTest >> testModifyIvarToHistory [
+	"test if we can transform a standard ivar to a history slot when instances are present"
+
+	| slot instance |
+	slot := #slot1 =>InstanceVariableSlot .
+	aClass := self make: [ :builder | builder slots: {slot} ].
+
+	self compileAccessorsFor: slot.
+
+	instance := aClass new.
+	instance slot1: 25.
+	slot := #slot1 =>HistorySlot.
+	aClass := self make: [ :builder | builder slots: {slot} ].
+	
+	self assert: instance slot1 equals: 25.
+	self assert: (slot readHistory: instance) asArray equals: #(nil 25)
 ]


### PR DESCRIPTION
- add two tests for HistorySlot related to adding  slots to existing instances (green!)
- add #rawRead: like the Spec Slot to start to use the same vocabulary for these wrappers
- use #raweRead instead of super read:
- add #emitValue: for speed. (no emitStore yet)
- simplify usesSpecialVariables 
- simplify definitionForNautilus
- useFullDefinitions --> needsFullDefinition


fixes #3320