### PR TITLE
3428-Use-more-reasonable-error-when-writing-to-read-only-changes-file

### DIFF
--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -318,7 +318,8 @@ SourceFileArray >> forceChangesToDisk [
 
 	| changesFile |
 	changesFile := self changesFileStream.
-	changesFile flush.
+	changesFile isReadOnly ifFalse: [ 
+		changesFile flush ].
 	changesFile close.
 	changesFile tryOpen.
 	changesFile setToEnd


### PR DESCRIPTION
safer sources file flushfixes #3428