### PR TITLE
Fix #3138: Restore logging of SnapshotDone.

### DIFF
--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -535,10 +535,10 @@ EpMonitor >> sessionStore [
 
 { #category : #'announcement handling' }
 EpMonitor >> snapshotDone: aSnapshotDone [
-"-> disable this event as a workaround to case 18374"
+	"Log the event, but only the original save (read SnapshotDone comment)."
 
-"	aSnapshotDone isNewImage 
-		ifFalse: [ self sessionSnapshot ]"
+	aSnapshotDone isNewImage
+		ifFalse: [ self sessionSnapshot ]
 ]
 
 { #category : #private }
@@ -573,6 +573,7 @@ EpMonitor >> subscribeToSystemAnnouncer [
 		ClassCommented -> #classCommented:.
 		MethodRecategorized -> #methodRecategorized:.
 		MCVersionSaved	-> #monticelloVersionSaved:.
+		SnapshotDone -> #snapshotDone:.
 		
 	} do: [ :pair |
 		systemAnnouncer weak


### PR DESCRIPTION
Restore logging of SnapshotDone.
Fix #3138