### PR TITLE
Fixes #3302 for Pharo 7.

### DIFF
--- a/src/Tool-ExternalBrowser/ExternalBrowser.class.st
+++ b/src/Tool-ExternalBrowser/ExternalBrowser.class.st
@@ -87,7 +87,7 @@ ExternalBrowser class >> serviceBrowseCode [
 		selector: #browseStream:
 		description: 'Open a "file-contents browser" on this file, allowing you to view and selectively load its code'
 		buttonLabel: 'Code')
-		argumentGetter: [ :file| file readStream]
+		argumentGetter: [ :file| file readOnlyStream]
 ]
 
 { #category : #'System-FileRegistry' }

--- a/src/Tool-ExternalBrowser/ExternalChangesBrowser.class.st
+++ b/src/Tool-ExternalBrowser/ExternalChangesBrowser.class.st
@@ -114,7 +114,7 @@ ExternalChangesBrowser class >> serviceBrowseCSOrSTFile [
 		selector: #openOnStream:
 		description: 'Open a changelist tool on this file'
 		buttonLabel: 'Changes')
-		argumentGetter: [ :stream | stream readStream ]
+		argumentGetter: [ :stream | stream readOnlyStream ]
 ]
 
 { #category : #'file service' }


### PR DESCRIPTION
(Trying again targeting Pharo7.0 branch rather than whoops targeting Pharo8.0.)

In Pharo 7.0.3...
Tools > File Browser
Select an ST file
Click
==> Instance of FileList did not understand #readStream (issue #3302)

A debugger appearing for clicking a button in a standard tool provides a poor impression to newcomers. The fix is simple replacing #readStream call with #readOnlyStream, so please consider merging this for the next Pharo 7 point release.

This is a backport of Pharo 8 issue #3301, which may need some additional work since FileList >> readOnlyStream depends on deprecated FileStream.