### PR TITLE
Fix (P7) forked processes of TestResource from being terminated between TestCase methods being executed

### DIFF
--- a/src/SUnit-Core/TestResource.class.st
+++ b/src/SUnit-Core/TestResource.class.st
@@ -97,9 +97,13 @@ TestResource class >> makeAvailable [
 	current := nil.
 	candidate := self new.
 	self resources do: [:each | each availableFor: candidate].
-	[candidate setUp.
+	
+	"Execute the TestResource's #setUp method within the DefaultExecutionEnvironment to prevent
+	forked processes created within #setUp from being terminated by the TestExecutionEnvironment
+	(in #checkForkedProcesses) it is running in."
+	DefaultExecutionEnvironment beActiveDuring: [[candidate setUp.
 	candidate isAvailable ifTrue: [current := candidate]]
-		ensure: [current == candidate ifFalse: [candidate tearDown]]
+		ensure: [current == candidate ifFalse: [candidate tearDown]]]
 ]
 
 { #category : #'instance creation' }

--- a/src/SUnit-Tests/TestResourceWithForkedProcessTestCase.class.st
+++ b/src/SUnit-Tests/TestResourceWithForkedProcessTestCase.class.st
@@ -1,0 +1,37 @@
+"
+SUnit tests for forked processes in test resources
+"
+Class {
+	#name : #TestResourceWithForkedProcessTestCase,
+	#superclass : #TestCase,
+	#category : #'SUnit-Tests-Core'
+}
+
+{ #category : #accessing }
+TestResourceWithForkedProcessTestCase class >> resources [
+
+	"Answer the TestResource class having a forked process"
+
+	^ Array with: WithForkedProcessTestResource
+]
+
+{ #category : #tests }
+TestResourceWithForkedProcessTestCase >> testFirst [
+
+	"Test whether the TestResource's forked process is not terminated.
+	A second test method will do the same and thereby validate that forked processes
+	of a TestResource do not get terminated (in between tests)."
+
+	self
+		assert: WithForkedProcessTestResource current forkedProcess isTerminated not
+		description: 'A forked process within a TestResource should not be terminated'
+]
+
+{ #category : #tests }
+TestResourceWithForkedProcessTestCase >> testSecond [
+
+	"Test whether the TestResource's forked process is not terminated between tests"
+
+	"Use the other test method's implementation"
+	self testFirst
+]

--- a/src/SUnit-Tests/WithForkedProcessTestResource.class.st
+++ b/src/SUnit-Tests/WithForkedProcessTestResource.class.st
@@ -1,0 +1,39 @@
+"
+I am a TestResource for testing whether my forked processes do not get terminated
+between individual TestCases being executed.
+"
+Class {
+	#name : #WithForkedProcessTestResource,
+	#superclass : #TestResource,
+	#instVars : [
+		'forkedProcess'
+	],
+	#category : #'SUnit-Tests-Resources'
+}
+
+{ #category : #accessing }
+WithForkedProcessTestResource >> forkedProcess [
+
+	"Answer the receiver's forked process"
+
+	^ forkedProcess
+]
+
+{ #category : #running }
+WithForkedProcessTestResource >> setUp [
+
+	"Create a forked process which should live until the #tearDown message is received.
+	The process is and should remain in suspended state."
+
+	super setUp.
+	forkedProcess := [ "empty process" ] newProcess
+]
+
+{ #category : #running }
+WithForkedProcessTestResource >> tearDown [
+
+	"Terminate forked process"
+
+	super tearDown.
+	forkedProcess ifNotNil: [ forkedProcess terminate ]
+]


### PR DESCRIPTION
Fixes issue number 3582 in Pharo7.0 branche (another PR is already created for Pharo8.0 branche)