### PR TITLE
Improve-slot-error-message

### DIFF
--- a/src/Slot-Core/SlotNotFound.class.st
+++ b/src/Slot-Core/SlotNotFound.class.st
@@ -1,12 +1,11 @@
 "
-I am an exception to indicate that a slot is found in a layout.
+I am an exception to indicate that a slot is found in a layout or in the image.
 "
 Class {
 	#name : #SlotNotFound,
 	#superclass : #ClassBuilderError,
 	#instVars : [
-		'name',
-		'targetClass'
+		'name'
 	],
 	#category : #'Slot-Core-Exception'
 }
@@ -18,17 +17,9 @@ SlotNotFound class >> signalForName: aSymbol [
 		signal
 ]
 
-{ #category : #signalling }
-SlotNotFound class >> signalForName: aSymbol inClass: aClass [
-	self new
-		name: aSymbol;
-		targetClass: aClass;
-		signal
-]
-
 { #category : #accessing }
 SlotNotFound >> messageText [
-	^ 'Slot ''', name asString, ''' not found', (targetClass ifNil: [''] ifNotNil:[' in ', targetClass name])
+	^ 'Could not build slot named ''' , name asString , ''' because the assignated slot was not found in the image.'
 ]
 
 { #category : #accessing }
@@ -39,14 +30,4 @@ SlotNotFound >> name [
 { #category : #accessing }
 SlotNotFound >> name: anObject [
 	name := anObject
-]
-
-{ #category : #accessing }
-SlotNotFound >> targetClass [
-	^ targetClass
-]
-
-{ #category : #accessing }
-SlotNotFound >> targetClass: aClass [
-	targetClass := aClass
 ]

--- a/src/Slot-Core/Symbol.extension.st
+++ b/src/Slot-Core/Symbol.extension.st
@@ -2,6 +2,9 @@ Extension { #name : #Symbol }
 
 { #category : #'*Slot-Core' }
 Symbol >> => aVariable [
+	"If the slot we give as argument is not present in the image, we will get a nil. In that case we should throw an explicit error to the user saying a slot is missing."
+
+	aVariable ifNil: [ SlotNotFound signalForName: self ].
 	^ aVariable named: self
 ]
 

--- a/src/Slot-Tests/SlotTest.class.st
+++ b/src/Slot-Tests/SlotTest.class.st
@@ -35,11 +35,23 @@ SlotTest >> testIsReadInMethod [
 	self assert: ((self class slotNamed: #ivarForTesting) isReadIn: self class >> testSelector)
 ]
 
+{ #category : #'tests - testing' }
+SlotTest >> testIsReferenced [
+	self assert: (Point slotNamed: #x) isReferenced
+]
+
 { #category : #'tests - read/write' }
 SlotTest >> testIsWrittenInMethod [
 	
 	ivarForTesting := #test.
 	self assert: ((self class slotNamed: #ivarForTesting) isWrittenIn: self class >> testSelector)
+]
+
+{ #category : #'tests - misc' }
+SlotTest >> testNotFoundSlotRaiseExplicitError [
+	"When a slot is not present in the image, we will try to build the slot with nil. In that case we should return an error."
+
+	self should: [ #test => nil ] raise: SlotNotFound
 ]
 
 { #category : #'tests - read/write' }
@@ -86,9 +98,10 @@ SlotTest >> testRemoveProperty [
 	self assert: ivar properties isNil
 ]
 
-{ #category : #'tests - testing' }
-SlotTest >> testisReferenced [
-	self assert: (Point slotNamed: #x) isReferenced
+{ #category : #'tests - misc' }
+SlotTest >> testSlotUsers [
+	self assert: (ToOneRelationSlot slotUsers includes: SlotExampleMovie).
+	self deny: (ToOneRelationSlot slotUsers includes: SlotExamplePerson)
 ]
 
 { #category : #'tests - misc' }
@@ -96,10 +109,4 @@ SlotTest >> testisUsed [
 	self assert: InstanceVariableSlot isUsed.
 	self assert: IndexedSlot isUsed. "subclasses are users"
 	self assert: ProcessLocalSlot isUsed. "references count as uses, too"
-]
-
-{ #category : #'tests - misc' }
-SlotTest >> testslotUsers [
-	self assert: (ToOneRelationSlot slotUsers includes: SlotExampleMovie).
-	self deny: (ToOneRelationSlot slotUsers includes: SlotExamplePerson)
 ]


### PR DESCRIPTION
Raise a SlotNotFound error if a slot is missing in the image and we use it in a class. 

This also clean SlotNotFound and rename some tests.