### PR TITLE
5015-Epicea-EpLostCHangesDetector-should-be-Spec2fied

### DIFF
--- a/src/EpiceaBrowsers/EpLostChangesDetector.class.st
+++ b/src/EpiceaBrowsers/EpLostChangesDetector.class.st
@@ -113,9 +113,8 @@ EpLostChangesDetector >> openBrowserIfLostChanges [
 	lostChangesLog := EpLog newWithStore: (OmMemoryStore withAll: lostChanges).
 
 	browser := EpLogBrowserPresenter newWithLog: lostChangesLog.
-	browser
-		refresh;
-		title: 'Epicea - Lost Changes Detected';
-		openWithSpec.
+	browser refresh.
+	browser withWindowDo: [ :w | w title: 'Epicea - Lost Changes Detected'].
+	browser openWithSpec.
 
 ]


### PR DESCRIPTION
fixes: #5015 Now epicea does not raise an error