### PR TITLE
4029-CodeCompletion-bug-fix-for-visitBlockNode

### DIFF
--- a/src/NECompletion/RBMethodNode.extension.st
+++ b/src/NECompletion/RBMethodNode.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #RBMethodNode }
-
-{ #category : #'*NECompletion' }
-RBMethodNode >> completionToken [
-	^ ''
-]

--- a/src/NECompletion/RBParseErrorNode.extension.st
+++ b/src/NECompletion/RBParseErrorNode.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #RBParseErrorNode }
-
-{ #category : #'*NECompletion' }
-RBParseErrorNode >> completionToken [
-	^''
-]

--- a/src/NECompletion/RBProgramNode.extension.st
+++ b/src/NECompletion/RBProgramNode.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : #RBProgramNode }
 
 { #category : #'*NECompletion' }
+RBProgramNode >> completionToken [
+	^ String empty
+]
+
+{ #category : #'*NECompletion' }
 RBProgramNode >> narrowWith: aString [
 
  	"Do nothing"

--- a/src/NECompletion/RBSequenceNode.extension.st
+++ b/src/NECompletion/RBSequenceNode.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #RBSequenceNode }
-
-{ #category : #'*NECompletion' }
-RBSequenceNode >> completionToken [
-	^ String empty
-]

--- a/src/NECompletion/TestMatchedNodeProducer.class.st
+++ b/src/NECompletion/TestMatchedNodeProducer.class.st
@@ -40,6 +40,12 @@ TestMatchedNodeProducer >> visitArgumentNode: anArgumentNode [
 ]
 
 { #category : #visiting }
+TestMatchedNodeProducer >> visitBlockNode: aRBBlockNode [
+	
+	^ #()
+]
+
+{ #category : #visiting }
 TestMatchedNodeProducer >> visitGlobalNode: aRBGlobalNode [ 
 	^ self visitVariableNode: aRBGlobalNode 
 ]
@@ -122,7 +128,7 @@ TestMatchedNodeProducer >> visitTemporaryNode: aNode [
 { #category : #visiting }
 TestMatchedNodeProducer >> visitVariableNode: aRBVariableNode [  
 	aRBVariableNode isDefinition ifTrue: [ ^ (self select: Symbol allSymbols beginningWith: aRBVariableNode name) ].
-   (aRBVariableNode isArgument ifTrue: [ ^ (self select: Symbol allSymbols beginningWith: aRBVariableNode name) ]).
+   (aRBVariableNode isArgument ifTrue: [ ^ (self select: Symbol allSymbols beginningWith: aRBVariableNode name) select: [ :each | each numArgs = 0 ] ]).
 	"using a stream to store results should be better"
 	^ (self select: Smalltalk globals keys beginningWith: aRBVariableNode name) , 
 	  (self select: (currentClass allSlots collect: [ :each | each name ]) beginningWith: aRBVariableNode name) ,


### PR DESCRIPTION
- add fallBack #completionToken to RBProgramNode
- add #visitBlockNode: to the NodeProducer
- for arguments: only show 0-arg selectors as possible completion