### PR TITLE
Commander-test-cases-should-end-with-Test

### DIFF
--- a/src/Commander-Core-Tests/CmdCommandActivationStrategyTest.class.st
+++ b/src/Commander-Core-Tests/CmdCommandActivationStrategyTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #CmdCommandActivationStrategyTests,
+	#name : #CmdCommandActivationStrategyTest,
 	#superclass : #TestCase,
 	#category : #'Commander-Core-Tests'
 }
 
 { #category : #tests }
-CmdCommandActivationStrategyTests >> testCreationNewActivatorForGivenContext [
+CmdCommandActivationStrategyTest >> testCreationNewActivatorForGivenContext [
 	| activation context actual |
 	activation := CmdCommandActivationExample withAnnotatedClass: CmdCommandExampleInheritedFromAbstract.
 	context := CmdToolContextStub new.
@@ -20,7 +20,7 @@ CmdCommandActivationStrategyTests >> testCreationNewActivatorForGivenContext [
 ]
 
 { #category : #tests }
-CmdCommandActivationStrategyTests >> testIteratingInstancesShouldSkipAbstractCommands [
+CmdCommandActivationStrategyTest >> testIteratingInstancesShouldSkipAbstractCommands [
 
 	| activators context |
 	context := CmdToolContextStub1 new.

--- a/src/Commander-Core-Tests/CmdCommandActivatorTest.class.st
+++ b/src/Commander-Core-Tests/CmdCommandActivatorTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #CmdCommandActivatorTests,
+	#name : #CmdCommandActivatorTest,
 	#superclass : #TestCase,
 	#category : #'Commander-Core-Tests'
 }
 
 { #category : #tests }
-CmdCommandActivatorTests >> testConvertingCommandToActivator [
+CmdCommandActivatorTest >> testConvertingCommandToActivator [
 
 	| activator command |
 	command := CmdCommandExampleInRootMenu new.
@@ -20,7 +20,7 @@ CmdCommandActivatorTests >> testConvertingCommandToActivator [
 ]
 
 { #category : #tests }
-CmdCommandActivatorTests >> testConvertingToActivator [
+CmdCommandActivatorTest >> testConvertingToActivator [
 
 	| activator |
 	activator := CmdCommandActivator new.
@@ -29,7 +29,7 @@ CmdCommandActivatorTests >> testConvertingToActivator [
 ]
 
 { #category : #tests }
-CmdCommandActivatorTests >> testCreationNewForNewCommand [
+CmdCommandActivatorTest >> testCreationNewForNewCommand [
 
 	| activator newActivator |
 	activator := CmdCommandActivator new.

--- a/src/Commander-Core-Tests/CmdMenuTest.class.st
+++ b/src/Commander-Core-Tests/CmdMenuTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #CmdMenuTests,
+	#name : #CmdMenuTest,
 	#superclass : #TestCase,
 	#category : #'Commander-Core-Tests'
 }
 
 { #category : #tests }
-CmdMenuTests >> buildMenuInContext: aToolContext [
+CmdMenuTest >> buildMenuInContext: aToolContext [
 	| menu |
 	menu := CmdMenu  
 		activatedBy: CmdMenuCommandActivationExample.
@@ -16,7 +16,7 @@ CmdMenuTests >> buildMenuInContext: aToolContext [
 ]
 
 { #category : #tests }
-CmdMenuTests >> testCommandItemShouldContainPreparedCommandInstance [
+CmdMenuTest >> testCommandItemShouldContainPreparedCommandInstance [
 	| menu command context containingItems |
 	context := CmdToolContextStub1 new.
 	menu := self buildMenuInContext: context.
@@ -29,7 +29,7 @@ CmdMenuTests >> testCommandItemShouldContainPreparedCommandInstance [
 ]
 
 { #category : #tests }
-CmdMenuTests >> testWhenCommandShouldBeInDeepChildGroup [
+CmdMenuTest >> testWhenCommandShouldBeInDeepChildGroup [
 	| menu containingItems parents |
 	menu := self buildMenuInContext: CmdToolContextStub2 new.
 	
@@ -42,7 +42,7 @@ CmdMenuTests >> testWhenCommandShouldBeInDeepChildGroup [
 ]
 
 { #category : #tests }
-CmdMenuTests >> testWhenCommandShouldBeInMultipleGroups [
+CmdMenuTest >> testWhenCommandShouldBeInMultipleGroups [
 	| menu containingGroups |
 	menu := self buildMenuInContext: CmdToolContextStub1 new.
 	
@@ -53,7 +53,7 @@ CmdMenuTests >> testWhenCommandShouldBeInMultipleGroups [
 ]
 
 { #category : #tests }
-CmdMenuTests >> testWhenCommandShouldBeInRootMenu [
+CmdMenuTest >> testWhenCommandShouldBeInRootMenu [
 	| menu containingItems |
 	menu := self buildMenuInContext: CmdToolContextStub1 new.
 	
@@ -63,7 +63,7 @@ CmdMenuTests >> testWhenCommandShouldBeInRootMenu [
 ]
 
 { #category : #tests }
-CmdMenuTests >> testWhenGivenContextIsUnused [
+CmdMenuTest >> testWhenGivenContextIsUnused [
 	| menu |
 	menu := self buildMenuInContext: CmdUnusedToolContextStub new.
 	


### PR DESCRIPTION
Commander test cases should end with Test instead of Tests.