### PR TITLE
3646-simplify-allSelectorsInProtocol

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -137,11 +137,9 @@ ClassDescription >> allSelectorsInProtocol: aName [
 	"Answer a list of all the methods of the receiver and all its 
 	superclasses that are in the protocol named aName"
 	
-	| aColl |
-	aColl := OrderedCollection new.
-	self withAllSuperclasses do: [:aClass | 
-		aColl addAll: (aClass organization listAtCategoryNamed: aName) ].
-	^ aColl asSet asArray sort
+	^self withAllSuperclasses
+		flatCollectAsSet: [ :class | class organization listAtCategoryNamed: aName ]
+		
 ]
 
 { #category : #'pool variable' }


### PR DESCRIPTION
allSelectorsInProtocol: can be written using flatCollectAsSet: and should not sort (that is UI concern)

fixed #3646