### PR TITLE
3509-Slots-do-not-use-Association-to-reference-objects-in-compiled-code-but-AdditionalBinding

### DIFF
--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -634,7 +634,7 @@ OCASTTranslator >> visitNode: aNode [
 { #category : #'visitor-double dispatching' }
 OCASTTranslator >> visitParseErrorNode: anErrorNode [  
 	methodBuilder 
-		pushLiteralVariable: #error -> anErrorNode asSyntaxErrorNotification;
+		pushLiteralVariable: (AdditionalBinding key: #error value: anErrorNode asSyntaxErrorNotification);
 		send: #signal.
 
 

--- a/src/OpalCompiler-Tests/OCBytecodeGeneratorTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeGeneratorTest.class.st
@@ -331,7 +331,7 @@ OCBytecodeGeneratorTest >> testPushLiteralVariable [
 	cm := self newBytecodeGen
 		numArgs: 0;
 		numTemps: 0;
-		pushLiteralVariable: (LookupKey key: '1');
+		pushLiteralVariable: (AdditionalBinding key: '1');
 		returnTop;
 		compiledMethod.
 

--- a/src/Reflectivity/RFLiteralVariableNode.class.st
+++ b/src/Reflectivity/RFLiteralVariableNode.class.st
@@ -14,7 +14,7 @@ Class {
 
 { #category : #'instance creation' }
 RFLiteralVariableNode class >> value: anObject [
-	^self new binding: #RFMetaBinding -> anObject
+	^self new binding: (AdditionalBinding key: #RFMetaBinding value: anObject)
 ]
 
 { #category : #visiting }

--- a/src/Slot-Core/AdditionalBinding.class.st
+++ b/src/Slot-Core/AdditionalBinding.class.st
@@ -6,6 +6,8 @@ When handing over a dictionary with additonal binding to the compiler:
         evaluate: 'test := 42'.
 
 all associations are changed to be AdditionaBinding.
+
+AddionalBinding is used, too, by both Slots and Reflectivity to reference directly objects from generated code.
 "
 Class {
 	#name : #AdditionalBinding,

--- a/src/Slot-Core/LiteralVariable.class.st
+++ b/src/Slot-Core/LiteralVariable.class.st
@@ -67,7 +67,7 @@ LiteralVariable >> emitStore: aMethodBuilder [
 		addTemp: tempName;
 		storeTemp: tempName;
 		popTop;
-		pushLiteralVariable: #global -> self;
+		pushLiteralVariable: (AdditionalBinding key: #global value: self);
 		pushTemp: tempName;
 		send: #write:
 ]
@@ -75,7 +75,7 @@ LiteralVariable >> emitStore: aMethodBuilder [
 { #category : #'code generation' }
 LiteralVariable >> emitValue: aMethodBuilder [
 	aMethodBuilder
-		pushLiteralVariable: #global -> self;
+		pushLiteralVariable: (AdditionalBinding key: #global value: self);
 		send: #read
 ]
 

--- a/src/Slot-Core/Slot.class.st
+++ b/src/Slot-Core/Slot.class.st
@@ -157,7 +157,7 @@ Slot >> emitStore: aMethodBuilder [
 		storeTemp: tempName;
 		popTop;
 		pushReceiver;
-		pushLiteralVariable: #slot -> self;
+		pushLiteralVariable: (AdditionalBinding key: #slot value: self);
 		pushTemp: tempName;
 		send: #writeSlot:value:
 ]
@@ -165,7 +165,7 @@ Slot >> emitStore: aMethodBuilder [
 { #category : #'code generation' }
 Slot >> emitValue: aMethodBuilder [
 	aMethodBuilder
-		pushLiteralVariable: #slot -> self;
+		pushLiteralVariable: (AdditionalBinding key: #slot value: self);
 		pushReceiver;
 		send: #read:
 ]

--- a/src/Slot-Examples/RelationSlot.class.st
+++ b/src/Slot-Examples/RelationSlot.class.st
@@ -79,7 +79,7 @@ RelationSlot >> emitStore: aMethodBuilder [
 		storeTemp: tempName;
 		popTop;
 		pushReceiver;
-		pushLiteralVariable: #slot -> self;
+		pushLiteralVariable: (AdditionalBinding key: #slot value: self);
 		pushTemp: tempName;
 		send: #writeSlot:value:
 ]


### PR DESCRIPTION
fix all places where we use an association as a binding and instead use AdditionalBinding

fixes #3509