### PR TITLE
OrderedClassPool

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -294,9 +294,9 @@ Class >> classInstaller [
 
 { #category : #accessing }
 Class >> classPool [
-	"Answer the dictionary of class variables."
+	"Answer the ordred dictionary of class variables"
 
-	^classPool ifNil: [ classPool := Dictionary new ]
+	^classPool ifNil: [ classPool := OrderedDictionary new ]
 ]
 
 { #category : #accessing }

--- a/src/Slot-Core/OrderedDictionary.extension.st
+++ b/src/Slot-Core/OrderedDictionary.extension.st
@@ -1,0 +1,25 @@
+Extension { #name : #OrderedDictionary }
+
+{ #category : #'*Slot-Core' }
+OrderedDictionary >> declareVariable: newGlobal from: aDictionary [ 
+	"Add aGlobal to the receiver. If key already exists, do nothing. If aDictionary 
+	includes key, then remove it from aDictionary and use its association as 
+	the element of the receiver."
+
+	| globalName |
+	globalName := newGlobal key.
+	self associationAt: globalName ifPresent:  [:existingGlobal |
+		"need to take care to migrate existing variables to new global if class if different"
+		(existingGlobal class == newGlobal class) 
+			ifTrue: [^self].
+		newGlobal value: existingGlobal value.
+		self removeKey: globalName.
+		self add: newGlobal.
+		].
+	(aDictionary includesKey: globalName)
+		ifTrue:  [
+			self add: ((aDictionary associationAt: globalName) primitiveChangeClassTo: ClassVariable new).
+			aDictionary removeKey: globalName]
+		ifFalse: [
+			self add: newGlobal]
+]


### PR DESCRIPTION
The class pool is not ordered. This leads to the sad state of affairs that we ordere the #classVarNames when we access them...

This is an experiment to see what breakes if we just make them OrderedDisctionaries. The next step then is to remove the #sort from #classVarNames...