### PR TITLE
3680-Fuel-serialization-should-null-external-addresses

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -167,6 +167,7 @@ BaselineOfIDE >> baseline: spec [
 		spec package: 'AST-Core-Tests'.
 		spec package: 'FileSystem-Tests-Core'.
 		spec package: 'Fuel-Tests-Core'.
+		spec package: 'Fuel-Platform-Pharo-Core-Tests'.
 		spec package: 'Fuel-Tools-Pharo'.
 		spec package: 'Gofer-Tests'.
 		spec package: 'Kernel-Tests'.
@@ -447,6 +448,7 @@ spec group: 'General-Tests-Group' with: #(
 	'Monticello-Tests'	"required by MonticelloMocks"
 	'MonticelloMocks'
 	'Fuel-Tests-Core'
+	'Fuel-Platform-Pharo-Core-Tests'	
 	'Balloon-Tests'
 	'Collections-DoubleLinkedList-Tests'
 	'Collections-Arithmetic-Tests'

--- a/src/Fuel-Platform-Pharo-Core-Tests/FLSerializeExternalAddressTest.class.st
+++ b/src/Fuel-Platform-Pharo-Core-Tests/FLSerializeExternalAddressTest.class.st
@@ -1,0 +1,42 @@
+Class {
+	#name : #FLSerializeExternalAddressTest,
+	#superclass : #TestCase,
+	#category : #'Fuel-Platform-Pharo-Core-Tests'
+}
+
+{ #category : #utils }
+FLSerializeExternalAddressTest >> deserialize: aByteArray [
+
+	^ FLMaterializer materializeFromByteArray: aByteArray
+]
+
+{ #category : #utils }
+FLSerializeExternalAddressTest >> serialize: anObject [
+
+	^ FLSerializer serializeToByteArray: anObject 
+]
+
+{ #category : #tests }
+FLSerializeExternalAddressTest >> testDeserializedExternalAddressIsNull [
+
+	| externalAddress byteArray |
+
+	externalAddress := ExternalAddress fromAddress: 1234567890.
+	byteArray := self serialize: externalAddress.
+	externalAddress := self deserialize: byteArray.
+	
+	self assert: externalAddress isNull.
+]
+
+{ #category : #tests }
+FLSerializeExternalAddressTest >> testSerializeExternalAddressCorrectly [
+
+	| externalAddress byteArray |
+
+	externalAddress := ExternalAddress fromAddress: 1234567890.
+	byteArray := self serialize: externalAddress.
+	
+	self assert: byteArray isNotNil.
+	self assert: byteArray size > 0
+	
+]

--- a/src/Fuel-Platform-Pharo-Core-Tests/package.st
+++ b/src/Fuel-Platform-Pharo-Core-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Fuel-Platform-Pharo-Core-Tests' }

--- a/src/Fuel-Platform-Pharo-Core/ExternalAddress.extension.st
+++ b/src/Fuel-Platform-Pharo-Core/ExternalAddress.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #ExternalAddress }
+
+{ #category : #'*Fuel-Platform-Pharo-Core' }
+ExternalAddress >> fuelAccept: aGeneralMapper [
+
+	^ aGeneralMapper
+		visitSubstitution: self
+		by: ExternalAddress null
+		onRecursionDo: [ ^ super fuelAccept: aGeneralMapper ]
+]

--- a/src/Fuel-Platform-Pharo-Core/ExternalAddress.extension.st
+++ b/src/Fuel-Platform-Pharo-Core/ExternalAddress.extension.st
@@ -5,6 +5,6 @@ ExternalAddress >> fuelAccept: aGeneralMapper [
 
 	^ aGeneralMapper
 		visitSubstitution: self
-		by: ExternalAddress null
-		onRecursionDo: [ ^ super fuelAccept: aGeneralMapper ]
+		by: self class null
+		onRecursionDo: [ ^ aGeneralMapper visitFixedObject: self ]
 ]

--- a/src/Fuel-Platform-Pharo-Core/FLPharoPlatform.class.st
+++ b/src/Fuel-Platform-Pharo-Core/FLPharoPlatform.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FLPharoPlatform,
 	#superclass : #FLPlatform,
-	#category : 'Fuel-Platform-Pharo-Core'
+	#category : #'Fuel-Platform-Pharo-Core'
 }
 
 { #category : #testing }


### PR DESCRIPTION
The addresses should be null before serialization and handled correctly after the deserialization.