### PR TITLE
4510-ensureCreateFile-in-a-file-stored-in-a-memory-store-overwrite-file-contents

### DIFF
--- a/src/FileSystem-Memory/MemoryFileWriteStream.class.st
+++ b/src/FileSystem-Memory/MemoryFileWriteStream.class.st
@@ -38,10 +38,10 @@ MemoryFileWriteStream >> file: aMemoryFileSystemFile [
 
 { #category : #writing }
 MemoryFileWriteStream >> flush [
-	| content |
-	content := self stream contents.
-	(content size > 0)
-		ifTrue: [ file updateContents: content ]
+	| contents |
+	contents := self stream contents.
+	(contents size > 0)
+		ifTrue: [ file updateContents: contents ]
 ]
 
 { #category : #testing }

--- a/src/FileSystem-Memory/MemoryFileWriteStream.class.st
+++ b/src/FileSystem-Memory/MemoryFileWriteStream.class.st
@@ -38,7 +38,10 @@ MemoryFileWriteStream >> file: aMemoryFileSystemFile [
 
 { #category : #writing }
 MemoryFileWriteStream >> flush [
-	file updateContents: self stream contents
+	| content |
+	content := self stream contents.
+	(content size > 0)
+		ifTrue: [ file updateContents: content ]
 ]
 
 { #category : #testing }

--- a/src/FileSystem-Tests-Memory/MemoryFileSystemTest.class.st
+++ b/src/FileSystem-Tests-Memory/MemoryFileSystemTest.class.st
@@ -134,6 +134,19 @@ MemoryFileSystemTest >> testDirectoryMoveToRename [
 ]
 
 { #category : #tests }
+MemoryFileSystemTest >> testEnsureCreateFileDoesNotOverwriteExistingContent [
+	| file |
+	file := filesystem root / 'a.txt'.
+	file writeStreamDo: [ :s | s nextPutAll: 'ok' ].
+	self assert: file contents equals: 'ok'.
+	
+	file ensureCreateFile.
+
+	self assert: file contents equals: 'ok'.
+
+]
+
+{ #category : #tests }
 MemoryFileSystemTest >> testIsMemoryFileSystem [
 	self assert: filesystem isMemoryFileSystem.
 	


### PR DESCRIPTION
Do not update file  content when flushing  if stream has no content.Fixes #4510