### PR TITLE
2863-Stack-should-not-inherit-from-LinkedList

### DIFF
--- a/src/Collections-Stack/AbstractStackStrategy.class.st
+++ b/src/Collections-Stack/AbstractStackStrategy.class.st
@@ -17,7 +17,7 @@ Class {
 { #category : #enumerating }
 AbstractStackStrategy >> do: aBlock [
  	"Evaluate aBlock with each of the receiver's elements as the argument.
- 	 Starts by the element at the top of the Linked list and goes to the deepest element."
+ 	 Starts by the element at the top of the stackt and goes to the deepest element."
 
   	self subclassResponsibility
 ]

--- a/src/Collections-Stack/AbstractStackStrategy.class.st
+++ b/src/Collections-Stack/AbstractStackStrategy.class.st
@@ -1,0 +1,53 @@
+"
+I am an abstract stack strategy. My subclasses can be used as Stack internal implementation.
+
+I define the common API to be understood by stack strategies:
+ - #push: to push an object at the top of the stack.
+ - #top to get the object at the top of the stack without removing it.
+ - #pop to remove the object at the top of the stack and return it.
+ - #do: to iterate on stack elements from top to bottom.
+ - #size to get the size of the stack.
+"
+Class {
+	#name : #AbstractStackStrategy,
+	#superclass : #Object,
+	#category : #'Collections-Stack-Strategies'
+}
+
+{ #category : #enumerating }
+AbstractStackStrategy >> do: aBlock [
+ 	"Evaluate aBlock with each of the receiver's elements as the argument.
+ 	 Starts by the element at the top of the Linked list and goes to the deepest element."
+
+  	self subclassResponsibility
+]
+
+{ #category : #removing }
+AbstractStackStrategy >> pop [
+ 	"Remove the object at the top of the stack and returns it.
+ 	 The implementation depends on the internal representation of the stack.
+ 	 Any subclass should implement this method properly."
+ 	^ self subclassResponsibility
+]
+
+{ #category : #adding }
+AbstractStackStrategy >> push: newObject [
+ 	"Push newObject on the top of the stack.
+ 	 The implementation depends on the internal representation of the stack.
+ 	 Any subclass should implement this method properly."
+ 	self subclassResponsibility
+]
+
+{ #category : #accessing }
+AbstractStackStrategy >> size [
+	"Returns the size of the stack."
+ 	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+AbstractStackStrategy >> top [
+ 	"Returns the element at the top of the stack without removing it.
+ 	 The implementation depends on the internal representation of the stack.
+ 	 Any subclass should implement this method properly."
+ 	^ self subclassResponsibility
+]

--- a/src/Collections-Stack/AbstractStackStrategy.class.st
+++ b/src/Collections-Stack/AbstractStackStrategy.class.st
@@ -38,6 +38,12 @@ AbstractStackStrategy >> push: newObject [
  	self subclassResponsibility
 ]
 
+{ #category : #initialization }
+AbstractStackStrategy >> reset [
+	"Reset the Stack. Removes all the object it used to contain."
+	self subclassResponsibility
+]
+
 { #category : #accessing }
 AbstractStackStrategy >> size [
 	"Returns the size of the stack."

--- a/src/Collections-Stack/LinkedListStackStrategy.class.st
+++ b/src/Collections-Stack/LinkedListStackStrategy.class.st
@@ -1,0 +1,46 @@
+"
+I am a stack using a LinkedList under the hood.
+
+The first link of the linked list is considered as the top of the stack as it is efficient to add / remove.
+"
+Class {
+	#name : #LinkedListStackStrategy,
+	#superclass : #AbstractStackStrategy,
+	#instVars : [
+		'linkedList'
+	],
+	#category : #'Collections-Stack-Strategies'
+}
+
+{ #category : #enumerating }
+LinkedListStackStrategy >> do: aBlock [
+ 	linkedList do: aBlock
+]
+
+{ #category : #initialization }
+LinkedListStackStrategy >> initialize [
+ 	super initialize.
+ 	linkedList := LinkedList new
+]
+
+{ #category : #removing }
+LinkedListStackStrategy >> pop [
+ 	"We use the first link of the linked list as the top of the stack as it is efficient to add / remove."
+ 	^ linkedList removeFirst
+]
+
+{ #category : #removing }
+LinkedListStackStrategy >> push: newObject [
+ 	linkedList addFirst: newObject.
+ 	^ newObject
+]
+
+{ #category : #accessing }
+LinkedListStackStrategy >> size [
+ 	^ linkedList size
+]
+
+{ #category : #accessing }
+LinkedListStackStrategy >> top [
+ 	^ linkedList first
+]

--- a/src/Collections-Stack/LinkedListStackStrategy.class.st
+++ b/src/Collections-Stack/LinkedListStackStrategy.class.st
@@ -19,8 +19,8 @@ LinkedListStackStrategy >> do: aBlock [
 
 { #category : #initialization }
 LinkedListStackStrategy >> initialize [
- 	super initialize.
- 	linkedList := LinkedList new
+	super initialize.
+	self reset
 ]
 
 { #category : #removing }
@@ -33,6 +33,11 @@ LinkedListStackStrategy >> pop [
 LinkedListStackStrategy >> push: newObject [
  	linkedList addFirst: newObject.
  	^ newObject
+]
+
+{ #category : #initialization }
+LinkedListStackStrategy >> reset [
+	linkedList := LinkedList new
 ]
 
 { #category : #accessing }

--- a/src/Collections-Stack/NewStack.class.st
+++ b/src/Collections-Stack/NewStack.class.st
@@ -80,6 +80,11 @@ NewStack >> remove: oldObject ifAbsent: anExceptionBlock [
 	self shouldNotImplement
 ]
 
+{ #category : #removing }
+NewStack >> removeAll [
+	self strategy reset
+]
+
 { #category : #accessing }
 NewStack >> strategy [
 	^ strategy

--- a/src/Collections-Stack/NewStack.class.st
+++ b/src/Collections-Stack/NewStack.class.st
@@ -1,0 +1,92 @@
+"
+I am a parametrizable stack. That is to say, I provide the interface of a stack but depending on my #strategy, I can use a LinkedList, an OrderedCollection, etc for implementation details.
+"
+Class {
+	#name : #NewStack,
+	#superclass : #Collection,
+	#instVars : [
+		'strategy'
+	],
+	#category : #'Collections-Stack-Base'
+}
+
+{ #category : #factory }
+NewStack class >> usingLinkedList [
+ 	"Returns an instance of Stack using a LinkedList under the hood."
+ 	^ self usingStrategy: LinkedListStackStrategy new
+]
+
+{ #category : #factory }
+NewStack class >> usingOrderedCollection [
+ 	"Returns an instance of Stack using a OrderedCollection under the hood."
+ 	^ self usingStrategy: OrderedCollectionStackStrategy new
+]
+
+{ #category : #'instance creation' }
+NewStack class >> usingStrategy: aStackStrategy [
+ 	"Given a aStackStrategy, returns an instance of Stack using this strategy under the hood."
+ 	^ self new
+ 		initializeWith: aStackStrategy;
+ 		yourself
+]
+
+{ #category : #adding }
+NewStack >> add: newObject [
+ 	"Include newObject as one of the receiver's elements. Answer newObject. 
+ 	ArrayedCollections cannot respond to this message."
+
+  	^ self push: newObject
+]
+
+{ #category : #enumerating }
+NewStack >> do: aBlock [
+ 	"Evaluate aBlock with each of the receiver's elements as the argument."
+
+  	self strategy do: aBlock
+]
+
+{ #category : #initialization }
+NewStack >> initialize [
+	super initialize.
+	strategy := LinkedListStackStrategy new
+]
+
+{ #category : #initialization }
+NewStack >> initializeWith: aStrategy [
+	strategy := aStrategy
+]
+
+{ #category : #removing }
+NewStack >> pop [
+	" Remove the object at the top of the stack and return it.
+
+  	 (Stack new push: 1; push: 2; pop) >>> 2
+	"
+ 	^ self strategy pop
+]
+
+{ #category : #adding }
+NewStack >> push: newObject [
+ 	"Push newObject on the top of the stack."
+ 	self strategy push: newObject.
+ 	^ newObject
+]
+
+{ #category : #removing }
+NewStack >> remove: oldObject ifAbsent: anExceptionBlock [
+	"A stack should not implement that.
+	 Use a linked list if you really need this feature.
+	"
+	self shouldNotImplement
+]
+
+{ #category : #accessing }
+NewStack >> strategy [
+	^ strategy
+]
+
+{ #category : #accessing }
+NewStack >> top [
+ 	"Returns the object at the top of the stack without removing it."
+ 	^ self strategy top
+]

--- a/src/Collections-Stack/OrderedCollectionStackStrategy.class.st
+++ b/src/Collections-Stack/OrderedCollectionStackStrategy.class.st
@@ -1,0 +1,45 @@
+"
+I am a stack using a OrderedCollection under the hood.
+
+I store the top of the stack at the bottom of the collection as it is more efficient.
+"
+Class {
+	#name : #OrderedCollectionStackStrategy,
+	#superclass : #AbstractStackStrategy,
+	#instVars : [
+		'orderedCollection'
+	],
+	#category : #'Collections-Stack-Strategies'
+}
+
+{ #category : #enumerating }
+OrderedCollectionStackStrategy >> do: aBlock [
+	orderedCollection reverseDo: aBlock
+]
+
+{ #category : #initialization }
+OrderedCollectionStackStrategy >> initialize [
+ 	super initialize.
+ 	orderedCollection := OrderedCollection new
+]
+
+{ #category : #removing }
+OrderedCollectionStackStrategy >> pop [
+ 	^ orderedCollection removeLast
+]
+
+{ #category : #adding }
+OrderedCollectionStackStrategy >> push: newObject [
+ 	orderedCollection addLast: newObject.
+ 	^ newObject
+]
+
+{ #category : #accessing }
+OrderedCollectionStackStrategy >> size [
+ 	^ orderedCollection size
+]
+
+{ #category : #accessing }
+OrderedCollectionStackStrategy >> top [
+ 	^ orderedCollection last
+]

--- a/src/Collections-Stack/OrderedCollectionStackStrategy.class.st
+++ b/src/Collections-Stack/OrderedCollectionStackStrategy.class.st
@@ -19,8 +19,8 @@ OrderedCollectionStackStrategy >> do: aBlock [
 
 { #category : #initialization }
 OrderedCollectionStackStrategy >> initialize [
- 	super initialize.
- 	orderedCollection := OrderedCollection new
+	super initialize.
+	self reset
 ]
 
 { #category : #removing }
@@ -32,6 +32,11 @@ OrderedCollectionStackStrategy >> pop [
 OrderedCollectionStackStrategy >> push: newObject [
  	orderedCollection addLast: newObject.
  	^ newObject
+]
+
+{ #category : #initialization }
+OrderedCollectionStackStrategy >> reset [
+	orderedCollection := OrderedCollection new
 ]
 
 { #category : #accessing }

--- a/src/Collections-Tests/AbstractStackStrategyTest.class.st
+++ b/src/Collections-Tests/AbstractStackStrategyTest.class.st
@@ -1,0 +1,95 @@
+Class {
+	#name : #AbstractStackStrategyTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'strategy'
+	],
+	#category : #'Collections-Tests-Stack'
+}
+
+{ #category : #testing }
+AbstractStackStrategyTest class >> isAbstract [
+ 	^ self = AbstractStackStrategyTest
+]
+
+{ #category : #running }
+AbstractStackStrategyTest >> setUp [
+ 	super setUp.
+ 	strategy := self stackStrategyClass new
+]
+
+{ #category : #accessing }
+AbstractStackStrategyTest >> stackStrategyClass [
+ 	^ self subclassResponsibility
+]
+
+{ #category : #tests }
+AbstractStackStrategyTest >> testEmptyError [
+ 	| aStack |
+ 	aStack := strategy.
+ 	self should: [ aStack top ] raise: Error.
+ 	self should: [ aStack pop ] raise: Error.
+ 	aStack push: 'element'.
+ 	aStack top.
+ 	aStack pop.	"The stack is empty again due to previous pop"
+ 	self should: [ aStack top ] raise: Error.
+ 	self should: [ aStack pop ] raise: Error
+]
+
+{ #category : #tests }
+AbstractStackStrategyTest >> testPop [
+
+  	| res elem aStack |
+ 	aStack := strategy.
+ 	elem := 'anElement'.	
+ 	self assert: aStack size equals: 0.
+
+  	aStack push: 'a'.
+ 	aStack push: elem.
+ 	res := aStack pop.	
+ 	self assert: res equals: elem.
+ 	self assert: res == elem.
+
+  	self assert: aStack size equals: 1.
+ 	aStack pop.
+ 	self assert: aStack size equals: 0.
+]
+
+{ #category : #tests }
+AbstractStackStrategyTest >> testPush [
+ 	| aStack |
+ 	aStack := strategy.
+ 	aStack push: 'a'.
+ 	self assert: aStack size equals: 1.	
+ 	aStack push: 'b'.
+ 	self assert: aStack size equals: 2.
+]
+
+{ #category : #tests }
+AbstractStackStrategyTest >> testSize [
+
+  	| aStack |
+ 	aStack := strategy.
+ 	self assert: aStack size equals: 0.
+ 	aStack push: 'a'.
+ 	self assert: aStack size equals: 1.
+ 	aStack push: 'b'.
+ 	self assert: aStack size equals: 2.
+ 	aStack pop.
+ 	self assert: aStack size equals: 1.
+ 	aStack pop.
+ 	self assert: aStack size equals: 0.
+]
+
+{ #category : #tests }
+AbstractStackStrategyTest >> testTop [
+
+  	| aStack |
+ 	aStack := strategy.
+ 	self assert: aStack size equals: 0.
+ 	aStack push: 'a'.
+ 	aStack push: 'b'.
+ 	self assert: aStack top equals: 'b'.
+ 	self assert: aStack top equals: 'b'.
+ 	self assert: aStack size equals: 2.
+]

--- a/src/Collections-Tests/AbstractStackStrategyTest.class.st
+++ b/src/Collections-Tests/AbstractStackStrategyTest.class.st
@@ -66,6 +66,22 @@ AbstractStackStrategyTest >> testPush [
 ]
 
 { #category : #tests }
+AbstractStackStrategyTest >> testReset [
+	| stack |
+	stack := strategy.
+	
+	stack push: 1.
+	stack push: 2.
+	stack push: 3.
+	
+	self assert: stack size equals: 3.
+	
+	stack reset.
+	
+	self assert: stack size equals: 0
+]
+
+{ #category : #tests }
 AbstractStackStrategyTest >> testSize [
 
   	| aStack |

--- a/src/Collections-Tests/LinkedListStackStrategyTest.class.st
+++ b/src/Collections-Tests/LinkedListStackStrategyTest.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #LinkedListStackStrategyTest,
+	#superclass : #AbstractStackStrategyTest,
+	#category : #'Collections-Tests-Stack'
+}
+
+{ #category : #accessing }
+LinkedListStackStrategyTest >> stackStrategyClass [
+ 	^ LinkedListStackStrategy
+]

--- a/src/Collections-Tests/OrderedCollectionStackStrategyTest.class.st
+++ b/src/Collections-Tests/OrderedCollectionStackStrategyTest.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #OrderedCollectionStackStrategyTest,
+	#superclass : #AbstractStackStrategyTest,
+	#category : #'Collections-Tests-Stack'
+}
+
+{ #category : #accessing }
+OrderedCollectionStackStrategyTest >> stackStrategyClass [
+ 	^ OrderedCollectionStackStrategy
+]

--- a/src/Collections-Tests/StackTest.class.st
+++ b/src/Collections-Tests/StackTest.class.st
@@ -81,6 +81,21 @@ StackTest >> testPush [
 ]
 
 { #category : #tests }
+StackTest >> testRemoveAll [
+	| aStack |
+	aStack := NewStack new.
+	aStack push: 1.
+	aStack push: 2.
+	aStack push: 3.
+	
+	self assert: aStack size equals: 3.
+	
+	aStack removeAll.
+	
+	self assert: aStack isEmpty
+]
+
+{ #category : #tests }
 StackTest >> testSize [
 	
 	| aStack |

--- a/src/Collections-Tests/StackTest.class.st
+++ b/src/Collections-Tests/StackTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for stacks
 Class {
 	#name : #StackTest,
 	#superclass : #TestCase,
-	#traits : 'TEmptyTest - {#testIfNotEmptyifEmpty. #testIfEmpty. #testNotEmpty} + (TCloneTest - {#testCopyNonEmpty})',
+	#traits : 'TEmptyTest + TCloneTest',
 	#classTraits : 'TEmptyTest classTrait + TCloneTest classTrait',
 	#instVars : [
 		'empty',
@@ -28,8 +28,8 @@ StackTest >> nonEmpty [
 { #category : #running }
 StackTest >> setUp [
 	super setUp.
-	empty := Stack new.
-	nonEmpty := Stack new.
+	empty := NewStack new.
+	nonEmpty := NewStack new.
 	nonEmpty push: 1.
 	nonEmpty push: -2.
 	nonEmpty push: 3.
@@ -40,7 +40,7 @@ StackTest >> setUp [
 { #category : #tests }
 StackTest >> testEmptyError [
 	| aStack |
-	aStack := Stack new.
+	aStack := NewStack new.
 	self should: [ aStack top ] raise: Error.
 	self should: [ aStack pop ] raise: Error.
 	aStack push: 'element'.
@@ -54,7 +54,7 @@ StackTest >> testEmptyError [
 StackTest >> testPop [
 	| aStack res elem |
 	elem := 'anElement'.
-	aStack := Stack new.
+	aStack := NewStack new.
 	self assertEmpty: aStack.
 
 	aStack push: 'a'.
@@ -72,7 +72,7 @@ StackTest >> testPop [
 StackTest >> testPush [
 	
 	| aStack |
-	aStack := Stack new.
+	aStack := NewStack new.
 	aStack push: 'a'.
 	self assert: aStack size = 1.	
 	aStack push: 'b'.
@@ -84,7 +84,7 @@ StackTest >> testPush [
 StackTest >> testSize [
 	
 	| aStack |
-	aStack := Stack new.
+	aStack := NewStack new.
 	self assert: aStack size = 0.
 	aStack push: 'a'.
 	self assert: aStack size = 1.
@@ -105,7 +105,7 @@ StackTest >> testSize [
 { #category : #tests }
 StackTest >> testTop [
 	| aStack |
-	aStack := Stack new.
+	aStack := NewStack new.
 	self assertEmpty: aStack.
 	aStack push: 'a'.
 	aStack push: 'b'.

--- a/src/Deprecated80/Stack.class.st
+++ b/src/Deprecated80/Stack.class.st
@@ -1,11 +1,19 @@
 "
-I implement a simple Stack. #push: adds a new object of any kind on top of the stack. #pop returns the first element and remove it from the stack. #top answer the first element of the stack without removing it.
+This class is deprecated because while exposing the API of a Stack, it was also inheriting form LinkedList which allowed people to use LinkedList API.
+
+This was wrong because if one needs something else than #pop, #push, #top and #size, then it means that what one is looking for is a LinkedList.
+Thus, one should explicitely use it.
 "
 Class {
 	#name : #Stack,
 	#superclass : #LinkedList,
-	#category : #'Collections-Stack-Base'
+	#category : #Deprecated80
 }
+
+{ #category : #deprecation }
+Stack class >> isDeprecated [
+	^ true
+]
 
 { #category : #removing }
 Stack >> pop [

--- a/src/Deprecated80/Stack.class.st
+++ b/src/Deprecated80/Stack.class.st
@@ -3,6 +3,8 @@ This class is deprecated because while exposing the API of a Stack, it was also 
 
 This was wrong because if one needs something else than #pop, #push, #top and #size, then it means that what one is looking for is a LinkedList.
 Thus, one should explicitely use it.
+
+Use NewStack instead.
 "
 Class {
 	#name : #Stack,

--- a/src/Graphics-Files/LzwGifDecoder.class.st
+++ b/src/Graphics-Files/LzwGifDecoder.class.st
@@ -121,13 +121,13 @@ LzwGifDecoder >> handleCode: anInteger withPreviousCode: prevInteger on: aWriteS
 				the prefix index values and take the suffix each
 				time"
 				ifFalse: [ 
-					searchStack := Stack new.
+					searchStack := NewStack new.
 					searchIndex := anInteger + 1.
 					[ searchIndex > clearCode ] whileTrue: [ 
 						searchStack push: (suffixTable at: searchIndex).
 						searchIndex := (prefixTable at: searchIndex) + 1 ].
 					searchStack push: (suffixTable at: searchIndex).
-					first := searchStack first.
+					first := searchStack top.
 					searchStack do: [ :int |
 						self writeBit: int on: aWriteStream ] ]. 
 			]
@@ -141,13 +141,13 @@ LzwGifDecoder >> handleCode: anInteger withPreviousCode: prevInteger on: aWriteS
 						writeBit: first on: aWriteStream.
 					 ]
 				ifFalse: [ 
-					searchStack := Stack new.
+					searchStack := NewStack new.
 					searchIndex := prevInteger + 1.
 					[ searchIndex > clearCode ] whileTrue: [ 
 						searchStack push: (suffixTable at: searchIndex).
 						searchIndex := (prefixTable at: searchIndex) + 1 ].
 					searchStack push: (suffixTable at: searchIndex).
-					first := searchStack first.
+					first := searchStack top.
 					searchStack do: [ :int |
 						self writeBit: int on: aWriteStream ].
 					self writeBit: first on: aWriteStream ]. 

--- a/src/HelpSystem-Core/WikiStyleHelpBuilder.class.st
+++ b/src/HelpSystem-Core/WikiStyleHelpBuilder.class.st
@@ -118,7 +118,7 @@ WikiStyleHelpBuilder >> helpTag [
 WikiStyleHelpBuilder >> helpTopicFromFormattedString: aString title: aTitle [
 	| helpString currentLevel section topicStack topic |
 	helpString := aString.
-	topicStack := Stack new.
+	topicStack := NewStack new.
 	topicStack push: (HelpTopic new title: aTitle).
 	currentLevel := 0.
 	section := ''.

--- a/src/Hiedra/HiRulerBuilder.class.st
+++ b/src/Hiedra/HiRulerBuilder.class.st
@@ -43,7 +43,7 @@ HiRulerBuilder >> buildLinksStartingAt: aValue [
 	"This method traverses the values using the linkBlock."
 
 	| pending |
-	pending := Stack new.
+	pending := NewStack new.
 	self stackLinksFrom: aValue in: pending.
 
 	[ pending isEmpty ] whileFalse: [

--- a/src/Monticello/MCScanner.class.st
+++ b/src/Monticello/MCScanner.class.st
@@ -31,7 +31,7 @@ MCScanner >> next [
 	 for some packages on some platforms, so we implement it using a local stack."
 
 	| stack |
-	stack := Stack with: Stack new.
+	stack := NewStack with: NewStack new.
 	[
 		| c |
 		stream skipSeparators.
@@ -43,7 +43,7 @@ MCScanner >> next [
 		"Any alphanumeric, including an integer, is treated as a Symbol even if not preceeded by a $#"
 		c isAlphaNumeric ifTrue: [ stack top push: self nextSymbol ] ifFalse: [
 		"For an array, start a new level on the stack"
-		c = $( ifTrue: [ stream next. stack push: Stack new ] ifFalse: [
+		c = $( ifTrue: [ stream next. stack push: NewStack new ] ifFalse: [
 		"At the end of an array, so add it to the previous level"
 		c = $) ifTrue: [ | x | stream next. x := stack pop. stack top push: x asArray reverse ] ifFalse: [ 
 		"Unexpected token"

--- a/src/Moose-Algos-Graph/MalTarjan.class.st
+++ b/src/Moose-Algos-Graph/MalTarjan.class.st
@@ -89,7 +89,7 @@ MalTarjan >> putOnStack: aTarjanNode [
 { #category : #running }
 MalTarjan >> run [
 	sccs := OrderedCollection new.
-	stack := Stack new.
+	stack := NewStack new.
 	runningIndex := 0.
 	self nodes
 		do: [ :n | 

--- a/src/NECompletion/TypingVisitor.class.st
+++ b/src/NECompletion/TypingVisitor.class.st
@@ -13,7 +13,7 @@ Class {
 { #category : #visiting }
 TypingVisitor >> initialize [
 
-	typeStack := Stack new.
+	typeStack := NewStack new.
 	typeStack push: Dictionary new.
 ]
 

--- a/src/OpalCompiler-Core/IRBuilder.class.st
+++ b/src/OpalCompiler-Core/IRBuilder.class.st
@@ -154,7 +154,7 @@ IRBuilder >> initialize [
 	jumpAheadStacks := IdentityDictionary new.
 	jumpBackTargetStacks := IdentityDictionary new.
 	sourceMapNodes := OrderedCollection new.	"stack"
-	currentScope := Stack new.
+	currentScope := NewStack new.
 	self pushScope: ir.
 	
 	"Leave an empty sequence up front (guaranteed not to be in loop)"

--- a/src/OpalCompiler-Core/IRBytecodeDecompiler.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeDecompiler.class.st
@@ -28,7 +28,7 @@ IRBytecodeDecompiler >> checkIfJumpTarget [
 IRBytecodeDecompiler >> decompile: aCompiledMethod [
 	instructionStream := InstructionStream on: aCompiledMethod.
 	irBuilder := IRReconstructor new.
-	scopeStack := Stack new.
+	scopeStack := NewStack new.
 	self pushScope: #() numArgs: aCompiledMethod numArgs.
 	irBuilder irPrimitive: aCompiledMethod irPrimitive.
 	

--- a/src/OpalCompiler-Core/IRTranslatorV2.class.st
+++ b/src/OpalCompiler-Core/IRTranslatorV2.class.st
@@ -62,8 +62,8 @@ IRTranslatorV2 >> currentScope [
 
 { #category : #initialization }
 IRTranslatorV2 >> initialize [
-	currentScope := Stack new.
-	tempVectorStack := Stack new.
+	currentScope := NewStack new.
+	tempVectorStack := NewStack new.
 
 ]
 

--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -97,9 +97,9 @@ RBRefactoryChangeManager >> changeFactory [
 
 { #category : #private }
 RBRefactoryChangeManager >> clearUndoRedoList [
-	undo := Stack new.
+	undo := NewStack new.
 	redo := OrderedCollection new.
-	undoPointers := Stack new
+	undoPointers := NewStack new
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Commander2/SpMenuPresenterBuilder.class.st
+++ b/src/Spec2-Commander2/SpMenuPresenterBuilder.class.st
@@ -36,7 +36,7 @@ SpMenuPresenterBuilder >> initialize [
 	
 	super initialize.
 	self menuPresenter: self class menuPresenterClass new.
-	stack := Stack new
+	stack := NewStack new
 		push: self menuPresenter;
 		yourself
 ]

--- a/src/System-History/ConfigurableHistoryIterator.class.st
+++ b/src/System-History/ConfigurableHistoryIterator.class.st
@@ -115,8 +115,8 @@ ConfigurableHistoryIterator >> hasPrevious [
 { #category : #initialization }
 ConfigurableHistoryIterator >> initialize [
 	super initialize.
-	undoStack := Stack new.
-	redoStack := Stack new
+	undoStack := NewStack new.
+	redoStack := NewStack new
 ]
 
 { #category : #actions }

--- a/src/Tool-DependencyAnalyser-Tests/DAPackageDependencyTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAPackageDependencyTest.class.st
@@ -70,7 +70,7 @@ DAPackageDependencyTest >> testDependenciesFrom [
 		add: (self referenceDependency: String);
 		add: (self referenceDependency: Object);
 		add: (self referenceDependency: String);
-		add: (self inheritanceDependency: Stack).
+		add: (self inheritanceDependency: NewStack).
 	self assert: ((aCompositeDependency referenceDependenciesFrom: String) size = 2).
 ]
 

--- a/src/Tool-DependencyAnalyser/DATarjanAlgorithm.class.st
+++ b/src/Tool-DependencyAnalyser/DATarjanAlgorithm.class.st
@@ -17,7 +17,7 @@ Class {
 DATarjanAlgorithm >> initialize [
 	super initialize.
 	stronglyConnectedComponents := OrderedCollection new.
-	stack := Stack new.
+	stack := NewStack new.
 	runningIndex := 0
 
 ]


### PR DESCRIPTION
Introduced a NewStack object that inherits from Collection and provide the minimal Stack API.

This NewStack uses a strategy design pattern for its internal storage.
I created LinkedList strategy and OrderedCollection strategy.

Stack class is now deprecated. This is the best way to avoid breaking everything.

The idea is that once we remove the deprecated Stack (next major release). We can rename NewStack as Stack, create a deprecated NewStack subclass and get back to a well named Stack.

Fixes #2863 