### PR TITLE
Fix board mail link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,4 +11,4 @@ Specifically:
 
 If any member of the community violates this code of conduct, the maintainers of the Pharo project may take action, removing issues, comments, and PRs or blocking accounts as deemed appropriate. We will not tolerate harassment from anyone in the Pharo community, even outside of Pharo’s public communication channels.
 
-If you are subject to or witness unacceptable behavior, or have any other concerns, please [email us](board@pharo.org).
+If you are subject to or witness unacceptable behavior, or have any other concerns, please [email us](mailto:board@pharo.org).


### PR DESCRIPTION
Because if you clicked the previous version will get a 404 Not Found of a GitHub page.