### PR TITLE
Add isNil code critic rule

### DIFF
--- a/src/GeneralRules/GRGuardClauseRule.class.st
+++ b/src/GeneralRules/GRGuardClauseRule.class.st
@@ -19,18 +19,18 @@ foo
 ]]]
 "
 Class {
-	#name : #GRGuradGuardClauseRule,
+	#name : #GRGuardClauseRule,
 	#superclass : #ReNodeRewriteRule,
 	#category : #GeneralRules
 }
 
 { #category : #accessing }
-GRGuradGuardClauseRule >> group [
+GRGuardClauseRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
 { #category : #initialization }
-GRGuradGuardClauseRule >> initialize [
+GRGuardClauseRule >> initialize [
 	super initialize.
 	self 
 		addMatchingMethod: '`@methodName: `@args 
@@ -58,6 +58,6 @@ GRGuradGuardClauseRule >> initialize [
 ]
 
 { #category : #accessing }
-GRGuradGuardClauseRule >> name [
+GRGuardClauseRule >> name [
 	^ 'Replace single branch conditional with guard clause'
 ]

--- a/src/GeneralRules/RBIsNilAndConditionalRule.class.st
+++ b/src/GeneralRules/RBIsNilAndConditionalRule.class.st
@@ -1,0 +1,40 @@
+"
+Replaces isNil ifTrue , isNil ifFalse and isNil ifTrue:ifFalse by ifNil: , ifNotNil and ifNil:ifNotNil: to make the code more readable. Helps to avoid unnecesary temporal variables.
+"
+Class {
+	#name : #RBIsNilAndConditionalRule,
+	#superclass : #ReNodeRewriteRule,
+	#category : #'GeneralRules-Migrated'
+}
+
+{ #category : #accessing }
+RBIsNilAndConditionalRule >> group [
+
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : #initialization }
+RBIsNilAndConditionalRule >> initialize [
+
+	super initialize.
+	self
+		replace: '``@receiver isNil ifFalse: ``@notNilBlock' with: '``@receiver ifNotNil: ``@notNilBlock';
+		replace: '``@receiver isNil ifTrue: ``@nilBlock' with: '``@receiver ifNil: ``@nilBlock';
+		replace: '``@receiver isNil ifTrue: ``@nilBlock ifFalse: ``@notNilBlock'
+			with: '``@receiver ifNil: ``@nilBlock ifNotNil: ``@notNilBlock';
+		replace: '``@receiver isNil ifFalse: ``@notNilBlock ifTrue: ``@nilBlock'
+			with: '``@receiver ifNil: ``@nilBlock ifNotNil: ``@notNilBlock'
+]
+
+{ #category : #accessing }
+RBIsNilAndConditionalRule >> name [
+
+	^ 'Sends isNil and a conditional check instead of using #ifNil: #ifNotNil: or #ifNil:ifNotNil:'
+]
+
+{ #category : #accessing }
+RBIsNilAndConditionalRule >> rationale [
+
+	^ 'Using specific conditional methods leads to shorter code and helps in avoiding unneeded temporary variables.<n><n>Replaces<n><t>isNil ifTrue: ~~> ifNil:<n><t>isNil ifFalse: ~~> ifNotNil:<n><t>isNil ifTrue:ifFalse ~~> ifNil:ifNotNil:'
+		expandMacros
+]


### PR DESCRIPTION
- Add a code critic rule to use `ifNil:` variants instead of `isNil` and a conditional check, including the automatic fix option.

- Rename `GRGuradGuardClauseRule` to fix typo.