### PR TITLE
Fixes 2936

### DIFF
--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -95,15 +95,12 @@ RBScanner class >> initializeUnderscore [
 ]
 
 { #category : #testing }
-RBScanner class >> isSelector: aSymbol [ 
-	| scanner token |
+RBScanner class >> isSelector: aSymbol [
+	| scanner |
 	scanner := self basicNew.
 	scanner on: (ReadStream on: aSymbol asString).
 	scanner step.
-	token := scanner scanAnySymbol.
-	token isLiteralToken ifFalse: [^false].
-	token value isEmpty ifTrue: [^false].
-	^scanner atEnd
+	^ scanner isSelector
 ]
 
 { #category : #testing }
@@ -214,6 +211,61 @@ RBScanner >> getComments [
 { #category : #testing }
 RBScanner >> isReadable [
 	^true
+]
+
+{ #category : #testing }
+RBScanner >> isSelector [
+	characterType = #binary
+		ifTrue: [ [ characterType = #binary ] whileTrue: [ self step ].
+			^ characterType = #eof ].
+	characterType ~= #alphabetic
+		ifTrue: [ ^ false ].
+	^ self isSelectorNonBinary
+]
+
+{ #category : #testing }
+RBScanner >> isSelectorNonBinary [
+	"inspect the next line and view as morph"
+
+	"ZnEasy getPng: 'http://www.plantuml.com/plantuml/png/RO-n2i8m48RtUugRXRn0XzBg98wEuX2R4mlNHE8LwTkRL4Xxa2cNx_z2_ki-OgFC4mF8A4nu9QP1GeJRuOx6j7WSlOqBDlXOXy9xVhzipy5Joco-m0vfeoQuP9n2cjFp8PygRJ7_qo259m2ide8REliBBTyGNQa16p9LGUUw1C1_uThk9TBrEl9kdlW7'"
+
+	| state |
+	state := #alphaAlone.
+	[ characterType = #alphabetic ]
+		whileTrue: [ state = #colon
+				ifTrue: [ state := #inKeyword ].
+			self scanName.
+			characterType = #eof
+				ifTrue: [ ^ state = #alphaAlone ].
+			currentCharacter = $:
+				ifTrue: [ state := #colon.
+					self step ] ].
+	characterType = #eof
+		ifTrue: [ ^ state = #colon ].
+	^ false
+
+	"Diagram by:
+@startuml
+
+title Selector
+[*] --> Binary : binary
+[*] --> AlphaAlone : alpha
+AlphaAlone --> AlphaAlone: alpha
+AlphaAlone -d-> Colon : colon
+AlphaAlone -> [*] : eof
+
+
+Colon -> [*] : eof
+Colon -> InKeyword : alpha
+
+InKeyword --> InKeyword : alpha
+InKeyword --> Colon : colon
+
+
+Binary --> Binary : binary
+Binary --> [*] : eof
+
+@enduml"
 ]
 
 { #category : #testing }

--- a/src/Refactoring-Tests-Core/RBConditionTest.class.st
+++ b/src/Refactoring-Tests-Core/RBConditionTest.class.st
@@ -10,9 +10,8 @@ RBConditionTest >> testCheckInvalidMethodName [
 
 	self deny: (RBCondition checkMethodName: 'fofo fo').
 	self deny: (RBCondition checkMethodName: '123fofo').
-	"bug in RBParser!!!"
-	"self deny: (RBCondition checkMethodName: 'foo::')."
-	"self deny: (RBCondition checkMethodName: 'agr:goo:aa')."
+	self deny: (RBCondition checkMethodName: 'foo::').
+	self deny: (RBCondition checkMethodName: 'agr:goo:aa').
 	self deny: (RBCondition checkMethodName: 'foo:123:').
 	self deny: (RBCondition checkMethodName: 'foo[arg]').
 	self deny: (RBCondition checkMethodName: 'foo:=arg').
@@ -21,6 +20,7 @@ RBConditionTest >> testCheckInvalidMethodName [
 	self deny: (RBCondition checkMethodName: 'foo:+arg)').
 	self deny: (RBCondition checkMethodName: '<<foo:<<arg)').
 	self deny: (RBCondition checkMethodName: 'foo:agr^:').
+	self deny: (RBCondition checkMethodName: 'foo:agr')
 ]
 
 { #category : #tests }


### PR DESCRIPTION
The test for isSelector is not done in the test class for RBScanner, but there is an extensive suite of tests in RBConditionTest (Should I raise an issue to have them moved???). I reincluded the two outcommented tests in testCheckInvalidMethodName

My brief view on this bug is that selectors are *not* part of the smalltalk grammar, and as such there was no good mechanism and tokens to use. The current version failed for that reason, trying to get by using what was there. I added a new method (and its helper), to check for validity of selectors. It is a small state machine, see documentation in helper class.

The new scanner for isSelector: is based on [this statemachine](http://www.plantuml.com/plantuml/png/RO-n2i8m48RtUugRXRn0XzBg98wEuX2R4mlNHE8LwTkRL4Xxa2cNx_z2_ki-OgFC4mF8A4nu9QP1GeJRuOx6j7WSlOqBDlXOXy9xVhzipy5Joco-m0vfeoQuP9n2cjFp8PygRJ7_qo259m2ide8REliBBTyGNQa16p9LGUUw1C1_uThk9TBrEl9kdlW7).