### PR TITLE
Add-argumentNamed-to-Pragma

### DIFF
--- a/src/Kernel-Tests/PragmaTest.class.st
+++ b/src/Kernel-Tests/PragmaTest.class.st
@@ -13,6 +13,12 @@ Class {
 	#category : #'Kernel-Tests-Pragmas'
 }
 
+{ #category : #helper }
+PragmaTest >> methodWithPragma [
+	<testPragmaArg1: #toto arg2: 2 arg3: true>
+	
+]
+
 { #category : #running }
 PragmaTest >> setUp [
 	super setUp.
@@ -24,42 +30,61 @@ PragmaTest >> setUp [
 ]
 
 { #category : #tests }
+PragmaTest >> testArgumentAt [
+	| pragma |
+	pragma := (self class >> #methodWithPragma) pragmas anyOne.
+	self assert: (pragma argumentAt: 1) equals: #toto.
+	self assert: (pragma argumentAt: 2) equals: 2.
+	self assert: (pragma argumentAt: 3)
+]
+
+{ #category : #tests }
+PragmaTest >> testArgumentNamed [
+	| pragma |
+	pragma := (self class >> #methodWithPragma) pragmas anyOne.
+	self assert: (pragma argumentNamed: #testPragmaArg1) equals: #toto.
+	self assert: (pragma argumentNamed: #arg2) equals: 2.
+	self assert: (pragma argumentNamed: #arg3).
+	self should: [ pragma argumentNamed: #nonExisting ] raise: Error
+]
+
+{ #category : #tests }
+PragmaTest >> testArgumentNamedIfNone [
+	| pragma |
+	pragma := (self class >> #methodWithPragma) pragmas anyOne.
+	self assert: (pragma argumentNamed: #arg3 ifNone: [ false ]).
+	self deny: (pragma argumentNamed: #nonExisting ifNone: [ false ])
+]
+
+{ #category : #tests }
 PragmaTest >> testCopy [
-
 	| copy |
-
 	copy := atPragma copy.
 
-	self deny: atPragma == copy.
-	self assert: atPragma method == copy method.
-	self assert: atPragma selector == copy selector.
-	self assert: atPragma arguments == copy arguments.
+	self deny: atPragma identicalTo: copy.
+	self assert: atPragma method identicalTo: copy method.
+	self assert: atPragma selector identicalTo: copy selector.
+	self assert: atPragma arguments identicalTo: copy arguments
 ]
 
 { #category : #tests }
 PragmaTest >> testEqual [
+	self assert: atPragma equals: atPragma.
+	self assert: atPragma equals: anotherAtPragma.
+	self assert: anotherAtPragma equals: atPragma.
+	self assert: atPragma equals: anotherAtPragma.
+	self assert: anotherAtPragma equals: yetAnotherAtPragma.
+	self assert: yetAnotherAtPragma equals: atPragma.
 
-	self assert: atPragma = atPragma.		"Reflexivity"
-
-	self assert: atPragma = anotherAtPragma.		"Simmetry"
-	self assert: anotherAtPragma = atPragma.
-
-	self assert: atPragma = anotherAtPragma.		"Transitivity"
-	self assert: anotherAtPragma = yetAnotherAtPragma.
-	self assert: yetAnotherAtPragma = atPragma.
-
-	self deny: atPragma = atPutPragma.
+	self deny: atPragma equals: atPutPragma
 ]
 
 { #category : #tests }
 PragmaTest >> testHash [
-
-	self assert: atPragma hash = atPragma hash.
-
-	self assert: atPragma hash = anotherAtPragma hash.
-	self assert: anotherAtPragma hash = atPragma hash.
-
-	self assert: atPragma hash = anotherAtPragma hash.
-	self assert: anotherAtPragma hash = yetAnotherAtPragma hash.
-	self assert: yetAnotherAtPragma hash = atPragma hash.
+	self assert: atPragma hash equals: atPragma hash.
+	self assert: atPragma hash equals: anotherAtPragma hash.
+	self assert: anotherAtPragma hash equals: atPragma hash.
+	self assert: atPragma hash equals: anotherAtPragma hash.
+	self assert: anotherAtPragma hash equals: yetAnotherAtPragma hash.
+	self assert: yetAnotherAtPragma hash equals: atPragma hash
 ]

--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -129,6 +129,25 @@ Pragma >> argumentAt: anInteger [
 ]
 
 { #category : #'accessing-pragma' }
+Pragma >> argumentNamed: aSymbol [
+	"Answer the argument of the pragma after the keyword given as parameter.
+	If none, raise an error."
+
+	^ self argumentNamed: aSymbol ifNone: [ self error: 'No argument of this name.' ]
+]
+
+{ #category : #'accessing-pragma' }
+Pragma >> argumentNamed: aSymbol ifNone: aBlockClosure [
+	"Answer the argument of the pragma after the keyword given as parameter.
+	If none, return the result of the block given as parameter."
+
+	^ self argumentAt:
+		(self selector keywords
+			indexOf: aSymbol asMutator
+			ifAbsent: [ ^ aBlockClosure value])
+]
+
+{ #category : #'accessing-pragma' }
 Pragma >> arguments [
 	"Answer the arguments of the receiving pragma. For a pragma defined as <key1: val1 key2: val2> this will answer #(val1 val2)."
 	

--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -139,7 +139,9 @@ Pragma >> argumentNamed: aSymbol [
 { #category : #'accessing-pragma' }
 Pragma >> argumentNamed: aSymbol ifNone: aBlockClosure [
 	"Answer the argument of the pragma after the keyword given as parameter.
-	If none, return the result of the block given as parameter."
+	If none, return the result of the block given as parameter.
+	
+	I am more readable than #argumentAt: but also slower."
 
 	^ self argumentAt:
 		(self selector keywords


### PR DESCRIPTION
Add a new way to access arguments of pragma.

The new way is to use #argumentNamed:. 

I also added some tests on pragmas.