### PR TITLE
#parseTree needs to use compiler

### DIFF
--- a/src/AST-Core/CompiledMethod.extension.st
+++ b/src/AST-Core/CompiledMethod.extension.st
@@ -23,8 +23,8 @@ CompiledMethod >> firstComment [
 { #category : #'*AST-Core' }
 CompiledMethod >> parseTree [
 	"returns an AST for this method, do not cache it. (see #ast for the cached alternative)"
-	^(RBParser 
-		parseMethod: self sourceCode 
-		onError: [ :msg :pos | 
-			^ self decompile ]) methodClass: self methodClass.
+	^self methodClass compiler 
+		source: self sourceCode;
+		failBlock: [^ self decompile ];
+		parse
 ]

--- a/src/OpalCompiler-Tests/ASTTransformationPluginTest.class.st
+++ b/src/OpalCompiler-Tests/ASTTransformationPluginTest.class.st
@@ -6,14 +6,14 @@ Class {
 
 { #category : #tests }
 ASTTransformationPluginTest >> testClassWithPluginEnabled [
-	self assert: ASTTransformExamplePluginActive new example42 = 'meaning of life'
+	self assert: ASTTransformExamplePluginActive new example42 equals: 'meaning of life'
 ]
 
 { #category : #tests }
 ASTTransformationPluginTest >> testTransform [
-		| ast |
-		ast := (OCOpalExamples>>#exampleReturn42) ast copy.
-		self assert: ast body statements first value value =  42.
-		ast := ASTPluginMeaningOfLife transform: ast.
-		self assert: ast body statements first value value =  'meaning of life'.
+	| ast |
+	ast := (OCOpalExamples >> #exampleReturn42) ast copy.
+	self assert: ast body statements first value value equals: 42.
+	ast := ASTPluginMeaningOfLife transform: ast.
+	self assert: ast body statements first value value equals: 'meaning of life'
 ]


### PR DESCRIPTION
#parseTree should use the compiler. This way compiler settings of the class are taken into account