### PR TITLE
Use Integer literal to avoid Float in GemStone

### DIFF
--- a/src/Kernel/DateAndTime.class.st
+++ b/src/Kernel/DateAndTime.class.st
@@ -201,7 +201,7 @@ DateAndTime class >> now [
 	[ 10000 timesRepeat: [ self now. ] ] timeToRun / 10000.0 . "
 
 	| nanoTicks |
-	nanoTicks := self clock microsecondClockValue * 1e3.
+	nanoTicks := self clock microsecondClockValue * 1000.
 	^ self basicNew
 		setJdn: SqueakEpoch 
 		seconds: 0


### PR DESCRIPTION
GemStone treats 1e3 as a SmallDouble (Float) while Pharo treats it as an Integer. Here we make it explicitly an Integer as 1000.