### PR TITLE
2442-Commander-should-not-use-Smalltalk-ui-icons-but-self-iconNamed

### DIFF
--- a/src/Calypso-Browser/ClyMainItemCellMorph.class.st
+++ b/src/Calypso-Browser/ClyMainItemCellMorph.class.st
@@ -217,11 +217,6 @@ ClyMainItemCellMorph >> expandedButton [
 		borderWidth: 0
 ]
 
-{ #category : #accessing }
-ClyMainItemCellMorph >> iconNamed: aString [ 
-	^Smalltalk ui icons iconNamed: aString
-]
-
 { #category : #initialization }
 ClyMainItemCellMorph >> initialize [
 	super initialize.

--- a/src/Calypso-SystemPlugins-SUnit-Queries/ClyTestResultProperty.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Queries/ClyTestResultProperty.class.st
@@ -87,15 +87,16 @@ ClyTestResultProperty >> brokenCount [
 
 { #category : #presentation }
 ClyTestResultProperty >> createIcon [
-	allCount = 0 ifTrue: [ ^ Smalltalk ui icons iconNamed: #testNotRunIcon ].
+
+	allCount = 0 ifTrue: [ ^ self iconNamed: #testNotRunIcon ].
 	allCount = successCount
-		ifTrue: [ ^Smalltalk ui icons iconNamed: #testGreenIcon ].
+		ifTrue: [ ^ self iconNamed: #testGreenIcon ].
 	errorCount = 0 & (failureCount > 0)
-		ifTrue: [ ^Smalltalk ui icons iconNamed: #testYellowIcon ].
+		ifTrue: [ ^ self iconNamed: #testYellowIcon ].
 	errorCount > 0
-		ifTrue: [ ^Smalltalk ui icons iconNamed: #testRedIcon ].
+		ifTrue: [ ^ self iconNamed: #testRedIcon ].
 		
-	^Smalltalk ui icons iconNamed: #testNotRunIcon.
+	^ self iconNamed: #testNotRunIcon
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fixes #2442

Technically, this issue was already managed. But I benefit from it to clean remaining calypso issues.