### PR TITLE
4001-BehaviorparseTreeFor-should-call-parseTree-on-CompiledMethod

### DIFF
--- a/src/AST-Core/Behavior.extension.st
+++ b/src/AST-Core/Behavior.extension.st
@@ -2,5 +2,5 @@ Extension { #name : #Behavior }
 
 { #category : #'*ast-core' }
 Behavior >> parseTreeFor: aSymbol [	
-	^ RBParser parseMethod: (self sourceCodeAt: aSymbol) onError: [ :msg :pos | ^ nil ]
+	^ (self compiledMethodAt: aSymbol) parseTree
 ]


### PR DESCRIPTION
fixes #4001

#parseFor: should reuse the method #parseTree on CompiledMethod