### PR TITLE
3565-Small-cleanup-on-SystemNavigation-and-SmalltalkImage

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
@@ -50,8 +50,7 @@ ClyClassDefinitionEditorToolMorph >> defaultIconName [
 { #category : #accessing }
 ClyClassDefinitionEditorToolMorph >> editingText [
 	self flag: #todo.
-	
-	^editingClass definitionForNautilus
+	^ editingClass definition
 ]
 
 { #category : #building }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1565,12 +1565,7 @@ SmalltalkImage >> renameClass: aClass from: oldName [
 SmalltalkImage >> renameClassNamed: oldName as: newName [
 	"Invoked from fileouts:  if there is currently a class in the system named oldName, then rename it to newName.  If anything untoward happens, report it in the Transcript.  "
 
-	| oldClass |
-	(oldClass := self at: oldName asSymbol ifAbsent: [ nil ]) 
-		ifNil: [ 
-			self crTrace: 'Class-rename for ' , oldName , ' ignored because ' , oldName , ' does not exist.'.
-			^ self ].
-	oldClass rename: newName
+	^ globals renameClassNamed: oldName as: newName
 ]
 
 { #category : #'memory space' }

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -49,11 +49,11 @@ SystemDictionary >> allBehaviors [
 SystemDictionary >> allBehaviorsDo: aBlock [
 	"Execute a block on each class, metaclass, trait and trait class"
 
-	self environment valuesDo: [ :aClass |
+	self valuesDo: [ :aClass |
 		aClass isBehavior ifTrue: [  
 			aBlock
 				value: aClass;
-				value: aClass classSide]].
+				value: aClass classSide]]
 ]
 
 { #category : #'classes and traits' }

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -46,6 +46,17 @@ SystemDictionary >> allBehaviors [
 ]
 
 { #category : #'classes and traits' }
+SystemDictionary >> allBehaviorsDo: aBlock [
+	"Execute a block on each class, metaclass, trait and trait class"
+
+	self environment valuesDo: [ :aClass |
+		aClass isBehavior ifTrue: [  
+			aBlock
+				value: aClass;
+				value: aClass classSide]].
+]
+
+{ #category : #'classes and traits' }
 SystemDictionary >> allClasses [  
 	"Return all the class defines in the Smalltalk SystemDictionary"
 

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -34,11 +34,7 @@ SystemNavigation >> allBehaviors [
 SystemNavigation >> allBehaviorsDo: aBlock [
 	"Execute a block on each class, metaclass, trait and trait class"
 
-	self environment valuesDo: [ :aClass |
-		aClass isBehavior ifTrue: [  
-			aBlock
-				value: aClass;
-				value: aClass classSide]].
+	self environment allBehaviorsDo: aBlock
 ]
 
 { #category : #query }
@@ -87,12 +83,8 @@ SystemNavigation >> allClassesDo: aBlock [
 
 { #category : #query }
 SystemNavigation >> allClassesImplementing: aSelector [  
-	"Answer an Array of all classes that implement the message aSelector."
-
-	| aCollection |
-	aCollection := ReadWriteStream on: Array new.
-	self allBehaviorsDo: [:class | (class includesSelector: aSelector) ifTrue: [aCollection nextPut: class]].
-	^ aCollection contents
+	"Answer all classes that implement the message aSelector."
+	^self allBehaviors collect: [:class | class includesSelector: aSelector]
 ]
 
 { #category : #packages }
@@ -122,18 +114,7 @@ SystemNavigation >> allClassesUsingSharedPool: aString [
 SystemNavigation >> allExistingProtocolsFor: instanceSide [
 	"Answer all protocols on instance or class side"
 	
-	| allExistingProtocols |
-	allExistingProtocols := environment allClassesAndTraits
-		inject: IdentitySet new
-		into: [ :col :e | 
-			| class |
-			class := instanceSide
-				ifTrue: [ e instanceSide ]
-				ifFalse: [ e classSide ].
-			col
-				addAll: class protocols;
-				yourself ].
-	^ allExistingProtocols
+	^self allBehaviors flatCollectAsSet: [ :class | class protocols ]
 ]
 
 { #category : #private }
@@ -152,10 +133,7 @@ SystemNavigation >> allGlobalRefsOn: aSymbol [
 SystemNavigation >> allImplementedMessages [
 	"Answer a Collection of all the messages that are implemented in the system."
 	
-	| messages |
-	messages := IdentitySet new.
-	self allBehaviorsDo: [:each | messages addAll: each selectors].
-	^ messages
+	^Symbol selectorTable
 ]
 
 { #category : #query }
@@ -490,10 +468,8 @@ SystemNavigation >> isUnsentMessage: selector [
 
 { #category : #'message sends' }
 SystemNavigation >> isUsedClass: aClass [
-
-	self allBehaviorsDo: [ :behavior | 
-		(behavior hasSelectorReferringTo: aClass binding) ifTrue: [ ^true ]].
-	^ false
+	self deprecated: 'just use #isUsed'.
+	^aClass isUsed
 ]
 
 { #category : #query }

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -113,8 +113,8 @@ SystemNavigation >> allClassesUsingSharedPool: aString [
 { #category : #query }
 SystemNavigation >> allExistingProtocolsFor: instanceSide [
 	"Answer all protocols on instance or class side"
-	
-	^self allBehaviors flatCollectAsSet: [ :class | class protocols ]
+
+	^self allClasses flatCollectAsSet: [ :class | instanceSide ifTrue: [class protocols] ifFalse: [ class class protocols ] ]
 ]
 
 { #category : #private }


### PR DESCRIPTION
- renameClassNamed:as: is implemented the same on SystemDictionary and SmallkImage -> just forward one to the other
- implement #allBehaviorsDo: in SytemDictionary

SystemNavigation:

- allBehaviorsDo: can forward to the environment like all other similar methods
- simplify allClassesImplementing: and allExistingProtocolsFor: by using the collection protocol correctly
- allImplementedMessages can use the selector cache on Symbol instead of iterating over all methods
- deprecate unused isUsedClass: (we have #isUsed on class)

fixes #3565