### PR TITLE
3600-Iceberg-is-sometimes-unable-to-commit-classes

### DIFF
--- a/src/Monticello/MCCacheRepository.class.st
+++ b/src/Monticello/MCCacheRepository.class.st
@@ -7,9 +7,9 @@ Class {
 	#name : #MCCacheRepository,
 	#superclass : #MCDirectoryRepository,
 	#instVars : [
+		'cacheEnabled',
 		'packageCaches',
-		'seenFiles',
-		'cacheEnabled'
+		'seenFiles'
 	],
 	#classInstVars : [
 		'default'

--- a/src/Monticello/MCChangeSelectionRequest.class.st
+++ b/src/Monticello/MCChangeSelectionRequest.class.st
@@ -5,8 +5,8 @@ Class {
 	#name : #MCChangeSelectionRequest,
 	#superclass : #Notification,
 	#instVars : [
-		'patch',
-		'label'
+		'label',
+		'patch'
 	],
 	#category : #'Monticello-Versioning'
 }

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -5,15 +5,15 @@ Class {
 	#name : #MCClassDefinition,
 	#superclass : #MCDefinition,
 	#instVars : [
-		'name',
-		'superclassName',
-		'variables',
 		'category',
-		'type',
+		'classTraitComposition',
 		'comment',
 		'commentStamp',
+		'name',
+		'superclassName',
 		'traitComposition',
-		'classTraitComposition'
+		'type',
+		'variables'
 	],
 	#category : #'Monticello-Modeling'
 }
@@ -357,31 +357,20 @@ commentStamp: stampStringOrNil [
 ]
 
 { #category : #initializing }
-MCClassDefinition >> initializeWithName: nameString
-superclassName: superclassString
-traitComposition: traitCompositionString
-classTraitComposition: classTraitCompositionString
-category: categoryString 
-instVarNames: ivarArray
-classVarNames: cvarArray
-poolDictionaryNames: poolArray
-classInstVarNames: civarArray
-type: typeSymbol
-comment: commentString
-commentStamp: stampStringOrNil [
+MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol comment: commentString commentStamp: stampStringOrNil [
 	name := nameString asSymbol.
-	superclassName := superclassString ifNil: ['nil'] ifNotNil: [superclassString asSymbol].
+	superclassName := superclassString ifNil: [ 'nil' ] ifNotNil: [ superclassString asSymbol ].
 	traitComposition := traitCompositionString.
 	classTraitComposition := classTraitCompositionString.
 	category := categoryString.
-	name = #CompiledMethod ifTrue: [type := #compiledMethod] ifFalse: [type := typeSymbol].
+	name = #CompiledMethod ifTrue: [ type := #compiledMethod ] ifFalse: [ type := typeSymbol ].
 	comment := commentString withSqueakLineEndings.
-	commentStamp := stampStringOrNil ifNil: [self defaultCommentStamp].
-	variables := OrderedCollection  new.
-	self addVariables: ivarArray ofType: MCInstanceVariableDefinition.
+	commentStamp := stampStringOrNil ifNil: [ self defaultCommentStamp ].
+	variables := OrderedCollection new.
+	self addVariables: ivarArray asSortedCollection ofType: MCInstanceVariableDefinition.
 	self addVariables: cvarArray asSortedCollection ofType: MCClassVariableDefinition.
 	self addVariables: poolArray asSortedCollection ofType: MCPoolImportDefinition.
-	self addVariables: civarArray ofType: MCClassInstanceVariableDefinition.
+	self addVariables: civarArray ofType: MCClassInstanceVariableDefinition
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCClassTraitDefinition.class.st
+++ b/src/Monticello/MCClassTraitDefinition.class.st
@@ -6,8 +6,8 @@ Class {
 	#superclass : #MCDefinition,
 	#instVars : [
 		'baseTrait',
-		'classTraitComposition',
-		'category'
+		'category',
+		'classTraitComposition'
 	],
 	#category : #'Monticello-Modeling'
 }

--- a/src/Monticello/MCDataStream.class.st
+++ b/src/Monticello/MCDataStream.class.st
@@ -24,9 +24,9 @@ Class {
 	#name : #MCDataStream,
 	#superclass : #Stream,
 	#instVars : [
+		'basePos',
 		'byteStream',
-		'topCall',
-		'basePos'
+		'topCall'
 	],
 	#classVars : [
 		'ReadSelectors',

--- a/src/Monticello/MCDependencySorter.class.st
+++ b/src/Monticello/MCDependencySorter.class.st
@@ -5,9 +5,9 @@ Class {
 	#name : #MCDependencySorter,
 	#superclass : #Object,
 	#instVars : [
-		'required',
+		'orderedItems',
 		'provided',
-		'orderedItems'
+		'required'
 	],
 	#category : #'Monticello-Loading'
 }

--- a/src/Monticello/MCFileBasedRepository.class.st
+++ b/src/Monticello/MCFileBasedRepository.class.st
@@ -5,8 +5,8 @@ Class {
 	#name : #MCFileBasedRepository,
 	#superclass : #MCRepository,
 	#instVars : [
-		'cache',
 		'allFileNames',
+		'cache',
 		'cacheFileNames'
 	],
 	#category : #'Monticello-Repositories'

--- a/src/Monticello/MCFrontier.class.st
+++ b/src/Monticello/MCFrontier.class.st
@@ -5,8 +5,8 @@ Class {
 	#name : #MCFrontier,
 	#superclass : #Object,
 	#instVars : [
-		'frontier',
-		'bag'
+		'bag',
+		'frontier'
 	],
 	#category : #'Monticello-Versioning'
 }

