### PR TITLE
Make SlotClassDefinition the default

### DIFF
--- a/src/Slot-Core/Slot.class.st
+++ b/src/Slot-Core/Slot.class.st
@@ -81,7 +81,7 @@ Slot class >> named: aSymbol [
 
 { #category : #settings }
 Slot class >> showSlotClassDefinition [
-	^slotClassDefinition ifNil: [ slotClassDefinition := false ]
+	^slotClassDefinition ifNil: [ slotClassDefinition := true ]
 ]
 
 { #category : #settings }


### PR DESCRIPTION
- enable the slot class definitin form by default

I want to for one see if all tests are green, in addtion I think it might be a good idea to have  this on for the next release