### PR TITLE
Change name of method argument 

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -593,7 +593,7 @@ Class >> hasSubclasses [
 ]
 
 { #category : #'subclass creation - immediate' }
-Class >> immediateSubclass: className instanceVariableNames: instvarNames 
+Class >> immediateSubclass: className instanceVariableNames: instVarNameList  
 	classVariableNames: classVarNames package: cat [
 	"
 	An immediate subclass define a class for which its value is coded within the OOP itself (like SmallInteger in 32 bits). It is not meant to be used by non-experimented users.
@@ -601,7 +601,7 @@ Class >> immediateSubclass: className instanceVariableNames: instvarNames
 	Immediates are objects that are stored in an object pointer using a tag to distinguish them from ordinary object pointers.  In v3 the only immediate is SmallInteger.  In 32-but spur there are SmallInteger and Character.  An implication of this is that in spur all Characters can be compared using #==.  In 64-bit Spur there is also SmallFloat64.  If a float's exponent is in the middle 8-bits of the 11-bit exponent range then it will be immediate.  If a float's exponent is outside of the middle 8-bits it will be boxed.
 	"
 	^self immediateSubclass: className
-		instanceVariableNames: instvarNames
+		instanceVariableNames: instVarNameList 
 		classVariableNames: classVarNames
 		poolDictionaries: ''
 		package: cat
@@ -1162,23 +1162,23 @@ Class >> usesPoolVarNamed: aString [
 ]
 
 { #category : #'subclass creation - deprecated' }
-Class >> variableByteSubclass: className instanceVariableNames: instvarNames classVariableNames: classVarNames category: cat [
+Class >> variableByteSubclass: className instanceVariableNames: instVarNameList  classVariableNames: classVarNames category: cat [
 	"Added to allow for a simplified subclass creation experience. "
 
 	^ self
 		variableByteSubclass: className
-		instanceVariableNames: instvarNames
+		instanceVariableNames: instVarNameList 
 		classVariableNames: classVarNames
 		package: cat
 ]
 
 { #category : #'subclass creation - variableByte' }
-Class >> variableByteSubclass: className instanceVariableNames: instvarNames classVariableNames: classVarNames package: cat [
+Class >> variableByteSubclass: className instanceVariableNames: instVarNameList  classVariableNames: classVarNames package: cat [
 	"Added to allow for a simplified subclass creation experience. "
 
 	^ self
 		variableByteSubclass: className
-		instanceVariableNames: instvarNames
+		instanceVariableNames: instVarNameList 
 		classVariableNames: classVarNames
 		poolDictionaries: ''
 		package: cat


### PR DESCRIPTION
to avoid duplicating GemStone instance variable name.