### PR TITLE
OpalTempReadSimplify-Step2

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -25,7 +25,7 @@ Context >> lookupSymbol: aSymbol [
 	scope := self sourceNodeExecuted scope.
 	var := scope lookupVar: aSymbol asString.
 	"Local variables"
-	(var isKindOf: OCTempVariable) ifTrue: [^ var searchFromContext: self scope: scope].
+	(var isKindOf: OCTempVariable) ifTrue: [^ var readFromContext: self scope: scope].
 	"Instance variables"
 	(var isKindOf: OCSlotVariable) ifTrue: [^ self receiver instVarNamed: aSymbol].
 	"Class variables and globals"

--- a/src/OpalCompiler-Core/DebuggerMethodMapOpal.class.st
+++ b/src/OpalCompiler-Core/DebuggerMethodMapOpal.class.st
@@ -75,7 +75,7 @@ DebuggerMethodMapOpal >> tempNamed: name in: aContext [
 	| scope var |
 	scope := aContext sourceNodeExecuted scope.
 	var := scope lookupVar: name.
-	^var searchFromContext: aContext scope: scope.
+	^var readFromContext: aContext scope: scope.
 		
 ]
 

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -179,7 +179,7 @@ OCAbstractMethodScope >> lookupAndReadVar: name inContext: aContext [
 	
 	variable := self
 		variableNamed: name
-		ifAbsent: [ 	^self outerScopeLookupVar: name inContext: aContext].
+		ifAbsent: [ 	^self outerScope lookupAndReadVar: name inContext: (self nextOuterScopeContextOf: aContext)].
 	theValue := variable readFromContext: aContext.
 	^ theValue
 ]
@@ -240,14 +240,14 @@ OCAbstractMethodScope >> newOptimizedBlockScope: int [
 			yourself.
 ]
 
+{ #category : #lookup }
+OCAbstractMethodScope >> nextOuterScopeContextOf: aContext [
+	^aContext
+]
+
 { #category : #scope }
 OCAbstractMethodScope >> outerNotOptimizedScope [
 	^self
-]
-
-{ #category : #lookup }
-OCAbstractMethodScope >> outerScopeLookupVar: name inContext: aContext [
-	Error signal: 'Cannot find variable named''', name, ''' in this method'
 ]
 
 { #category : #scope }

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -180,7 +180,7 @@ OCAbstractMethodScope >> lookupAndReadVar: name inContext: aContext [
 	variable := self
 		variableNamed: name
 		ifAbsent: [ 	^self outerScopeLookupVar: name inContext: aContext].
-	theValue := variable readFromContext: aContext scope: self.
+	theValue := variable readFromContext: aContext.
 	^ theValue
 ]
 
@@ -192,7 +192,7 @@ OCAbstractMethodScope >> lookupTempVector: name inContext: aContext [
 	variable := self
 		variableNamed: name
 		ifAbsent: [^ self outerScope lookupTempVector: name inContext: aContext outerContext ].
-	theVector := variable readFromContext: aContext scope: self.
+	theVector := variable readFromContext: aContext.
 	theVector ifNil: [ ^ self outerScope lookupTempVector: name inContext: aContext outerContext ].
 	^ { variable . theVector }
 ]

--- a/src/OpalCompiler-Core/OCArgumentVariable.class.st
+++ b/src/OpalCompiler-Core/OCArgumentVariable.class.st
@@ -30,3 +30,8 @@ OCArgumentVariable >> isWritable [
 
 	^ false
 ]
+
+{ #category : #debugging }
+OCArgumentVariable >> writeFromContext: aContext scope: contextScope value: aValue [
+	self error: 'Arguments are read only'
+]

--- a/src/OpalCompiler-Core/OCBlockScope.class.st
+++ b/src/OpalCompiler-Core/OCBlockScope.class.st
@@ -35,10 +35,3 @@ OCBlockScope >> nextOuterScopeContextOf: aContext [
 	But if it is method context lookup will continue in same context but within outer scope"
 	^ aContext outerContext ifNil: [ aContext ]
 ]
-
-{ #category : #lookup }
-OCBlockScope >> outerScopeLookupVar: name inContext: aContext [
-	^ self outerScope 
-		lookupAndReadVar: name
-		inContext: (self nextOuterScopeContextOf: aContext)
-]

--- a/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
@@ -51,9 +51,14 @@ OCCopyingTempVariable >> tempVectorForTempStoringIt [
 
 { #category : #debugging }
 OCCopyingTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
+	
+	
+	originalVar writeFromContext: aContext scope: contextScope value: aValue.
+	
 	self flag: #FIXME.
 	"we need to change all the copies and the original, too"
+	
 	^aContext 
-		tempAt: (self indexFromIRFromScope: contextScope) 
+		tempAt: (self indexFromIRFromScope: contextScope)
 		put: aValue
 ]

--- a/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
@@ -48,3 +48,12 @@ OCCopyingTempVariable >> tempVectorForTempStoringIt [
 		ifFalse: [^ searchScope tempVector]
 	
 ]
+
+{ #category : #debugging }
+OCCopyingTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
+	self flag: #FIXME.
+	"we need to change all the copies and the original, too"
+	^aContext 
+		tempAt: (self indexFromIRFromScope: contextScope) 
+		put: aValue
+]

--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -56,6 +56,11 @@ OCTempVariable >> hash [
 ]
 
 { #category : #debugging }
+OCTempVariable >> indexFromIR [
+	^scope outerNotOptimizedScope node irInstruction indexForVarNamed: name
+]
+
+{ #category : #debugging }
 OCTempVariable >> indexFromIRFromScope: aScope [
 	^aScope outerNotOptimizedScope node irInstruction indexForVarNamed: name
 ]
@@ -133,13 +138,13 @@ OCTempVariable >> markWrite [
 ]
 
 { #category : #debugging }
-OCTempVariable >> readFromContext: aContext scope: contextScope [
+OCTempVariable >> readFromContext: aContext [
 
-	^ aContext tempAt: (self indexFromIRFromScope: contextScope)
+	^ aContext tempAt: self indexFromIR
 ]
 
 { #category : #debugging }
-OCTempVariable >> searchFromContext: aContext scope: contextScope [
+OCTempVariable >> readFromContext: aContext scope: contextScope [
 
 	^ contextScope lookupAndReadVar: name inContext: aContext
 ]

--- a/src/OpalCompiler-Core/OCVectorTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCVectorTempVariable.class.st
@@ -36,16 +36,6 @@ OCVectorTempVariable >> isTempVectorTemp [
 OCVectorTempVariable >> readFromContext: aContext scope: contextScope [
 
 	| offset pairVariableVector |
-	self isThisEverCalled: 'this should never be called on vector temps'.
-	pairVariableVector := contextScope lookupTempVector: vectorName inContext: aContext.
-	offset := pairVariableVector first indexInTempVectorFromIR: name.
-	^pairVariableVector second at: offset.
-]
-
-{ #category : #debugging }
-OCVectorTempVariable >> searchFromContext: aContext scope: contextScope [
-
-	| offset pairVariableVector |
 	pairVariableVector := contextScope lookupTempVector: vectorName inContext: aContext.
 	offset := pairVariableVector first indexInTempVectorFromIR: name.
 	^pairVariableVector second at: offset.
@@ -72,7 +62,7 @@ OCVectorTempVariable >> vectorOffset [
 OCVectorTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 	| tempVectorVar theVector offset |
 	tempVectorVar := contextScope lookupVar: vectorName.
-	theVector := tempVectorVar readFromContext: aContext scope: tempVectorVar scope.
+	theVector := tempVectorVar readFromContext: aContext.
 	offset := tempVectorVar indexInTempVectorFromIR: name.
 	^theVector at: offset put: aValue.
 ]


### PR DESCRIPTION
This is the next step for simplifying temp reading in contexts.

- add #indexFromIR
- use it in what was readFromContext:scope:, rename it to #readFromContext: (as it does need the scope)
- rename #searchFromContext:scope: to be #readFromContext:scope:
- for arguments: make clear that writing is not possible

Much better... more steps will be done after this (the goal is to remove the #scope: parameter and make it even simpler)