### PR TITLE
4760-Debugger-we-can-not-step-into-methods-anymore

### DIFF
--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -226,6 +226,11 @@ DebugSession >> isInterruptedContextDoesNotUnderstand [
 	^ self interruptedContext selector == #doesNotUnderstand:
 ]
 
+{ #category : #context }
+DebugSession >> isLatestContext: aContext [
+  	^ interruptedProcess suspendedContext == aContext
+]
+
 { #category : #testing }
 DebugSession >> isTestMethod: aCompiledMethod of: aTestCase [
 
@@ -264,7 +269,7 @@ DebugSession >> pcRangeForContext: aContext [
 
 	(aContext isNil or: [ aContext isDead ])
 		ifTrue: [ ^ 1 to: 0 ].
-	^ aContext pcRange
+	^ aContext pcRangeContextIsActive: (self isLatestContext: aContext)
 ]
 
 { #category : #'debugging actions' }

--- a/src/Debugging-Core/CompiledCode.extension.st
+++ b/src/Debugging-Core/CompiledCode.extension.st
@@ -103,6 +103,12 @@ CompiledCode >> pcPreviousTo: pc [
 ]
 
 { #category : #'*Debugging-Core' }
+CompiledCode >> rangeForPC: aPC [	
+ 	"return which code to hightlight in the debugger"		
+ 	^(self sourceNodeForPC: aPC) debugHighlightRange
+]
+
+{ #category : #'*Debugging-Core' }
 CompiledCode >> symbolicBytecodes [
 	"Answer Collection that contains of all the byte codes in a method as an instance of SymbolicInstruction"
 

--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -62,6 +62,23 @@ Context >> pcRange [
 ]
 
 { #category : #'*Debugging-Core' }
+Context >> pcRangeContextIsActive: contextIsActive [
+ 	"return the debug highlight for aPC"		 
+	| thePC |
+
+  	"make sure we have some usable value (can happen for contexts in the ProcessBrowser"		
+ 	thePC := pc ifNil: [self method endPC].		
+
+  	"When on the top of the stack the pc is pointing to right instruction, but deeper in the stack		
+ 	the pc was already advanced one bytecode, so we need to go back this one bytecode, which		
+ 	can consist of multiple bytes. But on IR, we record the *last* bytecode offset as the offset of		
+ 	the IR instruction, which means we can just go back one"		
+ 	thePC := contextIsActive ifTrue: [thePC] ifFalse: [thePC - 1].		
+
+  	^self method rangeForPC: thePC
+]
+
+{ #category : #'*Debugging-Core' }
 Context >> previousPcWithCorrectMapping [
 	"Answer a pc inside the enclosing block or mathod that is correctly mapped to an AST node"
 	"This is an ugly and temporary fix for Pharo 3. 

--- a/src/Tool-ProcessBrowser/ProcessBrowser.class.st
+++ b/src/Tool-ProcessBrowser/ProcessBrowser.class.st
@@ -809,7 +809,7 @@ ProcessBrowser >> pcRange [
 	the selected context's program counter value."
 	(selectedContext isNil or: [methodText isEmptyOrNil])
 		ifTrue: [^ 1 to: 0].
-	^selectedContext pcRange
+	^selectedContext pcRangeContextIsActive: (stackListIndex = 1)
 ]
 
 { #category : #'process list' }


### PR DESCRIPTION
use #pcRangeForContext: again, not #pcRange... we need to fix #sourceNodeExecuted before we can use it

fixes #4760