### PR TITLE
Fix-typo-in-FastTable

### DIFF
--- a/src/Deprecated80/FTFunction.extension.st
+++ b/src/Deprecated80/FTFunction.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #FTFunction }
+
+{ #category : #'*Deprecated80' }
+FTFunction >> beExplicite [
+	self deprecated: 'Use #beExplicit instead' transformWith: '`@receiver beExplicite' -> '`@receiver beExplicit'.
+	^ self beExplicit
+]
+
+{ #category : #'*Deprecated80' }
+FTFunction >> isExplicite [
+	self deprecated: 'Use #isExplicit instead' transformWith: '`@receiver isExplicite' -> '`@receiver isExplicit'.
+	^ self isExplicit
+]

--- a/src/Morphic-Widgets-FastTable/FTFilterFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTFilterFunction.class.st
@@ -38,7 +38,7 @@ FTFilterFunction >> filter [
 	table refresh.
 	table deselectAll.
 		
-	self isExplicite
+	self isExplicit
 		ifTrue: [ self resizeWidget ]
 ]
 
@@ -79,7 +79,7 @@ FTFilterFunction >> initializeFilter [
 
 { #category : #'event handling' }
 FTFilterFunction >> keyStroke: anEvent [
-	self isExplicite ifTrue: [ ^false ].
+	self isExplicit ifTrue: [ ^false ].
 	
 	(anEvent keyCharacter = Character escape and: [ initialDataSource isNotNil ])
 		ifTrue: [ ^ self reinitializeTable ].	"If the user escape after a search, he want the full data source again so we reinitialize the table."

--- a/src/Morphic-Widgets-FastTable/FTFilterFunctionWithAction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTFilterFunctionWithAction.class.st
@@ -48,8 +48,8 @@ FTFilterFunctionWithAction >> action: aBlockClosure named: aString [
 ]
 
 { #category : #accessing }
-FTFilterFunctionWithAction >> beExplicite [
-	super beExplicite.
+FTFilterFunctionWithAction >> beExplicit [
+	super beExplicit.
 	table addMorph: actionButton.
 	table selectedIndex = 0
 		ifTrue: [ table selectIndex: 1 ]

--- a/src/Morphic-Widgets-FastTable/FTFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTFunction.class.st
@@ -58,7 +58,7 @@ FTFunction class >> table: aFastTableMorph [
 ]
 
 { #category : #accessing }
-FTFunction >> beExplicite [
+FTFunction >> beExplicit [
 	"This method is call by the FastTable if the user want the widget to be explicit. Describe what to do to be explicit."
 
 	self subclassResponsibility
@@ -78,7 +78,7 @@ FTFunction >> initializeTable: aTable [
 ]
 
 { #category : #testing }
-FTFunction >> isExplicite [
+FTFunction >> isExplicit [
 	"See FTFunctionWithField to get an example."
 
 	self subclassResponsibility

--- a/src/Morphic-Widgets-FastTable/FTFunctionWithField.class.st
+++ b/src/Morphic-Widgets-FastTable/FTFunctionWithField.class.st
@@ -37,7 +37,7 @@ FTFunctionWithField class >> isAbstract [
 ]
 
 { #category : #accessing }
-FTFunctionWithField >> beExplicite [
+FTFunctionWithField >> beExplicit [
 	self initializeMorph.
 	table
 		addMorph: field;
@@ -72,7 +72,7 @@ FTFunctionWithField >> initializeMorph [
 ]
 
 { #category : #testing }
-FTFunctionWithField >> isExplicite [
+FTFunctionWithField >> isExplicit [
 	^ field isNotNil
 ]
 

--- a/src/Morphic-Widgets-FastTable/FTNilFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTNilFunction.class.st
@@ -14,7 +14,7 @@ Class {
 }
 
 { #category : #accessing }
-FTNilFunction >> beExplicite [
+FTNilFunction >> beExplicit [
 	"Do nothing"
 ]
 
@@ -26,7 +26,7 @@ FTNilFunction >> disable [
 ]
 
 { #category : #testing }
-FTNilFunction >> isExplicite [
+FTNilFunction >> isExplicit [
 	^ false
 ]
 

--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -274,7 +274,7 @@ FTTableMorph >> deselectAll [
 FTTableMorph >> disableFunction [
 	"Disabling it just sets the funtion to nil, so I can safely skip it in #keyStrokeSearch:"
 
-	function isExplicite
+	function isExplicit
 		ifTrue: [ function disable.
 			self resizeAllSubviews	"This is call because now the container will take all the available space." ].
 	function := FTNilFunction table: self
@@ -913,7 +913,7 @@ FTTableMorph >> resizeAllSubviews [
 	self container setNeedsRefreshExposedRows.
 	self container updateExposedRows.
 	self verticalScrollBar value: (self rowIndexToVerticalScrollBarValue: showIndex).
-	function isExplicite
+	function isExplicit
 		ifTrue: [ function resizeWidget ]
 ]
 
@@ -925,7 +925,7 @@ FTTableMorph >> resizeContainer [
 					 @ (self bounds bottom - self horizontalScrollBarHeight - self borderWidth).
 	self container
 		bounds:
-			(function isExplicite
+			(function isExplicit
 				ifTrue: [ function resizeContainerFrom: topLeft to: bottomRight ]
 				ifFalse: [ topLeft corner: bottomRight ])
 ]

--- a/src/SystemCommands-RefactoringSupport/SycRefactoringPreview.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycRefactoringPreview.class.st
@@ -162,7 +162,7 @@ SycRefactoringPreview >> initializeWidgets [
 	table := self newTable.
 	diffPresenter := self newDiff.
 	scopeDropList := self newDropList.
-	
+
 	table
 		addColumn:
 			((SpCheckBoxTableColumn evaluated: [ :x | selectedRefactorings at: x ])
@@ -171,10 +171,10 @@ SycRefactoringPreview >> initializeWidgets [
 				width: 20);
 		addColumn: (SpStringTableColumn evaluated: #name);
 		hideColumnHeaders.
-		
+
 	diffPresenter disable.
-	scopeDropList displayBlock: [ :scope | scope description capitalized ].
-	
+	scopeDropList display: [ :scope | scope description capitalized ].
+
 	self
 		selectectAllCheckBox;
 		setShortcuts;


### PR DESCRIPTION
Fix typo in FastTable. *Explicite should be *Explicit.