### PR TITLE
Replace-assert-equals-from-packages-starting-with-P

### DIFF
--- a/src/ProfStef-Tests/PharoTutorialGoTest.class.st
+++ b/src/ProfStef-Tests/PharoTutorialGoTest.class.st
@@ -49,5 +49,5 @@ PharoTutorialGoTest >> testGoTwiceUseSameLessonView [
 	ProfStef go.
 	firstLessonView := ProfStef default lessonView.
 	ProfStef goOn: PharoSyntaxTutorial.
-	self assert: (firstLessonView ==  ProfStef default lessonView).
+	self assert: firstLessonView identicalTo: ProfStef default lessonView
 ]

--- a/src/ProfStef-Tests/PharoTutorialHelpTest.class.st
+++ b/src/ProfStef-Tests/PharoTutorialHelpTest.class.st
@@ -17,8 +17,8 @@ PharoTutorialHelpTest >> testCreateATutorial [
 	| helpTopic |
 	helpTopic := PharoTutorialHelp createATutorial.
 	self assert: helpTopic notNil.
-	self assert: helpTopic class == HelpTopic.
-	self assert: helpTopic title = 'Create a tutorial'
+	self assert: helpTopic class identicalTo: HelpTopic.
+	self assert: helpTopic title equals: 'Create a tutorial'
 ]
 
 { #category : #tests }
@@ -26,16 +26,16 @@ PharoTutorialHelpTest >> testIntroduction [
 	| helpTopic |
 	helpTopic := PharoTutorialHelp introduction.
 	self assert: helpTopic notNil.
-	self assert: helpTopic class == HelpTopic.
-	self assert: helpTopic title = 'Introduction'
+	self assert: helpTopic class identicalTo: HelpTopic.
+	self assert: helpTopic title equals: 'Introduction'
 ]
 
 { #category : #tests }
 PharoTutorialHelpTest >> testListOfTutorials [
 	| helpTopic |
-	helpTopic  := PharoTutorialHelp listOfTutorials.
-	self assert: (helpTopic notNil).
-	self assert: (helpTopic title =  'List of tutorials'  )
+	helpTopic := PharoTutorialHelp listOfTutorials.
+	self assert: helpTopic notNil.
+	self assert: helpTopic title equals: 'List of tutorials'
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Replace assert = in packages starting by P.

Replace:

- assert: = by assert: equals:
- deny = by deny: equals:
- assert: == by assert: identicalTo:
- deny: == by deny: identicalTo:f