### PR TITLE
3622-cleanup-subclassesDo-multiple-identical-implementations

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1726,12 +1726,6 @@ Behavior >> subclassInstVarNames [
 	^self allSubclasses flatCollectAsSet: [:aSubclass | aSubclass instVarNames]
 ]
 
-{ #category : #enumerating }
-Behavior >> subclassesDo: aBlock [
-	"Evaluate the argument, aBlock, for each of the receiver's immediate subclasses."
-	self subclasses do: aBlock
-]
-
 { #category : #'accessing class hierarchy' }
 Behavior >> superclass [
 	"Answer the receiver's superclass, a Class."

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -1269,12 +1269,6 @@ ClassDescription >> storeOn: aStream [
 	aStream nextPutAll: self name
 ]
 
-{ #category : #'accessing class hierarchy' }
-ClassDescription >> subclassesDo: aBlock [
-	"Evaluate the argument, aBlock, for each of the receiver's immediate subclasses."
-	^self subclasses do: aBlock
-]
-
 { #category : #initialization }
 ClassDescription >> superclass: aClass methodDictionary: mDict format: fmt [
 	"Basic initialization of the receiver"


### PR DESCRIPTION
subclassesDo: is define the same in Behavior, ClassDescription and Class.

--> as #sublasses is only defined in Class, we only need the method there

fixes #3622