### PR TITLE
CompilerNilCompiler

### DIFF
--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -136,12 +136,12 @@ CompletionContext >> node [
 
 { #category : #parsing }
 CompletionContext >> parseSource [
-	ast := Smalltalk compiler
+	ast := class compiler
 		source: source;
 		noPattern: isWorkspace;
-		options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
+		options: #(+ optionParseErrors + optionSkipSemanticWarnings);
 		parse.
-	ast doSemanticAnalysisIn: class.
+	ast doSemanticAnalysis.
 	TypingVisitor new visitNode: ast
 ]
 

--- a/src/OpalCompiler-Core/CompiledCode.extension.st
+++ b/src/OpalCompiler-Core/CompiledCode.extension.st
@@ -7,9 +7,7 @@ CompiledCode >> ast [
 
 { #category : #'*opalcompiler-core' }
 CompiledCode >> compiler [
-	^self methodClass 
-		ifNil: [Smalltalk compiler] 
-		ifNotNil: [:class | class compiler].
+	^self methodClass compiler
 ]
 
 { #category : #'*opalcompiler-core' }

--- a/src/OpalCompiler-Core/InstructionStream.extension.st
+++ b/src/OpalCompiler-Core/InstructionStream.extension.st
@@ -2,8 +2,6 @@ Extension { #name : #InstructionStream }
 
 { #category : #'*OpalCompiler-Core' }
 InstructionStream class >> compiler [
-	"The JIT compiler needs to trap all reads to instance variables of contexts. As this check is costly, it is only done
-	in the long form of the bytecodes, which are not used often. In this hierarchy we force the compiler to alwasy generate
-	long bytecodes"
+	"The JIT compiler needs to trap all reads to instance variables of contexts. As this check is costly, it is only done in the long form of the bytecodes, which are not used often. In this hierarchy we force the compiler to alwasy generate long bytecodes"
 	^super compiler options: #(+ optionLongIvarAccessBytecodes)
 ]

--- a/src/OpalCompiler-Core/UndefinedObject.extension.st
+++ b/src/OpalCompiler-Core/UndefinedObject.extension.st
@@ -7,6 +7,6 @@ UndefinedObject >> allTempNames [
 
 { #category : #'*OpalCompiler-Core' }
 UndefinedObject >> compiler [
-	"Expressions (for exampke DoIts) are compiled with nil as the class. If we have this method, we can easily use the compiler that the class defines for syntax highlighting and code completion (without needing to add a check for nil)"
+	"Expressions (for example DoIts) are compiled with nil as the class. If we have this method, we can easily use the compiler that the class defines for syntax highlighting and code completion (without needing to add a check for nil)"
 	^self class compilerClass new class: self
 ]

--- a/src/OpalCompiler-Core/UndefinedObject.extension.st
+++ b/src/OpalCompiler-Core/UndefinedObject.extension.st
@@ -4,3 +4,9 @@ Extension { #name : #UndefinedObject }
 UndefinedObject >> allTempNames [
 	^#()
 ]
+
+{ #category : #'*OpalCompiler-Core' }
+UndefinedObject >> compiler [
+	"nil is used as a class for when compiling expressions (for exampke DoIts)"
+	^Smalltalk compiler
+]

--- a/src/OpalCompiler-Core/UndefinedObject.extension.st
+++ b/src/OpalCompiler-Core/UndefinedObject.extension.st
@@ -7,6 +7,6 @@ UndefinedObject >> allTempNames [
 
 { #category : #'*OpalCompiler-Core' }
 UndefinedObject >> compiler [
-	"nil is used as a class for when compiling expressions (for exampke DoIts)"
-	^Smalltalk compiler
+	"Expressions (for exampke DoIts) are compiled with nil as the class. If we have this method, we can easily use the compiler that the class defines for syntax highlighting and code completion (without needing to add a check for nil)"
+	^self class compilerClass new class: self
 ]

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -971,13 +971,13 @@ SHRBTextStyler >> pixelHeight [
 { #category : #private }
 SHRBTextStyler >> privateStyle: aText [
 	| ast |
-	ast := Smalltalk compiler
+	ast := classOrMetaClass compiler
 		source: aText;
 		noPattern: self isForWorkspace ;
 		options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
 		requestor: workspace;
 		parse.				
-	ast doSemanticAnalysisIn: classOrMetaClass.
+	ast doSemanticAnalysis.
 	^ self style: aText ast: ast
 ]
 


### PR DESCRIPTION
add a #compiler method to UndefinedObject. We use nil when compiling and parsing expressions, if we have this method, we can easily use the compiler that the class defines for syntax highlight and code completion (without needing to add an if to check for nil)