### PR TITLE
4736-MethodMapExamples-should-not-use-MethodMap-directly

### DIFF
--- a/src/OpalCompiler-Tests/MethodMapExamples.class.st
+++ b/src/OpalCompiler-Tests/MethodMapExamples.class.st
@@ -7,141 +7,127 @@ Class {
 { #category : #examples }
 MethodMapExamples >> defineCopiedVarBecomeDeadContext [
 	| a b |
-	b := [ a := 1.a := a + 1. (DebuggerMethodMapOpal forMethod: thisContext method)  tempNamed:'a' in:thisContext].
+	b := [ a := 1.a := a + 1. thisContext tempNamed:'a' ].
 	^ b
 ]
 
 { #category : #examples }
 MethodMapExamples >> exampleCopiedVarFromDeadContext [
-	<sampleInstance>
 	^ self defineCopiedVarBecomeDeadContext value
 ]
 
 { #category : #examples }
 MethodMapExamples >> exampleSimpleTemp [
-	<sampleInstance>
 	| b |
 	b := 1.
-	^(DebuggerMethodMapOpal forMethod: thisContext method) tempNamed: 'b' in: thisContext
+	^thisContext tempNamed: 'b'
 ]
 
 { #category : #examples }
 MethodMapExamples >> exampleTempNamedCopying [
-	<sampleInstance>
 	| b |
 	b := 1.
 	^[ | a |
-		 a := b . (DebuggerMethodMapOpal forMethod: thisContext method) tempNamed: 'b' in: thisContext ] value
+		 a := b . thisContext tempNamed: 'b' ] value
 ]
 
 { #category : #examples }
 MethodMapExamples >> exampleTempNamedCopying2 [
-	<sampleInstance>
 	| b |
 	b := 1.
 	^[ | a |
-		a := b . (DebuggerMethodMapOpal forMethod: thisContext method) tempNamed: 'b' in: thisContext ] value
+		a := b . thisContext tempNamed: 'b' ] value
 ]
 
 { #category : #examples }
 MethodMapExamples >> exampleTempNamedPutCopying [
-	<sampleInstance>
 	| b |
 	b := 1.
 	^[ | a |
-		 a := b . (DebuggerMethodMapOpal forMethod: thisContext method) tempNamed: 'b' in: thisContext put: 2. thisContext tempNamed: 'b' ] value
+		 a := b . thisContext tempNamed: 'b'  put: 2. thisContext tempNamed: 'b' ] value
 ]
 
 { #category : #examples }
 MethodMapExamples >> exampleTempNamedPutCopying2 [
-	<sampleInstance>
 	| b |
 	b := 1.
 	^[ | a |
-		 a := b . (DebuggerMethodMapOpal forMethod: thisContext method) tempNamed: 'b' in: thisContext put: 2. thisContext outerContext tempNamed: 'b' ] value
+		 a := b .thisContext tempNamed: 'b' put: 2. thisContext outerContext tempNamed: 'b' ] value
 ]
 
 { #category : #examples }
 MethodMapExamples >> exampleTempNamedPutTempVector [
-	<sampleInstance>
 	| b |
 	b := 1.
 	^[ | a |
-		 b := 2 . (DebuggerMethodMapOpal forMethod: thisContext method) tempNamed: 'b' in: thisContext put: 3. thisContext tempNamed: 'b' ] value
+		 b := 2 . thisContext tempNamed: 'b' put: 3. thisContext tempNamed: 'b' ] value
 ]
 
 { #category : #examples }
 MethodMapExamples >> exampleTempNamedPutTempVector2 [
-	<sampleInstance>
 	| b |
 	b := 1.
 	^[ | a |
-		 b := 2 . (DebuggerMethodMapOpal forMethod: thisContext method) tempNamed: 'b' in: thisContext put: 3. thisContext outerContext tempNamed: 'b' ] value
+		 b := 2 . thisContext tempNamed: 'b' put: 3. thisContext outerContext tempNamed: 'b' ] value
 ]
 
 { #category : #examples }
 MethodMapExamples >> exampleTempNamedTempCopyingNestedBlock [
-	<sampleInstance>
 	
 	^[| b |
 		b := 1.
 		[   | a |
 		 a := 2.
-		 a := b . (DebuggerMethodMapOpal forMethod: thisContext method) tempNamed: 'b' in: thisContext ] value] value
+		 a := b . thisContext tempNamed: 'b' ] value] value
 ]
 
 { #category : #examples }
 MethodMapExamples >> exampleTempNamedTempCopyingNestedBlockPROBLEM [
-	<sampleInstance>
 	 | a |
 		 a := 2. 
 	^[| b | 
 		b := 1.
 		[  
-		 a := b . (DebuggerMethodMapOpal forMethod: thisContext method) tempNamed: 'b' in: thisContext ] value] value
+		 a := b . thisContext tempNamed: 'b' ] value] value
 ]
 
 { #category : #examples }
 MethodMapExamples >> exampleTempNamedTempVector [
-	<sampleInstance>
 	| b |
 	b := 1.
 	^[ | a |
-		 b := 2 . (DebuggerMethodMapOpal forMethod: thisContext method) tempNamed: 'b' in: thisContext ] value
+		 b := 2 . thisContext tempNamed: 'b' ] value
 ]
 
 { #category : #examples }
 MethodMapExamples >> exampleTempNamedTempVector2 [
-	<sampleInstance>
 	| b |
 	b := 1.
 	^[ | a |
-		 b := 2 . (DebuggerMethodMapOpal forMethod: thisContext method) tempNamed: 'b' in: thisContext outerContext ] value
+		 b := 2 . thisContext tempNamed: 'b' ] value
 ]
 
 { #category : #examples }
 MethodMapExamples >> exampleTempNamedTempVectorInOptimizedBlock [
-	<sampleInstance>
 "temp a is in a temp vector and is accessed from with in the optimized ifTrue:ifFalse: block. But 
 the definition is not in the outer block, but in the method scope"
 	| result a |
 	[ a := 1.
 	result := true
-		ifTrue: [ 1 + ((DebuggerMethodMapOpal forMethod: thisContext method) tempNamed: 'a' in: thisContext) ]
+		ifTrue: [ 1 + (thisContext tempNamed: 'a')]
 		ifFalse: [ 4 ] ] value.
 	^ result
 ]
 
 { #category : #examples }
 MethodMapExamples >> exampleTempNamedTempVectorInlinedLoop [
-	<sampleInstance>
 "This test is for accessing temp var c within an inlined loop scope. 
 Temp var c is written in the loop and closed in a block -> therefore it is in a tempvector. "
 	| a b c |
 	c := nil.
 	a := 1.
 	[ c := 42.
-	b := (DebuggerMethodMapOpal forMethod: thisContext method) tempNamed:'c' in: thisContext. a < 1 ]
+	b := thisContext tempNamed:'c' . a < 1 ]
 		whileTrue: [ a := a + 1.
 				[ c asString ] ].
 	^ b
@@ -149,11 +135,10 @@ Temp var c is written in the loop and closed in a block -> therefore it is in a 
 
 { #category : #examples }
 MethodMapExamples >> exampleTempNamedTempVectorNestedBlock [
-	<sampleInstance>
 	 | a |
       a  := 1.
 	^[| b |
 		b := a.
 		[  
-		 b := 2 . (DebuggerMethodMapOpal forMethod: thisContext method) tempNamed: 'b' in: thisContext ] value] value
+		 b := 2 . thisContext tempNamed: 'b' ] value] value
 ]

--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -196,50 +196,12 @@ MethodMapTest >> testSimpleSourceMapping [
 
 	method := Object>>('ha', 'lt') asSymbol.
 
-	range := (self compileMethod: method) rangeForPC: (Smalltalk vm for32bit: 23 for64bit: 43).
+	range := method rangeForPC: (Smalltalk vm for32bit: 23 for64bit: 43).
 	highlight := method sourceCode copyFrom:  range first to: range last.
 	self assert: highlight equals: 'now'.
 
 
 	
-]
-
-{ #category : #'testing - source mapping' }
-MethodMapTest >> testSourceMappingBlock [
-	| method range highlight pcs |
-
-	method := MethodMapExamples>>#exampleTempNamedCopying.
-	
-	"Cannot check for class since those encoders are changing names all the time..."
-	pcs := (Smalltalk vm 
-		for32bit: [
-			(method encoderClass name endsWith: 'SistaV1')
-				ifTrue: [ 41 to: 45 ]
-				ifFalse: [ 42 to: 46 ] ] 
-		for64bit: [
-			(method encoderClass name endsWith: 'SistaV1')
-				ifTrue: [ 73 to: 77 ]
-				ifFalse: [ 74 to: 78 ] ]).		
-	
-	range := (DebuggerMethodMapOpal forMethod: (self compileMethod: method)) rangeForPC: pcs first.
-	highlight := method sourceCode copyFrom:  range first to: range last.
-	self assert: highlight equals: 'b'.
-
-	range := (DebuggerMethodMapOpal forMethod: (self compileMethod: method)) rangeForPC: pcs second.
-	highlight := method sourceCode copyFrom:  range first to: range last.
-	self assert: highlight equals: 'a := b'.
-	
-	range := (DebuggerMethodMapOpal forMethod: (self compileMethod: method)) rangeForPC: pcs third.
-	highlight := method sourceCode copyFrom:  range first to: range last.
-	self assert: highlight equals:'DebuggerMethodMapOpal'.
-	
-	range := (DebuggerMethodMapOpal forMethod: (self compileMethod: method)) rangeForPC: pcs fourth.
-	highlight := method sourceCode copyFrom:  range first to: range last.
-	self assert: highlight equals:'thisContext'.
-	
-	range := (DebuggerMethodMapOpal forMethod: (self compileMethod: method)) rangeForPC: pcs fifth.
-	highlight := method sourceCode copyFrom:  range first to: range last.
-	self assert: highlight equals: 'method'.
 ]
 
 { #category : #'testing - temp access' }


### PR DESCRIPTION
- change MethodMapExamples to not reference DebuggerMethodMapOpal directly
- remove one test (#testSourceMappingBlock), this test will be rewritten to test source ranges more directly (and thus be inpendend of the bytecode offsets). When that is done, the test and examples wil be  splitt and renamed to be more clear about what they are (temp access and bc2txt mapping)

fixes #4736