### PR TITLE
Refactor a few tests to new classes

### DIFF
--- a/src/Files-Tests/FileRegistryTest.class.st
+++ b/src/Files-Tests/FileRegistryTest.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : #FileRegistryTest,
+	#superclass : #TestCase,
+	#category : #'Files-Tests-Core'
+}
+
+{ #category : #tests }
+FileRegistryTest >> testFilesAreRegisteredInWeakRegistry [
+
+	|  f |
+	f := (File named: 'asd.txt') writeStream.
+	[self assert: (File registry keys includes: f)]
+		ensure: [ f ifNotNil: [ f close ] ]
+]
+
+{ #category : #tests }
+FileRegistryTest >> testRegistryShouldBeCleaned [
+
+	| oldSize |
+	"We force some garbage collection to avoid noise in the test"
+	3 timesRepeat: [Smalltalk garbageCollect].
+	oldSize := File registry size.
+
+	(File named: 'asd.txt') writeStream.
+	3 timesRepeat: [Smalltalk garbageCollect].
+	
+	self assert: oldSize equals: File registry size.
+]

--- a/src/Files-Tests/FileTest.class.st
+++ b/src/Files-Tests/FileTest.class.st
@@ -54,15 +54,6 @@ FileTest >> testFileExists [
 ]
 
 { #category : #tests }
-FileTest >> testFilesAreRegisteredInWeakRegistry [
-
-	|  f |
-	f := (File named: 'asd.txt') writeStream.
-	[self assert: (File registry keys includes: f)]
-		ensure: [ f ifNotNil: [ f close ] ]
-]
-
-{ #category : #tests }
 FileTest >> testOpenFileForReadDoesNotDeleteExistingFile [
 
 	| size |
@@ -109,18 +100,4 @@ FileTest >> testOpeningForAppendSetsPositionAtEnd [
 	file := (File named: 'asd.txt') openForAppend.
 	[ self assert: file position equals: 3
 		] ensure: [ file ifNotNil: [ file close ] ]
-]
-
-{ #category : #tests }
-FileTest >> testRegistryShouldBeCleaned [
-
-	| oldSize |
-	"We force some garbage collection to avoid noise in the test"
-	3 timesRepeat: [Smalltalk garbageCollect].
-	oldSize := File registry size.
-
-	(File named: 'asd.txt') writeStream.
-	3 timesRepeat: [Smalltalk garbageCollect].
-	
-	self assert: oldSize equals: File registry size.
 ]

--- a/src/Network-Tests/TCPSocketTest.class.st
+++ b/src/Network-Tests/TCPSocketTest.class.st
@@ -2,7 +2,7 @@
 SUnit tests for sockets
 "
 Class {
-	#name : #SocketTest,
+	#name : #TCPSocketTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'listenerSocket',
@@ -13,7 +13,7 @@ Class {
 }
 
 { #category : #mocks }
-SocketTest >> faultyUDPSocket [
+TCPSocketTest >> faultyUDPSocket [
 
 	| cls |
 	
@@ -29,26 +29,26 @@ SocketTest >> faultyUDPSocket [
 ]
 
 { #category : #setup }
-SocketTest >> listenerAddress [
+TCPSocketTest >> listenerAddress [
 	^NetNameResolver loopBackAddress
 
 ]
 
 { #category : #setup }
-SocketTest >> listenerPort [
+TCPSocketTest >> listenerPort [
 	^42324
 
 ]
 
 { #category : #running }
-SocketTest >> setUp [
+TCPSocketTest >> setUp [
 	super setUp.
 	listenerSocket := Socket newTCP listenOn: self listenerPort backlogSize: 4 interface: self listenerAddress
 
 ]
 
 { #category : #running }
-SocketTest >> tearDown [
+TCPSocketTest >> tearDown [
 
 	listenerSocket ifNotNil:[listenerSocket destroy].
 	clientSocket ifNotNil:[clientSocket destroy].
@@ -58,7 +58,7 @@ SocketTest >> tearDown [
 ]
 
 { #category : #tests }
-SocketTest >> testClientConnect [
+TCPSocketTest >> testClientConnect [
 	"Tests a client socket connection"
 
 	clientSocket := Socket newTCP.
@@ -69,7 +69,7 @@ SocketTest >> testClientConnect [
 ]
 
 { #category : #tests }
-SocketTest >> testDataReceive [
+TCPSocketTest >> testDataReceive [
 	"Test data transfer and related methods"
 
 	self testDataSending.
@@ -82,7 +82,7 @@ SocketTest >> testDataReceive [
 ]
 
 { #category : #tests }
-SocketTest >> testDataSending [
+TCPSocketTest >> testDataSending [
 	"Test data transfer and related methods"
 
 	self testServerAccept.
@@ -94,7 +94,7 @@ SocketTest >> testDataSending [
 ]
 
 { #category : #tests }
-SocketTest >> testLocalAddress [
+TCPSocketTest >> testLocalAddress [
 	"Tests the various localAddress values for sockets"
 
 	self testServerAccept.
@@ -105,7 +105,7 @@ SocketTest >> testLocalAddress [
 ]
 
 { #category : #tests }
-SocketTest >> testLocalPort [
+TCPSocketTest >> testLocalPort [
 	"Tests the various localPort values for sockets"
 
 	self testServerAccept.
@@ -116,7 +116,7 @@ SocketTest >> testLocalPort [
 ]
 
 { #category : #tests }
-SocketTest >> testRemoteAddress [
+TCPSocketTest >> testRemoteAddress [
 	"Tests the various remoteAddress values for sockets"
 
 	self testServerAccept.
@@ -127,7 +127,7 @@ SocketTest >> testRemoteAddress [
 ]
 
 { #category : #tests }
-SocketTest >> testRemotePort [
+TCPSocketTest >> testRemotePort [
 	"Tests the various remoteAddress values for sockets"
 
 	self testServerAccept.
@@ -138,7 +138,7 @@ SocketTest >> testRemotePort [
 ]
 
 { #category : #tests }
-SocketTest >> testServerAccept [
+TCPSocketTest >> testServerAccept [
 	"Tests a server-side accept"
 
 	self testClientConnect.
@@ -146,54 +146,4 @@ SocketTest >> testServerAccept [
 	self assert: serverSocket notNil.
 	self assert: serverSocket isConnected
 
-]
-
-{ #category : #tests }
-SocketTest >> testUDPBroadcastError [
-	"Test that we get a specific error when failure is due to sending to a broadcast address without SO_BROADCAST set"
-	"Use 255.255.255.255 for testing, which in RFC 919 is defined as 'denoting a broadcast on a local hardware network, which must not be forwarded. 
-	This address may be used, for example, by hosts that do not know their network number and are asking some server for it.'"
-
-	self
-		should: [ 
-			Socket newUDP
-				setOption: 'SO_BROADCAST' value: false;
-				sendUDPData: #[] toHost: #[255 255 255 255] port: 1950 ]
-		raise: NoBroadcastAllowed.
-	self
-		shouldnt: [ 
-			Socket newUDP
-				setOption: 'SO_BROADCAST' value: true;
-				sendUDPData: #[] toHost: #[255 255 255 255] port: 1 ]
-		raise: NoBroadcastAllowed
-]
-
-{ #category : #tests }
-SocketTest >> testUDPFaultySend [
-
-	| socket host |
-	
-	socket := self faultyUDPSocket.	
-	host := #[1 2 3 4].
-	
-	"Check that sending is not caught in a infinite loop"
-	self should: [ 
-		
-		self 
-			deny: (socket isBroadcastAddress: host);
-			should: [socket sendUDPData: #[123] toHost: host port: 1 ] raise: NetworkError.
-			
-		host := #[ 255 255 255 255].
-		
-		self 
-			assert: (socket isBroadcastAddress: host);
-			should: [ socket sendUDPData: #[123] toHost: host port: 1 ] raise: NoBroadcastAllowed.
-			
-		socket setOption: 'SO_BROADCAST' value: true.
-		
-		self should: [ socket sendUDPData: #[123] toHost: host port: 1 ] raise: NetworkError.
-		
-	] notTakeMoreThanMilliseconds: 20.
-
-	socket destroy
 ]

--- a/src/Network-Tests/UDPSocketTest.class.st
+++ b/src/Network-Tests/UDPSocketTest.class.st
@@ -1,0 +1,60 @@
+Class {
+	#name : #UDPSocketTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'listenerSocket',
+		'clientSocket',
+		'serverSocket'
+	],
+	#category : #'Network-Tests-Kernel'
+}
+
+{ #category : #tests }
+UDPSocketTest >> testUDPBroadcastError [
+	"Test that we get a specific error when failure is due to sending to a broadcast address without SO_BROADCAST set"
+	"Use 255.255.255.255 for testing, which in RFC 919 is defined as 'denoting a broadcast on a local hardware network, which must not be forwarded. 
+	This address may be used, for example, by hosts that do not know their network number and are asking some server for it.'"
+
+	self
+		should: [ 
+			Socket newUDP
+				setOption: 'SO_BROADCAST' value: false;
+				sendUDPData: #[] toHost: #[255 255 255 255] port: 1950 ]
+		raise: NoBroadcastAllowed.
+	self
+		shouldnt: [ 
+			Socket newUDP
+				setOption: 'SO_BROADCAST' value: true;
+				sendUDPData: #[] toHost: #[255 255 255 255] port: 1 ]
+		raise: NoBroadcastAllowed
+]
+
+{ #category : #tests }
+UDPSocketTest >> testUDPFaultySend [
+
+	| socket host |
+	
+	socket := self faultyUDPSocket.	
+	host := #[1 2 3 4].
+	
+	"Check that sending is not caught in a infinite loop"
+	self should: [ 
+		
+		self 
+			deny: (socket isBroadcastAddress: host);
+			should: [socket sendUDPData: #[123] toHost: host port: 1 ] raise: NetworkError.
+			
+		host := #[ 255 255 255 255].
+		
+		self 
+			assert: (socket isBroadcastAddress: host);
+			should: [ socket sendUDPData: #[123] toHost: host port: 1 ] raise: NoBroadcastAllowed.
+			
+		socket setOption: 'SO_BROADCAST' value: true.
+		
+		self should: [ socket sendUDPData: #[123] toHost: host port: 1 ] raise: NetworkError.
+		
+	] notTakeMoreThanMilliseconds: 20.
+
+	socket destroy
+]


### PR DESCRIPTION
Most tests in FileTest are for the public API but two test the internal implementation. I'd like to have these in a separate class so I can pass everything in FileTest when the code is ported to GemStone.

All but two tests in SocketTest are for TCP; the exceptions are for UDP. I'd like to separate these into two classes so I can test these capabilities separately. 