### PR TITLE
Improve-stability-of-Docking-bar-morph

### DIFF
--- a/src/Morphic-Widgets-Extra/DockingBarMorph.class.st
+++ b/src/Morphic-Widgets-Extra/DockingBarMorph.class.st
@@ -802,37 +802,35 @@ DockingBarMorph >> updatePosition [
 	"private - update the receiver's position.
 	Fixed so as not to keep changing position!
 	(called twice if adhereing)"
-	
-	| edgeSymbol margin |
-	edgeSymbol := self edgeToAdhereTo.
-	edgeSymbol == #none
-		ifTrue: [self
-				perform: (edgeSymbol , ':') asSymbol
-				with: (self owner perform: edgeSymbol)].
-	""
-	margin := self avoidVisibleBordersAtEdge
-				ifTrue: [self borderWidth asPoint]
-				ifFalse: [0 asPoint].
-	""
-	self isAdheringToTop
-		ifTrue: [| usedHeight | 
-			usedHeight := self usedHeightByPredominantDockingBarsOfChastes: #(#top ).
-			self topLeft: self owner topLeft - margin + (0 @ usedHeight)].
-	self isAdheringToBottom
-		ifTrue: [| usedHeight | 
-			usedHeight := self usedHeightByPredominantDockingBarsOfChastes: #(#bottom ).
-			self bottomLeft: self owner bottomLeft + (-1 @ 1 * margin) - (0 @ usedHeight)].
-	""
-	self isAdheringToLeft
-		ifTrue: [| usedHeight usedWidth | 
-			usedHeight := self usedHeightByPredominantDockingBarsOfChastes: #(#top ).
-			usedWidth := self usedWidthByPredominantDockingBarsOfChastes: #(#left ).
-			self topLeft: self owner topLeft - margin + (usedWidth @ usedHeight)].
-	self isAdheringToRight
-		ifTrue: [| usedHeight usedWidth | 
-			usedHeight := self usedHeightByPredominantDockingBarsOfChastes: #(#top ).
-			usedWidth := self usedWidthByPredominantDockingBarsOfChastes: #(#right ).
-			self topRight: self owner topRight + (1 @ -1 * margin) + (usedWidth negated @ usedHeight)]
+
+	self owner
+		ifNotNil: [ :anOwner | 
+			| edgeSymbol margin usedHeight |
+			edgeSymbol := self edgeToAdhereTo.
+			edgeSymbol == #none
+				ifTrue: [ self perform: (edgeSymbol , ':') asSymbol with: (anOwner perform: edgeSymbol) ].
+
+			margin := (self avoidVisibleBordersAtEdge ifTrue: [ self borderWidth ] ifFalse: [ 0 ]) asPoint.
+
+			self isAdheringToTop
+				ifTrue: [ usedHeight := self usedHeightByPredominantDockingBarsOfChastes: #(#top).
+					self topLeft: anOwner topLeft - margin + (0 @ usedHeight) ].
+
+			self isAdheringToBottom
+				ifTrue: [ usedHeight := self usedHeightByPredominantDockingBarsOfChastes: #(#bottom).
+					self bottomLeft: anOwner bottomLeft + (-1 @ 1 * margin) - (0 @ usedHeight) ].
+
+			self isAdheringToLeft
+				ifTrue: [ | usedWidth |
+					usedHeight := self usedHeightByPredominantDockingBarsOfChastes: #(#top).
+					usedWidth := self usedWidthByPredominantDockingBarsOfChastes: #(#left).
+					self topLeft: anOwner topLeft - margin + (usedWidth @ usedHeight) ].
+
+			self isAdheringToRight
+				ifTrue: [ | usedWidth |
+					usedHeight := self usedHeightByPredominantDockingBarsOfChastes: #(#top).
+					usedWidth := self usedWidthByPredominantDockingBarsOfChastes: #(#right).
+					self topRight: anOwner topRight + (1 @ -1 * margin) + (usedWidth negated @ usedHeight) ] ]
 ]
 
 { #category : #'private - accessing' }


### PR DESCRIPTION
I have projects adding elements to the MenuBar in Pharo. In the CI of the projects it often happens that it crash in DockingBarMorph>>updatePosition because between the start and end of the method the owner was removed. 

This commit store the owner to not end up with a nil during the update.