### PR TITLE
Simplify morph creation from Athens surface

### DIFF
--- a/src/Athens-Core/AthensSurface.class.st
+++ b/src/Athens-Core/AthensSurface.class.st
@@ -37,6 +37,12 @@ AthensSurface >> asForm [
 	self subclassResponsibility
 ]
 
+{ #category : #converting }
+AthensSurface >> asMorph [
+	"Answer a Morph, given this Athens surface"
+	^ self asForm asMorph
+]
+
 { #category : #caching }
 AthensSurface >> cacheAt: anObject ifAbsentPut: aBlock [
 	"Answer an object from surface's cache identified by anObject,

--- a/src/Athens-Examples/AthensCairoSurfaceExamples.class.st
+++ b/src/Athens-Examples/AthensCairoSurfaceExamples.class.st
@@ -47,7 +47,7 @@ AthensCairoSurfaceExamples class >> exampleDrawTextPath [
 		f unlock.
 	].
 	
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 
 ]
 
@@ -77,7 +77,7 @@ A cairo image surface bits are exposed to bitblt operations via surface plugin.
 		2 timesRepeat: [ can draw. can setPaint: (Color green alpha:0.5)]
 	].
 
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 ]
 
 { #category : #utilities }

--- a/src/Athens-Examples/AthensSurfaceExamples.class.st
+++ b/src/Athens-Examples/AthensSurfaceExamples.class.st
@@ -45,7 +45,7 @@ AthensSurfaceExamples class >> draw2Strings [
 		can pathTransform translateBy: advance.
 		can drawString: 'in mind.'].
 	
-	surf asForm asMorph openInWindow.
+	surf asMorph openInWindow.
 ]
 
 { #category : #examples }
@@ -189,7 +189,7 @@ AthensSurfaceExamples class >> example10 [
 		can setStrokePaint: Color red.
 		can draw ].
 		
-	surf asForm asMorph openInWindow.
+	surf asMorph openInWindow.
 
 ]
 
@@ -243,7 +243,7 @@ AthensSurfaceExamples class >> example3 [
 		]	
 	].
 
-	surf asForm asMorph openInWindow. 
+	surf asMorph openInWindow. 
 
 ]
 
@@ -277,7 +277,7 @@ AthensSurfaceExamples class >> example3stroke [
 		]	
 	].
 
-	surf asForm asMorph openInWindow. 
+	surf asMorph openInWindow. 
 
 ]
 
@@ -304,7 +304,7 @@ AthensSurfaceExamples class >> example4 [
 		can drawShape: path.
 	].
 
-	surf asForm asMorph openInWindow. 
+	surf asMorph openInWindow. 
 
 ]
 
@@ -338,7 +338,7 @@ AthensSurfaceExamples class >> example5 [
 			])
 	].
 
-	surf asForm asMorph openInWindow. 
+	surf asMorph openInWindow. 
 ]
 
 { #category : #examples }
@@ -366,7 +366,7 @@ AthensSurfaceExamples class >> example6 [
 		can pathTransform translateX: 50 Y: 50; rotateByDegrees: 30.
 		can drawShape: (0@0 corner: 50@50) ].
 
-		surf asForm asMorph openInWindow
+		surf asMorph openInWindow
 
 ]
 
@@ -392,7 +392,7 @@ AthensSurfaceExamples class >> example6point1 [
 
 		can drawShape: (0@0 corner: 50@50) ].
 
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 ]
 
 { #category : #examples }
@@ -420,7 +420,7 @@ AthensSurfaceExamples class >> example6stroke [
 		can pathTransform translateX: 50 Y: 50.
 		can drawShape: (0@0 corner: 50@50) ].
 
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 ]
 
 { #category : #examples }
@@ -455,7 +455,7 @@ AthensSurfaceExamples class >> example7 [
 			
 		].		
 	].
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 ]
 
 { #category : #examples }
@@ -477,7 +477,7 @@ AthensSurfaceExamples class >> example8 [
 
 			can drawShape: (0@0 corner: 200@200)].
 
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 ]
 
 { #category : #examples }
@@ -499,7 +499,7 @@ AthensSurfaceExamples class >> example9 [
 			setPaint: paint;
 			drawShape: (0@0 corner: 100@200)].
 
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 ]
 
 { #category : #examples }
@@ -522,7 +522,7 @@ AthensSurfaceExamples class >> exampleClip [
 		]
 	].
 
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 ]
 
 { #category : #examples }
@@ -551,7 +551,7 @@ AthensSurfaceExamples class >> exampleDrawForm [
 		can pathTransform translateX: 30 Y: 30. 
 		can draw ].
 	
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 ]
 
 { #category : #examples }
@@ -573,7 +573,7 @@ AthensSurfaceExamples class >> exampleDrawForm2 [
 		can paintTransform scaleBy: 3; rotateByDegrees: 30.
 		can draw ].
 	
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 ]
 
 { #category : #examples }
@@ -597,7 +597,7 @@ AthensSurfaceExamples class >> exampleDrawText [
 		can pathTransform translateX: 0 Y: (font getPreciseAscent).
 		can drawString: 'Hello Athens!' ].
 	
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 
 ]
 
@@ -620,7 +620,7 @@ AthensSurfaceExamples class >> exampleStrokeRect [
 		]	
 	].
 
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 ]
 
 { #category : #examples }
@@ -633,7 +633,7 @@ AthensSurfaceExamples class >> exampleUseForm [
 	form getCanvas fillRectangle: (20@20 corner: 50@50)  color: (Color blue).
 	
 	surf := AthensCairoSurface fromForm: form.
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 
 ]
 

--- a/src/Athens-Examples/AthensTextRenderManualTests.class.st
+++ b/src/Athens-Examples/AthensTextRenderManualTests.class.st
@@ -65,7 +65,7 @@ AthensTextRenderManualTests class >> test2 [
 		c renderOn: canvas
 	].
 
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 ]
 
 { #category : #tests }
@@ -90,7 +90,7 @@ AthensTextRenderManualTests class >> test3 [
 			canvas pathTransform translateBy: 0 @11.
 		].
 	].
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 
 
 ]
@@ -114,7 +114,7 @@ AthensTextRenderManualTests class >> test4 [
 			canvas pathTransform translateBy: 0.1@10.
 		]
 	].
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 
 
 ]
@@ -137,7 +137,7 @@ AthensTextRenderManualTests class >> test5 [
 			canvas pathTransform translateBy: 10@0.1.
 		]
 	].
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 
 
 ]
@@ -237,7 +237,7 @@ AthensTextRenderManualTests class >> testWindowRender [
 		canvas fullDrawMorph: win.
 	].
 
-	surf asForm asMorph openInWindow
+	surf asMorph openInWindow
 
 
 ]


### PR DESCRIPTION
A new method named #asMorph has been created in the AthensSurface class,
returning the Morph representation of the surface.

This new method have been used in the Athens examples.

Fixes: #4517