### PR TITLE
4574-confusing-comment-in-ThreadSafeTranscriptendEntry

### DIFF
--- a/src/Transcript-Core/ThreadSafeTranscript.class.st
+++ b/src/Transcript-Core/ThreadSafeTranscript.class.st
@@ -119,8 +119,8 @@ ThreadSafeTranscript >> critical: block [
 
 { #category : #streaming }
 ThreadSafeTranscript >> endEntry [
-"	Signal to #step to display all the characters since the last #step. 
-	Stream is reset there.
+"	
+	The next #stepGlobal message (usually invoked by Morhic stepping) will raise an #appendEntry update and reset the stream.
 "  
   	self critical: [ deferredEndEntry := true ].
 ]


### PR DESCRIPTION
fixes #4574update ThreadSafeTranscript>>#endEntry comment