### PR TITLE
CustomHelp and subclasses should have systemIcon

### DIFF
--- a/src/HelpSystem-Core/CustomHelp.class.st
+++ b/src/HelpSystem-Core/CustomHelp.class.st
@@ -268,6 +268,12 @@ CustomHelp class >> subheading: aString [
 ]
 
 { #category : #accessing }
+CustomHelp class >> systemIcon [ 
+
+	^self icon
+]
+
+{ #category : #accessing }
 CustomHelp class >> theme [
 	^ Smalltalk ui theme
 ]


### PR DESCRIPTION
provide a systemIcon method in CustomHelp class so any subclass representing a help book has the correct icon already in system browser

Fix #3534