### PR TITLE
Completion: Editor accessor CompletionEngineClass

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -109,7 +109,7 @@ BaselineOfBasicTools >> postload: loader package: packageSpec [
 	Smalltalk cleanOutUndeclared. 
 	
 	CompletionSorter register.
-	RubSmalltalkEditor completionEngine: CompletionEngine.
+	RubSmalltalkEditor completionEngineClass: CompletionEngine.
 	
 	Author reset.
 

--- a/src/NECompletion/NECPreferences.class.st
+++ b/src/NECompletion/NECPreferences.class.st
@@ -194,12 +194,12 @@ NECPreferences class >> settingsOn: aBuilder [
 					availableControllers := self availableEngines.
 					availableControllers size > 1
 						ifTrue: [ 
-							(aBuilder pickOne: #completionEngine)
+							(aBuilder pickOne: #completionEngineClass)
 								order: -1;
 								label: 'CompletionEngine';
 								target: RubSmalltalkEditor;
-								getSelector: #completionEngine;
-								setSelector: #completionEngine:;
+								getSelector: #completionEngineClass;
+								setSelector: #completionEngineClass:;
 								domainValues: availableControllers ].
 					availableSorters := self availableSorters.
 					availableSorters size > 1

--- a/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
+++ b/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
@@ -579,7 +579,7 @@ RubSmalltalkEditorTest >> testBestNodeWithValidValueMidSource [
 RubSmalltalkEditorTest >> testInstanceVersusSharedCompletionEngine [
 
 	| textEditor currentCompletion |
-	[ currentCompletion := RubSmalltalkEditor completionEngine.
+	[ currentCompletion := RubSmalltalkEditor completionEngineClass.
 	textEditor := RubSmalltalkEditor new.
 	self assert: textEditor completionEngine class equals: currentCompletion.
 	
@@ -589,7 +589,7 @@ RubSmalltalkEditorTest >> testInstanceVersusSharedCompletionEngine [
 	textEditor := RubSmalltalkEditor new.
 	self assert: textEditor completionEngine isNil.
 	
-	RubSmalltalkEditor completionEngine: CompletionEngine.
+	RubSmalltalkEditor completionEngineClass: CompletionEngine.
 	self assert: textEditor completionEngine isNil.
 	
 	"but now when we create a new one it gets the correct engine"
@@ -597,7 +597,7 @@ RubSmalltalkEditorTest >> testInstanceVersusSharedCompletionEngine [
 	self assert: textEditor completionEngine class equals: CompletionEngine.
 	
 	
-	] ensure: [ RubSmalltalkEditor completionEngine: currentCompletion ]
+	] ensure: [ RubSmalltalkEditor completionEngineClass: currentCompletion ]
 	
 ]
 
@@ -1039,12 +1039,12 @@ RubSmalltalkEditorTest >> testPlaygroundWidenOnSelf [
 RubSmalltalkEditorTest >> testSettingCompletionFromEditor [
 
 	| currentCompletion |
-	[ currentCompletion := RubSmalltalkEditor completionEngine. 
+	[ currentCompletion := RubSmalltalkEditor completionEngineClass. 
 	
-	RubSmalltalkEditor completionEngine: CompletionEngine.
-	self assert: RubSmalltalkEditor completionEngine equals: CompletionEngine.
+	RubSmalltalkEditor completionEngineClass: CompletionEngine.
+	self assert: RubSmalltalkEditor completionEngineClass equals: CompletionEngine.
 	
-	] ensure: [ RubSmalltalkEditor completionEngine: currentCompletion ]
+	] ensure: [ RubSmalltalkEditor completionEngineClass: currentCompletion ]
 	
 ]
 
@@ -1052,15 +1052,15 @@ RubSmalltalkEditorTest >> testSettingCompletionFromEditor [
 RubSmalltalkEditorTest >> testSettingCompletionFromEditorToTextArea [
 
 	| textEditor currentCompletion |
-	[ currentCompletion := RubSmalltalkEditor completionEngine.
+	[ currentCompletion := RubSmalltalkEditor completionEngineClass.
 	
-	RubSmalltalkEditor completionEngine: CompletionEngine.
+	RubSmalltalkEditor completionEngineClass: CompletionEngine.
 	textEditor := RubSmalltalkEditor new.
 	self assert: textEditor completionEngine class equals: CompletionEngine.
 	textEditor textArea: RubEditingArea new. 
 	self assert: textEditor textArea completionEngine class equals: CompletionEngine.
 	
-	] ensure: [ RubSmalltalkEditor completionEngine: currentCompletion ]
+	] ensure: [ RubSmalltalkEditor completionEngineClass: currentCompletion ]
 	
 ]
 

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -135,13 +135,13 @@ RubSmalltalkEditor class >> buildShortcutsOn: aBuilder [
 ]
 
 { #category : #'completion engine' }
-RubSmalltalkEditor class >> completionEngine [
+RubSmalltalkEditor class >> completionEngineClass [
 	
 	^ CompletionEngineClass
 ]
 
 { #category : #'completion engine' }
-RubSmalltalkEditor class >> completionEngine: anEngine [
+RubSmalltalkEditor class >> completionEngineClass: anEngine [
 	
 	CompletionEngineClass := anEngine
 ]


### PR DESCRIPTION
In  a prior change we changed the class var of RubSmalltalkEditor to be CompletionEngineClass. 
This change renames the accessor, too.