### PR TITLE
3897-unify-name-of-RGMethodDefinition-and-CompiledMethod

### DIFF
--- a/src/Ring-Deprecated-Core-Kernel/RGMethodDefinition.class.st
+++ b/src/Ring-Deprecated-Core-Kernel/RGMethodDefinition.class.st
@@ -491,6 +491,12 @@ RGMethodDefinition >> methodClass [
 ]
 
 { #category : #accessing }
+RGMethodDefinition >> name [
+	"name ivar is used for selector, but the name of a method is Class>>selector"
+	^self printString
+]
+
+{ #category : #accessing }
 RGMethodDefinition >> numArgs [
 	^ self selector asString numArgs
 ]


### PR DESCRIPTION
fixes #3897