### PR TITLE
Backport of fix for diamond problem in traits with slots.

### DIFF
--- a/src/TraitsV2/TaSequence.class.st
+++ b/src/TraitsV2/TaSequence.class.st
@@ -315,7 +315,7 @@ TaSequence >> validateMethods: aTrait [
 { #category : #validations }
 TaSequence >> validateSlots: anElement [
 	self slots do: [ :e | anElement slots do: [ :other | 
-					(e name = other name and: [ e ~= other ])
+					(e name = other name and: [ e definingClass ~= other definingClass ])
 						ifTrue: [ self error: 'The added trait duplicates an existing slot ' , e name printString ] ] ]
 ]
 


### PR DESCRIPTION
This fix handles the validation of slots that came from different traits but they are defined in a single trait.

As they are defined once they should not be a conflict.