### PR TITLE
4112-TestRunner-is-using-instVarNamed-instead-of-an-accesor

### DIFF
--- a/src/SUnit-Core/TestResult.class.st
+++ b/src/SUnit-Core/TestResult.class.st
@@ -198,6 +198,11 @@ TestResult >> errors [
 ]
 
 { #category : #accessing }
+TestResult >> errors: anOrderedCollection [
+	errors := anOrderedCollection
+]
+
+{ #category : #accessing }
 TestResult >> expectedDefectCount [
 	^ self expectedDefects size
 ]
@@ -226,6 +231,11 @@ TestResult >> failureCount [
 { #category : #compatibility }
 TestResult >> failures [
 	^ self unexpectedFailures, self unexpectedPasses 
+]
+
+{ #category : #accessing }
+TestResult >> failures: aSet [
+	failures := aSet
 ]
 
 { #category : #'filein/out' }
@@ -311,6 +321,11 @@ TestResult >> isPassedFor: class selector: selector [
 { #category : #compatibility }
 TestResult >> passed [
 	^ self expectedPasses, self expectedDefects
+]
+
+{ #category : #accessing }
+TestResult >> passed: anOrderedCollection [
+	passed := anOrderedCollection
 ]
 
 { #category : #accessing }

--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -867,14 +867,14 @@ TestRunner >> runCoverage [
 
 { #category : #actions }
 TestRunner >> runErrors [
-	self result instVarNamed: 'errors' put: OrderedCollection new.
+	self result errors: OrderedCollection new.
 	self runTestSuites: self errorTestSuites.
 ]
 
 { #category : #actions }
 TestRunner >> runFailures [
-	self result instVarNamed: 'failures' put: Set new.
-	self runTestSuites: self failureTestSuites.
+	self result failures: Set new.
+	self runTestSuites: self failureTestSuites
 ]
 
 { #category : #actions }


### PR DESCRIPTION
fix issue #4112 .
instVarNamed:  replace by setter