### PR TITLE
ifNil usage on UFFI

### DIFF
--- a/src/UnifiedFFI/FFIExternalStructureFlatLayout.class.st
+++ b/src/UnifiedFFI/FFIExternalStructureFlatLayout.class.st
@@ -50,23 +50,24 @@ FFIExternalStructureFlatLayout >> alignment: anObject [
 
 { #category : #'system v abi' }
 FFIExternalStructureFlatLayout >> combineSysVAMD64RegisterClass: leftClass with: rightClass [
+
 	"AMD64 SystemV eightbyte classification reduction"
-	
+
 	"Same class."
 	leftClass == rightClass ifTrue: [ ^ leftClass ].
-	
+
 	"If one has no class, use the other."
-	leftClass isNil ifTrue: [ ^ rightClass ].
-	rightClass isNil ifTrue: [ ^ leftClass ].
-	
+	leftClass ifNil: [ ^ rightClass ].
+	rightClass ifNil: [ ^ leftClass ].
+
 	"If one is memory, the result is memory."
-	(leftClass == #memory or: [ rightClass == #memory ]) ifTrue: [ ^ #memory ].
-	
+	( leftClass == #memory or: [ rightClass == #memory ] ) ifTrue: [ ^ #memory ].	
+
 	"If one is integer, the result is integer."
-	(leftClass == #integer or: [ rightClass == #integer ]) ifTrue: [ ^ #integer ].
-	
-	"TODO: If one of the classes is X87, X87UP, COMPLEX_X87 class, #memory is used as class."
-	
+	( leftClass == #integer or: [ rightClass == #integer ] ) ifTrue: [ ^ #integer ].
+
+	"TODO: If one of the classes is X87, X87UP, COMPLEX_X87 class, #memory is used as class."	
+
 	"Otherwise, use the SSE class"
 	^ #float
 ]

--- a/src/UnifiedFFI/FFIFunctionParser.class.st
+++ b/src/UnifiedFFI/FFIFunctionParser.class.st
@@ -228,26 +228,28 @@ FFIFunctionParser >> parseReturn [
 
 { #category : #parsing }
 FFIFunctionParser >> parseType [
+
 	" parse type name and optional number of asterisks, following it"
+
 	| typeName ptrArity |
 
 	typeName := self parseWord.
-	typeName isNil ifTrue: [ ^ self error: 'type name expected' ].
+	typeName ifNil: [ ^ self error: 'type name expected' ].	
 
-	"skip 'const' , which is often used but has no any use for us "	
-	typeName = 'const' ifTrue: [
-		self skipSpace.
-		typeName := self parseWord.
-		typeName isNil ifTrue: [ ^ self error: 'type name expected' ] ].
-	
+	"skip 'const' , which is often used but has no any use for us "
+	typeName = 'const'
+		ifTrue: [ self skipSpace.
+			typeName := self parseWord.
+			typeName ifNil: [ ^ self error: 'type name expected' ]
+			].
+
 	ptrArity := 0.
-	[ self skipSpace. stream peek = $* ] 
-	whileTrue: [ 
-		ptrArity := ptrArity + 1.
-		stream next ].
-
+	[ self skipSpace. stream peek = $* ]
+		whileTrue: [ ptrArity := ptrArity + 1.
+			stream next
+			].	
 	"Answer a tuple name, arity"
-	^ { typeName. ptrArity }
+	^ {typeName. ptrArity}
 ]
 
 { #category : #parsing }


### PR DESCRIPTION
Use `ifNil:`,  `ifNotNil:` and `ifNil:ifNotNil:` instead of `isNil` and `ifTrue/ifFalse` combinations 