### PR TITLE
5077-Add-byteAt-as-alias-to-digitAt-to-Integer-in-Pharo-7-to-support-forward-compatibility-with-Pharo-8

### DIFF
--- a/src/Kernel/Integer.class.st
+++ b/src/Kernel/Integer.class.st
@@ -567,6 +567,13 @@ Integer >> bitXor: n [
 		length: (self digitLength max: norm digitLength)
 ]
 
+{ #category : #'system primitives' }
+Integer >> byteAt: index [
+	"Alias to support forward compatibility with Pharo 8"
+	
+	^ self digitAt: index
+]
+
 { #category : #'truncation and round off' }
 Integer >> ceiling [ 
 	"Refer to the comment in Number|ceiling."


### PR DESCRIPTION
Add byteAt: as alias to digitAt: to Integer in Pharo 7 to support forward compatibility with Pharo 8

https://github.com/pharo-project/pharo/issues/5077