### PR TITLE
4272 Fix Spelling of Responsability

### DIFF
--- a/src/Debugger-Actions/SubclassResponsibilityDebugAction.class.st
+++ b/src/Debugger-Actions/SubclassResponsibilityDebugAction.class.st
@@ -4,18 +4,18 @@ A SubclassResponsabilityDebugAction is a debugging action that can create a meth
 
 "
 Class {
-	#name : #SubclassResponsabilityDebugAction,
+	#name : #SubclassResponsibilityDebugAction,
 	#superclass : #DebugAction,
 	#category : #'Debugger-Actions-Actions'
 }
 
 { #category : #registration }
-SubclassResponsabilityDebugAction class >> actionType [
+SubclassResponsibilityDebugAction class >> actionType [
 	<debuggingAction>
 ]
 
 { #category : #testing }
-SubclassResponsabilityDebugAction >> appliesToDebugger: aDebugger [
+SubclassResponsibilityDebugAction >> appliesToDebugger: aDebugger [
 	| interruptedContext |
 	
 	interruptedContext := aDebugger session interruptedContext.
@@ -28,7 +28,7 @@ SubclassResponsabilityDebugAction >> appliesToDebugger: aDebugger [
 ]
 
 { #category : #private }
-SubclassResponsabilityDebugAction >> askForSuperclassOf: aClass to: aSuperclass toImplement: aSelector ifCancel: cancelBlock [
+SubclassResponsibilityDebugAction >> askForSuperclassOf: aClass to: aSuperclass toImplement: aSelector ifCancel: cancelBlock [
 	| classes currentSuperclass chosenClassIndex |
 	
 	classes := OrderedCollection new.
@@ -49,19 +49,19 @@ SubclassResponsabilityDebugAction >> askForSuperclassOf: aClass to: aSuperclass 
 ]
 
 { #category : #accessing }
-SubclassResponsabilityDebugAction >> defaultLabel [
+SubclassResponsibilityDebugAction >> defaultLabel [
 
 	^  'Create'
 ]
 
 { #category : #accessing }
-SubclassResponsabilityDebugAction >> defaultOrder [
+SubclassResponsibilityDebugAction >> defaultOrder [
 
 	^ 1
 ]
 
 { #category : #actions }
-SubclassResponsabilityDebugAction >> executeAction [
+SubclassResponsibilityDebugAction >> executeAction [
 	| senderContext msg msgCategory chosenClass |
 	
 	senderContext := self interruptedContext sender.
@@ -84,12 +84,12 @@ SubclassResponsabilityDebugAction >> executeAction [
 ]
 
 { #category : #accessing }
-SubclassResponsabilityDebugAction >> help [
-	^ 'Create a method in a class having the responsability to implement it.'
+SubclassResponsibilityDebugAction >> help [
+	^ 'Create a method in a class having the responsibility to implement it.'
 ]
 
 { #category : #accessing }
-SubclassResponsabilityDebugAction >> id [
+SubclassResponsibilityDebugAction >> id [
 
-	^ #subclassResponsability
+	^ #subclassResponsibility
 ]

--- a/src/GT-Debugger/SubclassResponsibilityDebugAction.extension.st
+++ b/src/GT-Debugger/SubclassResponsibilityDebugAction.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : #SubclassResponsabilityDebugAction }
+Extension { #name : #SubclassResponsibilityDebugAction }
 
 { #category : #'*GT-Debugger' }
-SubclassResponsabilityDebugAction class >> gtStackDebuggingActionFor: aDebugger [
+SubclassResponsibilityDebugAction class >> gtStackDebuggingActionFor: aDebugger [
 	<gtStackDebuggingAction>
 	
 	^ (self forDebugger: aDebugger)

--- a/src/Zinc-HTTP/ZnSingleThreadedServer.class.st
+++ b/src/Zinc-HTTP/ZnSingleThreadedServer.class.st
@@ -132,7 +132,7 @@ ZnSingleThreadedServer >> augmentResponse: response forRequest: request [
 { #category : #'request handling' }
 ZnSingleThreadedServer >> authenticateAndDelegateRequest: request [
 	"Handle request and return a response.
-	If we have a delegate, pass the responsability.
+	If we have a delegate, pass the responsibility.
 	If we have no delegate, we return a page not found.
 	Make sure to pass via our authenticator."
 
@@ -147,7 +147,7 @@ ZnSingleThreadedServer >> authenticateAndDelegateRequest: request [
 { #category : #'request handling' }
 ZnSingleThreadedServer >> authenticateRequest: request do: block [
 	"Validate request and execute block.
-	When our authenticator is not nil, pass the responsability"
+	When our authenticator is not nil, pass the responsibility"
 
 	^ self authenticator
 		ifNil: [ block value ]


### PR DESCRIPTION
the class comment spelling error has already been fixed in Pharo8. But there where other cases of  "Responsability" which are fixed by this PR