### PR TITLE
Replace-assert-equals-from-packages-starting-with-A

### DIFF
--- a/src/AST-Core-Tests/NumberParserTest.class.st
+++ b/src/AST-Core-Tests/NumberParserTest.class.st
@@ -153,46 +153,52 @@ NumberParserTest >> testFloatMaxAndMin [
 
 { #category : #'tests - Float' }
 NumberParserTest >> testFloatPrintString [
-		
 	| f r bases |
 	f := Float basicNew: 2.
 	r := Random new seed: 1234567.
 	"printing a Float in base other than 10 is broken if lowercase digits are allowed"
-	bases := self areLowercaseDigitsAllowed
-		ifTrue: [#(10)]
-		ifFalse: [#(2 8 10 16)].
+	bases := self areLowercaseDigitsAllowed ifTrue: [ #(10) ] ifFalse: [ #(2 8 10 16) ].
 	100
-		timesRepeat: [f basicAt: 1 put: (r nextInt: 16r100000000)- 1.
+		timesRepeat: [ f basicAt: 1 put: (r nextInt: 16r100000000) - 1.
 			f basicAt: 2 put: (r nextInt: 16r100000000) - 1.
 			bases
-				do: [:base | | str |
-						str := (String new: 64) writeStream.
-						f negative ifTrue: [str nextPut: $-].
-						str print: base; nextPut: $r.
-						f absPrintExactlyOn: str base: base.
-						self assert: (NumberParser parse: str contents) = f]].
+				do: [ :base | 
+					| str |
+					str := (String new: 64) writeStream.
+					f negative ifTrue: [ str nextPut: $- ].
+					str
+						print: base;
+						nextPut: $r.
+					f absPrintExactlyOn: str base: base.
+					self assert: (NumberParser parse: str contents) equals: f ] ].
 	"test big num near infinity"
 	10
-		timesRepeat: [f basicAt: 1 put: 16r7FE00000 + ((r nextInt: 16r100000) - 1).
+		timesRepeat: [ f basicAt: 1 put: 16r7FE00000 + ((r nextInt: 16r100000) - 1).
 			f basicAt: 2 put: (r nextInt: 16r100000000) - 1.
 			bases
-				do: [:base | | str |
-						str := (String new: 64) writeStream.
-						f negative ifTrue: [str nextPut: $-].
-						str print: base; nextPut: $r.
-						f absPrintExactlyOn: str base: base.
-						self assert: (NumberParser parse: str contents) = f]].
+				do: [ :base | 
+					| str |
+					str := (String new: 64) writeStream.
+					f negative ifTrue: [ str nextPut: $- ].
+					str
+						print: base;
+						nextPut: $r.
+					f absPrintExactlyOn: str base: base.
+					self assert: (NumberParser parse: str contents) equals: f ] ].
 	"test infinitesimal (gradual underflow)"
 	10
-		timesRepeat: [f basicAt: 1 put: 0 + ((r nextInt: 16r100000) - 1).
+		timesRepeat: [ f basicAt: 1 put: 0 + ((r nextInt: 16r100000) - 1).
 			f basicAt: 2 put: (r nextInt: 16r100000000) - 1.
 			bases
-				do: [:base | | str |
-						str := (String new: 64) writeStream.
-						f negative ifTrue: [str nextPut: $-].
-						str print: base; nextPut: $r.
-						f absPrintExactlyOn: str base: base.
-						self assert: (NumberParser parse: str contents) = f]].
+				do: [ :base | 
+					| str |
+					str := (String new: 64) writeStream.
+					f negative ifTrue: [ str nextPut: $- ].
+					str
+						print: base;
+						nextPut: $r.
+					f absPrintExactlyOn: str base: base.
+					self assert: (NumberParser parse: str contents) equals: f ] ]
 ]
 
 { #category : #'tests - Float' }

--- a/src/AST-Core-Tests/RBMethodNodeTest.class.st
+++ b/src/AST-Core-Tests/RBMethodNodeTest.class.st
@@ -64,11 +64,11 @@ RBMethodNodeTest >> testNodeForOffsetAssignment [
 	source := 'method Object := Class'.
 	ast := self parserClass parseMethod: source.
 	foundNode := ast nodeForOffset: 9.
-	self assert: foundNode class == RBVariableNode.
+	self assert: foundNode class identicalTo: RBVariableNode.
 	foundNode := ast nodeForOffset: 14.
-	self assert: foundNode class == RBAssignmentNode.
+	self assert: foundNode class identicalTo: RBAssignmentNode.
 	foundNode := ast nodeForOffset: 19.
-	self assert: foundNode class == RBVariableNode
+	self assert: foundNode class identicalTo: RBVariableNode
 ]
 
 { #category : #tests }
@@ -79,11 +79,11 @@ RBMethodNodeTest >> testNodeForOffsetMessage [
 	source := 'method Object doit: Class'.
 	ast := self parserClass parseMethod: source.
 	foundNode := ast nodeForOffset: 9.
-	self assert: foundNode class == RBVariableNode.
+	self assert: foundNode class identicalTo: RBVariableNode.
 	foundNode := ast nodeForOffset: 14.
-	self assert: foundNode class == RBMessageNode.
+	self assert: foundNode class identicalTo: RBMessageNode.
 	foundNode := ast nodeForOffset: 22.
-	self assert: foundNode class == RBVariableNode
+	self assert: foundNode class identicalTo: RBVariableNode
 ]
 
 { #category : #tests }
@@ -94,7 +94,7 @@ RBMethodNodeTest >> testNodeForOffsetTempDefinition [
 	source := 'method | temp |'.
 	ast := self parserClass parseFaultyMethod: source.
 	foundNode := ast nodeForOffset: 12.
-	self assert: foundNode class == RBVariableNode
+	self assert: foundNode class identicalTo: RBVariableNode
 ]
 
 { #category : #tests }
@@ -105,7 +105,7 @@ RBMethodNodeTest >> testNodeForOffsetVar [
 	source := 'method Object'.
 	ast := self parserClass parseMethod: source.
 	foundNode := ast nodeForOffset: 9.
-	self assert: foundNode class == RBVariableNode
+	self assert: foundNode class identicalTo: RBVariableNode
 ]
 
 { #category : #tests }

--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -258,10 +258,11 @@ RBParserTest >> testEqualToWithMapping [
 
 { #category : #'tests comparing' }
 RBParserTest >> testEquivalentExceptRenaming [
-	#(('a 3-4' 'a 4-3' false ) ('a #[3 4]' 'a #(3 4)' false ) ('a variable1 ~~ "comment" variable2' 'a variable1 ~~ variable2' true ) ('a variable1' 'a variable2' false ) ('a [:a :b | a + b]' 'a [:b :a | a + b]' false ) ('a | a b | a + b' 'a | b a | a + b' true ) ('a | a | a msg1; msg2' 'a | b | b msg2; msg2' false ) ('a c' 'a d' true ) ('a | a b | a := b. ^b msg1' 'a | a b | b := a. ^a msg1' true ) ('a | a b | a := b. ^b msg1: a' 'a | a b | b := a. ^b msg1: a' false ) ('a: b b + 4' 'a: e e + 4' true ) ('a: b b + 4' 'b: b b + 4' false ) ('a: b b: c b + c' 'a: c b: b c + b' true ) ('a: a b: b a + b' 'a: b b: a a + b' false ) ) do: [:each | self assert: ((self parserClass parseMethod: each first)
-				equalTo: (self parserClass parseMethod: (each at: 2))
-				exceptForVariables: #('c' ))
-				== each last ]
+	#(#('a 3-4' 'a 4-3' false) #('a #[3 4]' 'a #(3 4)' false) #('a variable1 ~~ "comment" variable2' 'a variable1 ~~ variable2' true) #('a variable1' 'a variable2' false) #('a [:a :b | a + b]' 'a [:b :a | a + b]' false) #('a | a b | a + b' 'a | b a | a + b' true) #('a | a | a msg1; msg2' 'a | b | b msg2; msg2' false) #('a c' 'a d' true) #('a | a b | a := b. ^b msg1' 'a | a b | b := a. ^a msg1' true) #('a | a b | a := b. ^b msg1: a' 'a | a b | b := a. ^b msg1: a' false) #('a: b b + 4' 'a: e e + 4' true) #('a: b b + 4' 'b: b b + 4' false) #('a: b b: c b + c' 'a: c b: b c + b' true) #('a: a b: b a + b' 'a: b b: a a + b' false))
+		do: [ :each | 
+			self
+				assert: ((self parserClass parseMethod: each first) equalTo: (self parserClass parseMethod: (each at: 2)) exceptForVariables: #('c'))
+				identicalTo: each last ]
 ]
 
 { #category : #tests }
@@ -349,8 +350,8 @@ RBParserTest >> testMatchInContext [
 
 { #category : #tests }
 RBParserTest >> testMethodPatterns [
-	#(#('+ a ^self + a' #+) #('foo ^self foo' #foo) #('foo: a bar: b ^a + b' #foo:bar:)) 
-		do: [:each | self assert: (self parserClass  parseMethodPattern: each first) == each last]
+	#(#('+ a ^self + a' #+) #('foo ^self foo' #foo) #('foo: a bar: b ^a + b' #foo:bar:))
+		do: [ :each | self assert: (self parserClass parseMethodPattern: each first) identicalTo: each last ]
 ]
 
 { #category : #tests }
@@ -397,8 +398,8 @@ RBParserTest >> testNegativeNumberError [
 RBParserTest >> testNodesDo [
 	| size |
 	size := 0.
-	self treeWithEverything nodesDo: [:e | size := size + 1].
-	self assert: size = 19
+	self treeWithEverything nodesDo: [ :e | size := size + 1 ].
+	self assert: size equals: 19
 ]
 
 { #category : #'tests parsing' }
@@ -415,21 +416,23 @@ RBParserTest >> testNumberParsing [
 RBParserTest >> testNumberRadixParsing [
 	2 to: 32 do: [ :radix | 
 		| radixString |
-		radixString := radix printString, 'r'.
-		0 to: 72 do: [ :i | 
-			self  assert: (self parserClass parseExpression: (radixString, (i radix: radix)))
-				value = i ] ]
+		radixString := radix printString , 'r'.
+		0 to: 72 do: [ :i | self assert: (self parserClass parseExpression: radixString , (i radix: radix)) value equals: i ] ]
 ]
 
 { #category : #tests }
 RBParserTest >> testParents [
-	(Array with: self treeWithEverything with: self treeWithReallyEverything) do: [ :tree |
-		(Array with: tree with: tree copy) do: [ :root |
-			root nodesDo: [ :node |
-				node children do: [ :each |
-					(each parent isMessage and: [ each parent isCascaded ]) ifFalse: [ 
-						self assert: each parent == node.
-						self assert: each methodNode == root ] ] ] ] ]
+	(Array with: self treeWithEverything with: self treeWithReallyEverything)
+		do: [ :tree | 
+			(Array with: tree with: tree copy)
+				do: [ :root | 
+					root
+						nodesDo: [ :node | 
+							node children
+								do: [ :each | 
+									(each parent isMessage and: [ each parent isCascaded ])
+										ifFalse: [ self assert: each parent identicalTo: node.
+											self assert: each methodNode identicalTo: root ] ] ] ] ]
 ]
 
 { #category : #'tests parsing faulty' }
@@ -641,19 +644,19 @@ RBParserTest >> testParsingLiteralMessages [
 RBParserTest >> testPositions [
 	| blockNode |
 	blockNode := self parserClass parseExpression: '[:a :b | ]'.
-	self assert: blockNode left = 1.
-	self assert: blockNode right = 10.
-	self assert: blockNode bar = 8.
-	self assert: blockNode sourceInterval = (1 to: 10).
-	self assert: blockNode size = 1.	"test dummy collection protocol"
+	self assert: blockNode left equals: 1.
+	self assert: blockNode right equals: 10.
+	self assert: blockNode bar equals: 8.
+	self assert: blockNode sourceInterval equals: (1 to: 10).
+	self assert: blockNode size equals: 1.	"test dummy collection protocol"
 	blockNode printString.	"coverage"
 	self deny: (blockNode isLast: (RBVariableNode named: 'b')).
-	self compare: blockNode
-		to: (RBBlockNode 
-				arguments: (OrderedCollection with: (RBVariableNode named: 'a')
-						with: (RBVariableNode named: 'b'))
-				body: (RBSequenceNode statements: OrderedCollection new)).
-				
+	self
+		compare: blockNode
+		to:
+			(RBBlockNode
+				arguments: (OrderedCollection with: (RBVariableNode named: 'a') with: (RBVariableNode named: 'b'))
+				body: (RBSequenceNode statements: OrderedCollection new))
 ]
 
 { #category : #'tests parsing' }
@@ -777,37 +780,31 @@ RBParserTest >> testPrimitives [
 { #category : #tests }
 RBParserTest >> testQuerying [
 	| tree aNode arg1Node bNode |
-	tree := self parserClass 
-				parseMethod: ('test: a`	| b |`	b := (self foo: a; bar) baz.`	b := super test: b.`	^[:arg1 | self foa1 + (super foo: arg1 foo: a foo: b)]' 
-						copyReplaceAll: '`'
-						with: (String with: (Character value: 13))).
-	self 
-		assert: tree selfMessages asSortedCollection asArray = #(#bar #foa1 #foo:).
-	self assert: tree superMessages asSortedCollection asArray 
-				= #(#foo:foo:foo: #test:).
+	tree := self parserClass
+		parseMethod:
+			('test: a`	| b |`	b := (self foo: a; bar) baz.`	b := super test: b.`	^[:arg1 | self foa1 + (super foo: arg1 foo: a foo: b)]'
+				copyReplaceAll: '`'
+				with: (String with: (Character value: 13))).
+	self assert: tree selfMessages asSortedCollection asArray equals: #(#bar #foa1 #foo:).
+	self assert: tree superMessages asSortedCollection asArray equals: #(#foo:foo:foo: #test:).
 	aNode := tree whichNodeIsContainedBy: (112 to: 112).
-	self assert: aNode name = 'a'.
+	self assert: aNode name equals: 'a'.
 	bNode := tree whichNodeIsContainedBy: (119 to: 119).
-	self assert: bNode name = 'b'.
+	self assert: bNode name equals: 'b'.
 	arg1Node := tree whichNodeIsContainedBy: (102 to: 105).
-	self assert: arg1Node name = 'arg1'.
-	self assert: (arg1Node statementNode isMessage 
-				and: [arg1Node statementNode selector = #+]).
+	self assert: arg1Node name equals: 'arg1'.
+	self assert: (arg1Node statementNode isMessage and: [ arg1Node statementNode selector = #+ ]).
 	self assert: (arg1Node whoDefines: 'arg1') isBlock.
 	self assert: (aNode whoDefines: 'a') isMethod.
 	self assert: (aNode whoDefines: 'b') isSequence.
-	self assert: (tree whichNodeIsContainedBy: (91 to: 119)) selector 
-				= #foo:foo:foo:.
+	self assert: (tree whichNodeIsContainedBy: (91 to: 119)) selector equals: #foo:foo:foo:.
 	self assert: (tree whichNodeIsContainedBy: (69 to: 121)) isBlock.
 	self assert: (tree whichNodeIsContainedBy: (69 to: 118)) isNil.
-	self assert: aNode blockVariables asSortedCollection asArray = #('arg1').
-	self assert: aNode temporaryVariables asSortedCollection asArray = #('b').
-	self assert: tree allDefinedVariables asSortedCollection asArray 
-				= #('a' 'arg1' 'b').
-	self assert: tree allArgumentVariables asSortedCollection asArray 
-				= #('a' 'arg1').
-	self 
-		assert: tree allTemporaryVariables asSortedCollection asArray = #('b')
+	self assert: aNode blockVariables asSortedCollection asArray equals: #('arg1').
+	self assert: aNode temporaryVariables asSortedCollection asArray equals: #('b').
+	self assert: tree allDefinedVariables asSortedCollection asArray equals: #('a' 'arg1' 'b').
+	self assert: tree allArgumentVariables asSortedCollection asArray equals: #('a' 'arg1').
+	self assert: tree allTemporaryVariables asSortedCollection asArray equals: #('b')
 ]
 
 { #category : #tests }
@@ -832,9 +829,7 @@ RBParserTest >> testQueryingPrimitiveErrorVar [
 { #category : #tests }
 RBParserTest >> testReplacingNodes [
 	| tree search block |
-	tree := self parserClass
-		parseMethod:
-			'+ a | a b | self ifTrue: [a] ifFalse: [b := c]. a := b. [:b :c :a | a foo: a; foo1: a; foo2: a foo: b]. {a. b}. ^a'.
+	tree := self parserClass parseMethod: '+ a | a b | self ifTrue: [a] ifFalse: [b := c]. a := b. [:b :c :a | a foo: a; foo1: a; foo2: a foo: b]. {a. b}. ^a'.
 	search := self parseTreeSearcher.
 	block := [ :aNode :answer | aNode replaceWith: (RBVariableNode named: 'q') ].
 	search
@@ -842,18 +837,10 @@ RBParserTest >> testReplacingNodes [
 		matchesArgument: 'a' do: block.
 	search executeTree: tree.
 	self
-		assert:
-			tree
-				=
-					(self parserClass
-						parseMethod:
-							'+ q | q b | self ifTrue: [q] ifFalse: [b := c]. q := b. [:b :c :q | q foo: q; foo1: q; foo2: q foo: b]. {q. b}. ^q').
-	self
-		assert:
-			tree removeDeadCode
-				=
-					(self parserClass
-						parseMethod: '+ q | q b | self ifTrue: [] ifFalse: [b := c]. q := b. {q. b}. ^q')
+		assert: tree
+		equals:
+			(self parserClass parseMethod: '+ q | q b | self ifTrue: [q] ifFalse: [b := c]. q := b. [:b :c :q | q foo: q; foo1: q; foo2: q foo: b]. {q. b}. ^q').
+	self assert: tree removeDeadCode equals: (self parserClass parseMethod: '+ q | q b | self ifTrue: [] ifFalse: [b := c]. q := b. {q. b}. ^q')
 ]
 
 { #category : #'tests parsing' }

--- a/src/AST-Core-Tests/RBReadBeforeWrittenTesterTest.class.st
+++ b/src/AST-Core-Tests/RBReadBeforeWrittenTesterTest.class.st
@@ -9,13 +9,10 @@ Class {
 
 { #category : #tests }
 RBReadBeforeWrittenTesterTest >> testReadBeforeWritten [
-	#(('a ifTrue: [^self]' true ) ('self foo. a := b' false ) ('condition ifTrue: [a := b] ifFalse: [self foo: a]' true ) ('condition ifTrue: [a := b] ifFalse: [self foo]. a isNil' true ) ('condition ifTrue: [a := b]. a := c' false ) ('[a := b] whileFalse: [a isNil]' false ) ('self foo: b' false ) ) do: 
-		[:each | 
-		self assert: ((RBReadBeforeWrittenTester readBeforeWritten: #('a' ) in: (self parseExpression: each first))
-				includes: 'a')
-				== each last.
-		self assert: (RBReadBeforeWrittenTester isVariable: 'a' readBeforeWrittenIn: (self parseExpression: each first))
-				equals: each last].
+	#(#('a ifTrue: [^self]' true) #('self foo. a := b' false) #('condition ifTrue: [a := b] ifFalse: [self foo: a]' true) #('condition ifTrue: [a := b] ifFalse: [self foo]. a isNil' true) #('condition ifTrue: [a := b]. a := c' false) #('[a := b] whileFalse: [a isNil]' false) #('self foo: b' false))
+		do: [ :each | 
+			self assert: ((RBReadBeforeWrittenTester readBeforeWritten: #('a') in: (self parseExpression: each first)) includes: 'a') identicalTo: each last.
+			self assert: (RBReadBeforeWrittenTester isVariable: 'a' readBeforeWrittenIn: (self parseExpression: each first)) equals: each last ].
 	#('| temp read written written1 |
 			read ifTrue: [^self].
 			written1 := self foo ifFalse: [written := true] ifTrue: [written := false].
@@ -29,11 +26,11 @@ RBReadBeforeWrittenTesterTest >> testReadBeforeWritten [
 			[written := 2] whileFalse.
 			self do: [:each | | read | each & read]' '| read |
 			self do: [:each | read := each].
-			self do: [:each | each & read]' ) do: 
-		[:each | 
-		| read | 
-		read := RBReadBeforeWrittenTester variablesReadBeforeWrittenIn: (self parseExpression: each).
-		self assert: (read size = 1 and: [read includes: 'read'])]
+			self do: [:each | each & read]')
+		do: [ :each | 
+			| read |
+			read := RBReadBeforeWrittenTester variablesReadBeforeWrittenIn: (self parseExpression: each).
+			self assert: (read size = 1 and: [ read includes: 'read' ]) ]
 ]
 
 { #category : #tests }

--- a/src/Announcements-Core-Tests/WeakAnnouncerTest.class.st
+++ b/src/Announcements-Core-Tests/WeakAnnouncerTest.class.st
@@ -163,16 +163,14 @@ WeakAnnouncerTest >> testWeakObject [
 
 { #category : #tests }
 WeakAnnouncerTest >> testWeakSubscription [
-	| obj  subscription |
-
+	| obj subscription |
 	self longTestCase.
-	
+
 	obj := Object new.
-	
-	subscription := 
-		(announcer when: AnnouncementMockA send: #value to: obj) makeWeak.
-		
-	self assert: (obj == subscription subscriber).
+
+	subscription := (announcer when: AnnouncementMockA send: #value to: obj) makeWeak.
+
+	self assert: obj identicalTo: subscription subscriber
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Replace assert = in packages starting by A.

Replace:

- assert: = by assert: equals:
- deny = by deny: equals:
- assert: == by assert: identicalTo:
- deny: == by deny: identicalTo: