### PR TITLE
4550-Remove-class-refactoring-should-not-warn-user-if-the-class-reference-itself

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyBrowserMorph.extension.st
+++ b/src/Calypso-SystemTools-Core/ClyBrowserMorph.extension.st
@@ -46,7 +46,8 @@ ClyBrowserMorph >> confirmUnusedClasses: classes [
 	| refQuery noUsers answer subclasses users |
 	
 	refQuery := ClyClassReferencesQuery toAny: classes from: self systemScope.	
-	noUsers := self confirmEmptySystemQuery: refQuery excluding: classes.
+	"we need to exclude both the class and instance side of the class"
+	noUsers := self confirmEmptySystemQuery: refQuery excluding: (classes flatCollect: [ :each | { each . each classSide } ]).
 	
 	subclasses := (classes flatCollect: [:each | each subclasses]) copyWithoutAll: classes.
 	subclasses ifNotEmpty: [ 


### PR DESCRIPTION
fix #4550 

fix is  to exclude both class and instance side