### PR TITLE
Add-sortUsing-to-SortedCollection

### DIFF
--- a/src/Collections-Sequenceable/SortedCollection.class.st
+++ b/src/Collections-Sequenceable/SortedCollection.class.st
@@ -13,14 +13,14 @@ I should be used only if you really need to keep the elements sorted all the tim
 Public API and Key Messages
 -------------------
 
-- class method: #sortBlock:  aBlock 		is a contructor. 
+- class method: #sortUsing:  aBlockOrSortFunction 		is a contructor. 
 		
 - #sort: aBlock 		is a function to change the way I am sorted. I will also update the index of my elements with the new block.
 
 Example
 -------------------
 
-	sortColl := SortedCollection sortBlock: [ :elem1 :elem2 | elem1 < elem2 ].
+	sortColl := SortedCollection sortUsing: [ :elem1 :elem2 | elem1 < elem2 ].
 	sortColl
 		add: 4;
 		add: 2;
@@ -78,7 +78,7 @@ Class {
 SortedCollection class >> sortBlock: aBlock [ 
 	"Answer an instance of me such that its elements are sorted according to the criterion specified in aBlock."
 
-	^self new sortBlock: aBlock
+	^ self sortUsing aBlock
 ]
 
 { #category : #'instance creation' }

--- a/src/Collections-Sequenceable/SortedCollection.class.st
+++ b/src/Collections-Sequenceable/SortedCollection.class.st
@@ -81,6 +81,13 @@ SortedCollection class >> sortBlock: aBlock [
 	^self new sortBlock: aBlock
 ]
 
+{ #category : #'instance creation' }
+SortedCollection class >> sortUsing: aBlockOrSortFunction [
+	"Answer an instance of me such that its elements are sorted according to the criterion specified by the block or sort function."
+
+	^ self new sortBlock: aBlockOrSortFunction
+]
+
 { #category : #comparing }
 SortedCollection >> = aSortedCollection [
 	"Answer true if my and aSortedCollection's species are the same,

--- a/src/Collections-Sequenceable/SortedCollection.class.st
+++ b/src/Collections-Sequenceable/SortedCollection.class.st
@@ -78,7 +78,7 @@ Class {
 SortedCollection class >> sortBlock: aBlock [ 
 	"Answer an instance of me such that its elements are sorted according to the criterion specified in aBlock."
 
-	^ self sortUsing aBlock
+	^ self sortUsing: aBlock
 ]
 
 { #category : #'instance creation' }

--- a/src/Collections-Tests/SortedCollectionTest.class.st
+++ b/src/Collections-Tests/SortedCollectionTest.class.st
@@ -830,6 +830,15 @@ SortedCollectionTest >> testSortBlock [
 ]
 
 { #category : #'tests - basic' }
+SortedCollectionTest >> testSortUsing [
+	| aSortedCollection |
+	aSortedCollection := (SortedCollection sortUsing: #yourself ascending)
+		addAll: #(2 6 3 8 4 3 7 6);
+		yourself.
+	self assert: aSortedCollection asArray equals: #(2 3 3 4 6 6 7 8)
+]
+
+{ #category : #'tests - basic' }
 SortedCollectionTest >> testSpeciesLooseSortBlock [
 	"This is a non regression test for http://bugs.squeak.org/view.php?id=6535"
 


### PR DESCRIPTION
SortedCollection can now be used with a SortFunction instead of a block. 

For me it seems weird to give a sort function using the API #sortBlock:. In this PR I add a method #sortUsing: to SortedCollection.

Maybe in the future we could deprecate #sortBlock: in order to use #sortUsing: everywhere.