### PR TITLE
Avoid Symbol as argument to #ifNotNil:

### DIFF
--- a/src/Hermes/HEInteger.class.st
+++ b/src/Hermes/HEInteger.class.st
@@ -28,5 +28,5 @@ HEInteger >> doReadFrom: aReader [
 	isNegative := aReader readByte = 1.
 	anArray := aReader readByteArray.
 
-	value := anArray asInteger *(isNegative ifTrue: -1 ifFalse: 1)
+	value := anArray asInteger * (isNegative ifTrue: [-1] ifFalse: [1])
 ]

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -270,7 +270,7 @@ Class >> category [
 			ifTrue: [ ^symbol ] ].
 	result := (self environment organization categoryOfElement: self name)
 		ifNil: [ #Unclassified ]
-		ifNotNil: #yourself.
+		ifNotNil: [:value | value].
 	self basicCategory: result.
 	
 	^ result

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -309,7 +309,7 @@ SourceFileArray >> finishedReading: aReadOnlyFileArray from: aQueue [
 SourceFileArray >> flushChangesFile [
 	
 	flushChanges ifFalse: [ ^ self ].
-	self changesFileStream ifNotNil: #flush.
+	self changesFileStream ifNotNil: [:stream | stream flush].
 ]
 
 { #category : #'public - file system operations' }


### PR DESCRIPTION
In some dialects, #ifNotNil: is an optimized selector that is expected to have a Block as an argument. It would make porting easier if this convention were followed in a couple places in Pharo.