### PR TITLE
Backport - Fix nextVersion for cases where an entry with basename only exists in…

### DIFF
--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -366,7 +366,8 @@ FileReference >> nextVersion [
 	parent := self parent.
 	nameWithoutExtension := self basename copyUpTo: $..
 	
-	versionNumbers := parent children 
+	"Check for filenames with the assumption it consists at least of basename and a single dot"
+	versionNumbers := (parent childrenMatching: nameWithoutExtension, '.*') 
 				select: [ :f| 
 					(f basename beginsWith: nameWithoutExtension) ]
 				thenCollect: [ :f| 


### PR DESCRIPTION
… the directory. In that case the calculation of the offset raises a primitive failure. #nextVersion has been rewritten in pharo8 so this is only for pharo7 backport