### PR TITLE
4547-CompiledCode-misses-a-subclassResponsibilty-for-methodClass

### DIFF
--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -501,6 +501,11 @@ CompiledCode >> longPrintOn: aStream [
 
 ]
 
+{ #category : #accessing }
+CompiledCode >> methodClass [
+	self subclassResponsibility
+]
+
 { #category : #initialization }
 CompiledCode >> needsFrameSize: newFrameSize [
 	"Set the largeFrameBit to accomodate the newFrameSize"


### PR DESCRIPTION
add #methodClass, fix #4547