### PR TITLE
3654-SystemNavigation-browseAllStoresIntofrom-and-cleanup

### DIFF
--- a/src/System-Support-Tests/SystemNavigationTest.class.st
+++ b/src/System-Support-Tests/SystemNavigationTest.class.st
@@ -29,12 +29,6 @@ SystemNavigationTest >> createClassFactory [
 	^ ClassFactoryWithOrganization newWithOrganization: self organizationToTest
 ]
 
-{ #category : #utilities }
-SystemNavigationTest >> createMethodNamed: selector realParent: class [
-
-	^ RGMethodDefinition realClass: class selector: selector
-]
-
 { #category : #'setUp-tearDown' }
 SystemNavigationTest >> createSystemNavigationToTest [
 	^SystemNavigation new

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -18,14 +18,6 @@ SystemNavigation class >> default [
 ]
 
 { #category : #query }
-SystemNavigation >> allAccessesTo: instVarName from: aClass [
-	| methods |
-	methods := aClass allMethodsAccessingSlot: (aClass slotNamed: instVarName).
-	^methods collect: [:meth | meth methodReference]
-
-]
-
-{ #category : #query }
 SystemNavigation >> allBehaviors [
 	^ self environment allBehaviors
 ]
@@ -306,15 +298,6 @@ SystemNavigation >> allSentMessages [
 ]
 
 { #category : #query }
-SystemNavigation >> allStoresInto: instVarName of: aClass [
-    | coll |
-    coll := OrderedCollection new.
-    aClass
-        withAllSubAndSuperclassesDo: [ :class | (class whichSelectorsStoreInto: instVarName) do: [ :sel | coll add: (class>>sel) methodReference ] ].
-    ^ coll
-]
-
-{ #category : #query }
 SystemNavigation >> allUnimplementedCalls [
 	"Answer an Array of each message that is sent by an expression in a  
 	method but is not implemented by any object in the system."
@@ -356,12 +339,6 @@ SystemNavigation >> allUnsentMessagesIn: selectorSet [
 	
 	^ (selectorSet copyWithoutAll: self allSentMessages) 
 			select: [ :each | (self allCallsOn: each) isEmpty ]   
-]
-
-{ #category : #query }
-SystemNavigation >> createMethodNamed: aSelector realParent: class [
-
-	^ (class>>aSelector) methodReference
 ]
 
 { #category : #accessing }

--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -20,15 +20,6 @@ SystemNavigation >> browseAllAccessesTo: instVarName from: aClass [
 ]
 
 { #category : #'*Tool-Base' }
-SystemNavigation >> browseAllCallsOn: aLiteral localTo: aClass [
-	"Create and schedule a message browser on each method in or below the given class that refers to
-	aLiteral. For example, SystemNavigation new browseAllCallsOn: #open:label: localTo: CodeHolder."
-
-
-	^ self browseAllSendersOf: aLiteral localTo: aClass
-]
-
-{ #category : #'*Tool-Base' }
 SystemNavigation >> browseAllCallsOnClass: aClass [
 	"Create and schedule a message browser on each method that refers to 
 	aClass. For example, SystemNavigation new browseAllCallsOnClass: Object."
@@ -96,21 +87,6 @@ SystemNavigation >> browseAllSendersOf: aLiteral [
 ]
 
 { #category : #'*Tool-Base' }
-SystemNavigation >> browseAllSendersOf: aLiteral localTo: aClass [
-	"Create and schedule a message browser on each method in or below the given class that refers to
-	aLiteral.
-	Example: 
-		SystemNavigation new browseAllSendersOf: #open:label: localTo: CodeHolder."
-
-	aClass ifNil: [ ^self inform: 'no selected class' ].
-	^ self headingAndAutoselectForLiteral: aLiteral do:
-		[:label :autoSelect|
-		self browseMessageList: (aClass allLocalCallsOn: aLiteral) asSortedCollection
-			name: label, ' local to ', aClass name
-			autoSelect: autoSelect]
-]
-
-{ #category : #'*Tool-Base' }
 SystemNavigation >> browseAllSendersOrUsersOf: aLiteralOrClass [ 
 	"Create and schedule a message browser on each method that refers to 
 	a literal or class name"
@@ -125,11 +101,18 @@ SystemNavigation >> browseAllStoresInto: instVarName from: aClass [
     "Create and schedule a Message Set browser for all the receiver's methods 
     or any methods of a subclass/superclass that refer to the instance variable name."
 
-    "self new browseAllStoresInto: 'youpi' from: BalloonEdgeData class."
+    "self new browseAllStoresInto: 'x' from: Point."
 
-    ^ self browseMessageList: (self allStoresInto: instVarName of: aClass)
-                name: 'Stores into ' , instVarName 
-                autoSelect: instVarName
+	| methods slot |
+	slot := aClass slotNamed: instVarName.
+	methods := (aClass allMethodsWritingSlot: slot) 
+		collect: [:meth | meth methodReference].
+	
+	^ self
+		browseMessageList: methods
+		name: 'Stores into ' , instVarName
+		autoSelect: instVarName
+		refreshingBlock: [ :method | slot isWrittenIn: method ]
 
 ]
 


### PR DESCRIPTION
browseAllStoresInto:from: should be implemented like browseAllAccessesTo:from:

in addition, delete some dead code that is unused and makes no sense as a public API

fixe #3654