### PR TITLE
5282-MessageNotUnderstood-TextfindLastOccurrenceOfStringstartingAt-

### DIFF
--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -972,7 +972,7 @@ SHRBTextStyler >> pixelHeight [
 SHRBTextStyler >> privateStyle: aText [
 	| ast |
 	ast := classOrMetaClass compiler
-		source: aText;
+		source: aText asString;
 		noPattern: self isForWorkspace ;
 		options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
 		requestor: workspace;


### PR DESCRIPTION
make sure the parser is handed a string, not a text. fixes #5282