### PR TITLE
Some-cleanings-on-protocols

### DIFF
--- a/src/Alien-Core/FFICallbackReturnValue.class.st
+++ b/src/Alien-Core/FFICallbackReturnValue.class.st
@@ -45,13 +45,13 @@ FFICallbackReturnValue >> primReturnFromContext: callbackContext "<ContextPart>"
 	self primitiveFailed
 ]
 
-{ #category : #'instance initalization' }
+{ #category : #'instance initialization' }
 FFICallbackReturnValue >> returnDouble: f [
 	self signedLongAt: self typeOffset put: 2.
 	self doubleAt: self valueOffset put: f asFloat
 ]
 
-{ #category : #'instance initalization' }
+{ #category : #'instance initialization' }
 FFICallbackReturnValue >> returnInteger: n [
 	self signedLongAt: self typeOffset put: 0.
 	self signedLongAt: self valueOffset put: n asInteger

--- a/src/Alien-Core/FFICallbackThunk.class.st
+++ b/src/Alien-Core/FFICallbackThunk.class.st
@@ -148,7 +148,7 @@ FFICallbackThunk >> initialize [
 	['X64Win64']	->	[self initializeX64Win64] }
 ]
 
-{ #category : #'instance initalization' }
+{ #category : #'instance initialization' }
 FFICallbackThunk >> initializeARM32 [
 	"Initialize the receiver with a __ccall thunk.  The thunk calls thunkEntry in the Alien/IA32ABI plugin,
 	 whose source is in platforms/Cross/plugins/IA32ABI/arm32abicc.c.  thunkEntry is the entry point
@@ -189,14 +189,14 @@ FFICallbackThunk >> initializeARM32 [
 	"self newCCall"
 ]
 
-{ #category : #'instance initalization' }
+{ #category : #'instance initialization' }
 FFICallbackThunk >> initializeStdcall: bytes [
 	"Initialize the receiver with a __stdcall thunk with bytes argument bytes."
 	Callback abi caseOf: {
 	['IA32']		->	[self initializeX86Stdcall: bytes] }
 ]
 
-{ #category : #'instance initalization' }
+{ #category : #'instance initialization' }
 FFICallbackThunk >> initializeX64 [
 	"Initialize the receiver with a __ccall thunk.  The thunk calls thunkEntry in the Alien/IA32ABI plugin,
 	 whose source is in platforms/Cross/plugins/IA32ABI/x64sysvabicc.c.  thunkEntry is the entry point
@@ -235,7 +235,7 @@ FFICallbackThunk >> initializeX64 [
 	"self newCCall"
 ]
 
-{ #category : #'instance initalization' }
+{ #category : #'instance initialization' }
 FFICallbackThunk >> initializeX64Win64 [
 	"Initialize the receiver with a __ccall thunk.  The thunk calls thunkEntry in the Alien/IA32ABI plugin,
 	 whose source is in platforms/Cross/plugins/IA32ABI/x64win64abicc.c.  thunkEntry is the entry point
@@ -275,7 +275,7 @@ FFICallbackThunk >> initializeX64Win64 [
 	"self newCCall"
 ]
 
-{ #category : #'instance initalization' }
+{ #category : #'instance initialization' }
 FFICallbackThunk >> initializeX86 [
 	"Initialize the receiver with a __ccall thunk.  The thunk calls thunkEntry in the Alien/IA32ABI plugin,
 	 whose source is in platforms/Cross/plugins/IA32ABI/x64win64abicc.c.  thunkEntry is the entry point
@@ -310,7 +310,7 @@ FFICallbackThunk >> initializeX86 [
 		unsignedLongAt: 21 put: 16r9090C30C
 ]
 
-{ #category : #'instance initalization' }
+{ #category : #'instance initialization' }
 FFICallbackThunk >> initializeX86Stdcall: bytes [
 	"Initialize the receiver with a __stdcall thunk with bytes argument bytes. (See initializeX86 fort more info)"
 	"thunk:		push   %esp				0x54							0xa1905454

--- a/src/ClassParser/CDClassDefinitionNode.class.st
+++ b/src/ClassParser/CDClassDefinitionNode.class.st
@@ -12,7 +12,7 @@ Class {
 	#category : #'ClassParser-Model'
 }
 
-{ #category : #'instance-creation' }
+{ #category : #'instance creation' }
 CDClassDefinitionNode class >> on: aRBMessageNode [ 
 	
 	^ self new

--- a/src/ClassParser/CDNode.class.st
+++ b/src/ClassParser/CDNode.class.st
@@ -17,7 +17,7 @@ Class {
 	#category : #'ClassParser-Model'
 }
 
-{ #category : #'instance-creation' }
+{ #category : #'instance creation' }
 CDNode class >> on: aRBMessageNode [ 
 	
 	^ self new

--- a/src/ClassParser/CDSharedVariableNode.class.st
+++ b/src/ClassParser/CDSharedVariableNode.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'ClassParser-Model'
 }
 
-{ #category : #'instance-creation' }
+{ #category : #'instance creation' }
 CDSharedVariableNode class >> slot: aSlot node: aNode [ 
 	
 	^ self new

--- a/src/ClassParser/CDSlotNode.class.st
+++ b/src/ClassParser/CDSlotNode.class.st
@@ -13,7 +13,7 @@ Class {
 	#category : #'ClassParser-Model'
 }
 
-{ #category : #'instance-creation' }
+{ #category : #'instance creation' }
 CDSlotNode class >> node: aNode name: aName slotClassName: aSymbol initializationMessage: aMessageNode start: start stop: stop [
 	
 	^ self new
@@ -26,7 +26,7 @@ CDSlotNode class >> node: aNode name: aName slotClassName: aSymbol initializatio
 		yourself
 ]
 
-{ #category : #'instance-creation' }
+{ #category : #'instance creation' }
 CDSlotNode class >> node: aNode name: aName slotClassName: aSymbol start: start stop: stop [
 	
 	^ self new

--- a/src/Collections-Sequenceable/Array2D.class.st
+++ b/src/Collections-Sequenceable/Array2D.class.st
@@ -179,7 +179,7 @@ Array2D >> = aMatrix [
 					and: [ aMatrix privateContents = contents ] ] ]
 ]
 
-{ #category : #'not implemented' }
+{ #category : #adding }
 Array2D >> add: newObject [
 	self shouldNotImplement
 ]
@@ -405,7 +405,7 @@ Array2D >> diagonal [
 	^ (1 to: (numberOfRows min: numberOfColumns)) collect: [:j | contents at: (i := i + numberOfColumns + 1)]
 ]
 
-{ #category : #'not implemented' }
+{ #category : #enumerating }
 Array2D >> difference: aCollection [
 	"Union is in because the result is always a Set.
 	 Difference and intersection are out because the result is like the receiver,
@@ -525,7 +525,7 @@ Array2D >> indicesInject: start into: aBlock [
 	^ current
 ]
 
-{ #category : #'not implemented' }
+{ #category : #enumerating }
 Array2D >> intersection: aCollection [
 	"Union is in because the result is always a Set.
 	 Difference and intersection are out because the result is like the receiver,
@@ -624,7 +624,7 @@ Array2D >> readStream [
 	^ contents readStream
 ]
 
-{ #category : #'not implemented' }
+{ #category : #enumerating }
 Array2D >> reject: aBlock [
 	self shouldNotImplement
 ]
@@ -670,7 +670,7 @@ Array2D >> rows: rows columns: columns contents: anArray [
 	^self
 ]
 
-{ #category : #'not implemented' }
+{ #category : #enumerating }
 Array2D >> select: aBlock [
 	self shouldNotImplement
 ]

--- a/src/Compression/GZipReadStream.class.st
+++ b/src/Compression/GZipReadStream.class.st
@@ -10,7 +10,7 @@ Class {
 	#category : #'Compression-Streams'
 }
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 GZipReadStream class >> fileIn: fullFileName [
 	"FileIn the contents of a gzipped file"
 
@@ -19,7 +19,7 @@ GZipReadStream class >> fileIn: fullFileName [
 		do: [ :aStream | CodeImporter evaluateString: aStream contents asString ]
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 GZipReadStream class >> fileIntoNewChangeSet: fullFileName [
 	"FileIn the contents of a gzipped file"
 
@@ -35,7 +35,7 @@ GZipReadStream class >> fileIntoNewChangeSet: fullFileName [
 							csClass newChangesFromStream: aReadStream named: fullFileName asFileReference basename ] ] ]
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 GZipReadStream class >> saveContents: fullFileName [
 	"Save the contents of a gzipped file"
 
@@ -57,7 +57,7 @@ GZipReadStream class >> saveContents: fullFileName [
 	^ newName
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 GZipReadStream class >> uncompressedFileName: fullName [
 	^((fullName endsWith: '.gz') and: [self confirm: ('{1}
 appears to be a compressed file.
@@ -94,7 +94,7 @@ GZipReadStream class >> unzip: fullFileName to: pathName [
 	^ newName
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 GZipReadStream class >> viewContents: fullFileName [
 	"Open the decompressed contents of the .gz file with the given name.  This method is only required for the registering-file-list of Squeak 3.3a and beyond, but does no harm in an earlier system"
 

--- a/src/Compression/ZipArchive.class.st
+++ b/src/Compression/ZipArchive.class.st
@@ -39,7 +39,7 @@ ZipArchive class >> compressionStored [
 	^CompressionStored
 ]
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 ZipArchive class >> extractAllIn: aFileReferenceOrFileName [
 	"Service method to extract all contents of a zip."
 	| directory |

--- a/src/DeprecatedFileStream/MultiByteBinaryOrTextStream.class.st
+++ b/src/DeprecatedFileStream/MultiByteBinaryOrTextStream.class.st
@@ -302,7 +302,7 @@ MultiByteBinaryOrTextStream >> reset [
 	self converter. "ensure that we have a converter."
 ]
 
-{ #category : #'fileIn/out' }
+{ #category : #'file in/out' }
 MultiByteBinaryOrTextStream >> setConverterForCode [
 
 	| current |
@@ -319,7 +319,7 @@ MultiByteBinaryOrTextStream >> setConverterForCode [
 
 ]
 
-{ #category : #'fileIn/out' }
+{ #category : #'file in/out' }
 MultiByteBinaryOrTextStream >> setEncoderForSourceCodeNamed: streamName [
 
 	| l |

--- a/src/DeprecatedFileStream/MultiByteFileStream.class.st
+++ b/src/DeprecatedFileStream/MultiByteFileStream.class.st
@@ -139,7 +139,7 @@ MultiByteFileStream >> bareNext [
 
 ]
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 MultiByteFileStream >> basicChunk [
 	"If our buffer in collection contains an chunk with no embedded !'s, nor
 	any non-ascii characters, return that.
@@ -457,7 +457,7 @@ MultiByteFileStream >> next: anInteger putAll: aCollection startingAt: startInde
         ^self converter next: anInteger putAll: aCollection startingAt: startIndex toStream: self
 ]
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 MultiByteFileStream >> nextChunk [
 	"Answer the contents of the receiver, up to the next terminator
 	character. Doubled terminators indicate an embedded terminator
@@ -519,7 +519,7 @@ MultiByteFileStream >> nextMatchAll: aColl [
 
 ]
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 MultiByteFileStream >> nextPreamble [
 	"Assuming that preamble part does not contain ]lang[ tag"
 	self skipSeparators.

--- a/src/Glamour-Morphic-Pager/GLMPagerBarBrick.class.st
+++ b/src/Glamour-Morphic-Pager/GLMPagerBarBrick.class.st
@@ -9,13 +9,13 @@ Class {
 	#category : #'Glamour-Morphic-Pager-Brick'
 }
 
-{ #category : #'bar-accessing' }
+{ #category : #accessing }
 GLMPagerBarBrick >> buttonsBrick [
 
 	^ buttonsBrick
 ]
 
-{ #category : #'bar-accessing' }
+{ #category : #accessing }
 GLMPagerBarBrick >> buttonsBrick: aBrick [
 
 	buttonsBrick := aBrick.
@@ -37,39 +37,39 @@ GLMPagerBarBrick >> initialize [
 		useVerticalLinearLayout
 ]
 
-{ #category : #'bar-instance creation' }
+{ #category : #'instance creation' }
 GLMPagerBarBrick >> newButtonsBrick [
 
 	^ GLMPagerButtonsPaneBrick new
 ]
 
-{ #category : #'bar-instance creation' }
+{ #category : #'instance creation' }
 GLMPagerBarBrick >> newSliderBrick [
 
 	^ GLMPagerScrollSlidingBrick new
 ]
 
-{ #category : #'bar-event-handling' }
+{ #category : #'event-handling' }
 GLMPagerBarBrick >> onPagePoped [
 
 	buttonsBrick onPagePoped.
 	self recomputeScrollBar.
 ]
 
-{ #category : #'bar-event-handling' }
+{ #category : #'event-handling' }
 GLMPagerBarBrick >> onPagePushed: addedAnnouncement [
 
 	self buttonsBrick onPagePushed: addedAnnouncement.
 	self recomputeScrollBar
 ]
 
-{ #category : #'bar-accessing' }
+{ #category : #accessing }
 GLMPagerBarBrick >> pagerModel [
 
 	^ pagerModel
 ]
 
-{ #category : #'bar-accessing' }
+{ #category : #accessing }
 GLMPagerBarBrick >> pagerModel: aModel [
 	
 	pagerModel := aModel.
@@ -87,13 +87,13 @@ GLMPagerBarBrick >> recomputeScrollBar [
 	self sliderBrick ifNotNil: #setWidthAfterResizing
 ]
 
-{ #category : #'bar-accessing' }
+{ #category : #accessing }
 GLMPagerBarBrick >> sliderBrick [
 
 	^ sliderBrick
 ]
 
-{ #category : #'bar-accessing' }
+{ #category : #accessing }
 GLMPagerBarBrick >> sliderBrick: aBrick [
 
 	sliderBrick := aBrick.

--- a/src/Glamour-Morphic-Pager/GLMPagerBrick.class.st
+++ b/src/Glamour-Morphic-Pager/GLMPagerBrick.class.st
@@ -57,25 +57,25 @@ GLMPagerBrick >> initializeShortcuts [
 		toAction: [ self pressedScrollerSizeCombination: #right ].
 ]
 
-{ #category : #'pager-instance creation' }
+{ #category : #'instance creation' }
 GLMPagerBrick >> newPagerBar [
 
 	^ GLMPagerBarBrick new
 ]
 
-{ #category : #'pager-instance creation' }
+{ #category : #'instance creation' }
 GLMPagerBrick >> newScrollBrick [
 
 	^ GLMPagerScrollBrick new
 ]
 
-{ #category : #'pager-event-handling' }
+{ #category : #'event-handling' }
 GLMPagerBrick >> onPagePoped [
 
 	self showOrHideScrollBar
 ]
 
-{ #category : #'pager-event-handling' }
+{ #category : #'event-handling' }
 GLMPagerBrick >> onPagePushed [
 
 	self showOrHideScrollBar
@@ -88,13 +88,13 @@ GLMPagerBrick >> outOfWorld: aWorld [
 	^ super outOfWorld: aWorld.
 ]
 
-{ #category : #'pager-accessing' }
+{ #category : #accessing }
 GLMPagerBrick >> pagerBar [
 
 	^ pagerBar
 ]
 
-{ #category : #'pager-accessing' }
+{ #category : #accessing }
 GLMPagerBrick >> pagerBar: aBrick [
 
 	pagerBar := aBrick.
@@ -109,12 +109,12 @@ GLMPagerBrick >> pagerBar: aBrick [
 	self addBrickBack: self pagerBar
 ]
 
-{ #category : #'pager-accessing' }
+{ #category : #accessing }
 GLMPagerBrick >> pagerModel [
 	^ pagerModel
 ]
 
-{ #category : #'pager-accessing' }
+{ #category : #accessing }
 GLMPagerBrick >> pagerModel: aModel [
 
 	pagerModel := aModel.
@@ -128,19 +128,19 @@ GLMPagerBrick >> pagerModel: aModel [
 	self pagerBar: self newPagerBar
 ]
 
-{ #category : #'pager-api' }
+{ #category : #api }
 GLMPagerBrick >> popAndReplacePane: aMorph [
 	"replaces last pane with new pane"
 	self pagerModel popAndReplacePane: aMorph
 ]
 
-{ #category : #'pager-api' }
+{ #category : #api }
 GLMPagerBrick >> popPane [
 	"pops the last pane with smooth animation"
 	self pagerModel popPane: true.
 ]
 
-{ #category : #'pager-actions' }
+{ #category : #actions }
 GLMPagerBrick >> pressedScrollerSizeCombination: aSymbol [
 
 	firstCombination ifNil: [ firstCombination := aSymbol. ^ self].
@@ -149,7 +149,7 @@ GLMPagerBrick >> pressedScrollerSizeCombination: aSymbol [
 	firstCombination := nil.
 ]
 
-{ #category : #'pager-api' }
+{ #category : #api }
 GLMPagerBrick >> pushPane: aMorph [
 	"pushes a pane to the end with smooth scroll animation"
 	| isSmooth |
@@ -158,13 +158,13 @@ GLMPagerBrick >> pushPane: aMorph [
 	self pagerModel pushPane: aMorph smooth: isSmooth
 ]
 
-{ #category : #'pager-accessing' }
+{ #category : #accessing }
 GLMPagerBrick >> scrollBrick [
 
 	^ scrollBrick
 ]
 
-{ #category : #'pager-accessing' }
+{ #category : #accessing }
 GLMPagerBrick >> scrollBrick: aBrick [
 
 	scrollBrick := aBrick.
@@ -177,7 +177,7 @@ GLMPagerBrick >> scrollBrick: aBrick [
 	self addBrickBack: self scrollBrick
 ]
 
-{ #category : #'pager-actions' }
+{ #category : #actions }
 GLMPagerBrick >> scrollerSizeShortcutAction: first second: second [
 	
 	(first = #left) & (second = #left) ifTrue: [ pagerModel enlargeToLeft ].
@@ -186,7 +186,7 @@ GLMPagerBrick >> scrollerSizeShortcutAction: first second: second [
 	(first = #right) & (second = #right) ifTrue: [ pagerModel enlargeToRight ]
 ]
 
-{ #category : #'pager-actions' }
+{ #category : #actions }
 GLMPagerBrick >> showOrHideScrollBar [
 	
 	((self pagerModel size > self pagerModel minimumPageNumberForScrollbar) & (self showScrollBarWhenNeeded))
@@ -195,14 +195,14 @@ GLMPagerBrick >> showOrHideScrollBar [
 		ifFalse: [ self removeBrick: self pagerBar ].
 ]
 
-{ #category : #'pager-accessing' }
+{ #category : #accessing }
 GLMPagerBrick >> showScrollBarWhenNeeded [
 	"retuns true if scrollbar should be visible if number of pages > 1,
 	otherwise false"
 	^ showScrollBarWhenNeeded ifNil: [ showScrollBarWhenNeeded := true ]
 ]
 
-{ #category : #'pager-accessing' }
+{ #category : #accessing }
 GLMPagerBrick >> showScrollBarWhenNeeded: aBoolean [
 
 	showScrollBarWhenNeeded := aBoolean

--- a/src/Glamour-Morphic-Pager/GLMPagerButtonsPaneBrick.class.st
+++ b/src/Glamour-Morphic-Pager/GLMPagerButtonsPaneBrick.class.st
@@ -8,7 +8,7 @@ Class {
 	#category : #'Glamour-Morphic-Pager-Brick'
 }
 
-{ #category : #'buttons-adding' }
+{ #category : #adding }
 GLMPagerButtonsPaneBrick >> addButton: aBrick [
 
 	self buttons add: aBrick.
@@ -31,26 +31,26 @@ GLMPagerButtonsPaneBrick >> addButton: aBrick [
 	self updateButtons.
 ]
 
-{ #category : #'buttons-calculations' }
+{ #category : #calculations }
 GLMPagerButtonsPaneBrick >> buttonCenterByIndex: aNumber [
 	| width |
 	width := self pagerModel circleButtonSize.
 	^ ( ( aNumber - 1 ) * ( width ) ) + ( width / 2 ).
 ]
 
-{ #category : #'buttons-accessing' }
+{ #category : #accessing }
 GLMPagerButtonsPaneBrick >> buttons [
 
 	^ buttons ifNil: [ buttons := OrderedCollection new ]
 ]
 
-{ #category : #'buttons-accessing' }
+{ #category : #accessing }
 GLMPagerButtonsPaneBrick >> buttons: anObject [
 
 	buttons := anObject
 ]
 
-{ #category : #'buttons-testing' }
+{ #category : #testing }
 GLMPagerButtonsPaneBrick >> isScrollMustBeChecked: anIndex withLeft: leftBound andRight: rightBound [
 	| buttonCenter |
 	
@@ -58,7 +58,7 @@ GLMPagerButtonsPaneBrick >> isScrollMustBeChecked: anIndex withLeft: leftBound a
 	^ (leftBound <= buttonCenter ) & (rightBound > buttonCenter)
 ]
 
-{ #category : #'buttons-updating' }
+{ #category : #updating }
 GLMPagerButtonsPaneBrick >> markButtonsInside: aBounds [
 	|index boundsLeft boundsRight firstFound lastFound |	
 	self flag: 'refactor me'.
@@ -99,25 +99,25 @@ GLMPagerButtonsPaneBrick >> markButtonsInside: aBounds [
 
 ]
 
-{ #category : #'buttons-instance-creation' }
+{ #category : #'instance creation' }
 GLMPagerButtonsPaneBrick >> newButton [
 
 	^ GLMPagerScrollButtonBrick new
 ]
 
-{ #category : #'buttons-event-handling' }
+{ #category : #'event-handling' }
 GLMPagerButtonsPaneBrick >> onButtonClicked: ann [
 
 	self pagerModel switchPaneTo: ann buttonModel index
 ]
 
-{ #category : #'buttons-event-handling' }
+{ #category : #'event-handling' }
 GLMPagerButtonsPaneBrick >> onButtonDeselected [
 
 	GLMPagerPanePreviewMorph uniqueInstance hideFromWorld
 ]
 
-{ #category : #'buttons-event-handling' }
+{ #category : #'event-handling' }
 GLMPagerButtonsPaneBrick >> onButtonSelected: ann [
 
 	"notify adapter that we need to update pane preview"
@@ -125,7 +125,7 @@ GLMPagerButtonsPaneBrick >> onButtonSelected: ann [
 	self pagerModel updatePreview: ann buttonModel index
 ]
 
-{ #category : #'buttons-event-handling' }
+{ #category : #'event-handling' }
 GLMPagerButtonsPaneBrick >> onFocusedPageChanged [
 
 	self
@@ -134,7 +134,7 @@ GLMPagerButtonsPaneBrick >> onFocusedPageChanged [
 
 ]
 
-{ #category : #'buttons-event-handling' }
+{ #category : #'event-handling' }
 GLMPagerButtonsPaneBrick >> onPagePoped [
 	|button|
 	
@@ -146,32 +146,32 @@ GLMPagerButtonsPaneBrick >> onPagePoped [
 	self updateButtons
 ]
 
-{ #category : #'buttons-event-handling' }
+{ #category : #'event-handling' }
 GLMPagerButtonsPaneBrick >> onPagePushed: addedAnnouncement [
 	
 	self addButton: self newButton
 ]
 
-{ #category : #'buttons-event-handling' }
+{ #category : #'event-handling' }
 GLMPagerButtonsPaneBrick >> onPageSwitched [
 
 	self updateButtons
 ]
 
-{ #category : #'buttons-event-handling' }
+{ #category : #'event-handling' }
 GLMPagerButtonsPaneBrick >> onScrollBoundsChanged: boundsChangedAnnouncement [
 
 	self markButtonsInside: boundsChangedAnnouncement bounds.
 	
 ]
 
-{ #category : #'buttons-accessing' }
+{ #category : #accessing }
 GLMPagerButtonsPaneBrick >> pagerModel [
 
 	^ pagerModel
 ]
 
-{ #category : #'buttons-accessing' }
+{ #category : #accessing }
 GLMPagerButtonsPaneBrick >> pagerModel: aModel [
 	
 	pagerModel := aModel.
@@ -183,7 +183,7 @@ GLMPagerButtonsPaneBrick >> pagerModel: aModel [
 	self updateButtons
 ]
 
-{ #category : #'buttons-updating' }
+{ #category : #updating }
 GLMPagerButtonsPaneBrick >> updateButtons [
 	"first we uncheck all buttons"
 	self buttons select: #isFocused thenDo: #uncheck.
@@ -192,7 +192,7 @@ GLMPagerButtonsPaneBrick >> updateButtons [
 		self buttons from: self pagerModel firstVisiblePageIndex to: self pagerModel lastVisiblePageIndex do: #check ]
 ]
 
-{ #category : #'buttons-updating' }
+{ #category : #updating }
 GLMPagerButtonsPaneBrick >> updateButtonsFocus [
 	"unfocus all"
 	self buttons do: #setNotFocused.

--- a/src/Glamour-Morphic-Pager/GLMPagerScrollButtonBrick.class.st
+++ b/src/Glamour-Morphic-Pager/GLMPagerScrollButtonBrick.class.st
@@ -10,27 +10,27 @@ Class {
 	#category : #'Glamour-Morphic-Pager-Brick'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 GLMPagerScrollButtonBrick >> checkedFocusedIcon [
 	^ checkedFocusedIcon
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 GLMPagerScrollButtonBrick >> checkedFocusedIcon: aForm [
 	checkedFocusedIcon := aForm.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 GLMPagerScrollButtonBrick >> checkedIcon [
 	^ checkedIcon
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 GLMPagerScrollButtonBrick >> checkedIcon: aForm [
 	checkedIcon := aForm.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'brick-interactable-actions' }
 GLMPagerScrollButtonBrick >> click: anEvent [
 	super click: anEvent.
 	
@@ -38,7 +38,7 @@ GLMPagerScrollButtonBrick >> click: anEvent [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'brick-interactable-actions' }
 GLMPagerScrollButtonBrick >> deselect [
 	super deselect.
 	
@@ -63,12 +63,12 @@ GLMPagerScrollButtonBrick >> initialize [
 	focused := false.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'brick-interactable-testing' }
 GLMPagerScrollButtonBrick >> isFocused [
 	^ focused
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'brick-interactable-actions' }
 GLMPagerScrollButtonBrick >> select [
 	super select.
 	
@@ -76,7 +76,7 @@ GLMPagerScrollButtonBrick >> select [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 GLMPagerScrollButtonBrick >> setFocused [
 
 	focused ifFalse: [
@@ -85,7 +85,7 @@ GLMPagerScrollButtonBrick >> setFocused [
 		focused := true ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 GLMPagerScrollButtonBrick >> setNotFocused [
 
 	focused ifTrue: [

--- a/src/Glamour-Morphic-Pager/GLMPagerScrollSlidingBrick.class.st
+++ b/src/Glamour-Morphic-Pager/GLMPagerScrollSlidingBrick.class.st
@@ -14,7 +14,7 @@ Class {
 	#category : #'Glamour-Morphic-Pager-Brick'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #draging }
 GLMPagerScrollSlidingBrick >> computeScrollValue: aNumber [
 	|newValue delta|
 	
@@ -26,7 +26,7 @@ GLMPagerScrollSlidingBrick >> computeScrollValue: aNumber [
 		ifFalse: [ newValue / delta ])
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #draging }
 GLMPagerScrollSlidingBrick >> computeWidth [
 
 	^ self pagerModel
@@ -34,7 +34,7 @@ GLMPagerScrollSlidingBrick >> computeWidth [
 		ifNotNil: [ :m | m circleButtonSize * m actualNumberOfVisiblePages ]
 ]
 
-{ #category : #'slider-draging' }
+{ #category : #draging }
 GLMPagerScrollSlidingBrick >> dragResizingLeft: anEvent [
 	| left right |
 	
@@ -46,7 +46,7 @@ GLMPagerScrollSlidingBrick >> dragResizingLeft: anEvent [
 	
 ]
 
-{ #category : #'slider-draging' }
+{ #category : #draging }
 GLMPagerScrollSlidingBrick >> dragResizingRight: anEvent [
 	| left right |
 
@@ -58,7 +58,7 @@ GLMPagerScrollSlidingBrick >> dragResizingRight: anEvent [
 	
 ]
 
-{ #category : #'slider-draging' }
+{ #category : #draging }
 GLMPagerScrollSlidingBrick >> dragSliding: evt [
 	| newLeft value|
 	
@@ -98,7 +98,7 @@ GLMPagerScrollSlidingBrick >> initialize [
 		enable
 ]
 
-{ #category : #'slider-testing' }
+{ #category : #testing }
 GLMPagerScrollSlidingBrick >> isLeftResizingZone: evt [
 	
 	^ (self globalBounds withWidth: resizingZoneWidth) containsPoint: evt position
@@ -106,7 +106,7 @@ GLMPagerScrollSlidingBrick >> isLeftResizingZone: evt [
 	
 ]
 
-{ #category : #'slider-testing' }
+{ #category : #testing }
 GLMPagerScrollSlidingBrick >> isRightResizingZone: evt [
 	|resizingRectangle top left globalBounds|
 	globalBounds := self globalBounds.
@@ -121,13 +121,13 @@ GLMPagerScrollSlidingBrick >> isRightResizingZone: evt [
 	
 ]
 
-{ #category : #'slider-accessing' }
+{ #category : #accessing }
 GLMPagerScrollSlidingBrick >> leftPosition [
 
 	^ leftPosition ifNil: [ leftPosition := 0 ]
 ]
 
-{ #category : #'slider-accessing' }
+{ #category : #accessing }
 GLMPagerScrollSlidingBrick >> leftPosition: anInteger [
 
 	leftPosition := anInteger
@@ -183,7 +183,7 @@ GLMPagerScrollSlidingBrick >> mouseUp: evt [
 		ifTrue: [ self setCursorToResizing: evt ] 
 ]
 
-{ #category : #'slider-scrolling' }
+{ #category : #scrolling }
 GLMPagerScrollSlidingBrick >> moveLeft: left [ "Integer - pixels"
 	"moves scrollbar inside parent to the specified left distance in pixels and notifies all listeners about that"
 	"Highly optimised to not update layout during moving"
@@ -221,13 +221,13 @@ GLMPagerScrollSlidingBrick >> onResized [
 	self setWidthAfterResizing
 ]
 
-{ #category : #'slider-accessing' }
+{ #category : #accessing }
 GLMPagerScrollSlidingBrick >> pagerModel [
 
 	^ pagerModel
 ]
 
-{ #category : #'slider-accessing' }
+{ #category : #accessing }
 GLMPagerScrollSlidingBrick >> pagerModel: anAdapter [
 	
 	pagerModel := anAdapter.
@@ -239,44 +239,44 @@ GLMPagerScrollSlidingBrick >> pagerModel: anAdapter [
 	self width: self computeWidth
 ]
 
-{ #category : #'slider-cursor' }
+{ #category : #cursor }
 GLMPagerScrollSlidingBrick >> resizeCursor [
 
 	^ Cursor resizeForEdge: #left
 ]
 
-{ #category : #'slider-scrolling' }
+{ #category : #scrolling }
 GLMPagerScrollSlidingBrick >> scrollTo: aFloat [ "Float - percentage/100"
 	"scrolls to a specified float number which must be in interval [0.0, 1.0]"
 	self moveLeft: (owner width - self width) * aFloat.
 ]
 
-{ #category : #'slider-scrolling' }
+{ #category : #scrolling }
 GLMPagerScrollSlidingBrick >> scrollTo: aValue smooth: aBoolean [
 	"better to ignore smooth parameter,
 	because animation is not neccessary"
 	self scrollTo: aValue
 ]
 
-{ #category : #'slider-scrolling' }
+{ #category : #scrolling }
 GLMPagerScrollSlidingBrick >> scrollToPane: anIndex smooth: isSmooth [
 
 	self scrollTo: (pagerModel convertIndexToValue: anIndex) smooth: isSmooth.
 ]
 
-{ #category : #'slider-cursor' }
+{ #category : #cursor }
 GLMPagerScrollSlidingBrick >> setCursorToNormal: evt [
 		
 	evt hand showTemporaryCursor: nil
 ]
 
-{ #category : #'slider-cursor' }
+{ #category : #cursor }
 GLMPagerScrollSlidingBrick >> setCursorToResizing: evt [
 	
 	evt hand showTemporaryCursor: self resizeCursor
 ]
 
-{ #category : #'slider-draging' }
+{ #category : #draging }
 GLMPagerScrollSlidingBrick >> setPosition: aPoint [
 	"aPoint x - is my bounds left
 	aPoint y - is my bounds right"
@@ -291,7 +291,7 @@ GLMPagerScrollSlidingBrick >> setPosition: aPoint [
 	self pagerModel notifyScrollerBoundsChanged: aPoint
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 GLMPagerScrollSlidingBrick >> setWidthAfterResizing [
 	| left right |
 	
@@ -301,7 +301,7 @@ GLMPagerScrollSlidingBrick >> setWidthAfterResizing [
 	self setPosition: left@right
 ]
 
-{ #category : #'slider-scrolling' }
+{ #category : #scrolling }
 GLMPagerScrollSlidingBrick >> synchronizeScrollTo: aValue [
 
 	pagerModel synchronizeScrollTo: aValue.

--- a/src/Graphics-Display Objects/ColorForm.class.st
+++ b/src/Graphics-Display Objects/ColorForm.class.st
@@ -272,7 +272,7 @@ ColorForm >> flipBy: direction centerAt: aPoint [
 	^newForm 
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ColorForm >> hibernate [
 	"Make myself take up less space. See comment in Form>hibernate."
 
@@ -346,7 +346,7 @@ ColorForm >> pixelValueAt: aPoint [
 
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ColorForm >> readAttributesFrom: aBinaryStream [
 	super readAttributesFrom: aBinaryStream.
 	colors := ColorArray new: (2 raisedTo: depth).
@@ -408,7 +408,7 @@ ColorForm >> setExtent: extent depth: bitsPerPixel [
 
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ColorForm >> storeOn: aStream [
 	aStream nextPut: $(.
 	super storeOn: aStream.
@@ -436,7 +436,7 @@ ColorForm >> transparentColor: aColor [
 
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ColorForm >> unhibernate [
 	colors ifNotNil:[colors := colors asArray].
 	^super unhibernate.
@@ -455,7 +455,7 @@ ColorForm >> unusedColormapEntry [
 
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ColorForm >> writeAttributesOn: file [
 	| colorArray |
 	super writeAttributesOn: file.

--- a/src/Graphics-Display Objects/Form.class.st
+++ b/src/Graphics-Display Objects/Form.class.st
@@ -1379,7 +1379,7 @@ Form >> height [
 	^ height
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> hibernate [
 	"Replace my bitmap with a compactly encoded representation (a ByteArray).  It is vital that BitBlt and any other access to the bitmap (such as writing to a file) not be used when in this state.  Since BitBlt will fail if the bitmap size is wrong (not = bitsSize), we do not allow replacement by a byteArray of the same (or larger) size."
 
@@ -1922,7 +1922,7 @@ Form >> privateFloodFillValue: aColor [
 	^f2 pixelValueAt: 0@0.
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> readAttributesFrom: aBinaryStream [
 	| offsetX offsetY |
 	depth := aBinaryStream next.
@@ -1939,7 +1939,7 @@ Form >> readAttributesFrom: aBinaryStream [
 
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> readBitsFrom: aBinaryStream [
 	
 	bits := Bitmap newFromStream: aBinaryStream.
@@ -1948,7 +1948,7 @@ Form >> readBitsFrom: aBinaryStream [
 
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> readFrom: aBinaryStream [
 	"Reads the receiver from the given binary stream with the format:
 		depth, extent, offset, bits."
@@ -1956,7 +1956,7 @@ Form >> readFrom: aBinaryStream [
 	self readBitsFrom: aBinaryStream
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> readFromOldFormat: aBinaryStream [
 	"Read a Form in the original ST-80 format."
 
@@ -2091,7 +2091,7 @@ Form >> relativeTextAnchorPosition [
 	^nil		"so forms can be in TextAnchors"
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> replaceByResource: aForm [
 	"Replace the receiver by some resource that just got loaded"
 	(self extent = aForm extent and:[self depth = aForm depth]) ifTrue:[
@@ -2321,7 +2321,7 @@ Form >> smear: dir distance: dist [
 		skew := skew+skew]
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> store15To24HexBitsOn:aStream [
 
 	| buf lineWidth |
@@ -2359,17 +2359,17 @@ Form >> store15To24HexBitsOn:aStream [
 	].
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> store32To24HexBitsOn:aStream [
 	^self storeBits:20 to:0 on:aStream.
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> storeBits:startBit to:stopBit on:aStream [
 	bits storeBits:startBit to:stopBit on:aStream.
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> storeBitsOn:aStream base:anInteger [
 	bits do: [:word | 
 		anInteger = 10
@@ -2379,18 +2379,18 @@ Form >> storeBitsOn:aStream base:anInteger [
 
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> storeHexBitsOn:aStream [
 	^self storeBits:28 to:0 on:aStream.
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> storeOn: aStream [
 
 	self storeOn: aStream base: 10
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> storeOn: aStream base: anInteger [ 
 	"Store the receiver out as an expression that can be evaluated to recreate a Form with the same contents as the original."
 
@@ -2480,7 +2480,7 @@ Form >> trimBordersOfColor: aColor [
 
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> unhibernate [
 	"If my bitmap has been compressed into a ByteArray,
 	then expand it now, and return true."
@@ -2560,7 +2560,7 @@ Form >> wipeImage: otherImage at: topLeft delta: delta clippingBox: clipBox [
 			ifFalse: [nil]]
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> writeAttributesOn: file [
 	self unhibernate.
 	file nextPut: depth.
@@ -2575,12 +2575,12 @@ Form >> writeAttributesOn: file [
 	
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> writeBitsOn: file [
 	bits writeOn: file
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> writeOn: file [
 	"Write the receiver on the file in the format
 		depth, extent, offset, bits."
@@ -2588,7 +2588,7 @@ Form >> writeOn: file [
 	self writeBitsOn: file
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Form >> writeUncompressedOn: file [
 	"Write the receiver on the file in the format depth, extent, offset, bits.  Warning:  Caller must put header info on file!  Use writeUncompressedOnFileNamed: instead."
 	self unhibernate.

--- a/src/Graphics-Fonts/StrikeFontSet.class.st
+++ b/src/Graphics-Fonts/StrikeFontSet.class.st
@@ -57,7 +57,7 @@ StrikeFontSet class >> findMaximumLessThan: f in: array [
 
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 StrikeFontSet class >> installNewFontAtIndex: newIndex fromOld: oldIndex [
 
 	
@@ -87,7 +87,7 @@ StrikeFontSet class >> newFontArray: anArray [
 
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 StrikeFontSet class >> removeFontsForEncoding: leadingChar encodingName: encodingSymbol [
 
 	| insts |

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -23,12 +23,12 @@ Class {
 	#category : #'Kernel-Classes'
 }
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 Class class >> allSuperclassesFor: aClass cache: cache [ 	
 	^ cache at: aClass ifAbsentPut: [aClass allSuperclasses asArray]
 ]
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 Class class >> doesNotIncludeInstanceOrSuperclassesFor: aClass in: unprocessedClasses cache: cache [ 
 	| soleInstance |
 	soleInstance := aClass soleInstance.
@@ -43,7 +43,7 @@ Class class >> hasNoDependenciesFor: aClass in: unprocessedClasses cache: cache 
 			self hasNoDependenciesForMetaclass: aClass in: unprocessedClasses cache: cache]] 
 ]
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 Class class >> hasNoDependenciesForMetaclass: aClass in: unprocessedClasses cache: cache [ 
 	| soleInstance |
 	soleInstance := aClass soleInstance.
@@ -51,7 +51,7 @@ Class class >> hasNoDependenciesForMetaclass: aClass in: unprocessedClasses cach
 				self hasNoSuperclassesOf: soleInstance in: unprocessedClasses cache: cache]
 ]
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 Class class >> hasNoSuperclassesOf: aClass in: unprocessedClasses cache: cache [ 
 	^ (unprocessedClasses includesAnyOf: (self allSuperclassesFor: aClass cache: cache)) not
 	
@@ -64,7 +64,7 @@ Class class >> rootsOfTheWorld [
 	^(self environment select: [:each | each isBehavior and: [each superclass isNil]]) asOrderedCollection
 ]
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 Class class >> superclassOrder: classes [
     "Arrange the classes in the collection, classes, in superclass order so the 
     classes can be properly filed in. Do it in sets instead of ordered collections.

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -201,13 +201,13 @@ ClassDescription >> classClass [
 	^ self classSide
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ClassDescription >> classComment: aString [
 	"Store the comment, aString or Text or RemoteString, associated with the class we are orgainzing.  Empty string gets stored only if had a non-empty one before."
 	^ self classComment: aString stamp: '<historical>'
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ClassDescription >> classComment: aString stamp: aStamp [
 	"Store the comment, aString or Text or RemoteString, associated with the class we are organizing.  Empty string gets stored only if had a non-empty one before."
 
@@ -375,7 +375,7 @@ ClassDescription >> comment: aStringOrText stamp: aStamp [
 	self instanceSide classComment: aStringOrText stamp: aStamp.
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ClassDescription >> commentStamp: changeStamp [
 	self organization commentStamp: changeStamp
 ]
@@ -563,7 +563,7 @@ ClassDescription >> copyCategory: cat from: aClass classified: newCat [
 		classified: newCat
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ClassDescription >> definition [
 	"Answer a String that defines the receiver."
 
@@ -580,7 +580,7 @@ ClassDescription >> definitionForNautilus [
 	^ self definition
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ClassDescription >> definitionWithSlots [
 	"The class definition with a way to specify slots. Shown when the class defines special Slot"
 	
@@ -635,7 +635,7 @@ ClassDescription >> definitionWithSlots [
 	^ stream contents
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ClassDescription >> definitionWithoutSlots [
 
 	| poolString stream |
@@ -1005,7 +1005,7 @@ ClassDescription >> obsolete [
 	super obsolete.
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ClassDescription >> oldDefinition [
 	"Answer a String that defines the receiver."
 

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -118,7 +118,7 @@ Metaclass >> classVariables [
 	^self instanceSide classVariables
 ]
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 Metaclass >> definition [
 	"Refer to the comment in ClassDescription|definition."
 
@@ -128,7 +128,7 @@ Metaclass >> definition [
 	^ self definitionWithoutSlots
 ]
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 Metaclass >> definitionWithSlots [
 	"Refer to the comment in ClassDescription|definition."
 
@@ -140,7 +140,7 @@ Metaclass >> definitionWithSlots [
 			nextPutAll: self slotDefinitionString ]
 ]
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 Metaclass >> definitionWithoutSlots [
 
 	^ String streamContents: [:stream |
@@ -260,7 +260,7 @@ Metaclass >> obsoleteSubclasses [
 	^ self instanceSide obsoleteSubclasses collect: [ :aSubclass | aSubclass classSide ]
 ]
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 Metaclass >> oldDefinition [
 	"Refer to the comment in ClassDescription|definition.
 	 This method is for compatibility with Class>>#oldDefinition"

--- a/src/ReleaseTests/ProtocolConventionsTest.class.st
+++ b/src/ReleaseTests/ProtocolConventionsTest.class.st
@@ -31,6 +31,11 @@ Some classes are violating this convention:
 ]
 
 { #category : #tests }
+ProtocolConventionsTest >> testFileInOutProtocolIsUsed [
+	self assertProtocols: #(#'filein/out' #'fileIn/Out' #'fileIn/out' #'filein/Out') areNotUsedInsteadOf: #'file in/out'
+]
+
+{ #category : #tests }
 ProtocolConventionsTest >> testInstanceCreationProtocolIsUsed [
 	self assertProtocols: #(#'instance-creation') areNotUsedInsteadOf: #'instance creation'
 ]

--- a/src/ReleaseTests/ProtocolConventionsTest.class.st
+++ b/src/ReleaseTests/ProtocolConventionsTest.class.st
@@ -10,9 +10,10 @@ Class {
 }
 
 { #category : #asserting }
-ProtocolConventionsTest >> assertProtocol: aCollectionOfSelectors areNotUsedInsteadOf: aProtocolName [
+ProtocolConventionsTest >> assertProtocols: aCollectionOfSelectors areNotUsedInsteadOf: aProtocolName [
 	| violations |
-	violations := self class environment allClasses select: [ :c | c protocols includesAny: aCollectionOfSelectors ].
+	violations := self class environment allClassesAndTraits
+		select: [ :c | (c protocols includesAny: aCollectionOfSelectors) or: [ c class protocols includesAny: aCollectionOfSelectors ] ].
 	self
 		assert: violations isEmpty
 		description: [ 'In the default Pharo images, the protocol #{1} should be used instead of {2}.
@@ -30,6 +31,11 @@ Some classes are violating this convention:
 ]
 
 { #category : #tests }
+ProtocolConventionsTest >> testInstanceCreationProtocolIsUsed [
+	self assertProtocols: #(#'instance-creation') areNotUsedInsteadOf: #'instance creation'
+]
+
+{ #category : #tests }
 ProtocolConventionsTest >> testRemovalProtocolIsUsed [
-	self assertProtocol: #(#remove #removal) areNotUsedInsteadOf: #removing
+	self assertProtocols: #(#remove #removal) areNotUsedInsteadOf: #removing
 ]

--- a/src/Ring-Definitions-Core/RGBehaviorDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGBehaviorDefinition.class.st
@@ -215,7 +215,7 @@ RGBehaviorDefinition >> compiledMethodNamed: selector [
 	ifFalse:[ nil ]
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 RGBehaviorDefinition >> definition [
 
 	^ self definitionSource

--- a/src/SUnit-Core/TestResult.class.st
+++ b/src/SUnit-Core/TestResult.class.st
@@ -238,7 +238,7 @@ TestResult >> failures: aSet [
 	failures := aSet
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 TestResult >> fileOutOn: aFileStream [
 	"Write in aFileStream like:
 	3 run, 2 passes, 0 expected failures, 1 failures, 0 errors, 0 unexpected passes

--- a/src/SUnit-Tests/ResumableTestFailureTestCase.class.st
+++ b/src/SUnit-Tests/ResumableTestFailureTestCase.class.st
@@ -45,7 +45,7 @@ ResumableTestFailureTestCase >> regularTestFailureTest [
 	self assert: false description: 'You should see me'
 ]
 
-{ #category : #'Not categorized' }
+{ #category : #'test data' }
 ResumableTestFailureTestCase >> resumableTestFailureTest [
 	self
 		assert: false description: 'You should see more than me' resumable: true; 
@@ -69,7 +69,7 @@ ResumableTestFailureTestCase >> tearDown [
 	super tearDown 
 ]
 
-{ #category : #running }
+{ #category : #tests }
 ResumableTestFailureTestCase >> testResumable [
 	| result suite |
 	suite := self classForTestSuite new.

--- a/src/SUnit-Tests/SimpleTestResourceTestCase.class.st
+++ b/src/SUnit-Tests/SimpleTestResourceTestCase.class.st
@@ -77,14 +77,14 @@ SimpleTestResourceTestCase >> setUp [
 		description: 'This test uses a resource but it was not set up'
 ]
 
-{ #category : #running }
+{ #category : #tests }
 SimpleTestResourceTestCase >> testDebugTestWithResource [
 	"The debug will raise an error if the resource is not set up properly."
 	
 	self clearOuterResourceStateDuring: [(self class selector: #setRun) debug]
 ]
 
-{ #category : #running }
+{ #category : #tests }
 SimpleTestResourceTestCase >> testResourceCollection [
 	self assert: self class buildSuiteFromSelectors resources size = self resources size
 		description: 'The suite should have the same number of resources as its test'.
@@ -94,7 +94,7 @@ SimpleTestResourceTestCase >> testResourceCollection [
 			description: each name , ':  I have this resource but my suite does not'].
 ]
 
-{ #category : #'not categorized' }
+{ #category : #tests }
 SimpleTestResourceTestCase >> testResourceInitRelease [
 	| suite error failure |
 	suite := self classForTestSuite new.
@@ -105,7 +105,7 @@ SimpleTestResourceTestCase >> testResourceInitRelease [
 	self assert: resource hasSetup
 ]
 
-{ #category : #running }
+{ #category : #tests }
 SimpleTestResourceTestCase >> testRunSuiteWithResource [
 	| suite |
 	suite :=  self classForTestSuite new.
@@ -118,7 +118,7 @@ SimpleTestResourceTestCase >> testRunSuiteWithResource [
 			description: 'A suite of tests needing SimpleTestResource did not run as expected'].
 ]
 
-{ #category : #running }
+{ #category : #tests }
 SimpleTestResourceTestCase >> testRunTestWithResource [
 	self clearOuterResourceStateDuring:
 		[self

--- a/src/System-Changes/ChangeSet.class.st
+++ b/src/System-Changes/ChangeSet.class.st
@@ -90,7 +90,7 @@ ChangeSet class >> changeSetsNamedSuchThat: nameBlock [
 	^ AllChangeSets select: [:aChangeSet | nameBlock value: aChangeSet name]
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet class >> classesOrder: classes [
 	"Answer a collection with the classes ordered so they can be filed in."
 
@@ -186,7 +186,7 @@ ChangeSet class >> doesAnyChangeSetHaveClass: aClass andSelector: aSelector [
 	^ (self countOfChangeSetsWithClass: aClass andSelector: aSelector) > 0
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet class >> fileOutChangeSetsNamed: nameList [
 	"File out the list of change sets whose names are provided"
      "ChangesOrganizer fileOutChangeSetsNamed: #('New Changes' 'miscTidies-sw')"
@@ -235,7 +235,7 @@ ChangeSet class >> gatherChangeSets [		"ChangeSet gatherChangeSets"
 	^ AllChangeSets
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet class >> hasNoDependenciesFor: aTrait in: traits [
 	"Answer if the trait does not depend on a trait in the collection."
 
@@ -460,7 +460,7 @@ ChangeSet class >> scanFile: file category: cat class: class meta: meta stamp: s
 	^items
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet class >> traitsOrder: aCollection [ 
 	"Arrange the traits in the collection, first who don't depend on others."
 
@@ -547,7 +547,7 @@ ChangeSet >> assimilateAllChangesFoundIn: otherChangeSet [
 
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> assurePostscriptExists [
 	"Make sure there is a StringHolder holding the postscript.  "
 
@@ -562,7 +562,7 @@ Be sure to put any further comments in double-quotes, like this one."
 ' ]
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> assurePreambleExists [
 	"Make sure there is a StringHolder holding the preamble; if it's found to have reverted to empty contents, put up the template"
 
@@ -677,7 +677,7 @@ ChangeSet >> changedMessageList [
 	^ messageList asArray sort
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> checkForSlips [
 	"Return a collection of method refs with possible debugging code in them."
 	| slips |
@@ -765,7 +765,7 @@ ChangeSet >> containsClass: aClass [
 	^ self changedClasses includes: aClass
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> defaultChangeSetDirectory [
 	^self class defaultChangeSetDirectory
 ]
@@ -873,7 +873,7 @@ ChangeSet >> fatDefForClass: class [
 	^ outStrm contents
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> fileOut [
 	"File out the receiver, to a file whose name is a function of the  
 	change-set name and a unique numeric tag."
@@ -884,7 +884,7 @@ ChangeSet >> fileOut [
 	self fileOutBody: fileReference.
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> fileOutBody: fileReference [
 
 	UIManager default
@@ -904,7 +904,7 @@ ChangeSet >> fileOutBody: fileReference [
 				toFileReference: fileReference ]
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> fileOutChangesFor: class on: stream [
 	"Write out all the method changes for this class."
 
@@ -954,7 +954,7 @@ ChangeSet >> fileOutClassDefinition: class on: stream [
 	stream cr
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> fileOutOn: stream [ 
 	"Write out all the changes the receiver knows about"
 
@@ -984,7 +984,7 @@ ChangeSet >> fileOutOn: stream [
 		[:aClassName | stream nextChunkPut: 'Smalltalk removeClassNamed: #', aClassName; cr].
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> fileOutPSFor: class on: stream [
 	"Write out removals and initialization for this class."
 
@@ -1017,7 +1017,7 @@ ChangeSet >> fileOutPSFor: class on: stream [
 	stream cr
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> fileOutPostscriptOn: stream [
 	"If the receiver has a postscript, put it out onto the stream.  "
 
@@ -1031,7 +1031,7 @@ ChangeSet >> fileOutPostscriptOn: stream [
 		cr
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> fileOutPreambleOn: stream [
 	"If the receiver has a preamble, put it out onto the stream.  "
 
@@ -1082,7 +1082,7 @@ ChangeSet >> hasPreamble [
 	^ preamble notNil
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> hasReportableSlip: aMethod [
 	"Answer whether the receiver contains anything that should be brought 
 	to the attention of the author when filing out. Customize the lists here 
@@ -1273,13 +1273,13 @@ ChangeSet >> oldNameFor: class [
 	^ (changeRecords at: class name) priorName
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> postscript [
 	"Answer the string representing the postscript.  "
 	^postscript ifNotNil:[postscript isString ifTrue:[postscript] ifFalse:[postscript contents asString]]
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> postscript: aString [
 	"Answer the string representing the postscript.  "
 	postscript := aString
@@ -1290,45 +1290,45 @@ ChangeSet >> postscriptHasDependents [
 	^false
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> postscriptString [
 	"Answer the string representing the postscript.  "
 	^self postscript
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> postscriptString: aString [
 	"Establish aString as the new contents of the postscript.  "
 	self postscript: aString
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> preamble [
 	"Answer the string representing the preamble"
 	^preamble ifNotNil:[preamble isString ifTrue:[preamble] ifFalse:[preamble contents asString]]
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> preamble: aString [
 	"Establish aString as the new contents of the preamble.  "
 
 	preamble := aString
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> preambleString [
 	"Answer the string representing the preamble"
 
 	^self preamble
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> preambleString: aString [
 	"Establish aString as the new contents of the preamble.  "
 	self preamble: aString.
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 ChangeSet >> preambleTemplate [
 	"Answer a string that will form the default contents for a change set's preamble.
 	Just a first stab at what the content should be."

--- a/src/System-Sources/SourceFile.class.st
+++ b/src/System-Sources/SourceFile.class.st
@@ -123,13 +123,13 @@ SourceFile >> next: anInteger putAll: aString startingAt: startIndex [
 
 ]
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 SourceFile >> nextChunk [
 
 	^ (ChunkReadStream on: stream) next
 ]
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 SourceFile >> nextChunkPut: aChunk [
 
 	^ (ChunkWriteStream on: stream) nextPut: aChunk

--- a/src/Tool-DependencyAnalyser/DADependenciesHTMLPublisher.class.st
+++ b/src/Tool-DependencyAnalyser/DADependenciesHTMLPublisher.class.st
@@ -150,21 +150,6 @@ DADependenciesHTMLPublisher >> publish [
 ]
 
 { #category : #publishing }
-DADependenciesHTMLPublisher >> publish: aPackageName dependants: dependants [
-	| dependantLinks |
-	
-	dependants ifEmpty: [ ^ self ].
-	
-	dependantLinks := dependants sorted collect: [ :name | '<a href="#', name , '">' , name , '</a>' ].	
-	stream << 
-'						<tr>
-							<td id="' << aPackageName << '">' << (self htmlForPackage: aPackageName) << '</td>
-							<td> ' << (self badgeFor: 'N/A') << ' </td>
-							<td>' << (self sizeBadgeFor: dependants) << Character space << (Character space join: dependantLinks) << '</td>
-						</tr>'; lf.
-]
-
-{ #category : #publishing }
 DADependenciesHTMLPublisher >> publish: aPackageName dependencies: dependencies dependants: dependants [
 	| dependantLinks |
 	dependantLinks := dependants sorted collect: [ :name | '<a href="#', name , '">' , name , '</a>' ].

--- a/src/TraitsV2/MetaclassForTraits.class.st
+++ b/src/TraitsV2/MetaclassForTraits.class.st
@@ -41,7 +41,7 @@ MetaclassForTraits >> asTraitComposition [
 	^ TaClassCompositionElement for: self
 ]
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 MetaclassForTraits >> definition [
 	^ String streamContents: [ :s | 
 		s nextPutAll: self instanceSide name;

--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -193,7 +193,7 @@ Trait >> classTrait [
 	^ self class
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Trait >> definition [
 	
 	(self instanceSide name == #Trait) ifTrue: [ ^ super definition ].
@@ -254,7 +254,7 @@ Trait >> notifyOfRecategorizedSelector: selector from: oldCategory to: newCatego
 	self traitUsers do: [ :e | e recategorizeSelector: selector from: oldCategory to: newCategory ].
 ]
 
-{ #category : #'filein/out' }
+{ #category : #'file in/out' }
 Trait >> oldDefinition [
 
 	^ self definition

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -203,10 +203,10 @@ TraitedClass >> isLocalAliasSelector: aSymbol [
 
 { #category : #testing }
 TraitedClass >> isLocalMethodsProtocol: aProtocol [
-
 	"Checks if the protocol has local selectors"
-	aProtocol methods ifEmpty: [ ^true ].
-	^aProtocol methods anySatisfy: [ :each | self isLocalSelector: each]
+
+	aProtocol methodSelectors ifEmpty: [ ^ true ].
+	^ aProtocol methodSelectors anySatisfy: [ :each | self isLocalSelector: each ]
 ]
 
 { #category : #testing }

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -70,7 +70,7 @@ TraitedMetaclass >> baseLocalMethods: anObject [
 	baseLocalMethods := anObject
 ]
 
-{ #category : #'fileIn/Out' }
+{ #category : #'file in/out' }
 TraitedMetaclass >> definition [
 	"Refer to the comment in ClassDescription|definition."
 

--- a/src/UnifiedFFI/FFIVariableArgument.class.st
+++ b/src/UnifiedFFI/FFIVariableArgument.class.st
@@ -15,7 +15,7 @@ Class {
 	#category : #'UnifiedFFI-Arguments'
 }
 
-{ #category : #'instance-creation' }
+{ #category : #'instance creation' }
 FFIVariableArgument class >> name: aString typeName: aTypeName arity: anInteger [
 	
 	^ self new

--- a/src/UnifiedFFI/LibC.class.st
+++ b/src/UnifiedFFI/LibC.class.st
@@ -75,8 +75,7 @@ LibC >> macLibraryName [
 
 { #category : #'api - misc' }
 LibC >> memCopy: src to: dest size: n [
-	^ self
-		ffiCall: #(#void #* #memcpy #(#void #* #dest #, #const #void #* #src #, #size_t #n))
+	^ self ffiCall: #(#void #* #memcpy #(#void #* #dest #, #const #void #* #src #, #size_t #n))
 ]
 
 { #category : #'api - processes' }


### PR DESCRIPTION
Some cleanings in protocols

- rename 'instance-creation' into 'instance creation'
- add non regression test on the previous cleaning
- remove useless prefixes on some protocols to reduce the number of protocols used in the image
- Improve ProtocolConventionsTest>>#assertProtocols:areNotUsedInsteadOf: to take traits and class sides into account
- rename 'instance initalization' into 'instance initialization'
- remove some dead code
- Unify 'filein/out' protocols to have the same form + add non regression test.
- Categorize methods in 'not categorized' protocol
- Improve classification of some methods