### PR TITLE
4306-Add-comment-why-name-cache-in-SystemDictionary-is-sorted

### DIFF
--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -197,10 +197,11 @@ SystemDictionary >> fillCaches [
 		When bootstrapping we want the class Class of the current kernel defined in the current namespace.
 		Since the current namespace should contains the class that describes itself as well as a new Class class.
 		we are done :)."
-		
-	classNames sort.
+	
+	
+	"The cached names are sorted to allow for a very efficient hasBindingThatBeginsWith: check"	
+	cachedClassNames := classNames sort.
 	cachedNonClassNames := nonClassNames sort.
-	cachedClassNames := classNames.
 	^{ classNames. nonClassNames }
 ]
 


### PR DESCRIPTION
add comment to explain why we sort the name cache