### PR TITLE
Replace-assert-equals-from-packages-starting-with-Z

### DIFF
--- a/src/Zinc-Character-Encoding-Tests/ZnBufferedStreamByteTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnBufferedStreamByteTest.class.st
@@ -124,16 +124,22 @@ ZnBufferedStreamByteTest >> testInt32Aliases [
 { #category : #testing }
 ZnBufferedStreamByteTest >> testInt8 [
 	| bytes readStream |
-	bytes := ByteArray streamContents: [ :out |
-		ZnBufferedWriteStream on: out do: [ :bout |
-			bout int8: 123; uint8: 123; int8: -123 ] ].
+	bytes := ByteArray
+		streamContents: [ :out | 
+			ZnBufferedWriteStream
+				on: out
+				do: [ :bout | 
+					bout
+						int8: 123;
+						uint8: 123;
+						int8: -123 ] ].
 	readStream := ZnBufferedReadStream on: bytes readStream.
 	self assert: readStream peek equals: 123.
 	self assert: readStream int8 equals: 123.
 	self assert: readStream peek equals: 123.
 	self assert: readStream uint8 equals: 123.
-	self deny: readStream peek = 123.
-	self deny: readStream peek = -123.
+	self deny: readStream peek equals: 123.
+	self deny: readStream peek equals: -123.
 	self assert: readStream int8 equals: -123
 ]
 

--- a/src/Zinc-Character-Encoding-Tests/ZnBufferedWriteStreamTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnBufferedWriteStreamTest.class.st
@@ -20,22 +20,31 @@ ZnBufferedWriteStreamTest >> testNextPutAllStartingAt [
 { #category : #testing }
 ZnBufferedWriteStreamTest >> testWriting [
 	| string |
-	string := String streamContents: [ :stringStream | | bufferedStream |
-		bufferedStream := ZnBufferedWriteStream on: stringStream.
-		0 to: 9 do: [ :each | bufferedStream nextPut: (Character digitValue: each) ].
-		bufferedStream flush ].
-	self assert: string = '0123456789'
+	string := String
+		streamContents: [ :stringStream | 
+			| bufferedStream |
+			bufferedStream := ZnBufferedWriteStream on: stringStream.
+			0 to: 9 do: [ :each | bufferedStream nextPut: (Character digitValue: each) ].
+			bufferedStream flush ].
+	self assert: string equals: '0123456789'
 ]
 
 { #category : #testing }
 ZnBufferedWriteStreamTest >> testWritingOverflow [
 	| string |
-	string := String streamContents: [ :stringStream | | bufferedStream |
-		bufferedStream := ZnBufferedWriteStream on: stringStream.
-		bufferedStream sizeBuffer: 8.
-		0 to: 9 do: [ :each | bufferedStream nextPut: (Character digitValue: each) ].
-		bufferedStream nextPutAll: '0123'; nextPutAll: '4567'; nextPutAll: '89'.
-		bufferedStream nextPutAll: '0123456789'; nextPutAll: '0123456789'.
-		bufferedStream flush ].
-	self assert: string = '0123456789012345678901234567890123456789'
+	string := String
+		streamContents: [ :stringStream | 
+			| bufferedStream |
+			bufferedStream := ZnBufferedWriteStream on: stringStream.
+			bufferedStream sizeBuffer: 8.
+			0 to: 9 do: [ :each | bufferedStream nextPut: (Character digitValue: each) ].
+			bufferedStream
+				nextPutAll: '0123';
+				nextPutAll: '4567';
+				nextPutAll: '89'.
+			bufferedStream
+				nextPutAll: '0123456789';
+				nextPutAll: '0123456789'.
+			bufferedStream flush ].
+	self assert: string equals: '0123456789012345678901234567890123456789'
 ]

--- a/src/Zinc-Character-Encoding-Tests/ZnCharacterEncoderTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnCharacterEncoderTest.class.st
@@ -142,10 +142,9 @@ ZnCharacterEncoderTest >> testConvencienceMethods [
 	encoder := ZnUTF8Encoder new.
 	string := 'élève en Français'.
 	self assert: (encoder decodeBytes: (encoder encodeString: string)) equals: string.
-	self assert: (encoder encodedByteCountForString: string) = 20.
-	
-	#( 'ccc' 'ççç' 'c' 'ç' 'çc' 'cç' ) do: [ :each |
-		self assert: (encoder decodeBytes: (encoder encodeString: each)) equals: each ]
+	self assert: (encoder encodedByteCountForString: string) equals: 20.
+
+	#('ccc' 'ççç' 'c' 'ç' 'çc' 'cç') do: [ :each | self assert: (encoder decodeBytes: (encoder encodeString: each)) equals: each ]
 ]
 
 { #category : #testing }
@@ -210,17 +209,19 @@ ZnCharacterEncoderTest >> testLatin1Encoder [
 { #category : #testing }
 ZnCharacterEncoderTest >> testLatin2Encoder [
 	"Example characters taken from http://en.wikipedia.org/wiki/Latin2"
-	
+
 	| encoder inputBytes outputBytes inputString outputString |
 	encoder := ZnCharacterEncoder newForEncoding: 'latin2'.
-	inputString := String 
-		with: (16r0154 asCharacter) with: (16r0110 asCharacter) 
-		with: ( 16r0155 asCharacter) with: (16r0111 asCharacter).
+	inputString := String
+		with: 16r0154 asCharacter
+		with: 16r0110 asCharacter
+		with: 16r0155 asCharacter
+		with: 16r0111 asCharacter.
 	inputBytes := #(192 208 224 240) asByteArray.
 	outputBytes := self encodeString: inputString with: encoder.
-	self assert: outputBytes = inputBytes.
+	self assert: outputBytes equals: inputBytes.
 	outputString := self decodeBytes: inputBytes with: encoder.
-	self assert: outputString = inputString 
+	self assert: outputString equals: inputString
 ]
 
 { #category : #testing }
@@ -246,9 +247,9 @@ ZnCharacterEncoderTest >> testNullEncoder [
 	| encoder bytes string |
 	encoder := ZnNullEncoder new.
 	bytes := self encodeString: 'abc' with: encoder.
-	self assert: bytes = #(97 98 99) asByteArray.
+	self assert: bytes equals: #(97 98 99) asByteArray.
 	string := self decodeBytes: #(65 66 67) asByteArray with: encoder.
-	self assert: string = 'ABC' 
+	self assert: string equals: 'ABC'
 ]
 
 { #category : #testing }
@@ -539,15 +540,19 @@ ZnCharacterEncoderTest >> testUTF8ByteOrderMark [
 { #category : #testing }
 ZnCharacterEncoderTest >> testUTF8Encoder [
 	"The examples are taken from http://en.wikipedia.org/wiki/UTF-8#Description"
-	
+
 	| encoder inputBytes outputBytes inputString outputString |
 	encoder := ZnUTF8Encoder new.
-	inputString := String with: $$ with: (16r00A2 asCharacter) with: (16r20AC asCharacter) with: (16r024B62 asCharacter).
+	inputString := String
+		with: $$
+		with: 16r00A2 asCharacter
+		with: 16r20AC asCharacter
+		with: 16r024B62 asCharacter.
 	inputBytes := #(16r24 16rC2 16rA2 16rE2 16r82 16rAC 16rF0 16rA4 16rAD 16rA2) asByteArray.
 	outputBytes := self encodeString: inputString with: encoder.
-	self assert: outputBytes = inputBytes.
+	self assert: outputBytes equals: inputBytes.
 	outputString := self decodeBytes: inputBytes with: encoder.
-	self assert: outputString = inputString 
+	self assert: outputString equals: inputString
 ]
 
 { #category : #testing }
@@ -555,19 +560,19 @@ ZnCharacterEncoderTest >> testUTF8EncoderAuto [
 	| encoder inputString bytes outputString |
 	encoder := ZnUTF8Encoder new.
 	inputString := String withAll: ((1 to: 3072) collect: [ :each | Character value: each ]).
-	bytes := self encodeString: inputString with: encoder. 
+	bytes := self encodeString: inputString with: encoder.
 	outputString := self decodeBytes: bytes with: encoder.
-	self assert: inputString = outputString 
+	self assert: inputString equals: outputString
 ]
 
 { #category : #testing }
-ZnCharacterEncoderTest >> testUTF8EncoderByteCount [	
+ZnCharacterEncoderTest >> testUTF8EncoderByteCount [
 	| encoder |
 	encoder := ZnUTF8Encoder new.
-	self assert: (encoder encodedByteCountFor: $$) = 1.
-	self assert: (encoder encodedByteCountFor: (16r00A2 asCharacter)) = 2.
-	self assert: (encoder encodedByteCountFor: (16r20AC asCharacter)) = 3.
-	self assert: (encoder encodedByteCountFor: (16r024B62 asCharacter)) = 4
+	self assert: (encoder encodedByteCountFor: $$) equals: 1.
+	self assert: (encoder encodedByteCountFor: 16r00A2 asCharacter) equals: 2.
+	self assert: (encoder encodedByteCountFor: 16r20AC asCharacter) equals: 3.
+	self assert: (encoder encodedByteCountFor: 16r024B62 asCharacter) equals: 4
 ]
 
 { #category : #testing }

--- a/src/Zinc-Character-Encoding-Tests/ZnCharacterStreamTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnCharacterStreamTest.class.st
@@ -67,18 +67,18 @@ ZnCharacterStreamTest >> testReadStream [
 	stream := ZnCharacterReadStream on: 'ABC' asByteArray readStream.
 	self deny: stream atEnd.
 	self deny: stream isBinary.
-	self assert: stream next = $A.
+	self assert: stream next equals: $A.
 	self deny: stream atEnd.
-	self assert: stream peek = $B.
+	self assert: stream peek equals: $B.
 	self deny: stream atEnd.
-	self assert: stream peek = $B.
+	self assert: stream peek equals: $B.
 	self deny: stream atEnd.
-	self assert: stream next = $B.
+	self assert: stream next equals: $B.
 	self deny: stream atEnd.
-	self assert: stream next = $C.
+	self assert: stream next equals: $C.
 	self assert: stream atEnd.
 	self assert: stream next isNil.
-	self assert: stream peek isNil		
+	self assert: stream peek isNil
 ]
 
 { #category : #testing }

--- a/src/Zinc-Resource-Meta-Tests/ZnFileUrlTest.class.st
+++ b/src/Zinc-Resource-Meta-Tests/ZnFileUrlTest.class.st
@@ -94,15 +94,14 @@ ZnFileUrlTest >> testSpaces [
 { #category : #testing }
 ZnFileUrlTest >> testTrailingSlash [
 	| fileReference1 fileReference2 fileUrl1 fileUrl2 |
-	
 	fileReference1 := '/foo/bar' asFileReference.
 	fileReference2 := '/foo/bar/' asFileReference.
 	self assert: fileReference1 equals: fileReference2.
 	self assert: fileReference1 asZnUrl equals: fileReference2 asZnUrl.
-	
+
 	fileUrl1 := 'file:///foo/bar' asZnUrl.
 	fileUrl2 := 'file:///foo/bar/' asZnUrl.
-	self deny: fileUrl1 = fileUrl2.
+	self deny: fileUrl1 equals: fileUrl2.
 	self assert: fileUrl1 asFileReference equals: fileUrl2 asFileReference
 ]
 

--- a/src/Zinc-Resource-Meta-Tests/ZnMimeTypeTest.class.st
+++ b/src/Zinc-Resource-Meta-Tests/ZnMimeTypeTest.class.st
@@ -56,9 +56,7 @@ ZnMimeTypeTest >> testComparingWithParameters [
 
 { #category : #testing }
 ZnMimeTypeTest >> testCopying [
-
 	| mimeType1 mimeType2 |
-
 	mimeType1 := ZnMimeType textPlain.
 	mimeType2 := ZnMimeType textPlain.
 	self assert: mimeType1 equals: mimeType2.
@@ -67,9 +65,9 @@ ZnMimeTypeTest >> testCopying [
 	self assert: mimeType1 charSet equals: 'utf-8'.
 	mimeType2 charSet: 'latin1'.
 	self assert: mimeType2 charSet equals: 'latin1'.
-	self assert: ( mimeType1 matches: mimeType2 ).
-	self deny: mimeType1 parameters = mimeType2 parameters.
-	self deny: mimeType1 charSet = mimeType2 charSet
+	self assert: (mimeType1 matches: mimeType2).
+	self deny: mimeType1 parameters equals: mimeType2 parameters.
+	self deny: mimeType1 charSet equals: mimeType2 charSet
 ]
 
 { #category : #testing }
@@ -98,14 +96,9 @@ ZnMimeTypeTest >> testIsBinary [
 
 { #category : #testing }
 ZnMimeTypeTest >> testMatches [
-	#(
-		( 'text/plain' 'text/*' )
-		( 'text/plain' '*/*' )
-		( 'text/plain;charset=utf-8' 'text/*' ) 
-		( 'text/plain;charset=utf-8' 'text/plain' )
-		( 'text/plain' 'text/plain;charset=utf-8' )
-		( 'text/plain;charset=utf-8' 'text/plain;charset=ascii' ) ) do: [ :each |
-			self deny: each first asZnMimeType = each second asZnMimeType.
+	#(#('text/plain' 'text/*') #('text/plain' '*/*') #('text/plain;charset=utf-8' 'text/*') #('text/plain;charset=utf-8' 'text/plain') #('text/plain' 'text/plain;charset=utf-8') #('text/plain;charset=utf-8' 'text/plain;charset=ascii'))
+		do: [ :each | 
+			self deny: each first asZnMimeType equals: each second asZnMimeType.
 			self assert: (each first asZnMimeType matches: each second asZnMimeType) ]
 ]
 

--- a/src/Zinc-Resource-Meta-Tests/ZnMultiValueDictionaryTest.class.st
+++ b/src/Zinc-Resource-Meta-Tests/ZnMultiValueDictionaryTest.class.st
@@ -22,15 +22,19 @@ ZnMultiValueDictionaryTest >> testDynamicLimit [
 ZnMultiValueDictionaryTest >> testMultiValues [
 	| dictionary values keys |
 	dictionary := ZnMultiValueDictionary new.
-	dictionary at: 'foo' add: 1; at: 'foo' add: 2.
-	self assert: (dictionary at: 'foo') = #(1 2).
-	self assert: dictionary keys asArray = #('foo').
+	dictionary
+		at: 'foo' add: 1;
+		at: 'foo' add: 2.
+	self assert: (dictionary at: 'foo') equals: #(1 2).
+	self assert: dictionary keys asArray equals: #('foo').
 	values := OrderedCollection new.
 	keys := OrderedCollection new.
-	dictionary keysAndValuesDo: [ :key :value | keys add: key. values add: value ].
-	self assert: values = (OrderedCollection with: 1 with: 2).
-	self assert: keys = (OrderedCollection with: 'foo' with: 'foo')
-	
+	dictionary
+		keysAndValuesDo: [ :key :value | 
+			keys add: key.
+			values add: value ].
+	self assert: values equals: (OrderedCollection with: 1 with: 2).
+	self assert: keys equals: (OrderedCollection with: 'foo' with: 'foo')
 ]
 
 { #category : #testing }

--- a/src/Zinc-Resource-Meta-Tests/ZnResourceMetaUtilsTest.class.st
+++ b/src/Zinc-Resource-Meta-Tests/ZnResourceMetaUtilsTest.class.st
@@ -13,11 +13,10 @@ ZnResourceMetaUtilsTest >> testDecodePercent [
 { #category : #testing }
 ZnResourceMetaUtilsTest >> testQueryParsing [
 	| string fields |
-	string := 'foo=100&x=', (ZnPercentEncoder new encode: '/a b').
+	string := 'foo=100&x=' , (ZnPercentEncoder new encode: '/a b').
 	fields := ZnResourceMetaUtils parseQueryFrom: string readStream.
-	self assert: (fields at: 'foo') = '100'.
-	self assert: (fields at: 'x') = '/a b'.
-	
+	self assert: (fields at: 'foo') equals: '100'.
+	self assert: (fields at: 'x') equals: '/a b'
 ]
 
 { #category : #testing }

--- a/src/Zinc-Resource-Meta-Tests/ZnUrlTest.class.st
+++ b/src/Zinc-Resource-Meta-Tests/ZnUrlTest.class.st
@@ -30,8 +30,8 @@ ZnUrlTest >> testAsRelativeUrl [
 
 { #category : #testing }
 ZnUrlTest >> testAuthority [
-	self assert: 'http://localhost:8080/foo/bar/doc.txt' asZnUrl authority = 'localhost:8080'.
-	self assert: 'http://www.google.com?q=Smalltalk' asZnUrl authority = 'www.google.com'
+	self assert: 'http://localhost:8080/foo/bar/doc.txt' asZnUrl authority equals: 'localhost:8080'.
+	self assert: 'http://www.google.com?q=Smalltalk' asZnUrl authority equals: 'www.google.com'
 ]
 
 { #category : #testing }
@@ -91,12 +91,11 @@ ZnUrlTest >> testDefaultPortUnknownScheme [
 { #category : #testing }
 ZnUrlTest >> testDefaultScheme [
 	| url |
-	url := ZnUrl fromString: 'www.example.com/foo.html' defaultScheme: #http.  
+	url := ZnUrl fromString: 'www.example.com/foo.html' defaultScheme: #http.
 	self assert: url hasScheme.
-	self assert: url scheme = #http.
-	self assert: url host = 'www.example.com'.
-	self assert: url pathSegments = (OrderedCollection with: 'foo.html')
-	
+	self assert: url scheme equals: #http.
+	self assert: url host equals: 'www.example.com'.
+	self assert: url pathSegments equals: (OrderedCollection with: 'foo.html')
 ]
 
 { #category : #testing }
@@ -107,9 +106,8 @@ ZnUrlTest >> testDefaultSchemeAndPort [
 	self assert: url hasPort not.
 	self assert: url port isNil.
 	self assert: url scheme isNil.
-	self assert: url schemeOrDefault = #http.
-	self assert: url portOrDefault = 80
-	
+	self assert: url schemeOrDefault equals: #http.
+	self assert: url portOrDefault equals: 80
 ]
 
 { #category : #testing }
@@ -118,23 +116,20 @@ ZnUrlTest >> testDefaults [
 	url := '' asZnUrl asZnUrlWithDefaults.
 	self assert: url hasScheme.
 	self assert: url hasPort.
-	self assert: url scheme = #http.
-	self assert: url port = 80
-	
+	self assert: url scheme equals: #http.
+	self assert: url port equals: 80
 ]
 
 { #category : #testing }
 ZnUrlTest >> testEncodedSlash [
-	self assert: 'http://example.com/foo//' asZnUrl pathPrintString = '/foo//'.
-	self assert: 'http://example.com/foo//bar/' asZnUrl pathPrintString = '/foo//bar/'.
-	self assert: 'http://example.com/foo//bar/file.txt' asZnUrl pathPrintString = '/foo//bar/file.txt'.
+	self assert: 'http://example.com/foo//' asZnUrl pathPrintString equals: '/foo//'.
+	self assert: 'http://example.com/foo//bar/' asZnUrl pathPrintString equals: '/foo//bar/'.
+	self assert: 'http://example.com/foo//bar/file.txt' asZnUrl pathPrintString equals: '/foo//bar/file.txt'.
 
-	self assert: 'http://example.com/foo/%2F' asZnUrl pathPrintString = '/foo/%2F'.
-	self assert: 'http://example.com/foo/%2Fbar/' asZnUrl pathPrintString = '/foo/%2Fbar/'.
-	self assert: 'http://example.com/foo/%2F/bar/' asZnUrl pathPrintString = '/foo/%2F/bar/'.
-	self assert: 'http://example.com/foo/%2Ffoo.txt' asZnUrl pathPrintString = '/foo/%2Ffoo.txt'.
-
-
+	self assert: 'http://example.com/foo/%2F' asZnUrl pathPrintString equals: '/foo/%2F'.
+	self assert: 'http://example.com/foo/%2Fbar/' asZnUrl pathPrintString equals: '/foo/%2Fbar/'.
+	self assert: 'http://example.com/foo/%2F/bar/' asZnUrl pathPrintString equals: '/foo/%2F/bar/'.
+	self assert: 'http://example.com/foo/%2Ffoo.txt' asZnUrl pathPrintString equals: '/foo/%2Ffoo.txt'
 ]
 
 { #category : #testing }
@@ -242,13 +237,13 @@ ZnUrlTest >> testParsePathOnly [
 	self assert: url hasHost not.
 	self assert: url hasPort not.
 	self assert: url isAbsolute not.
-	self assert: url pathSegments = (OrderedCollection with: 'images' with: 'foo.png' ).
-	self assert: url firstPathSegment = 'images'.
-	self assert: url lastPathSegment = 'foo.png'.
+	self assert: url pathSegments equals: (OrderedCollection with: 'images' with: 'foo.png').
+	self assert: url firstPathSegment equals: 'images'.
+	self assert: url lastPathSegment equals: 'foo.png'.
 	self assert: url hasQuery.
-	self assert: (url queryAt: 'size') = 'large'.
+	self assert: (url queryAt: 'size') equals: 'large'.
 	self assert: url hasFragment.
-	self assert: url fragment = 'center'  
+	self assert: url fragment equals: 'center'
 ]
 
 { #category : #testing }
@@ -268,21 +263,21 @@ ZnUrlTest >> testParsingEmpty [
 ZnUrlTest >> testParsingEscape [
 	| url |
 	url := ZnUrl fromString: 'http://localhost/foo%62%61%72'.
-	self assert: url firstPathSegment = 'foobar'
+	self assert: url firstPathSegment equals: 'foobar'
 ]
 
 { #category : #testing }
 ZnUrlTest >> testParsingSimple [
 	| url |
 	url := ZnUrl fromString: 'http://www.example.com:8080/foo/bar/baz.txt?x=1&y=2#m1'.
-	self assert: url scheme = #http.
-	self assert: url host = 'www.example.com'.
-	self assert: url port = 8080.
+	self assert: url scheme equals: #http.
+	self assert: url host equals: 'www.example.com'.
+	self assert: url port equals: 8080.
 	self assert: url hasPath.
 	self assert: url isFilePath.
 	self assert: url hasQuery.
 	self assert: url hasFragment.
-	self assert: url fragment = 'm1'
+	self assert: url fragment equals: 'm1'
 ]
 
 { #category : #testing }
@@ -409,21 +404,21 @@ ZnUrlTest >> testPrintingSimple [
 		addPathSegment: 'foo.html';
 		queryAt: 'q' put: '100';
 		fragment: 'mark'.
-	self assert: url authority = 'www.seaside.st:8080'.
+	self assert: url authority equals: 'www.seaside.st:8080'.
 	self assert: url isAbsolute.
 	self assert: url isFilePath.
-	self assert: url printString = 'http://www.seaside.st:8080/example/foo.html?q=100#mark'.
-	self assert: url file = 'foo.html'.
-	self assert: url directory = 'example'.
-	self assert: url pathPrintString = '/example/foo.html'.
-	self assert: url pathQueryFragmentPrintString = '/example/foo.html?q=100#mark'
+	self assert: url printString equals: 'http://www.seaside.st:8080/example/foo.html?q=100#mark'.
+	self assert: url file equals: 'foo.html'.
+	self assert: url directory equals: 'example'.
+	self assert: url pathPrintString equals: '/example/foo.html'.
+	self assert: url pathQueryFragmentPrintString equals: '/example/foo.html?q=100#mark'
 ]
 
 { #category : #testing }
 ZnUrlTest >> testQuery [
 	| url |
 	url := 'http://foo.com/test?q' asZnUrl.
-	self assert: url printString = 'http://foo.com/test?q'
+	self assert: url printString equals: 'http://foo.com/test?q'
 ]
 
 { #category : #testing }
@@ -444,10 +439,9 @@ ZnUrlTest >> testQueryEncoding [
 	url := 'http://www.google.com' asZnUrl.
 	url addPathSegment: 'some encoding here'.
 	url queryAt: 'and some encoding' put: 'here, too#'.
-	self assert: url printString = 'http://www.google.com/some%20encoding%20here?and%20some%20encoding=here,%20too%23'.
-	self assert: url path =  'some encoding here'.
-	self assert: (url queryAt: 'and some encoding') = 'here, too#'
-	
+	self assert: url printString equals: 'http://www.google.com/some%20encoding%20here?and%20some%20encoding=here,%20too%23'.
+	self assert: url path equals: 'some encoding here'.
+	self assert: (url queryAt: 'and some encoding') equals: 'here, too#'
 ]
 
 { #category : #testing }
@@ -473,9 +467,9 @@ ZnUrlTest >> testQueryManipulation [
 	url := 'http://www.google.com/?one=1&two=2' asZnUrl.
 	url queryAt: 'three' put: '3'.
 	url queryRemoveKey: 'one'.
-	self assert: url queryKeys sorted = #(three two).
-	self assert: (url queryAt: 'two') = '2'.
-	self assert: (url queryAt: 'three') = '3'.
+	self assert: url queryKeys sorted equals: #(three two).
+	self assert: (url queryAt: 'two') equals: '2'.
+	self assert: (url queryAt: 'three') equals: '3'.
 	url queryRemoveAll.
 	self deny: url hasQuery
 ]
@@ -486,11 +480,11 @@ ZnUrlTest >> testQueryRemoveAll [
 		do: [ :each | 
 			| url |
 			url := 'http://foo.com/test?name=value' asZnUrl.
-			self deny: url = each asZnUrl.
+			self deny: url equals: each asZnUrl.
 			url queryRemoveAll.
 			self
 				assert: url query isEmpty;
-				assert: url = each asZnUrl ]
+				assert: url equals: each asZnUrl ]
 ]
 
 { #category : #testing }
@@ -563,7 +557,7 @@ ZnUrlTest >> testRelative [
 	url := 'http://api.foo.com:8080' asZnUrl.
 	self assert: url isAbsolute.
 	url parseFrom: '/user/1?format=full'.
-	self assert: url printString = 'http://api.foo.com:8080/user/1?format=full'
+	self assert: url printString equals: 'http://api.foo.com:8080/user/1?format=full'
 ]
 
 { #category : #testing }
@@ -607,7 +601,6 @@ ZnUrlTest >> testWindowsFileUrl [
 { #category : #testing }
 ZnUrlTest >> testWriteUrlPathQueryFragmentOfOn [
 	| string |
-	string := String streamContents: [ :stream |
-		'http://host:7777/foo/bar/doc.txt?x=1#mark' asZnUrl printPathQueryFragmentOn:  stream ].
-	self assert: string = '/foo/bar/doc.txt?x=1#mark'
+	string := String streamContents: [ :stream | 'http://host:7777/foo/bar/doc.txt?x=1#mark' asZnUrl printPathQueryFragmentOn: stream ].
+	self assert: string equals: '/foo/bar/doc.txt?x=1#mark'
 ]

--- a/src/Zinc-Tests/ZnBivalentWriteStreamTest.class.st
+++ b/src/Zinc-Tests/ZnBivalentWriteStreamTest.class.st
@@ -7,17 +7,26 @@ Class {
 { #category : #testing }
 ZnBivalentWriteStreamTest >> testByteWriting [
 	| string |
-	string := String streamContents: [ :stream | | writeStream |
-		writeStream := ZnBivalentWriteStream on: stream.
-		writeStream nextPut: 97; nextPutAll: #(98 99) asByteArray ].
-	self assert: string asByteArray = #(97 98 99) asByteArray
+	string := String
+		streamContents: [ :stream | 
+			| writeStream |
+			writeStream := ZnBivalentWriteStream on: stream.
+			writeStream
+				nextPut: 97;
+				nextPutAll: #(98 99) asByteArray ].
+	self assert: string asByteArray equals: #(97 98 99) asByteArray
 ]
 
 { #category : #testing }
 ZnBivalentWriteStreamTest >> testCharacterWriting [
 	| bytes |
-	bytes := ByteArray streamContents: [ :stream | | writeStream |
-		writeStream := ZnBivalentWriteStream on: stream.
-		writeStream nextPut: $a; space; nextPutAll: '123' ].
-	self assert: bytes = 'a 123' asByteArray
+	bytes := ByteArray
+		streamContents: [ :stream | 
+			| writeStream |
+			writeStream := ZnBivalentWriteStream on: stream.
+			writeStream
+				nextPut: $a;
+				space;
+				nextPutAll: '123' ].
+	self assert: bytes equals: 'a 123' asByteArray
 ]

--- a/src/Zinc-Tests/ZnClientTest.class.st
+++ b/src/Zinc-Tests/ZnClientTest.class.st
@@ -44,36 +44,43 @@ ZnClientTest >> testConstruction [
 		addPath: 'file.txt';
 		queryAt: 'key' put: '123456';
 		headerAt: 'X-token' put: 'ABCDEF'.
-	self assert: client request url host = 'www.example.com'.
-	self assert: client request url port = 8080.
-	self assert: client request url pathQueryFragmentPrintString = '/foo/a%20space/file.txt?key=123456'.
-	self assert: (client request headers at: 'X-token') = 'ABCDEF'
+	self assert: client request url host equals: 'www.example.com'.
+	self assert: client request url port equals: 8080.
+	self assert: client request url pathQueryFragmentPrintString equals: '/foo/a%20space/file.txt?key=123456'.
+	self assert: (client request headers at: 'X-token') equals: 'ABCDEF'
 ]
 
 { #category : #testing }
 ZnClientTest >> testCookies [
 	| client |
-	self withServerDo: [ :server |
-		server onRequestRespond: [ :request | | cookie1 cookie2 response |
-			cookie1 := request cookies detect: [ :each | each name = 'x' ] ifNone: [ ZnCookie name: 'x' value: '0' ].
-			cookie2 := request cookies detect: [ :each | each name = 'y' ] ifNone: [ ZnCookie name: 'y' value: '100' ].
-			cookie1 value: (cookie1 value asInteger + 1) asString.
-			cookie2 value: (cookie2 value asInteger + 2) asString.
-			response := ZnResponse ok: (ZnEntity text: 'OK').
-			response addCookie: cookie1; addCookie: cookie2.
-			response ].
-		client := ZnClient new url: server localUrl; yourself.
-		self assert: (client session cookieJar cookieAt: 'x' forUrl: client request url) isNil.
-		self assert: (client session cookieJar cookieAt: 'y' forUrl: client request url) isNil.
-		client get.
-		self assert: client isSuccess.
-		self assert: (client session cookieJar cookieAt: 'x' forUrl: client request url) value = '1'.
-		self assert: (client session cookieJar cookieAt: 'y' forUrl: client request url) value = '102'.
-		client get.
-		self assert: client isSuccess.
-		self assert: (client session cookieJar cookieAt: 'x' forUrl: client request url) value = '2'.
-		self assert: (client session cookieJar cookieAt: 'y' forUrl: client request url) value = '104'.
-		client close ]
+	self
+		withServerDo: [ :server | 
+			server
+				onRequestRespond: [ :request | 
+					| cookie1 cookie2 response |
+					cookie1 := request cookies detect: [ :each | each name = 'x' ] ifNone: [ ZnCookie name: 'x' value: '0' ].
+					cookie2 := request cookies detect: [ :each | each name = 'y' ] ifNone: [ ZnCookie name: 'y' value: '100' ].
+					cookie1 value: (cookie1 value asInteger + 1) asString.
+					cookie2 value: (cookie2 value asInteger + 2) asString.
+					response := ZnResponse ok: (ZnEntity text: 'OK').
+					response
+						addCookie: cookie1;
+						addCookie: cookie2.
+					response ].
+			client := ZnClient new
+				url: server localUrl;
+				yourself.
+			self assert: (client session cookieJar cookieAt: 'x' forUrl: client request url) isNil.
+			self assert: (client session cookieJar cookieAt: 'y' forUrl: client request url) isNil.
+			client get.
+			self assert: client isSuccess.
+			self assert: (client session cookieJar cookieAt: 'x' forUrl: client request url) value equals: '1'.
+			self assert: (client session cookieJar cookieAt: 'y' forUrl: client request url) value equals: '102'.
+			client get.
+			self assert: client isSuccess.
+			self assert: (client session cookieJar cookieAt: 'x' forUrl: client request url) value equals: '2'.
+			self assert: (client session cookieJar cookieAt: 'y' forUrl: client request url) value equals: '104'.
+			client close ]
 ]
 
 { #category : #testing }
@@ -85,55 +92,48 @@ ZnClientTest >> testDownloadSmallHTML [
 		url: self smallHtmlUrl;
 		downloadTo: ZnFileSystemUtils defaultDirectoryPath.
 	self assert: client isSuccess.
-	self assert: client response contentType = ZnMimeType textHtml.
-	ZnFileSystemUtils 
-		oldFileNamed: self smallHtmlUrl pathSegments last
-		do: [ :stream | self assert: (stream upToEnd includesSubstring: 'Small') ].
+	self assert: client response contentType equals: ZnMimeType textHtml.
+	ZnFileSystemUtils oldFileNamed: self smallHtmlUrl pathSegments last do: [ :stream | self assert: (stream upToEnd includesSubstring: 'Small') ].
 	ZnFileSystemUtils deleteIfExists: self smallHtmlUrl pathSegments last.
 	"Second download to an explicitly named file"
-	client 
+	client
 		url: self smallHtmlUrl;
 		downloadTo: self smallHtmlUrl pathSegments last.
 	self assert: client isSuccess.
-	self assert: client response contentType = ZnMimeType textHtml.
-	ZnFileSystemUtils 
-		oldFileNamed: self smallHtmlUrl pathSegments last
-		do: [ :stream | self assert: (stream upToEnd includesSubstring: 'Small') ].	
+	self assert: client response contentType equals: ZnMimeType textHtml.
+	ZnFileSystemUtils oldFileNamed: self smallHtmlUrl pathSegments last do: [ :stream | self assert: (stream upToEnd includesSubstring: 'Small') ].
 	client close.
 	ZnFileSystemUtils deleteIfExists: self smallHtmlUrl pathSegments last
-
 ]
 
 { #category : #testing }
 ZnClientTest >> testGetAfterPost [
-	self withServerDo: [ :server | | client |
-		server onRequestRespond: [ :request | 
-			request uri firstPathSegment = 'one'
-				ifTrue: [
-					(request method = #POST and: [ request hasEntity ])
-						ifTrue: [ ZnResponse ok: (ZnEntity text: 'OK for one') ]
-						ifFalse: [ ZnResponse badRequest: request ] ]
-				ifFalse: [
-					request uri firstPathSegment = 'two'
-						ifTrue: [ 
-							(request method = #GET and: [ request hasEntity not ])
-								ifTrue: [ ZnResponse ok: (ZnEntity text: 'OK for two') ]
-								ifFalse: [ ZnResponse badRequest: request ] ]
-		 				ifFalse: [ ZnResponse notFound: request uri ] ] ].
-		(client := ZnClient new) 
-			autoResetEntityMethods: #(HEAD DELETE GET);
-			url: server localUrl;
-			url: 'one';
-			entity: (ZnEntity text: 'One two three');
-			post.
-		self assert: client isSuccess.
-		self assert: client contents = 'OK for one'.
-		client
-			url: 'two';
-			get.
-		self assert: client isSuccess.
-		self assert: client contents = 'OK for two'.
-		client close ]
+	self
+		withServerDo: [ :server | 
+			| client |
+			server
+				onRequestRespond: [ :request | 
+					request uri firstPathSegment = 'one'
+						ifTrue:
+							[ (request method = #POST and: [ request hasEntity ]) ifTrue: [ ZnResponse ok: (ZnEntity text: 'OK for one') ] ifFalse: [ ZnResponse badRequest: request ] ]
+						ifFalse: [ request uri firstPathSegment = 'two'
+								ifTrue:
+									[ (request method = #GET and: [ request hasEntity not ]) ifTrue: [ ZnResponse ok: (ZnEntity text: 'OK for two') ] ifFalse: [ ZnResponse badRequest: request ] ]
+								ifFalse: [ ZnResponse notFound: request uri ] ] ].
+			(client := ZnClient new)
+				autoResetEntityMethods: #(HEAD DELETE GET);
+				url: server localUrl;
+				url: 'one';
+				entity: (ZnEntity text: 'One two three');
+				post.
+			self assert: client isSuccess.
+			self assert: client contents equals: 'OK for one'.
+			client
+				url: 'two';
+				get.
+			self assert: client isSuccess.
+			self assert: client contents equals: 'OK for two'.
+			client close ]
 ]
 
 { #category : #testing }
@@ -159,15 +159,12 @@ ZnClientTest >> testGetGeoIP [
 		url: self t3EasyGeoIPUrl;
 		queryAt: 'address' put: '81.83.7.35';
 		accept: ZnMimeType applicationJson;
-		contentReader: [ :entity | 
-					testingEnvironment
-						at: #NeoJSONReader
-						ifPresent: [ :parserClass | parserClass fromString: entity contents ]
-						ifAbsent: [ ^ self ] ];
+		contentReader:
+				[ :entity | testingEnvironment at: #NeoJSONReader ifPresent: [ :parserClass | parserClass fromString: entity contents ] ifAbsent: [ ^ self ] ];
 		ifFail: [ ^ self fail ];
 		get.
 	self assert: result isDictionary.
-	self assert: (result at: #country) = 'BE'.
+	self assert: (result at: #country) equals: 'BE'.
 	client close
 ]
 
@@ -197,7 +194,7 @@ ZnClientTest >> testGetSmallHTML [
 		get.
 	self assert: client isSuccess.
 	self assert: client isContentTypeAcceptable.
-	self assert: client response contentType = ZnMimeType textHtml.
+	self assert: client response contentType equals: ZnMimeType textHtml.
 	self assert: (client contents includesSubstring: 'Small').
 	self assert: client isConnected.
 	client close.
@@ -207,7 +204,6 @@ ZnClientTest >> testGetSmallHTML [
 { #category : #testing }
 ZnClientTest >> testGetSmallHTMLBinary [
 	| client html bytes |
-	
 	(client := ZnClient new)
 		url: self smallHtmlUrl;
 		get.
@@ -216,14 +212,16 @@ ZnClientTest >> testGetSmallHTMLBinary [
 	self assert: (client contents includesSubstring: 'Small').
 	html := client contents.
 	self assert: html isString.
-	
-	client beBinary; get.
+
+	client
+		beBinary;
+		get.
 	self assert: client isSuccess.
-	self assert: client response contentType = ZnMimeType textHtml.
+	self assert: client response contentType equals: ZnMimeType textHtml.
 	bytes := client contents.
 	self deny: bytes isString.
 	self assert: bytes utf8Decoded equals: html.
-	
+
 	client close
 ]
 
@@ -235,7 +233,7 @@ ZnClientTest >> testGetSmallHTMLOneShot [
 		url: self smallHtmlUrl;
 		get.
 	self assert: client isSuccess.
-	self assert: client response contentType = ZnMimeType textHtml.
+	self assert: client response contentType equals: ZnMimeType textHtml.
 	self assert: (client contents includesSubstring: 'Small').
 	self deny: client isConnected
 ]
@@ -248,9 +246,9 @@ ZnClientTest >> testGetSmallHTMLStreaming [
 		streaming: true;
 		get.
 	self assert: client isSuccess.
-	self assert: client response contentType = ZnMimeType textHtml.
+	self assert: client response contentType equals: ZnMimeType textHtml.
 	self assert: result isStream.
-	self assert: client entity stream = result.
+	self assert: client entity stream equals: result.
 	contents := ZnUTF8Encoder new decodeBytes: result upToEnd.
 	self assert: (contents includesSubstring: 'Small').
 	client close
@@ -263,13 +261,13 @@ ZnClientTest >> testGetSmallHTMLTwice [
 		url: self smallHtmlUrl;
 		get.
 	self assert: client isSuccess.
-	self assert: client response contentType = ZnMimeType textHtml.
+	self assert: client response contentType equals: ZnMimeType textHtml.
 	self assert: (client contents includesSubstring: 'Small').
-	client 
+	client
 		url: self smallHtmlUrl pathPrintString;
 		get.
 	self assert: client isSuccess.
-	self assert: client response contentType = ZnMimeType textHtml.
+	self assert: client response contentType equals: ZnMimeType textHtml.
 	self assert: (client contents includesSubstring: 'Small').
 	client close
 ]
@@ -283,7 +281,7 @@ ZnClientTest >> testGetSmallHTMLUrlConstruction [
 		path: self smallHtmlUrl pathPrintString;
 		get.
 	self assert: client isSuccess.
-	self assert: client response contentType = ZnMimeType textHtml.
+	self assert: client response contentType equals: ZnMimeType textHtml.
 	self assert: (client contents includesSubstring: 'Small').
 	client close
 ]
@@ -599,85 +597,91 @@ ZnClientTest >> testRedirectDontFollow [
 
 { #category : #testing }
 ZnClientTest >> testRedirectWithCookies [
-	self withServerDo: [ :server | | client cookie |
-		server onRequestRespond: [ :request | 
-			request uri firstPathSegment = 'one'
-				ifTrue: [ 
-					(ZnResponse redirect: 'two')
-						addCookie: (ZnCookie name: 'session' value: '123456');
-						yourself ]
-				ifFalse: [
-					cookie := request cookies detect: [ :each | each name = 'session' ] ifNone: [ nil ].
-					(request uri firstPathSegment = 'two' and: [ cookie notNil and: [ cookie value = '123456' ] ])
-						ifTrue: [ ZnResponse ok: (ZnEntity text: 'OK!') ]
-		 				ifFalse: [ ZnResponse badRequest: request ] ] ].
-		(client := ZnClient new) 
-			url: server localUrl; addPath: 'one'; 
-			post.
-		self assert: client isSuccess.
-		self assert: client contents = 'OK!'.
-		client close ]
+	self
+		withServerDo: [ :server | 
+			| client cookie |
+			server
+				onRequestRespond: [ :request | 
+					request uri firstPathSegment = 'one'
+						ifTrue: [ (ZnResponse redirect: 'two')
+								addCookie: (ZnCookie name: 'session' value: '123456');
+								yourself ]
+						ifFalse: [ cookie := request cookies detect: [ :each | each name = 'session' ] ifNone: [ nil ].
+							(request uri firstPathSegment = 'two' and: [ cookie notNil and: [ cookie value = '123456' ] ])
+								ifTrue: [ ZnResponse ok: (ZnEntity text: 'OK!') ]
+								ifFalse: [ ZnResponse badRequest: request ] ] ].
+			(client := ZnClient new)
+				url: server localUrl;
+				addPath: 'one';
+				post.
+			self assert: client isSuccess.
+			self assert: client contents equals: 'OK!'.
+			client close ]
 ]
 
 { #category : #testing }
 ZnClientTest >> testRedirectWithCustomHeader [
-	self withServerDo: [ :server | | client cookie |
-		server onRequestRespond: [ :request | 
-			(request headers at: 'X-Custom' ifAbsent: [ nil ]) = 'The Secret'
-				ifFalse: [ ZnResponse badRequest: request ]
-				ifTrue: [
-					request uri firstPathSegment = 'one'
-						ifTrue: [ ZnResponse redirect: 'two' ]
-						ifFalse: [
-							request uri firstPathSegment = 'two'
-								ifTrue: [ ZnResponse ok: (ZnEntity text: 'OK!') ]
-		 						ifFalse: [ ZnResponse badRequest: request ] ] ] ].
-		(client := ZnClient new) 
-			url: server localUrl; 
-			addPath: 'one';
-			headerAt: 'X-Custom' put: 'The Secret'; 
-			get.
-		self assert: client isSuccess.
-		self assert: client contents = 'OK!'.
-		client close ]
+	self
+		withServerDo: [ :server | 
+			| client cookie |
+			server
+				onRequestRespond: [ :request | 
+					(request headers at: 'X-Custom' ifAbsent: [ nil ]) = 'The Secret'
+						ifFalse: [ ZnResponse badRequest: request ]
+						ifTrue: [ request uri firstPathSegment = 'one'
+								ifTrue: [ ZnResponse redirect: 'two' ]
+								ifFalse: [ request uri firstPathSegment = 'two' ifTrue: [ ZnResponse ok: (ZnEntity text: 'OK!') ] ifFalse: [ ZnResponse badRequest: request ] ] ] ].
+			(client := ZnClient new)
+				url: server localUrl;
+				addPath: 'one';
+				headerAt: 'X-Custom' put: 'The Secret';
+				get.
+			self assert: client isSuccess.
+			self assert: client contents equals: 'OK!'.
+			client close ]
 ]
 
 { #category : #testing }
 ZnClientTest >> testRelativeRedirect [
-	self withServerDo: [ :server | | client |
-		server onRequestRespond: [ :request | 
-			request uri firstPathSegment = 'one'
-				ifTrue: [ ZnResponse redirect: 'two' ]
-				ifFalse: [
-					request uri firstPathSegment = 'two'
-						ifTrue: [ ZnResponse ok: (ZnEntity text: 'OK!') ]
-		 				ifFalse: [ ZnResponse notFound: request uri ] ] ].
-		(client := ZnClient new) 
-			url: server localUrl; addPath: 'one'; 
-			post.
-		self assert: client isSuccess.
-		self assert: client contents = 'OK!'.
-		client close ]
+	self
+		withServerDo: [ :server | 
+			| client |
+			server
+				onRequestRespond: [ :request | 
+					request uri firstPathSegment = 'one'
+						ifTrue: [ ZnResponse redirect: 'two' ]
+						ifFalse: [ request uri firstPathSegment = 'two' ifTrue: [ ZnResponse ok: (ZnEntity text: 'OK!') ] ifFalse: [ ZnResponse notFound: request uri ] ] ].
+			(client := ZnClient new)
+				url: server localUrl;
+				addPath: 'one';
+				post.
+			self assert: client isSuccess.
+			self assert: client contents equals: 'OK!'.
+			client close ]
 ]
 
 { #category : #testing }
 ZnClientTest >> testRelativeRedirect307 [
-	self withServerDo: [ :server | | client |
-		server onRequestRespond: [ :request | 
-			request uri firstPathSegment = 'one'
-				ifTrue: [ (ZnResponse redirect: 'two') statusLine: (ZnStatusLine code: 307); yourself ]
-				ifFalse: [
-					((request uri firstPathSegment = 'two') 
-							and: [ request method = #POST and: [ request contents = 'BODY' ] ])
-						ifTrue: [ ZnResponse ok: (ZnEntity text: 'OK!') ]
-		 				ifFalse: [ ZnResponse notFound: request uri ] ] ].
-		(client := ZnClient new) 
-			url: server localUrl; addPath: 'one'; 
-			entity: (ZnEntity text: 'BODY');
-			post.
-		self assert: client isSuccess.
-		self assert: client contents = 'OK!'.
-		client close ]
+	self
+		withServerDo: [ :server | 
+			| client |
+			server
+				onRequestRespond: [ :request | 
+					request uri firstPathSegment = 'one'
+						ifTrue: [ (ZnResponse redirect: 'two')
+								statusLine: (ZnStatusLine code: 307);
+								yourself ]
+						ifFalse: [ (request uri firstPathSegment = 'two' and: [ request method = #POST and: [ request contents = 'BODY' ] ])
+								ifTrue: [ ZnResponse ok: (ZnEntity text: 'OK!') ]
+								ifFalse: [ ZnResponse notFound: request uri ] ] ].
+			(client := ZnClient new)
+				url: server localUrl;
+				addPath: 'one';
+				entity: (ZnEntity text: 'BODY');
+				post.
+			self assert: client isSuccess.
+			self assert: client contents equals: 'OK!'.
+			client close ]
 ]
 
 { #category : #testing }
@@ -721,25 +725,31 @@ ZnClientTest >> testTimeout [
 
 { #category : #testing }
 ZnClientTest >> testUploadSmallDocument [
-	self withServerDo: [ :server | | client contents path |
-		path := ZnFileSystemUtils fullNameFor: 'small.txt'.
-		contents := String streamContents: [ :stream |
-			stream print: DateAndTime now; space; print: 9999 atRandom ].
-		ZnFileSystemUtils deleteIfExists: 'small.txt'.
-		ZnFileSystemUtils newFileNamed: path do: [ :stream | stream nextPutAll: contents ].
-		(client := ZnClient new)
-			url: server localUrl;
-			addPath: 'echo';
-			uploadEntityFrom: path.
-		self assert: client request entity contentType = ZnMimeType textPlain.
-		client contentType: ZnMimeType textPlain. "Not needed, just test the code path"
-		self assert: client request entity contentType = ZnMimeType textPlain.
-		client post.
-		self assert: client isSuccess.
-		self assert: client entity contentType = ZnMimeType textPlain.
-		self assert: (client contents includesSubstring: contents).
-		client close.
-		ZnFileSystemUtils deleteIfExists: 'small.txt' ]
+	self
+		withServerDo: [ :server | 
+			| client contents path |
+			path := ZnFileSystemUtils fullNameFor: 'small.txt'.
+			contents := String
+				streamContents: [ :stream | 
+					stream
+						print: DateAndTime now;
+						space;
+						print: 9999 atRandom ].
+			ZnFileSystemUtils deleteIfExists: 'small.txt'.
+			ZnFileSystemUtils newFileNamed: path do: [ :stream | stream nextPutAll: contents ].
+			(client := ZnClient new)
+				url: server localUrl;
+				addPath: 'echo';
+				uploadEntityFrom: path.
+			self assert: client request entity contentType equals: ZnMimeType textPlain.
+			client contentType: ZnMimeType textPlain.	"Not needed, just test the code path"
+			self assert: client request entity contentType equals: ZnMimeType textPlain.
+			client post.
+			self assert: client isSuccess.
+			self assert: client entity contentType equals: ZnMimeType textPlain.
+			self assert: (client contents includesSubstring: contents).
+			client close.
+			ZnFileSystemUtils deleteIfExists: 'small.txt' ]
 ]
 
 { #category : #testing }

--- a/src/Zinc-Tests/ZnDispatcherDelegateTest.class.st
+++ b/src/Zinc-Tests/ZnDispatcherDelegateTest.class.st
@@ -6,26 +6,38 @@ Class {
 
 { #category : #testing }
 ZnDispatcherDelegateTest >> testDispatcherDelegate [
-	self withServerDo: [ :server |  | client |
-		server delegate: (ZnDispatcherDelegate new 
-			map: '/hello' to: [ :request :response | response entity: (ZnStringEntity html: '<h1>hello server</h1>') ];
-			map: '/' to: [ :request :response | response entity: (ZnStringEntity html: '<h1>default</h1>') ]).
+	self
+		withServerDo: [ :server | 
+			| client |
+			server
+				delegate:
+					(ZnDispatcherDelegate new
+						map: '/hello' to: [ :request :response | response entity: (ZnStringEntity html: '<h1>hello server</h1>') ];
+						map: '/' to: [ :request :response | response entity: (ZnStringEntity html: '<h1>default</h1>') ]).
 
-		client := ZnClient new.
-		
-		client get: (server localUrl addPathSegment: 'missing'; yourself).
-		self assert: (client response contentType = ZnMimeType textPlain).
-		self assert: (client response status = 404).
-		
-		client get: server localUrl.
-		self assert: (client response contentType = ZnMimeType textHtml).
-		self assert: (client response status = 200).
-		
-		client get: (server localUrl addPathSegment: 'hello'; yourself).
-		self assert: (client response contentType = ZnMimeType textHtml).
-		self assert: (client response status = 200).
-		
-		client close ]
+			client := ZnClient new.
+
+			client
+				get:
+					(server localUrl
+						addPathSegment: 'missing';
+						yourself).
+			self assert: client response contentType equals: ZnMimeType textPlain.
+			self assert: client response status equals: 404.
+
+			client get: server localUrl.
+			self assert: client response contentType equals: ZnMimeType textHtml.
+			self assert: client response status equals: 200.
+
+			client
+				get:
+					(server localUrl
+						addPathSegment: 'hello';
+						yourself).
+			self assert: client response contentType equals: ZnMimeType textHtml.
+			self assert: client response status equals: 200.
+
+			client close ]
 ]
 
 { #category : #private }

--- a/src/Zinc-Tests/ZnEasyTest.class.st
+++ b/src/Zinc-Tests/ZnEasyTest.class.st
@@ -11,12 +11,18 @@ ZnEasyTest >> smallHtmlUrl [
 
 { #category : #testing }
 ZnEasyTest >> testDelete [
-	self withServerDo: [ :server | | response |
-		response := ZnEasy delete: (server localUrl addPathSegments: #('echo' 'foo'); yourself).
-		self assert: (response headers contentType = ZnMimeType textPlain).
-		self assert: (response statusLine code = 200).
-		self assert: (response entity string includesSubstring: 'DELETE').
-		self assert: (response entity string includesSubstring: 'foo') ]
+	self
+		withServerDo: [ :server | 
+			| response |
+			response := ZnEasy
+				delete:
+					(server localUrl
+						addPathSegments: #('echo' 'foo');
+						yourself).
+			self assert: response headers contentType equals: ZnMimeType textPlain.
+			self assert: response statusLine code equals: 200.
+			self assert: (response entity string includesSubstring: 'DELETE').
+			self assert: (response entity string includesSubstring: 'foo') ]
 ]
 
 { #category : #testing }
@@ -48,8 +54,8 @@ ZnEasyTest >> testGetSmallHTMLDocument [
 	| url response |
 	url := self smallHtmlUrl.
 	response := ZnEasy get: url.
-	self assert: (response headers contentType = ZnMimeType textHtml).
-	self assert: (response statusLine code = 200).
+	self assert: response headers contentType equals: ZnMimeType textHtml.
+	self assert: response statusLine code equals: 200.
 	self assert: (response entity string includesSubstring: 'small')
 ]
 
@@ -58,42 +64,63 @@ ZnEasyTest >> testHeadSmallHTMLDocument [
 	| url response |
 	url := self smallHtmlUrl.
 	response := ZnEasy head: url.
-	self assert: (response headers contentType = ZnMimeType textHtml).
-	self assert: (response statusLine code = 200).
+	self assert: response headers contentType equals: ZnMimeType textHtml.
+	self assert: response statusLine code equals: 200.
 	self assert: response hasEntity not
 ]
 
 { #category : #testing }
 ZnEasyTest >> testPost [
-	self withServerDo: [ :server | | response data |
-		data := String streamContents: [ :stream | 1 to: 32 do: [ :each | stream nextPut: 'abc' atRandom ] ].
-		response := ZnEasy post: (server localUrl addPathSegment: 'echo'; yourself) data: (ZnEntity text: data).
-		self assert: (response headers contentType = ZnMimeType textPlain).
-		self assert: (response statusLine code = 200).
-		self assert: (response entity string includesSubstring: 'POST').
-		self assert: (response entity string includesSubstring: data) ]
+	self
+		withServerDo: [ :server | 
+			| response data |
+			data := String streamContents: [ :stream | 1 to: 32 do: [ :each | stream nextPut: 'abc' atRandom ] ].
+			response := ZnEasy
+				post:
+					(server localUrl
+						addPathSegment: 'echo';
+						yourself)
+				data: (ZnEntity text: data).
+			self assert: response headers contentType equals: ZnMimeType textPlain.
+			self assert: response statusLine code equals: 200.
+			self assert: (response entity string includesSubstring: 'POST').
+			self assert: (response entity string includesSubstring: data) ]
 ]
 
 { #category : #testing }
 ZnEasyTest >> testPostUnicodeUtf8 [
-	self withServerDo: [ :server | | response data |
-		data := String streamContents: [ :stream | 0 to: 16r024F do: [ :each | stream nextPut: each asCharacter ] ].
-		response := ZnEasy post: (server localUrl addPathSegment: 'echo'; yourself) data: (ZnEntity text: data).
-		self assert: (response headers contentType = ZnMimeType textPlain).
-		self assert: (response statusLine code = 200).
-		self assert: (response entity string includesSubstring: 'POST').
-		self assert: (response entity string includesSubstring: data) ]
+	self
+		withServerDo: [ :server | 
+			| response data |
+			data := String streamContents: [ :stream | 0 to: 16r024F do: [ :each | stream nextPut: each asCharacter ] ].
+			response := ZnEasy
+				post:
+					(server localUrl
+						addPathSegment: 'echo';
+						yourself)
+				data: (ZnEntity text: data).
+			self assert: response headers contentType equals: ZnMimeType textPlain.
+			self assert: response statusLine code equals: 200.
+			self assert: (response entity string includesSubstring: 'POST').
+			self assert: (response entity string includesSubstring: data) ]
 ]
 
 { #category : #testing }
 ZnEasyTest >> testPut [
-	self withServerDo: [ :server | | response data |
-		data := String streamContents: [ :stream | 1 to: 32 do: [ :each | stream nextPut: 'abc' atRandom ] ].
-		response := ZnEasy put: (server localUrl addPathSegment: 'echo'; yourself) data: (ZnEntity text: data).
-		self assert: (response headers contentType = ZnMimeType textPlain).
-		self assert: (response statusLine code = 200).
-		self assert: (response entity string includesSubstring: 'PUT').
-		self assert: (response entity string includesSubstring: data) ]
+	self
+		withServerDo: [ :server | 
+			| response data |
+			data := String streamContents: [ :stream | 1 to: 32 do: [ :each | stream nextPut: 'abc' atRandom ] ].
+			response := ZnEasy
+				put:
+					(server localUrl
+						addPathSegment: 'echo';
+						yourself)
+				data: (ZnEntity text: data).
+			self assert: response headers contentType equals: ZnMimeType textPlain.
+			self assert: response statusLine code equals: 200.
+			self assert: (response entity string includesSubstring: 'PUT').
+			self assert: (response entity string includesSubstring: data) ]
 ]
 
 { #category : #testing }

--- a/src/Zinc-Tests/ZnEntityReaderTest.class.st
+++ b/src/Zinc-Tests/ZnEntityReaderTest.class.st
@@ -7,11 +7,7 @@ Class {
 { #category : #testing }
 ZnEntityReaderTest >> testChunked [
 	| input headers reader entity |
-	input := '3', String crlf,
-		'con', String crlf,
-		'8', String crlf,
-		'sequence', String crlf,
-		'0', String crlf, String crlf.
+	input := '3' , String crlf , 'con' , String crlf , '8' , String crlf , 'sequence' , String crlf , '0' , String crlf , String crlf.
 	(headers := ZnHeaders new)
 		at: 'Content-Type' put: 'text/plain';
 		at: 'Transfer-Encoding' put: 'chunked'.
@@ -19,19 +15,13 @@ ZnEntityReaderTest >> testChunked [
 		headers: headers;
 		stream: input asByteArray readStream.
 	entity := reader readEntity.
-	self assert: entity contents = 'consequence'
+	self assert: entity contents equals: 'consequence'
 ]
 
 { #category : #testing }
 ZnEntityReaderTest >> testChunkedWithExtraHeaders [
 	| input headers reader entity |
-	input := '3', String crlf,
-		'con', String crlf,
-		'8', String crlf,
-		'sequence', String crlf,
-		'0', String crlf, 
-		'X-Foo:bar', String crlf, 
-		String crlf.
+	input := '3' , String crlf , 'con' , String crlf , '8' , String crlf , 'sequence' , String crlf , '0' , String crlf , 'X-Foo:bar' , String crlf , String crlf.
 	(headers := ZnHeaders new)
 		at: 'Content-Type' put: 'text/plain';
 		at: 'Transfer-Encoding' put: 'chunked'.
@@ -39,8 +29,8 @@ ZnEntityReaderTest >> testChunkedWithExtraHeaders [
 		headers: headers;
 		stream: input asByteArray readStream.
 	entity := reader readEntity.
-	self assert: entity contents = 'consequence'.
-	self assert: (headers at: 'X-Foo') = 'bar'
+	self assert: entity contents equals: 'consequence'.
+	self assert: (headers at: 'X-Foo') equals: 'bar'
 ]
 
 { #category : #testing }
@@ -55,9 +45,9 @@ ZnEntityReaderTest >> testReadStreaming [
 		stream: data readStream;
 		streaming.
 	entity := reader readEntity.
-	self assert: entity contentType = ZnMimeType applicationOctetStream.
-	self assert: entity contentLength = data size.
-	self assert: entity contents = data
+	self assert: entity contentType equals: ZnMimeType applicationOctetStream.
+	self assert: entity contentLength equals: data size.
+	self assert: entity contents equals: data
 ]
 
 { #category : #testing }
@@ -72,8 +62,8 @@ ZnEntityReaderTest >> testReadStreamingWriting [
 		stream: data readStream;
 		streaming.
 	entity := reader readEntity.
-	self assert: entity contentType = ZnMimeType applicationOctetStream.
-	self assert: entity contentLength = data size.
+	self assert: entity contentType equals: ZnMimeType applicationOctetStream.
+	self assert: entity contentLength equals: data size.
 	output := ByteArray streamContents: [ :stream | entity writeOn: stream ].
-	self assert: output = data
+	self assert: output equals: data
 ]

--- a/src/Zinc-Tests/ZnEntityTest.class.st
+++ b/src/Zinc-Tests/ZnEntityTest.class.st
@@ -12,14 +12,11 @@ ZnEntityTest >> testApplicationUrlEncodingAddAll [
 	data at: 'bar' put: 2 asString.
 	entity := ZnApplicationFormUrlEncodedEntity new.
 	"Asking for the content length will force an internal computation of the representation"
-	self assert: entity contentLength = 0.
+	self assert: entity contentLength equals: 0.
 	entity addAll: data.
 	string := String streamContents: [ :stream | entity writeOn: stream ].
 	self assert: entity contentLength > 0.
-	entity := ZnEntity 
-		readFrom: string readStream 
-		usingType: ZnApplicationFormUrlEncodedEntity designatedMimeType 
-		andLength: string size.
+	entity := ZnEntity readFrom: string readStream usingType: ZnApplicationFormUrlEncodedEntity designatedMimeType andLength: string size.
 	self assert: (entity at: 'foo') equals: '1'.
 	self assert: (entity at: 'bar') equals: '2'
 ]
@@ -27,7 +24,7 @@ ZnEntityTest >> testApplicationUrlEncodingAddAll [
 { #category : #testing }
 ZnEntityTest >> testMultiPartFormDataWriteRead [
 	| input output bytes |
-	input := (ZnMultiPartFormDataEntity new)
+	input := ZnMultiPartFormDataEntity new
 		addPart: (ZnMimePart fieldName: 'extra' value: 'my-extra');
 		addPart: (ZnMimePart fieldName: 'info' value: 'my-info');
 		addPart: (ZnMimePart fieldName: 'file' fileName: 'foo.txt' entity: (ZnEntity text: 'Zinc HTTP Components'));
@@ -37,25 +34,23 @@ ZnEntityTest >> testMultiPartFormDataWriteRead [
 	self assert: (input contentType matches: ZnMimeType multiPartFormData).
 	bytes := ByteArray streamContents: [ :stream | input writeOn: stream ].
 	output := (ZnMultiPartFormDataEntity type: input contentType) readFrom: bytes readStream.
-	self assert: (output partNamed: 'extra') fieldValue = 'my-extra'.
-	self assert: (output partNamed: 'info') fieldValue = 'my-info'.
-	self assert: (output partNamed: 'extra') fieldValueString = 'my-extra'.
-	self assert: (output partNamed: 'info') fieldValueString = 'my-info'.
-	self assert: (output partNamed: 'file') contents = 'Zinc HTTP Components'.
+	self assert: (output partNamed: 'extra') fieldValue equals: 'my-extra'.
+	self assert: (output partNamed: 'info') fieldValue equals: 'my-info'.
+	self assert: (output partNamed: 'extra') fieldValueString equals: 'my-extra'.
+	self assert: (output partNamed: 'info') fieldValueString equals: 'my-info'.
+	self assert: (output partNamed: 'file') contents equals: 'Zinc HTTP Components'.
 	output := (ZnMultiPartFormDataEntity type: input contentType length: input contentLength) readFrom: bytes readStream.
-	self assert: (output partNamed: 'extra') fieldValue = 'my-extra'.
-	self assert: (output partNamed: 'info') fieldValue = 'my-info'.
-	self assert: (output partNamed: 'extra') fieldValueString = 'my-extra'.
-	self assert: (output partNamed: 'info') fieldValueString = 'my-info'.
-	self assert: (output partNamed: 'file') contents = 'Zinc HTTP Components'.
-
-	
+	self assert: (output partNamed: 'extra') fieldValue equals: 'my-extra'.
+	self assert: (output partNamed: 'info') fieldValue equals: 'my-info'.
+	self assert: (output partNamed: 'extra') fieldValueString equals: 'my-extra'.
+	self assert: (output partNamed: 'info') fieldValueString equals: 'my-info'.
+	self assert: (output partNamed: 'file') contents equals: 'Zinc HTTP Components'
 ]
 
 { #category : #testing }
 ZnEntityTest >> testMultiPartFormDataWriteReadBinary [
 	| input output bytes |
-	input := (ZnMultiPartFormDataEntity new)
+	input := ZnMultiPartFormDataEntity new
 		addPart: (ZnMimePart fieldName: 'extra' value: 'my-extra');
 		addPart: (ZnMimePart fieldName: 'info' value: 'my-info');
 		addPart: (ZnMimePart fieldName: 'file' fileName: 'foo.txt' entity: (ZnEntity text: 'Zinc HTTP Components'));
@@ -65,26 +60,23 @@ ZnEntityTest >> testMultiPartFormDataWriteReadBinary [
 	self assert: (input contentType matches: ZnMimeType multiPartFormData).
 	bytes := ByteArray streamContents: [ :stream | input writeOn: stream ].
 	output := ZnEntity readBinaryFrom: bytes readStream usingType: input contentType andLength: bytes size.
-	self assert: (output partNamed: 'extra') fieldValue = 'my-extra' asByteArray.
-	self assert: (output partNamed: 'info') fieldValue = 'my-info' asByteArray.
-	self assert: (output partNamed: 'extra') fieldValueString = 'my-extra'.
-	self assert: (output partNamed: 'info') fieldValueString = 'my-info'.
+	self assert: (output partNamed: 'extra') fieldValue equals: 'my-extra' asByteArray.
+	self assert: (output partNamed: 'info') fieldValue equals: 'my-info' asByteArray.
+	self assert: (output partNamed: 'extra') fieldValueString equals: 'my-extra'.
+	self assert: (output partNamed: 'info') fieldValueString equals: 'my-info'.
 	self deny: (output partNamed: 'file') contents isString.
-	self assert: (output partNamed: 'file') contents = 'Zinc HTTP Components' asByteArray
+	self assert: (output partNamed: 'file') contents equals: 'Zinc HTTP Components' asByteArray
 ]
 
 { #category : #testing }
 ZnEntityTest >> testReading [
 	| contents entity |
 	contents := 'This is a test'.
-	entity := ZnEntity 
-				readFrom: contents asByteArray readStream 
-				usingType: ZnMimeType textPlain 
-				andLength: contents size.
+	entity := ZnEntity readFrom: contents asByteArray readStream usingType: ZnMimeType textPlain andLength: contents size.
 	self assert: entity contents isString.
-	self assert: entity string = contents.
-	self assert: entity contentLength = contents size.
-	self assert: entity contentType = ZnMimeType textPlain 
+	self assert: entity string equals: contents.
+	self assert: entity contentLength equals: contents size.
+	self assert: entity contentType equals: ZnMimeType textPlain
 ]
 
 { #category : #testing }
@@ -117,14 +109,11 @@ ZnEntityTest >> testReadingApplicationFormUrlEncodingNoLength [
 ZnEntityTest >> testReadingBinary [
 	| contents entity |
 	contents := 'This is a test'.
-	entity := ZnEntity 
-				readBinaryFrom: contents asByteArray readStream 
-				usingType: ZnMimeType textPlain 
-				andLength: contents size.
+	entity := ZnEntity readBinaryFrom: contents asByteArray readStream usingType: ZnMimeType textPlain andLength: contents size.
 	self deny: entity contents isString.
-	self assert: entity contents = contents asByteArray.
-	self assert: entity contentLength = contents size.
-	self assert: entity contentType = ZnMimeType textPlain 
+	self assert: entity contents equals: contents asByteArray.
+	self assert: entity contentLength equals: contents size.
+	self assert: entity contentType equals: ZnMimeType textPlain
 ]
 
 { #category : #testing }
@@ -161,36 +150,48 @@ ZnEntityTest >> testStringEntityEncoderInitialization [
 { #category : #testing }
 ZnEntityTest >> testUTF8ReadingDetermined [
 	| string entity bytes |
-	string := String with: $$ with: (16r00A2 asCharacter) with: ( 16r20AC asCharacter) with: (16r024B62 asCharacter).
+	string := String
+		with: $$
+		with: 16r00A2 asCharacter
+		with: 16r20AC asCharacter
+		with: 16r024B62 asCharacter.
 	entity := ZnStringEntity type: ZnMimeType textPlain length: 10.
 	bytes := #(16r24 16rC2 16rA2 16rE2 16r82 16rAC 16rF0 16rA4 16rAD 16rA2) asByteArray.
 	entity readFrom: bytes readStream.
-	self assert: entity contentType = ZnMimeType textPlain.
-	self assert: entity contentLength = 10.
-	self assert: entity contents = string
+	self assert: entity contentType equals: ZnMimeType textPlain.
+	self assert: entity contentLength equals: 10.
+	self assert: entity contents equals: string
 ]
 
 { #category : #testing }
 ZnEntityTest >> testUTF8ReadingUndetermined [
 	| string entity bytes |
-	string := String with: $$ with: (16r00A2 asCharacter) with: ( 16r20AC asCharacter) with: (16r024B62 asCharacter).
+	string := String
+		with: $$
+		with: 16r00A2 asCharacter
+		with: 16r20AC asCharacter
+		with: 16r024B62 asCharacter.
 	entity := ZnStringEntity type: ZnMimeType textPlain.
 	bytes := #(16r24 16rC2 16rA2 16rE2 16r82 16rAC 16rF0 16rA4 16rAD 16rA2) asByteArray.
 	entity readFrom: bytes readStream.
-	self assert: entity contentType = ZnMimeType textPlain.
-	self assert: entity contentLength = 10.
-	self assert: entity contents = string
+	self assert: entity contentType equals: ZnMimeType textPlain.
+	self assert: entity contentLength equals: 10.
+	self assert: entity contents equals: string
 ]
 
 { #category : #testing }
 ZnEntityTest >> testUTF8Writing [
 	| string entity bytes |
-	string := String with: $$ with: (16r00A2 asCharacter) with: ( 16r20AC asCharacter) with: (16r024B62 asCharacter).
+	string := String
+		with: $$
+		with: 16r00A2 asCharacter
+		with: 16r20AC asCharacter
+		with: 16r024B62 asCharacter.
 	entity := ZnStringEntity text: string.
-	self assert: entity contentType = ZnMimeType textPlain.
-	self assert: entity contentLength = 10.
+	self assert: entity contentType equals: ZnMimeType textPlain.
+	self assert: entity contentLength equals: 10.
 	bytes := ByteArray streamContents: [ :stream | entity writeOn: stream ].
-	self assert: bytes = #(16r24 16rC2 16rA2 16rE2 16r82 16rAC 16rF0 16rA4 16rAD 16rA2) asByteArray
+	self assert: bytes equals: #(16r24 16rC2 16rA2 16rE2 16r82 16rAC 16rF0 16rA4 16rAD 16rA2) asByteArray
 ]
 
 { #category : #testing }
@@ -217,8 +218,8 @@ ZnEntityTest >> testWritingApplicationUrlEncoding [
 	entity := ZnApplicationFormUrlEncodedEntity new.
 	entity at: 'foo' put: 'bar'.
 	string := String streamContents: [ :stream | entity writeOn: stream ].
-	self assert: string = 'foo=bar'.
-	self assert: entity contentLength = 7
+	self assert: string equals: 'foo=bar'.
+	self assert: entity contentLength equals: 7
 ]
 
 { #category : #testing }
@@ -228,9 +229,8 @@ ZnEntityTest >> testWritingApplicationUrlEncodingWithTextEncodingLatin1 [
 	entity contentType charSet: 'iso-8859-1'.
 	entity at: 'foo' put: (Character value: 246) asString.
 	string := String streamContents: [ :stream | entity writeOn: stream ].
-	self assert: string = 'foo=%F6'.
-	self assert: entity contentLength = 7
-	
+	self assert: string equals: 'foo=%F6'.
+	self assert: entity contentLength equals: 7
 ]
 
 { #category : #testing }
@@ -240,6 +240,6 @@ ZnEntityTest >> testWritingApplicationUrlEncodingWithTextEncodingUtf8 [
 	entity contentType charSet: 'utf-8'.
 	entity at: 'foo' put: (Character value: 246) asString.
 	string := String streamContents: [ :stream | entity writeOn: stream ].
-	self assert: string = 'foo=%C3%B6'.
-	self assert: entity contentLength = 10
+	self assert: string equals: 'foo=%C3%B6'.
+	self assert: entity contentLength equals: 10
 ]

--- a/src/Zinc-Tests/ZnHeadersTest.class.st
+++ b/src/Zinc-Tests/ZnHeadersTest.class.st
@@ -110,13 +110,13 @@ ZnHeadersTest >> testReadingMultilineNonBinary [
 { #category : #testing }
 ZnHeadersTest >> testWriting [
 	| headers string |
-	headers := ZnHeaders new 
-		at: 'Content-Type' put: 'text/plain'; 
+	headers := ZnHeaders new
+		at: 'Content-Type' put: 'text/plain';
 		at: 'Content-Length' put: '128';
 		yourself.
 	string := String streamContents: [ :stream | headers writeOn: stream ].
-	self assert: (string includesSubstring: 'Content-Type: text/plain', String crlf).
-	self assert: (string includesSubstring: 'Content-Length: 128', String crlf).
-	self assert: (string occurrencesOf: Character cr) = 2.
-	self assert: (string occurrencesOf: Character lf) = 2
+	self assert: (string includesSubstring: 'Content-Type: text/plain' , String crlf).
+	self assert: (string includesSubstring: 'Content-Length: 128' , String crlf).
+	self assert: (string occurrencesOf: Character cr) equals: 2.
+	self assert: (string occurrencesOf: Character lf) equals: 2
 ]

--- a/src/Zinc-Tests/ZnLimitedReadStreamTest.class.st
+++ b/src/Zinc-Tests/ZnLimitedReadStreamTest.class.st
@@ -9,7 +9,7 @@ ZnLimitedReadStreamTest >> testBinary [
 	| data limitedReadStream |
 	data := #(0 1 2 3 4 5 6 7 8 9) asByteArray.
 	limitedReadStream := ZnLimitedReadStream on: data readStream limit: 5.
-	self assert: limitedReadStream upToEnd = #(0 1 2 3 4) asByteArray
+	self assert: limitedReadStream upToEnd equals: #(0 1 2 3 4) asByteArray
 ]
 
 { #category : #testing }
@@ -17,7 +17,7 @@ ZnLimitedReadStreamTest >> testBinaryAll [
 	| data limitedReadStream |
 	data := #(0 1 2 3 4 5 6 7 8 9) asByteArray.
 	limitedReadStream := ZnLimitedReadStream on: data readStream limit: data size.
-	self assert: limitedReadStream upToEnd = data
+	self assert: limitedReadStream upToEnd equals: data
 ]
 
 { #category : #testing }
@@ -45,13 +45,12 @@ ZnLimitedReadStreamTest >> testNext [
 	self assert: limitedReadStream next isNil.
 	limitedReadStream := ZnLimitedReadStream on: 'ABC' readStream limit: 10.
 	self assert: limitedReadStream atEnd not.
-	self assert: limitedReadStream next = $A.
-	self assert: limitedReadStream peek = $B.
+	self assert: limitedReadStream next equals: $A.
+	self assert: limitedReadStream peek equals: $B.
 	limitedReadStream next.
-	self assert: limitedReadStream next = $C.
+	self assert: limitedReadStream next equals: $C.
 	self assert: limitedReadStream next isNil.
 	self assert: limitedReadStream atEnd
-	
 ]
 
 { #category : #testing }
@@ -59,7 +58,7 @@ ZnLimitedReadStreamTest >> testNextCount [
 	| data stream |
 	data := '0123456789'.
 	stream := ZnLimitedReadStream on: data readStream limit: 8.
-	self assert: (stream next: 4) = '0123'
+	self assert: (stream next: 4) equals: '0123'
 ]
 
 { #category : #testing }
@@ -68,8 +67,8 @@ ZnLimitedReadStreamTest >> testNextCountInto [
 	data := '0123456789'.
 	stream := ZnLimitedReadStream on: data readStream limit: 8.
 	buffer := String new: 4.
-	self assert: (stream next: 4 into: buffer) = '0123'.
-	self assert: buffer = '0123'
+	self assert: (stream next: 4 into: buffer) equals: '0123'.
+	self assert: buffer equals: '0123'
 ]
 
 { #category : #testing }
@@ -78,8 +77,7 @@ ZnLimitedReadStreamTest >> testNextCountIntoShort [
 	data := '0123456789'.
 	stream := ZnLimitedReadStream on: data readStream limit: 5.
 	buffer := String new: 6.
-	self assert: (stream next: 6 into: buffer) = '01234'
-	
+	self assert: (stream next: 6 into: buffer) equals: '01234'
 ]
 
 { #category : #testing }
@@ -87,7 +85,7 @@ ZnLimitedReadStreamTest >> testNextCountShort [
 	| data stream |
 	data := '0123456789'.
 	stream := ZnLimitedReadStream on: data readStream limit: 5.
-	self assert: (stream next: 6) = '01234'
+	self assert: (stream next: 6) equals: '01234'
 ]
 
 { #category : #testing }
@@ -95,7 +93,7 @@ ZnLimitedReadStreamTest >> testSimple [
 	| data limitedReadStream |
 	data := '0123456789'.
 	limitedReadStream := ZnLimitedReadStream on: data readStream limit: 5.
-	self assert: limitedReadStream upToEnd = '01234'
+	self assert: limitedReadStream upToEnd equals: '01234'
 ]
 
 { #category : #testing }
@@ -103,7 +101,7 @@ ZnLimitedReadStreamTest >> testSimpleEof [
 	| data limitedReadStream |
 	data := '0123456789'.
 	limitedReadStream := ZnLimitedReadStream on: data readStream limit: 15.
-	self assert: limitedReadStream upToEnd = '0123456789'.
+	self assert: limitedReadStream upToEnd equals: '0123456789'.
 	self assert: limitedReadStream atEnd.
 	self assert: limitedReadStream next isNil
 ]

--- a/src/Zinc-Tests/ZnLineReaderTest.class.st
+++ b/src/Zinc-Tests/ZnLineReaderTest.class.st
@@ -7,10 +7,10 @@ Class {
 { #category : #testing }
 ZnLineReaderTest >> testBinary [
 	| input reader |
-	input := ('Foo', String crlf, 'Bar', String crlf) asByteArray.
+	input := ('Foo' , String crlf , 'Bar' , String crlf) asByteArray.
 	reader := ZnLineReader on: input readStream.
-	self assert: reader nextLine = 'Foo'.
-	self assert: reader nextLine = 'Bar'.
+	self assert: reader nextLine equals: 'Foo'.
+	self assert: reader nextLine equals: 'Bar'.
 	self assert: reader nextLine isEmpty
 ]
 
@@ -33,9 +33,9 @@ ZnLineReaderTest >> testLineTooLongDefault [
 { #category : #testing }
 ZnLineReaderTest >> testSimple [
 	| input reader |
-	input := 'Foo', String crlf, 'Bar', String crlf.
+	input := 'Foo' , String crlf , 'Bar' , String crlf.
 	reader := ZnLineReader on: input readStream.
-	self assert: reader nextLine = 'Foo'.
-	self assert: reader nextLine = 'Bar'.
+	self assert: reader nextLine equals: 'Foo'.
+	self assert: reader nextLine equals: 'Bar'.
 	self assert: reader nextLine isEmpty
 ]

--- a/src/Zinc-Tests/ZnMagicCookieJarTest.class.st
+++ b/src/Zinc-Tests/ZnMagicCookieJarTest.class.st
@@ -20,7 +20,7 @@ ZnMagicCookieJarTest >> testAdd [
 	jar := ZnCookieJar new.
 	count := jar cookies size.
 	jar add: (ZnCookie fromString: self cookieString for: 'www.google.com' asZnUrl).
-	self assert: ((jar cookies size) = (count + 1))
+	self assert: jar cookies size equals: count + 1
 ]
 
 { #category : #testing }
@@ -40,6 +40,8 @@ ZnMagicCookieJarTest >> testCookiesForUrl [
 	jar := ZnCookieJar new.
 	c1 := ZnCookie fromString: self cookieString for: 'http://www.google.com' asZnUrl.
 	c2 := ZnCookie fromString: self cookieStringAlt for: 'http://www.pharo-project.org' asZnUrl.
-	jar add: c1; add: c2.
-	self assert: ((jar cookiesForUrl: 'http://www.google.com' asZnUrl) size = 1)
+	jar
+		add: c1;
+		add: c2.
+	self assert: (jar cookiesForUrl: 'http://www.google.com' asZnUrl) size equals: 1
 ]

--- a/src/Zinc-Tests/ZnMagicCookieTest.class.st
+++ b/src/Zinc-Tests/ZnMagicCookieTest.class.st
@@ -18,11 +18,10 @@ ZnMagicCookieTest >> cookieStringSubpath [
 ZnMagicCookieTest >> testFromString [
 	| cookie |
 	cookie := ZnCookie fromString: self cookieString for: 'www.google.com' asZnUrl.
-	self assert: (cookie name = 'PREF').
-	self assert: (cookie path notNil).
-	self assert: (cookie domain = '.google.com').
-	self assert: (cookie isExpired not)
-	
+	self assert: cookie name equals: 'PREF'.
+	self assert: cookie path notNil.
+	self assert: cookie domain equals: '.google.com'.
+	self assert: cookie isExpired not
 ]
 
 { #category : #testing }

--- a/src/Zinc-Tests/ZnRequestLineTest.class.st
+++ b/src/Zinc-Tests/ZnRequestLineTest.class.st
@@ -7,11 +7,11 @@ Class {
 { #category : #testing }
 ZnRequestLineTest >> testReading [
 	| requestLine string |
-	string := 'GET /foo/bar/xyz.txt HTTP/1.1', String crlf.
+	string := 'GET /foo/bar/xyz.txt HTTP/1.1' , String crlf.
 	requestLine := ZnRequestLine readFrom: string readStream.
-	self assert: requestLine method = #GET.
-	self assert: requestLine uriPathQueryFragment = '/foo/bar/xyz.txt'.
-	self assert: requestLine version = ZnConstants defaultHTTPVersion 
+	self assert: requestLine method equals: #GET.
+	self assert: requestLine uriPathQueryFragment equals: '/foo/bar/xyz.txt'.
+	self assert: requestLine version equals: ZnConstants defaultHTTPVersion
 ]
 
 { #category : #testing }
@@ -33,5 +33,5 @@ ZnRequestLineTest >> testWriting [
 	| requestLine string |
 	requestLine := ZnRequestLine method: 'GET' uri: '/foo/bar/xyz.txt'.
 	string := String streamContents: [ :stream | requestLine writeOn: stream ].
-	self assert: string = ('GET /foo/bar/xyz.txt HTTP/1.1', String crlf)
+	self assert: string equals: 'GET /foo/bar/xyz.txt HTTP/1.1' , String crlf
 ]

--- a/src/Zinc-Tests/ZnRequestTest.class.st
+++ b/src/Zinc-Tests/ZnRequestTest.class.st
@@ -9,37 +9,32 @@ ZnRequestTest >> testBasicAuthenticate [
 	| request |
 	request := ZnRequest new.
 	request setBasicAuthenticationUsername: 'user' password: 'secret'.
-	self assert: (request headers at: 'Authorization') = 'Basic dXNlcjpzZWNyZXQ='.
-	self assert: request basicAuthentication asArray equals: #( 'user' 'secret' ).
+	self assert: (request headers at: 'Authorization') equals: 'Basic dXNlcjpzZWNyZXQ='.
+	self assert: request basicAuthentication asArray equals: #('user' 'secret').
 	request setBasicAuthenticationUsername: 'user' password: ''.
-	self assert: (request headers at: 'Authorization') = 'Basic dXNlcjo='.
-	self assert: request basicAuthentication asArray equals: #( 'user' '' ).
+	self assert: (request headers at: 'Authorization') equals: 'Basic dXNlcjo='.
+	self assert: request basicAuthentication asArray equals: #('user' '').
 	request setBasicAuthenticationUsername: 'user' password: ':colons:'.
-	self assert: (request headers at: 'Authorization') = 'Basic dXNlcjo6Y29sb25zOg=='.
-	self assert: request basicAuthentication asArray equals: #( 'user' ':colons:' ).
+	self assert: (request headers at: 'Authorization') equals: 'Basic dXNlcjo6Y29sb25zOg=='.
+	self assert: request basicAuthentication asArray equals: #('user' ':colons:')
 ]
 
 { #category : #testing }
 ZnRequestTest >> testCookiesParsing [
 	| input request cookies testCookie1 testCookie2 |
-	input := 'GET /foo.html HTTP/1.1', String crlf, 
-		'Cookie: testCookie1=123; testCookie2=321', String crlf,
-		'Host: foo.com', String crlf, 
-		'Agent: SUnit', String crlf, 
-		String crlf.
+	input := 'GET /foo.html HTTP/1.1' , String crlf , 'Cookie: testCookie1=123; testCookie2=321' , String crlf , 'Host: foo.com' , String crlf , 'Agent: SUnit'
+		, String crlf , String crlf.
 	request := ZnRequest readFrom: input readStream.
-	
+
 	cookies := request cookies.
 	testCookie1 := cookies detect: [ :each | each name = 'testCookie1' ].
 	testCookie2 := cookies detect: [ :each | each name = 'testCookie2' ].
-	
+
 	self assert: testCookie1 notNil.
-	self assert: testCookie1 value = '123'.	
-	
+	self assert: testCookie1 value equals: '123'.
+
 	self assert: testCookie2 notNil.
-	self assert: testCookie2 value = '321'.	
-
-
+	self assert: testCookie2 value equals: '321'
 ]
 
 { #category : #testing }
@@ -83,16 +78,12 @@ ZnRequestTest >> testMergedFields [
 { #category : #testing }
 ZnRequestTest >> testReading [
 	| input request |
-	input := 'GET /foo.html HTTP/1.1', String crlf, 
-		'Host: foo.com', String crlf, 
-		'Agent: SUnit', String crlf, 
-		String crlf.
+	input := 'GET /foo.html HTTP/1.1' , String crlf , 'Host: foo.com' , String crlf , 'Agent: SUnit' , String crlf , String crlf.
 	request := ZnRequest readFrom: input readStream.
-	self assert: request method = #GET.
+	self assert: request method equals: #GET.
 	self assert: request hasHeaders.
-	self assert: (request headers at: 'Host') = 'foo.com'.
+	self assert: (request headers at: 'Host') equals: 'foo.com'.
 	self assert: request hasEntity not
-
 ]
 
 { #category : #testing }

--- a/src/Zinc-Tests/ZnResponseTest.class.st
+++ b/src/Zinc-Tests/ZnResponseTest.class.st
@@ -9,9 +9,9 @@ ZnResponseTest >> testAbsoluteCreated [
 	| response uri |
 	uri := 'http://www.example.com:8888/something/else/foo.txt'.
 	response := ZnResponse created: uri asZnUrl.
-	self assert: response code = 201.
+	self assert: response code equals: 201.
 	self assert: response hasHeaders.
-	self assert: (response headers at: 'Location') = uri.
+	self assert: (response headers at: 'Location') equals: uri.
 	self assert: response hasEntity.
 	self assert: (response entity contents includesSubstring: uri)
 ]
@@ -21,13 +21,12 @@ ZnResponseTest >> testAbsoluteRedirect [
 	| response uri |
 	uri := 'http://foo.com:8080/something/else/foo.txt?key=123'.
 	response := ZnResponse redirect: uri asZnUrl.
-	self assert: response code = 302.
+	self assert: response code equals: 302.
 	self assert: response isRedirect.
 	self assert: response hasHeaders.
-	self assert: (response headers at: 'Location') = uri.
+	self assert: (response headers at: 'Location') equals: uri.
 	self assert: response hasEntity.
 	self assert: (response entity contents includesSubstring: uri)
-
 ]
 
 { #category : #testing }
@@ -84,9 +83,9 @@ ZnResponseTest >> testCreated [
 	| response uri |
 	uri := '/something/else/foo.txt'.
 	response := ZnResponse created: uri.
-	self assert: response code = 201.
+	self assert: response code equals: 201.
 	self assert: response hasHeaders.
-	self assert: (response headers at: 'Location') = uri.
+	self assert: (response headers at: 'Location') equals: uri.
 	self assert: response hasEntity.
 	self assert: (response entity contents includesSubstring: uri)
 ]
@@ -118,7 +117,7 @@ ZnResponseTest >> testIsError [
 ZnResponseTest >> testNotFound [
 	| response |
 	response := ZnResponse notFound: 'http:///secret.txt'.
-	self assert: response code = 404.
+	self assert: response code equals: 404.
 	self assert: (response headers includesKey: 'Server').
 	self assert: (response headers includesKey: 'Date').
 	self assert: (response entity contents includesSubstring: 'secret.txt')
@@ -129,17 +128,17 @@ ZnResponseTest >> testRedirect [
 	| response uri |
 	uri := '/something/else/foo.txt'.
 	response := ZnResponse redirect: uri.
-	self assert: response code = 302.
-	self assert: response code = 302.
+	self assert: response code equals: 302.
+	self assert: response code equals: 302.
 	self assert: response hasHeaders.
-	self assert: (response headers at: 'Location') = uri.
+	self assert: (response headers at: 'Location') equals: uri.
 	self assert: response hasEntity.
 	self assert: (response entity contents includesSubstring: uri).
 	response := ZnResponse redirect: uri asZnUrl.
-	self assert: response code = 302.
-	self assert: response code = 302.
+	self assert: response code equals: 302.
+	self assert: response code equals: 302.
 	self assert: response hasHeaders.
-	self assert: (response headers at: 'Location') = uri.
+	self assert: (response headers at: 'Location') equals: uri.
 	self assert: response hasEntity.
 	self assert: (response entity contents includesSubstring: uri)
 ]
@@ -151,20 +150,17 @@ ZnResponseTest >> testSlashdotGzipChunked [
 		setConnectionClose;
 		setAcceptEncodingGzip.
 	stream := ZnNetworkingUtils socketStreamToUrl: request url.
-	response := [ 
-  		request writeOn: stream. 
-  		stream flush. 
-  		ZnDefaultCharacterEncoder 
-			value: ZnNullEncoder new
-			during: [ ZnResponse readFrom: stream ] ] ensure: [ stream close ].
+	response := [ request writeOn: stream.
+	stream flush.
+	ZnDefaultCharacterEncoder value: ZnNullEncoder new during: [ ZnResponse readFrom: stream ] ]
+		ensure: [ stream close ].
 	response isRedirect ifTrue: [ ^ self ].
-	self assert: response code = 200.
+	self assert: response code equals: 200.
 	self assert: ((response headers at: 'Content-Type') beginsWith: 'text/html').
-	self assert: (response headers at: 'Content-Encoding' ifAbsent: [ 'gzip' ]) = 'gzip'.
-	self assert: (response headers at: 'Transfer-Encoding' ifAbsent: [ 'chunked' ]) = 'chunked'.
+	self assert: (response headers at: 'Content-Encoding' ifAbsent: [ 'gzip' ]) equals: 'gzip'.
+	self assert: (response headers at: 'Transfer-Encoding' ifAbsent: [ 'chunked' ]) equals: 'chunked'.
 	contents := response entity contents.
 	self assert: ((contents includesSubstring: 'Slashdot') or: [ contents includesSubstring: 'refresh' ])
-
 ]
 
 { #category : #testing }

--- a/src/Zinc-Tests/ZnServerTest.class.st
+++ b/src/Zinc-Tests/ZnServerTest.class.st
@@ -95,24 +95,38 @@ ZnServerTest >> runningOnWindows [
 
 { #category : #testing }
 ZnServerTest >> testAuthorizationFailed [
-	self withServerDo: [ :server | | response |
-		server authenticator: (ZnBasicAuthenticator username: 'foo' password: 'secret').
-		response := ZnEasy get: (server localUrl addPathSegment: 'echo'; yourself).
-		self assert: (response headers contentType = ZnMimeType textPlain).
-		self assert: (response statusLine code = 401).
-		self assert: ((response headers at: 'WWW-Authenticate') includesSubstring: 'Basic').
-		self assert: ((response headers at: 'WWW-Authenticate') includesSubstring: 'Zinc') ]
+	self
+		withServerDo: [ :server | 
+			| response |
+			server authenticator: (ZnBasicAuthenticator username: 'foo' password: 'secret').
+			response := ZnEasy
+				get:
+					(server localUrl
+						addPathSegment: 'echo';
+						yourself).
+			self assert: response headers contentType equals: ZnMimeType textPlain.
+			self assert: response statusLine code equals: 401.
+			self assert: ((response headers at: 'WWW-Authenticate') includesSubstring: 'Basic').
+			self assert: ((response headers at: 'WWW-Authenticate') includesSubstring: 'Zinc') ]
 ]
 
 { #category : #testing }
 ZnServerTest >> testAuthorizationSuccessful [
-	self withServerDo: [ :server | | response |
-		server authenticator: (ZnBasicAuthenticator username: 'foo' password: 'secret').
-		response := ZnEasy get: (server localUrl addPathSegments: #('echo' 'foo'); yourself) username: 'foo' password: 'secret'.
-		self assert: (response headers contentType = ZnMimeType textPlain).
-		self assert: (response statusLine code = 200).
-		self assert: (response entity string includesSubstring: 'Zinc').
-		self assert: (response entity string includesSubstring: 'foo') ]
+	self
+		withServerDo: [ :server | 
+			| response |
+			server authenticator: (ZnBasicAuthenticator username: 'foo' password: 'secret').
+			response := ZnEasy
+				get:
+					(server localUrl
+						addPathSegments: #('echo' 'foo');
+						yourself)
+				username: 'foo'
+				password: 'secret'.
+			self assert: response headers contentType equals: ZnMimeType textPlain.
+			self assert: response statusLine code equals: 200.
+			self assert: (response entity string includesSubstring: 'Zinc').
+			self assert: (response entity string includesSubstring: 'foo') ]
 ]
 
 { #category : #testing }
@@ -134,16 +148,14 @@ ZnServerTest >> testCustomDefaultDelegate [
 { #category : #testing }
 ZnServerTest >> testDefault [
 	| port server initialDefaultServer wasRunning |
-	wasRunning := ZnServer default 
-		ifNil: [ false ] 
-		ifNotNil: [ ZnServer default isRunning ].
+	wasRunning := ZnServer default ifNil: [ false ] ifNotNil: [ ZnServer default isRunning ].
 	initialDefaultServer := ZnServer stopDefault.
 	self assert: ZnServer default isNil.
 	port := self port.
 	server := ZnServer startDefaultOn: port.
 	self assert: ZnServer default notNil.
-	self assert: ZnServer default == server.
-	self assert: ZnServer default port = port.
+	self assert: ZnServer default identicalTo: server.
+	self assert: ZnServer default port equals: port.
 	self assert: ZnServer default isRunning.
 	self assert: (ZnServer managedServers includes: server).
 	ZnServer stopDefault.
@@ -153,52 +165,64 @@ ZnServerTest >> testDefault [
 	server := ZnServer startDefaultOn: port.
 	"Starting the default again is actually a restart"
 	ZnServer startDefaultOn: port.
-	self assert: ZnServer default == server.
+	self assert: ZnServer default identicalTo: server.
 	ZnServer stopDefault.
 	ZnServer adoptAsDefault: initialDefaultServer.
-	self assert: initialDefaultServer == ZnServer default.
+	self assert: initialDefaultServer identicalTo: ZnServer default.
 	wasRunning ifTrue: [ ZnServer default start ]
 ]
 
 { #category : #testing }
 ZnServerTest >> testEcho [
-	self withServerDo: [ :server | | response |
-		response := ZnEasy get: (server localUrl addPathSegments: #('echo' 'foo'); yourself).
-		self assert: (response contentType = ZnMimeType textPlain).
-		self assert: (response statusLine code = 200).
-		self assert: (response entity contents includesSubstring: 'Zinc').
-		self assert: (response entity contents includesSubstring: 'foo').
-		self assert: (response entity contents includesSubstring: server printString) ]
+	self
+		withServerDo: [ :server | 
+			| response |
+			response := ZnEasy
+				get:
+					(server localUrl
+						addPathSegments: #('echo' 'foo');
+						yourself).
+			self assert: response contentType equals: ZnMimeType textPlain.
+			self assert: response statusLine code equals: 200.
+			self assert: (response entity contents includesSubstring: 'Zinc').
+			self assert: (response entity contents includesSubstring: 'foo').
+			self assert: (response entity contents includesSubstring: server printString) ]
 ]
 
 { #category : #testing }
 ZnServerTest >> testEchoBinary [
-	self withServerDo: [ :server | | response entityIn entityOut |
-		server reader: [ :stream | ZnRequest readBinaryFrom: stream ].
-		entityIn := ZnEntity with: 'ABC' type: 'text/plain'.
-		response := ZnEasy put: (server localUrl addPathSegment: 'echo'; yourself)  data: entityIn.
-		self assert: (response contentType = ZnMimeType textPlain).
-		self assert: (response statusLine code = 200).
-		entityOut := ZnEntity with: entityIn string asByteArray type: entityIn contentType.
-		self assert: (response entity contents includesSubstring: entityOut printString) ]
+	self
+		withServerDo: [ :server | 
+			| response entityIn entityOut |
+			server reader: [ :stream | ZnRequest readBinaryFrom: stream ].
+			entityIn := ZnEntity with: 'ABC' type: 'text/plain'.
+			response := ZnEasy
+				put:
+					(server localUrl
+						addPathSegment: 'echo';
+						yourself)
+				data: entityIn.
+			self assert: response contentType equals: ZnMimeType textPlain.
+			self assert: response statusLine code equals: 200.
+			entityOut := ZnEntity with: entityIn string asByteArray type: entityIn contentType.
+			self assert: (response entity contents includesSubstring: entityOut printString) ]
 ]
 
 { #category : #testing }
 ZnServerTest >> testEchoLocalInterface [
 	| server response |
-	(server := ZnServer on: self port)
-		bindingAddress: NetNameResolver loopBackAddress.
-	[ 
-		server start.
-		self 
-			assert: server isRunning & server isListening
-			description: ('Failed to start server on port {1}. Is there one already?' format: { server port }).
-		response := ZnEasy get: (server localUrl addPathSegments: #('echo' 'foo'); yourself).
-		self assert: (response contentType = ZnMimeType textPlain).
-		self assert: (response statusLine code = 200).
-		self assert: (response entity contents includesSubstring: 'Zinc').
-		self assert: (response entity contents includesSubstring: 'foo')
-	]
+	(server := ZnServer on: self port) bindingAddress: NetNameResolver loopBackAddress.
+	[ server start.
+	self assert: server isRunning & server isListening description: ('Failed to start server on port {1}. Is there one already?' format: {server port}).
+	response := ZnEasy
+		get:
+			(server localUrl
+				addPathSegments: #('echo' 'foo');
+				yourself).
+	self assert: response contentType equals: ZnMimeType textPlain.
+	self assert: response statusLine code equals: 200.
+	self assert: (response entity contents includesSubstring: 'Zinc').
+	self assert: (response entity contents includesSubstring: 'foo') ]
 		ensure: [ server stop ]
 ]
 
@@ -322,14 +346,20 @@ ZnServerTest >> testGetConnectionClose [
 
 { #category : #testing }
 ZnServerTest >> testGetUnicodeUtf8 [
-	self withServerDo: [ :server | | response html |
-		response := ZnEasy get: (server localUrl addPathSegment: 'unicode'; yourself).
-		self assert: (response contentType = ZnMimeType textHtml).
-		self assert: (response statusLine code = 200).
-		self assert: response contentType isCharSetUTF8.
-		html := response entity contents.
-		self assert: (html includesSubstring: 'Unicode').
-		0 to: 16r024F do: [ :each | self assert: (html includes: each asCharacter) ] ]
+	self
+		withServerDo: [ :server | 
+			| response html |
+			response := ZnEasy
+				get:
+					(server localUrl
+						addPathSegment: 'unicode';
+						yourself).
+			self assert: response contentType equals: ZnMimeType textHtml.
+			self assert: response statusLine code equals: 200.
+			self assert: response contentType isCharSetUTF8.
+			html := response entity contents.
+			self assert: (html includesSubstring: 'Unicode').
+			0 to: 16r024F do: [ :each | self assert: (html includes: each asCharacter) ] ]
 ]
 
 { #category : #testing }
@@ -366,20 +396,19 @@ ZnServerTest >> testLocalUrl [
 
 { #category : #testing }
 ZnServerTest >> testOSAssignedPort [
-	| server | 
+	| server |
 	server := ZnServer on: 0.
 	self assert: server port equals: 0.
-	[ 
-		| response |
-		server start.
-		self assert: server port > 0. 
-		response := ZnEasy get: server localUrl / #echo / #foo.
-		self assert: (response contentType = ZnMimeType textPlain).
-		self assert: (response statusLine code = 200).
-		self assert: (response entity contents includesSubstring: 'Zinc').
-		self assert: (response entity contents includesSubstring: 'foo').
-		self assert: (response entity contents includesSubstring: server printString) ] 
-			ensure: [ server stop ]
+	[ | response |
+	server start.
+	self assert: server port > 0.
+	response := ZnEasy get: server localUrl / #echo / #foo.
+	self assert: response contentType equals: ZnMimeType textPlain.
+	self assert: response statusLine code equals: 200.
+	self assert: (response entity contents includesSubstring: 'Zinc').
+	self assert: (response entity contents includesSubstring: 'foo').
+	self assert: (response entity contents includesSubstring: server printString) ]
+		ensure: [ server stop ]
 ]
 
 { #category : #testing }
@@ -420,61 +449,70 @@ ZnServerTest >> testRespond [
 
 { #category : #testing }
 ZnServerTest >> testSession [
-	self withServerDo: [ :server | | client sessionId |
-		client := ZnClient new url: (server localUrl addPathSegment: #session); yourself.
-		self assert: client session cookieJar cookies isEmpty.
-		client get.
-		self assert: client isSuccess.
-		self assert: client session cookieJar cookies size = 1.
-		sessionId := client session cookieJar cookies anyOne value.
-		self assert: (client contents includesSubstring: sessionId).
-		client get.
-		self assert: client isSuccess.
-		self assert: client session cookieJar cookies size = 1.
-		self assert: client session cookieJar cookies anyOne value equals: sessionId.
-		self assert: (client contents includesSubstring: sessionId) ]
-
+	self
+		withServerDo: [ :server | 
+			| client sessionId |
+			client := ZnClient new
+				url: (server localUrl addPathSegment: #session);
+				yourself.
+			self assert: client session cookieJar cookies isEmpty.
+			client get.
+			self assert: client isSuccess.
+			self assert: client session cookieJar cookies size equals: 1.
+			sessionId := client session cookieJar cookies anyOne value.
+			self assert: (client contents includesSubstring: sessionId).
+			client get.
+			self assert: client isSuccess.
+			self assert: client session cookieJar cookies size equals: 1.
+			self assert: client session cookieJar cookies anyOne value equals: sessionId.
+			self assert: (client contents includesSubstring: sessionId) ]
 ]
 
 { #category : #testing }
 ZnServerTest >> testSessionExpired [
-	self withServerDo: [ :server | | client sessionId |
-		client := ZnClient new url: (server localUrl addPathSegment: #session); yourself.
-		self assert: client session cookieJar cookies isEmpty.
-		client get.
-		self assert: client isSuccess.
-		self assert: client session cookieJar cookies size = 1.
-		sessionId := client session cookieJar cookies anyOne value.
-		self assert: (client contents includesSubstring: sessionId).
-		"Kill the server session as if it was expired"
-		server sessionManager removeSessionWithId: sessionId.
-		"The client still presents the old session id but should get a new one"
-		client get.
-		self assert: client isSuccess.
-		self assert: client session cookieJar cookies size = 1.
-		self deny: client session cookieJar cookies anyOne value = sessionId ]
-
+	self
+		withServerDo: [ :server | 
+			| client sessionId |
+			client := ZnClient new
+				url: (server localUrl addPathSegment: #session);
+				yourself.
+			self assert: client session cookieJar cookies isEmpty.
+			client get.
+			self assert: client isSuccess.
+			self assert: client session cookieJar cookies size equals: 1.
+			sessionId := client session cookieJar cookies anyOne value.
+			self assert: (client contents includesSubstring: sessionId).
+			"Kill the server session as if it was expired"
+			server sessionManager removeSessionWithId: sessionId.
+			"The client still presents the old session id but should get a new one"
+			client get.
+			self assert: client isSuccess.
+			self assert: client session cookieJar cookies size equals: 1.
+			self deny: client session cookieJar cookies anyOne value equals: sessionId ]
 ]
 
 { #category : #testing }
 ZnServerTest >> testSessionRoute [
-	self withServerDo: [ :server | | client sessionId |
-		server route: 'r1'.
-		self assert: server route equals: 'r1'.
-		client := ZnClient new url: (server localUrl addPathSegment: #session); yourself.
-		self assert: client session cookieJar cookies isEmpty.
-		client get.
-		self assert: client isSuccess.
-		self assert: client session cookieJar cookies size = 1.
-		sessionId := client session cookieJar cookies anyOne value.
-		self assert: (client contents includesSubstring: sessionId).
-		self assert: (sessionId endsWith: '.r1').
-		client get.
-		self assert: client isSuccess.
-		self assert: client session cookieJar cookies size = 1.
-		self assert: client session cookieJar cookies anyOne value equals: sessionId.
-		self assert: (client contents includesSubstring: sessionId) ]
-
+	self
+		withServerDo: [ :server | 
+			| client sessionId |
+			server route: 'r1'.
+			self assert: server route equals: 'r1'.
+			client := ZnClient new
+				url: (server localUrl addPathSegment: #session);
+				yourself.
+			self assert: client session cookieJar cookies isEmpty.
+			client get.
+			self assert: client isSuccess.
+			self assert: client session cookieJar cookies size equals: 1.
+			sessionId := client session cookieJar cookies anyOne value.
+			self assert: (client contents includesSubstring: sessionId).
+			self assert: (sessionId endsWith: '.r1').
+			client get.
+			self assert: client isSuccess.
+			self assert: client session cookieJar cookies size equals: 1.
+			self assert: client session cookieJar cookies anyOne value equals: sessionId.
+			self assert: (client contents includesSubstring: sessionId) ]
 ]
 
 { #category : #testing }

--- a/src/Zinc-Tests/ZnStaticFileServerDelegateTest.class.st
+++ b/src/Zinc-Tests/ZnStaticFileServerDelegateTest.class.st
@@ -51,86 +51,74 @@ ZnStaticFileServerDelegateTest >> tearDown [
 
 { #category : #tests }
 ZnStaticFileServerDelegateTest >> testBasicGet [
-	self withServerDo: [ :server | | client |
-		(client := ZnClient new) 
-			beOneShot;
-			url: server localUrl;
-			addPath: #('local-files' 'small.html');
-			get.
-		self assert: client isSuccess.
-		self assert: client response contentType = ZnMimeType textHtml.
-		self assert: client contents equals: self smallHtml.
-		self 
-			assert: (ZnUtils parseHttpDate: (client response headers at: 'Modification-Date'))
-			equals: (ZnFileSystemUtils modificationTimeFor: 'small.html') asUTC.
-		self 
-			assert: (ZnUtils parseHttpDate: (client response headers at: 'Expires')) > (DateAndTime now + 10 days).
-		self 
-			assert: (client response headers at: 'Cache-Control')
-			equals: (server delegate maxAgeFor: ZnMimeType textHtml) ]
+	self
+		withServerDo: [ :server | 
+			| client |
+			(client := ZnClient new)
+				beOneShot;
+				url: server localUrl;
+				addPath: #('local-files' 'small.html');
+				get.
+			self assert: client isSuccess.
+			self assert: client response contentType equals: ZnMimeType textHtml.
+			self assert: client contents equals: self smallHtml.
+			self assert: (ZnUtils parseHttpDate: (client response headers at: 'Modification-Date')) equals: (ZnFileSystemUtils modificationTimeFor: 'small.html') asUTC.
+			self assert: (ZnUtils parseHttpDate: (client response headers at: 'Expires')) > (DateAndTime now + 10 days).
+			self assert: (client response headers at: 'Cache-Control') equals: (server delegate maxAgeFor: ZnMimeType textHtml) ]
 ]
 
 { #category : #tests }
 ZnStaticFileServerDelegateTest >> testBasicGetLarge [
-	self withServerDo: [ :server | | client |
-		(client := ZnClient new) 
-			beOneShot;
-			url: server localUrl;
-			addPath: #('local-files' 'large.html');
-			get.
-		self assert: client isSuccess.
-		self assert: client response contentType = ZnMimeType textHtml.
-		self assert: client contents equals: self largeHtml.
-		self 
-			assert: (ZnUtils parseHttpDate: (client response headers at: 'Modification-Date'))
-			equals: (ZnFileSystemUtils modificationTimeFor: 'large.html') asUTC.
-		self 
-			assert: (ZnUtils parseHttpDate: (client response headers at: 'Expires')) > (DateAndTime now + 10 days).
-		self 
-			assert: (client response headers at: 'Cache-Control')
-			equals: (server delegate maxAgeFor: ZnMimeType textHtml) ]
+	self
+		withServerDo: [ :server | 
+			| client |
+			(client := ZnClient new)
+				beOneShot;
+				url: server localUrl;
+				addPath: #('local-files' 'large.html');
+				get.
+			self assert: client isSuccess.
+			self assert: client response contentType equals: ZnMimeType textHtml.
+			self assert: client contents equals: self largeHtml.
+			self assert: (ZnUtils parseHttpDate: (client response headers at: 'Modification-Date')) equals: (ZnFileSystemUtils modificationTimeFor: 'large.html') asUTC.
+			self assert: (ZnUtils parseHttpDate: (client response headers at: 'Expires')) > (DateAndTime now + 10 days).
+			self assert: (client response headers at: 'Cache-Control') equals: (server delegate maxAgeFor: ZnMimeType textHtml) ]
 ]
 
 { #category : #tests }
 ZnStaticFileServerDelegateTest >> testBasicGetWide [
-	self withServerDo: [ :server | | client |
-		(client := ZnClient new) 
-			beOneShot;
-			url: server localUrl;
-			addPath: #('local-files' 'wide.html');
-			get.
-		self assert: client isSuccess.
-		self assert: client response contentType = ZnMimeType textHtml.
-		self assert: client contents equals: self wideHtml.
-		self 
-			assert: (ZnUtils parseHttpDate: (client response headers at: 'Modification-Date'))
-			equals: (ZnFileSystemUtils modificationTimeFor: 'large.html') asUTC.
-		self 
-			assert: (ZnUtils parseHttpDate: (client response headers at: 'Expires')) > (DateAndTime now + 10 days).
-		self 
-			assert: (client response headers at: 'Cache-Control')
-			equals: (server delegate maxAgeFor: ZnMimeType textHtml) ]
+	self
+		withServerDo: [ :server | 
+			| client |
+			(client := ZnClient new)
+				beOneShot;
+				url: server localUrl;
+				addPath: #('local-files' 'wide.html');
+				get.
+			self assert: client isSuccess.
+			self assert: client response contentType equals: ZnMimeType textHtml.
+			self assert: client contents equals: self wideHtml.
+			self assert: (ZnUtils parseHttpDate: (client response headers at: 'Modification-Date')) equals: (ZnFileSystemUtils modificationTimeFor: 'large.html') asUTC.
+			self assert: (ZnUtils parseHttpDate: (client response headers at: 'Expires')) > (DateAndTime now + 10 days).
+			self assert: (client response headers at: 'Cache-Control') equals: (server delegate maxAgeFor: ZnMimeType textHtml) ]
 ]
 
 { #category : #tests }
 ZnStaticFileServerDelegateTest >> testBasicHead [
-	self withServerDo: [ :server | | client |
-		(client := ZnClient new) 
-			beOneShot;
-			url: server localUrl;
-			addPath: #('local-files' 'small.html');
-			head.
-		self assert: client isSuccess.
-		self assert: client response contentType = ZnMimeType textHtml.
-		self deny: client response hasEntity.
-		self 
-			assert: (ZnUtils parseHttpDate: (client response headers at: 'Modification-Date'))
-			equals: (ZnFileSystemUtils modificationTimeFor: 'small.html') asUTC.
-		self 
-			assert: (ZnUtils parseHttpDate: (client response headers at: 'Expires')) > (DateAndTime now + 10 days).
-		self 
-			assert: (client response headers at: 'Cache-Control')
-			equals: (server delegate maxAgeFor: ZnMimeType textHtml) ]
+	self
+		withServerDo: [ :server | 
+			| client |
+			(client := ZnClient new)
+				beOneShot;
+				url: server localUrl;
+				addPath: #('local-files' 'small.html');
+				head.
+			self assert: client isSuccess.
+			self assert: client response contentType equals: ZnMimeType textHtml.
+			self deny: client response hasEntity.
+			self assert: (ZnUtils parseHttpDate: (client response headers at: 'Modification-Date')) equals: (ZnFileSystemUtils modificationTimeFor: 'small.html') asUTC.
+			self assert: (ZnUtils parseHttpDate: (client response headers at: 'Expires')) > (DateAndTime now + 10 days).
+			self assert: (client response headers at: 'Cache-Control') equals: (server delegate maxAgeFor: ZnMimeType textHtml) ]
 ]
 
 { #category : #tests }

--- a/src/Zinc-Tests/ZnStatusLineTest.class.st
+++ b/src/Zinc-Tests/ZnStatusLineTest.class.st
@@ -18,11 +18,11 @@ ZnStatusLineTest >> testInitialization [
 { #category : #testing }
 ZnStatusLineTest >> testReading [
 	| statusLine string |
-	string := 'HTTP/1.1 200 OK', String crlf.
+	string := 'HTTP/1.1 200 OK' , String crlf.
 	statusLine := ZnStatusLine readFrom: string readStream.
-	self assert: statusLine code = 200.
-	self assert: statusLine reason = 'OK'.
-	self assert: statusLine version = ZnConstants defaultHTTPVersion 
+	self assert: statusLine code equals: 200.
+	self assert: statusLine reason equals: 'OK'.
+	self assert: statusLine version equals: ZnConstants defaultHTTPVersion
 ]
 
 { #category : #testing }
@@ -61,5 +61,5 @@ ZnStatusLineTest >> testWriting [
 	| statusLine string |
 	statusLine := ZnStatusLine ok.
 	string := String streamContents: [ :stream | statusLine writeOn: stream ].
-	self assert: string = ('HTTP/1.1 200 OK', String crlf)
+	self assert: string equals: 'HTTP/1.1 200 OK' , String crlf
 ]

--- a/src/Zinc-Tests/ZnUserAgentSessionTest.class.st
+++ b/src/Zinc-Tests/ZnUserAgentSessionTest.class.st
@@ -28,7 +28,7 @@ ZnUserAgentSessionTest >> testAddCredential [
 	session := ZnUserAgentSession new.
 	count := session credentials size.
 	session addCredential: self dummyCredential.
-	self assert: ((session credentials size) = (count + 1))
+	self assert: session credentials size equals: count + 1
 ]
 
 { #category : #testing }

--- a/src/Zinc-Tests/ZnUtilsTest.class.st
+++ b/src/Zinc-Tests/ZnUtilsTest.class.st
@@ -7,35 +7,40 @@ Class {
 { #category : #testing }
 ZnUtilsTest >> testBase64 [
 	| short long encoded legalCharactes |
-	legalCharactes := (String withAll: ($A to: $Z), ($a to: $z), ($0 to: $9)), '='.
+	legalCharactes := (String withAll: ($A to: $Z) , ($a to: $z) , ($0 to: $9)) , '='.
 	short := String withAll: ((1 to: 16) collect: [ :each | 'abc' atRandom ]).
 	encoded := ZnUtils encodeBase64: short.
-	self assert: (ZnUtils decodeBase64: encoded) = short.
+	self assert: (ZnUtils decodeBase64: encoded) equals: short.
 	self assert: (encoded allSatisfy: [ :each | legalCharactes includes: each ]).
 	"We don't want line breaks!"
 	long := String withAll: ((1 to: 64) collect: [ :each | 'abc' atRandom ]).
 	encoded := ZnUtils encodeBase64: long.
-	self assert: (ZnUtils decodeBase64: encoded) = long.
+	self assert: (ZnUtils decodeBase64: encoded) equals: long.
 	self assert: (encoded allSatisfy: [ :each | legalCharactes includes: each ])
-
 ]
 
 { #category : #testing }
 ZnUtilsTest >> testCapitalizeString [
-	self assert: (ZnUtils capitalizeString: 'content-type') = 'Content-Type'.
-	self assert: (ZnUtils capitalizeString: 'CONTENT-type') = 'Content-Type'.
-	self assert: (ZnUtils capitalizeString: 'content-TYPE') = 'Content-Type'.
-	self assert: (ZnUtils capitalizeString: 'WWW-Authenticate') = 'Www-Authenticate'.
-	self assert: (ZnUtils capitalizeString: 'Content-MD5') = 'Content-Md5'.
+	self assert: (ZnUtils capitalizeString: 'content-type') equals: 'Content-Type'.
+	self assert: (ZnUtils capitalizeString: 'CONTENT-type') equals: 'Content-Type'.
+	self assert: (ZnUtils capitalizeString: 'content-TYPE') equals: 'Content-Type'.
+	self assert: (ZnUtils capitalizeString: 'WWW-Authenticate') equals: 'Www-Authenticate'.
+	self assert: (ZnUtils capitalizeString: 'Content-MD5') equals: 'Content-Md5'
 ]
 
 { #category : #testing }
 ZnUtilsTest >> testHttpDate [
 	| timestamp string |
-	timestamp := (DateAndTime year: 2010 month: 9 day: 1 hour: 10 minute: 10 second: 10 offset: 0 seconds).
+	timestamp := DateAndTime
+		year: 2010
+		month: 9
+		day: 1
+		hour: 10
+		minute: 10
+		second: 10
+		offset: 0 seconds.
 	string := ZnUtils httpDate: timestamp.
-	self assert: (string = 'Wed, 01 Sep 2010 10:10:10 GMT')
-	
+	self assert: string equals: 'Wed, 01 Sep 2010 10:10:10 GMT'
 ]
 
 { #category : #testing }
@@ -58,98 +63,90 @@ ZnUtilsTest >> testNextPutAll [
 { #category : #testing }
 ZnUtilsTest >> testParseHttpDate [
 	"RFC 822, updated by RFC 1123"
-	
+
 	| timeStamp |
 	timeStamp := ZnUtils parseHttpDate: 'Tue, 13 Sep 2011 08:04:49 GMT'.
-	self assert: timeStamp dayOfMonth = 13.
-	self assert: timeStamp monthIndex = 9.
-	self assert: timeStamp year = 2011.
-	self assert: timeStamp hour = 8.
-	self assert: timeStamp minute = 4.
-	self assert: timeStamp second = 49.
-	self assert: timeStamp offset = Duration zero.
+	self assert: timeStamp dayOfMonth equals: 13.
+	self assert: timeStamp monthIndex equals: 9.
+	self assert: timeStamp year equals: 2011.
+	self assert: timeStamp hour equals: 8.
+	self assert: timeStamp minute equals: 4.
+	self assert: timeStamp second equals: 49.
+	self assert: timeStamp offset equals: Duration zero
 ]
 
 { #category : #testing }
 ZnUtilsTest >> testParseHttpDateAlternative1 [
 	"ANSI C's asctime() format"
-	
+
 	| timeStamp |
 	timeStamp := ZnUtils parseHttpDate: 'Tue Jan 01 00:00:01 2036'.
-	self assert: timeStamp dayOfMonth = 1.
-	self assert: timeStamp monthIndex = 1.
-	self assert: timeStamp year = 2036.
-	self assert: timeStamp hour = 0.
-	self assert: timeStamp minute = 0.
-	self assert: timeStamp second = 1.
-	self assert: timeStamp offset = Duration zero
+	self assert: timeStamp dayOfMonth equals: 1.
+	self assert: timeStamp monthIndex equals: 1.
+	self assert: timeStamp year equals: 2036.
+	self assert: timeStamp hour equals: 0.
+	self assert: timeStamp minute equals: 0.
+	self assert: timeStamp second equals: 1.
+	self assert: timeStamp offset equals: Duration zero
 ]
 
 { #category : #testing }
 ZnUtilsTest >> testParseHttpDateDashes [
 	"RFC 850, obsoleted by RFC 1036"
-	
+
 	| timeStamp |
 	timeStamp := ZnUtils parseHttpDate: 'Tuesday, 13-Sep-11 08:04:49 GMT'.
-	self assert: timeStamp dayOfMonth = 13.
-	self assert: timeStamp monthIndex = 9.
-	self assert: timeStamp year = 2011.
-	self assert: timeStamp hour = 8.
-	self assert: timeStamp minute = 4.
-	self assert: timeStamp second = 49.
-	self assert: timeStamp offset = Duration zero
+	self assert: timeStamp dayOfMonth equals: 13.
+	self assert: timeStamp monthIndex equals: 9.
+	self assert: timeStamp year equals: 2011.
+	self assert: timeStamp hour equals: 8.
+	self assert: timeStamp minute equals: 4.
+	self assert: timeStamp second equals: 49.
+	self assert: timeStamp offset equals: Duration zero
 ]
 
 { #category : #testing }
 ZnUtilsTest >> testParseHttpDateDashesAlternative1 [
 	"RFC 850, obsoleted by RFC 1036"
-	
+
 	| timeStamp |
 	timeStamp := ZnUtils parseHttpDate: 'Tue, 13-Sep-2011 08:04:49 GMT'.
-	self assert: timeStamp dayOfMonth = 13.
-	self assert: timeStamp monthIndex = 9.
-	self assert: timeStamp year = 2011.
-	self assert: timeStamp hour = 8.
-	self assert: timeStamp minute = 4.
-	self assert: timeStamp second = 49.
-	self assert: timeStamp offset = Duration zero
+	self assert: timeStamp dayOfMonth equals: 13.
+	self assert: timeStamp monthIndex equals: 9.
+	self assert: timeStamp year equals: 2011.
+	self assert: timeStamp hour equals: 8.
+	self assert: timeStamp minute equals: 4.
+	self assert: timeStamp second equals: 49.
+	self assert: timeStamp offset equals: Duration zero
 ]
 
 { #category : #testing }
 ZnUtilsTest >> testReadUpToEndBinary [
 	| data |
-	data := ByteArray streamContents: [ :stream | 
-		1 to: 10000 do: [ :each | 
-			stream nextPut: #(1 2 3) atRandom ] ].
-	self assert: (ZnUtils readUpToEnd: data readStream limit: nil) = data.
-	self assert: (ZnUtils readUpToEnd: data readStream limit: 10000) = data.
-	self should: [ ZnUtils readUpToEnd: data readStream limit: 9999 ] raise: ZnEntityTooLarge 
-
+	data := ByteArray streamContents: [ :stream | 1 to: 10000 do: [ :each | stream nextPut: #(1 2 3) atRandom ] ].
+	self assert: (ZnUtils readUpToEnd: data readStream limit: nil) equals: data.
+	self assert: (ZnUtils readUpToEnd: data readStream limit: 10000) equals: data.
+	self should: [ ZnUtils readUpToEnd: data readStream limit: 9999 ] raise: ZnEntityTooLarge
 ]
 
 { #category : #testing }
 ZnUtilsTest >> testReadUpToEndNonBinary [
 	| data |
-	data := String streamContents: [ :stream | 
-		1 to: 10000 do: [ :each | 
-			stream nextPut: 'abc' atRandom ] ].
-	self assert: (ZnUtils readUpToEnd: data readStream limit: nil) = data.
-	self assert: (ZnUtils readUpToEnd: data readStream limit: 10000) = data.
-	self should: [ ZnUtils readUpToEnd: data readStream limit: 9999 ] raise: ZnEntityTooLarge 
-
+	data := String streamContents: [ :stream | 1 to: 10000 do: [ :each | stream nextPut: 'abc' atRandom ] ].
+	self assert: (ZnUtils readUpToEnd: data readStream limit: nil) equals: data.
+	self assert: (ZnUtils readUpToEnd: data readStream limit: 10000) equals: data.
+	self should: [ ZnUtils readUpToEnd: data readStream limit: 9999 ] raise: ZnEntityTooLarge
 ]
 
 { #category : #testing }
 ZnUtilsTest >> testStreamingBinary [
 	| data in out |
-	data := ByteArray streamContents: [ :stream | 
-		1 to: 10000 do: [ :each |
-			stream nextPut: #(1 2 3) atRandom ] ].
+	data := ByteArray streamContents: [ :stream | 1 to: 10000 do: [ :each | stream nextPut: #(1 2 3) atRandom ] ].
 	in := data readStream.
 	out := WriteStream on: (ByteArray new: data size).
 	ZnUtils streamFrom: in to: out size: data size.
 	self assert: in atEnd.
-	self assert: out contents = data 
+	self assert: out contents equals: data
 ]
 
 { #category : #testing }
@@ -168,14 +165,12 @@ ZnUtilsTest >> testStreamingBinaryWithoutSize [
 { #category : #testing }
 ZnUtilsTest >> testStreamingNonBinary [
 	| data in out |
-	data := String streamContents: [ :stream | 
-		1 to: 10000 do: [ :each | 
-			stream nextPut: 'abc' atRandom ] ].
+	data := String streamContents: [ :stream | 1 to: 10000 do: [ :each | stream nextPut: 'abc' atRandom ] ].
 	in := data readStream.
 	out := WriteStream on: (String new: data size).
 	ZnUtils streamFrom: in to: out size: data size.
 	self assert: in atEnd.
-	self assert: out contents = data 
+	self assert: out contents equals: data
 ]
 
 { #category : #testing }

--- a/src/Zodiac-Tests/ZdcByteArrayManagerTest.class.st
+++ b/src/Zodiac-Tests/ZdcByteArrayManagerTest.class.st
@@ -16,7 +16,7 @@ ZdcByteArrayManagerTest >> testClearing [
 	one := (1 to: 10) asByteArray.
 	byteArrayManager recycle: one.
 	two := byteArrayManager byteArrayOfSize: 10 zero: true.
-	self assert: one == two.
+	self assert: one identicalTo: two.
 	self assert: two equals: (ByteArray new: 10)
 ]
 
@@ -29,5 +29,5 @@ ZdcByteArrayManagerTest >> testSimple [
 	byteArray := byteArrayManager byteArrayOfSize: 4096 zero: false.
 	byteArrayManager recycle: byteArray.
 	self assert: byteArrayManager totalSize equals: 4096.
-	self assert: (byteArrayManager byteArrayOfSize: 4096 zero: false) == byteArray
+	self assert: (byteArrayManager byteArrayOfSize: 4096 zero: false) identicalTo: byteArray
 ]


### PR DESCRIPTION
Replace assert = in packages starting by Z.

Replace:

- assert: = by assert: equals:
- deny = by deny: equals:
- assert: == by assert: identicalTo:
- deny: == by deny: identicalTo: