### PR TITLE
MCClassTraitDefinition-should-take-category-into-account-for-equality

### DIFF
--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -115,14 +115,12 @@ MCClassDefinition class >> name: nameString superclassName: superclassString tra
 
 { #category : #comparing }
 MCClassDefinition >> = aDefinition [
-	^(super = aDefinition)
-		and: [superclassName = aDefinition superclassName
-		and: [self traitCompositionString = aDefinition traitCompositionString
-		and: [self classTraitCompositionString = aDefinition classTraitCompositionString
-		and: [category = aDefinition category
-		and: [type = aDefinition type
-		and: [self sortedVariables = aDefinition sortedVariables
-		and: [comment = aDefinition comment]]]]]]]
+	^ super = aDefinition
+		and: [ superclassName = aDefinition superclassName
+		and: [ self traitCompositionString = aDefinition traitCompositionString
+		and: [ self classTraitCompositionString = aDefinition classTraitCompositionString
+		and: [ category = aDefinition category
+		and: [ type = aDefinition type and: [ self sortedVariables = aDefinition sortedVariables and: [ comment = aDefinition comment ] ] ] ] ] ] ]
 ]
 
 { #category : #visiting }

--- a/src/Monticello/MCClassTraitDefinition.class.st
+++ b/src/Monticello/MCClassTraitDefinition.class.st
@@ -27,16 +27,15 @@ MCClassTraitDefinition class >> baseTraitName: aString classTraitComposition: cl
 
 { #category : #comparing }
 MCClassTraitDefinition >> = aDefinition [
-	^ (super = aDefinition)
-		and: [baseTrait = aDefinition baseTrait
-		and: [self classTraitCompositionString = aDefinition classTraitCompositionString]]
-
-
+	^ super = aDefinition
+		and: [ baseTrait = aDefinition baseTrait
+		and: [ self classTraitCompositionString = aDefinition classTraitCompositionString
+		and: [ category = aDefinition category ] ] ]
 ]
 
 { #category : #visiting }
 MCClassTraitDefinition >> accept: aVisitor [
-	^ aVisitor visitClassTraitDefinition: self.
+	^ aVisitor visitClassTraitDefinition: self
 ]
 
 { #category : #accessing }
@@ -47,9 +46,10 @@ MCClassTraitDefinition >> baseTrait [
 
 { #category : #accessing }
 MCClassTraitDefinition >> category [
-	^ category ifNil: [(Smalltalk classOrTraitNamed: self baseTrait)
-							ifNotNil: [:bTrait | bTrait category]
-							ifNil: [self error: 'Can''t detect the category']] 
+	^ category ifNil: [
+		(Smalltalk classOrTraitNamed: self baseTrait)
+			ifNotNil: [ :bTrait | bTrait category ]
+			ifNil: [ self error: 'Can''t detect the category' ] ]
 ]
 
 { #category : #accessing }
@@ -66,9 +66,7 @@ MCClassTraitDefinition >> classTraitComposition [
 
 { #category : #accessing }
 MCClassTraitDefinition >> classTraitCompositionString [
-	^self classTraitComposition ifNil: ['{}'].
-
-
+	^ self classTraitComposition ifNil: [ '{}' ]
 ]
 
 { #category : #accessing }
@@ -80,9 +78,7 @@ MCClassTraitDefinition >> definitionString [
 
 { #category : #accessing }
 MCClassTraitDefinition >> description [
-	^Array
-		with: baseTrait
-		with: classTraitComposition
+	^ Array with: baseTrait with: classTraitComposition
 ]
 
 { #category : #comparing }
@@ -90,14 +86,14 @@ MCClassTraitDefinition >> hash [
 	| hash |
 	hash := String stringHash: baseTrait initialHash: 0.
 	hash := String stringHash: self classTraitCompositionString initialHash: hash.
-	^hash
-
+	hash := String stringHash: category initialHash: hash.
+	^ hash
 ]
 
 { #category : #initialization }
 MCClassTraitDefinition >> initializeWithBaseTraitName: aTraitName classTraitComposition: aString [
 	baseTrait := aTraitName.
-	classTraitComposition := aString.
+	classTraitComposition := aString
 ]
 
 { #category : #initialization }
@@ -145,7 +141,7 @@ MCClassTraitDefinition >> source [
 	^self definitionString
 ]
 
-{ #category : #accessing }
+{ #category : #printing }
 MCClassTraitDefinition >> summary [
 	^self baseTrait , ' classTrait'
 

--- a/src/Monticello/MCDefinition.class.st
+++ b/src/Monticello/MCDefinition.class.st
@@ -43,7 +43,7 @@ MCDefinition >> definition [
 	^ self
 ]
 
-{ #category : #comparing }
+{ #category : #accessing }
 MCDefinition >> description [
 	self subclassResponsibility
 ]

--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -102,9 +102,8 @@ MCMethodDefinition class >> shutDown [
 { #category : #comparing }
 MCMethodDefinition >> = aDefinition [
 	^ super = aDefinition
-		and: [ 
-			aDefinition category = self category
-				and: [ aDefinition source withInternalLineEndings = self source withInternalLineEndings ] ]
+		and: [ aDefinition category = self category
+		and: [ aDefinition source withInternalLineEndings = self source withInternalLineEndings ] ]
 ]
 
 { #category : #visiting }


### PR DESCRIPTION
MCClassTraitDefinition should take category into account for equality. 

I got a bug this week because it considered that an instance with a nil category was the same that an instance with a category.