### PR TITLE
3437-Add-test-for-Adding-an-instance-class-variable-remove-the-traits-of-a-class

### DIFF
--- a/src/TraitsV2-Tests/T2TraitWithComplexSlotsTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithComplexSlotsTest.class.st
@@ -66,6 +66,31 @@ T2TraitWithComplexSlotsTest >> testTraitWithComplexSlot [
 ]
 
 { #category : #'instance creation' }
+T2TraitWithComplexSlotsTest >> testTraitWithComplexSlotAddClassSlot [
+	| t1 c1 |
+	self createSlotClass.
+	t1 := self newTrait: #T1 with: { #ivar }.
+	c1 := self newClass: #C1 with: { #aSlot } uses: { t1 }.
+	self assert: (c1 traitComposition includesTrait: t1).
+	c1 addClassSlot:  #ivar2 => InstanceVariableSlot.
+	self assert: c1 instVarNames equals: #( aSlot ivar ).
+	self assert: c1 class instVarNames equals: #( ivar2 ).
+	self assert: (c1 traitComposition includesTrait: t1)
+]
+
+{ #category : #'instance creation' }
+T2TraitWithComplexSlotsTest >> testTraitWithComplexSlotAddSlot [
+	| t1 c1 |
+	self createSlotClass.
+	t1 := self newTrait: #T1 with: { #ivar }.
+	c1 := self newClass: #C1 with: { #aSlot } uses: { t1 }.
+	self assert: (c1 traitComposition includesTrait: t1).
+	c1 addSlot: #ivar2 => InstanceVariableSlot.
+	self assert: c1 instVarNames equals: #( aSlot ivar2 ivar ).
+	self assert: (c1 traitComposition includesTrait: t1)
+]
+
+{ #category : #'instance creation' }
 T2TraitWithComplexSlotsTest >> testTraitWithComplexSlotAfter [
 	| t1 c1 obj |
 	

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -193,10 +193,11 @@ TraitedMetaclass >> isLocalAliasSelector: aSymbol [
 
 { #category : #testing }
 TraitedMetaclass >> isLocalMethodsProtocol: aProtocol [
+	"Checks if the given protocol includes any local defined selector"
 
-	"Checks if the given protocol includes any local defined selector"	
-	aProtocol methods ifEmpty: [ ^true ].
-	^aProtocol methods anySatisfy: [ :each | self isLocalSelector: each]
+	aProtocol methodSelectors ifEmpty: [ ^ true ].
+	^ aProtocol methodSelectors anySatisfy: [ :each | 
+		  self isLocalSelector: each ]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
- add test for adding a class side slot (class instance variable) and check that it gets added. 
- Check especially that the class does not lose the trait.
- add another test just testing adding slots, not class side slots
- autimattic deprecation rewrite

fixes #3437