### PR TITLE
Lint review Tests in UnifiedFFI-Tests

### DIFF
--- a/src/UnifiedFFI-Tests/FFICallbackParametersTests.class.st
+++ b/src/UnifiedFFI-Tests/FFICallbackParametersTests.class.st
@@ -50,7 +50,7 @@ FFICallbackParametersTests >> testCharacterParameters [
 			$z asInteger
 		].
 
-	self assert: (self callCallback: callback withArgs: params) equals: $z asInteger.
+	self assert: (self callCallback: callback withArgs: params) equals: $z asInteger
 ]
 
 { #category : #running }
@@ -68,7 +68,7 @@ FFICallbackParametersTests >> testFloatParameters [
 			7.0
 		].
 
-	self assert: (self callCallback: callback withArgs: {1.0. 2.0. 3.0. 4.0. 5.0. 6.0}) equals: 7.0.
+	self assert: (self callCallback: callback withArgs: {1.0. 2.0. 3.0. 4.0. 5.0. 6.0}) equals: 7.0
 ]
 
 { #category : #running }
@@ -101,7 +101,7 @@ FFICallbackParametersTests >> testIdentityStruct [
 		autoRelease;
 		yourself.
 
-	self assert: (self callCallback: callback withArgs: { param }) equals: param.
+	self assert: (self callCallback: callback withArgs: { param }) equals: param
 ]
 
 { #category : #running }
@@ -119,7 +119,7 @@ FFICallbackParametersTests >> testIntegerParameters [
 			7
 		].
 
-	self assert: (self callCallback: callback withArgs: #(1 2 3 4 5 6)) equals: 7.
+	self assert: (self callCallback: callback withArgs: #(1 2 3 4 5 6)) equals: 7
 
 
 ]
@@ -141,7 +141,7 @@ FFICallbackParametersTests >> testIntegerPointerParameters [
 			self assert: f value equals: 6.
 		].
 
-	self callCallback: callback withArgs: params.
+	self callCallback: callback withArgs: params
 ]
 
 { #category : #running }
@@ -159,7 +159,7 @@ FFICallbackParametersTests >> testMixingParameters [
 			self assert: g value equals: $g.
 		].
 
-	self callCallback: callback withArgs: {1. 2.0. $c. 4. 5.0. 6. $g}.
+	self callCallback: callback withArgs: {1. 2.0. $c. 4. 5.0. 6. $g}
 ]
 
 { #category : #running }
@@ -181,7 +181,7 @@ FFICallbackParametersTests >> testPassing2DoubleStructureInTheStack [
 		autoRelease;
 		yourself.
 
-	self assert: (self callCallback: callback withArgs: { param }) equals: 99.
+	self assert: (self callCallback: callback withArgs: { param }) equals: 99
 ]
 
 { #category : #running }
@@ -203,7 +203,7 @@ FFICallbackParametersTests >> testPassing2Int64StructureInTheStack [
 		autoRelease;
 		yourself.
 
-	self assert: (self callCallback: callback withArgs: { param }) equals: 99.
+	self assert: (self callCallback: callback withArgs: { param }) equals: 99
 ]
 
 { #category : #running }
@@ -234,7 +234,7 @@ FFICallbackParametersTests >> testPassing4DoubleStructureInTheStack [
 		autoRelease;
 		yourself.
 
-	self assert: (self callCallback: callback withArgs: { param }) equals: 99.
+	self assert: (self callCallback: callback withArgs: { param }) equals: 99
 ]
 
 { #category : #running }
@@ -260,7 +260,7 @@ FFICallbackParametersTests >> testPassing4Int64StructureInTheStack [
 		autoRelease;
 		yourself.
 
-	self assert: (self callCallback: callback withArgs: { param }) equals: 99.
+	self assert: (self callCallback: callback withArgs: { param }) equals: 99
 ]
 
 { #category : #running }
@@ -286,7 +286,7 @@ FFICallbackParametersTests >> testPassing4IntStructureInTheStack [
 		autoRelease;
 		yourself.
 
-	self assert: (self callCallback: callback withArgs: { param }) equals: 99.
+	self assert: (self callCallback: callback withArgs: { param }) equals: 99
 ]
 
 { #category : #running }
@@ -317,5 +317,5 @@ FFICallbackParametersTests >> testPassingStructureInTheStack [
 		autoRelease;
 		yourself.
 		
-	self assert: (self callCallback: callback withArgs: { param }) equals: 77.
+	self assert: (self callCallback: callback withArgs: { param }) equals: 77
 ]

--- a/src/UnifiedFFI-Tests/FFICallbackTests.class.st
+++ b/src/UnifiedFFI-Tests/FFICallbackTests.class.st
@@ -51,7 +51,7 @@ FFICallbackTests >> testCqsort [
 		results := values asArray ]
 	ensure: [ values free ].
 	
-	self assert: results equals: expected.
+	self assert: results equals: expected
 ]
 
 { #category : #tests }
@@ -81,7 +81,7 @@ FFICallbackTests >> testCqsortWithByteArray [
 		results := values asArray ]
 	ensure: [ values free ].
 	
-	self assert: results equals: expected.
+	self assert: results equals: expected
 ]
 
 { #category : #tests }
@@ -103,7 +103,7 @@ FFICallbackTests >> testEnumerationReturnValue [
 				block: [ CCC value ].
 	"Dummy value of nil is possible since signature has no arguments"
 	returnValue := cb backendCallback valueWithContext: self sp: nil. 
-	self assert: returnValue equals: CCC value.
+	self assert: returnValue equals: CCC value
 ]
 
 { #category : #support }

--- a/src/UnifiedFFI-Tests/FFICalloutAPITests.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutAPITests.class.st
@@ -127,7 +127,7 @@ FFICalloutAPITests >> testByteArrayToExternalAddress [
 		toExternalAddress: (dest := ExternalAddress allocate: 12) autoRelease 
 		size: 12.
 		
-	self assert: (dest copyFrom: 1 to: 12) asString = 'Hello, World'.
+	self assert: (dest copyFrom: 1 to: 12) asString equals: 'Hello, World'.
 	
 ]
 
@@ -176,7 +176,7 @@ FFICalloutAPITests >> testCallWithObjectCreation [
 	[
 		self shouldnt: [ object := FFICalloutObjectForTest primCreate: 1 ] raise: Error.
 		self assert: object notNil.
-		self assert: object class = FFICalloutObjectForTest.
+		self assert: object class equals: FFICalloutObjectForTest.
 		self assert: object handle notNil.
 		self deny: object handle isNull ]
 	ensure: [ 
@@ -201,7 +201,7 @@ FFICalloutAPITests >> testCallWithObjectParameter [
 	self 
 		shouldnt: [ FFICalloutObjectForTest primObject: object strcpy: text ] 
 		raise: Error.
-	self assert: object handle asString = (text copyWith: (Character value: 0))
+	self assert: object handle asString equals: (text copyWith: (Character value: 0))
 ]
 
 { #category : #'tests object' }
@@ -219,7 +219,7 @@ FFICalloutAPITests >> testCallWithSelfParameter [
 		shouldnt: [ object strcpy: 'Hello, World' ] 
 		raise: Error.
 	"Since is a strcpy it will answer a byte array terminated in zero"
-	self assert: object handle asString = ('Hello, World' copyWith: (Character value: 0))
+	self assert: object handle asString equals: ('Hello, World' copyWith: (Character value: 0))
 ]
 
 { #category : #'tests atomic' }
@@ -237,7 +237,7 @@ FFICalloutAPITests >> testCharCall [
 	self assert: result equals: $a.
 
 	result := self ffiToLower: true.
-	self assert: result equals: (Character value: 1).
+	self assert: result equals: (Character value: 1)
 
 ]
 
@@ -247,7 +247,8 @@ FFICalloutAPITests >> testCharPointer [
 	result := self 
 		primStr: ('Hello, ' asByteArray copyWith: 0) 
 		cat: ('World' asByteArray copyWith: 0).
-	self assert: result = 'Hello, World'.
+				
+	self assert: result equals: 'Hello, World'.
 ]
 
 { #category : #'tests atomic' }
@@ -270,7 +271,7 @@ FFICalloutAPITests >> testDoubleCall [
 	self assert: result equals: 65.0.
 
 	result := self ffiDoubleAbs: true.
-	self assert: result equals: 1.0.
+	self assert: result equals: 1.0
 
 ]
 
@@ -294,7 +295,7 @@ FFICalloutAPITests >> testFloatCall [
 	self assert: result equals: 65.0.
 
 	result := self ffiFloatAbs: true.
-	self assert: result equals: 1.0.
+	self assert: result equals: 1.0
 
 	
 
@@ -335,7 +336,7 @@ FFICalloutAPITests >> testLongLongs [
 	self assert: result equals: long1.
 	
 	result := self ffiLongLongAbs: long2.
-	self assert: result equals: long2 abs.
+	self assert: result equals: long2 abs
 ]
 
 { #category : #'tests atomic' }
@@ -346,7 +347,7 @@ FFICalloutAPITests >> testPrintString [
 	buffer := ByteArray new: 12.
 	result := self ffiCopyString: 'Hello World!' to: buffer.
 	self assert: result equals: 'Hello World!'.
-	self assert: buffer asString equals: 'Hello World!'.	
+	self assert: buffer asString equals: 'Hello World!'
 ]
 
 { #category : #'tests pointer' }
@@ -358,5 +359,6 @@ FFICalloutAPITests >> testVoidPointer [
 		to: (dest := ByteArray new: 12) 
 		size: 12.
 		
-	self assert: dest asString = 'Hello, World'
+	self deny: result isNull.	
+	self assert: dest asString equals: 'Hello, World'
 ]

--- a/src/UnifiedFFI-Tests/FFICalloutTests.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutTests.class.st
@@ -103,7 +103,7 @@ FFICalloutTests >> testParseOptions [
 	self assert: (generator optionAt: #optStringOrNil).
 	
 	generator parseOptions: #(- optEncoding).
-	self deny: (generator optionAt: #optEncoding).
+	self deny: (generator optionAt: #optEncoding)
 	
 	
 ]

--- a/src/UnifiedFFI-Tests/FFIConstantHandleTests.class.st
+++ b/src/UnifiedFFI-Tests/FFIConstantHandleTests.class.st
@@ -17,7 +17,7 @@ FFIConstantHandleTests >> getTime: t [
 
 { #category : #primitives }
 FFIConstantHandleTests >> getTimeReturnConstantHandle: t [
-     ^self ffiCall: #(FFIConstantHandle time(TIME_T_PTR t) ) module: LibC
+     ^self ffiCall: #(FFIConstantHandle time(TIME_T_PTR t)) module: LibC
 ]
 
 { #category : #tests }
@@ -26,7 +26,7 @@ FFIConstantHandleTests >> testCall [
 	
 	object := FFIConstantHandle new.
 	time := self getTime: object.
-	self assert: time equals: object handle.
+	self assert: time equals: object handle
 ]
 
 { #category : #tests }
@@ -37,5 +37,5 @@ FFIConstantHandleTests >> testReturn [
 	
 	object := TIME_T_PTR new value: 0.
 	time := self getTimeReturnConstantHandle: object.
-	self assert: time handle equals: object value.
+	self assert: time handle equals: object value
 ]

--- a/src/UnifiedFFI-Tests/FFIExternalArrayTests.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalArrayTests.class.st
@@ -62,7 +62,7 @@ FFIExternalArrayTests >> testExternalAtPutFloat [
 		array := FFIExternalArray externalNewType: 'float' size: 10.
 		1 to: 10 do: [ :index | array at: index put: random next ].
 		1 to: 10 do: [ :index | self assert: (array at: index) isFloat ] ]
-	ensure: [ array free ].
+	ensure: [ array free ]
 ]
 
 { #category : #tests }
@@ -73,5 +73,5 @@ FFIExternalArrayTests >> testResolveType [
 	self assert: (FFIExternalArray resolveType: 'void *') class equals: FFIVoid.
 	self assert: (FFIExternalArray resolveType: 'void *') pointerArity equals: 1.
 	self assert: (FFIExternalArray resolveType: FFIUInt16) class equals: FFIUInt16.
-	self assert: (FFIExternalArray resolveType: String) class equals: FFIExternalString.
+	self assert: (FFIExternalArray resolveType: String) class equals: FFIExternalString
 ]

--- a/src/UnifiedFFI-Tests/FFIExternalPackedStructureTests.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalPackedStructureTests.class.st
@@ -31,7 +31,7 @@ FFIExternalPackedStructureTests >> testExternallyAllocatedStructure [
 		self assert: struct2 double equals: 2.0.	
 		self flag: #pharoTodo. "This is not yet implemented"
 		"self assert: (struct2 int64 = 123456789101112)."	 ] 
-	ensure: [  struct free ]
+	ensure: [ struct free ]
 ]
 
 { #category : #tests }

--- a/src/UnifiedFFI-Tests/FFIExternalStructureFieldParserTests.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalStructureFieldParserTests.class.st
@@ -38,6 +38,6 @@ FFIExternalStructureFieldParserTests >> testParseFieldsStructure [
 	self assert: (fieldSpec typeFor: #double) class equals: FFIFloat64.
 	self assert: (fieldSpec typeFor: #int64) class equals: FFIInt64.
 	self assert: (fieldSpec typeFor: #ulong) class equals: FFIULong.
-	self assert: (fieldSpec typeFor: #size_t) class equals: FFISizeT.
+	self assert: (fieldSpec typeFor: #size_t) class equals: FFISizeT
 	
 ]

--- a/src/UnifiedFFI-Tests/FFIExternalStructureTests.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalStructureTests.class.st
@@ -24,7 +24,7 @@ FFIExternalStructureTests >> testExternalStructWithArray [
 		equals: {$A. $B. $C. $D. $E}.
 	self 
 		assert: structWithArrays byte10 asArray 
-		equals: #(1 2 3 4 5 6 7 8 9 0).
+		equals: #(1 2 3 4 5 6 7 8 9 0)
 ]
 
 { #category : #tests }
@@ -74,7 +74,7 @@ FFIExternalStructureTests >> testFlatStructureLayout [
 	self assert: flatLayout fields first registerClass equals: #float.
 	self assert: flatLayout fields second registerClass equals: #float.
 	self assert: flatLayout fields third registerClass equals: #float.
-	self assert: flatLayout fields fourth registerClass equals: #float.
+	self assert: flatLayout fields fourth registerClass equals: #float
 
 ]
 
@@ -88,7 +88,7 @@ FFIExternalStructureTests >> testFlatStructureLayout2 [
 	self assert: flatLayout fields first registerClass equals: #float.
 	self assert: flatLayout fields second registerClass equals: #integer.
 	self assert: flatLayout fields third registerClass equals: #float.
-	self assert: flatLayout fields fourth registerClass equals: #float.
+	self assert: flatLayout fields fourth registerClass equals: #float
 
 ]
 
@@ -102,7 +102,7 @@ FFIExternalStructureTests >> testFlatStructureLayoutSysVAMD64PostProcess [
 	self assert: flatLayout fields first registerClass equals: #float.
 	self assert: flatLayout fields second registerClass equals: #float.
 	self assert: flatLayout integerRegisterCount equals: 0.
-	self assert: flatLayout floatRegisterCount equals: 2.
+	self assert: flatLayout floatRegisterCount equals: 2
 ]
 
 { #category : #tests }
@@ -115,7 +115,7 @@ FFIExternalStructureTests >> testFlatStructureLayoutSysVAMD64PostProcess2 [
 	self assert: flatLayout fields first registerClass equals: #integer.
 	self assert: flatLayout fields second registerClass equals: #float.
 	self assert: flatLayout integerRegisterCount equals: 1.
-	self assert: flatLayout floatRegisterCount equals: 1.
+	self assert: flatLayout floatRegisterCount equals: 1
 	
 ]
 
@@ -137,7 +137,7 @@ FFIExternalStructureTests >> testNestedStructure [
 	self assert: s1 nested double equals: 42.0.	
 	self assert: s1 nested long equals: -123456.
 	self assert: s1 nested ulong equals: 123456.
-	self assert: s1 nested size_t equals: 23.
+	self assert: s1 nested size_t equals: 23
 
 ]
 
@@ -161,7 +161,7 @@ FFIExternalStructureTests >> testNestedStructureWithArray [
 		equals: {$A. $B. $C. $D. $E}.
 	self 
 		assert: nestedStruct nested byte10 asArray 
-		equals: #(1 2 3 4 5 6 7 8 9 0).
+		equals: #(1 2 3 4 5 6 7 8 9 0)
 ]
 
 { #category : #tests }
@@ -210,7 +210,7 @@ FFIExternalStructureTests >> testStructWithArray [
 		equals: {$A. $B. $C. $D. $E}.
 	self 
 		assert: structWithArrays byte10 asArray 
-		equals: #(1 2 3 4 5 6 7 8 9 0).
+		equals: #(1 2 3 4 5 6 7 8 9 0)
 	
 	
 
@@ -229,5 +229,5 @@ FFIExternalStructureTests >> testStructWithPointerAccess [
 	s2 long: 42.
 	s1 nestedPointer: s2.
 	self deny: s1 nestedPointer isNull.
-	self assert: s1 nestedPointer long equals: 42.
+	self assert: s1 nestedPointer long equals: 42
 ]

--- a/src/UnifiedFFI-Tests/FFIExternalValueHolderTests.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalValueHolderTests.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #primitives }
 FFIExternalValueHolderTests >> getTime: t [
-     ^self ffiCall: #(long time(TIME_T_PTR t) ) module: LibC
+     ^self ffiCall: #(long time(TIME_T_PTR t)) module: LibC
              
 ]
 
@@ -24,7 +24,7 @@ FFIExternalValueHolderTests >> testCall [
 	object := TIME_T_PTR new.
 
 	time := self getTime: object.
-	self assert: time equals: object value.
+	self assert: time equals: object value
 ]
 
 { #category : #tests }
@@ -38,6 +38,6 @@ FFIExternalValueHolderTests >> testCreateValueHolder [
 	self assert: object value equals: 0.
 	
 	object value: 42.
-	self assert: object value equals: 42.
+	self assert: object value equals: 42
 
 ]

--- a/src/UnifiedFFI-Tests/FFIOpaqueObjectTests.class.st
+++ b/src/UnifiedFFI-Tests/FFIOpaqueObjectTests.class.st
@@ -50,7 +50,7 @@ FFIOpaqueObjectTests >> testParseAsBigArityPointer [
 	fnSpec := self newParser parseNamedFunction: #( FFIOpaqueObject **function ( ) ). 
 	returnType := fnSpec returnType.
 	self assert: returnType class equals: FFIOpaqueObjectType.
-	self assert: returnType pointerArity equals: 2.
+	self assert: returnType pointerArity equals: 2
 ]
 
 { #category : #tests }
@@ -65,5 +65,5 @@ FFIOpaqueObjectTests >> testParseAsPointer [
 	fnSpec := self newParser parseNamedFunction: #( FFIOpaqueObject *function ( ) ). 
 	returnType := fnSpec returnType.
 	self assert: returnType class equals: FFIOpaqueObjectType.
-	self assert: returnType pointerArity equals: 1.
+	self assert: returnType pointerArity equals: 1
 ]

--- a/src/UnifiedFFI-Tests/FFITypeArrayTests.class.st
+++ b/src/UnifiedFFI-Tests/FFITypeArrayTests.class.st
@@ -62,5 +62,5 @@ FFITypeArrayTests >> testExternalAtPutFloat [
 		array := (FFITypeArray ofType: 'float' size: 10) externalNew.
 		1 to: 10 do: [ :index | array at: index put: random next ].
 		1 to: 10 do: [ :index | self assert: (array at: index) isFloat ] ]
-	ensure: [ array free ].
+	ensure: [ array free ]
 ]

--- a/src/UnifiedFFI-Tests/ManifestUnifiedFFITests.class.st
+++ b/src/UnifiedFFI-Tests/ManifestUnifiedFFITests.class.st
@@ -1,0 +1,48 @@
+"
+I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestUnifiedFFITests,
+	#superclass : #PackageManifest,
+	#category : #'UnifiedFFI-Tests-Manifest'
+}
+
+{ #category : #'code-critics' }
+ManifestUnifiedFFITests class >> ruleGRTemporaryNeitherReadNorWrittenRuleV1FalsePositive [
+	^ #(#(#(#RGMethodDefinition #(#FFICalloutAPITests #testByteArrayToExternalAddress #false)) #'2019-07-05T11:54:43.174226+02:00') )
+]
+
+{ #category : #'code-critics' }
+ManifestUnifiedFFITests class >> ruleRBLiteralArrayContainsCommaRuleV1FalsePositive [
+	^ #(#(#(#RGPackageDefinition #(#'UnifiedFFI-Tests')) #'2019-07-05T11:49:09.935226+02:00') )
+]
+
+{ #category : #'code-critics' }
+ManifestUnifiedFFITests class >> ruleRBLiteralArrayContainsSuspiciousTrueFalseOrNilRuleV1FalsePositive [
+	^ #(#(#(#RGMethodDefinition #(#FFIFunctionParserTests #testParseFunction #false)) #'2019-07-05T12:04:26.431226+02:00') )
+]
+
+{ #category : #'code-critics' }
+ManifestUnifiedFFITests class >> ruleRBLongMethodsRuleV1FalsePositive [
+	^ #(#(#(#RGMethodDefinition #(#FFICalloutTests #testBuildingFnSpec #false)) #'2019-07-05T11:56:50.062226+02:00') )
+]
+
+{ #category : #'code-critics' }
+ManifestUnifiedFFITests class >> ruleRBRefersToClassRuleV1FalsePositive [
+	^ #(#(#(#RGMethodDefinition #(#FFICompilerPluginTests #testDecompilationOfFFIMethodShouldHaveNamedArgs #false)) #'2019-07-05T11:57:50.898226+02:00') )
+]
+
+{ #category : #'code-critics' }
+ManifestUnifiedFFITests class >> ruleRBShouldntRaiseErrorRuleV1FalsePositive [
+	^ #(#(#(#RGMethodDefinition #(#FFICalloutAPITests #testCallWithObjectCreation #false)) #'2019-07-05T11:52:11.496226+02:00') #(#(#RGMethodDefinition #(#FFICalloutAPITests #testCallWithObjectParameter #false)) #'2019-07-05T11:52:27.292226+02:00') #(#(#RGMethodDefinition #(#FFICalloutAPITests #testCallWithSelfParameter #false)) #'2019-07-05T11:52:42.022226+02:00') )
+]
+
+{ #category : #'code-critics' }
+ManifestUnifiedFFITests class >> ruleRBTempsReadBeforeWrittenRuleV1FalsePositive [
+	^ #(#(#(#RGMethodDefinition #(#FFICalloutAPITests #testCallWithObjectCreation #false)) #'2019-07-05T11:52:01.493226+02:00') )
+]
+
+{ #category : #'code-critics' }
+ManifestUnifiedFFITests class >> ruleRBUncommonMessageSendRuleV1FalsePositive [
+	^ #(#(#(#RGClassDefinition #(#FFIExternalEnumerationTests)) #'2019-07-05T12:00:45.523226+02:00') )
+]


### PR DESCRIPTION
- use assert:equals:
- remove dots and unnecessary spaces
- some formatting
- ban some rules (for instance literal array which is usual in UFFI, or uncommon message send which is fine in the enum tests, ...)

Fix #3796