### PR TITLE
new-vm-identifying-methods

### DIFF
--- a/src/Kernel/DelayMillisecondTicker.class.st
+++ b/src/Kernel/DelayMillisecondTicker.class.st
@@ -38,11 +38,11 @@ DelayMillisecondTicker >> tickAfterMilliseconds: milliseconds [
 
 { #category : #'api-system' }
 DelayMillisecondTicker >> waitForUserSignalled: timingSemaphore orExpired: activeDelay [
-	|nextTick|
+	| nextTick |
 	"Sleep until the active delay is due, or timingSemaphore signalled by DelayScheduler user-api."
 	
 	"We sleep at most 1sec here as a soft busy-loop so that we don't accidentally miss signals."
-	nextTick := self nowTick + (1"sec" * 1000"msecs").
+	nextTick := self nowTick + (ProcessorScheduler idleTime max: 1000).
 	activeDelay ifNotNil: [
 		nextTick := nextTick min: activeDelay resumptionTick ].
 		
@@ -50,5 +50,4 @@ DelayMillisecondTicker >> waitForUserSignalled: timingSemaphore orExpired: activ
 	self primSignal: timingSemaphore atMilliseconds: nextTick.
 	"WARNING! Stepping <Over> the following line may lock the Image. Use <Proceed>."
 	timingSemaphore wait.
-	
 ]

--- a/src/OSWindow-SDL2/SDL2.class.st
+++ b/src/OSWindow-SDL2/SDL2.class.st
@@ -31,11 +31,10 @@ SDL2 class >> checkLibraryName: aName [
 
 { #category : #clipboard }
 SDL2 class >> clipboardText [
-	| text |
+	| textPointer |
 	
-	text := self primClipboardText.
-	^ text readStringUTF8
-
+	textPointer := self primClipboardText.
+	^ [textPointer readStringUTF8] ensure: [ textPointer free ]
 ]
 
 { #category : #clipboard }
@@ -51,7 +50,9 @@ SDL2 class >> clipboardText: text [
 			toStream: stream.
 		stream nextPut: 0 ].
 	
-	self primClipboardText: encoded
+	encoded setPinnedInMemory: true.
+	
+	self primClipboardText: encoded.
 ]
 
 { #category : #cursor }
@@ -91,7 +92,8 @@ SDL2 class >> disableScreenSaver [
 
 { #category : #native }
 SDL2 class >> ffiLibraryName [
-	^ self moduleName
+	
+	^ SDL2Library
 ]
 
 { #category : #native }
@@ -218,7 +220,7 @@ SDL2 class >> initLibrary [
 SDL2 class >> initPlatformSpecific [
 
 	Smalltalk os isMacOSX ifTrue: [  
-		SDLOSXPlatformInitializer new run.	
+		SDLOSXPlatformInitializer uniqueInstance run.	
 	] 
 ]
 
@@ -290,7 +292,7 @@ SDL2 class >> pollEvent: event [
 
 { #category : #clipboard }
 SDL2 class >> primClipboardText [
-	^ self ffiCall: #( ExternalAddress SDL_GetClipboardText ( ) )
+	^ self ffiCall: #(void* SDL_GetClipboardText ( ) )
 ]
 
 { #category : #clipboard }
@@ -336,6 +338,11 @@ SDL2 class >> showCursor: toggle [
 SDL2 class >> ticks [
 	"Gets the number of milliseconds since the SDL library was initialized"
 	^ self ffiCall: #( Uint32 SDL_GetTicks ( ) )
+]
+
+{ #category : #event }
+SDL2 class >> waitEvent: event timeout: aTimeout [
+	^ self ffiCall: #(int SDL_WaitEventTimeout(SDL_Event event, int aTimeout) )
 ]
 
 { #category : #common }

--- a/src/OSWindow-SDL2/SDL2Library.class.st
+++ b/src/OSWindow-SDL2/SDL2Library.class.st
@@ -1,0 +1,44 @@
+Class {
+	#name : #SDL2Library,
+	#superclass : #FFILibrary,
+	#category : #'OSWindow-SDL2-Bindings'
+}
+
+{ #category : #'nb-library' }
+SDL2Library >> calloutAPIClass [ 
+
+	^ TFCalloutAPI
+]
+
+{ #category : #'accessing platform' }
+SDL2Library >> checkLibraryName: aName [
+
+	^ (ExternalAddress loadSymbol: 'SDL_Init' from: aName) notNil
+]
+
+{ #category : #'accessing platform' }
+SDL2Library >> findSDL2 [
+
+	"Look for SDL2 using different names."
+	#(0							"Static"
+	SDL2
+	'libSDL2-2.0.0.dylib'		"Mac"
+	'libSDL2-2.0.so.0'			"Linux 1"
+	'libSDL2-2.0.so.0.2.1'	"Linux 2"
+	'SDL2.dll'					"Windows"
+	) do: [ :eachName | 
+		[ (self checkLibraryName: eachName) ifTrue: [ ^ eachName ] ] 
+		ifError: [nil] ].
+	self error: 'Failed to find SDL2 library.'
+]
+
+{ #category : #'accessing platform' }
+SDL2Library >> macModuleName [ 
+	^ self findSDL2 
+]
+
+{ #category : #'nb-library' }
+SDL2Library >> runner [
+
+	^ TFMainThreadRunner uniqueInstance
+]

--- a/src/OSWindow-SDL2/SDLOSXPlatformInitializer.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPlatformInitializer.class.st
@@ -3,21 +3,39 @@ I execute specific initialization for OSX
 "
 Class {
 	#name : #SDLOSXPlatformInitializer,
-	#superclass : #Object,
+	#superclass : #FFILibrary,
 	#category : #'OSWindow-SDL2-Bindings'
 }
 
 { #category : #running }
+SDLOSXPlatformInitializer >> calloutAPIClass [ 
+
+	^ TFCalloutAPI 
+]
+
+{ #category : #running }
+SDLOSXPlatformInitializer >> ffiLibraryName [ 
+
+	^ self
+]
+
+{ #category : #running }
 SDLOSXPlatformInitializer >> lookupClass: aString [
 
-	^ self ffiCall: #(void* objc_lookUpClass(char *aString)) module: 'libobjc.dylib'
+	^ self ffiCall: #(void* objc_lookUpClass(char *aString)) 
 ]
 
 { #category : #running }
 SDLOSXPlatformInitializer >> lookupSelector: aString [
 
-	^ self ffiCall: #(void* sel_registerName(const char *aString)) module: 'libobjc.dylib'
+	^ self ffiCall: #(void* sel_registerName(const char *aString)) 
+]
 
+{ #category : #'accessing platform' }
+SDLOSXPlatformInitializer >> macModuleName [ 
+
+	^ 'libobjc.dylib'
+	
 ]
 
 { #category : #running }
@@ -30,7 +48,13 @@ SDLOSXPlatformInitializer >> run [
 ]
 
 { #category : #running }
+SDLOSXPlatformInitializer >> runner [
+
+	^ TFMainThreadRunner uniqueInstance
+]
+
+{ #category : #running }
 SDLOSXPlatformInitializer >> sendMessage: sel to: cls [
 
-	^ self ffiCall: #(void* objc_msgSend(void* cls, void* sel)) module: 'libobjc.dylib'
+	^ self ffiCall: #(void* objc_msgSend(void* cls, void* sel))
 ]

--- a/src/System-Support/VirtualMachine.class.st
+++ b/src/System-Support/VirtualMachine.class.st
@@ -342,6 +342,14 @@ VirtualMachine >> is64bit [
 ]
 
 { #category : #testing }
+VirtualMachine >> isAIOInterrupt [
+	"Answer true. If the vm is capable of being interupted until there is an AIO event. 
+	 (This means we are going idle until we have something real to process)"
+
+	^ (self getSystemAttribute: 1010) = 'AIO'
+]
+
+{ #category : #testing }
 VirtualMachine >> isPharoVM [
 	"Answers if this VM is a valid PharoVM (made with our sources)"
 	| version |
@@ -373,6 +381,13 @@ VirtualMachine >> isRunningCogit [
 	 (vmParameterAt: 46 is the size of the machine code zone)"
 
 	^[(self parameterAt: 46) > 0] on: Error do:[:ex| ex return: false]
+]
+
+{ #category : #testing }
+VirtualMachine >> isRunningInWorkerThread [
+	"Answers whether the vm is running on worker thread ot not"
+
+	^ (self getSystemAttribute: 1011) = 'WORKER_THREAD'
 ]
 
 { #category : #testing }


### PR DESCRIPTION
introduce methods to indentify new properties of the VM.
adapt dely ticker to take same time as the idleTime (otherwise it has no sense, the tick will always happen even when there is no need for it).