### PR TITLE
Add-simple-undo-redo-without-wrapper

### DIFF
--- a/src/System-History-Tests/ConfigurableHistoryIteratorTest.class.st
+++ b/src/System-History-Tests/ConfigurableHistoryIteratorTest.class.st
@@ -1,0 +1,146 @@
+Class {
+	#name : #ConfigurableHistoryIteratorTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'historyList',
+		'saved'
+	],
+	#category : #'System-History-Tests'
+}
+
+{ #category : #running }
+ConfigurableHistoryIteratorTest >> setUp [
+	super setUp.
+	historyList := ConfigurableHistoryIterator undo: [ :integer | saved := integer ] redo: [ :integer | saved := integer asString ]
+]
+
+{ #category : #tests }
+ConfigurableHistoryIteratorTest >> testHasNext [
+	historyList register: 3.
+
+	self deny: historyList hasNext.
+
+	historyList undo.
+
+	self assert: historyList hasNext
+]
+
+{ #category : #tests }
+ConfigurableHistoryIteratorTest >> testHasPrevious [
+	historyList register: 3.
+
+	self assert: historyList hasPrevious.
+
+	historyList undo.
+
+	self deny: historyList hasPrevious
+]
+
+{ #category : #tests }
+ConfigurableHistoryIteratorTest >> testRedo [
+	historyList register: 3.
+	historyList register: 5.
+
+	historyList undo.
+	historyList undo.
+
+	self assert: historyList hasNext.
+
+	historyList redo.
+
+	self assert: historyList hasNext.
+	self assert: saved equals: '3'.
+	self assert: historyList current equals: 3.
+	
+	historyList redo.
+
+	self deny: historyList hasNext.
+	self assert: saved equals: '5'.
+	self assert: historyList current equals: 5.
+	
+	self should: [ historyList redo ] raise: NothingToRedo
+]
+
+{ #category : #tests }
+ConfigurableHistoryIteratorTest >> testRedoIfEmpty [
+	historyList register: 3.
+
+	historyList undo.
+
+	self assert: historyList hasNext.
+
+	historyList redoIfEmpty: [ saved := nil ].
+
+	self deny: historyList hasNext.
+	self assert: saved equals: '3'.
+	
+	historyList redoIfEmpty: [ saved := nil ].
+
+	self assert: saved isNil
+]
+
+{ #category : #tests }
+ConfigurableHistoryIteratorTest >> testRegister [
+	historyList register: 3.
+	self assert: historyList size equals: 1.
+	self assert: historyList current identicalTo: 3.
+
+	historyList register: 5.
+	self assert: historyList size equals: 2.
+	self assert: historyList current identicalTo: 5
+]
+
+{ #category : #tests }
+ConfigurableHistoryIteratorTest >> testRegisterClearRedo [
+	historyList register: 3.
+	historyList register: 5.
+
+	historyList undo.
+
+	self assert: historyList size equals: 1.
+	self assert: historyList hasNext.
+
+	historyList register: 4.
+
+	self assert: historyList size equals: 2.
+	self deny: historyList hasNext
+]
+
+{ #category : #tests }
+ConfigurableHistoryIteratorTest >> testUndo [
+	historyList register: 3.
+	historyList register: 5.
+
+	self assert: historyList hasPrevious.
+	self assert: historyList current identicalTo: 5.
+
+	historyList undo.
+
+	self assert: historyList hasPrevious.
+	self assert: historyList current identicalTo: 3.
+	self assert: saved equals: 5.
+
+	historyList undo.
+
+	self deny: historyList hasPrevious.
+	self should: [ historyList current ] raise: NothingToUndo.
+	self assert: saved equals: 3.
+	self should: [ historyList undo ] raise: NothingToUndo
+]
+
+{ #category : #tests }
+ConfigurableHistoryIteratorTest >> testUndoIfEmpty [
+	historyList register: 3.
+
+	self assert: historyList hasPrevious.
+	self assert: historyList current identicalTo: 3.
+
+	historyList undoIfEmpty: [ saved := nil ].
+
+	self deny: historyList hasPrevious.
+	self assert: saved equals: 3.
+
+	historyList undoIfEmpty: [ saved := nil ].
+
+	self assert: saved isNil
+]

--- a/src/System-History/ConfigurableHistoryIterator.class.st
+++ b/src/System-History/ConfigurableHistoryIterator.class.st
@@ -1,7 +1,7 @@
 "
 I am an history iterator you can configure with two blocks. One to define what to do during the redo action and the second to define what to do during the undo action. 
 
-Then you can register objects to me and ask to undo and redo actions, I will then use my undo and redo actions with my stored object to execute it.
+Then you can register context objects to me and ask to undo and redo actions, I will then use my undo and redo actions with my stored context to execute it.
 
 Examples
 --------------------
@@ -51,18 +51,18 @@ Internal Representation and Key Implementation Points.
 
     Instance Variables
 	redoAction:		<aValuable>		A valuable to execute when we redo an action.
-	redoStack:		<aStack>			A stack containing the elements that can be redone.
+	redoStack:		<aStack>			A stack containing the contexts that can be redone.
 	undoAction:		<aValuable>		A valuable to execute when we undo an action.
-	undoStack:		<aStack>			A stack containing the elements that can be undone.
+	undoStack:		<aStack>			A stack containing the contexts that can be undone.
 						
 	I work with a system of two stacks:
-	- One stack to store objects to undo 
-	- One stack to store ojbects to redo
+	- One stack to store contexts to undo 
+	- One stack to store contexts to redo
 	
 	When the user wants to undo something, I'll pop the undo stack, evaluate the undo action with it and push it on the redo stack.
 	When the user wants to redo something, I'll pop the redo stack, evaluate the redo action with it and push it on the undo stack.
 	
-	When the user add a new item on the undo stack, I flush the redo stack.
+	When the user add a new context on the undo stack, I flush the redo stack.
 
 "
 Class {
@@ -76,6 +76,11 @@ Class {
 	],
 	#category : #'System-History-Iterators'
 }
+
+{ #category : #'instance creation' }
+ConfigurableHistoryIterator class >> action: aBlock [
+	^ self undo: aBlock redo: aBlock
+]
 
 { #category : #'instance creation' }
 ConfigurableHistoryIterator class >> undo: aBlockClosure redo: aBlockClosure2 [

--- a/src/System-History/ConfigurableHistoryIterator.class.st
+++ b/src/System-History/ConfigurableHistoryIterator.class.st
@@ -1,0 +1,149 @@
+"
+I am an history iterator you can configure with two blocks. One to define what to do during the redo action and the second to define what to do during the undo action. 
+
+Then you can register objects to me and ask to undo and redo actions, I will then use my undo and redo actions with my stored object to execute it.
+
+Examples
+--------------------
+	
+	| saved history |
+	history := self
+		undo: [ :integer | saved := integer ]
+		redo: [ :integer | saved := integer asString ].
+	
+	history hasPrevious. ""false""
+	history hasNext. ""false"" 
+	
+	history register: 3.
+	
+	history current. ""3""
+	history hasNext. ""false""
+	history hasPrevious. ""true""
+	
+	history undo.
+	saved. ""3""
+	
+	history hasPrevious. ""false""
+	history undo. ""EXCEPTION: NothingToUndo""
+	
+	history undoIfEmpty: [ saved := nil ].
+	saved. ""nil""
+	
+	history register: 3.
+	history register: 4.
+	
+	history undo.
+	history undo.
+	
+	history hasNext. ""true""
+	history redo.
+	saved. ""'3'""
+	history redo.
+	saved. ""'4'""
+	history redo. ""EXCEPTION: NothingToRedo""
+	
+	history redoIfEmpty: [ saved := nil ].
+	saved. ""nil""
+	
+ 
+Internal Representation and Key Implementation Points.
+--------------------
+
+    Instance Variables
+	redoAction:		<aValuable>		A valuable to execute when we redo an action.
+	redoStack:		<aStack>			A stack containing the elements that can be redone.
+	undoAction:		<aValuable>		A valuable to execute when we undo an action.
+	undoStack:		<aStack>			A stack containing the elements that can be undone.
+
+"
+Class {
+	#name : #ConfigurableHistoryIterator,
+	#superclass : #Object,
+	#instVars : [
+		'undoStack',
+		'redoStack',
+		'undoAction',
+		'redoAction'
+	],
+	#category : #'System-History-Iterators'
+}
+
+{ #category : #'instance creation' }
+ConfigurableHistoryIterator class >> undo: aBlockClosure redo: aBlockClosure2 [
+	^ self new
+		undoAction: aBlockClosure;
+		redoAction: aBlockClosure2;
+		yourself
+]
+
+{ #category : #accessing }
+ConfigurableHistoryIterator >> current [
+	self hasPrevious ifFalse: [ NothingToUndo signal ].
+	^ undoStack top
+]
+
+{ #category : #testing }
+ConfigurableHistoryIterator >> hasNext [
+	^ redoStack isNotEmpty
+]
+
+{ #category : #testing }
+ConfigurableHistoryIterator >> hasPrevious [
+	^ undoStack isNotEmpty
+]
+
+{ #category : #initialization }
+ConfigurableHistoryIterator >> initialize [
+	super initialize.
+	undoStack := Stack new.
+	redoStack := Stack new
+]
+
+{ #category : #action }
+ConfigurableHistoryIterator >> redo [
+	self redoIfEmpty: [ NothingToRedo signal ]
+]
+
+{ #category : #accessing }
+ConfigurableHistoryIterator >> redoAction: anObject [
+	redoAction := anObject
+]
+
+{ #category : #action }
+ConfigurableHistoryIterator >> redoIfEmpty: aBlockClosure [
+	| element |
+	self hasNext ifFalse: [ ^ aBlockClosure value ].
+	element := redoStack pop.
+	redoAction value: element.
+	undoStack push: element
+]
+
+{ #category : #adding }
+ConfigurableHistoryIterator >> register: anObject [
+	undoStack push: anObject.
+	redoStack removeAll
+]
+
+{ #category : #accessing }
+ConfigurableHistoryIterator >> size [
+	^ undoStack size
+]
+
+{ #category : #action }
+ConfigurableHistoryIterator >> undo [
+	self undoIfEmpty: [ NothingToUndo signal ]
+]
+
+{ #category : #accessing }
+ConfigurableHistoryIterator >> undoAction: anObject [
+	undoAction := anObject
+]
+
+{ #category : #action }
+ConfigurableHistoryIterator >> undoIfEmpty: aBlockClosure [
+	| element |
+	self hasPrevious ifFalse: [ ^ aBlockClosure value ].
+	element := undoStack pop.
+	undoAction value: element.
+	redoStack push: element
+]

--- a/src/System-History/ConfigurableHistoryIterator.class.st
+++ b/src/System-History/ConfigurableHistoryIterator.class.st
@@ -54,6 +54,15 @@ Internal Representation and Key Implementation Points.
 	redoStack:		<aStack>			A stack containing the elements that can be redone.
 	undoAction:		<aValuable>		A valuable to execute when we undo an action.
 	undoStack:		<aStack>			A stack containing the elements that can be undone.
+						
+	I work with a system of two stacks:
+	- One stack to store objects to undo 
+	- One stack to store ojbects to redo
+	
+	When the user wants to undo something, I'll pop the undo stack, evaluate the undo action with it and push it on the redo stack.
+	When the user wants to redo something, I'll pop the redo stack, evaluate the redo action with it and push it on the undo stack.
+	
+	When the user add a new item on the undo stack, I flush the redo stack.
 
 "
 Class {

--- a/src/System-History/ConfigurableHistoryIterator.class.st
+++ b/src/System-History/ConfigurableHistoryIterator.class.st
@@ -87,17 +87,23 @@ ConfigurableHistoryIterator class >> undo: aBlockClosure redo: aBlockClosure2 [
 
 { #category : #accessing }
 ConfigurableHistoryIterator >> current [
+	"I return the current element of the iteration. In case there is nothing to undo, I raise an exception."
+
 	self hasPrevious ifFalse: [ NothingToUndo signal ].
 	^ undoStack top
 ]
 
 { #category : #testing }
 ConfigurableHistoryIterator >> hasNext [
+	"Return true if there is at least one action to redo."
+
 	^ redoStack isNotEmpty
 ]
 
 { #category : #testing }
 ConfigurableHistoryIterator >> hasPrevious [
+	"Return true if there is at least one action to undo."
+
 	^ undoStack isNotEmpty
 ]
 
@@ -108,8 +114,10 @@ ConfigurableHistoryIterator >> initialize [
 	redoStack := Stack new
 ]
 
-{ #category : #action }
+{ #category : #actions }
 ConfigurableHistoryIterator >> redo [
+	"Redo the next action, in case there is none, raise an exception."
+
 	self redoIfEmpty: [ NothingToRedo signal ]
 ]
 
@@ -118,8 +126,10 @@ ConfigurableHistoryIterator >> redoAction: anObject [
 	redoAction := anObject
 ]
 
-{ #category : #action }
+{ #category : #actions }
 ConfigurableHistoryIterator >> redoIfEmpty: aBlockClosure [
+	"Redo the next action and register it in the undo list. In case there is no next action, execute the block as parameter."
+
 	| element |
 	self hasNext ifFalse: [ ^ aBlockClosure value ].
 	element := redoStack pop.
@@ -129,17 +139,23 @@ ConfigurableHistoryIterator >> redoIfEmpty: aBlockClosure [
 
 { #category : #adding }
 ConfigurableHistoryIterator >> register: anObject [
+	"Register an object to the undo list. This will flush the redo list."
+
 	undoStack push: anObject.
 	redoStack removeAll
 ]
 
 { #category : #accessing }
 ConfigurableHistoryIterator >> size [
+	"Return the size of the previous history"
+
 	^ undoStack size
 ]
 
-{ #category : #action }
+{ #category : #actions }
 ConfigurableHistoryIterator >> undo [
+	"Undo the previous action, in case there is none, raise an exception."
+
 	self undoIfEmpty: [ NothingToUndo signal ]
 ]
 
@@ -148,8 +164,9 @@ ConfigurableHistoryIterator >> undoAction: anObject [
 	undoAction := anObject
 ]
 
-{ #category : #action }
+{ #category : #actions }
 ConfigurableHistoryIterator >> undoIfEmpty: aBlockClosure [
+	"Redo the previous action and register it in the redo list. In case there is no previous action, execute the block as parameter."
 	| element |
 	self hasPrevious ifFalse: [ ^ aBlockClosure value ].
 	element := undoStack pop.

--- a/src/System-History/HistoryIterator.class.st
+++ b/src/System-History/HistoryIterator.class.st
@@ -30,7 +30,7 @@ Class {
 		'recorder',
 		'maxSize'
 	],
-	#category : #'System-History'
+	#category : #'System-History-Iterators'
 }
 
 { #category : #adding }

--- a/src/System-History/HistoryLeaf.class.st
+++ b/src/System-History/HistoryLeaf.class.st
@@ -4,7 +4,7 @@ This class represents the abstract leaf structure of items stored in History tre
 Class {
 	#name : #HistoryLeaf,
 	#superclass : #Object,
-	#category : #'System-History'
+	#category : #'System-History-Utilities'
 }
 
 { #category : #adding }

--- a/src/System-History/HistoryNode.class.st
+++ b/src/System-History/HistoryNode.class.st
@@ -77,7 +77,7 @@ Class {
 		'history',
 		'opened'
 	],
-	#category : #'System-History'
+	#category : #'System-History-Utilities'
 }
 
 { #category : #adding }

--- a/src/System-History/NothingToRedo.class.st
+++ b/src/System-History/NothingToRedo.class.st
@@ -1,0 +1,8 @@
+"
+I am an exception raised by a history iterator if the user try to redo an element of the history while there is nothing to redo.
+"
+Class {
+	#name : #NothingToRedo,
+	#superclass : #Exception,
+	#category : #'System-History-Exceptions'
+}

--- a/src/System-History/NothingToUndo.class.st
+++ b/src/System-History/NothingToUndo.class.st
@@ -1,0 +1,8 @@
+"
+I am an exception raised by a history iterator if the user try to undo an element of the history while there is nothing to undo.
+"
+Class {
+	#name : #NothingToUndo,
+	#superclass : #Exception,
+	#category : #'System-History-Exceptions'
+}

--- a/src/System-History/UndoRedoGroup.class.st
+++ b/src/System-History/UndoRedoGroup.class.st
@@ -7,7 +7,7 @@ Instance Variables
 Class {
 	#name : #UndoRedoGroup,
 	#superclass : #HistoryNode,
-	#category : #'System-History'
+	#category : #'System-History-Utilities'
 }
 
 { #category : #'undo-undo' }

--- a/src/System-History/UndoRedoRecord.class.st
+++ b/src/System-History/UndoRedoRecord.class.st
@@ -19,7 +19,7 @@ Class {
 		'redoMessage',
 		'undoMessage'
 	],
-	#category : #'System-History'
+	#category : #'System-History-Utilities'
 }
 
 { #category : #compatibility }


### PR DESCRIPTION
For the FileDialog of Pharo 8 I want to use an undo/redo system. I checked HistoryIterator but I find it too complicated for my needs.

In this PR I introduce a new history iterator. You configure it with an undo and redo block and then you can directly register objects you navigate into. When and undo or redo will happen, the objects will be used as parameter of the valuables to execute the action.

For example check test class and class comment of ConfigurableHistoryIterator.