### PR TITLE
2861-ExecutionCounter-allCounters-should-be-cleaned-when-system-changes

### DIFF
--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -73,12 +73,12 @@ Breakpoint class >> handleClassRemoved: anAnnouncement [
 
 { #category : #'system announcements' }
 Breakpoint class >> handleMethodModified: anAnnouncement [
-	self removeBreakpointsFromMethod: anAnnouncement oldMethod
+	self removeFromMethod: anAnnouncement oldMethod
 ]
 
 { #category : #'system announcements' }
 Breakpoint class >> handleMethodRemoved: anAnnouncement [
-	self removeBreakpointsFromMethod: anAnnouncement method
+	self removeFromMethod: anAnnouncement method
 ]
 
 { #category : #initialization }
@@ -114,20 +114,20 @@ Breakpoint class >> removeAll [
 	self all copy do: #remove
 ]
 
-{ #category : #removing }
-Breakpoint class >> removeBreakpointsFromMethod: aMethod [ 
-	self all copy do: [ :breakpoint |
-		breakpoint link methods
-			detect: [ :m | m == aMethod ]
-			ifFound: [ self all remove: breakpoint ] ]
-]
-
 { #category : #cleanup }
 Breakpoint class >> removeFrom: aNode [
 	| links breakpointsToRemove |
 	links := aNode beforeLinks select: [ :link | link metaObject = Break].
 	breakpointsToRemove := self all select: [ :br | links includes: br link].
 	breakpointsToRemove do: #remove
+]
+
+{ #category : #cleanup }
+Breakpoint class >> removeFromMethod: aMethod [ 
+	self all copy do: [ :breakpoint |
+		breakpoint link methods
+			detect: [ :m | m == aMethod ]
+			ifFound: [ self all remove: breakpoint ] ]
 ]
 
 { #category : #api }

--- a/src/Reflectivity/ExecutionCounter.class.st
+++ b/src/Reflectivity/ExecutionCounter.class.st
@@ -35,11 +35,44 @@ ExecutionCounter class >> debugWorldMenuOn: aBuilder [
 		action: [ ExecutionCounter resetAll ]
 ]
 
+{ #category : #'system annoucements' }
+ExecutionCounter class >> handleClassRemoved: anAnnouncement [
+	self allCounters copy do: [ :breakpoint |
+		breakpoint link methods
+			detect: [ :m | m methodClass = anAnnouncement classRemoved ]
+			ifFound: [ self allCounters remove: breakpoint ] ]
+]
+
+{ #category : #'system annoucements' }
+ExecutionCounter class >> handleMethodModified: anAnnouncement [
+	self removeFromMethod: anAnnouncement oldMethod
+]
+
+{ #category : #'system annoucements' }
+ExecutionCounter class >> handleMethodRemoved: anAnnouncement [
+	self removeFromMethod: anAnnouncement method
+]
+
+{ #category : #'class initialization' }
+ExecutionCounter class >> initialize [
+	self registerInsterestToSystemAnnouncement 
+]
+
 { #category : #'instance creation' }
 ExecutionCounter class >> installOn: aRBProgramNode [
 	^self new
 		node: aRBProgramNode;
 		install.
+]
+
+{ #category : #'class initialization' }
+ExecutionCounter class >> registerInsterestToSystemAnnouncement [
+	<systemEventRegistration>
+
+	SystemAnnouncer uniqueInstance unsubscribe: self.
+	SystemAnnouncer uniqueInstance weak when: MethodRemoved send: #handleMethodRemoved: to: self.
+	SystemAnnouncer uniqueInstance weak when: MethodModified send: #handleMethodModified: to: self.
+	SystemAnnouncer uniqueInstance weak when: ClassRemoved send: #handleClassRemoved: to: self
 ]
 
 { #category : #cleanup }
@@ -52,6 +85,14 @@ ExecutionCounter class >> removeAll [
 ExecutionCounter class >> removeFrom: aNode [
 
 	(self allCounters at: aNode ifAbsent: [ ^self ]) uninstall
+]
+
+{ #category : #cleanup }
+ExecutionCounter class >> removeFromMethod: aMethod [ 
+	self allCounters copy do: [ :counter |
+		counter link methods
+			detect: [ :m | m == aMethod ]
+			ifFound: [ self allCounters remove: counter ] ]
 ]
 
 { #category : #cleanup }


### PR DESCRIPTION
add cleanup code. 

Yes, in a future PR we shoudl introduce a common superclass for these. fixes #2861