### PR TITLE
4563-reflectivity-update-rfValue

### DIFF
--- a/src/Kernel/FullBlockClosure.class.st
+++ b/src/Kernel/FullBlockClosure.class.st
@@ -94,6 +94,24 @@ FullBlockClosure >> receiver: anObject [
 ]
 
 { #category : #evaluating }
+FullBlockClosure >> rfvalue [
+	"Activate the receiver, creating a closure activation (MethodContext)
+	 whose closure is the receiver and whose caller is the sender of this
+	 message. Supply the copied values to the activation as its copied
+	 temps. Primitive. Essential."
+	<primitive: 207>
+	<metaLinkOptions: #( + optionDisabledLink)>
+	| newContext |
+	numArgs ~= 0 ifTrue:
+		[self numArgsError: 0].
+	false
+		ifTrue: "Old code to simulate the closure value primitive on VMs that lack it."
+			[newContext := self asContextWithSender: thisContext sender.
+			thisContext privSender: newContext]
+		ifFalse: [self primitiveFailed]
+]
+
+{ #category : #evaluating }
 FullBlockClosure >> rfvalueNoContextSwitch [
 	"same as valueNoContextSwitch, for recursion stopping metalinks"
 	<primitive: 209>

--- a/src/Reflectivity/BlockClosure.extension.st
+++ b/src/Reflectivity/BlockClosure.extension.st
@@ -20,6 +20,8 @@ BlockClosure >> rfvalue [
 	"same as value, for recursion stopping metalinks"
 	<primitive: 201>
 	<metaLinkOptions: #( + optionDisabledLink)>
+	numArgs ~= 0 ifTrue:
+		[self numArgsError: 0].
 	^self primitiveFailed
 ]
 


### PR DESCRIPTION
just add a copy with methods where metalinks are turned off. they are used in the code path that activates links, thus having the copy allows us to annotate the orginals without running into strange loops.

fixes #4563