### PR TITLE
Adding platform specific initialization for OSX

### DIFF
--- a/src/OSWindow-SDL2/SDL2.class.st
+++ b/src/OSWindow-SDL2/SDL2.class.st
@@ -205,10 +205,21 @@ SDL2 class >> initLibrary [
 	Session == Smalltalk session ifTrue: [ ^ 1 ].
 	"Configure SDL2 in 'application mode', to let the screen to turn off on inactivity.
 	 But we let the user to restore 'game mode' on screen, by using #disableScreenSaver"
+	
+	self initPlatformSpecific.
+	
 	self setHint: SDL_HINT_VIDEO_ALLOW_SCREENSAVER value: '1'.
 	self setHint: SDL_HINT_NO_SIGNAL_HANDLERS value: '1'.
 	self init: SDL_INIT_NOPARACHUTE.
 	Session := Smalltalk session.
+]
+
+{ #category : #common }
+SDL2 class >> initPlatformSpecific [
+
+	Smalltalk os isMacOSX ifTrue: [  
+		SDLOSXPlatformInitializer new run.	
+	] 
 ]
 
 { #category : #common }

--- a/src/OSWindow-SDL2/SDLOSXPlatformInitializer.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPlatformInitializer.class.st
@@ -1,0 +1,36 @@
+"
+I execute specific initialization for OSX
+"
+Class {
+	#name : #SDLOSXPlatformInitializer,
+	#superclass : #Object,
+	#category : #'OSWindow-SDL2-Bindings'
+}
+
+{ #category : #running }
+SDLOSXPlatformInitializer >> lookupClass: aString [
+
+	^ self ffiCall: #(void* objc_lookUpClass(char *aString)) module: 'libobjc.dylib'
+]
+
+{ #category : #running }
+SDLOSXPlatformInitializer >> lookupSelector: aString [
+
+	^ self ffiCall: #(void* sel_registerName(const char *aString)) module: 'libobjc.dylib'
+
+]
+
+{ #category : #running }
+SDLOSXPlatformInitializer >> run [ 
+	| sel cls |
+
+	sel := self lookupSelector: 'sharedApplication'.
+	cls := self lookupClass: 'NSApplication'.
+	self sendMessage: sel to: cls
+]
+
+{ #category : #running }
+SDLOSXPlatformInitializer >> sendMessage: sel to: cls [
+
+	^ self ffiCall: #(void* objc_msgSend(void* cls, void* sel)) module: 'libobjc.dylib'
+]


### PR DESCRIPTION
When SDL is initialized in OSX we have to force the Pharo NIB.
Nowadays, the NIB is empty in headless and exists when it is not headless.
It is important that we guarantee that the menu is the correct.
