### PR TITLE
5062-includesKey-does-not-work-after-garbage-collect-in-WeakValueDictionary

### DIFF
--- a/src/Collections-Tests/WeakValueDictionaryTest.class.st
+++ b/src/Collections-Tests/WeakValueDictionaryTest.class.st
@@ -125,6 +125,13 @@ WeakValueDictionaryTest >> testDoesNotIncludeNilAfterGarbageCollection [
 ]
 
 { #category : #tests }
+WeakValueDictionaryTest >> testIncludesKeyAnswerFalseForGarbageCollectedValues [
+	"This test should not be called #testIncludesKey to not override that test of the same name in the superclass."
+
+	self deny: (self dictionaryWithGarbageCollectedValue includesKey: self keyWithGarbageCollectedValue)
+]
+
+{ #category : #tests }
 WeakValueDictionaryTest >> testKeysAndValuesDoWithGarbageCollectedValue [
 
 	self dictionaryWithGarbageCollectedValue keysAndValuesDo: [:key :value | self fail ]

--- a/src/Collections-Weak/WeakValueDictionary.class.st
+++ b/src/Collections-Weak/WeakValueDictionary.class.st
@@ -77,7 +77,9 @@ WeakValueDictionary >> includesKey: key [
 
 	"Here we need to check that we have a key and also that the value of the key was not garbarge collected."
 
-	^ (array at: (self scanFor: key)) ifNil: [ false ] ifNotNil: [ :value | value value isNotNil ]
+	^ (array at: (self scanFor: key))
+		ifNil: [ false ]
+		ifNotNil: [ :value | value value isNotNil ]
 ]
 
 { #category : #private }

--- a/src/Collections-Weak/WeakValueDictionary.class.st
+++ b/src/Collections-Weak/WeakValueDictionary.class.st
@@ -73,9 +73,7 @@ WeakValueDictionary >> at: key put: anObject [
 
 { #category : #testing }
 WeakValueDictionary >> includesKey: key [
-	"Answer whether the receiver has a key equal to the argument, key."
-
-	"Here we need to check that we have a key and also that the value of the key was not garbarge collected."
+	"Answer whether the receiver has a key equal to the argument and also that the value associated to this key was not garbage collected."
 
 	^ (array at: (self scanFor: key))
 		ifNil: [ false ]

--- a/src/Collections-Weak/WeakValueDictionary.class.st
+++ b/src/Collections-Weak/WeakValueDictionary.class.st
@@ -71,6 +71,15 @@ WeakValueDictionary >> at: key put: anObject [
 	^ anObject
 ]
 
+{ #category : #testing }
+WeakValueDictionary >> includesKey: key [
+	"Answer whether the receiver has a key equal to the argument, key."
+
+	"Here we need to check that we have a key and also that the value of the key was not garbarge collected."
+
+	^ (array at: (self scanFor: key)) ifNil: [ false ] ifNotNil: [ :value | value value isNotNil ]
+]
+
 { #category : #private }
 WeakValueDictionary >> rehash [
 	| newSelf |


### PR DESCRIPTION
WeakValueDictionary>>#includesKey: should return false if the value was GCed. 

Fix the bug + add a test (thanks Guillaume).

Fixes #5062