### PR TITLE
3630-small-cleanup-traits-in-Behaviour-isComposedBy-move-to-traits-

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -406,11 +406,6 @@ Behavior >> basicIdentityHash [
 	self primitiveFailed
 ]
 
-{ #category : #accessing }
-Behavior >> basicLocalSelectors [
-	^nil
-]
-
 { #category : #'instance creation' }
 Behavior >> basicNew [
 	"Primitive. Answer an instance of the receiver (which is a class) with no 
@@ -1104,15 +1099,6 @@ Behavior >> isCompact [
 Behavior >> isCompiledMethodClass [
 	"Answer whether the receiver has compiled method instances that mix pointers and bytes."
 	^self instSpec >= 24
-]
-
-{ #category : #accessing }
-Behavior >> isComposedBy: aTrait [
-	"Answers if this object includes trait aTrait into its composition"
-	aTrait isTrait ifFalse: [ ^false].
-	^self hasTraitComposition 
-		ifTrue: [ self traitComposition includesTrait: aTrait ]
-		ifFalse: [ false ]
 ]
 
 { #category : #'testing method dictionary' }

--- a/src/TraitsV2/Behavior.extension.st
+++ b/src/TraitsV2/Behavior.extension.st
@@ -16,6 +16,15 @@ Behavior >> isAliasSelector: aSymbol [
 ]
 
 { #category : #'*TraitsV2' }
+Behavior >> isComposedBy: aTrait [
+	"Answers if this object includes trait aTrait into its composition"
+	aTrait isTrait ifFalse: [ ^false].
+	^self hasTraitComposition 
+		ifTrue: [ self traitComposition includesTrait: aTrait ]
+		ifFalse: [ false ]
+]
+
+{ #category : #'*TraitsV2' }
 Behavior >> isLocalAliasSelector: aSymbol [
 	"Return true if the selector aSymbol is an alias defined
 	in my trait composition."


### PR DESCRIPTION
- isComposedBy: â> move to Traits package
- basicLocalSelectors can be deleted, left over internal method of old traits implementation

fixes #3630