### PR TITLE
4201-Add-isHidden-file-attribute

### DIFF
--- a/src/FileSystem-Core/DiskDirectoryEntry.class.st
+++ b/src/FileSystem-Core/DiskDirectoryEntry.class.st
@@ -283,6 +283,13 @@ DiskDirectoryEntry >> isFile [
 ]
 
 { #category : #testing }
+DiskDirectoryEntry >> isHidden [
+	"Answer a boolean indicating whether the receiver is hidden"
+
+	^reference fileSystem isHidden: reference attributes: self statAttributes
+]
+
+{ #category : #testing }
 DiskDirectoryEntry >> isReadable [
 	"Answer a boolean indicating whether the VM can read the receivers file"
 

--- a/src/FileSystem-Core/DiskDirectoryEntry.class.st
+++ b/src/FileSystem-Core/DiskDirectoryEntry.class.st
@@ -175,8 +175,6 @@ DiskDirectoryEntry >> getAllAttributes [
 	allAttributes := self primitives fileAttributes: self pathString mask: self allAttributeMask.
 	statAttributes := allAttributes at: 1.
 	accessAttributes := allAttributes at: 2.
-	(statAttributes at: 1) ifNotNil: 
-		[ statAttributes at: 1 put: (self primitives decodePathString: (statAttributes at: 1)) ].
 
 ]
 
@@ -184,10 +182,8 @@ DiskDirectoryEntry >> getAllAttributes [
 DiskDirectoryEntry >> getStatAttributes [
 	"Store the receivers stat() attributes for future reference"
 
-	statAttributes := self primitives fileAttributes: self pathString mask: self statAttributeMask.
-	(statAttributes at: 1) ifNotNil: 
-		[ statAttributes at: 1 put: (self primitives decodePathString: (statAttributes at: 1)) ].
-	^statAttributes
+	^statAttributes := self primitives fileAttributes: self pathString mask: self statAttributeMask.
+
 ]
 
 { #category : #accessing }

--- a/src/FileSystem-Core/FileSystem.class.st
+++ b/src/FileSystem-Core/FileSystem.class.st
@@ -565,6 +565,14 @@ FileSystem >> isFile: aResolvable [
 ]
 
 { #category : #'public-testing' }
+FileSystem >> isHidden: aResolvable attributes: statAttributesArray [
+	"Resolve the argument, and answer a boolean indicating whether the file is hidden or not.
+	statAttributesArray is optional and may be supplied for performance.  It is the result of File>>fileAttributes:mask: or nil"
+
+	^ store isHidden: (self resolve: aResolvable) attributes: statAttributesArray 
+]
+
+{ #category : #'public-testing' }
 FileSystem >> isReadable: aResolvable [
 	"Resolve the argument, and answer true if the there is
 	a file or directory that can be read from."

--- a/src/FileSystem-Core/FileSystemDirectoryEntry.class.st
+++ b/src/FileSystem-Core/FileSystemDirectoryEntry.class.st
@@ -195,6 +195,13 @@ FileSystemDirectoryEntry >> isFile [
 ]
 
 { #category : #testing }
+FileSystemDirectoryEntry >> isHidden [
+	"Return whether the receiver is hidden"
+
+	^false
+]
+
+{ #category : #testing }
 FileSystemDirectoryEntry >> isReadable [
 
 	^false

--- a/src/FileSystem-Disk/UnixStore.class.st
+++ b/src/FileSystem-Disk/UnixStore.class.st
@@ -53,3 +53,11 @@ UnixStore >> checkName: aFileName fixErrors: fixing [
 	
 	^ fName copyReplaceAll: self delimiter asString with: '#'
 ]
+
+{ #category : #testing }
+UnixStore >> isHidden: aResolvable attributes: statAttributesArray [
+	"Answer a boolean indicating whether the file is hidden or not.
+	On Unix, use the file naming convention that file names beginning with a dot are not displayed"
+
+	^aResolvable basename first = $.
+]

--- a/src/FileSystem-Disk/WindowsStore.class.st
+++ b/src/FileSystem-Disk/WindowsStore.class.st
@@ -171,6 +171,19 @@ WindowsStore >> isFIFO: aPath [
 ]
 
 { #category : #testing }
+WindowsStore >> isHidden: aPath attributes: statAttributesArray [
+	"Answer a boolean indicating whether the file is hidden or not.
+	statAttributesArray is optional and may be supplied for performance.  It is the result of File>>fileAttributes:mask: or nil"
+
+	| attributesArray |
+	
+	attributesArray := statAttributesArray ifNil: 
+		[ File fileAttributes: (self stringFromPath: aPath) mask: 1 ].
+
+	^(attributesArray at: 13) anyMask: 16r2
+]
+
+{ #category : #testing }
 WindowsStore >> isReadable: aPath [
 	"Answer a boolean indicating whether the supplied path is readable"
 

--- a/src/FileSystem-Tests-Attributes/DiskFileAttributesTest.class.st
+++ b/src/FileSystem-Tests-Attributes/DiskFileAttributesTest.class.st
@@ -167,6 +167,12 @@ DiskFileAttributesTest >> testIsFIFO [
 ]
 
 { #category : #tests }
+DiskFileAttributesTest >> testIsHidden [
+
+	self collectionAssert: [ :each | each isHidden ] equals: false.
+]
+
+{ #category : #tests }
 DiskFileAttributesTest >> testIsReadable [
 
 	self collectionAssert: [ :each | each isReadable ].

--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -265,7 +265,15 @@ File class >> fileAttributeNumberMap [
 { #category : #attributes }
 File class >> fileAttributes: aString mask: attributeMask [
 
-	^self primFileAttributes: (self encodePathString: aString) mask: attributeMask
+	| attributes statAttributes mask |
+
+	attributes := self primFileAttributes: (self encodePathString: aString) mask: attributeMask.
+	mask := attributeMask bitAnd: 2r11.
+	mask = 1 ifTrue: [ statAttributes := attributes ].
+	mask = 3 ifTrue: [ statAttributes := attributes at: 1 ].
+	(statAttributes isNotNil and: [ (statAttributes at: 1) isNotNil ]) ifTrue: 
+		[ statAttributes at: 1 put: (self decodePathString: (statAttributes at: 1)) ].
+	^attributes
 ]
 
 { #category : #'primitives-version' }
@@ -722,6 +730,7 @@ stat() information:
 	9: accessDate
 	10: modifiedDate
 	11: creationDate
+	12: Windows File Attributes mask (https://docs.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants)
 
 access() information
 


### PR DESCRIPTION
Add DiskDirectoryEntry>>isHidden

For Windows, this will be the FILE_ATTRIBUTE_HIDDEN bit, see https://docs.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants.

For Unix, this will use the file naming convention that files beginning with a '.' are not listed.

Fixes: #4201