### PR TITLE
uffi-add-missing-methods

### DIFF
--- a/src/UnifiedFFI/FFIFunctionArgument.class.st
+++ b/src/UnifiedFFI/FFIFunctionArgument.class.st
@@ -15,6 +15,12 @@ FFIFunctionArgument >> asOldArraySpec [
 	self subclassResponsibility
 ]
 
+{ #category : #accessing }
+FFIFunctionArgument >> defaultReturnOnError [
+
+	^ self resolvedType defaultReturnOnError
+]
+
 { #category : #resolution }
 FFIFunctionArgument >> emitReturnArgument: anIRBuilder context: aContext [
 

--- a/src/UnifiedFFI/FFITypeDeclaration.class.st
+++ b/src/UnifiedFFI/FFITypeDeclaration.class.st
@@ -38,13 +38,19 @@ FFITypeDeclaration >> asOldArraySpec [
 	^ { name . arity }
 ]
 
+{ #category : #accessing }
+FFITypeDeclaration >> defaultReturnOnError [
+
+	^ self resolvedType defaultReturnOnError
+]
+
 { #category : #'emitting code' }
 FFITypeDeclaration >> emitReturn: anIRBuilder resultTempVar: aString context: aContext [
 	
 	^ resolvedType emitReturn: anIRBuilder resultTempVar: aString context: aContext
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 FFITypeDeclaration >> externalTypeWithArity [
 	
 	^ resolvedType externalTypeWithArity


### PR DESCRIPTION
add missing methods (needed to handle callbacks)