### PR TITLE
add-method-to-identify-aio-interrupt-vm

### DIFF
--- a/src/Kernel/DelayMillisecondTicker.class.st
+++ b/src/Kernel/DelayMillisecondTicker.class.st
@@ -38,17 +38,16 @@ DelayMillisecondTicker >> tickAfterMilliseconds: milliseconds [
 
 { #category : #'api-system' }
 DelayMillisecondTicker >> waitForUserSignalled: timingSemaphore orExpired: activeDelay [
-	|nextTick|
+	| nextTick |
 	"Sleep until the active delay is due, or timingSemaphore signalled by DelayScheduler user-api."
 	
 	"We sleep at most 1sec here as a soft busy-loop so that we don't accidentally miss signals."
-	nextTick := self nowTick + (1"sec" * 1000"msecs").
+	nextTick := self nowTick + (ProcessorScheduler idleTime max: 1000).
 	activeDelay ifNotNil: [
 		nextTick := nextTick min: activeDelay resumptionTick ].
 		
 	timingSemaphore initSignals.
 	self primSignal: timingSemaphore atMilliseconds: nextTick.
 	"WARNING! Stepping <Over> the following line may lock the Image. Use <Proceed>."
-	timingSemaphore wait.
-	
+	timingSemaphore wait
 ]

--- a/src/Kernel/ProcessorScheduler.class.st
+++ b/src/Kernel/ProcessorScheduler.class.st
@@ -28,6 +28,18 @@ Class {
 	#category : #'Kernel-Processes'
 }
 
+{ #category : #defaults }
+ProcessorScheduler class >> defaultAIOInterruptIdleTime [
+		
+	^ 60000000
+]
+
+{ #category : #defaults }
+ProcessorScheduler class >> defaultIdleTime [
+		
+	^ 50000
+]
+
 { #category : #'background process' }
 ProcessorScheduler class >> idleProcess [
 	"A default background process which is invisible. During the idle time, the delays may not wake up."
@@ -36,7 +48,7 @@ ProcessorScheduler class >> idleProcess [
 		[self relinquishProcessorForMicroseconds: IdleTime]
 ]
 
-{ #category : #settings }
+{ #category : #accessing }
 ProcessorScheduler class >> idleTime [
 
 	"The default idle time for the Pharo process in case of inactivity. In idle mode, the system can be awakened by a signal. This value can limit the minimal delay time."
@@ -44,7 +56,7 @@ ProcessorScheduler class >> idleTime [
 	^ IdleTime
 ]
 
-{ #category : #settings }
+{ #category : #accessing }
 ProcessorScheduler class >> idleTime: microsecondsCount [
 
 	IdleTime := microsecondsCount
@@ -73,11 +85,23 @@ ProcessorScheduler class >> initialize [
 	LowIOPriority := 60.
 	HighIOPriority := 70.
 	TimingPriority := 80.
-	IdleTime := 50000.
+	self initializeIdleTime.
 
 	SessionManager default
 		registerSystemClassNamed: self name
 		atPriority: 30.
+]
+
+{ #category : #'class initialization' }
+ProcessorScheduler class >> initializeIdleTime [
+	
+	"If value was changed manually, do not verify the value"
+	({ self defaultIdleTime. self defaultAIOInterruptIdleTime } includes: IdleTime) 
+		ifFalse: [ ^ self ].
+
+	IdleTime := Smalltalk vm isAIOInterrupt 
+		ifTrue: [ self defaultAIOInterruptIdleTime ]
+		ifFalse: [ self defaultIdleTime ]
 ]
 
 { #category : #'instance creation' }
@@ -98,11 +122,12 @@ ProcessorScheduler class >> relinquishProcessorForMicroseconds: anInteger [
 
 ]
 
-{ #category : #'background process' }
+{ #category : #'system startup' }
 ProcessorScheduler class >> startUp [
 	"Install a background process of the lowest possible priority that is always runnable."
 	"Details: The virtual machine requires that there is always some runnable process that can be scheduled; this background process ensures that this is the case."
 
+	self initializeIdleTime.
 	Smalltalk installLowSpaceWatcher.
 	BackgroundProcess ifNotNil: [BackgroundProcess terminate].
 	BackgroundProcess := [self idleProcess] newProcess.

--- a/src/System-Support/VirtualMachine.class.st
+++ b/src/System-Support/VirtualMachine.class.st
@@ -333,6 +333,12 @@ VirtualMachine >> is64bit [
 ]
 
 { #category : #testing }
+VirtualMachine >> isAIOInterrupt [
+
+	^ (self getSystemAttribute: 1010) = 'AIO'
+]
+
+{ #category : #testing }
 VirtualMachine >> isPharoVM [
 	"Answers if this VM is a valid PharoVM (made with our sources)"
 	| version |


### PR DESCRIPTION
Prepare the image to react to the new AIO interrupt VM. IdleTime now can be bigger (we are trying with 1min, but it can be even larger). In presence of a non-AIO Interrupt VM, we behave as usual.