### PR TITLE
Monticello-should-use-new-class-definition

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -1025,8 +1025,8 @@ ClassDescription >> oldDefinition [
 			store: self classVariablesString.
 	aStream cr; tab; nextPutAll: 'poolDictionaries: ';
 			store: self sharedPoolsString.
-	aStream cr; tab; nextPutAll: 'category: ';
-			store: self category asString.
+	aStream cr; tab; nextPutAll: 'package: ';
+			store: self package name asString.
 
 	superclass ifNil: [ 
 		aStream nextPutAll: '.'; cr.

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -95,7 +95,7 @@ MCClassDefinitionTest >> testCreation [
 MCClassDefinitionTest >> testDefinitionString [
 	| d |
 	d := self mockClassA asClassDefinition.
-	self assert: d definitionString equals: self mockClassA oldDefinition.
+	self assert: d definitionString equals: self mockClassA oldDefinition
 ]
 
 { #category : #tests }

--- a/src/Monticello-Tests/MCStWriterTest.class.st
+++ b/src/Monticello-Tests/MCStWriterTest.class.st
@@ -49,7 +49,7 @@ MCMock subclass: #MCMockClassA
 	instanceVariableNames: ''ivar''
 	classVariableNames: ''CVar InitializationOrder''
 	poolDictionaries: ''''
-	category: ''MonticelloMocks''!
+	package: ''MonticelloMocks''!
 
 !MCMockClassA commentStamp: '''' prior: 0!
 This is a mock class. The Monticello tests manipulated it to simulate a developer modifying code in the image.!
@@ -63,7 +63,7 @@ MCMock subclass: #MCMockClassB
 	instanceVariableNames: ''ivarb''
 	classVariableNames: ''CVar''
 	poolDictionaries: ''MCMockAPoolDictionary''
-	category: ''MonticelloMocks''!
+	package: ''MonticelloMocks''!
 
 MCMockClassB class
 	instanceVariableNames: ''ciVar''!

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -475,7 +475,7 @@ MCClassDefinition >> printDefinitionOn: stream [
 			nextPutAll: 'poolDictionaries: ';
 			store: self sharedPoolsString;
 			cr; tab;
-			nextPutAll: 'category: ';
+			nextPutAll: 'package: ';
 			store: self category asString
 ]
 


### PR DESCRIPTION
Update Monticello to print class definition using #package: instead of #category: