### PR TITLE
FileSystem>>copyFileAndDelete:to: don't raise a FileDoesNotExistException if the destination doesn't exist

### DIFF
--- a/src/FileSystem-Core/FileSystem.class.st
+++ b/src/FileSystem-Core/FileSystem.class.st
@@ -252,7 +252,7 @@ FileSystem >> copyFileAndDelete: sourcePath to: destination [
 	[self copy: sourcePath toReference: destination] 
 		on: Error 
 		do: [ :error |
-			destination delete.
+			destination ensureDelete.
 			error signal].
 	self delete: sourcePath.
 	^destination


### PR DESCRIPTION
When renaming files Pharo falls back to copy-and-delete if the rename primitive fails (e.g. because the files are on different OS file systems).If the copy fails the destination is (appropriately) deleted:	[self copy: sourcePath toReference: destination] 		on: Error 		do: [ :error |			destination delete.			error signal].However with the current implementation, if the destination doesn't exist, e.g. because the destination's directory doesn't exist, or doesn't have write access, the delete operation will raise a FileDoesNotExistException and mask the underlying cause of the copy failure.Modify FileSystem>>copyFileAndDelete:to: so that it doesn't raise an exception if the destination doesn't exist.