### PR TITLE
Backport-5072-MCClassTraitDefinition-should-take-category-into-account-for-equality

### DIFF
--- a/src/Monticello/MCClassTraitDefinition.class.st
+++ b/src/Monticello/MCClassTraitDefinition.class.st
@@ -28,11 +28,10 @@ MCClassTraitDefinition class >> baseTraitName: aString classTraitComposition: cl
 
 { #category : #comparing }
 MCClassTraitDefinition >> = aDefinition [
-	^ (super = aDefinition)
-		and: [baseTrait = aDefinition baseTrait
-		and: [self classTraitCompositionString = aDefinition classTraitCompositionString]]
-
-
+	^ super = aDefinition
+		and: [ baseTrait = aDefinition baseTrait
+		and: [ self classTraitCompositionString = aDefinition classTraitCompositionString
+		and: [ category = aDefinition category ] ] ]
 ]
 
 { #category : #visiting }
@@ -91,8 +90,8 @@ MCClassTraitDefinition >> hash [
 	| hash |
 	hash := String stringHash: baseTrait initialHash: 0.
 	hash := String stringHash: self classTraitCompositionString initialHash: hash.
-	^hash
-
+	hash := String stringHash: category initialHash: hash.
+	^ hash
 ]
 
 { #category : #initialization }

--- a/src/Monticello/MCClassTraitDefinition.class.st
+++ b/src/Monticello/MCClassTraitDefinition.class.st
@@ -90,7 +90,7 @@ MCClassTraitDefinition >> hash [
 	| hash |
 	hash := String stringHash: baseTrait initialHash: 0.
 	hash := String stringHash: self classTraitCompositionString initialHash: hash.
-	hash := String stringHash: category initialHash: hash.
+	category ifNotNil: [ :cat | hash := String stringHash: cat initialHash: hash ].
 	^ hash
 ]
 


### PR DESCRIPTION
This is fixing a bug while loading code.

In Pharo 7, the loading of code is using a cache for MCDefinitions. 
When you create a new definition, it checks if one equivalent was already created, if yes, it return this one.

The equality of MCClassTraitDefinition does not take the category into account and I got bug while loading code because the MCClassTraitDefinition was wrong because it found one with another category.