### PR TITLE
3612-add-allMethodsReadingSlot-and-allMethodsWritingSlot-and-tests

### DIFF
--- a/src/Kernel-Tests/BehaviorTest.class.st
+++ b/src/Kernel-Tests/BehaviorTest.class.st
@@ -204,6 +204,41 @@ BehaviorTest >> testRemoveProperty [
 	self assert: (self class propertyAt: #testKeySelector) equals: nil
 ]
 
+{ #category : #'tests - queries' }
+BehaviorTest >> testallMethodsAccessingSlot [
+	| methods |	
+	"Check the source code availability to do not fail on images without sources"
+	(Point>>#x) hasSourceCode ifFalse: [ ^ self ].
+
+
+	methods := LookupKey allMethodsAccessingSlot: (LookupKey slotNamed: #key).
+	self assert: (methods includes: (Association >>#key:value:))
+
+]
+
+{ #category : #'tests - queries' }
+BehaviorTest >> testallMethodsReadingSlot [
+	| methods |	
+	"Check the source code availability to do not fail on images without sources"
+	(Point>>#x) hasSourceCode ifFalse: [ ^ self ].
+
+	methods := LookupKey allMethodsReadingSlot: (LookupKey slotNamed: #key).
+	self assert: (methods includes: (Ephemeron >>#mourn))
+
+]
+
+{ #category : #'tests - queries' }
+BehaviorTest >> testallMethodsWritingSlot [
+	| methods |	
+	"Check the source code availability to do not fail on images without sources"
+	(Point>>#x) hasSourceCode ifFalse: [ ^ self ].
+
+
+	methods := LookupKey allMethodsWritingSlot: (LookupKey slotNamed: #key).
+	self assert: (methods includes: (Association >>#key:value:))
+
+]
+
 { #category : #tests }
 BehaviorTest >> testallSuperclassesIncluding [
 		

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -200,9 +200,19 @@ Behavior >> allMethods [
 { #category : #queries }
 Behavior >> allMethodsAccessingSlot: aSlot [
 	"return all methods that access aSlot in this class and subclasses"
-	^self withAllSubclasses flatCollect: [ :class |
-		class methodsAccessingSlot: aSlot.
-	]
+	^self withAllSubclasses flatCollect: [ :class | class methodsAccessingSlot: aSlot ]
+]
+
+{ #category : #queries }
+Behavior >> allMethodsReadingSlot: aSlot [
+	"return all methods that access aSlot in this class and subclasses"
+	^self withAllSubclasses flatCollect: [ :class | class methodsReadingSlot: aSlot]
+]
+
+{ #category : #queries }
+Behavior >> allMethodsWritingSlot: aSlot [
+	"return all methods that access aSlot in this class and subclasses"
+	^self withAllSubclasses flatCollect: [ :class | class methodsWritingSlot: aSlot ]
 ]
 
 { #category : #'accessing method dictionary' }
@@ -1712,12 +1722,8 @@ Behavior >> subclassDefinerClass [
 
 { #category : #'accessing instances and variables' }
 Behavior >> subclassInstVarNames [
-	"Answer a Set of the names of the receiver's subclasses' instance 
-	variables."
-	| vars |
-	vars := Set new.
-	self allSubclasses do: [:aSubclass | vars addAll: aSubclass instVarNames].
-	^vars
+	"Answer a Set of the names of the receiver's subclasses' instance variables."
+	^self allSubclasses flatCollectAsSet: [:aSubclass | aSubclass instVarNames]
 ]
 
 { #category : #enumerating }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -110,13 +110,8 @@ ClassDescription >> addSlot: aSlot [
 ClassDescription >> allInstVarNamesEverywhere [
 	"Answer the set of inst var names used by the receiver, all superclasses, and all subclasses"
 
-	| aList |
-	aList := OrderedCollection new.
-	(self allSuperclasses , self withAllSubclasses asOrderedCollection) do:
-		[:cls | aList addAll: cls instVarNames].
-	^ aList asSet
-
-	"BorderedMorph allInstVarNamesEverywhere"
+	^ self allSuperclasses , self withAllSubclasses asOrderedCollection
+		flatCollectAsSet: [ :cls | cls instVarNames ]
 ]
 
 { #category : #'accessing method dictionary' }
@@ -159,17 +154,6 @@ ClassDescription >> allSharedPools [
 { #category : #slots }
 ClassDescription >> allSlots [
 	^self classLayout allVisibleSlots
-]
-
-{ #category : #slots }
-ClassDescription >> allSlotsEverywhere [
-	"Answer the set of slots used by the receiver, all superclasses, and all subclasses"
-
-	| aList |
-	aList := OrderedCollection new.
-	(self allSuperclasses , self withAllSubclasses asOrderedCollection) do:
-		[:cls | aList addAll: cls slots].
-	^ aList asSet
 ]
 
 { #category : #enumerating }


### PR DESCRIPTION
-allMethodsWritingSlot:
-allMethodsReadingSlot
-tests for these and allMethodsAccessingSlot:
-simplify subclassInstVarNames
-simplify allInstVarNamesEverywhere
-remove allSlotsEverywhere (un used and makes no sense)