### PR TITLE
CompletionFallBackGlobals

### DIFF
--- a/src/NECompletion/RBProgramNode.extension.st
+++ b/src/NECompletion/RBProgramNode.extension.st
@@ -2,10 +2,18 @@ Extension { #name : #RBProgramNode }
 
 { #category : #'*NECompletion' }
 RBProgramNode >> completionEntries: offset [
-	"for now we give all selectors as a fallback, maybe we should add variables, too"
-	^Symbol selectorTable 
+	"for now we give all selectors and gloabls as a fallback"
+	| selectors globals |
+	
+	selectors := Symbol selectorTable 
 		select: [ :each | each beginsWith: (self completionToken: offset)] 
-		thenCollect: [ :each | NECSymbolEntry contents: each node: self ]
+		thenCollect: [ :each | NECSymbolEntry contents: each node: self ].
+		
+	globals := Smalltalk globals keys 
+			select: [ :each | each beginsWith: (self completionToken: offset)]
+			thenCollect: [ :each | NECGlobalEntry contents: each  node: self ].
+			
+	^ selectors , globals
 
 ]
 


### PR DESCRIPTION
add globals to the suggested things when in fallback mode (work before cursor).

I guess we should move the code from the variable case here... what I do not like is that we need to add a parameter to all the methods ( the cursor position)