### PR TITLE
3341-Begin-to-split-tests-linked-to-Halt-in-Kernel

### DIFF
--- a/src/Kernel-Tests-Extended/CodeSimulationTest.class.st
+++ b/src/Kernel-Tests-Extended/CodeSimulationTest.class.st
@@ -2,16 +2,13 @@
 SUnit tests for code simulation
 "
 Class {
-	#name : #CodeSimulationTests,
+	#name : #CodeSimulationTest,
 	#superclass : #TestCase,
-	#classVars : [
-		'log'
-	],
 	#category : #'Kernel-Tests-Extended-Methods'
 }
 
 { #category : #private }
-CodeSimulationTests >> indexedBasicAt: index [ 
+CodeSimulationTest >> indexedBasicAt: index [ 
 	<primitive: 60 error: code >
 	^ code
 
@@ -19,44 +16,37 @@ CodeSimulationTests >> indexedBasicAt: index [
 ]
 
 { #category : #tests }
-CodeSimulationTests >> methodWithError [
+CodeSimulationTest >> methodWithError [
 	self error: 'my error'
 ]
 
 { #category : #tests }
-CodeSimulationTests >> methodWithHalt [
-	<haltOrBreakpointForTesting>
-	self halt
-]
-
-{ #category : #tests }
-CodeSimulationTests >> methodWithTranscript [
+CodeSimulationTest >> methodWithTranscript [
 	Transcript show: 'something'
 ]
 
 { #category : #tests }
-CodeSimulationTests >> runSimulated: aBlock [
+CodeSimulationTest >> runSimulated: aBlock [
 	thisContext runSimulated: aBlock contextAtEachStep: [ :current |  ]
 ]
 
 { #category : #tests }
-CodeSimulationTests >> testDNU [
-
-	self should: [ self runSimulated: [self absentMethod] ] raise: MessageNotUnderstood
+CodeSimulationTest >> testDNU [
+	self should: [ self runSimulated: [ self absentMethod ] ] raise: MessageNotUnderstood
 ]
 
 { #category : #tests }
-CodeSimulationTests >> testError [
+CodeSimulationTest >> testError [
 	self should: [ self runSimulated: [self methodWithError] ] raise: Error
 ]
 
 { #category : #'tests - primitives' }
-CodeSimulationTests >> testErrorCodeNotFound [
+CodeSimulationTest >> testErrorCodeNotFound [
 	| ctx result resultSimu |
 	
 	self skip.
 	
-	Smalltalk vm isRunningCog ifFalse: [^self].
+	Smalltalk vm isRunningCog ifFalse: [ ^ self ].
 	
 	result := self veryBasicAt: 1.
 		
@@ -73,11 +63,11 @@ CodeSimulationTests >> testErrorCodeNotFound [
 		
 	self assert: resultSimu isArray.	
 	self assert: Context  primitiveFailToken first == resultSimu first.
-	self assert: result = resultSimu second.
+	self assert: result equals: resultSimu second.
 ]
 
 { #category : #'tests - primitives' }
-CodeSimulationTests >> testErrorCodeNotFoundIndexed [
+CodeSimulationTest >> testErrorCodeNotFoundIndexed [
 	| ctx result resultSimu |
 	
 	Smalltalk vm isRunningCog ifFalse: [^self].
@@ -96,55 +86,48 @@ CodeSimulationTests >> testErrorCodeNotFoundIndexed [
 		doPrimitive: 60  method:  (self class>>#indexedBasicAt:) receiver: self args: #(100).
 		
 	self assert: resultSimu isArray.	
-	self assert: resultSimu size = 2.
+	self assert: resultSimu size equals: 2.
 	self assert: Context  primitiveFailToken first == resultSimu first.
-	self assert: result = resultSimu second.
+	self assert: result equals: resultSimu second.
 ]
 
 { #category : #'tests - primitives' }
-CodeSimulationTests >> testErrorToken [
+CodeSimulationTest >> testErrorToken [
 	| token1 token2 |
 	
 	token1 := Context primitiveFailToken.
 	token2 := Context primitiveFailTokenFor: 100.
 
 	self assert: token1 first == token2 first.
-	self assert: token1 second == nil.
-	self assert: token2 second == 100.
+	self assert: token1 second isNil.
+	self assert: token2 second equals: 100.
 ]
 
 { #category : #tests }
-CodeSimulationTests >> testErrorWithErrorHandler [
-	self runSimulated: [[self methodWithError] on: Error do: [:err | ]]  
+CodeSimulationTest >> testErrorWithErrorHandler [
+	self
+		runSimulated: [ [ self methodWithError ]
+				on: Error
+				do: [ :err |  ] ]
 ]
 
 { #category : #tests }
-CodeSimulationTests >> testGoodSimulation [
+CodeSimulationTest >> testGoodSimulation [
 	self runSimulated: [ 1 + 2 ].
 ]
 
 { #category : #tests }
-CodeSimulationTests >> testHalt [
-	self should: [ self runSimulated: [self methodWithHalt] ] raise: Halt
+CodeSimulationTest >> testTranscriptPrinting [
+	self runSimulated: [ self methodWithTranscript ]
 ]
 
 { #category : #tests }
-CodeSimulationTests >> testHaltWithHaltHandler [
-	self runSimulated: [[self methodWithHalt] on: Halt do: [:err |]]  
-]
-
-{ #category : #tests }
-CodeSimulationTests >> testTranscriptPrinting [
-	self runSimulated: [self methodWithTranscript]  
-]
-
-{ #category : #tests }
-CodeSimulationTests >> testTranscriptPrintingWithOpenedTranscriptExists [
-	self runSimulated: [self methodWithTranscript]  
+CodeSimulationTest >> testTranscriptPrintingWithOpenedTranscriptExists [
+	self runSimulated: [ self methodWithTranscript ]
 ]
 
 { #category : #private }
-CodeSimulationTests >> veryBasicAt: index [ 
+CodeSimulationTest >> veryBasicAt: index [ 
 	<primitive: 'dooo' module: 'bar' error: code>
 	^ code
 

--- a/src/Kernel-Tests-Extended/CodeSimulationWithHaltTest.class.st
+++ b/src/Kernel-Tests-Extended/CodeSimulationWithHaltTest.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : #CodeSimulationWithHaltTest,
+	#superclass : #CodeSimulationTest,
+	#category : #'Kernel-Tests-Extended-Methods'
+}
+
+{ #category : #tests }
+CodeSimulationWithHaltTest >> methodWithHalt [
+	<haltOrBreakpointForTesting>
+	self halt
+]
+
+{ #category : #tests }
+CodeSimulationWithHaltTest >> testHalt [
+	self should: [ self runSimulated: [ self methodWithHalt ] ] raise: Halt
+]
+
+{ #category : #tests }
+CodeSimulationWithHaltTest >> testHaltWithHaltHandler [
+	self
+		runSimulated: [ [ self methodWithHalt ]
+				on: Halt
+				do: [ :err |  ] ]
+]

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -199,31 +199,6 @@ CompiledMethodTest >> testCompiledMethodAsString [
 	thisContext method asString
 ]
 
-{ #category : #'as yet unclassified' }
-CompiledMethodTest >> testContainsHalt [
-	
-	| annonClass |
-	
-	self 
-	deny: (Object >> #halt) containsHalt;
-	deny: (Object >> #haltIfNil) containsHalt;
-	deny: (Halt class >> #once) containsHalt;
-	assert: (UndefinedObjectTest >> #testIfNil) containsHalt.
-	
-	annonClass := Object newAnonymousSubclass.
-	annonClass 
-	compile: 'm1 self halt';
-	compile: 'm2 self haltIfNil';
-	compile: 'm3 self yourself'.
-	
-	self
-	assert: (annonClass >> #m1) containsHalt;
-	assert: (annonClass >> #m2) containsHalt;
-	deny: (annonClass >> #m3) containsHalt.
-	
-	
-]
-
 { #category : #tests }
 CompiledMethodTest >> testCopy [
 	<pragma: #pragma>

--- a/src/Kernel-Tests-Extended/HaltTest.extension.st
+++ b/src/Kernel-Tests-Extended/HaltTest.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : #ObjectTest }
+Extension { #name : #HaltTest }
 
 { #category : #'*Kernel-Tests-Extended' }
-ObjectTest >> testHaltOnce [
+HaltTest >> testHaltOnce [
 	<haltOrBreakpointForTesting>
 	| anObject block |
 	anObject := Object new.

--- a/src/Kernel-Tests-WithCompiler/HaltTest.extension.st
+++ b/src/Kernel-Tests-WithCompiler/HaltTest.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : #ObjectTest }
+Extension { #name : #HaltTest }
 
 { #category : #'*Kernel-Tests-WithCompiler' }
-ObjectTest >> testHaltFromCount [
+HaltTest >> testHaltFromCount [
 	<haltOrBreakpointForTesting>
 
 	| anObject haltCount |
@@ -29,7 +29,7 @@ ObjectTest >> testHaltFromCount [
 ]
 
 { #category : #'*Kernel-Tests-WithCompiler' }
-ObjectTest >> testHaltOnCount [
+HaltTest >> testHaltOnCount [
 	<haltOrBreakpointForTesting>
 
 	| anObject haltCount |

--- a/src/Kernel-Tests/HaltTest.class.st
+++ b/src/Kernel-Tests/HaltTest.class.st
@@ -1,0 +1,103 @@
+Class {
+	#name : #HaltTest,
+	#superclass : #TestCase,
+	#category : #'Kernel-Tests-Objects'
+}
+
+{ #category : #helpers }
+HaltTest >> a [
+	self b
+]
+
+{ #category : #helpers }
+HaltTest >> a1 [
+	self b1
+]
+
+{ #category : #helpers }
+HaltTest >> b [
+	<haltOrBreakpointForTesting>
+	self haltIf: #testHaltIf
+]
+
+{ #category : #helpers }
+HaltTest >> b1 [
+	<haltOrBreakpointForTesting>
+	self haltIf: #testasdasdfHaltIf
+]
+
+{ #category : #helpers }
+HaltTest >> shouldHaltAfter: aNumber times: aBlock [
+	
+	self shouldHaltWhen: [ aNumber timesRepeat: aBlock ].
+]
+
+{ #category : #helpers }
+HaltTest >> shouldHaltWhen: aBlock [
+
+	self should: aBlock raise: Halt.
+]
+
+{ #category : #helpers }
+HaltTest >> shouldntHaltAfter: aNumber times: aBlock [
+	
+	self shouldntHaltWhen: [ aNumber timesRepeat: aBlock ].
+]
+
+{ #category : #helpers }
+HaltTest >> shouldntHaltWhen: aBlock [
+
+	self shouldnt: aBlock raise: Halt.
+]
+
+{ #category : #'as yet unclassified' }
+HaltTest >> testContainsHalt [
+	
+	| annonClass |
+	
+	self 
+	deny: (Object >> #halt) containsHalt;
+	deny: (Object >> #haltIfNil) containsHalt;
+	deny: (Halt class >> #once) containsHalt;
+	assert: (self class>> #testHaltIfNil) containsHalt.
+	
+	annonClass := Object newAnonymousSubclass.
+	annonClass 
+	compile: 'm1 self halt';
+	compile: 'm2 self haltIfNil';
+	compile: 'm3 self yourself'.
+	
+	self
+	assert: (annonClass >> #m1) containsHalt;
+	assert: (annonClass >> #m2) containsHalt;
+	deny: (annonClass >> #m3) containsHalt.
+	
+	
+]
+
+{ #category : #tests }
+HaltTest >> testHaltIf [
+	<haltOrBreakpointForTesting>
+
+	self shouldHaltWhen: [self haltIf: true].
+	self shouldntHaltWhen: [self haltIf: false].
+
+	self shouldHaltWhen: [self haltIf: [true]].
+	self shouldntHaltWhen: [self haltIf: [false]].
+
+	self shouldHaltWhen: [self haltIf: #testHaltIf].
+	self shouldntHaltWhen: [self haltIf: #teadfasdfltIf].
+
+	self shouldHaltWhen: [self a].
+	self shouldntHaltWhen: [self a1].
+
+	self shouldHaltWhen: [self haltIf: [:receiver | receiver class = self class]].
+	self shouldntHaltWhen: [self haltIf: [:receiver | receiver class ~= self class]].
+]
+
+{ #category : #'tests - testing' }
+HaltTest >> testHaltIfNil [
+	<haltOrBreakpointForTesting>
+
+	self should: [ nil haltIfNil] raise: Halt.
+]

--- a/src/Kernel-Tests/ObjectTest.class.st
+++ b/src/Kernel-Tests/ObjectTest.class.st
@@ -7,52 +7,6 @@ Class {
 	#category : #'Kernel-Tests-Objects'
 }
 
-{ #category : #private }
-ObjectTest >> a [
-	self b.
-]
-
-{ #category : #private }
-ObjectTest >> a1 [
-	self b1.
-]
-
-{ #category : #private }
-ObjectTest >> b [
-	<haltOrBreakpointForTesting>
-	self haltIf: #testHaltIf.
-]
-
-{ #category : #private }
-ObjectTest >> b1 [
-	<haltOrBreakpointForTesting>
-	self haltIf: #testasdasdfHaltIf.
-]
-
-{ #category : #'assertions - halt' }
-ObjectTest >> shouldHaltAfter: aNumber times: aBlock [
-	
-	self shouldHaltWhen: [ aNumber timesRepeat: aBlock ].
-]
-
-{ #category : #'assertions - halt' }
-ObjectTest >> shouldHaltWhen: aBlock [
-
-	self should: aBlock raise: Halt.
-]
-
-{ #category : #'assertions - halt' }
-ObjectTest >> shouldntHaltAfter: aNumber times: aBlock [
-	
-	self shouldntHaltWhen: [ aNumber timesRepeat: aBlock ].
-]
-
-{ #category : #'assertions - halt' }
-ObjectTest >> shouldntHaltWhen: aBlock [
-
-	self shouldnt: aBlock raise: Halt.
-]
-
 { #category : #tests }
 ObjectTest >> testAs [
 	| coll1 coll2 |
@@ -110,26 +64,6 @@ ObjectTest >> testDisplayStringLimitedString [
 	| actual |
 	actual := Object new displayStringLimitedTo: 4.
 	self assert: actual equals: 'an O...etc...'
-]
-
-{ #category : #'tests - debugging' }
-ObjectTest >> testHaltIf [
-	<haltOrBreakpointForTesting>
-
-	self shouldHaltWhen: [self haltIf: true].
-	self shouldntHaltWhen: [self haltIf: false].
-
-	self shouldHaltWhen: [self haltIf: [true]].
-	self shouldntHaltWhen: [self haltIf: [false]].
-
-	self shouldHaltWhen: [self haltIf: #testHaltIf].
-	self shouldntHaltWhen: [self haltIf: #teadfasdfltIf].
-
-	self shouldHaltWhen: [self a].
-	self shouldntHaltWhen: [self a1].
-
-	self shouldHaltWhen: [self haltIf: [:receiver | receiver class = self class]].
-	self shouldntHaltWhen: [self haltIf: [:receiver | receiver class ~= self class]].
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/UndefinedObjectTest.class.st
+++ b/src/Kernel-Tests/UndefinedObjectTest.class.st
@@ -22,30 +22,15 @@ UndefinedObjectTest >> testDeepCopy [
 ]
 
 { #category : #'tests - testing' }
-UndefinedObjectTest >> testHaltIfNil [
-	<haltOrBreakpointForTesting>
-
-	self should: [ nil haltIfNil] raise: Halt.
-]
-
-{ #category : #'tests - testing' }
 UndefinedObjectTest >> testIfNil [
 	<haltOrBreakpointForTesting>
-
-	self should: [ nil ifNil: [self halt]] raise: Halt.
-
-
-
+	self should: [ nil ifNil: [ self error ] ] raise: Error
 ]
 
 { #category : #'tests - testing' }
 UndefinedObjectTest >> testIfNilIfNotNil [
 	<haltOrBreakpointForTesting>
-
-	self should: [ nil ifNil: [self halt] ifNotNil: [self error] ] raise: Halt.
-
-
-
+	self should: [ nil ifNil: [ self error ] ifNotNil: [  ] ] raise: Error
 ]
 
 { #category : #'tests - testing' }
@@ -69,11 +54,7 @@ UndefinedObjectTest >> testIfNotNilDo [
 { #category : #'tests - testing' }
 UndefinedObjectTest >> testIfNotNilIfNil [
 	<haltOrBreakpointForTesting>
-
-	self should: [ nil ifNotNil: [self error] ifNil: [self halt] ] raise: Halt.
-
-
-
+	self should: [ nil ifNotNil: [  ] ifNil: [ self error ] ] raise: Error
 ]
 
 { #category : #'tests - testing' }


### PR DESCRIPTION
Confine Halt test into two dedicated classes.

This will make it easier to remove Halt from Kernel later since we will just need to change the two new classes from the kernel. 

I also fix some lints in other tests.

Fixes #3341