### PR TITLE
WeakValueDictionary-return-association-with-collectionElements-instead-of-nil

### DIFF
--- a/src/Collections-Support/WeakValueAssociation.class.st
+++ b/src/Collections-Support/WeakValueAssociation.class.st
@@ -1,10 +1,15 @@
 "
 I am a lookup key (acting like an association but) holding only weakly on my value.
+
+I also store the kind of association that was given to the WeakValueDictionary to be able to recreate it in case it is necessary.
 "
 Class {
 	#name : #WeakValueAssociation,
 	#superclass : #LookupKey,
 	#type : #weak,
+	#instVars : [
+		'originalAssociationClass'
+	],
 	#category : #'Collections-Support-Associations'
 }
 
@@ -18,6 +23,11 @@ WeakValueAssociation class >> new [
 	^ self new: 1
 ]
 
+{ #category : #converting }
+WeakValueAssociation >> asOriginalAssociation [
+	^ self originalAssociationClass ifNotNil: [ :class | class key: self key value: self value enclosedElement ] ifNil: [ self ]
+]
+
 { #category : #accessing }
 WeakValueAssociation >> key: aKey value: anObject [ 
 	"Store the arguments as the variables of the receiver."
@@ -26,13 +36,23 @@ WeakValueAssociation >> key: aKey value: anObject [
 	self value: anObject
 ]
 
-{ #category : #evaluating }
-WeakValueAssociation >> value [
-	^self at: 1
+{ #category : #accessing }
+WeakValueAssociation >> originalAssociationClass [
+	^ originalAssociationClass
 ]
 
 { #category : #accessing }
-WeakValueAssociation >> value: anObject [ 
+WeakValueAssociation >> originalAssociationClass: anObject [
+	originalAssociationClass := anObject
+]
+
+{ #category : #evaluating }
+WeakValueAssociation >> value [
+	^ self at: 1
+]
+
+{ #category : #accessing }
+WeakValueAssociation >> value: anObject [
 	"Store the argument, anObject, as the value of the receiver."
 
 	self at: 1 put: anObject

--- a/src/Collections-Support/WeakValueAssociation.class.st
+++ b/src/Collections-Support/WeakValueAssociation.class.st
@@ -5,9 +5,6 @@ Class {
 	#name : #WeakValueAssociation,
 	#superclass : #LookupKey,
 	#type : #weak,
-	#instVars : [
-		'originalAssociationClass'
-	],
 	#category : #'Collections-Support-Associations'
 }
 

--- a/src/Collections-Support/WeakValueAssociation.class.st
+++ b/src/Collections-Support/WeakValueAssociation.class.st
@@ -1,7 +1,5 @@
 "
 I am a lookup key (acting like an association but) holding only weakly on my value.
-
-I also store the kind of association that was given to the WeakValueDictionary to be able to recreate it in case it is necessary.
 "
 Class {
 	#name : #WeakValueAssociation,
@@ -23,27 +21,12 @@ WeakValueAssociation class >> new [
 	^ self new: 1
 ]
 
-{ #category : #converting }
-WeakValueAssociation >> asOriginalAssociation [
-	^ self originalAssociationClass ifNotNil: [ :class | class key: self key value: self value enclosedElement ] ifNil: [ self ]
-]
-
 { #category : #accessing }
 WeakValueAssociation >> key: aKey value: anObject [ 
 	"Store the arguments as the variables of the receiver."
 
 	key := aKey.
 	self value: anObject
-]
-
-{ #category : #accessing }
-WeakValueAssociation >> originalAssociationClass [
-	^ originalAssociationClass
-]
-
-{ #category : #accessing }
-WeakValueAssociation >> originalAssociationClass: anObject [
-	originalAssociationClass := anObject
 ]
 
 { #category : #evaluating }

--- a/src/Collections-Tests/WeakValueDictionaryTest.class.st
+++ b/src/Collections-Tests/WeakValueDictionaryTest.class.st
@@ -132,6 +132,17 @@ WeakValueDictionaryTest >> testKeysAndValuesDoWithGarbageCollectedValue [
 ]
 
 { #category : #tests }
+WeakValueDictionaryTest >> testReturnedAssociationsAreRight [
+	| dictionary |
+	dictionary := self classToBeTested new.
+	dictionary add: (GlobalVariable key: 'test' value: nil).
+	dictionary add: (GlobalVariable key: 'test2' value: 1).
+	self assert: (dictionary associationAt: 'test') value isNil.
+	self assert: (dictionary associationAt: 'test2') value equals: 1.
+	self assert: ((dictionary associationAt: 'test') isKindOf: GlobalVariable)
+]
+
+{ #category : #tests }
 WeakValueDictionaryTest >> testSizeWithGarbageCollectedValue [
 
 	self

--- a/src/Collections-Tests/WeakValueDictionaryTest.class.st
+++ b/src/Collections-Tests/WeakValueDictionaryTest.class.st
@@ -135,11 +135,10 @@ WeakValueDictionaryTest >> testKeysAndValuesDoWithGarbageCollectedValue [
 WeakValueDictionaryTest >> testReturnedAssociationsAreRight [
 	| dictionary |
 	dictionary := self classToBeTested new.
-	dictionary add: (GlobalVariable key: 'test' value: nil).
-	dictionary add: (GlobalVariable key: 'test2' value: 1).
+	dictionary at: 'test' put: nil.
+	dictionary at: 'test2' put: 1.
 	self assert: (dictionary associationAt: 'test') value isNil.
-	self assert: (dictionary associationAt: 'test2') value equals: 1.
-	self assert: ((dictionary associationAt: 'test') isKindOf: GlobalVariable)
+	self assert: (dictionary associationAt: 'test2') value equals: 1
 ]
 
 { #category : #tests }

--- a/src/Collections-Weak/WeakValueDictionary.class.st
+++ b/src/Collections-Weak/WeakValueDictionary.class.st
@@ -16,19 +16,7 @@ Class {
 
 { #category : #adding }
 WeakValueDictionary >> add: anAssociation [
-	"Set the value at key to be anObject.  If key is not found, create a new
-	entry for key and set is value to anObject. Answer anObject."
-
-	| index |
-	index := self findElementOrNil: anAssociation key.
-	(array at: index)
-		ifNil: [ self
-				atNewIndex: index
-				put:
-					((WeakValueAssociation key: anAssociation key value: anAssociation value asCollectionElement)
-						originalAssociationClass: anAssociation class;
-						yourself) ]
-		ifNotNil: [ :element | element value: anAssociation value asSetElement ].
+	self at: anAssociation key put: anAssociation value.
 	^ anAssociation
 ]
 
@@ -39,7 +27,7 @@ WeakValueDictionary >> associationAt: key ifAbsent: aBlock [
 
 	^ (array at: (self findElementOrNil: key))
 		ifNil: [ aBlock value ]
-		ifNotNil: [ :assoc | assoc asOriginalAssociation ]
+		ifNotNil: [ :assoc | assoc key -> assoc value enclosedElement ]
 ]
 
 { #category : #enumerating }

--- a/src/Collections-Weak/WeakValueDictionary.class.st
+++ b/src/Collections-Weak/WeakValueDictionary.class.st
@@ -5,7 +5,7 @@ Clients may expect to get a nil value for any object they request since they can
 Implementation details:
 
 To store keys and values I am using a WeakValueAssociation. This association has a key and a value.
-The key is the key the user is giving me, but I am wrapping the value into a CollectionElementWrapper. This is explained because I need to do a distinction between nil values given by the user and nil values created by the garbage collection.
+The key is the key the user is giving me, but if the user gives me a nil as value, I wrap it into a CollectionElement. This is explained because I need to do a distinction between nil values given by the user and nil values created by the garbage collection.
 When the value of a WeakValueAssociation is a collection element wrapper on nil, then it means the user directly gave us a nil. In case the value of the WeakValueAssociation is nil, it means that we originally had a value that was garbaged collected.
 "
 Class {
@@ -16,8 +16,30 @@ Class {
 
 { #category : #adding }
 WeakValueDictionary >> add: anAssociation [
-	self at: anAssociation key put: anAssociation value.
+	"Set the value at key to be anObject.  If key is not found, create a new
+	entry for key and set is value to anObject. Answer anObject."
+
+	| index |
+	index := self findElementOrNil: anAssociation key.
+	(array at: index)
+		ifNil: [ self
+				atNewIndex: index
+				put:
+					((WeakValueAssociation key: anAssociation key value: anAssociation value asCollectionElement)
+						originalAssociationClass: anAssociation class;
+						yourself) ]
+		ifNotNil: [ :element | element value: anAssociation value asSetElement ].
 	^ anAssociation
+]
+
+{ #category : #adding }
+WeakValueDictionary >> associationAt: key ifAbsent: aBlock [
+	"Answer the association with the given key.
+	If the key is not found, return the result of evaluating aBlock."
+
+	^ (array at: (self findElementOrNil: key))
+		ifNil: [ aBlock value ]
+		ifNotNil: [ :assoc | assoc asOriginalAssociation ]
 ]
 
 { #category : #enumerating }
@@ -76,9 +98,6 @@ WeakValueDictionary >> valuesDo: aBlock [
 
 	tally = 0 ifTrue: [ ^ self ].
 	1 to: array size do: [ :eachIndex | 
-		| eachAssociation eachValue |
-		eachAssociation := array at: eachIndex.
-		nil == eachAssociation value
-			ifFalse: [ eachValue := eachAssociation value enclosedElement.
-				aBlock value: eachValue ] ]
+		(array at: eachIndex) value
+			ifNotNil: [ :assocValue | aBlock value: assocValue enclosedElement ] ]
 ]


### PR DESCRIPTION
Fix bug in WeakValueDictionary when #assotiationAt: was returning the wrong kind of association.

```Smalltalk
testReturnedAssociationsAreRight
	| dictionary |
	dictionary := WeakValueDictionary new.
	dictionary add: (GlobalVariable key: 'test' value: nil).
	dictionary add: (GlobalVariable key: 'test2' value: 1).
	self assert: (dictionary associationAt: 'test') value isNil.
	self assert: (dictionary associationAt: 'test2') value equals: 1.
	self assert: ((dictionary associationAt: 'test') isKindOf: GlobalVariable)
```