### PR TITLE
4281-Deprecation-should-be-transitif

### DIFF
--- a/src/Calypso-SystemPlugins-Deprecation-Queries/ClyDeprecationEnvironmentPlugin.class.st
+++ b/src/Calypso-SystemPlugins-Deprecation-Queries/ClyDeprecationEnvironmentPlugin.class.st
@@ -15,9 +15,7 @@ ClyDeprecationEnvironmentPlugin >> collectMethodGroupProviders [
 
 { #category : #'item decoration' }
 ClyDeprecationEnvironmentPlugin >> decorateBrowserItem: anItem ofClass: aClass [
-
-	((aClass respondsTo: #isDeprecated) and: [aClass isDeprecated]) 
-		ifTrue: [ anItem markWith: ClyDeprecatedItemTag]
+	aClass isDeprecated ifTrue: [ anItem markWith: ClyDeprecatedItemTag ]
 ]
 
 { #category : #'item decoration' }
@@ -29,7 +27,5 @@ ClyDeprecationEnvironmentPlugin >> decorateBrowserItem: anItem ofMethod: aMethod
 
 { #category : #'item decoration' }
 ClyDeprecationEnvironmentPlugin >> decorateBrowserItem: anItem ofPackage: aPackage [
-
-	((aPackage respondsTo: #isDeprecated) and: [aPackage isDeprecated]) 
-		ifTrue: [ anItem markWith: ClyDeprecatedItemTag]
+	aPackage isDeprecated ifTrue: [ anItem markWith: ClyDeprecatedItemTag ]
 ]

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -309,13 +309,13 @@ CompiledMethodTest >> testIsAbstract [
 { #category : #'tests - testing' }
 CompiledMethodTest >> testIsDeprecated [
 	| deprecatedSelectors |
-	deprecatedSelectors := #(deprecatedMethod deprecatedMethod2 deprecatedMethod3 deprecatedMethod4 deprecatedMethod5 deprecatedMethod6 deprecatedMethod7)
-		asSet.
-	self class
-		selectorsDo: [ :each | 
-			(deprecatedSelectors includes: each)
-				ifTrue: [ self assert: (self class >> each) isDeprecated ]
-				ifFalse: [ self deny: (self class >> each) isDeprecated ] ]
+	deprecatedSelectors := #(deprecatedMethod deprecatedMethod2 deprecatedMethod3 deprecatedMethod4 deprecatedMethod5 deprecatedMethod6 deprecatedMethod7) asSet.
+	self class selectorsDo: [ :each |
+		(deprecatedSelectors includes: each)
+			ifTrue: [ self assert: (self class >> each) isDeprecated ]
+			ifFalse: [ self deny: (self class >> each) isDeprecated ] ].
+
+	DeprecatedClassForTest selectorsDo: [ :each | self assert: (DeprecatedClassForTest >> each) isDeprecated ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -309,7 +309,7 @@ CompiledMethodTest >> testIsAbstract [
 { #category : #'tests - testing' }
 CompiledMethodTest >> testIsDeprecated [
 	| deprecatedSelectors |
-	deprecatedSelectors := #(deprecatedMethod deprecatedMethod2 deprecatedMethod3 deprecatedMethod4 deprecatedMethod5 deprecatedMethod6 deprecatedMethod7) asSet.
+	deprecatedSelectors := #(deprecatedMethod deprecatedMethod2 deprecatedMethod3 deprecatedMethod4 deprecatedMethod5 deprecatedMethod6 deprecatedMethod7).
 	self class selectorsDo: [ :each |
 		(deprecatedSelectors includes: each)
 			ifTrue: [ self assert: (self class >> each) isDeprecated ]

--- a/src/Kernel-Tests-Extended/DeprecatedClassForTest.class.st
+++ b/src/Kernel-Tests-Extended/DeprecatedClassForTest.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #DeprecatedClassForTest,
+	#superclass : #Object,
+	#category : #'Kernel-Tests-Extended-Methods'
+}
+
+{ #category : #deprecation }
+DeprecatedClassForTest class >> isDeprecated [
+	^ true
+]
+
+{ #category : #examples }
+DeprecatedClassForTest >> deprecatedMethod [
+	self deprecated: 'I am deprecated for tests'
+]
+
+{ #category : #examples }
+DeprecatedClassForTest >> indirectDeprecatedMethod [
+	
+]

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -671,12 +671,6 @@ Class >> isClassOrTrait [
 	^true
 ]
 
-{ #category : #deprecation }
-Class >> isDeprecated [
-
-	^ false
-]
-
 { #category : #testing }
 Class >> isObsolete [
 	"Return true if the receiver is obsolete."

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -815,6 +815,11 @@ ClassDescription >> isClassSide [
 	^self == self classSide
 ]
 
+{ #category : #testing }
+ClassDescription >> isDeprecated [
+	^ self package isDeprecated
+]
+
 { #category : #'accessing parallel hierarchy' }
 ClassDescription >> isInstanceSide [
 	"Return true whether the receiver is a class (in a couple class/metaclass sense)."

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -518,6 +518,8 @@ CompiledMethod >> isConflict [
 { #category : #testing }
 CompiledMethod >> isDeprecated [
 	"Object selectorsInProtocol: #deprecation"
+	self methodClass instanceSide isDeprecated ifTrue: [ ^ true ].
+
 	(self
 		sendsAnySelectorOf:
 			#(#deprecated: #deprecated:on:in: #deprecated:on:in:transformWith: #deprecated:transformWith:))

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -518,7 +518,7 @@ CompiledMethod >> isConflict [
 { #category : #testing }
 CompiledMethod >> isDeprecated [
 	"Object selectorsInProtocol: #deprecation"
-	self methodClass instanceSide isDeprecated ifTrue: [ ^ true ].
+	self methodClass isDeprecated ifTrue: [ ^ true ].
 
 	(self
 		sendsAnySelectorOf:

--- a/src/Kernel/PackageManifest.class.st
+++ b/src/Kernel/PackageManifest.class.st
@@ -23,6 +23,11 @@ PackageManifest class >> ignoredDependencies [
 	^ #(#'System-Settings-Core')
 ]
 
+{ #category : #deprecation }
+PackageManifest class >> isDeprecated [
+	^ false
+]
+
 { #category : #testing }
 PackageManifest class >> isManifest [
 	^ (self = PackageManifest) not

--- a/src/Manifest-Core/RPackage.extension.st
+++ b/src/Manifest-Core/RPackage.extension.st
@@ -8,13 +8,6 @@ RPackage >> criticNameOn: aStream [
 ]
 
 { #category : #'*Manifest-Core' }
-RPackage >> isDeprecated [
-	^self packageManifestOrNil 
-		ifNil: [ ^false ]
-		ifNotNil: [ :manifest | manifest isDeprecated ]
-]
-
-{ #category : #'*Manifest-Core' }
 RPackage >> manifestBuilderForRuleChecker: aRuleChecker [
 	"Return the manifestsince the rulechecker is keeping a cache, we ask it back"
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -957,6 +957,13 @@ RPackage >> isDefault [
 ]
 
 { #category : #testing }
+RPackage >> isDeprecated [
+	^ self packageManifestOrNil 
+		ifNil: [ ^ false ]
+		ifNotNil: [ :manifest | manifest isDeprecated ]
+]
+
+{ #category : #testing }
 RPackage >> isEmpty [
 	self name = self class defaultPackageName ifTrue: [ ^false ].
 	^self classes isEmpty and: [ self extensionSelectors isEmpty]


### PR DESCRIPTION
Refactor deprecation to:
- Ensure every class can answer to #isDeprecated
- Consider a class in a deprecated package as deprecated
- Consider a method in a deprecated class as deprecated
- Remove ugly #respondsTo:

Fixes #4281