### PR TITLE
Opal-test-cases-should-end-with-Test

### DIFF
--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #MethodMapTests,
+	#name : #MethodMapTest,
 	#superclass : #TestCase,
 	#category : #'OpalCompiler-Tests-Misc'
 }
 
 { #category : #util }
-MethodMapTests >> compileAndRunExample: aSelector [
+MethodMapTest >> compileAndRunExample: aSelector [
 	| cm |
 	
 	cm := self compileMethod:  MethodMapExamples>>aSelector.
@@ -13,32 +13,32 @@ MethodMapTests >> compileAndRunExample: aSelector [
 ]
 
 { #category : #util }
-MethodMapTests >> compileMethod: aMethod [
+MethodMapTest >> compileMethod: aMethod [
 
 	^aMethod parseTree generate: aMethod trailer.
 	
 ]
 
 { #category : #'testing - ast mapping' }
-MethodMapTests >> deadContext [
+MethodMapTest >> deadContext [
 	^ thisContext
 ]
 
 { #category : #'testing - ast mapping' }
-MethodMapTests >> inlinedBlockSourceNode [
+MethodMapTest >> inlinedBlockSourceNode [
 	1 to: 1 do: [ :i | ^ thisContext sourceNode ]. 
 
 
 ]
 
 { #category : #helpers }
-MethodMapTests >> parseExpression: aString [
+MethodMapTest >> parseExpression: aString [
 
 	^ RBParser parseExpression: aString
 ]
 
 { #category : #'testing - ast mapping' }
-MethodMapTests >> testBlockAndContextSourceNode [
+MethodMapTest >> testBlockAndContextSourceNode [
 		
 	|block blockNodeViaContext blockNodeViaClosure |
 
@@ -54,7 +54,7 @@ MethodMapTests >> testBlockAndContextSourceNode [
 ]
 
 { #category : #'testing - ast mapping' }
-MethodMapTests >> testBlockSourceNode [
+MethodMapTest >> testBlockSourceNode [
 	| sourceNode |
 	sourceNode := [ 1 + 2 ] sourceNode.
 	self assert: sourceNode equals: (self parseExpression: '[ 1 + 2 ]').
@@ -63,7 +63,7 @@ MethodMapTests >> testBlockSourceNode [
 ]
 
 { #category : #'testing - ast mapping' }
-MethodMapTests >> testBlockWithArgAndEnclosedBlockSourceNode [
+MethodMapTest >> testBlockWithArgAndEnclosedBlockSourceNode [
 	| sourceNode |
 	sourceNode := [ :arg |  [ arg ] ] sourceNode.
 	self assert: sourceNode equals: (self parseExpression: '[ :arg | [ arg ] ]').
@@ -71,7 +71,7 @@ MethodMapTests >> testBlockWithArgAndEnclosedBlockSourceNode [
 ]
 
 { #category : #'testing - ast mapping' }
-MethodMapTests >> testBlockWithEnclosedBlockSourceNode [
+MethodMapTest >> testBlockWithEnclosedBlockSourceNode [
 	| sourceNode |
 	sourceNode := [ [ ] ] sourceNode.
 	self assert: sourceNode equals: (self parseExpression: '[ [ ] ]').
@@ -79,7 +79,7 @@ MethodMapTests >> testBlockWithEnclosedBlockSourceNode [
 ]
 
 { #category : #'testing - ast mapping' }
-MethodMapTests >> testBlockWithTempsSourceNode [
+MethodMapTest >> testBlockWithTempsSourceNode [
 	| sourceNode |
 	sourceNode := [ | t1 t2 | ] sourceNode.
 	self assert: sourceNode equals: (self parseExpression: '[ | t1 t2 | ]').
@@ -87,12 +87,12 @@ MethodMapTests >> testBlockWithTempsSourceNode [
 ]
 
 { #category : #'testing - temp access' }
-MethodMapTests >> testCopiedVarFromDeadContext [
+MethodMapTest >> testCopiedVarFromDeadContext [
 	self assert:  (self compileAndRunExample:  #exampleCopiedVarFromDeadContext) equals: 2.
 ]
 
 { #category : #'testing - ast mapping' }
-MethodMapTests >> testDeadContextSourceNode [
+MethodMapTest >> testDeadContextSourceNode [
 	| deadContext |
 	deadContext := self deadContext.
 	self assert: deadContext isDead. 
@@ -101,69 +101,69 @@ MethodMapTests >> testDeadContextSourceNode [
 ]
 
 { #category : #'testing - temp access' }
-MethodMapTests >> testExampleSimpleTemp [
+MethodMapTest >> testExampleSimpleTemp [
 	self assert: (self compileAndRunExample: #exampleSimpleTemp) equals: 1
 ]
 
 { #category : #'testing - temp access' }
-MethodMapTests >> testExampleTempNamedCopying [
+MethodMapTest >> testExampleTempNamedCopying [
 	self assert: (self compileAndRunExample: #exampleTempNamedCopying) equals: 1
 ]
 
 { #category : #'testing - temp access' }
-MethodMapTests >> testExampleTempNamedCopying2 [
+MethodMapTest >> testExampleTempNamedCopying2 [
 	self assert: (self compileAndRunExample: #exampleTempNamedCopying2) equals: 1
 ]
 
 { #category : #'testing - temp access' }
-MethodMapTests >> testExampleTempNamedPutCopying [
+MethodMapTest >> testExampleTempNamedPutCopying [
 	self assert: (self compileAndRunExample: #exampleTempNamedPutCopying) equals: 2.
 ]
 
 { #category : #'testing - temp access' }
-MethodMapTests >> testExampleTempNamedPutCopying2 [
+MethodMapTest >> testExampleTempNamedPutCopying2 [
 "modifying a copied temp variable will *not* modify the value in the outer context. 
 (See other test case OCClosureCompilerTest>>#testDebuggerTempAccess and notes on fogbugz issue 17702"
 	self assert: (self compileAndRunExample: #exampleTempNamedPutCopying2) equals: 1
 ]
 
 { #category : #'testing - temp access' }
-MethodMapTests >> testExampleTempNamedPutTempVector [
+MethodMapTest >> testExampleTempNamedPutTempVector [
 	self assert: (self compileAndRunExample: #exampleTempNamedPutTempVector) equals: 3.
 ]
 
 { #category : #'testing - temp access' }
-MethodMapTests >> testExampleTempNamedPutTempVector2 [
+MethodMapTest >> testExampleTempNamedPutTempVector2 [
 	self assert: (self compileAndRunExample: #exampleTempNamedPutTempVector2) equals: 3
 ]
 
 { #category : #'testing - temp access' }
-MethodMapTests >> testExampleTempNamedTempVector [
+MethodMapTest >> testExampleTempNamedTempVector [
 	self assert: (self compileAndRunExample: #exampleTempNamedTempVector) equals: 2
 ]
 
 { #category : #'testing - temp access' }
-MethodMapTests >> testExampleTempNamedTempVector2 [
+MethodMapTest >> testExampleTempNamedTempVector2 [
 	self assert: (self compileAndRunExample: #exampleTempNamedTempVector2) equals: 2
 ]
 
 { #category : #'testing - temp access' }
-MethodMapTests >> testExampleTempNamedTempVectorInOptimizedBlock [
+MethodMapTest >> testExampleTempNamedTempVectorInOptimizedBlock [
 	self assert:  (self compileAndRunExample:  #exampleTempNamedTempVectorInOptimizedBlock ) equals: 2.
 ]
 
 { #category : #'testing - temp access' }
-MethodMapTests >> testExampleTempNamedTempVectorInlinedLoop [
+MethodMapTest >> testExampleTempNamedTempVectorInlinedLoop [
 	self assert:  (self compileAndRunExample:  #exampleTempNamedTempVectorInlinedLoop ) equals: 42.
 ]
 
 { #category : #'testing - temp access' }
-MethodMapTests >> testExampleTempNamedTempVectorNestedBlock [
+MethodMapTest >> testExampleTempNamedTempVectorNestedBlock [
 	self assert:  (self compileAndRunExample:  #exampleTempNamedTempVectorNestedBlock ) equals: 2.
 ]
 
 { #category : #'testing - ast mapping' }
-MethodMapTests >> testMethodSourceNodeAtInitialPC [
+MethodMapTest >> testMethodSourceNodeAtInitialPC [
 
 	| method actual |
 	method := self class >> testSelector.
@@ -174,13 +174,13 @@ MethodMapTests >> testMethodSourceNodeAtInitialPC [
 ]
 
 { #category : #'testing - ast mapping' }
-MethodMapTests >> testMethodSourceNodeAtPC [
+MethodMapTest >> testMethodSourceNodeAtPC [
 	self assert: (((Object>>#halt) sourceNodeForPC:  (Smalltalk vm for32bit: 22 for64bit: 42)) isKindOf: RBMessageNode).
 
 ]
 
 { #category : #'testing - ast mapping' }
-MethodMapTests >> testPrimitiveMethodSourceNodeAtInitialPC [
+MethodMapTest >> testPrimitiveMethodSourceNodeAtInitialPC [
 
 	| method actual |
 	method := SmallInteger >> #+.
@@ -191,7 +191,7 @@ MethodMapTests >> testPrimitiveMethodSourceNodeAtInitialPC [
 ]
 
 { #category : #'testing - source mapping' }
-MethodMapTests >> testSimpleSourceMapping [
+MethodMapTest >> testSimpleSourceMapping [
 	| method range highlight |
 
 	method := Object>>('ha', 'lt') asSymbol.
@@ -205,7 +205,7 @@ MethodMapTests >> testSimpleSourceMapping [
 ]
 
 { #category : #'testing - source mapping' }
-MethodMapTests >> testSourceMappingBlock [
+MethodMapTest >> testSourceMappingBlock [
 	| method range highlight pcs |
 
 	method := MethodMapExamples>>#exampleTempNamedCopying.
@@ -243,17 +243,17 @@ MethodMapTests >> testSourceMappingBlock [
 ]
 
 { #category : #'testing - temp access' }
-MethodMapTests >> testTempNamedTempCopyingNestedBlock [
+MethodMapTest >> testTempNamedTempCopyingNestedBlock [
 	self assert: (self compileAndRunExample:  #exampleTempNamedTempCopyingNestedBlock) equals: 1.
 ]
 
 { #category : #'testing - temp access' }
-MethodMapTests >> testTempNamedTempCopyingNestedBlockPROBLEM [
+MethodMapTest >> testTempNamedTempCopyingNestedBlockPROBLEM [
 	self assert:  (self compileAndRunExample:  #exampleTempNamedTempCopyingNestedBlockPROBLEM) equals: 1.
 ]
 
 { #category : #'testing - ast mapping' }
-MethodMapTests >> testThisContextSourceNode [
+MethodMapTest >> testThisContextSourceNode [
 	self assert: (thisContext sourceNode isKindOf: RBMethodNode).
 	self assert: ([thisContext sourceNode] value isKindOf: RBBlockNode).
 	self assert: ([true ifTrue: [thisContext sourceNode]]value isKindOf: RBBlockNode).
@@ -263,7 +263,7 @@ MethodMapTests >> testThisContextSourceNode [
 ]
 
 { #category : #'testing - ast mapping' }
-MethodMapTests >> testThisContextSourceNodeInInlinedMessage [
+MethodMapTest >> testThisContextSourceNodeInInlinedMessage [
 	| inlinedBlockSourceNode |
 	inlinedBlockSourceNode := self inlinedBlockSourceNode.
 	self assert: (inlinedBlockSourceNode isKindOf: RBBlockNode).

--- a/src/OpalCompiler-Tests/MustBeBooleanTest.class.st
+++ b/src/OpalCompiler-Tests/MustBeBooleanTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #MustBeBooleanTests,
+	#name : #MustBeBooleanTest,
 	#superclass : #TestCase,
 	#category : #'OpalCompiler-Tests-Misc'
 }
 
 { #category : #tests }
-MustBeBooleanTests >> testAnd [
+MustBeBooleanTest >> testAnd [
 	| myBooleanObject |
 	
 	myBooleanObject := MyBooleanObject new.
@@ -13,7 +13,7 @@ MustBeBooleanTests >> testAnd [
 ]
 
 { #category : #tests }
-MustBeBooleanTests >> testDNU [
+MustBeBooleanTest >> testDNU [
 	| code |
 	code := [ (true ifFalse:[]) ifTrue:[] ].
 	self should: code raise: MessageNotUnderstood .
@@ -22,7 +22,7 @@ MustBeBooleanTests >> testDNU [
 ]
 
 { #category : #tests }
-MustBeBooleanTests >> testIfTrueEffect [
+MustBeBooleanTest >> testIfTrueEffect [
 	| temp fakeBool |
 	
 	fakeBool := MyBooleanObject new.
@@ -35,7 +35,7 @@ MustBeBooleanTests >> testIfTrueEffect [
 ]
 
 { #category : #tests }
-MustBeBooleanTests >> testIfTrueValue [
+MustBeBooleanTest >> testIfTrueValue [
 	| myBooleanObject |
 	
 	self assert: (MyBooleanObject new ifTrue: [ 1 + 2 ]) equals: '3 sent from my boolean object'.
@@ -44,7 +44,7 @@ MustBeBooleanTests >> testIfTrueValue [
 ]
 
 { #category : #tests }
-MustBeBooleanTests >> testIfTrueWithClosureAfterJump [
+MustBeBooleanTest >> testIfTrueWithClosureAfterJump [
 	"A closure is a multibyte instruction, that should not be
 	1) confused for an ending jump in ifTrue/ifFalse structure
 	2) set as jumptarget, or have PC manually set to, none but its first byte."
@@ -57,7 +57,7 @@ MustBeBooleanTests >> testIfTrueWithClosureAfterJump [
 ]
 
 { #category : #tests }
-MustBeBooleanTests >> testOr [
+MustBeBooleanTest >> testOr [
 	| myBooleanObject |
 	
 	myBooleanObject := MyBooleanObject new.
@@ -65,7 +65,7 @@ MustBeBooleanTests >> testOr [
 ]
 
 { #category : #tests }
-MustBeBooleanTests >> testSemanticAnalysisCleaned [
+MustBeBooleanTest >> testSemanticAnalysisCleaned [
 	"this used to fail as we did not clean semantic analysis data before recompiling"
 	
 	self should: [self shouldnt: [1 ifTrue:  [[:dir :path|
@@ -73,7 +73,7 @@ MustBeBooleanTests >> testSemanticAnalysisCleaned [
 ]
 
 { #category : #tests }
-MustBeBooleanTests >> testWhile [
+MustBeBooleanTest >> testWhile [
 	| myFlag |
 	self should: [[ nil ] whileFalse: [myFlag := true ]] raise: MessageNotUnderstood.
 ]

--- a/src/OpalCompiler-Tests/OCClosureTest.class.st
+++ b/src/OpalCompiler-Tests/OCClosureTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #OCClosureTests,
+	#name : #OCClosureTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'collection'
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #utilities }
-OCClosureTests >> assertValues: anArray [
+OCClosureTest >> assertValues: anArray [
 	| values |
 	values := collection collect: [ :each | each value ].
 	self 
@@ -18,19 +18,19 @@ OCClosureTests >> assertValues: anArray [
 ]
 
 { #category : #testing }
-OCClosureTests >> methodArgument: anObject [
+OCClosureTest >> methodArgument: anObject [
 	^ [ anObject ]
 	
 ]
 
 { #category : #running }
-OCClosureTests >> setUp [
+OCClosureTest >> setUp [
 	super setUp.
 	collection := OrderedCollection new
 ]
 
 { #category : #testing }
-OCClosureTests >> testBlockArgument [
+OCClosureTest >> testBlockArgument [
 	| block block1 block2 |
 	block := [ :arg | | temp | temp := arg. [ temp ] ].
 	block1 := block value: 1.
@@ -40,7 +40,7 @@ OCClosureTests >> testBlockArgument [
 ]
 
 { #category : #testing }
-OCClosureTests >> testBlockTemp [
+OCClosureTest >> testBlockTemp [
 	| block block1 block2 |
 	block := [ :arg | [ arg ] ].
 	block1 := block value: 1.
@@ -50,7 +50,7 @@ OCClosureTests >> testBlockTemp [
 ]
 
 { #category : #testing }
-OCClosureTests >> testBlockTemps [
+OCClosureTest >> testBlockTemps [
 	
 	| block block1 block2 |
 	"Regression test: Bytecode offset of IR was to last byte of IR node, which for blocks include temp initialization bytes. This caused scan for block creation bytecode to fail when there were many block temps, and no source node to be found."
@@ -64,7 +64,7 @@ OCClosureTests >> testBlockTemps [
 ]
 
 { #category : #'testing-empty' }
-OCClosureTests >> testEmptyBlockOneArgument [
+OCClosureTest >> testEmptyBlockOneArgument [
 	self
 		assert: (self class compiler evaluate: '[ :a ] value: 1') isNil
 		description: 'Empty blocks in ST-80 should return nil'.
@@ -77,7 +77,7 @@ OCClosureTests >> testEmptyBlockOneArgument [
 ]
 
 { #category : #'testing-empty' }
-OCClosureTests >> testEmptyBlockTwoArguments [
+OCClosureTest >> testEmptyBlockTwoArguments [
 	self
 		assert: (self class compiler evaluate: '[ :a :b ] value: 1 value: 2') isNil
 		description: 'Empty blocks in ST-80 should return nil'.
@@ -90,7 +90,7 @@ OCClosureTests >> testEmptyBlockTwoArguments [
 ]
 
 { #category : #'testing-empty' }
-OCClosureTests >> testEmptyBlockZeroArguments [
+OCClosureTest >> testEmptyBlockZeroArguments [
 	self
 		assert: (self class compiler evaluate: '[ ] value') isNil
 		description: 'Empty blocks in ST-80 should return nil'.
@@ -100,7 +100,7 @@ OCClosureTests >> testEmptyBlockZeroArguments [
 ]
 
 { #category : #testing }
-OCClosureTests >> testIsClean [
+OCClosureTest >> testIsClean [
 	 | local |
 	 local := #testIsClean.
 	self assert: [] isClean. "closes over nothing at all"
@@ -113,7 +113,7 @@ OCClosureTests >> testIsClean [
 ]
 
 { #category : #testing }
-OCClosureTests >> testMethodArgument [
+OCClosureTest >> testMethodArgument [
 	| temp block |
 	temp := 0.
 	block := [ [ temp ] ].
@@ -124,7 +124,7 @@ OCClosureTests >> testMethodArgument [
 ]
 
 { #category : #testing }
-OCClosureTests >> testMethodTemp [
+OCClosureTest >> testMethodTemp [
 	| block1 block2 |
 	block1 := self methodArgument: 1.
 	block2 := self methodArgument: 2.
@@ -133,14 +133,14 @@ OCClosureTests >> testMethodTemp [
 ]
 
 { #category : #'testing-todo' }
-OCClosureTests >> testToDoArgument [
+OCClosureTest >> testToDoArgument [
 	1 to: 5 do: [ :index |
 		collection add: [ index ] ].
 	self assertValues: #(1 2 3 4 5)
 ]
 
 { #category : #'testing-todo' }
-OCClosureTests >> testToDoArgumentNotInlined [
+OCClosureTest >> testToDoArgumentNotInlined [
 	| block |
 	block := [ :index |
 		collection add: [ index ] ].
@@ -149,7 +149,7 @@ OCClosureTests >> testToDoArgumentNotInlined [
 ]
 
 { #category : #'testing-todo' }
-OCClosureTests >> testToDoInsideTemp [
+OCClosureTest >> testToDoInsideTemp [
 	1 to: 5 do: [ :index | 
 		| temp | 
 		temp := index. 
@@ -158,7 +158,7 @@ OCClosureTests >> testToDoInsideTemp [
 ]
 
 { #category : #'testing-todo' }
-OCClosureTests >> testToDoInsideTempNotInlined [
+OCClosureTest >> testToDoInsideTempNotInlined [
 	| block |
 	block := [ :index | 
 		| temp | 
@@ -169,7 +169,7 @@ OCClosureTests >> testToDoInsideTempNotInlined [
 ]
 
 { #category : #'testing-todo' }
-OCClosureTests >> testToDoOutsideTemp [
+OCClosureTest >> testToDoOutsideTemp [
 	| temp |
 	1 to: 5 do: [ :index | 
 		temp := index. 
@@ -178,7 +178,7 @@ OCClosureTests >> testToDoOutsideTemp [
 ]
 
 { #category : #'testing-todo' }
-OCClosureTests >> testToDoOutsideTempNotInlined [
+OCClosureTest >> testToDoOutsideTempNotInlined [
 	| block temp |
 	block := [ :index | 
 		temp := index. 
@@ -188,7 +188,7 @@ OCClosureTests >> testToDoOutsideTempNotInlined [
 ]
 
 { #category : #'testing-while' }
-OCClosureTests >> testWhileModificationAfter [
+OCClosureTest >> testWhileModificationAfter [
 	| index |
 	index := 0.
 	[ index < 5 ] whileTrue: [
@@ -198,7 +198,7 @@ OCClosureTests >> testWhileModificationAfter [
 ]
 
 { #category : #'testing-while' }
-OCClosureTests >> testWhileModificationAfterNotInlined [
+OCClosureTest >> testWhileModificationAfterNotInlined [
 	| index block |
 	index := 0.
 	block := [ 
@@ -209,7 +209,7 @@ OCClosureTests >> testWhileModificationAfterNotInlined [
 ]
 
 { #category : #'testing-while' }
-OCClosureTests >> testWhileModificationBefore [
+OCClosureTest >> testWhileModificationBefore [
 	| index |
 	index := 0.
 	[ index < 5 ] whileTrue: [ 
@@ -219,7 +219,7 @@ OCClosureTests >> testWhileModificationBefore [
 ]
 
 { #category : #'testing-while' }
-OCClosureTests >> testWhileModificationBeforeNotInlined [
+OCClosureTest >> testWhileModificationBeforeNotInlined [
 	| index block |
 	index := 0.
 	block := [ 
@@ -230,7 +230,7 @@ OCClosureTests >> testWhileModificationBeforeNotInlined [
 ]
 
 { #category : #'testing-while' }
-OCClosureTests >> testWhileWithTemp [
+OCClosureTest >> testWhileWithTemp [
 	| index |
 	index := 0.
 	[ index < 5 ] whileTrue: [
@@ -241,7 +241,7 @@ OCClosureTests >> testWhileWithTemp [
 ]
 
 { #category : #'testing-while' }
-OCClosureTests >> testWhileWithTempIsNil [
+OCClosureTest >> testWhileWithTempIsNil [
 	
 	| index |
 	index := 0.
@@ -254,7 +254,7 @@ OCClosureTests >> testWhileWithTempIsNil [
 ]
 
 { #category : #'testing-while' }
-OCClosureTests >> testWhileWithTempNotInlined [
+OCClosureTest >> testWhileWithTempNotInlined [
 	| index block |
 	index := 0.
 	block := [

--- a/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #OCCompiledMethodIntegrityTests,
+	#name : #OCCompiledMethodIntegrityTest,
 	#superclass : #TestCase,
 	#category : #'OpalCompiler-Tests-Misc'
 }
 
 { #category : #test }
-OCCompiledMethodIntegrityTests >> testBlockTemps [
+OCCompiledMethodIntegrityTest >> testBlockTemps [
 
 	| newCompiledMethod |
 	newCompiledMethod := OpalCompiler new 
@@ -21,7 +21,7 @@ OCCompiledMethodIntegrityTests >> testBlockTemps [
 ]
 
 { #category : #test }
-OCCompiledMethodIntegrityTests >> testNotUsedArgument [
+OCCompiledMethodIntegrityTest >> testNotUsedArgument [
 
 	| newCompiledMethod |
 	
@@ -38,7 +38,7 @@ OCCompiledMethodIntegrityTests >> testNotUsedArgument [
 ]
 
 { #category : #test }
-OCCompiledMethodIntegrityTests >> testPragmas [
+OCCompiledMethodIntegrityTest >> testPragmas [
 
 	| newCompiledMethod |
 	
@@ -60,7 +60,7 @@ OCCompiledMethodIntegrityTests >> testPragmas [
 ]
 
 { #category : #test }
-OCCompiledMethodIntegrityTests >> testPrimitive [
+OCCompiledMethodIntegrityTest >> testPrimitive [
 
 	| newCompiledMethod |
 	
@@ -78,7 +78,7 @@ OCCompiledMethodIntegrityTests >> testPrimitive [
 ]
 
 { #category : #test }
-OCCompiledMethodIntegrityTests >> testRemoteTempInVector [
+OCCompiledMethodIntegrityTest >> testRemoteTempInVector [
 
 	| newCompiledMethod |
 
@@ -103,7 +103,7 @@ OCCompiledMethodIntegrityTests >> testRemoteTempInVector [
 ]
 
 { #category : #test }
-OCCompiledMethodIntegrityTests >> testUndeclaredVariable [
+OCCompiledMethodIntegrityTest >> testUndeclaredVariable [
 
 	| newCompiledMethod undeclaredBinding |
 	

--- a/src/OpalCompiler-Tests/OCIfNotNilTest.class.st
+++ b/src/OpalCompiler-Tests/OCIfNotNilTest.class.st
@@ -1,18 +1,18 @@
 Class {
-	#name : #OCIfNotNilTests,
+	#name : #OCIfNotNilTest,
 	#superclass : #TestCase,
 	#category : #'OpalCompiler-Tests-FromOld'
 }
 
 { #category : #tests }
-OCIfNotNilTests >> testIfNilIfNotNil0Arg [
+OCIfNotNilTest >> testIfNilIfNotNil0Arg [
 
 	self assert: (5 ifNil: [#foo] ifNotNil: [#bar]) = #bar.
 	self assert: (nil ifNil: [#foo] ifNotNil: [#bar]) = #foo
 ]
 
 { #category : #tests }
-OCIfNotNilTests >> testIfNilIfNotNil0ArgAsVar [
+OCIfNotNilTest >> testIfNilIfNotNil0ArgAsVar [
 
 	| block1 block2 |
 	block1 := [#foo].
@@ -22,14 +22,14 @@ OCIfNotNilTests >> testIfNilIfNotNil0ArgAsVar [
 ]
 
 { #category : #tests }
-OCIfNotNilTests >> testIfNilIfNotNil1Arg [
+OCIfNotNilTest >> testIfNilIfNotNil1Arg [
 
 	self assert: (5 ifNil: [#foo] ifNotNil: [:a | a printString]) = '5'.
 	self assert: (nil ifNil: [#foo] ifNotNil: [:a | a printString]) = #foo
 ]
 
 { #category : #tests }
-OCIfNotNilTests >> testIfNilIfNotNil1ArgAsVar [
+OCIfNotNilTest >> testIfNilIfNotNil1ArgAsVar [
 
 	| block1 block2 |
 	block1 := [#foo].
@@ -39,13 +39,13 @@ OCIfNotNilTests >> testIfNilIfNotNil1ArgAsVar [
 ]
 
 { #category : #tests }
-OCIfNotNilTests >> testIfNotNil0Arg [
+OCIfNotNilTest >> testIfNotNil0Arg [
 	self assert: (5 ifNotNil: [ #foo ]) = #foo.
 	self assert: (nil ifNotNil: [ #foo ]) isNil
 ]
 
 { #category : #tests }
-OCIfNotNilTests >> testIfNotNil0ArgAsVar [
+OCIfNotNilTest >> testIfNotNil0ArgAsVar [
 	| block |
 	block := [ #foo ].
 	self assert: (5 ifNotNil: block) = #foo.
@@ -53,13 +53,13 @@ OCIfNotNilTests >> testIfNotNil0ArgAsVar [
 ]
 
 { #category : #tests }
-OCIfNotNilTests >> testIfNotNil1Arg [
+OCIfNotNilTest >> testIfNotNil1Arg [
 	self assert: (5 ifNotNil: [ :a | a printString ]) = '5'.
 	self assert: (nil ifNotNil: [ :a | a printString ]) isNil
 ]
 
 { #category : #tests }
-OCIfNotNilTests >> testIfNotNil1ArgAsVar [
+OCIfNotNilTest >> testIfNotNil1ArgAsVar [
 	| block |
 	block := [ :a | a printString ].
 	self assert: (5 ifNotNil: block) = '5'.
@@ -67,20 +67,20 @@ OCIfNotNilTests >> testIfNotNil1ArgAsVar [
 ]
 
 { #category : #tests }
-OCIfNotNilTests >> testIfNotNil1ArgWithStatement [
+OCIfNotNilTest >> testIfNotNil1ArgWithStatement [
 	self assert: (5 ifNotNil: [ :a | 3. a ]) = 5.
 	self assert: (5 ifNotNil: [ :a | a. 3 ]) = 3.
 ]
 
 { #category : #tests }
-OCIfNotNilTests >> testIfNotNilIfNil0Arg [
+OCIfNotNilTest >> testIfNotNilIfNil0Arg [
 
 	self assert: (5 ifNotNil: [#foo] ifNil: [#bar]) = #foo.
 	self assert: (nil ifNotNil: [#foo] ifNil: [#bar]) = #bar
 ]
 
 { #category : #tests }
-OCIfNotNilTests >> testIfNotNilIfNil0ArgAsVar [
+OCIfNotNilTest >> testIfNotNilIfNil0ArgAsVar [
 
 	| block1 block2 |
 	block1 := [#foo].
@@ -90,14 +90,14 @@ OCIfNotNilTests >> testIfNotNilIfNil0ArgAsVar [
 ]
 
 { #category : #tests }
-OCIfNotNilTests >> testIfNotNilIfNil1Arg [
+OCIfNotNilTest >> testIfNotNilIfNil1Arg [
 
 	self assert: (5 ifNotNil: [:a | a printString] ifNil: [#foo]) = '5'.
 	self assert: (nil ifNotNil: [:a | a printString] ifNil: [#foo]) = #foo
 ]
 
 { #category : #tests }
-OCIfNotNilTests >> testIfNotNilIfNil1ArgAsVar [
+OCIfNotNilTest >> testIfNotNilIfNil1ArgAsVar [
 
 	| block1 block2 |
 	block1 := [#foo].

--- a/src/OpalCompiler-Tests/OCNewCompilerWithChangesFunctionalTest.class.st
+++ b/src/OpalCompiler-Tests/OCNewCompilerWithChangesFunctionalTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #OCNewCompilerWithChangesFunctionalTests,
+	#name : #OCNewCompilerWithChangesFunctionalTest,
 	#superclass : #TestCase,
 	#category : #'OpalCompiler-Tests-Misc'
 }
 
 { #category : #'test - block returning' }
-OCNewCompilerWithChangesFunctionalTests >> testBlockReturning [
+OCNewCompilerWithChangesFunctionalTest >> testBlockReturning [
 	
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new
@@ -46,7 +46,7 @@ OCNewCompilerWithChangesFunctionalTests >> testBlockReturning [
 ]
 
 { #category : #tests }
-OCNewCompilerWithChangesFunctionalTests >> testBlockTemp [
+OCNewCompilerWithChangesFunctionalTest >> testBlockTemp [
 	
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new
@@ -130,7 +130,7 @@ OCNewCompilerWithChangesFunctionalTests >> testBlockTemp [
 ]
 
 { #category : #'other-tests' }
-OCNewCompilerWithChangesFunctionalTests >> testDifferentBlocksWithSameArgumentName [
+OCNewCompilerWithChangesFunctionalTest >> testDifferentBlocksWithSameArgumentName [
 	
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new
@@ -206,7 +206,7 @@ OCNewCompilerWithChangesFunctionalTests >> testDifferentBlocksWithSameArgumentNa
 ]
 
 { #category : #tests }
-OCNewCompilerWithChangesFunctionalTests >> testMethodArgument [
+OCNewCompilerWithChangesFunctionalTest >> testMethodArgument [
 	
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new 
@@ -284,7 +284,7 @@ OCNewCompilerWithChangesFunctionalTests >> testMethodArgument [
 ]
 
 { #category : #tests }
-OCNewCompilerWithChangesFunctionalTests >> testMethodTemp [
+OCNewCompilerWithChangesFunctionalTest >> testMethodTemp [
 	
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new
@@ -352,7 +352,7 @@ OCNewCompilerWithChangesFunctionalTests >> testMethodTemp [
 ]
 
 { #category : #'other-tests' }
-OCNewCompilerWithChangesFunctionalTests >> testModulePrimitive [
+OCNewCompilerWithChangesFunctionalTest >> testModulePrimitive [
 	
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new 
@@ -386,7 +386,7 @@ OCNewCompilerWithChangesFunctionalTests >> testModulePrimitive [
 ]
 
 { #category : #'test - array compilation' }
-OCNewCompilerWithChangesFunctionalTests >> testMultiElementArray [
+OCNewCompilerWithChangesFunctionalTest >> testMultiElementArray [
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new 
 									encoderClass:  EncoderForV3PlusClosures; 
@@ -418,7 +418,7 @@ OCNewCompilerWithChangesFunctionalTests >> testMultiElementArray [
 ]
 
 { #category : #tests }
-OCNewCompilerWithChangesFunctionalTests >> testOneFloat [
+OCNewCompilerWithChangesFunctionalTest >> testOneFloat [
 	
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new 
@@ -441,7 +441,7 @@ OCNewCompilerWithChangesFunctionalTests >> testOneFloat [
 ]
 
 { #category : #tests }
-OCNewCompilerWithChangesFunctionalTests >> testPragma [
+OCNewCompilerWithChangesFunctionalTest >> testPragma [
 	
 	| aCompiledMethod bytecode |
 	aCompiledMethod := OpalCompiler new 
@@ -458,7 +458,7 @@ OCNewCompilerWithChangesFunctionalTests >> testPragma [
 ]
 
 { #category : #tests }
-OCNewCompilerWithChangesFunctionalTests >> testReturnBlockInMethod [
+OCNewCompilerWithChangesFunctionalTest >> testReturnBlockInMethod [
 	
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new
@@ -487,7 +487,7 @@ OCNewCompilerWithChangesFunctionalTests >> testReturnBlockInMethod [
 ]
 
 { #category : #tests }
-OCNewCompilerWithChangesFunctionalTests >> testSetUp [
+OCNewCompilerWithChangesFunctionalTest >> testSetUp [
 	
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new
@@ -520,7 +520,7 @@ OCNewCompilerWithChangesFunctionalTests >> testSetUp [
 ]
 
 { #category : #'test - array compilation' }
-OCNewCompilerWithChangesFunctionalTests >> testSimpleArray [
+OCNewCompilerWithChangesFunctionalTest >> testSimpleArray [
 	
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new
@@ -543,7 +543,7 @@ OCNewCompilerWithChangesFunctionalTests >> testSimpleArray [
 ]
 
 { #category : #tests }
-OCNewCompilerWithChangesFunctionalTests >> testSteamContentsLimitedToSequenceableCollectionClass [
+OCNewCompilerWithChangesFunctionalTest >> testSteamContentsLimitedToSequenceableCollectionClass [
 	| aCompiledMethod bytecode expected |
 	
 	aCompiledMethod := OpalCompiler new
@@ -612,7 +612,7 @@ OCNewCompilerWithChangesFunctionalTests >> testSteamContentsLimitedToSequenceabl
 ]
 
 { #category : #tests }
-OCNewCompilerWithChangesFunctionalTests >> testToDoArgumentNotInlined [
+OCNewCompilerWithChangesFunctionalTest >> testToDoArgumentNotInlined [
 	
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new
@@ -670,7 +670,7 @@ OCNewCompilerWithChangesFunctionalTests >> testToDoArgumentNotInlined [
 ]
 
 { #category : #tests }
-OCNewCompilerWithChangesFunctionalTests >> testToDoInsideTempNotInlined [
+OCNewCompilerWithChangesFunctionalTest >> testToDoInsideTempNotInlined [
 	"Some instructions are the same but we have a different number at he begining, and the storeTemp and popIntoTemp issue"
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new
@@ -738,7 +738,7 @@ OCNewCompilerWithChangesFunctionalTests >> testToDoInsideTempNotInlined [
 ]
 
 { #category : #tests }
-OCNewCompilerWithChangesFunctionalTests >> testToDoOutsideTempNotInlined [
+OCNewCompilerWithChangesFunctionalTest >> testToDoOutsideTempNotInlined [
 	"there seems to be a better indexzation of the temps we have one more"
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new
@@ -810,7 +810,7 @@ OCNewCompilerWithChangesFunctionalTests >> testToDoOutsideTempNotInlined [
 ]
 
 { #category : #tests }
-OCNewCompilerWithChangesFunctionalTests >> testWhileModificationAfterNotInlined [
+OCNewCompilerWithChangesFunctionalTest >> testWhileModificationAfterNotInlined [
 	"The bytecodes integers are different in some cases."
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new
@@ -899,7 +899,7 @@ OCNewCompilerWithChangesFunctionalTests >> testWhileModificationAfterNotInlined 
 ]
 
 { #category : #tests }
-OCNewCompilerWithChangesFunctionalTests >> testWhileModificationBeforeNotInlined [
+OCNewCompilerWithChangesFunctionalTest >> testWhileModificationBeforeNotInlined [
 	"The bytecodes integers are different in some cases."
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new
@@ -987,7 +987,7 @@ OCNewCompilerWithChangesFunctionalTests >> testWhileModificationBeforeNotInlined
 ]
 
 { #category : #tests }
-OCNewCompilerWithChangesFunctionalTests >> testWhileWithTempNotInlined [
+OCNewCompilerWithChangesFunctionalTest >> testWhileWithTempNotInlined [
 	"The bytecodes integers are different in some cases."
 	| aCompiledMethod bytecode expected |
 	aCompiledMethod := OpalCompiler new

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #OpalCompilerTests,
+	#name : #OpalCompilerTest,
 	#superclass : #TestCase,
 	#category : #'OpalCompiler-Tests-Misc'
 }
 
 { #category : #'tests - bindings' }
-OpalCompilerTests >> testArrayBindingsWithUppercaseNameDoOverwriteGlobals [
+OpalCompilerTest >> testArrayBindingsWithUppercaseNameDoOverwriteGlobals [
 	| result |
 	result := Smalltalk compiler
 		bindings: {(#UndefinedObject -> Object)};
@@ -14,7 +14,7 @@ OpalCompilerTests >> testArrayBindingsWithUppercaseNameDoOverwriteGlobals [
 ]
 
 { #category : #'tests - bindings' }
-OpalCompilerTests >> testArrayBindingsWriteGlobals [
+OpalCompilerTest >> testArrayBindingsWriteGlobals [
 	| result |
 	result := Smalltalk compiler
 		 bindings: {(#Object -> Point)};
@@ -23,7 +23,7 @@ OpalCompilerTests >> testArrayBindingsWriteGlobals [
 ]
 
 { #category : #'tests - bindings' }
-OpalCompilerTests >> testArrayEvaluateWithBindings [
+OpalCompilerTest >> testArrayEvaluateWithBindings [
 	| result |
 	result := Smalltalk compiler
 		bindings: {(#a -> 3)};
@@ -32,7 +32,7 @@ OpalCompilerTests >> testArrayEvaluateWithBindings [
 ]
 
 { #category : #'tests - bindings' }
-OpalCompilerTests >> testArrayEvaluateWithBindingsWithUppercaseName [
+OpalCompilerTest >> testArrayEvaluateWithBindingsWithUppercaseName [
 	| result |
 	result := Smalltalk compiler
 		bindings: {(#MyVar -> 3)};
@@ -41,7 +41,7 @@ OpalCompilerTests >> testArrayEvaluateWithBindingsWithUppercaseName [
 ]
 
 { #category : #'tests - bindings' }
-OpalCompilerTests >> testBindingsWithUppercaseNameDoOverwriteGlobals [
+OpalCompilerTest >> testBindingsWithUppercaseNameDoOverwriteGlobals [
 	| result |
 	result := Smalltalk compiler
 		bindings: {(#UndefinedObject -> Object)} asDictionary;
@@ -50,7 +50,7 @@ OpalCompilerTests >> testBindingsWithUppercaseNameDoOverwriteGlobals [
 ]
 
 { #category : #'tests - bindings' }
-OpalCompilerTests >> testBindingsWriteGlobals [
+OpalCompilerTest >> testBindingsWriteGlobals [
 	| result |
 	result := Smalltalk compiler
 		 bindings: {(#Object -> Point)} asDictionary;
@@ -59,7 +59,7 @@ OpalCompilerTests >> testBindingsWriteGlobals [
 ]
 
 { #category : #tests }
-OpalCompilerTests >> testCompileEmbeddsSource [
+OpalCompilerTest >> testCompileEmbeddsSource [
 	| result |
 	result := Smalltalk compiler
 		class: UndefinedObject;
@@ -79,7 +79,7 @@ OpalCompilerTests >> testCompileEmbeddsSource [
 ]
 
 { #category : #tests }
-OpalCompilerTests >> testCompileWithNilClass [
+OpalCompilerTest >> testCompileWithNilClass [
 	"we shoud use UndefinedObject if the class is nil"
 	| method |
 	method := Smalltalk compiler compile: 'tst 1+2'.
@@ -87,7 +87,7 @@ OpalCompilerTests >> testCompileWithNilClass [
 ]
 
 { #category : #'tests - bindings' }
-OpalCompilerTests >> testEvaluateWithBindings [
+OpalCompilerTest >> testEvaluateWithBindings [
 	| result |
 	result := Smalltalk compiler
 		bindings: {(#a -> 3)} asDictionary;
@@ -96,7 +96,7 @@ OpalCompilerTests >> testEvaluateWithBindings [
 ]
 
 { #category : #'tests - bindings' }
-OpalCompilerTests >> testEvaluateWithBindingsWithUppercaseName [
+OpalCompilerTest >> testEvaluateWithBindingsWithUppercaseName [
 	| result |
 	result := Smalltalk compiler
 		bindings: {(#MyVar -> 3)} asDictionary;


### PR DESCRIPTION
Opal test cases should end with Test instead of Tests.