### PR TITLE
Improving GT Spotter performance. First pass

### DIFF
--- a/src/GT-SpotterExtensions-Core/GTSpotter.extension.st
+++ b/src/GT-SpotterExtensions-Core/GTSpotter.extension.st
@@ -249,7 +249,7 @@ GTSpotter >> spotterForPragmasFor: aStep [
 	aStep listProcessor 
 			allCandidates: [ Pragma allInstances collect: [ :e | e keyword ] as: Set ];
 			title: 'Pragmas';
-			itemName: [ :pragma | pragma keyword ];
+			itemName: [ :pragma | pragma ];
 			filter: self defaultFilterClass;
 			wantsToDisplayOnEmptyQuery: false
 ]

--- a/src/GT-SpotterExtensions-Core/GTSpotter.extension.st
+++ b/src/GT-SpotterExtensions-Core/GTSpotter.extension.st
@@ -247,7 +247,7 @@ GTSpotter >> spotterForPackagesFor: aStep [
 GTSpotter >> spotterForPragmasFor: aStep [
 	<spotterOrder: 40>
 	aStep listProcessor 
-			allCandidates: [ PragmaType all ];
+			allCandidates: [ Pragma allInstances collect: [ :e | e keyword ] as: Set ];
 			title: 'Pragmas';
 			itemName: [ :pragma | pragma keyword ];
 			filter: self defaultFilterClass;

--- a/src/HelpSystem-Core/SystemHelp.class.st
+++ b/src/HelpSystem-Core/SystemHelp.class.st
@@ -10,17 +10,28 @@ So ""HelpBrowser open"" is the same as ""HelpBrowser openOn: SystemHelp"".
 Class {
 	#name : #SystemHelp,
 	#superclass : #Object,
+	#classInstVars : [
+		'pragmaCollector',
+		'helpTopic'
+	],
 	#category : #'HelpSystem-Core-Utilities'
 }
 
 { #category : #'private accessing' }
 SystemHelp class >> allSystemHelpPragmas [
-	^(PragmaCollector filter: [:prag | prag keyword = self pragmaKeyword ]) collected
+	^ self pragmaCollector collected
 
 ]
 
-{ #category : #conversion }
+{ #category : #accessing }
 SystemHelp class >> asHelpTopic [ 
+
+	^ helpTopic ifNil: [ helpTopic := self createHelpTopic].
+
+]
+
+{ #category : #reset }
+SystemHelp class >> createHelpTopic [
 	|topic helpOnHelp sortedTopics |
 	topic := HelpTopic named: 'Help'.
 	self allSystemHelpPragmas do: [:each | 
@@ -32,8 +43,18 @@ SystemHelp class >> asHelpTopic [
 	sortedTopics remove: helpOnHelp.
 	sortedTopics addLast: helpOnHelp.
 	topic subtopics: sortedTopics.
-	^topic.
+	^topic
 
+]
+
+{ #category : #accessing }
+SystemHelp class >> pragmaCollector [
+	^ pragmaCollector
+		ifNil: [ pragmaCollector := (PragmaCollector
+				filter: [ :prag | prag keyword = self pragmaKeyword ])
+				reset;
+				whenChangedDo: [ self resetHelpTopic ];
+				yourself ]
 ]
 
 { #category : #'private accessing' }
@@ -41,4 +62,10 @@ SystemHelp class >> pragmaKeyword [
 
 	^#systemHelp
 
+]
+
+{ #category : #reset }
+SystemHelp class >> resetHelpTopic [
+
+	helpTopic := self createHelpTopic 
 ]

--- a/src/HelpSystem-Core/SystemHelp.class.st
+++ b/src/HelpSystem-Core/SystemHelp.class.st
@@ -15,7 +15,7 @@ Class {
 
 { #category : #'private accessing' }
 SystemHelp class >> allSystemHelpPragmas [
-	^(PragmaCollector filter: [:prag | prag keyword = self pragmaKeyword ]) reset collected
+	^(PragmaCollector filter: [:prag | prag keyword = self pragmaKeyword ]) collected
 
 ]
 

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -35,15 +35,11 @@ SystemNavigation >> allBehaviors [
 SystemNavigation >> allBehaviorsDo: aBlock [
 	"Execute a block on each class, metaclass, trait and trait class"
 
-	self environment allClassesDo: [ :aClass | 
-		aBlock
-			value: aClass;
-			value: aClass classSide ].
-
-	self environment allTraitsDo: [ :aTrait | 
-		aBlock
-			value: aTrait;
-			value: aTrait classSide ]
+	self environment valuesDo: [ :aClass |
+		aClass isBehavior ifTrue: [  
+			aBlock
+				value: aClass;
+				value: aClass classSide]].
 ]
 
 { #category : #query }


### PR DESCRIPTION
Before
=====

Report for: GTSpotterBenchmarks
Benchmark EmptyQuery
EmptyQuery total: iterations=10 runtime: 403.0ms +/-7.2

Benchmark MessageQuery
MessageQuery total: iterations=10 runtime: 1000ms +/-17

Benchmark InvalidSelectorQuery
InvalidSelectorQuery total: iterations=10 runtime: 975.2ms +/-8.2

Benchmark GTPackageQuery
GTPackageQuery total: iterations=10 runtime: 1028ms +/-48

Benchmark SelectQuery
SelectQuery total: iterations=10 runtime: 1008ms +/-31

After
===
Report for: GTSpotterBenchmarks
Benchmark EmptyQuery
EmptyQuery total: iterations=10 runtime: 12.3ms +/-3.1

Benchmark MessageQuery
MessageQuery total: iterations=10 runtime: 576ms +/-51

Benchmark InvalidSelectorQuery
InvalidSelectorQuery total: iterations=10 runtime: 524ms +/-13

Benchmark GTPackageQuery
GTPackageQuery total: iterations=10 runtime: 544ms +/-37

Benchmark SelectQuery
SelectQuery total: iterations=10 runtime: 522ms +/-23

On an empty image, running the benchmarks in Pharo-benchmark project.
