### PR TITLE
4403-cannot-change-position-in-a-memory-write-stream

### DIFF
--- a/src/FileSystem-Memory/MemoryFileWriteStream.class.st
+++ b/src/FileSystem-Memory/MemoryFileWriteStream.class.st
@@ -62,6 +62,15 @@ MemoryFileWriteStream >> position [
 ]
 
 { #category : #positioning }
+MemoryFileWriteStream >> position: anInteger [
+	"Set the current position for accessing the objects to be anInteger, as long 
+	as anInteger is within the bounds of the receiver's contents. If it is not, 
+	create an error notification."
+
+	stream position: anInteger
+]
+
+{ #category : #positioning }
 MemoryFileWriteStream >> setToEnd [
 	^ self stream setToEnd
 ]


### PR DESCRIPTION
add missing #position:  in MemoryFileWriteStream. Fixes #4403