### PR TITLE
2588-New-Rubric-widget-has-placeholder-centered-instead-of-left-aligned

### DIFF
--- a/src/Rubric/RubScrolledTextMorph.class.st
+++ b/src/Rubric/RubScrolledTextMorph.class.st
@@ -270,7 +270,16 @@ RubScrolledTextMorph >> columnRuler [
 { #category : #configure }
 RubScrolledTextMorph >> configureGhostText: aTextArea [
 	aTextArea width: self scrollBounds width.
-	aTextArea center: self scrollBounds center
+
+	"If the text input is smaller in height than the ghost area 
+	we use the center, if it bigger we can use 0.
+	Using center will calculate a negative top value, that is 
+	required when the ghost is bigger than the input box"	
+			
+	(aTextArea height < self scrollBounds height)
+		ifTrue: [ aTextArea top: self scrollBounds top ]
+		ifFalse: [ aTextArea center: self scrollBounds center.
+					  aTextArea left: self scrollBounds left ] 
 ]
 
 { #category : #'interactive error protocol' }

--- a/src/Rubric/RubTextFieldMorph.class.st
+++ b/src/Rubric/RubTextFieldMorph.class.st
@@ -73,12 +73,14 @@ RubTextFieldMorph >> closeChooser [
 		ifNotNil: [entryCompletion closeChooser]
 ]
 
-{ #category : #configure }
+{ #category : #accessing }
 RubTextFieldMorph >> configureGhostText: aTextArea [
+
+	"Text Input always is in the middle of the text input"
+
 	super configureGhostText: aTextArea.
-	self hasKeyboardFocus
-		ifTrue: [ 
-			aTextArea left: self left]
+	aTextArea center: self scrollBounds center.
+	aTextArea left: self scrollBounds left 
 ]
 
 { #category : #defaults }


### PR DESCRIPTION
Text Input are centered in all the cases.
In the text are in the top of the widget. Or the center if the text area is smaller.