### PR TITLE
Make Symbol references in literal Array explicit

### DIFF
--- a/src/Collections-Streams/Stream.class.st
+++ b/src/Collections-Streams/Stream.class.st
@@ -132,7 +132,7 @@ Stream >> next: anInteger [
 
 { #category : #accessing }
 Stream >> next: anInteger put: anObject [ 
-	<compilerOptions: #(+ optionInlineTimesRepeat)>
+	<compilerOptions: #(#+ optionInlineTimesRepeat)>
 	
 	"Make anObject be the next anInteger number of objects accessible by the 
 	receiver. Answer anObject."

--- a/src/Kernel/NonBooleanReceiver.class.st
+++ b/src/Kernel/NonBooleanReceiver.class.st
@@ -9,9 +9,9 @@ Some constructs are optimized in the compiler :
 So you cannot by default use them on non boolean objects.
 	
 If you really need to use optimized constructs, you can enable Opal compiler and do one of the following :
-		- recompile your method with the pragma : <compilerOptions: #(+ optIlineNone)>
+		- recompile your method with the pragma : <compilerOptions: #(#+ optIlineNone)>
 		- recompile your class with the method : MyClass class>>compiler 
-			^ super compiler options: #(+ optIlineNone)
+			^ super compiler options: #(#+ optIlineNone)
 		- call from this method by Object>>#mustBeBooleanInMagic:""
 "
 Class {

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1512,9 +1512,9 @@ Object >> mustBeBooleanIn: context [
 	So you cannot by default use them on non boolean objects."
 	
 	"If you really need to use optimized constructs, you can enable Opal compiler and do one of the following :
-		- recompile your method with the pragma : <compilerOptions: #(+ optIlineNone)>
+		- recompile your method with the pragma : <compilerOptions: #(#+ optIlineNone)>
 		- recompile your class with the method : MyClass class>>compiler 
-			^ super compiler options: #(+ optIlineNone)
+			^ super compiler options: #(#+ optIlineNone)
 		- enable the option mustBeBooleanDeOptimize to call mustBeBooleanDeOptimizeIn: instead of this method "
 
 	| proceedValue |

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -288,23 +288,23 @@ CompilationContext class >> optionsDescription [
 	
 	"each entry is fall-back default value (+/-), option name, description"
 	^ #(
-	(+ optionInlineIf 					'Inline ifTrue:, ifFalse:, ifTrue:ifFalse:, ifFalse:ifTrue: if specific conditions are met (See isInlineIf)')
-	(+ optionInlineIfNil 				'Inline ifNil:, ifNotNil:, ifNil:ifNotNil:, ifNotNil:ifNil: if specific conditions are met (See isInlineIfNil)')
-	(+ optionInlineAndOr 				'Inline and:, or: if specific conditions are met (See isInlineAndOr)')
-	(+ optionInlineWhile 				'Inline whileTrue, whileTrue:, whileFalse:, whileFalse if specific conditions are met (See isInlineWhile)')
-	(+ optionInlineToDo 				'Inline to:do:, to:by:do: if specific conditions are met (See isInlineToDo)')
-	(+ optionInlineCase 				'Inline caseOf:, caseOf:otherwise: if specific conditions are met (See isInlineCase)')
-	(- optionInlineTimesRepeat 		'Inline timesRepeat: if specific conditions are met (See isInlineTimesRepeat)')
-	(- optionInlineRepeat 			'Inline repeat if specific conditions are met (See isInlineRepeat)')
-	(- optionInlineNone 				'To turn off all inlining options. Overrides the others')
+	#(#+ optionInlineIf 					'Inline ifTrue:, ifFalse:, ifTrue:ifFalse:, ifFalse:ifTrue: if specific conditions are met (See isInlineIf)')
+	#(#+ optionInlineIfNil 				'Inline ifNil:, ifNotNil:, ifNil:ifNotNil:, ifNotNil:ifNil: if specific conditions are met (See isInlineIfNil)')
+	#(#+ optionInlineAndOr 				'Inline and:, or: if specific conditions are met (See isInlineAndOr)')
+	#(#+ optionInlineWhile 				'Inline whileTrue, whileTrue:, whileFalse:, whileFalse if specific conditions are met (See isInlineWhile)')
+	#(#+ optionInlineToDo 				'Inline to:do:, to:by:do: if specific conditions are met (See isInlineToDo)')
+	#(#+ optionInlineCase 				'Inline caseOf:, caseOf:otherwise: if specific conditions are met (See isInlineCase)')
+	#(#- optionInlineTimesRepeat 		'Inline timesRepeat: if specific conditions are met (See isInlineTimesRepeat)')
+	#(#- optionInlineRepeat 			'Inline repeat if specific conditions are met (See isInlineRepeat)')
+	#(#- optionInlineNone 				'To turn off all inlining options. Overrides the others')
 	
-	(- optionEmbeddSources         'Embedd sources into CompiledMethod instead of storing in .changes')
+	#(#- optionEmbeddSources         'Embedd sources into CompiledMethod instead of storing in .changes')
 	
-	(- optionReadOnlyLiterals 			'Compiler sets literals as read-only')
-	(- optionFullBlockClosure 			'Compiler compiles closure creation to use FullBlockClosure instead of BlockClosure')
-	(- optionLongIvarAccessBytecodes 	'Specific inst var accesses to Maybe context objects')
-	(+ optionOptimizeIR 					'Rewrite jumps in bytecode in a slightly more efficient way')
-	(- optionParseErrors 					'Parse syntactically wrong code')
+	#(#- optionReadOnlyLiterals 			'Compiler sets literals as read-only')
+	#(#- optionFullBlockClosure 			'Compiler compiles closure creation to use FullBlockClosure instead of BlockClosure')
+	#(#- optionLongIvarAccessBytecodes 	'Specific inst var accesses to Maybe context objects')
+	#(#+ optionOptimizeIR 					'Rewrite jumps in bytecode in a slightly more efficient way')
+	#(#- optionParseErrors 					'Parse syntactically wrong code')
 	) 
 ]
 

--- a/src/OpalCompiler-Core/InstructionStream.extension.st
+++ b/src/OpalCompiler-Core/InstructionStream.extension.st
@@ -5,5 +5,5 @@ InstructionStream class >> compiler [
 	"The JIT compiler needs to trap all reads to instance variables of contexts. As this check is costly, it is only done
 	in the long form of the bytecodes, which are not used often. In this hierarchy we force the compiler to alwasy generate
 	long bytecodes"
-	^super compiler options: #(+ optionLongIvarAccessBytecodes)
+	^super compiler options: #(#+ optionLongIvarAccessBytecodes)
 ]

--- a/src/OpalCompiler-Core/Object.extension.st
+++ b/src/OpalCompiler-Core/Object.extension.st
@@ -19,7 +19,7 @@ Object >> mustBeBooleanCompileExpression: context andCache: cache [
 	"Keep same compilation context as the sender node's"
 	methodNode compilationContext: sendNode methodNode compilationContext copy.
 	"Disable inlining so the message send will be unoptimized"
-	methodNode compilationContext compilerOptions: #(- optionInlineIf optionInlineAndOr optionInlineWhile).
+	methodNode compilationContext compilerOptions: #(#- optionInlineIf optionInlineAndOr optionInlineWhile).
 	"Generate the method"	
 	OCASTSemanticCleaner clean: methodNode.
 	method := methodNode generate.

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -599,7 +599,7 @@ OpalCompiler >> logged: aBoolean [
 OpalCompiler >> noPattern: aBoolean [
 	self compilationContext noPattern: aBoolean.
 	"when we compile an expression, embedd sources, as the resulting method will never be installed"
-	compilationContext parseOptions: #(+ #optionEmbeddSources).
+	compilationContext parseOptions: #(#+ #optionEmbeddSources).
 	
 ]
 

--- a/src/OpalCompiler-Core/Set.extension.st
+++ b/src/OpalCompiler-Core/Set.extension.st
@@ -5,7 +5,7 @@ Set >> parseOptions: anArray [
 
 	"parse an array, which is a sequence of options in a form of: 
 	
-	#( + option1 option2 - option3 ... )
+	#( #+ option1 option2 - option3 ... )
 	
 	each time the #+ is seen, the options which follow it will be subject for inclusion
 	and, correspondingly, if #- seen, then they will be excluded	.

--- a/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
@@ -16,7 +16,7 @@ OCCompileWithFailureTest >> testEvalSimpleMethodWithError [
 	| ast cm |
 	ast := OpalCompiler new
 				source: 'method 3+';
-				options: #(+ optionParseErrors);
+				options: #(#+ optionParseErrors);
 				parse.
 	
 	self assert: ast isMethod.

--- a/src/OpalCompiler-Tests/OpalCompilerTests.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTests.class.st
@@ -63,7 +63,7 @@ OpalCompilerTests >> testCompileEmbeddsSource [
 	| result |
 	result := Smalltalk compiler
 		class: UndefinedObject;
-		options: #( + #optionEmbeddSources );
+		options: #( #+ #optionEmbeddSources );
 		compile: 'tt ^3+4'.
 	self assert: (result valueWithReceiver: nil arguments: #()) equals: 7.
 	self deny: result trailer hasSourcePointer. "no sourcePointer"

--- a/src/Reflectivity-Examples/ReflectivityDemos.class.st
+++ b/src/Reflectivity-Examples/ReflectivityDemos.class.st
@@ -39,7 +39,7 @@ ReflectivityDemos >> demoSelfSendLogging [
 		metaObject: [ :context :object | context sender receiver == object
 				ifTrue: [ context crLog ] ];
 		selector: #value:value:;
-		option: #(+optionCompileOnLinkInstallation);
+		option: #(#+ optionCompileOnLinkInstallation);
 		arguments: #(context object);
 		control: #before.
 		

--- a/src/Reflectivity-Tests/MetaLinkTest.class.st
+++ b/src/Reflectivity-Tests/MetaLinkTest.class.st
@@ -72,7 +72,7 @@ MetaLinkTest >> testDefintionString [
 MetaLinkTest >> testLinkOption [
 	| link |
 	link := MetaLink new 
-		options: #(+option1 -option2).
+		options: #(#+ option1 #- option2).
 	
 	self assert: link option1.
 	self deny: link option2.

--- a/src/Reflectivity-Tests/ReflectivityControlTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityControlTest.class.st
@@ -309,7 +309,7 @@ ReflectivityControlTest >> testAfterSendWeak [
 		metaObject: self;
 		selector: #tagExec:;
 		control: #after;
-		option: #(+ optionWeakAfter);
+		option: #(#+ optionWeakAfter);
 		arguments: #(node).
 	sendNode link: link.
 	self assert: sendNode hasMetalinkAfter.
@@ -853,14 +853,14 @@ ReflectivityControlTest >> testFailingDoubleRWInstead [
 		metaObject: readMO; 
 		selector: #value:;
 		control: #instead;
-		options: #(+ optionCompileOnLinkInstallation);
+		options: #(#+ optionCompileOnLinkInstallation);
 		arguments: #(object).
 		
 	writeLink := MetaLink new 
 		metaObject: writeMO; 
 		selector: #value:value:;
 		control: #instead;
-		options: #(+ optionCompileOnLinkInstallation);
+		options: #(#+ optionCompileOnLinkInstallation);
 		arguments: #(newValue object).
 	
 	readSites do: [ :readNode | readNode link: readLink ].
@@ -884,7 +884,7 @@ ReflectivityControlTest >> testFailingDoubleRWInsteadSimplified [
 		metaObject: readMO; 
 		selector: #value:;
 		control: #instead;
-		options: #(+ optionCompileOnLinkInstallation);
+		options: #(#+ optionCompileOnLinkInstallation);
 		arguments: #(object).
 			
 	readNode link: readLink.
@@ -1194,7 +1194,7 @@ ReflectivityControlTest >> testLinkOneShot [
 	sendNode := (ReflectivityExamples>>#exampleMethod) sendNodes first.
 	link := MetaLink new 
 		metaObject: self; 
-		options: #(+ optionOneShot);
+		options: #(#+ optionOneShot);
 		selector: #tagExec.
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
@@ -1214,7 +1214,7 @@ ReflectivityControlTest >> testLinkOptionDisabledLink [
 	sendNode := (ReflectivityExamples>>#exampleMethod) sendNodes first.
 	link := MetaLink new 
 		metaObject: self; 
-		options: #(+ optionDisabledLink);
+		options: #(#+ optionDisabledLink);
 		selector: #tagExec.
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
@@ -1231,7 +1231,7 @@ ReflectivityControlTest >> testLinkoptionInlineCondition [
 	sendNode := (ReflectivityExamples>>#exampleMethod) sendNodes first.
 	link := MetaLink new 
 		metaObject: self; 
-		options: #(- optionInlineCondition);
+		options: #(#- optionInlineCondition);
 		condition: [ true ];
 		selector: #tagExec.
 	sendNode link: link.
@@ -1260,7 +1260,7 @@ ReflectivityControlTest >> testLinkoptionInlineMetaObject [
 	sendNode := (ReflectivityExamples>>#exampleMethod) sendNodes first.
 	link := MetaLink new 
 		metaObject: self; 
-		options: #(- optionInlineMetaObject);
+		options: #(#- optionInlineMetaObject);
 		selector: #tagExec.
 	sendNode link: link.
 	self assert: sendNode hasMetalink.

--- a/src/Reflectivity-Tests/ReflectivityExamples.class.st
+++ b/src/Reflectivity-Tests/ReflectivityExamples.class.st
@@ -24,7 +24,7 @@ ReflectivityExamples class >> exampleMethodWithMetaLinkOptionsViaClass [
 { #category : #options }
 ReflectivityExamples class >> metaLinkOptions [
 	^{
-	#exampleMethodWithMetaLinkOptionsViaClass -> #( + optionCompileOnLinkInstallation)
+	#exampleMethodWithMetaLinkOptionsViaClass -> #( #+ optionCompileOnLinkInstallation)
 	}
 ]
 
@@ -142,7 +142,7 @@ ReflectivityExamples >> exampleMethodMultipleSites [
 
 { #category : #examples }
 ReflectivityExamples >> exampleMethodWithMetaLinkOptions [
-	<metaLinkOptions: #( +optionCompileOnLinkInstallation)>
+	<metaLinkOptions: #( #+optionCompileOnLinkInstallation)>
 	^ 2 + 3
 ]
 

--- a/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
@@ -1311,7 +1311,7 @@ ReflectivityReificationTest >> testReifyOptionArgsAsArray [
 			self assert: args equals: #().
 			self assert: link == link ];
 		selector: #valueWithArguments:;
-		option: #(+ argsAsArray);
+		option: #(#+ argsAsArray);
 		arguments: #(object selector arguments link);
 		control: #after.
 	methodNode link: link.

--- a/src/Reflectivity/AdditionalMethodState.extension.st
+++ b/src/Reflectivity/AdditionalMethodState.extension.st
@@ -3,8 +3,8 @@ Extension { #name : #AdditionalMethodState }
 { #category : #'*Reflectivity' }
 AdditionalMethodState >> metaLinkOptions [
 	^{
-	#selector -> #( + optionCompileOnLinkInstallation).
-	#isMethodProperties -> #( + optionCompileOnLinkInstallation).
-	#metaLinkOptions -> #( + optionCompileOnLinkInstallation)
+	#selector -> #( #+ optionCompileOnLinkInstallation).
+	#isMethodProperties -> #( #+ optionCompileOnLinkInstallation).
+	#metaLinkOptions -> #( #+ optionCompileOnLinkInstallation)
 	}
 ]

--- a/src/Reflectivity/Behavior.extension.st
+++ b/src/Reflectivity/Behavior.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #Behavior }
 { #category : #'*Reflectivity' }
 Behavior >> metaLinkOptions [
 	^{
-	#methodDict -> #( + optionCompileOnLinkInstallation).
-	#metaLinkOptions -> #( + optionCompileOnLinkInstallation)
+	#methodDict -> #( #+ optionCompileOnLinkInstallation).
+	#metaLinkOptions -> #( #+ optionCompileOnLinkInstallation)
 	}
 ]

--- a/src/Reflectivity/BlockClosure.extension.st
+++ b/src/Reflectivity/BlockClosure.extension.st
@@ -5,7 +5,7 @@ BlockClosure >> rfEnsure: aBlock [
 	"same as #esure, carefully written to never have active meta-links as it is called in the code path that checks for recursion"
 
 	<primitive: 198>
-	<metaLinkOptions: #( + optionDisabledLink)>
+	<metaLinkOptions: #( #+ optionDisabledLink)>
 	| returnValue b |
 	returnValue := self rfvalue.
 	aBlock isNil
@@ -21,7 +21,7 @@ BlockClosure >> rfEnsure: aBlock [
 BlockClosure >> rfvalue [
 	"same as value, for recursion stopping metalinks"
 	<primitive: 201>
-	<metaLinkOptions: #( + optionDisabledLink)>
+	<metaLinkOptions: #( #+ optionDisabledLink)>
 	^self primitiveFailed
 ]
 

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -164,7 +164,7 @@ Breakpoint >> condition: aCondition [
 
 { #category : #initialization }
 Breakpoint >> initialize [
-	options := #(+ optionCompileOnLinkInstallation + optionAnnounce)
+	options := #(#+ optionCompileOnLinkInstallation + optionAnnounce)
 ]
 
 { #category : #install }

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -164,7 +164,7 @@ Breakpoint >> condition: aCondition [
 
 { #category : #initialization }
 Breakpoint >> initialize [
-	options := #(#+ optionCompileOnLinkInstallation + optionAnnounce)
+	options := #(#+ optionCompileOnLinkInstallation #+ optionAnnounce)
 ]
 
 { #category : #install }

--- a/src/Reflectivity/CompiledMethod.extension.st
+++ b/src/Reflectivity/CompiledMethod.extension.st
@@ -83,13 +83,13 @@ CompiledMethod >> invalidate [
 { #category : #'*Reflectivity' }
 CompiledMethod >> metaLinkOptions [
 	^{
-	#penultimateLiteral -> #( + optionCompileOnLinkInstallation).
-	#selector -> #( + optionCompileOnLinkInstallation).
-	#objectAt: -> #( + optionCompileOnLinkInstallation).
-	#header -> #( + optionCompileOnLinkInstallation).
-	#numLiterals -> #( + optionCompileOnLinkInstallation).
-	#literalAt: -> #( + optionCompileOnLinkInstallation).
-	#metaLinkOptions -> #( + optionCompileOnLinkInstallation)
+	#penultimateLiteral -> #( #+ optionCompileOnLinkInstallation).
+	#selector -> #( #+ optionCompileOnLinkInstallation).
+	#objectAt: -> #( #+ optionCompileOnLinkInstallation).
+	#header -> #( #+ optionCompileOnLinkInstallation).
+	#numLiterals -> #( #+ optionCompileOnLinkInstallation).
+	#literalAt: -> #( #+ optionCompileOnLinkInstallation).
+	#metaLinkOptions -> #( #+ optionCompileOnLinkInstallation)
 	}
 ]
 

--- a/src/Reflectivity/Context.extension.st
+++ b/src/Reflectivity/Context.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #Context }
 Context >> rftempAt: index put: value [ 
 	"same as #tempAt:put:, for recursion stopping metalinks"
 	<primitive: 211>
-	<metaLinkOptions: #( + optionDisabledLink)>
+	<metaLinkOptions: #( #+ optionDisabledLink)>
 	"should never reach here, so no rfat:put: needed"
 	^self at: index put: value
 ]

--- a/src/Reflectivity/HashedCollection.extension.st
+++ b/src/Reflectivity/HashedCollection.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #HashedCollection }
 { #category : #'*Reflectivity' }
 HashedCollection >> metaLinkOptions [
 	^{
-	#findElementOrNil: -> #( + optionCompileOnLinkInstallation).
-	#metaLinkOptions -> #( + optionCompileOnLinkInstallation)
+	#findElementOrNil: -> #( #+ optionCompileOnLinkInstallation).
+	#metaLinkOptions -> #( #+ optionCompileOnLinkInstallation)
 	}
 ]

--- a/src/Reflectivity/MetaLink.class.st
+++ b/src/Reflectivity/MetaLink.class.st
@@ -251,7 +251,7 @@ MetaLink >> invalidate [
 
 { #category : #accessing }
 MetaLink >> level [
-	<metaLinkOptions: #( + optionDisabledLink)>
+	<metaLinkOptions: #( #+ optionDisabledLink)>
 	^ level
 ]
 

--- a/src/Reflectivity/MetaLink.class.st
+++ b/src/Reflectivity/MetaLink.class.st
@@ -46,15 +46,15 @@ Class {
 { #category : #options }
 MetaLink class >> defaultOptions [
 	^ #(
-	+ optionInlineMetaObject            "meta object is inlined by default."
-	+ optionInlineCondition              "condition is inlined by default."
-	- optionCompileOnLinkInstallation   "generate compiledMethod on link installation"
-	- optionOneShot                     "remove link after first activation"
-	- optionMetalevel                   "force level: 0 for the link"
-	- optionDisabledLink                "links are active by default"
-	+ optionWeakAfter 						  "do not use #ensure: for #after "
-	- optionAnnounce                    "do we announce adding / removing links? Slow"
-	- argsAsArray                       "pass all arguments in one array. By default off as it adds an array creation"
+	#+ optionInlineMetaObject            "meta object is inlined by default."
+	#+ optionInlineCondition             "condition is inlined by default."
+	#- optionCompileOnLinkInstallation   "generate compiledMethod on link installation"
+	#- optionOneShot                     "remove link after first activation"
+	#- optionMetalevel                   "force level: 0 for the link"
+	#- optionDisabledLink                "links are active by default"
+	#+ optionWeakAfter                   "do not use #ensure: for #after "
+	#- optionAnnounce                    "do we announce adding / removing links? Slow"
+	#- argsAsArray                       "pass all arguments in one array. By default off as it adds an array creation"
 	)
 ]
 

--- a/src/Reflectivity/MethodDictionary.extension.st
+++ b/src/Reflectivity/MethodDictionary.extension.st
@@ -3,8 +3,8 @@ Extension { #name : #MethodDictionary }
 { #category : #'*Reflectivity' }
 MethodDictionary >> metaLinkOptions [
 	^{
-	#scanFor: -> #( + optionCompileOnLinkInstallation).
-	#at:put: -> #( + optionCompileOnLinkInstallation).
-	#metaLinkOptions -> #( + optionCompileOnLinkInstallation)
+	#scanFor: -> #( #+ optionCompileOnLinkInstallation).
+	#at:put: -> #( #+ optionCompileOnLinkInstallation).
+	#metaLinkOptions -> #( #+ optionCompileOnLinkInstallation)
 	}
 ]

--- a/src/Reflectivity/Process.extension.st
+++ b/src/Reflectivity/Process.extension.st
@@ -2,33 +2,33 @@ Extension { #name : #Process }
 
 { #category : #'*Reflectivity' }
 Process >> isActive: n [
-	<metaLinkOptions: #( + optionDisabledLink)>
+	<metaLinkOptions: #( #+ optionDisabledLink)>
 	^level = n or: [ level == nil ]. 
 ]
 
 { #category : #'*Reflectivity' }
 Process >> isMeta [
-	<metaLinkOptions: #( + optionDisabledLink)>
+	<metaLinkOptions: #( #+ optionDisabledLink)>
 	level ifNil: [ level := 0 ].
 	^level ~= 0
 ]
 
 { #category : #'*Reflectivity' }
 Process >> level [
-	<metaLinkOptions: #( + optionDisabledLink)>
+	<metaLinkOptions: #( #+ optionDisabledLink)>
 	^level ifNil: [ level := 0 ]
 ]
 
 { #category : #'*Reflectivity' }
 Process >> rfeffectiveProcess [
 	"same as #effectiveProcess but for internal use for metalink activation"
-	<metaLinkOptions: #( + optionDisabledLink)>
+	<metaLinkOptions: #( #+ optionDisabledLink)>
 	^effectiveProcess ifNil: [self] 
 ]
 
 { #category : #'*Reflectivity' }
 Process >> shiftLevelDown [
-	<metaLinkOptions: #( + optionDisabledLink)>
+	<metaLinkOptions: #( #+ optionDisabledLink)>
 	level ifNil: [ level := 0 ].
 	(level rfIsEqual: 0) ifTrue: [ ^level ].
 	(level rfIsEqual: 1) ifTrue: [ ^level := 0 ].
@@ -37,7 +37,7 @@ Process >> shiftLevelDown [
 
 { #category : #'*Reflectivity' }
 Process >> shiftLevelUp [
-	<metaLinkOptions: #( + optionDisabledLink)>
+	<metaLinkOptions: #( #+ optionDisabledLink)>
 	level ifNil: [ level := 0 ].
 	level := level rfPlus: 1
 ]

--- a/src/Reflectivity/ProcessorScheduler.extension.st
+++ b/src/Reflectivity/ProcessorScheduler.extension.st
@@ -3,6 +3,6 @@ Extension { #name : #ProcessorScheduler }
 { #category : #'*Reflectivity' }
 ProcessorScheduler >> rfactiveProcess [
 	"Answer the currently running Process."
-	<metaLinkOptions: #( + optionDisabledLink)>
+	<metaLinkOptions: #( #+ optionDisabledLink)>
 	^activeProcess rfeffectiveProcess
 ]

--- a/src/Reflectivity/ProtoObject.extension.st
+++ b/src/Reflectivity/ProtoObject.extension.st
@@ -3,8 +3,8 @@ Extension { #name : #ProtoObject }
 { #category : #'*Reflectivity' }
 ProtoObject >> metaLinkOptions [
 	^{
-	#isNil -> #( + optionCompileOnLinkInstallation).
-	#metaLinkOptions -> #( + optionCompileOnLinkInstallation)
+	#isNil -> #( #+ optionCompileOnLinkInstallation).
+	#metaLinkOptions -> #( #+ optionCompileOnLinkInstallation)
 	}
 ]
 
@@ -23,7 +23,7 @@ ProtoObject >> rfIsEqual: anObject [
 	object (have the same object pointer). Do not redefine the message == in 
 	any other class! Essential. No Lookup. Do not override in any subclass. 
 	See Object documentation whatIsAPrimitive."
-	<metaLinkOptions: #( + optionDisabledLink)>
+	<metaLinkOptions: #( #+ optionDisabledLink)>
 	<primitive: 110>
 	self primitiveFailed
 ]

--- a/src/Reflectivity/RBMethodNode.extension.st
+++ b/src/Reflectivity/RBMethodNode.extension.st
@@ -9,8 +9,8 @@ RBMethodNode >> hasOption: aSymbol for: aLink [
 { #category : #'*Reflectivity' }
 RBMethodNode >> metaLinkOptions [
 	^{
-	#metaLinkOptionsFromClassAndMethod -> #( + optionCompileOnLinkInstallation).
-	#metaLinkOptions -> #( + optionCompileOnLinkInstallation)
+	#metaLinkOptionsFromClassAndMethod -> #( #+ optionCompileOnLinkInstallation).
+	#metaLinkOptions -> #( #+ optionCompileOnLinkInstallation)
 	}
 ]
 

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -205,24 +205,24 @@ ReflectiveMethod >> linkCount: aNumber [
 { #category : #invalidate }
 ReflectiveMethod >> metaLinkOptions [
 	^{
-	#invalidate -> #( + optionCompileOnLinkInstallation).
-	#increaseLinkCount -> #( + optionCompileOnLinkInstallation).
-	#linkCount: -> #( + optionCompileOnLinkInstallation).
-	#methodClass: -> #( + optionCompileOnLinkInstallation).
-	#compiledMethod: -> #( + optionCompileOnLinkInstallation).
-	#ast -> #( + optionCompileOnLinkInstallation).
-	#installCompiledMethod -> #( + optionCompileOnLinkInstallation).
-	#installReflectiveMethod -> #( + optionCompileOnLinkInstallation).
-	#installMethod:-> #( + optionCompileOnLinkInstallation).
-	#installLink: -> #( + optionCompileOnLinkInstallation).
-	#reinstallASTInCache -> #( + optionCompileOnLinkInstallation).
-	#removeLink: -> #( + optionCompileOnLinkInstallation).
-	#selector: -> #( + optionCompileOnLinkInstallation).
-	#run:with:in: -> #( + optionCompileOnLinkInstallation).
-	#compiledMethod -> #( + optionCompileOnLinkInstallation).
-	#reflectiveMethod -> #( + optionCompileOnLinkInstallation).
-	#decreaseLinkCount -> #( + optionCompileOnLinkInstallation).
-	#metaLinkOptions -> #( + optionCompileOnLinkInstallation)
+	#invalidate -> #( #+ optionCompileOnLinkInstallation).
+	#increaseLinkCount -> #( #+ optionCompileOnLinkInstallation).
+	#linkCount: -> #( #+ optionCompileOnLinkInstallation).
+	#methodClass: -> #( #+ optionCompileOnLinkInstallation).
+	#compiledMethod: -> #( #+ optionCompileOnLinkInstallation).
+	#ast -> #( #+ optionCompileOnLinkInstallation).
+	#installCompiledMethod -> #( #+ optionCompileOnLinkInstallation).
+	#installReflectiveMethod -> #( #+ optionCompileOnLinkInstallation).
+	#installMethod:-> #( #+ optionCompileOnLinkInstallation).
+	#installLink: -> #( #+ optionCompileOnLinkInstallation).
+	#reinstallASTInCache -> #( #+ optionCompileOnLinkInstallation).
+	#removeLink: -> #( #+ optionCompileOnLinkInstallation).
+	#selector: -> #( #+ optionCompileOnLinkInstallation).
+	#run:with:in: -> #( #+ optionCompileOnLinkInstallation).
+	#compiledMethod -> #( #+ optionCompileOnLinkInstallation).
+	#reflectiveMethod -> #( #+ optionCompileOnLinkInstallation).
+	#decreaseLinkCount -> #( #+ optionCompileOnLinkInstallation).
+	#metaLinkOptions -> #( #+ optionCompileOnLinkInstallation)
 	}
 ]
 

--- a/src/Reflectivity/Set.extension.st
+++ b/src/Reflectivity/Set.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #Set }
 { #category : #'*Reflectivity' }
 Set >> metaLinkOptions [
 	^{
-	#parseOptions: -> #( + optionCompileOnLinkInstallation).
-	#metaLinkOptions -> #( + optionCompileOnLinkInstallation)
+	#parseOptions: -> #( #+ optionCompileOnLinkInstallation).
+	#metaLinkOptions -> #( #+ optionCompileOnLinkInstallation)
 	}
 ]

--- a/src/Reflectivity/SmallInteger.extension.st
+++ b/src/Reflectivity/SmallInteger.extension.st
@@ -6,7 +6,7 @@ SmallInteger >> rfMinus: aNumber [
 	result if it is a SmallInteger. Fail if the argument or the result is not a
 	SmallInteger. Essential. No Lookup. See Object documentation
 	whatIsAPrimitive."
-	<metaLinkOptions: #( + optionDisabledLink)>
+	<metaLinkOptions: #( #+ optionDisabledLink)>
 	<primitive: 2>
 	^super - aNumber
 ]
@@ -16,7 +16,7 @@ SmallInteger >> rfPlus: aNumber [
 	"Primitive. Add the receiver to the argument and answer with the result
 	if it is a SmallInteger. Fail if the argument or the result is not a
 	SmallInteger  Essential  No Lookup. See Object documentation whatIsAPrimitive."
-	<metaLinkOptions: #( + optionDisabledLink)>
+	<metaLinkOptions: #( #+ optionDisabledLink)>
 	<primitive: 1>
 	^ super + aNumber
 ]

--- a/src/Reflectivity/SmalltalkImage.extension.st
+++ b/src/Reflectivity/SmalltalkImage.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #SmalltalkImage }
 { #category : #'*Reflectivity' }
 SmalltalkImage >> metaLinkOptions [
 	^{
-	#vm -> #( + optionCompileOnLinkInstallation).
-	#metaLinkOptions -> #( + optionCompileOnLinkInstallation)
+	#vm -> #( #+ optionCompileOnLinkInstallation).
+	#metaLinkOptions -> #( #+ optionCompileOnLinkInstallation)
 	}
 ]

--- a/src/Reflectivity/VirtualMachine.extension.st
+++ b/src/Reflectivity/VirtualMachine.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #VirtualMachine }
 { #category : #'*Reflectivity' }
 VirtualMachine >> metaLinkOptions [
 	^{
-	#isSpur -> #( + optionCompileOnLinkInstallation).
-	#metaLinkOptions -> #( + optionCompileOnLinkInstallation)
+	#isSpur -> #( #+ optionCompileOnLinkInstallation).
+	#metaLinkOptions -> #( #+ optionCompileOnLinkInstallation)
 	}
 ]

--- a/src/Reflectivity/Watchpoint.class.st
+++ b/src/Reflectivity/Watchpoint.class.st
@@ -110,7 +110,7 @@ Watchpoint >> install [
 				arguments: #(value);
 				control: #after;
 				condition: [ recording ];
-				option: #(#+ optionWeakAfter +optionAnnounce).
+				option: #(#+ optionWeakAfter #+ optionAnnounce).
 	node link: link.
 	self class allWatchpoints at: node put: self.
 ]

--- a/src/Reflectivity/Watchpoint.class.st
+++ b/src/Reflectivity/Watchpoint.class.st
@@ -110,7 +110,7 @@ Watchpoint >> install [
 				arguments: #(value);
 				control: #after;
 				condition: [ recording ];
-				option: #(+ optionWeakAfter +optionAnnounce).
+				option: #(#+ optionWeakAfter +optionAnnounce).
 	node link: link.
 	self class allWatchpoints at: node put: self.
 ]

--- a/src/SmartSuggestions/SugsMenuBuilder.class.st
+++ b/src/SmartSuggestions/SugsMenuBuilder.class.st
@@ -48,7 +48,7 @@ SugsMenuBuilder class >> findBestNodeFor: context [
 		ifTrue: [ 
 			root := Smalltalk compiler
 				source: context code;
-				options: #(+ optionParseErrors);
+				options: #(#+ optionParseErrors);
 				parse.
 			context selectedClass ifNotNil: [ :theClass | root methodNode methodClass: theClass ].
 			root doSemanticAnalysis ]

--- a/src/System-OSEnvironments/UnixEnvironment.class.st
+++ b/src/System-OSEnvironments/UnixEnvironment.class.st
@@ -148,7 +148,7 @@ UnixEnvironment >> basicGetEnvRawViaFFI: arg1 [
 	"This method calls the Standard C Library getenv() function.
 	The name of the argument (arg1) should fit decompiled version."
 	
-	 ^ self ffiCall: #( String getenv (String arg1) ) module: LibC
+	 ^ self ffiCall: #( String getenv #(String arg1) ) module: LibC
 ]
 
 { #category : #accessing }
@@ -287,11 +287,11 @@ UnixEnvironment >> removeKey: key encoded: anEncoding [
 UnixEnvironment >> setEnv: nameString value: valueString [
 	"This method calls the Standard C Library setenv() function"
 
-	^ self ffiCall: #(int setenv #(String nameString , String valueString , 1)) module: LibC
+	^ self ffiCall: #(int setenv #(String nameString #, String valueString #, 1)) module: LibC
 ]
 
 { #category : #private }
 UnixEnvironment >> unsetEnv: string [
 	"This method calls the Standard C Library getenv() function"
-	 ^ self ffiCall: #( int unsetenv (String string) ) module: LibC
+	 ^ self ffiCall: #( int unsetenv #(String string) ) module: LibC
 ]

--- a/src/System-OSEnvironments/Win32Environment.class.st
+++ b/src/System-OSEnvironments/Win32Environment.class.st
@@ -48,7 +48,7 @@ Win32Environment >> at: aKey put: aValue [
 
 { #category : #private }
 Win32Environment >> environmentStrings [
-	 ^ self ffiCall: #( void * GetEnvironmentStrings () )
+	 ^ self ffiCall: #( void #* GetEnvironmentStrings #() )
 ]
 
 { #category : #private }
@@ -98,7 +98,7 @@ Win32Environment >> keysAndValuesDo: aBlock [
 { #category : #private }
 Win32Environment >> removeEnvironmentVariable: nameString [
 
-	 ^ self ffiCall: #( int SetEnvironmentVariableW ( Win32WideString nameString, 0 ) )
+	 ^ self ffiCall: #( int SetEnvironmentVariableW #( Win32WideString nameString #, 0 ) )
 ]
 
 { #category : #accessing }
@@ -119,12 +119,12 @@ Win32Environment >> setEnv: nameString value: valueString [
 	"This method calls the the platform specific set environment routine"
 
 	^ self
-		ffiCall: #(int SetEnvironmentVariableA #(String nameString , String valueString))
+		ffiCall: #(int SetEnvironmentVariableA #(String nameString #, String valueString))
 		module: #Kernel32
 ]
 
 { #category : #private }
 Win32Environment >> setEnvironmentVariable: nameString value: valueString [
 
-	 ^ self ffiCall: #( int SetEnvironmentVariableW ( Win32WideString nameString, Win32WideString valueString ) )
+	 ^ self ffiCall: #( int SetEnvironmentVariableW #( Win32WideString nameString #, Win32WideString valueString ) )
 ]

--- a/src/System-Platforms/WinPlatform.class.st
+++ b/src/System-Platforms/WinPlatform.class.st
@@ -62,7 +62,7 @@ WinPlatform >> ffiLibraryName [
 { #category : #'environment-variables' }
 WinPlatform >> getEnvironmentVariable: lpName into: lpBuffer size: nSize [
 	"Primitive to obtain an environment variable using windows Wide Strings"
-	^ self ffiCall: #(ulong GetEnvironmentVariableW (Win32WideString lpName, Win32WideString  lpBuffer, ulong nSize))
+	^ self ffiCall: #(ulong GetEnvironmentVariableW #(Win32WideString lpName #,  Win32WideString  lpBuffer #,  ulong nSize))
 ]
 
 { #category : #accessing }
@@ -95,7 +95,7 @@ WinPlatform >> keyForValue: aKeyValue [
 { #category : #accessing }
 WinPlatform >> lastError [
 
-	^ self ffiCall: #(ulong GetLastError())
+	^ self ffiCall: #(ulong GetLastError #())
 ]
 
 { #category : #accessing }
@@ -112,13 +112,13 @@ WinPlatform >> menuShortcutString [
 { #category : #'string-manipulation' }
 WinPlatform >> multiByteToWideCharacterCodepage: codepage flags: flags input: input inputLen: inputLen output: output outputLen: outputLen [
 
-	^self ffiCall: #(int MultiByteToWideChar(uint codepage, ulong flags, String input, int inputLen, Win32WideString output, int outputLen ))
+	^self ffiCall: #(int MultiByteToWideChar #(uint codepage #,  ulong flags #,  String input #,  int inputLen #,  Win32WideString output #,  int outputLen ))
 ]
 
 { #category : #'environment-variables' }
 WinPlatform >> setEnvironmentVariable: nameString value: valueString [
 
-	 ^ self ffiCall: #( int SetEnvironmentVariableW ( Win32WideString nameString, Win32WideString valueString ) )
+	 ^ self ffiCall: #( int SetEnvironmentVariableW #( Win32WideString nameString #,  Win32WideString valueString ) )
 ]
 
 { #category : #accessing }
@@ -135,13 +135,13 @@ WinPlatform >> virtualKey: virtualKeyCode [
 
 { #category : #'string-manipulation' }
 WinPlatform >> wideCharacterToMultiByteCodepage: codepage flags: flags input: input inputLen: inputLen output: output outputLen: outputLen [
-	^self ffiCall: #(int WideCharToMultiByte(uint codepage,
-    ulong flags,
-    Win32WideString input,
-    int inputLen,
-    String output,
-    int outputLen,
-    0,
+	^self ffiCall: #(int WideCharToMultiByte #(uint codepage #,
+    ulong flags #,
+    Win32WideString input #,
+    int inputLen #,
+    String output #,
+    int outputLen #,
+    0 #,
     0
  ))
 ]

--- a/src/UnifiedFFI-Tests/FFICalloutTests.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutTests.class.st
@@ -93,16 +93,16 @@ FFICalloutTests >> testParseOptions [
 	
 	generator parseOptions: #(optStringOrNil).
 	self assert: (generator optionAt: #optStringOrNil).
-	generator parseOptions: #(- optStringOrNil).
+	generator parseOptions: #(#- optStringOrNil).
 	self deny: (generator optionAt: #optStringOrNil).
 	
 	"Lets move on to something a bit more advanced..."
 	self deny: (generator optionAt: #optNotThere).
-	generator parseOptions: #(+ optEncoding: utf8 optStringOrNil  - optNotThere).
+	generator parseOptions: #(#+ optEncoding: utf8 optStringOrNil  - optNotThere).
 	self assert: (generator optionAt: #optEncoding) equals: #utf8.
 	self assert: (generator optionAt: #optStringOrNil).
 	
-	generator parseOptions: #(- optEncoding).
+	generator parseOptions: #(#- optEncoding).
 	self deny: (generator optionAt: #optEncoding)
 	
 	

--- a/src/UnifiedFFI/FFICallback.class.st
+++ b/src/UnifiedFFI/FFICallback.class.st
@@ -61,7 +61,7 @@ FFICallback class >> forAddress: address [
 { #category : #'private primitives' }
 FFICallback class >> primQsort: array with: count with: size with: compare [
 	self
-		ffiCall: #(void qsort (FFIExternalArray array, size_t count, size_t size, FFICallback compare)) 
+		ffiCall: #(void qsort #(FFIExternalArray array #, size_t count #, size_t size #, FFICallback compare)) 
 		module: LibC
 ]
 

--- a/src/UnifiedFFI/FFICallbackFunctionResolution.class.st
+++ b/src/UnifiedFFI/FFICallbackFunctionResolution.class.st
@@ -17,7 +17,7 @@ callAbsoluteMethod
 	self absolute: 42.0.
 
 absolute: aNumber
-	self ffiCall: #(double absolute (double aNumber)) options: #(+optCallbackCall)	
+	self ffiCall: #(double absolute #(double aNumber)) options: #(#+ optCallbackCall)	
 
 "
 Class {

--- a/src/UnifiedFFI/FFICallout.class.st
+++ b/src/UnifiedFFI/FFICallout.class.st
@@ -291,7 +291,7 @@ FFICallout >> options: anObject [
 FFICallout >> parseOptions: optionsArray [
 	"parse an array, which is a sequence of options in a form of: 
 	
-	#( + option1 option2 option3: param3  - option5 -option6: ... )
+	#( #+ option1 option2 option3: param3  - option5 -option6: ... )
 	
 	each time the #+ is seen, the options which follow it will be subject for inclusion
 	and, correspondingly, if #- seen, then they will be excluded	.

--- a/src/UnifiedFFI/FFIConstantHandle.class.st
+++ b/src/UnifiedFFI/FFIConstantHandle.class.st
@@ -11,7 +11,7 @@ User32 class>>initialize
 	HWND := #FFIConstantHandle.
 
 User32 class>>getActiveWindow
-	^ self ffiCall: #(HWND GetActiveWindow()) module: 'User32.dll'
+	^ self ffiCall: #(HWND GetActiveWindow #()) module: 'User32.dll'
 ]]]
 "
 Class {

--- a/src/UnifiedFFI/FFIExternalObject.class.st
+++ b/src/UnifiedFFI/FFIExternalObject.class.st
@@ -16,7 +16,7 @@ here, assume that someExternalFunction() returns some handle (or pointer) to som
 When used as argument type, the value, which is used to pass to the external function is value held in my handle instance variable:
 
 MyExternalObject>>compareWith: anotherExternalObject
-   ^ self ffiCall: #( void compare ( self , MyExternalObject anotherExternalObject))
+   ^ self ffiCall: #( void compare #( self #, MyExternalObject anotherExternalObject))
 
 The main advantage of using ==FFIExternalObject== subclass as a type name for arguments is that it provides type safety by checking the incoming argument, that it is an instance of your class, and nothing else. If not, the primitive will fail without calling the external function.
 

--- a/src/UnifiedFFI/FFIExternalType.class.st
+++ b/src/UnifiedFFI/FFIExternalType.class.st
@@ -259,8 +259,8 @@ FFIExternalType >> needsArityPacking [
 	"Regular types needs to be ''rolled'' if they are passed as pointers to its calling functions. 
 	 For example, executing consecutivelly this (simplified) two functions: 
 	 [[[
-	 	time := self ffiCall: #(time_t time(time_t* t) ). ""this will answer a long.""
-	 	self ffiCall: #(tm* localtime(time_t* time) ) ""this requires a pointer to time."" 
+	 	time := self ffiCall: #(time_t time #(time_t #* t) ). ""this will answer a long.""
+	 	self ffiCall: #(tm #* localtime #(time_t #* time) ) ""this requires a pointer to time."" 
 	 ]]]
 	 This mechanism allows UnifiedFFI to perform the roll of this pointers for you (it performs 
 	 the equivallent of ==&time== in C). 
@@ -278,7 +278,7 @@ FFIExternalType >> needsArityUnpacking [
 	 from C functions).
 	 For instance, in case you have functions with the form:
 	 [[[ 
-		self ffiCall: #(void getPoint( double *x, double *y)) 
+		self ffiCall: #(void getPoint #( double #* x, double #* y)) 
 	 ]]]
 	 you cannot use instances of Float (since they are immutable in Pharo)... in that case you will
 	 need to use an FFIExternalValueHolder."

--- a/src/UnifiedFFI/FFIExternalValueHolder.class.st
+++ b/src/UnifiedFFI/FFIExternalValueHolder.class.st
@@ -31,7 +31,7 @@ and then use it in function signature:
 
 [ [ [ 
 getFoo: value
-  ^ self ffiCall: #(void getFoo ( SomeType *  value ))
+  ^ self ffiCall: #(void getFoo #( SomeType #* value ))
 ] ] ]
 
 and call it like: 

--- a/src/UnifiedFFI/LibC.class.st
+++ b/src/UnifiedFFI/LibC.class.st
@@ -58,14 +58,14 @@ LibC class >> system: command [
 LibC >> currentProcessId [
 	"Returns the process identifier (PID) of the calling process."
  
-	 ^self ffiCall: #(int getpid(void)) 
+	 ^self ffiCall: #(int getpid #(void)) 
 ]
 
 { #category : #'api - accessing' }
 LibC >> fgetc: stream [
 	"Get character from stream."
 	 
-	 ^self ffiCall: #(int* fgetc(ExternalAddress* stream))
+	 ^self ffiCall: #(int #* fgetc #(ExternalAddress #* stream))
 ]
 
 { #category : #'private - accessing' }
@@ -75,14 +75,14 @@ LibC >> macModuleName [
 
 { #category : #'api - misc' }
 LibC >> memCopy: src to: dest size: n [
-	^ self ffiCall: #(void *memcpy(void *dest, const void *src, size_t n))
+	^ self ffiCall: #(void #* memcpy #(void #* dest #, const void #* src #, size_t n))
 ]
 
 { #category : #'api - processes' }
 LibC >> parentProcessId [
 	"Returns the process ID of the parent of the calling process."
 	 
-	 ^self ffiCall: #(int getppid(void))
+	 ^self ffiCall: #(int getppid #(void))
 ]
 
 { #category : #'api - piping' }
@@ -126,7 +126,7 @@ LibC >> runCommand: cmd [
 
 { #category : #'api - misc' }
 LibC >> system: command [
-	^ self ffiCall: #(int system #(char * command))
+	^ self ffiCall: #(int system #(char #* command))
 ]
 
 { #category : #'private - accessing' }

--- a/src/UnifiedFFI/UnixDynamicLoader.class.st
+++ b/src/UnifiedFFI/UnixDynamicLoader.class.st
@@ -15,7 +15,7 @@ UnixDynamicLoader class >> isAvailable [
 
 { #category : #misc }
 UnixDynamicLoader >> lastError [
-	^ self ffiCall: #(String dlerror(void))
+	^ self ffiCall: #(String dlerror #(void))
 ]
 
 { #category : #misc }
@@ -25,11 +25,11 @@ UnixDynamicLoader >> loadLibrary: path [
 
 { #category : #misc }
 UnixDynamicLoader >> loadLibrary: filename flag: flag [
-	^ self ffiCall: #(void *dlopen(const char *filename, int flag))
+	^ self ffiCall: #(void #* dlopen #(const char #* filename #, int flag))
 ]
 
 { #category : #misc }
 UnixDynamicLoader >> loadSymbolFrom: handle name: symbol [
-	^ self ffiCall: #(void *dlsym(void *handle, String symbol))
+	^ self ffiCall: #(void #* dlsym #(void #* handle #, String symbol))
 
 ]

--- a/src/UnifiedFFI/WindowsDynamicLoader.class.st
+++ b/src/UnifiedFFI/WindowsDynamicLoader.class.st
@@ -14,17 +14,17 @@ WindowsDynamicLoader class >> isAvailable [
 
 { #category : #misc }
 WindowsDynamicLoader >> lastError [
-	^ self ffiCall: #(int32 GetLastError(void))
+	^ self ffiCall: #(int32 GetLastError #(void))
 ]
 
 { #category : #misc }
 WindowsDynamicLoader >> loadLibrary: lpFileName [
-	^ self ffiCall: #(void *LoadLibrary(String lpFileName))
+	^ self ffiCall: #(void #* LoadLibrary #(String lpFileName))
 ]
 
 { #category : #misc }
 WindowsDynamicLoader >> loadSymbolFrom: hModule name: lpProcName [
-	^ self ffiCall: #(void *GetProcAddress(void *hModule, String lpProcName))
+	^ self ffiCall: #(void #* GetProcAddress #(void #* hModule #, String lpProcName))
 
 ]
 


### PR DESCRIPTION
While Pharo recognizes punctuation characters (like + and -) to be symbols most of the image makes the array element explicit with the # symbol. This makes it easier to read in other dialects.