### PR TITLE
Rename-Protocol-methods-into-methodSelectors

### DIFF
--- a/src/Calypso-SystemQueries/ClassDescription.extension.st
+++ b/src/Calypso-SystemQueries/ClassDescription.extension.st
@@ -7,9 +7,7 @@ ClassDescription >> tagsForAllMethods [
 	| allProtocols |
 	allProtocols := self organization protocols reject: [ :each | each name = Protocol unclassified | each isExtensionProtocol ].
 
-	^ allProtocols select: [ :protocol |
-		protocol methods
-			ifEmpty: [ true ]
-			ifNotEmpty: [ :methods | methods anySatisfy: [ :method | self selectors includes: method ] ] ]
+	^ allProtocols
+		select: [ :protocol | protocol methodSelectors ifEmpty: [ true ] ifNotEmpty: [ :methods | methods anySatisfy: [ :method | self selectors includes: method ] ] ]
 		thenCollect: #name
 ]

--- a/src/CodeExport/ProtocolOrganizer.extension.st
+++ b/src/CodeExport/ProtocolOrganizer.extension.st
@@ -2,11 +2,19 @@ Extension { #name : #ProtocolOrganizer }
 
 { #category : #'*CodeExport' }
 ProtocolOrganizer >> stringForFileOut [
-
-	^ String streamContents: [:aStream | 
-			self protocols do: [:p | 
-				aStream << $( << p name printString.
-				p methods do: [:m |
-					aStream << ' ' << m asString ].
-				aStream << $); cr ]]
+	^ String
+		streamContents: [ :aStream | 
+			self protocols
+				do: [ :p | 
+					aStream
+						nextPut: $(;
+						nextPutAll: p name printString.
+					p methodSelectors
+						do: [ :m | 
+							aStream
+								space;
+								nextPutAll: m ].
+					aStream
+						nextPut: $);
+						cr ] ]
 ]

--- a/src/Deprecated80/Protocol.extension.st
+++ b/src/Deprecated80/Protocol.extension.st
@@ -1,0 +1,31 @@
+Extension { #name : #Protocol }
+
+{ #category : #'*Deprecated80' }
+Protocol >> addMethod: aSymbol [
+	self deprecated: 'Use #addMethodSelector: instead' transformWith: '`@receiver addMethod: `@arg' -> '`@receiver addMethodSelector: `@arg'.
+	^ self addMethodSelector: aSymbol
+]
+
+{ #category : #'*Deprecated80' }
+Protocol >> methods [
+	self deprecated: 'Use #methodSelectors instead.' transformWith: '`@receiver methods' -> '`@receiver methodSelectors'.
+	^ self methodSelectors
+]
+
+{ #category : #'*Deprecated80' }
+Protocol >> methods: aCollection [
+	self deprecated: 'Use #methodSelectors: instead.' transformWith: '`@receiver methods: `@arg' -> '`@receiver methodSelectors: `@arg'.
+	^ self methodSelectors: aCollection
+]
+
+{ #category : #'*Deprecated80' }
+Protocol >> removeAllMethods [
+	self deprecated: 'Use #removeAllMethodSelectors instead' transformWith: '`@receiver removeAllMethods' -> '`@receiver removeAllMethodSelectors'.
+	^ self removeAllMethodSelectors
+]
+
+{ #category : #'*Deprecated80' }
+Protocol >> removeMethod: aSymbol [
+	self deprecated: 'Use #removeMethodSelector: instead' transformWith: '`@receiver removeMethod: `@arg' -> '`@receiver removeMethodSelector: `@arg'.
+	^ self removeMethodSelector: aSymbol
+]

--- a/src/Deprecated80/Protocol.extension.st
+++ b/src/Deprecated80/Protocol.extension.st
@@ -19,6 +19,14 @@ Protocol >> methods: aCollection [
 ]
 
 { #category : #'*Deprecated80' }
+Protocol class >> name: nm methods: methods [
+	self
+		deprecated: 'Use #name:methodSelectors: instead'
+		transformWith: '`@receiver name: `@arg1 methods: `@arg2' -> '`@receiver name: `@arg1 methodSelectors: `@arg2'.
+	^ self name: nm methods: methods
+]
+
+{ #category : #'*Deprecated80' }
 Protocol >> removeAllMethods [
 	self deprecated: 'Use #removeAllMethodSelectors instead' transformWith: '`@receiver removeAllMethods' -> '`@receiver removeAllMethodSelectors'.
 	^ self removeAllMethodSelectors

--- a/src/Deprecated80/ProtocolOrganizer.extension.st
+++ b/src/Deprecated80/ProtocolOrganizer.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #ProtocolOrganizer }
+
+{ #category : #'*Deprecated80' }
+ProtocolOrganizer >> allMethods [
+	self deprecated: 'Use #allMethodSelectors instead' transformWith: '`@receiver allMethods' -> '`@receiver allMethodSelectors'.
+	^ self allMethodSelectors
+]

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -62,17 +62,17 @@ ClassOrganizationTest >> testListAtCategoryNamed [
 	self assertEmpty: methods.
 
 	methods := self organization listAtCategoryNamed: 'one'.
-	self assert: methods size = 1.
-	self assert: methods first = #one
+	self assert: methods size equals: 1.
+	self assert: methods first equals: #one
 ]
 
 { #category : #tests }
 ClassOrganizationTest >> testRemoveCategory [
-	self assert: self organization categories size = 2.
+	self assert: self organization categories size equals: 2.
 	self should: [ self organization removeCategory: 'one' ] raise: Error.
 	self organization removeCategory: 'empty'.
-	self assert: self organization categories size = 1.
-	self assert: self organization categories first = 'one'
+	self assert: self organization categories size equals: 1.
+	self assert: self organization categories first equals: 'one'
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/MagnitudeTest.class.st
+++ b/src/Kernel-Tests/MagnitudeTest.class.st
@@ -25,6 +25,7 @@ MagnitudeTest >> testBeBetweenAnd [
 	self assert: (30 beBetween: 20 and: 5) equals: 20.
 ]
 
+{ #category : #'as yet unclassified' }
 MagnitudeTest >> testBetweenAnd [
 	self assert: (3 between: 0 and: 5).
 	self assert: (5.0 between: 5.0 and: 5.0).

--- a/src/Kernel/AllProtocol.class.st
+++ b/src/Kernel/AllProtocol.class.st
@@ -40,15 +40,13 @@ AllProtocol >> isVirtualProtocol [
 ]
 
 { #category : #accessing }
-AllProtocol >> methods [
-
-	^ self protocolOrganizer allMethods
+AllProtocol >> methodSelectors [
+	^ self protocolOrganizer allMethodSelectors
 ]
 
 { #category : #accessing }
 AllProtocol >> name [
-
-	^ (self methods isEmpty and: [ protocolOrganizer protocols isEmpty])
+	^ (self isEmpty and: [ protocolOrganizer protocols isEmpty ])
 		ifTrue: [ self class nullCategory ]
 		ifFalse: [ name ]
 ]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -831,9 +831,9 @@ ClassDescription >> isInstanceSide [
 
 { #category : #testing }
 ClassDescription >> isLocalMethodsProtocol: aProtocol [
-	aProtocol methods ifEmpty: [ ^true ].
-	
-	^aProtocol methods anySatisfy: [ :each | self isLocalSelector: each]
+	aProtocol methodSelectors ifEmpty: [ ^ true ].
+
+	^ aProtocol methodSelectors anySatisfy: [ :each | self isLocalSelector: each ]
 ]
 
 { #category : #testing }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -368,7 +368,7 @@ ClassOrganization >> renameCategory: oldName toBe: newName [
 
 	self notifyOfChangedCategoryFrom: oldName to: newName.
 	"I need to notify also the selector changes, otherwise RPackage will not notice"
-	(self protocolOrganizer protocolNamed: newName) methods 
+	(self protocolOrganizer protocolNamed: newName) methodSelectors 
 		do: [ :each | self notifyOfChangedSelector: each from: oldName to: newName ]
 ]
 

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -48,8 +48,7 @@ ClassOrganization >> allCategories [
 
 { #category : #'backward compatibility' }
 ClassOrganization >> allMethodSelectors [
-	
-	^ protocolOrganizer allMethods
+	^ protocolOrganizer allMethodSelectors
 ]
 
 { #category : #accessing }

--- a/src/Kernel/Protocol.class.st
+++ b/src/Kernel/Protocol.class.st
@@ -6,8 +6,8 @@ Class {
 	#name : #Protocol,
 	#superclass : #Object,
 	#instVars : [
-		'methods',
-		'name'
+		'name',
+		'methodSelectors'
 	],
 	#category : #'Kernel-Protocols'
 }
@@ -58,13 +58,12 @@ Protocol class >> unclassified [
 
 { #category : #accessing }
 Protocol >> addAllMethodsFrom: aProtocol [
-
-	aProtocol methods do: [ :each | self addMethod: each ].
+	aProtocol methodSelectors do: [ :each | self addMethodSelector: each ]
 ]
 
 { #category : #accessing }
-Protocol >> addMethod: aSymbol [
-	^ methods add: aSymbol
+Protocol >> addMethodSelector: aSymbol [
+	^ methodSelectors add: aSymbol
 ]
 
 { #category : #private }
@@ -80,7 +79,7 @@ Protocol >> canBeRenamed [
 { #category : #testing }
 Protocol >> includesSelector: selector [
 
-	^ methods includes: selector
+	^ methodSelectors includes: selector
 ]
 
 { #category : #initialization }
@@ -88,14 +87,13 @@ Protocol >> initialize [
 
 	super initialize.
 
-	methods := IdentitySet new.
+	methodSelectors := IdentitySet new.
 	name := self class defaultName.
 ]
 
 { #category : #testing }
 Protocol >> isEmpty [
-
-	^ self methods isEmpty
+	^ self methodSelectors isEmpty
 ]
 
 { #category : #testing }
@@ -110,15 +108,13 @@ Protocol >> isVirtualProtocol [
 ]
 
 { #category : #accessing }
-Protocol >> methods [
-
-	^ methods
+Protocol >> methodSelectors [
+	^ methodSelectors
 ]
 
 { #category : #accessing }
-Protocol >> methods: anObject [
-	
-	methods := anObject
+Protocol >> methodSelectors: anObject [
+	methodSelectors := anObject
 ]
 
 { #category : #accessing }
@@ -134,26 +130,23 @@ Protocol >> name: anObject [
 
 { #category : #printing }
 Protocol >> printOn: aStream [
-
-	aStream 
+	aStream
 		nextPutAll: self class name;
 		nextPutAll: ' (';
 		nextPutAll: self name;
 		nextPutAll: ') - ';
-		print: self methods size;
+		print: self methodSelectors size;
 		nextPutAll: ' selector(s)'
 ]
 
 { #category : #accessing }
-Protocol >> removeAllMethods [
-
-	^ methods removeAll.
+Protocol >> removeAllMethodSelectors [
+	^ methodSelectors removeAll
 ]
 
 { #category : #accessing }
-Protocol >> removeMethod: aSymbol [
-
-	^ methods remove: aSymbol
+Protocol >> removeMethodSelector: aSymbol [
+	^ methodSelectors remove: aSymbol
 ]
 
 { #category : #accessing }

--- a/src/Kernel/Protocol.class.st
+++ b/src/Kernel/Protocol.class.st
@@ -37,10 +37,9 @@ Protocol class >> name: nm [
 ]
 
 { #category : #'instance creation' }
-Protocol class >> name: nm methods: methods [ 
-
+Protocol class >> name: nm methodSelectors: methods [
 	^ self new
-		methods: methods;
+		methodSelectors: methods;
 		name: nm asSymbol;
 		yourself
 ]

--- a/src/Kernel/ProtocolOrganizer.class.st
+++ b/src/Kernel/ProtocolOrganizer.class.st
@@ -33,9 +33,8 @@ ProtocolOrganizer >> addProtocolNamed: aName [
 ]
 
 { #category : #accessing }
-ProtocolOrganizer >> allMethods [
-
-	^ self protocols flatCollect: [:p | p methods ].
+ProtocolOrganizer >> allMethodSelectors [
+	^ self protocols flatCollect: [ :p | p methodSelectors ]
 ]
 
 { #category : #accessing }
@@ -57,19 +56,16 @@ ProtocolOrganizer >> allProtocolsNames [
 ]
 
 { #category : #'protocol - adding' }
-ProtocolOrganizer >> classify: aSymbol inProtocolNamed: aProtocolName [ 
+ProtocolOrganizer >> classify: aSymbol inProtocolNamed: aProtocolName [
 	| name protocol |
-	
 	name := aProtocolName.
-	name = allProtocol name
-		ifTrue: [ name := Protocol unclassified ].
-		
+	name = allProtocol name ifTrue: [ name := Protocol unclassified ].
+
 	"maybe here we should check if this method already belong to another protocol"
-	(self protocolsOfSelector: aSymbol) do: [:p | p removeMethod: aSymbol ].
+	(self protocolsOfSelector: aSymbol) do: [ :p | p removeMethodSelector: aSymbol ].
 	protocol := self getProtocolNamed: name ifNone: [ self addProtocolNamed: name ].
-	
-	protocol addMethod: aSymbol
-	
+
+	protocol addMethodSelector: aSymbol
 ]
 
 { #category : #private }
@@ -119,10 +115,9 @@ ProtocolOrganizer >> initialize [
 
 { #category : #'backward compatibility' }
 ProtocolOrganizer >> methodsInProtocolNamed: aName [
-	aName = AllProtocol defaultName 
-		ifTrue: [ ^ self allMethods ].
+	aName = AllProtocol defaultName ifTrue: [ ^ self allMethodSelectors ].
 
-	^ (self protocolNamed: aName) methods
+	^ (self protocolNamed: aName) methodSelectors
 ]
 
 { #category : #private }
@@ -133,7 +128,7 @@ ProtocolOrganizer >> moveMethodsFrom: fromProtocolNamed to: toProtocolNamed [
 	toProtocol := self protocolNamed: toProtocolNamed.
 	
 	toProtocol addAllMethodsFrom: fromProtocol.
-	fromProtocol removeAllMethods.
+	fromProtocol removeAllMethodSelectors.
 	
 	^ toProtocol.
 ]
@@ -190,7 +185,7 @@ ProtocolOrganizer >> removeEmptyProtocols [
 { #category : #accessing }
 ProtocolOrganizer >> removeMethod: aSymbol [
 
-	(self protocolsOfSelector: aSymbol) do: [ :p | p removeMethod: aSymbol ]
+	(self protocolsOfSelector: aSymbol) do: [ :p | p removeMethodSelector: aSymbol ]
 ]
 
 { #category : #'protocol - removing' }

--- a/src/Kernel/ProtocolOrganizer.class.st
+++ b/src/Kernel/ProtocolOrganizer.class.st
@@ -81,13 +81,12 @@ ProtocolOrganizer >> extensionProtocols [
 
 { #category : #importing }
 ProtocolOrganizer >> fromSpec: aSpec [
-	
-	aSpec do: [:spec || name methods |
-		name := spec first asSymbol.
-		methods := spec allButFirst asSet.
-		self addProtocol: (Protocol 
-								name: name
-								methods: methods) ]
+	aSpec
+		do: [ :spec | 
+			| name methods |
+			name := spec first asSymbol.
+			methods := spec allButFirst asSet.
+			self addProtocol: (Protocol name: name methodSelectors: methods) ]
 ]
 
 { #category : #protocol }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -528,7 +528,7 @@ RPackageOrganizer >> initializeMethodsFor: aBehavior [
 	(aBehavior organization protocols
 		select: [ :each | each isExtensionProtocol not ])
 		do: [ :eachProtocol | 
-			 (eachProtocol methods 
+			 (eachProtocol methodSelectors 
 				select: [ :eachSelector | (aBehavior >> eachSelector) origin = aBehavior ])
 				do: [ :eachSelector | package addMethod: (aBehavior >> eachSelector) ] ]
 ]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -489,7 +489,7 @@ RPackageOrganizer >> initializeExtensionsFor: aBehavior protocol: aProtocol [
 	package := self packageMatchingExtensionName: protocolName.
 	package ifNil: [
 		package := self basicRegisterPackage: (self packageClass named: protocolName) ].
-	nonTraitMethods := aProtocol methods 
+	nonTraitMethods := aProtocol methodSelectors 
 		select: [ :eachSelector | (aBehavior >> eachSelector) origin = aBehavior ].
 	nonTraitMethods ifEmpty:[^ self].
 	self registerExtendingPackage: package forClass: aBehavior.

--- a/src/Reflectivity/MetaLinkInstaller.class.st
+++ b/src/Reflectivity/MetaLinkInstaller.class.st
@@ -135,14 +135,14 @@ MetaLinkInstaller >> findSubNode: node in: methodNode [
 { #category : #initialization }
 MetaLinkInstaller >> initialize [
 	anonSubclassesBuilder := MetaLinkAnonymousClassBuilder new.
-	linksRegistry := MetaLinkRegistry new. 
+	linksRegistry := MetaLinkRegistry new.
 	linkToNodesMapper := MetaLinkNodesMapper new.
 	superJumpLinks := OrderedCollection new.
-	
-	SystemAnnouncer uniqueInstance weak subscribe: MetalinkChanged send: #metalinkChanged: to: self.
-	SystemAnnouncer uniqueInstance weak subscribe: MethodModified send: #methodChanged: to: self.
-	SystemAnnouncer uniqueInstance weak subscribe: MethodRemoved send: #methodRemoved: to: self.
-	SystemAnnouncer uniqueInstance weak subscribe: MethodAdded  send: #methodAdded: to: self
+
+	SystemAnnouncer uniqueInstance weak when: MetalinkChanged send: #metalinkChanged: to: self.
+	SystemAnnouncer uniqueInstance weak when: MethodModified send: #methodChanged: to: self.
+	SystemAnnouncer uniqueInstance weak when: MethodRemoved send: #methodRemoved: to: self.
+	SystemAnnouncer uniqueInstance weak when: MethodAdded send: #methodAdded: to: self
 ]
 
 { #category : #installation }

--- a/src/Shift-ClassBuilder/ClassOrganization.extension.st
+++ b/src/Shift-ClassBuilder/ClassOrganization.extension.st
@@ -4,5 +4,5 @@ Extension { #name : #ClassOrganization }
 ClassOrganization >> copyFrom: otherOrganization [
 	commentRemoteString := otherOrganization commentRemoteString.
 	commentStamp := otherOrganization commentStamp.
-	otherOrganization protocols do: [ :p | p methods do: [ :m | protocolOrganizer classify: m inProtocolNamed: p name ] ].
+	otherOrganization protocols do: [ :p | p methodSelectors do: [ :m | protocolOrganizer classify: m inProtocolNamed: p name ] ]
 ]


### PR DESCRIPTION
The API of Protocol is, currently, misleading. A protocol has a method #methods but this one does not return methods but selectors. 

In this PR I updated the API to #methodSelectors to be explicit.