### PR TITLE
2188-Reflectivity-uses-a-Symbol-while-RBVariableNode-a-string-for-SelfNode-name

### DIFF
--- a/src/AST-Core/RBSelfNode.class.st
+++ b/src/AST-Core/RBSelfNode.class.st
@@ -7,6 +7,13 @@ Class {
 	#category : #'AST-Core-Nodes'
 }
 
+{ #category : #'instance creation' }
+RBSelfNode class >> new [
+	^super new 
+		named: 'self' start: nil;
+		yourself.
+]
+
 { #category : #visiting }
 RBSelfNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitSelfNode: self

--- a/src/AST-Core/RBSuperNode.class.st
+++ b/src/AST-Core/RBSuperNode.class.st
@@ -7,6 +7,13 @@ Class {
 	#category : #'AST-Core-Nodes'
 }
 
+{ #category : #'instance creation' }
+RBSuperNode class >> new [
+	^super new 
+		named: 'super' start: nil;
+		yourself.
+]
+
 { #category : #visiting }
 RBSuperNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitSuperNode: self

--- a/src/AST-Core/RBThisContextNode.class.st
+++ b/src/AST-Core/RBThisContextNode.class.st
@@ -7,6 +7,13 @@ Class {
 	#category : #'AST-Core-Nodes'
 }
 
+{ #category : #'instance creation' }
+RBThisContextNode class >> new [
+	^super new 
+		named: 'thisContext' start: nil;
+		yourself.
+]
+
 { #category : #visiting }
 RBThisContextNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitThisContextNode: self

--- a/src/Flashback-Decompiler/FBDASTBuilder.class.st
+++ b/src/Flashback-Decompiler/FBDASTBuilder.class.st
@@ -123,7 +123,7 @@ FBDASTBuilder >> codeMethod: selector arguments: args body: body pragmas: pragma
 
 { #category : #building }
 FBDASTBuilder >> codeReceiver [
-	^ (RBSelfNode named: 'self')
+	^ RBSelfNode new
 ]
 
 { #category : #building }
@@ -143,7 +143,7 @@ FBDASTBuilder >> codeReturn: value [
 
 { #category : #building }
 FBDASTBuilder >> codeSelf [
-	^ (RBSelfNode named: 'self')
+	^ RBSelfNode new
 ]
 
 { #category : #building }
@@ -153,7 +153,7 @@ FBDASTBuilder >> codeSequence: temps [
 
 { #category : #building }
 FBDASTBuilder >> codeSuper [
-	^ (RBSuperNode named: 'super')
+	^ RBSuperNode new
 ]
 
 { #category : #building }
@@ -163,7 +163,7 @@ FBDASTBuilder >> codeTemp: tempName [
 
 { #category : #building }
 FBDASTBuilder >> codeThisContext [
-	^ RBThisContextNode named: 'thisContext'
+	^ RBThisContextNode new
 ]
 
 { #category : #building }

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -31,7 +31,7 @@ RBMethodNode >> ensureCachedArgumentNames [
 RBMethodNode class >> errorMethodNode: selector errorMessage: messageText [	
 	| message |
 	message := RBMessageNode 
-		receiver: (RBSelfNode named: 'self')
+		receiver: RBSelfNode new
 		selector: #error: 
 		arguments: {RBLiteralNode value: messageText}.
 	^ self 

--- a/src/Reflectivity/RFThisContextReification.class.st
+++ b/src/Reflectivity/RFThisContextReification.class.st
@@ -19,15 +19,15 @@ RFThisContextReification class >> key [
 
 { #category : #generate }
 RFThisContextReification >> genForInstanceVariableSlot [
-	^RBThisContextNode named: #thisContext
+	^RBThisContextNode new
 ]
 
 { #category : #generate }
 RFThisContextReification >> genForLiteralVariable [
-	^RBThisContextNode named: #thisContext
+	^RBThisContextNode new
 ]
 
 { #category : #generate }
 RFThisContextReification >> genForRBProgramNode [
-	^RBThisContextNode named: #thisContext
+	^RBThisContextNode new
 ]

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -99,7 +99,7 @@ ReflectiveMethod >> generatePrimitiveWrapper [
 	wrappedMethod := ast generate: compiledMethod trailer.
 	
 	send := RBMessageNode
-		receiver: (RBSelfNode named: #self)
+		receiver: RBSelfNode new
 		selector:  #rFwithArgs:executeMethod:
 		arguments: {RBArrayNode statements: ast arguments . (RFLiteralVariableNode value: wrappedMethod)}.
 	


### PR DESCRIPTION
- implement #new for RBSelfNode, RBThisContextNode and RBSuperNode
- change all users to use this instead of #named: 

fixes #2188