### PR TITLE
Completion Fix backStop, use selectorTable

### DIFF
--- a/src/NECompletion/RBProgramNode.extension.st
+++ b/src/NECompletion/RBProgramNode.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #RBProgramNode }
 { #category : #'*NECompletion' }
 RBProgramNode >> completionEntries: offset [
 	"for now we give all selectors as a fallback, maybe we should add variables, too"
-	^Symbol allSelectors 
+	^Symbol selectorTable 
 		select: [ :each | each beginsWith: (self completionToken: offset)] 
 		thenCollect: [ :each | NECSymbolEntry contents: each node: self ]
 


### PR DESCRIPTION
fix the backstop code: we need to use #selectorTable to get all possible method selectors as possible completions