### PR TITLE
move-asStringYMDHM-to-base-package

### DIFF
--- a/src/Kernel/DateAndTime.class.st
+++ b/src/Kernel/DateAndTime.class.st
@@ -303,6 +303,17 @@ DateAndTime >> asDuration [
 ]
 
 { #category : #converting }
+DateAndTime >> asStringYMDHM [
+
+	^ String streamContents: [ :aStream |
+		self printYMDOn: aStream.
+		aStream nextPut: Character space.
+		self hour printOn: aStream base: 10 length: 2 padded: true.
+		aStream nextPut: $:.
+		self minute printOn: aStream base: 10 length: 2 padded: true ]
+]
+
+{ #category : #converting }
 DateAndTime >> asTime [
 
 	^ Time seconds: self secondsSinceMidnightLocalTime nanoSeconds: nanos


### PR DESCRIPTION
moving this method from iceberg to base package. 
This is because more packages are now using it (like Dr Test)