### PR TITLE
4435-Cannot-browse-trait-in-class-description

### DIFF
--- a/src/ClassParser-Tests/ASTClassBuilderTest.class.st
+++ b/src/ClassParser-Tests/ASTClassBuilderTest.class.st
@@ -245,6 +245,52 @@ ASTClassBuilderTest >> testCreateNormalClassWithTraitComposition [
 	self assert: (class isComposedBy: TIncludesWithIdentityCheckTest).
 ]
 
+{ #category : #NormalClass }
+ASTClassBuilderTest >> testCreateTraitUsingAnotherSingleTrait [
+
+   | ast class |
+
+	ast := CDClassDefinitionParser parse: 'Trait named: #TTestTrait
+															uses: TOccurrencesTest'.
+	class := ShiftClassBuilder new
+		buildEnvironment: self environment;
+		buildFromAST: ast;
+		build.
+	
+	self assert: (class isComposedBy: TOccurrencesTest).
+]
+
+{ #category : #NormalClass }
+ASTClassBuilderTest >> testCreateTraitUsingAnotherTraitComposition [
+
+   | ast class |
+
+	ast := CDClassDefinitionParser parse: 'Trait named: #TTestTrait
+															uses: TOccurrencesTest + TAddForUniquenessTest'.
+	class := ShiftClassBuilder new
+		buildEnvironment: self environment;
+		buildFromAST: ast;
+		build.
+	
+	self assert: (class isComposedBy: TOccurrencesTest).
+	self assert: (class isComposedBy: TAddForUniquenessTest).
+]
+
+{ #category : #NormalClass }
+ASTClassBuilderTest >> testCreateTraitWithoutOtherTraits [
+
+   | ast class |
+
+	ast := CDClassDefinitionParser parse: 'Trait named: #TTestTrait
+															uses: {}'.
+	class := ShiftClassBuilder new
+		buildEnvironment: self environment;
+		buildFromAST: ast;
+		build.
+		
+	self assert: class traits isEmpty
+]
+
 { #category : #running }
 ASTClassBuilderTest >> testCreateVariableByteClassNamed [
 

--- a/src/ClassParser/CDTraitCompositionBuilder.class.st
+++ b/src/ClassParser/CDTraitCompositionBuilder.class.st
@@ -17,13 +17,21 @@ CDTraitCompositionBuilder >> buildFrom: aNode [
 
 { #category : #visiting }
 CDTraitCompositionBuilder >> visitArrayNode: aRBArrayNode [ 
+	self flag: #todo.
 	
-	^ aRBArrayNode statements collect: [ :each | 
+	aRBArrayNode statements ifEmpty: [ 
+		^CDTraitCompositionSequenceNode new 
+			sequence: #();
+			originalNode: aRBArrayNode;
+			yourself].
+	
+	self error: 'Is not supported yet'
+	"
+	aRBArrayNode statements collect: [ :each | 
 		each isLiteralNode
 			ifTrue: [ each value ]
-			ifFalse: [ each receiver value -> each arguments first value ] ]
-		
-		
+			ifFalse: [ each receiver value -> each arguments first value ] ]	
+	"
 ]
 
 { #category : #visiting }

--- a/src/ClassParser/CDTraitCompositionBuilder.class.st
+++ b/src/ClassParser/CDTraitCompositionBuilder.class.st
@@ -17,21 +17,25 @@ CDTraitCompositionBuilder >> buildFrom: aNode [
 
 { #category : #visiting }
 CDTraitCompositionBuilder >> visitArrayNode: aRBArrayNode [ 
-	self flag: #todo.
+	| parent argumentName |
+	self flag: #todo. 
+	"It needs to be refactored. I do not know how it was supposed to be handle properly.
+	Here is workaround to fix issue with empty #uses section"
+	parent := aRBArrayNode parent.
+	parent isMessage ifTrue: [ 
+		argumentName := parent keywords at: (parent arguments indexOf: aRBArrayNode).
+		argumentName = #uses: ifTrue: [ 
+			aRBArrayNode statements ifEmpty: [ 
+				^CDTraitCompositionSequenceNode new 
+					sequence: #();
+					originalNode: aRBArrayNode;
+					yourself].
+			self error: 'Is not supported yet']].
 	
-	aRBArrayNode statements ifEmpty: [ 
-		^CDTraitCompositionSequenceNode new 
-			sequence: #();
-			originalNode: aRBArrayNode;
-			yourself].
-	
-	self error: 'Is not supported yet'
-	"
-	aRBArrayNode statements collect: [ :each | 
+	^aRBArrayNode statements collect: [ :each | 
 		each isLiteralNode
 			ifTrue: [ each value ]
-			ifFalse: [ each receiver value -> each arguments first value ] ]	
-	"
+			ifFalse: [ each receiver value -> each arguments first value ] ]
 ]
 
 { #category : #visiting }


### PR DESCRIPTION
- Fix trait definition parsing when uses section is empty- tests for trait creation