### PR TITLE
5300-Traits-categories-are-not-updated-when-rebuilding-classes

### DIFF
--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -136,6 +136,13 @@ ClassOrganization >> classify: selector under: aProtocolName suppressIfDefault: 
 	oldCategory ifNotNil: [ self notifyOfChangedSelector: selector from: oldCategory to: aProtocolName ]
 ]
 
+{ #category : #cleanup }
+ClassOrganization >> cleanUpCategoriesForClass: aClass [
+	"remove all entries that have no methods"
+	 self allMethodSelectors do: [:each | 
+		(aClass includesSelector: each) ifFalse: [self removeElement: each ]].
+]
+
 { #category : #accessing }
 ClassOrganization >> comment [
 

--- a/src/TraitsV2-Tests/T2TraitTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitTest.class.st
@@ -229,6 +229,20 @@ T2TraitTest >> testRemovingTraitsRemoveTraitedClassMethodsWithSubclasses [
 ]
 
 { #category : #tests }
+T2TraitTest >> testRemovingTraitsUpdatesCategories [
+	| t1 t2 c1 |
+	
+	t1 := self createT1.
+	t2 := self createT2.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: t1 + t2.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: {}.		
+
+	c1 organization allMethodSelectors do: [:each | self assert: (c1 includesSelector: each) ].
+	c1 class organization allMethodSelectors do: [:each | 
+		self assert: (c1 class includesSelector: each) ]
+]
+
+{ #category : #tests }
 T2TraitTest >> testSelectorsWithExplicitOrigin [
 	"Obtain the subset of selectors that are defined either locally or inherited from traits. But, exclude selectors of methods from implicit traits such as TraitedClass"
 	| t1 c1 |

--- a/src/TraitsV2/TraitBuilderEnhancer.class.st
+++ b/src/TraitsV2/TraitBuilderEnhancer.class.st
@@ -34,6 +34,10 @@ TraitBuilderEnhancer class >> isApplicableFor: aBuilder [
 { #category : #'class modifications' }
 TraitBuilderEnhancer >> afterMethodsCompiled: aBuilder [
 
+	"we need to remove the categories leftover after removing Traits"
+	aBuilder newClass organization cleanUpCategoriesForClass: aBuilder newClass.
+	aBuilder newClass class organization cleanUpCategoriesForClass: aBuilder newClass class.
+	
 	(self isTraitedMetaclass: aBuilder)
 		ifFalse: [ ^ self ].
 


### PR DESCRIPTION
a test and fix for #5300: categories not upated when Traits are removed from classes.