### PR TITLE
Completion: More Cleanups

### DIFF
--- a/src/NECompletion/CompletionEngine.class.st
+++ b/src/NECompletion/CompletionEngine.class.st
@@ -12,7 +12,6 @@ Class {
 	#name : #CompletionEngine,
 	#superclass : #Object,
 	#instVars : [
-		'model',
 		'menuMorph',
 		'editor',
 		'context',
@@ -76,7 +75,6 @@ CompletionEngine >> handleKeystrokeAfter: aKeyboardEvent editor: aParagraphEdito
 	aParagraphEditor atCompletionPosition 
 		ifFalse: [ ^ self closeMenu ].
 	
-	self setModel: aParagraphEditor model.
 	context narrowWith: aParagraphEditor wordAtCaret.
 	menuMorph narrowCompletion.
 	(context isNil or: [ context hasEntries not])
@@ -92,7 +90,6 @@ CompletionEngine >> handleKeystrokeBefore: aKeyboardEvent editor: anEditor [
 
 	| keyCharacter controlKeyPressed |
 	self setEditor: anEditor.
-	self setModel: editor model.
 	keyCharacter := aKeyboardEvent keyCharacter.
 	controlKeyPressed := aKeyboardEvent controlKeyPressed.
 	self isMenuOpen
@@ -221,11 +218,6 @@ CompletionEngine >> menuMorphClass [
 	^ NECMenuMorph
 ]
 
-{ #category : #accessing }
-CompletionEngine >> model [
-	^model
-]
-
 { #category : #keyboard }
 CompletionEngine >> newSmartCharacterInsertionStringForLeft: left right: right [
 	((NECPreferences smartCharactersWithDoubleSpace includes: left) or: [
@@ -243,25 +235,18 @@ CompletionEngine >> newSmartCharacterInsertionStringForLeft: left right: right [
 
 { #category : #'menu morph' }
 CompletionEngine >> openMenu [
-	^ self openMenuFor: editor.
-]
-
-{ #category : #'menu morph' }
-CompletionEngine >> openMenuFor: aParagraphEditor [ 
 	| theMenu |
 	self stopCompletionDelay.
 	
 	context := self contextClass
 				engine: self
-				class: model selectedClassOrMetaClass 
-				source: aParagraphEditor text string
-				position: aParagraphEditor caret - 1.
-	
-	editor := aParagraphEditor.
+				class: editor model selectedClassOrMetaClass 
+				source: editor text string
+				position: editor caret - 1.
 
 	theMenu := self menuMorphClass
-				controller: self
-				position: (aParagraphEditor selectionPosition: context completionToken).
+				engine: self
+				position: (editor selectionPosition: context completionToken).
 				
 	theMenu isClosed
 		ifFalse: [ menuMorph := theMenu ].
@@ -292,11 +277,6 @@ CompletionEngine >> setEditor: anObject [
 		editor morph ifNotNil: [:m | m announcer unsubscribe: self] ].
 	editor := anObject.
 	editor morph onAnnouncement: MorphLostFocus send: #closeMenu to: self.
-]
-
-{ #category : #initialization }
-CompletionEngine >> setModel: aStringHolder [ 
-	model := aStringHolder
 ]
 
 { #category : #keyboard }

--- a/src/NECompletion/NECMenuMorph.class.st
+++ b/src/NECompletion/NECMenuMorph.class.st
@@ -19,11 +19,11 @@ Class {
 		'selected',
 		'firstVisible',
 		'titleStringMorph',
-		'controller',
 		'context',
 		'pageHeight',
 		'detailMorph',
-		'detailPosition'
+		'detailPosition',
+		'engine'
 	],
 	#category : #'NECompletion-View'
 }
@@ -33,19 +33,16 @@ NECMenuMorph class >> backgroundColor [
 	^NECPreferences backgroundColor
 ]
 
-{ #category : #'instance creation' }
-NECMenuMorph class >> controller: aECController position: aPoint [ 
-	| newObject |
-	newObject := self new.
-	newObject setController: aECController position: aPoint.
-	^ newObject
-]
-
 { #category : #preferences }
 NECMenuMorph class >> convertToSHSymbol: aSymbol [
 	^ (SHRBTextStyler new attributesFor: aSymbol) isNotEmpty
 		ifTrue: [ aSymbol ]
 		ifFalse: [ #default ]
+]
+
+{ #category : #'instance creation' }
+NECMenuMorph class >> engine: aCompletionEngine position: aPoint [ 
+	^ self new engine: aCompletionEngine position: aPoint
 ]
 
 { #category : #'help text' }
@@ -240,7 +237,7 @@ NECMenuMorph class >> titleFont [
 { #category : #actions }
 NECMenuMorph >> browse [
 	(self selectedEntry browse)
-		ifTrue: [ controller closeMenu ]
+		ifTrue: [ engine closeMenu ]
 ]
 
 { #category : #actions }
@@ -275,7 +272,7 @@ NECMenuMorph >> currentPage [
 { #category : #private }
 NECMenuMorph >> delete [
 	super delete.
-	controller menuClosed
+	engine menuClosed
 ]
 
 { #category : #drawing }
@@ -412,6 +409,17 @@ NECMenuMorph >> end [
 	self changed.
 ]
 
+{ #category : #initialization }
+NECMenuMorph >> engine: aCompletionEngine position: aPoint [
+	engine := aCompletionEngine.
+	context := engine context.
+	self position: aPoint - (20 @ 0).
+	self narrowCompletion
+		ifFalse: [ ^ self ].
+	self createTitle.
+	self openInWorld
+]
+
 { #category : #private }
 NECMenuMorph >> firstVisible [
 	^firstVisible min: context entryCount
@@ -482,10 +490,10 @@ NECMenuMorph >> insertCommonPrefixOrSelected [
 	prefix := context commonPrefix.
 	prefix = context completionToken ifTrue:[^ self insertSelected].
 	self flag: 'Pending issue 7308, "controller editor wordAtCaret" below should be changed to "context completionToken"'.
-	prefix size > controller editor wordAtCaret size
+	prefix size > engine editor wordAtCaret size
 		ifTrue: [ 
 			self insertCompletion: prefix.
-			context narrowWith: controller editor wordAtCaret ].
+			context narrowWith: engine editor wordAtCaret ].
 	^ true
 ]
 
@@ -493,7 +501,7 @@ NECMenuMorph >> insertCommonPrefixOrSelected [
 NECMenuMorph >> insertCompletion: aString [
 
 	| caret old pos editor offset|
-	editor := controller editor.
+	editor := engine editor.
 	caret := editor caret.
 	editor selectInvisiblyFrom: caret - context completionToken size to: caret - 1.
 	old := editor selection. 
@@ -542,7 +550,7 @@ NECMenuMorph >> mouseDown: evt [
 	super mouseDown: evt.
 	evt wasHandled: false.
 	self flag: #pharoFixMe "ugly hack".
-	controller editor morph owner owner
+	engine editor morph owner owner
 		takeKeyboardFocus;
 		handleMouseDown: evt.
 	self close.
@@ -664,17 +672,6 @@ NECMenuMorph >> selected: aNumber [
 { #category : #accessing }
 NECMenuMorph >> selectedEntry [
 	^ context entries at: self selected
-]
-
-{ #category : #initialization }
-NECMenuMorph >> setController: aECController position: aPoint [
-	controller := aECController.
-	context := controller context.
-	self position: aPoint - (20 @ 0).
-	self narrowCompletion
-		ifFalse: [ ^ self ].
-	self createTitle.
-	self openInWorld
 ]
 
 { #category : #actions }

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -1281,7 +1281,6 @@ RubSmalltalkEditor >> textArea: atextArea [
 
 	atextArea setCompletionEngine: self completionEngine.
 	super textArea: atextArea.
-	completionEngine setModel: self model
 ]
 
 { #category : #'menu messages' }


### PR DESCRIPTION
Some more cleanups:
- more renames controller -> engine
- uniyfy editor and model ivars: we can just use the model of the editor, they will always be the same
- remove parameter in #openMenuFor: