### PR TITLE
4703-GTInspectorContextNamedTempNode-should-not-use-debuggerMap

### DIFF
--- a/src/GT-Inspector/GTInspectorContextNamedTempNode.class.st
+++ b/src/GT-Inspector/GTInspectorContextNamedTempNode.class.st
@@ -40,7 +40,7 @@ GTInspectorContextNamedTempNode >> label [
 
 { #category : #accessing }
 GTInspectorContextNamedTempNode >> rawValue [
-	^ self hostObject debuggerMap namedTempAt: tempIndex in: self hostObject
+	^ self hostObject namedTempAt: tempIndex
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
#rawValue can just call #namedTempAt: on the context, no need to call #debuggerMap. fixes #4703