### PR TITLE
2845-Error-in-CollectionflatCollect-b-as-String

### DIFF
--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -695,11 +695,11 @@ Collection >> flatCollect: aBlock as: aCollectionClass [
 	"Evaluate aBlock for each of the receiver's elements and answer the
 	list of all resulting values flatten one level. Assumes that aBlock returns some kind
 	of collection for each element. Equivalent to the lisp's mapcan"
+
 	| col |
-	col := aCollectionClass new: self size. 	
-	self do: [ :each |
-		col addAll: (aBlock value: each) ].
-	^col
+	col := OrderedCollection new: self size.
+	self do: [ :each | col addAll: (aBlock value: each) ].
+	^ aCollectionClass withAll: col 
 ]
 
 { #category : #enumerating }

--- a/src/Collections-Tests/TEnumeratingTest.trait.st
+++ b/src/Collections-Tests/TEnumeratingTest.trait.st
@@ -49,7 +49,13 @@ TEnumeratingTest >> testFlatCollectAs [
 
 	self 
 		assert: (self simpleCollection flatCollect: [ :x | { x }, { x } ] as: IdentitySet) 
-		equals: self simpleCollection asIdentitySet
+		equals: self simpleCollection asIdentitySet.
+	self
+		assert: (#(foo bar baz) flatCollect: #yourself as: String)
+		equals: 'foobarbaz'.
+	self 
+		assert: (#(#(1 2) #(4 3)) flatCollect: #yourself as: Array)
+		equals: #(1 2 4 3)
 ]
 
 { #category : #'tests - enumerating' }


### PR DESCRIPTION
Fixes #2845

The reason for the error  is that the method `#flatCollect:as:` inserts elements into the collection type given as second argument. String is immutable, so that is not possible.