### PR TITLE
3648-classThatDefinesInstanceVariable-is-taking-names-not-variables

### DIFF
--- a/src/Deprecated80/ClassDescription.extension.st
+++ b/src/Deprecated80/ClassDescription.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #ClassDescription }
+
+{ #category : #'*Deprecated80' }
+ClassDescription >> classThatDefinesInstanceVariable: instVarName [
+	self 
+		deprecated: 'use #classThatDefinesInstVarNamed:' 
+		transformWith: '`@receiver classThatDefinesInstanceVariable: `@statement' -> '`@receiver classThatDefinesInstVarNamed: `@statement'.
+	
+	^self classThatDefinesInstVarNamed: instVarName
+]

--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -83,6 +83,14 @@ ClassDescriptionTest >> testSlots [
 	
 ]
 
+{ #category : #'tests - instance variables' }
+ClassDescriptionTest >> testclassThatDefinesInstVarNamed [
+	self assert: (Point classThatDefinesInstVarNamed: 'x') equals: Point.
+	self assert: (Class classThatDefinesInstVarNamed: 'methodDict') equals: Behavior.
+	self assert: (Point classThatDefinesInstVarNamed: 'methodDict') equals: nil.
+	
+]
+
 { #category : #'tests - slots' }
 ClassDescriptionTest >> testprintHierarchy [
 	| expected result |

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -160,11 +160,12 @@ ClassDescription >> allSlots [
 ClassDescription >> allUnreferencedInstanceVariables [
 	"Return a list of the instance variables known to the receiver which are not referenced in the receiver or any of its subclasses OR superclasses"
 
-	^ self allInstVarNames reject: [:ivn |
-		| definingClass |		
-		definingClass := self classThatDefinesInstanceVariable: ivn.
-		definingClass withAllSubclasses anySatisfy: [:class |  
-				(class whichSelectorsAccess: ivn asSymbol) notEmpty]]
+	^ self allInstVarNames
+		reject: [ :ivn | 
+			| definingClass |
+			definingClass := self classThatDefinesInstVarNamed: ivn.
+			definingClass withAllSubclasses
+				anySatisfy: [ :class | (class whichSelectorsAccess: ivn asSymbol) notEmpty ] ]
 ]
 
 { #category : #authors }
@@ -313,9 +314,11 @@ ClassDescription >> classThatDefinesClassVariable: classVarName [
 ]
 
 { #category : #'instance variables' }
-ClassDescription >> classThatDefinesInstanceVariable: instVarName [
-	(self instVarNames notNil and: [self instVarNames includes: instVarName asString]) ifTrue: [^ self]. 
-	^self superclass ifNotNil: [self superclass classThatDefinesInstanceVariable: instVarName]
+ClassDescription >> classThatDefinesInstVarNamed: instVarName [
+	^self 
+		slotNamed: instVarName
+		 ifFound: [ :slot | slot definingClass  ]
+		 ifNone: nil
 ]
 
 { #category : #slots }

--- a/src/NECompletion/NECInstVarTypeGuesser.class.st
+++ b/src/NECompletion/NECInstVarTypeGuesser.class.st
@@ -13,7 +13,7 @@ Class {
 { #category : #public }
 NECInstVarTypeGuesser >> methodRefs [
 	| theClass selectors |
-	theClass := receiverClass classThatDefinesInstanceVariable: variableName.
+	theClass := receiverClass classThatDefinesInstVarNamed: variableName.
 	theClass ifNil: [ ^ nil ].
 	selectors := theClass whichSelectorsStoreInto: variableName.
 	^ selectors collect: [ :each | 


### PR DESCRIPTION
#classThatDefinesInstanceVariable: takes as an arg a name. This should be explicit and follow all the other API about instVarNames.

- add classThatDefinesInstVarNamed: and implement it using the slot API instead of searching names
- rewriting deprecation of classThatDefinesInstanceVariable:
- rewrite users