### PR TITLE
4282-Backport-Pharo7-trying-to-add-an-ivar-to-UndefinedObject-crashes-the-VM-4017

### DIFF
--- a/src/Shift-ClassBuilder/DangerousClassNotifier.class.st
+++ b/src/Shift-ClassBuilder/DangerousClassNotifier.class.st
@@ -93,5 +93,7 @@ DangerousClassNotifier class >> tooDangerousClasses [
 		#ProtoObject #Object
 		"Contexts and their superclasses"
 		#InstructionStream #Context #BlockClosure #CompiledMethod #CompiledCode #CompiledBlock
+		"UndefinedObject crashes the VM"
+ 		#UndefinedObject
 	)
 ]


### PR DESCRIPTION
backport to warn when trying to add ivar to UndefinedObject