### PR TITLE
Smaller Initial World Extent for osWindow World

### DIFF
--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -130,7 +130,7 @@ OSWorldRenderer >> doActivate [
 
 	| attributes initialExtent |
 	
-	initialExtent := world worldState realWindowExtent ifNil: [1500@1000].
+	initialExtent := world worldState realWindowExtent ifNil: [976@665].
 
 	attributes := OSWindowAttributes new.
 	attributes


### PR DESCRIPTION
We have to use the same initial extent as in the image generated by the CI