### PR TITLE
In bootstrap: Preparing heap before writing the image to shrink its size

### DIFF
--- a/bootstrap/src/Pharo30Bootstrap/PBImageBuilderSpur50.class.st
+++ b/bootstrap/src/Pharo30Bootstrap/PBImageBuilderSpur50.class.st
@@ -508,6 +508,7 @@ PBImageBuilderSpur50 >> writeSnapshot: imageFileName ofTransformedImage: spurHea
 				ifFalse: [ex pass]]."
 	sim := spurHeap coInterpreter.
 	sim bootstrapping: true.
+	spurHeap segmentManager prepareForSnapshot.
 	spurHeap
 		setEndOfMemory: spurHeap endOfMemory + spurHeap bridgeSize. "hack; initializeInterpreter: cuts it back by bridgeSize"
 	sim initializeInterpreter: 0;


### PR DESCRIPTION
Fixes the problem in which all bootstrapped images are generated weighting 30 MB aprox.