### PR TITLE
Classify-reset-in-initialization

### DIFF
--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -51,7 +51,7 @@ ASTCache class >> initialize [
 	SessionManager default registerSystemClassNamed: self name
 ]
 
-{ #category : #'initialization-release' }
+{ #category : #initialization }
 ASTCache class >> reset [
 	<script>
 	self default reset.
@@ -71,7 +71,7 @@ ASTCache >> at: aCompiledMethod [
 			aCompiledMethod parseTree doSemanticAnalysisIn: aCompiledMethod methodClass ]
 ]
 
-{ #category : #'initialization-release' }
+{ #category : #initialization }
 ASTCache >> reset [
 	self removeAll
 ]

--- a/src/Athens-Balloon/AthensBalloonEngine.class.st
+++ b/src/Athens-Balloon/AthensBalloonEngine.class.st
@@ -212,7 +212,7 @@ AthensBalloonEngine >> registerRadialGradient: colorRamp center: aCenter radius:
 			radial:  true.
 ]
 
-{ #category : #initialize }
+{ #category : #initialization }
 AthensBalloonEngine >> reset [
 	workBuffer ifNil:[workBuffer := self class allocateOrRecycleBuffer: 10000].
 	self primInitializeBuffer: workBuffer.

--- a/src/Balloon/BalloonEngine.class.st
+++ b/src/Balloon/BalloonEngine.class.st
@@ -907,7 +907,7 @@ BalloonEngine >> release [
 	super release.
 ]
 
-{ #category : #initialize }
+{ #category : #initialization }
 BalloonEngine >> reset [
 	workBuffer ifNil:[workBuffer := self class allocateOrRecycleBuffer: 10000].
 	self primInitializeBuffer: workBuffer.

--- a/src/Calypso-NavigationModel/ClyNavigationEnvironment.class.st
+++ b/src/Calypso-NavigationModel/ClyNavigationEnvironment.class.st
@@ -153,7 +153,7 @@ ClyNavigationEnvironment class >> over: aSystem [
 		system: aSystem
 ]
 
-{ #category : #default }
+{ #category : #initialization }
 ClyNavigationEnvironment class >> reset [
 	"It will reset all caches and unsubscribe from system environment"
 	<script>

--- a/src/Calypso-NavigationModel/ClyQueryResultMetadata.class.st
+++ b/src/Calypso-NavigationModel/ClyQueryResultMetadata.class.st
@@ -79,7 +79,7 @@ ClyQueryResultMetadata >> removeProperty: aProperty [
 	properties remove: aProperty ifAbsent: [  ]
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 ClyQueryResultMetadata >> reset [
 	properties removeAll
 ]

--- a/src/Calypso-NavigationModel/ClyUnknownQuery.class.st
+++ b/src/Calypso-NavigationModel/ClyUnknownQuery.class.st
@@ -27,7 +27,7 @@ ClyUnknownQuery class >> mergeOwnInstances: queries [
 	^queries anyOne
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 ClyUnknownQuery class >> reset [
 	instance := nil
 ]

--- a/src/Calypso-NavigationModel/ClyUnknownScope.class.st
+++ b/src/Calypso-NavigationModel/ClyUnknownScope.class.st
@@ -20,7 +20,7 @@ ClyUnknownScope class >> instance [
 	^instance ifNil: [ instance := ClyUnknownScope new ]
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 ClyUnknownScope class >> reset [
 	instance := nil
 ]

--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -48,7 +48,7 @@ ClySystemEnvironment class >> currentImage [
 			changesAnnouncer: SystemAnnouncer uniqueInstance]
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 ClySystemEnvironment class >> reset [
 	<script>
 	currentImage := nil

--- a/src/ClassAnnotation/ClassAnnotationRegistry.class.st
+++ b/src/ClassAnnotation/ClassAnnotationRegistry.class.st
@@ -156,7 +156,7 @@ ClassAnnotationRegistry class >> handleOldMethodChange: aMethodModified [
 	self resetIf: [ self doesMethodAffectAnnotations: aMethodModified oldMethod]
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 ClassAnnotationRegistry class >> reset [
 	<script>
 	

--- a/src/CodeImport/ChunkReadStream.class.st
+++ b/src/CodeImport/ChunkReadStream.class.st
@@ -116,7 +116,7 @@ ChunkReadStream >> readUpToEndOfStyleChunk [
 	^decoratedStream upTo: $[
 ]
 
-{ #category : #decorated }
+{ #category : #initialization }
 ChunkReadStream >> reset [
 	nextChar := nil.
 	decoratedStream reset.

--- a/src/Collections-Sequenceable/OrderedCollection.class.st
+++ b/src/Collections-Sequenceable/OrderedCollection.class.st
@@ -754,7 +754,7 @@ OrderedCollection >> removeLast: n [
 	^ list
 ]
 
-{ #category : #removing }
+{ #category : #initialization }
 OrderedCollection >> reset [
 	"Quickly remove all elements. The objects will be still referenced, but will not be 	accessible."
 	

--- a/src/Collections-Streams/Generator.class.st
+++ b/src/Collections-Streams/Generator.class.st
@@ -170,7 +170,7 @@ Generator >> printOn: aStream [
 	aStream nextPutAll: self class name; nextPutAll: ' on: '; print: block
 ]
 
-{ #category : #public }
+{ #category : #initialization }
 Generator >> reset [
 	"Reset the generator, i.e., start it over"
 	continue ifNotNil:[continue unwindTo: home].

--- a/src/Collections-Streams/NullStream.class.st
+++ b/src/Collections-Streams/NullStream.class.st
@@ -240,7 +240,7 @@ NullStream >> readInto: collection startingAt: startIndex count: n [
 	^ n
 ]
 
-{ #category : #positioning }
+{ #category : #initialization }
 NullStream >> reset [
 	"Set the receiver's position to the beginning of the sequence of objects."
 

--- a/src/Collections-Streams/PositionableStream.class.st
+++ b/src/Collections-Streams/PositionableStream.class.st
@@ -588,7 +588,7 @@ PositionableStream >> readInto: aCollection startingAt: startIndex count: n [
 	^ n
 ]
 
-{ #category : #positioning }
+{ #category : #initialization }
 PositionableStream >> reset [
 	"Set the receiver's position to the beginning of the sequence of objects."
 

--- a/src/Collections-Streams/WriteStream.class.st
+++ b/src/Collections-Streams/WriteStream.class.st
@@ -260,7 +260,7 @@ WriteStream >> position: anInteger [
 	super position: anInteger
 ]
 
-{ #category : #positioning }
+{ #category : #initialization }
 WriteStream >> reset [ 
 	"Refer to the comment in PositionableStream|reset."
 

--- a/src/Compression/InflateStream.class.st
+++ b/src/Compression/InflateStream.class.st
@@ -674,7 +674,7 @@ InflateStream >> readInto: buffer startingAt: startIndex count: n [
 	^n
 ]
 
-{ #category : #positioning }
+{ #category : #initialization }
 InflateStream >> reset [
 	"Position zero - nothing decoded yet"
 	position := readLimit := 0.

--- a/src/DeprecatedFileStream/FileStream.class.st
+++ b/src/DeprecatedFileStream/FileStream.class.st
@@ -782,7 +782,7 @@ FileStream >> reopen [
 
 ]
 
-{ #category : #positioning }
+{ #category : #initialization }
 FileStream >> reset [
 	"Set the current character position to the beginning of the file."
 

--- a/src/DeprecatedFileStream/MultiByteBinaryOrTextStream.class.st
+++ b/src/DeprecatedFileStream/MultiByteBinaryOrTextStream.class.st
@@ -290,7 +290,7 @@ MultiByteBinaryOrTextStream >> peekFor: item [
 
 ]
 
-{ #category : #positioning }
+{ #category : #initialization }
 MultiByteBinaryOrTextStream >> reset [
 
 	super reset.

--- a/src/DeprecatedFileStream/MultiByteFileStream.class.st
+++ b/src/DeprecatedFileStream/MultiByteFileStream.class.st
@@ -628,7 +628,7 @@ MultiByteFileStream >> requestDropStream: dropIndex [
 	^result
 ]
 
-{ #category : #positioning }
+{ #category : #initialization }
 MultiByteFileStream >> reset [
 
 	super reset.

--- a/src/DeprecatedFileStream/RWBinaryOrTextStream.class.st
+++ b/src/DeprecatedFileStream/RWBinaryOrTextStream.class.st
@@ -140,7 +140,7 @@ RWBinaryOrTextStream >> readInto: aCollection startingAt: startIndex count: n [
 	^ max
 ]
 
-{ #category : #positioning }
+{ #category : #initialization }
 RWBinaryOrTextStream >> reset [
 	"Set the receiver's position to the beginning of the sequence of objects."
 

--- a/src/DeprecatedFileStream/StandardFileStream.class.st
+++ b/src/DeprecatedFileStream/StandardFileStream.class.st
@@ -898,7 +898,7 @@ StandardFileStream >> requestDropStream: dropIndex [
 	self enableReadBuffering
 ]
 
-{ #category : #positioning }
+{ #category : #initialization }
 StandardFileStream >> reset [
 	self ensureOpen.
 	self position: 0.

--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -93,7 +93,7 @@ DiskStore class >> readOnlyVariant [
 	^ self subclassResponsibility
 ]
 
-{ #category : #current }
+{ #category : #initialization }
 DiskStore class >> reset [
 	DefaultWorkingDirectory := nil.
 	CurrentFS := nil

--- a/src/FileSystem-Memory/MemoryStore.class.st
+++ b/src/FileSystem-Memory/MemoryStore.class.st
@@ -35,7 +35,7 @@ MemoryStore class >> isCaseSensitive [
 	^ true
 ]
 
-{ #category : #'class initialization' }
+{ #category : #initialization }
 MemoryStore class >> reset [
 	CurrentFS := nil
 ]

--- a/src/Files/AbstractBinaryFileStream.class.st
+++ b/src/Files/AbstractBinaryFileStream.class.st
@@ -255,7 +255,7 @@ AbstractBinaryFileStream >> readInto: readBuffer startingAt: startIndex count: c
 	^ File read: handle into: readBuffer startingAt: startIndex count: count
 ]
 
-{ #category : #positioning }
+{ #category : #initialization }
 AbstractBinaryFileStream >> reset [
 	self position: 0
 ]

--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -855,7 +855,7 @@ File class >> rename: oldFileFullName to: newFileFullName [
 	^nil
 ]
 
-{ #category : #'class initialization' }
+{ #category : #initialization }
 File class >> reset [
 	"Initialise the receiver for the current platform"
 

--- a/src/Fuel-Platform-Core/FLPlatform.class.st
+++ b/src/Fuel-Platform-Core/FLPlatform.class.st
@@ -105,7 +105,7 @@ FLPlatform class >> removeModifications [
 	SystemOrganizer default removeCategory: self hacksCategoryName
 ]
 
-{ #category : #'private-convenience' }
+{ #category : #initialization }
 FLPlatform class >> reset [
 	Current := nil
 ]

--- a/src/Fuel-Tests-Core/FLSingletonMock.class.st
+++ b/src/Fuel-Tests-Core/FLSingletonMock.class.st
@@ -23,7 +23,7 @@ FLSingletonMock class >> new [
 	self error: 'I''m a singleton!'
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 FLSingletonMock class >> reset [
 	Instance := nil
 ]

--- a/src/GT-EventRecorder/GTEventRecorder.class.st
+++ b/src/GT-EventRecorder/GTEventRecorder.class.st
@@ -71,7 +71,7 @@ GTEventRecorder class >> registerInterestToSystemAnnouncement [
 			to: uniqueInstance
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 GTEventRecorder class >> reset [
 	"Stop and remove the process for sending usage data. Delete all recorder that from the queue."
 	uniqueInstance ifNil: [ ^ self ].

--- a/src/GT-Inspector/GTSnippets.class.st
+++ b/src/GT-Inspector/GTSnippets.class.st
@@ -18,7 +18,7 @@ GTSnippets class >> instance [
 	^ instance ifNil: [ instance := self new ]
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 GTSnippets class >> reset [
 	instance := nil
 ]

--- a/src/GT-Playground/GTPlayBook.class.st
+++ b/src/GT-Playground/GTPlayBook.class.st
@@ -111,7 +111,7 @@ GTPlayBook class >> instance [
 	^ instance ifNil: [ instance := self new ]
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 GTPlayBook class >> reset [
 	
 	instance := nil.

--- a/src/GT-Spotter-UI/GTSpotterGlobalShortcut.class.st
+++ b/src/GT-Spotter-UI/GTSpotterGlobalShortcut.class.st
@@ -40,7 +40,7 @@ GTSpotterGlobalShortcut class >> openGlobalSpotterDebug [
 		showPreview
 ]
 
-{ #category : #cleanup }
+{ #category : #initialization }
 GTSpotterGlobalShortcut class >> reset [
 	
 	(self currentWorld findA: GTSpotterMorph) ifNotNil: [ :aSpotterMorph | aSpotterMorph spotterModel exitDueTo: #reset ]

--- a/src/GT-Spotter/GTSpotterIterator.class.st
+++ b/src/GT-Spotter/GTSpotterIterator.class.st
@@ -201,7 +201,7 @@ GTSpotterIterator >> reject: aBlock thenDo: aBlock2 [
 			ifFalse: [ aBlock2 value: each ] ]
 ]
 
-{ #category : #public }
+{ #category : #initialization }
 GTSpotterIterator >> reset [
 	items := nil.
 ]

--- a/src/GT-Tests-Spotter/GTSpotterExceptionsTest.class.st
+++ b/src/GT-Tests-Spotter/GTSpotterExceptionsTest.class.st
@@ -21,7 +21,7 @@ GTSpotterExceptionsTest class >> fatals [
 	^ fatals ifNil: [ fatals := OrderedCollection new ]
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 GTSpotterExceptionsTest class >> reset [
 	exceptions := nil.
 	fatals := nil.

--- a/src/Glamour-Helpers/GLMLogger.class.st
+++ b/src/Glamour-Helpers/GLMLogger.class.st
@@ -28,7 +28,7 @@ GLMLogger class >> nullInstance [
 		nullInstance := GLMNullLogger new ]
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 GLMLogger class >> reset [
 	instance := nil
 ]

--- a/src/Glamour-Morphic-Brick/GLMAnimation.class.st
+++ b/src/Glamour-Morphic-Brick/GLMAnimation.class.st
@@ -217,7 +217,7 @@ GLMAnimation >> onStepped: aBlock [
 	steppedLogic := aBlock
 ]
 
-{ #category : #actions }
+{ #category : #initialization }
 GLMAnimation >> reset [
 
 	isCompleted := false.

--- a/src/Glamour-Morphic-Brick/GLMHorizontalLinearLayout.class.st
+++ b/src/Glamour-Morphic-Brick/GLMHorizontalLinearLayout.class.st
@@ -13,7 +13,7 @@ GLMHorizontalLinearLayout class >> cleanUp [
 	self reset
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 GLMHorizontalLinearLayout class >> reset [
 	"
 	self reset

--- a/src/Glamour-Morphic-Brick/GLMVerticalLinearLayout.class.st
+++ b/src/Glamour-Morphic-Brick/GLMVerticalLinearLayout.class.st
@@ -13,7 +13,7 @@ GLMVerticalLinearLayout class >> cleanUp [
 	self reset
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 GLMVerticalLinearLayout class >> reset [
 	"
 	self reset

--- a/src/Glamour-Morphic-Widgets/GLMWatcherWindow.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMWatcherWindow.class.st
@@ -30,7 +30,7 @@ GLMWatcherWindow class >> buildKeymapsOn: aBuilder [
 	aBuilder attachShortcutCategory: #Glamour to: Morph.
 ]
 
-{ #category : #'instance creation' }
+{ #category : #initialization }
 GLMWatcherWindow class >> reset [ 
 	"self reset"
 	uniqueInstance := nil

--- a/src/Graphics-Files/JPEGReadStream.class.st
+++ b/src/Graphics-Files/JPEGReadStream.class.st
@@ -207,7 +207,7 @@ JPEGReadStream >> nextBytes: n [
 	^(self next: n) asByteArray
 ]
 
-{ #category : #positioning }
+{ #category : #initialization }
 JPEGReadStream >> reset [
 	super reset.
 	self resetBitBuffer

--- a/src/Graphics-Fonts/StrikeFont.class.st
+++ b/src/Graphics-Fonts/StrikeFont.class.st
@@ -1932,7 +1932,7 @@ StrikeFont >> releaseCachedState [
 	self reset.
 ]
 
-{ #category : #emphasis }
+{ #category : #initialization }
 StrikeFont >> reset [
 	"Reset the cache of derivative emphasized fonts"
 	fallbackFont class = FixedFaceFont ifTrue: [ fallbackFont := nil ].

--- a/src/Graphics-Fonts/StrikeFontSet.class.st
+++ b/src/Graphics-Fonts/StrikeFontSet.class.st
@@ -796,7 +796,7 @@ StrikeFontSet >> questionGlyphInfoInto: glyphInfoArray [
 
 ]
 
-{ #category : #'private - initialization' }
+{ #category : #initialization }
 StrikeFontSet >> reset [
 	"Reset the cache of derivative emphasized fonts"
 

--- a/src/Hiedra/HiColumnController.class.st
+++ b/src/Hiedra/HiColumnController.class.st
@@ -125,7 +125,7 @@ HiColumnController >> renderer: aHiRulerRenderer [
 	renderer := aHiRulerRenderer
 ]
 
-{ #category : #API }
+{ #category : #initialization }
 HiColumnController >> reset [
 	"Reset the internal state with the purpose to regenerate the visualization the next time #cellMorphFor: is executed."
 

--- a/src/Kernel-Chronology-Extras/Stopwatch.class.st
+++ b/src/Kernel-Chronology-Extras/Stopwatch.class.st
@@ -85,7 +85,7 @@ Stopwatch >> reActivate [
 
 ]
 
-{ #category : #actions }
+{ #category : #initialization }
 Stopwatch >> reset [
 
 	self suspend.

--- a/src/Keymapping-Core/KMDispatcher.class.st
+++ b/src/Keymapping-Core/KMDispatcher.class.st
@@ -209,7 +209,7 @@ KMDispatcher >> removeKeyCombination: aShortcut [
 	removalTarget removeKeymapEntry: keymap
 ]
 
-{ #category : #initialize }
+{ #category : #initialization }
 KMDispatcher >> reset [
 	self resetTargets.
 	self resetPerInstanceTarget

--- a/src/Keymapping-Core/KMKeymap.class.st
+++ b/src/Keymapping-Core/KMKeymap.class.st
@@ -171,7 +171,7 @@ KMKeymap >> printOn: aStream [
 		cr.    
 ]
 
-{ #category : #'enabling/disabling' }
+{ #category : #initialization }
 KMKeymap >> reset [
 
 	self shortcut: self defaultShortcut.

--- a/src/Keymapping-Core/KMRepository.class.st
+++ b/src/Keymapping-Core/KMRepository.class.st
@@ -33,7 +33,7 @@ KMRepository class >> default: aDefault [
 	^ Singleton := aDefault
 ]
 
-{ #category : #'instance creation' }
+{ #category : #initialization }
 KMRepository class >> reset [
 	"Do not reset KMDispatchers instances, it may make the image unusable or force the user to close all the windows."
 	

--- a/src/Metacello-Core/MetacelloScriptRegistryExecutor.class.st
+++ b/src/Metacello-Core/MetacelloScriptRegistryExecutor.class.st
@@ -17,6 +17,6 @@ MetacelloScriptRegistryExecutor >> projectSpecSelectBlock [
 MetacelloScriptRegistryExecutor >> remove [
 ]
 
-{ #category : #'actions api' }
+{ #category : #initialization }
 MetacelloScriptRegistryExecutor >> reset [
 ]

--- a/src/Monticello/MCCacheRepository.class.st
+++ b/src/Monticello/MCCacheRepository.class.st
@@ -66,7 +66,7 @@ MCCacheRepository class >> initialize [
 	self resetIfInvalid
 ]
 
-{ #category : #utilities }
+{ #category : #initialization }
 MCCacheRepository class >> reset [
 
 	default := nil.

--- a/src/Monticello/MCDataStream.class.st
+++ b/src/Monticello/MCDataStream.class.st
@@ -534,7 +534,7 @@ MCDataStream >> readTrue [
     ^ true
 ]
 
-{ #category : #other }
+{ #category : #initialization }
 MCDataStream >> reset [
     "Reset the stream."
 

--- a/src/Moose-Algos-Graph/MalDijkstra.class.st
+++ b/src/Moose-Algos-Graph/MalDijkstra.class.st
@@ -73,7 +73,7 @@ MalDijkstra >> pathWeight [
 	^ self end pathWeight
 ]
 
-{ #category : #running }
+{ #category : #initialization }
 MalDijkstra >> reset [
 
 	self nodes do: [:n|

--- a/src/Morphic-Base/SystemProgressMorph.class.st
+++ b/src/Morphic-Base/SystemProgressMorph.class.st
@@ -118,7 +118,7 @@ SystemProgressMorph class >> initialize [
 	self reset.
 ]
 
-{ #category : #'instance creation' }
+{ #category : #initialization }
 SystemProgressMorph class >> reset [
 	"SystemProgressMorph reset"
 	UniqueInstance ifNotNil: [ UniqueInstance delete ].

--- a/src/Morphic-Widgets-FastTable/FTFilterFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTFilterFunction.class.st
@@ -104,7 +104,7 @@ FTFilterFunction >> reinitializeTable [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 FTFilterFunction >> reset [
 	"self filter"
 ]

--- a/src/Morphic-Widgets-FastTable/FTFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTFunction.class.st
@@ -91,7 +91,7 @@ FTFunction >> keyStroke: anEvent [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 FTFunction >> reset [
 	self subclassResponsibility 
 ]

--- a/src/Morphic-Widgets-FastTable/FTNilFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTNilFunction.class.st
@@ -36,7 +36,7 @@ FTNilFunction >> keyStroke: anEvent [
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 FTNilFunction >> reset [
 ]
 

--- a/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
+++ b/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
@@ -79,7 +79,7 @@ MenubarMorph class >> open [
 		open.
 ]
 
-{ #category : #'instance creation' }
+{ #category : #initialization }
 MenubarMorph class >> reset [
 
 	<script>

--- a/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
@@ -40,7 +40,7 @@ TaskbarMorph class >> maximumButtonsDefault [
 	^100
 ]
 
-{ #category : #initializing }
+{ #category : #initialization }
 TaskbarMorph class >> reset [
 	<script>
 	"Remove the taskbar and add a new one." 

--- a/src/NECompletion/NECModel.class.st
+++ b/src/NECompletion/NECModel.class.st
@@ -153,7 +153,7 @@ NECModel >> printOn: aStream [
 				aStream nextPutAll: ')' ]
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 NECModel >> reset [
 	self resetSelectors.
 	self resetEntries.

--- a/src/NECompletion/NECVarTypeGuesser.class.st
+++ b/src/NECompletion/NECVarTypeGuesser.class.st
@@ -187,7 +187,7 @@ NECVarTypeGuesser >> pushTemporaryVariable: offset [
 	types add: info
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 NECVarTypeGuesser >> reset [
 	contextCount > 0 ifTrue:[^self].
 	types reset.

--- a/src/NewValueHolder-Core/CollectionValueHolder.class.st
+++ b/src/NewValueHolder-Core/CollectionValueHolder.class.st
@@ -290,7 +290,7 @@ CollectionValueHolder >> replaceAll: oldObject with: newObject [
 	self valueChanged: oldObject
 ]
 
-{ #category : #protocol }
+{ #category : #initialization }
 CollectionValueHolder >> reset [
 
 	value reset.

--- a/src/NewValueHolder-Core/SelectionValueHolder.class.st
+++ b/src/NewValueHolder-Core/SelectionValueHolder.class.st
@@ -44,7 +44,7 @@ SelectionValueHolder >> initialize [
 	selection whenChangedSend: #valueChanged to: self.
 ]
 
-{ #category : #protocol }
+{ #category : #initialization }
 SelectionValueHolder >> reset [
 
 	self index value: 0.

--- a/src/OSWindow-SDL2-Examples/OSWindowJoystickExample.class.st
+++ b/src/OSWindow-SDL2-Examples/OSWindowJoystickExample.class.st
@@ -78,7 +78,7 @@ OSWindowJoystickExample >> redraw [
 		drawBullets
 ]
 
-{ #category : #'game controls' }
+{ #category : #initialization }
 OSWindowJoystickExample >> reset [
 	characterPosition := 320@240.
 	characterVelocity := 0@0.

--- a/src/Ombu/OmStoreFactory.class.st
+++ b/src/Ombu/OmStoreFactory.class.st
@@ -28,7 +28,7 @@ OmStoreFactory class >> initialize [
 	SessionManager default registerSystemClassNamed: self name
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 OmStoreFactory class >> reset [
 	"
 	self reset

--- a/src/ProfStef-Core/ProfStef.class.st
+++ b/src/ProfStef-Core/ProfStef.class.st
@@ -206,7 +206,7 @@ ProfStef class >> previous [
 	^ self default previous
 ]
 
-{ #category : #'class initialization' }
+{ #category : #initialization }
 ProfStef class >> reset [
 	<script>
 		

--- a/src/Reflectivity/ExecutionCounter.class.st
+++ b/src/Reflectivity/ExecutionCounter.class.st
@@ -97,7 +97,7 @@ ExecutionCounter >> node: anObject [
 	node := anObject
 ]
 
-{ #category : #counter }
+{ #category : #initialization }
 ExecutionCounter >> reset [
 	count := 0
 ]

--- a/src/Reflectivity/RFMetaContext.class.st
+++ b/src/Reflectivity/RFMetaContext.class.st
@@ -16,7 +16,7 @@ RFMetaContext class >> current [
 	^ActiveMetaContext value
 ]
 
-{ #category : #reset }
+{ #category : #initialization }
 RFMetaContext class >> reset [
 	ActiveMetaContext value: self new.
 ]

--- a/src/Renraku/ReRuleManager.class.st
+++ b/src/Renraku/ReRuleManager.class.st
@@ -134,7 +134,7 @@ ReRuleManager class >> removeManagerFor: anRPackage [
 	
 ]
 
-{ #category : #utilities }
+{ #category : #initialization }
 ReRuleManager class >> reset [
 	<script>
 	managers := nil.

--- a/src/STON-Core/STONReader.class.st
+++ b/src/STON-Core/STONReader.class.st
@@ -553,7 +553,7 @@ STONReader >> processSubObjectsOf: object [
 	^ object
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #initialization }
 STONReader >> reset [
 	unresolvedReferences := 0.
 	objects removeAll

--- a/src/STON-Core/STONWriter.class.st
+++ b/src/STON-Core/STONWriter.class.st
@@ -353,7 +353,7 @@ STONWriter >> referencePolicy: policy [
 
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #initialization }
 STONWriter >> reset [
 	objects removeAll
 ]

--- a/src/SUnit-Core/TestResource.class.st
+++ b/src/SUnit-Core/TestResource.class.st
@@ -113,7 +113,7 @@ TestResource class >> new [
 	^super new initialize.
 ]
 
-{ #category : #'instance creation' }
+{ #category : #initialization }
 TestResource class >> reset [
 	[self isAlreadyAvailable ifTrue: [current tearDown]]
 		ensure: [current := nil]

--- a/src/Spec-Core/SliderPresenter.class.st
+++ b/src/Spec-Core/SliderPresenter.class.st
@@ -210,7 +210,7 @@ SliderPresenter >> quantum: aNumber [
 	quantum value: aNumber
 ]
 
-{ #category : #api }
+{ #category : #initialization }
 SliderPresenter >> reset [
 	"<api:#do>"
 	"Reset the cursor to the minimum value"

--- a/src/Spec-Core/SpecNullApplication.class.st
+++ b/src/Spec-Core/SpecNullApplication.class.st
@@ -8,7 +8,7 @@ Class {
 	#category : #'Spec-Core-Base'
 }
 
-{ #category : #accessing }
+{ #category : #initialization }
 SpecNullApplication class >> reset [
 	<script>
 	

--- a/src/Spec-Core/SpecSelectionValueHolder.class.st
+++ b/src/Spec-Core/SpecSelectionValueHolder.class.st
@@ -47,7 +47,7 @@ SpecSelectionValueHolder >> initialize [
 	selection whenChangedSend: #valueChanged to: self.
 ]
 
-{ #category : #protocol }
+{ #category : #initialization }
 SpecSelectionValueHolder >> reset [
 
 	self index value: 0.

--- a/src/Spec-MorphicAdapters/MorphicStyleSheet.class.st
+++ b/src/Spec-MorphicAdapters/MorphicStyleSheet.class.st
@@ -47,7 +47,7 @@ MorphicStyleSheet class >> newDefault [
 	^ MorphicDefaultStyleSheet new
 ]
 
-{ #category : #utils }
+{ #category : #initialization }
 MorphicStyleSheet class >> reset [ 
 	<script>
 	

--- a/src/Spec-MorphicAdapters/NotebookPageMorph.class.st
+++ b/src/Spec-MorphicAdapters/NotebookPageMorph.class.st
@@ -68,7 +68,7 @@ NotebookPageMorph >> model: anObject [
 	model := anObject
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 NotebookPageMorph >> reset [
 
 	self actualPageMorph: nil

--- a/src/Spec2-Adapters-Morphic/SpMorphicStyleSheet.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicStyleSheet.class.st
@@ -47,7 +47,7 @@ SpMorphicStyleSheet class >> newDefault [
 	^ SpMorphicDefaultStyleSheet new
 ]
 
-{ #category : #utils }
+{ #category : #initialization }
 SpMorphicStyleSheet class >> reset [ 
 	<script>
 	

--- a/src/Spec2-Adapters-Morphic/SpNotebookPageMorph.class.st
+++ b/src/Spec2-Adapters-Morphic/SpNotebookPageMorph.class.st
@@ -68,7 +68,7 @@ SpNotebookPageMorph >> model: anObject [
 	model := anObject
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 SpNotebookPageMorph >> reset [
 
 	self actualPageMorph: nil

--- a/src/Spec2-Commander2-ContactBook/SpContactBook.class.st
+++ b/src/Spec2-Commander2-ContactBook/SpContactBook.class.st
@@ -34,7 +34,7 @@ SpContactBook class >> family [
 			yourself]
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 SpContactBook class >> reset [
 	<script>
 	coworkers := nil.

--- a/src/Spec2-Core/SpNullApplication.class.st
+++ b/src/Spec2-Core/SpNullApplication.class.st
@@ -8,7 +8,7 @@ Class {
 	#category : #'Spec2-Core-Base'
 }
 
-{ #category : #accessing }
+{ #category : #initialization }
 SpNullApplication class >> reset [
 	<script>
 	

--- a/src/Spec2-Core/SpSliderPresenter.class.st
+++ b/src/Spec2-Core/SpSliderPresenter.class.st
@@ -201,7 +201,7 @@ SpSliderPresenter >> quantum: aNumber [
 	quantum := aNumber
 ]
 
-{ #category : #api }
+{ #category : #initialization }
 SpSliderPresenter >> reset [
 	"<api:#do>"
 	"Reset the cursor to the minimum value"

--- a/src/StartupPreferences/StartupPreferencesLoader.class.st
+++ b/src/StartupPreferences/StartupPreferencesLoader.class.st
@@ -163,7 +163,7 @@ StartupPreferencesLoader class >> preferencesVersionFolder [
 		ifNotNil: [ :folder | folder / SystemVersion current dottedMajorMinor ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : #initialization }
 StartupPreferencesLoader class >> reset [
 
 	UniqueInstance := nil

--- a/src/System-Caching/CacheStatistics.class.st
+++ b/src/System-Caching/CacheStatistics.class.st
@@ -50,7 +50,7 @@ CacheStatistics >> misses [
 	^ misses
 ]
 
-{ #category : #initialize }
+{ #category : #initialization }
 CacheStatistics >> reset [
 	hits := misses := 0
 ]

--- a/src/System-Caching/CacheWeight.class.st
+++ b/src/System-Caching/CacheWeight.class.st
@@ -66,7 +66,7 @@ CacheWeight >> remove: value [
 	total := total - weight
 ]
 
-{ #category : #initialize }
+{ #category : #initialization }
 CacheWeight >> reset [
 	total := 0
 ]

--- a/src/System-CommandLine/VTermOutputDriver.class.st
+++ b/src/System-CommandLine/VTermOutputDriver.class.st
@@ -354,7 +354,7 @@ VTermOutputDriver >> red: aString [
 	self red; << aString; flush; clear.
 ]
 
-{ #category : #coloring }
+{ #category : #initialization }
 VTermOutputDriver >> reset [
 	currentColor := 0.
 	currentBackground := 0.

--- a/src/System-CommandLine/VTermOutputDriver2.class.st
+++ b/src/System-CommandLine/VTermOutputDriver2.class.st
@@ -632,7 +632,7 @@ VTermOutputDriver2 >> redFont: aString [
 	self write: aString withColor: Color red
 ]
 
-{ #category : #deprecated }
+{ #category : #initialization }
 VTermOutputDriver2 >> reset [
 	^self resetStyle
 ]

--- a/src/System-History/HistoryIterator.class.st
+++ b/src/System-History/HistoryIterator.class.st
@@ -223,7 +223,7 @@ HistoryIterator >> removeFirst [
 	self recorder removeFirst
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 HistoryIterator >> reset [
 	self recorder reset.
 	index := nil.

--- a/src/System-History/HistoryNode.class.st
+++ b/src/System-History/HistoryNode.class.st
@@ -196,7 +196,7 @@ HistoryNode >> removeLast: count [
 	self history removeLast: count
 ]
 
-{ #category : #'opening-closing' }
+{ #category : #initialization }
 HistoryNode >> reset [
 	history := nil.
 	opened := true

--- a/src/System-Identification/GlobalIdentifier.class.st
+++ b/src/System-Identification/GlobalIdentifier.class.st
@@ -66,7 +66,7 @@ GlobalIdentifier class >> new [
 	self shouldNotImplement
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #initialization }
 GlobalIdentifier class >> reset [
 	"self reset"
 	uniqueInstance := nil

--- a/src/System-Sources/ChangesLog.class.st
+++ b/src/System-Sources/ChangesLog.class.st
@@ -34,7 +34,7 @@ ChangesLog class >> registerInterestToSystemAnnouncement [
 
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 ChangesLog class >> reset [
 	SystemAnnouncer uniqueInstance unsubscribe: DefaultInstance.
 	DefaultInstance := nil.

--- a/src/System-Sources/PharoFilesOpener.class.st
+++ b/src/System-Sources/PharoFilesOpener.class.st
@@ -18,7 +18,7 @@ PharoFilesOpener class >> default [
 	^ Default ifNil: [ Default := self new ]
 ]
 
-{ #category : #singleton }
+{ #category : #initialization }
 PharoFilesOpener class >> reset [
 	Default := nil
 ]

--- a/src/System-Support/Author.class.st
+++ b/src/System-Support/Author.class.st
@@ -83,7 +83,7 @@ Author class >> requestFullName [
 	^ Author uniqueInstance requestFullName
 ]
 
-{ #category : #'instance creation' }
+{ #category : #initialization }
 Author class >> reset [
 	<script>
 	^ self uniqueInstance reset.
@@ -165,7 +165,7 @@ Author >> requestFullName [
 	] "nil means that the dialog was cancelled "
 ]
 
-{ #category : #compatibility }
+{ #category : #initialization }
 Author >> reset [
 	fullName := ''
 ]

--- a/src/Text-Core/TextAttribute.class.st
+++ b/src/Text-Core/TextAttribute.class.st
@@ -84,7 +84,7 @@ TextAttribute >> oldEmphasisCode: default [
 	^ default
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 TextAttribute >> reset [
 	"Allow subclasses to prepare themselves for merging attributes"
 ]

--- a/src/Text-Core/TextKern.class.st
+++ b/src/Text-Core/TextKern.class.st
@@ -59,7 +59,7 @@ TextKern >> kern: kernValue [
 	self reset.
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 TextKern >> reset [
 	active := true
 ]

--- a/src/Tool-Catalog/CatalogProvider.class.st
+++ b/src/Tool-Catalog/CatalogProvider.class.st
@@ -75,7 +75,7 @@ CatalogProvider >> projects [
 	^ projects ifNil: [ #() ]
 ]
 
-{ #category : #actions }
+{ #category : #initialization }
 CatalogProvider >> reset [
 	"Reset my cached data so that I will reload it on next access"
 	

--- a/src/Tool-CriticBrowser/CriticWorkingConfiguration.class.st
+++ b/src/Tool-CriticBrowser/CriticWorkingConfiguration.class.st
@@ -36,7 +36,7 @@ CriticWorkingConfiguration class >> new [
 	^ self shouldNotImplement
 ]
 
-{ #category : #'instance creation' }
+{ #category : #initialization }
 CriticWorkingConfiguration class >> reset [
 
 	Current := nil

--- a/src/Tool-DependencyAnalyser/DAPackageCycleDetector.class.st
+++ b/src/Tool-DependencyAnalyser/DAPackageCycleDetector.class.st
@@ -196,7 +196,7 @@ DAPackageCycleDetector >> relationGraph [
 	^ relationGraph
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 DAPackageCycleDetector >> reset [
 	cycles := SortedCollection new.
 	visitedNodes := nil.

--- a/src/UnifiedFFI/FFICallbackFunctionResolution.class.st
+++ b/src/UnifiedFFI/FFICallbackFunctionResolution.class.st
@@ -54,7 +54,7 @@ FFICallbackFunctionResolution class >> registerCallback: aCallback as: functionN
 
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 FFICallbackFunctionResolution class >> reset [
 	CallbackRegistry := nil
 ]

--- a/src/UnifiedFFI/FFIExternalResourceManager.class.st
+++ b/src/UnifiedFFI/FFIExternalResourceManager.class.st
@@ -86,7 +86,7 @@ FFIExternalResourceManager class >> addResource: anObject executor: anExecutor [
 	self uniqueInstance addResource: anObject executor: anExecutor
 ]
 
-{ #category : #'instance creation' }
+{ #category : #initialization }
 FFIExternalResourceManager class >> reset [
 	uniqueInstance := nil
 ]

--- a/src/UnifiedFFI/FFIExternalStructure.class.st
+++ b/src/UnifiedFFI/FFIExternalStructure.class.st
@@ -229,7 +229,7 @@ FFIExternalStructure class >> removeAllOffsetVariables [
 		thenDo: [ :each | self removeClassVarNamed: each ]
 ]
 
-{ #category : #'class management' }
+{ #category : #initialization }
 FFIExternalStructure class >> reset [
 	"Reset this structure and all its nested structures"
 	self resetStructureIfNotIn: Set new

--- a/src/UnifiedFFI/FFIExternalValueHolder.class.st
+++ b/src/UnifiedFFI/FFIExternalValueHolder.class.st
@@ -68,7 +68,7 @@ FFIExternalValueHolder class >> ofType: aTypeName [
 		type: (FFIExternalType resolveType: aTypeName)
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 FFIExternalValueHolder class >> reset [
 	type := nil
 ]

--- a/src/UnifiedFFI/FFIMethodRegistry.class.st
+++ b/src/UnifiedFFI/FFIMethodRegistry.class.st
@@ -92,7 +92,7 @@ FFIMethodRegistry >> removeMethod: aMethod [
 		put: (aMethod propertyValueAt: #ffiNonCompiledMethod)
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 FFIMethodRegistry >> reset [
 	"FFI compiled methods will keep the old method as a property, making easy to replace it 
 	 when changing platforms."

--- a/src/Zinc-HTTP/ZnChunkedReadStream.class.st
+++ b/src/Zinc-HTTP/ZnChunkedReadStream.class.st
@@ -249,7 +249,7 @@ ZnChunkedReadStream >> readInto: collection startingAt: offset count: requestedC
 	^ read
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 ZnChunkedReadStream >> reset [
 	"We don't allow it"
 ]

--- a/src/Zinc-HTTP/ZnLimitedReadStream.class.st
+++ b/src/Zinc-HTTP/ZnLimitedReadStream.class.st
@@ -232,7 +232,7 @@ ZnLimitedReadStream >> readInto: collection startingAt: offset count: count [
 	^ actual
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 ZnLimitedReadStream >> reset [
 	"We don't allow it"
 ]

--- a/src/Zinc-HTTP/ZnLineReader.class.st
+++ b/src/Zinc-HTTP/ZnLineReader.class.st
@@ -75,7 +75,7 @@ ZnLineReader >> processNext [
 	
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 ZnLineReader >> reset [
 	position := 0
 ]

--- a/src/Zodiac-Core/ZdcIOBuffer.class.st
+++ b/src/Zodiac-Core/ZdcIOBuffer.class.st
@@ -279,7 +279,7 @@ ZdcIOBuffer >> readInto: collection startingAt: offset count: requestedCount [
 	^ toRead
 ]
 
-{ #category : #operations }
+{ #category : #initialization }
 ZdcIOBuffer >> reset [
 	"Do a hard reset"
 	


### PR DESCRIPTION
Categorize all #reset methods that are in Pharo (We'll have to do Iceberg & co later) into initialization.

See: http://forum.world.st/Convention-for-quot-reset-quot-methods-td5019493.html

Next step is to fix Iceberg & co then add a release test. But I don't know if we will be able to have this fix soon in the image since Iceberg is been refactored.