### PR TITLE
5029-ChunkWriteStreamnextPut-contains-a-very-inefficient-loop

### DIFF
--- a/src/CodeExport/ChunkWriteStream.class.st
+++ b/src/CodeExport/ChunkWriteStream.class.st
@@ -32,18 +32,20 @@ ChunkWriteStream >> nextChunkPut: aString [
 
 { #category : #accessing }
 ChunkWriteStream >> nextPut: aString [
-    "Append the argument, aString, to the receiver, doubling embedded terminators."
- 
-    | i remainder terminator | 
-    terminator := $!.
-    remainder := aString asString.
-    [(i := remainder indexOf: terminator) = 0] whileFalse:
-        [decoratedStream nextPutAll: (remainder copyFrom: 1 to: i).
-        decoratedStream nextPut: terminator.  "double imbedded terminators"
-        remainder := remainder copyFrom: i+1 to: remainder size].
-    decoratedStream nextPutAll: remainder. 
-    decoratedStream nextPut: terminator.
-    decoratedStream flush.
+	"Append the argument, aString, to the receiver, doubling embedded ! terminators and adding a extra one"
+
+	| string start bangIndex |
+	string := aString asString.
+	start := 1.
+	[ (bangIndex := string indexOf: self terminatorMark startingAt: start) = 0 ]
+		whileFalse: [
+			decoratedStream next: bangIndex - start + 1 putAll: string startingAt: start.
+			self bang. "double it"
+			start := bangIndex + 1 ].
+	decoratedStream next: string size - start + 1 putAll: string startingAt: start.
+	self bang. "one extra"
+	decoratedStream flush
+
 ]
 
 { #category : #accessing }

--- a/src/CodeExport/WriteStream.extension.st
+++ b/src/CodeExport/WriteStream.extension.st
@@ -2,23 +2,23 @@ Extension { #name : #WriteStream }
 
 { #category : #'*CodeExport' }
 WriteStream >> nextChunkPut: aString [
-	"Append the argument, aString, to the receiver, doubling embedded terminators."
+	"Append the argument, aString, to the receiver, doubling embedded ! terminators and adding a extra one"
  
-	| i remainder terminator | 
-	terminator := $!.
-	remainder := aString asString.
-	[(i := remainder indexOf: terminator) = 0] whileFalse:
-		[self nextPutAll: (remainder copyFrom: 1 to: i).
-		self nextPut: terminator.  "double imbedded terminators"
-		remainder := remainder copyFrom: i+1 to: remainder size].
-	self nextPutAll: remainder. 
-	aString asString includesUnifiedCharacter ifTrue: [
-		self nextPut: terminator.
-		self nextPutAll: ']lang['.
-		aString asString writeLeadingCharRunsOn: self.
+	| string start bangIndex |
+	string := aString asString.
+	start := 1.
+	[ (bangIndex := string indexOf: $! startingAt: start) = 0 ]
+		whileFalse: [
+			self next: bangIndex - start + 1 putAll: string startingAt: start.
+			self nextPut: $!. "double it"
+			start := bangIndex + 1 ].
+	self next: string size - start + 1 putAll: string startingAt: start.
+	string includesUnifiedCharacter ifTrue: [
+		self nextPut: $!; nextPutAll: ']lang['.
+		string writeLeadingCharRunsOn: self.
 	].
-	self nextPut: terminator.
-	self flush.
+	self nextPut: $!. "one extra"
+	self flush
 ]
 
 { #category : #'*CodeExport' }

--- a/src/System-Sources/SourceFile.class.st
+++ b/src/System-Sources/SourceFile.class.st
@@ -116,6 +116,13 @@ SourceFile >> next: anInteger [
 	^ stream next: anInteger
 ]
 
+{ #category : #accessing }
+SourceFile >> next: anInteger putAll: aString startingAt: startIndex [
+
+	stream next: anInteger putAll: aString startingAt: startIndex
+
+]
+
 { #category : #'fileIn/Out' }
 SourceFile >> nextChunk [
 

--- a/src/System-Sources/SourceFileCharacterReadWriteStream.class.st
+++ b/src/System-Sources/SourceFileCharacterReadWriteStream.class.st
@@ -72,6 +72,12 @@ SourceFileCharacterReadWriteStream >> next: anInteger [
 ]
 
 { #category : #accessing }
+SourceFileCharacterReadWriteStream >> next: anInteger putAll: aString startingAt: startIndex [
+
+	^ writeStream next: anInteger putAll: aString startingAt: startIndex
+]
+
+{ #category : #accessing }
 SourceFileCharacterReadWriteStream >> nextPut: aCharacter [
 
 	^ writeStream nextPut: aCharacter


### PR DESCRIPTION
https://github.com/pharo-project/pharo/issues/5029

Improve the efficiency of the loop in ChunkWriteStream>>#nextPut: and WrtiteStream>>#nextChunkPut:
Add #next:putAll:startingAt: to SourceFile and SourceFileCharacterReadWriteStream