### PR TITLE
4790-SequenceableCollectiongroupsOfatATimeCollect-is-buggy-if-a-symbol-is-provided-as-second-argument

### DIFF
--- a/src/Collections-Abstract/SequenceableCollection.class.st
+++ b/src/Collections-Abstract/SequenceableCollection.class.st
@@ -1057,7 +1057,7 @@ SequenceableCollection >> groupsOf: n atATimeCollect: aBlock [
 	"(#(1 1 1 10 10 10 100  100 100) groupsOf: 3 atATimeCollect: [ :x | x ]) >>> #(#(1 1 1) #(10 10 10) #(100 100 100))"
 
 	| passArray |
-	passArray := aBlock numArgs = 1.
+	passArray := aBlock numArgs <= 1.
 	^ (n to: self size by: n)
 		collect: [ :index | 
 			| args |

--- a/src/Collections-Tests/TIterateSequencedReadableTest.trait.st
+++ b/src/Collections-Tests/TIterateSequencedReadableTest.trait.st
@@ -144,13 +144,8 @@ TIterateSequencedReadableTest >> testFromToDo [
 { #category : #'tests - iterate on sequenced reable collections' }
 TIterateSequencedReadableTest >> testGroupsOfAtATimeCollect [
 	| groupsOf2 |
-	self
-		assert: (self empty groupsOf: 2 atATimeCollect: [ :x | x ])
-		equals: #().
-		
-	self
-		assert: (self empty groupsOf: 2 atATimeCollect: #yourself)
-		equals: #().
+	self assertEmpty: (self empty groupsOf: 2 atATimeCollect: [ :x | x ]).
+   self assertEmpty: (self empty groupsOf: 2 atATimeCollect: #yourself).
 		
 	groupsOf2 := self nonEmptyMoreThan1Element groupsOf: 2 atATimeCollect: [ :x | x ].
 	

--- a/src/Collections-Tests/TIterateSequencedReadableTest.trait.st
+++ b/src/Collections-Tests/TIterateSequencedReadableTest.trait.st
@@ -142,6 +142,28 @@ TIterateSequencedReadableTest >> testFromToDo [
 ]
 
 { #category : #'tests - iterate on sequenced reable collections' }
+TIterateSequencedReadableTest >> testGroupsOfAtATimeCollect [
+	| groupsOf2 |
+	self
+		assert: (self empty groupsOf: 2 atATimeCollect: [ :x | x ])
+		equals: #().
+		
+	self
+		assert: (self empty groupsOf: 2 atATimeCollect: #yourself)
+		equals: #().
+		
+	groupsOf2 := self nonEmptyMoreThan1Element groupsOf: 2 atATimeCollect: [ :x | x ].
+	
+	self assert: groupsOf2 size equals: self nonEmptyMoreThan1Element size // 2.
+	self assert: (groupsOf2 allSatisfy: [ :array | array size = 2 ]).
+	
+	groupsOf2 := self nonEmptyMoreThan1Element groupsOf: 3 atATimeCollect: #yourself.
+	
+	self assert: groupsOf2 size equals: self nonEmptyMoreThan1Element size // 3.
+	self assert: (groupsOf2 allSatisfy: [ :array | array size = 3 ]).
+]
+
+{ #category : #'tests - iterate on sequenced reable collections' }
 TIterateSequencedReadableTest >> testKeysAndValuesDo [
 	"| result |
 	result:= OrderedCollection new.

--- a/src/Collections-Tests/TIterateSequencedReadableTest.trait.st
+++ b/src/Collections-Tests/TIterateSequencedReadableTest.trait.st
@@ -145,8 +145,8 @@ TIterateSequencedReadableTest >> testFromToDo [
 TIterateSequencedReadableTest >> testGroupsOfAtATimeCollect [
 	| groupsOf2 |
 	self assertEmpty: (self empty groupsOf: 2 atATimeCollect: [ :x | x ]).
-   self assertEmpty: (self empty groupsOf: 2 atATimeCollect: #yourself).
-		
+	self assertEmpty: (self empty groupsOf: 2 atATimeCollect: #yourself).
+	
 	groupsOf2 := self nonEmptyMoreThan1Element groupsOf: 2 atATimeCollect: [ :x | x ].
 	
 	self assert: groupsOf2 size equals: self nonEmptyMoreThan1Element size // 2.


### PR DESCRIPTION
Fixed SequenceableCollection>>#groupsOf:atATimeCollect: and added a test.

Fixes #4790 