### PR TITLE
3381-MorphhandlesMouseMove-does--not-works-if-using-an-event-handler

### DIFF
--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -3156,7 +3156,7 @@ Morph >> handlesMouseDown: evt [
 
 { #category : #'events-processing' }
 Morph >> handlesMouseMove: anEvent [
-	"Rules say that by default a morph gets #mouseMove if and only if:
+	"Rules say that by default a morph gets #mouseMove if
 		* the hand is not dragging anything,
 			+ and some button is down,
 			+ and the receiver is the current mouse focus."

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -3156,7 +3156,7 @@ Morph >> handlesMouseDown: evt [
 
 { #category : #'events-processing' }
 Morph >> handlesMouseMove: anEvent [
-	"Rules say that by default a morph gets #mouseMove if
+	"Rules say that by default a morph gets #mouseMove if and only if:
 		* the hand is not dragging anything,
 			+ and some button is down,
 			+ and the receiver is the current mouse focus."

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -3156,12 +3156,14 @@ Morph >> handlesMouseDown: evt [
 
 { #category : #'events-processing' }
 Morph >> handlesMouseMove: anEvent [
-	"Rules say that by default a morph gets #mouseMove iff
+	"Rules say that by default a morph gets #mouseMove if
 		* the hand is not dragging anything,
 			+ and some button is down,
 			+ and the receiver is the current mouse focus."
 			
-	"self eventHandler ifNotNil: [:handler | ^handler handlesMouseMove: anEvent ]."
+	self eventHandler ifNotNil: [ :handler | 
+		(handler handlesMouseMove: anEvent) ifTrue: [ 
+			^ true ] ].
 				
 	^anEvent hand submorphs isEmpty and: [ 	 
 		(anEvent anyButtonPressed and:[


### PR DESCRIPTION
Fixes #3381