### PR TITLE
OSWorld renderer OSWindow should start centered

### DIFF
--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -136,6 +136,7 @@ OSWorldRenderer >> doActivate [
 	attributes
 		extent: initialExtent;
 		title: Smalltalk shortImageName;
+		windowCentered:true;
 		icon: (self iconNamed: #pharoBig).
 
 	display := Form extent: initialExtent depth: 32.


### PR DESCRIPTION
The window of the world has to start centered.