### PR TITLE
remove period from end of method names

### DIFF
--- a/src/DeprecatedFileStream/MultiByteFileStream.class.st
+++ b/src/DeprecatedFileStream/MultiByteFileStream.class.st
@@ -471,7 +471,7 @@ MultiByteFileStream >> nextChunk [
 							| character state |
 							[(character := self next) == nil
 								or: [character == $!
-										and: [state := converter saveStateOf: self..
+										and: [state := converter saveStateOf: self.
 											self next ~~ $!]]]
 								whileFalse: [stream nextPut: character].
 							character

--- a/src/DeprecatedFileStream/MultiByteFileStream.class.st
+++ b/src/DeprecatedFileStream/MultiByteFileStream.class.st
@@ -530,7 +530,7 @@ MultiByteFileStream >> nextPreamble [
 							| character state |
 							[(character := self next) == nil
 								or: [character == $!
-										and: [state := converter saveStateOf: self..
+										and: [state := converter saveStateOf: self.
 											self next ~~ $!]]]
 								whileFalse: [stream nextPut: character].
 							character

--- a/src/FFI-Kernel/ExternalAddress.class.st
+++ b/src/FFI-Kernel/ExternalAddress.class.st
@@ -163,7 +163,7 @@ ExternalAddress >> fromInteger: address [
 	| sz pointer |
 	sz := self size.
 	pointer := ByteArray new: sz.
-	pointer integerAt: 1 put: address size: sz signed: false. .
+	pointer integerAt: 1 put: address size: sz signed: false.
 	self basicAt: 1 put: (pointer byteAt: 1);
 		basicAt: 2 put: (pointer byteAt: 2);
 		basicAt: 3 put: (pointer byteAt: 3);

--- a/src/FreeType/FT2Face.class.st
+++ b/src/FreeType/FT2Face.class.st
@@ -263,13 +263,13 @@ FT2Face >> ffiLoadGlyph: glyph_index flags: load_flags [
 ]
 
 { #category : #'private-ffi-calls' }
-FT2Face >> ffiOutline: outline embolden: strength [.
+FT2Face >> ffiOutline: outline embolden: strength [
 
 	^ self ffiCall: #(FT_Error FT_Outline_Embolden(FT_Outline*  outline, FT_Pos strength ))
 ]
 
 { #category : #'private-ffi-calls' }
-FT2Face >> ffiOutline: outline transformByMatrix: matrix [.
+FT2Face >> ffiOutline: outline transformByMatrix: matrix [
 	^ self ffiCall: #(void FT_Outline_Transform( FT_Outline*  outline, FT_Matrix*   matrix ))
 ]
 

--- a/src/GT-Debugger/UITheme.extension.st
+++ b/src/GT-Debugger/UITheme.extension.st
@@ -13,7 +13,7 @@ UITheme >> samePackageContextStyleFor: aContext [
 ]
 
 { #category : #'*GT-Debugger' }
-UITheme >> styleContext: aContext from: aDebugger. [
+UITheme >> styleContext: aContext from: aDebugger [
 
 	(aDebugger selectedContext == aContext) ifTrue: [ ^ {TextColor color: Smalltalk ui theme textColor}  ].
 

--- a/src/GT-EventRecorder/GTEventDelivery.class.st
+++ b/src/GT-EventRecorder/GTEventDelivery.class.st
@@ -155,7 +155,7 @@ GTEventDelivery >> offerPermission [
 ]
 
 { #category : #delivery }
-GTEventDelivery >> packAndDeliver: aBoolean. [
+GTEventDelivery >> packAndDeliver: aBoolean [
 	recorder pack.
 	self deliver: aBoolean.
 	

--- a/src/Glamour-FastTable/TGLMFastTable.trait.st
+++ b/src/Glamour-FastTable/TGLMFastTable.trait.st
@@ -67,7 +67,7 @@ TGLMFastTable >> dataCache [
 ]
 
 { #category : #cache }
-TGLMFastTable >> dataCacheFor: anElement [.
+TGLMFastTable >> dataCacheFor: anElement [
 
 	^ self dataCache at: anElement ifAbsentPut: [ Dictionary new ]
 ]

--- a/src/Glamour-PagerModel/GLMPagerModel.class.st
+++ b/src/Glamour-PagerModel/GLMPagerModel.class.st
@@ -496,7 +496,7 @@ GLMPagerModel >> virtualLastVisiblePageIndex [
 ]
 
 { #category : #private }
-GLMPagerModel >> virtualLastVisiblePageIndex: anIndex. [
+GLMPagerModel >> virtualLastVisiblePageIndex: anIndex [
 
 	virtualLastVisiblePageIndex := self normalizePaneIndex: anIndex.
 ]

--- a/src/Hermes-Extensions/HEExtendedInstaller.class.st
+++ b/src/Hermes-Extensions/HEExtendedInstaller.class.st
@@ -25,12 +25,12 @@ HEExtendedInstaller >> duplicationMode: anObject [
 ]
 
 { #category : #'validating existance' }
-HEExtendedInstaller >> existingClass: aHEClass. [
+HEExtendedInstaller >> existingClass: aHEClass [
 	^ duplicationMode existingClass: aHEClass on: self.
 ]
 
 { #category : #'validating existance' }
-HEExtendedInstaller >> existingTrait: aHETrait. [
+HEExtendedInstaller >> existingTrait: aHETrait [
 	^ duplicationMode existingTrait: aHETrait on: self.
 ]
 

--- a/src/Hermes/HEInstaller.class.st
+++ b/src/Hermes/HEInstaller.class.st
@@ -157,7 +157,7 @@ HEInstaller >> existingClass: aHEClass [
 ]
 
 { #category : #'validating existance' }
-HEInstaller >> existingTrait: aHETrait. [
+HEInstaller >> existingTrait: aHETrait [
 	(environment includesKey: aHETrait traitName) ifTrue:[ 
 		self error: (self messageExistingTrait: aHETrait)
 	].

--- a/src/JenkinsTools-Core/HDTestReport.class.st
+++ b/src/JenkinsTools-Core/HDTestReport.class.st
@@ -341,7 +341,7 @@ HDTestReport >> writeError: error stack: stack [
 ]
 
 { #category : #private }
-HDTestReport >> writeException: error stack: stack. [
+HDTestReport >> writeException: error stack: stack [
 
 	stream 
 		nextPutAll: (self encode: error class name); 

--- a/src/Morphic-Base/GradientFillStyle.extension.st
+++ b/src/Morphic-Base/GradientFillStyle.extension.st
@@ -68,7 +68,7 @@ GradientFillStyle >> changeColorSelector: aSymbol hand: aHand morph: aMorph orig
 ]
 
 { #category : #'*Morphic-Base-Balloon' }
-GradientFillStyle >> changeFirstColorIn: aMorph event: evt [.
+GradientFillStyle >> changeFirstColorIn: aMorph event: evt [
 	^self changeColorOf: aMorph rampIndex: 1
 ]
 

--- a/src/Morphic-Core/VMWorldRenderer.class.st
+++ b/src/Morphic-Core/VMWorldRenderer.class.st
@@ -185,7 +185,7 @@ VMWorldRenderer >> forceDisplayUpdate [
 ]
 
 { #category : #operations }
-VMWorldRenderer >> fullscreenMode: aValue [.
+VMWorldRenderer >> fullscreenMode: aValue [
 
 	Display fullscreenMode: aValue.
 	self checkForNewScreenSize.

--- a/src/Morphic-Widgets-Pluggable/PluggableListMorph.class.st
+++ b/src/Morphic-Widgets-Pluggable/PluggableListMorph.class.st
@@ -565,7 +565,7 @@ PluggableListMorph >> getMenu: shiftKeyState [
 ]
 
 { #category : #accessing }
-PluggableListMorph >> getSelectionListSelector: getListSel [.
+PluggableListMorph >> getSelectionListSelector: getListSel [
 
 	getSelectionListSelector := getListSel
 ]
@@ -1488,7 +1488,7 @@ PluggableListMorph >> setSelectedMorph: aMorph [
 ]
 
 { #category : #accessing }
-PluggableListMorph >> setSelectionListSelector: getListSel [.
+PluggableListMorph >> setSelectionListSelector: getListSel [
 
 	setSelectionListSelector := getListSel
 ]

--- a/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
@@ -1573,7 +1573,7 @@ MorphTreeMorph >> removeColumn: aTreeColumn [
 ]
 
 { #category : #'column handling' }
-MorphTreeMorph >> removeColumnAtIndex: aPosition [.
+MorphTreeMorph >> removeColumnAtIndex: aPosition [
 	"remove a column at a given position - rough implementation"
 	self columns removeAt: aPosition.
 	self columnsChanged.

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -154,7 +154,7 @@ OSWorldRenderer >> driver [
 ]
 
 { #category : #operations }
-OSWorldRenderer >> fullscreenMode: aValue [.
+OSWorldRenderer >> fullscreenMode: aValue [
 
 	osWindow fullscreen: aValue.
 	self checkForNewScreenSize.

--- a/src/OSWindow-SDL2/OSSDL2WindowHandle.class.st
+++ b/src/OSWindow-SDL2/OSSDL2WindowHandle.class.st
@@ -18,7 +18,7 @@ Class {
 }
 
 { #category : #'instance creation' }
-OSSDL2WindowHandle class >> newWithHandle: handle attributes: attributes [.
+OSSDL2WindowHandle class >> newWithHandle: handle attributes: attributes [
 	^ self basicNew initWithHandle: handle attributes: attributes; yourself
 ]
 

--- a/src/RecentSubmissions/RecentMessageList.class.st
+++ b/src/RecentSubmissions/RecentMessageList.class.st
@@ -144,7 +144,7 @@ RecentMessageList >> aMethodHasBeenRemoved: aMethodEvent [
 ]
 
 { #category : #actions }
-RecentMessageList >> addMethodReference: aMethodReference. [
+RecentMessageList >> addMethodReference: aMethodReference [
 
 	self addMethodReferenceSilently: aMethodReference.
 	self checkSize.

--- a/src/Rubric/RubMethodEditingExample.class.st
+++ b/src/Rubric/RubMethodEditingExample.class.st
@@ -205,7 +205,7 @@ RubMethodEditingExample >> textModel [
 ]
 
 { #category : #accessing }
-RubMethodEditingExample >> updateCodeWith: someText [.
+RubMethodEditingExample >> updateCodeWith: someText [
 	self textModel setText: someText.
 
 ]

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -271,7 +271,7 @@ ClassFactoryForTestCase >> newTraitNamed: aTraitName uses: aTraitComposition tag
 ]
 
 { #category : #creating }
-ClassFactoryForTestCase >> newTraitUsing: aTraitComposition. [
+ClassFactoryForTestCase >> newTraitUsing: aTraitComposition [
 	^self 
 		newTraitNamed: self newTraitName 
 		uses: aTraitComposition 

--- a/src/Shift-ClassInstaller/ShiftAnonymousClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftAnonymousClassInstaller.class.st
@@ -16,7 +16,7 @@ ShiftAnonymousClassInstaller >> comment: newClass [
 ]
 
 { #category : #building }
-ShiftAnonymousClassInstaller >> installInEnvironment: newClass [.
+ShiftAnonymousClassInstaller >> installInEnvironment: newClass [
 	^ self
 ]
 

--- a/src/SmartSuggestions/NautilusRefactoring.extension.st
+++ b/src/SmartSuggestions/NautilusRefactoring.extension.st
@@ -12,7 +12,7 @@ NautilusRefactoring >> accessorsInstVarNamed: aVariableName from: aClass [
 ]
 
 { #category : #'*SmartSuggestions' }
-NautilusRefactoring >> privateAccessorsClassVarNamed: aVariableName from:  aClass. [
+NautilusRefactoring >> privateAccessorsClassVarNamed: aVariableName from:  aClass [
 	^ RBCreateAccessorsForVariableRefactoring 
 			model: environment
 			variable: aVariableName
@@ -21,7 +21,7 @@ NautilusRefactoring >> privateAccessorsClassVarNamed: aVariableName from:  aClas
 ]
 
 { #category : #'*SmartSuggestions' }
-NautilusRefactoring >> privateAccessorsInstVarNamed: aVariableName from:  aClass. [
+NautilusRefactoring >> privateAccessorsInstVarNamed: aVariableName from:  aClass [
 	^ RBCreateAccessorsForVariableRefactoring 
 			model: environment
 			variable: aVariableName

--- a/src/UnifiedFFI/FFIExternalStructureFlatLayout.class.st
+++ b/src/UnifiedFFI/FFIExternalStructureFlatLayout.class.st
@@ -28,7 +28,7 @@ FFIExternalStructureFlatLayout >> addField: registerClass size: fieldSize alignm
 ]
 
 { #category : #building }
-FFIExternalStructureFlatLayout >> addMemoryFieldSize: fieldSize alignment: fieldAlignment [.
+FFIExternalStructureFlatLayout >> addMemoryFieldSize: fieldSize alignment: fieldAlignment [
 	self addField: #memory size: fieldSize alignment: fieldAlignment
 ]
 


### PR DESCRIPTION
While Pharo appears to allow a period at the end of a method name, it doesn't seem to be intentional and doesn't port well to other dialects.