### PR TITLE
Adding halt to the list of captured exceptions when single stepping

### DIFF
--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1674,7 +1674,6 @@ Context >> runUntilErrorOrReturnFrom: aSender [
 	context := aSender insertSender: (Context
 		contextOn: Error, Halt do: [:ex |
 			error ifNil: [
-				"this is ugly but it fixes the side-effects of not sending an Unhandled error on Halt"
 				error := ex.
 				topContext := thisContext.
 				ex resumeUnchecked: here jump ]

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1672,10 +1672,10 @@ Context >> runUntilErrorOrReturnFrom: aSender [
 	"Insert ensure and exception handler contexts under aSender"
 	error := nil.
 	context := aSender insertSender: (Context
-		contextOn: Error do: [:ex |
+		contextOn: Error, Halt do: [:ex |
 			error ifNil: [
 				"this is ugly but it fixes the side-effects of not sending an Unhandled error on Halt"
-				error := (ex isKindOf: UnhandledError) ifTrue: [ ex exception ] ifFalse: [ ex ].
+				error := ex.
 				topContext := thisContext.
 				ex resumeUnchecked: here jump ]
 			ifNotNil: [ ex pass ]]).


### PR DESCRIPTION
- Halt was missing from the catched exceptions, was it removed on pur…pose? (present in P5, removed in P6)

- UnhandledError cannot be catched, as it is not a subclass of Error
#fixes #5280 