### PR TITLE
3434-Random--nextInt-should-fail-early-when-argument-is-FloatInfinity

### DIFF
--- a/src/Random-Core/Random.class.st
+++ b/src/Random-Core/Random.class.st
@@ -112,7 +112,7 @@ Random >> nextInt: anInteger [
 	Handle large numbers too (for cryptography)."
 
 	anInteger strictlyPositive ifFalse: [ self error: 'Range must be positive' ].
-	anInteger asFloat isInfinite
+	anInteger asFloat isInfinite "are we outside the range of float? - use fraction"
 		ifTrue: [^(self privateNextValue asFraction * anInteger) truncated + 1].
 	^ (self privateNextValue * anInteger) truncated + 1
 ]


### PR DESCRIPTION
Fixes 3434

Added a comment that the expression "anInteger asFloat isInfinite" is just a way to check if we are outside the range of float.