### PR TITLE
Completion Cleanup:  use all Literals

### DIFF
--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -39,7 +39,7 @@ CompletionContext >> completionToken [
 CompletionContext >> createModel [
 	self parseSource.
 	node := ast nodeForOffset: position.
-  ^ (CompletionModel new node: node) clazz: theClass
+  ^ (CompletionModel new node: node) class: theClass
 ]
 
 { #category : #accessing }

--- a/src/NECompletion/CompletionModel.class.st
+++ b/src/NECompletion/CompletionModel.class.st
@@ -5,7 +5,7 @@ Class {
 	#name : #CompletionModel,
 	#superclass : #Object,
 	#instVars : [
-		'clazz',
+		'class',
 		'node',
 		'completionToken',
 		'entries',
@@ -30,8 +30,8 @@ CompletionModel class >> sorter: aSorter [
 ]
 
 { #category : #accessing }
-CompletionModel >> clazz: anObject [
-	clazz := anObject
+CompletionModel >> class: aClass [
+	class := aClass.
 ]
 
 { #category : #entries }
@@ -88,7 +88,7 @@ CompletionModel >> initEntries [
 	| producer suggestionsList |
 	producer := CompletionProducerVisitor new.
 	self sorter: self class sorter.
-	producer completionContext: clazz.
+	producer completionContext: class.
 	suggestionsList := self sortList: (producer completionListForNode: node).
 	^ suggestionsList collect: [ :each | CompletionEntry contents: each node: node ]
 ]

--- a/src/NECompletion/CompletionProducerVisitor.class.st
+++ b/src/NECompletion/CompletionProducerVisitor.class.st
@@ -58,7 +58,7 @@ CompletionProducerVisitor >> visitLiteralNode: aRBLiteralValueNode [
 	| value |
 	
 	value := aRBLiteralValueNode value.
-	(value isKindOf: Symbol) ifFalse: [ ^#() ].
+	value isSymbol ifFalse: [ ^ #() ].
 	"return all symbols that start with value"
 	^Symbol allSymbols select: [ :each | (each beginsWith: value) and: [each isLiteralSymbol]]
 ]

--- a/src/NECompletion/CompletionProducerVisitor.class.st
+++ b/src/NECompletion/CompletionProducerVisitor.class.st
@@ -24,12 +24,6 @@ CompletionProducerVisitor >> completionListForNode: aRBNode [
 	^ aRBNode acceptVisitor: self
 ]
 
-{ #category : #visiting }
-CompletionProducerVisitor >> methodNames [
-	^ Symbol selectorTable
-	
-]
-
 { #category : #utilities }
 CompletionProducerVisitor >> select: aCollection beginningWith: aString [
 	^ aCollection select: [ :each | each beginsWith: aString asString ]
@@ -61,16 +55,12 @@ CompletionProducerVisitor >> visitLiteralArrayNode: aRBLiteralArrayNode [
 
 { #category : #visiting }
 CompletionProducerVisitor >> visitLiteralNode: aRBLiteralValueNode [
-	| results |
-	(aRBLiteralValueNode value isKindOf: Symbol) ifFalse: [ ^#() ].
+	| value |
+	
+	value := aRBLiteralValueNode value.
+	(value isKindOf: Symbol) ifFalse: [ ^#() ].
 	"return all symbols that start with value"
-	results := OrderedCollection new.
-	Symbol allSymbolTablesDo: [ :symbol |
-		(symbol beginsWith: aRBLiteralValueNode value)
-			ifTrue: [ results add: symbol ].
-		results size >= 10 ifTrue: [ ^ results ]
-	].
-	^ results
+	^Symbol allSymbols select: [ :each | (each beginsWith: value) and: [each isLiteralSymbol]]
 ]
 
 { #category : #visiting }
@@ -86,7 +76,7 @@ CompletionProducerVisitor >> visitMessageNode:  aRBMessageNode [
 
 { #category : #visiting }
 CompletionProducerVisitor >> visitMethodNode: aRBMethodNode [
-	^ self select: self methodNames beginningWith: aRBMethodNode selector
+	^ self select: Symbol selectorTable beginningWith: aRBMethodNode selector
 ]
 
 { #category : #visiting }
@@ -128,12 +118,11 @@ CompletionProducerVisitor >> visitVariableNode: aRBVariableNode [
 	aRBVariableNode isDefinition ifTrue: [ ^ (self select: Symbol allSymbols beginningWith: aRBVariableNode name) select: [ :each | each numArgs = 0 ] ].
    aRBVariableNode isArgument ifTrue: [ ^ (self select: Symbol allSymbols beginningWith: aRBVariableNode name) select: [ :each | each numArgs = 0 ] ].
 	"using a stream to store results should be better"
-	^ (self select: Smalltalk globals keys beginningWith: aRBVariableNode name) , 
-	  (self select: (lookupClass allSlots collect: [ :each | each name ]) beginningWith: aRBVariableNode name) ,
+	^	(self select: Smalltalk globals keys beginningWith: aRBVariableNode name), 
+	 	(self select: (lookupClass allSlots collect: [ :each | each name ]) beginningWith: aRBVariableNode name),
 		(self select: aRBVariableNode methodNode temporaryNames beginningWith: aRBVariableNode name),
 		(self select: aRBVariableNode methodNode argumentNames beginningWith: aRBVariableNode name),
 		(self select: lookupClass allClassVarNames beginningWith: aRBVariableNode name),
 		(self select: (lookupClass allSharedPools flatCollect: [ :each | each classVarNames]) beginningWith: aRBVariableNode name)
-		",(self select: self methodNames beginningWith: aRBVariableNode name)"
 
 ]


### PR DESCRIPTION
- rename ivar clazz to class (as there is no reading accessor, no clash with the #class message of Object)
- remove #methodNames: (inline in the one sender)
- completion of Literals: do not stop at 10, we use all literals when completing  var definitions, and it works