### PR TITLE
4843-Semantic-Analysis-add-a-temp-variable-for-the-Temp-Vector-Copied-Var

### DIFF
--- a/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
@@ -68,6 +68,8 @@ OCASTClosureAnalyzer >> visitVariableNode: aVariableNode [
 	aVariableNode adaptToSemanticNode.
 	aVariableNode isTemp ifFalse: [^self].
 	var := self lookupAndFixBinding: aVariableNode.
-	var isTempVectorTemp ifTrue: [scope addCopyingTempToAllScopesUpToDefVectorNamed: var vectorName].
+	var isTempVectorTemp ifTrue: [ | vectorVar |
+		vectorVar := scope lookupVar: var vectorName.
+		scope addCopyingTempToAllScopesUpToDefTemp: vectorVar].
 	var isCopying ifTrue: [scope addCopyingTempToAllScopesUpToDefTemp: var].
 ]

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -145,7 +145,7 @@ OCAbstractMethodScope >> localTemps [
 			self copiedVars
 				do: [ :var | 
 					var isStoringTempVector
-						ifTrue: [ var tempVectorForTempStoringIt
+						ifTrue: [ var originalVar scope tempVector
 								do: [ :tempVectorVars | str nextPut: tempVectorVars ] ] ].
 			str nextPutAll: self tempVars ]
 ]

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -9,7 +9,8 @@ Class {
 		'tempVars',
 		'copiedVars',
 		'tempVector',
-		'id'
+		'id',
+		'tempVectorVar'
 	],
 	#category : #'OpalCompiler-Core-Semantics'
 }
