### PR TITLE
Copy a selector converted to a test method selector

### DIFF
--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyJumpToTestMethodCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyJumpToTestMethodCommand.class.st
@@ -94,8 +94,5 @@ ClyJumpToTestMethodCommand >> systemEnvironment [
 
 { #category : #accessing }
 ClyJumpToTestMethodCommand >> testMethodNameFor: aMethod [
-	^ (String
-		streamContents: [ :s | 
-			s nextPutAll: 'test'.
-			(aMethod selector splitOn: $:) do: [ :each | s nextPutAll: each capitalized ] ]) asSymbol
+	^ aMethod selector asTestSelector
 ]

--- a/src/Calypso-SystemTools-Core/SycCopyTestMethodNameToClypboardCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycCopyTestMethodNameToClypboardCommand.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #SycCopyTestMethodNameToClypboardCommand }
+
+{ #category : #'*Calypso-SystemTools-Core' }
+SycCopyTestMethodNameToClypboardCommand class >> methodContextMenuActivation [
+	<classAnnotation>
+	
+	^CmdContextMenuActivation byItemOf: CmdExtraMenuGroup for: ClyMethod asCalypsoItemContext
+]

--- a/src/Deprecated80/Character.extension.st
+++ b/src/Deprecated80/Character.extension.st
@@ -6,3 +6,11 @@ Character >> basicSqueakToIso [
 	self deprecated: 'Use #basicPharoToIso instead.' transformWith: '`@receiver basicSqueakToIso' -> '`@receiver basicPharoToIso'.
 	^ self basicPharoToIso
 ]
+
+{ #category : #'*Deprecated80' }
+Character class >> devide [
+
+	self deprecated: 'Use message divide' transformWith: '`@receiver devide' -> '`@receiver divide'.
+	
+	^self divide
+]

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -128,11 +128,6 @@ Character class >> delete [
 	^ self value: 127
 ]
 
-{ #category : #'special characters' }
-Character class >> devide [
-	^self codePoint: 247
-]
-
 { #category : #'instance creation' }
 Character class >> digitValue: x [ 
 	"Answer the Character whose digit value is x. For example,
@@ -141,6 +136,11 @@ Character class >> digitValue: x [
 	| n |
 	n := x asInteger.
 	^self value: (n < 10 ifTrue: [n + 48] ifFalse: [n + 55])
+]
+
+{ #category : #'special characters' }
+Character class >> divide [
+	^self codePoint: 247
 ]
 
 { #category : #'accessing untypeable characters' }
@@ -288,7 +288,7 @@ Character class >> space [
 
 { #category : #'special characters' }
 Character class >> specialCharacters [
-	^'+-/\*~<>=@,%|&?!', {self centeredDot . self devide . self plusOrMinus . self times }
+	^'+-/\*~<>=@,%|&?!', {self centeredDot . self divide . self plusOrMinus . self times }
 ]
 
 { #category : #queries }

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -128,6 +128,14 @@ Character class >> delete [
 	^ self value: 127
 ]
 
+{ #category : #'special characters' }
+Character class >> devide [
+
+	self deprecated: 'Use message divide' transformWith: '`@receiver devide' -> '`@receiver divide'.
+	
+	^self divide
+]
+
 { #category : #'instance creation' }
 Character class >> digitValue: x [ 
 	"Answer the Character whose digit value is x. For example,

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -128,14 +128,6 @@ Character class >> delete [
 	^ self value: 127
 ]
 
-{ #category : #'special characters' }
-Character class >> devide [
-
-	self deprecated: 'Use message divide' transformWith: '`@receiver devide' -> '`@receiver divide'.
-	
-	^self divide
-]
-
 { #category : #'instance creation' }
 Character class >> digitValue: x [ 
 	"Answer the Character whose digit value is x. For example,

--- a/src/SUnit-Core/Character.extension.st
+++ b/src/SUnit-Core/Character.extension.st
@@ -1,0 +1,26 @@
+Extension { #name : #Character }
+
+{ #category : #'*SUnit-Core' }
+Character class >> specialCharacterNames [
+	^ Dictionary newFrom: { 
+		$+ -> 'plus'.
+		$- -> 'minus'.
+		$/ -> 'slash'.
+		$\ -> 'backslash'.
+		$* -> 'star'.
+		$~ -> 'tilda'.
+		$< -> 'less than'.
+		$> -> 'greater-than'.
+		$= -> 'equals-sign'.
+		$@ -> 'at sign'.
+		$, -> 'comma'.
+		$% -> 'percent sign'.
+		$| -> 'pipe'.
+		$& -> 'ampersand'.
+		$? -> 'question mark'.
+		$! -> 'exclamation mark'.
+		self centeredDot -> 'centered dot'.
+		self divide -> 'divide'.
+		self plusOrMinus -> 'plus-minus'.
+		self times -> 'times' }
+]

--- a/src/SUnit-Core/Symbol.extension.st
+++ b/src/SUnit-Core/Symbol.extension.st
@@ -3,6 +3,14 @@ Extension { #name : #Symbol }
 { #category : #'*SUnit-Core' }
 Symbol >> asTestSelector [
 
+	"Converts a method selector into a test selector in form of #testOriginalSelector"
+
+	"#+ asTestSelector >>> #testPlus"
+	"#+-<> asTestSelector >>> #testBackslashPlusMinusLessThanGreaterThan"
+	"#message asTestSelector  >>> #testMessage"
+	"#mySelector asTestSelector >>> #testMySelector"
+	"#at:putNext: asTestSelector >>> #testAtPutNext"
+
 	self isBinary ifTrue: [ 
 		^ (#test, (self flatCollect: [ :each | (((Character specialCharacterNames at: each) copyReplaceAll: '-' with: ' ') substrings collect: #capitalized) joinUsing: ''])) asSymbol ].
 	

--- a/src/SUnit-Core/Symbol.extension.st
+++ b/src/SUnit-Core/Symbol.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #Symbol }
+
+{ #category : #'*SUnit-Core' }
+Symbol >> asTestSelector [
+
+	self isBinary ifTrue: [ 
+		^ (#test, (self flatCollect: [ :each | (((Character specialCharacterNames at: each) copyReplaceAll: '-' with: ' ') substrings collect: #capitalized) joinUsing: ''])) asSymbol ].
+	
+	^ (#test, (((self copyReplaceAll: ':' with: ' ') substrings collect: #capitalized) joinUsing: '')) asSymbol
+]

--- a/src/SystemCommands-MethodCommands/SycCopyTestMethodNameToClypboardCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycCopyTestMethodNameToClypboardCommand.class.st
@@ -1,0 +1,33 @@
+"
+Copy selected methods selector into Clipboard as testOriginalSelector
+"
+Class {
+	#name : #SycCopyTestMethodNameToClypboardCommand,
+	#superclass : #SycMethodCommand,
+	#category : #'SystemCommands-MethodCommands'
+}
+
+{ #category : #accessing }
+SycCopyTestMethodNameToClypboardCommand >> defaultMenuIconName [
+	^#smallCopy
+]
+
+{ #category : #accessing }
+SycCopyTestMethodNameToClypboardCommand >> defaultMenuItemName [
+	^'Copy test method selector(s) to Clipboard'
+]
+
+{ #category : #accessing }
+SycCopyTestMethodNameToClypboardCommand >> description [
+	^'Copy selected methods selector into Clipboard as testXXX'
+]
+
+{ #category : #execution }
+SycCopyTestMethodNameToClypboardCommand >> execute [
+	| text |
+	text := (methods collect: [ :each | each selector asTestSelector ]) joinUsing: String cr.
+	
+	Clipboard clipboardText: text.
+	
+	self inform: 'Copied methods:', String cr, text
+]


### PR DESCRIPTION
add Calypso command to copy a selector converted to a test method selector (method context menu - extra)

#\+-<> asTestSelector .
 "#testBackslashPlusMinusLessThanGreaterThan"
#message asTestSelector.
 "#testMessage"
#mySelector asTestSelector.
 "#testMySelector"
#at:putNext: asTestSelector.
 "#testAtPutNext"

fixes 'devide' typo