### PR TITLE
Deprecation Transform: We should define it using Pragmas

### DIFF
--- a/src/Kernel/Deprecation.class.st
+++ b/src/Kernel/Deprecation.class.st
@@ -200,10 +200,10 @@ Deprecation >> showWarning [
 Deprecation >> signal [
 	| pragma |
 	(context method hasPragmaNamed: #transform:to:) ifFalse: [ ^super signal ].
-	
+
 	pragma := context method pragmaAt: #transform:to:.
 	self rule: pragma arguments first -> pragma arguments second.
-	^self transform
+	self transform
 ]
 
 { #category : #handling }

--- a/src/Kernel/Deprecation.class.st
+++ b/src/Kernel/Deprecation.class.st
@@ -197,6 +197,16 @@ Deprecation >> showWarning [
 ]
 
 { #category : #handling }
+Deprecation >> signal [
+	| pragma |
+	(context method hasPragmaNamed: #transform:to:) ifFalse: [ ^super signal ].
+	
+	pragma := context method pragmaAt: #transform:to:.
+	self rule: pragma arguments first -> pragma arguments second.
+	^self transform
+]
+
+{ #category : #handling }
 Deprecation >> transform [
 	| node rewriteRule aMethod |
 	self shouldTransform ifFalse: [ ^ self ].


### PR DESCRIPTION
this change provides to defines transformations in all deprecation calls. Not need to use #deprecated:transformWith:. Instead use a normal deprecation method (any of them) and add the transformation as a pragma:

<transform:   '`@receiver asSetElement'  with: '`@receiver asCollectionElement'>

The selector for the pragma is too general, but I would like to avoind adding the term "deprecation" as I want to add a scheme for tagging methods for backward compatibility which are transformed, too.