### PR TITLE
3497-instVarIndexForifAbsent-is-wrong

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -779,15 +779,10 @@ ClassDescription >> instVarIndexFor: instVarName [
 ClassDescription >> instVarIndexFor: instVarName ifAbsent: aBlock [
 	"Answer the index of the named instance variable."
 
-	| index |
-	index := self classLayout instVarIndexFor: instVarName ifAbsent: 0.
-	index = 0 ifTrue: 
-		[^self superclass
-			ifNil: [aBlock value]
-			ifNotNil: [self superclass instVarIndexFor: instVarName ifAbsent: aBlock]].
-	^self superclass
-		ifNil: [index]
-		ifNotNil: [index + self superclass instSize]
+	^self
+		slotNamed: instVarName
+		ifFound: [ :slot | slot isVirtual ifTrue: aBlock ifFalse: [slot index]]
+		ifNone: aBlock
 ]
 
 { #category : #private }

--- a/src/Slot-Core/AbstractLayout.class.st
+++ b/src/Slot-Core/AbstractLayout.class.st
@@ -97,12 +97,6 @@ AbstractLayout >> host: aClass [
 ]
 
 { #category : #accessing }
-AbstractLayout >> instVarIndexFor: aString ifAbsent: aBlockClosure [
-	"we do not have instance variables"
-	^aBlockClosure value
-]
-
-{ #category : #accessing }
 AbstractLayout >> instVarNames [
 	^ {}
 ]

--- a/src/Slot-Core/PointerLayout.class.st
+++ b/src/Slot-Core/PointerLayout.class.st
@@ -167,17 +167,6 @@ PointerLayout >> initializeInstance: anInstance [
 ]
 
 { #category : #accessing }
-PointerLayout >> instVarIndexFor: aString ifAbsent: aBlockClosure [
-	| idx |
-	idx := 1.
-	slotScope do: [:each |
-		each isVisible ifTrue: [
-			each name = aString ifTrue: [^idx].
-			idx := idx +1]].
-	^aBlockClosure value
-]
-
-{ #category : #accessing }
 PointerLayout >> instVarNames [
 	^ slotScope visibleSlotNames
 ]


### PR DESCRIPTION
implement instVarIndexFor:ifAbsent: not by interating over all slots and counting, but instead by just asking the slot for it's index.

fixes #3497