### PR TITLE
Rename "Move to class package" to "Move to the defining class"

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -181,7 +181,7 @@ ClyMethodEditorToolMorph >> packageEditingMethod: aMethod [
 				execute].
 	
 		(extendingPackage isNil and: [ aMethod isExtension ]) ifTrue: [ 
-			(SycMoveMethodsToClassPackageCommand for: {aMethod}) 
+			(SycMoveMethodsToPackageDefiningClassCommand for: {aMethod}) 
 				execute]
 	]
 ]

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToPackageDefiningClassCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToPackageDefiningClassCommand.class.st
@@ -4,7 +4,7 @@ I am a command to move method to the package of defining class.
 I am used to convert extension method to normal one
 "
 Class {
-	#name : #SycMoveMethodsToClassPackageCommand,
+	#name : #SycMoveMethodsToPackageDefiningClassCommand,
 	#superclass : #SycMethodRepackagingCommand,
 	#instVars : [
 		'targetTagName'
@@ -13,12 +13,12 @@ Class {
 }
 
 { #category : #testing }
-SycMoveMethodsToClassPackageCommand class >> canBeExecutedInContext: aToolContext [
+SycMoveMethodsToPackageDefiningClassCommand class >> canBeExecutedInContext: aToolContext [
 	^aToolContext isExtensionMethodSelected
 ]
 
 { #category : #activation }
-SycMoveMethodsToClassPackageCommand class >> methodContextMenuActivation [
+SycMoveMethodsToPackageDefiningClassCommand class >> methodContextMenuActivation [
 	<classAnnotation>
 	
 	^CmdContextMenuActivation 
@@ -28,17 +28,17 @@ SycMoveMethodsToClassPackageCommand class >> methodContextMenuActivation [
 ]
 
 { #category : #accessing }
-SycMoveMethodsToClassPackageCommand >> defaultMenuIconName [ 
+SycMoveMethodsToPackageDefiningClassCommand >> defaultMenuIconName [ 
 	^ #smallRedo
 ]
 
 { #category : #accessing }
-SycMoveMethodsToClassPackageCommand >> defaultMenuItemName [
-	^'Move to class package'
+SycMoveMethodsToPackageDefiningClassCommand >> defaultMenuItemName [
+	^'Move to package defining the class'
 ]
 
 { #category : #execution }
-SycMoveMethodsToClassPackageCommand >> execute [
+SycMoveMethodsToPackageDefiningClassCommand >> execute [
 
 	| classPackage |
 	methods do: [ :each | 
@@ -48,18 +48,18 @@ SycMoveMethodsToClassPackageCommand >> execute [
 ]
 
 { #category : #execution }
-SycMoveMethodsToClassPackageCommand >> prepareFullExecutionInContext: aToolContext [
+SycMoveMethodsToPackageDefiningClassCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 	
 	targetTagName := aToolContext requestSingleMethodTag: 'Choose protocol for methods'
 ]
 
 { #category : #accessing }
-SycMoveMethodsToClassPackageCommand >> targetTagName [
+SycMoveMethodsToPackageDefiningClassCommand >> targetTagName [
 	^ targetTagName
 ]
 
 { #category : #accessing }
-SycMoveMethodsToClassPackageCommand >> targetTagName: anObject [
+SycMoveMethodsToPackageDefiningClassCommand >> targetTagName: anObject [
 	targetTagName := anObject
 ]


### PR DESCRIPTION
The former name of this refactoring command could be misunderstood and
have been changed to a clearer one. The class implementing the
refactoring have been renamed, too.

Fixes: #4451