### PR TITLE
4406-fix-class-def-parser-for-simple-definitions

### DIFF
--- a/src/ClassParser/CDClassDefinitionParser.class.st
+++ b/src/ClassParser/CDClassDefinitionParser.class.st
@@ -199,7 +199,6 @@ CDClassDefinitionParser >> parseSlotNode: aRBMessageNode [
 			^ self ].
 
 	"If we are here we did not recognize the slot syntax"
-	self halt
 ]
 
 { #category : #parsing }

--- a/src/ClassParser/CDClassDefinitionParser.class.st
+++ b/src/ClassParser/CDClassDefinitionParser.class.st
@@ -175,20 +175,31 @@ CDClassDefinitionParser >> parseSelectorPart: aString withArgument: aNode [
 
 { #category : #parsing }
 CDClassDefinitionParser >> parseSlotNode: aRBMessageNode [
-	
-	aRBMessageNode selector = '=>' ifTrue: [ | slot |
-		slot := CDSlotNode
-			node: aRBMessageNode
-			name: aRBMessageNode receiver value
-			typeName: aRBMessageNode arguments first name
-			start: aRBMessageNode start
-			stop: aRBMessageNode stop.
-		classDefinition addSlot: slot.
-		^ self
-	].
+	aRBMessageNode isLiteralNode
+		ifTrue: [ | slot |
+			slot := CDSlotNode
+				node: aRBMessageNode
+				name: aRBMessageNode value
+				typeName: aRBMessageNode value
+				start: aRBMessageNode start
+				stop: aRBMessageNode stop.
+			classDefinition addSlot: slot.
+			^ self ].
+		
+	self flag: #fixme. "This seems to not support Slots with Parameters for now".
+	aRBMessageNode selector = '=>'
+		ifTrue: [ | slot |
+			slot := CDSlotNode
+				node: aRBMessageNode
+				name: aRBMessageNode receiver value
+				typeName: aRBMessageNode arguments first name
+				start: aRBMessageNode start
+				stop: aRBMessageNode stop.
+			classDefinition addSlot: slot.
+			^ self ].
 
 	"If we are here we did not recognize the slot syntax"
-	self halt.
+	self halt
 ]
 
 { #category : #parsing }


### PR DESCRIPTION
support simplified slot defintions (using #symbol). fixes #4406