### PR TITLE
3432-RBMethodNodetempnames-is-used-in-the-build

### DIFF
--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -1069,7 +1069,8 @@ CompiledMethod >> tags [
 
 { #category : #'source code management' }
 CompiledMethod >> tempNames [
-	^self methodNode tempNames.
+	"on the level of the compiled method, tempNames includes argument names"
+	^self ast argumentNames, self ast temporaryNames
 ]
 
 { #category : #'accessing-tags' }


### PR DESCRIPTION
- use argumentNames and temporaryNames from the ast instead of the deprecated tempNames
- we use #ast instead of #parseTree to fill the AST Cache