### PR TITLE
TextBackgroundColorAttribute

### DIFF
--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -572,7 +572,8 @@ RubAbstractTextArea >> completionPostAction [
 RubAbstractTextArea >> compose [
 
 	self prepareParagraphToCompose.
-	self paragraph compose 
+	self paragraph compose.
+	self markBackgroundColors
 ]
 
 { #category : #composing }
@@ -1194,6 +1195,21 @@ RubAbstractTextArea >> margins: aMargin [
 	margins := m
 ]
 
+{ #category : #composing }
+RubAbstractTextArea >> markBackgroundColors [
+	"Scan through text to find spans of TextBackgroundColor, and mark them using TextBackgroundColorSegmentMorph."
+
+	self text runs
+		withStartStopAndValueDo: [ :start :stop :value | 
+			value do: [ :v | 
+					(v isKindOf: TextBackgroundColor)
+						ifTrue: [ self addSegment: 
+							(TextBackgroundColorSegmentMorph
+								color: v color
+								from: start
+								to: stop+1) ] ] ] 
+]
+
 { #category : #'accessing selection' }
 RubAbstractTextArea >> markBlock [
 	^ self editingState markBlock
@@ -1453,6 +1469,7 @@ RubAbstractTextArea >> paragraphReplacedTextFrom: start to: stop with: aText [
 				ifFalse: [ self updateExtentFromParagraph ] ].
 	self scrollPane ifNotNil: [ :sp | sp textChanged ].
 	self announce: (RubTextChanged from: start to: stop with: aText).
+	self markBackgroundColors .
 
 ]
 

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -1204,7 +1204,7 @@ RubAbstractTextArea >> markBackgroundColors [
 			value do: [ :v | 
 					(v isKindOf: TextBackgroundColor)
 						ifTrue: [ self addSegment: 
-							(TextBackgroundColorSegmentMorph
+							(RubTextBackgroundColorSegmentMorph
 								color: v color
 								from: start
 								to: stop+1) ] ] ] 

--- a/src/Rubric/RubTextBackgroundColorSegmentMorph.class.st
+++ b/src/Rubric/RubTextBackgroundColorSegmentMorph.class.st
@@ -2,13 +2,13 @@
 I am a segmentmorph intended to implement the visual presentation of a TextBackgroundColor for a text.
 "
 Class {
-	#name : #TextBackgroundColorSegmentMorph,
+	#name : #RubTextBackgroundColorSegmentMorph,
 	#superclass : #RubTextSegmentMorph,
-	#category : #'Text-Core-Utilities'
+	#category : #'Rubric-Editing-Core'
 }
 
 { #category : #'as yet unclassified' }
-TextBackgroundColorSegmentMorph class >> color: aColor from: start to: stop [ 
+RubTextBackgroundColorSegmentMorph class >> color: aColor from: start to: stop [ 
 	^ self new
 		color: aColor;
 		from: start to: stop; 
@@ -16,6 +16,6 @@ TextBackgroundColorSegmentMorph class >> color: aColor from: start to: stop [
 ]
 
 { #category : #accessing }
-TextBackgroundColorSegmentMorph >> color: aColor [
+RubTextBackgroundColorSegmentMorph >> color: aColor [
 	color := aColor
 ]

--- a/src/Text-Core/TextBackgroundColor.class.st
+++ b/src/Text-Core/TextBackgroundColor.class.st
@@ -1,0 +1,111 @@
+"
+I am a text attribute representing background color of a text. I am used as any other TextAttribute.
+
+
+"
+Class {
+	#name : #TextBackgroundColor,
+	#superclass : #TextAttribute,
+	#instVars : [
+		'color'
+	],
+	#category : #'Text-Core-Attributes'
+}
+
+{ #category : #constants }
+TextBackgroundColor class >> black [
+	^ self new color: Color black
+]
+
+{ #category : #constants }
+TextBackgroundColor class >> blue [
+	^ self new color: Color blue
+]
+
+{ #category : #'instance creation' }
+TextBackgroundColor class >> color: aColor [
+	^ self new color: aColor
+]
+
+{ #category : #constants }
+TextBackgroundColor class >> cyan [
+	^ self new color: Color cyan
+]
+
+{ #category : #constants }
+TextBackgroundColor class >> gray [
+	^ self new color: Color gray
+]
+
+{ #category : #constants }
+TextBackgroundColor class >> green [
+	^ self new color: Color green
+]
+
+{ #category : #constants }
+TextBackgroundColor class >> magenta [
+	^ self new color: Color magenta
+]
+
+{ #category : #constants }
+TextBackgroundColor class >> red [
+	^ self new color: Color red
+]
+
+{ #category : #'instance creation' }
+TextBackgroundColor class >> scanFrom: strm [
+	"read a color in the funny format used by Text styles on files. c125000255 or cblue;"
+
+	| r g b |
+	strm peek isDigit
+		ifTrue:
+			[r := (strm next: 3) asNumber.
+			g := (strm next: 3) asNumber.
+			b := (strm next: 3) asNumber.
+			^ self color: (Color r: r g: g b: b range: 255)].
+	"A name of a color"
+	^ self color: (Color perform: (strm upTo: $;) asSymbol)
+]
+
+{ #category : #constants }
+TextBackgroundColor class >> white [ 
+	^ self new color: Color white
+]
+
+{ #category : #constants }
+TextBackgroundColor class >> yellow [
+	^ self new color: Color yellow
+]
+
+{ #category : #comparing }
+TextBackgroundColor >> = other [ 
+	^ (other class == self class) 
+		and: [other color = color]
+]
+
+{ #category : #converting }
+TextBackgroundColor >> asColor [ 
+
+	^ color
+]
+
+{ #category : #accessing }
+TextBackgroundColor >> color [
+	^ color
+]
+
+{ #category : #accessing }
+TextBackgroundColor >> color: aColor [
+	color := aColor
+]
+
+{ #category : #scanning }
+TextBackgroundColor >> dominates: other [
+"Only one background color attribute on a same portion of text."
+	^ other class == self class
+]
+
+{ #category : #comparing }
+TextBackgroundColor >> hash [
+	^ color hash
+]

--- a/src/Text-Core/TextBackgroundColorSegmentMorph.class.st
+++ b/src/Text-Core/TextBackgroundColorSegmentMorph.class.st
@@ -1,0 +1,21 @@
+"
+I am a segmentmorph intended to implement the visual presentation of a TextBackgroundColor for a text.
+"
+Class {
+	#name : #TextBackgroundColorSegmentMorph,
+	#superclass : #RubTextSegmentMorph,
+	#category : #'Text-Core-Utilities'
+}
+
+{ #category : #'as yet unclassified' }
+TextBackgroundColorSegmentMorph class >> color: aColor from: start to: stop [ 
+	^ self new
+		color: aColor;
+		from: start to: stop; 
+		yourself
+]
+
+{ #category : #accessing }
+TextBackgroundColorSegmentMorph >> color: aColor [
+	color := aColor
+]


### PR DESCRIPTION
Adds a TextBackgroundColor with support in Rubrics RubAbstractTextArea

It works on my machine, and want to see if the CI finds errors outside what I can do.

Example: 
'this is a text' asText addAttribute: (TextBackgroundColor color: Color veryLightGray lighter) from: 6 to: 9