### PR TITLE
The WorldState should keep the value of the window size.

### DIFF
--- a/src/Morphic-Core/VMWorldRenderer.class.st
+++ b/src/Morphic-Core/VMWorldRenderer.class.st
@@ -70,6 +70,8 @@ VMWorldRenderer >> checkForNewScreenSize [
    Display setExtent: self actualScreenSize depth: 32.
    Display beDisplay.
 
+	world worldState storedExtent: self actualScreenSize.
+
 	world restoreMorphicDisplay.
 
 ]

--- a/src/Morphic-Core/VMWorldRenderer.class.st
+++ b/src/Morphic-Core/VMWorldRenderer.class.st
@@ -70,7 +70,7 @@ VMWorldRenderer >> checkForNewScreenSize [
    Display setExtent: self actualScreenSize depth: 32.
    Display beDisplay.
 
-	world worldState storedExtent: self actualScreenSize.
+	world worldState realWindowExtent: self actualScreenSize.
 
 	world restoreMorphicDisplay.
 

--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -20,7 +20,7 @@ Class {
 		'activeHand',
 		'currentCursor',
 		'worldRenderer',
-		'storedExtent'
+		'realWindowExtent'
 	],
 	#classVars : [
 		'CanSurrenderToOS',
@@ -708,6 +708,18 @@ WorldState >> listOfSteppingMorphs [
 
 ]
 
+{ #category : #hands }
+WorldState >> realWindowExtent [
+
+	^ realWindowExtent
+]
+
+{ #category : #hands }
+WorldState >> realWindowExtent: aValue [
+
+	realWindowExtent := aValue
+]
+
 { #category : #canvas }
 WorldState >> recordDamagedRect: damageRect [
 
@@ -836,18 +848,6 @@ WorldState >> stopStepping: aMorph selector: aSelector [
 		(lastStepMessage receiver == aMorph and:[lastStepMessage selector == aSelector])
 			ifTrue:[lastStepMessage := nil]].
 	stepList removeAll: (stepList select:[:stepMsg| stepMsg receiver == aMorph and:[stepMsg selector == aSelector]]).
-]
-
-{ #category : #hands }
-WorldState >> storedExtent [
-
-	^ storedExtent
-]
-
-{ #category : #hands }
-WorldState >> storedExtent: aValue [
-
-	storedExtent := aValue
 ]
 
 { #category : #alarms }

--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -19,7 +19,8 @@ Class {
 		'menuBuilder',
 		'activeHand',
 		'currentCursor',
-		'worldRenderer'
+		'worldRenderer',
+		'storedExtent'
 	],
 	#classVars : [
 		'CanSurrenderToOS',
@@ -835,6 +836,18 @@ WorldState >> stopStepping: aMorph selector: aSelector [
 		(lastStepMessage receiver == aMorph and:[lastStepMessage selector == aSelector])
 			ifTrue:[lastStepMessage := nil]].
 	stepList removeAll: (stepList select:[:stepMsg| stepMsg receiver == aMorph and:[stepMsg selector == aSelector]]).
+]
+
+{ #category : #hands }
+WorldState >> storedExtent [
+
+	^ storedExtent
+]
+
+{ #category : #hands }
+WorldState >> storedExtent: aValue [
+
+	storedExtent := aValue
 ]
 
 { #category : #alarms }

--- a/src/OSWindow-Core/OSWindow.class.st
+++ b/src/OSWindow-Core/OSWindow.class.st
@@ -198,6 +198,12 @@ OSWindow >> extent: newExtent [
 	self validHandle extent: newExtent
 ]
 
+{ #category : #'window management' }
+OSWindow >> focus [
+
+	self validHandle raise.
+]
+
 { #category : #accessing }
 OSWindow >> fullscreen: aBoolean [
 	self validHandle fullscreen: aBoolean

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -57,7 +57,7 @@ OSWorldRenderer >> checkForNewScreenSize [
 	display := Form extent: self actualScreenSize depth: 32.
 	self osWindowRenderer form: display.
 
-	world worldState storedExtent: self actualScreenSize.
+	world worldState realWindowExtent: self actualScreenSize.
 
 	world restoreMorphicDisplay.
 
@@ -130,7 +130,7 @@ OSWorldRenderer >> doActivate [
 
 	| attributes initialExtent |
 	
-	initialExtent := world worldState storedExtent ifNil: [1500@1000].
+	initialExtent := world worldState realWindowExtent ifNil: [1500@1000].
 
 	attributes := OSWindowAttributes new.
 	attributes

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -145,6 +145,8 @@ OSWorldRenderer >> doActivate [
 	attributes preferableDriver: driver.
 	osWindow := OSWindow createWithAttributes: attributes eventHandler: (OSWindowMorphicEventHandler for: world).
 	
+	osWindow focus. 
+	
 	world worldState doFullRepaint.
 	world displayWorld.
 	

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -57,6 +57,8 @@ OSWorldRenderer >> checkForNewScreenSize [
 	display := Form extent: self actualScreenSize depth: 32.
 	self osWindowRenderer form: display.
 
+	world worldState storedExtent: self actualScreenSize.
+
 	world restoreMorphicDisplay.
 
 ]
@@ -126,16 +128,18 @@ OSWorldRenderer >> displayWorldState: aWorldState ofWorld: aWorld submorphs: sub
 { #category : #initialization }
 OSWorldRenderer >> doActivate [
 
-	| attributes |
+	| attributes initialExtent |
+	
+	initialExtent := world worldState storedExtent ifNil: [1500@1000].
 
 	attributes := OSWindowAttributes new.
 	attributes
-		extent: 1000@1000;
+		extent: initialExtent;
 		title: Smalltalk shortImageName;
 		icon: (self iconNamed: #pharoBig).
 
-	display := Form extent: 1000@1000 depth: 32.
-	world extent: 1000@1000.
+	display := Form extent: initialExtent depth: 32.
+	world extent: initialExtent.
 
 	driver := self pickMostSuitableWindowDriver.
 	attributes preferableDriver: driver.

--- a/src/OSWindow-SDL2/OSSDL2WindowHandle.class.st
+++ b/src/OSWindow-SDL2/OSSDL2WindowHandle.class.st
@@ -286,6 +286,12 @@ OSSDL2WindowHandle >> prepareExternalResourceForAutoRelease [
 	handle autoRelease
 ]
 
+{ #category : #accessing }
+OSSDL2WindowHandle >> raise [
+
+	handle raise
+]
+
 { #category : #'mouse capture' }
 OSSDL2WindowHandle >> releaseMouse [
 	SDL2 setRelativeMouseMode: false

--- a/src/OSWindow-SDL2/SDL_Window.class.st
+++ b/src/OSWindow-SDL2/SDL_Window.class.st
@@ -112,6 +112,12 @@ SDL_Window >> primDestroy [
 	^ self ffiCall: #( void SDL_DestroyWindow ( self ) )
 ]
 
+{ #category : #'window management' }
+SDL_Window >> raise [
+
+	^ self ffiCall: #( void SDL_RaiseWindow( self ) )
+]
+
 { #category : #'external resource management' }
 SDL_Window >> resourceData [
 	^ {self getHandle. self windowID }


### PR DESCRIPTION
This is useful to store the value in the image, so the OSWindow can have it. 
And it does not depend on a primitive to access it.