### PR TITLE
4433-Pragmakeyword-should-be-deprecated-via-deprecation-mechanism

### DIFF
--- a/src/Clap-Core/ClapContext.class.st
+++ b/src/Clap-Core/ClapContext.class.st
@@ -37,7 +37,7 @@ ClapContext class >> defaultRoot [
 
 { #category : #accessing }
 ClapContext class >> pragmaCommands [
-	^ (PragmaCollector filter: [:prg | prg keyword = 'commandline']) reset
+	^ (PragmaCollector filter: [:prg | prg selector = 'commandline']) reset
 		collect: [ :pragma |
 			| theClass theSelector |
 			theClass := pragma method methodClass.

--- a/src/ClassAnnotation/ClassAnnotationRegistry.class.st
+++ b/src/ClassAnnotation/ClassAnnotationRegistry.class.st
@@ -67,7 +67,7 @@ ClassAnnotationRegistry class >> annotationPragmaName [
 ClassAnnotationRegistry class >> annotationPragmasIn: aClass do: aBlock [
 
 	Pragma withPragmasIn: aClass do: [ :pragma |
-		pragma keyword == self annotationPragmaName ifTrue: [aBlock value: pragma]]
+		pragma selector == self annotationPragmaName ifTrue: [aBlock value: pragma]]
 ]
 
 { #category : #'pragma collecting' }

--- a/src/Deprecated80/Pragma.extension.st
+++ b/src/Deprecated80/Pragma.extension.st
@@ -1,0 +1,33 @@
+Extension { #name : #Pragma }
+
+{ #category : #'*Deprecated80' }
+Pragma >> keyword [
+	self
+		deprecated: 'Use #selector instead.'
+		transformWith: '`@receiver keyword' -> '`@receiver selector'.
+	^ self selector
+]
+
+{ #category : #'*Deprecated80' }
+Pragma >> setArguments: anArray [
+	self
+		deprecated: 'Use #arguments: instead.'
+		transformWith: '`@receiver setArguments: `@arg' -> '`@receiver arguments: `@arg'.
+	self arguments: anArray
+]
+
+{ #category : #'*Deprecated80' }
+Pragma >> setKeyword: aSymbol [
+	self
+		deprecated: 'Use #selector: instead.'
+		transformWith: '`@receiver setKeyword: `@arg' -> '`@receiver selector: `@arg'.
+	self selector: aSymbol
+]
+
+{ #category : #'*Deprecated80' }
+Pragma >> setMethod: aCompiledMethod [
+	self
+		deprecated: 'Use #method: instead.'
+		transformWith: '`@receiver setMethod: `@arg' -> '`@receiver method: `@arg'.
+	self method: aCompiledMethod
+]

--- a/src/Deprecated80/Pragma.extension.st
+++ b/src/Deprecated80/Pragma.extension.st
@@ -9,6 +9,15 @@ Pragma >> keyword [
 ]
 
 { #category : #'*Deprecated80' }
+Pragma class >> keyword: aSymbol arguments: anArray [
+	self
+		deprecated: 'Use #selector:arguments: instead.'
+		transformWith: '`@receiver keyword: `@arg1 arguments: `@arg2' -> '`@receiver selector: `@arg1 arguments: `@arg2'.
+	
+	^ self selector: aSymbol arguments: anArray
+]
+
+{ #category : #'*Deprecated80' }
 Pragma >> setArguments: anArray [
 	self
 		deprecated: 'Use #arguments: instead.'

--- a/src/FFI-Kernel/ExternalStructure.class.st
+++ b/src/FFI-Kernel/ExternalStructure.class.st
@@ -414,7 +414,7 @@ ExternalStructure class >> shouldGenerate: fieldname policy: aSymbol [
 	aSymbol = #generated
 		ifTrue: [^ (self methodDictionary includesKey: fieldname)
 				and: [(self methodDictionary at: fieldname) pragmas
-						anySatisfy: [:p | p keyword = #generated]]].
+						anySatisfy: [:p | p selector = #generated]]].
 	self error: 'unknow generation policy'
 ]
 

--- a/src/Flashback-Decompiler/FBDDecompiler.class.st
+++ b/src/Flashback-Decompiler/FBDDecompiler.class.st
@@ -199,7 +199,7 @@ FBDDecompiler >> errorCodeNameFor: cm [
 	"Assumes the method holds a primitive with error code"
 	| primitivePragma selectorParts |
 	primitivePragma := cm pragmas detect: [ :pragma | 
-		selectorParts := pragma keyword separateKeywords splitOn: '  '.
+		selectorParts := pragma selector separateKeywords splitOn: '  '.
 		selectorParts first = 'primitive:' ].
 	^ primitivePragma argumentAt: (selectorParts indexOf: 'error:')
 ]
@@ -451,7 +451,7 @@ FBDDecompiler >> popIntoTemporaryVariable: offset [
 FBDDecompiler >> pragmasForMethod: aCompiledMethod [
 	^ aCompiledMethod pragmas collect: [ :each |
 		RBPragmaNode 
-			selector: each keyword 
+			selector: each selector 
 			arguments: (each arguments collect: [ :arg | RBLiteralNode value: arg ]) ]
 ]
 

--- a/src/Fuel-Platform-Core/FLPlatform.class.st
+++ b/src/Fuel-Platform-Core/FLPlatform.class.st
@@ -64,7 +64,7 @@ FLPlatform class >> extensionPragmas [
 			self class withAllSuperclassesDo: [ :class |
 				stop ifFalse: [
 					Pragma withPragmasIn: class do:  [ :pragma |
-						(pragma keyword = selector and: [
+						(pragma selector = selector and: [
 							"don't collect overridden methods"
 							(pragmas includesKey: pragma selector) not ]) ifTrue: [
 								pragmas

--- a/src/GT-InspectorExtensions-Core/CompiledCode.extension.st
+++ b/src/GT-InspectorExtensions-Core/CompiledCode.extension.st
@@ -65,7 +65,7 @@ CompiledCode >> gtInspectorPragmasIn: composite [
 						| methods | 
 						methods := OrderedCollection new.
 						Object withAllSubclassesDo: [ :each | 
-							methods addAll: ((Pragma allNamed: pragma keyword in: each) collect: #method) ].
+							methods addAll: ((Pragma allNamed: pragma selector in: each) collect: #method) ].
 						methods ];
 					format: #selector ].
 			t transmit

--- a/src/GT-InspectorExtensions-Core/Pragma.extension.st
+++ b/src/GT-InspectorExtensions-Core/Pragma.extension.st
@@ -20,7 +20,7 @@ Pragma class >> gtInspectorAnnotatedMethodsIn: composite [
 			Object withAllSubclassesDo: [:each |
 				Pragma withPragmasIn: each do: [:p |
 					pragmas add: p]].
-			(pragmas groupedBy: #keyword) associations sorted: [ :a :b | 
+			(pragmas groupedBy: #selector) associations sorted: [ :a :b | 
 				a key < b key ]
 		];
 		column: 'Keyword' evaluated: [ :each | each key ];

--- a/src/GT-SpotterExtensions-Core/GTSpotter.extension.st
+++ b/src/GT-SpotterExtensions-Core/GTSpotter.extension.st
@@ -246,12 +246,12 @@ GTSpotter >> spotterForPackagesFor: aStep [
 { #category : #'*GT-SpotterExtensions-Core' }
 GTSpotter >> spotterForPragmasFor: aStep [
 	<spotterOrder: 40>
-	aStep listProcessor 
-			allCandidates: [ Pragma allInstances collect: [ :e | e keyword ] as: Set ];
-			title: 'Pragmas';
-			itemName: [ :pragma | pragma ];
-			filter: self defaultFilterClass;
-			wantsToDisplayOnEmptyQuery: false
+	aStep listProcessor
+		allCandidates: [ Pragma allInstances collect: [ :e | e selector ] as: Set ];
+		title: 'Pragmas';
+		itemName: [ :pragma | pragma ];
+		filter: self defaultFilterClass;
+		wantsToDisplayOnEmptyQuery: false
 ]
 
 { #category : #'*GT-SpotterExtensions-Core' }

--- a/src/GT-SpotterExtensions-Core/PragmaType.class.st
+++ b/src/GT-SpotterExtensions-Core/PragmaType.class.st
@@ -26,7 +26,7 @@ PragmaType class >> all [
 	Object withAllSubclassesDo: [:each |
 		Pragma withPragmasIn: each do: [:p |
 			pragmas add: p]].
-	^ (pragmas groupedBy: #keyword) associations collect: [ :association |
+	^ (pragmas groupedBy: #selector) associations collect: [ :association |
 		PragmaType new
 			keyword: association key; 
 			pragmas: association value ] 
@@ -72,7 +72,7 @@ PragmaType >> pragmas [
 		pragmas := OrderedCollection new.
 		SystemNavigation new allBehaviorsDo: [ :each |
 			Pragma withPragmasIn: each do: [ :p |
-				p keyword = self keyword ifTrue: [ 
+				p selector = self selector ifTrue: [ 
 					pragmas add: p ] ] ].
 		pragmas ]
 ]

--- a/src/GT-Tests-Spotter/GTSpotterStepTest.class.st
+++ b/src/GT-Tests-Spotter/GTSpotterStepTest.class.st
@@ -214,7 +214,7 @@ GTSpotterStepTest >> implementors: aSelector inPackages: anArray [
 { #category : #'private-navigation' }
 GTSpotterStepTest >> pragma: aSelector of: aCompiledMethod [
 	^ aCompiledMethod pragmas 
-		detect: [ :each | each keyword = aSelector ] 
+		detect: [ :each | each selector = aSelector ] 
 		ifNone: [ nil ]
 ]
 
@@ -233,7 +233,7 @@ GTSpotterStepTest >> pragmas: aSelector inPackages: anArray [
 				package methods do: [ :cm | 
 					cm methodClass isTrait ifFalse: [ 
 						(cm pragmas 
-							detect: [ :p | p keyword = aSelector ] 
+							detect: [ :p | p selector = aSelector ] 
 							ifNone: [ nil ]) ifNotNil: [ :p | pragmas add: p ] ] ] ] ] ].
 	^ pragmas
 ]

--- a/src/HelpSystem-Core/SystemHelp.class.st
+++ b/src/HelpSystem-Core/SystemHelp.class.st
@@ -51,7 +51,7 @@ SystemHelp class >> createHelpTopic [
 SystemHelp class >> pragmaCollector [
 	^ pragmaCollector
 		ifNil: [ pragmaCollector := (PragmaCollector
-				filter: [ :prag | prag keyword = self pragmaKeyword ])
+				filter: [ :prag | prag selector = self pragmaKeyword ])
 				reset;
 				whenChangedDo: [ self resetHelpTopic ];
 				yourself ]

--- a/src/HelpSystem-Core/WikiStyleHelpBuilder.class.st
+++ b/src/HelpSystem-Core/WikiStyleHelpBuilder.class.st
@@ -29,7 +29,7 @@ Class {
 
 { #category : #'private accessing' }
 WikiStyleHelpBuilder class >> allHelpPragmas [
-	 ^(PragmaCollector filter: [:pragma | self pragmaKeywords includes: pragma keyword]) reset collected
+	 ^(PragmaCollector filter: [:pragma | self pragmaKeywords includes: pragma selector]) reset collected
 
 ]
 

--- a/src/Hermes-Extensions/HEDuplicationModeStrategy.class.st
+++ b/src/Hermes-Extensions/HEDuplicationModeStrategy.class.st
@@ -13,7 +13,7 @@ Class {
 { #category : #'as yet unclassified' }
 HEDuplicationModeStrategy class >> forOption: keyword [
 	^ (self allSubclasses
-		detect: [ :e | e selector = keyword ]
+		detect: [ :e | e keyword = keyword ]
 		ifNone: [ self error: 'There is no duplication strategy for ''' , keyword , '''' ]) new
 ]
 

--- a/src/Hermes-Extensions/HEDuplicationModeStrategy.class.st
+++ b/src/Hermes-Extensions/HEDuplicationModeStrategy.class.st
@@ -13,7 +13,7 @@ Class {
 { #category : #'as yet unclassified' }
 HEDuplicationModeStrategy class >> forOption: keyword [
 	^ (self allSubclasses
-		detect: [ :e | e keyword = keyword ]
+		detect: [ :e | e selector = keyword ]
 		ifNone: [ self error: 'There is no duplication strategy for ''' , keyword , '''' ]) new
 ]
 

--- a/src/Hermes/HEPragma.class.st
+++ b/src/Hermes/HEPragma.class.st
@@ -53,6 +53,6 @@ HEPragma >> method [
 { #category : #accessing }
 HEPragma >> value: aPragma [
 	method := aPragma method asExportedLiteral.
-	keyword := aPragma keyword asExportedLiteral.
+	keyword := aPragma selector asExportedLiteral.
 	arguments := aPragma arguments asExportedLiteral 
 ]

--- a/src/Kernel-Tests/PragmaTest.class.st
+++ b/src/Kernel-Tests/PragmaTest.class.st
@@ -32,7 +32,7 @@ PragmaTest >> testCopy [
 
 	self deny: atPragma == copy.
 	self assert: atPragma method == copy method.
-	self assert: atPragma keyword == copy keyword.
+	self assert: atPragma selector == copy selector.
 	self assert: atPragma arguments == copy arguments.
 ]
 

--- a/src/Kernel/AdditionalMethodState.class.st
+++ b/src/Kernel/AdditionalMethodState.class.st
@@ -257,7 +257,7 @@ AdditionalMethodState >> keysAndValuesDo: aBlock [
 		| propertyOrPragma "<Association|Pragma>" |
 		(propertyOrPragma := self basicAt: i) isVariableBinding
 			ifTrue: [aBlock value: propertyOrPragma key value: propertyOrPragma value]
-			ifFalse: [aBlock value: propertyOrPragma keyword value: propertyOrPragma]]
+			ifFalse: [aBlock value: propertyOrPragma selector value: propertyOrPragma]]
 ]
 
 { #category : #accessing }
@@ -373,7 +373,7 @@ AdditionalMethodState >> removeKey: aKey ifAbsent: aBlock [
 		propertyOrPragma := self basicAt: i.
 		(propertyOrPragma isVariableBinding
 				ifTrue: [propertyOrPragma key]
-				ifFalse: [propertyOrPragma keyword])
+				ifFalse: [propertyOrPragma selector])
 			== aKey ifTrue:
 			[^method removeProperty: aKey]].
 	^aBlock value
@@ -392,8 +392,8 @@ AdditionalMethodState >> selector: aSymbol [
 { #category : #accessing }
 AdditionalMethodState >> setMethod: aMethod [
 	method := aMethod.
-	1 to: self basicSize do:
-		[:i| | propertyOrPragma "<Association|Pragma>" |
-		(propertyOrPragma := self basicAt: i) isVariableBinding ifFalse:
-			[propertyOrPragma setMethod: aMethod]]
+	1 to: self basicSize do: [ :i | 
+		| propertyOrPragma	"<Association|Pragma>" |
+		(propertyOrPragma := self basicAt: i) isVariableBinding
+			ifFalse: [ propertyOrPragma method: aMethod ] ]
 ]

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -565,7 +565,7 @@ CompiledCode >> primitiveErrorVariableName [
 	self isPrimitive ifTrue:
 		[self pragmas do:
 			[:pragma| | kwds ecIndex |
-			((kwds := pragma keyword keywords) first = 'primitive:'
+			((kwds := pragma selector keywords) first = 'primitive:'
 			and: [(ecIndex := kwds indexOf: 'error:') > 0]) ifTrue:
 				[^pragma argumentAt: ecIndex]]].
 	^nil

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -734,7 +734,7 @@ CompiledMethod >> postCopy [
 	| penultimateLiteral |
 	(penultimateLiteral := self penultimateLiteral) isMethodProperties ifTrue:
 		[self penultimateLiteral: (penultimateLiteral copy
-									setMethod: self;
+									method: self;
 									yourself).
 		 self penultimateLiteral pragmas do:
 			[:p| p setMethod: self]]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -450,7 +450,7 @@ CompiledMethod >> getSourceReplacingSelectorWith: newSelector [
 
 { #category : #'accessing-pragmas & properties' }
 CompiledMethod >> hasPragmaNamed: aSymbol [
-	^ self pragmas anySatisfy: [ :pragma | pragma keyword = aSymbol ]
+	^ self pragmas anySatisfy: [ :pragma | pragma selector = aSymbol ]
 ]
 
 { #category : #testing }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -737,7 +737,7 @@ CompiledMethod >> postCopy [
 									method: self;
 									yourself).
 		 self penultimateLiteral pragmas do:
-			[:p| p setMethod: self]]
+			[:p| p method: self]]
 
 ]
 

--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -168,12 +168,6 @@ Pragma >> key [
 	^self selector
 ]
 
-{ #category : #'to be deprecated' }
-Pragma >> keyword [
-	"to be deprecated for #selector"
-	^ self selector
-]
-
 { #category : #accessing }
 Pragma >> message [
 	"Answer the message of the receiving pragma."
@@ -245,24 +239,6 @@ Pragma >> sendTo: anObject [
 	"Send the pragma keyword together with its arguments to anObject and answer the result."
 	
 	^ anObject perform: self keyword withArguments: self arguments
-]
-
-{ #category : #'to be deprecated' }
-Pragma >> setArguments: anArray [
-	"to be deprecated for #arguments:"
-	arguments := anArray
-]
-
-{ #category : #'to be deprecated' }
-Pragma >> setKeyword: aSymbol [
-	"to be deprecated for #selector:"
-	self selector: aSymbol
-]
-
-{ #category : #'to be deprecated' }
-Pragma >> setMethod: aCompiledMethod [
-	"to be deprecated for #method:"
-	method := aCompiledMethod
 ]
 
 { #category : #processing }

--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -26,14 +26,18 @@ Class {
 { #category : #finding }
 Pragma class >> allNamed: aSymbol from: aSubClass to: aSuperClass [
 	"Answer a collection of all pragmas found in methods of all classes between aSubClass and aSuperClass (inclusive) whose keyword is aSymbol."
-	
-	^ Array streamContents: [ :stream |
-		aSubClass withAllSuperclassesDo: [ :class |
-			self withPragmasIn: class do:  [ :pragma |
-				pragma keyword = aSymbol
-					ifTrue: [ stream nextPut: pragma ] ].
-			aSuperClass = class
-				ifTrue: [ ^ stream contents ] ] ].
+
+	^ Array
+		streamContents: [ :stream | 
+			aSubClass
+				withAllSuperclassesDo: [ :class | 
+					self
+						withPragmasIn: class
+						do: [ :pragma | 
+							pragma selector = aSymbol
+								ifTrue: [ stream nextPut: pragma ] ].
+					aSuperClass = class
+						ifTrue: [ ^ stream contents ] ] ]
 ]
 
 { #category : #finding }
@@ -52,11 +56,11 @@ Pragma class >> allNamed: aSymbol from: aSubClass to: aSuperClass sortedUsing: a
 
 { #category : #finding }
 Pragma class >> allNamed: aSymbol in: aClass [
-	"Answer a collection of all pragmas found in methods of aClass whose keyword is aSymbol."
+	"Answer a collection of all pragmas found in methods of aClass whose selector is aSymbol."
 	
 	^ Array streamContents: [ :stream |
 		self withPragmasIn: aClass do: [ :pragma |
-			pragma keyword = aSymbol
+			pragma selector = aSymbol
 				ifTrue: [ stream nextPut: pragma ] ] ].
 ]
 
@@ -77,18 +81,18 @@ Pragma class >> allNamed: aSymbol in: aClass sortedUsing: aSortBlock [
 { #category : #'instance creation' }
 Pragma class >> for: aMethod selector: aSelector arguments: anArray [
 	^self new
-		setMethod: aMethod;
-		setKeyword: aSelector;
-		setArguments: anArray;
+		method aMethod;
+		selector: aSelector;
+		arguments: anArray;
 		yourself
 ]
 
 { #category : #private }
-Pragma class >> keyword: aSymbol arguments: anArray [
+Pragma class >> selector: aSymbol arguments: anArray [
 	^ self new
-		setKeyword: aSymbol;
-		setArguments: anArray;
-		yourself.
+		selector: aSymbol;
+		arguments: anArray;
+		yourself
 ]
 
 { #category : #private }
@@ -104,7 +108,7 @@ Pragma >> = aPragma [
 
 	self method = aPragma method ifFalse: [^false].
 	self method selector = aPragma method selector ifFalse: [ ^false ].
-	self keyword = aPragma keyword ifFalse: [^false].
+	self selector = aPragma selector ifFalse: [^false].
 	self arguments = aPragma arguments ifFalse: [^false].
 
 	^true.
@@ -155,7 +159,7 @@ Pragma >> hash [
 
 	| hash |
 
-	hash := self method hash bitXor: self keyword hash.
+	hash := self method hash bitXor: self selector hash.
 	1 to: self basicSize do: [:index | hash := hash bitXor: (self basicAt: index) hash].
 
 	^hash.
@@ -212,10 +216,10 @@ Pragma >> numArgs [
 { #category : #printing }
 Pragma >> printOn: aStream [
 	aStream nextPut: $<.
-	self keyword precedence = 1
-		ifTrue: [ aStream nextPutAll: self keyword ]
+	self selector precedence = 1
+		ifTrue: [ aStream nextPutAll: self selector ]
 		ifFalse: [
-			self keyword keywords with: self arguments do: [ :key :arg |
+			self selector keywords with: self arguments do: [ :key :arg |
 				aStream nextPutAll: key; space; print: arg; space ].
 			aStream skip: -1 ].
 	aStream nextPut: $>.
@@ -238,7 +242,7 @@ Pragma >> selector: aSymbol [
 Pragma >> sendTo: anObject [
 	"Send the pragma keyword together with its arguments to anObject and answer the result."
 	
-	^ anObject perform: self keyword withArguments: self arguments
+	^ anObject perform: self selector withArguments: self arguments
 ]
 
 { #category : #processing }

--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -81,7 +81,7 @@ Pragma class >> allNamed: aSymbol in: aClass sortedUsing: aSortBlock [
 { #category : #'instance creation' }
 Pragma class >> for: aMethod selector: aSelector arguments: anArray [
 	^self new
-		method aMethod;
+		method: aMethod;
 		selector: aSelector;
 		arguments: anArray;
 		yourself

--- a/src/Keymapping-Core/CompiledMethod.extension.st
+++ b/src/Keymapping-Core/CompiledMethod.extension.st
@@ -2,6 +2,5 @@ Extension { #name : #CompiledMethod }
 
 { #category : #'*Keymapping-Core' }
 CompiledMethod >> isShortcutDeclaration [
-
-	^self pragmas anySatisfy: [ :p | p keyword = #shortcut ]
+	^ self pragmas anySatisfy: [ :p | p selector = #shortcut ]
 ]

--- a/src/Keymapping-Pragmas/KMPragmaKeymapBuilder.class.st
+++ b/src/Keymapping-Pragmas/KMPragmaKeymapBuilder.class.st
@@ -20,7 +20,7 @@ Class {
 { #category : #private }
 KMPragmaKeymapBuilder class >> event: anEvent [
 	anEvent method ifNil: [ ^self ].
-	((anEvent method pragmas collect: #keyword) includesAnyOf: self pragmas )
+	((anEvent method pragmas collect: #selector) includesAnyOf: self pragmas )
 		ifTrue: [ self uniqueInstance reset ]
 ]
 
@@ -127,7 +127,7 @@ KMPragmaKeymapBuilder >> pragmaCollector [
 	^ pragmaCollector
 		ifNil: [ pragmaCollector := PragmaCollector
 				filter: [ :prg | 
-					(self pragmaKeywords includes: prg keyword)
+					(self pragmaKeywords includes: prg selector)
 						and: [ prg methodSelector numArgs = 1 ] ].
 			(self pragmaKeywords notNil and: [ self pragmaKeywords notEmpty ])
 				ifTrue: [ pragmaCollector reset ].

--- a/src/MenuRegistration/PragmaMenuBuilder.class.st
+++ b/src/MenuRegistration/PragmaMenuBuilder.class.st
@@ -262,7 +262,7 @@ PragmaMenuBuilder >> pragmaCollector [
 	^ pragmaCollector
 		ifNil: [ pragmaCollector := PragmaCollector
 				filter: [ :prg | 
-					(self pragmaKeywords includes: prg keyword)
+					(self pragmaKeywords includes: prg selector)
 						and: [ prg methodSelector numArgs = 1 ] ].
 			(self pragmaKeywords notNil and: [ self pragmaKeywords notEmpty ])
 				ifTrue: [ pragmaCollector reset ].

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -117,10 +117,11 @@ IRBytecodeGenerator >> addPragma: aPragma [
 { #category : #results }
 IRBytecodeGenerator >> addProperties: cm [
 	"set the properties of cm according to properties saved"
-	properties ifNotNil: [
-		cm penultimateLiteral: properties.
-		properties  method: cm.
-		properties  pragmas do: [:each | each setMethod: cm] ].
+
+	properties
+		ifNotNil: [ cm penultimateLiteral: properties.
+			properties method: cm.
+			properties pragmas do: [ :each | each method: cm ] ]
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/RBPragmaNode.extension.st
+++ b/src/OpalCompiler-Core/RBPragmaNode.extension.st
@@ -2,7 +2,9 @@ Extension { #name : #RBPragmaNode }
 
 { #category : #'*opalcompiler-core' }
 RBPragmaNode >> asPragma [
-	^ Pragma keyword: selector arguments: (arguments collect: [ :each | each value ]) asArray
+	^ Pragma
+		selector: selector
+		arguments: (arguments collect: [ :each | each value ]) asArray
 ]
 
 { #category : #'*opalcompiler-core' }

--- a/src/OpalCompiler-Tests/MethodPragmaTest.class.st
+++ b/src/OpalCompiler-Tests/MethodPragmaTest.class.st
@@ -11,7 +11,7 @@ Class {
 MethodPragmaTest >> assertPragma: aString givesKeyword: aSymbol arguments: anArray [
 	| pragma  |
 	pragma := self pragma: aString selector: #zork.
-	self assert: pragma keyword = aSymbol.
+	self assert: pragma selector = aSymbol.
 	self assert: pragma arguments = anArray.
 
 ]
@@ -232,13 +232,6 @@ MethodPragmaTest >> testCompileValue [
 ]
 
 { #category : #'testing-pragma' }
-MethodPragmaTest >> testKeyword [
-	| pragma |
-	pragma := Pragma keyword: #foo: arguments: #( 123 ).
-	self assert: pragma keyword = #foo:.
-]
-
-{ #category : #'testing-pragma' }
 MethodPragmaTest >> testMessage [
 	| pragma message |
 	pragma := Pragma keyword: #foo: arguments: #( 123 ).
@@ -333,6 +326,13 @@ MethodPragmaTest >> testPrimitiveNamedErrorCode2 [
 	self assert: self lookup equals: nil.
 	
 
+]
+
+{ #category : #'testing-pragma' }
+MethodPragmaTest >> testSelector [
+	| pragma |
+	pragma := Pragma selector: #foo: arguments: #( 123 ).
+	self assert: pragma selector = #foo:.
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Tests/OCPragmaTest.class.st
+++ b/src/OpalCompiler-Tests/OCPragmaTest.class.st
@@ -75,8 +75,8 @@ OCPragmaTest >> testDoublePragma [
 	| aRBMethode |	
 	aRBMethode := OpalCompiler new parse: self methodDoublePragma.
 	
-	self assert: (aRBMethode compiledMethod pragmas first keyword = #hello:).
-	self assert: (aRBMethode compiledMethod pragmas second keyword = #hello:)
+	self assert: (aRBMethode compiledMethod pragmas first selector = #hello:).
+	self assert: (aRBMethode compiledMethod pragmas second selector = #hello:)
 ]
 
 { #category : #testing }
@@ -99,8 +99,8 @@ OCPragmaTest >> testPragmaAfterBeforTemp [
 	| aRBMethode |
 	aRBMethode := OpalCompiler new parse: self methodPragmaAfterBeforTemps.
 
-	self assert: (aRBMethode compiledMethod pragmas first keyword = #hello:).
-	self assert: (aRBMethode compiledMethod pragmas second keyword = #world:)
+	self assert: (aRBMethode compiledMethod pragmas first selector = #hello:).
+	self assert: (aRBMethode compiledMethod pragmas second selector = #world:)
 	
 ]
 
@@ -111,7 +111,7 @@ OCPragmaTest >> testPragmaTwoParam [
 	aRBMethode := OpalCompiler new parse: self methodPragmaTwoParam.
 
 
-	self assert: (aRBMethode compiledMethod pragmas first keyword = #hello:by:)
+	self assert: (aRBMethode compiledMethod pragmas first selector = #hello:by:)
 	
 ]
 
@@ -121,7 +121,7 @@ OCPragmaTest >> testPragmaUnarayMessage [
 
 	aRBMethode := OpalCompiler new parse: self methodPragmaUnarayMessage.
 	
-	self assert: (aRBMethode compiledMethod pragmas first keyword = #hello)
+	self assert: (aRBMethode compiledMethod pragmas first selector = #hello)
 ]
 
 { #category : #testing }
@@ -162,6 +162,6 @@ OCPragmaTest >> testPrimitiveStringModule [
 OCPragmaTest >> testSinglePragma [
 	| aRBMethode |
 	aRBMethode := OpalCompiler new parse: self methodSinglePragma.
-	self assert: (aRBMethode compiledMethod pragmas first keyword = #hello:)
+	self assert: (aRBMethode compiledMethod pragmas first selector = #hello:)
 	
 ]

--- a/src/Refactoring-Environment/RBPragmaEnvironment.class.st
+++ b/src/Refactoring-Environment/RBPragmaEnvironment.class.st
@@ -63,7 +63,7 @@ RBPragmaEnvironment >> includesClass: aClass [
 
 { #category : #testing }
 RBPragmaEnvironment >> includesPragma: aPragma [
-	^ (keywords includes: aPragma keyword) and: [ condition value: aPragma ]
+	^ (keywords includes: aPragma selector) and: [ condition value: aPragma ]
 ]
 
 { #category : #testing }

--- a/src/Reflectivity/RBMethodNode.extension.st
+++ b/src/Reflectivity/RBMethodNode.extension.st
@@ -30,7 +30,7 @@ RBMethodNode >> metaLinkOptionsFromClassAndMethod [
 	(self pragmas
 		select: [ :pragma | pragma selector == #metaLinkOptions: ])
 		do:
-			[ :pragma | (pragma asPragma setKeyword: #parseOptions:) sendTo: options ].
+			[ :pragma | (pragma asPragma selector: #parseOptions:) sendTo: options ].
 	^ options
 ]
 

--- a/src/SUnit-UI/TestReviver.class.st
+++ b/src/SUnit-UI/TestReviver.class.st
@@ -191,7 +191,7 @@ TestReviver >> selectTestFailures [
 		method pragmas isEmpty
 			ifTrue: [ results add: aFile ]
 			ifFalse:  [
-				(method pragmas first keyword = #expectedFailure) 
+				(method pragmas first selector = #expectedFailure) 
 					ifFalse: [ results add: aFile ].
 				 ]
 	].

--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -181,13 +181,12 @@ ComposablePresenter class >> platform [
 
 { #category : #protocol }
 ComposablePresenter class >> specSelectors [
-	
-	^  self class withAllSuperclasses flatCollect: [ :class |
-		(((SpecPragmaCollector behavior: class)
-			filter: [ :pragma | pragma keyword = #spec])
-			reset;
-			collected)
-			collect: [ :pragmas | pragmas method selector ]]
+	^ self class withAllSuperclasses
+		flatCollect: [ :class | 
+			(((SpecPragmaCollector behavior: class)
+				filter: [ :pragma | pragma selector = #spec ])
+				reset;
+				collected) collect: [ :pragmas | pragmas method selector ] ]
 ]
 
 { #category : #specs }
@@ -362,22 +361,21 @@ ComposablePresenter >> defaultSpec [
 
 { #category : #private }
 ComposablePresenter >> defaultSpecSelector [
-
-	self class class withAllSuperclassesDo: [ :class |
-		(((SpecPragmaCollector behavior: class)
-			filter: [ :pragma | 
-				pragma keyword = 'spec:' and: [ pragma arguments includes: #default ]])
-			reset;
-			collected)
-				ifNotEmpty: [ :pragmas | ^ pragmas first method selector ]].
-
+	self class class
+		withAllSuperclassesDo: [ :class | 
+			(((SpecPragmaCollector behavior: class)
+				filter:
+					[ :pragma | pragma selector = 'spec:' and: [ pragma arguments includes: #default ] ])
+				reset;
+				collected)
+				ifNotEmpty: [ :pragmas | ^ pragmas first method selector ] ].
 	self specSelectors
-		ifNotEmpty: [:col | col size = 1 ifTrue: [ ^ col first ]].
-		
+		ifNotEmpty: [ :col | 
+			col size = 1
+				ifTrue: [ ^ col first ] ].
+
 	"should use pragmas"
 	^ #defaultSpec
-	
-
 ]
 
 { #category : #accessing }

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -40,7 +40,7 @@ SystemAnnouncer class >> restoreAllNotifications [
 	
 	| collector |
 	self reset.
-	collector := PragmaCollector filter: [ :pragma | pragma keyword = #systemEventRegistration ].
+	collector := PragmaCollector filter: [ :pragma | pragma selector = #systemEventRegistration ].
 	collector reset.
 	collector do: [ :pragma |
 		pragma methodClass instanceSide perform: pragma methodSelector ]

--- a/src/System-FileRegistry/FileServices.class.st
+++ b/src/System-FileRegistry/FileServices.class.st
@@ -22,7 +22,7 @@ FileServices class >> itemsForDirectory: aFileDirectory [
 
 	| services |
 	services := OrderedCollection new.
-	(PragmaCollector filter: [ :pragma | pragma keyword = 'directoryService' ]) reset
+	(PragmaCollector filter: [ :pragma | pragma selector = 'directoryService' ]) reset
 		do: [ :each | services addAll: (each methodClass soleInstance perform: each methodSelector with: aFileDirectory) ].
 	^ services
 ]
@@ -34,7 +34,7 @@ FileServices class >> itemsForFile: fullName [
 	| services suffix |
 	suffix := self suffixOf: fullName.
 	services := OrderedCollection new.
-	(PragmaCollector filter: [ :pragma | pragma keyword = 'fileService' ])
+	(PragmaCollector filter: [ :pragma | pragma selector = 'fileService' ])
 		reset
 		do: [ :each | 
 			services

--- a/src/System-Settings-Browser/SettingBrowser.class.st
+++ b/src/System-Settings-Browser/SettingBrowser.class.st
@@ -280,7 +280,7 @@ SettingBrowser class >> searchedTextList [
 
 { #category : #accessing }
 SettingBrowser class >> settingsKeywords [ 
-	^ ((PragmaCollector new filter: [:prg | prg keyword = #settingPragmaProcessor]) reset) collect: [:p | p method selector].
+	^ ((PragmaCollector new filter: [:prg | prg selector = #settingPragmaProcessor]) reset) collect: [:p | p method selector].
 
 ]
 

--- a/src/System-Settings-Browser/SettingTree.class.st
+++ b/src/System-Settings-Browser/SettingTree.class.st
@@ -31,7 +31,7 @@ SettingTree class >> acceptableKeywords: aCollectionOfStrings [
 
 { #category : #accessing }
 SettingTree >> acceptableKeywords: keywords [
-	self collector filter: [:prg | prg methodClass isMeta and: [keywords includes: prg keyword]].
+	self collector filter: [:prg | prg methodClass isMeta and: [keywords includes: prg selector]].
 	nodeList := nil.
 	self collector reset.
 

--- a/src/System-Settings-Browser/SettingTreeBuilder.class.st
+++ b/src/System-Settings-Browser/SettingTreeBuilder.class.st
@@ -21,7 +21,7 @@ SettingTreeBuilder class >> acceptableKeywords: aCollectionOfRegExps [
 { #category : #accessing }
 SettingTreeBuilder >> buildPragma: aPragma [
 	currentPragma := aPragma.
-	self perform: aPragma keyword withArguments: aPragma arguments.
+	self perform: aPragma selector withArguments: aPragma arguments.
 	^ nodeList
 ]
 

--- a/src/Tool-Catalog/CatalogBrowser.class.st
+++ b/src/Tool-Catalog/CatalogBrowser.class.st
@@ -99,7 +99,7 @@ CatalogBrowser >> buildContextMenuOn: aList [
 	| col |
 	col := (PragmaCollector new
 		filter:
-			[ :prg | prg keyword = #contextMenu and: [ prg methodClass = self class ] ])
+			[ :prg | prg selector = #contextMenu and: [ prg methodClass = self class ] ])
 		reset.
 	"the pragma menu builder is probably doing a better job than this code but it was unclear"
 	(col collected
@@ -110,7 +110,7 @@ CatalogBrowser >> buildContextMenuOn: aList [
 { #category : #'private - utilities' }
 CatalogBrowser >> buildMenuOn: aList [
 	| col |
-	col := (PragmaCollector filter: [ :prg | prg keyword = #menuOrder: and: [ prg methodClass = self class ] ]) reset.
+	col := (PragmaCollector filter: [ :prg | prg selector = #menuOrder: and: [ prg methodClass = self class ] ]) reset.
 	col collected sort: [ :a :b | (a argumentAt: 1) <= (b argumentAt: 1) ].
 	col do: [ :each | self perform: each methodSelector with: aList ]
 ]

--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -418,12 +418,12 @@ Finder >> pragmaSearch: aString [
 	result := Dictionary new.
 	
 	byCondition :=  self useRegEx 
-		ifTrue: [[ :pragma | pragma keyword matchesRegexIgnoringCase: aString ]]
-		ifFalse: [[ :pragma | pragma keyword includesSubstring: aString caseSensitive: false ]].
+		ifTrue: [[ :pragma | pragma selector matchesRegexIgnoringCase: aString ]]
+		ifFalse: [[ :pragma | pragma selector includesSubstring: aString caseSensitive: false ]].
 				
 	(PragmaCollector filter: byCondition) reset; 
 		do: [ :pragma |
-			(result at: (pragma keyword) ifAbsentPut: OrderedCollection new)				
+			(result at: (pragma selector) ifAbsentPut: OrderedCollection new)				
 				add: pragma method ].
 	^ result
 ]

--- a/src/UnifiedFFI/FFICompilerPlugin.class.st
+++ b/src/UnifiedFFI/FFICompilerPlugin.class.st
@@ -104,11 +104,18 @@ FFICompilerPlugin class >> initializeFFICalloutSelectors [
 
 { #category : #'private - initialization' }
 FFICompilerPlugin class >> initializeFFICalloutSelectorsListUpdate [
-
-	collector := PragmaCollector filter: [ :pragma | pragma keyword = #ffiCalloutTranslator ].
-	collector reset do: [ :pragma | self addFFICalloutSelectorFromPragma: pragma ].
-	collector when: PragmaAdded send: #addFFICalloutSelectorEvent: to: self.
-	collector when: PragmaRemoved send: #removeFFICalloutSelectorEvent: to: self
+	collector := PragmaCollector
+		filter: [ :pragma | pragma selector = #ffiCalloutTranslator ].
+	collector reset
+		do: [ :pragma | self addFFICalloutSelectorFromPragma: pragma ].
+	collector
+		when: PragmaAdded
+		send: #addFFICalloutSelectorEvent:
+		to: self.
+	collector
+		when: PragmaRemoved
+		send: #removeFFICalloutSelectorEvent:
+		to: self
 ]
 
 { #category : #installation }


### PR DESCRIPTION
- Deprecated pragma methods that needed to be.
- Migrated code to not use deprecated pragma API.

Fixes #4433