### PR TITLE
Alien: NotFoundError name is too generic, use LibrarySymbolNotFoundError

### DIFF
--- a/src/Alien-Core/Alien.class.st
+++ b/src/Alien-Core/Alien.class.st
@@ -274,7 +274,7 @@ Alien class >> lookupOrNil: symbol  "<String>" inLibrary: libraryName [ "<String
 	"Answer the address of symbol in libraryName, or nil if it is not in the library.
 	Exceptions will be raised for invalid libraries, symbol names, etc."
 	^[self lookup: symbol inLibrary: libraryName ]
-		on: NotFoundError
+		on: LibrarySymbolNotFoundError
 		do: [:ex| nil]
 ]
 
@@ -629,7 +629,7 @@ Alien >> primFindSymbol: symbolName [ "<String> ^<Integer>"
 	 its address, or fail if the receiver is invalid or the symbol cannot be found."
 	<primitive: 'primInLibraryFindSymbol' module: 'IA32ABI' error: errorCode>
 	^errorCode == #'not found'
-		ifTrue: [NotFoundError signal]
+		ifTrue: [LibrarySymbolNotFoundError signal]
 		ifFalse: [self primitiveFailed]
 ]
 

--- a/src/Alien-Core/LibrarySymbolNotFoundError.class.st
+++ b/src/Alien-Core/LibrarySymbolNotFoundError.class.st
@@ -1,0 +1,8 @@
+"
+A symbol within a library was not found, see Alien>>#primFindSymbol:
+"
+Class {
+	#name : #LibrarySymbolNotFoundError,
+	#superclass : #Error,
+	#category : #'Alien-Core'
+}

--- a/src/Alien-Core/NotFoundError.class.st
+++ b/src/Alien-Core/NotFoundError.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #NotFoundError,
-	#superclass : #Error,
-	#category : #'Alien-Core'
-}


### PR DESCRIPTION
- rename NotFoundError into LibrarySymbolNotFoundError (because the name is too generic)
- add a class comment

Fix #3536 and get in synch with Alien-Core-TorstenBergmann.101.mcz from http://www.squeaksource.com/Alien.html