### PR TITLE
Fix #2853. When removing a class, also log its contained methods

### DIFF
--- a/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
+++ b/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
@@ -125,6 +125,22 @@ EpCodeChangeIntegrationTest >> testClassRemoval [
 ]
 
 { #category : #tests }
+EpCodeChangeIntegrationTest >> testClassRemovalWithMethods [
+
+	| events category |
+	aClass := classFactory newClass.
+	category := aClass category.
+	1 to: 7 do: [:index |
+		aClass compile: 'inst', index asString.
+		aClass classSide compile: 'class', index asString ].
+	aClass removeFromSystem.
+	
+	events := self allLogEventsWith: EpMethodRemoval.
+	self assert: events size equals: 14.
+	self assert: (events allSatisfy: [ :each | each affectedPackageName = category ])
+]
+
+{ #category : #tests }
 EpCodeChangeIntegrationTest >> testInstanceVariableAddition [
 
 	aClass := classFactory newClass.

--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -200,9 +200,32 @@ EpMonitor >> behaviorRemoved: aClassRemovedAnnouncement [
 		classRemoved category: aClassRemovedAnnouncement categoryName.
 		classRemoved package: aClassRemovedAnnouncement packageAffected name.
 
+		(aClassRemovedAnnouncement classRemoved methods, aClassRemovedAnnouncement classRemoved classSide methods) 
+			do: [:each | self behaviorRemovedImpliesMethodRemoved: each defaultPackageName: classRemoved package ].
+
 		aClassRemovedAnnouncement classAffected isTrait
 			ifTrue:  [ self traitRemoved: classRemoved ]
 			ifFalse: [ self classRemoved: classRemoved ] ]
+]
+
+{ #category : #'announcement handling' }
+EpMonitor >> behaviorRemovedImpliesMethodRemoved: aMethodInAnObsoleteBehavior defaultPackageName: aSymbol [
+	| packageName |
+	packageName := (RPackageOrganizer default 
+		packageForProtocol: aMethodInAnObsoleteBehavior protocol 
+		inClass: aMethodInAnObsoleteBehavior methodClass) name.
+
+	"If the method is local, (belongs to the class being removed) then the package was wrong,  and we fix it"
+	packageName = RPackage defaultPackageName 
+		ifTrue: [ packageName := aSymbol ].
+		
+	self addEvent: 
+		(EpMethodRemoval method: 
+			(aMethodInAnObsoleteBehavior asEpiceaRingDefinition
+				parentName: aMethodInAnObsoleteBehavior methodClass originalName;
+				protocol: aMethodInAnObsoleteBehavior protocol;
+				package: packageName;
+				yourself))
 ]
 
 { #category : #'announcement handling' }


### PR DESCRIPTION
I propose this fix/workaround to tackle this issue.