### PR TITLE
Reflectivity: ASTCacheReset not needed

### DIFF
--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -64,7 +64,9 @@ ASTCache >> at: aCompiledMethod [
 	^ self 
 		at: aCompiledMethod
 		ifAbsentPut: [ 
-			aCompiledMethod parseTree doSemanticAnalysisIn: aCompiledMethod methodClass ]
+			aCompiledMethod reflectiveMethod 
+				ifNil: [ aCompiledMethod parseTree doSemanticAnalysisIn: aCompiledMethod methodClass ]
+				ifNotNil: [: rfMethod | rfMethod ast ] ]
 ]
 
 { #category : #initialization }

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -49,12 +49,7 @@ ReflectiveMethod >> compiledMethod: aCompiledMethod [
 
 	compiledMethod := aCompiledMethod.
 	class := aCompiledMethod methodClass.
-	ast := compiledMethod ast.
-	
-	SystemAnnouncer uniqueInstance weak 
-		when: ASTCacheReset 
-		send: #reinstallASTInCache 
-		to: self
+	ast := compiledMethod ast
 ]
 
 { #category : #invalidate }


### PR DESCRIPTION
In a discusstion with Manuel we realized that we do not need the ASTCacheReset for Metalinks: if we inatall a link, we have a Reflective Method. This hold on to the AST. Thus instead of keeping it in the cache, we can just by default ask the reflective method if it exists.we keep ASTCacheReset for other users that want persist annotations on the AST... for now.