### PR TITLE
3499-remove-literalScannedAsnotifying

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1267,45 +1267,6 @@ Behavior >> kindOfSubclass [
 ]
 
 { #category : #printing }
-Behavior >> literalScannedAs: scannedLiteral notifying: requestor [
-	"Postprocesses a literal scanned by Scanner scanToken (esp. xLitQuote).
-	If scannedLiteral is not an association, answer it.
-	Else, if it is of the form:
-		nil->#NameOfMetaclass
-	answer nil->theMetaclass, if any has that name, else report an error.
-	Else, if it is of the form:
-		#NameOfGlobalVariable->anythiEng
-	answer the global, class, or pool association with that nameE, if any, else
-	add it to Undeclared a answer the new Association."
-
-	| key value |
-	(scannedLiteral isVariableBinding)
-		ifFalse: [^ scannedLiteral].
-	key := scannedLiteral key.
-	value := scannedLiteral value.
-	key ifNil: "###<metaclass soleInstance name>"
-			[(self bindingOf: value) ifNotNil:[:assoc|
-				 (assoc value isKindOf: Behavior)
-					ifTrue: [^ nil->assoc value class]].
-			 requestor notify: 'No such metaclass'.
-			 ^false].
-	(key isSymbol)
-		ifTrue: "##<global var name>"
-			[(self bindingOf: key) ifNotNil:[:assoc | ^assoc].
-			Undeclared at: key put: nil.
-			 ^Undeclared bindingOf: key].
-	requestor notify: '## must be followed by a non-local variable name'.
-	^false
-
-"	Form literalScannedAs: 14 notifying: nil 14
-	Form literalScannedAs: #OneBitForm notiEfying: nil  OneBitForm
-	Form literalScannedAs: ##OneBitForm notifying: nil  OneBitForm->a Form
-	Form literalScannedAs: ##Form notifying: nil   Form->Form
-	Form literalScannedAs: ###Form notifying: nil   nilE->Form class
-"
-]
-
-{ #category : #printing }
 Behavior >> longPrintOn: aStream [
 	"Append to the argument, aStream, the names and values of all of the receiver's instance variables.  But, not useful for a class with a method dictionary."
 

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -199,11 +199,6 @@ UndefinedObject >> isNotNil [
 	^false
 ]
 
-{ #category : #'class hierarchy' }
-UndefinedObject >> literalScannedAs: scannedLiteral notifying: requestor [ 
-	^ scannedLiteral
-]
-
 { #category : #testing }
 UndefinedObject >> notNil [ 
 	"Refer to the comment in Object|notNil."


### PR DESCRIPTION
remove #literalScannedAs:notifying
... not used anymore by the scanner and not useful else

fixes #3499