### PR TITLE
4238-Calypso-does-not-show-protocols-of-traits

### DIFF
--- a/src/Calypso-SystemQueries/ClassDescription.extension.st
+++ b/src/Calypso-SystemQueries/ClassDescription.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #ClassDescription }
+
+{ #category : #'*Calypso-SystemQueries' }
+ClassDescription >> tagsForAllMethods [
+	"I act as #tagsForMethods but I also takes into account methods comming from traits"
+
+	| allProtocols |
+	allProtocols := self organization protocols reject: [ :each | each name = Protocol unclassified | each isExtensionProtocol ].
+
+	^ allProtocols select: [ :each | each methods anySatisfy: [ :method | self selectors includes: method ] ] thenCollect: #name
+]

--- a/src/Calypso-SystemQueries/ClyTaggedMethodGroupProvider.class.st
+++ b/src/Calypso-SystemQueries/ClyTaggedMethodGroupProvider.class.st
@@ -12,16 +12,15 @@ Class {
 
 { #category : #'building groups' }
 ClyTaggedMethodGroupProvider >> buildGroupsFrom: aClassScope [
-	
 	| groups |
 	groups := IdentityDictionary new.
 	
 	aClassScope classesDo: [ :eachClass |
-		eachClass tagsForMethods do: [:eachTag | 
+		eachClass tagsForAllMethods do: [ :eachTag | 
 			groups at: eachTag ifAbsentPut: [ 
-				ClyTaggedMethodGroup withMethodsFrom: aClassScope taggedBy: eachTag]]].
+				ClyTaggedMethodGroup withMethodsFrom: aClassScope taggedBy: eachTag ] ] ].
 
-	^groups values
+	^ groups values
 ]
 
 { #category : #'system changes' }


### PR DESCRIPTION
In calypso, also show protocols when only methods from traits are inside.

Fixes #4238