### PR TITLE
Remove-some-unused-Beacon-methods-from-ZnLogEvent

### DIFF
--- a/src/Zinc-HTTP/ZnLogEvent.class.st
+++ b/src/Zinc-HTTP/ZnLogEvent.class.st
@@ -108,16 +108,6 @@ ZnLogEvent >> printOn: stream [
 	self printContentsOn: stream
 ]
 
-{ #category : #beacon }
-ZnLogEvent >> printOneLineContentsOn: stream [
-	self printContentsOn: stream
-]
-
-{ #category : #beacon }
-ZnLogEvent >> printOneLineOn: stream [
-	self printOn: stream
-]
-
 { #category : #accessing }
 ZnLogEvent >> timestamp [
 	^ timestamp


### PR DESCRIPTION
Remove some unused Beacon methods from ZnLogEvent 

Sync with https://github.com/svenvc/zinc/commit/a994ba8d631c11fe41fdead63f72a46135fb0bc7 / https://github.com/svenvc/zinc/issues/49