### PR TITLE
3734-add-usingMethod-for-Behaviour

### DIFF
--- a/src/Kernel-Tests-Extended/SharedPoolTest.extension.st
+++ b/src/Kernel-Tests-Extended/SharedPoolTest.extension.st
@@ -3,7 +3,28 @@ Extension { #name : #SharedPoolTest }
 { #category : #'*Kernel-Tests-Extended' }
 SharedPoolTest >> testPoolUsers [
 	| result |
-	result := ChronologyConstants poolUsers.
-	self assert: result asSet equals: {Date. DateAndTime. Duration. Month. Time. TimeZone. Week. LocalTimeZone . AbstractTimeZone } asSet.
+	result := ChronologyConstants methodsAccessingPoolVariables.
+	self assert: (result includes: (Duration>>#asNanoSeconds) methodReference)
+		 
+]
+
+{ #category : #'*Kernel-Tests-Extended' }
+SharedPoolTest >> testmethodsAccessingPoolVariables [
+	| result |
+	result := ChronologyConstants methodsAccessingPoolVariables.
+	"we find accesses to the vars of the shared pool"
+	self assert: (result includes: (Duration>>#asNanoSeconds) methodReference).
+	"but we do not include references to the pool itself"
+	self deny: (result includes: (ClassTest>>#testSharedPoolOfVarNamed) methodReference)
+]
+
+{ #category : #'*Kernel-Tests-Extended' }
+SharedPoolTest >> testusingMethods [
+	| result |
+	result := ChronologyConstants usingMethods.
+	"we find accesses to the vars of the shared pool"
+	self assert: (result includes: (Duration>>#asNanoSeconds) methodReference).
+	"and we find references to the pool itself"
+	self assert: (result includes: (ClassTest>>#testSharedPoolOfVarNamed) methodReference)
 		 
 ]

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1832,6 +1832,13 @@ Behavior >> unreferencedInstanceVariables [
 ]
 
 { #category : #queries }
+Behavior >> usingMethods [
+	"all methods that reference me"
+	self isAnonymous ifTrue: [ ^#() ].
+	^self binding usingMethods
+]
+
+{ #category : #queries }
 Behavior >> whichClassDefinesClassVar: aString [ 
 	Symbol hasInterned: aString ifTrue: [ :aSymbol |
 		^self whichSuperclassSatisfies: 

--- a/src/Kernel/SharedPool.class.st
+++ b/src/Kernel/SharedPool.class.st
@@ -71,21 +71,21 @@ SharedPool class >> localBindingOf: varName [
 	^nil
 ]
 
-{ #category : #pools }
+{ #category : #queries }
 SharedPool class >> methodsAccessingPoolVariables [
 	"Answer all methods that use one of the variables defined by the shared pool"
 	^ self classVariables flatCollect: [ :variable | variable usingMethods ]
 ]
 
-{ #category : #pools }
+{ #category : #queries }
 SharedPool class >> poolUsers [
 	"Answer all classes that uses the shared pool"
 
 	^self environment allClasses select:  [:class | class includesSharedPoolNamed: self name]
 ]
 
-{ #category : #pools }
+{ #category : #queries }
 SharedPool class >> usingMethods [
-	"Answer all methods that referene the Pool or of the variables defined by the shared pool"
+	"Answer all methods that reference the Pool the variables defined by the shared pool"
 	^super usingMethods, self methodsAccessingPoolVariables
 ]

--- a/src/Kernel/SharedPool.class.st
+++ b/src/Kernel/SharedPool.class.st
@@ -72,6 +72,12 @@ SharedPool class >> localBindingOf: varName [
 ]
 
 { #category : #pools }
+SharedPool class >> methodsAccessingPoolVariables [
+	"Answer all methods that use one of the variables defined by the shared pool"
+	^ self classVariables flatCollect: [ :variable | variable usingMethods ]
+]
+
+{ #category : #pools }
 SharedPool class >> poolUsers [
 	"Answer all classes that uses the shared pool"
 
@@ -80,7 +86,6 @@ SharedPool class >> poolUsers [
 
 { #category : #pools }
 SharedPool class >> usingMethods [
-	"Answer all methods that use one of the variables defined by the shared pool"
-
-	^self classVariables flatCollect: [ :variable | variable usingMethods ]
+	"Answer all methods that referene the Pool or of the variables defined by the shared pool"
+	^super usingMethods, self methodsAccessingPoolVariables
 ]

--- a/src/System-Support/Behavior.extension.st
+++ b/src/System-Support/Behavior.extension.st
@@ -2,9 +2,9 @@ Extension { #name : #Behavior }
 
 { #category : #'*System-Support' }
 Behavior >> allCallsOn [
-	"Answer a SortedCollection of all the methods that refer to me by name or as part of an association in a global dict."
+	"Answer all the methods that refer to me by name or as part of an association in a global dict."
 	self isAnonymous ifTrue: [ ^#() ].
-	^ (self allCallsOnIn: self systemNavigation)
+	^self usingMethods, self name asSymbol senders
 ]
 
 { #category : #'*System-Support' }


### PR DESCRIPTION
- add #usingMethods in Behavior 
- rewrite allCallsOn to use it
- improve #usingMethods of SharedPoll to return both the references to the Pool as well as all the vars
-let later factored out as  #methodsAccessingPoolVariables