### PR TITLE
5085-Move-clap-into-BaselineOfBaseLibraries-2

### DIFF
--- a/src/BaselineOfBaseLibraries/BaselineOfBaseLibraries.class.st
+++ b/src/BaselineOfBaseLibraries/BaselineOfBaseLibraries.class.st
@@ -29,5 +29,11 @@ BaselineOfBaseLibraries >> baseline: spec [
 				baseline: 'Beacon'
 				with: [ spec
 						loads: #('CoreTests');
-						repository: repository ] ]
+						repository: repository ].
+
+			spec 
+				baseline: 'Clap' 
+				with: [ spec
+					loads: #('core'); 
+					repository: repository ] ]
 ]

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -115,7 +115,8 @@ BaselineOfIDE >> baseline: spec [
 			spec repository: repository; loads: 'traits-tests' ].
 		spec baseline: 'Slot' with: [
 			spec repository: repository; loads: 'slot-tests' ].
-		spec baseline: 'Clap' with: [ spec repository: repository ].
+		spec baseline: 'Clap' with: [ 
+			spec repository: repository; loads: 'development'].
 		spec baseline: 'SUnit' with: [
 			spec repository: repository; loads: 'Tests' ].
 		spec baseline: 'BlueInk' with: [ 


### PR DESCRIPTION
load Clap core in BaselineOfBaseLibrariesfixes #5085