### PR TITLE
Class variable isolation

### DIFF
--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -40,6 +40,14 @@ Class {
 }
 
 { #category : #'process specific' }
+Process class >> psKeysSema [
+	"Isolate handling of class variable"
+
+	PSKeysSema ifNil: [ PSKeysSema := Semaphore forMutualExclusion ].
+	^PSKeysSema
+]
+
+{ #category : #'process specific' }
 Process class >> allocatePSKey: aPSVariable [
 
 	"Add a new process-specific key. 
@@ -47,8 +55,7 @@ Process class >> allocatePSKey: aPSVariable [
 	if object is not registered, first search for an empty slot for insertion and if not found, grow an array to add new object"
 
 	| index |
-	PSKeysSema ifNil: [ PSKeysSema := Semaphore forMutualExclusion ].
-	PSKeysSema critical: [
+	self psKeysSema critical: [
 		PSKeys 
 			ifNil: [ PSKeys := WeakArray with: aPSVariable. index := 1 ]
 			ifNotNil: [ 

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -31,7 +31,7 @@ SystemAnnouncer class >> reset [
 		thenDo: [:each | each weakRegistry remove: each subscriber ifAbsent: []]. 
 	Smalltalk garbageCollect.
 		
-	announcer := nil.
+	self announcer: nil.
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Isolate references to a couple class variables to simplify porting.