### PR TITLE
3739-Rules-override-wrong-method

### DIFF
--- a/src/GeneralRules/GRTemporaryVariableCapitalizationRule.class.st
+++ b/src/GeneralRules/GRTemporaryVariableCapitalizationRule.class.st
@@ -8,16 +8,8 @@ Class {
 }
 
 { #category : #running }
-GRTemporaryVariableCapitalizationRule >> check: aNode forCritiquesDo: aCriticBlock [
-
-	((self checkIsVariableWithParent: aNode) and: [ 
-	
-	((self checkIsArgumentDefinition: aNode) or: [ 
-	  self checkIsTempDefinition: aNode ])
-	
-	and: [ aNode name first isUppercase ] ]) 
-
-	ifTrue: [ aCriticBlock cull: (self critiqueFor: aNode) ]
+GRTemporaryVariableCapitalizationRule >> basicCheck: aNode [
+	^ (self checkIsVariableWithParent: aNode) and: [ ((self checkIsArgumentDefinition: aNode) or: [ self checkIsTempDefinition: aNode ]) and: [ aNode name first isUppercase ] ]
 ]
 
 { #category : #'running-helpers' }

--- a/src/GeneralRules/GRUndeclaredVariableRule.class.st
+++ b/src/GeneralRules/GRUndeclaredVariableRule.class.st
@@ -8,12 +8,8 @@ Class {
 }
 
 { #category : #running }
-GRUndeclaredVariableRule >> check: aNode forCritiquesDo: aCriticBlock [
-	
-	(aNode isVariable and: [
-	 aNode isUndeclared ]) ifTrue: [ 
-		aCriticBlock value: (
-			self critiqueFor: aNode) ]
+GRUndeclaredVariableRule >> basicCheck: aNode [
+	^ aNode isVariable and: [ aNode isUndeclared ]
 ]
 
 { #category : #helpers }

--- a/src/GeneralRules/RBAddRemoveDependentsRule.class.st
+++ b/src/GeneralRules/RBAddRemoveDependentsRule.class.st
@@ -20,7 +20,7 @@ RBAddRemoveDependentsRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBAddRemoveDependentsRule >> check: aClass forCritiquesDo: aCriticBlock [
+RBAddRemoveDependentsRule >> basicCheck: aClass [
 	| addSends removeSends |
 	addSends := 0.
 	removeSends := 0.
@@ -30,12 +30,9 @@ RBAddRemoveDependentsRule >> check: aClass forCritiquesDo: aCriticBlock [
 			(aClass compiledMethodAt: sel) ast
 				nodesDo: [ :each | 
 					each isMessage
-						ifTrue: [
-							each selector = #addDependent:
-								ifTrue: [ addSends := addSends + 1 ].
-							each selector = #removeDependent:
-								ifTrue: [ removeSends := removeSends + 1 ] ] ] ].
-	addSends > removeSends ifTrue: [ aCriticBlock cull: (self critiqueFor: aClass) ]
+						ifTrue: [ each selector = #addDependent: ifTrue: [ addSends := addSends + 1 ].
+							each selector = #removeDependent: ifTrue: [ removeSends := removeSends + 1 ] ] ] ].
+	^ addSends > removeSends
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBAssignmentOnBlockArgumentRule.class.st
+++ b/src/GeneralRules/RBAssignmentOnBlockArgumentRule.class.st
@@ -27,10 +27,8 @@ RBAssignmentOnBlockArgumentRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBAssignmentOnBlockArgumentRule >> check: aMethod forCritiquesDo: aCriticBlock [
-	((RBFindBlockArgumentAssignment collectAssignments: aMethod ast) notEmpty) ifTrue: [ 
-		aCriticBlock cull: (self critiqueFor: aMethod) ] 
-		
+RBAssignmentOnBlockArgumentRule >> basicCheck: aMethod [
+	^ (RBFindBlockArgumentAssignment collectAssignments: aMethod ast) isNotEmpty
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBBadMessageRule.class.st
+++ b/src/GeneralRules/RBBadMessageRule.class.st
@@ -20,10 +20,8 @@ RBBadMessageRule >> badSelectors [
 ]
 
 { #category : #enumerating }
-RBBadMessageRule >> check: aNode forCritiquesDo: aCriticBlock [
-    (aNode isMessage and: [ 
-    self badSelectors includes: aNode selector ])
-        ifTrue: [ aCriticBlock cull: (self critiqueFor: aNode) ]
+RBBadMessageRule >> basicCheck: aNode [
+	^ aNode isMessage and: [ self badSelectors includes: aNode selector ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBClassNotReferencedRule.class.st
+++ b/src/GeneralRules/RBClassNotReferencedRule.class.st
@@ -20,10 +20,8 @@ RBClassNotReferencedRule class >> uniqueIdentifierName [
 ]
 
 { #category : #enumerating }
-RBClassNotReferencedRule >> check: aClass forCritiquesDo: aCritiqueBlock [
-
-    aClass isUsed ifFalse: [
-        aCritiqueBlock cull: (self critiqueFor: aClass) ] 
+RBClassNotReferencedRule >> basicCheck: aClass [
+	^ aClass isUsed not
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBCollectSelectNotUsedRule.class.st
+++ b/src/GeneralRules/RBCollectSelectNotUsedRule.class.st
@@ -17,14 +17,10 @@ RBCollectSelectNotUsedRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBCollectSelectNotUsedRule >> check: aNode forCritiquesDo: aCritiqueBlock [
-
-
-	aNode isMessage ifFalse: [ ^ self ].
-	(#(#select: #collect: #reject:) includes: aNode selector) ifFalse: [ ^ self ].
-	aNode isUsed ifTrue: [ ^ self ].
-	
-	aCritiqueBlock cull: ( self critiqueFor: aNode )
+RBCollectSelectNotUsedRule >> basicCheck: aNode [
+	aNode isMessage ifFalse: [ ^ false ].
+	(#(#select: #collect: #reject:) includes: aNode selector) ifFalse: [ ^ false ].
+	^ aNode isUsed not
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBCollectionCopyEmptyRule.class.st
+++ b/src/GeneralRules/RBCollectionCopyEmptyRule.class.st
@@ -20,12 +20,8 @@ RBCollectionCopyEmptyRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBCollectionCopyEmptyRule >> check: aClass forCritiquesDo: aCritiqueBlock [
-	((aClass inheritsFrom: Collection)
-	and: [ aClass isVariable 
-	and: [ (aClass includesSelector: #copyEmpty) not 
-	and: [ aClass instVarNames isEmpty not ]]]) ifTrue: [
-		aCritiqueBlock cull: (self critiqueFor: aClass) ]
+RBCollectionCopyEmptyRule >> basicCheck: aClass [
+	^ (aClass inheritsFrom: Collection) and: [ aClass isVariable and: [ (aClass includesSelector: #copyEmpty) not and: [ aClass instVarNames isNotEmpty ] ] ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBDeadBlockRule.class.st
+++ b/src/GeneralRules/RBDeadBlockRule.class.st
@@ -16,9 +16,8 @@ RBDeadBlockRule class >> uniqueIdentifierName [
 ]
 
 { #category : #'as yet unclassified' }
-RBDeadBlockRule >> check: node forCritiquesDo: aCriticBlock [
-	(node isBlock and: [ node isUsed not ])
-		ifTrue: [ aCriticBlock cull: (self critiqueFor: node) ]
+RBDeadBlockRule >> basicCheck: node [
+	^ node isBlock and: [ node isUsed not ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBDefineBasicCheckRule.class.st
+++ b/src/GeneralRules/RBDefineBasicCheckRule.class.st
@@ -16,19 +16,18 @@ RBDefineBasicCheckRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
-RBDefineBasicCheckRule >> check: aClass forCritiquesDo: aCritiqueBlock [
-	((aClass inheritsFrom: RBLintRule) and: [ 
-		aClass isVisible and: [ 
-	  (aClass lookupSelector: #basicCheck:) isSubclassResponsibility ] ])
+{ #category : #running }
+RBDefineBasicCheckRule >> basicCheck: aClass [
+	^ (aClass inheritsFrom: RBLintRule) and: [ aClass isVisible and: [ (aClass lookupSelector: #basicCheck:) isSubclassResponsibility ] ]
+]
 
-		ifTrue: [ aCritiqueBlock cull: (
-			ReMissingMethodCritique
-				for: aClass
-				by: self
-				class: aClass
-				selector: #basicCheck:)
-				beShouldBeImplemented ]
+{ #category : #helpers }
+RBDefineBasicCheckRule >> critiqueFor: aClass [
+	^ (ReMissingMethodCritique
+		for: aClass
+		by: self
+		class: aClass
+		selector: #basicCheck:) beShouldBeImplemented
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBDefineEntityComplianceCheckRule.class.st
+++ b/src/GeneralRules/RBDefineEntityComplianceCheckRule.class.st
@@ -13,13 +13,8 @@ RBDefineEntityComplianceCheckRule class >> checksClass [
 ]
 
 { #category : #running }
-RBDefineEntityComplianceCheckRule >> check: aClass forCritiquesDo: aCritiqueBlock [
-	
-	((aClass inheritsFrom: RBLintRule) and: [ 
-		aClass isVisible and: [
-			self complianceMethods noneSatisfy: [ :method |
-				aClass perform: method ] ] ]) ifTrue: [
-        aCritiqueBlock cull: (self critiqueFor: aClass) ]
+RBDefineEntityComplianceCheckRule >> basicCheck: aClass [
+	^ (aClass inheritsFrom: RBLintRule) and: [ aClass isVisible and: [ self complianceMethods noneSatisfy: [ :method | aClass perform: method ] ] ]
 ]
 
 { #category : #properties }

--- a/src/GeneralRules/RBDefinesEqualNotHashRule.class.st
+++ b/src/GeneralRules/RBDefinesEqualNotHashRule.class.st
@@ -30,9 +30,8 @@ RBDefinesEqualNotHashRule class >> uniqueIdentifierName [
 ]
 
 { #category : #enumerating }
-RBDefinesEqualNotHashRule >> check: aClass forCritiquesDo: aCritiqueBlock [ 
-	((aClass includesSelector: #=) and: [ (aClass includesSelector: #hash) not ]) ifTrue: [
-        aCritiqueBlock cull: (self critiqueFor: aClass) ]
+RBDefinesEqualNotHashRule >> basicCheck: aClass [
+	^ (aClass includesSelector: #=) and: [ (aClass includesSelector: #hash) not ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBEqualNotUsedRule.class.st
+++ b/src/GeneralRules/RBEqualNotUsedRule.class.st
@@ -14,12 +14,9 @@ RBEqualNotUsedRule class >> uniqueIdentifierName [
 	^'EqualNotUsedRule'
 ]
 
-{ #category : #'as yet unclassified' }
-RBEqualNotUsedRule >> check: node forCritiquesDo: aCriticBlock [
-	(node isMessage
-		and: [ node isUsed not
-				and: [ #(#= #== #~= #~~ #< #> #<= #>=) includes: node selector ] ])
-		ifTrue: [ aCriticBlock cull: (self critiqueFor: node) ]
+{ #category : #running }
+RBEqualNotUsedRule >> basicCheck: node [
+	^ node isMessage and: [ node isUsed not and: [ #(#= #== #~= #~~ #< #> #<= #>=) includes: node selector ] ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBEqualsTrueRule.class.st
+++ b/src/GeneralRules/RBEqualsTrueRule.class.st
@@ -15,15 +15,13 @@ RBEqualsTrueRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBEqualsTrueRule >> check: aNode forCritiquesDo: aCriticBlock [
+RBEqualsTrueRule >> basicCheck: aNode [
 	| parent |
-	aNode isLiteralNode ifFalse: [ ^ self ].
-	(#(true false) includes: aNode value) ifFalse: [ ^ self ].
-	(parent := aNode parent) ifNil: [ ^ self ].
-	parent isMessage ifFalse: [ ^ self ].
-	(#(#= #== #~= #~~) includes: parent selector) ifFalse: [ ^ self ].
-	
-	aCriticBlock cull: (self critiqueFor: aNode)
+	aNode isLiteralNode ifFalse: [ ^ false ].
+	(#(true false) includes: aNode value) ifFalse: [ ^ false ].
+	(parent := aNode parent) ifNil: [ ^ false ].
+	parent isMessage ifFalse: [ ^ false ].
+	^ #(#= #== #~= #~~) includes: parent selector
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBEquivalentSuperclassMethodsRule.class.st
+++ b/src/GeneralRules/RBEquivalentSuperclassMethodsRule.class.st
@@ -22,15 +22,14 @@ RBEquivalentSuperclassMethodsRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBEquivalentSuperclassMethodsRule >> check: aMethod forCritiquesDo: aCritiqueBlock [
-    (self ignoredSelectors includes: aMethod selector)
-        ifTrue: [ ^ self ].
-    aMethod methodClass superclass
-        ifNotNil: [ :superclass |
-            (superclass lookupSelector: aMethod selector)
-            ifNotNil: [ :overridenMethod |
-                aMethod ast = overridenMethod ast ifTrue: [
-                     aCritiqueBlock cull: (self critiqueFor: aMethod) ] ] ]
+RBEquivalentSuperclassMethodsRule >> basicCheck: aMethod [
+	(self ignoredSelectors includes: aMethod selector) ifTrue: [ ^ false ].
+
+	^ aMethod methodClass superclass
+		ifNotNil: [ :superclass | (superclass lookupSelector: aMethod selector)
+			ifNotNil: [ :overridenMethod | aMethod ast = overridenMethod ast ]
+			ifNil: [ false ] ]
+		ifNil: [ false ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBExcessiveArgumentsRule.class.st
+++ b/src/GeneralRules/RBExcessiveArgumentsRule.class.st
@@ -29,10 +29,8 @@ RBExcessiveArgumentsRule >> argumentsCount [
 ]
 
 { #category : #running }
-RBExcessiveArgumentsRule >> check: aMethod forCritiquesDo: aCritiqueBlock [
-	(aMethod numArgs >= self argumentsCount) ifTrue: [
-        aCritiqueBlock cull: (self critiqueFor: aMethod) ]
-		
+RBExcessiveArgumentsRule >> basicCheck: aMethod [
+	^ aMethod numArgs >= self argumentsCount
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBExcessiveInheritanceRule.class.st
+++ b/src/GeneralRules/RBExcessiveInheritanceRule.class.st
@@ -28,11 +28,10 @@ RBExcessiveInheritanceRule class >> uniqueIdentifierName [
 ]
 
 { #category : #enumerating }
-RBExcessiveInheritanceRule >> check: aClass forCritiquesDo: aCritiqueBlock [
-	aClass isMeta ifTrue: [ ^ self ].
+RBExcessiveInheritanceRule >> basicCheck: aClass [
+	aClass isMeta ifTrue: [ ^ false ].
 	
-	aClass allSuperclasses size >= self inheritanceDepth ifTrue: [
-        aCritiqueBlock cull: (self critiqueFor: aClass) ]
+	^ aClass allSuperclasses size >= self inheritanceDepth
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBExcessiveMethodsRule.class.st
+++ b/src/GeneralRules/RBExcessiveMethodsRule.class.st
@@ -26,10 +26,8 @@ RBExcessiveMethodsRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBExcessiveMethodsRule >> check: aClass forCritiquesDo: aCritiqueBlock [ 
-	(aClass selectors size >= self methodsCount) ifTrue: [
-        aCritiqueBlock cull: (self critiqueFor: aClass) ]
-		
+RBExcessiveMethodsRule >> basicCheck: aClass [
+	^ aClass selectors size >= self methodsCount
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBExcessiveVariablesRule.class.st
+++ b/src/GeneralRules/RBExcessiveVariablesRule.class.st
@@ -22,11 +22,8 @@ RBExcessiveVariablesRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBExcessiveVariablesRule >> check: aClass forCritiquesDo: aCritiqueBlock [
-	(aClass instVarNames size >= self variablesCount
-		or: [ aClass classVarNames size >= self variablesCount ]) ifTrue: [
-        aCritiqueBlock cull: (self critiqueFor: aClass) ]
-			
+RBExcessiveVariablesRule >> basicCheck: aClass [
+	^ aClass instVarNames size >= self variablesCount or: [ aClass classVarNames size >= self variablesCount ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBExtraBlockRule.class.st
+++ b/src/GeneralRules/RBExtraBlockRule.class.st
@@ -16,20 +16,16 @@ RBExtraBlockRule class >> uniqueIdentifierName [
 ]
 
 { #category : #enumerating }
-RBExtraBlockRule >> blockEvaluatingMessages [
-	^ #(#value #value: #value:value: #value:value:value: #valueWithArguments:)
+RBExtraBlockRule >> basicCheck: node [
+	node isMessage ifFalse: [ ^ false ].
+	node receiver isBlock ifFalse: [ ^ false ].
+	node parent isCascade ifTrue: [ ^ false ].
+	^ self blockEvaluatingMessages includes: node selector
 ]
 
 { #category : #enumerating }
-RBExtraBlockRule >> check: node forCritiquesDo: aCriticBlock [
-	node isMessage ifFalse: [ ^ self ].
-	node receiver isBlock ifFalse: [ ^ self ].
-	node parent isCascade ifTrue: [ ^ self ].
-	(self blockEvaluatingMessages includes: node selector)
-		ifFalse: [ ^ self ].
-	
-	aCriticBlock cull: (self critiqueFor: node)
-
+RBExtraBlockRule >> blockEvaluatingMessages [
+	^ #(#value #value: #value:value: #value:value:value: #valueWithArguments:)
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBImplementedNotSentRule.class.st
+++ b/src/GeneralRules/RBImplementedNotSentRule.class.st
@@ -124,17 +124,13 @@ RBImplementedNotSentRule class >> unsubscribe [
 ]
 
 { #category : #running }
-RBImplementedNotSentRule >> check: aMethod forCritiquesDo: aCriticBlock [
+RBImplementedNotSentRule >> basicCheck: aMethod [
 	"Check if there are any senders. Furthermore methods with pragmas are likely to be sent through reflection, thus do not report those. Also test methods are sent through reflection, so ignore those as well."
-	
-	aMethod pragmas ifNotEmpty: [ ^ self ].
-	(aMethod methodClass isMeta not and: [
-	aMethod methodClass isTestCase ]) ifTrue: [ ^ self ].
-	
-	(self class allMessages includes: aMethod selector)
-		ifTrue: [ ^ self ].
-	
-	aCriticBlock cull: (self critiqueFor: aMethod)
+
+	aMethod pragmas ifNotEmpty: [ ^ false ].
+	(aMethod methodClass isMeta not and: [ aMethod methodClass isTestCase ]) ifTrue: [ ^ false ].
+
+	^ (self class allMessages includes: aMethod selector) not
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBJustSendsSuperRule.class.st
+++ b/src/GeneralRules/RBJustSendsSuperRule.class.st
@@ -23,12 +23,8 @@ RBJustSendsSuperRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBJustSendsSuperRule >> check: aMethod forCritiquesDo: aCritiqueBlock [ 
-	(aMethod ast isPrimitive not and: 
-		[ matcher 
-			executeMethod: aMethod ast
-			initialAnswer: false ]) ifTrue: [
-        aCritiqueBlock cull: (self critiqueFor: aMethod) ]
+RBJustSendsSuperRule >> basicCheck: aMethod [
+	^ aMethod ast isPrimitive not and: [ matcher executeMethod: aMethod ast initialAnswer: false ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBLiteralArrayCharactersRule.class.st
+++ b/src/GeneralRules/RBLiteralArrayCharactersRule.class.st
@@ -15,13 +15,10 @@ RBLiteralArrayCharactersRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBLiteralArrayCharactersRule >> check: aNode forCritiquesDo: aCriticBlock [
-
-	aNode isLiteralArray ifFalse: [ ^ self ].
-	aNode value ifEmpty: [ ^ self ].
-	(aNode value allSatisfy: #isCharacter)
-		ifTrue: [ 
-			aCriticBlock cull: (self critiqueFor: aNode) ]
+RBLiteralArrayCharactersRule >> basicCheck: aNode [
+	aNode isLiteralArray ifFalse: [ ^ false ].
+	aNode value ifEmpty: [ ^ false ].
+	^ aNode value allSatisfy: #isCharacter
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBLiteralArrayContainsCommaRule.class.st
+++ b/src/GeneralRules/RBLiteralArrayContainsCommaRule.class.st
@@ -15,12 +15,8 @@ RBLiteralArrayContainsCommaRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBLiteralArrayContainsCommaRule >> check: aNode forCritiquesDo: aCritiqueBlock [ 
-	aNode isLiteralArray ifFalse: [ ^ self ].
-	(aNode value includes: #,) ifFalse: [ ^ self ].
-
-
-	aCritiqueBlock cull: (self critiqueFor: aNode)
+RBLiteralArrayContainsCommaRule >> basicCheck: aNode [
+	^ aNode isLiteralArray and: [ aNode value includes: #, ]
 ]
 
 { #category : #private }

--- a/src/GeneralRules/RBLiteralArrayContainsSuspiciousTrueFalseOrNilRule.class.st
+++ b/src/GeneralRules/RBLiteralArrayContainsSuspiciousTrueFalseOrNilRule.class.st
@@ -20,13 +20,8 @@ RBLiteralArrayContainsSuspiciousTrueFalseOrNilRule class >> uniqueIdentifierName
 ]
 
 { #category : #running }
-RBLiteralArrayContainsSuspiciousTrueFalseOrNilRule >> check: aNode forCritiquesDo: aCriticBlock [
-
-	aNode isLiteralArray ifFalse: [ ^ self ].
-	(aNode value includesAny: #(#true #false #nil))
-		ifFalse: [ ^ self ].
-		
-	aCriticBlock cull: (self critiqueFor: aNode) 
+RBLiteralArrayContainsSuspiciousTrueFalseOrNilRule >> basicCheck: aNode [
+	^ aNode isLiteralArray and: [ aNode value includesAny: #(#true #false #nil) ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBLocalMethodsSameThanTraitRule.class.st
+++ b/src/GeneralRules/RBLocalMethodsSameThanTraitRule.class.st
@@ -20,16 +20,16 @@ RBLocalMethodsSameThanTraitRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBLocalMethodsSameThanTraitRule >> check: aClass forCritiquesDo: aCriticBlock [
-	
+RBLocalMethodsSameThanTraitRule >> basicCheck: aClass [
 	"The comparison between methods is made using the ast, this is better than comparing source code only since it does not take into account identations, extra parenthesis, etc"
 
-	(aClass isTrait not and: [ aClass hasTraitComposition and: [  
-		aClass localMethods anySatisfy: [ :method | |traitCompositionMethod |
-			traitCompositionMethod := aClass traitComposition compiledMethodAt: method selector ifAbsent: [nil].
-			traitCompositionMethod notNil and: [
-				(traitCompositionMethod ast = method ast) ] ] ] ]) ifTrue: [ 
-		aCriticBlock cull: (self critiqueFor: aClass) ]
+	^ aClass isTrait not
+		and: [ aClass hasTraitComposition
+				and: [ aClass localMethods
+						anySatisfy: [ :method | 
+							| traitCompositionMethod |
+							traitCompositionMethod := aClass traitComposition compiledMethodAt: method selector ifAbsent: [ nil ].
+							traitCompositionMethod notNil and: [ traitCompositionMethod ast = method ast ] ] ] ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBLongMethodsRule.class.st
+++ b/src/GeneralRules/RBLongMethodsRule.class.st
@@ -28,16 +28,16 @@ RBLongMethodsRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBLongMethodsRule >> check: aMethod forCritiquesDo: aCriticBlock [
+RBLongMethodsRule >> basicCheck: aMethod [
 	| numberOfStatements |
 	numberOfStatements := 0.
 
-	(aMethod ast nodesDo: [ :node |
-		node isSequence ifTrue: [ 
-			numberOfStatements := numberOfStatements + node statements size.
-			numberOfStatements >= self longMethodSize ifTrue: [
-				^ aCriticBlock cull: (self critiqueFor: aMethod) ] ] ])
-		
+	aMethod ast
+		nodesDo: [ :node | 
+			node isSequence
+				ifTrue: [ numberOfStatements := numberOfStatements + node statements size.
+					numberOfStatements >= self longMethodSize ifTrue: [ ^ true ] ] ].
+	^ false
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBMethodSourceContainsLinefeedsRule.class.st
+++ b/src/GeneralRules/RBMethodSourceContainsLinefeedsRule.class.st
@@ -20,9 +20,8 @@ RBMethodSourceContainsLinefeedsRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBMethodSourceContainsLinefeedsRule >> check: aMethod forCritiquesDo: aCriticBlock [
-	(aMethod sourceCode includes: Character lf) ifTrue: [ 
-		aCriticBlock cull: (self critiqueFor: aMethod) ]
+RBMethodSourceContainsLinefeedsRule >> basicCheck: aMethod [
+	^ aMethod sourceCode includes: Character lf
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBMissingSuperSendsRule.class.st
+++ b/src/GeneralRules/RBMissingSuperSendsRule.class.st
@@ -20,27 +20,22 @@ RBMissingSuperSendsRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBMissingSuperSendsRule >> check: aMethod forCritiquesDo: aCriticBlock [
+RBMissingSuperSendsRule >> basicCheck: aMethod [
 	| definer superMethod |
-	aMethod methodClass isMeta ifTrue: [ ^ self ].
-	(self methodsRequiringSuper includes: aMethod selector) ifFalse: [ ^ self ]. 
-	
-	definer := aMethod methodClass superclass ifNotNil: [ :sc |
-		sc whichClassIncludesSelector: aMethod selector ].
-	definer ifNil: [ ^ self ].
-	
+	aMethod methodClass isMeta ifTrue: [ ^ false ].
+	(self methodsRequiringSuper includes: aMethod selector) ifFalse: [ ^ false ].
+
+	definer := aMethod methodClass superclass ifNotNil: [ :sc | sc whichClassIncludesSelector: aMethod selector ].
+	definer ifNil: [ ^ false ].
+
 	"super defines same method"
-	(aMethod superMessages includes: aMethod selector) ifTrue: [ ^self ]. 
-	
+	(aMethod superMessages includes: aMethod selector) ifTrue: [ ^ false ].
+
 	"but I don't call it"
-	superMethod := definer 
-		compiledMethodAt: aMethod selector
-		ifAbsent: [  ].
-	
-	superMethod isReturnSelf ifTrue: [ ^ self ].
-	(superMethod sendsSelector: #subclassResponsibility) ifTrue: [ ^ self ].
-	
-	aCriticBlock cull: (self critiqueFor: aMethod)
+	superMethod := definer compiledMethodAt: aMethod selector ifAbsent: [  ].
+
+	superMethod isReturnSelf ifTrue: [ ^ false ].
+	^ (superMethod sendsSelector: #subclassResponsibility) not
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBNoClassCommentRule.class.st
+++ b/src/GeneralRules/RBNoClassCommentRule.class.st
@@ -20,11 +20,9 @@ RBNoClassCommentRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBNoClassCommentRule >> check: aClass forCritiquesDo: aCriticBlock [
-	(aClass isMeta or: [ aClass isTestCase ])
-		ifTrue: [ ^ false ].
-	(aClass hasComment not) ifTrue: [ 
-		aCriticBlock cull: (self critiqueFor: aClass) ]
+RBNoClassCommentRule >> basicCheck: aClass [
+	(aClass isMeta or: [ aClass isTestCase ]) ifTrue: [ ^ false ].
+	^ aClass hasComment not
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBPrecedenceRule.class.st
+++ b/src/GeneralRules/RBPrecedenceRule.class.st
@@ -15,17 +15,14 @@ RBPrecedenceRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBPrecedenceRule >> check: aNode forCritiquesDo: aCriticBlock [
+RBPrecedenceRule >> basicCheck: aNode [
 	| leftOperand |
-	
-	aNode isMessage ifFalse: [ ^ self ].
-	aNode selector = #* ifFalse: [ ^ self ].
+	aNode isMessage ifFalse: [ ^ false ].
+	aNode selector = #* ifFalse: [ ^ false ].
 	leftOperand := aNode receiver.
-	leftOperand isMessage ifFalse: [ ^ self ].
-	leftOperand hasParentheses ifTrue: [ ^ self ].
-	(#(#+ #-) includes: leftOperand selector) ifFalse: [ ^ self ].
-	
-	aCriticBlock cull: (self critiqueFor: aNode)
+	leftOperand isMessage ifFalse: [ ^ false ].
+	leftOperand hasParentheses ifTrue: [ ^ false ].
+	^ #(#+ #-) includes: leftOperand selector
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBRefersToClassRule.class.st
+++ b/src/GeneralRules/RBRefersToClassRule.class.st
@@ -21,12 +21,10 @@ RBRefersToClassRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBRefersToClassRule >> check: aMethod forCritiquesDo: aCriticBlock [
+RBRefersToClassRule >> basicCheck: aMethod [
 	| class |
 	class := aMethod methodClass instanceSide.
-	(aMethod hasLiteral: (class environment associationAt: class name ifAbsent: [ ^ self ])) ifTrue: [ 
-		aCriticBlock cull: (self critiqueFor: aMethod) ]
-	
+	^ aMethod hasLiteral: (class environment associationAt: class name ifAbsent: [ ^ false ])
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBSendsDifferentSuperRule.class.st
+++ b/src/GeneralRules/RBSendsDifferentSuperRule.class.st
@@ -27,13 +27,8 @@ RBSendsDifferentSuperRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBSendsDifferentSuperRule >> check: aMethod forCritiquesDo: aCriticBlock [
-
-	(aMethod superMessages anySatisfy: [ :message |
-		message ~= aMethod selector ]) ifTrue: [ 
-		aCriticBlock cull: (self critiqueFor: aMethod) ]
-	
-
+RBSendsDifferentSuperRule >> basicCheck: aMethod [
+	^ aMethod superMessages anySatisfy: [ :message | message ~= aMethod selector ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBSendsMethodDictRule.class.st
+++ b/src/GeneralRules/RBSendsMethodDictRule.class.st
@@ -20,12 +20,9 @@ RBSendsMethodDictRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBSendsMethodDictRule >> check: aMethod forCritiquesDo: aCriticBlock [	
-	({Behavior. ClassDescription. Class. } includes: aMethod methodClass)
-		ifTrue: [ ^ self ].
-	(aMethod messages includes: #methodDict) ifTrue: [ 
-		aCriticBlock cull: (self critiqueFor: aMethod) ]
-		
+RBSendsMethodDictRule >> basicCheck: aMethod [
+	({Behavior . ClassDescription . Class} includes: aMethod methodClass) ifTrue: [ ^ false ].
+	^ aMethod messages includes: #methodDict
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBSendsUnknownMessageToGlobalRule.class.st
+++ b/src/GeneralRules/RBSendsUnknownMessageToGlobalRule.class.st
@@ -15,22 +15,14 @@ RBSendsUnknownMessageToGlobalRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBSendsUnknownMessageToGlobalRule >> check: aNode forCritiquesDo: aCriticBlock [
+RBSendsUnknownMessageToGlobalRule >> basicCheck: aNode [
 	| messageReceiver |
+	aNode isMessage ifFalse: [ ^ false ].
 
-	aNode isMessage ifFalse: [ ^ self ].
-	
 	messageReceiver := aNode receiver.
-	messageReceiver isVariable ifFalse: [ ^ self ].
-	
+	messageReceiver isVariable ifFalse: [ ^ false ].
 
-	((Smalltalk globals
-		at: messageReceiver name asSymbol
-		ifAbsent: [ ^ self ])
-			respondsTo: aNode selector)
-				ifTrue: [ ^ self ].
-		
-	aCriticBlock cull: (self critiqueFor: aNode)
+	^ ((Smalltalk globals at: messageReceiver name asSymbol ifAbsent: [ ^ false ]) respondsTo: aNode selector) not
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBTempsReadBeforeWrittenRule.class.st
+++ b/src/GeneralRules/RBTempsReadBeforeWrittenRule.class.st
@@ -20,12 +20,8 @@ RBTempsReadBeforeWrittenRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBTempsReadBeforeWrittenRule >> check: aMethod forCritiquesDo: aCriticBlock [
-	| a |
-	a asString.
-	a := 1.
-	((RBReadBeforeWrittenTester variablesReadBeforeWrittenIn: aMethod ast) notEmpty) ifTrue: [ 
-		aCriticBlock cull: (self critiqueFor: aMethod) ]
+RBTempsReadBeforeWrittenRule >> basicCheck: aMethod [
+	^ (RBReadBeforeWrittenTester variablesReadBeforeWrittenIn: aMethod ast) isNotEmpty
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBUnaryAccessingMethodWithoutReturnRule.class.st
+++ b/src/GeneralRules/RBUnaryAccessingMethodWithoutReturnRule.class.st
@@ -19,18 +19,12 @@ RBUnaryAccessingMethodWithoutReturnRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBUnaryAccessingMethodWithoutReturnRule >> check: aMethod forCritiquesDo: aCriticBlock [
+RBUnaryAccessingMethodWithoutReturnRule >> basicCheck: aMethod [
+	(aMethod numArgs > 0 or: [ aMethod isAbstract ]) ifTrue: [ ^ false ].
+	((aMethod methodClass organization categoryOfElement: aMethod selector) asString beginsWith: 'accessing') ifFalse: [ ^ false ].
+	aMethod ast nodesDo: [ :each | each isReturn ifTrue: [ ^ false ] ].
 
-	(aMethod numArgs > 0 or: [ aMethod isAbstract ]) ifTrue: [ ^ self ].
-	((aMethod methodClass organization categoryOfElement: aMethod selector) asString
-		beginsWith: 'accessing')
-		ifFalse: [ ^ self ].
-	aMethod ast
-		nodesDo: [ :each | 
-			each isReturn
-				ifTrue: [ ^ self ] ].
-	
-	aCriticBlock cull:  (self critiqueFor: aMethod)
+	^ true
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBUnclassifiedMethodsRule.class.st
+++ b/src/GeneralRules/RBUnclassifiedMethodsRule.class.st
@@ -20,10 +20,8 @@ RBUnclassifiedMethodsRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBUnclassifiedMethodsRule >> check: aMethod forCritiquesDo: aCriticBlock [
-	(aMethod protocol = Protocol unclassified) ifTrue: [ 
-		aCriticBlock cull: (self critiqueFor: aMethod) ]
-		
+RBUnclassifiedMethodsRule >> basicCheck: aMethod [
+	^ aMethod protocol = Protocol unclassified
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBUncommonMessageSendRule.class.st
+++ b/src/GeneralRules/RBUncommonMessageSendRule.class.st
@@ -23,10 +23,8 @@ RBUncommonMessageSendRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBUncommonMessageSendRule >> check: aMethod forCritiquesDo: aCriticBlock [
-	(aMethod messages anySatisfy: [ :each |
-		(each isEmpty or: [ each first isUppercase or: [ literalNames includes: each ] ]) ]) ifTrue: [ 
-		aCriticBlock cull: (self critiqueFor: aMethod) ]
+RBUncommonMessageSendRule >> basicCheck: aMethod [
+	^ aMethod messages anySatisfy: [ :each | each isEmpty or: [ each first isUppercase or: [ literalNames includes: each ] ] ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBUnnecessaryAssignmentRule.class.st
+++ b/src/GeneralRules/RBUnnecessaryAssignmentRule.class.st
@@ -15,13 +15,10 @@ RBUnnecessaryAssignmentRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBUnnecessaryAssignmentRule >> check: aNode forCritiquesDo: aCriticBlock [
-	
-	aNode isReturn ifFalse: [ ^ self ].
-	aNode isAssignment ifFalse: [ ^ self ].
-	(aNode whoDefines: aNode variable name) ifNil: [ ^ self ].
-	
-	aCriticBlock cull: (self critiqueFor: aNode)
+RBUnnecessaryAssignmentRule >> basicCheck: aNode [
+	aNode isReturn ifFalse: [ ^ false ].
+	aNode isAssignment ifFalse: [ ^ false ].
+	^ (aNode whoDefines: aNode variable name) isNotNil
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBUnpackagedCodeRule.class.st
+++ b/src/GeneralRules/RBUnpackagedCodeRule.class.st
@@ -25,13 +25,8 @@ RBUnpackagedCodeRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBUnpackagedCodeRule >> check: anEntity forCritiquesDo: aCriticBlock [
-
-	anEntity package ifNotNil: [ :package |
-		package isDefault ifFalse: [ ^ self ] ].
-	
-	aCriticBlock cull: (
-		self critiqueFor: anEntity)
+RBUnpackagedCodeRule >> basicCheck: anEntity [
+	^ anEntity package isNotNil and: [ anEntity package isDefault ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBUsesAddRule.class.st
+++ b/src/GeneralRules/RBUsesAddRule.class.st
@@ -14,12 +14,9 @@ RBUsesAddRule class >> uniqueIdentifierName [
 	^'UsesAddRule'
 ]
 
-{ #category : #'as yet unclassified' }
-RBUsesAddRule >> check: node forCritiquesDo: aCriticBlock [
-	(node isMessage
-		and: [ (node selector == #add: or: [ node selector == #addAll: ])
-				and: [ node isDirectlyUsed ] ])
-		ifTrue: [ aCriticBlock cull: (self critiqueFor: node) ]
+{ #category : #running }
+RBUsesAddRule >> basicCheck: node [
+	^ node isMessage and: [ (#(#add: #addAll:) includes: node selector) and: [ node isDirectlyUsed ] ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBUsesTrueRule.class.st
+++ b/src/GeneralRules/RBUsesTrueRule.class.st
@@ -26,9 +26,8 @@ RBUsesTrueRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBUsesTrueRule >> check: aMethod forCritiquesDo: aCriticBlock [
-	((aMethod refersToLiteral: trueBinding) or: [ aMethod refersToLiteral: falseBinding ]) ifTrue: [ 
-		aCriticBlock cull: (self critiqueFor: aMethod) ]
+RBUsesTrueRule >> basicCheck: aMethod [
+	^ (aMethod refersToLiteral: trueBinding) or: [ aMethod refersToLiteral: falseBinding ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBUsesWorldGlobalRule.class.st
+++ b/src/GeneralRules/RBUsesWorldGlobalRule.class.st
@@ -16,14 +16,8 @@ RBUsesWorldGlobalRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBUsesWorldGlobalRule >> check: aNode forCritiquesDo: aCriticBlock [
-
-	(aNode isVariable 
-		and: [ aNode isGlobal 
-		and: [ #(#World #ActiveWorld) includes: aNode name ] ])
-		ifFalse: [ ^ self ].
-
-	aCriticBlock cull: (self critiqueFor: aNode)
+RBUsesWorldGlobalRule >> basicCheck: aNode [
+	^ aNode isVariable and: [ aNode isGlobal and: [ #(#World #ActiveWorld) includes: aNode name ] ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBUtilityMethodsRule.class.st
+++ b/src/GeneralRules/RBUtilityMethodsRule.class.st
@@ -20,19 +20,11 @@ RBUtilityMethodsRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBUtilityMethodsRule >> check: aMethod forCritiquesDo: aCriticBlock [
-
-	((aMethod methodClass isMeta or: 
-	 [ aMethod selector numArgs == 0 or: 
-	 [ self utilityProtocols includes: aMethod protocol ] ]) not and: [
-		(self 
-			subclassOf: aMethod methodClass
-			overrides: aMethod selector) not and: [
-				aMethod superMessages isEmpty and: [ aMethod selfMessages isEmpty and: [ 
-					aMethod methodClass allInstVarNames,
-				   aMethod methodClass allClassVarNames asArray,
-				 	#('self') noneSatisfy: [ :each | aMethod ast references: each ] ] ] ] ])
-	ifTrue: [ aCriticBlock cull: (self critiqueFor: aMethod) ]
+RBUtilityMethodsRule >> basicCheck: aMethod [
+	^ (aMethod methodClass isMeta or: [ aMethod selector numArgs == 0 or: [ self utilityProtocols includes: aMethod protocol ] ]) not
+		and: [ (self subclassOf: aMethod methodClass overrides: aMethod selector) not
+				and: [ aMethod superMessages isEmpty
+						and: [ aMethod selfMessages isEmpty and: [ aMethod methodClass allInstVarNames , aMethod methodClass allClassVarNames asArray , #('self') noneSatisfy: [ :each | aMethod ast references: each ] ] ] ] ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBVariableReferencedOnceRule.class.st
+++ b/src/GeneralRules/RBVariableReferencedOnceRule.class.st
@@ -20,27 +20,22 @@ RBVariableReferencedOnceRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBVariableReferencedOnceRule >> check: aClass forCritiquesDo: aCriticBlock [
-	(aClass instVarNames anySatisfy:
-		[ :each | 
-		| defClass selector |
-		(aClass withAllSubclasses 
-			inject: 0
-			into: 
-				[ :sum :class | 
-				| sels |
-				sels := class whichSelectorsAccess: each.
-				sels size == 1 ifTrue: 
-					[ selector := sels asArray first.
-					defClass := class ].
-				sum + sels size ]) == 1 and: 
-			[ | tree |
-			tree := defClass parseTreeFor: selector.
-			tree notNil and: 
-				[ (RBReadBeforeWrittenTester 
-					isVariable: each
-					writtenBeforeReadIn: tree) ] ] ]) ifTrue: [ 
-		aCriticBlock cull: (self critiqueFor: aClass) ]
+RBVariableReferencedOnceRule >> basicCheck: aClass [
+	^ aClass instVarNames
+		anySatisfy: [ :each | 
+			| defClass selector |
+			(aClass withAllSubclasses
+				inject: 0
+				into: [ :sum :class | 
+					| sels |
+					sels := class whichSelectorsAccess: each.
+					sels size == 1
+						ifTrue: [ selector := sels asArray first.
+							defClass := class ].
+					sum + sels size ]) == 1
+				and: [ | tree |
+					tree := defClass parseTreeFor: selector.
+					tree notNil and: [ RBReadBeforeWrittenTester isVariable: each writtenBeforeReadIn: tree ] ] ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBYourselfNotUsedRule.class.st
+++ b/src/GeneralRules/RBYourselfNotUsedRule.class.st
@@ -15,12 +15,10 @@ RBYourselfNotUsedRule class >> uniqueIdentifierName [
 ]
 
 { #category : #enumerating }
-RBYourselfNotUsedRule >> check: aNode forCritiquesDo: aCriticBlock [
-	aNode isMessage ifFalse: [ ^ self ].
-	aNode selector = #yourself ifFalse: [ ^ self ].
-	aNode isUsed ifFalse: [ 
-		aCriticBlock cull: (
-			self critiqueFor: aNode) ]
+RBYourselfNotUsedRule >> basicCheck: aNode [
+	aNode isMessage ifFalse: [ ^ false ].
+	aNode selector = #yourself ifFalse: [ ^ false ].
+	^ aNode isUsed not
 ]
 
 { #category : #accessing }

--- a/src/Kernel-Rules/SendsDeprecatedMethodToGlobalRule.class.st
+++ b/src/Kernel-Rules/SendsDeprecatedMethodToGlobalRule.class.st
@@ -15,19 +15,16 @@ SendsDeprecatedMethodToGlobalRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-SendsDeprecatedMethodToGlobalRule >> check: aNode forCritiquesDo: aCriticBlock [
+SendsDeprecatedMethodToGlobalRule >> basicCheck: aNode [
 	| messageReceiver |
+	aNode isMessage ifFalse: [ ^ false ].
 
-	aNode isMessage ifFalse: [ ^ self ].
-	
 	messageReceiver := aNode receiver.
-	messageReceiver isVariable ifFalse: [ ^ self ].
-	messageReceiver isGlobal ifFalse: [ ^ self ].
-	(self
-		check: aNode selector
-		forDeprecationIn: messageReceiver name) ifFalse: [ ^ self ].
-		
-	aCriticBlock cull: (self critiqueFor: aNode)
+	messageReceiver isVariable ifFalse: [ ^ false ].
+	messageReceiver isGlobal ifFalse: [ ^ false ].
+	(self check: aNode selector forDeprecationIn: messageReceiver name) ifFalse: [ ^ false ].
+
+	^ true
 ]
 
 { #category : #running }

--- a/src/Renraku/ReProperMethodProtocolNameRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameRule.class.st
@@ -32,10 +32,8 @@ ReProperMethodProtocolNameRule >> badMethodProtocolNames [
 ]
 
 { #category : #running }
-ReProperMethodProtocolNameRule >> check: aMethod forCritiquesDo: aCritiqueBlock [
-
-	(self badMethodProtocolNames includes: aMethod category)
-   		ifTrue: [ aCritiqueBlock cull: (self critiqueFor: aMethod) ]
+ReProperMethodProtocolNameRule >> basicCheck: aMethod [
+	^ self badMethodProtocolNames includes: aMethod category
 ]
 
 { #category : #'private - accessing' }

--- a/src/Renraku/ReReturnMethodRule.class.st
+++ b/src/Renraku/ReReturnMethodRule.class.st
@@ -14,14 +14,10 @@ ReReturnMethodRule class >> checksMethod [
 ]
 
 { #category : #running }
-ReReturnMethodRule >> check: aMethod forCritiquesDo: aCriticBlock [
-	(aMethod overriddenMethods anySatisfy: [ :method |
-		method hasPragmaNamed: #shouldReturn. ])
-			ifFalse: [ ^ self ].
-	
-	aMethod ast lastIsReturn ifTrue: [ ^ self ].
-	
-	aCriticBlock cull: (self critiqueFor: aMethod)
+ReReturnMethodRule >> basicCheck: aMethod [
+	(aMethod overriddenMethods anySatisfy: [ :method | method hasPragmaNamed: #shouldReturn ]) ifFalse: [ ^ false ].
+
+	^ aMethod ast lastIsReturn not
 ]
 
 { #category : #accessing }

--- a/src/SUnit-Rules/ShouldSendSuperSetUpAsFirstMessage.class.st
+++ b/src/SUnit-Rules/ShouldSendSuperSetUpAsFirstMessage.class.st
@@ -34,11 +34,8 @@ ShouldSendSuperSetUpAsFirstMessage class >> superSetUpNotCalledFirstIn: aCompile
 ]
 
 { #category : #running }
-ShouldSendSuperSetUpAsFirstMessage >> check: aMethod forCritiquesDo: aCritiqueBlock [
-
-	((aMethod methodClass inheritsFrom: TestCase)
-		and: [ aMethod selector = #setUp and: [ self class superSetUpNotCalledFirstIn: aMethod ]])
-			ifTrue: [ aCritiqueBlock cull: (self critiqueFor: aMethod) ]
+ShouldSendSuperSetUpAsFirstMessage >> basicCheck: aMethod [
+	^ (aMethod methodClass inheritsFrom: TestCase) and: [ aMethod selector = #setUp and: [ self class superSetUpNotCalledFirstIn: aMethod ] ]
 ]
 
 { #category : #accessing }

--- a/src/SUnit-Rules/ShouldSendSuperTearDownAsLastMessage.class.st
+++ b/src/SUnit-Rules/ShouldSendSuperTearDownAsLastMessage.class.st
@@ -34,11 +34,8 @@ ShouldSendSuperTearDownAsLastMessage class >> superTearDownNotCalledLastIn: aCom
 ]
 
 { #category : #running }
-ShouldSendSuperTearDownAsLastMessage >> check: aMethod forCritiquesDo: aCritiqueBlock [
-
-	((aMethod methodClass inheritsFrom: TestCase)
-		and: [ aMethod selector = #tearDown and: [ self class superTearDownNotCalledLastIn: aMethod ]])
-			ifTrue: [ aCritiqueBlock cull: (self critiqueFor: aMethod) ]
+ShouldSendSuperTearDownAsLastMessage >> basicCheck: aMethod [
+	^ (aMethod methodClass inheritsFrom: TestCase) and: [ aMethod selector = #tearDown and: [ self class superTearDownNotCalledLastIn: aMethod ] ]
 ]
 
 { #category : #accessing }

--- a/src/System-Settings-Rules/SettingDontTranslateDescriptionRule.class.st
+++ b/src/System-Settings-Rules/SettingDontTranslateDescriptionRule.class.st
@@ -8,11 +8,8 @@ Class {
 }
 
 { #category : #running }
-SettingDontTranslateDescriptionRule >> check: aNode forCritiquesDo: aBlock [
-
-	aNode methodNode ifNotNil: [ :methNode |
-		(self checkPreconditionOn: methNode) ifTrue: [
-			super check: aNode forCritiquesDo: aBlock ] ]
+SettingDontTranslateDescriptionRule >> basicCheck: aNode [
+	^ aNode methodNode ifNil: [ false ] ifNotNil: [ :methNode | self checkPreconditionOn: methNode ]
 ]
 
 { #category : #helpers }


### PR DESCRIPTION
Override #basicCheck: instead of #check:forCritiquesDo: when possible to avoid duplication.

Fixes #3739