### PR TITLE
introduce methods to indentify new properties of the VM

### DIFF
--- a/src/Kernel/DelayMillisecondTicker.class.st
+++ b/src/Kernel/DelayMillisecondTicker.class.st
@@ -38,11 +38,11 @@ DelayMillisecondTicker >> tickAfterMilliseconds: milliseconds [
 
 { #category : #'api-system' }
 DelayMillisecondTicker >> waitForUserSignalled: timingSemaphore orExpired: activeDelay [
-	|nextTick|
+	| nextTick |
 	"Sleep until the active delay is due, or timingSemaphore signalled by DelayScheduler user-api."
 	
 	"We sleep at most 1sec here as a soft busy-loop so that we don't accidentally miss signals."
-	nextTick := self nowTick + (1"sec" * 1000"msecs").
+	nextTick := self nowTick + (ProcessorScheduler idleTime max: 1000).
 	activeDelay ifNotNil: [
 		nextTick := nextTick min: activeDelay resumptionTick ].
 		
@@ -50,5 +50,4 @@ DelayMillisecondTicker >> waitForUserSignalled: timingSemaphore orExpired: activ
 	self primSignal: timingSemaphore atMilliseconds: nextTick.
 	"WARNING! Stepping <Over> the following line may lock the Image. Use <Proceed>."
 	timingSemaphore wait.
-	
 ]

--- a/src/Kernel/DelayMillisecondTicker.class.st
+++ b/src/Kernel/DelayMillisecondTicker.class.st
@@ -38,11 +38,11 @@ DelayMillisecondTicker >> tickAfterMilliseconds: milliseconds [
 
 { #category : #'api-system' }
 DelayMillisecondTicker >> waitForUserSignalled: timingSemaphore orExpired: activeDelay [
-	| nextTick |
+	|nextTick|
 	"Sleep until the active delay is due, or timingSemaphore signalled by DelayScheduler user-api."
 	
 	"We sleep at most 1sec here as a soft busy-loop so that we don't accidentally miss signals."
-	nextTick := self nowTick + (ProcessorScheduler idleTime max: 1000).
+	nextTick := self nowTick + (1"sec" * 1000"msecs").
 	activeDelay ifNotNil: [
 		nextTick := nextTick min: activeDelay resumptionTick ].
 		
@@ -50,4 +50,5 @@ DelayMillisecondTicker >> waitForUserSignalled: timingSemaphore orExpired: activ
 	self primSignal: timingSemaphore atMilliseconds: nextTick.
 	"WARNING! Stepping <Over> the following line may lock the Image. Use <Proceed>."
 	timingSemaphore wait.
+	
 ]

--- a/src/System-Support/VirtualMachine.class.st
+++ b/src/System-Support/VirtualMachine.class.st
@@ -343,7 +343,7 @@ VirtualMachine >> is64bit [
 
 { #category : #testing }
 VirtualMachine >> isAIOInterrupt [
-	"Answer true. If the vm is capable of being interupted until there is an AIO event. 
+	"Answer true, if the vm is capable of being interupted until there is an AIO event. 
 	 (This means we are going idle until we have something real to process)"
 
 	^ (self getSystemAttribute: 1010) = 'AIO'

--- a/src/System-Support/VirtualMachine.class.st
+++ b/src/System-Support/VirtualMachine.class.st
@@ -342,6 +342,14 @@ VirtualMachine >> is64bit [
 ]
 
 { #category : #testing }
+VirtualMachine >> isAIOInterrupt [
+	"Answer true. If the vm is capable of being interupted until there is an AIO event. 
+	 (This means we are going idle until we have something real to process)"
+
+	^ (self getSystemAttribute: 1010) = 'AIO'
+]
+
+{ #category : #testing }
 VirtualMachine >> isPharoVM [
 	"Answers if this VM is a valid PharoVM (made with our sources)"
 	| version |
@@ -373,6 +381,13 @@ VirtualMachine >> isRunningCogit [
 	 (vmParameterAt: 46 is the size of the machine code zone)"
 
 	^[(self parameterAt: 46) > 0] on: Error do:[:ex| ex return: false]
+]
+
+{ #category : #testing }
+VirtualMachine >> isRunningInWorkerThread [
+	"Answers whether the vm is running on worker thread ot not"
+
+	^ (self getSystemAttribute: 1011) = 'WORKER_THREAD'
 ]
 
 { #category : #testing }


### PR DESCRIPTION
adapt dely ticker to take same time as the idleTime (otherwise it has no sense, the tick will always happen even when there is no need for it).

(second attempt)