### PR TITLE
New package for debugging settings and removing Spec debugger filtering settings code

### DIFF
--- a/src/BaselineOfUI/BaselineOfUI.class.st
+++ b/src/BaselineOfUI/BaselineOfUI.class.st
@@ -48,6 +48,7 @@ BaselineOfUI >> baseline: spec [
 		spec package: 'Debugger-Actions'.
 		spec package: 'Debugger-Filters'.
 		spec package: 'Debugger-Model'.
+		spec package: 'Debugging-Settings'.
 
 		spec package: 'Fonts-Chooser'.
 

--- a/src/Debugging-Settings/DebugSystemSettings.class.st
+++ b/src/Debugging-Settings/DebugSystemSettings.class.st
@@ -4,7 +4,7 @@ Settings for debugging
 Class {
 	#name : #DebugSystemSettings,
 	#superclass : #Object,
-	#category : #'Debugger-Model-Settings'
+	#category : #'Debugging-Settings'
 }
 
 { #category : #'private - settings' }
@@ -91,8 +91,7 @@ DebugSystemSettings class >> debugSettingsOn: aBuilder [
 				label: 'Directly open the full Debugger';
 				target: Smalltalk tools debugger;
 				description: 'When true, always directly open the full Debugger view when debugging instead of showing only a small popup' .
-			
-			self addDebugFilterSessingsOn: aBuilder.
+		
 				
 			(aBuilder setting: #logFileName)
 				label: 'Log file name' ;

--- a/src/Debugging-Settings/package.st
+++ b/src/Debugging-Settings/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Debugging-Settings' }


### PR DESCRIPTION
- Moving debugging settings classes from debugging model package to a dedicated debugging settings package (its not about the debugging model!)

- Temporary removing old-spec-related debugging filters settings which is blocking for (r)evolution of the spec debugger

Fixes#3692