### PR TITLE
3606 - Add option to rename parameters

### DIFF
--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -15,7 +15,8 @@ Class {
 		'extractedParseTree',
 		'modifiedParseTree',
 		'parameters',
-		'needsReturn'
+		'needsReturn',
+		'dictParameters'
 	],
 	#category : #'Refactoring-Core-Refactorings'
 }
@@ -124,6 +125,16 @@ RBExtractMethodRefactoring >> checkTemporaries [
 { #category : #transforming }
 RBExtractMethodRefactoring >> createTemporariesInExtractedMethodFor: assigned [ 
 	assigned do: [:each | extractedParseTree body addTemporaryNamed: each]
+]
+
+{ #category : #accessing }
+RBExtractMethodRefactoring >> dictParameters [
+	^ dictParameters
+]
+
+{ #category : #accessing }
+RBExtractMethodRefactoring >> dictParameters: aDictionary [
+	dictParameters := aDictionary 
 ]
 
 { #category : #transforming }
@@ -327,6 +338,25 @@ RBExtractMethodRefactoring >> remainingTemporaries [
 	^temps
 ]
 
+{ #category : #accessing }
+RBExtractMethodRefactoring >> renameAllParameters [
+	dictParameters ifNotNil: [
+		dictParameters keysAndValuesDo: [ :key : value | 
+			key ~= value ifTrue: [ self renameParameterWith: key to: value ]]
+	]
+]
+
+{ #category : #accessing }
+RBExtractMethodRefactoring >> renameNode: aParseTree withOldName: oldName toWithName: newName [ 
+	(RBParseTreeRewriter rename: oldName to: newName) executeTree: aParseTree
+]
+
+{ #category : #accessing }
+RBExtractMethodRefactoring >> renameParameterWith: oldName to: newName [
+	self renameNode: extractedParseTree withOldName: oldName toWithName: newName.
+	
+]
+
 { #category : #transforming }
 RBExtractMethodRefactoring >> reorderParametersToMatch: aSelector [ 
 	| tree dictionary |
@@ -364,7 +394,33 @@ RBExtractMethodRefactoring >> transform [
 				ifFalse: [existingSelector]).
 	existingSelector isNil 
 		ifTrue: 
-			[class compile: extractedParseTree newSource
+			[ self renameAllParameters.
+			class compile: extractedParseTree newSource
 				withAttributesFrom: (class methodFor: selector)].
 	class compileTree: modifiedParseTree
+]
+
+{ #category : #accessing }
+RBExtractMethodRefactoring >> validateRenameNode: aParseTree withOldName: oldName toWithName: newName [ 
+	|conditions block|
+	conditions := ((RBCondition isValidInstanceVariableName: newName for: class)
+		& (RBCondition definesSelector: selector in: class)
+		& (RBCondition definesInstanceVariable: newName in: class) not 
+		& (RBCondition definesClassVariable: newName in: class) not).
+	conditions check
+		ifFalse: [ block := conditions errorBlock.
+			block
+				ifNotNil: [ self refactoringError: conditions errorString with: block ]
+				ifNil: [ self refactoringError: conditions errorString ] ].
+	(dictParameters values includes: newName) ifTrue: [
+		self refactoringError: newName asString , ' is already defined as parameter' ].
+	(aParseTree whoDefines: newName)
+		ifNotNil: [ self refactoringError: newName asString , ' is already defined' ].
+	(aParseTree allDefinedVariables includes: newName)
+		ifTrue: [ self refactoringError: newName asString , ' is already defined' ]
+]
+
+{ #category : #accessing }
+RBExtractMethodRefactoring >> validateRenameOf: oldName to: newName [
+	self validateRenameNode: extractedParseTree withOldName: oldName toWithName: newName 
 ]

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -338,21 +338,24 @@ RBExtractMethodRefactoring >> remainingTemporaries [
 	^temps
 ]
 
-{ #category : #accessing }
+{ #category : #renaming }
 RBExtractMethodRefactoring >> renameAllParameters [
+	"Rename all parameters that change"
 	dictParameters ifNotNil: [
 		dictParameters keysAndValuesDo: [ :key : value | 
 			key ~= value ifTrue: [ self renameParameterWith: key to: value ]]
 	]
 ]
 
-{ #category : #accessing }
+{ #category : #renaming }
 RBExtractMethodRefactoring >> renameNode: aParseTree withOldName: oldName toWithName: newName [ 
 	(RBParseTreeRewriter rename: oldName to: newName) executeTree: aParseTree
 ]
 
-{ #category : #accessing }
+{ #category : #renaming }
 RBExtractMethodRefactoring >> renameParameterWith: oldName to: newName [
+	
+	"Rename a parameter of extracted method from oldName to newName"
 	self renameNode: extractedParseTree withOldName: oldName toWithName: newName.
 	
 ]
@@ -400,8 +403,9 @@ RBExtractMethodRefactoring >> transform [
 	class compileTree: modifiedParseTree
 ]
 
-{ #category : #accessing }
-RBExtractMethodRefactoring >> validateRenameNode: aParseTree withOldName: oldName toWithName: newName [ 
+{ #category : #preconditions }
+RBExtractMethodRefactoring >> validateRenameNode: aParseTree withOldName: oldName toNewName: newName [ 
+	"Validate if newName is already defined as: instance variable, class variable, another parameter"
 	|conditions block|
 	conditions := ((RBCondition isValidInstanceVariableName: newName for: class)
 		& (RBCondition definesSelector: selector in: class)
@@ -420,7 +424,7 @@ RBExtractMethodRefactoring >> validateRenameNode: aParseTree withOldName: oldNam
 		ifTrue: [ self refactoringError: newName asString , ' is already defined' ]
 ]
 
-{ #category : #accessing }
+{ #category : #preconditions }
 RBExtractMethodRefactoring >> validateRenameOf: oldName to: newName [
-	self validateRenameNode: extractedParseTree withOldName: oldName toWithName: newName 
+	self validateRenameNode: extractedParseTree withOldName: oldName toNewName: newName 
 ]

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -16,7 +16,7 @@ Class {
 		'modifiedParseTree',
 		'parameters',
 		'needsReturn',
-		'dictParameters'
+		'parameterMap'
 	],
 	#category : #'Refactoring-Core-Refactorings'
 }
@@ -125,16 +125,6 @@ RBExtractMethodRefactoring >> checkTemporaries [
 { #category : #transforming }
 RBExtractMethodRefactoring >> createTemporariesInExtractedMethodFor: assigned [ 
 	assigned do: [:each | extractedParseTree body addTemporaryNamed: each]
-]
-
-{ #category : #accessing }
-RBExtractMethodRefactoring >> dictParameters [
-	^ dictParameters
-]
-
-{ #category : #accessing }
-RBExtractMethodRefactoring >> dictParameters: aDictionary [
-	dictParameters := aDictionary 
 ]
 
 { #category : #transforming }
@@ -306,6 +296,16 @@ RBExtractMethodRefactoring >> nameNewMethod: aSymbol [
 	modifiedParseTree := RBParseTreeRewriter replace: self methodDelimiter with: newSend in: modifiedParseTree
 ]
 
+{ #category : #accessing }
+RBExtractMethodRefactoring >> parameterMap [
+	^ parameterMap
+]
+
+{ #category : #accessing }
+RBExtractMethodRefactoring >> parameterMap: aDictionary [
+	parameterMap := aDictionary 
+]
+
 { #category : #transforming }
 RBExtractMethodRefactoring >> placeholderNode [
 	| node |
@@ -341,8 +341,8 @@ RBExtractMethodRefactoring >> remainingTemporaries [
 { #category : #renaming }
 RBExtractMethodRefactoring >> renameAllParameters [
 	"Rename all parameters that change"
-	dictParameters ifNotNil: [
-		dictParameters keysAndValuesDo: [ :key : value | 
+	parameterMap ifNotNil: [
+		parameterMap keysAndValuesDo: [ :key : value | 
 			key ~= value ifTrue: [ self renameParameterWith: key to: value ]]
 	]
 ]
@@ -416,7 +416,7 @@ RBExtractMethodRefactoring >> validateRenameNode: aParseTree withOldName: oldNam
 			block
 				ifNotNil: [ self refactoringError: conditions errorString with: block ]
 				ifNil: [ self refactoringError: conditions errorString ] ].
-	(dictParameters values includes: newName) ifTrue: [
+	(parameterMap values includes: newName) ifTrue: [
 		self refactoringError: newName asString , ' is already defined as parameter' ].
 	(aParseTree whoDefines: newName)
 		ifNotNil: [ self refactoringError: newName asString , ' is already defined' ].

--- a/src/Refactoring-Missing/RBMethodName.extension.st
+++ b/src/Refactoring-Missing/RBMethodName.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #RBMethodName }
+
+{ #category : #'*Refactoring-Missing' }
+RBMethodName >> methodName [
+	^ String streamContents: [ :s | self printOn: s ]
+]

--- a/src/Refactoring-Missing/SycMethodNameEditor3.class.st
+++ b/src/Refactoring-Missing/SycMethodNameEditor3.class.st
@@ -1,0 +1,310 @@
+Class {
+	#name : #SycMethodNameEditor3,
+	#superclass : #ComposablePresenter,
+	#instVars : [
+		'selectorInput',
+		'argumentsList',
+		'previewResult',
+		'upButton',
+		'downButton',
+		'methodName',
+		'editParameter',
+		'okEdit',
+		'editerArgumentList',
+		'refactoring'
+	],
+	#category : #'Refactoring-Missing'
+}
+
+{ #category : #specs }
+SycMethodNameEditor3 class >> defaultSpec [
+	^ SpecBoxLayout newVertical
+		add:
+			(SpecBoxLayout newHorizontal
+				add: 'Selector'
+					withConstraints: [ :aConstraints | aConstraints width: 80 ];
+				add: #selectorInput;
+				yourself);
+		add:
+			(SpecBoxLayout newHorizontal
+				add: 'Arguments'
+					withConstraints: [ :aConstraints | aConstraints width: 80 ];
+				add: #argumentsList;
+				add:
+					(SpecBoxLayout newVertical
+						add: #upButton
+							withConstraints: [ :aConstraints | aConstraints height: 30 ];
+						add: #downButton
+							withConstraints: [ :aConstraints | aConstraints height: 30 ];
+						yourself)
+					withConstraints: [ :aConstraints | aConstraints width: 30 ];
+				yourself);
+		add:
+			(SpecBoxLayout newHorizontal
+				add: 'Edit'
+					withConstraints: [ :aConstraints | aConstraints width: 80 ];
+				add: #editParameter; 
+				add:
+					(SpecBoxLayout newVertical
+						add: #okEdit
+							withConstraints: [ :aConstraints | aConstraints height: 20 ];
+						yourself)
+					withConstraints: [ :aConstraints | aConstraints width: 30 ];
+				yourself);
+		add:
+			(SpecBoxLayout newHorizontal
+				add: 'Preview'
+					withConstraints: [ :aConstraints | aConstraints width: 80 ];
+				add: #previewResult; yourself);
+		yourself
+]
+
+{ #category : #specs }
+SycMethodNameEditor3 class >> example [
+	<script>
+	self
+		openOn:
+			(RBMethodName
+				selector: (UseOnlyForTest >> #a:b:) selector
+				arguments: ((UseOnlyForTest >> #a:b:) ast arguments collect: #name))
+]
+
+{ #category : #specs }
+SycMethodNameEditor3 class >> example2 [
+	<script>
+	self
+		openOn:
+			(RBMethodName
+				selector: (UseOnlyForTest >> #a:b:) selector
+				arguments: ((UseOnlyForTest >> #a:b:) ast arguments collect: #name))
+]
+
+{ #category : #specs }
+SycMethodNameEditor3 class >> openOn: aMethod [
+	"I take a RBMethodName as parameter and open the refactoring UI in a modal to rename it."
+
+	^ (self on: aMethod) openModalWithSpec
+]
+
+{ #category : #specs }
+SycMethodNameEditor3 class >> openOn: aMethod withRefactoring: refactoring [
+	|temp|
+	temp := (self on: aMethod).
+	temp refactoring: refactoring.
+	temp initializeEditerArgumentList.
+	^ temp openModalWithSpec
+]
+
+{ #category : #services }
+SycMethodNameEditor3 >> alert: aString [
+	"Display a message for the user to read and then dismiss."
+
+	aString isEmptyOrNil
+		ifFalse: [ UIManager default alert: aString ]
+]
+
+{ #category : #accessing }
+SycMethodNameEditor3 >> argumentsList [
+	^ argumentsList
+]
+
+{ #category : #accessing }
+SycMethodNameEditor3 >> downButton [
+	^ downButton
+]
+
+{ #category : #services }
+SycMethodNameEditor3 >> editParameter [
+	"Validate the change of name the parameters and update a argumentsList and label"
+	| selected newName|
+	newName := editParameter text asSymbol.
+	selected := argumentsList items at: (argumentsList selection selectedIndex).
+	newName = selected ifTrue: [ ^ self ].
+	refactoring dictParameters: editerArgumentList;
+		   		   validateRenameOf: selected to: newName.
+	editerArgumentList at: (self getKeyOf: selected) put: newName.
+	self updateItem: selected to: newName.
+	self updateLabel
+]
+
+{ #category : #services }
+SycMethodNameEditor3 >> getKeyOf: aValue [
+	"Get a real parameter's name of extracted method given a new parameter's name"
+	|keyOfValue|
+	editerArgumentList keysAndValuesDo: [ :key :value | 
+		aValue = value ifTrue: [ keyOfValue := key ] ].
+	^ keyOfValue
+]
+
+{ #category : #services }
+SycMethodNameEditor3 >> getParametersOrder [
+	"Get the new parameters order with the old parameters names"
+	^ argumentsList items collect: [ :each | self getKeyOf: each ]
+	
+]
+
+{ #category : #accessing }
+SycMethodNameEditor3 >> initializeDialogWindow: aModalPresenter [
+	aModalPresenter
+		closeOnBackdropClick: true;
+		addButton: 'Rename' do: [ :presenter | self renameMethodAndClose: presenter ];
+		addButton: 'Cancel' do: [ :presenter | 
+			presenter
+				beCancel;
+				close ];
+		initialExtent: 600 @ 300;
+		title: 'Method name editor'
+]
+
+{ #category : #services }
+SycMethodNameEditor3 >> initializeEditerArgumentList [
+	"Create a dictionary with old parameters name as key and value.
+	It value can change after if you rename a parameter"
+	editerArgumentList := Dictionary new.
+	methodName arguments do: [ :each | 
+		editerArgumentList at: each put: each ]
+]
+
+{ #category : #services }
+SycMethodNameEditor3 >> initializePresenter [ 
+	selectorInput whenTextChangedDo: [ :text | self updateLabel ].
+	upButton action: [ self pushUpSelectedArgument ].
+	downButton action: [ self pushDownSelectedArgument ].
+
+	argumentsList
+		whenModelChangedDo: [ :model | 
+			argumentsList selectIndex: 1.
+			model
+				ifEmpty: [ upButton disable.
+					downButton disable ] ].
+
+	argumentsList items: methodName arguments.
+	
+	self updateEditTemp.
+	argumentsList whenSelectionChangedDo: [ self updateEditTemp ].
+	okEdit action: [ self validateEditParameter ]
+
+]
+
+{ #category : #services }
+SycMethodNameEditor3 >> initializeWidgets [
+	selectorInput := self instantiate: TextInputFieldPresenter.
+	argumentsList := self newList.
+	previewResult := self newLabel.
+	upButton := self newButton.
+	downButton := self newButton.
+	
+	selectorInput autoAccept: true.
+	upButton label: 'Up'.
+	downButton label: 'Dn'.
+	selectorInput text: methodName selector.
+	previewResult label: methodName methodName.
+	
+	editParameter := self newTextInput autoAccept: true.
+	okEdit := self newButton.
+	
+	okEdit label: 'Ok'
+	
+]
+
+{ #category : #services }
+SycMethodNameEditor3 >> okEdit [
+	^ okEdit
+]
+
+{ #category : #accessing }
+SycMethodNameEditor3 >> previewResult [
+	^ previewResult
+]
+
+{ #category : #accessing }
+SycMethodNameEditor3 >> pushDownSelectedArgument [
+	| selectedIndex |
+	selectedIndex := argumentsList selectedIndex.
+	selectedIndex = argumentsList items size
+		ifTrue: [ ^ self inform: 'The argument is already the last of the list.' ].
+	argumentsList items swap: selectedIndex with: selectedIndex + 1.
+	argumentsList selectIndex: selectedIndex + 1.
+	self updateLabel
+]
+
+{ #category : #accessing }
+SycMethodNameEditor3 >> pushUpSelectedArgument [
+	| selectedIndex |
+	selectedIndex := argumentsList selectedIndex.
+	selectedIndex = 1
+		ifTrue: [ ^ self inform: 'The argument is already the first of the list.' ].
+	argumentsList items swap: selectedIndex with: selectedIndex - 1.
+	argumentsList selectIndex: selectedIndex - 1.
+	self updateLabel
+]
+
+{ #category : #services }
+SycMethodNameEditor3 >> refactoring: anObject [
+	refactoring := anObject 
+]
+
+{ #category : #services }
+SycMethodNameEditor3 >> renameMethodAndClose: presenter [
+	^ self previewResult label = '(invalid)'
+		ifTrue: [ self inform: 'Invalid method name' ]
+		ifFalse: [
+			refactoring dictParameters: editerArgumentList.
+			methodName
+				arguments: self getParametersOrder;
+				selector: selectorInput text.
+			presenter
+				beOk;
+				close ]
+]
+
+{ #category : #accessing }
+SycMethodNameEditor3 >> selectorInput [
+	^ selectorInput
+]
+
+{ #category : #accessing }
+SycMethodNameEditor3 >> setModelBeforeInitialization: aRBMethodName [
+	methodName := aRBMethodName
+]
+
+{ #category : #accessing }
+SycMethodNameEditor3 >> upButton [
+	^ upButton
+]
+
+{ #category : #services }
+SycMethodNameEditor3 >> updateEditTemp [
+	| selectedIndex |
+	selectedIndex := argumentsList selection selectedIndex.
+	selectedIndex = 0 ifFalse: [ 
+	editParameter text: (argumentsList items at: selectedIndex)]
+]
+
+{ #category : #services }
+SycMethodNameEditor3 >> updateItem: selected to: newName [
+	argumentsList items doWithIndex: [ :each :index | 
+		each = selected ifTrue: [ argumentsList items at: index put: newName  ] ]
+]
+
+{ #category : #accessing }
+SycMethodNameEditor3 >> updateLabel [
+	"Update the new method name to display to the user when the user change its name or order of the arguments."
+
+	previewResult
+		label:
+			(RBMethodName
+				selector: self selectorInput text
+				arguments: self argumentsList items) methodName
+]
+
+{ #category : #services }
+SycMethodNameEditor3 >> validateEditParameter [
+	"Validate the rename of a parameter, if exist an error show an alert"
+	self previewResult label = '(invalid)'
+		ifTrue: [ self alert: 'You can not rename parameters if you have an invalid method name' ]
+		ifFalse: [ [ self editParameter  ]
+ 			on: RBRefactoringError 
+			do: [:ex | self alert: ex messageText] 
+	]
+]

--- a/src/Refactoring-Missing/SycMethodNameEditor3.class.st
+++ b/src/Refactoring-Missing/SycMethodNameEditor3.class.st
@@ -120,7 +120,7 @@ SycMethodNameEditor3 >> editParameter [
 	newName := editParameter text asSymbol.
 	selected := argumentsList items at: (argumentsList selection selectedIndex).
 	newName = selected ifTrue: [ ^ self ].
-	refactoring dictParameters: editerArgumentList;
+	refactoring parameterMap: editerArgumentList;
 		   		   validateRenameOf: selected to: newName.
 	editerArgumentList at: (self getKeyOf: selected) put: newName.
 	self updateItem: selected to: newName.
@@ -249,7 +249,7 @@ SycMethodNameEditor3 >> renameMethodAndClose: presenter [
 	^ self previewResult label = '(invalid)'
 		ifTrue: [ self inform: 'Invalid method name' ]
 		ifFalse: [
-			refactoring dictParameters: editerArgumentList.
+			refactoring parameterMap: editerArgumentList.
 			methodName
 				arguments: self getParametersOrder;
 				selector: selectorInput text.

--- a/src/Refactoring-Missing/UseOnlyForTest.class.st
+++ b/src/Refactoring-Missing/UseOnlyForTest.class.st
@@ -1,0 +1,47 @@
+"
+this a class only use for test MethodNameEditor 
+"
+Class {
+	#name : #UseOnlyForTest,
+	#superclass : #Object,
+	#instVars : [
+		'njghvijn',
+		'klbikjgi'
+	],
+	#category : #'Refactoring-Missing'
+}
+
+{ #category : #'as yet unclassified' }
+UseOnlyForTest >> a [ 
+	 
+]
+
+{ #category : #'as yet unclassified' }
+UseOnlyForTest >> a: A [ 
+	 
+]
+
+{ #category : #'as yet unclassified' }
+UseOnlyForTest >> a: A b: B [ 
+	 
+]
+
+{ #category : #'as yet unclassified' }
+UseOnlyForTest >> a: A b: B c: C [
+	 
+]
+
+{ #category : #'as yet unclassified' }
+UseOnlyForTest >> bug: qqqjjhhhhhhhhhhhqqqjjhhhhhhhhhhhqqqjjhhhhhhhhhhhqqqjjhhhhhhhhhhhqqqjjhhhhhhhhhhqqqjjhhhhhhhhhhhh [
+		 
+]
+
+{ #category : #'as yet unclassified' }
+UseOnlyForTest >> zzzzzzz [
+		 
+]
+
+{ #category : #'as yet unclassified' }
+UseOnlyForTest >> zzzzzzz: qqqjjhhhhhhhhhhhqqqjjhhhhhhhhhhhqqqjjhhhhhhhhhhhqqqjjhhhhhhhhhhhqqqjjhhhhhhhhhhqqqjjhhhhhhhhhhhh [
+		 
+]

--- a/src/Refactoring-Missing/package.st
+++ b/src/Refactoring-Missing/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Refactoring-Missing' }

--- a/src/Refactoring-Tests-Core/RBExtractMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBExtractMethodTest.class.st
@@ -138,7 +138,7 @@ RBExtractMethodTest >> testExtractWithRenamingOfParameters [
 		from: #displayName
 		in: RBLintRuleTestData.
 	self setupMethodNameFor: refactoring toReturn: #foo:.
-	refactoring dictParameters: (Dictionary new at: #nameStream put: #newParameter; yourself ).
+	refactoring parameterMap: (Dictionary new at: #nameStream put: #newParameter; yourself ).
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBLintRuleTestData.
 
@@ -215,7 +215,7 @@ RBExtractMethodTest >> testValidateRenameParameters [
 		from: #displayName
 		in: RBLintRuleTestData.
 	self setupMethodNameFor: refactoring toReturn: #foo:.
-	refactoring dictParameters: (Dictionary new at: #nameStream put: #nameStream; yourself ).
+	refactoring parameterMap: (Dictionary new at: #nameStream put: #nameStream; yourself ).
 	"Fail when use instance variables as new parameters"
 	self should: [ refactoring validateRenameOf: #nameStream to: #name ] raise: RBRefactoringError.	
 	self should: [refactoring validateRenameOf: #nameStream to: #foo1] raise: RBRefactoringError.

--- a/src/Refactoring-Tests-Core/RBExtractMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBExtractMethodTest.class.st
@@ -131,6 +131,31 @@ RBExtractMethodTest >> testExtractMethodThatNeedsTemporaryVariable [
 ]
 
 { #category : #tests }
+RBExtractMethodTest >> testExtractWithRenamingOfParameters [
+	| refactoring class|
+	refactoring := RBExtractMethodRefactoring
+		extract: (78 to: 197)
+		from: #displayName
+		in: RBLintRuleTestData.
+	self setupMethodNameFor: refactoring toReturn: #foo:.
+	refactoring dictParameters: (Dictionary new at: #nameStream put: #newParameter; yourself ).
+	self executeRefactoring: refactoring.
+	class := refactoring model classNamed: #RBLintRuleTestData.
+
+	self assert: (class parseTreeFor: #displayName) = (self parseMethod: 'displayName
+	| nameStream |
+	nameStream := WriteStream on: (String new: 64).
+	self foo: nameStream.
+	^nameStream contents').
+	"Extracted method with renamed parameters"
+	self assert: (class parseTreeFor: #foo:) = (self parseMethod: 'foo: newParameter 	newParameter nextPutAll: self name;
+		nextPutAll: '' (''.
+	self problemCount printOn: newParameter.
+	newParameter nextPut: $).')
+	
+]
+
+{ #category : #tests }
 RBExtractMethodTest >> testModelExtractMethodWithTemporariesSelected [
 	| class refactoring |
 	model := RBClassModelFactory rbNamespace new.
@@ -180,4 +205,24 @@ RBExtractMethodTest >> testNonExistantSelector [
 			extract: (10 to: 20)
 			from: #checkClass1:
 			in: RBBasicLintRuleTestData)
+]
+
+{ #category : #tests }
+RBExtractMethodTest >> testValidateRenameParameters [
+	| refactoring |
+	refactoring := RBExtractMethodRefactoring
+		extract: (78 to: 197)
+		from: #displayName
+		in: RBLintRuleTestData.
+	self setupMethodNameFor: refactoring toReturn: #foo:.
+	refactoring dictParameters: (Dictionary new at: #nameStream put: #nameStream; yourself ).
+	"Fail when use instance variables as new parameters"
+	self should: [ refactoring validateRenameOf: #nameStream to: #name ] raise: RBRefactoringError.	
+	self should: [refactoring validateRenameOf: #nameStream to: #foo1] raise: RBRefactoringError.
+	"Fail when use class variables as new parameters"
+	self should: [refactoring validateRenameOf: #nameStream to: #Foo1] raise: RBRefactoringError.
+	"Fail when use temporary variables as new parameters"
+	
+	"Should not fail"
+	"self shouldnt: [refactoring validateRenameOf: #nameStream to: #validName] raise: RBRefactoringError."
 ]


### PR DESCRIPTION
Added the option of renamed to the extract method refactoring, however you can only perform the rename by modifying the preview used in SystemCommands. fixes #3606