### PR TITLE
Improve #printString implementations

### DIFF
--- a/src/Moose-Algos-Graph/MalGraphEdge.class.st
+++ b/src/Moose-Algos-Graph/MalGraphEdge.class.st
@@ -60,12 +60,6 @@ MalGraphEdge >> printOn: aStream [
 ]
 
 { #category : #accessing }
-MalGraphEdge >> printString [
-
-	^ self from printString, ' -> ', self to printString
-]
-
-{ #category : #accessing }
 MalGraphEdge >> to [
 	^ to
 ]

--- a/src/Moose-Algos-Graph/MalGraphEdgeTest.class.st
+++ b/src/Moose-Algos-Graph/MalGraphEdgeTest.class.st
@@ -1,0 +1,12 @@
+Class {
+	#name : #MalGraphEdgeTest,
+	#superclass : #TestCase,
+	#category : #'Moose-Algos-Graph-Tests'
+}
+
+{ #category : #tests }
+MalGraphEdgeTest >> testPrintString [
+	self
+		assert: (MalGraphEdge with: 'model' from: 'from' to: 'to') printString
+		equals:  '''from'' -> ''to'''.
+]

--- a/src/Moose-Algos-Graph/MalHitsNode.class.st
+++ b/src/Moose-Algos-Graph/MalHitsNode.class.st
@@ -35,13 +35,13 @@ MalHitsNode >> label [
 ]
 
 { #category : #printing }
-MalHitsNode >> printString [
+MalHitsNode >> printOn: aStream [
+	aStream nextPut: $(.
+	self model printOn: aStream.
+	aStream space.
+	self auth printOn: aStream showingDecimalPlaces: 2.
+	aStream space.
+	self hub printOn: aStream showingDecimalPlaces: 2.
+	aStream nextPutAll: ')'.
 
-	^ 	'(',
-		self model printString,
-		' ',
-		(self auth printShowingDecimalPlaces: 2),
-		' ',
-		(self hub printShowingDecimalPlaces: 2),
-		') '
 ]

--- a/src/Moose-Algos-Graph/MalHitsNodeTest.class.st
+++ b/src/Moose-Algos-Graph/MalHitsNodeTest.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : #MalHitsNodeTest,
+	#superclass : #TestCase,
+	#category : #'Moose-Algos-Graph-Tests'
+}
+
+{ #category : #tests }
+MalHitsNodeTest >> testPrintString [
+	|node|
+	node := MalHitsNode new
+		model: 'model';
+		auth: 7;
+		hub: 11;
+		yourself.
+	self assert: node printString equals: '(''model'' 7.00 11.00)'.
+]

--- a/src/Moose-Algos-Graph/MalWeightedEdge.class.st
+++ b/src/Moose-Algos-Graph/MalWeightedEdge.class.st
@@ -13,10 +13,15 @@ MalWeightedEdge >> asTuple [
 	^ {from model. to model. weight}
 ]
 
-{ #category : #accessing }
-MalWeightedEdge >> printString [
+{ #category : #printing }
+MalWeightedEdge >> printOn: aStream [
+	self from printOn: aStream.
+	aStream nextPutAll: ' -> '.
+	self to printOn: aStream.
+	aStream nextPutAll: ' ('.
+	self weight printOn: aStream.
+	aStream nextPut: $).
 
-	^ self from printString, ' -> ', self to printString, ' (', self weight printString, ')'
 ]
 
 { #category : #accessing }

--- a/src/Moose-Algos-Graph/MalWeightedEdgeTest.class.st
+++ b/src/Moose-Algos-Graph/MalWeightedEdgeTest.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : #MalWeightedEdgeTest,
+	#superclass : #TestCase,
+	#category : #'Moose-Algos-Graph-Tests'
+}
+
+{ #category : #tests }
+MalWeightedEdgeTest >> testPrintString [
+	|edge|
+	edge := MalWeightedEdge with: 'model' from: 'from' to: 'to'.
+	edge weight: 7.
+	self assert: edge printString equals: '''from'' -> ''to'' (7)'.
+]


### PR DESCRIPTION
On MalGraphEdge, MalHitsNode and MalWeightedEdge, the #printString
implementation was calling #printString on their ivars, causing the
creation of too many temporary Streams and spurious copies.

This patch reimplement those methods in a more performance-aware way,
while adding some unit tests that were running also before the
implementation to be modified, avoiding changing the former behavior of
the methods.

Fixes: #4855