### PR TITLE
5250-someClass-basicNew-printString-fails-for-around-10000-classes

### DIFF
--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1645,7 +1645,9 @@ Object >> printString [
 	"Answer a String whose characters are a description of the receiver. 
 	If you want to print without a character limit, use fullPrintString."
 
-	^ self printStringLimitedTo: 50000
+	[^ self printStringLimitedTo: 50000]
+	on: Exception
+	do: [ ^ 'an unPrintable/unInitialized ', self class name ]
 ]
 
 { #category : #printing }


### PR DESCRIPTION
Fixes #5250
Introduce a robustness to the general #printString. All non-failing printString calls continue to work. The fix is in particularly nice when debugging initialization code.