### PR TITLE
2568-copyUpTo-and-copyUpThrough-are-identical-in-SequencableCollection

### DIFF
--- a/src/Collections-Abstract/SequenceableCollection.class.st
+++ b/src/Collections-Abstract/SequenceableCollection.class.st
@@ -619,10 +619,10 @@ SequenceableCollection >> copyReplaceFrom: start to: stop with: replacementColle
 
 { #category : #copying }
 SequenceableCollection >> copyUpThrough: anElement [
-    "Answer all elements up to and including anObject. If there
-     is no such object, answer a copy of the receiver."
-
-	^self first: (self indexOf: anElement ifAbsent: [^ self copy])
+	self 
+		deprecated: 'use #copyUpTo: on the method instead' 
+		transformWith: '`@receiver copyUpThrough: `@argument' -> '`@receiver copyUpTo: `@argument'.
+    ^self copyUpTo: anElement
 ]
 
 { #category : #copying }

--- a/src/Text-Core/RunArray.class.st
+++ b/src/Text-Core/RunArray.class.st
@@ -370,17 +370,6 @@ RunArray >> copyReplaceFrom: start to: stop with: replacement [
 ]
 
 { #category : #copying }
-RunArray >> copyUpThrough: anElement [
-	"Optimized"
-
-	| newValues |
-	newValues := values copyUpThrough: anElement.
-	^ self class
-		runs: (runs copyFrom: 1 to: newValues size)
-		values: newValues
-]
-
-{ #category : #copying }
 RunArray >> copyUpTo: anElement [ 
 	"Optimized"
 


### PR DESCRIPTION
deprecated the method with rewrite. fixes #2568