### PR TITLE
Rename method argument

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -507,12 +507,12 @@ Class >> environment: anEnvironment [
 ]
 
 { #category : #'subclass creation - weak' }
-Class >> ephemeronSubclass: className instanceVariableNames: instVarNames 
+Class >> ephemeronSubclass: className instanceVariableNames: instVarNameList 
 	classVariableNames: classVarNames package: cat [
 	"Added to allow for a simplified subclass creation experience. "
 	
 	^ self ephemeronSubclass: className 
-		instanceVariableNames: instVarNames 
+		instanceVariableNames: instVarNameList 
 		classVariableNames: classVarNames 
 		poolDictionaries: ''
 		category: cat
@@ -1002,24 +1002,24 @@ Class >> subclass: t instanceVariableNames: ins [
 ]
 
 { #category : #'subclass creation - deprecated' }
-Class >> subclass: aSubclassSymbol instanceVariableNames: instVarNames classVariableNames: classVarNames category: aCategorySymbol [
+Class >> subclass: aSubclassSymbol instanceVariableNames: instVarNameList classVariableNames: classVarNames category: aCategorySymbol [
 	"Added to allow for a simplified subclass creation experience. "
 
 	^ self
 		subclass: aSubclassSymbol
-		instanceVariableNames: instVarNames
+		instanceVariableNames: instVarNameList
 		classVariableNames: classVarNames
 		poolDictionaries: ''
 		package: aCategorySymbol
 ]
 
 { #category : #'subclass creation' }
-Class >> subclass: aSubclassSymbol instanceVariableNames: instVarNames classVariableNames: classVarNames package: aPackageSymbol [
+Class >> subclass: aSubclassSymbol instanceVariableNames: instVarNameList classVariableNames: classVarNames package: aPackageSymbol [
 	"Added to allow for a simplified subclass creation experience. "
 
 	^ self
 		subclass: aSubclassSymbol
-		instanceVariableNames: instVarNames
+		instanceVariableNames: instVarNameList
 		classVariableNames: classVarNames
 		poolDictionaries: ''
 		package: aPackageSymbol
@@ -1205,11 +1205,11 @@ Class >> variableByteSubclass: t instanceVariableNames: f
 ]
 
 { #category : #'subclass creation - variable' }
-Class >> variableSubclass: className instanceVariableNames: instVarNames classVariableNames: classVarNames category: cat [
+Class >> variableSubclass: className instanceVariableNames: instVarNameList classVariableNames: classVarNames category: cat [
 	"Added to allow for a simplified subclass creation experience. "
 
 	^ self variableSubclass: className
-		instanceVariableNames: instVarNames 
+		instanceVariableNames: instVarNameList 
 		classVariableNames: classVarNames 
 		poolDictionaries: ''
 		category: cat
@@ -1217,8 +1217,8 @@ Class >> variableSubclass: className instanceVariableNames: instVarNames classVa
 ]
 
 { #category : #'subclass creation - variable' }
-Class >> variableSubclass: className instanceVariableNames: instVarNames classVariableNames: classVarNames package: cat [
-	^self variableSubclass: className instanceVariableNames: instVarNames classVariableNames: classVarNames category: cat
+Class >> variableSubclass: className instanceVariableNames: instVarNameList classVariableNames: classVarNames package: cat [
+	^self variableSubclass: className instanceVariableNames: instVarNameList classVariableNames: classVarNames category: cat
 ]
 
 { #category : #'subclass creation - variable' }
@@ -1245,19 +1245,19 @@ Class >> variableSubclass: t instanceVariableNames: f classVariableNames: d pool
 ]
 
 { #category : #'subclass creation - variableWord' }
-Class >> variableWordSubclass: className instanceVariableNames: instVarNames
+Class >> variableWordSubclass: className instanceVariableNames: instVarNameList
 	classVariableNames: classVarNames category: cat [
 	"Added to allow for a simplified subclass creation experience. "
 	 
 	^ self variableWordSubclass: className
-		instanceVariableNames: instVarNames  
+		instanceVariableNames: instVarNameList  
 		classVariableNames: classVarNames 
 		poolDictionaries: ''
 		package: cat
 ]
 
 { #category : #'subclass creation - variableWord' }
-Class >> variableWordSubclass: className instanceVariableNames: instVarNames
+Class >> variableWordSubclass: className instanceVariableNames: instVarNameList
 	classVariableNames: classVarNames package: cat [
 	"
 	Variable word is like variable byte (ByteArray), variable size, with indices instead of named instance variables, but each index points to a full word (32 bits).
@@ -1266,7 +1266,7 @@ Class >> variableWordSubclass: className instanceVariableNames: instVarNames
 	"
 	 
 	^ self variableWordSubclass: className
-		instanceVariableNames: instVarNames  
+		instanceVariableNames: instVarNameList  
 		classVariableNames: classVarNames 
 		poolDictionaries: ''
 		package: cat
@@ -1301,24 +1301,24 @@ Class >> variableWordSubclass: t instanceVariableNames: f
 ]
 
 { #category : #'subclass creation - weak' }
-Class >> weakSubclass: className instanceVariableNames: instVarNames 
+Class >> weakSubclass: className instanceVariableNames: instVarNameList 
 	classVariableNames: classVarNames category: cat [
 	"Added to allow for a simplified subclass creation experience. "
 	
 	^ self weakSubclass: className 
-		instanceVariableNames: instVarNames 
+		instanceVariableNames: instVarNameList 
 		classVariableNames: classVarNames 
 		poolDictionaries: ''
 		category: cat
 ]
 
 { #category : #'subclass creation - weak' }
-Class >> weakSubclass: className instanceVariableNames: instVarNames 
+Class >> weakSubclass: className instanceVariableNames: instVarNameList 
 	classVariableNames: classVarNames package: cat [
 	"Added to allow for a simplified subclass creation experience. "
 	
 	^ self weakSubclass: className 
-		instanceVariableNames: instVarNames 
+		instanceVariableNames: instVarNameList 
 		classVariableNames: classVarNames 
 		poolDictionaries: ''
 		category: cat

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -233,7 +233,7 @@ UndefinedObject >> storeOn: aStream [
 
 { #category : #'class hierarchy' }
 UndefinedObject >> subclass: nameOfClass  
-	instanceVariableNames: instVarNames
+	instanceVariableNames: instVarNameList
 	classVariableNames: classVarNames
 	poolDictionaries: poolDictnames
 	category: category [
@@ -241,7 +241,7 @@ UndefinedObject >> subclass: nameOfClass
 	self traceCr: ('Attempt to create ', nameOfClass, ' as a subclass of nil.  Possibly a class is being loaded before its superclass.').
 	^ Object
 		subclass: nameOfClass
-		instanceVariableNames: instVarNames
+		instanceVariableNames: instVarNameList
 		classVariableNames: classVarNames
 		poolDictionaries: poolDictnames
 		category: category

--- a/src/TraitsV2/Class.extension.st
+++ b/src/TraitsV2/Class.extension.st
@@ -1,13 +1,13 @@
 Extension { #name : #Class }
 
 { #category : #'*TraitsV2' }
-Class >> immediateSubclass: aClassName uses: aTraitCompositionOrArray instanceVariableNames: instVarNames 
+Class >> immediateSubclass: aClassName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList 
 	classVariableNames: classVarNames package: cat [
 	"Added to allow for a simplified subclass creation experience. "
 	
 	^ self immediateSubclass: aClassName 
 		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNames  
+		instanceVariableNames: instVarNameList  
 		classVariableNames: classVarNames 
 		poolDictionaries: ''
 		package: cat
@@ -50,24 +50,24 @@ Class >> subclass: t uses: aTraitComposition [
 ]
 
 { #category : #'*TraitsV2' }
-Class >> subclass: aTraitName uses: aTraitCompositionOrArray instanceVariableNames: instVarNames classVariableNames: classVarNames category: cat [ 
+Class >> subclass: aTraitName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: cat [ 
 
 	^ self
 		subclass: aTraitName
 		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNames
+		instanceVariableNames: instVarNameList
 		classVariableNames: classVarNames
 		poolDictionaries: ''
 		category: cat 
 ]
 
 { #category : #'*TraitsV2' }
-Class >> subclass: aTraitName uses: aTraitCompositionOrArray instanceVariableNames: instVarNames classVariableNames: classVarNames package: cat [
+Class >> subclass: aTraitName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: cat [
 
 	^ self
 		subclass: aTraitName
 		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNames
+		instanceVariableNames: instVarNameList
 		classVariableNames: classVarNames
 		category: cat
 ]
@@ -245,12 +245,12 @@ Class >> subclass: aSubclassSymbol uses: aTraitCompositionOrArray slots: slotDef
 ]
 
 { #category : #'*TraitsV2' }
-Class >> variableByteSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNames classVariableNames: classVarNames category: cat [
+Class >> variableByteSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: cat [
 
 	^ self
 		variableByteSubclass: className
 		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNames
+		instanceVariableNames: instVarNameList
 		classVariableNames: classVarNames
 		poolDictionaries: ''
 		category: cat
@@ -275,24 +275,24 @@ Class >> variableByteSubclass: aName uses: aTraitComposition instanceVariableNam
 ]
 
 { #category : #'*TraitsV2' }
-Class >> variableSubclass: aClassName uses: aTraitCompositionOrArray instanceVariableNames: instVarNames classVariableNames: classVarNames category: cat [
+Class >> variableSubclass: aClassName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: cat [
 
 	^ self
 		variableSubclass: aClassName
 		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNames
+		instanceVariableNames: instVarNameList
 		classVariableNames: classVarNames
 		poolDictionaries: ''
 		category: cat
 ]
 
 { #category : #'*TraitsV2' }
-Class >> variableSubclass: aClassName uses: aTraitCompositionOrArray instanceVariableNames: instVarNames classVariableNames: classVarNames package: cat [
+Class >> variableSubclass: aClassName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: cat [
 
 	^ self
 		variableSubclass: aClassName
 		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNames
+		instanceVariableNames: instVarNameList
 		classVariableNames: classVarNames
 		category: cat
 ]
@@ -323,22 +323,22 @@ Class >> variableSubclass: aName uses: aTraitComposition instanceVariableNames: 
 ]
 
 { #category : #'*TraitsV2' }
-Class >> variableWordSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNames classVariableNames: classVarNames category: cat [
+Class >> variableWordSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: cat [
 
 	^ self
 		variableWordSubclass: className
 		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNames
+		instanceVariableNames: instVarNameList
 		classVariableNames: classVarNames
 		package: cat
 ]
 
 { #category : #'*TraitsV2' }
-Class >> variableWordSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNames classVariableNames: classVarNames package: cat [
+Class >> variableWordSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: cat [
 	^ self
 		variableWordSubclass: className
 		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNames
+		instanceVariableNames: instVarNameList
 		classVariableNames: classVarNames
 		poolDictionaries: ''
 		package: cat
@@ -370,24 +370,24 @@ Class >> variableWordSubclass: aName uses: aTraitComposition instanceVariableNam
 ]
 
 { #category : #'*TraitsV2' }
-Class >> weakSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNames classVariableNames: classVarNames category: cat [
+Class >> weakSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: cat [
 
 	^ self
 		weakSubclass: className
 		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNames
+		instanceVariableNames: instVarNameList
 		classVariableNames: classVarNames
 		poolDictionaries: ''
 		category: cat
 ]
 
 { #category : #'*TraitsV2' }
-Class >> weakSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNames classVariableNames: classVarNames package: cat [
+Class >> weakSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: cat [
 
 	^ self
 		weakSubclass: className
 		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNames
+		instanceVariableNames: instVarNameList
 		classVariableNames: classVarNames
 		category: cat
 ]


### PR DESCRIPTION
The identifier 'instVarNames' is an instance variable name in Class in GemStone, so using it as a method argument gives a compile error. I believe that renaming it should be otherwise inconsequential in Pharo.