### PR TITLE
4883-FileSystemResolver-should-let-the-user-add-its-own-origins

### DIFF
--- a/src/FileSystem-Core/FileSystemResolver.class.st
+++ b/src/FileSystem-Core/FileSystemResolver.class.st
@@ -59,7 +59,7 @@ FileSystemResolver >> resolveString: aString [
 
 { #category : #resolving }
 FileSystemResolver >> supportedOrigins [
-	^ #()
+	^ (Pragma allNamed: #origin from: self class to: FileSystemResolver) collect: #methodSelector
 ]
 
 { #category : #resolving }

--- a/src/FileSystem-Core/MacOSResolver.class.st
+++ b/src/FileSystem-Core/MacOSResolver.class.st
@@ -32,18 +32,15 @@ MacOSResolver >> preferences [
 	^ self home / 'Library' / 'Preferences'
 ]
 
-{ #category : #resolving }
-MacOSResolver >> supportedOrigins [
-	^ super supportedOrigins , #(userApplicationSupport systemApplicationSupport systemLibrary userLibrary)
-]
-
 { #category : #origins }
 MacOSResolver >> systemApplicationSupport [
+	<origin>
 	^ self systemLibrary / 'Application Support'
 ]
 
 { #category : #origins }
 MacOSResolver >> systemLibrary [
+	<origin>
 	^  FileSystem disk root / 'Library'
 ]
 
@@ -54,10 +51,12 @@ MacOSResolver >> temp [
 
 { #category : #origins }
 MacOSResolver >> userApplicationSupport [
+	<origin>
 	^self userLibrary / 'Application Support'
 ]
 
 { #category : #origins }
 MacOSResolver >> userLibrary [
+	<origin>
 	^  self home / 'Library'
 ]

--- a/src/FileSystem-Core/PlatformResolver.class.st
+++ b/src/FileSystem-Core/PlatformResolver.class.st
@@ -29,7 +29,9 @@ PlatformResolver class >> primitiveGetUntrustedUserDirectory [
 { #category : #origins }
 PlatformResolver >> cache [
 	"Operating Systems often define standard locations for a personal cache directory. The cache directory is a user-specific non-essential (cached) place where data should be written."
-	self subclassResponsibility
+
+	<origin>
+	^ self subclassResponsibility
 ]
 
 { #category : #private }
@@ -60,31 +62,38 @@ PlatformResolver >> directoryFromEnvVariableNamed: aString or: aBlock [
 
 { #category : #origins }
 PlatformResolver >> documents [
+	<origin>
 	^ self home / 'Documents'
 ]
 
 { #category : #origins }
 PlatformResolver >> downloads [
+	<origin>
 	^ self home / 'Downloads'
+]
+
+{ #category : #'as yet unclassified' }
+PlatformResolver >> googleDrive [
+	<origin>
+	^ self home / 'Google Drive'
 ]
 
 { #category : #origins }
 PlatformResolver >> home [
+	<origin>
 	^ self subclassResponsibility
 ]
 
 { #category : #origins }
 PlatformResolver >> preferences [
+	<origin>
 	^ self subclassResponsibility
-]
-
-{ #category : #resolving }
-PlatformResolver >> supportedOrigins [
-	^ #(home desktop documents downloads preferences cache temp)
 ]
 
 { #category : #origins }
 PlatformResolver >> temp [
 	"Where to put files that are not supposed to last long"
-	^ self subclassResponsibility 
+
+	<origin>
+	^ self subclassResponsibility
 ]

--- a/src/FileSystem-Core/SystemResolver.class.st
+++ b/src/FileSystem-Core/SystemResolver.class.st
@@ -41,36 +41,37 @@ SystemResolver class >> userLocalDirectory: aFileReference [
 
 { #category : #origins }
 SystemResolver >> changes [
+	<origin>
 	^ self image withExtension: Smalltalk changesSuffix
 ]
 
 { #category : #origins }
 SystemResolver >> image [
+	<origin>
 	^ self resolveString: Smalltalk imagePath
 ]
 
 { #category : #origins }
 SystemResolver >> imageDirectory [
+	<origin>
 	^ self image parent
 ]
 
 { #category : #origins }
 SystemResolver >> localDirectory [ 
+	<origin>
 	^ self class userLocalDirectory 
 		ifNil: [ (self imageDirectory / self class defaultLocalDirectoryName) ensureCreateDirectory ]
 ]
 
-{ #category : #resolving }
-SystemResolver >> supportedOrigins [
-	^ #(image imageDirectory changes vmBinary vmDirectory workingDirectory localDirectory)
-]
-
 { #category : #origins }
 SystemResolver >> vmBinary [
+	<origin>
 	^ self resolveString: Smalltalk vm fullPath
 ]
 
 { #category : #origins }
 SystemResolver >> vmDirectory [
+	<origin>
 	^ self resolveString: Smalltalk vm directory
 ]

--- a/src/FileSystem-Core/UnixResolver.class.st
+++ b/src/FileSystem-Core/UnixResolver.class.st
@@ -46,11 +46,6 @@ UnixResolver >> preferences [
 	^ self directoryFromEnvVariableNamed: 'XDG_CONFIG_HOME' or: [ self home / '.config' ]
 ]
 
-{ #category : #resolving }
-UnixResolver >> supportedOrigins [
-	^ super supportedOrigins , #( userData )
-]
-
 { #category : #origins }
 UnixResolver >> temp [
 	^ '/tmp' asFileReference
@@ -58,6 +53,7 @@ UnixResolver >> temp [
 
 { #category : #origins }
 UnixResolver >> userData [
+	<origin>
 	^ self directoryFromEnvVariableNamed: 'XDG_DATA_HOME' or: [ self home / '.local' / 'share' ]
 ]
 

--- a/src/FileSystem-Tests-Core/FileSystemResolverTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemResolverTest.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #testing }
 FileSystemResolverTest class >> isAbstract [
-	^ self name = #FileSystemResolverTest
+	^ self = FileSystemResolverTest
 ]
 
 { #category : #asserting }

--- a/src/FileSystem-Tests-Core/InteractiveResolverTest.class.st
+++ b/src/FileSystem-Tests-Core/InteractiveResolverTest.class.st
@@ -27,8 +27,7 @@ InteractiveResolverTest >> testCached [
 
 { #category : #tests }
 InteractiveResolverTest >> testNew [
-	[self assertOriginResolves: #home]
+	[ self assertOriginResolves: #home ]
 		on: ResolutionRequest
-		do: [:req | req resume: self home].
-	
+		do: [ :req | req resume: self home ]
 ]

--- a/src/FileSystem-Tests-Core/PlatformResolverTest.class.st
+++ b/src/FileSystem-Tests-Core/PlatformResolverTest.class.st
@@ -18,6 +18,17 @@ PlatformResolverTest >> testCache [
 ]
 
 { #category : #tests }
+PlatformResolverTest >> testCanAddOrigin [
+	[ resolver class
+		compile:
+			'newOriginForTest
+	<origin>
+	^ self home / ''toto'''.
+	self assert: (resolver supportedOrigins includes: #newOriginForTest) ]
+		ensure: [ resolver class compiledMethodAt: #newOriginForTest ifPresent: [ :m | m removeFromSystem ] ]
+]
+
+{ #category : #tests }
 PlatformResolverTest >> testHome [
 	| home |
 	home := self assertOriginResolves: #home.

--- a/src/FileSystem-Tests-Core/PlatformResolverTest.class.st
+++ b/src/FileSystem-Tests-Core/PlatformResolverTest.class.st
@@ -14,8 +14,7 @@ PlatformResolverTest >> createResolver [
 
 { #category : #tests }
 PlatformResolverTest >> testCache [
-	| cache |
-	cache := self assertOriginResolves: #cache
+	self assertOriginResolves: #cache
 ]
 
 { #category : #tests }

--- a/src/FileSystem-Tests-Core/SystemResolverTest.class.st
+++ b/src/FileSystem-Tests-Core/SystemResolverTest.class.st
@@ -31,8 +31,7 @@ SystemResolverTest >> testImageDirectory [
 SystemResolverTest >> testLocalDirectory [
 	| reference |
 	reference := resolver resolve: #localDirectory.
-	self assert: (reference isKindOf: FileReference).
-	^ reference
+	self assert: (reference isKindOf: FileReference)
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Use pragma to collect the supported origins of the file system resolvers. 

This allows one to add its own origins to the resolvers.