### PR TITLE
5190-Match-comments-should-turned-into-executable-comments

### DIFF
--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2031,23 +2031,23 @@ String >> match: text [
 	"Answer whether text matches the pattern in this string.
 	Matching ignores upper/lower case differences.
 	Where this string contains #, text may contain any character.
-	Where this string contains *, text may contain any sequence of characters.
-	'*'			match: 'zort' true
-	'*baz'		match: 'mobaz' true
-	'*baz'		match: 'mobazo' false
-	'*baz*'		match: 'mobazo' true
-	'*baz*'		match: 'mozo' false
-	'foo*'		match: 'foozo' true
-	'foo*'		match: 'bozo' false
-	'foo*baz'	match: 'foo23baz' true
-	'foo*baz'	match: 'foobaz' true
-	'foo*baz'	match: 'foo23bazo' false
-	'foo'		match: 'Foo' true
-	'foo*baz*zort' match: 'foobazort' false
-	'foo*baz*zort' match: 'foobazzort' false
-	'*foo#zort'	match: 'afoo3zortthenfoo3zort' true
-	'*foo*zort'	match: 'afoodezortorfoo3zort' true
-"
+	Where this string contains *, text may contain any sequence of characters."
+	
+	"('*' match: 'zort') >>> true"
+	"('*baz' match: 'mobaz') >>> true"
+	"('*baz' match: 'mobazo') >>>false"
+	"('*baz*' match: 'mobazo') >>> true"
+	"('*baz*' match: 'mozo') >>> false"
+	"('foo*' match: 'foozo') >>> true"
+	"('foo*' match: 'bozo') >>> false"
+	"('foo*baz' match: 'foo23baz') >>> true"
+	"('foo*baz' match: 'foobaz') >>> true"
+	"('foo*baz' match: 'foo23bazo') >>> false"
+	"('foo' match: 'Foo') >>> true"
+	"('foo*baz*zort' match: 'foobazort') >>> false"
+	"('foo*baz*zort' match: 'foobazzort') >>> false"
+	"('*foo#zort' match: 'afoo3zortthenfoo3zort') >>> true"
+	"('*foo*zort' match: 'afoodezortorfoo3zort') >>> true"
 
 	^ self startingAt: 1 match: text startingAt: 1
 ]


### PR DESCRIPTION
fixes: #5190
added executable comments