### PR TITLE
Completion: Fix emebdded Browser

### DIFF
--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -59,7 +59,7 @@ CompletionContext >> commonPrefix [
 CompletionContext >> completionAt: aNumber [
 	| entry |
 	
-	entry := (self entries at: aNumber) completion separateKeywords.
+	entry := (self entries at: aNumber) contents asSymbol separateKeywords.
 	^ NECPreferences spaceAfterCompletion 
 		ifTrue: [ entry, ' ' ]
 		ifFalse: [ entry ]

--- a/src/NECompletion/CompletionEngine.class.st
+++ b/src/NECompletion/CompletionEngine.class.st
@@ -88,10 +88,11 @@ CompletionEngine >> handleKeystrokeBefore: aKeyboardEvent editor: anEditor [
 	
 	This method would be cleaner if splitted."
 
-	| keyCharacter controlKeyPressed |
+	| keyCharacter controlKeyPressed commandKeyPressed |
 	self setEditor: anEditor.
 	keyCharacter := aKeyboardEvent keyCharacter.
 	controlKeyPressed := aKeyboardEvent controlKeyPressed.
+	commandKeyPressed := aKeyboardEvent commandKeyPressed.
 	self isMenuOpen
 		ifFalse: [ ^ self handleKeystrokeWithoutMenu: aKeyboardEvent ].
 	(keyCharacter = Character home and: [ self captureNavigationKeys ])
@@ -102,11 +103,11 @@ CompletionEngine >> handleKeystrokeBefore: aKeyboardEvent editor: anEditor [
 		ifTrue: [ 
 			menuMorph end.
 			^ true ].
-	(keyCharacter = Character arrowRight and: [ self captureNavigationKeys ])
+	(keyCharacter = Character arrowRight and: [commandKeyPressed and: [ self captureNavigationKeys ]])
 		ifTrue: [ 
 			menuMorph showDetail.
 			^ true ].
-	(keyCharacter = Character arrowLeft and: [ self captureNavigationKeys ])
+	(keyCharacter = Character arrowLeft  and: [commandKeyPressed and: [ self captureNavigationKeys ]])
 		ifTrue: [ ^ self leftArrow ].
 	keyCharacter = Character arrowUp
 		ifTrue: [ 

--- a/src/NECompletion/NECCVariableEntry.class.st
+++ b/src/NECompletion/NECCVariableEntry.class.st
@@ -1,0 +1,8 @@
+"
+my subclasses model pssible completions for variables
+"
+Class {
+	#name : #NECCVariableEntry,
+	#superclass : #NECEntry,
+	#category : #'NECompletion-Model'
+}

--- a/src/NECompletion/NECClassVarEntry.class.st
+++ b/src/NECompletion/NECClassVarEntry.class.st
@@ -3,7 +3,7 @@ I represent a class Variable
 "
 Class {
 	#name : #NECClassVarEntry,
-	#superclass : #NECEntry,
+	#superclass : #NECCVariableEntry,
 	#category : #'NECompletion-Model'
 }
 

--- a/src/NECompletion/NECEntry.class.st
+++ b/src/NECompletion/NECEntry.class.st
@@ -15,13 +15,8 @@ Class {
 }
 
 { #category : #'instance creation' }
-NECEntry class >> contents: aString [ 
-	^ self new setContents: aString
-]
-
-{ #category : #'instance creation' }
 NECEntry class >> contents: aString node: aNode [
-	^ self new setContents: aString node: aNode
+	^ self new contents: aString node: aNode
 ]
 
 { #category : #operations }
@@ -32,15 +27,10 @@ NECEntry >> <= aECEntry [
 { #category : #'ui related' }
 NECEntry >> browse [
 	| class |
-	"no really correct, we need the class of the node..."
-	class := node methodNode compilationContext getClass.
-	Smalltalk tools browser openOnClass: class.
-	^true
-]
-
-{ #category : #accessing }
-NECEntry >> completion [
-	^ self contents asSymbol
+	class := Smalltalk globals at: contents ifAbsent: [ nil ].
+	class
+		ifNotNil: [ Smalltalk tools browser openOnClass: class].
+	^ true
 ]
 
 { #category : #accessing }
@@ -48,12 +38,16 @@ NECEntry >> contents [
 	^contents
 ]
 
+{ #category : #accessing }
+NECEntry >> contents: aString node: aNode [
+	contents := aString.
+	node := aNode
+]
+
 { #category : #'detail information' }
 NECEntry >> createDescription [
 	| clazz |
-	"no really correct, we need the class of the node..."
-	
-	clazz := node methodNode compilationContext getClass.
+	clazz := Smalltalk globals at: contents ifAbsent: [ nil ].
 	^ clazz 
 		ifNil: [ NECEntryDescription label: self label ]
 		ifNotNil: 
@@ -87,15 +81,4 @@ NECEntry >> printOn: aStream [
 		nextPut: $,;
 		nextPutAll: self hightlightSymbol;
 		nextPut: $)
-]
-
-{ #category : #accessing }
-NECEntry >> setContents: aString [ 
-	contents := aString.
-]
-
-{ #category : #accessing }
-NECEntry >> setContents: aString node: aNode [
-	contents := aString.
-	node := aNode
 ]

--- a/src/NECompletion/NECGlobalEntry.class.st
+++ b/src/NECompletion/NECGlobalEntry.class.st
@@ -3,7 +3,7 @@ I represent a global variable.
 "
 Class {
 	#name : #NECGlobalEntry,
-	#superclass : #NECEntry,
+	#superclass : #NECCVariableEntry,
 	#category : #'NECompletion-Model'
 }
 

--- a/src/NECompletion/NECInstVarEntry.class.st
+++ b/src/NECompletion/NECInstVarEntry.class.st
@@ -3,7 +3,7 @@ I represent an instance variable.
 "
 Class {
 	#name : #NECInstVarEntry,
-	#superclass : #NECEntry,
+	#superclass : #NECCVariableEntry,
 	#category : #'NECompletion-Model'
 }
 

--- a/src/NECompletion/NECLocalEntry.class.st
+++ b/src/NECompletion/NECLocalEntry.class.st
@@ -5,7 +5,7 @@ In addition tools such as the workspace may turn their bindings into instance of
 "
 Class {
 	#name : #NECLocalEntry,
-	#superclass : #NECEntry,
+	#superclass : #NECCVariableEntry,
 	#category : #'NECompletion-Model'
 }
 

--- a/src/NECompletion/NECMenuMorph.class.st
+++ b/src/NECompletion/NECMenuMorph.class.st
@@ -281,8 +281,8 @@ NECMenuMorph >> detailMessage [
 	^ String streamContents: [:stream |
 		NECPreferences captureNavigationKeys ifTrue: [
 			stream << (detailMorph
-				ifNil: ['-> open detail']
-				ifNotNil: ['<- close detail']	) ] ]
+				ifNil: ['cmd-> open detail']
+				ifNotNil: ['cmd<- close detail']	) ] ]
 ]
 
 { #category : #accessing }

--- a/src/NECompletion/NECPreferences.class.st
+++ b/src/NECompletion/NECPreferences.class.st
@@ -129,7 +129,7 @@ NECPreferences class >> initialize [
 	caseSensitive := true.
 	smartCharacters := true.
 	expandPrefixes := true.
-	captureNavigationKeys := false.
+	captureNavigationKeys := true.
 	useEnterToAccept := self defaultUseEnterToAccept.
 	smartCharactersMapping := Dictionary new.
 	smartCharactersMapping

--- a/src/NECompletion/NECSelectorEntry.class.st
+++ b/src/NECompletion/NECSelectorEntry.class.st
@@ -1,9 +1,9 @@
 "
-I represent a selector
+I represent a selector of a method
 "
 Class {
 	#name : #NECSelectorEntry,
-	#superclass : #NECEntry,
+	#superclass : #NECSymbolEntry,
 	#category : #'NECompletion-Model'
 }
 
@@ -25,19 +25,6 @@ NECSelectorEntry >> browse [
 			true ]
 ]
 
-{ #category : #'detail information' }
-NECSelectorEntry >> createDescription [
-	"Creates description either from looking up the method in a class,
-	or in the system."
-
-	^ self
-		findMethodAndDo: [:method | 
-			self
-				methodSourceDescription: method methodClass
-				method: method ]
-		ifAbsent: [:selector | self implementorsDescription: selector]
-]
-
 { #category : #private }
 NECSelectorEntry >> findMethodAndDo: foundBlock ifAbsent: notfoundBlock [ 
 	| theClass result implementors |
@@ -53,26 +40,6 @@ NECSelectorEntry >> findMethodAndDo: foundBlock ifAbsent: notfoundBlock [
 	^ foundBlock value: result
 ]
 
-{ #category : #private }
-NECSelectorEntry >> implementorsDescription: aSymbol [ 
-	| implementors output |
-	output := WriteStream on: String new.
-	implementors := self systemNavigation allImplementorsOf: aSymbol.
-	implementors isEmpty ifTrue: 
-		[ ^ NECEntryDescription 
-			label: 'symbol'
-			title: '(no implementors)'
-			description: 'This is just symbol.' ].
-	implementors do: [ :each | 
-		output
-			nextPutAll: each className printString;
-			cr ].
-	^ NECEntryDescription 
-		label: self label
-		title: '(Implementors)'
-		description: output contents
-]
-
 { #category : #accessing }
 NECSelectorEntry >> label [
 	"I return whether the variable is a class or a method."
@@ -81,19 +48,4 @@ NECSelectorEntry >> label [
 		propertyAt: #type 
 		ifPresent:  [ 'method' ] 
 		ifAbsent:  [ 'class' ]
-]
-
-{ #category : #private }
-NECSelectorEntry >> methodSourceDescription: aClass method: aCompiledMethod [ 
-	"I return if it's a class or a method, its class name, and the implementation."
-	| styler styledText |
-	
-	styler := SHRBTextStyler new.
-	styler classOrMetaClass: aClass.
-	styledText := styler styledTextFor: (aCompiledMethod sourceCode) asText.
-	
-	^ NECEntryDescription
-		label: self label
-		title: aClass printString
-		description: styledText
 ]

--- a/src/NECompletion/NECSelectorEntry.class.st
+++ b/src/NECompletion/NECSelectorEntry.class.st
@@ -11,12 +11,12 @@ Class {
 NECSelectorEntry >> browse [
 	| class |
 	class := node receiver propertyAt: #type ifAbsent: nil.
-	class ifNil: [ SystemNavigation new browseAllImplementorsOf: class].
+	class ifNil: [ SystemNavigation new browseAllImplementorsOf: contents].
 	
 	^ self
-		findMethodAndDo: [ :clss :method | 
+		findMethodAndDo: [ :method | 
 			Smalltalk tools browser 
-				openOnClass: clss 
+				openOnClass: method methodClass 
 				selector: method selector. 
 			true ]
 		ifAbsent: [ :selector | 
@@ -31,9 +31,9 @@ NECSelectorEntry >> createDescription [
 	or in the system."
 
 	^ self
-		findMethodAndDo: [:clazz :method | 
+		findMethodAndDo: [:method | 
 			self
-				methodSourceDescription: clazz
+				methodSourceDescription: method methodClass
 				method: method ]
 		ifAbsent: [:selector | self implementorsDescription: selector]
 ]
@@ -50,7 +50,7 @@ NECSelectorEntry >> findMethodAndDo: foundBlock ifAbsent: notfoundBlock [
 							ref realClass lookupSelector: ref selector]
 						ifFalse: [^ notfoundBlock value: contents]]
 				ifNotNil: [theClass lookupSelector: contents ]. 
-	^ foundBlock value: result first value: result second
+	^ foundBlock value: result
 ]
 
 { #category : #private }

--- a/src/NECompletion/NECSelfEntry.class.st
+++ b/src/NECompletion/NECSelfEntry.class.st
@@ -3,7 +3,7 @@ I represent self
 "
 Class {
 	#name : #NECSelfEntry,
-	#superclass : #NECEntry,
+	#superclass : #NECCVariableEntry,
 	#category : #'NECompletion-Model'
 }
 

--- a/src/NECompletion/NECSuperEntry.class.st
+++ b/src/NECompletion/NECSuperEntry.class.st
@@ -3,7 +3,7 @@ I represent super.
 "
 Class {
 	#name : #NECSuperEntry,
-	#superclass : #NECEntry,
+	#superclass : #NECCVariableEntry,
 	#category : #'NECompletion-Model'
 }
 

--- a/src/NECompletion/NECSymbolEntry.class.st
+++ b/src/NECompletion/NECSymbolEntry.class.st
@@ -1,0 +1,70 @@
+"
+I represent a symbol, there might be a method with this selector
+"
+Class {
+	#name : #NECSymbolEntry,
+	#superclass : #NECEntry,
+	#category : #'NECompletion-Model'
+}
+
+{ #category : #'detail information' }
+NECSymbolEntry >> createDescription [
+	"Creates description either from looking up the method in a class,
+	or in the system."
+
+	^ self
+		findMethodAndDo: [:method | 
+			self
+				methodSourceDescription: method methodClass
+				method: method ]
+		ifAbsent: [:selector | self implementorsDescription: selector]
+]
+
+{ #category : #'detail information' }
+NECSymbolEntry >> findMethodAndDo: foundBlock ifAbsent: notfoundBlock [ 
+	| result  implementors |
+	
+	implementors := self systemNavigation allImplementorsOf: contents.
+	implementors size == 1
+						ifTrue: [| ref | 
+							ref := implementors first.
+							result := ref realClass lookupSelector: ref selector]
+						ifFalse: [^ notfoundBlock value: contents].
+			
+	^ foundBlock value: result
+]
+
+{ #category : #private }
+NECSymbolEntry >> implementorsDescription: aSymbol [ 
+	| implementors output |
+	output := WriteStream on: String new.
+	implementors := self systemNavigation allImplementorsOf: aSymbol.
+	implementors isEmpty ifTrue: 
+		[ ^ NECEntryDescription 
+			label: 'symbol'
+			title: '(no implementors)'
+			description: 'This is just symbol.' ].
+	implementors do: [ :each | 
+		output
+			nextPutAll: each className printString;
+			cr ].
+	^ NECEntryDescription 
+		label: self label
+		title: '(Implementors)'
+		description: output contents
+]
+
+{ #category : #private }
+NECSymbolEntry >> methodSourceDescription: aClass method: aCompiledMethod [ 
+	"I return if it's a class or a method, its class name, and the implementation."
+	| styler styledText |
+	
+	styler := SHRBTextStyler new.
+	styler classOrMetaClass: aClass.
+	styledText := styler styledTextFor: (aCompiledMethod sourceCode) asText.
+	
+	^ NECEntryDescription
+		label: self label
+		title: aClass printString
+		description: styledText
+]

--- a/src/NECompletion/RBLiteralValueNode.extension.st
+++ b/src/NECompletion/RBLiteralValueNode.extension.st
@@ -6,7 +6,7 @@ RBLiteralValueNode >> completionEntries [
 	"return all symbols that start with value"
 	^Symbol allSymbols 
 		select: [ :each | (each beginsWith: value) and: [each isLiteralSymbol]] 
-		thenCollect: [ :each | NECEntry contents: each node: self ]
+		thenCollect: [ :each | NECSymbolEntry contents: each node: self ]
 ]
 
 { #category : #'*NECompletion' }


### PR DESCRIPTION
There is a setting to turn on an embedded mini browser in code completion. This PR makes it work for Globals and message sends (the most used use case). Some more work should be done for selectors, other kinds of vars. But it is usable.