### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,7 +5,7 @@ We expect Pharo community members to act professionally and respectfully, and we
 
 Specifically:
 
-- Respect people, their identities, their culture, and their work.
+- Respect people, their culture, and their work.
 - Be kind. Be courteous. Be welcoming.
 - Listen. Consider and acknowledge people’s points before responding.
 


### PR DESCRIPTION
* One's identity is not relevant in a technical forum. 
* One's code is not better because of one's identity.
* One's arguments are not more sound because of one's identity.
* Ones point of view are not more important because of one's identity.

Any calls to respect someone's identity are thinly veiled attempts to impose objectionable left wing political language onto the community.  I don't care how anyone identifies, but I'm under no obligation to play along and it is not disrespectful to disagree with these political beliefs. The maintenance of ones identity and self image is theirs to worry about, I have no obligation to support the maintenance of someone else's ego. You can identify as a pink unicorn for all I care, but no I do not have to respect that or play along.

If you bring up your identity at all in a disagreement (the only time a CoC matters), you are the one in the wrong, you are the one trying to manipulate people; there's no reason anyone here needs to know or care about your identity. 

Please strike these two words from the document. Absent these, the document becomes politically neutral and is no longer objectionable IMHO.