### PR TITLE
4778-OSWindow-should-use-the-full-image-name

### DIFF
--- a/src/OSWindow-Core/OSWindowWorldMorph.class.st
+++ b/src/OSWindow-Core/OSWindowWorldMorph.class.st
@@ -120,7 +120,7 @@ OSWindowWorldMorph >> recreateOSWindow [
 	attributes := OSWindowAttributes new.
 	attributes
 		extent: self extent;
-		title: Smalltalk shortImageName;
+		title: Smalltalk image imageFile fullName;
 		icon: (self iconNamed: #pharoIcon);
 		resizable: isResizeable.
 	self updateDisplay.

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -135,7 +135,7 @@ OSWorldRenderer >> doActivate [
 	attributes := OSWindowAttributes new.
 	attributes
 		extent: initialExtent;
-		title: Smalltalk shortImageName;
+		title: Smalltalk image imageFile fullName;
 		windowCentered:true;
 		icon: (self iconNamed: #pharoBig).
 


### PR DESCRIPTION
use full image name in the window titlefixes #4778