### PR TITLE
Remove `bounds` ivar from AthensBalloonPath

### DIFF
--- a/src/Athens-Balloon/AthensBalloonPath.class.st
+++ b/src/Athens-Balloon/AthensBalloonPath.class.st
@@ -5,7 +5,6 @@ Class {
 	#name : #AthensBalloonPath,
 	#superclass : #AthensPath,
 	#instVars : [
-		'bounds',
 		'contours'
 	],
 	#category : #'Athens-Balloon-Path'
@@ -36,7 +35,6 @@ AthensBalloonPath >> contoursForStroke [
 { #category : #converting }
 AthensBalloonPath >> convertFromBuilder: aBuilder [
 	| segment cContours |
-	bounds := aBuilder pathBounds.
 	segment := aBuilder pathStart.
 	
 


### PR DESCRIPTION
That ivar was not used so this patch removes it.

Fixes: #4549