### PR TITLE
CodeCompletionLessSorting

### DIFF
--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -478,12 +478,6 @@ RBMethodNode >> methodOrBlockNode [
 	"^ self"
 ]
 
-{ #category : #completion }
-RBMethodNode >> narrowWith: aString [
-
-	self selector: aString asSymbol
-]
-
 { #category : #accessing }
 RBMethodNode >> newSource [
 	replacements ifNil: [^self formattedCode].

--- a/src/NECompletion-Tests/CompletionContextTest.class.st
+++ b/src/NECompletion-Tests/CompletionContextTest.class.st
@@ -438,7 +438,7 @@ CompletionContextTest >> testUntypedSelectorsOnly [
 	context := self createContextFor: text at: text size.
 	model := context model.
 	self assert: model hasMessage.
-	self assert: model message = 'press key for selectors'.
+	self assert: model message equals: 'press key for selectors'.
 	context narrowWith: 'ab'.
 	self denyEmpty: (model entriesOfType: #selector).
 	self assertEmpty: (model entriesOfType: #local).

--- a/src/NECompletion/CompletionModel.class.st
+++ b/src/NECompletion/CompletionModel.class.st
@@ -123,9 +123,11 @@ CompletionModel >> narrowString [
 
 { #category : #action }
 CompletionModel >> narrowWith: aString [ 
-	completionToken := aString ifNil: [  '' ].
-	node narrowWith: completionToken.
-	entries := nil
+	completionToken := aString ifNil: [ '' ].
+	entries := entries 
+		ifNil: [ self initEntries ]
+		ifNotNil: [  entries select: [ :each | each contents beginsWith: completionToken  ] ]
+
 ]
 
 { #category : #accessing }

--- a/src/NECompletion/RBLiteralValueNode.extension.st
+++ b/src/NECompletion/RBLiteralValueNode.extension.st
@@ -4,13 +4,3 @@ Extension { #name : #RBLiteralValueNode }
 RBLiteralValueNode >> completionToken [
 	^ self value asString
 ]
-
-{ #category : #'*NECompletion' }
-RBLiteralValueNode >> narrowWith: aString [
-
- 	self flag: #maybeBug.
-	"This seems to work because we only arrive here with Symbols.
-	It may not work with other kind of literal values"
-	value := aString asSymbol.
-	sourceText := aString
-]

--- a/src/NECompletion/RBMessageNode.extension.st
+++ b/src/NECompletion/RBMessageNode.extension.st
@@ -7,12 +7,6 @@ RBMessageNode >> completionToken [
 ]
 
 { #category : #'*NECompletion' }
-RBMessageNode >> narrowWith: aString [
-
- 	self selector: aString asSymbol
-]
-
-{ #category : #'*NECompletion' }
 RBMessageNode >> typeForCompletionIfAbsent: aBlock [
 
  	^ self receiver typeForCompletionIfAbsent: aBlock

--- a/src/NECompletion/RBProgramNode.extension.st
+++ b/src/NECompletion/RBProgramNode.extension.st
@@ -6,12 +6,6 @@ RBProgramNode >> completionToken [
 ]
 
 { #category : #'*NECompletion' }
-RBProgramNode >> narrowWith: aString [
-
- 	"Do nothing"
-]
-
-{ #category : #'*NECompletion' }
 RBProgramNode >> typeForCompletionIfAbsent: aBlock [
 
  	^ self propertyAt: #type ifAbsent: [ ^ aBlock value ]

--- a/src/NECompletion/RBVariableNode.extension.st
+++ b/src/NECompletion/RBVariableNode.extension.st
@@ -5,9 +5,3 @@ RBVariableNode >> completionToken [
 
 	^ self name
 ]
-
-{ #category : #'*NECompletion' }
-RBVariableNode >> narrowWith: aString [
-
- 	self name: aString asSymbol
-]


### PR DESCRIPTION
#narrowWith: should not reset the model
 - we re-use the already found (and sorted) entries.
- we do not need to update the AST as the state is now in the model.