### PR TITLE
4060-RBParserparseErrorNode-uses-stop-position-not-start-to-create-ErrorNode

### DIFF
--- a/src/AST-Core-Tests/RBParseErrorNodeTest.class.st
+++ b/src/AST-Core-Tests/RBParseErrorNodeTest.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #RBParseErrorNodeTest,
+	#superclass : #RBParseTreeTest,
+	#category : #'AST-Core-Tests-Nodes'
+}
+
+{ #category : #tests }
+RBParseErrorNodeTest >> testErrorNodeStart [
+	"check that the start of the error node is correct"
+	| ast |
+	ast := RBParser parseFaultyMethod: 'method ( 1 + 3'.
+	"the start should be much earlier then the end of the method"
+	self assert: (ast body statements first start < 14). 
+
+]

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -446,7 +446,7 @@ RBParser >> parseErrorNode: aMessageString [
 	aMessageString = ''')'' expected'
 		ifTrue: [ errorPosition := source findLastOccurrenceOfString: '(' startingAt: 1 ].
 	sourceString := source copyFrom: errorPosition to: source size.
-	^ RBParseErrorNode errorMessage: aMessageString value: sourceString at: self errorPosition
+	^ RBParseErrorNode errorMessage: aMessageString value: sourceString at: self errorPosition - sourceString size
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -445,6 +445,8 @@ RBParser >> parseErrorNode: aMessageString [
 	"the error at the end means in some cases that the start of the error is before"
 	aMessageString = ''')'' expected'
 		ifTrue: [ errorPosition := source findLastOccurrenceOfString: '(' startingAt: 1 ].
+	aMessageString = '''|'' expected'
+		ifTrue: [ errorPosition := source findLastOccurrenceOfString: '|' startingAt: 1 ].
 	sourceString := source copyFrom: errorPosition to: source size.
 	^ RBParseErrorNode errorMessage: aMessageString value: sourceString at: self errorPosition - sourceString size
 ]

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -448,7 +448,7 @@ RBParser >> parseErrorNode: aMessageString [
 	aMessageString = '''|'' expected'
 		ifTrue: [ errorPosition := source findLastOccurrenceOfString: '|' startingAt: 1 ].
 	sourceString := source copyFrom: errorPosition to: source size.
-	^ RBParseErrorNode errorMessage: aMessageString value: sourceString at: self errorPosition - sourceString size
+	^ RBParseErrorNode errorMessage: aMessageString value: sourceString at: errorPosition
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -447,6 +447,7 @@ RBParser >> parseErrorNode: aMessageString [
 		ifTrue: [ errorPosition := source findLastOccurrenceOfString: '(' startingAt: 1 ].
 	aMessageString = '''|'' expected'
 		ifTrue: [ errorPosition := source findLastOccurrenceOfString: '|' startingAt: 1 ].
+	(errorPosition = 0) ifTrue: [ errorPosition := self errorPosition].
 	sourceString := source copyFrom: errorPosition to: source size.
 	^ RBParseErrorNode errorMessage: aMessageString value: sourceString at: errorPosition
 ]

--- a/src/NECompletion/TestMatchedNodeProducer.class.st
+++ b/src/NECompletion/TestMatchedNodeProducer.class.st
@@ -82,10 +82,8 @@ TestMatchedNodeProducer >> visitMessageNode:  aRBMessageNode [
 
 { #category : #visiting }
 TestMatchedNodeProducer >> visitMethodNode: aRBMethodNode [ 
-	"there is a bug that we end up here when in temp definition, workaround turn it off for now"
-	"this turns off completion of methods and temp defitions, see issue tracker"
-	 ^#().
-	"(self select: self methodNames beginningWith: aRBMethodNode selector)"
+		
+	^(self select: self methodNames beginningWith: aRBMethodNode selector)
 ]
 
 { #category : #visiting }

--- a/src/NECompletion/TestMatchedNodeProducer.class.st
+++ b/src/NECompletion/TestMatchedNodeProducer.class.st
@@ -105,6 +105,12 @@ TestMatchedNodeProducer >> visitPragmaNode: aPragmaNode [
 ]
 
 { #category : #visiting }
+TestMatchedNodeProducer >> visitReturnNode: aNode [
+	
+	^ #()
+]
+
+{ #category : #visiting }
 TestMatchedNodeProducer >> visitSelfNode: aRBSelfNode [ 
 	^ self visitVariableNode: aRBSelfNode 
 ]


### PR DESCRIPTION
- fixes #4060
- fixes #4061 add return node