--- a/src/Monticello/MCMczReader.class.st
+++ b/src/Monticello/MCMczReader.class.st
@@ -5,9 +5,9 @@ Class {
 	#name : #MCMczReader,
 	#superclass : #MCVersionReader,
 	#instVars : [
-		'zip',
+		'filename',
 		'infoCache',
-		'filename'
+		'zip'
 	],
 	#category : #'Monticello-Storing'
 }

--- a/src/Monticello/MCMczWriter.class.st
+++ b/src/Monticello/MCMczWriter.class.st
@@ -5,8 +5,8 @@ Class {
 	#name : #MCMczWriter,
 	#superclass : #MCWriter,
 	#instVars : [
-		'zip',
-		'infoWriter'
+		'infoWriter',
+		'zip'
 	],
 	#category : #'Monticello-Storing'
 }

--- a/src/Monticello/MCMergeRecord.class.st
+++ b/src/Monticello/MCMergeRecord.class.st
@@ -5,12 +5,12 @@ Class {
 	#name : #MCMergeRecord,
 	#superclass : #Object,
 	#instVars : [
-		'version',
-		'packageSnapshot',
 		'ancestorInfo',
 		'ancestorSnapshot',
 		'imagePatch',
-		'mergePatch'
+		'mergePatch',
+		'packageSnapshot',
+		'version'
 	],
 	#category : #'Monticello-Versioning'
 }

--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -16,11 +16,11 @@ Class {
 	#name : #MCMethodDefinition,
 	#superclass : #MCDefinition,
 	#instVars : [
-		'classIsMeta',
-		'source',
 		'category',
-		'selector',
+		'classIsMeta',
 		'className',
+		'selector',
+		'source',
 		'timeStamp'
 	],
 	#classVars : [

--- a/src/Monticello/MCModification.class.st
+++ b/src/Monticello/MCModification.class.st
@@ -5,8 +5,8 @@ Class {
 	#name : #MCModification,
 	#superclass : #MCPatchOperation,
 	#instVars : [
-		'obsoletion',
-		'modification'
+		'modification',
+		'obsoletion'
 	],
 	#category : #'Monticello-Patching'
 }

--- a/src/Monticello/MCPackageCache.class.st
+++ b/src/Monticello/MCPackageCache.class.st
@@ -5,8 +5,8 @@ Class {
 	#name : #MCPackageCache,
 	#superclass : #Object,
 	#instVars : [
-		'sorter',
-		'fileNames'
+		'fileNames',
+		'sorter'
 	],
 	#category : #'Monticello-Repositories'
 }

--- a/src/Monticello/MCPackageLoader.class.st
+++ b/src/Monticello/MCPackageLoader.class.st
@@ -16,14 +16,14 @@ Class {
 	#name : #MCPackageLoader,
 	#superclass : #Object,
 	#instVars : [
-		'requirements',
-		'unloadableDefinitions',
-		'obsoletions',
 		'additions',
-		'removals',
 		'errorDefinitions',
+		'methodAdditions',
+		'obsoletions',
 		'provisions',
-		'methodAdditions'
+		'removals',
+		'requirements',
+		'unloadableDefinitions'
 	],
 	#category : #'Monticello-Loading'
 }

--- a/src/Monticello/MCPackageManager.class.st
+++ b/src/Monticello/MCPackageManager.class.st
@@ -13,8 +13,8 @@ Class {
 	#name : #MCPackageManager,
 	#superclass : #Model,
 	#instVars : [
-		'package',
-		'modified'
+		'modified',
+		'package'
 	],
 	#classVars : [
 		'PrivateAnnouncer'

--- a/src/Monticello/MCScriptDefinition.class.st
+++ b/src/Monticello/MCScriptDefinition.class.st
@@ -5,8 +5,8 @@ Class {
 	#name : #MCScriptDefinition,
 	#superclass : #MCDefinition,
 	#instVars : [
-		'script',
-		'packageName'
+		'packageName',
+		'script'
 	],
 	#category : #'Monticello-Modeling'
 }

