### PR TITLE
ClassAnnotation-test-case-should-end-with-Test

### DIFF
--- a/src/ClassAnnotation-Tests/ActiveClassAnnotationsTest.class.st
+++ b/src/ClassAnnotation-Tests/ActiveClassAnnotationsTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #ActiveClassAnnotationsTests,
+	#name : #ActiveClassAnnotationsTest,
 	#superclass : #ClassAnnotationTestCase,
 	#category : #'ClassAnnotation-Tests'
 }
 
 { #category : #tests }
-ActiveClassAnnotationsTests >> testCanBeEnumeratedForGivenClassAndUser [
+ActiveClassAnnotationsTest >> testCanBeEnumeratedForGivenClassAndUser [
 
 	| annotationUser actual expected |
 	annotationUser := AnnotationUserExample new.
@@ -19,7 +19,7 @@ ActiveClassAnnotationsTests >> testCanBeEnumeratedForGivenClassAndUser [
 ]
 
 { #category : #tests }
-ActiveClassAnnotationsTests >> testCanBeEnumeratedForGivenUser [
+ActiveClassAnnotationsTest >> testCanBeEnumeratedForGivenUser [
 
 	| annotationUser actual expected |
 	annotationUser := AnnotationUserExample new.
@@ -33,7 +33,7 @@ ActiveClassAnnotationsTests >> testCanBeEnumeratedForGivenUser [
 ]
 
 { #category : #tests }
-ActiveClassAnnotationsTests >> testIncludeOnlyInstancesWhichAreActiveForGivenUser [
+ActiveClassAnnotationsTest >> testIncludeOnlyInstancesWhichAreActiveForGivenUser [
 
 	| actual annotationUser expected |
 	annotationUser := AnnotationUserExample new.
@@ -46,7 +46,7 @@ ActiveClassAnnotationsTests >> testIncludeOnlyInstancesWhichAreActiveForGivenUse
 ]
 
 { #category : #tests }
-ActiveClassAnnotationsTests >> testNotIncludeInstancesWhichAreNotActiveForGivenUser [
+ActiveClassAnnotationsTest >> testNotIncludeInstancesWhichAreNotActiveForGivenUser [
 
 	| actual annotationUser |
 	annotationUser := AnnotationUserExample new.
@@ -58,7 +58,7 @@ ActiveClassAnnotationsTests >> testNotIncludeInstancesWhichAreNotActiveForGivenU
 ]
 
 { #category : #tests }
-ActiveClassAnnotationsTests >> testNotIncludeInstancesWithoutContext [
+ActiveClassAnnotationsTest >> testNotIncludeInstancesWithoutContext [
 
 	| annotations annotationUser |
 	annotationUser := AnnotationUserExample new.

--- a/src/ClassAnnotation-Tests/ClassAnnotationTest.class.st
+++ b/src/ClassAnnotation-Tests/ClassAnnotationTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #ClassAnnotationTests,
+	#name : #ClassAnnotationTest,
 	#superclass : #ClassAnnotationTestCase,
 	#category : #'ClassAnnotation-Tests'
 }
 
 { #category : #running }
-ClassAnnotationTests >> tearDown [
+ClassAnnotationTest >> tearDown [
 	"Some tests redefine following annotation. 
 	Here we clear redefining state which forces cache reset"
 	ClassAnnotationExample3 revertRedefinedInstances.
@@ -15,7 +15,7 @@ ClassAnnotationTests >> tearDown [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testCheckIfAnnotatesGivenClass [
+ClassAnnotationTest >> testCheckIfAnnotatesGivenClass [
 	| ann|
 	ann := ClassAnnotationExample1 withAnnotatedClass: ClassWithSingleAnnotation.
 	
@@ -24,7 +24,7 @@ ClassAnnotationTests >> testCheckIfAnnotatesGivenClass [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testComparisonOfTwoAnnotationsWithDifferentClass [
+ClassAnnotationTest >> testComparisonOfTwoAnnotationsWithDifferentClass [
 	| ann1 ann2 |
 	ann1 := ClassAnnotationExample1 withAnnotatedClass: ClassWithSingleAnnotation.
 	ann1 declarationSelector: #selector1.
@@ -36,7 +36,7 @@ ClassAnnotationTests >> testComparisonOfTwoAnnotationsWithDifferentClass [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testComparisonOfTwoAnnotationsWithDifferentSelector [
+ClassAnnotationTest >> testComparisonOfTwoAnnotationsWithDifferentSelector [
 	| ann1 ann2 |
 	ann1 := ClassAnnotationExample1 withAnnotatedClass: ClassWithThreeAnnotations.
 	ann1 declarationSelector: #selector1.
@@ -48,7 +48,7 @@ ClassAnnotationTests >> testComparisonOfTwoAnnotationsWithDifferentSelector [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testComparisonOfTwoAnnotationsWithSameSelectorAndClass [
+ClassAnnotationTest >> testComparisonOfTwoAnnotationsWithSameSelectorAndClass [
 	| ann1 ann2 |
 	ann1 := ClassAnnotationExample1 withAnnotatedClass: ClassWithThreeAnnotations.
 	ann1 declarationSelector: #selector1.
@@ -61,7 +61,7 @@ ClassAnnotationTests >> testComparisonOfTwoAnnotationsWithSameSelectorAndClass [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testComparisonOfTwoDifferentAnnotations [
+ClassAnnotationTest >> testComparisonOfTwoDifferentAnnotations [
 	| ann1 ann2 |
 	ann1 := ClassAnnotationExample1 withAnnotatedClass: ClassWithSingleAnnotation.
 	ann1 declarationSelector: #selector1.
@@ -73,7 +73,7 @@ ClassAnnotationTests >> testComparisonOfTwoDifferentAnnotations [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testCreationForExplicitAnnotationContext [
+ClassAnnotationTest >> testCreationForExplicitAnnotationContext [
 	| ann context |
 	context := SimpleAnnotationContext of: AnnotationUserExample.
 	ann := ClassAnnotationExample1 for: context.
@@ -83,7 +83,7 @@ ClassAnnotationTests >> testCreationForExplicitAnnotationContext [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testForgettingAnnotation [
+ClassAnnotationTest >> testForgettingAnnotation [
 	| annotation |
 	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
 	
@@ -93,7 +93,7 @@ ClassAnnotationTests >> testForgettingAnnotation [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testGettingAllRedefinedInstances [
+ClassAnnotationTest >> testGettingAllRedefinedInstances [
 	| annotation allRedefined |
 	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
 	annotation redefineBy: [ annotation priority: -1000 ].
@@ -104,7 +104,7 @@ ClassAnnotationTests >> testGettingAllRedefinedInstances [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testGettingAllRedefinedInstancesShouldCleanGarbage [
+ClassAnnotationTest >> testGettingAllRedefinedInstancesShouldCleanGarbage [
 	| annotation allRedefined |
 	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
 	annotation redefineBy: [ annotation priority: -1000 ].
@@ -116,7 +116,7 @@ ClassAnnotationTests >> testGettingAllRedefinedInstancesShouldCleanGarbage [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testGettingAllRedefiningInstances [
+ClassAnnotationTest >> testGettingAllRedefiningInstances [
 	| annotation allRedefining |
 	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
 	annotation redefineBy: [ annotation priority: -1000 ].
@@ -128,7 +128,7 @@ ClassAnnotationTests >> testGettingAllRedefiningInstances [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testGettingAllRedefiningInstancesShouldCleanGarbage [
+ClassAnnotationTest >> testGettingAllRedefiningInstancesShouldCleanGarbage [
 	| annotation allRedefined |
 	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
 	annotation redefineBy: [ annotation priority: -1000 ].
@@ -140,7 +140,7 @@ ClassAnnotationTests >> testGettingAllRedefiningInstancesShouldCleanGarbage [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testGettingFreshInstance [
+ClassAnnotationTest >> testGettingFreshInstance [
 	| ann actual |
 	ann := ClassAnnotationExample1 withAnnotatedClass: ClassWithSingleAnnotation.
 	ann declarationSelector: #annotationExample. 
@@ -151,7 +151,7 @@ ClassAnnotationTests >> testGettingFreshInstance [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testGettingRedefinedInstance [
+ClassAnnotationTest >> testGettingRedefinedInstance [
 	| annotation redefinedInstance |
 	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
 	annotation redefineBy: [ annotation priority: -1000 ].
@@ -163,7 +163,7 @@ ClassAnnotationTests >> testGettingRedefinedInstance [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testGettingRedefiningInstance [
+ClassAnnotationTest >> testGettingRedefiningInstance [
 	| annotation actual |
 	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
 	annotation redefineBy: [ annotation priority: -1000 ].
@@ -174,7 +174,7 @@ ClassAnnotationTests >> testGettingRedefiningInstance [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testGettingSingleAnnotationUsingSelector [
+ClassAnnotationTest >> testGettingSingleAnnotationUsingSelector [
 	| expected actual |
 	
 	expected := ClassWithThreeAnnotations classAnnotations 
@@ -185,7 +185,7 @@ ClassAnnotationTests >> testGettingSingleAnnotationUsingSelector [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testHasNullContextByDefault [
+ClassAnnotationTest >> testHasNullContextByDefault [
 	
 	| ann |
 	ann := ClassAnnotationExample1 new.
@@ -194,7 +194,7 @@ ClassAnnotationTests >> testHasNullContextByDefault [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testHasZeroPriorityByDefault [
+ClassAnnotationTest >> testHasZeroPriorityByDefault [
 	
 	| ann |
 	ann := ClassAnnotationExample1 new.
@@ -203,7 +203,7 @@ ClassAnnotationTests >> testHasZeroPriorityByDefault [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testNotSimilarToAnnotationOfDifferentClass [
+ClassAnnotationTest >> testNotSimilarToAnnotationOfDifferentClass [
 	| ann1 ann2 |
 	ann1 := ClassAnnotationExample1 withAnnotatedClass: ClassWithSingleAnnotation.
 	
@@ -213,7 +213,7 @@ ClassAnnotationTests >> testNotSimilarToAnnotationOfDifferentClass [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testNotSimilarToAnnotationOfSameClassButForDifferentContext [
+ClassAnnotationTest >> testNotSimilarToAnnotationOfSameClassButForDifferentContext [
 	| ann1 ann2 |
 	ann1 := ClassAnnotationExample1 withAnnotatedClass: ClassWithSingleAnnotation.
 	
@@ -223,7 +223,7 @@ ClassAnnotationTests >> testNotSimilarToAnnotationOfSameClassButForDifferentCont
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testNotSimilarToDifferentKindAnnotation [
+ClassAnnotationTest >> testNotSimilarToDifferentKindAnnotation [
 	| ann1 ann2 |
 	ann1 := ClassAnnotationExample1 withAnnotatedClass: ClassWithSingleAnnotation.
 	
@@ -233,7 +233,7 @@ ClassAnnotationTests >> testNotSimilarToDifferentKindAnnotation [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testObsolete [
+ClassAnnotationTest >> testObsolete [
 	| annotation |
 	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
 	self deny: annotation isObsolete.
@@ -244,7 +244,7 @@ ClassAnnotationTests >> testObsolete [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testRedefiningInstance [
+ClassAnnotationTest >> testRedefiningInstance [
 	| annotation newAnnotation |
 	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
 	
@@ -259,7 +259,7 @@ ClassAnnotationTests >> testRedefiningInstance [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testRedefiningInstanceTwice [
+ClassAnnotationTest >> testRedefiningInstanceTwice [
 	| annotation newAnnotation reverted |
 	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
 	
@@ -277,7 +277,7 @@ ClassAnnotationTests >> testRedefiningInstanceTwice [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testRedefiningInstanceUsingBlockWithArgument [
+ClassAnnotationTest >> testRedefiningInstanceUsingBlockWithArgument [
 	| newAnnotation |
 	
 	ClassWithSingleAnnotation classAnnotations anyOne
@@ -289,7 +289,7 @@ ClassAnnotationTests >> testRedefiningInstanceUsingBlockWithArgument [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testRevertingAllRedefinedInstances [
+ClassAnnotationTest >> testRevertingAllRedefinedInstances [
 	| annotation |
 	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
 	annotation class revertRedefinedInstances.
@@ -299,7 +299,7 @@ ClassAnnotationTests >> testRevertingAllRedefinedInstances [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testRevertingRedefinedInstance [
+ClassAnnotationTest >> testRevertingRedefinedInstance [
 	| annotation revertedAnnotation |
 	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
 	annotation redefineBy: [ annotation priority: -1000 ].
@@ -312,7 +312,7 @@ ClassAnnotationTests >> testRevertingRedefinedInstance [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testSimilarToAnnotationOfSameClassForSameContext [
+ClassAnnotationTest >> testSimilarToAnnotationOfSameClassForSameContext [
 	| ann1 ann2 |
 	ann1 := ClassAnnotationExample1 for: AnnotationUserExample withAnnotatedClass: ClassWithSingleAnnotation.
 	
@@ -322,7 +322,7 @@ ClassAnnotationTests >> testSimilarToAnnotationOfSameClassForSameContext [
 ]
 
 { #category : #tests }
-ClassAnnotationTests >> testSimilarToAnnotationOfSameClassWhenBothDoNotDefinedWithContext [
+ClassAnnotationTest >> testSimilarToAnnotationOfSameClassWhenBothDoNotDefinedWithContext [
 	| ann1 ann2 |
 	ann1 := ClassAnnotationExample1 withAnnotatedClass: ClassWithSingleAnnotation.
 	

--- a/src/ClassAnnotation-Tests/CompositeAnnotationContextTest.class.st
+++ b/src/ClassAnnotation-Tests/CompositeAnnotationContextTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #CompositeAnnotationContextTests,
+	#name : #CompositeAnnotationContextTest,
 	#superclass : #TestCase,
 	#category : #'ClassAnnotation-Tests'
 }
 
 { #category : #tests }
-CompositeAnnotationContextTests >> testComparison [
+CompositeAnnotationContextTest >> testComparison [
 	
 	self 
 		assert: Object asAnnotationContext, Array asAnnotationContext 
@@ -19,7 +19,7 @@ CompositeAnnotationContextTests >> testComparison [
 ]
 
 { #category : #tests }
-CompositeAnnotationContextTests >> testCreationByComma [
+CompositeAnnotationContextTest >> testCreationByComma [
 	
 	| context1 context2 context |
 	context1 := Object asAnnotationContext.
@@ -32,7 +32,7 @@ CompositeAnnotationContextTests >> testCreationByComma [
 ]
 
 { #category : #tests }
-CompositeAnnotationContextTests >> testCreationByCommaWithCompatibleArgument [
+CompositeAnnotationContextTest >> testCreationByCommaWithCompatibleArgument [
 	
 	| context1 context |
 	context1 := Object asAnnotationContext.
@@ -44,7 +44,7 @@ CompositeAnnotationContextTests >> testCreationByCommaWithCompatibleArgument [
 ]
 
 { #category : #tests }
-CompositeAnnotationContextTests >> testCreationByCommaWithMultipleCompatipleContexts [
+CompositeAnnotationContextTest >> testCreationByCommaWithMultipleCompatipleContexts [
 	
 	| context1 context |
 	context1 := Object asAnnotationContext.
@@ -58,7 +58,7 @@ CompositeAnnotationContextTests >> testCreationByCommaWithMultipleCompatipleCont
 ]
 
 { #category : #tests }
-CompositeAnnotationContextTests >> testCreationByCommaWithMultipleContexts [
+CompositeAnnotationContextTest >> testCreationByCommaWithMultipleContexts [
 	
 	| context1 context2 context context3 |
 	context1 := Object asAnnotationContext.

--- a/src/ClassAnnotation-Tests/QueryAnnotationsFromClassTest.class.st
+++ b/src/ClassAnnotation-Tests/QueryAnnotationsFromClassTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #QueryAnnotationsFromClassTests,
+	#name : #QueryAnnotationsFromClassTest,
 	#superclass : #ClassAnnotationTestCase,
 	#category : #'ClassAnnotation-Tests'
 }
 
 { #category : #tests }
-QueryAnnotationsFromClassTests >> testAllowDebugBrokenAnnotations [
+QueryAnnotationsFromClassTest >> testAllowDebugBrokenAnnotations [
 
 	| annotations ann |
 	annotations := ClassWithBrokenAnnotatingMethod classAnnotations.	
@@ -21,7 +21,7 @@ QueryAnnotationsFromClassTests >> testAllowDebugBrokenAnnotations [
 ]
 
 { #category : #tests }
-QueryAnnotationsFromClassTests >> testAllowDebugForbiddenBrokenAnnotations [
+QueryAnnotationsFromClassTest >> testAllowDebugForbiddenBrokenAnnotations [
 
 	| annotations ann |
 	annotations := ClassWithForbiddenAnnotationExample classAnnotations.	
@@ -36,7 +36,7 @@ QueryAnnotationsFromClassTests >> testAllowDebugForbiddenBrokenAnnotations [
 ]
 
 { #category : #tests }
-QueryAnnotationsFromClassTests >> testCanBeEnumerated [
+QueryAnnotationsFromClassTest >> testCanBeEnumerated [
 
 	| enumerated |
 	enumerated := OrderedCollection new.
@@ -46,7 +46,7 @@ QueryAnnotationsFromClassTests >> testCanBeEnumerated [
 ]
 
 { #category : #tests }
-QueryAnnotationsFromClassTests >> testReturnsInstancesFromAllAnnotatingMethods [
+QueryAnnotationsFromClassTest >> testReturnsInstancesFromAllAnnotatingMethods [
 
 	| annotations |
 	annotations := ClassWithThreeAnnotations classAnnotations.
@@ -57,7 +57,7 @@ QueryAnnotationsFromClassTests >> testReturnsInstancesFromAllAnnotatingMethods [
 ]
 
 { #category : #tests }
-QueryAnnotationsFromClassTests >> testWhenAnnotationFailsCheckForForbiddenProperty [
+QueryAnnotationsFromClassTest >> testWhenAnnotationFailsCheckForForbiddenProperty [
 
 	| annotations ann |
 	[ ClassAnnotationExampleWithFailedForbiddenCheck new isForbidden.
@@ -75,7 +75,7 @@ QueryAnnotationsFromClassTests >> testWhenAnnotationFailsCheckForForbiddenProper
 ]
 
 { #category : #tests }
-QueryAnnotationsFromClassTests >> testWhenClassHasNoAnnotations [
+QueryAnnotationsFromClassTest >> testWhenClassHasNoAnnotations [
 
 	| annotations |
 	annotations := ClassWithoutAnnotations classAnnotations.
@@ -84,7 +84,7 @@ QueryAnnotationsFromClassTests >> testWhenClassHasNoAnnotations [
 ]
 
 { #category : #tests }
-QueryAnnotationsFromClassTests >> testWhenDeclaringMethodIsBroken [
+QueryAnnotationsFromClassTest >> testWhenDeclaringMethodIsBroken [
 
 	| annotations ann |
 	annotations := ClassWithBrokenAnnotatingMethod classAnnotations.	
@@ -99,7 +99,7 @@ QueryAnnotationsFromClassTests >> testWhenDeclaringMethodIsBroken [
 ]
 
 { #category : #tests }
-QueryAnnotationsFromClassTests >> testWhenDeclaringMethodNotReturnAnnotation [
+QueryAnnotationsFromClassTest >> testWhenDeclaringMethodNotReturnAnnotation [
 
 	| annotations ann |
 	annotations := ClassWithBadAnnotatingMethod classAnnotations.	
@@ -113,7 +113,7 @@ QueryAnnotationsFromClassTests >> testWhenDeclaringMethodNotReturnAnnotation [
 ]
 
 { #category : #tests }
-QueryAnnotationsFromClassTests >> testWhenItOverridesSuperclassAnnotations [
+QueryAnnotationsFromClassTest >> testWhenItOverridesSuperclassAnnotations [
 
 	| annotations |
 	annotations := SubclassWithOverridenAnnotation classAnnotations.
@@ -124,7 +124,7 @@ QueryAnnotationsFromClassTests >> testWhenItOverridesSuperclassAnnotations [
 ]
 
 { #category : #tests }
-QueryAnnotationsFromClassTests >> testWhenSuperclassIsAnnotatedToo [
+QueryAnnotationsFromClassTest >> testWhenSuperclassIsAnnotatedToo [
 
 	| annotations |
 	annotations := SubclassWithOnlyInheritedAnnotation classAnnotations.

--- a/src/ClassAnnotation-Tests/RegisteredClassAnnotationsTest.class.st
+++ b/src/ClassAnnotation-Tests/RegisteredClassAnnotationsTest.class.st
@@ -1,18 +1,18 @@
 Class {
-	#name : #RegisteredClassAnnotationsTests,
+	#name : #RegisteredClassAnnotationsTest,
 	#superclass : #ClassAnnotationTestCase,
 	#category : #'ClassAnnotation-Tests'
 }
 
 { #category : #running }
-RegisteredClassAnnotationsTests >> setUp [
+RegisteredClassAnnotationsTest >> setUp [
 	super setUp.
 	
 	ClassAnnotation resetCache
 ]
 
 { #category : #running }
-RegisteredClassAnnotationsTests >> tearDown [
+RegisteredClassAnnotationsTest >> tearDown [
 		
 	ClassAnnotation resetCache.
 	
@@ -20,7 +20,7 @@ RegisteredClassAnnotationsTests >> tearDown [
 ]
 
 { #category : #tests }
-RegisteredClassAnnotationsTests >> testAreCached [
+RegisteredClassAnnotationsTest >> testAreCached [
 
 	| annotations |
 	annotations := ClassAnnotationExample1 registeredInstances.
@@ -29,7 +29,7 @@ RegisteredClassAnnotationsTests >> testAreCached [
 ]
 
 { #category : #tests }
-RegisteredClassAnnotationsTests >> testAreDifferentForDifferentAnnotationClasses [
+RegisteredClassAnnotationsTest >> testAreDifferentForDifferentAnnotationClasses [
 
 	| annotations1 annotations2 |
 	annotations1 := ClassAnnotationExample1 registeredInstances.
@@ -39,7 +39,7 @@ RegisteredClassAnnotationsTests >> testAreDifferentForDifferentAnnotationClasses
 ]
 
 { #category : #tests }
-RegisteredClassAnnotationsTests >> testAreEmptyForUnusedAnnotation [
+RegisteredClassAnnotationsTest >> testAreEmptyForUnusedAnnotation [
 
 	| actual |
 	actual := ClassAnnotationUnusedExample registeredInstances.
@@ -48,7 +48,7 @@ RegisteredClassAnnotationsTests >> testAreEmptyForUnusedAnnotation [
 ]
 
 { #category : #tests }
-RegisteredClassAnnotationsTests >> testAreSortedByPriority [
+RegisteredClassAnnotationsTest >> testAreSortedByPriority [
 
 	| annotations expected |
 	annotations := ClassAnnotationExampleWithPriority registeredInstances.
@@ -60,7 +60,7 @@ RegisteredClassAnnotationsTests >> testAreSortedByPriority [
 ]
 
 { #category : #tests }
-RegisteredClassAnnotationsTests >> testCanBeEnumerated [
+RegisteredClassAnnotationsTest >> testCanBeEnumerated [
 
 	| enumerated |
 	enumerated := OrderedCollection new.
@@ -70,7 +70,7 @@ RegisteredClassAnnotationsTests >> testCanBeEnumerated [
 ]
 
 { #category : #tests }
-RegisteredClassAnnotationsTests >> testCanBeQueriedForConcreteClass [
+RegisteredClassAnnotationsTest >> testCanBeQueriedForConcreteClass [
 
 	| annotations |
 	annotations := ClassAnnotationExample1 registeredInstancesFor: ClassWithThreeAnnotations.
@@ -80,7 +80,7 @@ RegisteredClassAnnotationsTests >> testCanBeQueriedForConcreteClass [
 ]
 
 { #category : #tests }
-RegisteredClassAnnotationsTests >> testIncludeCopiesForEachSubclassOfOriginDeclaration [
+RegisteredClassAnnotationsTest >> testIncludeCopiesForEachSubclassOfOriginDeclaration [
 
 	| annotations |
 	annotations := ClassAnnotationExample3 registeredInstances.
@@ -89,7 +89,7 @@ RegisteredClassAnnotationsTests >> testIncludeCopiesForEachSubclassOfOriginDecla
 ]
 
 { #category : #tests }
-RegisteredClassAnnotationsTests >> testIncludeForbiddenClassesAsSpecialForbiddenAnnotations [
+RegisteredClassAnnotationsTest >> testIncludeForbiddenClassesAsSpecialForbiddenAnnotations [
 	| allForbidden forbidden actualAnnotation |
 	
 	allForbidden := ForbiddenClassAnnotation registeredInstancesFor: ClassWithForbiddenAnnotationExample.
@@ -99,7 +99,7 @@ RegisteredClassAnnotationsTests >> testIncludeForbiddenClassesAsSpecialForbidden
 ]
 
 { #category : #tests }
-RegisteredClassAnnotationsTests >> testIncludeInstancesFromAllAnnotatingMethodsOfAnyClassInSystem [
+RegisteredClassAnnotationsTest >> testIncludeInstancesFromAllAnnotatingMethodsOfAnyClassInSystem [
 
 	| annotations |
 	annotations := ClassAnnotationExample1 registeredInstances.
@@ -109,7 +109,7 @@ RegisteredClassAnnotationsTests >> testIncludeInstancesFromAllAnnotatingMethodsO
 ]
 
 { #category : #tests }
-RegisteredClassAnnotationsTests >> testNotIncludeForbiddenClassesAsBrokenAnnotations [
+RegisteredClassAnnotationsTest >> testNotIncludeForbiddenClassesAsBrokenAnnotations [
 	| broken |
 	
 	broken := BrokenClassAnnotation registeredInstancesFor: ClassWithForbiddenAnnotationExample.
@@ -119,7 +119,7 @@ RegisteredClassAnnotationsTests >> testNotIncludeForbiddenClassesAsBrokenAnnotat
 ]
 
 { #category : #tests }
-RegisteredClassAnnotationsTests >> testNotIncludeInstancesAnnotatingForbiddenClasses [
+RegisteredClassAnnotationsTest >> testNotIncludeInstancesAnnotatingForbiddenClasses [
 	"In that test the annotation define canAnnotateClass: with constant false answer.
 	So any annotating methods which define it should never register their instances"
 	| annotations |

--- a/src/ClassAnnotation-Tests/SimpleAnnotationContextTest.class.st
+++ b/src/ClassAnnotation-Tests/SimpleAnnotationContextTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #SimpleAnnotationContextTests,
+	#name : #SimpleAnnotationContextTest,
 	#superclass : #TestCase,
 	#category : #'ClassAnnotation-Tests'
 }
 
 { #category : #tests }
-SimpleAnnotationContextTests >> testComparison [
+SimpleAnnotationContextTest >> testComparison [
 	
 	self assert: Object asAnnotationContext equals: Object asAnnotationContext. 
 	self assert: Object asAnnotationContext hash equals: Object asAnnotationContext hash.

--- a/src/ClassAnnotation-Tests/VisibleClassAnnotationsTest.class.st
+++ b/src/ClassAnnotation-Tests/VisibleClassAnnotationsTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #VisibleClassAnnotationsTests,
+	#name : #VisibleClassAnnotationsTest,
 	#superclass : #ClassAnnotationTestCase,
 	#category : #'ClassAnnotation-Tests'
 }
 
 { #category : #tests }
-VisibleClassAnnotationsTests >> testCanBeEnumeratedForGivenClassAndUser [
+VisibleClassAnnotationsTest >> testCanBeEnumeratedForGivenClassAndUser [
 
 	| annotationUser actual expected |
 	annotationUser := AnnotationUserExample new.
@@ -19,7 +19,7 @@ VisibleClassAnnotationsTests >> testCanBeEnumeratedForGivenClassAndUser [
 ]
 
 { #category : #tests }
-VisibleClassAnnotationsTests >> testCanBeEnumeratedForGivenUser [
+VisibleClassAnnotationsTest >> testCanBeEnumeratedForGivenUser [
 
 	| annotationUser actual expected |
 	annotationUser := AnnotationUserExample new.
@@ -33,7 +33,7 @@ VisibleClassAnnotationsTests >> testCanBeEnumeratedForGivenUser [
 ]
 
 { #category : #tests }
-VisibleClassAnnotationsTests >> testIncludeInstancesDeclaredForSuperclassOfGivenUser [
+VisibleClassAnnotationsTest >> testIncludeInstancesDeclaredForSuperclassOfGivenUser [
 
 	| annotations annotationUser declaredContext |
 	annotationUser := AnnotationUserExample new.
@@ -45,7 +45,7 @@ VisibleClassAnnotationsTests >> testIncludeInstancesDeclaredForSuperclassOfGiven
 ]
 
 { #category : #tests }
-VisibleClassAnnotationsTests >> testIncludeOnlyInstancesCreatedForGivenUser [
+VisibleClassAnnotationsTest >> testIncludeOnlyInstancesCreatedForGivenUser [
 
 	| annotations annotationUser declaredContexts |
 	annotationUser := AnnotationUserExample new.
@@ -57,7 +57,7 @@ VisibleClassAnnotationsTests >> testIncludeOnlyInstancesCreatedForGivenUser [
 ]
 
 { #category : #tests }
-VisibleClassAnnotationsTests >> testNotIncludeInstancesWithoutContext [
+VisibleClassAnnotationsTest >> testNotIncludeInstancesWithoutContext [
 
 	| annotations annotationUser |
 	annotationUser := AnnotationUserExample new.
@@ -67,7 +67,7 @@ VisibleClassAnnotationsTests >> testNotIncludeInstancesWithoutContext [
 ]
 
 { #category : #tests }
-VisibleClassAnnotationsTests >> testWhenThereIsNoOne [
+VisibleClassAnnotationsTest >> testWhenThereIsNoOne [
 
 	| annotations annotationUser |
 	annotationUser := Object new. "context can be anything"


### PR DESCRIPTION
Class annotation test case should end with Test and not Tests.