### PR TITLE
Fixed typo in category

### DIFF
--- a/src/SortFunctions-Core/UndefinedSortFunction.class.st
+++ b/src/SortFunctions-Core/UndefinedSortFunction.class.st
@@ -51,12 +51,12 @@ UndefinedSortFunction >> initialize [
 	direction := -1
 ]
 
-{ #category : #'initailize-release' }
+{ #category : #converting }
 UndefinedSortFunction >> undefinedFirst [
 	direction := -1
 ]
 
-{ #category : #'initailize-release' }
+{ #category : #converting }
 UndefinedSortFunction >> undefinedLast [
 	direction := 1
 ]


### PR DESCRIPTION
Just fixed a typo in the categories and make it consistent with the superclass ones.