### PR TITLE
4734-Add a rule to warn when referencing Smalltalk

### DIFF
--- a/src/GeneralRules-Tests/RBGlobalVariableRuleTest.class.st
+++ b/src/GeneralRules-Tests/RBGlobalVariableRuleTest.class.st
@@ -1,0 +1,43 @@
+Class {
+	#name : #RBGlobalVariableRuleTest,
+	#superclass : #TestCase,
+	#category : #'GeneralRules-Tests'
+}
+
+{ #category : #tests }
+RBGlobalVariableRuleTest >> applyingCritiques [
+	^ self class methods
+		select: [ :m | (RBGlobalVariablesUsage new check: m) isNotEmpty ]
+]
+
+{ #category : #tests }
+RBGlobalVariableRuleTest >> methodNotUsesGlobal [
+	String streamContents: [ :str | str nextPut: #something ]
+]
+
+{ #category : #tests }
+RBGlobalVariableRuleTest >> methodNotUsesGlobal2 [
+	Object new 
+]
+
+{ #category : #tests }
+RBGlobalVariableRuleTest >> methodUsesGlobal [
+	Smalltalk version 
+]
+
+{ #category : #tests }
+RBGlobalVariableRuleTest >> methodUsesGlobal2 [
+	Processor activeProcess
+]
+
+{ #category : #tests }
+RBGlobalVariableRuleTest >> testTheRuleOnlyDetect2MethodsWithGlobalVariables [
+	self assert: self applyingCritiques size equals: 2
+]
+
+{ #category : #tests }
+RBGlobalVariableRuleTest >> testTheRuleOnlyMethodUsesGlobal1And2 [
+	self
+		assert: (self applyingCritiques collect: #selector) asArray
+		equals: {#methodUsesGlobal . #methodUsesGlobal2}
+]

--- a/src/GeneralRules-Tests/RBGlobalVariableRuleTest.class.st
+++ b/src/GeneralRules-Tests/RBGlobalVariableRuleTest.class.st
@@ -17,7 +17,15 @@ RBGlobalVariableRuleTest >> methodNotUsesGlobal [
 
 { #category : #tests }
 RBGlobalVariableRuleTest >> methodNotUsesGlobal2 [
-	Object new 
+	| x y z a b c |
+	x := '...'.
+	y := 1.9 .
+	z := #(a b c).
+	a := { 1 . 2 . 3 }.
+	b := #a.
+	c := $a.
+	
+	^ x
 ]
 
 { #category : #tests }
@@ -31,6 +39,12 @@ RBGlobalVariableRuleTest >> methodUsesGlobal2 [
 ]
 
 { #category : #tests }
+RBGlobalVariableRuleTest >> testTheRuleCanCheckMethodsWithDifferentKindsOfLiterals [
+	self assert: (RBGlobalVariablesUsage new check: self class>>#methodNotUsesGlobal2)
+		isEmpty  
+]
+
+{ #category : #tests }
 RBGlobalVariableRuleTest >> testTheRuleOnlyDetect2MethodsWithGlobalVariables [
 	self assert: self applyingCritiques size equals: 2
 ]
@@ -38,6 +52,6 @@ RBGlobalVariableRuleTest >> testTheRuleOnlyDetect2MethodsWithGlobalVariables [
 { #category : #tests }
 RBGlobalVariableRuleTest >> testTheRuleOnlyMethodUsesGlobal1And2 [
 	self
-		assert: (self applyingCritiques collect: #selector) asArray
-		equals: {#methodUsesGlobal . #methodUsesGlobal2}
+		assert: (self applyingCritiques collect: #selector) asSet
+		equals: {#methodUsesGlobal . #methodUsesGlobal2} asSet
 ]

--- a/src/GeneralRules/RBGlobalVariablesUsage.class.st
+++ b/src/GeneralRules/RBGlobalVariablesUsage.class.st
@@ -17,7 +17,13 @@ RBGlobalVariablesUsage class >> checksMethod [
 { #category : #running }
 RBGlobalVariablesUsage >> basicCheck: aMethod [
 	^ (aMethod literals
-		select: [ :l | l isSymbol not and: [ l isGlobalVariable ] ])
+		select: [ :l | 
+			l isSymbol not 
+				and: [ l isString not
+				and: [ l isNumber not
+				and: [ l isArray not
+				and: [ l isCharacter not
+				and: [ l isGlobalVariable ] ] ] ] ] ])
 		anySatisfy: [ :v | v value isClass not ]
 ]
 

--- a/src/GeneralRules/RBGlobalVariablesUsage.class.st
+++ b/src/GeneralRules/RBGlobalVariablesUsage.class.st
@@ -1,0 +1,54 @@
+"
+Global Variables are a known design smell. 
+
+Specially in Pharo, we do not want to keep global bindings because their usage can a will produce undesirable implicit coupling, avoiding out language to evolve into the usage of powerful modules. 
+"
+Class {
+	#name : #RBGlobalVariablesUsage,
+	#superclass : #ReAbstractRule,
+	#category : #'GeneralRules-Migrated'
+}
+
+{ #category : #'testing-interest' }
+RBGlobalVariablesUsage class >> checksMethod [
+	^ true
+]
+
+{ #category : #running }
+RBGlobalVariablesUsage >> basicCheck: aMethod [
+	^ (aMethod literals
+		select: [ :l | l isSymbol not and: [ l isGlobalVariable ] ])
+		anySatisfy: [ :v | v value isClass not ]
+]
+
+{ #category : #running }
+RBGlobalVariablesUsage >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : #accessing }
+RBGlobalVariablesUsage >> name [
+	^ 'Global variable usage'
+]
+
+{ #category : #running }
+RBGlobalVariablesUsage >> rationale [
+	^ 'http://wiki.c2.com/?GlobalVariablesAreBad
+	
+	Why Global Variables Should Be Avoided When Unnecessary
+
+    Non-locality -- Source code is easiest to understand when the scope of its individual elements are limited. Global variables can be read or modified by any part of the program, making it difficult to remember or reason about every possible use.
+    No Access Control or Constraint Checking -- A global variable can be get or set by any part of the program, and any rules regarding its use can be easily broken or forgotten. (In other words, get/set accessors are generally preferable over direct data access, and this is even more so for global data.) By extension, the lack of access control greatly hinders achieving security in situations where you may wish to run untrusted code (such as working with 3rd party plugins).
+    Implicit coupling -- A program with many global variables often has tight couplings between some of those variables, and couplings between variables and functions. Grouping coupled items into cohesive units usually leads to better programs.
+    Concurrency issues -- if globals can be accessed by multiple threads of execution, synchronization is necessary (and too-often neglected). When dynamically linking modules with globals, the composed system might not be thread-safe even if the two independent modules tested in dozens of different contexts were safe.
+    Namespace pollution -- Global names are available everywhere. You may unknowingly end up using a global when you think you are using a local (by misspelling or forgetting to declare the local) or vice versa. Also, if you ever have to link together modules that have the same global variable names, if you are lucky, you will get linking errors. If you are unlucky, the linker will simply treat all uses of the same name as the same object.
+    Memory allocation issues -- Some environments have memory allocation schemes that make allocation of globals tricky. This is especially true in languages where "constructors" have side-effects other than allocation (because, in that case, you can express unsafe situations where two globals mutually depend on one another). Also, when dynamically linking modules, it can be unclear whether different libraries have their own instances of globals or whether the globals are shared.
+    Testing and Confinement - source that utilizes globals is somewhat more difficult to test because one cannot readily set up a ''clean'' environment between runs. More generally, source that utilizes global services of any sort (e.g. reading and writing files or databases) that aren''t explicitly provided to that source is difficult to test for the same reason. For communicating systems, the ability to test system invariants may require running more than one ''copy'' of a system simultaneously, which is greatly hindered by any use of shared services - including global memory - that are not provided for sharing as part of the test. 
+	
+	'
+]
+
+{ #category : #running }
+RBGlobalVariablesUsage >> severity [
+	^ #warning
+]


### PR DESCRIPTION
Fix #4734. Add a rule to warn when referencing Smalltalk!.
It does not only do a warning for Smalltalk but for what ever usage of global variable. 
For achieving so it implements RBGlobalVariablesUsage.
This rule is tested by RBGlobalVariableRuleTest