### PR TITLE
Debugger-test-cases-should-end-with-Test

### DIFF
--- a/src/Debugger-Tests/AssignmentAndLiteralDebuggerTest.class.st
+++ b/src/Debugger-Tests/AssignmentAndLiteralDebuggerTest.class.st
@@ -1,17 +1,17 @@
 Class {
-	#name : #AssignmentAndLiteralDebuggerTests,
-	#superclass : #DebuggerTests,
+	#name : #AssignmentAndLiteralDebuggerTest,
+	#superclass : #DebuggerTest,
 	#category : #'Debugger-Tests'
 }
 
 { #category : #running }
-AssignmentAndLiteralDebuggerTests >> setUp [
+AssignmentAndLiteralDebuggerTest >> setUp [
 	super setUp.
 	self settingUpSessionAndProcessAndContextForBlock: [ |var| var:=4].
 ]
 
 { #category : #tests }
-AssignmentAndLiteralDebuggerTests >> testInterruptedContextEqualsSuspendedContextOfInterruptedProcess [
+AssignmentAndLiteralDebuggerTest >> testInterruptedContextEqualsSuspendedContextOfInterruptedProcess [
 	self assert: session interruptedContext equals: session interruptedProcess suspendedContext.
 	session stepInto.
 	session stepInto.
@@ -19,33 +19,33 @@ AssignmentAndLiteralDebuggerTests >> testInterruptedContextEqualsSuspendedContex
 ]
 
 { #category : #tests }
-AssignmentAndLiteralDebuggerTests >> testNewDebugSession [
+AssignmentAndLiteralDebuggerTest >> testNewDebugSession [
 	self assert: context size equals: 0.
 	self assert: session interruptedContext equals: context.
 ]
 
 { #category : #tests }
-AssignmentAndLiteralDebuggerTests >> testStepIntoAssignment [
+AssignmentAndLiteralDebuggerTest >> testStepIntoAssignment [
 	session stepInto.
 	session stepInto.
 	self assert: (context tempNamed: 'var') equals: 4.
 ]
 
 { #category : #tests }
-AssignmentAndLiteralDebuggerTests >> testStepIntoLiteral [
+AssignmentAndLiteralDebuggerTest >> testStepIntoLiteral [
 	session stepInto.
 	self assert: context top equals: 4.
 ]
 
 { #category : #tests }
-AssignmentAndLiteralDebuggerTests >> testStepOverAssignment [
+AssignmentAndLiteralDebuggerTest >> testStepOverAssignment [
 	session stepOver.
 	session stepOver.
 	self assert: (context tempNamed: 'var') equals: 4.
 ]
 
 { #category : #tests }
-AssignmentAndLiteralDebuggerTests >> testStepOverLiteral [
+AssignmentAndLiteralDebuggerTest >> testStepOverLiteral [
 	session stepOver.
 	self assert: context top equals: 4.
 ]

--- a/src/Debugger-Tests/DebugSessionContexts2Test.class.st
+++ b/src/Debugger-Tests/DebugSessionContexts2Test.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #DebugSessionContexts2,
-	#superclass : #DebuggerTests,
+	#name : #DebugSessionContexts2Test,
+	#superclass : #DebuggerTest,
 	#classVars : [
 		'debugSession'
 	],
@@ -8,17 +8,17 @@ Class {
 }
 
 { #category : #'as yet unclassified' }
-DebugSessionContexts2 class >> debugSession [
+DebugSessionContexts2Test class >> debugSession [
 	^ debugSession.
 ]
 
 { #category : #'instance creation' }
-DebugSessionContexts2 class >> debugSession: aValue [
+DebugSessionContexts2Test class >> debugSession: aValue [
 	debugSession := aValue
 ]
 
 { #category : #running }
-DebugSessionContexts2 >> setUp [
+DebugSessionContexts2Test >> setUp [
 	"Creates a debugSession in a way that mimicks the real way DebugSessions are created normally in the image (in a process, a halt is raised, the process creates a debugSession and gets suspended). Note that this isn't a perfect replica of the normal way a debugSession gets created, because the normal way involves the UIManager and would create a pre-debug window."
 	super setUp.
 	process := [ 1 + 1.
@@ -29,7 +29,7 @@ DebugSessionContexts2 >> setUp [
 ]
 
 { #category : #tests }
-DebugSessionContexts2 >> testContextsAfterStepInto [
+DebugSessionContexts2Test >> testContextsAfterStepInto [
 	"Checks that after one step into of the debug session, the suspendedContext of its interruptedProcess is at the user's code (not in the debugging machinery) and is the same object as the interruptedContext of the DebugSession."
 
 	session stepInto.
@@ -42,13 +42,13 @@ DebugSessionContexts2 >> testContextsAfterStepInto [
 ]
 
 { #category : #tests }
-DebugSessionContexts2 >> testInterruptedContext [
+DebugSessionContexts2Test >> testInterruptedContext [
 	"Checks that the interruptedContext of the debug session is the last context the execution went through that contains the user's code and not the debugging machinery."
 	self assert: (session interruptedContext method) equals: (self class)>>#setUp.
 ]
 
 { #category : #tests }
-DebugSessionContexts2 >> testSuspendedContext [
+DebugSessionContexts2Test >> testSuspendedContext [
 	"Checks that the suspendedContext of the interruptedProcess of a DebugSession is the last context the execution was at when its process was suspended."
 	self assert: (session interruptedProcess suspendedContext method) equals: MyHalt>>#defaultAction.
 ]

--- a/src/Debugger-Tests/DebugSessionContextsTest.class.st
+++ b/src/Debugger-Tests/DebugSessionContextsTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #DebugSessionContexts,
-	#superclass : #DebuggerTests,
+	#name : #DebugSessionContextsTest,
+	#superclass : #DebuggerTest,
 	#instVars : [
 		'debuggedThisContext'
 	],
@@ -8,25 +8,25 @@ Class {
 }
 
 { #category : #running }
-DebugSessionContexts >> setUp [
+DebugSessionContextsTest >> setUp [
 	"Creates a debugSession in a way that mimicks the real way DebugSessions are created normally in the image (in a process, a halt is raised, the process creates a debugSession and gets suspended). Note that this isn't a perfect replica of the normal way a debugSession gets created, because the normal way involves the UIManager and would create a pre-debug window."
+
 	super setUp.
-	process := [ | debugSession |	
+	process := [ | debugSession |
 	debugSession := Processor activeProcess newDebugSessionNamed: 'test' startedAt: (debuggedThisContext := thisContext).
 	Processor activeProcess suspend ] fork.
 	"The line under is a bit dirty. It is to make sure that the debugged process has suspended itself before it is being examined by the test methods."
-	[process isSuspended] whileFalse: [ 100 milliSeconds wait. ]
-
+	[ process isSuspended ] whileFalse: [ 100 milliSeconds wait ]
 ]
 
 { #category : #tests }
-DebugSessionContexts >> testInitialContentOfInterruptedContext [
+DebugSessionContextsTest >> testInitialContentOfInterruptedContext [
 	"Checks that the interruptedContext of the DebugSession is the thisContext of the code where the DebugSession was created"
 	self assert: ((process suspendedContext lookupSymbol: #debugSession) interruptedContext ) identicalTo: debuggedThisContext.
 ]
 
 { #category : #tests }
-DebugSessionContexts >> testInitialContentOfSuspendedContext [
+DebugSessionContextsTest >> testInitialContentOfSuspendedContext [
 	"Checks that the interruptedContext of the DebugSession is the thisContext of the code where the DebugSession was created"
 	self assert: ((process suspendedContext lookupSymbol: #debugSession) interruptedProcess suspendedContext) identicalTo: debuggedThisContext.
 ]

--- a/src/Debugger-Tests/DebuggerTest.class.st
+++ b/src/Debugger-Tests/DebuggerTest.class.st
@@ -3,7 +3,7 @@ Superclass for classes containing debugger tests.
 Provides the ability to send #debuggerOnSetUpSession to a debugger test class to obtain a debugger opened on the debug session set up by that class for its tests.
 "
 Class {
-	#name : #DebuggerTests,
+	#name : #DebuggerTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'context',
@@ -14,18 +14,18 @@ Class {
 }
 
 { #category : #utilities }
-DebuggerTests >> inspectCurrentNode: aDebugSession [
+DebuggerTest >> inspectCurrentNode: aDebugSession [
 	context := aDebugSession interruptedContext.
 	(context method sourceNodeForPC: context pc) inspect.
 ]
 
 { #category : #accessing }
-DebuggerTests >> session [
+DebuggerTest >> session [
 	^ session
 ]
 
 { #category : #running }
-DebuggerTests >> setUp [
+DebuggerTest >> setUp [
 	super setUp.
 	context := nil.
 	process := nil.
@@ -33,7 +33,7 @@ DebuggerTests >> setUp [
 ]
 
 { #category : #utilities }
-DebuggerTests >> settingUpSessionAndProcessAndContextForBlock: aBlock [
+DebuggerTest >> settingUpSessionAndProcessAndContextForBlock: aBlock [
 	context := aBlock asContext.
 	process := Process 
 	    forContext: context 

--- a/src/Debugger-Tests/ErrorWasInUIProcessTest.class.st
+++ b/src/Debugger-Tests/ErrorWasInUIProcessTest.class.st
@@ -1,18 +1,18 @@
 Class {
-	#name : #ErrorWasInUIProcessTests,
-	#superclass : #DebuggerTests,
+	#name : #ErrorWasInUIProcessTest,
+	#superclass : #DebuggerTest,
 	#category : #'Debugger-Tests'
 }
 
 { #category : #tests }
-ErrorWasInUIProcessTests >> testErrorWasInUIProcessIsFalseWhenDebugSessionWasCreatedByANewProcess [
+ErrorWasInUIProcessTest >> testErrorWasInUIProcessIsFalseWhenDebugSessionWasCreatedByANewProcess [
 	"Test that errorWasInUIProcess is false if the DebugSession was created by a new process"
 	self settingUpSessionAndProcessAndContextForBlock: [ 1+1].
 	self assert: (session errorWasInUIProcess not)
 ]
 
 { #category : #tests }
-ErrorWasInUIProcessTests >> testErrorWasInUIProcessIsTrueWhenDebugSessionWasCreatedByTheUIProcess [
+ErrorWasInUIProcessTest >> testErrorWasInUIProcessIsTrueWhenDebugSessionWasCreatedByTheUIProcess [
 	"Test that errorWasInUIProcess is true when the DebugSession was created by the UI process"
 	
 	self skipOnPharoCITestingEnvironment.

--- a/src/Debugger-Tests/IsContextPostMortemTest.class.st
+++ b/src/Debugger-Tests/IsContextPostMortemTest.class.st
@@ -1,21 +1,21 @@
 Class {
-	#name : #IsContextPostMortemTests,
-	#superclass : #DebuggerTests,
+	#name : #IsContextPostMortemTest,
+	#superclass : #DebuggerTest,
 	#category : #'Debugger-Tests'
 }
 
 { #category : #helper }
-IsContextPostMortemTests >> stepA1 [
+IsContextPostMortemTest >> stepA1 [
 	^ self stepA2
 ]
 
 { #category : #helper }
-IsContextPostMortemTests >> stepA2 [
+IsContextPostMortemTest >> stepA2 [
 	^ 42
 ]
 
 { #category : #tests }
-IsContextPostMortemTests >> testIsContextPostMortem [
+IsContextPostMortemTest >> testIsContextPostMortem [
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepA1 ].
 	session stepInto.
 	"The top context of the context chain is not post mortem"

--- a/src/Debugger-Tests/IsLatestContextTest.class.st
+++ b/src/Debugger-Tests/IsLatestContextTest.class.st
@@ -2,22 +2,22 @@
 Testing the DebugSession>isLatestContext: method
 "
 Class {
-	#name : #IsLatestContextTests,
-	#superclass : #DebuggerTests,
+	#name : #IsLatestContextTest,
+	#superclass : #DebuggerTest,
 	#category : #'Debugger-Tests'
 }
 
 { #category : #helper }
-IsLatestContextTests >> stepA1 [
+IsLatestContextTest >> stepA1 [
 	self stepA2
 ]
 
 { #category : #helper }
-IsLatestContextTests >> stepA2 [
+IsLatestContextTest >> stepA2 [
 ]
 
 { #category : #tests }
-IsLatestContextTests >> testIsLatestContextTest [
+IsLatestContextTest >> testIsLatestContextTest [
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepA1 ].
 	"Checking that a Context that has nothing to do with the debugged execution is not LatestContext"
 	self assert: (session isLatestContext: [] asContext) not.

--- a/src/Debugger-Tests/MyHalt.class.st
+++ b/src/Debugger-Tests/MyHalt.class.st
@@ -12,6 +12,6 @@ MyHalt >> defaultAction [
 	| debugSession |
 	debugSession := Processor activeProcess newDebugSessionNamed: 'test' startedAt: self signalerContext.
 	"Storing the debug session in this class variable so that it can be recovered by the test"
-	DebugSessionContexts2 debugSession: debugSession.
+	DebugSessionContexts2Test debugSession: debugSession.
 	Processor activeProcess suspend.
 ]

--- a/src/Debugger-Tests/RestartTest.class.st
+++ b/src/Debugger-Tests/RestartTest.class.st
@@ -1,16 +1,16 @@
 Class {
-	#name : #RestartTests,
-	#superclass : #DebuggerTests,
+	#name : #RestartTest,
+	#superclass : #DebuggerTest,
 	#category : #'Debugger-Tests'
 }
 
 { #category : #tests }
-RestartTests >> stepA1 [
+RestartTest >> stepA1 [
 	self stepA2.
 ]
 
 { #category : #tests }
-RestartTests >> stepA2 [
+RestartTest >> stepA2 [
 	| a |
 	a := 1.
 	1+1.
@@ -18,7 +18,7 @@ RestartTests >> stepA2 [
 ]
 
 { #category : #tests }
-RestartTests >> testStepRestartAndRestepTopContext [
+RestartTest >> testStepRestartAndRestepTopContext [
 	"Get the execution to a context on method stepA2.
 	Step over in it to reach the end (and check that the temporary variable assignement works)
 	Restart the context.

--- a/src/Debugger-Tests/StepIntoTest.class.st
+++ b/src/Debugger-Tests/StepIntoTest.class.st
@@ -1,31 +1,31 @@
 Class {
-	#name : #StepIntoTests,
-	#superclass : #DebuggerTests,
+	#name : #StepIntoTest,
+	#superclass : #DebuggerTest,
 	#category : #'Debugger-Tests'
 }
 
 { #category : #helper }
-StepIntoTests >> callQuickMethodWithoutReturningItsResult [
+StepIntoTest >> callQuickMethodWithoutReturningItsResult [
 	self quickMethod.
 ]
 
 { #category : #helper }
-StepIntoTests >> quickMethod [
+StepIntoTest >> quickMethod [
 	^1.
 ]
 
 { #category : #helper }
-StepIntoTests >> returnQuickMethodResult [
+StepIntoTest >> returnQuickMethodResult [
 	^ self quickMethod.
 ]
 
 { #category : #helper }
-StepIntoTests >> stepA1 [
+StepIntoTest >> stepA1 [
 	^42
 ]
 
 { #category : #tests }
-StepIntoTests >> testDetectionOfExecutionEnd [
+StepIntoTest >> testDetectionOfExecutionEnd [
 	self settingUpSessionAndProcessAndContextForBlock: [  ].
 	session stepInto.
 	"These ways do not detect that the execution ended"
@@ -39,7 +39,7 @@ StepIntoTests >> testDetectionOfExecutionEnd [
 ]
 
 { #category : #tests }
-StepIntoTests >> testStepIntoDeadContextShouldRaiseException [
+StepIntoTest >> testStepIntoDeadContextShouldRaiseException [
 	self settingUpSessionAndProcessAndContextForBlock: [  ].
 	session stepInto. "The first step into executes the (empty) body of the block and returns from it. From this point on, the context is dead since it returned."
 	
@@ -55,7 +55,7 @@ StepIntoTests >> testStepIntoDeadContextShouldRaiseException [
 ]
 
 { #category : #tests }
-StepIntoTests >> testStepIntoMethodCallShouldActivateIt [
+StepIntoTest >> testStepIntoMethodCallShouldActivateIt [
 	"Stepping into a method call should create a context for it at the top of the context stack"
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepA1].
 	session stepInto.
@@ -66,7 +66,7 @@ StepIntoTests >> testStepIntoMethodCallShouldActivateIt [
 ]
 
 { #category : #tests }
-StepIntoTests >> testStepIntoQuickMethodCallNotReturnedShouldLeaveTheValueStackEmpty [
+StepIntoTest >> testStepIntoQuickMethodCallNotReturnedShouldLeaveTheValueStackEmpty [
 	"Stepping into a quick method whose result is not used should leave the value stack empty"
 	self settingUpSessionAndProcessAndContextForBlock: [ self callQuickMethodWithoutReturningItsResult].
 	session stepInto.
@@ -81,7 +81,7 @@ StepIntoTests >> testStepIntoQuickMethodCallNotReturnedShouldLeaveTheValueStackE
 ]
 
 { #category : #tests }
-StepIntoTests >> testStepIntoQuickMethodCallReturnedShouldPushReturnValueToTheStack [
+StepIntoTest >> testStepIntoQuickMethodCallReturnedShouldPushReturnValueToTheStack [
 	"Stepping into a call to a quick method whose result is used should push its return value to the stack"
 	self settingUpSessionAndProcessAndContextForBlock: [ self returnQuickMethodResult].
 	session stepInto.

--- a/src/Debugger-Tests/StepOverTest.class.st
+++ b/src/Debugger-Tests/StepOverTest.class.st
@@ -1,77 +1,77 @@
 Class {
-	#name : #StepOverTests,
-	#superclass : #DebuggerTests,
+	#name : #StepOverTest,
+	#superclass : #DebuggerTest,
 	#category : #'Debugger-Tests'
 }
 
 { #category : #helper }
-StepOverTests >> step1 [
+StepOverTest >> step1 [
 	self step2.
 ]
 
 { #category : #helper }
-StepOverTests >> step2 [
+StepOverTest >> step2 [
 	[ self step3 ] on: Notification do: [ ^2 ].
 ]
 
 { #category : #helper }
-StepOverTests >> step3 [
+StepOverTest >> step3 [
 	self step4.
 	^4
 ]
 
 { #category : #helper }
-StepOverTests >> step4 [
+StepOverTest >> step4 [
 	self notify: 'hey'
 ]
 
 { #category : #helper }
-StepOverTests >> stepA1 [
+StepOverTest >> stepA1 [
 	self stepA2.
 	^ 42.
 ]
 
 { #category : #helper }
-StepOverTests >> stepA2 [
+StepOverTest >> stepA2 [
 	^ True
 ]
 
 { #category : #helper }
-StepOverTests >> stepB1 [
+StepOverTest >> stepB1 [
 	self stepB2.
 	^42.
 ]
 
 { #category : #helper }
-StepOverTests >> stepB2 [
+StepOverTest >> stepB2 [
 	self stepB3
 ]
 
 { #category : #helper }
-StepOverTests >> stepB3 [
+StepOverTest >> stepB3 [
 	^ 42
 ]
 
 { #category : #tests }
-StepOverTests >> stepC1 [
+StepOverTest >> stepC1 [
 	self stepC2.
 ]
 
 { #category : #tests }
-StepOverTests >> stepC2 [
+StepOverTest >> stepC2 [
 	1+1.
 	^ 2
 ]
 
 { #category : #tests }
-StepOverTests >> testErrorSignalledDuringStepOverShouldBeCaught [
+StepOverTest >> testErrorSignalledDuringStepOverShouldBeCaught [
 	"An Error signaled while being steppedOver should not be unhandled"
 	self settingUpSessionAndProcessAndContextForBlock: [ Error signal: 'hey'. ].
 	self shouldnt: [[ session interruptedProcess isTerminated ] whileFalse: [ session stepOver. ]] raise: Error.
 ]
 
 { #category : #tests }
-StepOverTests >> testStepOver [
+StepOverTest >> testStepOver [
 	"Stepping over a message node brings the execution to the next node in the same method."
 	| node |
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepA1 ].
@@ -90,7 +90,7 @@ StepOverTests >> testStepOver [
 ]
 
 { #category : #tests }
-StepOverTests >> testStepOverComputedReturn [
+StepOverTest >> testStepOverComputedReturn [
 	"When doing a stepOver on a return node whose return value is already computed, the current context returns and the session goes to the message node responsible for the context that just returned" 
 	"<-> indicates the node being executed
 	Initial situation:
@@ -124,21 +124,21 @@ StepOverTests >> testStepOverComputedReturn [
 ]
 
 { #category : #tests }
-StepOverTests >> testStepOverDoesNotUnderstand [
+StepOverTest >> testStepOverDoesNotUnderstand [
 	"Stepping over a message not understood should not raise an unhandled exception"
 	self settingUpSessionAndProcessAndContextForBlock: [ self messageNotUnderstood].
 	self shouldnt: [[ session interruptedProcess isTerminated ] whileFalse: [ session stepOver. ]] raise: Exception.
 ]
 
 { #category : #tests }
-StepOverTests >> testStepOverHalt [
+StepOverTest >> testStepOverHalt [
 	"Stepping over a self halt should not raise an unhandled exception"
 	self settingUpSessionAndProcessAndContextForBlock: [ self halt. ].
 	self shouldnt: [[ session interruptedProcess isTerminated ] whileFalse: [ session stepOver. ]] raise: Exception.
 ]
 
 { #category : #tests }
-StepOverTests >> testStepOverLastNodeOfContext [
+StepOverTest >> testStepOverLastNodeOfContext [
 	"Stepping over the last node of a method brings the execution to the method node of that method."
 	| node |
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepB1 ].
@@ -160,7 +160,7 @@ StepOverTests >> testStepOverLastNodeOfContext [
 ]
 
 { #category : #tests }
-StepOverTests >> testStepOverNonErrorExceptionSignalWithHandlerDeeperInTheContextStack [
+StepOverTest >> testStepOverNonErrorExceptionSignalWithHandlerDeeperInTheContextStack [
 	"Context stack (from top to bottom) of the execution:
 	self step4 | signal a Notification exception
 	self step3 | just calls step 4. Point at which this test performs the stepOver

--- a/src/Debugger-Tests/StepThroughTest.class.st
+++ b/src/Debugger-Tests/StepThroughTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #StepThroughTests,
-	#superclass : #DebuggerTests,
+	#name : #StepThroughTest,
+	#superclass : #DebuggerTest,
 	#instVars : [
 		'assistant'
 	],
@@ -8,39 +8,39 @@ Class {
 }
 
 { #category : #helper }
-StepThroughTests >> evalBlockThenReturnOne: aBlock [
+StepThroughTest >> evalBlockThenReturnOne: aBlock [
 	aBlock value.
 	^1.
 ]
 
 { #category : #helper }
-StepThroughTests >> stepA1 [
+StepThroughTest >> stepA1 [
 	self evalBlockThenReturnOne: [ self stepA2 ].
 ]
 
 { #category : #helper }
-StepThroughTests >> stepA2 [
+StepThroughTest >> stepA2 [
 	^ 2+2
 ]
 
 { #category : #helper }
-StepThroughTests >> stepB1 [
+StepThroughTest >> stepB1 [
 	self stepB2.
 	self stepB3.
 ]
 
 { #category : #helper }
-StepThroughTests >> stepB2 [
+StepThroughTest >> stepB2 [
 	^ 42
 ]
 
 { #category : #helper }
-StepThroughTests >> stepB3 [
+StepThroughTest >> stepB3 [
 	^ 43
 ]
 
 { #category : #tests }
-StepThroughTests >> testStepThrough [
+StepThroughTest >> testStepThrough [
 	"In a context c, define a block b, send a message to another method to get b evaluated.
 	Testing that a step through on this message send moves the execution to the point where the block b is about to be evaluated."
 	| node |
@@ -66,7 +66,7 @@ StepThroughTests >> testStepThrough [
 ]
 
 { #category : #tests }
-StepThroughTests >> testStepThroughDoesTheSameThingAsStepOverWhenNoBlockIsInvolved [
+StepThroughTest >> testStepThroughDoesTheSameThingAsStepOverWhenNoBlockIsInvolved [
 	"Testing that when no block is involved, a step through moves the execution to the same point a step over would"
 	| node |
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepB1 ].


### PR DESCRIPTION
Debugger test cases should end with Test instead of Tests.