### PR TITLE
4458 rotation halo is broken

### DIFF
--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -3167,9 +3167,9 @@ Morph >> handlesMouseMove: anEvent [
 			+ and some button is down,
 			+ and the receiver is the current mouse focus."
 			
-	self eventHandler ifNotNil: [ :handler | 
+	"self eventHandler ifNotNil: [ :handler | 
 		(handler handlesMouseMove: anEvent) ifTrue: [ 
-			^ true ] ].
+			^ true ] ]."
 				
 	^anEvent hand submorphs isEmpty and: [ 	 
 		(anEvent anyButtonPressed and:[

--- a/src/Morphic-Tests/MorphTest.class.st
+++ b/src/Morphic-Tests/MorphTest.class.st
@@ -8,7 +8,8 @@ Class {
 	#name : #MorphTest,
 	#superclass : #TestCase,
 	#instVars : [
-		'morph'
+		'morph',
+		'circleMorph'
 	],
 	#category : #'Morphic-Tests-Kernel'
 }
@@ -16,12 +17,14 @@ Class {
 { #category : #running }
 MorphTest >> setUp [
 	super setUp.
-	morph := Morph new
+	morph := Morph new.
+	circleMorph := CircleMorph new.
 ]
 
 { #category : #running }
 MorphTest >> tearDown [
 	morph delete.
+	circleMorph delete.
 	super tearDown
 ]
 
@@ -202,6 +205,26 @@ MorphTest >> testIntoWorldTransferToNewGuy [
 { #category : #'testing - classification' }
 MorphTest >> testIsMorph [
 	self assert: (morph isMorph).
+]
+
+{ #category : #'as yet unclassified' }
+MorphTest >> testMouseOverRotationHandleShouldNotSignalMessageNotUnderstood [
+	"Mousing hover the rotation handle of a morph should not raise '#degrees was sent to nil'"
+
+	"This test is performed on @circleMorph and not just @morph because the morph used needs to want to generate a rotation halo (see method #wantsHaloHandleWithSelector:inHalo:). Instances of Morph do not want that, but instances of CircleMorph do."
+	| mouseDownEventToCreateHalos handMorph halo pos mouseMoveEvent |
+	handMorph := WorldMorph cursorOwnerWorld worldState hands first.
+	mouseDownEventToCreateHalos := MouseButtonEvent new setType: #mouseDown position: circleMorph position buttons: 73 hand: handMorph.
+	"73 encodes the shift+Alt/Option modifiers"
+	circleMorph openInWorld.
+	halo := circleMorph addHalo: mouseDownEventToCreateHalos.
+	"Specifically finding the rotation halo does not seem easy to do in a robust way (you could always search for the name of the icon or some other characteristic like that, but what if the icon is changed in the future?). So we'll send a mouse hover event to each submorph. "
+	halo submorphs do: [ :subMorph |
+		pos := subMorph position.
+		mouseMoveEvent := MouseMoveEvent new setType: #mouseMove startPoint: pos endPoint: pos trail: nil buttons: 0 hand: handMorph stamp: 0.
+		self flag: #improvement. "Is there a way to be more precise in the following assertion: to say that the block shouldn't raise a MessageNotUnderstood **for the #degrees selector**?"
+		self shouldnt: [subMorph handleEvent: mouseMoveEvent] raise: MessageNotUnderstood.
+	].
 ]
 
 { #category : #'testing - initialization' }

--- a/src/Morphic-Tests/MorphTest.class.st
+++ b/src/Morphic-Tests/MorphTest.class.st
@@ -207,7 +207,7 @@ MorphTest >> testIsMorph [
 	self assert: (morph isMorph).
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'testing - initialization' }
 MorphTest >> testMouseOverRotationHandleShouldNotSignalMessageNotUnderstood [
 	"Mousing hover the rotation handle of a morph should not raise '#degrees was sent to nil'"
 
@@ -215,14 +215,13 @@ MorphTest >> testMouseOverRotationHandleShouldNotSignalMessageNotUnderstood [
 	| mouseDownEventToCreateHalos handMorph halo pos mouseMoveEvent |
 	handMorph := WorldMorph cursorOwnerWorld worldState hands first.
 	mouseDownEventToCreateHalos := MouseButtonEvent new setType: #mouseDown position: circleMorph position buttons: 73 hand: handMorph.
-	"73 encodes the shift+Alt/Option modifiers"
 	circleMorph openInWorld.
 	halo := circleMorph addHalo: mouseDownEventToCreateHalos.
 	"Specifically finding the rotation halo does not seem easy to do in a robust way (you could always search for the name of the icon or some other characteristic like that, but what if the icon is changed in the future?). So we'll send a mouse hover event to each submorph. "
 	halo submorphs do: [ :subMorph |
 		pos := subMorph position.
 		mouseMoveEvent := MouseMoveEvent new setType: #mouseMove startPoint: pos endPoint: pos trail: nil buttons: 0 hand: handMorph stamp: 0.
-		self flag: #improvement. "Is there a way to be more precise in the following assertion: to say that the block shouldn't raise a MessageNotUnderstood **for the #degrees selector**?"
+		"Is there a way to be more precise in the following assertion: to say that the block shouldn't raise a MessageNotUnderstood **for the #degrees selector**?"
 		self shouldnt: [subMorph handleEvent: mouseMoveEvent] raise: MessageNotUnderstood.
 	].
 ]


### PR DESCRIPTION
Fixes #4458 
And adds a test for it.

This is the quick way of fixing the bug: removing the fact that a Morph receives MouseMove events if he explicitly registered for them, regardless of whether the requirements are met (see method Morph>>#handlesMouseMove:).

This bypass feature has been added by #3381 , but it doesn't give a concrete case of why it was added.

If this feature must stay after all, fixing this bug could be done by refactoring the HaloMorph class, to create dedicated subclasses for each type of morph handle and implement their methods #mouseMove: and #mouseDown: in a way that removes the need for the explicit event registration happening in the methods creating the handles (for example HaloMorph>>#addRotateHandle: