### PR TITLE
4007-Propagate-correctly-changes-in-a-trait-when-used-in-an-anonymous-class

### DIFF
--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -124,6 +124,10 @@ ShiftClassInstaller >> initialize [
 
 { #category : #building }
 ShiftClassInstaller >> installInEnvironment: newClass [
+
+	"I only install if there is a name / non anonymous"
+	builder name ifNil: [ ^ self ].
+
 	"I only install in the environment if there is not oldClass installed."
 	(self installingEnvironment hasClassNamed: builder name) ifFalse:[
 		self installingEnvironment installClass: newClass withName: builder name.
@@ -136,6 +140,10 @@ ShiftClassInstaller >> installInEnvironment: newClass [
 
 { #category : #building }
 ShiftClassInstaller >> installSubclassInSuperclass: newClass [
+
+	"I only install if there is a name / non anonymous"
+	builder name ifNil: [ ^ self ].
+
 	newClass superclass addSubclass: newClass
 ]
 

--- a/src/TraitsV2-Tests/T2TraitTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitTest.class.st
@@ -304,3 +304,23 @@ T2TraitTest >> testTraitHaveUsersInstanceVariable [
 	self assert: (aClass slotNamed: #users) definingClass equals: t1
 
 ]
+
+{ #category : #tests }
+T2TraitTest >> testUsingTraitInAnonymousSubClassAndRedefiningIt [
+	| t1 aClass |
+
+	t1 := self newTrait: #T1 with: #().
+
+	aClass := Smalltalk anonymousClassInstaller make: [ :builder |
+		builder superclass: Object.
+		builder traitComposition: t1.
+	].
+
+	self deny: (Object subclasses includes: aClass).
+	
+	t1 := self newTrait: #T1 with: #(aSlot).
+	self assert: (aClass hasSlotNamed: #aSlot).
+	
+	self deny: (Object subclasses includes: aClass).
+
+]


### PR DESCRIPTION
When a trait is used in an anonymous class changing the trait should not install in the system environment.