### PR TITLE
Remove deprecation as #tempNames is used in the build

### DIFF
--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -672,8 +672,7 @@ RBMethodNode >> stop [
 
 { #category : #accessing }
 RBMethodNode >> tempNames [
-	"compatibility method to old MethodNode"
-	self deprecated: 'This method was flagged for cleaning. We have the impression it might not be used so we are deprecating it. If you encounter this deprecation, please report with the scenario to reproduce.'.
+	"compatibility method to old MethodNode. Is used in the build"
 	^ self argumentNames, self temporaryNames
 ]
 


### PR DESCRIPTION
Resolves #3432