### PR TITLE
3580-unify-RGMethodDefinition-creation-in-SystemNavigation-and-methodReference

### DIFF
--- a/src/Ring-Deprecated-Core-Kernel/CompiledMethod.extension.st
+++ b/src/Ring-Deprecated-Core-Kernel/CompiledMethod.extension.st
@@ -77,7 +77,8 @@ CompiledMethod >> methodReference [
 	| class selector |
 	class := self methodClass ifNil: [^nil].
 	selector := self selector ifNil: [^nil].
-	^RGMethodDefinition realClass: class selector: selector.
+	^(RGMethodDefinition realClass: class selector: selector) 
+		package: (class>>selector) package asRingDefinition; yourself
 	
 ]
 

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -401,10 +401,7 @@ SystemNavigation >> categoriesInPackageNamed: packageName [
 { #category : #query }
 SystemNavigation >> createMethodNamed: aSelector realParent: class [
 
-	"This method has some problems."
-	"1 - It should use the object that comes from the browsed environment"
-	"2 - It does not create a method but a representation of it so be careful"
-	^ (RGMethodDefinition realClass: class selector: aSelector) package:  (class>>aSelector) package asRingDefinition; yourself .
+	^ (class>>aSelector) methodReference
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
unify RGMethodDefinition creation in SystemNavigation and #methodReference

fixes #3580