### PR TITLE
Syntax Highlighter: Simplify Parsing

### DIFF
--- a/src/Rubric/RubSmalltalkScriptingMode.class.st
+++ b/src/Rubric/RubSmalltalkScriptingMode.class.st
@@ -33,6 +33,12 @@ RubSmalltalkScriptingMode >> parseSource: aString [
 	^RBParser parseFaultyExpression: aString
 ]
 
+{ #category : #shout }
+RubSmalltalkScriptingMode >> updateStyler [
+	super updateStyler.
+	self textArea shoutStyler beForSmalltalkScripting
+]
+
 { #category : #update }
 RubSmalltalkScriptingMode >> updateTextAreaWhenPlugged [
 	super updateTextAreaWhenPlugged.

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -971,9 +971,9 @@ SHRBTextStyler >> pixelHeight [
 { #category : #private }
 SHRBTextStyler >> privateStyle: aText [
 	| ast |
-	ast := (self isForWorkspace not) 
-		ifTrue: [RBParser parseFaultyMethod: aText asString] 
-		ifFalse:[RBParser parseFaultyExpression: aText asString].
+	ast := self isForWorkspace 
+		ifFalse: [ RBParser parseFaultyMethod: aText ] 
+		ifTrue: [ RBParser parseFaultyExpression: aText ].
 	
 	ast methodNode compilationContext: (Smalltalk compiler compilationContextClass new
 				forSyntaxHighlighting: true;

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -964,23 +964,6 @@ SHRBTextStyler >> methodOrBlockTempStyleFor: aTemporaryNode [
 ]
 
 { #category : #private }
-SHRBTextStyler >> parse: aText isMethod: isMethod [
-	|root|
-	
-	isMethod 
-		ifTrue: [
-			[root := RBParser parseFaultyMethod: aText asString.
-			root methodNode methodClass: classOrMetaClass.
-			^root] 
-				on: Error 
-				do: [
-					"Problem: if called with a exprssion, we end here.
-					leads to wrong use by clients. Need to be fixed"
-					^RBParser parseFaultyExpression: aText asString]]
-		ifFalse:[ ^RBParser parseFaultyExpression: aText asString ].
-]
-
-{ #category : #private }
 SHRBTextStyler >> pixelHeight [
 	^ pixelHeight ifNil: [ pixelHeight := (font ifNil: [ TextStyle defaultFont ]) pixelSize ]
 ]
@@ -988,7 +971,10 @@ SHRBTextStyler >> pixelHeight [
 { #category : #private }
 SHRBTextStyler >> privateStyle: aText [
 	| ast |
-	ast := self parse: aText isMethod: self isForWorkspace not.
+	ast := (self isForWorkspace not) 
+		ifTrue: [RBParser parseFaultyMethod: aText asString] 
+		ifFalse:[RBParser parseFaultyExpression: aText asString].
+	
 	ast methodNode compilationContext: (Smalltalk compiler compilationContextClass new
 				forSyntaxHighlighting: true;
 				requestor: workspace).


### PR DESCRIPTION
Simplify Parsing in the case of Syntax Hightlighting.

The method #parse:isMethod:  used to have an "on: Error" handler. Which actually got called because the message send used to be a DNU
(becuause #parseFaultyMethod: was returning sometimes RBParseErrorNode, not a method node...).

As we fixed #parseFaultyMethod: to always return a method, we  can now do this  much cleaner.