### PR TITLE
3710-speedup-implementors-of

### DIFF
--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -94,15 +94,12 @@ SystemNavigation >> allImplementedMessages [
 ]
 
 { #category : #query }
-SystemNavigation >> allImplementorsOf: aSelector [ 
+SystemNavigation >> allImplementorsOf: aSelector [
 	"Answer all the methods that implement the message aSelector."
-	
-	| aCollection |
-	aCollection := OrderedCollection  new.
-	self allBehaviorsDo: [:class | 
-		(class includesSelector: aSelector)
-			ifTrue: [aCollection add: (class>>aSelector) methodReference]].
-	^ aCollection
+
+	^ self allBehaviors
+		select: [ :class | class includesSelector: aSelector ]
+		thenCollect: [ :class | (class >> aSelector) methodReference ]
 ]
 
 { #category : #query }


### PR DESCRIPTION
fixes #3710

With the allBehaviors cache, we can radically simplify (and speedup!) a lot of code used very very often.

[#name implementors] bench

before: "'69.688 per second'"
after: "'119.385 per second'"