### PR TITLE
3657-add-allClassVariables

### DIFF
--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -145,15 +145,6 @@ ClassTest >> testClassSide [
 	self assert: Point class classSide equals: Point class. 
 ]
 
-{ #category : #'tests - class variables' }
-ClassTest >> testClassVarNames [
-
-	self assert: (Object classVarNames includes: #DependentsFields).
-	
-	"A class and it's meta-class share the class variables"
-	self assert: (Object classVarNames = Object class classVarNames).
-]
-
 { #category : #'as yet unclassified' }
 ClassTest >> testCompileAll [
 	ClassTest compileAll
@@ -435,6 +426,30 @@ ClassTest >> testUsesPoolVarNamed [
 	self assert: (RootClassPoolUser usesPoolVarNamed: 'Author').
 	"a subclass  has  the one of its superclass"
 	self assert: (SubclassPoolUser usesPoolVarNamed: 'Author').
+]
+
+{ #category : #'tests - class variables' }
+ClassTest >> testallClassVariables [
+
+	self assert: SmalltalkImage allClassVariables last name equals: #DependentsFields
+]
+
+{ #category : #'tests - class variables' }
+ClassTest >> testclassVarNames [
+
+	self assert: (Object classVarNames includes: #DependentsFields).
+	
+	"A class and it's meta-class share the class variables"
+	self assert: (Object classVarNames = Object class classVarNames).
+]
+
+{ #category : #'tests - class variables' }
+ClassTest >> testclassVariables [
+
+	self assert: Object classVariables first name equals: #DependentsFields.
+	
+	"A class and it's meta-class share the class variables"
+	self assert: (Object classVariables = Object class classVariables).
 ]
 
 { #category : #'tests - class creation' }

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -186,6 +186,13 @@ Class >> allClassVarNames [
 			^aSet]
 ]
 
+{ #category : #'class variables' }
+Class >> allClassVariables [
+	"Answer the meta objects of all class variables of the class and its superclass"
+
+	^self withAllSuperclasses flatCollect:  [ :each | each classVariables ]
+]
+
 { #category : #'pool variables' }
 Class >> allSharedPools [
 	"Answer an ordered collection of the pools the receiver shares, including those defined  in the superclasses of the receiver."

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -104,10 +104,18 @@ Metaclass >> classSide [
 
 { #category : #'accessing instances and variables' }
 Metaclass >> classVarNames [
+	"Answer the names of the class variables defined in the receiver's instance."
+	
+	self instanceSide ifNil: [ ^ Array new ].
+	^self instanceSide classVarNames
+]
+
+{ #category : #'class variables' }
+Metaclass >> classVariables [
 	"Answer a set of the names of the class variables defined in the receiver's instance."
 	
-	self instanceSide ifNil: [ ^ Set new ].
-	^self instanceSide classVarNames
+	self instanceSide ifNil: [ ^ Array new].
+	^self instanceSide classVariables
 ]
 
 { #category : #'fileIn/Out' }


### PR DESCRIPTION
add #allClassVariables

we have classVariables retiring the variables of the class, in the spirit of #allSlots, #allIClassVarNames  and so on, we should have #allClassVariables returning the class vars of the class and it's superclass

fixes #3657