### PR TITLE
4506-line-end-conversion-does-not-work-for-old-ByteTextConverters

### DIFF
--- a/src/Multilingual-Tests/ByteTextConverterTest.class.st
+++ b/src/Multilingual-Tests/ByteTextConverterTest.class.st
@@ -36,6 +36,61 @@ ByteTextConverterTest >> testLatin2ToUnicodeConversion [
 ]
 
 { #category : #testing }
+ByteTextConverterTest >> testLineEndConversion [
+	"Regression test for line end conversion.
+	Many byte encodings have overlap in the non-ascii range (and thus 0 entries in the 128-255 range of latin1Map, meaning they shouldn't be converted.
+	Previously a full nonAsciiMap with 1 as entries for the entire 128-255 range was installed.
+	This only ever really worked for utf-8 - for byte text converters it would lead to exceptions on any non-ascii character that didn't have to be converted."
+	| cp1252Bytes internalString converter encodedBytes  |
+        
+	"æøå all map to the same code points in cp1252 as in unicode."
+	cp1252Bytes := #[16rE6 16r0D 16r0A 16rF8 16r0D 16r0A 16rE5] .
+	internalString := String streamContents: [:s | 
+		s nextPut: $æ;
+			nextPut: Character cr;
+			nextPut: $ø;
+			nextPut: Character cr;
+			nextPut: $å].
+	converter := CP1252TextConverter new.
+	converter installLineEndConvention: String crlf.
+	
+	encodedBytes := (converter convertToSystemString: internalString) asByteArray.
+	
+	encodedBytes with: cp1252Bytes do: [ :encoded :truth | 
+		self assert: encoded equals: truth].	
+]
+
+{ #category : #testing }
+ByteTextConverterTest >> testLineEndConversionWideString [
+	"Regression test for line end conversion of wide strings.
+	- This uses a different path from the optimized path employed for byte (latin1) strings,
+	and essentially translates character by character.
+	This was written before line end conversion was added to the converters, assumed all translations were 1-1, and didn't use the latin1Encodings where line end conversion is installed at all, so never worked..."
+	| cp1252Bytes internalString converter encodedBytes  |
+        
+	"æøå all map to the same code points in cp1252 as in unicode. 
+	€ however, is codePoint 16r20AC in unicode (meaning the internalString will be wide), 
+	but 16r80 in cp1252"
+	
+	cp1252Bytes := #[16rE6 16r0D 16r0A 16rF8 16r0D 16r0A 16rE5 16r0D 16r0A 16r80] .
+	internalString := String streamContents: [:s | 
+		s nextPut: $æ;
+			nextPut: Character cr;
+			nextPut: $ø;
+			nextPut: Character cr;
+			nextPut: $å;
+			nextPutAll: String cr;
+			nextPut: $€].
+	converter := CP1252TextConverter new.
+	converter installLineEndConvention: String crlf.
+	
+	encodedBytes := (converter convertToSystemString: internalString) asByteArray.
+	
+	encodedBytes with: cp1252Bytes do: [ :encoded :truth | 
+		self assert: encoded equals: truth].	
+]
+
+{ #category : #testing }
 ByteTextConverterTest >> testUnicodeToLatin2Conversion [
         | latin2Bytes internalString encodingStream encodedBytes  |
 

--- a/src/Multilingual-TextConversion/ByteTextConverter.class.st
+++ b/src/Multilingual-TextConversion/ByteTextConverter.class.st
@@ -102,11 +102,9 @@ ByteTextConverter >> nextPut: unicodeCharacter toStream: aStream [
 { #category : #conversion }
 ByteTextConverter >> unicodeToByte: unicodeChar [
 
-	^unicodeChar codePoint < 256
-		ifTrue: [(latin1Map at: unicodeChar codePoint + 1) = 1 
-						ifTrue: [latin1Encodings at: unicodeChar codePoint + 1]
-						ifFalse: [unicodeChar]]
-		ifFalse: [self class unicodeToByteTable at: unicodeChar codePoint ifAbsent: [0 asCharacter]]
+	^unicodeChar charCode < 128
+		ifTrue: [unicodeChar]
+		ifFalse: [self class unicodeToByteTable at: unicodeChar charCode ifAbsent: [0 asCharacter]]
 ]
 
 { #category : #conversion }

--- a/src/Multilingual-TextConversion/ByteTextConverter.class.st
+++ b/src/Multilingual-TextConversion/ByteTextConverter.class.st
@@ -93,13 +93,36 @@ ByteTextConverter >> nextPut: unicodeCharacter toStream: aStream [
 
 	aStream isBinary
 		ifTrue: [aStream basicNextPut: unicodeCharacter charCode]
-		ifFalse: [aStream basicNextPut: (self unicodeToByte: unicodeCharacter)]
+		ifFalse: [
+			self 
+				unicodeToBytes: unicodeCharacter 
+				do: [:encodedChar | aStream basicNextPut: encodedChar ]]
 ]
 
 { #category : #conversion }
 ByteTextConverter >> unicodeToByte: unicodeChar [
 
-	^unicodeChar charCode < 128
-		ifTrue: [unicodeChar]
-		ifFalse: [self class unicodeToByteTable at: unicodeChar charCode ifAbsent: [0 asCharacter]]
+	^unicodeChar codePoint < 256
+		ifTrue: [(latin1Map at: unicodeChar codePoint + 1) = 1 
+						ifTrue: [latin1Encodings at: unicodeChar codePoint + 1]
+						ifFalse: [unicodeChar]]
+		ifFalse: [self class unicodeToByteTable at: unicodeChar codePoint ifAbsent: [0 asCharacter]]
+]
+
+{ #category : #conversion }
+ByteTextConverter >> unicodeToBytes: unicodeChar do: aBlock [
+	"Use the latin1 map if we can. 
+	This also covers line-end conversions, so mapping is potentially 1->N"
+	unicodeChar codePoint < 256 
+		ifTrue: [
+			"A 0 entry means the character in converter's encoding has same codePoint as unicode"
+			(latin1Map at: unicodeChar codePoint + 1) = 1 
+				ifTrue: [	(latin1Encodings at: unicodeChar codePoint + 1) do: 
+								[:each | aBlock value: each ]]
+				ifFalse: [aBlock value: unicodeChar]]
+		ifFalse: [|encodedChar|
+			encodedChar := self class unicodeToByteTable 
+				at: unicodeChar codePoint 
+				ifAbsent: [0 asCharacter].
+			aBlock value: encodedChar]
 ]

--- a/src/Multilingual-TextConversion/Character.extension.st
+++ b/src/Multilingual-TextConversion/Character.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #Character }
 Character >> macRomanToUnicode [
 	"Convert the receiver from MacRoman Unicode."
 
-	^MacRomanTextConverter new unicodeToByte: self
+	MacRomanTextConverter new unicodeToBytes: self do: [ :encodedChar | ^encodedChar ]
 ]
 
 { #category : #'*Multilingual-TextConversion' }

--- a/src/Multilingual-TextConversion/TextConverter.class.st
+++ b/src/Multilingual-TextConversion/TextConverter.class.st
@@ -1,5 +1,15 @@
 "
-The abstract class for all different type of text converters.  nextFromStream: and nextPut:toStream: are the public accessible methods.  If you are going to make a subclass for a stateful text conversion, you should override restoreStateOf:with: and saveStateOf: along the line of CompoundTextConverter.
+The historical abstract class for all different type of text converters. 
+
+nextFromStream: and nextPut:toStream: are the public accessible methods.  If you are going to make a subclass for a stateful text conversion, you should override restoreStateOf:with: and saveStateOf: along the line of CompoundTextConverter.
+
+Let this class be a lesson in the dangers of mixing too many responsibilities.
+As it's primary use was with FileStreams, and all FileStreams in Pharo do a full flush on each write,
+a lot of effort went into converting each nextPutAll:toStream: to the least amount of nextPutAll: sends needed. 
+This included optimizing for byteStrings by clever use of seek primitives and a map of non-ascii characters up to codePoint 255 that would need to be converted.
+Later on, another clever idea that the same map could be used to perform line end conversion, ended up in a half-baked implementation that only worked for byte strings, and utf8. The bugs associated with it (See ByteTextConverterTest >> #testLineEndConversion/testLineEndConversionWideString), remained unfixed until this class was superceded by ZnConverters, due to the difficulty of maintaining a class with so many mixed responsibilities.
+
+
 
 "
 Class {
@@ -113,6 +123,8 @@ TextConverter class >> newForEncoding: aString [
 
 { #category : #conversion }
 TextConverter >> convertFromSystemString: aString [
+	"System in this case means a system using this converters encoding.
+	So, convert from encoded String -> internal (unicode) String"
 
 	| readStream writeStream |
 	readStream := aString readStream.
@@ -126,7 +138,8 @@ TextConverter >> convertFromSystemString: aString [
 
 { #category : #conversion }
 TextConverter >> convertToSystemString: aString [
-
+	"System in this case means a system using this converters encoding.
+	So, convert from internal (unicode) String -> encoded String"
 	| writeStream |
 	writeStream := String new writeStream.
 	self nextPutAll: aString toStream: writeStream.
@@ -151,8 +164,8 @@ TextConverter >> installLineEndConvention: lineEndStringOrNil [
 	
 	lineEndStringOrNil ifNotNil:
 		[latin1Encodings := latin1Encodings copy.
-		latin1Encodings at: Character cr asciiValue + 1 put: (self convertFromSystemString: lineEndStringOrNil).
-		latin1Map := ByteString nonAsciiMap copy.
+		latin1Encodings at: Character cr asciiValue + 1 put: (self convertToSystemString: lineEndStringOrNil).
+		latin1Map := self class latin1Map copy.
 		latin1Map at: Character cr asciiValue + 1 put: 1]
 ]
 


### PR DESCRIPTION
Fixes #4506 , contains tests for line end conversion issues in the old ByteTextConverters:  .

Also updated class comment of TextConverter to better explain why it's no longer recommended for active use.

Couldn't find the "development" branch as described on 
https://github.com/pharo-project/pharo/wiki/Contribute-a-fix-to-Pharo
but saw there were pull requests being merged on Pharo8, so hopefully this is the right way...