### PR TITLE
FormCanvas-has-wrong-lazy-initialization

### DIFF
--- a/src/Graphics-Canvas/FormCanvas.class.st
+++ b/src/Graphics-Canvas/FormCanvas.class.st
@@ -16,6 +16,44 @@ Class {
 	#category : #'Graphics-Canvas'
 }
 
+{ #category : #caching }
+FormCanvas class >> defaultTranslucentPatterns [
+	| patterns |
+	patterns := Array new: 8.
+	#(1 2 4 8)
+		do: [ :d | 
+			| mask bits pattern patternList |
+			patternList := Array new: 5.
+			mask := (1 bitShift: d) - 1.
+			bits := 2 * d.
+			[ bits >= 32 ]
+				whileFalse: [ mask := mask bitOr: (mask bitShift: bits).	"double the length of mask"
+					bits := bits + bits ].
+
+			"0% pattern"
+			pattern := Bitmap with: 0 with: 0.
+			patternList at: 1 put: pattern.
+
+			"25% pattern"
+			pattern := Bitmap with: mask with: 0.
+			patternList at: 2 put: pattern.
+
+			"50% pattern"
+			pattern := Bitmap with: mask with: mask bitInvert32.
+			patternList at: 3 put: pattern.
+
+			"75% pattern"
+			pattern := Bitmap with: mask with: 4294967295.
+			patternList at: 4 put: pattern.
+
+			"100% pattern"
+			pattern := Bitmap with: 4294967295 with: 4294967295.
+			patternList at: 5 put: pattern.
+			patterns at: d put: patternList ].
+
+	^ patterns
+]
+
 { #category : #'instance creation' }
 FormCanvas class >> extent: aPoint [
 
@@ -38,58 +76,6 @@ FormCanvas class >> extent: extent depth: depth origin: aPoint clipRect: aRectan
 		yourself
 ]
 
-{ #category : #caching }
-FormCanvas class >> initializeTranslucentPatterns [
-	
-	TranslucentPatterns := Array new: 8. 
-	#(1 2 4 8 ) do: 
-		[ :d | | mask bits pattern patternList | 
-		patternList := Array new: 5.
-		mask := (1 bitShift: d) - 1.
-		bits := 2 * d.
-		[ bits >= 32 ] whileFalse: 
-			[ mask := mask bitOr: (mask bitShift: bits).	"double the length of mask"
-			bits := bits + bits ].
-		"0% pattern"
-		pattern := Bitmap 
-			with: 0
-			with: 0.
-		patternList 
-			at: 1
-			put: pattern.
-		"25% pattern"
-		pattern := Bitmap 
-			with: mask
-			with: 0.
-		patternList 
-			at: 2
-			put: pattern.
-		"50% pattern"
-		pattern := Bitmap 
-			with: mask
-			with: mask bitInvert32.
-		patternList 
-			at: 3
-			put: pattern.
-		"75% pattern"
-		pattern := Bitmap 
-			with: mask
-			with: 4294967295.
-		patternList 
-			at: 4
-			put: pattern.
-		"100% pattern"
-		pattern := Bitmap 
-			with: 4294967295
-			with: 4294967295.
-		patternList 
-			at: 5
-			put: pattern.
-		TranslucentPatterns 
-			at: d
-			put: patternList ]
-]
-
 { #category : #'instance creation' }
 FormCanvas class >> on: aForm [
 
@@ -100,7 +86,7 @@ FormCanvas class >> on: aForm [
 { #category : #caching }
 FormCanvas class >> translucentPatterns [
 
-	^ TranslucentPatterns ifNil: [ self initializeTranslucentPatterns ]
+	^ TranslucentPatterns ifNil: [ TranslucentPatterns := self defaultTranslucentPatterns ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fix wrong defensive strategy in FormCanvas.

In FormCanvas we have a defensive strategy but it miss the return of the variable the first time it is called. It was returning FormCanvas class instead.

This should make CI a little more resilient.