### PR TITLE
Add-copy-title-command-to-windows

### DIFF
--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -438,8 +438,10 @@ SystemWindow class >> windowMenuOn: aBuilder [
 		action: [ aBuilder model showAbout ];
 		iconName: #smallHelpIcon;
 		withSeparatorAfter.
-	(aBuilder item: #'Change title...')
-		action: [ aBuilder model relabel ];
+	(aBuilder item: #'Change title')
+		action: [ aBuilder model relabel ].
+	(aBuilder item: #'Copy title')
+		action: [ aBuilder model copyTitle ];
 		withSeparatorAfter.
 	(aBuilder item: #'Send to back')
 		action: [ aBuilder model sendToBack ].
@@ -786,6 +788,12 @@ SystemWindow >> collapsedFrame [
 { #category : #drawing }
 SystemWindow >> colorForInsets [
 	^self paneColor colorForInsets
+]
+
+{ #category : #label }
+SystemWindow >> copyTitle [
+	Clipboard clipboardText: self label.
+	self inform: 'Window title copied.'
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
It often happens to me or other people I know to edit the title of a window to copy it.

In this PR I propose to directly add a command to copy the title of a window via the little arrow at the top right of the window.