### PR TITLE
Opal: DefiningContext should be looked up by scope

### DIFF
--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -176,13 +176,12 @@ OCAbstractMethodScope >> localTemps [
 ]
 
 { #category : #lookup }
-OCAbstractMethodScope >> lookupDefiningContextFor: name startingFrom: aContext [
-	"We lookup a variable in a context. If it not in this context, we look in the outer context using the corresponding outer scope. If found, we return the context"
+OCAbstractMethodScope >> lookupDefiningContextForVariable: var startingFrom: aContext [
+	"Is this the definition context for var? If it not, we look in the outer context using the corresponding outer scope. If found, we return the context"
 	
-	self
-		variableNamed: name
-		ifAbsent: [ ^self outerScope lookupDefiningContextFor: name startingFrom: (self nextOuterScopeContextOf: aContext)].
-	^aContext
+	^self = var scope
+		ifFalse: [ self outerScope lookupDefiningContextForVariable: var startingFrom: (self nextOuterScopeContextOf: aContext) ]
+		ifTrue: [ aContext ]
 ]
 
 { #category : #lookup }

--- a/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
@@ -53,12 +53,11 @@ OCCopyingTempVariable >> tempVectorForTempStoringIt [
 OCCopyingTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 	
 	| definitionContext |
-	definitionContext := contextScope lookupDefiningContextFor: name startingFrom: aContext.
-	
+	definitionContext := contextScope lookupDefiningContextForVariable: self startingFrom: aContext.
 	originalVar writeFromContext: aContext scope: contextScope value: aValue.
 	
 	self flag: #FIXME.
-	"we need to change all the copies and the original, too"
+	"we need to change all the copies, too"
 	
 	^definitionContext 
 		tempAt: self indexFromIR

--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -135,7 +135,7 @@ OCTempVariable >> markWrite [
 { #category : #debugging }
 OCTempVariable >> readFromContext: aContext scope: contextScope [
 	| definitionContext |
-	definitionContext := contextScope lookupDefiningContextFor: name startingFrom: aContext.
+	definitionContext := contextScope lookupDefiningContextForVariable: self startingFrom: aContext.
 	^ self readFromLocalContext: definitionContext
 ]
 
@@ -149,7 +149,7 @@ OCTempVariable >> readFromLocalContext: aContext [
 OCTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 
 	| definitionContext |
-	definitionContext := contextScope lookupDefiningContextFor: name startingFrom: aContext.
+	definitionContext := contextScope lookupDefiningContextForVariable: self startingFrom: aContext.
 
 	^definitionContext 
 		tempAt: self indexFromIR

--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -122,9 +122,9 @@ MethodMapTest >> testExampleTempNamedPutCopying [
 
 { #category : #'testing - temp access' }
 MethodMapTest >> testExampleTempNamedPutCopying2 [
-"modifying a copied temp variable will *not* modify the value in the outer context. 
-(See other test case OCClosureCompilerTest>>#testDebuggerTempAccess and notes on fogbugz issue 17702"
-	self assert: (self compileAndRunExample: #exampleTempNamedPutCopying2) equals: 1
+	"modifying a copied temp variable will *not* modify the value in the outer context"
+
+	self assert: (self compileAndRunExample: #exampleTempNamedPutCopying2) equals: 2
 ]
 
 { #category : #'testing - temp access' }

--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -122,7 +122,7 @@ MethodMapTest >> testExampleTempNamedPutCopying [
 
 { #category : #'testing - temp access' }
 MethodMapTest >> testExampleTempNamedPutCopying2 [
-	"modifying a copied temp variable will *not* modify the value in the outer context"
+	"modifying a copied temp variable will modify the value in the outer context"
 
 	self assert: (self compileAndRunExample: #exampleTempNamedPutCopying2) equals: 2
 ]

--- a/src/OpalCompiler-Tests/OCClosureCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCClosureCompilerTest.class.st
@@ -317,9 +317,9 @@ OCClosureCompilerTest >> doTestDebuggerTempAccessWith: one with: two [
 		self  evaluate: 'local1 := 25' in: thisContext to: self.
 		self assert: local1 = 25.
 		{ r1. r2. r3. r4 } "placate the compiler"].
-	self assert: local1 = -3.0.
-	"this is not 25 as the var is a local, non escaping variable that was copied into the block,
-	If the compiler would have known about the write, it would have made the var escaping".
+	self assert: local1 = 25.
+	"this is 25 even though the var is a local, non escaping variable that was copied into the block.
+	But the DoIt compiles temp acces using #namedTempAt:put:, which updates the copies and the original".
 	self assert: remote1 = (6/7)
 ]
 


### PR DESCRIPTION
lookupDefiningContextFor: startingFrom:  was using variable names. It is better to instead walk up contexts till the scope is the definition scope of the variable (independend of the name).