### PR TITLE
4275-allInstVarNames-should-call-instVarNames

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -130,11 +130,9 @@ Behavior >> allInstVarNames [
 	Array ordering is the order in which the variables are stored and 
 	accessed by the interpreter."
 
-	| vars |
-	vars := self superclass 
-		ifNil: [ self slots collect: #name ]	"Guarantee a copy is answered."
-		ifNotNil: [ self superclass allInstVarNames , (self slots collect: #name) ].
-	^vars
+	^ self superclass
+		ifNil: [ self instVarNames ]
+		ifNotNil: [ self superclass allInstVarNames , self instVarNames ]
 ]
 
 { #category : #'accessing instances and variables' }

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -132,7 +132,7 @@ Behavior >> allInstVarNames [
 
 	^ self superclass
 		ifNil: [ self instVarNames ]
-		ifNotNil: [ self superclass allInstVarNames , self instVarNames ]
+		ifNotNil: [ :sup | sup allInstVarNames , self instVarNames ]
 ]
 
 { #category : #'accessing instances and variables' }


### PR DESCRIPTION
simplify #allInstaVarnames  by re-using #instVarNames