### PR TITLE
Replace-assert-equals-from-non-test-methods

### DIFF
--- a/src/AST-Core-Tests/RBParseTreeRewriterTest.class.st
+++ b/src/AST-Core-Tests/RBParseTreeRewriterTest.class.st
@@ -11,9 +11,9 @@ Class {
 }
 
 { #category : #utilities }
-RBParseTreeRewriterTest >> compare: anObject to: anotherObject [ 
-	self assert: anObject hash = anotherObject hash.
-	self assert: anObject = anotherObject
+RBParseTreeRewriterTest >> compare: anObject to: anotherObject [
+	self assert: anObject hash equals: anotherObject hash.
+	self assert: anObject equals: anotherObject
 ]
 
 { #category : #helpers }

--- a/src/Collections-Tests/ArrayTest.class.st
+++ b/src/Collections-Tests/ArrayTest.class.st
@@ -94,14 +94,12 @@ ArrayTest >> anotherValue [
 ]
 
 { #category : #asserting }
-ArrayTest >> assertSameContents: aCollection whenConvertedTo: aClass [ 
+ArrayTest >> assertSameContents: aCollection whenConvertedTo: aClass [
 	| result |
 	result := aCollection perform: ('as' , aClass name) asSymbol.
 	self assert: (result class includesBehavior: aClass).
-	result do: 
-		[ :each | 
-		self assert: (aCollection occurrencesOf: each) = (result occurrencesOf: each) ].
-	self assert: result size = aCollection size
+	result do: [ :each | self assert: (aCollection occurrencesOf: each) equals: (result occurrencesOf: each) ].
+	self assert: result size equals: aCollection size
 ]
 
 { #category : #initialization }

--- a/src/Collections-Tests/FIFOQueueTest.class.st
+++ b/src/Collections-Tests/FIFOQueueTest.class.st
@@ -18,9 +18,7 @@ FIFOQueueTest >> newQueue [
 
 { #category : #running }
 FIFOQueueTest >> runValidationTest [
-	| q sema prio pusher feeder
-		feeders r crit done |
-
+	| q sema prio pusher feeder feeders r crit done |
 	r := Random new.
 	q := AtomicSharedQueue new.
 	feeders := OrderedCollection new.
@@ -28,31 +26,32 @@ FIFOQueueTest >> runValidationTest [
 	sema := Semaphore new.
 	crit := Semaphore forMutualExclusion.
 	done := Semaphore new.
-	
+
 	prio := Processor activePriority.
-	pusher := [ sema wait. 1 to: 100 do: [:i | q nextPut: i ]. ].
-	feeder := [ sema wait. 
-		[ q next. 
-		crit critical: [count := count + 1 ]. count < 1000 ] whileTrue. done signal ].
-	
-	10 timesRepeat: [
-		| proc |
-		proc := pusher newProcess priority: prio + (r next * 10) asInteger  - 5.
-		proc resume.
-		proc := feeder newProcess priority: prio + (r next * 10) asInteger  - 10.
-		feeders add: proc. 
-		proc resume.		
-	].
+	pusher := [ sema wait.
+	1 to: 100 do: [ :i | q nextPut: i ] ].
+	feeder := [ sema wait.
+	[ q next.
+	crit critical: [ count := count + 1 ].
+	count < 1000 ] whileTrue.
+	done signal ].
+
+	10
+		timesRepeat: [ | proc |
+			proc := pusher newProcess priority: prio + (r next * 10) asInteger - 5.
+			proc resume.
+			proc := feeder newProcess priority: prio + (r next * 10) asInteger - 10.
+			feeders add: proc.
+			proc resume ].
 
 	" let them run "
 	20 timesRepeat: [ sema signal ].
 	Processor yield.
-	
-	done waitTimeoutSeconds: 10.
-	 
-	feeders do: [:ea | ea terminate ].
-	self assert: (count = 1000 ) 
 
+	done waitTimeoutSeconds: 10.
+
+	feeders do: [ :ea | ea terminate ].
+	self assert: count equals: 1000
 ]
 
 { #category : #running }

--- a/src/Collections-Tests/MethodDictionaryTest.class.st
+++ b/src/Collections-Tests/MethodDictionaryTest.class.st
@@ -38,7 +38,7 @@ MethodDictionaryTest >> anotherValue [
 
 { #category : #assertions }
 MethodDictionaryTest >> assertPreservesCapacity: oldDictionary comparedTo: rehashedDictionary [
-	self assert: oldDictionary capacity = rehashedDictionary capacity.
+	self assert: oldDictionary capacity equals: rehashedDictionary capacity
 ]
 
 { #category : #assertions }

--- a/src/Collections-Tests/OrderedDictionaryTest.class.st
+++ b/src/Collections-Tests/OrderedDictionaryTest.class.st
@@ -33,10 +33,10 @@ OrderedDictionaryTest >> absentValue [
 { #category : #assertions }
 OrderedDictionaryTest >> assertDictionary: aFirstDictionary doesNotEqual: aSecondDictionary [
 	"Test symmetric inequality"
-	
+
 	self
-		deny: aFirstDictionary = aSecondDictionary;
-		deny: aSecondDictionary = aFirstDictionary
+		deny: aFirstDictionary equals: aSecondDictionary;
+		deny: aSecondDictionary equals: aFirstDictionary
 ]
 
 { #category : #assertions }
@@ -61,51 +61,47 @@ OrderedDictionaryTest >> assertIsArray: anArray withElements: aCollection [
 { #category : #assertions }
 OrderedDictionaryTest >> assertIsDictionary: aFirstDictionary copiedFrom: aSecondDictionary withOrderedAssociations: anAssociationCollection [
 	self
-		deny: aFirstDictionary == aSecondDictionary;
-		deny: aFirstDictionary dictionary == aSecondDictionary dictionary;
-		deny: aFirstDictionary orderedKeys == aSecondDictionary orderedKeys.
+		deny: aFirstDictionary identicalTo: aSecondDictionary;
+		deny: aFirstDictionary dictionary identicalTo: aSecondDictionary dictionary;
+		deny: aFirstDictionary orderedKeys identicalTo: aSecondDictionary orderedKeys.
 
 	"esnure the associations were copied (the keys and values can be shared)"
-	aFirstDictionary associations do: [:each |
-		self deny: (aSecondDictionary associations identityIncludes: each)].
+	aFirstDictionary associations do: [ :each | self deny: (aSecondDictionary associations identityIncludes: each) ].
 
-	self
-		assertIsDictionary: aFirstDictionary
-		withOrderedAssociations: anAssociationCollection.
+	self assertIsDictionary: aFirstDictionary withOrderedAssociations: anAssociationCollection
 ]
 
 { #category : #assertions }
 OrderedDictionaryTest >> assertIsDictionary: anObject withOrderedAssociations: anAssociationCollection [
 	"Tests that anObject is an instance of the correct dictionary class
 	with the specified ordered associations"
+
 	self
-		assert: anObject class == self dictionaryClass;
+		assert: anObject class identicalTo: self dictionaryClass;
 		assert: anObject orderedKeys size >= anAssociationCollection size;
 		assert: anObject associations size equals: anAssociationCollection size.
 
-	anAssociationCollection withIndexDo: [:each :i |
-		self isTestingIdentityDictionary
-			ifTrue: [
-				self
-					assert: (anObject orderedKeys at: i) == each key;
-					assert: (anObject associations at: i) key == each key]
-			ifFalse: [
-				self
-					assert: (anObject orderedKeys at: i) equals: each key;
-					assert: (anObject associations at: i) key equals: each key].
-		self assert: (anObject associations at: i) value equals: each value].
+	anAssociationCollection
+		withIndexDo: [ :each :i | 
+			self isTestingIdentityDictionary
+				ifTrue: [ self
+						assert: (anObject orderedKeys at: i) identicalTo: each key;
+						assert: (anObject associations at: i) key identicalTo: each key ]
+				ifFalse: [ self
+						assert: (anObject orderedKeys at: i) equals: each key;
+						assert: (anObject associations at: i) key equals: each key ].
+			self assert: (anObject associations at: i) value equals: each value ]
 ]
 
 { #category : #assertions }
 OrderedDictionaryTest >> assertIsDictionary: anObject withUnorderedAssociations: anAssociationCollection [
 	"Tests that anObject is an instance of the correct dictionary class
 	with the specified associations, but ignoring the order"
-	
+
 	self
-		assert: anObject class == self dictionaryClass;
+		assert: anObject class identicalTo: self dictionaryClass;
 		assert: anObject size equals: anAssociationCollection size.
-	anAssociationCollection do: [:each |
-		self assert: (anObject includesAssociation: each)].
+	anAssociationCollection do: [ :each | self assert: (anObject includesAssociation: each) ]
 ]
 
 { #category : #assertions }

--- a/src/FreeType-Tests/FreeTypeCacheTest.class.st
+++ b/src/FreeType-Tests/FreeTypeCacheTest.class.st
@@ -487,36 +487,28 @@ FreeTypeCacheTest >> testSingleton [
 { #category : #private }
 FreeTypeCacheTest >> validateCollections: aFreeTypeCache [
 	"check that the fifo list entries match the fontTable dict hierarchy"
+
 	| fontTable fontTableEntries fifo lastLink |
 	fontTable := aFreeTypeCache instVarNamed: #fontTable.
 	fifo := aFreeTypeCache instVarNamed: #fifo.
-	lastLink := (fifo instVarNamed:#lastLink).
+	lastLink := fifo instVarNamed: #lastLink.
 	fontTableEntries := Set new.
-	fontTable keysAndValuesDo:[:k1 :v1 |
-		v1 keysAndValuesDo:[:k2 :v2 |
-			v2 keysAndValuesDo:[:k3 :v3 |
-				fontTableEntries add: v3 ]]].
-	self assert: fifo size = fontTableEntries size.
-	self assert: (fifo asSet = fontTableEntries).
-	self assert: (lastLink isNil or:[lastLink nextLink isNil]) 
-	
-
-	
+	fontTable keysAndValuesDo: [ :k1 :v1 | v1 keysAndValuesDo: [ :k2 :v2 | v2 keysAndValuesDo: [ :k3 :v3 | fontTableEntries add: v3 ] ] ].
+	self assert: fifo size equals: fontTableEntries size.
+	self assert: fifo asSet equals: fontTableEntries.
+	self assert: (lastLink isNil or: [ lastLink nextLink isNil ])
 ]
 
 { #category : #private }
 FreeTypeCacheTest >> validateSizes: aFreeTypeCache [
 	"check that the used, maximumSize, and caches entries are valid"
+
 	| fontTable calcSize max used |
 	fontTable := aFreeTypeCache instVarNamed: #fontTable.
 	used := aFreeTypeCache instVarNamed: #used.
 	max := aFreeTypeCache instVarNamed: #maximumSize.
 	calcSize := 0.
-	fontTable do:[:charCodeTable |
-		charCodeTable do:[:typeTable |
-			typeTable do:[:entry |
-				calcSize := calcSize + (aFreeTypeCache sizeOf: entry object)]]].
-	self assert: calcSize = used.
-	self assert: (max isNil or:[used <= max])
-	
+	fontTable do: [ :charCodeTable | charCodeTable do: [ :typeTable | typeTable do: [ :entry | calcSize := calcSize + (aFreeTypeCache sizeOf: entry object) ] ] ].
+	self assert: calcSize equals: used.
+	self assert: (max isNil or: [ used <= max ])
 ]

--- a/src/GT-Tests-Spotter/GTSpotterExceptionsTest.class.st
+++ b/src/GT-Tests-Spotter/GTSpotterExceptionsTest.class.st
@@ -97,16 +97,17 @@ GTSpotterExceptionsTest >> shouldRaise: anErrorClass process: aString origin: an
 	self assertResetExceptions.
 
 	spotter exceptionHandler: exceptionHandler.
-	self assert: spotter exceptionHandler == exceptionHandler.
-	
-	self should: [ self process: aString origin: anOrigin ] 
-		raise: anErrorClass 
+	self assert: spotter exceptionHandler identicalTo: exceptionHandler.
+
+	self
+		should: [ self process: aString origin: anOrigin ]
+		raise: anErrorClass
 		withExceptionDo: [ :exception | 
-			self assert: exception class == anErrorClass.
-			aBlock value: exception. ].
-		
-	self assert: spotter exceptionHandler == exceptionHandler.
-	
+			self assert: exception class identicalTo: anErrorClass.
+			aBlock value: exception ].
+
+	self assert: spotter exceptionHandler identicalTo: exceptionHandler.
+
 	self assertException: anErrorClass
 ]
 
@@ -118,11 +119,11 @@ GTSpotterExceptionsTest >> shouldntRaise: anError process: aString origin: anOri
 { #category : #private }
 GTSpotterExceptionsTest >> shouldntRaise: anError process: aString origin: anOrigin during: exceptionHandler [
 	spotter exceptionHandler: exceptionHandler.
-	self assert: spotter exceptionHandler == exceptionHandler.
-	
+	self assert: spotter exceptionHandler identicalTo: exceptionHandler.
+
 	self shouldnt: [ self process: aString origin: anOrigin ] raise: anError.
-	
-	self assert: spotter exceptionHandler == exceptionHandler.
+
+	self assert: spotter exceptionHandler identicalTo: exceptionHandler
 ]
 
 { #category : #tests }

--- a/src/GT-Tests-Spotter/GTSpotterStepTest.class.st
+++ b/src/GT-Tests-Spotter/GTSpotterStepTest.class.st
@@ -21,7 +21,7 @@ GTSpotterStepTest >> assertCandidateMatching: aBlock [
 	candidates := currentProcessor allFilteredCandidates select: [ :each | aBlock value: each ].
 
 	self denyEmpty: candidates.
-	self assert: candidates size = 1.
+	self assert: candidates size equals: 1.
 
 	currentCandidate := candidates anyOne.
 	self assert: currentCandidate notNil.
@@ -45,12 +45,12 @@ GTSpotterStepTest >> assertDiveIn: aSelector [
 	link := spotter currentStep candidates getCandidateLink: currentCandidate in: currentProcessor.
 
 	self assert: link notNil.
-	self assert: link candidate == currentCandidate.
-	self assert: link processor == currentProcessor.
+	self assert: link candidate identicalTo: currentCandidate.
+	self assert: link processor identicalTo: currentProcessor.
 
 	" set the selection - like the UI would do "
 	self shouldnt: [ spotter currentStep select: link ] raise: Error.
-	self assert: spotter currentStep selected == link.
+	self assert: spotter currentStep selected identicalTo: link.
 
 	" perform the dive operation - like the UI would do "
 	self shouldnt: [ spotter currentStep perform: aSelector ] raise: Error.
@@ -59,11 +59,11 @@ GTSpotterStepTest >> assertDiveIn: aSelector [
 
 	self denyEmpty: spotter steps.
 	self assert: spotter steps size > previousStepsSize.
-	self assert: spotter steps size = (previousStepsSize + 1).
+	self assert: spotter steps size equals: previousStepsSize + 1.
 
-	self deny: previousStep = currentStep.
-	self deny: previousStep = spotter currentStep.
-	self assert: currentStep = spotter currentStep
+	self deny: previousStep equals: currentStep.
+	self deny: previousStep equals: spotter currentStep.
+	self assert: currentStep equals: spotter currentStep
 ]
 
 { #category : #convenience }
@@ -82,13 +82,13 @@ GTSpotterStepTest >> assertDiveOut [
 	self shouldnt: [ spotter popStep ] raise: Error.
 	currentStep := spotter currentStep.
 	currentProcessor := currentCandidate := previousContext := currentContext := nil.
-	
+
 	self assert: spotter steps size < previousStepsSize.
-	self assert: spotter steps size = (previousStepsSize - 1).
-	
+	self assert: spotter steps size equals: previousStepsSize - 1.
+
 	self deny: (previousStepsSize > 1 and: [ previousStep = currentStep ]).
 	self deny: (previousStepsSize > 1 and: [ previousStep = spotter currentStep ]).
-	self assert: currentStep = spotter currentStep.
+	self assert: currentStep equals: spotter currentStep
 ]
 
 { #category : #convenience }
@@ -120,13 +120,13 @@ GTSpotterStepTest >> assertProcessorIncludesAll: aCollection [
 GTSpotterStepTest >> assertProcessorMatching: aBlock [
 	| processors |
 	processors := spotter currentStep processors select: [ :each | aBlock value: each ].
-	
+
 	self assert: processors notEmpty.
-	self assert: processors size = 1.
-	
+	self assert: processors size equals: 1.
+
 	currentProcessor := processors anyOne.
 	self assert: currentProcessor notNil.
-	
+
 	^ currentProcessor
 ]
 
@@ -138,16 +138,16 @@ GTSpotterStepTest >> assertProcessorNotEmpty [
 
 { #category : #convenience }
 GTSpotterStepTest >> assertSearch: aString [
-
 	" assert conditions before search "
+
 	self deny: (spotter currentStep context matches: aString).
-	
+
 	self basicSearch: aString.
-		
+
 	" assert conditions after search "
-	self deny: previousContext == currentContext.
-	self deny: previousContext == spotter currentStep context.
-	self assert: spotter currentStep context text asString = aString asString
+	self deny: previousContext identicalTo: currentContext.
+	self deny: previousContext identicalTo: spotter currentStep context.
+	self assert: spotter currentStep context text asString equals: aString asString
 ]
 
 { #category : #convenience }
@@ -156,23 +156,24 @@ GTSpotterStepTest >> assortCandidatesSize: aNumber [
 
 { #category : #private }
 GTSpotterStepTest >> basicSearch: aString [
-	
 	" assert conditions before search "
-	self flag: '#currentStep should be made more stable. This will fail for an empty, uninitialized spotter / but after multiple diveIn/diveOut it will be ok - inconsistent'.
-	self assert: spotter currentStep == spotter currentStep.
-	
+
+	self
+		flag: '#currentStep should be made more stable. This will fail for an empty, uninitialized spotter / but after multiple diveIn/diveOut it will be ok - inconsistent'.
+	self assert: spotter currentStep identicalTo: spotter currentStep.
+
 	" backup preconditions "
 	previousStep := spotter currentStep.
 	previousContext := previousStep context.
 
 	self shouldnt: [ spotter setText: aString from: nil ] raise: Error.
-	
+
 	" backup postconditions "
 	currentStep := spotter currentStep.
 	currentContext := spotter currentStep context.
-	
+
 	" assert conditions after search "
-	self assert: previousStep == currentStep.
+	self assert: previousStep identicalTo: currentStep
 ]
 
 { #category : #'private-navigation' }
@@ -183,15 +184,15 @@ GTSpotterStepTest >> defaultPackages [
 { #category : #convenience }
 GTSpotterStepTest >> denySearch: aString [
 	" if the new input is the same as before we do not expect a new search to be triggered . Therefore the context should not change "
-	
+
 	"self assert: (spotter currentStep context matches: aStringOrText)."
-	
+
 	self basicSearch: aString.
-	
+
 	" assert conditions after search "
-	self assert: previousContext == currentContext.
-	self assert: previousContext == spotter currentStep context.
-	self assert: (previousContext matches: aString).
+	self assert: previousContext identicalTo: currentContext.
+	self assert: previousContext identicalTo: spotter currentStep context.
+	self assert: (previousContext matches: aString)
 ]
 
 { #category : #'private-navigation' }

--- a/src/Graphics-Tests/PNGReadWriterTest.class.st
+++ b/src/Graphics-Tests/PNGReadWriterTest.class.st
@@ -161,14 +161,14 @@ CiHUAAAAGUlEQVR4XmNgZMQPGBhHvoKRr2DkKxihCgBEmAQBphO0cAAAAABJRU5ErkJggg=='
 
 { #category : #'tests - decoding' }
 PNGReadWriterTest >> decodeColors: colorsAndFiles depth: requiredDepth [
-	
-	colorsAndFiles do:[:assoc| | bytes color form |
-		color := assoc key.
-		bytes := assoc value base64Decoded.
-		form := PNGReadWriter formFromStream: bytes readStream.
-		self assert: form depth = requiredDepth.
-		self assert: (form pixelValueAt: 1@1) = (color pixelValueForDepth: requiredDepth).
-	].
+	colorsAndFiles
+		do: [ :assoc | 
+			| bytes color form |
+			color := assoc key.
+			bytes := assoc value base64Decoded.
+			form := PNGReadWriter formFromStream: bytes readStream.
+			self assert: form depth equals: requiredDepth.
+			self assert: (form pixelValueAt: 1 @ 1) equals: (color pixelValueForDepth: requiredDepth) ]
 ]
 
 { #category : #helpers }
@@ -218,35 +218,40 @@ PNGReadWriterTest >> drawTransparentStuffOn: aForm [
 { #category : #helpers }
 PNGReadWriterTest >> encodeAndDecode: original [
 	"Make sure that the given form is encoded and decoded correctly"
+
 	| stream bytes decoded |
 	"encode"
 	stream := ByteArray new writeStream.
-	(PNGReadWriter on: stream) nextPutImage: original; close.
+	(PNGReadWriter on: stream)
+		nextPutImage: original;
+		close.
 	bytes := stream contents.
 
 	self writeEncoded: bytes.
 
 	"decode"
 	stream := self readEncoded: bytes.
-	[decoded := (PNGReadWriter new on: stream) nextImage.
+	[ decoded := (PNGReadWriter new on: stream) nextImage.
 	decoded display.
 
 	"compare"
-	self assert: original width = decoded width.
-	self assert: original height = decoded height.
-	self assert: original depth = decoded depth.
-	self assert: original bits = decoded bits.
-	self assert: original class == decoded class.
-	(original isColorForm) ifTrue:[
-		original colors with: decoded colors do:[:c1 :c2| | maxErr |
-			"we must round here due to encoding errors"
-			maxErr := 1. "max. error for 8bit rgb component"
-			self assert: ((c1 red * 255) truncated - (c2 red * 255) truncated) abs <= maxErr.
-			self assert: ((c1 green * 255) truncated - (c2 green * 255) truncated) abs <= maxErr.
-			self assert: ((c1 blue * 255) truncated - (c2 blue * 255) truncated) abs <= maxErr.
-			self assert: ((c1 alpha * 255) truncated - (c2 alpha * 255) truncated) abs <= maxErr.
-		].
-	]] ensure: [ stream close ].
+	self assert: original width equals: decoded width.
+	self assert: original height equals: decoded height.
+	self assert: original depth equals: decoded depth.
+	self assert: original bits equals: decoded bits.
+	self assert: original class identicalTo: decoded class.
+	original isColorForm
+		ifTrue: [ original colors
+				with: decoded colors
+				do: [ :c1 :c2 | 
+					| maxErr |
+					"we must round here due to encoding errors"
+					maxErr := 1.	"max. error for 8bit rgb component"
+					self assert: ((c1 red * 255) truncated - (c2 red * 255) truncated) abs <= maxErr.
+					self assert: ((c1 green * 255) truncated - (c2 green * 255) truncated) abs <= maxErr.
+					self assert: ((c1 blue * 255) truncated - (c2 blue * 255) truncated) abs <= maxErr.
+					self assert: ((c1 alpha * 255) truncated - (c2 alpha * 255) truncated) abs <= maxErr ] ] ]
+		ensure: [ stream close ]
 ]
 
 { #category : #helpers }
@@ -287,23 +292,24 @@ PNGReadWriterTest >> encodeAndDecodeForm: original [
 { #category : #helpers }
 PNGReadWriterTest >> encodeAndDecodeReverse: original [
 	"Make sure that the given form is encoded and decoded correctly"
+
 	| stream bytes decoded reversed |
-	fileName := 'testReverse', original depth printString,'.png'.
-	self assert: original class == Form. "won't work with ColorForm"
+	fileName := 'testReverse' , original depth printString , '.png'.
+	self assert: original class identicalTo: Form.	"won't work with ColorForm"
 	"Switch pixel order"
 	reversed := Form extent: original extent depth: original depth negated.
 	original displayOn: reversed.
-	self assert: original width = reversed width.
-	self assert: original height = reversed height.
-	self assert: original depth = reversed depth.
-	self deny: original nativeDepth = reversed nativeDepth.
-	original depth = 32
-		ifTrue:[self assert: original bits = reversed bits]
-		ifFalse:[self deny: original bits = reversed bits].
+	self assert: original width equals: reversed width.
+	self assert: original height equals: reversed height.
+	self assert: original depth equals: reversed depth.
+	self deny: original nativeDepth equals: reversed nativeDepth.
+	original depth = 32 ifTrue: [ self assert: original bits equals: reversed bits ] ifFalse: [ self deny: original bits equals: reversed bits ].
 
 	"encode"
 	stream := ByteArray new writeStream.
-	(PNGReadWriter on: stream) nextPutImage: reversed; close.
+	(PNGReadWriter on: stream)
+		nextPutImage: reversed;
+		close.
 	bytes := stream contents.
 	self writeEncoded: bytes.
 
@@ -313,22 +319,23 @@ PNGReadWriterTest >> encodeAndDecodeReverse: original [
 	decoded display.
 
 	"compare"
-	self assert: original width = decoded width.
-	self assert: original height = decoded height.
-	self assert: original depth = decoded depth.
-	self assert: original bits = decoded bits.
-	self assert: original class == decoded class.
-	(original isColorForm) ifTrue:[
-		original colors with: decoded colors do:[:c1 :c2| | maxErr |
-			"we must round here due to encoding errors"
-			maxErr := 1. "max. error for 8bit rgb component"
-			self assert: ((c1 red * 255) truncated - (c2 red * 255) truncated) abs <= maxErr.
-			self assert: ((c1 green * 255) truncated - (c2 green * 255) truncated) abs <= maxErr.
-			self assert: ((c1 blue * 255) truncated - (c2 blue * 255) truncated) abs <= maxErr.
-			self assert: ((c1 alpha * 255) truncated - (c2 alpha * 255) truncated) abs <= maxErr.
-		].
-	].
-	self deleteFile.
+	self assert: original width equals: decoded width.
+	self assert: original height equals: decoded height.
+	self assert: original depth equals: decoded depth.
+	self assert: original bits equals: decoded bits.
+	self assert: original class identicalTo: decoded class.
+	original isColorForm
+		ifTrue: [ original colors
+				with: decoded colors
+				do: [ :c1 :c2 | 
+					| maxErr |
+					"we must round here due to encoding errors"
+					maxErr := 1.	"max. error for 8bit rgb component"
+					self assert: ((c1 red * 255) truncated - (c2 red * 255) truncated) abs <= maxErr.
+					self assert: ((c1 green * 255) truncated - (c2 green * 255) truncated) abs <= maxErr.
+					self assert: ((c1 blue * 255) truncated - (c2 blue * 255) truncated) abs <= maxErr.
+					self assert: ((c1 alpha * 255) truncated - (c2 alpha * 255) truncated) abs <= maxErr ] ].
+	self deleteFile
 ]
 
 { #category : #helpers }
@@ -375,16 +382,16 @@ PNGReadWriterTest >> encodeAndDecodeWithError: aStream [
 
 { #category : #'tests - decoding' }
 PNGReadWriterTest >> encodeColors: colorsAndFiles depth: requiredDepth [
-	
-	colorsAndFiles do:[:assoc| | original encoded color ff |
-		color := assoc key.
-		original := assoc value base64Decoded.
-		ff := Form extent: 32@32 depth: requiredDepth.
-		ff fillColor: color.
-		encoded := ByteArray new writeStream.
-		PNGReadWriter putForm: ff onStream: encoded.
-		self assert: (encoded contents = original contents).
-	].
+	colorsAndFiles
+		do: [ :assoc | 
+			| original encoded color ff |
+			color := assoc key.
+			original := assoc value base64Decoded.
+			ff := Form extent: 32 @ 32 depth: requiredDepth.
+			ff fillColor: color.
+			encoded := ByteArray new writeStream.
+			PNGReadWriter putForm: ff onStream: encoded.
+			self assert: encoded contents equals: original contents ]
 ]
 
 { #category : #helpers }

--- a/src/Kernel-Tests-WithCompiler/SelfEvaluatingObjectTest.class.st
+++ b/src/Kernel-Tests-WithCompiler/SelfEvaluatingObjectTest.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #utilities }
 SelfEvaluatingObjectTest >> assertCode: code print: aString [
-	self assert: (self class evaluate: code) printString = aString
+	self assert: (self class evaluate: code) printString equals: aString
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ContextTest.class.st
+++ b/src/Kernel-Tests/ContextTest.class.st
@@ -50,52 +50,62 @@ ContextTest class >> returnNonActiveContextOfBlock [
 { #category : #private }
 ContextTest >> privRestartArgBlockTest [
 	"This tests may loop endlessly if incorrect, so call it from another method testing it does not time out"
-	|firstTimeThrough |
-	firstTimeThrough := true.
-	
-	self assert: 30 equals: ([:a | |b| 
-		self assert: 10 = a .
-		self assert: nil == b.
-		b := a + 20. 
-		firstTimeThrough ifTrue: [
-			firstTimeThrough := false.
-			thisContext restart.].
-		b] value: 10)
 
+	| firstTimeThrough |
+	firstTimeThrough := true.
+
+	self
+		assert: 30
+		equals:
+			([ :a | 
+			| b |
+			self assert: 10 equals: a.
+			self assert: nil identicalTo: b.
+			b := a + 20.
+			firstTimeThrough
+				ifTrue: [ firstTimeThrough := false.
+					thisContext restart ].
+			b ] value: 10)
 ]
 
 { #category : #private }
 ContextTest >> privRestartBlockArgsNoRemoteTempsTest [
 	"This tests may loop endlessly if incorrect, so call it from another method testing it does not time out"
-	
-	self assert: 30 equals: ([:a :first | |b| 
-		self assert: 10 = a .
-		self assert: nil == b.
-		b := a + 20. 
-		first ifTrue: [
-			"Cheat and modify one of the args so we will not loop endlessly"
-			 thisContext tempAt: 2 put: false.
-			thisContext restart.].
-		b] value: 10 value: true)
 
+	self
+		assert: 30
+		equals:
+			([ :a :first | 
+			| b |
+			self assert: 10 equals: a.
+			self assert: nil identicalTo: b.
+			b := a + 20.
+			first
+				ifTrue: [ "Cheat and modify one of the args so we will not loop endlessly"
+					thisContext tempAt: 2 put: false.
+					thisContext restart ].
+			b ] value: 10 value: true)
 ]
 
 { #category : #private }
 ContextTest >> privRestartBlockTest [
 	"This tests may loop endlessly if incorrect, so call it from another method testing it does not time out"
-	|a firstTimeThrough |
+
+	| a firstTimeThrough |
 	firstTimeThrough := true.
 	a := 10.
-	
-	self assert: 30 equals: [|b| 
-		self assert: 10 = a .
-		self assert: nil == b.
-		b := a + 20. 
-		firstTimeThrough ifTrue: [
-			firstTimeThrough := false.
-			thisContext restart.].
-		b] value
 
+	self
+		assert: 30
+		equals:
+			[ | b |
+			self assert: 10 equals: a.
+			self assert: nil identicalTo: b.
+			b := a + 20.
+			firstTimeThrough
+				ifTrue: [ firstTimeThrough := false.
+					thisContext restart ].
+			b ] value
 ]
 
 { #category : #running }
@@ -189,8 +199,7 @@ ContextTest >> verifyJumpWithSelector: selector [
 	normalStackp := (guineaPig perform: selector) stackPtr.
 	guineaPig beReadOnlyObject.
 	[ readOnlyStackp := (guineaPig perform: selector) stackPtr ]
-		on: ModificationForbidden 
+		on: ModificationForbidden
 		do: [ :ex | ex resumeUnchecked: nil ].
-	self assert: normalStackp = readOnlyStackp.
-	
+	self assert: normalStackp equals: readOnlyStackp
 ]

--- a/src/Kernel-Tests/FractionTest.class.st
+++ b/src/Kernel-Tests/FractionTest.class.st
@@ -9,8 +9,8 @@ Class {
 
 { #category : #private }
 FractionTest >> assert: a classAndValueEquals: b [
-	self assert: a class = b class.
-	self assert: a = b
+	self assert: a class equals: b class.
+	self assert: a equals: b
 ]
 
 { #category : #'tests - conversions' }

--- a/src/Kernel-Tests/IntegerTest.class.st
+++ b/src/Kernel-Tests/IntegerTest.class.st
@@ -9,8 +9,8 @@ Class {
 
 { #category : #private }
 IntegerTest >> assert: a classAndValueEquals: b [
-	self assert: a class = b class.
-	self assert: a = b
+	self assert: a class equals: b class.
+	self assert: a equals: b
 ]
 
 { #category : #'tests - basic' }

--- a/src/Kernel-Tests/ProcessSpecificTest.class.st
+++ b/src/Kernel-Tests/ProcessSpecificTest.class.st
@@ -10,12 +10,12 @@ Class {
 
 { #category : #testing }
 ProcessSpecificTest >> checkDynamic: value [
-	self assert: TestDynamicVariable value = value
+	self assert: TestDynamicVariable value equals: value
 ]
 
 { #category : #testing }
 ProcessSpecificTest >> checkLocal: value [
-	self assert: TestLocalVariable value = value
+	self assert: TestLocalVariable value equals: value
 ]
 
 { #category : #testing }

--- a/src/Metacello-TestsCore/MetacelloStackCacheTestCase.class.st
+++ b/src/Metacello-TestsCore/MetacelloStackCacheTestCase.class.st
@@ -69,35 +69,33 @@ MetacelloStackCacheTestCase >> directReturnOfValue [
 
 { #category : #tests }
 MetacelloStackCacheTestCase >> mixedStack [
-
-	^MetacelloPlatform current 
+	^ MetacelloPlatform current
 		stackCacheFor: #mixed
-		at: #key 
-		doing: [:cache | | value |
+		at: #key
+		doing: [ :cache | 
+			| value |
 			value := cache at: #x ifAbsent: [ 0 ].
-			value > 3 ifTrue: [ ^value ].
+			value > 3 ifTrue: [ ^ value ].
 			value := value + 1.
 			cache at: #x put: value.
-			self assert: self directReturnOfValue == 6.
-			self assert: self mixedStackCall == 4.
+			self assert: self directReturnOfValue identicalTo: 6.
+			self assert: self mixedStackCall identicalTo: 4.
 			self mixedStack ]
-
 ]
 
 { #category : #tests }
 MetacelloStackCacheTestCase >> mixedStackCall [
-
-	^MetacelloPlatform current 
+	^ MetacelloPlatform current
 		stackCacheFor: #mixedStack
-		at: #key 
-		doing: [:cache | | value |
+		at: #key
+		doing: [ :cache | 
+			| value |
 			value := cache at: #x ifAbsent: [ 0 ].
-			value > 3 ifTrue: [ ^value ].
+			value > 3 ifTrue: [ ^ value ].
 			value := value + 1.
 			cache at: #x put: value.
-			self assert: self cachedReturnOfValue == 6.
+			self assert: self cachedReturnOfValue identicalTo: 6.
 			self mixedStackCall ]
-
 ]
 
 { #category : #tests }

--- a/src/Metacello-TestsMC/MetacelloScriptingStdTstHarnessTestCase.class.st
+++ b/src/Metacello-TestsMC/MetacelloScriptingStdTstHarnessTestCase.class.st
@@ -126,27 +126,22 @@ MetacelloScriptingStdTstHarnessTestCase >> unloadPackage: packageName [
 
 { #category : #utilities }
 MetacelloScriptingStdTstHarnessTestCase >> validate: expectedConfigurationClassName expConfigVersion: expectedConfigurationVersion expConfigRepo: expectedConfigurationRepository expBaselineClassName: expectedBaselineClassName expBaselineVersion: expectedBaselineVersion expBaselineRepo: expectedBaselineRepository [
-  MetacelloProjectRegistration registry configurationRegistry
-    at: expectedConfigurationClassName
-    ifPresent: [ :existing | 
-      | spec x |
-      spec := existing configurationProjectSpec.
-      self
-        assert: (x := spec version versionString) = expectedConfigurationVersion.
-      self
-        assert:
-          (spec repositoryDescriptions includes: expectedConfigurationRepository) ]
-    ifAbsent: [ self assert: expectedConfigurationVersion == nil ].
-  MetacelloProjectRegistration registry baselineRegistry
-    at: expectedBaselineClassName
-    ifPresent: [ :existing | 
-      | spec |
-      spec := existing baselineProjectSpec.
-      self assert: spec versionString = expectedBaselineVersion.
-      self
-        assert:
-          (spec repositoryDescriptions includes: expectedBaselineRepository) ]
-    ifAbsent: [ self assert: expectedBaselineVersion == nil ]
+	MetacelloProjectRegistration registry configurationRegistry
+		at: expectedConfigurationClassName
+		ifPresent: [ :existing | 
+			| spec x |
+			spec := existing configurationProjectSpec.
+			self assert: (x := spec version versionString) equals: expectedConfigurationVersion.
+			self assert: (spec repositoryDescriptions includes: expectedConfigurationRepository) ]
+		ifAbsent: [ self assert: expectedConfigurationVersion identicalTo: nil ].
+	MetacelloProjectRegistration registry baselineRegistry
+		at: expectedBaselineClassName
+		ifPresent: [ :existing | 
+			| spec |
+			spec := existing baselineProjectSpec.
+			self assert: spec versionString equals: expectedBaselineVersion.
+			self assert: (spec repositoryDescriptions includes: expectedBaselineRepository) ]
+		ifAbsent: [ self assert: expectedBaselineVersion identicalTo: nil ]
 ]
 
 { #category : #utilities }
@@ -174,12 +169,12 @@ MetacelloScriptingStdTstHarnessTestCase >> verify: packageName loadedFrom: repos
 
 { #category : #utilities }
 MetacelloScriptingStdTstHarnessTestCase >> verify: packageName version: fileName [
-    | externalCoreWorkingCopy x |
-    externalCoreWorkingCopy := MCWorkingCopy allManagers detect: [ :wc | wc packageName = packageName ].
-    self assert: (x := externalCoreWorkingCopy ancestors first name) = fileName
+	| externalCoreWorkingCopy x |
+	externalCoreWorkingCopy := MCWorkingCopy allManagers detect: [ :wc | wc packageName = packageName ].
+	self assert: (x := externalCoreWorkingCopy ancestors first name) equals: fileName
 ]
 
 { #category : #utilities }
 MetacelloScriptingStdTstHarnessTestCase >> verifyPackageNotLoaded: packageName [
-    self assert: (MCWorkingCopy allManagers detect: [ :wc | wc packageName = packageName ] ifNone: [  ]) == nil
+	self assert: (MCWorkingCopy allManagers detect: [ :wc | wc packageName = packageName ] ifNone: [  ]) identicalTo: nil
 ]

--- a/src/Monticello-Tests/MCAncestryTest.class.st
+++ b/src/Monticello-Tests/MCAncestryTest.class.st
@@ -23,9 +23,9 @@ MCAncestryTest >> assertCommonAncestorOf: leftName and: rightName is: ancestorNa
 { #category : #asserting }
 MCAncestryTest >> assertNamesOf: versionInfoCollection are: nameArray [
 	| names |
-	names := versionInfoCollection collect: [:ea | ea name].
-	
-	self assert: names asArray = nameArray
+	names := versionInfoCollection collect: [ :ea | ea name ].
+
+	self assert: names asArray equals: nameArray
 ]
 
 { #category : #asserting }

--- a/src/Monticello-Tests/MCDependencySorterTest.class.st
+++ b/src/Monticello-Tests/MCDependencySorterTest.class.st
@@ -17,15 +17,15 @@ MCDependencySorterTest >> assertItems: anArray orderAs: depOrder withRequired: m
 { #category : #asserting }
 MCDependencySorterTest >> assertItems: anArray orderAs: depOrder withRequired: missingDeps toLoad: unloadableItems extraProvisions: provisions [
 	| order sorter items missing unloadable |
-	items := anArray collect: [:ea | self itemWithSpec: ea].
+	items := anArray collect: [ :ea | self itemWithSpec: ea ].
 	sorter := MCDependencySorter items: items.
 	sorter addExternalProvisions: provisions.
-	order := (sorter orderedItems collect: [:ea | ea name]) asArray.
-	self assert: order = depOrder.
+	order := (sorter orderedItems collect: [ :ea | ea name ]) asArray.
+	self assert: order equals: depOrder.
 	missing := sorter externalRequirements.
-	self assert: missing asSet = missingDeps asSet.
-	unloadable := (sorter itemsWithMissingRequirements collect: [:ea | ea name]) asArray.
-	self assert: unloadable asSet = unloadableItems asSet
+	self assert: missing asSet equals: missingDeps asSet.
+	unloadable := (sorter itemsWithMissingRequirements collect: [ :ea | ea name ]) asArray.
+	self assert: unloadable asSet equals: unloadableItems asSet
 ]
 
 { #category : #building }

--- a/src/Monticello-Tests/MCFileInTest.class.st
+++ b/src/Monticello-Tests/MCFileInTest.class.st
@@ -28,16 +28,14 @@ MCFileInTest >> assertFileOutFrom: writerClass canBeFiledInWith: aBlock [
 MCFileInTest >> assertInitializersCalled [
 	| cvar |
 	cvar := self mockClassA cVar.
-	self assert: cvar = #initialized
+	self assert: cvar equals: #initialized
 ]
 
 { #category : #testing }
 MCFileInTest >> assertInitializersOrder [
-
 	| initializationOrder |
 	initializationOrder := self mockClassA initializationOrder.
-	self assert: initializationOrder = 2.	
-
+	self assert: initializationOrder equals: 2
 ]
 
 { #category : #asserting }

--- a/src/Monticello-Tests/MCMergingTest.class.st
+++ b/src/Monticello-Tests/MCMergingTest.class.st
@@ -9,20 +9,17 @@ Class {
 
 { #category : #asserting }
 MCMergingTest >> assert: aCollection hasElements: anArray [
-	self assert: (aCollection collect: [:ea | ea token]) asSet = anArray asSet
+	self assert: (aCollection collect: [ :ea | ea token ]) asSet equals: anArray asSet
 ]
 
 { #category : #asserting }
 MCMergingTest >> assertMerge: local with: remote base: ancestor gives: result conflicts: conflictResult [
 	| merger |
 	conflicts := #().
-	merger := MCThreeWayMerger
-				base: (self snapshotWithElements: local)
-				target: (self snapshotWithElements: remote)
-				ancestor: (self snapshotWithElements: ancestor).
-	merger conflicts do: [:ea | self handleConflict: ea].
+	merger := MCThreeWayMerger base: (self snapshotWithElements: local) target: (self snapshotWithElements: remote) ancestor: (self snapshotWithElements: ancestor).
+	merger conflicts do: [ :ea | self handleConflict: ea ].
 	self assert: merger mergedSnapshot definitions hasElements: result.
-	self assert: conflicts asSet = conflictResult asSet.
+	self assert: conflicts asSet equals: conflictResult asSet
 ]
 
 { #category : #emulating }

--- a/src/Monticello-Tests/MCRepositoryTest.class.st
+++ b/src/Monticello-Tests/MCRepositoryTest.class.st
@@ -35,7 +35,7 @@ MCRepositoryTest >> assertMissing: aVersionInfo [
 
 { #category : #asserting }
 MCRepositoryTest >> assertVersionInfos: aCollection [
-	self assert: repository allVersionInfos asSet = aCollection asSet
+	self assert: repository allVersionInfos asSet equals: aCollection asSet
 ]
 
 { #category : #'tests-input data' }

--- a/src/Monticello-Tests/MCScannerTest.class.st
+++ b/src/Monticello-Tests/MCScannerTest.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #asserting }
 MCScannerTest >> assertScans: anArray [
-	self assert: (MCScanner scan: anArray printString readStream) = anArray
+	self assert: (MCScanner scan: anArray printString readStream) equals: anArray
 ]
 
 { #category : #tests }

--- a/src/Monticello-Tests/MCStWriterTest.class.st
+++ b/src/Monticello-Tests/MCStWriterTest.class.st
@@ -25,11 +25,11 @@ MCStWriterTest >> assertChunkIsWellFormed: chunk [
 ]
 
 { #category : #asserting }
-MCStWriterTest >> assertContentsOf: strm match: expected [ 
+MCStWriterTest >> assertContentsOf: strm match: expected [
 	| actual |
 	actual := strm contents.
-	self assert: actual size = expected size.
-	actual with: expected do: [:a :e | self assert: a = e]
+	self assert: actual size equals: expected size.
+	actual with: expected do: [ :a :e | self assert: a equals: e ]
 ]
 
 { #category : #asserting }

--- a/src/Monticello-Tests/MCTestCase.class.st
+++ b/src/Monticello-Tests/MCTestCase.class.st
@@ -24,8 +24,7 @@ MCTestCase class >> resources [
 
 { #category : #asserting }
 MCTestCase >> assertPackage: actual matches: expected [
-	self assert: actual = expected
-
+	self assert: actual equals: expected
 ]
 
 { #category : #asserting }
@@ -45,11 +44,10 @@ MCTestCase >> assertVersion: actual matches: expected [
 
 { #category : #asserting }
 MCTestCase >> assertVersionInfo: actual matches: expected [
-	self assert: actual name = expected name.
-	self assert: actual message = expected message.
-	self assert: actual ancestors size = expected ancestors size.
-	actual ancestors with: expected ancestors do: [:a :e | self assertVersionInfo: a matches: e]
-	
+	self assert: actual name equals: expected name.
+	self assert: actual message equals: expected message.
+	self assert: actual ancestors size equals: expected ancestors size.
+	actual ancestors with: expected ancestors do: [ :a :e | self assertVersionInfo: a matches: e ]
 ]
 
 { #category : #compiling }

--- a/src/Monticello-Tests/MCVersionTest.class.st
+++ b/src/Monticello-Tests/MCVersionTest.class.st
@@ -13,8 +13,8 @@ MCVersionTest >> assert: aSelector orders: sexpr as: array [
 	| expected |
 	expected := OrderedCollection new.
 	version := self versionFromTree: sexpr.
-	version perform: aSelector with: [:ea | expected add: ea info name].
-	self assert: expected asArray = array
+	version perform: aSelector with: [ :ea | expected add: ea info name ].
+	self assert: expected asArray equals: array
 ]
 
 { #category : #asserting }
@@ -22,12 +22,9 @@ MCVersionTest >> assert: aSelector orders: sexpr as: expected unresolved: unreso
 	| missing |
 	missing := OrderedCollection new.
 	version := self versionFromTree: sexpr.
-	version 
-		perform: aSelector 
-		with: [:ea | visited add: ea info name]
-		with: [:ea | missing add: ea name].
-	self assert: visited asArray = expected.
-	self assert: missing asArray = unresolved.
+	version perform: aSelector with: [ :ea | visited add: ea info name ] with: [ :ea | missing add: ea name ].
+	self assert: visited asArray equals: expected.
+	self assert: missing asArray equals: unresolved
 ]
 
 { #category : #building }

--- a/src/Monticello-Tests/MCWorkingCopyTest.class.st
+++ b/src/Monticello-Tests/MCWorkingCopyTest.class.st
@@ -15,20 +15,24 @@ Class {
 MCWorkingCopyTest >> assertNameWhenSavingTo: aRepository is: aString [
 	| name |
 	name := nil.
-	[aRepository storeVersion: (workingCopy newVersionIn: aRepository)]
+	[ aRepository storeVersion: (workingCopy newVersionIn: aRepository) ]
 		on: MCVersionNameAndMessageRequest
-		do: [:n | name := n suggestedName. n resume: (Array with: name with: '')].
-	self assert: name = aString
+		do: [ :n | 
+			name := n suggestedName.
+			n resume: (Array with: name with: '') ].
+	self assert: name equals: aString
 ]
 
 { #category : #asserting }
 MCWorkingCopyTest >> assertNumberWhenSavingTo: aRepository is: aNumber [
 	| name |
 	name := nil.
-	[aRepository storeVersion: (workingCopy newVersionIn: aRepository)]
+	[ aRepository storeVersion: (workingCopy newVersionIn: aRepository) ]
 		on: MCVersionNameAndMessageRequest
-		do: [:n | name := n suggestedName. n resume: (Array with: name with: '')].
-	self assert: name = (self packageName, '-', Author fullName, '.', aNumber asString)
+		do: [ :n | 
+			name := n suggestedName.
+			n resume: (Array with: name with: '') ].
+	self assert: name equals: self packageName , '-' , Author fullName , '.' , aNumber asString
 ]
 
 { #category : #actions }

--- a/src/OpalCompiler-Tests/MethodPragmaTest.class.st
+++ b/src/OpalCompiler-Tests/MethodPragmaTest.class.st
@@ -9,11 +9,10 @@ Class {
 
 { #category : #utilities }
 MethodPragmaTest >> assertPragma: aString givesKeyword: aSymbol arguments: anArray [
-	| pragma  |
+	| pragma |
 	pragma := self pragma: aString selector: #zork.
-	self assert: pragma selector = aSymbol.
-	self assert: pragma arguments = anArray.
-
+	self assert: pragma selector equals: aSymbol.
+	self assert: pragma arguments equals: anArray
 ]
 
 { #category : #utilities }

--- a/src/OpalCompiler-Tests/OCBytecodeDecompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeDecompilerTest.class.st
@@ -85,69 +85,71 @@ OCBytecodeDecompilerTest >> pushClosureCopyOneCopiedTemp [
 
 { #category : #examples }
 OCBytecodeDecompilerTest >> remoteTemp [
-
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
-		createTempVectorNamed:#methodVector withVars: #(b);      "b we know will be written to, so make a tempvector entry" 
-		addTemps: #(a);  "we have one real temp"
-		pushLiteral: 1;
+		createTempVectorNamed: #methodVector withVars: #(b);
+		"b we know will be written to, so make a tempvector entry"
+			addTemps: #(a);
+		"we have one real temp"
+			pushLiteral: 1;
 		storeTemp: #a;
 		popTop;
 		pushClosureCopyCopiedValues: #(#a #methodVector) args: #() jumpTo: #block;
-			pushTemp: #a;                                                                                             "a is just read, so we copy it to the block"
+		pushTemp: #a;
+		"a is just read, so we copy it to the block"
 			pushLiteral: 1;
-			send: #+;
-			storeRemoteTemp: #b inVector: #methodVector;							      "b comes from tempvetor, as we do write to it"
-	     	 	blockReturnTop;
-		jumpAheadTarget: #block;	
+		send: #+;
+		storeRemoteTemp: #b inVector: #methodVector;
+		"b comes from tempvetor, as we do write to it"
+			blockReturnTop;
+		jumpAheadTarget: #block;
 		send: #value;
-		pushRemoteTemp: #b inVector: #methodVector;				
+		pushRemoteTemp: #b inVector: #methodVector;
 		returnTop;
 		ir.
-	
+
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #() ) = 2).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: 2.
+	^ iRMethod
 ]
 
 { #category : #examples }
 OCBytecodeDecompilerTest >> remoteTempNested [
-
 	| iRMethod aCompiledMethod |
-
 	iRMethod := IRBuilder new
-		createTempVectorNamed:#methodVector withVars: #(b);      "b we know will be written to, so make a tempvector entry" 
-		addTemps: #(a);  "we have one real temp"
-		
-		pushLiteral: 1;
+		createTempVectorNamed: #methodVector withVars: #(b);
+		"b we know will be written to, so make a tempvector entry"
+			addTemps: #(a);
+		"we have one real temp"
+			pushLiteral: 1;
 		storeTemp: #a;
 		popTop;
 		pushClosureCopyCopiedValues: #(methodVector a) args: #() jumpTo: #block;
-		createTempVectorNamed:#blockVector withVars: #(f);    
-			pushTemp: #a;                                                                                             "a is just read, so we copy it to the block"
-				pushClosureCopyCopiedValues: #(methodVector) args: #()  jumpTo: #block2;
-				pushLiteral: 1;
-				storeRemoteTemp: #b inVector: #methodVector;							      "f comes from tempvetor, as we do write to it"
-				blockReturnTop;		
-				jumpAheadTarget: #block2;	
-			send: #value;
-			send: #+;
-			storeRemoteTemp: #b inVector: #methodVector;							      "b comes from tempvetor, as we do write to it"
-	     	 	blockReturnTop;
-			
-		jumpAheadTarget: #block;	
+		createTempVectorNamed: #blockVector withVars: #(f);
+		pushTemp: #a;
+		"a is just read, so we copy it to the block"
+			pushClosureCopyCopiedValues: #(methodVector) args: #() jumpTo: #block2;
+		pushLiteral: 1;
+		storeRemoteTemp: #b inVector: #methodVector;
+		"f comes from tempvetor, as we do write to it"
+			blockReturnTop;
+		jumpAheadTarget: #block2;
 		send: #value;
-		pushRemoteTemp: #b inVector: #methodVector;				
+		send: #+;
+		storeRemoteTemp: #b inVector: #methodVector;
+		"b comes from tempvetor, as we do write to it"
+			blockReturnTop;
+		jumpAheadTarget: #block;
+		send: #value;
+		pushRemoteTemp: #b inVector: #methodVector;
 		returnTop;
 		ir.
-	
+
 	aCompiledMethod := iRMethod compiledMethod.
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: ((aCompiledMethod valueWithReceiver: nil arguments: #()) = 2).
-	^iRMethod
-	
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: 2.
+	^ iRMethod
 ]
 
 { #category : #running }

--- a/src/OpalCompiler-Tests/OCClosureCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCClosureCompilerTest.class.st
@@ -289,38 +289,40 @@ mn generate: #(0 0 0 0).
 ]
 
 { #category : #tests }
-OCClosureCompilerTest >> doTestDebuggerTempAccessWith: one with: two [ 
+OCClosureCompilerTest >> doTestDebuggerTempAccessWith: one with: two [
 	"Test debugger access for temps"
+
 	| outerContext local1 remote1 |
 	outerContext := thisContext.
 	local1 := 3.
-	remote1 := 1/2.
-	self assert: (self evaluate: 'one' in: thisContext to: self) == one.
-	self assert: (self  evaluate: 'two' in: thisContext to: self) == two.
-	self assert: (self  evaluate: 'local1' in: thisContext to: self) == local1.
-	self assert: (self  evaluate: 'remote1' in: thisContext to: self) == remote1.
-	self  evaluate: 'local1 := -3.0' in: thisContext to: self.
-	self assert: local1 = -3.0.
-	(1 to: 2) do:
-		[:i| | local2 r1 r2 r3 r4 |
-		local2 := i * 3.
-		remote1 := local2 / 7.
-		self assert: thisContext ~~ outerContext.
-		self assert: (r1 := self  evaluate: 'one' in: thisContext to: self) == one.
-		self assert: (r2 := self  evaluate: 'two' in: thisContext to: self) == two.
-		self assert: (r3 := self  evaluate: 'i' in: thisContext to: self) == i.
-		self assert: (r4 := self  evaluate: 'local2' in: thisContext to: self) == local2.
-		self assert: (r4 := self  evaluate: 'remote1' in: thisContext to: self) == remote1.
-		self assert: (r4 := self  evaluate: 'remote1' in: outerContext to: self) == remote1.
-		self  evaluate: 'local2 := 15' in: thisContext to: self.
-		self assert: local2 = 15.
-		self  evaluate: 'local1 := 25' in: thisContext to: self.
-		self assert: local1 = 25.
-		{ r1. r2. r3. r4 } "placate the compiler"].
-	self assert: local1 = 25.
+	remote1 := 1 / 2.
+	self assert: (self evaluate: 'one' in: thisContext to: self) identicalTo: one.
+	self assert: (self evaluate: 'two' in: thisContext to: self) identicalTo: two.
+	self assert: (self evaluate: 'local1' in: thisContext to: self) identicalTo: local1.
+	self assert: (self evaluate: 'remote1' in: thisContext to: self) identicalTo: remote1.
+	self evaluate: 'local1 := -3.0' in: thisContext to: self.
+	self assert: local1 equals: -3.0.
+	(1 to: 2)
+		do: [ :i | 
+			| local2 r1 r2 r3 r4 |
+			local2 := i * 3.
+			remote1 := local2 / 7.
+			self assert: thisContext ~~ outerContext.
+			self assert: (r1 := self evaluate: 'one' in: thisContext to: self) identicalTo: one.
+			self assert: (r2 := self evaluate: 'two' in: thisContext to: self) identicalTo: two.
+			self assert: (r3 := self evaluate: 'i' in: thisContext to: self) identicalTo: i.
+			self assert: (r4 := self evaluate: 'local2' in: thisContext to: self) identicalTo: local2.
+			self assert: (r4 := self evaluate: 'remote1' in: thisContext to: self) identicalTo: remote1.
+			self assert: (r4 := self evaluate: 'remote1' in: outerContext to: self) identicalTo: remote1.
+			self evaluate: 'local2 := 15' in: thisContext to: self.
+			self assert: local2 equals: 15.
+			self evaluate: 'local1 := 25' in: thisContext to: self.
+			self assert: local1 equals: 25.
+			{r1 . r2 . r3 . r4}	"placate the compiler" ].
+	self assert: local1 equals: 25.
 	"this is 25 even though the var is a local, non escaping variable that was copied into the block.
-	But the DoIt compiles temp acces using #tempAt:put:, which updates the copies and the original".
-	self assert: remote1 = (6/7)
+	But the DoIt compiles temp acces using #tempAt:put:, which updates the copies and the original"
+	self assert: remote1 equals: 6 / 7
 ]
 
 { #category : #running }

--- a/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
@@ -42,11 +42,11 @@ Class {
 
 { #category : #private }
 OCCompilerNotifyingTest >> enumerateAllSelections [
-	1 to: self numberOfSelections do: [:n |
-		self assert: (self evaluateSelectionNumber: n) == failure.
-		self assert: morph editor selection asString equals: (expectedErrors at: n).  
+	1 to: self numberOfSelections do: [ :n | 
+		self assert: (self evaluateSelectionNumber: n) identicalTo: failure.
+		self assert: morph editor selection asString equals: (expectedErrors at: n).
 		self assert: (expectedErrorPositions at: n) equals: morph editor startIndex.
-		morph editor cut].
+		morph editor cut ]
 ]
 
 { #category : #private }

--- a/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
+++ b/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
@@ -43,9 +43,9 @@ RBBrowserEnvironmentTest >> classNamesFor: anEnvironment [
 		addAll: anEnvironment not classNames;
 		yourself.
 	allClassNames := universalEnvironment classNames asSortedCollection.
-	self assert: classNames asSortedCollection = allClassNames.
+	self assert: classNames asSortedCollection equals: allClassNames.
 	self assertEmpty: (anEnvironment & anEnvironment not) classNames.
-	self assert: (anEnvironment | anEnvironment not) classNames asSortedCollection = allClassNames
+	self assert: (anEnvironment | anEnvironment not) classNames asSortedCollection equals: allClassNames
 ]
 
 { #category : #mockup }
@@ -68,11 +68,11 @@ RBBrowserEnvironmentTest >> classesFor: aBrowserEnvironment [
 ]
 
 { #category : #private }
-RBBrowserEnvironmentTest >> copyFor: aBrowserEnvironment [ 
+RBBrowserEnvironmentTest >> copyFor: aBrowserEnvironment [
 	| newEnvironment |
 	newEnvironment := aBrowserEnvironment copy.
-	self assert: newEnvironment numberSelectors = aBrowserEnvironment numberSelectors.
-	self assert: (newEnvironment not & aBrowserEnvironment) numberSelectors = 0
+	self assert: newEnvironment numberSelectors equals: aBrowserEnvironment numberSelectors.
+	self assert: (newEnvironment not & aBrowserEnvironment) numberSelectors equals: 0
 ]
 
 { #category : #private }
@@ -97,10 +97,10 @@ RBBrowserEnvironmentTest >> numberSelectorsFor: aBrowserEnvironment [
 	| numberSelectors numberSelectorsNot |
 	numberSelectors := aBrowserEnvironment numberSelectors.
 	numberSelectorsNot := aBrowserEnvironment not numberSelectors.
-	self assert: numberSelectors + numberSelectorsNot = universalEnvironment numberSelectors.
-	self assert: (aBrowserEnvironment & aBrowserEnvironment not) numberSelectors = 0.
-	self assert: (universalEnvironment & aBrowserEnvironment) numberSelectors = numberSelectors.
-	self assert: (aBrowserEnvironment & universalEnvironment) numberSelectors = numberSelectors
+	self assert: numberSelectors + numberSelectorsNot equals: universalEnvironment numberSelectors.
+	self assert: (aBrowserEnvironment & aBrowserEnvironment not) numberSelectors equals: 0.
+	self assert: (universalEnvironment & aBrowserEnvironment) numberSelectors equals: numberSelectors.
+	self assert: (aBrowserEnvironment & universalEnvironment) numberSelectors equals: numberSelectors
 ]
 
 { #category : #private }
@@ -513,7 +513,7 @@ RBBrowserEnvironmentTest >> uniqueClassesIn: aBrowserEnvironment [
 ]
 
 { #category : #private }
-RBBrowserEnvironmentTest >> universalTestFor: aBrowserEnvironment [ 
+RBBrowserEnvironmentTest >> universalTestFor: aBrowserEnvironment [
 	self labelFor: aBrowserEnvironment.
 	self uniqueClassesIn: aBrowserEnvironment.
 	self numberSelectorsFor: aBrowserEnvironment.
@@ -524,5 +524,5 @@ RBBrowserEnvironmentTest >> universalTestFor: aBrowserEnvironment [
 	self protocolsFor: aBrowserEnvironment.
 	self classesFor: aBrowserEnvironment.
 	self keysFor: aBrowserEnvironment.
-	self assert: aBrowserEnvironment problemCount = 0 = aBrowserEnvironment isEmpty
+	self assert: aBrowserEnvironment problemCount = 0 equals: aBrowserEnvironment isEmpty
 ]

--- a/src/Ring-Tests-Core/RGEnvironmentBackendTest.class.st
+++ b/src/Ring-Tests-Core/RGEnvironmentBackendTest.class.st
@@ -14,22 +14,19 @@ RGEnvironmentBackendTest >> backendClass [
 
 { #category : #'as yet unclassified' }
 RGEnvironmentBackendTest >> checkHierarchyConsistencyOf: anRGClass [
+	self assert: anRGClass ~~ anRGClass superclass.
+	self assert: anRGClass ~~ anRGClass metaclass.
+	self assert: anRGClass ~~ anRGClass superclass metaclass.
 
-	self assert: (anRGClass ~~ anRGClass superclass).
-	self assert: (anRGClass ~~ anRGClass metaclass).
-	self assert: (anRGClass ~~ anRGClass superclass metaclass).
+	self assert: anRGClass superclass ~~ anRGClass metaclass.
+	self assert: anRGClass superclass ~~ anRGClass superclass metaclass.
+	self assert: anRGClass metaclass ~~ anRGClass superclass metaclass.
 
-	self assert: (anRGClass superclass ~~ anRGClass metaclass).
-	self assert: (anRGClass superclass ~~ anRGClass superclass metaclass).
-	self assert: (anRGClass metaclass ~~ anRGClass superclass metaclass).
+	self assert: anRGClass superclass superclass identicalTo: anRGClass superclass.
+	self assert: anRGClass superclass metaclass identicalTo: anRGClass metaclass superclass.
 
-	self assert: (anRGClass superclass superclass == anRGClass superclass).
-	self assert: (anRGClass superclass metaclass == anRGClass metaclass superclass).
-
-	self assert: (anRGClass superclass metaclass superclass == anRGClass superclass metaclass).
-	self assert: (anRGClass superclass metaclass metaclass == anRGClass superclass metaclass).
-	
-
+	self assert: anRGClass superclass metaclass superclass identicalTo: anRGClass superclass metaclass.
+	self assert: anRGClass superclass metaclass metaclass identicalTo: anRGClass superclass metaclass
 ]
 
 { #category : #tests }

--- a/src/Ring-Tests-Core/RGTest.class.st
+++ b/src/Ring-Tests-Core/RGTest.class.st
@@ -17,24 +17,21 @@ RGTest >> checkClassesConsistency: object1 and: object2 [
 
 { #category : #utilities }
 RGTest >> checkHierarchyConsistencyOf: anRGClass [
-
 	"prove that all relations between class, superclass, metaclass and superclass metaclass are consistent"
 
-	self assert: (anRGClass ~~ anRGClass superclass).
-	self assert: (anRGClass ~~ anRGClass metaclass).
-	self assert: (anRGClass ~~ anRGClass superclass metaclass).
+	self assert: anRGClass ~~ anRGClass superclass.
+	self assert: anRGClass ~~ anRGClass metaclass.
+	self assert: anRGClass ~~ anRGClass superclass metaclass.
 
-	self assert: (anRGClass superclass ~~ anRGClass metaclass).
-	self assert: (anRGClass superclass ~~ anRGClass superclass metaclass).
-	self assert: (anRGClass metaclass ~~ anRGClass superclass metaclass).
+	self assert: anRGClass superclass ~~ anRGClass metaclass.
+	self assert: anRGClass superclass ~~ anRGClass superclass metaclass.
+	self assert: anRGClass metaclass ~~ anRGClass superclass metaclass.
 
-	self assert: (anRGClass superclass superclass == anRGClass superclass).
-	self assert: (anRGClass superclass metaclass == anRGClass metaclass superclass).
+	self assert: anRGClass superclass superclass identicalTo: anRGClass superclass.
+	self assert: anRGClass superclass metaclass identicalTo: anRGClass metaclass superclass.
 
-	self assert: (anRGClass superclass metaclass superclass == anRGClass superclass metaclass).
-	self assert: (anRGClass superclass metaclass metaclass == anRGClass superclass metaclass).
-	
-
+	self assert: anRGClass superclass metaclass superclass identicalTo: anRGClass superclass metaclass.
+	self assert: anRGClass superclass metaclass metaclass identicalTo: anRGClass superclass metaclass
 ]
 
 { #category : #utilities }
@@ -58,20 +55,14 @@ RGTest >> checkImplicitSingleClassEnvironmentOf: anRGClass [
 
 { #category : #utilities }
 RGTest >> checkImplicitSingleTraitEnvironmentOf: anRGTrait [
-	
 	self assert: anRGTrait environment ask behaviors size equals: 10.
 	self assert: anRGTrait environment ask packages size equals: 5.
 
 	self checkHierarchyConsistencyOf: anRGTrait metaclass.
-	
-	self assert: (anRGTrait ~~ anRGTrait classTrait).
-	self assert: (anRGTrait superclass == anRGTrait superclass).
-	self assert: (anRGTrait classTrait superclass == anRGTrait classTrait superclass).
-	
-	
-	
-	
 
+	self assert: anRGTrait ~~ anRGTrait classTrait.
+	self assert: anRGTrait superclass identicalTo: anRGTrait superclass.
+	self assert: anRGTrait classTrait superclass identicalTo: anRGTrait classTrait superclass
 ]
 
 { #category : #tests }

--- a/src/SUnit-Tests/ClassFactoryWithOrganizationTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryWithOrganizationTest.class.st
@@ -17,7 +17,7 @@ ClassFactoryWithOrganizationTest class >> defaultTimeLimit [
 
 { #category : #testing }
 ClassFactoryWithOrganizationTest >> assertEnvironmentOf: aBehavior [
-	self assert: aBehavior environment = self testedEnvironment
+	self assert: aBehavior environment equals: self testedEnvironment
 ]
 
 { #category : #running }

--- a/src/SUnit-Tests/SUnitExtensionsTest.class.st
+++ b/src/SUnit-Tests/SUnitExtensionsTest.class.st
@@ -84,20 +84,12 @@ SUnitExtensionsTest >> shouldFixTest [
 
 { #category : #'real tests' }
 SUnitExtensionsTest >> shouldRaiseWithExceptionDoTest [
-
-	self 
-		should: [ Error signal: '1' ]
-		raise: Error
-		withExceptionDo: [ :anException | self assert: anException messageText = '1' ]
+	self should: [ Error signal: '1' ] raise: Error withExceptionDo: [ :anException | self assert: anException messageText equals: '1' ]
 ]
 
 { #category : #'real tests' }
 SUnitExtensionsTest >> shouldRaiseWithSignalDoTest [
-
-	self 
-		should: [ Error signal: '1' ]
-		raise: Error
-		withExceptionDo: [ :anException | self assert: anException messageText = '1' ]
+	self should: [ Error signal: '1' ] raise: Error withExceptionDo: [ :anException | self assert: anException messageText equals: '1' ]
 ]
 
 { #category : #accessing }
@@ -128,7 +120,7 @@ SUnitExtensionsTest >> testAutoAssertFalse [
 
 { #category : #test }
 SUnitExtensionsTest >> testAutoAssertTrue [
-	self assert: 1 = 1.
+	self assert: 1 equals: 1.
 	self assert: true
 ]
 
@@ -143,7 +135,7 @@ SUnitExtensionsTest >> testAutoDenyFalse [
 
 { #category : #test }
 SUnitExtensionsTest >> testAutoDenyTrue [
-	self deny: 1 = 2.
+	self deny: 1 equals: 2.
 	self deny: false
 ]
 

--- a/src/Shift-ClassBuilder-Tests/ShAbstractClassBuilderTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShAbstractClassBuilderTest.class.st
@@ -21,7 +21,7 @@ ShAbstractClassBuilderTest >> doValidateMethods: selectors on: class [
 	selectors
 		do: [ :selector | 
 			self assert: (class canUnderstand: selector).
-			self assert: (class >> selector) classBinding value == class ]
+			self assert: (class >> selector) classBinding value identicalTo: class ]
 ]
 
 { #category : #running }
@@ -63,11 +63,10 @@ ShAbstractClassBuilderTest >> validateResult [
 	| obj |
 	self assert: result isClass.
 	self assert: result class isMeta.
-	
+
 	obj := result new.
 	self assert: obj isNotNil.
-	self assert: obj class == result
-
+	self assert: obj class identicalTo: result
 ]
 
 { #category : #validation }
@@ -101,5 +100,5 @@ ShAbstractClassBuilderTest >> validateSlots: allSlots [
 
 { #category : #'private validating' }
 ShAbstractClassBuilderTest >> validateSuperclass: aSuperclass [
-	self assert: result superclass == aSuperclass
+	self assert: result superclass identicalTo: aSuperclass
 ]

--- a/src/System-Installers-Tests/MCMczInstallerTest.class.st
+++ b/src/System-Installers-Tests/MCMczInstallerTest.class.st
@@ -23,11 +23,8 @@ MCMczInstallerTest class >> suite [
 
 { #category : #assertions }
 MCMczInstallerTest >> assertDict: dict matchesInfo: info [
-	#(name id message date time author)
-		do: [:sel |  (info perform: sel) ifNotNil: [:i | dict at: sel ifPresent: [:d | self assert: i = d]]].
-	info ancestors 
-			with: (dict at: #ancestors) 
-			do: [:i :d | self assertDict: d matchesInfo: i]
+	#(name id message date time author) do: [ :sel | (info perform: sel) ifNotNil: [ :i | dict at: sel ifPresent: [ :d | self assert: i equals: d ] ] ].
+	info ancestors with: (dict at: #ancestors) do: [ :i :d | self assertDict: d matchesInfo: i ]
 ]
 
 { #category : #assertions }

--- a/src/Tests/ClassRenameFixTest.class.st
+++ b/src/Tests/ClassRenameFixTest.class.st
@@ -54,7 +54,7 @@ ClassRenameFixTest >> renameClassUsing: aBlock [
 	foundClasses := testingEnvironment organization listAtCategoryNamed: 'ClassRenameFix-GeneradClass'.
 	self assert: foundClasses notEmpty.
 	self assert: (foundClasses includes: newClassName).
-	self assert: createdClass name = newClassName
+	self assert: createdClass name equals: newClassName
 ]
 
 { #category : #running }
@@ -92,6 +92,6 @@ ClassRenameFixTest >> testRenameClassUsingClass [
 ClassRenameFixTest >> verifyRenameEvent: aRenamedEvent [
 	| renamedClass |
 	renamedClass := aRenamedEvent classRenamed.
-	self assert: (testingEnvironment classNamed: newClassName) name = newClassName.
-	self assert: renamedClass name = newClassName
+	self assert: (testingEnvironment classNamed: newClassName) name equals: newClassName.
+	self assert: renamedClass name equals: newClassName
 ]

--- a/src/Tests/TraitsTestCase.class.st
+++ b/src/Tests/TraitsTestCase.class.st
@@ -19,9 +19,8 @@ TraitsTestCase class >> resources [
 ]
 
 { #category : #utilities }
-TraitsTestCase >> assertPrints: aString like: anotherString [ 
-	self assert: (aString copyWithout: $ )
-		= (anotherString copyWithout: $ )
+TraitsTestCase >> assertPrints: aString like: anotherString [
+	self assert: (aString copyWithout: $ ) equals: (anotherString copyWithout: $ )
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Replace assert = in all non test methods from TestCase subclasses.

Replace:

- assert: = by assert: equals:
- deny = by deny: equals:
- assert: == by assert: identicalTo:
- deny: == by deny: identicalTo: