### PR TITLE
Calypso-should-not-depend-on-deprecated-streams

### DIFF
--- a/src/Calypso-SystemPlugins-FileOut-Queries/ClyMethodGroup.extension.st
+++ b/src/Calypso-SystemPlugins-FileOut-Queries/ClyMethodGroup.extension.st
@@ -4,10 +4,12 @@ Extension { #name : #ClyMethodGroup }
 ClyMethodGroup >> fileOut [
 	| internalStream class |
 	internalStream := (String new: 1000) writeStream.
-	internalStream header; timeStamp; cr.
-	self methods do: [:each |
-		each origin printMethodChunk: each selector on: internalStream ].
+	internalStream
+		header;
+		timeStamp;
+		cr.
+	self methods do: [ :each | each origin printMethodChunk: each selector on: internalStream ].
 	internalStream trailer.
 	class := methodQuery scope basisObjects anyOne.
-	^ FileStream writeSourceCodeFrom: internalStream baseName: (class name , '-' , self name) isSt: true.
+	^ CodeExporter writeSourceCodeFrom: internalStream baseName: class name , '-' , self name isSt: true
 ]


### PR DESCRIPTION
Remove dependency between Calypso and deprecated file streams.