--- a/src/Monticello/MCVersion.class.st
+++ b/src/Monticello/MCVersion.class.st
@@ -5,11 +5,11 @@ Class {
 	#name : #MCVersion,
 	#superclass : #Object,
 	#instVars : [
-		'package',
-		'info',
-		'snapshot',
+		'completeSnapshot',
 		'dependencies',
-		'completeSnapshot'
+		'info',
+		'package',
+		'snapshot'
 	],
 	#category : #'Monticello-Versioning'
 }

--- a/src/Monticello/MCVersionInfo.class.st
+++ b/src/Monticello/MCVersionInfo.class.st
@@ -5,12 +5,12 @@ Class {
 	#name : #MCVersionInfo,
 	#superclass : #MCAncestry,
 	#instVars : [
-		'id',
-		'name',
-		'message',
+		'author',
 		'date',
-		'time',
-		'author'
+		'id',
+		'message',
+		'name',
+		'time'
 	],
 	#category : #'Monticello-Versioning'
 }

--- a/src/Monticello/MCVersionLoaderStarted.class.st
+++ b/src/Monticello/MCVersionLoaderStarted.class.st
@@ -5,8 +5,8 @@ Class {
 	#name : #MCVersionLoaderStarted,
 	#superclass : #Announcement,
 	#instVars : [
-		'versionLoader',
-		'label'
+		'label',
+		'versionLoader'
 	],
 	#category : #'Monticello-Announcements'
 }

--- a/src/Monticello/MCVersionLoaderStopped.class.st
+++ b/src/Monticello/MCVersionLoaderStopped.class.st
@@ -5,8 +5,8 @@ Class {
 	#name : #MCVersionLoaderStopped,
 	#superclass : #Announcement,
 	#instVars : [
-		'versionLoader',
-		'label'
+		'label',
+		'versionLoader'
 	],
 	#category : #'Monticello-Announcements'
 }

--- a/src/Monticello/MCVersionMerger.class.st
+++ b/src/Monticello/MCVersionMerger.class.st
@@ -5,8 +5,8 @@ Class {
 	#name : #MCVersionMerger,
 	#superclass : #Object,
 	#instVars : [
-		'records',
-		'merger'
+		'merger',
+		'records'
 	],
 	#category : #'Monticello-Versioning'
 }

--- a/src/Monticello/MCVersionNameAndMessageRequest.class.st
+++ b/src/Monticello/MCVersionNameAndMessageRequest.class.st
@@ -5,8 +5,8 @@ Class {
 	#name : #MCVersionNameAndMessageRequest,
 	#superclass : #Notification,
 	#instVars : [
-		'suggestion',
-		'suggestedLogComment'
+		'suggestedLogComment',
+		'suggestion'
 	],
 	#category : #'Monticello-Versioning'
 }

--- a/src/Monticello/MCVersionReader.class.st
+++ b/src/Monticello/MCVersionReader.class.st
@@ -5,10 +5,10 @@ Class {
 	#name : #MCVersionReader,
 	#superclass : #MCReader,
 	#instVars : [
-		'package',
-		'info',
 		'definitions',
-		'dependencies'
+		'dependencies',
+		'info',
+		'package'
 	],
 	#category : #'Monticello-Storing'
 }

--- a/src/Monticello/MCVersionSaved.class.st
+++ b/src/Monticello/MCVersionSaved.class.st
@@ -5,8 +5,8 @@ Class {
 	#name : #MCVersionSaved,
 	#superclass : #Announcement,
 	#instVars : [
-		'version',
-		'repository'
+		'repository',
+		'version'
 	],
 	#category : #'Monticello-Announcements'
 }

--- a/src/Monticello/MCVersionSorter.class.st
+++ b/src/Monticello/MCVersionSorter.class.st
@@ -5,11 +5,11 @@ Class {
 	#name : #MCVersionSorter,
 	#superclass : #Object,
 	#instVars : [
-		'layers',
 		'depthIndex',
 		'depths',
-		'stepparents',
-		'roots'
+		'layers',
+		'roots',
+		'stepparents'
 	],
 	#category : #'Monticello-Versioning'
 }

--- a/src/Monticello/MethodAddition.class.st
+++ b/src/Monticello/MethodAddition.class.st
@@ -5,16 +5,16 @@ Class {
 	#name : #MethodAddition,
 	#superclass : #Object,
 	#instVars : [
-		'text',
 		'category',
 		'changeStamp',
-		'requestor',
+		'compiledMethod',
 		'logSource',
 		'myClass',
-		'selector',
-		'compiledMethod',
+		'priorCategoryOrNil',
 		'priorMethodOrNil',
-		'priorCategoryOrNil'
+		'requestor',
+		'selector',
+		'text'
 	],
 	#category : #'Monticello-Loading'
 }


### PR DESCRIPTION
Fix bug in MCClassDefinition

In some cases we receive a string of variables (expl: 'var1 var2 var3') and we need to transform it into a collection of variable names. 

Fixes #3600