### PR TITLE
4229-Lint-clean-BehaviorallInstVarNames

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -131,9 +131,9 @@ Behavior >> allInstVarNames [
 	accessed by the interpreter."
 
 	| vars |
-	self superclass == nil
-		ifTrue: [vars := self slots collect: #name]	"Guarantee a copy is answered."
-		ifFalse: [vars := self superclass allInstVarNames , (self slots collect: #name)].
+	vars := self superclass 
+		ifNil: [ self slots collect: #name ]	"Guarantee a copy is answered."
+		ifNotNil: [ self superclass allInstVarNames , (self slots collect: #name) ].
 	^vars
 ]
 


### PR DESCRIPTION
Lint clean Behavior>>allInstVarNames

Fix #4229