### PR TITLE
Roassal3Extentions

### DIFF
--- a/src/Announcements-Core-Tests/AnnouncerSubscriberMockA.class.st
+++ b/src/Announcements-Core-Tests/AnnouncerSubscriberMockA.class.st
@@ -1,0 +1,26 @@
+"
+I am a mock class for testing in announcers
+"
+Class {
+	#name : #AnnouncerSubscriberMockA,
+	#superclass : #Object,
+	#instVars : [
+		'announcer'
+	],
+	#category : #'Announcements-Core-Tests-Mocks'
+}
+
+{ #category : #accessing }
+AnnouncerSubscriberMockA >> announcer [
+	^ announcer
+]
+
+{ #category : #accessing }
+AnnouncerSubscriberMockA >> announcer: anAnnouncer [
+	announcer := anAnnouncer
+]
+
+{ #category : #events }
+AnnouncerSubscriberMockA >> registerEvents [
+	self announcer when: AnnouncementMockA do: [ :evt | " something" ].
+]

--- a/src/Announcements-Core-Tests/AnnouncerSubscriberMockB.class.st
+++ b/src/Announcements-Core-Tests/AnnouncerSubscriberMockB.class.st
@@ -1,0 +1,8 @@
+"
+I am a mock class for testing in announcers
+"
+Class {
+	#name : #AnnouncerSubscriberMockB,
+	#superclass : #AnnouncerSubscriberMockA,
+	#category : #'Announcements-Core-Tests-Mocks'
+}

--- a/src/Announcements-Core-Tests/AnnouncerTest.class.st
+++ b/src/Announcements-Core-Tests/AnnouncerTest.class.st
@@ -33,6 +33,26 @@ AnnouncerTest >> setUp [
 	announcer := self newAnnouncer
 ]
 
+{ #category : #'test - subscribers' }
+AnnouncerTest >> testAccessingSubscribers [
+	"The subscripber class is this test, because this class puts the "
+	| subscribers |
+	subscribers := announcer subscriptionsForClass: self class.
+	self assert: subscribers size equals: 0.
+	
+	announcer when: AnnouncementMockA do: [  ]."1"
+	announcer when: AnnouncementMockB do: [  ]."2"
+	subscribers := announcer subscriptionsForClass: self class.
+	self assert: subscribers size equals: 2.
+	
+	subscribers do: [ :subscriber |	announcer unsubscribe: subscriber ].
+	
+	subscribers := announcer subscriptionsForClass: self class.
+	self assert: subscribers size equals: 0.
+	
+
+]
+
 { #category : #tests }
 AnnouncerTest >> testAnnounceClass [
 	self assert: (announcer announce: AnnouncementMockA) class equals: AnnouncementMockA
@@ -64,6 +84,14 @@ AnnouncerTest >> testAnnouncingReentrant [
 	self assert: ok
 
 
+]
+
+{ #category : #'test - subscribers' }
+AnnouncerTest >> testHandleSubscriberClass [
+	"The subscripber class is this test, because this class puts the "
+	announcer when: AnnouncementMockA do: [  ].
+	self assert: (announcer handleSubscriberClass: self class).
+	self deny: (announcer handleSubscriberClass: AnnouncementMockA).
 ]
 
 { #category : #tests }

--- a/src/Announcements-Core-Tests/AnnouncerTest.class.st
+++ b/src/Announcements-Core-Tests/AnnouncerTest.class.st
@@ -35,7 +35,6 @@ AnnouncerTest >> setUp [
 
 { #category : #'test - subscribers' }
 AnnouncerTest >> testAccessingSubscribers [
-	"The subscripber class is this test, because this class puts the "
 	| subscribers |
 	subscribers := announcer subscriptionsForClass: self class.
 	self assert: subscribers size equals: 0.
@@ -88,7 +87,6 @@ AnnouncerTest >> testAnnouncingReentrant [
 
 { #category : #'test - subscribers' }
 AnnouncerTest >> testHandleSubscriberClass [
-	"The subscripber class is this test, because this class puts the "
 	announcer when: AnnouncementMockA do: [  ].
 	self assert: (announcer handleSubscriberClass: self class).
 	self deny: (announcer handleSubscriberClass: AnnouncementMockA).
@@ -279,6 +277,29 @@ AnnouncerTest >> testSubscribeSubclass [
 	announcement := nil.
 	instance := announcer announce: AnnouncementMockC.
 	self assert: announcement equals: instance
+]
+
+{ #category : #'test - subscribers' }
+AnnouncerTest >> testSubscribersForClass [
+	| subscribers mockA mockB |
+	self assert: announcer numberOfSubscriptions equals: 0.
+	
+	mockA := AnnouncerSubscriberMockA new.
+	mockA announcer: announcer.
+	mockB := AnnouncerSubscriberMockB new.
+	mockB announcer: announcer.
+	mockA registerEvents.
+	mockB registerEvents.
+	
+	self assert: announcer numberOfSubscriptions > 0.
+	subscribers := announcer subscriptionsForClass: AnnouncerSubscriberMockA.
+	self assert: subscribers size equals: 2.
+	"AnnouncerSubscriberMockB inherits AnnouncerSubscriberMockA"
+	subscribers := announcer subscriptionsForClass: AnnouncerSubscriberMockB.
+	self assert: subscribers size equals: 1.
+	subscribers := announcer subscriptionsForClass: self class.
+	self assert: subscribers size equals: 0.
+
 ]
 
 { #category : #tests }

--- a/src/Announcements-Core/Announcer.class.st
+++ b/src/Announcements-Core/Announcer.class.st
@@ -29,6 +29,12 @@ Announcer >> basicSubscribe: subscription [
 ]
 
 { #category : #testing }
+Announcer >> handleSubscriberClass: eventClass [
+	self subscriptions ifNil: [ ^ false ].
+	^ self subscriptions handleSubscriberClass: eventClass
+]
+
+{ #category : #testing }
 Announcer >> hasSubscriber: anObject [
 
 	registry subscriptionsOf: anObject do: [:each | ^ true].
@@ -86,6 +92,12 @@ Announcer >> subscribe: anAnnouncementClass send: aSelector to: anObject [
 Announcer >> subscriptions [
 
 	^ registry
+]
+
+{ #category : #accessing }
+Announcer >> subscriptionsForClass: subscriberClass [
+	"Return the list of subscription for a given class"
+	^ self subscriptions subscriptionsForClass: subscriberClass
 ]
 
 { #category : #subscription }

--- a/src/Announcements-Core/SubscriptionRegistry.class.st
+++ b/src/Announcements-Core/SubscriptionRegistry.class.st
@@ -52,6 +52,14 @@ SubscriptionRegistry >> deliver: anAnnouncement to: subs startingAt: startIndex 
 				self deliver: anAnnouncement to: subs startingAt: index + 1 ]]
 ]
 
+{ #category : #testing }
+SubscriptionRegistry >> handleSubscriberClass: eventClass [
+	"Return true if the receiver has a callback subscripbed for the event class"
+	^ subscriptions anySatisfy: [ :sub | 
+		(sub subscriber class == eventClass) or: 
+			[ sub subscriber class includesBehavior: eventClass ] ]
+]
+
 { #category : #initialization }
 SubscriptionRegistry >> initialize [
 	monitor := Semaphore forMutualExclusion.
@@ -111,6 +119,16 @@ SubscriptionRegistry >> reset [
 { #category : #accessing }
 SubscriptionRegistry >> subscriptions [
 	^ subscriptions
+]
+
+{ #category : #accessing }
+SubscriptionRegistry >> subscriptionsForClass: subscriberClass [
+	"Return the list of subscription for a given class"
+	^ Array streamContents: [ :s|
+			subscriptions do: [:each| 
+				(each subscriber class == subscriberClass 
+				 or: [each subscriber class includesBehavior: subscriberClass])
+					ifTrue: [ s nextPut: each subscriber ]]]
 ]
 
 { #category : #accessing }

--- a/src/Athens-Cairo/AthensCairoCanvas.class.st
+++ b/src/Athens-Cairo/AthensCairoCanvas.class.st
@@ -96,6 +96,13 @@ AthensCairoCanvas >> fill [
 
 ]
 
+{ #category : #'ffi-calls' }
+AthensCairoCanvas >> fillPreserve [
+	^ self nbCall: #(#void #cairo_fill_preserve #(#self))
+
+	
+]
+
 { #category : #accessing }
 AthensCairoCanvas >> fillRule [
 	^ self ffiCall: #( cairo_fill_rule_t cairo_get_fill_rule ( self ) )
@@ -391,6 +398,14 @@ void                cairo_text_extents                  (cairo_t *cr,
 "
 	^ self ffiCall: #( void cairo_text_extents (self, char * utf8String, cairo_text_extents_t * extentsObj) )
 	
+]
+
+{ #category : #'ffi-calls' }
+AthensCairoCanvas >> textPath: anUTF8String [
+	"A drawing operator that generates the shape from a string of UTF-8 characters, rendered according to the current font_face, font_size (font_matrix), and font_options. "
+	
+	^ self nbCall: #(void cairo_text_path (self, char * anUTF8String ))
+
 ]
 
 { #category : #'path segments visitor' }

--- a/src/Athens-Examples/AthensCairoSurfaceExamples.class.st
+++ b/src/Athens-Examples/AthensCairoSurfaceExamples.class.st
@@ -8,6 +8,50 @@ Class {
 }
 
 { #category : #examples }
+AthensCairoSurfaceExamples class >> exampleDrawTextPath [
+ 
+	| surf  font |
+	font := LogicalFont familyName: 'Source Sans Pro' pointSize: 40.
+
+	surf := self newSurface: 500@100.
+	
+	surf drawDuring: [:can |
+		| f |
+		"clear background"
+		surf clear: Color white.
+		
+		f := CairoScaledFont fromFreetypeFont: font realFont. 
+		"Set text position"
+		can pathTransform translateX: 10 Y: (font getPreciseAscent)+10.
+		"new path to draw the string"
+		can newPath.
+		
+		f lock.
+		"set font properties"
+		can 
+			setPathMatrix;
+			setScaledFont: f.
+		(Color red asAthensPaintOn: can)
+			loadOnCairoCanvas: can.
+		"creates a path text"
+		can textPath: 'Text with border :V'.
+		"It fills and preserve the last path"
+		can fillPreserve.
+		
+		(can setStrokePaint: Color black)
+			width: 2;
+			dashes: #(10 1) offset: 0;
+			"in order to use the path of cairo"
+			prepareForDrawingOn: can.
+		can stroke.
+		f unlock.
+	].
+	
+	Display getCanvas drawImage: surf asForm at: 0@0
+
+]
+
+{ #category : #examples }
 AthensCairoSurfaceExamples class >> exampleInterop [
 
 "

--- a/src/Graphics-Tests/RectangleTest.class.st
+++ b/src/Graphics-Tests/RectangleTest.class.st
@@ -200,6 +200,29 @@ RectangleTest >> testFlipByCenterAt [
 ]
 
 { #category : #tests }
+RectangleTest >> testFloatCenter [ 
+	| r1 c |
+	r1 := 0@0 extent: 11@21.
+	c := r1 floatCenter.
+	self assert: (r1 containsPoint: c) description: 'the center is inside the rectangle'.
+	self assert: (r1 topLeft distanceTo: c) equals: (r1 bottomRight distanceTo: c).
+	self assert: (r1 bottomLeft distanceTo: c) equals: (r1 topRight distanceTo: c).
+	self assert: (r1 topLeft distanceTo: c) equals: (r1 bottomLeft distanceTo: c).
+	self assert: (r1 translateBy: -20@10) floatCenter = (c translateBy: -20@10) description: 'the center is translated with the rectangle'
+]
+
+{ #category : #tests }
+RectangleTest >> testFloatCenterExtent [
+	| r1 c |
+	r1 := Rectangle 
+		floatCenter: 1.3@1.3 asPoint
+		extent: 4.4 asPoint.
+	c := r1 floatCenter.
+	self assert: c equals: r1 floatCenter.
+	
+]
+
+{ #category : #tests }
 RectangleTest >> testInsettingByNumberShouldWork [
 
 	| rec1 rec2 |

--- a/src/Graphics-Tests/RectangleTest.class.st
+++ b/src/Graphics-Tests/RectangleTest.class.st
@@ -215,11 +215,19 @@ RectangleTest >> testFloatCenter [
 RectangleTest >> testFloatCenterExtent [
 	| r1 c |
 	r1 := Rectangle 
-		floatCenter: 1.3@1.3 asPoint
+		floatCenter: 1.3@1.3
 		extent: 4.4 asPoint.
 	c := r1 floatCenter.
-	self assert: c equals: r1 floatCenter.
-	
+	self
+		assert: (c closeTo: 1.3@1.3);
+		assert: (r1 topLeft distanceTo: c) 
+			equals: (r1 bottomRight distanceTo: c);
+		assert: (r1 bottomLeft distanceTo: c) 
+			equals: (r1 topRight distanceTo: c);
+		assert: (r1 topLeft distanceTo: c)
+			equals: (r1 bottomLeft distanceTo: c);
+		assert: ((r1 translateBy: -20@10) floatCenter closeTo: (c translateBy: -20@10))
+			description: 'the center is translated with the rectangle'
 ]
 
 { #category : #tests }

--- a/src/Kernel/Rectangle.class.st
+++ b/src/Kernel/Rectangle.class.st
@@ -32,8 +32,7 @@ Class {
 
 { #category : #'instance creation' }
 Rectangle class >> center: centerPoint extent: extentPoint [ 
-	"Answer an instance of me whose center is centerPoint and width 
-	by height is extentPoint.  "
+	"Answer an instance of me whose center is centerPoint asInteger  "
 
 	^self origin: centerPoint - (extentPoint//2) extent: extentPoint
 ]
@@ -47,6 +46,13 @@ Rectangle class >> encompassing: listOfPoints [
 		topLeft := topLeft min: p.
 		bottomRight := bottomRight max: p ].
 	^ topLeft corner: bottomRight
+]
+
+{ #category : #'instance creation' }
+Rectangle class >> floatCenter: centerPoint extent: extentPoint [ 
+	"Answer an instance of me whose center is centerPoint and width 
+	by height is extentPoint."
+	^self origin: centerPoint - (extentPoint/2.0) extent: extentPoint
 ]
 
 { #category : #'instance creation' }
@@ -438,6 +444,12 @@ Rectangle >> flipBy: direction centerAt: aPoint [
 	"Return a copy flipped #vertical or #horizontal, about aPoint."
 	^ (origin flipBy: direction centerAt: aPoint)
 		rectangle: (corner flipBy: direction centerAt: aPoint)
+]
+
+{ #category : #accessing }
+Rectangle >> floatCenter [
+	"Answer the point at the center of the receiver."
+	^ self topLeft + self bottomRight / 2.0
 ]
 
 { #category : #'truncation and roundoff' }

--- a/src/Kernel/Rectangle.class.st
+++ b/src/Kernel/Rectangle.class.st
@@ -448,7 +448,7 @@ Rectangle >> flipBy: direction centerAt: aPoint [
 
 { #category : #accessing }
 Rectangle >> floatCenter [
-	"Answer the point at the center of the receiver."
+	"Answer the float point at the center of the receiver."
 	^ self topLeft + self bottomRight / 2.0
 ]
 


### PR DESCRIPTION
Simple extension for 

- Rectangle, floatCenter, because #center in Rectangle returns the Integer Point and not the Float Point
- Announcer(accessing subscribers by class), Useful to know the subscriber for the announcer.

from Roassal3 package