### PR TITLE
4271-Trait-adding-duplicated-slot-error-is-not-explicit-enough

### DIFF
--- a/src/TraitsV2/TaSequence.class.st
+++ b/src/TraitsV2/TaSequence.class.st
@@ -314,9 +314,12 @@ TaSequence >> validateMethods: aTrait [
 
 { #category : #validations }
 TaSequence >> validateSlots: anElement [
-	self slots do: [ :e | anElement slots do: [ :other | 
+	self slots
+		do: [ :e | 
+			anElement slots
+				do: [ :other | 
 					(e name = other name and: [ e definingClass ~= other definingClass ])
-						ifTrue: [ self error: 'The added trait duplicates an existing slot ' , e name printString ] ] ]
+						ifTrue: [ self error: 'The added trait duplicates an existing slot ' , e name printString , '. Duplication between ' , e definingClass asString , ' and ' , other definingClass asString ] ] ]
 ]
 
 { #category : #operations }


### PR DESCRIPTION
Improve error message of duplicated slots.

Fixes #4271