### PR TITLE
3376-Reducing-the-amount-of-hardcoded-reference-to-RBParser

### DIFF
--- a/src/AST-Tests-Core/RBCommentNodeVisitorTest.class.st
+++ b/src/AST-Tests-Core/RBCommentNodeVisitorTest.class.st
@@ -3,14 +3,14 @@ SUnit tests for RBCommentNodeVisitor
 "
 Class {
 	#name : #RBCommentNodeVisitorTest,
-	#superclass : #TestCase,
+	#superclass : #RBParseTreeTest,
 	#category : #'AST-Tests-Core'
 }
 
 { #category : #tests }
 RBCommentNodeVisitorTest >> testVisitDetect [
 	| node tree |
-	tree := RBParser parseExpression: '
+	tree := self parseExpression: '
 	"comment 1"
 	"comment 2"
 	"comment 3"
@@ -25,7 +25,7 @@ RBCommentNodeVisitorTest >> testVisitDetect [
 { #category : #tests }
 RBCommentNodeVisitorTest >> testVisitDo [
 	| node tree count |
-	tree := RBParser parseExpression: '
+	tree := self parseExpression: '
 	"comment 1"
 	"comment 2"
 	"comment 3"
@@ -41,7 +41,7 @@ RBCommentNodeVisitorTest >> testVisitDo [
 { #category : #tests }
 RBCommentNodeVisitorTest >> testVisitSelect [
 	| node tree |
-	tree := RBParser parseExpression: '
+	tree := self parseExpression: '
 	"comment 1"
 	"comment 2"
 	"comment 3"

--- a/src/AST-Tests-Core/RBDumpNodeTest.class.st
+++ b/src/AST-Tests-Core/RBDumpNodeTest.class.st
@@ -3,7 +3,7 @@ SUnit tests for the #dump and #dumpOn: methods on RBProgramNodes
 "
 Class {
 	#name : #RBDumpNodeTest,
-	#superclass : #TestCase,
+	#superclass : #RBParseTreeTest,
 	#category : #'AST-Tests-Core'
 }
 
@@ -11,7 +11,7 @@ Class {
 RBDumpNodeTest >> testArrayNodeDump [
 	| node dumpedNode |
 	"Empty Array"
-	node := RBParser parseExpression: '{}'.
+	node := self parseExpression: '{}'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBArrayNode. 
@@ -19,7 +19,7 @@ RBDumpNodeTest >> testArrayNodeDump [
 	self assert: node printString equals: dumpedNode printString.
 	
 	"non-empty Array"
-	node := RBParser parseExpression: '{1 + 1. true. Object new}'.
+	node := self parseExpression: '{1 + 1. true. Object new}'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBArrayNode. 
@@ -32,7 +32,7 @@ RBDumpNodeTest >> testArrayNodeDump [
 { #category : #tests }
 RBDumpNodeTest >> testAssignmentNodeDump [
 	| node dumpedNode |
-	node := RBParser parseExpression: 'a := 3.'.
+	node := self parseExpression: 'a := 3.'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBAssignmentNode. 
@@ -46,7 +46,7 @@ RBDumpNodeTest >> testAssignmentNodeDump [
 RBDumpNodeTest >> testBlockNodeDump [
 	| node dumpedNode |
 	"Simple block"
-	node := RBParser parseExpression: '[self]'.
+	node := self parseExpression: '[self]'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBBlockNode. 
@@ -54,7 +54,7 @@ RBDumpNodeTest >> testBlockNodeDump [
 	self assert: node printString equals: dumpedNode printString.
 	
 	"Block with argument"
-	node := RBParser parseExpression: '[:each | each]'.
+	node := self parseExpression: '[:each | each]'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBBlockNode. 
@@ -62,7 +62,7 @@ RBDumpNodeTest >> testBlockNodeDump [
 	self assert: node printString equals: dumpedNode printString.
 	
 	"Block with arguments and temps"
-	node := RBParser parseExpression: '[:each :i | |a b| a := each. b := i.]'.
+	node := self parseExpression: '[:each :i | |a b| a := each. b := i.]'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBBlockNode. 
@@ -73,7 +73,7 @@ RBDumpNodeTest >> testBlockNodeDump [
 { #category : #tests }
 RBDumpNodeTest >> testCascadeNodeDump [
 	| node dumpedNode |
-	node := RBParser parseExpression: 'self foo; bar'.
+	node := self parseExpression: 'self foo; bar'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBCascadeNode. 
@@ -116,7 +116,7 @@ RBDumpNodeTest >> testDumpOnSelfClassMethods [
 { #category : #tests }
 RBDumpNodeTest >> testErrorNodeDump [
 	| node dumpedNode |
-	node := RBParser parseFaultyExpression: '( +'.
+	node := self parseFaultyExpression: '( +'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBParseErrorNode. 
@@ -129,7 +129,7 @@ RBDumpNodeTest >> testErrorNodeDump [
 RBDumpNodeTest >> testGlobalNodeDump [
 	| node dumpedNode |
 	"Global nodes are only generated when a semantic analysis is triggered on a method"
-	node := RBParser parseMethod: 'foo ^ Object'.
+	node := self parseMethod: 'foo ^ Object'.
 	dumpedNode := Smalltalk compiler evaluate: node doSemanticAnalysis dump.
 	
 	self assert: dumpedNode statements first value class equals: RBGlobalNode. 
@@ -141,7 +141,7 @@ RBDumpNodeTest >> testGlobalNodeDump [
 { #category : #tests }
 RBDumpNodeTest >> testLiteralArrayNodeDump [
 	| node dumpedNode |
-	node := RBParser parseExpression: '#(1 $a true ''a'')'.
+	node := self parseExpression: '#(1 $a true ''a'')'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBLiteralArrayNode. 
@@ -154,7 +154,7 @@ RBDumpNodeTest >> testLiteralArrayNodeDump [
 RBDumpNodeTest >> testLiteralValueNodeDump [
 	| node dumpedNode |
 	"Numeric are literals"
-	node := RBParser parseExpression: '1'.
+	node := self parseExpression: '1'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBLiteralValueNode. 
@@ -162,7 +162,7 @@ RBDumpNodeTest >> testLiteralValueNodeDump [
 	self assert: node printString equals: dumpedNode printString.
 	
 	"Symbol are literals"
-	node := RBParser parseExpression: '#foo'.
+	node := self parseExpression: '#foo'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBLiteralValueNode. 
@@ -170,7 +170,7 @@ RBDumpNodeTest >> testLiteralValueNodeDump [
 	self assert: node printString equals: dumpedNode printString.
 	
 	"Booleans are literals"
-	node := RBParser parseExpression: 'true'.
+	node := self parseExpression: 'true'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBLiteralValueNode. 
@@ -178,7 +178,7 @@ RBDumpNodeTest >> testLiteralValueNodeDump [
 	self assert: node printString equals: dumpedNode printString.
 	
 	"char are literals"
-	node := RBParser parseExpression: '$a'.
+	node := self parseExpression: '$a'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBLiteralValueNode. 
@@ -186,7 +186,7 @@ RBDumpNodeTest >> testLiteralValueNodeDump [
 	self assert: node printString equals: dumpedNode printString.
 	
 	"String are literals"
-	node := RBParser parseExpression: '''a'''.
+	node := self parseExpression: '''a'''.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBLiteralValueNode. 
@@ -198,7 +198,7 @@ RBDumpNodeTest >> testLiteralValueNodeDump [
 RBDumpNodeTest >> testMessageNodeDump [
 	| node dumpedNode |
 	"Simple selector"
-	node := RBParser parseExpression: 'self foo'.
+	node := self parseExpression: 'self foo'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBMessageNode. 
@@ -206,7 +206,7 @@ RBDumpNodeTest >> testMessageNodeDump [
 	self assert: node printString equals: dumpedNode printString.
 	
 	"With an argument"
-	node := RBParser parseExpression: 'self foo: 1'.
+	node := self parseExpression: 'self foo: 1'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBMessageNode. 
@@ -214,7 +214,7 @@ RBDumpNodeTest >> testMessageNodeDump [
 	self assert: node printString equals: dumpedNode printString.
 	
 	"With many arguments"
-	node := RBParser parseExpression: 'self foo: 1 bar: 2'.
+	node := self parseExpression: 'self foo: 1 bar: 2'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBMessageNode. 
@@ -222,7 +222,7 @@ RBDumpNodeTest >> testMessageNodeDump [
 	self assert: node printString equals: dumpedNode printString.
 	
 	"Binary message"
-	node := RBParser parseExpression: '1 + 2'.
+	node := self parseExpression: '1 + 2'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBMessageNode. 
@@ -234,7 +234,7 @@ RBDumpNodeTest >> testMessageNodeDump [
 { #category : #tests }
 RBDumpNodeTest >> testMethodNodeDump [
 	| node dumpedNode |
-	node := RBParser parseMethod: 'foo <useless>'.
+	node := self parseMethod: 'foo <useless>'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBMethodNode. 
@@ -248,7 +248,7 @@ RBDumpNodeTest >> testMethodNodeDump [
 { #category : #tests }
 RBDumpNodeTest >> testPragmaNodeDump [
 	| node dumpedNode |
-	node := RBParser parseMethod: 'foo <useless>'.
+	node := self parseMethod: 'foo <useless>'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode pragmas first class equals: RBPragmaNode. 
@@ -262,7 +262,7 @@ RBDumpNodeTest >> testPragmaNodeDump [
 { #category : #tests }
 RBDumpNodeTest >> testReturnNodeDump [
 	| node dumpedNode |
-	node := RBParser parseExpression: '^ 1 + 1'.
+	node := self parseExpression: '^ 1 + 1'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBReturnNode. 
@@ -276,7 +276,7 @@ RBDumpNodeTest >> testReturnNodeDump [
 { #category : #tests }
 RBDumpNodeTest >> testSelfNodeDump [
 	| node dumpedNode |
-	node := RBParser parseExpression: 'self'.
+	node := self parseExpression: 'self'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBSelfNode. 
@@ -288,7 +288,7 @@ RBDumpNodeTest >> testSelfNodeDump [
 { #category : #tests }
 RBDumpNodeTest >> testSequenceNodeDump [
 	| node dumpedNode |
-	node := RBParser parseExpression: 'foo. bar.'.
+	node := self parseExpression: 'foo. bar.'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBSequenceNode. 
@@ -302,7 +302,7 @@ RBDumpNodeTest >> testSequenceNodeDump [
 { #category : #tests }
 RBDumpNodeTest >> testSuperNodeDump [
 	| node dumpedNode |
-	node := RBParser parseExpression: 'super'.
+	node := self parseExpression: 'super'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBSuperNode. 
@@ -314,7 +314,7 @@ RBDumpNodeTest >> testSuperNodeDump [
 { #category : #tests }
 RBDumpNodeTest >> testThisContextNodeDump [
 	| node dumpedNode |
-	node := RBParser parseExpression: 'thisContext'.
+	node := self parseExpression: 'thisContext'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBThisContextNode. 
@@ -326,7 +326,7 @@ RBDumpNodeTest >> testThisContextNodeDump [
 { #category : #tests }
 RBDumpNodeTest >> testVariableNodeDump [
 	| node dumpedNode |
-	node := RBParser parseExpression: 'a'.
+	node := self parseExpression: 'a'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
 	self assert: dumpedNode class equals: RBVariableNode. 

--- a/src/AST-Tests-Core/RBFormatterTest.class.st
+++ b/src/AST-Tests-Core/RBFormatterTest.class.st
@@ -3,7 +3,7 @@ SUnit tests for BISimpleFormatter
 "
 Class {
 	#name : #RBFormatterTest,
-	#superclass : #TestCase,
+	#superclass : #RBParseTreeTest,
 	#category : #'AST-Tests-Core'
 }
 
@@ -46,21 +46,21 @@ RBFormatterTest >> testFormatPragmaWithLastIsSymbolArgument [
 	| inputSource tree outputSource |
 	"formatter should not create invalid code by removing whitespace between #= and >"
 	inputSource := 'foo  <selector: #= > ^ self'.
-	tree := RBParser parseMethod: inputSource.
+	tree := self parseMethod: inputSource.
 	outputSource := self formatterClass new format: tree.
-	self shouldnt: [RBParser parseMethod: outputSource] raise: SyntaxErrorNotification.
+	self shouldnt: [self parseMethod: outputSource] raise: SyntaxErrorNotification.
 	
 	"already worked and still should for non-symbol arguments"
 	inputSource := 'foo  <selector: 0 > ^ self'.
-	tree := RBParser parseMethod: inputSource.
+	tree := self parseMethod: inputSource.
 	outputSource := self formatterClass new format: tree.
-	self shouldnt: [RBParser parseMethod: outputSource] raise: SyntaxErrorNotification.
+	self shouldnt: [self parseMethod: outputSource] raise: SyntaxErrorNotification.
 	
 	"already worked and should still work for pragmas without arguments"
 	inputSource := 'foo  <selector> ^ self'.
-	tree := RBParser parseMethod: inputSource.
+	tree := self parseMethod: inputSource.
 	outputSource := self formatterClass new format: tree.
-	self shouldnt: [RBParser parseMethod: outputSource] raise: SyntaxErrorNotification
+	self shouldnt: [self parseMethod: outputSource] raise: SyntaxErrorNotification
 
 
 ]
@@ -69,7 +69,7 @@ RBFormatterTest >> testFormatPragmaWithLastIsSymbolArgument [
 RBFormatterTest >> testLiteralDynamicArray [
 	| source tree1 |
 	source := 'foo ^ { ''film'' . ''FILM''} '.
-	tree1 := RBParser parseMethod: source.
+	tree1 := self parseMethod: source.
 	self assert: ((self formatterClass new format: tree1) occurrencesOf: $.) equals: 1
 ]
 
@@ -78,7 +78,7 @@ RBFormatterTest >> testParseError [
 	| inputSource errorNode |
 	"parse error nodes should have the faulty code"
 	inputSource := ')'.
-   errorNode := RBParser parseFaultyExpression: inputSource.
+   errorNode := self parseFaultyExpression: inputSource.
 	self assert: errorNode source equals: errorNode formattedCode
 
 ]
@@ -88,7 +88,7 @@ RBFormatterTest >> testParseError2 [
 	| inputSource errorNode |
 	"parse error nodes should have the faulty code"
 	inputSource := '( 1 + 2'.
-   errorNode := RBParser parseFaultyExpression: inputSource.
+   errorNode := self parseFaultyExpression: inputSource.
 	self assert: errorNode source equals: errorNode formattedCode
 
 ]
@@ -99,7 +99,7 @@ RBFormatterTest >> testPreserveLiteralArrayFormat [
 	"symbols within a literal array can omit the # character, if it is used that way,
 	the formatter should not add a # character but just use the source form."
 	inputSource := '#(#withnumbersign nonumbersign ''string'')'.
-   literalArrayNode := RBParser parseExpression: inputSource.
+   literalArrayNode := self parseExpression: inputSource.
 	self assert: literalArrayNode source equals: literalArrayNode formattedCode
 
 ]
@@ -111,7 +111,7 @@ RBFormatterTest >> testPreserveLiteralNumberFormat [
 	radix float, fractional constants. The formatter should not change the
 	formatting."
 	inputSource := '#(1 4r33 16r0F 0.02 2e-2 -1)'.
-   numbersNode := RBParser parseExpression: inputSource.
+   numbersNode := self parseExpression: inputSource.
 	self assert: numbersNode source equals: numbersNode formattedCode
 
 ]

--- a/src/AST-Tests-Core/RBMethodNodeTest.class.st
+++ b/src/AST-Tests-Core/RBMethodNodeTest.class.st
@@ -12,11 +12,17 @@ RBMethodNodeTest >> methodWithArg: someArgName and: someAnotherArgName [
 
 ]
 
+{ #category : #helpers }
+RBMethodNodeTest >> parseMethod: aString [ 
+
+	^ RBParser parseMethod: aString
+]
+
 { #category : #tests }
 RBMethodNodeTest >> testAddingMethodProperties [
 
 	| ast |
-	ast := RBParser parseMethod: 'one ^ self'.
+	ast := self parseMethod: 'one ^ self'.
 	self assert: ast methodProperties isNil. 
 	
 	ast methodPropertyAt: #testKey put: #testValue.
@@ -40,9 +46,9 @@ RBMethodNodeTest >> testCachingMethodArguments [
 { #category : #tests }
 RBMethodNodeTest >> testSelectorAndArgumentNames [
 
-	self assert: (RBParser parseMethod: 'one ^ self') selectorAndArgumentNames equals: 'one'.
-	self assert: (RBParser parseMethod: 'one:   aOne ^ self') selectorAndArgumentNames equals: 'one:   aOne'.
-	self assert: (RBParser parseMethod: 'one:   aOne two:   aTwo ^ self') selectorAndArgumentNames equals: 'one:   aOne two:   aTwo'.
-	self assert: (RBParser parseMethod: '*   aOne') selectorAndArgumentNames equals: '*   aOne'.
-	self assert: (RBParser parseMethod: '**   aOne') selectorAndArgumentNames equals: '**   aOne'
+	self assert: (self parseMethod: 'one ^ self') selectorAndArgumentNames equals: 'one'.
+	self assert: (self parseMethod: 'one:   aOne ^ self') selectorAndArgumentNames equals: 'one:   aOne'.
+	self assert: (self parseMethod: 'one:   aOne two:   aTwo ^ self') selectorAndArgumentNames equals: 'one:   aOne two:   aTwo'.
+	self assert: (self parseMethod: '*   aOne') selectorAndArgumentNames equals: '*   aOne'.
+	self assert: (self parseMethod: '**   aOne') selectorAndArgumentNames equals: '**   aOne'
 ]

--- a/src/AST-Tests-Core/RBNullFormatterTest.class.st
+++ b/src/AST-Tests-Core/RBNullFormatterTest.class.st
@@ -7,11 +7,17 @@ Class {
 	#category : #'AST-Tests-Core'
 }
 
+{ #category : #helpers }
+RBNullFormatterTest >> parseMethod: aString [ 
+
+	^ RBParser parseMethod: aString
+]
+
 { #category : #tests }
 RBNullFormatterTest >> testGivenAMethodNodeWhenSourceAvailableThenSourceReturnedAsResultOfFormatting [
 	| ast sourceCode |
 	sourceCode := (Collection class>>#with:with:) sourceCode.
-	ast := RBParser parseMethod: sourceCode.
+	ast := self parseMethod: sourceCode.
 	self 
 		assert: (RBNullFormatter new format: ast)
 		equals: sourceCode
@@ -21,7 +27,7 @@ RBNullFormatterTest >> testGivenAMethodNodeWhenSourceAvailableThenSourceReturned
 RBNullFormatterTest >> testGivenAMethodNodeWhenSourceNotAvailableThenSelectorWithWarningMessageReturnedAsResultOfFormatting [
 	| ast sourceCode |
 	sourceCode := (Collection class>>#with:with:) sourceCode.
-	ast := RBParser parseMethod: sourceCode.
+	ast := self parseMethod: sourceCode.
 	ast source: nil.
 	self 
 		assert: (RBNullFormatter new format: ast)

--- a/src/AST-Tests-Core/RBParseTreeRewriterTest.class.st
+++ b/src/AST-Tests-Core/RBParseTreeRewriterTest.class.st
@@ -16,6 +16,30 @@ RBParseTreeRewriterTest >> compare: anObject to: anotherObject [
 	self assert: anObject = anotherObject
 ]
 
+{ #category : #helpers }
+RBParseTreeRewriterTest >> parseExpression: aString [
+
+	^ RBParser parseExpression: aString
+]
+
+{ #category : #helpers }
+RBParseTreeRewriterTest >> parseMethod: aString [
+
+	^ RBParser parseMethod: aString
+]
+
+{ #category : #helpers }
+RBParseTreeRewriterTest >> parseRewriteExpression: aString [ 
+
+	^ RBParser parseRewriteExpression: aString
+]
+
+{ #category : #helpers }
+RBParseTreeRewriterTest >> parseRewriteMethod: aString [ 
+
+	^ RBParser parseRewriteMethod: aString
+]
+
 { #category : #running }
 RBParseTreeRewriterTest >> setUp [
 	super setUp.
@@ -38,7 +62,7 @@ RBParseTreeRewriterTest >> testBlockRewrites [
 	self
 		compare: tree
 		to:
-			(RBParser
+			(self
 				parseMethod:
 					'method: xxx
 	<primitive: 1>
@@ -59,7 +83,7 @@ RBParseTreeRewriterTest >> testBlockRewritesAreNotChained [
 	self
 		compare: tree
 		to:
-			(RBParser
+			(self
 				parseMethod:
 					'method: asdf
 	<primitive: 1>
@@ -71,7 +95,7 @@ RBParseTreeRewriterTest >> testBlockRewritesAreNotChained [
 RBParseTreeRewriterTest >> testBlockRewritesArguments [
 	"this test just shows that all the arguments are replaced. Check in contrast with testBlockRewritesArgumentsTakeIntoAccountConditions"
 	| tree |
-	tree := RBParser 
+	tree := self 
 				parseMethod: 'method: asdf bar: bar
 	<primitive: 1>
 	<primitive: 2>
@@ -89,7 +113,7 @@ RBParseTreeRewriterTest >> testBlockRewritesArguments [
 		
 	rewriter executeTree: tree.
 	self compare: tree
-		to: (RBParser 
+		to: (self 
 				parseMethod: 'method: xxx bar: yyy
 	<primitive: 1>
 	<primitive: 2>
@@ -100,7 +124,7 @@ RBParseTreeRewriterTest >> testBlockRewritesArguments [
 RBParseTreeRewriterTest >> testBlockRewritesArgumentsTakeIntoAccountConditions [
 	"this test shows that the condition controls the rewriting on the terms: here the bar argument is not rewritten because the condition is set to false."
 	| tree |
-	tree := RBParser 
+	tree := self 
 				parseMethod: 'method: asdf bar: bar
 	<primitive: 1>
 	<primitive: 2>
@@ -116,7 +140,7 @@ RBParseTreeRewriterTest >> testBlockRewritesArgumentsTakeIntoAccountConditions [
 		
 	rewriter executeTree: tree.
 	self compare: tree
-		to: (RBParser 
+		to: (self 
 				parseMethod: 'method: xxx bar: bar
 	<primitive: 1>
 	<primitive: 2>
@@ -134,7 +158,7 @@ RBParseTreeRewriterTest >> testBlockRewritesFirstRuleTakePrecedence [
 	self
 		compare: tree
 		to:
-			(RBParser
+			(self
 				parseMethod:
 					'method: asdf
 	<primitive: 1>
@@ -154,7 +178,7 @@ RBParseTreeRewriterTest >> testBlockRewritesWithTrueConditionIsNotExecutedWhenNo
 	self
 		compare: tree
 		to:
-			(RBParser
+			(self
 				parseMethod:
 					'method: xxx
 	<primitive: 1>
@@ -171,9 +195,9 @@ RBParseTreeRewriterTest >> testMultimatch [
 		with: '``@object foo: ``@foo'
 		when: [:aNode | (count := count + 1) == 2].
 	self compare: (rewriter
-				executeTree: (RBParser parseExpression: 'self at: (bar at: 3)');
+				executeTree: (self parseExpression: 'self at: (bar at: 3)');
 				tree)
-		to: (RBParser parseExpression: 'self at: (bar foo: 3)')
+		to: (self parseExpression: 'self at: (bar foo: 3)')
 ]
 
 { #category : #'tests - to be refined' }
@@ -182,10 +206,10 @@ RBParseTreeRewriterTest >> testPatternCascade [
 	rewriter replace: 'self `;messages; foo: 4; `;messages1'
 		with: 'self `;messages1; bar: 4; `;messages'.
 	self compare: (rewriter
-				executeTree: (RBParser 
+				executeTree: (self 
 							parseExpression: 'self foo; printString; foo: 4; bar. self foo: 4');
 				tree)
-		to: (RBParser 
+		to: (self 
 				parseExpression: 'self bar; bar: 4; foo; printString. self foo:4')
 ]
 
@@ -196,7 +220,7 @@ RBParseTreeRewriterTest >> testRewriteDoesNotReuseOriginalNodes [
 	that don't refer to the same parent (the method node) and that is wrong."
 
 	| ast search replace |
-	ast := RBParser
+	ast := self
 		parseMethod:
 			'foo
 self statement1.
@@ -222,7 +246,7 @@ RBParseTreeRewriterTest >> testRewriteDynamicArray [
 	rewriter := RBParseTreeRewriter new replace: '
 		{`@first. `@second. `@third}' with: 'Array with: `@first  with: `@second  with: `@third'.
 
-	newSource := (rewriter executeTree: (RBParser parseRewriteExpression: ' {(1 @ 255).	(Color lightMagenta). 3}'))
+	newSource := (rewriter executeTree: (self parseRewriteExpression: ' {(1 @ 255).	(Color lightMagenta). 3}'))
 		ifTrue: [ rewriter tree formattedCode].
 	self assert: newSource equals: 'Array with: 1 @ 255 with: Color lightMagenta with: 3'.
 ]
@@ -236,19 +260,19 @@ RBParseTreeRewriterTest >> testRewriteMethods [
 			| rewrite |
 			rewrite := RBParseTreeRewriter new.
 			rewrite replaceMethod: (each at: 3) with: each last.
-			self compare: (RBParser 
+			self compare: (self 
 						parseMethod: (rewrite
-								executeTree: (RBParser parseMethod: each first);
+								executeTree: (self parseMethod: each first);
 								tree) formattedCode)
-				to: (RBParser parseMethod: (each at: 2)).
+				to: (self parseMethod: (each at: 2)).
 			rewrite := RBParseTreeRewriter new.
-			rewrite replaceTree: (RBParser parseRewriteMethod: (each at: 3))
-				withTree: (RBParser parseRewriteMethod: each last).
-			self compare: (RBParser 
+			rewrite replaceTree: (self parseRewriteMethod: (each at: 3))
+				withTree: (self parseRewriteMethod: each last).
+			self compare: (self 
 						parseMethod: (rewrite
-								executeTree: (RBParser parseMethod: each first);
+								executeTree: (self parseMethod: each first);
 								tree) formattedCode)
-				to: (RBParser parseMethod: (each at: 2))]
+				to: (self parseMethod: (each at: 2))]
 ]
 
 { #category : #'tests - to be refined' }
@@ -300,9 +324,9 @@ RBParseTreeRewriterTest >> testRewrites [
 		rewrite := RBParseTreeRewriter new.
 		rewrite replace: (each at: 3)
 			with: each last.
-		self compare: (RBParser parseExpression: (rewrite executeTree: (RBParser parseExpression: each first);
+		self compare: (self parseExpression: (rewrite executeTree: (self parseExpression: each first);
 				 tree) formattedCode)
-			to: (RBParser parseExpression: (each at: 2))]
+			to: (self parseExpression: (each at: 2))]
 ]
 
 { #category : #setup }

--- a/src/AST-Tests-Core/RBParseTreeSearcherTest.class.st
+++ b/src/AST-Tests-Core/RBParseTreeSearcherTest.class.st
@@ -10,6 +10,12 @@ Class {
 	#category : #'AST-Tests-Core'
 }
 
+{ #category : #helpers }
+RBParseTreeSearcherTest >> parseExpression: aString [ 
+
+	^ RBParser parseExpression: aString
+]
+
 { #category : #'tests - to de refined' }
 RBParseTreeSearcherTest >> parseTreeSearcher [
 	^ RBParseTreeSearcher new
@@ -27,7 +33,7 @@ RBParseTreeSearcherTest >> testDynamicArrayStatements [
 
 	| dict |
 	searcher matches: '{`@first. `@second. `@third.}' do: [ :aNode :answer |  dict:= searcher context ].
-	dict := searcher executeTree: (RBParser parseExpression:'{ (1@2) . Color red . 3}').
+	dict := searcher executeTree: (self parseExpression:'{ (1@2) . Color red . 3}').
 	self assert: (dict at: (RBPatternVariableNode named:'`@first')) formattedCode equals: '(1 @ 2)'.
 	self assert: (dict at: (RBPatternVariableNode named:'`@second')) formattedCode equals: 'Color red'.
 	self assert: (dict at: (RBPatternVariableNode named:'`@third')) formattedCode equals: '3'
@@ -40,7 +46,7 @@ RBParseTreeSearcherTest >> testDynamicArrayWithStatementListPattern [
 
 	| dict |
 	searcher matches: '{`.@stmts.}' do: [ :aNode :answer |  dict:= searcher context ].
-	dict := searcher executeTree: (RBParser parseExpression:'{ (1@2) . Color red . 3}').
+	dict := searcher executeTree: (self parseExpression:'{ (1@2) . Color red . 3}').
 	self assert: (dict at: (RBPatternVariableNode named: '`.@stmts')) size equals: 3
 
 ]
@@ -54,7 +60,7 @@ RBParseTreeSearcherTest >> testSearching [
 		assert:
 			(searcher
 				executeTree:
-					(RBParser
+					(self
 						parseExpression: 'self at: 1 put: 2; at: 2 ifAbsent: []; ifAbsent: 2 at: 1; at: 4; foo')
 				initialAnswer: 0)
 		equals: 2.
@@ -91,7 +97,7 @@ RBParseTreeSearcherTest >> testSearchingComposedSelector [
 	"the result is 2 because the parse tree searcher only finds at:x: messages like at:put: and at:ifAbsent:"	
 	self 
 		assert: (searcher 
-					executeTree: (RBParser 	
+					executeTree: (self 	
 							parseExpression: 'self at: 1 put: 2; at: 2 ifAbsent: []; ifAbsent: 2 at: 1; at: 4; foo')
 					initialAnswer: 0) equals: 2
 	
@@ -106,7 +112,7 @@ RBParseTreeSearcherTest >> testSearchingComposedSelector2 [
 	"the result is 1 because the parse tree searcher only finds at: messages like at: and not ifAbsent: at:"	
 	self 
 		assert: (searcher 
-					executeTree: (RBParser parseExpression: 'self ifAbsent: 2 at: 1; at: 4; foo')
+					executeTree: (self parseExpression: 'self ifAbsent: 2 at: 1; at: 4; foo')
 					initialAnswer: 0)
 		equals: 1
 ]

--- a/src/AST-Tests-Core/RBParseTreeTest.class.st
+++ b/src/AST-Tests-Core/RBParseTreeTest.class.st
@@ -1,0 +1,34 @@
+Class {
+	#name : #RBParseTreeTest,
+	#superclass : #TestCase,
+	#category : #'AST-Tests-Core'
+}
+
+{ #category : #helpers }
+RBParseTreeTest >> parseExpression: aString [ 
+
+	^ RBParser parseExpression: aString
+]
+
+{ #category : #helpers }
+RBParseTreeTest >> parseFaultyExpression: aString [ 
+
+	^ RBParser parseFaultyExpression: aString
+]
+
+{ #category : #private }
+RBParseTreeTest >> parseFaultyMethod: text [
+	^RBParser parseFaultyMethod: text.
+]
+
+{ #category : #helpers }
+RBParseTreeTest >> parseMethod: aString [ 
+
+	^ RBParser parseMethod: aString
+]
+
+{ #category : #helpers }
+RBParseTreeTest >> parseRewriteMethod: aString [ 
+
+	^ RBParser parseRewriteMethod: aString
+]

--- a/src/AST-Tests-Core/RBParserTest.class.st
+++ b/src/AST-Tests-Core/RBParserTest.class.st
@@ -3,7 +3,7 @@ SUnit tests for RBParser
 "
 Class {
 	#name : #RBParserTest,
-	#superclass : #TestCase,
+	#superclass : #RBParseTreeTest,
 	#category : #'AST-Tests-Core'
 }
 
@@ -42,11 +42,6 @@ RBParserTest >> parseError: expression onError: aBlock [
 { #category : #private }
 RBParserTest >> parseFaultyExpression: text [
 	^ self parserClass parseFaultyExpression: text
-]
-
-{ #category : #private }
-RBParserTest >> parseFaultyMethod: text [
-	^RBParser parseFaultyMethod: text.
 ]
 
 { #category : #tests }
@@ -118,7 +113,7 @@ RBParserTest >> testBinarySelectors [
 				selectorStrings addLast: (String with: first with: second with: third)]]].
 
 	selectorStrings do: [:each | | methodNode messageNode |
-		methodNode := RBParser parseMethod: each, 'anObject
+		methodNode := self parseMethod: each, 'anObject
 	^self',each,'anObject'.
 		self assert: methodNode selector equals: each asSymbol.
 		self assert: methodNode argumentNames asArray equals: #(anObject).

--- a/src/AST-Tests-Core/RBPatternParserTest.class.st
+++ b/src/AST-Tests-Core/RBPatternParserTest.class.st
@@ -35,7 +35,7 @@ RBPatternParserTest >> testPatternBlockNode1 [
 	| searchPattern tree |
 	searchPattern := RBPatternParser
 		parseExpression: '(`a = `b) `{`a name size = `b name size}'.
-	tree := RBParser parseExpression: 'a = c'.
+	tree := self parseExpression: 'a = c'.
 	self assert: (searchPattern match: tree inContext: Dictionary new)
 ]
 
@@ -44,6 +44,6 @@ RBPatternParserTest >> testPatternBlockNode2 [
 	| searchPattern tree |
 	searchPattern := RBPatternParser
 		parseExpression: '(`a = `b) `{`a name anySatisfy: [ :e | `b name includes: e]}'.
-	tree := RBParser parseExpression: 'a = a1'.
+	tree := self parseExpression: 'a = a1'.
 	self assert: (searchPattern match: tree inContext: Dictionary new)
 ]

--- a/src/AST-Tests-Core/RBProgramNodeTest.class.st
+++ b/src/AST-Tests-Core/RBProgramNodeTest.class.st
@@ -3,7 +3,7 @@ SUnit tests for RBProgramNode
 "
 Class {
 	#name : #RBProgramNodeTest,
-	#superclass : #TestCase,
+	#superclass : #RBParseTreeTest,
 	#instVars : [
 		'node'
 	],
@@ -18,16 +18,6 @@ RBProgramNodeTest class >> packageNamesUnderTest [
 { #category : #accessing }
 RBProgramNodeTest >> node [
 	^ node ifNil: [ node := RBProgramNode new ]
-]
-
-{ #category : #utilities }
-RBProgramNodeTest >> parseExpression: aString [
-	^ RBParser parseExpression: aString
-]
-
-{ #category : #utilities }
-RBProgramNodeTest >> parseMethod: aString [
-	^ RBParser parseMethod: aString
 ]
 
 { #category : #'testing-adding' }
@@ -412,7 +402,7 @@ RBProgramNodeTest >> testReplaceVariable [
 { #category : #'testing-messages' }
 RBProgramNodeTest >> testSentMessages [
 	| tree messages |
-	tree := RBParser
+	tree := self
 		parseRewriteMethod:
 			'methodName
 				| temp |

--- a/src/AST-Tests-Core/RBReadBeforeWrittenTesterTest.class.st
+++ b/src/AST-Tests-Core/RBReadBeforeWrittenTesterTest.class.st
@@ -3,7 +3,7 @@ SUnit tests for RBReadBeforeWrittenTester
 "
 Class {
 	#name : #RBReadBeforeWrittenTesterTest,
-	#superclass : #TestCase,
+	#superclass : #RBParseTreeTest,
 	#category : #'AST-Tests-Core'
 }
 
@@ -11,10 +11,10 @@ Class {
 RBReadBeforeWrittenTesterTest >> testReadBeforeWritten [
 	#(('a ifTrue: [^self]' true ) ('self foo. a := b' false ) ('condition ifTrue: [a := b] ifFalse: [self foo: a]' true ) ('condition ifTrue: [a := b] ifFalse: [self foo]. a isNil' true ) ('condition ifTrue: [a := b]. a := c' false ) ('[a := b] whileFalse: [a isNil]' false ) ('self foo: b' false ) ) do: 
 		[:each | 
-		self assert: ((RBReadBeforeWrittenTester readBeforeWritten: #('a' ) in: (RBParser parseExpression: each first))
+		self assert: ((RBReadBeforeWrittenTester readBeforeWritten: #('a' ) in: (self parseExpression: each first))
 				includes: 'a')
 				== each last.
-		self assert: (RBReadBeforeWrittenTester isVariable: 'a' readBeforeWrittenIn: (RBParser parseExpression: each first))
+		self assert: (RBReadBeforeWrittenTester isVariable: 'a' readBeforeWrittenIn: (self parseExpression: each first))
 				equals: each last].
 	#('| temp read written written1 |
 			read ifTrue: [^self].
@@ -32,7 +32,7 @@ RBReadBeforeWrittenTesterTest >> testReadBeforeWritten [
 			self do: [:each | each & read]' ) do: 
 		[:each | 
 		| read | 
-		read := RBReadBeforeWrittenTester variablesReadBeforeWrittenIn: (RBParser parseExpression: each).
+		read := RBReadBeforeWrittenTester variablesReadBeforeWrittenIn: (self parseExpression: each).
 		self assert: (read size = 1 and: [read includes: 'read'])]
 ]
 
@@ -42,7 +42,7 @@ RBReadBeforeWrittenTesterTest >> testReadBeforeWritten1 [
 		assertEmpty:
 			(RBReadBeforeWrittenTester
 				variablesReadBeforeWrittenIn:
-					(RBParser
+					(self
 						parseMethod:
 							'addAll: aCollection 
 	"Answer aCollection, having added all elements

--- a/src/AST-Tests-Core/RBVariableNodeTest.class.st
+++ b/src/AST-Tests-Core/RBVariableNodeTest.class.st
@@ -3,7 +3,7 @@ SUnit tests for RBVariableNode
 "
 Class {
 	#name : #RBVariableNodeTest,
-	#superclass : #TestCase,
+	#superclass : #RBParseTreeTest,
 	#category : #'AST-Tests-Core'
 }
 
@@ -14,7 +14,7 @@ RBVariableNodeTest >> testStartForReplacement [
 	source := 'foo
 	|a b c de d|
 	de := 4'.
-	tree := RBParser parseMethod: source.
+	tree := self parseMethod: source.
 	dTemporary := tree body temporaries last.
 	self assert: dTemporary name equals: #d.
 	self assert: (source copyFrom: dTemporary start to: dTemporary stop) equals: 'd'.
@@ -31,7 +31,7 @@ RBVariableNodeTest >> testStartForReplacement02 [
 	
 d|
 	de := 4'.
-	tree := RBParser parseMethod: source.
+	tree := self parseMethod: source.
 	dTemporary := tree body temporaries last.
 	self assert: dTemporary name equals: #d.
 	self assert: (source copyFrom: dTemporary start to: dTemporary stop) equals: 'd'.

--- a/src/OpalCompiler-Tests/MethodMapTests.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTests.class.st
@@ -31,6 +31,12 @@ MethodMapTests >> inlinedBlockSourceNode [
 
 ]
 
+{ #category : #helpers }
+MethodMapTests >> parseExpression: aString [
+
+	^ RBParser parseExpression: aString
+]
+
 { #category : #'testing - ast mapping' }
 MethodMapTests >> testBlockAndContextSourceNode [
 		
@@ -51,7 +57,7 @@ MethodMapTests >> testBlockAndContextSourceNode [
 MethodMapTests >> testBlockSourceNode [
 	| sourceNode |
 	sourceNode := [ 1 + 2 ] sourceNode.
-	self assert: sourceNode equals: (RBParser parseExpression: '[ 1 + 2 ]').
+	self assert: sourceNode equals: (self parseExpression: '[ 1 + 2 ]').
 
 
 ]
@@ -60,7 +66,7 @@ MethodMapTests >> testBlockSourceNode [
 MethodMapTests >> testBlockWithArgAndEnclosedBlockSourceNode [
 	| sourceNode |
 	sourceNode := [ :arg |  [ arg ] ] sourceNode.
-	self assert: sourceNode equals: (RBParser parseExpression: '[ :arg | [ arg ] ]').
+	self assert: sourceNode equals: (self parseExpression: '[ :arg | [ arg ] ]').
 
 ]
 
@@ -68,7 +74,7 @@ MethodMapTests >> testBlockWithArgAndEnclosedBlockSourceNode [
 MethodMapTests >> testBlockWithEnclosedBlockSourceNode [
 	| sourceNode |
 	sourceNode := [ [ ] ] sourceNode.
-	self assert: sourceNode equals: (RBParser parseExpression: '[ [ ] ]').
+	self assert: sourceNode equals: (self parseExpression: '[ [ ] ]').
 
 ]
 
@@ -76,7 +82,7 @@ MethodMapTests >> testBlockWithEnclosedBlockSourceNode [
 MethodMapTests >> testBlockWithTempsSourceNode [
 	| sourceNode |
 	sourceNode := [ | t1 t2 | ] sourceNode.
-	self assert: sourceNode equals: (RBParser parseExpression: '[ | t1 t2 | ]').
+	self assert: sourceNode equals: (self parseExpression: '[ | t1 t2 | ]').
 
 ]
 
@@ -261,5 +267,5 @@ MethodMapTests >> testThisContextSourceNodeInInlinedMessage [
 	| inlinedBlockSourceNode |
 	inlinedBlockSourceNode := self inlinedBlockSourceNode.
 	self assert: (inlinedBlockSourceNode isKindOf: RBBlockNode).
-	self assert: inlinedBlockSourceNode equals: (RBParser parseExpression: '[ :i | ^ thisContext sourceNode ]')
+	self assert: inlinedBlockSourceNode equals: (self parseExpression: '[ :i | ^ thisContext sourceNode ]')
 ]

--- a/src/Refactoring-Tests-Core/RBAbstractClassVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBAbstractClassVariableTest.class.st
@@ -19,16 +19,16 @@ RBAbstractClassVariableTest >> testAbstractClassVariable [
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	meta := class classSide.
-	self assert: (meta parseTreeFor: #recursiveSelfRule) = (RBParser parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
-	self assert: (meta parseTreeFor: #recursiveSelfRule:) = (RBParser parseMethod: 'recursiveSelfRule: anObject RecursiveSelfRule := anObject').
-	self assert: (meta parseTreeFor: #nuke) = (RBParser parseMethod: 'nuke
+	self assert: (meta parseTreeFor: #recursiveSelfRule) = (self parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
+	self assert: (meta parseTreeFor: #recursiveSelfRule:) = (self parseMethod: 'recursiveSelfRule: anObject RecursiveSelfRule := anObject').
+	self assert: (meta parseTreeFor: #nuke) = (self parseMethod: 'nuke
 							self recursiveSelfRule: nil').
-	self assert: (meta parseTreeFor: #initializeAfterLoad1) = (RBParser parseMethod: 'initializeAfterLoad1
+	self assert: (meta parseTreeFor: #initializeAfterLoad1) = (self parseMethod: 'initializeAfterLoad1
 							self recursiveSelfRule: RBParseTreeSearcher new.
 							self recursiveSelfRule
 								addMethodSearches: #(''`@methodName: `@args | `@temps | self `@methodName: `@args'' ''`@methodName: `@args | `@temps | ^self `@methodName: `@args'')
 										-> [:aNode :answer | true]').
-	self assert: (class parseTreeFor: #checkMethod:) = (RBParser parseMethod: 'checkMethod: aSmalllintContext 
+	self assert: (class parseTreeFor: #checkMethod:) = (self parseMethod: 'checkMethod: aSmalllintContext 
 							class := aSmalllintContext selectedClass.
 							(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
 									[(self class recursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
@@ -62,19 +62,19 @@ RBAbstractClassVariableTest >> testModelAbstractClassVariable [
 		variable: 'ClassVarName1'
 		class: class.
 	self executeRefactoring: refactoring.
-	self assert: (meta parseTreeFor: #classVarName1) = (RBParser parseMethod: 'classVarName1 ^ClassVarName1').
-	self assert: (meta parseTreeFor: #classVarName1:) = (RBParser parseMethod: 'classVarName1: anObject ^ClassVarName1 := anObject').
-	self assert: (meta parseTreeFor: #foo) = (RBParser parseMethod: 'foo
+	self assert: (meta parseTreeFor: #classVarName1) = (self parseMethod: 'classVarName1 ^ClassVarName1').
+	self assert: (meta parseTreeFor: #classVarName1:) = (self parseMethod: 'classVarName1: anObject ^ClassVarName1 := anObject').
+	self assert: (meta parseTreeFor: #foo) = (self parseMethod: 'foo
 					^self classVarName1: self classVarName1 * self classVarName1 * self classVarName1').
-	self assert: (class parseTreeFor: #classVarName1) = (RBParser parseMethod: 'classVarName1
+	self assert: (class parseTreeFor: #classVarName1) = (self parseMethod: 'classVarName1
 							^self class classVarName1').
-	self assert: (class parseTreeFor: #classVarName1:) = (RBParser parseMethod: 'classVarName1: anObject
+	self assert: (class parseTreeFor: #classVarName1:) = (self parseMethod: 'classVarName1: anObject
 							^self class classVarName1: anObject').
-	self assert: (class parseTreeFor: #asdf) = (RBParser parseMethod: 'asdf
+	self assert: (class parseTreeFor: #asdf) = (self parseMethod: 'asdf
 						^self classVarName1: (self class classVarName1: self class classVarName1 + 1)').
-	self assert: ((model classNamed: #Bar) parseTreeFor: #foo) = (RBParser parseMethod: 'foo
+	self assert: ((model classNamed: #Bar) parseTreeFor: #foo) = (self parseMethod: 'foo
 					instVarName1 := instVarName1 + instVarName2 + self class classVarName1').
-	self assert: ((model classNamed: #Bar) parseTreeFor: #foo) = (RBParser parseMethod: 'foo
+	self assert: ((model classNamed: #Bar) parseTreeFor: #foo) = (self parseMethod: 'foo
 						instVarName1 := instVarName1 + instVarName2 + self class classVarName1')
 ]
 
@@ -88,8 +88,8 @@ RBAbstractClassVariableTest >> testModelAbstractClassVariableOverridenMethodsInS
 		variable: 'ClassVarName2'
 		class: class.
 	self executeRefactoring: refactoring.
-	self assert: (meta parseTreeFor: #classVarName21) = (RBParser parseMethod: 'classVarName21 ^ClassVarName2').
-	self assert: (meta parseTreeFor: #classVarName21:) = (RBParser parseMethod: 'classVarName21: anObject ClassVarName2 := anObject')
+	self assert: (meta parseTreeFor: #classVarName21) = (self parseMethod: 'classVarName21 ^ClassVarName2').
+	self assert: (meta parseTreeFor: #classVarName21:) = (self parseMethod: 'classVarName21: anObject ClassVarName2 := anObject')
 ]
 
 { #category : #'failure tests' }

--- a/src/Refactoring-Tests-Core/RBAbstractInstanceVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBAbstractInstanceVariableTest.class.st
@@ -18,10 +18,10 @@ RBAbstractInstanceVariableTest >> testAbstractInstanceVariable [
 		class: RBTransformationRuleTestData.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #class1) = (RBParser parseMethod: 'class1 ^class').
-	self assert: (class parseTreeFor: #class:) = (RBParser parseMethod: 'class: anObject
+	self assert: (class parseTreeFor: #class1) = (self parseMethod: 'class1 ^class').
+	self assert: (class parseTreeFor: #class:) = (self parseMethod: 'class: anObject
 	class := anObject').
-	self assert: (class parseTreeFor: #superSends) = (RBParser parseMethod: 'superSends
+	self assert: (class parseTreeFor: #superSends) = (self parseMethod: 'superSends
 	| rule |
 	rule := RBParseTreeRewriter new.
 	rule addSearch: ''super `@message: ``@args'' 
@@ -32,7 +32,7 @@ RBAbstractInstanceVariableTest >> testAbstractInstanceVariable [
 						ifNone: [nil]) isNil] 
 							-> ''self `@message: ``@args'').
 	self rewriteUsing: rule').
-	self assert: (class parseTreeFor: #checkMethod:) = (RBParser parseMethod: 'checkMethod: aSmalllintContext 
+	self assert: (class parseTreeFor: #checkMethod:) = (self parseMethod: 'checkMethod: aSmalllintContext 
 	self class: aSmalllintContext selectedClass.
 	(rewriteRule executeTree: aSmalllintContext parseTree) 
 		ifTrue: 
@@ -54,21 +54,21 @@ RBAbstractInstanceVariableTest >> testAbstractWithAssignmentUsed [
 				class: class.
 	self executeRefactoring: refactoring.
 	self assert: (class parseTreeFor: #foo) 
-				= (RBParser parseMethod: 'foo
+				= (self parseMethod: 'foo
 						^self instVarName21: 3').
 	self 
-		assert: (class parseTreeFor: #instVarName2:) = (RBParser 
+		assert: (class parseTreeFor: #instVarName2:) = (self 
 						parseMethod: 'instVarName2: anObject
 						self instVarName21: anObject').
 	self 
-		assert: (class parseTreeFor: #instVarName21:) = (RBParser 
+		assert: (class parseTreeFor: #instVarName21:) = (self 
 						parseMethod: 'instVarName21: anObject
 						^instVarName2 := anObject').
 	self assert: (class parseTreeFor: #instVarName2) 
-				= (RBParser parseMethod: 'instVarName2
+				= (self parseMethod: 'instVarName2
 						^instVarName2').
 	self 
-		assert: ((model classNamed: #Bar) parseTreeFor: #foo) = (RBParser 
+		assert: ((model classNamed: #Bar) parseTreeFor: #foo) = (self 
 						parseMethod: 'foo
 						instVarName1 := instVarName1 + self instVarName2 + ClassVarName1')
 ]
@@ -83,20 +83,20 @@ RBAbstractInstanceVariableTest >> testAbstractWithDefaultNamesUsed [
 				class: class.
 	self executeRefactoring: refactoring.
 	self 
-		assert: (class parseTreeFor: #bar) = (RBParser 
+		assert: (class parseTreeFor: #bar) = (self 
 						parseMethod: 'bar
 						"Add one to instVarName1"
 
 						self instVarName11: self instVarName11 + 1').
 	self 
-		assert: (class parseTreeFor: #instVarName11:) = (RBParser 
+		assert: (class parseTreeFor: #instVarName11:) = (self 
 						parseMethod: 'instVarName11: anObject
 						instVarName1 := anObject').
 	self assert: (class parseTreeFor: #instVarName11) 
-				= (RBParser parseMethod: 'instVarName11
+				= (self parseMethod: 'instVarName11
 						^instVarName1').
 	self 
-		assert: ((model classNamed: #Bar) parseTreeFor: #foo) = (RBParser 
+		assert: ((model classNamed: #Bar) parseTreeFor: #foo) = (self 
 						parseMethod: 'foo
 						self instVarName11: self instVarName11 + instVarName2 + ClassVarName1')
 ]
@@ -120,13 +120,13 @@ RBAbstractInstanceVariableTest >> testMetaclassInstanceVariables [
 				class: class.
 	self executeRefactoring: refactoring.
 	self assert: (class parseTreeFor: #foo1) 
-				= (RBParser parseMethod: 'foo1
+				= (self parseMethod: 'foo1
 						^foo').
 	self assert: (class parseTreeFor: #foo:) 
-				= (RBParser parseMethod: 'foo: anObject
+				= (self parseMethod: 'foo: anObject
 						^foo := anObject').
 	self assert: (class parseTreeFor: #zzz) 
-				= (RBParser parseMethod: 'zzz ^self foo: self foo1 + self foo1 * 2')
+				= (self parseMethod: 'zzz ^self foo: self foo1 + self foo1 * 2')
 ]
 
 { #category : #'failure tests' }

--- a/src/Refactoring-Tests-Core/RBAddMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBAddMethodTest.class.st
@@ -18,7 +18,7 @@ RBAddMethodTest >> testAddMethod [
 		toClass: RBBasicLintRuleTestData
 		inProtocols: #(#accessing ).
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBBasicLintRuleTestData) parseTreeFor: #printString1) = (RBParser parseMethod: 'printString1 ^super printString')
+	self assert: ((refactoring model classNamed: #RBBasicLintRuleTestData) parseTreeFor: #printString1) = (self parseMethod: 'printString1 ^super printString')
 ]
 
 { #category : #'failure tests' }
@@ -48,7 +48,7 @@ RBAddMethodTest >> testModelAddMethod [
 				inProtocols: #(#accessing).
 	self executeRefactoring: refactoring.
 	self assert: (class parseTreeFor: #printString1) 
-				= (RBParser parseMethod: 'printString1 ^super printString')
+				= (self parseMethod: 'printString1 ^super printString')
 ]
 
 { #category : #'failure tests' }

--- a/src/Refactoring-Tests-Core/RBAddParameterTest.class.st
+++ b/src/Refactoring-Tests-Core/RBAddParameterTest.class.st
@@ -20,12 +20,12 @@ RBAddParameterTest >> testAddParameterForTwoArgumentMessage [
 		initializer: '#(1.0)'.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: #called:bar:on:) = (RBParser parseMethod: 'called: anObject bar: aBlock on: anObject1
+	self assert: (class parseTreeFor: #called:bar:on:) = (self parseMethod: 'called: anObject bar: aBlock on: anObject1
 							Transcript
 								show: anObject printString;
 								cr.
 								aBlock value').
-	self assert: (class parseTreeFor: #caller) = (RBParser parseMethod: 'caller
+	self assert: (class parseTreeFor: #caller) = (self parseMethod: 'caller
 							| anObject |
 							anObject := 5.
 							self 
@@ -44,9 +44,9 @@ RBAddParameterTest >> testAddParameterThatReferencesGlobalAndLiteral [
 		initializer: 'OrderedCollection new: 5'.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: #testFoo:bar:) = (RBParser parseMethod: 'testFoo: anObject bar: anObject1
+	self assert: (class parseTreeFor: #testFoo:bar:) = (self parseMethod: 'testFoo: anObject bar: anObject1
 								^self class + anObject').
-	self assert: (class parseTreeFor: #callFoo) = (RBParser parseMethod: 'callFoo ^self testFoo: 5 bar: (OrderedCollection new: 5)').
+	self assert: (class parseTreeFor: #callFoo) = (self parseMethod: 'callFoo ^self testFoo: 5 bar: (OrderedCollection new: 5)').
 	self deny: (class directlyDefinesMethod: ('test' , 'Foo:') asSymbol)
 ]
 
@@ -61,9 +61,9 @@ RBAddParameterTest >> testAddParameterThatReferencesModelGlobal [
 		initializer: 'Bar new'.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: #testFoo:bar:) = (RBParser parseMethod: 'testFoo: anObject bar: anObject1
+	self assert: (class parseTreeFor: #testFoo:bar:) = (self parseMethod: 'testFoo: anObject bar: anObject1
 								^self class + anObject').
-	self assert: (class parseTreeFor: #callFoo) = (RBParser parseMethod: 'callFoo ^self testFoo: 5 bar: (Bar new)').
+	self assert: (class parseTreeFor: #callFoo) = (self parseMethod: 'callFoo ^self testFoo: 5 bar: (Bar new)').
 	self deny: (class directlyDefinesMethod: ('test' , 'Foo:') asSymbol)
 ]
 
@@ -77,9 +77,9 @@ RBAddParameterTest >> testAddParameterThatReferencesSelf [
 		initializer: 'self printString'.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: #testFoo:bar:) = (RBParser parseMethod: 'testFoo: anObject bar: anObject1
+	self assert: (class parseTreeFor: #testFoo:bar:) = (self parseMethod: 'testFoo: anObject bar: anObject1
 								^self class + anObject').
-	self assert: (class parseTreeFor: #callFoo) = (RBParser parseMethod: 'callFoo ^self testFoo: 5 bar: (self printString)').
+	self assert: (class parseTreeFor: #callFoo) = (self parseMethod: 'callFoo ^self testFoo: 5 bar: (self printString)').
 	self deny: (class directlyDefinesMethod: ('test' , 'Foo:') asSymbol)
 ]
 

--- a/src/Refactoring-Tests-Core/RBApplyClassDeprecationRefactoringTest.class.st
+++ b/src/Refactoring-Tests-Core/RBApplyClassDeprecationRefactoringTest.class.st
@@ -57,10 +57,10 @@ RBApplyClassDeprecationRefactoringTest >> testModelRenameClass [
 	self assert: (model classNamed: #ClassDeprecatorTestingClassDeprecatedUser) equals: user.
 
 	self assert: (user parseTreeFor: #foo)
-		equals: (RBParser parseMethod: 'foo ^ClassDeprecatorTestingClassReplacement').
+		equals: (self parseMethod: 'foo ^ClassDeprecatorTestingClassReplacement').
 		
 	self assert: (user parseTreeFor: #objectName) 
-		equals: (RBParser parseMethod: 'objectName ^#(ClassDeprecatorTestingClassReplacement)').
+		equals: (self parseMethod: 'objectName ^#(ClassDeprecatorTestingClassReplacement)').
 
 	self assert: user superclass name 
 		equals: #ClassDeprecatorTestingClassReplacement

--- a/src/Refactoring-Tests-Core/RBChildrenToSiblingsTest.class.st
+++ b/src/Refactoring-Tests-Core/RBChildrenToSiblingsTest.class.st
@@ -73,20 +73,20 @@ RBChildrenToSiblingsTest >> testModelChildrenToSibling [
 	self assert: class classSide superclass = superclass classSide.
 	self assert: subclass superclass = superclass.
 	self assert: subclass classSide superclass = superclass classSide.
-	self assert: (superclass parseTreeFor: #same) = (RBParser parseMethod: 'same ^self initialize isKindOf: AbstractSuperclass').
-	self assert: (superclass parseTreeFor: #different) = (RBParser parseMethod: 'different self subclassResponsibility').
-	self assert: (superclass parseTreeFor: #initialize) = (RBParser parseMethod: 'initialize
+	self assert: (superclass parseTreeFor: #same) = (self parseMethod: 'same ^self initialize isKindOf: AbstractSuperclass').
+	self assert: (superclass parseTreeFor: #different) = (self parseMethod: 'different self subclassResponsibility').
+	self assert: (superclass parseTreeFor: #initialize) = (self parseMethod: 'initialize
 							instVarName1 := instVarName2 := ClassVarName1 := ClassVarName2 := 0').
 	self assert: (superclass directlyDefinesInstanceVariable: 'instVarName1').
 	self assert: (superclass directlyDefinesInstanceVariable: 'instVarName2').
 	self assert: (superclass directlyDefinesClassVariable: 'ClassVarName1').
 	self assert: (superclass directlyDefinesClassVariable: 'ClassVarName2').
 	self assert: (superclass classSide directlyDefinesInstanceVariable: 'classInstVarName1').
-	self assert: (superclass classSide parseTreeFor: #foo) = (RBParser parseMethod: 'foo
+	self assert: (superclass classSide parseTreeFor: #foo) = (self parseMethod: 'foo
 							^classInstVarName1 + ClassVarName1 + ClassVarName2').
-	self assert: (superclass classSide parseTreeFor: #new) = (RBParser parseMethod: 'new
+	self assert: (superclass classSide parseTreeFor: #new) = (self parseMethod: 'new
 							^super new initialize').
-	self assert: (superclass classSide parseTreeFor: #bar) = (RBParser parseMethod: 'bar
+	self assert: (superclass classSide parseTreeFor: #bar) = (self parseMethod: 'bar
 							self subclassResponsibility').
 	self deny: (class directlyDefinesInstanceVariable: 'instVarName1').
 	self deny: (class directlyDefinesInstanceVariable: 'instVarName2').
@@ -96,8 +96,8 @@ RBChildrenToSiblingsTest >> testModelChildrenToSibling [
 	self deny: (class directlyDefinesMethod: #same).
 	self deny: (class directlyDefinesMethod: #initialize).
 	self deny: (class classSide directlyDefinesMethod: #new).
-	self assert: (class parseTreeFor: #different) = (RBParser parseMethod: 'different
+	self assert: (class parseTreeFor: #different) = (self parseMethod: 'different
 							^instVarName1 + instVarName2').
-	self assert: (class classSide parseTreeFor: #bar) = (RBParser parseMethod: 'bar
+	self assert: (class classSide parseTreeFor: #bar) = (self parseMethod: 'bar
 							^self printString')
 ]

--- a/src/Refactoring-Tests-Core/RBCreateAccessorsForVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBCreateAccessorsForVariableTest.class.st
@@ -35,8 +35,8 @@ RBCreateAccessorsForVariableTest >> testNewClassVariableAccessors [
 	self denyEmpty: ref changes changes.
 	self assert: ref setterMethod == #foo1:.
 	self assert: ref getterMethod == #foo1.
-	self assert: (class parseTreeFor: #foo1) = (RBParser parseMethod: 'foo1 ^Foo1').
-	self assert: (class parseTreeFor: #foo1:) = (RBParser parseMethod: 'foo1: anObject Foo1 := anObject')
+	self assert: (class parseTreeFor: #foo1) = (self parseMethod: 'foo1 ^Foo1').
+	self assert: (class parseTreeFor: #foo1:) = (self parseMethod: 'foo1: anObject Foo1 := anObject')
 ]
 
 { #category : #tests }
@@ -48,8 +48,8 @@ RBCreateAccessorsForVariableTest >> testNewInstanceVariableAccessors [
 	self denyEmpty: ref changes changes.
 	self assert: ref setterMethod == #foo1:.
 	self assert: ref getterMethod == #foo1.
-	self assert: (class parseTreeFor: #foo1) = (RBParser parseMethod: 'foo1 ^foo1').
-	self assert: (class parseTreeFor: #foo1:) = (RBParser parseMethod: 'foo1: anObject foo1 := anObject')
+	self assert: (class parseTreeFor: #foo1) = (self parseMethod: 'foo1 ^foo1').
+	self assert: (class parseTreeFor: #foo1:) = (self parseMethod: 'foo1: anObject foo1 := anObject')
 ]
 
 { #category : #'failure tests' }

--- a/src/Refactoring-Tests-Core/RBExtractMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBExtractMethodTest.class.st
@@ -58,11 +58,11 @@ RBExtractMethodTest >> testExtractMethodAtEndOfMethodThatNeedsReturn [
 		toReturn: #foo:.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBLintRuleTestData.
-	self assert: (class parseTreeFor: #openEditor) = (RBParser parseMethod: 'openEditor
+	self assert: (class parseTreeFor: #openEditor) = (self parseMethod: 'openEditor
 	| rules |
 	rules := self failedRules.
 	^self foo: rules').
-	self assert: (class parseTreeFor: #foo:) = (RBParser parseMethod: 'foo: rules
+	self assert: (class parseTreeFor: #foo:) = (self parseMethod: 'foo: rules
 	rules isEmpty ifTrue: [^self].
 	rules size == 1 ifTrue: [^rules first viewResults]')
 ]
@@ -81,11 +81,11 @@ RBExtractMethodTest >> testExtractMethodThatMovesTemporaryVariable [
 		toReturn: #foo1.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #superSends) = (RBParser parseMethod: 'superSends
+	self assert: (class parseTreeFor: #superSends) = (self parseMethod: 'superSends
 	| rule |
 	rule := self foo1.
 	self rewriteUsing: rule').
-	self assert: (class parseTreeFor: #foo1) = (RBParser parseMethod: 'foo1 | rule | 	rule := RBParseTreeRewriter new.
+	self assert: (class parseTreeFor: #foo1) = (self parseMethod: 'foo1 | rule | 	rule := RBParseTreeRewriter new.
 	rule addSearch: ''super `@message: ``@args''
 				-> (
 					[:aNode | 
@@ -110,11 +110,11 @@ RBExtractMethodTest >> testExtractMethodThatNeedsArgument [
 		toReturn: #foo:.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #checkMethod:) = (RBParser parseMethod: 'checkMethod: aSmalllintContext 
+	self assert: (class parseTreeFor: #checkMethod:) = (self parseMethod: 'checkMethod: aSmalllintContext 
 	class := aSmalllintContext selectedClass.
 	(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
 			[self foo: aSmalllintContext]').
-	self assert: (class parseTreeFor: #foo:) = (RBParser parseMethod: 'foo: aSmalllintContext (RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
+	self assert: (class parseTreeFor: #foo:) = (self parseMethod: 'foo: aSmalllintContext (RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
 				ifFalse: 
 					[builder compile: rewriteRule tree printString
 						in: class
@@ -135,12 +135,12 @@ RBExtractMethodTest >> testExtractMethodThatNeedsTemporaryVariable [
 		toReturn: #foo:.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBLintRuleTestData.
-	self assert: (class parseTreeFor: #displayName) = (RBParser parseMethod: 'displayName
+	self assert: (class parseTreeFor: #displayName) = (self parseMethod: 'displayName
 	| nameStream |
 	nameStream := WriteStream on: (String new: 64).
 	self foo: nameStream.
 	^nameStream contents').
-	self assert: (class parseTreeFor: #foo:) = (RBParser parseMethod: 'foo: nameStream 	nameStream nextPutAll: self name;
+	self assert: (class parseTreeFor: #foo:) = (self parseMethod: 'foo: nameStream 	nameStream nextPutAll: self name;
 		nextPutAll: '' (''.
 	self problemCount printOn: nameStream.
 	nameStream nextPut: $).')
@@ -161,9 +161,9 @@ RBExtractMethodTest >> testModelExtractMethodWithTemporariesSelected [
 	self setupMethodNameFor: refactoring toReturn: #foobar.
 	self executeRefactoring: refactoring.
 	self assert: (class parseTreeFor: #foo) 
-				= (RBParser parseMethod: 'foo [self foobar] value').
+				= (self parseMethod: 'foo [self foobar] value').
 	self assert: (class parseTreeFor: #foobar) 
-				= (RBParser parseMethod: 'foobar |temp | temp := 5. ^temp * temp')
+				= (self parseMethod: 'foobar |temp | temp := 5. ^temp * temp')
 ]
 
 { #category : #tests }
@@ -182,11 +182,11 @@ RBExtractMethodTest >> testModelExtractMethodWithTemporaryAssigned [
 	self setupMethodNameFor: refactoring toReturn: #foobar.
 	self executeRefactoring: refactoring.
 	self assert: (class parseTreeFor: #foo) 
-				= (RBParser parseMethod: 'foo | temp | temp := self foobar. ^temp * temp').
+				= (self parseMethod: 'foo | temp | temp := self foobar. ^temp * temp').
 	self 
-		assert: ((class parseTreeFor: #foobar) = (RBParser 
+		assert: ((class parseTreeFor: #foobar) = (self 
 						parseMethod: 'foobar | bar temp | bar := 5. temp := bar * bar. Transcript show: temp printString; cr. ^temp.')) |
-				((class parseTreeFor: #foobar) = (RBParser 
+				((class parseTreeFor: #foobar) = (self 
 						parseMethod: 'foobar | temp bar | bar := 5. temp := bar * bar. Transcript show: temp printString; cr. ^temp.'))
 ]
 

--- a/src/Refactoring-Tests-Core/RBExtractMethodToComponentTest.class.st
+++ b/src/Refactoring-Tests-Core/RBExtractMethodToComponentTest.class.st
@@ -68,11 +68,11 @@ RBExtractMethodToComponentTest >> testExtractMethodAtEndOfMethodThatNeedsReturn 
 	class := refactoring model classNamed: #RBLintRuleTestData.
 	selectorsSize := class selectors size.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
-	self assert: (class parseTreeFor: #openEditor) = (RBParser parseMethod: 'openEditor
+	self assert: (class parseTreeFor: #openEditor) = (self parseMethod: 'openEditor
 								| rules |
 								rules := self failedRules.
 								^rules foo: self').
-	self assert: ((refactoring model classNamed: #Collection) parseTreeFor: #foo:) = (RBParser parseMethod: 'foo: asdf
+	self assert: ((refactoring model classNamed: #Collection) parseTreeFor: #foo:) = (self parseMethod: 'foo: asdf
 								self isEmpty ifTrue: [^asdf].
 								self size == 1 ifTrue: [^self first viewResults].
 								^asdf').
@@ -95,11 +95,11 @@ RBExtractMethodToComponentTest >> testMoveWithoutSelfReference [
 	selectorsSize := class selectors size.
 	self executeRefactoring: refactoring.
 	self 
-		assert: (class parseTreeFor: #copyDictionary:) = (RBParser 
+		assert: (class parseTreeFor: #copyDictionary:) = (self 
 						parseMethod: 'copyDictionary: aDictionary ^aDictionary copyWithAssociations').
 	self 
 		assert: ((refactoring model classNamed: #Dictionary) 
-				parseTreeFor: #copyWithAssociations) = (RBParser 
+				parseTreeFor: #copyWithAssociations) = (self 
 							parseMethod: 'copyWithAssociations 
 							| newDictionary |
 							newDictionary := Dictionary new: self size.

--- a/src/Refactoring-Tests-Core/RBExtractToTemporaryTest.class.st
+++ b/src/Refactoring-Tests-Core/RBExtractToTemporaryTest.class.st
@@ -52,7 +52,7 @@ RBExtractToTemporaryTest >> testExtractToTemporaryForLastStatementInBlock [
 		from: #caller2
 		in: RBRefactoryTestDataApp.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #caller2) = (RBParser parseMethod: 'caller2
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #caller2) = (self parseMethod: 'caller2
 	^(1 to: 10) inject: 1 into: [:sum :each | | temp | temp := sum * (self foo: each). temp]')
 ]
 
@@ -67,7 +67,7 @@ RBExtractToTemporaryTest >> testExtractToTemporaryInsideBlock [
 		from: #noMoveDefinition
 		in: RBRefactoryTestDataApp.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #noMoveDefinition) = (RBParser parseMethod: 'noMoveDefinition
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #noMoveDefinition) = (self parseMethod: 'noMoveDefinition
 	| temp |
 	^(self collect: 
 			[:each | 
@@ -87,7 +87,7 @@ RBExtractToTemporaryTest >> testExtractToTemporaryWithDuplicates [
 		from: #demoMethodWithDuplicates
 		in: RBRefactoryTestDataApp.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #demoMethodWithDuplicates) = (RBParser parseMethod: 'demoMethodWithDuplicates
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #demoMethodWithDuplicates) = (self parseMethod: 'demoMethodWithDuplicates
 	| a b result1 result2 answer temp |
 	a := 3.
 	temp := a + 5.

--- a/src/Refactoring-Tests-Core/RBInlineAllMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBInlineAllMethodTest.class.st
@@ -11,9 +11,9 @@ RBInlineAllMethodTest >> testInlineMethodWithMultipleSendersInMethod [
 		sendersOf: #caller2
 		in: RBRefactoryTestDataApp.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineLast) = (RBParser parseMethod: 'inlineLast
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineLast) = (self parseMethod: 'inlineLast
 	5 = 3 ifTrue: [^self caller] ifFalse: [^(1 to: 10) inject: 1 into: [:sum :each | sum * (self foo: each)]] ').
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #multipleCalls) = (RBParser parseMethod: 'multipleCalls
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #multipleCalls) = (self parseMethod: 'multipleCalls
 	(1 to: 10) inject: 1 into: [:sum :each | sum * (self foo: each)].
 	(1 to: 10) inject: 1 into: [:sum1 :each1 | sum1 * (self foo: each1)]')
 ]
@@ -31,7 +31,7 @@ RBInlineAllMethodTest >> testRecursiveMethod [
 				sendersOf: #foo
 				in: class).
 	self assert: (class parseTreeFor: #foo) 
-				= (RBParser parseMethod: 'foo ^self foo').
+				= (self parseMethod: 'foo ^self foo').
 	self assert: (class parseTreeFor: #bar) 
-				= (RBParser parseMethod: 'bar ^self foo')
+				= (self parseMethod: 'bar ^self foo')
 ]

--- a/src/Refactoring-Tests-Core/RBInlineMethodFromComponentTest.class.st
+++ b/src/Refactoring-Tests-Core/RBInlineMethodFromComponentTest.class.st
@@ -21,7 +21,7 @@ RBInlineMethodFromComponentTest >> testInlineComponentIntoCascadedMessage [
 			setupInlineExpressionFor: refactoring
 			toReturn: false.
 		self executeRefactoring: refactoring ].
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineComponent) = (RBParser parseMethod: 'inlineComponent
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineComponent) = (self parseMethod: 'inlineComponent
 	| a aBehavior |
 	a := 5.
 	aBehavior := a class.
@@ -57,7 +57,7 @@ RBInlineMethodFromComponentTest >> testInlineComponentMethodMax [
 			setupImplementorToInlineFor: refactoring
 			toReturn: class.
 		self executeRefactoring: refactoring ].
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineMax) = (RBParser parseMethod: 'inlineMax
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineMax) = (self parseMethod: 'inlineMax
 								| x y q |
 								x := 5.
 								y := 10.
@@ -85,7 +85,7 @@ RBInlineMethodFromComponentTest >> testInlineEmptyComponentMethod [
 			setupImplementorToInlineFor: refactoring
 			toReturn: (refactoring model classNamed: #Object).
 		self executeRefactoring: refactoring ].
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineComponent) = (RBParser parseMethod: 'inlineComponent
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineComponent) = (self parseMethod: 'inlineComponent
 	| a anObject |
 	a := 5.
 	anObject := a class.
@@ -122,7 +122,7 @@ RBInlineMethodFromComponentTest >> testModelInlineMethodWithSameVariableNames [
 			self setupInlineExpressionFor: refactoring toReturn: false.
 			self executeRefactoring: refactoring].
 	self assert: ((refactoring model classNamed: #Object) parseTreeFor: #foo) 
-				= (RBParser 
+				= (self 
 						parseMethod: 'foo | a b c | a := InlineMethodFromComponentTest new. b := 1. c := 2. ^a + b + c')
 ]
 
@@ -147,7 +147,7 @@ RBInlineMethodFromComponentTest >> testModelInlineMethodWithSameVariableNames1 [
 			self setupImplementorToInlineFor: refactoring toReturn: class.
 			self executeRefactoring: refactoring].
 	self assert: ((refactoring model classNamed: #Object) parseTreeFor: #foo) 
-				= (RBParser 
+				= (self 
 						parseMethod: 'foo | aRectangle temp | aRectangle := 0@0 corner: 1@1. temp := aRectangle. ^aRectangle origin extent: temp extent')
 ]
 
@@ -169,6 +169,6 @@ RBInlineMethodFromComponentTest >> testModelInlineMethodWithSameVariableNames2 [
 			self setupInlineExpressionFor: refactoring toReturn: false.
 			self executeRefactoring: refactoring].
 	self assert: ((refactoring model classNamed: #Object) parseTreeFor: #foo) 
-				= (RBParser 
+				= (self 
 						parseMethod: 'foo | a b c | a := InlineMethodFromComponentTest new. b := 1. c := 2. ^c + b + a')
 ]

--- a/src/Refactoring-Tests-Core/RBInlineMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBInlineMethodTest.class.st
@@ -43,7 +43,7 @@ RBInlineMethodTest >> testInlineMethod [
 		inMethod: #sentNotImplementedInApplication
 		forClass: RBBasicLintRuleTestData class.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model metaclassNamed: #RBBasicLintRuleTestData) parseTreeFor: #sentNotImplementedInApplication) = (RBParser parseMethod: 'sentNotImplementedInApplication
+	self assert: ((refactoring model metaclassNamed: #RBBasicLintRuleTestData) parseTreeFor: #sentNotImplementedInApplication) = (self parseMethod: 'sentNotImplementedInApplication
 									| detector |
 									detector := self new.
 									detector name: ''Messages sent but not implemented in application''.
@@ -96,7 +96,7 @@ RBInlineMethodTest >> testInlineMethod1 [
 		setupInlineExpressionFor: refactoring
 		toReturn: false.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #caller) = (RBParser parseMethod: 'caller 
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #caller) = (self parseMethod: 'caller 
 									| anObject anObject1 | 
 									anObject := 5.
 									anObject1 := anObject + 1.
@@ -119,7 +119,7 @@ RBInlineMethodTest >> testInlineMethod2 [
 		setupInlineExpressionFor: refactoring
 		toReturn: false.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #caller1) = (RBParser parseMethod: 'caller1 
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #caller1) = (self parseMethod: 'caller1 
 								| anObject each1 anObject1 | 
 								anObject := 5.
 								anObject1 := anObject + 1.
@@ -143,7 +143,7 @@ RBInlineMethodTest >> testInlineMethod3 [
 		setupInlineExpressionFor: refactoring
 		toReturn: false.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #caller2) = (RBParser parseMethod: 'caller2
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #caller2) = (self parseMethod: 'caller2
 								^(1 to: 10) inject: 1 into: [:sum :each | sum * ((1 to: 10) inject: each into: [:sum1 :each1 | sum1 + each1])]	')
 ]
 
@@ -160,7 +160,7 @@ RBInlineMethodTest >> testInlineMethod4 [
 		setupInlineExpressionFor: refactoring
 		toReturn: false.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineJunk) = (RBParser parseMethod: 'inlineJunk
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineJunk) = (self parseMethod: 'inlineJunk
 										| asdf bar1 baz1 asdf1 |
 										bar1 := 
 												[:each | 
@@ -187,7 +187,7 @@ RBInlineMethodTest >> testInlineMethod5 [
 		inMethod: #inlineLast
 		forClass: RBRefactoryTestDataApp.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineLast) = (RBParser parseMethod: 'inlineLast
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineLast) = (self parseMethod: 'inlineLast
 									5 = 3 ifTrue: [^self caller] ifFalse: [^	(1 to: 10) inject: 1 into: [:sum :each | sum * (self foo: each)]]')
 ]
 
@@ -206,7 +206,7 @@ RBInlineMethodTest >> testInlineMethodForSuperSend [
 	self executeRefactoring: refactoring.
 	self 
 		assert: ((model classNamed: #RBRenameInstanceVariableChange) 
-				parseTreeFor: #executeNotifying:) = (RBParser 
+				parseTreeFor: #executeNotifying:) = (self 
 							parseMethod: 'executeNotifying: aBlock 
 									| undo undos undo1 |
 									self addNewVariable.
@@ -240,7 +240,7 @@ RBInlineMethodTest >> testInlineRecursiveCascadedMethod [
 		inMethod: #inlineMethod
 		forClass: RBRefactoryTestDataApp.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineMethod) = (RBParser parseMethod: 'inlineMethod
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineMethod) = (self parseMethod: 'inlineMethod
 									| temp temp1 |
 									self foo.
 									temp1 := self foo; inlineMethod; bar.
@@ -260,7 +260,7 @@ RBInlineMethodTest >> testModelInlineRecursiveMethod [
 				forClass: class.
 	self executeRefactoring: refactoring.
 	self 
-		assert: (class parseTreeFor: #foo) = (RBParser 
+		assert: (class parseTreeFor: #foo) = (self 
 						parseMethod: 'foo self bar. self bar. self foo. self bar. self bar')
 ]
 

--- a/src/Refactoring-Tests-Core/RBInlineParameterTest.class.st
+++ b/src/Refactoring-Tests-Core/RBInlineParameterTest.class.st
@@ -21,7 +21,7 @@ RBInlineParameterTest >> testInlineLiteralArray [
 		selector: ('inline' , 'ParameterMethod:') asSymbol.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: #inlineParameterMethod) = (RBParser parseMethod: 'inlineParameterMethod | aSymbol | aSymbol := #(asdf). ^aSymbol isSymbol').
-	self assert: (class parseTreeFor: #sendInlineParameterMethod) = (RBParser parseMethod: 'sendInlineParameterMethod ^self inlineParameterMethod').
+	self assert: (class parseTreeFor: #inlineParameterMethod) = (self parseMethod: 'inlineParameterMethod | aSymbol | aSymbol := #(asdf). ^aSymbol isSymbol').
+	self assert: (class parseTreeFor: #sendInlineParameterMethod) = (self parseMethod: 'sendInlineParameterMethod ^self inlineParameterMethod').
 	self deny: (class directlyDefinesMethod: ('inline' , 'ParameterMethod:') asSymbol)
 ]

--- a/src/Refactoring-Tests-Core/RBInlineTemporaryTest.class.st
+++ b/src/Refactoring-Tests-Core/RBInlineTemporaryTest.class.st
@@ -14,7 +14,7 @@ RBInlineTemporaryTest >> testInlineTemporary [
 		from: #inlineMethod
 		in: RBRefactoryTestDataApp.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineMethod) = (RBParser parseMethod: 'inlineMethod
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineMethod) = (self parseMethod: 'inlineMethod
 										^self
 													foo;
 													inlineMethod;

--- a/src/Refactoring-Tests-Core/RBMoveMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBMoveMethodTest.class.st
@@ -23,8 +23,8 @@ RBMoveMethodTest >> testMoveMethodIntoArgument [
 			toReturn: #foo:.
 		self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #checkMethod:) = (RBParser parseMethod: 'checkMethod: aSmalllintContext aSmalllintContext foo: self').
-	self assert: ((refactoring model classNamed: #RBSmalllintContext) parseTreeFor: #foo:) = (RBParser parseMethod: 'foo: transformationRule
+	self assert: (class parseTreeFor: #checkMethod:) = (self parseMethod: 'checkMethod: aSmalllintContext aSmalllintContext foo: self').
+	self assert: ((refactoring model classNamed: #RBSmalllintContext) parseTreeFor: #foo:) = (self parseMethod: 'foo: transformationRule
 	transformationRule class: self selectedClass.
 	(transformationRule rewriteRule executeTree: self parseTree) ifTrue: 
 			[(transformationRule class recursiveSelfRule executeTree: transformationRule rewriteRule tree initialAnswer: false)
@@ -32,14 +32,14 @@ RBMoveMethodTest >> testMoveMethodIntoArgument [
 					[transformationRule builder compile: transformationRule rewriteRule tree printString
 						in: transformationRule class1
 						classified: self protocols]]').
-	self assert: (class parseTreeFor: #class1) = (RBParser parseMethod: 'class1 ^class').
-	self assert: (class parseTreeFor: #class:) = (RBParser parseMethod: 'class: anObject class := anObject').
-	self assert: (class classSide parseTreeFor: #recursiveSelfRule:) = (RBParser parseMethod: 'recursiveSelfRule: anObject RecursiveSelfRule := anObject').
-	self assert: (class classSide parseTreeFor: #recursiveSelfRule) = (RBParser parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
-	self assert: (class parseTreeFor: #builder) = (RBParser parseMethod: 'builder ^builder').
-	self assert: (class parseTreeFor: #builder:) = (RBParser parseMethod: 'builder: anObject builder := anObject').
-	self assert: (class parseTreeFor: #rewriteRule) = (RBParser parseMethod: 'rewriteRule ^rewriteRule').
-	self assert: (class parseTreeFor: #rewriteRule:) = (RBParser parseMethod: 'rewriteRule: anObject rewriteRule := anObject')
+	self assert: (class parseTreeFor: #class1) = (self parseMethod: 'class1 ^class').
+	self assert: (class parseTreeFor: #class:) = (self parseMethod: 'class: anObject class := anObject').
+	self assert: (class classSide parseTreeFor: #recursiveSelfRule:) = (self parseMethod: 'recursiveSelfRule: anObject RecursiveSelfRule := anObject').
+	self assert: (class classSide parseTreeFor: #recursiveSelfRule) = (self parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
+	self assert: (class parseTreeFor: #builder) = (self parseMethod: 'builder ^builder').
+	self assert: (class parseTreeFor: #builder:) = (self parseMethod: 'builder: anObject builder := anObject').
+	self assert: (class parseTreeFor: #rewriteRule) = (self parseMethod: 'rewriteRule ^rewriteRule').
+	self assert: (class parseTreeFor: #rewriteRule:) = (self parseMethod: 'rewriteRule: anObject rewriteRule := anObject')
 ]
 
 { #category : #tests }
@@ -62,8 +62,8 @@ RBMoveMethodTest >> testMoveMethodIntoClassVariable [
 			withArguments: #('transformationRule' 'aSmalllintContext' ).
 		self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #checkMethod:) = (RBParser parseMethod: 'checkMethod: aSmalllintContext RecursiveSelfRule foo: self foo: aSmalllintContext').
-	self assert: ((refactoring model classNamed: #RBParseTreeSearcher) parseTreeFor: #foo:foo:) = (RBParser parseMethod: 'foo: transformationRule foo: aSmalllintContext
+	self assert: (class parseTreeFor: #checkMethod:) = (self parseMethod: 'checkMethod: aSmalllintContext RecursiveSelfRule foo: self foo: aSmalllintContext').
+	self assert: ((refactoring model classNamed: #RBParseTreeSearcher) parseTreeFor: #foo:foo:) = (self parseMethod: 'foo: transformationRule foo: aSmalllintContext
 	transformationRule class: aSmalllintContext selectedClass.
 	(transformationRule rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
 			[(self executeTree: transformationRule rewriteRule tree initialAnswer: false)
@@ -71,12 +71,12 @@ RBMoveMethodTest >> testMoveMethodIntoClassVariable [
 					[transformationRule builder compile: transformationRule rewriteRule tree printString
 						in: transformationRule class1
 						classified: aSmalllintContext protocols]]').
-	self assert: (class parseTreeFor: #class1) = (RBParser parseMethod: 'class1 ^class').
-	self assert: (class parseTreeFor: #class:) = (RBParser parseMethod: 'class: anObject class := anObject').
-	self assert: (class parseTreeFor: #builder) = (RBParser parseMethod: 'builder ^builder').
-	self assert: (class parseTreeFor: #builder:) = (RBParser parseMethod: 'builder: anObject builder := anObject').
-	self assert: (class parseTreeFor: #rewriteRule) = (RBParser parseMethod: 'rewriteRule ^rewriteRule').
-	self assert: (class parseTreeFor: #rewriteRule:) = (RBParser parseMethod: 'rewriteRule: anObject rewriteRule := anObject')
+	self assert: (class parseTreeFor: #class1) = (self parseMethod: 'class1 ^class').
+	self assert: (class parseTreeFor: #class:) = (self parseMethod: 'class: anObject class := anObject').
+	self assert: (class parseTreeFor: #builder) = (self parseMethod: 'builder ^builder').
+	self assert: (class parseTreeFor: #builder:) = (self parseMethod: 'builder: anObject builder := anObject').
+	self assert: (class parseTreeFor: #rewriteRule) = (self parseMethod: 'rewriteRule ^rewriteRule').
+	self assert: (class parseTreeFor: #rewriteRule:) = (self parseMethod: 'rewriteRule: anObject rewriteRule := anObject')
 ]
 
 { #category : #tests }
@@ -99,8 +99,8 @@ RBMoveMethodTest >> testMoveMethodIntoInstanceVariable [
 			withArguments: #('transformationRule' 'aSmalllintContext' ).
 		self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #checkMethod:) = (RBParser parseMethod: 'checkMethod: aSmalllintContext rewriteRule foo: self foo: aSmalllintContext').
-	self assert: ((refactoring model classNamed: #RBParseTreeRewriter) parseTreeFor: #foo:foo:) = (RBParser parseMethod: 'foo: transformationRule foo: aSmalllintContext
+	self assert: (class parseTreeFor: #checkMethod:) = (self parseMethod: 'checkMethod: aSmalllintContext rewriteRule foo: self foo: aSmalllintContext').
+	self assert: ((refactoring model classNamed: #RBParseTreeRewriter) parseTreeFor: #foo:foo:) = (self parseMethod: 'foo: transformationRule foo: aSmalllintContext
 	transformationRule class: aSmalllintContext selectedClass.
 	(self executeTree: aSmalllintContext parseTree) ifTrue: 
 			[(transformationRule class recursiveSelfRule executeTree: self tree initialAnswer: false)
@@ -108,12 +108,12 @@ RBMoveMethodTest >> testMoveMethodIntoInstanceVariable [
 					[transformationRule builder compile: self tree printString
 						in: transformationRule class1
 						classified: aSmalllintContext protocols]]').
-	self assert: (class parseTreeFor: #class1) = (RBParser parseMethod: 'class1 ^class').
-	self assert: (class parseTreeFor: #class:) = (RBParser parseMethod: 'class: anObject class := anObject').
-	self assert: (class classSide parseTreeFor: #recursiveSelfRule:) = (RBParser parseMethod: 'recursiveSelfRule: anObject RecursiveSelfRule := anObject').
-	self assert: (class classSide parseTreeFor: #recursiveSelfRule) = (RBParser parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
-	self assert: (class parseTreeFor: #builder) = (RBParser parseMethod: 'builder ^builder').
-	self assert: (class parseTreeFor: #builder:) = (RBParser parseMethod: 'builder: anObject builder := anObject')
+	self assert: (class parseTreeFor: #class1) = (self parseMethod: 'class1 ^class').
+	self assert: (class parseTreeFor: #class:) = (self parseMethod: 'class: anObject class := anObject').
+	self assert: (class classSide parseTreeFor: #recursiveSelfRule:) = (self parseMethod: 'recursiveSelfRule: anObject RecursiveSelfRule := anObject').
+	self assert: (class classSide parseTreeFor: #recursiveSelfRule) = (self parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
+	self assert: (class parseTreeFor: #builder) = (self parseMethod: 'builder ^builder').
+	self assert: (class parseTreeFor: #builder:) = (self parseMethod: 'builder: anObject builder := anObject')
 ]
 
 { #category : #tests }
@@ -135,8 +135,8 @@ RBMoveMethodTest >> testMoveMethodThatReferencesPoolDictionary [
 			toReturn: #junk1.
 		self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBLintRuleTestData.
-	self assert: (class parseTreeFor: #junk) = (RBParser parseMethod: 'junk ^RefactoryTestDataApp junk1').
-	self assert: ((refactoring model metaclassNamed: #RBRefactoryTestDataApp) parseTreeFor: #junk1) = (RBParser parseMethod: 'junk1
+	self assert: (class parseTreeFor: #junk) = (self parseMethod: 'junk ^RefactoryTestDataApp junk1').
+	self assert: ((refactoring model metaclassNamed: #RBRefactoryTestDataApp) parseTreeFor: #junk1) = (self parseMethod: 'junk1
 	^RBRefactoryTestDataApp printString copyFrom: 1 to: CR').
 	self assert: (class directlyDefinesPoolDictionary: 'TextConstants' asSymbol)
 ]

--- a/src/Refactoring-Tests-Core/RBMoveVariableDefinitionTest.class.st
+++ b/src/Refactoring-Tests-Core/RBMoveVariableDefinitionTest.class.st
@@ -14,7 +14,7 @@ RBMoveVariableDefinitionTest >> testMoveDefinition [
 		in: RBRefactoryTestDataApp
 		selector: #moveDefinition.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #moveDefinition) = (RBParser parseMethod: 'moveDefinition
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #moveDefinition) = (self parseMethod: 'moveDefinition
 								^(self collect: 
 										[:each | 
 										| temp |
@@ -37,7 +37,7 @@ RBMoveVariableDefinitionTest >> testMoveDefinitionIntoBlockThatIsAReceiverOfACas
 		in: RBRefactoryTestDataApp
 		selector: #referencesConditionFor:.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #referencesConditionFor:) = (RBParser parseMethod: 'referencesConditionFor: aClass 
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #referencesConditionFor:) = (self parseMethod: 'referencesConditionFor: aClass 
 								| environment  |
 								^(RBCondition withBlock: 
 										[| association |association := Smalltalk globals associationAt: aClass name

--- a/src/Refactoring-Tests-Core/RBProtectInstanceVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBProtectInstanceVariableTest.class.st
@@ -12,9 +12,9 @@ RBProtectInstanceVariableTest >> testProtectInstanceVariable [
 		class: RBSubclassOfClassToRename.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBSubclassOfClassToRename.
-	self assert: (class parseTreeFor: #calls1) = (RBParser parseMethod: 'calls1
+	self assert: (class parseTreeFor: #calls1) = (self parseMethod: 'calls1
 								^rewriteRule1 := (rewriteRule1 := self calls)').
-	self assert: (class parseTreeFor: #calls) = (RBParser parseMethod: 'calls
+	self assert: (class parseTreeFor: #calls) = (self parseMethod: 'calls
 								^rewriteRule1 := rewriteRule1 , rewriteRule1').
 	self deny: (class directlyDefinesMethod: ('rewrite' , 'Rule1') asSymbol).
 	self deny: (class directlyDefinesMethod: ('rewrite' , 'Rule1:') asSymbol)

--- a/src/Refactoring-Tests-Core/RBPullUpMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBPullUpMethodTest.class.st
@@ -22,7 +22,7 @@ RBPullUpMethodTest >> testPullUpAndCopyDown [
 				pullUp: #(#yourself)
 				from: class).
 	self assert: (class superclass parseTreeFor: #yourself) 
-				= (RBParser parseMethod: 'yourself ^1').
+				= (self parseMethod: 'yourself ^1').
 	self deny: (class directlyDefinesMethod: #yourself).
 	class := model classNamed: #Foo2.
 	self assert: (class directlyDefinesMethod: #yourself).
@@ -52,9 +52,9 @@ RBPullUpMethodTest >> testPullUpMethodWithCopyOverriddenMethodsDown [
 			pullUp: #(#isComposite )
 			from: RBCompositeLintRuleTestData.
 		self executeRefactoring: refactoring ].
-	self assert: ((refactoring model classNamed: #RBBasicLintRuleTestData) parseTreeFor: #isComposite) = (RBParser parseMethod: 'isComposite ^false').
-	self assert: ((refactoring model classNamed: ('RBFoo' , 'LintRuleTestData') asSymbol) parseTreeFor: #isComposite) = (RBParser parseMethod: 'isComposite ^false').
-	self assert: ((refactoring model classNamed: #RBLintRuleTestData) parseTreeFor: #isComposite) = (RBParser parseMethod: 'isComposite ^true').
+	self assert: ((refactoring model classNamed: #RBBasicLintRuleTestData) parseTreeFor: #isComposite) = (self parseMethod: 'isComposite ^false').
+	self assert: ((refactoring model classNamed: ('RBFoo' , 'LintRuleTestData') asSymbol) parseTreeFor: #isComposite) = (self parseMethod: 'isComposite ^false').
+	self assert: ((refactoring model classNamed: #RBLintRuleTestData) parseTreeFor: #isComposite) = (self parseMethod: 'isComposite ^true').
 	self deny: ((refactoring model classNamed: #RBCompositeLintRuleTestData) directlyDefinesMethod: #isComposite)
 ]
 

--- a/src/Refactoring-Tests-Core/RBPushDownMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBPushDownMethodTest.class.st
@@ -15,7 +15,7 @@ RBPushDownMethodTest >> testPushDownMethod [
 	self deny: (class directlyDefinesMethod: #name:).
 	class subclasses do: 
 		[ :each | 
-		self assert: (each parseTreeFor: #name:) = (RBParser parseMethod: 'name: aString name := aString') ]
+		self assert: (each parseTreeFor: #name:) = (self parseMethod: 'name: aString name := aString') ]
 ]
 
 { #category : #'failure tests' }

--- a/src/Refactoring-Tests-Core/RBRefactoringBrowserTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRefactoringBrowserTest.class.st
@@ -27,6 +27,18 @@ RBRefactoringBrowserTest >> objectClassVariable [
 	^Object classPool keys detect: [:each | true]
 ]
 
+{ #category : #helpers }
+RBRefactoringBrowserTest >> parseExpression: aString [
+
+	^ RBParser parseExpression: aString
+]
+
+{ #category : #helpers }
+RBRefactoringBrowserTest >> parseMethod: aString [ 
+
+	^ RBParser parseMethod: aString
+]
+
 { #category : #private }
 RBRefactoringBrowserTest >> proceedThroughWarning: aBlock [ 
 	aBlock on: RBRefactoringWarning do: [ :ex | ex resume ]

--- a/src/Refactoring-Tests-Core/RBRemoveParameterTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRemoveParameterTest.class.st
@@ -40,9 +40,9 @@ RBRemoveParameterTest >> testRemoveParameter [
 		selector: ('rename' , 'ThisMethod:') asSymbol.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: #renameThisMethod) = (RBParser parseMethod: 'renameThisMethod
+	self assert: (class parseTreeFor: #renameThisMethod) = (self parseMethod: 'renameThisMethod
 								^self').
-	self assert: (class parseTreeFor: #callMethod) = (RBParser parseMethod: 'callMethod
+	self assert: (class parseTreeFor: #callMethod) = (self parseMethod: 'callMethod
 								^(self renameThisMethod)').
 	self deny: (class directlyDefinesMethod: ('rename' , 'ThisMethod:') asSymbol)
 ]

--- a/src/Refactoring-Tests-Core/RBRenameClassTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenameClassTest.class.st
@@ -43,9 +43,9 @@ RBRenameClassTest >> testModelRenameClass [
 	self assert: (model includesClassNamed: #Thing).
 	self deny: (model includesClassNamed: #Object).
 	self 
-		assert: (class parseTreeFor: #foo) = (RBParser parseMethod: 'foo ^Thing').
+		assert: (class parseTreeFor: #foo) = (self parseMethod: 'foo ^Thing').
 	self assert: (class parseTreeFor: #objectName) 
-				= (RBParser parseMethod: 'objectName ^#(Thing)').
+				= (self parseMethod: 'objectName ^#(Thing)').
 	self assert: class superclass name = #Thing
 ]
 
@@ -71,9 +71,9 @@ RBRenameClassTest >> testModelRenameSequenceClass [
 	self deny: (model includesClassNamed: #Foo2).
 	self assert: (model includesClassNamed: #Foo3).
 	self assert: ((model classNamed: #Foo3) parseTreeFor: #foo) 
-		= (RBParser parseMethod: 'foo ^ Foo3').
+		= (self parseMethod: 'foo ^ Foo3').
 	self assert: ((model classNamed: #Foo3) parseTreeFor: #objectName) 
-		= (RBParser parseMethod: 'objectName ^ #(Foo3)')
+		= (self parseMethod: 'objectName ^ #(Foo3)')
 ]
 
 { #category : #tests }
@@ -85,7 +85,7 @@ RBRenameClassTest >> testRenameClass [
 	self executeRefactoring: refactoring.
 	self 
 		assert: ((refactoring model classNamed: ('RBNew' , 'ClassName') asSymbol) 
-				parseTreeFor: #method1) = (RBParser parseMethod: 'method1
+				parseTreeFor: #method1) = (self parseMethod: 'method1
 	^self method2').
 	self deny: (refactoring model 
 				includesClassNamed: ('RBClass' , 'ToRename') asSymbol).
@@ -94,10 +94,10 @@ RBRenameClassTest >> testRenameClass [
 	self assert: class superclass 
 				= (refactoring model classNamed: ('RBNew' , 'ClassName') asSymbol).
 	self assert: (class parseTreeFor: #symbolReference) 
-				= (RBParser parseMethod: 'symbolReference
+				= (self parseMethod: 'symbolReference
 								^#RBNewClassName').
 	self assert: (class parseTreeFor: #reference) 
-				= (RBParser parseMethod: 'reference
+				= (self parseMethod: 'reference
 								^RBNewClassName new')
 ]
 

--- a/src/Refactoring-Tests-Core/RBRenameClassVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenameClassVariableTest.class.st
@@ -39,14 +39,14 @@ RBRenameClassVariableTest >> testRenameClassVar [
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	self assert: (class directlyDefinesClassVariable: #RSR).
 	self deny: (class directlyDefinesClassVariable: #RecursiveSelfRule).
-	self assert: (class classSide parseTreeFor: #initializeAfterLoad1) = (RBParser parseMethod: 'initializeAfterLoad1
+	self assert: (class classSide parseTreeFor: #initializeAfterLoad1) = (self parseMethod: 'initializeAfterLoad1
 								RSR := RBParseTreeSearcher new.
 								RSR
 									addMethodSearches: #(''`@methodName: `@args | `@temps | self `@methodName: `@args'' ''`@methodName: `@args | `@temps | ^self `@methodName: `@args'')
 											-> [:aNode :answer | true]').
-	self assert: (class classSide parseTreeFor: #nuke) = (RBParser parseMethod: 'nuke
+	self assert: (class classSide parseTreeFor: #nuke) = (self parseMethod: 'nuke
 								RSR := nil').
-	self assert: (class parseTreeFor: #checkMethod:) = (RBParser parseMethod: 'checkMethod: aSmalllintContext 
+	self assert: (class parseTreeFor: #checkMethod:) = (self parseMethod: 'checkMethod: aSmalllintContext 
 								class := aSmalllintContext selectedClass.
 								(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
 										[(RSR executeTree: rewriteRule tree initialAnswer: false)
@@ -68,8 +68,8 @@ RBRenameClassVariableTest >> testRenameClassVarInSharedPool [
 	class := refactoring model classNamed: #RBSharedPoolForTestData.
 	userClass := refactoring model classNamed: #RBClassUsingSharedPoolForTestData.
 	
-	self assert: (class parseTreeFor: #msg1) = (RBParser parseMethod: 'msg1 ^ VarOne').	
-	self assert: (class parseTreeFor: #msg2) = (RBParser parseMethod: 'msg2 ^ VarOne').	
-	self assert: (userClass parseTreeFor: #msg3) = (RBParser parseMethod: 'msg3 ^ VarOne').	
+	self assert: (class parseTreeFor: #msg1) = (self parseMethod: 'msg1 ^ VarOne').	
+	self assert: (class parseTreeFor: #msg2) = (self parseMethod: 'msg2 ^ VarOne').	
+	self assert: (userClass parseTreeFor: #msg3) = (self parseMethod: 'msg3 ^ VarOne').	
 
 ]

--- a/src/Refactoring-Tests-Core/RBRenameInstanceVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenameInstanceVariableTest.class.st
@@ -32,7 +32,7 @@ RBRenameInstanceVariableTest >> testRenameInstVar [
 		assert:
 			(class parseTreeFor: #checkClass:)
 				=
-					(RBParser
+					(self
 						parseMethod:
 							'checkClass: aSmalllintContext 
 								^asdf value: aSmalllintContext value: result').
@@ -40,7 +40,7 @@ RBRenameInstanceVariableTest >> testRenameInstVar [
 		assert:
 			(class parseTreeFor: #initialize)
 				=
-					(RBParser
+					(self
 						parseMethod:
 							'initialize
 	super initialize.

--- a/src/Refactoring-Tests-Core/RBRenameMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenameMethodTest.class.st
@@ -36,7 +36,7 @@ RBRenameMethodTest >> testRenameMethodPermuteArgs [
 		assert:
 			(class parseTreeFor: ('demoRenameMethod:' , 'PermuteArgs:') asSymbol)
 				=
-					(RBParser
+					(self
 						parseMethod:
 							'demoRenameMethod: arg2 PermuteArgs: arg1 self do: arg1.
 	self do: arg2.
@@ -44,7 +44,7 @@ RBRenameMethodTest >> testRenameMethodPermuteArgs [
 	self
 		assert:
 			(class parseTreeFor: #demoExampleCall)
-				= (RBParser parseMethod: 'demoExampleCall ^self demoRenameMethod: 2 PermuteArgs: 1')
+				= (self parseMethod: 'demoExampleCall ^self demoRenameMethod: 2 PermuteArgs: 1')
 ]
 
 { #category : #tests }
@@ -57,8 +57,8 @@ RBRenameMethodTest >> testRenamePermuteArgs [
 		permutation: #(2 1 ).
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: ('rename:' , 'two:') asSymbol) = (RBParser parseMethod: 'rename: argumentMethod two: this ^self printString, this, argumentMethod').
-	self assert: (class parseTreeFor: #exampleCall) = (RBParser parseMethod: 'exampleCall <sampleInstance> ^self rename: 2 two: 1')
+	self assert: (class parseTreeFor: ('rename:' , 'two:') asSymbol) = (self parseMethod: 'rename: argumentMethod two: this ^self printString, this, argumentMethod').
+	self assert: (class parseTreeFor: #exampleCall) = (self parseMethod: 'exampleCall <sampleInstance> ^self rename: 2 two: 1')
 ]
 
 { #category : #tests }
@@ -93,11 +93,11 @@ RBRenameMethodTest >> testRenameTestMethod [
 		permutation: (1 to: 1).
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: #renameThisMethod2:) = (RBParser parseMethod: 'renameThisMethod2: anArg
+	self assert: (class parseTreeFor: #renameThisMethod2:) = (self parseMethod: 'renameThisMethod2: anArg
 	^self').
-	self assert: (class parseTreeFor: #callMethod) = (RBParser parseMethod: 'callMethod
+	self assert: (class parseTreeFor: #callMethod) = (self parseMethod: 'callMethod
 	^(self renameThisMethod2: 5)').
-	self assert: (class parseTreeFor: #symbolReference) = (RBParser parseMethod: 'symbolReference
+	self assert: (class parseTreeFor: #symbolReference) = (self parseMethod: 'symbolReference
 		^ #(#renameThisMethod2: #(4 #renameThisMethod2:))').
 	self deny: (class directlyDefinesMethod: ('rename' , 'ThisMethod:') asSymbol)
 ]
@@ -112,9 +112,9 @@ RBRenameMethodTest >> testRenameTestMethod1 [
 		permutation: (1 to: 0).
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: #testMethod2) = (RBParser parseMethod: 'testMethod2
+	self assert: (class parseTreeFor: #testMethod2) = (self parseMethod: 'testMethod2
 	^self testMethod2 , ([:each | each testMethod2] value: #(#(#testMethod2) 2 #testMethod2))').
-	self assert: ((refactoring model classNamed: #RBBasicLintRuleTestData) parseTreeFor: #classBlock:) = (RBParser parseMethod: 'classBlock: aBlock
+	self assert: ((refactoring model classNamed: #RBBasicLintRuleTestData) parseTreeFor: #classBlock:) = (self parseMethod: 'classBlock: aBlock
 	classBlock := aBlock testMethod2').
 	self deny: (class directlyDefinesMethod: ('test' , 'Method1') asSymbol)
 ]

--- a/src/Refactoring-Tests-Core/RBRenameTemporaryTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenameTemporaryTest.class.st
@@ -80,7 +80,7 @@ RBRenameTemporaryTest >> testRenameTemporary [
 		in: RBLintRuleTestData
 		selector: #openEditor.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBLintRuleTestData) parseTreeFor: #openEditor) = (RBParser parseMethod: 'openEditor
+	self assert: ((refactoring model classNamed: #RBLintRuleTestData) parseTreeFor: #openEditor) = (self parseMethod: 'openEditor
 								| asdf |
 								asdf := self failedRules.
 								asdf isEmpty ifTrue: [^self].

--- a/src/Refactoring-Tests-Core/RBSplitCascadeRefactoringTest.class.st
+++ b/src/Refactoring-Tests-Core/RBSplitCascadeRefactoringTest.class.st
@@ -26,7 +26,7 @@ RBSplitCascadeRefactoringTest >> testSplitCascadeRefactoring [
 		from: #methodWithCascades
 		in: self class.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBSplitCascadeRefactoringTest) parseTreeFor: #methodWithCascades) equals: (RBParser parseMethod: 'methodWithCascades
+	self assert: ((refactoring model classNamed: #RBSplitCascadeRefactoringTest) parseTreeFor: #methodWithCascades) equals: (self parseMethod: 'methodWithCascades
 	| a receiver |
 	receiver := Object new.
 	receiver initialize.

--- a/src/Refactoring-Tests-Core/RBTemporaryToInstanceVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBTemporaryToInstanceVariableTest.class.st
@@ -45,7 +45,7 @@ RBTemporaryToInstanceVariableTest >> testTemporaryToInstanceVariable [
 		variable: 'nameStream'.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBLintRuleTestData.
-	self assert: (class parseTreeFor: #displayName) = (RBParser parseMethod: 'displayName
+	self assert: (class parseTreeFor: #displayName) = (self parseMethod: 'displayName
 								nameStream := WriteStream on: (String new: 64).
 								nameStream
 									nextPutAll: self name;

--- a/src/Refactoring-Tests-Core/RBVariableTypeTest.class.st
+++ b/src/Refactoring-Tests-Core/RBVariableTypeTest.class.st
@@ -55,7 +55,7 @@ RBVariableTypeTest >> testParseTreeTypes [
 	model := RBClassModelFactory rbNamespace new.
 	types := RBRefactoryTyper 
 				typesFor: 'foo'
-				in: (RBParser 
+				in: (self 
 						parseExpression: 'foo printString; testBasicLintRuleTypes; testParseTreeTypes')
 				model: model.
 	self assert: types size = 1.

--- a/src/Refactoring2-Transformations-Tests/RBAddAccessorsForClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddAccessorsForClassTransformationTest.class.st
@@ -14,9 +14,9 @@ RBAddAccessorsForClassTransformationTest >> testRefactoring [
 	
 	class := refactoring model classNamed: #RBVariableTransformation.
 	self assert: (class parseTreeFor: #variableName)
-		  equals: (RBParser parseMethod: 'variableName ^variableName').
+		  equals: (self parseMethod: 'variableName ^variableName').
 	self assert: (class parseTreeFor: #variableName:)
-		  equals: (RBParser parseMethod: 'variableName: anObject variableName := anObject')
+		  equals: (self parseMethod: 'variableName: anObject variableName := anObject')
 ]
 
 { #category : #testing }
@@ -29,7 +29,7 @@ RBAddAccessorsForClassTransformationTest >> testTransform [
 	
 	class := transformation model classNamed: self changeMock name asSymbol.
 	self assert: (class parseTreeFor: #instVar)
-		  equals: (RBParser parseMethod: 'instVar ^instVar').
+		  equals: (self parseMethod: 'instVar ^instVar').
 	self assert: (class parseTreeFor: #instVar:)
-		  equals: (RBParser parseMethod: 'instVar: anObject instVar := anObject')
+		  equals: (self parseMethod: 'instVar: anObject instVar := anObject')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddMethodTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddMethodTransformationTest.class.st
@@ -58,7 +58,7 @@ RBAddMethodTransformationTest >> testModel [
 		asRefactoring transform.
 		
 	self assert: (class parseTreeFor: #printString1) 
-		  equals: (RBParser parseMethod: 'printString1 ^super printString')
+		  equals: (self parseMethod: 'printString1 ^super printString')
 ]
 
 { #category : #testing }
@@ -72,7 +72,7 @@ RBAddMethodTransformationTest >> testRefactoring [
 						asRefactoring transform.
 	
 	self assert: ((refactoring model classNamed: #RBBasicDummyLintRuleTest) parseTreeFor: #printString1)
-		  equals: (RBParser parseMethod: 'printString1 ^super printString')
+		  equals: (self parseMethod: 'printString1 ^super printString')
 ]
 
 { #category : #testing }
@@ -87,5 +87,5 @@ RBAddMethodTransformationTest >> testTransform [
 	
 	class := transformation model classNamed: self changeMock name.
 	self assert: (class parseTreeFor: #printString1)
-		  equals: (RBParser parseMethod: 'printString1 ^super printString')
+		  equals: (self parseMethod: 'printString1 ^super printString')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorTransformationTest.class.st
@@ -18,8 +18,8 @@ RBAddVariableAccessorTransformationTest >> testNewClassVariableAccessors [
 
 	class := refactoring model metaclassNamed: #RBDummyLintRuleTest.
 	self denyEmpty: refactoring changes changes.
-	self assert: (class parseTreeFor: #foo1) equals: (RBParser parseMethod: 'foo1 ^Foo1').
-	self assert: (class parseTreeFor: #foo1:) equals: (RBParser parseMethod: 'foo1: anObject Foo1 := anObject')
+	self assert: (class parseTreeFor: #foo1) equals: (self parseMethod: 'foo1 ^Foo1').
+	self assert: (class parseTreeFor: #foo1:) equals: (self parseMethod: 'foo1: anObject Foo1 := anObject')
 ]
 
 { #category : #testing }
@@ -29,8 +29,8 @@ RBAddVariableAccessorTransformationTest >> testNewInstanceVariableAccessors [
 
 	class := refactoring model classNamed: #RBDummyLintRuleTest.
 	self denyEmpty: refactoring changes changes.
-	self assert: (class parseTreeFor: #foo1) = (RBParser parseMethod: 'foo1 ^foo1').
-	self assert: (class parseTreeFor: #foo1:) = (RBParser parseMethod: 'foo1: anObject foo1 := anObject')
+	self assert: (class parseTreeFor: #foo1) = (self parseMethod: 'foo1 ^foo1').
+	self assert: (class parseTreeFor: #foo1:) = (self parseMethod: 'foo1: anObject foo1 := anObject')
 ]
 
 { #category : #testing }
@@ -54,8 +54,8 @@ RBAddVariableAccessorTransformationTest >> testRefactoring [
 
 	class := refactoring model classNamed: #RBDummyLintRuleTest.
 	self denyEmpty: refactoring changes changes.
-	self assert: (class parseTreeFor: #foo1) = (RBParser parseMethod: 'foo1 ^foo1').
-	self assert: (class parseTreeFor: #foo1:) = (RBParser parseMethod: 'foo1: anObject foo1 := anObject')
+	self assert: (class parseTreeFor: #foo1) = (self parseMethod: 'foo1 ^foo1').
+	self assert: (class parseTreeFor: #foo1:) = (self parseMethod: 'foo1: anObject foo1 := anObject')
 ]
 
 { #category : #testing }
@@ -70,6 +70,6 @@ RBAddVariableAccessorTransformationTest >> testTransform [
 	self assert: transformation model changes changes size equals: 2.
 	
 	class := transformation model classNamed: self changeMock name asSymbol.
-	self assert: (class parseTreeFor: #instVar) = (RBParser parseMethod: 'instVar ^instVar').
-	self assert: (class parseTreeFor: #instVar:) = (RBParser parseMethod: 'instVar: anObject instVar := anObject')
+	self assert: (class parseTreeFor: #instVar) = (self parseMethod: 'instVar ^instVar').
+	self assert: (class parseTreeFor: #instVar:) = (self parseMethod: 'instVar: anObject instVar := anObject')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBCompositeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBCompositeTransformationTest.class.st
@@ -31,5 +31,5 @@ RBCompositeTransformationTest >> testTransform [
 	class := transformation model classNamed: (self changeMock name, 'Temporary') asSymbol.
 	self assert: (class directlyDefinesInstanceVariable: 'asdf').
 	self assert: (class parseTreeFor: #printString1)
-		  equals: (RBParser parseMethod: 'printString1 ^super printString')
+		  equals: (self parseMethod: 'printString1 ^super printString')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBDeprecateClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBDeprecateClassTransformationTest.class.st
@@ -20,12 +20,12 @@ RBDeprecateClassTransformationTest >> testTransform [
 	class := transformation model metaclassNamed: self changeMock name.
 	
 	self assert: (class parseTreeFor: #new)
-		equals: (RBParser parseMethod: 'new
+		equals: (self parseMethod: 'new
 				self deprecated: ''Use superclass '' on: ''4 May 2016''  in: #Pharo60.
 				^ super new').
 	self assert: (class parseTreeFor: #deprecated)
-		equals: (RBParser parseMethod: 'deprecated ^ true').
+		equals: (self parseMethod: 'deprecated ^ true').
 	self assert: (class parseTreeFor: #systemIcon)
-		equals: (RBParser parseMethod: 'systemIcon
+		equals: (self parseMethod: 'systemIcon
 				^ Smalltalk ui icons iconNamed: #packageDelete').
 ]

--- a/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -80,12 +80,12 @@ RBExtractMethodTransformationTest >> testNeedsReturn [
 	
 	class := refactoring model classNamed: #RBDummyLintRuleTest.
 	self assert: (class parseTreeFor: #openEditor)
-		  equals: (RBParser parseMethod: 'openEditor
+		  equals: (self parseMethod: 'openEditor
 				| rules |
 				rules := self failedRules.
 				^self foo: rules').
 	self assert: (class parseTreeFor: #foo:)
-		  equals: (RBParser parseMethod: 'foo: rules
+		  equals: (self parseMethod: 'foo: rules
 				rules isEmpty ifTrue: [^self].
 				rules size == 1 ifTrue: [^rules first viewResults]')
 ]
@@ -109,12 +109,12 @@ RBExtractMethodTransformationTest >> testRefactoring [
 	
 	class := transformation model classNamed: #RBTransformationRuleTestData.
 	self assert: (class parseTreeFor: #checkMethod:) 
-		  equals: (RBParser parseMethod: 'checkMethod: aSmalllintContext 
+		  equals: (self parseMethod: 'checkMethod: aSmalllintContext 
 			class := aSmalllintContext selectedClass.
 			(rewriteRule executeTree: aSmalllintContext parseTree)
 				ifTrue: [self foo: aSmalllintContext]').	
 	self assert: (class parseTreeFor: #foo:)
-		  equals: (RBParser parseMethod: 'foo: aSmalllintContext 
+		  equals: (self parseMethod: 'foo: aSmalllintContext 
 			(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
 				ifFalse: [ builder
 							compile: rewriteRule tree printString
@@ -151,12 +151,12 @@ RBExtractMethodTransformationTest >> testTransform [
 	
 	class := transformation model classNamed: self changeMock name.		
 	self assert: (class parseTreeFor: #foo) 
-		  equals: (RBParser parseMethod: 'foo
+		  equals: (self parseMethod: 'foo
 													| temp |
 													temp := self foobar.
 													^temp * temp').
 	self assert: (class parseTreeFor: #foobar)
-		  equals: (RBParser parseMethod: 'foobar
+		  equals: (self parseMethod: 'foobar
 													| temp bar |
 													bar := 5.
 													temp := bar * bar.
@@ -180,12 +180,12 @@ RBExtractMethodTransformationTest >> testWithArgument [
 		
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	self assert: (class parseTreeFor: #checkMethod:) 
-		  equals: (RBParser parseMethod: 'checkMethod: aSmalllintContext 
+		  equals: (self parseMethod: 'checkMethod: aSmalllintContext 
 					class := aSmalllintContext selectedClass.
 					(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
 						[self foo: aSmalllintContext]').
 	self assert: (class parseTreeFor: #foo:) 
-		  equals: (RBParser parseMethod: 'foo: aSmalllintContext
+		  equals: (self parseMethod: 'foo: aSmalllintContext
 					(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
 						ifFalse: 
 							[builder compile: rewriteRule tree printString
@@ -212,9 +212,9 @@ RBExtractMethodTransformationTest >> testWithTemporariesSelected [
 	
 	self assert: refactoring model changes changes size equals: 4.
 	self assert: (class parseTreeFor: #foo) 
-		  equals: (RBParser parseMethod: 'foo [self foobar] value').
+		  equals: (self parseMethod: 'foo [self foobar] value').
 	self assert: (class parseTreeFor: #foobar) 
-		  equals: (RBParser parseMethod: 'foobar |temp | temp := 5. ^temp * temp')
+		  equals: (self parseMethod: 'foobar |temp | temp := 5. ^temp * temp')
 ]
 
 { #category : #testing }
@@ -241,9 +241,9 @@ RBExtractMethodTransformationTest >> testWithTemporaryAssigned [
 	
 	self assert: refactoring model changes changes size equals: 4.
 	self assert: (class parseTreeFor: #foo) 
-		  equals: (RBParser parseMethod: 'foo | temp | temp := self foobar. ^temp * temp').
+		  equals: (self parseMethod: 'foo | temp | temp := self foobar. ^temp * temp').
 	self assert: (class parseTreeFor: #foobar) 
-		  equals: (RBParser parseMethod: 'foobar | temp bar | bar := 5. temp := bar * bar. Transcript show: temp printString; cr. ^temp.')
+		  equals: (self parseMethod: 'foobar | temp bar | bar := 5. temp := bar * bar. Transcript show: temp printString; cr. ^temp.')
 ]
 
 { #category : #testing }
@@ -262,12 +262,12 @@ RBExtractMethodTransformationTest >> testWithTemporaryVariable [
 	
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	self assert: (class parseTreeFor: #superSends)
-		  equals: (RBParser parseMethod: 'superSends
+		  equals: (self parseMethod: 'superSends
 				| rule |
 				rule := self foo1.
 				self rewriteUsing: rule').
 	self assert: (class parseTreeFor: #foo1)
-		  equals: (RBParser parseMethod: 'foo1 | rule |
+		  equals: (self parseMethod: 'foo1 | rule |
 				rule := RBParseTreeRewriter new.
 				rule addSearch: ''super `@message: ``@args''
 					-> ([:aNode | 
@@ -294,13 +294,13 @@ RBExtractMethodTransformationTest >> testWithTemporaryVariable2 [
 
 	class := refactoring model classNamed: #RBDummyLintRuleTest.
 	self assert: (class parseTreeFor: #displayName)
-		  equals: (RBParser parseMethod: 'displayName
+		  equals: (self parseMethod: 'displayName
 					| nameStream |
 					nameStream := WriteStream on: (String new: 64).
 					self foo: nameStream.
 					^nameStream contents').
 	self assert: (class parseTreeFor: #foo:)
-		  equals: (RBParser parseMethod: 'foo: nameStream
+		  equals: (self parseMethod: 'foo: nameStream
 					nameStream nextPutAll: self name;
 								nextPutAll: '' (''.
 					self problemCount printOn: nameStream.

--- a/src/Refactoring2-Transformations-Tests/RBMoveTemporaryVariableDefinitionTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveTemporaryVariableDefinitionTransformationTest.class.st
@@ -25,7 +25,7 @@ RBMoveTemporaryVariableDefinitionTransformationTest >> testMoveDefinition [
 		
 	class := transformation model classNamed: #RBDummyRefactoryTestDataApp.
 	self assert: (class parseTreeFor: #moveDefinition)
-		  equals: (RBParser parseMethod: 'moveDefinition
+		  equals: (self parseMethod: 'moveDefinition
 								^(self collect: 
 										[:each | 
 										| temp |
@@ -50,7 +50,7 @@ RBMoveTemporaryVariableDefinitionTransformationTest >> testMoveDefinitionIntoBlo
 							
 	class := transformation model classNamed: #RBDummyRefactoryTestDataApp.
 	self assert: (class parseTreeFor: #referencesConditionFor:)
-		  equals: (RBParser parseMethod: 'referencesConditionFor: aClass 
+		  equals: (self parseMethod: 'referencesConditionFor: aClass 
 						| environment  |
 						^(RBCondition withBlock: 
 								[| association |association := Smalltalk associationAt: aClass name

--- a/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
@@ -23,17 +23,17 @@ RBProtectVariableTransformationTest >> testAccessorsAlreadyExist [
 	
 	class := model classNamed: #Foo.
 	self assert: (class parseTreeFor: #bar)
-		equals: (RBParser parseMethod: 'bar
+		equals: (self parseMethod: 'bar
 			"Add one to instVarName1"
 			self instVarName11: self instVarName11 + 1').
 	self assert: (class parseTreeFor: #instVarName11:) 
-		equals: (RBParser parseMethod: 'instVarName11: anObject
+		equals: (self parseMethod: 'instVarName11: anObject
 			instVarName1 := anObject').
 	self assert: (class parseTreeFor: #instVarName11) 
-		equals: (RBParser parseMethod: 'instVarName11 ^instVarName1').
+		equals: (self parseMethod: 'instVarName11 ^instVarName1').
 		
 	self assert: ((model classNamed: #Bar) parseTreeFor: #foo) 
-		equals: (RBParser parseMethod: 'foo
+		equals: (self parseMethod: 'foo
 			self instVarName11: self instVarName11 + instVarName2 + ClassVarName1')
 ]
 
@@ -48,20 +48,20 @@ RBProtectVariableTransformationTest >> testClassVariable [
 	
 	class := (refactoring model classNamed: #RBTransformationRuleTestData) theMetaClass.
 	self assert: (class parseTreeFor: #recursiveSelfRule)
-			equals: (RBParser parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
+			equals: (self parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
 	self assert: (class parseTreeFor: #recursiveSelfRule:) 
-			equals: (RBParser parseMethod: 'recursiveSelfRule: anObject RecursiveSelfRule := anObject').
+			equals: (self parseMethod: 'recursiveSelfRule: anObject RecursiveSelfRule := anObject').
 	
 	self assert: (class parseTreeFor: #nuke) 
-			equals: (RBParser parseMethod: 'nuke self recursiveSelfRule: nil').
+			equals: (self parseMethod: 'nuke self recursiveSelfRule: nil').
 	self assert: (class parseTreeFor: #initializeAfterLoad1) 
-			equals: (RBParser parseMethod: 'initializeAfterLoad1
+			equals: (self parseMethod: 'initializeAfterLoad1
 				self recursiveSelfRule: RBParseTreeSearcher new.
 				self recursiveSelfRule
 					addMethodSearches: #(''`@methodName: `@args | `@temps | self `@methodName: `@args'' ''`@methodName: `@args | `@temps | ^self `@methodName: `@args'')
 					-> [:aNode :answer | true]').
 	self assert: ((refactoring model classNamed: #RBTransformationRuleTestData) parseTreeFor: #checkMethod:) 
-			equals: (RBParser parseMethod: 'checkMethod: aSmalllintContext 
+			equals: (self parseMethod: 'checkMethod: aSmalllintContext 
 				class := aSmalllintContext selectedClass.
 				(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
 					[(self class recursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
@@ -83,18 +83,18 @@ RBProtectVariableTransformationTest >> testClassVariableInModel [
 	
 	class := (model classNamed: #Foo) theMetaClass.
 	self assert: (class parseTreeFor: #classVarName1) 
-			equals: (RBParser parseMethod: 'classVarName1 ^ClassVarName1').
+			equals: (self parseMethod: 'classVarName1 ^ClassVarName1').
 	self assert: (class parseTreeFor: #classVarName1:) 
-			equals: (RBParser parseMethod: 'classVarName1: anObject ClassVarName1 := anObject').
+			equals: (self parseMethod: 'classVarName1: anObject ClassVarName1 := anObject').
 	
 	self assert: (class parseTreeFor: #foo)
-			equals: (RBParser parseMethod: 'foo
+			equals: (self parseMethod: 'foo
 				^self classVarName1: self classVarName1 * self classVarName1 * self classVarName1').
 					
 	self assert: (class theNonMetaClass parseTreeFor: #classVarName1)
-			equals: (RBParser parseMethod: 'classVarName1 ^self class classVarName1').
+			equals: (self parseMethod: 'classVarName1 ^self class classVarName1').
 	self assert: (class theNonMetaClass parseTreeFor: #classVarName1:) 
-			equals: (RBParser parseMethod: 'classVarName1: anObject
+			equals: (self parseMethod: 'classVarName1: anObject
 				^self class classVarName1: anObject').
 				
 	"self assert: (class theNonMetaClass parseTreeFor: #asdf)
@@ -123,12 +123,12 @@ RBProtectVariableTransformationTest >> testMetaclass [
 		asRefactoring transform.
 				
 	self assert: (class parseTreeFor: #foo1) 
-			equals: (RBParser parseMethod: 'foo1 ^foo').
+			equals: (self parseMethod: 'foo1 ^foo').
 	self assert: (class parseTreeFor: #foo:)
-			equals: (RBParser parseMethod: 'foo: anObject foo := anObject').
+			equals: (self parseMethod: 'foo: anObject foo := anObject').
 			
 	self assert: (class parseTreeFor: #zzz) 
-			equals: (RBParser parseMethod: 'zzz ^self foo: self foo1 + self foo1 * 2')
+			equals: (self parseMethod: 'zzz ^self foo: self foo1 + self foo1 * 2')
 ]
 
 { #category : #testing }
@@ -150,13 +150,13 @@ RBProtectVariableTransformationTest >> testRefactoring [
 						asRefactoring transform.
 	
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #builder) equals: (RBParser parseMethod: 'builder ^builder').
-	self assert: (class parseTreeFor: #builder:) equals: (RBParser parseMethod: 'builder: anObject
+	self assert: (class parseTreeFor: #builder) equals: (self parseMethod: 'builder ^builder').
+	self assert: (class parseTreeFor: #builder:) equals: (self parseMethod: 'builder: anObject
 	builder := anObject').
-	self assert: (class parseTreeFor: #viewResults) equals: (RBParser parseMethod: 'viewResults
+	self assert: (class parseTreeFor: #viewResults) equals: (self parseMethod: 'viewResults
 		self builder inspect.
 		self resetResult').
-	self assert: (class parseTreeFor: #checkMethod:) equals: (RBParser parseMethod: 'checkMethod: aSmalllintContext 
+	self assert: (class parseTreeFor: #checkMethod:) equals: (self parseMethod: 'checkMethod: aSmalllintContext 
 	class := aSmalllintContext selectedClass.
 	(rewriteRule executeTree: aSmalllintContext parseTree) 
 		ifTrue: 
@@ -181,7 +181,7 @@ RBProtectVariableTransformationTest >> testTransform [
 	self assert: (class directlyDefinesLocalMethod: #class1).
 	self assert: (class directlyDefinesLocalMethod: #class:).
 	
-	self assert: (class parseTreeFor: #superSends) equals: (RBParser parseMethod: 
+	self assert: (class parseTreeFor: #superSends) equals: (self parseMethod: 
 	'superSends
 		| rule |
 		rule := RBParseTreeRewriter new.
@@ -194,7 +194,7 @@ RBProtectVariableTransformationTest >> testTransform [
 						-> ''self `@message: ``@args'').
 		self rewriteUsing: rule').
 	
-	self assert: (class parseTreeFor: #checkMethod:) equals: (RBParser parseMethod:
+	self assert: (class parseTreeFor: #checkMethod:) equals: (self parseMethod:
 	'checkMethod: aSmalllintContext 
 		self class: aSmalllintContext selectedClass.
 		(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
@@ -268,13 +268,13 @@ RBProtectVariableTransformationTest >> testWithAssignment [
 	
 	class := model classNamed: #Foo.
 	self assert: (class parseTreeFor: #instVarName2:)
-		equals: (RBParser parseMethod: 'instVarName2: anObject instVarName2 := anObject').
+		equals: (self parseMethod: 'instVarName2: anObject instVarName2 := anObject').
 	self assert: (class parseTreeFor: #instVarName2) 
-		equals: (RBParser parseMethod: 'instVarName2 ^instVarName2').
+		equals: (self parseMethod: 'instVarName2 ^instVarName2').
 	
 	self assert: (class parseTreeFor: #foo)
-		equals: (RBParser parseMethod: 'foo ^self instVarName2: 3').
+		equals: (self parseMethod: 'foo ^self instVarName2: 3').
 	self assert: ((model classNamed: #Bar) parseTreeFor: #foo)
-		equals: (RBParser parseMethod: 'foo
+		equals: (self parseMethod: 'foo
 			instVarName1 := instVarName1 + self instVarName2 + ClassVarName1')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
@@ -24,9 +24,9 @@ RBRemoveDirectAccessToVariableTransformationTest >> testClassVariable [
 	
 	class := (refactoring model classNamed: #RBRefactoryChangeManager) theMetaClass.
 	self assert: (class parseTreeFor: #initialize) 
-			equals: (RBParser parseMethod: 'initialize self nuke. self undoSize: 20').
+			equals: (self parseMethod: 'initialize self nuke. self undoSize: 20').
 	self assert: (class theNonMetaClass parseTreeFor: #addUndo:) 
-			equals: (RBParser parseMethod: 'addUndo: aRefactoringChange
+			equals: (self parseMethod: 'addUndo: aRefactoringChange
 				undo addLast: aRefactoringChange.
 				undo size > self class undoSize
 					ifTrue: [ undo removeFirst ].
@@ -89,7 +89,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testInstanceVariable [
 	
 	class := model classNamed: #Foo.
 	self assert: (class parseTreeFor: #foo) 
-			equals: (RBParser parseMethod: 'foo ^ self instVarName2: 3')
+			equals: (self parseMethod: 'foo ^ self instVarName2: 3')
 ]
 
 { #category : #testing }
@@ -128,13 +128,13 @@ RBRemoveDirectAccessToVariableTransformationTest >> testRefactoring [
 
 	class := refactoring model classNamed: #RBNamespace.
 	self assert: (class parseTreeFor: #includesGlobal:)
-		equals: (RBParser parseMethod: 'includesGlobal: aSymbol 
+		equals: (self parseMethod: 'includesGlobal: aSymbol 
 			(self hasRemoved: aSymbol) ifTrue: [^false].
 			(self includesClassNamed: aSymbol) ifTrue: [^true].
 			self environment at: aSymbol ifAbsent: [^false].
 			^ true').
 	self assert: (class parseTreeFor: #initialize) 
-		equals: (RBParser parseMethod: 'initialize
+		equals: (self parseMethod: 'initialize
 			super initialize.
 			changes := RBRefactoryChangeManager changeFactory compositeRefactoryChange.
 			self environment: RBBrowserEnvironment new.
@@ -156,7 +156,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testTransform [
 	
 	class := transformation model classNamed: #RBTransformationRuleTestData.
 	self assert: (class parseTreeFor: #superSends)
-		  equals: (RBParser parseMethod: 
+		  equals: (self parseMethod: 
 	'superSends
 		| rule |
 		rule := RBParseTreeRewriter new.
@@ -170,7 +170,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testTransform [
 		self rewriteUsing: rule').
 	
 	self assert: (class parseTreeFor: #checkMethod:)
-		  equals: (RBParser parseMethod:
+		  equals: (self parseMethod:
 	'checkMethod: aSmalllintContext 
 		self class: aSmalllintContext selectedClass.
 		(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 

--- a/src/Refactoring2-Transformations-Tests/RBRenameClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameClassTransformationTest.class.st
@@ -62,9 +62,9 @@ RBRenameClassTransformationTest >> testModelRenameSequenceClass [
 	self deny: (model includesClassNamed: #Foo2).
 	self assert: (model includesClassNamed: #Foo3).
 	self assert: ((model classNamed: #Foo3) parseTreeFor: #foo) 
-		  equals: (RBParser parseMethod: 'foo ^ Foo3').
+		  equals: (self parseMethod: 'foo ^ Foo3').
 	self assert: ((model classNamed: #Foo3) parseTreeFor: #objectName) 
-		  equals: (RBParser parseMethod: 'objectName ^ #(Foo3)')
+		  equals: (self parseMethod: 'objectName ^ #(Foo3)')
 ]
 
 { #category : #testing }
@@ -89,9 +89,9 @@ RBRenameClassTransformationTest >> testRefactoring [
 	self assert: (model includesClassNamed: #Thing).
 	self deny: (model includesClassNamed: #Object).
 	self assert: (class parseTreeFor: #foo) 
-		  equals: (RBParser parseMethod: 'foo ^Thing').
+		  equals: (self parseMethod: 'foo ^Thing').
 	self assert: (class parseTreeFor: #objectName) 
-		  equals: (RBParser parseMethod: 'objectName ^#(Thing)').
+		  equals: (self parseMethod: 'objectName ^#(Thing)').
 	self assert: class superclass name equals: #Thing
 ]
 
@@ -108,14 +108,14 @@ RBRenameClassTransformationTest >> testTransform [
 	
 	class := transformation model classNamed: 'RBNewDummyClassName' asSymbol.
 	self assert: (class parseTreeFor: #method1)
-		  equals: (RBParser parseMethod: 'method1 ^ self method2').
+		  equals: (self parseMethod: 'method1 ^ self method2').
 	self deny: (transformation model includesClassNamed: 'RBDummyClassToRename' asSymbol).
 				
 	class := transformation model classNamed: 'RBDummySubclassOfClassToRename' asSymbol.
 	self assert: class superclass 
 		  equals: (transformation model classNamed: 'RBNewDummyClassName' asSymbol).
 	self assert: (class parseTreeFor: #symbolReference) 
-		  equals: (RBParser parseMethod: 'symbolReference ^ #RBNewDummyClassName').
+		  equals: (self parseMethod: 'symbolReference ^ #RBNewDummyClassName').
 	self assert: (class parseTreeFor: #reference) 
-		  equals: (RBParser parseMethod: 'reference ^ RBNewDummyClassName new')
+		  equals: (self parseMethod: 'reference ^ RBNewDummyClassName new')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRenameTemporaryVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameTemporaryVariableTransformationTest.class.st
@@ -67,7 +67,7 @@ RBRenameTemporaryVariableTransformationTest >> testRename [
 							transform.
 							
 	self assert: ((transformation model classNamed: #RBLintRuleTestData) parseTreeFor: #openEditor)
-		  equals: (RBParser parseMethod: 'openEditor
+		  equals: (self parseMethod: 'openEditor
 								| asdf |
 								asdf := self failedRules.
 								asdf isEmpty ifTrue: [^self].

--- a/src/Refactoring2-Transformations-Tests/RBRenameVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameVariableTransformationTest.class.st
@@ -18,15 +18,15 @@ RBRenameVariableTransformationTest >> testClassVariable [
 	self assert: (class directlyDefinesClassVariable: #RSR).
 	self deny: (class directlyDefinesClassVariable: #RecursiveSelfRule).
 	self assert: (class theMetaClass parseTreeFor: #initializeAfterLoad1) 
-		  equals: (RBParser parseMethod: 
+		  equals: (self parseMethod: 
 				'initializeAfterLoad1
 					RSR := RBParseTreeSearcher new.
 					RSR addMethodSearches: #(''`@methodName: `@args | `@temps | self `@methodName: `@args'' ''`@methodName: `@args | `@temps | ^self `@methodName: `@args'')
 						-> [:aNode :answer | true]').
 	self assert: (class theMetaClass parseTreeFor: #nuke) 
-		  equals: (RBParser parseMethod: 'nuke RSR := nil').
+		  equals: (self parseMethod: 'nuke RSR := nil').
 	self assert: (class parseTreeFor: #checkMethod:) 
-		  equals: (RBParser parseMethod: 
+		  equals: (self parseMethod: 
 				'checkMethod: aSmalllintContext 
 					class := aSmalllintContext selectedClass.
 					(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
@@ -60,11 +60,11 @@ RBRenameVariableTransformationTest >> testRefactoring [
 	self assert: (class directlyDefinesInstanceVariable: 'asdf').
 	self deny: (class directlyDefinesInstanceVariable: 'classBlock').
 	self assert: (class parseTreeFor: #checkClass:)
-		  equals: (RBParser parseMethod:
+		  equals: (self parseMethod:
 				'checkClass: aSmalllintContext 
 					^asdf value: aSmalllintContext value: result').
 	self assert: (class parseTreeFor: #initialize)
-		  equals: (RBParser parseMethod:
+		  equals: (self parseMethod:
 				'initialize
 					super initialize.
 					self anInstVar: 1.
@@ -87,11 +87,11 @@ RBRenameVariableTransformationTest >> testTransform [
 	self assert: (class directlyDefinesInstanceVariable: 'asdf').
 	self deny: (class directlyDefinesInstanceVariable: 'classBlock').
 	self assert: (class parseTreeFor: #checkClass:)
-		  equals: (RBParser parseMethod:
+		  equals: (self parseMethod:
 				'checkClass: aSmalllintContext 
 					^asdf value: aSmalllintContext value: result').
 	self assert: (class parseTreeFor: #initialize)
-		  equals: (RBParser parseMethod:
+		  equals: (self parseMethod:
 				'initialize
 					super initialize.
 					self anInstVar: 1.

--- a/src/Refactoring2-Transformations-Tests/RBSplitClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBSplitClassTransformationTest.class.st
@@ -42,12 +42,12 @@ RBSplitClassTransformationTest >> testTransform [
 	self assert: (class instanceVariableNames includes: #newReceiver).
 	
 	self assert: (class parseTreeFor: #receiver:)
-		  equals: (RBParser parseMethod:
+		  equals: (self parseMethod:
 				'receiver: aString
 					newReceiver receiver: aString').
 					
 	self assert: (class parseTreeFor: #receiver)
-		  equals: (RBParser parseMethod:
+		  equals: (self parseMethod:
 				'receiver
 					^ newReceiver receiver 
 						ifNil: [ self receiver: ', 'self' surroundedBySingleQuotes,

--- a/src/Refactoring2-Transformations-Tests/RBTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBTransformationTest.class.st
@@ -103,6 +103,12 @@ RBTransformationTest >> objectClassVariable [
 	^ Object classPool keys detect: [:each | true]
 ]
 
+{ #category : #parsing }
+RBTransformationTest >> parseMethod: aString [
+
+	^ RBParser parseMethod: aString
+]
+
 { #category : #running }
 RBTransformationTest >> perform: aChange do: aBlock [
 	"Perform a change in the system silently, evaluate aBlock and then undo the change again."

--- a/src/SmartSuggestions-Tests/SugsBreakConditionSuggestionTest.class.st
+++ b/src/SmartSuggestions-Tests/SugsBreakConditionSuggestionTest.class.st
@@ -4,13 +4,19 @@ Class {
 	#category : #'SmartSuggestions-Tests'
 }
 
+{ #category : #helpers }
+SugsBreakConditionSuggestionTest >> parseMethod: aString [
+
+	^ RBParser parseMethod: aString
+]
+
 { #category : #tests }
 SugsBreakConditionSuggestionTest >> testMessageSend_conditionBlockProducerMethodAST [
 	self 
 		assert:
 			(SugsBreakConditionSuggestion new conditionBlockProducerMethodAST: 'val msg: arg')
 		equals:
-			(RBParser parseMethod: 'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: ((ThisContext lookupSymbol: #val) msg: (ThisContext lookupSymbol: #arg))]')
+			(self parseMethod: 'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: ((ThisContext lookupSymbol: #val) msg: (ThisContext lookupSymbol: #arg))]')
 ]
 
 { #category : #tests }
@@ -19,7 +25,7 @@ SugsBreakConditionSuggestionTest >> testSelf_conditionBlockProducerMethodAST [
 		assert:
 			(SugsBreakConditionSuggestion new conditionBlockProducerMethodAST: 'self')
 		equals:
-			(RBParser parseMethod: 'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: ThisContext receiver ]')
+			(self parseMethod: 'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: ThisContext receiver ]')
 ]
 
 { #category : #tests }
@@ -28,7 +34,7 @@ SugsBreakConditionSuggestionTest >> testSimpleCondition_conditionBlockProducerMe
 		assert:
 			(SugsBreakConditionSuggestion new conditionBlockProducerMethodAST: 'true')
 		equals:
-			(RBParser parseMethod: 'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: true ]')
+			(self parseMethod: 'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: true ]')
 ]
 
 { #category : #tests }
@@ -37,7 +43,7 @@ SugsBreakConditionSuggestionTest >> testSuperSendNoArg_conditionBlockProducerMet
 		assert:
 			(SugsBreakConditionSuggestion new conditionBlockProducerMethodAST: 'super msg')
 		equals:
-			(RBParser parseMethod: 'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: (ThisContext receiver perform: #msg withArguments: {} inSuperclass: ThisContext receiver class superclass)]')
+			(self parseMethod: 'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: (ThisContext receiver perform: #msg withArguments: {} inSuperclass: ThisContext receiver class superclass)]')
 ]
 
 { #category : #tests }
@@ -46,7 +52,7 @@ SugsBreakConditionSuggestionTest >> testSuperSendWithArgs_conditionBlockProducer
 		assert:
 			(SugsBreakConditionSuggestion new conditionBlockProducerMethodAST: 'super foo: arg1 bar: arg2')
 		equals:
-			(RBParser parseMethod: 'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: (ThisContext receiver perform: #foo:bar: withArguments: {ThisContext lookupSymbol: #arg1. ThisContext lookupSymbol: #arg2.} inSuperclass: ThisContext receiver class superclass)]')
+			(self parseMethod: 'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: (ThisContext receiver perform: #foo:bar: withArguments: {ThisContext lookupSymbol: #arg1. ThisContext lookupSymbol: #arg2.} inSuperclass: ThisContext receiver class superclass)]')
 ]
 
 { #category : #tests }
@@ -55,7 +61,7 @@ SugsBreakConditionSuggestionTest >> testVariableLookup_conditionBlockProducerMet
 		assert:
 			(SugsBreakConditionSuggestion new conditionBlockProducerMethodAST: 'var')
 		equals:
-			(RBParser parseMethod: 'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: (ThisContext lookupSymbol: #var)]')
+			(self parseMethod: 'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: (ThisContext lookupSymbol: #var)]')
 ]
 
 { #category : #tests }
@@ -64,7 +70,7 @@ SugsBreakConditionSuggestionTest >> testVariableNamedThisContext_conditionBlockP
 		assert:
 			(SugsBreakConditionSuggestion new conditionBlockProducerMethodAST: 'ThisContext')
 		equals:
-			(RBParser parseMethod: 'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: (ThisContext lookupSymbol: #ThisContext)]')
+			(self parseMethod: 'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: (ThisContext lookupSymbol: #ThisContext)]')
 ]
 
 { #category : #tests }
@@ -73,5 +79,5 @@ SugsBreakConditionSuggestionTest >> testthisContext_conditionBlockProducerMethod
 		assert:
 			(SugsBreakConditionSuggestion new conditionBlockProducerMethodAST: 'thisContext')
 		equals:
-			(RBParser parseMethod: 'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: ThisContext ]')
+			(self parseMethod: 'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: ThisContext ]')
 ]


### PR DESCRIPTION
Partial fix for #3376.
Removing direct references to RBParser. Extracting them to helper methods in tests.