### PR TITLE
4314-Cannot-use-slot-as-class-variable-Raise-explicit-error

### DIFF
--- a/src/Slot-Core/Slot.class.st
+++ b/src/Slot-Core/Slot.class.st
@@ -132,6 +132,13 @@ Slot >> addSlotInitToInitialize: aClass [
 		during: [ aClass compile: source classified: 'initialization' ]
 ]
 
+{ #category : #'class building' }
+Slot >> asClassVariable [
+	self
+		error:
+			'Slots can not be used to define Class Variables, you need to create a LiteralVariable subclass instead'
+]
+
 { #category : #converting }
 Slot >> asSlot [
 	^ self


### PR DESCRIPTION
add a better warning when a slot class is used as a class variable. fixes #4314