### PR TITLE
4480-Fix-Typos-in-BooleanSlot-class-comment

### DIFF
--- a/src/Slot-Examples/BooleanSlot.class.st
+++ b/src/Slot-Examples/BooleanSlot.class.st
@@ -1,7 +1,5 @@
 "
-**Unfinished, see #todo**
-
-I am a Slot that does not allocate one field for each slot. Instead, all Booleanlots of the whole hierarchy are allocated in an integrer that is stored in an invisible slot .
+I am a Slot that does not allocate one field for each slot. Instead, all BooleanSlots of the whole hierarchy are allocated in an integer that is stored in an invisible slot.
 
 
 "


### PR DESCRIPTION
Fix Typos in BooleanSlot class comment 


Fix #4480