### PR TITLE
moveCodeCompletionAroundToEditor

### DIFF
--- a/src/NECompletion/NECController.class.st
+++ b/src/NECompletion/NECController.class.st
@@ -34,23 +34,6 @@ NECController class >> cleanUp [
 ]
 
 { #category : #accessing }
-NECController class >> codeCompletionAround: aBlock textMorph: aTextMorph keyStroke: evt [
-	"Inserts code completion if allowed in this morph"
-	
-	| editor controller |
-	self isCompletionEnabled ifFalse: [ ^aBlock value ].
-	editor := aTextMorph editor ifNil: [ ^aBlock value ].
-	editor isCompletionEnabled ifFalse: [  ^aBlock value ].
-	controller := self uniqueInstance.
-	controller setModel: editor model.
-	
-	(controller handleKeystrokeBefore: evt editor: editor) ifTrue:  [^ self ].
-	aBlock value.
-	controller handleKeystrokeAfter: evt editor: editor.
-
-]
-
-{ #category : #accessing }
 NECController class >> contextClass [
 	^ContextClass ifNil: [ ^NECContext ] 
 ]

--- a/src/NECompletion/TestTypingVisitor.class.st
+++ b/src/NECompletion/TestTypingVisitor.class.st
@@ -54,7 +54,7 @@ TestTypingVisitor >> visitBlockNode: aBlockNode [
 ]
 
 { #category : #visiting }
-TestTypingVisitor >> visitGlobalNode: aGlobalNode [
+TestTypingVisitor >> visitGlobalNode: aGlobalNode [ 
 	aGlobalNode propertyAt: #type put: (Smalltalk globals at: aGlobalNode name) class.
 ]
 

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -343,15 +343,18 @@ RubSmalltalkEditor >> compileSelectionFor: anObject in: evalContext [
 ]
 
 { #category : #'completion engine' }
-RubSmalltalkEditor >> completionAround:  aBlock  keyStroke: anEvent [
+RubSmalltalkEditor >> completionAround: aBlock keyStroke: anEvent [
 	"I'm a editor for Smalltalk, so, ok do completion around"
 	
-	self isCompletionEnabled 
-		ifTrue: [ self completionEngine 
-						codeCompletionAround: aBlock 
-						textMorph: textArea 
-						keyStroke: anEvent
-					]
+	| controller |
+	self isCompletionEnabled ifFalse: [  ^aBlock value ].
+	controller := CompletionEngine uniqueInstance.
+	controller setModel: self model.
+	
+	(controller handleKeystrokeBefore: anEvent editor: self) ifTrue:  [^ self ].
+	aBlock value.
+	controller handleKeystrokeAfter: anEvent editor: self.
+
 ]
 
 { #category : #'completion engine' }
@@ -794,7 +797,7 @@ RubSmalltalkEditor >> internalCallToImplementorsOf: aSelector [
 
 { #category : #'completion engine' }
 RubSmalltalkEditor >> isCompletionEnabled [
-
+	CompletionEngine isCompletionEnabled ifFalse: [ ^false ].
 	^ completionEngine isNotNil and: [ self editingMode isCompletionEnabled ]
 ]
 

--- a/src/Text-Edition/TextEditor.class.st
+++ b/src/Text-Edition/TextEditor.class.st
@@ -824,12 +824,6 @@ TextEditor >> closeTypeIn [
 			self doneTyping]
 ]
 
-{ #category : #private }
-TextEditor >> codeCompletionAround:  aBlock textMorph:  aTextMorph keyStroke: anEvent [
-	" No code completion for simple text editor, so nothing special to do here around the block execution"
-	aBlock value
-]
-
 { #category : #'menu messages' }
 TextEditor >> compareToClipboard [
 	"Check to see if whether the receiver's text is the same as the text currently on the clipboard, and inform the user."


### PR DESCRIPTION
This is a preparation to get rid of the uniqueInstace in the completion engine: the editor should handle instantiation.

To prepare this, we move the method where the uniqueInstance is created to the editor. This implifies the code a bit already, too