### PR TITLE
Cleanup #ultimateSourceCodeAt:ifAbsent:

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1822,17 +1822,6 @@ Behavior >> typeOfClass [
 	^#normal
 ]
 
-{ #category : #'accessing method dictionary' }
-Behavior >> ultimateSourceCodeAt: selector ifAbsent: aBlock [
-	"Return the source code at selector, deferring to superclass if necessary"
-	^ self sourceCodeAt: selector ifAbsent:
-		[self superclass
-			ifNil:
-				[aBlock value]
-			 ifNotNil:
-				[self superclass ultimateSourceCodeAt: selector ifAbsent: aBlock]]
-]
-
 { #category : #'user interface' }
 Behavior >> unreferencedInstanceVariables [
 	"Return a list of the instance variables defined in the receiver which are not referenced in the receiver or any of its subclasses."

--- a/src/Tool-Profilers/TimeProfiler.class.st
+++ b/src/Tool-Profilers/TimeProfiler.class.st
@@ -527,13 +527,11 @@ TimeProfiler >> selectedClass [
 
 { #category : #'accessing-computed' }
 TimeProfiler >> selectedMethodCode [
-	^ self selectedNode 
-		ifNil: [ self helpMessage ]
-		ifNotNil: [ :currNode | 
-			| class selector |
-			class := currNode methodClass.
-			selector := currNode selector.
-			(class ultimateSourceCodeAt: selector ifAbsent: [ 'error' ])]
+	| node method |
+	node := self selectedNode.
+	node ifNil: [ ^ self helpMessage ].
+	method := (node methodClass lookupSelector: node selector) ifNil: [ ^'Method not found' ].
+	^method sourceCode
 ]
 
 { #category : #compiling }


### PR DESCRIPTION
TimeProfiler has a method in Behavior that makes no sense. One can just use #lookupSelector: instead and the code is even easier to understand.