### PR TITLE
Compiler: Use API for HighLight and Completion

### DIFF
--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -123,13 +123,11 @@ CompletionContext >> node [
 
 { #category : #parsing }
 CompletionContext >> parseSource [
-	ast := isWorkspace 
-		ifFalse: [ RBParser parseFaultyMethod: source ] 
-		ifTrue: [ RBParser parseFaultyExpression: source ].
-	
-	ast methodNode compilationContext: (Smalltalk compiler compilationContext
-				parseOptions: #(+ optionParseErrors + optionSkipSemanticWarnings);
-				requestor: isWorkspace).
+	ast := Smalltalk compiler
+		source: source;
+		noPattern: isWorkspace;
+		options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
+		parse.
 	ast doSemanticAnalysisIn: class.
 	TypingVisitor new visitNode: ast
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -673,10 +673,11 @@ OpalCompiler >> parse: textOrStream in: aClass notifying: req [
 
 { #category : #private }
 OpalCompiler >> parseExpression [
-
-	^ast := self compilationContext optionParseErrors 
+	ast := self compilationContext optionParseErrors 
 		ifTrue: [self parserClass parseFaultyExpression: source contents]
-		ifFalse: [self parserClass parseExpression: source contents]
+		ifFalse: [self parserClass parseExpression: source contents].
+	ast methodNode compilationContext: self compilationContext.
+	^ast.
 ]
 
 { #category : #'public access' }

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -971,13 +971,12 @@ SHRBTextStyler >> pixelHeight [
 { #category : #private }
 SHRBTextStyler >> privateStyle: aText [
 	| ast |
-	ast := self isForWorkspace 
-		ifFalse: [ RBParser parseFaultyMethod: aText ] 
-		ifTrue: [ RBParser parseFaultyExpression: aText ].
-	
-	ast methodNode compilationContext: (Smalltalk compiler compilationContext
-				parseOptions: #(+ optionParseErrors + optionSkipSemanticWarnings);
-				requestor: workspace).
+	ast := Smalltalk compiler
+		source: aText;
+		noPattern: self isForWorkspace ;
+		options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
+		requestor: workspace;
+		parse.				
 	ast doSemanticAnalysisIn: classOrMetaClass.
 	^ self style: aText ast: ast
 ]


### PR DESCRIPTION
Both code completion and syntax highlighting where doing the parsing manually instead of just using the Compiler API.

This PR changes the code to use the Compiler API instead, making it much easier to understand. It fixes in addition to store the compilation context for parsed expressions  so it does not get lost.