### PR TITLE
Behaviorals-understand-traits-but-not-allTraits

### DIFF
--- a/src/GT-SpotterExtensions-Core/Behavior.extension.st
+++ b/src/GT-SpotterExtensions-Core/Behavior.extension.st
@@ -17,7 +17,7 @@ Behavior >> spotterCompositionFor: aStep [
 	<spotterOrder: 25>
 	aStep listProcessor
 			title: 'Composing traits';
-			allCandidates: [ self traitComposition allTraits ];
+			allCandidates: [ self allTraits ];
 			itemIcon: #systemIcon;
 			filter: GTFilterSubstring
 ]

--- a/src/TraitsV2/Behavior.extension.st
+++ b/src/TraitsV2/Behavior.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : #Behavior }
 
 { #category : #'*TraitsV2' }
+Behavior >> allTraits [
+	^ #()
+]
+
+{ #category : #'*TraitsV2' }
 Behavior >> hasTraitComposition [
 	
 	^ false 

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -344,5 +344,5 @@ TraitedClass >> traitUsers [
 
 { #category : #accessing }
 TraitedClass >> traits [
-	^ self traitComposition traits.
+	^ self traitComposition traits
 ]


### PR DESCRIPTION
With this fix, you can ask #allTraits to all classes even if they don't have traits. 
This works the same way than the #traits method.