### PR TITLE
3514-SystemNavigation-allAccessesTo-instVarName-from-aClass-should-delegate-to-slot-with-allMethodsAccessingSlot

### DIFF
--- a/src/GT-SpotterExtensions-Core/Slot.extension.st
+++ b/src/GT-SpotterExtensions-Core/Slot.extension.st
@@ -8,10 +8,8 @@ Slot >> spotterAccessesFor: aStep [
 			aStep origin isKindOf: Class]]) ifTrue: [
 		aStep listProcessor
 				title: 'Accesses';
-				allCandidates: [ 
-					SystemNavigation default 
-						allAccessesTo: self name 
-						from: aStep previousStep origin ];
+				allCandidates: [  
+						(aStep previousStep origin slotNamed: self name) usingMethods ];
 				itemName: [:each | each asString];
 				filter: GTFilterSubstring ]
 ]

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -19,11 +19,10 @@ SystemNavigation class >> default [
 
 { #category : #query }
 SystemNavigation >> allAccessesTo: instVarName from: aClass [
-	| coll |
-	coll := OrderedCollection new.
-	aClass
-		withAllSubAndSuperclassesDo: [ :class | (class whichSelectorsAccess: instVarName) do: [ :sel | coll add: (self createMethodNamed: sel realParent: class) ] ].
-	^ coll
+	| methods |
+	methods := aClass allMethodsAccessingSlot: (aClass slotNamed: instVarName).
+	^methods collect: [:meth | self createMethodNamed: meth selector realParent: meth methodClass]
+
 ]
 
 { #category : #query }

--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -5,13 +5,15 @@ SystemNavigation >> browseAllAccessesTo: instVarName from: aClass [
 	"Create and schedule a Message Set browser for all the receiver's methods 
 	or any methods of a subclass/superclass that refer to the instance variable name."
 
-	"self new browseAllAccessesTo: 'contents' from: Collection."
+	"self new browseAllAccessesTo: 'x' from: Point."
 
-	| coll slot |
-	coll := self allAccessesTo: instVarName from: aClass.
+	| methods slot |
 	slot := aClass slotNamed: instVarName.
+	methods := (aClass allMethodsAccessingSlot: slot) 
+		collect: [:meth | self createMethodNamed: meth selector realParent: meth methodClass].
+	
 	^ self
-		browseMessageList: coll
+		browseMessageList: methods
 		name: 'Accesses to ' , instVarName
 		autoSelect: instVarName
 		refreshingBlock: [ :method | slot isAccessedIn: method ]


### PR DESCRIPTION
allAccessesTo: instVarName from: aClass should delegate to slot with allMethodsAccessingSlot:

fixes #3514