### PR TITLE
More minor cleanup for portability

### DIFF
--- a/src/Kernel-Tests/BehaviorTest.class.st
+++ b/src/Kernel-Tests/BehaviorTest.class.st
@@ -56,7 +56,7 @@ BehaviorTest >> testAllSelectorsAbove [
 BehaviorTest >> testAllSelectorsAboveUntil [
 		
 	|sels |
-	sels := Date allSelectorsAboveUntil: Object..
+	sels := Date allSelectorsAboveUntil: Object.
 	self deny: (sels includes: #mmddyyyy). 
 	self deny: (sels includes: #weekday).
 	self assert: (sels includes: #at:).

--- a/src/Kernel-Tests/BlockClosureTest.class.st
+++ b/src/Kernel-Tests/BlockClosureTest.class.st
@@ -150,11 +150,15 @@ BlockClosureTest >> testNew [
 
 { #category : #tests }
 BlockClosureTest >> testNoArguments [
+	| block1 block2 |
+	"avoid compile error in GemStone"
+	block1 := [:arg | 1 + 2].
+	block2 := [:arg1 :arg2 | 1 + 2].
 	[10
-		timesRepeat: [:arg | 1 + 2]]
+		timesRepeat: block1]
 		ifError: [:err | self deny: err = 'This block requires 1 arguments.'].
 	[10
-		timesRepeat: [:arg1 :arg2 | 1 + 2]]
+		timesRepeat: block2]
 		ifError: [:err  | self deny: err = 'This block requires 2 arguments.'] 
 ]
 

--- a/src/Kernel-Tests/NumberTest.class.st
+++ b/src/Kernel-Tests/NumberTest.class.st
@@ -142,8 +142,10 @@ NumberTest >> testRaisedToIntegerWithFloats [
 { #category : #tests }
 NumberTest >> testReadFrom [
 	
-	self assert: 1.0e-14	= (Number readFrom: '1.0e-14').
-	self assert: 2r1e26	= (Number readFrom: '2r1e26').
+	self assert: 1.0e-14    = (Number readFrom: '1.0e-14').
+	"Use a literal number format that compiles in GemStone.
+	 Note that the test still checks the same value."
+	self assert: 16r4000000 = (Number readFrom: '2r1e26').
 	self should: [Number readFrom: 'foo'] raise: Error
 ]
 

--- a/src/Kernel-Tests/TestDelayBasicSchedulerMicrosecondTicker.class.st
+++ b/src/Kernel-Tests/TestDelayBasicSchedulerMicrosecondTicker.class.st
@@ -243,8 +243,8 @@ TestDelayBasicSchedulerMicrosecondTicker >> testPerformanceInlined_ifNotNil [
 { #category : #tests }
 TestDelayBasicSchedulerMicrosecondTicker >> testPerformanceInlined_ifTrue [
 	"For optimal performance, the outer conditionals of #timingPriorityHandleEvent should be inlined"
-	|codeSample|
-	codeSample := [ nil ifTrue: [ 0 ]].
+	| codeSample x |
+	codeSample := [ x ifTrue: [ 0 ]].
 	self assert: codeSample sourceNode body statements first isInlined
 ]
 

--- a/src/SUnit-Core/TestExecutionEnvironment.class.st
+++ b/src/SUnit-Core/TestExecutionEnvironment.class.st
@@ -149,7 +149,7 @@ TestExecutionEnvironment >> prepareForNewProcess: aProcess [
 	forkedProcesses add: aProcess.
 	aProcess suspendedContext sender ifNotNil: [ ^self ]. "Some existing tests in system create processes on arbitrary block and then check suspendedContext state. Without this 'if' all this tests will fail"
 	processBlock := aProcess suspendedContext receiver.
-	processBlock isClosure ifFalse: [ ^self ]. "same case as in previous comment".
+	processBlock isClosure ifFalse: [ ^self ]. "same case as in previous comment"
 	
 	aProcess on: Error do: [ :err | | activeProcess |
 		"It is possible to fork process with copy of stack from another process
@@ -175,7 +175,7 @@ TestExecutionEnvironment >> runTestCase: aTestCase [
 
 	[[self runTestCaseSafelly: aTestCase] ensure: [
 		testCompleted := true.
-		watchDogSemaphore signal]. "signal that test case completes".
+		watchDogSemaphore signal]. "signal that test case completes"
 	
 	self checkForkedProcesses] ifCurtailed: [
 		forkedProcesses removeAll.


### PR DESCRIPTION
Remove duplicate periods; avoid GemStone compile errors. This brings us to 1640 classes and 27,850 methods that are loading (but not necessarily running!) in GemStone.