### PR TITLE
3048-StringwithUnixLineEndings-shouldnt-modify-the-the-original-string

### DIFF
--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2589,25 +2589,32 @@ String >> withInternetLineEndings [
 
 { #category : #'platform conventions' }
 String >> withLineEndings: lineEndingString [
-
-	| stream |
+	"Answer a new instance where all occurrences of CRLF, CR, and LF are substituted with the specified line ending string."
 	
-	stream := nil.
-	self lineIndicesDo: [ :start :endWithoutDelimiters :end |
-		(stream isNil and: [ endWithoutDelimiters ~= end ]) ifTrue: [
-			(self copyFrom: endWithoutDelimiters + 1 to: end) = lineEndingString ifFalse: [
-				stream := WriteStream with: self copy.
-				stream position: start - 1 ]].
-		stream ifNotNil: [
-			stream next: endWithoutDelimiters - start + 1 putAll: self startingAt: start.
-			endWithoutDelimiters = end ifFalse: [
-				stream nextPutAll: lineEndingString ]]].
-	^stream
-		ifNil: [ self ]
-		ifNotNil: [ 
-			stream position = self size
-				ifTrue: [ stream originalContents ]
-				ifFalse: [ stream contents ]]
+	^ self species streamContents: [ :out |
+		| in c |
+		in := self readStream.
+		[ in atEnd ] whileFalse: [
+			c := in next.
+			"CR"
+			c == Character cr ifTrue: [
+				c := in peek.
+				"CR LF"
+				c == Character lf ifTrue: [
+					in next.
+				].
+				out nextPutAll: lineEndingString
+			] ifFalse: [
+				"LF"
+				c == Character lf ifTrue: [
+					out nextPutAll: lineEndingString
+				] ifFalse: [
+					out nextPut: c
+				]
+			]
+		]
+	]
+
 ]
 
 { #category : #converting }
@@ -2664,24 +2671,16 @@ String >> withSeparatorsCompacted [
 
 { #category : #'platform conventions' }
 String >> withSqueakLineEndings [
-	"Assume the string is textual, and that CR, LF, and CRLF are all valid line endings.
-	Replace each occurence with a single CR."
+	"Answer a new instance where all occurrences of CRLF and LF are substituted with CR."
 
-	(self includes: Character lf) ifFalse: [ ^self ].
-	(self includes: Character cr) ifFalse: [
-		^self translateWith: String crLfExchangeTable ].
-	^self withLineEndings: String cr
+	^ self withLineEndings: String cr
 ]
 
 { #category : #'platform conventions' }
 String >> withUnixLineEndings [
-	"Assume the string is textual, and that CR, LF, and CRLF are all valid line endings.
-	Replace each occurence with a single LF."
+	"Answer a new instance where all occurrences of CRLF and LF are substituted with LF."
 
-	(self includes: Character cr) ifFalse: [ ^self ].
-	(self includes: Character lf) ifFalse: [
-		^self translateWith: String crLfExchangeTable ].
-	^self withLineEndings: String lf
+	^ self withLineEndings: String lf
 ]
 
 { #category : #converting }

--- a/src/Collections-Tests/StringTest.class.st
+++ b/src/Collections-Tests/StringTest.class.st
@@ -2007,6 +2007,7 @@ StringTest >> testWithSqueakLineEndings [
 		'abc', String crlf, String crlf, 'abc' -> ('abc', String cr, String cr, 'abc').
 		String cr, 'abc', String cr, String crlf, 'abc', String lf -> (String cr, 'abc', String cr, String cr, 'abc', String cr).
 		String lf, 'abc', String lf, String crlf, 'abc', String cr -> (String cr, 'abc', String cr, String cr, 'abc', String cr).
+		(WideString with: 403 asCharacter with: Character lf) -> (WideString with: 403 asCharacter with: Character cr).
 	} do: [ :each |
 		self assert: each key withSqueakLineEndings equals: each value ]
 ]
@@ -2027,6 +2028,7 @@ StringTest >> testWithUnixLineEndings [
 		'abc', String crlf, String crlf, 'abc' -> ('abc', String lf, String lf, 'abc').
 		String cr, 'abc', String cr, String crlf, 'abc', String lf -> (String lf, 'abc', String lf, String lf, 'abc', String lf).
 		String lf, 'abc', String lf, String crlf, 'abc', String cr -> (String lf, 'abc', String lf, String lf, 'abc', String lf).
+		(WideString with: 403 asCharacter with: Character cr) -> (WideString with: 403 asCharacter with: Character lf).
 	} do: [ :each |
 		self assert: each key withUnixLineEndings equals: each value ]
 ]


### PR DESCRIPTION
Fixes #3048. Rewrite #withLineEndings: to do not mutate the receiver. 

Pair-programmed with Ronie. 

We added WideString to tests, and we also removed the checks for 
special cases in #withUnixLineEndings and #withSqueakLineEndings.