### PR TITLE
CompletionCleanup: get class from AST

### DIFF
--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -7,12 +7,12 @@ Class {
 	#instVars : [
 		'source',
 		'position',
-		'theClass',
 		'completionToken',
 		'model',
 		'ast',
 		'node',
-		'isWorkspace'
+		'isWorkspace',
+		'class'
 	],
 	#category : #'NECompletion-New'
 }
@@ -39,7 +39,7 @@ CompletionContext >> completionToken [
 CompletionContext >> createModel [
 	self parseSource.
 	node := ast nodeForOffset: position.
-  ^ (CompletionModel new node: node) class: theClass
+	^ CompletionModel new node: node
 ]
 
 { #category : #accessing }
@@ -63,9 +63,9 @@ CompletionContext >> parseSource [
 	ast methodNode 
 		compilationContext: 
 			(Smalltalk compiler compilationContextClass new
-             class: theClass;forSyntaxHighlighting: true).
+             class: class;forSyntaxHighlighting: true).
 		
-	ast doSemanticAnalysisIn: theClass.
+	ast doSemanticAnalysisIn: class.
 	TypingVisitor new visitNode: ast
 ]
 
@@ -83,7 +83,7 @@ CompletionContext >> setController: aECController class: aClass source: aString 
 		ifNotNil: [ aECController isScripting ]
 		ifNil: [ false ].
 
-	theClass := aClass. 
+	class := aClass. 
 	source := aString.
 	position := anInteger
 ]

--- a/src/NECompletion/CompletionEntry.class.st
+++ b/src/NECompletion/CompletionEntry.class.st
@@ -6,7 +6,6 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'contents',
-		'type',
 		'node'
 	],
 	#category : #'NECompletion-New'

--- a/src/NECompletion/CompletionModel.class.st
+++ b/src/NECompletion/CompletionModel.class.st
@@ -5,7 +5,6 @@ Class {
 	#name : #CompletionModel,
 	#superclass : #Object,
 	#instVars : [
-		'class',
 		'node',
 		'completionToken',
 		'entries',
@@ -27,11 +26,6 @@ CompletionModel class >> sorter: aSorter [
 
 	Sorter := aSorter
 	
-]
-
-{ #category : #accessing }
-CompletionModel >> class: aClass [
-	class := aClass.
 ]
 
 { #category : #entries }
@@ -88,7 +82,6 @@ CompletionModel >> initEntries [
 	| producer suggestionsList |
 	producer := CompletionProducerVisitor new.
 	self sorter: self class sorter.
-	producer completionContext: class.
 	suggestionsList := self sortList: (producer completionListForNode: node).
 	^ suggestionsList collect: [ :each | CompletionEntry contents: each node: node ]
 ]

--- a/src/NECompletion/CompletionProducerVisitor.class.st
+++ b/src/NECompletion/CompletionProducerVisitor.class.st
@@ -4,19 +4,11 @@ I'm a little visitor. I take the specific node of the string that has to be comp
 Class {
 	#name : #CompletionProducerVisitor,
 	#superclass : #RBProgramNodeVisitor,
-	#instVars : [
-		'currentClass'
-	],
 	#classInstVars : [
 		'aCollection'
 	],
 	#category : #'NECompletion-New'
 }
-
-{ #category : #accessing }
-CompletionProducerVisitor >> completionContext: aClass [ 
-	currentClass := aClass.
-]
 
 { #category : #completion }
 CompletionProducerVisitor >> completionListForNode: aRBNode [
@@ -113,15 +105,16 @@ CompletionProducerVisitor >> visitThisContextNode: aThisContextNode [
 
 { #category : #visiting }
 CompletionProducerVisitor >> visitVariableNode: aRBVariableNode [
-	| lookupClass |
-	lookupClass := currentClass ifNil: [ UndefinedObject ].
+	| methodNode lookupClass |
+	methodNode := aRBVariableNode methodNode.
+	lookupClass := methodNode compilationContext getClass.
 	aRBVariableNode isDefinition ifTrue: [ ^ (self select: Symbol allSymbols beginningWith: aRBVariableNode name) select: [ :each | each numArgs = 0 ] ].
    aRBVariableNode isArgument ifTrue: [ ^ (self select: Symbol allSymbols beginningWith: aRBVariableNode name) select: [ :each | each numArgs = 0 ] ].
 	"using a stream to store results should be better"
 	^	(self select: Smalltalk globals keys beginningWith: aRBVariableNode name), 
 	 	(self select: (lookupClass allSlots collect: [ :each | each name ]) beginningWith: aRBVariableNode name),
-		(self select: aRBVariableNode methodNode temporaryNames beginningWith: aRBVariableNode name),
-		(self select: aRBVariableNode methodNode argumentNames beginningWith: aRBVariableNode name),
+		(self select: methodNode temporaryNames beginningWith: aRBVariableNode name),
+		(self select: methodNode argumentNames beginningWith: aRBVariableNode name),
 		(self select: lookupClass allClassVarNames asOrderedCollection beginningWith: aRBVariableNode name),
 		(self select: (lookupClass allSharedPools flatCollect: [ :each | each classVarNames]) beginningWith: aRBVariableNode name)
 


### PR DESCRIPTION
-CompletionContext: rename ivar "theClass" to "class"
-CompletionModel and CompletionProducerVisitor do not need the class. We can just ask the AST.
-remove "type" ivar from CompletionEntry