### PR TITLE
2594-Add-a-way-to-browse-the-cursors-in-an-inspector

### DIFF
--- a/src/GT-InspectorExtensions-Core/Cursor.extension.st
+++ b/src/GT-InspectorExtensions-Core/Cursor.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #Cursor }
+
+{ #category : #'*GT-InspectorExtensions-Core' }
+Cursor class >> gtInspectorCursorsIn: composite [ 
+	<gtInspectorPresentationOrder: 10>
+	composite list 
+		title: 'Cursors';
+		display: [self classVariables sorted: [ :a :b | a key < b key ] ];
+		icon: [ :each | each value ];
+		format: [ :each | each key ]
+]


### PR DESCRIPTION
Fixes #2594
Add a way to browse the cursors in an inspector.
Inspect "Cursor class".