### PR TITLE
Add tests for LargePositiveInteger&LargeNegativeInteger from last version of Squeak

### DIFF
--- a/src/Kernel-Tests-Extended/LargePositiveIntegerTest.extension.st
+++ b/src/Kernel-Tests-Extended/LargePositiveIntegerTest.extension.st
@@ -6,23 +6,23 @@ LargePositiveIntegerTest >> testLargeSqrtFloor [
 	This was the case in a previous implementation, so this is a non regression test."
 
 	| large root |
-	large := (SmallInteger maxVal << 100 + 1) << 100.
+	large := (SmallInteger maxVal << 100) + 1 << 100.
 	root := large sqrtFloor.
 	self assert: root squared <= large.
-	 self assert: (root+1) squared > large.
+	self assert: (root + 1) squared > large
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
 LargePositiveIntegerTest >> testMultDicAddSub [
-
-	| n f f1 |	
+	| n f f1 |
 	n := 100.
 	f := 100 factorial.
-	f1 := f*(n+1).
-	n timesRepeat: [f1 := f1 - f].
-	self assert: f1 equals: f. 
-
-	n timesRepeat: [f1 := f1 + f].
-	self assert: f1 // f equals: n+1. 
-	self assert: f1 negated equals: (Number readFrom: '-' , f1 printString)
+	f1 := f * (n + 1).
+	n timesRepeat: [ f1 := f1 - f ].
+	self assert: f1 equals: f.
+	n timesRepeat: [ f1 := f1 + f ].
+	self assert: f1 // f equals: n + 1.
+	self
+		assert: f1 negated
+		equals: (Number readFrom: '-' , f1 printString)
 ]

--- a/src/Kernel-Tests/LargeNegativeIntegerTest.class.st
+++ b/src/Kernel-Tests/LargeNegativeIntegerTest.class.st
@@ -8,14 +8,112 @@ Class {
 }
 
 { #category : #tests }
+LargeNegativeIntegerTest >> testDenormalizedPrintString [
+	"Check that an un-normalized instance behaves reasonably."
+
+	| i i0 |
+	i := LargeNegativeInteger new: 4.
+	i basicAt: 2 put: 255.
+	self assert: i size equals: 4.
+	self assert: i printString equals: '-65280'.
+	self assert: i normalize equals: -65280.
+	self assert: (i normalize isMemberOf: SmallInteger).
+	i0 := LargeNegativeInteger new: 0.
+	self assert: i0 size equals: 0.
+	self assert: i0 printString equals: '-0'.
+	self assert: i0 normalize equals: 0.
+	self assert: (i0 normalize isMemberOf: SmallInteger)
+]
+
+{ #category : #tests }
+LargeNegativeIntegerTest >> testDigitAt [
+
+	| lni |
+	lni := -114605103402541699037609980192546360895434064385.
+	1 to: 20 do: [:i | | digit |
+		digit := lni digitAt: i.
+		self assert: i equals: digit]
+
+]
+
+{ #category : #tests }
+LargeNegativeIntegerTest >> testDigitAtPut [
+
+	| lni |
+	lni := LargeNegativeInteger new: 20.
+	1 to: 20 do: [:i | lni digitAt: i put: i].
+	self assert: -114605103402541699037609980192546360895434064385equals: lni
+
+]
+
+{ #category : #tests }
+LargeNegativeIntegerTest >> testDigitLength [
+
+	| lni |
+	lni := -114605103402541699037609980192546360895434064385.
+	self assert: 20 equals: lni digitLength
+
+]
+
+{ #category : #tests }
 LargeNegativeIntegerTest >> testEmptyTemplate [
 	"Check that an uninitialized instance behaves reasonably."
 
 	| i |
 	i := LargeNegativeInteger new: 4.
-	self assert: i size = 4.
-	self assert: i printString = '-0'.
-	self assert: i normalize = 0
+	self assert: i size equals: 4.
+	self assert: i printString equals: '-0'.
+	self assert: i normalize equals: 0
+]
+
+{ #category : #tests }
+LargeNegativeIntegerTest >> testMinimumNegativeIntegerArithmetic [
+	"We are speaking of minimum integer in underlying hardware here.
+	In 2-complement, abs(INT_MIN) = (INT-MAX+1) and thus overflows hardware register.
+	Since some old VM forgot this edge case they may fail and it's better to be aware of it.
+	http://code.google.com/p/cog/issues/detail?id=92
+	http://bugs.squeak.org/view.php?id=7705
+	We only test the cases of 32 and 64 bit signed integers."
+
+	#(32 64) do: [:nBits |
+		| largePositiveInt largeNegativeInt |
+		largePositiveInt := (1 << (nBits - 1)).
+		largeNegativeInt := largePositiveInt negated.
+		self assert: (largeNegativeInt >> 3) equals: (largeNegativeInt bitInvert >> 3) bitInvert.
+		self assert: (largeNegativeInt + 1) equals: (largePositiveInt - 1) negated.
+		self assert: (largeNegativeInt - -1) equals: (largePositiveInt - 1) negated.
+		self assert: (largeNegativeInt // -1) equals: largePositiveInt.
+		self assert: (largeNegativeInt \\ -1) equals: 0.
+		self assert: (largeNegativeInt rem: -1) equals: 0.
+		self assert: (largeNegativeInt quo: -1) equals: largePositiveInt.
+		self assert: (largeNegativeInt * -1) equals: largePositiveInt.
+		self assert: (largeNegativeInt / -1) equals: largePositiveInt]
+]
+
+{ #category : #tests }
+LargeNegativeIntegerTest >> testReplaceFromToWithStartingAt [
+
+	| lni20 lni7 |
+	lni20 := LargeNegativeInteger new: 20.
+	1 to: 20 do: [:i | lni20 digitAt: i put: i].
+	lni7 := LargeNegativeInteger new: 7.
+	1 to: 7 do: [:i | lni7 digitAt: i put: 11 - i].
+	lni20 replaceFrom: 6 to: 10 with: lni7 startingAt: 2.
+	"unmodified digits"
+	(1 to: 5) , (11 to: 20) do: [:e | | digit |
+		digit := lni20 digitAt: e.
+		self assert: e equals: digit].
+	"replaced digits"
+	6 to: 10 do: [:e | | digit replacementDigit |
+		digit := lni20 digitAt: e.
+		replacementDigit := lni7 digitAt: e - 4.
+		self assert: replacementDigit equals: digit]
+
+]
+
+{ #category : #tests }
+LargeNegativeIntegerTest >> testSqrt [
+	self should: [(SmallInteger minVal - 1) sqrt] raise: DomainError
 ]
 
 { #category : #'tests-printing' }

--- a/src/Kernel-Tests/LargePositiveIntegerTest.class.st
+++ b/src/Kernel-Tests/LargePositiveIntegerTest.class.st
@@ -8,6 +8,41 @@ Class {
 }
 
 { #category : #tests }
+LargePositiveIntegerTest >> assertSqrtCorrectlyRoundedForExponent: exp [
+	"Requires exp > Float precision, so that f ulp/2 is integer"
+	{1.5. 1.25 squared. 2.0 predecessor} do: [:sf |
+		| f xe xp xm |
+		
+		f := sf timesTwoPower: exp.
+	
+		"make two integers around the pivot"
+		xe := f asInteger + (f ulp asInteger / 2).
+		xm := xe squared - 1.
+		xp := xe squared + 1.
+		self assert: xe squared sqrt equals: xe.
+		self assert: xe squared sqrt isInteger.
+	
+		"check rounding when result is near f squared"
+		self assert: xm sqrt equals: f.
+		self assert: xm sqrt isFloat.
+		self assert: xp sqrt equals: f successor.
+		self assert: xp sqrt isFloat.
+	
+		"same in the other direction"
+		xe := f asInteger - (f ulp asInteger / 2).
+		xm := xe squared - 1.
+		xp := xe squared + 1.
+		self assert: xe squared sqrt equals: xe.
+		self assert: xe squared sqrt isInteger.
+	
+		"check rounding when result is near f squared"
+		self assert: xm sqrt equals: f predecessor.
+		self assert: xm sqrt isFloat.
+		self assert: xp sqrt equals: f.
+		self assert: xp sqrt isFloat].
+]
+
+{ #category : #tests }
 LargePositiveIntegerTest >> testBitShift [
 
 	"Check bitShift from and back to SmallInts"
@@ -16,15 +51,62 @@ LargePositiveIntegerTest >> testBitShift [
 ]
 
 { #category : #tests }
-LargePositiveIntegerTest >> testEmptyTemplate [
+LargePositiveIntegerTest >> testDenormalizedPrintString [
+	"Check that an un-normalized instance behaves reasonably."
 
+	| i i0 |
+	i := LargePositiveInteger new: 4.
+	i basicAt: 2 put: 255.
+	self assert: i size equals: 4.
+	self assert: i printString equals: '65280'.
+	self assert: i normalize equals: 65280.
+	self assert: (i normalize isMemberOf: SmallInteger).
+	i0 := LargePositiveInteger new: 0.
+	self assert: i0 size equals: 0.
+	self assert: i0 printString equals: '0'.
+	self assert: i0 normalize equals: 0.
+	self assert: (i0 normalize isMemberOf: SmallInteger)
+]
+
+{ #category : #tests }
+LargePositiveIntegerTest >> testDigitAt [
+
+	| lpi |
+	lpi := 114605103402541699037609980192546360895434064385.
+	1 to: 20 do: [:i | | digit |
+		digit := lpi digitAt: i.
+		self assert: i equals: digit]
+
+]
+
+{ #category : #tests }
+LargePositiveIntegerTest >> testDigitAtPut [
+
+	| lpi |
+	lpi := LargePositiveInteger new: 20.
+	1 to: 20 do: [:i | lpi digitAt: i put: i].
+	self assert: 114605103402541699037609980192546360895434064385equals: lpi
+
+]
+
+{ #category : #tests }
+LargePositiveIntegerTest >> testDigitLength [
+
+	| lpi |
+	lpi := 114605103402541699037609980192546360895434064385.
+	self assert: 20 equals: lpi digitLength
+
+]
+
+{ #category : #tests }
+LargePositiveIntegerTest >> testEmptyTemplate [
 	"Check that an uninitialized instance behaves reasonably."
 
 	| i |
 	i := LargePositiveInteger new: 4.
-	self assert: i size = 4.
-	self assert: i printString = '0'.
-	self assert: i normalize = 0
+	self assert: i size equals: 4.
+	self assert: i printString equals: '0'.
+	self assert: i normalize equals: 0
 ]
 
 { #category : #tests }
@@ -37,6 +119,51 @@ LargePositiveIntegerTest >> testNormalize [
 	self assert: (SmallInteger minVal - 3 + 6) == (SmallInteger minVal+3).
 ]
 
+{ #category : #tests }
+LargePositiveIntegerTest >> testReciprocalModulo [
+	| large r |
+	large := 1 bitShift: 48.
+	r := Random seed: 46912151.
+	4691
+		timesRepeat: [ | a b c t |
+			a := (r nextInt: large) + 1.
+			b := (r nextInt: large) + 1.
+			a > b
+				ifTrue: [ t := a.
+					a := b.
+					b := t ].
+			(a gcd: b) = 1
+				ifTrue: [ c := a reciprocalModulo: b.
+					self assert: a * c \\ b equals: 1 ]
+				ifFalse: [ self should: [ a reciprocalModulo: b ] raise: Error ] ]
+]
+
+{ #category : #tests }
+LargePositiveIntegerTest >> testReplaceFromToWithStartingAt [
+
+	| lpi20 lpi7 |
+	lpi20 := LargePositiveInteger new: 20.
+	1 to: 20 do: [:i | lpi20 digitAt: i put: i].
+	lpi7 := LargePositiveInteger new: 7.
+	1 to: 7 do: [:i | lpi7 digitAt: i put: 11 - i].
+	lpi20 replaceFrom: 6 to: 10 with: lpi7 startingAt: 2.
+	"unmodified digits"
+	(1 to: 5) , (11 to: 20) do: [:e | | digit |
+		digit := lpi20 digitAt: e.
+		self assert: e equals: digit].
+	"replaced digits"
+	6 to: 10 do: [:e | | digit replacementDigit |
+		digit := lpi20 digitAt: e.
+		replacementDigit := lpi7 digitAt: e - 4.
+		self assert: replacementDigit equals: digit]
+
+]
+
+{ #category : #tests }
+LargePositiveIntegerTest >> testSqrt [
+	self assert: (SmallInteger maxVal + 1) sqrt equals: (SmallInteger maxVal + 1) asFloat sqrt.
+]
+
 { #category : #'tests-printing' }
 LargePositiveIntegerTest >> testStoreOn [
 	| integer |
@@ -44,4 +171,36 @@ LargePositiveIntegerTest >> testStoreOn [
 	self
 		assert: integer class equals: LargePositiveInteger;
 		assert: (String streamContents: [ :s | integer storeOn: s ]) equals: integer asString
+]
+
+{ #category : #tests }
+LargePositiveIntegerTest >> x106kbits [
+	"Return a 106 kilo bits integer"
+	^(15 to: 55 by: 4)
+				inject: 9876543210
+				into: [:big :bits | big * big << bits + bits]
+]
+
+{ #category : #tests }
+LargePositiveIntegerTest >> x13kbits [
+	"Return a 13 kilo bits integer"
+	^(15 to: 44 by: 4)
+				inject: 9753102468
+				into: [:big :bits | big * big << bits + bits]
+]
+
+{ #category : #tests }
+LargePositiveIntegerTest >> x23kbits [
+	"Return a 23 kilo bits integer"
+	^(11 to: 44 by: 4)
+			inject: 1234567890
+			into: [:big :bits | big * big << bits + bits]
+]
+
+{ #category : #tests }
+LargePositiveIntegerTest >> x92kbits [
+	"Return a 92 kilo bits integer"
+	^(11 to: 51 by: 4)
+			inject: 1357924680
+			into: [:big :bits | big * big << bits + bits]
 ]


### PR DESCRIPTION
- add green tests for LargePositiveInteger from Squeak5.3alpha-18685-64bits
- methods reformatting