### PR TITLE
Cleanup #guessTypeForName:

### DIFF
--- a/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
+++ b/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
@@ -197,11 +197,6 @@ ClyTextEditorToolMorph >> findAnyString: strings in: text [
 ]
 
 { #category : #'rubric interaction model' }
-ClyTextEditorToolMorph >> guessTypeForName: aString [
-	^nil
-]
-
-{ #category : #'rubric interaction model' }
 ClyTextEditorToolMorph >> hasBindingOf: aString [ 
 	^self selectedClassOrMetaClass hasBindingOf: aString
 ]

--- a/src/Glamour-Morphic-Widgets/GLMRubricSmalltalkTextModel.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMRubricSmalltalkTextModel.class.st
@@ -55,11 +55,6 @@ GLMRubricSmalltalkTextModel >> formatSourceCode [
 ]
 
 { #category : #bindings }
-GLMRubricSmalltalkTextModel >> guessTypeForName: aString [ 
-	^ nil
-]
-
-{ #category : #bindings }
 GLMRubricSmalltalkTextModel >> hasBindingOf: aSymbol [
 
 	^ self variableBindings includesKey: aSymbol

--- a/src/Glamour-Morphic-Widgets/GLMSmalltalkCodeModel.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMSmalltalkCodeModel.class.st
@@ -49,11 +49,6 @@ GLMSmalltalkCodeModel >> doItReceiver [
 	^ self glamourPresentation doItReceiver 
 ]
 
-{ #category : #completion }
-GLMSmalltalkCodeModel >> guessTypeForName: aString [ 
-	^ nil
-]
-
 { #category : #accessing }
 GLMSmalltalkCodeModel >> hasBindingOf: aSymbol [
 	^ self variableBindings includesKey: aSymbol

--- a/src/NECompletion/AbstractTool.extension.st
+++ b/src/NECompletion/AbstractTool.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #AbstractTool }
-
-{ #category : #'*necompletion-extensions' }
-AbstractTool >> guessTypeForName: aString [
-	^nil
-]

--- a/src/NECompletion/FinderUI.extension.st
+++ b/src/NECompletion/FinderUI.extension.st
@@ -1,12 +1,5 @@
 Extension { #name : #FinderUI }
 
-{ #category : #'*NECompletion' }
-FinderUI >> guessTypeForName: aString [ 
- 
-	self flag: 'we may be able to do something more sophisticated here, but needed something to prevent a DNU. Returning nil was taken from AbstractTool. See Debugger or Workspace for actual guessing logic'.
-	^ nil
-]
-
 { #category : #'*necompletion' }
 FinderUI >> selectedClassOrMetaClass [
 

--- a/src/NECompletion/NECLocalEntry.class.st
+++ b/src/NECompletion/NECLocalEntry.class.st
@@ -9,12 +9,6 @@ Class {
 	#category : #'NECompletion-Model'
 }
 
-{ #category : #operations }
-NECLocalEntry >> guessTypeWith: anECContext [ 
-	^ (anECContext guessTempVarClass: contents type: self type) 
-		ifNil: [anECContext guessArgument: contents]
-]
-
 { #category : #testing }
 NECLocalEntry >> isLocal [
 	^true

--- a/src/NECompletion/NECSelectorEntry.class.st
+++ b/src/NECompletion/NECSelectorEntry.class.st
@@ -66,18 +66,6 @@ NECSelectorEntry >> findMethodWith: anECContext do: foundBlock ifAbsent: notfoun
 	^ foundBlock value: result first value: result second
 ]
 
-{ #category : #operations }
-NECSelectorEntry >> guessTypeWith: anECContext [
-	"If the variable is a class, i return the variable itself or its class name.
-	Otherwise i return nil."
-	| globalEntry |
-	anECContext ifNil: [ ^ nil ].
-	globalEntry := anECContext globals at: contents ifAbsent: [^ nil].
-	globalEntry isBehavior ifTrue: [^ globalEntry].
-	globalEntry ifNotNil: [^ globalEntry class].
-	^ nil
-]
-
 { #category : #private }
 NECSelectorEntry >> implementorsDescription: aSymbol [ 
 	| implementors output |

--- a/src/NECompletion/NECSelfEntry.class.st
+++ b/src/NECompletion/NECSelfEntry.class.st
@@ -7,11 +7,6 @@ Class {
 	#category : #'NECompletion-Model'
 }
 
-{ #category : #operations }
-NECSelfEntry >> guessTypeWith: anECContext [ 
-	^ anECContext theClass
-]
-
 { #category : #accessing }
 NECSelfEntry >> label [
 	^ 'self'

--- a/src/NECompletion/NECSuperEntry.class.st
+++ b/src/NECompletion/NECSuperEntry.class.st
@@ -7,11 +7,6 @@ Class {
 	#category : #'NECompletion-Model'
 }
 
-{ #category : #operations }
-NECSuperEntry >> guessTypeWith: anECContext [ 
-	^ anECContext theClass ifNotNil: [anECContext theClass superclass]
-]
-
 { #category : #accessing }
 NECSuperEntry >> label [
 	^ 'super'

--- a/src/Rubric/RubScrolledTextModel.class.st
+++ b/src/Rubric/RubScrolledTextModel.class.st
@@ -106,25 +106,6 @@ RubScrolledTextModel >> getText [
 	^ self text
 ]
 
-{ #category : #'necompletion-extensions' }
-RubScrolledTextModel >> guessTypeForName: aString [
-	"Packaging notes:
-	Since this method is necessary for Ecompletion to work we had the following possibilities:
-		- Case 1: add this method as an extension of NECompletion, but it was creating a dependency from NECompletion to 	 		  Rubric.
-		- Case 2: add this method in this package. 
-		It implies somehow that Rubric depends on NEC but this is a lose coupling, when NECompletion is not loaded, we will get 		some dead code.
-		- Case 3: we could create a package NEC-Rubric that depends on Rubric and NECompletion. It seems a bit overkill.
-		
-	Now it looks like RubSmalltalkEditor could be packaged out of Rubric-Core.
-	and it would handle this. 
-	In addition the logic completion based on codeCompletionAround:  textMorph:  keyStroke: 
-	and the use of the registration as a tool is not really good because the completion requirement is not explicit. 
-	A better solution would be that the SmalltalkEditor has a default dummy ecompleter and that we can pass a more 
-	advanced one."
-		
-	^ self interactionModel ifNotNil: [ :im | im guessTypeForName: aString ]
-]
-
 { #category : #shout }
 RubScrolledTextModel >> hasBindingOf: aString [
 	^ interactionModel ifNil: [ false ] ifNotNil: [ interactionModel hasBindingOf: aString ]

--- a/src/Rubric/RubWorkspaceExample.class.st
+++ b/src/Rubric/RubWorkspaceExample.class.st
@@ -97,21 +97,8 @@ RubWorkspaceExample >> getText [
 ]
 
 { #category : #shout }
-RubWorkspaceExample >> guessTypeForName: aString [
-
-	| binding |
-
-	bindings
-		ifNotNil: [ binding := bindings at: aString ifAbsent: [ nil ].
-			binding ifNotNil: [ ^ binding class ]
-			].
-
-	^ nil
-]
-
-{ #category : #shout }
 RubWorkspaceExample >> hasBindingOf: aString [
-	^(self guessTypeForName: aString) notNil
+	^bindings includesKey: aString asSymbol
 ]
 
 { #category : #shout }

--- a/src/Spec-MorphicAdapters/MorphicTextAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTextAdapter.class.st
@@ -144,12 +144,6 @@ MorphicTextAdapter >> getText [
 	^ self model text
 ]
 
-{ #category : #NOCompletion }
-MorphicTextAdapter >> guessTypeForName: aString [
-
-	^nil
-]
-
 { #category : #'spec protocol' }
 MorphicTextAdapter >> hasEditingConflicts: aBoolean [
  

--- a/src/Spec2-Adapters-Morphic/SpMorphicCodeAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicCodeAdapter.class.st
@@ -41,12 +41,6 @@ SpMorphicCodeAdapter >> doItReceiver [
 	^ self model doItReceiver
 ]
 
-{ #category : #NOCompletion }
-SpMorphicCodeAdapter >> guessTypeForName: aString [
-
-	^nil
-]
-
 { #category : #private }
 SpMorphicCodeAdapter >> hasSyntaxHighlight [
 	^ self model hasSyntaxHighlight

--- a/src/Tool-Workspace/Workspace.class.st
+++ b/src/Tool-Workspace/Workspace.class.st
@@ -194,20 +194,8 @@ Workspace >> fileName: anObject [
 ]
 
 { #category : #'shout bindings' }
-Workspace >> guessTypeForName: aString [
-
-	| binding |
-
-	bindings
-		ifNotNil: [ binding := bindings at: aString ifAbsent: [ nil ].
-			binding ifNotNil: [ ^ binding class ]
-			].
-	^ nil
-]
-
-{ #category : #'shout bindings' }
 Workspace >> hasBindingOf: aString [ 
-	^(self guessTypeForName: aString) notNil
+	^bindings includesKey: aString asSymbol
 ]
 
 { #category : #'shout bindings' }


### PR DESCRIPTION
#guessTypeForName: is only used to  implement #hasBindingOf: in Workspace. This is not needed as we can just use #includesKey. Faster and much cleaner.