### PR TITLE
Remove convertInterval:for: of tests of Refactoring

### DIFF
--- a/src/Refactoring-Tests-Core/RBExtractMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBExtractMethodTest.class.st
@@ -7,16 +7,14 @@ Class {
 { #category : #'failure tests' }
 RBExtractMethodTest >> testBadInterval [
 	self
-		shouldFail: (RBExtractMethodRefactoring 
-				extract: (self 
-						convertInterval: (24 to: 30)
-						for: (RBRefactoryTestDataApp sourceCodeAt: #testMethod))
+		shouldFail:
+			(RBExtractMethodRefactoring
+				extract: (24 to: 30)
 				from: #testMethod
 				in: RBRefactoryTestDataApp);
-		shouldFail: (RBExtractMethodRefactoring 
-				extract: (self 
-						convertInterval: (80 to: 147)
-						for: (RBBasicLintRuleTestData class sourceCodeAt: #subclassOf:overrides:))
+		shouldFail:
+			(RBExtractMethodRefactoring
+				extract: (80 to: 147)
 				from: #subclassOf:overrides:
 				in: RBBasicLintRuleTestData class)
 ]
@@ -24,22 +22,19 @@ RBExtractMethodTest >> testBadInterval [
 { #category : #'failure tests' }
 RBExtractMethodTest >> testExtractFailure [
 	self
-		shouldFail: (RBExtractMethodRefactoring 
-				extract: (self 
-						convertInterval: (80 to: 269)
-						for: (RBBasicLintRuleTestData class sourceCodeAt: #subclassOf:overrides:))
+		shouldFail:
+			(RBExtractMethodRefactoring
+				extract: (80 to: 269)
 				from: #subclassOf:overrides:
 				in: RBBasicLintRuleTestData class);
-		shouldFail: (RBExtractMethodRefactoring 
-				extract: (self 
-						convertInterval: (53 to: 56)
-						for: (RBBasicLintRuleTestData class sourceCodeAt: #subclassOf:overrides:))
+		shouldFail:
+			(RBExtractMethodRefactoring
+				extract: (53 to: 56)
 				from: #subclassOf:overrides:
 				in: RBBasicLintRuleTestData class);
-		shouldFail: (RBExtractMethodRefactoring 
-				extract: (self 
-						convertInterval: (77 to: 222)
-						for: (RBBasicLintRuleTestData class sourceCodeAt: #subclassResponsibilityNotDefined))
+		shouldFail:
+			(RBExtractMethodRefactoring
+				extract: (77 to: 222)
 				from: #subclassResponsibilityNotDefined
 				in: RBBasicLintRuleTestData class)
 ]
@@ -47,22 +42,30 @@ RBExtractMethodTest >> testExtractFailure [
 { #category : #tests }
 RBExtractMethodTest >> testExtractMethodAtEndOfMethodThatNeedsReturn [
 	| refactoring class |
-	refactoring := RBExtractMethodRefactoring 
-		extract: (self 
-				convertInterval: (52 to: 133)
-				for: (RBLintRuleTestData sourceCodeAt: #openEditor))
+	refactoring := RBExtractMethodRefactoring
+		extract: (52 to: 133)
 		from: #openEditor
 		in: RBLintRuleTestData.
-	self 
-		setupMethodNameFor: refactoring
-		toReturn: #foo:.
+	self setupMethodNameFor: refactoring toReturn: #foo:.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBLintRuleTestData.
-	self assert: (class parseTreeFor: #openEditor) = (RBParser parseMethod: 'openEditor
+	self
+		assert:
+			(class parseTreeFor: #openEditor)
+				=
+					(RBParser
+						parseMethod:
+							'openEditor
 	| rules |
 	rules := self failedRules.
 	^self foo: rules').
-	self assert: (class parseTreeFor: #foo:) = (RBParser parseMethod: 'foo: rules
+	self
+		assert:
+			(class parseTreeFor: #foo:)
+				=
+					(RBParser
+						parseMethod:
+							'foo: rules
 	rules isEmpty ifTrue: [^self].
 	rules size == 1 ifTrue: [^rules first viewResults]')
 ]
@@ -70,22 +73,30 @@ RBExtractMethodTest >> testExtractMethodAtEndOfMethodThatNeedsReturn [
 { #category : #tests }
 RBExtractMethodTest >> testExtractMethodThatMovesTemporaryVariable [
 	| refactoring class |
-	refactoring := RBExtractMethodRefactoring 
-		extract: (self 
-				convertInterval: (22 to: 280)
-				for: (RBTransformationRuleTestData sourceCodeAt: #superSends))
+	refactoring := RBExtractMethodRefactoring
+		extract: (22 to: 280)
 		from: #superSends
 		in: RBTransformationRuleTestData.
-	self 
-		setupMethodNameFor: refactoring
-		toReturn: #foo1.
+	self setupMethodNameFor: refactoring toReturn: #foo1.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #superSends) = (RBParser parseMethod: 'superSends
+	self
+		assert:
+			(class parseTreeFor: #superSends)
+				=
+					(RBParser
+						parseMethod:
+							'superSends
 	| rule |
 	rule := self foo1.
 	self rewriteUsing: rule').
-	self assert: (class parseTreeFor: #foo1) = (RBParser parseMethod: 'foo1 | rule | 	rule := RBParseTreeRewriter new.
+	self
+		assert:
+			(class parseTreeFor: #foo1)
+				=
+					(RBParser
+						parseMethod:
+							'foo1 | rule | 	rule := RBParseTreeRewriter new.
 	rule addSearch: ''super `@message: ``@args''
 				-> (
 					[:aNode | 
@@ -99,22 +110,30 @@ RBExtractMethodTest >> testExtractMethodThatMovesTemporaryVariable [
 { #category : #tests }
 RBExtractMethodTest >> testExtractMethodThatNeedsArgument [
 	| refactoring class |
-	refactoring := RBExtractMethodRefactoring 
-		extract: (self 
-				convertInterval: (145 to: 343)
-				for: (RBTransformationRuleTestData sourceCodeAt: #checkMethod:))
+	refactoring := RBExtractMethodRefactoring
+		extract: (145 to: 343)
 		from: #checkMethod:
 		in: RBTransformationRuleTestData.
-	self 
-		setupMethodNameFor: refactoring
-		toReturn: #foo:.
+	self setupMethodNameFor: refactoring toReturn: #foo:.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #checkMethod:) = (RBParser parseMethod: 'checkMethod: aSmalllintContext 
+	self
+		assert:
+			(class parseTreeFor: #checkMethod:)
+				=
+					(RBParser
+						parseMethod:
+							'checkMethod: aSmalllintContext 
 	class := aSmalllintContext selectedClass.
 	(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
 			[self foo: aSmalllintContext]').
-	self assert: (class parseTreeFor: #foo:) = (RBParser parseMethod: 'foo: aSmalllintContext (RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
+	self
+		assert:
+			(class parseTreeFor: #foo:)
+				=
+					(RBParser
+						parseMethod:
+							'foo: aSmalllintContext (RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
 				ifFalse: 
 					[builder compile: rewriteRule tree printString
 						in: class
@@ -124,23 +143,31 @@ RBExtractMethodTest >> testExtractMethodThatNeedsArgument [
 { #category : #tests }
 RBExtractMethodTest >> testExtractMethodThatNeedsTemporaryVariable [
 	| refactoring class |
-	refactoring := RBExtractMethodRefactoring 
-		extract: (self 
-				convertInterval: (78 to: 197)
-				for: (RBLintRuleTestData sourceCodeAt: #displayName))
+	refactoring := RBExtractMethodRefactoring
+		extract: (78 to: 197)
 		from: #displayName
 		in: RBLintRuleTestData.
-	self 
-		setupMethodNameFor: refactoring
-		toReturn: #foo:.
+	self setupMethodNameFor: refactoring toReturn: #foo:.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBLintRuleTestData.
-	self assert: (class parseTreeFor: #displayName) = (RBParser parseMethod: 'displayName
+	self
+		assert:
+			(class parseTreeFor: #displayName)
+				=
+					(RBParser
+						parseMethod:
+							'displayName
 	| nameStream |
 	nameStream := WriteStream on: (String new: 64).
 	self foo: nameStream.
 	^nameStream contents').
-	self assert: (class parseTreeFor: #foo:) = (RBParser parseMethod: 'foo: nameStream 	nameStream nextPutAll: self name;
+	self
+		assert:
+			(class parseTreeFor: #foo:)
+				=
+					(RBParser
+						parseMethod:
+							'foo: nameStream 	nameStream nextPutAll: self name;
 		nextPutAll: '' (''.
 	self problemCount printOn: nameStream.
 	nameStream nextPut: $).')

--- a/src/Refactoring-Tests-Core/RBExtractMethodToComponentTest.class.st
+++ b/src/Refactoring-Tests-Core/RBExtractMethodToComponentTest.class.st
@@ -7,16 +7,14 @@ Class {
 { #category : #'failure tests' }
 RBExtractMethodToComponentTest >> testBadInterval [
 	self
-		shouldFail: (RBExtractMethodToComponentRefactoring 
-				extract: (self 
-						convertInterval: (24 to: 30)
-						for: (RBRefactoryTestDataApp sourceCodeAt: #testMethod))
+		shouldFail:
+			(RBExtractMethodToComponentRefactoring
+				extract: (24 to: 30)
 				from: #testMethod
 				in: RBRefactoryTestDataApp);
-		shouldFail: (RBExtractMethodToComponentRefactoring 
-				extract: (self 
-						convertInterval: (80 to: 147)
-						for: (RBBasicLintRuleTestData class sourceCodeAt: #subclassOf:overrides:))
+		shouldFail:
+			(RBExtractMethodToComponentRefactoring
+				extract: (80 to: 147)
 				from: #subclassOf:overrides:
 				in: RBBasicLintRuleTestData class)
 ]
@@ -24,22 +22,19 @@ RBExtractMethodToComponentTest >> testBadInterval [
 { #category : #'failure tests' }
 RBExtractMethodToComponentTest >> testExtractFailure [
 	self
-		shouldFail: (RBExtractMethodToComponentRefactoring 
-				extract: (self 
-						convertInterval: (80 to: 269)
-						for: (RBBasicLintRuleTestData class sourceCodeAt: #subclassOf:overrides:))
+		shouldFail:
+			(RBExtractMethodToComponentRefactoring
+				extract: (80 to: 269)
 				from: #subclassOf:overrides:
 				in: RBBasicLintRuleTestData class);
-		shouldFail: (RBExtractMethodToComponentRefactoring 
-				extract: (self 
-						convertInterval: (53 to: 56)
-						for: (RBBasicLintRuleTestData class sourceCodeAt: #subclassOf:overrides:))
+		shouldFail:
+			(RBExtractMethodToComponentRefactoring
+				extract: (53 to: 56)
 				from: #subclassOf:overrides:
 				in: RBBasicLintRuleTestData class);
-		shouldFail: (RBExtractMethodToComponentRefactoring 
-				extract: (self 
-						convertInterval: (77 to: 222)
-						for: (RBBasicLintRuleTestData class sourceCodeAt: #subclassResponsibilityNotDefined))
+		shouldFail:
+			(RBExtractMethodToComponentRefactoring
+				extract: (77 to: 222)
 				from: #subclassResponsibilityNotDefined
 				in: RBBasicLintRuleTestData class)
 ]
@@ -47,32 +42,36 @@ RBExtractMethodToComponentTest >> testExtractFailure [
 { #category : #tests }
 RBExtractMethodToComponentTest >> testExtractMethodAtEndOfMethodThatNeedsReturn [
 	| refactoring class selectorsSize |
-	refactoring := RBExtractMethodToComponentRefactoring 
-		extract: (self 
-				convertInterval: (52 to: 133)
-				for: (RBLintRuleTestData sourceCodeAt: #openEditor))
+	refactoring := RBExtractMethodToComponentRefactoring
+		extract: (52 to: 133)
 		from: #openEditor
 		in: RBLintRuleTestData.
-	self 
-		setupMethodNameFor: refactoring
-		toReturn: #foo:.
-	self 
-		setupSelfArgumentNameFor: refactoring
-		toReturn: 'asdf'.
-	self 
-		setupVariableToMoveToFor: refactoring
-		toReturn: 'rules'.
-	self 
+	self setupMethodNameFor: refactoring toReturn: #foo:.
+	self setupSelfArgumentNameFor: refactoring toReturn: 'asdf'.
+	self setupVariableToMoveToFor: refactoring toReturn: 'rules'.
+	self
 		setupVariableTypesFor: refactoring
 		toReturn: (Array with: (refactoring model classNamed: #Collection)).
 	class := refactoring model classNamed: #RBLintRuleTestData.
 	selectorsSize := class selectors size.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
-	self assert: (class parseTreeFor: #openEditor) = (RBParser parseMethod: 'openEditor
+	self
+		assert:
+			(class parseTreeFor: #openEditor)
+				=
+					(RBParser
+						parseMethod:
+							'openEditor
 								| rules |
 								rules := self failedRules.
 								^rules foo: self').
-	self assert: ((refactoring model classNamed: #Collection) parseTreeFor: #foo:) = (RBParser parseMethod: 'foo: asdf
+	self
+		assert:
+			((refactoring model classNamed: #Collection) parseTreeFor: #foo:)
+				=
+					(RBParser
+						parseMethod:
+							'foo: asdf
 								self isEmpty ifTrue: [^asdf].
 								self size == 1 ifTrue: [^self first viewResults].
 								^asdf').
@@ -82,25 +81,32 @@ RBExtractMethodToComponentTest >> testExtractMethodAtEndOfMethodThatNeedsReturn 
 { #category : #tests }
 RBExtractMethodToComponentTest >> testMoveWithoutSelfReference [
 	| refactoring class selectorsSize |
-	refactoring := RBExtractMethodToComponentRefactoring 
-				extract: (self convertInterval: (118 to: 286)
-						for: (RBReadBeforeWrittenTester sourceCodeAt: #copyDictionary:))
-				from: #copyDictionary:
-				in: RBReadBeforeWrittenTester.
+	refactoring := RBExtractMethodToComponentRefactoring
+		extract: (118 to: 286)
+		from: #copyDictionary:
+		in: RBReadBeforeWrittenTester.
 	self setupMethodNameFor: refactoring toReturn: #copyWithAssociations.
 	self setupVariableToMoveToFor: refactoring toReturn: 'aDictionary'.
-	self setupVariableTypesFor: refactoring
+	self
+		setupVariableTypesFor: refactoring
 		toReturn: (Array with: (refactoring model classNamed: #Dictionary)).
 	class := refactoring model classNamed: #RBReadBeforeWrittenTester.
 	selectorsSize := class selectors size.
 	self executeRefactoring: refactoring.
-	self 
-		assert: (class parseTreeFor: #copyDictionary:) = (RBParser 
+	self
+		assert:
+			(class parseTreeFor: #copyDictionary:)
+				=
+					(RBParser
 						parseMethod: 'copyDictionary: aDictionary ^aDictionary copyWithAssociations').
-	self 
-		assert: ((refactoring model classNamed: #Dictionary) 
-				parseTreeFor: #copyWithAssociations) = (RBParser 
-							parseMethod: 'copyWithAssociations 
+	self
+		assert:
+			((refactoring model classNamed: #Dictionary)
+				parseTreeFor: #copyWithAssociations)
+				=
+					(RBParser
+						parseMethod:
+							'copyWithAssociations 
 							| newDictionary |
 							newDictionary := Dictionary new: self size.
 							self

--- a/src/Refactoring-Tests-Core/RBExtractToTemporaryTest.class.st
+++ b/src/Refactoring-Tests-Core/RBExtractToTemporaryTest.class.st
@@ -7,24 +7,21 @@ Class {
 { #category : #'failure tests' }
 RBExtractToTemporaryTest >> testBadInterval [
 	self
-		shouldFail: (RBExtractToTemporaryRefactoring 
-				extract: (self 
-						convertInterval: (24 to: 30)
-						for: (RBRefactoryTestDataApp sourceCodeAt: #testMethod))
+		shouldFail:
+			(RBExtractToTemporaryRefactoring
+				extract: (24 to: 30)
 				to: 'asdf'
 				from: #testMethod
 				in: RBRefactoryTestDataApp);
-		shouldFail: (RBExtractToTemporaryRefactoring 
-				extract: (self 
-						convertInterval: (14 to: 105)
-						for: (RBRefactoryTestDataApp sourceCodeAt: #testMethod1))
+		shouldFail:
+			(RBExtractToTemporaryRefactoring
+				extract: (14 to: 105)
 				to: 'asdf'
 				from: #testMethod1
 				in: RBRefactoryTestDataApp);
-		shouldFail: (RBExtractToTemporaryRefactoring 
-				extract: (self 
-						convertInterval: (61 to: 101)
-						for: (RBRefactoryTestDataApp sourceCodeAt: #noMoveDefinition))
+		shouldFail:
+			(RBExtractToTemporaryRefactoring
+				extract: (61 to: 101)
 				to: 'asdf'
 				from: #noMoveDefinition
 				in: RBRefactoryTestDataApp)
@@ -32,42 +29,52 @@ RBExtractToTemporaryTest >> testBadInterval [
 
 { #category : #'failure tests' }
 RBExtractToTemporaryTest >> testBadName [
-	self shouldFail: (RBExtractToTemporaryRefactoring 
-			extract: (self 
-					convertInterval: (14 to: 23)
-					for: (RBRefactoryTestDataApp sourceCodeAt: #testMethod))
-			to: 'a sdf'
-			from: #testMethod
-			in: RBRefactoryTestDataApp)
+	self
+		shouldFail:
+			(RBExtractToTemporaryRefactoring
+				extract: (14 to: 23)
+				to: 'a sdf'
+				from: #testMethod
+				in: RBRefactoryTestDataApp)
 ]
 
 { #category : #tests }
 RBExtractToTemporaryTest >> testExtractToTemporaryForLastStatementInBlock [
 	| refactoring |
-	refactoring := RBExtractToTemporaryRefactoring 
-		extract: (self 
-				convertInterval: (52 to: 73)
-				for: (RBRefactoryTestDataApp sourceCodeAt: #caller2))
+	refactoring := RBExtractToTemporaryRefactoring
+		extract: (52 to: 73)
 		to: 'temp'
 		from: #caller2
 		in: RBRefactoryTestDataApp.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #caller2) = (RBParser parseMethod: 'caller2
+	self
+		assert:
+			((refactoring model classNamed: #RBRefactoryTestDataApp)
+				parseTreeFor: #caller2)
+				=
+					(RBParser
+						parseMethod:
+							'caller2
 	^(1 to: 10) inject: 1 into: [:sum :each | | temp | temp := sum * (self foo: each). temp]')
 ]
 
 { #category : #tests }
 RBExtractToTemporaryTest >> testExtractToTemporaryInsideBlock [
 	| refactoring |
-	refactoring := RBExtractToTemporaryRefactoring 
-		extract: (self 
-				convertInterval: (133 to: 141)
-				for: (RBRefactoryTestDataApp sourceCodeAt: #noMoveDefinition))
+	refactoring := RBExtractToTemporaryRefactoring
+		extract: (133 to: 141)
 		to: 'asdf'
 		from: #noMoveDefinition
 		in: RBRefactoryTestDataApp.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #noMoveDefinition) = (RBParser parseMethod: 'noMoveDefinition
+	self
+		assert:
+			((refactoring model classNamed: #RBRefactoryTestDataApp)
+				parseTreeFor: #noMoveDefinition)
+				=
+					(RBParser
+						parseMethod:
+							'noMoveDefinition
 	| temp |
 	^(self collect: 
 			[:each | 
@@ -80,9 +87,7 @@ RBExtractToTemporaryTest >> testExtractToTemporaryInsideBlock [
 RBExtractToTemporaryTest >> testExtractToTemporaryWithDuplicates [
 	| refactoring |
 	refactoring := RBExtractToTemporaryRefactoring 
-		extract: (self 
-				convertInterval: (73 to: 77)
-				for: (RBRefactoryTestDataApp sourceCodeAt: #demoMethodWithDuplicates))
+		extract: (73 to: 77)
 		to: 'temp'
 		from: #demoMethodWithDuplicates
 		in: RBRefactoryTestDataApp.

--- a/src/Refactoring-Tests-Core/RBInlineMethodFromComponentTest.class.st
+++ b/src/Refactoring-Tests-Core/RBInlineMethodFromComponentTest.class.st
@@ -7,21 +7,24 @@ Class {
 { #category : #tests }
 RBInlineMethodFromComponentTest >> testInlineComponentIntoCascadedMessage [
 	| refactoring |
-	self proceedThroughWarning: 
-		[ refactoring := RBInlineMethodFromComponentRefactoring 
-			inline: (self 
-					convertInterval: (35 to: 79)
-					for: (RBRefactoryTestDataApp sourceCodeAt: #inlineComponent))
-			inMethod: #inlineComponent
-			forClass: RBRefactoryTestDataApp.
-		(refactoring model classNamed: #Behavior) 
-			compile: 'hasImmediateInstances ^self format = 0'
-			classified: #(#accessing ).
-		self 
-			setupInlineExpressionFor: refactoring
-			toReturn: false.
-		self executeRefactoring: refactoring ].
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineComponent) = (RBParser parseMethod: 'inlineComponent
+	self
+		proceedThroughWarning: [ refactoring := RBInlineMethodFromComponentRefactoring
+				inline: (35 to: 79)
+				inMethod: #inlineComponent
+				forClass: RBRefactoryTestDataApp.
+			(refactoring model classNamed: #Behavior)
+				compile: 'hasImmediateInstances ^self format = 0'
+				classified: #(#accessing).
+			self setupInlineExpressionFor: refactoring toReturn: false.
+			self executeRefactoring: refactoring ].
+	self
+		assert:
+			((refactoring model classNamed: #RBRefactoryTestDataApp)
+				parseTreeFor: #inlineComponent)
+				=
+					(RBParser
+						parseMethod:
+							'inlineComponent
 	| a aBehavior |
 	a := 5.
 	aBehavior := a class.
@@ -33,31 +36,33 @@ RBInlineMethodFromComponentTest >> testInlineComponentIntoCascadedMessage [
 { #category : #tests }
 RBInlineMethodFromComponentTest >> testInlineComponentMethodMax [
 	| refactoring |
-	self proceedThroughWarning: 
-		[ | class |
-		refactoring := RBInlineMethodFromComponentRefactoring 
-			inline: (self 
-					convertInterval: (47 to: 58)
-					for: (RBRefactoryTestDataApp sourceCodeAt: #inlineMax))
-			inMethod: #inlineMax
-			forClass: RBRefactoryTestDataApp.
-		self 
-			setupInlineExpressionFor: refactoring
-			toReturn: true.
-		class := refactoring model classNamed: #Magnitude.
-		class 
-			compile: 'max: aMagnitude 
+	self
+		proceedThroughWarning: [ | class |
+			refactoring := RBInlineMethodFromComponentRefactoring
+				inline: (47 to: 58)
+				inMethod: #inlineMax
+				forClass: RBRefactoryTestDataApp.
+			self setupInlineExpressionFor: refactoring toReturn: true.
+			class := refactoring model classNamed: #Magnitude.
+			class
+				compile:
+					'max: aMagnitude 
 					"Answer the receiver or the argument, whichever has the greater magnitude."
 
 					self > aMagnitude
 						ifTrue: [^self]
 						ifFalse: [^aMagnitude]'
-			classified: #(#accessing ).
-		self 
-			setupImplementorToInlineFor: refactoring
-			toReturn: class.
-		self executeRefactoring: refactoring ].
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineMax) = (RBParser parseMethod: 'inlineMax
+				classified: #(#accessing).
+			self setupImplementorToInlineFor: refactoring toReturn: class.
+			self executeRefactoring: refactoring ].
+	self
+		assert:
+			((refactoring model classNamed: #RBRefactoryTestDataApp)
+				parseTreeFor: #inlineMax)
+				=
+					(RBParser
+						parseMethod:
+							'inlineMax
 								| x y q |
 								x := 5.
 								y := 10.
@@ -70,22 +75,25 @@ RBInlineMethodFromComponentTest >> testInlineComponentMethodMax [
 { #category : #tests }
 RBInlineMethodFromComponentTest >> testInlineEmptyComponentMethod [
 	| refactoring |
-	self proceedThroughWarning: 
-		[ refactoring := RBInlineMethodFromComponentRefactoring 
-			inline: (self 
-					convertInterval: (35 to: 91)
-					for: (RBRefactoryTestDataApp sourceCodeAt: #inlineComponent))
-			inMethod: #inlineComponent
-			forClass: RBRefactoryTestDataApp.
-		self 
-			setupInlineExpressionFor: refactoring
-			toReturn: false.
-		"The following line is needed because some people implement #yourself themselves."
-		self 
-			setupImplementorToInlineFor: refactoring
-			toReturn: (refactoring model classNamed: #Object).
-		self executeRefactoring: refactoring ].
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineComponent) = (RBParser parseMethod: 'inlineComponent
+	self
+		proceedThroughWarning: [ refactoring := RBInlineMethodFromComponentRefactoring
+				inline: (35 to: 91)
+				inMethod: #inlineComponent
+				forClass: RBRefactoryTestDataApp.
+			self setupInlineExpressionFor: refactoring toReturn: false.
+			"The following line is needed because some people implement #yourself themselves."
+			self
+				setupImplementorToInlineFor: refactoring
+				toReturn: (refactoring model classNamed: #Object).
+			self executeRefactoring: refactoring ].
+	self
+		assert:
+			((refactoring model classNamed: #RBRefactoryTestDataApp)
+				parseTreeFor: #inlineComponent)
+				=
+					(RBParser
+						parseMethod:
+							'inlineComponent
 	| a anObject |
 	a := 5.
 	anObject := a class.
@@ -96,12 +104,12 @@ RBInlineMethodFromComponentTest >> testInlineEmptyComponentMethod [
 
 { #category : #'failure tests' }
 RBInlineMethodFromComponentTest >> testInlineMethodFromComponentFailure [
-	self shouldFail: (RBInlineMethodFromComponentRefactoring 
-			inline: (self 
-					convertInterval: (50 to: 64)
-					for: (RBRefactoryTestDataApp sourceCodeAt: #inlineFailed))
-			inMethod: #inlineFailed
-			forClass: RBRefactoryTestDataApp)
+	self
+		shouldFail:
+			(RBInlineMethodFromComponentRefactoring
+				inline: (50 to: 64)
+				inMethod: #inlineFailed
+				forClass: RBRefactoryTestDataApp)
 ]
 
 { #category : #tests }

--- a/src/Refactoring-Tests-Core/RBInlineMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBInlineMethodTest.class.st
@@ -7,28 +7,24 @@ Class {
 { #category : #'failure tests' }
 RBInlineMethodTest >> testBadInterval [
 	self
-		shouldFail: (RBInlineMethodRefactoring 
-				inline: (self 
-						convertInterval: (13 to: 23)
-						for: (RBRefactoryTestDataApp sourceCodeAt: #testMethod))
+		shouldFail:
+			(RBInlineMethodRefactoring
+				inline: (13 to: 23)
 				inMethod: #testMethod
 				forClass: RBRefactoryTestDataApp);
-		shouldFail: (RBInlineMethodRefactoring 
-				inline: (self 
-						convertInterval: (14 to: 17)
-						for: (RBRefactoryTestDataApp sourceCodeAt: #testMethod))
+		shouldFail:
+			(RBInlineMethodRefactoring
+				inline: (14 to: 17)
 				inMethod: #testMethod
 				forClass: RBRefactoryTestDataApp);
-		shouldFail: (RBInlineMethodRefactoring 
-				inline: (self 
-						convertInterval: (24 to: 30)
-						for: (RBRefactoryTestDataApp sourceCodeAt: #testMethod))
+		shouldFail:
+			(RBInlineMethodRefactoring
+				inline: (24 to: 30)
 				inMethod: #testMethod
 				forClass: RBRefactoryTestDataApp);
-		shouldFail: (RBInlineMethodRefactoring 
-				inline: (self 
-						convertInterval: (1 to: 30)
-						for: (RBRefactoryTestDataApp sourceCodeAt: #testMethod))
+		shouldFail:
+			(RBInlineMethodRefactoring
+				inline: (1 to: 30)
 				inMethod: #testMethod
 				forClass: RBRefactoryTestDataApp)
 ]
@@ -36,14 +32,19 @@ RBInlineMethodTest >> testBadInterval [
 { #category : #tests }
 RBInlineMethodTest >> testInlineMethod [
 	| refactoring |
-	refactoring := RBInlineMethodRefactoring 
-		inline: (self 
-				convertInterval: (455 to: 504)
-				for: (RBBasicLintRuleTestData class sourceCodeAt: #sentNotImplementedInApplication))
+	refactoring := RBInlineMethodRefactoring
+		inline: (455 to: 504)
 		inMethod: #sentNotImplementedInApplication
 		forClass: RBBasicLintRuleTestData class.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model metaclassNamed: #RBBasicLintRuleTestData) parseTreeFor: #sentNotImplementedInApplication) = (RBParser parseMethod: 'sentNotImplementedInApplication
+	self
+		assert:
+			((refactoring model metaclassNamed: #RBBasicLintRuleTestData)
+				parseTreeFor: #sentNotImplementedInApplication)
+				=
+					(RBParser
+						parseMethod:
+							'sentNotImplementedInApplication
 									| detector |
 									detector := self new.
 									detector name: ''Messages sent but not implemented in application''.
@@ -86,17 +87,20 @@ RBInlineMethodTest >> testInlineMethod [
 { #category : #tests }
 RBInlineMethodTest >> testInlineMethod1 [
 	| refactoring |
-	refactoring := RBInlineMethodRefactoring 
-		inline: (self 
-				convertInterval: (39 to: 84)
-				for: (RBRefactoryTestDataApp sourceCodeAt: #caller))
+	refactoring := RBInlineMethodRefactoring
+		inline: (39 to: 84)
 		inMethod: #caller
 		forClass: RBRefactoryTestDataApp.
-	self 
-		setupInlineExpressionFor: refactoring
-		toReturn: false.
+	self setupInlineExpressionFor: refactoring toReturn: false.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #caller) = (RBParser parseMethod: 'caller 
+	self
+		assert:
+			((refactoring model classNamed: #RBRefactoryTestDataApp)
+				parseTreeFor: #caller)
+				=
+					(RBParser
+						parseMethod:
+							'caller 
 									| anObject anObject1 | 
 									anObject := 5.
 									anObject1 := anObject + 1.
@@ -109,17 +113,20 @@ RBInlineMethodTest >> testInlineMethod1 [
 { #category : #tests }
 RBInlineMethodTest >> testInlineMethod2 [
 	| refactoring |
-	refactoring := RBInlineMethodRefactoring 
-		inline: (self 
-				convertInterval: (40 to: 120)
-				for: (RBRefactoryTestDataApp sourceCodeAt: #caller1))
+	refactoring := RBInlineMethodRefactoring
+		inline: (40 to: 120)
 		inMethod: #caller1
 		forClass: RBRefactoryTestDataApp.
-	self 
-		setupInlineExpressionFor: refactoring
-		toReturn: false.
+	self setupInlineExpressionFor: refactoring toReturn: false.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #caller1) = (RBParser parseMethod: 'caller1 
+	self
+		assert:
+			((refactoring model classNamed: #RBRefactoryTestDataApp)
+				parseTreeFor: #caller1)
+				=
+					(RBParser
+						parseMethod:
+							'caller1 
 								| anObject each1 anObject1 | 
 								anObject := 5.
 								anObject1 := anObject + 1.
@@ -133,34 +140,40 @@ RBInlineMethodTest >> testInlineMethod2 [
 { #category : #tests }
 RBInlineMethodTest >> testInlineMethod3 [
 	| refactoring |
-	refactoring := RBInlineMethodRefactoring 
-		inline: (self 
-				convertInterval: (58 to: 73)
-				for: (RBRefactoryTestDataApp sourceCodeAt: #caller2))
+	refactoring := RBInlineMethodRefactoring
+		inline: (58 to: 73)
 		inMethod: #caller2
 		forClass: RBRefactoryTestDataApp.
-	self 
-		setupInlineExpressionFor: refactoring
-		toReturn: false.
+	self setupInlineExpressionFor: refactoring toReturn: false.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #caller2) = (RBParser parseMethod: 'caller2
+	self
+		assert:
+			((refactoring model classNamed: #RBRefactoryTestDataApp)
+				parseTreeFor: #caller2)
+				=
+					(RBParser
+						parseMethod:
+							'caller2
 								^(1 to: 10) inject: 1 into: [:sum :each | sum * ((1 to: 10) inject: each into: [:sum1 :each1 | sum1 + each1])]	')
 ]
 
 { #category : #tests }
 RBInlineMethodTest >> testInlineMethod4 [
 	| refactoring |
-	refactoring := RBInlineMethodRefactoring 
-		inline: (self 
-				convertInterval: (31 to: 112)
-				for: (RBRefactoryTestDataApp sourceCodeAt: #inlineJunk))
+	refactoring := RBInlineMethodRefactoring
+		inline: (31 to: 112)
 		inMethod: #inlineJunk
 		forClass: RBRefactoryTestDataApp.
-	self 
-		setupInlineExpressionFor: refactoring
-		toReturn: false.
+	self setupInlineExpressionFor: refactoring toReturn: false.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineJunk) = (RBParser parseMethod: 'inlineJunk
+	self
+		assert:
+			((refactoring model classNamed: #RBRefactoryTestDataApp)
+				parseTreeFor: #inlineJunk)
+				=
+					(RBParser
+						parseMethod:
+							'inlineJunk
 										| asdf bar1 baz1 asdf1 |
 										bar1 := 
 												[:each | 
@@ -180,14 +193,19 @@ RBInlineMethodTest >> testInlineMethod4 [
 { #category : #tests }
 RBInlineMethodTest >> testInlineMethod5 [
 	| refactoring |
-	refactoring := RBInlineMethodRefactoring 
-		inline: (self 
-				convertInterval: (53 to: 64)
-				for: (RBRefactoryTestDataApp sourceCodeAt: #inlineLast))
+	refactoring := RBInlineMethodRefactoring
+		inline: (53 to: 64)
 		inMethod: #inlineLast
 		forClass: RBRefactoryTestDataApp.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineLast) = (RBParser parseMethod: 'inlineLast
+	self
+		assert:
+			((refactoring model classNamed: #RBRefactoryTestDataApp)
+				parseTreeFor: #inlineLast)
+				=
+					(RBParser
+						parseMethod:
+							'inlineLast
 									5 = 3 ifTrue: [^self caller] ifFalse: [^	(1 to: 10) inject: 1 into: [:sum :each | sum * (self foo: each)]]')
 ]
 
@@ -195,19 +213,22 @@ RBInlineMethodTest >> testInlineMethod5 [
 RBInlineMethodTest >> testInlineMethodForSuperSend [
 	| refactoring |
 	model := Smalltalk compiler evaluate: self inlineMethodTestData.
-	(model classNamed: #RBRenameVariableChange) removeMethod: #executeNotifying:.
-	refactoring := RBInlineMethodRefactoring 
-				model: model
-				inline: (self convertInterval: (102 to: 131)
-						for: ((model classNamed: #RBRenameInstanceVariableChange) 
-								sourceCodeFor: #executeNotifying:))
-				inMethod: #executeNotifying:
-				forClass: (model classNamed: #RBRenameInstanceVariableChange).
+	(model classNamed: #RBRenameVariableChange)
+		removeMethod: #executeNotifying:.
+	refactoring := RBInlineMethodRefactoring
+		model: model
+		inline: (102 to: 131)
+		inMethod: #executeNotifying:
+		forClass: (model classNamed: #RBRenameInstanceVariableChange).
 	self executeRefactoring: refactoring.
-	self 
-		assert: ((model classNamed: #RBRenameInstanceVariableChange) 
-				parseTreeFor: #executeNotifying:) = (RBParser 
-							parseMethod: 'executeNotifying: aBlock 
+	self
+		assert:
+			((model classNamed: #RBRenameInstanceVariableChange)
+				parseTreeFor: #executeNotifying:)
+				=
+					(RBParser
+						parseMethod:
+							'executeNotifying: aBlock 
 									| undo undos undo1 |
 									self addNewVariable.
 									self copyOldValuesToNewVariable.
@@ -233,14 +254,19 @@ RBInlineMethodTest >> testInlineMethodForSuperSendThatAlsoSendsSuper [
 { #category : #tests }
 RBInlineMethodTest >> testInlineRecursiveCascadedMethod [
 	| refactoring |
-	refactoring := RBInlineMethodRefactoring 
-		inline: (self 
-				convertInterval: (33 to: 62)
-				for: (RBRefactoryTestDataApp sourceCodeAt: #inlineMethod))
+	refactoring := RBInlineMethodRefactoring
+		inline: (33 to: 62)
 		inMethod: #inlineMethod
 		forClass: RBRefactoryTestDataApp.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineMethod) = (RBParser parseMethod: 'inlineMethod
+	self
+		assert:
+			((refactoring model classNamed: #RBRefactoryTestDataApp)
+				parseTreeFor: #inlineMethod)
+				=
+					(RBParser
+						parseMethod:
+							'inlineMethod
 									| temp temp1 |
 									self foo.
 									temp1 := self foo; inlineMethod; bar.
@@ -274,30 +300,30 @@ RBInlineMethodTest >> testNonExistantSelector [
 
 { #category : #'failure tests' }
 RBInlineMethodTest >> testOverriden [
-	self shouldWarn: (RBInlineMethodRefactoring 
-			inline: (self 
-					convertInterval: (15 to: 26)
-					for: (RBLintRuleTestData sourceCodeAt: #failedRules))
-			inMethod: #failedRules
-			forClass: RBLintRuleTestData)
+	self
+		shouldWarn:
+			(RBInlineMethodRefactoring
+				inline: (15 to: 26)
+				inMethod: #failedRules
+				forClass: RBLintRuleTestData)
 ]
 
 { #category : #'failure tests' }
 RBInlineMethodTest >> testPrimitive [
-	self shouldFail: (RBInlineMethodRefactoring 
-			inline: (self 
-					convertInterval: (14 to: 23)
-					for: (RBRefactoryTestDataApp sourceCodeAt: #testMethod))
-			inMethod: #testMethod
-			forClass: RBRefactoryTestDataApp)
+	self
+		shouldFail:
+			(RBInlineMethodRefactoring
+				inline: (14 to: 23)
+				inMethod: #testMethod
+				forClass: RBRefactoryTestDataApp)
 ]
 
 { #category : #'failure tests' }
 RBInlineMethodTest >> testReturn [
-	self shouldFail: (RBInlineMethodRefactoring 
-			inline: (self 
-					convertInterval: (418 to: 485)
-					for: (RBBasicLintRuleTestData class sourceCodeAt: #utilityMethods))
-			inMethod: #utilityMethods
-			forClass: RBBasicLintRuleTestData class)
+	self
+		shouldFail:
+			(RBInlineMethodRefactoring
+				inline: (418 to: 485)
+				inMethod: #utilityMethods
+				forClass: RBBasicLintRuleTestData class)
 ]

--- a/src/Refactoring-Tests-Core/RBInlineTemporaryTest.class.st
+++ b/src/Refactoring-Tests-Core/RBInlineTemporaryTest.class.st
@@ -7,14 +7,19 @@ Class {
 { #category : #tests }
 RBInlineTemporaryTest >> testInlineTemporary [
 	| refactoring |
-	refactoring := RBInlineTemporaryRefactoring 
-		inline: (self 
-				convertInterval: (24 to: 72)
-				for: (RBRefactoryTestDataApp sourceCodeAt: #inlineMethod))
+	refactoring := RBInlineTemporaryRefactoring
+		inline: (24 to: 72)
 		from: #inlineMethod
 		in: RBRefactoryTestDataApp.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineMethod) = (RBParser parseMethod: 'inlineMethod
+	self
+		assert:
+			((refactoring model classNamed: #RBRefactoryTestDataApp)
+				parseTreeFor: #inlineMethod)
+				=
+					(RBParser
+						parseMethod:
+							'inlineMethod
 										^self
 													foo;
 													inlineMethod;
@@ -23,30 +28,30 @@ RBInlineTemporaryTest >> testInlineTemporary [
 
 { #category : #tests }
 RBInlineTemporaryTest >> testInlineTemporaryBadInterval [
-	self shouldFail: (RBInlineTemporaryRefactoring 
-			inline: (self 
-					convertInterval: (29 to: 100)
-					for: (RBRefactoryTestDataApp sourceCodeAt: #moveDefinition))
-			from: #moveDefinition
-			in: RBRefactoryTestDataApp)
+	self
+		shouldFail:
+			(RBInlineTemporaryRefactoring
+				inline: (29 to: 100)
+				from: #moveDefinition
+				in: RBRefactoryTestDataApp)
 ]
 
 { #category : #tests }
 RBInlineTemporaryTest >> testInlineTemporaryMutlipleAssignment [
-	self shouldFail: (RBInlineTemporaryRefactoring 
-			inline: (self 
-					convertInterval: (60 to: 83)
-					for: (RBRefactoryTestDataApp sourceCodeAt: #moveDefinition))
-			from: #moveDefinition
-			in: RBRefactoryTestDataApp)
+	self
+		shouldFail:
+			(RBInlineTemporaryRefactoring
+				inline: (60 to: 83)
+				from: #moveDefinition
+				in: RBRefactoryTestDataApp)
 ]
 
 { #category : #tests }
 RBInlineTemporaryTest >> testInlineTemporaryReadBeforeWritten [
-	self shouldFail: (RBInlineTemporaryRefactoring 
-			inline: (self 
-					convertInterval: (48 to: 56)
-					for: (RBRefactoryTestDataApp sourceCodeAt: #inlineTemporary))
-			from: #inlineTemporary
-			in: RBRefactoryTestDataApp)
+	self
+		shouldFail:
+			(RBInlineTemporaryRefactoring
+				inline: (48 to: 56)
+				from: #inlineTemporary
+				in: RBRefactoryTestDataApp)
 ]

--- a/src/Refactoring-Tests-Core/RBMoveVariableDefinitionTest.class.st
+++ b/src/Refactoring-Tests-Core/RBMoveVariableDefinitionTest.class.st
@@ -7,14 +7,19 @@ Class {
 { #category : #tests }
 RBMoveVariableDefinitionTest >> testMoveDefinition [
 	| refactoring |
-	refactoring := RBMoveVariableDefinitionRefactoring 
-		bindTight: (self 
-				convertInterval: (19 to: 22)
-				for: (RBRefactoryTestDataApp sourceCodeAt: #moveDefinition))
+	refactoring := RBMoveVariableDefinitionRefactoring
+		bindTight: (19 to: 22)
 		in: RBRefactoryTestDataApp
 		selector: #moveDefinition.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #moveDefinition) = (RBParser parseMethod: 'moveDefinition
+	self
+		assert:
+			((refactoring model classNamed: #RBRefactoryTestDataApp)
+				parseTreeFor: #moveDefinition)
+				=
+					(RBParser
+						parseMethod:
+							'moveDefinition
 								^(self collect: 
 										[:each | 
 										| temp |
@@ -30,14 +35,19 @@ RBMoveVariableDefinitionTest >> testMoveDefinition [
 { #category : #tests }
 RBMoveVariableDefinitionTest >> testMoveDefinitionIntoBlockThatIsAReceiverOfACascadedMessage [
 	| refactoring |
-	refactoring := RBMoveVariableDefinitionRefactoring 
-		bindTight: (self 
-				convertInterval: (48 to: 58)
-				for: (RBRefactoryTestDataApp sourceCodeAt: #referencesConditionFor:))
+	refactoring := RBMoveVariableDefinitionRefactoring
+		bindTight: (48 to: 58)
 		in: RBRefactoryTestDataApp
 		selector: #referencesConditionFor:.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #referencesConditionFor:) = (RBParser parseMethod: 'referencesConditionFor: aClass 
+	self
+		assert:
+			((refactoring model classNamed: #RBRefactoryTestDataApp)
+				parseTreeFor: #referencesConditionFor:)
+				=
+					(RBParser
+						parseMethod:
+							'referencesConditionFor: aClass 
 								| environment  |
 								^(RBCondition withBlock: 
 										[| association |association := Smalltalk globals associationAt: aClass name
@@ -52,31 +62,30 @@ RBMoveVariableDefinitionTest >> testMoveDefinitionIntoBlockThatIsAReceiverOfACas
 
 { #category : #tests }
 RBMoveVariableDefinitionTest >> testNoMoveDefinition [
-	self shouldFail: (RBMoveVariableDefinitionRefactoring 
-			bindTight: (self 
-					convertInterval: (21 to: 24)
-					for: (RBRefactoryTestDataApp sourceCodeAt: #moveDefinition))
-			in: RBRefactoryTestDataApp
-			selector: #noMoveDefinition)
+	self
+		shouldFail:
+			(RBMoveVariableDefinitionRefactoring
+				bindTight: (21 to: 24)
+				in: RBRefactoryTestDataApp
+				selector: #noMoveDefinition)
 ]
 
 { #category : #tests }
 RBMoveVariableDefinitionTest >> testNonExistantName [
 	self
-		shouldFail: (RBMoveVariableDefinitionRefactoring 
+		shouldFail:
+			(RBMoveVariableDefinitionRefactoring
 				bindTight: (1 to: 10)
 				in: RBLintRuleTestData
 				selector: #name1);
-		shouldFail: (RBMoveVariableDefinitionRefactoring 
-				bindTight: (self 
-						convertInterval: (44 to: 54)
-						for: (RBLintRuleTestData sourceCodeAt: #displayName))
+		shouldFail:
+			(RBMoveVariableDefinitionRefactoring
+				bindTight: (44 to: 54)
 				in: RBLintRuleTestData
 				selector: #displayName);
-		shouldFail: (RBMoveVariableDefinitionRefactoring 
-				bindTight: (self 
-						convertInterval: (16 to: 25)
-						for: (RBLintRuleTestData sourceCodeAt: #displayName))
+		shouldFail:
+			(RBMoveVariableDefinitionRefactoring
+				bindTight: (16 to: 25)
 				in: RBLintRuleTestData
 				selector: #displayName)
 ]

--- a/src/Refactoring-Tests-Core/RBRefactoringBrowserTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRefactoringBrowserTest.class.st
@@ -10,13 +10,6 @@ RBRefactoringBrowserTest class >> isAbstract [
 ]
 
 { #category : #private }
-RBRefactoringBrowserTest >> convertInterval: anInterval for: aString [ 
-	"Convert the interval to ignore differences in end of line conventions."
-
-	^anInterval
-]
-
-{ #category : #private }
 RBRefactoringBrowserTest >> executeRefactoring: aRefactoring [ 
 	aRefactoring primitiveExecute.
 	RBParser parseExpression: aRefactoring storeString

--- a/src/Refactoring-Tests-Core/RBRenameTemporaryTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenameTemporaryTest.class.st
@@ -6,43 +6,39 @@ Class {
 
 { #category : #'failure tests' }
 RBRenameTemporaryTest >> testBadInterval [
-	self shouldFail: (RBRenameTemporaryRefactoring 
-			renameTemporaryFrom: (self 
-					convertInterval: (14 to: 17)
-					for: (RBRefactoryTestDataApp sourceCodeAt: #testMethod))
-			to: 'asdf'
-			in: RBRefactoryTestDataApp
-			selector: #testMethod)
+	self
+		shouldFail:
+			(RBRenameTemporaryRefactoring
+				renameTemporaryFrom: (14 to: 17)
+				to: 'asdf'
+				in: RBRefactoryTestDataApp
+				selector: #testMethod)
 ]
 
 { #category : #'failure tests' }
 RBRenameTemporaryTest >> testBadName [
 	self
-		shouldFail: (RBRenameTemporaryRefactoring 
-				renameTemporaryFrom: (self 
-						convertInterval: (15 to: 19)
-						for: (RBLintRuleTestData sourceCodeAt: #openEditor))
+		shouldFail:
+			(RBRenameTemporaryRefactoring
+				renameTemporaryFrom: (15 to: 19)
 				to: 'name'
 				in: RBLintRuleTestData
 				selector: #openEditor);
-		shouldFail: (RBRenameTemporaryRefactoring 
-				renameTemporaryFrom: (self 
-						convertInterval: (15 to: 19)
-						for: (RBLintRuleTestData sourceCodeAt: #openEditor))
+		shouldFail:
+			(RBRenameTemporaryRefactoring
+				renameTemporaryFrom: (15 to: 19)
 				to: 'rules'
 				in: RBLintRuleTestData
 				selector: #openEditor);
-		shouldFail: (RBRenameTemporaryRefactoring 
-				renameTemporaryFrom: (self 
-						convertInterval: (15 to: 19)
-						for: (RBLintRuleTestData sourceCodeAt: #openEditor))
+		shouldFail:
+			(RBRenameTemporaryRefactoring
+				renameTemporaryFrom: (15 to: 19)
 				to: 'DependentFields'
 				in: RBLintRuleTestData
 				selector: #openEditor);
-		shouldFail: (RBRenameTemporaryRefactoring 
-				renameTemporaryFrom: (self 
-						convertInterval: (15 to: 19)
-						for: (RBLintRuleTestData sourceCodeAt: #openEditor))
+		shouldFail:
+			(RBRenameTemporaryRefactoring
+				renameTemporaryFrom: (15 to: 19)
 				to: 'a b'
 				in: RBLintRuleTestData
 				selector: #openEditor)
@@ -72,15 +68,20 @@ RBRenameTemporaryTest >> testModelBadName [
 { #category : #tests }
 RBRenameTemporaryTest >> testRenameTemporary [
 	| refactoring |
-	refactoring := RBRenameTemporaryRefactoring 
-		renameTemporaryFrom: (self 
-				convertInterval: (15 to: 19)
-				for: (RBLintRuleTestData sourceCodeAt: #openEditor))
+	refactoring := RBRenameTemporaryRefactoring
+		renameTemporaryFrom: (15 to: 19)
 		to: 'asdf'
 		in: RBLintRuleTestData
 		selector: #openEditor.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBLintRuleTestData) parseTreeFor: #openEditor) = (RBParser parseMethod: 'openEditor
+	self
+		assert:
+			((refactoring model classNamed: #RBLintRuleTestData)
+				parseTreeFor: #openEditor)
+				=
+					(RBParser
+						parseMethod:
+							'openEditor
 								| asdf |
 								asdf := self failedRules.
 								asdf isEmpty ifTrue: [^self].

--- a/src/Refactoring-Tests-Core/RBSplitCascadeRefactoringTest.class.st
+++ b/src/Refactoring-Tests-Core/RBSplitCascadeRefactoringTest.class.st
@@ -20,13 +20,19 @@ RBSplitCascadeRefactoringTest >> methodWithCascades [
 { #category : #tests }
 RBSplitCascadeRefactoringTest >> testSplitCascadeRefactoring [
 	| refactoring |
-	refactoring := RBSplitCascadeRefactoring split: (self 
-				convertInterval: (54 to: 55)
-				for: (self class sourceCodeAt: #methodWithCascades))
+	refactoring := RBSplitCascadeRefactoring
+		split: (54 to: 55)
 		from: #methodWithCascades
 		in: self class.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBSplitCascadeRefactoringTest) parseTreeFor: #methodWithCascades) equals: (RBParser parseMethod: 'methodWithCascades
+	self
+		assert:
+			((refactoring model classNamed: #RBSplitCascadeRefactoringTest)
+				parseTreeFor: #methodWithCascades)
+		equals:
+			(RBParser
+				parseMethod:
+					'methodWithCascades
 	| a receiver |
 	receiver := Object new.
 	receiver initialize.


### PR DESCRIPTION
Remove unnecessary and redundant method convertInterval:for:, this only return the interval, put inline the interval in all senders of this method