### PR TITLE
Cleanup: #copiedMethodsFromSuperclass

### DIFF
--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -425,7 +425,7 @@ Collection >> collect: collectBlock thenSelect: selectBlock [
 
 { #category : #testing }
 Collection >> contains: aBlock [
-	"VW compatibility"
+	"For compatibility, please use #anySatisfy: instead!"
 	^self anySatisfy: aBlock
 ]
 

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -601,51 +601,6 @@ Behavior >> compiledMethodAt: selector ifPresent: aBlock ifAbsent: anotherBlock 
 	^ self methodDict at: selector ifPresent: aBlock ifAbsent: anotherBlock
 ]
 
-{ #category : #queries }
-Behavior >> copiedFromSuperclass: method [
-	"Returns the methods that the receiver copied with its ancestors"
-	
-	self allSuperclassesDo: [ :cls|
-		(cls includesSelector: method selector)
-			ifTrue: [ 
-				((cls >> method selector) sourceCode  = method sourceCode)
-					ifTrue: [ ^ {cls >> method selector}]
-					ifFalse: [ ^ #()]]].
-	^ #().
-	
-]
-
-{ #category : #queries }
-Behavior >> copiedMethodsFromSuperclass [
-	"Returns the methods that the receiver copied with its ancestors"
-	
-	| methods |
-	methods := OrderedCollection new.
-	self methodsDo: [ :method|
-		methods addAll:  (self copiedFromSuperclass: method)].
-	^ methods
-]
-
-{ #category : #queries }
-Behavior >> copiesFromSuperclass: method [
-	"Checks whether the receiver copied the argument,  method, from its superclasses"
-	
-	self allSuperclassesDo: [ :cls|
-		(cls includesSelector: method selector)
-			ifTrue: [ ^ (cls >> method selector) sourceCode  = method sourceCode]].
-	^ false
-]
-
-{ #category : #queries }
-Behavior >> copiesMethodsFromSuperclass [
-	"Checks whether the receiver copied some method from its superclass"
-
-	self methodsDo: [ :method|
-		(self copiesFromSuperclass: method)
-			ifTrue: [ ^ true ]].
-	^ false
-]
-
 { #category : #copying }
 Behavior >> deepCopy [
 	"Classes should only be shallowCopied or made anew."
@@ -858,6 +813,7 @@ Behavior >> handleFailingFailingBasicNew: sizeRequested [
 { #category : #testing }
 Behavior >> hasAbstractMethods [
 	"Tells whether the receiver locally defines an abstract method, i.e., a method sending subclassResponsibility"
+	"we do not use #anySatisfy: for speed"
 	
 	self methodsDo: [:each | each isAbstract ifTrue: [ ^true ]].
 	^false


### PR DESCRIPTION
- copiedMethodsFromSuperclass and friends are not used, we now have  rule for this instead 
Two small things:
- #hasAbsractMethods: explain why not #anySatisfy
- better comment in #contains