### PR TITLE
3806-testPoolUsers-needs-to-test-poolUsers-not-methodsAccessingPoolVariables

### DIFF
--- a/src/Kernel-Tests-Extended/SharedPoolTest.extension.st
+++ b/src/Kernel-Tests-Extended/SharedPoolTest.extension.st
@@ -3,9 +3,8 @@ Extension { #name : #SharedPoolTest }
 { #category : #'*Kernel-Tests-Extended' }
 SharedPoolTest >> testPoolUsers [
 	| result |
-	result := ChronologyConstants methodsAccessingPoolVariables.
-	self assert: (result includes: (Duration>>#asNanoSeconds) methodReference)
-		 
+	result := ChronologyConstants poolUsers.
+	self assert: result asSet equals: {Date. DateAndTime. Duration. Month. Time. TimeZone. Week. LocalTimeZone . AbstractTimeZone } asSet.
 ]
 
 { #category : #'*Kernel-Tests-Extended' }


### PR DESCRIPTION
fix #3806