### PR TITLE
CacheTempOffset

### DIFF
--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -5,7 +5,8 @@ Class {
 	#name : #OCTempVariable,
 	#superclass : #OCAbstractLocalVariable,
 	#instVars : [
-		'escaping'
+		'escaping',
+		'index'
 	],
 	#category : #'OpalCompiler-Core-Semantics'
 }
@@ -57,7 +58,7 @@ OCTempVariable >> hash [
 
 { #category : #debugging }
 OCTempVariable >> indexFromIR [
-	^scope indexFromIRForVarNamed: name
+	^index ifNil: [index := scope indexFromIRForVarNamed: name]
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
we should cache the offset of the temp var. This is for one for speed, but more important is makes clear that there is a 1-1 relationship between offsets and semantic variables.We can in a second step do the same for the offset in the temp vector for temp vector temps.