### PR TITLE
Speedup #usingMethod for classes and Globals

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -872,12 +872,9 @@ Behavior >> hasMethods [
 
 { #category : #'testing method dictionary' }
 Behavior >> hasSelectorReferringTo: literal [
-	"Answer true if any of my methods access the argument as a 
-	literal. Dives into the compact literal notation, making it slow but 
-	thorough "
+	"Answer true if any of my methods access the argument as a literal"
 
 	^self methods anySatisfy: [ :method | method hasLiteral: literal ]
-		
 ]
 
 { #category : #'testing class hierarchy' }
@@ -1804,16 +1801,7 @@ Behavior >> thoroughWhichMethodsReferTo: literal [
 
 { #category : #'testing method dictionary' }
 Behavior >> thoroughWhichSelectorsReferTo: literal [
-	"Answer a set of selectors whose methods access the argument as a 
-	literal. Dives into the compact literal notation, making it slow but 
-	thorough "
-	| specialIndex selectors |
-	"for speed we check the special selectors here once per class"
-	specialIndex := Smalltalk specialSelectorIndexOrNil: literal.
-	selectors := OrderedCollection new.
-	self selectorsAndMethodsDo: [ :sel :method |
-			(method hasSelector: literal specialSelectorIndex: specialIndex) ifTrue: [selectors add: sel]].
-	^ selectors
+	^ (self thoroughWhichMethodsReferTo: literal) collect: [ :method | method selector ]
 ]
 
 { #category : #accessing }
@@ -1887,8 +1875,15 @@ Behavior >> whichClassIncludesSelector: aSymbol [
 ]
 
 { #category : #'testing method dictionary' }
-Behavior >> whichSelectorsReferTo: literal [ 
-	^ self thoroughWhichSelectorsReferTo: literal
+Behavior >> whichMethodsReferTo: aLiteral [
+	"Answer methods whose methods directly refers to the argument as a literal"
+
+	^ self methods select: [ :method | method hasLiteral: aLiteral ]
+]
+
+{ #category : #'testing method dictionary' }
+Behavior >> whichSelectorsReferTo: literal [
+	^ (self whichMethodsReferTo: literal) collect: [ :method | method selector ]
 ]
 
 { #category : #queries }

--- a/src/Slot-Core/ClassVariable.class.st
+++ b/src/Slot-Core/ClassVariable.class.st
@@ -53,5 +53,5 @@ ClassVariable >> usingMethods [
 	self definingClass isPool ifTrue: [ ^ super usingMethods ].
 	"if we are a class variable, we only need to search the sublasses and metaclasses"
 	^ self definingClass withAllSubclasses flatCollect: [ :class | 
-			(class thoroughWhichMethodsReferTo: self), (class class thoroughWhichMethodsReferTo: self) ]
+			(class whichMethodsReferTo: self), (class class whichMethodsReferTo: self) ]
 ]

--- a/src/Slot-Core/LiteralVariable.class.st
+++ b/src/Slot-Core/LiteralVariable.class.st
@@ -225,7 +225,7 @@ LiteralVariable >> removeProperty: propName ifAbsent: aBlock [
 
 { #category : #queries }
 LiteralVariable >> usingMethods [
-	^SystemNavigation new allReferencesTo: self
+	^SystemNavigation new allReferencesToBinding: self
 ]
 
 { #category : #'meta-object-protocol' }

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -191,6 +191,14 @@ SystemNavigation >> allReferencesTo: aLiteral do: aBlock [
 			ifTrue: [ class withThorougMethodsReferTo: aLiteral do: aBlock ] ]
 ]
 
+{ #category : #query }
+SystemNavigation >> allReferencesToBinding: aVariablesBinding [
+	"Answer all the methods that refer to aVariableBinding, do not go into netsted Arrays"
+
+	^ self allBehaviors flatCollect: [ :class | 
+			(class whichMethodsReferTo: aVariablesBinding) collect: [ :method | method methodReference ] ]
+]
+
 { #category : #'message sends' }
 SystemNavigation >> allSendersOf: selector [ 
 	^self allReferencesTo: selector


### PR DESCRIPTION
#usingMethods for globals and classes should not iterate over all nested arrays inside methods: we can only have symbols there.