### PR TITLE
4447-[CI] Wget log is too verbose

### DIFF
--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -14,17 +14,17 @@ SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 mkdir -p "${BOOTSTRAP_CACHE}" #required to generate hermes files
 
 ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/getPharoVM.sh 61
-wget https://github.com/guillep/PharoBootstrap/releases/download/v1.5.0/bootstrapImage.zip
+wget -nv https://github.com/guillep/PharoBootstrap/releases/download/v1.5.0/bootstrapImage.zip
 unzip bootstrapImage.zip
 
 cd "${BOOTSTRAP_CACHE}"
 #We need the old sources file next to the image because of sources condensation step
-wget http://files.pharo.org/sources/PharoV60.sources
+wget -nv http://files.pharo.org/sources/PharoV60.sources
 echo "Prepare icons"
 mkdir icon-packs
 cd icon-packs
 # update the commit hash as soon as you need a new version of the icons to be loaded
-wget https://github.com/pharo-project/pharo-icon-packs/archive/v1.0.0-idea11.zip -O idea11.zip
+wget -nv https://github.com/pharo-project/pharo-icon-packs/archive/v1.0.0-idea11.zip -O idea11.zip
 cd ..
 cd ..
 

--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -14,17 +14,17 @@ SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 mkdir -p "${BOOTSTRAP_CACHE}" #required to generate hermes files
 
 ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/getPharoVM.sh 61
-wget -nv https://github.com/guillep/PharoBootstrap/releases/download/v1.5.0/bootstrapImage.zip
+wget --progress=dot:mega https://github.com/guillep/PharoBootstrap/releases/download/v1.5.0/bootstrapImage.zip
 unzip bootstrapImage.zip
 
 cd "${BOOTSTRAP_CACHE}"
 #We need the old sources file next to the image because of sources condensation step
-wget -nv http://files.pharo.org/sources/PharoV60.sources
+wget --progress=dot:mega http://files.pharo.org/sources/PharoV60.sources
 echo "Prepare icons"
 mkdir icon-packs
 cd icon-packs
 # update the commit hash as soon as you need a new version of the icons to be loaded
-wget -nv https://github.com/pharo-project/pharo-icon-packs/archive/v1.0.0-idea11.zip -O idea11.zip
+wget --progress=dot:mega https://github.com/pharo-project/pharo-icon-packs/archive/v1.0.0-idea11.zip -O idea11.zip
 cd ..
 cd ..
 


### PR DESCRIPTION
Put the download of the bootstrap in non verbose mode.

See  #4447