### PR TITLE
Make-TestRunner-the-default-again

### DIFF
--- a/src/BaselineOfDrTests/BaselineOfDrTests.class.st
+++ b/src/BaselineOfDrTests/BaselineOfDrTests.class.st
@@ -9,32 +9,15 @@ BaselineOfDrTests >> baseline: spec [
 	<baseline>
 	spec
 		for: #common
-		do: [ 
-			spec postLoadDoIt: #'postload:package:'.
-			
-			spec
+		do: [ spec
 				package: 'DrTests';
-				package: 'DrTests-TestsRunner'
-					with: [ spec requires: #('DrTests') ];
-				package: 'DrTests-TestCoverage'
-					with: [ spec requires: #('DrTests') ];
-				package: 'DrTests-TestsProfiling'
-					with: [ spec requires: #('DrTests') ];
-				package: 'DrTests-Tests'
-					with: [ spec requires: #('DrTests' 'DrTests-TestsRunner' 'DrTests-TestCoverage-MocksForTests') ];
-				package: 'DrTests-TestCoverage-Tests'
-					with: [ spec requires: #('DrTests-TestCoverage' 'DrTests-TestCoverage-MocksForTests') ];
-				package: 'DrTests-TestsProfiling-Tests'
-					with: [ spec requires: #('DrTests-TestsProfiling') ];
-				package: 'DrTests-TestCoverage-MocksForTests'
-					with: [ spec requires: #('DrTests-TestCoverage') ];
-				package: 'DrTests-CommentsToTests'
-					with: [ spec requires: #('DrTests' 'DrTests-TestsRunner') ];
-				package: 'DrTests-CommentsToTests-Tests'
-					with: [ spec requires: #('DrTests-CommentsToTests') ] ]
-]
-
-{ #category : #actions }
-BaselineOfDrTests >> postload: loader package: packageSpec [
-	DrTests beDefaultTestRunner
+				package: 'DrTests-TestsRunner' with: [ spec requires: #('DrTests') ];
+				package: 'DrTests-TestCoverage' with: [ spec requires: #('DrTests') ];
+				package: 'DrTests-TestsProfiling' with: [ spec requires: #('DrTests') ];
+				package: 'DrTests-Tests' with: [ spec requires: #('DrTests' 'DrTests-TestsRunner' 'DrTests-TestCoverage-MocksForTests') ];
+				package: 'DrTests-TestCoverage-Tests' with: [ spec requires: #('DrTests-TestCoverage' 'DrTests-TestCoverage-MocksForTests') ];
+				package: 'DrTests-TestsProfiling-Tests' with: [ spec requires: #('DrTests-TestsProfiling') ];
+				package: 'DrTests-TestCoverage-MocksForTests' with: [ spec requires: #('DrTests-TestCoverage') ];
+				package: 'DrTests-CommentsToTests' with: [ spec requires: #('DrTests' 'DrTests-TestsRunner') ];
+				package: 'DrTests-CommentsToTests-Tests' with: [ spec requires: #('DrTests-CommentsToTests') ] ]
 ]

--- a/src/DrTests/DrTests.class.st
+++ b/src/DrTests/DrTests.class.st
@@ -122,7 +122,7 @@ DrTests class >> defaultSpec [
 { #category : #'world menu' }
 DrTests class >> menuCommandOn: aBuilder [
 	<worldMenu>
-	(aBuilder item: #'Dr Test')
+	(aBuilder item: #'Dr Test (preview)')
 		parent: #Tools;
 		action: [ self open ];
 		order: 20;


### PR DESCRIPTION
Make TestRunner default test tool.

DrTest is not yet mature to replace the TestRunner. For the next version of Pharo, TestRunner should still be the default and DrTest present as a preview. 

This PR restaure the TestRunner as default runner and still let a DrTest in the tool menu but tagged as preview.