### PR TITLE
3550-updateInstancesFrom-is-now-done-by-the-classbuilder

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -1371,65 +1371,6 @@ ClassDescription >> untagFrom: aSymbol [
 	package addClass: self
 ]
 
-{ #category : #initialization }
-ClassDescription >> updateInstances: oldInstances from: oldClass isMeta: isMeta [
-	"Recreate any existing instances of the argument, oldClass, as instances of the receiver,
-	 which is a newly changed class. Permute variables as necessary, and forward old instances
-	 to new instances.  Answer nil to defeat old clients that expect an array of old instances.
-	 The old behaviour, which necessitated a global GC, exchanged identities and answered
-	 the old instances.  But no clients used the result.  This way we avoid the unnecessary GC,"
-
-	| variable instSize newInstances |
-	oldInstances isEmpty
-		ifTrue: [ ^ nil ].	"no instances to convert"
-	isMeta ifTrue:
-		[(oldInstances size = 1
-		  and: [self soleInstance class == self
-				or: [self soleInstance class == oldClass]]) ifFalse:
-			[^self error: 'Metaclasses can only have one instance']].
-	variable := self isVariable.
-	instSize := self instSize.
-	newInstances := Array new: oldInstances size.
-	1 to: oldInstances size do: [ :i | newInstances at: i put: (self newInstanceFrom: (oldInstances at: i) variable: variable size: instSize) ].	"Now perform a bulk mutation of old instances into new ones"
-	oldInstances elementsForwardIdentityTo: newInstances.
-	^ nil
-]
-
-{ #category : #initialization }
-ClassDescription >> updateInstancesFrom: oldClass [
-	"Recreate any existing instances of the argument, oldClass, as instances of 
-	the receiver, which is a newly changed class. Permute variables as 
-	necessary. Return the array of old instances (none of which should be
-	pointed to legally by anyone but the array)."
-	"ar 7/15/1999: The updating below is possibly dangerous. If there are any
-	contexts having an old instance as receiver it might crash the system if
-	the new receiver in which the context is executed has a different layout.
-	See bottom below for a simple example:"
-	| oldInstances |
-	oldInstances := oldClass allInstances asArray.
-	oldInstances := self updateInstances: oldInstances from: oldClass isMeta: self isMeta.
-	^nil
-
-"	| crashingBlock class |
-	class := Object subclass: #CrashTestDummy
-		instanceVariableNames: 'instVar'
-		classVariableNames: ''
-		poolDictionaries: ''
-		category: 'Crash-Test'.
-	class compile:'instVar: value instVar := value'.
-	class compile:'crashingBlock ^[instVar]'.
-	crashingBlock := (class new) instVar: 42; crashingBlock.
-	Object subclass: #CrashTestDummy
-		instanceVariableNames: ''
-		classVariableNames: ''
-		poolDictionaries: ''
-		category: 'Crash-Test'.
-	crashingBlock.
-	crashingBlock value.
-	"
-
-]
-
 { #category : #'pool variable' }
 ClassDescription >> usesLocalPoolVarNamed: aString [
 	^false.


### PR DESCRIPTION
remove methods:

the (quite complex) logic in #updateInstancesFrom: and updateInstances:from:isMeta: has been taken over by the class builder (and takes into account user defined instance variables).

I think we should delete these methods: they are not part of the public API

fixes #3550