### PR TITLE
Remove somme Smalltalk references on Spec-2 example

### DIFF
--- a/src/Spec2-Examples/SpListPresenter.extension.st
+++ b/src/Spec2-Examples/SpListPresenter.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #SpListPresenter }
 SpListPresenter class >> example [
 	<sampleInstance>
 	^ self new
-		items: Smalltalk globals allClasses;
+		items: self environment allClasses;
 		openWithSpec;
 		yourself
 ]
@@ -13,7 +13,7 @@ SpListPresenter class >> example [
 SpListPresenter class >> exampleMultipleSelection [
 	<sampleInstance>
 	^ self new
-		items: Smalltalk globals allClasses;
+		items: self environment allClasses;
 		beMultipleSelection;
 		openWithSpec;
 		yourself
@@ -23,7 +23,7 @@ SpListPresenter class >> exampleMultipleSelection [
 SpListPresenter class >> exampleWithHeaderTitle [
 	<sampleInstance>
 	^ self new
-		items: Smalltalk globals allClasses;
+		items: self environment allClasses;
 		headerTitle: 'Title';
 		openWithSpec;
 		yourself

--- a/src/Spec2-Examples/SpListSelectionPresenter.class.st
+++ b/src/Spec2-Examples/SpListSelectionPresenter.class.st
@@ -44,7 +44,7 @@ SpListSelectionPresenter >> initializeWidgets [
 	textModel1 := self newText.
 	textModel2 := self newCode.
 	listModel beMultipleSelection.
-	listModel items: Smalltalk globals allClasses
+	listModel items: self class environment allClasses
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Examples/SpTextFieldExample.class.st
+++ b/src/Spec2-Examples/SpTextFieldExample.class.st
@@ -39,7 +39,7 @@ SpTextFieldExample >> initialExtent [
 { #category : #initialization }
 SpTextFieldExample >> initializePresenter [
 	
-	textField acceptBlock: [:text | Smalltalk globals at: text asSymbol
+	textField acceptBlock: [:text | self class environment at: text asSymbol
 								ifPresent: [:class | methodBrowser messages: class methods ]
 								ifAbsent: [ methodBrowser messages: #() ]]
 ]


### PR DESCRIPTION
Restart the removal of Smalltalks reference with smaller pull requests and commits.
This one removes almost all of them in spec2-example.