### PR TITLE
3761-CompiledCodeargumentNames-should-be-reviewed

### DIFF
--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -90,10 +90,7 @@ CompiledCode >> allLiterals [
 
 { #category : #'source code management' }
 CompiledCode >> argumentNames [
-	^self 
-		propertyAt: #argumentNames 
-		ifAbsent: [ self ast argumentNames ]
-
+	^ self ast argumentNames
 ]
 
 { #category : #converting }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -324,6 +324,11 @@ CompiledMethod class >> toReturnSelfTrailerBytes: trailer [
 	^self newBytes: 3 trailerBytes: trailer nArgs: 0 nTemps: 0 nStack: 0 nLits: 2 primitive: 256
 ]
 
+{ #category : #'source code management' }
+CompiledMethod >> argumentNames [
+	^ self propertyAt: #argumentNames ifAbsent: [ super argumentNames ]
+]
+
 { #category : #'accessing-backward compatible' }
 CompiledMethod >> category [
 	"Please favor protocol instead of category. We want to have method protocol and class package and tag = a category"

--- a/src/OpalCompiler-Core/CompiledCode.extension.st
+++ b/src/OpalCompiler-Core/CompiledCode.extension.st
@@ -1,5 +1,10 @@
 Extension { #name : #CompiledCode }
 
+{ #category : #'*OpalCompiler-Core' }
+CompiledCode >> ast [
+	^ self subclassResponsibility
+]
+
 { #category : #'*opalcompiler-core' }
 CompiledCode >> compiler [
 	^self methodClass 


### PR DESCRIPTION
Make #argumentNames work for CompiledBlock.

Fixes #3761