### PR TITLE
Adding a variation of trait sequence composition that has preference for one of the members.

### DIFF
--- a/src/TraitsV2-Tests/T2PrecedenceCompositionTest.class.st
+++ b/src/TraitsV2-Tests/T2PrecedenceCompositionTest.class.st
@@ -1,0 +1,150 @@
+Class {
+	#name : #T2PrecedenceCompositionTest,
+	#superclass : #T2AbstractTest,
+	#category : #'TraitsV2-Tests-Tests'
+}
+
+{ #category : #tests }
+T2PrecedenceCompositionTest >> testClassCompositionOnPrecedenceKeepsPreference [
+
+	| t1 t2 original copy |
+
+	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 classTrait uses: {} slots: #().
+
+	t2 := self newTrait: #T2 with: #() uses: #().
+	t2 classTrait uses: {} slots: #().
+
+	t1 compile: 'm1 ^ 42'.
+	t2 compile: 'm1 ^ 33'.
+	
+	original := (t2 + t1) withPrecedenceOf: t2.
+	copy := original classComposition.
+	
+	self 
+		assert: original preferedTrait innerClass 
+		equals: copy preferedTrait innerClass instanceSide.
+
+]
+
+{ #category : #tests }
+T2PrecedenceCompositionTest >> testCopyingAPrecedenceKeepsPreference [
+
+	| t1 t2 original copy |
+
+	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 classTrait uses: {} slots: #().
+
+	t2 := self newTrait: #T2 with: #() uses: #().
+	t2 classTrait uses: {} slots: #().
+
+	t1 compile: 'm1 ^ 42'.
+	t2 compile: 'm1 ^ 33'.
+	
+	original := (t2 + t1) withPrecedenceOf: t2.
+	copy := original copyTraitExpression.
+	
+	self assert: original preferedTrait equals: copy preferedTrait
+
+]
+
+{ #category : #tests }
+T2PrecedenceCompositionTest >> testPrecedencesCanBeCombined [
+
+	| t1 t2 t3 c1 |
+
+	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 classTrait uses: {} slots: #().
+
+	t2 := self newTrait: #T2 with: #() uses: #().
+	t2 classTrait uses: {} slots: #().
+
+	t3 := self newTrait: #T3 with: #() uses: #().
+	t3 classTrait uses: {} slots: #().
+
+	t1 compile: 'm1 ^ 42'.
+	t2 compile: 'm1 ^ 33'.
+
+	t3 compile: 'm2 ^ 11'.
+
+	c1 := self newClass: #C1 with: #() uses: (((t2 + t1) withPrecedenceOf: t2) + t3).
+	
+	self assert: (c1 new m1) equals: 33.	
+	self assert: (c1 new m2) equals: 11.
+]
+
+{ #category : #tests }
+T2PrecedenceCompositionTest >> testWithPrecedenceIsNonAConflict [
+
+	| t1 t2 c1 |
+
+	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 classTrait uses: {} slots: #().
+
+	t2 := self newTrait: #T2 with: #() uses: #().
+	t2 classTrait uses: {} slots: #().
+
+	t1 compile: 'm1 ^ 42'.
+	t2 compile: 'm1 ^ 33'.
+	
+	c1 := self newClass: #C1 with: #() uses: ((t1 + t2) withPrecedenceOf: t2).
+
+	self deny: (c1 >> #m1) isConflict
+]
+
+{ #category : #tests }
+T2PrecedenceCompositionTest >> testWithPrecedenceUsesThePreferedOne [
+
+	| t1 t2 c1 |
+
+	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 classTrait uses: {} slots: #().
+
+	t2 := self newTrait: #T2 with: #() uses: #().
+	t2 classTrait uses: {} slots: #().
+
+	t1 compile: 'm1 ^ 42'.
+	t2 compile: 'm1 ^ 33'.
+	
+	c1 := self newClass: #C1 with: #() uses: ((t1 + t2) withPrecedenceOf: t2).
+
+	self assert: (c1 new m1) equals: 33.
+]
+
+{ #category : #tests }
+T2PrecedenceCompositionTest >> testWithPrecedenceUsesThePreferedOneWithoutCaringOrderOfSequence [
+
+	| t1 t2 c1 |
+
+	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 classTrait uses: {} slots: #().
+
+	t2 := self newTrait: #T2 with: #() uses: #().
+	t2 classTrait uses: {} slots: #().
+
+	t1 compile: 'm1 ^ 42'.
+	t2 compile: 'm1 ^ 33'.
+	
+	c1 := self newClass: #C1 with: #() uses: ((t2 + t1) withPrecedenceOf: t2).
+
+	self assert: (c1 new m1) equals: 33.
+]
+
+{ #category : #tests }
+T2PrecedenceCompositionTest >> testWithoutPrecedenceIsAConflict [
+
+	| t1 t2 c1 |
+
+	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 classTrait uses: {} slots: #().
+
+	t2 := self newTrait: #T2 with: #() uses: #().
+	t2 classTrait uses: {} slots: #().
+
+	t1 compile: 'm1 ^ 42'.
+	t2 compile: 'm1 ^ 33'.
+	
+	c1 := self newClass: #C1 with: #() uses: t1 + t2.
+
+	self assert: (c1 >> #m1) isConflict
+]

--- a/src/TraitsV2-Tests/T2PrecedenceCompositionTest.class.st
+++ b/src/TraitsV2-Tests/T2PrecedenceCompositionTest.class.st
@@ -49,6 +49,68 @@ T2PrecedenceCompositionTest >> testCopyingAPrecedenceKeepsPreference [
 ]
 
 { #category : #tests }
+T2PrecedenceCompositionTest >> testPrecedencesAreGeneratedInClassDefinition [
+	| t1 t2 t3 c1 |
+	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 classTrait uses: {} slots: #().
+
+	t2 := self newTrait: #T2 with: #() uses: #().
+	t2 classTrait uses: {} slots: #().
+
+	t3 := self newTrait: #T3 with: #() uses: #().
+	t3 classTrait uses: {} slots: #().
+
+	t1 compile: 'm1 ^ 42'.
+	t2 compile: 'm1 ^ 33'.
+	t3 compile: 'm2 ^ 11'.
+
+	c1 := self
+		newClass: #C1
+		with: #()
+		uses: (t2 + t1 + t3 withPrecedenceOf: t2).
+
+	self
+		assert: c1 definition
+		equals:
+			'Object subclass: #C1
+	uses: (T2 + T1 + T3 withPrecedenceOf: T2)
+	instanceVariableNames: ''''
+	classVariableNames: ''''
+	package: ''TraitsV2-Tests-TestClasses'''
+]
+
+{ #category : #tests }
+T2PrecedenceCompositionTest >> testPrecedencesAreGeneratedInClassDefinitionWithAlias [
+	| t1 t2 t3 c1 |
+	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 classTrait uses: {} slots: #().
+
+	t2 := self newTrait: #T2 with: #() uses: #().
+	t2 classTrait uses: {} slots: #().
+
+	t3 := self newTrait: #T3 with: #() uses: #().
+	t3 classTrait uses: {} slots: #().
+
+	t1 compile: 'm1 ^ 42'.
+	t2 compile: 'm1 ^ 33'.
+	t3 compile: 'm2 ^ 11'.
+
+	c1 := self
+		newClass: #C1
+		with: #()
+		uses: (t2 + (t1 -- #aSlot) + t3 withPrecedenceOf: t2).
+
+	self
+		assert: c1 definition
+		equals:
+			'Object subclass: #C1
+	uses: (T2 + (T1 -- #aSlot) + T3 withPrecedenceOf: T2)
+	instanceVariableNames: ''''
+	classVariableNames: ''''
+	package: ''TraitsV2-Tests-TestClasses'''
+]
+
+{ #category : #tests }
 T2PrecedenceCompositionTest >> testPrecedencesCanBeCombined [
 
 	| t1 t2 t3 c1 |

--- a/src/TraitsV2/TaPrecedenceComposition.class.st
+++ b/src/TraitsV2/TaPrecedenceComposition.class.st
@@ -1,0 +1,67 @@
+Class {
+	#name : #TaPrecedenceComposition,
+	#superclass : #TaSequence,
+	#instVars : [
+		'preferedTrait'
+	],
+	#category : #'TraitsV2-Compositions'
+}
+
+{ #category : #accessing }
+TaPrecedenceComposition >> classComposition [
+	^ (self class withAll: (members collect:#classComposition))
+		preferedTrait: preferedTrait classComposition;
+		yourself
+]
+
+{ #category : #accessing }
+TaPrecedenceComposition >> copyTraitExpression [
+
+	^ (self class withAll: (members collect:#copyTraitExpression))
+		preferedTrait: preferedTrait copyTraitExpression;
+		yourself
+]
+
+{ #category : #accessing }
+TaPrecedenceComposition >> copyWithoutTrait: aTrait [
+	| newMembers |
+
+	newMembers := members collect: [ :e | e copyWithoutTrait: aTrait ] thenReject: #isEmpty.
+
+	^ (self class withAll: newMembers)
+		preferedTrait: (preferedTrait copyWithoutTrait: aTrait);
+		yourself
+	
+
+]
+
+{ #category : #testing }
+TaPrecedenceComposition >> isConflictingSelector: aSelector [
+
+	"If the method is in the preferedTrait it is not a conflict"
+	
+	(preferedTrait methods anySatisfy: [ :each | each selector = aSelector and: [ each isRequired not ] ])
+		ifTrue: [ ^ false ].
+		
+	^ super isConflictingSelector: aSelector.
+]
+
+{ #category : #accessing }
+TaPrecedenceComposition >> memberForSelector: aSelector [
+
+	"I look first in the prefered trait if not in the other member"
+	((preferedTrait selectors includes: aSelector) and: [ (preferedTrait compiledMethodAt: aSelector) isRequired not ]) ifTrue: [ ^ preferedTrait ].
+	
+	^ super memberForSelector: aSelector.
+
+]
+
+{ #category : #accessing }
+TaPrecedenceComposition >> preferedTrait [
+	^ preferedTrait
+]
+
+{ #category : #accessing }
+TaPrecedenceComposition >> preferedTrait: anObject [
+	preferedTrait := anObject
+]

--- a/src/TraitsV2/TaPrecedenceComposition.class.st
+++ b/src/TraitsV2/TaPrecedenceComposition.class.st
@@ -65,3 +65,9 @@ TaPrecedenceComposition >> preferedTrait [
 TaPrecedenceComposition >> preferedTrait: anObject [
 	preferedTrait := anObject
 ]
+
+{ #category : #accessing }
+TaPrecedenceComposition >> traitCompositionExpression [
+		
+	^  '(' , (super traitCompositionExpression) , ' withPrecedenceOf: ' , preferedTrait traitCompositionExpression , ')'
+]

--- a/src/TraitsV2/TaSequence.class.st
+++ b/src/TraitsV2/TaSequence.class.st
@@ -319,6 +319,20 @@ TaSequence >> validateSlots: anElement [
 						ifTrue: [ self error: 'The added trait duplicates an existing slot ' , e name printString ] ] ]
 ]
 
+{ #category : #precedence }
+TaSequence >> withPrecedenceOf: aTrait [ 
+	
+	| aTraitComposition |
+	aTraitComposition := aTrait asTraitComposition.
+	
+	(members includes: aTraitComposition)
+		ifFalse: [ self error: 'A trait cannot be marked with precedence if it is not in the sequence' ].
+		
+	^ (TaPrecedenceComposition withAll: members)
+			preferedTrait: aTraitComposition;
+			yourself
+]
+
 { #category : #operations }
 TaSequence >> without: aTrait [
 	| newMembers |


### PR DESCRIPTION
This preferred sequence is valid as it implements the same semantics than removing the methods duplicated before:

Let's think T2 defines #m1 and #m2.

(T1 + T2) withPrecedenceOf: T2 ==> 
(T1 - {#m1. #m2}) + T2