### PR TITLE
Add new #printOneLineString and related methods

### DIFF
--- a/src/Collections-Streams/FilteringStream.class.st
+++ b/src/Collections-Streams/FilteringStream.class.st
@@ -1,0 +1,44 @@
+"
+I am a basic filtering stream that will wrap every object put in the stream in a block, before sending it to my decoree.
+
+"
+Class {
+	#name : #FilteringStream,
+	#superclass : #DecoratorStream,
+	#instVars : [
+		'filter'
+	],
+	#category : #'Collections-Streams-Base'
+}
+
+{ #category : #'instance creation' }
+FilteringStream class >> on: aStream [
+	self error: 'FilteringStreams are created with #on:with:'
+]
+
+{ #category : #'instance creation' }
+FilteringStream class >> on: aStream with: aBlock [
+	^ self basicNew
+		on: aStream;
+		filter: aBlock;
+		yourself.
+]
+
+{ #category : #accessing }
+FilteringStream >> filter [
+	^ filter
+]
+
+{ #category : #accessing }
+FilteringStream >> filter: anObject [
+	filter := anObject
+]
+
+{ #category : #accessing }
+FilteringStream >> nextPut: anObject [ 
+	"Insert the argument, anObject, as the next object accessible by the 
+	receiver. Answer anObject."
+	
+	super nextPut: (filter value: anObject).
+	^anObject 
+]

--- a/src/Collections-Streams/FilteringStreamTest.class.st
+++ b/src/Collections-Streams/FilteringStreamTest.class.st
@@ -1,0 +1,26 @@
+"
+This is the unit test for the class FilteringStream
+"
+Class {
+	#name : #FilteringStreamTest,
+	#superclass : #TestCase,
+	#category : #'Collections-Streams-Tests'
+}
+
+{ #category : #tests }
+FilteringStreamTest >> testWithCharacters [
+	|f|
+	f := FilteringStream on: (String new writeStream) with: [:x | x].
+	f nextPut: $a.
+	self assert: f contents size equals: 1. 
+	self assert: (f contents at:1) equals: $a.
+]
+
+{ #category : #tests }
+FilteringStreamTest >> testWithNumbers [
+	|f|
+	f := FilteringStream on: (WriteStream with: LinkedList new) with: [:x | x + 10].
+	f nextPut: 23.
+	self assert: f contents size equals: 1. 
+	self assert: (f contents at:1) equals: 33.
+]

--- a/src/Kernel-Tests/ObjectTest.class.st
+++ b/src/Kernel-Tests/ObjectTest.class.st
@@ -103,6 +103,31 @@ ObjectTest >> testPrintLimitedString [
 ]
 
 { #category : #'tests-printing' }
+ObjectTest >> testPrintOnOneLine [
+	|ws|
+	ws := String new writeStream.
+	'this is a test' printOnOneLine: ws.
+	self assert: ws contents equals: '''this is a test'''.
+
+]
+
+{ #category : #'tests-printing' }
+ObjectTest >> testPrintOnOneLineString [
+	self 
+		assert: ('this is a test' printOnOneLineString) 
+		equals: '''this is a test'''.
+	
+	self 
+		assert: ('this is a', Character cr asString, 'test') printOnOneLineString 
+		equals: '''this is a test'''.
+	
+	self 
+		assert: ('this is a', Character lf asString, 'test') printOnOneLineString 
+		equals: '''this is a test'''.
+
+]
+
+{ #category : #'tests-printing' }
 ObjectTest >> testPrintString [
 
 	self assert: Object new printString equals: 'an Object'

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1704,6 +1704,30 @@ Object >> printOn: aStream [
 ]
 
 { #category : #printing }
+Object >> printOnOneLine: aStream [
+	"Append to the argument, aStream, a sequence of characters that  
+	identifies the receiver, while replacing cr and lf with one space.
+	
+	This is usually called by #printOnOneLineString with a filtering
+	stream, replacing cr and lf with spaces"
+
+	self printOn: aStream.
+]
+
+{ #category : #printing }
+Object >> printOnOneLineString [
+	"Answer a String whose characters are a description of the receiver, 
+	avoiding printing cr and lf"
+
+	|spaces filter|
+	spaces := { Character cr. Character lf }.
+	filter := FilteringStream on: String new writeStream with: [ :c | 
+		(spaces includes: c) ifTrue:[ Character space ] ifFalse:[c] ].
+	self printOnOneLine: filter.
+	^ filter contents
+]
+
+{ #category : #printing }
 Object >> printString [
 	"Answer a String whose characters are a description of the receiver. 
 	If you want to print without a character limit, use fullPrintString."


### PR DESCRIPTION
It's nice to have a #printOneLineString that is just like #printString
but avoids printing CRs and LFs. This patch implements such idea adding
a method named #printOnOneLine:, working on a Stream, and a
FilteringStream.

The FilteringStream is used to replace CRs and LFs with a space, but can
be used to filter elements going into a Stream via a generic block.

Original PR #4854 
Issue: #4849 