### PR TITLE
Unify TempVector Read Write

### DIFF
--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -176,19 +176,6 @@ OCAbstractMethodScope >> lookupDefiningContextForVariable: var startingFrom: aCo
 ]
 
 { #category : #lookup }
-OCAbstractMethodScope >> lookupTempVector: name inContext: aContext [
-	"Similar to lookupAndReadVar:inContext: but looks for a temp vector. If we don't find the temp vector (because it was nilled or not created), we lookup in the outer context with the corresponding outer scope"
-	
-	| variable theVector |
-	variable := self
-		variableNamed: name
-		ifAbsent: [^ self outerScope lookupTempVector: name inContext: aContext outerContext ].
-	theVector := variable readFromLocalContext: aContext.
-	theVector ifNil: [ ^ self outerScope lookupTempVector: name inContext: aContext outerContext ].
-	^ { variable . theVector }
-]
-
-{ #category : #lookup }
 OCAbstractMethodScope >> lookupVar: name [
 	copiedVars at: name ifPresent: [:v | ^ v].
 	tempVector  at: name ifPresent: [:v | ^ v].

--- a/src/OpalCompiler-Core/OCVectorTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCVectorTempVariable.class.st
@@ -35,10 +35,15 @@ OCVectorTempVariable >> isTempVectorTemp [
 { #category : #debugging }
 OCVectorTempVariable >> readFromContext: aContext scope: contextScope [
 
-	| offset pairVariableVector |
-	pairVariableVector := contextScope lookupTempVector: vectorName inContext: aContext.
-	offset := pairVariableVector first indexInTempVectorFromIR: name.
-	^pairVariableVector second at: offset.
+	| tempVectorVar theVector offset |
+	tempVectorVar := contextScope lookupVar: vectorName.
+	theVector := tempVectorVar readFromLocalContext: aContext.
+	theVector ifNil: [ ^ 
+		 "If we don't find the temp vector (because it was nilled or not created), we 
+		  lookup in the outer context with the corresponding outer scope"
+		self readFromContext: aContext outerContext scope: contextScope outerScope].
+	offset := tempVectorVar indexInTempVectorFromIR: name.
+	^theVector at: offset
 ]
 
 { #category : #accessing }
@@ -63,6 +68,10 @@ OCVectorTempVariable >> writeFromContext: aContext scope: contextScope value: aV
 	| tempVectorVar theVector offset |
 	tempVectorVar := contextScope lookupVar: vectorName.
 	theVector := tempVectorVar readFromLocalContext: aContext.
+	theVector ifNil: [ ^ 
+		 "If we don't find the temp vector (because it was nilled or not created), we 
+		  lookup in the outer context with the corresponding outer scope"
+		self readFromContext: aContext outerContext scope: contextScope outerScope].
 	offset := tempVectorVar indexInTempVectorFromIR: name.
 	^theVector at: offset put: aValue.
 ]


### PR DESCRIPTION
unify read and write of temp vector vars: use the strategy that we used for writing, this way we do not need a helper method returning a tupple.