### PR TITLE
STON-test-cases-should-end-with-Test

### DIFF
--- a/src/STON-Tests/STONCStyleCommentsSkipStreamTest.class.st
+++ b/src/STON-Tests/STONCStyleCommentsSkipStreamTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #STONCStyleCommentsSkipStreamTests,
+	#name : #STONCStyleCommentsSkipStreamTest,
 	#superclass : #TestCase,
 	#category : #'STON-Tests-Utilities'
 }
 
 { #category : #testing }
-STONCStyleCommentsSkipStreamTests >> testCommentInString [
+STONCStyleCommentsSkipStreamTest >> testCommentInString [
 	self 
 		assert: (STONCStyleCommentsSkipStream on: '''/*comment*/''' readStream) upToEnd 
 		equals: '''/*comment*/'''.
@@ -24,7 +24,7 @@ STONCStyleCommentsSkipStreamTests >> testCommentInString [
 ]
 
 { #category : #testing }
-STONCStyleCommentsSkipStreamTests >> testMultiLineComment [
+STONCStyleCommentsSkipStreamTest >> testMultiLineComment [
 	self 
 		assert: (STONCStyleCommentsSkipStream on: 'foo\//comment\bar' withCRs readStream) upToEnd 
 		equals: 'foo\bar' withCRs.
@@ -38,7 +38,7 @@ STONCStyleCommentsSkipStreamTests >> testMultiLineComment [
 ]
 
 { #category : #testing }
-STONCStyleCommentsSkipStreamTests >> testNonComment [
+STONCStyleCommentsSkipStreamTest >> testNonComment [
 	self assert: (STONCStyleCommentsSkipStream on: 'foo' readStream) upToEnd equals: 'foo'.
 	self assert: (STONCStyleCommentsSkipStream on: 'foo' readStream) nextLine equals: 'foo'.
 	self deny: (STONCStyleCommentsSkipStream on: 'foo' readStream) atEnd.
@@ -46,7 +46,7 @@ STONCStyleCommentsSkipStreamTests >> testNonComment [
 ]
 
 { #category : #testing }
-STONCStyleCommentsSkipStreamTests >> testSTON [
+STONCStyleCommentsSkipStreamTest >> testSTON [
 	"Comments are processed first and totally removed.
 	They are not even whitespace (not that whitespace is relevant in STON)."
 	
@@ -66,7 +66,7 @@ STONCStyleCommentsSkipStreamTests >> testSTON [
 ]
 
 { #category : #testing }
-STONCStyleCommentsSkipStreamTests >> testSingleLineComment [
+STONCStyleCommentsSkipStreamTest >> testSingleLineComment [
 	self assert: (STONCStyleCommentsSkipStream on: 'foo/*comment*/bar' readStream) upToEnd equals: 'foobar'.
 	self assert: (STONCStyleCommentsSkipStream on: 'foo/*comment*/bar' readStream) nextLine equals: 'foobar'.
 	self deny: (STONCStyleCommentsSkipStream on: 'foo/*comment*/bar' readStream) atEnd.

--- a/src/STON-Tests/STONJSONTest.class.st
+++ b/src/STON-Tests/STONJSONTest.class.st
@@ -2,13 +2,13 @@
 STONJSONTests contains unit tests for the JSON functionality available in STON.
 "
 Class {
-	#name : #STONJSONTests,
+	#name : #STONJSONTest,
 	#superclass : #TestCase,
 	#category : #'STON-Tests-Base'
 }
 
 { #category : #tests }
-STONJSONTests >> testBooleans [
+STONJSONTest >> testBooleans [
 	self assert: (STONJSON toString: true) equals: 'true'.
 	self assert: (STONJSON toString: false) equals: 'false'.
 	self assert: (STONJSON fromString: 'true') equals: true.
@@ -16,7 +16,7 @@ STONJSONTests >> testBooleans [
 ]
 
 { #category : #tests }
-STONJSONTests >> testCircular [
+STONJSONTest >> testCircular [
 	"Circular datastructures cannot be encoded using JSON"
 	self
 		should: [ | foo |
@@ -27,7 +27,7 @@ STONJSONTests >> testCircular [
 ]
 
 { #category : #tests }
-STONJSONTests >> testFloats [
+STONJSONTest >> testFloats [
 	self assert: (STONJSON toString: 1.0) equals: '1.0'.
 	self assert: (STONJSON toString: 0.0) equals: '0.0'.
 	self assert: (STONJSON toString: -1.0) equals: '-1.0'.
@@ -39,7 +39,7 @@ STONJSONTests >> testFloats [
 ]
 
 { #category : #tests }
-STONJSONTests >> testIntegers [
+STONJSONTest >> testIntegers [
 	self assert: (STONJSON toString: 1) equals: '1'.
 	self assert: (STONJSON toString: 0) equals: '0'.
 	self assert: (STONJSON toString: -1) equals: '-1'.
@@ -51,7 +51,7 @@ STONJSONTests >> testIntegers [
 ]
 
 { #category : #tests }
-STONJSONTests >> testLists [
+STONJSONTest >> testLists [
 	self assert: (STONJSON toString: #(1 2 3)) equals: '[1,2,3]'.
 	self assert: (STONJSON toString: #(1 -2 true 3 nil)) equals: '[1,-2,true,3,null]'.
 	self assert: (STONJSON toString: #(1 (2) 3)) equals: '[1,[2],3]'.
@@ -63,7 +63,7 @@ STONJSONTests >> testLists [
 ]
 
 { #category : #tests }
-STONJSONTests >> testMaps [
+STONJSONTest >> testMaps [
 	self assert: (STONJSON toString: { 'temperature'->37 } asDictionary) equals: '{"temperature":37}'.
 	self assert: (STONJSON toString: Dictionary new) equals: '{}'.
 	self assert: (STONJSON fromString: '{"temperature":37}') equals: { 'temperature'->37 } asDictionary.
@@ -71,13 +71,13 @@ STONJSONTests >> testMaps [
 ]
 
 { #category : #tests }
-STONJSONTests >> testNull [
+STONJSONTest >> testNull [
 	self assert: (STONJSON toString: nil) equals: 'null'.
 	self assert: (STONJSON fromString: 'null') equals: nil.
 ]
 
 { #category : #tests }
-STONJSONTests >> testShared [
+STONJSONTest >> testShared [
 	"Structure sharing cannot be encoded using JSON"
 	self
 		should: [ | foo |
@@ -87,7 +87,7 @@ STONJSONTests >> testShared [
 ]
 
 { #category : #tests }
-STONJSONTests >> testStrings [
+STONJSONTest >> testStrings [
 	self assert: (STONJSON toString: 'string') equals: '"string"'.
 	self assert: (STONJSON toString: '') equals: '""'.
 	self assert: (STONJSON toString: 'élèves français') equals: '"élèves français"'.
@@ -101,7 +101,7 @@ STONJSONTests >> testStrings [
 ]
 
 { #category : #tests }
-STONJSONTests >> testUnknown [
+STONJSONTest >> testUnknown [
 	"Only Array for lists and Dictionary for maps are allowed for JSON encoding,
 	any other Smalltalk object cannot be encoded (following the specs).
 	Even considering all collections to be lists won't work because the type 

--- a/src/STON-Tests/STONLargeWriteReadTest.class.st
+++ b/src/STON-Tests/STONLargeWriteReadTest.class.st
@@ -2,13 +2,13 @@
 STONLargeWriteReadTests test the optimalizations for large structures.
 "
 Class {
-	#name : #STONLargeWriteReadTests,
-	#superclass : #STONWriteReadTests,
+	#name : #STONLargeWriteReadTest,
+	#superclass : #STONWriteReadTest,
 	#category : #'STON-Tests-Writer'
 }
 
 { #category : #private }
-STONLargeWriteReadTests >> materialize: string [
+STONLargeWriteReadTest >> materialize: string [
 	^ STON reader
 		on: string readStream;
 		optimizeForLargeStructures;
@@ -16,7 +16,7 @@ STONLargeWriteReadTests >> materialize: string [
 ]
 
 { #category : #private }
-STONLargeWriteReadTests >> serialize: anObject [
+STONLargeWriteReadTest >> serialize: anObject [
 	^ String streamContents: [ :stream |
 		STON writer 
 			on: stream; 
@@ -25,7 +25,7 @@ STONLargeWriteReadTests >> serialize: anObject [
 ]
 
 { #category : #private }
-STONLargeWriteReadTests >> serializeJson: anObject [
+STONLargeWriteReadTest >> serializeJson: anObject [
 	^ String streamContents: [ :stream |
 		STON jsonWriter 
 			on: stream; 

--- a/src/STON-Tests/STONReaderTest.class.st
+++ b/src/STON-Tests/STONReaderTest.class.st
@@ -3,20 +3,20 @@ STONReaderTests test materialization.
 
 "
 Class {
-	#name : #STONReaderTests,
+	#name : #STONReaderTest,
 	#superclass : #TestCase,
 	#category : #'STON-Tests-Reader'
 }
 
 { #category : #private }
-STONReaderTests >> materialize: string [
+STONReaderTest >> materialize: string [
 	^ STON reader 
 		on: string readStream;
 		next
 ]
 
 { #category : #tests }
-STONReaderTests >> testAssociation [
+STONReaderTest >> testAssociation [
 	self assert: (self materialize: '''foo'':1') = ('foo' -> 1).
 	self assert: (self materialize: '#bar:2') = (#bar -> 2).
 	self assert: (self materialize: '''foo bar'':#ok') = ('foo bar' -> #ok).
@@ -32,29 +32,29 @@ STONReaderTests >> testAssociation [
 ]
 
 { #category : #tests }
-STONReaderTests >> testBoolean [
+STONReaderTest >> testBoolean [
 	self assert: (self materialize: 'true') equals: true.
 	self assert: (self materialize: 'false') equals: false
 ]
 
 { #category : #tests }
-STONReaderTests >> testByteArray [
+STONReaderTest >> testByteArray [
 	self assert: (self materialize: 'ByteArray[''010203'']') = #(1 2 3) asByteArray
 
 ]
 
 { #category : #tests }
-STONReaderTests >> testCharacter [
+STONReaderTest >> testCharacter [
 	self assert: (self materialize: 'Character[''A'']') == $A.
 ]
 
 { #category : #tests }
-STONReaderTests >> testClass [
+STONReaderTest >> testClass [
 	self assert: (self materialize: 'Class[#Point]') equals: Point
 ]
 
 { #category : #tests }
-STONReaderTests >> testClassWithUnderscore [
+STONReaderTest >> testClassWithUnderscore [
 
 	| cls data reader |
 
@@ -72,7 +72,7 @@ STONReaderTests >> testClassWithUnderscore [
 ]
 
 { #category : #tests }
-STONReaderTests >> testConvertingNewLines [
+STONReaderTest >> testConvertingNewLines [
 	| input result output |
 	input := '''line ending with CR', String cr, 
 		'line ending with LF', String lf, 
@@ -90,21 +90,21 @@ STONReaderTests >> testConvertingNewLines [
 ]
 
 { #category : #tests }
-STONReaderTests >> testDate [
+STONReaderTest >> testDate [
 	| date |
 	date := Date year: 2012 month: 1 day: 1.
 	self assert: (self materialize: 'Date[''2012-01-01'']') = date
 ]
 
 { #category : #tests }
-STONReaderTests >> testDateAndTime [
+STONReaderTest >> testDateAndTime [
 	| dateAndTime |
 	dateAndTime := DateAndTime year: 2012 month: 1 day: 1 hour: 6 minute: 30 second: 15 offset: 1 hour.
 	self assert: (self materialize: 'DateAndTime[''2012-01-01T06:30:15+01:00'']') = dateAndTime
 ]
 
 { #category : #tests }
-STONReaderTests >> testDeepStructure [
+STONReaderTest >> testDeepStructure [
 	| holder deepest structure writer ston reader result |
 	"Create a deep nested structure so that the deepest element is a reference back to a top level holder."
 	holder := Array with: 42.
@@ -121,7 +121,7 @@ STONReaderTests >> testDeepStructure [
 ]
 
 { #category : #tests }
-STONReaderTests >> testDictionary [
+STONReaderTest >> testDictionary [
 	| collection |
 	collection := STON mapClass new at: 1 put: 1; at: 2 put: 2; yourself.
 	self assert: (self materialize: '{1:1,2:2}') = collection.
@@ -130,7 +130,7 @@ STONReaderTests >> testDictionary [
 ]
 
 { #category : #tests }
-STONReaderTests >> testDictionaryWithComplexKeys [
+STONReaderTest >> testDictionaryWithComplexKeys [
 	| collection reader |
 	collection := STON mapClass new at: true put: 1; at: #(foo) put: 2; yourself.
 	"allowing complex map keys used to be optional, now it is always the default"
@@ -139,7 +139,7 @@ STONReaderTests >> testDictionaryWithComplexKeys [
 ]
 
 { #category : #tests }
-STONReaderTests >> testDictionaryWithIndirectReferenceKeys [
+STONReaderTest >> testDictionaryWithIndirectReferenceKeys [
 	| keysCollection dictionary ston object |
 	keysCollection := OrderedCollection streamContents: [ :out |
 		10 timesRepeat: [ out nextPut: UUID new ] ].
@@ -155,7 +155,7 @@ STONReaderTests >> testDictionaryWithIndirectReferenceKeys [
 ]
 
 { #category : #tests }
-STONReaderTests >> testDictionaryWithReferenceKeys [
+STONReaderTest >> testDictionaryWithReferenceKeys [
 	| keysCollection dictionary ston object |
 	keysCollection := OrderedCollection streamContents: [ :out |
 		10 timesRepeat: [ out nextPut: UUID new ] ].
@@ -171,7 +171,7 @@ STONReaderTests >> testDictionaryWithReferenceKeys [
 ]
 
 { #category : #tests }
-STONReaderTests >> testError [
+STONReaderTest >> testError [
 	#( 'foo' '{foo:}' '{foo,}' '[1,]' '+1' ']' '#' '' '  ' '	' 'nul' 'tru' 'fals' ) do: [ :each |
 		self 
 			should: [ self materialize: each ] 
@@ -180,7 +180,7 @@ STONReaderTests >> testError [
 ]
 
 { #category : #tests }
-STONReaderTests >> testFloat [
+STONReaderTest >> testFloat [
 	self assert: ((self materialize: '1.5') closeTo: 1.5).
 	self assert: ((self materialize: '-1.5') closeTo: -1.5).
 	self assert: (self materialize: '0.0') isZero.
@@ -192,7 +192,7 @@ STONReaderTests >> testFloat [
 ]
 
 { #category : #tests }
-STONReaderTests >> testIdentityDictionary [
+STONReaderTest >> testIdentityDictionary [
 	| collection |
 	collection := IdentityDictionary new at: 1 put: 1; at: 2 put: 2; yourself.
 	self assert: (self materialize: 'IdentityDictionary{1:1,2:2}') = collection.
@@ -201,7 +201,7 @@ STONReaderTests >> testIdentityDictionary [
 ]
 
 { #category : #tests }
-STONReaderTests >> testIllegalCharacterEscapes [
+STONReaderTest >> testIllegalCharacterEscapes [
 	self should: [ STON fromString: '''\a''' ] raise: STONReaderError.
 	self should: [ STON fromString: '''\u''' ] raise: STONReaderError.
 	self should: [ STON fromString: '''\u00''' ] raise: STONReaderError.
@@ -210,7 +210,7 @@ STONReaderTests >> testIllegalCharacterEscapes [
 ]
 
 { #category : #tests }
-STONReaderTests >> testInteger [
+STONReaderTest >> testInteger [
 	self assert: (self materialize: '1') = 1.
 	self assert: (self materialize: '-1') = -1.
 	self assert: (self materialize: '0') = 0.
@@ -219,7 +219,7 @@ STONReaderTests >> testInteger [
 ]
 
 { #category : #tests }
-STONReaderTests >> testJsonString [
+STONReaderTest >> testJsonString [
 	"Allow double quotes for backwards JSON compatibility"
 	
 	| string |
@@ -233,25 +233,25 @@ STONReaderTests >> testJsonString [
 ]
 
 { #category : #tests }
-STONReaderTests >> testList [
+STONReaderTest >> testList [
 	self assert: STON listClass = Array.
 	self assert: (self materialize: '[1,2,3]') = (STON listClass with: 1 with: 2 with: 3).
 	self assert: (self materialize: '[]') = STON listClass new
 ]
 
 { #category : #tests }
-STONReaderTests >> testMap [
+STONReaderTest >> testMap [
 	self assert: (self materialize: '{#foo:1}') = (STON mapClass new at: #foo put: 1; yourself).
 	self assert: (self materialize: '{}') = STON mapClass new
 ]
 
 { #category : #tests }
-STONReaderTests >> testMetaclass [
+STONReaderTest >> testMetaclass [
 	self assert: (self materialize: 'Metaclass[#Point]') equals: Point class
 ]
 
 { #category : #tests }
-STONReaderTests >> testMultiple [
+STONReaderTest >> testMultiple [
 	| reader |
 	reader := STON reader 
 		on: '123 -123 nil #foo true [ 0 ] false { #one : 1 }' readStream.
@@ -269,7 +269,7 @@ STONReaderTests >> testMultiple [
 ]
 
 { #category : #tests }
-STONReaderTests >> testNewSymbol [
+STONReaderTest >> testNewSymbol [
 	| n notASymbol shouldBeSymbol |
 	
 	"Find a name that has not yet been interned"
@@ -283,12 +283,12 @@ STONReaderTests >> testNewSymbol [
 ]
 
 { #category : #tests }
-STONReaderTests >> testNil [
+STONReaderTest >> testNil [
 	self assert: (self materialize: 'nil') isNil
 ]
 
 { #category : #tests }
-STONReaderTests >> testNonBMPCharacterDecoding [
+STONReaderTest >> testNonBMPCharacterDecoding [
 	"Characters not in the Basic Multilingual Plane are encoded as a UTF-16 surrogate pair"
 
 	| string object |
@@ -298,18 +298,18 @@ STONReaderTests >> testNonBMPCharacterDecoding [
 ]
 
 { #category : #tests }
-STONReaderTests >> testNull [
+STONReaderTest >> testNull [
 	self assert: (self materialize: 'null') isNil
 ]
 
 { #category : #tests }
-STONReaderTests >> testObject [
+STONReaderTest >> testObject [
 	self assert: (self materialize: 'Point[1,2]') = (1@2).
 	self assert: (self materialize: 'Point[1.5,-0.5]') = (1.5 @ -0.5).
 ]
 
 { #category : #tests }
-STONReaderTests >> testOrderedCollection [
+STONReaderTest >> testOrderedCollection [
 	| collection |
 	collection := OrderedCollection with: 1 with: 2 with: 3.
 	self assert: (self materialize: 'OrderedCollection[1,2,3]') = collection.
@@ -317,12 +317,12 @@ STONReaderTests >> testOrderedCollection [
 ]
 
 { #category : #tests }
-STONReaderTests >> testPoint [
+STONReaderTest >> testPoint [
 	self assert: (self materialize: 'Point[1,2]') = (1@2)
 ]
 
 { #category : #tests }
-STONReaderTests >> testReferenceCycle [
+STONReaderTest >> testReferenceCycle [
 	| array |
 	array := (self materialize: '[1,@1]').
 	self assert: array class = STON listClass.
@@ -332,7 +332,7 @@ STONReaderTests >> testReferenceCycle [
 ]
 
 { #category : #tests }
-STONReaderTests >> testReferenceSharing [
+STONReaderTest >> testReferenceSharing [
 	| one array |
 	one := { #one }.
 	array := (self materialize: '[[#one],@2,@2]').
@@ -342,7 +342,7 @@ STONReaderTests >> testReferenceSharing [
 ]
 
 { #category : #tests }
-STONReaderTests >> testSetWithIndirectReferenceElements [
+STONReaderTest >> testSetWithIndirectReferenceElements [
 	| elementsCollection set ston object |
 	elementsCollection := OrderedCollection streamContents: [ :out |
 		10 timesRepeat: [ out nextPut: UUID new ] ].
@@ -356,7 +356,7 @@ STONReaderTests >> testSetWithIndirectReferenceElements [
 ]
 
 { #category : #tests }
-STONReaderTests >> testSetWithReferenceElements [
+STONReaderTest >> testSetWithReferenceElements [
 	| elementsCollection set ston object |
 	elementsCollection := OrderedCollection streamContents: [ :out |
 		10 timesRepeat: [ out nextPut: UUID new ] ].
@@ -370,7 +370,7 @@ STONReaderTests >> testSetWithReferenceElements [
 ]
 
 { #category : #tests }
-STONReaderTests >> testStreaming [
+STONReaderTest >> testStreaming [
 	| reader |
 	reader := STON reader 
 		on: '1 2 3 4 5 6 7 8 9 10' readStream.
@@ -382,7 +382,7 @@ STONReaderTests >> testStreaming [
 ]
 
 { #category : #tests }
-STONReaderTests >> testString [
+STONReaderTest >> testString [
 	| string |
 	self assert: (self materialize: '''foo''') = 'foo'.
 	self assert: (self materialize: '''FOO''') = 'FOO'.
@@ -394,13 +394,13 @@ STONReaderTests >> testString [
 ]
 
 { #category : #tests }
-STONReaderTests >> testSymbol [
+STONReaderTest >> testSymbol [
 	self assert: (self materialize: '#''foo''') = #foo.
 	self assert: (self materialize: '#foo') = #foo
 ]
 
 { #category : #tests }
-STONReaderTests >> testTime [
+STONReaderTest >> testTime [
 	| time |
 	time := Time hour: 6 minute: 30 second: 15.
 	self assert: (self materialize: 'Time[''06:30:15'']') equals: time.
@@ -410,7 +410,7 @@ STONReaderTests >> testTime [
 ]
 
 { #category : #tests }
-STONReaderTests >> testUnknownClasses [
+STONReaderTest >> testUnknownClasses [
 	| input object |
 	input := 'FooBar { #foo : 1, #bar : true }'.
 	self should: [ self materialize: input ] raise: STONReaderError.
@@ -425,7 +425,7 @@ STONReaderTests >> testUnknownClasses [
 ]
 
 { #category : #tests }
-STONReaderTests >> testUser [
+STONReaderTest >> testUser [
 	| user |
 	(user := STONTestUser new)
 		username: 'john@foo.com';
@@ -434,7 +434,7 @@ STONReaderTests >> testUser [
 ]
 
 { #category : #tests }
-STONReaderTests >> testUser2 [
+STONReaderTest >> testUser2 [
 	| user |
 	(user := STONTestUser2 new)
 		username: 'john@foo.com';
@@ -443,7 +443,7 @@ STONReaderTests >> testUser2 [
 ]
 
 { #category : #tests }
-STONReaderTests >> testWhitespace [
+STONReaderTest >> testWhitespace [
 	| whitespace |
 	whitespace := { Character space. Character tab. Character cr. Character lf }.
 	self assert: (self materialize: whitespace, '123') = 123
@@ -451,7 +451,7 @@ STONReaderTests >> testWhitespace [
 ]
 
 { #category : #tests }
-STONReaderTests >> testWideSymbol [
+STONReaderTest >> testWideSymbol [
 	self assert: (self materialize: '#''яблоко''') = #яблоко.
 	self assert: (self materialize: '#яблоко') = #яблоко
 ]

--- a/src/STON-Tests/STONTest.class.st
+++ b/src/STON-Tests/STONTest.class.st
@@ -3,13 +3,13 @@ STONTests tests the API offered by STON.
 
 "
 Class {
-	#name : #STONTests,
+	#name : #STONTest,
 	#superclass : #TestCase,
 	#category : #'STON-Tests-Base'
 }
 
 { #category : #utilities }
-STONTests class >> fastReadFromFileNamed: path [
+STONTest class >> fastReadFromFileNamed: path [
 	^ path asFileReference
 		readStreamDo: [ :stream | 
 			STON reader
@@ -19,7 +19,7 @@ STONTests class >> fastReadFromFileNamed: path [
 ]
 
 { #category : #utilities }
-STONTests class >> fastWrite: object toFileNamed: path [
+STONTest class >> fastWrite: object toFileNamed: path [
 	^ path asFileReference
 		writeStreamDo: [ :fileStream | 
 			ZnBufferedWriteStream
@@ -32,7 +32,7 @@ STONTests class >> fastWrite: object toFileNamed: path [
 ]
 
 { #category : #utilities }
-STONTests class >> readFromFileNamed: path [
+STONTest class >> readFromFileNamed: path [
 	^ path asFileReference
 		readStreamDo: [ :stream | 
 			STON reader
@@ -41,7 +41,7 @@ STONTests class >> readFromFileNamed: path [
 ]
 
 { #category : #utilities }
-STONTests class >> write: object toFileNamed: path [
+STONTest class >> write: object toFileNamed: path [
 	^ path asFileReference
 		writeStreamDo: [ :stream | 
 			STON writer
@@ -50,14 +50,14 @@ STONTests class >> write: object toFileNamed: path [
 ]
 
 { #category : #tests }
-STONTests >> testFromString [
+STONTest >> testFromString [
 	| object |
 	object := STON listClass withAll: { 1. 0. -1. true. false. nil }.
 	self assert: (STON fromString: '[1,0,-1,true,false,nil]') = object
 ]
 
 { #category : #tests }
-STONTests >> testFromStringWithComments [
+STONTest >> testFromStringWithComments [
 	| object |
 	object := STON listClass withAll: { 1. 0. -1. true. false. nil }.
 	self 
@@ -66,7 +66,7 @@ STONTests >> testFromStringWithComments [
 ]
 
 { #category : #tests }
-STONTests >> testPrettyPrinting [
+STONTest >> testPrettyPrinting [
 	| object |
 	object := STONTestUser dummy.
 	self assert: (STON fromString: (STON toStringPretty: object)) = object.
@@ -75,7 +75,7 @@ STONTests >> testPrettyPrinting [
 ]
 
 { #category : #tests }
-STONTests >> testRoomExitCycles [
+STONTest >> testRoomExitCycles [
 	| model room1 room2 exit1 exit2 ston object |
 	(room1 := STONTestMap new) at: #name put: 'Room 1'.
 	(room2 := STONTestMap new) at: #name put: 'Room 2'.
@@ -106,7 +106,7 @@ STONTests >> testRoomExitCycles [
 ]
 
 { #category : #tests }
-STONTests >> testToString [
+STONTest >> testToString [
 	| object |
 	object := STON listClass withAll: { 1. 0. -1. true. false. nil }.
 	self assert: (STON toString: object) = '[1,0,-1,true,false,nil]'

--- a/src/STON-Tests/STONWriteAsciiOnlyReadTest.class.st
+++ b/src/STON-Tests/STONWriteAsciiOnlyReadTest.class.st
@@ -2,13 +2,13 @@
 Unit tests for writing ASCII only
 "
 Class {
-	#name : #STONWriteAsciiOnlyReadTests,
-	#superclass : #STONWriteReadTests,
+	#name : #STONWriteAsciiOnlyReadTest,
+	#superclass : #STONWriteReadTest,
 	#category : #'STON-Tests-Writer'
 }
 
 { #category : #private }
-STONWriteAsciiOnlyReadTests >> serialize: anObject [
+STONWriteAsciiOnlyReadTest >> serialize: anObject [
 	^ String streamContents: [ :stream |
 		STON writer 
 			on: stream; 
@@ -17,7 +17,7 @@ STONWriteAsciiOnlyReadTests >> serialize: anObject [
 ]
 
 { #category : #private }
-STONWriteAsciiOnlyReadTests >> serializeJson: anObject [
+STONWriteAsciiOnlyReadTest >> serializeJson: anObject [
 	^ String streamContents: [ :stream |
 		STON jsonWriter 
 			on: stream; 

--- a/src/STON-Tests/STONWritePrettyPrinterReadTest.class.st
+++ b/src/STON-Tests/STONWritePrettyPrinterReadTest.class.st
@@ -2,13 +2,13 @@
 STONWritePrettyPrinterReadTests tests pretty printed serialization followed by materialization.
 "
 Class {
-	#name : #STONWritePrettyPrinterReadTests,
-	#superclass : #STONWriteReadTests,
+	#name : #STONWritePrettyPrinterReadTest,
+	#superclass : #STONWriteReadTest,
 	#category : #'STON-Tests-Writer'
 }
 
 { #category : #private }
-STONWritePrettyPrinterReadTests >> serialize: anObject [
+STONWritePrettyPrinterReadTest >> serialize: anObject [
 	^ String streamContents: [ :stream |
 		STON writer 
 			on: stream; 
@@ -17,7 +17,7 @@ STONWritePrettyPrinterReadTests >> serialize: anObject [
 ]
 
 { #category : #private }
-STONWritePrettyPrinterReadTests >> serializeJson: anObject [
+STONWritePrettyPrinterReadTest >> serializeJson: anObject [
 	^ String streamContents: [ :stream |
 		STON jsonWriter 
 			on: stream; 

--- a/src/STON-Tests/STONWriteReadCommentsTest.class.st
+++ b/src/STON-Tests/STONWriteReadCommentsTest.class.st
@@ -2,13 +2,13 @@
 Unit test writing and reading of comments
 "
 Class {
-	#name : #STONWriteReadCommentsTests,
-	#superclass : #STONWriteReadTests,
+	#name : #STONWriteReadCommentsTest,
+	#superclass : #STONWriteReadTest,
 	#category : #'STON-Tests-Writer'
 }
 
 { #category : #private }
-STONWriteReadCommentsTests >> materialize: string [
+STONWriteReadCommentsTest >> materialize: string [
 	^ STON reader
 		on: (STONCStyleCommentsSkipStream on: string readStream);
 		optimizeForLargeStructures;
@@ -16,7 +16,7 @@ STONWriteReadCommentsTests >> materialize: string [
 ]
 
 { #category : #private }
-STONWriteReadCommentsTests >> serialize: anObject [
+STONWriteReadCommentsTest >> serialize: anObject [
 	^ String streamContents: [ :stream |
 		stream << '/* initial comment */'.
 		STON writer 

--- a/src/STON-Tests/STONWriteReadTest.class.st
+++ b/src/STON-Tests/STONWriteReadTest.class.st
@@ -2,20 +2,20 @@
 STONWriteReadTests test serialization followed by materialization.
 "
 Class {
-	#name : #STONWriteReadTests,
+	#name : #STONWriteReadTest,
 	#superclass : #TestCase,
 	#category : #'STON-Tests-Writer'
 }
 
 { #category : #private }
-STONWriteReadTests >> materialize: string [
+STONWriteReadTest >> materialize: string [
 	^ STON reader 
 		on: string readStream;
 		next
 ]
 
 { #category : #private }
-STONWriteReadTests >> serialize: anObject [
+STONWriteReadTest >> serialize: anObject [
 	^ String streamContents: [ :stream |
 		STON writer 
 			on: stream;
@@ -23,7 +23,7 @@ STONWriteReadTests >> serialize: anObject [
 ]
 
 { #category : #private }
-STONWriteReadTests >> serializeAndMaterialize: object [
+STONWriteReadTest >> serializeAndMaterialize: object [
 	| serialization materialization |
 	serialization := self serialize: object.
 	materialization := self materialize: serialization.
@@ -32,7 +32,7 @@ STONWriteReadTests >> serializeAndMaterialize: object [
 ]
 
 { #category : #private }
-STONWriteReadTests >> serializeAndMaterializeJsonMode: object [
+STONWriteReadTest >> serializeAndMaterializeJsonMode: object [
 	| serialization materialization |
 	serialization := self serializeJson: object.
 	materialization := self materialize: serialization.
@@ -41,7 +41,7 @@ STONWriteReadTests >> serializeAndMaterializeJsonMode: object [
 ]
 
 { #category : #private }
-STONWriteReadTests >> serializeJson: anObject [
+STONWriteReadTest >> serializeJson: anObject [
 	^ String streamContents: [ :stream |
 		STON jsonWriter 
 			on: stream;
@@ -49,7 +49,7 @@ STONWriteReadTests >> serializeJson: anObject [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testAssociations [
+STONWriteReadTest >> testAssociations [
 	| associations |
 	associations := OrderedCollection new.
 	1 to: 10 do: [ :each |
@@ -58,14 +58,14 @@ STONWriteReadTests >> testAssociations [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testCharacters [
+STONWriteReadTest >> testCharacters [
 	| characters |
 	characters := STON listClass withAll: ($a to: $z), ($A to: $Z).
 	self serializeAndMaterialize: characters
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testClasses [
+STONWriteReadTest >> testClasses [
 	| classes |
 	classes := STON listClass withAll: { Point. Integer. Object }.
 	self serializeAndMaterialize: classes.
@@ -76,7 +76,7 @@ STONWriteReadTests >> testClasses [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testCollections [
+STONWriteReadTest >> testCollections [
 	| collections |
 	collections := STON listClass withAll: {
 		#(1 2 3).
@@ -93,7 +93,7 @@ STONWriteReadTests >> testCollections [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testCustomAssociations [
+STONWriteReadTest >> testCustomAssociations [
 	| associations |
 	associations := OrderedCollection new.
 	associations add: #foo->100.
@@ -102,7 +102,7 @@ STONWriteReadTests >> testCustomAssociations [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testDatesAndTimes [
+STONWriteReadTest >> testDatesAndTimes [
 	| datesAndTimes |
 	datesAndTimes := STON listClass withAll: { 
 		Time now. 
@@ -113,7 +113,7 @@ STONWriteReadTests >> testDatesAndTimes [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testDomainObject [
+STONWriteReadTest >> testDomainObject [
 	| object objects |
 	object := STONTestDomainObject dummy.
 	self serializeAndMaterialize: object.
@@ -128,7 +128,7 @@ STONWriteReadTests >> testDomainObject [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testEmpty [
+STONWriteReadTest >> testEmpty [
 	| empty |
 	empty := STON listClass new.
 	self serializeAndMaterialize: empty.
@@ -137,7 +137,7 @@ STONWriteReadTests >> testEmpty [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testFileSystemSupport [
+STONWriteReadTest >> testFileSystemSupport [
 	| fileReferences fileLocators |
 	fileReferences := STON listClass withAll: { 
 		FileLocator image asFileReference.
@@ -152,7 +152,7 @@ STONWriteReadTests >> testFileSystemSupport [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testFloats [
+STONWriteReadTest >> testFloats [
 	| floats serialization materialization |
 	floats := STON listClass withAll: ((-10 to: 10) collect: [ :each | each * Float pi ]).
 	serialization := self serialize: floats.
@@ -165,7 +165,7 @@ STONWriteReadTests >> testFloats [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testIntervals [
+STONWriteReadTest >> testIntervals [
 	| intervals |
 	intervals := STON listClass withAll: { 
 		1 to: 10.
@@ -175,7 +175,7 @@ STONWriteReadTests >> testIntervals [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testJsonMode [
+STONWriteReadTest >> testJsonMode [
 	| object |
 	object := STON listClass withAll: {
 		Float pi.
@@ -193,7 +193,7 @@ STONWriteReadTests >> testJsonMode [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testOrderedDictionary [
+STONWriteReadTest >> testOrderedDictionary [
 	"OrderedDictionary is special because it does not inherit from Dictionary.
 	It might also not exist in some dialects, where this test could be skipped."
 	
@@ -211,14 +211,14 @@ STONWriteReadTests >> testOrderedDictionary [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testPrimitives [
+STONWriteReadTest >> testPrimitives [
 	| primitives |
 	primitives := STON listClass withAll: { true. false. nil }.
 	self serializeAndMaterialize: primitives
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testSmallDictionary [
+STONWriteReadTest >> testSmallDictionary [
 	"SmallDictionary is special because it does not inherit from Dictionary.
 	It might also not exist in some dialects, where this test could be skipped."
 	
@@ -232,14 +232,14 @@ STONWriteReadTests >> testSmallDictionary [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testSmallIntegers [
+STONWriteReadTest >> testSmallIntegers [
 	| integers |
 	integers := STON listClass withAll: (-10 to: 10).
 	self serializeAndMaterialize: integers
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testSpecialCharacters [
+STONWriteReadTest >> testSpecialCharacters [
 	| primitives |
 	primitives := STON listClass withAll: { 
 		String withAll: { Character tab. Character lf. Character cr }.
@@ -251,7 +251,7 @@ STONWriteReadTests >> testSpecialCharacters [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testStrings [
+STONWriteReadTest >> testStrings [
 	| strings |
 	strings := Collection allSubclasses 
 		collect: [ :each | each name asString ].
@@ -264,7 +264,7 @@ STONWriteReadTests >> testStrings [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testSymbols [
+STONWriteReadTest >> testSymbols [
 	| symbols |
 	self serializeAndMaterialize: #( #bytes #'' ).
 	symbols := Collection allSubclasses collect: [ :each | each name ].
@@ -273,7 +273,7 @@ STONWriteReadTests >> testSymbols [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testTextAndRunArray [
+STONWriteReadTest >> testTextAndRunArray [
 	| texts |
 	texts := { 
 		'Text!' asText. 
@@ -283,7 +283,7 @@ STONWriteReadTests >> testTextAndRunArray [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testUUIDs [
+STONWriteReadTest >> testUUIDs [
 	| uuids |
 	uuids := STON listClass withAll: { 
 		UUID new.
@@ -293,7 +293,7 @@ STONWriteReadTests >> testUUIDs [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testUser [
+STONWriteReadTest >> testUser [
 	| user users |
 	user := STONTestUser dummy.
 	self serializeAndMaterialize: user.
@@ -308,7 +308,7 @@ STONWriteReadTests >> testUser [
 ]
 
 { #category : #tests }
-STONWriteReadTests >> testUser2 [
+STONWriteReadTest >> testUser2 [
 	| user users |
 	user := STONTestUser2 dummy.
 	self serializeAndMaterialize: user.

--- a/src/STON-Tests/STONWriterTest.class.st
+++ b/src/STON-Tests/STONWriterTest.class.st
@@ -2,13 +2,13 @@
 STONWriterTests test serialization.
 "
 Class {
-	#name : #STONWriterTests,
+	#name : #STONWriterTest,
 	#superclass : #TestCase,
 	#category : #'STON-Tests-Writer'
 }
 
 { #category : #private }
-STONWriterTests >> serialize: anObject [
+STONWriterTest >> serialize: anObject [
 	^ String streamContents: [ :stream |
 		STON writer 
 			on: stream;
@@ -16,7 +16,7 @@ STONWriterTests >> serialize: anObject [
 ]
 
 { #category : #private }
-STONWriterTests >> serializeAsciiOnly: anObject [
+STONWriterTest >> serializeAsciiOnly: anObject [
 	^ String streamContents: [ :stream |
 		STON writer 
 			on: stream;
@@ -25,7 +25,7 @@ STONWriterTests >> serializeAsciiOnly: anObject [
 ]
 
 { #category : #private }
-STONWriterTests >> serializeJson: anObject [
+STONWriterTest >> serializeJson: anObject [
 	^ String streamContents: [ :stream |
 		STON jsonWriter 
 			on: stream; 
@@ -33,7 +33,7 @@ STONWriterTests >> serializeJson: anObject [
 ]
 
 { #category : #private }
-STONWriterTests >> serializePretty: anObject [
+STONWriterTest >> serializePretty: anObject [
 	^ String streamContents: [ :stream |
 		STON writer 
 			on: stream; 
@@ -42,7 +42,7 @@ STONWriterTests >> serializePretty: anObject [
 ]
 
 { #category : #tests }
-STONWriterTests >> testAssociation [
+STONWriterTest >> testAssociation [
 	self assert: (self serialize: 'foo' -> 1) =  '''foo'':1'.
 	self assert: (self serialize: #bar -> 2) =  '#bar:2'.
 	self assert: (self serialize: 'foo bar' -> #ok) =  '''foo bar'':#ok'.
@@ -51,24 +51,24 @@ STONWriterTests >> testAssociation [
 ]
 
 { #category : #tests }
-STONWriterTests >> testBoolean [
+STONWriterTest >> testBoolean [
 	self assert: (self serialize: true) = 'true'.
 	self assert: (self serialize: false) = 'false'
 ]
 
 { #category : #tests }
-STONWriterTests >> testByteArray [
+STONWriterTest >> testByteArray [
 	self assert: (self serialize: #(1 2 3) asByteArray) = 'ByteArray[''010203'']' 
 
 ]
 
 { #category : #tests }
-STONWriterTests >> testClass [
+STONWriterTest >> testClass [
 	self assert: (self serialize: Point) = 'Class[#Point]'
 ]
 
 { #category : #tests }
-STONWriterTests >> testCustomNewline [
+STONWriterTest >> testCustomNewline [
 	| output |
 	output := String streamContents: [ :out |
 		(STON writer on: out)
@@ -81,21 +81,21 @@ STONWriterTests >> testCustomNewline [
 ]
 
 { #category : #tests }
-STONWriterTests >> testDate [
+STONWriterTest >> testDate [
 	| date |
 	date := Date year: 2012 month: 1 day: 1.
 	self assert: (self serialize: date) = 'Date[''2012-01-01'']'
 ]
 
 { #category : #tests }
-STONWriterTests >> testDateAndTime [
+STONWriterTest >> testDateAndTime [
 	| dateAndTime |
 	dateAndTime := DateAndTime year: 2012 month: 1 day: 1 hour: 6 minute: 30 second: 15 offset: 1 hour.
 	self assert: (self serialize: dateAndTime) = 'DateAndTime[''2012-01-01T06:30:15+01:00'']'
 ]
 
 { #category : #tests }
-STONWriterTests >> testDictionary [
+STONWriterTest >> testDictionary [
 	| collection |
 	collection := STON mapClass new at: 1 put: 1; at: 2 put: 2; yourself.
 	self assert: (self serialize: collection) = '{1:1,2:2}'.
@@ -103,14 +103,14 @@ STONWriterTests >> testDictionary [
 ]
 
 { #category : #tests }
-STONWriterTests >> testDictionaryWithComplexKeys [
+STONWriterTest >> testDictionaryWithComplexKeys [
 	| collection |
 	collection := STON mapClass new at: true put: 1; at: #(foo) put: 2; yourself.
 	self assert: (#('{true:1,[#foo]:2}' '{[#foo]:2,true:1}') includes: (self serialize: collection))
 ]
 
 { #category : #tests }
-STONWriterTests >> testDoubleQuotedString [
+STONWriterTest >> testDoubleQuotedString [
 	| string |
 	self assert: (self serializeJson: 'foo') = '"foo"'.
 	self assert: (self serializeJson: 'FOO') = '"FOO"'.
@@ -123,17 +123,17 @@ STONWriterTests >> testDoubleQuotedString [
 ]
 
 { #category : #tests }
-STONWriterTests >> testEmptyArrayPretty [
+STONWriterTest >> testEmptyArrayPretty [
 	self assert: (self serializePretty: STON listClass new) equals: '[ ]' 
 ]
 
 { #category : #tests }
-STONWriterTests >> testEmptyDictionaryPretty [
+STONWriterTest >> testEmptyDictionaryPretty [
 	self assert: (self serializePretty: STON mapClass new) equals: '{ }' 
 ]
 
 { #category : #tests }
-STONWriterTests >> testFloat [
+STONWriterTest >> testFloat [
 	self assert: (self serialize: 1.5) = '1.5'.
 	self assert: (self serialize: 0.0) = '0.0'.
 	self assert: (self serialize: -1.5) = '-1.5'.
@@ -145,7 +145,7 @@ STONWriterTests >> testFloat [
 ]
 
 { #category : #tests }
-STONWriterTests >> testIdentityDictionary [
+STONWriterTest >> testIdentityDictionary [
 	| collection |
 	collection := IdentityDictionary new at: 1 put: 1; at: 2 put: 2; yourself.
 	self assert: (self serialize: collection) = 'IdentityDictionary{1:1,2:2}'.
@@ -153,7 +153,7 @@ STONWriterTests >> testIdentityDictionary [
 ]
 
 { #category : #tests }
-STONWriterTests >> testInteger [
+STONWriterTest >> testInteger [
 	self assert: (self serialize: 1) = '1'.
 	self assert: (self serialize: 0) = '0'.
 	self assert: (self serialize: -1) = '-1'.
@@ -162,7 +162,7 @@ STONWriterTests >> testInteger [
 ]
 
 { #category : #tests }
-STONWriterTests >> testIsSimpleSymbol [
+STONWriterTest >> testIsSimpleSymbol [
 	self assert: (STON writer isSimpleSymbol: #foo).
 	self assert: (STON writer isSimpleSymbol: #az).
 	self assert: (STON writer isSimpleSymbol: #AZ).
@@ -177,7 +177,7 @@ STONWriterTests >> testIsSimpleSymbol [
 ]
 
 { #category : #tests }
-STONWriterTests >> testKeepingNewLines [
+STONWriterTest >> testKeepingNewLines [
 	| input result output |
 	input := 'line ending with CR', String cr, 
 		'line ending with LF', String lf, 
@@ -197,14 +197,14 @@ STONWriterTests >> testKeepingNewLines [
 ]
 
 { #category : #tests }
-STONWriterTests >> testList [
+STONWriterTest >> testList [
 	self assert: (self serialize: (STON listClass withAll: #(1 2 3))) = '[1,2,3]'.
 	self assert: (self serialize: STON listClass new) = '[]'.
 	self assert: (self serialize: (STON listClass withAll: { 1. -1. 0. #foo. 'a b c'. true. false. nil })) = '[1,-1,0,#foo,''a b c'',true,false,nil]'
 ]
 
 { #category : #tests }
-STONWriterTests >> testMap [
+STONWriterTest >> testMap [
 	| map |
 	(map := STON mapClass new)
 		at: #foo put: 1;
@@ -222,17 +222,17 @@ STONWriterTests >> testMap [
 ]
 
 { #category : #tests }
-STONWriterTests >> testMetaclass [
+STONWriterTest >> testMetaclass [
 	self assert: (self serialize: Point class) = 'Metaclass[#Point]'
 ]
 
 { #category : #tests }
-STONWriterTests >> testNil [
+STONWriterTest >> testNil [
 	self assert: (self serialize: nil) = 'nil'
 ]
 
 { #category : #tests }
-STONWriterTests >> testNonBMPCharacterEncoding [
+STONWriterTest >> testNonBMPCharacterEncoding [
 	"Characters not in the Basic Multilingual Plane are encoded as a UTF-16 surrogate pair"
 
 	| string json |
@@ -243,12 +243,12 @@ STONWriterTests >> testNonBMPCharacterEncoding [
 ]
 
 { #category : #tests }
-STONWriterTests >> testNull [
+STONWriterTest >> testNull [
 	self assert: (self serializeJson: nil) equals: 'null'
 ]
 
 { #category : #tests }
-STONWriterTests >> testOrderedCollection [
+STONWriterTest >> testOrderedCollection [
 	| collection |
 	collection := OrderedCollection with: 1 with: 2 with: 3.
 	self assert: (self serialize: collection) = 'OrderedCollection[1,2,3]'.
@@ -256,12 +256,12 @@ STONWriterTests >> testOrderedCollection [
 ]
 
 { #category : #tests }
-STONWriterTests >> testPoint [
+STONWriterTest >> testPoint [
 	self assert: (self serialize: 1@2) = 'Point[1,2]'
 ]
 
 { #category : #tests }
-STONWriterTests >> testReferenceCycle [
+STONWriterTest >> testReferenceCycle [
 	| array |
 	array := STON listClass with: 1 with: nil.
 	array at: 2 put: array.
@@ -269,7 +269,7 @@ STONWriterTests >> testReferenceCycle [
 ]
 
 { #category : #tests }
-STONWriterTests >> testReferenceSharing [
+STONWriterTest >> testReferenceSharing [
 	| array one |
 	one := { #one }.
 	array := STON listClass with: one with: one with: one.
@@ -277,7 +277,7 @@ STONWriterTests >> testReferenceSharing [
 ]
 
 { #category : #tests }
-STONWriterTests >> testReferenceSharingError [
+STONWriterTest >> testReferenceSharingError [
 	| serializer array one |
 	serializer := [ :object | 
 		String streamContents: [ :stream |
@@ -294,7 +294,7 @@ STONWriterTests >> testReferenceSharingError [
 ]
 
 { #category : #tests }
-STONWriterTests >> testReferenceSharingIgnore [
+STONWriterTest >> testReferenceSharingIgnore [
 	| serializer array one |
 	serializer := [ :object | 
 		String streamContents: [ :stream |
@@ -308,7 +308,7 @@ STONWriterTests >> testReferenceSharingIgnore [
 ]
 
 { #category : #tests }
-STONWriterTests >> testRestrictedClassesInJsonMode [
+STONWriterTest >> testRestrictedClassesInJsonMode [
 	self should: [ self serializeJson: 1@2 ] raise: STONWriterError.
 	self should: [ self serializeJson: #foo->100 ] raise: STONWriterError.
 	self should: [ self serializeJson: STONTestUser dummy ] raise: STONWriterError.
@@ -316,7 +316,7 @@ STONWriterTests >> testRestrictedClassesInJsonMode [
 ]
 
 { #category : #tests }
-STONWriterTests >> testString [
+STONWriterTest >> testString [
 	| string |
 	self assert: (self serialize: 'foo') = '''foo'''.
 	self assert: (self serialize: 'FOO') = '''FOO'''.
@@ -329,7 +329,7 @@ STONWriterTests >> testString [
 ]
 
 { #category : #tests }
-STONWriterTests >> testSymbol [
+STONWriterTest >> testSymbol [
 	self assert: (self serialize: #foo) = '#foo'.
 	self assert: (self serialize: #FOO) = '#FOO'.
 	self assert: (self serialize: #bytes) = '#bytes'.
@@ -342,14 +342,14 @@ STONWriterTests >> testSymbol [
 ]
 
 { #category : #tests }
-STONWriterTests >> testSymbolAsString [
+STONWriterTest >> testSymbolAsString [
 	self assert: (self serializeJson: #foo) = '"foo"'.
 	self assert: (self serializeJson: #'FOO') = '"FOO"'.
 
 ]
 
 { #category : #tests }
-STONWriterTests >> testTime [
+STONWriterTest >> testTime [
 	| time |
 	time := Time hour: 6 minute: 30 second: 15.
 	self assert: (self serialize: time) equals: 'Time[''06:30:15'']'.
@@ -359,7 +359,7 @@ STONWriterTests >> testTime [
 ]
 
 { #category : #tests }
-STONWriterTests >> testUser [
+STONWriterTest >> testUser [
 	| user |
 	(user := STONTestUser new)
 		username: 'john@foo.com';
@@ -370,7 +370,7 @@ STONWriterTests >> testUser [
 ]
 
 { #category : #tests }
-STONWriterTests >> testUser2 [
+STONWriterTest >> testUser2 [
 	| user |
 	(user := STONTestUser2 new)
 		username: 'john@foo.com';
@@ -381,7 +381,7 @@ STONWriterTests >> testUser2 [
 ]
 
 { #category : #tests }
-STONWriterTests >> testUser3Nil [
+STONWriterTest >> testUser3Nil [
 	| user |
 	user := STONTestUser3 new.
 	self 
@@ -390,7 +390,7 @@ STONWriterTests >> testUser3Nil [
 ]
 
 { #category : #tests }
-STONWriterTests >> testUserNil [
+STONWriterTest >> testUserNil [
 	| user |
 	user := STONTestUser new.
 	self assert: (self serialize: user) equals: 'TestUser{#enabled:true}'


### PR DESCRIPTION
STON test cases should end with Test instead of Tests.