### PR TITLE
More explicit Quit confirmation (Fixes #3773)

### DIFF
--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -199,9 +199,15 @@ WorldState class >> pharoItemsOn: aBuilder [
 
 { #category : #'world menu items' }
 WorldState class >> quitSession [
-	| save |
-	save := UIManager default confirm: 'Save changes before quitting?' translated orCancel: [ ^ self ].
-	save 
+	| response |
+	response := UIManager default 
+						confirm: 'Save changes before quitting?' 
+						trueChoice: 'Save' 
+						falseChoice: 'Discard' 
+						cancelChoice: 'Cancel'
+						default: nil. 
+	response ifNil: [ ^self ].
+	response 
 		ifTrue: [Smalltalk snapshot: true andQuit: true] 
 		ifFalse: [Smalltalk snapshot: false andQuit: true]
  


### PR DESCRIPTION
When "Pharo > Quit" is selected (on purpose or accidently)
the question "Save changes before quitting? YES/NO"
Its easy to accidentally invert the logic of YES/NO questions (if you've habits from other software with inverted logic). The consequence of pushing a button is implied from the question and not explicit on the button.

It is better for the button to be an explicit verb "SAVE/DISCARD"
Rule #1 ==> https://uxmovement.com/buttons/5-rules-for-choosing-the-right-words-on-button-labels/