### PR TITLE
Remove-PNGReader-test-missing-resources

### DIFF
--- a/src/Graphics-Tests/PNGReadWriterTest.class.st
+++ b/src/Graphics-Tests/PNGReadWriterTest.class.st
@@ -637,23 +637,6 @@ PNGReadWriterTest >> testPngEncodingColors8 [
 	self encodeColors: self coloredFiles8 depth: 8.
 ]
 
-{ #category : #'tests - bits' }
-PNGReadWriterTest >> testPngSuite [
-	"Requires the suite from 
-		ftp://swrinde.nde.swri.edu/pub/png/images/suite/PngSuite.zip
-	to be present as PngSuite.zip"
-	| file |
-	file := [ FileStream readOnlyFileNamed: 'PngSuite.zip'] on: Error do:[:ex| ex return].
-	file ifNil:[^self].
-	[ | zip entries |zip := ZipArchive new readFrom: file.
-	entries := zip members select:[:mbr| mbr fileName asLowercase endsWith: '.png'].
-	entries do:[:mbr| 
-		(mbr fileName asLowercase first = $x)
-			ifTrue: [self encodeAndDecodeWithError: mbr contentStream ]
-			ifFalse: [self encodeAndDecodeStream: mbr contentStream ] ].
-	] ensure:[file close].
-]
-
 { #category : #'tests - colors' }
 PNGReadWriterTest >> testRed16 [
 	self encodeAndDecodeColor: Color red depth: 16


### PR DESCRIPTION
Remove test that needs an unavailable resource.

There is a link but the resource seems unavailable now. So this is just dead code now.