### PR TITLE
Epicea browser: Do no remove filters on log selection change

### DIFF
--- a/src/EpiceaBrowsers/EpUnifiedBrowserPresenter.class.st
+++ b/src/EpiceaBrowsers/EpUnifiedBrowserPresenter.class.st
@@ -114,7 +114,6 @@ EpUnifiedBrowserPresenter >> refreshWithLogSelected: item [
 
 	logPresenter
 		theLog: freshLog;
-		removeAllFilters;
 		refresh;
 		cleanEntryContent
 ]


### PR DESCRIPTION
In Epicea's code changes browser, do not remove active filters when another log is selected.

Fix #4815
