### PR TITLE
3557-cleanup-asSystemNavigationEnvironment

### DIFF
--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -117,29 +117,6 @@ RBBrowserEnvironment >> asSelectorEnvironment [
 	^(RBClassEnvironment onEnvironment: self classes: self classes) asSelectorEnvironment
 ]
 
-{ #category : #conversion }
-RBBrowserEnvironment >> asSystemNavigationEnvironment [
-
-	| env globalsNames |
-	"Optimization for the default environment AKA Smalltalk"
-	self class == RBBrowserEnvironment 
-		ifTrue: [ ^ Smalltalk globals ].
-	
-	env := SystemDictionary new.
-	
-	self classesDo: [:each | 
-		env add: ( Smalltalk globals associationAt: each instanceSide name )].
-	self traitsDo:  [:each | 
-		env add: ( Smalltalk globals associationAt: each name )].
-	globalsNames := Smalltalk globals keys asOrderedCollection.
-	globalsNames removeAll: ( Smalltalk globals classNames ).
-	 globalsNames removeAll: ( Smalltalk globals traitNames ).
-	globalsNames do: [:each | 
-		env add: ( Smalltalk globals associationAt: each )].
-
-	^ env
-]
-
 { #category : #'accessing-classes' }
 RBBrowserEnvironment >> associationAt: aKey [
 	^ self associationAt: aKey ifAbsent: [ self error: aKey printString , ' not found' ]

--- a/src/Refactoring-Environment/SystemNavigation.extension.st
+++ b/src/Refactoring-Environment/SystemNavigation.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #SystemNavigation }
-
-{ #category : #'*Refactoring-Environment' }
-SystemNavigation >> browsedEnvironment: aBrowserEnvironment [
-
-	environment := aBrowserEnvironment asSystemNavigationEnvironment
-]


### PR DESCRIPTION
#asSystemNavigationEnvironment is not used anymore. I do not think that deprecation is needed as it was an internal feature, not a public API

fixes #3557