### PR TITLE
2311-Strange-behaviour-in-DebugSessionpcRangeForContext-

### DIFF
--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -265,18 +265,14 @@ DebugSession >> name: aString [
 
 { #category : #context }
 DebugSession >> pcRangeForContext: aContext [
-
 	"Answer the indices in the source code for the method corresponding to 
 	aContext's program counter value."
 
-	aContext
-		ifNil: [ self terminate ]
-		ifNotNil: [ aContext isDead
-				ifTrue: [ ^ 1 to: 0 ].
-			^ aContext debuggerMap
-				rangeForPC: aContext pc
-				contextIsActiveContext: ( self isLatestContext: aContext )
-			]
+	(aContext isNil or: [ aContext isDead ])
+		ifTrue: [ ^ 1 to: 0 ].
+	^ aContext debuggerMap
+		rangeForPC: aContext pc
+		contextIsActiveContext: (self isLatestContext: aContext)
 ]
 
 { #category : #'debugging actions' }


### PR DESCRIPTION
return the same value 1 to: 0 in case context being nil as it was already for dead contexts. 

fixes #2311 
fixes #3979