### PR TITLE
4209 ast mapping is wrong when using sistav1 and fullblockclosures

### DIFF
--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -451,6 +451,7 @@ OCASTTranslator >> translateFullBlock: aBlockNode [
 			withVars: (aBlockNode scope tempVector collect: [:each| each name]) asArray.
 	].
 	valueTranslator visitNode: aBlockNode body.
+	methodBuilder mapToNode: aBlockNode body.
 	methodBuilder addBlockReturnTopIfRequired.
 	aBlockNode ir: self ir.
 	^ aBlockNode ir compiledBlock: aBlockNode scope

--- a/src/OpalCompiler-Tests/OCASTTranslatorMappingForFullBlockClosuresTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorMappingForFullBlockClosuresTest.class.st
@@ -44,6 +44,11 @@ OCASTTranslatorMappingForFullBlockClosuresTest >> setUp [
 		yourself
 ]
 
+{ #category : #running }
+OCASTTranslatorMappingForFullBlockClosuresTest >> tearDown [
+	
+]
+
 { #category : #testing }
 OCASTTranslatorMappingForFullBlockClosuresTest >> testBlockWithParametersASTMapping [
 	|method blockNode|

--- a/src/OpalCompiler-Tests/OCASTTranslatorMappingForFullBlockClosuresTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorMappingForFullBlockClosuresTest.class.st
@@ -61,7 +61,7 @@ OCASTTranslatorMappingForFullBlockClosuresTest >> testBlockWithParametersASTMapp
 { #category : #testing }
 OCASTTranslatorMappingForFullBlockClosuresTest >> testSimpleBlockASTMapping [
 	|method blockNode|
-	method := self compileSourceToMethod: 'm ^[1 + 2] value'.
+	method := self compileSourceToMethod: 'm ^[40 + 2] value'.
 	blockNode := method ast statements first value receiver.
 	self assertBlockNodeHasCorrectIR: blockNode.
 	self assertMethodReturnValue: method

--- a/src/OpalCompiler-Tests/OCASTTranslatorMappingForFullBlockClosuresTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorMappingForFullBlockClosuresTest.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : #OCASTTranslatorMappingForFullBlockClosuresTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'ctx',
+		'compiler'
+	],
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #testing }
+OCASTTranslatorMappingForFullBlockClosuresTest >> assertBlockNodeHasCorrectIR: blockNode [
+	| sequence |
+	blockNode methodNode ir.
+	sequence := blockNode ir startSequence.
+	self assert: (sequence allSatisfy: [ :ir | ir sourceNode notNil ]).
+	self assert: sequence last equals: blockNode body
+]
+
+{ #category : #support }
+OCASTTranslatorMappingForFullBlockClosuresTest >> compileSourceToMethod: source [
+	| method |
+	method := compiler
+		source: source;
+		compile.
+	method ast compilationContext: ctx.
+	^ method
+]
+
+{ #category : #running }
+OCASTTranslatorMappingForFullBlockClosuresTest >> setUp [
+	ctx := CompilationContext new
+		encoderClass: EncoderForSistaV1;
+		setOptions: {#optionFullBlockClosure . #optionEmbeddSources} asSet.
+	compiler := OpalCompiler new
+		compilationContext: ctx;
+		yourself
+]
+
+{ #category : #testing }
+OCASTTranslatorMappingForFullBlockClosuresTest >> testSimpleBlockASTMapping [
+	|method blockNode|
+	method := self compileSourceToMethod: 'm [1 + 2]'.
+	blockNode := method ast statements first.
+	self assertBlockNodeHasCorrectIR: blockNode
+]

--- a/src/OpalCompiler-Tests/OCASTTranslatorMappingForFullBlockClosuresTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorMappingForFullBlockClosuresTest.class.st
@@ -36,6 +36,7 @@ OCASTTranslatorMappingForFullBlockClosuresTest >> compileSourceToMethod: source 
 
 { #category : #running }
 OCASTTranslatorMappingForFullBlockClosuresTest >> setUp [
+	super setUp.
 	ctx := CompilationContext new
 		encoderClass: EncoderForSistaV1;
 		setOptions: {#optionFullBlockClosure . #optionEmbeddSources} asSet.
@@ -46,7 +47,7 @@ OCASTTranslatorMappingForFullBlockClosuresTest >> setUp [
 
 { #category : #running }
 OCASTTranslatorMappingForFullBlockClosuresTest >> tearDown [
-	
+	super tearDown 
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Tests/OCASTTranslatorMappingForFullBlockClosuresTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorMappingForFullBlockClosuresTest.class.st
@@ -12,9 +12,9 @@ Class {
 OCASTTranslatorMappingForFullBlockClosuresTest >> assertBlockNodeHasCorrectIR: blockNode [
 	| sequence |
 	blockNode methodNode ir.
-	sequence := blockNode ir startSequence.
+	sequence := blockNode ir startSequence sequence.
 	self assert: (sequence allSatisfy: [ :ir | ir sourceNode notNil ]).
-	self assert: sequence last equals: blockNode body
+	self assert: sequence last sourceNode equals: blockNode body
 ]
 
 { #category : #support }
@@ -40,7 +40,7 @@ OCASTTranslatorMappingForFullBlockClosuresTest >> setUp [
 { #category : #testing }
 OCASTTranslatorMappingForFullBlockClosuresTest >> testSimpleBlockASTMapping [
 	|method blockNode|
-	method := self compileSourceToMethod: 'm [1 + 2]'.
-	blockNode := method ast statements first.
+	method := self compileSourceToMethod: 'm [1 + 2] value'.
+	blockNode := method ast statements first receiver.
 	self assertBlockNodeHasCorrectIR: blockNode
 ]

--- a/src/OpalCompiler-Tests/OCASTTranslatorMappingForFullBlockClosuresTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorMappingForFullBlockClosuresTest.class.st
@@ -17,6 +17,13 @@ OCASTTranslatorMappingForFullBlockClosuresTest >> assertBlockNodeHasCorrectIR: b
 	self assert: sequence last sourceNode equals: blockNode body
 ]
 
+{ #category : #testing }
+OCASTTranslatorMappingForFullBlockClosuresTest >> assertMethodReturnValue: method [
+	self
+		assert: (method valueWithReceiver: nil arguments: #())
+		equals: 42
+]
+
 { #category : #support }
 OCASTTranslatorMappingForFullBlockClosuresTest >> compileSourceToMethod: source [
 	| method |
@@ -38,9 +45,19 @@ OCASTTranslatorMappingForFullBlockClosuresTest >> setUp [
 ]
 
 { #category : #testing }
+OCASTTranslatorMappingForFullBlockClosuresTest >> testBlockWithParametersASTMapping [
+	|method blockNode|
+	method := self compileSourceToMethod: 'm ^[:i :j|i+j] value: 41 value: 1'.
+	blockNode := method ast statements first value receiver.
+	self assertBlockNodeHasCorrectIR: blockNode.
+	self assertMethodReturnValue: method
+]
+
+{ #category : #testing }
 OCASTTranslatorMappingForFullBlockClosuresTest >> testSimpleBlockASTMapping [
 	|method blockNode|
-	method := self compileSourceToMethod: 'm [1 + 2] value'.
-	blockNode := method ast statements first receiver.
-	self assertBlockNodeHasCorrectIR: blockNode
+	method := self compileSourceToMethod: 'm ^[1 + 2] value'.
+	blockNode := method ast statements first value receiver.
+	self assertBlockNodeHasCorrectIR: blockNode.
+	self assertMethodReturnValue: method
 ]


### PR DESCRIPTION
Added a mapping in `OCAsTTranslator >> translateFullBlock:`

- Need to test more cases: can we generate them?
- Need to discuss the fix: which node should we map?
- Fixes the problem for the spec debugger but there are other problems related to the GT debugger

Fixes #4209 