### PR TITLE
5315-DrTests-can-not-browse-middle-list-items

### DIFF
--- a/src/DrTests-TestCoverage/CompiledMethod.extension.st
+++ b/src/DrTests-TestCoverage/CompiledMethod.extension.st
@@ -1,11 +1,6 @@
 Extension { #name : #CompiledMethod }
 
 { #category : #'*DrTests-TestCoverage' }
-CompiledMethod >> drTestsBrowse [
-	Smalltalk tools browser openOnClass: self methodClass selector: self selector
-]
-
-{ #category : #'*DrTests-TestCoverage' }
 CompiledMethod >> drTestsName [
 	^ self selector asString
 ]

--- a/src/DrTests-Tests/DrTestsUITest.class.st
+++ b/src/DrTests-Tests/DrTestsUITest.class.st
@@ -31,7 +31,7 @@ DrTestsUITest >> testBrowseButton [
 
 { #category : #tests }
 DrTestsUITest >> testClickButtonRunCallsPluginRun [
-	drTestsUI pluginsDropList selectedItem: DTMockPlugin.
+	drTestsUI pluginsDropList selectItem: DTMockPlugin.
 	drTestsUI startButton performAction.
 	self assert: drTestsUI currentPlugin hasBeenRun
 ]
@@ -127,21 +127,22 @@ DrTestsUITest >> testSelectingPackageWillUpdateTheClassesList [
 
 { #category : #tests }
 DrTestsUITest >> testSelectingPluginWillUpdateCurrentPluginInstanceVariable [
-	drTestsUI pluginsDropList selectedItem: plugin2.
+	drTestsUI pluginsDropList selectItem: plugin2.
 	self assert: drTestsUI currentPlugin class equals: plugin2
 ]
 
 { #category : #tests }
 DrTestsUITest >> testSelectingPluginWillUpdatePackagesList [
-	drTestsUI pluginsDropList selectedItem: plugin2.
+	drTestsUI pluginsDropList selectItem: plugin2.
 	self
 		assertCollection: drTestsUI packagesList items
-		hasSameElements: drTestsUI currentPlugin packagesAvailableForAnalysis
+		hasSameElements:
+		drTestsUI currentPlugin packagesAvailableForAnalysis
 ]
 
 { #category : #tests }
 DrTestsUITest >> testSelectingPluginWillUpdateWindowTitle [
-	drTestsUI pluginsDropList selectedItem: plugin2.
+	drTestsUI pluginsDropList selectItem: plugin2.
 	self
 		assert: drTestsUI title
 		equals: 'Dr Tests - ' , drTestsUI currentPlugin pluginName

--- a/src/DrTests-TestsRunner/DTTestsRunnerResult.class.st
+++ b/src/DrTests-TestsRunner/DTTestsRunnerResult.class.st
@@ -27,6 +27,7 @@ DTTestsRunnerResult >> buildNodeGroupedByTypeAndClass: anOrderedColletion type: 
 			subResults: ((anOrderedColletion groupedBy: #class) associations collect: [ :assoc |
 				DTTreeNode new
 					name: assoc key name;
+					browseBlock: [ assoc key drTestsBrowse ];
 					subResults: (self buildLeavesFrom: assoc value type: testResultType);
 					yourself ]);
 			yourself

--- a/src/DrTests/ClassDescription.extension.st
+++ b/src/DrTests/ClassDescription.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #ClassDescription }
+
+{ #category : #'*DrTests' }
+ClassDescription >> drTestsBrowse [
+	Smalltalk tools browser openOnClass: self
+]

--- a/src/DrTests/CompiledMethod.extension.st
+++ b/src/DrTests/CompiledMethod.extension.st
@@ -4,3 +4,8 @@ Extension { #name : #CompiledMethod }
 CompiledMethod >> asResultForDrTest [
 	^ DTTestLeaf content: self
 ]
+
+{ #category : #'*DrTests' }
+CompiledMethod >> drTestsBrowse [
+	Smalltalk tools browser openOnClass: self methodClass selector: self selector
+]

--- a/src/DrTests/DTAbstractTreeNode.class.st
+++ b/src/DrTests/DTAbstractTreeNode.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'DrTests-Model'
 }
 
+{ #category : #testing }
+DTAbstractTreeNode >> canBeBrowsed [
+	^ self subclassResponsibility
+]
+
 { #category : #actions }
 DTAbstractTreeNode >> drTestsBrowse [
 	"Actions to perform in order to browse the result.

--- a/src/DrTests/DTBrowseSelectedItem.class.st
+++ b/src/DrTests/DTBrowseSelectedItem.class.st
@@ -1,3 +1,6 @@
+"
+I browse the item selected in middle list of DrTests.
+"
 Class {
 	#name : #DTBrowseSelectedItem,
 	#superclass : #DTMiddleListCommand,

--- a/src/DrTests/DTBrowseSelectedItem.class.st
+++ b/src/DrTests/DTBrowseSelectedItem.class.st
@@ -1,0 +1,21 @@
+Class {
+	#name : #DTBrowseSelectedItem,
+	#superclass : #DTMiddleListCommand,
+	#category : #'DrTests-Commands'
+}
+
+{ #category : #testing }
+DTBrowseSelectedItem >> canBeExecuted [
+	^ self selectedItems size = 1
+]
+
+{ #category : #executing }
+DTBrowseSelectedItem >> execute [
+	self drTest browseSelectedItem
+]
+
+{ #category : #initialization }
+DTBrowseSelectedItem >> initialize [
+	super initialize.
+	self name: 'Browse'
+]

--- a/src/DrTests/DTMiddleListCommand.class.st
+++ b/src/DrTests/DTMiddleListCommand.class.st
@@ -1,3 +1,6 @@
+"
+I am an abstract command concerning DrTests' middle list.
+"
 Class {
 	#name : #DTMiddleListCommand,
 	#superclass : #DTCommand,

--- a/src/DrTests/DTMiddleListCommand.class.st
+++ b/src/DrTests/DTMiddleListCommand.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #DTMiddleListCommand,
+	#superclass : #DTCommand,
+	#category : #'DrTests-Commands'
+}
+
+{ #category : #accessing }
+DTMiddleListCommand >> selectedItems [
+	^ self drTest selectedItems
+]

--- a/src/DrTests/DTResultBrowseCommand.class.st
+++ b/src/DrTests/DTResultBrowseCommand.class.st
@@ -7,9 +7,14 @@ Class {
 	#category : #'DrTests-Commands'
 }
 
+{ #category : #testing }
+DTResultBrowseCommand >> canBeExecuted [
+	^ self resultSelected canBeBrowsed
+]
+
 { #category : #hooks }
 DTResultBrowseCommand >> execute [
-	self context browseSelectedResult
+	self drTest browseSelectedResult
 ]
 
 { #category : #hooks }

--- a/src/DrTests/DTTreeLeaf.class.st
+++ b/src/DrTests/DTTreeLeaf.class.st
@@ -23,6 +23,11 @@ DTTreeLeaf >> acceptVisitor: aDTResultsTreeVisitor [
 	^ aDTResultsTreeVisitor visitDTTreeLeaf: self
 ]
 
+{ #category : #testing }
+DTTreeLeaf >> canBeBrowsed [
+	^ true
+]
+
 { #category : #accessing }
 DTTreeLeaf >> content [
 	^ content

--- a/src/DrTests/DTTreeNode.class.st
+++ b/src/DrTests/DTTreeNode.class.st
@@ -9,7 +9,8 @@ Class {
 		'name',
 		'subResults',
 		'contextMenuBlock',
-		'subResultsAggregator'
+		'subResultsAggregator',
+		'browseBlock'
 	],
 	#category : #'DrTests-Model'
 }
@@ -27,6 +28,21 @@ DTTreeNode >> acceptVisitor: aDTResultsTreeVisitor [
 ]
 
 { #category : #accessing }
+DTTreeNode >> browseBlock [
+	^ browseBlock
+]
+
+{ #category : #accessing }
+DTTreeNode >> browseBlock: anObject [
+	browseBlock := anObject
+]
+
+{ #category : #testing }
+DTTreeNode >> canBeBrowsed [
+	^ self browseBlock isNotNil
+]
+
+{ #category : #accessing }
 DTTreeNode >> contentForReRun [
 	^ (DTLeavesCollector collectLeavesOf: self) flatCollect: #contentForReRun
 ]
@@ -39,6 +55,16 @@ DTTreeNode >> contextMenuBlock [
 { #category : #accessing }
 DTTreeNode >> contextMenuBlock: anObject [
 	contextMenuBlock := anObject
+]
+
+{ #category : #actions }
+DTTreeNode >> drTestsBrowse [
+	"Browse the tree node according to what is specified by my #browseBlock.
+	 If my #browseBlock is nil, does nothing."
+	self canBeBrowsed
+		ifFalse: [ ^ self ].
+	
+	self browseBlock cull: self
 ]
 
 { #category : #menu }
@@ -61,7 +87,7 @@ DTTreeNode >> initialize [
 	super initialize.
 	self
 		contextMenuBlock: [ :menu | ]. "Does nothing by default."
-	self subResultsAggregator: [ :subRes | (DTLeavesCollector collectLeavesOf: self) size ]
+	self subResultsAggregator: [ :subRes | (DTLeavesCollector collectLeavesOf: self) size ].
 ]
 
 { #category : #accessing }

--- a/src/DrTests/DrTests.class.st
+++ b/src/DrTests/DrTests.class.st
@@ -40,16 +40,24 @@ DrTests class >> beDefaultTestRunner [
 ]
 
 { #category : #commands }
-DrTests class >> buildCommandsGroupWith: presenterIntance forRoot: rootCommandGroup [
+DrTests class >> buildCommandsGroupWith: presenterInstance forRoot: rootCommandGroup [
 	rootCommandGroup
-		register: (self buildContextualPackageGroupWith: presenterIntance);
-		register: (self buildResultGroupWith: presenterIntance)
+		register: (self buildContextualPackageGroupWith: presenterInstance);
+		register: (self buildItemsListGroupWith: presenterInstance);
+		register: (self buildResultGroupWith: presenterInstance)
 ]
 
 { #category : #commands }
 DrTests class >> buildContextualPackageGroupWith: presenterIntance [
 	^ (CmCommandGroup named: 'Package menu') asSpecGroup
 		register: (self buildPackageGroupWith: presenterIntance);
+		yourself
+]
+
+{ #category : #commands }
+DrTests class >> buildItemsListGroupWith: presenterInstance [
+	^ (CmCommandGroup named: 'List items menu') asSpecGroup
+		register: (DTBrowseSelectedItem forSpec context: presenterInstance);
 		yourself
 ]
 
@@ -156,6 +164,14 @@ DrTests class >> reloadConfiguration: aDTPluginConfiguration withResults: aDTPlu
 ]
 
 { #category : #actions }
+DrTests >> browseSelectedItem [
+	"Because of DTBrowseSelectedItem>>#canBeExecuted, we know there is a single item in the selection.
+	 Thus, we take the first one and browse it.
+	"
+	self selectedItems first drTestsBrowse
+]
+
+{ #category : #actions }
 DrTests >> browseSelectedResult [
 	self resultSelected drTestsBrowse
 ]
@@ -198,7 +214,8 @@ DrTests >> initializeItemsListAndLabel [
 		sortingBlock: #name ascending;
 		displayBlock: [ :item | item name ];
 		whenSelectionChangedDo: [ self whenItemsSelectionChanged: self selectedItems ];
-		beMultipleSelection.
+		beMultipleSelection;
+		contextMenu: [ (self rootCommandsGroup / 'List items menu') beRoot asMenuPresenter ].
 	packagesList
 		whenSelectionChangedDo: [ self whenPackagesSelectionChanged: self packagesSelected ]
 ]

--- a/src/DrTests/DrTests.class.st
+++ b/src/DrTests/DrTests.class.st
@@ -157,7 +157,7 @@ DrTests class >> reloadConfiguration: aDTPluginConfiguration withResults: aDTPlu
 
 { #category : #actions }
 DrTests >> browseSelectedResult [
-	self resultSelected content drTestsBrowse
+	self resultSelected drTestsBrowse
 ]
 
 { #category : #private }


### PR DESCRIPTION
Implementation of infrastructure + command for browsing middle-list items.

This PR depends on #5313 as I created a branch from the related branch.
#5313 needs to be integrated before this PR.

Fix #5315