### PR TITLE
3111-Why-do-we-have-in-Object--isCodeCompletionAllowed

### DIFF
--- a/src/Spec-Core/TextInputFieldPresenter.class.st
+++ b/src/Spec-Core/TextInputFieldPresenter.class.st
@@ -182,12 +182,6 @@ TextInputFieldPresenter >> initialize [
 	isEncrypted whenChangedDo: [ :bool | self changed: #encrypted: with: { bool } ].
 ]
 
-{ #category : #NOCompletion }
-TextInputFieldPresenter >> isCodeCompletionAllowed [
-	
-	^ false
-]
-
 { #category : #api }
 TextInputFieldPresenter >> removeEntryCompletion [
 	"< api:#do>"

--- a/src/Spec-Core/TextPresenter.class.st
+++ b/src/Spec-Core/TextPresenter.class.st
@@ -384,14 +384,6 @@ TextPresenter >> isAboutToStyle [
 	^ self aboutToStyleBlock value
 ]
 
-{ #category : #NOCompletion }
-TextPresenter >> isCodeCompletionAllowed [
-	"<api:#inspect>"
-	"Return if code completion is allowed"
-	
-	^ isCodeCompletionAllowedHolder value
-]
-
 { #category : #api }
 TextPresenter >> isCodeCompletionAllowed: aBoolean [
 	"<api: #boolean getter: #isCodeCompletionAllowed registration: #whenCodeCompletionAllowedChanged:>"

--- a/src/Spec-MorphicAdapters/MorphicTextAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTextAdapter.class.st
@@ -168,12 +168,6 @@ MorphicTextAdapter >> isAboutToStyle [
 	^ self model isAboutToStyle
 ]
 
-{ #category : #NOCompletion }
-MorphicTextAdapter >> isCodeCompletionAllowed [
-
-	^ self model isCodeCompletionAllowed
-]
-
 { #category : #'spec protocol' }
 MorphicTextAdapter >> isForSmalltalkCode [
 	^ self model isForSmalltalkCode

--- a/src/Spec-MorphicAdapters/MorphicTextInputFieldAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTextInputFieldAdapter.class.st
@@ -84,9 +84,3 @@ MorphicTextInputFieldAdapter >> ghostText: aText [
 
 	^ self model ghostText: aText
 ]
-
-{ #category : #NOCompletion }
-MorphicTextInputFieldAdapter >> isCodeCompletionAllowed [
-	
-	^ false
-]


### PR DESCRIPTION
remove the last #isCodeCompletionAllowed implementors