### PR TITLE
4654-Add-comment-to-RBProgramNodeisFaulty

### DIFF
--- a/src/AST-Core/RBLiteralValueNode.class.st
+++ b/src/AST-Core/RBLiteralValueNode.class.st
@@ -54,11 +54,6 @@ RBLiteralValueNode >> copyInContext: aDictionary [
 	^ self class value: self value
 ]
 
-{ #category : #testing }
-RBLiteralValueNode >> isFaulty [
-	^false
-]
-
 { #category : #accessing }
 RBLiteralValueNode >> sourceText [
 	^ sourceText ifNil: [

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -435,7 +435,8 @@ RBProgramNode >> isEvaluatedFirst [
 
 { #category : #testing }
 RBProgramNode >> isFaulty [
-	self subclassResponsibility
+	"return true if the AST contains a RBParseErrorNode"
+	^false
 ]
 
 { #category : #deprecated }

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -98,11 +98,6 @@ RBVariableNode >> isDefinition [
 ]
 
 { #category : #testing }
-RBVariableNode >> isFaulty [
-	^false
-]
-
-{ #category : #testing }
 RBVariableNode >> isImmediateNode [
 	^true
 ]

--- a/src/Reflectivity/RFLiteralVariableNode.class.st
+++ b/src/Reflectivity/RFLiteralVariableNode.class.st
@@ -40,11 +40,6 @@ RFLiteralVariableNode >> dumpOn: aStream [
 	self value printOn: aStream
 ]
 
-{ #category : #testing }
-RFLiteralVariableNode >> isFaulty [
-	^false
-]
-
 { #category : #accessing }
 RFLiteralVariableNode >> start [
 	^0


### PR DESCRIPTION
- add a comment to #isFaulty
- do not use subclass responsibility, but ^false as the default

fixes #4654