### PR TITLE
4481-Copying-class-does-not-copy-class-comment

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -476,7 +476,7 @@ Class >> deprecationRefactorings [
 
 { #category : #copying }
 Class >> duplicateClassWithNewName: aSymbol [
-	| copysName class |
+	| copysName class newComment |
 			
 	copysName := aSymbol asSymbol.
 	copysName = self name
@@ -491,6 +491,9 @@ Class >> duplicateClassWithNewName: aSymbol [
 		
 	class copyAllCategoriesFrom: self.
 	class class copyAllCategoriesFrom: self class.
+	"we copy the comment but with an explanation that it might be out of date"
+	newComment := 'I am a copy of class ', self name, '. This comment is copied from there, and might not be entirely accurate'.
+	class comment: newComment , String cr,  String cr,  self comment.
 	^ class
 ]
 


### PR DESCRIPTION
fixes #4481

- copy over class comment on copy
- but with a note on top