### PR TITLE
3730-SystemNavigation-allSendersOf-and-allReferencesTo-simplification

### DIFF
--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -194,20 +194,12 @@ SystemNavigation >> allPrimitiveMethods [
 ]
 
 { #category : #query }
-SystemNavigation >> allReferencesTo: aLiteral [ 
-	"Answer a Collection of all the methods that refer to aLiteral even deeply embedded in literal array."
+SystemNavigation >> allReferencesTo: aLiteral [
+	"Answer all the methods that refer to aLiteral even deeply embedded in literal array."
 
-	"self new allReferencesTo: #+"
-	"self new allReferencesTo: Point binding"
-	
-	| result |
-	result := OrderedCollection new.
-	self allBehaviorsDo: [ :class |
-		| selectors | 
-		selectors :=  class thoroughWhichSelectorsReferTo: aLiteral.
-		selectors do: [ :selector |
-			result addLast: (class>>selector) methodReference ] ].
-	^ result
+	^ self allBehaviors flatCollect: [ :class | 
+			(class thoroughWhichSelectorsReferTo: aLiteral)
+				collect: [ :selector | (class >> selector) methodReference ] ]
 ]
 
 { #category : #query }
@@ -255,12 +247,7 @@ SystemNavigation >> allReferencesToSubstring: aString do: aBlock [
 
 { #category : #'message sends' }
 SystemNavigation >> allSendersOf: selector [ 
-	|  senders |
-	senders := OrderedCollection new.
-	self allBehaviorsDo: [ :behavior | 
-		(behavior thoroughWhichSelectorsReferTo: selector) do: [ :sel| 
-			senders add: (behavior>>sel) methodReference ] ].
-	^ senders
+	^self allReferencesTo: selector
 ]
 
 { #category : #query }


### PR DESCRIPTION
fixes #3730
allReferencesTo: and allSendersOf: (and allCallsOn:) so all the same

- rewrite to use #allBehaviors and flatCollect
- make allSendersOf: call allReferencesTo: (as allCallsOn: does this already)

unifying the three methods is then future work