### PR TITLE
fix/ffilibrary-should-return-itself

### DIFF
--- a/src/UnifiedFFI/FFILibrary.class.st
+++ b/src/UnifiedFFI/FFILibrary.class.st
@@ -51,6 +51,12 @@ FFILibrary >> calloutAPIClass [
 	^ FFICalloutAPI calloutAPIClass 
 ]
 
+{ #category : #accessing }
+FFILibrary >> ffiLibrary [
+
+	^ self
+]
+
 { #category : #'library path' }
 FFILibrary >> ffiLibraryName [
 	^ self libraryName


### PR DESCRIPTION
FFILibrary needs to return self when calling #ffiLibrary