### PR TITLE
3111-Why-do-we-have-in-Object--isCodeCompletionAllowed

### DIFF
--- a/src/Glamour-Morphic-Widgets/GLMRubricSmalltalkTextModel.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMRubricSmalltalkTextModel.class.st
@@ -90,11 +90,6 @@ GLMRubricSmalltalkTextModel >> highlightSmalltalkContext: aClassOrMetaclass [
 	highlightSmalltalkContext := aClassOrMetaclass
 ]
 
-{ #category : #testing }
-GLMRubricSmalltalkTextModel >> isCodeCompletionAllowed [ 
-	^true
-]
-
 { #category : #accessing }
 GLMRubricSmalltalkTextModel >> selectedBehavior [
 	

--- a/src/Glamour-Morphic-Widgets/GLMSmalltalkCodeModel.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMSmalltalkCodeModel.class.st
@@ -84,11 +84,6 @@ GLMSmalltalkCodeModel >> highlightSmalltalkContext: anObject [
 	highlightSmalltalkContext := anObject
 ]
 
-{ #category : #completion }
-GLMSmalltalkCodeModel >> isCodeCompletionAllowed [ 
-	^true
-]
-
 { #category : #accessing }
 GLMSmalltalkCodeModel >> selectedClassOrMetaClass [
 	^ self highlightSmalltalkContext

--- a/src/NECompletion/AbstractTool.extension.st
+++ b/src/NECompletion/AbstractTool.extension.st
@@ -4,8 +4,3 @@ Extension { #name : #AbstractTool }
 AbstractTool >> guessTypeForName: aString [
 	^nil
 ]
-
-{ #category : #'*NECompletion' }
-AbstractTool >> isCodeCompletionAllowed [ 
-	^true
-]

--- a/src/NECompletion/FinderUI.extension.st
+++ b/src/NECompletion/FinderUI.extension.st
@@ -8,12 +8,6 @@ FinderUI >> guessTypeForName: aString [
 ]
 
 { #category : #'*necompletion' }
-FinderUI >> isCodeCompletionAllowed [
-
-	^ true
-]
-
-{ #category : #'*necompletion' }
 FinderUI >> selectedClassOrMetaClass [
 
 	^ self selectedClass

--- a/src/NECompletion/NECController.class.st
+++ b/src/NECompletion/NECController.class.st
@@ -28,11 +28,6 @@ Class {
 	#category : #'NECompletion-View'
 }
 
-{ #category : #testing }
-NECController class >> allowModel: aModel [ 
-	^NECPreferences enabled and: [ aModel isCodeCompletionAllowed ]
-]
-
 { #category : #cleanup }
 NECController class >> cleanUp [
 	self reset
@@ -42,21 +37,17 @@ NECController class >> cleanUp [
 NECController class >> codeCompletionAround: aBlock textMorph: aTextMorph keyStroke: evt [
 	"Inserts code completion if allowed in this morph"
 	
-	| editor stringHolder completionAllowed controller |
-	editor := aTextMorph editor.
-	stringHolder := editor ifNotNil:[ editor model ].
-	completionAllowed := self allowModel: stringHolder.
-	completionAllowed 
-		ifTrue: [ 
-			controller := self uniqueInstance.
-			controller setModel: stringHolder.
-			(controller handleKeystrokeBefore: evt editor: editor)
-				ifTrue:  [^ self ] ].
-
-	aBlock value.
+	| editor controller |
+	NECPreferences enabled ifFalse: [ ^aBlock value ].
+	editor := aTextMorph editor ifNil: [ ^aBlock value ].
+	editor isCodeCompletionAllowed ifFalse: [  ^aBlock value ].
+	controller := self uniqueInstance.
+	controller setModel: editor model.
 	
-	completionAllowed
-		ifTrue: [ controller handleKeystrokeAfter: evt editor: editor ]
+	(controller handleKeystrokeBefore: evt editor: editor) ifTrue:  [^ self ].
+	aBlock value.
+	controller handleKeystrokeAfter: evt editor: editor.
+
 ]
 
 { #category : #accessing }

--- a/src/NECompletion/Object.extension.st
+++ b/src/NECompletion/Object.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #Object }
-
-{ #category : #'*NECompletion' }
-Object >> isCodeCompletionAllowed [
-	^false
-]

--- a/src/NECompletion/Workspace.extension.st
+++ b/src/NECompletion/Workspace.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #Workspace }
-
-{ #category : #'*necompletion' }
-Workspace >> isCodeCompletionAllowed [
-	^true
-
-]

--- a/src/Rubric/RubScrolledTextModel.class.st
+++ b/src/Rubric/RubScrolledTextModel.class.st
@@ -156,13 +156,6 @@ RubScrolledTextModel >> interactionModel: anObject [
 	interactionModel := anObject
 ]
 
-{ #category : #'necompletion-extensions' }
-RubScrolledTextModel >> isCodeCompletionAllowed [
-	| allowed |
-	self reconfigureViewWith: [ :scrolledText | allowed := scrolledText textArea editingMode isCodeCompletionAllowed ].
-	^ allowed
-]
-
 { #category : #menu }
 RubScrolledTextModel >> menu [
 	^ nil

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -791,6 +791,13 @@ RubSmalltalkEditor >> internalCallToImplementorsOf: aSelector [
 ]
 
 { #category : #'completion engine' }
+RubSmalltalkEditor >> isCodeCompletionAllowed [
+	self flag: #TODO. "isCompletionEnabled and isCodeCompletionAllowed need to be unified"
+	^self isCompletionEnabled.
+	
+]
+
+{ #category : #'completion engine' }
 RubSmalltalkEditor >> isCompletionEnabled [
 
 	^ completionEngine isNil not

--- a/src/Rubric/RubTextAreaExamples.class.st
+++ b/src/Rubric/RubTextAreaExamples.class.st
@@ -114,12 +114,6 @@ RubTextAreaExamples class >> interactionModel [
 	^ ModelForShout 
 ]
 
-{ #category : #NOcompletion }
-RubTextAreaExamples class >> isCodeCompletionAllowed [
-
-	^ true.
-]
-
 { #category : #accessing }
 RubTextAreaExamples class >> menu [
 	^ nil

--- a/src/Rubric/RubWorkspaceExample.class.st
+++ b/src/Rubric/RubWorkspaceExample.class.st
@@ -130,12 +130,6 @@ RubWorkspaceExample >> initialize [
 	mustDeclareVariables := false
 ]
 
-{ #category : #completion }
-RubWorkspaceExample >> isCodeCompletionAllowed [
-
-	^ true.
-]
-
 { #category : #'user interface' }
 RubWorkspaceExample >> newScrolledText [
 	| st |

--- a/src/Spec-Core/AbstractTextPresenter.class.st
+++ b/src/Spec-Core/AbstractTextPresenter.class.st
@@ -331,29 +331,6 @@ AbstractTextPresenter >> initialize [
 	self registerEvents
 ]
 
-{ #category : #NOCompletion }
-AbstractTextPresenter >> isCodeCompletionAllowed [
-	"Return if code completion is allowed"
-	
-	"self 
-		deprecated: 'The forCode functionality has moved to TextCodePresenter, please use it instead TextPresenter.' 
-		on: '2019-04-05' 
-		in: #Pharo8"
-		
-	^ false
-]
-
-{ #category : #api }
-AbstractTextPresenter >> isCodeCompletionAllowed: aBoolean [
-	"<api: #boolean getter: #isCodeCompletionAllowed registration: #whenCodeCompletionAllowedChanged:>"
-	"Set if code completion is allowed"
-	
-	"self 
-		deprecated: 'The forCode functionality has moved to TextCodePresenter, please use it instead TextPresenter.' 
-		on: '2019-04-05' 
-		in: #Pharo8"
-]
-
 { #category : #api }
 AbstractTextPresenter >> isForSmalltalkCode [
 

--- a/src/Spec-MorphicAdapters/MorphicCodeAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicCodeAdapter.class.st
@@ -52,12 +52,6 @@ MorphicCodeAdapter >> hasSyntaxHighlight [
 ]
 
 { #category : #NOCompletion }
-MorphicCodeAdapter >> isCodeCompletionAllowed [
-
-	^ true
-]
-
-{ #category : #NOCompletion }
 MorphicCodeAdapter >> receiverClass [
 
 	^ self behavior

--- a/src/Spec-MorphicAdapters/MorphicTextAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTextAdapter.class.st
@@ -134,12 +134,6 @@ MorphicTextAdapter >> hasUnacceptedEdits: aBoolean [
 	self model hasUnacceptedEdits: aBoolean
 ]
 
-{ #category : #testing }
-MorphicTextAdapter >> isCodeCompletionAllowed [
-
-	^ false
-]
-
 { #category : #'spec protocol' }
 MorphicTextAdapter >> notify: errorMessage at: position in: sourceCode [
 

--- a/src/Spec2-Adapters-Morphic/SpMorphicCodeAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicCodeAdapter.class.st
@@ -52,12 +52,6 @@ SpMorphicCodeAdapter >> hasSyntaxHighlight [
 ]
 
 { #category : #NOCompletion }
-SpMorphicCodeAdapter >> isCodeCompletionAllowed [
-
-	^ true
-]
-
-{ #category : #NOCompletion }
 SpMorphicCodeAdapter >> receiverClass [
 
 	^ self behavior

--- a/src/Spec2-Adapters-Morphic/SpMorphicTextAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTextAdapter.class.st
@@ -134,12 +134,6 @@ SpMorphicTextAdapter >> hasUnacceptedEdits: aBoolean [
 	self model hasUnacceptedEdits: aBoolean
 ]
 
-{ #category : #testing }
-SpMorphicTextAdapter >> isCodeCompletionAllowed [
-
-	^ false
-]
-
 { #category : #'spec protocol' }
 SpMorphicTextAdapter >> notify: errorMessage at: position in: sourceCode [
 

--- a/src/Spec2-Core/SpAbstractTextPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractTextPresenter.class.st
@@ -331,29 +331,6 @@ SpAbstractTextPresenter >> initialize [
 	self registerEvents
 ]
 
-{ #category : #NOCompletion }
-SpAbstractTextPresenter >> isCodeCompletionAllowed [
-	"Return if code completion is allowed"
-	
-	"self 
-		deprecated: 'The forCode functionality has moved to TextCodePresenter, please use it instead TextPresenter.' 
-		on: '2019-04-05' 
-		in: #Pharo8"
-		
-	^ false
-]
-
-{ #category : #api }
-SpAbstractTextPresenter >> isCodeCompletionAllowed: aBoolean [
-	"<api: #boolean getter: #isCodeCompletionAllowed registration: #whenCodeCompletionAllowedChanged:>"
-	"Set if code completion is allowed"
-	
-	"self 
-		deprecated: 'The forCode functionality has moved to TextCodePresenter, please use it instead TextPresenter.' 
-		on: '2019-04-05' 
-		in: #Pharo8"
-]
-
 { #category : #api }
 SpAbstractTextPresenter >> isForSmalltalkCode [
 


### PR DESCRIPTION
- NEController>> codeCompletionAround: textMorph: keyStroke:
  -- simplify
 -- call  on the editor, not the model

- remove isCodeCompletionAllowed and isCodeCompletionAllowed:  everywhere but the editor and editing mode classes

In a next PR we then can continue simplifying