### PR TITLE
5309-Rules-display-wrong-or-not-all-codelines

### DIFF
--- a/src/GeneralRules-Tests/RBSelfSentNotImplementedRuleTest.class.st
+++ b/src/GeneralRules-Tests/RBSelfSentNotImplementedRuleTest.class.st
@@ -1,0 +1,8 @@
+"
+A RBSelfSentNotImplementedRuleTest is a test class for testing the behavior of RBSelfSentNotImplementedRule
+"
+Class {
+	#name : #RBSelfSentNotImplementedRuleTest,
+	#superclass : #TestCase,
+	#category : #'GeneralRules-Tests-Migrated'
+}

--- a/src/GeneralRules-Tests/RBSelfSentNotImplementedRuleTest.class.st
+++ b/src/GeneralRules-Tests/RBSelfSentNotImplementedRuleTest.class.st
@@ -6,3 +6,25 @@ Class {
 	#superclass : #TestCase,
 	#category : #'GeneralRules-Tests-Migrated'
 }
+
+{ #category : #'as yet unclassified' }
+RBSelfSentNotImplementedRuleTest >> foo [
+	"Do not highlight this bar. I am a method used in testCheckForCritiques"
+
+	self bar.
+	self bar; bar.
+	(2 + 5) bar.
+	7 < 10 ifTrue: [ self check:7 forCritiquesDo: 9 ]
+]
+
+{ #category : #tests }
+RBSelfSentNotImplementedRuleTest >> testCheckForCritiques [
+	|method critiques|
+	method := self class >> #foo.
+	critiques := OrderedCollection new.
+	RBSelfSentNotImplementedRule new check: method forCritiquesDo:[:critique | critiques add: critique].
+	
+	self assert: critiques size equals: 4.
+	self assert: critiques first sourceAnchor interval equals: (86 to: 88).
+	
+]

--- a/src/GeneralRules/RBSelfSentNotImplementedRule.class.st
+++ b/src/GeneralRules/RBSelfSentNotImplementedRule.class.st
@@ -21,21 +21,19 @@ RBSelfSentNotImplementedRule class >> uniqueIdentifierName [
 
 { #category : #running }
 RBSelfSentNotImplementedRule >> check: aMethod forCritiquesDo: aCriticBlock [
-
-	aMethod methodClass isTrait ifTrue: [ ^ self ].	
-
-	(aMethod selfMessages reject: [ :each | (aMethod methodClass allSelectors includes: each) ]),
-	(aMethod superMessages select: [ :each |
-		aMethod methodClass superclass isNil or: [
-		(aMethod methodClass superclass canUnderstand: each) not ] ]) 
-
-	ifNotEmpty: [ :messages | messages do: [ :message |
-			aCriticBlock cull: (ReTrivialCritique
-			withAnchor: (ReSearchStringSourceAnchor
+	| problemSends |
+	aMethod methodClass isTrait ifTrue: [ ^ self ].
+	problemSends := 
+		(aMethod sendNodes select: [ :msgSend | msgSend isSelfSend  | msgSend isSuperSend ]) 
+			reject: [:msgSend | aMethod methodClass canUnderstand: (msgSend selector)].
+	
+	problemSends do: [ :msgSend |.
+			aCriticBlock cull: (ReTrivialCritique  
+			withAnchor: (ReIntervalSourceAnchor
 				entity: aMethod
-				string: message)
+				interval: (msgSend keywordsPositions first to: msgSend stop))
 			by: self
-			hint: message) ] ]
+			hint: msgSend selector asString) ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fixes #5309

Finds multiple errors and report them by position instead of search.