### PR TITLE
3809-unify-isCompletionEnabled-and-isCodeCompletionAllowed

### DIFF
--- a/src/NECompletion/NECController.class.st
+++ b/src/NECompletion/NECController.class.st
@@ -38,9 +38,9 @@ NECController class >> codeCompletionAround: aBlock textMorph: aTextMorph keyStr
 	"Inserts code completion if allowed in this morph"
 	
 	| editor controller |
-	NECPreferences enabled ifFalse: [ ^aBlock value ].
+	self isCompletionEnabled ifFalse: [ ^aBlock value ].
 	editor := aTextMorph editor ifNil: [ ^aBlock value ].
-	editor isCodeCompletionAllowed ifFalse: [  ^aBlock value ].
+	editor isCompletionEnabled ifFalse: [  ^aBlock value ].
 	controller := self uniqueInstance.
 	controller setModel: editor model.
 	
@@ -65,6 +65,11 @@ NECController class >> initialize [
 	"self initialize"
 	
 	self register
+]
+
+{ #category : #accessing }
+NECController class >> isCompletionEnabled [
+	^NECPreferences enabled
 ]
 
 { #category : #'tools registry' }

--- a/src/Rubric/RubAbstractSmalltalkMode.class.st
+++ b/src/Rubric/RubAbstractSmalltalkMode.class.st
@@ -14,7 +14,7 @@ RubAbstractSmalltalkMode >> editorClass [
 ]
 
 { #category : #testing }
-RubAbstractSmalltalkMode >> isCodeCompletionAllowed [
+RubAbstractSmalltalkMode >> isCompletionEnabled [
 	^ true
 ]
 

--- a/src/Rubric/RubEditingMode.class.st
+++ b/src/Rubric/RubEditingMode.class.st
@@ -94,7 +94,7 @@ RubEditingMode >> interactive [
 ]
 
 { #category : #testing }
-RubEditingMode >> isCodeCompletionAllowed [
+RubEditingMode >> isCompletionEnabled [
 	^ false
 ]
 

--- a/src/Rubric/RubSmalltalkCommentMode.class.st
+++ b/src/Rubric/RubSmalltalkCommentMode.class.st
@@ -36,6 +36,6 @@ RubSmalltalkCommentMode >> formatMethodCode [
 ]
 
 { #category : #testing }
-RubSmalltalkCommentMode >> isCodeCompletionAllowed [
+RubSmalltalkCommentMode >> isCompletionEnabled [
 	^ false
 ]

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -791,16 +791,9 @@ RubSmalltalkEditor >> internalCallToImplementorsOf: aSelector [
 ]
 
 { #category : #'completion engine' }
-RubSmalltalkEditor >> isCodeCompletionAllowed [
-	self flag: #TODO. "isCompletionEnabled and isCodeCompletionAllowed need to be unified"
-	^self isCompletionEnabled.
-	
-]
-
-{ #category : #'completion engine' }
 RubSmalltalkEditor >> isCompletionEnabled [
 
-	^ completionEngine isNil not
+	^ completionEngine isNotNil and: [ self editingMode isCompletionEnabled ]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
- unify isCompletionEnabled and isCodeCompletionAllowed in favour of isCompletionEnabled
- isCompletionEnabled on the editor now asks the editing mode: code completion is enabled when in Code Mode!
- add #isCompletionEnabled on the NEController, too (just queries Preferences)

fixes #3809