### PR TITLE
move setModel: out of completionAround:keyStroke:

### DIFF
--- a/src/NECompletion/NECContext.class.st
+++ b/src/NECompletion/NECContext.class.st
@@ -458,8 +458,7 @@ NECContext >> isVariablesOnly [
 { #category : #accessing }
 NECContext >> model [
 
-	model ifNil: [ model := self createModel ].
-	^ model
+	^model ifNil: [ model := self createModel ]
 ]
 
 { #category : #action }

--- a/src/NECompletion/NECController.class.st
+++ b/src/NECompletion/NECController.class.st
@@ -30,7 +30,7 @@ Class {
 
 { #category : #accessing }
 NECController class >> contextClass [
-	^ContextClass ifNil: [ ^NECContext ] 
+	^ContextClass ifNil: [ NECContext ] 
 ]
 
 { #category : #accessing }

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -344,16 +344,15 @@ RubSmalltalkEditor >> compileSelectionFor: anObject in: evalContext [
 
 { #category : #'completion engine' }
 RubSmalltalkEditor >> completionAround: aBlock keyStroke: anEvent [
-	"I'm a editor for Smalltalk, so, ok do completion around"
+	"I'm a editor for Smalltalk, so, doo completion around"
 	
 	self isCompletionEnabled ifFalse: [  ^aBlock value ].
-	completionEngine setModel: self model.
 	
 	(completionEngine handleKeystrokeBefore: anEvent editor: self) ifTrue:  [^ self ].
 	(self selectorChooserHandlesKeyboard: anEvent)
 				ifFalse: [ aBlock value ].
 	self selectorChooserKeystroke: anEvent.
-	completionEngine handleKeystrokeAfter: anEvent editor: self.
+	completionEngine handleKeystrokeAfter: anEvent editor: self
 
 ]
 
@@ -1293,8 +1292,8 @@ RubSmalltalkEditor >> tallySelection [
 RubSmalltalkEditor >> textArea: atextArea [
 
 	atextArea setCompletionEngine: self completionEngine.
-	"Right now RubTextEditor does not support completion"
-	super textArea: atextArea
+	super textArea: atextArea.
+	completionEngine setModel: self model
 ]
 
 { #category : #'menu messages' }

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -344,7 +344,7 @@ RubSmalltalkEditor >> compileSelectionFor: anObject in: evalContext [
 
 { #category : #'completion engine' }
 RubSmalltalkEditor >> completionAround: aBlock keyStroke: anEvent [
-	"I'm a editor for Smalltalk, so, doo completion around"
+	"I'm a editor for Smalltalk, so, do completion around"
 	
 	self isCompletionEnabled ifFalse: [  ^aBlock value ].
 	


### PR DESCRIPTION
- move setModel: out of completionAround:keyStroke:
- small trivial cleanup in NEContext and NECController