@@ -27,29 +28,12 @@ OCAbstractMethodScope >> addCopyingTemp: aTempVar [
 ]
 
 { #category : #'temp vars - copying' }
-OCAbstractMethodScope >> addCopyingTempNamed: name [
-	copiedVars add: (OCCopyingTempVariable new
-			name: name;
-			scope: self;
-			yourself).
-	^copiedVars
-]
-
-{ #category : #'temp vars - copying' }
 OCAbstractMethodScope >> addCopyingTempToAllScopesUpToDefTemp: aVar [
 
 	(self hasCopyingTempNamed: aVar name) ifFalse: [self addCopyingTemp: aVar].
-	tempVars at: aVar name ifPresent: [:v | ^ self].
+	self = aVar scope ifTrue: [^ self].
 	^ self outerScope addCopyingTempToAllScopesUpToDefTemp: aVar.
 				
-]
-
-{ #category : #'temp vars - copying' }
-OCAbstractMethodScope >> addCopyingTempToAllScopesUpToDefVectorNamed: aName [
-		
-	(self hasCopyingTempNamed: aName) ifFalse: [self addCopyingTempNamed: aName].
-	self tempVectorName = aName ifTrue: [^ self].
-	^ self outerScope addCopyingTempToAllScopesUpToDefVectorNamed: aName.
 ]
 
 { #category : #'temp vars' }
@@ -177,10 +161,12 @@ OCAbstractMethodScope >> lookupDefiningContextForVariable: var startingFrom: aCo
 
 { #category : #lookup }
 OCAbstractMethodScope >> lookupVar: name [
+	
 	copiedVars at: name ifPresent: [:v | ^ v].
-	tempVector  at: name ifPresent: [:v | ^ v].
+	tempVector at: name ifPresent: [:v | ^ v].
 	tempVars at: name ifPresent: [:v | ^ v].
 	name = 'thisContext' ifTrue: [^ thisContextVar].
+	name = self tempVectorName ifTrue: [ ^ self tempVectorVar ].
 	^self outerScope lookupVar: name
 	
 ]
@@ -285,4 +271,12 @@ OCAbstractMethodScope >> tempVectorName [
 	"the name of the tempVector is not a valid name of a temp variable
 	 This way we avoid name clashes "
 	^'0vector', id asString
+]
+
+{ #category : #'temp vars - vector' }
+OCAbstractMethodScope >> tempVectorVar [
+	^ tempVectorVar ifNil: [ tempVectorVar := OCTempVariable new
+			name: self tempVectorName;
+			scope: self;
+			yourself]
 ]

--- a/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
@@ -12,12 +12,6 @@ Class {
 	#category : #'OpalCompiler-Core-Semantics'
 }
 
-{ #category : #debugging }
-OCCopyingTempVariable >> indexInTempVectorFromIR: aName [
-	^(self tempVectorDefinitionScopeForTempStoringIt node irInstruction tempVectorNamed: name) 
-		indexForVarNamed: aName
-]
-
 { #category : #testing }
 OCCopyingTempVariable >> isCopying [
 	^true
@@ -31,27 +25,6 @@ OCCopyingTempVariable >> originalVar [
 { #category : #accessing }
 OCCopyingTempVariable >> originalVar: anObject [
 	originalVar := anObject
-]
-
-{ #category : #'temp vector' }
-OCCopyingTempVariable >> tempVectorDefinitionScopeForTempStoringIt [
-	"If I am stroring a temp Vector, this method returns the definition scope"
-	
-	| searchScope |
-	self isStoringTempVector ifFalse: [^nil].
-	searchScope := scope.
-	
-	[searchScope isInstanceScope or: [searchScope tempVectorName = name]] 
-		whileFalse: [searchScope := searchScope outerScope].
-	searchScope isInstanceScope 
-		ifTrue: [ ^nil] "not found"
-		ifFalse: [^ searchScope ]
-]
-
-{ #category : #'temp vector' }
-OCCopyingTempVariable >> tempVectorForTempStoringIt [
-	"If I am stroring a temp Vector, this method returns this vector"
-	^self tempVectorDefinitionScopeForTempStoringIt tempVector
 ]
 
 { #category : #debugging }

--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -61,6 +61,12 @@ OCTempVariable >> indexFromIR [
 	^index ifNil: [index := scope indexFromIRForVarNamed: name]
 ]
 
+{ #category : #debugging }
+OCTempVariable >> indexInTempVectorFromIR: aName [
+	"if I am storing  temp vector, return the index of var name"
+	^(scope node irInstruction tempVectorNamed: name) indexForVarNamed: aName
+]
+
 { #category : #initialization }
 OCTempVariable >> initialize [
 	super initialize.

--- a/src/OpalCompiler-Core/OCVectorTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCVectorTempVariable.class.st
@@ -61,12 +61,12 @@ OCVectorTempVariable >> readVectorFromContext: aContext scope: contextScope [
 	so we need to read possibly from a context above aContext"
 	theVector := tempVectorVar readFromContext: aContext scope: contextScope.
 	"Cache the index in the temp vecor (for speed and easy debugging)"
-	index := index ifNil: [ tempVectorVar indexInTempVectorFromIR: name ].
+	index := index ifNil: [ tempVectorVar originalVar indexInTempVectorFromIR: name ].
 	"We can call this method on a context in any state, e.g. even when the copied var is not yet initialized.
 	In this case, we lookup in the outer context with the corresponding outer scope"
 	^ theVector ifNil: [ aContext outerContext 
 		"but there might be no outer context, so in that case, just return an empty array of the correct size"
-			ifNil: [ Array new: tempVectorVar tempVectorForTempStoringIt size ]
+			ifNil: [ Array new: tempVectorVar originalVar scope tempVector size ]
 			ifNotNil: [: ctxt | self readVectorFromContext: ctxt scope: contextScope outerScope ]]
 ]
 
@@ -84,7 +84,7 @@ OCVectorTempVariable >> vectorName: anObject [
 OCVectorTempVariable >> vectorOffset [
 	"Temps that are stored in a temp vector have a unique index in the vector.
 	 We first lookup the temp vector sem var by name and then get the index from the IR"
-	^index ifNil: [index := (scope lookupVar: vectorName) indexInTempVectorFromIR: name]
+	^index ifNil: [index := (scope lookupVar: vectorName) originalVar indexInTempVectorFromIR: name]
 ]
 
 { #category : #debugging }


### PR DESCRIPTION
this change makes sure that the copied vars of the temp vector are standard copied vars. This allows us to easily find their definiton scope (this will be used in a second step) and in addition simplify the code a bitfixes #4843