### PR TITLE
4324-activateCursor-method-is-missing-on-WorldMorph

### DIFF
--- a/src/Graphics-Display Objects/Cursor.class.st
+++ b/src/Graphics-Display Objects/Cursor.class.st
@@ -1035,7 +1035,7 @@ Cursor class >> write [
 
 { #category : #primitives }
 Cursor >> activateInCursorOwner: aCursorOwner [
-	^ aCursorOwner activateCursor: self
+	^ self beCursor
 ]
 
 { #category : #converting }

--- a/src/Graphics-Display Objects/Cursor.class.st
+++ b/src/Graphics-Display Objects/Cursor.class.st
@@ -147,8 +147,7 @@ Cursor class >> currentCursor: aCursor [
 		^ self
 	].
 
-	CurrentCursor := aCursor.
-	"aCursor beCursor"
+	CurrentCursor := aCursor	
 ]
 
 { #category : #constants }

--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -113,6 +113,11 @@ WorldMorph class >> removeExtraWorld: aWorld [
 	
 ]
 
+{ #category : #cursor }
+WorldMorph >> activateCursor: aCursor [
+     aCursor beCursor
+]
+
 { #category : #operations }
 WorldMorph >> activateCursor: aCursor withMask: maskForm [
 


### PR DESCRIPTION
activateCursor: method is missing on WorldMorph

Fix #4324