### PR TITLE
Integrate-ObservableSlot-as-part-of-VariablesLibrary

### DIFF
--- a/src/VariablesLibrary-Tests/ComputedSlotTest.class.st
+++ b/src/VariablesLibrary-Tests/ComputedSlotTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ComputedSlotTest,
 	#superclass : #SlotSilentTest,
-	#category : #'VariablesLibrary-Tests'
+	#category : #'VariablesLibrary-Tests-Tests'
 }
 
 { #category : #tests }

--- a/src/VariablesLibrary-Tests/HistorySlotTest.class.st
+++ b/src/VariablesLibrary-Tests/HistorySlotTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #HistorySlotTest,
 	#superclass : #SlotSilentTest,
-	#category : #'VariablesLibrary-Tests'
+	#category : #'VariablesLibrary-Tests-Tests'
 }
 
 { #category : #tests }

--- a/src/VariablesLibrary-Tests/InitializedClassVariableTest.class.st
+++ b/src/VariablesLibrary-Tests/InitializedClassVariableTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #InitializedClassVariableTest,
 	#superclass : #SlotSilentTest,
-	#category : #'VariablesLibrary-Tests'
+	#category : #'VariablesLibrary-Tests-Tests'
 }
 
 { #category : #tests }

--- a/src/VariablesLibrary-Tests/InitializedSlotTest.class.st
+++ b/src/VariablesLibrary-Tests/InitializedSlotTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #InitializedSlotTest,
 	#superclass : #SlotSilentTest,
-	#category : #'VariablesLibrary-Tests'
+	#category : #'VariablesLibrary-Tests-Tests'
 }
 
 { #category : #tests }

--- a/src/VariablesLibrary-Tests/LazyClassVariableTest.class.st
+++ b/src/VariablesLibrary-Tests/LazyClassVariableTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #LazyClassVariableTest,
 	#superclass : #SlotSilentTest,
-	#category : #'VariablesLibrary-Tests'
+	#category : #'VariablesLibrary-Tests-Tests'
 }
 
 { #category : #tests }

--- a/src/VariablesLibrary-Tests/LazySlotTest.class.st
+++ b/src/VariablesLibrary-Tests/LazySlotTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #LazySlotTest,
 	#superclass : #SlotSilentTest,
-	#category : #'VariablesLibrary-Tests'
+	#category : #'VariablesLibrary-Tests-Tests'
 }
 
 { #category : #tests }

--- a/src/VariablesLibrary-Tests/ObservablePoint.class.st
+++ b/src/VariablesLibrary-Tests/ObservablePoint.class.st
@@ -1,0 +1,42 @@
+"
+I am a mock point used to test observable properties. I have an observable property x and a non-observable property y.
+
+I use TObservable that has methods to ease the usage of my observable properties.
+"
+Class {
+	#name : #ObservablePoint,
+	#superclass : #Object,
+	#traits : 'TObservable',
+	#classTraits : 'TObservable classTrait',
+	#instVars : [
+		'#x => ObservableSlot',
+		'#y'
+	],
+	#category : #'VariablesLibrary-Tests-Observable'
+}
+
+{ #category : #initialization }
+ObservablePoint >> initialize [
+	super initialize.
+	self class initializeSlots: self.
+]
+
+{ #category : #accessing }
+ObservablePoint >> x [
+	^ x
+]
+
+{ #category : #accessing }
+ObservablePoint >> x: anInteger [ 
+	x := anInteger
+]
+
+{ #category : #accessing }
+ObservablePoint >> y [
+	^ y
+]
+
+{ #category : #accessing }
+ObservablePoint >> y: anInteger [ 
+	y := anInteger
+]

--- a/src/VariablesLibrary-Tests/ObservableSlotTest.class.st
+++ b/src/VariablesLibrary-Tests/ObservableSlotTest.class.st
@@ -1,0 +1,104 @@
+Class {
+	#name : #ObservableSlotTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'point'
+	],
+	#category : #'VariablesLibrary-Tests-Observable'
+}
+
+{ #category : #running }
+ObservableSlotTest >> setUp [
+	super setUp.
+	point := ObservablePoint new
+]
+
+{ #category : #tests }
+ObservableSlotTest >> testChangeInInstanceVariableRaisesEventOnlyOnce [
+	| count |
+	count := 0.
+	point property: #x whenChangedDo: [ count := count + 1 ].
+
+	point x: 17.
+
+	self assert: count equals: 1
+]
+
+{ #category : #tests }
+ObservableSlotTest >> testExplicitNotificationRaisesEventOnlyOnce [
+	| count |
+	count := 0.
+	point property: #x whenChangedDo: [ count := count + 1 ].
+
+	point notifyPropertyChanged: #x.
+
+	self assert: count equals: 1
+]
+
+{ #category : #tests }
+ObservableSlotTest >> testExplicitNotificationRaisesEventWithNewValue [
+	| newValue |
+	point x: 17.
+	point property: #x whenChangedDo: [ :new | newValue := new ].
+
+	point notifyPropertyChanged: #x.
+
+	self assert: newValue equals: 17
+]
+
+{ #category : #tests }
+ObservableSlotTest >> testExplicitNotifyUnexistentPropertyChangedRaisesError [
+	self should: [ point notifyPropertyChanged: #z ] raise: SlotNotFound
+]
+
+{ #category : #tests }
+ObservableSlotTest >> testObservableSlotWorksAsNormalSlot [
+	point x: 17.
+	point y: 299.
+
+	self assert: point x equals: 17.
+	self assert: point y equals: 299
+]
+
+{ #category : #tests }
+ObservableSlotTest >> testSubscribeBlockWithoutParametersIsCalled [
+	| called |
+	called := false.
+	point property: #x whenChangedDo: [ called := true ].
+
+	point x: 17.
+
+	self assert: called
+]
+
+{ #category : #tests }
+ObservableSlotTest >> testSubscribeToChangeRaisesEventWithNewValue [
+	| newValue |
+	point property: #x whenChangedDo: [ :new | newValue := new ].
+
+	point x: 17.
+
+	self assert: newValue equals: 17
+]
+
+{ #category : #tests }
+ObservableSlotTest >> testSubscribeToExistentNonObservablePropertyRaisesError [
+
+	self
+		should: [
+			point
+				property: #y
+				whenChangedDo: [ self fail: 'This event shouldnt have been subscribed at all' ] ]
+		raise: NonObservableSlotError
+]
+
+{ #category : #tests }
+ObservableSlotTest >> testSubscribeToUnexistentPropertyRaisesError [
+
+	self
+		should: [
+			point
+				property: #z
+				whenChangedDo: [ self fail: 'This event shouldnt have been subscribed at all' ] ]
+		raise: SlotNotFound
+]

--- a/src/VariablesLibrary-Tests/WeakClassVariableTest.class.st
+++ b/src/VariablesLibrary-Tests/WeakClassVariableTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #WeakClassVariableTest,
 	#superclass : #SlotSilentTest,
-	#category : #'VariablesLibrary-Tests'
+	#category : #'VariablesLibrary-Tests-Tests'
 }
 
 { #category : #tests }

--- a/src/VariablesLibrary-Tests/WeakSlotTest.class.st
+++ b/src/VariablesLibrary-Tests/WeakSlotTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #WeakSlotTest,
 	#superclass : #SlotSilentTest,
-	#category : #'VariablesLibrary-Tests'
+	#category : #'VariablesLibrary-Tests-Tests'
 }
 
 { #category : #tests }

--- a/src/VariablesLibrary/NonObservableSlotError.class.st
+++ b/src/VariablesLibrary/NonObservableSlotError.class.st
@@ -1,0 +1,8 @@
+"
+I am an error raised when a user try to interact with a slot as an observable slot, but this slot is not observable.
+"
+Class {
+	#name : #NonObservableSlotError,
+	#superclass : #Error,
+	#category : #'VariablesLibrary-Observable'
+}

--- a/src/VariablesLibrary/ObservableSlot.class.st
+++ b/src/VariablesLibrary/ObservableSlot.class.st
@@ -1,0 +1,87 @@
+"
+I am a slot allowing users to register behavior to execute when my value change. 
+
+The classes using me should use TObservable alongside with me. This trait will give them methods to interact with me.
+
+I am able to prevent infinit loop by locking the executions of the actions I store while they are executed. This is useful if two observable slots update each other during their registered actions.
+
+Public API and Key Messages
+--------------------
+
+My users will not interact directly with me but via TObservable.
+Check the class comment of this trait for more information.
+
+Examples
+--------------------
+
+	Object subclass: #ObservablePoint
+		uses: TObservable
+		slots: { #x => ObservableSlot. #y }
+		classVariables: {  }
+		package: 'VariablesLibrary-Tests-Observable'
+ 
+Internal Representation and Key Implementation Points.
+--------------------
+
+	I am wrapping a ObservableValueHolder in order to store the content of the variable and to register the actions to execute when it changes.
+"
+Class {
+	#name : #ObservableSlot,
+	#superclass : #IndexedSlot,
+	#category : #'VariablesLibrary-Observable'
+}
+
+{ #category : #'code generation' }
+ObservableSlot >> emitStore: aMethodBuilder [
+	"generate bytecode for 'varName value: <stackTop>'"
+
+	| temp |
+	temp := Object new.	"we need a unique Object as a temp name"
+	"We pop the value from the stack into a temp to push it back in the right order"
+	aMethodBuilder addTemp: temp.
+	aMethodBuilder storeTemp: temp.
+	aMethodBuilder popTop.
+
+	"Push the value holder into the stack, then the value again, then send"
+	aMethodBuilder pushInstVar: index.
+	aMethodBuilder pushTemp: temp.
+	aMethodBuilder send: #value:
+]
+
+{ #category : #'code generation' }
+ObservableSlot >> emitValue: aMethodBuilder [
+	"Push the value holder into the stack"
+	aMethodBuilder pushInstVar: index.
+	aMethodBuilder send: #value
+]
+
+{ #category : #initialization }
+ObservableSlot >> initialize: anObject [
+	super write: ObservableValueHolder new to: anObject
+]
+
+{ #category : #testing }
+ObservableSlot >> isObservable [
+	^ true
+]
+
+{ #category : #'meta-object-protocol' }
+ObservableSlot >> rawRead: anObject [
+	^ super read: anObject
+]
+
+{ #category : #'meta-object-protocol' }
+ObservableSlot >> read: anObject [
+	^ (self rawRead: anObject) value
+]
+
+{ #category : #'meta-object-protocol' }
+ObservableSlot >> wantsInitialization [
+	^ true
+]
+
+{ #category : #'meta-object-protocol' }
+ObservableSlot >> write: aValue to: anObject [
+	(self rawRead: anObject) ifNotNil: [ :v | v value: aValue ].
+	^ aValue
+]

--- a/src/VariablesLibrary/ObservableValueHolder.class.st
+++ b/src/VariablesLibrary/ObservableValueHolder.class.st
@@ -1,0 +1,102 @@
+"
+I am a class holding any object. Each time the object changes, I execute a list of commands the user might have register in me.
+
+I am used as an internal mecanism of the ObservableSlot. The slot contains one of my instance and is giving me the blocks to execute when the value change. 
+
+I SHOULD NOT BE USED DIRECTLY BUT VIA AN OBSERVABLE SLOT.
+ 
+In addition, infinite loops of propagation are prevented.
+
+Use case: you have two lists A, and B, and you want to keep their selection synchronised. So when A selection changes, you set B selection. But since B selection changes, you set A selection, and so on… 
+
+This case is prevented by the use of a `lock` variable.
+"
+Class {
+	#name : #ObservableValueHolder,
+	#superclass : #Object,
+	#instVars : [
+		'subscriptions',
+		'lock',
+		'value'
+	],
+	#category : #'VariablesLibrary-Observable'
+}
+
+{ #category : #'instance creation' }
+ObservableValueHolder class >> value: contents [
+
+	^ self new
+		rawValue: contents;
+		yourself
+]
+
+{ #category : #initialization }
+ObservableValueHolder >> initialize [
+	super initialize.
+	lock := false.
+	subscriptions := OrderedCollection new
+]
+
+{ #category : #printing }
+ObservableValueHolder >> printOn: aStream [
+	super printOn: aStream.
+	
+	aStream 
+		nextPutAll: '[ '; 
+		print: self value;
+		nextPutAll: ' ]'
+]
+
+{ #category : #accessing }
+ObservableValueHolder >> rawValue: aValue [
+	value := aValue
+]
+
+{ #category : #accessing }
+ObservableValueHolder >> subscriptions [
+	^ subscriptions
+]
+
+{ #category : #accessing }
+ObservableValueHolder >> subscriptions: anObject [
+	subscriptions := anObject
+]
+
+{ #category : #transfert }
+ObservableValueHolder >> transferSubscriptionsTo: aSpValueHolder [
+	aSpValueHolder subscriptions: subscriptions
+]
+
+{ #category : #evaluating }
+ObservableValueHolder >> value [
+	^ value
+]
+
+{ #category : #accessing }
+ObservableValueHolder >> value: anObject [
+	"Handle circular references as explained in the class comment"
+	lock ifTrue: [ ^ self ].
+	
+	lock := true.
+	
+	[ | oldValue |
+	oldValue := value.
+	value := anObject.
+	self valueChanged: oldValue ]
+		ensure: [ lock := false ]
+]
+
+{ #category : #accessing }
+ObservableValueHolder >> valueChanged [
+	self valueChanged: nil
+]
+
+{ #category : #accessing }
+ObservableValueHolder >> valueChanged: oldValue [
+	subscriptions do: [ :block | block cull: self value cull: oldValue ]
+]
+
+{ #category : #enumerating }
+ObservableValueHolder >> whenChangedDo: aBlock [
+	subscriptions add: aBlock
+]

--- a/src/VariablesLibrary/Slot.extension.st
+++ b/src/VariablesLibrary/Slot.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #Slot }
+
+{ #category : #'*VariablesLibrary' }
+Slot >> isObservable [
+	"Return true for observable slots."
+
+	^ false
+]

--- a/src/VariablesLibrary/TObservable.trait.st
+++ b/src/VariablesLibrary/TObservable.trait.st
@@ -1,0 +1,61 @@
+"
+I am a trait allowing one to interact with an ObservableSlot. 
+
+An ObservableSlot allows one to register actions that will be executed when the content of a variable change.
+
+Public API and Key Messages
+--------------------
+
+- #property:whenChangedDo: 		With this method one can declare than when the value in a given observable slot change, an action must be executed. 
+- #property:rawValue: 			With this method a value can be writen without launching any action.
+
+Examples
+--------------------
+
+	| count |
+	count := 0.
+	point := ObservablePoint new.
+	point property: #x whenChangedDo: [ count := count + 1 ].
+
+	point x: 17.
+
+	self assert: count equals: 1
+
+
+"
+Trait {
+	#name : #TObservable,
+	#category : #'VariablesLibrary-Observable'
+}
+
+{ #category : #events }
+TObservable >> notifyPropertyChanged: aName [
+	self flag: #pharoTodo.	"This is used for collections but collections should be managed in a better way and this method removed."
+	(self observablePropertyNamed: aName) valueChanged
+]
+
+{ #category : #events }
+TObservable >> observablePropertyNamed: aName [
+	| slot |
+	slot := self class slotNamed: aName.
+	slot isObservable ifFalse: [ NonObservableSlotError signal: aName ].
+
+	"Obtain the raw value.
+	We need to access the underlying value holder to subscribe to it"
+	^ slot rawRead: self
+]
+
+{ #category : #events }
+TObservable >> property: aName rawValue: anObject [
+	"Write in the slot without announcing it."
+
+	(self observablePropertyNamed: aName) rawValue: anObject
+]
+
+{ #category : #events }
+TObservable >> property: aName whenChangedDo: aBlockClosure [ 
+	
+	"Obtain the raw value.
+	We need to access the underlying value holder to subscribe to it"
+	(self observablePropertyNamed: aName) whenChangedDo: aBlockClosure
+]


### PR DESCRIPTION
Introduce ObservableSlot as part of VariableLibrary. 

This slot is a copy of the spec SpObservableSlot and will replace this one.

This slot comes with tests and I improved the documentation that was started in Spec.