### PR TITLE
Opal: compiler shoud not copy AST for pluging

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -244,7 +244,6 @@ OpalCompiler >> callPlugins [
 	| plugins  |
 	plugins := compilationContext astTransformPlugins ifEmpty: [ ^self ].
 	plugins sort: [:a :b | a priority > b priority]. "priority 0 is sorted last"
-	ast := ast copy.
 	plugins do: [ :each | ast := each transform: ast]. 
 ]
 


### PR DESCRIPTION
the compiler does not need to copy the AST before calling plugins as they can do that if needed. Speeds up compilation by 3-5%