### PR TITLE
4806-Add-zippedunzipped-to-ByteArray

### DIFF
--- a/src/Compression-Tests/ZipExtensionTest.class.st
+++ b/src/Compression-Tests/ZipExtensionTest.class.st
@@ -8,6 +8,29 @@ Class {
 }
 
 { #category : #tests }
+ZipExtensionTest >> testBinaryZipped [
+	| data compressed |
+	
+	data := #[ 1 2 3 4 5 6 7 8 9 0 ].
+	compressed := data zipped.
+	self assert: compressed unzipped equals: data.
+	
+	data := #[].
+	compressed := data zipped.
+	self assert: compressed unzipped equals: data.
+	
+	data := #[ 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 ].
+	compressed := data zipped.
+	self assert: compressed unzipped equals: data.
+	
+	"next are the bytes written by 
+	$ echo -n Pharo | gzip - > /tmp/foo.gz"
+	compressed := #[31 139 8 0 94 254 149 93 0 3 11 200 72 44 202 7 0 144 33 178 137 5 0 0 0].
+	self assert: compressed unzipped asString equals: 'Pharo'
+
+]
+
+{ #category : #tests }
 ZipExtensionTest >> testZipped [
 	| compressed |
 	compressed := 'hello' zipped.

--- a/src/Compression/ByteArray.extension.st
+++ b/src/Compression/ByteArray.extension.st
@@ -17,3 +17,25 @@ ByteArray >> lastIndexOfPKSignature: aSignature [
 	].
 	^0
 ]
+
+{ #category : #'*Compression' }
+ByteArray >> unzipped [
+	"Assuming the receiver contains GZIP compressed data, 
+	return a ByteArray with the decompressed data."
+	
+	"#[31 139 8 0 0 0 0 0 0 0 99 100 98 6 0 29 128 188 85 3 0 0 0] unzipped >>> #[1 2 3]"
+
+	^ (GZipReadStream on: self) upToEnd
+]
+
+{ #category : #'*Compression' }
+ByteArray >> zipped [
+	"Return a ByteArray containing a GZIP compressed version of the receiver"
+	
+	"#[ 1 2 3 ] zipped >>> #[31 139 8 0 0 0 0 0 0 0 99 100 98 6 0 29 128 188 85 3 0 0 0]"
+
+	^ ByteArray streamContents: [ :out | 
+		(GZipWriteStream on: out)
+			nextPutAll: self;
+			close ]
+]


### PR DESCRIPTION
Add #zipped and #unzipped to ByteArray with method comments, runnable examples and unit tests
These are extensions to Compression
Thanks to Tomohiro Oda for pointing out correct binary usage of the GZip streams