### PR TITLE
3333-Test-Runner-history-menu-is-broken

### DIFF
--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -1116,7 +1116,8 @@ TestRunner >> statusHeight [
 
 { #category : #'accessing-menu' }
 TestRunner >> statusMenu: aMenu [
-	^ aMenu
+	^ aMenu 
+		defaultTarget: self;
 		add: 'History' selector: #showHistoryMenu;
 		add: 'Store result as progress reference' selector: #storeResultIntoTestCases;
 		add: 'Show progress' selector: #showProgress; 


### PR DESCRIPTION
Fix testrunner menu. Set the defaultTarget. https://github.com/pharo-project/pharo/issues/3333