### PR TITLE
2283-WorldState-refers-to-missing-class-DelayScheduler

### DIFF
--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -666,7 +666,7 @@ WorldState >> interCyclePause: milliSecs [
         		ifFalse: [ 0 ]
         		ifTrue: [ lastCycleTime + milliSecs - Time millisecondClockValue ].
  
-      		self flag: 'Issue 14754 - wait2>millisecs is only True for clock rollover. Remove it once DelayScheduler based on microsecondClock - Ben Coman 19.01.2015'.
+      		self flag: 'Issue 14754 - wait2>millisecs is only True for clock rollover. Remove it once display scheduler is based on microsecondClock - Ben Coman 19.01.2015'.
       		wait2 > milliSecs 
         		ifTrue: [ 0 ]
         		ifFalse: [ wait2 ]. 

--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -666,7 +666,7 @@ WorldState >> interCyclePause: milliSecs [
         		ifFalse: [ 0 ]
         		ifTrue: [ lastCycleTime + milliSecs - Time millisecondClockValue ].
  
-      		self flag: 'Issue 14754 - wait2>millisecs is only True for clock rollover. Remove it once display scheduler is based on microsecondClock - Ben Coman 19.01.2015'.
+      		self flag: 'Issue 14754 - wait2>millisecs is only True for clock rollover. Remove it once delay scheduler is based on microsecondClock - Ben Coman 19.01.2015'.
       		wait2 > milliSecs 
         		ifTrue: [ 0 ]
         		ifFalse: [ wait2 ]. 


### PR DESCRIPTION
fix the reference to the non existing class. This PR does not fix anyting else, that is another thing to do. fixes #2283