### PR TITLE
NULLWorldRenderer-checkForNewScreenSize

### DIFF
--- a/src/Morphic-Core/NullWorldRenderer.class.st
+++ b/src/Morphic-Core/NullWorldRenderer.class.st
@@ -47,8 +47,6 @@ NullWorldRenderer >> canvas: x [
 { #category : #'display box access' }
 NullWorldRenderer >> checkForNewScreenSize [
 
-	world restoreMorphicDisplay.
-
 ]
 
 { #category : #activation }


### PR DESCRIPTION
NULLWorldRenderer does not has a screen, so there is not a morphic diplay to restore