### PR TITLE
Repackage PositionableStream class >> with:do: 

### DIFF
--- a/src/Collections-Streams/PositionableStream.class.st
+++ b/src/Collections-Streams/PositionableStream.class.st
@@ -31,6 +31,14 @@ PositionableStream class >> on: aCollection from: firstIndex to: lastIndex [
 		to: lastIndex
 ]
 
+{ #category : #'enumerating' }
+PositionableStream class >> with: aCollectionOrStream do: aBlock [
+	"Evaluates a block with a new stream based on the collection or stream. Answers the result of the block evaluation. Follows the style of FileStream>>fileNamed:do:."
+	| aStream |
+	aStream := self on: aCollectionOrStream.
+	[ ^ aBlock value: aStream ] ensure: [ aStream close ]
+]
+
 { #category : #testing }
 PositionableStream >> atEnd [
 	"Primitive. Answer whether the receiver can access any more objects.

--- a/src/Fuel-Tests-Core/PositionableStream.extension.st
+++ b/src/Fuel-Tests-Core/PositionableStream.extension.st
@@ -1,9 +1,0 @@
-Extension { #name : #PositionableStream }
-
-{ #category : #'*Fuel-Tests-Core' }
-PositionableStream class >> with: aCollectionOrStream do: aBlock [
-	"Evaluates a block with a new stream based on the collection or stream. Answers the result of the block evaluation. Follows the style of FileStream>>fileNamed:do:."
-	| aStream |
-	aStream := self on: aCollectionOrStream.
-	[ ^ aBlock value: aStream ] ensure: [ aStream close ]
-]


### PR DESCRIPTION
This method is referenced from `GZipReadStream class>>unzip:to:` but is provided by a testing package. Should I rewrite the code to not use the missing method? Or move the method to the minimal image? Or something else?

With this PR I propose to move it from `Fuel-Tests-Core` to `Collections-Streams` since it might be used elsewhere. I'm happy to take another approach, but at present the minimal image is broken so something should be done.