### PR TITLE
4017-tryning-to-add-an-ivar-to-UndefinedObject-crashes-the-VM

### DIFF
--- a/src/Shift-ClassBuilder/DangerousClassNotifier.class.st
+++ b/src/Shift-ClassBuilder/DangerousClassNotifier.class.st
@@ -93,5 +93,7 @@ DangerousClassNotifier class >> tooDangerousClasses [
 		#ProtoObject #Object
 		"Contexts and their superclasses"
 		#InstructionStream #Context #BlockClosure #CompiledMethod #CompiledCode #CompiledBlock
+		"UndefinedObject crashes the VM"
+		#UndefinedObject
 	)
 ]


### PR DESCRIPTION
add UndefinedObject to the #tooDangerousClass so people get warned when they try to add an ivar to it

fixes #4017