### PR TITLE
Replace-assert-equals-from-packages-starting-with-R

### DIFF
--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -685,27 +685,26 @@ RPackageIncrementalTest >> testMethodPackageResolution [
 	a1 := self createNewClassNamed: a1Name inPackage: p1.
 	a1 compileSilently: 'method ^ #methodDefinedInP2'.
 	a1 class compileSilently: 'method ^ #methodDefinedInP2'.
-	
-	p1 addMethod:  (a1>>#method).
-	p1 addMethod:  (a1 class>>#method).
-	
-	self assert: (a1 >> #method) package == p1.
-	self assert: (a1 class >> #method) package == p1.
+
+	p1 addMethod: a1 >> #method.
+	p1 addMethod: a1 class >> #method.
+
+	self assert: (a1 >> #method) package identicalTo: p1.
+	self assert: (a1 class >> #method) package identicalTo: p1
 ]
 
 { #category : #'test package belonging' }
 RPackageIncrementalTest >> testPackageOfClassForClassesNotDefinedInPackageButJustExtendingIt [
-	| p1 p2 a2  |
+	| p1 p2 a2 |
 	p1 := self createNewPackageNamed: 'P1'.
 	p2 := self createNewPackageNamed: 'P2'.
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: (a2>>#methodDefinedInP1).
-	
+	p1 addMethod: a2 >> #methodDefinedInP1.
+
 	self assert: a2 package equals: p2.
-	p1 extensionMethods do: 
-		[:each | self deny: each methodClass package = p1 ].
+	p1 extensionMethods do: [ :each | self deny: each methodClass package equals: p1 ]
 	"the package of a class which is extended inside a package p, is not p
 	but the package where the class was defined"
 ]

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -251,16 +251,12 @@ RPackageReadOnlyCompleteSetupTest >> testExtensionMethods [
 	self assert: (extensionMethods includes: a2 class >> #classSideMethodDefinedInP3).
 	cpt := 0.
 	package
-		metaclassExtensionSlicesDo: [ :className :listOfSelectors | 
-			(className = a2 name and: [ listOfSelectors includes: #classSideMethodDefinedInP3 ])
-				ifTrue: [ cpt := cpt + 1 ] ].
+		metaclassExtensionSlicesDo: [ :className :listOfSelectors | (className = a2 name and: [ listOfSelectors includes: #classSideMethodDefinedInP3 ]) ifTrue: [ cpt := cpt + 1 ] ].
 	self assert: cpt equals: 1.
 	cpt := 0.
 	package
-		classExtensionSlicesDo: [ :className :listOfSelectors | 
-			(className = a2 name and: [ listOfSelectors includes: #methodDefinedInP3 ])
-				ifTrue: [ cpt := cpt + 1 ] ].
-	self assert: cpt = 1
+		classExtensionSlicesDo: [ :className :listOfSelectors | (className = a2 name and: [ listOfSelectors includes: #methodDefinedInP3 ]) ifTrue: [ cpt := cpt + 1 ] ].
+	self assert: cpt equals: 1
 ]
 
 { #category : #'test situation' }

--- a/src/RPackage-Tests/RPackageRenameTest.class.st
+++ b/src/RPackage-Tests/RPackageRenameTest.class.st
@@ -31,8 +31,8 @@ RPackageRenameTest >> tearDown [
 { #category : #tests }
 RPackageRenameTest >> testRenamePackage [
 	"Test that we do rename the package as expected."
-	| package workingCopy class |
 
+	| package workingCopy class |
 	package := RPackageOrganizer default registerPackageNamed: 'Test1'.
 	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1').
 	class := Object
@@ -49,17 +49,16 @@ RPackageRenameTest >> testRenamePackage [
 	self assert: (package includesClass: class).
 	self assert: (package classTagNamed: #TAG ifAbsent: [ nil ]) notNil.
 	self assert: ((package classTagNamed: #TAG ifAbsent: [ nil ]) includesClass: class).
-	self assert: class category = #'TestRename-TAG'.	
+	self assert: class category equals: #'TestRename-TAG'.
 	self deny: (Smalltalk organization includesCategory: #Test1).
 	self deny: (MCWorkingCopy hasPackageNamed: #Test1).
-	
+
 	"cleaning"
 	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'TestRename').
 	self assert: workingCopy modified.
-	workingCopy unload.	
+	workingCopy unload.
 	self deny: (RPackageOrganizer default includesPackageNamed: #TestRename).
-	self deny: (MCWorkingCopy hasPackageNamed: #TestRename).
-
+	self deny: (MCWorkingCopy hasPackageNamed: #TestRename)
 ]
 
 { #category : #tests }

--- a/src/RPackage-Tests/RPackageTraitTest.class.st
+++ b/src/RPackage-Tests/RPackageTraitTest.class.st
@@ -87,37 +87,38 @@ RPackageTraitTest >> setUp [
 RPackageTraitTest >> testPackageOfClassMethodFromTraitExtensionIsExtendingPackage [
 	"The package of a method defined in atrait but package in another package than the extended trait is the 
 	package containing the extension."
-	
+
 	"The package of a method in A1 (which is coming from the trait T1 used by A1) is the package of T1"
-	self assert: ((a1>>#traitMethodExtendedFromP4) packageFromOrganizer: self packageClass organizer) = p4.
+
+	self assert: (a1 >> #traitMethodExtendedFromP4 packageFromOrganizer: self packageClass organizer) equals: p4.
 	"The package of a method in A1 (which is coming from the trait T1 used by A1 but extended in package T2) is the package of T2"
-	self assert: ((a1>>#traitMethodExtendedFromP6) packageFromOrganizer: self packageClass organizer) = p6.
+	self assert: (a1 >> #traitMethodExtendedFromP6 packageFromOrganizer: self packageClass organizer) equals: p6
 ]
 
 { #category : #tests }
 RPackageTraitTest >> testPackageOfClassMethodFromTraitIsTraitPackage [
-
 	"test that a class method coming from a trait is packaged in the trait package"
-	self assert: ((a1>>#traitMethodDefinedInP4) packageFromOrganizer: self packageClass organizer) = p4.
-	self assert: ((a1>>#traitMethodDefinedInP5) packageFromOrganizer: self packageOrganizerClass default) = p5.
+
+	self assert: (a1 >> #traitMethodDefinedInP4 packageFromOrganizer: self packageClass organizer) equals: p4.
+	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: self packageOrganizerClass default) equals: p5
 ]
 
 { #category : #tests }
 RPackageTraitTest >> testPackageOfClassMethodIsClassPackage [
 	"The package of a local method (not defined in a trait) is the package of its class"
-	
-	self assert: ((a1>>#localMethodDefinedInP1) packageFromOrganizer: self packageClass organizer) = p4.
-	self assert: ((a1>>#anotherLocalMethodDefinedInP1) packageFromOrganizer: self packageOrganizerClass default) = p4.
-	self assert: ((a1>>#anotherLocalMethodDefinedInP1) packageFromOrganizer: self packageClass organizer) = p4.
+
+	self assert: (a1 >> #localMethodDefinedInP1 packageFromOrganizer: self packageClass organizer) equals: p4.
+	self assert: (a1 >> #anotherLocalMethodDefinedInP1 packageFromOrganizer: self packageOrganizerClass default) equals: p4.
+	self assert: (a1 >> #anotherLocalMethodDefinedInP1 packageFromOrganizer: self packageClass organizer) equals: p4
 ]
 
 { #category : #tests }
 RPackageTraitTest >> testPackageOfTraitMethodIsTraitPackage [
 	"The package of a trait method is the package of its trait."
 
-	self assert: ((a1 >> #traitMethodDefinedInP5) packageFromOrganizer: self packageClass organizer) = p5.
-	self assert: ((a1 >> #traitMethodDefinedInP5)packageFromOrganizer: self packageOrganizerClass default) = p5.
-	self assert: ((a1>>#traitMethodDefinedInP4) packageFromOrganizer: self packageClass organizer) = p4.
+	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: self packageClass organizer) equals: p5.
+	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: self packageOrganizerClass default) equals: p5.
+	self assert: (a1 >> #traitMethodDefinedInP4 packageFromOrganizer: self packageClass organizer) equals: p4
 ]
 
 { #category : #tests }

--- a/src/Random-Tests/RandomTest.class.st
+++ b/src/Random-Tests/RandomTest.class.st
@@ -34,13 +34,14 @@ RandomTest >> testDistribution [
 
 { #category : #tests }
 RandomTest >> testIfCompletelyBroken [
-
 	"If the results are not these values (accounting for precision of printing) 
 	then something is horribly wrong"
-	
-	gen seed: 2345678901.
-	self assert: (((1 to: 10) collect: [:i | gen next round: 15]) = #(0.149243269650845 0.331633021743797 0.756196448000239 0.393701540023881 0.941783181364547 0.549929193942775 0.659962596213428 0.991354559078512 0.696074432551895 0.922987899707159)).	
 
+	gen seed: 2345678901.
+	self
+		assert: ((1 to: 10) collect: [ :i | gen next round: 15 ])
+		equals:
+			#(0.149243269650845 0.331633021743797 0.756196448000239 0.393701540023881 0.941783181364547 0.549929193942775 0.659962596213428 0.991354559078512 0.696074432551895 0.922987899707159)
 ]
 
 { #category : #tests }

--- a/src/Refactoring-Tests-Core/RBChildrenToSiblingsTest.class.st
+++ b/src/Refactoring-Tests-Core/RBChildrenToSiblingsTest.class.st
@@ -62,7 +62,7 @@ RBChildrenToSiblingsTest >> testModelChildrenToSibling [
 	| refactoring class subclass superclass |
 	class := model classNamed: #ConcreteSuperclass.
 	subclass := model classNamed: #ConcreteSubclass.
-	refactoring := RBChildrenToSiblingsRefactoring 
+	refactoring := RBChildrenToSiblingsRefactoring
 		model: model
 		name: #AbstractSuperclass
 		class: class
@@ -75,18 +75,38 @@ RBChildrenToSiblingsTest >> testModelChildrenToSibling [
 	self assert: subclass classSide superclass equals: superclass classSide.
 	self assert: (superclass parseTreeFor: #same) equals: (self parseMethod: 'same ^self initialize isKindOf: AbstractSuperclass').
 	self assert: (superclass parseTreeFor: #different) equals: (self parseMethod: 'different self subclassResponsibility').
-	self assert: (superclass parseTreeFor: #initialize) equals: (self parseMethod: 'initialize
+	self
+		assert: (superclass parseTreeFor: #initialize)
+		equals:
+			(self
+				parseMethod:
+					'initialize
 							instVarName1 := instVarName2 := ClassVarName1 := ClassVarName2 := 0').
 	self assert: (superclass directlyDefinesInstanceVariable: 'instVarName1').
 	self assert: (superclass directlyDefinesInstanceVariable: 'instVarName2').
 	self assert: (superclass directlyDefinesClassVariable: 'ClassVarName1').
 	self assert: (superclass directlyDefinesClassVariable: 'ClassVarName2').
 	self assert: (superclass classSide directlyDefinesInstanceVariable: 'classInstVarName1').
-	self assert: (superclass classSide parseTreeFor: #foo) equals: (self parseMethod: 'foo
+	self
+		assert: (superclass classSide parseTreeFor: #foo)
+		equals:
+			(self
+				parseMethod:
+					'foo
 							^classInstVarName1 + ClassVarName1 + ClassVarName2').
-	self assert: (superclass classSide parseTreeFor: #new) equals: (self parseMethod: 'new
+	self
+		assert: (superclass classSide parseTreeFor: #new)
+		equals:
+			(self
+				parseMethod:
+					'new
 							^super new initialize').
-	self assert: (superclass classSide parseTreeFor: #bar) equals: (self parseMethod: 'bar
+	self
+		assert: (superclass classSide parseTreeFor: #bar)
+		equals:
+			(self
+				parseMethod:
+					'bar
 							self subclassResponsibility').
 	self deny: (class directlyDefinesInstanceVariable: 'instVarName1').
 	self deny: (class directlyDefinesInstanceVariable: 'instVarName2').
@@ -96,8 +116,18 @@ RBChildrenToSiblingsTest >> testModelChildrenToSibling [
 	self deny: (class directlyDefinesMethod: #same).
 	self deny: (class directlyDefinesMethod: #initialize).
 	self deny: (class classSide directlyDefinesMethod: #new).
-	self assert: (class parseTreeFor: #different) equals: (self parseMethod: 'different
+	self
+		assert: (class parseTreeFor: #different)
+		equals:
+			(self
+				parseMethod:
+					'different
 							^instVarName1 + instVarName2').
-	self assert: (class classSide parseTreeFor: #bar) = (self parseMethod: 'bar
+	self
+		assert: (class classSide parseTreeFor: #bar)
+		equals:
+			(self
+				parseMethod:
+					'bar
 							^self printString')
 ]

--- a/src/Refactoring-Tests-Core/RBCreateAccessorsForVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBCreateAccessorsForVariableTest.class.st
@@ -13,28 +13,22 @@ RBCreateAccessorsForVariableTest >> setUp [
 { #category : #tests }
 RBCreateAccessorsForVariableTest >> testExistingInstanceVariableAccessors [
 	| ref |
-	ref := RBCreateAccessorsForVariableRefactoring 
-		variable: 'name'
-		class: RBLintRuleTestData
-		classVariable: false.
+	ref := RBCreateAccessorsForVariableRefactoring variable: 'name' class: RBLintRuleTestData classVariable: false.
 	self executeRefactoring: ref.
 	self assertEmpty: ref changes changes.
-	self assert: ref setterMethod == #name:.
-	self assert: ref getterMethod == #name
+	self assert: ref setterMethod identicalTo: #name:.
+	self assert: ref getterMethod identicalTo: #name
 ]
 
 { #category : #tests }
 RBCreateAccessorsForVariableTest >> testNewClassVariableAccessors [
 	| ref class |
-	ref := RBCreateAccessorsForVariableRefactoring 
-		variable: 'Foo1'
-		class: RBLintRuleTestData
-		classVariable: true.
+	ref := RBCreateAccessorsForVariableRefactoring variable: 'Foo1' class: RBLintRuleTestData classVariable: true.
 	self executeRefactoring: ref.
 	class := ref model metaclassNamed: #RBLintRuleTestData.
 	self denyEmpty: ref changes changes.
-	self assert: ref setterMethod == #foo1:.
-	self assert: ref getterMethod == #foo1.
+	self assert: ref setterMethod identicalTo: #foo1:.
+	self assert: ref getterMethod identicalTo: #foo1.
 	self assert: (class parseTreeFor: #foo1) equals: (self parseMethod: 'foo1 ^Foo1').
 	self assert: (class parseTreeFor: #foo1:) equals: (self parseMethod: 'foo1: anObject Foo1 := anObject')
 ]
@@ -46,8 +40,8 @@ RBCreateAccessorsForVariableTest >> testNewInstanceVariableAccessors [
 	self executeRefactoring: ref.
 	class := ref model classNamed: #RBLintRuleTestData.
 	self denyEmpty: ref changes changes.
-	self assert: ref setterMethod == #foo1:.
-	self assert: ref getterMethod == #foo1.
+	self assert: ref setterMethod identicalTo: #foo1:.
+	self assert: ref getterMethod identicalTo: #foo1.
 	self assert: (class parseTreeFor: #foo1) equals: (self parseMethod: 'foo1 ^foo1').
 	self assert: (class parseTreeFor: #foo1:) equals: (self parseMethod: 'foo1: anObject foo1 := anObject')
 ]

--- a/src/Refactoring-Tests-Core/RBExtractMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBExtractMethodTest.class.st
@@ -132,23 +132,34 @@ RBExtractMethodTest >> testExtractMethodThatNeedsTemporaryVariable [
 
 { #category : #tests }
 RBExtractMethodTest >> testExtractWithRenamingOfParameters [
-	| refactoring class|
-	refactoring := RBExtractMethodRefactoring
-		extract: (78 to: 197)
-		from: #displayName
-		in: RBLintRuleTestData.
+	| refactoring class |
+	refactoring := RBExtractMethodRefactoring extract: (78 to: 197) from: #displayName in: RBLintRuleTestData.
 	self setupMethodNameFor: refactoring toReturn: #foo:.
-	refactoring parameterMap: (Dictionary new at: #nameStream put: #newParameter; yourself ).
+	refactoring
+		parameterMap:
+			(Dictionary new
+				at: #nameStream put: #newParameter;
+				yourself).
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBLintRuleTestData.
 
- 	self assert: (class parseTreeFor: #displayName) = (self parseMethod: 'displayName
+	self
+		assert: (class parseTreeFor: #displayName)
+		equals:
+			(self
+				parseMethod:
+					'displayName
 	| nameStream |
 	nameStream := WriteStream on: (String new: 64).
 	self foo: nameStream.
 	^nameStream contents').
 	"Extracted method with renamed parameters"
-	self assert: (class parseTreeFor: #foo:) = (self parseMethod: 'foo: newParameter 	newParameter nextPutAll: self name;
+	self
+		assert: (class parseTreeFor: #foo:)
+		equals:
+			(self
+				parseMethod:
+					'foo: newParameter 	newParameter nextPutAll: self name;
 		nextPutAll: '' (''.
 	self problemCount printOn: newParameter.
 	newParameter nextPut: $).')

--- a/src/Refactoring-Tests-Core/RBExtractMethodToComponentTest.class.st
+++ b/src/Refactoring-Tests-Core/RBExtractMethodToComponentTest.class.st
@@ -42,60 +42,60 @@ RBExtractMethodToComponentTest >> testExtractFailure [
 { #category : #tests }
 RBExtractMethodToComponentTest >> testExtractMethodAtEndOfMethodThatNeedsReturn [
 	| refactoring class selectorsSize |
-	refactoring := RBExtractMethodToComponentRefactoring
-		extract: (52 to: 133)
-		from: #openEditor
-		in: RBLintRuleTestData.
+	refactoring := RBExtractMethodToComponentRefactoring extract: (52 to: 133) from: #openEditor in: RBLintRuleTestData.
 	self setupMethodNameFor: refactoring toReturn: #foo:.
 	self setupSelfArgumentNameFor: refactoring toReturn: 'asdf'.
 	self setupVariableToMoveToFor: refactoring toReturn: 'rules'.
-	self
-		setupVariableTypesFor: refactoring
-		toReturn: (Array with: (refactoring model classNamed: #Collection)).
+	self setupVariableTypesFor: refactoring toReturn: (Array with: (refactoring model classNamed: #Collection)).
 	class := refactoring model classNamed: #RBLintRuleTestData.
 	selectorsSize := class selectors size.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 
-	self assert: (class parseTreeFor: #openEditor) equals: (self parseMethod: 'openEditor
+	self
+		assert: (class parseTreeFor: #openEditor)
+		equals:
+			(self
+				parseMethod:
+					'openEditor
 								| rules |
 								rules := self failedRules.
 								^rules foo: self').
-	self assert: ((refactoring model classNamed: #Collection) parseTreeFor: #foo:) equals: (self parseMethod: 'foo: asdf
+	self
+		assert: ((refactoring model classNamed: #Collection) parseTreeFor: #foo:)
+		equals:
+			(self
+				parseMethod:
+					'foo: asdf
 								self isEmpty ifTrue: [^asdf].
 								self size == 1 ifTrue: [^self first viewResults].
 								^asdf').
-	self assert: class selectors size = selectorsSize
+	self assert: class selectors size equals: selectorsSize
 ]
 
 { #category : #tests }
 RBExtractMethodToComponentTest >> testMoveWithoutSelfReference [
 	| refactoring class selectorsSize |
-	refactoring := RBExtractMethodToComponentRefactoring
-		extract: (118 to: 286)
-		from: #copyDictionary:
-		in: RBReadBeforeWrittenTester.
+	refactoring := RBExtractMethodToComponentRefactoring extract: (118 to: 286) from: #copyDictionary: in: RBReadBeforeWrittenTester.
 	self setupMethodNameFor: refactoring toReturn: #copyWithAssociations.
 	self setupVariableToMoveToFor: refactoring toReturn: 'aDictionary'.
-	self
-		setupVariableTypesFor: refactoring
-		toReturn: (Array with: (refactoring model classNamed: #Dictionary)).
+	self setupVariableTypesFor: refactoring toReturn: (Array with: (refactoring model classNamed: #Dictionary)).
 	class := refactoring model classNamed: #RBReadBeforeWrittenTester.
 	selectorsSize := class selectors size.
 	self executeRefactoring: refactoring.
 
-	self 
-		assert: (class parseTreeFor: #copyDictionary:) equals: (self 
-						parseMethod: 'copyDictionary: aDictionary ^aDictionary copyWithAssociations').
-	self 
-		assert: ((refactoring model classNamed: #Dictionary) 
-				parseTreeFor: #copyWithAssociations) equals: (self 
-							parseMethod: 'copyWithAssociations 
+	self assert: (class parseTreeFor: #copyDictionary:) equals: (self parseMethod: 'copyDictionary: aDictionary ^aDictionary copyWithAssociations').
+	self
+		assert: ((refactoring model classNamed: #Dictionary) parseTreeFor: #copyWithAssociations)
+		equals:
+			(self
+				parseMethod:
+					'copyWithAssociations 
 							| newDictionary |
 							newDictionary := Dictionary new: self size.
 							self
 								keysAndValuesDo: [:key :value | newDictionary at: key put: value].
 							^newDictionary').
-	self assert: class selectors size = selectorsSize
+	self assert: class selectors size equals: selectorsSize
 ]
 
 { #category : #'failure tests' }

--- a/src/Refactoring-Tests-Core/RBRenameClassVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenameClassVariableTest.class.st
@@ -31,22 +31,34 @@ RBRenameClassVariableTest >> testNonExistantName [
 { #category : #tests }
 RBRenameClassVariableTest >> testRenameClassVar [
 	| refactoring class |
-	refactoring := RBRenameClassVariableRefactoring 
-		rename: #RecursiveSelfRule
-		to: #RSR
-		in: RBTransformationRuleTestData.
+	refactoring := RBRenameClassVariableRefactoring rename: #RecursiveSelfRule to: #RSR in: RBTransformationRuleTestData.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	self assert: (class directlyDefinesClassVariable: #RSR).
 	self deny: (class directlyDefinesClassVariable: #RecursiveSelfRule).
-	self assert: (class classSide parseTreeFor: #initializeAfterLoad1) equals: (self parseMethod: 'initializeAfterLoad1
+	self
+		assert: (class classSide parseTreeFor: #initializeAfterLoad1)
+		equals:
+			(self
+				parseMethod:
+					'initializeAfterLoad1
 								RSR := RBParseTreeSearcher new.
 								RSR
 									addMethodSearches: #(''`@methodName: `@args | `@temps | self `@methodName: `@args'' ''`@methodName: `@args | `@temps | ^self `@methodName: `@args'')
 											-> [:aNode :answer | true]').
-	self assert: (class classSide parseTreeFor: #nuke) = (self parseMethod: 'nuke
+	self
+		assert: (class classSide parseTreeFor: #nuke)
+		equals:
+			(self
+				parseMethod:
+					'nuke
 								RSR := nil').
-	self assert: (class parseTreeFor: #checkMethod:) = (self parseMethod: 'checkMethod: aSmalllintContext 
+	self
+		assert: (class parseTreeFor: #checkMethod:)
+		equals:
+			(self
+				parseMethod:
+					'checkMethod: aSmalllintContext 
 								class := aSmalllintContext selectedClass.
 								(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
 										[(RSR executeTree: rewriteRule tree initialAnswer: false)

--- a/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
+++ b/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
@@ -268,7 +268,7 @@ RBBrowserEnvironmentTest >> testEnvironmentWrapper [
 	wrapper := RBBrowserEnvironmentWrapper onEnvironment: printString.
 	self assert: wrapper numberSelectors equals: printString numberSelectors.
 	self assert: wrapper numberClasses equals: printString numberClasses.
-	self assert: wrapper environment == printString
+	self assert: wrapper environment identicalTo: printString
 ]
 
 { #category : #testing }
@@ -333,13 +333,11 @@ RBBrowserEnvironmentTest >> testOrEnvironment [
 	orEnvironment := env1 | env1 not.
 	self assert: (env2 | env1) packages size equals: 1.
 	self universalTestFor: orEnvironment.
-	self assert: orEnvironment numberSelectors 
-				equals: universalEnvironment numberSelectors.
-	self assert: orEnvironment classNames asSortedCollection 
-				equals: universalEnvironment classNames asSortedCollection.
-	self assert: (orEnvironment protocolsFor: Object) 
-				= ((universalEnvironment protocolsFor: Object) reject: [:each| (Object allSelectorsInProtocol: each) isEmpty ])
-
+	self assert: orEnvironment numberSelectors equals: universalEnvironment numberSelectors.
+	self assert: orEnvironment classNames asSortedCollection equals: universalEnvironment classNames asSortedCollection.
+	self
+		assert: (orEnvironment protocolsFor: Object)
+		equals: ((universalEnvironment protocolsFor: Object) reject: [ :each | (Object allSelectorsInProtocol: each) isEmpty ])
 ]
 
 { #category : #'testing-environments' }
@@ -394,16 +392,13 @@ RBBrowserEnvironmentTest >> testRemoveSelectorByAndAndNot [
 { #category : #testing }
 RBBrowserEnvironmentTest >> testSelectMethods [
 	| environment |
-	environment := RBBrowserEnvironment new selectMethods: [:each | false].
+	environment := RBBrowserEnvironment new selectMethods: [ :each | false ].
 	self assert: environment numberSelectors equals: 0.
 	self assert: environment numberClasses equals: 0.
-	environment := RBBrowserEnvironment new selectMethods: [:each | true].
-	self assert: environment numberSelectors 
-				equals: RBBrowserEnvironment new numberSelectors.
-	environment := RBBrowserEnvironment new 
-				selectMethods: [:each | each refersToLiteral: #environment].
-	self assert: environment numberSelectors 
-				= (RBBrowserEnvironment new referencesTo: #environment) numberSelectors
+	environment := RBBrowserEnvironment new selectMethods: [ :each | true ].
+	self assert: environment numberSelectors equals: RBBrowserEnvironment new numberSelectors.
+	environment := RBBrowserEnvironment new selectMethods: [ :each | each refersToLiteral: #environment ].
+	self assert: environment numberSelectors equals: (RBBrowserEnvironment new referencesTo: #environment) numberSelectors
 ]
 
 { #category : #'testing-environments' }

--- a/src/Refactoring2-Transformations-Tests/RBAddClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddClassTransformationTest.class.st
@@ -13,26 +13,24 @@ RBAddClassTransformationTest >> setUp [
 
 { #category : #testing }
 RBAddClassTransformationTest >> testAddClass [
-
 	| refactoring newClass superClass classTest |
 	refactoring := (RBAddClassTransformation
 		addClass: #FooTest
 		superclass: #RBTransformationTest
 		subclasses: #(RBAddClassTransformationTest)
-		category: #'Refactory-Testing')
-		asRefactoring.
+		category: #'Refactory-Testing') asRefactoring.
 	refactoring transform.
-		
+
 	newClass := refactoring model classNamed: #FooTest.
 	superClass := refactoring model classNamed: #RBTransformationTest.
 	classTest := refactoring model classNamed: self class name.
-	self assert: newClass superclass = superClass.
+	self assert: newClass superclass equals: superClass.
 	self assert: (superClass subclasses includes: newClass).
-	self assert: newClass theMetaClass superclass = superClass theMetaClass.
+	self assert: newClass theMetaClass superclass equals: superClass theMetaClass.
 	self assert: (superClass theMetaClass subclasses includes: newClass theMetaClass).
-	self assert: classTest superclass = newClass.
+	self assert: classTest superclass equals: newClass.
 	self assert: (newClass subclasses includes: classTest).
-	self assert: classTest theMetaClass superclass = newClass theMetaClass.
+	self assert: classTest theMetaClass superclass equals: newClass theMetaClass.
 	self assert: (newClass theMetaClass subclasses includes: classTest theMetaClass)
 ]
 
@@ -62,7 +60,6 @@ RBAddClassTransformationTest >> testInvalidSubclass [
 
 { #category : #testing }
 RBAddClassTransformationTest >> testModelAddClass [
-
 	| refactoring newClass superClass subclass |
 	subclass := model classNamed: #Bar.
 	superClass := model classNamed: #Foo.
@@ -71,18 +68,17 @@ RBAddClassTransformationTest >> testModelAddClass [
 		addClass: #FooTest
 		superclass: #Foo
 		subclasses: #(Bar)
-		category: #'Refactory-Testing')
-		asRefactoring.
+		category: #'Refactory-Testing') asRefactoring.
 	refactoring transform.
-		
+
 	newClass := model classNamed: #FooTest.
-	self assert: newClass superclass = superClass.
+	self assert: newClass superclass equals: superClass.
 	self assert: (superClass subclasses includes: newClass).
-	self assert: newClass theMetaClass superclass = superClass theMetaClass.
+	self assert: newClass theMetaClass superclass equals: superClass theMetaClass.
 	self assert: (superClass theMetaClass subclasses includes: newClass theMetaClass).
-	self assert: subclass superclass = newClass.
+	self assert: subclass superclass equals: newClass.
 	self assert: (newClass subclasses includes: subclass).
-	self assert: subclass theMetaClass superclass = newClass theMetaClass.
+	self assert: subclass theMetaClass superclass equals: newClass theMetaClass.
 	self assert: (newClass theMetaClass subclasses includes: subclass theMetaClass)
 ]
 
@@ -114,21 +110,19 @@ RBAddClassTransformationTest >> testModelInvalidSubclass [
 
 { #category : #testing }
 RBAddClassTransformationTest >> testTransform [
-
 	| transformation newClass superclass |
 	transformation := (RBAddClassTransformation
-		addClass: self changeMock name, 'Temporary'
+		addClass: self changeMock name , 'Temporary'
 		superclass: #Object
-		subclasses: OrderedCollection new 
-		category: self class category)
-		transform.
-	
+		subclasses: OrderedCollection new
+		category: self class category) transform.
+
 	self assert: transformation model changes changes size equals: 1.
-	
-	newClass := transformation model classNamed: (self changeMock name, 'Temporary') asSymbol.
+
+	newClass := transformation model classNamed: (self changeMock name , 'Temporary') asSymbol.
 	superclass := transformation model classNamed: #Object.
-	self assert: newClass superclass = superclass.
+	self assert: newClass superclass equals: superclass.
 	self assert: (superclass subclasses includes: newClass).
-	self assert: newClass theMetaClass superclass = superclass theMetaClass.
-	self assert: (superclass theMetaClass subclasses includes: newClass theMetaClass).
+	self assert: newClass theMetaClass superclass equals: superclass theMetaClass.
+	self assert: (superclass theMetaClass subclasses includes: newClass theMetaClass)
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorTransformationTest.class.st
@@ -29,8 +29,8 @@ RBAddVariableAccessorTransformationTest >> testNewInstanceVariableAccessors [
 
 	class := refactoring model classNamed: #RBDummyLintRuleTest.
 	self denyEmpty: refactoring changes changes.
-	self assert: (class parseTreeFor: #foo1) = (self parseMethod: 'foo1 ^foo1').
-	self assert: (class parseTreeFor: #foo1:) = (self parseMethod: 'foo1: anObject foo1 := anObject')
+	self assert: (class parseTreeFor: #foo1) equals: (self parseMethod: 'foo1 ^foo1').
+	self assert: (class parseTreeFor: #foo1:) equals: (self parseMethod: 'foo1: anObject foo1 := anObject')
 ]
 
 { #category : #testing }
@@ -54,22 +54,18 @@ RBAddVariableAccessorTransformationTest >> testRefactoring [
 
 	class := refactoring model classNamed: #RBDummyLintRuleTest.
 	self denyEmpty: refactoring changes changes.
-	self assert: (class parseTreeFor: #foo1) = (self parseMethod: 'foo1 ^foo1').
-	self assert: (class parseTreeFor: #foo1:) = (self parseMethod: 'foo1: anObject foo1 := anObject')
+	self assert: (class parseTreeFor: #foo1) equals: (self parseMethod: 'foo1 ^foo1').
+	self assert: (class parseTreeFor: #foo1:) equals: (self parseMethod: 'foo1: anObject foo1 := anObject')
 ]
 
 { #category : #testing }
 RBAddVariableAccessorTransformationTest >> testTransform [
-
 	| transformation class |
-	transformation := (RBAddVariableAccessorTransformation
-							instanceVariable: 'instVar'
-							class: self changeMock name)
-							transform.
-	
+	transformation := (RBAddVariableAccessorTransformation instanceVariable: 'instVar' class: self changeMock name) transform.
+
 	self assert: transformation model changes changes size equals: 2.
-	
+
 	class := transformation model classNamed: self changeMock name asSymbol.
-	self assert: (class parseTreeFor: #instVar) = (self parseMethod: 'instVar ^instVar').
-	self assert: (class parseTreeFor: #instVar:) = (self parseMethod: 'instVar: anObject instVar := anObject')
+	self assert: (class parseTreeFor: #instVar) equals: (self parseMethod: 'instVar ^instVar').
+	self assert: (class parseTreeFor: #instVar:) equals: (self parseMethod: 'instVar: anObject instVar := anObject')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveClassTransformationTest.class.st
@@ -14,19 +14,15 @@ RBRemoveClassTransformationTest >> resumeIfCannotRemove: error [
 
 { #category : #testing }
 RBRemoveClassTransformationTest >> testRefactoring [
-
 	| refactoring |
-	refactoring := (RBRemoveClassTransformation 
-						className: #RBFooDummyLintRuleTest1)
-						asRefactoring.
-	
+	refactoring := (RBRemoveClassTransformation className: #RBFooDummyLintRuleTest1) asRefactoring.
+
 	[ refactoring transform ]
 		on: RBRefactoringError
 		do: [ :error | self resumeIfCannotRemove: error ].
-		
+
 	self assert: (refactoring model classNamed: #RBFooDummyLintRuleTest1) isNil.
-	self assert: (refactoring model classNamed: 'RBTransformationDummyRuleTest1' asSymbol) superclass
-					= (refactoring model classNamed: #RBDummyLintRuleTest)
+	self assert: (refactoring model classNamed: 'RBTransformationDummyRuleTest1' asSymbol) superclass equals: (refactoring model classNamed: #RBDummyLintRuleTest)
 ]
 
 { #category : #testing }

--- a/src/Reflectivity-Tests/ASTCacheResetTest.class.st
+++ b/src/Reflectivity-Tests/ASTCacheResetTest.class.st
@@ -44,7 +44,7 @@ ASTCacheResetTest >> testCacheResetPreserveLinks [
 	self annotatedMethod.
 	self assert: counter equals: 1.
 	ASTCache reset.
-	self assert: (self class >> #annotatedMethod) ast statements last value links anyOne == link.
+	self assert: (self class >> #annotatedMethod) ast statements last value links anyOne identicalTo: link.
 	self annotatedMethod.
 	self assert: counter equals: 2
 ]

--- a/src/Reflectivity-Tests/LinkInstallerTest.class.st
+++ b/src/Reflectivity-Tests/LinkInstallerTest.class.st
@@ -60,14 +60,14 @@ LinkInstallerTest >> testCallToSuperWithArgs [
 LinkInstallerTest >> testFindingAnonymousNodes [
 	| link varNode instance objectSpecificVarNode |
 	varNode := (ReflectivityExamples >> #exampleSendNoReturn) ast allChildren atRandom.
-	
+
 	link := MetaLink new.
 	instance := ReflectivityExamples new.
-	
+
 	varNode link: link forObject: instance.
 	objectSpecificVarNode := link linkInstaller linkToNodesMapper findNodeLike: varNode forObject: instance.
-	
-	self deny: varNode == objectSpecificVarNode.
+
+	self deny: varNode identicalTo: objectSpecificVarNode.
 	self assert: varNode equals: objectSpecificVarNode
 ]
 
@@ -133,14 +133,14 @@ LinkInstallerTest >> testLinkOnRBProgramNode [
 	| link varNode instance objectSpecificVarNode |
 	varNode := (ReflectivityExamples >> #exampleSendNoReturn) ast allChildren atRandom.
 	link := MetaLink new.
-	
+
 	instance := ReflectivityExamples new.
 	varNode link: link forObject: instance.
 	objectSpecificVarNode := link linkInstaller linkToNodesMapper findNodeLike: varNode forObject: instance.
-	
+
 	self deny: varNode hasMetalink.
 	self assert: objectSpecificVarNode hasMetalink.
-	self assert: objectSpecificVarNode links asArray first == link
+	self assert: objectSpecificVarNode links asArray first identicalTo: link
 ]
 
 { #category : #permalinks }
@@ -255,20 +255,19 @@ LinkInstallerTest >> testMetaLinkOnOneObject [
 { #category : #'links - installing' }
 LinkInstallerTest >> testMetaLinkWithAnonymousClasses [
 	| metalink |
-
 	"We just need to link a MetaLink to an object"
 	metalink := MetaLink new.
 	(obj1 class >> #exampleMethod) ast link: metalink forObject: obj1.
 
 	"One of the 2 objects must have migrated to another class"
 	self assert: obj1 class ~= obj2 class.
-	self assert: obj1 class superclass == ReflectivityExamples.
-	self assert: obj2 class == ReflectivityExamples.
+	self assert: obj1 class superclass identicalTo: ReflectivityExamples.
+	self assert: obj2 class identicalTo: ReflectivityExamples.
 
 	"After removing the link, the object is back to its original class"
 	(obj1 class >> #exampleMethod) ast removeLink: metalink forObject: obj1.
-	self assert: obj1 class == ReflectivityExamples.
-	self assert: obj2 class == ReflectivityExamples
+	self assert: obj1 class identicalTo: ReflectivityExamples.
+	self assert: obj2 class identicalTo: ReflectivityExamples
 ]
 
 { #category : #'links - updating' }
@@ -276,7 +275,7 @@ LinkInstallerTest >> testMethodModified [
 	"When modifying a method for which there was an object specific link,
 	all links must be removed"
 
-	| metalink node |	
+	| metalink node |
 	obj1 compileTemporaryMethods.
 	node := (ReflectivityExamples >> #methodToBeModified) ast allChildren atRandom.
 
@@ -284,14 +283,14 @@ LinkInstallerTest >> testMethodModified [
 	metalink := MetaLink new.
 	node link: metalink forObject: obj1.
 	self assert: obj1 class isAnonymous.
-	
+
 	"Modifyinh the original method should remove all object specific links and
 	migrate back the object to its original class"
-	ReflectivityExamples compile: ('methodToBeModified ^', Time now printString printString).
+	ReflectivityExamples compile: 'methodToBeModified ^' , Time now printString printString.
 	self deny: obj1 class isAnonymous.
-	self assert: obj1 class == ReflectivityExamples.
+	self assert: obj1 class identicalTo: ReflectivityExamples.
 	self deny: metalink hasNodes.
-	self assert: (metalink linkInstaller linkToNodesMapper findNodeLike: node forObject: obj1) isNil. 
+	self assert: (metalink linkInstaller linkToNodesMapper findNodeLike: node forObject: obj1) isNil
 ]
 
 { #category : #'links - updating' }
@@ -299,7 +298,7 @@ LinkInstallerTest >> testMethodRemoved [
 	"When removing a method for which there was an object specific link,
 	all links must be removed"
 
-	| metalink node |	
+	| metalink node |
 	obj1 compileTemporaryMethods.
 	node := (ReflectivityExamples >> #methodToBeRemoved) ast allChildren atRandom.
 
@@ -307,14 +306,14 @@ LinkInstallerTest >> testMethodRemoved [
 	metalink := MetaLink new.
 	node link: metalink forObject: obj1.
 	self assert: obj1 class isAnonymous.
-		
+
 	"Removing the original method should remove all object specific links and
 	migrate back the object to its original class"
 	ReflectivityExamples removeSelector: #methodToBeRemoved.
 	self deny: obj1 class isAnonymous.
-	self assert: obj1 class == ReflectivityExamples.
+	self assert: obj1 class identicalTo: ReflectivityExamples.
 	self deny: metalink hasNodes.
-	self assert: (metalink linkInstaller linkToNodesMapper findNodeLike: node forObject: obj1) isNil. 
+	self assert: (metalink linkInstaller linkToNodesMapper findNodeLike: node forObject: obj1) isNil
 ]
 
 { #category : #permalinks }
@@ -549,17 +548,17 @@ LinkInstallerTest >> testPropagateLinksOnRBProgramNode [
 	link := MetaLink new.
 	link2 := MetaLink new.
 	varNode link: link.
-		
+
 	instance := ReflectivityExamples new.
 	varNode link: link2 forObject: instance.
 	objectSpecificVarNode := link2 linkInstaller linkToNodesMapper findNodeLike: varNode forObject: instance.
 
 	self assert: varNode links size equals: 1.
-	self assert: varNode links asArray first == link.
-	
+	self assert: varNode links asArray first identicalTo: link.
+
 	self assert: objectSpecificVarNode links size equals: 2.
 	self assert: (objectSpecificVarNode links includes: link).
-	self assert: (objectSpecificVarNode links includes: link2).
+	self assert: (objectSpecificVarNode links includes: link2)
 ]
 
 { #category : #'links - updating' }

--- a/src/Reflectivity-Tests/MetaLinkObjectAPITest.class.st
+++ b/src/Reflectivity-Tests/MetaLinkObjectAPITest.class.st
@@ -47,238 +47,229 @@ MetaLinkObjectAPITest >> tearDown [
 
 { #category : #'class api' }
 MetaLinkObjectAPITest >> testLinkClassToAST [
-	|link instance|	
+	| link instance |
 	link := self link.
-		
+
 	ReflectivityExamples2 link: link toAST: (ReflectivityExamples2 >> #exampleMethod) ast.
 	self assert: tag isEmpty.
 	instance := ReflectivityExamples2 new.
 	instance exampleMethod.
-	self assert: tag size = 1.
-	self assert: tag first == instance
-	
-		
+	self assert: tag size equals: 1.
+	self assert: tag first identicalTo: instance
 ]
 
 { #category : #'class api' }
 MetaLinkObjectAPITest >> testLinkClassToClassVarNamed [
-	|link instance|	
+	| link instance |
 	link := self link.
-		
+
 	ReflectivityExamples2 link: link toClassVariableNamed: #classVar.
 	self assert: tag isEmpty.
-	
+
 	instance := ReflectivityExamples2 new.
 	instance methodWithClassVarAccess.
-	
-	self assert: tag size = 2.
-	self assert: (tag allSatisfy: [ :t| t == instance])
-	
+
+	self assert: tag size equals: 2.
+	self assert: (tag allSatisfy: [ :t | t == instance ])
 ]
 
 { #category : #'class api' }
 MetaLinkObjectAPITest >> testLinkClassToSlotNamed [
-
-	|link instance|	
+	| link instance |
 	link := self link.
-		
+
 	ReflectivityExamples2 link: link toSlotNamed: #instVar.
 	self assert: tag isEmpty.
-	
+
 	instance := ReflectivityExamples2 new.
 	instance methodWithInstVarAccess.
-	
-	self assert: tag size = 2.
-	self assert: (tag allSatisfy: [ :t| t == instance])
+
+	self assert: tag size equals: 2.
+	self assert: (tag allSatisfy: [ :t | t == instance ])
 ]
 
 { #category : #'class api' }
 MetaLinkObjectAPITest >> testLinkClassToTempVarNamed [
-	|link instance|	
+	| link instance |
 	link := self linkForTemp.
-		
+
 	ReflectivityExamples2 link: link toTemporaryNamed: #temp inMethod: #methodWithTempVarAccess.
 	self assert: tag isEmpty.
-	
+
 	instance := ReflectivityExamples2 new.
 	instance methodWithTempVarAccess.
-	
-	self assert: tag size = 4.
-	self assert: (tag allSatisfy: [ :t| t = 'ok'])
+
+	self assert: tag size equals: 4.
+	self assert: (tag allSatisfy: [ :t | t = 'ok' ])
 ]
 
 { #category : #'object - api' }
 MetaLinkObjectAPITest >> testLinkObjectToAST [
-	|link instance instance2|	
-	link := self link.	
+	| link instance instance2 |
+	link := self link.
 
 	instance := ReflectivityExamples2 new.
 	instance2 := ReflectivityExamples2 new.
-	
+
 	instance link: link toAST: (ReflectivityExamples2 >> #exampleMethod) ast.
 	self assert: tag isEmpty.
-	
+
 	instance exampleMethod.
 	instance2 exampleMethod.
-	self assert: tag size = 1.
-	self assert: tag first == instance
+	self assert: tag size equals: 1.
+	self assert: tag first identicalTo: instance
 ]
 
 { #category : #'object - api' }
 MetaLinkObjectAPITest >> testLinkObjectToClassVarName [
-	|link instance |	
+	| link instance |
 	self skip.
 	self flag: 'must be fixed'.
-	
+
 	link := self link.
-	
-	instance := ReflectivityExamples2 new.	
-	
+
+	instance := ReflectivityExamples2 new.
+
 	instance link: link toClassVariableNamed: #classVar.
-	self assert: tag isEmpty.	
+	self assert: tag isEmpty.
 
 	instance methodWithClassVarAccess.
 	ReflectivityExamples2 new methodWithClassVarAccess.
-	
-	self assert: tag size = 4.
-	self assert: (tag allSatisfy: [ :t| t == instance])
+
+	self assert: tag size equals: 4.
+	self assert: (tag allSatisfy: [ :t | t == instance ])
 ]
 
 { #category : #'object - api' }
 MetaLinkObjectAPITest >> testLinkObjectToSlotNamed [
-
-	|link instance |	
+	| link instance |
 	link := self link.
-	
-	instance := ReflectivityExamples2 new.	
-	
+
+	instance := ReflectivityExamples2 new.
+
 	instance link: link toSlotNamed: #instVar.
-	self assert: tag isEmpty.	
+	self assert: tag isEmpty.
 
 	instance methodWithInstVarAccess.
 	ReflectivityExamples2 new methodWithInstVarAccess.
-	
-	self assert: tag size = 4.
-	self assert: (tag allSatisfy: [ :t| t == instance])
+
+	self assert: tag size equals: 4.
+	self assert: (tag allSatisfy: [ :t | t == instance ])
 ]
 
 { #category : #'object - api' }
 MetaLinkObjectAPITest >> testLinkObjectToTempVarName [
-
-	|link instance |	
+	| link instance |
 	link := self link.
-	
-	instance := ReflectivityExamples2 new.	
-	
+
+	instance := ReflectivityExamples2 new.
+
 	instance link: link toTemporaryNamed: #temp inMethod: #methodWithTempVarAccess.
-	self assert: tag isEmpty.	
+	self assert: tag isEmpty.
 
 	instance methodWithTempVarAccess.
 	ReflectivityExamples2 new methodWithTempVarAccess.
-	
-	self assert: tag size = 4.
-	self assert: (tag allSatisfy: [ :t| t == instance])
+
+	self assert: tag size equals: 4.
+	self assert: (tag allSatisfy: [ :t | t == instance ])
 ]
 
 { #category : #'common api' }
 MetaLinkObjectAPITest >> testLinkToClassVarNameAll [
-
-	|link instance |	
+	| link instance |
 	link := self link.
-	
+
 	"For all instances"
-	instance := ReflectivityExamples2 new.		
+	instance := ReflectivityExamples2 new.
 	ReflectivityExamples2 link: link toClassVariableNamed: #classVar option: #all.
-	self assert: tag isEmpty.	
+	self assert: tag isEmpty.
 
 	instance methodWithClassVarAccess.
-	
-	self assert: tag size = 4.
-	self assert: (tag allSatisfy: [ :t| t == instance]).
-	
-	"For instance only"	
+
+	self assert: tag size equals: 4.
+	self assert: (tag allSatisfy: [ :t | t == instance ]).
+
+	"For instance only"
 	link uninstall.
 	tag := OrderedCollection new.
 	instance link: link toClassVariableNamed: #classVar option: #all.
 
 	instance methodWithClassVarAccess.
 	ReflectivityExamples2 new methodWithClassVarAccess.
-	
-	self assert: tag size = 4.
-	self assert: (tag allSatisfy: [ :t| t == instance])
+
+	self assert: tag size equals: 4.
+	self assert: (tag allSatisfy: [ :t | t == instance ])
 ]
 
 { #category : #'common api' }
 MetaLinkObjectAPITest >> testLinkToClassVarNameReads [
-
-	|link instance |	
+	| link instance |
 	link := self link.
-	
+
 	"For all instances"
-	instance := ReflectivityExamples2 new.		
+	instance := ReflectivityExamples2 new.
 	ReflectivityExamples2 link: link toClassVariableNamed: #classVar option: #read.
-	self assert: tag isEmpty.	
+	self assert: tag isEmpty.
 
 	instance methodWithClassVarAccess.
-	
-	self assert: tag size = 2.
-	self assert: (tag allSatisfy: [ :t| t == instance]).
-	
-	"For instance only"	
+
+	self assert: tag size equals: 2.
+	self assert: (tag allSatisfy: [ :t | t == instance ]).
+
+	"For instance only"
 	link uninstall.
 	tag := OrderedCollection new.
 	instance link: link toClassVariableNamed: #classVar option: #read.
 
 	instance methodWithClassVarAccess.
 	ReflectivityExamples2 new methodWithClassVarAccess.
-	
-	self assert: tag size = 2.
-	self assert: (tag allSatisfy: [ :t| t == instance])
+
+	self assert: tag size equals: 2.
+	self assert: (tag allSatisfy: [ :t | t == instance ])
 ]
 
 { #category : #'common api' }
 MetaLinkObjectAPITest >> testLinkToClassVarNameWrites [
-	|link instance |	
+	| link instance |
 	link := self link.
-	
+
 	"For all instances"
-	instance := ReflectivityExamples2 new.		
+	instance := ReflectivityExamples2 new.
 	ReflectivityExamples2 link: link toClassVariableNamed: #classVar option: #write.
-	self assert: tag isEmpty.	
+	self assert: tag isEmpty.
 
 	instance methodWithClassVarAccess.
-	
-	self assert: tag size = 2.
-	self assert: (tag allSatisfy: [ :t| t == instance]).
-	
-	"For instance only"	
+
+	self assert: tag size equals: 2.
+	self assert: (tag allSatisfy: [ :t | t == instance ]).
+
+	"For instance only"
 	link uninstall.
 	tag := OrderedCollection new.
 	instance link: link toClassVariableNamed: #classVar option: #write.
 
 	instance methodWithClassVarAccess.
 	ReflectivityExamples2 new methodWithClassVarAccess.
-	
-	self assert: tag size = 2.
-	self assert: (tag allSatisfy: [ :t| t == instance])
+
+	self assert: tag size equals: 2.
+	self assert: (tag allSatisfy: [ :t | t == instance ])
 ]
 
 { #category : #'common api' }
 MetaLinkObjectAPITest >> testLinkToSlotNamedAll [
+	| link instance |
+	link := self link.
+	instance := ReflectivityExamples2 new.
 
-	|link instance |	
-	link := self link.	
-	instance := ReflectivityExamples2 new.	
-
-	"For all instances"	
+	"For all instances"
 	ReflectivityExamples2 link: link toSlotNamed: #instVar option: #all.
-	self assert: tag isEmpty.	
+	self assert: tag isEmpty.
 
 	instance methodWithInstVarAccess.
-	
-	self assert: tag size = 4.
-	self assert: (tag allSatisfy: [ :t| t == instance]).
-	
+
+	self assert: tag size equals: 4.
+	self assert: (tag allSatisfy: [ :t | t == instance ]).
+
 	"For instance only"
 	link uninstall.
 	tag := OrderedCollection new.
@@ -286,27 +277,26 @@ MetaLinkObjectAPITest >> testLinkToSlotNamedAll [
 
 	instance methodWithInstVarAccess.
 	ReflectivityExamples2 new methodWithInstVarAccess.
-	
-	self assert: tag size = 4.
-	self assert: (tag allSatisfy: [ :t| t == instance])
+
+	self assert: tag size equals: 4.
+	self assert: (tag allSatisfy: [ :t | t == instance ])
 ]
 
 { #category : #'common api' }
 MetaLinkObjectAPITest >> testLinkToSlotNamedReads [
+	| link instance |
+	link := self link.
+	instance := ReflectivityExamples2 new.
 
-	|link instance |	
-	link := self link.	
-	instance := ReflectivityExamples2 new.	
-
-	"For all instances"	
+	"For all instances"
 	ReflectivityExamples2 link: link toSlotNamed: #instVar option: #read.
-	self assert: tag isEmpty.	
+	self assert: tag isEmpty.
 
 	instance methodWithInstVarAccess.
-	
-	self assert: tag size = 2.
-	self assert: (tag allSatisfy: [ :t| t == instance]).
-	
+
+	self assert: tag size equals: 2.
+	self assert: (tag allSatisfy: [ :t | t == instance ]).
+
 	"For instance only"
 	link uninstall.
 	tag := OrderedCollection new.
@@ -314,26 +304,26 @@ MetaLinkObjectAPITest >> testLinkToSlotNamedReads [
 
 	instance methodWithInstVarAccess.
 	ReflectivityExamples2 new methodWithInstVarAccess.
-	
-	self assert: tag size = 2.
-	self assert: (tag allSatisfy: [ :t| t == instance])
+
+	self assert: tag size equals: 2.
+	self assert: (tag allSatisfy: [ :t | t == instance ])
 ]
 
 { #category : #'common api' }
 MetaLinkObjectAPITest >> testLinkToSlotNamedWrites [
-	|link instance |	
-	link := self link.	
-	instance := ReflectivityExamples2 new.	
+	| link instance |
+	link := self link.
+	instance := ReflectivityExamples2 new.
 
-	"For all instances"	
+	"For all instances"
 	ReflectivityExamples2 link: link toSlotNamed: #instVar option: #write.
-	self assert: tag isEmpty.	
+	self assert: tag isEmpty.
 
 	instance methodWithInstVarAccess.
-	
-	self assert: tag size = 2.
-	self assert: (tag allSatisfy: [ :t| t == instance]).
-	
+
+	self assert: tag size equals: 2.
+	self assert: (tag allSatisfy: [ :t | t == instance ]).
+
 	"For instance only"
 	link uninstall.
 	tag := OrderedCollection new.
@@ -341,89 +331,112 @@ MetaLinkObjectAPITest >> testLinkToSlotNamedWrites [
 
 	instance methodWithInstVarAccess.
 	ReflectivityExamples2 new methodWithInstVarAccess.
-	
-	self assert: tag size = 2.
-	self assert: (tag allSatisfy: [ :t| t == instance])
+
+	self assert: tag size equals: 2.
+	self assert: (tag allSatisfy: [ :t | t == instance ])
 ]
 
 { #category : #'common api' }
 MetaLinkObjectAPITest >> testLinkToTempVarNameAll [
+	| link instance |
+	link := self link.
+	instance := ReflectivityExamples2 new.
 
-	|link instance |	
-	link := self link.	
-	instance := ReflectivityExamples2 new.	
-	
 	"For all instances"
-	ReflectivityExamples2 link: link toTemporaryNamed: #temp inMethod: #methodWithTempVarAccess option: #all.
-	self assert: tag isEmpty.	
+	ReflectivityExamples2
+		link: link
+		toTemporaryNamed: #temp
+		inMethod: #methodWithTempVarAccess
+		option: #all.
+	self assert: tag isEmpty.
 
 	instance methodWithTempVarAccess.
-	
-	self assert: tag size = 4.
-	self assert: (tag allSatisfy: [ :t| t == instance]).
-	
+
+	self assert: tag size equals: 4.
+	self assert: (tag allSatisfy: [ :t | t == instance ]).
+
 	"For instance only"
 	link uninstall.
 	tag := OrderedCollection new.
-	instance link: link toTemporaryNamed: #temp inMethod: #methodWithTempVarAccess option: #all.
+	instance
+		link: link
+		toTemporaryNamed: #temp
+		inMethod: #methodWithTempVarAccess
+		option: #all.
 
 	instance methodWithTempVarAccess.
 	ReflectivityExamples2 new methodWithTempVarAccess.
-	
-	self assert: tag size = 4.
-	self assert: (tag allSatisfy: [ :t| t == instance])
+
+	self assert: tag size equals: 4.
+	self assert: (tag allSatisfy: [ :t | t == instance ])
 ]
 
 { #category : #'common api' }
 MetaLinkObjectAPITest >> testLinkToTempVarNameReads [
-	|link instance |	
-	link := self link.	
-	instance := ReflectivityExamples2 new.	
-	
+	| link instance |
+	link := self link.
+	instance := ReflectivityExamples2 new.
+
 	"For all instances"
-	ReflectivityExamples2 link: link toTemporaryNamed: #temp inMethod: #methodWithTempVarAccess option: #read.
-	self assert: tag isEmpty.	
+	ReflectivityExamples2
+		link: link
+		toTemporaryNamed: #temp
+		inMethod: #methodWithTempVarAccess
+		option: #read.
+	self assert: tag isEmpty.
 
 	instance methodWithTempVarAccess.
-	
-	self assert: tag size = 2.
-	self assert: (tag allSatisfy: [ :t| t == instance]).
-	
+
+	self assert: tag size equals: 2.
+	self assert: (tag allSatisfy: [ :t | t == instance ]).
+
 	"For instance only"
 	link uninstall.
 	tag := OrderedCollection new.
-	instance link: link toTemporaryNamed: #temp inMethod: #methodWithTempVarAccess option: #read.
+	instance
+		link: link
+		toTemporaryNamed: #temp
+		inMethod: #methodWithTempVarAccess
+		option: #read.
 
 	instance methodWithTempVarAccess.
 	ReflectivityExamples2 new methodWithTempVarAccess.
-	
-	self assert: tag size = 2.
-	self assert: (tag allSatisfy: [ :t| t == instance])
+
+	self assert: tag size equals: 2.
+	self assert: (tag allSatisfy: [ :t | t == instance ])
 ]
 
 { #category : #'common api' }
 MetaLinkObjectAPITest >> testLinkToTempVarNameWrites [
-	|link instance |	
-	link := self link.	
-	instance := ReflectivityExamples2 new.	
-	
+	| link instance |
+	link := self link.
+	instance := ReflectivityExamples2 new.
+
 	"For all instances"
-	ReflectivityExamples2 link: link toTemporaryNamed: #temp inMethod: #methodWithTempVarAccess option: #write.
-	self assert: tag isEmpty.	
+	ReflectivityExamples2
+		link: link
+		toTemporaryNamed: #temp
+		inMethod: #methodWithTempVarAccess
+		option: #write.
+	self assert: tag isEmpty.
 
 	instance methodWithTempVarAccess.
-	
-	self assert: tag size = 2.
-	self assert: (tag allSatisfy: [ :t| t == instance]).
-	
+
+	self assert: tag size equals: 2.
+	self assert: (tag allSatisfy: [ :t | t == instance ]).
+
 	"For instance only"
 	link uninstall.
 	tag := OrderedCollection new.
-	instance link: link toTemporaryNamed: #temp inMethod: #methodWithTempVarAccess option: #write.
+	instance
+		link: link
+		toTemporaryNamed: #temp
+		inMethod: #methodWithTempVarAccess
+		option: #write.
 
 	instance methodWithTempVarAccess.
 	ReflectivityExamples2 new methodWithTempVarAccess.
-	
-	self assert: tag size = 2.
-	self assert: (tag allSatisfy: [ :t| t == instance])
+
+	self assert: tag size equals: 2.
+	self assert: (tag allSatisfy: [ :t | t == instance ])
 ]

--- a/src/Reflectivity-Tests/MetaLinkTargetResolverTest.class.st
+++ b/src/Reflectivity-Tests/MetaLinkTargetResolverTest.class.st
@@ -11,8 +11,8 @@ Class {
 MetaLinkTargetResolverTest >> testFindClassVariable [
 	| classVar |
 	classVar := ReflectivityExamples classVariableNamed: 'singleton'.
-	self assert: (MetalinkTargetResolver classVariableNamed: 'singleton' for: ReflectivityExamples) == classVar.
-	self assert: (MetalinkTargetResolver classVariableNamed: 'singleton' for: ReflectivityExamples new) == classVar
+	self assert: (MetalinkTargetResolver classVariableNamed: 'singleton' for: ReflectivityExamples) identicalTo: classVar.
+	self assert: (MetalinkTargetResolver classVariableNamed: 'singleton' for: ReflectivityExamples new) identicalTo: classVar
 ]
 
 { #category : #tests }
@@ -21,28 +21,27 @@ MetaLinkTargetResolverTest >> testFindClassVariableWithOptions [
 	classVar := ReflectivityExamples classVariableNamed: 'singleton'.
 	readNodes := classVar readNodes asIdentitySet.
 	writeNodes := classVar assignmentNodes asIdentitySet.
-	self assert: (MetalinkTargetResolver classVariableNamed: 'singleton' for: ReflectivityExamples option: #read) = readNodes.
-	self assert: (MetalinkTargetResolver classVariableNamed: 'singleton' for: ReflectivityExamples option: #write) = writeNodes.
+	self assert: (MetalinkTargetResolver classVariableNamed: 'singleton' for: ReflectivityExamples option: #read) equals: readNodes.
+	self assert: (MetalinkTargetResolver classVariableNamed: 'singleton' for: ReflectivityExamples option: #write) equals: writeNodes.
 	self
-		assert:
-			(MetalinkTargetResolver classVariableNamed: 'singleton' for: ReflectivityExamples option: #all)
-				= (Array with: writeNodes with: readNodes) flattened asIdentitySet
+		assert: (MetalinkTargetResolver classVariableNamed: 'singleton' for: ReflectivityExamples option: #all)
+		equals: (Array with: writeNodes with: readNodes) flattened asIdentitySet
 ]
 
 { #category : #tests }
 MetaLinkTargetResolverTest >> testFindMethod [
-	| ast  |
+	| ast |
 	ast := (ReflectivityExamples >> #exampleMethod) ast.
-	self assert: (MetalinkTargetResolver methodNamed: #exampleMethod for: ReflectivityExamples) == ast.
-	self assert: (MetalinkTargetResolver methodNamed: #exampleMethod for: ReflectivityExamples new) == ast
+	self assert: (MetalinkTargetResolver methodNamed: #exampleMethod for: ReflectivityExamples) identicalTo: ast.
+	self assert: (MetalinkTargetResolver methodNamed: #exampleMethod for: ReflectivityExamples new) identicalTo: ast
 ]
 
 { #category : #tests }
 MetaLinkTargetResolverTest >> testFindSlot [
 	| slot |
 	slot := ReflectivityExamples slotNamed: 'tag'.
-	self assert: (MetalinkTargetResolver slotNamed: 'tag' for: ReflectivityExamples) == slot.
-	self assert: (MetalinkTargetResolver slotNamed: 'tag' for: ReflectivityExamples new) == slot
+	self assert: (MetalinkTargetResolver slotNamed: 'tag' for: ReflectivityExamples) identicalTo: slot.
+	self assert: (MetalinkTargetResolver slotNamed: 'tag' for: ReflectivityExamples new) identicalTo: slot
 ]
 
 { #category : #tests }
@@ -51,20 +50,19 @@ MetaLinkTargetResolverTest >> testFindSlotWithOptions [
 	slot := ReflectivityExamples slotNamed: 'tag'.
 	readNodes := slot readNodes asIdentitySet.
 	writeNodes := slot assignmentNodes asIdentitySet.
-	self assert: (MetalinkTargetResolver slotNamed: 'tag' for: ReflectivityExamples option: #read) = readNodes.
-	self assert: (MetalinkTargetResolver slotNamed: 'tag' for: ReflectivityExamples option: #write) = writeNodes.
+	self assert: (MetalinkTargetResolver slotNamed: 'tag' for: ReflectivityExamples option: #read) equals: readNodes.
+	self assert: (MetalinkTargetResolver slotNamed: 'tag' for: ReflectivityExamples option: #write) equals: writeNodes.
 	self
-		assert:
-			(MetalinkTargetResolver slotNamed: 'tag' for: ReflectivityExamples option: #all)
-				= (Array with: writeNodes with: readNodes) flattened asIdentitySet
+		assert: (MetalinkTargetResolver slotNamed: 'tag' for: ReflectivityExamples option: #all)
+		equals: (Array with: writeNodes with: readNodes) flattened asIdentitySet
 ]
 
 { #category : #tests }
 MetaLinkTargetResolverTest >> testFindTemporaryVariable [
 	| temp |
-	temp := (ReflectivityExamples >> #exampleIfTrueIfFalse) temporaryVariableNamed: #t.	
-	self assert: (MetalinkTargetResolver temporaryNamed: #t inMethod: #exampleIfTrueIfFalse for: ReflectivityExamples) = temp.
-	self assert: (MetalinkTargetResolver temporaryNamed: #t inMethod: #exampleIfTrueIfFalse for: ReflectivityExamples new) = temp.
+	temp := ReflectivityExamples >> #exampleIfTrueIfFalse temporaryVariableNamed: #t.
+	self assert: (MetalinkTargetResolver temporaryNamed: #t inMethod: #exampleIfTrueIfFalse for: ReflectivityExamples) equals: temp.
+	self assert: (MetalinkTargetResolver temporaryNamed: #t inMethod: #exampleIfTrueIfFalse for: ReflectivityExamples new) equals: temp
 ]
 
 { #category : #tests }
@@ -79,25 +77,28 @@ MetaLinkTargetResolverTest >> testFindTemporaryVariableWithOptions [
 				temporaryNamed: #t
 				inMethod: #exampleIfTrueIfFalse
 				for: ReflectivityExamples
-				option: #read) = readNodes.
+				option: #read)
+		equals: readNodes.
 	self
 		assert:
 			(MetalinkTargetResolver
 				temporaryNamed: #t
 				inMethod: #exampleIfTrueIfFalse
 				for: ReflectivityExamples
-				option: #write) = writeNodes.
+				option: #write)
+		equals: writeNodes.
 	self
 		assert:
 			(MetalinkTargetResolver
 				temporaryNamed: #t
 				inMethod: #exampleIfTrueIfFalse
 				for: ReflectivityExamples
-				option: #all) = (Array with: writeNodes with: readNodes) flattened asIdentitySet
+				option: #all)
+		equals: (Array with: writeNodes with: readNodes) flattened asIdentitySet
 ]
 
 { #category : #tests }
 MetaLinkTargetResolverTest >> testRecoverClassFromEntity [
-	self assert: (MetalinkTargetResolver classFor: ReflectivityExamples new) == ReflectivityExamples.
-	self assert: (MetalinkTargetResolver classFor: ReflectivityExamples) == ReflectivityExamples
+	self assert: (MetalinkTargetResolver classFor: ReflectivityExamples new) identicalTo: ReflectivityExamples.
+	self assert: (MetalinkTargetResolver classFor: ReflectivityExamples) identicalTo: ReflectivityExamples
 ]

--- a/src/Reflectivity-Tests/ReflectivityControlTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityControlTest.class.st
@@ -80,8 +80,7 @@ ReflectivityControlTest >> testAfterAssignment [
 { #category : #'tests - after' }
 ReflectivityControlTest >> testAfterBlock [
 	| blockNode |
-	blockNode := (ReflectivityExamples >> #exampleBlock) ast statements
-		first value receiver.
+	blockNode := (ReflectivityExamples >> #exampleBlock) ast statements first value receiver.
 	self assert: blockNode isBlock.
 	link := MetaLink new
 		metaObject: self;
@@ -89,15 +88,11 @@ ReflectivityControlTest >> testAfterBlock [
 		control: #after.
 	blockNode link: link.
 	self assert: blockNode hasMetalinkAfter.
-	self
-		assert: (ReflectivityExamples >> #exampleBlock) class
-		equals: ReflectiveMethod.
+	self assert: (ReflectivityExamples >> #exampleBlock) class equals: ReflectiveMethod.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleBlock == 5.
+	self assert: ReflectivityExamples new exampleBlock identicalTo: 5.
 	self assert: tag equals: 'yes'.
-	self
-		assert: (ReflectivityExamples >> #exampleBlock) class
-		equals: CompiledMethod
+	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod
 ]
 
 { #category : #'tests - after' }
@@ -113,7 +108,7 @@ ReflectivityControlTest >> testAfterBlockSequence [
 	self assert: sequence hasMetalinkAfter.
 	self assert: (ReflectivityExamples >> #exampleBlock) class equals: ReflectiveMethod.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleBlock == 5.
+	self assert: ReflectivityExamples new exampleBlock identicalTo: 5.
 	self assert: tag equals: 'yes'.
 	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod
 ]
@@ -166,7 +161,7 @@ ReflectivityControlTest >> testAfterLiteral [
 	self assert: literalNode hasMetalinkAfter.
 	self assert: (ReflectivityExamples >> #exampleLiteral) class equals: ReflectiveMethod.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleLiteral == 2.
+	self assert: ReflectivityExamples new exampleLiteral identicalTo: 2.
 	self assert: tag equals: 'yes'.
 	self assert: (ReflectivityExamples >> #exampleLiteral) class equals: CompiledMethod.
 	self deny: (ReflectivityExamples >> #exampleLiteral) isQuick
@@ -443,7 +438,7 @@ ReflectivityControlTest >> testBeforeBlock [
 	self assert: blockNode hasMetalinkBefore.
 	self assert: (ReflectivityExamples >> #exampleBlock) class equals: ReflectiveMethod.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleBlock == 5.
+	self assert: ReflectivityExamples new exampleBlock identicalTo: 5.
 	self assert: tag equals: 'yes'.
 	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod
 ]
@@ -460,7 +455,7 @@ ReflectivityControlTest >> testBeforeBlockSequence [
 	self assert: sequence hasMetalinkBefore.
 	self assert: (ReflectivityExamples >> #exampleBlock) class equals: ReflectiveMethod.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleBlock == 5.
+	self assert: ReflectivityExamples new exampleBlock identicalTo: 5.
 	self assert: tag equals: 'yes'.
 	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod
 ]
@@ -530,7 +525,7 @@ ReflectivityControlTest >> testBeforeLiteral [
 	self assert: literalNode hasMetalinkBefore.
 	self assert: (ReflectivityExamples >> #exampleLiteral) class equals: ReflectiveMethod.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleLiteral == 2.
+	self assert: ReflectivityExamples new exampleLiteral identicalTo: 2.
 	self assert: tag equals: 'yes'.
 	self assert: (ReflectivityExamples >> #exampleLiteral) class equals: CompiledMethod.
 	self deny: (ReflectivityExamples >> #exampleLiteral) isQuick
@@ -603,7 +598,7 @@ ReflectivityControlTest >> testBeforeReturn [
 	self assert: returnNode hasMetalinkBefore.
 	self assert: (ReflectivityExamples >> #exampleLiteral) class equals: ReflectiveMethod.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleLiteral == 2.
+	self assert: ReflectivityExamples new exampleLiteral identicalTo: 2.
 	self assert: tag equals: 'yes'.
 	self assert: (ReflectivityExamples >> #exampleLiteral) class equals: CompiledMethod.
 	self deny: (ReflectivityExamples >> #exampleLiteral) isQuick
@@ -795,12 +790,14 @@ ReflectivityControlTest >> testConditionDisableEnableWithArguments [
 { #category : #'tests - level' }
 ReflectivityControlTest >> testConditionMetaLevel [
 	"check that the condition is evaluated on the same meta level as the link"
+
 	| sendNode |
 	sendNode := (ReflectivityExamples >> #exampleMethod) sendNodes first.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
-		condition: [ self assert: Processor activeProcess level == 1. true ];
+		condition: [ self assert: Processor activeProcess level identicalTo: 1.
+			true ];
 		level: 0;
 		arguments: #(#node).
 	sendNode link: link.
@@ -951,11 +948,11 @@ ReflectivityControlTest >> testInsteadBlock [
 		metaObject: self;
 		control: #instead;
 		selector: #return3.
-	self assert: ReflectivityExamples new exampleBlock == 5.
+	self assert: ReflectivityExamples new exampleBlock identicalTo: 5.
 	blockNode link: link.
 	self assert: blockNode hasMetalinkInstead.
 	self assert: (ReflectivityExamples >> #exampleBlock) class equals: ReflectiveMethod.
-	self assert: ReflectivityExamples new exampleBlock == 3.
+	self assert: ReflectivityExamples new exampleBlock identicalTo: 3.
 	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod
 ]
 
@@ -1031,7 +1028,7 @@ ReflectivityControlTest >> testInsteadLiteral [
 	literalNode link: link.
 	self assert: literalNode hasMetalinkInstead.
 	self assert: (ReflectivityExamples >> #exampleLiteral) class equals: ReflectiveMethod.
-	self assert: ReflectivityExamples new exampleLiteral == 3.
+	self assert: ReflectivityExamples new exampleLiteral identicalTo: 3.
 	self assert: (ReflectivityExamples >> #exampleLiteral) class equals: CompiledMethod.
 	self deny: (ReflectivityExamples >> #exampleLiteral) isQuick
 ]

--- a/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
@@ -49,16 +49,16 @@ ReflectivityReificationTest >> testBlockOperationAfter [
 		metaObject: self;
 		selector: #tagExec:;
 		control: #after;
-		arguments: #(operation). 
+		arguments: #(operation).
 	blockNode link: link.
 	self assert: blockNode hasMetalinkAfter.
 	self assert: (ReflectivityExamples >> #exampleBlock) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
-	self assert: instance exampleBlock == 5 .
+	self assert: instance exampleBlock identicalTo: 5.
 	self assert: tag value value equals: 5.
 	self assert: tag class equals: RFBlockOperation.
-	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod.
+	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod
 ]
 
 { #category : #'tests - blocks' }
@@ -75,10 +75,10 @@ ReflectivityReificationTest >> testBlockOperationBefore [
 	self assert: blockNode hasMetalinkBefore.
 	self assert: (ReflectivityExamples >> #exampleBlock) class equals: ReflectiveMethod.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleBlock == 5.
+	self assert: ReflectivityExamples new exampleBlock identicalTo: 5.
 	self assert: tag class equals: RFBlockOperation.
 	self assert: tag value value equals: 5.
-	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod.
+	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod
 ]
 
 { #category : #'tests - blocks' }
@@ -90,16 +90,16 @@ ReflectivityReificationTest >> testBlockOperationInstead [
 		metaObject: self;
 		selector: #tagExec:;
 		control: #instead;
-		arguments: #(operation). 
+		arguments: #(operation).
 	blockNode link: link.
 	self assert: blockNode hasMetalinkInstead.
 	self assert: (ReflectivityExamples >> #exampleBlock) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
-	self assert: instance exampleBlock == self .
+	self assert: instance exampleBlock identicalTo: self.
 	self assert: tag value value equals: 5.
 	self assert: tag class equals: RFBlockOperation.
-	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod.
+	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod
 ]
 
 { #category : #'tests - blocks - body' }
@@ -116,9 +116,9 @@ ReflectivityReificationTest >> testBlockSequenceArguments [
 	self assert: blockNode hasMetalinkBefore.
 	self assert: (ReflectivityExamples >> #exampleBlock) class equals: ReflectiveMethod.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleBlock == 5.
+	self assert: ReflectivityExamples new exampleBlock identicalTo: 5.
 	self assert: tag equals: #().
-	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod.
+	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod
 ]
 
 { #category : #'tests - blocks - body' }
@@ -135,9 +135,9 @@ ReflectivityReificationTest >> testBlockSequenceArgumentsWithArg [
 	self assert: blockNode hasMetalinkBefore.
 	self assert: (ReflectivityExamples >> #exampleBlockWithArg) class equals: ReflectiveMethod.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleBlockWithArg == 5.
+	self assert: ReflectivityExamples new exampleBlockWithArg identicalTo: 5.
 	self assert: tag equals: #(2).
-	self assert: (ReflectivityExamples >> #exampleBlockWithArg) class equals: CompiledMethod.
+	self assert: (ReflectivityExamples >> #exampleBlockWithArg) class equals: CompiledMethod
 ]
 
 { #category : #'tests - blocks - body' }
@@ -154,9 +154,9 @@ ReflectivityReificationTest >> testBlockSequenceArgumentsWithArgAfter [
 	self assert: blockNode hasMetalinkAfter.
 	self assert: (ReflectivityExamples >> #exampleBlockWithArg) class equals: ReflectiveMethod.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleBlockWithArg == 5.
+	self assert: ReflectivityExamples new exampleBlockWithArg identicalTo: 5.
 	self assert: tag equals: #(2).
-	self assert: (ReflectivityExamples >> #exampleBlockWithArg) class equals: CompiledMethod.
+	self assert: (ReflectivityExamples >> #exampleBlockWithArg) class equals: CompiledMethod
 ]
 
 { #category : #'tests - blocks - body' }
@@ -173,9 +173,9 @@ ReflectivityReificationTest >> testBlockSequenceArgumentsWithArgAfterInstead [
 	self assert: blockNode hasMetalinkInstead.
 	self assert: (ReflectivityExamples >> #exampleBlockWithArg) class equals: ReflectiveMethod.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleBlockWithArg == self.
+	self assert: ReflectivityExamples new exampleBlockWithArg identicalTo: self.
 	self assert: tag equals: #(2).
-	self assert: (ReflectivityExamples >> #exampleBlockWithArg) class equals: CompiledMethod.
+	self assert: (ReflectivityExamples >> #exampleBlockWithArg) class equals: CompiledMethod
 ]
 
 { #category : #'tests - blocks' }
@@ -192,9 +192,9 @@ ReflectivityReificationTest >> testBlockValueAfter [
 	self assert: blockNode hasMetalinkAfter.
 	self assert: (ReflectivityExamples >> #exampleBlock) class equals: ReflectiveMethod.
 	self assert: tag isNil.
-	self assert: ReflectivityExamples new exampleBlock == 5.
+	self assert: ReflectivityExamples new exampleBlock identicalTo: 5.
 	self assert: tag printString equals: [ 2 + 3 ] printString.
-	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod.
+	self assert: (ReflectivityExamples >> #exampleBlock) class equals: CompiledMethod
 ]
 
 { #category : #'tests - misc' }
@@ -203,13 +203,13 @@ ReflectivityReificationTest >> testLiteralOperationAfter [
 	literalNode := (ReflectivityExamples >> #exampleLiteral) ast statements first value.
 	self assert: literalNode isLiteralNode.
 	link := MetaLink new
-		metaObject: [:value | self assert: value value equals: 2];
+		metaObject: [ :value | self assert: value value equals: 2 ];
 		selector: #value:;
 		arguments: #(operation);
 		control: #after.
 	literalNode link: link.
 	self assert: literalNode hasMetalinkAfter.
-	self assert: ReflectivityExamples new exampleLiteral == 2.
+	self assert: ReflectivityExamples new exampleLiteral identicalTo: 2
 ]
 
 { #category : #'tests - misc' }
@@ -218,13 +218,13 @@ ReflectivityReificationTest >> testLiteralValueAfter [
 	literalNode := (ReflectivityExamples >> #exampleLiteral) ast statements first value.
 	self assert: literalNode isLiteralNode.
 	link := MetaLink new
-		metaObject: [:value | self assert: value equals: 2];
+		metaObject: [ :value | self assert: value equals: 2 ];
 		selector: #value:;
 		arguments: #(value);
 		control: #after.
 	literalNode link: link.
 	self assert: literalNode hasMetalinkAfter.
-	self assert: ReflectivityExamples new exampleLiteral == 2.
+	self assert: ReflectivityExamples new exampleLiteral identicalTo: 2
 ]
 
 { #category : #'tests - misc' }
@@ -233,13 +233,13 @@ ReflectivityReificationTest >> testLiteralValueBefore [
 	literalNode := (ReflectivityExamples >> #exampleLiteral) ast statements first value.
 	self assert: literalNode isLiteralNode.
 	link := MetaLink new
-		metaObject: [:value | self assert: value equals: 2];
+		metaObject: [ :value | self assert: value equals: 2 ];
 		selector: #value:;
 		arguments: #(value);
 		control: #before.
 	literalNode link: link.
 	self assert: literalNode hasMetalinkBefore.
-	self assert: ReflectivityExamples new exampleLiteral == 2.	
+	self assert: ReflectivityExamples new exampleLiteral identicalTo: 2
 ]
 
 { #category : #'tests - sends' }
@@ -555,58 +555,58 @@ ReflectivityReificationTest >> testReifyClassVariableClass [
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleClassVarRead equals: #AClassVar.
-	self assert: tag == ReflectivityExamples
+	self assert: tag identicalTo: ReflectivityExamples
 ]
 
 { #category : #'tests - variables' }
 ReflectivityReificationTest >> testReifyClassVariableContext [
 	| classVar instance |
 	classVar := ReflectivityExamples classVariableNamed: #ClassVar.
-	link := MetaLink new 
-		metaObject: self; 
+	link := MetaLink new
+		metaObject: self;
 		selector: #tagExec:;
 		arguments: #(context).
 	classVar link: link.
 	self assert: classVar hasMetalink.
 	self assert: (ReflectivityExamples >> #exampleClassVarRead) class equals: ReflectiveMethod.
-	self assert: (tag isNil).
+	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleClassVarRead equals: #AClassVar.
-	self assert: (tag class == Context).
+	self assert: tag class identicalTo: Context
 ]
 
 { #category : #'tests - variables' }
 ReflectivityReificationTest >> testReifyClassVariableEntity [
 	| classVar instance |
 	classVar := ReflectivityExamples classVariableNamed: #ClassVar.
-	link := MetaLink new 
-		metaObject: self; 
+	link := MetaLink new
+		metaObject: self;
 		selector: #tagExec:;
 		arguments: #(entity).
 	classVar link: link.
 	self assert: classVar hasMetalink.
 	self assert: (ReflectivityExamples >> #exampleClassVarRead) class equals: ReflectiveMethod.
-	self assert: (tag isNil).
+	self assert: tag isNil.
 	instance := ReflectivityExamples new.
-	self assert: (instance exampleClassVarRead == #AClassVar).
-	self assert: tag equals: classVar.
+	self assert: instance exampleClassVarRead identicalTo: #AClassVar.
+	self assert: tag equals: classVar
 ]
 
 { #category : #'tests - variables' }
 ReflectivityReificationTest >> testReifyClassVariableLink [
 	| classVar instance |
 	classVar := ReflectivityExamples classVariableNamed: #ClassVar.
-	link := MetaLink new 
-		metaObject: self; 
+	link := MetaLink new
+		metaObject: self;
 		selector: #tagExec:;
 		arguments: #(link).
 	classVar link: link.
 	self assert: classVar hasMetalink.
 	self assert: (ReflectivityExamples >> #exampleClassVarRead) class equals: ReflectiveMethod.
-	self assert: (tag isNil).
+	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleClassVarRead equals: #AClassVar.
-	self assert: (tag == link).
+	self assert: tag identicalTo: link
 ]
 
 { #category : #'tests - variables' }
@@ -630,17 +630,17 @@ ReflectivityReificationTest >> testReifyClassVariableName [
 ReflectivityReificationTest >> testReifyClassVariableObject [
 	| classVar instance |
 	classVar := ReflectivityExamples classVariableNamed: #ClassVar.
-	link := MetaLink new 
-		metaObject: self; 
+	link := MetaLink new
+		metaObject: self;
 		selector: #tagExec:;
 		arguments: #(object).
 	classVar link: link.
 	self assert: classVar hasMetalink.
 	self assert: (ReflectivityExamples >> #exampleClassVarRead) class equals: ReflectiveMethod.
-	self assert: (tag isNil).
+	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleClassVarRead equals: #AClassVar.
-	self assert: (tag class == ReflectivityExamples).
+	self assert: tag class identicalTo: ReflectivityExamples
 ]
 
 { #category : #'tests - variables' }
@@ -722,7 +722,7 @@ ReflectivityReificationTest >> testReifyGlobalOperation [
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleGlobalRead equals: GlobalForTesting.
-	self assert: tag class == RFGlobalRead.
+	self assert: tag class identicalTo: RFGlobalRead.
 	self assert: tag value equals: GlobalForTesting
 ]
 
@@ -755,7 +755,7 @@ ReflectivityReificationTest >> testReifyGlobalVariable [
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleGlobalRead equals: GlobalForTesting.
-	self assert: tag class == GlobalVariable
+	self assert: tag class identicalTo: GlobalVariable
 ]
 
 { #category : #'tests - variables' }
@@ -910,8 +910,8 @@ ReflectivityReificationTest >> testReifyMethod [
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleIvarRead equals: 33.
-	self assert: tag equals: (ReflectivityExamples >> #exampleIvarRead).
-	self deny: (tag == origMethod).
+	self assert: tag equals: ReflectivityExamples >> #exampleIvarRead.
+	self deny: tag identicalTo: origMethod
 ]
 
 { #category : #'tests - method ' }
@@ -959,7 +959,7 @@ ReflectivityReificationTest >> testReifyMethodArgsAfter2 [
 			self assert: aReceiver class equals: ReflectivityExamples.
 			self assert: aSelector equals: #exampleMethod.
 			self assert: args equals: #().
-			self assert: link == link ];
+			self assert: link identicalTo: link ];
 		selector: #value:value:value:value:;
 		arguments: #(object selector arguments link);
 		control: #after.
@@ -1220,7 +1220,7 @@ ReflectivityReificationTest >> testReifyOperationMethodAfter [
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: (instance exampleWithArg: 3) equals: 5.
-	self assert: tag class == RFMethodOperation.
+	self assert: tag class identicalTo: RFMethodOperation.
 	self assert: tag value equals: 5
 ]
 
@@ -1239,7 +1239,7 @@ ReflectivityReificationTest >> testReifyOperationMethodInstead [
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: (instance exampleWithArg: 3) equals: self.
-	self assert: tag class == RFMethodOperation.
+	self assert: tag class identicalTo: RFMethodOperation.
 	self assert: tag value equals: 5
 ]
 
@@ -1309,7 +1309,7 @@ ReflectivityReificationTest >> testReifyOptionArgsAsArray [
 			self assert: aReceiver class equals: ReflectivityExamples.
 			self assert: aSelector equals: #exampleMethod.
 			self assert: args equals: #().
-			self assert: link == link ];
+			self assert: link identicalTo: link ];
 		selector: #valueWithArguments:;
 		option: #(+ argsAsArray);
 		arguments: #(object selector arguments link);
@@ -1337,8 +1337,8 @@ ReflectivityReificationTest >> testReifyOrigMethod [
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleIvarRead equals: 33.
-	self deny: tag equals: (ReflectivityExamples >> #exampleIvarRead).
-	self assert: (tag == origMethod).
+	self deny: tag equals: ReflectivityExamples >> #exampleIvarRead.
+	self assert: tag identicalTo: origMethod
 ]
 
 { #category : #'tests - sends' }
@@ -1453,8 +1453,7 @@ ReflectivityReificationTest >> testReifySendAll [
 { #category : #'tests - sends' }
 ReflectivityReificationTest >> testReifySendArgsAsArray [
 	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
-		statements first value.
+	sendNode := (ReflectivityExamples >> #exampleMethod) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
@@ -1467,8 +1466,8 @@ ReflectivityReificationTest >> testReifySendArgsAsArray [
 	instance := ReflectivityExamples new.
 	self assert: instance exampleMethod equals: 5.
 	self assert: tag isArray.
-	self assert: tag first == #+.
-	self assert: tag second class == Context
+	self assert: tag first identicalTo: #+.
+	self assert: tag second class identicalTo: Context
 ]
 
 { #category : #'tests - sends' }
@@ -1697,9 +1696,9 @@ ReflectivityReificationTest >> testReifySlotOperation [
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleIvarRead equals: 33.
-	self assert: tag class == RFSlotRead.
-	self deny: tag  equals: 'ivar'.
-	self assert: tag value equals: 33.
+	self assert: tag class identicalTo: RFSlotRead.
+	self deny: tag equals: 'ivar'.
+	self assert: tag value equals: 33
 ]
 
 { #category : #'tests - operations' }
@@ -1716,9 +1715,9 @@ ReflectivityReificationTest >> testReifySlotOperationAfter [
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleIvarRead equals: 33.
-	self assert: tag class == RFSlotRead.
-	self deny: tag  equals: 'ivar'.
-	self assert: tag value equals: 33.
+	self assert: tag class identicalTo: RFSlotRead.
+	self deny: tag equals: 'ivar'.
+	self assert: tag value equals: 33
 ]
 
 { #category : #'tests - operations' }
@@ -1735,9 +1734,9 @@ ReflectivityReificationTest >> testReifySlotOperationInstead [
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleIvarRead equals: self.
-	self assert: tag class == RFSlotRead.
-	self deny: tag  equals: 'ivar'.
-	self assert: tag value equals: 33.
+	self assert: tag class identicalTo: RFSlotRead.
+	self deny: tag equals: 'ivar'.
+	self assert: tag value equals: 33
 ]
 
 { #category : #'tests - variables' }
@@ -1812,14 +1811,17 @@ ReflectivityReificationTest >> testReifyTempOperation [
 	varNode := (ReflectivityExamples >> #exampleAssignment) ast body statements last value.
 	executed := false.
 	link := MetaLink new
-		metaObject: [:operation | executed := true. self assert: operation class == RFTempRead. self assert: operation value equals: 3. ];
+		metaObject: [ :operation | 
+			executed := true.
+			self assert: operation class identicalTo: RFTempRead.
+			self assert: operation value equals: 3 ];
 		selector: #value:;
 		arguments: #(operation).
 	varNode link: link.
 	self assert: varNode hasMetalink.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleAssignment equals: 3.
-	self assert: executed.
+	self assert: executed
 ]
 
 { #category : #'tests - operations' }
@@ -1828,7 +1830,10 @@ ReflectivityReificationTest >> testReifyTempOperationAfter [
 	varNode := (ReflectivityExamples >> #exampleAssignment) ast body statements last value.
 	executed := false.
 	link := MetaLink new
-		metaObject: [:operation | executed := true. self assert: operation class == RFTempRead. self assert: operation value equals: 3. ];
+		metaObject: [ :operation | 
+			executed := true.
+			self assert: operation class identicalTo: RFTempRead.
+			self assert: operation value equals: 3 ];
 		selector: #value:;
 		control: #after;
 		arguments: #(operation).
@@ -1836,7 +1841,7 @@ ReflectivityReificationTest >> testReifyTempOperationAfter [
 	self assert: varNode hasMetalink.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleAssignment equals: 3.
-	self assert: executed.
+	self assert: executed
 ]
 
 { #category : #'tests - operations' }
@@ -1845,7 +1850,11 @@ ReflectivityReificationTest >> testReifyTempOperationInstead [
 	varNode := (ReflectivityExamples >> #exampleAssignment) ast body statements last value.
 	executed := false.
 	link := MetaLink new
-		metaObject: [:operation | executed := true. self assert: operation class == RFTempRead. self assert: operation value equals: 3. operation value];
+		metaObject: [ :operation | 
+			executed := true.
+			self assert: operation class identicalTo: RFTempRead.
+			self assert: operation value equals: 3.
+			operation value ];
 		selector: #value:;
 		control: #instead;
 		arguments: #(operation).
@@ -1853,7 +1862,7 @@ ReflectivityReificationTest >> testReifyTempOperationInstead [
 	self assert: varNode hasMetalink.
 	instance := ReflectivityExamples new.
 	self assert: instance exampleAssignment equals: 3.
-	self assert: executed.
+	self assert: executed
 ]
 
 { #category : #'tests - variablenodes' }

--- a/src/Reflectivity-Tools-Tests/MethodConstantTest.class.st
+++ b/src/Reflectivity-Tools-Tests/MethodConstantTest.class.st
@@ -26,22 +26,20 @@ MethodConstantTest >> sumOfTwoConsts: firstBlock and: secondBlock [
 
 { #category : #tests }
 MethodConstantTest >> testAPIFromBlock [
-
 	| constInitialResult constSecondResult |
-	constInitialResult := self constFromBlock: [DateAndTime now].
+	constInitialResult := self constFromBlock: [ DateAndTime now ].
 	constSecondResult := self constFromBlock: nil.
-	
-	self assert: constSecondResult == constInitialResult
+
+	self assert: constSecondResult identicalTo: constInitialResult
 ]
 
 { #category : #tests }
 MethodConstantTest >> testAPIFromMessageSendReceiver [
-
 	| constInitialResult constSecondResult |
 	constInitialResult := self constFromReceiverExpression.
 	constSecondResult := self constFromReceiverExpression.
-	
-	self assert: constSecondResult == constInitialResult
+
+	self assert: constSecondResult identicalTo: constInitialResult
 ]
 
 { #category : #tests }
@@ -68,11 +66,10 @@ MethodConstantTest >> testTwoConstsInSameMethod [
 
 { #category : #tests }
 MethodConstantTest >> testUsingConstJustInSameMethod [
-
 	| values |
-	self skip. "not working for the first call: would need on stack replacement"
+	self skip.	"not working for the first call: would need on stack replacement"
 	values := OrderedCollection new.
 	2 timesRepeat: [ values add: DateAndTime now asMethodConstant ].
-	
-	self assert: values first == values last
+
+	self assert: values first identicalTo: values last
 ]

--- a/src/Reflectivity-Tools-Tests/RuntimeTyperTest.class.st
+++ b/src/Reflectivity-Tools-Tests/RuntimeTyperTest.class.st
@@ -55,23 +55,19 @@ RuntimeTyperTest >> examplePlus: arg [
 { #category : #tests }
 RuntimeTyperTest >> testPlus [
 	| link variable |
-	
 	link := MetaLink new
 		metaObject: #node;
 		selector: #tagType:;
 		arguments: #(value);
 		control: #after.
-		
-	(self class>>#examplePlus:) ast assignmentNodes do: [ :node | node link: link ].
-	
-	self assert: (self examplePlus: 1) = 2.
-	self assert: (self examplePlus: 1.1) = 2.1.
-	
-	"link uninstall."
-	
-	variable := (self class>>#examplePlus:) ast assignmentNodes first variable.
-	self assert: ((variable propertyAt: #types) includes: SmallInteger).  
-		
 
-		
+	(self class >> #examplePlus:) ast assignmentNodes do: [ :node | node link: link ].
+
+	self assert: (self examplePlus: 1) equals: 2.
+	self assert: (self examplePlus: 1.1) equals: 2.1.
+
+	"link uninstall."
+
+	variable := (self class >> #examplePlus:) ast assignmentNodes first variable.
+	self assert: ((variable propertyAt: #types) includes: SmallInteger)
 ]

--- a/src/Reflectivity-Tools-Tests/WatchpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/WatchpointTest.class.st
@@ -6,50 +6,44 @@ Class {
 
 { #category : #adding }
 WatchpointTest >> testAddSameWatchpointSameNode [
-	|node watchpoint watchpoint2|
-	
-	node := (ReflectivityExamples>>#exampleAssignment) ast body children first.
+	| node watchpoint watchpoint2 |
+	node := (ReflectivityExamples >> #exampleAssignment) ast body children first.
 	watchpoint := Watchpoint in: node.
 	watchpoint2 := Watchpoint in: node.
-	
-	self assert: (watchpoint = watchpoint2).
-	
+
+	self assert: watchpoint equals: watchpoint2.
+
 	watchpoint uninstall.
-	
-	self deny: (node hasWatchpoint)
-	
+
+	self deny: node hasWatchpoint
 ]
 
 { #category : #adding }
 WatchpointTest >> testAddWatchpoint [
-	|node watchpoint|
-	
-	node := (ReflectivityExamples>>#exampleAssignment) ast body children first.
+	| node watchpoint |
+	node := (ReflectivityExamples >> #exampleAssignment) ast body children first.
 	watchpoint := Watchpoint in: node.
-	
+
 	self assert: node hasWatchpoint.
-	self assert: (Watchpoint allWatchpoints at: node) = watchpoint.
-	
+	self assert: (Watchpoint allWatchpoints at: node) equals: watchpoint.
+
 	watchpoint uninstall.
 	self deny: node hasWatchpoint.
-	self deny: (Watchpoint allWatchpoints includesKey: node). 
-	
+	self deny: (Watchpoint allWatchpoints includesKey: node)
 ]
 
 { #category : #adding }
 WatchpointTest >> testAddWatchpointsSameNode [
-	|node watchpoint watchpoint2|
-	
-	node := (ReflectivityExamples>>#exampleAssignment) ast body children first.
+	| node watchpoint watchpoint2 |
+	node := (ReflectivityExamples >> #exampleAssignment) ast body children first.
 	watchpoint := Watchpoint in: node.
 	watchpoint2 := Watchpoint in: node.
-	
-	self assert: (watchpoint = watchpoint2).
-	
+
+	self assert: watchpoint equals: watchpoint2.
+
 	watchpoint uninstall.
-	
-	self deny: (node hasWatchpoint)
-	
+
+	self deny: node hasWatchpoint
 ]
 
 { #category : #'deleting history' }
@@ -63,8 +57,8 @@ WatchpointTest >> testDeleteAllHistory [
 	ReflectivityExamples new exampleAssignmentIvar: 2.
 	ReflectivityExamples new exampleAssignmentIvar.
 
-	self assert: watchpoint1 values first value = 2.
-	self assert: watchpoint2 values first value = 3.
+	self assert: watchpoint1 values first value equals: 2.
+	self assert: watchpoint2 values first value equals: 3.
 
 	Watchpoint deleteAllHistory.
 
@@ -100,8 +94,8 @@ WatchpointTest >> testDeleteHistoryFromNode [
 	ReflectivityExamples new exampleAssignmentIvar: 1.
 	ReflectivityExamples new exampleAssignmentIvar: 2.
 
-	self assert: watchpoint values first value = 1.
-	self assert: watchpoint values second value = 2.
+	self assert: watchpoint values first value equals: 1.
+	self assert: watchpoint values second value equals: 2.
 
 	Watchpoint deleteHistoryFrom: node.
 	self assertEmpty: watchpoint values.
@@ -111,74 +105,66 @@ WatchpointTest >> testDeleteHistoryFromNode [
 
 { #category : #values }
 WatchpointTest >> testSaveOneValue [
-	|node watchpoint|
-	
-	node := (ReflectivityExamples>>#exampleAssignmentIvar) ast body children first.
+	| node watchpoint |
+	node := (ReflectivityExamples >> #exampleAssignmentIvar) ast body children first.
 	watchpoint := Watchpoint in: node.
 	ReflectivityExamples new exampleAssignmentIvar.
-	
-	self assert: (watchpoint values first value = 3).
-	
-	watchpoint uninstall.
-	
+
+	self assert: watchpoint values first value equals: 3.
+
+	watchpoint uninstall
 ]
 
 { #category : #values }
 WatchpointTest >> testSaveValues [
-	|node watchpoint|
-	
-	node := (ReflectivityExamples>>#exampleAssignmentIvar:) ast body children first.
+	| node watchpoint |
+	node := (ReflectivityExamples >> #exampleAssignmentIvar:) ast body children first.
 	watchpoint := Watchpoint in: node.
 	ReflectivityExamples new exampleAssignmentIvar: 1.
 	ReflectivityExamples new exampleAssignmentIvar: 2.
-	
-	self assert: (watchpoint values first value = 1).
-	self assert: (watchpoint values second value = 2).
-	
-	watchpoint uninstall.
-	
+
+	self assert: watchpoint values first value equals: 1.
+	self assert: watchpoint values second value equals: 2.
+
+	watchpoint uninstall
 ]
 
 { #category : #values }
 WatchpointTest >> testSendMessage [
-	|node watchpoint|
-	
-	node := (ReflectivityExamples>>#exampleMessageSend) ast body children first.
+	| node watchpoint |
+	node := (ReflectivityExamples >> #exampleMessageSend) ast body children first.
 	watchpoint := Watchpoint in: node.
 	ReflectivityExamples new exampleMessageSend.
-	
-	self assert: (watchpoint values first value class = ReflectivityExamples).
-	
-	watchpoint uninstall.
-	
+
+	self assert: watchpoint values first value class equals: ReflectivityExamples.
+
+	watchpoint uninstall
 ]
 
 { #category : #recording }
 WatchpointTest >> testStopRecording [
-	|node watchpoint dummy|
-	
-	node := (ReflectivityExamples>>#exampleAssignmentIvar:) ast body children first.
+	| node watchpoint dummy |
+	node := (ReflectivityExamples >> #exampleAssignmentIvar:) ast body children first.
 	watchpoint := Watchpoint in: node.
 	dummy := ReflectivityExamples new.
-	
+
 	dummy exampleAssignmentIvar: 1.
 	dummy exampleAssignmentIvar: 2.
-	self assert: (watchpoint values size = 2).
-	self assert: (watchpoint values second value = 2).
-	
+	self assert: watchpoint values size equals: 2.
+	self assert: watchpoint values second value equals: 2.
+
 	watchpoint stop.
 	dummy exampleAssignmentIvar: 3.
-	self assert: (watchpoint values size = 2).
-	
+	self assert: watchpoint values size equals: 2.
+
 	watchpoint start.
 	dummy exampleAssignmentIvar: 4.
-	self assert: (watchpoint values size = 3).
-	self assert: (watchpoint values third value = 4).
-	
+	self assert: watchpoint values size equals: 3.
+	self assert: watchpoint values third value equals: 4.
+
 	watchpoint uninstall.
-	
-	self deny: (node hasWatchpoint)
-	
+
+	self deny: node hasWatchpoint
 ]
 
 { #category : #values }

--- a/src/Regex-Core-Tests/RxMatcherTest.class.st
+++ b/src/Regex-Core-Tests/RxMatcherTest.class.st
@@ -1068,18 +1068,14 @@ RxMatcherTest >> testMatches [
 RxMatcherTest >> testMatchesIn [
 	| matcher |
 	matcher := self matcherClass forString: '\w+'.
-	self assert: (matcher matchesIn: 'now is the time') asArray 
-		= #('now' 'is' 'the' 'time')
+	self assert: (matcher matchesIn: 'now is the time') asArray equals: #('now' 'is' 'the' 'time')
 ]
 
 { #category : #'testing-protocol' }
 RxMatcherTest >> testMatchesInCollect [
 	| matcher |
 	matcher := self matcherClass forString: '\w+'.
-	self assert: (matcher
-		matchesIn: 'now is the time'
-		collect: [ :each | each reversed ]) asArray
-			= #('won' 'si' 'eht' 'emit')
+	self assert: (matcher matchesIn: 'now is the time' collect: [ :each | each reversed ]) asArray equals: #('won' 'si' 'eht' 'emit')
 ]
 
 { #category : #'testing-protocol' }
@@ -1087,7 +1083,7 @@ RxMatcherTest >> testMatchesInDo [
 	| matcher expected |
 	matcher := self matcherClass forString: '\w+'.
 	expected := #('now' 'is' 'the' 'time') asOrderedCollection.
-	matcher matchesIn: 'now is the time' do: [ :each | self assert: each = expected removeFirst ].
+	matcher matchesIn: 'now is the time' do: [ :each | self assert: each equals: expected removeFirst ].
 	self assertEmpty: expected
 ]
 
@@ -1095,18 +1091,14 @@ RxMatcherTest >> testMatchesInDo [
 RxMatcherTest >> testMatchesOnStream [
 	| matcher |
 	matcher := self matcherClass forString: '\w+'.
-	self assert: (matcher matchesOnStream: 'now is the time' readStream) asArray 
-		= #('now' 'is' 'the' 'time')
+	self assert: (matcher matchesOnStream: 'now is the time' readStream) asArray equals: #('now' 'is' 'the' 'time')
 ]
 
 { #category : #'testing-protocol' }
 RxMatcherTest >> testMatchesOnStreamCollect [
 	| matcher |
 	matcher := self matcherClass forString: '\w+'.
-	self assert: (matcher 
-		matchesOnStream: 'now is the time' readStream 
-		collect: [ :each | each reversed ]) asArray
-			= #('won' 'si' 'eht' 'emit')
+	self assert: (matcher matchesOnStream: 'now is the time' readStream collect: [ :each | each reversed ]) asArray equals: #('won' 'si' 'eht' 'emit')
 ]
 
 { #category : #'testing-protocol' }
@@ -1114,7 +1106,7 @@ RxMatcherTest >> testMatchesOnStreamDo [
 	| matcher expected |
 	matcher := self matcherClass forString: '\w+'.
 	expected := #('now' 'is' 'the' 'time') asOrderedCollection.
-	matcher matchesOnStream: 'now is the time' readStream do: [ :each | self assert: each = expected removeFirst ].
+	matcher matchesOnStream: 'now is the time' readStream do: [ :each | self assert: each equals: expected removeFirst ].
 	self assertEmpty: expected
 ]
 
@@ -1133,8 +1125,8 @@ RxMatcherTest >> testMatchingRangesIn [
 	expected := #(1 3 5 6 8 10 12 15) asOrderedCollection.
 	(matcher matchingRangesIn: 'now is the time')
 		do: [ :range | 
-			self assert: range first = expected removeFirst.
-			self assert: range last = expected removeFirst ].
+			self assert: range first equals: expected removeFirst.
+			self assert: range last equals: expected removeFirst ].
 	self assertEmpty: expected
 ]
 


### PR DESCRIPTION
Replace assert = in packages starting by R.

Replace:

- assert: = by assert: equals:
- deny = by deny: equals:
- assert: == by assert: identicalTo:
- deny: == by deny: identicalTo: