### PR TITLE
Add option to rename parameters when extract a method

### DIFF
--- a/src/NautilusRefactoring/NautilusRefactoring.class.st
+++ b/src/NautilusRefactoring/NautilusRefactoring.class.st
@@ -346,6 +346,14 @@ NautilusRefactoring >> handleMethodNameRequest: aMethodName [
 ]
 
 { #category : #display }
+NautilusRefactoring >> handleMethodNameRequest: aMethodName in: ref [
+	|dialog|
+	dialog := SycMethodNameEditor openOn: aMethodName withRefactoring: ref.
+	dialog cancelled ifTrue: [  CmdCommandAborted signal ].
+	^ aMethodName
+]
+
+{ #category : #display }
 NautilusRefactoring >> handleWarning: anException [
 	self inform: anException messageText.
 	anException resume
@@ -1063,7 +1071,7 @@ NautilusRefactoring >> refactoringOptions: aRefactoring [
 		setOption: #implementorToInline
 		toUse: [ :ref :imps | self requestImplementorToInline: imps ];
 		setOption: #methodName
-		toUse: [ :ref :name | self requestMethodNameFor: name ];
+		toUse: [ :ref :name | self requestMethodNameFor: name in: ref ];
 		setOption: #selfArgumentName
 		toUse: [ :ref | self requestSelfArgumentName ];
 		setOption: #selectVariableToMoveTo
@@ -1230,6 +1238,11 @@ NautilusRefactoring >> requestImplementorToInline: imps [
 { #category : #display }
 NautilusRefactoring >> requestMethodNameFor: aMethodName [
 	^ self handleMethodNameRequest: aMethodName
+]
+
+{ #category : #requests }
+NautilusRefactoring >> requestMethodNameFor: aMethodName in: ref [
+	^ self handleMethodNameRequest: aMethodName in: ref
 ]
 
 { #category : #option }

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -15,7 +15,9 @@ Class {
 		'extractedParseTree',
 		'modifiedParseTree',
 		'parameters',
-		'needsReturn'
+		'needsReturn',
+		'selectorNewMethod',
+		'parameterMap'
 	],
 	#category : #'Refactoring-Core-Refactorings'
 }
@@ -52,11 +54,9 @@ RBExtractMethodRefactoring >> checkAssignments: variableNames [
 			[self refactoringError: 'Cannot extract assignment without all references.'].
 	removeAssigned removeAll: outsideVars.
 	(RBReadBeforeWrittenTester readBeforeWritten: removeAssigned
-		in: extractedParseTree) isEmpty 
-		ifFalse: 
+		in: extractedParseTree) ifNotEmpty: 
 			[self refactoringError: 'Cannot extract assignment if read before written.'].
-	removeAssigned 
-		do: [:each | (node whoDefines: each) removeTemporaryNamed: each].
+	removeAssigned do: [:each | (node whoDefines: each) removeTemporaryNamed: each].
 	self createTemporariesInExtractedMethodFor: variableNames
 ]
 
@@ -100,15 +100,13 @@ RBExtractMethodRefactoring >> checkSingleAssignment: varName [
 
 { #category : #transforming }
 RBExtractMethodRefactoring >> checkSpecialExtractions [
-
 	| node |
-
 	node := self placeholderNode parent.
-	node ifNil: [ ^ self ].
-	( node isAssignment and: [ node variable = self placeholderNode ] )
-		ifTrue: [ self refactoringFailure: 'Cannot extract left hand side of an assignment' ].
-	node isCascade
-		ifTrue: [ self refactoringError: 'Cannot extract first message of a cascaded message' ]
+	node ifNil: [^self].
+	(node isAssignment and: [node variable = self placeholderNode]) ifTrue: 
+			[self refactoringFailure: 'Cannot extract left hand side of an assignment'].
+	node isCascade ifTrue: 
+			[self refactoringError: 'Cannot extract first message of a cascaded message']
 ]
 
 { #category : #transforming }
@@ -117,7 +115,7 @@ RBExtractMethodRefactoring >> checkTemporaries [
 	temps := self remainingTemporaries.
 	accesses := temps select: [:each | extractedParseTree references: each].
 	assigned := accesses select: [:each | extractedParseTree assigns: each].
-	assigned isEmpty ifFalse: [self checkAssignments: assigned].
+	assigned ifNotEmpty: [self checkAssignments: assigned].
 	^parameters := (accesses asOrderedCollection)
 				removeAll: assigned;
 				yourself
@@ -145,72 +143,68 @@ RBExtractMethodRefactoring >> extract: anInterval from: aSelector in: aClass [
 
 { #category : #transforming }
 RBExtractMethodRefactoring >> extractMethod [
-
 	| parseTree isSequence extractCode subtree newCode errorMessage |
-
 	extractCode := self getExtractedSource.
 	extractedParseTree := RBParser
 		parseExpression: extractCode
 		onError: [ :string :pos :parser | 
 			errorMessage := string.
-			parser parseErrorNode: string
-			].
+			parser parseErrorNode: string ].
 	extractedParseTree ifNil: [ self refactoringFailure: 'Invalid source to extract' ].
 	extractedParseTree isFaulty
-		ifTrue: [ self refactoringFailure: 'Invalid source to extract - ' , errorMessage ].
-	( extractedParseTree isSequence and: [ extractedParseTree statements isEmpty ] )
+		ifTrue: [ self
+				refactoringFailure: 'Invalid source to extract - ' , errorMessage ].
+	(extractedParseTree isSequence
+		and: [ extractedParseTree statements isEmpty ])
 		ifTrue: [ self refactoringError: 'Select some code to extract' ].
-	isSequence := extractedParseTree isSequence or: [ extractedParseTree isReturn ].
+	isSequence := extractedParseTree isSequence
+		or: [ extractedParseTree isReturn ].
 	extractedParseTree := RBMethodNode
 		selector: #value
 		arguments: #()
 		body:
-			( extractedParseTree isSequence
+			(extractedParseTree isSequence
 				ifTrue: [ extractedParseTree ]
-				ifFalse:
-					[ RBSequenceNode temporaries: #() statements: ( OrderedCollection with: extractedParseTree ) ] ).
-	extractedParseTree body temporaries isEmpty not
-		ifTrue: [ extractedParseTree body temporaries: #() ].
+				ifFalse: [ RBSequenceNode
+						temporaries: #()
+						statements: (OrderedCollection with: extractedParseTree) ]).
+	extractedParseTree body temporaries ifNotEmpty: [ extractedParseTree body temporaries: #() ].
 	extractedParseTree source: extractCode.
 	parseTree := class parseTreeFor: selector.
 	parseTree ifNil: [ self refactoringFailure: 'Could not parse ' , selector printString ].
 	subtree := isSequence
 		ifTrue: [ self parseTreeSearcherClass
 				treeMatchingStatements: extractedParseTree body formattedCode
-				in: parseTree
-			]
+				in: parseTree ]
 		ifFalse: [ self parseTreeSearcherClass treeMatching: extractCode in: parseTree ].
 	subtree ifNil: [ self refactoringFailure: 'Could not extract code from method' ].
 	newCode := self methodDelimiter.
 	isSequence
 		ifTrue: [ | stmts |
-
 			stmts := extractedParseTree body statements.
-			stmts isEmpty
-				ifFalse: [ stmts last isAssignment
+			stmts ifNotEmpty: [ stmts last isAssignment
 						ifTrue: [ | name |
-
 							name := stmts last variable name.
-							( self shouldExtractAssignmentTo: name )
+							(self shouldExtractAssignmentTo: name)
 								ifFalse: [ newCode := '<1s> := <2s>' expandMacrosWith: name with: newCode.
-									stmts at: stmts size put: stmts last value
-									]
-							]
-					]
-			].
+									stmts at: stmts size put: stmts last value ] ] ] ].
+					
 	modifiedParseTree := isSequence
 		ifTrue: [ RBParseTreeRewriter
 				replaceStatements: subtree formattedCode
 				with: newCode
 				in: parseTree
-				onInterval: extractionInterval
-			]
+				onInterval: extractionInterval ]
 		ifFalse: [ RBParseTreeRewriter
 				replace: subtree formattedCode
 				with: newCode
 				in: parseTree
-				onInterval: extractionInterval
-			]
+				onInterval: extractionInterval ]
+]
+
+{ #category : #accessing }
+RBExtractMethodRefactoring >> extractedParseTree [
+	^ extractedParseTree
 ]
 
 { #category : #transforming }
@@ -225,62 +219,56 @@ RBExtractMethodRefactoring >> getExtractedSource [
 
 { #category : #transforming }
 RBExtractMethodRefactoring >> getNewMethodName [
-
 	| newSelector methodName newMethodName |
-
 	methodName := RBMethodName new.
 	methodName arguments: parameters.
-
-	[ newMethodName := self requestMethodNameFor: methodName.
-	newMethodName ifNil: [ self refactoringFailure: 'Did not extract code' ].
+	
+	[newMethodName := self requestMethodNameFor: methodName.
+	newMethodName ifNil: [self refactoringFailure: 'Did not extract code'].
 	newSelector := newMethodName selector.
-	( self checkMethodName: newSelector in: class )
-		ifFalse: [ self refactoringWarning: newSelector , ' is not a valid selector name.'.
-			newSelector := nil
-			].
-	( class hierarchyDefinesMethod: newSelector asSymbol )
-		ifTrue: [ ( self shouldOverride: newSelector in: class )
-				ifFalse: [ newSelector := nil ]
-			].
-	newSelector isNil
-	] whileTrue: [  ].
+	(self checkMethodName: newSelector in: class) 
+		ifFalse: 
+			[self refactoringWarning: newSelector , ' is not a valid selector name.'.
+			newSelector := nil].
+	(class hierarchyDefinesMethod: newSelector asSymbol) 
+		ifTrue: 
+			[(self shouldOverride: newSelector in: class) ifFalse: [ newSelector := nil ]].
+	newSelector isNil] 
+			whileTrue: [].
 	parameters := newMethodName arguments asOrderedCollection.
-	^ newSelector asSymbol
+	^newSelector asSymbol
 ]
 
 { #category : #transforming }
 RBExtractMethodRefactoring >> isMethodEquivalentTo: aSelector [ 
+	
 	selector == aSelector ifTrue: [^false].
+	
 	aSelector numArgs ~~ parameters size ifTrue: [^false].
+	
 	(self isParseTreeEquivalentTo: aSelector) ifFalse: [^false].
 	self reorderParametersToMatch: aSelector.
 	^true
 ]
 
 { #category : #transforming }
-RBExtractMethodRefactoring >> isParseTreeEquivalentTo: aSelector [
-
+RBExtractMethodRefactoring >> isParseTreeEquivalentTo: aSelector [ 
 	| tree definingClass |
-
 	definingClass := class whoDefinesMethod: aSelector.
 	tree := definingClass parseTreeFor: aSelector.
-	tree ifNil: [ ^ false ].
-	tree isPrimitive
-		ifTrue: [ ^ false ].
-	( tree body
-		equalTo: extractedParseTree body
-		exceptForVariables: ( tree arguments collect: [ :each | each name ] ) )
-		ifFalse: [ ^ false ].
-	( definingClass = class
-		or: [ ( tree superMessages
-				detect: [ :each | 
-					( class superclass whichClassIncludesSelector: aSelector )
-						~= ( definingClass superclass whichClassIncludesSelector: each )
-					]
-				ifNone: [ nil ] ) isNil
-			] )
-		ifFalse: [ ^ false ].
-	^ self shouldUseExistingMethod: aSelector
+	tree ifNil: [^false].
+	tree isPrimitive ifTrue: [^false].
+	(tree body equalTo: extractedParseTree body
+		exceptForVariables: (tree arguments collect: [:each | each name])) 
+			ifFalse: [^false].
+	(definingClass = class or: 
+			[(tree superMessages detect: 
+					[:each | 
+					(class superclass whichClassIncludesSelector: aSelector) 
+						~= (definingClass superclass whichClassIncludesSelector: each)]
+				ifNone: [nil]) isNil]) 
+		ifFalse: [^false].
+	^self shouldUseExistingMethod: aSelector
 ]
 
 { #category : #transforming }
@@ -310,12 +298,27 @@ RBExtractMethodRefactoring >> nameNewMethod: aSymbol [
 	modifiedParseTree := RBParseTreeRewriter replace: self methodDelimiter with: newSend in: modifiedParseTree
 ]
 
+{ #category : #accessing }
+RBExtractMethodRefactoring >> parameterMap [
+	^ parameterMap
+]
+
+{ #category : #accessing }
+RBExtractMethodRefactoring >> parameterMap: aDictionary [
+	parameterMap := aDictionary 
+]
+
+{ #category : #transforming }
+RBExtractMethodRefactoring >> parameters: anOrderedCollection [
+	parameters := anOrderedCollection 
+]
+
 { #category : #transforming }
 RBExtractMethodRefactoring >> placeholderNode [
-
 	| node |
-
-	node := self parseTreeSearcherClass treeMatching: self methodDelimiter in: modifiedParseTree.
+	node := self parseTreeSearcherClass
+		treeMatching: self methodDelimiter
+		in: modifiedParseTree.
 	node ifNil: [ self refactoringFailure: 'Cannot extract code' ].
 	^ node
 ]
@@ -342,6 +345,25 @@ RBExtractMethodRefactoring >> remainingTemporaries [
 ]
 
 { #category : #transforming }
+RBExtractMethodRefactoring >> renameAllParameters [
+	parameterMap ifNotNil: [
+		parameterMap keysAndValuesDo: [ :key : value | 
+			key ~= value ifTrue: [ self renameParameterWith: key to: value ]]
+	]
+]
+
+{ #category : #renaming }
+RBExtractMethodRefactoring >> renameNode: aParseTree withOldName: oldName toWithName: newName [ 
+	(RBParseTreeRewriter rename: oldName to: newName) executeTree: aParseTree
+]
+
+{ #category : #renaming }
+RBExtractMethodRefactoring >> renameParameterWith: oldName to: newName [
+	self renameNode: extractedParseTree withOldName: oldName toWithName: newName.
+	
+]
+
+{ #category : #transforming }
 RBExtractMethodRefactoring >> reorderParametersToMatch: aSelector [ 
 	| tree dictionary |
 	tree := class parseTreeFor: aSelector.
@@ -353,6 +375,16 @@ RBExtractMethodRefactoring >> reorderParametersToMatch: aSelector [
 						ifAbsent: 
 							[self 
 								refactoringFailure: 'An internal error occured, please report this error.']]
+]
+
+{ #category : #transforming }
+RBExtractMethodRefactoring >> requestExistingSelector [ 
+	^(self options at: #existingSelector) value: self
+]
+
+{ #category : #accessing }
+RBExtractMethodRefactoring >> selectorNewMethod: anObject [
+	selectorNewMethod := anObject 
 ]
 
 { #category : #printing }
@@ -371,13 +403,39 @@ RBExtractMethodRefactoring >> storeOn: aStream [
 
 { #category : #transforming }
 RBExtractMethodRefactoring >> transform [
-
 	| existingSelector |
-
 	existingSelector := self existingSelector.
-	self
-		nameNewMethod: ( existingSelector ifNil: [ self getNewMethodName ] ifNotNil: [ existingSelector ] ).
-	existingSelector
-		ifNil: [ class compile: extractedParseTree newSource withAttributesFrom: ( class methodFor: selector ) ].
+	self nameNewMethod: (existingSelector ifNil: [
+	selectorNewMethod ifNil: [ self getNewMethodName]]
+				ifNotNil: [existingSelector]).
+	existingSelector ifNil: 
+			[ self renameAllParameters.
+			class compile: extractedParseTree newSource
+				withAttributesFrom: (class methodFor: selector)].
 	class compileTree: modifiedParseTree
+]
+
+{ #category : #renaming }
+RBExtractMethodRefactoring >> validateRenameNode: aParseTree withOldName: oldName toWithName: newName [ 
+	|conditions block|
+	conditions := ((RBCondition isValidInstanceVariableName: newName for: class)
+		& (RBCondition definesSelector: selector in: class)
+		& (RBCondition definesInstanceVariable: newName in: class) not 
+		& (RBCondition definesClassVariable: newName in: class) not).
+	conditions check
+		ifFalse: [ block := conditions errorBlock.
+			block
+				ifNotNil: [ self refactoringError: conditions errorString with: block ]
+				ifNil: [ self refactoringError: conditions errorString ] ].
+	(parameterMap values includes: newName) ifTrue: [
+		self refactoringError: newName asString , ' is already defined as parameter' ].
+	(aParseTree whoDefines: newName)
+		ifNotNil: [ self refactoringError: newName asString , ' is already defined' ].
+	(aParseTree allDefinedVariables includes: newName)
+		ifTrue: [ self refactoringError: newName asString , ' is already defined' ]
+]
+
+{ #category : #renaming }
+RBExtractMethodRefactoring >> validateRenameOf: oldName to: newName [
+	self validateRenameNode: extractedParseTree withOldName: oldName toWithName: newName 
 ]

--- a/src/Refactoring-Tests-Core/RBExtractMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBExtractMethodTest.class.st
@@ -131,6 +131,30 @@ RBExtractMethodTest >> testExtractMethodThatNeedsTemporaryVariable [
 ]
 
 { #category : #tests }
+RBExtractMethodTest >> testExtractWithRenamingOfParameters [
+	| refactoring class|
+	refactoring := RBExtractMethodRefactoring
+		extract: (78 to: 197)
+		from: #displayName
+		in: RBLintRuleTestData.
+	self setupMethodNameFor: refactoring toReturn: #foo:.
+	refactoring parameterMap: (Dictionary new at: #nameStream put: #newParameter; yourself ).
+	self executeRefactoring: refactoring.
+	class := refactoring model classNamed: #RBLintRuleTestData.
+
+ 	self assert: (class parseTreeFor: #displayName) = (self parseMethod: 'displayName
+	| nameStream |
+	nameStream := WriteStream on: (String new: 64).
+	self foo: nameStream.
+	^nameStream contents').
+	"Extracted method with renamed parameters"
+	self assert: (class parseTreeFor: #foo:) = (self parseMethod: 'foo: newParameter 	newParameter nextPutAll: self name;
+		nextPutAll: '' (''.
+	self problemCount printOn: newParameter.
+	newParameter nextPut: $).')
+]
+
+{ #category : #tests }
 RBExtractMethodTest >> testModelExtractMethodWithTemporariesSelected [
 	| class refactoring |
 	model := RBClassModelFactory rbNamespace new.
@@ -180,4 +204,21 @@ RBExtractMethodTest >> testNonExistantSelector [
 			extract: (10 to: 20)
 			from: #checkClass1:
 			in: RBBasicLintRuleTestData)
+]
+
+{ #category : #tests }
+RBExtractMethodTest >> testValidateRenameParameters [
+	| refactoring |
+	refactoring := RBExtractMethodRefactoring
+		extract: (78 to: 197)
+		from: #displayName
+		in: RBLintRuleTestData.
+	self setupMethodNameFor: refactoring toReturn: #foo:.
+	refactoring parameterMap: (Dictionary new at: #nameStream put: #nameStream; yourself ).
+	"Fail when use instance variables as new parameters"
+	self should: [ refactoring validateRenameOf: #nameStream to: #name ] raise: RBRefactoringError.	
+	self should: [refactoring validateRenameOf: #nameStream to: #foo1] raise: RBRefactoringError.
+	"Fail when use class variables as new parameters"
+	self should: [refactoring validateRenameOf: #nameStream to: #Foo1] raise: RBRefactoringError.
+	"Fail when use temporary variables as new parameters"
 ]

--- a/src/SystemCommands-RefactoringSupport/SycMethodNameEditor.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycMethodNameEditor.class.st
@@ -37,10 +37,59 @@ Class {
 		'previewResult',
 		'upButton',
 		'downButton',
-		'methodName'
+		'methodName',
+		'editParameter',
+		'okEdit',
+		'editerArgumentList',
+		'refactoring',
+		'isEditable'
 	],
 	#category : #'SystemCommands-RefactoringSupport'
 }
+
+{ #category : #specs }
+SycMethodNameEditor class >> defaultEditableSpec [
+	<spec>
+	^ SpBoxLayout newVertical
+		add:
+			(SpBoxLayout newHorizontal
+				add: 'Selector'
+					withConstraints: [ :aConstraints | aConstraints width: 80 ];
+				add: #selectorInput;
+				yourself);
+		add:
+			(SpBoxLayout newHorizontal
+				add: 'Arguments'
+					withConstraints: [ :aConstraints | aConstraints width: 80 ];
+				add: #argumentsList;
+				add:
+					(SpBoxLayout newVertical
+						add: #upButton
+							withConstraints: [ :aConstraints | aConstraints height: 30 ];
+						add: #downButton
+							withConstraints: [ :aConstraints | aConstraints height: 30 ];
+						yourself)
+					withConstraints: [ :aConstraints | aConstraints width: 30 ];
+				yourself);
+		add:
+			(SpBoxLayout newHorizontal
+				add: 'Edit'
+					withConstraints: [ :aConstraints | aConstraints width: 80 ];
+				add: #editParameter; 
+				add:
+					(SpBoxLayout newVertical
+						add: #okEdit
+							withConstraints: [ :aConstraints | aConstraints height: 20 ];
+						yourself)
+					withConstraints: [ :aConstraints | aConstraints width: 30 ];
+				yourself);
+		add:
+			(SpBoxLayout newHorizontal
+				add: 'Preview'
+					withConstraints: [ :aConstraints | aConstraints width: 80 ];
+				add: #previewResult yourself);
+		yourself
+]
 
 { #category : #specs }
 SycMethodNameEditor class >> defaultSpec [
@@ -73,10 +122,42 @@ SycMethodNameEditor class >> defaultSpec [
 		yourself
 ]
 
+{ #category : #example }
+SycMethodNameEditor class >> example2 [
+	<script>
+	self
+		openOn:
+			(RBMethodName
+				selector: (RBExtractMethodRefactoring >> #validateRenameOf:to:) selector
+				arguments: ((RBExtractMethodRefactoring >> #validateRenameOf:to:) ast arguments collect: #name))
+]
+
 { #category : #specs }
 SycMethodNameEditor class >> openOn: aMethod [
 	"I take a RBMethodName as parameter and open the refactoring UI in a modal to rename it."
-	^ (self on: aMethod) openModalWithSpec
+	|temp|
+	temp := (self on: aMethod).
+	temp isEditable: false.
+	temp initializeEditerArgumentList.
+	^ temp openModalWithSpec
+]
+
+{ #category : #specs }
+SycMethodNameEditor class >> openOn: aMethod withRefactoring: refactoring [
+	|temp|
+	temp := (self on: aMethod).
+	temp refactoring: refactoring.
+	temp isEditable: true.
+	temp initializeEditerArgumentList.
+	^ temp openModalWithSpec
+]
+
+{ #category : #services }
+SycMethodNameEditor >> alert: aString [
+	"Display a message for the user to read and then dismiss."
+
+	aString isEmptyOrNil
+		ifFalse: [ UIManager default alert: aString ]
 ]
 
 { #category : #accessing }
@@ -89,17 +170,48 @@ SycMethodNameEditor >> downButton [
 	^ downButton
 ]
 
+{ #category : #services }
+SycMethodNameEditor >> editParameter [
+	| selected newName|
+	newName := editParameter text asSymbol.
+	selected := argumentsList items at: (argumentsList selection selectedIndex).
+	newName = selected ifTrue: [ ^ self ].
+	refactoring parameterMap: editerArgumentList;
+		   		   validateRenameOf: selected to: newName.
+	editerArgumentList at: (self getKeyOf: selected) put: newName.
+	self updateItem: selected to: newName.
+	self updateLabel
+]
+
+{ #category : #services }
+SycMethodNameEditor >> getKeyOf: aValue [
+	|keyOfValue|
+	editerArgumentList keysAndValuesDo: [ :key :value | 
+		aValue = value ifTrue: [ keyOfValue := key ] ].
+	^ keyOfValue
+]
+
+{ #category : #services }
+SycMethodNameEditor >> getParametersOrder [
+	^ argumentsList items collect: [ :each | self getKeyOf: each ]
+	
+]
+
 { #category : #initialization }
 SycMethodNameEditor >> initializeDialogWindow: aModalPresenter [
 	aModalPresenter
 		closeOnBackdropClick: true;
 		addButton: 'Rename' do: [ :presenter | self renameMethodAndClose: presenter ];
-		addButton: 'Cancel' do: [ :presenter | 
-			presenter
-				beCancel;
-				close ];
-		initialExtent: 600 @ 300;
+		addButton: 'Cancel' do: [ :presenter | presenter beCancel; close ];
+		initialExtent: 600 @ 300 ;
 		title: 'Method name editor'
+]
+
+{ #category : #services }
+SycMethodNameEditor >> initializeEditerArgumentList [
+	editerArgumentList := Dictionary new.
+	methodName arguments do: [ :each | 
+		editerArgumentList at: each put: each ]
 ]
 
 { #category : #initialization }
@@ -115,7 +227,12 @@ SycMethodNameEditor >> initializePresenter [
 				ifEmpty: [ upButton disable.
 					downButton disable ] ].
 
-	argumentsList items: methodName arguments
+	argumentsList items: methodName arguments.
+	self updateEditTemp.
+	
+	argumentsList whenSelectionChangedDo: [ self updateEditTemp ].
+	okEdit action: [ self validateEditParameter ]
+
 ]
 
 { #category : #initialization }
@@ -130,7 +247,26 @@ SycMethodNameEditor >> initializeWidgets [
 	upButton label: 'Up'.
 	downButton label: 'Dn'.
 	selectorInput text: methodName selector.
-	previewResult label: methodName methodName
+	previewResult label: methodName methodName.
+	editParameter := (self instantiate: SpTextInputFieldPresenter) autoAccept: true.
+	okEdit := self newButton.
+	
+	okEdit label: 'Ok'
+	
+]
+
+{ #category : #accessing }
+SycMethodNameEditor >> isEditable: aBoolean [ 
+	isEditable := aBoolean .
+	
+	isEditable ifTrue: [ self buildWithSpecLayout: self class defaultEditableSpec ]
+	ifFalse: [ self buildWithSpecLayout: self class defaultSpec ]
+	
+]
+
+{ #category : #services }
+SycMethodNameEditor >> okEdit [
+	^ okEdit
 ]
 
 { #category : #accessing }
@@ -160,12 +296,24 @@ SycMethodNameEditor >> pushUpSelectedArgument [
 	self updateLabel
 ]
 
+{ #category : #services }
+SycMethodNameEditor >> refactoring [
+	^ refactoring
+]
+
+{ #category : #services }
+SycMethodNameEditor >> refactoring: anObject [
+	refactoring := anObject 
+]
+
 { #category : #action }
 SycMethodNameEditor >> renameMethodAndClose: presenter [
 	^ self previewResult label = '(invalid)'
 		ifTrue: [ self inform: 'Invalid method name' ]
-		ifFalse: [ methodName
-				arguments: argumentsList items;
+		ifFalse: [
+			refactoring ifNotNil: [ refactoring parameterMap: editerArgumentList].
+			methodName
+				arguments: self getParametersOrder;
 				selector: selectorInput text.
 			presenter
 				beOk;
@@ -187,6 +335,20 @@ SycMethodNameEditor >> upButton [
 	^ upButton
 ]
 
+{ #category : #services }
+SycMethodNameEditor >> updateEditTemp [
+	| selectedIndex |
+	selectedIndex := argumentsList selection selectedIndex.
+	selectedIndex = 0 ifFalse: [ 
+	editParameter text: (argumentsList items at: selectedIndex)]
+]
+
+{ #category : #services }
+SycMethodNameEditor >> updateItem: selected to: newName [
+	argumentsList items doWithIndex: [ :each :index | 
+		each = selected ifTrue: [ argumentsList items at: index put: newName  ] ]
+]
+
 { #category : #action }
 SycMethodNameEditor >> updateLabel [
 	"Update the new method name to display to the user when the user change its name or order of the arguments."
@@ -195,5 +357,15 @@ SycMethodNameEditor >> updateLabel [
 		label:
 			(RBMethodName
 				selector: self selectorInput text
-				arguments: self argumentsList items) methodName
+				arguments: argumentsList items) methodName
+]
+
+{ #category : #services }
+SycMethodNameEditor >> validateEditParameter [
+	self previewResult label = '(invalid)'
+		ifTrue: [ self alert: 'You can not rename parameters if you have an invalid method name' ]
+		ifFalse: [ [ self editParameter  ]
+ 			on: RBRefactoringError 
+			do: [:ex | self alert: ex messageText] 
+	]
 ]

--- a/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
@@ -29,15 +29,15 @@ SycExtractMethodCommand >> defaultMenuItemName [
 
 { #category : #execution }
 SycExtractMethodCommand >> execute [
-	| refactoring dialog selectedInterval |
+
+	| selectedInterval dialog refactoring|
 	selectedInterval := selectedTextInterval ifEmpty: [ sourceNode sourceInterval ].
-	
 	refactoring := RBExtractMethodRefactoring	
 		extract: selectedInterval from: method selector in: method origin.
 	self setUpOptionToUseExistingMethodDuring: refactoring.
 	self setUpOptionToOverrideExistingMethodDuring: refactoring.
-	refactoring setOption: #methodName toUse:  [ :ref :methodName |
-		dialog := SycMethodNameEditor openOn: methodName.
+	refactoring setOption: #methodName toUse: [ :ref :methodName |
+		dialog := SycMethodNameEditor openOn: methodName withRefactoring: ref.
 		dialog cancelled ifTrue: [  CmdCommandAborted signal ].
 		methodName].
 	


### PR DESCRIPTION
Fixes #3606 

Update SycMethodNameEditor to accept rename parameters, add tests, update RBExctractMethodRefactoring to support rename of parameters

Link video how rename parameters when extract a method: https://www.youtube.com/watch?v=xQ97YXFulkU