### PR TITLE
First pass on compiler tests for full blocks

### DIFF
--- a/src/Kernel/BlockClosure.class.st
+++ b/src/Kernel/BlockClosure.class.st
@@ -969,7 +969,8 @@ BlockClosure >> whileFalse: aBlock [
 	This is in case the message is sent to other than a literal block.
 	Evaluate the argument, aBlock, as long as the value of the receiver is false."
 
-	self value ifFalse: [ aBlock value. self whileFalse: aBlock ]
+	self value ifFalse: [ aBlock value. self whileFalse: aBlock ].
+	^ nil
 ]
 
 { #category : #controlling }
@@ -1001,5 +1002,6 @@ BlockClosure >> whileTrue: aBlock [
 	This is in case the message is sent to other than a literal block.
 	Evaluate the argument, aBlock, as long as the value of the receiver is true."
 
-	self value ifTrue: [ aBlock value. self whileTrue: aBlock ]
+	self value ifTrue: [ aBlock value. self whileTrue: aBlock ].
+	^ nil
 ]

--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -66,6 +66,12 @@ CompiledBlock >> methodNode [
 ]
 
 { #category : #accessing }
+CompiledBlock >> numberOfReservedLiterals [
+
+	^ 1
+]
+
+{ #category : #accessing }
 CompiledBlock >> outerCode [
 	"answer the compiled code that I am installed in, or nil if none."
 	^self literalAt: self numLiterals

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -433,7 +433,7 @@ CompiledCode >> literals [
 	"Answer an Array of the literals referenced by the receiver.	
 	 Exclude superclass + selector/properties"
 	| literals numberLiterals |
-	literals := Array new: (numberLiterals := self numLiterals - 2).
+	literals := Array new: (numberLiterals := self numLiterals - self numberOfReservedLiterals).
 	1 to: numberLiterals do: [:index |
 		literals at: index put: (self objectAt: index + 1)].
 	^literals
@@ -528,6 +528,12 @@ CompiledCode >> numTemps [
 	"Answer the number of temporary variables used by the receiver."
 	
 	^ (self header bitShift: -18) bitAnd: 16r3F
+]
+
+{ #category : #accessing }
+CompiledCode >> numberOfReservedLiterals [
+
+	self subclassResponsibility
 ]
 
 { #category : #literals }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -690,6 +690,12 @@ CompiledMethod >> name [
 ]
 
 { #category : #accessing }
+CompiledMethod >> numberOfReservedLiterals [
+
+	^ 2
+]
+
+{ #category : #accessing }
 CompiledMethod >> origin [
 	^ self methodClass findOriginClassOf: self
 ]

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -40,14 +40,6 @@ Class {
 }
 
 { #category : #'process specific' }
-Process class >> psKeysSema [
-	"Isolate handling of class variable"
-
-	PSKeysSema ifNil: [ PSKeysSema := Semaphore forMutualExclusion ].
-	^PSKeysSema
-]
-
-{ #category : #'process specific' }
 Process class >> allocatePSKey: aPSVariable [
 
 	"Add a new process-specific key. 
@@ -98,6 +90,14 @@ Process class >> forContext: aContext priority: anInteger [
 	newProcess priority: anInteger.
 	Processor activeProcess installEnvIntoForked: newProcess.
 	^newProcess
+]
+
+{ #category : #'process specific' }
+Process class >> psKeysSema [
+	"Isolate handling of class variable"
+
+	PSKeysSema ifNil: [ PSKeysSema := Semaphore forMutualExclusion ].
+	^PSKeysSema
 ]
 
 { #category : #'process specific' }

--- a/src/OpalCompiler-Tests/OCASTAndOrTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTAndOrTranslatorTest.class.st
@@ -1,0 +1,108 @@
+Class {
+	#name : #OCASTAndOrTranslatorTest,
+	#superclass : #OCASTSingleBlockTranslatorTest,
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #'building suites' }
+OCASTAndOrTranslatorTest class >> testParameters [
+	^ super testParameters *
+		(ParametrizedTestMatrix new
+			forSelector: #optimization addOptions: { #optionInlineAndOr . #optionInlineNone })
+]
+
+{ #category : #'testing - andor' }
+OCASTAndOrTranslatorTest >> testAndWithLeftFalseShortcircuitsRight [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	false and: {argument}'
+		withBlock: '[ result := 17 ]'.
+	self assert: instance result equals: nil
+]
+
+{ #category : #'testing - andor' }
+OCASTAndOrTranslatorTest >> testAndWithLeftTrueEvaluatesRight [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	true and: {argument}'
+		withBlock: '[ result := 17 ]'.
+	self assert: instance result equals: 17.
+]
+
+{ #category : #'testing - andor' }
+OCASTAndOrTranslatorTest >> testFalseAndAnythingReturnsFalse [
+
+	| result |
+	result := self
+		testComposedExample: 'example: anything
+	{definition}.
+	^ false and: {argument}'
+		withBlock: '[ anything ]'
+		withArguments: #(17).
+	self deny: result
+]
+
+{ #category : #'testing - andor' }
+OCASTAndOrTranslatorTest >> testFalseOrAnythingReturnsAnything [
+
+	| result |
+	result := self
+		testComposedExample: 'example: anything
+	{definition}.
+	^ false or: {argument}'
+		withBlock: '[ anything ]'
+		withArguments: #(17).
+	self assert: result equals: 17
+]
+
+{ #category : #'testing - andor' }
+OCASTAndOrTranslatorTest >> testOrWithLeftFalseEvaluatesRight [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	false or: {argument}'
+		withBlock: '[ result := 17 ]'.
+	self assert: instance result equals: 17.
+]
+
+{ #category : #'testing - andor' }
+OCASTAndOrTranslatorTest >> testOrWithLeftTrueShortcircuitsRight [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	true or: {argument}'
+		withBlock: '[ result := 17 ]'.
+	self assert: instance result equals: nil
+]
+
+{ #category : #'testing - andor' }
+OCASTAndOrTranslatorTest >> testTrueAndAnythingReturnsAnything [
+
+	| result |
+	result := self
+		testComposedExample: 'example: anything
+	{definition}.
+	^ true and: {argument}'
+		withBlock: '[ anything ]'
+		withArguments: #(17).
+	self assert: result equals: 17
+]
+
+{ #category : #'testing - andor' }
+OCASTAndOrTranslatorTest >> testTrueOrAnythingReturnsTrue [
+
+	| result |
+	result := self
+		testComposedExample: 'example: anything
+	{definition}.
+	^ true or: {argument}'
+		withBlock: '[ anything ]'
+		withArguments: #(17).
+	self assert: result
+]

--- a/src/OpalCompiler-Tests/OCASTBasicTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTBasicTranslatorTest.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #OCASTBasicTranslatorTest,
+	#superclass : #OCASTTranslatorTest,
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #'testing - simple' }
+OCASTBasicTranslatorTest >> testEmptyMethodReturnsReceiver [
+
+	self assert: (self testExample: #exampleEmptyMethod) equals: instance
+]
+
+{ #category : #'testing - simple' }
+OCASTBasicTranslatorTest >> testInitialInstanceIsEmpty [
+
+	self assert: instance result equals: nil
+]
+
+{ #category : #'testing - errors' }
+OCASTBasicTranslatorTest >> testSyntaxError [
+	
+	self
+		should: [ self compileSource: 'foo (']
+		raise: SyntaxErrorNotification
+]

--- a/src/OpalCompiler-Tests/OCASTBlockTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTBlockTranslatorTest.class.st
@@ -1,0 +1,204 @@
+Class {
+	#name : #OCASTBlockTranslatorTest,
+	#superclass : #OCASTTranslatorTest,
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #'tests-readvariables' }
+OCASTBlockTranslatorTest >> testBlockCapturesVariableNotValue [
+	
+	| result |
+	"Test that the block captures the variable and not the value at the moment of the closure"
+	result := self testSource: 'example
+	| t block |
+	t := 1.
+	block := [ t ].
+	t := 2.
+	^ block value'.
+	
+	self assert: result equals: 2
+]
+
+{ #category : #'tests-writevariables' }
+OCASTBlockTranslatorTest >> testBlockExplicitReturn [
+	
+	| result |
+	result := self testSource: 'example
+	[ ^ 5 ] value.
+	^ 2'.
+	
+	self assert: result equals: 5
+]
+
+{ #category : #'tests-arguments' }
+OCASTBlockTranslatorTest >> testBlockWithArgumentReturnsLastExpression [
+	
+	| result |
+	result := self testSource: 'example
+	^ [ :arg | arg ] value: 7'.
+	
+	self assert: result equals: 7
+]
+
+{ #category : #'tests-readvariables' }
+OCASTBlockTranslatorTest >> testBlockWithExternalTempReturnsLastExpression [
+	
+	| result |
+	result := self testSource: 'example
+	| t |
+	t := 1.
+	^ [ t ] value'.
+	
+	self assert: result equals: 1
+]
+
+{ #category : #'tests-arguments' }
+OCASTBlockTranslatorTest >> testBlockWithFiveArgumentReturnsLastExpression [
+	
+	| result |
+	result := self testSource: 'example
+	^ [ :arg1 :arg2 :arg3 :arg4 :arg5 | arg1 + arg2 + arg3 + arg4 + arg5 ] 
+		valueWithArguments: #( 2 3 4 5 6 )'.
+	
+	self assert: result equals: 20
+]
+
+{ #category : #'tests-arguments' }
+OCASTBlockTranslatorTest >> testBlockWithFourArgumentReturnsLastExpression [
+	
+	| result |
+	result := self testSource: 'example
+	^ [ :arg1 :arg2 :arg3 :arg4 | arg1 + arg2 + arg3 + arg4 ] value: 2 value: 3 value: 4 value: 5'.
+	
+	self assert: result equals: 14
+]
+
+{ #category : #'tests-readvariables' }
+OCASTBlockTranslatorTest >> testBlockWithInstanceVariableReturnsLastExpression [
+	
+	| result value |
+	value := Object new.
+	instance iVar: value.
+	
+	result := self testSource: 'example
+	^ [ iVar ] value'.
+	
+	self assert: result equals: value
+]
+
+{ #category : #'tests-literals' }
+OCASTBlockTranslatorTest >> testBlockWithLiteralReturnsLastExpression [
+	
+	| result |
+	result := self testSource: 'example
+	^ [ 1 ] value'.
+	
+	self assert: result equals: 1
+]
+
+{ #category : #'tests-readvariables' }
+OCASTBlockTranslatorTest >> testBlockWithTempReturnsLastExpression [
+	
+	| result |
+	result := self testSource: 'example
+	^ [ | t | t := 1. t ] value'.
+	
+	self assert: result equals: 1
+]
+
+{ #category : #'tests-arguments' }
+OCASTBlockTranslatorTest >> testBlockWithThreeArgumentReturnsLastExpression [
+	
+	| result |
+	result := self testSource: 'example
+	^ [ :arg1 :arg2 :arg3 | arg1 + arg2 + arg3 ] value: 2 value: 3 value: 4'.
+	
+	self assert: result equals: 9
+]
+
+{ #category : #'tests-arguments' }
+OCASTBlockTranslatorTest >> testBlockWithTwoArgumentReturnsLastExpression [
+	
+	| result |
+	result := self testSource: 'example
+	^ [ :arg1 :arg2 | arg1 + arg2 ] value: 2 value: 3'.
+	
+	self assert: result equals: 5
+]
+
+{ #category : #'tests-writevariables' }
+OCASTBlockTranslatorTest >> testBlockWritesInstanceVariable [
+	
+	self testSource: 'example
+	[ iVar := 1 ] value'.
+	
+	self assert: instance iVar equals: 1
+]
+
+{ #category : #'tests-writevariables' }
+OCASTBlockTranslatorTest >> testBlocksShareOuterVariables [
+	
+	| result |
+	result := self testSource: 'example
+	| blocks |
+	blocks := [| t |
+		{
+			"setter" [ :value | t := value ].
+			"getter" [ t ]
+		}
+	] value.
+	blocks first value: 5.
+	^ blocks second value '.
+	
+	self assert: result equals: 5
+]
+
+{ #category : #'tests-literals' }
+OCASTBlockTranslatorTest >> testEmptyBlockReturnsNil [
+	
+	| result |
+	result := self testSource: 'example
+	^ [] value'.
+	
+	self assert: result isNil
+]
+
+{ #category : #'tests-readvariables' }
+OCASTBlockTranslatorTest >> testNestedBlockWithExternalTempReturnsLastExpression [
+	
+	| result |
+	result := self testSource: 'example
+	| t1 t2 |
+	t1 := 1.
+	t2 := 2.
+	^ [ [ t1 ] value + t2 ] value'.
+	
+	self assert: result equals: 3
+]
+
+{ #category : #'tests-writevariables' }
+OCASTBlockTranslatorTest >> testOuterBlockTemporaryVariable [
+	
+	| result |
+	result := self testSource: 'example
+	| block |
+	block := [| t |
+		t := 0.
+		[ t := t + 1. t ]
+	] value.
+	^ block value; value '.
+	
+	self assert: result equals: 2
+]
+
+{ #category : #'tests-writevariables' }
+OCASTBlockTranslatorTest >> testWritesTemporaryVariable [
+	
+	| result |
+	result := self testSource: 'example
+	| t |
+	[ t := 1 ] value.
+	^ t'.
+	
+	self assert: result equals: 1
+]

--- a/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
@@ -72,11 +72,11 @@ OCASTCheckerTest >> testExampleSelf [
 	ast := (OCOpalExamples>>#exampleSelf) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 1.
+	self assert: ast scope tempVars size equals: 0.
 	self assert: (ast scope lookupVar: 'self') isSelf.
 	
-	assignment := RBParseTreeSearcher treeMatching: '`var := ``@anything' in: ast. 
-	self assert: assignment value binding isSelf.
+	assignment := RBParseTreeSearcher treeMatching: 'self result: ``@anything' in: ast. 
+	self assert: assignment arguments first binding isSelf.
 ]
 
 { #category : #'testing - variables' }
@@ -93,11 +93,11 @@ OCASTCheckerTest >> testExampleSuper [
 	ast := (OCOpalExamples>>#exampleSuper) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 1.
+	self assert: ast scope tempVars size equals: 0.
 	self assert: (ast scope lookupVar: 'super') isSuper.
 	
-	assignment := RBParseTreeSearcher treeMatching: '`var := ``@anything' in: ast. 
-	self assert: assignment value binding isSuper.
+	assignment := RBParseTreeSearcher treeMatching: 'self result:``@anything' in: ast. 
+	self assert: assignment arguments first binding isSuper.
 ]
 
 { #category : #'testing - variables' }
@@ -114,11 +114,11 @@ OCASTCheckerTest >> testExampleThisContext [
 	ast := (OCOpalExamples>>#exampleThisContext) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 1.
+	self assert: ast scope tempVars size equals: 0.
 	self assert: (ast scope lookupVar: 'thisContext') isThisContext.
 	
-	assignment := RBParseTreeSearcher treeMatching: '`var := ``@anything' in: ast. 
-	self assert: assignment value binding isThisContext.
+	assignment := RBParseTreeSearcher treeMatching: 'self result: ``@anything' in: ast. 
+	self assert: assignment arguments first binding isThisContext.
 ]
 
 { #category : #'testing - blocks - optimized' }
@@ -133,7 +133,7 @@ OCASTCheckerTest >> testExampleToDoArgument [
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testInstanceVar [
 	| ast assignment |
-	ast := (OCOpalExamples >> #exampleiVar) parseTree.
+	ast := (OCOpalExamples >> #exampleInstanceVariableAssignment) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
 	self assertEmpty: ast scope tempVars.
@@ -267,7 +267,7 @@ OCASTCheckerTest >> testOptimizedBlocksAndSameNameTemps [
 { #category : #'testing - simple' }
 OCASTCheckerTest >> testReturn1 [
 	| ast |
-	ast := (OCOpalExamples >> #exampleReturn1) parseTree.
+	ast := (OCOpalExamples >> #exampleReturn42) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
 	self assertEmpty: ast scope tempVars
@@ -278,7 +278,7 @@ OCASTCheckerTest >> testSemanticAnalysisOnNonMethodNode [
 	| ast |
 	{[ 1 + 2 ].
 	thisContext.
-	(OCOpalExamples >> #exampleReturn1)}
+	(OCOpalExamples >> #exampleReturn42)}
 		do: [ :object | 
 			ast := object sourceNode.
 			ast doSemanticAnalysis ].

--- a/src/OpalCompiler-Tests/OCASTDoubleBlockTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTDoubleBlockTranslatorTest.class.st
@@ -1,0 +1,76 @@
+Class {
+	#name : #OCASTDoubleBlockTranslatorTest,
+	#superclass : #OCASTSingleBlockTranslatorTest,
+	#instVars : [
+		'extractBlock2InTemp'
+	],
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #private }
+OCASTDoubleBlockTranslatorTest class >> isAbstract [
+
+	^ self == OCASTDoubleBlockTranslatorTest
+]
+
+{ #category : #'building suites' }
+OCASTDoubleBlockTranslatorTest class >> testParameters [
+
+	^ super testParameters *
+		(ParametrizedTestMatrix new
+			forSelector: #extractBlock2InTemp addOptions: { true . false };
+			yourself)
+]
+
+{ #category : #accessing }
+OCASTDoubleBlockTranslatorTest >> extractBlock2InTemp [
+	^ extractBlock2InTemp
+]
+
+{ #category : #accessing }
+OCASTDoubleBlockTranslatorTest >> extractBlock2InTemp: anObject [
+	extractBlock2InTemp := anObject
+]
+
+{ #category : #tests }
+OCASTDoubleBlockTranslatorTest >> testComposedExample: template withFirstBlock: firstBlockCode withSecondBlock: secondBlockCode [
+
+	^ self
+		testComposedExample: template
+		withTemps: #()
+		withFirstBlock: firstBlockCode
+		withSecondBlock: secondBlockCode
+]
+
+{ #category : #tests }
+OCASTDoubleBlockTranslatorTest >> testComposedExample: template withTemps: predefinedTemps withFirstBlock: firstBlockCode withSecondBlock: secondBlockCode [
+	| temps declaration argument1 argument2 source |
+	temps := OrderedCollection new.
+	temps addAll: predefinedTemps.
+	self extractBlockInTemp ifTrue: [ 
+			temps add: 'block1'.
+			declaration := 'block1 := ', firstBlockCode, '.'.
+			argument1 := 'block1' ]
+		ifFalse: [
+			declaration := ''.
+			argument1 := firstBlockCode ].
+	self extractBlock2InTemp ifTrue: [ 
+			temps add: 'block2'.
+			declaration := declaration , 'block2 := ', secondBlockCode, '.'.
+			argument2 := 'block2' ]
+		ifFalse: [
+			argument2 := secondBlockCode ].
+
+	declaration := String streamContents: [ :stream |
+		stream nextPut: $|.
+		temps do: [ :each | stream nextPutAll: each; space ].
+		stream nextPut: $|.
+		stream nextPutAll: declaration.
+	].
+
+	source := template format: { 
+		'definition' -> declaration.
+		'argument1' -> argument1.
+		'argument2' -> argument2 } asDictionary.
+	^ self testSource: source.
+]

--- a/src/OpalCompiler-Tests/OCASTDoubleBranchConditionalTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTDoubleBranchConditionalTranslatorTest.class.st
@@ -1,0 +1,114 @@
+Class {
+	#name : #OCASTDoubleBranchConditionalTranslatorTest,
+	#superclass : #OCASTDoubleBlockTranslatorTest,
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #'building suites' }
+OCASTDoubleBranchConditionalTranslatorTest class >> testParameters [
+	^ super testParameters *
+		(ParametrizedTestMatrix new
+			forSelector: #optimization addOptions: { #optionInlineIf . #optionInlineIfNil . #optionInlineNone })
+]
+
+{ #category : #'testing - conditionals' }
+OCASTDoubleBranchConditionalTranslatorTest >> testFalseIfFalseIfTrueEvaluatesFalseBlock [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	^false ifFalse: {argument1} ifTrue: {argument2}'
+		withFirstBlock: '[iVar := ''false'']'
+		withSecondBlock: '[ self error ]'.
+
+	self assert: instance iVar equals: 'false'
+]
+
+{ #category : #'testing - conditionals' }
+OCASTDoubleBranchConditionalTranslatorTest >> testFalseIfFalseIfTrueReturnsFalseBlockValue [
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	^false ifFalse: {argument1} ifTrue: {argument2}'
+		withFirstBlock: '[iVar := ''false'']'
+		withSecondBlock: '[ self error ]'..
+	self assert: result equals: 'false' 
+]
+
+{ #category : #'testing - conditionals' }
+OCASTDoubleBranchConditionalTranslatorTest >> testFalseIfTrueIfFalseEvaluatesFalseBlock [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	^false ifTrue: {argument1} ifFalse: {argument2}'
+		withFirstBlock: '[ self error ]'
+		withSecondBlock: '[iVar := ''false'']'.
+
+	self assert: instance iVar equals: 'false' 
+]
+
+{ #category : #'testing - conditionals' }
+OCASTDoubleBranchConditionalTranslatorTest >> testFalseIfTrueIfFalseReturnsFalseBlockValue [
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	^false ifTrue: {argument1} ifFalse: {argument2}'
+		withFirstBlock: '[ self error ]'
+		withSecondBlock: '[iVar := ''false'']'.
+
+	self assert: result equals: 'false'
+]
+
+{ #category : #'testing - conditionals' }
+OCASTDoubleBranchConditionalTranslatorTest >> testTrueIfFalseIfTrueEvaluatesTrueBlock [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	^true ifFalse: {argument1} ifTrue: {argument2}'
+		withFirstBlock: '[ self error ]'
+		withSecondBlock: '[iVar := ''true'']'.
+
+	self assert: instance iVar equals: 'true' 
+]
+
+{ #category : #'testing - conditionals' }
+OCASTDoubleBranchConditionalTranslatorTest >> testTrueIfFalseIfTrueReturnsTrueBlockValue [
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	^true ifFalse: {argument1} ifTrue: {argument2}'
+		withFirstBlock: '[ self error ]'
+		withSecondBlock: '[iVar := ''true'']'.
+	self assert: result equals: 'true' 
+]
+
+{ #category : #'testing - conditionals' }
+OCASTDoubleBranchConditionalTranslatorTest >> testTrueIfTrueIfFalseEvaluatesTrueBlock [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	^true ifTrue: {argument1} ifFalse: {argument2}'
+		withFirstBlock: '[iVar := ''true'']'
+		withSecondBlock: '[ self error ]'.
+
+	self assert: instance iVar equals: 'true' 
+]
+
+{ #category : #'testing - conditionals' }
+OCASTDoubleBranchConditionalTranslatorTest >> testTrueIfTrueIfFalseReturnsTrueBlockValue [
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	^true ifTrue: {argument1} ifFalse: {argument2}'
+		withFirstBlock: '[iVar := ''true'']'
+		withSecondBlock: '[ self error ]'.
+
+	self assert: result equals: 'true' 
+]

--- a/src/OpalCompiler-Tests/OCASTLiteralTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTLiteralTranslatorTest.class.st
@@ -1,0 +1,70 @@
+Class {
+	#name : #OCASTLiteralTranslatorTest,
+	#superclass : #OCASTTranslatorTest,
+	#instVars : [
+		'literalExample',
+		'expectedLiteralValue'
+	],
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #'building suites' }
+OCASTLiteralTranslatorTest class >> testParameters [
+
+	^ super testParameters * {
+			{ #literalExample -> #exampleNonSpecialLiteralInteger. #expectedLiteralValue -> 10 }.
+			{ #literalExample -> #exampleLiteralLargeInteger. #expectedLiteralValue -> 16rFFFFFFFFFFFFFFFF }.
+			{ #literalExample -> #exampleLiteralCharacter. #expectedLiteralValue -> $H }.
+			{ #literalExample -> #exampleLiteralArray. #expectedLiteralValue -> #(1 2 3) }.
+			{ #literalExample -> #exampleLiteralByteArray. #expectedLiteralValue -> #[1 2 3] }.
+			{ #literalExample -> #exampleLiteralFloat. #expectedLiteralValue -> 1.2 }.
+			{ #literalExample -> #exampleLiteralBoxedFloat. #expectedLiteralValue -> 9.999999999999996e157 }.
+			{ #literalExample -> #exampleLiteralByteSymbol. #expectedLiteralValue -> #bytesymbol }.
+			{ #literalExample -> #exampleLiteralWideSymbol. #expectedLiteralValue -> #'áèîöÑü' }.
+			{ #literalExample -> #exampleLiteralByteString. #expectedLiteralValue -> 'bytestring' }.
+			{ #literalExample -> #exampleLiteralWideString. #expectedLiteralValue -> 'áèîöÑü' }
+	}
+]
+
+{ #category : #accessing }
+OCASTLiteralTranslatorTest >> expectedLiteralValue [
+	^ expectedLiteralValue
+]
+
+{ #category : #accessing }
+OCASTLiteralTranslatorTest >> expectedLiteralValue: anObject [
+	expectedLiteralValue := anObject
+]
+
+{ #category : #accessing }
+OCASTLiteralTranslatorTest >> literalExample [
+	^ literalExample
+]
+
+{ #category : #accessing }
+OCASTLiteralTranslatorTest >> literalExample: anObject [
+	literalExample := anObject
+]
+
+{ #category : #'testing - literals' }
+OCASTLiteralTranslatorTest >> testLiteralIsInLiteralFrame [
+	
+	| array |
+	array := self testExample: literalExample.
+	
+	self assert: (method literals identityIncludes: array).
+]
+
+{ #category : #'testing - literals' }
+OCASTLiteralTranslatorTest >> testLiteralReturnsAlwaysSameLiteral [
+	
+	self compileExample: literalExample.
+	
+	self assert: (self executeMethodOnInstance: method) == (self executeMethodOnInstance: method)
+]
+
+{ #category : #'testing - literals' }
+OCASTLiteralTranslatorTest >> testLiteralReturnsLiteral [
+	
+	self assert: (self testExample: literalExample) equals: expectedLiteralValue
+]

--- a/src/OpalCompiler-Tests/OCASTRepeatTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTRepeatTranslatorTest.class.st
@@ -1,0 +1,66 @@
+Class {
+	#name : #OCASTRepeatTranslatorTest,
+	#superclass : #OCASTSingleBlockTranslatorTest,
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #'building suites' }
+OCASTRepeatTranslatorTest class >> testParameters [
+	^ super testParameters *
+		(ParametrizedTestMatrix new
+			forSelector: #optimization addOptions: { #optionInlineRepeat . #optionInlineNone })
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTRepeatTranslatorTest >> testRepeatExecutesBlock [
+
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	total := 1.
+	{argument} repeat.
+	 ^ total'
+		withTemps: #('total')
+		withBlock: '[ total := total  + 1. total > 5 ifTrue: [ ^ total ] ]'.
+	
+	self assert: result equals: 6.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTRepeatTranslatorTest >> testRepeatWithTempInBlock [
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	total := 1.
+	{argument} repeat.
+	 ^ total'
+		withTemps: #('total')
+		withBlock: '[ | tempInBlock | 
+			tempInBlock := total.
+			total := tempInBlock + 1.
+			total > 5 ifTrue: [ ^ total ] ]'.
+	
+	self assert: result equals: 6.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTRepeatTranslatorTest >> testTimesRepeatWithTempInBlock [
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	total := 1.
+	5 timesRepeat: {argument}.
+	 ^ total'
+		withTemps: #('total')
+		withBlock: '[ | tempInBlock | 
+			tempInBlock := total.
+			total := total + tempInBlock ]'.
+	
+	self assert: result equals: 2 ** 5.
+]

--- a/src/OpalCompiler-Tests/OCASTSingleBlockTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTSingleBlockTranslatorTest.class.st
@@ -1,0 +1,79 @@
+Class {
+	#name : #OCASTSingleBlockTranslatorTest,
+	#superclass : #OCASTTranslatorTest,
+	#instVars : [
+		'extractBlockInTemp'
+	],
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #'building suites' }
+OCASTSingleBlockTranslatorTest class >> isAbtract [
+
+	^ self == OCASTSingleBlockTranslatorTest
+]
+
+{ #category : #'building suites' }
+OCASTSingleBlockTranslatorTest class >> testParameters [
+
+	^ super testParameters * 
+		(ParametrizedTestMatrix new
+			forSelector: #extractBlockInTemp addOptions: { true . false };
+			yourself)
+]
+
+{ #category : #support }
+OCASTSingleBlockTranslatorTest >> extractBlockInTemp [
+
+	^ extractBlockInTemp	ifNil: [ extractBlockInTemp := false ]
+]
+
+{ #category : #accessing }
+OCASTSingleBlockTranslatorTest >> extractBlockInTemp: aBoolean [ 
+	extractBlockInTemp := aBoolean
+]
+
+{ #category : #support }
+OCASTSingleBlockTranslatorTest >> testComposedExample: template withBlock: blockCode [
+
+	^ self testComposedExample: template withBlock: blockCode withArguments: #()
+]
+
+{ #category : #support }
+OCASTSingleBlockTranslatorTest >> testComposedExample: template withBlock: blockCode withArguments: arguments [
+	
+	^ self
+		testComposedExample: template
+		withTemps: #() 
+		withBlock: blockCode
+		withArguments: arguments
+]
+
+{ #category : #support }
+OCASTSingleBlockTranslatorTest >> testComposedExample: template withTemps: temps withBlock: blockCode [
+
+	^ self testComposedExample: template  withTemps: temps withBlock: blockCode withArguments: #()
+]
+
+{ #category : #support }
+OCASTSingleBlockTranslatorTest >> testComposedExample: template  withTemps: temps withBlock: blockCode withArguments: arguments [
+	| declaration argument source methodTemps |
+	methodTemps := OrderedCollection withAll: temps.
+	self extractBlockInTemp ifTrue: [ 
+			methodTemps add: 'block'.
+			declaration := 'block := ', blockCode.
+			argument := 'block' ]
+		ifFalse: [
+			declaration := ''.
+			argument := blockCode ].
+	
+	declaration := String streamContents: [ :stream |
+		stream nextPut: $|.
+		methodTemps do: [ :each | stream nextPutAll: each; space ].
+		stream nextPut: $|.
+		stream nextPutAll: declaration. ].
+	source := template format: { 
+		'definition' -> declaration.
+		'argument' -> argument } asDictionary.
+	^ self testSource: source withArguments: arguments
+]

--- a/src/OpalCompiler-Tests/OCASTSingleBranchConditionalTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTSingleBranchConditionalTranslatorTest.class.st
@@ -1,0 +1,356 @@
+Class {
+	#name : #OCASTSingleBranchConditionalTranslatorTest,
+	#superclass : #OCASTSingleBlockTranslatorTest,
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #'building suites' }
+OCASTSingleBranchConditionalTranslatorTest class >> testParameters [
+	^ super testParameters *
+		(ParametrizedTestMatrix new
+			forSelector: #optimization addOptions: { #optionInlineIf . #optionInlineIfNil . #optionInlineNone })
+]
+
+{ #category : #'testing-ifFalse' }
+OCASTSingleBranchConditionalTranslatorTest >> testFalseIfFalseEvaluatesBlock [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	^false ifFalse: {argument}'
+		withBlock: '[iVar := 17]'.
+	self assert: instance iVar equals: 17
+]
+
+{ #category : #'testing-ifFalse' }
+OCASTSingleBranchConditionalTranslatorTest >> testFalseIfFalseEvaluatesBlockWithTempInsideBlock [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	^false ifFalse: {argument}'
+		withBlock: '[ | temp |
+			temp := 17.
+			iVar := temp ]'.
+	self assert: instance iVar equals: 17
+]
+
+{ #category : #'testing-ifFalse' }
+OCASTSingleBranchConditionalTranslatorTest >> testFalseIfFalseEvaluatesBlockWithTempOutsideBlock [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	^false ifFalse: {argument}'
+		withTemps: #( 'temp' )
+		withBlock: '[
+			temp := 17.
+			iVar := temp ]'.
+	self assert: instance iVar equals: 17
+]
+
+{ #category : #'testing-ifFalse' }
+OCASTSingleBranchConditionalTranslatorTest >> testFalseIfFalseReturnsBlockValue [
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	^false ifFalse: {argument}'
+		withBlock: '[1]'.
+	self assert: result equals: 1
+]
+
+{ #category : #'testing-ifFalse' }
+OCASTSingleBranchConditionalTranslatorTest >> testFalseIfFalseReturnsBlockValueWithTempInsideBlock [
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	^false ifFalse: {argument}'
+		withBlock: '[ | temp | 
+			temp := 1.
+			temp ]'.
+	self assert: result equals: 1
+]
+
+{ #category : #'testing-ifFalse' }
+OCASTSingleBranchConditionalTranslatorTest >> testFalseIfFalseReturnsBlockValueWithTempOutsideBlock [
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	^false ifFalse: {argument}'
+		withTemps: #( 'temp' )
+		withBlock: '[ 
+			temp := 1.
+			temp ]'.
+	self assert: result equals: 1
+]
+
+{ #category : #'testing-ifTrue' }
+OCASTSingleBranchConditionalTranslatorTest >> testFalseIfTrueDoesNotEvaluateBlock [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	^false ifTrue: {argument}'
+		withBlock: '[iVar := 17]'.
+	self assert: instance iVar equals: nil
+]
+
+{ #category : #'testing-ifTrue' }
+OCASTSingleBranchConditionalTranslatorTest >> testFalseIfTrueReturnsNil [
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	^false ifTrue: {argument}'
+		withBlock: '[1]'.
+	self assert: result equals: nil
+]
+
+{ #category : #'testing-ifNil' }
+OCASTSingleBranchConditionalTranslatorTest >> testNilIfNilEvaluatesBlock [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	^nil ifNil: {argument}'
+		withBlock: '[ iVar := 17 ]'.
+	self assert: instance iVar equals: 17
+]
+
+{ #category : #'testing-ifNil' }
+OCASTSingleBranchConditionalTranslatorTest >> testNilIfNilReturnsBlockValue [
+	| result |
+	
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	^nil ifNil: {argument}'
+		withBlock: '[ iVar := 17 ]'.
+	self assert: result equals: 17
+]
+
+{ #category : #'testing-ifNotNil' }
+OCASTSingleBranchConditionalTranslatorTest >> testNilIfNotNilDoesNotEvaluateBlock [
+
+	self
+		shouldnt: [
+			self
+				testComposedExample: 'example
+			{definition}.
+			^ nil ifNotNil: {argument}'
+				withBlock: '[ self error ]' ]
+		raise: Error
+]
+
+{ #category : #'testing-ifNotNil' }
+OCASTSingleBranchConditionalTranslatorTest >> testNilIfNotNilReturnsNil [
+	| result |
+	
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	^nil ifNotNil: {argument}'
+		withBlock: '[ self error ]'.
+	self assert: result equals: nil
+]
+
+{ #category : #'testing-ifNotNil' }
+OCASTSingleBranchConditionalTranslatorTest >> testNilIfNotNilWithArgumentDoesNotEvaluateBlock [
+	self shouldnt: [ 
+		self
+			testComposedExample: 'example
+		{definition}.
+		^nil ifNotNil: {argument}'
+			withBlock: '[ :arg | self error ]' ] raise: Error
+]
+
+{ #category : #'testing-ifNotNil' }
+OCASTSingleBranchConditionalTranslatorTest >> testNilIfNotNilWithArgumentReturnsNil [
+	| result |
+	result := self
+			testComposedExample: 'example
+		{definition}.
+		^nil ifNotNil: {argument}'
+			withBlock: '[ :arg | self error ]'.
+	self assert: result equals: nil
+]
+
+{ #category : #'testing-ifNil' }
+OCASTSingleBranchConditionalTranslatorTest >> testNotNilIfNilDoesNotEvaluateBlock [
+
+	self
+		shouldnt: [ 
+			self
+				testComposedExample: 'example
+			{definition}.
+			^1 ifNil: {argument}'
+				withBlock: '[ self error ]' ]
+		raise: Error
+]
+
+{ #category : #'testing-ifNil' }
+OCASTSingleBranchConditionalTranslatorTest >> testNotNilIfNilReturnsReceiver [
+	| result |
+	result := self
+			testComposedExample: 'example
+		{definition}.
+		^1 ifNil: {argument}'
+			withBlock: '[ self error ]'.
+	self assert: result equals: 1
+]
+
+{ #category : #'testing-ifNotNil' }
+OCASTSingleBranchConditionalTranslatorTest >> testNotNilIfNotNilEvaluatesBlock [
+
+	self
+		testComposedExample: 'example
+		{definition}.
+		^1 ifNotNil: {argument}'
+		withBlock: '[ iVar := 17 ]'.
+
+	self assert: instance iVar equals: 17
+]
+
+{ #category : #'testing-ifNotNil' }
+OCASTSingleBranchConditionalTranslatorTest >> testNotNilIfNotNilReturnsBlockValue [
+	| result |
+	result := self
+		testComposedExample: 'example
+		{definition}.
+		^1 ifNotNil: {argument}'
+		withBlock: '[ iVar := 17 ]'.
+	self assert: result equals: 17
+]
+
+{ #category : #'testing-ifNotNil' }
+OCASTSingleBranchConditionalTranslatorTest >> testNotNilIfNotNilWithArgumentEvaluatesBlock [
+
+	self
+		testComposedExample: 'example
+		{definition}.
+		^1 ifNotNil: {argument}'
+		withBlock: '[ :arg | iVar := arg ]'.
+
+	self assert: instance iVar equals: 1
+]
+
+{ #category : #'testing-ifNotNil' }
+OCASTSingleBranchConditionalTranslatorTest >> testNotNilIfNotNilWithArgumentReturnsBlockValue [
+	| result |
+	result := 	self
+		testComposedExample: 'example
+		{definition}.
+		^1 ifNotNil: {argument}'
+		withBlock: '[ :arg | iVar := arg ]'.
+	self assert: result equals: 1
+]
+
+{ #category : #'testing-ifFalse' }
+OCASTSingleBranchConditionalTranslatorTest >> testTrueIfFalseDoesNotEvaluateBlock [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	^true ifFalse: {argument}'
+		withBlock: '[iVar := 17]'.
+
+	self assert: instance iVar equals: nil
+]
+
+{ #category : #'testing-ifFalse' }
+OCASTSingleBranchConditionalTranslatorTest >> testTrueIfFalseReturnsNil [
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	^true ifFalse: {argument}'
+		withBlock: '[ 1 ]'.
+	self assert: result equals: nil
+]
+
+{ #category : #'testing-ifTrue' }
+OCASTSingleBranchConditionalTranslatorTest >> testTrueIfTrueEvaluateBlock [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	^true ifTrue: {argument}'
+		withBlock: '[ iVar := 17 ]'.
+	self assert: instance iVar equals: 17
+]
+
+{ #category : #'testing-ifTrue' }
+OCASTSingleBranchConditionalTranslatorTest >> testTrueIfTrueEvaluateBlockWithTempInsideBlock [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	^true ifTrue: {argument}'
+		withBlock: '[ | temp |
+			temp := 17.
+			iVar := temp ]'.
+	self assert: instance iVar equals: 17
+]
+
+{ #category : #'testing-ifTrue' }
+OCASTSingleBranchConditionalTranslatorTest >> testTrueIfTrueEvaluateBlockWithTempOutsideBlock [
+
+	self
+		testComposedExample: 'example
+	{definition}.
+	^true ifTrue: {argument}'
+		withTemps: #( 'temp' )
+		withBlock: '[
+			temp := 17.
+			iVar := temp ]'.
+	self assert: instance iVar equals: 17
+]
+
+{ #category : #'testing-ifTrue' }
+OCASTSingleBranchConditionalTranslatorTest >> testTrueIfTrueReturnsBlockValue [
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	^true ifTrue: {argument}'
+		withBlock: '[ 1 ]'.
+	self assert: result equals: 1
+]
+
+{ #category : #'testing-ifTrue' }
+OCASTSingleBranchConditionalTranslatorTest >> testTrueIfTrueReturnsBlockValueWithTempInsideBlock [
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	^true ifTrue: {argument}'
+		withBlock: '[ | temp |
+			temp := 1.
+			temp ]'.
+	self assert: result equals: 1
+]
+
+{ #category : #'testing-ifTrue' }
+OCASTSingleBranchConditionalTranslatorTest >> testTrueIfTrueReturnsBlockValueWithTempOutsideBlock [
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	^true ifTrue: {argument}'
+		withTemps: #( 'temp' )
+		withBlock: '[
+			temp := 1.
+			temp ]'.
+	self assert: result equals: 1
+]

--- a/src/OpalCompiler-Tests/OCASTSpecialLiteralTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTSpecialLiteralTranslatorTest.class.st
@@ -1,0 +1,48 @@
+Class {
+	#name : #OCASTSpecialLiteralTranslatorTest,
+	#superclass : #OCASTTranslatorTest,
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #'testing - literals' }
+OCASTSpecialLiteralTranslatorTest >> testDynamicLiteralArrayIsNotInLiteralFrame [
+	
+	| aCompiledMethod array |
+	aCompiledMethod := self compileExample: #examplePushDynamicLiteralArray.
+	array := self executeMethodOnInstance: aCompiledMethod.
+	
+	self deny: (aCompiledMethod literals identityIncludes: array).
+]
+
+{ #category : #'testing - literals' }
+OCASTSpecialLiteralTranslatorTest >> testDynamicLiteralArrayReturnsAlwaysNewArray [
+	
+	| aCompiledMethod |
+	aCompiledMethod := self compileExample: #examplePushDynamicLiteralArray.
+	
+	self assert: (self executeMethodOnInstance: aCompiledMethod) ~~ (self executeMethodOnInstance: aCompiledMethod)
+]
+
+{ #category : #'testing - literals' }
+OCASTSpecialLiteralTranslatorTest >> testDynamicLiteralArrayReturnsArray [
+
+	self assert: (self testExample: #examplePushDynamicLiteralArray) equals: #(1 3)
+]
+
+{ #category : #'testing - literals' }
+OCASTSpecialLiteralTranslatorTest >> testDynamicLiteralArrayReturnsEqualsArray [
+	
+	| aCompiledMethod |
+	aCompiledMethod := self compileExample: #examplePushDynamicLiteralArray.
+	
+	self assert: (self executeMethodOnInstance: aCompiledMethod) equals: (self executeMethodOnInstance: aCompiledMethod)
+]
+
+{ #category : #'testing - literals' }
+OCASTSpecialLiteralTranslatorTest >> testSpecialLiteralsNotInLiteralFrame [
+
+	self testExample: #examplePushNonSpecialSmallInteger.
+	self assert: instance result equals: 10.
+	self assert: (method hasLiteral: 10)
+	
+]

--- a/src/OpalCompiler-Tests/OCASTTimesRepeatTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTimesRepeatTranslatorTest.class.st
@@ -1,0 +1,97 @@
+Class {
+	#name : #OCASTTimesRepeatTranslatorTest,
+	#superclass : #OCASTSingleBlockTranslatorTest,
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #'building suites' }
+OCASTTimesRepeatTranslatorTest class >> testParameters [
+	^ super testParameters *
+		(ParametrizedTestMatrix new
+			forSelector: #optimization addOptions: { #optionInlineTimesRepeat . #optionInlineNone })
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTTimesRepeatTranslatorTest >> testTimesRepeatExecutesBlock [
+
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	total := 1.
+	5 timesRepeat: {argument}.
+	 ^ total'
+		withTemps: #('total')
+		withBlock: '[ total := total  + total ]'.
+	
+	self assert: result equals: 2 ** 5.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTTimesRepeatTranslatorTest >> testTimesRepeatReturnsReceiver [
+
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	^ 5 timesRepeat: {argument}'
+		withBlock: '[ 1+2 ]'.
+	
+	self assert: result equals: 5
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTTimesRepeatTranslatorTest >> testTimesRepeatWithCalculatedArguments [
+
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	total := 1.
+	times := 6.
+	times - 1 timesRepeat: {argument}.
+	 ^ total'
+		withTemps: #('times' 'total')
+		withBlock: '[ total := total + total ]'.
+	
+	self assert: result equals: 2 ** 5.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTTimesRepeatTranslatorTest >> testTimesRepeatWithTempInBlock [
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	total := 1.
+	5 timesRepeat: {argument}.
+	 ^ total'
+		withTemps: #('total')
+		withBlock: '[ | tempInBlock | 
+			tempInBlock := total.
+			total := total + tempInBlock ]'.
+	
+	self assert: result equals: 2 ** 5.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTTimesRepeatTranslatorTest >> testTimesRepeatWithTempOutsideBlock [
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	total := 1.
+	5 timesRepeat: {argument}.
+	 ^ total'
+		withTemps: #('total' 'tempOutsideBlock')
+		withBlock: '[
+			tempOutsideBlock := total.
+			total := total + tempOutsideBlock ]'.
+	
+	self assert: result equals: 2 ** 5.
+]

--- a/src/OpalCompiler-Tests/OCASTToDoTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTToDoTranslatorTest.class.st
@@ -1,0 +1,102 @@
+Class {
+	#name : #OCASTToDoTranslatorTest,
+	#superclass : #OCASTSingleBlockTranslatorTest,
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #'building suites' }
+OCASTToDoTranslatorTest class >> testParameters [
+	^ super testParameters *
+		(ParametrizedTestMatrix new
+			forSelector: #optimization addOptions: { #optionInlineToDo . #optionInlineNone })
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTToDoTranslatorTest >> testToDoExecutesBlock [
+
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	total := 0.
+	1 to: 5 do: {argument}.
+	 ^ total'
+		withTemps: #('total')
+		withBlock: '[ :index | total := total + index ]'.
+	
+	self assert: result equals: 15.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTToDoTranslatorTest >> testToDoReturnsReceiver [
+
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	^ 1 to: 5 do: {argument}'
+		withBlock: '[ :index | 1+2 ]'.
+	
+	self assert: result equals: 1.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTToDoTranslatorTest >> testToDoWithCalculatedArguments [
+
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	total := 0.
+	begin := 1.
+	end := 6.
+	begin to: end - 1 do: {argument}.
+	 ^ total'
+		withTemps: #('begin' 'end' 'total')
+		withBlock: '[ :index | total := total + index ]'.
+	
+	self assert: result equals: 15.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTToDoTranslatorTest >> testToDoWithTempInBlock [
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	total := 0.
+	begin := 1.
+	end := 6.
+	begin to: end - 1 do: {argument}.
+	 ^ total'
+		withTemps: #('begin' 'end' 'total')
+		withBlock: '[ :index | | tempInBlock | 
+			tempInBlock := index.
+			total := total + tempInBlock ]'.
+	
+	self assert: result equals: 15.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTToDoTranslatorTest >> testToDoWithTempOutsideBlock [
+
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	total := 0.
+	begin := 1.
+	end := 6.
+	begin to: end - 1 do: {argument}.
+	 ^ total'
+		withTemps: #('begin' 'end' 'total' 'tempOutsideBlock')
+		withBlock: '[ :index |
+			tempOutsideBlock := index.
+			total := total + tempOutsideBlock ]'.
+	
+	self assert: result equals: 15.
+]

--- a/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
@@ -1,349 +1,185 @@
 Class {
 	#name : #OCASTTranslatorTest,
-	#superclass : #TestCase,
+	#superclass : #ParametrizedTestCase,
+	#instVars : [
+		'instance',
+		'method',
+		'globals',
+		'encoder',
+		'fullblocks',
+		'optimization'
+	],
 	#category : #'OpalCompiler-Tests-AST'
 }
 
-{ #category : #'testing - simple' }
-OCASTTranslatorTest >> testEmptyMethod [
-	| ast ir aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleEmptyMethod) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new .
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleEmptyMethod.
-	
-	
+{ #category : #'building suites' }
+OCASTTranslatorTest class >> testParameters [
+
+	^ super testParameters
+		addCase: { #encoder -> EncoderForV3PlusClosures };
+		addCase: { #encoder -> EncoderForSistaV1. #fullblocks -> true };
+		addCase: { #encoder -> EncoderForSistaV1. #fullblocks -> false }
 ]
 
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleAndOr [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleAndOr) parseTree.
+{ #category : #accessing }
+OCASTTranslatorTest >> compilationContext [
+
+	| context |
+	context := CompilationContext new
+		encoderClass: self encoder;
+		environment: globals;
+		interactive: true;
+		yourself.
+	fullblocks ifTrue: [ context setOptions: { #optionFullBlockClosure . optimization } ].
+	^ context
+]
+
+{ #category : #support }
+OCASTTranslatorTest >> compileExample: aSelector [
+	
+	^ self compileSource: (OCOpalExamples>> aSelector) sourceCode
+]
+
+{ #category : #support }
+OCASTTranslatorTest >> compileSource: source [
+	| ir ast |
+	ast := RBParser parseMethod: source.
+	ast compilationContext: self compilationContext.
 	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
+	^ 	method := ir compiledMethod
+]
+
+{ #category : #accessing }
+OCASTTranslatorTest >> encoder [
+
+	^ encoder
+]
+
+{ #category : #accessing }
+OCASTTranslatorTest >> encoder: anEncoder [
+
+	encoder := anEncoder
+]
+
+{ #category : #support }
+OCASTTranslatorTest >> executeMethod: aMethod onReceiver: receiver [
+
+	^ aMethod valueWithReceiver: receiver arguments: #()
+]
+
+{ #category : #support }
+OCASTTranslatorTest >> executeMethod: aMethod onReceiver: receiver withArgument: anArgument [
+
+	^ self executeMethod: aMethod onReceiver: receiver withArguments: {anArgument}
+]
+
+{ #category : #support }
+OCASTTranslatorTest >> executeMethod: aMethod onReceiver: receiver withArguments: arguments [
+
+	^ aMethod valueWithReceiver: receiver arguments: arguments
+]
+
+{ #category : #support }
+OCASTTranslatorTest >> executeMethodOnInstance: aMethod [
+
+	^ self executeMethod: aMethod onReceiver: instance
+]
+
+{ #category : #accessing }
+OCASTTranslatorTest >> fullblocks [
+	^ fullblocks
+]
+
+{ #category : #accessing }
+OCASTTranslatorTest >> fullblocks: anObject [
+	fullblocks := anObject
+]
+
+{ #category : #accessing }
+OCASTTranslatorTest >> globals [
+	^ globals
+]
+
+{ #category : #accessing }
+OCASTTranslatorTest >> globals: anObject [
+	globals := anObject
+]
+
+{ #category : #setup }
+OCASTTranslatorTest >> initialize [
+
+	super initialize.
+	fullblocks := false.
+]
+
+{ #category : #accessing }
+OCASTTranslatorTest >> instance [
+	^ instance
+]
+
+{ #category : #accessing }
+OCASTTranslatorTest >> instance: anObject [
+	instance := anObject
+]
+
+{ #category : #support }
+OCASTTranslatorTest >> instanceVariablesToKeep [
+
+	^ super instanceVariablesToKeep , #('fullblocks')
+]
+
+{ #category : #accessing }
+OCASTTranslatorTest >> method [
+	^ method
+]
+
+{ #category : #accessing }
+OCASTTranslatorTest >> method: anObject [
+	^ method := anObject
+]
+
+{ #category : #accessing }
+OCASTTranslatorTest >> optimization [
+	^ optimization
+]
+
+{ #category : #accessing }
+OCASTTranslatorTest >> optimization: anObject [
+	optimization := anObject
+]
+
+{ #category : #setup }
+OCASTTranslatorTest >> setUp [
+
+	super setUp.
 	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleAndOr.
-	
-	
+	globals := Dictionary new.
 ]
 
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleAndOr2 [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleAndOr2) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleAndOr2.
-	
-	
+{ #category : #setup }
+OCASTTranslatorTest >> tearDown [
+
+	OCOpalExamples reset.
+	super tearDown
 ]
 
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleAndOr3 [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleAndOr3) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleAndOr3.
-	
-	
+{ #category : #support }
+OCASTTranslatorTest >> testExample: aSelector [
+
+	^ self testExample: aSelector withArguments: #()
 ]
 
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleAndOr4 [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleAndOr4) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleAndOr4.
-	
-	
+{ #category : #support }
+OCASTTranslatorTest >> testExample: aSelector withArgument: anArgument [
+
+	^ self testExample: aSelector withArguments: { anArgument }
 ]
 
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleAndOr5 [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleAndOr5) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleAndOr5.
-	
-	
-]
+{ #category : #support }
+OCASTTranslatorTest >> testExample: aSelector withArguments: arguments [
 
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleAndOr6 [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleAndOr6) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleAndOr6.
-	
-	
-]
+	^ self testSource: ((OCOpalExamples>> aSelector) sourceCode) withArguments: arguments
 
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleBlockArgument [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleBlockArgument) parseTree.
-	ir := ast doSemanticAnalysis ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleBlockArgument.
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleBlockExternal [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleBlockExternal) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new. 
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleBlockExternal.
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleBlockExternal2 [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleBlockExternal2) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleBlockExternal2.
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleBlockExternalArg [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleBlockExternalArg) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleBlockExternalArg.
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleBlockExternalNested [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleBlockExternalNested) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleBlockExternalNested.
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleBlockInternal [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleBlockInternal) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleBlockInternal.
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleBlockMethodArgument [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleBlockMethodArgument:) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #(2)) = 4.
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleBlockNested [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleBlockNested) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleBlockNested.
-	
-]
-
-{ #category : #'testing - misc' }
-OCASTTranslatorTest >> testExampleEffectValues [
-	| cm |
-	cm := OCOpalExamples compiler compile: (OCOpalExamples>>#exampleEffectValues) sourceCode.
-	self assert: (cm literals includes: #getMe).
-	self assert: (cm literals includes: Class binding).
-	self assert: (cm literals includes: #( got that ? )).
-]
-
-{ #category : #'testing - simple' }
-OCASTTranslatorTest >> testExampleIfFalse [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleIfFalse) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleIfFalse.
-	
-	
-]
-
-{ #category : #'testing - simple' }
-OCASTTranslatorTest >> testExampleIfFalseIfTrue [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleIfFalseIfTrue) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleIfFalseIfTrue.
-	
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleIfNotNilArg [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleIfNotNilArg) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleIfNotNilArg.
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleIfNotNilReturnNil [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleIfNotNilReturnNil) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleIfNotNilReturnNil.
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleIfTrue [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleIfTrue) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = 'result'.
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleIfTrueAssign [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleIfTrueAssign) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = 1.
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleIfTrueIfFalse [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleIfTrueIfFalse) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = 'result'.
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleInlineBlockCollectionLR3 [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleInlineBlockCollectionLR3) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = (2 to: 12) asArray.
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleMethodTempInNestedBlock [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleMethodTempInNestedBlock) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: ((aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleMethodTempInNestedBlock)
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleMethodWithOptimizedBlocksA [
-	| ir ast aCompiledMethod instance |
-	ast  := (OCOpalExamples>>#exampleMethodWithOptimizedBlocksA) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new .
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleMethodWithOptimizedBlocksA.
-	
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleNestedBlockScoping [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleNestedBlockScoping) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleNestedBlockScoping.
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleOptimizedBlockWrittenAfterClosedOverCase1 [
-	| ir ast aCompiledMethod instance |
-	ast  := (OCOpalExamples>>#optimizedBlockWrittenAfterClosedOverCase1) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new .
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance optimizedBlockWrittenAfterClosedOverCase1.
-	
-	
 ]
 
 { #category : #'testing - primitives' }
@@ -407,488 +243,22 @@ OCASTTranslatorTest >> testExamplePrimitiveModuleError [
 	self assert: ir tempKeys equals: #(#errorCode)
 ]
 
-{ #category : #'testing - variables' }
-OCASTTranslatorTest >> testExampleSelf [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleSelf) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleSelf.
-	
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleSimpleBlock [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleSimpleBlock) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) value = instance exampleSimpleBlock value.
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleSimpleBlockArgument1 [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleSimpleBlockArgument1) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockArgument1.
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleSimpleBlockArgument2 [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleSimpleBlockArgument2) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockArgument2.
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleSimpleBlockArgument3 [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleSimpleBlockArgument3) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockArgument3.
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleSimpleBlockArgument4 [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleSimpleBlockArgument4) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockArgument4 .
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleSimpleBlockArgument5 [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleSimpleBlockArgument5) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockArgument5 .
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleSimpleBlockEmpty [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleSimpleBlockEmpty) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockEmpty .
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleSimpleBlockLocal [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleSimpleBlockLocal) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockLocal .
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleSimpleBlockLocalIf [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleSimpleBlockLocalIf) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockLocalIf.
-	
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleSimpleBlockLocalIfNested [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleSimpleBlockLocalIfNested) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockLocalIfNested.
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleSimpleBlockLocalWhile [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleSimpleBlockLocalWhile) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockLocalWhile.
-	
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleSimpleBlockNested [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleSimpleBlockNested) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockNested.
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleSimpleBlockReturn [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleSimpleBlockReturn) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockReturn.
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleSimpleBlockiVar [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleSimpleBlockiVar) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: ((aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockiVar)
-	
-]
-
-{ #category : #'testing - variables' }
-OCASTTranslatorTest >> testExampleSuper [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleSuper) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleSuper.
-	
-	
-]
-
-{ #category : #'testing - variables' }
-OCASTTranslatorTest >> testExampleThisContext [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleThisContext) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: OCOpalExamples new exampleThisContext isContext.
-	self assert: ((OCOpalExamples>>#exampleThisContext) valueWithReceiver: instance arguments: #()) isContext.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) isContext.
-	
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleTimesRepeatEffect [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleTimesRepeatEffect) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleTimesRepeatEffect.
-	
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleTimesRepeatValue [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleTimesRepeatValue) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleTimesRepeatValue.
-	
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleToDoArgument [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleToDoArgument) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleToDoArgument.
-	
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleToDoArgumentLimitIsExpression [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleToDoArgumentLimitIsExpression) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleToDoArgumentLimitIsExpression.
-	
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleToDoArgumentNotInlined [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleToDoArgumentNotInlined) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleToDoArgumentNotInlined.
-	
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleToDoInsideTemp [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleToDoInsideTemp) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleToDoInsideTemp.
-	
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleToDoInsideTempNotInlined [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleToDoInsideTempNotInlined) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleToDoInsideTempNotInlined.
-	
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleToDoOutsideTemp [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleToDoOutsideTemp) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleToDoOutsideTemp.
-	
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleToDoOutsideTempNotInlined [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleToDoOutsideTempNotInlined) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleToDoOutsideTempNotInlined.
-	
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleWhileModificationAfterNotInlined [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleWhileModificationAfterNotInlined) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleWhileModificationAfterNotInlined.
-	
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleWhileModificationBefore [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleWhileModificationBefore) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: OCOpalExamples new arguments: #()) = instance exampleWhileModificationBefore.
-	
-]
-
-{ #category : #'testing - blocks - optimized' }
-OCASTTranslatorTest >> testExampleWhileModificationBeforeNotInlined [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleWhileModificationBeforeNotInlined) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleWhileModificationBeforeNotInlined.
-	
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleWhileWithTemp [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleWhileWithTemp) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleWhileWithTemp.
-	
-	
-]
-
-{ #category : #'testing - blocks' }
-OCASTTranslatorTest >> testExampleWhileWithTempNotInlined [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleWhileWithTempNotInlined) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleWhileWithTempNotInlined.
-	
-	
-]
-
 { #category : #'testing - simple' }
-OCASTTranslatorTest >> testNewArray [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleNewArray) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleNewArray.
-	
-	
+OCASTTranslatorTest >> testSendSpecialBinaryMessage [
+
+	self assert: (Smalltalk specialSelectors includes: #+).
+	self assert: (self testExample: #exampleReturn1plus2) equals: 3
 ]
 
-{ #category : #'testing - simple' }
-OCASTTranslatorTest >> testOnePlusTwo [
-	| ast ir aCompiledMethod instance |
-	ast  := (OCOpalExamples>>#exampleReturn1plus2) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleReturn1plus2.
-	
-	
+{ #category : #support }
+OCASTTranslatorTest >> testSource: sourceCode [
+
+	^ self testSource: sourceCode withArguments: #()
 ]
 
-{ #category : #'testing - misc' }
-OCASTTranslatorTest >> testPushArray [
-	| ast ir aCompiledMethod instance |
-	ast := (OCOpalExamples>>#examplePushArray) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new .
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance examplePushArray.
-]
+{ #category : #support }
+OCASTTranslatorTest >> testSource: sourceCode withArguments: arguments [
 
-{ #category : #'testing - misc' }
-OCASTTranslatorTest >> testPushBigArray [
-	| ast ir aCompiledMethod instance |
-	ast := (OCOpalExamples>>#examplePushBigArray) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new .
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance examplePushBigArray.
-]
-
-{ #category : #'testing - simple' }
-OCASTTranslatorTest >> testReturn1 [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleReturn1) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleReturn1.
-	
-	
-]
-
-{ #category : #'testing - misc' }
-OCASTTranslatorTest >> testTodoValue [
-	| ast ir aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleToDoValue) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new .
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleToDoValue.
-]
-
-{ #category : #'testing - misc' }
-OCASTTranslatorTest >> testTodoValueLimitExpression [
-	| ast ir aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleToDoValueLimitExpression) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new .
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleToDoValueLimitExpression.
-]
-
-{ #category : #'testing - variables' }
-OCASTTranslatorTest >> testiVar [
-	| ir ast aCompiledMethod instance |
-	ast := (OCOpalExamples>>#exampleiVar) parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
-	instance := OCOpalExamples new.
-	
-	aCompiledMethod := ir compiledMethod.
-	self assert: (aCompiledMethod valueWithReceiver: instance arguments: #()) = instance exampleiVar.
-	
-	
+	self compileSource: sourceCode.
+	^ self executeMethod: method onReceiver: instance withArguments: arguments
 ]

--- a/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
@@ -105,7 +105,7 @@ OCASTTranslatorTest >> globals: anObject [
 	globals := anObject
 ]
 
-{ #category : #setup }
+{ #category : #initialization }
 OCASTTranslatorTest >> initialize [
 
 	super initialize.
@@ -148,7 +148,7 @@ OCASTTranslatorTest >> optimization: anObject [
 	optimization := anObject
 ]
 
-{ #category : #setup }
+{ #category : #running }
 OCASTTranslatorTest >> setUp [
 
 	super setUp.
@@ -156,7 +156,7 @@ OCASTTranslatorTest >> setUp [
 	globals := Dictionary new.
 ]
 
-{ #category : #setup }
+{ #category : #running }
 OCASTTranslatorTest >> tearDown [
 
 	OCOpalExamples reset.

--- a/src/OpalCompiler-Tests/OCASTVariableTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTVariableTranslatorTest.class.st
@@ -1,0 +1,131 @@
+Class {
+	#name : #OCASTVariableTranslatorTest,
+	#superclass : #OCASTTranslatorTest,
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #'testing - variables' }
+OCASTVariableTranslatorTest >> testAssignArgumentVariable [
+	self
+		should: [self compileSource: 'argument: anArgument
+	anArgument := 17'] raise: OCStoreIntoReadOnlyVariableError
+]
+
+{ #category : #'testing - variables' }
+OCASTVariableTranslatorTest >> testAssignClassVariable [
+	self assert: instance iVar equals: nil.
+	self testExample: #exampleClassVariableAssignment.
+	self assert: instance classVariable equals: 1
+]
+
+{ #category : #'testing - variables' }
+OCASTVariableTranslatorTest >> testAssignGlobalVariable [
+	globals add: (GlobalVariable key: #GlobalVariable value: nil).
+	self testSource: 'exampleGlobalVariableAssignment
+	GlobalVariable := 17'.
+	self assert: (globals at: #GlobalVariable) equals: 17
+]
+
+{ #category : #'testing - variables' }
+OCASTVariableTranslatorTest >> testAssignInstanceVariable [
+	self assert: instance iVar equals: nil.
+	self testExample: #exampleInstanceVariableAssignment.
+	self assert: instance iVar equals: 1
+	
+]
+
+{ #category : #'testing - variables' }
+OCASTVariableTranslatorTest >> testAssignSelfVariable [
+	self
+		should: [self compileSource: 'foo
+	self := 17'] raise: OCStoreIntoSpecialVariableError
+]
+
+{ #category : #'testing - variables' }
+OCASTVariableTranslatorTest >> testAssignSuperVariable [
+	self
+		should: [self compileSource: 'foo
+	super := 17'] raise: OCStoreIntoSpecialVariableError
+]
+
+{ #category : #'testing - variables' }
+OCASTVariableTranslatorTest >> testAssignTemporaryVariable [
+	self testExample: #exampleTemporaryVariableAssignment.
+	
+	self assert: instance result equals: 17
+]
+
+{ #category : #'testing - variables' }
+OCASTVariableTranslatorTest >> testAssignThisContextVariable [
+	self
+		should: [self compileSource: 'foo
+	thisContext := 17'] raise: OCStoreIntoSpecialVariableError
+]
+
+{ #category : #'testing - variables' }
+OCASTVariableTranslatorTest >> testPushArgumentVariable [
+	self testExample: #examplePushArgumentVariable: withArgument: 17.
+	
+	self assert: instance result equals: 17
+]
+
+{ #category : #'testing - variables' }
+OCASTVariableTranslatorTest >> testPushClassVariable [
+	instance classVariable: 17.
+	self testExample: #examplePushClassVariable.
+	
+	self assert: instance result equals: 17
+]
+
+{ #category : #'testing - variables' }
+OCASTVariableTranslatorTest >> testPushGlobalVariable [
+
+	globals add: (GlobalVariable key: #GlobalVariable value: 17).
+	self testSource: 'exampleGlobalVariableAssignment
+	self message: GlobalVariable'.
+	
+	self assert: instance result equals: 17
+]
+
+{ #category : #'testing - variables' }
+OCASTVariableTranslatorTest >> testPushInstanceVariable [
+	instance iVar: 17.
+	self testExample: #examplePushInstanceVariable.
+	
+	self assert: instance result equals: 17
+]
+
+{ #category : #'testing - variables' }
+OCASTVariableTranslatorTest >> testPushSelf [
+	
+	self assert: instance result equals: nil.
+	self testExample: #exampleSelf.
+	self assert: instance result equals: instance
+]
+
+{ #category : #'testing - variables' }
+OCASTVariableTranslatorTest >> testPushSuper [
+	
+	self assert: instance result equals: nil.
+	self testExample: #exampleSuper.
+	self assert: instance result equals: instance
+]
+
+{ #category : #'testing - variables' }
+OCASTVariableTranslatorTest >> testPushTemporaryVariable [
+	instance iVar: 17.
+	self testExample: #examplePushTemporaryVariable.
+	
+	self assert: instance result equals: 17
+]
+
+{ #category : #'testing - variables' }
+OCASTVariableTranslatorTest >> testPushThisContext [
+	
+	| method |
+	method := self compileExample: #exampleThisContext.
+	self executeMethodOnInstance: method.
+
+	self assert: instance result isContext.
+	self assert: instance result method equals: method.	
+]

--- a/src/OpalCompiler-Tests/OCASTWhileFalseTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTWhileFalseTranslatorTest.class.st
@@ -1,0 +1,96 @@
+Class {
+	#name : #OCASTWhileFalseTranslatorTest,
+	#superclass : #OCASTDoubleBlockTranslatorTest,
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #'building suites' }
+OCASTWhileFalseTranslatorTest class >> testParameters [
+	^ super testParameters *
+		(ParametrizedTestMatrix new
+			forSelector: #optimization addOptions: { #optionInlineWhile . #optionInlineNone })
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTWhileFalseTranslatorTest >> testWhileFalseExecutesLeftBlock [
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	temp := 0.
+	{argument1} whileFalse: {argument2}.
+	^ temp'
+		withTemps: #( 'temp' )
+		withFirstBlock: '[ temp := temp + 1. temp > 4 ]'
+		withSecondBlock: '[ ]'.
+
+	self assert: result equals: 5.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTWhileFalseTranslatorTest >> testWhileFalseExecutesLeftBlockWithTemp [
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	temp := 0.
+	{argument1} whileFalse: {argument2}.
+	^ temp'
+		withTemps: #( 'temp' )
+		withFirstBlock: '[ | intemp |
+			intemp := temp + 1.
+			temp := intemp.
+			intemp > 4 ]'
+		withSecondBlock: '[ ]'.
+
+	self assert: result equals: 5.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTWhileFalseTranslatorTest >> testWhileFalseExecutesRightBlock [
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	temp := 0.
+	{argument1} whileFalse: {argument2}.
+	^ temp'
+		withTemps: #( 'temp' )
+		withFirstBlock: '[ temp > 4 ]'
+		withSecondBlock: '[ temp := temp + 1 ]'.
+
+	self assert: result equals: 5.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTWhileFalseTranslatorTest >> testWhileFalseExecutesRightBlockWithTemp [
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	temp := 0.
+	{argument1} whileFalse: {argument2}.
+	^ temp'
+		withTemps: #( 'temp' )
+		withFirstBlock: '[ temp > 4 ]'
+		withSecondBlock: '[ | intemp |
+			intemp := temp + 1.
+			temp := intemp ]'.
+
+	self assert: result equals: 5.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTWhileFalseTranslatorTest >> testWhileFalseReturnsNil [
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	temp := 0.
+	^ {argument1} whileFalse: {argument2}'
+		withTemps: #( 'temp' )
+		withFirstBlock: '[ temp := temp + 1. temp > 4 ]'
+		withSecondBlock: '[ ]'.
+
+	self assert: result equals: nil.
+]

--- a/src/OpalCompiler-Tests/OCASTWhileTrueTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTWhileTrueTranslatorTest.class.st
@@ -1,0 +1,97 @@
+Class {
+	#name : #OCASTWhileTrueTranslatorTest,
+	#superclass : #OCASTDoubleBlockTranslatorTest,
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #'building suites' }
+OCASTWhileTrueTranslatorTest class >> testParameters [
+	^ super testParameters *
+		(ParametrizedTestMatrix new
+			forSelector: #optimization addOptions: { #optionInlineWhile . #optionInlineNone })
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTWhileTrueTranslatorTest >> testWhileTrueExecutesLeftBlock [
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	temp := 0.
+	{argument1} whileTrue: {argument2}.
+	^ temp'
+		withTemps: #( 'temp' )
+		withFirstBlock: '[ temp := temp + 1. temp < 5 ]'
+		withSecondBlock: '[ ]'.
+
+	self assert: result equals: 5.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTWhileTrueTranslatorTest >> testWhileTrueExecutesLeftBlockWithTemp [
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	temp := 0.
+	{argument1} whileTrue: {argument2}.
+	^ temp'
+		withTemps: #( 'temp' )
+		withFirstBlock: '[ | intemp |
+			intemp := temp + 1.
+			temp := intemp.
+			intemp < 5 ]'
+		withSecondBlock: '[ ]'.
+
+	self assert: result equals: 5.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTWhileTrueTranslatorTest >> testWhileTrueExecutesRightBlock [
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	temp := 0.
+	{argument1} whileTrue: {argument2}.
+	^ temp'
+		withTemps: #( 'temp' )
+		withFirstBlock: '[ temp < 5 ]'
+		withSecondBlock: '[ temp := temp + 1 ]'.
+
+	self assert: result equals: 5.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTWhileTrueTranslatorTest >> testWhileTrueExecutesRightBlockWithTemp [
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	temp := 0.
+	{argument1} whileTrue: {argument2}.
+	^ temp'
+		withTemps: #( 'temp' )
+		withFirstBlock: '[ temp < 5 ]'
+		withSecondBlock: '[ | intemp |
+			intemp := temp + 1.
+			temp := intemp.
+			temp ]'.
+
+	self assert: result equals: 5.
+]
+
+{ #category : #'testing - blocks - optimized' }
+OCASTWhileTrueTranslatorTest >> testWhileTrueReturnsNil [
+	| result |
+	result := self
+		testComposedExample: 'example
+	{definition}.
+	temp := 0.
+	^ {argument1} whileTrue: {argument2}'
+		withTemps: #( 'temp' )
+		withFirstBlock: '[ temp := temp + 1. temp < 5 ]'
+		withSecondBlock: '[ ]'.
+
+	self assert: result equals: nil.
+]

--- a/src/OpalCompiler-Tests/OCBytecodeDecompilerExamplesTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeDecompilerExamplesTest.class.st
@@ -260,13 +260,13 @@ OCBytecodeDecompilerExamplesTest >> testExamplePushArray [
 OCBytecodeDecompilerExamplesTest >> testExampleReturn1 [
 	| ir method newMethod instance |
 	
-	method := (OCOpalExamples>>#exampleReturn1) parseTree generate.
+	method := (OCOpalExamples>>#exampleReturn42) parseTree generate.
 	instance := OCOpalExamples new.
 	
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleReturn1
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleReturn42
 ]
 
 { #category : #'tests-simple' }
@@ -499,7 +499,10 @@ OCBytecodeDecompilerExamplesTest >> testExampleThisContext [
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) isContext
+	instance := OCOpalExamples new.
+	newMethod valueWithReceiver: instance arguments: #().
+	
+	self assert: instance result isContext
 ]
 
 { #category : #'tests-blocks-optimized' }

--- a/src/OpalCompiler-Tests/OCOpalExamples.class.st
+++ b/src/OpalCompiler-Tests/OCOpalExamples.class.st
@@ -222,6 +222,45 @@ OCOpalExamples >> exampleForInlinedBlockArgument [
 ]
 
 { #category : #'examples-blocks-optimized' }
+OCOpalExamples >> exampleIfFalse [
+	<sampleInstance>
+	true
+		ifTrue: [  ]
+		ifFalse: [ ^ 1 ].
+	^ 2
+]
+
+{ #category : #'examples-blocks-optimized' }
+OCOpalExamples >> exampleIfFalseIfTrue [
+	<sampleInstance>
+	true ifFalse: [^1] ifTrue: [^2].
+]
+
+{ #category : #'examples-blocks-optimized' }
+OCOpalExamples >> exampleIfNotNilArg [
+	<sampleInstance>
+	^1 even ifNotNil: [ :arg | arg not ]
+]
+
+{ #category : #'examples-blocks-optimized' }
+OCOpalExamples >> exampleIfNotNilReturnNil [
+	<sampleInstance>
+	^nil ifNotNil: [ :arg | arg not ]
+]
+
+{ #category : #'examples-blocks-optimized' }
+OCOpalExamples >> exampleIfTrue [
+	[ 1 < 2
+		ifTrue: [ ^ 'result' ]] value
+]
+
+{ #category : #'examples-blocks-optimized' }
+OCOpalExamples >> exampleIfTrueIfFalse [
+	<sampleInstance>
+	 1 <2 ifTrue: [^'result'] ifFalse: [2].
+]
+
+{ #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleInlineBlockCollectionLR3 [
 	<sampleInstance>
 	| col |
@@ -320,6 +359,19 @@ OCOpalExamples >> exampleMethodTempInNestedBlock [
 	^block value.
 ]
 
+{ #category : #'examples-blocks-optimized' }
+OCOpalExamples >> exampleMethodWithOptimizedBlocksA [
+	<sampleInstance>
+	| s c |
+	s := self isNil
+			ifTrue: [| a | a := 'isNil'. a]
+			ifFalse: [| a | a := 'notNil'. a].
+	c := String new: s size.
+	1 to: s size do:
+		[:i| c at: i put: (s at: i)].
+	^c. "notNil"
+]
+
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleNestedBlockScoping [
 	<sampleInstance>
@@ -331,6 +383,16 @@ OCOpalExamples >> exampleNestedBlockScoping [
 	c := [:a |
 			z + a].
 	^ (b value: 2) + (c value: 1)
+]
+
+{ #category : #'examples-blocks-optimized' }
+OCOpalExamples >> exampleNewArray [
+	<sampleInstance>
+
+	| temp |
+	
+	temp := Array new: 3.
+	^temp
 ]
 
 { #category : #'examples-conditionals' }
@@ -430,6 +492,15 @@ OCOpalExamples >> examplePushArgumentVariable: argument [
 	<sampleInstance>
 	
 	self message: argument
+]
+
+{ #category : #'examples-blocks-optimized' }
+OCOpalExamples >> examplePushArray [
+	<sampleInstance>
+	| t |
+
+	{1 .t:=1}.
+	^t
 ]
 
 { #category : #'examples-misc' }
@@ -884,6 +955,13 @@ OCOpalExamples >> exampleWhileWithTempNotInlined [
 OCOpalExamples >> exampleWithArgument: anArg [
 	<sampleInstance>
 	^ anArg
+]
+
+{ #category : #'examples-blocks-optimized' }
+OCOpalExamples >> exampleiVar [
+	<sampleInstance>
+	iVar := 1.
+	^iVar.
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Tests/OCOpalExamples.class.st
+++ b/src/OpalCompiler-Tests/OCOpalExamples.class.st
@@ -6,7 +6,11 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'iVar',
-		'collection'
+		'collection',
+		'result'
+	],
+	#classVars : [
+		'ClassVariable'
 	],
 	#category : #'OpalCompiler-Tests-AST'
 }
@@ -14,6 +18,24 @@ Class {
 { #category : #compiler }
 OCOpalExamples class >> compilerClass [
 	^OpalCompiler
+]
+
+{ #category : #compiler }
+OCOpalExamples class >> reset [
+
+	ClassVariable := nil
+]
+
+{ #category : #accessing }
+OCOpalExamples >> classVariable [
+
+	^ ClassVariable
+]
+
+{ #category : #accessing }
+OCOpalExamples >> classVariable: anInteger [ 
+
+	ClassVariable := anInteger
 ]
 
 { #category : #examples }
@@ -33,56 +55,16 @@ OCOpalExamples >> doubleRemoteAnidatedBlocks [
 
 ]
 
-{ #category : #'examples-blocks-optimized' }
-OCOpalExamples >> exampleAndOr [
-	| t1 t2 |
-	t1 := true.
-	t2 := false.
-	t1 and: [ t2. '1' logCr ]. "effect"   
+{ #category : #'examples-andor' }
+OCOpalExamples >> exampleAndValueWithEffect [
+	
+	true and: [ result := 17 ]
 ]
 
-{ #category : #'examples-blocks-optimized' }
-OCOpalExamples >> exampleAndOr2 [
-	| t1 t2 |
-	t1 := true.
-	t2 := false.  
-	t2 or: [ t1. '2' logCr ]. "effect" 
-]
-
-{ #category : #'examples-blocks-optimized' }
-OCOpalExamples >> exampleAndOr3 [
-	<sampleInstance>
-	| t1 t2 |
-	t1 := true.
-	t2 := false.  
-	^ t1 and: [ t2 ] "value" 
-]
-
-{ #category : #'examples-blocks-optimized' }
-OCOpalExamples >> exampleAndOr4 [
-	<sampleInstance>
-	| t1 t2 |
-	t1 := true.
-	t2 := false.  
-	^ t2 or: [ t1 ] "value"  
-]
-
-{ #category : #'examples-blocks-optimized' }
-OCOpalExamples >> exampleAndOr5 [
-	<sampleInstance>
-	| t1 t2 |
-	t1 := true.
-	t2 := false.  
-	^ t2 or: [ t1 and: [ t2 ] ]
-]
-
-{ #category : #'examples-blocks-optimized' }
-OCOpalExamples >> exampleAndOr6 [
-	<sampleInstance>
-	| t1 t2 |
-	t1 := true.
-	t2 := false.  
-	^ t1 and: [ t2 or: [ t1 ] ]
+{ #category : #'examples-andor' }
+OCOpalExamples >> exampleAndValueWithShortcircuitEffect [
+	
+	false and: [ result := 17 ]
 ]
 
 { #category : #'examples-blocks' }
@@ -152,6 +134,12 @@ OCOpalExamples >> exampleBlockNested [
 	^[ [1] value] value
 ]
 
+{ #category : #'examples-variables' }
+OCOpalExamples >> exampleClassVariableAssignment [
+	<sampleInstance>
+	ClassVariable := 1
+]
+
 { #category : #'examples-pragmas' }
 OCOpalExamples >> exampleDoublePrimitive [
 	<primitive: 1>
@@ -167,6 +155,54 @@ OCOpalExamples >> exampleEffectValues [
 
 { #category : #'examples-simple' }
 OCOpalExamples >> exampleEmptyMethod [
+]
+
+{ #category : #'examples-andor' }
+OCOpalExamples >> exampleFalseAndAnything: anything [
+	<sampleInstance>
+	^ false and: [ anything ]
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleFalseIfFalse [
+	<sampleInstance>
+	^false ifFalse: [1]
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleFalseIfFalseIfTrue [
+	<sampleInstance>
+	^false ifFalse: [iVar := 'false'] ifTrue: [ self error ]
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleFalseIfFalseWithEffect [
+	<sampleInstance>
+	^false ifFalse: [iVar := 17]
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleFalseIfTrue [
+	<sampleInstance>
+	^false ifTrue: [1]
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleFalseIfTrueIfFalse [
+	<sampleInstance>
+	^false ifTrue: [ self error ] ifFalse: [iVar := 'false'] 
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleFalseIfTrueWithEffect [
+	<sampleInstance>
+	^false ifTrue: [iVar := 17]
+]
+
+{ #category : #'examples-andor' }
+OCOpalExamples >> exampleFalseOrAnything: anything [
+	<sampleInstance>
+	^ false or: [ anything ]
 ]
 
 { #category : #'examples-variables' }
@@ -186,51 +222,6 @@ OCOpalExamples >> exampleForInlinedBlockArgument [
 ]
 
 { #category : #'examples-blocks-optimized' }
-OCOpalExamples >> exampleIfFalse [
-	<sampleInstance>
-	true ifFalse: [^1].
-	^2
-]
-
-{ #category : #'examples-blocks-optimized' }
-OCOpalExamples >> exampleIfFalseIfTrue [
-	true ifFalse: [^1] ifTrue: [^2].
-]
-
-{ #category : #'examples-blocks-optimized' }
-OCOpalExamples >> exampleIfNotNilArg [
-	<sampleInstance>
-	^1 even ifNotNil: [ :arg | arg not ]
-]
-
-{ #category : #'examples-blocks-optimized' }
-OCOpalExamples >> exampleIfNotNilReturnNil [
-	<sampleInstance>
-	^nil ifNotNil: [ :arg | arg not ]
-]
-
-{ #category : #'examples-blocks-optimized' }
-OCOpalExamples >> exampleIfTrue [
-	<sampleInstance>
-	 1  < 2 ifTrue: [^'result']. 
-]
-
-{ #category : #'examples-blocks-optimized' }
-OCOpalExamples >> exampleIfTrueAssign [
-	<sampleInstance>
-	| a |
-	a := 1 <2 ifTrue: [1] ifFalse: [2].
-	^a 
-]
-
-{ #category : #'examples-blocks-optimized' }
-OCOpalExamples >> exampleIfTrueIfFalse [
-	<sampleInstance>
-	 1 <2 ifTrue: [^'result'] ifFalse: [2].
-	
-]
-
-{ #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleInlineBlockCollectionLR3 [
 	<sampleInstance>
 	| col |
@@ -238,6 +229,82 @@ OCOpalExamples >> exampleInlineBlockCollectionLR3 [
 	1 to: 11 do: [ :each | | i | i := each. col add: [ i ]. i := i + 1 ].
 	^ (col collect: [ :each | each value ]) asArray "= (2 to: 12) asArray"
 
+]
+
+{ #category : #'examples-variables' }
+OCOpalExamples >> exampleInstanceVariableAssignment [
+	<sampleInstance>
+	iVar := 1
+]
+
+{ #category : #'examples-literals' }
+OCOpalExamples >> exampleLiteralArray [
+	<sampleInstance>
+
+	^ #( 1 2 3)
+]
+
+{ #category : #'examples-literals' }
+OCOpalExamples >> exampleLiteralBoxedFloat [
+	<sampleInstance>
+
+	^ 9.999999999999996e157
+]
+
+{ #category : #'examples-literals' }
+OCOpalExamples >> exampleLiteralByteArray [
+	<sampleInstance>
+
+	^ #[ 1 2 3 ]
+]
+
+{ #category : #'examples-literals' }
+OCOpalExamples >> exampleLiteralByteString [
+	<sampleInstance>
+
+	^ 'bytestring'
+]
+
+{ #category : #'examples-literals' }
+OCOpalExamples >> exampleLiteralByteSymbol [
+	<sampleInstance>
+
+	^ #bytesymbol
+]
+
+{ #category : #'examples-literals' }
+OCOpalExamples >> exampleLiteralCharacter [
+	<sampleInstance>
+
+	^ $H
+]
+
+{ #category : #'examples-literals' }
+OCOpalExamples >> exampleLiteralFloat [
+	<sampleInstance>
+
+	^ 1.2
+]
+
+{ #category : #'examples-literals' }
+OCOpalExamples >> exampleLiteralLargeInteger [
+	<sampleInstance>
+
+	^ 16rFFFFFFFFFFFFFFFF
+]
+
+{ #category : #'examples-literals' }
+OCOpalExamples >> exampleLiteralWideString [
+	<sampleInstance>
+
+	^ 'áèîöÑü'
+]
+
+{ #category : #'examples-literals' }
+OCOpalExamples >> exampleLiteralWideSymbol [
+	<sampleInstance>
+
+	^ #'áèîöÑü'
 ]
 
 { #category : #'examples-blocks' }
@@ -253,19 +320,6 @@ OCOpalExamples >> exampleMethodTempInNestedBlock [
 	^block value.
 ]
 
-{ #category : #'examples-blocks-optimized' }
-OCOpalExamples >> exampleMethodWithOptimizedBlocksA [
-	<sampleInstance>
-	| s c |
-	s := self isNil
-			ifTrue: [| a | a := 'isNil'. a]
-			ifFalse: [| a | a := 'notNil'. a].
-	c := String new: s size.
-	1 to: s size do:
-		[:i| c at: i put: (s at: i)].
-	^c. "notNil"
-]
-
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleNestedBlockScoping [
 	<sampleInstance>
@@ -279,14 +333,59 @@ OCOpalExamples >> exampleNestedBlockScoping [
 	^ (b value: 2) + (c value: 1)
 ]
 
-{ #category : #'examples-simple' }
-OCOpalExamples >> exampleNewArray [
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleNilIfNil [
+	<sampleInstance>
+	^nil ifNil: [ iVar := 17 ]
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleNilIfNotNil [
+	<sampleInstance>
+	^nil ifNotNil: [ self error ]
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleNilIfNotNilWithArgument [
+	<sampleInstance>
+	^nil ifNotNil: [ :arg | self error ]
+]
+
+{ #category : #'examples-literals' }
+OCOpalExamples >> exampleNonSpecialLiteralInteger [
 	<sampleInstance>
 
-	| temp |
+	^ 10
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleNotNilIfNil [
+	<sampleInstance>
+	^1 ifNil: [ self error ]
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleNotNilIfNotNil [
+	<sampleInstance>
+	^1 ifNotNil: [ iVar := 17 ]
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleNotNilIfNotNilWithArgument [
+	<sampleInstance>
+	^1 ifNotNil: [ :arg | iVar := arg ]
+]
+
+{ #category : #'examples-andor' }
+OCOpalExamples >> exampleOrValueWithEffect [
 	
-	temp := Array new: 3.
-	^temp
+	false or: [ result := 17 ]
+]
+
+{ #category : #'examples-andor' }
+OCOpalExamples >> exampleOrValueWithShortcircuitEffect [
+	
+	true or: [ result := 17 ]
 ]
 
 { #category : #'examples-pragmas' }
@@ -326,21 +425,53 @@ OCOpalExamples >> examplePrimitiveModuleError [
 	^ errorCode
 ]
 
-{ #category : #'examples-misc' }
-OCOpalExamples >> examplePushArray [
+{ #category : #'examples-variables' }
+OCOpalExamples >> examplePushArgumentVariable: argument [
 	<sampleInstance>
-	| t |
-
-	{1 .t:=1}.
-	^t
+	
+	self message: argument
 ]
 
 { #category : #'examples-misc' }
-OCOpalExamples >> examplePushBigArray [
+OCOpalExamples >> examplePushBigDynamicLiteralArray [
 	<sampleInstance>
 	"This array should have a size more than 127 elements"
-	{ 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 .  255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 }.
-	^ 1
+	self message: { 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 .  255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 }
+]
+
+{ #category : #'examples-variables' }
+OCOpalExamples >> examplePushClassVariable [
+	<sampleInstance>
+	
+	self result: ClassVariable
+]
+
+{ #category : #'examples-misc' }
+OCOpalExamples >> examplePushDynamicLiteralArray [
+	<sampleInstance>
+	^  { 1 . 1+2 }
+]
+
+{ #category : #'examples-variables' }
+OCOpalExamples >> examplePushInstanceVariable [
+	<sampleInstance>
+	
+	self result: iVar
+]
+
+{ #category : #'examples-literals' }
+OCOpalExamples >> examplePushNonSpecialSmallInteger [
+	<sampleInstance>
+	self result: 10
+]
+
+{ #category : #'examples-variables' }
+OCOpalExamples >> examplePushTemporaryVariable [
+	<sampleInstance>
+	
+	| temporary |
+	temporary := iVar.
+	self result: temporary
 ]
 
 { #category : #'examples-blocks-optimized' }
@@ -368,12 +499,6 @@ OCOpalExamples >> exampleRepeatValue [
 ]
 
 { #category : #'examples-simple' }
-OCOpalExamples >> exampleReturn1 [
-	<sampleInstance>
-	^1
-]
-
-{ #category : #'examples-simple' }
 OCOpalExamples >> exampleReturn1plus2 [
 	<sampleInstance>
 	^1+2
@@ -387,10 +512,8 @@ OCOpalExamples >> exampleReturn42 [
 
 { #category : #'examples-variables' }
 OCOpalExamples >> exampleSelf [
-	<sampleInstance>
-	| t |
-	t := self.
-	^self.
+	
+	self result: self
 ]
 
 { #category : #'examples-blocks' }
@@ -498,9 +621,8 @@ OCOpalExamples >> exampleSimpleBlockiVar [
 { #category : #'examples-variables' }
 OCOpalExamples >> exampleSuper [
 	<sampleInstance>
-	| t |
-	t := super.
-	^super.
+	
+	self result: super
 ]
 
 { #category : #'examples-blocks' }
@@ -510,11 +632,19 @@ OCOpalExamples >> exampleSuperReceiver [
 ]
 
 { #category : #'examples-variables' }
+OCOpalExamples >> exampleTemporaryVariableAssignment [
+	<sampleInstance>
+	
+	| temporary |
+	temporary := 17.
+	self message: temporary
+]
+
+{ #category : #'examples-variables' }
 OCOpalExamples >> exampleThisContext [
 	<sampleInstance>
-	| t |
-	t := thisContext.
-	^thisContext.
+	
+	self result: thisContext
 ]
 
 { #category : #'examples-blocks-optimized' }
@@ -623,6 +753,54 @@ OCOpalExamples >> exampleToDoValueLimitExpression [
 
 ]
 
+{ #category : #'examples-andor' }
+OCOpalExamples >> exampleTrueAndAnything: argument [
+	<sampleInstance>
+	^ true and: [ argument ]
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleTrueIfFalse [
+	<sampleInstance>
+	^true ifFalse: [1]
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleTrueIfFalseIfTrue [
+	<sampleInstance>
+	^true ifFalse: [ self error ] ifTrue: [iVar := 'true']
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleTrueIfFalseWithEffect [
+	<sampleInstance>
+	^true ifFalse: [iVar := 17]
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleTrueIfTrue [
+	<sampleInstance>
+	^true ifTrue: [1]
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleTrueIfTrueIfFalse [
+	<sampleInstance>
+	^true ifTrue: [iVar := 'true'] ifFalse: [ self error ]
+]
+
+{ #category : #'examples-conditionals' }
+OCOpalExamples >> exampleTrueIfTrueWithEffect [
+	<sampleInstance>
+	^true ifTrue: [iVar := 17]
+]
+
+{ #category : #'examples-andor' }
+OCOpalExamples >> exampleTrueOrAnything: anything [
+	<sampleInstance>
+	^ true or: [ anything ]
+]
+
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleWhileModificationAfterNotInlined [
 	<sampleInstance>
@@ -708,16 +886,25 @@ OCOpalExamples >> exampleWithArgument: anArg [
 	^ anArg
 ]
 
-{ #category : #'examples-variables' }
-OCOpalExamples >> exampleiVar [
-	<sampleInstance>
-	iVar := 1.
-	^iVar.
+{ #category : #accessing }
+OCOpalExamples >> iVar [
+	^ iVar
+]
+
+{ #category : #accessing }
+OCOpalExamples >> iVar: anInteger [ 
+	iVar := anInteger
 ]
 
 { #category : #initialization }
 OCOpalExamples >> initialize [
 	collection := OrderedCollection new
+]
+
+{ #category : #accessing }
+OCOpalExamples >> message: anObject [
+
+	result := anObject
 ]
 
 { #category : #examples }
@@ -880,6 +1067,17 @@ OCOpalExamples >> optimizedBlocksAndSameNameTemps [
 	1 to: s size do:
 		[:i| c at: i put: (s at: i)].
 	^c
+]
+
+{ #category : #accessing }
+OCOpalExamples >> result [
+
+	^ result
+]
+
+{ #category : #accessing }
+OCOpalExamples >> result: anObject [
+	result := anObject
 ]
 
 { #category : #examples }

--- a/src/ParametrizedTests/Array.extension.st
+++ b/src/ParametrizedTests/Array.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #Array }
+
+{ #category : #'*ParametrizedTests' }
+Array >> asTestMatrix [
+
+	| matrix |
+	matrix := ParametrizedTestMatrix new.
+	self do: [ :e | matrix addCase: e ].
+	^ matrix
+]

--- a/src/ParametrizedTests/Association.extension.st
+++ b/src/ParametrizedTests/Association.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #Association }
+
+{ #category : #'*ParametrizedTests' }
+Association >> asTestParameter [
+
+	^ ParametrizedTestExpandedParameter new
+		selector: self key;
+		valuable: self value;
+		yourself
+]

--- a/src/ParametrizedTests/PaSuiteTest.class.st
+++ b/src/ParametrizedTests/PaSuiteTest.class.st
@@ -110,3 +110,66 @@ PaSuiteTest >> testMatrixExampleHasTheCorrectTests [
 			{ 'c'. 1}. { 'c'. 2}. { 'c'. 3}.}
 	
 ]
+
+{ #category : #tests }
+PaSuiteTest >> testMultiplyMatrixWithCasesMultiplyCases [
+
+	| m1 m2 m3 |
+	m1 := ParametrizedTestMatrix new.
+	m1 addCase: { #option1 -> #a . #option2 -> #a }.
+	m1 addCase: { #option1 -> #b . #option2 -> #c }.
+	
+	m2 := ParametrizedTestMatrix new.
+	m2 addCase: { #option3 -> #a . #option4 -> #a }.
+	m2 addCase: { #option3 -> #b . #option4 -> #c }.
+	
+	m3 := m1 * m2.
+	
+	self assert: m3 equals: {
+		{ #option1 -> #a. #option2 -> #a. #option3 -> #a. #option4 -> #a  }.
+		{ #option1 -> #a. #option2 -> #a. #option3 -> #b. #option4 -> #c  }.
+		{ #option1 -> #b. #option2 -> #c. #option3 -> #a. #option4 -> #a  }.
+		{ #option1 -> #b. #option2 -> #c. #option3 -> #b. #option4 -> #c  }.
+	} asTestMatrix.
+]
+
+{ #category : #tests }
+PaSuiteTest >> testMultiplyMatrixWithOptionsAndCasesMultiplyCases [
+
+	| m1 m2 m3 |
+	m1 := ParametrizedTestMatrix new.
+	m1 forSelector: #option1 addOptions: #(a b).
+	
+	m2 := ParametrizedTestMatrix new.
+	m2 addCase: { #option3 -> #a . #option4 -> #a }.
+	m2 addCase: { #option3 -> #b . #option4 -> #c }.
+	
+	m3 := m1 * m2.
+	
+	self assert: m3 equals: {
+		{ #option1 -> #a. #option3 -> #a. #option4 -> #a  }.
+		{ #option1 -> #a. #option3 -> #b. #option4 -> #c  }.
+		{ #option1 -> #b. #option3 -> #a. #option4 -> #a  }.
+		{ #option1 -> #b. #option3 -> #b. #option4 -> #c  }.
+	} asTestMatrix.
+]
+
+{ #category : #tests }
+PaSuiteTest >> testMultiplyMatrixWithOptionsMultiplyCases [
+
+	| m1 m2 m3 |
+	m1 := ParametrizedTestMatrix new.
+	m1 forSelector: #option1 addOptions: #(a b).
+	
+	m2 := ParametrizedTestMatrix new.
+	m2 forSelector: #option2 addOptions: #(a b).
+	
+	m3 := m1 * m2.
+	
+	self assert: m3 equals: {
+		{ #option1 -> #a. #option2 -> #a }.
+		{ #option1 -> #a. #option2 -> #b }.
+		{ #option1 -> #b. #option2 -> #a }.
+		{ #option1 -> #b. #option2 -> #b }.
+	} asTestMatrix.
+]

--- a/src/ParametrizedTests/ParametrizedTestCase.class.st
+++ b/src/ParametrizedTests/ParametrizedTestCase.class.st
@@ -72,14 +72,9 @@ ParametrizedTestCase class >> testParameters [
 ]
 
 { #category : #private }
-ParametrizedTestCase >> cleanUpInstanceVariables [
-	| instanceVariablesNames |
+ParametrizedTestCase >> instanceVariablesToKeep [
 
-	instanceVariablesNames := #('testSelector' 'parametersToUse').
-	self class allInstVarNames
-		do: [ :name | 
-			(instanceVariablesNames includes: name)
-				ifFalse: [ self instVarNamed: name put: nil ] ]
+	^ super instanceVariablesToKeep, #('testSelector' 'parametersToUse')
 ]
 
 { #category : #accessing }

--- a/src/ParametrizedTests/ParametrizedTestExpandedParameter.class.st
+++ b/src/ParametrizedTests/ParametrizedTestExpandedParameter.class.st
@@ -13,6 +13,13 @@ Class {
 	#category : #'ParametrizedTests-Core'
 }
 
+{ #category : #accessing }
+ParametrizedTestExpandedParameter >> = anOption [
+
+	^ self selector = anOption selector
+		and: [ self valuable = anOption valuable ]
+]
+
 { #category : #applying }
 ParametrizedTestExpandedParameter >> applyTo: aTest [
 
@@ -22,6 +29,23 @@ ParametrizedTestExpandedParameter >> applyTo: aTest [
 		ifFalse: [ self valuable ].
 
 	aTest perform: selector asMutator with: anObject
+]
+
+{ #category : #converting }
+ParametrizedTestExpandedParameter >> asTestParameter [
+
+	^ self
+]
+
+{ #category : #accessing }
+ParametrizedTestExpandedParameter >> hash [
+
+	^ self selector hash + self valuable hash
+]
+
+{ #category : #accessing }
+ParametrizedTestExpandedParameter >> key [
+	self shouldBeImplemented.
 ]
 
 { #category : #printing }

--- a/src/ParametrizedTests/ParametrizedTestExpandedParameter.class.st
+++ b/src/ParametrizedTests/ParametrizedTestExpandedParameter.class.st
@@ -13,7 +13,7 @@ Class {
 	#category : #'ParametrizedTests-Core'
 }
 
-{ #category : #accessing }
+{ #category : #comparing }
 ParametrizedTestExpandedParameter >> = anOption [
 
 	^ self selector = anOption selector
@@ -37,7 +37,7 @@ ParametrizedTestExpandedParameter >> asTestParameter [
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : #comparing }
 ParametrizedTestExpandedParameter >> hash [
 
 	^ self selector hash + self valuable hash

--- a/src/ParametrizedTests/ParametrizedTestMatrix.class.st
+++ b/src/ParametrizedTests/ParametrizedTestMatrix.class.st
@@ -25,7 +25,7 @@ ParametrizedTestMatrix >> * aParametrizedTestMatrix [
 	^ newMatrix
 ]
 
-{ #category : #combination }
+{ #category : #comparing }
 ParametrizedTestMatrix >> = aMatrix [
 
 	^ self expandMatrix = aMatrix expandMatrix
@@ -81,7 +81,7 @@ ParametrizedTestMatrix >> forSelector: aSelector addOptions: someOptions [
 				yourself)
 ]
 
-{ #category : #combination }
+{ #category : #comparing }
 ParametrizedTestMatrix >> hash [
 
 	^ self expandMatrix hash

--- a/src/ParametrizedTests/ParametrizedTestMatrix.class.st
+++ b/src/ParametrizedTests/ParametrizedTestMatrix.class.st
@@ -14,18 +14,37 @@ Class {
 	#category : #'ParametrizedTests-Core'
 }
 
+{ #category : #combination }
+ParametrizedTestMatrix >> * aParametrizedTestMatrix [ 
+
+	| newMatrix |
+	newMatrix := ParametrizedTestMatrix new.
+	self expandMatrix do: [ :subcase1 |
+		aParametrizedTestMatrix asTestMatrix expandMatrix do: [ :subcase2 |
+			newMatrix addCase: subcase1, subcase2  ] ].
+	^ newMatrix
+]
+
+{ #category : #combination }
+ParametrizedTestMatrix >> = aMatrix [
+
+	^ self expandMatrix = aMatrix expandMatrix
+]
+
 { #category : #cases }
 ParametrizedTestMatrix >> addCase: aCollection [
 
-	cases add: (aCollection asDictionary associations
-		collect: [ :assoc | 
-			ParametrizedTestExpandedParameter new
-				selector: assoc key;
-				valuable: assoc value;
-				yourself ]
+	cases add: (aCollection
+		collect: [ :assoc | assoc asTestParameter ]
 		as: Array).
 		
 	^ self 
+]
+
+{ #category : #converting }
+ParametrizedTestMatrix >> asTestMatrix [
+
+	^ self
 ]
 
 { #category : #generating }
@@ -60,6 +79,12 @@ ParametrizedTestMatrix >> forSelector: aSelector addOptions: someOptions [
 				selector: aSelector;
 				values: someOptions;
 				yourself)
+]
+
+{ #category : #combination }
+ParametrizedTestMatrix >> hash [
+
+	^ self expandMatrix hash
 ]
 
 { #category : #initialization }

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -584,7 +584,7 @@ TestCase >> announcer [
 { #category : #private }
 TestCase >> cleanUpInstanceVariables [
 	self class allInstVarNames do: [ :name |
-		name = 'testSelector' ifFalse: [
+		(self instanceVariablesToKeep includes: name) ifFalse: [
 			self instVarNamed: name put: nil ] ]
 ]
 
@@ -637,6 +637,11 @@ TestCase >> failureLog [
 	^Transcript
 
 			
+]
+
+{ #category : #private }
+TestCase >> instanceVariablesToKeep [
+	^ #('testSelector')
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Integrating full blocks for real requires that we do a pass on the compiler tests.
The compiler tests are right now using the default compiler, thus they cannot test the full blocks.

This PR introduces:
 - more compiler tests
 - refactored compiler tests to configure the bytecode backend and optimizations
 - extending SUnit and Parametrized tests to allow combination/multiplication of test matrixes