### PR TITLE
4462-RBMessageNode-signature-should-return-the-signature-of-a-method-definition

### DIFF
--- a/src/AST-Core-Tests/RBMessageNodeTest.class.st
+++ b/src/AST-Core-Tests/RBMessageNodeTest.class.st
@@ -5,7 +5,37 @@ Class {
 }
 
 { #category : #testing }
-RBMessageNodeTest >> testselectorInterval [
+RBMessageNodeTest >> testSelectorAndArgumentNames [
+		| tree message |
+		tree := self parseMethod: 'test self doit'.
+		message := tree sendNodes first.
+		self assert: message selectorAndArgumentNames equals: 'doit'
+		
+		
+]
+
+{ #category : #testing }
+RBMessageNodeTest >> testSelectorAndArgumentNamesForSimpleKeywords [
+		| tree message |
+		tree := self parseMethod: 'test self doit: 5'.
+		message := tree sendNodes first.
+		self assert: message selectorAndArgumentNames equals: 'doit: 5'
+		
+		
+]
+
+{ #category : #testing }
+RBMessageNodeTest >> testSelectorAndArgumentNamesForUnary [
+		| tree message |
+		tree := self parseMethod: 'test self doit'.
+		message := tree sendNodes first.
+		self assert: message selectorAndArgumentNames equals: 'doit'
+		
+		
+]
+
+{ #category : #testing }
+RBMessageNodeTest >> testSelectorInterval [
 		| tree message |
 		tree := self parseMethod: 'test self doit'.
 		message := tree sendNodes first.
@@ -13,4 +43,37 @@ RBMessageNodeTest >> testselectorInterval [
 		tree := self parseMethod: 'test self doit: #nice with: 5'.
 		message := tree sendNodes first.
 		self assert: message selectorInterval equals: (11 to: 27).
+]
+
+{ #category : #testing }
+RBMessageNodeTest >> testSelectorPartsForBinaryMessages [
+		| tree message |
+		tree := self parseMethod: 'test 1 + 2 '.
+		message := tree sendNodes first.
+		self assert: message selectorParts equals: #(#+).
+		
+		
+]
+
+{ #category : #testing }
+RBMessageNodeTest >> testSelectorPartsForKeywordMessages [
+		| tree message |
+		tree := self parseMethod: 'test self doit: 5'.
+		message := tree sendNodes first.
+		self assert: message selectorParts equals: #(#doit:).
+		
+		tree := self parseMethod: 'test self between: 0 and: 5 '.
+		message := tree sendNodes first.
+		self assert: message selectorParts equals: #(#between: #and:).
+		
+]
+
+{ #category : #testing }
+RBMessageNodeTest >> testSelectorPartsForUnaryMessages [
+		| tree message |
+		tree := self parseMethod: 'test self doit'.
+		message := tree sendNodes first.
+		self assert: message selectorParts equals: #(#doit).
+		
+		
 ]

--- a/src/AST-Core-Tests/RBMessageNodeTest.class.st
+++ b/src/AST-Core-Tests/RBMessageNodeTest.class.st
@@ -5,13 +5,15 @@ Class {
 }
 
 { #category : #testing }
-RBMessageNodeTest >> testSelectorAndArgumentNames [
+RBMessageNodeTest >> testSelectorAndArgumentNamesForComposedKeywords [
 		| tree message |
-		tree := self parseMethod: 'test self doit'.
+		tree := self parseMethod: 'test self between: x and: y'.
 		message := tree sendNodes first.
-		self assert: message selectorAndArgumentNames equals: 'doit'
+		self assert: message selectorAndArgumentNames equals: 'between: x and: y'.
 		
-		
+		tree := self parseMethod: 'test self between: x and: y and: zzz'.
+		message := tree sendNodes first.
+		self assert: message selectorAndArgumentNames equals: 'between: x and: y and: zzz'
 ]
 
 { #category : #testing }

--- a/src/AST-Core-Tests/RBMessageNodeTest.class.st
+++ b/src/AST-Core-Tests/RBMessageNodeTest.class.st
@@ -17,6 +17,16 @@ RBMessageNodeTest >> testSelectorAndArgumentNamesForComposedKeywords [
 ]
 
 { #category : #testing }
+RBMessageNodeTest >> testSelectorAndArgumentNamesForComposedKeywordsAndComplexArgs [
+		| tree message |
+		tree := self parseMethod: 'test self between: x + 2 and: (y foo: 3)'.
+		message := tree sendNodes first.
+		self assert: message selectorAndArgumentNames equals: 'between: x + 2 and: (y foo: 3)'.
+		
+		
+]
+
+{ #category : #testing }
 RBMessageNodeTest >> testSelectorAndArgumentNamesForSimpleKeywords [
 		| tree message |
 		tree := self parseMethod: 'test self doit: 5'.

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -406,11 +406,19 @@ RBMessageNode >> selectorAndArgumentNames [
 	"Returns the selector and argument names portion of a method as a string"
 
 	^ self arguments
-		ifEmpty: [self keywords first]
-		ifNotEmpty: [| lastArgument |
-			lastArgument := self arguments last.
-			self halt. 
-			self source first: lastArgument start + (lastArgument value asString size - 1)]
+		ifEmpty: [ self keywords first ]
+		ifNotEmpty: [
+			(String streamContents: [ :st | 
+				self selectorParts
+			 		with: self arguments 
+					do: [:sel :arg | 
+							st 
+								<< sel asString;
+								<< ' ';
+								<< arg formattedCode;
+								<< ' ']]) allButLast ]
+								
+					
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -402,6 +402,18 @@ RBMessageNode >> selector: aSelector [
 ]
 
 { #category : #accessing }
+RBMessageNode >> selectorAndArgumentNames [
+	"Returns the selector and argument names portion of a method as a string"
+
+	^ self arguments
+		ifEmpty: [self keywords first]
+		ifNotEmpty: [| lastArgument |
+			lastArgument := self arguments last.
+			self halt. 
+			self source first: lastArgument start + (lastArgument value asString size - 1)]
+]
+
+{ #category : #accessing }
 RBMessageNode >> selectorInterval [
 	| positions |
 	positions := self keywordsIntervals. 
@@ -410,7 +422,9 @@ RBMessageNode >> selectorInterval [
 
 { #category : #accessing }
 RBMessageNode >> selectorParts [
-	^ self keywords collect: #asSymbol.
+	"Returns a collection containing all the selector composing a message"
+	
+	^ self keywords collect: [ :each | each asSymbol]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fixes #4462