### PR TITLE
3572-SystemNavigationallReferencesToPool-should-be-implemented-on-SharedPool

### DIFF
--- a/src/Deprecated80/SystemNavigation.extension.st
+++ b/src/Deprecated80/SystemNavigation.extension.st
@@ -24,6 +24,13 @@ SystemNavigation >> allLocalCallsOn: aSymbol ofClass: aClass [
 ]
 
 { #category : #'*Deprecated80' }
+SystemNavigation >> allReferencesToPool: aPool [
+	"Answer all the references to variable aPool"
+	self deprecated: 'use #usingMethods on the Pool'.
+	^aPool usingMethods 
+]
+
+{ #category : #'*Deprecated80' }
 SystemNavigation >> allUnreferencedClassVariablesOf: aClass [
 	"Answer a list of the receiver's unreferenced class vars, including those defined in superclasses"
 	self deprecated: 'just all allUnreferencedClassVariables on the class'.

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -192,23 +192,6 @@ SystemNavigation >> allReferencesTo: aLiteral do: aBlock [
 			ifTrue: [ class withThorougMethodsReferTo: aLiteral do: aBlock ] ]
 ]
 
-{ #category : #query }
-SystemNavigation >> allReferencesToPool: aPool [
-	"Answer all the references to variable aPool"
-
-	| list |
-	list := OrderedCollection new.
-	self
-		allClassesDo: [ :cls | 
-			cls
-				selectorsAndMethodsDo: [ :sel :meth | 
-					meth literals
-						detect: [ :lit | (lit isVariableBinding and: [ lit key notNil ]) 
-													and: [ aPool includesKey: lit key ] ]
-						ifFound: [ list add: (cls>>sel) methodReference ] ] ].
-	^ list
-]
-
 { #category : #'message sends' }
 SystemNavigation >> allSendersOf: selector [ 
 	^self allReferencesTo: selector


### PR DESCRIPTION
SharedPool class should be the place to implement allReferencesToPool:
-> just call #usingMethods
-> deprecate the method on SystemNavigation