### PR TITLE
ifNil usage on FFI, Files, Fonts and Fuel

### DIFF
--- a/src/FFI-Kernel/ExternalFunction.class.st
+++ b/src/FFI-Kernel/ExternalFunction.class.st
@@ -72,17 +72,20 @@ ExternalFunction class >> externalCallFailed [
 
 { #category : #'error handling' }
 ExternalFunction class >> externalCallFailedWith: primErrorCode [
+
 	"Raise an error after a failed call to an external function.
 	 The primFailCode could be any of:
 		- a symbol; one of the standard primitive errors defined in Smalltalk primitiveErrorTable
 		- nil; the VM does not support primitive errors and is not providing error codes
 		- an integer; one of the FFI codes incremented by Smalltalk primitiveErrorTable size + 2
 		  so as not to clash with the standard primitive errors."
-	^self error: (primErrorCode isInteger
-					ifTrue: [self errorMessageFor: primErrorCode - (Smalltalk primitiveErrorTable size + 2)]
-					ifFalse: [primErrorCode isNil
-								ifTrue: ['Call to external function failed']
-								ifFalse: [primErrorCode]])
+
+	^ self
+		error:
+			( primErrorCode isInteger
+				ifTrue: [ self errorMessageFor: primErrorCode - ( Smalltalk primitiveErrorTable size + 2 ) ]
+				ifFalse:
+					[ primErrorCode ifNil: [ 'Call to external function failed' ] ifNotNil: [ primErrorCode ] ] )
 ]
 
 { #category : #'compiler support' }

--- a/src/FFI-Kernel/ExternalStructure.class.st
+++ b/src/FFI-Kernel/ExternalStructure.class.st
@@ -101,29 +101,32 @@ ExternalStructure class >> checkFieldLayoutChange [
 
 { #category : #'field definition' }
 ExternalStructure class >> compileAlias: spec withAccessors: aSymbol [
+
 	"Define all the fields in the receiver.
 	Return the newly compiled spec."
+
 	| fieldName fieldType isPointerField externalType newCompiledSpec |
+
 	fieldName := spec first.
 	fieldType := spec second.
 	isPointerField := fieldType last = $*.
 	fieldType := fieldType copyWithout: $*.
 	externalType := ExternalType atomicTypeNamed: fieldType.
-	externalType isNil ifTrue:["non-atomic"
-		Symbol hasInterned: fieldType ifTrue:[:sym|
-			externalType := ExternalType structTypeNamed: sym]].
-	externalType isNil ifTrue:[
-		Transcript show:'(', fieldType,' is void)'.
-		externalType := ExternalType void].
-	isPointerField ifTrue:[externalType := externalType asPointerType].
-	(fieldName notNil and:[self shouldGenerate: fieldName policy: aSymbol]) ifTrue:[
-		self defineAliasAccessorsFor: fieldName
-			type: externalType].
-	newCompiledSpec := isPointerField 
-		ifTrue:[WordArray with: 
-					(ExternalType structureSpec bitOr: ExternalType pointerSpec)]
-		ifFalse:[externalType compiledSpec].
-	^newCompiledSpec
+	externalType
+		ifNil:
+			[ "non-atomic" Symbol hasInterned: fieldType ifTrue: [ :sym | externalType := ExternalType structTypeNamed: sym ] ].
+	externalType
+		ifNil: [ Transcript show: '(' , fieldType , ' is void)'.
+			externalType := ExternalType void
+			].
+	isPointerField
+		ifTrue: [ externalType := externalType asPointerType ].
+	( fieldName notNil and: [ self shouldGenerate: fieldName policy: aSymbol ] )
+		ifTrue: [ self defineAliasAccessorsFor: fieldName type: externalType ].
+	newCompiledSpec := isPointerField
+		ifTrue: [ WordArray with: ( ExternalType structureSpec bitOr: ExternalType pointerSpec ) ]
+		ifFalse: [ externalType compiledSpec ].
+	^ newCompiledSpec
 ]
 
 { #category : #'field definition' }

--- a/src/FFI-Kernel/ExternalType.class.st
+++ b/src/FFI-Kernel/ExternalType.class.st
@@ -517,16 +517,15 @@ ExternalType >> isVoid [
 
 { #category : #private }
 ExternalType >> newReferentClass: aClass [
+
 	"The class I'm referencing has changed. Update my spec."
 
 	referentClass := aClass.
 	self isPointerType
 		ifTrue: [ ^ self ].	"for pointers only the referentClass changed"
-	compiledSpec := referentClass isNil
-		ifTrue:
-			[ "my class has been removed - make me 'struct { void }'" WordArray with: FFIFlagStructure ]
-		ifFalse:
-			[ "my class has been changed - update my compiledSpec" referentClass compiledSpec ]
+	compiledSpec := referentClass
+		ifNil: [ "my class has been removed - make me 'struct { void }'" WordArray with: FFIFlagStructure ]
+		ifNotNil: [ "my class has been changed - update my compiledSpec" referentClass compiledSpec ]
 ]
 
 { #category : #accessing }
@@ -559,10 +558,12 @@ ExternalType >> printAtomicType: spec on: aStream [
 
 { #category : #printing }
 ExternalType >> printOn: aStream [
-	referentClass isNil
-		ifTrue:[aStream nextPutAll: (AtomicTypeNames at: self atomicType)]
-		ifFalse:[aStream nextPutAll: referentClass name].
-	self isPointerType ifTrue:[aStream nextPut: $*].
+
+	referentClass
+		ifNil: [ aStream nextPutAll: ( AtomicTypeNames at: self atomicType ) ]
+		ifNotNil: [ aStream nextPutAll: referentClass name ].
+	self isPointerType
+		ifTrue: [ aStream nextPut: $* ]
 ]
 
 { #category : #printing }
@@ -688,10 +689,27 @@ ExternalType >> setReferencedType: aType [
 
 { #category : #printing }
 ExternalType >> storeOn: aStream [
-	referentClass isNil
-		ifTrue:[aStream nextPutAll: ExternalType name; space; nextPutAll: (AtomicTypeNames at: self atomicType)]
-		ifFalse:[aStream nextPut: $(; nextPutAll: ExternalType name; space; nextPutAll: #structTypeNamed:; space;  store: referentClass name; nextPut: $)].
-	self isPointerType ifTrue: [aStream space; nextPutAll: #asPointer].
+
+	referentClass
+		ifNil: [ aStream
+				nextPutAll: ExternalType name;
+				space;
+				nextPutAll: ( AtomicTypeNames at: self atomicType )
+			]
+		ifNotNil: [ aStream
+				nextPut: $(;
+				nextPutAll: ExternalType name;
+				space;
+				nextPutAll: #structTypeNamed:;
+				space;
+				store: referentClass name;
+				nextPut: $)
+			].
+	self isPointerType
+		ifTrue: [ aStream
+				space;
+				nextPutAll: #asPointer
+			]
 ]
 
 { #category : #printing }

--- a/src/Files/FileException.class.st
+++ b/src/Files/FileException.class.st
@@ -48,9 +48,8 @@ FileException >> isResumable [
 
 { #category : #exceptiondescription }
 FileException >> messageText [
+
 	"Return an exception's message text."
 
-	^ messageText isNil
-		ifTrue: [ fileName printString ]
-		ifFalse: [ messageText ]
+	^ messageText ifNil: [ fileName printString ] ifNotNil: [ messageText ]
 ]

--- a/src/Fonts-Chooser/FontChooserMorph.class.st
+++ b/src/Fonts-Chooser/FontChooserMorph.class.st
@@ -444,30 +444,38 @@ FontChooserMorph >> pointSizeString: aText [
 
 { #category : #accessing }
 FontChooserMorph >> previewText [
+
 	"Answer the preview text based on current font."
-	
+
 	| sample i maxLineLength endOfLineCharacters |
-	model selectedFont isNil ifTrue: [ ^'' ].
+
+	model selectedFont ifNil: [ ^ '' ].
 	sample := String new writeStream.
-	model selectedFont isSymbolFont ifFalse: [ 
-		| pangram |
-		pangram := self selectedPangram.
-		sample 
-			nextPutAll: pangram; cr;
-			nextPutAll: pangram asUppercase;
-			cr ].
+	model selectedFont isSymbolFont
+		ifFalse: [ | pangram |
+
+			pangram := self selectedPangram.
+			sample
+				nextPutAll: pangram;
+				cr;
+				nextPutAll: pangram asUppercase;
+				cr
+			].
 	i := 0.
 	maxLineLength := 30.
 	endOfLineCharacters := '@Z`z'.
-	33 to: 255 do: [ :asciiValue | | character |
+	33 to: 255 do: [ :asciiValue | 
+		| character |
+
 		character := Character value: asciiValue.
 		sample nextPut: character.
 		i := i + 1.
-		((endOfLineCharacters includes: character) or: [ i = maxLineLength ]) 
-			ifTrue: [ 
-				i := 0.
-				sample cr ] ].
-	^ sample contents.
+		( ( endOfLineCharacters includes: character ) or: [ i = maxLineLength ] )
+			ifTrue: [ i := 0.
+				sample cr
+				]
+		].
+	^ sample contents
 ]
 
 { #category : #accessing }

--- a/src/FreeType/FT2Face.class.st
+++ b/src/FreeType/FT2Face.class.st
@@ -55,10 +55,12 @@ Class {
 
 { #category : #finalization }
 FT2Face class >> finalizeResourceData: handle [
-	handle isNil ifTrue: [ ^ self ].
-	handle isNull ifTrue: [ ^ self ].
 
-	FT2Library current ffiDoneFace: handle. 
+	handle ifNil: [ ^ self ].
+	handle isNull
+		ifTrue: [ ^ self ].
+
+	FT2Library current ffiDoneFace: handle.
 	handle beNull
 ]
 

--- a/src/FreeType/FreeTypeExternalMemory.class.st
+++ b/src/FreeType/FreeTypeExternalMemory.class.st
@@ -20,8 +20,10 @@ FreeTypeExternalMemory class >> bytes: aByteArray [
 
 { #category : #finalization }
 FreeTypeExternalMemory class >> finalizeResourceData: handle [
-	handle isNil ifTrue: [ ^ self ].
-	handle isNull ifTrue: [ ^ self ].
+
+	handle ifNil: [ ^ self ].
+	handle isNull
+		ifTrue: [ ^ self ].
 	handle free.
 	handle beNull
 ]

--- a/src/Fuel-Tests-Core/BlockClosure.extension.st
+++ b/src/Fuel-Tests-Core/BlockClosure.extension.st
@@ -2,25 +2,22 @@ Extension { #name : #BlockClosure }
 
 { #category : #'*Fuel-Tests-Core' }
 BlockClosure >> assertWellMaterializedInto: aBlockClosure in: aTestCase [
-	
-	aTestCase assert: self ~~ aBlockClosure. 
-	aTestCase assert: (self class == aBlockClosure class).
+
+	aTestCase assert: self ~~ aBlockClosure.
+	aTestCase assert: self class == aBlockClosure class.
 	aTestCase assert: numArgs = aBlockClosure numArgs.
 	aTestCase assert: startpc = aBlockClosure startpc.
-	
-	outerContext isNil
-        ifTrue: [ self assert: aBlockClosure outerContext isNil ]
-        ifFalse: [
-            self isClean
-                ifTrue: [    
-                    "self assert: self receiver = aBlockClosure receiver."
-                    self assert: (self method isEqualRegardlessTrailerTo: aBlockClosure method).
-                    self assert: aBlockClosure outerContext sender isNil.
-                    self assert: aBlockClosure outerContext arguments isEmpty.
-                      ]
-                ifFalse: [outerContext assertWellMaterializedInto: aBlockClosure outerContext in: aTestCase]
-             ]
 
+	outerContext
+		ifNil: [ self assert: aBlockClosure outerContext isNil ]
+		ifNotNil: [ self isClean
+				ifTrue: [ "self assert: self receiver = aBlockClosure receiver."
+					self assert: ( self method isEqualRegardlessTrailerTo: aBlockClosure method ).
+					self assert: aBlockClosure outerContext sender isNil.
+					self assert: aBlockClosure outerContext arguments isEmpty
+					]
+				ifFalse: [ outerContext assertWellMaterializedInto: aBlockClosure outerContext in: aTestCase ]
+			]
 ]
 
 { #category : #'*Fuel-Tests-Core' }

--- a/src/Fuel-Tests-Core/Context.extension.st
+++ b/src/Fuel-Tests-Core/Context.extension.st
@@ -3,19 +3,19 @@ Extension { #name : #Context }
 { #category : #'*Fuel-Tests-Core' }
 Context >> assertWellMaterializedInto: aMethodContext in: aTestCase [
 
-	aTestCase assert: self ~~ aMethodContext. 
-	aTestCase assert: (self class == aMethodContext class).
-	aTestCase assert: self tempNames = aMethodContext  tempNames.
+	aTestCase assert: self ~~ aMethodContext.
+	aTestCase assert: self class == aMethodContext class.
+	aTestCase assert: self tempNames = aMethodContext tempNames.
 	aTestCase assert: pc = aMethodContext pc.
 	aTestCase assert: stackp = aMethodContext stackPtr.
-	closureOrNil isNil 
-		ifTrue: [ aTestCase assert: aMethodContext closure isNil ]
-		ifFalse: [ closureOrNil assertWellMaterializedInto: aMethodContext closure in: aTestCase ].
+	closureOrNil
+		ifNil: [ aTestCase assert: aMethodContext closure isNil ]
+		ifNotNil: [ closureOrNil assertWellMaterializedInto: aMethodContext closure in: aTestCase ].
 	aTestCase assert: receiver = aMethodContext receiver.
-	aTestCase assert: (method isEqualRegardlessTrailerTo: aMethodContext method).
-	sender isNil 
-		ifTrue: [ aTestCase assert: aMethodContext sender isNil ]
-		ifFalse: [ sender assertWellMaterializedInto: aMethodContext sender in: aTestCase ]
+	aTestCase assert: ( method isEqualRegardlessTrailerTo: aMethodContext method ).
+	sender
+		ifNil: [ aTestCase assert: aMethodContext sender isNil ]
+		ifNotNil: [ sender assertWellMaterializedInto: aMethodContext sender in: aTestCase ]
 ]
 
 { #category : #'*Fuel-Tests-Core' }


### PR DESCRIPTION
Use `ifNil:`,  `ifNotNil:` and `ifNil:ifNotNil:` instead of `isNil` and `ifTrue/ifFalse` combinations 