### PR TITLE
3228-RBSequenceNode-and-RBArrayNode-contain-instances-of-RBStatementNode-according-to-their-comment-but-this-class-does-not-exist

### DIFF
--- a/src/AST-Core/RBArrayNode.class.st
+++ b/src/AST-Core/RBArrayNode.class.st
@@ -5,7 +5,7 @@ Instance Variables
 	left:	 <Integer | nil> position of {
 	periods: <SequenceableCollection of: Integer> the positions of all the periods that separate the statements
 	right: <Integer | nil> position of }
-	statements: <SequenceableCollection of: RBStatementNode> the statement nodes
+	statements: <SequenceableCollection of: RBValueNode> the statement nodes
 "
 Class {
 	#name : #RBArrayNode,

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -4,7 +4,7 @@ RBSequenceNode is an AST node that represents a sequence of statements. Both RBB
 Instance Variables:
 	leftBar	<Integer | nil>	the position of the left | in the temporaries definition
 	rightBar	<Integer | nil>	the position of the right | in the temporaries definition
-	statements	<SequenceableCollection of: RBStatementNode>	the statement nodes
+	statements	<SequenceableCollection of: RBReturnNode or RBValueNode> the statement nodes
 	periods	<SequenceableCollection of: Integer>	the positions of all the periods that separate the statements
 	temporaries	<SequenceableCollection of: RBVariableNode>	the temporaries defined
 


### PR DESCRIPTION
I decided to only change the documentation (not rename the ivar in RBArrayNode). 

fixes #3228