### PR TITLE
table-headers-should-not-be-rows

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTTableContainerMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableContainerMorph.class.st
@@ -94,7 +94,9 @@ FTTableContainerMorph >> calculateExactVisibleRows [
 
 	| visibleRows |
 	visibleRows := self height / (self table rowHeight + self table intercellSpacing y).
-	^ headerRow ifNotNil: [ visibleRows - 1 ] ifNil: [ visibleRows ]
+	^ headerRow 
+		ifNotNil: [ visibleRows - 1 ] 
+		ifNil: [ visibleRows ]
 ]
 
 { #category : #private }
@@ -411,7 +413,7 @@ FTTableContainerMorph >> updateHeaderRow [
 		columnHeaders at: index put: headerCell.
 		FTDisplayColumn column: each width: columnWidth ].
 	 
-	headerRow := (FTTableRowMorph table: self table)
+	headerRow := (FTTableHeaderRowMorph table: self table)
 		privateOwner: self;
 		addAllMorphs: columnHeaders;
 		yourself

--- a/src/Morphic-Widgets-FastTable/FTTableHeaderRowMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableHeaderRowMorph.class.st
@@ -1,0 +1,15 @@
+"
+I'm a header for a table.
+All my work is to keep header cells, but my behavior is slightly different to my parent (since I cannot be selected, for example)
+"
+Class {
+	#name : #FTTableHeaderRowMorph,
+	#superclass : #FTTableRowMorph,
+	#category : #'Morphic-Widgets-FastTable'
+}
+
+{ #category : #'event handling' }
+FTTableHeaderRowMorph >> handlesMouseOver: event [
+
+	^ false
+]


### PR DESCRIPTION
separating FTTableRowMorph and FTTableHeaderRowMorph to make sure header row behaves different to a simple row