### PR TITLE
4616-Move-BecomeTest-from-Tests-to-Kernel-Tests

### DIFF
--- a/src/Kernel-Tests/BecomeTest.class.st
+++ b/src/Kernel-Tests/BecomeTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #BecomeTest,
 	#superclass : #TestCase,
-	#category : #'Tests-VM'
+	#category : #'Kernel-Tests-Objects'
 }
 
 { #category : #testing }


### PR DESCRIPTION
Move BecomeTest from Tests to Kernel-Tests

Fix #4616