### PR TITLE
Deprecate two exceptions never used

### DIFF
--- a/src/Deprecated80/FloatingPointException.class.st
+++ b/src/Deprecated80/FloatingPointException.class.st
@@ -8,5 +8,11 @@ ZeroDivide, DomainError and NaNException are examples of more specific Arithmeti
 Class {
 	#name : #FloatingPointException,
 	#superclass : #ArithmeticError,
-	#category : #'Kernel-Exceptions'
+	#category : #Deprecated80
 }
+
+{ #category : #deprecation }
+FloatingPointException class >> isDeprecated [
+
+	^ true
+]

--- a/src/Deprecated80/NaNException.class.st
+++ b/src/Deprecated80/NaNException.class.st
@@ -4,5 +4,11 @@ I am NaNException, an ArithmeticException signaled when Float nan was encountere
 Class {
 	#name : #NaNException,
 	#superclass : #ArithmeticError,
-	#category : #'Kernel-Exceptions'
+	#category : #Deprecated80
 }
+
+{ #category : #deprecation }
+NaNException class >> isDeprecated [
+
+	^ true
+]


### PR DESCRIPTION
`FloatingPointException` and `NaNException` are never signaled nor handled