### PR TITLE
Fonts-should-not-depend-on-deprecated-file-streams

### DIFF
--- a/src/Graphics-Fonts/FontSet.class.st
+++ b/src/Graphics-Fonts/FontSet.class.st
@@ -29,15 +29,6 @@ FontSet class >> acceptsLoggingOfCompilation [
 	^ self == FontSet
 ]
 
-{ #category : #'filein/out' }
-FontSet class >> fileOut [
-	"FileOut and then change the properties of the file so that it won't be
-	treated as text by, eg, email attachment facilities"
-
-	super fileOut.
-	(FileStream oldFileNamed: self name , '.st') close
-]
-
 { #category : #private }
 FontSet class >> fontCategory [
 	^ 'Graphics-Fonts' asSymbol

--- a/src/Graphics-Fonts/StrikeFont.class.st
+++ b/src/Graphics-Fonts/StrikeFont.class.st
@@ -1616,8 +1616,7 @@ StrikeFont >> newFromStrike: fileName [
 	is optional."
 	| strike startName raster16  |
 	name := fileName copyUpTo: $..	"assumes extension (if any) is '.strike'"
-	strike := FileStream readOnlyFileNamed: name , '.strike.'.
-	strike binary.
+	strike := File openForReadFileNamed: name , '.strike.'.
 
 	"strip off direcory name if any"
 	startName := name size.
@@ -1754,7 +1753,7 @@ StrikeFont >> readFromBitFont: fileName [
 	written by Peter DiCamillo at Brown University"
 	"StrikeFont new readFromBitFont: 'Palatino10.BF' "
 	| f lastAscii charLine width ascii charForm line missingForm tempGlyphs iRect p rectLine left tokens right |
-	f := FileStream readOnlyFileNamed: fileName.
+	f := File openForReadFileNamed: fileName.
 	self readBFHeaderFrom: f.
 
 	"NOTE: if font has been scaled (and in any case),
@@ -1885,8 +1884,7 @@ StrikeFont >> readFromStrike2: fileName [
 	| file |
 	self assert:['*.sf2' match: fileName]. "likely incompatible"
 	name := fileName copyUpTo: $..	"Drop filename extension"
-	file := FileStream readOnlyFileNamed: fileName.
-	file binary.
+	file := File openForReadFileNamed: fileName.
 	[ self readFromStrike2Stream: file ] ensure: [ file close ]
 ]
 


### PR DESCRIPTION
Fonts should not depend on deprecated file streams.