### PR TITLE
Deprecate #llCallsOnIn:

### DIFF
--- a/src/System-Support/Behavior.extension.st
+++ b/src/System-Support/Behavior.extension.st
@@ -18,10 +18,8 @@ Behavior >> allCallsOn: aSymbol [
 { #category : #'*System-Support' }
 Behavior >> allCallsOnIn: aSystemNavigation [
 	"Answer a SortedCollection of all the methods that refer to me by name or as part of an association in a global dict."
-
-	^ (aSystemNavigation 
-		allReferencesTo: (self environment associationAt: self instanceSide name)), 
-		(aSystemNavigation allCallsOn: self instanceSide name)	
+	self deprecated: 'use allCallsOn'.
+	^ self allCallsOn
 ]
 
 { #category : #'*System-Support' }

--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -25,7 +25,7 @@ SystemNavigation >> browseAllCallsOnClass: aClass [
 	aClass. For example, SystemNavigation new browseAllCallsOnClass: Object."
 
 	^ self
-		browseMessageList: (aClass allCallsOnIn: self)
+		browseMessageList: aClass allCallsOn
 		name: 'Users of class ' , aClass instanceSide name
 		autoSelect: aClass instanceSide name
 ]


### PR DESCRIPTION
allCallsOnIn: is not really useful: it is just called from SystemNavivation with itself as a parameter. Use #allCallsOn instead