### PR TITLE
3965-Minimal-image-calls-but-doesnt-include-SmalltalkImageplatformName

### DIFF
--- a/src/System-Platforms/SmalltalkImage.extension.st
+++ b/src/System-Platforms/SmalltalkImage.extension.st
@@ -13,3 +13,8 @@ SmalltalkImage >> platform [
 	
 	^ self os
 ]
+
+{ #category : #'*System-Platforms' }
+SmalltalkImage >> platformName [
+	^ self os platformName
+]

--- a/src/UnifiedFFI/SmalltalkImage.extension.st
+++ b/src/UnifiedFFI/SmalltalkImage.extension.st
@@ -4,8 +4,3 @@ Extension { #name : #SmalltalkImage }
 SmalltalkImage >> getSystemAttribute: aNumber [
 	^ self vm getSystemAttribute: aNumber
 ]
-
-{ #category : #'*UnifiedFFI' }
-SmalltalkImage >> platformName [
-	^ self os platformName
-]


### PR DESCRIPTION
Move SmalltalkImage>>#platformName from UnifiedFFI to System-Platforms.

Fixes #3965