### PR TITLE
Dictionary #value  should use #streamContents:

### DIFF
--- a/src/Collections-Unordered/Dictionary.class.st
+++ b/src/Collections-Unordered/Dictionary.class.st
@@ -777,10 +777,9 @@ Dictionary >> valueAtNewKey: aKey put: anObject atIndex: index declareFrom: aDic
 { #category : #accessing }
 Dictionary >> values [
 	"Answer a Collection containing the receiver's values."
-	| out |
-	out := (Array new: self size) writeStream.
-	self valuesDo: [:value | out nextPut: value].
-	^ out contents
+	^Array 
+		new: self size 
+		streamContents: [ :out | self valuesDo: [:value | out nextPut: value]]
 ]
 
 { #category : #enumerating }

--- a/src/Collections-Unordered/SmallDictionary.class.st
+++ b/src/Collections-Unordered/SmallDictionary.class.st
@@ -756,12 +756,9 @@ SmallDictionary >> storeOn: aStream [
 { #category : #accessing }
 SmallDictionary >> values [
 	"Answer a Collection containing the receiver's values."
-	"^ values copyFrom: 1 to: size."
-	
-| out |
-	out := (Array new: self size) writeStream.
-	self valuesDo: [:value | out nextPut: value].
-	^ out contents
+	^Array 
+		new: self size 
+		streamContents: [ :out | self valuesDo: [:value | out nextPut: value]]
 ]
 
 { #category : #enumerating }


### PR DESCRIPTION
Dictionary and SmallDictionary #values can use new:streamContents: (#keys is doing that already).

Speed is not impacted as the implemention does exactly the same,