### PR TITLE
3698-Improve-LastSpacePosition-comment-in-class-String

### DIFF
--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1889,14 +1889,13 @@ String >> keywords [
 
 { #category : #testing }
 String >> lastSpacePosition [
-	"Answer the character position of the final space or other separator character in the receiver, and 0 if none
+	"Answer the character position of the final space or other separator character in the receiver, and 0 if none"
+	"'fred the bear' lastSpacePosition >>> 9"
+	"'ziggie' lastSpacePosition >>> 0"
+	"'elvis ' lastSpacePosition >>> 6"
+	"'elvis  ' lastSpacePosition >>> 7"
+	"'' lastSpacePosition >>> 0"
 
-	'fred the bear' lastSpacePosition
-	'ziggie' lastSpacePosition
-	'elvis ' lastSpacePosition
-	'wimpy  ' lastSpacePosition
-	'' lastSpacePosition
-	"
 	self size to: 1 by: -1 do:
 		[:i | ((self at: i) isSeparator) ifTrue: [^ i]].
 	^ 0


### PR DESCRIPTION
Fixes: #3698 turn comments in executable comments