### PR TITLE
Opal-clean-lookUpVar

### DIFF
--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -172,8 +172,21 @@ OCAbstractMethodScope >> localTemps [
 ]
 
 { #category : #lookup }
+OCAbstractMethodScope >> lookupAndReadVar: name inContext: aContext [
+	"We lookup a variable in a context. If it not in this context, we look in the outer context using the corresponding outer scope. If found, we return the value"
+	
+	| variable theValue |
+	
+	variable := self
+		variableNamed: name
+		ifAbsent: [ 	^self outerScopeLookupVar: name inContext: aContext].
+	theValue := variable readFromContext: aContext scope: self.
+	^ theValue
+]
+
+{ #category : #lookup }
 OCAbstractMethodScope >> lookupTempVector: name inContext: aContext [
-	"Similar to lookupVariable:inContext: but looks for a temp vector. If we don't find the temp vector (because it was nilled or not created), we lookup in the outer context with the corresponding outer scope"
+	"Similar to lookupAndReadVar:inContext: but looks for a temp vector. If we don't find the temp vector (because it was nilled or not created), we lookup in the outer context with the corresponding outer scope"
 	
 	| variable theVector |
 	variable := self
@@ -195,23 +208,10 @@ OCAbstractMethodScope >> lookupVar: name [
 ]
 
 { #category : #lookup }
-OCAbstractMethodScope >> lookupVar: name inContext: aContext [
-	"We lookup a variable in a context. If it not in this context, we look in the outer context using the corresponding outer scope"
-	
-	| variable theValue |
-	variable := self
-		variableNamed: name
-		ifAbsent: [ 	^self outerScopeLookupVar: name inContext: aContext].
-	theValue := variable readFromContext: aContext scope: self.
-	^ theValue
-]
-
-{ #category : #lookup }
 OCAbstractMethodScope >> lookupVarForDeclaration: name [
 	tempVars at: name ifPresent: [:v | ^ v].
 	name = 'thisContext' ifTrue: [^ thisContextVar].
 	^self outerScope lookupVarForDeclaration: name
-	
 ]
 
 { #category : #debugging }

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -56,6 +56,12 @@ OCAbstractScope >> isMethodScope [
 ]
 
 { #category : #lookup }
+OCAbstractScope >> lookupAndReadVar: name inContext: aContext [
+
+	^ self outerScope lookupAndReadVar: name inContext: aContext outerContext
+]
+
+{ #category : #lookup }
 OCAbstractScope >> lookupSelector: name [
 
 	Symbol hasInterned: name ifTrue: [ :sym | ^ sym].
@@ -67,12 +73,6 @@ OCAbstractScope >> lookupVar: name [
 	"subclass responsibility"
 
 	^ self outerScope lookupVar: name
-]
-
-{ #category : #lookup }
-OCAbstractScope >> lookupVar: name inContext: aContext [
-
-	^ self outerScope lookupVar: name inContext: aContext outerContext
 ]
 
 { #category : #lookup }

--- a/src/OpalCompiler-Core/OCBlockScope.class.st
+++ b/src/OpalCompiler-Core/OCBlockScope.class.st
@@ -39,6 +39,6 @@ OCBlockScope >> nextOuterScopeContextOf: aContext [
 { #category : #lookup }
 OCBlockScope >> outerScopeLookupVar: name inContext: aContext [
 	^ self outerScope 
-		lookupVar: name
+		lookupAndReadVar: name
 		inContext: (self nextOuterScopeContextOf: aContext)
 ]

--- a/src/OpalCompiler-Core/OCClassScope.class.st
+++ b/src/OpalCompiler-Core/OCClassScope.class.st
@@ -61,13 +61,6 @@ OCClassScope >> lookupVar: name [
 ]
 
 { #category : #lookup }
-OCClassScope >> lookupVar: name inContext: aContext [
-	"I'll lookup a variable in a class. The context does not play any role in here because variables in classes are statically defined"
-
-	^ self lookupVar: name
-]
-
-{ #category : #lookup }
 OCClassScope >> lookupVarForDeclaration: name [
 	^self lookupVar: name
 ]

--- a/src/OpalCompiler-Core/OCEnvironmentScope.class.st
+++ b/src/OpalCompiler-Core/OCEnvironmentScope.class.st
@@ -37,13 +37,6 @@ OCEnvironmentScope >> lookupVar: name [
 
 ]
 
-{ #category : #lookup }
-OCEnvironmentScope >> lookupVar: name inContext: aContext [
-	"I'll lookup a variable in the (global) environment. The context does not play any role in here because variables in classes are statically defined"
-
-	^ self lookupVar: name
-]
-
 { #category : #creation }
 OCEnvironmentScope >> newClassScope: aClass [
 

--- a/src/OpalCompiler-Core/OCExtraBindingScope.class.st
+++ b/src/OpalCompiler-Core/OCExtraBindingScope.class.st
@@ -54,21 +54,6 @@ OCExtraBindingScope >> lookupVar: name [
 	^ super lookupVar: name 
 ]
 
-{ #category : #lookup }
-OCExtraBindingScope >> lookupVar: name inContext: context [
-
-	name = 'self' ifTrue: [  ^outerScope lookupVar: name inContext: context outerContext].
-	name = 'super' ifTrue: [  ^outerScope lookupVar: name inContext: context outerContext].
-	"Globals are not shadowed"
-	name first isUppercase ifTrue: [  | found |
-		found := outerScope outerScope lookupVar: name inContext: context outerContext.
-		found ifNotNil: [ ^found ]].
-	
-	(bindings bindingOf: name asSymbol) ifNotNil: [:assoc | 
-		^ OCLiteralVariable new assoc: assoc; scope: self; yourself].
-	^ super lookupVar: name inContext: context outerContext.
-]
-
 { #category : #'instance creation' }
 OCExtraBindingScope >> newMethodScope [
 	 

--- a/src/OpalCompiler-Core/OCInstanceScope.class.st
+++ b/src/OpalCompiler-Core/OCInstanceScope.class.st
@@ -61,15 +61,6 @@ OCInstanceScope >> lookupVar: name [
 ]
 
 { #category : #lookup }
-OCInstanceScope >> lookupVar: name inContext: aContext [
-	"Return a ScopeVar for my inst var with this name.  Return nil if none found"
-
-	name = 'self' ifTrue: [^ selfVar].
-	name = 'super' ifTrue: [^ superVar].
-	^ vars at: name ifAbsent: [self outerScope lookupVar: name inContext: aContext ]
-]
-
-{ #category : #lookup }
 OCInstanceScope >> lookupVarForDeclaration: name [
 	"Return a ScopeVar for my inst var with this name.  Return nil if none found"
 	name = 'self' ifTrue: [^ selfVar].

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -68,18 +68,6 @@ OCRequestorScope >> lookupVar: name [
 ]
 
 { #category : #lookup }
-OCRequestorScope >> lookupVar: name inContext: context [
-
-	name = 'self' ifTrue: [  ^outerScope lookupVar: name inContext: context outerContext].
-	name = 'super' ifTrue: [  ^outerScope lookupVar: name inContext: context outerContext].
-	name first isUppercase ifTrue: [ ^outerScope lookupVar: name inContext: context outerContext]. 
-	
-	(requestor bindingOf: name asSymbol) ifNotNil: [:assoc | 
-		^ OCLiteralVariable new assoc: assoc; scope: self; yourself].
-	^ super lookupVar: name inContext: context outerContext.
-]
-
-{ #category : #lookup }
 OCRequestorScope >> newMethodScope [
 	 
 	^ OCMethodScope new outerScope: (self outerScope: outerScope instanceScope) 

--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -134,7 +134,7 @@ OCTempVariable >> markWrite [
 
 { #category : #debugging }
 OCTempVariable >> readFromContext: aContext scope: contextScope [
-	^ aContext tempAt: self indexFromIR
+	^ aContext tempAt: (contextScope outerNotOptimizedScope node irInstruction indexForVarNamed: name)
 ]
 
 { #category : #debugging }

--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -55,6 +55,11 @@ OCTempVariable >> hash [
 	^ name hash bitXor: (usage hash bitXor: scope hash).
 ]
 
+{ #category : #debugging }
+OCTempVariable >> indexFromIR [
+	^scope outerNotOptimizedScope node irInstruction indexForVarNamed: name
+]
+
 { #category : #initialization }
 OCTempVariable >> initialize [
 	super initialize.
@@ -129,13 +134,13 @@ OCTempVariable >> markWrite [
 
 { #category : #debugging }
 OCTempVariable >> readFromContext: aContext scope: contextScope [
-	^ aContext tempAt: (contextScope outerNotOptimizedScope node irInstruction indexForVarNamed: name)
+	^ aContext tempAt: self indexFromIR
 ]
 
 { #category : #debugging }
 OCTempVariable >> searchFromContext: aContext scope: contextScope [
 
-	^ contextScope lookupVar: name inContext: aContext
+	^ contextScope lookupAndReadVar: name inContext: aContext
 ]
 
 { #category : #debugging }

--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -134,7 +134,8 @@ OCTempVariable >> markWrite [
 
 { #category : #debugging }
 OCTempVariable >> readFromContext: aContext scope: contextScope [
-	^ aContext tempAt: (contextScope outerNotOptimizedScope node irInstruction indexForVarNamed: name)
+
+	^ aContext tempAt: (self indexFromIRFromScope: contextScope)
 ]
 
 { #category : #debugging }
@@ -146,6 +147,6 @@ OCTempVariable >> searchFromContext: aContext scope: contextScope [
 { #category : #debugging }
 OCTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 	^aContext 
-		tempAt: (contextScope outerNotOptimizedScope node irInstruction indexForVarNamed: name) 
+		tempAt: (self indexFromIRFromScope: contextScope) 
 		put: aValue
 ]

--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -56,8 +56,12 @@ OCTempVariable >> hash [
 ]
 
 { #category : #debugging }
-OCTempVariable >> indexFromIR [
-	^scope outerNotOptimizedScope node irInstruction indexForVarNamed: name
+OCTempVariable >> indexFromIRFromScope: aScope [
+	"I think we do not need the aScope parameter: scope of the var will always be aScope, 
+	as shown by the assert."
+	"next step: use indexFromIR instead"
+	self assert: scope == aScope.
+	^aScope outerNotOptimizedScope node irInstruction indexForVarNamed: name
 ]
 
 { #category : #initialization }

--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -57,10 +57,6 @@ OCTempVariable >> hash [
 
 { #category : #debugging }
 OCTempVariable >> indexFromIRFromScope: aScope [
-	"I think we do not need the aScope parameter: scope of the var will always be aScope, 
-	as shown by the assert."
-	"next step: use indexFromIR instead"
-	self assert: scope == aScope.
 	^aScope outerNotOptimizedScope node irInstruction indexForVarNamed: name
 ]
 

--- a/src/OpalCompiler-Core/OCVectorTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCVectorTempVariable.class.st
@@ -36,6 +36,7 @@ OCVectorTempVariable >> isTempVectorTemp [
 OCVectorTempVariable >> readFromContext: aContext scope: contextScope [
 
 	| offset pairVariableVector |
+	self isThisEverCalled: 'this should never be called on vector temps'.
 	pairVariableVector := contextScope lookupTempVector: vectorName inContext: aContext.
 	offset := pairVariableVector first indexInTempVectorFromIR: name.
 	^pairVariableVector second at: offset.


### PR DESCRIPTION
- rename lookUpVar:inContext: to #lookupAndReadVar:inContext
- remove all the  lookUpVar:inContext methods that where not needed
- factor out caclulation of index into #indexFromIR (for temps)