### PR TITLE
3369-Context-should-not-depend-on-Halt

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -284,8 +284,7 @@ Context >> stepToHome: aContext [
 		context := aContext insertSender: (Context
 			contextOn: UnhandledError do: [:ex |
 				error ifNil: [
-					"this is ugly but it fixes the side-effects of not sending an Unhandled error on Halt"
-					error := (ex isKindOf: Halt) ifTrue: [ ex ] ifFalse: [ ex exception ].
+					error := ex exception.
 					topContext := thisContext.
 					ex resumeUnchecked: here jump ]
 						ifNotNil: [ ex pass ]]).

--- a/src/Kernel/Halt.class.st
+++ b/src/Kernel/Halt.class.st
@@ -229,3 +229,10 @@ Halt >> defaultAction [
 	^ UIManager default unhandledErrorDefaultAction: self
 	"^ UnhandledError signalForException: self" 
 ]
+
+{ #category : #private }
+Halt >> exception [
+	"In the context management, it might happen that we get an Halt instead of an UnhandledError. The context will ask the exception. In case we have an halt, we should return self."
+
+	^ self
+]


### PR DESCRIPTION
Remove dependency between Debugging-Core and Halt. 

Fixes #3369