### PR TITLE
4094-Formatting-cleanups-Balloon-Tests

### DIFF
--- a/src/Balloon-Tests/PointArrayTest.class.st
+++ b/src/Balloon-Tests/PointArrayTest.class.st
@@ -61,7 +61,7 @@ PointArrayTest >> testAtPutInt4 [
 { #category : #tests }
 PointArrayTest >> testAtPutLargeInteger [
 
-	self should:  [pointArray at: 2 put: 123456789012345678901234567890@987654323456787654378989] raise: Error.	
+	self should: [ pointArray at: 2 put: 123456789012345678901234567890@987654323456787654378989 ] raise: Error.	
 ]
 
 { #category : #tests }

--- a/src/Balloon-Tests/ShortIntegerArrayTest.class.st
+++ b/src/Balloon-Tests/ShortIntegerArrayTest.class.st
@@ -21,7 +21,7 @@ ShortIntegerArrayTest >> setUp [
 { #category : #tests }
 ShortIntegerArrayTest >> testAt [
 
-	self assert: 2  equals: (shortIntegerArray at: 3)
+	self assert: 2 equals: (shortIntegerArray at: 3)
 	
 ]
 
@@ -29,7 +29,7 @@ ShortIntegerArrayTest >> testAt [
 ShortIntegerArrayTest >> testAtPut [
 
 	shortIntegerArray at: 3 put: 100.
-	self assert: 100  equals: (shortIntegerArray at: 3)
+	self assert: 100 equals: (shortIntegerArray at: 3)
 	
 ]
 
@@ -59,7 +59,7 @@ ShortIntegerArrayTest >> testWriteBigEndianOn [
 
 	|stream|
 	stream := WriteStream on: Array new.
-	shortIntegerArray write: (12 bitShift: 24)+(34 bitShift: 16)+(56 bitShift: 8)+78 bigEndianOn: stream.
+	shortIntegerArray write: (12 bitShift: 24) + (34 bitShift: 16) + (56 bitShift: 8) + 78 bigEndianOn: stream.
 	self assert: #(12 34 56 78) equals: stream contents
 ]
 
@@ -68,6 +68,6 @@ ShortIntegerArrayTest >> testWriteLittleEndianOn [
 
 	|stream|
 	stream := WriteStream on: Array new.
-	shortIntegerArray write: (12 bitShift: 24) +(34 bitShift: 16)+(56 bitShift: 8)+78 littleEndianOn: stream.
+	shortIntegerArray write: (12 bitShift: 24) + (34 bitShift: 16) + (56 bitShift: 8) + 78 littleEndianOn: stream.
 	self assert: #(56 78 12 34) equals: stream contents
 ]


### PR DESCRIPTION
Formatting cleanups Balloon-Tests 

- remove unnecessary spaces
- add better formatting for readability

Fix #4094