### PR TITLE
Deprecating  subclassInstVarNames method.

### DIFF
--- a/src/Deprecated80/Behavior.extension.st
+++ b/src/Deprecated80/Behavior.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #Behavior }
+
+{ #category : #'*Deprecated80' }
+Behavior >> subclassInstVarNames [
+	"Answer a Set of the names of the receiver's subclasses' instance variables."
+
+	self
+		deprecated:
+			'This method is dead code in Pharo and will be removed. You can run (aClass subClasses flatCollect: instVarNames)'.
+	^ self allSubclasses
+		flatCollectAsSet: [ :aSubclass | aSubclass instVarNames ]
+]

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1718,12 +1718,6 @@ Behavior >> subclassDefinerClass [
 	^Smalltalk compilerClass
 ]
 
-{ #category : #'accessing instances and variables' }
-Behavior >> subclassInstVarNames [
-	"Answer a Set of the names of the receiver's subclasses' instance variables."
-	^self allSubclasses flatCollectAsSet: [:aSubclass | aSubclass instVarNames]
-]
-
 { #category : #'accessing class hierarchy' }
 Behavior >> superclass [
 	"Answer the receiver's superclass, a Class."


### PR DESCRIPTION
Fixes #3818 