### PR TITLE
4577-IntegerasArray-should-be-removed

### DIFF
--- a/src/Kernel/Integer.class.st
+++ b/src/Kernel/Integer.class.st
@@ -295,17 +295,6 @@ Integer >> as31BitSmallInt [
 ]
 
 { #category : #'converting-arrays' }
-Integer >> asArray [
-
-	| stream |
-	stream := Array new writeStream.
-	self digitLength to: 1 by: -1 do: [:digitIndex |
-		stream nextPut: (self digitAt: digitIndex)].
-	^ stream contents
-
-]
-
-{ #category : #'converting-arrays' }
 Integer >> asByteArray [
 
 	| stream |


### PR DESCRIPTION
fixes #4577remove Integer>>#asArray
do not use (auto)deprectaion because rewrite to asByteArray is not what people may expect