### PR TITLE
3468-Slots-use-variable-name-instead-of-Object-new-as-temp

### DIFF
--- a/src/Slot-Core/Slot.class.st
+++ b/src/Slot-Core/Slot.class.st
@@ -151,7 +151,7 @@ Slot >> definitionString [
 Slot >> emitStore: aMethodBuilder [
 	"generate bytecode to call the reflective write method of the Slot"
 	| tempName |
-	tempName := Object new.  "we need a unique Object as a temp name"
+	tempName := '0slotTempForStackManipulation'.  
 	aMethodBuilder
 		addTemp: tempName;
 		storeTemp: tempName;

--- a/src/Slot-Examples/BooleanSlot.class.st
+++ b/src/Slot-Examples/BooleanSlot.class.st
@@ -24,7 +24,7 @@ BooleanSlot >> baseSlotRead: anObject [
 BooleanSlot >> emitStore: methodBuilder [
 	"generate bytecode for 'baseSlot bitAt: index put: <stackTop>'"
 	| tempName |
-	tempName := Object new.  "we need a unique Object as a temp name"
+	tempName := '0slotTempForStackManipulation'.
 	methodBuilder
 		send: #asBit;
 		addTemp: tempName;

--- a/src/Slot-Examples/ProcessLocalSlot.class.st
+++ b/src/Slot-Examples/ProcessLocalSlot.class.st
@@ -33,7 +33,7 @@ Class {
 ProcessLocalSlot >> emitStore: aMethodBuilder [
 	"generate bytecode for 'varname value: <stackTop>'"
 	| temp |
-	temp := Object new.  "we need a unique Object as a temp name"
+	temp := '0slotTempForStackManipulation'.
 	"We pop the value from the stack into a temp to push it back in the right order"
 	aMethodBuilder addTemp: temp.
 	aMethodBuilder storeTemp: temp.

--- a/src/Slot-Examples/PropertySlot.class.st
+++ b/src/Slot-Examples/PropertySlot.class.st
@@ -15,7 +15,7 @@ Class {
 PropertySlot >> emitStore: methodBuilder [
 	"generate bytecode for 'baseSlot at: 1 put: <stackTop>'"
 	| tempName |
-	tempName := Object new.  "we need a unique Object as a temp name"
+	tempName := '0slotTempForStackManipulation'.
 	methodBuilder
 		addTemp: tempName;
 		storeTemp: tempName;

--- a/src/Slot-Examples/RelationSlot.class.st
+++ b/src/Slot-Examples/RelationSlot.class.st
@@ -73,7 +73,7 @@ RelationSlot >> checkValue: aValue [
 RelationSlot >> emitStore: aMethodBuilder [
 	"copy of #emitStore from Slot as my superclass has overriden it"
 	| tempName |
-	tempName := Object new.  "we need a unique Object as a temp name"
+	tempName := '0slotTempForStackManipulation'.
 	aMethodBuilder
 		addTemp: tempName;
 		storeTemp: tempName;

--- a/src/Slot-Examples/UnlimitedInstanceVariableSlot.class.st
+++ b/src/Slot-Examples/UnlimitedInstanceVariableSlot.class.st
@@ -14,7 +14,7 @@ Class {
 UnlimitedInstanceVariableSlot >> emitStore: methodBuilder [
 	"generate bytecode for 'baseSlot at: index put: <stackTop>'"
 	| tempName |
-	tempName := Object new.  "we need a unique Object as a temp name"
+	tempName := '0slotTempForStackManipulation'.
 	methodBuilder
 		addTemp: tempName;
 		storeTemp: tempName;

--- a/src/Slot-Examples/WeakSlot.class.st
+++ b/src/Slot-Examples/WeakSlot.class.st
@@ -21,7 +21,7 @@ Class {
 WeakSlot >> emitStore: aMethodBuilder [
 	"generate bytecode for 'varname at: 1 put: <stackTop>'"
 	| temp |
-	temp := Object new. "we need a unique Object as a temp name"
+	temp := '0slotTempForStackManipulation'.
 	"Pop the value to store into a temp to push it back in the right order"
 	aMethodBuilder addTemp: temp.
 	aMethodBuilder storeTemp: temp.

--- a/src/Spec-Core/SpecObservableSlot.class.st
+++ b/src/Spec-Core/SpecObservableSlot.class.st
@@ -9,7 +9,7 @@ SpecObservableSlot >> emitStore: aMethodBuilder [
 	"generate bytecode for 'varName value: <stackTop>'"
 
 	| temp |
-	temp := Object new.	"we need a unique Object as a temp name"
+	temp := '0slotTempForStackManipulation'.
 	"We pop the value from the stack into a temp to push it back in the right order"
 	aMethodBuilder addTemp: temp.
 	aMethodBuilder storeTemp: temp.


### PR DESCRIPTION
the #emitStore: methods of some slots need a space to save a value from the stack. We use "Object new" now, but this is not needed: if we use the same name all the time, we can safely remove it (it is never used in a way that we need a dedicated temp for every use)

We need to use a name, though, that can not be a valid name for a temp. I suggest 0slotTempForStackManipulation

fixes #3468