### PR TITLE
2312-ondo-contexts-added-on-step-through-not-removed

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -295,7 +295,7 @@ Context >> stepToHome: aContext [
 	[ctxt := ctxt step.
 	error ifNotNil: [
 		"Error was raised, remove inserted above contexts then return signaler context"
-			"aContext terminateTo: context sender."  "remove above ensure and handler contexts"
+			aContext terminateTo: context sender.  "remove above ensure and handler contexts"
 			^ {ctxt. error}].
 	
 	home == ctxt home] whileFalse: [


### PR DESCRIPTION
uncomment a commented line that removes the on:do: handler.

fixes #2312