### PR TITLE
5018-RPackageSetcollectFromAllPackages-and-collectFromAllPackageswith-can-be-replaced-by-flatCollect

### DIFF
--- a/src/Deprecated80/RPackageSet.extension.st
+++ b/src/Deprecated80/RPackageSet.extension.st
@@ -1,6 +1,20 @@
 Extension { #name : #RPackageSet }
 
 { #category : #'*Deprecated80' }
+RPackageSet >> collectFromAllPackages: selector [
+	self deprecated: 'Use `packages flatCollect:` instead.' transformWith: '`@receiver collectFromAllPackages: `@arg' -> '`@receiver packages flatCollect: `@arg'.
+	^ self packages inject: #() into: [ :all :each | all , (each perform: selector) asArray ]
+]
+
+{ #category : #'*Deprecated80' }
+RPackageSet >> collectFromAllPackages: selector with: anObject [
+	self deprecated: 'Use `packages flatCollect:` instead' on: '27-10-2019' in: #Pharo8.
+	^self packages
+		inject: #()
+		into: [ :all :each | all, (each perform: selector with: anObject) asArray ]
+]
+
+{ #category : #'*Deprecated80' }
 RPackageSet >> extensionClasses [
 	self deprecated: 'Use #extensionClasses instead.' transformWith: '`@receiver extensionClasses' -> '`@receiver extendedClasses'.
 	^ self extendedClasses

--- a/src/RPackage-Core/RPackageSet.class.st
+++ b/src/RPackage-Core/RPackageSet.class.st
@@ -109,31 +109,17 @@ RPackageSet >> changeRecordForOverriddenMethod: aMethodDefinition [
 
 { #category : #accessing }
 RPackageSet >> classes [
-	^classes ifNil: [ classes := self collectFromAllPackages: #definedClasses ]
-]
-
-{ #category : #private }
-RPackageSet >> collectFromAllPackages: selector [
-	^self packages
-		inject: #()
-		into: [ :all :each | all, (each perform: selector) asArray ]
-]
-
-{ #category : #private }
-RPackageSet >> collectFromAllPackages: selector with: anObject [
-	^self packages
-		inject: #()
-		into: [ :all :each | all, (each perform: selector with: anObject) asArray ]
+	^classes ifNil: [ classes := self packages flatCollect: #definedClasses ]
 ]
 
 { #category : #accessing }
 RPackageSet >> definedClasses [
-	^definedClasses ifNil: [ definedClasses := self collectFromAllPackages: #definedClasses ]
+	^definedClasses ifNil: [ definedClasses := self packages flatCollect: #definedClasses ]
 ]
 
 { #category : #'system compatibility' }
 RPackageSet >> extendedClasses [
-	^ self collectFromAllPackages: #extendedClasses
+	^ self packages flatCollect: #extendedClasses
 ]
 
 { #category : #'system compatibility' }
@@ -143,8 +129,9 @@ RPackageSet >> extensionCategoriesForClass: aClass [
 
 { #category : #accessing }
 RPackageSet >> extensionMethods [
-	^extensionMethods ifNil: [
-		extensionMethods := ((self collectFromAllPackages: #extensionMethods) collect: #asRingDefinition) asSet asArray ]
+	^ extensionMethods ifNil: [
+		extensionMethods :=
+		((self packages flatCollect: [ :p | p extensionMethods ] as: Set) collect: #asRingDefinition) asArray ]
 ]
 
 { #category : #testing }
@@ -192,7 +179,7 @@ RPackageSet >> methodCategoryPrefix [
 
 { #category : #accessing }
 RPackageSet >> methods [
-	^methods ifNil: [ methods := (self collectFromAllPackages: #methods) collect: #asRingDefinition ]
+	^ methods ifNil: [ methods := (self packages flatCollect: [ :p | p methods ]) collect: #asRingDefinition ]
 ]
 
 { #category : #accessing }
@@ -207,8 +194,7 @@ RPackageSet >> packages [
 
 { #category : #'system compatibility' }
 RPackageSet >> systemCategories [
-	^systemCategories ifNil: [ systemCategories := (self collectFromAllPackages: #systemCategories) asSet asArray].
-	
+	^ systemCategories ifNil: [ systemCategories := (self packages flatCollect: #systemCategories as: Set) asArray ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Use #flatCollect: instead of #collectFromAllPackages: since it is more optimized.

Fixes #5018