### PR TITLE
Move the #errorNotKeyed message from Collection to Bag

### DIFF
--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -653,13 +653,6 @@ Collection >> errorNotFound: anObject [
 ]
 
 { #category : #private }
-Collection >> errorNotKeyed [
-
-	self error: ('Instances of {1} do not respond to keyed accessing messages.' format: {self class name})
-
-]
-
-{ #category : #private }
 Collection >> errorSizeMismatch [
 	"Signal a SizeMismatch exception"
 

--- a/src/Collections-Unordered/Bag.class.st
+++ b/src/Collections-Unordered/Bag.class.st
@@ -93,16 +93,6 @@ Bag >> associationsDo: aBlock [
 ]
 
 { #category : #accessing }
-Bag >> at: index [ 
-	self errorNotKeyed
-]
-
-{ #category : #accessing }
-Bag >> at: index put: anObject [ 
-	self errorNotKeyed
-]
-
-{ #category : #accessing }
 Bag >> cumulativeCounts [
 	"Answer with a collection of cumulative percents covered by elements so far."
 	


### PR DESCRIPTION
The #errorNotKeyed message is sent only by the Bag class, so it shouldn't belong to che Collection class.

Fixes: #4808