### PR TITLE
3005-Extra-message-for-RBMessageNode-to-get-interval-for-full-selector-part

### DIFF
--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -402,6 +402,13 @@ RBMessageNode >> selector: aSelector [
 ]
 
 { #category : #accessing }
+RBMessageNode >> selectorInterval [
+	| positions |
+	positions := self keywordsIntervals. 
+	^positions first first to: positions last last.
+]
+
+{ #category : #accessing }
 RBMessageNode >> selectorParts [
 	^ self keywords collect: #asSymbol.
 ]

--- a/src/AST-Tests-Core/RBMessageNodeTest.class.st
+++ b/src/AST-Tests-Core/RBMessageNodeTest.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : #RBMessageNodeTest,
+	#superclass : #RBParseTreeTest,
+	#category : #'AST-Tests-Core'
+}
+
+{ #category : #testing }
+RBMessageNodeTest >> testselectorInterval [
+		| tree message |
+		tree := self parseMethod: 'test self doit'.
+		message := tree sendNodes first.
+		self assert: message selectorInterval equals: (11 to: 14).
+		tree := self parseMethod: 'test self doit: #nice with: 5'.
+		message := tree sendNodes first.
+		self assert: message selectorInterval equals: (11 to: 27).
+]


### PR DESCRIPTION
added a method #selectorInverval with test. fixes #3005