### PR TITLE
3732-cleanup-allLocalCallsOn

### DIFF
--- a/src/Deprecated80/SystemNavigation.extension.st
+++ b/src/Deprecated80/SystemNavigation.extension.st
@@ -17,6 +17,13 @@ SystemNavigation >> allClassesUsingSharedPool: aString [
 ]
 
 { #category : #'*Deprecated80' }
+SystemNavigation >> allLocalCallsOn: aSymbol ofClass: aClass [
+	"Answe all the methods that call on aSymbol, anywhere in my class hierarchy."
+	self deprecated: 'use allLocalCallsOn: on the class directly'.
+	^aClass allLocalCallsOn: aSymbol
+]
+
+{ #category : #'*Deprecated80' }
 SystemNavigation >> allUnreferencedClassVariablesOf: aClass [
 	"Answer a list of the receiver's unreferenced class vars, including those defined in superclasses"
 	self deprecated: 'just all allUnreferencedClassVariables on the class'.

--- a/src/Deprecated80/SystemNavigation.extension.st
+++ b/src/Deprecated80/SystemNavigation.extension.st
@@ -18,7 +18,7 @@ SystemNavigation >> allClassesUsingSharedPool: aString [
 
 { #category : #'*Deprecated80' }
 SystemNavigation >> allLocalCallsOn: aSymbol ofClass: aClass [
-	"Answe all the methods that call on aSymbol, anywhere in my class hierarchy."
+	"Answer all the methods that call on aSymbol, anywhere in my class hierarchy."
 	self deprecated: 'use allLocalCallsOn: on the class directly'.
 	^aClass allLocalCallsOn: aSymbol
 ]

--- a/src/Kernel-Tests-Extended/BehaviorTest.extension.st
+++ b/src/Kernel-Tests-Extended/BehaviorTest.extension.st
@@ -1,18 +1,6 @@
 Extension { #name : #BehaviorTest }
 
 { #category : #'*Kernel-Tests-Extended' }
-BehaviorTest >> testAllLocalCallsOn [
-	
-	self assert: (( Point allLocalCallsOn: #asPoint )  notEmpty).
-	self assert: (( Point allLocalCallsOn: #asPoint )  size = 4).
-	self assert: (( Point allLocalCallsOn: #asPoint )  includes: (Point>> #roundDownTo:) asRingDefinition).
-	self assert: (( Point allLocalCallsOn: #asPoint )  includes: (Point >> #roundUpTo:) asRingDefinition).
-	self assert: (( Point allLocalCallsOn: #asPoint )  includes: (Point >> #roundTo:) asRingDefinition).
-	self assert: (( Point allLocalCallsOn: #asPoint )  includes: (Point >> #truncateTo: ) asRingDefinition).
-	
-]
-
-{ #category : #'*Kernel-Tests-Extended' }
 BehaviorTest >> testAllReferencesTo [
 	| result |
 	result := SystemNavigation new allReferencesTo: Point binding.

--- a/src/Kernel-Tests-Extended/ClassDescriptionTest.extension.st
+++ b/src/Kernel-Tests-Extended/ClassDescriptionTest.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #ClassDescriptionTest }
+
+{ #category : #'*Kernel-Tests-Extended' }
+ClassDescriptionTest >> testAllLocalCallsOn [
+	
+	self assert: (( Point allLocalCallsOn: #asPoint )  notEmpty).
+	self assert: (( Point allLocalCallsOn: #asPoint )  size equals: 4).
+	self assert: (( Point allLocalCallsOn: #asPoint )  includes: (Point>> #roundDownTo:) ).
+	self assert: (( Point allLocalCallsOn: #asPoint )  includes: (Point >> #roundUpTo:) ).
+	self assert: (( Point allLocalCallsOn: #asPoint )  includes: (Point >> #roundTo:) ).
+	self assert: (( Point allLocalCallsOn: #asPoint )  includes: (Point >> #truncateTo: ) ).
+]

--- a/src/Kernel-Tests-Extended/ClassDescriptionTest.extension.st
+++ b/src/Kernel-Tests-Extended/ClassDescriptionTest.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #ClassDescriptionTest }
 ClassDescriptionTest >> testAllLocalCallsOn [
 	
 	self assert: (( Point allLocalCallsOn: #asPoint )  notEmpty).
-	self assert: (( Point allLocalCallsOn: #asPoint )  size equals: 4).
+	self assert: (( Point allLocalCallsOn: #asPoint )  size) equals: 4.
 	self assert: (( Point allLocalCallsOn: #asPoint )  includes: (Point>> #roundDownTo:) ).
 	self assert: (( Point allLocalCallsOn: #asPoint )  includes: (Point >> #roundUpTo:) ).
 	self assert: (( Point allLocalCallsOn: #asPoint )  includes: (Point >> #roundTo:) ).

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -181,14 +181,6 @@ Behavior >> allInstancesOrNil [
 	^nil
 ]
 
-{ #category : #'obsolete subclasses' }
-Behavior >> allLocalCallsOn: aSymbol [
-	"Answer a SortedCollection of all the methods that call on aSymbol, anywhere in my class hierarchy."
-
-	^(SystemNavigation new allLocalCallsOn: aSymbol ofClass: (self instanceSide)).
-
-]
-
 { #category : #'accessing method dictionary' }
 Behavior >> allMethods [
 	"Return the collection of compiled method I and my superclasses are defining"
@@ -1899,6 +1891,13 @@ Behavior >> withAllSubclassesDo: aBlock [
 	"Evaluate the argument, aBlock, for the receiver and each of its subclasses."
 	
 	self withAllSubclasses do: aBlock
+]
+
+{ #category : #'accessing class hierarchy' }
+Behavior >> withAllSuperAndSubclasses [
+	"Answer the receiver's class hierarchy"
+
+	^self allSuperclasses, self withAllSubclasses
 ]
 
 { #category : #enumerating }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -110,8 +110,16 @@ ClassDescription >> addSlot: aSlot [
 ClassDescription >> allInstVarNamesEverywhere [
 	"Answer the set of inst var names used by the receiver, all superclasses, and all subclasses"
 
-	^ self allSuperclasses , self withAllSubclasses asOrderedCollection
-		flatCollectAsSet: [ :cls | cls instVarNames ]
+	^ self withAllSuperAndSubclasses flatCollectAsSet: [ :cls | cls instVarNames ]
+]
+
+{ #category : #'obsolete subclasses' }
+ClassDescription >> allLocalCallsOn: aSymbol [
+	"Answer all the methods that call on aSymbol, anywhere in my class hierarchy."
+
+	^ self instanceSide withAllSuperAndSubclasses flatCollect: [ :class | 
+			(class whichSelectorsReferTo: aSymbol), (class class whichSelectorsReferTo: aSymbol)
+				collect: [ :symbol | class >> symbol ] ]
 ]
 
 { #category : #'accessing method dictionary' }

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -103,25 +103,6 @@ SystemNavigation >> allImplementorsOf: aSelector [
 ]
 
 { #category : #query }
-SystemNavigation >> allLocalCallsOn: aSymbol ofClass: aClass [
-	"Answer a SortedCollection of all the methods that call on aSymbol, anywhere in my class hierarchy."
-	
-	| aSet cls |
-	aSet := Set new.
-	cls := aClass instanceSide.
-	cls withAllSuperAndSubclassesDo: [ :class |
-		(class whichSelectorsReferTo: aSymbol)
-			do: [:sel |
-				aSet add: (class>>sel) methodReference ]].
-		
-	cls class withAllSuperAndSubclassesDo: [ :class |
-		(class whichSelectorsReferTo: aSymbol)
-			do: [:sel |
-				aSet add: (class>>sel) methodReference ]].
-	^aSet
-]
-
-{ #category : #query }
 SystemNavigation >> allMethods [
 	^ self environment allMethods
 


### PR DESCRIPTION
- deprecate #allLocalCallsOn:ofClass: in SystemNavigation, implement it in ClassDescription>>allLocalCallsOn:
- add withAllSuperAndSubclasses, use it in #allInstVarNamesEverywhere
- simplify allLocalCallsOn: to use allInstVarNamesEverywhere and flatCollect

fixes #3732