### PR TITLE
RBRefersToClassRule-should-ignore-isAbstract-methods

### DIFF
--- a/src/GeneralRules-Tests/RBAbstractMockToTestRefersToClassRule.class.st
+++ b/src/GeneralRules-Tests/RBAbstractMockToTestRefersToClassRule.class.st
@@ -1,0 +1,23 @@
+"
+I am a Mock to test RBRefersToClassRule.
+"
+Class {
+	#name : #RBAbstractMockToTestRefersToClassRule,
+	#superclass : #Object,
+	#category : #'GeneralRules-Tests-Mock'
+}
+
+{ #category : #testing }
+RBAbstractMockToTestRefersToClassRule class >> isAbstract [
+	^ self = RBAbstractMockToTestRefersToClassRule
+]
+
+{ #category : #helpers }
+RBAbstractMockToTestRefersToClassRule >> methodHardCodingClass [
+	^ RBAbstractMockToTestRefersToClassRule
+]
+
+{ #category : #helpers }
+RBAbstractMockToTestRefersToClassRule >> methodWithoutCodingClass [
+	^ 42
+]

--- a/src/GeneralRules-Tests/RBGlobalVariableRuleTest.class.st
+++ b/src/GeneralRules-Tests/RBGlobalVariableRuleTest.class.st
@@ -40,8 +40,7 @@ RBGlobalVariableRuleTest >> methodUsesGlobal2 [
 
 { #category : #tests }
 RBGlobalVariableRuleTest >> testTheRuleCanCheckMethodsWithDifferentKindsOfLiterals [
-	self assert: (RBGlobalVariablesUsage new check: self class>>#methodNotUsesGlobal2)
-		isEmpty  
+	self assertEmpty: (RBGlobalVariablesUsage new check: self class >> #methodNotUsesGlobal2)
 ]
 
 { #category : #tests }
@@ -51,7 +50,5 @@ RBGlobalVariableRuleTest >> testTheRuleOnlyDetect2MethodsWithGlobalVariables [
 
 { #category : #tests }
 RBGlobalVariableRuleTest >> testTheRuleOnlyMethodUsesGlobal1And2 [
-	self
-		assert: (self applyingCritiques collect: #selector) asSet
-		equals: {#methodUsesGlobal . #methodUsesGlobal2} asSet
+	self assertCollection: (self applyingCritiques collect: #selector) hasSameElements: {#methodUsesGlobal . #methodUsesGlobal2}
 ]

--- a/src/GeneralRules-Tests/RBRefersToClassRuleTest.class.st
+++ b/src/GeneralRules-Tests/RBRefersToClassRuleTest.class.st
@@ -1,0 +1,28 @@
+"
+A RBRefersToClassRuleTest is a test class for testing the behavior of RBRefersToClassRule
+"
+Class {
+	#name : #RBRefersToClassRuleTest,
+	#superclass : #TestCase,
+	#category : #'GeneralRules-Tests-Migrated'
+}
+
+{ #category : #helpers }
+RBRefersToClassRuleTest >> newRule [
+	^ RBRefersToClassRule new
+]
+
+{ #category : #tests }
+RBRefersToClassRuleTest >> testIsAbstractNotDetected [
+	self assertEmpty: (self newRule check: RBAbstractMockToTestRefersToClassRule class>> #isAbstract)
+]
+
+{ #category : #tests }
+RBRefersToClassRuleTest >> testRuleDetectHardCodedClass [
+	self denyEmpty: (self newRule check: RBAbstractMockToTestRefersToClassRule >> #methodHardCodingClass)
+]
+
+{ #category : #tests }
+RBRefersToClassRuleTest >> testRuleWithoutHardCodedClass [
+	self assertEmpty: (self newRule check: RBAbstractMockToTestRefersToClassRule >> #methodWithoutCodingClass)
+]

--- a/src/GeneralRules-Tests/RBSmalllintTest.class.st
+++ b/src/GeneralRules-Tests/RBSmalllintTest.class.st
@@ -14,7 +14,7 @@ RBSmalllintTest >> assertEnvironment: anEnvironment hasAllClassesOfTheResult: cr
 
 	critiques do: [ :crit |
 		| target |
-		target := crit sourceAnchor entity.
+		target := crit entity.
 		self assert: target isClass.
 		self assert: (anEnvironment includesClass: target) ]
 ]
@@ -24,7 +24,7 @@ RBSmalllintTest >> assertEnvironment: anEnvironment hasAllMethodsOfTheResult: cr
 
 	critiques do: [ :crit |
 		| target |
-		target := crit sourceAnchor entity.
+		target := crit entity.
 		self assert: target isCompiledMethod.
 		self assert: (anEnvironment includesMethod: target) ]
 ]
@@ -49,14 +49,14 @@ RBSmalllintTest >> assertIsValidRule: aRule [
 RBSmalllintTest >> assertResult: critiques hasAllClassesInEnvironment: anEnvironment [
 	anEnvironment classesDo: [ :class |
 		self assert: (critiques anySatisfy: [ :crit |
-			crit sourceAnchor entity instanceSide = class instanceSide ]) ]
+			crit entity instanceSide = class instanceSide ]) ]
 ]
 
 { #category : #asserting }
 RBSmalllintTest >> assertResult: critiques hasAllMethodsInEnvironment: anEnvironment [
 	anEnvironment methodsDo: [ :method |
 		self assert: (critiques anySatisfy: [ :crit |
-			crit sourceAnchor entity = method ]) ]
+			crit entity = method ]) ]
 ]
 
 { #category : #private }

--- a/src/GeneralRules/RBRefersToClassRule.class.st
+++ b/src/GeneralRules/RBRefersToClassRule.class.st
@@ -23,6 +23,9 @@ RBRefersToClassRule class >> uniqueIdentifierName [
 { #category : #running }
 RBRefersToClassRule >> basicCheck: aMethod [
 	| class |
+	"The class method #isAbstract needs to explicitly hardcode class references. So we do not criticize this."
+	(aMethod methodClass isClassSide and: [ aMethod selector = #isAbstract ]) ifTrue: [ ^ false ].
+
 	class := aMethod methodClass instanceSide.
 	^ aMethod hasLiteral: (class environment associationAt: class name ifAbsent: [ ^ false ])
 ]


### PR DESCRIPTION
#isAbstract methods need to hardcode classes to be useful in hierarchy. RBRefersToClussRule should not declare those methods as failures to the rule. 

This PR also add tests to this rule.