### PR TITLE
[Do not integrate] DeprecatedGlobalVariable experiment

### DIFF
--- a/src/Announcements-Core/DeprecatedClassExample.class.st
+++ b/src/Announcements-Core/DeprecatedClassExample.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #DeprecatedClassExample,
+	#superclass : #Object,
+	#category : #'Announcements-Core'
+}
+
+{ #category : #testing }
+DeprecatedClassExample class >> isDeprecated [ 
+	^true
+]
+
+{ #category : #deprecation }
+DeprecatedClassExample class >> readDeprecatedValue [
+
+	self
+		deprecated: 'Please use #crTrace678 instead'
+		transformWith: 'DeprecatedClassExample' -> 'Object'.
+
+	^self
+]

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -768,6 +768,12 @@ Object >> deprecated: anExplanationString transformWith: aRule when: conditionBl
 		
 ]
 
+{ #category : #deprecation }
+Object >> deprecationUserExample [
+
+	^(Array with: DeprecatedClassExample) first binding asString
+]
+
 { #category : #displaying }
 Object >> displayString [
 	"While printString is about to give a detailled information about an object, displayString is a message that should return a short string-based representation to be used by list and related UI frameworks. By default, simply return printString.
@@ -1672,6 +1678,12 @@ Object >> putOn: aStream [
 	Return self."
 	
 	aStream nextPut: self
+]
+
+{ #category : #deprecation }
+Object >> readDeprecatedValue [
+	self deprecated: 'This object is deprecated'.
+	^self
 ]
 
 { #category : #reading }

--- a/src/Slot-Core/DeprecatedGlobalVariable.class.st
+++ b/src/Slot-Core/DeprecatedGlobalVariable.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #DeprecatedGlobalVariable,
+	#superclass : #GlobalVariable,
+	#category : #'Slot-Core-Variables'
+}
+
+{ #category : #'code generation' }
+DeprecatedGlobalVariable >> emitValue: methodBuilder [
+
+	methodBuilder pushLiteralVariable: self; send: #readDeprecatedValue
+]


### PR DESCRIPTION
It is a proof of idea to represent deprecated classes with special first class variable: DeprecatedGlobalVariable. 
It compiles the variable read as a message send #readDeprecatedValue to the class. So existing method deprecation logic can be reused here:
- by default it calls simple #deprecated: message which shows the warning
- concrete classes can transform senders using rewrite expression

The PR does not implement the hook to use new variable instead of existing GlobalVariable binding.
So for testing load PR and evaluate following code:
```Smalltalk
DeprecatedClassExample binding primitiveChangeClassTo: DeprecatedGlobalVariable new.
```
PR includes example of deprecated class user. To see transformation evaluate:
```Smalltalk
nil deprecationUserExample.
```
Try also remove the method DeprecatedClassExample class>>#readDeprecatedValue to see the simple warning.

For real usage the following logic needs to be implemented:
- compiler plugin to alter the class binding when #isDeprecated method is modified(created/removed). 
- support full package deprecation where bindings of all classes becomes deprecated. Package deprecation is also based on #isDeprecated method (for Manifest class). So the compiler plugin can be responsible for this logic also.
- improve existing Deprecated class to take into account the class deprecation scenario. Now the warning tells that method #readDeprecatedValue is deprecated but it should talk about class. Probably it would require two separate subclasses: MethodDeprecated and ClassDeprecated