### PR TITLE
5102-FastTable-Horizontal-Scrolling-not-implemented

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTExamples.class.st
+++ b/src/Morphic-Widgets-FastTable/FTExamples.class.st
@@ -807,7 +807,7 @@ FTExamples class >> exampleTableHorizontalScroll [
 
 	<example>
 	| table |
-	table := FTTableMorph newTrialHorizontalScrollBar
+	table := FTTableMorph newWithHorizontalScrollBar
 		extent: 650 @ 500;
 		addColumn: ((FTColumn id: '#') width: 40);
 		addColumn: ((FTColumn id: 'Name') width: 350);

--- a/src/Morphic-Widgets-FastTable/FTFilterFunctionWithAction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTFilterFunctionWithAction.class.st
@@ -79,8 +79,8 @@ FTFilterFunctionWithAction >> initializeActionButtonNamed: aString [
 FTFilterFunctionWithAction >> resizeButton [
 	| topLeft bottomRight |
 	self flag: #pharoTodo.	"Maybe it could be cool to let the user choose if the field need to be at the top or the bottom."
-	bottomRight := (table bounds right - table verticalScrollBarWidth) @ table bottom.
-	topLeft := (bottomRight x - actionButton width) @ (table bounds bottom - self fieldHeigh).
+	bottomRight := (table bounds right - table verticalScrollBarWidth) @ (table bottom - table horizontalScrollBarHeight).
+	topLeft := (bottomRight x - actionButton width) @ (table bounds bottom - self fieldHeigh - table horizontalScrollBarHeight).
 	actionButton bounds: (topLeft corner: bottomRight)
 ]
 
@@ -88,9 +88,9 @@ FTFilterFunctionWithAction >> resizeButton [
 FTFilterFunctionWithAction >> resizeField [
 	| topLeft bottomRight |
 	self flag: #pharoTodo.	"Maybe it could be cool to let the user choose if the field need to be at the top or the bottom."
-	topLeft := table bounds left @ (table bounds bottom - self fieldHeigh).
+	topLeft := table bounds left @ (table bounds bottom - self fieldHeigh - table horizontalScrollBarHeight).
 	bottomRight := (table bounds right - table verticalScrollBarWidth - (actionButton width + 5))
-		@ table bottom.
+		@ (table bottom - table horizontalScrollBarHeight).
 	field bounds: (topLeft corner: bottomRight)
 ]
 

--- a/src/Morphic-Widgets-FastTable/FTFunctionWithField.class.st
+++ b/src/Morphic-Widgets-FastTable/FTFunctionWithField.class.st
@@ -85,8 +85,8 @@ FTFunctionWithField >> resizeContainerFrom: topLeftPoint to: bottomLeftPoint [
 FTFunctionWithField >> resizeWidget [
 	| topLeft bottomRight |
 	self flag: #pharoTodo.	"Maybe it could be cool to let the user choose if the field need to be at the top or the bottom."
-	topLeft := table bounds left @ (table bounds bottom - self fieldHeigh).
-	bottomRight := (table bounds right - table verticalScrollBarWidth) @ table bottom.
+	topLeft := table bounds left @ (table bounds bottom - self fieldHeigh - table horizontalScrollBarHeight ).
+	bottomRight := (table bounds right - table verticalScrollBarWidth) @ (table bottom - table horizontalScrollBarHeight).
 	field bounds: (topLeft corner: bottomRight)
 ]
 

--- a/src/Morphic-Widgets-FastTable/FTTableContainerMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableContainerMorph.class.st
@@ -22,7 +22,8 @@ Internal Representation and Key Implementation Points.
     Instance Variables
 	exposedRows:		A dictionary of index/row with all the exposed rows.
 	headerRow:			When not nil contains the header row of the container.
-	needsRefreshExposedRows:		A boolean that is true if the container need a refresh. 
+	needsRefreshExposedRows:		A boolean that is true if the container need a refresh.
+	startColumnIndex: An integer - first column to start drawing when scrolling horizontally, nil/0 - old behaviour (no scrolling)
 
 The method #drawOn: is responsible of my rendering.
 "
@@ -32,7 +33,8 @@ Class {
 	#instVars : [
 		'needsRefreshExposedRows',
 		'headerRow',
-		'exposedRows'
+		'exposedRows',
+		'startColumnIndex'
 	],
 	#category : #'Morphic-Widgets-FastTable'
 }
@@ -60,32 +62,53 @@ FTTableContainerMorph >> addResizeSplitters [
 			yourself)	 ]
 ]
 
+{ #category : #updating }
+FTTableContainerMorph >> adjustToHorizontalScrollBarValue: aNumber [ 
+	| newStartColumnIndex | 
+	newStartColumnIndex := (self table numberOfColumns * aNumber) rounded 
+		min: self table numberOfColumns 
+		max: 1 .
+	newStartColumnIndex ~= self startColumnIndex 
+		ifTrue: [ 
+			self startColumnIndex: newStartColumnIndex.
+			self changed  ]
+
+]
+
 { #category : #private }
 FTTableContainerMorph >> calculateColumnWidths [
+
 	"do three runs 
 	- first collect defined columnwidth that fit
 	- collect remaining undefined columnwidth 
 	- return if all fit 
-	  or collect and distribute remaining width"
+	  or collect and distribute remaining width.
+	
+ 	DanilOsipchuk: the method was adjusted to distribute space starting from startColumnIndex 
+	to enable horizontal scrolling when columns do not fit the window,
+	see #columnOrderOfWidthDistribution"
+	
 
 	| undefinedColumnWidths widths remainingWidth |
 	remainingWidth := self table bounds width.
 
-	widths := self table columns
-		collect: [ :c | 
-			| columnWidth |
-			columnWidth := c acquireWidth: remainingWidth.
-			remainingWidth := remainingWidth - columnWidth.
-			columnWidth ].
+	widths := Array new: self table numberOfColumns withAll: 0.
+	self columnOrderOfWidthDistribution do: [ :idx || column columnWidth |
+		column := self table columns at: idx. 
+		columnWidth := column acquireWidth: remainingWidth.
+		widths at: idx put: columnWidth.
+		remainingWidth := remainingWidth - columnWidth ].
 
-	"all fit - finish"
 	undefinedColumnWidths := widths count: #isZero.
 	undefinedColumnWidths isZero
 		ifTrue: [ widths size > 1 ifTrue: [ "Set the remaining space to the last column" widths at: widths size put: widths last + remainingWidth ].
 			^ widths ].
 
+
 	"collect and distribute remaining space"
-	^ widths collect: [ :c | c = 0 ifTrue: [ remainingWidth / undefinedColumnWidths ] ifFalse: [ c ] ]
+	self columnOrderOfWidthDistribution do: [ :idx | 
+		(widths at: idx) = 0 	ifTrue: [ widths at: idx put: (remainingWidth / undefinedColumnWidths) ] ].
+	^widths
 ]
 
 { #category : #private }
@@ -153,6 +176,20 @@ FTTableContainerMorph >> changed [
 FTTableContainerMorph >> clipSubmorphs [
 
 	^ true
+]
+
+{ #category : #private }
+FTTableContainerMorph >> columnOrderOfWidthDistribution [
+	"returns column indexes ordered by priority to get screenspace"
+	| idxToLast idxToFirstReversed |
+	self startColumnIndex isZero "a special case implementing default/current behaviour -- natural order of columns starting from the first one"
+		ifTrue: [ ^(1 to: self table numberOfColumns) ].
+	"new behaviour intended to garantee the visibility of columns around startColumnIndex
+		first give width starting from startColumnIndex towards end,
+		then from previous available column towards beginning"
+	idxToLast := startColumnIndex to: self table numberOfColumns.
+	idxToFirstReversed := startColumnIndex>1 ifTrue: [startColumnIndex-1 to: 1 by: -1] ifFalse: [#()].
+	^idxToLast,idxToFirstReversed
 ]
 
 { #category : #private }
@@ -247,6 +284,18 @@ FTTableContainerMorph >> drawRowsOn: canvas [
 ]
 
 { #category : #private }
+FTTableContainerMorph >> exposedColumnsRange: columnWidths [
+	"Return a subset of indexes for columns which are to be drawn.
+	startColumnIndex=0 is default/current behaviour -- draw all, even if they will not fit
+	otherwise, we select only indexes of columns having non-zero screen width"
+	
+	^self startColumnIndex isZero
+		ifTrue: [1 to: self table numberOfColumns] 
+		ifFalse: [(1 to: columnWidths size) select: [ :idx | (columnWidths at: idx)>0 ]  ]
+
+]
+
+{ #category : #private }
 FTTableContainerMorph >> exposedRows [
 	"Answer a dictionary of rowIndex->row pairs"
 
@@ -270,7 +319,8 @@ FTTableContainerMorph >> headerRow [
 { #category : #initialization }
 FTTableContainerMorph >> initialize [ 
 	super initialize.
-	needsRefreshExposedRows := false
+	needsRefreshExposedRows := false.
+	startColumnIndex :=0.
 ]
 
 { #category : #testing }
@@ -349,6 +399,17 @@ FTTableContainerMorph >> setNeedsRefreshExposedRows [
 ]
 
 { #category : #accessing }
+FTTableContainerMorph >> startColumnIndex [
+	startColumnIndex ifNil: [ startColumnIndex := 0 ].
+	^startColumnIndex
+]
+
+{ #category : #accessing }
+FTTableContainerMorph >> startColumnIndex: anObject [
+	startColumnIndex := anObject
+]
+
+{ #category : #accessing }
 FTTableContainerMorph >> table [
 	^ self owner
 ]
@@ -365,13 +426,13 @@ FTTableContainerMorph >> updateAllRows [
 
 { #category : #updating }
 FTTableContainerMorph >> updateExposedRows [
-	| visibleRows numberOfColumns columns columnWidths startIndex |
+	"updated (as #updateHeaderRow also) to draw only subset of columns if horizontal scrolling in use, see #exposedColumnsRange:"
+	| visibleRows columns columnWidths startIndex |
 	
 	self canRefreshValues ifFalse: [ ^ self ].
 
 	visibleRows := self calculateMaxVisibleRows.
 	startIndex := self calculateStartIndexWhenShowing: visibleRows.
-	numberOfColumns := self table numberOfColumns.
 	columns := self table columns. 
 	columnWidths := self calculateColumnWidths.
 
@@ -379,7 +440,7 @@ FTTableContainerMorph >> updateExposedRows [
 	startIndex to: ((startIndex + visibleRows - 1) min: self table numberOfRows) do: [ :rowIndex | 
 		| row |
 		row := FTTableRowMorph table: self table.
-		1 to: numberOfColumns do: [ :columnIndex | | cell |
+		(self exposedColumnsRange: columnWidths) do: [ :columnIndex | | cell |
 			cell := (self table dataSource 
 				cellColumn: (columns at: columnIndex)
 				row: rowIndex).  
@@ -395,23 +456,25 @@ FTTableContainerMorph >> updateHeaderRow [
 	 Please, note that If one of the headers is nil, I assume all are nil and I return. 
 	 This is probably not the best approach, but like that I enforce people defines at least 
 	 a default if they want headers."
-	| columnHeaders columnWidths |
+	| columns columnHeaders columnWidths |
 
 	self canRefreshValues ifFalse: [ ^ self ].
 
-	headerRow := nil.	
-	columnHeaders := Array new: self table numberOfColumns.
+	headerRow := nil.
+	columns := self table columns.	
+	columnHeaders := OrderedCollection new.
 	columnWidths := self calculateColumnWidths.
 	
-	self table columns withIndexDo: [ :each :index | | headerCell columnWidth|
+	(self exposedColumnsRange: columnWidths)  do: [ :index | | column headerCell columnWidth|
+		column := columns at: index.
 		columnWidth := columnWidths at: index.
-		headerCell :=  self table dataSource headerColumn: each. 
+		headerCell :=  self table dataSource headerColumn: column. 
 		headerCell ifNil: [ ^ self ]. 
 		headerCell 
 			color: self table headerColor;
 			width: columnWidth.
-		columnHeaders at: index put: headerCell.
-		FTDisplayColumn column: each width: columnWidth ].
+		columnHeaders addLast: headerCell.
+		FTDisplayColumn column: column width: columnWidth ].
 	 
 	headerRow := (FTTableHeaderRowMorph table: self table)
 		privateOwner: self;

--- a/src/Morphic-Widgets-FastTable/FTTableContainerMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableContainerMorph.class.st
@@ -84,7 +84,7 @@ FTTableContainerMorph >> calculateColumnWidths [
 	- return if all fit 
 	  or collect and distribute remaining width.
 	
- 	DanilOsipchuk: the method was adjusted to distribute space starting from startColumnIndex 
+   the method was adjusted to distribute space starting from startColumnIndex 
 	to enable horizontal scrolling when columns do not fit the window,
 	see #columnOrderOfWidthDistribution"
 	

--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -513,8 +513,7 @@ FTTableMorph >> horizontalScrollBarHeight [
 { #category : #private }
 FTTableMorph >> horizontalScrollBarValue: aNumber [
 	trialHSB ifNotNil: [ 
-		self inform: 'FTTableMorph>>#horizontalScrollBarValue: ', aNumber printString , String cr, 
-			'Does nothing yet.' , String cr, 'Need some advise here.'
+	self container adjustToHorizontalScrollBarValue: aNumber.
 	].
 ]
 

--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -19,6 +19,11 @@ You can disable this with the method #disableSearch.
 But you also have the possibility to make your FastTable filterable with the method #enableFilter. But search and filter cannot be use in the same time.
 
 I manage different kind of selections through a strategy design pattern. For example I have a strategy to manage simple or multiple selection and I have a strategy to manage cell or row selection.
+
+Horizontal scrolling being a new feature is not enabled by default. Use #newWithHorizontalScrollBar or set horizontalScrollBar var to anything at early initialization stage (before #initializeScrollBars where it is being checked)
+
+
+
 "
 Class {
 	#name : #FTTableMorph,
@@ -43,7 +48,6 @@ Class {
 		'needToggleAtMouseUp',
 		'function',
 		'resizable',
-		'trialHSB',
 		'selectionModeStrategy'
 	],
 	#category : #'Morphic-Widgets-FastTable'
@@ -94,10 +98,10 @@ FTTableMorph class >> defaultSelectionColor [
 ]
 
 { #category : #temporary }
-FTTableMorph class >> newTrialHorizontalScrollBar [
-	"This method just temporary to guard new changes from hurtingtools durign development"
+FTTableMorph class >> newWithHorizontalScrollBar [
+	"This method is temporary to introduce horisontal scrolling gradually"
 	"See GTExamples class >> exampleTableHorizontalScroll"
-	^self basicNew initializeTrialHorizontalScrollBar
+	^self basicNew initializeWithHorizontalScrollBar
 ]
 
 { #category : #'drag and drop' }
@@ -502,7 +506,7 @@ FTTableMorph >> horizontalScrollBar [
 
 { #category : #private }
 FTTableMorph >> horizontalScrollBarHeight [
-	^trialHSB 
+	^horizontalScrollBar 
 		ifNil: [ 0 ] 
 		ifNotNil: [ 
 			self isHorizontalScrollBarVisible ifFalse: [ ^ 0 ].
@@ -512,7 +516,7 @@ FTTableMorph >> horizontalScrollBarHeight [
 
 { #category : #private }
 FTTableMorph >> horizontalScrollBarValue: aNumber [
-	trialHSB ifNotNil: [ 
+	horizontalScrollBar ifNotNil: [ 
 	self container adjustToHorizontalScrollBarValue: aNumber.
 	].
 ]
@@ -576,7 +580,9 @@ FTTableMorph >> initializeScrollBars [
 		yourself.
 	self addMorph: verticalScrollBar.
 
-	trialHSB ifNotNil: [ 	
+	"introducing horizontal scrolling gradually: 
+	enable the feature only when the var is set during initialization"
+	horizontalScrollBar ifNotNil: [ 	
 		horizontalScrollBar := ScrollBar new 
 			model: self; 
 			setValueSelector: #horizontalScrollBarValue:;
@@ -592,8 +598,8 @@ FTTableMorph >> initializeSelectedIndexes [
 ]
 
 { #category : #initialization }
-FTTableMorph >> initializeTrialHorizontalScrollBar [
-	trialHSB := true.
+FTTableMorph >> initializeWithHorizontalScrollBar [
+	horizontalScrollBar := true.
 	self initialize.
 ]
 
@@ -612,7 +618,7 @@ FTTableMorph >> intercellSpacing: aNumberOrPoint [
 
 { #category : #private }
 FTTableMorph >> isHorizontalScrollBarVisible [
-	^trialHSB 
+	^horizontalScrollBar 
 		ifNil: [ false ] 
 		ifNotNil: [ 
 			self horizontalScrollBar owner isNotNil.
@@ -895,7 +901,7 @@ FTTableMorph >> refresh [
 	self ensureAtLeastOneColumn.
 	self recalculateVerticalScrollBar.
 	self verticalScrollBar changed.
-	trialHSB ifNotNil: [ self horizontalScrollBar changed ].
+	horizontalScrollBar ifNotNil: [ self horizontalScrollBar changed ].
 	self container changed
 	
 ]
@@ -910,7 +916,7 @@ FTTableMorph >> resetPosition [
 	"Resets all values to original value"
 	showIndex := 0.
 	self verticalScrollBar value: 0.
-	trialHSB ifNotNil: [	self horizontalScrollBar value: 0 ].
+	horizontalScrollBar ifNotNil: [	self horizontalScrollBar value: 0 ].
 	self container setNeedsRefreshExposedRows.
 	self container updateExposedRows.
 ]
@@ -918,7 +924,7 @@ FTTableMorph >> resetPosition [
 { #category : #private }
 FTTableMorph >> resizeAllSubviews [
 	self resizeVerticalScrollBar.
-	trialHSB ifNotNil: [ self resizeHorizontalScrollBar ].
+	horizontalScrollBar ifNotNil: [ self resizeHorizontalScrollBar ].
 	"if we resized scrollbar, we need to recalculate it because values change (and now visibility 
 	 can be toggled, shown items can change, etc.)"
 	self recalculateVerticalScrollBar.
@@ -946,7 +952,7 @@ FTTableMorph >> resizeContainer [
 { #category : #private }
 FTTableMorph >> resizeHorizontalScrollBar [
 	| width height corner |
-	trialHSB ifNotNil: [ 
+	horizontalScrollBar ifNotNil: [ 
 		width := self bounds width - (self borderWidth * 2) - self verticalScrollBarWidth.
 		height := self scrollBarThickness.
 		corner := self bounds bottomLeft - ((width + self borderWidth)@(0 - self borderWidth)).


### PR DESCRIPTION
A simple implementation of horizontal scrolling for FTTableMorph, to enable one has to set trialHSB:=true during initialization, otherwise current behavior is unchanged.
When enabled FTTableContainerMorph  allocates space to columns (#calculateColumnWidths) starting (#columnOrderOfWidthDistribution) from startColumnIndex ( instance var added with this commit, when set to 0 used as a flag to activate current/default behavior )  corresponding to the horizontal bar position triggered by  #adjustToHorizontalScrollBarValue: Only columns which manage to get space are being drawn  (#exposedColumnsRange: )

FTTableMorph newTrialHorizontalScrollBar                  <-- existing example
FTTableMorph>>#initialize                                                     <--  add trialHSB := true.  to enable it everywhere