### PR TITLE
Fix allocation tests

### DIFF
--- a/src/Kernel-Tests/AllocationTest.class.st
+++ b/src/Kernel-Tests/AllocationTest.class.st
@@ -8,10 +8,25 @@ Class {
 }
 
 { #category : #testing }
-AllocationTest >> testOneGigAllocation [
+AllocationTest >> testOneGBAllocation [
 	"Documentating a weird bug in the allocator"
 	
 	| sz array failed |
+	failed := false.
+	sz := 1024*1024*1024.
+	array := [ByteArray new: sz] on: OutOfMemory do: [:ex| failed := true].
+	self assert: (failed or:[array size = sz]).
+	
+]
+
+{ #category : #testing }
+AllocationTest >> testOneGWordAllocation [
+	"Documentating a weird bug in the allocator"
+	
+	| sz array failed |
+	"This takes too much time to run"
+	self timeLimit: 1 minute.
+	
 	failed := false.
 	sz := 1024*1024*1024.
 	array := [Array new: sz] on: OutOfMemory do: [:ex| failed := true].
@@ -20,7 +35,19 @@ AllocationTest >> testOneGigAllocation [
 ]
 
 { #category : #testing }
-AllocationTest >> testOneMegAllocation [
+AllocationTest >> testOneMBAllocation [
+	"Documentating a weird bug in the allocator"
+	
+	| sz array failed |
+	failed := false.
+	sz := 1024*1024.
+	array := [ByteArray new: sz] on: OutOfMemory do: [:ex| failed := true].
+	self assert: (failed or:[array size = sz]).
+	
+]
+
+{ #category : #testing }
+AllocationTest >> testOneMWordAllocation [
 	"Documentating a weird bug in the allocator"
 	
 	| sz array failed |


### PR DESCRIPTION
Allocation tests timeout in 64 bits and are not correctly named.

 - Rename methods to reflect correctly if they are testing GBytes or GWords
 - Add missing GBytes tests
 - extend test timeout for long running tests