### PR TITLE
2449-Automatic-rewriting-of-deprecated-code-needs-feedback-to-developers-whose-code-is-changed

### DIFF
--- a/src/Kernel/Deprecation.class.st
+++ b/src/Kernel/Deprecation.class.st
@@ -159,10 +159,16 @@ Deprecation >> logTranscript [
 
 { #category : #accessing }
 Deprecation >> messageText [
-	"Return an exception's message text."
-
-	^ 'The method ', self deprecatedMethodName, ' called from ', self sendingMethodName ,' has been deprecated.
-', explanationString
+	^String streamContents: [ :str |
+		self shouldTransform ifTrue: [ 
+			str nextPutAll:  'Automatic deprecation code rewrite: '].
+		str 
+			nextPutAll: 'The method ';
+			nextPutAll: self deprecatedMethodName;
+			nextPutAll: ' called from ';
+			nextPutAll: self sendingMethodName;
+			nextPutAll: ' has been deprecated. ';
+		 	nextPutAll: explanationString]
 ]
 
 { #category : #settings }


### PR DESCRIPTION
add a message when code transformation is done:

Automatic deprecation code rewrite: The method Object>>#test called from Object>>#test2 has been deprecated. use test2