### PR TITLE
added a test and modified BIConfigurableFormatter

### DIFF
--- a/src/BlueInk-Core/BIConfigurableFormatter.class.st
+++ b/src/BlueInk-Core/BIConfigurableFormatter.class.st
@@ -498,6 +498,7 @@ BIConfigurableFormatter >> currentLineLength [
 { #category : #'public interface' }
 BIConfigurableFormatter >> format: aParseTree [
 	originalSource := aParseTree source.
+	self initializeCodeStream.
 	self visitNode: aParseTree.
 	^ codeStream contents
 ]
@@ -843,8 +844,13 @@ BIConfigurableFormatter >> initialize [
 	self indent: 0.
 	self isInCascadeNode: false.
 	lookaheadCode := IdentityDictionary new.
-	codeStream := WriteStream on: (String new: 256).
+	self initializeCodeStream.
 	context := DefaultPrettyPrintContext
+]
+
+{ #category : #initialization }
+BIConfigurableFormatter >> initializeCodeStream [
+	codeStream := WriteStream on: (String new: 256)
 ]
 
 { #category : #'public interface' }

--- a/src/BlueInk-Tests/BIConfigurableFormatterFormattingTest.class.st
+++ b/src/BlueInk-Tests/BIConfigurableFormatterFormattingTest.class.st
@@ -17,3 +17,13 @@ BIConfigurableFormatterFormattingTest class >> shouldInheritSelectors [
 BIConfigurableFormatterFormattingTest >> formatterClass [
 	^ BIConfigurableFormatter
 ]
+
+{ #category : #tests }
+BIConfigurableFormatterFormattingTest >> testShouldReinitializeCodeStreamBetweenFormating [
+	|astNode formater context|
+	context := BIPrettyPrinterContext new.
+	formater := BIConfigurableFormatter new installNewContext: context.
+	astNode := RBParser parseExpression: '1'.
+	self assert: (formater format: astNode) equals: '1'.
+	self assert: (formater format: astNode) equals: '1'.
+]


### PR DESCRIPTION
Corrected issue #3518 where the codeStream of the pretty printer didn't reinitialized between two format
Exemple

	|astNode formater context|
	context := BIPrettyPrinterContext new.
	formater := BIConfigurableFormatter new installNewContext: context.
	astNode := RBParser parseExpression: '1'.

	formater format: astNode will give '1'
	formater format: astNode will give '11'
