### PR TITLE
2799-rename-NuclearSiteTestingClassTest

### DIFF
--- a/src/Renraku-Test/ReCodeBasedTestCase.class.st
+++ b/src/Renraku-Test/ReCodeBasedTestCase.class.st
@@ -16,19 +16,19 @@ Class {
 ReCodeBasedTestCase >> setUp [
 	super setUp.
 	testClass := Object
-		subclass: 'NuclearSiteTestingClass'
+		subclass: 'RenrakuProgramaticallyCreatedClassTestClass'
 		instanceVariableNames: ''
 		classVariableNames: ''
 		poolDictionaries: ''
-		category: testPackage name.
-	testMethod := testClass >> (testClass compile: 'nuclearSiteTestingMethod ^ self').
-	
+		package: testPackage name.
+	testMethod := testClass
+		>> (testClass compile: 'testingMethod ^ self').
 	testClass2 := Object
-		subclass: 'NuclearSiteTestingClass2'
+		subclass: 'RenrakuProgramaticallyCreatedClassTestClass2'
 		instanceVariableNames: ''
 		classVariableNames: ''
 		poolDictionaries: ''
-		category: testPackage name.
+		package: testPackage name
 ]
 
 { #category : #running }

--- a/src/Renraku-Test/ReTestBasedTestCase.class.st
+++ b/src/Renraku-Test/ReTestBasedTestCase.class.st
@@ -10,16 +10,16 @@ Class {
 { #category : #running }
 ReTestBasedTestCase >> setUp [
 	super setUp.
-	
-	validTestPackage := (RPackage named: #'Renraku-Nuclear-Site-Tests') register.
-	
+	validTestPackage := (RPackage
+		named: #'Renraku-Programatically-Created-Class-Tests') register.
+
 	"create tests in wrong package"
 	testClass := TestCase
-		subclass: 'NuclearSiteTestingClassTest'
+		subclass: 'RenrakuProgramaticallyCreatedClassTest'
 		instanceVariableNames: ''
 		classVariableNames: ''
 		poolDictionaries: ''
-		package: testPackage name.
+		package: testPackage name
 ]
 
 { #category : #running }

--- a/src/Renraku-Test/ReTestClassNameShouldNotEndWithTestsTest.class.st
+++ b/src/Renraku-Test/ReTestClassNameShouldNotEndWithTestsTest.class.st
@@ -6,16 +6,16 @@ Class {
 
 { #category : #tests }
 ReTestClassNameShouldNotEndWithTestsTest >> testBasicCheck [
-	
 	self
-		assert: (testClass critiques noneSatisfy: [ :critic | critic rule class = ReTestClassNameShouldNotEndWithTests ]).
-		
-		
-	"test class name endind with 'Tests'"
-	testClass rename:'NuclearSiteTestingClassTests'.
-	
-	self
-		assert: (testClass critiques anySatisfy: [ :critic | critic rule class = ReTestClassNameShouldNotEndWithTests ]).
-	
+		assert:
+			(testClass critiques
+				noneSatisfy: [ :critic | critic rule class = ReTestClassNameShouldNotEndWithTests ]).
 
+
+	"test class name endind with 'Tests'"
+	testClass rename: 'RenrakuProgramaticallyCreatedClassTests'.
+	self
+		assert:
+			(testClass critiques
+				anySatisfy: [ :critic | critic rule class = ReTestClassNameShouldNotEndWithTests ])
 ]


### PR DESCRIPTION
Fixes #2799

Renamed package and class names created via the tests.