### PR TITLE
3356-In-RBFactoryChange-all-methods-should-use-changefactory-instance-variable-instead-of-accessing-the-singleton

### DIFF
--- a/src/Refactoring-Changes/RBCompositeRefactoryChange.class.st
+++ b/src/Refactoring-Changes/RBCompositeRefactoryChange.class.st
@@ -41,17 +41,17 @@ RBCompositeRefactoryChange >> addChange: aRefactoryChange [
 
 { #category : #'refactory-changes' }
 RBCompositeRefactoryChange >> addClassVariable: variableName to: aClass [ 
-	^ self addChange: (RBRefactoryChangeManager changeFactory addClassVariable: variableName to: aClass)
+	^ self addChange: (changeFactory addClassVariable: variableName to: aClass)
 ]
 
 { #category : #'refactory-changes' }
 RBCompositeRefactoryChange >> addInstanceVariable: variableName to: aClass [ 
-	^ self addChange: (RBRefactoryChangeManager changeFactory addInstanceVariable: variableName to: aClass)
+	^ self addChange: (changeFactory addInstanceVariable: variableName to: aClass)
 ]
 
 { #category : #'refactory-changes' }
 RBCompositeRefactoryChange >> addPool: aPoolVariable to: aClass [ 
-	^ self addChange: (RBRefactoryChangeManager changeFactory addPoolVariable: aPoolVariable to: aClass)
+	^ self addChange: (changeFactory addPoolVariable: aPoolVariable to: aClass)
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -139,8 +139,7 @@ RBRefactoryChangeManager >> ignoreChangesWhile: aBlock [
 
 { #category : #initialization }
 RBRefactoryChangeManager >> initialize [
-	undo := OrderedCollection new.
-	redo := OrderedCollection new.
+	self clearUndoRedoList.
 	isPerformingRefactoring := false.
 	self connectToChanges
 ]

--- a/src/Refactoring-Tests-Changes/RBRefactoringChangeTest.class.st
+++ b/src/Refactoring-Tests-Changes/RBRefactoringChangeTest.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #TestCase,
 	#instVars : [
 		'changes',
-		'workingEnvironment'
+		'workingEnvironment',
+		'changeFactory'
 	],
 	#category : #'Refactoring-Tests-Changes'
 }
@@ -86,7 +87,9 @@ RBRefactoringChangeTest >> setUp [
 	workingEnvironment := Smalltalk globals.
 	"In the future we should make sure that the tests can run on a new environment."
 	self createMockClass.
-	changes := RBRefactoryChangeManager changeFactory compositeRefactoryChangeNamed: 'testing'
+	changeFactory := RBRefactoryChangeManager changeFactory.
+	"changeFactory is used in tests too"
+	changes := changeFactory compositeRefactoryChangeNamed: 'testing'
 ]
 
 { #category : #utilities }
@@ -117,7 +120,7 @@ RBRefactoringChangeTest >> testAddClassInstanceVariable [
 { #category : #tests }
 RBRefactoringChangeTest >> testAddClassInteractively [
 	| change |
-	change := RBRefactoryChangeManager changeFactory addClassDefinition: 'TestCase subclass: #' , self class name , '
+	change := changeFactory addClassDefinition: 'TestCase subclass: #' , self class name , '
 	instanceVariableNames: ''instVar''
 	classVariableNames: ''ClassVar''
 	poolDictionaries: ''PoolDict''
@@ -273,7 +276,7 @@ RBRefactoringChangeTest >> testCompileInClassified [
 { #category : #tests }
 RBRefactoringChangeTest >> testCompileInInteractively [
 	| change |
-	change := RBRefactoryChangeManager changeFactory addMethodSource: 'setUp' in: self class classified: #running for: self.
+	change := changeFactory addMethodSource: 'setUp' in: self class classified: #running for: self.
 	self assert: change controller equals: self.
 	self assert: change changeClassName equals: self class name.
 	self assert: change changeClass equals: self class.
@@ -337,7 +340,7 @@ RBRefactoringChangeTest >> testPerformAddRemoveClassInstanceVariable [
 { #category : #'tests-perform' }
 RBRefactoringChangeTest >> testPerformAddRemoveClassInteractively [
 	| change |
-	change := RBRefactoryChangeManager changeFactory addClassDefinition: 'Object subclass: #' , self changeMock name , 'Temporary
+	change := changeFactory addClassDefinition: 'Object subclass: #' , self changeMock name , 'Temporary
 	instanceVariableNames: ''''
 	classVariableNames: ''''
 	poolDictionaries: ''''
@@ -388,7 +391,7 @@ RBRefactoringChangeTest >> testPerformAddRemoveMethod [
 { #category : #'tests-perform' }
 RBRefactoringChangeTest >> testPerformAddRemoveMethodInteractively [
 	| change |
-	change := RBRefactoryChangeManager changeFactory addMethodSource: 'method ^ 1' in: self changeMock classified: #utilities for: self. 
+	change := changeFactory addMethodSource: 'method ^ 1' in: self changeMock classified: #utilities for: self. 
 	self perform: change do: [ self assert: (self changeMock canUnderstand: #method) ].
 	self deny: (self changeMock canUnderstand: #method).
 	self assert: change definedSelector equals: #method


### PR DESCRIPTION
Fixes: #3356: 
- remove usage of class and use its initialized instance instead
- clean class hardcoding in related tests (all green).