### PR TITLE
4986-Improve-messageBrowser-title-customization

### DIFF
--- a/src/Spec2-Tools/MessageBrowser.class.st
+++ b/src/Spec2-Tools/MessageBrowser.class.st
@@ -550,7 +550,7 @@ MessageBrowser >> textModel: aModel [
 
 { #category : #private }
 MessageBrowser >> title [
-	^ title ifNil: [ title := self defaultTitle ]
+	^ title ifNil: [ self defaultTitle ]
 
 ]
 

--- a/src/Spec2-Tools/MessageBrowser.class.st
+++ b/src/Spec2-Tools/MessageBrowser.class.st
@@ -13,7 +13,8 @@ Class {
 	#superclass : #AbstractMessageCentricBrowser,
 	#instVars : [
 		'textModel',
-		'refreshingBlock'
+		'refreshingBlock',
+		'title'
 	],
 	#category : #'Spec2-Tools-Senders'
 }
@@ -174,6 +175,11 @@ MessageBrowser >> connectPresenters [
 		whenSelectionChangedDo: [ :selection | [ :item | self selectItem: item ] cull: selection selectedItem ];
 		whenModelChangedDo: [ self updateTitle ].
 	textModel acceptBlock: [ :text :notifyer | (self accept: text notifying: notifyer) notNil ]
+]
+
+{ #category : #private }
+MessageBrowser >> defaultTitle [ 
+	^ self class title , ' [' , messageList numberOfElements printString , ']'
 ]
 
 { #category : #'text selection' }
@@ -544,7 +550,14 @@ MessageBrowser >> textModel: aModel [
 
 { #category : #private }
 MessageBrowser >> title [
-	^ self class title , ' [' , messageList numberOfElements printString , ']'
+	^ title ifNil: [ title := self defaultTitle ]
+
+]
+
+{ #category : #private }
+MessageBrowser >> title: aString [ 
+	title := aString.
+	self updateTitle 
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fixes: #4986 now message list title can be changed by users.