### PR TITLE
3478-Some-slots-cannot-be-assigned-in-a-block

### DIFF
--- a/src/Slot-Examples/ProcessLocalSlot.class.st
+++ b/src/Slot-Examples/ProcessLocalSlot.class.st
@@ -37,6 +37,7 @@ ProcessLocalSlot >> emitStore: aMethodBuilder [
 	"We pop the value from the stack into a temp to push it back in the right order"
 	aMethodBuilder addTemp: temp.
 	aMethodBuilder storeTemp: temp.
+	aMethodBuilder popTop.
 	
 	"Push the process local variable into the stack, then the value again, then send"
 	aMethodBuilder pushInstVar: index.

--- a/src/Slot-Examples/WeakSlot.class.st
+++ b/src/Slot-Examples/WeakSlot.class.st
@@ -25,6 +25,7 @@ WeakSlot >> emitStore: aMethodBuilder [
 	"Pop the value to store into a temp to push it back in the right order"
 	aMethodBuilder addTemp: temp.
 	aMethodBuilder storeTemp: temp.
+	aMethodBuilder popTop.
 	
 	"Push the weak array into the stack, then the arguments, then send"
 	aMethodBuilder pushInstVar: index.

--- a/src/Slot-Tests/ProcessLocalSlotTest.class.st
+++ b/src/Slot-Tests/ProcessLocalSlotTest.class.st
@@ -5,6 +5,29 @@ Class {
 }
 
 { #category : #tests }
+ProcessLocalSlotTest >> testIsPossibleToSetSlotInBlock [
+	| slot writerString instance |
+	slot := #slot1 => ProcessLocalSlot.
+	aClass := self make: [ :builder | builder slots: {slot} ].
+
+	writerString := String streamContents: [ :str |
+		str 
+			nextPutAll: slot name;
+			nextPutAll: ': anObject';
+			cr;tab;
+			nextPutAll: 'true ifTrue: [ ';
+			nextPutAll: slot name;
+			nextPutAll: ':= anObject ]'.
+		].
+	
+	aClass compile: writerString.
+	
+	instance := aClass new.
+	instance slot1: #test.
+	self assert: (instance instVarNamed: #slot1) value equals: #test.
+]
+
+{ #category : #tests }
 ProcessLocalSlotTest >> testRead [
 	| slot |
 	slot := #slot1 => ProcessLocalSlot.

--- a/src/Spec-Core/SpecObservableSlot.class.st
+++ b/src/Spec-Core/SpecObservableSlot.class.st
@@ -13,6 +13,7 @@ SpecObservableSlot >> emitStore: aMethodBuilder [
 	"We pop the value from the stack into a temp to push it back in the right order"
 	aMethodBuilder addTemp: temp.
 	aMethodBuilder storeTemp: temp.
+	aMethodBuilder popTop.
 
 	"Push the value holder into the stack, then the value again, then send"
 	aMethodBuilder pushInstVar: index.


### PR DESCRIPTION
do not forget to pop the value when storing in the temp in #emitStore:

fixes #3478