### PR TITLE
3659-add-isUsed-and-slotUsers-for-Slots-

### DIFF
--- a/src/Slot-Core/Slot.class.st
+++ b/src/Slot-Core/Slot.class.st
@@ -66,6 +66,11 @@ Slot class >> initialize [
 		ifNotNil: [ (WeakIdentityKeyDictionary newFrom: Properties) rehash]
 ]
 
+{ #category : #testing }
+Slot class >> isUsed [
+	^super isUsed or: [self slotUsers isNotEmpty ]
+]
+
 { #category : #'instance creation' }
 Slot class >> named: aSymbol [
 	self checkValidName: aSymbol.
@@ -92,6 +97,13 @@ Slot class >> slotSetting: aBuilder [
 		description: 'If checked then browsers show always the slot class definition';
 		parent: #codeBrowsing; 
 		target: self
+]
+
+{ #category : #testing }
+Slot class >> slotUsers [
+	"all classes or traits that have slots of this kind"
+	^self environment allBehaviors 
+		flatCollect:  [ :class | class slots select: [ :slot | slot class == self ] ]
 ]
 
 { #category : #comparing }

--- a/src/Slot-Tests/SlotTest.class.st
+++ b/src/Slot-Tests/SlotTest.class.st
@@ -85,3 +85,10 @@ SlotTest >> testRemoveProperty [
 		
 	self assert: ivar properties isNil.
 ]
+
+{ #category : #'tests - misc' }
+SlotTest >> testisUsed [
+	self assert: InstanceVariableSlot isUsed.
+	self assert: IndexedSlot isUsed. "subclasses are users"
+	self assert: ProcessLocalSlot isUsed. "references count as uses, too"
+]


### PR DESCRIPTION
#isUsed returns false if the class is not used at all. For slots, we need to check if there are any classes that define slots of this kind.

The method #slotUsers is useful in itself, e.g. for adding a UI to browse all the classes that use a certain kind of Slot later

fixes #3659