### PR TITLE
[shortToReview] remove call to basicNew in Object >> #->

### DIFF
--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -248,7 +248,7 @@ Object >> -> anObject [
 	
 	"Note that key and value can be ANY object."
 	
-	^Association basicNew key: self value: anObject
+	^Association key: self value: anObject
 ]
 
 { #category : #comparing }


### PR DESCRIPTION
If that is, in fact, normal, it should have a comment saying why. 
(Like if it's used in the boostrap? Although I feel this is probably too high level for that)

There's other references to basicNew in Object, but I don't feel as comfortable removing them :p
