### PR TITLE
Replace-assert-equals-from-packages-starting-with-O

### DIFF
--- a/src/OSWindow-Tests/OSWindowAttributesTest.class.st
+++ b/src/OSWindow-Tests/OSWindowAttributesTest.class.st
@@ -9,11 +9,10 @@ Class {
 
 { #category : #tests }
 OSWindowAttributesTest >> testDefaults [
-
 	| attributes |
-	attributes := OSWindowAttributes new.	
-	self assert: attributes position = attributes class defaultPosition.
-	self assert: attributes extent = attributes class defaultExtent.
-	self assert: attributes fullscreen  = attributes class defaultFullscreen.
-	self assert: attributes title = attributes class defaultTitle
+	attributes := OSWindowAttributes new.
+	self assert: attributes position equals: attributes class defaultPosition.
+	self assert: attributes extent equals: attributes class defaultExtent.
+	self assert: attributes fullscreen equals: attributes class defaultFullscreen.
+	self assert: attributes title equals: attributes class defaultTitle
 ]

--- a/src/OSWindow-Tests/OSWindowTest.class.st
+++ b/src/OSWindow-Tests/OSWindowTest.class.st
@@ -21,16 +21,12 @@ OSWindowTest >> testCreatingWindow [
 
 { #category : #tests }
 OSWindowTest >> testNewWindowDefaults [
-
 	| window |
-	
 	window := OSWindow newWithNullDriver.
 
-	[	self assert: (window isValid).
-		self assert: window extent = OSWindowAttributes defaultExtent
-	] ensure: [ window destroy ]
-		
-	
+	[ self assert: window isValid.
+	self assert: window extent equals: OSWindowAttributes defaultExtent ]
+		ensure: [ window destroy ]
 ]
 
 { #category : #tests }

--- a/src/Ombu-Tests/OmSessionStoreNameStrategyTest.class.st
+++ b/src/Ombu-Tests/OmSessionStoreNameStrategyTest.class.st
@@ -62,13 +62,12 @@ OmSessionStoreNameStrategyTest >> tearDown [
 
 { #category : #tests }
 OmSessionStoreNameStrategyTest >> testWithExistingFile [
-
 	self createFileWith: 'existing'.
 
 	name := strategy nextTo: 'existing' in: self directory.
-	
+
 	self assert: name isString.
-	self deny: name = 'existing'.
+	self deny: name equals: 'existing'.
 	self deny: (self fileReferenceWith: name) exists
 ]
 

--- a/src/Ombu-Tests/OmSessionStoreTest.class.st
+++ b/src/Ombu-Tests/OmSessionStoreTest.class.st
@@ -28,7 +28,6 @@ OmSessionStoreTest >> tearDown [
 
 { #category : #tests }
 OmSessionStoreTest >> testResetWithNextStoreNameWithRandomSuffix [
-
 	| aFileReference anotherFileReference |
 	store storeNameStrategy: OmRandomSuffixStrategy new.
 
@@ -36,34 +35,33 @@ OmSessionStoreTest >> testResetWithNextStoreNameWithRandomSuffix [
 	aFileReference := store writingFileReference.
 	store resetWithNextStoreName.
 	anotherFileReference := store writingFileReference.
-	
-	self deny: aFileReference = anotherFileReference
+
+	self deny: aFileReference equals: anotherFileReference
 ]
 
 { #category : #tests }
 OmSessionStoreTest >> testResetWithNextStoreNameWithSequentialSuffix [
 	"The sequencial suffix doesn't change unless the file is created"
-	
+
 	| aFileReference anotherFileReference |
 	store storeNameStrategy: OmSequentialSuffixStrategy new.
-	
+
 	store resetWithNextStoreName.
 	aFileReference := store writingFileReference.
 	store resetWithNextStoreName.
 	anotherFileReference := store writingFileReference.
-	
+
 	self assert: aFileReference equals: anotherFileReference.
-	
+
 	store newEntry: (OmEntry content: 42).
 	store flush.
 	store resetWithNextStoreName.
 	anotherFileReference := store writingFileReference.
-	self deny: aFileReference = anotherFileReference.
+	self deny: aFileReference equals: anotherFileReference
 ]
 
 { #category : #tests }
 OmSessionStoreTest >> testResetWithNextStoreNameWithTimeStampSuffix [
-
 	| aFileReference anotherFileReference |
 	store storeNameStrategy: OmTimeStampSuffixStrategy new.
 
@@ -72,8 +70,8 @@ OmSessionStoreTest >> testResetWithNextStoreNameWithTimeStampSuffix [
 	50 milliSeconds wait.
 	store resetWithNextStoreName.
 	anotherFileReference := store writingFileReference.
-	
-	self deny: aFileReference = anotherFileReference
+
+	self deny: aFileReference equals: anotherFileReference
 ]
 
 { #category : #tests }

--- a/src/OpalCompiler-Tests/IRBuilderTest.class.st
+++ b/src/OpalCompiler-Tests/IRBuilderTest.class.st
@@ -55,8 +55,7 @@ IRBuilderTest >> testDup [
 
 { #category : #testing }
 IRBuilderTest >> testInstVar [
-
-	| iRMethod aCompiledMethod  |
+	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		pushInstVar: 1;
 		pushInstVar: 2;
@@ -66,15 +65,12 @@ IRBuilderTest >> testInstVar [
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
- 	self assert: ((aCompiledMethod valueWithReceiver: (3@4) arguments: #() ) = 7).
-	^iRMethod
-	
-	
+	self assert: (aCompiledMethod valueWithReceiver: 3 @ 4 arguments: #()) equals: 7.
+	^ iRMethod
 ]
 
 { #category : #testing }
 IRBuilderTest >> testJumpAheadTo [
-
 	| iRMethod aCompiledMethod iRBuilder |
 	iRBuilder := IRBuilder new.
 	iRMethod := iRBuilder
@@ -83,16 +79,15 @@ IRBuilderTest >> testJumpAheadTo [
 		send: #+;
 		jumpAheadTo: #end;
 		pushLiteral: 3;
-		jumpAheadTarget: #end;	
+		jumpAheadTarget: #end;
 		returnTop;
 		ir.
 
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #())  = 3.
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: 3.
+	^ iRMethod
 ]
 
 { #category : #testing }
@@ -140,19 +135,16 @@ IRBuilderTest >> testJumpBackTo [
 
 { #category : #testing }
 IRBuilderTest >> testLiteralArray [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
-		pushLiteral: #(test 4 you); 	
+		pushLiteral: #(test 4 you);
 		returnTop;
 		ir.
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = #(test 4 you)).
-	^iRMethod
-
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: #(test 4 you).
+	^ iRMethod
 ]
 
 { #category : #testing }
@@ -174,19 +166,16 @@ IRBuilderTest >> testLiteralBoolean [
 
 { #category : #testing }
 IRBuilderTest >> testLiteralCharacter [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
-		pushLiteral: $e; 	
+		pushLiteral: $e;
 		returnTop;
 		ir.
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = $e).
-	^iRMethod
-
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: $e.
+	^ iRMethod
 ]
 
 { #category : #testing }
@@ -208,19 +197,16 @@ IRBuilderTest >> testLiteralFloat [
 
 { #category : #testing }
 IRBuilderTest >> testLiteralInteger [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
-		pushLiteral: 2; 	
+		pushLiteral: 2;
 		returnTop;
 		ir.
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = 2).
-	^iRMethod
-
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: 2.
+	^ iRMethod
 ]
 
 { #category : #testing }
@@ -242,91 +228,77 @@ IRBuilderTest >> testLiteralNil [
 
 { #category : #testing }
 IRBuilderTest >> testLiteralString [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
-		pushLiteral: 'hello'; 	
+		pushLiteral: 'hello';
 		returnTop;
 		ir.
 
 	aCompiledMethod := iRMethod compiledMethod.
 
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-     self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = 'hello').
-	^iRMethod
-
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: 'hello'.
+	^ iRMethod
 ]
 
 { #category : #testing }
 IRBuilderTest >> testLiteralSymbol [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
-		pushLiteral: #you; 	
+		pushLiteral: #you;
 		returnTop;
 		ir.
 
 	aCompiledMethod := iRMethod compiledMethod.
 
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-     self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = #you).
-	^iRMethod
-
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: #you.
+	^ iRMethod
 ]
 
 { #category : #testing }
 IRBuilderTest >> testLiteralVariableClass [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
-		pushLiteralVariable: Object binding;	
+		pushLiteralVariable: Object binding;
 		returnTop;
 		ir.
 
 	aCompiledMethod := iRMethod compiledMethod.
 
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-     self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = Object).
-	^iRMethod
-
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: Object.
+	^ iRMethod
 ]
 
 { #category : #testing }
 IRBuilderTest >> testLiteralVariableClassVariable [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
-		pushLiteralVariable: (DateAndTime bindingOf: #LocalTimeZone); 	
+		pushLiteralVariable: (DateAndTime bindingOf: #LocalTimeZone);
 		returnTop;
 		ir.
 
 	aCompiledMethod := iRMethod compiledMethod.
 
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-     self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = DateAndTime localTimeZone).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: DateAndTime localTimeZone.
+	^ iRMethod
 ]
 
 { #category : #testing }
 IRBuilderTest >> testLiteralVariableGlobale [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
-		pushLiteralVariable: (testingEnvironment associationAt: #Smalltalk);	
+		pushLiteralVariable: (testingEnvironment associationAt: #Smalltalk);
 		returnTop;
 		ir.
 
 	aCompiledMethod := iRMethod compiledMethod.
 
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-     self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = Smalltalk).
-	^iRMethod
-
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: Smalltalk.
+	^ iRMethod
 ]
 
 { #category : #testing }
@@ -349,7 +321,6 @@ IRBuilderTest >> testPopTop [
 
 { #category : #'testing - blocks' }
 IRBuilderTest >> testPushClosureCopyNoCopied [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		pushReceiver;
@@ -357,22 +328,20 @@ IRBuilderTest >> testPushClosureCopyNoCopied [
 		pushLiteral: 1;
 		pushLiteral: 2;
 		send: #+;
-	      blockReturnTop;
-		jumpAheadTarget: #block;	
+		blockReturnTop;
+		jumpAheadTarget: #block;
 		send: #value;
 		returnTop;
 		ir.
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = 3).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: 3.
+	^ iRMethod
 ]
 
 { #category : #'testing - blocks' }
 IRBuilderTest >> testPushClosureCopyNoCopiedArg [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		pushReceiver;
@@ -380,8 +349,8 @@ IRBuilderTest >> testPushClosureCopyNoCopiedArg [
 		pushLiteral: 1;
 		pushTemp: #d;
 		send: #+;
-	      blockReturnTop;
-		jumpAheadTarget: #block;	
+		blockReturnTop;
+		jumpAheadTarget: #block;
 		pushLiteral: 1;
 		send: #value:;
 		returnTop;
@@ -389,14 +358,12 @@ IRBuilderTest >> testPushClosureCopyNoCopiedArg [
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = 2).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: 2.
+	^ iRMethod
 ]
 
 { #category : #'testing - blocks' }
 IRBuilderTest >> testPushClosureCopyNoCopiedArgNamed [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		pushReceiver;
@@ -404,8 +371,8 @@ IRBuilderTest >> testPushClosureCopyNoCopiedArgNamed [
 		pushLiteral: 1;
 		pushTemp: #d;
 		send: #+;
-	      blockReturnTop;
-		jumpAheadTarget: #block;	
+		blockReturnTop;
+		jumpAheadTarget: #block;
 		pushLiteral: 1;
 		send: #value:;
 		returnTop;
@@ -413,14 +380,12 @@ IRBuilderTest >> testPushClosureCopyNoCopiedArgNamed [
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = 2).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: 2.
+	^ iRMethod
 ]
 
 { #category : #'testing - blocks' }
 IRBuilderTest >> testPushClosureCopyOneCopied [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		addTemps: #(c a);
@@ -431,20 +396,19 @@ IRBuilderTest >> testPushClosureCopyOneCopied [
 		pushClosureCopyCopiedValues: #(a) args: #() jumpTo: #block;
 		pushTemp: #a;
 		blockReturnTop;
-		jumpAheadTarget: #block;	
+		jumpAheadTarget: #block;
 		send: #value;
 		returnTop;
 		ir.
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-     self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = 1).
-	^iRMethod
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: 1.
+	^ iRMethod
 ]
 
 { #category : #'testing - blocks' }
 IRBuilderTest >> testPushClosureCopyOneCopiedArg [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		addTemps: #(c a);
@@ -457,7 +421,7 @@ IRBuilderTest >> testPushClosureCopyOneCopiedArg [
 		pushTemp: #d;
 		send: #+;
 		blockReturnTop;
-		jumpAheadTarget: #block;	
+		jumpAheadTarget: #block;
 		pushLiteral: 1;
 		send: #value:;
 		returnTop;
@@ -465,14 +429,12 @@ IRBuilderTest >> testPushClosureCopyOneCopiedArg [
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-     self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = 2).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: 2.
+	^ iRMethod
 ]
 
 { #category : #'testing - blocks' }
 IRBuilderTest >> testPushClosureCopyOneCopiedTemp [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		addTemps: #(c a);
@@ -481,29 +443,28 @@ IRBuilderTest >> testPushClosureCopyOneCopiedTemp [
 		storeTemp: #a;
 		popTop;
 		pushClosureCopyCopiedValues: #(a) args: #() jumpTo: #block;
-		addTemps: #(d);  "the temp"
-		pushTemp: #a;
+		addTemps: #(d);
+		"the temp"
+			pushTemp: #a;
 		pushLiteral: 1;
 		send: #+;
-		storeTemp:  #d;
+		storeTemp: #d;
 		popTop;
 		pushTemp: #d;
 		blockReturnTop;
-		jumpAheadTarget: #block;	
+		jumpAheadTarget: #block;
 		send: #value;
 		returnTop;
 		ir.
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-     self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = 2).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: 2.
+	^ iRMethod
 ]
 
 { #category : #'testing - blocks' }
 IRBuilderTest >> testPushClosureCopyOneCopiedTempArg [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		addTemps: #(c a);
@@ -512,15 +473,16 @@ IRBuilderTest >> testPushClosureCopyOneCopiedTempArg [
 		storeTemp: #a;
 		popTop;
 		pushClosureCopyCopiedValues: #(a) args: #(e) jumpTo: #block;
-		addTemps: #(d);  "the temp"
-		pushTemp: #a;
+		addTemps: #(d);
+		"the temp"
+			pushTemp: #a;
 		pushTemp: #e;
 		send: #+;
-		storeTemp:  #d;
+		storeTemp: #d;
 		popTop;
 		pushTemp: #d;
 		blockReturnTop;
-		jumpAheadTarget: #block;	
+		jumpAheadTarget: #block;
 		pushLiteral: 1;
 		send: #value:;
 		returnTop;
@@ -528,14 +490,12 @@ IRBuilderTest >> testPushClosureCopyOneCopiedTempArg [
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-     self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = 2).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: 2.
+	^ iRMethod
 ]
 
 { #category : #testing }
 IRBuilderTest >> testPushConsArray [
-
 	| iRMethod aCompiledMethod receiver |
 	iRMethod := IRBuilder new
 		pushReceiver;
@@ -544,18 +504,16 @@ IRBuilderTest >> testPushConsArray [
 		ir.
 
 	aCompiledMethod := iRMethod compiledMethod.
-	
-	receiver :=  (5@8).
+
+	receiver := 5 @ 8.
 
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: ((aCompiledMethod valueWithReceiver: receiver arguments: #()) first == receiver).
-	^iRMethod
-
+	self assert: (aCompiledMethod valueWithReceiver: receiver arguments: #()) first identicalTo: receiver.
+	^ iRMethod
 ]
 
 { #category : #testing }
 IRBuilderTest >> testPushConsArray2 [
-
 	| iRMethod aCompiledMethod receiver |
 	iRMethod := IRBuilder new
 		pushLiteral: 'hi!';
@@ -564,13 +522,12 @@ IRBuilderTest >> testPushConsArray2 [
 		ir.
 
 	aCompiledMethod := iRMethod compiledMethod.
-	
-	receiver :=  (5@8).
+
+	receiver := 5 @ 8.
 
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: (((aCompiledMethod valueWithReceiver: receiver arguments: #()))= #('hi!')).
-	^iRMethod
-
+	self assert: (aCompiledMethod valueWithReceiver: receiver arguments: #()) equals: #('hi!').
+	^ iRMethod
 ]
 
 { #category : #testing }
@@ -595,7 +552,6 @@ IRBuilderTest >> testPushNewArray [
 
 { #category : #testing }
 IRBuilderTest >> testPushSelf [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		pushReceiver;
@@ -607,15 +563,13 @@ IRBuilderTest >> testPushSelf [
 
 
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-     self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) == UndefinedObject).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) identicalTo: UndefinedObject.
+	^ iRMethod
 ]
 
 { #category : #testing }
 IRBuilderTest >> testPushTempArgument [
-
-	| iRMethod aCompiledMethod  |
+	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		numArgs: 2;
 		addTemps: #(a b);
@@ -629,9 +583,8 @@ IRBuilderTest >> testPushTempArgument [
 
 
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-     self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #(2 8) ) = 10).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #(2 8)) equals: 10.
+	^ iRMethod
 ]
 
 { #category : #testing }
@@ -655,8 +608,7 @@ IRBuilderTest >> testPushTempTemp [
 
 { #category : #testing }
 IRBuilderTest >> testPushThisContext [
-
-	| iRMethod aCompiledMethod  |
+	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		pushThisContext;
 		send: #receiver;
@@ -665,107 +617,108 @@ IRBuilderTest >> testPushThisContext [
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: ((aCompiledMethod valueWithReceiver: 5 arguments: #() ) = 5).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: 5 arguments: #()) equals: 5.
+	^ iRMethod
 ]
 
 { #category : #'testing - blocks' }
 IRBuilderTest >> testRemoteTemp [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
-		addTemps: #(a c);  "we have one real temp"
-		createTempVectorNamed:#methodVector withVars: #(b);      "b we know will be written to, so make a tempvector entry" 
-		pushLiteral: 1;
+		addTemps: #(a c);
+		"we have one real temp"
+			createTempVectorNamed: #methodVector withVars: #(b);
+		"b we know will be written to, so make a tempvector entry"
+			pushLiteral: 1;
 		storeTemp: #a;
 		popTop;
 		pushClosureCopyCopiedValues: #(#a #c #methodVector) args: #() jumpTo: #block;
-			pushTemp: #a;                                                                                             "a is just read, so we copy it to the block"
+		pushTemp: #a;
+		"a is just read, so we copy it to the block"
 			pushLiteral: 1;
-			send: #+;
-			storeRemoteTemp: #b inVector: #methodVector;							      "b comes from tempvetor, as we do write to it"
-	     	 	blockReturnTop;
-		jumpAheadTarget: #block;	
+		send: #+;
+		storeRemoteTemp: #b inVector: #methodVector;
+		"b comes from tempvetor, as we do write to it"
+			blockReturnTop;
+		jumpAheadTarget: #block;
 		send: #value;
-		pushRemoteTemp: #b inVector: #methodVector;				
+		pushRemoteTemp: #b inVector: #methodVector;
 		returnTop;
 		ir.
-	
+
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = 2).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: 2.
+	^ iRMethod
 ]
 
 { #category : #'testing - blocks' }
 IRBuilderTest >> testRemoteTempNested [
-
 	| iRMethod aCompiledMethod |
-
-		iRMethod := IRBuilder new
-		addTemps: #(a);  "we have one real temp"
-		createTempVectorNamed:#methodVector withVars: #(b);      "b we know will be written to, so make a tempvector entry" 
-		pushLiteral: 1;
+	iRMethod := IRBuilder new
+		addTemps: #(a);
+		"we have one real temp"
+			createTempVectorNamed: #methodVector withVars: #(b);
+		"b we know will be written to, so make a tempvector entry"
+			pushLiteral: 1;
 		storeTemp: #a;
 		popTop;
 		pushClosureCopyCopiedValues: #(methodVector a) args: #() jumpTo: #block;
-		createTempVectorNamed:#blockVector withVars: #(f);    
-			pushTemp: #a;                                                                                             "a is just read, so we copy it to the block"
-				pushClosureCopyCopiedValues: #(methodVector) args: #() jumpTo: #block2;
-				pushLiteral: 1;
-				storeRemoteTemp: #b inVector: #methodVector;							      "f comes from tempvetor, as we do write to it"
-				blockReturnTop;		
-				jumpAheadTarget: #block2;	
-			send: #value;
-			send: #+;
-			storeRemoteTemp: #b inVector: #methodVector;							      "b comes from tempvetor, as we do write to it"
-	     	 	blockReturnTop;
-			
-		jumpAheadTarget: #block;	
+		createTempVectorNamed: #blockVector withVars: #(f);
+		pushTemp: #a;
+		"a is just read, so we copy it to the block"
+			pushClosureCopyCopiedValues: #(methodVector) args: #() jumpTo: #block2;
+		pushLiteral: 1;
+		storeRemoteTemp: #b inVector: #methodVector;
+		"f comes from tempvetor, as we do write to it"
+			blockReturnTop;
+		jumpAheadTarget: #block2;
 		send: #value;
-		pushRemoteTemp: #b inVector: #methodVector;				
+		send: #+;
+		storeRemoteTemp: #b inVector: #methodVector;
+		"b comes from tempvetor, as we do write to it"
+			blockReturnTop;
+		jumpAheadTarget: #block;
+		send: #value;
+		pushRemoteTemp: #b inVector: #methodVector;
 		returnTop;
 		ir.
-	
+
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #()) = 2).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: 2.
+	^ iRMethod
 ]
 
 { #category : #'testing - blocks' }
 IRBuilderTest >> testRemoteTempShadowed [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
-		addTemps: #(a);  "we have one real temp"
-		pushLiteral: 1;
+		addTemps: #(a);
+		"we have one real temp"
+			pushLiteral: 1;
 		storeTemp: #a;
 		popTop;
 		pushClosureCopyCopiedValues: #() args: #() jumpTo: #block;
-			addTemps: #(a);
-			pushTemp: #a;                                                                                             "a shadows the outer one"
+		addTemps: #(a);
+		pushTemp: #a;
+		"a shadows the outer one"
 			send: #isNil;
-	     	 	blockReturnTop;
-		jumpAheadTarget: #block;	
+		blockReturnTop;
+		jumpAheadTarget: #block;
 		send: #value;
 		returnTop;
 		ir.
-	
+
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = true).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: true.
+	^ iRMethod
 ]
 
 { #category : #testing }
 IRBuilderTest >> testReturnInstVar [
-
-	| iRMethod aCompiledMethod  |
+	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		pushInstVar: 1;
 		returnTop;
@@ -773,10 +726,8 @@ IRBuilderTest >> testReturnInstVar [
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
- 	self assert: ((aCompiledMethod valueWithReceiver: (3@4) arguments: #() ) = 3).
-	^iRMethod
-	
-	
+	self assert: (aCompiledMethod valueWithReceiver: 3 @ 4 arguments: #()) equals: 3.
+	^ iRMethod
 ]
 
 { #category : #testing }
@@ -816,8 +767,7 @@ IRBuilderTest >> testSendSuper [
 
 { #category : #testing }
 IRBuilderTest >> testStoreIntoVariable [
-
-	| iRMethod aCompiledMethod  |
+	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		pushLiteral: 4;
 		storeIntoLiteralVariable: (self class bindingOf: #TestToPush);
@@ -828,17 +778,15 @@ IRBuilderTest >> testStoreIntoVariable [
 
 
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-      aCompiledMethod valueWithReceiver: nil arguments: #().
-	self assert: (self class testToPush = 4).
+	aCompiledMethod valueWithReceiver: nil arguments: #().
+	self assert: self class testToPush equals: 4.
 	self class testToPush: nil.
-	^iRMethod
-	
+	^ iRMethod
 ]
 
 { #category : #testing }
 IRBuilderTest >> testStoreIvar [
-
-	| iRMethod aCompiledMethod  |
+	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		pushLiteral: 34;
 		storeInstVar: 2;
@@ -847,15 +795,13 @@ IRBuilderTest >> testStoreIvar [
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
- 	self assert: ((aCompiledMethod valueWithReceiver: self arguments: #() ) = 34).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: self arguments: #()) equals: 34.
+	^ iRMethod
 ]
 
 { #category : #testing }
 IRBuilderTest >> testStorePopIntoVariable [
-
-	| iRMethod aCompiledMethod  |
+	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		pushLiteral: 4;
 		storeIntoLiteralVariable: (self class bindingOf: #TestToPush);
@@ -868,17 +814,15 @@ IRBuilderTest >> testStorePopIntoVariable [
 
 
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-      aCompiledMethod valueWithReceiver: nil arguments: #().
-	self assert: (self class testToPush = 4).
+	aCompiledMethod valueWithReceiver: nil arguments: #().
+	self assert: self class testToPush equals: 4.
 	self class testToPush: nil.
-	^iRMethod
-	
+	^ iRMethod
 ]
 
 { #category : #testing }
 IRBuilderTest >> testStorePopIvar [
-
-	| iRMethod aCompiledMethod  |
+	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		pushLiteral: 34;
 		storeInstVar: 2;
@@ -889,15 +833,13 @@ IRBuilderTest >> testStorePopIvar [
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
- 	self assert: ((aCompiledMethod valueWithReceiver: self arguments: #() ) = 34).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: self arguments: #()) equals: 34.
+	^ iRMethod
 ]
 
 { #category : #testing }
 IRBuilderTest >> testStoreTemp [
-
-	| iRMethod aCompiledMethod  |
+	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
 		addTemps: #(a);
 		pushLiteral: 34;
@@ -909,7 +851,6 @@ IRBuilderTest >> testStoreTemp [
 
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
- 	self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = 34).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: 34.
+	^ iRMethod
 ]

--- a/src/OpalCompiler-Tests/IRPrinterTest.class.st
+++ b/src/OpalCompiler-Tests/IRPrinterTest.class.st
@@ -8,7 +8,10 @@ Class {
 IRPrinterTest >> testDup [
 	| ir |
 	ir := IRBuilderTest new testDup.
-	self assert: ir longPrintString = '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushLiteral: 3
 pushDup
@@ -21,8 +24,10 @@ returnTop
 IRPrinterTest >> testInstVar [
 	| ir |
 	ir := IRBuilderTest new testInstVar.
-	self assert: ir longPrintString = 
- '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushInstVar: 1
 pushInstVar: 2
@@ -35,7 +40,10 @@ returnTop
 IRPrinterTest >> testJumpAheadTo [
 	| ir |
 	ir := IRBuilderTest new testJumpAheadTo.
-	self assert: ir longPrintString =  '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushLiteral: 2
 pushLiteral: 1
@@ -51,7 +59,10 @@ returnTop
 IRPrinterTest >> testJumpAheadToIf [
 	| ir |
 	ir := IRBuilderTest new testJumpAheadToIf.
-	self assert: ir longPrintString =  '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushReceiver
 pushLiteral: true
@@ -69,7 +80,10 @@ returnTop
 IRPrinterTest >> testJumpBackTo [
 	| ir |
 	ir := IRBuilderTest new testJumpBackTo.
-	self assert: ir longPrintString =  '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushReceiver
 pushLiteral: false
@@ -90,8 +104,11 @@ returnTop
 { #category : #testing }
 IRPrinterTest >> testLiteralArray [
 	| ir |
-	ir := IRBuilderTest new testLiteralArray.  
-	self assert: ir longPrintString =  '
+	ir := IRBuilderTest new testLiteralArray.
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 returnLiteral: #(#test 4 #you)
 '
@@ -101,7 +118,10 @@ returnLiteral: #(#test 4 #you)
 IRPrinterTest >> testLiteralVariableClass [
 	| ir |
 	ir := IRBuilderTest new testLiteralVariableClass.
-	self assert: ir longPrintString =  '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushLiteralVariable: Object
 returnTop
@@ -112,7 +132,10 @@ returnTop
 IRPrinterTest >> testPopTop [
 	| ir |
 	ir := IRBuilderTest new testPopTop.
-	self assert: ir longPrintString =  '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushReceiver
 pushLiteral: false
@@ -125,7 +148,10 @@ returnTop
 IRPrinterTest >> testPushClosureCopyNoCopied [
 	| ir |
 	ir := IRBuilderTest new testPushClosureCopyNoCopied.
-	self assert: ir longPrintString =  '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushReceiver
 pushClosureCopyCopiedValues: #() args: #()
@@ -146,7 +172,10 @@ returnTop
 IRPrinterTest >> testPushConsArray [
 	| ir |
 	ir := IRBuilderTest new testPushConsArray.
-	self assert: ir longPrintString =  '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushReceiver
 pushConsArray: 1
@@ -158,7 +187,10 @@ returnTop
 IRPrinterTest >> testPushNewArray [
 	| ir |
 	ir := IRBuilderTest new testPushNewArray.
-	self assert: ir longPrintString  =  '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushNewArray: 1
 returnTop
@@ -169,7 +201,10 @@ returnTop
 IRPrinterTest >> testPushSelf [
 	| ir |
 	ir := IRBuilderTest new testPushSelf.
-	self assert: ir longPrintString =  '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushReceiver
 send: #class
@@ -181,7 +216,10 @@ returnTop
 IRPrinterTest >> testPushTempArgument [
 	| ir |
 	ir := IRBuilderTest new testPushTempArgument.
-	self assert: ir longPrintString = '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushTemp: #a
 pushTemp: #b
@@ -194,7 +232,10 @@ returnTop
 IRPrinterTest >> testPushTempTemp [
 	| ir |
 	ir := IRBuilderTest new testPushTempTemp.
-	self assert: ir longPrintString =  '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushTemp: #a
 returnTop
@@ -205,7 +246,10 @@ returnTop
 IRPrinterTest >> testPushThisContext [
 	| ir |
 	ir := IRBuilderTest new testPushThisContext.
-	self assert: ir longPrintString =  '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushThisContext
 send: #receiver
@@ -242,7 +286,10 @@ returnTop
 IRPrinterTest >> testRemoteTempNested [
 	| ir |
 	ir := IRBuilderTest new testRemoteTempNested.
-	self assert: ir longPrintString =   '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 createTempVectorNamed: #methodVector withVars: #(#b)
 pushLiteral: 1
@@ -276,7 +323,10 @@ returnTop
 IRPrinterTest >> testReturnTop [
 	| ir |
 	ir := IRBuilderTest new testReturnTop.
-	self assert: ir longPrintString =  '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 returnLiteral: false
 '
@@ -286,7 +336,10 @@ returnLiteral: false
 IRPrinterTest >> testSendSuper [
 	| ir |
 	ir := IRBuilderTest new testSendSuper.
-	self assert: ir longPrintString =  '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushReceiver
 send: #isThisEverCalled toSuperOf: IRBuilderTest
@@ -298,7 +351,10 @@ returnTop
 IRPrinterTest >> testStoreIntoVariable [
 	| ir |
 	ir := IRBuilderTest new testStoreIntoVariable.
-	self assert: ir longPrintString =  '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushLiteral: 4
 storeLiteralVariable: TestToPush
@@ -310,7 +366,10 @@ returnTop
 IRPrinterTest >> testStoreTemp [
 	| ir |
 	ir := IRBuilderTest new testStoreTemp.
-	self assert: ir longPrintString = '
+	self
+		assert: ir longPrintString
+		equals:
+			'
 label: 1
 pushLiteral: 34
 popIntoTemp: #a

--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -39,18 +39,12 @@ MethodMapTest >> parseExpression: aString [
 
 { #category : #'testing - ast mapping' }
 MethodMapTest >> testBlockAndContextSourceNode [
-		
-	|block blockNodeViaContext blockNodeViaClosure |
-
-
-	block := [blockNodeViaContext := thisContext sourceNode].
+	| block blockNodeViaContext blockNodeViaClosure |
+	block := [ blockNodeViaContext := thisContext sourceNode ].
 	block value.
 	blockNodeViaClosure := block sourceNode.
 
-	self assert: blockNodeViaContext == blockNodeViaClosure
-	
-
-
+	self assert: blockNodeViaContext identicalTo: blockNodeViaClosure
 ]
 
 { #category : #'testing - ast mapping' }

--- a/src/OpalCompiler-Tests/MethodPragmaTest.class.st
+++ b/src/OpalCompiler-Tests/MethodPragmaTest.class.st
@@ -69,20 +69,24 @@ MethodPragmaTest >> testAllNamedFromTo [
 MethodPragmaTest >> testAllNamedFromToSortedByArgument [
 	| pragmasCompiled pragmasDetected |
 	pragmasCompiled := self pragma: #foo: selector: #bar times: 5.
-	pragmasDetected := Pragma allNamed: #foo: from: self class to: Object sortedByArgument: 1.
-	self assert: pragmasDetected = (pragmasCompiled 
-		sort: [ :a :b | (a argumentAt: 1) < (b argumentAt: 1) ])
+	pragmasDetected := Pragma
+		allNamed: #foo:
+		from: self class
+		to: Object
+		sortedByArgument: 1.
+	self assert: pragmasDetected equals: (pragmasCompiled sort: [ :a :b | (a argumentAt: 1) < (b argumentAt: 1) ])
 ]
 
 { #category : #'testing-finding' }
 MethodPragmaTest >> testAllNamedFromToSortedUsing [
 	| pragmasCompiled pragmasDetected |
 	pragmasCompiled := self pragma: #foo: selector: #bar times: 5.
-	pragmasDetected := Pragma 
-		allNamed: #foo: from: self class to: Object 
+	pragmasDetected := Pragma
+		allNamed: #foo:
+		from: self class
+		to: Object
 		sortedUsing: [ :a :b | (a argumentAt: 1) > (b argumentAt: 1) ].
-	self assert: pragmasDetected = (pragmasCompiled 
-		sort: [ :a :b | (a argumentAt: 1) > (b argumentAt: 1) ]).
+	self assert: pragmasDetected equals: (pragmasCompiled sort: [ :a :b | (a argumentAt: 1) > (b argumentAt: 1) ])
 ]
 
 { #category : #'testing-finding' }
@@ -90,7 +94,7 @@ MethodPragmaTest >> testAllNamedIn [
 	| pragmasCompiled pragmasDetected |
 	pragmasCompiled := self pragma: #foo: selector: #bar times: 5.
 	pragmasDetected := Pragma allNamed: #foo: in: self class.
-	self assert: pragmasDetected = pragmasCompiled.
+	self assert: pragmasDetected equals: pragmasCompiled.
 
 	pragmasDetected := Pragma allNamed: #foo: in: Object.
 	self assertEmpty: pragmasDetected
@@ -101,19 +105,15 @@ MethodPragmaTest >> testAllNamedInSortedByArgument [
 	| pragmasCompiled pragmasDetected |
 	pragmasCompiled := self pragma: #foo: selector: #bar times: 5.
 	pragmasDetected := Pragma allNamed: #foo: in: self class sortedByArgument: 1.
-	self assert: pragmasDetected = (pragmasCompiled 
-		sort: [ :a :b | (a argumentAt: 1) < (b argumentAt: 1) ])
+	self assert: pragmasDetected equals: (pragmasCompiled sort: [ :a :b | (a argumentAt: 1) < (b argumentAt: 1) ])
 ]
 
 { #category : #'testing-finding' }
 MethodPragmaTest >> testAllNamedInSortedUsing [
 	| pragmasCompiled pragmasDetected |
 	pragmasCompiled := self pragma: #foo: selector: #bar times: 5.
-	pragmasDetected := Pragma 
-		allNamed: #foo: in: self class 
-		sortedUsing: [ :a :b | (a argumentAt: 1) > (b argumentAt: 1) ].
-	self assert: pragmasDetected = (pragmasCompiled 
-		sort: [ :a :b | (a argumentAt: 1) > (b argumentAt: 1) ]).
+	pragmasDetected := Pragma allNamed: #foo: in: self class sortedUsing: [ :a :b | (a argumentAt: 1) > (b argumentAt: 1) ].
+	self assert: pragmasDetected equals: (pragmasCompiled sort: [ :a :b | (a argumentAt: 1) > (b argumentAt: 1) ])
 ]
 
 { #category : #testing }
@@ -243,28 +243,28 @@ MethodPragmaTest >> testMessage [
 MethodPragmaTest >> testMethod [
 	| pragma |
 	pragma := self pragma: 'foo' selector: #bar.
-	self assert: pragma method == (self class >> #bar).
+	self assert: pragma method identicalTo: self class >> #bar
 ]
 
 { #category : #'testing-method' }
 MethodPragmaTest >> testMethodClass [
 	| pragma |
 	pragma := self pragma: 'foo' selector: #bar.
-	self assert: pragma methodClass == self class.
+	self assert: pragma methodClass identicalTo: self class
 ]
 
 { #category : #'testing-method' }
 MethodPragmaTest >> testMethodSelector [
 	| pragma |
 	pragma := self pragma: 'foo' selector: #bar.
-	self assert: pragma methodSelector == #bar.
+	self assert: pragma methodSelector identicalTo: #bar
 ]
 
 { #category : #'testing-compiled' }
 MethodPragmaTest >> testNoPragma [
 	| method |
 	method := self compile: '' selector: #foo.
-	self assert: method pragmas = #().
+	self assert: method pragmas equals: #()
 ]
 
 { #category : #testing }
@@ -281,9 +281,9 @@ MethodPragmaTest >> testNumArgs [
 { #category : #'testing-primitives' }
 MethodPragmaTest >> testPrimitiveIndexed1 [
 	"This test useses the #instVarAt: primitive."
-	
+
 	self compile: '<primitive: 74> ^ #inst' selector: #inst.
-	self assert: self inst = #inst.
+	self assert: self inst equals: #inst
 ]
 
 { #category : #'testing-primitives' }
@@ -291,7 +291,7 @@ MethodPragmaTest >> testPrimitiveIndexed2 [
 	"This test useses the #identityHash primitive."
 
 	self compile: '<primitive: 75> ^ #idHash' selector: #idHash.
-	self assert: self idHash = self basicIdentityHash.
+	self assert: self idHash equals: self basicIdentityHash
 ]
 
 { #category : #'testing-primitives' }
@@ -327,8 +327,8 @@ MethodPragmaTest >> testPrimitiveNamedErrorCode2 [
 { #category : #'testing-pragma' }
 MethodPragmaTest >> testSelector [
 	| pragma |
-	pragma := Pragma selector: #foo: arguments: #( 123 ).
-	self assert: pragma selector = #foo:.
+	pragma := Pragma selector: #foo: arguments: #(123).
+	self assert: pragma selector equals: #foo:
 ]
 
 { #category : #testing }
@@ -354,8 +354,8 @@ MethodPragmaTest >> testWithArgumentsDo [
 			(pragma
 				withArgumentsDo: [ :a :b | 
 					self
-						assert: a = 1;
-						assert: b = 2.
+						assert: a equals: 1;
+						assert: b equals: 2.
 					wasHere := true ]).
 	self assert: wasHere
 ]

--- a/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
@@ -16,43 +16,40 @@ OCASTCheckerTest >> nameAnalysisNoClosureIn: class for: ast [
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testDoubleRemoteAnidatedBlocks [
 	| ast scopes |
-	ast := (OCOpalExamples>>#doubleRemoteAnidatedBlocks) parseTree.
+	ast := (OCOpalExamples >> #doubleRemoteAnidatedBlocks) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 2.
-	
-	self assert:  (ast scope lookupVar: 'last') isEscaping.
+	self assert: ast scope tempVars size equals: 2.
+
+	self assert: (ast scope lookupVar: 'last') isEscaping.
 	self assert: (ast scope lookupVar: 'val') isEscaping.
-	
+
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
-	self assert: scopes size = 4.
-	
-	self assert: (scopes second lookupVar: 'i') isEscaping. "This is due to the inlined block."
+	self assert: scopes size equals: 4.
 
-	
-	self assert: scopes third tempVars size = 1.
-	self deny: (scopes third lookupVar: 'continue') isEscaping. "It is not escaping since is being accessed in an optimized block."
+	self assert: (scopes second lookupVar: 'i') isEscaping.	"This is due to the inlined block."
 
 
-
+	self assert: scopes third tempVars size equals: 1.
+	self deny: (scopes third lookupVar: 'continue') isEscaping	"It is not escaping since is being accessed in an optimized block."
 ]
 
 { #category : #'testing - simple' }
 OCASTCheckerTest >> testExampleIfNotNilReturnNil [
 	| ast |
-	ast := (OCOpalExamples>>#exampleIfNotNilReturnNil) parseTree.
+	ast := (OCOpalExamples >> #exampleIfNotNilReturnNil) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 0.
+	self assert: ast scope tempVars size equals: 0
 ]
 
 { #category : #'testing - blocks - optimized' }
 OCASTCheckerTest >> testExampleInlineBlockCollectionLR3 [
 	| ast |
-	ast := (OCOpalExamples>>#exampleInlineBlockCollectionLR3) parseTree.
+	ast := (OCOpalExamples >> #exampleInlineBlockCollectionLR3) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 1. "index is a temp of the outer method due to optimized block"
+	self assert: ast scope tempVars size equals: 1	"index is a temp of the outer method due to optimized block"
 ]
 
 { #category : #'testing - primitives' }
@@ -124,10 +121,10 @@ OCASTCheckerTest >> testExampleThisContext [
 { #category : #'testing - blocks - optimized' }
 OCASTCheckerTest >> testExampleToDoArgument [
 	| ast |
-	ast := (OCOpalExamples>>#exampleToDoArgument) parseTree.
+	ast := (OCOpalExamples >> #exampleToDoArgument) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 0.
+	self assert: ast scope tempVars size equals: 0
 ]
 
 { #category : #'testing - variables' }
@@ -148,120 +145,99 @@ OCASTCheckerTest >> testInstanceVar [
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testNoRemoteBlockArgument [
 	| ast |
-	ast := (OCOpalExamples>>#noRemoteBlockArgument) parseTree.
+	ast := (OCOpalExamples >> #noRemoteBlockArgument) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 3.
-	
-	self deny: (ast scope lookupVar: 'block') isEscaping .
+	self assert: ast scope tempVars size equals: 3.
+
+	self deny: (ast scope lookupVar: 'block') isEscaping.
 	self deny: (ast scope lookupVar: 'block1') isEscaping.
-	self deny: (ast scope lookupVar: 'block2') isEscaping.
-
-
-
+	self deny: (ast scope lookupVar: 'block2') isEscaping
 ]
 
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testNoRemoteBlockReturn [
 	| ast |
-	ast := (OCOpalExamples>>#noRemoteBlockReturn) parseTree.
+	ast := (OCOpalExamples >> #noRemoteBlockReturn) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 0.
-	
-
-
-
+	self assert: ast scope tempVars size equals: 0
 ]
 
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testNoRemoteBlockTemp [
 	| ast |
-	ast := (OCOpalExamples>>#noRemoteBlockTemp) parseTree.
+	ast := (OCOpalExamples >> #noRemoteBlockTemp) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 3.
-	
+	self assert: ast scope tempVars size equals: 3.
+
 	self deny: (ast scope lookupVar: 'block') isEscaping.
 	self deny: (ast scope lookupVar: 'block1') isEscaping.
-	self deny: (ast scope lookupVar: 'block2') isEscaping.
-
-
-
+	self deny: (ast scope lookupVar: 'block2') isEscaping
 ]
 
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testNoRemoteMethodTemp [
 	| ast |
-	ast := (OCOpalExamples>>#noRemoteMethodTemp) parseTree.
+	ast := (OCOpalExamples >> #noRemoteMethodTemp) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 2.
-	
+	self assert: ast scope tempVars size equals: 2.
+
 	self deny: (ast scope lookupVar: 'block1') isEscaping.
-	self deny: (ast scope lookupVar: 'block2') isEscaping.
-	
-
-
-
+	self deny: (ast scope lookupVar: 'block2') isEscaping
 ]
 
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testOptimizedBlockWrittenAfterClosedOverCase1 [
 	| ast scopes |
-	ast := (OCOpalExamples>>#optimizedBlockWrittenAfterClosedOverCase1) parseTree.
+	ast := (OCOpalExamples >> #optimizedBlockWrittenAfterClosedOverCase1) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 1.
-	
-	self deny: (ast scope lookupVar: 'index') isEscaping. 
-	self assert: (ast scope lookupVar: 'index') definingScope  = ast scope.
-	
+	self assert: ast scope tempVars size equals: 1.
+
+	self deny: (ast scope lookupVar: 'index') isEscaping.
+	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
+
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
-	
+
 	self assert: (scopes third lookupVar: 'temp') isWrite.
-	self assert: (scopes third lookupVar: 'temp') isEscaping.
-
-
+	self assert: (scopes third lookupVar: 'temp') isEscaping
 ]
 
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testOptimizedBlockWrittenAfterClosedOverCase2 [
 	| ast scopes |
-	ast := (OCOpalExamples>>#optimizedBlockWrittenAfterClosedOverCase2) parseTree.
+	ast := (OCOpalExamples >> #optimizedBlockWrittenAfterClosedOverCase2) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 1.
-	
-	self deny: (ast scope lookupVar: 'index') isEscaping. 
-	self assert: (ast scope lookupVar: 'index') definingScope= ast scope.
-	
+	self assert: ast scope tempVars size equals: 1.
+
+	self deny: (ast scope lookupVar: 'index') isEscaping.
+	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
+
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
-	
-	self assert: ( scopes third lookupVar: 'temp') isEscapingWrite.
-	self assert: ( scopes third lookupVar: 'temp') isEscaping.
 
-
+	self assert: (scopes third lookupVar: 'temp') isEscapingWrite.
+	self assert: (scopes third lookupVar: 'temp') isEscaping
 ]
 
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testOptimizedBlocksAndSameNameTemps [
 	| ast scopes |
-	ast := (OCOpalExamples>>#optimizedBlocksAndSameNameTemps) parseTree.
+	ast := (OCOpalExamples >> #optimizedBlocksAndSameNameTemps) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 2.
-	
+	self assert: ast scope tempVars size equals: 2.
+
 	self deny: (ast scope lookupVar: 's') isRemote.
 	self deny: (ast scope lookupVar: 'c') isRemote.
-	
+
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
-	
+
 	self deny: (scopes second lookupVar: 'a') isRemote.
-	self deny: (scopes fourth lookupVar: 'i') isRemote.
-
-
-
+	self deny: (scopes fourth lookupVar: 'i') isRemote
 ]
 
 { #category : #'testing - simple' }
@@ -293,85 +269,72 @@ OCASTCheckerTest >> testSemanticAnalysisOnNonMethodNode [
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testSingleRemoteDifferentBlocksSameArgumentName [
 	| ast |
-	ast := (OCOpalExamples>>#singleRemoteDifferentBlocksSameArgumentName) parseTree.
+	ast := (OCOpalExamples >> #singleRemoteDifferentBlocksSameArgumentName) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 3.
-	
+	self assert: ast scope tempVars size equals: 3.
+
 	self deny: (ast scope lookupVar: 'b') isEscaping.
 	self deny: (ast scope lookupVar: 'c') isEscaping.
-	self assert: (ast scope lookupVar: 'z') isEscaping.
-
-
-
+	self assert: (ast scope lookupVar: 'z') isEscaping
 ]
 
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testSingleRemoteMethodArgument [
 	| ast |
-	ast := (OCOpalExamples>>#singleRemoteMethodArgument) parseTree.
+	ast := (OCOpalExamples >> #singleRemoteMethodArgument) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 2.
-	
+	self assert: ast scope tempVars size equals: 2.
+
 	self deny: (ast scope lookupVar: 'block') isEscaping.
 	self assert: (ast scope lookupVar: 'temp') isEscaping.
-	self assert: (ast scope lookupVar: 'temp') isWrite.
-
-
-
+	self assert: (ast scope lookupVar: 'temp') isWrite
 ]
 
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testSingleRemoteTempVar [
 	| ast |
-	ast := (OCOpalExamples>>#singleRemoteTempVar) parseTree.
+	ast := (OCOpalExamples >> #singleRemoteTempVar) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 3.
-	
+	self assert: ast scope tempVars size equals: 3.
+
 	self assert: (ast scope lookupVar: 'index') isEscaping.
-	self assert: (ast scope lookupVar: 'index') definingScope = ast scope.
+	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
 	self deny: (ast scope lookupVar: 'block') isEscaping.
 	self assert: (ast scope lookupVar: 'theCollection') isEscaping.
 	self assert: (ast scope lookupVar: 'block') isTemp.
 	self assert: (ast scope lookupVar: 'theCollection') isTemp.
 	self deny: (ast scope lookupVar: 'theCollection') isInstance.
 	self deny: (ast scope lookupVar: 'index') isInstance.
-	self deny: (ast scope lookupVar: 'block') isInstance.
-
-
+	self deny: (ast scope lookupVar: 'block') isInstance
 ]
 
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testsingleRemoteTempVarWhileWithTempNotInlined [
 	| ast |
-	ast := (OCOpalExamples>>#exampleWhileWithTempNotInlined) parseTree.
+	ast := (OCOpalExamples >> #exampleWhileWithTempNotInlined) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 2.
-	
+	self assert: ast scope tempVars size equals: 2.
+
 	self assert: (ast scope lookupVar: 'index') isEscaping.
-	self assert: (ast scope lookupVar: 'index') definingScope = ast scope.
+	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
 	self deny: (ast scope lookupVar: 'block') isEscaping.
-	self assert: (ast scope lookupVar: 'block') isTemp.
-
-
-
+	self assert: (ast scope lookupVar: 'block') isTemp
 ]
 
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testsingleRemoteTempVarWrittenAfterClosedOver [
 	| ast |
-	ast := (OCOpalExamples>>#singleRemoteTempVarWrittenAfterClosedOver) parseTree.
+	ast := (OCOpalExamples >> #singleRemoteTempVarWrittenAfterClosedOver) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 2.
-	
+	self assert: ast scope tempVars size equals: 2.
+
 	self assert: (ast scope lookupVar: 'index') isWrite.
-	self assert: (ast scope lookupVar: 'index') definingScope = ast scope.
+	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
 	self deny: (ast scope lookupVar: 'block') isEscaping.
-	self assert: (ast scope lookupVar: 'block') isTemp.
-
-
+	self assert: (ast scope lookupVar: 'block') isTemp
 ]

--- a/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
@@ -18,64 +18,50 @@ OCASTClosureAnalyzerTest >> testBlockArgumentIsArgumentVariable [
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testDoubleRemoteAnidatedBlocks [
 	| ast scopes |
-	ast := (OCOpalExamples>>#doubleRemoteAnidatedBlocks) parseTree.
+	ast := (OCOpalExamples >> #doubleRemoteAnidatedBlocks) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 0.
-	self assert: ast scope tempVector size = 2.
-	
+	self assert: ast scope tempVars size equals: 0.
+	self assert: ast scope tempVector size equals: 2.
+
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
-	
+
 	self assert: (ast scope lookupVar: 'last') isRemote.
 	self assert: (ast scope lookupVar: 'val') isRemote.
-	self assert: (ast scope lookupVar: 'val') vectorName = '0vector0'.
-	self deny: (scopes second  lookupVar: 'i') isRemote. 
-	
-
-	
-	
-
-
-
+	self assert: (ast scope lookupVar: 'val') vectorName equals: '0vector0'.
+	self deny: (scopes second lookupVar: 'i') isRemote
 ]
 
 { #category : #'tests - blocks' }
 OCASTClosureAnalyzerTest >> testExampleBlockArgument [
 	| ast blockScope blockScope2 |
-	ast := (OCOpalExamples>>#exampleBlockArgument) parseTree.
+	ast := (OCOpalExamples >> #exampleBlockArgument) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 3.
-	self assert: ast scope tempVector size = 0.
-	self assert: ast scope copiedVars size = 0.
-	
-	self deny: (ast scope lookupVar: 'block') isRemote. 
-	self deny: (ast scope lookupVar: 'block1') isRemote. 
-	self deny: (ast scope lookupVar: 'block2') isRemote. 
-	
+	self assert: ast scope tempVars size equals: 3.
+	self assert: ast scope tempVector size equals: 0.
+	self assert: ast scope copiedVars size equals: 0.
+
+	self deny: (ast scope lookupVar: 'block') isRemote.
+	self deny: (ast scope lookupVar: 'block1') isRemote.
+	self deny: (ast scope lookupVar: 'block2') isRemote.
+
 	blockScope := (OCScopesCollector new visitNode: ast) scopes second.
-	
-	self assert: blockScope tempVars size = 2.
-	self assert: blockScope tempVector size = 0.
-	self assert: blockScope copiedVars size = 1.
+
+	self assert: blockScope tempVars size equals: 2.
+	self assert: blockScope tempVector size equals: 0.
+	self assert: blockScope copiedVars size equals: 1.
 	self deny: (blockScope lookupVar: 'temp') isRemote.
 	self assert: (blockScope lookupVar: 'temp') isEscapingRead.
 	self assert: (blockScope lookupVar: 'temp') isWrite.
 	self deny: (blockScope lookupVar: 'temp') isEscapingWrite.
 	self deny: (blockScope lookupVar: 'arg') isRemote.
-	
-	
+
+
 	blockScope2 := (OCScopesCollector new visitNode: ast) scopes third.
-	self assert: blockScope2 tempVars size = 0.
-	self assert: blockScope2 tempVector size = 0.
-	self assert: blockScope2 copiedVars size = 1.
-	
-	
-	
-	
-
-
-
+	self assert: blockScope2 tempVars size equals: 0.
+	self assert: blockScope2 tempVector size equals: 0.
+	self assert: blockScope2 copiedVars size equals: 1
 ]
 
 { #category : #'tests - optimized blocks' }
@@ -93,104 +79,74 @@ OCASTClosureAnalyzerTest >> testExampleSimpleBlockLocalIf [
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testExampleSimpleBlockLocalWhile [
 	| ast scopes |
-	ast := (OCOpalExamples>>#exampleSimpleBlockLocalWhile) parseTree.
+	ast := (OCOpalExamples >> #exampleSimpleBlockLocalWhile) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	
-	self assert: ast scope tempVars size = 0.
-	self assert: ast scope tempVector size = 1.
+
+	self assert: ast scope tempVars size equals: 0.
+	self assert: ast scope tempVector size equals: 1.
 	self assert: (ast scope lookupVar: 'a') isRemote.
-	
+
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
-	
-	self assert: scopes second tempVars size = 1.
-	self assert: scopes second tempVector size = 0.
+
+	self assert: scopes second tempVars size equals: 1.
+	self assert: scopes second tempVector size equals: 0.
 	self deny: (scopes second lookupVar: 'b') isRemote.
 	self assert: (scopes second lookupVar: 'b') isArg.
-	self deny: (scopes fourth lookupVar: 'hallo') isRemote.
-	
-
-
-	
-
-	
-	
-
-
-
+	self deny: (scopes fourth lookupVar: 'hallo') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testExampleSimpleBlockNested [
 	| ast scopes |
-	ast := (OCOpalExamples>>#exampleSimpleBlockNested) parseTree.
+	ast := (OCOpalExamples >> #exampleSimpleBlockNested) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	
-	self assert: ast scope tempVars size = 2.
-	self assert: ast scope tempVector size = 1.
+
+	self assert: ast scope tempVars size equals: 2.
+	self assert: ast scope tempVector size equals: 1.
 	self deny: (ast scope lookupVar: 'a') isRemote.
 	self deny: (ast scope lookupVar: 'dict') isRemote.
 	self assert: (ast scope lookupVar: 'match') isRemote.
-	
+
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
-	
-	self assert: scopes second tempVars size = 2.
-	self assert: scopes second tempVector size = 0.
+
+	self assert: scopes second tempVars size equals: 2.
+	self assert: scopes second tempVector size equals: 0.
 	self deny: (scopes second lookupVar: 'each') isRemote.
 	self deny: (scopes second lookupVar: 'index') isRemote.
-	
-	self assert: scopes second copiedVars size = 3
 
-
-	
-
-	
-	
-
-
-
+	self assert: scopes second copiedVars size equals: 3
 ]
 
 { #category : #'tests - blocks' }
 OCASTClosureAnalyzerTest >> testExampleWhileModificationBefore [
 	| ast |
-	ast := (OCOpalExamples>>#exampleWhileModificationBefore) parseTree.
+	ast := (OCOpalExamples >> #exampleWhileModificationBefore) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 0.
-	self assert: ast scope tempVector size = 1.
-	self assert: ast scope copiedVars size = 1.
-	
-	self assert: (ast scope lookupVar: 'index') isRemote. 
-	
+	self assert: ast scope tempVars size equals: 0.
+	self assert: ast scope tempVector size equals: 1.
+	self assert: ast scope copiedVars size equals: 1.
 
-	
-
-
-
+	self assert: (ast scope lookupVar: 'index') isRemote
 ]
 
 { #category : #'tests - blocks' }
 OCASTClosureAnalyzerTest >> testExampleWhileNoModification [
-"A block in an optimized loop with no modification on temp vars in the loop
+	"A block in an optimized loop with no modification on temp vars in the loop
 only needs to copy the tempvars. No write -> no indirection vector."
+
 	| ast |
-	ast := (OCOpalExamples>>#exampleWhileNoModification) parseTree.
+	ast := (OCOpalExamples >> #exampleWhileNoModification) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 3.
-	self assert: ast scope tempVector size = 0.
-	self assert: ast scope copiedVars size = 3.
-	self deny: (ast scope lookupVar: 'a') isRemote. 
-	self deny: (ast scope lookupVar: 'b') isRemote. 
-	self deny: (ast scope lookupVar: 'c') isRemote. 
-	
-
-	
-
-
-
+	self assert: ast scope tempVars size equals: 3.
+	self assert: ast scope tempVector size equals: 0.
+	self assert: ast scope copiedVars size equals: 3.
+	self deny: (ast scope lookupVar: 'a') isRemote.
+	self deny: (ast scope lookupVar: 'b') isRemote.
+	self deny: (ast scope lookupVar: 'c') isRemote
 ]
 
 { #category : #'testing - variables' }
@@ -217,412 +173,293 @@ OCASTClosureAnalyzerTest >> testMethodArgumentIsArgumentVariable [
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testNestedBlocksRemoteInBlockCase1 [
 	| ast scopes |
-	ast := (OCOpalExamples>>#nestedBlocksRemoteInBlockCase1) parseTree.
+	ast := (OCOpalExamples >> #nestedBlocksRemoteInBlockCase1) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	
-	self assert: ast scope tempVars size = 1.
-	self assert: ast scope tempVector size = 0.
+
+	self assert: ast scope tempVars size equals: 1.
+	self assert: ast scope tempVector size equals: 0.
 	self deny: (ast scope lookupVar: 'block') isRemote.
-	
+
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
-	
-	self assert: scopes second tempVars size = 0.
-	self assert: scopes second tempVector size = 2.
+
+	self assert: scopes second tempVars size equals: 0.
+	self assert: scopes second tempVector size equals: 2.
 	self assert: (scopes second tempVector at: 'a') isRemote.
-	self assert: (scopes second tempVector at: 'b') isRemote.
-
-
-	
-
-	
-	
-
-
-
+	self assert: (scopes second tempVector at: 'b') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testNestedBlocksRemoteInBlockCase2 [
 	| ast scopes |
-	ast := (OCOpalExamples>>#nestedBlocksRemoteInBlockCase2) parseTree.
+	ast := (OCOpalExamples >> #nestedBlocksRemoteInBlockCase2) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	
-	self assert: ast scope tempVars size = 1.
-	self assert: ast scope tempVector size = 0.
+
+	self assert: ast scope tempVars size equals: 1.
+	self assert: ast scope tempVector size equals: 0.
 	self deny: (ast scope lookupVar: 'block') isRemote.
-	
+
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
-	
-	self assert: scopes second tempVars size = 0.
-	self assert: scopes second tempVector size = 0.
-	
-	self assert: scopes third tempVars size = 0.
-	self assert: scopes third tempVector size = 1.
+
+	self assert: scopes second tempVars size equals: 0.
+	self assert: scopes second tempVector size equals: 0.
+
+	self assert: scopes third tempVars size equals: 0.
+	self assert: scopes third tempVector size equals: 1.
 	self assert: (scopes third tempVector at: 'a') isRemote.
-	
-	self assert: scopes fourth tempVars size = 0.
-	self assert: scopes fourth tempVector size = 0.
-	
-	self assert: scopes fifth tempVars size = 0.
-	self assert: scopes fifth tempVector size = 1.
-	self assert: (scopes fifth tempVector at: 'b') isRemote.
 
+	self assert: scopes fourth tempVars size equals: 0.
+	self assert: scopes fourth tempVector size equals: 0.
 
-	
-
-	
-	
-
-
-
+	self assert: scopes fifth tempVars size equals: 0.
+	self assert: scopes fifth tempVector size equals: 1.
+	self assert: (scopes fifth tempVector at: 'b') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testNestedBlocksRemoteInBlockCase3 [
 	| ast scopes |
-	ast := (OCOpalExamples>>#nestedBlocksRemoteInBlockCase3) parseTree.
+	ast := (OCOpalExamples >> #nestedBlocksRemoteInBlockCase3) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	
-	self assert: ast scope tempVars size = 0.
-	self assert: ast scope tempVector size = 1.
+
+	self assert: ast scope tempVars size equals: 0.
+	self assert: ast scope tempVector size equals: 1.
 	self assert: (ast scope lookupVar: 'block') isRemote.
-	
+
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
-	
-	self assert: scopes second tempVars size = 0.
-	self assert: scopes second tempVector size = 0.
-	
-	self assert: scopes third tempVars size = 0.
-	self assert: scopes third tempVector size = 1.
+
+	self assert: scopes second tempVars size equals: 0.
+	self assert: scopes second tempVector size equals: 0.
+
+	self assert: scopes third tempVars size equals: 0.
+	self assert: scopes third tempVector size equals: 1.
 	self assert: (scopes third tempVector at: 'a') isRemote.
-	
-	self assert: scopes fourth tempVars size = 0.
-	self assert: scopes fourth tempVector size = 0.
-	
-	self assert: scopes fifth tempVars size = 0.
-	self assert: scopes fifth tempVector size = 1.
-	self assert: (scopes fifth tempVector at: 'b') isRemote.
 
+	self assert: scopes fourth tempVars size equals: 0.
+	self assert: scopes fourth tempVector size equals: 0.
 
-	
-
-	
-	
-
-
-
+	self assert: scopes fifth tempVars size equals: 0.
+	self assert: scopes fifth tempVector size equals: 1.
+	self assert: (scopes fifth tempVector at: 'b') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testNoRemoteBlockArgument [
 	| ast |
-	ast := (OCOpalExamples>>#noRemoteBlockArgument) parseTree.
+	ast := (OCOpalExamples >> #noRemoteBlockArgument) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 3.
-	
-	self deny: (ast scope lookupVar: 'block') isRemote .
+	self assert: ast scope tempVars size equals: 3.
+
+	self deny: (ast scope lookupVar: 'block') isRemote.
 	self deny: (ast scope lookupVar: 'block1') isRemote.
-	self deny: (ast scope lookupVar: 'block2') isRemote.
-
-
-
+	self deny: (ast scope lookupVar: 'block2') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testNoRemoteReadInBlock [
 	| ast |
-	ast := (OCOpalExamples>>#noRemoteReadInBlock) parseTree.
+	ast := (OCOpalExamples >> #noRemoteReadInBlock) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 1.
-	self assert: ast scope tempVector size = 0.
-	
-	self deny: (ast scope lookupVar: 'a') isRemote.
+	self assert: ast scope tempVars size equals: 1.
+	self assert: ast scope tempVector size equals: 0.
 
-	
-
-	
-	
-
-
-
+	self deny: (ast scope lookupVar: 'a') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testNoRemoteReadNestedBlocks [
 	| ast scopes |
-	ast := (OCOpalExamples>>#noRemoteReadNestedBlocks) parseTree.
+	ast := (OCOpalExamples >> #noRemoteReadNestedBlocks) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 0.
-	self assert: ast scope tempVector size = 0.
-	
+	self assert: ast scope tempVars size equals: 0.
+	self assert: ast scope tempVector size equals: 0.
+
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
-	self assert: scopes second tempVars size = 1.
-	self assert: scopes second tempVector size = 0.
-	self deny: (scopes second lookupVar: 'a') isRemote.
-
-	
-
-	
-	
-
-
-
+	self assert: scopes second tempVars size equals: 1.
+	self assert: scopes second tempVector size equals: 0.
+	self deny: (scopes second lookupVar: 'a') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testOptimizedBlockReadInBlock [
 	| ast |
-	ast := (OCOpalExamples>>#optimizedBlockReadInBlock) parseTree.
+	ast := (OCOpalExamples >> #optimizedBlockReadInBlock) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	
-	self assert: ast scope tempVars size = 1.
-	self assert: ast scope tempVector size = 0.
-	self deny: (ast scope lookupVar: 't1') isRemote.
-	
 
-
-	
-
-	
-	
-
-
-
+	self assert: ast scope tempVars size equals: 1.
+	self assert: ast scope tempVector size equals: 0.
+	self deny: (ast scope lookupVar: 't1') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testOptimizedBlockWriteInBlock [
 	| ast |
-	ast := (OCOpalExamples>>#optimizedBlockWriteInBlock) parseTree.
+	ast := (OCOpalExamples >> #optimizedBlockWriteInBlock) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	
-	self assert: ast scope tempVars size = 1.
-	self assert: ast scope tempVector size = 0.
-	self deny: (ast scope lookupVar: 't1') isRemote.
-	
 
-
-	
-
-	
-	
-
-
-
+	self assert: ast scope tempVars size equals: 1.
+	self assert: ast scope tempVector size equals: 0.
+	self deny: (ast scope lookupVar: 't1') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testOptimizedBlockWriteInNestedBlock [
 	| ast |
-	ast := (OCOpalExamples>>#optimizedBlockWriteInNestedBlock) parseTree.
+	ast := (OCOpalExamples >> #optimizedBlockWriteInNestedBlock) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	
-	self assert: ast scope tempVars size = 0.
-	self assert: ast scope tempVector size = 1.
-	self assert: (ast scope lookupVar: 't1') isRemote.
-	
 
-
-	
-
-	
-	
-
-
-
+	self assert: ast scope tempVars size equals: 0.
+	self assert: ast scope tempVector size equals: 1.
+	self assert: (ast scope lookupVar: 't1') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testOptimizedBlockWriteInNestedBlockCase2 [
 	| ast |
-	ast := (OCOpalExamples>>#optimizedBlockWriteInNestedBlockCase2) parseTree.
+	ast := (OCOpalExamples >> #optimizedBlockWriteInNestedBlockCase2) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	
-	self assert: ast scope tempVars size = 1.
-	self assert: ast scope tempVector size = 0.
+
+	self assert: ast scope tempVars size equals: 1.
+	self assert: ast scope tempVector size equals: 0.
 	self deny: (ast scope lookupVar: 't1') isRemote.
-	self assert: ast scope copiedVars size = 0.
-	
-
-
-	
-
-	
-	
-
-
-
+	self assert: ast scope copiedVars size equals: 0
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testOptimizedBlockWriteInNestedBlockCase3 [
 	| ast scopes |
-	ast := (OCOpalExamples>>#optimizedBlockWriteInNestedBlockCase3) parseTree.
+	ast := (OCOpalExamples >> #optimizedBlockWriteInNestedBlockCase3) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	
-	self assert: ast scope tempVars size = 0.
-	self assert: ast scope tempVector size = 1.
+
+	self assert: ast scope tempVars size equals: 0.
+	self assert: ast scope tempVector size equals: 1.
 	self assert: (ast scope lookupVar: 't1') isRemote.
-	self assert: ast scope copiedVars size = 1. "Is this correct, I think that the copied vars should be empty."
-	
+	self assert: ast scope copiedVars size equals: 1.	"Is this correct, I think that the copied vars should be empty."
+
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
-	self assert: scopes second tempVars size = 0.
-	self assert: scopes second tempVector size = 0.
-	self assert: scopes second copiedVars size = 1.
-	scopes second copiedVars at: '0vector0' ifAbsent: [self fail].
-	self assert: ((scopes second copiedVars at: '0vector0') isStoringTempVector).	
-
-	
-	
-
-
-
+	self assert: scopes second tempVars size equals: 0.
+	self assert: scopes second tempVector size equals: 0.
+	self assert: scopes second copiedVars size equals: 1.
+	scopes second copiedVars at: '0vector0' ifAbsent: [ self fail ].
+	self assert: (scopes second copiedVars at: '0vector0') isStoringTempVector
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testOptimizedBlockWriteInNestedBlockCase4 [
 	| ast scopes |
-	ast := (OCOpalExamples>>#optimizedBlockWriteInNestedBlockCase4) parseTree.
+	ast := (OCOpalExamples >> #optimizedBlockWriteInNestedBlockCase4) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	
-	self assert: ast scope tempVars size = 0.
-	self assert: ast scope tempVector size = 1.
+
+	self assert: ast scope tempVars size equals: 0.
+	self assert: ast scope tempVector size equals: 1.
 	self assert: (ast scope lookupVar: 't1') isRemote.
-	self assert: ast scope copiedVars size = 1. "Is this correct, I think that the copied vars should be empty."
-	
+	self assert: ast scope copiedVars size equals: 1.	"Is this correct, I think that the copied vars should be empty."
+
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
-	self assert: scopes second tempVars size = 0.
-	self assert: scopes second tempVector size = 0.
-	self assert: scopes second copiedVars size = 1.
-	scopes second copiedVars at: '0vector0' ifAbsent: [self fail]
-	
-
-	
-	
-
-
-
+	self assert: scopes second tempVars size equals: 0.
+	self assert: scopes second tempVector size equals: 0.
+	self assert: scopes second copiedVars size equals: 1.
+	scopes second copiedVars at: '0vector0' ifAbsent: [ self fail ]
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testOptimizedBlockWrittenAfterClosedOverCase1 [
 	| ast scopes |
-	ast := (OCOpalExamples>>#optimizedBlockWrittenAfterClosedOverCase1) parseTree.
+	ast := (OCOpalExamples >> #optimizedBlockWrittenAfterClosedOverCase1) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	
-	self assert: ast scope tempVars size = 1.
-	self assert: ast scope tempVector size = 0.
-	
+
+	self assert: ast scope tempVars size equals: 1.
+	self assert: ast scope tempVector size equals: 0.
+
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
-	
-	self assert: scopes third  tempVars size = 0.
-	self assert: scopes third  tempVector size = 1.
-	
+
+	self assert: scopes third tempVars size equals: 0.
+	self assert: scopes third tempVector size equals: 1.
+
 	self deny: (scopes third lookupVar: 'index') isRemote.
-		"problem: as block is optimized, this var does not need to be remote"
-	self assert: (scopes third tempVector at: 'temp') isRemote.
-
-	
-	
-
-
-
+	"problem: as block is optimized, this var does not need to be remote"
+	self assert: (scopes third tempVector at: 'temp') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testOptimizedBlockWrittenAfterClosedOverCase2 [
 	| ast scopes |
-	ast := (OCOpalExamples>>#optimizedBlockWrittenAfterClosedOverCase2) parseTree.
+	ast := (OCOpalExamples >> #optimizedBlockWrittenAfterClosedOverCase2) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	
-	self assert: ast scope tempVars size = 1.
-	self assert: ast scope tempVector size =0.
+
+	self assert: ast scope tempVars size equals: 1.
+	self assert: ast scope tempVector size equals: 0.
 	self deny: (ast scope lookupVar: 'index') isRemote.
-	
+
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
-	self assert: (scopes third tempVector at: 'temp') isRemote.
-
-	
-	
-
-
-
+	self assert: (scopes third tempVector at: 'temp') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testSingleRemoteDifferentBlocksSameArgumentName [
 	| ast |
-	ast := (OCOpalExamples>>#singleRemoteDifferentBlocksSameArgumentName) parseTree.
+	ast := (OCOpalExamples >> #singleRemoteDifferentBlocksSameArgumentName) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 2.
-	self assert: ast scope tempVector size = 1.
-	
+	self assert: ast scope tempVars size equals: 2.
+	self assert: ast scope tempVector size equals: 1.
+
 	self deny: (ast scope lookupVar: 'b') isRemote.
 	self deny: (ast scope lookupVar: 'c') isRemote.
-	self assert: (ast scope lookupVar: 'z') isRemote.
-
+	self assert: (ast scope lookupVar: 'z') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testSingleRemoteMethodArgument [
 	| ast |
-	ast := (OCOpalExamples>>#singleRemoteMethodArgument) parseTree.
+	ast := (OCOpalExamples >> #singleRemoteMethodArgument) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 1.
-	self assert: ast scope tempVector size = 1.
-	
+	self assert: ast scope tempVars size equals: 1.
+	self assert: ast scope tempVector size equals: 1.
+
 	self deny: (ast scope lookupVar: 'block') isRemote.
-	self assert: (ast scope lookupVar: 'temp') isRemote.
-
-
+	self assert: (ast scope lookupVar: 'temp') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testSingleRemoteReadNestedBlocks [
 	| ast |
-	ast := (OCOpalExamples>>#singleRemoteReadNestedBlocks) parseTree.
+	ast := (OCOpalExamples >> #singleRemoteReadNestedBlocks) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 0.
-	self assert: ast scope tempVector size = 1.
-	
-	self assert: (ast scope lookupVar: 'a') isRemote.
+	self assert: ast scope tempVars size equals: 0.
+	self assert: ast scope tempVector size equals: 1.
 
-
+	self assert: (ast scope lookupVar: 'a') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testSingleRemoteTempVar [
 	| ast |
-	ast := (OCOpalExamples>>#singleRemoteTempVar) parseTree.
+	ast := (OCOpalExamples >> #singleRemoteTempVar) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 2.
-	self assert: ast scope tempVector size = 1.
-	
+	self assert: ast scope tempVars size equals: 2.
+	self assert: ast scope tempVector size equals: 1.
+
 	self assert: (ast scope lookupVar: 'index') isRemote.
-	self assert: (ast scope lookupVar: 'index') definingScope = ast scope.
+	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
 	self deny: (ast scope lookupVar: 'block') isRemote.
-	self deny: (ast scope lookupVar: 'collection') isRemote.
-
-
-
+	self deny: (ast scope lookupVar: 'collection') isRemote
 ]
 
 { #category : #'testing - variables' }
@@ -646,53 +483,39 @@ t1 := 1.
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testWrittenAfterClosedOver [
 	| ast |
-	ast := (OCOpalExamples>>#writtenAfterClosedOver) parseTree.
+	ast := (OCOpalExamples >> #writtenAfterClosedOver) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 0.
-	self assert: ast scope tempVector size = 1.
-	
-	self assert: (ast scope lookupVar: 'a') isRemote.
+	self assert: ast scope tempVars size equals: 0.
+	self assert: ast scope tempVector size equals: 1.
 
-	
-
-	
-	
-
-
-
+	self assert: (ast scope lookupVar: 'a') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testsingleRemoteTempVarWhileWithTempNotInlined [
 	| ast |
-	ast := (OCOpalExamples>>#exampleWhileWithTempNotInlined) parseTree.
+	ast := (OCOpalExamples >> #exampleWhileWithTempNotInlined) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 1.
-	self assert: ast scope tempVector size = 1.
-	
+	self assert: ast scope tempVars size equals: 1.
+	self assert: ast scope tempVector size equals: 1.
+
 	self assert: (ast scope lookupVar: 'index') isRemote.
-	self assert: (ast scope lookupVar: 'index') definingScope = ast scope.
-	self deny: (ast scope lookupVar: 'block') isRemote.
-
-
-
-
+	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
+	self deny: (ast scope lookupVar: 'block') isRemote
 ]
 
 { #category : #'tests - special cases' }
 OCASTClosureAnalyzerTest >> testsingleRemoteTempVarWrittenAfterClosedOver [
 	| ast |
-	ast := (OCOpalExamples>>#singleRemoteTempVarWrittenAfterClosedOver) parseTree.
+	ast := (OCOpalExamples >> #singleRemoteTempVarWrittenAfterClosedOver) parseTree.
 	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
-	self assert: ast scope tempVars size = 1.
-	self assert: ast scope tempVector size = 1.
-	
+	self assert: ast scope tempVars size equals: 1.
+	self assert: ast scope tempVector size equals: 1.
+
 	self assert: (ast scope lookupVar: 'index') isRemote.
-	self assert: (ast scope lookupVar: 'index') definingScope = ast scope.
-	self deny: (ast scope lookupVar: 'block') isRemote.
-
-
+	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
+	self deny: (ast scope lookupVar: 'block') isRemote
 ]

--- a/src/OpalCompiler-Tests/OCASTLiteralTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTLiteralTranslatorTest.class.st
@@ -57,10 +57,9 @@ OCASTLiteralTranslatorTest >> testLiteralIsInLiteralFrame [
 
 { #category : #'testing - literals' }
 OCASTLiteralTranslatorTest >> testLiteralReturnsAlwaysSameLiteral [
-	
 	self compileExample: literalExample.
-	
-	self assert: (self executeMethodOnInstance: method) == (self executeMethodOnInstance: method)
+
+	self assert: (self executeMethodOnInstance: method) identicalTo: (self executeMethodOnInstance: method)
 ]
 
 { #category : #'testing - literals' }

--- a/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
@@ -185,38 +185,25 @@ OCASTTranslatorTest >> testExample: aSelector withArguments: arguments [
 { #category : #'testing - primitives' }
 OCASTTranslatorTest >> testExamplePrimitiveErrorCode [
 	| method ast ir newMethod |
-	method := (OCOpalExamples>>#examplePrimitiveErrorCode).
+	method := OCOpalExamples >> #examplePrimitiveErrorCode.
 	ast := method parseTree.
 	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
 
 	newMethod := ir compiledMethod.
-	self assert: method primitive = newMethod primitive. 
-
-	
-
-	
-	
-
-	
+	self assert: method primitive equals: newMethod primitive
 ]
 
 { #category : #'testing - primitives' }
 OCASTTranslatorTest >> testExamplePrimitiveErrorCodeModule [
 	| method ast ir newMethod |
-	method := (OCOpalExamples>>#examplePrimitiveErrorCodeModule).
+	method := OCOpalExamples >> #examplePrimitiveErrorCodeModule.
 	ast := method parseTree.
 	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
 
 	newMethod := ir compiledMethod.
-	
-	self assert: method primitive = newMethod primitive. 
-	self assert: method pragmas printString  = newMethod pragmas printString
-	
 
-	
-	
-
-	
+	self assert: method primitive equals: newMethod primitive.
+	self assert: method pragmas printString equals: newMethod pragmas printString
 ]
 
 { #category : #'testing - primitives' }

--- a/src/OpalCompiler-Tests/OCArrayLiteralTest.class.st
+++ b/src/OpalCompiler-Tests/OCArrayLiteralTest.class.st
@@ -22,12 +22,10 @@ OCArrayLiteralTest >> tearDown [
 OCArrayLiteralTest >> testByteArrayBase [
 	self class compile: 'array ^ #[2r1010 8r333 16rFF]'.
 	self assert: (self array isKindOf: ByteArray).
-	self assert: (self array size = 3).
-	self assert: (self array first = 10).
-	self assert: (self array second = 219).
-	self assert: (self array last = 255)
-	
-
+	self assert: self array size equals: 3.
+	self assert: self array first equals: 10.
+	self assert: self array second equals: 219.
+	self assert: self array last equals: 255
 ]
 
 { #category : #tests }
@@ -40,48 +38,46 @@ OCArrayLiteralTest >> testByteArrayEmpty [
 { #category : #tests }
 OCArrayLiteralTest >> testByteArrayLiteral [
 	self class compile: 'array ^ #[ 1 2 3 4 ]'.
-	self assert: (self array = self array).
-	self assert: (self array == self array)
+	self assert: self array equals: self array.
+	self assert: self array identicalTo: self array
 ]
 
 { #category : #tests }
 OCArrayLiteralTest >> testByteArrayLong [
 	self class compile: 'array ^ #[ ' , ((0 to: 255) inject: ' ' into: [ :r :e | r , ' ' , e asString ]) , ' ]'.
 	self assert: (self array isKindOf: ByteArray).
-	self assert: (self array size = 256).
-	0 to: 255 do: [ :index | self assert: (self array at: index + 1) = index ]
+	self assert: self array size equals: 256.
+	0 to: 255 do: [ :index | self assert: (self array at: index + 1) equals: index ]
 ]
 
 { #category : #tests }
 OCArrayLiteralTest >> testByteArrayRange [
 	self class compile: 'array ^ #[ 0 255 ]'.
 	self assert: (self array isKindOf: ByteArray).
-	self assert: (self array size = 2).
-	self assert: (self array first = 0).
-	self assert: (self array last = 255)
+	self assert: self array size equals: 2.
+	self assert: self array first equals: 0.
+	self assert: self array last equals: 255
 ]
 
 { #category : #tests }
 OCArrayLiteralTest >> testByteArrayWithinArray [
 	self class compile: 'array ^ #( #[1] #[2] )'.
 	self assert: (self array isKindOf: Array).
-	self assert: (self array size = 2).
+	self assert: self array size equals: 2.
 	self assert: (self array first isKindOf: ByteArray).
-	self assert: (self array first first = 1).
+	self assert: self array first first equals: 1.
 	self assert: (self array last isKindOf: ByteArray).
-	self assert: (self array last first = 2)
-	
-
+	self assert: self array last first equals: 2
 ]
 
 { #category : #tests }
 OCArrayLiteralTest >> testReservedIdentifiers [
 	self class compile: 'array ^ #(nil true false)'.
-	self assert: self array = {nil. true. false}.
+	self assert: self array equals: {nil . true . false}
 ]
 
 { #category : #tests }
 OCArrayLiteralTest >> testSymbols [
 	self class compile: 'array ^ #(#nil #true #false #''nil'' #''true'' #''false'')'.
-	self assert: self array = {#nil. #true. #false. #nil. #true. #false}.
+	self assert: self array equals: {#nil . #true . #false . #nil . #true . #false}
 ]

--- a/src/OpalCompiler-Tests/OCBytecodeDecompilerExamplesTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeDecompilerExamplesTest.class.st
@@ -7,487 +7,445 @@ Class {
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleBlockArgument [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleBlockArgument) parseTree generate.
+	method := (OCOpalExamples >> #exampleBlockArgument) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleBlockArgument.
 
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleBlockArgument
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleBlockExternal [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleBlockExternal) parseTree generate.
+	method := (OCOpalExamples >> #exampleBlockExternal) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleBlockExternal.
 
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleBlockExternal
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleBlockExternal2 [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleBlockExternal2) parseTree generate.
+	method := (OCOpalExamples >> #exampleBlockExternal2) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleBlockExternal2.
 
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleBlockExternal2
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleBlockExternalArg [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleBlockExternalArg) parseTree generate.
+	method := (OCOpalExamples >> #exampleBlockExternalArg) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleBlockExternalArg.
 
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleBlockExternalArg
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleBlockExternalNested [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleBlockExternalNested) parseTree generate.
+	method := (OCOpalExamples >> #exampleBlockExternalNested) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleBlockExternalNested.
 
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleBlockExternalNested
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleBlockInternal [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleBlockInternal) parseTree generate.
+	method := (OCOpalExamples >> #exampleBlockInternal) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleBlockInternal.
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleBlockInternal
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleBlockNested [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleBlockNested) parseTree generate.
+	method := (OCOpalExamples >> #exampleBlockNested) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleBlockNested.
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleBlockNested
 ]
 
 { #category : #'tests-simple' }
 OCBytecodeDecompilerExamplesTest >> testExampleEmptyMethod [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleEmptyMethod) parseTree generate.
+	method := (OCOpalExamples >> #exampleEmptyMethod) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleEmptyMethod.
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleEmptyMethod
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleIfFalse [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleIfFalse) parseTree generate.
+	method := (OCOpalExamples >> #exampleIfFalse) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleIfFalse.
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleIfFalse
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleIfFalseIfTrue [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleIfFalseIfTrue) parseTree generate.
+	method := (OCOpalExamples >> #exampleIfFalseIfTrue) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleIfFalseIfTrue.
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleIfFalseIfTrue
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleIfIfNotNilReturnNil [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleIfNotNilReturnNil) parseTree generate.
+	method := (OCOpalExamples >> #exampleIfNotNilReturnNil) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleIfNotNilReturnNil
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleIfNotNilReturnNil
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleIfNotNilArg [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleIfNotNilArg) parseTree generate.
+	method := (OCOpalExamples >> #exampleIfNotNilArg) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleIfNotNilArg.
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleIfNotNilArg
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleIfTrue [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleIfTrue) parseTree generate.
+	method := (OCOpalExamples >> #exampleIfTrue) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleIfTrue
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleIfTrue
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleIfTrueIfFalse [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleIfTrueIfFalse) parseTree generate.
+	method := (OCOpalExamples >> #exampleIfTrueIfFalse) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleIfTrueIfFalse
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleIfTrueIfFalse
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleMethodTempInNestedBlock [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleMethodTempInNestedBlock) parseTree generate.
+	method := (OCOpalExamples >> #exampleMethodTempInNestedBlock) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleMethodTempInNestedBlock
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleMethodTempInNestedBlock
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleMethodWithOptimizedBlocksA [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleMethodWithOptimizedBlocksA) parseTree generate.
+	method := (OCOpalExamples >> #exampleMethodWithOptimizedBlocksA) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleMethodWithOptimizedBlocksA
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleMethodWithOptimizedBlocksA
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleNestedBlockScoping [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleNestedBlockScoping) parseTree generate.
+	method := (OCOpalExamples >> #exampleNestedBlockScoping) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleNestedBlockScoping
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleNestedBlockScoping
 ]
 
 { #category : #'tests-simple' }
 OCBytecodeDecompilerExamplesTest >> testExampleNewArray [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleNewArray) parseTree generate.
+	method := (OCOpalExamples >> #exampleNewArray) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleNewArray
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleNewArray
 ]
 
 { #category : #'tests-misc' }
 OCBytecodeDecompilerExamplesTest >> testExamplePushArray [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#examplePushArray) parseTree generate.
+	method := (OCOpalExamples >> #examplePushArray) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance examplePushArray
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance examplePushArray
 ]
 
 { #category : #'tests-simple' }
 OCBytecodeDecompilerExamplesTest >> testExampleReturn1 [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleReturn42) parseTree generate.
+	method := (OCOpalExamples >> #exampleReturn42) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleReturn42
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleReturn42
 ]
 
 { #category : #'tests-simple' }
 OCBytecodeDecompilerExamplesTest >> testExampleReturn1plus2 [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleReturn1plus2) parseTree generate.
+	method := (OCOpalExamples >> #exampleReturn1plus2) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleReturn1plus2
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleReturn1plus2
 ]
 
 { #category : #'tests-variables' }
 OCBytecodeDecompilerExamplesTest >> testExampleSelf [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleSelf) parseTree generate.
+	method := (OCOpalExamples >> #exampleSelf) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleSelf
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleSelf
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlock [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleSimpleBlock) parseTree generate.
+	method := (OCOpalExamples >> #exampleSimpleBlock) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) value = instance exampleSimpleBlock value
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) value equals: instance exampleSimpleBlock value
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockArgument1 [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleSimpleBlockArgument1) parseTree generate.
+	method := (OCOpalExamples >> #exampleSimpleBlockArgument1) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockArgument1
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleSimpleBlockArgument1
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockArgument2 [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleSimpleBlockArgument2) parseTree generate.
+	method := (OCOpalExamples >> #exampleSimpleBlockArgument2) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockArgument2
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleSimpleBlockArgument2
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockArgument3 [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleSimpleBlockArgument3) parseTree generate.
+	method := (OCOpalExamples >> #exampleSimpleBlockArgument3) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockArgument3
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleSimpleBlockArgument3
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockArgument4 [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleSimpleBlockArgument4) parseTree generate.
+	method := (OCOpalExamples >> #exampleSimpleBlockArgument4) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockArgument4
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleSimpleBlockArgument4
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockArgument5 [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleSimpleBlockArgument5) parseTree generate.
+	method := (OCOpalExamples >> #exampleSimpleBlockArgument5) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockArgument5
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleSimpleBlockArgument5
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockEmpty [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleSimpleBlockEmpty) parseTree generate.
+	method := (OCOpalExamples >> #exampleSimpleBlockEmpty) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockEmpty
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleSimpleBlockEmpty
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockLocal [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleSimpleBlockLocal) parseTree generate.
+	method := (OCOpalExamples >> #exampleSimpleBlockLocal) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockLocal
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleSimpleBlockLocal
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockLocalIf [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleSimpleBlockLocalIf) parseTree generate.
+	method := (OCOpalExamples >> #exampleSimpleBlockLocalIf) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockLocalIf
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleSimpleBlockLocalIf
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockLocalNested [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleSimpleBlockNested) parseTree generate.
+	method := (OCOpalExamples >> #exampleSimpleBlockNested) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockNested
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleSimpleBlockNested
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockLocalWhile [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleSimpleBlockLocalWhile) parseTree generate.
+	method := (OCOpalExamples >> #exampleSimpleBlockLocalWhile) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockLocalWhile
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleSimpleBlockLocalWhile
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockNested [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleSimpleBlockNested) parseTree generate.
+	method := (OCOpalExamples >> #exampleSimpleBlockNested) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockNested
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleSimpleBlockNested
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockReturn [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleSimpleBlockReturn) parseTree generate.
+	method := (OCOpalExamples >> #exampleSimpleBlockReturn) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockReturn
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleSimpleBlockReturn
 ]
 
 { #category : #'tests-blocks' }
 OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockiVar [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleSimpleBlockiVar) parseTree generate.
+	method := (OCOpalExamples >> #exampleSimpleBlockiVar) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleSimpleBlockiVar
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleSimpleBlockiVar
 ]
 
 { #category : #'tests-variables' }
 OCBytecodeDecompilerExamplesTest >> testExampleSuper [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleSuper) parseTree generate.
+	method := (OCOpalExamples >> #exampleSuper) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleSuper
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleSuper
 ]
 
 { #category : #'tests-variables' }
@@ -508,168 +466,155 @@ OCBytecodeDecompilerExamplesTest >> testExampleThisContext [
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleToDoArgument [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleToDoArgument) parseTree generate.
+	method := (OCOpalExamples >> #exampleToDoArgument) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleToDoArgument
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleToDoArgument
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleToDoArgumentNotInlined [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleToDoArgumentNotInlined) parseTree generate.
+	method := (OCOpalExamples >> #exampleToDoArgumentNotInlined) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleToDoArgumentNotInlined
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleToDoArgumentNotInlined
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleToDoInsideTemp [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleToDoInsideTemp) parseTree generate.
+	method := (OCOpalExamples >> #exampleToDoInsideTemp) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleToDoInsideTemp
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleToDoInsideTemp
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleToDoInsideTempNotInlined [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleToDoInsideTempNotInlined) parseTree generate.
+	method := (OCOpalExamples >> #exampleToDoInsideTempNotInlined) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleToDoInsideTempNotInlined
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleToDoInsideTempNotInlined
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleToDoOutsideTemp [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleToDoOutsideTemp) parseTree generate.
+	method := (OCOpalExamples >> #exampleToDoOutsideTemp) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleToDoOutsideTemp
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleToDoOutsideTemp
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleToDoOutsideTempNotInlined [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleToDoOutsideTempNotInlined) parseTree generate.
+	method := (OCOpalExamples >> #exampleToDoOutsideTempNotInlined) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleToDoOutsideTempNotInlined
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleToDoOutsideTempNotInlined
 ]
 
 { #category : #'tests-misc' }
 OCBytecodeDecompilerExamplesTest >> testExampleToDoValue [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleToDoValue) parseTree generate.
+	method := (OCOpalExamples >> #exampleToDoValue) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleToDoValue
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleToDoValue
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleWhileModificationAfterNotInlined [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleWhileModificationAfterNotInlined) parseTree generate.
+	method := (OCOpalExamples >> #exampleWhileModificationAfterNotInlined) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleWhileModificationAfterNotInlined
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleWhileModificationAfterNotInlined
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleWhileModificationBefore [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleWhileModificationBefore) parseTree generate.
+	method := (OCOpalExamples >> #exampleWhileModificationBefore) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleWhileModificationBefore
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleWhileModificationBefore
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleWhileModificationBeforeNotInlined [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleWhileModificationBeforeNotInlined) parseTree generate.
+	method := (OCOpalExamples >> #exampleWhileModificationBeforeNotInlined) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleWhileModificationBeforeNotInlined
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleWhileModificationBeforeNotInlined
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleWhileWithTemp [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleWhileWithTemp) parseTree generate.
+	method := (OCOpalExamples >> #exampleWhileWithTemp) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleWhileWithTemp
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleWhileWithTemp
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleWhileWithTempNotInlined [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleWhileWithTempNotInlined) parseTree generate.
+	method := (OCOpalExamples >> #exampleWhileWithTempNotInlined) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleWhileWithTempNotInlined
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleWhileWithTempNotInlined
 ]
 
 { #category : #'tests-variables' }
 OCBytecodeDecompilerExamplesTest >> testExampleiVar [
 	| ir method newMethod instance |
-	
-	method := (OCOpalExamples>>#exampleiVar) parseTree generate.
+	method := (OCOpalExamples >> #exampleiVar) parseTree generate.
 	instance := OCOpalExamples new.
-	
+
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
-	
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) = instance exampleiVar
+
+	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleiVar
 ]

--- a/src/OpalCompiler-Tests/OCBytecodeDecompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeDecompilerTest.class.st
@@ -231,7 +231,7 @@ OCBytecodeDecompilerTest >> testDup [
 	ir1 := IRBuilderTest new testDup.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic
 ]
 
@@ -242,7 +242,7 @@ OCBytecodeDecompilerTest >> testInstVar [
 	method := ir1 compiledMethod.
 	ir2 := method decompileIR.
 	method2 := ir2 compiledMethod.
-	self deny: method2 == method.
+	self deny: method2 identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: method2 equals: method
 ]
@@ -253,7 +253,7 @@ OCBytecodeDecompilerTest >> testJumpAheadTo [
 	ir1 := IRBuilderTest new testJumpAheadTo.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod equals: method
 ]
 
@@ -263,7 +263,7 @@ OCBytecodeDecompilerTest >> testJumpAheadToIf [
 	ir1 := IRBuilderTest new testJumpAheadToIf.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -274,7 +274,7 @@ OCBytecodeDecompilerTest >> testJumpBackTo [
 	ir1 := IRBuilderTest new testJumpBackTo.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -285,7 +285,7 @@ OCBytecodeDecompilerTest >> testLiteralArray [
 	ir1 := IRBuilderTest new testLiteralArray.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -296,7 +296,7 @@ OCBytecodeDecompilerTest >> testLiteralBoolean [
 	ir1 := IRBuilderTest new testLiteralBoolean.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -307,7 +307,7 @@ OCBytecodeDecompilerTest >> testLiteralCharacter [
 	ir1 := IRBuilderTest new testLiteralCharacter.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -318,7 +318,7 @@ OCBytecodeDecompilerTest >> testLiteralFloat [
 	ir1 := IRBuilderTest new testLiteralFloat.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -329,7 +329,7 @@ OCBytecodeDecompilerTest >> testLiteralInteger [
 	ir1 := IRBuilderTest new testLiteralInteger.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -340,7 +340,7 @@ OCBytecodeDecompilerTest >> testLiteralNil [
 	ir1 := IRBuilderTest new testLiteralNil.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -351,7 +351,7 @@ OCBytecodeDecompilerTest >> testLiteralString [
 	ir1 := IRBuilderTest new testLiteralString.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -362,7 +362,7 @@ OCBytecodeDecompilerTest >> testLiteralSymbol [
 	ir1 := IRBuilderTest new testLiteralSymbol.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -373,7 +373,7 @@ OCBytecodeDecompilerTest >> testLiteralVariableClass [
 	ir1 := IRBuilderTest new testLiteralVariableClass.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -384,7 +384,7 @@ OCBytecodeDecompilerTest >> testLiteralVariableClassVariable [
 	ir1 := IRBuilderTest new testLiteralVariableClassVariable.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -395,7 +395,7 @@ OCBytecodeDecompilerTest >> testLiteralVariableGlobale [
 	ir1 := IRBuilderTest new testLiteralVariableGlobale.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -406,7 +406,7 @@ OCBytecodeDecompilerTest >> testPopTop [
 	ir1 := IRBuilderTest new testPopTop.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -417,7 +417,7 @@ OCBytecodeDecompilerTest >> testPushClosureCopyNoCopied [
 	ir1 := self pushClosureCopyNoCopied.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -428,7 +428,7 @@ OCBytecodeDecompilerTest >> testPushClosureCopyNoCopiedArg [
 	ir1 := self pushClosureCopyNoCopiedArg.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -439,7 +439,7 @@ OCBytecodeDecompilerTest >> testPushClosureCopyOneCopiedArg [
 	ir1 := self pushClosureCopyOneCopiedArg.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -450,7 +450,7 @@ OCBytecodeDecompilerTest >> testPushClosureCopyOneCopiedTemp [
 	ir1 := self pushClosureCopyOneCopiedTemp.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -461,7 +461,7 @@ OCBytecodeDecompilerTest >> testPushConsArray [
 	ir1 := IRBuilderTest new testPushConsArray.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -472,7 +472,7 @@ OCBytecodeDecompilerTest >> testPushConsArray2 [
 	ir1 := IRBuilderTest new testPushConsArray2.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -483,7 +483,7 @@ OCBytecodeDecompilerTest >> testPushSelf [
 	ir1 := IRBuilderTest new testPushSelf.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -494,7 +494,7 @@ OCBytecodeDecompilerTest >> testPushTempArgument [
 	ir1 := IRBuilderTest new testPushTempArgument.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -505,7 +505,7 @@ OCBytecodeDecompilerTest >> testPushTempTemp [
 	ir1 := IRBuilderTest new testPushTempTemp.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -516,7 +516,7 @@ OCBytecodeDecompilerTest >> testPushThisContext [
 	ir1 := IRBuilderTest new testPushThisContext.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -527,7 +527,7 @@ OCBytecodeDecompilerTest >> testRemoteTemp [
 	ir1 := self remoteTemp.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -538,7 +538,7 @@ OCBytecodeDecompilerTest >> testRemoteTempNested [
 	ir1 := self remoteTempNested.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -549,7 +549,7 @@ OCBytecodeDecompilerTest >> testReturnTop [
 	ir1 := IRBuilderTest new testReturnTop.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -560,7 +560,7 @@ OCBytecodeDecompilerTest >> testSendSuper [
 	ir1 := IRBuilderTest new testSendSuper.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -571,7 +571,7 @@ OCBytecodeDecompilerTest >> testStoreIntoVariable [
 	ir1 := IRBuilderTest new testStoreIntoVariable.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
@@ -582,7 +582,7 @@ OCBytecodeDecompilerTest >> testStoreTemp [
 	ir1 := IRBuilderTest new testStoreTemp.
 	method := ir1 compiledMethod.
 	ir2 := IRBytecodeDecompiler new decompile: method.
-	self deny: ir2 compiledMethod == method.
+	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]

--- a/src/OpalCompiler-Tests/OCBytecodeGeneratorTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeGeneratorTest.class.st
@@ -33,8 +33,7 @@ OCBytecodeGeneratorTest >> testBlockReturnTop [
 
 { #category : #'tests - execution' }
 OCBytecodeGeneratorTest >> testClosureExample [
-	| cm  |
-	
+	| cm |
 	cm := self newBytecodeGen
 		numArgs: 0;
 		numTemps: 0;
@@ -44,22 +43,20 @@ OCBytecodeGeneratorTest >> testClosureExample [
 		label: #end;
 		returnTop;
 		compiledMethod.
-	
-		
+
+
 	cm methodClass: self class.
 	cm selector: #test.
 
 	self assert: (cm isKindOf: CompiledMethod).
-	self assert: ((cm valueWithReceiver: 2@2 arguments: #()) isKindOf: BlockClosure).
-	self assert: ((cm valueWithReceiver: 2@2 arguments: #()) value = (2@2)).
-	^cm
-	
+	self assert: ((cm valueWithReceiver: 2 @ 2 arguments: #()) isKindOf: BlockClosure).
+	self assert: (cm valueWithReceiver: 2 @ 2 arguments: #()) value equals: 2 @ 2.
+	^ cm
 ]
 
 { #category : #'tests - execution' }
 OCBytecodeGeneratorTest >> testExample [
 	| cm |
-	
 	cm := self newBytecodeGen
 		numArgs: 1;
 		numTemps: 1;
@@ -68,7 +65,7 @@ OCBytecodeGeneratorTest >> testExample [
 		send: #>;
 		if: false goto: #else;
 		pushLiteral: 'yes';
-		returnTop ;
+		returnTop;
 		label: #else;
 		pushLiteral: 'no';
 		returnTop;
@@ -77,16 +74,14 @@ OCBytecodeGeneratorTest >> testExample [
 	cm selector: #test.
 
 	self assert: (cm isKindOf: CompiledMethod).
-	self assert: (cm valueWithReceiver: 2@2 arguments: #(1)) = 'no' .
-	self assert: (cm valueWithReceiver: 2@2  arguments: #(3)) = 'yes' .	
-	^cm
-	
+	self assert: (cm valueWithReceiver: 2 @ 2 arguments: #(1)) equals: 'no'.
+	self assert: (cm valueWithReceiver: 2 @ 2 arguments: #(3)) equals: 'yes'.
+	^ cm
 ]
 
 { #category : #'tests - execution' }
 OCBytecodeGeneratorTest >> testExample2 [
 	| cm |
-	
 	cm := self newBytecodeGen
 		numArgs: 1;
 		numTemps: 1;
@@ -95,17 +90,16 @@ OCBytecodeGeneratorTest >> testExample2 [
 		send: #<;
 		if: false goto: #else;
 		pushLiteral: 'yes';
-		returnTop ;
+		returnTop;
 		label: #else;
 		pushLiteral: 'no';
 		returnTop;
 		compiledMethod.
 
 	self assert: (cm isKindOf: CompiledMethod).
-	self assert: (cm valueWithReceiver: 2@2 arguments: #(1)) = 'no' .
-	self assert: (cm valueWithReceiver: 2@2  arguments: #(3)) = 'yes' .	
-	^cm
-	
+	self assert: (cm valueWithReceiver: 2 @ 2 arguments: #(1)) equals: 'no'.
+	self assert: (cm valueWithReceiver: 2 @ 2 arguments: #(3)) equals: 'yes'.
+	^ cm
 ]
 
 { #category : #'tests - instructions' }
@@ -212,12 +206,10 @@ OCBytecodeGeneratorTest >> testLabel [
 
 { #category : #helper }
 OCBytecodeGeneratorTest >> testMethod: cm against: string [
-
 	| symbolic |
 	self assert: cm isCompiledMethod.
-	symbolic := String streamContents: [:str | cm longPrintOn: str ].
-	self assert: symbolic = string
-	
+	symbolic := String streamContents: [ :str | cm longPrintOn: str ].
+	self assert: symbolic equals: string
 ]
 
 { #category : #'tests - instructions' }
@@ -534,7 +526,6 @@ OCBytecodeGeneratorTest >> testSendToSuperOf [
 { #category : #'tests - instructions' }
 OCBytecodeGeneratorTest >> testStoreInstVar [
 	| gen cm symbolic |
-	
 	gen := self newBytecodeGen
 		numArgs: 0;
 		numTemps: 0;
@@ -542,13 +533,16 @@ OCBytecodeGeneratorTest >> testStoreInstVar [
 		storeInstVar: 1;
 		returnTop.
 	cm := gen compiledMethod.
-	symbolic := String streamContents: [:str | cm longPrintOn: str ].
+	symbolic := String streamContents: [ :str | cm longPrintOn: str ].
 
-	self assert: gen stackFrameSize = 1.
+	self assert: gen stackFrameSize equals: 1.
 	self assert: cm isCompiledMethod.
-	self assert: symbolic = (Smalltalk vm 
-		for32bit: '13 <76> pushConstant: 1\14 <81 00> storeIntoRcvr: 0\16 <7C> returnTop' withCRs 
-		for64bit: '25 <76> pushConstant: 1\26 <81 00> storeIntoRcvr: 0\28 <7C> returnTop' withCRs)
+	self
+		assert: symbolic
+		equals:
+			(Smalltalk vm
+				for32bit: '13 <76> pushConstant: 1\14 <81 00> storeIntoRcvr: 0\16 <7C> returnTop' withCRs
+				for64bit: '25 <76> pushConstant: 1\26 <81 00> storeIntoRcvr: 0\28 <7C> returnTop' withCRs)
 ]
 
 { #category : #'tests - instructions' }

--- a/src/OpalCompiler-Tests/OCClosureCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCClosureCompilerTest.class.st
@@ -354,62 +354,69 @@ OCClosureCompilerTest >> testInlineBlockCollectionEM1 [
 	| a1 b1 i1 a2 b2 i2 we wb |
 	b1 := OrderedCollection new.
 	i1 := 1.
-	[a1 := i1.
-	 i1 <= 3] whileTrue:
-		[b1 add: [a1].
-		i1 := i1 + 1].
-	b1 := b1 asArray collect: [:b | b value].
+	[ a1 := i1.
+	i1 <= 3 ]
+		whileTrue: [ b1 add: [ a1 ].
+			i1 := i1 + 1 ].
+	b1 := b1 asArray collect: [ :b | b value ].
 	b2 := OrderedCollection new.
 	i2 := 1.
-	we := [a2 := i2. i2 <= 3].
-	wb := [b2 add: [a2]. i2 := i2 + 1].
-	we whileTrue: wb. "defeat optimization"
-	b2 := b2 asArray collect: [:b | b value].
-	self assert: b1 = b2
+	we := [ a2 := i2.
+	i2 <= 3 ].
+	wb := [ b2 add: [ a2 ].
+	i2 := i2 + 1 ].
+	we whileTrue: wb.	"defeat optimization"
+	b2 := b2 asArray collect: [ :b | b value ].
+	self assert: b1 equals: b2
 ]
 
 { #category : #tests }
 OCClosureCompilerTest >> testInlineBlockCollectionLR1 [
 	"Test case from Lukas Renggli"
+
 	| col |
 	col := OrderedCollection new.
 	1 to: 11 do: [ :each | col add: [ each ] ].
-	self assert: (col collect: [ :each | each value ]) asArray = (1 to: 11) asArray
+	self assert: (col collect: [ :each | each value ]) asArray equals: (1 to: 11) asArray
 ]
 
 { #category : #tests }
 OCClosureCompilerTest >> testInlineBlockCollectionLR2 [
 	"Test case from Lukas Renggli"
+
 	| col |
 	col := OrderedCollection new.
-	1 to: 11 do: [ :each | #(1) do: [:ignored| col add: [ each ]] ].
-	self assert: (col collect: [ :each | each value ]) asArray = (1 to: 11) asArray
+	1 to: 11 do: [ :each | #(1) do: [ :ignored | col add: [ each ] ] ].
+	self assert: (col collect: [ :each | each value ]) asArray equals: (1 to: 11) asArray
 ]
 
 { #category : #tests }
 OCClosureCompilerTest >> testInlineBlockCollectionLR3 [
 	| col |
 	col := OrderedCollection new.
-	1 to: 11 do: [ :each | | i | i := each. col add: [ i ]. i := i + 1 ].
-	self assert: (col collect: [ :each | each value ]) asArray = (2 to: 12) asArray
+	1 to: 11 do: [ :each | 
+		| i |
+		i := each.
+		col add: [ i ].
+		i := i + 1 ].
+	self assert: (col collect: [ :each | each value ]) asArray equals: (2 to: 12) asArray
 ]
 
 { #category : #tests }
 OCClosureCompilerTest >> testInlineBlockCollectionSD1 [
 	| a1 b1 a2 b2 |
 	b1 := OrderedCollection new.
-	1 to: 3 do:
-		[:i |
+	1 to: 3 do: [ :i | 
 		a1 := i.
-		b1 add: [a1]].
-	b1 := b1 asArray collect: [:b | b value].
+		b1 add: [ a1 ] ].
+	b1 := b1 asArray collect: [ :b | b value ].
 	b2 := OrderedCollection new.
 	1 to: 3 do:
-		[:i |
+		[ :i | 
 		a2 := i.
-		b2 add: [a2]] yourself. "defeat optimization"
-	b2 := b2 asArray collect: [:b | b value].
-	self assert: b1 = b2
+		b2 add: [ a2 ] ] yourself.	"defeat optimization"
+	b2 := b2 asArray collect: [ :b | b value ].
+	self assert: b1 equals: b2
 ]
 
 { #category : #tests }

--- a/src/OpalCompiler-Tests/OCClosureTest.class.st
+++ b/src/OpalCompiler-Tests/OCClosureTest.class.st
@@ -32,11 +32,14 @@ OCClosureTest >> setUp [
 { #category : #testing }
 OCClosureTest >> testBlockArgument [
 	| block block1 block2 |
-	block := [ :arg | | temp | temp := arg. [ temp ] ].
+	block := [ :arg | 
+	| temp |
+	temp := arg.
+	[ temp ] ].
 	block1 := block value: 1.
 	block2 := block value: 2.
-	self assert: block1 value = 1.
-	self assert: block2 value = 2
+	self assert: block1 value equals: 1.
+	self assert: block2 value equals: 2
 ]
 
 { #category : #testing }
@@ -45,22 +48,24 @@ OCClosureTest >> testBlockTemp [
 	block := [ :arg | [ arg ] ].
 	block1 := block value: 1.
 	block2 := block value: 2.
-	self assert: block1 value = 1.
-	self assert: block2 value = 2
+	self assert: block1 value equals: 1.
+	self assert: block2 value equals: 2
 ]
 
 { #category : #testing }
 OCClosureTest >> testBlockTemps [
-	
 	| block block1 block2 |
 	"Regression test: Bytecode offset of IR was to last byte of IR node, which for blocks include temp initialization bytes. This caused scan for block creation bytecode to fail when there were many block temps, and no source node to be found."
-	block := [ :arg | | a b c d e f g | a:=b:=c:=d:=e:=f:=g := arg. [ a ] ].
+	block := [ :arg | 
+	| a b c d e f g |
+	a := b := c := d := e := f := g := arg.
+	[ a ] ].
 	self assert: block sourceNode isBlock.
 	self assert: block argumentNames equals: #(#arg).
 	block1 := block value: 1.
 	block2 := block value: 2.
-	self assert: block1 value = 1.
-	self assert: block2 value = 2
+	self assert: block1 value equals: 1.
+	self assert: block2 value equals: 2
 ]
 
 { #category : #'testing-empty' }
@@ -120,7 +125,7 @@ OCClosureTest >> testMethodArgument [
 	temp := 1.
 	block := block value.
 	temp := 2.
-	self assert: block value = 2
+	self assert: block value equals: 2
 ]
 
 { #category : #testing }
@@ -128,8 +133,8 @@ OCClosureTest >> testMethodTemp [
 	| block1 block2 |
 	block1 := self methodArgument: 1.
 	block2 := self methodArgument: 2.
-	self assert: block1 value = 1.
-	self assert: block2 value = 2
+	self assert: block1 value equals: 1.
+	self assert: block2 value equals: 2
 ]
 
 { #category : #'testing-todo' }

--- a/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
@@ -6,116 +6,109 @@ Class {
 
 { #category : #test }
 OCCompiledMethodIntegrityTest >> testBlockTemps [
-
 	| newCompiledMethod |
-	newCompiledMethod := OpalCompiler new 
-								source: 'ascentOf: aCharacter
+	newCompiledMethod := OpalCompiler new
+		source:
+			'ascentOf: aCharacter
 											^ [ | temp1 temp2 temp3 | 1= temp1. 2 = temp2. 3 = temp3].';
-								class: OCMockCompilationClass;
-								compile.
-								
-	self assert: newCompiledMethod numArgs = 1.
-	self assert: (newCompiledMethod numLiterals = 3 or: [newCompiledMethod numLiterals = 4 "Sista Bytecode" ]).
-	self assert: newCompiledMethod numTemps = 1.
-	self assert: newCompiledMethod primitive = 0.
+		class: OCMockCompilationClass;
+		compile.
+
+	self assert: newCompiledMethod numArgs equals: 1.
+	self assert: (newCompiledMethod numLiterals = 3 or: [ newCompiledMethod numLiterals = 4	"Sista Bytecode" ]).
+	self assert: newCompiledMethod numTemps equals: 1.
+	self assert: newCompiledMethod primitive equals: 0
 ]
 
 { #category : #test }
 OCCompiledMethodIntegrityTest >> testNotUsedArgument [
-
 	| newCompiledMethod |
-	
-	newCompiledMethod := OpalCompiler new 
-								source: 'ascentOf: aCharacter
+	newCompiledMethod := OpalCompiler new
+		source:
+			'ascentOf: aCharacter
 											^ self ascent.';
-								class: OCMockCompilationClass;
-								compile.
+		class: OCMockCompilationClass;
+		compile.
 
-	self assert: newCompiledMethod numArgs = 1.
-	self assert: newCompiledMethod numLiterals = 3.
-	self assert: newCompiledMethod numTemps = 1.
-	self assert: newCompiledMethod primitive = 0.
+	self assert: newCompiledMethod numArgs equals: 1.
+	self assert: newCompiledMethod numLiterals equals: 3.
+	self assert: newCompiledMethod numTemps equals: 1.
+	self assert: newCompiledMethod primitive equals: 0
 ]
 
 { #category : #test }
 OCCompiledMethodIntegrityTest >> testPragmas [
-
 	| newCompiledMethod |
-	
-	newCompiledMethod := OpalCompiler new 
-									source: 'methodDoublePragma
+	newCompiledMethod := OpalCompiler new
+		source:
+			'methodDoublePragma
 											<hello: 5>
 											<hello: 2>';
-									class: OCMockCompilationClass;
-									compile.
-									
-	self assert: newCompiledMethod numArgs = 0.
-	self assert: newCompiledMethod numLiterals = 2.
-	
+		class: OCMockCompilationClass;
+		compile.
+
+	self assert: newCompiledMethod numArgs equals: 0.
+	self assert: newCompiledMethod numLiterals equals: 2.
+
 	"AdditionalState assertions"
-	self assert: newCompiledMethod allLiterals first selector = #methodDoublePragma.
-	self assert: (newCompiledMethod allLiterals first instVarNamed: 'method') = newCompiledMethod.
-		
-	self assert: newCompiledMethod primitive = 256.
+	self assert: newCompiledMethod allLiterals first selector equals: #methodDoublePragma.
+	self assert: (newCompiledMethod allLiterals first instVarNamed: 'method') equals: newCompiledMethod.
+
+	self assert: newCompiledMethod primitive equals: 256
 ]
 
 { #category : #test }
 OCCompiledMethodIntegrityTest >> testPrimitive [
-
 	| newCompiledMethod |
-	
-	newCompiledMethod := OpalCompiler new 
-								source: 'size
+	newCompiledMethod := OpalCompiler new
+		source:
+			'size
 											<primitive: 62>
 											^ self basicSize.';
-								class: OCMockCompilationClass;
-								compile.
-							
-	self assert: newCompiledMethod numArgs = 0.
-	self assert: newCompiledMethod numLiterals = 3.
-	self assert: newCompiledMethod numTemps = 0.
-	self assert: newCompiledMethod primitive = 62.
+		class: OCMockCompilationClass;
+		compile.
+
+	self assert: newCompiledMethod numArgs equals: 0.
+	self assert: newCompiledMethod numLiterals equals: 3.
+	self assert: newCompiledMethod numTemps equals: 0.
+	self assert: newCompiledMethod primitive equals: 62
 ]
 
 { #category : #test }
 OCCompiledMethodIntegrityTest >> testRemoteTempInVector [
-
 	| newCompiledMethod |
-
 	"Here the problem was that the Scope kept both the remote temp answer and the new remote <?> this caused
 	that the number of temps were more than the correnct"
-	
-	newCompiledMethod := OpalCompiler new 
-											source: 'value
+	newCompiledMethod := OpalCompiler new
+		source:
+			'value
 													    | answer |
  													   self do:
        														 [:each |
         															answer := each value].
    													 ^answer';
-											class: Object;
-											compile.
+		class: Object;
+		compile.
 
-							
-	self assert: newCompiledMethod numArgs = 0.
-	self assert: newCompiledMethod numLiterals = 2.
-	self assert: newCompiledMethod numTemps = 1.
-	self assert: newCompiledMethod primitive = 0.
+
+	self assert: newCompiledMethod numArgs equals: 0.
+	self assert: newCompiledMethod numLiterals equals: 2.
+	self assert: newCompiledMethod numTemps equals: 1.
+	self assert: newCompiledMethod primitive equals: 0
 ]
 
 { #category : #test }
 OCCompiledMethodIntegrityTest >> testUndeclaredVariable [
-
 	| newCompiledMethod undeclaredBinding |
-	
-	newCompiledMethod := OpalCompiler new 
-								source: 'methodWithUndeclaredVar
+	newCompiledMethod := OpalCompiler new
+		source:
+			'methodWithUndeclaredVar
 											^ undeclaredTestVar';
-								class: OCMockCompilationClass;
-								compile.
+		class: OCMockCompilationClass;
+		compile.
 
-	undeclaredBinding := newCompiledMethod 
-		literals detect: [ :each | each name = #undeclaredTestVar ].
+	undeclaredBinding := newCompiledMethod literals detect: [ :each | each name = #undeclaredTestVar ].
 	self assert: undeclaredBinding class equals: UndeclaredVariable.
-	self assert: undeclaredBinding == (Undeclared associationAt: #undeclaredTestVar).
+	self assert: undeclaredBinding identicalTo: (Undeclared associationAt: #undeclaredTestVar).
 	Undeclared removeKey: #undeclaredTestVar
 ]

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -85,9 +85,9 @@ OCCompilerTest >> testAssignmentOfClassNameBinding [
 	text := 'temp | | MockForCompilation := nil'.
 
 	self
-		compileWithFailBlock: [ self assert: errorMessage = 'Cannot store into ->'.
-			self assert: errorLocation = 10.
-			self assert: errorSource contents = 'temp | | MockForCompilation := nil'.
+		compileWithFailBlock: [ self assert: errorMessage equals: 'Cannot store into ->'.
+			self assert: errorLocation equals: 10.
+			self assert: errorSource contents equals: 'temp | | MockForCompilation := nil'.
 			^ nil ].
 	self fail
 ]
@@ -112,16 +112,14 @@ OCCompilerTest >> testInBlockArgumentInstanceVariableShadowing [
 	interactive := true.
 	self initializeErrorMessage.
 	text := 'temp [:var1 | ]'.
-	
-	self compile.
-	
-	self flag: 'display menu instead of going into failblock'.
-	
-	self assert: (errorMessage = 'Name already defined ->').
-				self assert: (errorLocation = 8).
-				self assert: (errorSource contents = 'temp [:var1 | ]').
-				
 
+	self compile.
+
+	self flag: 'display menu instead of going into failblock'.
+
+	self assert: errorMessage equals: 'Name already defined ->'.
+	self assert: errorLocation equals: 8.
+	self assert: errorSource contents equals: 'temp [:var1 | ]'
 ]
 
 { #category : #'test shadowing' }
@@ -130,13 +128,12 @@ OCCompilerTest >> testInBlockTempArgumentShadowing [
 	self initializeErrorMessage.
 	text := 'temp [:temp | |temp|]'.
 
-	self compileWithFailBlock: [
-				self assert: (errorMessage = 'Name already defined ->').
-				self assert: (errorLocation = 16).
-				self assert: (errorSource contents = 'temp [:temp | |temp|]').
-						^nil].
-	self fail.
-
+	self
+		compileWithFailBlock: [ self assert: errorMessage equals: 'Name already defined ->'.
+			self assert: errorLocation equals: 16.
+			self assert: errorSource contents equals: 'temp [:temp | |temp|]'.
+			^ nil ].
+	self fail
 ]
 
 { #category : #'test shadowing' }
@@ -145,47 +142,40 @@ OCCompilerTest >> testInBlockTempInstanceVariableShadowing [
 	self initializeErrorMessage.
 	text := 'temp [:temp | |var1|]'.
 
-	self compileWithFailBlock: [
-				self assert: (errorMessage = 'Name already defined ->').
-				self assert: (errorLocation = 16).
-				self assert: (errorSource contents = 'temp [:temp | |var1|]').
-				^nil].
-	self fail.
+	self
+		compileWithFailBlock: [ self assert: errorMessage equals: 'Name already defined ->'.
+			self assert: errorLocation equals: 16.
+			self assert: errorSource contents equals: 'temp [:temp | |var1|]'.
+			^ nil ].
+	self fail
 ]
 
 { #category : #'test shadowing' }
 OCCompilerTest >> testInBlockTempShadowing [
-
 	interactive := true.
 	self initializeErrorMessage.
 	text := 'temp |var2| [:temp| |var2|]'.
 
-	self compileWithFailBlock: [
-				self assert: (errorMessage = 'Name already defined ->').
-				self assert: (errorLocation = 22).
-				self assert: (errorSource contents = 'temp |var2| [:temp| |var2|]').
-				^nil].
-	self fail.
-
-
-
+	self
+		compileWithFailBlock: [ self assert: errorMessage equals: 'Name already defined ->'.
+			self assert: errorLocation equals: 22.
+			self assert: errorSource contents equals: 'temp |var2| [:temp| |var2|]'.
+			^ nil ].
+	self fail
 ]
 
 { #category : #'test shadowing' }
 OCCompilerTest >> testInstanceVariableShadowing [
-
 	interactive := true.
 	self initializeErrorMessage.
 	text := 'var1 |var1|'.
 
-	self compileWithFailBlock: [
-					self assert: (errorMessage = 'Name already defined ->').
-					self assert: (errorLocation = 7).
-					self assert: (errorSource contents = 'var1 |var1|').
-					^nil].
-	self fail.
-
-
+	self
+		compileWithFailBlock: [ self assert: errorMessage equals: 'Name already defined ->'.
+			self assert: errorLocation equals: 7.
+			self assert: errorSource contents equals: 'var1 |var1|'.
+			^ nil ].
+	self fail
 ]
 
 { #category : #literals }
@@ -395,71 +385,67 @@ OCCompilerTest >> testNotInteractiveSiblingBlocksTempShadowing [
 
 { #category : #'test shadowing' }
 OCCompilerTest >> testReservedNameAsBlockArgumentShadowing [
-	
 	interactive := true.
-	#( 'self' 'super' 'thisContext' 'true' 'false' 'nil' ) do: [ :each |
-		self initializeErrorMessage.
-		[ :exit | 
-			OpalCompiler new 
+	#('self' 'super' 'thisContext' 'true' 'false' 'nil')
+		do: [ :each | 
+			self initializeErrorMessage.
+			[ :exit | 
+			OpalCompiler new
 				source: 'temp ^ [ :' , each , ' | ^ ' , each , ' ]';
 				class: MockForCompilation;
 				requestor: self;
 				failBlock: [ exit value ];
 				compile.
 			self fail ] valueWithExit.
-		self assert: ((errorMessage = 'Variable name expected ->' )or: [ errorMessage =  'Name already defined ->' ]).
-		self assert: errorLocation = 11 ]
+			self assert: (errorMessage = 'Variable name expected ->' or: [ errorMessage = 'Name already defined ->' ]).
+			self assert: errorLocation equals: 11 ]
 ]
 
 { #category : #'test shadowing' }
 OCCompilerTest >> testReservedNameAsMethodArgumentShadowing [
-
 	interactive := true.
-	#( 'self' 'super' 'thisContext' 'true' 'false' 'nil' ) do: [ :each |
-		self initializeErrorMessage.
-		[ :exit | 
-			OpalCompiler new 
+	#('self' 'super' 'thisContext' 'true' 'false' 'nil')
+		do: [ :each | 
+			self initializeErrorMessage.
+			[ :exit | 
+			OpalCompiler new
 				source: 'temp: ' , each , ' ^ ' , each;
-				class:  MockForCompilation;
+				class: MockForCompilation;
 				requestor: self;
 				failBlock: [ exit value ];
 				compile.
 			self fail ] valueWithExit.
-		self assert: ((errorMessage = 'Variable name expected ->' )or: [ errorMessage =  'Name already defined ->' ]).
-		self assert: errorLocation = 7 ]
+			self assert: (errorMessage = 'Variable name expected ->' or: [ errorMessage = 'Name already defined ->' ]).
+			self assert: errorLocation equals: 7 ]
 ]
 
 { #category : #literals }
 OCCompilerTest >> testScaledDecimalLiterals [
 	"Equal ScaledDecimal with different scales should use different slots
 	This is related to http://bugs.squeak.org/view.php?id=6797"
-	
+
 	"This correctly works when evaluated separately"
-	self deny: (Smalltalk compiler evaluate: '0.5s1') scale = (Smalltalk compiler evaluate: '0.5s2') scale.
-	
+
+	self deny: (Smalltalk compiler evaluate: '0.5s1') scale equals: (Smalltalk compiler evaluate: '0.5s2') scale.
+
 	"But not when evaluated together if literal reduction is too agressive"
-	self deny: (Smalltalk compiler evaluate: '0.5s1 scale =  0.5s2 scale').
+	self deny: (Smalltalk compiler evaluate: '0.5s1 scale =  0.5s2 scale')
 ]
 
 { #category : #'test shadowing' }
 OCCompilerTest >> testSiblingBlocksInstanceVariableShadowing [
-
 	interactive := true.
 	self initializeErrorMessage.
-	
+
 	OpalCompiler new
 		source: 'temp [:temp | ].[:temp | |var1|]';
 		class: MockForCompilation;
 		requestor: self;
-		failBlock: [
-				self assert: (errorMessage = 'Name already defined ->').
-				self assert: (errorLocation = 27).
-				^nil];
+		failBlock: [ self assert: errorMessage equals: 'Name already defined ->'.
+			self assert: errorLocation equals: 27.
+			^ nil ];
 		compile.
-	self fail.
-
-
-	
+	self fail
 ]
 
 { #category : #'test shadowing' }

--- a/src/OpalCompiler-Tests/OCContextTempMappingTest.class.st
+++ b/src/OpalCompiler-Tests/OCContextTempMappingTest.class.st
@@ -86,56 +86,53 @@ OCContextTempMappingTest >> testAccessingMethodArgFromOptimizedBlockContext [
 { #category : #tests }
 OCContextTempMappingTest >> testAccessingMultipleVariablesInVector [
 	| t1 t2 t3 t4 t5 t6 |
-	
 	"Check the source code availability to do not fail on images without sources"
 	thisContext method hasSourceCode ifFalse: [ ^ self skip ].
-	
+
 	t1 := 1.
 	t2 := 2.
 	t3 := 3.
-	t4 := 4. 
-	t5 := 5 .
+	t4 := 4.
+	t5 := 5.
 	t6 := 6.
-	[t5 := 50.
-	    t6 := 60.
-	    t3 + t4.
-	] value.
-	
-	self assert: t1 == (thisContext tempNamed: 't1').
-	self assert: t2 == (thisContext tempNamed: 't2').
-	self assert: t3 == (thisContext tempNamed: 't3').
-	self assert: t4 == (thisContext tempNamed: 't4').
-	self assert: t5 == (thisContext tempNamed: 't5').
-	self assert: t6 == (thisContext tempNamed: 't6').
+	[ t5 := 50.
+	t6 := 60.
+	t3 + t4 ] value.
+
+	self assert: t1 identicalTo: (thisContext tempNamed: 't1').
+	self assert: t2 identicalTo: (thisContext tempNamed: 't2').
+	self assert: t3 identicalTo: (thisContext tempNamed: 't3').
+	self assert: t4 identicalTo: (thisContext tempNamed: 't4').
+	self assert: t5 identicalTo: (thisContext tempNamed: 't5').
+	self assert: t6 identicalTo: (thisContext tempNamed: 't6')
 ]
 
 { #category : #tests }
 OCContextTempMappingTest >> testAccessingTempsVectorInBlock [
-
 	"Check the source code availability to do not fail on images without sources"
+
 	thisContext method hasSourceCode ifFalse: [ ^ self skip ].
 
 	[ | temp |
-		[ temp := 1.
-		self assert: ((thisContext tempNamed: 'temp') == 1) ] value.
-	] value
+	[ temp := 1.
+	self assert: (thisContext tempNamed: 'temp') identicalTo: 1 ] value ] value
 ]
 
 { #category : #tests }
 OCContextTempMappingTest >> testAccessingTempsVectorInBlock2 [
-
-	|a b r |
-	
+	| a b r |
 	"Check the source code availability to do not fail on images without sources"
 	thisContext method hasSourceCode ifFalse: [ ^ self skip ].
-	
-	a := [ r := 'failure'].
-	[ b :='success'.
-	r := thisContext ] on: Error do: a.
 
-	self assert: r == (r tempNamed: 'r').
-	self assert: (r tempNamed: 'a') == a.
-	self assert: (r tempNamed: 'b') == b.
+	a := [ r := 'failure' ].
+	[ b := 'success'.
+	r := thisContext ]
+		on: Error
+		do: a.
+
+	self assert: r identicalTo: (r tempNamed: 'r').
+	self assert: (r tempNamed: 'a') identicalTo: a.
+	self assert: (r tempNamed: 'b') identicalTo: b
 ]
 
 { #category : #tests }
@@ -157,46 +154,41 @@ OCContextTempMappingTest >> testAccessingTempsVectorInBlock3 [
 { #category : #tests }
 OCContextTempMappingTest >> testAccessingVariablesInBlock [
 	| theContext |
-
 	"Check the source code availability to do not fail on images without sources"
 	thisContext method hasSourceCode ifFalse: [ ^ self skip ].
 
 	[ | t1 |
-		t1 := true.
-		theContext := thisContext.
-		self assert: (thisContext tempNamed: 'theContext') == thisContext.
-		self assert: (theContext tempNamed: 't1').
-	] value
-	
+	t1 := true.
+	theContext := thisContext.
+	self assert: (thisContext tempNamed: 'theContext') identicalTo: thisContext.
+	self assert: (theContext tempNamed: 't1') ] value
 ]
 
 { #category : #tests }
 OCContextTempMappingTest >> testAccessingVariablesInOptimizedBlock [
-	
 	"Check the source code availability to do not fail on images without sources"
+
 	thisContext method hasSourceCode ifFalse: [ ^ self skip ].
 
-	1 to: 2 do: [ :index | |optimizedTemp|
+	1 to: 2 do: [ :index | 
+		| optimizedTemp |
 		optimizedTemp := index.
-		self assert: (thisContext tempNamed: 'optimizedTemp') == index
-	]
+		self assert: (thisContext tempNamed: 'optimizedTemp') identicalTo: index ]
 ]
 
 { #category : #tests }
 OCContextTempMappingTest >> testAccessingVariablesInOptimizedBlock2 [
-
 	| a b |
-
 	"Check the source code availability to do not fail on images without sources"
 	thisContext method hasSourceCode ifFalse: [ ^ self skip ].
 
-	a:=1.
-	b:=2.
-	
-	a < b ifTrue:[ |c|
-		c:=50.
-		self assert: (thisContext tempNamed: 'a') == 1.
-		self assert: (thisContext tempNamed: 'b') == 2.
-		self assert: (thisContext tempNamed: 'c') == 50.
-	].
+	a := 1.
+	b := 2.
+
+	a < b
+		ifTrue: [ | c |
+			c := 50.
+			self assert: (thisContext tempNamed: 'a') identicalTo: 1.
+			self assert: (thisContext tempNamed: 'b') identicalTo: 2.
+			self assert: (thisContext tempNamed: 'c') identicalTo: 50 ]
 ]

--- a/src/OpalCompiler-Tests/OCIfNotNilTest.class.st
+++ b/src/OpalCompiler-Tests/OCIfNotNilTest.class.st
@@ -6,41 +6,37 @@ Class {
 
 { #category : #tests }
 OCIfNotNilTest >> testIfNilIfNotNil0Arg [
-
-	self assert: (5 ifNil: [#foo] ifNotNil: [#bar]) = #bar.
-	self assert: (nil ifNil: [#foo] ifNotNil: [#bar]) = #foo
+	self assert: (5 ifNil: [ #foo ] ifNotNil: [ #bar ]) equals: #bar.
+	self assert: (nil ifNil: [ #foo ] ifNotNil: [ #bar ]) equals: #foo
 ]
 
 { #category : #tests }
 OCIfNotNilTest >> testIfNilIfNotNil0ArgAsVar [
-
 	| block1 block2 |
-	block1 := [#foo].
-	block2 := [#bar].
-	self assert: (5 ifNil: block1 ifNotNil: block2) = #bar.
-	self assert: (nil ifNil: block1 ifNotNil: block2) = #foo
+	block1 := [ #foo ].
+	block2 := [ #bar ].
+	self assert: (5 ifNil: block1 ifNotNil: block2) equals: #bar.
+	self assert: (nil ifNil: block1 ifNotNil: block2) equals: #foo
 ]
 
 { #category : #tests }
 OCIfNotNilTest >> testIfNilIfNotNil1Arg [
-
-	self assert: (5 ifNil: [#foo] ifNotNil: [:a | a printString]) = '5'.
-	self assert: (nil ifNil: [#foo] ifNotNil: [:a | a printString]) = #foo
+	self assert: (5 ifNil: [ #foo ] ifNotNil: [ :a | a printString ]) equals: '5'.
+	self assert: (nil ifNil: [ #foo ] ifNotNil: [ :a | a printString ]) equals: #foo
 ]
 
 { #category : #tests }
 OCIfNotNilTest >> testIfNilIfNotNil1ArgAsVar [
-
 	| block1 block2 |
-	block1 := [#foo].
-	block2 := [:a | a printString].
-	self assert: (5 ifNil: block1 ifNotNil: block2) = '5'.
-	self assert: (nil ifNil: block1 ifNotNil: block2) = #foo
+	block1 := [ #foo ].
+	block2 := [ :a | a printString ].
+	self assert: (5 ifNil: block1 ifNotNil: block2) equals: '5'.
+	self assert: (nil ifNil: block1 ifNotNil: block2) equals: #foo
 ]
 
 { #category : #tests }
 OCIfNotNilTest >> testIfNotNil0Arg [
-	self assert: (5 ifNotNil: [ #foo ]) = #foo.
+	self assert: (5 ifNotNil: [ #foo ]) equals: #foo.
 	self assert: (nil ifNotNil: [ #foo ]) isNil
 ]
 
@@ -48,13 +44,13 @@ OCIfNotNilTest >> testIfNotNil0Arg [
 OCIfNotNilTest >> testIfNotNil0ArgAsVar [
 	| block |
 	block := [ #foo ].
-	self assert: (5 ifNotNil: block) = #foo.
+	self assert: (5 ifNotNil: block) equals: #foo.
 	self assert: (nil ifNotNil: block) isNil
 ]
 
 { #category : #tests }
 OCIfNotNilTest >> testIfNotNil1Arg [
-	self assert: (5 ifNotNil: [ :a | a printString ]) = '5'.
+	self assert: (5 ifNotNil: [ :a | a printString ]) equals: '5'.
 	self assert: (nil ifNotNil: [ :a | a printString ]) isNil
 ]
 
@@ -62,46 +58,54 @@ OCIfNotNilTest >> testIfNotNil1Arg [
 OCIfNotNilTest >> testIfNotNil1ArgAsVar [
 	| block |
 	block := [ :a | a printString ].
-	self assert: (5 ifNotNil: block) = '5'.
+	self assert: (5 ifNotNil: block) equals: '5'.
 	self assert: (nil ifNotNil: block) isNil
 ]
 
 { #category : #tests }
 OCIfNotNilTest >> testIfNotNil1ArgWithStatement [
-	self assert: (5 ifNotNil: [ :a | 3. a ]) = 5.
-	self assert: (5 ifNotNil: [ :a | a. 3 ]) = 3.
+	self
+		assert:
+			(5
+				ifNotNil: [ :a | 
+					3.
+					a ])
+		equals: 5.
+	self
+		assert:
+			(5
+				ifNotNil: [ :a | 
+					a.
+					3 ])
+		equals: 3
 ]
 
 { #category : #tests }
 OCIfNotNilTest >> testIfNotNilIfNil0Arg [
-
-	self assert: (5 ifNotNil: [#foo] ifNil: [#bar]) = #foo.
-	self assert: (nil ifNotNil: [#foo] ifNil: [#bar]) = #bar
+	self assert: (5 ifNotNil: [ #foo ] ifNil: [ #bar ]) equals: #foo.
+	self assert: (nil ifNotNil: [ #foo ] ifNil: [ #bar ]) equals: #bar
 ]
 
 { #category : #tests }
 OCIfNotNilTest >> testIfNotNilIfNil0ArgAsVar [
-
 	| block1 block2 |
-	block1 := [#foo].
-	block2 := [#bar].
-	self assert: (5 ifNotNil: block2 ifNil: block1) = #bar.
-	self assert: (nil ifNotNil: block2 ifNil: block1) = #foo
+	block1 := [ #foo ].
+	block2 := [ #bar ].
+	self assert: (5 ifNotNil: block2 ifNil: block1) equals: #bar.
+	self assert: (nil ifNotNil: block2 ifNil: block1) equals: #foo
 ]
 
 { #category : #tests }
 OCIfNotNilTest >> testIfNotNilIfNil1Arg [
-
-	self assert: (5 ifNotNil: [:a | a printString] ifNil: [#foo]) = '5'.
-	self assert: (nil ifNotNil: [:a | a printString] ifNil: [#foo]) = #foo
+	self assert: (5 ifNotNil: [ :a | a printString ] ifNil: [ #foo ]) equals: '5'.
+	self assert: (nil ifNotNil: [ :a | a printString ] ifNil: [ #foo ]) equals: #foo
 ]
 
 { #category : #tests }
 OCIfNotNilTest >> testIfNotNilIfNil1ArgAsVar [
-
 	| block1 block2 |
-	block1 := [#foo].
-	block2 := [:a | a printString].
-	self assert: (5 ifNotNil: block2 ifNil: block1) = '5'.
-	self assert: (nil ifNotNil: block2 ifNil: block1) = #foo
+	block1 := [ #foo ].
+	block2 := [ :a | a printString ].
+	self assert: (5 ifNotNil: block2 ifNil: block1) equals: '5'.
+	self assert: (nil ifNotNil: block2 ifNil: block1) equals: #foo
 ]

--- a/src/OpalCompiler-Tests/OCNewCompilerWithChangesFunctionalTest.class.st
+++ b/src/OpalCompiler-Tests/OCNewCompilerWithChangesFunctionalTest.class.st
@@ -442,19 +442,17 @@ OCNewCompilerWithChangesFunctionalTest >> testOneFloat [
 
 { #category : #tests }
 OCNewCompilerWithChangesFunctionalTest >> testPragma [
-	
 	| aCompiledMethod bytecode |
-	aCompiledMethod := OpalCompiler new 
-									source: 'methodDoublePragma
+	aCompiledMethod := OpalCompiler new
+		source:
+			'methodDoublePragma
 											<hello: 5>
 											<hello: 2>';
-									class:  OCMockCompilationClass;
-									compile.
-									
+		class: OCMockCompilationClass;
+		compile.
+
 	bytecode := aCompiledMethod symbolic asString substrings: String cr.
-	self assert: bytecode first = 'Quick return self'.
-
-
+	self assert: bytecode first equals: 'Quick return self'
 ]
 
 { #category : #tests }

--- a/src/OpalCompiler-Tests/OCPragmaTest.class.st
+++ b/src/OpalCompiler-Tests/OCPragmaTest.class.st
@@ -72,11 +72,11 @@ OCPragmaTest >> methodSinglePragma [
 
 { #category : #testing }
 OCPragmaTest >> testDoublePragma [
-	| aRBMethode |	
+	| aRBMethode |
 	aRBMethode := OpalCompiler new parse: self methodDoublePragma.
-	
-	self assert: (aRBMethode compiledMethod pragmas first selector = #hello:).
-	self assert: (aRBMethode compiledMethod pragmas second selector = #hello:)
+
+	self assert: aRBMethode compiledMethod pragmas first selector equals: #hello:.
+	self assert: aRBMethode compiledMethod pragmas second selector equals: #hello:
 ]
 
 { #category : #testing }
@@ -95,73 +95,63 @@ OCPragmaTest >> testNoPragma [
 
 { #category : #testing }
 OCPragmaTest >> testPragmaAfterBeforTemp [
-	
 	| aRBMethode |
 	aRBMethode := OpalCompiler new parse: self methodPragmaAfterBeforTemps.
 
-	self assert: (aRBMethode compiledMethod pragmas first selector = #hello:).
-	self assert: (aRBMethode compiledMethod pragmas second selector = #world:)
-	
+	self assert: aRBMethode compiledMethod pragmas first selector equals: #hello:.
+	self assert: aRBMethode compiledMethod pragmas second selector equals: #world:
 ]
 
 { #category : #testing }
 OCPragmaTest >> testPragmaTwoParam [
- 
 	| aRBMethode |
 	aRBMethode := OpalCompiler new parse: self methodPragmaTwoParam.
 
 
-	self assert: (aRBMethode compiledMethod pragmas first selector = #hello:by:)
-	
+	self assert: aRBMethode compiledMethod pragmas first selector equals: #hello:by:
 ]
 
 { #category : #testing }
 OCPragmaTest >> testPragmaUnarayMessage [
 	| aRBMethode |
-
 	aRBMethode := OpalCompiler new parse: self methodPragmaUnarayMessage.
-	
-	self assert: (aRBMethode compiledMethod pragmas first selector = #hello)
+
+	self assert: aRBMethode compiledMethod pragmas first selector equals: #hello
 ]
 
 { #category : #testing }
 OCPragmaTest >> testPrimitiveNumber [
 	| aRBMethode |
-
 	aRBMethode := OpalCompiler new parse: self methodPrimitive.
-	self assert: (aRBMethode compiledMethod primitive = 4)
+	self assert: aRBMethode compiledMethod primitive equals: 4
 ]
 
 { #category : #testing }
 OCPragmaTest >> testPrimitivePragmaNumber [
 	| aRBMethode |
-
 	aRBMethode := OpalCompiler new parse: self methodPrimitivePragma.
-	self assert: (aRBMethode compiledMethod primitive = 4)
+	self assert: aRBMethode compiledMethod primitive equals: 4
 ]
 
 { #category : #testing }
 OCPragmaTest >> testPrimitiveString [
 	| aRBMethode |
-
 	aRBMethode := OpalCompiler new parse: self methodPrimitiveString.
-	
-	self assert: (aRBMethode compiledMethod primitive = 117)
+
+	self assert: aRBMethode compiledMethod primitive equals: 117
 ]
 
 { #category : #testing }
 OCPragmaTest >> testPrimitiveStringModule [
 	| aRBMethode |
-
 	aRBMethode := OpalCompiler new parse: self methodPrimitiveStringModule.
-	
-	self assert: (aRBMethode compiledMethod primitive = 117)
+
+	self assert: aRBMethode compiledMethod primitive equals: 117
 ]
 
 { #category : #testing }
 OCPragmaTest >> testSinglePragma [
 	| aRBMethode |
 	aRBMethode := OpalCompiler new parse: self methodSinglePragma.
-	self assert: (aRBMethode compiledMethod pragmas first selector = #hello:)
-	
+	self assert: aRBMethode compiledMethod pragmas first selector equals: #hello:
 ]

--- a/src/OpalCompiler-Tests/OCScannerTest.class.st
+++ b/src/OpalCompiler-Tests/OCScannerTest.class.st
@@ -11,7 +11,7 @@ OCScannerTest >> testAmbiguousSelector [
 	and http://bugs.squeak.org/view.php?id=7491"
 
 	'1@-1' parseLiterals.
-	self assert: ('1@-1' parseLiterals at: 2) asString = '@-'
+	self assert: ('1@-1' parseLiterals at: 2) asString equals: '@-'
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Tests/OCVariableSpecialisationTest.class.st
+++ b/src/OpalCompiler-Tests/OCVariableSpecialisationTest.class.st
@@ -9,14 +9,13 @@ OCVariableSpecialisationTest >> testVarTemp [
 	| sequenceNode returnNode |
 	sequenceNode := RBParser parseExpression: '| t1 t2 t3 | t1 := 1. t2 := 2. t3 := 3. ^t2'.
 	returnNode := sequenceNode statements last.
-	
+
 	"before semantic analysis, this is just a variableNode"
-	self assert: (returnNode value class == RBVariableNode ).
-	self deny: (returnNode value class == RBTemporaryNode).
-	
+	self assert: returnNode value class identicalTo: RBVariableNode.
+	self deny: returnNode value class identicalTo: RBTemporaryNode.
+
 	sequenceNode doSemanticAnalysis.
 	"after, it is specialized to a temporary"
 	returnNode := sequenceNode statements last.
-	self assert: (returnNode value class == RBTemporaryNode).
-	
+	self assert: returnNode value class identicalTo: RBTemporaryNode
 ]


### PR DESCRIPTION
Replace assert = in packages starting by O.

Replace:

- assert: = by assert: equals:
- deny = by deny: equals:
- assert: == by assert: identicalTo:
- deny: == by deny: identicalTo: