### PR TITLE
4025-some-callers-of-compiledMethodAtifPresentifAbsent-do-not-need-ifAbsent-part

### DIFF
--- a/src/EpiceaBrowsers/EpApplyPreviewer.class.st
+++ b/src/EpiceaBrowsers/EpApplyPreviewer.class.st
@@ -156,21 +156,20 @@ EpApplyPreviewer >> visitEvent: aChange [
 EpApplyPreviewer >> visitMethodChange: aChange [
 	"Addition and Modification come here"
 
-	self 
+	self
 		behaviorNamed: aChange behaviorAffectedName
 		ifPresent: [ :behavior | 
-			^behavior 
+			^ behavior
 				compiledMethodAt: aChange methodAffectedSelector
-				ifPresent: [ :method |
-					(method protocol ~= aChange methodAffectedProtocol or: [
-					method sourceCode ~= aChange methodAffectedSourceCode ]) 
-						ifTrue: [ { EpMethodModification oldMethod: method newMethod: aChange methodAffected } ]
+				ifPresent: [ :method | 
+					(method protocol ~= aChange methodAffectedProtocol
+						or: [ method sourceCode ~= aChange methodAffectedSourceCode ])
+						ifTrue: [ {(EpMethodModification
+								oldMethod: method
+								newMethod: aChange methodAffected)} ]
 						ifFalse: [ #() ] ]
-				ifAbsent: [ 
-					{ EpMethodAddition method: aChange methodAffected } ] ].
-	
-	^ { aChange }
-
+				ifAbsent: [ {(EpMethodAddition method: aChange methodAffected)} ] ].
+	^ {aChange}
 ]
 
 { #category : #visitor }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -900,21 +900,20 @@ Object >> explicitRequirement [
 	originalMethod := callingContext method.
 	originalMethod isFromTrait
 		ifFalse: errorBlock.
-		
 	originalReceiver := callingContext receiver.
 	originalSelector := originalMethod selector.
 	originalArguments := callingContext arguments.
-	
 	originalReceiver class superclass
 		withAllSuperclassesDo: [ :superClass | 
 			superClass
 				compiledMethodAt: originalSelector
 				ifPresent: [ :method | 
 					(method isProvided or: [ method isFromTrait not ])
-						ifTrue: [ 
-							callingContext return: (method valueWithReceiver: originalReceiver arguments: originalArguments) ] ]
-				ifAbsent: [  ] ].
-
+						ifTrue: [ callingContext
+								return:
+									(method
+										valueWithReceiver: originalReceiver
+										arguments: originalArguments) ] ] ].
 	errorBlock value
 ]
 

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -40,14 +40,6 @@ Class {
 }
 
 { #category : #'process specific' }
-Process class >> psKeysSema [
-	"Isolate handling of class variable"
-
-	PSKeysSema ifNil: [ PSKeysSema := Semaphore forMutualExclusion ].
-	^PSKeysSema
-]
-
-{ #category : #'process specific' }
 Process class >> allocatePSKey: aPSVariable [
 
 	"Add a new process-specific key. 
@@ -98,6 +90,14 @@ Process class >> forContext: aContext priority: anInteger [
 	newProcess priority: anInteger.
 	Processor activeProcess installEnvIntoForked: newProcess.
 	^newProcess
+]
+
+{ #category : #'process specific' }
+Process class >> psKeysSema [
+	"Isolate handling of class variable"
+
+	PSKeysSema ifNil: [ PSKeysSema := Semaphore forMutualExclusion ].
+	^PSKeysSema
 ]
 
 { #category : #'process specific' }

--- a/src/Monticello-Tests/MCWorkingCopyForExtensionsTest.class.st
+++ b/src/Monticello-Tests/MCWorkingCopyForExtensionsTest.class.st
@@ -8,18 +8,15 @@ Class {
 MCWorkingCopyForExtensionsTest >> tearDown [
 	'ATestPackage' asPackage removeFromSystem.
 	'AnotherTestPackage' asPackage removeFromSystem.
-	
 	Object
 		compiledMethodAt: #testingMethod
-		ifPresent: [ Object removeSelector: #testingMethod ]
-		ifAbsent: [  ].
-
-	('Atestpackage-something-else' asPackageIfAbsent: [ nil ]) ifNotNil: #removeFromSystem.
-
+		ifPresent: [ Object removeSelector: #testingMethod ].
+	('Atestpackage-something-else' asPackageIfAbsent: [ nil ])
+		ifNotNil: #removeFromSystem.
 	MCWorkingCopy registry
 		at: (MCPackage named: 'atestpackage-something-else')
 		ifPresent: [ :aWC | aWC unload ].
-	super tearDown.
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/Reflectivity/RBMethodNode.extension.st
+++ b/src/Reflectivity/RBMethodNode.extension.st
@@ -15,19 +15,23 @@ RBMethodNode >> metaLinkOptions [
 ]
 
 { #category : #'*Reflectivity' }
-RBMethodNode >> metaLinkOptionsFromClassAndMethod [ 
+RBMethodNode >> metaLinkOptionsFromClassAndMethod [
 	| options |
 	options := Set new.
-	self methodClass 
-		compiledMethodAt: #metaLinkOptions 
-		ifPresent: [:method | options parseOptions: ((method valueWithReceiver: nil arguments: #()) asDictionary at:  self selector ifAbsent: [#()])] 
-		ifAbsent: [].
+	self methodClass
+		compiledMethodAt: #metaLinkOptions
+		ifPresent: [ :method | 
+			options
+				parseOptions:
+					((method valueWithReceiver: nil arguments: #()) asDictionary
+						at: self selector
+						ifAbsent: [ #() ]) ].
 	"set meta link options defined per method"
-	(self pragmas select: [ :pragma | pragma selector == #metaLinkOptions:]) 
-		do: [ :pragma | (pragma asPragma setKeyword: #parseOptions:) sendTo: options ].
-	^options.
-		
-	
+	(self pragmas
+		select: [ :pragma | pragma selector == #metaLinkOptions: ])
+		do:
+			[ :pragma | (pragma asPragma setKeyword: #parseOptions:) sendTo: options ].
+	^ options
 ]
 
 { #category : #'*Reflectivity' }

--- a/src/ReleaseTests/ProperlyImplementedSUnitClassesTest.class.st
+++ b/src/ReleaseTests/ProperlyImplementedSUnitClassesTest.class.st
@@ -14,9 +14,12 @@ ProperlyImplementedSUnitClassesTest >> testAndMakeSureSuperSetupIsCalledAsFirstM
 	| violating |
 	violating := OrderedCollection new.
 	TestCase
-		allSubclassesDo:
-			[ :each | each compiledMethodAt: #setUp ifPresent: [ :method | (ShouldSendSuperSetUpAsFirstMessage superSetUpNotCalledFirstIn: method) ifTrue: [ violating add: method ] ] ifAbsent: nil ].
-
+		allSubclassesDo: [ :each | 
+			each
+				compiledMethodAt: #setUp
+				ifPresent: [ :method | 
+					(ShouldSendSuperSetUpAsFirstMessage superSetUpNotCalledFirstIn: method)
+						ifTrue: [ violating add: method ] ] ].
 	self assertEmpty: violating
 ]
 
@@ -27,7 +30,12 @@ ProperlyImplementedSUnitClassesTest >> testAndMakeSureSuperTearDownIsCalledAsLas
 	| violating |
 	violating := OrderedCollection new.
 	TestCase
-		allSubclassesDo:
-			[ :each | each compiledMethodAt: #tearDown ifPresent: [ :method | (ShouldSendSuperTearDownAsLastMessage superTearDownNotCalledLastIn: method) ifTrue: [ violating add: method ] ] ifAbsent: nil ].
+		allSubclassesDo: [ :each | 
+			each
+				compiledMethodAt: #tearDown
+				ifPresent: [ :method | 
+					(ShouldSendSuperTearDownAsLastMessage
+						superTearDownNotCalledLastIn: method)
+						ifTrue: [ violating add: method ] ] ].
 	self assertEmpty: violating
 ]


### PR DESCRIPTION
fixes #4025

Use compiledMethodAt:ifPresent where possible instead of compiledMethodAt:ifPresent:ifAbsent: