### PR TITLE
Completion: Reduce Copying of intermediate collections

### DIFF
--- a/src/NECompletion/AlphabeticSorter.class.st
+++ b/src/NECompletion/AlphabeticSorter.class.st
@@ -16,5 +16,5 @@ AlphabeticSorter class >> kind [
 { #category : #description }
 AlphabeticSorter class >> sortCompletionList: aList [
 
-	^ aList sorted.
+	^ aList asOrderedCollection sort
 ]

--- a/src/NECompletion/CompletionModel.class.st
+++ b/src/NECompletion/CompletionModel.class.st
@@ -146,7 +146,7 @@ CompletionModel >> notEmpty [
 { #category : #accessing }
 CompletionModel >> sortList: aList [
 	"this is where the sorting strategy is set"
-	^ sorter sortCompletionList: aList asOrderedCollection
+	^ sorter sortCompletionList: aList
 ]
 
 { #category : #accessing }

--- a/src/NECompletion/CompletionProducerVisitor.class.st
+++ b/src/NECompletion/CompletionProducerVisitor.class.st
@@ -7,6 +7,9 @@ Class {
 	#instVars : [
 		'currentClass'
 	],
+	#classInstVars : [
+		'aCollection'
+	],
 	#category : #'NECompletion-New'
 }
 
@@ -29,8 +32,7 @@ CompletionProducerVisitor >> methodNames [
 
 { #category : #utilities }
 CompletionProducerVisitor >> select: aCollection beginningWith: aString [
-	"Set withAll: is needed to convert potential IdentitySets to regular Sets"
-	^ Set withAll: (aCollection select: [ :each | each beginsWith: aString asString ])
+	^ aCollection select: [ :each | each beginsWith: aString asString ]
 ]
 
 { #category : #visiting }

--- a/src/NECompletion/ReverseAlphabeticSorter.class.st
+++ b/src/NECompletion/ReverseAlphabeticSorter.class.st
@@ -16,5 +16,5 @@ ReverseAlphabeticSorter class >> kind [
 { #category : #description }
 ReverseAlphabeticSorter class >> sortCompletionList: aList [
 
-	^ aList sorted reverse.
+	^ aList asOrderedCollection sort reverse
 ]


### PR DESCRIPTION
reduce the amount of intermediate copying:
  - no need to create a Set 
  - use #sort, not #sorted