### PR TITLE
Speedup code loading for big packages

### DIFF
--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -149,8 +149,7 @@ BaselineOfMorphic >> cleanUpAfterMorphicInitialization [
 	World cleanseOtherworldlySteppers.
 	Smalltalk organization removeEmptyCategories.
 	MCFileBasedRepository flushAllCaches.
-	MCMethodDefinition shutDown. 
-	MCDefinition clearInstances.
+	MCMethodDefinition shutDown.
 	ExternalDropHandler resetRegisteredHandlers.
 	Undeclared removeUnreferencedKeys.
 	Smalltalk globals flushClassNameCache.

--- a/src/Monticello-Tests/MCSnapshotTest.class.st
+++ b/src/Monticello-Tests/MCSnapshotTest.class.st
@@ -22,18 +22,3 @@ MCSnapshotTest >> testCreation [
 	self assert: (d allSatisfy: [:ea | ea isClassDefinition not or: [ea category endsWith: 'Mocks']]).
 	
 ]
-
-{ #category : #tests }
-MCSnapshotTest >> testInstanceReuse [
-	| x m n y |
-	
-	self timeLimit: 300 seconds.
-	
-	x := (MCPackage new name: self mockCategoryName) snapshot.
-	Smalltalk garbageCollect.
-	n := MCDefinition allSubInstances size.
-	y := (MCPackage new name: self mockCategoryName) snapshot.
-	Smalltalk garbageCollect.
-	m := MCDefinition allSubInstances size.
-	self assert: m = n
-]

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -63,29 +63,20 @@ comment: commentString [
 ]
 
 { #category : #'instance creation' }
-MCClassDefinition class >> name: nameString
-superclassName: superclassString
-category: categoryString 
-instVarNames: ivarArray
-classVarNames: cvarArray
-poolDictionaryNames: poolArray
-classInstVarNames: civarArray
-type: typeSymbol
-comment: commentString
-commentStamp: stampString [
-	^ self instanceLike:
-		(self new initializeWithName: nameString
-					superclassName: superclassString
-					traitComposition: '{}'
-					classTraitComposition: '{}'
-					category: categoryString 
-					instVarNames: ivarArray
-					classVarNames: cvarArray
-					poolDictionaryNames: poolArray
-					classInstVarNames: civarArray
-					type: typeSymbol
-					comment: commentString
-					commentStamp: stampString)
+MCClassDefinition class >> name: nameString superclassName: superclassString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol comment: commentString commentStamp: stampString [
+	^ self new
+		initializeWithName: nameString
+		superclassName: superclassString
+		traitComposition: '{}'
+		classTraitComposition: '{}'
+		category: categoryString
+		instVarNames: ivarArray
+		classVarNames: cvarArray
+		poolDictionaryNames: poolArray
+		classInstVarNames: civarArray
+		type: typeSymbol
+		comment: commentString
+		commentStamp: stampString
 ]
 
 { #category : #obsolete }
@@ -106,32 +97,20 @@ comment: commentString [
 ]
 
 { #category : #'instance creation' }
-MCClassDefinition class >> name: nameString
-superclassName: superclassString
-traitComposition: traitCompositionString
-classTraitComposition: classTraitCompositionString
-category: categoryString 
-instVarNames: ivarArray
-classVarNames: cvarArray
-poolDictionaryNames: poolArray
-classInstVarNames: civarArray
-type: typeSymbol
-comment: commentString
-commentStamp: stampString [
-	
-	^ self instanceLike:
-		(self new initializeWithName: nameString
-					superclassName: superclassString
-					traitComposition: traitCompositionString
-					classTraitComposition: classTraitCompositionString
-					category: categoryString 
-					instVarNames: ivarArray
-					classVarNames: cvarArray
-					poolDictionaryNames: poolArray
-					classInstVarNames: civarArray
-					type: typeSymbol
-					comment: commentString
-					commentStamp: stampString)
+MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol comment: commentString commentStamp: stampString [
+	^ self new
+		initializeWithName: nameString
+		superclassName: superclassString
+		traitComposition: traitCompositionString
+		classTraitComposition: classTraitCompositionString
+		category: categoryString
+		instVarNames: ivarArray
+		classVarNames: cvarArray
+		poolDictionaryNames: poolArray
+		classInstVarNames: civarArray
+		type: typeSymbol
+		comment: commentString
+		commentStamp: stampString
 ]
 
 { #category : #comparing }

--- a/src/Monticello/MCClassTraitDefinition.class.st
+++ b/src/Monticello/MCClassTraitDefinition.class.st
@@ -19,11 +19,10 @@ MCClassTraitDefinition class >> baseTraitName: aString classTraitComposition: cl
 
 { #category : #'instance creation' }
 MCClassTraitDefinition class >> baseTraitName: aString classTraitComposition: classTraitCompositionString category: aCategoryString [
-	^self instanceLike: (
-		self new
-			initializeWithBaseTraitName: aString
-			classTraitComposition: classTraitCompositionString
-			category: aCategoryString).
+	^ self new
+		initializeWithBaseTraitName: aString
+		classTraitComposition: classTraitCompositionString
+		category: aCategoryString
 ]
 
 { #category : #comparing }

--- a/src/Monticello/MCDefinition.class.st
+++ b/src/Monticello/MCDefinition.class.st
@@ -4,34 +4,8 @@ A MCDefinition is the root of inheritance of entities representing code.
 Class {
 	#name : #MCDefinition,
 	#superclass : #Object,
-	#classVars : [
-		'Instances',
-		'InstancesWriteLock'
-	],
 	#category : #'Monticello-Base'
 }
-
-{ #category : #cleanup }
-MCDefinition class >> cleanUp [
-	"Flush caches"
-
-	self clearInstances.
-]
-
-{ #category : #cleanup }
-MCDefinition class >> clearInstances [
-	WeakArray removeWeakDependent: Instances.
-	Instances := nil
-]
-
-{ #category : #'instance creation' }
-MCDefinition class >> instanceLike: aDefinition [
-	Instances ifNil: [ Instances := WeakSet new ].
-	InstancesWriteLock ifNil: [ InstancesWriteLock := Semaphore forMutualExclusion ].
-	^ (Instances like: aDefinition) 
-		ifNil: [
-			InstancesWriteLock critical: [ Instances add: aDefinition ]]
-]
 
 { #category : #comparing }
 MCDefinition >> <= other [

--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -38,19 +38,14 @@ MCMethodDefinition class >> cachedDefinitions [
 ]
 
 { #category : #'instance creation' }
-MCMethodDefinition class >> className: classString
-classIsMeta: metaBoolean
-selector: selectorString
-category: catString
-timeStamp: timeString
-source: sourceString [
-	^ self instanceLike:
-		(self new initializeWithClassName: classString
-					classIsMeta: metaBoolean
-					selector: selectorString
-					category: catString
-					timeStamp: timeString
-					source: sourceString)
+MCMethodDefinition class >> className: classString classIsMeta: metaBoolean selector: selectorString category: catString timeStamp: timeString source: sourceString [
+	^ self new
+		initializeWithClassName: classString
+		classIsMeta: metaBoolean
+		selector: selectorString
+		category: catString
+		timeStamp: timeString
+		source: sourceString
 ]
 
 { #category : #'instance creation' }
@@ -96,17 +91,6 @@ MCMethodDefinition class >> initializersEnabled [
 MCMethodDefinition class >> initializersEnabled: aBoolean [
 
 	InitializersEnabled := aBoolean
-]
-
-{ #category : #'instance creation' }
-MCMethodDefinition class >> instanceLike: aDefinition [
-	"The cache is playing havoc with the equality between methods. Methods of the same code but with different timestamps are considered equal. This breaks havoc with some filetree testing code which looks at timestamps."
-
-	| aMCMethodDefinition |
-	aMCMethodDefinition := super instanceLike: aDefinition.
-	^ aMCMethodDefinition timeStamp ~= aDefinition timeStamp
-		ifTrue: [ Instances add: aDefinition ]
-		ifFalse: [ aMCMethodDefinition ]
 ]
 
 { #category : #'system startup' }

--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -21,7 +21,8 @@ Class {
 		'category',
 		'selector',
 		'className',
-		'timeStamp'
+		'timeStamp',
+		'sortKey'
 	],
 	#classVars : [
 		'Definitions',
@@ -367,7 +368,12 @@ MCMethodDefinition >> shortSummaryPrefix [
 
 { #category : #comparing }
 MCMethodDefinition >> sortKey [
-	^ self className, '.', (self classIsMeta ifTrue: ['meta'] ifFalse: ['nonmeta']), '.', self selector
+	^ sortKey
+		ifNil: [ sortKey := self className , '.'
+				,
+					(self classIsMeta
+						ifTrue: [ 'meta' ]
+						ifFalse: [ 'nonmeta' ]) , '.' , self selector ]
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #'instance creation' }
 MCOrganizationDefinition class >> categories: anArray [
-	^ self instanceLike: (self new categories: anArray)
+	^ self new categories: anArray
 ]
 
 { #category : #comparing }

--- a/src/Monticello/MCPackageManager.class.st
+++ b/src/Monticello/MCPackageManager.class.st
@@ -187,6 +187,11 @@ MCPackageManager class >> managersForPackage: aPackage do: aBlock [
 { #category : #'system changes' }
 MCPackageManager class >> methodModified: anEvent [
 
+	"If the method has just been loaded by monticello itself, do not mark it as dirty"
+	anEvent propertyAt: #eventSource ifPresent: [ :source |
+		source == self class package name
+			ifTrue: [ ^ self ]].
+
    "trait methods aren't handled here"
 	anEvent isProvidedByATrait
 		ifTrue: [ ^ self ].

--- a/src/Monticello/MCScriptDefinition.class.st
+++ b/src/Monticello/MCScriptDefinition.class.st
@@ -18,7 +18,7 @@ MCScriptDefinition class >> from: aPackageInfo [
 
 { #category : #'instance creation' }
 MCScriptDefinition class >> script: aString packageName: packageString [
-	^ self instanceLike: (self new initializeWithScript: aString packageName: packageString)
+	^ self new initializeWithScript: aString packageName: packageString
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -8,38 +8,36 @@ Class {
 }
 
 { #category : #'instance creation' }
-MCTraitDefinition class >> name: classNameString traitComposition:  traitCompositionString category:  categoryString comment:  commentString commentStamp: commentStamp [
-	^ self instanceLike:
-		(self new initializeWithName: classNameString 
-			traitComposition:  traitCompositionString
-			category:  categoryString
-			comment:  commentString  
-			commentStamp:   commentStamp)
-
+MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString comment: commentString commentStamp: commentStamp [
+	^ self new
+		initializeWithName: classNameString
+		traitComposition: traitCompositionString
+		category: categoryString
+		comment: commentString
+		commentStamp: commentStamp
 ]
 
 { #category : #'instance creation' }
-MCTraitDefinition class >> name: classNameString traitComposition:  traitCompositionString category:  categoryString instVarNames: ivarArray classInstVarNames: civarArray comment:  commentString commentStamp:   commentStamp [
-	^ self instanceLike:
-		(self new initializeWithName: classNameString 
-			traitComposition:  traitCompositionString
-			category:  categoryString
-			instVarNames: ivarArray
-			classInstVarNames: civarArray
-			comment:  commentString  
-			commentStamp:   commentStamp)
+MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray comment: commentString commentStamp: commentStamp [
+	^ self new
+		initializeWithName: classNameString
+		traitComposition: traitCompositionString
+		category: categoryString
+		instVarNames: ivarArray
+		classInstVarNames: civarArray
+		comment: commentString
+		commentStamp: commentStamp
 ]
 
 { #category : #'instance creation' }
-MCTraitDefinition class >> name: classNameString traitComposition:  traitCompositionString category:  categoryString instVarNames: ivarArray comment: commentString commentStamp: commentStamp [
-	^ self instanceLike:
-		(self new initializeWithName: classNameString 
-			traitComposition:  traitCompositionString
-			category:  categoryString
-			instVarNames: ivarArray
-			comment:  commentString  
-			commentStamp:   commentStamp)
-
+MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray comment: commentString commentStamp: commentStamp [
+	^ self new
+		initializeWithName: classNameString
+		traitComposition: traitCompositionString
+		category: categoryString
+		instVarNames: ivarArray
+		comment: commentString
+		commentStamp: commentStamp
 ]
 
 { #category : #comparing }

--- a/src/Monticello/MethodAddition.class.st
+++ b/src/Monticello/MethodAddition.class.st
@@ -65,7 +65,12 @@ MethodAddition >> notifyObservers [
 	SystemAnnouncer uniqueInstance 
 		suspendAllWhile: [myClass organization classify: selector under: category].
 	priorMethodOrNil 
-		ifNil: [ SystemAnnouncer uniqueInstance methodAdded: compiledMethod ]
+		ifNil: [ SystemAnnouncer uniqueInstance
+				methodAdded: compiledMethod
+				configuredWith: [ :event | 
+					event
+						propertyAt: #eventSource
+						put: #Monticello ] ]
 		ifNotNil: [
 			SystemAnnouncer uniqueInstance methodChangedFrom: priorMethodOrNil to: compiledMethod oldProtocol: priorCategoryOrNil.
 			priorCategoryOrNil = category ifFalse: [

--- a/src/PragmaCollector/PragmaCollector.class.st
+++ b/src/PragmaCollector/PragmaCollector.class.st
@@ -64,12 +64,9 @@ PragmaCollector >> addedEventOccurs: anEvent [
 	"method adding event occured: if the 
 	concerned method contains a pragma then 
 	try to update myself with it"
-
-	Pragma
-		withPragmasIn: anEvent methodClass
-		do: [ :pragma | 
-			pragma methodSelector = anEvent selector
-				ifTrue: [ self addPragma: pragma ] ]
+	
+	anEvent method pragmas
+		do: [ :pragma | self addPragma: pragma ]
 ]
 
 { #category : #subscription }

--- a/src/System-Announcements/SystemAnnouncement.class.st
+++ b/src/System-Announcements/SystemAnnouncement.class.st
@@ -7,7 +7,8 @@ Class {
 	#name : #SystemAnnouncement,
 	#superclass : #Announcement,
 	#instVars : [
-		'timeStamp'
+		'timeStamp',
+		'properties'
 	],
 	#category : #'System-Announcements-System-Base'
 }

--- a/src/System-Announcements/SystemAnnouncement.class.st
+++ b/src/System-Announcements/SystemAnnouncement.class.st
@@ -18,6 +18,25 @@ SystemAnnouncement >> initialize [
 	self setTimeStamp.
 ]
 
+{ #category : #properties }
+SystemAnnouncement >> properties [
+
+	^ properties ifNil: [ properties := Dictionary new ]
+]
+
+{ #category : #properties }
+SystemAnnouncement >> propertyAt: aString ifPresent: aBlockClosure [ 
+	
+	properties ifNil: [ ^ self ].
+	^ properties at: aString ifPresent: aBlockClosure
+]
+
+{ #category : #properties }
+SystemAnnouncement >> propertyAt: aKey put: aValue [ 
+	
+	self properties at: aKey put: aValue
+]
+
 { #category : #private }
 SystemAnnouncement >> setTimeStamp [
 

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -197,7 +197,17 @@ SystemAnnouncer >> isSuspended [
 SystemAnnouncer >> methodAdded: aMethod [ 
 	"A method with the given selector was added to aClass, but not put in a protocol."
 
-	self announce: (MethodAdded method: aMethod)
+	^ self methodAdded: aMethod configuredWith: [ :method ]
+]
+
+{ #category : #triggering }
+SystemAnnouncer >> methodAdded: aMethod configuredWith: aBlock [
+	"A method with the given selector was added to aClass, but not put in a protocol."
+
+	| event |
+	event := MethodAdded method: aMethod.
+	aBlock value: event.
+	self announce: event.
 ]
 
 { #category : #triggering }


### PR DESCRIPTION
Several little improvements that improves the loading of big packages (e.g., loading VMMaker down from ~120 secs to ~50 secs)

- Accelerate pragma collector by not iterating all methods in the class
- Make Monticello to only listen to events coming not from Monticello
- Cache sort-key, for big packages containing lots of methods
- Remove weak cache that adds pressure on the GC for seemingly nothing
