### PR TITLE
3857-Remove-some-deprecations-from-Spec-1-to-make-image-more-usuable

### DIFF
--- a/src/Spec-Deprecated80/AbstractListPresenter.extension.st
+++ b/src/Spec-Deprecated80/AbstractListPresenter.extension.st
@@ -69,11 +69,6 @@ AbstractListPresenter >> menu: aBlock [
 	"Set the block used to defined the menu"
 
 	self
-		deprecated:
-			'Use #contextMenu: instead. The old way to create a MenuPresenter was this method taking a MenuMorph as parameter. This will not work with other backend and will be totally removed in Pharo7. Now you should use #contextMenu takin a MeruPresenter (or a block returning a menu presenter) as parameter.'
-		on: '2019-03-07'
-		in: #Pharo8.
-	self
 		contextMenu: [ aBlock
 				cull:
 					(MenuMorph new
@@ -84,11 +79,6 @@ AbstractListPresenter >> menu: aBlock [
 
 { #category : #'*Spec-Deprecated80' }
 AbstractListPresenter >> menu: aBlock shifted: aBoolean [
-	self
-		deprecated:
-			'Use #contextMenu: instead. The old way to create a MenuPresenter was this method taking a MenuMorph as parameter. This will not work with other backend and will be totally removed in Pharo7. Now you should use #contextMenu takin a MeruPresenter (or a block returning a menu presenter) as parameter.'
-		on: '2019-03-07'
-		in: #Pharo8.
 	self
 		contextMenu: [ aBlock
 				cull:

--- a/src/Spec-Deprecated80/ComposablePresenter.extension.st
+++ b/src/Spec-Deprecated80/ComposablePresenter.extension.st
@@ -39,7 +39,6 @@ ComposablePresenter >> newIconList [
 
 { #category : #'*Spec-Deprecated80' }
 ComposablePresenter >> newMultiColumnList [
-	self deprecated: 'Use newTable instead' on: '2019-02-05' in: #Pharo8.
 	^ self instantiate: MultiColumnListPresenter
 ]
 
@@ -67,9 +66,6 @@ ComposablePresenter >> newTabManager [
 
 { #category : #'*Spec-Deprecated80' }
 ComposablePresenter >> newTree [
-	
-	self deprecated: 'Use #newTreeTable instead'.
-
 	^ self instantiate: TreePresenter
 ]
 
@@ -86,13 +82,7 @@ ComposablePresenter >> on: aShortcut do: aBlock [
 
 { #category : #'*Spec-Deprecated80' }
 ComposablePresenter >> setModal: aWindow [
-
-	self 
-		deprecated: 'Do not use this directly. Use #openModalWithSpec (and family) instead.' 
-		on: '2019-02-26' 
-		in: #Pharo8.
-	
-	self changed: #setModal: with: { aWindow }
+	self changed: #setModal: with: {aWindow}
 ]
 
 { #category : #'*Spec-Deprecated80' }


### PR DESCRIPTION
Remove some of the most annoying deprecations of Spec 1 before we revert the code to get back to the real Spec 1.

Fixes #3857