### PR TITLE
Improve-AssertEquals-Rule

### DIFF
--- a/src/SUnit-Rules/AssertEqualSignIntoAssertEquals.class.st
+++ b/src/SUnit-Rules/AssertEqualSignIntoAssertEquals.class.st
@@ -33,13 +33,14 @@ AssertEqualSignIntoAssertEquals >> group [
 { #category : #initialization }
 AssertEqualSignIntoAssertEquals >> initialize [
 	super initialize.
-	self
-		replace: 'self assert: ``@object1 = ``@object2'
-		with: 'self assert: ``@object1 equals: ``@object2'
+	self replace: 'self assert: ``@object1 = ``@object2' with: 'self assert: ``@object1 equals: ``@object2'.
+	self replace: 'self deny: ``@object1 = ``@object2' with: 'self deny: ``@object1 equals: ``@object2'.
+	self replace: 'self assert: ``@object1 == ``@object2' with: 'self assert: ``@object1 identicalTo: ``@object2'.
+	self replace: 'self deny: ``@object1 == ``@object2' with: 'self deny: ``@object1 identicalTo: ``@object2'
 ]
 
 { #category : #accessing }
 AssertEqualSignIntoAssertEquals >> name [
 
-	^ 'Use assert:equals: instead of assert: and ='
+	^ 'Use assert:equals: instead of assert: and = (or deny:/identicalTo: and ==)'
 ]


### PR DESCRIPTION
Improve assert:equals: rule to avoid assert: =

It now matches more cases:

- assert: = with assert: equals:
- deny = with deny: equals:
- assert: == with assert: identicalTo:
- deny: == with deny: identicalTo: