### PR TITLE
3431-Random-calypso-errors-on-class-selection

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -451,7 +451,9 @@ Class >> definitionForNautilus [
 		on: '2019-05-14'
 		in: #Pharo8
 		transformWith: '`@receiver definitionForNautilus' 
-						-> '`@receiver definition'
+						-> '`@receiver definition'.
+						
+	^ self definition
 ]
 
 { #category : #deprecation }


### PR DESCRIPTION
Fix deprecation of #definitionForNautilus

Fixes #3431