### PR TITLE
5003-Menu-is-broken-in-class-definition-pane

### DIFF
--- a/src/Commander-Activators-ContextMenu/CmdMenuGroup.extension.st
+++ b/src/Commander-Activators-ContextMenu/CmdMenuGroup.extension.st
@@ -44,7 +44,8 @@ CmdMenuGroup >> registerContextMenuItemsWithBuilder: aBuilder [
 	contents do: [ :each | 
 		each registerContextMenuItemsWithBuilder: aBuilder ].
 	
-	self isInlined ifTrue: [ aBuilder withSeparatorAfter ]
+	self isInlined & aBuilder items notEmpty 
+		ifTrue: [ aBuilder withSeparatorAfter ]
 ]
 
 { #category : #'*Commander-Activators-ContextMenu' }


### PR DESCRIPTION
Fix for #5003.Fixes the case when items of inlined group do not add anything to the menu.