### PR TITLE
Completion: parse with requestor

### DIFF
--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -12,7 +12,8 @@ Class {
 		'node',
 		'isWorkspace',
 		'class',
-		'entries'
+		'entries',
+		'editor'
 	],
 	#classVars : [
 		'SorterClass'
@@ -75,6 +76,7 @@ CompletionContext >> engine: aCompletionEngine class: aClass source: aString pos
 	class := aClass. 
 	source := aString.
 	position := anInteger.
+	editor := aCompletionEngine editor.
 	
 	isWorkspace:= aCompletionEngine 
 		ifNotNil: [ aCompletionEngine isScripting ]
@@ -139,6 +141,7 @@ CompletionContext >> parseSource [
 	ast := class compiler
 		source: source;
 		noPattern: isWorkspace;
+		requestor: editor;
 		options: #(+ optionParseErrors + optionSkipSemanticWarnings);
 		parse.
 	ast doSemanticAnalysis.


### PR DESCRIPTION
To be able to access the vars defined in the playground / workspace, we need to compile with the editor as the requestor.

This PR just makes sure to parse with a requestor, it does not yet try to suggest the variabls defined by the requestor