### PR TITLE
Porting a new implementation of ZnBufferedReadWriteStream

### DIFF
--- a/src/FileSystem-Memory/MemoryFileWriteStream.class.st
+++ b/src/FileSystem-Memory/MemoryFileWriteStream.class.st
@@ -47,6 +47,12 @@ MemoryFileWriteStream >> isBinary [
 ]
 
 { #category : #writing }
+MemoryFileWriteStream >> next: numberOfElements putAll: aCollection startingAt: startingAt [ 
+
+	^ stream next: numberOfElements putAll: aCollection startingAt: startingAt 
+]
+
+{ #category : #writing }
 MemoryFileWriteStream >> nextPut: aCollection [
 	^ self stream nextPut: aCollection
 ]
@@ -59,6 +65,12 @@ MemoryFileWriteStream >> nextPutAll: aCollection [
 { #category : #positioning }
 MemoryFileWriteStream >> position [
 	^ self stream position
+]
+
+{ #category : #position }
+MemoryFileWriteStream >> position: aPosition [ 
+	
+	stream position: aPosition
 ]
 
 { #category : #positioning }

--- a/src/Tests/SourceFileArrayTest.class.st
+++ b/src/Tests/SourceFileArrayTest.class.st
@@ -375,10 +375,13 @@ SourceFileArrayTest >> testWriteToBufferedStream [
 	| fs array |
 	fs := FileSystem memory.
 	array := SourceFileArray new.
-	array
-		changesFileStream: (ZnBufferedReadWriteStream on: (fs / 'changes.chunk') writeStream).
-	array
-		sourcesFileStream: (ZnBufferedReadWriteStream on: (fs / 'sources.chunk') writeStream).
+	
+	array changesFileStream: 
+		(ZnCharacterReadWriteStream on: (ZnBufferedReadWriteStream on: (fs binaryWriteStreamOn: (fs / 'changes.chunk') path)) encoding: #utf8).
+	
+	array sourcesFileStream: 
+		(ZnCharacterReadWriteStream on: (ZnBufferedReadWriteStream on: (fs binaryWriteStreamOn: (fs / 'sources.chunk') path)) encoding: #utf8).
+
 	array
 		writeSource: 'some source'
 		preamble: 'some preamble'

--- a/src/Tool-ExternalBrowser/ExternalBrowser.class.st
+++ b/src/Tool-ExternalBrowser/ExternalBrowser.class.st
@@ -87,7 +87,7 @@ ExternalBrowser class >> serviceBrowseCode [
 		selector: #browseStream:
 		description: 'Open a "file-contents browser" on this file, allowing you to view and selectively load its code'
 		buttonLabel: 'Code')
-		argumentGetter: [ :file| file readOnlyStream]
+		argumentGetter: [ :fileReference | fileReference readStream ]
 ]
 
 { #category : #'System-FileRegistry' }

--- a/src/Tool-ExternalBrowser/ExternalChangesBrowser.class.st
+++ b/src/Tool-ExternalBrowser/ExternalChangesBrowser.class.st
@@ -114,7 +114,7 @@ ExternalChangesBrowser class >> serviceBrowseCSOrSTFile [
 		selector: #openOnStream:
 		description: 'Open a changelist tool on this file'
 		buttonLabel: 'Changes')
-		argumentGetter: [ :stream | stream readOnlyStream ]
+		argumentGetter: [ :fileReference | fileReference readStream ]
 ]
 
 { #category : #'file service' }

--- a/src/Zinc-Character-Encoding-Core/ZnBufferedReadWriteStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnBufferedReadWriteStream.class.st
@@ -129,7 +129,7 @@ ZnBufferedReadWriteStream >> flush [
 { #category : #testing }
 ZnBufferedReadWriteStream >> isBinary [
 	
-	^ readStream isBinary
+	^ innerStream isBinary 
 ]
 
 { #category : #private }
@@ -181,13 +181,6 @@ ZnBufferedReadWriteStream >> next: aQuantity [
 	^ read = aQuantity 
 		ifTrue: [ collection ]
 		ifFalse: [ collection copyFrom: 1 to: read - 1 ]     
-]
-
-{ #category : #accessing }
-ZnBufferedReadWriteStream >> next: count putAll: collection [
-
-	self writingActionDo: [ 
-		writeStream next: count putAll: collection ]
 ]
 
 { #category : #writing }
@@ -286,21 +279,6 @@ ZnBufferedReadWriteStream >> readInto: aBuffer startingAt: startingAt count: cou
 ]
 
 { #category : #private }
-ZnBufferedReadWriteStream >> readingActionDo: aBlock [
-
-	"Reading from the read stream.
-	We should 
-	 - flush the write stream
-	 - discard the read buffer (which may contain incorrect data).
-	 - and then perform the read."
-	
-	lastRead ifFalse: [ 
-		writeStream flush.
-		readStream discardBuffer ].
-	^ aBlock ensure: [ lastRead := true ]
-]
-
-{ #category : #private }
 ZnBufferedReadWriteStream >> refreshBufferFrom: aPosition [
 
 	| nextBufferPosition |
@@ -351,18 +329,6 @@ ZnBufferedReadWriteStream >> skip: aQuantity [
 	nextPosition := nextPosition + aQuantity
 ]
 
-{ #category : #accessing }
-ZnBufferedReadWriteStream >> truncate [
-	
-	self writingActionDo: [ writeStream truncate ]
-]
-
-{ #category : #accessing }
-ZnBufferedReadWriteStream >> truncate: anInteger [ 
-	
-	self writingActionDo: [ writeStream truncate: anInteger ]
-]
-
 { #category : #reading }
 ZnBufferedReadWriteStream >> upTo: value [ 
 	"Read upto but not including value and return them as a collection.
@@ -383,23 +349,4 @@ ZnBufferedReadWriteStream >> upToEnd [
 
 	toRead := (streamSize - (nextPosition - 1)) max: 0.
 	^ self next: toRead.
-]
-
-{ #category : #accessing }
-ZnBufferedReadWriteStream >> wrappedStream [
-
-	^ readStream wrappedStream
-]
-
-{ #category : #accessing }
-ZnBufferedReadWriteStream >> writingActionDo: aBlock [
-	
-	"Writing to the write stream.
-	We should 
-	 - write the write stream
-	 - discard the read buffer (which may contain incorrect data)"
-	lastRead ifTrue: [ 
-		writeStream discardBuffer ].
-	readStream discardBuffer.
-	^ aBlock ensure: [ lastRead := false ]
 ]

--- a/src/Zinc-Character-Encoding-Core/ZnBufferedReadWriteStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnBufferedReadWriteStream.class.st
@@ -15,9 +15,13 @@ Class {
 	#name : #ZnBufferedReadWriteStream,
 	#superclass : #Object,
 	#instVars : [
-		'readStream',
-		'writeStream',
-		'lastRead'
+		'innerStream',
+		'buffer',
+		'bufferLength',
+		'streamSize',
+		'bufferOffset',
+		'nextPosition',
+		'isDirty'
 	],
 	#category : #'Zinc-Character-Encoding-Core'
 }
@@ -34,37 +38,104 @@ ZnBufferedReadWriteStream class >> on: readStream do: block [
 	"Execute block with as argument a ZnBufferedReadStream on readStream.
 	Return the value of block."
 
-	^ block value: (self on: readStream)
+	| stream |
+
+	stream := self on: readStream.
+
+	^ [block value: stream ] ensure: [ stream flush ]
 ]
 
 { #category : #testing }
 ZnBufferedReadWriteStream >> atEnd [
 	
-	^ self readingActionDo: [ readStream atEnd ]
+	^ self atEnd: nextPosition
 ]
 
-{ #category : #accessing }
+{ #category : #private }
+ZnBufferedReadWriteStream >> atEnd: anInteger [ 
+	
+	anInteger < streamSize ifTrue: [ ^ false ].
+	anInteger <= (bufferOffset + bufferLength)  ifTrue: [ ^ false ].
+	
+	^ true
+]
+
+{ #category : #private }
+ZnBufferedReadWriteStream >> bufferAt: aPosition [
+
+	^ buffer at:  (aPosition - bufferOffset)
+	
+	
+]
+
+{ #category : #private }
+ZnBufferedReadWriteStream >> bufferAt: aPosition put: anElement [
+
+	self checkBufferFor: nextPosition.
+
+	bufferLength := (aPosition - bufferOffset) max: bufferLength.
+	buffer at: (aPosition - bufferOffset) put: anElement
+	
+]
+
+{ #category : #private }
+ZnBufferedReadWriteStream >> checkBufferFor: aPosition [
+
+	(self isPositionInBuffer: aPosition)
+		ifFalse: [ self refreshBufferFrom: aPosition ]
+]
+
+{ #category : #closing }
 ZnBufferedReadWriteStream >> close [
 	
-	writeStream flush.
-	writeStream close.
+	self flush.
+	innerStream close
 ]
 
 { #category : #testing }
 ZnBufferedReadWriteStream >> closed [
-	^ readStream closed
+
+	^ innerStream closed
 ]
 
-{ #category : #accessing }
+{ #category : #'initialize-release' }
+ZnBufferedReadWriteStream >> collectionSpecies [
+	^ innerStream isBinary
+		ifTrue: [ ByteArray ]
+		ifFalse: [ String ]
+]
+
+{ #category : #initialization }
+ZnBufferedReadWriteStream >> defaultBufferSize [
+	
+	^ 2 raisedToInteger: 16
+]
+
+{ #category : #writing }
 ZnBufferedReadWriteStream >> flush [
 	
-	self writingActionDo: [ writeStream flush ]
+	isDirty ifFalse: [ ^ self ]. 
+		
+	innerStream position: bufferOffset.
+	innerStream next: bufferLength putAll: buffer startingAt: 1.
+	
+	innerStream flush.
+	
+	streamSize := innerStream size.
+	
+	isDirty := false
 ]
 
 { #category : #testing }
 ZnBufferedReadWriteStream >> isBinary [
 	
 	^ readStream isBinary
+]
+
+{ #category : #private }
+ZnBufferedReadWriteStream >> isPositionInBuffer: aPosition [
+
+	^ aPosition between: bufferOffset and: bufferOffset + bufferLength
 ]
 
 { #category : #testing }
@@ -79,18 +150,37 @@ ZnBufferedReadWriteStream >> isStream [
 	^ true
 ]
 
-{ #category : #accessing }
-ZnBufferedReadWriteStream >> next [
+{ #category : #reading }
+ZnBufferedReadWriteStream >> next [ 
+	| value |
+
+	self atEnd 
+		ifTrue: [^ nil].	
+		
+	self checkBufferFor:nextPosition.
+		
+	value := self bufferAt: nextPosition.
 	
-	^ self readingActionDo: [ 
-		readStream next ]
+	nextPosition := nextPosition + 1.
+
+	^ value
 ]
 
-{ #category : #accessing }
-ZnBufferedReadWriteStream >> next: anInteger [ 
-	
-	^ self readingActionDo: [ 
-		readStream next: anInteger ]
+{ #category : #reading }
+ZnBufferedReadWriteStream >> next: aQuantity [
+
+	| read collection |
+
+	collection := self collectionSpecies new: aQuantity.	
+
+	read := self 
+		readInto: collection 
+		startingAt: 1 
+		count: aQuantity.
+
+	^ read = aQuantity 
+		ifTrue: [ collection ]
+		ifFalse: [ collection copyFrom: 1 to: read - 1 ]     
 ]
 
 { #category : #accessing }
@@ -100,61 +190,99 @@ ZnBufferedReadWriteStream >> next: count putAll: collection [
 		writeStream next: count putAll: collection ]
 ]
 
-{ #category : #accessing }
-ZnBufferedReadWriteStream >> next: count putAll: collection startingAt: offset [
-	
-	self writingActionDo: [
-		writeStream next: count putAll: collection startingAt: offset ]
+{ #category : #writing }
+ZnBufferedReadWriteStream >> next: aQuantity putAll: aCollection startingAt: startingAt [
+
+	aCollection readStreamDo: [ :s | 
+		s skip: startingAt - 1.
+		self nextPutAll:  (s next: aQuantity)].
 ]
 
-{ #category : #accessing }
-ZnBufferedReadWriteStream >> nextPut: aCharacter [ 
+{ #category : #writing }
+ZnBufferedReadWriteStream >> nextPut: anElement [ 
 	
-	self writingActionDo: [ writeStream nextPut: aCharacter ]
+	self checkBufferFor: nextPosition.
+		
+	self bufferAt: nextPosition put: anElement.
+	
+	isDirty := true.
+	nextPosition := nextPosition + 1
 ]
 
-{ #category : #accessing }
-ZnBufferedReadWriteStream >> nextPutAll: aString [ 
+{ #category : #writing }
+ZnBufferedReadWriteStream >> nextPutAll: aCollection [
 	
-	^ self writingActionDo: [ writeStream nextPutAll: aString ]
+	aCollection do: [ :each | self nextPut: each ]
 ]
 
 { #category : #'instance creation' }
 ZnBufferedReadWriteStream >> on: aStream [
 
-	lastRead := true.
-	readStream := ZnBufferedReadStream on: aStream.
-	writeStream := ZnBufferedWriteStream on: aStream.
+	innerStream := aStream.
+	nextPosition := aStream position + 1.
+	streamSize := aStream size.
+	
+	bufferOffset := -1.
+	bufferLength := 0.
+	isDirty := false.
+	
+	self sizeBuffer: self defaultBufferSize.
+	
+
 ]
 
-{ #category : #accessing }
+{ #category : #reading }
 ZnBufferedReadWriteStream >> peek [
 	
-	^ self readingActionDo: [ 
-		readStream peek ]
+	| value |
+	value := self next.
+	"If I have read correctly I reset the position"
+	value ifNotNil: [ nextPosition := nextPosition - 1  ].
+	
+	^ value
+	
 ]
 
-{ #category : #accessing }
+{ #category : #querying }
 ZnBufferedReadWriteStream >> position [
-	
-	^ lastRead
-		ifTrue: [ readStream position ]
-		ifFalse: [ writeStream position ]
+
+	^ nextPosition - 1 
+
 ]
 
-{ #category : #accessing }
-ZnBufferedReadWriteStream >> position: anInteger [ 
-	
-	self writingActionDo: [ 
-		writeStream position: anInteger ]
-	
+{ #category : #querying }
+ZnBufferedReadWriteStream >> position: aNewPosition [
+
+	^ nextPosition := aNewPosition + 1
+
 ]
 
-{ #category : #accessing }
-ZnBufferedReadWriteStream >> readInto: collection startingAt: offset count: requestedCount [
+{ #category : #reading }
+ZnBufferedReadWriteStream >> readInto: aBuffer startingAt: startingAt count: count [
+
+	| remainingCount maxPositionInBuffer read countToRead |
+
+	remainingCount := count.
+	read := 0.
 	
-	^ self readingActionDo: [ 
-		readStream readInto: collection startingAt: offset count: requestedCount ]
+	[ remainingCount > 0  and: [ self atEnd not ]]
+		whileTrue: [  
+			self checkBufferFor: nextPosition.
+			
+			maxPositionInBuffer := bufferOffset + bufferLength.
+			countToRead := ( maxPositionInBuffer - (nextPosition - 1) ) min: remainingCount. 
+			aBuffer
+				replaceFrom: startingAt + read
+				to: startingAt + read + countToRead - 1
+				with: buffer
+				startingAt: (nextPosition - bufferOffset).
+				
+			nextPosition := nextPosition + countToRead.
+			remainingCount := remainingCount - countToRead.
+			read := read + countToRead
+		].
+	
+	^ read.
 ]
 
 { #category : #private }
@@ -172,30 +300,55 @@ ZnBufferedReadWriteStream >> readingActionDo: aBlock [
 	^ aBlock ensure: [ lastRead := true ]
 ]
 
-{ #category : #accessing }
-ZnBufferedReadWriteStream >> setToEnd [
-	
-	^ self writingActionDo: [ 
-		writeStream setToEnd ]
+{ #category : #private }
+ZnBufferedReadWriteStream >> refreshBufferFrom: aPosition [
+
+	| nextBufferPosition |
+
+	nextBufferPosition := (((aPosition - 1) max:0) // buffer size) * buffer size.
+	bufferOffset = nextBufferPosition ifTrue: [ ^ self ].
+
+	self flush.
+
+	"If the position is outside the real stream I will only flush the buffer if I have to empty it."
+	(nextBufferPosition >= streamSize) 
+		ifTrue: [
+			bufferOffset := nextBufferPosition.
+			bufferLength := 0.	
+			^ self	].
+		 
+	(nextBufferPosition = (bufferOffset + bufferLength)) 
+		ifFalse: [ innerStream position: nextBufferPosition ].
+
+	bufferLength := innerStream readInto: buffer startingAt: 1 count: buffer size.
+	bufferOffset := nextBufferPosition.
 ]
 
-{ #category : #accessing }
-ZnBufferedReadWriteStream >> size [
-	^ readStream size
+{ #category : #reading }
+ZnBufferedReadWriteStream >> setToEnd [
+
+	nextPosition := (streamSize max: (bufferOffset + bufferLength)) + 1
+]
+
+{ #category : #querying }
+ZnBufferedReadWriteStream >> size [ 
+
+	^ streamSize max: (bufferOffset + bufferLength)
 ]
 
 { #category : #'initialize-release' }
-ZnBufferedReadWriteStream >> sizeBuffer: anInteger [ 
-	
-	readStream sizeBuffer: anInteger.
-	writeStream sizeBuffer: anInteger.
+ZnBufferedReadWriteStream >> sizeBuffer: size [
+
+	bufferLength > 0 ifTrue: [ self flush ].
+	bufferLength := 0.
+
+	buffer := self collectionSpecies new: size
 ]
 
-{ #category : #accessing }
-ZnBufferedReadWriteStream >> skip: anInteger [ 
-	
-	self readingActionDo: [ 
-		readStream skip: anInteger ]
+{ #category : #reading }
+ZnBufferedReadWriteStream >> skip: aQuantity [
+
+	nextPosition := nextPosition + aQuantity
 ]
 
 { #category : #accessing }
@@ -210,16 +363,26 @@ ZnBufferedReadWriteStream >> truncate: anInteger [
 	self writingActionDo: [ writeStream truncate: anInteger ]
 ]
 
-{ #category : #accessing }
-ZnBufferedReadWriteStream >> upTo: aCharacter [ 
+{ #category : #reading }
+ZnBufferedReadWriteStream >> upTo: value [ 
+	"Read upto but not including value and return them as a collection.
+	If value is not found, return the entire contents of the stream.
+	This could be further optimzed."
 	
-	^ self readingActionDo: [ readStream upTo: aCharacter ]
+	^ self collectionSpecies 
+		streamContents: [ :writeStream | | element |
+			[ self atEnd or: [ (element := self next) = value ] ] whileFalse: [ 
+				writeStream nextPut: element ] ]
 ]
 
-{ #category : #accessing }
+{ #category : #reading }
 ZnBufferedReadWriteStream >> upToEnd [
-	
-	^ self readingActionDo: [ readStream upToEnd ]
+	"Read elements until the stream is atEnd and return them as a collection."
+
+	| toRead |
+
+	toRead := (streamSize - (nextPosition - 1)) max: 0.
+	^ self next: toRead.
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
More insight about the change.
Basically in new machines with 4kb physical sectors solid hard drives, Windows formats the drives using 4kb sectors and emulating 512 bytes sectors. (https://docs.microsoft.com/es-es/windows/win32/w8cookbook/advanced-format--4k--disk-compatibility-update?redirectedfrom=MSDN)

Basically it handles the writing and reading of small sectors accessing the disk.
This is really bad in the changes file as we are reading and writing the same file all the time.
Moreover, the changes file was using buffered streams for reading and writing, but the integration of them is through the disk, so any combination of reading and writing operations flush the buffers forcing accesses to the disk, therefore, slowing the process.

In a stock Pharo 8 image, the time to compile methods in a machine using emulated 512 bytes segments takes a lot of time:

Object subclass: #Prb
instanceVariableNames: ''
classVariableNames: ''
package: 'Prueba'.

[20 timesRepeat: [ Prb compile: 'm2
^ 42']] timeToRun.

"0:00:00:23.194"

This problem is really clear when loading big projects, as compiling any class or method access the changes file. Moreover, this also improves the times in a machine without 4kb physical sector disks.

When using the new solution that shares the buffer and improves the flushing handle the times get better:

[20 timesRepeat: [ Prb compile: 'm2
^ 42']] timeToRun.
"0:00:00:00.323"