### PR TITLE
3513-RubSmalltalkEditorrefencesTo-should-no-use-instVarIndexOf-to-check-existence-of-invar

### DIFF
--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -988,7 +988,7 @@ RubSmalltalkEditor >> referencesTo: aVariableOrClassName [
 	env := self modelCurrentSelectedClass ifNil: [ Smalltalk globals ].
 
 	env isBehavior ifTrue: [
-		(env instVarIndexFor: aVariableOrClassName) > 0 ifTrue: [
+		(env hasSlotNamed: aVariableOrClassName) ifTrue: [
 		 ^ self systemNavigation browseAllAccessesTo: aVariableOrClassName from: env]].
 
 	ref:= (env bindingOf: aVariableOrClassName) ifNil: [ ^ self ].


### PR DESCRIPTION
fixes #3513