### PR TITLE
4782-ContextempNamedput-needs-to-update-the-all-the-copied-temps-up-to-the-definition

### DIFF
--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -270,7 +270,7 @@ OCAbstractMethodScope >> setCopyingTempToAllScopesUpToDefTemp: aVar to: aValue f
 	self = aVar scope
 		ifTrue: [ ^ aVar writeFromLocalContext: aContext put: aValue ].
 	(self lookupVar: aVar name) writeFromLocalContext: aContext put: aValue.
-	self outerScope
+	^self outerScope
 		setCopyingTempToAllScopesUpToDefTemp: aVar
 		to: aValue
 		from: (self nextOuterScopeContextOf: aContext)

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -263,6 +263,21 @@ OCAbstractMethodScope >> removeTemp: tempVar [
 	tempVars removeKey: tempVar name
 ]
 
+{ #category : #'temp vars - copying' }
+OCAbstractMethodScope >> setCopyingTempToAllScopesUpToDefTemp: aVar to: aValue from: aContext [
+	| copiedVar |
+	"we need to update all the copies if we change the value of a copied temp"
+
+	self = aVar scope
+		ifTrue: [ ^ self ].
+	copiedVar := self lookupVar: aVar name.
+	aContext tempAt: copiedVar indexFromIR put: aValue.
+	self outerScope
+		setCopyingTempToAllScopesUpToDefTemp: aVar
+		to: aValue
+		from: (self nextOuterScopeContextOf: aContext)
+]
+
 { #category : #'temp vars' }
 OCAbstractMethodScope >> tempVarNames [
 

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -265,13 +265,11 @@ OCAbstractMethodScope >> removeTemp: tempVar [
 
 { #category : #'temp vars - copying' }
 OCAbstractMethodScope >> setCopyingTempToAllScopesUpToDefTemp: aVar to: aValue from: aContext [
-	| copiedVar |
 	"we need to update all the copies if we change the value of a copied temp"
 
 	self = aVar scope
-		ifTrue: [ ^ self ].
-	copiedVar := self lookupVar: aVar name.
-	aContext tempAt: copiedVar indexFromIR put: aValue.
+		ifTrue: [ ^ aVar writeFromLocalContext: aContext put: aValue ].
+	(self lookupVar: aVar name) writeFromLocalContext: aContext put: aValue.
 	self outerScope
 		setCopyingTempToAllScopesUpToDefTemp: aVar
 		to: aValue

--- a/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
@@ -52,9 +52,6 @@ OCCopyingTempVariable >> tempVectorForTempStoringIt [
 { #category : #debugging }
 OCCopyingTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 
-	"we need to change this var all the copies, too"
-	contextScope setCopyingTempToAllScopesUpToDefTemp: originalVar to: aValue from: aContext.
-	"the original temp"
-	^originalVar writeFromContext: aContext scope: contextScope value: aValue
-
+	"we need to change this var, all the other copies, and the orginal"
+	contextScope setCopyingTempToAllScopesUpToDefTemp: originalVar to: aValue from: aContext
 ]

--- a/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
@@ -55,6 +55,6 @@ OCCopyingTempVariable >> writeFromContext: aContext scope: contextScope value: a
 	"we need to change this var all the copies, too"
 	contextScope setCopyingTempToAllScopesUpToDefTemp: originalVar to: aValue from: aContext.
 	"the original temp"
-	^originalVar writeFromContext: aContext scope: contextScope value: aValue.
+	^originalVar writeFromContext: aContext scope: contextScope value: aValue
 
 ]

--- a/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
@@ -53,5 +53,5 @@ OCCopyingTempVariable >> tempVectorForTempStoringIt [
 OCCopyingTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 
 	"we need to change this var, all the other copies, and the orginal"
-	contextScope setCopyingTempToAllScopesUpToDefTemp: originalVar to: aValue from: aContext
+	^contextScope setCopyingTempToAllScopesUpToDefTemp: originalVar to: aValue from: aContext
 ]

--- a/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
@@ -51,15 +51,10 @@ OCCopyingTempVariable >> tempVectorForTempStoringIt [
 
 { #category : #debugging }
 OCCopyingTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
-	
-	| definitionContext |
-	definitionContext := contextScope lookupDefiningContextForVariable: self startingFrom: aContext.
-	"we need to change all the copies, too"
+
+	"we need to change this var all the copies, too"
 	contextScope setCopyingTempToAllScopesUpToDefTemp: originalVar to: aValue from: aContext.
-	"and the original temp"
-	originalVar writeFromContext: aContext scope: contextScope value: aValue.
-	
-	^definitionContext 
-		tempAt: self indexFromIR
-		put: aValue
+	"the original temp"
+	^originalVar writeFromContext: aContext scope: contextScope value: aValue.
+
 ]

--- a/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
@@ -54,10 +54,10 @@ OCCopyingTempVariable >> writeFromContext: aContext scope: contextScope value: a
 	
 	| definitionContext |
 	definitionContext := contextScope lookupDefiningContextForVariable: self startingFrom: aContext.
-	originalVar writeFromContext: aContext scope: contextScope value: aValue.
-	
-	self flag: #FIXME.
 	"we need to change all the copies, too"
+	contextScope setCopyingTempToAllScopesUpToDefTemp: originalVar to: aValue from: aContext.
+	"and the original temp"
+	originalVar writeFromContext: aContext scope: contextScope value: aValue.
 	
 	^definitionContext 
 		tempAt: self indexFromIR

--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -150,8 +150,11 @@ OCTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 
 	| definitionContext |
 	definitionContext := contextScope lookupDefiningContextForVariable: self startingFrom: aContext.
+	self writeFromLocalContext: definitionContext put: aValue
+]
 
-	^definitionContext 
-		tempAt: self indexFromIR
-		put: aValue
+{ #category : #debugging }
+OCTempVariable >> writeFromLocalContext: aContext put: aValue [
+
+	^ aContext tempAt: self indexFromIR put: aValue
 ]

--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -150,7 +150,7 @@ OCTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 
 	| definitionContext |
 	definitionContext := contextScope lookupDefiningContextForVariable: self startingFrom: aContext.
-	self writeFromLocalContext: definitionContext put: aValue
+	^self writeFromLocalContext: definitionContext put: aValue
 ]
 
 { #category : #debugging }

--- a/src/OpalCompiler-Tests/MethodMapExamples.class.st
+++ b/src/OpalCompiler-Tests/MethodMapExamples.class.st
@@ -56,6 +56,14 @@ MethodMapExamples >> exampleTempNamedPutCopying2 [
 ]
 
 { #category : #examples }
+MethodMapExamples >> exampleTempNamedPutCopying3 [
+	| b |
+	b := 1.
+	^[[ | a |
+		 a := b .thisContext tempNamed: 'b' put: 2. thisContext outerContext tempNamed: 'b' ] value ] value
+]
+
+{ #category : #examples }
 MethodMapExamples >> exampleTempNamedPutTempVector [
 	| b |
 	b := 1.

--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -128,6 +128,13 @@ MethodMapTest >> testExampleTempNamedPutCopying2 [
 ]
 
 { #category : #'testing - temp access' }
+MethodMapTest >> testExampleTempNamedPutCopying3 [
+	"modifying a copied temp variable will modify the value in the outer context"
+
+	self assert: (self compileAndRunExample: #exampleTempNamedPutCopying3) equals: 2
+]
+
+{ #category : #'testing - temp access' }
 MethodMapTest >> testExampleTempNamedPutTempVector [
 	self assert: (self compileAndRunExample: #exampleTempNamedPutTempVector) equals: 3.
 ]


### PR DESCRIPTION
Copied temps are copied from the defining context into all the contexts.

If we now change the var in the debugger, it calls #tempNamed:put: on the context.

-> make sure to walk up the context to the definition context of the temp and set the value in the copy

fixes #4782