### PR TITLE
TabExample-should-use-Spec2-instead-of-Spec

### DIFF
--- a/src/Morphic-Examples/TabExample.class.st
+++ b/src/Morphic-Examples/TabExample.class.st
@@ -20,7 +20,7 @@ Class {
 
 { #category : #'instance creation' }
 TabExample class >> open [
-
+	<script>
 	^ self new open
 ]
 
@@ -62,7 +62,7 @@ TabExample >> freshListTab [
 		label: 'Fresh List'
 		icon: nil
 		retrievingBlock: [ 1 second asDelay wait.
-			ListPresenter new
+			SpListPresenter new
 				items: (1 to: 50) asOrderedCollection;
 				buildWithSpec ]
 		actions:
@@ -82,18 +82,16 @@ TabExample >> initialize [
 	manager := TabManagerMorph new.
 	manager
 		when: #tabManagerDeleted send: #delete to: self.
-	listModel := ListPresenter new.
+	listModel := SpListPresenter new.
 	listModel items: ((1 to: 1000) asOrderedCollection)
 ]
 
 { #category : #'instance creation' }
 TabExample >> open [
-	
 	window := manager openInWindow.
-	window extent: 400@300.
-	
-	self addTabs.
-"	listModel openWithSpec"
+	window extent: 400 @ 300.
+
+	self addTabs
 ]
 
 { #category : #'tabs creation' }

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -60,7 +60,7 @@ SystemDependenciesTest >> knownBasicToolsDependencies [
 	"ideally this list should be empty"	
 
 	^ #('AST-Core-Tests' 'Athens-Cairo' 'Athens-Core' "Those are added for the development of Spec2 and should probably be removed"
-	#'Athens-Morphic' 'Glamour-Morphic-Widgets' #NautilusRefactoring #'Refactoring-Critics' #'Reflectivity-Tools' #Shout #'Tool-Catalog' 'ParametrizedTests') sorted
+	#'Athens-Morphic' 'Glamour-Morphic-Widgets' #NautilusRefactoring #'Refactoring-Critics' #'Reflectivity-Tools' #Shout #'Tool-Catalog' 'ParametrizedTests')
 ]
 
 { #category : #'known dependencies' }
@@ -100,7 +100,7 @@ SystemDependenciesTest >> knownKernelDependencies [
 
 	"ideally this list should be empty"	
 
-	^ #(#CodeExport #CodeImport #CodeImportCommandLineHandlers #DeprecatedFileStream #'FileSystem-Core' #Monticello #'OpalCompiler-Core' #'Ring-Deprecated-Core-Kernel' #'System-Changes' #'System-Localization' #'AST-Core' #'Collections-Arithmetic' #Jobs #'Transcript-Core') sorted
+	^ #(#CodeExport #CodeImport #CodeImportCommandLineHandlers #DeprecatedFileStream #'FileSystem-Core' #Monticello #'OpalCompiler-Core' #'Ring-Deprecated-Core-Kernel' #'System-Changes' #'System-Localization' #'AST-Core' #'Collections-Arithmetic' #Jobs #'Transcript-Core')
 ]
 
 { #category : #'known dependencies' }
@@ -139,9 +139,8 @@ SystemDependenciesTest >> knownMorphicCoreDependencies [
 SystemDependenciesTest >> knownMorphicDependencies [
 	"ideally this list should be empty"
 
-	^ #(#'Fonts-Chooser' #'Network-Mail' #RecentSubmissions #'Refactoring-Critics' #'Refactoring-Environment' #Shout #'Spec-Core' #'Tool-Diff' #'Tool-FileList' #'Tool-Profilers'
+	^ #(#'Fonts-Chooser' #'Network-Mail' #RecentSubmissions #'Refactoring-Critics' #'Refactoring-Environment' #Shout #'Spec-Core' "Spec-Core should be removed later." #'Spec2-Core' #'Tool-Diff' #'Tool-FileList' #'Tool-Profilers'
 	#'Athens-Morphic' 	"Rubric has a dependency on It" )
-		sorted
 ]
 
 { #category : #'known dependencies' }
@@ -149,7 +148,7 @@ SystemDependenciesTest >> knownSUnitDependencies [
 
 	"ideally this list should be empty"	
 
-	^ #(#'Fonts-Abstract' #'Graphics-Files' #'Network-Mail' #'Refactoring-Critics' #'Refactoring-Environment' #'System-Localization' #'Transcript-Core') sorted
+	^ #(#'Fonts-Abstract' #'Graphics-Files' #'Network-Mail' #'Refactoring-Critics' #'Refactoring-Environment' #'System-Localization' #'Transcript-Core')
 ]
 
 { #category : #'known dependencies' }
@@ -157,7 +156,7 @@ SystemDependenciesTest >> knownSUnitKernelDependencies [
 
 	"ideally this list should be empty"	
 
-	^ #(#CodeExport #CodeImportCommandLineHandlers #DeprecatedFileStream #'FileSystem-Core' #Monticello #'OpalCompiler-Core' #'Ring-Deprecated-Core-Kernel' #'System-Changes' #'System-Localization' #Jobs #'AST-Core' #'Collections-Arithmetic' #'Transcript-Core' #CodeImport) sorted
+	^ #(#CodeExport #CodeImportCommandLineHandlers #DeprecatedFileStream #'FileSystem-Core' #Monticello #'OpalCompiler-Core' #'Ring-Deprecated-Core-Kernel' #'System-Changes' #'System-Localization' #Jobs #'AST-Core' #'Collections-Arithmetic' #'Transcript-Core' #CodeImport)
 ]
 
 { #category : #'known-dependencies' }
@@ -166,7 +165,7 @@ SystemDependenciesTest >> knownSpec2Dependencies [
 	^ #(
 		'WebBrowser-Core' "Spec's Link adapter"
 		'Keymapping-Settings' "Spec's KeymapBrowser example tool"
-		) sorted
+		)
 ]
 
 { #category : #'known dependencies' }
@@ -183,7 +182,7 @@ SystemDependenciesTest >> knownUIDependencies [
 	"ideally this list should be empty"	
 
 	^ #('AST-Core-Tests' 'Athens-Cairo' 'Athens-Core' "Those are added for the development of Spec2 and should probably be removed"
-	#'Athens-Morphic' #'Glamour-Morphic-Widgets' #'Network-Mail' #RecentSubmissions #'Refactoring-Critics' #'Refactoring-Environment' #'Reflectivity-Tools' #Shout #'Tool-Diff' #'Tool-FileList' #'Tool-ProcessBrowser' #'Tool-Profilers') sorted
+	#'Athens-Morphic' #'Glamour-Morphic-Widgets' #'Network-Mail' #RecentSubmissions #'Refactoring-Critics' #'Refactoring-Environment' #'Reflectivity-Tools' #Shout #'Tool-Diff' #'Tool-FileList' #'Tool-ProcessBrowser' #'Tool-Profilers')
 ]
 
 { #category : #utilities }
@@ -229,7 +228,7 @@ SystemDependenciesTest >> testExternalBasicToolsDependencies [
 		{ BaselineOfSpec2 name }, BaselineOfSpec2 allPackageNames,
 		{ BaselineOfBasicTools name }, BaselineOfBasicTools allPackageNames ).
 	
-	self assertCollection: dependencies equals: self knownBasicToolsDependencies.
+	self assertCollection: dependencies hasSameElements: self knownBasicToolsDependencies.
 ]
 
 { #category : #tests }
@@ -245,7 +244,7 @@ SystemDependenciesTest >> testExternalCompilerDependencies [
 		BaselineOfPharoBootstrap kernelAdditionalPackagesNames,				
 		BaselineOfPharoBootstrap compilerPackageNames).
 	
-	self assertCollection: dependencies equals: self knownCompilerDependencies.
+	self assertCollection: dependencies hasSameElements: self knownCompilerDependencies.
 ]
 
 { #category : #tests }
@@ -261,7 +260,7 @@ SystemDependenciesTest >> testExternalDisplayDependencies [
 		BaselineOfTraits corePackages,		
 		BaselineOfDisplay allPackageNames).
 	
-	self assertCollection: dependencies equals: self knownDisplayDependencies.
+	self assertCollection: dependencies hasSameElements: self knownDisplayDependencies.
 ]
 
 { #category : #tests }
@@ -278,7 +277,7 @@ SystemDependenciesTest >> testExternalFileSystemDependencies [
 		BaselineOfPharoBootstrap compilerPackageNames,
 		BaselineOfPharoBootstrap fileSystemPackageNames).
 	
-	self assertCollection: dependencies equals: self knownFileSystemDependencies.
+	self assertCollection: dependencies hasSameElements: self knownFileSystemDependencies.
 ]
 
 { #category : #tests }
@@ -306,7 +305,7 @@ SystemDependenciesTest >> testExternalIDEDependencies [
 	BaselineOfUnifiedFFI} do: [ :baseline | packages := packages , {baseline name} , baseline allPackageNames ].
 
 	dependencies := self externalDependendiesOf: packages.
-	self assertCollection: dependencies equals: self knownIDEDependencies
+	self assertCollection: dependencies hasSameElements: self knownIDEDependencies
 ]
 
 { #category : #tests }
@@ -317,7 +316,7 @@ SystemDependenciesTest >> testExternalKernelDependencies [
 	dependencies := self
 		externalDependendiesOf: BaselineOfPharoBootstrap kernelPackageNames , BaselineOfPharoBootstrap multilingualPackageNames, BaselineOfPharoBootstrap kernelAdditionalPackagesNames.
 
-	self assertCollection: dependencies equals: self knownKernelDependencies
+	self assertCollection: dependencies hasSameElements: self knownKernelDependencies
 ]
 
 { #category : #tests }
@@ -336,7 +335,7 @@ SystemDependenciesTest >> testExternalLocalMonticelloDependencies [
 		BaselineOfPharoBootstrap kernelAdditionalPackagesNames,
 		BaselineOfMonticello corePackageNames).
 	
-	self assertCollection: dependencies equals: self knownLocalMonticelloDependencies.
+	self assertCollection: dependencies hasSameElements: self knownLocalMonticelloDependencies.
 ]
 
 { #category : #tests }
@@ -348,7 +347,7 @@ SystemDependenciesTest >> testExternalMetacelloDependencies [
 	
 	dependencies := self externalDependendiesOf: self metacelloPackageNames, BaselineOfTraits corePackages.
 	
-	self assertCollection: dependencies equals: self knownMetacelloDependencies.
+	self assertCollection: dependencies hasSameElements: self knownMetacelloDependencies.
 ]
 
 { #category : #tests }
@@ -368,7 +367,7 @@ SystemDependenciesTest >> testExternalMonticelloDependencies [
 		BaselineOfMonticello corePackageNames,
 		BaselineOfMonticello remoteRepositoriesPackageNames).
 	
-	self assertCollection: dependencies equals: self knownMonticelloDependencies.
+	self assertCollection: dependencies hasSameElements: self knownMonticelloDependencies.
 ]
 
 { #category : #tests }
@@ -387,7 +386,7 @@ SystemDependenciesTest >> testExternalMorphicCoreDependencies [
 		BaselineOfUnifiedFFI allPackageNames,
 		BaselineOfMorphicCore allPackageNames ).
 	
-	self assertCollection: dependencies equals: self knownMorphicCoreDependencies.
+	self assertCollection: dependencies hasSameElements: self knownMorphicCoreDependencies.
 ]
 
 { #category : #tests }
@@ -408,7 +407,7 @@ SystemDependenciesTest >> testExternalMorphicDependencies [
 		BaselineOfMorphic allPackageNames,
 		BaselineOfMenuRegistration allPackageNames ).
 	
-	self assertCollection: dependencies equals: self knownMorphicDependencies.
+	self assertCollection: dependencies hasSameElements: self knownMorphicDependencies.
 ]
 
 { #category : #tests }
@@ -424,7 +423,7 @@ SystemDependenciesTest >> testExternalSUnitDependencies [
 		self tonelCorePackageNames,
 		BaselineOfSUnit defaultPackageNames).
 	
-	self assertCollection: dependencies equals: self knownSUnitDependencies.
+	self assertCollection: dependencies hasSameElements: self knownSUnitDependencies.
 ]
 
 { #category : #tests }
@@ -441,7 +440,7 @@ SystemDependenciesTest >> testExternalSUnitKernelDependencies [
 		BaselineOfPharoBootstrap kernelAdditionalPackagesNames,
 		BaselineOfPharoBootstrap sUnitPackageNames).
 	
-	self assertCollection: dependencies equals: self knownSUnitKernelDependencies.
+	self assertCollection: dependencies hasSameElements: self knownSUnitKernelDependencies.
 ]
 
 { #category : #tests }
@@ -474,7 +473,7 @@ SystemDependenciesTest >> testExternalSpec2Dependencies [
 		BaselineOfParametrizedTests allPackageNames))
 			copyWithoutAll: self knownMorphicDependencies, self knownBasicToolsDependencies, self knownUIDependencies.
 
-	self assertCollection: dependencies equals: self knownSpec2Dependencies
+	self assertCollection: dependencies hasSameElements: self knownSpec2Dependencies
 ]
 
 { #category : #tests }
@@ -491,7 +490,7 @@ SystemDependenciesTest >> testExternalUFFIDependencies [
 		BaselineOfSUnit defaultPackageNames,
 		BaselineOfUnifiedFFI allPackageNames).
 	
-	self assertCollection: dependencies equals: self knownUFFIDependencies.
+	self assertCollection: dependencies hasSameElements: self knownUFFIDependencies.
 ]
 
 { #category : #tests }
@@ -517,7 +516,7 @@ SystemDependenciesTest >> testExternalUIDependencies [
 		BaselineOfUI allPackageNames,
 		BaselineOfMenuRegistration allPackageNames )).
 	
-	self assertCollection: dependencies equals: self knownUIDependencies.
+	self assertCollection: dependencies hasSameElements: self knownUIDependencies.
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Make tab example use Spec 2