### PR TITLE
Commander-SpecSupport should be loaded

### DIFF
--- a/src/BaselineOfCommander/BaselineOfCommander.class.st
+++ b/src/BaselineOfCommander/BaselineOfCommander.class.st
@@ -45,5 +45,5 @@ BaselineOfCommander >> baseline: spec [
 			group: 'Core' with: #(#'Commander-Core');
 			group: 'AllActivators' with: #(#'Commander-Activators-Shortcut' #'Commander-Activators-ContextMenu' #'Commander-Activators-DragAndDrop' #'Commander-Activators-WorldMenu' #'Commander-Activators-TextView' #'Commander-Activators-Mouse');
 			group: 'Tests' with: #(#'Commander-Core-Tests' );
-			group: 'default' with: #('Core' 'AllActivators' 'Tests' 'Commander-Spec2-Compatibility') ]
+			group: 'default' with: #('Core' 'AllActivators' 'Tests' 'Commander-SpecSupport' 'Commander-Spec2-Compatibility') ]
 ]


### PR DESCRIPTION
The extensions to spec made by commander should be still loaded as long as we have commander and spec.

This is used by iceberg at least. 