### PR TITLE
3619-Simplify-allCallsOn-

### DIFF
--- a/src/Deprecated80/SystemNavigation.extension.st
+++ b/src/Deprecated80/SystemNavigation.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : #SystemNavigation }
 
 { #category : #'*Deprecated80' }
+SystemNavigation >> allCallsOn: aSymbol from: aClass [
+	self deprecated: 'use #allCallsOn: of class directly'.
+	^aClass allCallsOn: aSymbol
+]
+
+{ #category : #'*Deprecated80' }
 SystemNavigation >> allClassesUsingSharedPool: aString [  
 	"Answer all classes that uses the shared pool named aString."
 

--- a/src/System-Support-Tests/ClassQueryTest.class.st
+++ b/src/System-Support-Tests/ClassQueryTest.class.st
@@ -20,7 +20,7 @@ ClassQueryTest >> testAllCallsOnASymbol [
 
 	| set cm |
 	set := Object allCallsOn: #shallowCopy.
-	cm := (set detect: [ :rgMethod | (rgMethod selector == #copy) and: [rgMethod className = #Object]]) compiledMethod.
+	cm := (set detect: [ :rgMethod | (rgMethod selector == #copy) and: [rgMethod methodClass = Object]]).
 	self assert: (cm literals includes: #shallowCopy)
 ]
 

--- a/src/System-Support/Behavior.extension.st
+++ b/src/System-Support/Behavior.extension.st
@@ -9,9 +9,10 @@ Behavior >> allCallsOn [
 
 { #category : #'*System-Support' }
 Behavior >> allCallsOn: aSymbol [
-	"Answer a SortedCollection of all the methods that call on aSymbol."
+	"Answer of all the methods that call on aSymbol."
 
-	^ self  systemNavigation allCallsOn: aSymbol from: self .
+	^self withAllSubclasses flatCollect: [ :cls | 
+		(cls whichSelectorsReferTo: aSymbol) collect: [:sel | cls>>sel]]
 	
 ]
 

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -46,18 +46,6 @@ SystemNavigation >> allCallsOn: aSymbol [
 ]
 
 { #category : #query }
-SystemNavigation >> allCallsOn: aSymbol from: aClass [
-	"Answer a SortedCollection of all the methods that call on aSymbol."
-
-	| collection |
-	collection := OrderedCollection  new.
-	aClass withAllSubclassesDo: [ :class |
-		(class whichSelectorsReferTo: aSymbol) do: [:sel |
-				collection add: (class>>sel) methodReference]].
-	^collection
-]
-
-{ #category : #query }
 SystemNavigation >> allClasses [
 	"Returns all the classes in the current environment."
 


### PR DESCRIPTION
fixes #3619


#allCallsOn: on Behavior forwards to SystemNavigation, but that is not needed.

In addition, we can simplify

do not wrap, that is the job of the UI
do not sort, that is UI
use flatCollect: