### PR TITLE
4559-visitSlotInitializationNode-should-not-be-subclassResponsibility

### DIFF
--- a/src/ClassParser/RBProgramNodeVisitor.extension.st
+++ b/src/ClassParser/RBProgramNodeVisitor.extension.st
@@ -3,5 +3,5 @@ Extension { #name : #RBProgramNodeVisitor }
 { #category : #'*ClassParser' }
 RBProgramNodeVisitor >> visitSlotInitializationNode: aSlotInitializationNode [
 
-	self subclassResponsibility 
+	^aSlotInitializationNode
 ]


### PR DESCRIPTION
fixes #4559