### PR TITLE
5126-Deprecate-nbCall-and-related

### DIFF
--- a/src/UnifiedFFI-Legacy/Object.extension.st
+++ b/src/UnifiedFFI-Legacy/Object.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #Object }
 Object >> nbCall: fnSpec [
 	"You can override this method if you need to"
 	<ffiCalloutTranslator>
-	
+	self deprecated: 'use ffiCall: instead'.
 	^ (self ffiCalloutIn: thisContext sender)
 		convention: self ffiCallingConvention;
 		function: fnSpec library: self ffiLibraryName
@@ -14,7 +14,7 @@ Object >> nbCall: fnSpec [
 Object >> nbCall: fnSpec module: aModuleNameOrHandle [
 	"You can override this method if you need to"
 	<ffiCalloutTranslator>
-	
+	self deprecated: 'use ffiCall:module: instead'.
 	^ (self ffiCalloutIn: thisContext sender)
 		convention: self ffiCallingConvention;
 		function: fnSpec library: aModuleNameOrHandle
@@ -24,7 +24,7 @@ Object >> nbCall: fnSpec module: aModuleNameOrHandle [
 Object >> nbCall: fnSpec module: aModuleNameOrHandle options: callOptions [
 	"You can override this method if you need to"
 	<ffiCalloutTranslator>
-	
+	self deprecated: 'use ffiCall:module:options: instead'.
 	^ (self ffiCalloutIn: thisContext sender)
 		convention: self ffiCallingConvention;
 		options: callOptions;
@@ -35,7 +35,7 @@ Object >> nbCall: fnSpec module: aModuleNameOrHandle options: callOptions [
 Object >> nbCall: fnSpec options: callOptions [
 	"You can override this method if you need to"
 	<ffiCalloutTranslator>
-
+	self deprecated: 'use ffiCall:options: instead'.
 	^ (self ffiCalloutIn: thisContext sender)
 		convention: self ffiCallingConvention;
 		options: callOptions;


### PR DESCRIPTION
deprecated the nbCall:* methods.

fixes #5126