### PR TITLE
Recategorize setUp method as #running

### DIFF
--- a/src/UnifiedFFI-Tests/FFICalloutAPITest.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutAPITest.class.st
@@ -122,11 +122,11 @@ FFICalloutAPITest >> runCase [
 	ensure: [ FFICalloutAPI calloutAPIClass: oldAPIClass ]
 ]
 
-{ #category : #'tests context' }
+{ #category : #running }
 FFICalloutAPITest >> setUp [
 
 	super setUp.
-  self resetFFIMethods.
+	self resetFFIMethods.
 	senderCtx := Context
 		sender: nil
 		receiver: nil


### PR DESCRIPTION
This should make tests green again.