### PR TITLE
Compiler API: turn forSyntaxHighlighting into an option

### DIFF
--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -56,15 +56,12 @@ CompletionContext >> narrowWith: aString [
 
 { #category : #parsing }
 CompletionContext >> parseSource [
-
-	ast := isWorkspace
-		ifTrue: [RBParser parseFaultyExpression: source]
-		ifFalse: [RBParser parseFaultyMethod: source].
-	ast methodNode 
-		compilationContext: 
-			(Smalltalk compiler compilationContextClass new
-             class: class;forSyntaxHighlighting: true).
-		
+	 ast := Smalltalk compiler
+				source: source;
+				options: #(+ optionParseErrors + optionSkipSemanticWarnings);
+				class: class;
+				noPattern: isWorkspace;
+				parse.
 	ast doSemanticAnalysisIn: class.
 	TypingVisitor new visitNode: ast
 ]

--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -56,11 +56,13 @@ CompletionContext >> narrowWith: aString [
 
 { #category : #parsing }
 CompletionContext >> parseSource [
-	 ast := class compiler
-				source: source;
-				options: #(+ optionParseErrors + optionSkipSemanticWarnings);
-				noPattern: isWorkspace;
-				parse.
+	ast := isWorkspace 
+		ifFalse: [ RBParser parseFaultyMethod: source ] 
+		ifTrue: [ RBParser parseFaultyExpression: source ].
+	
+	ast methodNode compilationContext: (Smalltalk compiler compilationContext
+				parseOptions: #(+ optionParseErrors + optionSkipSemanticWarnings);
+				requestor: isWorkspace).
 	ast doSemanticAnalysisIn: class.
 	TypingVisitor new visitNode: ast
 ]

--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -56,10 +56,9 @@ CompletionContext >> narrowWith: aString [
 
 { #category : #parsing }
 CompletionContext >> parseSource [
-	 ast := Smalltalk compiler
+	 ast := class compiler
 				source: source;
 				options: #(+ optionParseErrors + optionSkipSemanticWarnings);
-				class: class;
 				noPattern: isWorkspace;
 				parse.
 	ast doSemanticAnalysisIn: class.

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -29,7 +29,6 @@ Class {
 		'astTranslatorClass',
 		'bytecodeGeneratorClass',
 		'compiledMethodTrailer',
-		'forSyntaxHighlighting',
 		'encoderClass',
 		'astTransformPlugins',
 		'requestorScopeClass',
@@ -280,6 +279,16 @@ CompilationContext class >> optionReadOnlyLiterals: aBoolean [
 	^ self writeDefaultOption: #optionReadOnlyLiterals value: aBoolean
 ]
 
+{ #category : #'options - settings API' }
+CompilationContext class >> optionSkipSemanticWarnings [
+	^ self readDefaultOption: #optionSkipSemanticWarnings
+]
+
+{ #category : #'options - settings API' }
+CompilationContext class >> optionSkipSemanticWarnings: aBoolean [
+	^ self writeDefaultOption: #optionSkipSemanticWarnings value: aBoolean
+]
+
 { #category : #options }
 CompilationContext class >> optionsDescription [
 	"Default options are held by DefaultOptions class variable.
@@ -305,6 +314,8 @@ CompilationContext class >> optionsDescription [
 	(- optionLongIvarAccessBytecodes 	'Specific inst var accesses to Maybe context objects')
 	(+ optionOptimizeIR 					'Rewrite jumps in bytecode in a slightly more efficient way')
 	(- optionParseErrors 					'Parse syntactically wrong code')
+	(- optionSkipSemanticWarnings 					'Do not warn about sementics (e.g. undeclared vars)')
+		
 	) 
 ]
 
@@ -425,16 +436,6 @@ CompilationContext >> failBlock [
 { #category : #accessing }
 CompilationContext >> failBlock: anObject [
 	failBlock := anObject
-]
-
-{ #category : #accessing }
-CompilationContext >> forSyntaxHighlighting [
-	^ forSyntaxHighlighting ifNil: [ ^false ]
-]
-
-{ #category : #accessing }
-CompilationContext >> forSyntaxHighlighting: aBoolean [
-	forSyntaxHighlighting := aBoolean
 ]
 
 { #category : #accessing }
@@ -565,6 +566,11 @@ CompilationContext >> optionParseErrors [
 CompilationContext >> optionReadOnlyLiterals [
 	^ options includes: #optionReadOnlyLiterals
 
+]
+
+{ #category : #options }
+CompilationContext >> optionSkipSemanticWarnings [
+	^ options includes: #optionSkipSemanticWarnings
 ]
 
 { #category : #options }

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -314,7 +314,7 @@ CompilationContext class >> optionsDescription [
 	(- optionLongIvarAccessBytecodes 	'Specific inst var accesses to Maybe context objects')
 	(+ optionOptimizeIR 					'Rewrite jumps in bytecode in a slightly more efficient way')
 	(- optionParseErrors 					'Parse syntactically wrong code')
-	(- optionSkipSemanticWarnings 					'Do not warn about sementics (e.g. undeclared vars)')
+	(- optionSkipSemanticWarnings 		'Do not warn about semantic problems (e.g. undeclared vars). Used for syntax highlight parsing')
 		
 	) 
 ]

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -99,8 +99,7 @@ OCASTSemanticAnalyzer >> scope: aSemScope [
 
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> storeIntoReadOnlyVariable: variableNode [
-	compilationContext forSyntaxHighlighting
-		ifTrue: [ ^ self ].
+	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ self ].
 		
 	^ OCStoreIntoReadOnlyVariableError new
 		node: variableNode;
@@ -111,8 +110,7 @@ OCASTSemanticAnalyzer >> storeIntoReadOnlyVariable: variableNode [
 
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> storeIntoSpecialVariable: variableNode [
-	compilationContext forSyntaxHighlighting
-		ifTrue: [ ^ self ].
+	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ self ].
 	^ OCStoreIntoSpecialVariableError new
 		node: variableNode;
 		compilationContext: compilationContext;
@@ -122,7 +120,7 @@ OCASTSemanticAnalyzer >> storeIntoSpecialVariable: variableNode [
 
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> undeclaredVariable: variableNode [
-	compilationContext forSyntaxHighlighting 
+	compilationContext optionSkipSemanticWarnings
 		ifTrue: [ ^OCUndeclaredVariable new name: variableNode name ].
 	^ OCUndeclaredVariableWarning new
 		node: variableNode;

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -44,7 +44,7 @@ OCRequestorScope >> lookupVar: name [
 	name first isUppercase ifTrue: [ ^ outerScope lookupVar: name].
 	
 	"do not 'create bindings' in requestor scope if we just want to style a possible unknown variable"
-	(compilationContext forSyntaxHighlighting
+	(compilationContext optionSkipSemanticWarnings
 		and: [ (requestor hasBindingOf: name asSymbol) not ])
 		ifTrue: [ ^ outerScope lookupVar: name ].
 

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -971,13 +971,14 @@ SHRBTextStyler >> pixelHeight [
 { #category : #private }
 SHRBTextStyler >> privateStyle: aText [
 	| ast |
-	ast := self isForWorkspace 
-		ifFalse: [ RBParser parseFaultyMethod: aText ] 
-		ifTrue: [ RBParser parseFaultyExpression: aText ].
-	
-	ast methodNode compilationContext: (Smalltalk compiler compilationContextClass new
-				forSyntaxHighlighting: true;
-				requestor: workspace).
+	ast := Smalltalk compiler
+				source: aText;
+				options: #(+ optionParseErrors + optionSkipSemanticWarnings);
+				class: classOrMetaClass;
+				noPattern: self isForWorkspace;
+				requestor: workspace;
+				parse.
+				
 	ast doSemanticAnalysisIn: classOrMetaClass.
 	^ self style: aText ast: ast
 ]

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -971,10 +971,9 @@ SHRBTextStyler >> pixelHeight [
 { #category : #private }
 SHRBTextStyler >> privateStyle: aText [
 	| ast |
-	ast := Smalltalk compiler
+	ast := classOrMetaClass compiler
 				source: aText;
 				options: #(+ optionParseErrors + optionSkipSemanticWarnings);
-				class: classOrMetaClass;
 				noPattern: self isForWorkspace;
 				requestor: workspace;
 				parse.

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -971,13 +971,13 @@ SHRBTextStyler >> pixelHeight [
 { #category : #private }
 SHRBTextStyler >> privateStyle: aText [
 	| ast |
-	ast := classOrMetaClass compiler
-				source: aText;
-				options: #(+ optionParseErrors + optionSkipSemanticWarnings);
-				noPattern: self isForWorkspace;
-				requestor: workspace;
-				parse.
-				
+	ast := self isForWorkspace 
+		ifFalse: [ RBParser parseFaultyMethod: aText ] 
+		ifTrue: [ RBParser parseFaultyExpression: aText ].
+	
+	ast methodNode compilationContext: (Smalltalk compiler compilationContext
+				parseOptions: #(+ optionParseErrors + optionSkipSemanticWarnings);
+				requestor: workspace).
 	ast doSemanticAnalysisIn: classOrMetaClass.
 	^ self style: aText ast: ast
 ]


### PR DESCRIPTION
- change the #forSyntaxHighlighting state to use a compiler option instead of an ivar 
- this allows us to use the compiler facade in both syntax highlighting and code completion for parsing, makign the code much easier to understand and remove direct references to RBParser.