### PR TITLE
Rules-are-failing-on-bytearrays

### DIFF
--- a/src/GeneralRules/RBGlobalVariablesUsage.class.st
+++ b/src/GeneralRules/RBGlobalVariablesUsage.class.st
@@ -18,7 +18,7 @@ RBGlobalVariablesUsage class >> checksMethod [
 RBGlobalVariablesUsage >> basicCheck: aMethod [
 	^ (aMethod literals
 		select: [ :l | l isLiteral not and: [ l isGlobalVariable ] ])
-		noneSatisfy: [ :v | v value isClass or: [ v value isTrait ] ]
+		noneSatisfy: [ :v | v value isClassOrTrait ]
 ]
 
 { #category : #running }

--- a/src/GeneralRules/RBGlobalVariablesUsage.class.st
+++ b/src/GeneralRules/RBGlobalVariablesUsage.class.st
@@ -17,14 +17,8 @@ RBGlobalVariablesUsage class >> checksMethod [
 { #category : #running }
 RBGlobalVariablesUsage >> basicCheck: aMethod [
 	^ (aMethod literals
-		select: [ :l | 
-			l isSymbol not 
-				and: [ l isString not
-				and: [ l isNumber not
-				and: [ l isArray not
-				and: [ l isCharacter not
-				and: [ l isGlobalVariable ] ] ] ] ] ])
-		anySatisfy: [ :v | v value isClass not ]
+		select: [ :l | l isLiteral not and: [ l isGlobalVariable ] ])
+		noneSatisfy: [ :v | v value isClass or: [ v value isTrait ] ]
 ]
 
 { #category : #running }


### PR DESCRIPTION
Fix two problems with Global Variable Usage rule.

- The rule crashed on ByteArray
- The rule considered Traits as globals