### PR TITLE
Use accessors rather than direct references for Pragma.selector

### DIFF
--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -113,7 +113,7 @@ Pragma >> = aPragma [
 { #category : #comparing }
 Pragma >> analogousCodeTo: anObject [ 
 	^self class == anObject class
-	  and: [selector == anObject selector
+	  and: [self selector == anObject selector
 	  and: [arguments = anObject arguments]]
 ]
 
@@ -138,7 +138,7 @@ Pragma >> arguments: anArray [
 
 { #category : #testing }
 Pragma >> hasLiteral: aLiteral [
-	^selector == aLiteral 
+	^self selector == aLiteral 
 	   or: [arguments hasLiteral: aLiteral]
 ]
 
@@ -146,7 +146,7 @@ Pragma >> hasLiteral: aLiteral [
 Pragma >> hasLiteralSuchThat: aBlock [
 	"Answer true if litBlock returns true for any literal in the receiver, even if embedded in further array structure.
 	 This method is only intended for private use by CompiledMethod hasLiteralSuchThat:"
-	^(aBlock value: selector)
+	^(aBlock value: self selector)
 	   or: [arguments hasLiteralSuchThat: aBlock]
 ]
 

--- a/src/Metacello-Bitbucket/MCBitbucketRepository.class.st
+++ b/src/Metacello-Bitbucket/MCBitbucketRepository.class.st
@@ -63,6 +63,6 @@ MCBitbucketRepository >> normalizeTagsData: jsonObject [
 ]
 
 { #category : #private }
-MCBitbucketRepository >> projectTagsUrlFor: projectPath [
-  ^ 'https://bitbucket.org/api/1.0/repositories/' , projectPath , '/tags'
+MCBitbucketRepository >> projectTagsUrlFor: projectPath2 [
+  ^ 'https://bitbucket.org/api/1.0/repositories/' , projectPath2 , '/tags'
 ]

--- a/src/Metacello-GitHub/MCGitHubRepository.class.st
+++ b/src/Metacello-GitHub/MCGitHubRepository.class.st
@@ -142,6 +142,6 @@ MCGitHubRepository >> normalizeTagsData: jsonObject [
 ]
 
 { #category : #private }
-MCGitHubRepository >> projectTagsUrlFor: projectPath [
-  ^ 'https://api.github.com/repos/' , projectPath , '/tags'
+MCGitHubRepository >> projectTagsUrlFor: projectPath2 [
+  ^ 'https://api.github.com/repos/' , projectPath2 , '/tags'
 ]

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -261,9 +261,9 @@ MCFileTreeStCypressReader >> methodSelectorFor: source [
 
 { #category : #accessing }
 MCFileTreeStCypressReader >> packageNameFromPackageDirectory [
-    | filename |
-    filename := self fileUtils directoryName: packageDirectory.
-    ^ filename copyFrom: 1 to: (filename lastIndexOf: $.) - 1
+    | filename2 |
+    filename2 := self fileUtils directoryName: packageDirectory.
+    ^ filename2 copyFrom: 1 to: (filename2 lastIndexOf: $.) - 1
 ]
 
 { #category : #validation }


### PR DESCRIPTION
GemStone doesn't have 'selector' as an instance variable and it would be easier for me to port the class if I have to change only two methods instead of five. But if there is a reason to prefer direct variable accesses, that's fine as well. (Note that I'm not arguing against direct access in general, just in this case!)