### PR TITLE
SharedPool Inspector: list all Shared pools

### DIFF
--- a/src/GT-InspectorExtensions-Core/SharedPool.extension.st
+++ b/src/GT-InspectorExtensions-Core/SharedPool.extension.st
@@ -6,7 +6,7 @@ SharedPool class >> gtInspectorAllSharedPoolsIn: composite [
 	<gtInspectorPresentationOrder: 20>
 	composite list 
 		title: 'Shared Pools';
-		display: [ self subclasses ];
+		display: [ self subclasses sorted: #name ascending ];
 		tags: [ :each | { each package name } ];
 		when: [self == SharedPool  ].
 ]

--- a/src/GT-InspectorExtensions-Core/SharedPool.extension.st
+++ b/src/GT-InspectorExtensions-Core/SharedPool.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #SharedPool }
+
+{ #category : #'*GT-InspectorExtensions-Core' }
+SharedPool class >> gtInspectorAllSharedPoolsIn: composite [
+	"This provides a list of all defined Shared Pools"
+	<gtInspectorPresentationOrder: 20>
+	composite list 
+		title: 'Shared Pools';
+		display: [ self subclasses ];
+		tags: [ :each | { each package name } ];
+		when: [self == SharedPool  ].
+]


### PR DESCRIPTION
add an inspector view that shows all declared Shared Pools when inspecting  the class SharedPoll