### PR TITLE
ClassBinding for Metaclass

### DIFF
--- a/src/ClassParser/CDClassDefinitionNode.class.st
+++ b/src/ClassParser/CDClassDefinitionNode.class.st
@@ -23,7 +23,7 @@ CDClassDefinitionNode class >> on: aRBMessageNode [
 { #category : #accessing }
 CDClassDefinitionNode >> binding [ 
 	Transcript show: '.'.
-	^ self class environment associationAt: self className ifAbsent: [nil -> self].
+	^ self class environment associationAt: self className ifAbsent: [ClassBinding key: nil value: self].
 ]
 
 { #category : #testing }

--- a/src/ClassParser/CDClassDefinitionNode.class.st
+++ b/src/ClassParser/CDClassDefinitionNode.class.st
@@ -23,7 +23,7 @@ CDClassDefinitionNode class >> on: aRBMessageNode [
 { #category : #accessing }
 CDClassDefinitionNode >> binding [ 
 	Transcript show: '.'.
-	^ self class environment associationAt: self className ifAbsent: [ClassBinding key: nil value: self].
+	^ self class environment associationAt: self className ifAbsent: [LiteralVariable key: nil value: self].
 ]
 
 { #category : #testing }

--- a/src/ClassParser/CDClassNameNode.class.st
+++ b/src/ClassParser/CDClassNameNode.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #accessing }
 CDClassNameNode >> binding [
 	| classBinding |
-	classBinding := self existingBindingIfAbsent: [ClassBinding key: className value: nil].
+	classBinding := self existingBindingIfAbsent: [LiteralVariable key: className value: nil].
 	^OCLiteralVariable new 
 		scope: originalNode scope;
 		assoc: classBinding

--- a/src/ClassParser/CDClassNameNode.class.st
+++ b/src/ClassParser/CDClassNameNode.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #accessing }
 CDClassNameNode >> binding [
 	| classBinding |
-	classBinding := self existingBindingIfAbsent: [className -> nil].
+	classBinding := self existingBindingIfAbsent: [ClassBinding key: className value: nil].
 	^OCLiteralVariable new 
 		scope: originalNode scope;
 		assoc: classBinding

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -451,7 +451,7 @@ Behavior >> becomeUncompact [
 
 { #category : #accessing }
 Behavior >> binding [
-	^ nil -> self
+	^ ClassBinding key: nil value: self
 ]
 
 { #category : #'accessing instances and variables' }

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -451,7 +451,7 @@ Behavior >> becomeUncompact [
 
 { #category : #accessing }
 Behavior >> binding [
-	^ ClassBinding key: nil value: self
+	^ LiteralVariable key: nil value: self
 ]
 
 { #category : #'accessing instances and variables' }

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -233,10 +233,10 @@ Class >> basicCategory: aSymbol [
 
 { #category : #compiling }
 Class >> binding [
-       "Answer a binding for the receiver, sharing if possible"
-      | binding |
-	binding := self environment associationAt: self name ifAbsent: [nil -> self].
-       ^binding value == self ifTrue: [binding] ifFalse: [nil -> self]
+   "Answer a binding for the receiver, sharing if possible"
+   | binding |
+	binding := self environment associationAt: self name ifAbsent: [ClassBinding key: nil value: self].
+   ^binding value == self ifTrue: [binding] ifFalse: [ClassBinding key: nil value: self]
 ]
 
 { #category : #compiling }

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -235,8 +235,8 @@ Class >> basicCategory: aSymbol [
 Class >> binding [
    "Answer a binding for the receiver, sharing if possible"
    | binding |
-	binding := self environment associationAt: self name ifAbsent: [ClassBinding key: nil value: self].
-   ^binding value == self ifTrue: [binding] ifFalse: [ClassBinding key: nil value: self]
+	binding := self environment associationAt: self name ifAbsent: [LiteralVariable key: nil value: self].
+   ^binding value == self ifTrue: [binding] ifFalse: [LiteralVariable key: nil value: self]
 ]
 
 { #category : #compiling }

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -71,7 +71,7 @@ Metaclass >> binding [
 	"return an association that can be used as the binding
 	 To share it between methods, reuse an existing one if possible"
 	^self methodDict 
-		ifEmpty: [ClassBinding key: nil value: self]
+		ifEmpty: [LiteralVariable key: nil value: self]
 		ifNotEmpty: [:dict | dict anyOne classBinding]
 ]
 

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -71,7 +71,7 @@ Metaclass >> binding [
 	"return an association that can be used as the binding
 	 To share it between methods, reuse an existing one if possible"
 	^self methodDict 
-		ifEmpty: [nil -> self]
+		ifEmpty: [ClassBinding key: nil value: self]
 		ifNotEmpty: [:dict | dict anyOne classBinding]
 ]
 

--- a/src/Slot-Core/ClassBinding.class.st
+++ b/src/Slot-Core/ClassBinding.class.st
@@ -1,0 +1,8 @@
+"
+Methods on the class side encode the class they are installed in by storing instances of ClassBinding in the literal of the method.
+"
+Class {
+	#name : #ClassBinding,
+	#superclass : #LiteralVariable,
+	#category : #'Slot-Core-Variables'
+}

--- a/src/Slot-Core/ClassBinding.class.st
+++ b/src/Slot-Core/ClassBinding.class.st
@@ -1,8 +1,0 @@
-"
-Methods on the class side encode the class they are installed in by storing instances of ClassBinding in the literal of the method.
-"
-Class {
-	#name : #ClassBinding,
-	#superclass : #LiteralVariable,
-	#category : #'Slot-Core-Variables'
-}


### PR DESCRIPTION
metaclasses use Association as a class binding. We should make a subclass of LiteralVariable so that we can implement a compatible API