### PR TITLE
4066-Categorize-methods-in-IRMethod

### DIFF
--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -122,7 +122,7 @@ IRMethod >> compilationContext: aCompilationContext [
 	compilationContext := aCompilationContext
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #translating }
 IRMethod >> compiledBlock: scope [
 
 	^compiledMethod 
@@ -193,7 +193,7 @@ IRMethod >> generate: trailer [
 	^ compiledMethod
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #translating }
 IRMethod >> generateBlock: trailer withScope: scope [
 	| irTranslator |
       irTranslator := IRTranslatorV2 context: compilationContext trailer: trailer.


### PR DESCRIPTION
Categorize methods in IRMethod

Fix #4066