### PR TITLE
Cleanup HTTPProgress example

### DIFF
--- a/src/Network-Kernel/HTTPProgress.class.st
+++ b/src/Network-Kernel/HTTPProgress.class.st
@@ -25,7 +25,6 @@ Class {
 
 { #category : #examples }
 HTTPProgress class >> example [
-	"self example"
 	
  	UIManager default informUserDuring: [ :bar |
 		bar label: 'Transfer Demo...'.

--- a/src/Network-Kernel/ManifestNetworkKernel.class.st
+++ b/src/Network-Kernel/ManifestNetworkKernel.class.st
@@ -1,0 +1,13 @@
+"
+I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestNetworkKernel,
+	#superclass : #PackageManifest,
+	#category : #'Network-Kernel-Manifest'
+}
+
+{ #category : #'code-critics' }
+ManifestNetworkKernel class >> ruleRBRefersToClassRuleV1FalsePositive [
+	^ #(#(#(#RGMethodDefinition #(#'HTTPProgress class' #example #true)) #'2019-07-05T10:28:44.466329+02:00') )
+]


### PR DESCRIPTION
- remove the executable comment as it is a clickable example already
- ban the lint rule - it is OK to refer to the class name in this method

Fix #3779