### PR TITLE
4149-instVarNames-is-not-including-instance-variables-coming-from-Stateful-traits

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -775,7 +775,7 @@ ClassDescription >> instVarMappingFrom: oldClass [
 ClassDescription >> instVarNames [
 	"Answer an Array of the receiver's instance variable names."
 
-	^self localSlots collect: [ :each | each name ]
+	^self slots collect: [ :each | each name ]
 ]
 
 { #category : #'accessing parallel hierarchy' }

--- a/src/Monticello/Class.extension.st
+++ b/src/Monticello/Class.extension.st
@@ -10,10 +10,10 @@ Class >> asClassDefinition [
 		traitComposition: self traitCompositionString
 		classTraitComposition: self class traitCompositionString
 		category: self category 
-		instVarNames: self instVarNames
+		instVarNames:  (self localSlots collect: #name)
 		classVarNames: self classVarNames
 		poolDictionaryNames: self sharedPoolNames
-		classInstVarNames: self class instVarNames
+		classInstVarNames: (self class localSlots collect: #name)
 		type: self typeOfClass
 		comment: self organization classComment	asString
 		commentStamp: self organization commentStamp].

--- a/src/Monticello/Trait.extension.st
+++ b/src/Monticello/Trait.extension.st
@@ -7,8 +7,8 @@ Trait >> asClassDefinition [
 			name: self name
 			traitComposition: self traitCompositionString
 			category: self category 
-			instVarNames: self instVarNames
-			classInstVarNames: self classSide slotNames
+			instVarNames: (self localSlots collect: #name)
+			classInstVarNames: (self class localSlots collect: #name)
 			comment: self organization classComment asString
 			commentStamp: self organization commentStamp ].
 		

--- a/src/TraitsV2-Tests/T2TraitMCDefinitionsTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitMCDefinitionsTest.class.st
@@ -118,8 +118,8 @@ T2TraitMCDefinitionsTest >> testDefinitionOfTraitUsingTrait [
 	t2 := self newTrait: #T2 with: #(a b c) uses: t1.
 	definition := t2 asClassDefinition.
 		
-	self assert: definition instanceVariablesString equals: 'a b c x y z'.
-	self assert: definition instanceVariables size equals: 6.
+	self assert: definition instanceVariablesString equals: 'a b c'.
+	self assert: definition instanceVariables size equals: 3.
 	self assert: definition traitComposition equals: 'T1'.
 	self assert: (definition instanceVariables allSatisfy: [ :e | e species = InstanceVariableSlot ])
 ]

--- a/src/TraitsV2-Tests/T2TraitMCDefinitionsTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitMCDefinitionsTest.class.st
@@ -118,8 +118,8 @@ T2TraitMCDefinitionsTest >> testDefinitionOfTraitUsingTrait [
 	t2 := self newTrait: #T2 with: #(a b c) uses: t1.
 	definition := t2 asClassDefinition.
 		
-	self assert: definition instanceVariablesString equals: 'a b c'.
-	self assert: definition instanceVariables size equals: 3.
+	self assert: definition instanceVariablesString equals: 'a b c x y z'.
+	self assert: definition instanceVariables size equals: 6.
 	self assert: definition traitComposition equals: 'T1'.
 	self assert: (definition instanceVariables allSatisfy: [ :e | e species = InstanceVariableSlot ])
 ]

--- a/src/TraitsV2-Tests/T2TraitWithSlotsTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithSlotsTest.class.st
@@ -134,15 +134,15 @@ T2TraitWithSlotsTest >> testRedefiningSuperclass [
 	c1 := self newClass: #C1 with: #(c d) uses: t1.
 	c2 := self newClass: #C2 superclass: c1 with: #(e) uses: t2.
 	
-	self assert: c2 instVarNames equals: #(e).
-	self assert: c1 instVarNames equals: #(c d).
+	self assert: (c2 localSlots collect: #name) equals: #(e).
+	self assert: (c1 localSlots collect: #name) equals: #(c d).
 	self assertCollection: (c2 allSlots collect: #name) hasSameElements: #(c d a b e g h).
 	self assertCollection: (c1 allSlots collect: #name) hasSameElements: #(c d a b).	
 
 	c1 := self newClass: #C1 with: #(c d) uses: t1.	
 
-	self assert: c2 instVarNames equals: #(e).
-	self assert: c1 instVarNames equals: #(c d).
+	self assert: (c2 localSlots collect: #name) equals: #(e).
+	self assert: (c1 localSlots collect: #name) equals: #(c d).
 	self assertCollection: (c2 allSlots collect: #name) hasSameElements: #(c d a b e g h).
 	self assertCollection: (c1 allSlots collect: #name) hasSameElements: #(c d a b).	
 ]


### PR DESCRIPTION
This is an idea to #4149, #3546 ,  #3520

the idea is that #instVarNames should return not only the local slots.