### PR TITLE
3323-traits-definition-message-should-use-package-instead-of-category

### DIFF
--- a/src/Athens-Cairo/TBird.trait.st
+++ b/src/Athens-Cairo/TBird.trait.st
@@ -1,0 +1,4 @@
+Trait {
+	#name : #TBird,
+	#category : #'Athens-Cairo-Library'
+}

--- a/src/Hermes/HEInstaller.class.st
+++ b/src/Hermes/HEInstaller.class.st
@@ -91,7 +91,7 @@ HEInstaller >> buildTrait: aTraitDefinition [
 	newTrait := traitClass
 		named: aTraitDefinition traitName
 		uses: traitComposition
-		category: aTraitDefinition category
+		package: aTraitDefinition category
 		env: environment.
 
 	newTrait classTrait traitComposition: (aTraitDefinition classTraitComposition asLiteralIn: environment) asTraitComposition.

--- a/src/Monticello-Tests/RPackageCategorySynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageCategorySynchronisationTest.class.st
@@ -44,8 +44,8 @@ RPackageCategorySynchronisationTest >> testRenameCategoryAlsoRenameAllExtensionP
 	YPackage := self organizer packageNamed: #YYYYY.
 	ZPackage := self organizer packageNamed: #ZZZZZ.
 	
-	classInY := self createNewClassNamed: 'ClassInYPackage' inCategory: 'YYYYY'.
-	classInZ := self createNewClassNamed: 'ClassInZPackage' inCategory: 'ZZZZZ'. 
+	classInY := self createNewClassNamed: 'ClassInYPackage' inPackage: 'YYYYY'.
+	classInZ := self createNewClassNamed: 'ClassInZPackage' inPackage: 'ZZZZZ'. 
 	
 	self createMethodNamed:  'extensionFromXInClassInY'  inClass: classInY   inCategory: '*XXXXX'. 
 	self createMethodNamed:  'longNameExtensionFromXInClassInY'  inClass: classInY   inCategory: '*XXXXX-subcategory'.     

--- a/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
@@ -15,7 +15,7 @@ RPackageClassesSynchronisationTest >> testAddClassAddItIntoPackageBestMatchName 
 	self addXMatchCategory.
 	
 	tmpPackage := self organizer packageNamed: #'XXXXX'.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX-YYYY'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX-YYYY'.
 
 	self assert: (tmpPackage definesClass: class).
 	self assert: class package equals: tmpPackage
@@ -29,7 +29,7 @@ RPackageClassesSynchronisationTest >> testAddClassAddItIntoPackageExactName [
 	self addXMatchCategory.
 
 	tmpPackage := self organizer packageNamed: #XXXXX.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 
 	self assert: (tmpPackage definesClass: class).
 	self assert: class package equals: tmpPackage
@@ -43,7 +43,7 @@ RPackageClassesSynchronisationTest >> testAddClassUpdateTheOrganizerMappings [
 	self addXCategory.
 	
 	tmpPackage := self organizer packageNamed: #XXXXX.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	 
 	self assert: class package equals: tmpPackage
 ]
@@ -64,7 +64,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRaisesClassRepackaged
 	self addYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	class category: 'YYYYY'.	
 	
 	self assert: ann notNil.
@@ -85,7 +85,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassInThe
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
 	
-	class := self createNewClassNamed: 'NewClass' inCategory: 'YYYYY'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'YYYYY'.
 	
 	class category: 'XXXXX-YYYY'.
 	self assert: (self organizer packageOf: class) = XPackage. 
@@ -103,7 +103,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassInThe
 	self addYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'YYYYY'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'YYYYY'.
 	
 	class category: 'XXXXX'.
 	
@@ -122,7 +122,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassInThe
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
 	
-	class := self createNewClassNamed: 'NewClass' inCategory: 'YYYYY'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'YYYYY'.
 	
 	class category: 'XXXXX'.
 	self deny: (self organizer packageOf: class) = YPackage. 
@@ -142,7 +142,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassMetho
 	YPackage := self organizer packageNamed: #YYYYY.
 	ZPackage := self organizer packageNamed: #ZZZZZ.
 	
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'method1' inClass: class inCategory: 'category'.
 	self createMethodNamed: 'method2' inClass: class inCategory: '*zzzzz'.
 	self createMethodNamed: 'method3' inClass: class inCategory: '*yyyyy'.
@@ -174,7 +174,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassUnregisterTheClassFro
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
 	
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 
 	class category: 'YYYYY'.
 	self deny: (XPackage includesClass: class).
@@ -192,7 +192,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassUnregisterTheClassMet
 	YPackage := self organizer packageNamed: #YYYYY.
 	ZPackage := self organizer packageNamed: #ZZZZZ.
 	
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'method1' inClass: class inCategory: 'category'.
 	self createMethodNamed: 'method2' inClass: class inCategory: '*zzzzz'.
 	self createMethodNamed: 'method3' inClass: class inCategory: '*yyyyy'.
@@ -212,7 +212,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassUpdateTheOrganizerMap
 	self addYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	class category: 'YYYYY'.	
 	self assert: (self organizer packageOf: class) equals: YPackage		
 ]
@@ -230,7 +230,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassWithMetaClassMethodsR
 	YPackage := self organizer packageNamed: #YYYYY.
 	ZPackage := self organizer packageNamed: #ZZZZZ.
 	
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	
 	self createMethodNamed: 'method1' inClass: class classSide inCategory: 'category'.
 	self createMethodNamed: 'method2' inClass: class classSide inCategory: '*yyyyy'.
@@ -254,7 +254,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassWithUnexistingPackage
 	self addXCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self assert: (self organizer packageOf: class) = XPackage. 
 	
 	class category: 'YYYYY'.
@@ -271,7 +271,7 @@ RPackageClassesSynchronisationTest >> testRemoveClassUnregisterTheClassDefinedMe
 	|XPackage  class|
 	self addXCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: 'classic category'. 
 	
 	Smalltalk removeClassNamed: 'NewClass'. 
@@ -286,7 +286,7 @@ RPackageClassesSynchronisationTest >> testRemoveClassUnregisterTheClassExtension
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'. 
 	
 	Smalltalk removeClassNamed: 'NewClass'. 
@@ -300,7 +300,7 @@ RPackageClassesSynchronisationTest >> testRemoveClassUnregisterTheClassFromItsPa
 	|XPackage  class|
 	self addXCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	
 	Smalltalk removeClassNamed: 'NewClass'. 
 	self deny: (XPackage includesClass: class)
@@ -313,7 +313,7 @@ RPackageClassesSynchronisationTest >> testRemoveClassUpdateTheOrganizerMappings 
 	|XPackage  class|
 	self addXCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 
 	Smalltalk removeClassNamed: 'NewClass'. 
 	self deny: (self organizer includesPackageBackPointerForClass: class)
@@ -327,7 +327,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateClassDefinedInThePare
 	self addXCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	
-	class := self createNewClassNamed: 'RPackageOldStubClass' inCategory: 'XXXXX'.	
+	class := self createNewClassNamed: 'RPackageOldStubClass' inPackage: 'XXXXX'.	
 	class rename: 'RPackageNewStubClass'.
 	
 	self assert: (XPackage includesClassNamed: 'RPackageNewStubClass'). 
@@ -341,7 +341,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateClassDefinedSelectors
 	| XPackage  class |
 	self addXCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: 'classic category'.
 	
 	class rename: 'RPackageNewStubClass'.
@@ -358,7 +358,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateClassExtensionSelecto
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'.
 	
 	class rename: 'RPackageNewStubClass'.
@@ -374,7 +374,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateMetaclassDefinedSelec
 	| XPackage  class |
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClassSideOfClass: class  inCategory: 'classic category'.
 	
 	class rename: 'RPackageNewStubClass'.
@@ -391,7 +391,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateMetaclassExtensionSel
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClassSideOfClass: class  inCategory: '*yyyyy'.
 	
 	class rename: 'RPackageNewStubClass'.
@@ -408,7 +408,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateOrganizerClassExtendi
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'RPackageOldStubClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'RPackageOldStubClass' inPackage: 'XXXXX'.
 	self createMethodNamed: #stubMethod inClass: class inCategory: '*yyyyy'. 
 	
 	class rename: 'RPackageNewStubClass'.
@@ -424,7 +424,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateOrganizerClassPackage
 	| XPackage class |
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	class := self createNewClassNamed: 'RPackageOldStubClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'RPackageOldStubClass' inPackage: 'XXXXX'.
 	
 	class rename: 'RPackageNewStubClass'.
 	
@@ -439,7 +439,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByAddingExtensionProtoc
 	|class| 
 	self addXCategory.
 	 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'newMethod' inClass: class inCategory: 'xxxxx'.  
 	class organization addCategory: '*yyyyy' before: nil.
 	
@@ -453,7 +453,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByAddingNewProtocolDoes
 	|XPackage class| 
 	self addXCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'newMethod' inClass: class inCategory: 'xxxxx'.  
 	class organization addCategory: 'accessing' before: nil.
 	
@@ -470,7 +470,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRemovingClassicCatego
 		
 	self addXCategory.
 	XPackage := self organizer packageNamed: 'XXXXX'.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: 'classic category'.
 	class removeProtocol: 'classic category'.
 	self deny: (XPackage includesDefinedSelector: #stubMethod ofClass: class).
@@ -484,7 +484,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRemovingExtensionCate
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage  := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'.
 	
@@ -501,7 +501,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingClassicCatego
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage  := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: 'classic category'.
 	self createMethodNamed: 'stubMethod2' inClass: class  inCategory: 'classic category'.
@@ -522,7 +522,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingClassicCatego
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage  := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: 'classic category'.
 	class organization renameCategory: 'classic category' toBe: '*yyyyy'.
 	self assert: (YPackage includesExtensionSelector: #stubMethod ofClass: class).
@@ -538,7 +538,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCate
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage  := self organizer packageNamed: #YYYYY.
 	ZPackage  := self organizer packageNamed: #ZZZZZ.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'.
 	class organization renameCategory: '*yyyyy' toBe: '*zzzzz'.
 	self assert: (ZPackage includesExtensionSelector: #stubMethod ofClass: class).
@@ -554,7 +554,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCate
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage  := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'.
 	self createMethodNamed: 'stubMethod2' inClass: class  inCategory: '*yyyyy'.
@@ -575,7 +575,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCate
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage  := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'.
 	class organization renameCategory: '*yyyyy' toBe: 'classic category'.
 	self deny: (YPackage includesExtensionSelector: #stubMethod ofClass: class).

--- a/src/Monticello-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
@@ -16,12 +16,12 @@ RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryB
 	self addXYCategory.
 	self addXMatchCategory.
 	
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX-YYYY'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX-YYYY'.
 	
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
 	
-	class := self createNewClassNamed: 'NewClass' inCategory: 'YYYYY'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'YYYYY'.
 
 	self createMethodNamed: #newMethod inClass:  class inCategory: '*XXXXX-YYYY'.
 
@@ -39,7 +39,7 @@ RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryM
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 
 	self createMethodNamed: #newMethod inClass:  class inCategory: '*YYYYY-subcategory'.
 
@@ -58,7 +58,7 @@ RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryN
 	
 	firstPackage := self organizer packageNamed: #XXXXX.
 	
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	
 	self createMethodNamed: #newMethod inClass:  class inCategory: '*SomethingDifferentNothingToDoWithWhatWeHave'.
 	
@@ -76,7 +76,7 @@ RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryN
 	
 	firstPackage := self organizer packageNamed: #XXXXX.
 	
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	
 	self createMethodNamed: #newMethod inClass:  class inCategory: '*SomethingDifferentNothingToDoWithWhatWeHave'.
 	
@@ -94,7 +94,7 @@ RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryN
 	self addXYCategory.
 	firstPackage := self organizer packageNamed: #XXXXX.
 	secondPackage := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	
 	self createMethodNamed: 'stubMethod' inClass:  class inCategory: '*yyYyY'.
 	
@@ -114,7 +114,7 @@ RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryW
 	
 	firstPackage := self organizer packageNamed: #XXXXX.
 	secondPackage := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	
 	
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*YYYYY'.
@@ -132,7 +132,7 @@ RPackageExtensionMethodsSynchronisationTest >> testModifyMethodByChangingCode [
 	| class firstPackage |
 	self addXCategory.
 	firstPackage := self organizer packageNamed: #XXXXX.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass:  class inCategory: 'classic category'.
 
 	class compile: 'stubMethod ^22222222222'.
@@ -151,7 +151,7 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 	| class secondPackage|
 	self addXYCategory.
 	secondPackage := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass:  class inCategory: secondPackage methodCategoryPrefix.
 
 	secondPackage addClass: class.
@@ -170,7 +170,7 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 	| class secondPackage|
 	self addXYCategory.
 	secondPackage := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass:  class inCategory: '*XXXXX'.
 
 	secondPackage addClass: class.
@@ -190,7 +190,7 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 	self addXYCategory.
 	firstPackage := self organizer  packageNamed: #XXXXX.
 	secondPackage := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass:  class inCategory: secondPackage methodCategoryPrefix.
 
 	secondPackage addClass: class.
@@ -221,7 +221,7 @@ RPackageExtensionMethodsSynchronisationTest >> testRemoveAllExtensionMethodsFrom
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage  := self organizer packageNamed: #YYYYY.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'. 
 	self createMethodNamed: 'stubMethod2' inClass: class classSide  inCategory: '*yyyyy'. 
 
@@ -240,7 +240,7 @@ RPackageExtensionMethodsSynchronisationTest >> testRemoveAllExtensionMethodsRemo
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage  := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'. 
 	self createMethodNamed: 'stubMethod2' inClass: class  inCategory: '*yyyyy'. 
 	
@@ -261,7 +261,7 @@ RPackageExtensionMethodsSynchronisationTest >> testRemoveExtensionMethodDoesNotR
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage  := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'. 
 	self createMethodNamed: 'stubMethod2' inClass: class  inCategory: '*yyyyy'. 
 	
@@ -283,7 +283,7 @@ RPackageExtensionMethodsSynchronisationTest >> testRemoveExtensionMethodRemoveMe
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage  := self organizer packageNamed: #YYYYY.
 	
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'.
 	
 	class removeSelector: #stubMethod.

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -138,7 +138,7 @@ RPackageMCSynchronisationTest >> createNewClassNamed: aName [
 ]
 
 { #category : #private }
-RPackageMCSynchronisationTest >> createNewClassNamed: aName inCategory: aCategoryName [
+RPackageMCSynchronisationTest >> createNewClassNamed: aName inPackage: aCategoryName [
 	
 	| cls |
 	cls := Object subclass: aName asSymbol
@@ -150,12 +150,12 @@ RPackageMCSynchronisationTest >> createNewClassNamed: aName inCategory: aCategor
 ]
 
 { #category : #private }
-RPackageMCSynchronisationTest >> createNewTraitNamed: aName inCategory: aCategoryName [
+RPackageMCSynchronisationTest >> createNewTraitNamed: aName inPackage: aPackageName [
 	
 	| trait |
 	trait := Trait named: aName asSymbol
-			uses: {}
-			category: aCategoryName.
+					uses: {}
+					package: aPackageName.
 	^ trait
 ]
 
@@ -233,7 +233,7 @@ RPackageMCSynchronisationTest >> testNotRepackagedAnnouncementWhenModifyMethodBy
 	self addXYCategory. 
 	firstPackage := self organizer  packageNamed: #XXXXX.
 	secondPackage := self organizer  packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 
 	self createMethodNamed: 'stubMethod' inClass:  class inCategory: '*yyyyy'.
 	
@@ -256,7 +256,7 @@ RPackageMCSynchronisationTest >> testNotRepackagedAnnouncementWhenMovingClassicC
 	self addXYCategory. 
 	firstPackage := self organizer  packageNamed: #XXXXX.
 	secondPackage := self organizer  packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 
 	self createMethodNamed: 'stubMethod' inClass:  class inCategory: 'classic'.
 	
@@ -279,7 +279,7 @@ RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMov
 	self addXYCategory. 
 	firstPackage := self organizer  packageNamed: #XXXXX.
 	secondPackage := self organizer  packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass:  class inCategory: 'classic category'.
 	
 	class organization classify: #stubMethod under: '*yyyyy'.		
@@ -309,7 +309,7 @@ RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMov
 	secondPackage := self organizer packageNamed: #YYYYY.
 	thirdPackage := self organizer packageNamed: #ZZZZZ.
 	
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass:  class inCategory: '*yyyyy'.
 	
 	class organization classify: #stubMethod under: '*zzzzz'.
@@ -332,7 +332,7 @@ RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMov
 	self addXYCategory. 
 	firstPackage := self organizer  packageNamed: #XXXXX.
 	secondPackage := self organizer  packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass:  class inCategory: '*yyyyy'.
 	
 	class organization classify: #stubMethod under: 'classic one'.		

--- a/src/Monticello-Tests/RPackageMethodsSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMethodsSynchronisationTest.class.st
@@ -15,7 +15,7 @@ RPackageMethodsSynchronisationTest >> testAddMethodInClassicCategoryAddMethodToT
 	self addXCategory.
 	
 	tmpPackage := self organizer packageNamed: #XXXXX.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 
 	self createMethodNamed: 'stubMethod' inClass:  class inCategory: 'classic category'.
 
@@ -31,7 +31,7 @@ RPackageMethodsSynchronisationTest >> testAddMethodInClassicCategoryAddMethodToT
 	self addXCategory.
 
 	tmpPackage := self organizer packageNamed: #XXXXX.
-	trait := self createNewTraitNamed: 'NewClass' inCategory: 'XXXXX'.
+	trait := self createNewTraitNamed: 'NewClass' inPackage: 'XXXXX'.
 
 	self createMethodNamed: 'stubMethod' inClass:  trait inCategory: 'classic category'.
 
@@ -46,7 +46,7 @@ RPackageMethodsSynchronisationTest >> testModifyMethodByMovingFromClassicCategor
 	| class firstPackage |
 	self addXCategory.
 	firstPackage := self organizer packageNamed: #XXXXX.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass:  class inCategory: 'classic category'.
 
 	"this we do"
@@ -67,7 +67,7 @@ RPackageMethodsSynchronisationTest >> testModifyMethodByMovingFromClassicCategor
 	self addXYCategory. 
 	firstPackage := self organizer  packageNamed: #XXXXX.
 	secondPackage := self organizer  packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass:  class inCategory: 'classic category'.
 
 	class organization classify: #stubMethod under: '*yyyyy'.	
@@ -91,7 +91,7 @@ RPackageMethodsSynchronisationTest >> testModifyMethodByMovingFromExtensionCateg
 	
 	firstPackage := self organizer  packageNamed: #XXXXX.
 	secondPackage := self organizer  packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass:  class inCategory: '*yyyyy'.
 
 	class organization classify: #stubMethod under: 'classic category'.
@@ -109,7 +109,7 @@ RPackageMethodsSynchronisationTest >> testModifyMethodByMovingFromExtensionCateg
 	XPackage := self organizer  packageNamed: #XXXXX.
 	YPackage := self organizer  packageNamed: #YYYYY.
 	ZPackage := self organizer  packageNamed: #ZZZZZ.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: #newMethod inClass:  class inCategory: '*yyyyy'.
 
 	class organization classify: #newMethod under: '*zzzzz'.
@@ -126,7 +126,7 @@ RPackageMethodsSynchronisationTest >> testRemoveMethodRemoveMethodFromItsPackage
 	|XPackage  class|
 	self addXCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: 'classic category'. 
 	
 	class removeSelector: #stubMethod.

--- a/src/Monticello-Tests/RPackageTraitSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageTraitSynchronisationTest.class.st
@@ -17,8 +17,8 @@ RPackageTraitSynchronisationTest >> testAddMethodByUsingATraitDoesNotAddTheMetho
 	self addYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
-	trait := self createNewTraitNamed: 'NewTrait' inCategory: 'YYYYY'.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	trait := self createNewTraitNamed: 'NewTrait' inPackage: 'YYYYY'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: trait inCategory: 'trait category'.
 
 	self assertEmpty: XPackage methods.
@@ -36,7 +36,7 @@ RPackageTraitSynchronisationTest >> testAddTraitAddItIntoPackageBestMatchName [
 	self addXMatchCategory.
 	
 	tmpPackage := self organizer packageNamed: #'XXXXX'.
-	class := self createNewTraitNamed: 'NewClass' inCategory: 'XXXXX-YYYY'.
+	class := self createNewTraitNamed: 'NewClass' inPackage: 'XXXXX-YYYY'.
 
 	self assert: (tmpPackage definesClass: class).
 	self assert: tmpPackage equals: class package.
@@ -50,7 +50,7 @@ RPackageTraitSynchronisationTest >> testAddTraitAddItIntoPackageExactName [
 	self addXMatchCategory.
 
 	tmpPackage := self organizer packageNamed: #XXXXX.
-	class := self createNewTraitNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewTraitNamed: 'NewClass' inPackage: 'XXXXX'.
 
 	self assert: (tmpPackage definesClass: class).
 	self assert: tmpPackage equals: class package.
@@ -64,7 +64,7 @@ RPackageTraitSynchronisationTest >> testAddTraitUpdateTheOrganizerMappings [
 	self addXCategory.
 	
 	tmpPackage := self organizer packageNamed: #XXXXX.
-	class := self createNewTraitNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self createNewTraitNamed: 'NewClass' inPackage: 'XXXXX'.
 	 
 	self assert: class package equals: tmpPackage
 ]
@@ -79,8 +79,8 @@ RPackageTraitSynchronisationTest >> testRemoveMethodComingFromTraitDoesNotRemove
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
 	
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	trait := self createNewTraitNamed: 'NewTrait' inCategory: 'YYYYY'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
+	trait := self createNewTraitNamed: 'NewTrait' inPackage: 'YYYYY'.
 	
 	self createMethodNamed: 'stubMethod' inClass: trait  inCategory: 'classic protocol'. 
 	class setTraitComposition: trait asTraitComposition.
@@ -99,8 +99,8 @@ RPackageTraitSynchronisationTest >> testRemoveTraitMethod [
 	self addYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	trait := self createNewTraitNamed: 'NewTrait' inCategory: 'YYYYY'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
+	trait := self createNewTraitNamed: 'NewTrait' inPackage: 'YYYYY'.
 	self createMethodNamed: 'stubMethod' inClass: trait  inCategory: 'classic protocol'. 
 	class setTraitComposition: trait asTraitComposition.
 	
@@ -119,8 +119,8 @@ RPackageTraitSynchronisationTest >> testRemoveTraitMethodOverridenByClassDoesRem
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
 	
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	trait := self createNewTraitNamed: 'NewTrait' inCategory: 'YYYYY'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
+	trait := self createNewTraitNamed: 'NewTrait' inPackage: 'YYYYY'.
 	
 	self createMethodNamed: 'stubMethod' inClass: trait  inCategory: 'classic protocol'. 
 	class setTraitComposition: trait asTraitComposition.
@@ -140,8 +140,8 @@ RPackageTraitSynchronisationTest >> testTraitCompositionMethodsArePackagedWithTh
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
 	
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	trait := self createNewTraitNamed: 'NewTrait' inCategory: 'YYYYY'.
+	class := self createNewClassNamed: 'NewClass' inPackage: 'XXXXX'.
+	trait := self createNewTraitNamed: 'NewTrait' inPackage: 'YYYYY'.
 	
 	self createMethodNamed: 'stubMethod' inClass: trait  inCategory: 'classic protocol'. 
 	class setTraitComposition: trait asTraitComposition.

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -82,7 +82,7 @@ MCTraitDefinition >> createClass [
 		named: name
 		uses: (Smalltalk compiler evaluate: self traitCompositionString)
 		slots: self instanceVariables
-		category: category.
+		package: category.
 	trait ifNotNil: [
 		trait classComment: comment stamp: commentStamp.
 		self classInstanceVariables ifNotEmpty: [

--- a/src/Monticello/MCTraitParser.class.st
+++ b/src/Monticello/MCTraitParser.class.st
@@ -18,7 +18,7 @@ MCTraitParser >> addDefinitionsTo: aCollection [
 	 
 	node := RBParser parseExpression: source.
 	
-	(node selector) caseOf: { 
+	node selector caseOf: { 
 		[#named:] -> [ 
 			compositionIndex := nil. slotsIndex := nil. categoryIndex := nil ].
 		[#named:uses:] -> [ 
@@ -28,8 +28,10 @@ MCTraitParser >> addDefinitionsTo: aCollection [
 		[#named:uses:package:] -> [ 
 			compositionIndex := 2. slotsIndex := nil. categoryIndex := 3 ].
 		[#named:uses:slots:category:] -> [ 
+			compositionIndex := 2. slotsIndex := 3. categoryIndex := 4 ].
+		[#named:uses:slots:package:] -> [ 
 			compositionIndex := 2. slotsIndex := 3. categoryIndex := 4 ]
-	} otherwise: [ self error: 'Unknown trit building selector' ].
+	} otherwise: [ self error: 'Unknown trait building selector' ].
 
 	traitName := node arguments first value.
 

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -89,7 +89,7 @@ RPackageIncrementalTest >> testAddClassAfterMethods [
 	| p1 a1 |
 	p1 := self createNewPackageNamed: self p1Name.
 	"the class is created but not added to the package for now"
-	a1 := self createNewClassNamed: #A1InPackageP1 inCategory: self p1Name.
+	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: self p1Name.
 	self assert: p1 definedClasses size equals: 0.
 	
 	"now we add a new method to the class and the to the package: it is considered
@@ -122,7 +122,7 @@ RPackageIncrementalTest >> testAddClassAfterMethodsAtMetaclassToo [
 	| p1 a1 |
 	p1 := self createNewPackageNamed: self p1Name.
 	"the class is created but not added to the package for now"
-	a1 := self createNewClassNamed: #A1InPackageP1 inCategory: self p1Name.
+	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: self p1Name.
 	self assert: p1 definedClasses size equals: 0.
 	
 	"now we add a new method to the class and the to the package: it is considered
@@ -154,11 +154,11 @@ RPackageIncrementalTest >> testAddClassAfterMethodsAtMetaclassToo [
 RPackageIncrementalTest >> testAddClassDefinitionNoDuplicate [
 	| p a1 b1 |
 	p := self createNewPackageNamed: self p1Name.
-	a1 := self createNewClassNamed: #A1InPackageP1 inCategory: self p1Name.
+	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: self p1Name.
 	self assert: p definedClasses size equals: 0.
 	p addClassDefinition: a1.
 	self assert: p definedClasses size equals: 1.
-	b1 := self createNewClassNamed: #B1InPackageP1 inCategory: self p1Name.
+	b1 := self createNewClassNamed: #B1InPackageP1 inPackage: self p1Name.
 	p addClassDefinition: a1.
 	"adding the same class does not do anything - luckily"
 	self assert: p definedClasses size equals: 1.
@@ -267,7 +267,7 @@ RPackageIncrementalTest >> testAddRemoveSelectorOfMetaclass [
 RPackageIncrementalTest >> testBogusClassAddition [
 	| p a1 |
 	p := self createNewPackageNamed: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p1Name.
+	a1 := self createNewClassNamed: #A1InPAckageP1 inPackage: self p1Name.
 	self assert: p definedClasses size equals: 0.
 	p addClassDefinitionName: a1 name.
 	self assert: p definedClasses size equals: 1.
@@ -280,7 +280,7 @@ RPackageIncrementalTest >> testBogusClassAddition [
 RPackageIncrementalTest >> testClassAddition [
 	| p a1 |
 	p := self createNewPackageNamed: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p1Name.
+	a1 := self createNewClassNamed: #A1InPAckageP1 inPackage: self p1Name.
 	self assert: p definedClasses size equals: 0.
 	p addClassDefinition: a1.
 	self assert: p definedClasses size equals: 1.
@@ -294,8 +294,8 @@ RPackageIncrementalTest >> testClassDefinitionRemoval [
 	| p a1 b1|
 	
 	p := self createNewPackageNamed: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p1Name.
-	b1 := self createNewClassNamed: #B1InPAckageP1 inCategory: self p1Name.
+	a1 := self createNewClassNamed: #A1InPAckageP1 inPackage: self p1Name.
+	b1 := self createNewClassNamed: #B1InPAckageP1 inPackage: self p1Name.
 	self assert: p definedClasses size equals: 0.
 	
 	p addClassDefinition: a1.
@@ -319,8 +319,8 @@ RPackageIncrementalTest >> testClassDefinitionRemoval [
 RPackageIncrementalTest >> testClassDefinitionRemovalName [
 	| p a1 b1|
 	p := self createNewPackageNamed: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p1Name.
-	b1 := self createNewClassNamed: #B1InPAckageP1 inCategory: self p1Name.
+	a1 := self createNewClassNamed: #A1InPAckageP1 inPackage: self p1Name.
+	b1 := self createNewClassNamed: #B1InPAckageP1 inPackage: self p1Name.
 	self assert: p definedClasses size equals: 0.
 	p addClassDefinitionName: a1 name.
 	p addClassDefinitionName: b1 name.
@@ -342,8 +342,8 @@ RPackageIncrementalTest >> testClassDefinitionWithTagsRemoval [
 	| p a1 b1|
 	
 	p := self createNewPackageNamed: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p1Name.
-	b1 := self createNewClassNamed: #B1InPAckageP1 inCategory: self p1Name.
+	a1 := self createNewClassNamed: #A1InPAckageP1 inPackage: self p1Name.
+	b1 := self createNewClassNamed: #B1InPAckageP1 inPackage: self p1Name.
 	self assert: p definedClasses size equals: 0.
 	
 	p addClassDefinition: a1.
@@ -372,14 +372,14 @@ RPackageIncrementalTest >> testClassDefinitionWithTagsRemoval [
 RPackageIncrementalTest >> testDefinedClassesAndDefinedClassNames [
 	| p a1 b1 |
 	p := self createNewPackageNamed: self p1Name.
-	a1 := self createNewClassNamed: #A1InPackageP1 inCategory: self p1Name.
+	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: self p1Name.
 	self assert: p definedClasses size equals: 0.
 	p addClassDefinition: a1.
 	self assert: p definedClasses size equals: 1.
 	self assert: (p definedClasses  includes: a1).
 	self assert: (p definedClassNames includes: a1 name).
 	
-	b1 := self createNewClassNamed: #B1InPackageP1 inCategory: self p1Name.
+	b1 := self createNewClassNamed: #B1InPackageP1 inPackage: self p1Name.
 	p addClassDefinition: b1.
 	self assert: p definedClasses size equals: 2.
 	self assert: (p definedClasses includes: b1).
@@ -752,7 +752,7 @@ RPackageIncrementalTest >> testRemoveClassAfterMethods [
 	| p1 a1 |
 	p1 := self createNewPackageNamed: self p1Name.
 	"the class is created but not added to the package for now"
-	a1 := self createNewClassNamed: #A1InPackageP1 inCategory: self p1Name.
+	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: self p1Name.
 	p1 addClassDefinition: a1.
 	self assert: p1 definedClasses size equals: 1.
 	a1 compileSilently: 'newlyAddedToA1 ^ #methodDefinedInP1'.
@@ -780,7 +780,7 @@ RPackageIncrementalTest >> testRemoveClassRemovesExtensions [
 	p1 := self createNewPackageNamed: self p1Name.
 	p2 := self createNewPackageNamed: self p2Name.
 	"the class is created but not added to the package for now"
-	a1 := self createNewClassNamed: #A1InPackageP1 inCategory: self p1Name.
+	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: self p1Name.
 	p1 addClassDefinition: a1.
 	self assert: p1 definedClasses size equals: 1.
 	a1 compileSilently: 'newlyAddedToA1 ^ #methodDefinedInP1'.
@@ -802,7 +802,7 @@ RPackageIncrementalTest >> testRemoveExtensionMethodRemovesExtensionsFromRPackag
 	p1 := self createNewPackageNamed: self p1Name.
 	p2 := self createNewPackageNamed: self p2Name.
 	"the class is created but not added to the package for now"
-	a1 := self createNewClassNamed: #A1InPackageP1 inCategory: self p1Name.
+	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: self p1Name.
 	p1 addClassDefinition: a1.
 	self assert: p1 definedClasses size equals: 1.
 	a1 compileSilently: 'newlyAddedToA1 ^ #methodDefinedInP1'.
@@ -839,7 +839,7 @@ RPackageIncrementalTest >> testTwoClassesWithExtensions [
 RPackageIncrementalTest >> testUniqueClassInDefinedClassesUsingAddClassDefinition [
 	| p a1 |
 	p := self createNewPackageNamed: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p1Name.
+	a1 := self createNewClassNamed: #A1InPAckageP1 inPackage: self p1Name.
 	self assert: p definedClasses size equals: 0.
 	p addClassDefinition: a1.
 	self assert: p definedClasses size equals: 1.

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -76,7 +76,7 @@ RPackageOrganizerTest >> setUp [
 	packageOrganizer debuggingName: 'For PackageOrganizerTest'.
 	previousAuthor := Author fullName ifNil: [Author fullName: 'RPackage'].
 	
-	self createNewClassNamed: 'QuadrangleForTesting' inCategory: self class category.
+	self createNewClassNamed: 'QuadrangleForTesting' inPackage: self class category.
 	self quadrangleClass compileSilently: 'intersect:aPoint ^ false'.
 ]
 
@@ -387,7 +387,7 @@ RPackageOrganizerTest >> testSilentlyRenameCategoryToBe [
 
 	| class |
 	
-	class := self createNewClassNamed: #ClassForTestAboutSilentRecategorization inCategory: 'RPackage-Tests'.
+	class := self createNewClassNamed: #ClassForTestAboutSilentRecategorization inPackage: 'RPackage-Tests'.
 	class organization addCategory:#foo.
 	self assert: (class organization categories includes: #foo).
 	self deny: (class organization categories includes: #bar).

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -21,7 +21,7 @@ RPackageTagTest >> testAddClass [
 	| package1 package2 class |
 
 	package1 := (self packageClass named: #Test1) register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1'.
+	class := self createNewClassNamed: 'TestClass' inPackage: 'Test1'.
 	
 	self assert: (package1 includesClass: class).
 	
@@ -43,7 +43,7 @@ RPackageTagTest >> testAddClassFromTag [
 	| package1 package2 class |
 
 	package1 := (self packageClass named: #Test1) register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
+	class := self createNewClassNamed: 'TestClass' inPackage: 'Test1-TAG1'.
 	
 	self assert: (package1 includesClass: class).
 	self assert: (package1 classTagNamed: #TAG1 ifAbsent: [ nil ]) notNil.
@@ -67,7 +67,7 @@ RPackageTagTest >> testAsRPackage [
 	| package1 tag convertedTag class |
 
 	package1 := (self packageClass named: #Test1) register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
+	class := self createNewClassNamed: 'TestClass' inPackage: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 	
 	tag := (package1 classTagNamed: #TAG1).
@@ -85,7 +85,7 @@ RPackageTagTest >> testAsRPackageWithExtensionMethods [
 	package1 addClassTag: #TAG1.
 
 	(self packageClass named: #Test2) register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test2'.
+	class := self createNewClassNamed: 'TestClass' inPackage: 'Test2'.
 
 	class compile: 'foo ^42' classified: '*Test1-TAG1'.
 
@@ -100,7 +100,7 @@ RPackageTagTest >> testPromoteAsRPackage [
 	| package1 package2 class tag1 |
 
 	package1 := (self packageClass named: #Test1) register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
+	class := self createNewClassNamed: 'TestClass' inPackage: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	tag1 := package1 classTagNamed: 'TAG1'.
@@ -118,10 +118,10 @@ RPackageTagTest >> testPromoteAsRPackageWithExtension [
 	| packageOriginal packagePromoted class classOther tag |
 
 	packageOriginal := (self packageClass named: #Test1) register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
+	class := self createNewClassNamed: 'TestClass' inPackage: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: #'accessing'.
 
-	classOther := self createNewClassNamed: 'TestClassOther' inCategory: 'XXXX'.
+	classOther := self createNewClassNamed: 'TestClassOther' inPackage: 'XXXX'.
 	classOther compile: 'bar ^42' classified: #'*Test1-TAG1'.
 
 	tag := packageOriginal classTagNamed: 'TAG1'.

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -33,7 +33,7 @@ RPackageTest >> testAddClass [
 
 	package1 := (RPackage named: #Test1) register.
 	done := 0.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
+	class := self createNewClassNamed: 'TestClass' inPackage: 'Test1-TAG'.
 	SystemAnnouncer uniqueInstance when: ClassRecategorized do: [ done := done + 1].
 	
 	self assert: (package1 includesClass: class).
@@ -56,7 +56,7 @@ RPackageTest >> testAddClassFromTag [
 	| package1 package2 class |
 
 	package1 := (self packageClass named: #Test1) register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
+	class := self createNewClassNamed: 'TestClass' inPackage: 'Test1-TAG'.
 	
 	self assert: (package1 includesClass: class).
 	
@@ -94,7 +94,7 @@ RPackageTest >> testDemoteToRPackageNamed [
 	| package1 package2 class  |
 
 	package1 := (self packageClass named: #'Test1-TAG1') register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
+	class := self createNewClassNamed: 'TestClass' inPackage: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackageNamed: 'Test1'.
@@ -112,7 +112,7 @@ RPackageTest >> testDemoteToRPackageNamedExistingPackage [
 
 	package1 := (self packageClass named: #'Test1-TAG1') register.
 	packageExisting := (self packageClass named: #'Test1') register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
+	class := self createNewClassNamed: 'TestClass' inPackage: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackageNamed: 'Test1'.
@@ -130,7 +130,7 @@ RPackageTest >> testDemoteToRPackageNamedMultilevelPackage1 [
 	| package1 package2  class  |
 
 	package1 := (self packageClass named: #'Test1-TAG1-X1') register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1-X1'.
+	class := self createNewClassNamed: 'TestClass' inPackage: 'Test1-TAG1-X1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackageNamed: 'Test1'.
@@ -147,7 +147,7 @@ RPackageTest >> testDemoteToRPackageNamedMultilevelPackage2 [
 	| package1 package2  class  |
 
 	package1 := (self packageClass named: #'Test1-TAG1-X1') register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1-X1'.
+	class := self createNewClassNamed: 'TestClass' inPackage: 'Test1-TAG1-X1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackageNamed: 'Test1-TAG1'.
@@ -164,10 +164,10 @@ RPackageTest >> testDemoteToRPackageNamedWithExtension [
 	| packageOriginal packageDemoted class classOther |
 
 	packageOriginal := (RPackage named: #'Test1-TAG1') register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
+	class := self createNewClassNamed: 'TestClass' inPackage: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
-	classOther := self createNewClassNamed: 'TestClassOther' inCategory: 'XXXX'.
+	classOther := self createNewClassNamed: 'TestClassOther' inPackage: 'XXXX'.
 	classOther compile: 'bar ^42' classified: #'*Test1-TAG1'.
 
 	packageOriginal demoteToTagInPackageNamed: 'Test1'.
@@ -230,7 +230,7 @@ RPackageTest >> testRenameToMakesMCDirty [
 	| package |
 	
 	package := (self packageClass named: #'Test1') register.
-	self createNewClassNamed: 'TestClass' inCategory: 'Test1'.
+	self createNewClassNamed: 'TestClass' inPackage: 'Test1'.
 	
 	package renameTo: 'Test2'.
 	

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -22,11 +22,11 @@ RPackageTestCase >> allManagers [
 
 { #category : #utilities }
 RPackageTestCase >> createNewClassNamed: aName [
-	^ self createNewClassNamed: aName inCategory: 'RPackageTest'
+	^ self createNewClassNamed: aName inPackage: 'RPackageTest'
 ]
 
 { #category : #utilities }
-RPackageTestCase >> createNewClassNamed: aName inCategory: cat [
+RPackageTestCase >> createNewClassNamed: aName inPackage: cat [
 	
 	| cls |
 	cls := Object subclass: aName
@@ -36,15 +36,6 @@ RPackageTestCase >> createNewClassNamed: aName inCategory: cat [
 		category: cat.
 	createdClasses add: cls.
 	createdCategories add: cat.
-	^ cls
-]
-
-{ #category : #utilities }
-RPackageTestCase >> createNewClassNamed: aName inPackage: p [
-	
-	| cls |
-	cls := self createNewClassNamed: aName.
-	p addClassDefinition: cls.
 	^ cls
 ]
 
@@ -60,27 +51,18 @@ RPackageTestCase >> createNewPackageNamed: aName [
 
 { #category : #utilities }
 RPackageTestCase >> createNewTraitNamed: aName [
-	^ self createNewTraitNamed: aName inCategory: 'RPackageTest'
+	^ self createNewTraitNamed: aName inPackage: 'RPackageTest'
 ]
 
 { #category : #utilities }
-RPackageTestCase >> createNewTraitNamed: aName inCategory: cat [
+RPackageTestCase >> createNewTraitNamed: aName inPackage: aPackageName [
 	
 	| cls |
 	cls := Trait named: aName
 			uses: {}
-			category: cat.
+			package: aPackageName.
 	createdClasses add: cls.
-	createdCategories add: cat.
-	^ cls
-]
-
-{ #category : #utilities }
-RPackageTestCase >> createNewTraitNamed: aName inPackage: p [
-	
-	| cls |
-	cls := self createNewTraitNamed: aName.
-	p addClassDefinition: cls.
+	createdCategories add: aPackageName.
 	^ cls
 ]
 

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -77,17 +77,17 @@ ClassFactoryForTestCase >> createdTraits [
 
 { #category : #accessing }
 ClassFactoryForTestCase >> defaultCategory [
-	^ (self packageName , '-', self defaultCategoryPostfix) asSymbol
-]
-
-{ #category : #accessing }
-ClassFactoryForTestCase >> defaultCategoryPostfix [
-	^ #Default
+	^ (self packageName , '-', self defaultTagPostfix) asSymbol
 ]
 
 { #category : #accessing }
 ClassFactoryForTestCase >> defaultSuperclass [ 
 	^Object
+]
+
+{ #category : #accessing }
+ClassFactoryForTestCase >> defaultTagPostfix [
+	^ #Default
 ]
 
 { #category : #cleaning }
@@ -175,7 +175,7 @@ ClassFactoryForTestCase >> newClassUsing: aTraitComposition [
 		uses: aTraitComposition 
 		instanceVariableNames: '' 
 		classVariableNames: ''
-		category: self defaultCategoryPostfix.
+		category: self defaultTagPostfix.
 ]
 
 { #category : #creating }
@@ -185,7 +185,7 @@ ClassFactoryForTestCase >> newSubclassOf: aClass instanceVariableNames: ivNamesS
 		uses: { }
 		instanceVariableNames: ivNamesString 
 		classVariableNames: classVarsString 
-		category: self defaultCategoryPostfix
+		category: self defaultTagPostfix
 ]
 
 { #category : #creating }
@@ -230,7 +230,7 @@ ClassFactoryForTestCase >> newSubclassOf: aClass using: aTraitComposition [
 		uses: aTraitComposition 
 		instanceVariableNames: '' 
 		classVariableNames: ''
-		category: self defaultCategoryPostfix.
+		category: self defaultTagPostfix.
 ]
 
 { #category : #creating }
@@ -238,15 +238,15 @@ ClassFactoryForTestCase >> newTrait [
 	^ self
 		newTraitNamed: self newTraitName
 		uses: Array new
-		category: self defaultCategoryPostfix
+		tag: self defaultTagPostfix
 ]
 
 { #category : #creating }
-ClassFactoryForTestCase >> newTraitInCategory: category [
+ClassFactoryForTestCase >> newTraitInTag: aTag [
 	^ self
 		newTraitNamed: self newTraitName
 		uses: Array new
-		category: category asSymbol.
+		tag: aTag asSymbol
 ]
 
 { #category : #creating }
@@ -257,13 +257,13 @@ ClassFactoryForTestCase >> newTraitName [
 ]
 
 { #category : #creating }
-ClassFactoryForTestCase >> newTraitNamed: aTraitName uses: aTraitComposition category: aCategory [
+ClassFactoryForTestCase >> newTraitNamed: aTraitName uses: aTraitComposition tag: aTag [
 	| newTrait |
 	
 	newTrait := Trait 
 					named: aTraitName
 					uses: aTraitComposition 
-					category: (self packageName, '-', aCategory) asSymbol..
+					package: (self packageName, '-', aTag) asSymbol.
 		
 	self createdTraits add: newTrait.
 	
@@ -275,7 +275,7 @@ ClassFactoryForTestCase >> newTraitUsing: aTraitComposition. [
 	^self 
 		newTraitNamed: self newTraitName 
 		uses: aTraitComposition 
-		category: self defaultCategoryPostfix.
+		tag: self defaultTagPostfix.
 ]
 
 { #category : #accessing }
@@ -304,7 +304,7 @@ ClassFactoryForTestCase >> silentlyNewSubclassOf: aClass instanceVariableNames: 
 		silentlyNewSubclassOf: aClass
 		instanceVariableNames: ivNamesString
 		classVariableNames: classVarsString
-		category: self defaultCategoryPostfix
+		category: self defaultTagPostfix
 ]
 
 { #category : #'creating - silently' }
@@ -356,5 +356,5 @@ ClassFactoryForTestCase >> withNotificationsNewClassWithInstanceVariableNames: i
 		newSubclassOf: Object
 		instanceVariableNames: instanceVariableNames
 		classVariableNames: ''
-		category: self defaultCategoryPostfix
+		category: self defaultTagPostfix
 ]

--- a/src/SUnit-Core/ClassFactoryWithOrganization.class.st
+++ b/src/SUnit-Core/ClassFactoryWithOrganization.class.st
@@ -35,7 +35,7 @@ ClassFactoryWithOrganization >> newClassNamed: aString subclassOf: aClass instan
 		subclassOf: aClass 
 		instanceVariableNames: ivNamesString 
 		classVariableNames: classVarsString 
-		category:  (self packageName, '-', self defaultCategoryPostfix) asSymbol.
+		category:  (self packageName, '-', self defaultTagPostfix) asSymbol.
 ]
 
 { #category : #creating }
@@ -62,7 +62,7 @@ ClassFactoryWithOrganization >> newSubclassOf: aClass instanceVariableNames: ivN
 		newSubclassOf: aClass 
 		instanceVariableNames: ivNamesString 
 		classVariableNames: classVarsString 
-		category:  (self packageName, '-', self defaultCategoryPostfix) asSymbol.
+		category:  (self packageName, '-', self defaultTagPostfix) asSymbol.
 ]
 
 { #category : #creating }

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -162,10 +162,10 @@ ClassFactoryForTestCaseTest >> testSingleTraitCreation [
 ClassFactoryForTestCaseTest >> testTraitCreationInDifferentCategories [
 	| firstThreeTraits lastTwoTraits |
 	3 timesRepeat: [
-		factory newTraitInCategory: #One].
+		factory newTraitInTag: #One].
 	firstThreeTraits := factory createdTraits copy.
 	2 timesRepeat: [
-		factory newTraitInCategory: #Two].
+		factory newTraitInTag: #Two].
 	lastTwoTraits := factory createdTraits copyWithoutAll: firstThreeTraits.
 	self assert: (firstThreeTraits allSatisfy: [:trait| trait category = (factory packageName, '-', #One) asSymbol]).
 	self assert: (lastTwoTraits allSatisfy: [:trait| trait category = (factory packageName, '-', #Two) asSymbol]).

--- a/src/Tests/TraitPureBehaviorTest.class.st
+++ b/src/Tests/TraitPureBehaviorTest.class.st
@@ -185,7 +185,7 @@ TraitPureBehaviorTest >> testOwnMethodsTakePrecedenceOverTraitsMethods [
 	Trait 
 		named: #T
 		uses: self t1
-		category: self class category.
+		package: self class category.
 	self assert: trait methodDict size = 3.
 	self assert: (trait selectors asSet includesAll: #(#m11 #m12 #m13 )).
 	self assert: (trait methodDict at: #m11) sourceCode = 'm11 ^999'.
@@ -253,14 +253,14 @@ TraitPureBehaviorTest >> testPropagationWhenTraitCompositionModifications [
 	Trait 
 		named: #T5
 		uses: self t1 + self t2 - { #m21. #m22 }
-		category: self class category.
+		package: self class category.
 	self assert: self c2 methodDict size = 7.
 
 	"adding methods"
 	Trait 
 		named: #T2
 		uses: self t3
-		category: self class category.
+		package: self class category.
 	self assert: self c2 methodDict size = 10.
 	self assert: (self c2 selectors asSet includesAll: #(#m31 #m32 #m33 ))
 ]

--- a/src/Tests/TraitTest.class.st
+++ b/src/Tests/TraitTest.class.st
@@ -18,7 +18,7 @@ TraitTest >> createClassUsing: aTrait [
 { #category : #utilities }
 TraitTest >> createTrait [
 	| trait |
-	trait := Trait named: #ATraitForTests uses: {} category: 'AAA'.
+	trait := Trait named: #ATraitForTests uses: {} package: 'AAA'.
 	trait compile: 'm1 ^1' classified: 'test'.
 	^ trait
 ]
@@ -88,7 +88,7 @@ TraitTest >> testErrorClassCreation [
     | tmpCategory trait aSubclass aClass |
 	
     tmpCategory := 'TemporaryGeneratedClasses'.
-    trait := Trait named: #TMyTrait uses: {} category: tmpCategory.
+    trait := Trait named: #TMyTrait uses: {} package: tmpCategory.
     
     [ aClass := nil
         subclass: #AClass
@@ -240,11 +240,9 @@ TraitTest >> testExplicitRequirementWithSuperclassImplementatiosAlwaysReturnsThe
 
 { #category : #testing }
 TraitTest >> testForbidInstantiation [
-
-   | tmpCategory trait |
-tmpCategory := 'TemporaryGeneratedClasses'.
-   trait := Trait named: #TMyTrait uses: {} category: tmpCategory.
-    
+	| tmpCategory trait |
+	tmpCategory := 'TemporaryGeneratedClasses'.
+	trait := Trait named: #TMyTrait uses: {} package: tmpCategory.
 	self should: [ trait basicNew ] raise: Error 
 ]
 

--- a/src/Tests/TraitsResource.class.st
+++ b/src/Tests/TraitsResource.class.st
@@ -170,7 +170,7 @@ TraitsResource >> createTraitNamed: aSymbol uses: aTraitComposition [
 	trait := Trait
 		named: aSymbol
 		uses: aTraitComposition
-		category: self categoryName.
+		package: self categoryName.
 	self createdClassesAndTraits add: trait.
 	^trait
 ]

--- a/src/Tests/TraitsTestCase.class.st
+++ b/src/Tests/TraitsTestCase.class.st
@@ -104,7 +104,7 @@ TraitsTestCase >> createTraitNamed: aSymbol uses: aTraitComposition [
 	trait := Trait
 		named: aSymbol
 		uses: aTraitComposition
-		category: self categoryName.
+		package: self categoryName.
 	self createdClassesAndTraits add: trait.
 	^trait
 ]

--- a/src/TraitsV2-Tests/T2AbstractTest.class.st
+++ b/src/TraitsV2-Tests/T2AbstractTest.class.st
@@ -48,7 +48,7 @@ T2AbstractTest >> newTrait: aName with: slots uses: aComposition [
 { #category : #'instance creation' }
 T2AbstractTest >> newTrait: aName with: slots uses: aComposition category: category [
 	| class |
-	class := Trait named: aName uses: aComposition slots: slots category: category  env: self class environment. 
+	class := Trait named: aName uses: aComposition slots: slots package: category  env: self class environment. 
 	createdClasses add:class.
 	
 	^class.

--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -29,24 +29,24 @@ Class {
 
 { #category : #'instance creation' }
 Trait class >> named: aSymbol [
-	^ self named: aSymbol uses: {} category: 'Unclassified'
+	^ self named: aSymbol uses: {} package: 'Unclassified'
 ]
 
 { #category : #'instance creation' }
 Trait class >> named: aSymbol uses: aCompositionOrArray [
-	^ self named: aSymbol uses: aCompositionOrArray category: 'Unclassified'
+	^ self named: aSymbol uses: aCompositionOrArray package: 'Unclassified'
 ]
 
-{ #category : #'instance creation' }
+{ #category : #deprecated }
 Trait class >> named: aSymbol uses: aTraitCompositionOrCollection category: aString [
 	^ self
 		named: aSymbol
 		uses: aTraitCompositionOrCollection
-		category: aString
+		package: aString
 		env: self environment
 ]
 
-{ #category : #'instance creation' }
+{ #category : #deprecated }
 Trait class >> named: aName uses: aTraitCompositionOrCollection category: aString env: anEnvironment [
 	^ self
 		named: aName
@@ -61,25 +61,51 @@ Trait class >> named: aSymbol uses: aTraitCompositionOrCollection package: aStri
 	^ self
 		named: aSymbol
 		uses: aTraitCompositionOrCollection
-		category: aString
+		package: aString
 		env: self environment
 ]
 
 { #category : #'instance creation' }
+Trait class >> named: aName uses: aTraitCompositionOrCollection package: aString env: anEnvironment [
+	^ self
+		named: aName
+		uses: aTraitCompositionOrCollection
+		slots: #()
+		package: aString
+		env: anEnvironment
+]
+
+{ #category : #deprecated }
 Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots category: aCategory [
 
 	^ self named: aName 
 		uses: aTraitCompositionOrCollection 
 		slots: someSlots 
-		category: aCategory 
+		package: aCategory 
+		env: self environment 
+]
+
+{ #category : #deprecated }
+Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots category: aCategory env: anEnvironment [ 
+	"It is unclear that it is not use by low level library such as MC so we should not use it but we do not remove it for now."
+	
+	^ self named: aName uses: aTraitCompositionOrCollection slots: someSlots package: aCategory env: anEnvironment 
+]
+
+{ #category : #'instance creation' }
+Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots package: aPackageName [
+
+	^ self named: aName 
+		uses: aTraitCompositionOrCollection 
+		slots: someSlots 
+		package: aPackageName 
 		env: self environment 
 ]
 
 { #category : #'instance creation' }
-Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots category: aCategory env: anEnvironment [ 
+Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots package: aPackageName env: anEnvironment [ 
 
 	| trait |
-
 	trait:= self classInstaller
 		make: [ :builder | 
 			builder
@@ -89,7 +115,7 @@ Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots
 				slots: someSlots;
 				sharedVariables: '';
 				sharedPools: '';
-				category: aCategory;
+				category: aPackageName;
 				traitComposition: aTraitCompositionOrCollection asTraitComposition;
 				classTraitComposition: aTraitCompositionOrCollection asTraitComposition classComposition;
 				classSlots: #() ].

--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -168,7 +168,7 @@ Trait >> definition [
 		self classLayout visibleSlots ifNotEmpty: [ 
 			s tab; nextPutAll: ' slots: ';
 			nextPutAll: self slotDefinitionString; cr. ].
-		s tab; nextPutAll: ' category: ';
+		s tab; nextPutAll: ' package: ';
 			nextPutAll: self category asString printString
 	]
 ]

--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -194,7 +194,7 @@ Trait >> definition [
 		self classLayout visibleSlots ifNotEmpty: [ 
 			s tab; nextPutAll: ' slots: ';
 			nextPutAll: self slotDefinitionString; cr. ].
-		s tab; nextPutAll: ' package: ';
+		s tab; nextPutAll: ' category: ';
 			nextPutAll: self category asString printString
 	]
 ]

--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -52,7 +52,7 @@ Trait class >> named: aName uses: aTraitCompositionOrCollection category: aStrin
 		named: aName
 		uses: aTraitCompositionOrCollection
 		slots: #()
-		category: aString
+		package: aString
 		env: anEnvironment
 ]
 


### PR DESCRIPTION
Fixes #3323: Revert definition because else we cannot remove the class. So I will add this to another issue.