### PR TITLE
Use stack instead of recursion in MCScanner>>next

### DIFF
--- a/src/Monticello/MCScanner.class.st
+++ b/src/Monticello/MCScanner.class.st
@@ -45,7 +45,7 @@ MCScanner >> next [
 		"For an array, start a new level on the stack"
 		c = $( ifTrue: [ stream next. stack push: Stack new ] ifFalse: [
 		"At the end of an array, so add it to the previous level"
-		c = $) ifTrue: [ | x | x := stack pop. stack top push: x asArray reverse ] ifFalse: [ 
+		c = $) ifTrue: [ | x | stream next. x := stack pop. stack top push: x asArray reverse ] ifFalse: [ 
 		"Unexpected token"
 		self error: 'Unknown token type' ]]]].
 		"Keep looping while we are in an array"

--- a/src/Monticello/MCScanner.class.st
+++ b/src/Monticello/MCScanner.class.st
@@ -28,8 +28,7 @@ MCScanner class >> scanTokens: aString [
 { #category : #actions }
 MCScanner >> next [
 	"This would be slightly simpler using recursion but it risks a stack overflow 
-	 for some packages on some platforms, so we implement it using a local stack. 
-	 The performance is essentially equivalent (<5% difference)."
+	 for some packages on some platforms, so we implement it using a local stack."
 
 	| stack |
 	stack := Stack with: Stack new.
@@ -40,19 +39,20 @@ MCScanner >> next [
 		"We essentially ignore the $# symbol and expect what follows to be a symbol or array"
 		c = $# ifTrue: [ c := stream next; peek ].
 		"Note that #'foo' will be treated as a String, not a Symbol"
-		c = $' ifTrue: [ stack last push: self nextString ] ifFalse: [
+		c = $' ifTrue: [ stack top push: self nextString ] ifFalse: [
 		"Any alphanumeric, including an integer, is treated as a Symbol even if not preceeded by a $#"
-		c isAlphaNumeric ifTrue: [ stack last push: self nextSymbol ] ifFalse: [
+		c isAlphaNumeric ifTrue: [ stack top push: self nextSymbol ] ifFalse: [
 		"For an array, start a new level on the stack"
 		c = $( ifTrue: [ stream next. stack push: Stack new ] ifFalse: [
 		"At the end of an array, so add it to the previous level"
-		c = $) ifTrue: [ | x | x := stack pop. stack last push: x asArray ] ifFalse: [ 
+		c = $) ifTrue: [ | x | x := stack pop. stack top push: x asArray reverse ] ifFalse: [ 
 		"Unexpected token"
 		self error: 'Unknown token type' ]]]].
 		"Keep looping while we are in an array"
 		1 < stack size.
 	] whileTrue: [].
-	^stack first first]
+	^stack top top
+]
 
 { #category : #actions }
 MCScanner >> nextArray [

--- a/src/Monticello/MCScanner.class.st
+++ b/src/Monticello/MCScanner.class.st
@@ -32,7 +32,7 @@ MCScanner >> next [
 	 The performance is essentially equivalent (<5% difference)."
 
 	| stack |
-	stack := OrderedCollection with: OrderedCollection new.
+	stack := Stack with: Stack new.
 	[
 		| c |
 		stream skipSeparators.
@@ -40,20 +40,19 @@ MCScanner >> next [
 		"We essentially ignore the $# symbol and expect what follows to be a symbol or array"
 		c = $# ifTrue: [ c := stream next; peek ].
 		"Note that #'foo' will be treated as a String, not a Symbol"
-		c = $' ifTrue: [ stack last add: self nextString ] ifFalse: [
+		c = $' ifTrue: [ stack last push: self nextString ] ifFalse: [
 		"Any alphanumeric, including an integer, is treated as a Symbol even if not preceeded by a $#"
-		c isAlphaNumeric ifTrue: [ stack last add: self nextSymbol ] ifFalse: [
+		c isAlphaNumeric ifTrue: [ stack last push: self nextSymbol ] ifFalse: [
 		"For an array, start a new level on the stack"
-		c = $( ifTrue: [ stream next. stack add: OrderedCollection new ] ifFalse: [
+		c = $( ifTrue: [ stream next. stack push: Stack new ] ifFalse: [
 		"At the end of an array, so add it to the previous level"
-		c = $) ifTrue: [ | x | x := stack removeLast. stack last add: x asArray ] ifFalse: [ 
+		c = $) ifTrue: [ | x | x := stack pop. stack last push: x asArray ] ifFalse: [ 
 		"Unexpected token"
 		self error: 'Unknown token type' ]]]].
 		"Keep looping while we are in an array"
 		1 < stack size.
 	] whileTrue: [].
-	^stack first first
-]
+	^stack first first]
 
 { #category : #actions }
 MCScanner >> nextArray [

--- a/src/Monticello/MCScanner.class.st
+++ b/src/Monticello/MCScanner.class.st
@@ -27,14 +27,32 @@ MCScanner class >> scanTokens: aString [
 
 { #category : #actions }
 MCScanner >> next [
-	| c |
-	stream skipSeparators.
-	c := stream peek.
-	c = $# ifTrue: [c := stream next; peek].
-	c = $' ifTrue: [^ self nextString].
-	c = $( ifTrue: [^ self nextArray].
-	c isAlphaNumeric ifTrue: [^ self nextSymbol].
-	self error: 'Unknown token type'.	
+	"This would be slightly simpler using recursion but it risks a stack overflow 
+	 for some packages on some platforms, so we implement it using a local stack. 
+	 The performance is essentially equivalent (<5% difference)."
+
+	| stack |
+	stack := OrderedCollection with: OrderedCollection new.
+	[
+		| c |
+		stream skipSeparators.
+		c := stream peek.
+		"We essentially ignore the $# symbol and expect what follows to be a symbol or array"
+		c = $# ifTrue: [ c := stream next; peek ].
+		"Note that #'foo' will be treated as a String, not a Symbol"
+		c = $' ifTrue: [ stack last add: self nextString ] ifFalse: [
+		"Any alphanumeric, including an integer, is treated as a Symbol even if not preceeded by a $#"
+		c isAlphaNumeric ifTrue: [ stack last add: self nextSymbol ] ifFalse: [
+		"For an array, start a new level on the stack"
+		c = $( ifTrue: [ stream next. stack add: OrderedCollection new ] ifFalse: [
+		"At the end of an array, so add it to the previous level"
+		c = $) ifTrue: [ | x | x := stack removeLast. stack last add: x asArray ] ifFalse: [ 
+		"Unexpected token"
+		self error: 'Unknown token type' ]]]].
+		"Keep looping while we are in an array"
+		1 < stack size.
+	] whileTrue: [].
+	^stack first first
 ]
 
 { #category : #actions }

--- a/src/System-Hashing/MD5NonPrimitive.class.st
+++ b/src/System-Hashing/MD5NonPrimitive.class.st
@@ -25,7 +25,7 @@ Class {
 
 { #category : #'class initialization' }
 MD5NonPrimitive class >> initialize [
-	"MD5 initialize"
+	"MD5NonPrimitive initialize"
 	"Obscure fact: those magic hex numbers that are hard to type in correctly are
 	actually the result of a simple trigonometric function and are therefore
 	easier to compute than proofread.  Laziness is sometimes a virtue."


### PR DESCRIPTION
This avoids a stack overflow when loading Metacello into GemStone.
I've also added a number of comments (which accounts for some of the extra length).