### PR TITLE
[Backport] P7 - Fixed problems with ZnMimeType hash when constructed using fromString: 

### DIFF
--- a/src/Zinc-Resource-Meta-Core/ZnMimeType.class.st
+++ b/src/Zinc-Resource-Meta-Core/ZnMimeType.class.st
@@ -135,7 +135,7 @@ ZnMimeType class >> fromString: aString [
 	sub := aString copyFrom: main size + 2 to: endOfSub.
 	endOfSub = aString size ifTrue: [ ^ self main: main sub: sub ].
 	parts := (aString copyFrom: endOfSub + 1 to: aString size) substrings: ';'.
-	parameters := Dictionary new.
+	parameters := SmallDictionary new.
 	parts do: [ :each | 
 		parameters
 			at: (each copyUpTo: $=) trimBoth 

--- a/src/Zinc-Resource-Meta-Tests/ZnMimeTypeTests.class.st
+++ b/src/Zinc-Resource-Meta-Tests/ZnMimeTypeTests.class.st
@@ -38,6 +38,20 @@ ZnMimeTypeTests >> testCharset [
 	self assert: mimeType charSet = 'utf-8'
 ]
 
+{ #category : #tests }
+ZnMimeTypeTests >> testComparingWithParameters [
+
+	| mimeType equalMimeType |
+
+	mimeType := ZnMimeType fromString: 'application/json;q=1'.
+	equalMimeType := ZnMimeType applicationJson parameterAt: 'q' put: '1'.
+
+	self
+		assert: mimeType equals: equalMimeType;
+		assert: mimeType hash equals: equalMimeType hash;
+		deny: mimeType equals: ZnMimeType applicationJson
+]
+
 { #category : #testing }
 ZnMimeTypeTests >> testCopying [
 	| mimeType1 mimeType2 |


### PR DESCRIPTION
Fixes #4255 in Pharo 7
- Added a test case for the problem
- Changed `ZnMimeType>>#fromString:` to use the same kind of dictionary used when lazy initialized