### PR TITLE
3559-cleanup-allClassesUsingSharedPool

### DIFF
--- a/src/Kernel/SharedPool.class.st
+++ b/src/Kernel/SharedPool.class.st
@@ -73,10 +73,7 @@ SharedPool class >> localBindingOf: varName [
 
 { #category : #pools }
 SharedPool class >> poolUsers [
-	"Answer an Array of all classes that uses the shared pool"
+	"Answer all classes that uses the shared pool"
 
-	| aCollection |
-	aCollection := ReadWriteStream on: Array new.
-	self environment allClassesDo: [:class | (class includesSharedPoolNamed: self name) ifTrue: [aCollection nextPut: class]].
-	^ aCollection contents
+	^self environment allClasses select:  [:class | class includesSharedPoolNamed: self name]
 ]

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -110,12 +110,12 @@ SystemNavigation >> allClassesInPackageNamed: packageName [
 
 { #category : #query }
 SystemNavigation >> allClassesUsingSharedPool: aString [  
-	"Answer an Array of all classes that uses the shared pool named aString."
+	"Answer all classes that uses the shared pool named aString."
 
-	| aCollection |
-	aCollection := ReadWriteStream on: Array new.
-	self allClassesDo: [:class | (class includesSharedPoolNamed: aString) ifTrue: [aCollection nextPut: class]].
-	^ aCollection contents
+	| pool |
+	self deprecated: 'just use #poolUsers directly'.
+	pool := self environment classNamed: aString ifAbsent: [ ^#() ].
+	^pool poolUsers
 ]
 
 { #category : #query }
@@ -304,22 +304,6 @@ SystemNavigation >> allReferencesToPool: aPool [
 						detect: [ :lit | (lit isVariableBinding and: [ lit key notNil ]) 
 													and: [ aPool includesKey: lit key ] ]
 						ifFound: [ list add: (self createMethodNamed: sel realParent: cls) ] ] ].
-	^ list
-]
-
-{ #category : #query }
-SystemNavigation >> allReferencesToPool: aPool from: aClass [
-	"Answer all the references to variables from aPool"
-
-	| list |
-	list := OrderedCollection new.
-	aClass
-		withAllSubclassesDo: [ :cls | 
-			cls
-				selectorsAndMethodsDo: [ :sel :meth | 
-					meth literals
-						detect: [ :lit | lit isVariableBinding and: [ (aPool bindingOf: lit key) notNil ] ]
-						ifFound: [ list add: (self createMethodNamed: sel realParent: aClass) ] ] ].
 	^ list
 ]
 

--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -350,23 +350,6 @@ SystemNavigation >> browseSendersOf: aSelector name: labelString autoSelect: aut
 ]
 
 { #category : #'*Tool-Base' }
-SystemNavigation >> browseSharedPoolUsersOf: aClass [
-
-	| pattern list | 
-	self okToChange ifFalse: [^ self ].
-	list := aClass poolUsers.
-	list isEmpty
-		ifTrue: [ ^ self ]
-		ifFalse: [pattern := UIManager default 
-				enterOrRequestFrom: list 
-				lines: #() 
-				title: 'Class name or fragment?'].
-
-	pattern ifNil: [^ self ].
-	pattern browse
-]
-
-{ #category : #'*Tool-Base' }
 SystemNavigation >> browseUndeclaredReferences [
 	"
 	SystemNavigation new browseUndeclaredReferences


### PR DESCRIPTION
- allClassesUsingSharedPool: can be deprecated as we have #poolUsers
- simplify poolUsers
- remove some dead code

fixes #3559