### PR TITLE
ProtoObject: #mustBeBooleanDeOptimize

### DIFF
--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1400,42 +1400,6 @@ Object >> longPrintStringLimitedTo: aLimitValue [
 	^ str isEmpty ifTrue: [self printString, String cr] ifFalse: [str]
 ]
 
-{ #category : #'block support' }
-Object >> mustBeBoolean [
-	"Catches attempts to test truth of non-Booleans.  This message is sent from the VM.  The sending context is rewound to just before the jump causing this exception."
-	^ Boolean mustBeBooleanDeOptimize
-		ifTrue: [ self mustBeBooleanDeOptimizeIn: thisContext sender  ]
-		ifFalse: [ self mustBeBooleanIn: thisContext sender ]
-]
-
-{ #category : #'block support' }
-Object >> mustBeBooleanIn: context [
-	"context is the where the non-boolean error occurred. Rewind context to before jump then raise error."
-	
-	"Some constructs are optimized in the compiler :
-	#whileTrue:
-	#whileFalse:
-	#ifTrue:
-	#ifFalse:
-	#ifTrue:ifFalse:
-	#ifFalse:ifTrue:
-	So you cannot by default use them on non boolean objects."
-	
-	"If you really need to use optimized constructs, you can enable Opal compiler and do one of the following :
-		- recompile your method with the pragma : <compilerOptions: #(+ optIlineNone)>
-		- recompile your class with the method : MyClass class>>compiler 
-			^ super compiler options: #(+ optIlineNone)
-		- enable the option mustBeBooleanDeOptimize to call mustBeBooleanDeOptimizeIn: instead of this method "
-
-	| proceedValue |
-	
-	context skipBackBeforeJump.
-	proceedValue := NonBooleanReceiver new
-		object: self;
-		signal: 'proceed for truth.'.
-	^ proceedValue ~~ false
-]
-
 { #category : #dependencies }
 Object >> myDependents [
 	"Private. Answer a list of all the receiver's dependents."

--- a/src/Kernel/ProtoObject.class.st
+++ b/src/Kernel/ProtoObject.class.st
@@ -212,6 +212,42 @@ ProtoObject >> modificationForbiddenFor: selector value: value [
 
 ]
 
+{ #category : #'block support' }
+ProtoObject >> mustBeBoolean [
+	"Catches attempts to test truth of non-Booleans.  This message is sent from the VM.  The sending context is rewound to just before the jump causing this exception."
+	^ Boolean mustBeBooleanDeOptimize
+		ifTrue: [ self mustBeBooleanDeOptimizeIn: thisContext sender  ]
+		ifFalse: [ self mustBeBooleanIn: thisContext sender ]
+]
+
+{ #category : #'block support' }
+ProtoObject >> mustBeBooleanIn: context [
+	"context is the where the non-boolean error occurred. Rewind context to before jump then raise error."
+	
+	"Some constructs are optimized in the compiler :
+	#whileTrue:
+	#whileFalse:
+	#ifTrue:
+	#ifFalse:
+	#ifTrue:ifFalse:
+	#ifFalse:ifTrue:
+	So you cannot by default use them on non boolean objects."
+	
+	"If you really need to use optimized constructs, you can enable Opal compiler and do one of the following :
+		- recompile your method with the pragma : <compilerOptions: #(+ optIlineNone)>
+		- recompile your class with the method : MyClass class>>compiler 
+			^ super compiler options: #(+ optIlineNone)
+		- enable the option mustBeBooleanDeOptimize to call mustBeBooleanDeOptimizeIn: instead of this method "
+
+	| proceedValue |
+	
+	context skipBackBeforeJump.
+	proceedValue := NonBooleanReceiver new
+		object: self;
+		signal: 'proceed for truth.'.
+	^ proceedValue ~~ false
+]
+
 { #category : #'memory scanning' }
 ProtoObject >> nextInstance [
 	"Primitive. Answer the next instance after the receiver in the 

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -195,7 +195,7 @@ MCClassDefinition >> classTraitCompositionString [
 
 { #category : #accessing }
 MCClassDefinition >> classVarNames [
-	^self selectVariables: #isClassVariable
+	^(self selectVariables: #isClassVariable) asArray sort
 ]
 
 { #category : #printing }

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -195,7 +195,7 @@ MCClassDefinition >> classTraitCompositionString [
 
 { #category : #accessing }
 MCClassDefinition >> classVarNames [
-	^(self selectVariables: #isClassVariable) asArray sort
+	^self selectVariables: #isClassVariable
 ]
 
 { #category : #printing }

--- a/src/OpalCompiler-Core/ProtoObject.extension.st
+++ b/src/OpalCompiler-Core/ProtoObject.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : #Object }
+Extension { #name : #ProtoObject }
 
 { #category : #'*OpalCompiler-Core' }
-Object >> mustBeBooleanCompileExpression: context andCache: cache [
+ProtoObject >> mustBeBooleanCompileExpression: context andCache: cache [
 	"Permits to redefine methods inlined by compiler.
 	Take the ast node corresponding to the mustBeBoolean error, compile it on the fly and executes it as a DoIt. Then resume the execution of the context."
 
@@ -34,7 +34,7 @@ Object >> mustBeBooleanCompileExpression: context andCache: cache [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-Object >> mustBeBooleanDeOptimizeIn: context [
+ProtoObject >> mustBeBooleanDeOptimizeIn: context [
 	"Permits to redefine methods inlined by compiler.
 	Take the ast node corresponding to the mustBeBoolean error, compile it on the fly and executes it as a DoIt. Then resume the execution of the context.
 	the generated DoIts are cached in the calling method"


### PR DESCRIPTION
if we move #mustBeBoolean to ProtoObject, the mechanism to get #ifTrue: sends will work for subclasses of ProtoObject. As this is used often for proxies, having that mechanism in ProtoObject makes sense, I think.