### PR TITLE
Compiler: Clean dead code

### DIFF
--- a/src/OpalCompiler-Core/IRBuilder.class.st
+++ b/src/OpalCompiler-Core/IRBuilder.class.st
@@ -416,7 +416,6 @@ IRBuilder >> startNewSequence [
 
 	currentSequence last transitionsToNextSequence
 		ifFalse: [ self add: (IRJump new destination: newSequence)].
-	self currentScope isPushClosureCopy ifTrue: [self currentScope lastBlockSequence: currentSequence].
 	currentSequence := newSequence.
 
 ]

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -166,6 +166,11 @@ IRBytecodeGenerator >> closureFrom: fromSeqId to: toSeqId copyNumCopiedValues: n
 ]
 
 { #category : #accessing }
+IRBytecodeGenerator >> compilationContext [
+	^ compilationContext ifNil: [compilationContext := CompilationContext default]
+]
+
+{ #category : #accessing }
 IRBytecodeGenerator >> compilationContext: aCompilationContext [
 	compilationContext := aCompilationContext
 ]
@@ -212,7 +217,7 @@ IRBytecodeGenerator >> compiledMethodWith: trailer [
 IRBytecodeGenerator >> compiledMethodWith: trailer header: header literals: lits [
 	| cm cmClass|
 	"we look up the class in the productionEnvironment"
-	cmClass := compilationContext productionEnvironment at: #CompiledMethod ifAbsent: [ CompiledMethod ].
+	cmClass := self compilationContext productionEnvironment at: #CompiledMethod ifAbsent: [ CompiledMethod ].
 	cm := trailer createMethod: self bytecodes size class: cmClass header: header.
 	(WriteStream with: cm)
 		position: cm initialPC - 1;
@@ -362,8 +367,7 @@ IRBytecodeGenerator >> initialize [
 	additionalLiterals := OCLiteralSet new.
 	forceLongForm := false.
 	"starting label in case one is not provided by client"
-	self label: self newDummySeqId.
-	compilationContext := CompilationContext default.
+	self label: self newDummySeqId
 	
 
 	

--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -339,11 +339,6 @@ IRMethod >> removeEmptyStart [
 
 ]
 
-{ #category : #inlining }
-IRMethod >> removeReturn [
-	self allSequences last removeLast.
-]
-
 { #category : #accessing }
 IRMethod >> sourceInterval [
 	^self sourceNode sourceInterval

--- a/src/OpalCompiler-Core/IRPushClosureCopy.class.st
+++ b/src/OpalCompiler-Core/IRPushClosureCopy.class.st
@@ -13,7 +13,6 @@ Class {
 		'blockSequence',
 		'tempMap',
 		'copiedValues',
-		'lastBlockSequence',
 		'arguments'
 	],
 	#category : #'OpalCompiler-Core-IR-Nodes'
@@ -86,16 +85,6 @@ IRPushClosureCopy >> isJump [
 { #category : #testing }
 IRPushClosureCopy >> isPushClosureCopy [
 	^true
-]
-
-{ #category : #accessing }
-IRPushClosureCopy >> lastBlockSequence [ 
-	^lastBlockSequence
-]
-
-{ #category : #accessing }
-IRPushClosureCopy >> lastBlockSequence: aSequence [
-	lastBlockSequence := aSequence
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -56,13 +56,6 @@ OCAbstractScope >> isMethodScope [
 ]
 
 { #category : #lookup }
-OCAbstractScope >> lookupSelector: name [
-
-	Symbol hasInterned: name ifTrue: [ :sym | ^ sym].
-	^ nil
-]
-
-{ #category : #lookup }
 OCAbstractScope >> lookupVar: name [
 	"search the scope (and the outer scopes) for a variable 'name' and return it"
 	^self subclassResponsibility
@@ -98,12 +91,6 @@ OCAbstractScope >> outerScope: aSemScope [
 
 	outerScope := aSemScope.
 	aSemScope addChild: self. 
-]
-
-{ #category : #lookup }
-OCAbstractScope >> possibleSelectorsFor: string [
-
-	^ Symbol possibleSelectorsFor: string
 ]
 
 { #category : #levels }

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -37,15 +37,6 @@ OCRequestorScope >> findVariable: aBlock ifNone: aNotFound [
 ]
 
 { #category : #lookup }
-OCRequestorScope >> lookupGlobalVar: aName [
-	"consider variables with upper case as global vars resolveable in the outer scope "
-
-	^ aName first isUppercase
-		ifTrue: [ outerScope lookupVar: aName ]
-		ifFalse: [ nil ]
-]
-
-{ #category : #lookup }
 OCRequestorScope >> lookupVar: name [
 
 	name = 'self' ifTrue: [ ^ outerScope lookupVar: name ].

--- a/src/Slot-Core/BlockClosure.extension.st
+++ b/src/Slot-Core/BlockClosure.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #BlockClosure }
 
 { #category : #'*Slot-Core' }
 BlockClosure >> hasTemporaryVariableNamed: aName [
-	^(self tempNames includes: aName)
+	^self tempNames includes: aName
 ]
 
 { #category : #'*Slot-Core' }

--- a/src/Slot-Core/CompiledMethod.extension.st
+++ b/src/Slot-Core/CompiledMethod.extension.st
@@ -2,8 +2,7 @@ Extension { #name : #CompiledMethod }
 
 { #category : #'*Slot-Core' }
 CompiledMethod >> hasTemporaryVariableNamed: aName [
-	^(self tempNames includes: aName)
-	
+	^ self tempNames includes: aName
 ]
 
 { #category : #'*Slot-Core' }

--- a/src/Slot-Core/Context.extension.st
+++ b/src/Slot-Core/Context.extension.st
@@ -2,5 +2,5 @@ Extension { #name : #Context }
 
 { #category : #'*Slot-Core' }
 Context >> hasTemporaryVariableNamed: aName [
-	^(self tempNames includes: aName)
+	^ self tempNames includes: aName
 ]


### PR DESCRIPTION
- IRMethod>>#removeReturn is dead code
- IRPushClosureCopy ivar "lastBlockSequence" is set but never used (and not documented)
- #lookUpSelector:,  possibleSelectorFor: and #lookUpGlobalVar: on semantic scope are not needed
- formatting of #hasTemporaryVariableNamed: (remove () )