### PR TITLE
4818-Test-failing-in-build-testExternalMorphicDependencies

### DIFF
--- a/src/Text-Core/TextURL.class.st
+++ b/src/Text-Core/TextURL.class.st
@@ -23,7 +23,7 @@ TextURL class >> scanFrom: strm [
 
 { #category : #evaluating }
 TextURL >> actOnClick: anEvent for: anObject in: paragraph editor: editor [
-	WebBrowser openOn: url
+	self notify: 'Please configure the actOnClickBlock to invoke the computation you need. In Pharo by default there is no external web browser'.
 
 ]
 


### PR DESCRIPTION
The Text package should not depend on WebBrowser, the user of this should put a correct block in the definition of the action.

Check  CustomHelp >> #url: as an example of correct usage.

Fixes #4818 