### PR TITLE
5104-The-Through-button-in-the-debugger-should-be-named-Step

### DIFF
--- a/src/Debugger-Actions/StepIntoDebugAction.class.st
+++ b/src/Debugger-Actions/StepIntoDebugAction.class.st
@@ -23,7 +23,7 @@ StepIntoDebugAction >> defaultKeymap [
 { #category : #accessing }
 StepIntoDebugAction >> defaultLabel [
 
-	^ 'Into'
+	^ 'Step into'
 ]
 
 { #category : #accessing }

--- a/src/Debugger-Actions/StepOverDebugAction.class.st
+++ b/src/Debugger-Actions/StepOverDebugAction.class.st
@@ -23,7 +23,7 @@ StepOverDebugAction >> defaultKeymap [
 { #category : #accessing }
 StepOverDebugAction >> defaultLabel [
 
-	^ 'Over'
+	^ 'Step over'
 ]
 
 { #category : #accessing }

--- a/src/Debugger-Actions/StepThroughDebugAction.class.st
+++ b/src/Debugger-Actions/StepThroughDebugAction.class.st
@@ -23,7 +23,7 @@ StepThroughDebugAction >> defaultKeymap [
 { #category : #accessing }
 StepThroughDebugAction >> defaultLabel [
 
-	^ 'Through'
+	^ 'Step'
 ]
 
 { #category : #accessing }

--- a/src/Debugger-Actions/StepThroughDebugAction.class.st
+++ b/src/Debugger-Actions/StepThroughDebugAction.class.st
@@ -23,7 +23,7 @@ StepThroughDebugAction >> defaultKeymap [
 { #category : #accessing }
 StepThroughDebugAction >> defaultLabel [
 
-	^ 'Step'
+	^ 'Step Through'
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
rename Through button to Step in the debuggerfixes #5104