### PR TITLE
4749-When-there-is-a-problem-in-the-FreeTypeFont-in-the-CI-server-the-image-is-locked

### DIFF
--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -793,13 +793,12 @@ FreeTypeFont >> simulatedItalicSlant [
 { #category : #'glyph lookup' }
 FreeTypeFont >> subGlyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub [
 
-	| |
 	^FreeTypeCache current
 		atFont: self
 		charCode: aCharacter asUnicode asInteger
 		type: FreeTypeCacheGlyphLCD + sub
 		ifAbsentPut: [
-			self mutex critical: [ 
+			self mutex criticalReleasingOnError: [ 
 				FreeTypeGlyphRenderer current
 					subGlyphOf: aCharacter 
 					colorValue: aColorValue 

--- a/src/Kernel/Semaphore.class.st
+++ b/src/Kernel/Semaphore.class.st
@@ -115,6 +115,25 @@ test is written carefully so that it will result in bytecodes only."
 	^self critical: mutuallyExcludedBlock
 ]
 
+{ #category : #'mutual exclusion' }
+Semaphore >> criticalReleasingOnError: mutuallyExcludedBlock [
+	"This is like #critical: but releasing the lock if there is an exception in the block"	
+	| blockValue caught |
+	caught := false.
+	[
+		caught := true.
+		self wait.
+		blockValue := mutuallyExcludedBlock 
+			on: Exception 
+			do: [ :e | caught ifTrue: [self signal]. 
+				caught := false.
+				e pass.].
+
+	] ensure: [caught ifTrue: [self signal]].
+
+	^blockValue
+]
+
 { #category : #'process termination handling' }
 Semaphore >> handleProcessTerminationOfWaitingContext: suspendedContext [
 


### PR DESCRIPTION
When there is an error in FreeTypeFont renderer the lock should be released, if not the system locks because no one is able to render anything else.