### PR TITLE
Replace-assert-equals-from-Epicea

### DIFF
--- a/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
+++ b/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
@@ -270,7 +270,6 @@ EpCodeChangeIntegrationTest >> testMethodProtocolChange [
 
 { #category : #tests }
 EpCodeChangeIntegrationTest >> testMethodRecompilationShouldNotLog [
-
 	| headBeforeRecompiling |
 	aClass := classFactory newClass.
 	aClass compile: 'fortyTwo ^42'.
@@ -278,8 +277,8 @@ EpCodeChangeIntegrationTest >> testMethodRecompilationShouldNotLog [
 	headBeforeRecompiling := monitor log head.
 
 	aClass compile: 'fortyTwo ^42'.
-	
-	self assert: monitor log head == headBeforeRecompiling
+
+	self assert: monitor log head identicalTo: headBeforeRecompiling
 ]
 
 { #category : #tests }

--- a/src/EpiceaBrowsers-Tests/EpOmbuExporterTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpOmbuExporterTest.class.st
@@ -58,31 +58,23 @@ EpOmbuExporterTest >> testBasicExport [
 
 { #category : #tests }
 EpOmbuExporterTest >> testCommentExportWithDependencyFix [
-
 	| selection oldComment newComment |
 	oldComment := nil.
 	selection := inputLog2 entries.
-	
-	inputLog2 store entriesDo: [ :entry |
-		entry content isEpLogEntriesComment ifTrue: [
-			oldComment := entry ]
-		].
-	
-	EpOmbuExporter new 
+
+	inputLog2 store entriesDo: [ :entry | entry content isEpLogEntriesComment ifTrue: [ oldComment := entry ] ].
+
+	EpOmbuExporter new
 		outputLog: outputLog;
 		fileOut: selection.
-		
-	self assert: outputLog entries size equals: selection size.
-	
-	outputLog store entriesDo: [ :entry |
-		entry content isEpLogEntriesComment ifTrue: [
-			newComment := entry ]
-		].
 
-	self deny: ((oldComment tagAt: EpLog priorReferenceKey) = (newComment tagAt: EpLog priorReferenceKey)).
-	self deny: ((oldComment tagAt: OmStore selfReferenceKey) = (newComment tagAt: OmStore selfReferenceKey)).
-	self deny: (oldComment content entryReferences = newComment content entryReferences)
-	
+	self assert: outputLog entries size equals: selection size.
+
+	outputLog store entriesDo: [ :entry | entry content isEpLogEntriesComment ifTrue: [ newComment := entry ] ].
+
+	self deny: (oldComment tagAt: EpLog priorReferenceKey) equals: (newComment tagAt: EpLog priorReferenceKey).
+	self deny: (oldComment tagAt: OmStore selfReferenceKey) equals: (newComment tagAt: OmStore selfReferenceKey).
+	self deny: oldComment content entryReferences equals: newComment content entryReferences
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Replace assert = in Epicea.

Replace:

- assert: = by assert: equals:
- assert: == by assert: identicalTo: