### PR TITLE
Wording fix on deleting a non-empty package

### DIFF
--- a/src/SystemCommands-PackageCommands/SycRemovePackageCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycRemovePackageCommand.class.st
@@ -37,6 +37,6 @@ SycRemovePackageCommand >> prepareFullExecutionInContext: aToolContext [
 	packagesWithClasses ifNotEmpty: [ 	
 		names := (packagesWithClasses collect: [:package | package name ]) joinUsing: ', '.
 		answer := UIManager default confirm: (
-			'Are you sure you want to delete the selection(s)?', String cr, names, ' still have classes').
+			'Are you sure you want to delete the selection(s)?', String cr, names, ' still contains classes.').
 		answer ifFalse: [ CmdCommandAborted signal ]]
 ]


### PR DESCRIPTION
"FooPackage still have classes" should be "FooPackage still contains
classes".