### PR TITLE
Fix mistake from PR3768

### DIFF
--- a/src/EmergencyEvaluator/ManifestEmergencyEvaluator.class.st
+++ b/src/EmergencyEvaluator/ManifestEmergencyEvaluator.class.st
@@ -1,0 +1,13 @@
+"
+I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestEmergencyEvaluator,
+	#superclass : #PackageManifest,
+	#category : #'EmergencyEvaluator-Manifest'
+}
+
+{ #category : #'code-critics' }
+ManifestEmergencyEvaluator class >> ruleRBCascadedNextPutAllsRuleV1FalsePositive [
+	^ #(#(#(#RGMethodDefinition #(#Transcripter #readEvalPrint #false)) #'2019-07-05T18:06:15.862172+02:00') )
+]

--- a/src/EmergencyEvaluator/Transcripter.class.st
+++ b/src/EmergencyEvaluator/Transcripter.class.st
@@ -21,7 +21,7 @@ Class {
 	#pools : [
 		'EventSensorConstants'
 	],
-	#category : #EmergencyEvaluator
+	#category : #'EmergencyEvaluator-Base'
 }
 
 { #category : #launching }
@@ -223,7 +223,7 @@ Transcripter >> readEvalPrint [
 				ifTrue: [okToRevert
 						ifTrue: [(self confirm: 'Revert: ' , RecentMessageList uniqueInstance lastEntry asString , ' ?')
 								ifTrue: [RecentMessageList uniqueInstance revertLastMethodSubmission.
-									self cr; show: 'reverted: '; nextPutAll: RecentMessageList uniqueInstance lastEntry asString.
+									self cr; show: 'reverted: ' , RecentMessageList uniqueInstance lastEntry asString.
 									okToRevert := false]]
 						ifFalse: [self cr; show: 'Only one level of revert currently supported']]
 				ifFalse: [self cr;


### PR DESCRIPTION
- revert to original version of readEvalPrint
- ban the rule so "," which is more readable can be used
- due to the additional manifest we tag the classes in a class category

Fix #3799