### PR TITLE
Compiler: #parse should not do the doit wrapping

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -282,6 +282,7 @@ OpalCompiler >> compilationContextClass: aClass [
 OpalCompiler >> compile [
 	| cm |
 	[ 	[	self parse.
+			self transformDoit.
 			self doSemanticAnalysis. 
 			self callPlugins.  
 		] 	on: ReparseAfterSourceEditing 
@@ -672,16 +673,10 @@ OpalCompiler >> parse: textOrStream in: aClass notifying: req [
 
 { #category : #private }
 OpalCompiler >> parseExpression [
-	| expression |
 
-	expression := self compilationContext optionParseErrors 
+	^ast := self compilationContext optionParseErrors 
 		ifTrue: [self parserClass parseFaultyExpression: source contents]
-		ifFalse: [self parserClass parseExpression: source contents].	
-	ast := context 
-		ifNil: [expression asDoit] 
-		ifNotNil: [expression asDoitForContext: context].
-	ast compilationContext: self compilationContext.
-	^ast.
+		ifFalse: [self parserClass parseExpression: source contents]
 ]
 
 { #category : #'public access' }
@@ -737,6 +732,17 @@ OpalCompiler >> requestorScopeClass: aClass [
 { #category : #accessing }
 OpalCompiler >> source: aString [
 	source := aString readStream.
+]
+
+{ #category : #'public access' }
+OpalCompiler >> transformDoit [
+	"if we compile an expression, we wrap it in a method here"
+	self compilationContext noPattern ifFalse: [ ^self ].
+	ast := context 
+		ifNil: [ast asDoit] 
+		ifNotNil: [ast asDoitForContext: context].
+	ast compilationContext: self compilationContext.
+	^ast
 ]
 
 { #category : #'old - deprecated' }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -737,12 +737,11 @@ OpalCompiler >> source: aString [
 { #category : #'public access' }
 OpalCompiler >> transformDoit [
 	"if we compile an expression, we wrap it in a method here"
-	self compilationContext noPattern ifFalse: [ ^self ].
+	self compilationContext noPattern ifFalse: [ ^ast ].
 	ast := context 
 		ifNil: [ast asDoit] 
 		ifNotNil: [ast asDoitForContext: context].
-	ast compilationContext: self compilationContext.
-	^ast
+	^ast compilationContext: self compilationContext
 ]
 
 { #category : #'old - deprecated' }


### PR DESCRIPTION
#parse should not wrap in a doit, as clients might want to use the Compiler to just parse an expression