### PR TITLE
4704-reduce-direct-calls-of-debuggerMap-rangeForPCcontextIsActiveContext

### DIFF
--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -270,9 +270,7 @@ DebugSession >> pcRangeForContext: aContext [
 
 	(aContext isNil or: [ aContext isDead ])
 		ifTrue: [ ^ 1 to: 0 ].
-	^ aContext debuggerMap
-		rangeForPC: aContext pc
-		contextIsActiveContext: (self isLatestContext: aContext)
+	^ aContext pcRangeContextIsActive: (self isLatestContext: aContext)
 ]
 
 { #category : #'debugging actions' }

--- a/src/Debugging-Core/CompiledBlock.extension.st
+++ b/src/Debugging-Core/CompiledBlock.extension.st
@@ -1,11 +1,6 @@
 Extension { #name : #CompiledBlock }
 
 { #category : #'*Debugging-Core' }
-CompiledBlock >> debuggerMap [
-	^self compilerClass debuggerMethodMapForMethod: self.
-]
-
-{ #category : #'*Debugging-Core' }
 CompiledBlock >> pcInOuter [
 	| outer end instructionStream |
 	outer := self outerCode.

--- a/src/Debugging-Core/CompiledCode.extension.st
+++ b/src/Debugging-Core/CompiledCode.extension.st
@@ -42,6 +42,11 @@ CompiledCode >> abstractBytecodeMessagesFrom: startpc to: endpc do: aBlock [
 ]
 
 { #category : #'*Debugging-Core' }
+CompiledCode >> debuggerMap [
+	^self compilerClass debuggerMethodMapForMethod: self.
+]
+
+{ #category : #'*Debugging-Core' }
 CompiledCode >> hasInstVarRef [
 	self localHasInstVarRef ifTrue: [ ^ true ].
 	^ self innerCompiledBlocksAnySatisfy: [ :cb | cb hasInstVarRef ]
@@ -95,6 +100,11 @@ CompiledCode >> pcPreviousTo: pc [
 		[prevPc := scanner pc.
 		 scanner interpretNextInstructionFor: client].
 	^prevPc
+]
+
+{ #category : #'*Debugging-Core' }
+CompiledCode >> rangeForPC: aPC contextIsActive: contextIsActive [
+	^self debuggerMap rangeForPC: aPC contextIsActiveContext: contextIsActive
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/Debugging-Core/CompiledCode.extension.st
+++ b/src/Debugging-Core/CompiledCode.extension.st
@@ -103,8 +103,9 @@ CompiledCode >> pcPreviousTo: pc [
 ]
 
 { #category : #'*Debugging-Core' }
-CompiledCode >> rangeForPC: aPC contextIsActive: contextIsActive [
-	^self debuggerMap rangeForPC: aPC contextIsActiveContext: contextIsActive
+CompiledCode >> rangeForPC: aPC [
+	"return which code to hightlight in the debugger"
+	^(self methodNode sourceNodeForPC: aPC) debugHighlightRange
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/Debugging-Core/CompiledMethod.extension.st
+++ b/src/Debugging-Core/CompiledMethod.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #CompiledMethod }
-
-{ #category : #'*Debugging-Core' }
-CompiledMethod >> debuggerMap [
-	^self compilerClass debuggerMethodMapForMethod: self.
-]

--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -56,6 +56,16 @@ Context >> namedTempAt: index put: aValue [
 ]
 
 { #category : #'*Debugging-Core' }
+Context >> pcRange [
+	^self pcRangeContextIsActive: false
+]
+
+{ #category : #'*Debugging-Core' }
+Context >> pcRangeContextIsActive: aBoolean [
+	^self method rangeForPC: pc contextIsActive: aBoolean
+]
+
+{ #category : #'*Debugging-Core' }
 Context >> previousPcWithCorrectMapping [
 	"Answer a pc inside the enclosing block or mathod that is correctly mapped to an AST node"
 	"This is an ugly and temporary fix for Pharo 3. 

--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -56,13 +56,20 @@ Context >> namedTempAt: index put: aValue [
 ]
 
 { #category : #'*Debugging-Core' }
-Context >> pcRange [
-	^self pcRangeContextIsActive: false
-]
-
-{ #category : #'*Debugging-Core' }
-Context >> pcRangeContextIsActive: aBoolean [
-	^self method rangeForPC: pc contextIsActive: aBoolean
+Context >> pcRangeContextIsActive: contextIsActive [
+	"return the debug highlight for aPC"
+	| thePC |
+	
+	"make sure we have some usable value (can happen for contexts in the ProcessBrowser"
+	thePC := pc ifNil: [self method endPC].
+	
+	"When on the top of the stack the pc is pointing to right instruction, but deeper in the stack
+	the pc was already advanced one bytecode, so we need to go back this one bytecode, which
+	can consist of multiple bytes. But on IR, we record the *last* bytecode offset as the offset of
+	the IR instruction, which means we can just go back one"
+	thePC := contextIsActive ifTrue: [pc] ifFalse: [pc - 1].
+	
+	^self method rangeForPC: thePC
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -67,7 +67,7 @@ Context >> pcRangeContextIsActive: contextIsActive [
 	the pc was already advanced one bytecode, so we need to go back this one bytecode, which
 	can consist of multiple bytes. But on IR, we record the *last* bytecode offset as the offset of
 	the IR instruction, which means we can just go back one"
-	thePC := contextIsActive ifTrue: [pc] ifFalse: [pc - 1].
+	thePC := contextIsActive ifTrue: [thePC] ifFalse: [thePC - 1].
 	
 	^self method rangeForPC: thePC
 ]

--- a/src/OpalCompiler-Core/DebuggerMethodMapOpal.class.st
+++ b/src/OpalCompiler-Core/DebuggerMethodMapOpal.class.st
@@ -64,8 +64,7 @@ DebuggerMethodMapOpal >> rangeForPC: aPC contextIsActiveContext: contextIsActive
 	IR instruction, which means we can just go back one"
 
 	pc := contextIsActive ifTrue: [aPC] ifFalse: [aPC - 1].
-	^(methodNode sourceNodeForPC:  pc) debugHighlightRange
-	
+	^(methodNode sourceNodeForPC: pc) debugHighlightRange
 ]
 
 { #category : #public }

--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -196,7 +196,7 @@ MethodMapTest >> testSimpleSourceMapping [
 
 	method := Object>>('ha', 'lt') asSymbol.
 
-	range := (DebuggerMethodMapOpal forMethod: (self compileMethod: method)) rangeForPC: (Smalltalk vm for32bit: 23 for64bit: 43).
+	range := (self compileMethod: method) rangeForPC: (Smalltalk vm for32bit: 23 for64bit: 43).
 	highlight := method sourceCode copyFrom:  range first to: range last.
 	self assert: highlight equals: 'now'.
 

--- a/src/SystemCommands-RefactoringSupport/RBPushUpPreview.class.st
+++ b/src/SystemCommands-RefactoringSupport/RBPushUpPreview.class.st
@@ -71,7 +71,8 @@ RBPushUpPreview >> classes [
 { #category : #initialization }
 RBPushUpPreview >> initializeDropList [
 	classDropList := self newDropList.
-	classDropList displayBlock: [ :scope | scope name ];
+	classDropList
+		display: [ :scope | scope name ];
 		iconBlock: [ :e | e systemIcon ]
 ]
 

--- a/src/Tool-ProcessBrowser/ProcessBrowser.class.st
+++ b/src/Tool-ProcessBrowser/ProcessBrowser.class.st
@@ -809,9 +809,9 @@ ProcessBrowser >> pcRange [
 	the selected context's program counter value."
 	(selectedContext isNil or: [methodText isEmptyOrNil])
 		ifTrue: [^ 1 to: 0].
-	^selectedContext debuggerMap
+	^selectedContext method
 		rangeForPC: (selectedContext pc ifNotNil: [:pc| pc] ifNil: [selectedContext method endPC])
-		contextIsActiveContext: stackListIndex = 1
+		contextIsActive: stackListIndex = 1
 ]
 
 { #category : #'process list' }

--- a/src/Tool-ProcessBrowser/ProcessBrowser.class.st
+++ b/src/Tool-ProcessBrowser/ProcessBrowser.class.st
@@ -809,9 +809,7 @@ ProcessBrowser >> pcRange [
 	the selected context's program counter value."
 	(selectedContext isNil or: [methodText isEmptyOrNil])
 		ifTrue: [^ 1 to: 0].
-	^selectedContext method
-		rangeForPC: (selectedContext pc ifNotNil: [:pc| pc] ifNil: [selectedContext method endPC])
-		contextIsActive: stackListIndex = 1
+	^selectedContext pcRangeContextIsActive: (stackListIndex = 1)
 ]
 
 { #category : #'process list' }


### PR DESCRIPTION
- Implement #rangeForPC:contextIsActive:  in CompiledCode, calling #debuggerMap
- implement versions on Context: pcRange, pcRangeContextIsActive: 
- push up #debuggerMap to CompiledCode
- fix senders

fixes #4704