### PR TITLE
3493-ClassOrganizationcopyFrom-should-not-use-instVarNamed

### DIFF
--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -180,7 +180,7 @@ ClassOrganization >> extensionProtocols [
 
 { #category : #testing }
 ClassOrganization >> hasComment [
-	^ self comment isEmptyOrNil not 
+	^ self commentRemoteString isNotNil
 ]
 
 { #category : #'backward compatibility' }

--- a/src/Shift-ClassBuilder/ClassOrganization.extension.st
+++ b/src/Shift-ClassBuilder/ClassOrganization.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #ClassOrganization }
 
 { #category : #'*Shift-ClassBuilder' }
 ClassOrganization >> copyFrom: otherOrganization [
-	comment := otherOrganization instVarNamed: #comment.
+	comment := otherOrganization commentRemoteString.
 	commentStamp := otherOrganization commentStamp.
 	otherOrganization protocols do: [ :p | p methods do: [ :m | protocolOrganizer classify: m inProtocolNamed: p name ] ].
 ]


### PR DESCRIPTION
- use accessor #commentRemoteString in #copyFrom:
- rewrite #hasComment to use #commentRemoteString, too (

fixes #3493