### PR TITLE
RBParseTreeTests should be abstract test class

### DIFF
--- a/src/AST-Core-Tests/RBParseTreeTest.class.st
+++ b/src/AST-Core-Tests/RBParseTreeTest.class.st
@@ -4,6 +4,12 @@ Class {
 	#category : #'AST-Core-Tests'
 }
 
+{ #category : #testing }
+RBParseTreeTest class >> isAbstract [ 
+
+	^self name = #RBParseTreeTest
+]
+
 { #category : #helpers }
 RBParseTreeTest >> parseExpression: aString [ 
 


### PR DESCRIPTION
 implement #isAbstract to mark it as abstract

Fix #3787