### PR TITLE
Replace-assert-equals-from-packages-starting-with-H

### DIFF
--- a/src/HelpSystem-Tests/ClassAPIHelpBuilderTest.class.st
+++ b/src/HelpSystem-Tests/ClassAPIHelpBuilderTest.class.st
@@ -9,41 +9,27 @@ Class {
 
 { #category : #testing }
 ClassAPIHelpBuilderTest >> testBuildingTraits [
-	|topic|
-	topic := ClassAPIHelpBuilder 
-				buildHelpTopicFrom: TSortable .				 
-	self assert: topic subtopics size = 2.
-	self assert: topic subtopics first title = 'Instance side'.
-	self assert: topic subtopics last title = 'Class side'
- 
-
- 
+	| topic |
+	topic := ClassAPIHelpBuilder buildHelpTopicFrom: TSortable.
+	self assert: topic subtopics size equals: 2.
+	self assert: topic subtopics first title equals: 'Instance side'.
+	self assert: topic subtopics last title equals: 'Class side'
 ]
 
 { #category : #testing }
 ClassAPIHelpBuilderTest >> testDefaultBuilding [
-	|topic|
-	topic := ClassAPIHelpBuilder 
-				buildHelpTopicFrom: Integer.				 
-	self assert: topic subtopics size = 2.
-	self assert: topic subtopics first title = 'Instance side'.
-	self assert: topic subtopics last title = 'Class side'
- 
-
- 
+	| topic |
+	topic := ClassAPIHelpBuilder buildHelpTopicFrom: Integer.
+	self assert: topic subtopics size equals: 2.
+	self assert: topic subtopics first title equals: 'Instance side'.
+	self assert: topic subtopics last title equals: 'Class side'
 ]
 
 { #category : #testing }
 ClassAPIHelpBuilderTest >> testMethodsButNoSubclasses [
-	|topic|
-	topic := ClassAPIHelpBuilder 
-				buildHierarchicalHelpTopicFrom: Integer 
-				withSubclasses: false 
-				withMethods: true.
-	self assert: topic subtopics size = 2.
-	self assert: topic subtopics first title = 'Instance side'.
-	self assert: topic subtopics last title = 'Class side'
- 
-
- 
+	| topic |
+	topic := ClassAPIHelpBuilder buildHierarchicalHelpTopicFrom: Integer withSubclasses: false withMethods: true.
+	self assert: topic subtopics size equals: 2.
+	self assert: topic subtopics first title equals: 'Instance side'.
+	self assert: topic subtopics last title equals: 'Class side'
 ]

--- a/src/HelpSystem-Tests/HelpBrowserTest.class.st
+++ b/src/HelpSystem-Tests/HelpBrowserTest.class.st
@@ -14,37 +14,28 @@ HelpBrowserTest >> defaultTestClass [
 
 { #category : #testing }
 HelpBrowserTest >> testDefaultHelpBrowser [
-	
 	| current replacement instance |
 	current := self defaultTestClass defaultHelpBrowser.
 	replacement := AdvancedHelpBrowserDummy.
-	[
-	  self defaultTestClass defaultHelpBrowser: replacement.
-	  self assert: self defaultTestClass defaultHelpBrowser == replacement.
- 
-	  instance := self defaultTestClass open.
-	  self assert: instance rootTopic notNil.
-	  self assert: instance isOpen.
-	] ensure: [ self defaultTestClass defaultHelpBrowser: current ]
-	 
+	[ self defaultTestClass defaultHelpBrowser: replacement.
+	self assert: self defaultTestClass defaultHelpBrowser identicalTo: replacement.
+
+	instance := self defaultTestClass open.
+	self assert: instance rootTopic notNil.
+	self assert: instance isOpen ]
+		ensure: [ self defaultTestClass defaultHelpBrowser: current ]
 ]
 
 { #category : #testing }
 HelpBrowserTest >> testDefaultHelpBrowserIsReplacable [
-	
 	| current replacement instance |
 	"save the one that is registered"
 	current := self defaultTestClass defaultHelpBrowser.
 	replacement := AdvancedHelpBrowserDummy.
-	[
-	  self defaultTestClass defaultHelpBrowser: replacement.
-	  self assert: self defaultTestClass defaultHelpBrowser == replacement.	  
-	  instance := self defaultTestClass open.
-	  
-	] ensure: [
-		self defaultTestClass defaultHelpBrowser: current
-	]
-	 
+	[ self defaultTestClass defaultHelpBrowser: replacement.
+	self assert: self defaultTestClass defaultHelpBrowser identicalTo: replacement.
+	instance := self defaultTestClass open ]
+		ensure: [ self defaultTestClass defaultHelpBrowser: current ]
 ]
 
 { #category : #testing }

--- a/src/HelpSystem-Tests/HelpTopicListItemWrapperTest.class.st
+++ b/src/HelpSystem-Tests/HelpTopicListItemWrapperTest.class.st
@@ -15,8 +15,7 @@ HelpTopicListItemWrapperTest >> defaultTestClass [
 
 { #category : #testing }
 HelpTopicListItemWrapperTest >> testDisplayLabel [
-	|instance|
+	| instance |
 	instance := self defaultTestClass with: (HelpTopic named: 'My Topic').
-	self assert: instance asString = 'My Topic'
-	
+	self assert: instance asString equals: 'My Topic'
 ]

--- a/src/HelpSystem-Tests/HelpTopicTest.class.st
+++ b/src/HelpSystem-Tests/HelpTopicTest.class.st
@@ -23,52 +23,47 @@ HelpTopicTest >> setUp [
 
 { #category : #testing }
 HelpTopicTest >> testAddingSubtopic [
-
-	|subtopic returned|
+	| subtopic returned |
 	subtopic := self defaultTestClass named: 'Subtopic'.
 	returned := topic addSubtopic: subtopic.
-	self assert: returned == subtopic.
-	self assert: (topic subtopics includes: subtopic) 
+	self assert: returned identicalTo: subtopic.
+	self assert: (topic subtopics includes: subtopic)
 ]
 
 { #category : #testing }
 HelpTopicTest >> testInitialization [
-	self assert: topic title = 'Unnamed Topic'.
+	self assert: topic title equals: 'Unnamed Topic'.
 	self assertEmpty: topic key.
 	self assertEmpty: topic contents
 ]
 
 { #category : #testing }
 HelpTopicTest >> testInstanceCreation [
-
-	|instance|
+	| instance |
 	instance := self defaultTestClass named: 'My Topic'.
-	self assert: instance title = 'My Topic'.
-
+	self assert: instance title equals: 'My Topic'
 ]
 
 { #category : #testing }
 HelpTopicTest >> testSortOrder [
-
-	|a b c sorted |
+	| a b c sorted |
 	a := self defaultTestClass named: 'A'.
 	b := self defaultTestClass named: 'B'.
 	c := self defaultTestClass named: 'C'.
 	sorted := (OrderedCollection with: b with: c with: a) asSortedCollection.
-	self assert: sorted first = a.
-	self assert: sorted last = c.
-	
+	self assert: sorted first equals: a.
+	self assert: sorted last equals: c
 ]
 
 { #category : #testing }
 HelpTopicTest >> testSubtopicOwnership [
-"Test that when a subtopic is added to a topic then owner of the subtopic is the topic"
-	|subtopic owner|
-	owner := self defaultTestClass named:  'I am the owner'.
-	subtopic := self defaultTestClass named: 'I am the subtopic'.
-	
-	owner addSubtopic: subtopic.
-	
-	self assert: (subtopic owner == owner).
+	"Test that when a subtopic is added to a topic then owner of the subtopic is the topic"
 
+	| subtopic owner |
+	owner := self defaultTestClass named: 'I am the owner'.
+	subtopic := self defaultTestClass named: 'I am the subtopic'.
+
+	owner addSubtopic: subtopic.
+
+	self assert: subtopic owner identicalTo: owner
 ]

--- a/src/HelpSystem-Tests/WikiStyleHelpBuilderTest.class.st
+++ b/src/HelpSystem-Tests/WikiStyleHelpBuilderTest.class.st
@@ -23,13 +23,12 @@ WikiStyleHelpBuilderTest >> setUp [
 
 { #category : #testing }
 WikiStyleHelpBuilderTest >> testDefaultSyntaxAlwaysPier [
-	self assert: builder defaultSyntax == #pier
+	self assert: builder defaultSyntax identicalTo: #pier
 ]
 
 { #category : #testing }
 WikiStyleHelpBuilderTest >> testExtractHelpContentsFromMarkedString [
-	|content|
+	| content |
 	content := builder extractHelpContentFromString: 'outer<help>inner</help>outer'.
-	self assert: content = 'inner'.
-	
+	self assert: content equals: 'inner'
 ]


### PR DESCRIPTION
Replace assert = in packages starting by H.

Replace:

- assert: = by assert: equals:
- deny = by deny: equals:
- assert: == by assert: identicalTo:
- deny: == by deny: identicalTo: