### PR TITLE
3836-Read-only-image-mode

### DIFF
--- a/src/DeprecatedFileStream/FileStream.class.st
+++ b/src/DeprecatedFileStream/FileStream.class.st
@@ -291,6 +291,10 @@ FileStream class >> flushAndVoidStdioFiles [
 FileStream class >> forceNewFileNamed: fileName [
  	"Create a new file with the given name, and answer a stream opened for writing on that file. If the file already exists, delete it without asking before creating the new file."
 
+	DiskStore wantsReadOnly ifTrue: [ (CannotDeleteFileException new
+		messageText: 'Could not delete the old version of file ' , fileName) signal.
+		^ NullStream new ].
+
 	^self concreteStream forceNewFileNamed: fileName
 ]
 

--- a/src/DeprecatedFileStream/FileStream.class.st
+++ b/src/DeprecatedFileStream/FileStream.class.st
@@ -291,7 +291,7 @@ FileStream class >> flushAndVoidStdioFiles [
 FileStream class >> forceNewFileNamed: fileName [
  	"Create a new file with the given name, and answer a stream opened for writing on that file. If the file already exists, delete it without asking before creating the new file."
 
-	FileSystemStore wantsReadOnly ifTrue: [ ((CannotDeleteFileException fileName: fileName)
+	SessionManager default currentSession isReadOnlyAccessMode ifTrue: [ ((CannotDeleteFileException fileName: fileName)
 		messageText: 'Could not delete the old version of file ' , fileName) signal.
 		^ NullStream new ].
 

--- a/src/DeprecatedFileStream/FileStream.class.st
+++ b/src/DeprecatedFileStream/FileStream.class.st
@@ -291,7 +291,7 @@ FileStream class >> flushAndVoidStdioFiles [
 FileStream class >> forceNewFileNamed: fileName [
  	"Create a new file with the given name, and answer a stream opened for writing on that file. If the file already exists, delete it without asking before creating the new file."
 
-	DiskStore wantsReadOnly ifTrue: [ ((CannotDeleteFileException fileName: fileName)
+	FileSystemStore wantsReadOnly ifTrue: [ ((CannotDeleteFileException fileName: fileName)
 		messageText: 'Could not delete the old version of file ' , fileName) signal.
 		^ NullStream new ].
 

--- a/src/DeprecatedFileStream/FileStream.class.st
+++ b/src/DeprecatedFileStream/FileStream.class.st
@@ -291,7 +291,7 @@ FileStream class >> flushAndVoidStdioFiles [
 FileStream class >> forceNewFileNamed: fileName [
  	"Create a new file with the given name, and answer a stream opened for writing on that file. If the file already exists, delete it without asking before creating the new file."
 
-	DiskStore wantsReadOnly ifTrue: [ (CannotDeleteFileException new
+	DiskStore wantsReadOnly ifTrue: [ ((CannotDeleteFileException fileName: fileName)
 		messageText: 'Could not delete the old version of file ' , fileName) signal.
 		^ NullStream new ].
 

--- a/src/DeprecatedFileStream/MultiByteFileStream.class.st
+++ b/src/DeprecatedFileStream/MultiByteFileStream.class.st
@@ -561,6 +561,11 @@ MultiByteFileStream >> nextPutAll: aCollection [
 { #category : #'open/close' }
 MultiByteFileStream >> open: fileName forWrite: writeMode [ 
 	| result |
+
+	(writeMode and: [DiskStore wantsReadOnly]) 
+		ifTrue: [ (CannotDeleteFileException new
+			messageText: 'Attempt to open file ' , fileName, ' as wrtitable on read-only filesystem') signal. ].
+
 	result := super open: fileName forWrite: writeMode.
 	result ifNotNil: [
 			converter ifNil: [self converter: UTF8TextConverter new].

--- a/src/DeprecatedFileStream/MultiByteFileStream.class.st
+++ b/src/DeprecatedFileStream/MultiByteFileStream.class.st
@@ -563,7 +563,7 @@ MultiByteFileStream >> open: fileName forWrite: writeMode [
 	| result |
 
 	(writeMode and: [DiskStore wantsReadOnly]) 
-		ifTrue: [ (CannotDeleteFileException new
+		ifTrue: [ ((CannotDeleteFileException fileName: fileName)
 			messageText: 'Attempt to open file ' , fileName, ' as wrtitable on read-only filesystem') signal. ].
 
 	result := super open: fileName forWrite: writeMode.

--- a/src/DeprecatedFileStream/MultiByteFileStream.class.st
+++ b/src/DeprecatedFileStream/MultiByteFileStream.class.st
@@ -562,7 +562,7 @@ MultiByteFileStream >> nextPutAll: aCollection [
 MultiByteFileStream >> open: fileName forWrite: writeMode [ 
 	| result |
 
-	(writeMode and: [FileSystemStore wantsReadOnly]) 
+	(writeMode and: [SessionManager default currentSession isReadOnlyAccessMode]) 
 		ifTrue: [ ((CannotDeleteFileException fileName: fileName)
 			messageText: 'Attempt to open file ' , fileName, ' as wrtitable on read-only filesystem') signal. ].
 

--- a/src/DeprecatedFileStream/MultiByteFileStream.class.st
+++ b/src/DeprecatedFileStream/MultiByteFileStream.class.st
@@ -562,7 +562,7 @@ MultiByteFileStream >> nextPutAll: aCollection [
 MultiByteFileStream >> open: fileName forWrite: writeMode [ 
 	| result |
 
-	(writeMode and: [DiskStore wantsReadOnly]) 
+	(writeMode and: [FileSystemStore wantsReadOnly]) 
 		ifTrue: [ ((CannotDeleteFileException fileName: fileName)
 			messageText: 'Attempt to open file ' , fileName, ' as wrtitable on read-only filesystem') signal. ].
 

--- a/src/DeprecatedFileStream/StandardFileStream.class.st
+++ b/src/DeprecatedFileStream/StandardFileStream.class.st
@@ -82,6 +82,10 @@ StandardFileStream class >> forceNewFileNamed: fileName [
 	asking before creating the new file."
 	| dir  fullName f |
 	
+	DiskStore wantsReadOnly ifTrue: [ (CannotDeleteFileException new
+		messageText: 'Could not delete the old version of file ' , fileName) signal.
+		^ NullStream new ].
+	
 	fullName := self fullName: fileName.
 	(self isAFileNamed: fullName)
 		ifFalse: [f := self new open: fullName forWrite: true.
@@ -534,6 +538,8 @@ StandardFileStream >> open: fileName forWrite: writeMode [
 	"Open the file with the given name. If writeMode is true, allow writing, otherwise open the file in read-only mode."
 	| f |
 	f := fileName asVmPathName.
+	
+	(writeMode and: [ FileSystem disk isWritable not ]) ifTrue: [ ^ nil ].
 
 	fileID := StandardFileStream retryWithGC:[self primOpen: f writable: writeMode] 
 					until:[:id| id notNil] 

--- a/src/DeprecatedFileStream/StandardFileStream.class.st
+++ b/src/DeprecatedFileStream/StandardFileStream.class.st
@@ -82,7 +82,7 @@ StandardFileStream class >> forceNewFileNamed: fileName [
 	asking before creating the new file."
 	| dir  fullName f |
 	
-	FileSystemStore wantsReadOnly ifTrue: [ ((CannotDeleteFileException fileName: fileName)
+	SessionManager default currentSession isReadOnlyAccessMode ifTrue: [ ((CannotDeleteFileException fileName: fileName)
 		messageText: 'Could not delete the old version of file ' , fileName) signal.
 		^ NullStream new ].
 	

--- a/src/DeprecatedFileStream/StandardFileStream.class.st
+++ b/src/DeprecatedFileStream/StandardFileStream.class.st
@@ -82,7 +82,7 @@ StandardFileStream class >> forceNewFileNamed: fileName [
 	asking before creating the new file."
 	| dir  fullName f |
 	
-	DiskStore wantsReadOnly ifTrue: [ (CannotDeleteFileException new
+	DiskStore wantsReadOnly ifTrue: [ ((CannotDeleteFileException fileName: fileName)
 		messageText: 'Could not delete the old version of file ' , fileName) signal.
 		^ NullStream new ].
 	

--- a/src/DeprecatedFileStream/StandardFileStream.class.st
+++ b/src/DeprecatedFileStream/StandardFileStream.class.st
@@ -82,7 +82,7 @@ StandardFileStream class >> forceNewFileNamed: fileName [
 	asking before creating the new file."
 	| dir  fullName f |
 	
-	DiskStore wantsReadOnly ifTrue: [ ((CannotDeleteFileException fileName: fileName)
+	FileSystemStore wantsReadOnly ifTrue: [ ((CannotDeleteFileException fileName: fileName)
 		messageText: 'Could not delete the old version of file ' , fileName) signal.
 		^ NullStream new ].
 	

--- a/src/FileSystem-Core/FileSystem.class.st
+++ b/src/FileSystem-Core/FileSystem.class.st
@@ -66,6 +66,18 @@ FileSystem >> accessTimeOf: aResolvable [
 ]
 
 { #category : #public }
+FileSystem >> beReadOnly [
+
+	store := store asReadOnlyStore
+]
+
+{ #category : #public }
+FileSystem >> beWritable [
+
+	store := store asWritableStore
+]
+
+{ #category : #public }
 FileSystem >> binaryReadStreamOn: aResolvable [
 	"Resolve the argument into an absolute path and open a file handle on the file
 	at that path. Ask the handle to give us a read stream for reading the file."
@@ -796,6 +808,11 @@ FileSystem >> sizeOf: aResolvable [
 { #category : #accessing }
 FileSystem >> store [
 	^ store
+]
+
+{ #category : #accessing }
+FileSystem >> store: aFileSystemStore [
+	store := aFileSystemStore
 ]
 
 { #category : #converting }

--- a/src/FileSystem-Core/FileSystem.class.st
+++ b/src/FileSystem-Core/FileSystem.class.st
@@ -583,6 +583,12 @@ FileSystem >> isSymlink: aResolvable [
 ]
 
 { #category : #'public-testing' }
+FileSystem >> isWritable [ 
+
+	^ self store isWritable
+]
+
+{ #category : #'public-testing' }
 FileSystem >> isWritable: aResolvable [
 	"Resolve the argument, and answer true if the there is
 	a file that can be written to or directory that can be changed."

--- a/src/FileSystem-Core/FileSystemStore.class.st
+++ b/src/FileSystem-Core/FileSystemStore.class.st
@@ -29,6 +29,25 @@ FileSystemStore class >> separator [
 	self shouldBeImplemented
 ]
 
+{ #category : #public }
+FileSystemStore class >> wantsReadOnly [
+
+	"check if the image was started in the read-only mode"
+
+	| arguments | 
+	
+	arguments := Array
+		streamContents: [ :str | 
+			| arg i |
+			i := 0.
+			[ i > 998 or: [ (arg := Smalltalk argumentAt: i) isNil ] ]
+				whileFalse: [ 
+					str nextPut: arg.
+					i := i + 1 ] ].
+
+	^ arguments anySatisfy: [ :each | each = '--readOnlyMode' ]
+]
+
 { #category : #accessing }
 FileSystemStore >> accessTimeOf: aPath [
 	"Return the date of last access of the File described by aPath"

--- a/src/FileSystem-Core/FileSystemStore.class.st
+++ b/src/FileSystem-Core/FileSystemStore.class.st
@@ -29,25 +29,6 @@ FileSystemStore class >> separator [
 	self shouldBeImplemented
 ]
 
-{ #category : #public }
-FileSystemStore class >> wantsReadOnly [
-
-	"check if the image was started in the read-only mode"
-
-	| arguments | 
-	
-	arguments := Array
-		streamContents: [ :str | 
-			| arg i |
-			i := 0.
-			[ i > 998 or: [ (arg := Smalltalk argumentAt: i) isNil ] ]
-				whileFalse: [ 
-					str nextPut: arg.
-					i := i + 1 ] ].
-
-	^ arguments anySatisfy: [ :each | each = '--readOnlyMode' ]
-]
-
 { #category : #accessing }
 FileSystemStore >> accessTimeOf: aPath [
 	"Return the date of last access of the File described by aPath"

--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -140,23 +140,6 @@ DiskStore class >> startUp: resuming [
 ]
 
 { #category : #public }
-DiskStore class >> wantsReadOnly [
-
-	| arguments | 
-	
-	arguments := Array
-		streamContents: [ :str | 
-			| arg i |
-			i := 0.
-			[ i > 998 or: [ (arg := Smalltalk argumentAt: i) isNil ] ]
-				whileFalse: [ 
-					str nextPut: arg.
-					i := i + 1 ] ].
-
-	^ arguments anySatisfy: [ :each | each = '--readOnlyMode' ]
-]
-
-{ #category : #public }
 DiskStore class >> writableVariant [
 
 	"return a class variant for read-only store. It should be properly defined in my subclasses"

--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -17,9 +17,15 @@ Class {
 
 { #category : #current }
 DiskStore class >> activeClass [
-	self allSubclassesDo: [:ea | 
-		ea isActiveClass ifTrue: [^ ea]].
-	^ self
+
+	| writableClass |
+	
+	writableClass := writableClass := self allSubclasses detect: [:each | 
+		each isActiveClass ] ifNone: [ ^ self ].
+	
+	^ self wantsReadOnly 
+		ifFalse: [ writableClass]
+		ifTrue: [ writableClass readOnlyVariant ].
 ]
 
 { #category : #'system startup' }
@@ -131,6 +137,23 @@ DiskStore class >> startUp: resuming [
 	resuming 
 		ifTrue: [ self reset ].
 	DefaultWorkingDirectory := self defaultWorkingDirectory.
+]
+
+{ #category : #public }
+DiskStore class >> wantsReadOnly [
+
+	| arguments | 
+	
+	arguments := Array
+		streamContents: [ :str | 
+			| arg i |
+			i := 0.
+			[ i > 998 or: [ (arg := Smalltalk argumentAt: i) isNil ] ]
+				whileFalse: [ 
+					str nextPut: arg.
+					i := i + 1 ] ].
+
+	^ arguments anySatisfy: [ :each | each = '--readOnlyMode' ]
 ]
 
 { #category : #public }

--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -79,10 +79,28 @@ DiskStore class >> maxFileNameLength [
 	self subclassResponsibility 
 ]
 
+{ #category : #public }
+DiskStore class >> readOnlyVariant [
+
+	"return a class variant for read-only store. It should be properly defined in my subclasses"
+
+	^ self
+]
+
 { #category : #current }
 DiskStore class >> reset [
 	DefaultWorkingDirectory := nil.
 	CurrentFS := nil
+]
+
+{ #category : #current }
+DiskStore class >> resetAsReadOnly [
+	^ CurrentFS := FileSystem store: self activeClass readOnlyVariant createDefault
+]
+
+{ #category : #current }
+DiskStore class >> resetAsWritable [
+	^ CurrentFS := FileSystem store: self activeClass writableVariant createDefault
 ]
 
 { #category : #'system startup' }
@@ -97,6 +115,14 @@ DiskStore class >> startUp: resuming [
 	resuming 
 		ifTrue: [ self reset ].
 	DefaultWorkingDirectory := self defaultWorkingDirectory.
+]
+
+{ #category : #public }
+DiskStore class >> writableVariant [
+
+	"return a class variant for read-only store. It should be properly defined in my subclasses"
+
+	^ self
 ]
 
 { #category : #comparing }
@@ -487,6 +513,12 @@ DiskStore >> isSymlink: aPath [
 
 	aPath isRoot ifTrue: [ ^false ].
 	^File isSymlink: (self stringFromPath: aPath)
+]
+
+{ #category : #testing }
+DiskStore >> isWritable [
+
+	^ true
 ]
 
 { #category : #testing }

--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -102,27 +102,13 @@ DiskStore class >> reset [
 { #category : #current }
 DiskStore class >> resetAsReadOnly [
 
-	"Reset the disk store as read-only. Change indentity of the old store to utilize it in the old users"
-
-	| old |
-	
-	old := CurrentFS.
-	CurrentFS := FileSystem store: self activeClass readOnlyVariant createDefault.
-	old becomeForward: CurrentFS.
-	^ CurrentFS
+	self currentFileSystem beReadOnly
 ]
 
 { #category : #current }
 DiskStore class >> resetAsWritable [
 
-	"Reset the disk store as writable. Change indentity of the old store to utilize it in the old users"
-
-	| old |
-	
-	old := CurrentFS.
-	CurrentFS := FileSystem store: self activeClass writableVariant createDefault.
-	old becomeForward: CurrentFS.
-	^ CurrentFS
+	self currentFileSystem beWritable
 ]
 
 { #category : #'system startup' }
@@ -157,6 +143,18 @@ DiskStore >> accessTimeOf: aPath [
 	"Return the date of last access of the File described by aPath"
 
 	^DateAndTime fromSqueakTime: (File fileAttribute: (self stringFromPath: aPath) number: 9)
+]
+
+{ #category : #public }
+DiskStore >> asReadOnlyStore [
+
+	^ self class readOnlyVariant createDefault
+]
+
+{ #category : #public }
+DiskStore >> asWritableStore [
+
+	^ self class writableVariant createDefault
 ]
 
 { #category : #private }

--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -23,7 +23,7 @@ DiskStore class >> activeClass [
 	writableClass := writableClass := self allSubclasses detect: [:each | 
 		each isActiveClass ] ifNone: [ ^ self ].
 	
-	^ self wantsReadOnly 
+	^ SessionManager default currentSession isReadOnlyAccessMode
 		ifFalse: [ writableClass]
 		ifTrue: [ writableClass readOnlyVariant ].
 ]

--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -90,7 +90,7 @@ DiskStore class >> readOnlyVariant [
 
 	"return a class variant for read-only store. It should be properly defined in my subclasses"
 
-	^ self
+	^ self subclassResponsibility
 ]
 
 { #category : #current }

--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -95,12 +95,28 @@ DiskStore class >> reset [
 
 { #category : #current }
 DiskStore class >> resetAsReadOnly [
-	^ CurrentFS := FileSystem store: self activeClass readOnlyVariant createDefault
+
+	"Reset the disk store as read-only. Change indentity of the old store to utilize it in the old users"
+
+	| old |
+	
+	old := CurrentFS.
+	CurrentFS := FileSystem store: self activeClass readOnlyVariant createDefault.
+	old becomeForward: CurrentFS.
+	^ CurrentFS
 ]
 
 { #category : #current }
 DiskStore class >> resetAsWritable [
-	^ CurrentFS := FileSystem store: self activeClass writableVariant createDefault
+
+	"Reset the disk store as writable. Change indentity of the old store to utilize it in the old users"
+
+	| old |
+	
+	old := CurrentFS.
+	CurrentFS := FileSystem store: self activeClass writableVariant createDefault.
+	old becomeForward: CurrentFS.
+	^ CurrentFS
 ]
 
 { #category : #'system startup' }

--- a/src/FileSystem-Disk/MacStore.class.st
+++ b/src/FileSystem-Disk/MacStore.class.st
@@ -12,6 +12,12 @@ MacStore class >> isActiveClass [
 	^ Smalltalk os isMacOS
 ]
 
+{ #category : #current }
+MacStore class >> readOnlyVariant [
+
+	^ ReadOnlyMacStore
+]
+
 { #category : #public }
 MacStore >> mimeTypesAt: aPath [
 	"Return a list of MIME types applicable to the receiver. This default implementation uses the file name extension to figure out what we're looking at but specific subclasses may use other means of figuring out what the type of some file is. Some systems like the macintosh use meta data on the file to indicate data type"

--- a/src/FileSystem-Disk/ReadOnlyFileHandle.class.st
+++ b/src/FileSystem-Disk/ReadOnlyFileHandle.class.st
@@ -1,0 +1,33 @@
+"
+I am a file handle on a read-only store.
+"
+Class {
+	#name : #ReadOnlyFileHandle,
+	#superclass : #FileHandle,
+	#category : #'FileSystem-Disk-Base'
+}
+
+{ #category : #testing }
+ReadOnlyFileHandle >> isWritable [
+	^ false
+]
+
+{ #category : #testing }
+ReadOnlyFileHandle >> setReference: aReference writable: aBoolean [
+
+	reference := aReference resolve.
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt to open file ' , reference pathString, ' as writable on a read-only file system') signal.
+
+	writable := aBoolean
+]
+
+{ #category : #testing }
+ReadOnlyFileHandle >> truncateTo: anInteger [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt to truncate file ' , reference pathString, ' on a read-only file system') signal.
+
+	^ self
+]

--- a/src/FileSystem-Disk/ReadOnlyFileHandle.class.st
+++ b/src/FileSystem-Disk/ReadOnlyFileHandle.class.st
@@ -17,8 +17,9 @@ ReadOnlyFileHandle >> setReference: aReference writable: aBoolean [
 
 	reference := aReference resolve.
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt to open file ' , reference pathString, ' as writable on a read-only file system') signal.
+	aBoolean ifTrue: [ 
+		(ReadOnlyFileException new
+			messageText: 'Attempt to open file ' , reference pathString, ' as writable on a read-only file system') signal ].
 
 	writable := aBoolean
 ]

--- a/src/FileSystem-Disk/ReadOnlyFileHandle.class.st
+++ b/src/FileSystem-Disk/ReadOnlyFileHandle.class.st
@@ -18,8 +18,7 @@ ReadOnlyFileHandle >> setReference: aReference writable: aBoolean [
 	reference := aReference resolve.
 
 	aBoolean ifTrue: [ 
-		(ReadOnlyFileException new
-			messageText: 'Attempt to open file ' , reference pathString, ' as writable on a read-only file system') signal ].
+		ReadOnlyFileException signal: 'Attempt to open file ', reference pathString, ' as writable on a read-only file system' ].
 
 	writable := aBoolean
 ]
@@ -27,8 +26,7 @@ ReadOnlyFileHandle >> setReference: aReference writable: aBoolean [
 { #category : #testing }
 ReadOnlyFileHandle >> truncateTo: anInteger [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt to truncate file ' , reference pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt to truncate file ', reference pathString, ' on a read-only file system'.
 
 	^ self
 ]

--- a/src/FileSystem-Disk/ReadOnlyMacStore.class.st
+++ b/src/FileSystem-Disk/ReadOnlyMacStore.class.st
@@ -1,5 +1,5 @@
 "
-I'm a specific store for macOS file systems that allows only read-only access
+I'm a specific store for macOS file systems that allows only read-only access. All read-only DiskStore subclasses share the same behavior. Usage of traits would be appropriate here, but it is not used because the kernel should not contain traits.
 "
 Class {
 	#name : #ReadOnlyMacStore,

--- a/src/FileSystem-Disk/ReadOnlyMacStore.class.st
+++ b/src/FileSystem-Disk/ReadOnlyMacStore.class.st
@@ -78,6 +78,12 @@ ReadOnlyMacStore >> handleClass [
 ]
 
 { #category : #public }
+ReadOnlyMacStore >> isWritable [
+
+	^ false
+]
+
+{ #category : #public }
 ReadOnlyMacStore >> isWritable: aPath [
 
 	^ false

--- a/src/FileSystem-Disk/ReadOnlyMacStore.class.st
+++ b/src/FileSystem-Disk/ReadOnlyMacStore.class.st
@@ -1,0 +1,93 @@
+Class {
+	#name : #ReadOnlyMacStore,
+	#superclass : #MacStore,
+	#category : #'FileSystem-Disk-Store'
+}
+
+{ #category : #public }
+ReadOnlyMacStore class >> isActiveClass [
+
+	^ false
+]
+
+{ #category : #public }
+ReadOnlyMacStore class >> writableVariant [
+
+	^ MacStore
+]
+
+{ #category : #public }
+ReadOnlyMacStore >> basicOpen: aPath writable: aBoolean [
+
+	aBoolean ifTrue: [ 
+		(ReadOnlyFileException new
+			messageText: 'Attempt to open file ' , aPath pathString, ' as writable on a read-only file system') signal.
+		^ self ].
+		
+	^ super basicOpen: aPath writable: aBoolean. 
+]
+
+{ #category : #public }
+ReadOnlyMacStore >> createDirectory: path [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt crate directory ' , path pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]
+
+{ #category : #public }
+ReadOnlyMacStore >> delete: path [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt delete ' , path pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]
+
+{ #category : #public }
+ReadOnlyMacStore >> file: path posixPermissions: anInteger [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]
+
+{ #category : #public }
+ReadOnlyMacStore >> file: path symlinkUid: uidInteger gid: gidInteger [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]
+
+{ #category : #public }
+ReadOnlyMacStore >> file: path uid: uidInteger gid: gidInteger [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]
+
+{ #category : #public }
+ReadOnlyMacStore >> handleClass [
+	^ ReadOnlyFileHandle
+]
+
+{ #category : #public }
+ReadOnlyMacStore >> isWritable: aPath [
+
+	^ false
+]
+
+{ #category : #public }
+ReadOnlyMacStore >> rename: sourcePath to: destinationPath [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt to rename file ' , sourcePath pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]

--- a/src/FileSystem-Disk/ReadOnlyMacStore.class.st
+++ b/src/FileSystem-Disk/ReadOnlyMacStore.class.st
@@ -23,8 +23,7 @@ ReadOnlyMacStore class >> writableVariant [
 ReadOnlyMacStore >> basicOpen: aPath writable: aBoolean [
 
 	aBoolean ifTrue: [ 
-		(ReadOnlyFileException new
-			messageText: 'Attempt to open file ' , aPath pathString, ' as writable on a read-only file system') signal.
+		ReadOnlyFileException signal: 'Attempt to open file ', aPath pathString, ' as writable on a read-only file system'.
 		^ self ].
 		
 	^ super basicOpen: aPath writable: aBoolean. 
@@ -33,8 +32,7 @@ ReadOnlyMacStore >> basicOpen: aPath writable: aBoolean [
 { #category : #public }
 ReadOnlyMacStore >> createDirectory: path [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt crate directory ' , path pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt crate directory ', path pathString, ' on a read-only file system'.
 	
 	^ self 
 ]
@@ -42,8 +40,7 @@ ReadOnlyMacStore >> createDirectory: path [
 { #category : #public }
 ReadOnlyMacStore >> delete: path [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt delete ' , path pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt delete ', path pathString, ' on a read-only file system'.
 	
 	^ self 
 ]
@@ -51,8 +48,7 @@ ReadOnlyMacStore >> delete: path [
 { #category : #public }
 ReadOnlyMacStore >> file: path posixPermissions: anInteger [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt to modify file ', path pathString, ' on a read-only file system'.
 	
 	^ self 
 ]
@@ -60,8 +56,7 @@ ReadOnlyMacStore >> file: path posixPermissions: anInteger [
 { #category : #public }
 ReadOnlyMacStore >> file: path symlinkUid: uidInteger gid: gidInteger [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt to modify file ', path pathString, ' on a read-only file system'.
 	
 	^ self 
 ]
@@ -69,8 +64,7 @@ ReadOnlyMacStore >> file: path symlinkUid: uidInteger gid: gidInteger [
 { #category : #public }
 ReadOnlyMacStore >> file: path uid: uidInteger gid: gidInteger [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt to modify file ', path pathString, ' on a read-only file system'.
 	
 	^ self 
 ]
@@ -95,8 +89,7 @@ ReadOnlyMacStore >> isWritable: aPath [
 { #category : #public }
 ReadOnlyMacStore >> rename: sourcePath to: destinationPath [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt to rename file ' , sourcePath pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt to rename file ', sourcePath pathString, ' on a read-only file system'.
 	
 	^ self 
 ]

--- a/src/FileSystem-Disk/ReadOnlyMacStore.class.st
+++ b/src/FileSystem-Disk/ReadOnlyMacStore.class.st
@@ -1,3 +1,6 @@
+"
+I'm a specific store for macOS file systems that allows only read-only access
+"
 Class {
 	#name : #ReadOnlyMacStore,
 	#superclass : #MacStore,

--- a/src/FileSystem-Disk/ReadOnlyUnixStore.class.st
+++ b/src/FileSystem-Disk/ReadOnlyUnixStore.class.st
@@ -1,3 +1,6 @@
+"
+I'm a specific store for Unix file systems that allows only read-only access
+"
 Class {
 	#name : #ReadOnlyUnixStore,
 	#superclass : #UnixStore,

--- a/src/FileSystem-Disk/ReadOnlyUnixStore.class.st
+++ b/src/FileSystem-Disk/ReadOnlyUnixStore.class.st
@@ -1,5 +1,5 @@
 "
-I'm a specific store for Unix file systems that allows only read-only access
+I'm a specific store for Unix file systems that allows only read-only access. All read-only DiskStore subclasses share the same behavior. Usage of traits would be appropriate here, but it is not used because the kernel should not contain traits.
 "
 Class {
 	#name : #ReadOnlyUnixStore,

--- a/src/FileSystem-Disk/ReadOnlyUnixStore.class.st
+++ b/src/FileSystem-Disk/ReadOnlyUnixStore.class.st
@@ -23,8 +23,7 @@ ReadOnlyUnixStore class >> writableVariant [
 ReadOnlyUnixStore >> basicOpen: aPath writable: aBoolean [
 
 	aBoolean ifTrue: [ 
-		(ReadOnlyFileException new
-			messageText: 'Attempt to open file ' , aPath pathString, ' as writable on a read-only file system') signal.
+		ReadOnlyFileException signal: 'Attempt to open file ', aPath pathString, ' as writable on a read-only file system'.
 		^ self ].
 		
 	^ super basicOpen: aPath writable: aBoolean. 
@@ -33,8 +32,7 @@ ReadOnlyUnixStore >> basicOpen: aPath writable: aBoolean [
 { #category : #public }
 ReadOnlyUnixStore >> createDirectory: path [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt crate directory ' , path pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt crate directory ', path pathString, ' on a read-only file system'.
 	
 	^ self 
 ]
@@ -42,8 +40,7 @@ ReadOnlyUnixStore >> createDirectory: path [
 { #category : #public }
 ReadOnlyUnixStore >> delete: path [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt delete ' , path pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt delete ', path pathString, ' on a read-only file system'.
 	
 	^ self 
 ]
@@ -51,8 +48,7 @@ ReadOnlyUnixStore >> delete: path [
 { #category : #public }
 ReadOnlyUnixStore >> file: path posixPermissions: anInteger [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt to modify file ', path pathString, ' on a read-only file system'.
 	
 	^ self 
 ]
@@ -60,8 +56,7 @@ ReadOnlyUnixStore >> file: path posixPermissions: anInteger [
 { #category : #public }
 ReadOnlyUnixStore >> file: path symlinkUid: uidInteger gid: gidInteger [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt to modify file ', path pathString, ' on a read-only file system'.
 	
 	^ self 
 ]
@@ -69,8 +64,7 @@ ReadOnlyUnixStore >> file: path symlinkUid: uidInteger gid: gidInteger [
 { #category : #public }
 ReadOnlyUnixStore >> file: path uid: uidInteger gid: gidInteger [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt to modify file ', path pathString, ' on a read-only file system'.
 	
 	^ self 
 ]
@@ -95,8 +89,7 @@ ReadOnlyUnixStore >> isWritable: aPath [
 { #category : #public }
 ReadOnlyUnixStore >> rename: sourcePath to: destinationPath [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt to rename file ' , sourcePath pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt to rename file ' , sourcePath pathString, ' on a read-only file system'.
 	
 	^ self 
 ]

--- a/src/FileSystem-Disk/ReadOnlyUnixStore.class.st
+++ b/src/FileSystem-Disk/ReadOnlyUnixStore.class.st
@@ -1,0 +1,93 @@
+Class {
+	#name : #ReadOnlyUnixStore,
+	#superclass : #UnixStore,
+	#category : #'FileSystem-Disk-Store'
+}
+
+{ #category : #public }
+ReadOnlyUnixStore class >> isActiveClass [
+
+	^ false
+]
+
+{ #category : #public }
+ReadOnlyUnixStore class >> writableVariant [
+
+	^ UnixStore
+]
+
+{ #category : #public }
+ReadOnlyUnixStore >> basicOpen: aPath writable: aBoolean [
+
+	aBoolean ifTrue: [ 
+		(ReadOnlyFileException new
+			messageText: 'Attempt to open file ' , aPath pathString, ' as writable on a read-only file system') signal.
+		^ self ].
+		
+	^ super basicOpen: aPath writable: aBoolean. 
+]
+
+{ #category : #public }
+ReadOnlyUnixStore >> createDirectory: path [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt crate directory ' , path pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]
+
+{ #category : #public }
+ReadOnlyUnixStore >> delete: path [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt delete ' , path pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]
+
+{ #category : #public }
+ReadOnlyUnixStore >> file: path posixPermissions: anInteger [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]
+
+{ #category : #public }
+ReadOnlyUnixStore >> file: path symlinkUid: uidInteger gid: gidInteger [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]
+
+{ #category : #public }
+ReadOnlyUnixStore >> file: path uid: uidInteger gid: gidInteger [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]
+
+{ #category : #public }
+ReadOnlyUnixStore >> handleClass [
+	^ ReadOnlyFileHandle
+]
+
+{ #category : #public }
+ReadOnlyUnixStore >> isWritable: aPath [
+
+	^ false
+]
+
+{ #category : #public }
+ReadOnlyUnixStore >> rename: sourcePath to: destinationPath [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt to rename file ' , sourcePath pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]

--- a/src/FileSystem-Disk/ReadOnlyUnixStore.class.st
+++ b/src/FileSystem-Disk/ReadOnlyUnixStore.class.st
@@ -78,6 +78,12 @@ ReadOnlyUnixStore >> handleClass [
 ]
 
 { #category : #public }
+ReadOnlyUnixStore >> isWritable [
+
+	^ false
+]
+
+{ #category : #public }
 ReadOnlyUnixStore >> isWritable: aPath [
 
 	^ false

--- a/src/FileSystem-Disk/ReadOnlyWindowsStore.class.st
+++ b/src/FileSystem-Disk/ReadOnlyWindowsStore.class.st
@@ -81,6 +81,12 @@ ReadOnlyWindowsStore >> handleClass [
 ]
 
 { #category : #public }
+ReadOnlyWindowsStore >> isWritable [
+
+	^ false
+]
+
+{ #category : #public }
 ReadOnlyWindowsStore >> isWritable: aPath [
 
 	^ false

--- a/src/FileSystem-Disk/ReadOnlyWindowsStore.class.st
+++ b/src/FileSystem-Disk/ReadOnlyWindowsStore.class.st
@@ -23,8 +23,7 @@ ReadOnlyWindowsStore class >> writableVariant [
 ReadOnlyWindowsStore >> basicOpen: aPath writable: aBoolean [
 
 	aBoolean ifTrue: [ 
-		(ReadOnlyFileException new
-			messageText: 'Attempt to open file ' , aPath pathString, ' as writable on a read-only file system') signal.
+		ReadOnlyFileException signal: 'Attempt to open file ' , aPath pathString, ' as writable on a read-only file system'.
 		^ self ].
 		
 	^ super basicOpen: aPath writable: aBoolean. 
@@ -33,8 +32,7 @@ ReadOnlyWindowsStore >> basicOpen: aPath writable: aBoolean [
 { #category : #public }
 ReadOnlyWindowsStore >> createDirectory: path [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt crate directory ' , path pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt crate directory ', path pathString, ' on a read-only file system'.
 	
 	^ self 
 ]
@@ -42,8 +40,7 @@ ReadOnlyWindowsStore >> createDirectory: path [
 { #category : #public }
 ReadOnlyWindowsStore >> delete: path [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt delete ' , path pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt delete ', path pathString, ' on a read-only file system'.
 	
 	^ self 
 ]
@@ -51,8 +48,7 @@ ReadOnlyWindowsStore >> delete: path [
 { #category : #public }
 ReadOnlyWindowsStore >> file: path posixPermissions: anInteger [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt to modify file ', path pathString, ' on a read-only file system'.
 	
 	^ self 
 ]
@@ -60,8 +56,7 @@ ReadOnlyWindowsStore >> file: path posixPermissions: anInteger [
 { #category : #public }
 ReadOnlyWindowsStore >> file: path symlinkUid: uidInteger gid: gidInteger [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt to modify file ', path pathString, ' on a read-only file system'.
 	
 	^ self 
 ]
@@ -69,8 +64,7 @@ ReadOnlyWindowsStore >> file: path symlinkUid: uidInteger gid: gidInteger [
 { #category : #public }
 ReadOnlyWindowsStore >> file: path uid: uidInteger gid: gidInteger [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt to modify file ', path pathString, ' on a read-only file system'.
 	
 	^ self 
 ]
@@ -95,8 +89,7 @@ ReadOnlyWindowsStore >> isWritable: aPath [
 { #category : #public }
 ReadOnlyWindowsStore >> rename: sourcePath to: destinationPath [
 
-	(ReadOnlyFileException new
-		messageText: 'Attempt to rename file ' , sourcePath pathString, ' on a read-only file system') signal.
+	ReadOnlyFileException signal: 'Attempt to rename file ', sourcePath pathString, ' on a read-only file system'.
 	
 	^ self 
 ]

--- a/src/FileSystem-Disk/ReadOnlyWindowsStore.class.st
+++ b/src/FileSystem-Disk/ReadOnlyWindowsStore.class.st
@@ -1,0 +1,96 @@
+"
+a Windows store that allows only read-only access
+"
+Class {
+	#name : #ReadOnlyWindowsStore,
+	#superclass : #WindowsStore,
+	#category : #'FileSystem-Disk-Store'
+}
+
+{ #category : #public }
+ReadOnlyWindowsStore class >> isActiveClass [
+
+	^ false
+]
+
+{ #category : #public }
+ReadOnlyWindowsStore class >> writableVariant [
+
+	^ WindowsStore
+]
+
+{ #category : #public }
+ReadOnlyWindowsStore >> basicOpen: aPath writable: aBoolean [
+
+	aBoolean ifTrue: [ 
+		(ReadOnlyFileException new
+			messageText: 'Attempt to open file ' , aPath pathString, ' as writable on a read-only file system') signal.
+		^ self ].
+		
+	^ super basicOpen: aPath writable: aBoolean. 
+]
+
+{ #category : #public }
+ReadOnlyWindowsStore >> createDirectory: path [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt crate directory ' , path pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]
+
+{ #category : #public }
+ReadOnlyWindowsStore >> delete: path [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt delete ' , path pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]
+
+{ #category : #public }
+ReadOnlyWindowsStore >> file: path posixPermissions: anInteger [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]
+
+{ #category : #public }
+ReadOnlyWindowsStore >> file: path symlinkUid: uidInteger gid: gidInteger [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]
+
+{ #category : #public }
+ReadOnlyWindowsStore >> file: path uid: uidInteger gid: gidInteger [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt to modify file ' , path pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]
+
+{ #category : #public }
+ReadOnlyWindowsStore >> handleClass [
+	^ ReadOnlyFileHandle
+]
+
+{ #category : #public }
+ReadOnlyWindowsStore >> isWritable: aPath [
+
+	^ false
+]
+
+{ #category : #public }
+ReadOnlyWindowsStore >> rename: sourcePath to: destinationPath [
+
+	(ReadOnlyFileException new
+		messageText: 'Attempt to rename file ' , sourcePath pathString, ' on a read-only file system') signal.
+	
+	^ self 
+]

--- a/src/FileSystem-Disk/ReadOnlyWindowsStore.class.st
+++ b/src/FileSystem-Disk/ReadOnlyWindowsStore.class.st
@@ -1,5 +1,5 @@
 "
-a Windows store that allows only read-only access
+I'm a specific store for Windows file systems that allows only read-only access
 "
 Class {
 	#name : #ReadOnlyWindowsStore,

--- a/src/FileSystem-Disk/ReadOnlyWindowsStore.class.st
+++ b/src/FileSystem-Disk/ReadOnlyWindowsStore.class.st
@@ -1,5 +1,5 @@
 "
-I'm a specific store for Windows file systems that allows only read-only access
+I'm a specific store for Windows file systems that allows only read-only access. All read-only DiskStore subclasses share the same behavior. Usage of traits would be appropriate here, but it is not used because the kernel should not contain traits.
 "
 Class {
 	#name : #ReadOnlyWindowsStore,

--- a/src/FileSystem-Disk/UnixStore.class.st
+++ b/src/FileSystem-Disk/UnixStore.class.st
@@ -30,6 +30,12 @@ UnixStore class >> maxFileNameLength [
 ]
 
 { #category : #public }
+UnixStore class >> readOnlyVariant [
+
+	^ ReadOnlyUnixStore
+]
+
+{ #category : #public }
 UnixStore class >> separator [ 
 	^ $:
 ]

--- a/src/FileSystem-Disk/WindowsStore.class.st
+++ b/src/FileSystem-Disk/WindowsStore.class.st
@@ -30,6 +30,12 @@ WindowsStore class >> maxFileNameLength [
 ]
 
 { #category : #accessing }
+WindowsStore class >> readOnlyVariant [
+
+	^ ReadOnlyWindowsStore
+]
+
+{ #category : #accessing }
 WindowsStore class >> separator [ 
 	^ $\
 ]

--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -1118,14 +1118,9 @@ File >> checkDoesNotExist [
 { #category : #private }
 File >> checkWritableFilesystem [
 
-	"We need to check if the image is in the read-only mode. While this is a responsibility of
-	the disk FileSystemStore that may not be installed in the image, we need to check the class presence"
+	"We need to check if the image is in the read-only mode"
 
-	| fileSystemStore |
-	
-	fileSystemStore := self class environment at: #FileSystemStore ifAbsent: [ ^ self ].
-
-	fileSystemStore wantsReadOnly ifTrue: [ 
+	SessionManager default currentSession isReadOnlyAccessMode ifTrue: [ 
 		ReadOnlyFileException signal: 'Attempt to open file ', name, ' as writable on a read-only file system'].
 
 

--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -1092,6 +1092,11 @@ File >> basename [
 { #category : #'open/close' }
 File >> basicOpenForWrite: writeMode [ 
 	"Open the file with the given name. If writeMode is true, allow writing, otherwise open the file in read-only mode."
+	
+	(writeMode and: [ FileSystem disk isWritable not ]) ifTrue: [ 
+		(ReadOnlyFileException new
+			messageText: 'Attempt to open file ' , name, ' as writable on a read-only file system') signal].
+
 	^ self class
 		retryWithGC: [ self class open: name utf8Encoded writable: writeMode ]
 		until:[ :id | id notNil ] 

--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -1093,9 +1093,7 @@ File >> basename [
 File >> basicOpenForWrite: writeMode [ 
 	"Open the file with the given name. If writeMode is true, allow writing, otherwise open the file in read-only mode."
 	
-	(writeMode and: [ FileSystem disk isWritable not ]) ifTrue: [ 
-		(ReadOnlyFileException new
-			messageText: 'Attempt to open file ' , name, ' as writable on a read-only file system') signal].
+	writeMode ifTrue: [ self checkWritableFilesystem ].
 
 	^ self class
 		retryWithGC: [ self class open: name utf8Encoded writable: writeMode ]
@@ -1115,6 +1113,20 @@ File >> checkDoesNotExist [
 	"
 	self exists ifTrue: [
 		^ FileAlreadyExistsException signalOnFile: self ]
+]
+
+{ #category : #private }
+File >> checkWritableFilesystem [
+
+	"We need to check if the image is in the read-only mode. While this is a responsibility of
+	the disk FileSystem that may not be installed in the image, we need to do an ugly workaround
+	using #canUnderstand"
+
+	((FileSystem canUnderstand: #disk) and: [ FileSystem disk isWritable not ]) ifTrue: [ 
+		(ReadOnlyFileException new
+			messageText: 'Attempt to open file ' , name, ' as writable on a read-only file system') signal].
+
+
 ]
 
 { #category : #'open/close' }

--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -1122,7 +1122,7 @@ File >> checkWritableFilesystem [
 	the disk FileSystem that may not be installed in the image, we need to do an ugly workaround
 	using #respondsTo:"
 
-	((FileSystem respondsTo: #disk) and: [ FileSystem disk isWritable not ]) ifTrue: [ 
+	FileSystemStore wantsReadOnly ifTrue: [ 
 		ReadOnlyFileException signal: 'Attempt to open file ', name, ' as writable on a read-only file system'].
 
 

--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -1120,9 +1120,9 @@ File >> checkWritableFilesystem [
 
 	"We need to check if the image is in the read-only mode. While this is a responsibility of
 	the disk FileSystem that may not be installed in the image, we need to do an ugly workaround
-	using #canUnderstand"
+	using #respondsTo:"
 
-	((FileSystem canUnderstand: #disk) and: [ FileSystem disk isWritable not ]) ifTrue: [ 
+	((FileSystem respondsTo: #disk) and: [ FileSystem disk isWritable not ]) ifTrue: [ 
 		(ReadOnlyFileException new
 			messageText: 'Attempt to open file ' , name, ' as writable on a read-only file system') signal].
 

--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -1119,10 +1119,13 @@ File >> checkDoesNotExist [
 File >> checkWritableFilesystem [
 
 	"We need to check if the image is in the read-only mode. While this is a responsibility of
-	the disk FileSystem that may not be installed in the image, we need to do an ugly workaround
-	using #respondsTo:"
+	the disk FileSystemStore that may not be installed in the image, we need to check the class presence"
 
-	FileSystemStore wantsReadOnly ifTrue: [ 
+	| fileSystemStore |
+	
+	fileSystemStore := self class environment at: #FileSystemStore ifAbsent: [ ^ self ].
+
+	fileSystemStore wantsReadOnly ifTrue: [ 
 		ReadOnlyFileException signal: 'Attempt to open file ', name, ' as writable on a read-only file system'].
 
 

--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -1123,8 +1123,7 @@ File >> checkWritableFilesystem [
 	using #respondsTo:"
 
 	((FileSystem respondsTo: #disk) and: [ FileSystem disk isWritable not ]) ifTrue: [ 
-		(ReadOnlyFileException new
-			messageText: 'Attempt to open file ' , name, ' as writable on a read-only file system') signal].
+		ReadOnlyFileException signal: 'Attempt to open file ', name, ' as writable on a read-only file system'].
 
 
 ]

--- a/src/Files/ReadOnlyFileException.class.st
+++ b/src/Files/ReadOnlyFileException.class.st
@@ -1,0 +1,8 @@
+"
+I am raised on an attempt to write to a read-only file store.
+"
+Class {
+	#name : #ReadOnlyFileException,
+	#superclass : #FileException,
+	#category : #'Files-Core'
+}

--- a/src/Files/Stdio.class.st
+++ b/src/Files/Stdio.class.st
@@ -43,15 +43,13 @@ Stdio class >> cleanStdioHandles [
 
 { #category : #private }
 Stdio class >> createStdioFileFor: moniker [
-	^ [ self createWriteStreamBlock cull: moniker asString ]
+	^ [[ self createWriteStreamBlock cull: moniker asString ]
 		on: CannotDeleteFileException
 		do:
 			[ "HACK: if the image is opened a second time windows barks about the already opened locked file"
-			[ self createWriteStreamBlock
+			 self createWriteStreamBlock
 				cull: moniker asString , '_' , (Random new nextInt: SmallInteger maxVal) asString ]
-				on: FileException
-				do:
-					[ "Nothing, we do not have the rights to write and cannot suppose a dependency to the class MemoryFileSystemFile" ] ]
+	 ] on: FileException do: [ NullStream new ] 
 ]
 
 { #category : #accessing }

--- a/src/GT-InspectorExtensions-Core/VirtualMachine.extension.st
+++ b/src/GT-InspectorExtensions-Core/VirtualMachine.extension.st
@@ -5,15 +5,11 @@ VirtualMachine >> gtInspectorDetailsIn: composite [
 	<gtInspectorPresentationOrder: 0>
 	composite table
 		title: 'Details';
-		display: [ 
-			{ 
-				'VM directory' -> self vmDirectory asFileReference.
-				'VM build date' -> self buildDate.
-				'VM version' -> self version.
-				'Image directory' -> self imagePath asFileReference parent.
-				'Image version' -> self imageVersionNumber.
-
-			} ];
+		display: [ {('VM directory' -> self directory asFileReference).
+			('VM build date' -> self buildDate).
+			('VM version' -> self version).
+			('Image directory' -> self imagePath asFileReference parent).
+			('Image version' -> self imageVersionNumber)} ];
 		column: 'Property' evaluated: #key;
 		column: 'Value' evaluated: #value;
 		send: #value

--- a/src/GT-Playground/GTPlayBook.class.st
+++ b/src/GT-Playground/GTPlayBook.class.st
@@ -26,7 +26,7 @@ Class {
 GTPlayBook class >> cacheDirectory [
 	" lazy initialize the cache and always ensure its existence - especially while the image is running "
 	cacheDirectory ifNil: [ cacheDirectory := self defaultCacheDirectory ].
-	cacheDirectory fileSystem isWritable ifFalse: [ ^ nil ].
+	cacheDirectory fileSystem isWritable ifFalse: [ ^ cacheDirectory ].
 	^ cacheDirectory ensureCreateDirectory
 ]
 

--- a/src/GT-Playground/GTPlayBook.class.st
+++ b/src/GT-Playground/GTPlayBook.class.st
@@ -26,6 +26,7 @@ Class {
 GTPlayBook class >> cacheDirectory [
 	" lazy initialize the cache and always ensure its existence - especially while the image is running "
 	cacheDirectory ifNil: [ cacheDirectory := self defaultCacheDirectory ].
+	cacheDirectory fileSystem isWritable ifFalse: [ ^ nil ].
 	^ cacheDirectory ensureCreateDirectory
 ]
 

--- a/src/GT-Playground/GTPlayPageFilePersistence.class.st
+++ b/src/GT-Playground/GTPlayPageFilePersistence.class.st
@@ -6,7 +6,12 @@ Class {
 
 { #category : #private }
 GTPlayPageFilePersistence >> deleteFromFileSystem [
-	self fileReference ensureDelete
+
+	| aFileReference |
+	
+	aFileReference := self fileReference.
+	(aFileReference notNil and: [ aFileReference fileSystem isWritable ]) ifTrue: [ 
+		aFileReference ensureDelete ]
 ]
 
 { #category : #accessing }
@@ -21,6 +26,11 @@ GTPlayPageFilePersistence >> fileName [
 
 { #category : #'accessing-dynamic' }
 GTPlayPageFilePersistence >> fileReference [
+
+	self fileDirectory ifNil: [ 
+		"the directory was not created (read-only filesystem etc.)"
+		^ nil ].
+	
 	^ self fileDirectory / self fileName
 ]
 
@@ -33,8 +43,13 @@ GTPlayPageFilePersistence >> save [
 
 { #category : #private }
 GTPlayPageFilePersistence >> writeToFileSystem [
-	self fileReference writeStreamDo: [ :stream | 
-		stream 
-			truncate; 
-			nextPutAll: self page contentString ]
+
+	| aFileReference |
+	
+	aFileReference := self fileReference.
+	(aFileReference notNil and: [ aFileReference fileSystem isWritable ]) ifTrue: [
+		aFileReference writeStreamDo: [ :stream | 
+			stream 
+				truncate; 
+				nextPutAll: self page contentString ]]
 ]

--- a/src/GT-Playground/GTPlayPageFilePersistence.class.st
+++ b/src/GT-Playground/GTPlayPageFilePersistence.class.st
@@ -34,6 +34,16 @@ GTPlayPageFilePersistence >> fileReference [
 	^ self fileDirectory / self fileName
 ]
 
+{ #category : #'accessing-dynamic' }
+GTPlayPageFilePersistence >> fileReferenceOrNil [
+
+	self fileDirectory ifNil: [ 
+		"the directory was not created (read-only filesystem etc.)"
+		^ nil ].
+	
+	^ self fileDirectory / self fileName
+]
+
 { #category : #actions }
 GTPlayPageFilePersistence >> save [
 	self page content isEmpty
@@ -46,7 +56,7 @@ GTPlayPageFilePersistence >> writeToFileSystem [
 
 	| aFileReference |
 	
-	aFileReference := self fileReference.
+	aFileReference := self fileReferenceOrNil.
 	(aFileReference notNil and: [ aFileReference fileSystem isWritable ]) ifTrue: [
 		aFileReference writeStreamDo: [ :stream | 
 			stream 

--- a/src/Ombu/OmFileStore.class.st
+++ b/src/Ombu/OmFileStore.class.st
@@ -228,7 +228,10 @@ OmFileStore >> flushEntryBuffer [
 		| initialPosition initialLocalName fileStream |
 		self entryBuffer isEmpty ifTrue: [ ^self ].
 		
-		fileStream := ZnCharacterReadWriteStream on: fileReference binaryReadWriteStream encoding: #utf8.
+		[ fileStream := ZnCharacterReadWriteStream on: fileReference binaryReadWriteStream encoding: #utf8. ] on: ReadOnlyFileException do: [ :anException |
+			^ self
+		 ].	
+	
 		[ | anEntryWriter |
 			fileStream setToEnd.
 			

--- a/src/Ombu/OmSessionStore.class.st
+++ b/src/Ombu/OmSessionStore.class.st
@@ -218,6 +218,8 @@ OmSessionStore >> resetWithStoreNamed: newName [
 	fileReference exists ifTrue: [
 		FileExists signalWith: fileReference ].
 	
+	self directory fileSystem isWritable ifFalse: [ ^ self ].
+	
 	"Then, we can proceed."
 	currentSession := Smalltalk session.
 	currentImagePathString := self imagePathString.

--- a/src/System-BasicCommandLineHandler/BasicCommandLineHandler.class.st
+++ b/src/System-BasicCommandLineHandler/BasicCommandLineHandler.class.st
@@ -168,6 +168,9 @@ BasicCommandLineHandler >> handleArgument: aString [
 
 	aString = '--interactive'
 		ifTrue: [ ^ self noQuit ].
+
+	aString = '--readOnlyMode'
+		ifTrue: [ ^ self readOnlyMode ].
 	
 	"none of the previous options matched hence we output an error message"
 	self error.
@@ -255,6 +258,12 @@ BasicCommandLineHandler >> list [
 { #category : #commands }
 BasicCommandLineHandler >> noQuit [
 	"Nothing to be done, unlike the other commands the image continues running"
+]
+
+{ #category : #commands }
+BasicCommandLineHandler >> readOnlyMode [
+
+	"just eat the argument because it was processed with by the DiskStore startUp before"
 ]
 
 { #category : #password }

--- a/src/System-BasicCommandLineHandler/BasicCommandLineHandler.class.st
+++ b/src/System-BasicCommandLineHandler/BasicCommandLineHandler.class.st
@@ -125,6 +125,12 @@ BasicCommandLineHandler >> default [
 ]
 
 { #category : #commands }
+BasicCommandLineHandler >> disabledAccessMode [
+
+	"just eat the argument because it was processed with by the SessionAccessModeResolver before"
+]
+
+{ #category : #commands }
 BasicCommandLineHandler >> error [
 	self arguments size = 1
 		ifTrue:  [
@@ -169,8 +175,14 @@ BasicCommandLineHandler >> handleArgument: aString [
 	aString = '--interactive'
 		ifTrue: [ ^ self noQuit ].
 
-	aString = '--readOnlyMode'
-		ifTrue: [ ^ self readOnlyMode ].
+	aString = '--readWriteAccessMode'
+		ifTrue: [ ^ self readWriteAccessMode ].
+	aString = '--readOnlyAccessMode'
+		ifTrue: [ ^ self readOnlyAccessMode ].
+	aString = '--writeOnlyAccessMode'
+		ifTrue: [ ^ self writeOnlyAccessMode ].
+	aString = '--disabledAccessMode'
+		ifTrue: [ ^ self disabledAccessMode ].
 	
 	"none of the previous options matched hence we output an error message"
 	self error.
@@ -261,9 +273,15 @@ BasicCommandLineHandler >> noQuit [
 ]
 
 { #category : #commands }
-BasicCommandLineHandler >> readOnlyMode [
+BasicCommandLineHandler >> readOnlyAccessMode [
 
-	"just eat the argument because it was processed with by the DiskStore startUp before"
+	"just eat the argument because it was processed with by the SessionAccessModeResolver before"
+]
+
+{ #category : #commands }
+BasicCommandLineHandler >> readWriteAccessMode [
+
+	"just eat the argument because it was processed with by the SessionAccessModeResolver before"
 ]
 
 { #category : #password }
@@ -300,4 +318,10 @@ BasicCommandLineHandler >> version [
 		nextPutAll: 'Image: '; print: SystemVersion current; cr;
 		nextPutAll: 'VM:    '; nextPutAll: Smalltalk vm version; cr.
 	self quit.
+]
+
+{ #category : #commands }
+BasicCommandLineHandler >> writeOnlyAccessMode [
+
+	"just eat the argument because it was processed with by the SessionAccessModeResolver before"
 ]

--- a/src/System-CommandLineHandler/PharoCommandLineHandler.class.st
+++ b/src/System-CommandLineHandler/PharoCommandLineHandler.class.st
@@ -5,8 +5,9 @@ Usage: [<subcommand>] [--help] [--copyright] [--version] [--list] [ --no-quit ]
 	--version    print the version for the image and the vm
 	--list       list a description of all active command line handlers
 	--no-quit    keep the image running without activating any other command line handler
-	--deploymentPassword if a password needs to be used by the user to launch the command
-	--readOnlyMode       forbid disk writes
+	--deploymentPassword   if a password needs to be used by the user to launch the command
+	--readWriteAccessMode, --readOnlyAccessMode, --writeOnlyAccessMode, --disabledAccessMode
+	             specify disk access mode, read-write mode as default
 	<subcommand> a valid subcommand in --list
 	
 	Preference File Modification:

--- a/src/System-CommandLineHandler/PharoCommandLineHandler.class.st
+++ b/src/System-CommandLineHandler/PharoCommandLineHandler.class.st
@@ -6,6 +6,7 @@ Usage: [<subcommand>] [--help] [--copyright] [--version] [--list] [ --no-quit ]
 	--list       list a description of all active command line handlers
 	--no-quit    keep the image running without activating any other command line handler
 	--deploymentPassword if a password needs to be used by the user to launch the command
+	--readOnlyMode       forbid disk writes
 	<subcommand> a valid subcommand in --list
 	
 	Preference File Modification:

--- a/src/System-Identification/GlobalIdentifier.class.st
+++ b/src/System-Identification/GlobalIdentifier.class.st
@@ -50,7 +50,7 @@ GlobalIdentifier class >> initialize [
 	SessionManager default
 		register: (ClassSessionHandler forClassNamed: self name)
 		inCategory: SessionManager default systemCategory  
-		atPriority: SessionManager default defaultPriority - 100.
+		atPriority: SessionManager default defaultPriority - 80.
 ]
 
 { #category : #initialization }

--- a/src/System-Identification/GlobalIdentifierPersistenceChecker.class.st
+++ b/src/System-Identification/GlobalIdentifierPersistenceChecker.class.st
@@ -12,5 +12,5 @@ Class {
 { #category : #testing }
 GlobalIdentifierPersistenceChecker >> isEnabled [
 	"See class comment or https://pharo.manuscript.com/f/cases/19944."
-	^ FileLocator home exists
+	^ FileLocator home exists and: [ FileLocator home fileSystem isWritable ]
 ]

--- a/src/System-SessionManager/SessionAccessModeResolver.class.st
+++ b/src/System-SessionManager/SessionAccessModeResolver.class.st
@@ -29,13 +29,13 @@ SessionAccessModeResolver class >> resolve [
 			
 	mode := #readWrite.
 
-	(arguments anySatisfy: [ :each | each = '--readWriteAccessMode' ])
+	(Smalltalk argumentsInclude: '--readWriteAccessMode')
 		ifTrue: [ mode := #readWrite ].
-	(arguments anySatisfy: [ :each | each = '--readOnlyAccessMode' ])
+	(Smalltalk argumentsInclude:  '--readOnlyAccessMode')
 		ifTrue: [ mode := #readOnly ].
-	(arguments anySatisfy: [ :each | each = '--writeOnlyAccessMode' ])
+	(Smalltalk argumentsInclude: '--writeOnlyAccessMode')
 		ifTrue: [ mode := #writeOnly ].
-	(arguments anySatisfy: [ :each | each = '--disabledAccessMode' ])
+	(Smalltalk argumentsInclude: '--disabledAccessMode')
 		ifTrue: [ mode := #disabled ].
 		
 	SessionManager default currentSession accessMode: mode.

--- a/src/System-SessionManager/SessionAccessModeResolver.class.st
+++ b/src/System-SessionManager/SessionAccessModeResolver.class.st
@@ -1,0 +1,49 @@
+"
+I check the image arguments and resolve if the access mode of the image. I am started very soon in the image start-up process.
+"
+Class {
+	#name : #SessionAccessModeResolver,
+	#superclass : #Object,
+	#category : #'System-SessionManager-Utilities'
+}
+
+{ #category : #'class initialization' }
+SessionAccessModeResolver class >> initialize [
+
+	"self initialize"
+
+	SessionManager default
+		register: (ClassSessionHandler forClassNamed: self name)
+		inCategory: SessionManager default systemCategory  
+		atPriority: SessionManager default defaultPriority - 90.
+]
+
+{ #category : #'class initialization' }
+SessionAccessModeResolver class >> resolve [ 
+
+	"check if the image was started in the read-only mode"
+
+	| arguments mode | 
+	
+	arguments := Smalltalk argumentsStartingAtIndex: 0.
+			
+	mode := #readWrite.
+
+	(arguments anySatisfy: [ :each | each = '--readWriteAccessMode' ])
+		ifTrue: [ mode := #readWrite ].
+	(arguments anySatisfy: [ :each | each = '--readOnlyAccessMode' ])
+		ifTrue: [ mode := #readOnly ].
+	(arguments anySatisfy: [ :each | each = '--writeOnlyAccessMode' ])
+		ifTrue: [ mode := #writeOnly ].
+	(arguments anySatisfy: [ :each | each = '--disabledAccessMode' ])
+		ifTrue: [ mode := #disabled ].
+		
+	SessionManager default currentSession accessMode: mode.
+]
+
+{ #category : #'class initialization' }
+SessionAccessModeResolver class >> startUp: resuming [
+
+	resuming ifTrue: [
+		self resolve ]
+]

--- a/src/System-SessionManager/WorkingSession.class.st
+++ b/src/System-SessionManager/WorkingSession.class.st
@@ -12,10 +12,23 @@ Class {
 		'manager',
 		'deferredStartupActions',
 		'id',
-		'creationTime'
+		'creationTime',
+		'properties'
 	],
 	#category : #'System-SessionManager-Utilities'
 }
+
+{ #category : #accessing }
+WorkingSession >> accessMode [
+
+	^ self properties at: #accessMode ifAbsent: [ #readWrite ]
+]
+
+{ #category : #accessing }
+WorkingSession >> accessMode: anObject [
+
+	^ self properties at: #accessMode put: anObject
+]
 
 { #category : #'deferred startup actions' }
 WorkingSession >> addDeferredStartupAction: aBlock [
@@ -55,7 +68,8 @@ WorkingSession >> id [
 WorkingSession >> initialize [
 	super initialize.
 	deferredStartupActions := OrderedCollection new.
-	creationTime := DateAndTime now
+	creationTime := DateAndTime now.
+	properties := Dictionary new.
 ]
 
 { #category : #'startup - shutdown' }
@@ -63,9 +77,39 @@ WorkingSession >> install [
 	manager installSession: self
 ]
 
+{ #category : #testing }
+WorkingSession >> isDisabledAccessMode [
+
+	^ self accessMode = #disabled
+]
+
+{ #category : #testing }
+WorkingSession >> isReadOnlyAccessMode [
+
+	^ self accessMode = #readOnly
+]
+
+{ #category : #testing }
+WorkingSession >> isReadWriteAccessMode [
+
+	^ self accessMode = #readWrite
+]
+
+{ #category : #testing }
+WorkingSession >> isWriteOnlyAccessMode [
+
+	^ self accessMode = #writeOnly
+]
+
 { #category : #accessing }
 WorkingSession >> manager: aSessionManager [ 
 	manager := aSessionManager
+]
+
+{ #category : #'startup - shutdown' }
+WorkingSession >> properties [
+
+	^ properties
 ]
 
 { #category : #'startup - shutdown' }

--- a/src/System-Sources/PharoFilesOpener.class.st
+++ b/src/System-Sources/PharoFilesOpener.class.st
@@ -69,6 +69,10 @@ PharoFilesOpener >> changesFileOrNilReadOnly: readOnly silent: silent [
 
 	silent
 		ifTrue: [ ^ changesFile ].
+		
+	changesFile isOpen ifFalse: [ 
+		changesFile := nil.
+		^ nil ].
 
 	(changesFile isReadOnly and: [ self shouldInformAboutReadOnlyChanges ])
 		ifTrue: [ self informProblemInChanges: self cannotWriteMsg ].

--- a/src/System-Sources/SourceFile.class.st
+++ b/src/System-Sources/SourceFile.class.st
@@ -52,6 +52,9 @@ SourceFile >> cr [
 { #category : #accessing }
 SourceFile >> flush [
 
+	(stream isNil or: [ stream isReadOnly ])
+		ifTrue: [ ^ self ].
+	
 	stream flush
 ]
 
@@ -247,8 +250,10 @@ SourceFile >> tryOpenReadOnly: readOnly [
 				^ self ] on: Error do: [  ] ] ].
 
 	potentialLocations do: [ :each | 
-			[ stream := (each asFileReference / basename) readStream.
-			^ self ] on: Error do: [  ] ]
+			[ stream := ZnCharacterReadStream
+					on: (each asFileReference / basename) binaryReadStream
+					encoding: 'utf8'.
+				^ self ] on: Error do: [  ] ]
 ]
 
 { #category : #accessing }

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -212,7 +212,9 @@ SourceFileArray >> closeFileArray: anArray [
 
 	anArray 
 		reject: [ :file | file isNil ] 
-		thenDo: [ :file | file close ]
+		thenDo: [ :file | file close ].
+		
+	^ anArray
 ]
 
 { #category : #private }
@@ -252,13 +254,21 @@ SourceFileArray >> emptyReadStreamsQueue [
 { #category : #'public - file system operations' }
 SourceFileArray >> ensureOpen [
 	"Ensure that the source and changes files are opened.
-	Close them before re-opening them.
+	Close them before re-opening them."
 	
-	This could be optimized by jut checking if they are open and doing nothing in that case."
+	| aSourcesFile aChangesFile |
+
 	self close.
+
+	aSourcesFile := PharoFilesOpener default sourcesFileOrNil.
+	aChangesFile := PharoFilesOpener default changesFileOrNil.
+	
+	aChangesFile ifNil: [ 
+		aChangesFile := PharoFilesOpener default changesFileOrNilReadOnly: true silent: false ].
+
 	files := Array
-		with: PharoFilesOpener default sourcesFileOrNil
-		with: PharoFilesOpener default changesFileOrNil.
+		with: aSourcesFile
+		with: aChangesFile.
 			
 	readOnlyQueue := SharedQueue new.
 ]

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -162,10 +162,17 @@ SmalltalkImage >> arguments [
 
 	"Smalltalk commandLine arguments"
 
+	^ self argumentsStartingAtIndex: 1
+]
+
+{ #category : #private }
+SmalltalkImage >> argumentsStartingAtIndex: anIndex [
+	"Answer an array with all the command line arguments"
+
 	^ Array
 		streamContents: [ :str | 
 			| arg i |
-			i := 1.
+			i := anIndex.
 			[ i > 998 or: [ (arg := self argumentAt: i) isNil ] ]
 				whileFalse: [ 
 					str nextPut: arg.

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -166,6 +166,12 @@ SmalltalkImage >> arguments [
 ]
 
 { #category : #private }
+SmalltalkImage >> argumentsInclude: aString [
+
+	^ (self argumentsStartingAtIndex: 0) includes: aString
+]
+
+{ #category : #private }
 SmalltalkImage >> argumentsStartingAtIndex: anIndex [
 	"Answer an array with all the command line arguments"
 


### PR DESCRIPTION
fixes #3836 

- Introduce ReadOnlyFileException 
- the platform-dependent filesystem Stores have read-only variants (strategies)
- BasicCommandLineHandler accepts new image option: `--readOnlyMode`. Internally, this option is ignored because its value must be known before the command line handler startup is executed. So the real processing of this image argument is done in DiskStore class >> wantsReadOnly. The FileStore read-only or writable strategy is determined using this message
- changes file processing was improved so it now works better with changes file while the writing to it is disabled. The new source code is installed directly into the methods
- Ombu and GTPlayground and the session manager are able to work in read-only mode
- the old streams and File are checking read-only mode (quite ugly, the old mess is even messier now)
- PharoDebug.log and std i/o placeholder files are not created in read-only mode

The read-only mode is just image-based mechanism so it does not prevent the image to modify files for real, the VM still can do it. 
