### PR TITLE
ReTestClassNameShouldEndWithTest-should-also-accept-TestCase

### DIFF
--- a/src/Renraku-Test/ReTestClassNameShouldEndWithTestTest.class.st
+++ b/src/Renraku-Test/ReTestClassNameShouldEndWithTestTest.class.st
@@ -6,16 +6,14 @@ Class {
 
 { #category : #tests }
 ReTestClassNameShouldEndWithTestTest >> testBasicCheck [
+	self assert: (testClass critiques noneSatisfy: [ :critic | critic rule class = ReTestClassNameShouldEndWithTest ]).
 	
-	self
-		assert: (testClass critiques noneSatisfy: [ :critic | critic rule class = ReTestClassNameShouldEndWithTest ]).
-		
-		
-	"test class name not endind with 'Test'"
-	testClass rename:'Toto'.
-	
-	self
-		assert: (testClass critiques anySatisfy: [ :critic | critic rule class = ReTestClassNameShouldEndWithTest ]).
-	
+	testClass rename: 'TotoTestCase'.
 
+	self assert: (testClass critiques noneSatisfy: [ :critic | critic rule class = ReTestClassNameShouldEndWithTest ]).
+
+	"test class name not endind with 'Test'"
+	testClass rename: 'Toto'.
+
+	self assert: (testClass critiques anySatisfy: [ :critic | critic rule class = ReTestClassNameShouldEndWithTest ])
 ]

--- a/src/Renraku/ReTestClassNameShouldEndWithTest.class.st
+++ b/src/Renraku/ReTestClassNameShouldEndWithTest.class.st
@@ -1,5 +1,5 @@
 "
-Check if a subclass of TestCase ends with 'Test'
+Check if a subclass of TestCase ends with 'Test' or 'TestCase'.
 "
 Class {
 	#name : #ReTestClassNameShouldEndWithTest,
@@ -15,9 +15,9 @@ ReTestClassNameShouldEndWithTest class >> checksClass [
 
 { #category : #running }
 ReTestClassNameShouldEndWithTest >> basicCheck: aClass [
-
-
-	^ (aClass inheritsFrom: TestCase) and: [(aClass name asString endsWith: 'Test') not].
+	| suffixes |
+	suffixes := #('Test' 'TestCase').
+	^ (aClass inheritsFrom: TestCase) and: [ suffixes noneSatisfy: [ :suffix | aClass name asString endsWith: suffix ] ]
 ]
 
 { #category : #running }
@@ -32,7 +32,7 @@ ReTestClassNameShouldEndWithTest >> name [
 
 { #category : #accessing }
 ReTestClassNameShouldEndWithTest >> rationale [
-	^ 'A test class (subclass of TestCase) should have it''s name ending with ''Test'''
+	^ 'A test class (subclass of TestCase) should have it''s name ending with ''Test'' or ''TestCase'''
 ]
 
 { #category : #running }


### PR DESCRIPTION
ReTestClassNameShouldEndWithTest should accept test classes ending with 'Test' but also 'TestCase'.