### PR TITLE
Zinc-Character-Encoding-test-cases-should-end-with-Test

### DIFF
--- a/src/Zinc-Character-Encoding-Tests/ZnBase64EncoderTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnBase64EncoderTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #ZnBase64EncoderTests,
+	#name : #ZnBase64EncoderTest,
 	#superclass : #TestCase,
 	#category : #'Zinc-Character-Encoding-Tests'
 }
 
 { #category : #benchmarks }
-ZnBase64EncoderTests class >> bench10kDecode [
+ZnBase64EncoderTest class >> bench10kDecode [
 	"self bench10kDecode"
 	
 	| string alphabet |
@@ -16,7 +16,7 @@ ZnBase64EncoderTests class >> bench10kDecode [
 ]
 
 { #category : #benchmarks }
-ZnBase64EncoderTests class >> bench10kEncode [
+ZnBase64EncoderTest class >> bench10kEncode [
 	"self bench10kEncode"
 	
 	| bytes |
@@ -26,7 +26,7 @@ ZnBase64EncoderTests class >> bench10kEncode [
 ]
 
 { #category : #benchmarks }
-ZnBase64EncoderTests class >> bench1kDecode [
+ZnBase64EncoderTest class >> bench1kDecode [
 	"self bench1kDecode"
 	
 	| string alphabet |
@@ -37,7 +37,7 @@ ZnBase64EncoderTests class >> bench1kDecode [
 ]
 
 { #category : #benchmarks }
-ZnBase64EncoderTests class >> bench1kEncode [
+ZnBase64EncoderTest class >> bench1kEncode [
 	"self bench1kEncode"
 	
 	| bytes |
@@ -47,7 +47,7 @@ ZnBase64EncoderTests class >> bench1kEncode [
 ]
 
 { #category : #benchmarks }
-ZnBase64EncoderTests class >> benchmarks [
+ZnBase64EncoderTest class >> benchmarks [
 	"self benchmarks"
 	
 	^ (#( bench1kEncode bench1kDecode bench10kEncode bench10kDecode )
@@ -55,7 +55,7 @@ ZnBase64EncoderTests class >> benchmarks [
 ]
 
 { #category : #testing }
-ZnBase64EncoderTests >> testCustomLineBreaking [
+ZnBase64EncoderTest >> testCustomLineBreaking [
 	| encoder input output charCount |
 	encoder := ZnBase64Encoder new.
 	encoder breakLinesAt: 16.
@@ -67,7 +67,7 @@ ZnBase64EncoderTests >> testCustomLineBreaking [
 ]
 
 { #category : #testing }
-ZnBase64EncoderTests >> testDecodingErrors [
+ZnBase64EncoderTest >> testDecodingErrors [
 	| encoder |
 	encoder := ZnBase64Encoder new.
 	self should: [ encoder decode: 'A' ] raise: ZnCharacterEncodingError.
@@ -86,7 +86,7 @@ ZnBase64EncoderTests >> testDecodingErrors [
 ]
 
 { #category : #testing }
-ZnBase64EncoderTests >> testEmpty [
+ZnBase64EncoderTest >> testEmpty [
 	| encoder |
 	encoder := ZnBase64Encoder new.
 	self 
@@ -98,7 +98,7 @@ ZnBase64EncoderTests >> testEmpty [
 ]
 
 { #category : #testing }
-ZnBase64EncoderTests >> testFullAlphabet [
+ZnBase64EncoderTest >> testFullAlphabet [
 	| encoder input output |
 	encoder := ZnBase64Encoder new.
 	input := encoder alphabet.
@@ -110,7 +110,7 @@ ZnBase64EncoderTests >> testFullAlphabet [
 ]
 
 { #category : #testing }
-ZnBase64EncoderTests >> testFullSpectrum [
+ZnBase64EncoderTest >> testFullSpectrum [
 	| encoder input output |
 	encoder := ZnBase64Encoder new.
 	input := (0 to: 255) asByteArray , (255 to: 0) asByteArray.
@@ -123,7 +123,7 @@ ZnBase64EncoderTests >> testFullSpectrum [
 ]
 
 { #category : #testing }
-ZnBase64EncoderTests >> testPadding [
+ZnBase64EncoderTest >> testPadding [
 	| encoder |
 	encoder := ZnBase64Encoder new.
 	self assert: (encoder encode: 'M' asByteArray) equals: 'TQ=='.
@@ -133,7 +133,7 @@ ZnBase64EncoderTests >> testPadding [
 ]
 
 { #category : #testing }
-ZnBase64EncoderTests >> testQuote [
+ZnBase64EncoderTest >> testQuote [
 	| input output encoder break |
 	encoder := ZnBase64Encoder new lineEndConvention: #cr; breakLines; yourself.
 	input := 'Man is distinguished, not only by his reason, but by this singular passion from other animals, which is a lust of the mind, that by a perseverance of delight in the continued and indefatigable generation of knowledge, exceeds the short vehemence of any carnal pleasure.'.
@@ -152,7 +152,7 @@ ZnBase64EncoderTests >> testQuote [
 ]
 
 { #category : #testing }
-ZnBase64EncoderTests >> testSimple [
+ZnBase64EncoderTest >> testSimple [
 	| encoder |
 	encoder := ZnBase64Encoder new.
 	self 
@@ -164,7 +164,7 @@ ZnBase64EncoderTests >> testSimple [
 ]
 
 { #category : #testing }
-ZnBase64EncoderTests >> testWhitespaceAtEnd [
+ZnBase64EncoderTest >> testWhitespaceAtEnd [
 	| encoder |
 	encoder := ZnBase64Encoder new.
 	"whitespace is #any non-alphabet character"

--- a/src/Zinc-Character-Encoding-Tests/ZnBufferedReadStreamTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnBufferedReadStreamTest.class.st
@@ -2,13 +2,13 @@
 I am ZnBufferedReadStreamTests.
 "
 Class {
-	#name : #ZnBufferedReadStreamTests,
+	#name : #ZnBufferedReadStreamTest,
 	#superclass : #TestCase,
 	#category : #'Zinc-Character-Encoding-Tests'
 }
 
 { #category : #testing }
-ZnBufferedReadStreamTests >> testBuffering [
+ZnBufferedReadStreamTest >> testBuffering [
 	| stream |
 	stream := ZnBufferedReadStream on: '01234567890123456789' readStream.
 	stream sizeBuffer: 8.
@@ -20,7 +20,7 @@ ZnBufferedReadStreamTests >> testBuffering [
 ]
 
 { #category : #testing }
-ZnBufferedReadStreamTests >> testPeek [
+ZnBufferedReadStreamTest >> testPeek [
 	| stream |
 	stream := ZnBufferedReadStream on: '0123456789' readStream.
 	stream sizeBuffer: 8.
@@ -34,7 +34,7 @@ ZnBufferedReadStreamTests >> testPeek [
 ]
 
 { #category : #testing }
-ZnBufferedReadStreamTests >> testReadInto [
+ZnBufferedReadStreamTest >> testReadInto [
 	| stream buffer count |
 	stream := ZnBufferedReadStream on: '0123456789' readStream.
 	stream sizeBuffer: 8.
@@ -50,7 +50,7 @@ ZnBufferedReadStreamTests >> testReadInto [
 ]
 
 { #category : #testing }
-ZnBufferedReadStreamTests >> testReadIntoLarger [
+ZnBufferedReadStreamTest >> testReadIntoLarger [
 	| stream buffer count |
 	stream := ZnBufferedReadStream on: '0123456789' readStream.
 	stream sizeBuffer: 4.
@@ -61,7 +61,7 @@ ZnBufferedReadStreamTests >> testReadIntoLarger [
 ]
 
 { #category : #testing }
-ZnBufferedReadStreamTests >> testReadUpTo [
+ZnBufferedReadStreamTest >> testReadUpTo [
 	| stream |
 	stream := ZnBufferedReadStream on: '0123456789' readStream.
 	stream sizeBuffer: 8.
@@ -71,7 +71,7 @@ ZnBufferedReadStreamTests >> testReadUpTo [
 ]
 
 { #category : #testing }
-ZnBufferedReadStreamTests >> testReadUpToEnd [
+ZnBufferedReadStreamTest >> testReadUpToEnd [
 	| stream |
 	stream := ZnBufferedReadStream on: '0123456789' readStream.
 	stream sizeBuffer: 4.

--- a/src/Zinc-Character-Encoding-Tests/ZnBufferedReadWriteStreamTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnBufferedReadWriteStreamTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #ZnBufferedReadWriteStreamTests,
+	#name : #ZnBufferedReadWriteStreamTest,
 	#superclass : #TestCase,
 	#category : #'Zinc-Character-Encoding-Tests'
 }
 
 { #category : #tests }
-ZnBufferedReadWriteStreamTests >> testBuffering [
+ZnBufferedReadWriteStreamTest >> testBuffering [
 	| stream |
 	stream := ZnBufferedReadWriteStream on: '01234567890123456789' readStream.
 	stream sizeBuffer: 8.
@@ -17,7 +17,7 @@ ZnBufferedReadWriteStreamTests >> testBuffering [
 ]
 
 { #category : #tests }
-ZnBufferedReadWriteStreamTests >> testNextPutAllStartingAt [
+ZnBufferedReadWriteStreamTest >> testNextPutAllStartingAt [
 	| string |
 	string := String streamContents: [ :stringStream | 
 		ZnBufferedReadWriteStream on: stringStream do: [ : bufferedStream |
@@ -30,7 +30,7 @@ ZnBufferedReadWriteStreamTests >> testNextPutAllStartingAt [
 ]
 
 { #category : #tests }
-ZnBufferedReadWriteStreamTests >> testPeek [
+ZnBufferedReadWriteStreamTest >> testPeek [
 	| stream |
 	stream := ZnBufferedReadWriteStream on: '0123456789' readStream.
 	stream sizeBuffer: 8.
@@ -44,7 +44,7 @@ ZnBufferedReadWriteStreamTests >> testPeek [
 ]
 
 { #category : #tests }
-ZnBufferedReadWriteStreamTests >> testReadInto [
+ZnBufferedReadWriteStreamTest >> testReadInto [
 	| stream buffer count |
 	stream := ZnBufferedReadWriteStream on: '0123456789' readStream.
 	stream sizeBuffer: 8.
@@ -60,7 +60,7 @@ ZnBufferedReadWriteStreamTests >> testReadInto [
 ]
 
 { #category : #tests }
-ZnBufferedReadWriteStreamTests >> testReadIntoLarger [
+ZnBufferedReadWriteStreamTest >> testReadIntoLarger [
 	| stream buffer count |
 	stream := ZnBufferedReadWriteStream on: '0123456789' readStream.
 	stream sizeBuffer: 4.
@@ -71,7 +71,7 @@ ZnBufferedReadWriteStreamTests >> testReadIntoLarger [
 ]
 
 { #category : #tests }
-ZnBufferedReadWriteStreamTests >> testReadThenWrite [
+ZnBufferedReadWriteStreamTest >> testReadThenWrite [
 	| stream stringStream |
 	
 	((SystemVersion current major < 7) or: [ SystemVersion current build < 690 ])
@@ -96,7 +96,7 @@ ZnBufferedReadWriteStreamTests >> testReadThenWrite [
 ]
 
 { #category : #tests }
-ZnBufferedReadWriteStreamTests >> testReadUpTo [
+ZnBufferedReadWriteStreamTest >> testReadUpTo [
 	| stream |
 	stream := ZnBufferedReadWriteStream on: '0123456789' readStream.
 	stream sizeBuffer: 8.
@@ -106,7 +106,7 @@ ZnBufferedReadWriteStreamTests >> testReadUpTo [
 ]
 
 { #category : #tests }
-ZnBufferedReadWriteStreamTests >> testReadUpToEnd [
+ZnBufferedReadWriteStreamTest >> testReadUpToEnd [
 	| stream |
 	stream := ZnBufferedReadWriteStream on: '0123456789' readStream.
 	stream sizeBuffer: 4.
@@ -116,7 +116,7 @@ ZnBufferedReadWriteStreamTests >> testReadUpToEnd [
 ]
 
 { #category : #tests }
-ZnBufferedReadWriteStreamTests >> testWriteThenRead [
+ZnBufferedReadWriteStreamTest >> testWriteThenRead [
 	| stream stringStream |
 	
 	((SystemVersion current major < 7) or: [ SystemVersion current build < 690 ])
@@ -139,7 +139,7 @@ ZnBufferedReadWriteStreamTests >> testWriteThenRead [
 ]
 
 { #category : #tests }
-ZnBufferedReadWriteStreamTests >> testWriting [
+ZnBufferedReadWriteStreamTest >> testWriting [
 	| string |
 	string := String streamContents: [ :stringStream | | bufferedStream |
 		bufferedStream := ZnBufferedReadWriteStream on: stringStream.
@@ -149,7 +149,7 @@ ZnBufferedReadWriteStreamTests >> testWriting [
 ]
 
 { #category : #tests }
-ZnBufferedReadWriteStreamTests >> testWritingOverflow [
+ZnBufferedReadWriteStreamTest >> testWritingOverflow [
 	| string |
 	string := String streamContents: [ :stringStream | | bufferedStream |
 		bufferedStream := ZnBufferedReadWriteStream on: stringStream.

--- a/src/Zinc-Character-Encoding-Tests/ZnBufferedStreamByteTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnBufferedStreamByteTest.class.st
@@ -9,13 +9,13 @@ https://en.wikipedia.org/wiki/Endianness
 https://en.wikipedia.org/wiki/Two%27s_complement
 "
 Class {
-	#name : #ZnBufferedStreamByteTests,
+	#name : #ZnBufferedStreamByteTest,
 	#superclass : #TestCase,
 	#category : #'Zinc-Character-Encoding-Tests'
 }
 
 { #category : #accessing }
-ZnBufferedStreamByteTests >> integerEncodingSpec [
+ZnBufferedStreamByteTest >> integerEncodingSpec [
 	^ #(
 "<hex-bytes> <integer> <u|s> <be|le> unsigned|signed big-endian|little-endian"
 ('00' 0 u be)
@@ -76,7 +76,7 @@ ZnBufferedStreamByteTests >> integerEncodingSpec [
 ]
 
 { #category : #testing }
-ZnBufferedStreamByteTests >> testInt16Aliases [
+ZnBufferedStreamByteTest >> testInt16Aliases [
 	| input writer |
 	writer := [ :block | 
 		ByteArray streamContents: [ :out | 
@@ -98,7 +98,7 @@ ZnBufferedStreamByteTests >> testInt16Aliases [
 ]
 
 { #category : #testing }
-ZnBufferedStreamByteTests >> testInt32Aliases [
+ZnBufferedStreamByteTest >> testInt32Aliases [
 	| input writer |
 	writer := [ :block | 
 		ByteArray streamContents: [ :out | 
@@ -122,7 +122,7 @@ ZnBufferedStreamByteTests >> testInt32Aliases [
 ]
 
 { #category : #testing }
-ZnBufferedStreamByteTests >> testInt8 [
+ZnBufferedStreamByteTest >> testInt8 [
 	| bytes readStream |
 	bytes := ByteArray streamContents: [ :out |
 		ZnBufferedWriteStream on: out do: [ :bout |
@@ -138,7 +138,7 @@ ZnBufferedStreamByteTests >> testInt8 [
 ]
 
 { #category : #testing }
-ZnBufferedStreamByteTests >> testNextIntegerOfSizeSignedBigEndian [
+ZnBufferedStreamByteTest >> testNextIntegerOfSizeSignedBigEndian [
 	self integerEncodingSpec do: [ :spec |
 		| input integer |
 		input := ByteArray readHexFrom: spec first.
@@ -150,7 +150,7 @@ ZnBufferedStreamByteTests >> testNextIntegerOfSizeSignedBigEndian [
 ]
 
 { #category : #testing }
-ZnBufferedStreamByteTests >> testNextIntegerOfSizeSignedBigEndianPut [
+ZnBufferedStreamByteTest >> testNextIntegerOfSizeSignedBigEndianPut [
 	self integerEncodingSpec do: [ :spec |
 		| input output |
 		input := ByteArray readHexFrom: spec first.

--- a/src/Zinc-Character-Encoding-Tests/ZnBufferedWriteStreamTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnBufferedWriteStreamTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #ZnBufferedWriteStreamTests,
+	#name : #ZnBufferedWriteStreamTest,
 	#superclass : #TestCase,
 	#category : #'Zinc-Character-Encoding-Tests'
 }
 
 { #category : #testing }
-ZnBufferedWriteStreamTests >> testNextPutAllStartingAt [
+ZnBufferedWriteStreamTest >> testNextPutAllStartingAt [
 	| string |
 	string := String streamContents: [ :stringStream | 
 		ZnBufferedWriteStream on: stringStream do: [ : bufferedStream |
@@ -18,7 +18,7 @@ ZnBufferedWriteStreamTests >> testNextPutAllStartingAt [
 ]
 
 { #category : #testing }
-ZnBufferedWriteStreamTests >> testWriting [
+ZnBufferedWriteStreamTest >> testWriting [
 	| string |
 	string := String streamContents: [ :stringStream | | bufferedStream |
 		bufferedStream := ZnBufferedWriteStream on: stringStream.
@@ -28,7 +28,7 @@ ZnBufferedWriteStreamTests >> testWriting [
 ]
 
 { #category : #testing }
-ZnBufferedWriteStreamTests >> testWritingOverflow [
+ZnBufferedWriteStreamTest >> testWritingOverflow [
 	| string |
 	string := String streamContents: [ :stringStream | | bufferedStream |
 		bufferedStream := ZnBufferedWriteStream on: stringStream.

--- a/src/Zinc-Character-Encoding-Tests/ZnCharacterEncoderTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnCharacterEncoderTest.class.st
@@ -1,21 +1,21 @@
 Class {
-	#name : #ZnCharacterEncoderTests,
+	#name : #ZnCharacterEncoderTest,
 	#superclass : #TestCase,
 	#category : #'Zinc-Character-Encoding-Tests'
 }
 
 { #category : #accessing }
-ZnCharacterEncoderTests class >> asciiCharacterSource [
+ZnCharacterEncoderTest class >> asciiCharacterSource [
 	^ ($A to: $Z), ($a to: $z), ($0 to: $9), '.-_/*+=|,;?!$&<>^%#', '    '
 ]
 
 { #category : #accessing }
-ZnCharacterEncoderTests class >> latin1CharacterSource [
+ZnCharacterEncoderTest class >> latin1CharacterSource [
 	^ ($A to: $Z), ($a to: $z), ($0 to: $9), '.-_/*+=|,;?!$&<>^%#', '       ', 'éèçüäßñ'
 ]
 
 { #category : #accessing }
-ZnCharacterEncoderTests class >> stringOfSize: size fromSource: source [
+ZnCharacterEncoderTest class >> stringOfSize: size fromSource: source [
 	"self stringOfSize: 1024 fromSource: self unicodeCharacterSource"
 	
 	^ String new: size streamContents: [ :out | 
@@ -23,12 +23,12 @@ ZnCharacterEncoderTests class >> stringOfSize: size fromSource: source [
 ]
 
 { #category : #accessing }
-ZnCharacterEncoderTests class >> unicodeCharacterSource [
+ZnCharacterEncoderTest class >> unicodeCharacterSource [
 	^ ($A to: $Z), ($a to: $z), ($0 to: $9), '.-_/*+=|,;?!$&<>^%#', '         ', 'éèçüäßñα', '€∏'
 ]
 
 { #category : #private }
-ZnCharacterEncoderTests >> decodeBytes: bytes with: encoder [
+ZnCharacterEncoderTest >> decodeBytes: bytes with: encoder [
 	| input |
 	input := bytes readStream.
 	^ String streamContents: [ :stream |
@@ -37,14 +37,14 @@ ZnCharacterEncoderTests >> decodeBytes: bytes with: encoder [
 ]
 
 { #category : #private }
-ZnCharacterEncoderTests >> encodeString: string with: encoder [
+ZnCharacterEncoderTest >> encodeString: string with: encoder [
 	^ ByteArray streamContents: [ :stream |
 		string do: [ :each |
 			encoder nextPut: each toStream: stream ] ]
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testAllByteEncoderDomains [
+ZnCharacterEncoderTest >> testAllByteEncoderDomains [
 	| encoder characterDomain byteDomain encoded |
 	ZnByteEncoder knownEncodingIdentifiers do: [ :identifier |
 		encoder := ZnCharacterEncoder newForEncoding: identifier.
@@ -65,7 +65,7 @@ ZnCharacterEncoderTests >> testAllByteEncoderDomains [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testBeLenient [
+ZnCharacterEncoderTest >> testBeLenient [
 	| encoder unmapped |
 	encoder := ZnCharacterEncoder newForEncoding: 'iso-8859-1'.
 	unmapped := (128 to: 159) asByteArray.
@@ -77,7 +77,7 @@ ZnCharacterEncoderTests >> testBeLenient [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testByteDecoding [
+ZnCharacterEncoderTest >> testByteDecoding [
 	| encoder bytes |
 	encoder := ZnUTF8Encoder new.
 	bytes := encoder encodeString: 'élève en Français'.
@@ -87,7 +87,7 @@ ZnCharacterEncoderTests >> testByteDecoding [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testByteEncoderFromUrl [
+ZnCharacterEncoderTest >> testByteEncoderFromUrl [
 	| encoderFromUrl iso88592 bytes characters |
 	encoderFromUrl := ZnByteEncoder newFromUrl: 'http://files.pharo.org/extra/unicode/8859-2.TXT'.
 	iso88592 := ZnCharacterEncoder newForEncoding: #iso88592.
@@ -105,7 +105,7 @@ ZnCharacterEncoderTests >> testByteEncoderFromUrl [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testCodePointEncodingDecoding [
+ZnCharacterEncoderTest >> testCodePointEncodingDecoding [
 	| encoder input output |
 	input := 'Düsseldorf Königsallee' collect: #codePoint as: Array.
 	self assert: input isCollection.
@@ -120,7 +120,7 @@ ZnCharacterEncoderTests >> testCodePointEncodingDecoding [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testCodePointStreams [
+ZnCharacterEncoderTest >> testCodePointStreams [
 	| string codePoints bytes result |
 	string := 'Düsseldorf Königsallee'.
 	codePoints := string collect: #codePoint as: Array.
@@ -137,7 +137,7 @@ ZnCharacterEncoderTests >> testCodePointStreams [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testConvencienceMethods [
+ZnCharacterEncoderTest >> testConvencienceMethods [
 	| encoder string |
 	encoder := ZnUTF8Encoder new.
 	string := 'élève en Français'.
@@ -149,7 +149,7 @@ ZnCharacterEncoderTests >> testConvencienceMethods [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testDefault [
+ZnCharacterEncoderTest >> testDefault [
 	| string bytes |
 	self assert: ZnCharacterEncoder default equals: ZnUTF8Encoder new.
 	string := 'Der Weg zur Hölle ist mit guten Vorsätzen gepflastert.'.
@@ -169,7 +169,7 @@ ZnCharacterEncoderTests >> testDefault [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testDetectEncoding [
+ZnCharacterEncoderTest >> testDetectEncoding [
 	| bytes |
 	bytes := 'abc' asByteArray.
 	self assert: (ZnCharacterEncoder detectEncoding: bytes) equals: ZnCharacterEncoder ascii.
@@ -181,7 +181,7 @@ ZnCharacterEncoderTests >> testDetectEncoding [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testKnownEncodingIdentifiers [
+ZnCharacterEncoderTest >> testKnownEncodingIdentifiers [
 	| all minimal asciiString |
 	all := ZnCharacterEncoder knownEncodingIdentifiers asSet.
 	minimal := #(utf8 latin1 null ascii iso88591) asSet.
@@ -198,7 +198,7 @@ ZnCharacterEncoderTests >> testKnownEncodingIdentifiers [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testLatin1Encoder [
+ZnCharacterEncoderTest >> testLatin1Encoder [
 	| encoder string bytes |
 	encoder := ZnCharacterEncoder newForEncoding: 'latin1'.
 	string := 'élève en Français'.
@@ -208,7 +208,7 @@ ZnCharacterEncoderTests >> testLatin1Encoder [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testLatin2Encoder [
+ZnCharacterEncoderTest >> testLatin2Encoder [
 	"Example characters taken from http://en.wikipedia.org/wiki/Latin2"
 	
 	| encoder inputBytes outputBytes inputString outputString |
@@ -224,7 +224,7 @@ ZnCharacterEncoderTests >> testLatin2Encoder [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testNextPutAllStartingAtToStream [
+ZnCharacterEncoderTest >> testNextPutAllStartingAtToStream [
 	| encoder |
 	encoder := ZnUTF8Encoder new.
 	#( 'ccc' 'ççç' 'c' 'ç' 'çc' 'cç' 'çç' ) do: [ :each |
@@ -242,7 +242,7 @@ ZnCharacterEncoderTests >> testNextPutAllStartingAtToStream [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testNullEncoder [
+ZnCharacterEncoderTest >> testNullEncoder [
 	| encoder bytes string |
 	encoder := ZnNullEncoder new.
 	bytes := self encodeString: 'abc' with: encoder.
@@ -252,7 +252,7 @@ ZnCharacterEncoderTests >> testNullEncoder [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testReadIntoStartingAtCountFromStream [
+ZnCharacterEncoderTest >> testReadIntoStartingAtCountFromStream [
 	| encoder |
 	encoder := ZnUTF8Encoder new.
 	#( 'ccc' 'ççç' 'c' 'ç' 'çc' 'cç' 'çç' ) do: [ :each |
@@ -272,7 +272,7 @@ ZnCharacterEncoderTests >> testReadIntoStartingAtCountFromStream [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testReadIntoStartingAtCountFromStreamAtEnd [
+ZnCharacterEncoderTest >> testReadIntoStartingAtCountFromStreamAtEnd [
 	| input encoder bytes readStream string read |
 	encoder := ZnUTF8Encoder new.
 	input := 'élève'.
@@ -285,7 +285,7 @@ ZnCharacterEncoderTests >> testReadIntoStartingAtCountFromStreamAtEnd [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testReadIntoStartingAtCountFromStreamWide [
+ZnCharacterEncoderTest >> testReadIntoStartingAtCountFromStreamWide [
 	| encoder |
 	encoder := ZnUTF8Encoder new.
 	{ 'abc', (WideString withAll: { 300 asCharacter. 400 asCharacter. 500 asCharacter}), 'xyz' } do: [ :each |
@@ -306,7 +306,7 @@ ZnCharacterEncoderTests >> testReadIntoStartingAtCountFromStreamWide [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testReadIntoStartingAtCountFromStreamWithOffset [
+ZnCharacterEncoderTest >> testReadIntoStartingAtCountFromStreamWithOffset [
 	| input encoder bytes readStream string read |
 	encoder := ZnUTF8Encoder new.
 	input := '_élève_'.
@@ -328,7 +328,7 @@ ZnCharacterEncoderTests >> testReadIntoStartingAtCountFromStreamWithOffset [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testStringEncoding [
+ZnCharacterEncoderTest >> testStringEncoding [
 	| encoder string |
 	encoder := ZnUTF8Encoder new.
 	string := 'élève en Français'.
@@ -339,7 +339,7 @@ ZnCharacterEncoderTests >> testStringEncoding [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF16Back [
+ZnCharacterEncoderTest >> testUTF16Back [
 	| encoder stream |
 	encoder := ZnUTF16Encoder new.
 	stream := (encoder encodeString: 'Les élèves Françaises') readStream.
@@ -354,7 +354,7 @@ ZnCharacterEncoderTests >> testUTF16Back [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF16EncoderBigEndian [
+ZnCharacterEncoderTest >> testUTF16EncoderBigEndian [
 	| string bytes encoder |
 	string := 'élève en Français'.
 	bytes := ByteArray readHexFrom:
@@ -366,7 +366,7 @@ ZnCharacterEncoderTests >> testUTF16EncoderBigEndian [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF16EncoderByteOrderMark [
+ZnCharacterEncoderTest >> testUTF16EncoderByteOrderMark [
 	| string bytes encoder encoded |
 	string := 'foo'.
 	bytes := ByteArray readHexFrom: 'FEFF0066006f006f'.
@@ -388,7 +388,7 @@ ZnCharacterEncoderTests >> testUTF16EncoderByteOrderMark [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF16EncoderLittleEndian [
+ZnCharacterEncoderTest >> testUTF16EncoderLittleEndian [
 	| string bytes encoder |
 	string := 'élève en Français'.
 	bytes := ByteArray readHexFrom:
@@ -401,7 +401,7 @@ ZnCharacterEncoderTests >> testUTF16EncoderLittleEndian [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF16EncoderWide1 [
+ZnCharacterEncoderTest >> testUTF16EncoderWide1 [
 	| string bytes encoder |
 	string := (Character codePoint: 16r1d11e) asString. "MUSICAL SYMBOL G CLEF"
 	bytes := ByteArray readHexFrom: 'D834DD1E'.
@@ -412,7 +412,7 @@ ZnCharacterEncoderTests >> testUTF16EncoderWide1 [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF32EncoderExampleFromD100 [
+ZnCharacterEncoderTest >> testUTF32EncoderExampleFromD100 [
 	| string bytes encoder |
 	string := #(16r0000004D 16r00000430 16r00004E8C 16r00010302) collect: #asCharacter as: String.
 	bytes := ByteArray readHexFrom: '4D000000300400008C4E000002030100'.
@@ -424,7 +424,7 @@ ZnCharacterEncoderTests >> testUTF32EncoderExampleFromD100 [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF32EncoderExampleFromD101 [
+ZnCharacterEncoderTest >> testUTF32EncoderExampleFromD101 [
 	| string encoder bytesBigEndianWithBom bytesLittleEndianWithBom |
 	string := #(16r0000004D 16r00000430 16r00004E8C 16r00010302) collect: #asCharacter as: String.
 	encoder := #utf32 asZnCharacterEncoder.
@@ -443,7 +443,7 @@ ZnCharacterEncoderTests >> testUTF32EncoderExampleFromD101 [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF32EncoderExampleFromD99 [
+ZnCharacterEncoderTest >> testUTF32EncoderExampleFromD99 [
 	| string bytes encoder |
 	string := #(16r0000004D 16r00000430 16r00004E8C 16r00010302) collect: #asCharacter as: String.
 	bytes := ByteArray readHexFrom: '0000004D0000043000004E8C00010302'.
@@ -455,7 +455,7 @@ ZnCharacterEncoderTests >> testUTF32EncoderExampleFromD99 [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF32EncoderSimple [
+ZnCharacterEncoderTest >> testUTF32EncoderSimple [
 	| string bytes encoder |
 	string := 'élève en Français'.
 	bytes := ByteArray readHexFrom: '000000e90000006c000000e8000000760000006500000020000000650000006e000000200000004600000072000000610000006e000000e7000000610000006900000073'.
@@ -467,7 +467,7 @@ ZnCharacterEncoderTests >> testUTF32EncoderSimple [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF32EncoderWide [
+ZnCharacterEncoderTest >> testUTF32EncoderWide [
 	| encoder |
 	encoder := ZnUTF32Encoder new.
 	{ 
@@ -482,7 +482,7 @@ ZnCharacterEncoderTests >> testUTF32EncoderWide [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF8Back [
+ZnCharacterEncoderTest >> testUTF8Back [
 	| encoder stream |
 	encoder := ZnUTF8Encoder new.
 	stream := (encoder encodeString: 'Les élèves Françaises') readStream.
@@ -497,7 +497,7 @@ ZnCharacterEncoderTests >> testUTF8Back [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF8Boundaries [
+ZnCharacterEncoderTest >> testUTF8Boundaries [
 	"Test encoding and decoding of the characters at the boundaries between 1, 2, 3, and 4 multi-byte sequences.
 	Values taken from http://en.wikipedia.org/wiki/Utf8#Description with the new RFC 3629 limit"
 	
@@ -516,7 +516,7 @@ ZnCharacterEncoderTests >> testUTF8Boundaries [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF8ByteOrderMark [
+ZnCharacterEncoderTest >> testUTF8ByteOrderMark [
 	"The Unicode Byte Order Mark (BOM) should be skipped."
 	
 	| bom string bytes encoder decodedString |
@@ -537,7 +537,7 @@ ZnCharacterEncoderTests >> testUTF8ByteOrderMark [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF8Encoder [
+ZnCharacterEncoderTest >> testUTF8Encoder [
 	"The examples are taken from http://en.wikipedia.org/wiki/UTF-8#Description"
 	
 	| encoder inputBytes outputBytes inputString outputString |
@@ -551,7 +551,7 @@ ZnCharacterEncoderTests >> testUTF8Encoder [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF8EncoderAuto [
+ZnCharacterEncoderTest >> testUTF8EncoderAuto [
 	| encoder inputString bytes outputString |
 	encoder := ZnUTF8Encoder new.
 	inputString := String withAll: ((1 to: 3072) collect: [ :each | Character value: each ]).
@@ -561,7 +561,7 @@ ZnCharacterEncoderTests >> testUTF8EncoderAuto [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF8EncoderByteCount [	
+ZnCharacterEncoderTest >> testUTF8EncoderByteCount [	
 	| encoder |
 	encoder := ZnUTF8Encoder new.
 	self assert: (encoder encodedByteCountFor: $$) = 1.
@@ -571,7 +571,7 @@ ZnCharacterEncoderTests >> testUTF8EncoderByteCount [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF8EncoderIncomplete [
+ZnCharacterEncoderTest >> testUTF8EncoderIncomplete [
 	"The examples are taken from http://en.wikipedia.org/wiki/UTF-8#Description"
 	
 	| encoder |
@@ -584,7 +584,7 @@ ZnCharacterEncoderTests >> testUTF8EncoderIncomplete [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF8EncoderRandom [
+ZnCharacterEncoderTest >> testUTF8EncoderRandom [
 	#(unicodeCharacterSource latin1CharacterSource asciiCharacterSource) do: [ :source |
 		| string bytes result |
 		string := self class stringOfSize: 256 fromSource: source.
@@ -594,7 +594,7 @@ ZnCharacterEncoderTests >> testUTF8EncoderRandom [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF8EncoderWide [
+ZnCharacterEncoderTest >> testUTF8EncoderWide [
 	| encoder |
 	encoder := ZnUTF8Encoder new.
 	{ 'abc'. 'élève en Français'. 'Pra-ská' copy at: 4 put: (Character value: 382); yourself. '' }
@@ -604,7 +604,7 @@ ZnCharacterEncoderTests >> testUTF8EncoderWide [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF8Overlong [
+ZnCharacterEncoderTest >> testUTF8Overlong [
 	"Overlong encoding, aka Non shortest form characters should be rejected.
 	See http://en.wikipedia.org/wiki/UTF-8#Overlong_encodings"
 	
@@ -619,7 +619,7 @@ ZnCharacterEncoderTests >> testUTF8Overlong [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF8ReadFaultyInput [
+ZnCharacterEncoderTest >> testUTF8ReadFaultyInput [
 	"Although not recommended, it is possible to read faulty UTF-8 encoded input by resuming ZnInvalidUTF8"
 	
 	"illegal leading byte"
@@ -651,7 +651,7 @@ ZnCharacterEncoderTests >> testUTF8ReadFaultyInput [
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTests >> testUTF8SurrogateCodePointsShouldFail [
+ZnCharacterEncoderTest >> testUTF8SurrogateCodePointsShouldFail [
 	| encoder surrogateCodePoint |
 	encoder := #utf8 asZnCharacterEncoder.
 	surrogateCodePoint := 16rD801.

--- a/src/Zinc-Character-Encoding-Tests/ZnCharacterStreamTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnCharacterStreamTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #ZnCharacterStreamTests,
+	#name : #ZnCharacterStreamTest,
 	#superclass : #TestCase,
 	#category : #'Zinc-Character-Encoding-Tests'
 }
 
 { #category : #testing }
-ZnCharacterStreamTests >> assertUpToAll: array [
+ZnCharacterStreamTest >> assertUpToAll: array [
 	| utf8Stream |
 	utf8Stream := self utf8ReadStreamOn: array first.
 	self assert: (array first readStream upToAll: array second) equals: array third.
@@ -13,7 +13,7 @@ ZnCharacterStreamTests >> assertUpToAll: array [
 ]
 
 { #category : #testing }
-ZnCharacterStreamTests >> testNextLine [
+ZnCharacterStreamTest >> testNextLine [
 	| stream |
 	stream := ZnCharacterReadStream on: 'abc' asByteArray readStream.
 	self assert: stream nextLine equals: 'abc'.
@@ -48,7 +48,7 @@ ZnCharacterStreamTests >> testNextLine [
 ]
 
 { #category : #testing }
-ZnCharacterStreamTests >> testPeek [
+ZnCharacterStreamTest >> testPeek [
 	| string bytes readStream |
 	string := 'élève en Français'.
 	bytes := ZnUTF8Encoder new encodeString: string.
@@ -62,7 +62,7 @@ ZnCharacterStreamTests >> testPeek [
 ]
 
 { #category : #testing }
-ZnCharacterStreamTests >> testReadStream [
+ZnCharacterStreamTest >> testReadStream [
 	| stream |
 	stream := ZnCharacterReadStream on: 'ABC' asByteArray readStream.
 	self deny: stream atEnd.
@@ -82,7 +82,7 @@ ZnCharacterStreamTests >> testReadStream [
 ]
 
 { #category : #testing }
-ZnCharacterStreamTests >> testSimpleUTF8ReadStream [
+ZnCharacterStreamTest >> testSimpleUTF8ReadStream [
 	| string bytes |
 	string := 'élève en Français'.
 	bytes := ZnUTF8Encoder new encodeString: string.
@@ -92,7 +92,7 @@ ZnCharacterStreamTests >> testSimpleUTF8ReadStream [
 ]
 
 { #category : #testing }
-ZnCharacterStreamTests >> testSimpleUTF8WriteStream [
+ZnCharacterStreamTest >> testSimpleUTF8WriteStream [
 	| string bytes stream |
 	string := 'élève en Français'.
 	bytes := ZnUTF8Encoder new encodeString: string.
@@ -104,7 +104,7 @@ ZnCharacterStreamTests >> testSimpleUTF8WriteStream [
 ]
 
 { #category : #testing }
-ZnCharacterStreamTests >> testUTF8ReadStreamReadInto [
+ZnCharacterStreamTest >> testUTF8ReadStreamReadInto [
 	| string bytes stream buffer |
 	string := 'élève en Français'.
 	bytes := ZnUTF8Encoder new encodeString: string.
@@ -123,7 +123,7 @@ ZnCharacterStreamTests >> testUTF8ReadStreamReadInto [
 ]
 
 { #category : #testing }
-ZnCharacterStreamTests >> testUpToAll [
+ZnCharacterStreamTest >> testUpToAll [
 	#(
 		('' '' '')
 		('' 'ß' '')
@@ -167,7 +167,7 @@ ZnCharacterStreamTests >> testUpToAll [
 ]
 
 { #category : #testing }
-ZnCharacterStreamTests >> testUpToAllTwice [
+ZnCharacterStreamTest >> testUpToAllTwice [
 	| utf8Stream stream |
 	utf8Stream := self utf8ReadStreamOn: 'eißendeße'.
 	self assert: (utf8Stream upToAll: 'ße') equals: 'ei'.
@@ -179,7 +179,7 @@ ZnCharacterStreamTests >> testUpToAllTwice [
 ]
 
 { #category : #testing }
-ZnCharacterStreamTests >> utf8ReadStreamOn: string [
+ZnCharacterStreamTest >> utf8ReadStreamOn: string [
 	^ ZnCharacterReadStream
 		on: (ZnUTF8Encoder new encodeString: string) readStream
 		encoding: #utf8

--- a/src/Zinc-Character-Encoding-Tests/ZnCrPortableWriteStreamTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnCrPortableWriteStreamTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #ZnCrPortableWriteStreamTests,
+	#name : #ZnCrPortableWriteStreamTest,
 	#superclass : #TestCase,
 	#category : #'Zinc-Character-Encoding-Tests'
 }
 
 { #category : #tests }
-ZnCrPortableWriteStreamTests >> testNextPut [
+ZnCrPortableWriteStreamTest >> testNextPut [
 	"Ensure that the line ends are written correctly"
 
 	| expectedString stream crStream |

--- a/src/Zinc-Character-Encoding-Tests/ZnFastLineReaderTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnFastLineReaderTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #ZnFastLineReaderTests,
+	#name : #ZnFastLineReaderTest,
 	#superclass : #TestCase,
 	#category : #'Zinc-Character-Encoding-Tests'
 }
 
 { #category : #testing }
-ZnFastLineReaderTests >> testLinesDo [
+ZnFastLineReaderTest >> testLinesDo [
 	| lines reader |
 	lines := #( 'foo' 'bar' 'last').
 	reader := ZnFastLineReader on: (Character lf join: lines) readStream.
@@ -16,7 +16,7 @@ ZnFastLineReaderTests >> testLinesDo [
 ]
 
 { #category : #testing }
-ZnFastLineReaderTests >> testNextLine [
+ZnFastLineReaderTest >> testNextLine [
 	| reader |
 	reader := ZnFastLineReader on: 'abc' readStream.
 	self assert: reader nextLine equals: 'abc'.

--- a/src/Zinc-Character-Encoding-Tests/ZnNewLineWriterStreamTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnNewLineWriterStreamTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #ZnNewLineWriterStreamTests,
+	#name : #ZnNewLineWriterStreamTest,
 	#superclass : #TestCase,
 	#category : #'Zinc-Character-Encoding-Tests'
 }
 
 { #category : #tests }
-ZnNewLineWriterStreamTests >> testClose [ 
+ZnNewLineWriterStreamTest >> testClose [ 
 
 	| string fs fileReference znstream |
 
@@ -24,7 +24,7 @@ ZnNewLineWriterStreamTests >> testClose [
 ]
 
 { #category : #tests }
-ZnNewLineWriterStreamTests >> testNextPut [
+ZnNewLineWriterStreamTest >> testNextPut [
 	"Ensure that the line ends are written correctly"
 
 	| expectedString stream crStream |

--- a/src/Zinc-Character-Encoding-Tests/ZnPercentEncoderTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnPercentEncoderTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #ZnPercentEncoderTests,
+	#name : #ZnPercentEncoderTest,
 	#superclass : #TestCase,
 	#category : #'Zinc-Character-Encoding-Tests'
 }
 
 { #category : #testing }
-ZnPercentEncoderTests >> testDecodePlusAsSpace [
+ZnPercentEncoderTest >> testDecodePlusAsSpace [
 	| encoder |
 	encoder := ZnPercentEncoder new.
 	self assert: (encoder decode: '+') equals: ' '.
@@ -16,7 +16,7 @@ ZnPercentEncoderTests >> testDecodePlusAsSpace [
 ]
 
 { #category : #testing }
-ZnPercentEncoderTests >> testDecodingErrors [
+ZnPercentEncoderTest >> testDecodingErrors [
 	| encoder |
 	encoder := ZnPercentEncoder new.
 	self should: [ encoder decode: 'foo%%bar' ] raise: ZnCharacterEncodingError.
@@ -27,7 +27,7 @@ ZnPercentEncoderTests >> testDecodingErrors [
 ]
 
 { #category : #testing }
-ZnPercentEncoderTests >> testLeadingZero [
+ZnPercentEncoderTest >> testLeadingZero [
 	| encoder |
 	encoder := ZnPercentEncoder new.
 	self assert: (encoder encode: 'foo', Character tab asString, 'bar') equals: 'foo%09bar'.
@@ -37,7 +37,7 @@ ZnPercentEncoderTests >> testLeadingZero [
 ]
 
 { #category : #testing }
-ZnPercentEncoderTests >> testNonAscii [
+ZnPercentEncoderTest >> testNonAscii [
 	| encoder |
 	encoder := ZnPercentEncoder new.
 	self 
@@ -52,7 +52,7 @@ ZnPercentEncoderTests >> testNonAscii [
 ]
 
 { #category : #testing }
-ZnPercentEncoderTests >> testSimple [
+ZnPercentEncoderTest >> testSimple [
 	| encoder |
 	encoder := ZnPercentEncoder new.
 	self assert: (encoder encode: 'foo bar') equals: 'foo%20bar'.
@@ -64,11 +64,11 @@ ZnPercentEncoderTests >> testSimple [
 ]
 
 { #category : #testing }
-ZnPercentEncoderTests >> testStringUrlDecoded [
+ZnPercentEncoderTest >> testStringUrlDecoded [
 	self assert: ('foo%20bar' urlDecoded) equals: 'foo bar' 
 ]
 
 { #category : #testing }
-ZnPercentEncoderTests >> testStringUrlEncoded [
+ZnPercentEncoderTest >> testStringUrlEncoded [
 	self assert: ('foo bar' urlEncoded) equals: 'foo%20bar'
 ]

--- a/src/Zinc-Character-Encoding-Tests/ZnPositionableReadStreamTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnPositionableReadStreamTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #ZnPositionableReadStreamTests,
+	#name : #ZnPositionableReadStreamTest,
 	#superclass : #TestCase,
 	#category : #'Zinc-Character-Encoding-Tests'
 }
 
 { #category : #testing }
-ZnPositionableReadStreamTests >> testBulkReading [
+ZnPositionableReadStreamTest >> testBulkReading [
 	| stream buffer |
 	stream := ZnPositionableReadStream on: #(0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) readStream.
 	buffer := Array new: 6.
@@ -20,7 +20,7 @@ ZnPositionableReadStreamTests >> testBulkReading [
 ]
 
 { #category : #testing }
-ZnPositionableReadStreamTests >> testEmpty [
+ZnPositionableReadStreamTest >> testEmpty [
 	| stream |
 	stream := ZnPositionableReadStream on: '' readStream.
 	self assert: stream atEnd.
@@ -31,7 +31,7 @@ ZnPositionableReadStreamTests >> testEmpty [
 ]
 
 { #category : #testing }
-ZnPositionableReadStreamTests >> testNestedExcursion [
+ZnPositionableReadStreamTest >> testNestedExcursion [
 	| stream |
 	stream := ZnPositionableReadStream on: 'abcdef---XYZ!1--------' readStream.
 	self assert: (stream next: 3) equals: 'abc'.
@@ -47,7 +47,7 @@ ZnPositionableReadStreamTests >> testNestedExcursion [
 ]
 
 { #category : #testing }
-ZnPositionableReadStreamTests >> testNew [
+ZnPositionableReadStreamTest >> testNew [
 	| stream |
 	stream := ZnPositionableReadStream on: 'abc' readStream.
 	self assert: stream position isZero.
@@ -58,7 +58,7 @@ ZnPositionableReadStreamTests >> testNew [
 ]
 
 { #category : #testing }
-ZnPositionableReadStreamTests >> testPlainExcursion [
+ZnPositionableReadStreamTest >> testPlainExcursion [
 	| stream |
 	stream := ZnPositionableReadStream on: 'abcdef-----------' readStream.
 	self assert: (stream next: 3) equals: 'abc'.
@@ -68,7 +68,7 @@ ZnPositionableReadStreamTests >> testPlainExcursion [
 ]
 
 { #category : #testing }
-ZnPositionableReadStreamTests >> testPlainNext [
+ZnPositionableReadStreamTest >> testPlainNext [
 	| stream |
 	stream := ZnPositionableReadStream on: 'abc' readStream.
 	self assert: stream next equals: $a.
@@ -82,7 +82,7 @@ ZnPositionableReadStreamTests >> testPlainNext [
 ]
 
 { #category : #testing }
-ZnPositionableReadStreamTests >> testPlainPeek [
+ZnPositionableReadStreamTest >> testPlainPeek [
 	| stream |
 	stream := ZnPositionableReadStream on: 'abc' readStream.
 	self assert: stream next equals: $a.
@@ -97,7 +97,7 @@ ZnPositionableReadStreamTests >> testPlainPeek [
 ]
 
 { #category : #testing }
-ZnPositionableReadStreamTests >> testPositionErrors [
+ZnPositionableReadStreamTest >> testPositionErrors [
 	| data stream |
 	data := ByteArray new: 1000 streamContents: [ :out | 
 		100 timesRepeat: [ out nextPutAll: #[ 0 1 2 3 4 5 6 7 8 9 ] ] ].
@@ -116,7 +116,7 @@ ZnPositionableReadStreamTests >> testPositionErrors [
 ]
 
 { #category : #testing }
-ZnPositionableReadStreamTests >> testReadAll [
+ZnPositionableReadStreamTest >> testReadAll [
 	| data stream |
 	data := String new: 200 streamContents: [ :out | 
 		200 timesRepeat: [ out nextPut: 'abc' atRandom ] ].
@@ -135,7 +135,7 @@ ZnPositionableReadStreamTests >> testReadAll [
 ]
 
 { #category : #testing }
-ZnPositionableReadStreamTests >> testReadAllLargerBuffer [
+ZnPositionableReadStreamTest >> testReadAllLargerBuffer [
 	| data stream |
 	data := String new: 500 streamContents: [ :out | 
 		500 timesRepeat: [ out nextPut: 'abc' atRandom ] ].
@@ -155,7 +155,7 @@ ZnPositionableReadStreamTests >> testReadAllLargerBuffer [
 ]
 
 { #category : #testing }
-ZnPositionableReadStreamTests >> testSearch [
+ZnPositionableReadStreamTest >> testSearch [
 	| data stream found |
 	data := String new: 2000 streamContents: [ :out | 
 		2000 timesRepeat: [ out nextPut: 'abc' atRandom ] ].
@@ -173,7 +173,7 @@ ZnPositionableReadStreamTests >> testSearch [
 ]
 
 { #category : #testing }
-ZnPositionableReadStreamTests >> testSearchBinary [
+ZnPositionableReadStreamTest >> testSearchBinary [
 	| data stream pattern found |
 	data := ByteArray new: 2000 streamContents: [ :out | 
 		2000 timesRepeat: [ out nextPut: 256 atRandom - 1 ] ].
@@ -192,7 +192,7 @@ ZnPositionableReadStreamTests >> testSearchBinary [
 ]
 
 { #category : #testing }
-ZnPositionableReadStreamTests >> testSkipAndBack [
+ZnPositionableReadStreamTest >> testSkipAndBack [
 	| stream |
 	stream := ZnPositionableReadStream on: 'abcdef' readStream.
 	stream skip: 2.
@@ -208,7 +208,7 @@ ZnPositionableReadStreamTests >> testSkipAndBack [
 ]
 
 { #category : #testing }
-ZnPositionableReadStreamTests >> testUTF8 [
+ZnPositionableReadStreamTest >> testUTF8 [
 	| data stream |
 	data := 'Les élèves Françaises ont 100 €'.
 	stream := ZnPositionableReadStream on: (ZnCharacterReadStream on: data utf8Encoded readStream).


### PR DESCRIPTION
Zinc character encoding should end with Test