### PR TITLE
Go back to version Iceberg 1.6.1

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -883,7 +883,7 @@ spec group: #default with: #(
 BaselineOfIDE >> loadIceberg [
 	Metacello new
 		baseline: 'Iceberg';
-		repository: 'github://pharo-vcs/iceberg:v1.7.2';
+		repository: 'github://pharo-vcs/iceberg:v1.6.1';
 		onConflictUseLoaded;
 		load.
 	(Smalltalk classNamed: #Iceberg) enableMetacelloIntegration: true.


### PR DESCRIPTION
This is required for spec1's revert (https://github.com/pharo-project/pharo/pull/4278)
We will later integrate latest version using spec2