### PR TITLE
3467-Push-up-has-unexplicit-warning

### DIFF
--- a/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
@@ -143,21 +143,23 @@ RBPullUpMethodRefactoring >> checkSuperSendsFromSiblings [
 { #category : #preconditions }
 RBPullUpMethodRefactoring >> checkSuperclass [
 	| overrideSelectors |
-	overrideSelectors := selectors 
-				select: [:each | class superclass definesMethod: each].
-	overrideSelectors := overrideSelectors reject: 
-					[:each | 
-					| myTree superTree |
-					myTree := class parseTreeFor: each.
-					superTree := class superclass parseTreeFor: each.
-					superTree equalTo: myTree exceptForVariables: #()].
-	overrideSelectors isEmpty ifTrue: [^self].
-	class superclass isAbstract 
-		ifFalse: 
-			[self refactoringError: ('Non-abstract class <2p> already defines <1p>' 
+	overrideSelectors := selectors
+		select: [ :each | class superclass directlyDefinesMethod: each ].
+	overrideSelectors := overrideSelectors
+		reject: [ :each | 
+			| myTree superTree |
+			myTree := class parseTreeFor: each.
+			superTree := class superclass parseTreeFor: each.
+			superTree equalTo: myTree exceptForVariables: #() ].
+	overrideSelectors isEmpty
+		ifTrue: [ ^ self ].
+	class superclass isAbstract
+		ifFalse: [ self
+				refactoringError:
+					('Non-abstract class <2p> already defines <1p>'
 						expandMacrosWith: overrideSelectors asArray first
-						with: class superclass)].
-	overrideSelectors do: [:each | self checkBackReferencesTo: each]
+						with: class superclass) ].
+	overrideSelectors do: [ :each | self checkBackReferencesTo: each ]
 ]
 
 { #category : #private }

--- a/src/Refactoring-Tests-Core/RBPullUpMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBPullUpMethodTest.class.st
@@ -66,6 +66,52 @@ RBPullUpMethodTest >> testPullUpReferencesInstVar [
 ]
 
 { #category : #'failure tests' }
+RBPullUpMethodTest >> testPullUpWhenSuperClassDoesNotDirectlyImplement [
+	| classEnvironment classes |
+	classes := #(#ClassA #ClassB #ClassC)
+		inject: OrderedCollection new
+		into: [ :sum :each | 
+			Smalltalk globals
+				at: each
+				ifPresent: [ :class | 
+					sum
+						add: class;
+						add: class class ].
+			sum ].
+	classEnvironment := RBClassEnvironment classes: classes.
+	model name: 'Test'.
+	"Classes"
+	#('Object subclass: #ClassA
+		instanceVariableNames: ''''
+		classVariableNames: ''''
+		poolDictionaries: ''''
+		category: ''Testing'' ' 'ClassA subclass: #ClassB
+		instanceVariableNames: ''''
+		classVariableNames: ''''
+		poolDictionaries: ''''
+		category: ''Testing'' ' 'ClassB subclass: #ClassC
+		instanceVariableNames: ''''
+		classVariableNames: ''''
+		poolDictionaries: ''''
+		category: ''Testing'' ') do: [ :each | model defineClass: each ].
+	#(#(#ClassA #(#('foo
+			^ ''ClassA foo''' #private))) #(#ClassC #(#('foo
+			^ ''ClassC foo''' #private))))
+		do: [ :each | 
+			| class |
+			class := model classNamed: each first.
+			each last
+				do:
+					[ :methodPair | class compile: methodPair first classified: methodPair last ] ].
+	self
+		shouldntWarn:
+			(RBPullUpMethodRefactoring
+				model: model
+				pullUp: #(#foo)
+				from: (model classNamed: #ClassC))
+]
+
+{ #category : #'failure tests' }
 RBPullUpMethodTest >> testPullUpWithInvalidSuperSend [
 	| class |
 	model 

--- a/src/Refactoring-Tests-Core/RBRefactoringTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRefactoringTest.class.st
@@ -435,6 +435,13 @@ RBRefactoringTest >> shouldWarn: aRefactoring [
 		raise: RBRefactoringWarning
 ]
 
+{ #category : #private }
+RBRefactoringTest >> shouldntWarn: aRefactoring [ 
+	self 
+		shouldnt: [ self executeRefactoring: aRefactoring ]
+		raise: RBRefactoringWarning
+]
+
 { #category : #tests }
 RBRefactoringTest >> testConditions [
 	| condition newCondition |


### PR DESCRIPTION
Fixing issue #3467
No warning when pushing up a method in the superclass if the superclass does not directly implement the method.
Added a test.