### PR TITLE
Improve AST-Core-Tests

### DIFF
--- a/src/AST-Core-Tests/ASTEvaluationTest.class.st
+++ b/src/AST-Core-Tests/ASTEvaluationTest.class.st
@@ -4,7 +4,7 @@ I am testing AST evaluation
 Class {
 	#name : #ASTEvaluationTest,
 	#superclass : #TestCase,
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Nodes'
 }
 
 { #category : #tests }

--- a/src/AST-Core-Tests/ManifestASTCoreTests.class.st
+++ b/src/AST-Core-Tests/ManifestASTCoreTests.class.st
@@ -1,0 +1,13 @@
+"
+I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestASTCoreTests,
+	#superclass : #PackageManifest,
+	#category : #'AST-Core-Tests-Manifest'
+}
+
+{ #category : #'code-critics' }
+ManifestASTCoreTests class >> ruleGRTemporaryNeitherReadNorWrittenRuleV1FalsePositive [
+	^ #(#(#(#RGMethodDefinition #(#ASTEvaluationTest #testEvaluateForContext #false)) #'2019-07-05T11:16:20.959329+02:00') )
+]

--- a/src/AST-Core-Tests/NumberParserTest.class.st
+++ b/src/AST-Core-Tests/NumberParserTest.class.st
@@ -6,7 +6,7 @@ It duplicates NumberParsingTest, with few more tests.
 Class {
 	#name : #NumberParserTest,
 	#superclass : #ClassTestCase,
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Parser'
 }
 
 { #category : #utilities }

--- a/src/AST-Core-Tests/NumberParsingTest.class.st
+++ b/src/AST-Core-Tests/NumberParsingTest.class.st
@@ -6,7 +6,7 @@ Note: ScaledDecimalTest contains related tests for parsing ScaledDecimal.
 Class {
 	#name : #NumberParsingTest,
 	#superclass : #TestCase,
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Parser'
 }
 
 { #category : #'tests - Float' }

--- a/src/AST-Core-Tests/RBCommentNodeVisitorTest.class.st
+++ b/src/AST-Core-Tests/RBCommentNodeVisitorTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for RBCommentNodeVisitor
 Class {
 	#name : #RBCommentNodeVisitorTest,
 	#superclass : #RBParseTreeTest,
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Nodes'
 }
 
 { #category : #tests }

--- a/src/AST-Core-Tests/RBCommentTest.class.st
+++ b/src/AST-Core-Tests/RBCommentTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for RBComment
 Class {
 	#name : #RBCommentTest,
 	#superclass : #TestCase,
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Nodes'
 }
 
 { #category : #tests }

--- a/src/AST-Core-Tests/RBDumpNodeTest.class.st
+++ b/src/AST-Core-Tests/RBDumpNodeTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for the RBDumpVisitor visit, called by the #dump method on RBProgram
 Class {
 	#name : #RBDumpNodeTest,
 	#superclass : #RBParseTreeTest,
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Nodes'
 }
 
 { #category : #tests }

--- a/src/AST-Core-Tests/RBFormatterTest.class.st
+++ b/src/AST-Core-Tests/RBFormatterTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for BISimpleFormatter
 Class {
 	#name : #RBFormatterTest,
 	#superclass : #RBParseTreeTest,
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Formatter'
 }
 
 { #category : #private }

--- a/src/AST-Core-Tests/RBMessageNodeTest.class.st
+++ b/src/AST-Core-Tests/RBMessageNodeTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #RBMessageNodeTest,
 	#superclass : #RBParseTreeTest,
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Nodes'
 }
 
 { #category : #testing }

--- a/src/AST-Core-Tests/RBMethodNodeTest.class.st
+++ b/src/AST-Core-Tests/RBMethodNodeTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for RBMethodNode
 Class {
 	#name : #RBMethodNodeTest,
 	#superclass : #TestCase,
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Nodes'
 }
 
 { #category : #helpers }

--- a/src/AST-Core-Tests/RBNullFormatterTest.class.st
+++ b/src/AST-Core-Tests/RBNullFormatterTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for RBNullFormatter
 Class {
 	#name : #RBNullFormatterTest,
 	#superclass : #TestCase,
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Formatter'
 }
 
 { #category : #helpers }

--- a/src/AST-Core-Tests/RBParseTreeRewriterTest.class.st
+++ b/src/AST-Core-Tests/RBParseTreeRewriterTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'rewriter'
 	],
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Matching'
 }
 
 { #category : #utilities }

--- a/src/AST-Core-Tests/RBParseTreeSearcherTest.class.st
+++ b/src/AST-Core-Tests/RBParseTreeSearcherTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'searcher'
 	],
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Matching'
 }
 
 { #category : #helpers }

--- a/src/AST-Core-Tests/RBParseTreeTest.class.st
+++ b/src/AST-Core-Tests/RBParseTreeTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #RBParseTreeTest,
 	#superclass : #TestCase,
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Parser'
 }
 
 { #category : #helpers }

--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for RBParser
 Class {
 	#name : #RBParserTest,
 	#superclass : #RBParseTreeTest,
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Parser'
 }
 
 { #category : #accessing }

--- a/src/AST-Core-Tests/RBPatternParserTest.class.st
+++ b/src/AST-Core-Tests/RBPatternParserTest.class.st
@@ -6,7 +6,7 @@ RBPatternParser needs some extra tests not covered by RBPatternTest for its exte
 Class {
 	#name : #RBPatternParserTest,
 	#superclass : #RBParserTest,
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Parser'
 }
 
 { #category : #accessing }

--- a/src/AST-Core-Tests/RBProgramNodeTest.class.st
+++ b/src/AST-Core-Tests/RBProgramNodeTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'node'
 	],
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Nodes'
 }
 
 { #category : #accessing }

--- a/src/AST-Core-Tests/RBReadBeforeWrittenTesterTest.class.st
+++ b/src/AST-Core-Tests/RBReadBeforeWrittenTesterTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for RBReadBeforeWrittenTester
 Class {
 	#name : #RBReadBeforeWrittenTesterTest,
 	#superclass : #RBParseTreeTest,
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Visitors'
 }
 
 { #category : #tests }

--- a/src/AST-Core-Tests/RBScannerTest.class.st
+++ b/src/AST-Core-Tests/RBScannerTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for RBScanner
 Class {
 	#name : #RBScannerTest,
 	#superclass : #TestCase,
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Parser'
 }
 
 { #category : #initialize }

--- a/src/AST-Core-Tests/RBVariableNodeTest.class.st
+++ b/src/AST-Core-Tests/RBVariableNodeTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for RBVariableNode
 Class {
 	#name : #RBVariableNodeTest,
 	#superclass : #RBParseTreeTest,
-	#category : #'AST-Core-Tests'
+	#category : #'AST-Core-Tests-Nodes'
 }
 
 { #category : #tests }


### PR DESCRIPTION
- tag the test classes in "AST-Core-Tests" similar to the tags of the classes they test in "AST-Core" package
- ban rule for testEvaluateForContext because the temp var is fine and accessed via reflection ("thisContext method variableNodes first")

Fix #3792