### PR TITLE
Opal: remove #variableNamed:

### DIFF
--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -286,13 +286,3 @@ OCAbstractMethodScope >> tempVectorName [
 	 This way we avoid name clashes "
 	^'0vector', id asString
 ]
-
-{ #category : #lookup }
-OCAbstractMethodScope >> variableNamed: name ifAbsent: aBlock [
-	copiedVars at: name ifPresent: [:v | ^ v].
-	tempVector  at: name ifPresent: [:v | ^ v].
-	tempVars at: name ifPresent: [:v | ^ v].
-	name = 'thisContext' ifTrue: [^ thisContextVar].
-	
-	^ aBlock value.
-]

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -111,9 +111,3 @@ OCAbstractScope >> scopeLevel [
 	outerScope ifNil: [^ 0].
 	^ outerScope scopeLevel + 1
 ]
-
-{ #category : #accessing }
-OCAbstractScope >> variableNamed: aName [
-
-	^ self variableNamed: aName ifAbsent: [ nil ]
-]

--- a/src/OpalCompiler-Core/OCClassScope.class.st
+++ b/src/OpalCompiler-Core/OCClassScope.class.st
@@ -75,14 +75,3 @@ OCClassScope >> printOn: stream [
 
 	class printOn: stream.
 ]
-
-{ #category : #lookup }
-OCClassScope >> variableNamed: name ifAbsent: aBlock [
-	"Return a SemVar for my pool var with this name.  Return nil if none found"
-
-	^(class bindingOf: name asSymbol) ifNotNil: [:assoc | 
-		OCLiteralVariable new 
-			assoc: assoc; 
-			scope: self; 
-			yourself] ifNil: aBlock
-]

--- a/src/OpalCompiler-Core/OCExtraBindingScope.class.st
+++ b/src/OpalCompiler-Core/OCExtraBindingScope.class.st
@@ -59,18 +59,3 @@ OCExtraBindingScope >> newMethodScope [
 	 
 	^ OCMethodScope new outerScope: (self outerScope: outerScope instanceScope) 
 ]
-
-{ #category : #'instance creation' }
-OCExtraBindingScope >> variableNamed: name ifAbsent: aBlock [
-
-	name = 'self' ifTrue: [  ^outerScope lookupVar: name].
-	name = 'super' ifTrue: [  ^outerScope lookupVar: name].
-	name first isUppercase ifTrue: [  | found |
-		found := outerScope lookupVar: name.
-		found ifNotNil: [ ^found ]].
-	
-	(bindings bindingOf: name asSymbol) ifNotNil: [:assoc | 
-		^ OCLiteralVariable new assoc: assoc; scope: self; yourself].
-
-	^ aBlock value
-]

--- a/src/OpalCompiler-Core/OCInstanceScope.class.st
+++ b/src/OpalCompiler-Core/OCInstanceScope.class.st
@@ -85,12 +85,3 @@ OCInstanceScope >> slots: slotCollection [
 				yourself)].
 
 ]
-
-{ #category : #lookup }
-OCInstanceScope >> variableNamed: name ifAbsent: aBlock [
-	"Return a ScopeVar for my inst var with this name.  Return nil if none found"
-
-	name = 'self' ifTrue: [^ selfVar].
-	name = 'super' ifTrue: [^ superVar].
-	^ vars at: name ifAbsent: aBlock
-]

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -82,16 +82,3 @@ OCRequestorScope >> requestor [
 OCRequestorScope >> requestor: anObject [
 	requestor := anObject
 ]
-
-{ #category : #lookup }
-OCRequestorScope >> variableNamed: name ifAbsent: aBlock [
-
-	name = 'self' ifTrue: [  ^outerScope lookupVar: name].
-	name = 'super' ifTrue: [  ^outerScope lookupVar: name].
-	name first isUppercase ifTrue: [ ^outerScope lookupVar: name ]. 
-	
-	(requestor bindingOf: name asSymbol) ifNotNil: [:assoc | 
-		^ OCLiteralVariable new assoc: assoc; scope: self; yourself].
-
-	^ aBlock value
-]


### PR DESCRIPTION
#variableNamed: and #variableNamed:ifAbsent: are dead code (there is #lookupVar: for that).