### PR TITLE
CompletionNavigationKeys

### DIFF
--- a/src/NECompletion/CompletionEntry.class.st
+++ b/src/NECompletion/CompletionEntry.class.st
@@ -6,7 +6,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'contents',
-		'node'
+		'node',
+		'description'
 	],
 	#category : #'NECompletion-New'
 }
@@ -21,6 +22,14 @@ CompletionEntry class >> contents: aString node: aNode [
 	^ self new setContents: aString node: aNode
 ]
 
+{ #category : #ui }
+CompletionEntry >> browseWith: aCompletionContext [
+	| class |
+	class := node methodNode compilationContext getClass.
+	Smalltalk tools browser openOnClass: class.
+	^true
+]
+
 { #category : #accessing }
 CompletionEntry >> completion [
 	^ self contents asSymbol
@@ -29,6 +38,11 @@ CompletionEntry >> completion [
 { #category : #accessing }
 CompletionEntry >> contents [
 	^contents
+]
+
+{ #category : #description }
+CompletionEntry >> descriptionWith: aCompletionContext [ 
+	^description ifNil: [ ^ description := node completionDescription].
 ]
 
 { #category : #initialization }

--- a/src/NECompletion/RBProgramNode.extension.st
+++ b/src/NECompletion/RBProgramNode.extension.st
@@ -1,6 +1,15 @@
 Extension { #name : #RBProgramNode }
 
 { #category : #'*NECompletion' }
+RBProgramNode >> completionDescription [
+	"TODO: we need to implement this to return an empty description here and something useful for all the cases like sens, symbols, variables..."
+	^NECEntryDescription 
+					label: 'label depends on node'
+					title: 'class or something else, depends on node'
+					description: 'here the class comment or method source'
+]
+
+{ #category : #'*NECompletion' }
 RBProgramNode >> completionToken [
 	^ String empty
 ]


### PR DESCRIPTION
There is an option to turn on a small integrated browser in completion. "Use navigation keys for extended completion functionality".

This PR adds the needed methods to show a stand-in there. Which means that this now just needs to be extended to show useful things for all the cases.