### PR TITLE
[Perfs] x10 on method compiling with #deferFlushDuring:

### DIFF
--- a/src/System-Sources/CompiledMethod.extension.st
+++ b/src/System-Sources/CompiledMethod.extension.st
@@ -20,10 +20,9 @@ CompiledMethod >> putSource: source withPreamble: preambleBlock [
 	SourceFiles 
 		writeSource: source 
 		preamble: (String streamContents: preambleBlock)
-		onSuccess: [ :newSourcePointer | 
+		onSuccess: [ :newSourcePointer :theChangesFileStream |
 			"Method chunk needs a final ! !"
-			SourceFiles changesWriteStreamDo: [ :file | 
-				(ChunkWriteStream on: file) nextPut: ' ' ].
+			(SourceChunkWriteStream on: theChangesFileStream) nextPut: ' '.
 			"Update with new source pointer"
 			self setSourcePointer: newSourcePointer ]
 		onFail: [ 

--- a/src/System-Sources/SourceChunkWriteStream.class.st
+++ b/src/System-Sources/SourceChunkWriteStream.class.st
@@ -1,0 +1,33 @@
+"
+I am a special ChunkWriteStream used to write on the streams without the flushing part.
+If the flushing part can be changed in my super class then my existence must be terminated.
+"
+Class {
+	#name : #SourceChunkWriteStream,
+	#superclass : #ChunkWriteStream,
+	#category : #'System-Sources-Utilities'
+}
+
+{ #category : #accessing }
+SourceChunkWriteStream >> nextPut: aString [
+	"Append the argument, aString, to the receiver, doubling embedded ! terminators and adding a extra one"
+
+	| string start bangIndex |
+	string := aString asString.
+	start := 1.
+	[ 
+	(bangIndex := string indexOf: self terminatorMark startingAt: start)
+	= 0 ] whileFalse: [ 
+		decoratedStream
+			next: bangIndex - start + 1
+			putAll: string
+			startingAt: start.
+		self bang. "double it"
+		start := bangIndex + 1 ].
+	decoratedStream
+		next: string size - start + 1
+		putAll: string
+		startingAt: start.
+	self bang. "one extra"
+	decoratedStream setToEnd
+]

--- a/src/System-Sources/SourceFile.class.st
+++ b/src/System-Sources/SourceFile.class.st
@@ -50,6 +50,14 @@ SourceFile >> cr [
 ]
 
 { #category : #accessing }
+SourceFile >> ensureWrittenPosition: aPosition [
+
+	self isReadOnly ifTrue: [ ^ self ].
+	
+	stream ensureWrittenPosition: aPosition
+]
+
+{ #category : #accessing }
 SourceFile >> flush [
 
 	(stream isNil or: [ stream isReadOnly ])

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -286,7 +286,7 @@ SourceFileArray >> readStreamAt: sourcePointer ifPresent: presentBlock ifAbsent:
 { #category : #'private - accessing file streams' }
 SourceFileArray >> readStreamAtFileIndex: index atPosition: position ifPresent: presentBlock ifAbsent: absentBlock [
  
-   | queue stream rofa result |
+   | queue stream rofa result file |
        
   	queue := readOnlyQueue.
   	rofa := queue nextOrNil ifNil: [ self createReadOnlyFiles ].
@@ -296,11 +296,15 @@ SourceFileArray >> readStreamAtFileIndex: index atPosition: position ifPresent: 
    stream := rofa at: index.
 	stream ifNil: [ ^ absentBlock value ].
 	
-   position > (files at: index) size ifTrue: [ 
+	file := files at: index.
+	
+   position > file size ifTrue: [ 
 		self finishedReading: rofa from: queue. 
 		^ absentBlock value 
 	].
-
+	
+	file ensureWrittenPosition: position.
+	
    stream position: position.
    result := presentBlock value: stream.
        

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -409,6 +409,7 @@ SourceFileArray >> timeStampAt: sourcePointer for: sourceDataPointers [
 
 	| preamble stamp tokens stampPosition |
 	stamp := ''.
+	flushChanges ifFalse: [ ^ stamp ].
 	preamble := self sourcedDataAt: sourcePointer.
 	(preamble includesSubstring: sourceDataPointers key)
 		ifTrue: [ 
@@ -433,9 +434,10 @@ SourceFileArray >> writeSource: aString preamble: preamble onSuccess: successBlo
 	file setToEnd.
 	file nextPutAll: preamble.
 	position := file position.
-	(ChunkWriteStream on: file) nextChunkPut: aString.
+	(SourceChunkWriteStream on: file) nextChunkPut: aString.
+
+	successBlock cull: (self sourcePointerFromFileIndex: 2 andPosition: position) cull: file.
 
 	self flushChangesFile.
 
-	successBlock value: (self sourcePointerFromFileIndex: 2 andPosition: position)
 ]

--- a/src/System-Sources/SourceFileBufferedReadWriteStream.class.st
+++ b/src/System-Sources/SourceFileBufferedReadWriteStream.class.st
@@ -103,6 +103,14 @@ SourceFileBufferedReadWriteStream >> defaultBufferSize [
 ]
 
 { #category : #writing }
+SourceFileBufferedReadWriteStream >> ensureWrittenPosition: aPosition [
+
+	isDirty ifFalse: [ ^ self ].
+	(self isPositionInBuffer: aPosition)
+		ifTrue: [ self flush ]
+]
+
+{ #category : #writing }
 SourceFileBufferedReadWriteStream >> flush [
 	
 	isDirty ifFalse: [ ^ self ]. 

--- a/src/System-Sources/SourceFileCharacterReadWriteStream.class.st
+++ b/src/System-Sources/SourceFileCharacterReadWriteStream.class.st
@@ -48,6 +48,11 @@ SourceFileCharacterReadWriteStream >> cr [
 ]
 
 { #category : #accessing }
+SourceFileCharacterReadWriteStream >> ensureWrittenPosition: aPosition [
+	writeStream wrappedStream ensureWrittenPosition: aPosition
+]
+
+{ #category : #accessing }
 SourceFileCharacterReadWriteStream >> flush [
 
 	writeStream flush

--- a/src/Tests/SourceFileArrayTest.class.st
+++ b/src/Tests/SourceFileArrayTest.class.st
@@ -360,6 +360,29 @@ SourceFileArrayTest >> testWriteSourceWritesInGivenSourceFileArray [
 ]
 
 { #category : #testing }
+SourceFileArrayTest >> testWriteSourceWritesInGivenSourceFileArrayWithFlushDefering [
+	| fs array |
+	fs := FileSystem memory.
+	array := SourceFileArray new.
+	array
+		changesFileStream:
+			(SourceFile on: 'changes.chunk' potentialLocations: { fs root })
+				tryOpen;
+		sourcesFileStream:
+			(SourceFile on: 'sources.chunk' potentialLocations: { fs root })
+				tryOpen;
+		deferFlushDuring: [ 
+			array
+				writeSource: 'some source'
+				preamble: 'some preamble'
+				onSuccess: [ :arg1 |  ]
+				onFail: [ self fail ] ].
+	self
+		assert: (fs / 'changes.chunk') contents
+		equals: 'some preamblesome source!'
+]
+
+{ #category : #testing }
 SourceFileArrayTest >> testWriteToBufferedStream [
 	| fs array |
 	fs := FileSystem memory.


### PR DESCRIPTION
Changes:
- Avoid flushing at the end of each chunk.
- Tools should not read the logfile when the deferFlushing is active because it can read incomplete chunks.

Bench:
Before:

> SourceFiles deferFlushDuring: [  [EphemeronTest compile: 'test ^true' ] bench]  "'82.668 per second'"

After:
>SourceFiles deferFlushDuring: [  [EphemeronTest compile: 'test ^true' ] bench]  "'1066.573 per second'"

