### PR TITLE
3362-RBClassModelFactory-rbClass-should-be-pushed-to-instance-side

### DIFF
--- a/src/Refactoring-Core/RBAbstractClass.class.st
+++ b/src/Refactoring-Core/RBAbstractClass.class.st
@@ -20,7 +20,7 @@ Like a real class I referre to my superclass and subclass, which again are actua
 "
 Class {
 	#name : #RBAbstractClass,
-	#superclass : #Object,
+	#superclass : #RBEntity,
 	#instVars : [
 		'name',
 		'newMethods',
@@ -163,7 +163,7 @@ RBAbstractClass >> compile: aString classified: aSymbolCollection [
 				compile: aString
 				in: self
 				classified: aSymbolCollection.
-	method := RBClassModelFactory rbMethod 
+	method := modelFactory rbMethod 
 				for: self
 				source: aString
 				selector: change selector.
@@ -178,7 +178,7 @@ RBAbstractClass >> compile: aString withAttributesFrom: aRBMethod [
 		compile: aString
 		in: self
 		classified: aRBMethod protocols.
-	method := RBClassModelFactory rbMethod  
+	method := modelFactory rbMethod  
 		for: self
 		source: aString
 		selector: change selector.
@@ -413,7 +413,7 @@ RBAbstractClass >> methodFor: aSelector [
 			compiledMethod isNil 
 				ifTrue: [nil]
 				ifFalse: 
-					[RBClassModelFactory rbMethod 
+					[modelFactory rbMethod 
 						for: self
 						fromMethod: compiledMethod
 						andSelector: aSelector]]
@@ -702,14 +702,14 @@ RBAbstractClass >> whoDefinesMethod: aSelector [
 
 { #category : #accessing }
 RBAbstractClass >> withAllSubclasses [
-	^(self allSubclasses)
+	^ self allSubclasses
 		add: self;
 		yourself
 ]
 
 { #category : #accessing }
 RBAbstractClass >> withAllSuperclasses [
-	^(self allSuperclasses)
+	^ self allSuperclasses
 		add: self;
 		yourself
 ]

--- a/src/Refactoring-Core/RBAbstractClass.class.st
+++ b/src/Refactoring-Core/RBAbstractClass.class.st
@@ -153,7 +153,7 @@ RBAbstractClass >> classSide [
 
 { #category : #'method accessing' }
 RBAbstractClass >> compile: aString [ 
-	^ self compile: aString withAttributesFrom: (self methodFor: (RBParser parseMethodPattern: aString))
+	^ self compile: aString withAttributesFrom: (self methodFor: (self parserClass parseMethodPattern: aString))
 ]
 
 { #category : #'method accessing' }
@@ -363,6 +363,7 @@ RBAbstractClass >> inheritsPoolDictionaries [
 
 { #category : #initialization }
 RBAbstractClass >> initialize [
+	super initialize.
 	name := #'Unknown Class'
 ]
 

--- a/src/Refactoring-Core/RBClass.class.st
+++ b/src/Refactoring-Core/RBClass.class.st
@@ -191,7 +191,7 @@ RBClass >> isSharedPool [
 { #category : #querying }
 RBClass >> methodsUsingClassVariableNamed: aClassVariableName [
  
-	^ (self realClass classVariableNamed: aClassVariableName) usingMethods collect: [ :aMethod | |modelClass|
+	^ (self realClass classVariableNamed: aClassVariableName) usingMethods collect: [ :aMethod | 			|modelClass|
 			modelClass := self model classNamed: aMethod methodClass name.
 			modelClass methodFor: aMethod selector
 		]
@@ -199,8 +199,7 @@ RBClass >> methodsUsingClassVariableNamed: aClassVariableName [
 
 { #category : #accessing }
 RBClass >> poolDictionaryNames: aCollectionOfStrings [ 
-	poolDictionaryNames := (aCollectionOfStrings 
-				collect: [:each | each asSymbol]) asOrderedCollection
+	poolDictionaryNames := (aCollectionOfStrings collect: [:each | each asSymbol]) asOrderedCollection
 ]
 
 { #category : #private }

--- a/src/Refactoring-Core/RBClassModelFactory.class.st
+++ b/src/Refactoring-Core/RBClassModelFactory.class.st
@@ -62,3 +62,27 @@ RBClassModelFactory class >> setRBNamespace: aClass [
  
 	RBnamespace := aClass
 ]
+
+{ #category : #'factory access' }
+RBClassModelFactory >> rbClass [ 
+
+	^ self class rbClass
+]
+
+{ #category : #'factory access' }
+RBClassModelFactory >> rbMetaclass [
+
+	^ self class rbMetaclass
+]
+
+{ #category : #'factory access' }
+RBClassModelFactory >> rbMethod [
+
+	^ self class rbMethod
+]
+
+{ #category : #'factory access' }
+RBClassModelFactory >> rbNamespace [
+
+	^ self class rbNamespace
+]

--- a/src/Refactoring-Core/RBEntity.class.st
+++ b/src/Refactoring-Core/RBEntity.class.st
@@ -1,3 +1,6 @@
+"
+I'm the root of the model classes.
+"
 Class {
 	#name : #RBEntity,
 	#superclass : #Object,
@@ -11,4 +14,10 @@ Class {
 RBEntity >> initialize [ 
 	super initialize.
 	modelFactory := RBClassModelFactory new. 
+]
+
+{ #category : #initialization }
+RBEntity >> parserClass [ 
+	
+	^ RBParser
 ]

--- a/src/Refactoring-Core/RBEntity.class.st
+++ b/src/Refactoring-Core/RBEntity.class.st
@@ -1,0 +1,14 @@
+Class {
+	#name : #RBEntity,
+	#superclass : #Object,
+	#instVars : [
+		'modelFactory'
+	],
+	#category : #'Refactoring-Core-Model'
+}
+
+{ #category : #initialization }
+RBEntity >> initialize [ 
+	super initialize.
+	modelFactory := RBClassModelFactory new. 
+]

--- a/src/Refactoring-Core/RBMethod.class.st
+++ b/src/Refactoring-Core/RBMethod.class.st
@@ -13,12 +13,12 @@ querying symbols, literals or the whole method source.
 "
 Class {
 	#name : #RBMethod,
-	#superclass : #Object,
+	#superclass : #RBEntity,
 	#instVars : [
-		'class',
 		'compiledMethod',
-		'source',
-		'selector'
+		'class',
+		'selector',
+		'source'
 	],
 	#category : #'Refactoring-Core-Model'
 }
@@ -165,7 +165,7 @@ RBMethod >> refersToVariable: aString [
 
 { #category : #accessing }
 RBMethod >> selector [
-	^selector
+	^ selector
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Core/RBMethod.class.st
+++ b/src/Refactoring-Core/RBMethod.class.st
@@ -93,7 +93,7 @@ RBMethod >> modelClass: aRBClass [
 
 { #category : #accessing }
 RBMethod >> parseTree [
-	^RBParser parseMethod: self source onError: [:str :pos | ^nil]
+	^ self parserClass parseMethod: self source onError: [:str :pos | ^nil]
 ]
 
 { #category : #testing }

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -36,7 +36,7 @@ Note, some of my methods for querying method senders and implementors don't work
 "
 Class {
 	#name : #RBNamespace,
-	#superclass : #Object,
+	#superclass : #RBEntity,
 	#instVars : [
 		'changes',
 		'environment',
@@ -232,10 +232,10 @@ RBNamespace >> compile: aString in: aRBClass classified: aSymbol [
 RBNamespace >> createNewClassFor: aBehavior [ 
 	| nonMeta meta className |
 	className := aBehavior instanceSide name.
-	nonMeta := (RBClassModelFactory rbClass existingNamed: className)
+	nonMeta := (modelFactory rbClass existingNamed: className)
 				model: self;
 				yourself.
-	meta := (RBClassModelFactory rbMetaclass existingNamed: className)
+	meta := (modelFactory rbMetaclass existingNamed: className)
 				model: self;
 				yourself.
 	^changedClasses at: className put: (Array with: nonMeta with: meta)
@@ -250,8 +250,8 @@ RBNamespace >> defineClass: aString [
 	newClass isNil
 		ifTrue: [ | newMetaclass |
 			self unmarkAsRemoved: newClassName.
-			newClass := RBClassModelFactory rbClass named: newClassName.
-			newMetaclass := RBClassModelFactory rbMetaclass named: newClassName.
+			newClass := modelFactory rbClass named: newClassName.
+			newMetaclass := modelFactory rbMetaclass named: newClassName.
 			newClass model: self.
 			newMetaclass model: self.
 			newClasses

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -324,6 +324,7 @@ RBNamespace >> includesGlobal: aSymbol [
 
 { #category : #initialization }
 RBNamespace >> initialize [
+	super initialize.
 	changes := RBRefactoryChangeManager changeFactory compositeRefactoryChange.
 	environment := RBBrowserEnvironment new.
 	newClasses := IdentityDictionary new.
@@ -496,7 +497,7 @@ RBNamespace >> reparentClasses: aRBClassCollection to: newClass [
 { #category : #'private-changes' }
 RBNamespace >> replaceClassNameIn: definitionString to: aSymbol [ 
 	| parseTree |
-	parseTree := RBParser parseExpression: definitionString.
+	parseTree := self parserClass parseExpression: definitionString.
 	parseTree receiver: (RBVariableNode named: aSymbol).
 	^parseTree formattedCode
 ]

--- a/src/Refactoring-Tests-Core/RBNamespaceTest.class.st
+++ b/src/Refactoring-Tests-Core/RBNamespaceTest.class.st
@@ -1,14 +1,23 @@
 Class {
 	#name : #RBNamespaceTest,
 	#superclass : #RBRefactoringBrowserTest,
+	#instVars : [
+		'modelFactory'
+	],
 	#category : #'Refactoring-Tests-Core'
 }
+
+{ #category : #running }
+RBNamespaceTest >> setUp [ 
+	
+	modelFactory := RBClassModelFactory new. 
+]
 
 { #category : #'class tests' }
 RBNamespaceTest >> testAllClassesDo [
 	| model classes |
 	classes := 0.
-	model := RBClassModelFactory rbNamespace new.
+	model := modelFactory rbNamespace new.
 	model allClassesDo: 
 			[:each | 
 			each name = #Object ifTrue: [each allSubclasses].
@@ -20,23 +29,23 @@ RBNamespaceTest >> testAllClassesDo [
 { #category : #'class tests' }
 RBNamespaceTest >> testCommentChange [
 	| st cl |
-	st := RBClassModelFactory rbNamespace new.
+	st := modelFactory rbNamespace new.
 	cl := st classNamed: self class name.
 	self assert: cl comment isString.
 	cl comment: 'a comment'.
-	self assert: cl comment = 'a comment'.
-	self assert: st changes changes size = 1.
-	self assert: st changes changes first comment = 'a comment'.
+	self assert: cl comment equals: 'a comment'.
+	self assert: st changes changes size equals: 1.
+	self assert: st changes changes first comment equals: 'a comment'.
 	cl comment: nil.
 	self assert: cl comment isNil.
-	self assert: st changes changes size = 2.
+	self assert: st changes changes size equals: 2.
 	self assert: st changes changes last comment isNil
 ]
 
 { #category : #'class tests' }
 RBNamespaceTest >> testDefineClassAfterDeletedChange [
 	| st |
-	st := RBClassModelFactory rbNamespace new.
+	st := modelFactory rbNamespace new.
 	st removeClassNamed: self class name.
 	self deny: (st includesClassNamed: self class name).
 	st defineClass: self class definition.
@@ -47,7 +56,7 @@ RBNamespaceTest >> testDefineClassAfterDeletedChange [
 { #category : #'class tests' }
 RBNamespaceTest >> testDefineClassChange [
 	| st |
-	st := RBClassModelFactory rbNamespace new.
+	st := modelFactory rbNamespace new.
 	st 
 		defineClass: 'RefactoringBrowserTest subclass: #SmalltalkTestXXX
 				instanceVariableNames: ''''
@@ -61,7 +70,7 @@ RBNamespaceTest >> testDefineClassChange [
 { #category : #'class tests' }
 RBNamespaceTest >> testImplementors [
 	| st |
-	st := RBClassModelFactory rbNamespace new.
+	st := modelFactory rbNamespace new.
 	self assert: ((st allImplementorsOf: #printString) 
 				includes: (st classNamed: #Object)).
 	(st classNamed: #Object) removeMethod: #printString.
@@ -71,10 +80,10 @@ RBNamespaceTest >> testImplementors [
 
 { #category : #'class tests' }
 RBNamespaceTest >> testIncludesClass [
-	self assert: (RBClassModelFactory rbNamespace new includesClassNamed: #Object).
-	self deny: (RBClassModelFactory rbNamespace new includesClassNamed: #Object1).
+	self assert: (modelFactory rbNamespace new includesClassNamed: #Object).
+	self deny: (modelFactory rbNamespace new includesClassNamed: #Object1).
 	self 
-		deny: ((RBClassModelFactory rbNamespace 
+		deny: ((modelFactory rbNamespace 
 				onEnvironment: (RBClassEnvironment onEnvironment: RBBrowserEnvironment new
 						classes: (Array with: Object))) 
 					includesClassNamed: #OrderedCollection)
@@ -83,7 +92,7 @@ RBNamespaceTest >> testIncludesClass [
 { #category : #'class tests' }
 RBNamespaceTest >> testModelImplementorsSenders [
 	| model class modelImps refs found |
-	model := RBClassModelFactory rbNamespace new.
+	model := modelFactory rbNamespace new.
 	model 
 		defineClass: 'Object subclass: #Asdf
 			instanceVariableNames: ''''
@@ -114,7 +123,7 @@ RBNamespaceTest >> testModelImplementorsSenders [
 { #category : #'class tests' }
 RBNamespaceTest >> testRedefineClassChange [
 	| st |
-	st := RBClassModelFactory rbNamespace new.
+	st := modelFactory rbNamespace new.
 	st defineClass: 'nil subclass: #Object
 				instanceVariableNames: ''a''
 				classVariableNames: ''A''
@@ -129,7 +138,7 @@ RBNamespaceTest >> testReferencesPrintOn [
 	| hasFoundObject hasFoundSelf smalltalk |
 	hasFoundObject := false.
 	hasFoundSelf := false.
-	smalltalk := RBClassModelFactory rbNamespace new.
+	smalltalk := modelFactory rbNamespace new.
 	smalltalk allReferencesTo: #printOn: do: [ :each | 
 		hasFoundObject := hasFoundObject
 			or: [ each selector = #fullPrintString 
@@ -146,7 +155,7 @@ RBNamespaceTest >> testReferencesPrintOnAfterAddition [
 	| hasFoundObject hasFoundSelf smalltalk |
 	hasFoundObject := false.
 	hasFoundSelf := false.
-	smalltalk := RBClassModelFactory rbNamespace new.
+	smalltalk := modelFactory rbNamespace new.
 	(smalltalk classNamed: #Object) 
 		compile: 'someTestReference self printOn: nil'
 		classified: #(testing).
@@ -169,7 +178,7 @@ RBNamespaceTest >> testReferencesPrintOnAfterRemove [
 	| hasFoundObject hasFoundSelf smalltalk |
 	hasFoundObject := false.
 	hasFoundSelf := false.
-	smalltalk := RBClassModelFactory rbNamespace new.
+	smalltalk := modelFactory rbNamespace new.
 	(smalltalk classNamed: #Object) 
 		removeMethod: #printString.
 	(smalltalk classNamed: self class name) 
@@ -188,7 +197,7 @@ RBNamespaceTest >> testReferencesPrintOnAfterRemove [
 { #category : #'class tests' }
 RBNamespaceTest >> testRemoveClassChange [
 	| st |
-	st := RBClassModelFactory rbNamespace new.
+	st := modelFactory rbNamespace new.
 	st removeClassNamed: self class name.
 	self deny: (st includesClassNamed: self class name).
 	self assert: (st classNamed: self class name) isNil
@@ -197,7 +206,7 @@ RBNamespaceTest >> testRemoveClassChange [
 { #category : #'class tests' }
 RBNamespaceTest >> testReparentSuperclassChange [
 	| st superclass subclasses |
-	st := RBClassModelFactory rbNamespace new.
+	st := modelFactory rbNamespace new.
 	superclass := st classFor: TestCase superclass.
 	subclasses := TestCase subclasses collect: [:each | st classFor: each].
 	st reparentClasses: subclasses to: superclass.
@@ -207,7 +216,7 @@ RBNamespaceTest >> testReparentSuperclassChange [
 { #category : #'class tests' }
 RBNamespaceTest >> testRoots [
 	| model |
-	model := RBClassModelFactory rbNamespace new.
+	model := modelFactory rbNamespace new.
 	self 
 		assert: (model rootClasses asSortedCollection: [:a :b | a name < b name]) 
 				asArray 

--- a/src/Refactoring-Tests-Core/RBNamespaceTest.class.st
+++ b/src/Refactoring-Tests-Core/RBNamespaceTest.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #running }
 RBNamespaceTest >> setUp [ 
-	
+	super setUp.
 	modelFactory := RBClassModelFactory new. 
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
@@ -135,6 +135,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testRefactoring [
 			^ true').
 	self assert: (class parseTreeFor: #initialize) 
 		equals: (RBParser parseMethod: 'initialize
+			super initialize.
 			changes := RBRefactoryChangeManager changeFactory compositeRefactoryChange.
 			self environment: RBBrowserEnvironment new.
 			newClasses := IdentityDictionary new.


### PR DESCRIPTION
Fixes: #3362 - Introducing RBEntity.- Making sure that we can use an instance. - removing hardcoded class.- Cleaning tests. 
- Extracting parser class.
- Making sure initialize is invoked.