### PR TITLE
Replace-assert-equals-from-Morphic

### DIFF
--- a/src/Morphic-Tests/LayoutFrameTest.class.st
+++ b/src/Morphic-Tests/LayoutFrameTest.class.st
@@ -34,13 +34,13 @@ LayoutFrameTest >> testIdentity [
 LayoutFrameTest >> testInset [
 	| lf rectangle |
 	lf := LayoutFrame new
-			leftOffset: 10;
-			topOffset: 10;
-			rightOffset: -10;
-			bottomOffset: -10;
-			yourself.
-	rectangle := lf layout: nil in: (50@10 corner: 150@70).
-	self assert: (60@20 corner: 140@60) = rectangle
+		leftOffset: 10;
+		topOffset: 10;
+		rightOffset: -10;
+		bottomOffset: -10;
+		yourself.
+	rectangle := lf layout: nil in: (50 @ 10 corner: 150 @ 70).
+	self assert: (60 @ 20 corner: 140 @ 60) equals: rectangle
 ]
 
 { #category : #tests }
@@ -52,29 +52,29 @@ LayoutFrameTest >> testLeftTopAligned [
 		rightFraction: 0 offset: 60;
 		bottomFraction: 0 offset: 25;
 		yourself.
-	rectangle := lf layout: nil in: (50@10 corner: 150@70).
-	self assert: (60@20 corner: 110@35) = rectangle
+	rectangle := lf layout: nil in: (50 @ 10 corner: 150 @ 70).
+	self assert: (60 @ 20 corner: 110 @ 35) equals: rectangle
 ]
 
 { #category : #tests }
 LayoutFrameTest >> testRightBottomQuadrant [
 	| lf rectangle |
 	lf := LayoutFrame new
-			leftFraction: 1/2 offset: 1;
-			topFraction: 1/2 offset: 1;
-			rightFraction: 1 offset: -2;
-			bottomFraction: 1 offset: -2;
-			yourself.
-	rectangle := lf layout: nil in: (50@10 corner: 150@70).
-	self assert: (101@41 corner: 148@68) = rectangle
+		leftFraction: 1 / 2 offset: 1;
+		topFraction: 1 / 2 offset: 1;
+		rightFraction: 1 offset: -2;
+		bottomFraction: 1 offset: -2;
+		yourself.
+	rectangle := lf layout: nil in: (50 @ 10 corner: 150 @ 70).
+	self assert: (101 @ 41 corner: 148 @ 68) equals: rectangle
 ]
 
 { #category : #tests }
 LayoutFrameTest >> testSpaceFill [
 	| lf rectangle |
 	lf := LayoutFrame identity.
-	rectangle := lf layout: nil in: (50@10 corner: 150@70).
-	self assert: (50@10 corner: 150@70) = rectangle
+	rectangle := lf layout: nil in: (50 @ 10 corner: 150 @ 70).
+	self assert: (50 @ 10 corner: 150 @ 70) equals: rectangle
 ]
 
 { #category : #tests }
@@ -83,13 +83,13 @@ LayoutFrameTest >> testTransform [
 
 	| lf rectangle |
 	lf := LayoutFrame new
-			leftOffset: 10;
-			topOffset: 10;
-			rightOffset: -10;
-			bottomOffset: -10;
-			yourself.
-	rectangle := lf layout: nil in: (50@10 corner: 150@70).
-	self assert: (60@20 corner: 140@60) = rectangle
+		leftOffset: 10;
+		topOffset: 10;
+		rightOffset: -10;
+		bottomOffset: -10;
+		yourself.
+	rectangle := lf layout: nil in: (50 @ 10 corner: 150 @ 70).
+	self assert: (60 @ 20 corner: 140 @ 60) equals: rectangle
 ]
 
 { #category : #tests }
@@ -98,15 +98,15 @@ LayoutFrameTest >> testTransformReturnASubArea [
 
 	| lf rectangle refRectangle |
 	lf := LayoutFrame new
-			leftOffset: 10;
-			topOffset: 10;
-			rightOffset: -10;
-			bottomOffset: -10;
-			yourself.
-	refRectangle := 0@0 extent: 100@200.
+		leftOffset: 10;
+		topOffset: 10;
+		rightOffset: -10;
+		bottomOffset: -10;
+		yourself.
+	refRectangle := 0 @ 0 extent: 100 @ 200.
 	rectangle := lf transform: refRectangle.
-	self assert: rectangle width = 80.
-	self assert: rectangle height = 180.
+	self assert: rectangle width equals: 80.
+	self assert: rectangle height equals: 180
 ]
 
 { #category : #tests }
@@ -115,13 +115,13 @@ LayoutFrameTest >> testTransformReturnEmptyRectangleWhenNotPossibleToPlace [
 
 	| lf rectangle refRectangle |
 	lf := LayoutFrame new
-			leftOffset: 10;
-			topOffset: 10;
-			rightOffset: -10;
-			bottomOffset: -10;
-			yourself.
-	refRectangle := 0@0 extent: 10@10.
+		leftOffset: 10;
+		topOffset: 10;
+		rightOffset: -10;
+		bottomOffset: -10;
+		yourself.
+	refRectangle := 0 @ 0 extent: 10 @ 10.
 	rectangle := lf transform: refRectangle.
-	self assert: rectangle width = 0.
-	self assert: rectangle height = 0.
+	self assert: rectangle width equals: 0.
+	self assert: rectangle height equals: 0
 ]

--- a/src/Morphic-Tests/MCPTest.class.st
+++ b/src/Morphic-Tests/MCPTest.class.st
@@ -29,6 +29,7 @@ MCPTest >> testTop [
 	""
 	morph top: newTop.
 	""
-	self assert: morph top = newTop;
-		 assert: morph bounds = newBounds
+	self
+		assert: morph top equals: newTop;
+		assert: morph bounds equals: newBounds
 ]

--- a/src/Morphic-Tests/MorphTest.class.st
+++ b/src/Morphic-Tests/MorphTest.class.st
@@ -44,19 +44,18 @@ MorphTest >> testExtent [
 	| m1 m2 v1 v2 v3 b1 b2 |
 	m1 := Morph new.
 	m2 := Morph new.
-	
+
 	v1 := 100.000001.
 	v2 := 100.000001000001.
 	v3 := 100.000001000002.
 
-	m1 extent: v1@v1.
+	m1 extent: v1 @ v1.
 	b1 := m1 bounds.
-	
-	m2 extent: v2@v3.
-	b2 := m2 bounds.
-	
-	self assert: (b2 = b1).
 
+	m2 extent: v2 @ v3.
+	b2 := m2 bounds.
+
+	self assert: b2 equals: b1
 ]
 
 { #category : #'as yet unclassified' }
@@ -74,47 +73,46 @@ MorphTest >> testIntoWorldCollapseOutOfWorld [
 	"Create the guys"
 	m1 := TestInWorldMorph new.
 	m2 := TestInWorldMorph new.
-	self assert: (m1 intoWorldCount = 0).
-	self assert: (m1 outOfWorldCount = 0).
-	self assert: (m2 intoWorldCount = 0).
-	self assert: (m2 outOfWorldCount = 0).
+	self assert: m1 intoWorldCount equals: 0.
+	self assert: m1 outOfWorldCount equals: 0.
+	self assert: m2 intoWorldCount equals: 0.
+	self assert: m2 outOfWorldCount equals: 0.
 
 	"add them to basic morph"
 	morph addMorphFront: m1.
 	m1 addMorphFront: m2.
-	self assert: (m1 intoWorldCount = 0).
-	self assert: (m1 outOfWorldCount = 0).
-	self assert: (m2 intoWorldCount = 0).
-	self assert: (m2 outOfWorldCount = 0).
+	self assert: m1 intoWorldCount equals: 0.
+	self assert: m1 outOfWorldCount equals: 0.
+	self assert: m2 intoWorldCount equals: 0.
+	self assert: m2 outOfWorldCount equals: 0.
 
 	"open the guy"
 	morph openInWorld.
-	self assert: (m1 intoWorldCount = 1).
-	self assert: (m1 outOfWorldCount = 0).
-	self assert: (m2 intoWorldCount = 1).
-	self assert: (m2 outOfWorldCount = 0).
+	self assert: m1 intoWorldCount equals: 1.
+	self assert: m1 outOfWorldCount equals: 0.
+	self assert: m2 intoWorldCount equals: 1.
+	self assert: m2 outOfWorldCount equals: 0.
 
 	"collapse it"
-	collapsed := 	CollapsedMorph new beReplacementFor: morph.
-	self assert: (m1 intoWorldCount = 1).
-	self assert: (m1 outOfWorldCount = 1).
-	self assert: (m2 intoWorldCount = 1).
-	self assert: (m2 outOfWorldCount = 1).
+	collapsed := CollapsedMorph new beReplacementFor: morph.
+	self assert: m1 intoWorldCount equals: 1.
+	self assert: m1 outOfWorldCount equals: 1.
+	self assert: m2 intoWorldCount equals: 1.
+	self assert: m2 outOfWorldCount equals: 1.
 
 	"expand it"
 	collapsed collapseOrExpand.
-	self assert: (m1 intoWorldCount = 2).
-	self assert: (m1 outOfWorldCount = 1).
-	self assert: (m2 intoWorldCount = 2).
-	self assert: (m2 outOfWorldCount = 1).
+	self assert: m1 intoWorldCount equals: 2.
+	self assert: m1 outOfWorldCount equals: 1.
+	self assert: m2 intoWorldCount equals: 2.
+	self assert: m2 outOfWorldCount equals: 1.
 
 	"delete it"
 	morph delete.
-	self assert: (m1 intoWorldCount = 2).
-	self assert: (m1 outOfWorldCount = 2).
-	self assert: (m2 intoWorldCount = 2).
-	self assert: (m2 outOfWorldCount = 2).
-
+	self assert: m1 intoWorldCount equals: 2.
+	self assert: m1 outOfWorldCount equals: 2.
+	self assert: m2 intoWorldCount equals: 2.
+	self assert: m2 outOfWorldCount equals: 2
 ]
 
 { #category : #'testing - into/outof world' }
@@ -123,30 +121,29 @@ MorphTest >> testIntoWorldDeleteOutOfWorld [
 	"Create the guys"
 	m1 := TestInWorldMorph new.
 	m2 := TestInWorldMorph new.
-	self assert: (m1 intoWorldCount = 0).
-	self assert: (m1 outOfWorldCount = 0).
-	self assert: (m2 intoWorldCount = 0).
-	self assert: (m2 outOfWorldCount = 0).
+	self assert: m1 intoWorldCount equals: 0.
+	self assert: m1 outOfWorldCount equals: 0.
+	self assert: m2 intoWorldCount equals: 0.
+	self assert: m2 outOfWorldCount equals: 0.
 
 	morph addMorphFront: m1.
-	m1 addMorphFront:  m2.
-	self assert: (m1 intoWorldCount = 0).
-	self assert: (m1 outOfWorldCount = 0).
-	self assert: (m2 intoWorldCount = 0).
-	self assert: (m2 outOfWorldCount = 0).
+	m1 addMorphFront: m2.
+	self assert: m1 intoWorldCount equals: 0.
+	self assert: m1 outOfWorldCount equals: 0.
+	self assert: m2 intoWorldCount equals: 0.
+	self assert: m2 outOfWorldCount equals: 0.
 
 	morph openInWorld.
-	self assert: (m1 intoWorldCount = 1).
-	self assert: (m1 outOfWorldCount = 0).
-	self assert: (m2 intoWorldCount = 1).
-	self assert: (m2 outOfWorldCount = 0).
+	self assert: m1 intoWorldCount equals: 1.
+	self assert: m1 outOfWorldCount equals: 0.
+	self assert: m2 intoWorldCount equals: 1.
+	self assert: m2 outOfWorldCount equals: 0.
 
 	morph delete.
-	self assert: (m1 intoWorldCount = 1).
-	self assert: (m1 outOfWorldCount = 1).
-	self assert: (m2 intoWorldCount = 1).
-	self assert: (m2 outOfWorldCount = 1).
-	
+	self assert: m1 intoWorldCount equals: 1.
+	self assert: m1 outOfWorldCount equals: 1.
+	self assert: m2 intoWorldCount equals: 1.
+	self assert: m2 outOfWorldCount equals: 1
 ]
 
 { #category : #'testing - into/outof world' }
@@ -155,48 +152,47 @@ MorphTest >> testIntoWorldTransferToNewGuy [
 	"Create the guys"
 	m1 := TestInWorldMorph new.
 	m2 := TestInWorldMorph new.
-	self assert: (m1 intoWorldCount = 0).
-	self assert: (m1 outOfWorldCount = 0).
-	self assert: (m2 intoWorldCount = 0).
-	self assert: (m2 outOfWorldCount = 0).
+	self assert: m1 intoWorldCount equals: 0.
+	self assert: m1 outOfWorldCount equals: 0.
+	self assert: m2 intoWorldCount equals: 0.
+	self assert: m2 outOfWorldCount equals: 0.
 
 	morph addMorphFront: m1.
-	m1 addMorphFront:  m2.
-	self assert: (m1 intoWorldCount = 0).
-	self assert: (m1 outOfWorldCount = 0).
-	self assert: (m2 intoWorldCount = 0).
-	self assert: (m2 outOfWorldCount = 0).
+	m1 addMorphFront: m2.
+	self assert: m1 intoWorldCount equals: 0.
+	self assert: m1 outOfWorldCount equals: 0.
+	self assert: m2 intoWorldCount equals: 0.
+	self assert: m2 outOfWorldCount equals: 0.
 
 	morph openInWorld.
-	self assert: (m1 intoWorldCount = 1).
-	self assert: (m1 outOfWorldCount = 0).
-	self assert: (m2 intoWorldCount = 1).
-	self assert: (m2 outOfWorldCount = 0).
+	self assert: m1 intoWorldCount equals: 1.
+	self assert: m1 outOfWorldCount equals: 0.
+	self assert: m2 intoWorldCount equals: 1.
+	self assert: m2 outOfWorldCount equals: 0.
 
 	morph addMorphFront: m2.
-	self assert: (m1 intoWorldCount = 1).
-	self assert: (m1 outOfWorldCount = 0).
-	self assert: (m2 intoWorldCount = 1).
-	self assert: (m2 outOfWorldCount = 0).
+	self assert: m1 intoWorldCount equals: 1.
+	self assert: m1 outOfWorldCount equals: 0.
+	self assert: m2 intoWorldCount equals: 1.
+	self assert: m2 outOfWorldCount equals: 0.
 
 	morph addMorphFront: m1.
-	self assert: (m1 intoWorldCount = 1).
-	self assert: (m1 outOfWorldCount = 0).
-	self assert: (m2 intoWorldCount = 1).
-	self assert: (m2 outOfWorldCount = 0).
+	self assert: m1 intoWorldCount equals: 1.
+	self assert: m1 outOfWorldCount equals: 0.
+	self assert: m2 intoWorldCount equals: 1.
+	self assert: m2 outOfWorldCount equals: 0.
 
 	m2 addMorphFront: m1.
-	self assert: (m1 intoWorldCount = 1).
-	self assert: (m1 outOfWorldCount = 0).
-	self assert: (m2 intoWorldCount = 1).
-	self assert: (m2 outOfWorldCount = 0).
+	self assert: m1 intoWorldCount equals: 1.
+	self assert: m1 outOfWorldCount equals: 0.
+	self assert: m2 intoWorldCount equals: 1.
+	self assert: m2 outOfWorldCount equals: 0.
 
 	morph delete.
-	self assert: (m1 intoWorldCount = 1).
-	self assert: (m1 outOfWorldCount = 1).
-	self assert: (m2 intoWorldCount = 1).
-	self assert: (m2 outOfWorldCount = 1).
-
+	self assert: m1 intoWorldCount equals: 1.
+	self assert: m1 outOfWorldCount equals: 1.
+	self assert: m2 intoWorldCount equals: 1.
+	self assert: m2 outOfWorldCount equals: 1
 ]
 
 { #category : #'testing - classification' }

--- a/src/Morphic-Tests/MorphTreeMorphTest.class.st
+++ b/src/Morphic-Tests/MorphTreeMorphTest.class.st
@@ -103,19 +103,15 @@ MorphTreeMorphTest >> testUpdatingSelectionsOnUpdateWithRemoval [
 
 	| c w t |
 	c := ClassTreeExample new.
-	[ 
-	w := c openOn: Collection.
+	[ w := c openOn: Collection.
 	t := c dependents last.
 	t expandAll.
-	c
-		selectItems:
-			{Bag.
-			CharacterSet}.
+	c selectItems: {Bag . CharacterSet}.
 	c selection selectedNodes do: [ :e | self assert: (t selectedMorphList anySatisfy: [ :sm | sm complexContents = e ]) ].
 	c rootClass: Bag.	"We change completely the list. CharacterSet is not anymore in the list after the update."
 	c updateList.
-	self assert: t selectedMorphList size = 1.	"We have only Bag selected now."
-	self assert: t selectedMorphList first complexContents withoutListWrapper == Bag.
+	self assert: t selectedMorphList size equals: 1.	"We have only Bag selected now."
+	self assert: t selectedMorphList first complexContents withoutListWrapper identicalTo: Bag.
 	c selection selectedNodes do: [ :e | self assert: (t selectedMorphList anySatisfy: [ :sm | sm complexContents = e ]) ] ]
 		ensure: [ w close ]
 ]

--- a/src/Morphic-Tests/MorphicEventHandlerTest.class.st
+++ b/src/Morphic-Tests/MorphicEventHandlerTest.class.st
@@ -23,54 +23,53 @@ MorphicEventHandlerTest >> tearDown [
 
 { #category : #tests }
 MorphicEventHandlerTest >> testClickFromMorph [
-
 	morph eventHandler on: #click send: #value to: true.
-	
-	self assert: ((morph click: nil) == true)
+
+	self assert: (morph click: nil) identicalTo: true
 ]
 
 { #category : #tests }
 MorphicEventHandlerTest >> testDoubleClickFromMorph [
-
 	morph eventHandler on: #doubleClick send: #value to: true.
-	
-	self assert: ((morph doubleClick: nil) == true)
+
+	self assert: (morph doubleClick: nil) identicalTo: true
 ]
 
 { #category : #tests }
 MorphicEventHandlerTest >> testDoubleClickTimeoutFromMorph [
-
 	morph eventHandler on: #doubleClickTimeout send: #value to: true.
-	
-	self assert: ((morph doubleClickTimeout: nil) == true)
+
+	self assert: (morph doubleClickTimeout: nil) identicalTo: true
 ]
 
 { #category : #tests }
 MorphicEventHandlerTest >> testKeyStrokeFromMorph [
-
 	| keyboardEvent |
-	keyboardEvent := KeyboardEvent new 
-							setType: #keystroke
-							buttons: 2
-							position: nil
-							keyValue: nil
-							charCode: 65
-							hand: nil
-							stamp: nil.
+	keyboardEvent := KeyboardEvent new
+		setType: #keystroke
+		buttons: 2
+		position: nil
+		keyValue: nil
+		charCode: 65
+		hand: nil
+		stamp: nil.
 
 	morph eventHandler on: #keyStroke send: #value to: true.
-	
-	self assert: ((morph handleKeystroke: keyboardEvent) == true)
+
+	self assert: (morph handleKeystroke: keyboardEvent) identicalTo: true
 ]
 
 { #category : #'tests-events' }
 MorphicEventHandlerTest >> testMouseEnterDraggingFromMorph [
-
-	| event | 
-	event := MouseEvent basicNew setType: #mouseOver position: nil buttons: 2 hand: Morph new.
+	| event |
+	event := MouseEvent basicNew
+		setType: #mouseOver
+		position: nil
+		buttons: 2
+		hand: Morph new.
 	morph eventHandler on: #mouseEnterDragging send: #value to: true.
-	
-	self assert: ((morph handleMouseEnter: event) == true)
+
+	self assert: (morph handleMouseEnter: event) identicalTo: true
 ]
 
 { #category : #tests }
@@ -96,18 +95,16 @@ MorphicEventHandlerTest >> testMouseEnterEventIsNotDuplicated [
 
 { #category : #'tests-events' }
 MorphicEventHandlerTest >> testMouseEnterFromMorph [
-
 	morph eventHandler on: #mouseEnter send: #value to: true.
-	
-	self assert: ((morph mouseEnter: nil) == true)
+
+	self assert: (morph mouseEnter: nil) identicalTo: true
 ]
 
 { #category : #'tests-events' }
 MorphicEventHandlerTest >> testMouseLeaveFromMorph [
-
 	morph eventHandler on: #mouseLeave send: #value to: true.
-	
-	self assert: ((morph mouseLeave: nil) == true)
+
+	self assert: (morph mouseLeave: nil) identicalTo: true
 ]
 
 { #category : #tests }

--- a/src/Morphic-Tests/PaginatedMorphTreeMorphTest.class.st
+++ b/src/Morphic-Tests/PaginatedMorphTreeMorphTest.class.st
@@ -16,7 +16,7 @@ PaginatedMorphTreeMorphTest >> testPager [
 	treeMorph buildContents.
 	aWindow addMorph: treeMorph fullFrame: LayoutFrame identity.
 	aWindow open.
-	aModel expandItemPath: { 40 }.
-	self assert: treeMorph pager currentPage == 2.
+	aModel expandItemPath: {40}.
+	self assert: treeMorph pager currentPage identicalTo: 2.
 	aWindow close
 ]

--- a/src/Morphic-Tests/PolygonMorphTest.class.st
+++ b/src/Morphic-Tests/PolygonMorphTest.class.st
@@ -11,32 +11,30 @@ Class {
 PolygonMorphTest >> testBoundsBug1035 [
 	"This is a non regression test for http://bugs.squeak.org/view.php?id=1035
 	PolygonMorph used to position badly when container bounds were growing"
-	
-	| submorph aMorph |
-	
-	submorph := (PolygonMorph
-		vertices: {0@0. 100@0. 0@100}
-		color: Color red borderWidth: 0 borderColor: Color transparent)
-			color: Color red.
 
-	submorph bounds. "0@0 corner: 100@100"
+	| submorph aMorph |
+	submorph := (PolygonMorph
+		vertices: {(0 @ 0) . (100 @ 0) . (0 @ 100)}
+		color: Color red
+		borderWidth: 0
+		borderColor: Color transparent) color: Color red.
+
+	submorph bounds.	"0@0 corner: 100@100"
 
 	aMorph := Morph new
 		color: Color blue;
 		layoutPolicy: ProportionalLayout new;
-		addMorph: submorph
-		fullFrame: ((0.1 @ 0.1 corner: 0.9 @ 0.9) asLayoutFrame).
+		addMorph: submorph fullFrame: (0.1 @ 0.1 corner: 0.9 @ 0.9) asLayoutFrame.
 
-	submorph bounds. "0@0 corner: 100@100 NOT YET UPDATED"
-	aMorph fullBounds. "0@0 corner: 50@40. CORRECT"
-	submorph bounds. "5@4 corner: 45@36 NOW UPDATED OK"
+	submorph bounds.	"0@0 corner: 100@100 NOT YET UPDATED"
+	aMorph fullBounds.	"0@0 corner: 50@40. CORRECT"
+	submorph bounds.	"5@4 corner: 45@36 NOW UPDATED OK"
 
-	aMorph extent: 100@100.
-	submorph bounds. "5@4 corner: 45@36 NOT YET UPDATED"
-	aMorph fullBounds. "-10@-14 corner: 100@100 WRONG"
-	submorph bounds. "-10@-14 corner: 70@66 NOW WRONG POSITION (BUT RIGHT EXTENT)"
+	aMorph extent: 100 @ 100.
+	submorph bounds.	"5@4 corner: 45@36 NOT YET UPDATED"
+	aMorph fullBounds.	"-10@-14 corner: 100@100 WRONG"
+	submorph bounds.	"-10@-14 corner: 70@66 NOW WRONG POSITION (BUT RIGHT EXTENT)"
 
-	self assert: aMorph fullBounds = (0 @ 0 extent: 100@100).
-	self assert: submorph bounds = (10 @ 10 corner: 90@90).
-
+	self assert: aMorph fullBounds equals: (0 @ 0 extent: 100 @ 100).
+	self assert: submorph bounds equals: (10 @ 10 corner: 90 @ 90)
 ]

--- a/src/Morphic-Tests/SupplyAnswerTest.class.st
+++ b/src/Morphic-Tests/SupplyAnswerTest.class.st
@@ -9,28 +9,27 @@ Class {
 
 { #category : #tests }
 SupplyAnswerTest >> testChooseDirectory [
-
 	| tmpDirectory answer |
-	tmpDirectory :=FileSystem / 'tmp'.
-	
-	answer := ([ MorphicUIManager new chooseDirectory ] valueSupplyingAnswer: { 'Choose Directory'. tmpDirectory }).
-	
-	self assert: answer = tmpDirectory.
+	tmpDirectory := FileSystem / 'tmp'.
+
+	answer := [ MorphicUIManager new chooseDirectory ] valueSupplyingAnswer: {'Choose Directory' . tmpDirectory}.
+
+	self assert: answer equals: tmpDirectory
 ]
 
 { #category : #tests }
 SupplyAnswerTest >> testFillInTheBlank [
-
 	| answer |
 	answer := [ MorphicUIManager new request: 'Your favorite color?' ] valueSupplyingAnswer: #('Your favorite color?' 'blue').
-	
-	self assert: answer = 'blue'.
+
+	self assert: answer equals: 'blue'
 ]
 
 { #category : #tests }
 SupplyAnswerTest >> testInform [
-
 	| answer |
-	[ MorphicUIManager new inform: 'blah' ] on: Exception do: [:ex | answer := ex messageText ].
-	self assert: answer  = 'blah'.
+	[ MorphicUIManager new inform: 'blah' ]
+		on: Exception
+		do: [ :ex | answer := ex messageText ].
+	self assert: answer equals: 'blah'
 ]

--- a/src/Morphic-Tests/WindowAnnouncementTest.class.st
+++ b/src/Morphic-Tests/WindowAnnouncementTest.class.st
@@ -20,58 +20,58 @@ WindowAnnouncementTest >> testCollapsing [
 	window := SystemWindow labelled: 'foo'.
 	t := 0.
 	window openInWorld.
-	window announcer when: WindowCollapsed do: [:ann | t := t + 1].
-	self assert: (t = 0).
+	window announcer when: WindowCollapsed do: [ :ann | t := t + 1 ].
+	self assert: t equals: 0.
 	window collapse.
-	self assert: (t = 1).
-
+	self assert: t equals: 1
 ]
 
 { #category : #'tests - window change' }
 WindowAnnouncementTest >> testMoving [
-	| t oldBounds  event |
+	| t oldBounds event |
 	window := SystemWindow labelled: 'foo'.
 	t := 0.
 	event := nil.
 
 	window openInWorld.
 	oldBounds := window bounds.
-	window announcer when: WindowMoved do: [:ann | t := t + 1. event := ann].
+	window announcer
+		when: WindowMoved
+		do: [ :ann | 
+			t := t + 1.
+			event := ann ].
 
-	self assert: (t = 0).
-	self assert: (event isNil).
-	
+	self assert: t equals: 0.
+	self assert: event isNil.
+
 	"We move the window"
-	window position: 50@50.
-	self assert: (t = 1).
-	self assert: (event oldPosition = oldBounds origin).
-	self assert: (event newPosition = (50@50 )).
+	window position: 50 @ 50.
+	self assert: t equals: 1.
+	self assert: event oldPosition equals: oldBounds origin.
+	self assert: event newPosition equals: 50 @ 50.
 
 	"We call position: without moving it actually, nothing should happen"
-	window position: 50@50.
-	self assert: (t = 1).
+	window position: 50 @ 50.
+	self assert: t equals: 1.
 
 	"If we simply resize the window, nothing should happen as well"
-	window extent: 50@60.
-	self assert: (t = 1).
-
-
+	window extent: 50 @ 60.
+	self assert: t equals: 1
 ]
 
 { #category : #'tests - window change' }
 WindowAnnouncementTest >> testResizing [
 	| t oldBounds newBounds |
 	window := SystemWindow labelled: 'foo'.
-	window setProperty: #minimumExtent toValue: 1@1.
+	window setProperty: #minimumExtent toValue: 1 @ 1.
 	t := 0.
 	window openInWorld.
 	oldBounds := window bounds.
-	window announcer when: WindowResizing do: [:ann | t := t + 1].
-	self assert: (t = 0).
-	window extent: 50@60.
+	window announcer when: WindowResizing do: [ :ann | t := t + 1 ].
+	self assert: t equals: 0.
+	window extent: 50 @ 60.
 	newBounds := window bounds.
-	self assert: (t = 1).
-
+	self assert: t equals: 1
 ]
 
 { #category : #'tests - window creation and deletion' }
@@ -85,7 +85,7 @@ WindowAnnouncementTest >> testResizingClosing [
 	window minimizeOrRestore.
 
 	"Resizing, moving, deActivation, collapsing "
-	self assert: coll size = 4.
+	self assert: coll size equals: 4.
 	self assert: coll first isResized.
 	self assert: coll second isMoved.
 	self assert: coll third isDeActivated.
@@ -93,7 +93,7 @@ WindowAnnouncementTest >> testResizingClosing [
 
 	window delete.
 
-	self assert: coll size = 5.
+	self assert: coll size equals: 5.
 	self assert: coll fifth isClosed.
 	window := nil
 ]
@@ -103,25 +103,24 @@ WindowAnnouncementTest >> testScrolling [
 	"This test tests the scrolling values of a scrollpane. We create a reeeeeally big (enormous) morph, to be sure its size is bigger than the screen and therefore its enclosing window has scrollbars.
 	When screen sizes become bigger, you should increase the value, or fix morphic, what happens first :).
 	"
+
 	| myMorph pane t |
 	window := SystemWindow labelled: 'foo'.
-	window extent: 300@200.
+	window extent: 300 @ 200.
 	myMorph := Morph new.
-	myMorph extent: 10000000000@1000000000.
+	myMorph extent: 10000000000 @ 1000000000.
 	pane := ScrollPane new.
 	pane scroller addMorph: myMorph.
-	window
-		addMorph: pane
-		fullFrame: LayoutFrame identity.
+	window addMorph: pane fullFrame: LayoutFrame identity.
 	t := 0 @ 0.
 	window openInWorld.
-	window announcer when: WindowScrolling do: [:ann | t := t + ann step ].
+	window announcer when: WindowScrolling do: [ :ann | t := t + ann step ].
 	pane hScrollBarValue: 10.
 	pane vScrollBarValue: 5.
 
 	window delete.
-	
-	self assert: (t = (10 @ 5)).
+
+	self assert: t equals: 10 @ 5.
 	window := nil
 ]
 
@@ -129,50 +128,59 @@ WindowAnnouncementTest >> testScrolling [
 WindowAnnouncementTest >> testWindowCreation [
 	| t oldBounds newBounds |
 	t := 0.
-	self currentWorld announcer when: WindowResizing do: [:ann | t := t + 1].
+	self currentWorld announcer when: WindowResizing do: [ :ann | t := t + 1 ].
 	window := SystemWindow labelled: 'foo'.
-	window setProperty: #minimumExtent toValue: 1@1.
+	window setProperty: #minimumExtent toValue: 1 @ 1.
 	window openInWorld.
 	oldBounds := window bounds.
-	window announcer when: WindowResizing do: [:ann | t := t + 1].
-	self assert: (t = 0).
-	window extent: 50@60.
+	window announcer when: WindowResizing do: [ :ann | t := t + 1 ].
+	self assert: t equals: 0.
+	window extent: 50 @ 60.
 	newBounds := window bounds.
-	self assert: (t = 1).
-
+	self assert: t equals: 1
 ]
 
 { #category : #'tests - window creation and deletion' }
 WindowAnnouncementTest >> testWindowCreationAndDeletion [
-	
 	| t newWindowCreated |
 	t := 0.
-	self currentWorld announcer when: WindowOpened do: [:ann | t := t + 1. newWindowCreated := ann window].
-	self currentWorld announcer when: WindowClosed do: [:ann | t := t + 10. newWindowCreated := ann window].
+	self currentWorld announcer
+		when: WindowOpened
+		do: [ :ann | 
+			t := t + 1.
+			newWindowCreated := ann window ].
+	self currentWorld announcer
+		when: WindowClosed
+		do: [ :ann | 
+			t := t + 10.
+			newWindowCreated := ann window ].
 	window := SystemWindow labelled: 'foo'.
 	window openInWorld.
 
-	self assert: (t = 1).
-	self assert: (window == newWindowCreated).
+	self assert: t equals: 1.
+	self assert: window identicalTo: newWindowCreated.
 	window delete.
 
-	self assert: (t = 11).
-	self assert: (window == newWindowCreated).
-
+	self assert: t equals: 11.
+	self assert: window identicalTo: newWindowCreated
 ]
 
 { #category : #'tests - window creation and deletion' }
 WindowAnnouncementTest >> testWindowLabelling [
 	"Test change of label for a window."
-	
+
 	| labels win |
 	labels := #().
-	self currentWorld announcer when: WindowLabelled do: [:ann | win := ann window. labels := labels copyWith: ann label].
+	self currentWorld announcer
+		when: WindowLabelled
+		do: [ :ann | 
+			win := ann window.
+			labels := labels copyWith: ann label ].
 	window := SystemWindow labelled: 'foo'.
 	window openInWorld.
-	self assert: win = window.
-	self assert: labels = #('foo').
+	self assert: win equals: window.
+	self assert: labels equals: #('foo').
 	window setLabel: 'bar'.
-	self assert: win = window.
-	self assert: labels = #('foo' 'bar')
+	self assert: win equals: window.
+	self assert: labels equals: #('foo' 'bar')
 ]


### PR DESCRIPTION
Replace assert = in Morphic.

Replace:

- assert: = by assert: equals:
- deny = by deny: equals:
- assert: == by assert: identicalTo:
- deny: == by deny: identicalTo: