### PR TITLE
ifNil usage on Debugger-Model

### DIFF
--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -265,16 +265,18 @@ DebugSession >> name: aString [
 
 { #category : #context }
 DebugSession >> pcRangeForContext: aContext [
+
 	"Answer the indices in the source code for the method corresponding to 
 	aContext's program counter value."
-	(aContext isNil) ifTrue: [ 
-		self terminate.
-		 ] ifFalse: [  
-	(aContext isDead) ifTrue:
-		[^1 to: 0].
-	^aContext debuggerMap
-		rangeForPC: aContext pc
-		contextIsActiveContext: (self isLatestContext: aContext) ]
+
+	aContext
+		ifNil: [ self terminate ]
+		ifNotNil: [ aContext isDead
+				ifTrue: [ ^ 1 to: 0 ].
+			^ aContext debuggerMap
+				rangeForPC: aContext pc
+				contextIsActiveContext: ( self isLatestContext: aContext )
+			]
 ]
 
 { #category : #'debugging actions' }


### PR DESCRIPTION
Use `ifNil:`,  `ifNotNil:` and `ifNil:ifNotNil:` instead of `isNil` and `ifTrue/ifFalse` combinations 