### PR TITLE
Cleanup #allClassVarNames

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -118,10 +118,11 @@ Behavior >> adoptInstance: anInstance [
 
 { #category : #'accessing instances and variables' }
 Behavior >> allClassVarNames [
-	"Answer a Set of the names of the receiver's and the receiver's ancestor's 
-	class variables."
+	"Answer the names of the receiver's and the receiver's ancestor's class variables."
 
-	^self superclass allClassVarNames
+	^ self superclass
+		ifNil: [ self classVarNames ]
+		ifNotNil: [ :sup | sup allClassVarNames , self classVarNames ]
 ]
 
 { #category : #'accessing instances and variables' }

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -329,7 +329,7 @@ Class >> classVarNamed: aString put: anObject [
 
 { #category : #'class variables' }
 Class >> classVarNames [
-	"Answer a collection of the names of the class variables defined in the receiver."
+	"Answer a collection of the receiver's class variable names."
 
 	^self classPool keys sort
 ]

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -172,21 +172,6 @@ Class >> addSubclass: aSubclass [
 ]
 
 { #category : #'class variables' }
-Class >> allClassVarNames [
-	"Answer a Set of the names of the receiver's class variables, including those
-	defined in the superclasses of the receiver."
-
-	| aSet |
-	self isRootInEnvironment
-		ifTrue: 
-			[^self classVarNames asSet]  "This is the keys so it is a new Set."
-		ifFalse: 
-			[aSet := self superclass allClassVarNames.
-			aSet addAll: self classVarNames.
-			^aSet]
-]
-
-{ #category : #'class variables' }
 Class >> allClassVariables [
 	"Answer the meta objects of all class variables of the class and its superclass"
 

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -106,16 +106,18 @@ Metaclass >> classSide [
 Metaclass >> classVarNames [
 	"Answer the names of the class variables defined in the receiver's instance."
 	
-	self instanceSide ifNil: [ ^ Array new ].
-	^self instanceSide classVarNames
+	^self instanceSide 
+		ifNil: [ #() ]
+		ifNotNil: [ self instanceSide classVarNames ]
 ]
 
 { #category : #'class variables' }
 Metaclass >> classVariables [
-	"Answer a set of the names of the class variables defined in the receiver's instance."
+	"Answer the names of the class variables defined in the receiver's instance."
 	
-	self instanceSide ifNil: [ ^ Array new].
-	^self instanceSide classVariables
+		^self instanceSide 
+			ifNil: [ ^ #()]
+			ifNotNil: [: class | class classVariables ]
 ]
 
 { #category : #'file in/out' }

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -108,16 +108,16 @@ Metaclass >> classVarNames [
 	
 	^self instanceSide 
 		ifNil: [ #() ]
-		ifNotNil: [ self instanceSide classVarNames ]
+		ifNotNil: [ :class | class classVarNames ]
 ]
 
 { #category : #'class variables' }
 Metaclass >> classVariables [
-	"Answer the names of the class variables defined in the receiver's instance."
-	
-		^self instanceSide 
-			ifNil: [ ^ #()]
-			ifNotNil: [: class | class classVariables ]
+	"Answer the class variables defined in the receiver's instance."
+
+	^ self instanceSide
+		ifNil: [ ^ #() ]
+		ifNotNil: [ :class | class classVariables ]
 ]
 
 { #category : #'file in/out' }

--- a/src/NECompletion/RBVariableNode.extension.st
+++ b/src/NECompletion/RBVariableNode.extension.st
@@ -12,7 +12,7 @@ RBVariableNode >> completionEntries [
 	 	(self select: (lookupClass allSlots collect: [ :each | each name ]) beginningWith: self name),
 		(self select: methodNode temporaryNames beginningWith: self name),
 		(self select: methodNode argumentNames beginningWith: self name),
-		(self select: lookupClass allClassVarNames asOrderedCollection beginningWith: self name),
+		(self select: lookupClass allClassVarNames beginningWith: self name),
 		(self select: (lookupClass allSharedPools flatCollect: [ :each | each classVarNames]) beginningWith: self name)
 
 ]

--- a/src/Ring-Core/RGClassStrategy.class.st
+++ b/src/Ring-Core/RGClassStrategy.class.st
@@ -119,11 +119,8 @@ RGClassStrategy >> classVariableDefinitionString [
 
 { #category : #'private - backend access' }
 RGClassStrategy >> classVariables [
-
-	| allClassVariables |
-	allClassVariables := OrderedCollection new.
-	self classVariablesDo: [ :each | allClassVariables add: each].
-	^ allClassVariables asArray
+	
+	^ Array streamContents: [ :str | self classVariablesDo: [ :each | str nextPut: each ] ]
 ]
 
 { #category : #'private - backend access' }

--- a/src/Ring-Core/RGTraitV2Strategy.class.st
+++ b/src/Ring-Core/RGTraitV2Strategy.class.st
@@ -133,10 +133,7 @@ RGTraitV2Strategy >> classVariableDefinitionString [
 { #category : #'private - backend access' }
 RGTraitV2Strategy >> classVariables [
 
-	| allClassVariables |
-	allClassVariables := OrderedCollection new.
-	self classVariablesDo: [ :each | allClassVariables add: each].
-	^ allClassVariables asArray
+	^ Array streamContents: [ :str | self classVariablesDo: [ :each | str nextPut: each ] ]
 ]
 
 { #category : #'private - backend access' }

--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -166,12 +166,6 @@ Trait >> addUser: aClass [
 	self users add: aClass
 ]
 
-{ #category : #'class variables' }
-Trait >> allClassVarNames [
-	
-	^ #()
-]
-
 { #category : #accessing }
 Trait >> asTraitComposition [
 	^ TaCompositionElement for: self.


### PR DESCRIPTION
- classVarNames does not need to be a set as the variables are unique in the hierarchy
- simplify #allClassVarNames to be implemented in the style of #allInstVarNames
- remove an asOrderedCollection in the code copletion code that is not needed anymore