### PR TITLE
3650-unify-hasSlotNamed-in-AbractLayout-and-ClassDescription

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -747,9 +747,10 @@ ClassDescription >> hasSlot: aSlot [
 
 { #category : #slots }
 ClassDescription >> hasSlotNamed: aString [
-	"Return true whether the receiver defines an instance variable named aString."
+	"Return true whether the receiver defines an instance variable named aString.
+	this includs non-visible slots"
 	
-	^ self allSlots anySatisfy: [:slot | slot name = aString]
+	^ self classLayout hasSlotNamed: aString
 ]
 
 { #category : #'instance variables' }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -146,7 +146,7 @@ ClassDescription >> allSelectorsInProtocol: aName [
 
 { #category : #'pool variable' }
 ClassDescription >> allSharedPools [
-	"Answer an ordered collection  of the shared pools the receiver shares, including those defined  in the superclasses of the receiver."
+	"Answer an ordered collection of the shared pools the receiver shares, including those defined  in the superclasses of the receiver."
 	
 	^ OrderedCollection new
 ]
@@ -262,7 +262,6 @@ ClassDescription >> classCommentBlank [
 
 	| stream |
 	stream := (String new: 100) writeStream.
-	
 	stream nextPutAll: 'Please comment me using the following template inspired by Class Responsibility Collaborator (CRC) design:
 
 For the Class part:  State a one line summary. For example, "I represent a paragraph of text".
@@ -590,9 +589,9 @@ ClassDescription >> definitionForNautilus [
 
 { #category : #'filein/out' }
 ClassDescription >> definitionWithSlots [
-	"the class definition with a way to specify slots. Shown when the class defines special Slot"
+	"The class definition with a way to specify slots. Shown when the class defines special Slot"
+	
 	| stream poolString|
-
 	poolString := self sharedPoolsString.
 
 	stream := (String new: 800) writeStream.
@@ -645,8 +644,8 @@ ClassDescription >> definitionWithSlots [
 
 { #category : #'filein/out' }
 ClassDescription >> definitionWithoutSlots [
-	| poolString stream |
 
+	| poolString stream |
 	poolString := self sharedPoolsString.
 	stream := (String new: 800) writeStream.
 	superclass
@@ -721,7 +720,7 @@ ClassDescription >> hasClassSide [
 
 { #category : #'accessing comment' }
 ClassDescription >> hasComment [
-	"return whether this class truly has a comment other than the default"
+	"Return whether this class truly has a comment other than the default"
 	^self instanceSide organization hasComment
 ]
 
@@ -748,7 +747,7 @@ ClassDescription >> hasSlot: aSlot [
 { #category : #slots }
 ClassDescription >> hasSlotNamed: aString [
 	"Return true whether the receiver defines an instance variable named aString.
-	this includs non-visible slots"
+	this includes non-visible slots"
 	
 	^ self classLayout hasSlotNamed: aString
 ]

--- a/src/Slot-Core/AbstractLayout.class.st
+++ b/src/Slot-Core/AbstractLayout.class.st
@@ -73,6 +73,8 @@ AbstractLayout >> hasSlot: aSlot [
 
 { #category : #api }
 AbstractLayout >> hasSlotNamed: aString [
+	"Return true whether the receiver defines an instance variable named aString.
+	this includs non-visible slots"
 	^self allSlots anySatisfy: [:slot | slot name = aString  ]
 ]
 


### PR DESCRIPTION
unify hasSlotNamed: in AbractLayout and ClassDescription

hasSlotNamed: just checks "visible" slots, the one on AbractLayout all. We should check always all slots (visibility means just that they are not shown when you ask for a list, this is all quite crude anyway and will be generalised into a "view" concept later.)

fixes #3650