### PR TITLE
3578-add-usingMethods-to-SharedPool-class

### DIFF
--- a/src/Calypso-Browser/ClyQueryViewMorph.class.st
+++ b/src/Calypso-Browser/ClyQueryViewMorph.class.st
@@ -398,12 +398,12 @@ ClyQueryViewMorph >> findItemsWith: actualObjects [
 { #category : #accessing }
 ClyQueryViewMorph >> grabSelectionAt: rowIndex [
 	| selectedItems |
-	(table isRowIndexSelected: rowIndex) ifTrue: [^self selection].
-	
-	selectedItems := rowIndex = 0 
-		ifTrue: [ #() ] ifFalse: [{self itemAt: rowIndex}].
-		
-	^self newSelectionWith: selectedItems.
+	(table isIndexSelected: rowIndex)
+		ifTrue: [ ^ self selection ].
+	selectedItems := rowIndex = 0
+		ifTrue: [ #() ]
+		ifFalse: [ {(self itemAt: rowIndex)} ].
+	^ self newSelectionWith: selectedItems
 ]
 
 { #category : #testing }

--- a/src/Kernel/SharedPool.class.st
+++ b/src/Kernel/SharedPool.class.st
@@ -77,3 +77,10 @@ SharedPool class >> poolUsers [
 
 	^self environment allClasses select:  [:class | class includesSharedPoolNamed: self name]
 ]
+
+{ #category : #pools }
+SharedPool class >> usingMethods [
+	"Answer all methods that use one of the variables defined by the shared pool"
+
+	^self classVariables flatCollect: [ :variable | variable usingMethods ]
+]


### PR DESCRIPTION
- add #usingMethods to get all methods that read or write the variables in a shared pool
- commit an automatic rewrite in Calypso