### PR TITLE
Cannot-rewrite-code-with-empty-replacement

### DIFF
--- a/src/AST-Core-Tests/RBParseTreeRewriterTest.class.st
+++ b/src/AST-Core-Tests/RBParseTreeRewriterTest.class.st
@@ -17,6 +17,15 @@ RBParseTreeRewriterTest >> compare: anObject to: anotherObject [
 ]
 
 { #category : #helpers }
+RBParseTreeRewriterTest >> methodWithNilAssignment [
+	| temp |
+	temp := 1.
+	temp := 1 + temp.
+	temp := nil.
+	
+]
+
+{ #category : #helpers }
 RBParseTreeRewriterTest >> parseExpression: aString [
 	^ self parserClass parseExpression: aString
 ]
@@ -328,6 +337,15 @@ RBParseTreeRewriterTest >> testRewrites [
 		self compare: (self parseExpression: (rewrite executeTree: (self parseExpression: each first);
 				 tree) formattedCode)
 			to: (self parseExpression: (each at: 2))]
+]
+
+{ #category : #'tests - ok' }
+RBParseTreeRewriterTest >> testRewritesWithEmptyRewriteRulesRemoveMatchingNodes [
+	| node |
+	rewriter replace: '`var := nil.' with: ''.
+
+	node := (self class >> #methodWithNilAssignment) parseTree.
+	self assert: (rewriter executeTree: node) description: 'The execution of the rewriter should update the AST of the test method since it has a nil assignment.'
 ]
 
 { #category : #setup }

--- a/src/AST-Core/RBEmptyNode.class.st
+++ b/src/AST-Core/RBEmptyNode.class.st
@@ -1,0 +1,50 @@
+"
+I am a node to represent nothing. 
+
+I can be useful for Pharo rewriters to represent a rewrite that should nemove the matching nodes.
+"
+Class {
+	#name : #RBEmptyNode,
+	#superclass : #RBProgramNode,
+	#instVars : [
+		'start'
+	],
+	#category : #'AST-Core-Nodes'
+}
+
+{ #category : #accessing }
+RBEmptyNode class >> at: aPosition [
+	^ self new
+		start: aPosition;
+		yourself
+]
+
+{ #category : #visiting }
+RBEmptyNode >> acceptVisitor: aProgramNodeVisitor [
+	^ aProgramNodeVisitor visitEmptyNode: self
+]
+
+{ #category : #testing }
+RBEmptyNode >> isEmptyNode [
+	^ true
+]
+
+{ #category : #testing }
+RBEmptyNode >> isFaulty [
+	^ true
+]
+
+{ #category : #accessing }
+RBEmptyNode >> start [
+	^ start
+]
+
+{ #category : #accessing }
+RBEmptyNode >> start: anObject [
+	start := anObject
+]
+
+{ #category : #accessing }
+RBEmptyNode >> stop [
+	^ self start
+]

--- a/src/AST-Core/RBEmptyNode.class.st
+++ b/src/AST-Core/RBEmptyNode.class.st
@@ -8,22 +8,85 @@ Class {
 	#superclass : #RBProgramNode,
 	#instVars : [
 		'start',
-		'periods'
+		'periods',
+		'temporaries'
 	],
 	#category : #'AST-Core-Nodes'
 }
 
-{ #category : #accessing }
-RBEmptyNode class >> at: aPosition periods: aColl [
+{ #category : #'instance creation' }
+RBEmptyNode class >> fillFrom: aSequenceNode [
 	^ self new
-		periods: aColl;
-		start: aPosition;
+		fillFrom: aSequenceNode;
 		yourself
+]
+
+{ #category : #comparing }
+RBEmptyNode >> = anObject [
+	"Can't send = to the temporaries and statements collection since they might change from arrays to OCs"
+
+	self == anObject ifTrue: [ ^ true ].
+	self class = anObject class ifFalse: [ ^ false ].
+	self temporaries size = anObject temporaries size ifFalse: [ ^ false ].
+	self temporaries with: anObject temporaries do: [ :first :second | first = second ifFalse: [ ^ false ] ].
+
+	^ true
 ]
 
 { #category : #visiting }
 RBEmptyNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitEmptyNode: self
+]
+
+{ #category : #accessing }
+RBEmptyNode >> allDefinedVariables [
+	^ self temporaryNames asOrderedCollection
+		addAll: super allDefinedVariables;
+		yourself
+]
+
+{ #category : #accessing }
+RBEmptyNode >> allTemporaryVariables [
+	^ self temporaryNames asOrderedCollection
+		addAll: super allTemporaryVariables;
+		yourself
+]
+
+{ #category : #accessing }
+RBEmptyNode >> children [
+	^ OrderedCollection withAll: self temporaries
+]
+
+{ #category : #matching }
+RBEmptyNode >> copyInContext: aDictionary [
+	^ self class new
+		temporaries: (self copyList: self temporaries inContext: aDictionary);
+		yourself
+]
+
+{ #category : #testing }
+RBEmptyNode >> defines: aName [
+	^ temporaries anySatisfy: [ :each | each name = aName ]
+]
+
+{ #category : #testing }
+RBEmptyNode >> directlyUses: aNode [
+	^ false
+]
+
+{ #category : #'instance creation' }
+RBEmptyNode >> fillFrom: aSequenceNode [
+	self
+		start: aSequenceNode start;
+		periods: aSequenceNode periods;
+		temporaries: aSequenceNode temporaries;
+		comments: aSequenceNode comments;
+		parent: aSequenceNode parent
+]
+
+{ #category : #comparing }
+RBEmptyNode >> hash [
+	^ self hashForCollection: self temporaries
 ]
 
 { #category : #testing }
@@ -36,6 +99,21 @@ RBEmptyNode >> isFaulty [
 	^ true
 ]
 
+{ #category : #replacing }
+RBEmptyNode >> match: aNode inContext: aDictionary [
+	self class = aNode class ifFalse: [ ^ false ].
+	^ self matchList: temporaries against: aNode temporaries inContext: aDictionary
+]
+
+{ #category : #replacing }
+RBEmptyNode >> methodComments [
+	| methodComments |
+	methodComments := OrderedCollection withAll: self comments.
+	temporaries do: [ :each | methodComments addAll: each comments ].
+	(parent notNil and: [ parent isBlock ]) ifTrue: [ parent arguments do: [ :each | methodComments addAll: each comments ] ].
+	^ methodComments asSortedCollection: [ :a :b | a start < b start ]
+]
+
 { #category : #accessing }
 RBEmptyNode >> periods [
 	^ periods
@@ -44,6 +122,19 @@ RBEmptyNode >> periods [
 { #category : #accessing }
 RBEmptyNode >> periods: anObject [
 	periods := anObject
+]
+
+{ #category : #copying }
+RBEmptyNode >> postCopy [
+	super postCopy.
+	self temporaries: (self temporaries collect: [ :each | each copy ])
+]
+
+{ #category : #replacing }
+RBEmptyNode >> replaceNode: aNode withNode: anotherNode [
+	self temporaries: (temporaries collect: [ :each | each == aNode
+		ifTrue: [ anotherNode ]
+		ifFalse: [ each ] ])
 ]
 
 { #category : #accessing }
@@ -58,5 +149,22 @@ RBEmptyNode >> start: anObject [
 
 { #category : #accessing }
 RBEmptyNode >> stop [
-	^ self start
+	^ {(temporaries isEmpty ifTrue: [ 0 ] ifFalse: [ temporaries last stop ]) . (periods isEmpty ifTrue: [ 0 ] ifFalse: [ periods last ])} max
+]
+
+{ #category : #accessing }
+RBEmptyNode >> temporaries [
+	^ temporaries
+]
+
+{ #category : #accessing }
+RBEmptyNode >> temporaries: anObject [
+	temporaries := anObject
+]
+
+{ #category : #accessing }
+RBEmptyNode >> temporaryVariables [
+	^ super temporaryVariables asOrderedCollection
+		addAll: self temporaryNames;
+		yourself
 ]

--- a/src/AST-Core/RBEmptyNode.class.st
+++ b/src/AST-Core/RBEmptyNode.class.st
@@ -7,14 +7,16 @@ Class {
 	#name : #RBEmptyNode,
 	#superclass : #RBProgramNode,
 	#instVars : [
-		'start'
+		'start',
+		'periods'
 	],
 	#category : #'AST-Core-Nodes'
 }
 
 { #category : #accessing }
-RBEmptyNode class >> at: aPosition [
+RBEmptyNode class >> at: aPosition periods: aColl [
 	^ self new
+		periods: aColl;
 		start: aPosition;
 		yourself
 ]
@@ -32,6 +34,16 @@ RBEmptyNode >> isEmptyNode [
 { #category : #testing }
 RBEmptyNode >> isFaulty [
 	^ true
+]
+
+{ #category : #accessing }
+RBEmptyNode >> periods [
+	^ periods
+]
+
+{ #category : #accessing }
+RBEmptyNode >> periods: anObject [
+	periods := anObject
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBNode.class.st
+++ b/src/AST-Core/RBNode.class.st
@@ -20,3 +20,8 @@ Class {
 RBNode >> acceptVisitor: aProgramNodeVisitor [
 	self subclassResponsibility
 ]
+
+{ #category : #testing }
+RBNode >> isEmptyNode [
+	^ false
+]

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -52,7 +52,7 @@ RBParser class >> parseExpression: aString onError: aBlock [
 	node := parser parseExpression: aString.
 	
 	"If there is no statement, it means it is not really a RBSequenceNode but an RBEmptyNode. It can happen while parsing a rewrite rule."
-	node statements ifEmpty: [ ^ RBEmptyNode at: node start ].
+	node statements ifEmpty: [ ^ RBEmptyNode at: node start periods: node periods ].
 	
 	^(node statements size = 1 and: [node temporaries isEmpty]) 
 		ifTrue: [node statements first]

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -50,7 +50,11 @@ RBParser class >> parseExpression: aString onError: aBlock [
 	parser errorBlock: aBlock.
 	parser initializeParserWith: aString.
 	node := parser parseExpression: aString.
-	^(node statements size == 1 and: [node temporaries isEmpty]) 
+	
+	"If there is no statement, it means it is not really a RBSequenceNode but an RBEmptyNode. It can happen while parsing a rewrite rule."
+	node statements ifEmpty: [ ^ RBEmptyNode at: node start ].
+	
+	^(node statements size = 1 and: [node temporaries isEmpty]) 
 		ifTrue: [node statements first]
 		ifFalse: [node]
 ]

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -52,7 +52,7 @@ RBParser class >> parseExpression: aString onError: aBlock [
 	node := parser parseExpression: aString.
 	
 	"If there is no statement, it means it is not really a RBSequenceNode but an RBEmptyNode. It can happen while parsing a rewrite rule."
-	node statements ifEmpty: [ ^ RBEmptyNode at: node start periods: node periods ].
+	node statements ifEmpty: [ ^ RBEmptyNode fillFrom: node ].
 	
 	^(node statements size = 1 and: [node temporaries isEmpty]) 
 		ifTrue: [node statements first]

--- a/src/AST-Core/RBProgramNodeVisitor.class.st
+++ b/src/AST-Core/RBProgramNodeVisitor.class.st
@@ -46,6 +46,11 @@ RBProgramNodeVisitor >> visitCascadeNode: aCascadeNode [
 ]
 
 { #category : #visiting }
+RBProgramNodeVisitor >> visitEmptyNode: aLiteralNode [
+	
+]
+
+{ #category : #visiting }
 RBProgramNodeVisitor >> visitGlobalNode: aSelfNode [
 	^ self visitVariableNode: aSelfNode
 ]

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -445,7 +445,7 @@ RBSequenceNode >> statements [
 
 { #category : #accessing }
 RBSequenceNode >> statements: stmtCollection [ 
-	statements := stmtCollection.
+	statements := stmtCollection reject: [ :each | each isEmptyNode ].
 	statements do: [:each | each parent: self]
 ]
 

--- a/src/BlueInk-Core/BIConfigurableFormatter.class.st
+++ b/src/BlueInk-Core/BIConfigurableFormatter.class.st
@@ -1431,6 +1431,12 @@ BIConfigurableFormatter >> visitCascadeNode: aCascadeNode [
 ]
 
 { #category : #visiting }
+BIConfigurableFormatter >> visitEmptyNode: aSequenceNode [
+	self formatTemporariesFor: aSequenceNode.
+	self formatCommentsFor: aSequenceNode
+]
+
+{ #category : #visiting }
 BIConfigurableFormatter >> visitLiteralArrayNode: aRBArrayLiteralNode [ 
 	| brackets |
 	codeStream nextPut: $#.


### PR DESCRIPTION
Allows one to write a rule to remove a node from the AST. 

In order to do that I introduced a RBEmptyNode in the AST to use when the rewrite rule contains nothing instead of an empty RBSequenceNode.