### PR TITLE
A formatter functionality according to the CommonLisp's one.

### DIFF
--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -843,6 +843,11 @@ String >> charactersExactlyMatching: aString [
 	^ count
 ]
 
+{ #category : #formatting }
+String >> clFormat: arguments [
+	self shouldBeImplemented 
+]
+
 { #category : #comparing }
 String >> compare: aString [ 
 	"Answer a comparison code telling how the receiver sorts relative to aString:


### PR DESCRIPTION
We want to implement a message that mimic the formatting functionalities provided by the CommonLisp's `format` function. In particular, we'll follow the approach of Seibel (https://github.com/gigamonkey/python-format) and validate it against http://www.gigamonkeys.com/book/a-few-format-recipes.html and the reference http://www.lispworks.com/documentation/lw50/CLHS/Body/22_c.htm.

We open this PR immediately to allow discussion about our effort and tracking either missing or desired feature provided by the original `format`.