### PR TITLE
Rubric-should-not-depend-on-deprecated-streams

### DIFF
--- a/src/Rubric/RubTextAreaExamples.class.st
+++ b/src/Rubric/RubTextAreaExamples.class.st
@@ -188,25 +188,17 @@ RubTextAreaExamples class >> profileSourcesFileViewing [
 	"The big test to check that a TextArea is able to compose and ''quickly'' show
 	 a big file content "
 
-	"self profileSourcesFileViewing"
-
+	<script>
 	| contents |
-	
-	contents := nil.
-	
-	self
-	show: 'Wait a moment loading text, the sources file is huge' translated
-	while: [ 
-		contents := (FileStream readOnlyFileNamed: Smalltalk sourcesFile basename) contents
-	].
+	"Do not profile reading of source file."
+	contents := Smalltalk sourcesFile contents.
 
-	TimeProfiler spyAllOn: [ 
-		RubEditingArea new
-			beWrapped;
-			width: 600;
-			updateTextWith: contents;
-			openInWorld  
-	]
+	TimeProfiler
+		spyAllOn: [ RubEditingArea new
+				beWrapped;
+				width: 600;
+				updateTextWith: contents;
+				openInWorld ]
 ]
 
 { #category : #examples }

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -1994,11 +1994,8 @@ RubTextEditor >> saveContentsInFile [
 	suggestedName ifNil: [suggestedName := labelToUse , '.text'].
 	fileName := UIManager default request: 'File name?'
 				initialAnswer: suggestedName.
-	fileName isEmptyOrNil 
-		ifFalse: 
-			[(FileStream newFileNamed: fileName)
-				nextPutAll: stringToSave;
-				close]
+	fileName isEmptyOrNil
+		ifFalse: [ fileName asFileReference writeStreamDo: [ :out | out nextPutAll: stringToSave ] ]
 ]
 
 { #category : #scrolling }


### PR DESCRIPTION
Update rubric to not depend on deprecated file streams.