### PR TITLE
3955-remove-testPerformanceInlined-ifNotNil-and-testPerformanceInlined-ifTrue

### DIFF
--- a/src/Kernel-Tests/TestDelayBasicSchedulerMicrosecondTicker.class.st
+++ b/src/Kernel-Tests/TestDelayBasicSchedulerMicrosecondTicker.class.st
@@ -233,22 +233,6 @@ TestDelayBasicSchedulerMicrosecondTicker >> testMultiSchedule [
 ]
 
 { #category : #tests }
-TestDelayBasicSchedulerMicrosecondTicker >> testPerformanceInlined_ifNotNil [
-	"For optimal performance, the outer conditionals of #timingPriorityHandleEvent should be inlined"
-	|codeSample|
-	codeSample := [ nil ifNotNil: [ 0 ]].
-	self assert: codeSample sourceNode body statements first isInlined
-]
-
-{ #category : #tests }
-TestDelayBasicSchedulerMicrosecondTicker >> testPerformanceInlined_ifTrue [
-	"For optimal performance, the outer conditionals of #timingPriorityHandleEvent should be inlined"
-	| codeSample x |
-	codeSample := [ x ifTrue: [ 0 ]].
-	self assert: codeSample sourceNode body statements first isInlined
-]
-
-{ #category : #tests }
 TestDelayBasicSchedulerMicrosecondTicker >> testSimpleOneDelay [
 	"
 	Event loop priority takes So it takes priority over following code"

--- a/src/Kernel/DelayBasicScheduler.class.st
+++ b/src/Kernel/DelayBasicScheduler.class.st
@@ -174,16 +174,13 @@ DelayBasicScheduler >> runBackendLoopAtTimingPriority [
 
 	"Unit tests may run this at a lower priority" 
 
-	"Debug lines to help code review. Could be removed after a settling in period"
-	<haltOrBreakpointForTesting>
-
 	[  [runTimerEventLoop] whileTrue: 
 		[	|nowTick|
 			"Warning! Stepping <Over> the following line may lock the Image. Use <Into> or <Proceed>."
 		 	ticker waitForUserSignalled: timingSemaphore orExpired: activeDelay. 
 
 			"When two debuggers appear, step/proceed through this higher priority one first."
-			debug ifTrue: [ self halt ].		
+			"debug ifTrue: [ self halt ]."
 
 			"Invoke the api back-ends, which set the transfer-variable to nil" 		
 			suspendSemaphore ifNotNil: [ self suspendAtTimingPriority    ].
@@ -192,14 +189,15 @@ DelayBasicScheduler >> runBackendLoopAtTimingPriority [
 
 			"Signal any expired delays"
 			nowTick := ticker nowTick.
-			[ 	activeDelay notNil and: [nowTick >= activeDelay resumptionTick] ] 
+			"do not use notNil here as an optimizaton"
+			[ 	(activeDelay ~= nil) and: [nowTick >= activeDelay resumptionTick] ] 
 					whileTrue: [
 						activeDelay timingPrioritySignalExpired.
 						activeDelay := suspendedDelays removeFirstOrNil ].
 		]
 	] ensure: [ "When timer event loop exits, expire remaining delays."
-		debug ifTrue: [ self halt ].
-		[activeDelay notNil] whileTrue: [
+		"debug ifTrue: [ self halt ]."
+		[activeDelay ~=  nil] whileTrue: [
 				activeDelay timingPrioritySignalExpired.
 				activeDelay := suspendedDelays removeFirstOrNil ]].
 ]

--- a/src/Kernel/ManifestKernel.class.st
+++ b/src/Kernel/ManifestKernel.class.st
@@ -38,6 +38,11 @@ ManifestKernel class >> ruleRBClassNameInSelectorRuleV1FalsePositive [
 ]
 
 { #category : #'code-critics' }
+ManifestKernel class >> ruleRBEqualNilRuleV1FalsePositive [
+	^ #(#(#(#RGClassDefinition #(#DelayBasicScheduler)) #'2019-07-24T17:00:02.461271+02:00') )
+]
+
+{ #category : #'code-critics' }
 ManifestKernel class >> ruleRBRefersToClassRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#'Character class' #allByteCharacters #true)) #'2019-01-28T20:55:28.683846+01:00') )
 ]


### PR DESCRIPTION
runBackendLoopAtTimingPriority
- comment out debug checks
- use #== instead of notNil
- ban the notNil rule for the class
- remove the two tests that checked for optimzied coed