### PR TITLE
2372-Add-scanTokens-to-RBScanner

### DIFF
--- a/src/AST-Core-Tests/RBScannerTest.class.st
+++ b/src/AST-Core-Tests/RBScannerTest.class.st
@@ -92,6 +92,20 @@ RBScannerTest >> testNextWithTwoDoubleQuotesInCommentGetError [
 		raise: SyntaxErrorNotification
 ]
 
+{ #category : #tests }
+RBScannerTest >> testScanTokens [
+	| inp exp |
+	inp := 'Object subclass: #NameOfSubclass'.
+	exp := {'Object'.
+	'subclass:'.
+	#NameOfSubclass asString}.
+	self assert: (RBScanner scanTokens: inp) equals: exp.
+	inp := 'classVariableNames: '''' "ha ha"
+package: ''UndefinedClasses-Experiment'.
+	exp := {'classVariableNames:' . '' . 'package:' . 'UndefinedClasses-Experiment'}.
+	self assert: (RBScanner scanTokens: inp) equals: exp
+]
+
 { #category : #utilities }
 RBScannerTest >> verifyErrorToken: scannedToken message: message valueExpected: valueExpected [
 	self assert: scannedToken isError.

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -150,6 +150,13 @@ RBScanner class >> patternVariableCharacter [
 	^ PatternVariableCharacter
 ]
 
+{ #category : #'public api' }
+RBScanner class >> scanTokens: aStringOrStream [
+	| scanner |
+	scanner := self on: aStringOrStream readStream.
+	^scanner contents collect:[ :t | t value ]
+]
+
 { #category : #testing }
 RBScanner >> atEnd [
 	^characterType = #eof


### PR DESCRIPTION
Fixes: #2372

I added a "scanTokens:" to RBScanner. I do not believe there should be a helper method in RBParser as the parser should focus on AST, but I am still new to all this.
The method was nearly there. I build on the #contents method of the scanner. Since the issue mentions a similarity to the #split method, I extract the token values from the scanner, and ignores the token types.
I added a test method as well, which check that white space and comments are removed.