### PR TITLE
3724-Anonther-small-cleanup-SystemNavigation

### DIFF
--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -185,15 +185,12 @@ SystemNavigation >> allObjectsOrNil [
 
 { #category : #query }
 SystemNavigation >> allPrimitiveMethods [
-	"Answer an OrderedCollection of all the methods that are implemented by primitives."
-	
-	| aColl |
-	aColl := OrderedCollection new: 200.
-	self allBehaviorsDo: [ :class | 
-		class selectorsAndMethodsDo: [ :sel :method | 
-			method isPrimitive
-				ifTrue: [ aColl addLast: class name , ' ' , sel , ' ' , method primitive printString ]]].
-	^ aColl
+	"Answer all the methods that are implemented by primitives."
+
+	^self allMethods
+		select: [ :method | method isPrimitive ]
+		thenCollect: [ :method | method methodClass name , ' ' , 
+			     method selector , ' ', method primitive printString ]
 ]
 
 { #category : #query }
@@ -240,20 +237,6 @@ SystemNavigation >> allReferencesToPool: aPool [
 													and: [ aPool includesKey: lit key ] ]
 						ifFound: [ list add: (cls>>sel) methodReference ] ] ].
 	^ list
-]
-
-{ #category : #query }
-SystemNavigation >> allReferencesToSubstring: aString do: aBlock [
-	"Perform aBlock on all the references to class whose name matches asString."
-	
-	| sortedClasses |
-	aString isEmptyOrNil ifTrue: [ ^ self ].
-	sortedClasses := SortedCollection new sortBlock: [ :a :b | a name size < b name size ].
-	(self allBehaviorsDo: [ :class |
-		(class name includesSubstring: aString caseSensitive: false) 
-			ifTrue: [ sortedClasses add: class ] ]).
-	sortedClasses do: [ :class |
-		self allReferencesTo: class binding do: aBlock ]
 ]
 
 { #category : #'message sends' }
@@ -381,10 +364,8 @@ SystemNavigation >> instanceSideMethodsWithNilKeyInLastLiteral [
 
 { #category : #'message sends' }
 SystemNavigation >> isUnsentMessage: selector [
-
-	self allBehaviorsDo: [ :behavior | 
-		(behavior thoroughHasSelectorReferringTo: selector) ifTrue: [ ^ false]].
-	^ true
+	^ self allBehaviors
+		noneSatisfy: [ :behavior | behavior thoroughHasSelectorReferringTo: selector ]
 ]
 
 { #category : #query }
@@ -471,6 +452,6 @@ SystemNavigation >> obsoleteMethodReferences [
 					ifTrue: [
 						(ref pointersTo) do: [ :meth | 
 							meth isCompiledMethod
-								ifTrue: [meth methodReference ifNotNil: [:mref | references nextPut: mref]]]]]].
+								ifTrue: [references nextPut: meth]]]]].
 	^ references contents
 ]

--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -486,50 +486,6 @@ SystemNavigation >> confirmRemovalOf: aSelector on: aClass [
 ]
 
 { #category : #'*Tool-Base' }
-SystemNavigation >> confirmRemovalOfSelectors: aCollection on: aClass [
-	"Determine if it is okay to remove the given selector. Answer 1 if it  
-	should be removed, 2 if it should be removed followed by a senders  
-	browse, and 3 if it should not be removed."
-	
-	"Smalltalk systemNavigation confirmRemovalOfSelectors: {#tearDown} on: TestCase >>> 3"
-	"Smalltalk systemNavigation confirmRemovalOfSelectors: {#tearDown. #setUp} on: TestCase >>> 3"
-
-	| collection count answer caption allCalls selectors oneCalls |
-	collection := aCollection asOrderedCollection copy.
-	oneCalls := OrderedCollection new.
-	aCollection
-		do:
-			[ :sel | 
-			allCalls := self allCallsOn: sel.
-			(count := allCalls size) = 0
-				ifTrue: [ collection remove: sel ].	"no senders -- let the removal happen without warning"
-			count = 1
-				ifTrue:
-					[ (allCalls first actualClass == aClass and: [ allCalls first selector == sel ])
-						ifTrue: [ oneCalls add: sel.
-							collection remove: sel ] ]	"only sender is itself" ].
-
-	"collection removeAll: (self buildSelfContainedCallsFrom: aCollection in: aClass)."
-	collection ifEmpty: [ ^ 1 ].
-	count := collection sum: [ :sel | (self allCallsOn: sel) size ].
-	selectors := collection joinUsing: ', #' last: ' and #'.
-	
-	caption := 'The <1?message:messages> #<2s> <1?has:have> <3p> <4?sender:senders' expandMacrosWithArguments: {collection size = 1. selectors. count. count = 1}.
-	
-	answer := UIManager default
-		chooseFrom:
-			#('Remove them' 'Remove, then browse senders (if still existing)' 'Don''t remove, but show me those senders' 'Forget it -- do nothing -- sorry I asked')
-		title: caption.
-	answer = 3
-		ifTrue: [ collection do: [ :aSelector | self browseAllSendersOf: aSelector ] ].
-	answer = 0
-		ifTrue: [ answer := 3 ].
-		
-	"If user didn't answer, treat it as cancel"
-	^ answer min: 3
-]
-
-{ #category : #'*Tool-Base' }
 SystemNavigation >> methodHierarchyBrowserForClass: aClass selector: sel [
 	"Create and schedule a message set browser on all implementors of the 
 	currently selected message selector. Do nothing if no message is selected."


### PR DESCRIPTION
- implement allPrimitiveMethods more compact
- isUnsentMessage: can use noneSatisfy:
- obsoleteMethodReferences should not wrap the result in a Ring Method Wrapper
- remove unused dead code:
    - allReferencesToSubstring:do:
    - confirmRemovalOfSelectors:on: 

fixes #3724