### PR TITLE
4530-Auto-completion-fail-on-thisContext

### DIFF
--- a/src/NECompletion/CompletionProducer.class.st
+++ b/src/NECompletion/CompletionProducer.class.st
@@ -153,6 +153,11 @@ CompletionProducer >> visitTemporaryNode: aNode [
 ]
 
 { #category : #visiting }
+CompletionProducer >> visitThisContextNode: aThisContextNode [
+	^ #()
+]
+
+{ #category : #visiting }
 CompletionProducer >> visitVariableNode: aRBVariableNode [
 	| lookupClass |
 	lookupClass := currentClass ifNil: [ UndefinedObject ].


### PR DESCRIPTION
Completion should not fail on #thisContext.Fixes #4530