### PR TITLE
Compiler: Document Plugin AST copying

### DIFF
--- a/src/OpalCompiler-Core/OCCompilerASTPlugin.class.st
+++ b/src/OpalCompiler-Core/OCCompilerASTPlugin.class.st
@@ -15,8 +15,8 @@ IR
 
 
 These plugins are called <<HERE>>, that is, after semantic analysis before generating the IR.
-They are sorted by #priority and handed a *copy* of the AST.
-
+They are sorted by #priority and handed the AST without making a copy (as plugins might just analyste
+the AST).. If you modify the AST, you have to make a copy before!
 
 
 "
@@ -36,9 +36,7 @@ OCCompilerASTPlugin class >> priority [
 
 { #category : #'instance creation' }
 OCCompilerASTPlugin class >> transform: ast [
-	^self new
-		ast: ast;
-		transform.
+	^self new transform: ast
 ]
 
 { #category : #accessing }
@@ -53,12 +51,13 @@ OCCompilerASTPlugin >> priority [
 
 { #category : #api }
 OCCompilerASTPlugin >> transform [
-	
+	"Plugins override this method. If you modify the AST, make sure to copy it before!"
 	self subclassResponsibility.
 ]
 
 { #category : #api }
 OCCompilerASTPlugin >> transform: anRBMethodNode [
-	"by default do nothing"
-	^ ast := anRBMethodNode.
+	ast := anRBMethodNode.
+	self transform.
+	^ast.
 ]

--- a/src/OpalCompiler-Core/OCCompilerASTPlugin.class.st
+++ b/src/OpalCompiler-Core/OCCompilerASTPlugin.class.st
@@ -15,8 +15,7 @@ IR
 
 
 These plugins are called <<HERE>>, that is, after semantic analysis before generating the IR.
-They are sorted by #priority and handed the AST without making a copy (as plugins might just analyste
-the AST).. If you modify the AST, you have to make a copy before!
+They are sorted by #priority and handed the AST without making a copy (as plugins might just analyse the AST). If you modify the AST, you have to make a copy before!
 
 
 "

--- a/src/OpalCompiler-Core/OCCompilerDynamicASTPlugin.class.st
+++ b/src/OpalCompiler-Core/OCCompilerDynamicASTPlugin.class.st
@@ -38,7 +38,7 @@ OCCompilerDynamicASTPlugin >> priority: anObject [
 
 { #category : #accessing }
 OCCompilerDynamicASTPlugin >> transform: ast [
-	^ transformBlock value: ast.
+	^ transformBlock value: ast copy.
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Tests/ASTPluginMeaningOfLife.class.st
+++ b/src/OpalCompiler-Tests/ASTPluginMeaningOfLife.class.st
@@ -17,6 +17,10 @@ ASTPluginMeaningOfLife class >> priority [
 { #category : #transformation }
 ASTPluginMeaningOfLife >> transform [
 	| rule |
+	"copy the AST as we modify it"
+	ast := ast copy. 
+	"we use the RBParseTreeRewriter to do the change, anothe option is to do it directly using
+	e.g #replaceWith:"
 	rule := RBParseTreeRewriter replaceLiteral: 42 with: 'meaning of life'.
 	rule executeTree: ast.
 	^ast


### PR DESCRIPTION
make it clearer that Plugins have to copy the AST if they modify it.

This was changed in Pharo8 as we realized that plugins might not change the AST (as indeed the FFI plugin does not). So not doing a copy makes things faster.