### PR TITLE
4422-DNU-in-finder-searching-for-print-this-invalid-selector

### DIFF
--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -379,7 +379,7 @@ Finder >> messagesNameSearch: aString [
 Finder >> methodSearch: aSelectBlock [ 
 	| result | 
 	result := OrderedCollection new.
-	
+	aSelectBlock ifNil: [ ^result ].
 	self packagesSelection classesAndTraits do:[ :class |
 			class methodsDo: [ :method | 
 				(aSelectBlock value: method) ifTrue: [ result add: method ]].


### PR DESCRIPTION
add a nil check. fixes #4422