### PR TITLE
Document and Improve TempVector Access

### DIFF
--- a/src/OpalCompiler-Core/OCVectorTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCVectorTempVariable.class.st
@@ -64,7 +64,10 @@ OCVectorTempVariable >> readVectorFromContext: aContext scope: contextScope [
 	index := index ifNil: [ tempVectorVar indexInTempVectorFromIR: name ].
 	"We can call this method on a context in any state, e.g. even when the copied var is not yet initialized.
 	In this case, we lookup in the outer context with the corresponding outer scope"
-	^ theVector ifNil: [ self readVectorFromContext: aContext outerContext scope: contextScope outerScope ]
+	^ theVector ifNil: [ 
+		"but there might be no outer context, so in that case, just return an empty array of the correct size"
+		aContext outerContext ifNil: [ ^Array new: tempVectorVar tempVectorForTempStoringIt size ].
+		self readVectorFromContext: aContext outerContext scope: contextScope outerScope ]
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCVectorTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCVectorTempVariable.class.st
@@ -54,12 +54,18 @@ OCVectorTempVariable >> readFromContext: aContext scope: contextScope [
 { #category : #debugging }
 OCVectorTempVariable >> readVectorFromContext: aContext scope: contextScope [
 	| tempVectorVar theVector |
+	"We need to first read the temp vector. We use the closest copied var up the stack possible 
+	 The whole point of using the vector is for everything to be accessible locally, the definition 
+	 context could be already garbage collected)"
 	tempVectorVar := contextScope lookupVar: vectorName.
-	theVector := tempVectorVar readFromLocalContext: aContext.
+	"We might be called from the debugger for a context that actually does not access the temp vector, 
+	so we need to read possibly from a context above aContext"
+	theVector := tempVectorVar readFromContext: aContext scope: contextScope.
+	"Cache the index in the temp vecor (for speed and easy debugging)"
 	index := index ifNil: [ tempVectorVar indexInTempVectorFromIR: name ].
 
-	"If we don't find the temp vector (because it was nilled or not created), we 
-	 lookup in the outer context with the corresponding outer scope"
+	"We can call this method on a context in any state, e.g. even when the copied var is not yet initialized.
+	 In this case, we lookup in the outer context with the corresponding outer scope"
 	^ theVector ifNil: [ self readVectorFromContext: aContext outerContext scope: contextScope outerScope ]
 ]
 

--- a/src/OpalCompiler-Core/OCVectorTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCVectorTempVariable.class.st
@@ -54,18 +54,16 @@ OCVectorTempVariable >> readFromContext: aContext scope: contextScope [
 { #category : #debugging }
 OCVectorTempVariable >> readVectorFromContext: aContext scope: contextScope [
 	| tempVectorVar theVector |
-	"We need to first read the temp vector. We use the closest copied var up the stack possible 
-	 The whole point of using the vector is for everything to be accessible locally, the definition 
-	 context could be already garbage collected)"
+	"We need to first read the temp vector. We use the closest copied var up the stack possible as
+	 as the definition context could be already garbage collected"
 	tempVectorVar := contextScope lookupVar: vectorName.
 	"We might be called from the debugger for a context that actually does not access the temp vector, 
 	so we need to read possibly from a context above aContext"
 	theVector := tempVectorVar readFromContext: aContext scope: contextScope.
 	"Cache the index in the temp vecor (for speed and easy debugging)"
 	index := index ifNil: [ tempVectorVar indexInTempVectorFromIR: name ].
-
 	"We can call this method on a context in any state, e.g. even when the copied var is not yet initialized.
-	 In this case, we lookup in the outer context with the corresponding outer scope"
+	In this case, we lookup in the outer context with the corresponding outer scope"
 	^ theVector ifNil: [ self readVectorFromContext: aContext outerContext scope: contextScope outerScope ]
 ]
 

--- a/src/OpalCompiler-Core/OCVectorTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCVectorTempVariable.class.st
@@ -64,10 +64,10 @@ OCVectorTempVariable >> readVectorFromContext: aContext scope: contextScope [
 	index := index ifNil: [ tempVectorVar indexInTempVectorFromIR: name ].
 	"We can call this method on a context in any state, e.g. even when the copied var is not yet initialized.
 	In this case, we lookup in the outer context with the corresponding outer scope"
-	^ theVector ifNil: [ 
+	^ theVector ifNil: [ aContext outerContext 
 		"but there might be no outer context, so in that case, just return an empty array of the correct size"
-		aContext outerContext ifNil: [ ^Array new: tempVectorVar tempVectorForTempStoringIt size ].
-		self readVectorFromContext: aContext outerContext scope: contextScope outerScope ]
+			ifNil: [ Array new: tempVectorVar tempVectorForTempStoringIt size ]
+			ifNotNil: [: ctxt | self readVectorFromContext: ctxt scope: contextScope outerScope ]]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- document temp vector reading in OCVectorTempVariable
- do not read from the local context but use the definition context of the copied var that contains the temp vector