### PR TITLE
3511-browseAllAccessesTofrom-needs-to-use-slots-to-check-isAccessedIn

### DIFF
--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -7,12 +7,14 @@ SystemNavigation >> browseAllAccessesTo: instVarName from: aClass [
 
 	"self new browseAllAccessesTo: 'contents' from: Collection."
 
-	| coll |
+	| coll slot |
 	coll := self allAccessesTo: instVarName from: aClass.
-	^ self browseMessageList: coll name: 'Accesses to ' , instVarName autoSelect: instVarName refreshingBlock: [ :method | | index |
-			index := aClass instVarIndexFor: instVarName.
-			(method readsField: index)
-				or: [ method writesField: index ] ]
+	slot := aClass slotNamed: instVarName.
+	^ self
+		browseMessageList: coll
+		name: 'Accesses to ' , instVarName
+		autoSelect: instVarName
+		refreshingBlock: [ :method | slot isAccessedIn: method ]
 ]
 
 { #category : #'*Tool-Base' }


### PR DESCRIPTION
#browseAllAccessesTo:from: needs to use slots to check isAccessedIn:, else it would only correctly update for instance variable slots

fixes #3511