### PR TITLE
4514-Move-stable-slots-out-of-Example-package

### DIFF
--- a/src/BaselineOfSlot/BaselineOfSlot.class.st
+++ b/src/BaselineOfSlot/BaselineOfSlot.class.st
@@ -21,12 +21,14 @@ BaselineOfSlot >> baseline: spec [
 		spec 
 			package: 'Slot-Core';
 			package: 'Slot-Examples' with: [ spec requires: #('Slot-Core') ];
-			package: 'Slot-Tests' with: [ spec requires: #('Slot-Core' 'Slot-Examples') ].
+			package: 'Slot-Tests' with: [ spec requires: #('Slot-Core' 'Slot-Examples') ];
+			package: 'VariablesLibrary' with: [ spec requires: #('Slot-Core') ];
+			package: 'VariablesLibrary-Tests' with: [ spec requires: #('VariablesLibrary' 'Slot-Tests') ].
 
-		spec group: 'core' with: #('Slot-Core').
+		spec group: 'core' with: #('Slot-Core' 'VariablesLibrary').
 	
 		spec group: 'default' with: #('core' 'slot-tests').
-		spec group: 'slot-tests' with: #('Slot-Tests').		
+		spec group: 'slot-tests' with: #('Slot-Tests' 'VariablesLibrary-Tests').		
 	 ].	
 
 ]

--- a/src/Slot-Tests/SlotClassVariableTest.class.st
+++ b/src/Slot-Tests/SlotClassVariableTest.class.st
@@ -79,10 +79,7 @@ SlotClassVariableTest >> testWantsInitializationAddsInitializeSlot [
 			name: self aClassName;
 			superclass: Object ].
 		
-	class1 addSlot: (InitializedSlot new 
-		name: #defaultValue;
-		default: 42;
-		yourself).
+	class1 addSlot: WriteOnceSlot new.
 
 	self assert: class1 slots size equals: 1.
 
@@ -101,10 +98,9 @@ SlotClassVariableTest >> testWantsInitializationSkipInitializeSlotIfAlreadyInHie
 		builder
 			name: self aClassName;
 			superclass: Object;
-			slots: { 
-				InitializedSlot new 
-					name: #defaultValue;
-					default: 42;
+			slots: {
+				WriteOnceSlot new
+					name: #foo;
 					yourself } ].
 
 	self assert: class1 slots size equals: 1.
@@ -115,9 +111,8 @@ SlotClassVariableTest >> testWantsInitializationSkipInitializeSlotIfAlreadyInHie
 			name: self anotherClassName;
 			superclass: class1;
 			slots: { 
-				InitializedSlot new 
-					name: #otherDefaultValue;
-					default: 42;
+				WriteOnceSlot new
+					name: #bar;
 					yourself } ].
 
 	self assert: class2 slots size equals: 1.

--- a/src/VariablesLibrary-Tests/ComputedSlotTest.class.st
+++ b/src/VariablesLibrary-Tests/ComputedSlotTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ComputedSlotTest,
 	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-Examples'
+	#category : #'VariablesLibrary-Tests'
 }
 
 { #category : #tests }

--- a/src/VariablesLibrary-Tests/HistorySlotTest.class.st
+++ b/src/VariablesLibrary-Tests/HistorySlotTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #HistorySlotTest,
 	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-Examples'
+	#category : #'VariablesLibrary-Tests'
 }
 
 { #category : #tests }

--- a/src/VariablesLibrary-Tests/InitializedClassVariableTest.class.st
+++ b/src/VariablesLibrary-Tests/InitializedClassVariableTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #InitializedClassVariableTest,
 	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-Examples'
+	#category : #'VariablesLibrary-Tests'
 }
 
 { #category : #tests }

--- a/src/VariablesLibrary-Tests/InitializedSlotTest.class.st
+++ b/src/VariablesLibrary-Tests/InitializedSlotTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #InitializedSlotTest,
 	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-Examples'
+	#category : #'VariablesLibrary-Tests'
 }
 
 { #category : #tests }

--- a/src/VariablesLibrary-Tests/LazyClassVariableTest.class.st
+++ b/src/VariablesLibrary-Tests/LazyClassVariableTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #LazyClassVariableTest,
 	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-Examples'
+	#category : #'VariablesLibrary-Tests'
 }
 
 { #category : #tests }

--- a/src/VariablesLibrary-Tests/LazySlotTest.class.st
+++ b/src/VariablesLibrary-Tests/LazySlotTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #LazySlotTest,
 	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-Examples'
+	#category : #'VariablesLibrary-Tests'
 }
 
 { #category : #tests }

--- a/src/VariablesLibrary-Tests/WeakClassVariableTest.class.st
+++ b/src/VariablesLibrary-Tests/WeakClassVariableTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #WeakClassVariableTest,
 	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-Examples'
+	#category : #'VariablesLibrary-Tests'
 }
 
 { #category : #tests }

--- a/src/VariablesLibrary-Tests/WeakSlotTest.class.st
+++ b/src/VariablesLibrary-Tests/WeakSlotTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #WeakSlotTest,
 	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-Examples'
+	#category : #'VariablesLibrary-Tests'
 }
 
 { #category : #tests }

--- a/src/VariablesLibrary-Tests/package.st
+++ b/src/VariablesLibrary-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'VariablesLibrary-Tests' }

--- a/src/VariablesLibrary/AbstractInitializedClassVariable.class.st
+++ b/src/VariablesLibrary/AbstractInitializedClassVariable.class.st
@@ -11,7 +11,7 @@ Class {
 	#instVars : [
 		'default'
 	],
-	#category : #'Slot-Examples-ClassVariables'
+	#category : #'VariablesLibrary-ClassVariables'
 }
 
 { #category : #accessing }

--- a/src/VariablesLibrary/AbstractInitializedSlot.class.st
+++ b/src/VariablesLibrary/AbstractInitializedSlot.class.st
@@ -11,7 +11,7 @@ Class {
 	#instVars : [
 		'default'
 	],
-	#category : #'Slot-Examples-Base'
+	#category : #'VariablesLibrary-Slots'
 }
 
 { #category : #comparing }

--- a/src/VariablesLibrary/ComputedSlot.class.st
+++ b/src/VariablesLibrary/ComputedSlot.class.st
@@ -17,7 +17,7 @@ Class {
 	#instVars : [
 		'block'
 	],
-	#category : #'Slot-Examples-Base'
+	#category : #'VariablesLibrary-Slots'
 }
 
 { #category : #comparing }

--- a/src/VariablesLibrary/HistorySlot.class.st
+++ b/src/VariablesLibrary/HistorySlot.class.st
@@ -8,7 +8,7 @@ Class {
 	#instVars : [
 		'size'
 	],
-	#category : #'Slot-Examples-Base'
+	#category : #'VariablesLibrary-Slots'
 }
 
 { #category : #'code generation' }

--- a/src/VariablesLibrary/InitializedClassVariable.class.st
+++ b/src/VariablesLibrary/InitializedClassVariable.class.st
@@ -10,7 +10,7 @@ I am a class variabke that can initialize itself class creation.
 Class {
 	#name : #InitializedClassVariable,
 	#superclass : #AbstractInitializedClassVariable,
-	#category : #'Slot-Examples-ClassVariables'
+	#category : #'VariablesLibrary-ClassVariables'
 }
 
 { #category : #'class building' }

--- a/src/VariablesLibrary/InitializedSlot.class.st
+++ b/src/VariablesLibrary/InitializedSlot.class.st
@@ -10,7 +10,7 @@ I am showing how a slot can initialize itself on object creation.
 Class {
 	#name : #InitializedSlot,
 	#superclass : #AbstractInitializedSlot,
-	#category : #'Slot-Examples-Base'
+	#category : #'VariablesLibrary-Slots'
 }
 
 { #category : #initialization }

--- a/src/VariablesLibrary/LazyClassVariable.class.st
+++ b/src/VariablesLibrary/LazyClassVariable.class.st
@@ -14,7 +14,7 @@ This class variable instead does the nil check as part of the variable read oper
 Class {
 	#name : #LazyClassVariable,
 	#superclass : #AbstractInitializedClassVariable,
-	#category : #'Slot-Examples-ClassVariables'
+	#category : #'VariablesLibrary-ClassVariables'
 }
 
 { #category : #'code generation' }

--- a/src/VariablesLibrary/LazySlot.class.st
+++ b/src/VariablesLibrary/LazySlot.class.st
@@ -14,7 +14,7 @@ The slot instead does the nil check as part of the slot read operation.
 Class {
 	#name : #LazySlot,
 	#superclass : #AbstractInitializedSlot,
-	#category : #'Slot-Examples-Base'
+	#category : #'VariablesLibrary-Slots'
 }
 
 { #category : #'code generation' }

--- a/src/VariablesLibrary/WeakClassVariable.class.st
+++ b/src/VariablesLibrary/WeakClassVariable.class.st
@@ -12,7 +12,7 @@ weakArray at: 1
 Class {
 	#name : #WeakClassVariable,
 	#superclass : #LiteralVariable,
-	#category : #'Slot-Examples-ClassVariables'
+	#category : #'VariablesLibrary-ClassVariables'
 }
 
 { #category : #'code generation' }

--- a/src/VariablesLibrary/WeakSlot.class.st
+++ b/src/VariablesLibrary/WeakSlot.class.st
@@ -14,7 +14,7 @@ This slot inherits from IndexedSlot to guarantee that this slot has a real field
 Class {
 	#name : #WeakSlot,
 	#superclass : #IndexedSlot,
-	#category : #'Slot-Examples-Base'
+	#category : #'VariablesLibrary-Slots'
 }
 
 { #category : #'code generation' }

--- a/src/VariablesLibrary/package.st
+++ b/src/VariablesLibrary/package.st
@@ -1,0 +1,1 @@
+Package { #name : #VariablesLibrary }


### PR DESCRIPTION
Moved stable slots out of example group.
Adapted baseline.
Fixed dependencies.Fixes #4514