### PR TITLE
[Perfs] Categorizer >> #numberOfCategoryOfElement: 

### DIFF
--- a/src/Kernel/Categorizer.class.st
+++ b/src/Kernel/Categorizer.class.st
@@ -398,21 +398,16 @@ Categorizer >> listAtProtocolNamed: categoryName [
 ]
 
 { #category : #private }
-Categorizer >> numberOfCategoryOfElement: element [ 
+Categorizer >> numberOfCategoryOfElement: element [
 	"Answer the index of the category with which the argument, element, is 
 	associated."
 
-	| categoryIndex elementIndex |
-	categoryIndex := 1.
-	elementIndex := 0.
-	[(elementIndex := elementIndex + 1) <= elementArray size]
-		whileTrue: 
-			["point to correct category"
-			[elementIndex > (categoryStops at: categoryIndex)]
-				whileTrue: [categoryIndex := categoryIndex + 1].
-			"see if this is element"
-			element = (elementArray at: elementIndex) ifTrue: [^categoryIndex]].
-	^0
+	| indexOfElementInElementArray |
+	indexOfElementInElementArray := elementArray
+		                                identityIndexOf: element asSymbol
+		                                ifAbsent: [ ^ 0 ].
+	^ categoryStops findFirst: [ :stopIndex | 
+		  stopIndex >= indexOfElementInElementArray ]
 ]
 
 { #category : #'queries - protocol' }


### PR DESCRIPTION
Divide by 2 the time taken to get a category from the Categorizer.

Benchmarks report (from https://github.com/pharo-project/pharo-benchmarks/pull/3): 

Before:
> Report for: ClassOrganizationAccessingBenchmarks
> Benchmark SystemOrganizerAMiddleItem
> SystemOrganizerAMiddleItem total: iterations=10 runtime: 59.40ms +/-0.62
> 
> Benchmark SystemOrganizerOneOfLastItems
> SystemOrganizerOneOfLastItems total: iterations=10 runtime: 267.9ms +/-1.8
> 
> Benchmark SystemOrganizerANonExistingItem
> SystemOrganizerANonExistingItem total: iterations=10 runtime: 274.20ms +/-0.80
> 
> Benchmark SystemOrganizerOneOfFirstItems
> SystemOrganizerOneOfFirstItems total: iterations=10 runtime: 1.00ms +/-0.60

After:
> Report for: ClassOrganizationAccessingBenchmarks
> Benchmark SystemOrganizerAMiddleItem
> SystemOrganizerAMiddleItem total: iterations=10 runtime: 25.40ms +/-0.30
> 
> Benchmark SystemOrganizerOneOfLastItems
> SystemOrganizerOneOfLastItems total: iterations=10 runtime: 109.20ms +/-0.53
> 
> Benchmark SystemOrganizerANonExistingItem
> SystemOrganizerANonExistingItem total: iterations=10 runtime: 85.10ms +/-0.42
> 
> Benchmark SystemOrganizerOneOfFirstItems
> SystemOrganizerOneOfFirstItems total: iterations=10 runtime: 0.70ms +/-0.54
