### PR TITLE
3679-Regression-with-drag-and-drop

### DIFF
--- a/src/Morphic-Base/DefaultExternalDropHandler.extension.st
+++ b/src/Morphic-Base/DefaultExternalDropHandler.extension.st
@@ -1,16 +1,17 @@
 Extension { #name : #DefaultExternalDropHandler }
 
 { #category : #'*Morphic-Base' }
-DefaultExternalDropHandler >> handle: dropStream in: pasteUp dropEvent: anEvent [ 
+DefaultExternalDropHandler >> handle: aFileReference in: pasteUp dropEvent: anEvent [
 	"the file was just droped, let's do our job"
+
 	| fileName services theOne |
-	fileName := dropStream name.
+	fileName := aFileReference fullName.
 	services := self servicesForFileNamed: fileName.
 
 	"no service, default behavior"
-	services isEmpty ifTrue: [
-			dropStream edit.
-			^ self].
+	services isEmpty
+		ifTrue: [ aFileReference inspect.
+			^ self ].
 	theOne := self chooseServiceFrom: services.
-	theOne ifNotNil: [theOne performServiceFor: dropStream]
+	theOne ifNotNil: [ theOne performServiceFor: aFileReference ]
 ]

--- a/src/Morphic-Core/PasteUpMorph.class.st
+++ b/src/Morphic-Core/PasteUpMorph.class.st
@@ -451,13 +451,16 @@ PasteUpMorph >> dropFiles: anEvent [
 	TODO:
 		- use a more general mechanism for figuring out what to do with the file (perhaps even offering a choice from a menu)
 		- remember the resource location or (when in browser) even the actual file handle"
-	| numFiles |	
+
+	| numFiles |
 	numFiles := anEvent contents.
-	
-	1 to: numFiles do: [:i | | aFileReference handler |
+	1 to: numFiles do: [ :i | 
+		| aFileReference handler |
 		aFileReference := FileReference requestDropReference: i.
-		handler := ExternalDropHandler lookupExternalDropHandler: aFileReference.
-		handler ifNotNil: [ aFileReference binaryWriteStreamDo: [ :stream | handler handle: stream in: self dropEvent: anEvent ] ]].
+		handler := ExternalDropHandler
+			lookupExternalDropHandler: aFileReference.
+		handler
+			ifNotNil: [ handler handle: aFileReference in: self dropEvent: anEvent ] ]
 ]
 
 { #category : #'Morphic-Base-Windows' }


### PR DESCRIPTION
handles file drop with a FileStream instead of a binary write stream. fixes https://github.com/pharo-project/pharo/issues/3679