### PR TITLE
FileTest cleanup

### DIFF
--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -20,11 +20,11 @@ DiskStore class >> activeClass [
 
 	| writableClass |
 	
-	writableClass := writableClass := self allSubclasses detect: [:each | 
+	writableClass := self allSubclasses detect: [:each | 
 		each isActiveClass ] ifNone: [ ^ self ].
 	
 	^ SessionManager default currentSession isReadOnlyAccessMode
-		ifFalse: [ writableClass]
+		ifFalse: [ writableClass ]
 		ifTrue: [ writableClass readOnlyVariant ].
 ]
 

--- a/src/Files-Tests/FileTest.class.st
+++ b/src/Files-Tests/FileTest.class.st
@@ -28,7 +28,9 @@ FileTest >> testCheckExistenceOfNonExistingFileDoesNotThrowException [
 
 	| file |
 	file := File named: 'asd.txt'.
-	self shouldnt: [file checkDoesNotExist] raise: Error.
+	[file checkDoesNotExist] 
+		on: FileAlreadyExistsException
+		do: [ :ex | self assert: false description: 'File should not exist!' ]
 ]
 
 { #category : #tests }
@@ -55,9 +57,9 @@ FileTest >> testFileExists [
 FileTest >> testFilesAreRegisteredInWeakRegistry [
 
 	|  f |
-	[f := (File named: 'asd.txt') writeStream.
-	self assert: (File registry keys includes: f)]
-		ensure: [ f ifNotNil: #close ]
+	f := (File named: 'asd.txt') writeStream.
+	[self assert: (File registry keys includes: f)]
+		ensure: [ f ifNotNil: [ f close ] ]
 ]
 
 { #category : #tests }
@@ -90,23 +92,23 @@ FileTest >> testOpeningFileObjectCreatesFile [
 ]
 
 { #category : #tests }
-FileTest >> testOpeningFileSetsPositionAtBeggining [
+FileTest >> testOpeningFileSetsPositionAtBeginning [
 
 	| file |
-	[(File named: 'asd.txt') writeStreamDo: [ :stream | stream nextPutAll: 'aaa' ].
+	(File named: 'asd.txt') writeStreamDo: [ :stream | stream nextPutAll: 'aaa' ].
 	file := (File named: 'asd.txt') openForWrite.
-	self assert: file position equals: 0 
-		] ensure: [ file ifNotNil: #close ]
+	[self assert: file position equals: 0 
+		] ensure: [ file ifNotNil: [ file close ] ]
 ]
 
 { #category : #tests }
 FileTest >> testOpeningForAppendSetsPositionAtEnd [
 
 	| file |
-	[ (File named: 'asd.txt') writeStreamDo: [ :stream | stream nextPutAll: 'aaa' ].
+	(File named: 'asd.txt') writeStreamDo: [ :stream | stream nextPutAll: 'aaa' ].
 	file := (File named: 'asd.txt') openForAppend.
-	self assert: file position equals: 3
-		] ensure: [ file ifNotNil: #close ]
+	[ self assert: file position equals: 3
+		] ensure: [ file ifNotNil: [ file close ] ]
 ]
 
 { #category : #tests }

--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -1,13 +1,9 @@
 "
-I represent a sequential binary File. I provide the minimum operations to:
-
-- move the cursor fo the file
-- reading
-- writing
+I represent a sequential binary File and provide primitives for various file operations.
 
 I am also the entry point of the FilePlugin primitives.
 
-!Examples of usage
+Examples of usage:
 
 ""Creating a file""
 file := File named: 'asd.txt' asFileReference fullName.


### PR DESCRIPTION
Cleanup comment for `File`.
Refactor `FileTest` for code critic issues and to use block rather than symbol as argument to `#ifNotNil:`.
Remove duplicate assignment.