### PR TITLE
2943-ToolRegistry-should-drop-support-for-completion

### DIFF
--- a/src/Morphic-Base/TextMorph.class.st
+++ b/src/Morphic-Base/TextMorph.class.st
@@ -905,12 +905,7 @@ TextMorph >> handleKeystroke: anEvent [
 	self allowsKeymapping
 		ifTrue: [ self dispatchKeystrokeForEvent: anEvent ] .
 	anEvent wasHandled
-		ifTrue: [
-			"We need to check for completion here because otherwise it will try to handle the keystroke, 
-			even if it was already processed."
-			(Smalltalk tools hasToolNamed: #codeCompletion) 
-				ifTrue: [ Smalltalk tools codeCompletion uniqueInstance closeMenu ].
-			^ self].
+		ifTrue: [ ^ self].
 	(self handlesKeyStroke: anEvent)
 		ifFalse: [^ self].
 	self keyStroke: anEvent.
@@ -1053,13 +1048,7 @@ TextMorph >> justified [
 TextMorph >> keyStroke: evt [ 
 	"Handle a keystroke event."
 	Transcript show: 'TextMorph';cr.
-	(Smalltalk tools hasToolNamed: #codeCompletion) 
-		ifTrue: [ 
-			Smalltalk tools 
-				codeCompletionAround: [ self basicKeyStroke: evt ] 
-				textMorph: self 
-				keyStroke: evt ]
-		ifFalse: [  self basicKeyStroke: evt ]
+	self basicKeyStroke: evt
 ]
 
 { #category : #'event handling' }

--- a/src/NECompletion/NECController.class.st
+++ b/src/NECompletion/NECController.class.st
@@ -82,13 +82,6 @@ NECController class >> register [
 	RubSmalltalkEditor completionEngine: self.
 ]
 
-{ #category : #'tools registry' }
-NECController class >> registerToolsOn: registry [
-	"self registerToolsOn: Smalltalk tools" 
-	registry remove: #codeCompletion
-
-]
-
 { #category : #'instance creation' }
 NECController class >> reset [
 	uniqueInstance := nil

--- a/src/Tool-Registry/PharoCommonTools.class.st
+++ b/src/Tool-Registry/PharoCommonTools.class.st
@@ -165,12 +165,6 @@ PharoCommonTools >> cleanUp [
 ]
 
 { #category : #'registry access' }
-PharoCommonTools >> codeCompletion [
-
-	^ self toolNamed: #codeCompletion
-]
-
-{ #category : #'registry access' }
 PharoCommonTools >> debugger [
 
 	^ self toolNamed: #debugger

--- a/src/Tool-Registry/ToolRegistry.class.st
+++ b/src/Tool-Registry/ToolRegistry.class.st
@@ -77,13 +77,6 @@ ToolRegistry >> browseDirectToolReferences [
 		name: 'All direct references to tools to fix'
 ]
 
-{ #category : #misc }
-ToolRegistry >> codeCompletionAround: aBlock textMorph: aTextMorph keyStroke: evt [
-	^(self hasToolNamed: #codeCompletion)
-	ifTrue: [ self codeCompletion codeCompletionAround: aBlock textMorph: aTextMorph keyStroke: evt ]
-	ifFalse: [ aBlock value ]
-]
-
 { #category : #'handling DNU' }
 ToolRegistry >> doesNotUnderstand: aMessage [
 	"Return a tool identified by a message selector.


### PR DESCRIPTION
remove #codeCompletion from tools. Side effect is that TextMorph does not support code completion anymore, but that is no problem as we use the Rubric Editor for all code editing

fixes #2943