### PR TITLE
Add a browse menu item

### DIFF
--- a/src/Glamour-Rubric-Presentations/GLMRubricSmalltalkCodePresentation.class.st
+++ b/src/Glamour-Rubric-Presentations/GLMRubricSmalltalkCodePresentation.class.st
@@ -127,6 +127,12 @@ GLMRubricSmalltalkCodePresentation >> executionSelectionActions [
 				keymap: PharoShortcuts current printItShortcut; 
 				yourself.
 		(GLMGenericAction new) 
+				title: 'Browse class of it'; 
+				action: [ :aPresentation |
+					aPresentation highlightEvaluateAndDo: [ :result | result class browse ] ]; 
+				icon: GLMUIThemeExtraIcons glamorousInspect;
+				yourself.
+		(GLMGenericAction new) 
 				title: 'Inspect it'; 
 				action: [ :aPresentation |
 					aPresentation highlightEvaluateAndDo: [ :result | result inspect ] ]; 

--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -47,6 +47,11 @@ RubSmalltalkCodeMode class >> menuOn: aBuilder [
 		selector: #printIt;
 		help: nil;
 		iconName: #smallPrintItIcon.
+	(aBuilder item: #'Browse class of it' translated)
+		order: 1;
+		selector: #browseClassOfIt;
+		help: nil;
+		iconName: #smallInspectItIcon.
 	(aBuilder item: #'Inspect it' translated)
 		keyText: 'i';
 		selector: #inspectIt;

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -283,6 +283,13 @@ RubSmalltalkEditor >> browseClassFromIt [
 ]
 
 { #category : #'menu messages' }
+RubSmalltalkEditor >> browseClassOfIt [
+	"Launch a browser for the class of the current selection"
+	self evaluateSelectionAndDo: [:result | result class browse]
+
+]
+
+{ #category : #'menu messages' }
 RubSmalltalkEditor >> browseIt [
 	"Launch a browser for the current selection, if appropriate"
 	^ self browseClassFromIt


### PR DESCRIPTION
The new menu item will evaluate the current selection and then open its
class. It can be used in the system browser and also in the Playground.

Fixes: #4839