### PR TITLE
Monticello-tests-should-not-depend-on-deprecated-streams

### DIFF
--- a/src/Monticello-Tests/MCFileInTest.class.st
+++ b/src/Monticello-Tests/MCFileInTest.class.st
@@ -61,7 +61,7 @@ MCFileInTest >> assertSuccessfulLoadWith: aBlock [
 MCFileInTest >> setUp [
 	super setUp.
 	expected := self mockSnapshot.
-	stream := RWBinaryOrTextStream on: String new.
+	stream := ReadWriteStream on: ''
 ]
 
 { #category : #running }

--- a/src/Monticello-Tests/MCSerializationTest.class.st
+++ b/src/Monticello-Tests/MCSerializationTest.class.st
@@ -9,10 +9,10 @@ MCSerializationTest >> assertDependenciesMatchWith: writerClass [
 	| stream readerClass expected actual |
 	readerClass := writerClass readerClass.
 	expected := self mockVersionWithDependencies.
-	stream := RWBinaryOrTextStream on: ByteArray new.
+	stream := ReadWriteStream on: ByteArray new.
 	writerClass fileOut: expected on: stream.
 	actual := (readerClass on: stream reset) dependencies.
-	self assert: actual = expected dependencies.
+	self assert: actual equals: expected dependencies.
 ]
 
 { #category : #asserting }
@@ -25,7 +25,7 @@ MCSerializationTest >> assertSnapshotsMatchWith: writerClass [
 	| readerClass expected stream actual |
 	readerClass := writerClass readerClass.
 	expected := self mockSnapshot.
-	stream := RWBinaryOrTextStream on: ByteArray new.
+	stream := ReadWriteStream on: ''.
 	(writerClass on: stream) writeSnapshot: expected.
 	actual := readerClass snapshotFromStream: stream reset.
 	self assertSnapshot: actual matches: expected.
@@ -36,10 +36,10 @@ MCSerializationTest >> assertVersionInfosMatchWith: writerClass [
 	| stream readerClass expected actual |
 	readerClass := writerClass readerClass.
 	expected := self mockVersion.
-	stream := RWBinaryOrTextStream on: ByteArray new.
+	stream := ReadWriteStream on: ByteArray new.
 	writerClass fileOut: expected on: stream.
 	actual := readerClass versionInfoFromStream: stream reset.
-	self assert: actual = expected info.
+	self assert: actual equals: expected info.
 ]
 
 { #category : #asserting }
@@ -47,7 +47,7 @@ MCSerializationTest >> assertVersionsMatchWith: writerClass [
 	| stream readerClass expected actual |
 	readerClass := writerClass readerClass.
 	expected := self mockVersion.
-	stream := RWBinaryOrTextStream on: ByteArray new.
+	stream := ReadWriteStream on: ByteArray new.
 	writerClass fileOut: expected on: stream.
 	actual := readerClass versionFromStream: stream reset.
 	self assertVersion: actual matches: expected.
@@ -71,7 +71,7 @@ MCSerializationTest >> mockDiffyVersion [
 MCSerializationTest >> testMcdSerialization [
 	| stream expected actual |
 	expected := self mockDiffyVersion.
-	stream := RWBinaryOrTextStream on: ByteArray new.
+	stream := ReadWriteStream on: ByteArray new.
 	MCMcdWriter fileOut: expected on: stream.
 	actual := MCMcdReader versionFromStream: stream reset.
 	self assertVersion: actual matches: expected.


### PR DESCRIPTION
Monticello tests should not depend on deprecated streams.