### PR TITLE
Fix-protocol-and-remove-useless-method

### DIFF
--- a/src/Deprecated80/Behavior.extension.st
+++ b/src/Deprecated80/Behavior.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Behavior }
+
+{ #category : #'*Deprecated80' }
+Behavior >> numberOfInstanceVariables [
+	self deprecated: 'Use #instSize or `slots size` instead.' transformWith: '`@receiver numberOfInstanceVariables' -> '`@receiver instSize'.
+	^ self instSize
+]

--- a/src/Kernel-Tests/BehaviorTest.class.st
+++ b/src/Kernel-Tests/BehaviorTest.class.st
@@ -110,6 +110,13 @@ BehaviorTest >> testIncludesMethod [
 	self deny: (LookupKey includesMethod: Point>>#x).
 ]
 
+{ #category : #metrics }
+BehaviorTest >> testInstSize [
+	self assert: Object instSize equals: 0.
+	self assert: Point instSize equals: 2.
+	self assert: Metaclass instSize equals: 1
+]
+
 { #category : #tests }
 BehaviorTest >> testIsAbstract [
 
@@ -177,13 +184,6 @@ BehaviorTest >> testMethodsWritingSlot [
 	numberViaSlot := (Point methodsWritingSlot: (Point slotNamed: #x)) size.
 	numberViaIVar := (Point whichSelectorsStoreInto: 'x') size.
 	self assert: numberViaSlot = numberViaIVar.
-]
-
-{ #category : #metrics }
-BehaviorTest >> testNumberOfInstanceVariables [
-	self assert: Object numberOfInstanceVariables equals: 0.
-	self assert: Point numberOfInstanceVariables equals: 2.
-	self assert: Metaclass numberOfInstanceVariables equals: 1
 ]
 
 { #category : #'tests - properties' }

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1359,12 +1359,6 @@ Behavior >> nonObsoleteClass [
 	^ self environment at: obsName asSymbol
 ]
 
-{ #category : #accessing }
-Behavior >> numberOfInstanceVariables [
-	^ self instVarNames size
-
-]
-
 { #category : #initialization }
 Behavior >> obsolete [
 	"nothing to be done"

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -942,7 +942,7 @@ Behavior >> initializeSlots: anObject [
 	self classLayout initializeInstance: anObject
 ]
 
-{ #category : #testing }
+{ #category : #'accessing instances and variables' }
 Behavior >> instSize [
 	"Answer the number of named instance variables
 	(as opposed to indexed variables) of the receiver.

--- a/src/Kernel/DeepCopier.class.st
+++ b/src/Kernel/DeepCopier.class.st
@@ -69,8 +69,6 @@ DeepCopier >> basicCheckClass: aClass [
 DeepCopier >> checkAllClasses [
 
 	| warnings |
-	self checkBasicClasses.
-
 	warnings := ((self systemNavigation allClassesImplementing: #veryDeepInner:),
 		(self systemNavigation allClassesImplementing: #veryDeepCopyWith:)) flatCollect: [ :aClass |
 			 self basicCheckClass: aClass ].
@@ -79,26 +77,14 @@ DeepCopier >> checkAllClasses [
 ]
 
 { #category : #checking }
-DeepCopier >> checkBasicClasses [
-	"Check that no indexes of instance vars have changed in certain classes.  If you get an error in this method, an implementation of veryDeepCopyWith: needs to be updated.  The idea is to catch a change while it is still in the system of the programmer who made it.  
-	DeepCopier new checkAllClasses"
-	Object instSize = 0 ifFalse: [ self error: 'Many implementers of veryDeepCopyWith: are out of date' ].
-
-
-
-]
-
-{ #category : #checking }
 DeepCopier >> checkClass: aClass [
-
-	| warnings |
-	self checkBasicClasses.
-	warnings := self basicCheckClass: aClass.
-	warnings ifNotEmpty: [
-		Warning new
-			messageText: 'VeryDeepCopy out of sync in some classes. Some classes contain veryDeepCopyWith: or veryDeepInner: methods that are not in sync with their instance variables. Check the exception #tag for a list of them';
-			tag: warnings;
-			signal ]
+	(self basicCheckClass: aClass)
+		ifNotEmpty: [ :warnings | 
+			Warning new
+				messageText:
+					'VeryDeepCopy out of sync in some classes. Some classes contain veryDeepCopyWith: or veryDeepInner: methods that are not in sync with their instance variables. Check the exception #tag for a list of them';
+				tag: warnings;
+				signal ]
 ]
 
 { #category : #'like fullCopy' }

--- a/src/Morphic-Widgets-FastTable/FTExampleClassInfoTableDataSource.class.st
+++ b/src/Morphic-Widgets-FastTable/FTExampleClassInfoTableDataSource.class.st
@@ -72,7 +72,7 @@ FTExampleClassInfoTableDataSource >> nameColumn: column row: rowIndex [
 { #category : #accessing }
 FTExampleClassInfoTableDataSource >> numberOfInstanceVariablesColumn: column row: rowIndex [
 	^ FTCellMorph new 
-		addMorph: (self elementAt: rowIndex) numberOfInstanceVariables asStringMorph;
+		addMorph: (self elementAt: rowIndex) instSize asStringMorph;
 		yourself
 ]
 

--- a/src/Morphic-Widgets-FastTable/FTExamples.class.st
+++ b/src/Morphic-Widgets-FastTable/FTExamples.class.st
@@ -611,7 +611,7 @@ FTExamples class >> exampleSortableTable2 [
 				yourself);
 		addColumn:
 			((FTColumn id: 'Number of instance variables')
-				sortableOnProperty: #numberOfInstanceVariables;
+				sortableOnProperty: #instSize;
 				yourself);
 		dataSource: FTExampleClassInfoTableDataSource new;
 		selectFirst;
@@ -645,7 +645,7 @@ FTExamples class >> exampleSortableTable3 [
 				yourself);
 		addColumn:
 			((FTColumn id: 'Number of instance variables')
-				sortableUsing: #numberOfInstanceVariables ascending , #name ascending; "Sort by number of inst var, if the same, sort by name."
+				sortableUsing: #instSize ascending , #name ascending; "Sort by number of inst var, if the same, sort by name."
 				yourself);
 		dataSource: FTExampleClassInfoTableDataSource new;
 		selectFirst;


### PR DESCRIPTION
Fix protocol of Behavior>>#instSize and remove useless check that Object has no instance variables.