### PR TITLE
5306-RBGlobalVariablesUsage-does-not-work-for-ByteArray

### DIFF
--- a/src/Athens-Cairo-Tests/CairoUTF8ConverterTest.class.st
+++ b/src/Athens-Cairo-Tests/CairoUTF8ConverterTest.class.st
@@ -39,8 +39,5 @@ CairoUTF8ConverterTest >> testReusingConverterShouldReplaceOldData [
 CairoUTF8ConverterTest >> testUnicodencodingShouldTerminateWithNull [
 	| buf |
 	buf := encoder convertChar: $a.
-	
-	
-	self assert: (buf first:2)   equals: #[97 0 ]
-
+	self assert: (buf first: 2) equals: #[ 97 0 ]
 ]

--- a/src/GeneralRules/RBGlobalVariablesUsage.class.st
+++ b/src/GeneralRules/RBGlobalVariablesUsage.class.st
@@ -16,15 +16,9 @@ RBGlobalVariablesUsage class >> checksMethod [
 
 { #category : #running }
 RBGlobalVariablesUsage >> basicCheck: aMethod [
-	^ (aMethod literals
-		select: [ :l | 
-			l isSymbol not 
-				and: [ l isString not
-				and: [ l isNumber not
-				and: [ l isArray not
-				and: [ l isCharacter not
-				and: [ l isGlobalVariable ] ] ] ] ] ])
-		anySatisfy: [ :v | v value isClass not ]
+	^ (aMethod literals 
+		select: [ :l | l isKindOf: GlobalVariable ]) 
+		  anySatisfy: [ :v | v value isClass not ]
 ]
 
 { #category : #running }


### PR DESCRIPTION
use isKindOf: check to filter for global variables. fixes #5306