### PR TITLE
4298-Calypso-does-not-show-empty-protocols

### DIFF
--- a/src/Calypso-SystemQueries/ClassDescription.extension.st
+++ b/src/Calypso-SystemQueries/ClassDescription.extension.st
@@ -7,5 +7,9 @@ ClassDescription >> tagsForAllMethods [
 	| allProtocols |
 	allProtocols := self organization protocols reject: [ :each | each name = Protocol unclassified | each isExtensionProtocol ].
 
-	^ allProtocols select: [ :each | each methods anySatisfy: [ :method | self selectors includes: method ] ] thenCollect: #name
+	^ allProtocols select: [ :protocol |
+		protocol methods
+			ifEmpty: [ true ]
+			ifNotEmpty: [ :methods | methods anySatisfy: [ :method | self selectors includes: method ] ] ]
+		thenCollect: #name
 ]


### PR DESCRIPTION
Calypso now show empty protocols (Bug I introduced in https://github.com/pharo-project/pharo/pull/4244)

Fixes #4298