### PR TITLE
3577-GLMRubricExample-presentation-has-unnecessary-tempvar-seg

### DIFF
--- a/src/Glamour-Rubric-Presentations/GLMSimpleRubricExample.class.st
+++ b/src/Glamour-Rubric-Presentations/GLMSimpleRubricExample.class.st
@@ -11,7 +11,7 @@ Class {
 GLMSimpleRubricExample >> presentation [
 	^ GLMCompositePresentation new
 		with: [ :a | 
-			| t seg |
+			| t |
 			t := a text.
 			t withLineNumbers: true.
 			t withAnnotation: true.


### PR DESCRIPTION
Remove unnecessary tempvar seg from GLMSimpleRubricExample