### PR TITLE
5314-Code-completion-issue-in-methods-with-syntax-error

### DIFF
--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -142,7 +142,7 @@ OCASTSemanticAnalyzer >> unusedVariable: variableNode [
 
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> variable: variableNode shadows: semVar [
-
+	compilationContext optionSkipSemanticWarnings ifTrue: [ ^semVar ].
 	^ OCShadowVariableWarning new
 		node: variableNode;
 		shadowedVar: semVar;


### PR DESCRIPTION
turn off shadowed variable warning when #optionSkipSemanticWarnings is enabled. fixes #5314