### PR TITLE
5140-Browse-senders-crash-on-characters

### DIFF
--- a/src/Calypso-SystemTools-QueryBrowser/ClyBrowserMorph.extension.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyBrowserMorph.extension.st
@@ -24,10 +24,10 @@ ClyBrowserMorph >> browseReferencesTo: aSymbol [
 ClyBrowserMorph >> browseReferencesTo: aSymbol from: anEnvironment [
 	
 	| classBinding |
-	aSymbol first isUppercase ifTrue: [ 
+	aSymbol isSymbol and: [ aSymbol first isUppercase ifTrue: [ 
 		classBinding := anEnvironment bindingOf: aSymbol.
 		classBinding ifNotNil: [ 
-			^self spawnQueryBrowserOn: (ClyClassReferencesQuery of: classBinding)]].
+			^self spawnQueryBrowserOn: (ClyClassReferencesQuery of: classBinding)]]].
 		
 	self browseSendersOf: aSymbol
 ]

--- a/src/Calypso-SystemTools-QueryBrowser/ClyTextEditor.extension.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyTextEditor.extension.st
@@ -75,7 +75,7 @@ ClyTextEditor >> referencesToIt [
 
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
 ClyTextEditor >> sendersOf: selectedSelector [
-	selectedSelector isCharacter ifTrue: [ ^ self ].
+
 	self browser browseReferencesTo: selectedSelector
 ]
 

--- a/src/Calypso-SystemTools-QueryBrowser/ClyTextEditor.extension.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyTextEditor.extension.st
@@ -31,9 +31,10 @@ ClyTextEditor >> implementorsOf: selectedSelector [
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
 ClyTextEditor >> implementorsOfIt [
 	| selector |
+
 	"self lineSelectAndEmptyCheck: [^ self]."
 	(selector := self selectedSelector) == nil ifTrue: [^ textArea flash].
-	
+	selector 	isCharacter ifTrue: [ ^ textArea flash ].
 	self browser browseImplementorsOf: selector
 ]
 
@@ -74,14 +75,13 @@ ClyTextEditor >> referencesToIt [
 
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
 ClyTextEditor >> sendersOf: selectedSelector [
-	
+	selectedSelector isCharacter ifTrue: [ ^ self ].
 	self browser browseReferencesTo: selectedSelector
 ]
 
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
 ClyTextEditor >> sendersOfIt [
 	| selector |
-	
 	"self lineSelectAndEmptyCheck: [^ self]."
 	(selector := self selectedSelector) == nil ifTrue: [^ textArea flash].
 	

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -720,6 +720,7 @@ RubSmalltalkEditor >> implementorsOfIt [
 	| aSelector |
 	"self lineSelectAndEmptyCheck: [^ self]."
 	(aSelector := self selectedSelector) ifNil: [^ textArea flash].
+	aSelector isCharacter ifTrue: [^ textArea flash].
 	self implementorsOf: aSelector
 ]
 


### PR DESCRIPTION
Fixes: #5140 at least $n sender and implementors do not break anymore. Now ClyTextEditor should have rewritten a bit rubSmalltalkEditor to avoid duplication.