### PR TITLE
3910-RBLocalMethodsSameThanTraitRule-should-give-info-on-which-methods-are-duplicated

### DIFF
--- a/src/GeneralRules/RBLocalMethodsSameThanTraitRule.class.st
+++ b/src/GeneralRules/RBLocalMethodsSameThanTraitRule.class.st
@@ -20,16 +20,24 @@ RBLocalMethodsSameThanTraitRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-RBLocalMethodsSameThanTraitRule >> basicCheck: aClass [
+RBLocalMethodsSameThanTraitRule >> check: aClass forCritiquesDo: aCriticBlock [
 	"The comparison between methods is made using the ast, this is better than comparing source code only since it does not take into account identations, extra parenthesis, etc"
 
-	^ aClass isTrait not
-		and: [ aClass hasTraitComposition
-				and: [ aClass localMethods
-						anySatisfy: [ :method | 
-							| traitCompositionMethod |
-							traitCompositionMethod := aClass traitComposition compiledMethodAt: method selector ifAbsent: [ nil ].
-							traitCompositionMethod notNil and: [ traitCompositionMethod ast = method ast ] ] ] ]
+	aClass isTrait ifTrue: [ ^ self ].
+	aClass hasTraitComposition ifFalse: [ ^ self ].
+	(aClass localMethods
+		select: [ :method | 
+			| traitCompositionMethod |
+			traitCompositionMethod := aClass traitComposition compiledMethodAt: method selector ifAbsent: [ nil ].
+			traitCompositionMethod notNil and: [ traitCompositionMethod ast = method ast ] ])
+		ifNotEmpty: [ :duplicatedMethods | 
+			duplicatedMethods
+				do: [ :duplicatedMethod | 
+					aCriticBlock
+						cull:
+							((ReTrivialCritique withAnchor: (self anchorFor: aClass) by: self)
+								tinyHint: duplicatedMethod selector;
+								yourself) ] ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/RBLocalMethodsSameThanTraitRule.class.st
+++ b/src/GeneralRules/RBLocalMethodsSameThanTraitRule.class.st
@@ -25,19 +25,14 @@ RBLocalMethodsSameThanTraitRule >> check: aClass forCritiquesDo: aCriticBlock [
 
 	aClass isTrait ifTrue: [ ^ self ].
 	aClass hasTraitComposition ifFalse: [ ^ self ].
-	(aClass localMethods
+	aClass localMethods
 		select: [ :method | 
 			| traitCompositionMethod |
 			traitCompositionMethod := aClass traitComposition compiledMethodAt: method selector ifAbsent: [ nil ].
-			traitCompositionMethod notNil and: [ traitCompositionMethod ast = method ast ] ])
-		ifNotEmpty: [ :duplicatedMethods | 
-			duplicatedMethods
-				do: [ :duplicatedMethod | 
-					aCriticBlock
-						cull:
-							((ReTrivialCritique withAnchor: (self anchorFor: aClass) by: self)
-								tinyHint: duplicatedMethod selector;
-								yourself) ] ]
+			traitCompositionMethod notNil and: [ traitCompositionMethod ast = method ast ] ]
+		thenDo: [ :duplicatedMethod |
+			aCriticBlock cull:
+				(ReRemoveMethodCritique for: aClass selector: duplicatedMethod selector by: self) ]
 ]
 
 { #category : #accessing }

--- a/src/Renraku/ReAbstractCritique.class.st
+++ b/src/Renraku/ReAbstractCritique.class.st
@@ -86,8 +86,7 @@ ReAbstractCritique >> actions [
 
 { #category : #actions }
 ReAbstractCritique >> ban [
-	
-	sourceAnchor sourceEntity ban: self  
+	self entity ban: self
 ]
 
 { #category : #accessing }
@@ -133,7 +132,7 @@ ReAbstractCritique >> gtInspectorSourceCodeIn: composite [
 { #category : #actions }
 ReAbstractCritique >> guidedBan [
 
-	ReCriticEngine guidedBy: sourceAnchor entity ban: self
+	ReCriticEngine guidedBy: self entity  ban: self
 ]
 
 { #category : #accessing }

--- a/src/Renraku/ReMissingMethodCritique.class.st
+++ b/src/Renraku/ReMissingMethodCritique.class.st
@@ -56,7 +56,7 @@ ReMissingMethodCritique >> initializeRule: aRule target: anEntity class: aClass 
 	class := aClass.
 	selector :=  aSymbol.
 	
-	tinyHint := class == sourceAnchor entity
+	tinyHint := class == self entity 
 		ifTrue: [ selector ]
 		ifFalse: [ class name, '>>#', selector ]
 ]

--- a/src/Renraku/ReProperty.class.st
+++ b/src/Renraku/ReProperty.class.st
@@ -22,6 +22,11 @@ ReProperty >> color [
 	^ Color black alpha: 0.1
 ]
 
+{ #category : #accessing }
+ReProperty >> entity [
+	^ self sourceAnchor entity
+]
+
 { #category : #actions }
 ReProperty >> gtInspectorActions [
 	^ (self actions collect: [ :act | 

--- a/src/Renraku/ReRemoveMethodCritique.class.st
+++ b/src/Renraku/ReRemoveMethodCritique.class.st
@@ -1,0 +1,28 @@
+"
+I am a critique that will propose to the user to remove a method.
+"
+Class {
+	#name : #ReRemoveMethodCritique,
+	#superclass : #ReAbstractCritique,
+	#instVars : [
+		'selector'
+	],
+	#category : #'Renraku-Critiques'
+}
+
+{ #category : #'instance creation' }
+ReRemoveMethodCritique class >> for: anEntity selector: aSelector by: aRule [
+	^ (self for: anEntity by: aRule)
+		tinyHint: aSelector;
+		yourself
+]
+
+{ #category : #accessing }
+ReRemoveMethodCritique >> change [
+	^ RBRemoveMethodChange remove: self tinyHint from: self entity
+]
+
+{ #category : #testing }
+ReRemoveMethodCritique >> providesChange [
+	^ true
+]

--- a/src/Renraku/ReReplaceNodeCritique.class.st
+++ b/src/Renraku/ReReplaceNodeCritique.class.st
@@ -26,7 +26,7 @@ ReReplaceNodeCritique >> change [
 	"creates new AST by replacing the node. Then the 'add method' change is generated from new AST"
 
 	| newTree newTreeNode |
-	newTree := sourceAnchor entity parseTree.
+	newTree := self entity  parseTree.
 	newTreeNode := newTree nodeAtTraversalIndex: (
 		oldNode methodNode traversalIndexOf: oldNode).
 	self assert: newTreeNode = oldNode.
@@ -35,7 +35,7 @@ ReReplaceNodeCritique >> change [
 	newTreeNode becomeForward: newNode.
 	^ RBAddMethodChange
 		compile: newTree methodNode newSource
-		in: sourceAnchor entity methodClass
+		in: self entity  methodClass
 ]
 
 { #category : #initialization }
@@ -50,5 +50,5 @@ ReReplaceNodeCritique >> initializeRule: aRule sourceAnchor: anAnchor oldNode: a
 { #category : #testing }
 ReReplaceNodeCritique >> providesChange [
 
-	^ sourceAnchor entity isCompiledMethod
+	^ self entity isCompiledMethod
 ]

--- a/src/Renraku/ReTransformationCritique.class.st
+++ b/src/Renraku/ReTransformationCritique.class.st
@@ -24,7 +24,7 @@ ReTransformationCritique class >> for: anEntity by: aRule tree: newAST [
 ReTransformationCritique >> change [
 	"re-add the method compiled from the new AST"
 	
-	^ RBAddMethodChange compile: newTree newSource in: sourceAnchor entity methodClass
+	^ RBAddMethodChange compile: newTree newSource in: self entity methodClass
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
RBLocalMethodsSameThanTraitRule now hint which method is duplicated.

Fixes #3910