### PR TITLE
5117-Division-by-zero-for-Float-should-be-infinity

### DIFF
--- a/src/Kernel-Tests/FloatTest.class.st
+++ b/src/Kernel-Tests/FloatTest.class.st
@@ -111,10 +111,10 @@ FloatTest >> testDivide [
 	self assert: 1.5 / 2.0 equals: 0.75.	
 	self assert: 2.0 / 1 equals: 2.0.
 	
-	self should: [ 2.0 / 0 ] raise: ZeroDivide.
-	self should: [ 2.0 / 0.0 ] raise: ZeroDivide.
-	self should: [ 1.2 / Float negativeZero ] raise: ZeroDivide.
-	self should: [ 1.2 / (1.3 - 1.3) ] raise: ZeroDivide
+	self assert:  2.0 / 0  equals: Float infinity.
+	self assert:  2.0 / 0.0  equals: Float infinity.
+	self assert:  1.2 / Float negativeZero  equals: Float infinity.
+	self assert:  1.2 / (1.3 - 1.3)  equals: Float infinity
 	
 ]
 
@@ -425,7 +425,7 @@ FloatTest >> testReciprocal [
 		assert: -1.0 reciprocal equals: -1.0;
 		assert: -2.0 reciprocal equals: -0.5.
 		
-	self should: [ 0.0 reciprocal ] raise: ZeroDivide
+	self assert:  0.0 reciprocal  equals: Float infinity
 ]
 
 { #category : #'tests - conversion' }
@@ -558,8 +558,8 @@ FloatTest >> testZero1 [
 FloatTest >> testZeroRaisedToNegativePower [
 	"this is a test related to http://bugs.squeak.org/view.php?id=6781"
 	
-	self should: [0.0 raisedTo: -1] raise: ZeroDivide.
-	self should: [0.0 raisedTo: -1.0] raise: ZeroDivide
+	self assert: (0.0 raisedTo: -1) equals: Float infinity.
+	self assert: (0.0 raisedTo: -1.0) equals: Float infinity
 ]
 
 { #category : #'tests - zero behavior' }

--- a/src/Kernel/BoxedFloat64.class.st
+++ b/src/Kernel/BoxedFloat64.class.st
@@ -66,10 +66,11 @@ BoxedFloat64 >> - aNumber [
 BoxedFloat64 >> / aNumber [ 
 	"Primitive. Answer the result of dividing receiver by aNumber.
 	Fail if the argument is not a Float. Essential. See Object documentation
-	whatIsAPrimitive."
+	whatIsAPrimitive.
+	Notice: According to IEEE754 division by zero is infinity, not an error"
 
 	<primitive: 50>
-	aNumber = 0.0 ifTrue: [ ^ ZeroDivide signalWithDividend: self].
+	aNumber = 0.0 ifTrue: [ ^ Float infinity].
 	^aNumber adaptToFloat: self andSend: #/
 ]
 

--- a/src/Kernel/Number.class.st
+++ b/src/Kernel/Number.class.st
@@ -628,7 +628,7 @@ Number >> raisedTo: aNumber [
 	1 = aNumber ifTrue: [^ self].	"Special case of exponent=1"
 	0 = self ifTrue: [				"Special case of self = 0"
 		aNumber < 0
-			ifTrue: [^ (ZeroDivide dividend: 1) signal]
+			ifTrue: [^ Float infinity]
 			ifFalse: [^ self]].
 	^ (aNumber * self ln) exp		"Otherwise use logarithms"
 ]

--- a/src/Kernel/SmallFloat64.class.st
+++ b/src/Kernel/SmallFloat64.class.st
@@ -52,10 +52,11 @@ SmallFloat64 >> - aNumber [
 SmallFloat64 >> / aNumber [ 
 	"Primitive. Answer the result of dividing receiver by aNumber.
 	Fail if the argument is not a Float. Essential. See Object documentation
-	whatIsAPrimitive."
+	whatIsAPrimitive.
+	Notice: According to IEEE754 division by zero is infinity, not an error"
 
 	<primitive: 550>
-	aNumber = 0.0 ifTrue: [ ^ ZeroDivide signalWithDividend: self].
+	aNumber = 0.0 ifTrue: [ ^ Float infinity].
 	^aNumber adaptToFloat: self andSend: #/
 ]
 


### PR DESCRIPTION
Fixes #5117. Allow division by zero for float as per IEEE754