### PR TITLE
Enable CDClassParser in class definition in Calypso

### DIFF
--- a/src/Calypso-SystemTools-Core/CDSharedVariableNode.extension.st
+++ b/src/Calypso-SystemTools-Core/CDSharedVariableNode.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #CDSharedVariableNode }
+
+{ #category : #'*Calypso-SystemTools-Core' }
+CDSharedVariableNode >> asCalypsoVariableOf: aClass [
+
+	| actualClass classVar |
+	actualClass := self classDefinitionNode existingClassIfAbsent: [
+		self error: 'Class is not exists yet'].
+	classVar := actualClass classVariableNamed: name asSymbol.
+	^ClyClassVariable on: classVar definedIn: actualClass
+]

--- a/src/Calypso-SystemTools-Core/CDSlotNode.extension.st
+++ b/src/Calypso-SystemTools-Core/CDSlotNode.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #CDSlotNode }
+
+{ #category : #'*Calypso-SystemTools-Core' }
+CDSlotNode >> asCalypsoVariableOf: aClass [ 
+	
+	| actualClass |
+	actualClass := self classDefinitionNode existingClassIfAbsent: [
+		self error: 'Class is not exists yet'].
+	^actualClass 
+		slotNamed: name asSymbol 
+		ifFound: [:aSlot | 
+			^ClyInstanceVariable on: aSlot definedIn: actualClass] 
+		ifNone: [self error: 'Slot is not created yet']
+]

--- a/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
@@ -60,6 +60,17 @@ ClyClassDefinitionEditorToolMorph >> fillStatusBar [
 	statusBar addCommandItem: (ClySlotClassDefinitionSwitchMorph for: self)
 ]
 
+{ #category : #testing }
+ClyClassDefinitionEditorToolMorph >> isCommandAvailable: aCommand [ 
+
+	^ aCommand canBeExecutedInClassEditor: self
+]
+
+{ #category : #accessing }
+ClyClassDefinitionEditorToolMorph >> parseClassDefinition [
+	^CDClassDefinitionParser parse: self editingText
+]
+
 { #category : #'selecting text' }
 ClyClassDefinitionEditorToolMorph >> selectSourceNode: aCDNode [ 
 	textMorph setSelection: aCDNode sourceInterval
@@ -77,8 +88,12 @@ ClyClassDefinitionEditorToolMorph >> selectVariableNamed: aString [
 
 { #category : #accessing }
 ClyClassDefinitionEditorToolMorph >> selectedSourceNode [
-	self flag: 'Future class parser should be used here'.
-	^nil
+	| selectedInterval definitionNode |
+	selectedInterval := self selectedTextInterval.
+	definitionNode := self parseClassDefinition.
+	
+	^(definitionNode bestNodeFor: selectedInterval)
+		ifNil: [ definitionNode ]
 ]
 
 { #category : #initialization }

--- a/src/Calypso-SystemTools-Core/ClyMethodEditorCommand.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorCommand.class.st
@@ -18,6 +18,12 @@ Class {
 }
 
 { #category : #testing }
+ClyMethodEditorCommand class >> canBeExecutedInClassEditor: aTool [
+
+	^ false
+]
+
+{ #category : #testing }
 ClyMethodEditorCommand class >> canBeExecutedInCodeMethodEditor: aTool [
 	
 	^ true


### PR DESCRIPTION
Enable SourceCodeContext in class definition editor based on class parser node.

It brings following features to the class definition in the browser:
- source code menu (cmd+t) for selected variables and class names
- shortcuts for selected variables and class names (cmd+r for rename)