### PR TITLE
4641-OCASTClosureAnalyzer-does-not-update-binding-of-temp-var-definitions

### DIFF
--- a/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
@@ -25,6 +25,14 @@ OCASTClosureAnalyzer >> doRemotes [
 	
 ]
 
+{ #category : #variables }
+OCASTClosureAnalyzer >> lookupAndFixBinding: aVariableNode [
+	| var |
+	var := scope lookupVar: aVariableNode name.
+	aVariableNode binding: var.
+	^var
+]
+
 { #category : #visiting }
 OCASTClosureAnalyzer >> visitArgumentNode: aVariableNode [
 
@@ -38,6 +46,7 @@ OCASTClosureAnalyzer >> visitBlockNode: aBlockNode [
 	scope := aBlockNode scope.	
 	self doRemotes; doCopying.
 	self visitNode: aBlockNode body.
+	aBlockNode temporaries do: [ :each | self lookupAndFixBinding: each ].
 	scope := scope popScope.
 ]
 
@@ -48,6 +57,7 @@ OCASTClosureAnalyzer >> visitMethodNode: aMethodNode [
 	scope := aMethodNode scope.	
 	self doRemotes; doCopying.
 	self visitNode: aMethodNode body.
+	aMethodNode temporaries do: [ :each | self lookupAndFixBinding: each ]
 ]
 
 { #category : #visiting }
@@ -57,8 +67,7 @@ OCASTClosureAnalyzer >> visitVariableNode: aVariableNode [
 	| var |
 	aVariableNode adaptToSemanticNode.
 	aVariableNode isTemp ifFalse: [^self].
-	var := scope lookupVar: aVariableNode name.
-	aVariableNode binding: var.
+	var := self lookupAndFixBinding: aVariableNode.
 	var isTempVectorTemp ifTrue: [scope addCopyingTempToAllScopesUpToDefVector: var vectorName].
 	var isCopying ifTrue: [scope addCopyingTempToAllScopesUpToDefTemp: var].
 ]

--- a/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
@@ -625,6 +625,24 @@ OCASTClosureAnalyzerTest >> testSingleRemoteTempVar [
 
 ]
 
+{ #category : #'testing - variables' }
+OCASTClosureAnalyzerTest >> testVariableDefintionScopeUpdate [
+	"the scope of local var definitons needs to be updated, too"
+
+	| ast |
+	ast := OpalCompiler new parse:
+			'm04_two_temps_one_temp_in_remote_vector
+
+| t1 t2 |
+
+t1 := 1.
+[ t2 := t1 +  1.0 ] value.
+
+^t2'.
+	ast doSemanticAnalysis.
+	self assert: ast temporaries second binding class equals: OCVectorTempVariable
+]
+
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testWrittenAfterClosedOver [
 	| ast |


### PR DESCRIPTION
factor out binding re-lookup and fix as #lookupAndFixBinding: and call it at the end of blocks and method on the temp defintion nodes

fixes #4641