### PR TITLE
3775-checkForSlips-should-not-use-methodReference

### DIFF
--- a/src/System-Changes/ChangeSet.class.st
+++ b/src/System-Changes/ChangeSet.class.st
@@ -688,7 +688,7 @@ ChangeSet >> checkForSlips [
 					[method := aClass compiledMethodAt: mAssoc key ifAbsent: [nil].
 					method ifNotNil:
 						[(self hasReportableSlip: method)
-							ifTrue: [ slips add: (aClass >> mAssoc key) methodReference ]]]]].
+							ifTrue: [ slips add: (aClass >> mAssoc key) ]]]]].
 	^ slips
 ]
 


### PR DESCRIPTION
Queries should just return methods