### PR TITLE
Fix recently-introduced portability problems

### DIFF
--- a/src/Kernel-Tests/LargeNegativeIntegerTest.class.st
+++ b/src/Kernel-Tests/LargeNegativeIntegerTest.class.st
@@ -42,7 +42,7 @@ LargeNegativeIntegerTest >> testDigitAtPut [
 	| lni |
 	lni := LargeNegativeInteger new: 20.
 	1 to: 20 do: [:i | lni digitAt: i put: i].
-	self assert: -114605103402541699037609980192546360895434064385equals: lni
+	self assert: -114605103402541699037609980192546360895434064385 equals: lni
 
 ]
 

--- a/src/Kernel-Tests/LargePositiveIntegerTest.class.st
+++ b/src/Kernel-Tests/LargePositiveIntegerTest.class.st
@@ -85,7 +85,7 @@ LargePositiveIntegerTest >> testDigitAtPut [
 	| lpi |
 	lpi := LargePositiveInteger new: 20.
 	1 to: 20 do: [:i | lpi digitAt: i put: i].
-	self assert: 114605103402541699037609980192546360895434064385equals: lpi
+	self assert: 114605103402541699037609980192546360895434064385 equals: lpi
 
 ]
 

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -197,7 +197,7 @@ SystemAnnouncer >> isSuspended [
 SystemAnnouncer >> methodAdded: aMethod [ 
 	"A method with the given selector was added to aClass, but not put in a protocol."
 
-	^ self methodAdded: aMethod configuredWith: [ :method ]
+	^ self methodAdded: aMethod configuredWith: [ :method | ]
 ]
 
 { #category : #triggering }


### PR DESCRIPTION
Add vertical bar after block temp variable.
Separate number from message.