### PR TITLE
Replace-assert-equals-from-packages-starting-with-J-and-K

### DIFF
--- a/src/Jobs-Tests/JobTest.class.st
+++ b/src/Jobs-Tests/JobTest.class.st
@@ -33,15 +33,12 @@ JobTest >> testChildJob [
 
 { #category : #tests }
 JobTest >> testCurrentJob [
-	
-	[ :job |
-		[ :job2 |
-			self assert: Job current == job2.
-			self deny: Job current == job.
-			] asJob run.
-	
-		self assert: Job current == job.
-		] asJob run
+	[ :job | 
+	[ :job2 | 
+	self assert: Job current identicalTo: job2.
+	self deny: Job current identicalTo: job ] asJob run.
+
+	self assert: Job current identicalTo: job ] asJob run
 ]
 
 { #category : #tests }
@@ -64,40 +61,35 @@ JobTest >> testJobAnnouncements [
 
 { #category : #tests }
 JobTest >> testLookupJob [
-	
 	[ :job | 
-		[ :job2 | | noneFound result |
+	[ :job2 | 
+	| noneFound result |
+	noneFound := false.
+	result := job2 lookup: [ :aJob | aJob == job2 ] ifNone: [ noneFound := true ].
+	self assert: result identicalTo: job2.
+	self deny: noneFound.
 
-			noneFound := false.
-			result := job2 lookup: [ :aJob | aJob == job2 ] ifNone: [ noneFound := true ].
-			self assert: result == job2.
-			self deny: noneFound.
-			
-			result := job2 lookup: [ :aJob | aJob == job ] ifNone: [ noneFound := true ].
-			self assert: result == job.
-			self deny: noneFound.
+	result := job2 lookup: [ :aJob | aJob == job ] ifNone: [ noneFound := true ].
+	self assert: result identicalTo: job.
+	self deny: noneFound.
 
-			result := job lookup: [ :aJob | aJob == job2 ] ifNone: [ noneFound := true. 42 ].
-			self assert: result equals: 42.
-			self assert: noneFound.
+	result := job
+		lookup: [ :aJob | aJob == job2 ]
+		ifNone: [ noneFound := true.
+			42 ].
+	self assert: result equals: 42.
+	self assert: noneFound ] asJob run.
 
-			] asJob run.
-	
-		self assert: Job current == job.
-		] asJob run
+	self assert: Job current identicalTo: job ] asJob run
 ]
 
 { #category : #tests }
 JobTest >> testOwner [
-	
-	[ :job |
-		self assert: job owner == self.
-		[ :job2 |
-			self assert: job owner == self.
-			self assert: job2 owner == self.
- 		] asJob run.
-	] asJob run
-
+	[ :job | 
+	self assert: job owner identicalTo: self.
+	[ :job2 | 
+	self assert: job owner identicalTo: self.
+	self assert: job2 owner identicalTo: self ] asJob run ] asJob run
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests-Extended/AdditionalMethodStateTest.class.st
+++ b/src/Kernel-Tests-Extended/AdditionalMethodStateTest.class.st
@@ -37,16 +37,15 @@ AdditionalMethodStateTest >> testAnalogousCodeTo [
 
 { #category : #tests }
 AdditionalMethodStateTest >> testCopy [
-
 	| copy |
 	copy := amState copy.
 
-	self deny: amState == copy.
-	self assert: amState method == copy method.
-	self assert: amState selector == copy selector.
+	self deny: amState identicalTo: copy.
+	self assert: amState method identicalTo: copy method.
+	self assert: amState selector identicalTo: copy selector.
 
 	self assert: amState pragmas equals: copy pragmas.
 	self assert: amState properties equals: copy properties.
 
-	amState pragmas withIndexDo: [:el :index| self deny: el == (copy pragmas at: index)].
+	amState pragmas withIndexDo: [ :el :index | self deny: el identicalTo: (copy pragmas at: index) ]
 ]

--- a/src/Kernel-Tests-Extended/BlockClosureTest.extension.st
+++ b/src/Kernel-Tests-Extended/BlockClosureTest.extension.st
@@ -29,15 +29,14 @@ BlockClosureTest >> testCannotReturn [
 
 { #category : #'*Kernel-Tests-Extended' }
 BlockClosureTest >> testRunSimulated [
-	self assert: (Context runSimulated: aBlockContext) class = Rectangle.
+	self assert: (Context runSimulated: aBlockContext) class equals: Rectangle
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
 BlockClosureTest >> testSourceNodeOptimized [
-	| block | 
-	block := [ :ctx | [ ctx atEnd ] whileTrue:[1+2 ] ] .
-	self assert: block sourceNode printString = 'RBBlockNode([ :ctx | [ ctx atEnd ] whileTrue: [ 1 + 2 ] ])'.
-
+	| block |
+	block := [ :ctx | [ ctx atEnd ] whileTrue: [ 1 + 2 ] ].
+	self assert: block sourceNode printString equals: 'RBBlockNode([ :ctx | [ ctx atEnd ] whileTrue: [ 1 + 2 ] ])'
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
@@ -54,5 +53,5 @@ BlockClosureTest >> testTallyInstructions [
 
 { #category : #'*Kernel-Tests-Extended' }
 BlockClosureTest >> testTallyMethods [
-	self assert: (Context tallyMethods: aBlockContext) size = 7.
+	self assert: (Context tallyMethods: aBlockContext) size equals: 7
 ]

--- a/src/Kernel-Tests-Extended/BlockClosuresTestCase.extension.st
+++ b/src/Kernel-Tests-Extended/BlockClosuresTestCase.extension.st
@@ -2,7 +2,5 @@ Extension { #name : #BlockClosuresTestCase }
 
 { #category : #'*Kernel-Tests-Extended' }
 BlockClosuresTestCase >> testExample1 [
-
-   self assert: ((self example1: 5) = 5 factorial)
-  
+	self assert: (self example1: 5) equals: 5 factorial
 ]

--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -251,14 +251,14 @@ ClassTest >> testMethodsReferencingClasses [
 ClassTest >> testNewSubclass [
 	| cls |
 	cls := Point newSubclass.
-	self assert: (cls isBehavior).
-	self assert: (cls superclass == Point).
+	self assert: cls isBehavior.
+	self assert: cls superclass identicalTo: Point.
 	self assert: (Point allSubclasses includes: cls).
-	self assert: (cls instVarNames = #()).
-	self assert: (cls category = self unclassifiedCategory).
-	self assert: (cls classVarNames = #()).
-	
-	cls removeFromSystem.
+	self assert: cls instVarNames equals: #().
+	self assert: cls category equals: self unclassifiedCategory.
+	self assert: cls classVarNames equals: #().
+
+	cls removeFromSystem
 ]
 
 { #category : #'tests - file in/out' }
@@ -300,23 +300,23 @@ ClassTest >> testOrdersMetaClassAfterItsClassInstance [
 { #category : #'tests - pools' }
 ClassTest >> testPoolVariableAccessibleInClassUser [
 	"This test shows that a Pool Variable is accessible from the class that declare the Pool usage: here the superclass"
- 
+
 	PoolDefiner initialize.
 	RootClassPoolUser compileAll.
-	
-	self assert: RootClassPoolUser gloups = 42.
-	self assert: RootClassPoolUser author = 'Ducasse'
+
+	self assert: RootClassPoolUser gloups equals: 42.
+	self assert: RootClassPoolUser author equals: 'Ducasse'
 ]
 
 { #category : #'tests - pools' }
 ClassTest >> testPoolVariableAccessibleInSubclassOfClassUser [
 	"This test shows that a Pool Variable is not accessible from a subclass that declare the Pool usage: here SubFlop subclass of Flop and this is a bug. "
- 
+
 	PoolDefiner initialize.
 	SubclassPoolUser compileAll.
-	
-	self assert: SubclassPoolUser gloups = 42.
-	self assert: SubclassPoolUser author = 'Ducasse'
+
+	self assert: SubclassPoolUser gloups equals: 42.
+	self assert: SubclassPoolUser author equals: 'Ducasse'
 ]
 
 { #category : #'tests - navigation' }
@@ -376,34 +376,32 @@ ClassTest >> testSharedPools [
 { #category : #'tests - class creation' }
 ClassTest >> testSubclass [
 	| cls |
-	(testEnvironment includesKey: #SubclassExample)
-		ifTrue: [ (testEnvironment at: #SubclassExample) removeFromSystem ].
-	
+	(testEnvironment includesKey: #SubclassExample) ifTrue: [ (testEnvironment at: #SubclassExample) removeFromSystem ].
+
 	self deny: (testEnvironment includesKey: #SubclassExample).
 	cls := Object subclass: #SubclassExample.
 	self assert: (testEnvironment includesKey: #SubclassExample).
 
-	self assert: (testEnvironment at: #SubclassExample) == cls.
+	self assert: (testEnvironment at: #SubclassExample) identicalTo: cls.
 	self assert: cls category equals: self unclassifiedCategory.
 	self assert: cls instVarNames equals: #().
-	
+
 	cls removeFromSystem
 ]
 
 { #category : #'tests - class creation' }
 ClassTest >> testSubclassInstanceVariableNames [
 	| cls |
-	(testEnvironment includesKey: #SubclassExample)
-		ifTrue: [ (testEnvironment at: #SubclassExample) removeFromSystem ].
-	
+	(testEnvironment includesKey: #SubclassExample) ifTrue: [ (testEnvironment at: #SubclassExample) removeFromSystem ].
+
 	self deny: (testEnvironment includesKey: #SubclassExample).
 	cls := Object subclass: #SubclassExample instanceVariableNames: 'x y'.
 	self assert: (testEnvironment includesKey: #SubclassExample).
 
-	self assert: (testEnvironment at: #SubclassExample) == cls.
+	self assert: (testEnvironment at: #SubclassExample) identicalTo: cls.
 	self assert: cls category equals: self unclassifiedCategory.
 	self assert: cls instVarNames equals: #('x' 'y').
-	
+
 	cls removeFromSystem
 ]
 

--- a/src/Kernel-Tests-Extended/CodeSimulationTest.class.st
+++ b/src/Kernel-Tests-Extended/CodeSimulationTest.class.st
@@ -43,64 +43,67 @@ CodeSimulationTest >> testError [
 { #category : #'tests - primitives' }
 CodeSimulationTest >> testErrorCodeNotFound [
 	| ctx result resultSimu |
-	
 	self skip.
-	
+
 	Smalltalk vm isRunningCog ifFalse: [ ^ self ].
-	
+
 	result := self veryBasicAt: 1.
-		
-	ctx := Context 
+
+	ctx := Context
 		sender: nil
 		receiver: nil
-		method: (Object>>#at: )
+		method: Object >> #at:
 		arguments: #(10).
-	
-	resultSimu := ctx 
+
+	resultSimu := ctx
 		push: nil;
 		push: 500;
-		doPrimitive: 117  method:  (self class>>#veryBasicAt:) receiver: self args: #(999).
-		
-	self assert: resultSimu isArray.	
-	self assert: Context  primitiveFailToken first == resultSimu first.
-	self assert: result equals: resultSimu second.
+		doPrimitive: 117
+			method: self class >> #veryBasicAt:
+			receiver: self
+			args: #(999).
+
+	self assert: resultSimu isArray.
+	self assert: Context primitiveFailToken first identicalTo: resultSimu first.
+	self assert: result equals: resultSimu second
 ]
 
 { #category : #'tests - primitives' }
 CodeSimulationTest >> testErrorCodeNotFoundIndexed [
 	| ctx result resultSimu |
-	
-	Smalltalk vm isRunningCog ifFalse: [^self].
-	
+	Smalltalk vm isRunningCog ifFalse: [ ^ self ].
+
 	result := self indexedBasicAt: 100.
-		
-	ctx := Context 
+
+	ctx := Context
 		sender: nil
 		receiver: nil
-		method: (Object>>#at: )
+		method: Object >> #at:
 		arguments: #(10).
-	
-	resultSimu := ctx 
+
+	resultSimu := ctx
 		push: nil;
 		push: 500;
-		doPrimitive: 60  method:  (self class>>#indexedBasicAt:) receiver: self args: #(100).
-		
-	self assert: resultSimu isArray.	
+		doPrimitive: 60
+			method: self class >> #indexedBasicAt:
+			receiver: self
+			args: #(100).
+
+	self assert: resultSimu isArray.
 	self assert: resultSimu size equals: 2.
-	self assert: Context  primitiveFailToken first == resultSimu first.
-	self assert: result equals: resultSimu second.
+	self assert: Context primitiveFailToken first identicalTo: resultSimu first.
+	self assert: result equals: resultSimu second
 ]
 
 { #category : #'tests - primitives' }
 CodeSimulationTest >> testErrorToken [
 	| token1 token2 |
-	
 	token1 := Context primitiveFailToken.
 	token2 := Context primitiveFailTokenFor: 100.
 
-	self assert: token1 first == token2 first.
+	self assert: token1 first identicalTo: token2 first.
 	self assert: token1 second isNil.
-	self assert: token2 second equals: 100.
+	self assert: token2 second equals: 100
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -189,14 +189,15 @@ CompiledMethodTest >> testComparison [
 
 	self assert: method1 equals: method1.
 	self assert: method2 equals: method2.
-	self deny: method1 = method2.
-	self deny: method2 = method1.
-	
-	Object methods do: [ :each |
-		self deny: method1 = each.
-		self deny: each = method1.
-		self deny: method2 = each.
-		self deny: each = method2 ]
+	self deny: method1 equals: method2.
+	self deny: method2 equals: method1.
+
+	Object methods
+		do: [ :each | 
+			self deny: method1 equals: each.
+			self deny: each equals: method1.
+			self deny: method2 equals: each.
+			self deny: each equals: method2 ]
 ]
 
 { #category : #'as yet unclassified' }
@@ -216,15 +217,10 @@ CompiledMethodTest >> testCopy [
 	self assert: method header equals: copy header.
 	self assert: method equals: copy.
 	self assert: method ~~ copy.
-	self assert: copy penultimateLiteral method == copy.
-	self assert: method penultimateLiteral method == method.
-	method pragmas do:
-		[:p|
-		self assert: p method == method].
-	copy pragmas do:
-		[:p|
-		self assert: p method == copy]
-
+	self assert: copy penultimateLiteral method identicalTo: copy.
+	self assert: method penultimateLiteral method identicalTo: method.
+	method pragmas do: [ :p | self assert: p method identicalTo: method ].
+	copy pragmas do: [ :p | self assert: p method identicalTo: copy ]
 ]
 
 { #category : #tests }
@@ -235,18 +231,13 @@ CompiledMethodTest >> testCopyWithTrailerBytes [
 	self assert: method pragmas notEmpty.
 	copy := method copyWithTrailerBytes: method trailer.
 	self assert: (method equivalentTo: copy).
-	self deny: method == copy.
-	self assert: method symbolic equals: copy symbolic. "but their bytecode should be the same"
+	self deny: method identicalTo: copy.
+	self assert: method symbolic equals: copy symbolic.	"but their bytecode should be the same"
 	self assert: method ~~ copy.
-	self assert: copy penultimateLiteral method == copy.
-	self assert: method penultimateLiteral method == method.
-	method pragmas do:
-		[:p|
-		self assert: p method == method].
-	copy pragmas do:
-		[:p|
-		self assert: p method == copy]
-
+	self assert: copy penultimateLiteral method identicalTo: copy.
+	self assert: method penultimateLiteral method identicalTo: method.
+	method pragmas do: [ :p | self assert: p method identicalTo: method ].
+	copy pragmas do: [ :p | self assert: p method identicalTo: copy ]
 ]
 
 { #category : #'as yet unclassified' }
@@ -266,15 +257,12 @@ CompiledMethodTest >> testEqualityClassSideMethod [
 
 { #category : #'as yet unclassified' }
 CompiledMethodTest >> testEqualityInstanceSideMethod [
-   	| method1 method2 |
+	| method1 method2 |
+	method1 := TestCase compiler compile: 'aMethod'.
+	method2 := TestCase compiler compile: 'aMethod'.
 
-	method1 :=  TestCase compiler compile: 'aMethod'.
-	method2 :=  TestCase compiler compile: 'aMethod'.
-
-	self assert: (method1 literalAt: method1 numLiterals) ==  (method2 literalAt: method2 numLiterals).
- 	self assert: method1 equals: method2.
-
-
+	self assert: (method1 literalAt: method1 numLiterals) identicalTo: (method2 literalAt: method2 numLiterals).
+	self assert: method1 equals: method2
 ]
 
 { #category : #'tests - instance variable' }
@@ -397,16 +385,14 @@ CompiledMethodTest >> testMethodClass [
 { #category : #'tests - accessing' }
 CompiledMethodTest >> testOrigin [
 	| regularMethod methodFromTrait |
-
 	"Regular method"
-	regularMethod := Behavior>>#name.
-	
+	regularMethod := Behavior >> #name.
+
 	"Method from a trait without alias "
-	methodFromTrait := Behavior>>#adoptInstance:.
+	methodFromTrait := Behavior >> #adoptInstance:.
 
-	self assert: regularMethod origin == regularMethod originMethod methodClass.
-	self assert: methodFromTrait origin == methodFromTrait originMethod methodClass.
-
+	self assert: regularMethod origin identicalTo: regularMethod originMethod methodClass.
+	self assert: methodFromTrait origin identicalTo: methodFromTrait originMethod methodClass
 ]
 
 { #category : #'tests - performing' }
@@ -470,35 +456,29 @@ CompiledMethodTest >> testReadsSlot [
 
 { #category : #'as yet unclassified' }
 CompiledMethodTest >> testSelector [
+	Author
+		useAuthor: 'TUTU_TEST'
+		during: [ | method cls |
+			method := self class >> #returnTrue.
+			self assert: method selector equals: #returnTrue.
 
-	Author useAuthor: 'TUTU_TEST' during: [ 
-		
-		|  method cls |
-		
-		method := (self class)>>#returnTrue.
-		self assert: method selector equals: #returnTrue.
-		
-		"now make an orphaned method. new semantics: return corrent name"	
-		Smalltalk removeClassNamed: #TUTU.
+			"now make an orphaned method. new semantics: return corrent name"
+			Smalltalk removeClassNamed: #TUTU.
 
-		cls := Object subclass: #TUTU
-			instanceVariableNames: ''
-			classVariableNames: ''
-			poolDictionaries: ''
-			category: self categoryNameForTemporaryClasses.
-		
-		cls compile: 'foo ^ 10'.
-		
-		method := cls >> #foo.
-		
-		Smalltalk removeClassNamed: #TUTU.
+			cls := Object
+				subclass: #TUTU
+				instanceVariableNames: ''
+				classVariableNames: ''
+				poolDictionaries: ''
+				category: self categoryNameForTemporaryClasses.
 
-		self assert: method selector = #foo. 
-		
-	].
-	
+			cls compile: 'foo ^ 10'.
 
+			method := cls >> #foo.
 
+			Smalltalk removeClassNamed: #TUTU.
+
+			self assert: method selector equals: #foo ]
 ]
 
 { #category : #'tests - testing' }

--- a/src/Kernel-Tests-Extended/CompiledMethodTrailerTest.extension.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTrailerTest.extension.st
@@ -2,16 +2,14 @@ Extension { #name : #CompiledMethodTrailerTest }
 
 { #category : #'*Kernel-Tests-Extended' }
 CompiledMethodTrailerTest >> testEmbeddingCompressedSourceCode [
-
 	| trailer newTrailer code |
-	
 	trailer := CompiledMethodTrailer new.
-	
+
 	code := 'foo'.
 	trailer compressSourceCode: code.
 	newTrailer := trailer testEncoding.
-	
-	self assert: (trailer kind == #EmbeddedSourceQCompress ).
+
+	self assert: trailer kind identicalTo: #EmbeddedSourceQCompress.
 	self assert: newTrailer sourceCode equals: code.
 
 	"the last bytecode index must be at 0"
@@ -29,9 +27,9 @@ CompiledMethodTrailerTest >> testEmbeddingCompressedSourceCode [
 	self assert: newTrailer sourceCode equals: code.'.
 
 	trailer compressSourceCode: code.
-	self assert: (trailer kind == #EmbeddedSourceZip ).
+	self assert: trailer kind identicalTo: #EmbeddedSourceZip.
 	newTrailer := trailer testEncoding.
-	
+
 	self assert: newTrailer sourceCode equals: code.
 	"the last bytecode index must be at 0"
 	self assert: newTrailer endPC equals: 0

--- a/src/Kernel-Tests-Extended/ContextTest.extension.st
+++ b/src/Kernel-Tests-Extended/ContextTest.extension.st
@@ -43,9 +43,8 @@ ContextTest >> testLookupSymbol [
 { #category : #'*Kernel-Tests-Extended' }
 ContextTest >> testSourceNodeExecuted [
 	| sourceNode |
-	
 	sourceNode := thisContext sender sender sourceNodeExecuted.
-	self assert: sourceNode selector = #performTest.
+	self assert: sourceNode selector equals: #performTest
 ]
 
 { #category : #'*Kernel-Tests-Extended' }

--- a/src/Kernel-Tests-Extended/DateAndTimeEpochTest.extension.st
+++ b/src/Kernel-Tests-Extended/DateAndTimeEpochTest.extension.st
@@ -10,13 +10,10 @@ DateAndTimeEpochTest >> testAsMonth [
 
 { #category : #'*Kernel-Tests-Extended' }
 DateAndTimeEpochTest >> testAsWeek [
-	self assert: aDateAndTime asWeek = (Week starting: '12-31-1900' asDate). 
-
-
+	self assert: aDateAndTime asWeek equals: (Week starting: '12-31-1900' asDate)
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
 DateAndTimeEpochTest >> testAsYear [
-	self assert: aDateAndTime asYear =   (Year starting: '01-01-1901' asDate). 
-
+	self assert: aDateAndTime asYear equals: (Year starting: '01-01-1901' asDate)
 ]

--- a/src/Kernel-Tests-Extended/DateAndTimeUnixEpochTest.extension.st
+++ b/src/Kernel-Tests-Extended/DateAndTimeUnixEpochTest.extension.st
@@ -10,13 +10,10 @@ DateAndTimeUnixEpochTest >> testAsMonth [
 
 { #category : #'*Kernel-Tests-Extended' }
 DateAndTimeUnixEpochTest >> testAsWeek [
-	self assert: aDateAndTime asWeek = (Week starting: '12-31-1969' asDate). 
-
-
+	self assert: aDateAndTime asWeek equals: (Week starting: '12-31-1969' asDate)
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
 DateAndTimeUnixEpochTest >> testAsYear [
-	self assert: aDateAndTime asYear =   (Year starting: '01-01-1970' asDate). 
-
+	self assert: aDateAndTime asYear equals: (Year starting: '01-01-1970' asDate)
 ]

--- a/src/Kernel-Tests-Extended/DurationTest.extension.st
+++ b/src/Kernel-Tests-Extended/DurationTest.extension.st
@@ -2,53 +2,49 @@ Extension { #name : #DurationTest }
 
 { #category : #'*Kernel-Tests-Extended' }
 DurationTest >> testAsDays [
-	self assert: (Duration days: 2) asDays = 2.
-	self assert: (Duration weeks: 1) asDays = 7.	
-	self assert: (aDuration asDays closeTo: 1.08546).
+	self assert: (Duration days: 2) asDays equals: 2.
+	self assert: (Duration weeks: 1) asDays equals: 7.
+	self assert: (aDuration asDays closeTo: 1.08546)
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
 DurationTest >> testAsHour [
-	|full half quarter|
-	full := (Duration minutes: 60).
-	half := (Duration minutes: 30).
-	quarter := (Duration minutes: 15).	
-	self 
-		assert: 1 hour = full;
-		assert: 1.0 hour = full;
-		assert: 0.5 hour = half; 
-		assert: (1/2) hour = half;
-		assert: (1/4) hour = quarter
+	| full half quarter |
+	full := Duration minutes: 60.
+	half := Duration minutes: 30.
+	quarter := Duration minutes: 15.
+	self
+		assert: 1 hour equals: full;
+		assert: 1.0 hour equals: full;
+		assert: 0.5 hour equals: half;
+		assert: (1 / 2) hour equals: half;
+		assert: (1 / 4) hour equals: quarter
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
 DurationTest >> testAsHours [
-	self assert: (Duration hours: 2) asHours = 2.
-	self assert: (Duration days: 1) asHours = 24.	
-	self assert: (aDuration asHours closeTo: 26.0511).
+	self assert: (Duration hours: 2) asHours equals: 2.
+	self assert: (Duration days: 1) asHours equals: 24.
+	self assert: (aDuration asHours closeTo: 26.0511)
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
 DurationTest >> testAsMinutes [
-	self assert: (Duration seconds: 60) asMinutes = 1.
-	self assert: (Duration hours: 1) asMinutes = 60.	
-	self assert: (aDuration asMinutes closeTo:  1563.0666).
-	self assert: ((Duration milliSeconds: 100) asMinutes closeTo: (1/600))
+	self assert: (Duration seconds: 60) asMinutes equals: 1.
+	self assert: (Duration hours: 1) asMinutes equals: 60.
+	self assert: (aDuration asMinutes closeTo: 1563.0666).
+	self assert: ((Duration milliSeconds: 100) asMinutes closeTo: 1 / 600)
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
 DurationTest >> testMonthDurations [
-
 	| jan feb dec |
 	jan := Duration month: #January.
 	feb := Duration month: #February.
 	dec := Duration month: #December.
-	
-	self 
-		assert: jan = (Year current months first duration);
-		assert: feb = (Year current months second duration);
-		assert: dec = (Year current months last duration)
 
-		
-
+	self
+		assert: jan equals: Year current months first duration;
+		assert: feb equals: Year current months second duration;
+		assert: dec equals: Year current months last duration
 ]

--- a/src/Kernel-Tests-Extended/FractionTest.extension.st
+++ b/src/Kernel-Tests-Extended/FractionTest.extension.st
@@ -103,11 +103,11 @@ FractionTest >> testExactSqrt [
 
 { #category : #'*Kernel-Tests-Extended' }
 FractionTest >> testFloorLog [
-	self assert: (1/100 floorLog: 10) = -2.
-	self assert: (((2 raisedTo: Float emax + 11)/3) floorLog: 10)
-		= ((Float emax + 11)*2 log - 3 log) floor description: 'Fraction>>log should not overflow'.
-	self assert: ((3/(2 raisedTo: Float precision - Float emin)) floorLog: 10)
-		= ((Float emin - Float precision)*2 log + 3 log) floor description: 'Fraction>>log should not underflow'
+	self assert: (1 / 100 floorLog: 10) equals: -2.
+	self assert: ((2 raisedTo: Float emax + 11) / 3 floorLog: 10) = ((Float emax + 11) * 2 log - 3 log) floor description: 'Fraction>>log should not overflow'.
+	self
+		assert: (3 / (2 raisedTo: Float precision - Float emin) floorLog: 10) = ((Float emin - Float precision) * 2 log + 3 log) floor
+		description: 'Fraction>>log should not underflow'
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
@@ -115,8 +115,9 @@ FractionTest >> testInexactRaisedTo [
 	"
 	FractionTest new testInexactRaisedTo
 	"
-	self assert: (((1 << 1024 + 1) / (1 << 1024 + 3)) raisedTo: 1/3) = 1.0.
-	self assert: (((1 << 1024 + 1) / (1 << 1024 + 3)) negated raisedTo: 1/3) = -1.0
+
+	self assert: (((1 << 1024) + 1) / ((1 << 1024) + 3) raisedTo: 1 / 3) equals: 1.0.
+	self assert: ((((1 << 1024) + 1) / ((1 << 1024) + 3)) negated raisedTo: 1 / 3) equals: -1.0
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
@@ -124,7 +125,8 @@ FractionTest >> testInexactSqrt [
 	"
 	FractionTest new testInexactSqrt
 	"
-	self assert: ((1 << 1024 + 1) / (1 << 1024 + 3)) sqrt = 1.0
+
+	self assert: (((1 << 1024) + 1) / ((1 << 1024) + 3)) sqrt equals: 1.0
 ]
 
 { #category : #'*Kernel-Tests-Extended' }

--- a/src/Kernel-Tests-Extended/IntegerTest.extension.st
+++ b/src/Kernel-Tests-Extended/IntegerTest.extension.st
@@ -2,11 +2,9 @@ Extension { #name : #IntegerTest }
 
 { #category : #'*Kernel-Tests-Extended' }
 IntegerTest >> testBenchFib [
-
-	self assert: (0 benchFib = 1).
-	self assert: (1 benchFib = 1).
-	self assert: (2 benchFib = 3).
-	
+	self assert: 0 benchFib equals: 1.
+	self assert: 1 benchFib equals: 1.
+	self assert: 2 benchFib equals: 3
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
@@ -17,14 +15,15 @@ IntegerTest >> testBigReceiverInexactNthRoot [
 
 	"Inexact 3rd root (not a whole cube number), so a Float must be answered.
 	However, receiver is too big for Float arithmethic."
+
 	| bigNum result |
-	bigNum := (100 factorial raisedTo: 3) + 1.		"Add 1 so it is not a whole cube"
-	self assert: bigNum asFloat isInfinite.			"Otherwise, we chose a bad sample"
+	bigNum := (100 factorial raisedTo: 3) + 1.	"Add 1 so it is not a whole cube"
+	self assert: bigNum asFloat isInfinite.	"Otherwise, we chose a bad sample"
 	result := bigNum nthRoot: 3.
 	self assert: result isFloat.
 	self deny: result isInfinite.
-	self assert: result = 100 factorial asFloat.		"No other float is closer. See following line"
-	self assert: 100 factorial asFloat = (100 factorial+1) asFloat
+	self assert: result equals: 100 factorial asFloat.	"No other float is closer. See following line"
+	self assert: 100 factorial asFloat equals: (100 factorial + 1) asFloat
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
@@ -35,15 +34,16 @@ IntegerTest >> testBigReceiverInexactSqrt [
 
 	"Inexact 3rd root (not a whole cube number), so a Float must be answered.
 	However, receiver is too big for Float arithmethic."
+
 	| bigNum result |
-	bigNum := 100 factorial squared + 1.		"Add 1 so it is not a whole square"
-	self assert: bigNum asFloat isInfinite.			"Otherwise, we chose a bad sample"
+	bigNum := 100 factorial squared + 1.	"Add 1 so it is not a whole square"
+	self assert: bigNum asFloat isInfinite.	"Otherwise, we chose a bad sample"
 	result := bigNum sqrt.
 	self assert: result isFloat.
 	self deny: result isInfinite.
-	self assert: result = 100 factorial asFloat.		"No other float is closer. See following lines"
+	self assert: result equals: 100 factorial asFloat.	"No other float is closer. See following lines"
 	self assert: (result successor asFraction squared - bigNum) abs >= (result asFraction squared - bigNum) abs.
-	self assert: (result predecessor asFraction squared - bigNum) abs >= (result asFraction squared - bigNum) abs.
+	self assert: (result predecessor asFraction squared - bigNum) abs >= (result asFraction squared - bigNum) abs
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
@@ -173,8 +173,8 @@ IntegerTest >> testExactSqrt [
 
 { #category : #'*Kernel-Tests-Extended' }
 IntegerTest >> testFloorLog [
-	self assert: (100 floorLog: 10) = 2.
-	self assert: (((2 raisedTo: Float emax + 3) floorLog: 10) = (2 log*(Float emax + 3)) floor) description: 'Integer>>floorLog: should not overflow'
+	self assert: (100 floorLog: 10) equals: 2.
+	self assert: ((2 raisedTo: Float emax + 3) floorLog: 10) = (2 log * (Float emax + 3)) floor description: 'Integer>>floorLog: should not overflow'
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
@@ -232,14 +232,10 @@ IntegerTest >> testIsProbablyPrime [
 
 { #category : #'*Kernel-Tests-Extended' }
 IntegerTest >> testLargePrimesUpTo [
-
-	| nn | 
-	nn := (2 raisedTo: 17) - 1. 
-	self deny: (Integer primesUpTo: nn) last = nn.
-	self assert: (Integer primesUpTo: nn + 1) last  = nn.
-	
-	
-
+	| nn |
+	nn := (2 raisedTo: 17) - 1.
+	self deny: (Integer primesUpTo: nn) last equals: nn.
+	self assert: (Integer primesUpTo: nn + 1) last equals: nn
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
@@ -302,113 +298,111 @@ IntegerTest >> testNthRootTruncated [
 
 { #category : #'*Kernel-Tests-Extended' }
 IntegerTest >> testPrimesUpTo [
-
-	| primes nn|
+	| primes nn |
 	primes := Integer primesUpTo: 100.
-	self assert: primes = #(2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97).
-	
+	self assert: primes equals: #(2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97).
+
 	"upTo: semantics means 'non-inclusive'"
 	primes := Integer primesUpTo: 5.
-	self assert: primes = #(2 3).
-	
+	self assert: primes equals: #(2 3).
+
 	"this test is green for nn>25000, see #testLargePrimesUpTo"
-	nn := 5. 
-	self deny: (Integer primesUpTo: nn) last = nn.
-	self assert: (Integer primesUpTo: nn + 1) last  = nn.
+	nn := 5.
+	self deny: (Integer primesUpTo: nn) last equals: nn.
+	self assert: (Integer primesUpTo: nn + 1) last equals: nn
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
 IntegerTest >> testRomanPrinting [
-	self assert: 0 printStringRoman = ''. "No symbol for zero"
-	self assert: 1 printStringRoman = 'I'.
-	self assert: 2 printStringRoman = 'II'.
-	self assert: 3 printStringRoman = 'III'.
-	self assert: 4 printStringRoman = 'IV'.
-	self assert: 5 printStringRoman = 'V'.
-	self assert: 6 printStringRoman = 'VI'.
-	self assert: 7 printStringRoman = 'VII'.
-	self assert: 8 printStringRoman = 'VIII'.
-	self assert: 9 printStringRoman = 'IX'.
-	self assert: 10 printStringRoman = 'X'.
-	self assert: 23 printStringRoman = 'XXIII'.
-	self assert: 36 printStringRoman = 'XXXVI'.
-	self assert: 49 printStringRoman = 'XLIX'.
-	self assert: 62 printStringRoman = 'LXII'.
-	self assert: 75 printStringRoman = 'LXXV'.
-	self assert: 88 printStringRoman = 'LXXXVIII'.
-	self assert: 99 printStringRoman = 'XCIX'.
-	self assert: 100 printStringRoman = 'C'.
-	self assert: 101 printStringRoman = 'CI'.
-	self assert: 196 printStringRoman = 'CXCVI'.
-	self assert: 197 printStringRoman = 'CXCVII'.
-	self assert: 198 printStringRoman = 'CXCVIII'.
-	self assert: 293 printStringRoman = 'CCXCIII'.
-	self assert: 294 printStringRoman = 'CCXCIV'.
-	self assert: 295 printStringRoman = 'CCXCV'.
-	self assert: 390 printStringRoman = 'CCCXC'.
-	self assert: 391 printStringRoman = 'CCCXCI'.
-	self assert: 392 printStringRoman = 'CCCXCII'.
-	self assert: 487 printStringRoman = 'CDLXXXVII'.
-	self assert: 488 printStringRoman = 'CDLXXXVIII'.
-	self assert: 489 printStringRoman = 'CDLXXXIX'.
-	self assert: 584 printStringRoman = 'DLXXXIV'.
-	self assert: 585 printStringRoman = 'DLXXXV'.
-	self assert: 586 printStringRoman = 'DLXXXVI'.
-	self assert: 681 printStringRoman = 'DCLXXXI'.
-	self assert: 682 printStringRoman = 'DCLXXXII'.
-	self assert: 683 printStringRoman = 'DCLXXXIII'.
-	self assert: 778 printStringRoman = 'DCCLXXVIII'.
-	self assert: 779 printStringRoman = 'DCCLXXIX'.
-	self assert: 780 printStringRoman = 'DCCLXXX'.
-	self assert: 875 printStringRoman = 'DCCCLXXV'.
-	self assert: 876 printStringRoman = 'DCCCLXXVI'.
-	self assert: 877 printStringRoman = 'DCCCLXXVII'.
-	self assert: 972 printStringRoman = 'CMLXXII'.
-	self assert: 973 printStringRoman = 'CMLXXIII'.
-	self assert: 974 printStringRoman = 'CMLXXIV'.
-	self assert: 1069 printStringRoman = 'MLXIX'.
-	self assert: 1070 printStringRoman = 'MLXX'.
-	self assert: 1071 printStringRoman = 'MLXXI'.
-	self assert: 1166 printStringRoman = 'MCLXVI'.
-	self assert: 1167 printStringRoman = 'MCLXVII'.
-	self assert: 1168 printStringRoman = 'MCLXVIII'.
-	self assert: 1263 printStringRoman = 'MCCLXIII'.
-	self assert: 1264 printStringRoman = 'MCCLXIV'.
-	self assert: 1265 printStringRoman = 'MCCLXV'.
-	self assert: 1360 printStringRoman = 'MCCCLX'.
-	self assert: 1361 printStringRoman = 'MCCCLXI'.
-	self assert: 1362 printStringRoman = 'MCCCLXII'.
-	self assert: 1457 printStringRoman = 'MCDLVII'.
-	self assert: 1458 printStringRoman = 'MCDLVIII'.
-	self assert: 1459 printStringRoman = 'MCDLIX'.
-	self assert: 1554 printStringRoman = 'MDLIV'.
-	self assert: 1555 printStringRoman = 'MDLV'.
-	self assert: 1556 printStringRoman = 'MDLVI'.
-	self assert: 1651 printStringRoman = 'MDCLI'.
-	self assert: 1652 printStringRoman = 'MDCLII'.
-	self assert: 1653 printStringRoman = 'MDCLIII'.
-	self assert: 1748 printStringRoman = 'MDCCXLVIII'.
-	self assert: 1749 printStringRoman = 'MDCCXLIX'.
-	self assert: 1750 printStringRoman = 'MDCCL'.
-	self assert: 1845 printStringRoman = 'MDCCCXLV'.
-	self assert: 1846 printStringRoman = 'MDCCCXLVI'.
-	self assert: 1847 printStringRoman = 'MDCCCXLVII'.
-	self assert: 1942 printStringRoman = 'MCMXLII'.
-	self assert: 1943 printStringRoman = 'MCMXLIII'.
-	self assert: 1944 printStringRoman = 'MCMXLIV'.
-	self assert: 2004 printStringRoman = 'MMIV'.
+	self assert: 0 printStringRoman equals: ''.	"No symbol for zero"
+	self assert: 1 printStringRoman equals: 'I'.
+	self assert: 2 printStringRoman equals: 'II'.
+	self assert: 3 printStringRoman equals: 'III'.
+	self assert: 4 printStringRoman equals: 'IV'.
+	self assert: 5 printStringRoman equals: 'V'.
+	self assert: 6 printStringRoman equals: 'VI'.
+	self assert: 7 printStringRoman equals: 'VII'.
+	self assert: 8 printStringRoman equals: 'VIII'.
+	self assert: 9 printStringRoman equals: 'IX'.
+	self assert: 10 printStringRoman equals: 'X'.
+	self assert: 23 printStringRoman equals: 'XXIII'.
+	self assert: 36 printStringRoman equals: 'XXXVI'.
+	self assert: 49 printStringRoman equals: 'XLIX'.
+	self assert: 62 printStringRoman equals: 'LXII'.
+	self assert: 75 printStringRoman equals: 'LXXV'.
+	self assert: 88 printStringRoman equals: 'LXXXVIII'.
+	self assert: 99 printStringRoman equals: 'XCIX'.
+	self assert: 100 printStringRoman equals: 'C'.
+	self assert: 101 printStringRoman equals: 'CI'.
+	self assert: 196 printStringRoman equals: 'CXCVI'.
+	self assert: 197 printStringRoman equals: 'CXCVII'.
+	self assert: 198 printStringRoman equals: 'CXCVIII'.
+	self assert: 293 printStringRoman equals: 'CCXCIII'.
+	self assert: 294 printStringRoman equals: 'CCXCIV'.
+	self assert: 295 printStringRoman equals: 'CCXCV'.
+	self assert: 390 printStringRoman equals: 'CCCXC'.
+	self assert: 391 printStringRoman equals: 'CCCXCI'.
+	self assert: 392 printStringRoman equals: 'CCCXCII'.
+	self assert: 487 printStringRoman equals: 'CDLXXXVII'.
+	self assert: 488 printStringRoman equals: 'CDLXXXVIII'.
+	self assert: 489 printStringRoman equals: 'CDLXXXIX'.
+	self assert: 584 printStringRoman equals: 'DLXXXIV'.
+	self assert: 585 printStringRoman equals: 'DLXXXV'.
+	self assert: 586 printStringRoman equals: 'DLXXXVI'.
+	self assert: 681 printStringRoman equals: 'DCLXXXI'.
+	self assert: 682 printStringRoman equals: 'DCLXXXII'.
+	self assert: 683 printStringRoman equals: 'DCLXXXIII'.
+	self assert: 778 printStringRoman equals: 'DCCLXXVIII'.
+	self assert: 779 printStringRoman equals: 'DCCLXXIX'.
+	self assert: 780 printStringRoman equals: 'DCCLXXX'.
+	self assert: 875 printStringRoman equals: 'DCCCLXXV'.
+	self assert: 876 printStringRoman equals: 'DCCCLXXVI'.
+	self assert: 877 printStringRoman equals: 'DCCCLXXVII'.
+	self assert: 972 printStringRoman equals: 'CMLXXII'.
+	self assert: 973 printStringRoman equals: 'CMLXXIII'.
+	self assert: 974 printStringRoman equals: 'CMLXXIV'.
+	self assert: 1069 printStringRoman equals: 'MLXIX'.
+	self assert: 1070 printStringRoman equals: 'MLXX'.
+	self assert: 1071 printStringRoman equals: 'MLXXI'.
+	self assert: 1166 printStringRoman equals: 'MCLXVI'.
+	self assert: 1167 printStringRoman equals: 'MCLXVII'.
+	self assert: 1168 printStringRoman equals: 'MCLXVIII'.
+	self assert: 1263 printStringRoman equals: 'MCCLXIII'.
+	self assert: 1264 printStringRoman equals: 'MCCLXIV'.
+	self assert: 1265 printStringRoman equals: 'MCCLXV'.
+	self assert: 1360 printStringRoman equals: 'MCCCLX'.
+	self assert: 1361 printStringRoman equals: 'MCCCLXI'.
+	self assert: 1362 printStringRoman equals: 'MCCCLXII'.
+	self assert: 1457 printStringRoman equals: 'MCDLVII'.
+	self assert: 1458 printStringRoman equals: 'MCDLVIII'.
+	self assert: 1459 printStringRoman equals: 'MCDLIX'.
+	self assert: 1554 printStringRoman equals: 'MDLIV'.
+	self assert: 1555 printStringRoman equals: 'MDLV'.
+	self assert: 1556 printStringRoman equals: 'MDLVI'.
+	self assert: 1651 printStringRoman equals: 'MDCLI'.
+	self assert: 1652 printStringRoman equals: 'MDCLII'.
+	self assert: 1653 printStringRoman equals: 'MDCLIII'.
+	self assert: 1748 printStringRoman equals: 'MDCCXLVIII'.
+	self assert: 1749 printStringRoman equals: 'MDCCXLIX'.
+	self assert: 1750 printStringRoman equals: 'MDCCL'.
+	self assert: 1845 printStringRoman equals: 'MDCCCXLV'.
+	self assert: 1846 printStringRoman equals: 'MDCCCXLVI'.
+	self assert: 1847 printStringRoman equals: 'MDCCCXLVII'.
+	self assert: 1942 printStringRoman equals: 'MCMXLII'.
+	self assert: 1943 printStringRoman equals: 'MCMXLIII'.
+	self assert: 1944 printStringRoman equals: 'MCMXLIV'.
+	self assert: 2004 printStringRoman equals: 'MMIV'.
 
-	self assert: -1 printStringRoman = '-I'.
-	self assert: -2 printStringRoman = '-II'.
-	self assert: -3 printStringRoman = '-III'.
-	self assert: -4 printStringRoman = '-IV'.
-	self assert: -5 printStringRoman = '-V'.
-	self assert: -6 printStringRoman = '-VI'.
-	self assert: -7 printStringRoman = '-VII'.
-	self assert: -8 printStringRoman = '-VIII'.
-	self assert: -9 printStringRoman = '-IX'.
-	self assert: -10 printStringRoman = '-X'.
-
+	self assert: -1 printStringRoman equals: '-I'.
+	self assert: -2 printStringRoman equals: '-II'.
+	self assert: -3 printStringRoman equals: '-III'.
+	self assert: -4 printStringRoman equals: '-IV'.
+	self assert: -5 printStringRoman equals: '-V'.
+	self assert: -6 printStringRoman equals: '-VI'.
+	self assert: -7 printStringRoman equals: '-VII'.
+	self assert: -8 printStringRoman equals: '-VIII'.
+	self assert: -9 printStringRoman equals: '-IX'.
+	self assert: -10 printStringRoman equals: '-X'
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
@@ -422,12 +416,7 @@ IntegerTest >> testSqrtErrorConditions [
 
 { #category : #'*Kernel-Tests-Extended' }
 IntegerTest >> testSqrtFloor [
-
-	#(-1234567890123 -10 -5 -1) do: [ :each |
-		self should: [ each sqrtFloor ] raise: Error ].
-	#(
-		0 1 2 3 4 5 10 16 30 160479924 386234481 501619156 524723498 580855366 766098594 834165249 1020363860 1042083924 1049218924
-		1459774772895569 3050005981408238 4856589481837079 5650488387708463 7831037396100244) do: [ :each |
-			self assert: each asFloat sqrt floor = each sqrtFloor ]
-		
+	#(-1234567890123 -10 -5 -1) do: [ :each | self should: [ each sqrtFloor ] raise: Error ].
+	#(0 1 2 3 4 5 10 16 30 160479924 386234481 501619156 524723498 580855366 766098594 834165249 1020363860 1042083924 1049218924 1459774772895569 3050005981408238 4856589481837079 5650488387708463 7831037396100244)
+		do: [ :each | self assert: each asFloat sqrt floor equals: each sqrtFloor ]
 ]

--- a/src/Kernel-Tests-Extended/MonthTest.class.st
+++ b/src/Kernel-Tests-Extended/MonthTest.class.st
@@ -44,8 +44,7 @@ MonthTest >> tearDown [
 
 { #category : #tests }
 MonthTest >> testConverting [
-
-	self assert: month asDate = '1 July 1998' asDate
+	self assert: month asDate equals: '1 July 1998' asDate
 ]
 
 { #category : #tests }
@@ -58,54 +57,46 @@ MonthTest >> testEnumerating [
 ]
 
 { #category : #tests }
-MonthTest >> testIndexOfMonth [	
-       | m |
-       m := #(#January #February #March #April #May #June #July #August
-#September #October #November #December).
+MonthTest >> testIndexOfMonth [
+	| m |
+	m := #(#January #February #March #April #May #June #July #August #September #October #November #December).
 
-       m withIndexDo: [:item :index | self assert: (Month indexOfMonth:
-item) = index].
+	m withIndexDo: [ :item :index | self assert: (Month indexOfMonth: item) equals: index ].
 
-       self should: [Month indexOfMonth: 1] raise: self defaultTestError.
-       self should: [Month indexOfMonth: #Marsh] raise: self defaultTestError.
-"notice the misspell!!"
-       self should: [Month indexOfMonth: #UnexistingMonth] raise:
- self defaultTestError.
+	self should: [ Month indexOfMonth: 1 ] raise: self defaultTestError.
+	self should: [ Month indexOfMonth: #Marsh ] raise: self defaultTestError.
+	"notice the misspell!!"
+	self should: [ Month indexOfMonth: #UnexistingMonth ] raise: self defaultTestError
 ]
 
 { #category : #tests }
 MonthTest >> testInquiries [
-
-	self 
-		assert: month index = 7;
-		assert: month name = #July;
-		assert: month duration = (31 days).
-
+	self
+		assert: month index equals: 7;
+		assert: month name equals: #July;
+		assert: month duration equals: 31 days
 ]
 
 { #category : #tests }
 MonthTest >> testInstanceCreation [
 	| m1 m2 |
-	m1 := Month starting:  '4 July 1998' asDate.
-	m2 := Month year: 1998 month: #July .
+	m1 := Month starting: '4 July 1998' asDate.
+	m2 := Month year: 1998 month: #July.
 	self
-		assert: month = m1;
-		assert: month = m2
+		assert: month equals: m1;
+		assert: month equals: m2
 ]
 
 { #category : #tests }
 MonthTest >> testNameOfMonth [
+	| m |
+	m := #(#January #February #March #April #May #June #July #August #September #October #November #December).
 
-       | m |
-       m := #(#January #February #March #April #May #June #July #August
-#September #October #November #December).
+	m withIndexDo: [ :item :index | self assert: (Month nameOfMonth: index) equals: item ].
 
-       m withIndexDo: [:item :index | self assert: (Month nameOfMonth:
-index) = item].
-
-       self should: [Month nameOfMonth: 0] raise: self defaultTestError.
-       self should: [Month nameOfMonth: 13] raise: self defaultTestError.
-       self should: [Month nameOfMonth: #January] raise: self defaultTestError.
+	self should: [ Month nameOfMonth: 0 ] raise: self defaultTestError.
+	self should: [ Month nameOfMonth: 13 ] raise: self defaultTestError.
+	self should: [ Month nameOfMonth: #January ] raise: self defaultTestError
 ]
 
 { #category : #tests }
@@ -126,27 +117,20 @@ MonthTest >> testPreviousNext [
 	p := month previous.
 
 	self
-		assert: n year = 1998;
-		assert: n index = 8;
-		assert: p year = 1998;
-		assert: p index = 6.
-
-
+		assert: n year equals: 1998;
+		assert: n index equals: 8;
+		assert: p year equals: 1998;
+		assert: p index equals: 6
 ]
 
 { #category : #tests }
 MonthTest >> testPrinting [
-
-	self 
-		assert: month printString = 'July 1998'.
-
+	self assert: month printString equals: 'July 1998'
 ]
 
 { #category : #tests }
 MonthTest >> testReadFrom [
-
 	| m |
 	m := Month readFrom: 'July 1998' readStream.
-	self 
-		assert: m = month
+	self assert: m equals: month
 ]

--- a/src/Kernel-Tests-Extended/NumberTest.extension.st
+++ b/src/Kernel-Tests-Extended/NumberTest.extension.st
@@ -2,6 +2,5 @@ Extension { #name : #NumberTest }
 
 { #category : #'*Kernel-Tests-Extended' }
 NumberTest >> testPercent [
-
-	self assert: (20 / 40) = 50 percent
+	self assert: 20 / 40 equals: 50 percent
 ]

--- a/src/Kernel-Tests-Extended/ProcessTest.class.st
+++ b/src/Kernel-Tests-Extended/ProcessTest.class.st
@@ -41,72 +41,84 @@ ProcessTest >> testForkAtHigherPriority [
 
 { #category : #'tests - exception handlers' }
 ProcessTest >> testInjectingExceptionHandlerFromProcessItself [
-
 	| error interceptedError process interrupted |
 	DefaultExecutionEnvironment beActive.
 	error := Error new messageText: 'test error'.
 	interrupted := true.
-	process := [ Processor activeProcess on: Error do: [ :err | interceptedError := err ].
-		error signal. interrupted := false ] fork.
-	
-	[process isTerminated] whileFalse: [ Processor yield ].
+	process := [ Processor activeProcess
+		on: Error
+		do: [ :err | interceptedError := err ].
+	error signal.
+	interrupted := false ] fork.
 
-	self assert: interceptedError == error.
-	self assert: interrupted 
+	[ process isTerminated ] whileFalse: [ Processor yield ].
+
+	self assert: interceptedError identicalTo: error.
+	self assert: interrupted
 ]
 
 { #category : #'tests - exception handlers' }
 ProcessTest >> testInjectingExceptionHandlerIntoNotRunningProcess [
-
 	| error interceptedError process interrupted |
 	DefaultExecutionEnvironment beActive.
 	error := Error new messageText: 'test error'.
-	interrupted := true.	
-	process := [ error signal. interrupted := false ] newProcess.
-	process on: Error do: [ :err | interceptedError := err ].
+	interrupted := true.
+	process := [ error signal.
+	interrupted := false ] newProcess.
+	process
+		on: Error
+		do: [ :err | interceptedError := err ].
 	process resume.
-	[process isTerminated] whileFalse: [ Processor yield ].
+	[ process isTerminated ] whileFalse: [ Processor yield ].
 
-	self assert: interceptedError == error.
+	self assert: interceptedError identicalTo: error.
 	self assert: interrupted
 ]
 
 { #category : #'tests - exception handlers' }
 ProcessTest >> testInjectingExceptionHandlerIntoProcessWithArg [
-
 	| error interceptedError process interrupted processArg |
 	DefaultExecutionEnvironment beActive.
 	error := Error new messageText: 'test error'.
-	interrupted := true.	
-	process := [:arg | processArg := arg. error signal. interrupted := false ] newProcessWith: #(#arg).
-	process on: Error do: [ :err | interceptedError := err ].
+	interrupted := true.
+	process := [ :arg | 
+	processArg := arg.
+	error signal.
+	interrupted := false ] newProcessWith: #(#arg).
+	process
+		on: Error
+		do: [ :err | interceptedError := err ].
 	process resume.
-	[process isTerminated] whileFalse: [ Processor yield ].
+	[ process isTerminated ] whileFalse: [ Processor yield ].
 
-	self assert: interceptedError == error.
+	self assert: interceptedError identicalTo: error.
 	self assert: interrupted.
-	self assert: processArg equals: #arg.
+	self assert: processArg equals: #arg
 ]
 
 { #category : #'tests - exception handlers' }
 ProcessTest >> testInjectingExceptionHandlerIntoRunningProcess [
-
 	| error interceptedError process sema started interrupted |
 	DefaultExecutionEnvironment beActive.
 	error := Error new messageText: 'test error'.
 	sema := Semaphore new.
 	started := false.
 	interrupted := true.
-	process := [started := true. sema wait. error signal. interrupted := false ] newProcess.
+	process := [ started := true.
+	sema wait.
+	error signal.
+	interrupted := false ] newProcess.
 	process resume.
-	[started] whileFalse: [ Processor yield ].
-	
-	process on: Error do: [ :err | interceptedError := err ].
-	
+	[ started ] whileFalse: [ Processor yield ].
+
+	process
+		on: Error
+		do: [ :err | interceptedError := err ].
+
 	sema signal.
-	[process isTerminated] whileFalse: [ Processor yield ].
-	
-	self assert: interceptedError == error.
+	[ process isTerminated ] whileFalse: [ Processor yield ].
+
+	self assert: interceptedError identicalTo: error.
 	self assert: interrupted
 ]
 
@@ -172,8 +184,7 @@ ProcessTest >> testInjectingMultipleExceptionHandlersIntoRunningProcess [
 
 { #category : #tests }
 ProcessTest >> testIsSelfEvaluating [
-
-	self assert: Processor printString = 'Processor'
+	self assert: Processor printString equals: 'Processor'
 ]
 
 { #category : #'tests - termination' }
@@ -183,21 +194,21 @@ ProcessTest >> testIsTerminatingForcedTermination [
 	started := false.
 	terminationSemaphore := Semaphore new.
 	terminationSemaphore signal.
-	process := [ 
-		started := true.
-		[ terminationSemaphore wait; wait. ] ensure: [
-			terminator := Processor activeProcess.
+	process := [ started := true.
+	[ terminationSemaphore
+		wait;
+		wait ]
+		ensure: [ terminator := Processor activeProcess.
 			unwindChecks value.
-			unwound := true ] 
-	] newProcess.
+			unwound := true ] ] newProcess.
 	process priority: Processor activePriority - 1.
-	
+
 	self assert: process isSuspended.
 	self deny: process isTerminating.
 	self deny: process isTerminated.
 	self deny: started.
 	self deny: unwound.
-	
+
 	process resume.
 	[ terminationSemaphore isSignaled ] whileTrue: [ 50 milliSeconds asDelay wait ].
 	self deny: process isSuspended.
@@ -205,30 +216,29 @@ ProcessTest >> testIsTerminatingForcedTermination [
 	self deny: process isTerminated.
 	self assert: started.
 	self deny: unwound.
-	self deny: terminator == process.
-	
+	self deny: terminator identicalTo: process.
+
 	terminationSemaphore signal.
 	"This will run the #ensure: block and block on the Semaphore."
 	process terminate.
 	"We want these checks to run during unwinding, so we need to cheat a bit."
-	unwindChecks := [
-		self assert: process isSuspended.
-		"We're inside of #terminate."
-		self assert: process isTerminating.
-		"Still unwinding, so not finished."
-		self deny: process isTerminated.
-		self assert: started.
-		"Not unwound yet."
-		self deny: unwound.
-		self assert: terminator == process ].
-	
+	unwindChecks := [ self assert: process isSuspended.
+	"We're inside of #terminate."
+	self assert: process isTerminating.
+	"Still unwinding, so not finished."
+	self deny: process isTerminated.
+	self assert: started.
+	"Not unwound yet."
+	self deny: unwound.
+	self assert: terminator identicalTo: process ].
+
 	[ process isTerminated ] whileFalse: [ 50 milliSeconds asDelay wait ].
 	self assert: process isSuspended.
 	self assert: process isTerminating.
 	self assert: process isTerminated.
 	self assert: started.
 	self assert: unwound.
-	self assert: terminator == process
+	self assert: terminator identicalTo: process
 ]
 
 { #category : #'tests - termination' }
@@ -236,28 +246,26 @@ ProcessTest >> testIsTerminatingForcedTerminationWithoutRunning [
 	| process unwound started terminator |
 	unwound := false.
 	started := false.
-	process := [ 
-		started := true.
-		[ Semaphore new wait ] ensure: [
-			terminator := Processor activeProcess.
-			unwound := true ] 
-	] newProcess.
+	process := [ started := true.
+	[ Semaphore new wait ]
+		ensure: [ terminator := Processor activeProcess.
+			unwound := true ] ] newProcess.
 	"This will prevent the process from getting a chance to run.
 	Effectively the pc of suspendedContext will be equal to startpc."
 	process priority: Processor systemBackgroundPriority.
-	
+
 	self assert: process isSuspended.
 	self deny: process isTerminating.
 	self deny: process isTerminated.
 	self deny: started.
 	self deny: unwound.
-	
+
 	process resume.
 	self deny: process isSuspended.
 	self deny: process isTerminating.
 	self deny: process isTerminated.
 	self deny: unwound.
-	
+
 	process terminate.
 	self assert: process isSuspended.
 	self assert: process isTerminating.
@@ -266,7 +274,7 @@ ProcessTest >> testIsTerminatingForcedTerminationWithoutRunning [
 	self deny: started.
 	"No unwind blocks were ever activated, so the next two lines can't be true."
 	self deny: unwound.
-	self deny: terminator == process
+	self deny: terminator identicalTo: process
 ]
 
 { #category : #'tests - termination' }
@@ -275,18 +283,16 @@ ProcessTest >> testIsTerminatingNormalTermination [
 	sem := Semaphore new.
 	unwound := false.
 	started := false.
-	process := [ 
-		started := true.
-		[ sem wait ] ensure: [
-		terminator := Processor activeProcess.
-		unwound := true ] 
-	] fork.
+	process := [ started := true.
+	[ sem wait ]
+		ensure: [ terminator := Processor activeProcess.
+			unwound := true ] ] fork.
 	self deny: process isSuspended.
 	self deny: process isTerminating.
 	self deny: process isTerminated.
 	self deny: started.
 	self deny: unwound.
-	
+
 	sem signal.
 	self waitForProcessTermination: process.
 	"#terminate will be sent by the process itself after its context has finished (see BlockClosure>>newProcess)"
@@ -297,7 +303,7 @@ ProcessTest >> testIsTerminatingNormalTermination [
 	"When inside of an unwind context, that unwind context needs run through."
 	self assert: unwound.
 	"A process should terminte itself."
-	self assert: terminator == process
+	self assert: terminator identicalTo: process
 ]
 
 { #category : #'tests - creation' }

--- a/src/Kernel-Tests-Extended/ScaledDecimalTest.extension.st
+++ b/src/Kernel-Tests-Extended/ScaledDecimalTest.extension.st
@@ -4,13 +4,13 @@ Extension { #name : #ScaledDecimalTest }
 ScaledDecimalTest >> testExactNthRoot [
 	| eight thousandth tenth two |
 	eight := 8.0s1.
-	two := eight raisedTo: 1/3.
-	self assert: two = 2.
-	self assert: (two class = eight class and: [two scale = eight scale]).
+	two := eight raisedTo: 1 / 3.
+	self assert: two equals: 2.
+	self assert: (two class = eight class and: [ two scale = eight scale ]).
 	thousandth := 0.001s3.
-	tenth := thousandth raisedTo: 1/3.
-	self assert: tenth * 10 = 1.
-	self assert: (tenth class = thousandth class and: [tenth scale = thousandth scale]).
+	tenth := thousandth raisedTo: 1 / 3.
+	self assert: tenth * 10 equals: 1.
+	self assert: (tenth class = thousandth class and: [ tenth scale = thousandth scale ])
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
@@ -18,25 +18,25 @@ ScaledDecimalTest >> testExactSqrt [
 	| four hundredth tenth two |
 	four := 4.0s1.
 	two := four sqrt.
-	self assert: two = 2.
-	self assert: (two class = four class and: [two scale = four scale]).
+	self assert: two equals: 2.
+	self assert: (two class = four class and: [ two scale = four scale ]).
 	hundredth := 0.01s2.
 	tenth := hundredth sqrt.
-	self assert: tenth * 10 = 1.
-	self assert: (tenth class = hundredth class and: [tenth scale = hundredth scale]).
+	self assert: tenth * 10 equals: 1.
+	self assert: (tenth class = hundredth class and: [ tenth scale = hundredth scale ])
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
 ScaledDecimalTest >> testInexactNthRoot [
 	| tenth cubicRoot3 fifthRootTenth three |
 	three := 3.0s1.
-	cubicRoot3 := three raisedTo: 1/3.
+	cubicRoot3 := three raisedTo: 1 / 3.
 	self assert: cubicRoot3 isFloat.
-	self deny: cubicRoot3 squared = 3.
+	self deny: cubicRoot3 squared equals: 3.
 	tenth := 0.10s2.
-	fifthRootTenth := tenth raisedTo: 1/5.
+	fifthRootTenth := tenth raisedTo: 1 / 5.
 	self assert: fifthRootTenth isFloat.
-	self deny: fifthRootTenth squared = tenth.
+	self deny: fifthRootTenth squared equals: tenth
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
@@ -45,9 +45,9 @@ ScaledDecimalTest >> testInexactSqrt [
 	three := 3.0s1.
 	sqrt3 := three sqrt.
 	self assert: sqrt3 isFloat.
-	self deny: sqrt3 squared = 3.
+	self deny: sqrt3 squared equals: 3.
 	tenth := 0.10s2.
 	sqrtTenth := tenth sqrt.
 	self assert: sqrtTenth isFloat.
-	self deny: sqrtTenth squared = tenth.
+	self deny: sqrtTenth squared equals: tenth
 ]

--- a/src/Kernel-Tests-Extended/ScheduleTest.class.st
+++ b/src/Kernel-Tests-Extended/ScheduleTest.class.st
@@ -69,63 +69,34 @@ ScheduleTest >> tearDown [
 ScheduleTest >> testBetweenAndDoDisjointWithSchedule [
 	| count |
 	count := 0.
-	aSchedule
-		between: (DateAndTime
-				year: 2004
-				month: 4
-				day: 1)
-		and: (DateAndTime
-				year: 2004
-				month: 4
-				day: 30)
-		do: [:each | count := count + 1].
-	self assert: count = 0
+	aSchedule between: (DateAndTime year: 2004 month: 4 day: 1) and: (DateAndTime year: 2004 month: 4 day: 30) do: [ :each | count := count + 1 ].
+	self assert: count equals: 0
 ]
 
 { #category : #tests }
 ScheduleTest >> testBetweenAndDoIncludedInSchedule [
 	| count |
 	count := 0.
-	aSchedule
-		between: (DateAndTime
-				year: 2003
-				month: 4
-				day: 1)
-		and: (DateAndTime
-				year: 2003
-				month: 4
-				day: 30)
-		do: [:each | count := count + 1].
-	self assert: count = 8
+	aSchedule between: (DateAndTime year: 2003 month: 4 day: 1) and: (DateAndTime year: 2003 month: 4 day: 30) do: [ :each | count := count + 1 ].
+	self assert: count equals: 8
 ]
 
 { #category : #tests }
 ScheduleTest >> testBetweenAndDoOverlappingSchedule [
 	| count |
 	count := 0.
-	aSchedule
-		between: (DateAndTime
-				year: 2002
-				month: 12
-				day: 1)
-		and: (DateAndTime
-				year: 2003
-				month: 1
-				day: 31)
-		do: [:each | count := count + 1].
-	self assert: count = 8
+	aSchedule between: (DateAndTime year: 2002 month: 12 day: 1) and: (DateAndTime year: 2003 month: 1 day: 31) do: [ :each | count := count + 1 ].
+	self assert: count equals: 8
 ]
 
 { #category : #tests }
 ScheduleTest >> testDateAndTimes [
 	| answer |
-	self assert: aSchedule dateAndTimes size  = 104.
-	self assert: aSchedule dateAndTimes first = firstEvent.
+	self assert: aSchedule dateAndTimes size equals: 104.
+	self assert: aSchedule dateAndTimes first equals: firstEvent.
 	answer := true.
-	aSchedule dateAndTimes do: [:each | (each dayOfWeekName = 'Saturday'
-		or: [each dayOfWeekName = 'Sunday']) ifFalse: [^false]].
+	aSchedule dateAndTimes do: [ :each | (each dayOfWeekName = 'Saturday' or: [ each dayOfWeekName = 'Sunday' ]) ifFalse: [ ^ false ] ].
 	self assert: answer
-
 ]
 
 { #category : #tests }
@@ -171,16 +142,13 @@ ScheduleTest >> testExampleFromSwikiPage [
 
 { #category : #tests }
 ScheduleTest >> testFromDateAndTime [
-
 	| oc1 oc2 |
 	oc1 := OrderedCollection new.
 	DateAndTime today to: DateAndTime tomorrow by: 10 hours do: [ :dt | oc1 add: dt ].
 
-	oc2 := { DateAndTime today. 
-			(DateAndTime today + 10 hours). 
-				(DateAndTime today + 20 hours) }.
+	oc2 := {DateAndTime today . (DateAndTime today + 10 hours) . (DateAndTime today + 20 hours)}.
 
-	self assert: (oc1 asArray = oc2)
+	self assert: oc1 asArray equals: oc2
 ]
 
 { #category : #tests }
@@ -208,8 +176,7 @@ ScheduleTest >> testMonotonicity [
 
 { #category : #tests }
 ScheduleTest >> testSchedule [
-	self assert: aSchedule schedule size = 2.
-	self assert: aSchedule schedule first = 1 days.	
-	self assert: aSchedule schedule second = 6 days.
-
+	self assert: aSchedule schedule size equals: 2.
+	self assert: aSchedule schedule first equals: 1 days.
+	self assert: aSchedule schedule second equals: 6 days
 ]

--- a/src/Kernel-Tests-Extended/SemaphoreTest.extension.st
+++ b/src/Kernel-Tests-Extended/SemaphoreTest.extension.st
@@ -4,10 +4,12 @@ Extension { #name : #SemaphoreTest }
 SemaphoreTest >> testWaitAndWaitTimeoutTogether [
 	| semaphore value waitProcess waitTimeoutProcess |
 	semaphore := Semaphore new.
-	
-	waitProcess := [semaphore wait. value := #wait] fork.
 
-	waitTimeoutProcess := [semaphore waitTimeoutMSecs: 50. value := #waitTimeout] fork.
+	waitProcess := [ semaphore wait.
+	value := #wait ] fork.
+
+	waitTimeoutProcess := [ semaphore waitTimeoutMSecs: 50.
+	value := #waitTimeout ] fork.
 
 	"Wait for the timeout to happen"
 	(Delay forMilliseconds: 100) wait.
@@ -15,9 +17,7 @@ SemaphoreTest >> testWaitAndWaitTimeoutTogether [
 	"The waitTimeoutProcess should already have timed out.  This should release the waitProcess"
 	semaphore signal.
 
-	[waitProcess isTerminated and: [waitTimeoutProcess isTerminated]]
-		whileFalse: [(Delay forMilliseconds: 100) wait].
+	[ waitProcess isTerminated and: [ waitTimeoutProcess isTerminated ] ] whileFalse: [ (Delay forMilliseconds: 100) wait ].
 
-	self assert: value = #wait.
-	
+	self assert: value equals: #wait
 ]

--- a/src/Kernel-Tests-Extended/SizeInMemoryTest.class.st
+++ b/src/Kernel-Tests-Extended/SizeInMemoryTest.class.st
@@ -33,39 +33,30 @@ SizeInMemoryTest >> paddedByteStringSize: numberOfChars [
 SizeInMemoryTest >> testSizeInMemoryCompactClasses [
 	self skip.
 	"One word for the header + one word per instance variable"
-	self assert:  (Association key: 'aKey' value: 23) sizeInMemory = 12.
+	self assert: (Association key: 'aKey' value: 23) sizeInMemory equals: 12.
 
 	"One word for the header + one word per instance variable"
-	self assert:  Rectangle new sizeInMemory = 12.
-
-
+	self assert: Rectangle new sizeInMemory equals: 12
 ]
 
 { #category : #tests }
 SizeInMemoryTest >> testSizeInMemoryLargeInstances [
-
 	"64 bits for the object header + a world per instance variable"
 
 	self
-		assert: Smalltalk allClasses sizeInMemory = (self align64Bits: (self headerSize + (3 * Smalltalk wordSize)));
-		assert:
-			Smalltalk allClasses asArray sizeInMemory
-				=
-					(self align64Bits:(self headerSize + (Smalltalk allClasses asArray size * Smalltalk wordSize)
-						+ self headerSize))
+		assert: Smalltalk allClasses sizeInMemory equals: (self align64Bits: self headerSize + (3 * Smalltalk wordSize));
+		assert: Smalltalk allClasses asArray sizeInMemory
+			equals: (self align64Bits: self headerSize + (Smalltalk allClasses asArray size * Smalltalk wordSize) + self headerSize)
 ]
 
 { #category : #tests }
 SizeInMemoryTest >> testSizeInMemoryNormalClasses [
 	"Two word for the header + one word per instance variable"
-	self assert: Date today sizeInMemory = (self align64Bits:( 2 * Smalltalk wordSize + self headerSize)).
+
+	self assert: Date today sizeInMemory equals: (self align64Bits: 2 * Smalltalk wordSize + self headerSize).
 
 	"Two word for the header + one word per instance variable"
-	self assert: TestCase new sizeInMemory = (self align64Bits:( 2 * Smalltalk wordSize + self headerSize)).
-
-
-
-
+	self assert: TestCase new sizeInMemory equals: (self align64Bits: 2 * Smalltalk wordSize + self headerSize)
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests-Extended/StopwatchTest.class.st
+++ b/src/Kernel-Tests-Extended/StopwatchTest.class.st
@@ -45,24 +45,24 @@ StopwatchTest >> setUp [
 StopwatchTest >> testChangingStatus [
 	aStopwatch activate.
 	self assert: aStopwatch isActive.
-	self assert: aStopwatch timespans size = 1.
+	self assert: aStopwatch timespans size equals: 1.
 	aStopwatch suspend.
 	self assert: aStopwatch isSuspended.
-	self assert: aStopwatch timespans size = 1.
+	self assert: aStopwatch timespans size equals: 1.
 	aStopwatch activate.
 	aStopwatch reActivate.
 	self assert: aStopwatch isActive.
-	self assert: aStopwatch timespans size = 3.
+	self assert: aStopwatch timespans size equals: 3.
 	aStopwatch reset.
 	self assert: aStopwatch isSuspended.
-	self assert: aStopwatch timespans size = 0.
+	self assert: aStopwatch timespans size equals: 0
 ]
 
 { #category : #tests }
 StopwatchTest >> testInitialStatus [
 	self assert: aStopwatch isSuspended.
 	self deny: aStopwatch isActive.
-	self assert: aStopwatch duration = 0 seconds
+	self assert: aStopwatch duration equals: 0 seconds
 ]
 
 { #category : #tests }
@@ -73,10 +73,8 @@ StopwatchTest >> testMultipleTimings [
 	aStopwatch activate.
 	aDelay wait.
 	aStopwatch suspend.
-	self assert: aStopwatch timespans size = 2. 
-	self assert: aStopwatch timespans first asDateAndTime <= 
-					aStopwatch timespans last asDateAndTime.
-
+	self assert: aStopwatch timespans size equals: 2.
+	self assert: aStopwatch timespans first asDateAndTime <= aStopwatch timespans last asDateAndTime
 ]
 
 { #category : #tests }
@@ -86,7 +84,7 @@ StopwatchTest >> testNew [
 
 	self
 		assert: sw isSuspended;
-		assert: sw state = #suspended;
+		assert: sw state equals: #suspended;
 		deny: sw isActive;
 		assertEmpty: sw timespans
 ]
@@ -130,43 +128,44 @@ StopwatchTest >> testSingleTiming [
 	aStopwatch activate.
 	aDelay wait.
 	aStopwatch suspend.
-	self assert: aStopwatch timespans size = 1. 
-	self assert: aStopwatch timespans first asDateAndTime >= timeBefore. 
-	self assert: aStopwatch timespans first asDateAndTime <= aStopwatch end.
-
+	self assert: aStopwatch timespans size equals: 1.
+	self assert: aStopwatch timespans first asDateAndTime >= timeBefore.
+	self assert: aStopwatch timespans first asDateAndTime <= aStopwatch end
 ]
 
 { #category : #tests }
 StopwatchTest >> testStartStop [
-
 	| sw t1 t2 t3 t4 |
 	sw := Stopwatch new.
 	t1 := DateAndTime now.
 	(Delay forMilliseconds: 10) wait.
-	sw activate; activate.
+	sw
+		activate;
+		activate.
 	(Delay forMilliseconds: 10) wait.
 	t2 := DateAndTime now.
-	
-	self 
-		deny: (sw isSuspended);
-		assert: (sw isActive);
-		assert: (sw timespans size = 1);
-		assert: (t1 <= sw start);
-		assert: (sw start <= t2).
+
+	self
+		deny: sw isSuspended;
+		assert: sw isActive;
+		assert: sw timespans size equals: 1;
+		assert: t1 <= sw start;
+		assert: sw start <= t2.
 
 	(Delay forMilliseconds: 10) wait.
 	t3 := DateAndTime now.
 	(Delay forMilliseconds: 10) wait.
-	sw suspend; suspend.
+	sw
+		suspend;
+		suspend.
 	(Delay forMilliseconds: 10) wait.
 	t4 := DateAndTime now.
 
-	self 
-		assert: (sw isSuspended);
-		deny: (sw isActive);
-		assert: (sw timespans size = 1);
+	self
+		assert: sw isSuspended;
+		deny: sw isActive;
+		assert: sw timespans size equals: 1;
 		assert: (sw end between: t3 and: t4);
-		assert: (t3 <= sw end);
-		assert: (sw end <= t4).
-
+		assert: t3 <= sw end;
+		assert: sw end <= t4
 ]

--- a/src/Kernel-Tests-Extended/TimeTest.extension.st
+++ b/src/Kernel-Tests-Extended/TimeTest.extension.st
@@ -2,25 +2,38 @@ Extension { #name : #TimeTest }
 
 { #category : #'*Kernel-Tests-Extended' }
 TimeTest >> testNanoConstructor [
-
 	| timeFromString timeFromNano timeFromNanoSecond |
-	
 	timeFromString := Time fromString: '01:23:45.67809'.
-	timeFromNano := Time hour: 1 minute: 23 second: 45 nano: 67809.
-	timeFromNanoSecond := Time hour: 1 minute: 23 second: 45 nanoSecond: 67809.
-	
-	self 
+	timeFromNano := Time
+		hour: 1
+		minute: 23
+		second: 45
+		nano: 67809.
+	timeFromNanoSecond := Time
+		hour: 1
+		minute: 23
+		second: 45
+		nanoSecond: 67809.
+
+	self
 		assert: timeFromString equals: timeFromNano;
-		deny: timeFromNano = timeFromNanoSecond.
-	
+		deny: timeFromNano equals: timeFromNanoSecond.
+
 	timeFromString := Time fromString: '01:23:45.0'.
-	timeFromNano := Time hour: 1 minute: 23 second: 45 nano: 0.
-	
+	timeFromNano := Time
+		hour: 1
+		minute: 23
+		second: 45
+		nano: 0.
+
 	self assert: timeFromString equals: timeFromNano.
 
 	timeFromString := Time fromString: '01:23:45.1234567890'.
-	timeFromNano := Time hour: 1 minute: 23 second: 45 nano: 1234567890.
-	
-	self assert: timeFromString equals: timeFromNano
+	timeFromNano := Time
+		hour: 1
+		minute: 23
+		second: 45
+		nano: 1234567890.
 
+	self assert: timeFromString equals: timeFromNano
 ]

--- a/src/Kernel-Tests-Extended/TimespanDoSpanAYearTest.class.st
+++ b/src/Kernel-Tests-Extended/TimespanDoSpanAYearTest.class.st
@@ -27,51 +27,48 @@ TimespanDoSpanAYearTest >> setUp [
 
 { #category : #tests }
 TimespanDoSpanAYearTest >> testMonthsDo [
-
 	| monthArray |
-
 	monthArray := Array
-				with: (Month starting: (DateAndTime year: 2004 day: 355) duration: 31 days)
-				with: (Month starting: (DateAndTime year: 2005 day: 1) duration: 31 days)
-				with: (Month starting: (DateAndTime year: 2005 day: 32) duration: 29 days)
-				with: (Month starting: (DateAndTime year: 2005 day: 61) duration: 31 days).
-				
-	self assert: aTimespan months = monthArray
+		with: (Month starting: (DateAndTime year: 2004 day: 355) duration: 31 days)
+		with: (Month starting: (DateAndTime year: 2005 day: 1) duration: 31 days)
+		with: (Month starting: (DateAndTime year: 2005 day: 32) duration: 29 days)
+		with: (Month starting: (DateAndTime year: 2005 day: 61) duration: 31 days).
+
+	self assert: aTimespan months equals: monthArray
 ]
 
 { #category : #tests }
 TimespanDoSpanAYearTest >> testNext [
-
-	self assert: aTimespan next
-			= (Timespan
-					starting: (DateAndTime
-							year: 2005
-							month: 3
-							day: 26
-							hour: 0
-							minute: 0
-							second: 0)
-					duration: aDuration)
+	self
+		assert: aTimespan next
+		equals:
+			(Timespan
+				starting:
+					(DateAndTime
+						year: 2005
+						month: 3
+						day: 26
+						hour: 0
+						minute: 0
+						second: 0)
+				duration: aDuration)
 ]
 
 { #category : #tests }
 TimespanDoSpanAYearTest >> testWeeksDo [
 	| weeks weekArray |
 	weeks := aTimespan weeks.
-	self assert: weeks size = ((aDuration days / 7.0) ceiling + 1).
+	self assert: weeks size equals: (aDuration days / 7.0) ceiling + 1.
 
 	weekArray := OrderedCollection new.
 	weekArray
 		addLast: (Week starting: (DateAndTime year: 2004 month: 12 day: 19) duration: 7 days);
 		addLast: (Week starting: (DateAndTime year: 2004 month: 12 day: 26) duration: 7 days).
 
-	2 to: 79 by: 7 do:
-		[ :i | weekArray
-				addLast: (Week starting: (DateAndTime year: 2005 day: i) duration: 7 days) ].
+	2 to: 79 by: 7 do: [ :i | weekArray addLast: (Week starting: (DateAndTime year: 2005 day: i) duration: 7 days) ].
 
 	weekArray := weekArray asArray.
-	self assert: aTimespan weeks = weekArray
-
+	self assert: aTimespan weeks equals: weekArray
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests-Extended/TimespanDoTest.extension.st
+++ b/src/Kernel-Tests-Extended/TimespanDoTest.extension.st
@@ -4,43 +4,25 @@ Extension { #name : #TimespanDoTest }
 TimespanDoTest >> testMonthsDo [
 	| monthArray |
 	monthArray := Array
-				with: (Month
-						starting: (DateAndTime year: 2003 day: 1)
-						duration: 31 days)
-				with: (Month
-						starting: (DateAndTime year: 2003 day: 32)
-						duration: 28 days)
-				with: (Month
-						starting: (DateAndTime year: 2003 day: 60)
-						duration: 31 days)		
-				with: (Month
-						starting: (DateAndTime year: 2003 day: 91)
-						duration: 30 days).
-	self assert: aTimespan months = monthArray
+		with: (Month starting: (DateAndTime year: 2003 day: 1) duration: 31 days)
+		with: (Month starting: (DateAndTime year: 2003 day: 32) duration: 28 days)
+		with: (Month starting: (DateAndTime year: 2003 day: 60) duration: 31 days)
+		with: (Month starting: (DateAndTime year: 2003 day: 91) duration: 30 days).
+	self assert: aTimespan months equals: monthArray
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
 TimespanDoTest >> testWeeksDo [
 	| weekArray |
 	weekArray := OrderedCollection new.
-	7
-		to: 98
-		by: 7
-		do: [:each | weekArray
-				addLast: (Week
-						starting: (DateAndTime year: 2003 day: each)
-						duration: 7 days)].
+	7 to: 98 by: 7 do: [ :each | weekArray addLast: (Week starting: (DateAndTime year: 2003 day: each) duration: 7 days) ].
 	weekArray := weekArray asArray.
-	self assert: aTimespan weeks = weekArray
-
+	self assert: aTimespan weeks equals: weekArray
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
 TimespanDoTest >> testYearsDo [
 	| yearArray |
-	yearArray := Array
-				with: (Year
-						starting: (DateAndTime year: 2003 day: 7)
-						duration: 365 days).
-	self assert: aTimespan years contents = yearArray contents
+	yearArray := Array with: (Year starting: (DateAndTime year: 2003 day: 7) duration: 365 days).
+	self assert: aTimespan years contents equals: yearArray contents
 ]

--- a/src/Kernel-Tests-Extended/WeekTest.class.st
+++ b/src/Kernel-Tests-Extended/WeekTest.class.st
@@ -78,7 +78,7 @@ WeekTest >> testByWeekNumberInCurrentYear [
 
 { #category : #tests }
 WeekTest >> testDayNames [
-	self assert: (Week dayNames) = #(#Sunday #Monday #Tuesday #Wednesday #Thursday #Friday #Saturday).
+	self assert: Week dayNames equals: #(#Sunday #Monday #Tuesday #Wednesday #Thursday #Friday #Saturday)
 ]
 
 { #category : #tests }
@@ -96,38 +96,36 @@ WeekTest >> testEnumerating [
 WeekTest >> testIndexOfDay [
 	| days |
 	days := #(#Sunday #Monday #Tuesday #Wednesday #Thursday #Friday #Saturday).
-	
-	days withIndexDo: [:item :index | self assert: (Week indexOfDay: item) = index].
-	
+
+	days withIndexDo: [ :item :index | self assert: (Week indexOfDay: item) equals: index ].
+
 	"This should probably raise an error rather than returning 0."
-	self assert: (Week indexOfDay: 0) = 0.
-	self assert: (Week indexOfDay: 1) = 0.
-	self assert: (Week indexOfDay: 7) = 0.
-	self assert: (Week indexOfDay: 8) = 0.
-	self assert: (Week indexOfDay: #Sunnyday) = 0.
+	self assert: (Week indexOfDay: 0) equals: 0.
+	self assert: (Week indexOfDay: 1) equals: 0.
+	self assert: (Week indexOfDay: 7) equals: 0.
+	self assert: (Week indexOfDay: 8) equals: 0.
+	self assert: (Week indexOfDay: #Sunnyday) equals: 0
 ]
 
 { #category : #tests }
 WeekTest >> testInquiries [
-
 	self
-		assert: week start asDate = '28 June 1998' asDate;
-		assert: week end asDate = '4 July 1998' asDate;
-		assert: week index = 5;
-		assert: week duration = (7 days).
-
+		assert: week start asDate equals: '28 June 1998' asDate;
+		assert: week end asDate equals: '4 July 1998' asDate;
+		assert: week index equals: 5;
+		assert: week duration equals: 7 days
 ]
 
 { #category : #tests }
 WeekTest >> testNameOfDay [
 	| days |
 	days := #(#Sunday #Monday #Tuesday #Wednesday #Thursday #Friday #Saturday).
-	
-	days withIndexDo: [:item :index | self assert: (Week nameOfDay: index) = item].
-	
-	self should: [Week nameOfDay: 0] raise: self defaultTestError.
-	self should: [Week nameOfDay: 8] raise: self defaultTestError.
-	self should: [Week nameOfDay: #Sunday] raise: self defaultTestError.
+
+	days withIndexDo: [ :item :index | self assert: (Week nameOfDay: index) equals: item ].
+
+	self should: [ Week nameOfDay: 0 ] raise: self defaultTestError.
+	self should: [ Week nameOfDay: 8 ] raise: self defaultTestError.
+	self should: [ Week nameOfDay: #Sunday ] raise: self defaultTestError
 ]
 
 { #category : #tests }
@@ -144,6 +142,6 @@ WeekTest >> testOffset [
 { #category : #tests }
 WeekTest >> testPreviousNext [
 	self
-		assert: week next = (Week starting: '6 July 1998' asDate);
-		assert: week previous = (Week starting:  '22 June 1998' asDate)
+		assert: week next equals: (Week starting: '6 July 1998' asDate);
+		assert: week previous equals: (Week starting: '22 June 1998' asDate)
 ]

--- a/src/Kernel-Tests-Extended/WriteBarrierTest.class.st
+++ b/src/Kernel-Tests-Extended/WriteBarrierTest.class.st
@@ -186,19 +186,19 @@ WriteBarrierTest >> testMutateIVObject [
 	| guineaPig |
 	guineaPig := MessageSend new.
 	guineaPig beReadOnlyObject.
-	[ guineaPig receiver: 1 ] 
-		on: ModificationForbidden 
+	[ guineaPig receiver: 1 ]
+		on: ModificationForbidden
 		do: [ :modification | "Surely a NoModification error" ].
 	guineaPig
 		beWritableObject;
 		selector: #+;
 		beReadOnlyObject.
-	[ guineaPig arguments: #(2) ] 
-		on: ModificationForbidden 
-		do: [  :modification |"Surely a NoModification error" ].
+	[ guineaPig arguments: #(2) ]
+		on: ModificationForbidden
+		do: [ :modification | "Surely a NoModification error" ].
 	self assert: guineaPig receiver isNil.
 	self assert: guineaPig arguments isNil.
-	self assert: guineaPig selector == #+.
+	self assert: guineaPig selector identicalTo: #+
 ]
 
 { #category : #'tests - object' }
@@ -235,11 +235,13 @@ WriteBarrierTest >> testMutateObjectInstVarShouldCatchRightFailure [
 	| guineaPig failure |
 	guineaPig := MessageSend new.
 	guineaPig beReadOnlyObject.
-	failure := [ guineaPig receiver: #test ] on: ModificationForbidden do: [:err | err].
+	failure := [ guineaPig receiver: #test ]
+		on: ModificationForbidden
+		do: [ :err | err ].
 
-	self assert: failure object == guineaPig.
+	self assert: failure object identicalTo: guineaPig.
 	self assert: failure newValue equals: #test.
-	self assert: failure fieldIndex equals: 1.
+	self assert: failure fieldIndex equals: 1
 ]
 
 { #category : #'tests - object' }
@@ -315,22 +317,23 @@ WriteBarrierTest >> testMutateObjectLastInstVarWithManyVars [
 { #category : #'tests - object' }
 WriteBarrierTest >> testMutateVariableObject [
 	| guineaPigs |
-	guineaPigs := {#[1 2 3] . #(1 2 3) }.
-	guineaPigs do: [ :guineaPig | 
-		guineaPig beReadOnlyObject.
-		[guineaPig at: 1 put: 4] 
-			on: ModificationForbidden  
-			do: [ "Surely a NoModification error" ].
-		guineaPig
-			beWritableObject;
-			at: 2 put:  5;
-			beReadOnlyObject.
-		[guineaPig at: 3 put: 6] 
-			on: ModificationForbidden  
-			do: [ "Surely a NoModification error" ].
-		self assert: guineaPig first = 1.
-		self assert: guineaPig second = 5.
-		self assert: guineaPig third = 3 ]
+	guineaPigs := {#[1 2 3] . #(1 2 3)}.
+	guineaPigs
+		do: [ :guineaPig | 
+			guineaPig beReadOnlyObject.
+			[ guineaPig at: 1 put: 4 ]
+				on: ModificationForbidden
+				do: [ "Surely a NoModification error" ].
+			guineaPig
+				beWritableObject;
+				at: 2 put: 5;
+				beReadOnlyObject.
+			[ guineaPig at: 3 put: 6 ]
+				on: ModificationForbidden
+				do: [ "Surely a NoModification error" ].
+			self assert: guineaPig first equals: 1.
+			self assert: guineaPig second equals: 5.
+			self assert: guineaPig third equals: 3 ]
 ]
 
 { #category : #'tests - object' }

--- a/src/Kernel-Tests-Extended/YearMonthWeekTest.class.st
+++ b/src/Kernel-Tests-Extended/YearMonthWeekTest.class.st
@@ -31,39 +31,37 @@ YearMonthWeekTest >> tearDown [
 
 { #category : #tests }
 YearMonthWeekTest >> testDaysInMonth [
-	self assert: (Month daysInMonth: 2 forYear: 2000) = 29.
-	self assert: (Month daysInMonth: 2 forYear: 2001) = 28.
-	self assert: (Month  daysInMonth: 2 forYear: 2004) = 29.
-	self assert: (Month  daysInMonth: 2 forYear: 2100) = 28.
-	
-	self assert: (Month  daysInMonth: 'January' forYear: 2003) = 31.
-	self assert: (Month  daysInMonth: 'February' forYear: 2003) = 28.
-	self assert: (Month  daysInMonth: 'March' forYear: 2003) = 31.
-	self assert: (Month  daysInMonth: 'April' forYear: 2003) = 30.
-	self assert: (Month  daysInMonth: 'May' forYear: 2003) = 31.
-	self assert: (Month  daysInMonth: 'June' forYear: 2003) = 30.
-	self assert: (Month  daysInMonth: 'July' forYear: 2003) = 31.
-	self assert: (Month  daysInMonth: 'August' forYear: 2003) = 31.
-	self assert: (Month  daysInMonth: 'September' forYear: 2003) = 30.
-	self assert: (Month  daysInMonth: 'October' forYear: 2003) = 31.
-	self assert: (Month  daysInMonth: 'November' forYear: 2003) = 30.
-	self assert: (Month  daysInMonth: 'December' forYear: 2003) = 31.
+	self assert: (Month daysInMonth: 2 forYear: 2000) equals: 29.
+	self assert: (Month daysInMonth: 2 forYear: 2001) equals: 28.
+	self assert: (Month daysInMonth: 2 forYear: 2004) equals: 29.
+	self assert: (Month daysInMonth: 2 forYear: 2100) equals: 28.
+
+	self assert: (Month daysInMonth: 'January' forYear: 2003) equals: 31.
+	self assert: (Month daysInMonth: 'February' forYear: 2003) equals: 28.
+	self assert: (Month daysInMonth: 'March' forYear: 2003) equals: 31.
+	self assert: (Month daysInMonth: 'April' forYear: 2003) equals: 30.
+	self assert: (Month daysInMonth: 'May' forYear: 2003) equals: 31.
+	self assert: (Month daysInMonth: 'June' forYear: 2003) equals: 30.
+	self assert: (Month daysInMonth: 'July' forYear: 2003) equals: 31.
+	self assert: (Month daysInMonth: 'August' forYear: 2003) equals: 31.
+	self assert: (Month daysInMonth: 'September' forYear: 2003) equals: 30.
+	self assert: (Month daysInMonth: 'October' forYear: 2003) equals: 31.
+	self assert: (Month daysInMonth: 'November' forYear: 2003) equals: 30.
+	self assert: (Month daysInMonth: 'December' forYear: 2003) equals: 31
 ]
 
 { #category : #tests }
 YearMonthWeekTest >> testDaysInYear [
-	self assert: (Year daysInYear: 2000) = 366.
-	self assert: (Year daysInYear: 2001) = 365.
-	self assert: (Year daysInYear: 2004) = 366.
-	self assert: (Year daysInYear: 2100) = 365.
-	self assert: (Year daysInYear: 2003) = 365.
+	self assert: (Year daysInYear: 2000) equals: 366.
+	self assert: (Year daysInYear: 2001) equals: 365.
+	self assert: (Year daysInYear: 2004) equals: 366.
+	self assert: (Year daysInYear: 2100) equals: 365.
+	self assert: (Year daysInYear: 2003) equals: 365
 ]
 
 { #category : #tests }
 YearMonthWeekTest >> testIndexOfDay [
-	self assert: (Week indexOfDay: 'Friday') = 6.
-
-
+	self assert: (Week indexOfDay: 'Friday') equals: 6
 ]
 
 { #category : #tests }
@@ -85,11 +83,9 @@ YearMonthWeekTest >> testMonthPrintOn [
 { #category : #tests }
 YearMonthWeekTest >> testStartDay [
 	Week startDay: 'Wednesday'.
-	self assert: Week startDay = 'Wednesday'.
+	self assert: Week startDay equals: 'Wednesday'.
 	Week startDay: 'Thursday'.
-	self assert: Week startDay = 'Thursday'.
-
-
+	self assert: Week startDay equals: 'Thursday'
 ]
 
 { #category : #tests }
@@ -99,7 +95,7 @@ YearMonthWeekTest >> testWeekPrintOn [
 	cs := 'a Week starting: 1900-12-30T00:00:00+00:00'.
 	rw := String new writeStream.
 	aWeek printOn: rw.
-	self assert: rw contents = cs
+	self assert: rw contents equals: cs
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests-Extended/YearTest.class.st
+++ b/src/Kernel-Tests-Extended/YearTest.class.st
@@ -39,19 +39,17 @@ YearTest >> testOffset [
 
 { #category : #tests }
 YearTest >> testPreviousInLeapYear [
-		
 	| leap |
 	leap := Year year: 2008.
-	self assert: leap isLeapYear. 
-	self assert: (Year year: (leap year - 1)) = leap previous 
+	self assert: leap isLeapYear.
+	self assert: (Year year: leap year - 1) equals: leap previous
 ]
 
 { #category : #tests }
 YearTest >> testStart [
-		
 	| yyyy |
 	yyyy := DateAndTime now year.
-	self assert: Year current start = (DateAndTime year: yyyy month: 1 day: 1)
+	self assert: Year current start equals: (DateAndTime year: yyyy month: 1 day: 1)
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests-WithCompiler/ContextTest.extension.st
+++ b/src/Kernel-Tests-WithCompiler/ContextTest.extension.st
@@ -18,21 +18,18 @@ ContextTest >> testSourceNodeOptimizedBlock [
 { #category : #'*Kernel-Tests-WithCompiler' }
 ContextTest >> testTempNamed [
 	| oneTemp context |
-	
 	oneTemp := 1.
-	self assert: (thisContext tempNamed: 'oneTemp') = oneTemp.
-	
-	context := self class contextWithTempForTesting.
-	self assert: (context tempNamed: 'string') = 'test'
+	self assert: (thisContext tempNamed: 'oneTemp') equals: oneTemp.
 
+	context := self class contextWithTempForTesting.
+	self assert: (context tempNamed: 'string') equals: 'test'
 ]
 
 { #category : #'*Kernel-Tests-WithCompiler' }
 ContextTest >> testTempNamedPut [
 	| oneTemp |
-	
 	oneTemp := 1.
-	self assert: (thisContext tempNamed: 'oneTemp') = oneTemp.
+	self assert: (thisContext tempNamed: 'oneTemp') equals: oneTemp.
 	thisContext tempNamed: 'oneTemp' put: 2.
-	self assert: (thisContext tempNamed: 'oneTemp') = 2.
+	self assert: (thisContext tempNamed: 'oneTemp') equals: 2
 ]

--- a/src/Kernel-Tests-WithCompiler/ScaledDecimalTest.extension.st
+++ b/src/Kernel-Tests-WithCompiler/ScaledDecimalTest.extension.st
@@ -3,24 +3,21 @@ Extension { #name : #ScaledDecimalTest }
 { #category : #'*Kernel-Tests-WithCompiler' }
 ScaledDecimalTest >> testStoreOnRoundTrip [
 	"this is http://bugs.squeak.org/view.php?id=4378"
-	
+
 	"Both results should be 1.
 	ScaledDecimal representations are exact
 	(though only scale digits or fractional part are printed)"
 
-	self assert:
-    		(self class compiler evaluate: (0.5s1 squared storeString)) * 4
-		= (0.5s1 squared * 4).
-		
-	
+	self assert: (self class compiler evaluate: 0.5s1 squared storeString) * 4 equals: 0.5s1 squared * 4.
+
+
 	"However, exact literals should store literaly
 	If not, they would break Decompiler."
-	
+
 	"BUG: i cannot write the test like this:
 	self assert:
     		0.5s2 squared storeString = '0.25s2'
 	BECAUSE compiler would consider 0.5s2 as = 0.5s1 and would reuse same slot..."
-	
-	self assert:
-    		0.25s2 storeString = '0.25s2'
+
+	self assert: 0.25s2 storeString equals: '0.25s2'
 ]

--- a/src/Kernel-Tests/BasicBehaviorClassMetaclassTest.class.st
+++ b/src/Kernel-Tests/BasicBehaviorClassMetaclassTest.class.st
@@ -14,39 +14,23 @@ Class {
 
 { #category : #tests }
 BasicBehaviorClassMetaclassTest >> testBehaviorClassClassDescriptionMetaclassHierarchy [
-	
-	self assert: Class superclass == ClassDescription.
-	self assert: Metaclass superclass == ClassDescription.
+	self assert: Class superclass identicalTo: ClassDescription.
+	self assert: Metaclass superclass identicalTo: ClassDescription.
 
-	self assert: ClassDescription superclass == Behavior.
+	self assert: ClassDescription superclass identicalTo: Behavior.
 	self assert: Behavior superclass equals: Object.
 
-	self assert: Class class class == Metaclass.
-	self assert: Metaclass class class == Metaclass.
-	self assert: ClassDescription class class == Metaclass.
-	self assert: Behavior class class == Metaclass
+	self assert: Class class class identicalTo: Metaclass.
+	self assert: Metaclass class class identicalTo: Metaclass.
+	self assert: ClassDescription class class identicalTo: Metaclass.
+	self assert: Behavior class class identicalTo: Metaclass
 ]
 
 { #category : #tests }
 BasicBehaviorClassMetaclassTest >> testMetaclass [
-	
-	self assert: OrderedCollection class class == Metaclass.
-	self assert: Dictionary class class == Metaclass.
-	self assert: Object class class == Metaclass.
-
-
-
-
-	
-	
-	
-
-
-
-	
-	
-
-	
+	self assert: OrderedCollection class class identicalTo: Metaclass.
+	self assert: Dictionary class class identicalTo: Metaclass.
+	self assert: Object class class identicalTo: Metaclass
 ]
 
 { #category : #tests }
@@ -65,16 +49,14 @@ BasicBehaviorClassMetaclassTest >> testMetaclassNumberOfInstances [
 
 { #category : #tests }
 BasicBehaviorClassMetaclassTest >> testMetaclassPointOfCircularity [
-
 	self assert: Metaclass class instanceCount equals: 1.
-	self assert: Metaclass class someInstance == Metaclass
+	self assert: Metaclass class someInstance identicalTo: Metaclass
 ]
 
 { #category : #tests }
 BasicBehaviorClassMetaclassTest >> testMetaclassSuperclass [
-
-	self assert: Dictionary class superclass == Dictionary superclass class.
-	self assert: OrderedCollection class superclass == OrderedCollection superclass class
+	self assert: Dictionary class superclass identicalTo: Dictionary superclass class.
+	self assert: OrderedCollection class superclass identicalTo: OrderedCollection superclass class
 ]
 
 { #category : #tests }
@@ -108,22 +90,21 @@ BasicBehaviorClassMetaclassTest >> testMetaclassSuperclassHierarchy [
 
 { #category : #tests }
 BasicBehaviorClassMetaclassTest >> testObjectAllSubclasses [
-
 	| n2 |
 	n2 := Object allSubclasses size.
-	self assert: n2 = (Object allSubclasses
-			select: [:cls | (cls class isKindOf: Metaclass)
-					or: [cls isKindOf: Metaclass]]) size
+	self assert: n2 equals: (Object allSubclasses select: [ :cls | (cls class isKindOf: Metaclass) or: [ cls isKindOf: Metaclass ] ]) size
 ]
 
 { #category : #tests }
-BasicBehaviorClassMetaclassTest >> testSuperclass [	
-
+BasicBehaviorClassMetaclassTest >> testSuperclass [
 	| s b |
 	s := OrderedCollection new.
-	b := [:cls | cls ifNotNil: [s add: cls. b value: cls superclass] ].
+	b := [ :cls | 
+	cls
+		ifNotNil: [ s add: cls.
+			b value: cls superclass ] ].
 	b value: OrderedCollection.
 
-	self assert: OrderedCollection allSuperclasses = s allButFirst.
-	self assert: OrderedCollection withAllSuperclasses = s.
+	self assert: OrderedCollection allSuperclasses equals: s allButFirst.
+	self assert: OrderedCollection withAllSuperclasses equals: s
 ]

--- a/src/Kernel-Tests/BecomeTest.class.st
+++ b/src/Kernel-Tests/BecomeTest.class.st
@@ -54,20 +54,17 @@ BecomeTest >> testBecomeForwardCopyIdentityHash [
 		1. the argument to becomeForward: IS modified to have the sender's identity hash.
 		2. the sender's identity hash is unchanged."
 
- 	| a b identityHashOfA |
-
+	| a b identityHashOfA |
 	a := 'ab' copy.
 	b := 'cd' copy.
 	identityHashOfA := a identityHash.
 
 	a becomeForward: b copyHash: true.
 
-	self 
-		assert: a == b;
+	self
+		assert: a identicalTo: b;
 		assert: a identityHash equals: identityHashOfA;
-		assert: b identityHash equals: identityHashOfA.
-
-
+		assert: b identityHash equals: identityHashOfA
 ]
 
 { #category : #testing }
@@ -76,20 +73,17 @@ BecomeTest >> testBecomeForwardDontCopyIdentityHash [
 		1. the argument to becomeForward: is NOT modified to have the receiver's identity hash.
 		2. the receiver's identity hash is unchanged."
 
- 	| a b identityHashOfB |
-
+	| a b identityHashOfB |
 	a := 'ab' copy.
 	b := 'cd' copy.
 	identityHashOfB := b identityHash.
 
 	a becomeForward: b copyHash: false.
 
-	self 
-		assert: a == b;
+	self
+		assert: a identicalTo: b;
 		assert: a identityHash equals: identityHashOfB;
-		assert: b identityHash equals: identityHashOfB.
-
-
+		assert: b identityHash equals: identityHashOfB
 ]
 
 { #category : #testing }

--- a/src/Kernel-Tests/BehaviorTest.class.st
+++ b/src/Kernel-Tests/BehaviorTest.class.st
@@ -35,9 +35,9 @@ BehaviorTest >> testAllMethods [
 
 { #category : #tests }
 BehaviorTest >> testAllSelectors [
-	self assert: ProtoObject allSelectors asSet = ProtoObject selectors asSet.
-	self assert: Object allSelectors asSet = (Object selectors asSet union: ProtoObject selectors).
-	self assert: (Object allSelectorsBelow: ProtoObject) asSet = (Object selectors) asSet.
+	self assert: ProtoObject allSelectors asSet equals: ProtoObject selectors asSet.
+	self assert: Object allSelectors asSet equals: (Object selectors asSet union: ProtoObject selectors).
+	self assert: (Object allSelectorsBelow: ProtoObject) asSet equals: Object selectors asSet
 ]
 
 { #category : #tests }
@@ -74,14 +74,14 @@ BehaviorTest >> testBehaviornewnewShouldNotCrash [
 
 { #category : #tests }
 BehaviorTest >> testBinding [
-	self assert: Object binding value = Object.
-	self assert: Object binding key = #Object.
-	
-	self assert: Object class binding value = Object class.
-	
+	self assert: Object binding value equals: Object.
+	self assert: Object binding key equals: #Object.
+
+	self assert: Object class binding value equals: Object class.
+
 	"returns nil for Metaclasses... like Encoder>>#associationFor:"
-	
-	self assert: Object class binding key isNil.
+
+	self assert: Object class binding key isNil
 ]
 
 { #category : #tests }
@@ -153,37 +153,34 @@ BehaviorTest >> testIsUsed [
 { #category : #'tests - queries' }
 BehaviorTest >> testMethodsAccessingSlot [
 	| numberViaSlot numberViaIVar |
-	
 	"Check the source code availability to do not fail on images without sources"
-	(Point>>#x) hasSourceCode ifFalse: [ ^ self ].
-	
+	(Point >> #x) hasSourceCode ifFalse: [ ^ self ].
+
 	numberViaSlot := (Point methodsAccessingSlot: (Point slotNamed: #x)) size.
 	numberViaIVar := (Point whichSelectorsAccess: 'x') size.
-	self assert: numberViaSlot = numberViaIVar.
+	self assert: numberViaSlot equals: numberViaIVar
 ]
 
 { #category : #'tests - queries' }
 BehaviorTest >> testMethodsReadingSlot [
 	| numberViaSlot numberViaIVar |
-	
 	"Check the source code availability to do not fail on images without sources"
-	(Point>>#x) hasSourceCode ifFalse: [ ^ self ].
-	
+	(Point >> #x) hasSourceCode ifFalse: [ ^ self ].
+
 	numberViaSlot := (Point methodsReadingSlot: (Point slotNamed: #x)) size.
 	numberViaIVar := (Point whichSelectorsRead: 'x') size.
-	self assert: numberViaSlot = numberViaIVar.
+	self assert: numberViaSlot equals: numberViaIVar
 ]
 
 { #category : #'tests - queries' }
 BehaviorTest >> testMethodsWritingSlot [
 	| numberViaSlot numberViaIVar |
-	
 	"Check the source code availability to do not fail on images without sources"
-	(Point>>#x) hasSourceCode ifFalse: [ ^ self ].
+	(Point >> #x) hasSourceCode ifFalse: [ ^ self ].
 
 	numberViaSlot := (Point methodsWritingSlot: (Point slotNamed: #x)) size.
 	numberViaIVar := (Point whichSelectorsStoreInto: 'x') size.
-	self assert: numberViaSlot = numberViaIVar.
+	self assert: numberViaSlot equals: numberViaIVar
 ]
 
 { #category : #'tests - properties' }

--- a/src/Kernel-Tests/BlockClosureTest.class.st
+++ b/src/Kernel-Tests/BlockClosureTest.class.st
@@ -32,8 +32,8 @@ BlockClosureTest >> testCull [
 	self should: [ [ :x :y :z |  ] cull: 1 ] raise: Error.
 	self should: [ [ :x :y :z :a |  ] cull: 1 ] raise: Error.
 	self should: [ [ :x :y :z :a :b |  ] cull: 1 ] raise: Error.
-	self assert: ([ 0 ] cull: 1) = 0.
-	self assert: ([ :x | x ] cull: 1) = 1
+	self assert: ([ 0 ] cull: 1) equals: 0.
+	self assert: ([ :x | x ] cull: 1) equals: 1
 ]
 
 { #category : #'tests - evaluating' }
@@ -44,9 +44,9 @@ BlockClosureTest >> testCullCull [
 	self should: [ [ :x :y :z |  ] cull: 1 cull: 2 ] raise: Error.
 	self should: [ [ :x :y :z :a |  ] cull: 1 cull: 2 ] raise: Error.
 	self should: [ [ :x :y :z :a :b |  ] cull: 1 cull: 2 ] raise: Error.
-	self assert: ([ 0 ] cull: 1 cull: 2) = 0.
-	self assert: ([ :x | x ] cull: 1 cull: 2) = 1.
-	self assert: ([ :x :y | y ] cull: 1 cull: 2) = 2
+	self assert: ([ 0 ] cull: 1 cull: 2) equals: 0.
+	self assert: ([ :x | x ] cull: 1 cull: 2) equals: 1.
+	self assert: ([ :x :y | y ] cull: 1 cull: 2) equals: 2
 ]
 
 { #category : #'tests - evaluating' }
@@ -57,10 +57,10 @@ BlockClosureTest >> testCullCullCull [
 	[ :x :y :z |  ] cull: 1 cull: 2 cull: 3.
 	self should: [ [ :x :y :z :a |  ] cull: 1 cull: 2 cull: 3 ] raise: Error.
 	self should: [ [ :x :y :z :a :b |  ] cull: 1 cull: 2 cull: 3 ] raise: Error.
-	self assert: ([ 0 ] cull: 1 cull: 2 cull: 3) = 0.
-	self assert: ([ :x | x ] cull: 1 cull: 2 cull: 3) = 1.
-	self assert: ([ :x :y | y ] cull: 1 cull: 2 cull: 3) = 2.
-	self assert: ([ :x :y :z | z ] cull: 1 cull: 2 cull: 3) = 3
+	self assert: ([ 0 ] cull: 1 cull: 2 cull: 3) equals: 0.
+	self assert: ([ :x | x ] cull: 1 cull: 2 cull: 3) equals: 1.
+	self assert: ([ :x :y | y ] cull: 1 cull: 2 cull: 3) equals: 2.
+	self assert: ([ :x :y :z | z ] cull: 1 cull: 2 cull: 3) equals: 3
 ]
 
 { #category : #'tests - evaluating' }
@@ -91,8 +91,7 @@ BlockClosureTest >> testCullCullCullCull [
 		cull: 3
 		cull: 4.
 	self
-		should: [ 
-			[ :x :y :z :a :b |  ]
+		should: [ [ :x :y :z :a :b |  ]
 				cull: 1
 				cull: 2
 				cull: 3
@@ -104,35 +103,40 @@ BlockClosureTest >> testCullCullCullCull [
 				cull: 1
 				cull: 2
 				cull: 3
-				cull: 4) = 0.
+				cull: 4)
+		equals: 0.
 	self
 		assert:
 			([ :x | x ]
 				cull: 1
 				cull: 2
 				cull: 3
-				cull: 4) = 1.
+				cull: 4)
+		equals: 1.
 	self
 		assert:
 			([ :x :y | y ]
 				cull: 1
 				cull: 2
 				cull: 3
-				cull: 4) = 2.
+				cull: 4)
+		equals: 2.
 	self
 		assert:
 			([ :x :y :z | z ]
 				cull: 1
 				cull: 2
 				cull: 3
-				cull: 4) = 3.
+				cull: 4)
+		equals: 3.
 	self
 		assert:
 			([ :x :y :z :a | a ]
 				cull: 1
 				cull: 2
 				cull: 3
-				cull: 4) = 4
+				cull: 4)
+		equals: 4
 ]
 
 { #category : #tests }
@@ -152,43 +156,41 @@ BlockClosureTest >> testNew [
 BlockClosureTest >> testNoArguments [
 	| block1 block2 |
 	"avoid compile error in GemStone"
-	block1 := [:arg | 1 + 2].
-	block2 := [:arg1 :arg2 | 1 + 2].
-	[10
-		timesRepeat: block1]
-		ifError: [:err | self deny: err = 'This block requires 1 arguments.'].
-	[10
-		timesRepeat: block2]
-		ifError: [:err  | self deny: err = 'This block requires 2 arguments.'] 
+	block1 := [ :arg | 1 + 2 ].
+	block2 := [ :arg1 :arg2 | 1 + 2 ].
+	[ 10 timesRepeat: block1 ] ifError: [ :err | self deny: err equals: 'This block requires 1 arguments.' ].
+	[ 10 timesRepeat: block2 ] ifError: [ :err | self deny: err equals: 'This block requires 2 arguments.' ]
 ]
 
 { #category : #'tests - on-fork' }
 BlockClosureTest >> testOnFork [
 	"Test that if code runs without errors, there is no fork! "
-	
+
 	| result1 result2 |
-	
 	result2 := nil.
 	result1 := [ 1 ] on: Exception fork: [ result2 := 2 ].
-	
+
 	Processor yield.
-	
-	self assert: (result1 = 1).
-	self assert: (result2 isNil ).
+
+	self assert: result1 equals: 1.
+	self assert: result2 isNil
 ]
 
 { #category : #'tests - on-fork' }
 BlockClosureTest >> testOnForkErrorExecutesBlock [
 	"Test that if code runs with error, there is fork"
-	
+
 	| result sema |
-	sema := Semaphore new.	
+	sema := Semaphore new.
 	result := nil.
-	[ 1/0 ] on: Exception fork: [ result := 2. sema signal].
-		
-	sema wait.	
+	[ 1 / 0 ]
+		on: Exception
+		fork: [ result := 2.
+			sema signal ].
+
+	sema wait.
 	"and of course result should be not nil "
-	self assert: result = 2.
+	self assert: result equals: 2
 ]
 
 { #category : #'tests - on-fork' }
@@ -221,20 +223,20 @@ BlockClosureTest >> testOnForkErrorReturnsNil [
 { #category : #'tests - on-fork' }
 BlockClosureTest >> testOnForkErrorTakesLessThanOneSecond [
 	"Test that if code runs with error, there is fork"
-	
-	| sema timeout |
 
-	self flag: 'This test is too brittle, failing often on Windows CI'; skip.
-		
+	| sema timeout |
+	self
+		flag: 'This test is too brittle, failing often on Windows CI';
+		skip.
+
 	self flag: 'The following line makes the test pass under headless linux. Everywhere else this test works'.
-	Smalltalk os isUnix
-		ifTrue: [ 1 milliSecond wait ].
-	
+	Smalltalk os isUnix ifTrue: [ 1 milliSecond wait ].
+
 	sema := Semaphore new.
-	[ 1/0 ] on: Exception fork: [ sema signal ].
-		
-	timeout := (sema waitTimeoutSeconds: 1).	
-	self assert: timeout == false
+	[ 1 / 0 ] on: Exception fork: [ sema signal ].
+
+	timeout := sema waitTimeoutSeconds: 1.
+	self assert: timeout identicalTo: false
 ]
 
 { #category : #'tests - on-fork' }
@@ -269,12 +271,8 @@ BlockClosureTest >> testOneArgument [
 	| c |
 	c := OrderedCollection new.
 	c add: 'hello'.
-	[c
-		do: [1 + 2]]
-		ifError: [:err | self deny: err = 'This block requires 0 arguments.'].
-	[c
-		do: [:arg1 :arg2 | 1 + 2]]
-		ifError: [:err | self deny: err = 'This block requires 2 arguments.'] 
+	[ c do: [ 1 + 2 ] ] ifError: [ :err | self deny: err equals: 'This block requires 0 arguments.' ].
+	[ c do: [ :arg1 :arg2 | 1 + 2 ] ] ifError: [ :err | self deny: err equals: 'This block requires 2 arguments.' ]
 ]
 
 { #category : #'tests - printing' }
@@ -287,10 +285,10 @@ BlockClosureTest >> testPrintOn [
 BlockClosureTest >> testSetUp [
 	"Note: In addition to verifying that the setUp worked the way it was expected to, testSetUp is used to illustrate the meaning of the simple access methods, methods that are not normally otherwise 'tested'"
 
-	self assert: aBlockContext home = contextOfaBlockContext.
-	self assert: aBlockContext receiver = self.
+	self assert: aBlockContext home equals: contextOfaBlockContext.
+	self assert: aBlockContext receiver equals: self.
 	"Depending on the closure implementation, it's either a compiled block, a compiled method or nil."
-	self assert: (aBlockContext method isNil or: [aBlockContext method isKindOf: CompiledCode]).
+	self assert: (aBlockContext method isNil or: [ aBlockContext method isKindOf: CompiledCode ])
 ]
 
 { #category : #testing }
@@ -398,35 +396,28 @@ BlockClosureTest >> testValueWithArguments [
 
 { #category : #'tests - evaluating' }
 BlockClosureTest >> testValueWithExitBreak [
+	| val |
+	[ :break | 
+	1 to: 10 do: [ :i | 
+		val := i.
+		i = 4 ifTrue: [ break value ] ] ] valueWithExit.
 
-	| val |	
-
-	[ :break |
-	    1 to: 10 do: [ :i |
-			val := i.
-			i = 4 ifTrue: [break value].
-		] 
-	] valueWithExit.
-
-	self assert: val = 4.
+	self assert: val equals: 4
 ]
 
 { #category : #'tests - evaluating' }
 BlockClosureTest >> testValueWithExitContinue [
+	| val last |
+	val := 0.
 
-	| val last |	
-	val := 0. 
+	1 to: 10 do: [ :i | 
+		[ :continue | 
+		i = 4 ifTrue: [ continue value ].
+		val := val + 1.
+		last := i ] valueWithExit ].
 
-	1 to: 10 do: [ :i |
-		[ :continue |
-			i = 4 ifTrue: [continue value].
-			val := val + 1.
-			last := i
-		] valueWithExit.
-	].
-
-	self assert: val = 9.
-	self assert: last = 10.	
+	self assert: val equals: 9.
+	self assert: last equals: 10
 ]
 
 { #category : #'tests - evaluating' }
@@ -434,44 +425,28 @@ BlockClosureTest >> testValueWithPossibleArgs [
 	| block blockWithArg blockWith2Arg |
 	block := [ 1 ].
 	blockWithArg := [ :arg | arg ].
-	blockWith2Arg := [ :arg1 :arg2 | 
-	{arg1.
-	arg2} ].
-	self assert: (block valueWithPossibleArgs: #()) = 1.
-	self assert: (block valueWithPossibleArgs: #(1)) = 1.
+	blockWith2Arg := [ :arg1 :arg2 | {arg1 . arg2} ].
+	self assert: (block valueWithPossibleArgs: #()) equals: 1.
+	self assert: (block valueWithPossibleArgs: #(1)) equals: 1.
 	self assert: (blockWithArg valueWithPossibleArgs: #()) isNil.
-	self assert: (blockWithArg valueWithPossibleArgs: #(1)) = 1.
-	self assert: (blockWithArg valueWithPossibleArgs: #(1 2)) = 1.
-	self
-		assert:
-			(blockWith2Arg valueWithPossibleArgs: #())
-				=
-					{nil.
-					nil}.
-	self
-		assert:
-			(blockWith2Arg valueWithPossibleArgs: #(1))
-				=
-					{1.
-					nil}.
-	self assert: (blockWith2Arg valueWithPossibleArgs: #(1 2)) = #(1 2).
-	self assert: (blockWith2Arg valueWithPossibleArgs: #(1 2 3)) = #(1 2)
+	self assert: (blockWithArg valueWithPossibleArgs: #(1)) equals: 1.
+	self assert: (blockWithArg valueWithPossibleArgs: #(1 2)) equals: 1.
+	self assert: (blockWith2Arg valueWithPossibleArgs: #()) equals: {nil . nil}.
+	self assert: (blockWith2Arg valueWithPossibleArgs: #(1)) equals: {1 . nil}.
+	self assert: (blockWith2Arg valueWithPossibleArgs: #(1 2)) equals: #(1 2).
+	self assert: (blockWith2Arg valueWithPossibleArgs: #(1 2 3)) equals: #(1 2)
 ]
 
 { #category : #'tests - evaluating' }
 BlockClosureTest >> testValueWithPossibleArgument [
-	| block  blockWithArg blockWith2Arg |
+	| block blockWithArg blockWith2Arg |
+	block := [ 1 ].
+	blockWithArg := [ :arg | arg ].
+	blockWith2Arg := [ :arg1 :arg2 | {arg1 . arg2} ].
 
-	block := [1].
-	blockWithArg  := [:arg | arg].
-	blockWith2Arg := [:arg1 :arg2 | {arg1. arg2}].
+	self assert: (block valueWithPossibleArgument: 1) equals: 1.
 
-	self assert: (block valueWithPossibleArgument: 1) = 1.
-	
-	self assert: (blockWithArg valueWithPossibleArgument: 1) = 1.
-	
-	self assert: (blockWith2Arg valueWithPossibleArgument: 1) = {1 . nil}.
-	
+	self assert: (blockWithArg valueWithPossibleArgument: 1) equals: 1.
 
-	
+	self assert: (blockWith2Arg valueWithPossibleArgument: 1) equals: {1 . nil}
 ]

--- a/src/Kernel-Tests/BlockClosuresTestCase.class.st
+++ b/src/Kernel-Tests/BlockClosuresTestCase.class.st
@@ -407,143 +407,107 @@ BlockClosuresTestCase >> testCannotReturn [
 
 { #category : #tests }
 BlockClosuresTestCase >> testContinuationExample1 [
-
-   | array |
-    array := (1 to: 20) asOrderedCollection.
-   self assert: ((self continuationExample1: array) = array)
-  
+	| array |
+	array := (1 to: 20) asOrderedCollection.
+	self assert: (self continuationExample1: array) equals: array
 ]
 
 { #category : #tests }
 BlockClosuresTestCase >> testContinuationExample2 [
-
-   | array |
-    array := (1 to: 20) asOrderedCollection.
-   self assert: ((self continuationExample2: array) = (array collect: [:x | x * x]))
-  
+	| array |
+	array := (1 to: 20) asOrderedCollection.
+	self assert: (self continuationExample2: array) equals: (array collect: [ :x | x * x ])
 ]
 
 { #category : #tests }
 BlockClosuresTestCase >> testContinuationExample3 [
-
-   | array |
-    array := (1 to: 20) asOrderedCollection.
-   self assert: ((self continuationExample3: array) = (array collect: [:x | x * x - 10]))
-  
+	| array |
+	array := (1 to: 20) asOrderedCollection.
+	self assert: (self continuationExample3: array) equals: (array collect: [ :x | x * x - 10 ])
 ]
 
 { #category : #tests }
 BlockClosuresTestCase >> testExample2 [
-
-   self assert: ((self example2: 5) = (1 to: 5) asOrderedCollection)
-  
+	self assert: (self example2: 5) equals: (1 to: 5) asOrderedCollection
 ]
 
 { #category : #tests }
 BlockClosuresTestCase >> testGpsExample1 [
-
-  | result array |
-
-  array := (1 to: 100) asArray.
-  result := array inject: 0
-              into: [:sum :val | sum + val].
- self assert: ((self gpsExample1: array) = result)
-  
+	| result array |
+	array := (1 to: 100) asArray.
+	result := array inject: 0 into: [ :sum :val | sum + val ].
+	self assert: (self gpsExample1: array) equals: result
 ]
 
 { #category : #tests }
 BlockClosuresTestCase >> testGpsExample2 [
-
-  | result array |
-
-  "  integer matrix elements should be used for the purpose of this test. " 
-  array := #(#(1 2 3 4 5) #(6 7 8 9 10) #(11 12 13 14 15) #(16 17 18 19 20) #(21 22 23 24 25)).
-  result := array inject: 0
-              into: [:sum :subarray |
-                      sum + (subarray inject: 0
-                                          into: [:s :elem | s + elem])].
- self assert: ((self gpsExample2: array) = result)
-  
+	| result array |
+	"  integer matrix elements should be used for the purpose of this test. "
+	array := #(#(1 2 3 4 5) #(6 7 8 9 10) #(11 12 13 14 15) #(16 17 18 19 20) #(21 22 23 24 25)).
+	result := array inject: 0 into: [ :sum :subarray | sum + (subarray inject: 0 into: [ :s :elem | s + elem ]) ].
+	self assert: (self gpsExample2: array) equals: result
 ]
 
 { #category : #tests }
 BlockClosuresTestCase >> testNestedLoopsExample1 [
-
-   | arrays result |
-   arrays := OrderedCollection new.
-   arrays add: #(#a #b);
-             add: #(1 2 3 4);
-             add: #('w' 'x' 'y' 'z').
-    result := OrderedCollection new.
-    CollectionCombinator new
-          forArrays:  arrays
-          processWith: [:item |result addLast: item].
-   self assert: ((self nestedLoopsExample: arrays) = result)
-  
+	| arrays result |
+	arrays := OrderedCollection new.
+	arrays
+		add: #(#a #b);
+		add: #(1 2 3 4);
+		add: #('w' 'x' 'y' 'z').
+	result := OrderedCollection new.
+	CollectionCombinator new forArrays: arrays processWith: [ :item | result addLast: item ].
+	self assert: (self nestedLoopsExample: arrays) equals: result
 ]
 
 { #category : #tests }
 BlockClosuresTestCase >> testReentrantBlock [
-
 	| fib |
-	fib := [:val | 
-		(val <= 0) ifTrue: [self error: 'not a natural number'].
-		(val <= 2) 
-			ifTrue: [1]
-			ifFalse: [(fib value: (val - 1)) + (fib value: (val - 2))]].
+	fib := [ :val | 
+	val <= 0 ifTrue: [ self error: 'not a natural number' ].
+	val <= 2 ifTrue: [ 1 ] ifFalse: [ (fib value: val - 1) + (fib value: val - 2) ] ].
 
-	self 
-		should: [fib value: 0] 
-		raise: self classForTestResult error.
-	self assert: ((fib value: 1) = 1).
-	self assert: ((fib value: 2) = 1).
-	self assert: ((fib value: 3) = 2).
-	self assert: ((fib value: 4) = 3).
-	self assert: ((fib value: 5) = 5).
-	self assert: ((fib value: 6) = 8).
-
+	self should: [ fib value: 0 ] raise: self classForTestResult error.
+	self assert: (fib value: 1) equals: 1.
+	self assert: (fib value: 2) equals: 1.
+	self assert: (fib value: 3) equals: 2.
+	self assert: (fib value: 4) equals: 3.
+	self assert: (fib value: 5) equals: 5.
+	self assert: (fib value: 6) equals: 8
 ]
 
 { #category : #tests }
 BlockClosuresTestCase >> testReentrantBlockOldEnvironment [
-
 	| fib |
 	fib := self constructFibonacciBlockInDeadFrame.
-	self 
-		should: [fib value: 0] 
-		raise: self classForTestResult error.
-	self assert: ((fib value: 1) = 1).
-	self assert: ((fib value: 2) = 1).
-	self assert: ((fib value: 3) = 2).
-	self assert: ((fib value: 4) = 3).
-	self assert: ((fib value: 5) = 5).
-	self assert: ((fib value: 6) = 8).
-
+	self should: [ fib value: 0 ] raise: self classForTestResult error.
+	self assert: (fib value: 1) equals: 1.
+	self assert: (fib value: 2) equals: 1.
+	self assert: (fib value: 3) equals: 2.
+	self assert: (fib value: 4) equals: 3.
+	self assert: (fib value: 5) equals: 5.
+	self assert: (fib value: 6) equals: 8
 ]
 
 { #category : #tests }
 BlockClosuresTestCase >> testReentrantBlockOldEnvironmentWithBlockArguement [
-
 	| fib |
 	fib := self constructFibonacciBlockWithBlockArgumentInDeadFrame.
-	self 
-		should: [fib value: 0 value: fib] 
-		raise: self classForTestResult error.
-	self assert: ((fib value: 1 value: fib) = 1).
-	self assert: ((fib value: 2 value: fib) = 1).
-	self assert: ((fib value: 3 value: fib) = 2).
-	self assert: ((fib value: 4 value: fib) = 3).
-	self assert: ((fib value: 5 value: fib) = 5).
-	self assert: ((fib value: 6 value: fib) = 8).
-
+	self should: [ fib value: 0 value: fib ] raise: self classForTestResult error.
+	self assert: (fib value: 1 value: fib) equals: 1.
+	self assert: (fib value: 2 value: fib) equals: 1.
+	self assert: (fib value: 3 value: fib) equals: 2.
+	self assert: (fib value: 4 value: fib) equals: 3.
+	self assert: (fib value: 5 value: fib) equals: 5.
+	self assert: (fib value: 6 value: fib) equals: 8
 ]
 
 { #category : #tests }
 BlockClosuresTestCase >> testSharedClosureEnvironment [
-	|blockArray|
+	| blockArray |
 	blockArray := self constructSharedClosureEnvironmentInDeadFrame.
-	self assert: ((blockArray at: 2) value = 10).
-	self assert: (((blockArray at: 1) value: 5) = 5).
-	self assert: ((blockArray at: 2) value = 5).
-
+	self assert: (blockArray at: 2) value equals: 10.
+	self assert: ((blockArray at: 1) value: 5) equals: 5.
+	self assert: (blockArray at: 2) value equals: 5
 ]

--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -20,8 +20,7 @@ ClassDescriptionTest >> testAllMethodCategoriesIntegratedThrough [
 
 { #category : #'tests - slots' }
 ClassDescriptionTest >> testAllSlots [
-	self assert: (Context allSlots size = 6).
-	
+	self assert: Context allSlots size equals: 6
 ]
 
 { #category : #'tests - slots' }
@@ -48,13 +47,12 @@ ClassDescriptionTest >> testHasSlotNamed [
 
 { #category : #tests }
 ClassDescriptionTest >> testMethods [
-	self assert: Object methods = Object methodDict values.  
+	self assert: Object methods equals: Object methodDict values
 ]
 
 { #category : #tests }
 ClassDescriptionTest >> testNumberOfMethods [
-	self assert: (Point numberOfMethods = (Point localMethods size + Point class localMethods size)).
-
+	self assert: Point numberOfMethods equals: Point localMethods size + Point class localMethods size
 ]
 
 { #category : #tests }
@@ -67,20 +65,17 @@ ClassDescriptionTest >> testOrganization [
 
 { #category : #'tests - slots' }
 ClassDescriptionTest >> testSlotNamed [
-	self assert: ((Point slotNamed: #x) name = #x).
-
+	self assert: (Point slotNamed: #x) name equals: #x
 ]
 
 { #category : #'tests - slots' }
 ClassDescriptionTest >> testSlotNames [
-	self assert: (Point slotNames = #(x y)).
-	
+	self assert: Point slotNames equals: #(x y)
 ]
 
 { #category : #'tests - slots' }
 ClassDescriptionTest >> testSlots [
-	self assert: (Context slots size = 4).
-	
+	self assert: Context slots size equals: 4
 ]
 
 { #category : #'tests - instance variables' }

--- a/src/Kernel-Tests/ClassHierarchyTest.class.st
+++ b/src/Kernel-Tests/ClassHierarchyTest.class.st
@@ -50,12 +50,14 @@ ClassHierarchyTest >> testObjectFormatInstSize [
 { #category : #tests }
 ClassHierarchyTest >> testSubclassInstVar [
 	| subclasses |
-	SystemNavigation new allClassesDo: [ :cls|
-		subclasses := cls subclasses.
-		self assert: subclasses isNil not.
-		subclasses do: [:subclass|
-			self assert: (subclasses occurrencesOf: subclass) equals: 1.
-			self assert: subclass superclass == cls ]]
+	SystemNavigation new
+		allClassesDo: [ :cls | 
+			subclasses := cls subclasses.
+			self assert: subclasses isNil not.
+			subclasses
+				do: [ :subclass | 
+					self assert: (subclasses occurrencesOf: subclass) equals: 1.
+					self assert: subclass superclass identicalTo: cls ] ]
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/CompiledMethodTrailerTest.class.st
+++ b/src/Kernel-Tests/CompiledMethodTrailerTest.class.st
@@ -33,18 +33,16 @@ CompiledMethodTrailerTest >> testEmbeddingSourceCodeWide [
 
 { #category : #tests }
 CompiledMethodTrailerTest >> testEncodingNoTrailer [
-
 	| trailer |
-	
 	trailer := CompiledMethodTrailer new.
-	
-	"by default it should be a no-trailer, 4 byte wide so it can be used to store a sourcePointer"	
-	self assert: (trailer kind == #NoTrailer ).
+
+	"by default it should be a no-trailer, 4 byte wide so it can be used to store a sourcePointer"
+	self assert: trailer kind identicalTo: #NoTrailer.
 	self assert: trailer size equals: 4.
-	
+
 	trailer := trailer testEncoding.
-	
-	self assert: (trailer kind == #NoTrailer ).
+
+	self assert: trailer kind identicalTo: #NoTrailer.
 	self assert: trailer size equals: 4.
 	"the last bytecode index must be at 0"
 	self assert: trailer endPC equals: 0
@@ -52,18 +50,16 @@ CompiledMethodTrailerTest >> testEncodingNoTrailer [
 
 { #category : #tests }
 CompiledMethodTrailerTest >> testEncodingSourcePointer [
-
 	| trailer |
-	
 	trailer := CompiledMethodTrailer new.
-	
-	CompiledMethod allInstancesDo: [:method | | ptr |
-		trailer method: method.
-		self assert: ( (ptr := method sourcePointer) == trailer sourcePointer).
-		"the last bytecode index must be at 0"
-		ptr ~= 0 ifTrue: [
-			self assert: method endPC equals: trailer endPC ].
-	 ].
+
+	CompiledMethod
+		allInstancesDo: [ :method | 
+			| ptr |
+			trailer method: method.
+			self assert: (ptr := method sourcePointer) identicalTo: trailer sourcePointer.
+			"the last bytecode index must be at 0"
+			ptr ~= 0 ifTrue: [ self assert: method endPC equals: trailer endPC ] ]
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ContextTest.class.st
+++ b/src/Kernel-Tests/ContextTest.class.st
@@ -109,8 +109,8 @@ ContextTest >> setUp [
 
 { #category : #tests }
 ContextTest >> testActivateReturnValue [
-	self assert:  ((aSender activateReturn: aMethodContext value: #()) isKindOf: Context).
-	self assert:  ((aSender activateReturn: aMethodContext value: #()) receiver = aMethodContext).
+	self assert: ((aSender activateReturn: aMethodContext value: #()) isKindOf: Context).
+	self assert: (aSender activateReturn: aMethodContext value: #()) receiver equals: aMethodContext
 ]
 
 { #category : #tests }
@@ -127,8 +127,8 @@ ContextTest >> testActiveHomeMethodContext [
 
 { #category : #tests }
 ContextTest >> testFindContextSuchThat [
-	self assert: (aMethodContext findContextSuchThat: [:each| true]) printString = aMethodContext printString.
-	self assert: (aMethodContext hasContext: aMethodContext). 
+	self assert: (aMethodContext findContextSuchThat: [ :each | true ]) printString equals: aMethodContext printString.
+	self assert: (aMethodContext hasContext: aMethodContext)
 ]
 
 { #category : #tests }
@@ -161,21 +161,25 @@ ContextTest >> testNonActiveBlockContextHome [
 { #category : #tests }
 ContextTest >> testReturn [
 	"Why am I overriding setUp? Because sender must be thisContext, i.e, testReturn, not setUp."
-	aMethodContext := Context sender: thisContext receiver: aReceiver method: aCompiledMethod arguments: #(). 
-	self assert: (aMethodContext return: 5) = 5.
+
+	aMethodContext := Context
+		sender: thisContext
+		receiver: aReceiver
+		method: aCompiledMethod
+		arguments: #().
+	self assert: (aMethodContext return: 5) equals: 5
 ]
 
 { #category : #tests }
 ContextTest >> testSetUp [
 	"Note: In addition to verifying that the setUp worked the way it was expected to, testSetUp is used to illustrate the meaning of the simple access methods, methods that are not normally otherwise 'tested'"
-	
-	self deny: aMethodContext isDead.
-	self assert: aMethodContext home = aMethodContext.
-	self assert: aMethodContext receiver = aReceiver.
-	self assert: (aMethodContext method isKindOf: CompiledMethod).
-	self assert: aMethodContext method = aCompiledMethod. 
-	self assert: aMethodContext client printString = 'ContextTest>>#testSetUp'.
 
+	self deny: aMethodContext isDead.
+	self assert: aMethodContext home equals: aMethodContext.
+	self assert: aMethodContext receiver equals: aReceiver.
+	self assert: (aMethodContext method isKindOf: CompiledMethod).
+	self assert: aMethodContext method equals: aCompiledMethod.
+	self assert: aMethodContext client printString equals: 'ContextTest>>#testSetUp'
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ContinuationTest.class.st
+++ b/src/Kernel-Tests/ContinuationTest.class.st
@@ -20,37 +20,55 @@ ContinuationTest >> callcc: aBlock [
 ContinuationTest >> testBlockEscape [
 	| x |
 	tmp := 0.
-	x := [ tmp := tmp + 1. tmp2 value ].
-	self callcc: [ :cc | tmp2 := cc. x value ].
-	tmp2 := [ ].
+	x := [ tmp := tmp + 1.
+	tmp2 value ].
+	self
+		callcc: [ :cc | 
+			tmp2 := cc.
+			x value ].
+	tmp2 := [  ].
 	x value.
-	self assert: tmp = 2
+	self assert: tmp equals: 2
 ]
 
 { #category : #tests }
 ContinuationTest >> testBlockTemps [
 	| y |
-	#(1 2 3) do: [ :i |
-		| x |
-		x := i.
-		tmp ifNil: [ tmp2 := (self callcc: [ :cc | tmp := cc. [ :q | ] ]) ].
-		tmp2 value: x.
-		x := 17 ].
-	y := (self callcc: [ :cc | tmp value: cc. 42 ]).
-	self assert: y = 1
+	#(1 2 3)
+		do: [ :i | 
+			| x |
+			x := i.
+			tmp
+				ifNil: [ tmp2 := self
+						callcc: [ :cc | 
+							tmp := cc.
+							[ :q |  ] ] ].
+			tmp2 value: x.
+			x := 17 ].
+	y := self
+		callcc: [ :cc | 
+			tmp value: cc.
+			42 ].
+	self assert: y equals: 1
 ]
 
 { #category : #tests }
 ContinuationTest >> testBlockVars [
 	| continuation |
 	tmp := 0.
-	tmp := (self callcc: [ :cc | continuation := cc. 0 ]) + tmp.
+	tmp := (self
+		callcc: [ :cc | 
+			continuation := cc.
+			0 ]) + tmp.
 	tmp2
 		ifNotNil: [ tmp2 value ]
-		ifNil: [
-			#(1 2 3) do: [ :i |
-				self callcc: [ :cc | tmp2 := cc. continuation value: i ] ] ].
-	self assert: tmp = 6
+		ifNil: [ #(1 2 3)
+				do: [ :i | 
+					self
+						callcc: [ :cc | 
+							tmp2 := cc.
+							continuation value: i ] ] ].
+	self assert: tmp equals: 6
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/DateAndTimeDosEpochTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeDosEpochTest.class.st
@@ -378,14 +378,13 @@ DateAndTimeDosEpochTest >> testToByDo [
 
 { #category : #tests }
 DateAndTimeDosEpochTest >> testToday [
-	self deny: aDateAndTime = DateAndTime today
-
+	self deny: aDateAndTime equals: DateAndTime today
 ]
 
 { #category : #tests }
 DateAndTimeDosEpochTest >> testTommorrow [
-	self assert: (DateAndTime today + 24 hours) equals: (DateAndTime tomorrow).
-	self deny: aDateAndTime = (DateAndTime tomorrow)
+	self assert: DateAndTime today + 24 hours equals: DateAndTime tomorrow.
+	self deny: aDateAndTime equals: DateAndTime tomorrow
 ]
 
 { #category : #tests }
@@ -434,6 +433,5 @@ DateAndTimeDosEpochTest >> testYearMonthDayHourMinuteSecondNanosSecondOffset [
 
 { #category : #tests }
 DateAndTimeDosEpochTest >> testYesterday [
-	self deny: aDateAndTime = DateAndTime yesterday
-
+	self deny: aDateAndTime equals: DateAndTime yesterday
 ]

--- a/src/Kernel-Tests/DateAndTimeEpochTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeEpochTest.class.st
@@ -45,182 +45,146 @@ DateAndTimeEpochTest >> tearDown [
 
 { #category : #tests }
 DateAndTimeEpochTest >> testAsDate [
-	self assert: aDateAndTime asDate =   'January 1, 1901' asDate.
-
-
+	self assert: aDateAndTime asDate equals: 'January 1, 1901' asDate
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testAsDateAndTime [
-	self assert: aDateAndTime asDateAndTime =  aDateAndTime
-	
-
+	self assert: aDateAndTime asDateAndTime equals: aDateAndTime
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testAsDuration [
-	self assert: aDateAndTime asDuration =  0 asDuration
-	
-
+	self assert: aDateAndTime asDuration equals: 0 asDuration
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testAsLocal [
-	self assert: aDateAndTime asLocal =  aDateAndTime.
-	self assert: aDateAndTime asLocal = (aDateAndTime offset: aDateAndTime class localOffset)
-	
-
+	self assert: aDateAndTime asLocal equals: aDateAndTime.
+	self assert: aDateAndTime asLocal equals: (aDateAndTime offset: aDateAndTime class localOffset)
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testAsNanoSeconds [
-	self assert: aDateAndTime asNanoSeconds =  0 asDuration asNanoSeconds
-	
-
+	self assert: aDateAndTime asNanoSeconds equals: 0 asDuration asNanoSeconds
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testAsSeconds [
-	self assert: aDateAndTime asSeconds =  0 asDuration asSeconds
-	
-
+	self assert: aDateAndTime asSeconds equals: 0 asDuration asSeconds
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testAsTime [
-	self assert: aDateAndTime asTime =  Time midnight.
-
+	self assert: aDateAndTime asTime equals: Time midnight
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testAsUTC [
-	self assert: aDateAndTime asUTC =  aDateAndTime
-          
+	self assert: aDateAndTime asUTC equals: aDateAndTime
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testCurrent [
-	self deny: aDateAndTime =  (DateAndTime current).
-
+	self deny: aDateAndTime equals: DateAndTime current
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testDateTime [
-	self assert: aDateAndTime =  (DateAndTime date: '01-01-1901' asDate time: '00:00:00' asTime)
-
+	self assert: aDateAndTime equals: (DateAndTime date: '01-01-1901' asDate time: '00:00:00' asTime)
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testDay [
-	self assert: aDateAndTime day =   DateAndTime new day
-
+	self assert: aDateAndTime day equals: DateAndTime new day
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testDayMonthYearDo [
-	|iterations|
+	| iterations |
 	iterations := 0.
-	self assert: (aDateAndTime dayMonthYearDo: [:eachDay :eachMonth :eachYear |  iterations := iterations + 1])  = 1.
-	self assert: (aDateAndTime dayMonthYearDo: [:eachDay :eachMonth :eachYear |  eachYear])  = 1901.
-	self assert: (aDateAndTime dayMonthYearDo: [:eachDay :eachMonth :eachYear |  eachMonth]) = 1.
-	self assert: (aDateAndTime dayMonthYearDo: [:eachDay :eachMonth :eachYear |  eachDay]) = 1.
-
+	self assert: (aDateAndTime dayMonthYearDo: [ :eachDay :eachMonth :eachYear | iterations := iterations + 1 ]) equals: 1.
+	self assert: (aDateAndTime dayMonthYearDo: [ :eachDay :eachMonth :eachYear | eachYear ]) equals: 1901.
+	self assert: (aDateAndTime dayMonthYearDo: [ :eachDay :eachMonth :eachYear | eachMonth ]) equals: 1.
+	self assert: (aDateAndTime dayMonthYearDo: [ :eachDay :eachMonth :eachYear | eachDay ]) equals: 1
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testDayOfMonth [
-	self assert: aDateAndTime dayOfMonth  = 1.
-
+	self assert: aDateAndTime dayOfMonth equals: 1
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testDayOfWeek [
-	self assert: aDateAndTime dayOfWeek  = 3.
-	self assert: aDateAndTime dayOfWeekAbbreviation = 'Tue'.
-	self assert: aDateAndTime dayOfWeekName = 'Tuesday'.
-
+	self assert: aDateAndTime dayOfWeek equals: 3.
+	self assert: aDateAndTime dayOfWeekAbbreviation equals: 'Tue'.
+	self assert: aDateAndTime dayOfWeekName equals: 'Tuesday'
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testDayOfYear [
-	self assert: aDateAndTime dayOfYear  = 1.
-
-
+	self assert: aDateAndTime dayOfYear equals: 1
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testDaysInMonth [
-	self assert: aDateAndTime daysInMonth  = 31.
-
-
+	self assert: aDateAndTime daysInMonth equals: 31
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testDaysInYear [
-	self assert: aDateAndTime daysInYear  = 365.
-
-
+	self assert: aDateAndTime daysInYear equals: 365
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testDaysLeftInYear [
-	self assert: aDateAndTime daysLeftInYear  = 364.
-
-
+	self assert: aDateAndTime daysLeftInYear equals: 364
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testDuration [
-	self assert: aDateAndTime duration  = 0 asDuration.
-
-
+	self assert: aDateAndTime duration equals: 0 asDuration
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testEpoch [
-	self assert: aDateAndTime =  '1901-01-01T00:00:00+00:00' asDateAndTime
-
+	self assert: aDateAndTime equals: '1901-01-01T00:00:00+00:00' asDateAndTime
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testFirstDayOfMonth [
-	self assert: aDateAndTime firstDayOfMonth =   1
-
+	self assert: aDateAndTime firstDayOfMonth equals: 1
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testFromSeconds [
-	self assert: aDateAndTime =  (DateAndTime fromSeconds: 0).
-
+	self assert: aDateAndTime equals: (DateAndTime fromSeconds: 0)
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testFromString [
-	self assert: aDateAndTime =  (DateAndTime fromString: ' 1901-01-01T00:00:00+00:00').
-	self assert: aDateAndTime =  (DateAndTime fromString: ' 1901-01-01T00:00:00').
-	self assert: aDateAndTime =  (DateAndTime fromString: ' 1901-01-01T00:00').
-	self assert: aDateAndTime =  (DateAndTime fromString: ' 1901-01-01T00:00:00+00:00').
-
+	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1901-01-01T00:00:00+00:00').
+	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1901-01-01T00:00:00').
+	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1901-01-01T00:00').
+	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1901-01-01T00:00:00+00:00')
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testHash [
-	self assert: aDateAndTime hash = DateAndTime new hash
+	self assert: aDateAndTime hash equals: DateAndTime new hash
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testHour [
-	self assert: aDateAndTime hour =    aDateAndTime hour24.
-	self assert: aDateAndTime hour =    0.
-	self assert: aDateAndTime hour =    aDateAndTime hours
-
+	self assert: aDateAndTime hour equals: aDateAndTime hour24.
+	self assert: aDateAndTime hour equals: 0.
+	self assert: aDateAndTime hour equals: aDateAndTime hours
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testHour12 [
-	self assert: aDateAndTime hour12  = DateAndTime new hour12.
-	self assert: aDateAndTime hour12  = 12
-
+	self assert: aDateAndTime hour12 equals: DateAndTime new hour12.
+	self assert: aDateAndTime hour12 equals: 12
 ]
 
 { #category : #tests }
@@ -231,8 +195,8 @@ DateAndTimeEpochTest >> testIsLeapYear [
 
 { #category : #tests }
 DateAndTimeEpochTest >> testJulianDayNumber [
-	self assert: aDateAndTime =  (DateAndTime julianDayNumber: 2415386).
-	self assert: aDateAndTime julianDayNumber = 2415386.
+	self assert: aDateAndTime equals: (DateAndTime julianDayNumber: 2415386).
+	self assert: aDateAndTime julianDayNumber equals: 2415386
 ]
 
 { #category : #tests }
@@ -244,94 +208,100 @@ DateAndTimeEpochTest >> testLessThan [
 
 { #category : #tests }
 DateAndTimeEpochTest >> testMeridianAbbreviation [
-	self assert: aDateAndTime meridianAbbreviation = 'AM'.
-
-	
+	self assert: aDateAndTime meridianAbbreviation equals: 'AM'
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testMiddleOf [
-	self assert: (aDateAndTime middleOf: '2:00:00:00' asDuration) = 
-	 (Timespan starting: '12-31-1900' asDate duration: 2 days).
-	
-
+	self assert: (aDateAndTime middleOf: '2:00:00:00' asDuration) equals: (Timespan starting: '12-31-1900' asDate duration: 2 days)
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testMidnight [
-	self assert: aDateAndTime midnight =  aDateAndTime
-
+	self assert: aDateAndTime midnight equals: aDateAndTime
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testMinus [
-	self assert: aDateAndTime - aDateAndTime =  '0:00:00:00' asDuration.
-	self assert: aDateAndTime - '0:00:00:00' asDuration = aDateAndTime.
-	self assert: aDateAndTime - aDuration =  (DateAndTime year: 1900 month: 12 day: 30 hour: 21 minute: 56 second: 55 nanoSecond: 999999995 offset: 0 hours ).
-	" I believe this Failure is a bug in the nanosecond part of (DateAndTime >> year:month:day:hour:minute:second:nanoSecond:offset:)" 
+	self assert: aDateAndTime - aDateAndTime equals: '0:00:00:00' asDuration.
+	self assert: aDateAndTime - '0:00:00:00' asDuration equals: aDateAndTime.
+	self
+		assert: aDateAndTime - aDuration
+		equals:
+			(DateAndTime
+				year: 1900
+				month: 12
+				day: 30
+				hour: 21
+				minute: 56
+				second: 55
+				nanoSecond: 999999995
+				offset: 0 hours)
+	" I believe this Failure is a bug in the nanosecond part of (DateAndTime >> year:month:day:hour:minute:second:nanoSecond:offset:)"
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testMinute [
-	self assert: aDateAndTime minute =  0
-
-
+	self assert: aDateAndTime minute equals: 0
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testMinutes [
-	self assert: aDateAndTime minutes = 0
-
+	self assert: aDateAndTime minutes equals: 0
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testMonth [
-	self assert: aDateAndTime month  = 1.
-	self assert: aDateAndTime monthAbbreviation = 'Jan'.
-	self assert: aDateAndTime monthName = 'January'.
-	self assert: aDateAndTime monthIndex = 1.
+	self assert: aDateAndTime month equals: 1.
+	self assert: aDateAndTime monthAbbreviation equals: 'Jan'.
+	self assert: aDateAndTime monthName equals: 'January'.
+	self assert: aDateAndTime monthIndex equals: 1
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testNanoSecond [
-	self assert: aDateAndTime nanoSecond =  0
-
-
+	self assert: aDateAndTime nanoSecond equals: 0
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testNew [
-	self assert: aDateAndTime =  (DateAndTime new).
-
+	self assert: aDateAndTime equals: DateAndTime new
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testNoon [
-	self assert: aDateAndTime noon = '1901-01-01T12:00:00+00:00' asDateAndTime
+	self assert: aDateAndTime noon equals: '1901-01-01T12:00:00+00:00' asDateAndTime
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testNow [
-	self deny: aDateAndTime =  (DateAndTime now).
-
+	self deny: aDateAndTime equals: DateAndTime now
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testOffset [
-
-	self assert: aDateAndTime offset =  '0:00:00:00' asDuration.
-	self assert: (aDateAndTime offset: '-0:12:00:00') equals:  '1900-12-31T12:00:00-12:00' asDateAndTime.
-	self assert: (aDateAndTime offset: '0:12:00:00') equals:  '1901-01-01T12:00:00+12:00' asDateAndTime
+	self assert: aDateAndTime offset equals: '0:00:00:00' asDuration.
+	self assert: (aDateAndTime offset: '-0:12:00:00') equals: '1900-12-31T12:00:00-12:00' asDateAndTime.
+	self assert: (aDateAndTime offset: '0:12:00:00') equals: '1901-01-01T12:00:00+12:00' asDateAndTime
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testPlus [
-	self assert: aDateAndTime + '0:00:00:00' = aDateAndTime.
-	self assert: aDateAndTime + 0 = aDateAndTime.
-	self assert: aDateAndTime + aDuration = (DateAndTime year: 1901 month: 1 day: 2 hour: 2 minute: 3 second: 4 nanoSecond: 5 offset: 0 hours )
+	self assert: aDateAndTime + '0:00:00:00' equals: aDateAndTime.
+	self assert: aDateAndTime + 0 equals: aDateAndTime.
+	self
+		assert: aDateAndTime + aDuration
+		equals:
+			(DateAndTime
+				year: 1901
+				month: 1
+				day: 2
+				hour: 2
+				minute: 3
+				second: 4
+				nanoSecond: 5
+				offset: 0 hours)
 	" I believe this is a bug in the nanosecond part of (DateAndTime >> year:month:day:hour:minute:second:nanoSecond:offset:)"
-	
-
 ]
 
 { #category : #tests }
@@ -342,48 +312,40 @@ DateAndTimeEpochTest >> testPrintOn [
 
 { #category : #tests }
 DateAndTimeEpochTest >> testSecond [
-	self assert: aDateAndTime second =  0
-
-
+	self assert: aDateAndTime second equals: 0
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testSeconds [
-	self assert: aDateAndTime seconds =  0
-
-
+	self assert: aDateAndTime seconds equals: 0
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testTicks [
-	self assert: aDateAndTime ticks =  (DateAndTime julianDayNumber: 2415386) ticks.
-	self assert: aDateAndTime ticks = #(2415386 0 0)
+	self assert: aDateAndTime ticks equals: (DateAndTime julianDayNumber: 2415386) ticks.
+	self assert: aDateAndTime ticks equals: #(2415386 0 0)
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testTicksOffset [
-	self assert: aDateAndTime =  (aDateAndTime ticks:  #(2415386 0 0) offset: DateAndTime localOffset).
-
+	self assert: aDateAndTime equals: (aDateAndTime ticks: #(2415386 0 0) offset: DateAndTime localOffset)
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testTimeZone [
-	self assert: aDateAndTime timeZoneName	= 'Universal Time'.
-	self assert: aDateAndTime timeZoneAbbreviation	=  'UTC'
-
-
+	self assert: aDateAndTime timeZoneName equals: 'Universal Time'.
+	self assert: aDateAndTime timeZoneAbbreviation equals: 'UTC'
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testTo [
-	self assert: (aDateAndTime to: aDateAndTime) = (DateAndTime new to: DateAndTime new) 
+	self assert: (aDateAndTime to: aDateAndTime) equals: (DateAndTime new to: DateAndTime new)
 	"MessageNotUnderstood: UndefinedObject>>starting:ending:  where UndefinedObject is Timespan "
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testToBy [
-	self assert: (aDateAndTime to: aDateAndTime + 10 days by: 5 days) = 
-				(DateAndTime new to: DateAndTime new + 10 days by: 5 days ) 
+	self assert: (aDateAndTime to: aDateAndTime + 10 days by: 5 days) equals: (DateAndTime new to: DateAndTime new + 10 days by: 5 days)
 	"MessageNotUnderstood: UndefinedObject>>starting:ending:  where UndefinedObject is Timespan "
 ]
 
@@ -395,65 +357,109 @@ DateAndTimeEpochTest >> testToByDo [
 
 { #category : #tests }
 DateAndTimeEpochTest >> testToday [
-	self deny: aDateAndTime =  (DateAndTime today).
-
+	self deny: aDateAndTime equals: DateAndTime today
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testTommorrow [
-	self assert: (DateAndTime today + 24 hours) =  (DateAndTime tomorrow).
-	self deny: aDateAndTime =  (DateAndTime tomorrow).
-     "MessageNotUnderstood: Date class>>starting:"
+	self assert: DateAndTime today + 24 hours equals: DateAndTime tomorrow.
+	self deny: aDateAndTime equals: DateAndTime tomorrow
+	"MessageNotUnderstood: Date class>>starting:"
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testUtcOffset [
-     self assert: (aDateAndTime offset: '0:12:00:00') =  '1901-01-01T12:00:00+12:00' asDateAndTime
+	self assert: (aDateAndTime offset: '0:12:00:00') equals: '1901-01-01T12:00:00+12:00' asDateAndTime
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testYear [
-	self assert: aDateAndTime year = 1901.
-
-	
+	self assert: aDateAndTime year equals: 1901
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testYearDay [
-	self assert: aDateAndTime =  (DateAndTime year: 1901 day: 1).
-
+	self assert: aDateAndTime equals: (DateAndTime year: 1901 day: 1)
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testYearDayHourMinuteSecond [
-	self assert: aDateAndTime =  (DateAndTime year: 1901 day: 1 hour: 0 minute: 0 second: 0).
-
+	self
+		assert: aDateAndTime
+		equals:
+			(DateAndTime
+				year: 1901
+				day: 1
+				hour: 0
+				minute: 0
+				second: 0)
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testYearMonthDay [
-	self assert: aDateAndTime =  (DateAndTime year: 1901 month: 1 day: 1).
-
+	self assert: aDateAndTime equals: (DateAndTime year: 1901 month: 1 day: 1)
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testYearMonthDayHourMinuteSecond [
-	self assert: aDateAndTime =  (DateAndTime year: 1901 month: 1 day: 1 hour: 0 minute: 0 second: 0).
-
+	self
+		assert: aDateAndTime
+		equals:
+			(DateAndTime
+				year: 1901
+				month: 1
+				day: 1
+				hour: 0
+				minute: 0
+				second: 0)
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testYearMonthDayHourMinuteSecondNanosSecondOffset [
-	self assert: aDateAndTime =  (DateAndTime year: 1901 month: 1 day: 1 hour: 0 minute: 0 second: 0 nanoSecond: 0 offset:0 hours ).
-	self assert: ((DateAndTime year: 1 month: 1 day: 1 hour: 0 minute: 0 second: 0 nanoSecond: 0 offset: 0 hours ) +
-				(Duration days: 1 hours: 2 minutes: 3 seconds: 4  nanoSeconds: 5) ) =  	
-				(DateAndTime year: 1 month: 1 day: 2 hour: 2 minute: 3 second: 4 nanoSecond: 5 offset: 0 hours ) 
-	" I believe this is a bug in the nanosecond part of (DateAndTime >> year:month:day:hour:minute:second:nanoSecond:offset:)"" I believe this is a bug in the nanosecond part of (DateAndTime >> year:month:day:hour:minute:second:nanoSecond:offset:)"   
-
+	self
+		assert: aDateAndTime
+		equals:
+			(DateAndTime
+				year: 1901
+				month: 1
+				day: 1
+				hour: 0
+				minute: 0
+				second: 0
+				nanoSecond: 0
+				offset: 0 hours).
+	self
+		assert:
+			(DateAndTime
+				year: 1
+				month: 1
+				day: 1
+				hour: 0
+				minute: 0
+				second: 0
+				nanoSecond: 0
+				offset: 0 hours)
+				+
+					(Duration
+						days: 1
+						hours: 2
+						minutes: 3
+						seconds: 4
+						nanoSeconds: 5)
+		equals:
+			(DateAndTime
+				year: 1
+				month: 1
+				day: 2
+				hour: 2
+				minute: 3
+				second: 4
+				nanoSecond: 5
+				offset: 0 hours)
+	" I believe this is a bug in the nanosecond part of (DateAndTime >> year:month:day:hour:minute:second:nanoSecond:offset:)"" I believe this is a bug in the nanosecond part of (DateAndTime >> year:month:day:hour:minute:second:nanoSecond:offset:)"
 ]
 
 { #category : #tests }
 DateAndTimeEpochTest >> testYesterday [
-	self deny: aDateAndTime =  (DateAndTime yesterday).
-
+	self deny: aDateAndTime equals: DateAndTime yesterday
 ]

--- a/src/Kernel-Tests/DateAndTimeLeapTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeLeapTest.class.st
@@ -137,9 +137,8 @@ DateAndTimeLeapTest >> testDaysLeftInYear [
 
 { #category : #tests }
 DateAndTimeLeapTest >> testFirstDayOfMonth [
-	self deny: aDateAndTime firstDayOfMonth =  1.
+	self deny: aDateAndTime firstDayOfMonth equals: 1.
 	self assert: aDateAndTime firstDayOfMonth equals: 32
-
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/DateAndTimeTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeTest.class.st
@@ -34,12 +34,10 @@ DateAndTimeTest >> selectorsToBeIgnored [
 
 { #category : #'tests - arithmetic' }
 DateAndTimeTest >> testArithmeticAcrossDateBoundary [
-
 	| t1 t2 |
-	t1 := '2004-01-07T11:55:00+00:00' asDateAndTime. 
-	t2 := t1 - ( (42900+1) seconds).  
-	self assert: t2 = ('2004-01-06T23:59:59+00:00' asDateAndTime)
-
+	t1 := '2004-01-07T11:55:00+00:00' asDateAndTime.
+	t2 := t1 - (42900 + 1) seconds.
+	self assert: t2 equals: '2004-01-06T23:59:59+00:00' asDateAndTime
 ]
 
 { #category : #tests }
@@ -93,62 +91,74 @@ DateAndTimeTest >> testAsUnixTimeIndependentOfTimezone [
 { #category : #tests }
 DateAndTimeTest >> testCreationWithOffsets [
 	| dt1 dt2 |
-	dt1 := (DateAndTime year: 2222 month: 1 day: 22 hour: 1 minute: 22 second: 33 offset: 0 hours).
-	dt2 := (DateAndTime year: 2222 month: 1 day: 22 hour: 1 minute: 22 second: 33 offset: 2 hours).
-	
+	dt1 := DateAndTime
+		year: 2222
+		month: 1
+		day: 22
+		hour: 1
+		minute: 22
+		second: 33
+		offset: 0 hours.
+	dt2 := DateAndTime
+		year: 2222
+		month: 1
+		day: 22
+		hour: 1
+		minute: 22
+		second: 33
+		offset: 2 hours.
+
 	"The timepoints are diffferent, AKA their UTC times don't correspond"
-	self deny: dt1 = dt2.
-	
+	self deny: dt1 equals: dt2.
+
 	"The relative components however are equal"
 	self assert: dt1 year equals: dt2 year.
 	self assert: dt1 month equals: dt2 month.
 	self assert: dt1 day equals: dt2 day.
-	
+
 	self assert: dt1 hours equals: dt2 hours.
 	self assert: dt1 minutes equals: dt2 minutes.
-	self assert: dt1 seconds equals: dt2 seconds.
+	self assert: dt1 seconds equals: dt2 seconds
 ]
 
 { #category : #tests }
 DateAndTimeTest >> testDateTimeDenotation1 [
- 	"DateAndTimeTest new testDateTimeDenotation1"
-	
+	"DateAndTimeTest new testDateTimeDenotation1"
+
 	"Detroit is 5 hours behind UTC, this offset to UTC is therefore written with a minus sign. This example tests the correct interpretation of the DateAndTime denotation. "
 
 	| twoPmInLondon twoPmUTCInLocalTimeOfDetroit nineAmInDetroit |
 	twoPmInLondon := DateAndTime
-				year: 2004
-				month: 11
-				day: 2
-				hour: 14
-				minute: 0
-				second: 0
-				offset: 0 hours.
+		year: 2004
+		month: 11
+		day: 2
+		hour: 14
+		minute: 0
+		second: 0
+		offset: 0 hours.
 	twoPmUTCInLocalTimeOfDetroit := twoPmInLondon offset: -5 hours.
-	nineAmInDetroit  := '2004-11-02T09:00:00-05:00' asDateAndTime.
-	self assert:  twoPmUTCInLocalTimeOfDetroit = nineAmInDetroit.
-	
-
+	nineAmInDetroit := '2004-11-02T09:00:00-05:00' asDateAndTime.
+	self assert: twoPmUTCInLocalTimeOfDetroit equals: nineAmInDetroit
 ]
 
 { #category : #tests }
 DateAndTimeTest >> testDateTimeDenotation2 [
- 	"DateAndTimeTest new testDateTimeDenotation2"
+	"DateAndTimeTest new testDateTimeDenotation2"
+
 	"Moscow is 3 hours ahead UTC, this offset to UTC is therefore positive. This example tests the correct interpretation of the DateAndTime denotation."
 
-	| lateEveningInLondon lateEveningInLocalTimeOfMoscow
-	localMoscowTimeFromDenotation |
+	| lateEveningInLondon lateEveningInLocalTimeOfMoscow localMoscowTimeFromDenotation |
 	lateEveningInLondon := DateAndTime
-				year: 2004
-				month: 11
-				day: 30
-				hour: 23
-				minute: 30
-				second: 0
-				offset: 0 hours.
+		year: 2004
+		month: 11
+		day: 30
+		hour: 23
+		minute: 30
+		second: 0
+		offset: 0 hours.
 	lateEveningInLocalTimeOfMoscow := lateEveningInLondon offset: 3 hours.
-	localMoscowTimeFromDenotation  := '2004-12-01T02:30:00+03:00' asDateAndTime.
-	self assert:  lateEveningInLocalTimeOfMoscow = localMoscowTimeFromDenotation.
+	localMoscowTimeFromDenotation := '2004-12-01T02:30:00+03:00' asDateAndTime.
+	self assert: lateEveningInLocalTimeOfMoscow equals: localMoscowTimeFromDenotation
 ]
 
 { #category : #tests }
@@ -164,16 +174,18 @@ DateAndTimeTest >> testDayOfWeekWithUTC [
 
 { #category : #'tests - epoch' }
 DateAndTimeTest >> testDosEpoch [
+	self
+		useNonUtcTimeZoneDuring: [ | localEpoch |
+			localEpoch := '1 January 1980 00:00' asDateAndTime.
+			self deny: DateAndTime dosEpoch equals: localEpoch ].
 
-  self useNonUtcTimeZoneDuring: [ | localEpoch |
-    localEpoch := '1 January 1980 00:00' asDateAndTime.
-    self deny: (DateAndTime dosEpoch = localEpoch) ].
-  
-  self useTimeZone: 'UTC' during: [ | localEpoch |
-    localEpoch := '1 January 1980 00:00' asDateAndTime.
-    self assert: DateAndTime dosEpoch equals: localEpoch ].
-  
-  self assert: DateAndTime dosEpoch equals: '1980-01-01T00:00:00+00:00' asDateAndTime.
+	self
+		useTimeZone: 'UTC'
+		during: [ | localEpoch |
+			localEpoch := '1 January 1980 00:00' asDateAndTime.
+			self assert: DateAndTime dosEpoch equals: localEpoch ].
+
+	self assert: DateAndTime dosEpoch equals: '1980-01-01T00:00:00+00:00' asDateAndTime
 ]
 
 { #category : #'tests - bogus date' }
@@ -202,33 +214,34 @@ DateAndTimeTest >> testFromDos [
 
 { #category : #tests }
 DateAndTimeTest >> testFromString [
-
 	| fromString fromStringNoOffset |
 	fromString := DateAndTime fromString: '-1199-01-05T20:33:14.321-05:00'.
-	self assert: (fromString printString = '-1199-01-05T20:33:14.321-05:00').
-	
+	self assert: fromString printString equals: '-1199-01-05T20:33:14.321-05:00'.
+
 	"if no offset is provided, the local offset should be used"
 	fromStringNoOffset := DateAndTime fromString: '-1199-01-05T20:33:14.321'.
-	self assert: (fromStringNoOffset offset = DateAndTime localOffset).
+	self assert: fromStringNoOffset offset equals: DateAndTime localOffset
 ]
 
 { #category : #'tests - instance' }
 DateAndTimeTest >> testInstanceCreation [
-
 	| t |
-	t := DateAndTime 
-			year: 1 month: 1 day: 2 
-			hour: 2 minute: 3 second: 4 nanoSecond: 5 
-			offset: 6 hours.
-	self 
-		assert: (t julianDayNumber = 1721427);
-		assert: (t offset = 6 hours);
-		assert: (t hour = 2);
-		assert: (t minute = 3);
-		assert: (t second = 4);
-		assert: (t nanoSecond = 5).
-		
-
+	t := DateAndTime
+		year: 1
+		month: 1
+		day: 2
+		hour: 2
+		minute: 3
+		second: 4
+		nanoSecond: 5
+		offset: 6 hours.
+	self
+		assert: t julianDayNumber equals: 1721427;
+		assert: t offset equals: 6 hours;
+		assert: t hour equals: 2;
+		assert: t minute equals: 3;
+		assert: t second equals: 4;
+		assert: t nanoSecond equals: 5
 ]
 
 { #category : #'tests - instance' }
@@ -261,59 +274,67 @@ DateAndTimeTest >> testMonotonicity [
 
 { #category : #'tests - under design' }
 DateAndTimeTest >> testNotSymmetricWithString [
-		
 	| t1 t2 |
-	t1 := DateAndTime 
-			year: 1 month: 1 day: 2 
-			hour: 2 minute: 3 second: 4 nanoSecond: 5 
-			offset: 6 hours.
-	t2 :=  '0001-01-02T02:03:04.000000005+06:00'.
-	self deny: t1 = t2.
-	self deny: t2 = t1.
-	
-	
-
+	t1 := DateAndTime
+		year: 1
+		month: 1
+		day: 2
+		hour: 2
+		minute: 3
+		second: 4
+		nanoSecond: 5
+		offset: 6 hours.
+	t2 := '0001-01-02T02:03:04.000000005+06:00'.
+	self deny: t1 equals: t2.
+	self deny: t2 equals: t1
 ]
 
 { #category : #tests }
 DateAndTimeTest >> testOffset [
 	| dateAndTime1 dateAndTime2 |
-	
-	dateAndTime1 :=  DateAndTime year: 1000 day: 100 hour: 1 minute: 2 second: 3 offset: 1 hours.
+	dateAndTime1 := DateAndTime
+		year: 1000
+		day: 100
+		hour: 1
+		minute: 2
+		second: 3
+		offset: 1 hours.
 	dateAndTime2 := dateAndTime1 offset: 1 hour.
 	self assert: dateAndTime1 equals: dateAndTime2.
 	self assert: dateAndTime1 localSeconds equals: dateAndTime2 localSeconds.
-	
+
 	dateAndTime2 := dateAndTime1 offset: -1 hour.
 	self assert: dateAndTime1 equals: dateAndTime2.
-	self deny: dateAndTime1 localSeconds == dateAndTime2 localSeconds.
-	
+	self deny: dateAndTime1 localSeconds identicalTo: dateAndTime2 localSeconds.
+
 	dateAndTime2 := dateAndTime1 offset: -2 hour.
 	self assert: dateAndTime1 equals: dateAndTime2.
-	self deny: dateAndTime1 localSeconds == dateAndTime2 localSeconds.
+	self deny: dateAndTime1 localSeconds identicalTo: dateAndTime2 localSeconds
 ]
 
 { #category : #'tests - epoch' }
 DateAndTimeTest >> testPharoEpoch [
+	self
+		useNonUtcTimeZoneDuring: [ | localEpoch |
+			localEpoch := '1901-01-01T00:00:00' asDateAndTime.
+			self deny: DateAndTime epoch equals: localEpoch.
+			self deny: ((DateAndTime fromSeconds: 0) offset: 0) equals: localEpoch ].
 
-  self useNonUtcTimeZoneDuring: [ | localEpoch |
-    localEpoch := '1901-01-01T00:00:00' asDateAndTime.
-    self deny: (DateAndTime epoch = localEpoch).
-    self deny: (((DateAndTime fromSeconds: 0) offset: 0) = localEpoch) ].
-    
-  self useTimeZone: 'UTC' during: [ | localEpoch |
-    localEpoch := '1901-01-01T00:00:00' asDateAndTime.
-    self assert: DateAndTime epoch equals: localEpoch.
-    self assert: ((DateAndTime fromSeconds: 0) offset: 0) equals: localEpoch ].
-  
-  self assert: DateAndTime epoch equals: '1901-01-01T00:00:00+00:00' asDateAndTime. 
-  self assert: ((DateAndTime fromSeconds: 0) offset: 0) equals: '1901-01-01T00:00:00+00:00' asDateAndTime.
+	self
+		useTimeZone: 'UTC'
+		during: [ | localEpoch |
+			localEpoch := '1901-01-01T00:00:00' asDateAndTime.
+			self assert: DateAndTime epoch equals: localEpoch.
+			self assert: ((DateAndTime fromSeconds: 0) offset: 0) equals: localEpoch ].
+
+	self assert: DateAndTime epoch equals: '1901-01-01T00:00:00+00:00' asDateAndTime.
+	self assert: ((DateAndTime fromSeconds: 0) offset: 0) equals: '1901-01-01T00:00:00+00:00' asDateAndTime
 ]
 
 { #category : #tests }
 DateAndTimeTest >> testPrintString [
 	| dt dtNoOffset |
-	dt :=DateAndTime
+	dt := DateAndTime
 		year: 2004
 		month: 11
 		day: 2
@@ -321,35 +342,33 @@ DateAndTimeTest >> testPrintString [
 		minute: 3
 		second: 5
 		nanoSecond: 12345
-		offset: (Duration seconds: (5 * 3600)).
-	self assert: dt printString = '2004-11-02T14:03:05.000012345+05:00'.
-	self assert: ('2002-05-16T17:20:45.1+01:01' asDateAndTime printString = '2002-05-16T17:20:45.1+01:01').
-	self assert: (' 2002-05-16T17:20:45.02+01:01' asDateAndTime printString = '2002-05-16T17:20:45.02+01:01').
- 	self assert: ('2002-05-16T17:20:45.000000009+01:01' asDateAndTime printString =  '2002-05-16T17:20:45.000000009+01:01').
-	self assert: ('2002-05-16T17:20:45+00:00' asDateAndTime printString = '2002-05-16T17:20:45+00:00' ).
-	self assert: (' 2002-05-16T17:20:45+01:57' asDateAndTime printString = '2002-05-16T17:20:45+01:57').
-	self assert: (' 2002-05-16T17:20:45-02:34' asDateAndTime printString = '2002-05-16T17:20:45-02:34').
-	self assert: ('2002-05-16T17:20:45+00:00' asDateAndTime printString = '2002-05-16T17:20:45+00:00').
-	self assert: ('1997-04-26T01:02:03+01:02:3' asDateAndTime printString = '1997-04-26T01:02:03+01:02:3').
+		offset: (Duration seconds: 5 * 3600).
+	self assert: dt printString equals: '2004-11-02T14:03:05.000012345+05:00'.
+	self assert: '2002-05-16T17:20:45.1+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.1+01:01'.
+	self assert: ' 2002-05-16T17:20:45.02+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.02+01:01'.
+	self assert: '2002-05-16T17:20:45.000000009+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.000000009+01:01'.
+	self assert: '2002-05-16T17:20:45+00:00' asDateAndTime printString equals: '2002-05-16T17:20:45+00:00'.
+	self assert: ' 2002-05-16T17:20:45+01:57' asDateAndTime printString equals: '2002-05-16T17:20:45+01:57'.
+	self assert: ' 2002-05-16T17:20:45-02:34' asDateAndTime printString equals: '2002-05-16T17:20:45-02:34'.
+	self assert: '2002-05-16T17:20:45+00:00' asDateAndTime printString equals: '2002-05-16T17:20:45+00:00'.
+	self assert: '1997-04-26T01:02:03+01:02:3' asDateAndTime printString equals: '1997-04-26T01:02:03+01:02:3'.
 	"When no offset is provided, the local one is used"
 	dtNoOffset := '2002-05-16T17:20' asDateAndTime.
-	self assert: (('2002-05-16T17:20:00*' match: dtNoOffset printString) and: [dtNoOffset offset = DateAndTime localOffset]).
-
-
-
+	self assert: (('2002-05-16T17:20:00*' match: dtNoOffset printString) and: [ dtNoOffset offset = DateAndTime localOffset ])
 ]
 
 { #category : #'tests - under design' }
 DateAndTimeTest >> testPrintStringNoOffset [
-	
 	| localOffsetHours localOffsetMinutes signString |
 	signString := DateAndTime localOffset hours positive ifTrue: [ '+' ] ifFalse: [ '-' ].
 	localOffsetHours := DateAndTime localOffset hours abs printStringPadded: 2.
 	localOffsetMinutes := DateAndTime localOffset minutes printStringPadded: 2.
-	self assert: ('2002-05-16T17:20' asDateAndTime printString
-						 = ('2002-05-16T17:20:00{1}{2}:{3}' format: { signString . localOffsetHours. localOffsetMinutes})).
-	self assert: ('2002-05-16T17:20:45' asDateAndTime printString
-						= ('2002-05-16T17:20:45{1}{2}:{3}' format: { signString . localOffsetHours. localOffsetMinutes})).
+	self
+		assert: '2002-05-16T17:20' asDateAndTime printString
+		equals: ('2002-05-16T17:20:00{1}{2}:{3}' format: {signString . localOffsetHours . localOffsetMinutes}).
+	self
+		assert: '2002-05-16T17:20:45' asDateAndTime printString
+		equals: ('2002-05-16T17:20:45{1}{2}:{3}' format: {signString . localOffsetHours . localOffsetMinutes})
 ]
 
 { #category : #'tests - under design' }
@@ -434,14 +453,14 @@ DateAndTimeTest >> testReadFromDefaultOffsetSpecified [
 { #category : #tests }
 DateAndTimeTest >> testReadFromFoolProofExtension [
 	"Convenient extension without a time, only a date"
-	
-	self assert: (DateAndTime fuzzyReadFrom: '2008' readStream) printString = '2008-01-01T00:00:00+00:00'.
-	self assert: (DateAndTime fuzzyReadFrom: '2008-08' readStream)   printString = '2008-08-01T00:00:00+00:00'.
-	self assert: (DateAndTime fuzzyReadFrom: '2006-08-28' readStream)  printString = '2006-08-28T00:00:00+00:00'.
+
+	self assert: (DateAndTime fuzzyReadFrom: '2008' readStream) printString equals: '2008-01-01T00:00:00+00:00'.
+	self assert: (DateAndTime fuzzyReadFrom: '2008-08' readStream) printString equals: '2008-08-01T00:00:00+00:00'.
+	self assert: (DateAndTime fuzzyReadFrom: '2006-08-28' readStream) printString equals: '2006-08-28T00:00:00+00:00'.
 	"Regular nanoseconds"
-	self assert: (DateAndTime fuzzyReadFrom: '2006-08-28T00:00:00.123456789' readStream)  printString = '2006-08-28T00:00:00.123456789+00:00'.
+	self assert: (DateAndTime fuzzyReadFrom: '2006-08-28T00:00:00.123456789' readStream) printString equals: '2006-08-28T00:00:00.123456789+00:00'.
 	"Extra picoseconds precision should not spoil the DateAndTime"
-	self assert: (DateAndTime fuzzyReadFrom: '2006-08-28T00:00:00.123456789000' readStream)  printString = '2006-08-28T00:00:00.123456789+00:00'.
+	self assert: (DateAndTime fuzzyReadFrom: '2006-08-28T00:00:00.123456789000' readStream) printString equals: '2006-08-28T00:00:00.123456789+00:00'
 ]
 
 { #category : #'tests - under design' }
@@ -459,17 +478,16 @@ DateAndTimeTest >> testReadFromOffset [
 
 { #category : #'tests - under design' }
 DateAndTimeTest >> testReadFromSecond [
-		
-	self assert: ('-1199-01-05T20:33:14.321-05:00' asDateAndTime printString = '-1199-01-05T20:33:14.321-05:00').
-	self assert: ('2002-05-16T17:20:45.1+01:01' asDateAndTime printString = '2002-05-16T17:20:45.1+01:01').
-	self assert: (' 2002-05-16T17:20:45.02+01:01' asDateAndTime printString = '2002-05-16T17:20:45.02+01:01').  
-	self assert: ('2002-05-16T17:20:45.000000009+01:01' asDateAndTime printString =  '2002-05-16T17:20:45.000000009+01:01').
-	self assert: (' 2002-05-16T17:20' asDateAndTime translateToUTC printString = '2002-05-16T17:20:00+00:00').
-	self assert: ('2002-05-16T17:20:45' asDateAndTime translateToUTC printString = '2002-05-16T17:20:45+00:00' ).
-	self assert: (' 2002-05-16T17:20:45+01:57' asDateAndTime printString = '2002-05-16T17:20:45+01:57').
-	self assert: (' 2002-05-16T17:20:45-02:34' asDateAndTime printString = '2002-05-16T17:20:45-02:34').
-	self assert: ('2002-05-16T17:20:45+00:00' asDateAndTime printString = '2002-05-16T17:20:45+00:00').
-	self assert: ('1997-04-26T01:02:03+01:02:3' asDateAndTime printString = '1997-04-26T01:02:03+01:02:3'). 
+	self assert: '-1199-01-05T20:33:14.321-05:00' asDateAndTime printString equals: '-1199-01-05T20:33:14.321-05:00'.
+	self assert: '2002-05-16T17:20:45.1+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.1+01:01'.
+	self assert: ' 2002-05-16T17:20:45.02+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.02+01:01'.
+	self assert: '2002-05-16T17:20:45.000000009+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.000000009+01:01'.
+	self assert: ' 2002-05-16T17:20' asDateAndTime translateToUTC printString equals: '2002-05-16T17:20:00+00:00'.
+	self assert: '2002-05-16T17:20:45' asDateAndTime translateToUTC printString equals: '2002-05-16T17:20:45+00:00'.
+	self assert: ' 2002-05-16T17:20:45+01:57' asDateAndTime printString equals: '2002-05-16T17:20:45+01:57'.
+	self assert: ' 2002-05-16T17:20:45-02:34' asDateAndTime printString equals: '2002-05-16T17:20:45-02:34'.
+	self assert: '2002-05-16T17:20:45+00:00' asDateAndTime printString equals: '2002-05-16T17:20:45+00:00'.
+	self assert: '1997-04-26T01:02:03+01:02:3' asDateAndTime printString equals: '1997-04-26T01:02:03+01:02:3'
 ]
 
 { #category : #'tests - offset' }
@@ -656,17 +674,20 @@ DateAndTimeTest >> testSecondsSinceMidnightLocalTimeNormalization [
 
 { #category : #'tests - instance' }
 DateAndTimeTest >> testSimpleAccessors [
-
 	| t |
-	t := DateAndTime 
-			year: 1 month: 1 day: 2 
-			hour: 2 minute: 3 second: 4 nanoSecond: 5 
-			offset: 6 hours.
-	self 
-		assert: (t hours = t hours);
-		assert: (t minutes = t minute);
-		assert: (t seconds = t second).
-
+	t := DateAndTime
+		year: 1
+		month: 1
+		day: 2
+		hour: 2
+		minute: 3
+		second: 4
+		nanoSecond: 5
+		offset: 6 hours.
+	self
+		assert: t hours equals: t hours;
+		assert: t minutes equals: t minute;
+		assert: t seconds equals: t second
 ]
 
 { #category : #'tests - arithmetic' }
@@ -713,36 +734,41 @@ DateAndTimeTest >> testSymmetric [
 
 { #category : #tests }
 DateAndTimeTest >> testTimeZoneEquivalence [
-  "DateAndTimeTest new testTimeZoneEquivalence"
+	"DateAndTimeTest new testTimeZoneEquivalence"
+
 	"When the clock on the wall in Detroit says 9:00am, the clock on the wall
 	in London says 2:00pm. The Duration difference between the corresponding
 	DateAndTime values should be zero."
-	
-	 " Detroit is 5 hours behind UTC, this offset to UTC is therefore written with a minus sign. This example tests both the correct interpretation of the DateAndTime denotation and correct DateAndTime arithmetics. "
+
+	" Detroit is 5 hours behind UTC, this offset to UTC is therefore written with a minus sign. This example tests both the correct interpretation of the DateAndTime denotation and correct DateAndTime arithmetics. "
 
 	| twoPmInLondon nineAmInDetroit durationDifference |
 	twoPmInLondon := '2004-11-02T14:00:00+00:00' asDateAndTime.
-	nineAmInDetroit  := '2004-11-02T09:00:00-05:00' asDateAndTime.
+	nineAmInDetroit := '2004-11-02T09:00:00-05:00' asDateAndTime.
 	durationDifference := twoPmInLondon - nineAmInDetroit.
-	self assert: durationDifference asSeconds = 0.
-	self assert: twoPmInLondon = nineAmInDetroit
-
+	self assert: durationDifference asSeconds equals: 0.
+	self assert: twoPmInLondon equals: nineAmInDetroit
 ]
 
 { #category : #tests }
 DateAndTimeTest >> testTimeZoneEquivalence2 [
-  "DateAndTimeTest new testTimeZoneEquivalence2"
+	"DateAndTimeTest new testTimeZoneEquivalence2"
+
 	"This example demonstates the fact that
         2004-05-24T22:40:00  UTC  is
         2004-05-25T01:40:00  in Moscow
      (Moscow is 3 hours ahead of UTC)  "
 
 	| thisMoment thisMomentInMoscow |
-    thisMoment := DateAndTime year: 2004 month: 5 day: 24 hour: 22 minute: 40.
-    thisMomentInMoscow := thisMoment offset: 3 hours.
-	self assert: (thisMoment - thisMomentInMoscow) asSeconds = 0.
-	self assert: thisMoment = thisMomentInMoscow
-
+	thisMoment := DateAndTime
+		year: 2004
+		month: 5
+		day: 24
+		hour: 22
+		minute: 40.
+	thisMomentInMoscow := thisMoment offset: 3 hours.
+	self assert: (thisMoment - thisMomentInMoscow) asSeconds equals: 0.
+	self assert: thisMoment equals: thisMomentInMoscow
 ]
 
 { #category : #'tests - under design' }

--- a/src/Kernel-Tests/DateAndTimeUnixEpochTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeUnixEpochTest.class.st
@@ -31,182 +31,146 @@ DateAndTimeUnixEpochTest >> tearDown [
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testAsDate [
-	self assert: aDateAndTime asDate =   'January 1, 1970' asDate.
-
-
+	self assert: aDateAndTime asDate equals: 'January 1, 1970' asDate
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testAsDateAndTime [
-	self assert: aDateAndTime asDateAndTime =  aDateAndTime
-	
-
+	self assert: aDateAndTime asDateAndTime equals: aDateAndTime
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testAsDuration [
-	self assert: aDateAndTime asDuration =  0 asDuration
-	
-
+	self assert: aDateAndTime asDuration equals: 0 asDuration
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testAsLocal [
-	self assert: aDateAndTime asLocal =  aDateAndTime.
-	self assert: aDateAndTime asLocal = (aDateAndTime offset: aDateAndTime class localOffset)
-	
-
+	self assert: aDateAndTime asLocal equals: aDateAndTime.
+	self assert: aDateAndTime asLocal equals: (aDateAndTime offset: aDateAndTime class localOffset)
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testAsNanoSeconds [
-	self assert: aDateAndTime asNanoSeconds =  0 asDuration asNanoSeconds
-	
-
+	self assert: aDateAndTime asNanoSeconds equals: 0 asDuration asNanoSeconds
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testAsSeconds [
-	self assert: aDateAndTime asSeconds = 2177452800
-	
-
+	self assert: aDateAndTime asSeconds equals: 2177452800
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testAsTime [
-	self assert: aDateAndTime asTime =  Time midnight.
-
+	self assert: aDateAndTime asTime equals: Time midnight
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testAsUTC [
-	self assert: aDateAndTime asUTC =  aDateAndTime
-          
+	self assert: aDateAndTime asUTC equals: aDateAndTime
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testCurrent [
-	self deny: aDateAndTime =  (DateAndTime current).
-
+	self deny: aDateAndTime equals: DateAndTime current
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testDateTime [
-	self assert: aDateAndTime =  (DateAndTime date: '01-01-1970' asDate time: '00:00:00' asTime)
-
+	self assert: aDateAndTime equals: (DateAndTime date: '01-01-1970' asDate time: '00:00:00' asTime)
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testDay [
-	self assert: aDateAndTime day =   DateAndTime new day
-
+	self assert: aDateAndTime day equals: DateAndTime new day
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testDayMonthYearDo [
-	|iterations|
+	| iterations |
 	iterations := 0.
-	self assert: (aDateAndTime dayMonthYearDo: [:eachDay :eachMonth :eachYear |  iterations := iterations + 1])  = 1.
-	self assert: (aDateAndTime dayMonthYearDo: [:eachDay :eachMonth :eachYear |  eachYear])  = 1970.
-	self assert: (aDateAndTime dayMonthYearDo: [:eachDay :eachMonth :eachYear |  eachMonth]) = 1.
-	self assert: (aDateAndTime dayMonthYearDo: [:eachDay :eachMonth :eachYear |  eachDay]) = 1.
-
+	self assert: (aDateAndTime dayMonthYearDo: [ :eachDay :eachMonth :eachYear | iterations := iterations + 1 ]) equals: 1.
+	self assert: (aDateAndTime dayMonthYearDo: [ :eachDay :eachMonth :eachYear | eachYear ]) equals: 1970.
+	self assert: (aDateAndTime dayMonthYearDo: [ :eachDay :eachMonth :eachYear | eachMonth ]) equals: 1.
+	self assert: (aDateAndTime dayMonthYearDo: [ :eachDay :eachMonth :eachYear | eachDay ]) equals: 1
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testDayOfMonth [
-	self assert: aDateAndTime dayOfMonth  = 1.
-
+	self assert: aDateAndTime dayOfMonth equals: 1
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testDayOfWeek [
-	self assert: aDateAndTime dayOfWeek  = 5.
-	self assert: aDateAndTime dayOfWeekAbbreviation = 'Thu'.
-	self assert: aDateAndTime dayOfWeekName = 'Thursday'.
-
+	self assert: aDateAndTime dayOfWeek equals: 5.
+	self assert: aDateAndTime dayOfWeekAbbreviation equals: 'Thu'.
+	self assert: aDateAndTime dayOfWeekName equals: 'Thursday'
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testDayOfYear [
-	self assert: aDateAndTime dayOfYear  = 1.
-
-
+	self assert: aDateAndTime dayOfYear equals: 1
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testDaysInMonth [
-	self assert: aDateAndTime daysInMonth  = 31.
-
-
+	self assert: aDateAndTime daysInMonth equals: 31
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testDaysInYear [
-	self assert: aDateAndTime daysInYear  = 365.
-
-
+	self assert: aDateAndTime daysInYear equals: 365
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testDaysLeftInYear [
-	self assert: aDateAndTime daysLeftInYear  = 364.
-
-
+	self assert: aDateAndTime daysLeftInYear equals: 364
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testDuration [
-	self assert: aDateAndTime duration  = 0 asDuration.
-
-
+	self assert: aDateAndTime duration equals: 0 asDuration
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testEpoch [
-	self assert: aDateAndTime =  '1970-01-01T00:00:00+00:00' asDateAndTime
-
+	self assert: aDateAndTime equals: '1970-01-01T00:00:00+00:00' asDateAndTime
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testFirstDayOfMonth [
-	self assert: aDateAndTime firstDayOfMonth =   1
-
+	self assert: aDateAndTime firstDayOfMonth equals: 1
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testFromSeconds [
-	self assert: aDateAndTime =  (DateAndTime fromSeconds: 2177452800).
-
+	self assert: aDateAndTime equals: (DateAndTime fromSeconds: 2177452800)
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testFromString [
-	self assert: aDateAndTime =  (DateAndTime fromString: ' 1970-01-01T00:00:00+00:00').
-	self assert: aDateAndTime =  (DateAndTime fromString: ' 1970-01-01T00:00:00').
-	self assert: aDateAndTime =  (DateAndTime fromString: ' 1970-01-01T00:00').
-	self assert: aDateAndTime =  (DateAndTime fromString: ' 1970-01-01T00:00:00+00:00').
-
+	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1970-01-01T00:00:00+00:00').
+	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1970-01-01T00:00:00').
+	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1970-01-01T00:00').
+	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1970-01-01T00:00:00+00:00')
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testHash [
-	self assert: aDateAndTime hash = (DateAndTime year: 1970 month: 1 day: 1) hash
+	self assert: aDateAndTime hash equals: (DateAndTime year: 1970 month: 1 day: 1) hash
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testHour [
-	self assert: aDateAndTime hour =    aDateAndTime hour24.
-	self assert: aDateAndTime hour =    0.
-	self assert: aDateAndTime hour =    aDateAndTime hours
-
+	self assert: aDateAndTime hour equals: aDateAndTime hour24.
+	self assert: aDateAndTime hour equals: 0.
+	self assert: aDateAndTime hour equals: aDateAndTime hours
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testHour12 [
-	self assert: aDateAndTime hour12  = DateAndTime new hour12.
-	self assert: aDateAndTime hour12  = 12
-
+	self assert: aDateAndTime hour12 equals: DateAndTime new hour12.
+	self assert: aDateAndTime hour12 equals: 12
 ]
 
 { #category : #tests }
@@ -217,8 +181,8 @@ DateAndTimeUnixEpochTest >> testIsLeapYear [
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testJulianDayNumber [
-	self assert: aDateAndTime =  (DateAndTime julianDayNumber: 2440588).
-	self assert: aDateAndTime julianDayNumber = 2440588.
+	self assert: aDateAndTime equals: (DateAndTime julianDayNumber: 2440588).
+	self assert: aDateAndTime julianDayNumber equals: 2440588
 ]
 
 { #category : #tests }
@@ -230,86 +194,94 @@ DateAndTimeUnixEpochTest >> testLessThan [
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testMeridianAbbreviation [
-	self assert: aDateAndTime meridianAbbreviation = 'AM'.
-
-	
+	self assert: aDateAndTime meridianAbbreviation equals: 'AM'
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testMiddleOf [
-	self assert: (aDateAndTime middleOf: '2:00:00:00' asDuration) = 
-	 (Timespan starting: '12-31-1969' asDate duration: 2 days).
-	
-
+	self assert: (aDateAndTime middleOf: '2:00:00:00' asDuration) equals: (Timespan starting: '12-31-1969' asDate duration: 2 days)
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testMidnight [
-	self assert: aDateAndTime midnight =  aDateAndTime
-
+	self assert: aDateAndTime midnight equals: aDateAndTime
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testMinus [
-	self assert: aDateAndTime - aDateAndTime =  '0:00:00:00' asDuration.
-	self assert: aDateAndTime - '0:00:00:00' asDuration = aDateAndTime.
-	self assert: aDateAndTime - aDuration =  (DateAndTime year: 1969 month: 12 day: 30 hour: 21 minute: 56 second: 55 nanoSecond: 999999995 offset: 0 hours ).
-	" I believe this Failure is a bug in the nanosecond part of (DateAndTime >> year:month:day:hour:minute:second:nanoSecond:offset:)" 
+	self assert: aDateAndTime - aDateAndTime equals: '0:00:00:00' asDuration.
+	self assert: aDateAndTime - '0:00:00:00' asDuration equals: aDateAndTime.
+	self
+		assert: aDateAndTime - aDuration
+		equals:
+			(DateAndTime
+				year: 1969
+				month: 12
+				day: 30
+				hour: 21
+				minute: 56
+				second: 55
+				nanoSecond: 999999995
+				offset: 0 hours)
+	" I believe this Failure is a bug in the nanosecond part of (DateAndTime >> year:month:day:hour:minute:second:nanoSecond:offset:)"
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testMinute [
-	self assert: aDateAndTime minute =  0
-
-
+	self assert: aDateAndTime minute equals: 0
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testMinutes [
-	self assert: aDateAndTime minutes = 0
-
+	self assert: aDateAndTime minutes equals: 0
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testMonth [
-	self assert: aDateAndTime month  = 1.
-	self assert: aDateAndTime monthAbbreviation = 'Jan'.
-	self assert: aDateAndTime monthName = 'January'.
-	self assert: aDateAndTime monthIndex = 1.
+	self assert: aDateAndTime month equals: 1.
+	self assert: aDateAndTime monthAbbreviation equals: 'Jan'.
+	self assert: aDateAndTime monthName equals: 'January'.
+	self assert: aDateAndTime monthIndex equals: 1
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testNanoSecond [
-	self assert: aDateAndTime nanoSecond =  0
-
-
+	self assert: aDateAndTime nanoSecond equals: 0
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testNoon [
-	self assert: aDateAndTime noon = '1970-01-01T12:00:00+00:00' asDateAndTime
+	self assert: aDateAndTime noon equals: '1970-01-01T12:00:00+00:00' asDateAndTime
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testNow [
-	self deny: aDateAndTime =  (DateAndTime now).
-
+	self deny: aDateAndTime equals: DateAndTime now
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testOffset [
-	self assert: aDateAndTime offset =  '0:00:00:00' asDuration.
-     self assert: (aDateAndTime offset: '0:12:00:00') equals:  '1970-01-01T12:00:00+12:00' asDateAndTime
+	self assert: aDateAndTime offset equals: '0:00:00:00' asDuration.
+	self assert: (aDateAndTime offset: '0:12:00:00') equals: '1970-01-01T12:00:00+12:00' asDateAndTime
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testPlus [
-	self assert: aDateAndTime + '0:00:00:00' = aDateAndTime.
-	self assert: aDateAndTime + 0 = aDateAndTime.
-	self assert: aDateAndTime + aDuration = (DateAndTime year: 1970 month: 1 day: 2 hour: 2 minute: 3 second: 4 nanoSecond: 5 offset: 0 hours )
+	self assert: aDateAndTime + '0:00:00:00' equals: aDateAndTime.
+	self assert: aDateAndTime + 0 equals: aDateAndTime.
+	self
+		assert: aDateAndTime + aDuration
+		equals:
+			(DateAndTime
+				year: 1970
+				month: 1
+				day: 2
+				hour: 2
+				minute: 3
+				second: 4
+				nanoSecond: 5
+				offset: 0 hours)
 	" I believe this is a bug in the nanosecond part of (DateAndTime >> year:month:day:hour:minute:second:nanoSecond:offset:)"
-	
-
 ]
 
 { #category : #tests }
@@ -320,49 +292,42 @@ DateAndTimeUnixEpochTest >> testPrintOn [
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testSecond [
-	self assert: aDateAndTime second =  0
-
-
+	self assert: aDateAndTime second equals: 0
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testSeconds [
-	self assert: aDateAndTime seconds =  0
-
-
+	self assert: aDateAndTime seconds equals: 0
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testTicks [
-	self assert: aDateAndTime ticks =  (DateAndTime julianDayNumber: 2440588) ticks.
-	self assert: aDateAndTime ticks = #(2440588 0 0)
+	self assert: aDateAndTime ticks equals: (DateAndTime julianDayNumber: 2440588) ticks.
+	self assert: aDateAndTime ticks equals: #(2440588 0 0)
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testTicksOffset [
-	self assert: aDateAndTime =  (aDateAndTime ticks:  #(2415386 0 0) offset: DateAndTime localOffset).
-
+	self assert: aDateAndTime equals: (aDateAndTime ticks: #(2415386 0 0) offset: DateAndTime localOffset)
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testTimeZone [
-	self assert: aDateAndTime timeZoneName	= 'Universal Time'.
-	self assert: aDateAndTime timeZoneAbbreviation	=  'UTC'
-
-
+	self assert: aDateAndTime timeZoneName equals: 'Universal Time'.
+	self assert: aDateAndTime timeZoneAbbreviation equals: 'UTC'
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testTo [
-	self assert: (aDateAndTime to: aDateAndTime) = ((DateAndTime year: 1970 month: 1 day: 1) to: (DateAndTime year: 1970 month: 1 day: 1)) 
+	self assert: (aDateAndTime to: aDateAndTime) equals: ((DateAndTime year: 1970 month: 1 day: 1) to: (DateAndTime year: 1970 month: 1 day: 1))
 	"MessageNotUnderstood: UndefinedObject>>starting:ending:  where UndefinedObject is Timespan "
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testToBy [
-	self assert: (aDateAndTime to: aDateAndTime + 10 days by: 5 days) = 
-				((DateAndTime year: 1970 month: 1 day: 1) to:
-				 (DateAndTime year: 1970 month: 1 day: 1) + 10 days by: 5 days ) 
+	self
+		assert: (aDateAndTime to: aDateAndTime + 10 days by: 5 days)
+		equals: ((DateAndTime year: 1970 month: 1 day: 1) to: (DateAndTime year: 1970 month: 1 day: 1) + 10 days by: 5 days)
 	"MessageNotUnderstood: UndefinedObject>>starting:ending:  where UndefinedObject is Timespan "
 ]
 
@@ -374,65 +339,109 @@ DateAndTimeUnixEpochTest >> testToByDo [
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testToday [
-	self deny: aDateAndTime =  (DateAndTime today).
-
+	self deny: aDateAndTime equals: DateAndTime today
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testTommorrow [
-	self assert: (DateAndTime today + 24 hours) =  (DateAndTime tomorrow).
-	self deny: aDateAndTime =  (DateAndTime tomorrow).
-     "MessageNotUnderstood: Date class>>starting:"
+	self assert: DateAndTime today + 24 hours equals: DateAndTime tomorrow.
+	self deny: aDateAndTime equals: DateAndTime tomorrow
+	"MessageNotUnderstood: Date class>>starting:"
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testUtcOffset [
-     self assert: (aDateAndTime offset: '0:12:00:00') =  '1970-01-01T12:00:00+12:00' asDateAndTime
+	self assert: (aDateAndTime offset: '0:12:00:00') equals: '1970-01-01T12:00:00+12:00' asDateAndTime
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testYear [
-	self assert: aDateAndTime year = 1970.
-
-	
+	self assert: aDateAndTime year equals: 1970
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testYearDay [
-	self assert: aDateAndTime =  (DateAndTime year: 1970 day: 1).
-
+	self assert: aDateAndTime equals: (DateAndTime year: 1970 day: 1)
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testYearDayHourMinuteSecond [
-	self assert: aDateAndTime =  (DateAndTime year: 1970 day: 1 hour: 0 minute: 0 second: 0).
-
+	self
+		assert: aDateAndTime
+		equals:
+			(DateAndTime
+				year: 1970
+				day: 1
+				hour: 0
+				minute: 0
+				second: 0)
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testYearMonthDay [
-	self assert: aDateAndTime =  (DateAndTime year: 1970 month: 1 day: 1).
-
+	self assert: aDateAndTime equals: (DateAndTime year: 1970 month: 1 day: 1)
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testYearMonthDayHourMinuteSecond [
-	self assert: aDateAndTime =  (DateAndTime year: 1970 month: 1 day: 1 hour: 0 minute: 0 second: 0).
-
+	self
+		assert: aDateAndTime
+		equals:
+			(DateAndTime
+				year: 1970
+				month: 1
+				day: 1
+				hour: 0
+				minute: 0
+				second: 0)
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testYearMonthDayHourMinuteSecondNanosSecondOffset [
-	self assert: aDateAndTime =  (DateAndTime year: 1970 month: 1 day: 1 hour: 0 minute: 0 second: 0 nanoSecond: 0 offset:0 hours ).
-	self assert: ((DateAndTime year: 1 month: 1 day: 1 hour: 0 minute: 0 second: 0 nanoSecond: 0 offset: 0 hours ) +
-				(Duration days: 1 hours: 2 minutes: 3 seconds: 4  nanoSeconds: 5) ) =  	
-				(DateAndTime year: 1 month: 1 day: 2 hour: 2 minute: 3 second: 4 nanoSecond: 5 offset: 0 hours ) 
-	" I believe this is a bug in the nanosecond part of (DateAndTime >> year:month:day:hour:minute:second:nanoSecond:offset:)"" I believe this is a bug in the nanosecond part of (DateAndTime >> year:month:day:hour:minute:second:nanoSecond:offset:)"   
-
+	self
+		assert: aDateAndTime
+		equals:
+			(DateAndTime
+				year: 1970
+				month: 1
+				day: 1
+				hour: 0
+				minute: 0
+				second: 0
+				nanoSecond: 0
+				offset: 0 hours).
+	self
+		assert:
+			(DateAndTime
+				year: 1
+				month: 1
+				day: 1
+				hour: 0
+				minute: 0
+				second: 0
+				nanoSecond: 0
+				offset: 0 hours)
+				+
+					(Duration
+						days: 1
+						hours: 2
+						minutes: 3
+						seconds: 4
+						nanoSeconds: 5)
+		equals:
+			(DateAndTime
+				year: 1
+				month: 1
+				day: 2
+				hour: 2
+				minute: 3
+				second: 4
+				nanoSecond: 5
+				offset: 0 hours)
+	" I believe this is a bug in the nanosecond part of (DateAndTime >> year:month:day:hour:minute:second:nanoSecond:offset:)"" I believe this is a bug in the nanosecond part of (DateAndTime >> year:month:day:hour:minute:second:nanoSecond:offset:)"
 ]
 
 { #category : #tests }
 DateAndTimeUnixEpochTest >> testYesterday [
-	self deny: aDateAndTime =  (DateAndTime yesterday).
-
+	self deny: aDateAndTime equals: DateAndTime yesterday
 ]

--- a/src/Kernel-Tests/DateTest.class.st
+++ b/src/Kernel-Tests/DateTest.class.st
@@ -217,8 +217,7 @@ DateTest >> testDuration [
 
 { #category : #tests }
 DateTest >> testEqual [
-
-	self assert: january23rd2004 = 'January 23, 2004' asDate.
+	self assert: january23rd2004 equals: 'January 23, 2004' asDate
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/DependentsArrayTest.class.st
+++ b/src/Kernel-Tests/DependentsArrayTest.class.st
@@ -9,10 +9,9 @@ Class {
 
 { #category : #test }
 DependentsArrayTest >> testSize [
-
-	self 
-		assert: (DependentsArray with: nil) size = 0;
-		assert: (DependentsArray with: nil with: 1 with: nil) size = 1;
-		assert: (DependentsArray with: 1 with: 3) size = 2;
-		assert: (DependentsArray with: nil with: nil with: nil) size = 0
+	self
+		assert: (DependentsArray with: nil) size equals: 0;
+		assert: (DependentsArray with: nil with: 1 with: nil) size equals: 1;
+		assert: (DependentsArray with: 1 with: 3) size equals: 2;
+		assert: (DependentsArray with: nil with: nil with: nil) size equals: 0
 ]

--- a/src/Kernel-Tests/DurationTest.class.st
+++ b/src/Kernel-Tests/DurationTest.class.st
@@ -37,202 +37,213 @@ DurationTest >> setUp [
 
 { #category : #tests }
 DurationTest >> testAbs [
-	self assert: aDuration abs = aDuration. 
-	self assert: (Duration nanoSeconds: -5)  abs =  (Duration nanoSeconds: 5). 
-
+	self assert: aDuration abs equals: aDuration.
+	self assert: (Duration nanoSeconds: -5) abs equals: (Duration nanoSeconds: 5)
 ]
 
 { #category : #tests }
 DurationTest >> testAsDay [
-	|full half quarter|
-	full := (Duration minutes: 60*24).
-	half := (Duration minutes: 60*12).
-	quarter := (Duration minutes: 60*6).	
-	self 
-		assert: 1 day  = full;
-		assert: 1.0 day  = full;
-		assert: 0.5 day  = half; 
-		assert: (1/2) day = half;
-		assert: (1/4) day = quarter.
-	self assert: 0.4 day + 0.6 day = 1 day	
+	| full half quarter |
+	full := Duration minutes: 60 * 24.
+	half := Duration minutes: 60 * 12.
+	quarter := Duration minutes: 60 * 6.
+	self
+		assert: 1 day equals: full;
+		assert: 1.0 day equals: full;
+		assert: 0.5 day equals: half;
+		assert: (1 / 2) day equals: half;
+		assert: (1 / 4) day equals: quarter.
+	self assert: 0.4 day + 0.6 day equals: 1 day
 ]
 
 { #category : #tests }
 DurationTest >> testAsDelay [
-	self deny: aDuration asDelay =   aDuration.
+	self deny: aDuration asDelay equals: aDuration
 	"want to come up with a more meaningful test"
-
 ]
 
 { #category : #tests }
 DurationTest >> testAsDuration [
-	self assert: aDuration asDuration =  aDuration
-	
-
+	self assert: aDuration asDuration equals: aDuration
 ]
 
 { #category : #tests }
-DurationTest >> testAsMilliSecond [ 
-	  
- 	self 
-		assert: 1 milliSecond = (1/1000) second;
-		assert: (1/2) milliSecond = (1/2000) second;
-		assert: 0.5 milliSecond = (1/2000) second;
-		assert: 500 milliSecond = (1/2) second
+DurationTest >> testAsMilliSecond [
+	self
+		assert: 1 milliSecond equals: (1 / 1000) second;
+		assert: (1 / 2) milliSecond equals: (1 / 2000) second;
+		assert: 0.5 milliSecond equals: (1 / 2000) second;
+		assert: 500 milliSecond equals: (1 / 2) second
 ]
 
 { #category : #tests }
 DurationTest >> testAsMilliSeconds [
-	
-	self assert: (Duration nanoSeconds: 1000000)  asMilliSeconds = 1.
-	self assert: (Duration seconds: 1)  asMilliSeconds = 1000.	
-	self assert: (Duration nanoSeconds: 1000000)  asMilliSeconds = 1.
-	self assert: (Duration nanoSeconds: 1000000)  asMilliSeconds = 1.
-	self assert: aDuration   asMilliSeconds = 93784000.
-	self assert: (Duration milliSeconds: 3775) asSeconds = 3.
-	self assert: (Duration milliSeconds: 3775) nanoSeconds = 775000000.
-	self assert: (Duration milliSeconds: -3775) asSeconds = -3.
-	self assert: (Duration milliSeconds: -3775) nanoSeconds = -775000000
+	self assert: (Duration nanoSeconds: 1000000) asMilliSeconds equals: 1.
+	self assert: (Duration seconds: 1) asMilliSeconds equals: 1000.
+	self assert: (Duration nanoSeconds: 1000000) asMilliSeconds equals: 1.
+	self assert: (Duration nanoSeconds: 1000000) asMilliSeconds equals: 1.
+	self assert: aDuration asMilliSeconds equals: 93784000.
+	self assert: (Duration milliSeconds: 3775) asSeconds equals: 3.
+	self assert: (Duration milliSeconds: 3775) nanoSeconds equals: 775000000.
+	self assert: (Duration milliSeconds: -3775) asSeconds equals: -3.
+	self assert: (Duration milliSeconds: -3775) nanoSeconds equals: -775000000
 ]
 
 { #category : #tests }
 DurationTest >> testAsMinute [
-
-	|full half quarter|
-	full := (Duration seconds: 60).
-	half := (Duration seconds: 30).
-	quarter := (Duration seconds: 15).	
-	self 
-		assert: 1 minute = full;
-		assert: 1.0 minute = full;
-		assert: 0.5 minute = half; 
-		assert: (1/2) minute = half;
-		assert: (1/4) minute = quarter.
-	self assert: 0.4 minute + 0.6 minute = 1 minute	
+	| full half quarter |
+	full := Duration seconds: 60.
+	half := Duration seconds: 30.
+	quarter := Duration seconds: 15.
+	self
+		assert: 1 minute equals: full;
+		assert: 1.0 minute equals: full;
+		assert: 0.5 minute equals: half;
+		assert: (1 / 2) minute equals: half;
+		assert: (1 / 4) minute equals: quarter.
+	self assert: 0.4 minute + 0.6 minute equals: 1 minute
 ]
 
 { #category : #tests }
 DurationTest >> testAsNanoSeconds [
-	self assert: (Duration nanoSeconds: 1)  asNanoSeconds = 1.
-	self assert: (Duration seconds: 1)  asNanoSeconds = 1000000000.	
-	self assert: aDuration   asNanoSeconds = 93784000000005.
+	self assert: (Duration nanoSeconds: 1) asNanoSeconds equals: 1.
+	self assert: (Duration seconds: 1) asNanoSeconds equals: 1000000000.
+	self assert: aDuration asNanoSeconds equals: 93784000000005
 ]
 
 { #category : #tests }
-DurationTest >> testAsSecond [ 
-	|full half quarter|
-	full := (Duration seconds: 1).
-	half := (Duration seconds: 0.5).
-	quarter := (Duration seconds: 0.25).	
-	self 
-		assert: 1 second = full;
-		assert: 1.0 second = full;
-		assert: 0.5 second = half; 
-		assert: (1/2) second = half;
-		assert: (1/4) second = quarter.
-	self assert: 0.4 second + 0.6 second = 1 second	
+DurationTest >> testAsSecond [
+	| full half quarter |
+	full := Duration seconds: 1.
+	half := Duration seconds: 0.5.
+	quarter := Duration seconds: 0.25.
+	self
+		assert: 1 second equals: full;
+		assert: 1.0 second equals: full;
+		assert: 0.5 second equals: half;
+		assert: (1 / 2) second equals: half;
+		assert: (1 / 4) second equals: quarter.
+	self assert: 0.4 second + 0.6 second equals: 1 second
 ]
 
 { #category : #tests }
 DurationTest >> testAsSeconds [
-	self assert: (Duration nanoSeconds: 1000000000)  asSeconds = 1.
-	self assert: (Duration seconds: 1)  asSeconds = 1.	
-	self assert: aDuration asSeconds = 93784.
+	self assert: (Duration nanoSeconds: 1000000000) asSeconds equals: 1.
+	self assert: (Duration seconds: 1) asSeconds equals: 1.
+	self assert: aDuration asSeconds equals: 93784.
 	self assert: 1 asSeconds equals: (Duration seconds: 1).
-	self assert: (1/2) asSeconds equals: (Duration milliSeconds: 500).
+	self assert: (1 / 2) asSeconds equals: (Duration milliSeconds: 500)
 ]
 
 { #category : #tests }
 DurationTest >> testAsWeek [
-	|full half quarter|
-	full := (Duration days: 7).	 
-	half := (Duration weeks: 0.5).			
-	quarter := (Duration weeks: 0.25).			
-	self 
-		assert: 1 week = full;
-		assert: 1.0 week = full;
-		assert: 0.5 week = half; 
-		assert: (1/2) week = half;
-		assert: (1/4) week = quarter.
-	self assert: 0.4 week + 0.6 week = 1 week	
+	| full half quarter |
+	full := Duration days: 7.
+	half := Duration weeks: 0.5.
+	quarter := Duration weeks: 0.25.
+	self
+		assert: 1 week equals: full;
+		assert: 1.0 week equals: full;
+		assert: 0.5 week equals: half;
+		assert: (1 / 2) week equals: half;
+		assert: (1 / 4) week equals: quarter.
+	self assert: 0.4 week + 0.6 week equals: 1 week
 ]
 
 { #category : #tests }
 DurationTest >> testAsWeeks [
-	|full half quarter|
-	full := (Duration days: 7).	 
-	half := (Duration weeks: 0.5).			
-	quarter := (Duration weeks: 0.25).			
-	self 
-		assert: 1 weeks = full;
-		assert: 1.0 weeks = full;
-		assert: 0.5 weeks = half; 
-		assert: (1/2) weeks = half;
-		assert: (1/4) weeks = quarter.
-	self assert: 1.4 weeks + 1.6 weeks = 3 weeks	
+	| full half quarter |
+	full := Duration days: 7.
+	half := Duration weeks: 0.5.
+	quarter := Duration weeks: 0.25.
+	self
+		assert: 1 weeks equals: full;
+		assert: 1.0 weeks equals: full;
+		assert: 0.5 weeks equals: half;
+		assert: (1 / 2) weeks equals: half;
+		assert: (1 / 4) weeks equals: quarter.
+	self assert: 1.4 weeks + 1.6 weeks equals: 3 weeks
 ]
 
 { #category : #tests }
 DurationTest >> testAsYear [
-
-	self 
-		assert: 1 year days = 365;
-		assert: 0.5 year asHours = ((364 / 2) * 24 + 12)
+	self
+		assert: 1 year days equals: 365;
+		assert: 0.5 year asHours equals: 364 / 2 * 24 + 12
 ]
 
 { #category : #tests }
 DurationTest >> testAsYears [
-
-	self 
-		assert: 2 years days = 730;
-		assert:	0.5 year asHours = ((364 / 2) * 24 + 12)
+	self
+		assert: 2 years days equals: 730;
+		assert: 0.5 year asHours equals: 364 / 2 * 24 + 12
 ]
 
 { #category : #tests }
 DurationTest >> testComparing [
-
 	| d1 d2 d3 |
 	d1 := Duration seconds: 10 nanoSeconds: 1.
 	d2 := Duration seconds: 10 nanoSeconds: 1.
 	d3 := Duration seconds: 10 nanoSeconds: 2.
-	
-	self
-		assert: (d1 = d1);
-		assert: (d1 = d2);
-		deny: (d1 = d3);
-		assert: (d1 < d3)
 
+	self
+		assert: d1 equals: d1;
+		assert: d1 equals: d2;
+		deny: d1 equals: d3;
+		assert: d1 < d3
 ]
 
 { #category : #tests }
 DurationTest >> testDays [
-	self assert: aDuration   days = 1.
-	self assert: (Duration   days: 1) days= 1.	
+	self assert: aDuration days equals: 1.
+	self assert: (Duration days: 1) days equals: 1
 ]
 
 { #category : #tests }
 DurationTest >> testDivide [
-	self assert: aDuration / aDuration = 1. 
-	self assert: aDuration / 2 = (Duration days: 0 hours: 13 minutes: 1 seconds: 32 nanoSeconds: 2). 
-	self assert: aDuration / (1/2) = (Duration days: 2 hours: 4 minutes: 6 seconds: 8 nanoSeconds: 10).
-
+	self assert: aDuration / aDuration equals: 1.
+	self
+		assert: aDuration / 2
+		equals:
+			(Duration
+				days: 0
+				hours: 13
+				minutes: 1
+				seconds: 32
+				nanoSeconds: 2).
+	self
+		assert: aDuration / (1 / 2)
+		equals:
+			(Duration
+				days: 2
+				hours: 4
+				minutes: 6
+				seconds: 8
+				nanoSeconds: 10)
 ]
 
 { #category : #tests }
 DurationTest >> testFromString [
-	self assert: aDuration = (Duration fromString: '1:02:03:04.000000005').
-
+	self assert: aDuration equals: (Duration fromString: '1:02:03:04.000000005')
 ]
 
 { #category : #tests }
 DurationTest >> testHash [
-	self assert: aDuration hash = (Duration days: 1 hours: 2 minutes: 3 seconds: 4 nanoSeconds: 5) hash
+	self
+		assert: aDuration hash
+		equals:
+			(Duration
+				days: 1
+				hours: 2
+				minutes: 3
+				seconds: 4
+				nanoSeconds: 5) hash
 ]
 
 { #category : #tests }
 DurationTest >> testHours [
-	self assert: aDuration   hours = 2.
-	self assert: (Duration   hours: 2) hours = 2.	
+	self assert: aDuration hours equals: 2.
+	self assert: (Duration hours: 2) hours equals: 2
 ]
 
 { #category : #tests }
@@ -255,8 +266,8 @@ DurationTest >> testHumanReadablePrintString [
 
 { #category : #tests }
 DurationTest >> testIntegerDivision [
-	self assert: aDuration // aDuration = 1. 
-	self assert: aDuration // 2 =  (aDuration / 2). 
+	self assert: aDuration // aDuration equals: 1.
+	self assert: aDuration // 2 equals: aDuration / 2
 	"is there ever a case where this is not true, since precision is always to the nano second?"
 ]
 
@@ -275,82 +286,137 @@ DurationTest >> testLessThan [
 
 { #category : #tests }
 DurationTest >> testMilliSeconds [
-	#(
-	"argument (milliseconds)        seconds nanoseconds"
-	(5                                                      0                       5000000)
-	(1005                                           1                       5000000)
-	(-5                                                     0                       -5000000)
-	(-1005                                          -1                      -5000000)
-	(1234567                                        1234            567000000)
-	(-1234567                                       -1234           -567000000))
-		do: [ :each |
+	#(#(5 0 5000000) #(1005 1 5000000) #(-5 0 -5000000) #(-1005 -1 -5000000) #(1234567 1234 567000000) #(-1234567 -1234 -567000000))
+		do: [ :each | 
 			| duration |
 			duration := Duration milliSeconds: each first.
-			self assert: duration asSeconds = each second.
-			self assert: duration nanoSeconds = each third ]
+			self assert: duration asSeconds equals: each second.
+			self assert: duration nanoSeconds equals: each third ]
+	"argument (milliseconds)        seconds nanoseconds"
 ]
 
 { #category : #tests }
 DurationTest >> testMinus [
-	self assert: aDuration - aDuration = (Duration seconds: 0).
-	self assert: aDuration - (Duration days: -1 hours: -2 minutes: -3 seconds: -4 nanoSeconds: -5) = 
-						    (Duration days: 2  hours: 4  minutes: 6  seconds: 8  nanoSeconds: 10). 
-	self assert: aDuration - (Duration days: 0  hours: 1  minutes: 2  seconds: 3  nanoSeconds: 4) = 
-						    (Duration days: 1  hours: 1  minutes: 1  seconds: 1  nanoSeconds: 1). 
-	self assert: aDuration - (Duration days: 0  hours: 3   minutes: 0  seconds: 5  nanoSeconds: 0) = 
-						    (Duration days: 0  hours: 23  minutes: 2  seconds: 59  nanoSeconds: 5). 
+	self assert: aDuration - aDuration equals: (Duration seconds: 0).
+	self
+		assert:
+			aDuration
+				-
+					(Duration
+						days: -1
+						hours: -2
+						minutes: -3
+						seconds: -4
+						nanoSeconds: -5)
+		equals:
+			(Duration
+				days: 2
+				hours: 4
+				minutes: 6
+				seconds: 8
+				nanoSeconds: 10).
+	self
+		assert:
+			aDuration
+				-
+					(Duration
+						days: 0
+						hours: 1
+						minutes: 2
+						seconds: 3
+						nanoSeconds: 4)
+		equals:
+			(Duration
+				days: 1
+				hours: 1
+				minutes: 1
+				seconds: 1
+				nanoSeconds: 1).
+	self
+		assert:
+			aDuration
+				-
+					(Duration
+						days: 0
+						hours: 3
+						minutes: 0
+						seconds: 5
+						nanoSeconds: 0)
+		equals:
+			(Duration
+				days: 0
+				hours: 23
+				minutes: 2
+				seconds: 59
+				nanoSeconds: 5)
 ]
 
 { #category : #tests }
 DurationTest >> testMinutes [
-	self assert: aDuration   minutes = 3.
-	self assert: (Duration minutes: 3) minutes = 3.	
+	self assert: aDuration minutes equals: 3.
+	self assert: (Duration minutes: 3) minutes equals: 3
 ]
 
 { #category : #tests }
 DurationTest >> testModulo [
-
 	| d1 d2 d3 |
 	d1 := 11.5 seconds.
 	d2 := d1 \\ 3.
-	self assert: d2 = (Duration nanoSeconds: 1).
+	self assert: d2 equals: (Duration nanoSeconds: 1).
 
-	d3 := d1 \\ (3 seconds).
-	self assert: d3 =  (Duration seconds: 2 nanoSeconds: 500000000).
+	d3 := d1 \\ 3 seconds.
+	self assert: d3 equals: (Duration seconds: 2 nanoSeconds: 500000000).
 
-	self assert: aDuration \\ aDuration = 
-		(Duration days: 0 hours: 0 minutes: 0 seconds: 0 nanoSeconds: 0). 
-	self assert: aDuration \\ 2 = 
-		(Duration days: 0 hours: 0 minutes: 0 seconds: 0 nanoSeconds: 1).
-	
-
-
+	self
+		assert: aDuration \\ aDuration
+		equals:
+			(Duration
+				days: 0
+				hours: 0
+				minutes: 0
+				seconds: 0
+				nanoSeconds: 0).
+	self
+		assert: aDuration \\ 2
+		equals:
+			(Duration
+				days: 0
+				hours: 0
+				minutes: 0
+				seconds: 0
+				nanoSeconds: 1)
 ]
 
 { #category : #tests }
 DurationTest >> testMultiply [
-	self assert: aDuration * 2 = (Duration days: 2 hours: 4 minutes: 6 seconds: 8 nanoSeconds: 10). 
+	self
+		assert: aDuration * 2
+		equals:
+			(Duration
+				days: 2
+				hours: 4
+				minutes: 6
+				seconds: 8
+				nanoSeconds: 10)
 ]
 
 { #category : #tests }
-DurationTest >> testNanoSecond [	 
-	self 
-		assert: (Duration nanoSeconds: 5) = 5 nanoSecond;	
-		assert: 0.5 nanoSecond = (Duration nanoSeconds: 0.5);	
-		assert: (1/2) nanoSecond = (Duration nanoSeconds: 0.5).	
-				
+DurationTest >> testNanoSecond [
+	self
+		assert: (Duration nanoSeconds: 5) equals: 5 nanoSecond;
+		assert: 0.5 nanoSecond equals: (Duration nanoSeconds: 0.5);
+		assert: (1 / 2) nanoSecond equals: (Duration nanoSeconds: 0.5)
 ]
 
 { #category : #tests }
 DurationTest >> testNanoSeconds [
-	self assert: aDuration nanoSeconds = 5.
-	self assert: (Duration nanoSeconds: 5) nanoSeconds = 5.	
+	self assert: aDuration nanoSeconds equals: 5.
+	self assert: (Duration nanoSeconds: 5) nanoSeconds equals: 5
 ]
 
 { #category : #tests }
 DurationTest >> testNegated [
-	self assert: aDuration + aDuration negated = (Duration seconds: 0). 
-
+	self assert: aDuration + aDuration negated equals: (Duration seconds: 0)
 ]
 
 { #category : #tests }
@@ -374,46 +440,51 @@ DurationTest >> testNormalizeNanoSeconds [
 	will be invalid."
 
 	| d t1 t2 |
-	t1 := '2004-01-07T11:55:01+00:00' asDateAndTime. 
+	t1 := '2004-01-07T11:55:01+00:00' asDateAndTime.
 	t2 := '2004-01-07T11:55:00.9+00:00' asDateAndTime.
-	d := t1 - t2. "100 millisecond difference"
+	d := t1 - t2.	"100 millisecond difference"
 	self assert: d nanoSeconds > 0.
-	self assert: d seconds = 0.
-	self assert: d nanoSeconds = 100000000.
-	self assert: d asString = '0:00:00:00.1'.
+	self assert: d seconds equals: 0.
+	self assert: d nanoSeconds equals: 100000000.
+	self assert: d asString equals: '0:00:00:00.1'.
 	"Verify that other combinations produces reasonable printString values"
-	self assert: (Duration seconds: 1 nanoSeconds: 100000000) printString = '0:00:00:01.1'.
-	self assert: (Duration seconds: -1 nanoSeconds: -100000000) printString = '-0:00:00:01.1'.
-	self assert: (Duration seconds: 1 nanoSeconds: -100000000) printString = '0:00:00:00.9'.
-	self assert: (Duration seconds: -1 nanoSeconds: 100000000) printString = '-0:00:00:00.9'
-
+	self assert: (Duration seconds: 1 nanoSeconds: 100000000) printString equals: '0:00:00:01.1'.
+	self assert: (Duration seconds: -1 nanoSeconds: -100000000) printString equals: '-0:00:00:01.1'.
+	self assert: (Duration seconds: 1 nanoSeconds: -100000000) printString equals: '0:00:00:00.9'.
+	self assert: (Duration seconds: -1 nanoSeconds: 100000000) printString equals: '-0:00:00:00.9'
 ]
 
 { #category : #tests }
 DurationTest >> testNumberConvenienceMethods [
-
 	self
-		assert: 1 week = (Duration days: 7);
-		assert: -1 week = (Duration days: -7);
-		assert: 1 day = (Duration days: 1);
-		assert: -1 day = (Duration days: -1);
-		assert: 1 hours = (Duration hours: 1);
-		assert: -1 hour = (Duration hours: -1);
-		assert: 1 minute = (Duration seconds: 60);
-		assert: -1 minute = (Duration seconds: -60);
-		assert: 1 second = (Duration seconds: 1);
-		assert: -1 second = (Duration seconds: -1);
-		assert: 1 milliSecond = (Duration milliSeconds: 1);
-		assert: -1 milliSecond = (Duration milliSeconds: -1);
-		assert: 1 nanoSecond = (Duration nanoSeconds: 1);
-		assert: -1 nanoSecond = (Duration nanoSeconds: -1)
-		
+		assert: 1 week equals: (Duration days: 7);
+		assert: -1 week equals: (Duration days: -7);
+		assert: 1 day equals: (Duration days: 1);
+		assert: -1 day equals: (Duration days: -1);
+		assert: 1 hours equals: (Duration hours: 1);
+		assert: -1 hour equals: (Duration hours: -1);
+		assert: 1 minute equals: (Duration seconds: 60);
+		assert: -1 minute equals: (Duration seconds: -60);
+		assert: 1 second equals: (Duration seconds: 1);
+		assert: -1 second equals: (Duration seconds: -1);
+		assert: 1 milliSecond equals: (Duration milliSeconds: 1);
+		assert: -1 milliSecond equals: (Duration milliSeconds: -1);
+		assert: 1 nanoSecond equals: (Duration nanoSeconds: 1);
+		assert: -1 nanoSecond equals: (Duration nanoSeconds: -1)
 ]
 
 { #category : #tests }
 DurationTest >> testPlus [
-	self assert: (aDuration + 0 hours) = aDuration.
-	self assert: (aDuration + aDuration) = (Duration days: 2 hours: 4 minutes: 6 seconds: 8 nanoSeconds: 10). 
+	self assert: aDuration + 0 hours equals: aDuration.
+	self
+		assert: aDuration + aDuration
+		equals:
+			(Duration
+				days: 2
+				hours: 4
+				minutes: 6
+				seconds: 8
+				nanoSeconds: 10)
 ]
 
 { #category : #tests }
@@ -436,21 +507,18 @@ DurationTest >> testPrintOn [
 
 { #category : #tests }
 DurationTest >> testQuotient [
-
 	| d1 d2 q |
 	d1 := 11.5 seconds.
 	d2 := d1 // 3.
-	self assert: d2 = (Duration seconds: 3 nanoSeconds: 833333333).
+	self assert: d2 equals: (Duration seconds: 3 nanoSeconds: 833333333).
 
-	q := d1 // (3 seconds).
-	self assert: q = 3.
-
-
+	q := d1 // 3 seconds.
+	self assert: q equals: 3
 ]
 
 { #category : #tests }
 DurationTest >> testReadFrom [
-	self assert: aDuration = (Duration readFrom: '1:02:03:04.000000005' readStream)
+	self assert: aDuration equals: (Duration readFrom: '1:02:03:04.000000005' readStream)
 ]
 
 { #category : #tests }
@@ -462,8 +530,7 @@ DurationTest >> testReadFromBogus [
 
 { #category : #tests }
 DurationTest >> testReadFromMillisecond [
-
-	self assert: (Duration readFrom: '0:00:00:00.001 ' readStream) nanoSeconds = 1000000
+	self assert: (Duration readFrom: '0:00:00:00.001 ' readStream) nanoSeconds equals: 1000000
 ]
 
 { #category : #tests }
@@ -486,46 +553,77 @@ DurationTest >> testReadFromNoException [
 
 { #category : #tests }
 DurationTest >> testRoundTo [
+	self assert: (5 minutes + 37 seconds roundTo: 2 minutes) equals: 6 minutes.
 
-	self assert: ((5 minutes + 37 seconds) roundTo: (2 minutes)) = (6 minutes).
-	
-	self assert:  (aDuration roundTo: (Duration days: 1)) =
-	               (Duration days: 1 hours: 0 minutes: 0 seconds: 0 nanoSeconds: 0).
-	self assert:  (aDuration roundTo: (Duration hours: 1)) =
-	               (Duration days: 1 hours: 2 minutes: 0 seconds: 0 nanoSeconds: 0).	
-	self assert:  (aDuration roundTo: (Duration minutes: 1)) =
-	               (Duration days: 1 hours: 2 minutes: 3 seconds: 0 nanoSeconds: 0).
+	self
+		assert: (aDuration roundTo: (Duration days: 1))
+		equals:
+			(Duration
+				days: 1
+				hours: 0
+				minutes: 0
+				seconds: 0
+				nanoSeconds: 0).
+	self
+		assert: (aDuration roundTo: (Duration hours: 1))
+		equals:
+			(Duration
+				days: 1
+				hours: 2
+				minutes: 0
+				seconds: 0
+				nanoSeconds: 0).
+	self
+		assert: (aDuration roundTo: (Duration minutes: 1))
+		equals:
+			(Duration
+				days: 1
+				hours: 2
+				minutes: 3
+				seconds: 0
+				nanoSeconds: 0)
 ]
 
 { #category : #tests }
 DurationTest >> testSeconds [
-	self assert: aDuration seconds = 4.
-	self assert: (Duration  nanoSeconds: 2) seconds = 0.	
-	self assert: (Duration  seconds: 2) seconds = 2.	
-	self assert: (Duration  days: 1 hours: 2 minutes: 3 seconds:4) seconds = (4).
-	self deny: (Duration  days: 1 hours: 2 minutes: 3 seconds:4) seconds = (1*24*60*60+(2*60*60)+(3*60)+4).	
+	self assert: aDuration seconds equals: 4.
+	self assert: (Duration nanoSeconds: 2) seconds equals: 0.
+	self assert: (Duration seconds: 2) seconds equals: 2.
+	self
+		assert:
+			(Duration
+				days: 1
+				hours: 2
+				minutes: 3
+				seconds: 4) seconds
+		equals: 4.
+	self
+		deny:
+			(Duration
+				days: 1
+				hours: 2
+				minutes: 3
+				seconds: 4) seconds
+		equals: 1 * 24 * 60 * 60 + (2 * 60 * 60) + (3 * 60) + 4
 ]
 
 { #category : #tests }
-DurationTest >> testSecondsNanoSeconds [ 
-	self assert: (Duration   seconds: 0 nanoSeconds: 5)  = (Duration  nanoSeconds: 5).	
+DurationTest >> testSecondsNanoSeconds [
+	self assert: (Duration seconds: 0 nanoSeconds: 5) equals: (Duration nanoSeconds: 5).
 	"not sure I should include in sunit since its Private "
-	self assert: (aDuration seconds: 0 nanoSeconds: 1) = (Duration nanoSeconds: 1). 
-
+	self assert: (aDuration seconds: 0 nanoSeconds: 1) equals: (Duration nanoSeconds: 1)
 ]
 
 { #category : #tests }
 DurationTest >> testStoreOn [
 	| stream |
 	aDuration storeOn: (stream := (String new: 20) writeStream).
-	self assert: stream contents = '(Duration seconds: 93784 nanoSeconds: 5)'.
-
-
+	self assert: stream contents equals: '(Duration seconds: 93784 nanoSeconds: 5)'
 ]
 
 { #category : #tests }
 DurationTest >> testTicks [
-	self assert: aDuration ticks =  #(1 7384 5)
+	self assert: aDuration ticks equals: #(1 7384 5)
 ]
 
 { #category : #tests }
@@ -541,19 +639,39 @@ DurationTest >> testTotalSeconds [
 
 { #category : #tests }
 DurationTest >> testTruncateTo [
-
-	self assert: ((5 minutes + 37 seconds) truncateTo: (2 minutes)) = (4 minutes).
-	self assert:  (aDuration truncateTo: (Duration days: 1)) =
-	               (Duration days: 1 hours: 0 minutes: 0 seconds: 0 nanoSeconds: 0).
-	self assert:  (aDuration truncateTo: (Duration hours: 1)) =
-	               (Duration days: 1 hours: 2 minutes: 0 seconds: 0 nanoSeconds: 0).	
-	self assert:  (aDuration truncateTo: (Duration minutes: 1)) =
-	               (Duration days: 1 hours: 2 minutes: 3 seconds: 0 nanoSeconds: 0).
+	self assert: (5 minutes + 37 seconds truncateTo: 2 minutes) equals: 4 minutes.
+	self
+		assert: (aDuration truncateTo: (Duration days: 1))
+		equals:
+			(Duration
+				days: 1
+				hours: 0
+				minutes: 0
+				seconds: 0
+				nanoSeconds: 0).
+	self
+		assert: (aDuration truncateTo: (Duration hours: 1))
+		equals:
+			(Duration
+				days: 1
+				hours: 2
+				minutes: 0
+				seconds: 0
+				nanoSeconds: 0).
+	self
+		assert: (aDuration truncateTo: (Duration minutes: 1))
+		equals:
+			(Duration
+				days: 1
+				hours: 2
+				minutes: 3
+				seconds: 0
+				nanoSeconds: 0)
 ]
 
 { #category : #tests }
 DurationTest >> testWeeks [
-	self assert: (Duration  weeks: 1) days= 7.	
+	self assert: (Duration weeks: 1) days equals: 7
 ]
 
 { #category : #tests }
@@ -579,5 +697,5 @@ DurationTest >> testWholeNanoseconds [
 
 { #category : #tests }
 DurationTest >> testZero [
-	self assert: (Duration zero) = (Duration seconds: 0).	
+	self assert: Duration zero equals: (Duration seconds: 0)
 ]

--- a/src/Kernel-Tests/ExceptionTest.class.st
+++ b/src/Kernel-Tests/ExceptionTest.class.st
@@ -246,13 +246,14 @@ ExceptionTest >> testResumableOuter [
 
 { #category : #'tests - outer' }
 ExceptionTest >> testResumablePass [
-
 	| result |
-	result := [Notification signal. 4] 
-		on: Notification 
-		do: [:ex | ex pass. ex return: 5].
-	self assert: result = 4
-
+	result := [ Notification signal.
+	4 ]
+		on: Notification
+		do: [ :ex | 
+			ex pass.
+			ex return: 5 ].
+	self assert: result equals: 4
 ]
 
 { #category : #'tests - exceptiontester' }

--- a/src/Kernel-Tests/FalseTest.class.st
+++ b/src/Kernel-Tests/FalseTest.class.st
@@ -28,15 +28,12 @@ FalseTest >> testAsBit [
 
 { #category : #'tests - controlling' }
 FalseTest >> testIfFalse [
-	
-	self assert: ((false ifFalse: ['alternativeBlock']) = 'alternativeBlock'). 
+	self assert: (false ifFalse: [ 'alternativeBlock' ]) equals: 'alternativeBlock'
 ]
 
 { #category : #'tests - controlling' }
 FalseTest >> testIfFalseIfTrue [
-
-	self assert: (false ifFalse: ['falseAlternativeBlock'] 
-                      ifTrue: ['trueAlternativeBlock']) = 'falseAlternativeBlock'. 
+	self assert: (false ifFalse: [ 'falseAlternativeBlock' ] ifTrue: [ 'trueAlternativeBlock' ]) equals: 'falseAlternativeBlock'
 ]
 
 { #category : #'tests - controlling' }
@@ -49,9 +46,7 @@ FalseTest >> testIfTrue [
 
 { #category : #'tests - controlling' }
 FalseTest >> testIfTrueIfFalse [
-
-	self assert: (false ifTrue: ['trueAlternativeBlock'] 
-                      ifFalse: ['falseAlternativeBlock']) = 'falseAlternativeBlock'. 
+	self assert: (false ifTrue: [ 'trueAlternativeBlock' ] ifFalse: [ 'falseAlternativeBlock' ]) equals: 'falseAlternativeBlock'
 ]
 
 { #category : #'tests - instance creation' }
@@ -75,20 +70,18 @@ FalseTest >> testOR [
 
 { #category : #'tests - controlling' }
 FalseTest >> testOr [
-
-	self assert: (false or: ['alternativeBlock']) = 'alternativeBlock'.
+	self assert: (false or: [ 'alternativeBlock' ]) equals: 'alternativeBlock'
 ]
 
 { #category : #'tests - printing' }
 FalseTest >> testPrintOn [
-
-	self assert: (String streamContents: [:stream | false printOn: stream]) = 'false'. 
+	self assert: (String streamContents: [ :stream | false printOn: stream ]) equals: 'false'
 ]
 
 { #category : #'tests - logical operations' }
 FalseTest >> testXor [
-	self assert: (false xor: true) = true.
-	self assert: (false xor: false) = false.
-	self assert: (false xor: [true]) = true.
-	self assert: (false xor: [false]) = false.
+	self assert: (false xor: true) equals: true.
+	self assert: (false xor: false) equals: false.
+	self assert: (false xor: [ true ]) equals: true.
+	self assert: (false xor: [ false ]) equals: false
 ]

--- a/src/Kernel-Tests/FloatTest.class.st
+++ b/src/Kernel-Tests/FloatTest.class.st
@@ -195,27 +195,24 @@ FloatTest >> testInfinity1 [
 
 { #category : #'tests - infinity behavior' }
 FloatTest >> testInfinity2 [
-
-	| i1  i2 |
+	| i1 i2 |
 	i1 := 10000 exp.
 	i2 := 1000000000 exp.
-	i2 := 0 - i2. " this is entirely ok. You can compute with infinite values."
+	i2 := 0 - i2.	" this is entirely ok. You can compute with infinite values."
 
 	self assert: i1 isInfinite & i2 isInfinite & i1 positive & i2 negative.
-	self deny: i1 = i2
-  	"All infinities are signed. Negative infinity is not equal to Infinity"
-
+	self deny: i1 equals: i2
+	"All infinities are signed. Negative infinity is not equal to Infinity"
 ]
 
 { #category : #'tests - conversion' }
 FloatTest >> testIntegerAsFloat [
 	"assert IEEE 754 round to nearest even mode is honoured"
-	
-	self deny: 16r1FFFFFFFFFFFF0801 asFloat = 16r1FFFFFFFFFFFF0800 asFloat. "this test is on 65 bits"
-	self deny: 16r1FFFFFFFFFFFF0802 asFloat = 16r1FFFFFFFFFFFF0800 asFloat. "this test is on 64 bits"
-	self assert: 16r1FFFFFFFFFFF1F800 asFloat equals: 16r1FFFFFFFFFFF20000 asFloat. "nearest even is upper"
-	self assert: 16r1FFFFFFFFFFFF0800 asFloat equals: 16r1FFFFFFFFFFFF0000 asFloat "nearest even is lower"
 
+	self deny: 16r1FFFFFFFFFFFF0801 asFloat equals: 16r1FFFFFFFFFFFF0800 asFloat.	"this test is on 65 bits"
+	self deny: 16r1FFFFFFFFFFFF0802 asFloat equals: 16r1FFFFFFFFFFFF0800 asFloat.	"this test is on 64 bits"
+	self assert: 16r1FFFFFFFFFFF1F800 asFloat equals: 16r1FFFFFFFFFFF20000 asFloat.	"nearest even is upper"
+	self assert: 16r1FFFFFFFFFFFF0800 asFloat equals: 16r1FFFFFFFFFFFF0000 asFloat	"nearest even is lower"
 ]
 
 { #category : #'tests - zero behavior' }
@@ -236,21 +233,16 @@ FloatTest >> testLiteralEqual [
 
 { #category : #'tests - characterization' }
 FloatTest >> testMaxExactInteger [
-
 	self assert: Float maxExactInteger asFloat truncated equals: Float maxExactInteger.
-	0 to: 10000 do: [ :j |
-		self assert: (Float maxExactInteger-j) asFloat truncated equals: (Float maxExactInteger-j) ].
-	self deny: (Float maxExactInteger+1) asFloat truncated = (Float maxExactInteger+1)
-	
+	0 to: 10000 do: [ :j | self assert: (Float maxExactInteger - j) asFloat truncated equals: Float maxExactInteger - j ].
+	self deny: (Float maxExactInteger + 1) asFloat truncated equals: Float maxExactInteger + 1
 ]
 
 { #category : #'tests - NaN behavior' }
 FloatTest >> testNaN1 [
-   
-	self assert: Float nan == Float nan.
-	self deny: Float nan = Float nan
+	self assert: Float nan identicalTo: Float nan.
+	self deny: Float nan equals: Float nan
 	"a NaN is not equal to itself."
-
 ]
 
 { #category : #'tests - NaN behavior' }
@@ -268,10 +260,10 @@ FloatTest >> testNaN2 [
 	nan2 := Float nan copy.
 
 	"test two instances of NaN with the same bit pattern"
-	self deny: nan1 = nan2.
-	self deny: nan1 == nan2.
-	self deny: nan1 = nan1.
-	self assert: nan1 == nan1.
+	self deny: nan1 equals: nan2.
+	self deny: nan1 identicalTo: nan2.
+	self deny: nan1 equals: nan1.
+	self assert: nan1 identicalTo: nan1.
 
 	"change the bit pattern of nan1"
 	self assert: nan1 size equals: 2.
@@ -279,14 +271,13 @@ FloatTest >> testNaN2 [
 	nan1 at: 1 put: (nan1 at: 1) + 999.
 	self assert: nan1 isNaN.
 	self assert: nan2 isNaN.
-	self deny: (nan1 at: 1) = (nan2 at: 1).
+	self deny: (nan1 at: 1) equals: (nan2 at: 1).
 
 	"test two instances of NaN with different bit patterns"
-	self deny: nan1 = nan2.
-	self deny: nan1 == nan2.
-	self deny: nan1 = nan1.
-	self assert: nan1 == nan1
-
+	self deny: nan1 equals: nan2.
+	self deny: nan1 identicalTo: nan2.
+	self deny: nan1 equals: nan1.
+	self assert: nan1 identicalTo: nan1
 ]
 
 { #category : #'tests - NaN behavior' }

--- a/src/Kernel-Tests/FractionTest.class.st
+++ b/src/Kernel-Tests/FractionTest.class.st
@@ -130,96 +130,94 @@ FractionTest >> testAsSmallerPowerOfTwo [
 
 { #category : #'tests - conversions' }
 FractionTest >> testCeiling [
-	self assert: (3 / 2) ceiling = 2.
-	self assert: (-3 / 2) ceiling = -1.
+	self assert: (3 / 2) ceiling equals: 2.
+	self assert: (-3 / 2) ceiling equals: -1
 ]
 
 { #category : #'tests - conversions' }
 FractionTest >> testFloor [
-	self assert: (3 / 2) floor = 1.
-	self assert: (-3 / 2) floor = -2.
+	self assert: (3 / 2) floor equals: 1.
+	self assert: (-3 / 2) floor equals: -2
 ]
 
 { #category : #'tests - printing' }
 FractionTest >> testFractionPrinting [
+	self assert: (353 / 359) printString equals: '(353/359)'.
+	self assert: (2 / 3 printStringBase: 2) equals: '(10/11)'.
+	self assert: (2 / 3 storeStringBase: 2) equals: '(2r10/2r11)'.
+	self assert: (5 / 7 printStringBase: 3) equals: '(12/21)'.
+	self assert: (5 / 7 storeStringBase: 3) equals: '(3r12/3r21)'.
+	self assert: (11 / 13 printStringBase: 4) equals: '(23/31)'.
+	self assert: (11 / 13 storeStringBase: 4) equals: '(4r23/4r31)'.
+	self assert: (17 / 19 printStringBase: 5) equals: '(32/34)'.
+	self assert: (17 / 19 storeStringBase: 5) equals: '(5r32/5r34)'.
+	self assert: (23 / 29 printStringBase: 6) equals: '(35/45)'.
+	self assert: (23 / 29 storeStringBase: 6) equals: '(6r35/6r45)'.
+	self assert: (31 / 37 printStringBase: 7) equals: '(43/52)'.
+	self assert: (31 / 37 storeStringBase: 7) equals: '(7r43/7r52)'.
+	self assert: (41 / 43 printStringBase: 8) equals: '(51/53)'.
+	self assert: (41 / 43 storeStringBase: 8) equals: '(8r51/8r53)'.
+	self assert: (47 / 53 printStringBase: 9) equals: '(52/58)'.
+	self assert: (47 / 53 storeStringBase: 9) equals: '(9r52/9r58)'.
+	self assert: (59 / 61 printStringBase: 10) equals: '(59/61)'.
+	self assert: (59 / 61 storeStringBase: 10) equals: '(59/61)'.
+	self assert: (67 / 71 printStringBase: 11) equals: '(61/65)'.
+	self assert: (67 / 71 storeStringBase: 11) equals: '(11r61/11r65)'.
+	self assert: (73 / 79 printStringBase: 12) equals: '(61/67)'.
+	self assert: (73 / 79 storeStringBase: 12) equals: '(12r61/12r67)'.
+	self assert: (83 / 89 printStringBase: 13) equals: '(65/6B)'.
+	self assert: (83 / 89 storeStringBase: 13) equals: '(13r65/13r6B)'.
+	self assert: (97 / 101 printStringBase: 14) equals: '(6D/73)'.
+	self assert: (97 / 101 storeStringBase: 14) equals: '(14r6D/14r73)'.
+	self assert: (103 / 107 printStringBase: 15) equals: '(6D/72)'.
+	self assert: (103 / 107 storeStringBase: 15) equals: '(15r6D/15r72)'.
+	self assert: (109 / 113 printStringBase: 16) equals: '(6D/71)'.
+	self assert: (109 / 113 storeStringBase: 16) equals: '(16r6D/16r71)'.
+	self assert: (127 / 131 printStringBase: 17) equals: '(78/7C)'.
+	self assert: (127 / 131 storeStringBase: 17) equals: '(17r78/17r7C)'.
+	self assert: (137 / 139 printStringBase: 18) equals: '(7B/7D)'.
+	self assert: (137 / 139 storeStringBase: 18) equals: '(18r7B/18r7D)'.
+	self assert: (149 / 151 printStringBase: 19) equals: '(7G/7I)'.
+	self assert: (149 / 151 storeStringBase: 19) equals: '(19r7G/19r7I)'.
+	self assert: (157 / 163 printStringBase: 20) equals: '(7H/83)'.
+	self assert: (157 / 163 storeStringBase: 20) equals: '(20r7H/20r83)'.
+	self assert: (167 / 173 printStringBase: 21) equals: '(7K/85)'.
+	self assert: (167 / 173 storeStringBase: 21) equals: '(21r7K/21r85)'.
+	self assert: (179 / 181 printStringBase: 22) equals: '(83/85)'.
+	self assert: (179 / 181 storeStringBase: 22) equals: '(22r83/22r85)'.
+	self assert: (191 / 193 printStringBase: 23) equals: '(87/89)'.
+	self assert: (191 / 193 storeStringBase: 23) equals: '(23r87/23r89)'.
+	self assert: (197 / 199 printStringBase: 24) equals: '(85/87)'.
+	self assert: (197 / 199 storeStringBase: 24) equals: '(24r85/24r87)'.
+	self assert: (211 / 223 printStringBase: 25) equals: '(8B/8N)'.
+	self assert: (211 / 223 storeStringBase: 25) equals: '(25r8B/25r8N)'.
+	self assert: (227 / 229 printStringBase: 26) equals: '(8J/8L)'.
+	self assert: (227 / 229 storeStringBase: 26) equals: '(26r8J/26r8L)'.
+	self assert: (233 / 239 printStringBase: 27) equals: '(8H/8N)'.
+	self assert: (233 / 239 storeStringBase: 27) equals: '(27r8H/27r8N)'.
+	self assert: (241 / 251 printStringBase: 28) equals: '(8H/8R)'.
+	self assert: (241 / 251 storeStringBase: 28) equals: '(28r8H/28r8R)'.
+	self assert: (257 / 263 printStringBase: 29) equals: '(8P/92)'.
+	self assert: (257 / 263 storeStringBase: 29) equals: '(29r8P/29r92)'.
+	self assert: (269 / 271 printStringBase: 30) equals: '(8T/91)'.
+	self assert: (269 / 271 storeStringBase: 30) equals: '(30r8T/30r91)'.
+	self assert: (277 / 281 printStringBase: 31) equals: '(8T/92)'.
+	self assert: (277 / 281 storeStringBase: 31) equals: '(31r8T/31r92)'.
+	self assert: (283 / 293 printStringBase: 32) equals: '(8R/95)'.
+	self assert: (283 / 293 storeStringBase: 32) equals: '(32r8R/32r95)'.
+	self assert: (307 / 311 printStringBase: 33) equals: '(9A/9E)'.
+	self assert: (307 / 311 storeStringBase: 33) equals: '(33r9A/33r9E)'.
+	self assert: (313 / 317 printStringBase: 34) equals: '(97/9B)'.
+	self assert: (313 / 317 storeStringBase: 34) equals: '(34r97/34r9B)'.
+	self assert: (331 / 337 printStringBase: 35) equals: '(9G/9M)'.
+	self assert: (331 / 337 storeStringBase: 35) equals: '(35r9G/35r9M)'.
+	self assert: (347 / 349 printStringBase: 36) equals: '(9N/9P)'.
+	self assert: (347 / 349 storeStringBase: 36) equals: '(36r9N/36r9P)'.
 
-	self assert: (353/359) printString = '(353/359)'.
-	self assert: ((2/3) printStringBase: 2) = '(10/11)'.
-	self assert: ((2/3) storeStringBase: 2) = '(2r10/2r11)'.
-	self assert: ((5/7) printStringBase: 3) = '(12/21)'.
-	self assert: ((5/7) storeStringBase: 3) = '(3r12/3r21)'.
-	self assert: ((11/13) printStringBase: 4) = '(23/31)'.
-	self assert: ((11/13) storeStringBase: 4) = '(4r23/4r31)'.
-	self assert: ((17/19) printStringBase: 5) = '(32/34)'.
-	self assert: ((17/19) storeStringBase: 5) = '(5r32/5r34)'.
-	self assert: ((23/29) printStringBase: 6) = '(35/45)'.
-	self assert: ((23/29) storeStringBase: 6) = '(6r35/6r45)'.
-	self assert: ((31/37) printStringBase: 7) = '(43/52)'.
-	self assert: ((31/37) storeStringBase: 7) = '(7r43/7r52)'.
-	self assert: ((41/43) printStringBase: 8) = '(51/53)'.
-	self assert: ((41/43) storeStringBase: 8) = '(8r51/8r53)'.
-	self assert: ((47/53) printStringBase: 9) = '(52/58)'.
-	self assert: ((47/53) storeStringBase: 9) = '(9r52/9r58)'.
-	self assert: ((59/61) printStringBase: 10) = '(59/61)'.
-	self assert: ((59/61) storeStringBase: 10) = '(59/61)'.
-	self assert: ((67/71) printStringBase: 11) = '(61/65)'.
-	self assert: ((67/71) storeStringBase: 11) = '(11r61/11r65)'.
-	self assert: ((73/79) printStringBase: 12) = '(61/67)'.
-	self assert: ((73/79) storeStringBase: 12) = '(12r61/12r67)'.
-	self assert: ((83/89) printStringBase: 13) = '(65/6B)'.
-	self assert: ((83/89) storeStringBase: 13) = '(13r65/13r6B)'.
-	self assert: ((97/101) printStringBase: 14) = '(6D/73)'.
-	self assert: ((97/101) storeStringBase: 14) = '(14r6D/14r73)'.
-	self assert: ((103/107) printStringBase: 15) = '(6D/72)'.
-	self assert: ((103/107) storeStringBase: 15) = '(15r6D/15r72)'.
-	self assert: ((109/113) printStringBase: 16) = '(6D/71)'.
-	self assert: ((109/113) storeStringBase: 16) = '(16r6D/16r71)'.
-	self assert: ((127/131) printStringBase: 17) = '(78/7C)'.
-	self assert: ((127/131) storeStringBase: 17) = '(17r78/17r7C)'.
-	self assert: ((137/139) printStringBase: 18) = '(7B/7D)'.
-	self assert: ((137/139) storeStringBase: 18) = '(18r7B/18r7D)'.
-	self assert: ((149/151) printStringBase: 19) = '(7G/7I)'.
-	self assert: ((149/151) storeStringBase: 19) = '(19r7G/19r7I)'.
-	self assert: ((157/163) printStringBase: 20) = '(7H/83)'.
-	self assert: ((157/163) storeStringBase: 20) = '(20r7H/20r83)'.
-	self assert: ((167/173) printStringBase: 21) = '(7K/85)'.
-	self assert: ((167/173) storeStringBase: 21) = '(21r7K/21r85)'.
-	self assert: ((179/181) printStringBase: 22) = '(83/85)'.
-	self assert: ((179/181) storeStringBase: 22) = '(22r83/22r85)'.
-	self assert: ((191/193) printStringBase: 23) = '(87/89)'.
-	self assert: ((191/193) storeStringBase: 23) = '(23r87/23r89)'.
-	self assert: ((197/199) printStringBase: 24) = '(85/87)'.
-	self assert: ((197/199) storeStringBase: 24) = '(24r85/24r87)'.
-	self assert: ((211/223) printStringBase: 25) = '(8B/8N)'.
-	self assert: ((211/223) storeStringBase: 25) = '(25r8B/25r8N)'.
-	self assert: ((227/229) printStringBase: 26) = '(8J/8L)'.
-	self assert: ((227/229) storeStringBase: 26) = '(26r8J/26r8L)'.
-	self assert: ((233/239) printStringBase: 27) = '(8H/8N)'.
-	self assert: ((233/239) storeStringBase: 27) = '(27r8H/27r8N)'.
-	self assert: ((241/251) printStringBase: 28) = '(8H/8R)'.
-	self assert: ((241/251) storeStringBase: 28) = '(28r8H/28r8R)'.
-	self assert: ((257/263) printStringBase: 29) = '(8P/92)'.
-	self assert: ((257/263) storeStringBase: 29) = '(29r8P/29r92)'.
-	self assert: ((269/271) printStringBase: 30) = '(8T/91)'.
-	self assert: ((269/271) storeStringBase: 30) = '(30r8T/30r91)'.
-	self assert: ((277/281) printStringBase: 31) = '(8T/92)'.
-	self assert: ((277/281) storeStringBase: 31) = '(31r8T/31r92)'.
-	self assert: ((283/293) printStringBase: 32) = '(8R/95)'.
-	self assert: ((283/293) storeStringBase: 32) = '(32r8R/32r95)'.
-	self assert: ((307/311) printStringBase: 33) = '(9A/9E)'.
-	self assert: ((307/311) storeStringBase: 33) = '(33r9A/33r9E)'.
-	self assert: ((313/317) printStringBase: 34) = '(97/9B)'.
-	self assert: ((313/317) storeStringBase: 34) = '(34r97/34r9B)'.
-	self assert: ((331/337) printStringBase: 35) = '(9G/9M)'.
-	self assert: ((331/337) storeStringBase: 35) = '(35r9G/35r9M)'.
-	self assert: ((347/349) printStringBase: 36) = '(9N/9P)'.
-	self assert: ((347/349) storeStringBase: 36) = '(36r9N/36r9P)'.
-
-	self assert: ((-2/3) printStringBase: 2) = '(-10/11)'.
-	self assert: ((-2/3) storeStringBase: 2) = '(-2r10/2r11)'.
-	self assert: ((5 / -7) printStringBase: 3) = '(-12/21)'.
-	self assert: ((5 / -7) storeStringBase: 3) = '(-3r12/3r21)'.
-
+	self assert: (-2 / 3 printStringBase: 2) equals: '(-10/11)'.
+	self assert: (-2 / 3 storeStringBase: 2) equals: '(-2r10/2r11)'.
+	self assert: (5 / -7 printStringBase: 3) equals: '(-12/21)'.
+	self assert: (5 / -7 storeStringBase: 3) equals: '(-3r12/3r21)'
 ]
 
 { #category : #'tests - conversions' }
@@ -276,24 +274,23 @@ FractionTest >> testReadFrom [
 
 { #category : #'tests - sinuses' }
 FractionTest >> testReciprocal [
-
-	self 
-		assert: (1/2) reciprocal = 2;
-		assert: (3/4) reciprocal = (4/3);
-		assert: (-1/3) reciprocal = -3;
-		assert: (-3/5) reciprocal = (-5/3)
+	self
+		assert: (1 / 2) reciprocal equals: 2;
+		assert: (3 / 4) reciprocal equals: 4 / 3;
+		assert: (-1 / 3) reciprocal equals: -3;
+		assert: (-3 / 5) reciprocal equals: -5 / 3
 ]
 
 { #category : #'tests - conversions' }
 FractionTest >> testRounded [
-	self assert: (4 / 5) rounded = 1.
-	self assert: (6 / 5) rounded = 1.
-	self assert: (-4 / 5) rounded = -1.
-	self assert: (-6 / 5) rounded = -1.
-	
+	self assert: (4 / 5) rounded equals: 1.
+	self assert: (6 / 5) rounded equals: 1.
+	self assert: (-4 / 5) rounded equals: -1.
+	self assert: (-6 / 5) rounded equals: -1.
+
 	"In case of tie, round to upper magnitude"
-	self assert: (3 / 2) rounded = 2.
-	self assert: (-3 / 2) rounded = -2.
+	self assert: (3 / 2) rounded equals: 2.
+	self assert: (-3 / 2) rounded equals: -2
 ]
 
 { #category : #'tests - rounding' }
@@ -304,6 +301,6 @@ FractionTest >> testRounding [
 
 { #category : #'tests - conversions' }
 FractionTest >> testTruncated [
-	self assert: (3 / 2) truncated = 1.
-	self assert: (-3 / 2) truncated = -1.
+	self assert: (3 / 2) truncated equals: 1.
+	self assert: (-3 / 2) truncated equals: -1
 ]

--- a/src/Kernel-Tests/IntegerDigitLogicTest.class.st
+++ b/src/Kernel-Tests/IntegerDigitLogicTest.class.st
@@ -10,66 +10,68 @@ Class {
 { #category : #tests }
 IntegerDigitLogicTest >> testAndSingleBitWithMinusOne [
 	"And a single bit with -1 and test for same value"
-	1 to: 100 do: [:i | self assert: ((1 bitShift: i) bitAnd: -1) = (1 bitShift: i)].
+
+	1 to: 100 do: [ :i | self assert: ((1 bitShift: i) bitAnd: -1) equals: (1 bitShift: i) ]
 ]
 
 { #category : #tests }
 IntegerDigitLogicTest >> testLargeShift [
 	"A sanity check for LargeInteger bitShifts"
-	
+
 	| suite |
-	suite := #( "some numbers on 64 bits or less"
-               '101101011101001100110111110110011101101101000001110110011'
-               '1101101001100010011001101110100000111011011010100011101100'
-               '101101101011110011001100110011011101011001111000100011101000'
-               '10101101101000101001111111111100101101011001011000100011100000'
-               '1000101010101001111011101010111001011111110011110001000110000000'
-               '1100101010101000010011101000110010111110110011110000000000000001' ).
+	suite := #('101101011101001100110111110110011101101101000001110110011' '1101101001100010011001101110100000111011011010100011101100' '101101101011110011001100110011011101011001111000100011101000' '10101101101000101001111111111100101101011001011000100011100000' '1000101010101001111011101010111001011111110011110001000110000000' '1100101010101000010011101000110010111110110011110000000000000001').	"some numbers on 64 bits or less"
 	"65 bits or less"
-	suite := suite , (suite collect: [:e | '1' , e reversed ]).
+	suite := suite , (suite collect: [ :e | '1' , e reversed ]).
 	"129 bits or less"
-	suite := suite , (suite collect: [:e | e ,e ]).
-	suite do: [:bits | | num ls rs |
-		num := Integer readFrom: bits readStream base: 2.
-		0 to: bits size-1 do: [:shift |
-			ls := (num bitShift: shift) printStringBase: 2.
-			rs := (num bitShift: 0-shift) printStringBase: 2.
-			self assert: ls = (bits , (String new: shift withAll: $0)).
-			self assert: rs = (bits copyFrom: 1 to: bits size - shift).]]
+	suite := suite , (suite collect: [ :e | e , e ]).
+	suite
+		do: [ :bits | 
+			| num ls rs |
+			num := Integer readFrom: bits readStream base: 2.
+			0 to: bits size - 1 do: [ :shift | 
+				ls := (num bitShift: shift) printStringBase: 2.
+				rs := (num bitShift: 0 - shift) printStringBase: 2.
+				self assert: ls equals: bits , (String new: shift withAll: $0).
+				self assert: rs equals: (bits copyFrom: 1 to: bits size - shift) ] ]
 ]
 
 { #category : #tests }
 IntegerDigitLogicTest >> testMixedSignDigitLogic [
 	"Verify that mixed sign logic with large integers works."
-	self assert: (-2 bitAnd: 16rFFFFFFFF) = 16rFFFFFFFE
+
+	self assert: (-2 bitAnd: 16rFFFFFFFF) equals: 16rFFFFFFFE
 ]
 
 { #category : #tests }
 IntegerDigitLogicTest >> testNBitAndNNegatedEqualsN [
 	"Verify that (n bitAnd: n negated) = n for single bits"
+
 	| n |
-	1 to: 100 do: [:i | n := 1 bitShift: i.
-				self assert: (n bitAnd: n negated) = n]
+	1 to: 100 do: [ :i | 
+		n := 1 bitShift: i.
+		self assert: (n bitAnd: n negated) equals: n ]
 ]
 
 { #category : #tests }
 IntegerDigitLogicTest >> testNNegatedEqualsNComplementedPlusOne [
 	"Verify that n negated = (n complemented + 1) for single bits"
+
 	| n |
-	1 to: 100 do: [:i | n := 1 bitShift: i.
-				self assert: n negated = ((n bitXor: -1) + 1)]
+	1 to: 100 do: [ :i | 
+		n := 1 bitShift: i.
+		self assert: n negated equals: (n bitXor: -1) + 1 ]
 ]
 
 { #category : #tests }
 IntegerDigitLogicTest >> testShiftMinusOne1LeftThenRight [
 	"Shift -1 left then right and test for 1"
-	1 to: 100 do: [:i | self assert: ((-1 bitShift: i) bitShift: i negated) = -1].
 
+	1 to: 100 do: [ :i | self assert: ((-1 bitShift: i) bitShift: i negated) equals: -1 ]
 ]
 
 { #category : #tests }
 IntegerDigitLogicTest >> testShiftOneLeftThenRight [
 	"Shift 1 bit left then right and test for 1"
-	1 to: 100 do: [:i | self assert: ((1 bitShift: i) bitShift: i negated) = 1].
 
+	1 to: 100 do: [ :i | self assert: ((1 bitShift: i) bitShift: i negated) equals: 1 ]
 ]

--- a/src/Kernel-Tests/IntegerTest.class.st
+++ b/src/Kernel-Tests/IntegerTest.class.st
@@ -83,44 +83,28 @@ IntegerTest >> testBitAnd [
 { #category : #'tests - bitLogic' }
 IntegerTest >> testBitAt [
 	| trials bitSequence2 |
-
 	self assert: (2r10 bitAt: 1) equals: 0.
 	self assert: (2r10 bitAt: 2) equals: 1.
-	
-	self
-		assert: ((1 to: 100) allSatisfy: [:i | (0 bitAt: i) = 0])
-		description: 'all bits of zero are set to zero'.
-	
-	self
-		assert: ((1 to: 100) allSatisfy: [:i | (-1 bitAt: i) = 1])
-		description: 'In two complements, all bits of -1 are set to 1'.
-		
-	
-	trials := #(
-		'2r10010011'
-		'2r11100100'
-		'2r10000000'
-		'2r0000101011011001'
-		'2r1000101011011001'
-		'2r0101010101011000'
-		'2r0010011110110010'
-		'2r0010011000000000'
-		'2r00100111101100101000101011011001'
-		'2r01110010011110110010100110101101'
-		'2r10101011101011001010000010110110'
-		'2r10101000000000000000000000000000'
-		'2r0010101110101001110010100000101101100010011110110010100010101100'
-		'2r1010101110101100101000001011011000100111101100101000101011011001'
-		'2r1010101110101000000000000000000000000000000000000000000000000000').
-	trials do: [:bitSequence | | aNumber |
-		aNumber := Number readFrom: bitSequence.
-		bitSequence2 := (bitSequence size - 2 to: 1 by: -1) inject: '2r' into: [:string :i | string copyWith: (Character digitValue: (aNumber bitAt: i))].
-		self assert: bitSequence2 = bitSequence].
-	
-	trials do: [:bitSequence | | bitInvert |
-		bitInvert := -1 - (Number readFrom: bitSequence).
-		bitSequence2 := (bitSequence size - 2 to: 1 by: -1) inject: '2r' into: [:string :i | string copyWith: (Character digitValue: 1 - (bitInvert bitAt: i))].
-		self assert: bitSequence2 = bitSequence description: '-1-x is similar to a bitInvert operation in two complement']
+
+	self assert: ((1 to: 100) allSatisfy: [ :i | (0 bitAt: i) = 0 ]) description: 'all bits of zero are set to zero'.
+
+	self assert: ((1 to: 100) allSatisfy: [ :i | (-1 bitAt: i) = 1 ]) description: 'In two complements, all bits of -1 are set to 1'.
+
+
+	trials := #('2r10010011' '2r11100100' '2r10000000' '2r0000101011011001' '2r1000101011011001' '2r0101010101011000' '2r0010011110110010' '2r0010011000000000' '2r00100111101100101000101011011001' '2r01110010011110110010100110101101' '2r10101011101011001010000010110110' '2r10101000000000000000000000000000' '2r0010101110101001110010100000101101100010011110110010100010101100' '2r1010101110101100101000001011011000100111101100101000101011011001' '2r1010101110101000000000000000000000000000000000000000000000000000').
+	trials
+		do: [ :bitSequence | 
+			| aNumber |
+			aNumber := Number readFrom: bitSequence.
+			bitSequence2 := (bitSequence size - 2 to: 1 by: -1) inject: '2r' into: [ :string :i | string copyWith: (Character digitValue: (aNumber bitAt: i)) ].
+			self assert: bitSequence2 equals: bitSequence ].
+
+	trials
+		do: [ :bitSequence | 
+			| bitInvert |
+			bitInvert := -1 - (Number readFrom: bitSequence).
+			bitSequence2 := (bitSequence size - 2 to: 1 by: -1) inject: '2r' into: [ :string :i | string copyWith: (Character digitValue: 1 - (bitInvert bitAt: i)) ].
+			self assert: bitSequence2 = bitSequence description: '-1-x is similar to a bitInvert operation in two complement' ]
 ]
 
 { #category : #'tests - bitLogic' }
@@ -236,6 +220,7 @@ IntegerTest >> testCreationFromBytes1 [
 IntegerTest >> testCreationFromBytes2 [
 	"It is illegal for a LargeInteger to be less than SmallInteger maxVal. Here we test that Integer>>byte!byte2:byte3:byte4: 
 	 reconstructs (SmallInteger maxVal + 1) as an instance of LargePositiveInteger."
+
 	| maxSmallInt hexString byte1 byte2 byte3 byte4 builtInteger |
 	Smalltalk vm wordSize = 4 ifFalse: [ ^ self skip ].
 	maxSmallInt := SmallInteger maxVal.
@@ -245,10 +230,13 @@ IntegerTest >> testCreationFromBytes2 [
 	byte3 := Number readFrom: (hexString copyFrom: 3 to: 4) base: 16.
 	byte2 := Number readFrom: (hexString copyFrom: 5 to: 6) base: 16.
 	byte1 := Number readFrom: (hexString copyFrom: 7 to: 8) base: 16.
-	builtInteger := Integer byte1: byte1 byte2: byte2 byte3: byte3 byte4: byte4.
+	builtInteger := Integer
+		byte1: byte1
+		byte2: byte2
+		byte3: byte3
+		byte4: byte4.
 	self assert: builtInteger equals: maxSmallInt + 1.
-	self deny: builtInteger class = SmallInteger
-
+	self deny: builtInteger class equals: SmallInteger
 ]
 
 { #category : #'tests - instance creation' }
@@ -396,57 +384,61 @@ IntegerTest >> testEven [
 
 { #category : #'tests - printing' }
 IntegerTest >> testHex [
-	self assert: 0 hex =  '16r0'.
-	self assert: 12 hex =  '16rC'.
-	self assert: 1234 hex =  '16r4D2'.
+	self assert: 0 hex equals: '16r0'.
+	self assert: 12 hex equals: '16rC'.
+	self assert: 1234 hex equals: '16r4D2'
 ]
 
 { #category : #'tests - bitLogic' }
 IntegerTest >> testHighBit [
-
 	| suite |
-	self assert: (2r1110 highBit) equals: 4.
-	self assert: (2r0110 highBit) equals: 3.
-	self assert: (2r0000 highBit) equals: 0.
-	
-	suite := (0 to: 1024) asArray , #(16rFDFD 16rFFFF 16r1000 16r1000000 16r1000001 16r70000000 16r7AFAFAFA ) , {SmallInteger maxVal . SmallInteger maxVal+1}.
-	suite := suite , (suite collect: [:e | e raisedTo: 20]).
-	
-	suite do: [:anInteger |
-		| highBit shifted |
-		highBit := 0.
-		shifted := 1.
-		[shifted > anInteger] whileFalse: [highBit := highBit+1. shifted := shifted bitShift: 1].
-		self assert: anInteger highBit = highBit].
+	self assert: 2r1110 highBit equals: 4.
+	self assert: 2r0110 highBit equals: 3.
+	self assert: 2r0000 highBit equals: 0.
+
+	suite := (0 to: 1024) asArray , #(16rFDFD 16rFFFF 16r1000 16r1000000 16r1000001 16r70000000 16r7AFAFAFA) , {SmallInteger maxVal . (SmallInteger maxVal + 1)}.
+	suite := suite , (suite collect: [ :e | e raisedTo: 20 ]).
+
+	suite
+		do: [ :anInteger | 
+			| highBit shifted |
+			highBit := 0.
+			shifted := 1.
+			[ shifted > anInteger ]
+				whileFalse: [ highBit := highBit + 1.
+					shifted := shifted bitShift: 1 ].
+			self assert: anInteger highBit equals: highBit ]
 ]
 
 { #category : #'tests - bitLogic' }
 IntegerTest >> testHighBitOfMagnitude [
 	| suite |
+	suite := (0 to: 1024) asArray , #(16rFDFD 16rFFFF 16r1000 16r1000000 16r1000001 16r70000000 16r7AFAFAFA) , {SmallInteger maxVal . (SmallInteger maxVal + 1)}.
+	suite := suite , (suite collect: [ :e | e raisedTo: 20 ]).
 
-	suite := (0 to: 1024) asArray , #(16rFDFD 16rFFFF 16r1000 16r1000000 16r1000001 16r70000000 16r7AFAFAFA ) , {SmallInteger maxVal . SmallInteger maxVal+1}.
-	suite := suite , (suite collect: [:e | e raisedTo: 20]).
-	
-	suite do: [:anInteger |
-		| highBit shifted |
-		highBit := 0.
-		shifted := 1.
-		[shifted > anInteger] whileFalse: [highBit := highBit+1. shifted := shifted bitShift: 1].
-		self assert: anInteger highBitOfMagnitude = highBit.
-		self assert: anInteger negated highBitOfMagnitude = highBit].
+	suite
+		do: [ :anInteger | 
+			| highBit shifted |
+			highBit := 0.
+			shifted := 1.
+			[ shifted > anInteger ]
+				whileFalse: [ highBit := highBit + 1.
+					shifted := shifted bitShift: 1 ].
+			self assert: anInteger highBitOfMagnitude equals: highBit.
+			self assert: anInteger negated highBitOfMagnitude equals: highBit ]
 ]
 
 { #category : #'tests - printing' }
 IntegerTest >> testIntegerHex [
 	| result |
 	result := 15 asInteger hex.
-	self assert: result = '16rF'.
+	self assert: result equals: '16rF'.
 	result := 0 asInteger hex.
-	self assert: result = '16r0'.
+	self assert: result equals: '16r0'.
 	result := 255 asInteger hex.
-	self assert: result = '16rFF'.
+	self assert: result equals: '16rFF'.
 	result := 90 asInteger hex.
-	self assert: result = '16r5A'
+	self assert: result equals: '16r5A'
 ]
 
 { #category : #'tests - printing' }
@@ -543,20 +535,20 @@ IntegerTest >> testIntegerReadsNotOkFromString [
 
 { #category : #'tests - instance creation' }
 IntegerTest >> testIntegerReadsOkFromStream [
-	self assert: (Integer readFrom: '123' readStream) = 123.
-	self assert: (Integer readFrom: '-123' readStream) = -123.
-	self assert: (Integer readFrom: 'a3' readStream base: 16) = 163.
-	self assert: (Integer readFrom: '-a3' readStream base: 16) = -163.
-	
-	self assert: (Integer readFrom: '3a' readStream base: 10) = 3.
+	self assert: (Integer readFrom: '123' readStream) equals: 123.
+	self assert: (Integer readFrom: '-123' readStream) equals: -123.
+	self assert: (Integer readFrom: 'a3' readStream base: 16) equals: 163.
+	self assert: (Integer readFrom: '-a3' readStream base: 16) equals: -163.
+
+	self assert: (Integer readFrom: '3a' readStream base: 10) equals: 3
 ]
 
 { #category : #'tests - instance creation' }
 IntegerTest >> testIntegerReadsOkFromString [
-	self assert: (Integer readFrom: '123') = 123.
-	self assert: (Integer readFrom: '-123') = -123.
-	self assert: (Integer readFrom: 'a3' base: 16) = 163.
-	self assert: (Integer readFrom: '-a3' base: 16) = -163.
+	self assert: (Integer readFrom: '123') equals: 123.
+	self assert: (Integer readFrom: '-123') equals: -123.
+	self assert: (Integer readFrom: 'a3' base: 16) equals: 163.
+	self assert: (Integer readFrom: '-a3' base: 16) equals: -163
 ]
 
 { #category : #'tests - other' }
@@ -602,23 +594,23 @@ IntegerTest >> testIsPowerOfTwoM6873 [
 
 { #category : #'tests - bitLogic' }
 IntegerTest >> testLowBit [
-
 	| suite |
 	"Simple examples"
-	self assert: (2r1011 lowBit) equals: 1.
-	self assert: (2r1010 lowBit) equals: 2.
-	self assert: (2r000000 lowBit) equals: 0.
-	
-	suite := (0 to: 1024) asArray , #(16rFDFD 16rFFFF 16r1000 16r1000000 16r1000001 16r70000000 16r7AFAFAFA ) , {SmallInteger maxVal . SmallInteger maxVal+1}.
-	suite := suite , (suite collect: [:e | e raisedTo: 20]).
-	
-	suite do: [:anInteger |
-		| lowBit |
-		lowBit := (anInteger respondsTo: #bitAt:)
-			ifTrue: [(1 to: anInteger highBit) detect: [:bitIndex | (anInteger bitAt: bitIndex) ~= 0] ifNone: [0]]
-			ifFalse: [(1 to: anInteger highBit) detect: [:bitIndex | (anInteger bitAnd: (1 bitShift: bitIndex-1)) ~= 0] ifNone: [0]].
-		self assert: anInteger lowBit = lowBit.
-		self assert: anInteger negated lowBit = lowBit].
+	self assert: 2r1011 lowBit equals: 1.
+	self assert: 2r1010 lowBit equals: 2.
+	self assert: 2r000000 lowBit equals: 0.
+
+	suite := (0 to: 1024) asArray , #(16rFDFD 16rFFFF 16r1000 16r1000000 16r1000001 16r70000000 16r7AFAFAFA) , {SmallInteger maxVal . (SmallInteger maxVal + 1)}.
+	suite := suite , (suite collect: [ :e | e raisedTo: 20 ]).
+
+	suite
+		do: [ :anInteger | 
+			| lowBit |
+			lowBit := (anInteger respondsTo: #bitAt:)
+				ifTrue: [ (1 to: anInteger highBit) detect: [ :bitIndex | (anInteger bitAt: bitIndex) ~= 0 ] ifNone: [ 0 ] ]
+				ifFalse: [ (1 to: anInteger highBit) detect: [ :bitIndex | (anInteger bitAnd: (1 bitShift: bitIndex - 1)) ~= 0 ] ifNone: [ 0 ] ].
+			self assert: anInteger lowBit equals: lowBit.
+			self assert: anInteger negated lowBit equals: lowBit ]
 ]
 
 { #category : #'tests - printing' }
@@ -815,19 +807,17 @@ IntegerTest >> testNotInstantiable [
 
 { #category : #'tests - printing' }
 IntegerTest >> testNumberOfDigits [
-	
-	2 to: 32 do: [:b |
-		1 to: 1000//b do: [:n |
+	2 to: 32 do: [ :b | 
+		1 to: 1000 // b do: [ :n | 
 			| bRaisedToN |
 			bRaisedToN := b raisedTo: n.
-			self assert: (bRaisedToN - 1 numberOfDigitsInBase: b) = n.
-			self assert: (bRaisedToN numberOfDigitsInBase: b) = (n+1).
-			self assert: (bRaisedToN + 1 numberOfDigitsInBase: b) = (n+1).
-			
-			self assert: (bRaisedToN negated + 1 numberOfDigitsInBase: b) = n.
-			self assert: (bRaisedToN negated numberOfDigitsInBase: b) = (n+1).
-			self assert: (bRaisedToN negated - 1 numberOfDigitsInBase: b) = (n+1).]].
+			self assert: (bRaisedToN - 1 numberOfDigitsInBase: b) equals: n.
+			self assert: (bRaisedToN numberOfDigitsInBase: b) equals: n + 1.
+			self assert: (bRaisedToN + 1 numberOfDigitsInBase: b) equals: n + 1.
 
+			self assert: (bRaisedToN negated + 1 numberOfDigitsInBase: b) equals: n.
+			self assert: (bRaisedToN negated numberOfDigitsInBase: b) equals: n + 1.
+			self assert: (bRaisedToN negated - 1 numberOfDigitsInBase: b) equals: n + 1 ] ]
 ]
 
 { #category : #'tests - printing' }
@@ -1040,17 +1030,15 @@ IntegerTest >> testPrintSeparatedByEverySignedOn [
 
 { #category : #'tests - printing' }
 IntegerTest >> testPrintStringBase [
-	
-	2 to: 32 do: [:b |
-		1 to: 1000//b do: [:n |
+	2 to: 32 do: [ :b | 
+		1 to: 1000 // b do: [ :n | 
 			| bRaisedToN |
 			bRaisedToN := b raisedTo: n.
-			self assert: (bRaisedToN - 1 printStringBase: b) = (String new: n withAll: (Character digitValue: b-1)).
-			self assert: (bRaisedToN printStringBase: b) = ('1' , (String new: n withAll: $0)).
-			
-			self assert: (bRaisedToN negated + 1 printStringBase: b) = ('-' , (String new: n withAll: (Character digitValue: b-1))).
-			self assert: (bRaisedToN negated printStringBase: b) = ('-1' , (String new: n withAll: $0))]].
+			self assert: (bRaisedToN - 1 printStringBase: b) equals: (String new: n withAll: (Character digitValue: b - 1)).
+			self assert: (bRaisedToN printStringBase: b) equals: '1' , (String new: n withAll: $0).
 
+			self assert: (bRaisedToN negated + 1 printStringBase: b) equals: '-' , (String new: n withAll: (Character digitValue: b - 1)).
+			self assert: (bRaisedToN negated printStringBase: b) equals: '-1' , (String new: n withAll: $0) ] ]
 ]
 
 { #category : #'tests - printing' }
@@ -1074,17 +1062,18 @@ IntegerTest >> testRaisedToErrorConditions [
 { #category : #'tests - instance creation' }
 IntegerTest >> testReadFrom [
 	"Ensure remaining characters in a stream are not lost when parsing an integer."
+
 	| rs i s |
 	rs := '123s could be confused with a ScaledDecimal' readStream.
 	i := Integer readFrom: rs.
-	self assert: i = 123.
+	self assert: i equals: 123.
 	s := rs upToEnd.
-	self assert: 's could be confused with a ScaledDecimal' = s.
+	self assert: 's could be confused with a ScaledDecimal' equals: s.
 	rs := '123.s could be confused with a ScaledDecimal' readStream.
 	i := Integer readFrom: rs.
-	self assert: i = 123.
+	self assert: i equals: 123.
 	s := rs upToEnd.
-	self assert: '.s could be confused with a ScaledDecimal' = s
+	self assert: '.s could be confused with a ScaledDecimal' equals: s
 ]
 
 { #category : #'tests - instance creation' }
@@ -1097,14 +1086,13 @@ IntegerTest >> testReadFromWithError [
 
 { #category : #'tests - arithmetic' }
 IntegerTest >> testReciprocalModulo [
-	1 to: 512 do: [:a |
-		a + 1 to: 512 do: [:b |
+	1 to: 512 do: [ :a | 
+		a + 1 to: 512 do: [ :b | 
 			| c |
 			(a gcd: b) = 1
-				ifTrue:
-					[c := a reciprocalModulo: b.
-					self assert: (a * c) \\ b = 1]
-				ifFalse: [self should: [ a reciprocalModulo: b ] raise: Error]]].
+				ifTrue: [ c := a reciprocalModulo: b.
+					self assert: a * c \\ b equals: 1 ]
+				ifFalse: [ self should: [ a reciprocalModulo: b ] raise: Error ] ] ]
 ]
 
 { #category : #'tests - rounding' }
@@ -1130,14 +1118,13 @@ IntegerTest >> testStringAsNumber [
 	"This covers parsing in Number>>readFrom:
 	Trailing decimal points should be ignored."
 
-	self assert: ('123' asNumber = 123).
-	self assert: ('-123' asNumber = -123).
-	self assert: ('123.' asNumber = 123).
-	self assert: ('-123.' asNumber = -123).
-	self assert: ('123This is not to be read' asNumber = 123).
-	self assert: ('123s could be confused with a ScaledDecimal' asNumber = 123).
-	self assert: ('123e could be confused with a Float' asNumber = 123).
-
+	self assert: '123' asNumber equals: 123.
+	self assert: '-123' asNumber equals: -123.
+	self assert: '123.' asNumber equals: 123.
+	self assert: '-123.' asNumber equals: -123.
+	self assert: '123This is not to be read' asNumber equals: 123.
+	self assert: '123s could be confused with a ScaledDecimal' asNumber equals: 123.
+	self assert: '123e could be confused with a Float' asNumber equals: 123
 ]
 
 { #category : #'tests - bitLogic' }
@@ -1156,13 +1143,10 @@ IntegerTest >> testTwoComplementBitLogicWithCarry [
 
 { #category : #'tests - bitLogic' }
 IntegerTest >> testTwoComplementRightShift [
-
 	| large small |
 	small := 2 << 16.
-	large := 2 << 32.	
-	self assert: ((small negated bitShift: -1) ~= ((small + 1) negated bitShift: -1)
-		== ((large negated bitShift: -1) ~= ((large + 1) negated bitShift: -1))).
-		
-     self assert: ((small bitShift: -1) ~= (small + 1 bitShift: -1)
-		== ((large bitShift: -1) ~= (large + 1 bitShift: -1))).
+	large := 2 << 32.
+	self assert: (small negated bitShift: -1) ~= ((small + 1) negated bitShift: -1) identicalTo: (large negated bitShift: -1) ~= ((large + 1) negated bitShift: -1).
+
+	self assert: (small bitShift: -1) ~= (small + 1 bitShift: -1) identicalTo: (large bitShift: -1) ~= (large + 1 bitShift: -1)
 ]

--- a/src/Kernel-Tests/LargePositiveIntegerTest.class.st
+++ b/src/Kernel-Tests/LargePositiveIntegerTest.class.st
@@ -113,10 +113,10 @@ LargePositiveIntegerTest >> testEmptyTemplate [
 LargePositiveIntegerTest >> testNormalize [
 	"Check normalization and conversion to/from SmallInts"
 
-	self assert: ((SmallInteger maxVal + 1 - 1) == SmallInteger maxVal).
-	self assert: (SmallInteger maxVal + 3 - 6) == (SmallInteger maxVal-3).
-	self should: ((SmallInteger minVal - 1 + 1) == SmallInteger minVal).
-	self assert: (SmallInteger minVal - 3 + 6) == (SmallInteger minVal+3).
+	self assert: SmallInteger maxVal + 1 - 1 identicalTo: SmallInteger maxVal.
+	self assert: SmallInteger maxVal + 3 - 6 identicalTo: SmallInteger maxVal - 3.
+	self should: SmallInteger minVal - 1 + 1 == SmallInteger minVal.
+	self assert: SmallInteger minVal - 3 + 6 identicalTo: SmallInteger minVal + 3
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/MonitorTest.class.st
+++ b/src/Kernel-Tests/MonitorTest.class.st
@@ -9,8 +9,7 @@ Class {
 
 { #category : #'tests - examples' }
 MonitorTest >> testExample1 [
-
-	| producer1 producer2  monitor goal work counter goalReached finished |
+	| producer1 producer2 monitor goal work counter goalReached finished |
 	goal := (1 to: 1000) asOrderedCollection.
 	work := OrderedCollection new.
 	counter := 0.
@@ -18,35 +17,29 @@ MonitorTest >> testExample1 [
 	finished := Semaphore new.
 	monitor := Monitor new.
 
-	producer1 := [
-       [monitor critical:
-             [monitor waitUntil: [counter \\5 = 0].
-              goalReached or: [work add: (counter := counter + 1)].
-              goalReached := counter >= goal size.
-              monitor signal
-            ].
-           goalReached
-          ]
-             whileFalse.
-         finished signal.
-	].
+	producer1 := [ [ monitor
+		critical: [ monitor waitUntil: [ counter \\ 5 = 0 ].
+			goalReached or: [ work add: (counter := counter + 1) ].
+			goalReached := counter >= goal size.
+			monitor signal ].
+	goalReached ] whileFalse.
+	finished signal ].
 
-	producer2 := [
-         [monitor critical:
-                [monitor waitWhile: [counter \\5 = 0].
-                 goalReached or: [work add: (counter := counter + 1)].
-                 goalReached := counter >= goal size.
-                 monitor signal].
-         goalReached
-       ] whileFalse.
-     finished signal
-	].
+	producer2 := [ [ monitor
+		critical: [ monitor waitWhile: [ counter \\ 5 = 0 ].
+			goalReached or: [ work add: (counter := counter + 1) ].
+			goalReached := counter >= goal size.
+			monitor signal ].
+	goalReached ] whileFalse.
+	finished signal ].
 
 	producer1 forkAt: Processor userBackgroundPriority.
 	producer2 forkAt: Processor userBackgroundPriority.
 
-	finished wait; wait.
-	self assert: goal = work
+	finished
+		wait;
+		wait.
+	self assert: goal equals: work
 ]
 
 { #category : #'tests - examples' }
@@ -54,7 +47,7 @@ MonitorTest >> testExample2 [
 	"Here is a second version that does not use a semaphore to inform the 
 	forking process about termination of both forked processes"
 
-	| producer1 producer2  monitor goal work counter goalReached activeProducers|
+	| producer1 producer2 monitor goal work counter goalReached activeProducers |
 	goal := (1 to: 1000) asOrderedCollection.
 	work := OrderedCollection new.
 	counter := 0.
@@ -62,48 +55,38 @@ MonitorTest >> testExample2 [
 	activeProducers := 0.
 	monitor := Monitor new.
 
-  producer1 :=
-      [ monitor critical: [activeProducers := activeProducers + 1].
-  [monitor critical:
-            [monitor waitUntil: [counter \\5 = 0].
-      goalReached or: [work add: (counter := counter + 1)].
-     " Transcript show: 'P1  '; show: counter printString; show: '  ';
+	producer1 := [ monitor critical: [ activeProducers := activeProducers + 1 ].
+	[ monitor
+		critical: [ monitor waitUntil: [ counter \\ 5 = 0 ].
+			goalReached or: [ work add: (counter := counter + 1) ].
+			" Transcript show: 'P1  '; show: counter printString; show: '  ';
        show: activeProducers printString; cr."
-      goalReached := counter >= goal size.
-      monitor signal
-            ].
-           goalReached
-          ]
-             whileFalse.
-         monitor critical: [activeProducers := activeProducers - 1.
-        monitor signal: #finish].
- ] .
+			goalReached := counter >= goal size.
+			monitor signal ].
+	goalReached ] whileFalse.
+	monitor
+		critical: [ activeProducers := activeProducers - 1.
+			monitor signal: #finish ] ].
 
- producer2 :=
-    [monitor critical: [activeProducers := activeProducers + 1].
+	producer2 := [ monitor critical: [ activeProducers := activeProducers + 1 ].
 
-  [monitor critical:
-          [monitor waitWhile: [counter \\5 = 0].
-    goalReached or: [work add: (counter := counter + 1)].
-    goalReached := counter >= goal size.
-    monitor signal].
-         goalReached ] whileFalse.
-     monitor critical: [
-		activeProducers := activeProducers - 1. 
-		monitor signal: #finish].
-	].
+	[ monitor
+		critical: [ monitor waitWhile: [ counter \\ 5 = 0 ].
+			goalReached or: [ work add: (counter := counter + 1) ].
+			goalReached := counter >= goal size.
+			monitor signal ].
+	goalReached ] whileFalse.
+	monitor
+		critical: [ activeProducers := activeProducers - 1.
+			monitor signal: #finish ] ].
 
 	producer1 forkAt: Processor userBackgroundPriority.
-	producer2  forkAt: Processor userBackgroundPriority.
+	producer2 forkAt: Processor userBackgroundPriority.
 
 
-	monitor critical: [
-		monitor waitUntil: [activeProducers = 0 & (goalReached)]
-				for: #finish.
-  	].
+	monitor critical: [ monitor waitUntil: [ activeProducers = 0 & goalReached ] for: #finish ].
 
-	self assert: goal = work
-
+	self assert: goal equals: work
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/NumberTest.class.st
+++ b/src/Kernel-Tests/NumberTest.class.st
@@ -17,28 +17,24 @@ NumberTest >> testAsInteger [
 
 { #category : #tests }
 NumberTest >> testFractionPart [
-
-	self 
-		assert: 2 fractionPart = 0;
-		assert: (1/2) fractionPart = (1/2);
-		assert: (4/3) fractionPart = (1/3);
-		assert: 2.0 fractionPart = 0.0;
-		assert: 0.5 fractionPart = 0.5;
-		assert: 2.5 fractionPart = 0.5
-
+	self
+		assert: 2 fractionPart equals: 0;
+		assert: (1 / 2) fractionPart equals: 1 / 2;
+		assert: (4 / 3) fractionPart equals: 1 / 3;
+		assert: 2.0 fractionPart equals: 0.0;
+		assert: 0.5 fractionPart equals: 0.5;
+		assert: 2.5 fractionPart equals: 0.5
 ]
 
 { #category : #tests }
 NumberTest >> testIntegerPart [
-
-	self 
-		assert: 2 integerPart = 2;
-		assert: (1/2) integerPart = 0;
-		assert: (4/3) integerPart = 1;
-		assert: 2.0 integerPart = 2.0;
-		assert: 0.5 integerPart = 0.0;
-		assert: 2.5 integerPart = 2.0
-
+	self
+		assert: 2 integerPart equals: 2;
+		assert: (1 / 2) integerPart equals: 0;
+		assert: (4 / 3) integerPart equals: 1;
+		assert: 2.0 integerPart equals: 2.0;
+		assert: 0.5 integerPart equals: 0.0;
+		assert: 2.5 integerPart equals: 2.0
 ]
 
 { #category : #tests }
@@ -49,26 +45,25 @@ NumberTest >> testNew [
 
 { #category : #tests }
 NumberTest >> testOne [
-
-	self 
-		assert: Integer one = 1;
-		assert: Float one = 1.0;
-		assert: Fraction one = 1
+	self
+		assert: Integer one equals: 1;
+		assert: Float one equals: 1.0;
+		assert: Fraction one equals: 1
 ]
 
 { #category : #tests }
 NumberTest >> testPrintShowingDecimalPlaces [
-	self assert: (111.2 printShowingDecimalPlaces: 2) = '111.20'.
-	self assert: (111.2 printShowingDecimalPlaces: 0) = '111'.
-	self assert: (111 printShowingDecimalPlaces: 0) = '111'.
-	self assert: (111111111111111 printShowingDecimalPlaces: 2) = '111111111111111.00'.
-	self assert: (10 printShowingDecimalPlaces: 20) ='10.00000000000000000000'.
-	self assert: (0.98 printShowingDecimalPlaces: 2) = '0.98'.
-	self assert: (-0.98 printShowingDecimalPlaces: 2) = '-0.98'.
-	self assert: (2.567 printShowingDecimalPlaces: 2) = '2.57'.
-	self assert: (-2.567 printShowingDecimalPlaces: 2) = '-2.57'.
-	self assert: (0.01 printShowingDecimalPlaces: 2) = '0.01'.
-	self assert: (-0.001 printShowingDecimalPlaces: 2) = '0.00'.
+	self assert: (111.2 printShowingDecimalPlaces: 2) equals: '111.20'.
+	self assert: (111.2 printShowingDecimalPlaces: 0) equals: '111'.
+	self assert: (111 printShowingDecimalPlaces: 0) equals: '111'.
+	self assert: (111111111111111 printShowingDecimalPlaces: 2) equals: '111111111111111.00'.
+	self assert: (10 printShowingDecimalPlaces: 20) equals: '10.00000000000000000000'.
+	self assert: (0.98 printShowingDecimalPlaces: 2) equals: '0.98'.
+	self assert: (-0.98 printShowingDecimalPlaces: 2) equals: '-0.98'.
+	self assert: (2.567 printShowingDecimalPlaces: 2) equals: '2.57'.
+	self assert: (-2.567 printShowingDecimalPlaces: 2) equals: '-2.57'.
+	self assert: (0.01 printShowingDecimalPlaces: 2) equals: '0.01'.
+	self assert: (-0.001 printShowingDecimalPlaces: 2) equals: '0.00'
 ]
 
 { #category : #tests }
@@ -81,11 +76,11 @@ NumberTest >> testPrintShowingDecimalPlaces2 [
 	5000000000000001 highBit = 53.
 	This number is represented exactly asFloat, it should print exactly"
 
-	self assert: (5000000000000001.0 printShowingDecimalPlaces: 0) = '5000000000000001'.	"50000000000001.25 asTrueFraction = (200000000000005/4).
+	self assert: (5000000000000001.0 printShowingDecimalPlaces: 0) equals: '5000000000000001'.	"50000000000001.25 asTrueFraction = (200000000000005/4).
 	200000000000005 highBit = 48, 4 isPowerOfTwo,
 	So this number is also represented exactly as Float, it should print exactly.
 	Beware: (50000000000001.25 / 0.01) rounded exhibit the same problem as above."
-	self assert: (50000000000001.25 printShowingDecimalPlaces: 2) = '50000000000001.25'.	"This number is close to maximum float value"
+	self assert: (50000000000001.25 printShowingDecimalPlaces: 2) equals: '50000000000001.25'.	"This number is close to maximum float value"
 	1.0e306 printShowingDecimalPlaces: 3
 ]
 
@@ -94,9 +89,9 @@ NumberTest >> testPrintShowingDecimalPlaces3 [
 	"This problem were reported at http://bugs.squeak.org/view.php?id=7028
 	unfortunate inversion of left / right padding"
 
-	self assert: (1.009 printShowingDecimalPlaces: 3) = '1.009'.
-	self assert: (35.900 printShowingDecimalPlaces: 3) = '35.900'.
-	self assert: (-0.097 printShowingDecimalPlaces: 3) = '-0.097'.
+	self assert: (1.009 printShowingDecimalPlaces: 3) equals: '1.009'.
+	self assert: (35.900 printShowingDecimalPlaces: 3) equals: '35.900'.
+	self assert: (-0.097 printShowingDecimalPlaces: 3) equals: '-0.097'
 ]
 
 { #category : #tests }
@@ -109,69 +104,65 @@ NumberTest >> testRaisedTo [
 
 { #category : #tests }
 NumberTest >> testRaisedToInteger [
+	self
+		assert: (2 raisedToInteger: 0) equals: 1;
+		assert: (2 raisedToInteger: 1) equals: 2;
+		assert: (2 raisedToInteger: 4) equals: 16;
+		assert: (0 raisedToInteger: 0) equals: 1;
+		assert: (0 raisedToInteger: 2) equals: 0;
+		assert: (2 raisedToInteger: -1) equals: 1 / 2;
+		assert: (2 raisedToInteger: -4) equals: 1 / 16.
 
-	self 
-		assert: (2 raisedToInteger: 0) = 1;
-		assert: (2 raisedToInteger: 1) = 2;
-		assert: (2 raisedToInteger: 4) = 16;
-		assert: (0 raisedToInteger: 0) = 1;
-		assert: (0 raisedToInteger: 2) = 0;
-		assert: (2 raisedToInteger: -1) = (1/2);
-		assert: (2 raisedToInteger: -4) = (1/16).
-	
-	self 
-		assert: (-3 raisedTo: 0) = 1;
-		assert: (-3 raisedTo: 1) = -3;
-		assert: (-3 raisedTo: 2) = 9;
-		assert: (-3 raisedTo: 3) = -27;
-		assert: (-3 raisedTo: -2) = (1/9);
-		assert: (-3 raisedTo: -3) = (-1/27).
-	
+	self
+		assert: (-3 raisedTo: 0) equals: 1;
+		assert: (-3 raisedTo: 1) equals: -3;
+		assert: (-3 raisedTo: 2) equals: 9;
+		assert: (-3 raisedTo: 3) equals: -27;
+		assert: (-3 raisedTo: -2) equals: 1 / 9;
+		assert: (-3 raisedTo: -3) equals: -1 / 27.
+
 	self should: [ 0 raisedTo: -1 ] raise: ZeroDivide
 ]
 
 { #category : #tests }
 NumberTest >> testRaisedToIntegerWithFloats [
+	self
+		assert: (2.0 raisedToInteger: 0) equals: 1.0;
+		assert: (2.0 raisedToInteger: 1) equals: 2.0;
+		assert: (2.0 raisedToInteger: 4) equals: 16.0;
+		assert: (0.0 raisedToInteger: 0) equals: 1.0;
+		assert: (0.0 raisedToInteger: 2) equals: 0.0;
+		assert: (2.0 raisedToInteger: -1) equals: 0.5;
+		assert: (2.0 raisedToInteger: -4) equals: 0.0625.
 
-	self 
-		assert: (2.0 raisedToInteger: 0) = 1.0;
-		assert: (2.0 raisedToInteger: 1) = 2.0;
-		assert: (2.0 raisedToInteger: 4) = 16.0;
-		assert: (0.0 raisedToInteger: 0) = 1.0;
-		assert: (0.0 raisedToInteger: 2) = 0.0;
-		assert: (2.0 raisedToInteger: -1) = 0.5;
-		assert: (2.0 raisedToInteger: -4) = 0.0625.
-	
-	self 
-		assert: (-3.0 raisedTo: 0) = 1.0;
-		assert: (-3.0 raisedTo: 1) = -3.0;
-		assert: (-3.0 raisedTo: 2) = 9.0;
-		assert: (-3.0 raisedTo: 3) = -27.0;
-		assert: (-2.0 raisedTo: -2) = 0.25;
-		assert: (-2.0 raisedTo: -3) = -0.125.
-	
+	self
+		assert: (-3.0 raisedTo: 0) equals: 1.0;
+		assert: (-3.0 raisedTo: 1) equals: -3.0;
+		assert: (-3.0 raisedTo: 2) equals: 9.0;
+		assert: (-3.0 raisedTo: 3) equals: -27.0;
+		assert: (-2.0 raisedTo: -2) equals: 0.25;
+		assert: (-2.0 raisedTo: -3) equals: -0.125.
+
 	self should: [ 0.0 raisedTo: -1 ] raise: ZeroDivide
 ]
 
 { #category : #tests }
 NumberTest >> testReadFrom [
-	
-	self assert: 1.0e-14    = (Number readFrom: '1.0e-14').
+	self assert: 1.0e-14 equals: (Number readFrom: '1.0e-14').
 	"Use a literal number format that compiles in GemStone.
 	 Note that the test still checks the same value."
-	self assert: 16r4000000 = (Number readFrom: '2r1e26').
-	self should: [Number readFrom: 'foo'] raise: Error
+	self assert: 16r4000000 equals: (Number readFrom: '2r1e26').
+	self should: [ Number readFrom: 'foo' ] raise: Error
 ]
 
 { #category : #tests }
 NumberTest >> testReciprocal [
+	self
+		assert: 1 reciprocal equals: 1;
+		assert: 2 reciprocal equals: 1 / 2;
+		assert: -1 reciprocal equals: -1;
+		assert: -3 reciprocal equals: -1 / 3.
 
-	self 
-		assert: 1 reciprocal = 1;
-		assert: 2 reciprocal = (1/2);
-		assert: -1 reciprocal = -1;
-		assert: -3 reciprocal = (-1/3).
-		
 	self should: [ 0 reciprocal ] raise: ZeroDivide
 ]
 

--- a/src/Kernel-Tests/ObjectTest.class.st
+++ b/src/Kernel-Tests/ObjectTest.class.st
@@ -10,46 +10,46 @@ Class {
 { #category : #tests }
 ObjectTest >> testAs [
 	| coll1 coll2 |
-	coll1 := { 1 . 2 . 3 }.
+	coll1 := {1 . 2 . 3}.
 	coll2 := coll1 as: OrderedCollection.
-	
+
 	self assert: coll2 equals: (OrderedCollection with: 1 with: 2 with: 3).
-	self deny: coll1 == coll2.
-	
+	self deny: coll1 identicalTo: coll2.
+
 	"If the object has the right type, do nothing."
 	coll2 := coll1 as: Array.
-	self assert: coll1 == coll2
+	self assert: coll1 identicalTo: coll2
 ]
 
 { #category : #tests }
-ObjectTest >> testBecome [	
+ObjectTest >> testBecome [
 	"this test should that all the variables pointing to an object are pointing now to another one, and all
       object pointing to the other are pointing to the object"
 
 	| pt1 pt2 pt3 |
-	pt1 := 0@0.
+	pt1 := 0 @ 0.
 	pt2 := pt1.
-	pt3 := 100@100.
+	pt3 := 100 @ 100.
 
 	pt1 become: pt3.
-	self assert: pt2 = (100@100).
-	self assert: pt3 = (0@0).
-	self assert: pt1 = (100@100).
+	self assert: pt2 equals: 100 @ 100.
+	self assert: pt3 equals: 0 @ 0.
+	self assert: pt1 equals: 100 @ 100
 ]
 
 { #category : #tests }
-ObjectTest >> testBecomeForward [	
+ObjectTest >> testBecomeForward [
 	"this test should that all the variables pointing to an object are pointing now to another one.
 	Not that this inverse is not true. This kind of become is called oneWayBecome in VW"
 
 	| pt1 pt2 pt3 |
-	pt1 := 0@0.
+	pt1 := 0 @ 0.
 	pt2 := pt1.
-	pt3 := 100@100.
+	pt3 := 100 @ 100.
 	pt1 becomeForward: pt3.
-	self assert: pt2 = (100@100).
-	self assert: pt3 == pt2.
-	self assert: pt1 = (100@100)
+	self assert: pt2 equals: 100 @ 100.
+	self assert: pt3 identicalTo: pt2.
+	self assert: pt1 equals: 100 @ 100
 ]
 
 { #category : #'tests-printing' }
@@ -110,28 +110,28 @@ ObjectTest >> testPrintString [
 
 { #category : #'tests - introspection' }
 ObjectTest >> testReadSlot [
-	self assert: (5@3 readSlot: (Point slotNamed: #x)) = 5
+	self assert: (5 @ 3 readSlot: (Point slotNamed: #x)) equals: 5
 ]
 
 { #category : #'tests - introspection' }
 ObjectTest >> testReadSlotNamed [
-	self assert: (5@3 readSlotNamed: #x) = 5
+	self assert: (5 @ 3 readSlotNamed: #x) equals: 5
 ]
 
 { #category : #'tests - introspection' }
 ObjectTest >> testWriteSlotNamedValue [
 	| object |
-	object := 5@6.
-	
-	self assert: (object writeSlotNamed: #x value: 7) = 7.
-	self assert: object = (7@6).
+	object := 5 @ 6.
+
+	self assert: (object writeSlotNamed: #x value: 7) equals: 7.
+	self assert: object equals: 7 @ 6
 ]
 
 { #category : #'tests - introspection' }
 ObjectTest >> testWriteSlotValue [
 	| object |
-	object := 5@6.
-	
-	self assert: (object writeSlot: (Point slotNamed: #x) value: 7) = 7.
-	self assert: object = (7@6).
+	object := 5 @ 6.
+
+	self assert: (object writeSlot: (Point slotNamed: #x) value: 7) equals: 7.
+	self assert: object equals: 7 @ 6
 ]

--- a/src/Kernel-Tests/ProcessSpecificTest.class.st
+++ b/src/Kernel-Tests/ProcessSpecificTest.class.st
@@ -63,18 +63,12 @@ ProcessSpecificTest >> testDynamicVariable [
 { #category : #testing }
 ProcessSpecificTest >> testDynamicVariableAccessFromDifferentProcess [
 	| process sem result |
-	
 	sem := Semaphore new.
-	process := [  
-		TestDynamicVariable 
-			value: 123 
-			during: [ sem wait ] ] fork.
+	process := [ TestDynamicVariable value: 123 during: [ sem wait ] ] fork.
 	Processor yield.
-	Processor activeProcess 
-		evaluate: [  result := TestDynamicVariable value ] 
-		onBehalfOf: process.
+	Processor activeProcess evaluate: [ result := TestDynamicVariable value ] onBehalfOf: process.
 	sem signal.
-	self assert: result = 123
+	self assert: result equals: 123
 ]
 
 { #category : #testing }

--- a/src/Kernel-Tests/ProtoObjectTest.class.st
+++ b/src/Kernel-Tests/ProtoObjectTest.class.st
@@ -17,27 +17,32 @@ ProtoObjectTest >> testFlag [
 
 { #category : #'tests - testing' }
 ProtoObjectTest >> testIfNil [
-	| object block reachabilityTest|
+	| object block reachabilityTest |
 	reachabilityTest := false.
 	object := ProtoObject new.
-	object ifNil: [reachabilityTest := true ].
-	self assert: (object ifNil: [ nil ]) == object.
+	object ifNil: [ reachabilityTest := true ].
+	self assert: (object ifNil: [ nil ]) identicalTo: object.
 	self assert: reachabilityTest equals: false.
 	"Now the same test without inlining."
 	reachabilityTest := false.
-	block := [ reachabilityTest := true].
+	block := [ reachabilityTest := true ].
 	object ifNil: block.
 	block := [ nil ].
-	self assert: (object ifNil: block) == object.
-	self assert: reachabilityTest equals: false.
+	self assert: (object ifNil: block) identicalTo: object.
+	self assert: reachabilityTest equals: false
 ]
 
 { #category : #'tests - testing' }
 ProtoObjectTest >> testIfNilIfNotNil [
-
 	| object returnValue block notReached1 reached1 notReached2 reached2 reached3 notReached3 reached4 notReached4 |
-	notReached1 := false. reached1 := false. notReached2 := false. reached2 := false.
-	notReached3 := false. reached3 := false. notReached4 := false. reached4 := false.
+	notReached1 := false.
+	reached1 := false.
+	notReached2 := false.
+	reached2 := false.
+	notReached3 := false.
+	reached3 := false.
+	notReached4 := false.
+	reached4 := false.
 	object := ProtoObject new.
 	returnValue := Object new.
 
@@ -50,9 +55,9 @@ ProtoObjectTest >> testIfNilIfNotNil [
 	self assert: reached2 equals: true.
 
 	self assert: (object ifNil: [ false ] ifNotNil: [ :o | o == object ]).
-	self assert: (object ifNil: [ nil ] ifNotNil: [ returnValue ]) == returnValue.
-	self assert: (object ifNil: [ nil ] ifNotNil: [ :o | returnValue ]) == returnValue.
-	
+	self assert: (object ifNil: [ nil ] ifNotNil: [ returnValue ]) identicalTo: returnValue.
+	self assert: (object ifNil: [ nil ] ifNotNil: [ :o | returnValue ]) identicalTo: returnValue.
+
 	"Now the same without inlining."
 	block := [ reached3 := true ].
 	object ifNil: [ notReached3 := true ] ifNotNil: block.
@@ -63,19 +68,18 @@ ProtoObjectTest >> testIfNilIfNotNil [
 	object ifNil: [ notReached4 := true ] ifNotNil: block.
 	self assert: notReached4 equals: false.
 	self assert: reached4 equals: true.
-	
+
 	block := [ :o | o == object ].
 	self assert: (object ifNil: [ false ] ifNotNil: block).
 	block := [ returnValue ].
-	self assert: (object ifNil: [ nil ] ifNotNil: block) = returnValue.
+	self assert: (object ifNil: [ nil ] ifNotNil: block) equals: returnValue.
 	block := [ :o | returnValue ].
-	self assert: (object ifNil: [ nil ] ifNotNil: block) = returnValue
+	self assert: (object ifNil: [ nil ] ifNotNil: block) equals: returnValue
 ]
 
 { #category : #'tests - testing' }
 ProtoObjectTest >> testIfNotNil [
-
-	| object returnValue block reached|
+	| object returnValue block reached |
 	object := ProtoObject new.
 	returnValue := Object new.
 	reached := false.
@@ -85,8 +89,8 @@ ProtoObjectTest >> testIfNotNil [
 	object ifNotNil: [ :o | reached := true ].
 	self assert: reached equals: true.
 	self assert: (object ifNotNil: [ :o | o == object ]).
-	self assert: (object ifNotNil: [ returnValue ]) == returnValue.
-	self assert: (object ifNotNil: [ :o | returnValue ]) == returnValue.	
+	self assert: (object ifNotNil: [ returnValue ]) identicalTo: returnValue.
+	self assert: (object ifNotNil: [ :o | returnValue ]) identicalTo: returnValue.
 	"Now the same without inlining."
 	block := [ reached := true ].
 	object ifNotNil: block.
@@ -98,52 +102,55 @@ ProtoObjectTest >> testIfNotNil [
 	block := [ :o | o == object ].
 	self assert: (object ifNotNil: block).
 	block := [ returnValue ].
-	self assert: (object ifNotNil: block) = returnValue.
+	self assert: (object ifNotNil: block) equals: returnValue.
 	block := [ :o | returnValue ].
-	self assert: (object ifNotNil: block) = returnValue
+	self assert: (object ifNotNil: block) equals: returnValue
 ]
 
 { #category : #'tests - testing' }
 ProtoObjectTest >> testIfNotNilIfNil [
-
-	| object returnValue block reached notReached|
+	| object returnValue block reached notReached |
 	object := ProtoObject new.
 	returnValue := Object new.
-	
-	reached := false. notReached := false.
+
+	reached := false.
+	notReached := false.
 	object ifNotNil: [ reached := true ] ifNil: [ notReached := true ].
 	self assert: reached equals: true.
 	self assert: notReached equals: false.
-	
-	reached := false. notReached := false.
+
+	reached := false.
+	notReached := false.
 	object ifNotNil: [ :o | reached := true ] ifNil: [ notReached := true ].
 	self assert: reached equals: true.
 	self assert: notReached equals: false.
-	
+
 	reached := false.
 	notReached := false.
 	self assert: (object ifNotNil: [ :o | o == object ] ifNil: [ false ]).
-	self assert: (object ifNotNil: [ returnValue ] ifNil: [ false ]) == returnValue.
-	self assert: (object ifNotNil: [ :o | returnValue ] ifNil: [ false ]) == returnValue.
+	self assert: (object ifNotNil: [ returnValue ] ifNil: [ false ]) identicalTo: returnValue.
+	self assert: (object ifNotNil: [ :o | returnValue ] ifNil: [ false ]) identicalTo: returnValue.
 	"Now the same without inlining."
-	reached := false.	notReached := false.
+	reached := false.
+	notReached := false.
 	block := [ reached := true ].
 	object ifNotNil: block ifNil: [ notReached := true ].
 	self assert: reached equals: true.
 	self assert: notReached equals: false.
-	
-	reached := false. notReached := false.	
+
+	reached := false.
+	notReached := false.
 	block := [ :o | reached := true ].
 	object ifNotNil: block ifNil: [ notReached := true ].
 	self assert: reached equals: true.
 	self assert: notReached equals: false.
-	
+
 	block := [ :o | o == object ].
 	self assert: (object ifNotNil: block ifNil: [ false ]).
 	block := [ returnValue ].
-	self assert: (object ifNotNil: block ifNil: [ false ]) == returnValue.
+	self assert: (object ifNotNil: block ifNil: [ false ]) identicalTo: returnValue.
 	block := [ :o | returnValue ].
-	self assert: (object ifNotNil: block ifNil: [ false ]) == returnValue
+	self assert: (object ifNotNil: block ifNil: [ false ]) identicalTo: returnValue
 ]
 
 { #category : #'tests - testing' }

--- a/src/Kernel-Tests/SemaphoreTest.class.st
+++ b/src/Kernel-Tests/SemaphoreTest.class.st
@@ -52,11 +52,12 @@ SemaphoreTest >> testCriticalIfError [
 SemaphoreTest >> testInCriticalWait [
 	"This tests whether a semaphore that has entered the wait in Semaphore>>critical:
 	leaves it without signaling the associated semaphore."
+
 	| s p |
 	s := Semaphore new.
-	p := [s critical:[]] fork.
+	p := [ s critical: [  ] ] fork.
 	Processor yield.
-	self assert: (p suspendingList == s).
+	self assert: p suspendingList identicalTo: s.
 	p terminate.
 	self assert: (s instVarNamed: #excessSignals) equals: 0
 ]
@@ -169,11 +170,11 @@ SemaphoreTest >> testWaitTimeDuration [
 	"Ensure that wait: aDuration behaves properly"
 
 	"Ensure that a timed out wait: aDuration returns true from the wait"
-	self assert: (Semaphore new wait: 50 milliSeconds) == true.
+
+	self assert: (Semaphore new wait: 50 milliSeconds) identicalTo: true.
 
 	"Ensure that a signaled wait: aDuration returns false from the wait"
-	self assert: (Semaphore new signal wait: 50 milliSeconds) == false.
-
+	self assert: (Semaphore new signal wait: 50 milliSeconds) identicalTo: false
 ]
 
 { #category : #tests }
@@ -181,17 +182,11 @@ SemaphoreTest >> testWaitTimeDurationWithCompletionAndTimeoutBlocks [
 	"Ensure that wait:onCompletion:onTimeout: behaves properly"
 
 	"Ensure that a timed out wait:onCompletion:onTimeout: returns the value of the timeout block"
-	self assert: (Semaphore new 
-		wait: 50 milliSeconds
-		onCompletion: [ #completed ]
-		onTimeout: [ #timeout ] ) == #timeout.
+
+	self assert: (Semaphore new wait: 50 milliSeconds onCompletion: [ #completed ] onTimeout: [ #timeout ]) identicalTo: #timeout.
 
 	"Ensure that a signaled wait:onCompletion:onTimeout: returns the value of the completed block"
-	self assert: (Semaphore new signal
-		wait: 50 milliSeconds
-		onCompletion: [ #completed ]
-		onTimeout: [ #timeout ]) == #completed.
-
+	self assert: (Semaphore new signal wait: 50 milliSeconds onCompletion: [ #completed ] onTimeout: [ #timeout ]) identicalTo: #completed
 ]
 
 { #category : #tests }
@@ -199,11 +194,11 @@ SemaphoreTest >> testWaitTimeoutMSecs [
 	"Ensure that waitTimeoutMSecs behaves properly"
 
 	"Ensure that a timed out waitTimeoutMSecs: returns true from the wait"
-	self assert: (Semaphore new waitTimeoutMSecs: 50) == true.
+
+	self assert: (Semaphore new waitTimeoutMSecs: 50) identicalTo: true.
 
 	"Ensure that a signaled waitTimeoutMSecs: returns false from the wait"
-	self assert: (Semaphore new signal waitTimeoutMSecs: 50) == false.
-
+	self assert: (Semaphore new signal waitTimeoutMSecs: 50) identicalTo: false
 ]
 
 { #category : #tests }
@@ -211,15 +206,9 @@ SemaphoreTest >> testWaitTimeoutSecondsOnCompletionOnTimeout [
 	"Ensure that waitTimeoutSeconds:onCompletion:onTimeout: behaves properly"
 
 	"Ensure that a timed out waitTimeoutSeconds:onCompletion:onTimeout: returns the value of the timeout block"
-	self assert: (Semaphore new 
-		waitTimeoutSeconds: 0.05
-		onCompletion: [ #completed ]
-		onTimeout: [ #timeout ] ) == #timeout.
+
+	self assert: (Semaphore new waitTimeoutSeconds: 0.05 onCompletion: [ #completed ] onTimeout: [ #timeout ]) identicalTo: #timeout.
 
 	"Ensure that a signaled waitTimeoutSeconds:onCompletion:onTimeout: returns the value of the completed block"
-	self assert: (Semaphore new signal
-		waitTimeoutSeconds: 0.05
-		onCompletion: [ #completed ]
-		onTimeout: [ #timeout ]) == #completed.
-
+	self assert: (Semaphore new signal waitTimeoutSeconds: 0.05 onCompletion: [ #completed ] onTimeout: [ #timeout ]) identicalTo: #completed
 ]

--- a/src/Kernel-Tests/SmallIntegerTest.class.st
+++ b/src/Kernel-Tests/SmallIntegerTest.class.st
@@ -25,20 +25,18 @@ SmallIntegerTest >> testByteAt [
 
 { #category : #'tests - operations' }
 SmallIntegerTest >> testCeiling [
-
-	self assert: 2 ceiling = 2.
-	self assert: -2 ceiling = -2.
-	self assert: 2.1 ceiling = 3.
-	self assert: -2.1 ceiling = -2.
+	self assert: 2 ceiling equals: 2.
+	self assert: -2 ceiling equals: -2.
+	self assert: 2.1 ceiling equals: 3.
+	self assert: -2.1 ceiling equals: -2
 ]
 
 { #category : #'tests - arithmetic' }
 SmallIntegerTest >> testDivide [
-
-	self assert: 2 / 1 = 2.
+	self assert: 2 / 1 equals: 2.
 	self assert: (3 / 2) isFraction.
-	self assert: 4 / 2 = 2.
-	self should: [ 1 / 0 ] raise: ZeroDivide.
+	self assert: 4 / 2 equals: 2.
+	self should: [ 1 / 0 ] raise: ZeroDivide
 ]
 
 { #category : #'tests - other' }
@@ -49,18 +47,14 @@ SmallIntegerTest >> testIsNotAbstract [
 
 { #category : #'tests - Class Methods' }
 SmallIntegerTest >> testMaxVal [
-	Smalltalk vm wordSize = 4
-		ifTrue: [ self assert: SmallInteger maxVal = 16r3FFFFFFF ].
-	Smalltalk vm wordSize = 8
-		ifTrue: [ self assert: SmallInteger maxVal = 16rFFFFFFFFFFFFFFF ]
+	Smalltalk vm wordSize = 4 ifTrue: [ self assert: SmallInteger maxVal equals: 16r3FFFFFFF ].
+	Smalltalk vm wordSize = 8 ifTrue: [ self assert: SmallInteger maxVal equals: 16rFFFFFFFFFFFFFFF ]
 ]
 
 { #category : #'tests - Class Methods' }
 SmallIntegerTest >> testMinVal [
-	Smalltalk vm wordSize = 4
-		ifTrue: [ self assert: SmallInteger minVal = -16r40000000 ].
-	Smalltalk vm wordSize = 8
-		ifTrue: [ self assert: SmallInteger minVal = -16r1000000000000000 ]
+	Smalltalk vm wordSize = 4 ifTrue: [ self assert: SmallInteger minVal equals: -16r40000000 ].
+	Smalltalk vm wordSize = 8 ifTrue: [ self assert: SmallInteger minVal equals: -16r1000000000000000 ]
 ]
 
 { #category : #'tests - Class Methods' }
@@ -71,11 +65,10 @@ SmallIntegerTest >> testNew [
 
 { #category : #'tests - printing' }
 SmallIntegerTest >> testPrintPaddedWith [
-
-self assert: (123 printPaddedWith: $0 to: 10 base: 2)  = '0001111011'.
-self assert: (123 printPaddedWith: $0 to: 10 base: 8)  = '0000000173'.
-self assert: (123 printPaddedWith: $0 to: 10 base: 10) = '0000000123'.
-self assert: (123 printPaddedWith: $0 to: 10 base: 16) = '000000007B'.
+	self assert: (123 printPaddedWith: $0 to: 10 base: 2) equals: '0001111011'.
+	self assert: (123 printPaddedWith: $0 to: 10 base: 8) equals: '0000000173'.
+	self assert: (123 printPaddedWith: $0 to: 10 base: 10) equals: '0000000123'.
+	self assert: (123 printPaddedWith: $0 to: 10 base: 16) equals: '000000007B'
 ]
 
 { #category : #'tests - printing' }

--- a/src/Kernel-Tests/TimeTest.class.st
+++ b/src/Kernel-Tests/TimeTest.class.st
@@ -54,142 +54,130 @@ TimeTest >> tearDown [
 
 { #category : #tests }
 TimeTest >> testAccessing [
-
 	self
-		assert: time hours = 4;
-		assert: time minutes = 2;
-		assert: time seconds = 47;
-		assert: time asSeconds = 14567.
-
+		assert: time hours equals: 4;
+		assert: time minutes equals: 2;
+		assert: time seconds equals: 47;
+		assert: time asSeconds equals: 14567
 ]
 
 { #category : #tests }
 TimeTest >> testAddSeconds [
-	self assert: (aTime addSeconds: 1) = (Time readFrom: '12:34:57' readStream).
-	self assert: (aTime addSeconds: 60) = (Time readFrom: '12:35:56' readStream).
-	self assert: (aTime addSeconds: 3600) = (Time readFrom: '13:34:56' readStream).
-	self assert: (aTime addSeconds: 24 * 60 * 60) = (Time readFrom: '12:34:56' readStream)
+	self assert: (aTime addSeconds: 1) equals: (Time readFrom: '12:34:57' readStream).
+	self assert: (aTime addSeconds: 60) equals: (Time readFrom: '12:35:56' readStream).
+	self assert: (aTime addSeconds: 3600) equals: (Time readFrom: '13:34:56' readStream).
+	self assert: (aTime addSeconds: 24 * 60 * 60) equals: (Time readFrom: '12:34:56' readStream)
 ]
 
 { #category : #tests }
 TimeTest >> testAddTime [
-	self assert: (aTime addTime: aTime) = (Time readFrom: '01:09:52' readStream)
+	self assert: (aTime addTime: aTime) equals: (Time readFrom: '01:09:52' readStream)
 ]
 
 { #category : #tests }
 TimeTest >> testArithmetic [
 	| t1 t2 t3 |
-	t1 := time addSeconds: 70.		"4:03:57 am"
+	t1 := time addSeconds: 70.	"4:03:57 am"
 	self
-		assert: t1 hours = 4;
-		assert: t1 minutes = 3;
-		assert: t1 seconds = 57.
+		assert: t1 hours equals: 4;
+		assert: t1 minutes equals: 3;
+		assert: t1 seconds equals: 57.
 
-	t2 := t1 addTime: (self timeClass fromSeconds: (60*60*5)).
+	t2 := t1 addTime: (self timeClass fromSeconds: 60 * 60 * 5).
 	self
-		assert: t2 hours = 9;
-		assert: t2 minutes = 3;
-		assert: t2 seconds = 57.
+		assert: t2 hours equals: 9;
+		assert: t2 minutes equals: 3;
+		assert: t2 seconds equals: 57.
 
-	t3 := t2 subtractTime: (self timeClass fromSeconds: (60*60*5) + 70).
-	self
-		assert: t3 = time.
-
+	t3 := t2 subtractTime: (self timeClass fromSeconds: 60 * 60 * 5 + 70).
+	self assert: t3 equals: time
 ]
 
 { #category : #tests }
 TimeTest >> testAsDate [
-	self assert: (aTime asDate) = (Date current)
-
+	self assert: aTime asDate equals: Date current
 ]
 
 { #category : #tests }
 TimeTest >> testAsDateAndTime [
-	self assert: (aTime asDateAndTime) = (DateAndTime current midnight + aTime)
-
+	self assert: aTime asDateAndTime equals: DateAndTime current midnight + aTime
 ]
 
 { #category : #tests }
 TimeTest >> testAsDuration [
-	self assert: (aTime asDuration) = (Duration days: 0 hours: 12 minutes: 34 seconds: 56)
-
+	self
+		assert: aTime asDuration
+		equals:
+			(Duration
+				days: 0
+				hours: 12
+				minutes: 34
+				seconds: 56)
 ]
 
 { #category : #tests }
 TimeTest >> testAsNanoSeconds [
-	self assert: (aTime asNanoSeconds) = 45296000000000
-
-
+	self assert: aTime asNanoSeconds equals: 45296000000000
 ]
 
 { #category : #tests }
 TimeTest >> testAsSeconds [
-	self assert: (aTime asSeconds) = 45296
-
+	self assert: aTime asSeconds equals: 45296
 ]
 
 { #category : #tests }
 TimeTest >> testAsTime [
-	self assert: (aTime asTime) = aTime
-
-
+	self assert: aTime asTime equals: aTime
 ]
 
 { #category : #tests }
 TimeTest >> testAsWeek [
-	self assert: aTime asWeek = (DateAndTime current midnight + aTime) asWeek
-
+	self assert: aTime asWeek equals: (DateAndTime current midnight + aTime) asWeek
 ]
 
 { #category : #tests }
 TimeTest >> testAsYear [
-	self assert: aTime asYear = (DateAndTime current midnight + aTime) asYear
-
+	self assert: aTime asYear equals: (DateAndTime current midnight + aTime) asYear
 ]
 
 { #category : #tests }
 TimeTest >> testComparing [
 	| t1 t2 t3 |
-	t1 := self timeClass fromSeconds: 14567.		"4:02:47 am"
-	t2 := self timeClass fromSeconds: 5000.		"1:23:20 am"
-	t3 := self timeClass fromSeconds: 80000.		"10:13:20 pm"
+	t1 := self timeClass fromSeconds: 14567.	"4:02:47 am"
+	t2 := self timeClass fromSeconds: 5000.	"1:23:20 am"
+	t3 := self timeClass fromSeconds: 80000.	"10:13:20 pm"
 
 	self
-		assert: time = t1;
-		assert: time hash = t1 hash;
-		assert: time = time copy.
+		assert: time equals: t1;
+		assert: time hash equals: t1 hash;
+		assert: time equals: time copy.
 	self
 		deny: t1 < t2;
-		assert: t1 < t3.
+		assert: t1 < t3
 ]
 
 { #category : #tests }
 TimeTest >> testConverting [
-
-	self
-		assert: time asSeconds = 14567.
+	self assert: time asSeconds equals: 14567
 ]
 
 { #category : #tests }
 TimeTest >> testDuration [
-	self assert: aTime duration = 0 seconds
+	self assert: aTime duration equals: 0 seconds
 ]
 
 { #category : #tests }
 TimeTest >> testEqual [
-		
-	self assert: aTime = (Time readFrom: '12:34:56' readStream).
-	self assert: aTime = (Time readFrom: '12:34:56.00' readStream).
-	self assert: aTime = (Time readFrom: '12:34:56.0000' readStream)
+	self assert: aTime equals: (Time readFrom: '12:34:56' readStream).
+	self assert: aTime equals: (Time readFrom: '12:34:56.00' readStream).
+	self assert: aTime equals: (Time readFrom: '12:34:56.0000' readStream)
 ]
 
 { #category : #tests }
 TimeTest >> testFromSeconds [
 	| t |
 	t := self timeClass fromSeconds: 14567.
-	self
-		assert: t = time
-
+	self assert: t equals: time
 ]
 
 { #category : #tests }
@@ -208,15 +196,15 @@ TimeTest >> testGeneralInquiries [
 
 { #category : #tests }
 TimeTest >> testHhmm24 [
-	self assert: aTime hhmm24 = '1234'
+	self assert: aTime hhmm24 equals: '1234'
 ]
 
 { #category : #tests }
 TimeTest >> testHour [
-	self assert: aTime hour =  12.
-	self assert: aTime hour12 =  12.
-	self assert: aTime hour24 =  12.
-	self assert: aTime hours =  12.
+	self assert: aTime hour equals: 12.
+	self assert: aTime hour12 equals: 12.
+	self assert: aTime hour24 equals: 12.
+	self assert: aTime hours equals: 12
 ]
 
 { #category : #tests }
@@ -226,33 +214,29 @@ TimeTest >> testLessThan [
 
 { #category : #tests }
 TimeTest >> testMeridianAbbreviation [
-	self assert: aTime meridianAbbreviation =  'PM'.
-
+	self assert: aTime meridianAbbreviation equals: 'PM'
 ]
 
 { #category : #tests }
 TimeTest >> testMinute [
-	self assert: aTime minute =  34.
-	self assert: aTime minutes =  34
-
+	self assert: aTime minute equals: 34.
+	self assert: aTime minutes equals: 34
 ]
 
 { #category : #tests }
 TimeTest >> testNanoSecond [
-	self assert: aTime nanoSecond = 0
+	self assert: aTime nanoSecond equals: 0
 	"Right now all times all seconds"
-
 ]
 
 { #category : #tests }
 TimeTest >> testNew [
-	
-	self assert: self timeClass new asSeconds = 0
+	self assert: self timeClass new asSeconds equals: 0
 ]
 
 { #category : #'tests - printing' }
 TimeTest >> testPrint24 [
-	self assert: aTime print24 = '12:34:56'
+	self assert: aTime print24 equals: '12:34:56'
 ]
 
 { #category : #'tests - printing' }
@@ -272,12 +256,12 @@ TimeTest >> testPrint24OnWithoutSeconds [
 
 { #category : #'tests - printing' }
 TimeTest >> testPrint24withNanos [
-	self assert: '12:34:56.1' asTime print24 = '12:34:56'
+	self assert: '12:34:56.1' asTime print24 equals: '12:34:56'
 ]
 
 { #category : #'tests - printing' }
 TimeTest >> testPrintMinutes [
-	self assert: aTime printMinutes = '12:34 pm'
+	self assert: aTime printMinutes equals: '12:34 pm'
 ]
 
 { #category : #'tests - printing' }
@@ -287,30 +271,32 @@ TimeTest >> testPrintOn [
 
 { #category : #tests }
 TimeTest >> testPrintStringNanos [
-	self assert: (Time hour: 15 minute: 15 second: 15  nanoSecond: (150 *
-1000000)) printString = '3:15:15.15 pm'
+	self
+		assert:
+			(Time
+				hour: 15
+				minute: 15
+				second: 15
+				nanoSecond: 150 * 1000000) printString
+		equals: '3:15:15.15 pm'
 ]
 
 { #category : #'tests - printing' }
 TimeTest >> testPrinting [
-
-	self	
-		assert: time printString = '4:02:47 am';
-		assert: time intervalString =  '4 hours 2 minutes 47 seconds';
-		assert: time print24 = '04:02:47';
-		assert: time printMinutes = '4:02 am';
-		assert: time hhmm24 = '0402'.
-
+	self
+		assert: time printString equals: '4:02:47 am';
+		assert: time intervalString equals: '4 hours 2 minutes 47 seconds';
+		assert: time print24 equals: '04:02:47';
+		assert: time printMinutes equals: '4:02 am';
+		assert: time hhmm24 equals: '0402'
 ]
 
 { #category : #'tests - input' }
 TimeTest >> testReadFrom [
-		
 	| string t |
 	string := '4:02:47 am'.
 	t := self timeClass readFrom: string readStream.
-	self assert: time printString = t printString.
-
+	self assert: time printString equals: t printString
 ]
 
 { #category : #'tests - input' }
@@ -326,29 +312,23 @@ TimeTest >> testReadFromWithError [
 
 { #category : #'tests - input' }
 TimeTest >> testReadFromWithNanos [
-		
-	#('4:02:47.5 am'
-	'4:02:55.521 pm'
-		"there is a bug with 520 instead of 521"
-	
-	) do: [:each |
-			|  t |
+	#('4:02:47.5 am' '4:02:55.521 pm')
+		do: [ :each | 
+			| t |
 			t := self timeClass readFrom: each readStream.
-			self assert: t printString = each]
-
+			self assert: t printString equals: each ]
+	"there is a bug with 520 instead of 521"
 ]
 
 { #category : #tests }
 TimeTest >> testSecond [
-	self assert: aTime second =  56.
-	self assert: aTime seconds =  56
-
+	self assert: aTime second equals: 56.
+	self assert: aTime seconds equals: 56
 ]
 
 { #category : #tests }
 TimeTest >> testSeconds [
-	
-	self assert: (Time readFrom: '20:33:14.321-05:00' readStream) asDuration seconds = 14
+	self assert: (Time readFrom: '20:33:14.321-05:00' readStream) asDuration seconds equals: 14
 ]
 
 { #category : #tests }
@@ -358,22 +338,20 @@ TimeTest >> testStoreOn [
 
 { #category : #tests }
 TimeTest >> testStoring [
-
-	self	
-		assert: time storeString = '''4:02:47 am'' asTime';
-		assert: time = ('4:02:47 am' asTime).
-
+	self
+		assert: time storeString equals: '''4:02:47 am'' asTime';
+		assert: time equals: '4:02:47 am' asTime
 ]
 
 { #category : #tests }
 TimeTest >> testSubtractTime [
-	self assert: (aTime subtractTime: aTime) = (Time readFrom: '00:00:00' readStream)
+	self assert: (aTime subtractTime: aTime) equals: (Time readFrom: '00:00:00' readStream)
 ]
 
 { #category : #tests }
 TimeTest >> testTicks [
-	self assert: aTime ticks = #(0 45296 0).
-	self assert: aTime  = (Time new ticks: #(0 45296 0))
+	self assert: aTime ticks equals: #(0 45296 0).
+	self assert: aTime equals: (Time new ticks: #(0 45296 0))
 ]
 
 { #category : #setup }

--- a/src/Kernel-Tests/TimespanDoTest.class.st
+++ b/src/Kernel-Tests/TimespanDoTest.class.st
@@ -40,60 +40,49 @@ TimespanDoTest >> setUp [
 TimespanDoTest >> testDatesDo [
 	| dateArray |
 	dateArray := OrderedCollection new.
-	7
-		to: 97
-		do: [:each | dateArray
-				addLast: (Date year: 2003 day: each)].
+	7 to: 97 do: [ :each | dateArray addLast: (Date year: 2003 day: each) ].
 	dateArray := dateArray asArray.
-	self assert: aTimespan dates = dateArray
+	self assert: aTimespan dates equals: dateArray
 ]
 
 { #category : #tests }
 TimespanDoTest >> testDoWith [
 	| count |
 	count := 0.
-	aTimespan
-		do: [:each | count := count + 1]
-		with: (Timespan
-				starting: aDate
-				duration: 7 days).
-	self assert: count = 13
+	aTimespan do: [ :each | count := count + 1 ] with: (Timespan starting: aDate duration: 7 days).
+	self assert: count equals: 13
 ]
 
 { #category : #tests }
 TimespanDoTest >> testDoWithWhen [
 	| count |
 	count := 0.
-	aTimespan
-		do: [:each | count := count + 1]
-		with: (Timespan starting: aDate duration: 7 days)
-		when: [:each | count < 5].
-	self assert: count = 5	
-
+	aTimespan do: [ :each | count := count + 1 ] with: (Timespan starting: aDate duration: 7 days) when: [ :each | count < 5 ].
+	self assert: count equals: 5
 ]
 
 { #category : #tests }
 TimespanDoTest >> testEveryDo [
-	|count  duration |
+	| count duration |
 	count := 0.
 	duration := 7 days.
-	(aTimespan
-			every: duration
-			do: [:each | count := count + 1]).
-	self assert: count = 13
-			
+	aTimespan every: duration do: [ :each | count := count + 1 ].
+	self assert: count equals: 13
 ]
 
 { #category : #tests }
 TimespanDoTest >> testNext [
-	self assert: aTimespan next 
-			= (Timespan
-					starting: (DateAndTime
-							year: 2003
-							month: 4
-							day: 8
-							hour: 0
-							minute: 0
-							second: 0)
-					duration: aDuration)
+	self
+		assert: aTimespan next
+		equals:
+			(Timespan
+				starting:
+					(DateAndTime
+						year: 2003
+						month: 4
+						day: 8
+						hour: 0
+						minute: 0
+						second: 0)
+				duration: aDuration)
 ]

--- a/src/Kernel-Tests/TrueTest.class.st
+++ b/src/Kernel-Tests/TrueTest.class.st
@@ -16,8 +16,7 @@ TrueTest >> testAND [
 
 { #category : #'tests - controlling' }
 TrueTest >> testAnd [
-	
-	self assert: ((true and: ['alternativeBlock']) = 'alternativeBlock'). 
+	self assert: (true and: [ 'alternativeBlock' ]) equals: 'alternativeBlock'
 ]
 
 { #category : #'tests - converting' }
@@ -34,22 +33,17 @@ TrueTest >> testIfFalse [
 
 { #category : #'tests - controlling' }
 TrueTest >> testIfFalseIfTrue [
-
-	self assert: (true ifFalse: ['falseAlternativeBlock'] 
-                      ifTrue: ['trueAlternativeBlock']) = 'trueAlternativeBlock'. 
+	self assert: (true ifFalse: [ 'falseAlternativeBlock' ] ifTrue: [ 'trueAlternativeBlock' ]) equals: 'trueAlternativeBlock'
 ]
 
 { #category : #'tests - controlling' }
 TrueTest >> testIfTrue [
-
-	self assert: ((true ifTrue: ['alternativeBlock']) = 'alternativeBlock'). 
+	self assert: (true ifTrue: [ 'alternativeBlock' ]) equals: 'alternativeBlock'
 ]
 
 { #category : #'tests - controlling' }
 TrueTest >> testIfTrueIfFalse [
-
-	self assert: (true ifTrue: ['trueAlternativeBlock'] 
-                      ifFalse: ['falseAlternativeBlock']) = 'trueAlternativeBlock'. 
+	self assert: (true ifTrue: [ 'trueAlternativeBlock' ] ifFalse: [ 'falseAlternativeBlock' ]) equals: 'trueAlternativeBlock'
 ]
 
 { #category : #'tests - instance creation' }
@@ -79,14 +73,13 @@ TrueTest >> testOr [
 
 { #category : #'tests - printing' }
 TrueTest >> testPrintOn [
-
-	self assert: (String streamContents: [:stream | true printOn: stream]) = 'true'. 
+	self assert: (String streamContents: [ :stream | true printOn: stream ]) equals: 'true'
 ]
 
 { #category : #'tests - logical operations' }
 TrueTest >> testXor [
-	self assert: (true xor: true) = false.
-	self assert: (true xor: false) = true.
-	self assert: (true xor: [true]) = false.
-	self assert: (true xor: [false]) = true.
+	self assert: (true xor: true) equals: false.
+	self assert: (true xor: false) equals: true.
+	self assert: (true xor: [ true ]) equals: false.
+	self assert: (true xor: [ false ]) equals: true
 ]

--- a/src/Kernel-Tests/UndefinedObjectTest.class.st
+++ b/src/Kernel-Tests/UndefinedObjectTest.class.st
@@ -89,10 +89,9 @@ UndefinedObjectTest >> testNotNil [
 
 { #category : #'tests - printing' }
 UndefinedObjectTest >> testPrintOn [
-
 	| string |
-	string := String streamContents: [:stream | nil printOn: stream].
-	self assert: (string = 'nil').
+	string := String streamContents: [ :stream | nil printOn: stream ].
+	self assert: string equals: 'nil'
 ]
 
 { #category : #'tests - copying' }

--- a/src/Kernel-Tests/WeakMessageSendTest.class.st
+++ b/src/Kernel-Tests/WeakMessageSendTest.class.st
@@ -81,13 +81,8 @@ WeakMessageSendTest >> testReceiverWithGC [
 
 { #category : #tests }
 WeakMessageSendTest >> testTwoArguments [
-
 	| m |
-	m := WeakMessageSend
-		receiver: Array
-		selector: #with:with:
-		arguments: { 1 . 2 }.
+	m := WeakMessageSend receiver: Array selector: #with:with: arguments: {1 . 2}.
 	Smalltalk garbageCollectMost.
-	self assert: (m value = { 1 . 2 }).
-
+	self assert: m value equals: {1 . 2}
 ]


### PR DESCRIPTION
Replace assert = in packages starting by J and K.

Replace:

- assert: = by assert: equals:
- deny = by deny: equals:
- assert: == by assert: identicalTo:
- deny: == by deny: identicalTo: