### PR TITLE
5290-Finder-example-search-break-with-two-argument-keyword-selectors

### DIFF
--- a/src/Tool-Finder/FinderExampleMethodNode.class.st
+++ b/src/Tool-Finder/FinderExampleMethodNode.class.st
@@ -17,10 +17,8 @@ FinderExampleMethodNode >> childNodeClassFromItem: anItem [
 
 { #category : #private }
 FinderExampleMethodNode >> receiver [
-	| index rec |
-	index := self item findString: self selector.
-	rec := self item copyFrom: 1 to: index - 1.
-	^ Smalltalk compiler evaluate: rec
+	"return the receiver of my item."
+	^(RBParser parseExpression: self item) receiver evaluate
 ]
 
 { #category : #private }


### PR DESCRIPTION
Fixes #5290 and #5189
Use the compiler instead of string manipulation - it is more robust