### PR TITLE
Add pool dictionary support for dependency analyzer

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -959,6 +959,15 @@ Class >> sharedPools: aCollection [
 	sharedPools := aCollection
 ]
 
+{ #category : #'pool variables' }
+Class >> sharedPoolsDo: aBlockClosure [ 
+	"Iterate shared pools.
+	The shared pool collection is lazily created on access.
+	This method avoids creating the collection for a simple iteration"
+	self hasSharedPools ifFalse: [ ^ self ].
+	self sharedPools do: aBlockClosure
+]
+
 { #category : #'initialize-release' }
 Class >> sharing: poolString [ 
 	"Set up sharedPools. Answer whether recompilation is advisable."

--- a/src/Tool-DependencyAnalyser-Tests/DAPackageRelationGraphTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAPackageRelationGraphTest.class.st
@@ -12,7 +12,10 @@ Class {
 		'packageA',
 		'packageB',
 		'packageC',
-		'packageD'
+		'packageD',
+		'packageKernelTests',
+		'packageMorphicBase',
+		'packageTextCore'
 	],
 	#category : #'Tool-DependencyAnalyser-Tests-Packages'
 }
@@ -29,6 +32,8 @@ DAPackageRelationGraphTest >> setUp [
 	packageCollectionAbstract := DAPackage on: (RPackageSet named: 'Collections-Abstract').
 	packageStrings := DAPackage on:(RPackageSet named: 'Collections-Strings').
 	packageKernel := DAPackage on:(RPackageSet named: 'Kernel').
+	packageMorphicBase := DAPackage on: (RPackageSet named: 'Morphic-Base').
+	packageTextCore := DAPackage on: (RPackageSet named: 'Text-Core').
 	packageRegexCore := DAPackage on:(RPackageSet named: 'Regex-Core').
 	packageCollectionsSequenceable := DAPackage on: (RPackageSet named: 'Collections-Sequenceable').
 	packagePackageDependencies := DAPackage on: (RPackageSet named:  #'Tool-DependencyAnalyser').
@@ -73,6 +78,13 @@ DAPackageRelationGraphTest >> testAddPackages [
 	array := Array with: packageCollectionAbstract with: packageCollectionsSequenceable with: packageKernel.
 	aPackageRelationGraph addPackages: array.
 	self assert: aPackageRelationGraph packages size equals: 3
+]
+
+{ #category : #tests }
+DAPackageRelationGraphTest >> testAddPoolDictionaryDependencies [
+	aPackageRelationGraph addPoolDictionaryDependencies: packageMorphicBase.
+ 
+	self assert: (packageMorphicBase dependentPackages includes: packageTextCore).
 ]
 
 { #category : #tests }

--- a/src/Tool-DependencyAnalyser-UI/DAPoolDictionaryDependency.extension.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPoolDictionaryDependency.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #DAPoolDictionaryDependency }
+
+{ #category : #'*Tool-DependencyAnalyser-UI' }
+DAPoolDictionaryDependency >> nodeClass [
+	^ DAPoolDictionaryDependencyNode
+]

--- a/src/Tool-DependencyAnalyser-UI/DAPoolDictionaryDependencyNode.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPoolDictionaryDependencyNode.class.st
@@ -1,0 +1,20 @@
+"
+I am a tree node showing pool dictionary dependencies.
+I define an icon for pool dictionaries and spawn a new browser on the pool dictionary when browsing the dependency.
+"
+Class {
+	#name : #DAPoolDictionaryDependencyNode,
+	#superclass : #DAClassNode,
+	#category : #'Tool-DependencyAnalyser-UI-Nodes'
+}
+
+{ #category : #accessing }
+DAPoolDictionaryDependencyNode >> icon [
+
+	^ self iconNamed: #classVarsSelected
+]
+
+{ #category : #'browse-nautilus' }
+DAPoolDictionaryDependencyNode >> spawnNewBrowser [
+	self browseClass: self content poolDictionary
+]

--- a/src/Tool-DependencyAnalyser/DAPackageRelationGraph.class.st
+++ b/src/Tool-DependencyAnalyser/DAPackageRelationGraph.class.st
@@ -99,6 +99,22 @@ DAPackageRelationGraph >> addPackages: aCollection [
 ]
 
 { #category : #adding }
+DAPackageRelationGraph >> addPoolDictionaryDependencies: aPackage [
+	"Iterate all classes in the package.
+	Add a pool dictionary dependency for each pool dictionary used in the package."
+
+	self package: aPackage
+		classesDo: [ :class | 
+			class sharedPoolsDo: [ :each | | targetPackage |
+				targetPackage := self packageForBehavior: each.
+				aPackage
+					add: ((DAPoolDictionaryDependency from: aPackage to: targetPackage)
+						theClass: class;
+						poolDictionary: each).
+				self addPackage: targetPackage ] ]
+]
+
+{ #category : #adding }
 DAPackageRelationGraph >> addReferenceDependencies: aPackage [
 	(self methodsFor: aPackage) 
 		do: [ :method | self findReferencesIn: method for: aPackage ]
@@ -237,6 +253,7 @@ DAPackageRelationGraph >> computeStaticDependencies: aPackage [
 	self addInheritanceDependencies: aPackage.
 	self addExtensionDependencies: aPackage.
 	self addReferenceDependencies: aPackage.
+	self addPoolDictionaryDependencies: aPackage.
 	self addTraitDependencies: aPackage.
 	self addMessageSendDependencies: aPackage
 ]

--- a/src/Tool-DependencyAnalyser/DAPoolDictionaryDependency.class.st
+++ b/src/Tool-DependencyAnalyser/DAPoolDictionaryDependency.class.st
@@ -1,0 +1,37 @@
+"
+I am a dependency produced by a pool Dictionary.
+For example the following class CharacterBlock depends on the Text package because it uses TextConstants that is defined in it.
+
+Rectangle subclass: #CharacterBlock
+	instanceVariableNames: 'stringIndex text textLine'
+	classVariableNames: ''
+	poolDictionaries: 'TextConstants'
+	package: 'Text-Scanning-Base'
+"
+Class {
+	#name : #DAPoolDictionaryDependency,
+	#superclass : #DADependencyFromClass,
+	#instVars : [
+		'superclass',
+		'poolDictionary'
+	],
+	#category : #'Tool-DependencyAnalyser-Core'
+}
+
+{ #category : #accessing }
+DAPoolDictionaryDependency >> poolDictionary [
+	^ poolDictionary
+]
+
+{ #category : #accessing }
+DAPoolDictionaryDependency >> poolDictionary: aClass [
+	poolDictionary := aClass
+]
+
+{ #category : #printing }
+DAPoolDictionaryDependency >> printReasonOn: aStream [
+	aStream
+		nextPutAll: self theClass name;
+		nextPutAll: ' uses pool dictionary ';
+		nextPutAll: self poolDictionary name
+]


### PR DESCRIPTION
Fix #4263. Add pool dictionary support for dependency analyzer
 - Add shared pool iteration avoiding storing an empty collection
 - Add PoolDictionary dependency + tests
 - Add PoolDictionaryDependencyNode for the UI