### PR TITLE
Allow-to-use-boolean-with-sort-functions

### DIFF
--- a/src/SortFunctions-Core/Boolean.extension.st
+++ b/src/SortFunctions-Core/Boolean.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Boolean }
+
+{ #category : #'*SortFunctions-Core' }
+Boolean >> threeWayCompareTo: anotherObject [
+	^ self asBit threeWayCompareTo: anotherObject asBit
+]

--- a/src/SortFunctions-Tests/SortFunctionTest.class.st
+++ b/src/SortFunctions-Tests/SortFunctionTest.class.st
@@ -89,6 +89,13 @@ SortFunctionTest >> testSingleArgBlock [
 	self assert: (function value: 3 @ 2 value: 1 @ 1)
 ]
 
+{ #category : #tests }
+SortFunctionTest >> testSortUsingBooleans [
+	| datas |
+	datas := #(1 2 3 4 5).
+	self assert: (datas sorted: #odd ascending) equals: #(2 4 1 3 5)
+]
+
 { #category : #'tests - sorting' }
 SortFunctionTest >> testSorting [
 	| data sorted |

--- a/src/SortFunctions-Tests/ThreeWayComparisonTest.class.st
+++ b/src/SortFunctions-Tests/ThreeWayComparisonTest.class.st
@@ -8,6 +8,14 @@ Class {
 }
 
 { #category : #tests }
+ThreeWayComparisonTest >> testBooleans [
+	self assert: (true threeWayCompareTo: false) equals: 1.
+	self assert: (false threeWayCompareTo: true) equals: -1.
+	self assert: (true threeWayCompareTo: true) equals: 0.
+	self assert: (false threeWayCompareTo: false) equals: 0
+]
+
+{ #category : #tests }
 ThreeWayComparisonTest >> testFloats [
 
 	| a b c d |


### PR DESCRIPTION
Add a comparison between booleans in sort functions.

With this I can replace:

```Smalltalk
meta allProperties
	sorted:
		[ :property1 :property2 | property1 name = #name ifTrue: [ -1 ] ifFalse: [ property2 name = #name ifTrue: [ 1 ] ifFalse: [ 0 ] ] ] ascending,
		[ :p | p isComposite ifTrue: [ 1 ] ifFalse: [ -1 ] ] ascending,
		#name ascending
```

by:

```Smalltalk
meta allProperties
	sorted:
		[ :property | property name = #name ] descending,
		#isComposite ascending,
		#name ascending
```