### PR TITLE
Fix spotter openning bug

### DIFF
--- a/src/BaselineOfPharoGT/BaselineOfPharoGT.class.st
+++ b/src/BaselineOfPharoGT/BaselineOfPharoGT.class.st
@@ -7,10 +7,6 @@ Class {
 { #category : #baselines }
 BaselineOfPharoGT >> baseline: spec [
 	<baseline>
-	
-	| repository | 
-	
-	repository := self packageRepositoryURL.	
 
 	spec for: #'common' do: [
 		spec postLoadDoIt: #'postload:package:'.

--- a/src/GT-Spotter-UI/GTSpotterHeaderBrick.class.st
+++ b/src/GT-Spotter-UI/GTSpotterHeaderBrick.class.st
@@ -134,7 +134,7 @@ GTSpotterHeaderBrick >> onThemerChanged [
 	self themer spotterThemer headerWidgetStyleFor: self.
 	self themer spotterThemer closeButtonWidgetStyleFor: self closeButton.
 	self themer spotterThemer searchFieldWidgetStyleFor: self searchField.
-	self themer spotterThemer settingsButtonWidgetStyleFor: self settingsButton
+	self class environment at: #GTEventRecorderSettings ifPresent: [self themer spotterThemer settingsButtonWidgetStyleFor: self settingsButton] 
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
As the settings button is added only when #GTEventRecorderSettings is there. Since it has been deleted, the same check should be done. 

Also cleaning the baseline.

