### PR TITLE
Push-down-method-on-right-owner

### DIFF
--- a/src/Morphic-Core/PasteUpMorph.class.st
+++ b/src/Morphic-Core/PasteUpMorph.class.st
@@ -179,27 +179,6 @@ PasteUpMorph >> backgroundMorph: aMorph [
 			]
 ]
 
-{ #category : #initialization }
-PasteUpMorph >> becomeActiveDuring: aBlock [
-	"Make the receiver the ActiveWorld during the evaluation of aBlock.
-	Note that this method does deliberately *not* use #ensure: to prevent
-	re-installation of the world on project switches."
-	| priorWorld priorHand priorEvent |
-	priorWorld := ActiveWorld.
-	priorHand := ActiveHand.
-	priorEvent := ActiveEvent.
-	ActiveWorld := self.
-	ActiveHand := self hands first. "default"
-	ActiveEvent := nil. "not in event cycle"
-	aBlock
-		on: Error
-		do: [:ex | 
-			ActiveWorld := priorWorld.
-			ActiveEvent := priorEvent.
-			ActiveHand := priorHand.
-			ex pass]
-]
-
 { #category : #viewing }
 PasteUpMorph >> bringTopmostsToFront [
 	submorphs

--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -194,6 +194,28 @@ WorldMorph >> beCursorOwner [
 	self class cursorOwnerWorld: self
 ]
 
+{ #category : #initialization }
+WorldMorph >> becomeActiveDuring: aBlock [
+	"Make the receiver the ActiveWorld during the evaluation of aBlock.
+	Note that this method does deliberately *not* use #ensure: to prevent
+	re-installation of the world on project switches."
+
+	| priorWorld priorHand priorEvent |
+	priorWorld := ActiveWorld.
+	priorHand := ActiveHand.
+	priorEvent := ActiveEvent.
+	ActiveWorld := self.
+	ActiveHand := self hands first.	"default"
+	ActiveEvent := nil.	"not in event cycle"
+	aBlock
+		on: Error
+		do: [ :ex | 
+			ActiveWorld := priorWorld.
+			ActiveEvent := priorEvent.
+			ActiveHand := priorHand.
+			ex pass ]
+]
+
 { #category : #'meta-actions' }
 WorldMorph >> buildMetaMenu: evt [
 	| menu |


### PR DESCRIPTION
#becomeActiveDuring: wakes sense only for the WorldMorph, thus it should not be on PasteUpMorph.