### PR TITLE
Replace-assert-equals-from-packages-starting-with-U

### DIFF
--- a/src/UndefinedClasses-Tests/UndefinedClassTest.class.st
+++ b/src/UndefinedClasses-Tests/UndefinedClassTest.class.st
@@ -83,14 +83,13 @@ UndefinedClassTest >> testCreateSubclassOfNilCreatesSubclassOfNil [
 
 { #category : #tests }
 UndefinedClassTest >> testCreateTwoUndefinedClassesOfSameNameShouldBeSameClass [
-
 	| foo foo2 |
 	self assertClassDoesNotExist: #Foo.
 
 	foo := UndefinedClass createUndefinedClassNamed: #Foo package: #Foo.
 	foo2 := UndefinedClass createUndefinedClassNamed: #Foo package: #Foo.
-	
-	self assert: foo == foo2
+
+	self assert: foo identicalTo: foo2
 ]
 
 { #category : #tests }

--- a/src/UnifiedFFI-Tests/FFIExternalPackedStructureTest.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalPackedStructureTest.class.st
@@ -36,26 +36,23 @@ FFIExternalPackedStructureTest >> testExternallyAllocatedStructure [
 
 { #category : #tests }
 FFIExternalPackedStructureTest >> testStructAccess [
-
 	| struct |
-	
 	struct := FFITestPackedStructure new.
-	self deny: struct getHandle class = ExternalAddress.	
+	self deny: struct getHandle class equals: ExternalAddress.
 	self deny: struct isNull.
-	
+
 	struct byte: 10.
 	struct short: -20.
 	struct long: 100.
 	struct float: 1.0.
 	struct double: 2.0.
-		self flag: #pharoTodo. "This is not yet implemented"
+	self flag: #pharoTodo.	"This is not yet implemented"
 	"struct int64: 123456789101112."
-	
+
 	self assert: struct byte equals: 10.
-	self assert: struct short equals: -20.	
-	self assert: struct long equals: 100.	
-	self assert: struct float equals: 1.0.	
-	self assert: struct double equals: 2.0.	
+	self assert: struct short equals: -20.
+	self assert: struct long equals: 100.
+	self assert: struct float equals: 1.0.
+	self assert: struct double equals: 2.0
 	"self assert: (struct int64 = 123456789101112).	"
-	
 ]

--- a/src/UnifiedFFI-Tests/FFIExternalStructureTest.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalStructureTest.class.st
@@ -166,28 +166,25 @@ FFIExternalStructureTest >> testNestedStructureWithArray [
 
 { #category : #tests }
 FFIExternalStructureTest >> testStructAccess [
-
 	| struct |
-	
 	struct := FFITestStructure new.
-	self deny: struct getHandle class = ExternalAddress.	
+	self deny: struct getHandle class equals: ExternalAddress.
 	self deny: struct isNull.
-	
+
 	struct byte: 10.
 	struct short: -20.
 	struct long: 100.
 	struct float: 1.0.
 	struct double: 2.0.
-		self flag: #pharoTodo. "This is not yet implemented"
+	self flag: #pharoTodo.	"This is not yet implemented"
 	"struct int64: 123456789101112."
-	
+
 	self assert: struct byte equals: 10.
-	self assert: struct short equals: -20.	
-	self assert: struct long equals: 100.	
-	self assert: struct float equals: 1.0.	
-	self assert: struct double equals: 2.0.	
+	self assert: struct short equals: -20.
+	self assert: struct long equals: 100.
+	self assert: struct float equals: 1.0.
+	self assert: struct double equals: 2.0
 	"self assert: struct int64 equals: 123456789101112.	"
-	
 ]
 
 { #category : #tests }

--- a/src/UnifiedFFI-Tests/FFIExternalUnionTest.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalUnionTest.class.st
@@ -9,21 +9,18 @@ Class {
 
 { #category : #tests }
 FFIExternalUnionTest >> testUnionAccess [
-
 	| union |
-	
 	union := FFITestUnion new.
-	self deny: union getHandle class = ExternalAddress.	
+	self deny: union getHandle class equals: ExternalAddress.
 	self deny: union isNull.
-	
+
 	union long: 16r04030201.
 	self assert: union byte equals: 16r01.
 	self assert: union short equals: 16r0201.
 	self assert: union long equals: 16r04030201.
-	self assert: (union float ~= 0).
-	self assert: (union double ~= 0).
-	
-		self flag: #pharoTodo. "This is not yet implemented"
-	"struct int64: 123456789101112."
+	self assert: union float ~= 0.
+	self assert: union double ~= 0.
 
+	self flag: #pharoTodo	"This is not yet implemented"
+	"struct int64: 123456789101112."
 ]


### PR DESCRIPTION
Replace assert = in packages starting by U.

Replace:

- assert: = by assert: equals:
- deny = by deny: equals:
- assert: == by assert: identicalTo:
- deny: == by deny: identicalTo: