### PR TITLE
3328-SubclassResponsibility-error-when-running-RBParserparseFaultyMethod

### DIFF
--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -690,7 +690,7 @@ RBParser >> parsePragma [
 	self step.
 	pragma := self basicParsePragma.
 	(currentToken isBinary and: [ currentToken value == #> ]) 
-		ifFalse: [ ^ self parserError: '''>'' expected' ].
+		ifFalse: [ ^ self addPragma: (self parserError: '''>'' expected') ].
 	pragma left: start; right: currentToken start.
 	self addPragma: pragma.
 ]
@@ -702,7 +702,7 @@ RBParser >> parsePragmaLiteral [
 			[^currentToken isForByteArray 
 				ifTrue: [self parseLiteralByteArray]
 				ifFalse: [self parseLiteralArray]].
-	currentToken isLiteralToken ifFalse: [self parserError:'Literal constant expected'].
+	currentToken isLiteralToken ifFalse: [^self parserError:'Literal constant expected'].
 	^self parsePrimitiveLiteral
 ]
 

--- a/src/AST-Tests-Core/RBParserTest.class.st
+++ b/src/AST-Tests-Core/RBParserTest.class.st
@@ -535,6 +535,15 @@ RBParserTest >> testParseFaultyMethodStop [
 	
 ]
 
+{ #category : #'tests parsing faulty' }
+RBParserTest >> testParseFaultyPragma [
+	| node |
+	node := self parseFaultyMethod: 'a <b:'.
+	self assert: node isMethod.
+	self assert: node pragmas size equals: 1.
+	self assert: node pragmas first isFaulty
+]
+
 { #category : #'tests parsing' }
 RBParserTest >> testParseMethodWithErrorTokenIsWellFormed [
 	| node strangeMethod body statement message errorNode |


### PR DESCRIPTION
fix issue parsing faulty pragmas -- fixes #3328