### PR TITLE
4850-removeDuplicates-fails-on-Arrays

### DIFF
--- a/src/Collections-Sequenceable/OrderedCollection.class.st
+++ b/src/Collections-Sequenceable/OrderedCollection.class.st
@@ -687,20 +687,8 @@ OrderedCollection >> removeAt: index [
 
 { #category : #removing }
 OrderedCollection >> removeDuplicates [
-	| iterator |
-	"Remove the copies of elements, but keep the same order"
-	
-	self ifEmpty: [ ^ self ].
-	iterator := 1.
-	[ iterator <= self size ]
-		whileTrue: [ | each newIndex |
-			each := self at: iterator.
-			newIndex := iterator + 1.
-			[ newIndex := (self indexOf: each startingAt: newIndex).
-			newIndex > 0 ]
-				whileTrue: [ self removeAt: newIndex ].
-			iterator := iterator + 1.
-	 ]
+	self deprecated: 'use asSet instead' on: '2019-11--04' asDate in: 'Pharo 8.0'.
+	^self asSet asOrderedCollection 
 ]
 
 { #category : #removing }

--- a/src/Refactoring2-Transformations/RBRemoveMessageSendTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBRemoveMessageSendTransformation.class.st
@@ -80,7 +80,7 @@ RBRemoveMessageSendTransformation >> privateTransform [
 	methodTree := self definingMethod.
 	
 	"try to find a message node with the same selector"
-	nodesToModify := ( methodTree allChildren removeDuplicates
+	nodesToModify := ( methodTree allChildren asSet
 		select: #isMessage )
 		select: [ :node | node selector = message asSymbol ].
 	

--- a/src/Refactoring2-Transformations/RBRemovePragmaTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBRemovePragmaTransformation.class.st
@@ -82,7 +82,7 @@ RBRemovePragmaTransformation >> privateTransform [
 	| methodTree pragmaNode nodesToRemove |
 	methodTree := self definingMethod.
 	pragmaNode := self parserClass parsePragma: pragma.
-	nodesToRemove := (methodTree allChildren removeDuplicates
+	nodesToRemove := (methodTree allChildren asSet
 		select: #isPragma)
 		select: [ :node | node selector = pragmaNode selector ].
 	nodesToRemove do: [ :node | node parent removePragma: node ].

--- a/src/Refactoring2-Transformations/RBRemoveReturnStatementTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBRemoveReturnStatementTransformation.class.st
@@ -67,7 +67,7 @@ RBRemoveReturnStatementTransformation >> privateTransform [
 	| methodTree nodesToRemove |
 	methodTree := self definingMethod.
 	
-	nodesToRemove := ( methodTree allChildren removeDuplicates
+	nodesToRemove := ( methodTree allChildren asSet
 		select: #isReturn )
 		select: [ :node | node sourceCode = returnValue ].
 	

--- a/src/TraitsV2/TaSequence.class.st
+++ b/src/TraitsV2/TaSequence.class.st
@@ -251,9 +251,8 @@ TaSequence >> selectors [
 
 { #category : #accessing }
 TaSequence >> slots [
-	^ (members flatCollect: #slots)
-		removeDuplicates;
-		yourself
+	^ ((members flatCollect: #slots)
+		asSet) asOrderedCollection 
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
fixes #4850

remove duplicates was badly implemented in the wrong class. Better to stick with #asSet which has a clear semantics and is efficient.