### PR TITLE
4454-TraitedMetaClassisRejectedMethod-rejects-too-many-methods

### DIFF
--- a/src/TraitsV2-Tests/T2SubclassingTraitedClassTest.class.st
+++ b/src/TraitsV2-Tests/T2SubclassingTraitedClassTest.class.st
@@ -34,3 +34,12 @@ T2SubclassingTraitedClassTest >> testCreatingMethodInSubclass2 [
 	self assert: (c2 >> #asd) package name equals: 'TraitsV2-Tests'.
 	self assert: (c2 >> #asd) package equals: c2 package.
 ]
+
+{ #category : #tests }
+T2SubclassingTraitedClassTest >> testCreatingMethodInTraitClassSide [
+	| t1 c1 |
+	t1 := self newTrait: #T1 with: #() uses: {}.
+	t1 class compile: 'someObject ^#executingOverridenMethod'.	
+	c1 := self newClass: #C1 with: #() uses: t1.
+	self assert: c1 someObject equals: #executingOverridenMethod.
+]

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -207,30 +207,31 @@ TraitedMetaclass >> isLocalSelector: aSelector [
 
 { #category : #testing }
 TraitedMetaclass >> isRejectedMethod: aSelector [
-	"The method is not installed in method dictionary if:
-	 - It is in the localMethods.
-	 - It is from Class (we already have them) and they are not overriden in TraitedClass.
-	 - If it is in TraitedClass and it is in my superclass (except if the trait I used defines the selector myself).
-	"
+	"Determine if the method is not to be installed in method dictionary"
 
-	| isFromClass isFromTraitedClass isMySuperclassTraitedClass isTheTraitIUseDefinesTheSelector |
+	| isFromClass isFromTraitedClass isTheTraitIUseDefinesTheSelector isMySuperclassTraitedClass |
+	
+	"the selector is one of the local methods"
 	(self isLocalSelector: aSelector)
 		ifTrue: [ ^ true ].
+		
+	"If a trait I used define the selector, we do not reject"	
+	isTheTraitIUseDefinesTheSelector := self traitComposition traits anySatisfy: [:inTrait | 
+		inTrait localMethods anySatisfy: [ :meth | meth selector = aSelector ]].
+	isTheTraitIUseDefinesTheSelector ifTrue:[ ^false ].	
 
+	
 	isFromClass := Class canUnderstand: aSelector.
 	isFromTraitedClass := TraitedClass methodDict includesKey: aSelector.
-	isMySuperclassTraitedClass := (superclass isKindOf: TraitedMetaclass) and: [superclass isObsolete not].
+	isMySuperclassTraitedClass := (superclass isKindOf: TraitedMetaclass) and: [
+	superclass isObsolete not].
 	
+	"It is from Class (we already have them) and they are not overriden in TraitedClass"
+	(isFromClass and: [ isFromTraitedClass not ]) ifTrue: [ ^ true ].
 	
-	(isFromClass and: [ isFromTraitedClass not ])
-		ifTrue: [ ^ true ].
-
+	"If it is in TraitedClass and it is in my superclass."
 	(isFromTraitedClass and: isMySuperclassTraitedClass)
-		ifTrue: [
-			isTheTraitIUseDefinesTheSelector := self traitComposition traits anySatisfy: [:inTrait | inTrait localMethods anySatisfy: [ :meth | meth selector = aSelector ]].
-			isTheTraitIUseDefinesTheSelector ifTrue:[ ^false ].
-			 ^ true ].
-
+		ifTrue: [ ^ true ].
 	^ false
 ]
 


### PR DESCRIPTION
- change #isRejectedMethod: to never reject methods that are in the trait composition
- inline the comments into the code (easier to understand)

Traits tests are green

fixes #4454 (I hope)