### PR TITLE
2335-MemoryFileWriteStream

### DIFF
--- a/src/FileSystem-Memory/MemoryFileWriteStream.class.st
+++ b/src/FileSystem-Memory/MemoryFileWriteStream.class.st
@@ -3,7 +3,7 @@ A file write stream - but within memory
 "
 Class {
 	#name : #MemoryFileWriteStream,
-	#superclass : #Object,
+	#superclass : #Stream,
 	#instVars : [
 		'file',
 		'stream'
@@ -13,10 +13,14 @@ Class {
 
 { #category : #'instance creation' }
 MemoryFileWriteStream class >> on: aFile [
-
-	^ self new
+	^ self basicNew
 		file: aFile;
 		yourself
+]
+
+{ #category : #testing }
+MemoryFileWriteStream >> atEnd [
+	self shouldNotImplement 
 ]
 
 { #category : #'opening-closing' }
@@ -29,6 +33,11 @@ MemoryFileWriteStream >> close [
 { #category : #'opening-closing' }
 MemoryFileWriteStream >> closed [
 	^ file closed
+]
+
+{ #category : #accessing }
+MemoryFileWriteStream >> contents [
+	self shouldNotImplement 
 ]
 
 { #category : #accessing }
@@ -47,6 +56,11 @@ MemoryFileWriteStream >> flush [
 { #category : #testing }
 MemoryFileWriteStream >> isBinary [
 	^ self stream isBinary
+]
+
+{ #category : #accessing }
+MemoryFileWriteStream >> next [
+	self shouldNotImplement 
 ]
 
 { #category : #writing }

--- a/src/FileSystem-Tests-Memory/MemoryFileSystemTest.class.st
+++ b/src/FileSystem-Tests-Memory/MemoryFileSystemTest.class.st
@@ -153,6 +153,16 @@ MemoryFileSystemTest >> testIsMemoryFileSystem [
 ]
 
 { #category : #tests }
+MemoryFileSystemTest >> testLargeFile [
+	| bytes |
+	bytes := ByteArray new: 80000.
+	self 
+		shouldnt: [(FileSystem memory / 'output.bytes')
+			binaryWriteStreamDo: [ :stream | stream nextPutAll: bytes]]
+		raise: Error.
+]
+
+{ #category : #tests }
 MemoryFileSystemTest >> testModifiedTimeWhenFileCreated [
 	self assert: (filesystem / 'file.txt') ensureCreateFile modificationTime notNil
 ]


### PR DESCRIPTION
Fixes for #2335-MemoryFileWriteStream-did-not-understand-nextputAllstartingAtHopefully without unwished commits.