### PR TITLE
4863-Completion-in-class-comment-leads-to-DNU

### DIFF
--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -483,7 +483,8 @@ RBParserTest >> testParseFaultyMethod [
 		add: 'method: asd  ^ {'; "Only Open a literal array"
 		add: 'selector '''; 
 		add: 'selector #^';
-		add: 'selector ¿'.
+		add: 'selector ¿';
+		add: ':nl'.
 
 
 	strangeExpressions do: [ :exp | 

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -64,12 +64,13 @@ RBParser class >> parseFaultyExpression: aString [
 { #category : #parsing }
 RBParser class >> parseFaultyMethod: aString [
 	"parse aString even if syntactically incorrect. Instead of raising an error, we create an AST with RB RBParseErrorNode"
+
 	| ast |
 	ast := self parseMethod: aString onError: self errorNodeBlock.
 	"make sure to return a RBMethodNode"
-	^(ast class == RBMethodNode)
-			ifFalse: [ RBMethodNode selector: #faulty body: ast asSequenceNode ]
-			ifTrue: [ ast ]
+	^ ast class == RBMethodNode
+		ifFalse: [ RBMethodNode selector: #faulty body: ast asSequenceNode ]
+		ifTrue: [ ast ]
 ]
 
 { #category : #parsing }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -64,7 +64,12 @@ RBParser class >> parseFaultyExpression: aString [
 { #category : #parsing }
 RBParser class >> parseFaultyMethod: aString [
 	"parse aString even if syntactically incorrect. Instead of raising an error, we create an AST with RB RBParseErrorNode"
-	^self parseMethod: aString onError: self errorNodeBlock
+	| ast |
+	ast := self parseMethod: aString onError: self errorNodeBlock.
+	"make sure to return a RBMethodNode"
+	^(ast class == RBMethodNode)
+			ifFalse: [ RBMethodNode selector: #faulty body: ast asSequenceNode ]
+			ifTrue: [ ast ]
 ]
 
 { #category : #parsing }


### PR DESCRIPTION
make sure that #parseFaultyMethod: returns a method even if the method iteself can only be parsed as an error node