### PR TITLE
3705-Unwanted-separator-between-save-and-quit-and-quit-menubar-items

### DIFF
--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -187,14 +187,14 @@ WorldState class >> pharoItemsOn: aBuilder [
 				selector: #saveAndQuit;
 				help: 'Save the current image on disk, and quit Pharo.';
 				order: 4;
-				iconName: #smallQuitIcon;
-				withSeparatorAfter. 
+				iconName: #smallQuitIcon. 
 			(aBuilder item: #Quit)
 				target: self;
 				selector: #quitSession;
 				help: 'Quit Pharo without saving the image on disk.';
 				order: 5;
-				iconName: #smallQuitIcon ]
+				iconName: #smallQuitIcon;
+				withSeparatorAfter ]
 ]
 
 { #category : #'world menu items' }


### PR DESCRIPTION
Remove separator after "save and quit".

Fixet #3705