### PR TITLE
4045-RBSequenceNode-stop-does-not-take-temp-definitions-into-account

### DIFF
--- a/src/AST-Core-Tests/RBSequenceNodeTest.class.st
+++ b/src/AST-Core-Tests/RBSequenceNodeTest.class.st
@@ -1,0 +1,12 @@
+Class {
+	#name : #RBSequenceNodeTest,
+	#superclass : #TestCase,
+	#category : #'AST-Core-Tests-Nodes'
+}
+
+{ #category : #tests }
+RBSequenceNodeTest >> testStop [
+| ast |
+ast := RBParser parseMethod: 'method | temp |'.
+self assert: ast body stop equals: ast body temporaries last stop.
+]

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -451,8 +451,11 @@ RBSequenceNode >> statements: stmtCollection [
 
 { #category : #accessing }
 RBSequenceNode >> stop [
-	^(periods isEmpty ifTrue: [0] ifFalse: [periods last]) 
-		max: (statements isEmpty ifTrue: [0] ifFalse: [statements last stop])
+	^{  
+	temporaries isEmpty ifTrue: [0] ifFalse: [ self temporaries last stop]. 
+	periods isEmpty ifTrue: [0] ifFalse: [periods last].
+	statements isEmpty ifTrue: [0] ifFalse: [statements last stop]
+	} max
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
test + fix for #4045