### PR TITLE
Fixes issue 3068

### DIFF
--- a/src/AST-Core/CompiledMethod.extension.st
+++ b/src/AST-Core/CompiledMethod.extension.st
@@ -8,9 +8,9 @@ CompiledMethod >> ast [
 
 { #category : #'*AST-Core' }
 CompiledMethod >> comments [
-	"Answer a string representing the comments in the method. Return an empty collection if the method's source code does not contain a comment."
+	"Answer a collection of strings representing the comments in the method. Return an empty collection if the method's source code does not contain a comment."
 
-	^ self ast comments collect: [ :comment | comment contents ]
+	^ self ast allChildren flatCollect: [:el| el comments collect: [:c| c contents]]
 ]
 
 { #category : #'*AST-Core' }

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -169,9 +169,15 @@ CompiledMethodTest >> testBytecode [
 
 { #category : #'tests - accessing' }
 CompiledMethodTest >> testComments [
+	"I am the first comment to be found in this test"
 	self
-		assert: (CompiledMethod >> #comments) comments first
-		equals: 'Answer a string representing the comments in the method. Return an empty collection if the method''s source code does not contain a comment.'.
+		assert: (CompiledMethodTest >> #testComments) comments first 
+	"And I am the second comment to be found in this test"
+		equals: 'I am the first comment to be found in this test'.
+	self
+		assert: (CompiledMethodTest >> #testComments) comments second
+		equals: 'And I am the second comment to be found in this test'.
+	"Next test assumes #compiledMethod has no comment..."
 	self assert: (CompiledMethod >> #compiledMethod) comments isEmpty
 ]
 


### PR DESCRIPTION
It seems that the is a near solution already in the discussion of the issue. 
There is a method #firstComment, which should return the first comment, while #comments should return a list of them all.
I changed the method to return an ordered collection of comments in the method.

I changed the test method to depend less on the comments in other parts of the system, and noted where it does. Obviously I made the test check if two comments can be extracted as well.