### PR TITLE
Add class deprecation through meta-links

### DIFF
--- a/src/Calypso-SystemPlugins-Reflectivity-Queries/MetalinkChanged.extension.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Queries/MetalinkChanged.extension.st
@@ -13,14 +13,15 @@ MetalinkChanged >> affectsMethods [
 
 { #category : #'*Calypso-SystemPlugins-Reflectivity-Queries' }
 MetalinkChanged >> affectsMethodsDefinedInClass: aClass [
-
-	^link methods anySatisfy: [ :each | each origin == aClass]
+	^ link methods
+		anySatisfy: [ :each | each methodClass isNotNil and: [ each origin == aClass ] ]
 ]
 
 { #category : #'*Calypso-SystemPlugins-Reflectivity-Queries' }
 MetalinkChanged >> affectsMethodsDefinedInPackage: aPackage [
-
-	^link methods anySatisfy: [ :each | each package == aPackage]
+	^ link methods
+		anySatisfy:
+			[ :each | each methodClass isNotNil and: [ each package == aPackage ] ]
 ]
 
 { #category : #'*Calypso-SystemPlugins-Reflectivity-Queries' }

--- a/src/ClassDeprecation-Tests/ClassDeprecationClassTest.class.st
+++ b/src/ClassDeprecation-Tests/ClassDeprecationClassTest.class.st
@@ -1,0 +1,71 @@
+"
+I am a copy of class ClassDeprecationMetaLinkTest. This comment is copied from there, and might not be entirely accurate
+
+This class contains tests
+"
+Class {
+	#name : #ClassDeprecationClassTest,
+	#superclass : #ClassDeprecationTest,
+	#category : #'ClassDeprecation-Tests'
+}
+
+{ #category : #running }
+ClassDeprecationClassTest >> setUp [
+	super setUp.
+	referencingClass compile: referencingOriginalSource
+]
+
+{ #category : #tests }
+ClassDeprecationClassTest >> testDeprecationTransformationExpression [
+	self
+		assert: deprecatedClass deprecationTransformationExpression
+		equals: replacementClass name
+]
+
+{ #category : #tests }
+ClassDeprecationClassTest >> testInstallDeprecationTransformMetaLinks [
+	| globalNodes |
+	globalNodes := self globalNodes: referencingClass >> #references.
+	self deny: globalNodes first hasDeprecationTransformMetaLink.
+	self deny: globalNodes second hasDeprecationTransformMetaLink.
+	self deny: globalNodes third hasDeprecationTransformMetaLink.
+	deprecatedClass installDeprecationTransformMetaLinks.
+	globalNodes := self globalNodes: referencingClass >> #references.
+	self assert: globalNodes first hasDeprecationTransformMetaLink.
+	self assert: globalNodes second hasDeprecationTransformMetaLink.
+	self deny: globalNodes third hasDeprecationTransformMetaLink
+]
+
+{ #category : #tests }
+ClassDeprecationClassTest >> testIsDeprecatedTransformable [
+	self deny: referencingClass isDeprecatedTransformable.
+	self assert: deprecatedClass isDeprecatedTransformable.
+	deprecatedClass class
+		compile:
+			'isDeprecated
+	<transformTo: ''' , replacementClass name
+				,
+					'''>
+	^ false'.
+	self deny: deprecatedClass isDeprecatedTransformable.
+	deprecatedClass class
+		compile:
+			'isDeprecated
+	^ true'.
+	self deny: deprecatedClass isDeprecatedTransformable
+]
+
+{ #category : #tests }
+ClassDeprecationClassTest >> testUninstallDeprecationTransformMetaLinks [
+	| globalNodes |
+	deprecatedClass installDeprecationTransformMetaLinks.
+	globalNodes := self globalNodes: referencingClass >> #references.
+	self assert: globalNodes first hasDeprecationTransformMetaLink.
+	self assert: globalNodes second hasDeprecationTransformMetaLink.
+	self deny: globalNodes third hasDeprecationTransformMetaLink.
+	deprecatedClass uninstallDeprecationTransformMetaLinks.
+	globalNodes := self globalNodes: referencingClass >> #references.
+	self deny: globalNodes first hasDeprecationTransformMetaLink.
+	self deny: globalNodes second hasDeprecationTransformMetaLink.
+	self deny: globalNodes third hasDeprecationTransformMetaLink
+]

--- a/src/ClassDeprecation-Tests/ClassDeprecationCompiledMethodTest.class.st
+++ b/src/ClassDeprecation-Tests/ClassDeprecationCompiledMethodTest.class.st
@@ -1,0 +1,88 @@
+"
+I am a copy of class ClassDeprecationClassTest. This comment is copied from there, and might not be entirely accurate
+
+I am a copy of class ClassDeprecationMetaLinkTest. This comment is copied from there, and might not be entirely accurate
+
+This class contains tests
+"
+Class {
+	#name : #ClassDeprecationCompiledMethodTest,
+	#superclass : #ClassDeprecationTest,
+	#category : #'ClassDeprecation-Tests'
+}
+
+{ #category : #running }
+ClassDeprecationCompiledMethodTest >> setUp [
+	super setUp.
+	referencingClass compile: referencingOriginalSource
+]
+
+{ #category : #tests }
+ClassDeprecationCompiledMethodTest >> testHasDeprecationTransformableReferences [
+	self
+		assert:
+			(referencingClass >> #references)
+				hasDeprecationTransformableReferences.
+	self
+		deny:
+			(deprecatedClass class >> #isDeprecated)
+				hasDeprecationTransformableReferences
+]
+
+{ #category : #tests }
+ClassDeprecationCompiledMethodTest >> testInstallDeprecationTransformMetaLinks [
+	| globalNodes |
+	globalNodes := self globalNodes: referencingClass >> #references.
+	self deny: globalNodes first hasDeprecationTransformMetaLink.
+	self deny: globalNodes second hasDeprecationTransformMetaLink.
+	self deny: globalNodes third hasDeprecationTransformMetaLink.
+	(referencingClass >> #references)
+		installDeprecationTransformMetaLinks.
+	globalNodes := self globalNodes: referencingClass >> #references.
+	self assert: globalNodes first hasDeprecationTransformMetaLink.
+	self assert: globalNodes second hasDeprecationTransformMetaLink.
+	self deny: globalNodes third hasDeprecationTransformMetaLink.
+	globalNodes := self
+		globalNodes: deprecatedClass class >> #isDeprecated.
+	self assert: globalNodes size equals: 0.
+	(deprecatedClass class >> #isDeprecated)
+		installDeprecationTransformMetaLinks.
+	globalNodes := self
+		globalNodes: deprecatedClass class >> #isDeprecated.
+	self assert: globalNodes size equals: 0
+]
+
+{ #category : #tests }
+ClassDeprecationCompiledMethodTest >> testIsDeprecationTransformableMethod [
+	self
+		deny: (referencingClass >> #references) isDeprecationTransformableMethod.
+	self
+		assert:
+			(deprecatedClass class >> #isDeprecated)
+				isDeprecationTransformableMethod
+]
+
+{ #category : #tests }
+ClassDeprecationCompiledMethodTest >> testUninstallDeprecationTransformMetaLinks [
+	| globalNodes |
+	(referencingClass >> #references)
+		installDeprecationTransformMetaLinks.
+	globalNodes := self globalNodes: referencingClass >> #references.
+	self assert: globalNodes first hasDeprecationTransformMetaLink.
+	self assert: globalNodes second hasDeprecationTransformMetaLink.
+	self deny: globalNodes third hasDeprecationTransformMetaLink.
+	(referencingClass >> #references)
+		uninstallDeprecationTransformMetaLinks.
+	globalNodes := self globalNodes: referencingClass >> #references.
+	self deny: globalNodes first hasDeprecationTransformMetaLink.
+	self deny: globalNodes second hasDeprecationTransformMetaLink.
+	self deny: globalNodes third hasDeprecationTransformMetaLink.
+	globalNodes := self
+		globalNodes: deprecatedClass class >> #isDeprecated.
+	self assert: globalNodes size equals: 0.
+	(deprecatedClass class >> #isDeprecated)
+		uninstallDeprecationTransformMetaLinks.
+	globalNodes := self
+		globalNodes: deprecatedClass class >> #isDeprecated.
+	self assert: globalNodes size equals: 0
+]

--- a/src/ClassDeprecation-Tests/ClassDeprecationFunctionalTest.class.st
+++ b/src/ClassDeprecation-Tests/ClassDeprecationFunctionalTest.class.st
@@ -1,0 +1,151 @@
+Class {
+	#name : #ClassDeprecationFunctionalTest,
+	#superclass : #ClassDeprecationTest,
+	#instVars : [
+		'referencingOriginalResult',
+		'referencingTransformedResult'
+	],
+	#category : #'ClassDeprecation-Tests'
+}
+
+{ #category : #tests }
+ClassDeprecationFunctionalTest >> assertDoesNotTransformSources [
+	"Asserts that #references was not instrumented and hence will not transform the source after execution."
+
+	self
+		assert: referencingClass new references
+		equals: referencingOriginalResult.
+	self
+		assert: (referencingClass compiledMethodAt: #references) sourceCode
+		equals: referencingOriginalSource
+]
+
+{ #category : #tests }
+ClassDeprecationFunctionalTest >> assertDoesTransformSources [
+	"Asserts that #references was instrumented and hence will transform the source after execution."
+
+	"first execution should not replace value, but replace source"
+	self
+		assert: referencingClass new references
+		equals: referencingOriginalResult.
+	self
+		assert: (referencingClass compiledMethodAt: #references) sourceCode
+		equals: referencingTransformedSource.
+	"second execution should replace value, but not source"
+	self
+		assert: referencingClass new references
+		equals: referencingTransformedResult.
+	self
+		assert: (referencingClass compiledMethodAt: #references) sourceCode
+		equals: referencingTransformedSource
+]
+
+{ #category : #running }
+ClassDeprecationFunctionalTest >> setUp [
+	super setUp.
+	referencingOriginalResult := {deprecatedClass.
+	1.
+	referencingClass.
+	deprecatedClass.
+	referencingClass}.
+	referencingTransformedResult := {replacementClass.
+	1.
+	referencingClass.
+	replacementClass.
+	referencingClass}
+]
+
+{ #category : #tests }
+ClassDeprecationFunctionalTest >> testDeprecateEnableReference [
+	self
+		deprecateClass: deprecatedClass
+		transformTo: replacementClass name.
+	ClassDeprecationMetaLink enable.
+	referencingClass compile: referencingOriginalSource.
+	self assertDoesTransformSources
+]
+
+{ #category : #tests }
+ClassDeprecationFunctionalTest >> testDeprecateReferenceEnable [
+	"first execution should not replace value, but replace source"
+	"second execution should replace value, but not source"
+	self
+		deprecateClass: deprecatedClass
+		transformTo: replacementClass name.
+	referencingClass compile: referencingOriginalSource.
+	ClassDeprecationMetaLink enable.
+	self assertDoesTransformSources
+]
+
+{ #category : #tests }
+ClassDeprecationFunctionalTest >> testEnableDeprecateReference [
+	ClassDeprecationMetaLink enable.
+	self
+		deprecateClass: deprecatedClass
+		transformTo: replacementClass name.
+	referencingClass compile: referencingOriginalSource.
+	self assertDoesTransformSources
+]
+
+{ #category : #tests }
+ClassDeprecationFunctionalTest >> testEnableReferenceDeprecate [
+	ClassDeprecationMetaLink enable.
+	referencingClass compile: referencingOriginalSource.
+	self
+		deprecateClass: deprecatedClass
+		transformTo: replacementClass name.
+	self assertDoesTransformSources
+]
+
+{ #category : #tests }
+ClassDeprecationFunctionalTest >> testReferenceDeprecateEnable [
+	referencingClass compile: referencingOriginalSource.
+	self
+		deprecateClass: deprecatedClass
+		transformTo: replacementClass name.
+	ClassDeprecationMetaLink enable.
+	self assertDoesTransformSources
+]
+
+{ #category : #tests }
+ClassDeprecationFunctionalTest >> testReferenceDeprecateEnableDisable [
+	referencingClass compile: referencingOriginalSource.
+	self
+		deprecateClass: deprecatedClass
+		transformTo: replacementClass name.
+	ClassDeprecationMetaLink
+		enable;
+		disable.
+	self assertDoesNotTransformSources
+]
+
+{ #category : #tests }
+ClassDeprecationFunctionalTest >> testReferenceDeprecateEnableUndeprecated [
+	referencingClass compile: referencingOriginalSource.
+	self
+		deprecateClass: deprecatedClass
+		transformTo: replacementClass name.
+	ClassDeprecationMetaLink enable.
+	self deprecateNotClass: deprecatedClass.
+	self assertDoesNotTransformSources
+]
+
+{ #category : #tests }
+ClassDeprecationFunctionalTest >> testReferenceEnableDeprecate [
+	referencingClass compile: referencingOriginalSource.
+	ClassDeprecationMetaLink enable.
+	self
+		deprecateClass: deprecatedClass
+		transformTo: replacementClass name.
+	self assertDoesTransformSources
+]
+
+{ #category : #tests }
+ClassDeprecationFunctionalTest >> testSetUp [
+	self
+		deny: referencingOriginalSource
+		equals: referencingTransformedSource.
+	self
+		deny: referencingOriginalResult
+		equals: referencingTransformedResult
+]

--- a/src/ClassDeprecation-Tests/ClassDeprecationMetaLinkInstallerTest.class.st
+++ b/src/ClassDeprecation-Tests/ClassDeprecationMetaLinkInstallerTest.class.st
@@ -1,0 +1,39 @@
+"
+I am a copy of class ClassDeprecationMetaLinkTest. This comment is copied from there, and might not be entirely accurate
+
+This class contains tests
+"
+Class {
+	#name : #ClassDeprecationMetaLinkInstallerTest,
+	#superclass : #ClassDeprecationTest,
+	#category : #'ClassDeprecation-Tests'
+}
+
+{ #category : #running }
+ClassDeprecationMetaLinkInstallerTest >> setUp [
+	super setUp.
+	referencingClass compile: referencingOriginalSource
+]
+
+{ #category : #tests }
+ClassDeprecationMetaLinkInstallerTest >> testVisit [
+	| globalNodes |
+	globalNodes := self globalNodes: referencingClass >> #references.
+	self deny: globalNodes first hasDeprecationTransformMetaLink.
+	self deny: globalNodes second hasDeprecationTransformMetaLink.
+	self deny: globalNodes third hasDeprecationTransformMetaLink.
+	ClassDeprecationMetaLinkInstaller new
+		visitNode: (referencingClass >> #references) ast.
+	globalNodes := self globalNodes: referencingClass >> #references.
+	self assert: globalNodes first hasDeprecationTransformMetaLink.
+	self assert: globalNodes second hasDeprecationTransformMetaLink.
+	self deny: globalNodes third hasDeprecationTransformMetaLink.
+	globalNodes := self
+		globalNodes: deprecatedClass class >> #isDeprecated.
+	self assert: globalNodes size equals: 0.
+	ClassDeprecationMetaLinkInstaller new
+		visitNode: (deprecatedClass class >> #isDeprecated) ast.
+	globalNodes := self
+		globalNodes: deprecatedClass class >> #isDeprecated.
+	self assert: globalNodes size equals: 0
+]

--- a/src/ClassDeprecation-Tests/ClassDeprecationMetaLinkTest.class.st
+++ b/src/ClassDeprecation-Tests/ClassDeprecationMetaLinkTest.class.st
@@ -1,0 +1,48 @@
+Class {
+	#name : #ClassDeprecationMetaLinkTest,
+	#superclass : #ClassDeprecationTest,
+	#instVars : [
+		'referencingIntermediateSource',
+		'metaLink'
+	],
+	#category : #'ClassDeprecation-Tests'
+}
+
+{ #category : #running }
+ClassDeprecationMetaLinkTest >> setUp [
+	super setUp.
+	metaLink := ClassDeprecationMetaLink new.
+	referencingIntermediateSource := 'references
+	^ {ClassDeprecationForTestReplacement.
+	1.
+	self class.
+	ClassDeprecationForTestDeprecated.
+	ClassDeprecationForTestReferencing}'..
+	referencingClass compile: referencingOriginalSource
+]
+
+{ #category : #tests }
+ClassDeprecationMetaLinkTest >> testDeprecationTransform [
+	| globalNode |
+	globalNode := (self globalNodes: referencingClass >> #references)
+		first.
+	metaLink deprecationTransform: globalNode.
+	self
+		assert: (referencingClass >> #references) sourceCode
+		equals: referencingIntermediateSource.
+	globalNode := (self globalNodes: referencingClass >> #references)
+		third.
+	self
+		should: [ metaLink deprecationTransform: globalNode ]
+		raise: AssertionFailure.
+	self
+		assert: (referencingClass >> #references) sourceCode
+		equals: referencingIntermediateSource
+]
+
+{ #category : #tests }
+ClassDeprecationMetaLinkTest >> testSetUp [
+	self assert: metaLink control equals: #before.
+	self assert: metaLink metaObject equals: metaLink.
+	self assert: metaLink selector equals: #deprecationTransform:
+]

--- a/src/ClassDeprecation-Tests/ClassDeprecationMetaLinkUninstallerTest.class.st
+++ b/src/ClassDeprecation-Tests/ClassDeprecationMetaLinkUninstallerTest.class.st
@@ -1,0 +1,43 @@
+"
+I am a copy of class ClassDeprecationMetaLinkInstallerTest. This comment is copied from there, and might not be entirely accurate
+
+I am a copy of class ClassDeprecationMetaLinkTest. This comment is copied from there, and might not be entirely accurate
+
+This class contains tests
+"
+Class {
+	#name : #ClassDeprecationMetaLinkUninstallerTest,
+	#superclass : #ClassDeprecationTest,
+	#category : #'ClassDeprecation-Tests'
+}
+
+{ #category : #running }
+ClassDeprecationMetaLinkUninstallerTest >> setUp [
+	super setUp.
+	referencingClass compile: referencingOriginalSource
+]
+
+{ #category : #tests }
+ClassDeprecationMetaLinkUninstallerTest >> testVisit [
+	| globalNodes |
+	ClassDeprecationMetaLinkInstaller new
+		visitNode: (referencingClass >> #references) ast.
+	globalNodes := self globalNodes: referencingClass >> #references.
+	self assert: globalNodes first hasDeprecationTransformMetaLink.
+	self assert: globalNodes second hasDeprecationTransformMetaLink.
+	self deny: globalNodes third hasDeprecationTransformMetaLink.
+	ClassDeprecationMetaLinkUninstaller new
+		visitNode: (referencingClass >> #references) ast.
+	globalNodes := self globalNodes: referencingClass >> #references.
+	self deny: globalNodes first hasDeprecationTransformMetaLink.
+	self deny: globalNodes second hasDeprecationTransformMetaLink.
+	self deny: globalNodes third hasDeprecationTransformMetaLink.
+	globalNodes := self
+		globalNodes: deprecatedClass class >> #isDeprecated.
+	self assert: globalNodes size equals: 0.
+	ClassDeprecationMetaLinkUninstaller new
+		visitNode: (deprecatedClass class >> #isDeprecated) ast.
+	globalNodes := self
+		globalNodes: deprecatedClass class >> #isDeprecated.
+	self assert: globalNodes size equals: 0
+]

--- a/src/ClassDeprecation-Tests/ClassDeprecationRBGlobalNodeTest.class.st
+++ b/src/ClassDeprecation-Tests/ClassDeprecationRBGlobalNodeTest.class.st
@@ -1,0 +1,135 @@
+"
+I am a copy of class ClassDeprecationClassTest. This comment is copied from there, and might not be entirely accurate
+
+I am a copy of class ClassDeprecationMetaLinkTest. This comment is copied from there, and might not be entirely accurate
+
+This class contains tests
+"
+Class {
+	#name : #ClassDeprecationRBGlobalNodeTest,
+	#superclass : #ClassDeprecationTest,
+	#category : #'ClassDeprecation-Tests'
+}
+
+{ #category : #accessing }
+ClassDeprecationRBGlobalNodeTest >> globalNodes [
+	^ self globalNodes: referencingClass >> #references
+]
+
+{ #category : #running }
+ClassDeprecationRBGlobalNodeTest >> setUp [
+	super setUp.
+	referencingClass compile: referencingOriginalSource
+]
+
+{ #category : #tests }
+ClassDeprecationRBGlobalNodeTest >> testDeprecationTransform [
+	| globalNode result |
+	self
+		should: [ self globalNodes third deprecationTransform ]
+		raise: AssertionFailure.
+	globalNode := self globalNodes first.
+	result := globalNode deprecationTransform.
+	globalNode methodNode doSemanticAnalysis.
+	self deny: globalNode equals: result.
+	globalNode := self globalNodes first.
+	self
+		assert: globalNode methodNode formattedCode
+		equals:
+			'references
+	^ {ClassDeprecationForTestReplacement.
+	1.
+	self class.
+	ClassDeprecationForTestDeprecated.
+	ClassDeprecationForTestReferencing}'.
+	self assert: result isVariable.
+	self assert: result isGlobal.
+	self assert: result binding isGlobalClassNameBinding.
+	self assert: result binding value equals: replacementClass
+]
+
+{ #category : #tests }
+ClassDeprecationRBGlobalNodeTest >> testDeprecationTransformMetaLink [
+	| globalNodes |
+	globalNodes := self globalNodes.
+	self
+		should: [ globalNodes first deprecationTransformMetaLink ]
+		raise: NotFound.
+	self
+		should: [ globalNodes second deprecationTransformMetaLink ]
+		raise: NotFound.
+	self
+		should: [ globalNodes third deprecationTransformMetaLink ]
+		raise: NotFound.
+	ClassDeprecationMetaLink enable.
+	globalNodes := self globalNodes.
+	self
+		assert:
+			(globalNodes first deprecationTransformMetaLink
+				isKindOf: ClassDeprecationMetaLink).
+	self
+		assert:
+			(globalNodes second deprecationTransformMetaLink
+				isKindOf: ClassDeprecationMetaLink).
+	self
+		should: [ globalNodes third deprecationTransformMetaLink ]
+		raise: NotFound
+]
+
+{ #category : #tests }
+ClassDeprecationRBGlobalNodeTest >> testHasDeprecationTransformMetaLink [
+	| globalNodes |
+	globalNodes := self globalNodes.
+	self deny: globalNodes first hasDeprecationTransformMetaLink.
+	self deny: globalNodes second hasDeprecationTransformMetaLink.
+	self deny: globalNodes third hasDeprecationTransformMetaLink.
+	ClassDeprecationMetaLink enable.
+	globalNodes := self globalNodes.
+	self assert: globalNodes first hasDeprecationTransformMetaLink.
+	self assert: globalNodes second hasDeprecationTransformMetaLink.
+	self deny: globalNodes third hasDeprecationTransformMetaLink
+]
+
+{ #category : #tests }
+ClassDeprecationRBGlobalNodeTest >> testInstallDeprecationTransformMetaLink [
+	| globalNode |
+	globalNode := self globalNodes first.
+	self assert: globalNode links size equals: 0.
+	globalNode installDeprecationTransformMetaLink.
+	self assert: globalNode links size equals: 1.
+	self
+		assert: (globalNode links first isKindOf: ClassDeprecationMetaLink).
+	globalNode installDeprecationTransformMetaLink.
+	self assert: globalNode links size equals: 1.
+	self
+		assert: (globalNode links first isKindOf: ClassDeprecationMetaLink)
+]
+
+{ #category : #tests }
+ClassDeprecationRBGlobalNodeTest >> testIsDeprecatedTransformable [
+	| globalNodes |
+	globalNodes := self globalNodes.
+	self assert: globalNodes first isDeprecatedTransformable.
+	self assert: globalNodes second isDeprecatedTransformable.
+	self deny: globalNodes third isDeprecatedTransformable
+]
+
+{ #category : #tests }
+ClassDeprecationRBGlobalNodeTest >> testSetUp [
+	| globalNodes |
+	globalNodes := self globalNodes.
+	self assert: globalNodes size equals: 3
+]
+
+{ #category : #tests }
+ClassDeprecationRBGlobalNodeTest >> testUninstallDeprecationTransformMetaLink [
+	| globalNode |
+	globalNode := self globalNodes first.
+	self assert: globalNode links size equals: 0.
+	globalNode uninstallDeprecationTransformMetaLink.
+	self assert: globalNode links size equals: 0.
+	globalNode installDeprecationTransformMetaLink.
+	self assert: globalNode links size equals: 1.
+	globalNode uninstallDeprecationTransformMetaLink.
+	self assert: globalNode links size equals: 0
+]

--- a/src/ClassDeprecation-Tests/ClassDeprecationTest.class.st
+++ b/src/ClassDeprecation-Tests/ClassDeprecationTest.class.st
@@ -1,0 +1,104 @@
+"
+I am a copy of class ClassDeprecationMetaLinkFunctionalTest. This comment is copied from there, and might not be entirely accurate
+
+This class contains tests
+"
+Class {
+	#name : #ClassDeprecationTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'systemAdditions',
+		'wasEnabled',
+		'deprecatedClass',
+		'referencingClass',
+		'referencingOriginalSource',
+		'referencingTransformedSource',
+		'replacementClass',
+		'oldAuthorFullName'
+	],
+	#category : #'ClassDeprecation-Tests'
+}
+
+{ #category : #adding }
+ClassDeprecationTest >> addClassNamed: aSymbol [
+	| class |
+	class := Object
+		subclass: aSymbol
+		instanceVariableNames: ''
+		classVariableNames: ''
+		package: self class category.
+	systemAdditions push: class.
+	^ class
+]
+
+{ #category : #adding }
+ClassDeprecationTest >> deprecateClass: aClass [
+	aClass classSide
+		compile:
+			'isDeprecated
+	^ true'
+]
+
+{ #category : #adding }
+ClassDeprecationTest >> deprecateClass: aClass transformTo: aString [
+	aClass classSide
+		compile:
+			'isDeprecated
+	<transformTo: ''' , aString
+				,
+					'''>
+	^ true'
+]
+
+{ #category : #adding }
+ClassDeprecationTest >> deprecateNotClass: aClass [
+	(aClass classSide >> #isDeprecated) removeFromSystem
+]
+
+{ #category : #accessing }
+ClassDeprecationTest >> globalNodes: aCompiledMethod [
+	^ aCompiledMethod ast allChildren
+		select: [ :e | e isVariable and: [ e isGlobal ] ]
+]
+
+{ #category : #running }
+ClassDeprecationTest >> setUp [
+	super setUp.
+	oldAuthorFullName := Author fullNamePerSe.
+	Author fullName: self class name.
+	systemAdditions := Stack new.
+	wasEnabled := ClassDeprecationMetaLink enabled.
+	ClassDeprecationMetaLink disable.
+	deprecatedClass := self
+		addClassNamed: #ClassDeprecationForTestDeprecated.
+	referencingClass := self
+		addClassNamed: #ClassDeprecationForTestReferencing.
+	replacementClass := self
+		addClassNamed: #ClassDeprecationForTestReplacement.
+	self
+		deprecateClass: deprecatedClass
+		transformTo: replacementClass name.
+	referencingOriginalSource := 'references
+	^ {ClassDeprecationForTestDeprecated.
+	1.
+	self class.
+	ClassDeprecationForTestDeprecated.
+	ClassDeprecationForTestReferencing}'.
+	referencingTransformedSource := 'references
+	^ {ClassDeprecationForTestReplacement.
+	1.
+	self class.
+	ClassDeprecationForTestReplacement.
+	ClassDeprecationForTestReferencing}'.
+]
+
+{ #category : #running }
+ClassDeprecationTest >> tearDown [
+	super tearDown.
+	[ systemAdditions isEmpty ]
+		whileFalse: [ systemAdditions pop removeFromSystem ].
+	ClassDeprecationMetaLink enable: wasEnabled.
+	oldAuthorFullName isEmptyOrNil
+		ifTrue: [ Author reset ]
+		ifFalse: [ Author fullName: oldAuthorFullName ]
+]

--- a/src/ClassDeprecation-Tests/package.st
+++ b/src/ClassDeprecation-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'ClassDeprecation-Tests' }

--- a/src/ClassDeprecation/Class.extension.st
+++ b/src/ClassDeprecation/Class.extension.st
@@ -1,0 +1,34 @@
+Extension { #name : #Class }
+
+{ #category : #'*ClassDeprecation' }
+Class >> deprecationTransformationExpression [
+	"Answers the expression a class reference should be transformed to. Can be any kind of expression, e.g. another class name or a method send."
+
+	^ ((self class compiledMethodAt: #isDeprecated)
+		pragmaAt: #transformTo:) arguments first
+]
+
+{ #category : #'*ClassDeprecation' }
+Class >> installDeprecationTransformMetaLinks [
+	"Installs the deprecationTransformMetaLinks on all methods referencing it."
+
+	self usingMethods
+		do: [ :e | e compiledMethod installDeprecationTransformMetaLinks ]
+]
+
+{ #category : #'*ClassDeprecation' }
+Class >> isDeprecatedTransformable [
+	"Answers whether or not it can be transformed with a deprecation transformation. I.e. it has a class-side #isDeprecated method with a #transformTo: pragma."
+
+	^ (self class includesSelector: #isDeprecated)
+		and: [ ((self class compiledMethodAt: #isDeprecated)
+				hasPragmaNamed: #transformTo:) and: [ self isDeprecated ] ]
+]
+
+{ #category : #'*ClassDeprecation' }
+Class >> uninstallDeprecationTransformMetaLinks [
+	"Uninstalls the deprecationTransformMetaLinks from all methods referencing it."
+
+	self usingMethods
+		do: [ :e | e compiledMethod uninstallDeprecationTransformMetaLinks ]
+]

--- a/src/ClassDeprecation/ClassDeprecationMetaLink.class.st
+++ b/src/ClassDeprecation/ClassDeprecationMetaLink.class.st
@@ -1,0 +1,126 @@
+"
+I am a meta-link that is transforms a reference to a deprecated class to its replacement for subsequent calls to the AST's method.
+"
+Class {
+	#name : #ClassDeprecationMetaLink,
+	#superclass : #MetaLink,
+	#classInstVars : [
+		'enabled'
+	],
+	#category : #ClassDeprecation
+}
+
+{ #category : #protocol }
+ClassDeprecationMetaLink class >> disable [
+	"Disable deprecation transformations if not already disabled. Uninstall all installed meta-links."
+
+	<script>
+	enabled
+		ifFalse: [ ^ self ].
+	enabled := false.
+	SystemAnnouncer uniqueInstance unsubscribe: self.
+	self allInstancesDo: #uninstall
+]
+
+{ #category : #protocol }
+ClassDeprecationMetaLink class >> enable [
+	"Enables deprecation transformations if not already enabled. Installs all meta-links required to perform transformations on execution on already deprecated transformable classes."
+
+	<script>
+	enabled
+		ifTrue: [ ^ self ].
+	enabled := true.
+	SystemAnnouncer uniqueInstance weak
+		when: MethodAdded , MethodModified
+			send: #onMethodAddedOrModified:
+			to: self;
+		when: MethodRemoved send: #onMethodRemoved: to: self.
+	self environment allClassesAndTraits
+		select: #isDeprecatedTransformable
+		thenDo: #installDeprecationTransformMetaLinks
+]
+
+{ #category : #'brick-interactable-actions' }
+ClassDeprecationMetaLink class >> enable: aBoolean [
+	aBoolean
+		ifTrue: [ self enable ]
+		ifFalse: [ self disable ]
+]
+
+{ #category : #'brick-interactable-actions' }
+ClassDeprecationMetaLink class >> enabled [
+	^ enabled
+]
+
+{ #category : #'class initialization' }
+ClassDeprecationMetaLink class >> initialize [
+	enabled := false
+]
+
+{ #category : #protocol }
+ClassDeprecationMetaLink class >> onMethodAddedOrModified: anEvent [
+	"When a method is added or modified, we have to handle two cases:
+
+i) The method is the #isDeprecationTransformableMethod. In that case we have to install meta-links for the transformation of existing references to the deprecated class.
+ii) The method #hasDeprecationTransformableReferences and is not #isDeprecated. In that case we install meta-links for references to deprecated transformable classes"
+
+	| method |
+	method := anEvent method.
+	method isDeprecationTransformableMethod
+		ifTrue: [ method methodClass instanceSide isDeprecated
+				ifTrue:
+					[ method methodClass instanceSide installDeprecationTransformMetaLinks ] ]
+		ifFalse: [ (method hasDeprecationTransformableReferences
+				and: [ method isDeprecated not ])
+				ifTrue: [ method installDeprecationTransformMetaLinks ] ]
+]
+
+{ #category : #protocol }
+ClassDeprecationMetaLink class >> onMethodRemoved: anEvent [
+	"If the removed method is the #isDeprecationTransformableMethod, we remove all existing meta-link for deprecation transforms, as they are no longer valid."
+
+	| method |
+	method := anEvent method.
+	method isDeprecationTransformableMethod
+		ifTrue: [ method methodClass instanceSide
+				uninstallDeprecationTransformMetaLinks ]
+]
+
+{ #category : #settings }
+ClassDeprecationMetaLink class >> settingsOn: aBuilder [
+	<systemsettings>
+	(aBuilder setting: #classDeprecation)
+		label: 'Automated class deprecation transformation' translated;
+		description:
+			'If true, then references to classes that are deprecated and have a #transformTo: pragma will be automatically migrated using the replacement expression'
+				translated;
+		setSelector: #enable:;
+		getSelector: #enabled;
+		target: self;
+		parent: #tools
+]
+
+{ #category : #'as yet unclassified' }
+ClassDeprecationMetaLink >> deprecationTransform: aNode [
+	"Transforms the deprecated node with its replacement and compiles the method to materialize the changes."
+
+	aNode deprecationTransform.
+	Author
+		useAuthor: 'AutoDeprecationRefactoring'
+		during: [ | methodNode method |
+			methodNode := aNode methodNode.
+			method := methodNode method.
+			method origin
+				compile: methodNode formattedCode
+				classified: method protocol ]
+]
+
+{ #category : #initialization }
+ClassDeprecationMetaLink >> initialize [
+	super initialize.
+	self
+		metaObject: self;
+		control: #before;
+		selector: #deprecationTransform:;
+		arguments: #(node).
+]

--- a/src/ClassDeprecation/ClassDeprecationMetaLinkInstaller.class.st
+++ b/src/ClassDeprecation/ClassDeprecationMetaLinkInstaller.class.st
@@ -1,0 +1,15 @@
+"
+I install the deprecated transformation meta-links within the AST.
+"
+Class {
+	#name : #ClassDeprecationMetaLinkInstaller,
+	#superclass : #RBProgramNodeVisitor,
+	#category : #ClassDeprecation
+}
+
+{ #category : #visiting }
+ClassDeprecationMetaLinkInstaller >> visitGlobalNode: aNode [
+	super visitGlobalNode: aNode.
+	aNode isDeprecatedTransformable
+		ifTrue: [ aNode installDeprecationTransformMetaLink ]
+]

--- a/src/ClassDeprecation/ClassDeprecationMetaLinkUninstaller.class.st
+++ b/src/ClassDeprecation/ClassDeprecationMetaLinkUninstaller.class.st
@@ -1,0 +1,15 @@
+"
+I uninstall the deprecated transformation meta-links within the AST.
+"
+Class {
+	#name : #ClassDeprecationMetaLinkUninstaller,
+	#superclass : #RBProgramNodeVisitor,
+	#category : #ClassDeprecation
+}
+
+{ #category : #visiting }
+ClassDeprecationMetaLinkUninstaller >> visitGlobalNode: aNode [
+	super visitGlobalNode: aNode.
+	aNode hasDeprecationTransformMetaLink
+		ifTrue: [ aNode uninstallDeprecationTransformMetaLink ]
+]

--- a/src/ClassDeprecation/CompiledMethod.extension.st
+++ b/src/ClassDeprecation/CompiledMethod.extension.st
@@ -1,0 +1,31 @@
+Extension { #name : #CompiledMethod }
+
+{ #category : #'*ClassDeprecation' }
+CompiledMethod >> hasDeprecationTransformableReferences [
+	"Answers whether or not it references any class that is deprecated and transformable."
+
+	^ self referencedClasses anySatisfy: #isDeprecatedTransformable
+]
+
+{ #category : #'*ClassDeprecation' }
+CompiledMethod >> installDeprecationTransformMetaLinks [
+	"Installs the deprecationTransformMetaLinks on applicable nodes in the AST."
+
+	self ast acceptVisitor: ClassDeprecationMetaLinkInstaller new
+]
+
+{ #category : #'*ClassDeprecation' }
+CompiledMethod >> isDeprecationTransformableMethod [
+	"Answers whether or not it is the method defining the deprecation transformation, which is the class-side #isDeprecated method with a #transformTo: pragma."
+
+	^ self selector = #isDeprecated
+		and: [ self methodClass isClassSide
+				and: [ self hasPragmaNamed: #transformTo: ] ]
+]
+
+{ #category : #'*ClassDeprecation' }
+CompiledMethod >> uninstallDeprecationTransformMetaLinks [
+	"Uninstalls the existing deprecationTransformMetaLinks from the AST."
+
+	self ast acceptVisitor: ClassDeprecationMetaLinkUninstaller new
+]

--- a/src/ClassDeprecation/RBGlobalNode.extension.st
+++ b/src/ClassDeprecation/RBGlobalNode.extension.st
@@ -1,0 +1,59 @@
+Extension { #name : #RBGlobalNode }
+
+{ #category : #'*ClassDeprecation' }
+RBGlobalNode >> deprecationTransform [
+	"Replaces itself with the deprecationTransformExpression of the refererred class."
+
+	| rule class |
+	self assert: [ self isDeprecatedTransformable ].
+	class := self binding value.
+	rule := RBParseTreeRewriter new
+		replace: class name
+		with: class deprecationTransformationExpression.
+	^ (rule executeTree: self)
+		ifTrue: [ | tree |
+			tree := rule tree.
+			self replaceWith: tree.
+			tree ]
+		ifFalse: [ self flag: 'TODO should we log something if nothing is done?'.
+			self ]
+]
+
+{ #category : #'*ClassDeprecation' }
+RBGlobalNode >> deprecationTransformMetaLink [
+	"Answers its deprecationTransformMetaLink, if any."
+
+	^ self links detect: [ :e | e isKindOf: ClassDeprecationMetaLink ]
+]
+
+{ #category : #'*ClassDeprecation' }
+RBGlobalNode >> hasDeprecationTransformMetaLink [
+	"Answers whether or not it has a deprecationTransformMetaLink."
+
+	^ self links
+		anySatisfy: [ :e | e isKindOf: ClassDeprecationMetaLink ]
+]
+
+{ #category : #'*ClassDeprecation' }
+RBGlobalNode >> installDeprecationTransformMetaLink [
+	"Installs a deprecationTransformMetaLink, if not already installed. Does nothing otherwise."
+
+	self hasDeprecationTransformMetaLink
+		ifFalse: [ self link: ClassDeprecationMetaLink new ]
+]
+
+{ #category : #'*ClassDeprecation' }
+RBGlobalNode >> isDeprecatedTransformable [
+	"Answers whether or not it can be transformed with a deprecation transformation. Currently, only class references can be transformed."
+
+	^ self binding isGlobalClassNameBinding
+		and: [ self binding value isDeprecatedTransformable ]
+]
+
+{ #category : #'*ClassDeprecation' }
+RBGlobalNode >> uninstallDeprecationTransformMetaLink [
+	"Uninstalls the deprecationTransformMetaLink, if already installed. Does nothing otherwise."
+
+	self hasDeprecationTransformMetaLink
+		ifTrue: [ self removeLink: self deprecationTransformMetaLink ]
+]

--- a/src/ClassDeprecation/package.st
+++ b/src/ClassDeprecation/package.st
@@ -1,0 +1,1 @@
+Package { #name : #ClassDeprecation }


### PR DESCRIPTION
I added a mechanism to use transformations for replacing deprecated classes that have a one-to-one replacement. It works by adding pragma to the class-side `#isDeprecated` method, e.g.
```
SomeDeprecatedClass class >> #isDeprecated 
    <transformTo: 'ReplacementClass'>
    ^ true
```
Once the pragma is added, all methods referencing the deprecated transformable class are instrumented. Before the reference to a deprecated class a meta-link is inserted that replaces the reference with the replacement expression (it uses the RB transformation language, hence it can be any expression, not just another class reference).

To make it work, I had to adapt two meta-link related methods in Calypso, as it may happen that a meta-link is uninstalled on a method that does not have a methodClass anymore. I could not reliably reproduce this though, but it seems to be happening when Calypso is refreshing system queries.