### PR TITLE
[easyReview] fixing comment typos

### DIFF
--- a/src/Kernel/MessageSend.class.st
+++ b/src/Kernel/MessageSend.class.st
@@ -1,5 +1,5 @@
 "
-Instances of MessageSend encapsulate message sends to objects. Arguments can be either predefined or supplied when the message send is performed. 
+Instances of MessageSend encapsulate messages send to objects. Arguments can be either predefined or supplied when the message send is performed. 
 
 Use #value to perform a message send with its predefined arguments and #valueWithArguments: if additonal arguments have to supplied.
 

--- a/src/Kernel/WeakMessageSend.class.st
+++ b/src/Kernel/WeakMessageSend.class.st
@@ -1,5 +1,5 @@
 "
-Instances of WeakMessageSend encapsulate messages send to objects, like MessageSend. Unlike MessageSend it is not necessarily a valid mesage. A request to value only results in a send if infact it is valid. 
+Instances of WeakMessageSend encapsulate messages send to objects, like MessageSend. Unlike MessageSend it is not necessarily a valid message. A request to value only results in a send if infact it is valid. 
 
 See also MessageSend comments. WeakMessageSend is used primarily for event registration. 
 

--- a/src/Kernel/WeakMessageSend.class.st
+++ b/src/Kernel/WeakMessageSend.class.st
@@ -1,7 +1,7 @@
 "
 Instances of WeakMessageSend encapsulate messages send to objects, like MessageSend. Unlike MessageSend it is not necessarily a valid mesage. A request to value only results in a send if infact it is valid. 
 
-See MessageSend comments also. WeakMessageSend is used primarily for event registration. 
+See also MessageSend comments. WeakMessageSend is used primarily for event registration. 
 
 Unlike MessageSend, WeakMessageSend store receivers (object receiving the message send) as the first and only element of its array as opposed to a named ivar.
 But like MessageSend, it does have

--- a/src/Kernel/WeakMessageSend.class.st
+++ b/src/Kernel/WeakMessageSend.class.st
@@ -1,7 +1,7 @@
 "
-Instances of WeakMessageSend encapsulate message sends to objects, like MessageSend. Unlike MessageSend it is not necessarily a valid mesage. A request to value only results in a send if infact it is valid. 
+Instances of WeakMessageSend encapsulate messages send to objects, like MessageSend. Unlike MessageSend it is not necessarily a valid mesage. A request to value only results in a send if infact it is valid. 
 
-See MessageSendComments also. WeakMessageSend is used primarily for event registration. 
+See MessageSend comments also. WeakMessageSend is used primarily for event registration. 
 
 Unlike MessageSend, WeakMessageSend store receivers (object receiving the message send) as the first and only element of its array as opposed to a named ivar.
 But like MessageSend, it does have

--- a/src/Kernel/WeakMessageSend.class.st
+++ b/src/Kernel/WeakMessageSend.class.st
@@ -1,9 +1,9 @@
 "
-Instances of WeakMessageSend encapsulate message sends to objects, like MessageSend. Unlike MessageSend it is not necessarily a valid mesage.  A request to value only results in a send if infact it is valid. 
+Instances of WeakMessageSend encapsulate message sends to objects, like MessageSend. Unlike MessageSend it is not necessarily a valid mesage. A request to value only results in a send if infact it is valid. 
 
-See MessageSendComments also. WeakMessageSend is used primarily for event regristration. 
+See MessageSendComments also. WeakMessageSend is used primarily for event registration. 
 
-Unlike MessageSend WeakMessageSend stoes receiver (object receiving the message send) as a the first and only element of its array as opposed to a named ivar.
+Unlike MessageSend, WeakMessageSend store receivers (object receiving the message send) as the first and only element of its array as opposed to a named ivar.
 But like MessageSend, it does have
  selector		Symbol -- message selector
  arguments		Array -- bound arguments


### PR DESCRIPTION
Didn't find MessageSendComments as a class, so I assume it's also a typo.