### PR TITLE
3338-Slots-isSpecial-cleanup-part-2

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -447,7 +447,7 @@ Class >> definitionForNautilus [
 	"Answer a String that defines the receiver."
 
 	| aStream poolString |
-	(self usesSpecialVariables or: [ Slot showSlotClassDefinition ])
+	(self needsSlotClassDefinition or: [ Slot showSlotClassDefinition ])
 		ifTrue: [ ^ self definitionForNautilusWithSlots ].
 	poolString := self sharedPoolsString.
 	aStream := (String new: 800) writeStream.

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -334,6 +334,12 @@ ClassDescription >> classThatDefinesInstanceVariable: instVarName [
 	^self superclass ifNotNil: [self superclass classThatDefinesInstanceVariable: instVarName]
 ]
 
+{ #category : #slots }
+ClassDescription >> classVariablesNeedFullDefinition [
+
+	^self classVariables anySatisfy: [ :each | each needsFullDefinition ]
+]
+
 { #category : #printing }
 ClassDescription >> classVariablesString [
 	"Answer a string of my class variable names separated by spaces."
@@ -843,6 +849,12 @@ ClassDescription >> methodsTaggedWith: aSymbol [
 	^self localMethods select: [ :each | each isTaggedWith: aSymbol ]
 ]
 
+{ #category : #slots }
+ClassDescription >> needsSlotClassDefinition [
+    "return true if we define something else than InstanceVariableSlots or normal class variables"
+    ^self slotsNeedFullDefinition or: [ self class slotsNeedFullDefinition or: [self classVariablesNeedFullDefinition ]]
+]
+
 { #category : #private }
 ClassDescription >> newInstanceFrom: oldInstance variable: variable size: instSize [
 	"Create a new instance of the receiver based on the given old instance.
@@ -1158,6 +1170,12 @@ ClassDescription >> slots [
 	^self classLayout visibleSlots
 ]
 
+{ #category : #slots }
+ClassDescription >> slotsNeedFullDefinition [
+	"return true if we define something else than InstanceVariableSlots"
+	^self slots anySatisfy: [ :each | each needsFullDefinition ]
+]
+
 { #category : #private }
 ClassDescription >> spaceUsed [
 	^super spaceUsed + (self hasClassSide
@@ -1326,24 +1344,6 @@ ClassDescription >> usesPoolVarNamed: aString [
 	"Only classes may use a pool variable named: aString"
 	
 	^ false
-]
-
-{ #category : #slots }
-ClassDescription >> usesSpecialClassVariables [
-
-	^self classVariables anySatisfy: [ :each | each needsFullDefinition ]
-]
-
-{ #category : #slots }
-ClassDescription >> usesSpecialSlot [
-	"return true if we define something else than InstanceVariableSlots"
-	^self slots anySatisfy: [ :each | each needsFullDefinition ]
-]
-
-{ #category : #slots }
-ClassDescription >> usesSpecialVariables [
-    "return true if we define something else than InstanceVariableSlots"
-    ^self usesSpecialSlot or: [ self class usesSpecialSlot or: [self usesSpecialClassVariables ]]
 ]
 
 { #category : #compiling }

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -118,7 +118,7 @@ Metaclass >> definition [
 		[:strm |
 		strm print: self.
 		
-		(self usesSpecialSlot or: [ Slot showSlotClassDefinition ])
+		(self slotsNeedFullDefinition or: [ Slot showSlotClassDefinition ])
 			ifFalse: [  
 						strm
 							crtab;

--- a/src/Monticello/Class.extension.st
+++ b/src/Monticello/Class.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #Class }
 { #category : #'*Monticello' }
 Class >> asClassDefinition [
 	"we use a very ugly hack to encode complex slots as string with MC... later MC should model Slots directly"
-	self usesSpecialVariables ifFalse: [  
+	self needsSlotClassDefinition ifFalse: [  
 	 ^MCClassDefinition
 		name: self name
 		superclassName: (self superclass ifNil: [ nil asString ] ifNotNil: [ self superclass name ])

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -186,7 +186,7 @@ MCClassDefinition >> classInstanceVariables [
 
 	variables ifNil: [ ^ #() ].
 
-	^self usesSpecialVariables 
+	^self needsSlotClassDefinition 
 		ifTrue: [ self variablesOfType: #isClassInstanceVariable]
 		ifFalse: [self classInstanceVariablesString asSlotCollection]
 ]
@@ -223,7 +223,7 @@ MCClassDefinition >> classVarNames [
 
 { #category : #printing }
 MCClassDefinition >> classVariables [
-	^self usesSpecialVariables 
+	^self needsSlotClassDefinition 
 		ifTrue: [self sortedVariablesOfType: #isClassVariable ]
 		ifFalse: [(self classVariablesString substrings: ' ') collect: [:x | x asSymbol => ClassVariable]].
 
@@ -391,7 +391,7 @@ MCClassDefinition >> instVarNames [
 
 { #category : #printing }
 MCClassDefinition >> instanceVariables [
-	^self usesSpecialVariables 
+	^self needsSlotClassDefinition 
 		ifTrue: [self variablesOfType: #isInstanceVariable]
 		ifFalse: [self instanceVariablesString asSlotCollection]
 ]
@@ -429,6 +429,14 @@ MCClassDefinition >> kindOfSubclass [
 { #category : #installing }
 MCClassDefinition >> load [
 	self createClass
+]
+
+{ #category : #installing }
+MCClassDefinition >> needsSlotClassDefinition [
+	"this checks if any ivar or class var is using more than just standard definitions.
+	Complex vars are encoded with a string that starts with a # or one that has a space"
+	
+	^self variables anySatisfy: [:var | (var name beginsWith:'#') or: [ var name includes: Character space ]]
 ]
 
 { #category : #accessing }
@@ -621,14 +629,6 @@ MCClassDefinition >> type [
 { #category : #installing }
 MCClassDefinition >> unload [
 	Smalltalk globals removeClassNamed: name
-]
-
-{ #category : #installing }
-MCClassDefinition >> usesSpecialVariables [
-	"this checks if any ivar or class var is using more than just standard definitions.
-	Complex vars are encoded with a string that starts with a # or one that has a space"
-	
-	^self variables anySatisfy: [:var | (var name beginsWith:'#') or: [ var name includes: Character space ]]
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -64,7 +64,7 @@ MCTraitDefinition >> accept: aVisitor [
 { #category : #printing }
 MCTraitDefinition >> classSlotDefinitionString [
 
-	^ self usesSpecialVariables 
+	^ self needsSlotClassDefinition 
 		ifTrue: [ self classInstanceVariables asString ]
 		ifFalse: [ 
 			String streamContents: [ :stream |
@@ -207,7 +207,7 @@ MCTraitDefinition >> slotDefinitionString [
 
 	variables ifNil: [ ^ '{ }' ].
 
-	^ self usesSpecialVariables 
+	^ self needsSlotClassDefinition 
 		ifTrue: [ self instanceVariables asString ]
 		ifFalse: [ 
 			String streamContents: [ :stream |

--- a/src/Monticello/Trait.extension.st
+++ b/src/Monticello/Trait.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #Trait }
 
 { #category : #'*Monticello' }
 Trait >> asClassDefinition [
-	self usesSpecialVariables ifFalse: [  
+	self needsSlotClassDefinition ifFalse: [  
 		^ MCTraitDefinition
 			name: self name
 			traitComposition: self traitCompositionString

--- a/src/Slot-Core/Slot.class.st
+++ b/src/Slot-Core/Slot.class.st
@@ -286,6 +286,12 @@ Slot >> name: aSymbol [
 	name := aSymbol
 ]
 
+{ #category : #accessing }
+Slot >> named: aSymbol [
+	"to be polymorhic with slot class"
+	name := aSymbol
+]
+
 { #category : #testing }
 Slot >> needsFullDefinition [
 	"I am more than just a backward compatible ivar slot, I need a full definition "

--- a/src/Slot-Core/Slot.class.st
+++ b/src/Slot-Core/Slot.class.st
@@ -289,7 +289,7 @@ Slot >> name: aSymbol [
 { #category : #accessing }
 Slot >> named: aSymbol [
 	"to be polymorhic with slot class"
-	name := aSymbol
+	self name: aSymbol
 ]
 
 { #category : #testing }

--- a/src/Slot-Core/String.extension.st
+++ b/src/Slot-Core/String.extension.st
@@ -20,15 +20,3 @@ String >> asSlotCollection [
 	whitespaces := ByteString withAll: { Character space . Character tab . Character cr }.
 	^(self substrings: whitespaces) collect: [ :substring | substring asSlot ]
 ]
-
-{ #category : #'*Slot-Core' }
-String >> asValidInstVarName [
-
-	| validName |
-	
-	validName := self select: [ :c | c isAlphaNumeric or: [ c == $_ ] ].
-	
-	^validName first isDigit 
-		ifTrue: [ 'v' , validName ]
-		ifFalse: [ validName ]
-]

--- a/src/Slot-Core/Symbol.extension.st
+++ b/src/Slot-Core/Symbol.extension.st
@@ -2,10 +2,7 @@ Extension { #name : #Symbol }
 
 { #category : #'*Slot-Core' }
 Symbol >> => aVariable [
-	aVariable isBehavior
-		ifTrue: [ ^ aVariable named: self].
-	^ aVariable name: self;
-		yourself
+	^ aVariable named: self
 ]
 
 { #category : #'*Slot-Core' }

--- a/src/Slot-Examples/BaseSlot.class.st
+++ b/src/Slot-Examples/BaseSlot.class.st
@@ -34,7 +34,7 @@ BaseSlot >> hash [
 
 { #category : #initalize }
 BaseSlot >> initialize: anObject [
-	self write: default to: anObject
+	self write: default copy to: anObject
 ]
 
 { #category : #testing }

--- a/src/Slot-Examples/InitializedSlot.class.st
+++ b/src/Slot-Examples/InitializedSlot.class.st
@@ -15,7 +15,7 @@ Class {
 
 { #category : #initialization }
 InitializedSlot >> initialize: anObject [
-	self write: (default cull: anObject) to: anObject
+	self write: (default copy cull: anObject) to: anObject
 ]
 
 { #category : #'meta-object-protocol' }

--- a/src/Slot-Tests/InitializedSlotTest.class.st
+++ b/src/Slot-Tests/InitializedSlotTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #ExampleSlotWithDefaultValueTest,
+	#name : #InitializedSlotTest,
 	#superclass : #SlotSilentTest,
 	#category : #'Slot-Tests-Examples'
 }
 
 { #category : #tests }
-ExampleSlotWithDefaultValueTest >> testExampleSlotWithDefaultValueCompiled [
+InitializedSlotTest >> testReadWriteCompiled [
 	| slot object|
 	slot := #slot1 => InitializedSlot default: 5.
 	aClass := self make: [ :builder | builder slots: {slot}].
@@ -25,7 +25,7 @@ ExampleSlotWithDefaultValueTest >> testExampleSlotWithDefaultValueCompiled [
 ]
 
 { #category : #tests }
-ExampleSlotWithDefaultValueTest >> testExampleSlotWithDefaultValueReflective [
+InitializedSlotTest >> testReflectiveReadWrite [
 	| slot object|
 	slot := #slot1 => InitializedSlot default: 5.
 	aClass := self make: [ :builder | builder slots: {slot}].
@@ -44,7 +44,7 @@ ExampleSlotWithDefaultValueTest >> testExampleSlotWithDefaultValueReflective [
 ]
 
 { #category : #tests }
-ExampleSlotWithDefaultValueTest >> testExampleSlotWithDefaultValueReflectiveSlot [
+InitializedSlotTest >> testReflectiveReadWriteBlock [
 	| slot object|
 	slot := #slot1 => InitializedSlot defaultBlock: [4+1].
 	aClass := self make: [ :builder | builder slots: {slot}].

--- a/src/Slot-Tests/PropertySlotTest.class.st
+++ b/src/Slot-Tests/PropertySlotTest.class.st
@@ -170,6 +170,36 @@ PropertySlotTest >> testRemovePropertySlotWithInstance [
 ]
 
 { #category : #tests }
+PropertySlotTest >> testRemovePropertySlotWithTwoInstances [
+	"add two property slots, remove one"
+	
+	| propertySlot1 propertySlot2 instance instance2 |
+	
+	propertySlot1 := #prop1 => PropertySlot.
+	propertySlot2 := #prop2 => PropertySlot.
+	
+	aClass := self make: [ :builder |
+		builder 
+			slots: {propertySlot1 . propertySlot2 }
+		].
+
+	instance := aClass new.
+	instance2 := aClass new.
+
+	propertySlot1 write: 41 to: instance.
+	propertySlot2 write: 42 to: instance.
+
+	self assert: (propertySlot1 read: instance) equals: 41.
+	self assert: (propertySlot2 read: instance) equals: 42.
+	self assert: (propertySlot1 read: instance2) equals: nil.
+	
+	propertySlot1 write: 5 to: instance2.
+	self assert: (propertySlot1 read: instance2) equals: 5.
+	
+	
+]
+
+{ #category : #tests }
 PropertySlotTest >> testWhichSelectorsAccessFindSlots [
 	| cls |
 	cls := Object newAnonymousSubclass.

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -83,7 +83,7 @@ TraitedMetaclass >> definition [
 				nextPutAll: 'uses: ';
 				print: self traitComposition ].
 		
-		(self usesSpecialSlot or: [ Slot showSlotClassDefinition ])
+		(self slotsNeedFullDefinition or: [ Slot showSlotClassDefinition ])
 			ifFalse: [  
 						strm
 							crtab;


### PR DESCRIPTION
rename #usesSpecialVariables-> #needsSlotClassDefinition
rename #usesSpecialSlot -> slotsNeedFullDefinition
rename #usesSpecialClassVariables -> classVariablesNeedFullDefinition
in addition:

simplify #=>
remove dead code: #asValidInstVarName

fixes #3338