### PR TITLE
Don't use an instance variable name as a method argument name.

### DIFF
--- a/src/FFI-Kernel/ExternalType.class.st
+++ b/src/FFI-Kernel/ExternalType.class.st
@@ -413,14 +413,14 @@ ExternalType >> asPointerType [
 ]
 
 { #category : #converting }
-ExternalType >> asPointerType: pointerSize [
+ExternalType >> asPointerType: anotherPointerSize [
 	"convert the receiver into a pointer type"
 	| type |
 	type := self asPointerType.
-	^type pointerSize = pointerSize
+	^type pointerSize = anotherPointerSize
 		ifTrue: [type]
 		ifFalse:
-			[type copy pointerSize: pointerSize; yourself]
+			[type copy pointerSize: anotherPointerSize; yourself]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Although Pharo appears to allow a method argument name to duplicate that of an instance variable, it is bad style and doesn't port well to other dialects.