### PR TITLE
2201-Metalinks-are-leaving-methods-with-unbound-globals

### DIFF
--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -328,7 +328,7 @@ SystemNavigation >> methodsWithUnboundGlobals [
 			[:l|
 			l isVariableBinding
 			and: [l key isSymbol "avoid class-side methodClass literals"
-			and: [ (l value isKindOf: Slot) not
+			and: [ (l isKindOf: AdditionalBinding) not
 			and: [(m methodClass classBindingOf: l key)
 					ifNil: [(Undeclared associationAt: l key ifAbsent: []) ~~ l]
 					ifNotNil: [:b| b ~~ l]]]]]]


### PR DESCRIPTION
we can now check for AdditionalBinding, this is only true if there are slots or metalinks referenced

fixes #2201