### PR TITLE
FIxesIssue4364

### DIFF
--- a/src/Collections-Sequenceable/SortedCollection.class.st
+++ b/src/Collections-Sequenceable/SortedCollection.class.st
@@ -88,6 +88,14 @@ SortedCollection class >> sortUsing: aBlockOrSortFunction [
 	^ self new sortBlock: aBlockOrSortFunction
 ]
 
+{ #category : #copying }
+SortedCollection >> , otherCollection [
+	| newSortedCollection |
+	newSortedCollection := super , otherCollection.
+	newSortedCollection sortBlock: self sortBlock .
+	^newSortedCollection 
+]
+
 { #category : #comparing }
 SortedCollection >> = aSortedCollection [
 	"Answer true if my and aSortedCollection's species are the same,

--- a/src/Collections-Tests/SortedCollectionTest.class.st
+++ b/src/Collections-Tests/SortedCollectionTest.class.st
@@ -515,6 +515,17 @@ SortedCollectionTest >> testCollect [
 	
 ]
 
+{ #category : #tests }
+SortedCollectionTest >> testComma [
+	| sortBlock collOne collTwo combined |
+	sortBlock := [ :a :b | a > b ].
+	collOne := (1 to: 5) asSortedCollection: sortBlock.
+	collTwo := (6 to: 10) asSortedCollection: sortBlock.
+	combined := collOne , collTwo.
+	self assert: combined sortBlock equals: sortBlock.
+	self assert: combined asArray equals: (1 to: 10) asArray reverse
+]
+
 { #category : #'tests - basic' }
 SortedCollectionTest >> testCopy [
 		

--- a/src/Collections-Tests/WeakValueDictionaryTest.class.st
+++ b/src/Collections-Tests/WeakValueDictionaryTest.class.st
@@ -141,16 +141,6 @@ WeakValueDictionaryTest >> testRehashDoesNotTransformAssociations [
 	self assert: (d privateAssociations anyOne isKindOf: WeakValueAssociation)
 ]
 
-{ #category : #'tests - size capacity' }
-WeakValueDictionaryTest >> testSize [
-	| d |
-	d := self classToBeTested new.
-	self assert: d size equals: 0.
-	d at: 1 put: 2.
-	d at: 2 put: nil.
-	self assert: d size equals: 2
-]
-
 { #category : #tests }
 WeakValueDictionaryTest >> testReturnedAssociationsAreRight [
 	| dictionary |
@@ -159,6 +149,16 @@ WeakValueDictionaryTest >> testReturnedAssociationsAreRight [
 	dictionary at: 'test2' put: 1.
 	self assert: (dictionary associationAt: 'test') value isNil.
 	self assert: (dictionary associationAt: 'test2') value equals: 1
+]
+
+{ #category : #'tests - size capacity' }
+WeakValueDictionaryTest >> testSize [
+	| d |
+	d := self classToBeTested new.
+	self assert: d size equals: 0.
+	d at: 1 put: 2.
+	d at: 2 put: nil.
+	self assert: d size equals: 2
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Fixes #4364 

I added the tests which was implicitly part of the original issue.
Besides Symbol, no other subclass of SequenceableCollection (which is the least superclass of SortedCollection to implement #,.).

The issue is only for sorted collection, as is a simple case of not copying the instance variable in sorted collection to the new object.