### PR TITLE
4565-Changing-Trait-and-package-during-class-compilation-at-the-same-time-does-not-work

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -780,16 +780,13 @@ RPackage >> importPackage: anRPackage [
 ]
 
 { #category : #private }
-RPackage >> importProtocol: aProtocol forClass: aClass [ 
-	"import all the methods of a protocol as defined in the receiver." 
-	
-		(aClass organization listAtCategoryNamed: aProtocol)
-			do: [:each | 
-				| aCompiledMethod |
-				aCompiledMethod := (aClass >> each).
-				aCompiledMethod isFromTrait ifFalse: [ self addMethod: aCompiledMethod ]].
-	
-	
+RPackage >> importProtocol: aProtocol forClass: aClass [
+	"import all the methods of a protocol as defined in the receiver."
+
+	(aClass organization listAtCategoryNamed: aProtocol) do: [ :each | 
+		aClass
+			compiledMethodAt: each
+			ifPresent: [ :method | method isFromTrait ifFalse: [ self addMethod: method ] ] ]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Make RPackage more robust against classes with categories in a bad state (that is, categorizer thinks there are methods but ther are none)

This fixes #4565, but of course this is a workaround..... I will open a new issue to fix the problem that when you remove a trait from a class, the categories are not cleaned.