### PR TITLE
Completion: #completionEntries creates entries

### DIFF
--- a/src/NECompletion-Tests/CompletionContextTest.class.st
+++ b/src/NECompletion-Tests/CompletionContextTest.class.st
@@ -12,7 +12,7 @@ CompletionContextTest class >> shouldInheritSelectors [
 { #category : #private }
 CompletionContextTest >> createContextFor: aString at: anInteger [ 
 	^ CompletionContext
-		controller: CompletionEngine new
+		engine: CompletionEngine new
 		class: NECTestClass
 		source: aString
 		position: anInteger

--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -12,8 +12,7 @@ Class {
 		'node',
 		'isWorkspace',
 		'class',
-		'entries',
-		'sorter'
+		'entries'
 	],
 	#classVars : [
 		'SorterClass'
@@ -93,10 +92,10 @@ CompletionContext >> hasMessage [
 
 { #category : #entries }
 CompletionContext >> initEntries [
-	| suggestionsList |
+	| suggestionsList sorter |
 	sorter := self class sorterClass new context: self.
 	suggestionsList := sorter sortCompletionList: node completionEntries.
-	^ suggestionsList collect: [ :each | NECEntry contents: each node: node ]
+	^ suggestionsList
 ]
 
 { #category : #accessing }

--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -21,9 +21,9 @@ Class {
 }
 
 { #category : #'instance creation' }
-CompletionContext class >> controller: aNECController class: aClass source: aString position: anInteger [ 
+CompletionContext class >> engine: aCompletionEngine class: aClass source: aString position: anInteger [ 
 	^ self new
-		setController: aNECController
+		engine: aCompletionEngine
 		class: aClass
 		source: aString
 		position: anInteger
@@ -68,6 +68,20 @@ CompletionContext >> completionAt: aNumber [
 { #category : #accessing }
 CompletionContext >> completionToken [
 	^ completionToken ifNil: [ ^ ''  ]
+]
+
+{ #category : #'initialize-release' }
+CompletionContext >> engine: aCompletionEngine class: aClass source: aString position: anInteger [ 
+	class := aClass. 
+	source := aString.
+	position := anInteger.
+	
+	isWorkspace:= aCompletionEngine 
+		ifNotNil: [ aCompletionEngine isScripting ]
+		ifNil: [ false ].
+	self parseSource.
+	node := ast nodeForOffset: position.
+	completionToken := node completionToken
 ]
 
 { #category : #accessing }
@@ -137,20 +151,6 @@ CompletionContext >> parseSource [
 CompletionContext >> position [
 	"not used outside of the instance creation method, but we make it available so sorter plugins could use it"
 	^ position
-]
-
-{ #category : #'initialize-release' }
-CompletionContext >> setController: aECController class: aClass source: aString position: anInteger [ 
-	class := aClass. 
-	source := aString.
-	position := anInteger.
-	
-	isWorkspace:= aECController 
-		ifNotNil: [ aECController isScripting ]
-		ifNil: [ false ].
-	self parseSource.
-	node := ast nodeForOffset: position.
-	completionToken := node completionToken
 ]
 
 { #category : #accessing }

--- a/src/NECompletion/CompletionEngine.class.st
+++ b/src/NECompletion/CompletionEngine.class.st
@@ -252,7 +252,7 @@ CompletionEngine >> openMenuFor: aParagraphEditor [
 	self stopCompletionDelay.
 	
 	context := self contextClass
-				controller: self
+				engine: self
 				class: model selectedClassOrMetaClass 
 				source: aParagraphEditor text string
 				position: aParagraphEditor caret - 1.

--- a/src/NECompletion/RBLiteralValueNode.extension.st
+++ b/src/NECompletion/RBLiteralValueNode.extension.st
@@ -4,7 +4,9 @@ Extension { #name : #RBLiteralValueNode }
 RBLiteralValueNode >> completionEntries [
 	value isSymbol ifFalse: [ ^ #() ].
 	"return all symbols that start with value"
-	^Symbol allSymbols select: [ :each | (each beginsWith: value) and: [each isLiteralSymbol]]
+	^Symbol allSymbols 
+		select: [ :each | (each beginsWith: value) and: [each isLiteralSymbol]] 
+		thenCollect: [ :each | NECEntry contents: each node: self ]
 ]
 
 { #category : #'*NECompletion' }

--- a/src/NECompletion/RBProgramNode.extension.st
+++ b/src/NECompletion/RBProgramNode.extension.st
@@ -13,5 +13,7 @@ RBProgramNode >> completionToken [
 { #category : #'*NECompletion' }
 RBProgramNode >> select: aCollection beginningWith: aString [
 	"note: to be inlined into the senders"
-	^ aCollection select: [ :each | each beginsWith: aString asString ]
+	^ aCollection 
+		select: [ :each | each beginsWith: aString asString ]
+		thenCollect: [ :each | NECEntry contents: each node: self ]
 ]

--- a/src/NECompletion/RBVariableNode.extension.st
+++ b/src/NECompletion/RBVariableNode.extension.st
@@ -5,8 +5,8 @@ RBVariableNode >> completionEntries [
 	| methodNode lookupClass |
 	methodNode := self methodNode.
 	lookupClass := methodNode compilationContext getClass.
-	self isDefinition ifTrue: [ ^ (self select: Symbol allSymbols beginningWith: self name) select: [ :each | each numArgs = 0 ] ].
-   self isArgument ifTrue: [ ^ (self select: Symbol allSymbols beginningWith: self name) select: [ :each | each numArgs = 0 ] ].
+	self isDefinition ifTrue: [ ^ (self select: Symbol allSymbols beginningWith: self name) select: [ :each | each contents numArgs = 0 ] ].
+   self isArgument ifTrue: [ ^ (self select: Symbol allSymbols beginningWith: self name) select: [ :each | each contents numArgs = 0 ] ].
 	"using a stream to store results should be better"
 	^	(self select: Smalltalk globals keys beginningWith: self name), 
 	 	(self select: (lookupClass allSlots collect: [ :each | each name ]) beginningWith: self name),


### PR DESCRIPTION
CompletionEntry: we do the wrapping too late. when we instantiate it we just have symbols, so we do not know what they
where originally (variable, selectors...)

Thus: create entries in the #completionEntries method 

TODO after this: we need to create one kind of  entries for selectors, other subclass for selectors