### PR TITLE
5344-DrTests-Allow-one-to-prioritise-tree-view

### DIFF
--- a/src/Deprecated80/DTCommentToTest.extension.st
+++ b/src/Deprecated80/DTCommentToTest.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #DTCommentToTest }
+
+{ #category : #'*Deprecated80' }
+DTCommentToTest >> oldPragmaForResultTrees [
+	"This is the symbol for the old pragma, in near future, it will not be supported anymore. Please update your code to use the pragma returned by #pragmaForResultTrees."
+	^ #'dTCommentToTestResultTreeNamed:'
+]

--- a/src/Deprecated80/DTMockPlugin.extension.st
+++ b/src/Deprecated80/DTMockPlugin.extension.st
@@ -2,5 +2,5 @@ Extension { #name : #DTMockPlugin }
 
 { #category : #'*Deprecated80' }
 DTMockPlugin >> oldPragmaForResultTrees [
-	^ #'pragmaForTest:order:'
+	^ #'pragmaForTest:'
 ]

--- a/src/Deprecated80/DTMockPlugin.extension.st
+++ b/src/Deprecated80/DTMockPlugin.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #DTMockPlugin }
+
+{ #category : #'*Deprecated80' }
+DTMockPlugin >> oldPragmaForResultTrees [
+	^ #'pragmaForTest:order:'
+]

--- a/src/Deprecated80/DTTestCoverage.extension.st
+++ b/src/Deprecated80/DTTestCoverage.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #DTTestCoverage }
+
+{ #category : #'*Deprecated80' }
+DTTestCoverage >> oldPragmaForResultTrees [
+	"This is the symbol for the old pragma, in near future, it will not be supported anymore. Please update your code to use the pragma returned by #pragmaForResultTrees."
+	^ #'dTTestCoverageResultTreeNamed:'
+]

--- a/src/Deprecated80/DTTestsProfiling.extension.st
+++ b/src/Deprecated80/DTTestsProfiling.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #DTTestsProfiling }
+
+{ #category : #'*Deprecated80' }
+DTTestsProfiling >> oldPragmaForResultTrees [
+	"This is the symbol for the old pragma, in near future, it will not be supported anymore. Please update your code to use the pragma returned by #pragmaForResultTrees."
+	^ #'dTTestsProfilingResultTreeNamed:'
+]

--- a/src/Deprecated80/DTTestsRunner.extension.st
+++ b/src/Deprecated80/DTTestsRunner.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #DTTestsRunner }
+
+{ #category : #'*Deprecated80' }
+DTTestsRunner >> oldPragmaForResultTrees [
+	"This is the symbol for the old pragma, in near future, it will not be supported anymore. Please update your code to use the pragma returned by #pragmaForResultTrees."
+	^ #'dTTestRunnerResultTreeNamed:'
+]

--- a/src/Deprecated80/DrTestsPlugin.extension.st
+++ b/src/Deprecated80/DrTestsPlugin.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #DrTestsPlugin }
+
+{ #category : #'*Deprecated80' }
+DrTestsPlugin >> oldPragmaForResultTrees [
+	"My subclasses implement this method to return the old pragma that was used to declare tree views.
+	 I will be removed once the migration will be achieved.
+	"
+	^ self subclassResponsibility
+]

--- a/src/DrTests-CommentsToTests/DTCommentToTest.class.st
+++ b/src/DrTests-CommentsToTests/DTCommentToTest.class.st
@@ -55,7 +55,7 @@ DTCommentToTest >> packagesAvailableForAnalysis [
 
 { #category : #accessing }
 DTCommentToTest >> pragmaForResultTrees [
-	^ #'dTCommentToTestResultTreeNamed:'
+	^ #'dtCommentToTestResultTreeNamed:order:'
 ]
 
 { #category : #api }

--- a/src/DrTests-CommentsToTests/DTCommentToTestResult.class.st
+++ b/src/DrTests-CommentsToTests/DTCommentToTestResult.class.st
@@ -16,7 +16,7 @@ Class {
 
 { #category : #accessing }
 DTCommentToTestResult >> buildTreeForUI [
-	<dTCommentToTestResultTreeNamed: 'Grouped by type of result'>
+	<dtCommentToTestResultTreeNamed: 'Grouped by type of result' order: 1>
 	^ DTTreeNode new
 		subResults:
 			{(DTTreeNode new

--- a/src/DrTests-TestCoverage/DTTestCoverage.class.st
+++ b/src/DrTests-TestCoverage/DTTestCoverage.class.st
@@ -64,7 +64,7 @@ DTTestCoverage >> itemsToBeAnalysedFor: packagesSelected [
 
 { #category : #accessing }
 DTTestCoverage >> pragmaForResultTrees [
-	^ #'dTTestCoverageResultTreeNamed:'
+	^ #'dtTestCoverageResultTreeNamed:order:'
 ]
 
 { #category : #api }

--- a/src/DrTests-TestCoverage/DTTestCoverageResult.class.st
+++ b/src/DrTests-TestCoverage/DTTestCoverageResult.class.st
@@ -16,7 +16,7 @@ Class {
 
 { #category : #accessing }
 DTTestCoverageResult >> buildTreeForUI [
-	<dTTestCoverageResultTreeNamed: 'List of uncovered methods'>
+	<dtTestCoverageResultTreeNamed: 'List of uncovered methods' order: 1>
 	^ DTTreeNode new
 		subResults:
 			{(DTTreeNode new

--- a/src/DrTests-Tests/DTMockPlugin.class.st
+++ b/src/DrTests-Tests/DTMockPlugin.class.st
@@ -57,7 +57,7 @@ DTMockPlugin >> packagesAvailableForAnalysis [
 
 { #category : #accessing }
 DTMockPlugin >> pragmaForResultTrees [
-	^ #'pragmaForTest:'
+	^ #'pragmaForTest:order:'
 ]
 
 { #category : #api }

--- a/src/DrTests-Tests/DTMockPluginResult.class.st
+++ b/src/DrTests-Tests/DTMockPluginResult.class.st
@@ -8,8 +8,16 @@ Class {
 }
 
 { #category : #accessing }
+DTMockPluginResult >> buildAnotherTreeForUI [
+	<pragmaForTest: 'for other tests' order: 2>
+	^ DTTreeNode new
+		subResults: {};
+		yourself
+]
+
+{ #category : #accessing }
 DTMockPluginResult >> buildTreeForUI [
-<pragmaForTest: 'for tests' order: 1>
+	<pragmaForTest: 'for tests' order: 1>
 	^ DTTreeNode new
 		subResults: {};
 		yourself

--- a/src/DrTests-Tests/DTMockPluginResult.class.st
+++ b/src/DrTests-Tests/DTMockPluginResult.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #accessing }
 DTMockPluginResult >> buildTreeForUI [
-<pragmaForTest: 'for tests'>
+<pragmaForTest: 'for tests' order: 1>
 	^ DTTreeNode new
 		subResults: {};
 		yourself

--- a/src/DrTests-Tests/DTMockPluginTest.class.st
+++ b/src/DrTests-Tests/DTMockPluginTest.class.st
@@ -16,6 +16,6 @@ DTMockPluginTest >> testResultTreeViews [
 	
 	self assert: treeViews size equals: 2.
 	
-	self assert: treeViews first name equals: 'test result'.
-	self assert: treeViews second name equals: 'test another result'.
+	self assert: treeViews first name equals: 'for tests'.
+	self assert: treeViews second name equals: 'for other tests'.
 ]

--- a/src/DrTests-Tests/DTMockPluginTest.class.st
+++ b/src/DrTests-Tests/DTMockPluginTest.class.st
@@ -1,0 +1,21 @@
+"
+A DTMockPluginTest is a test class for testing the behavior of DTMockPlugin
+"
+Class {
+	#name : #DTMockPluginTest,
+	#superclass : #TestCase,
+	#category : #'DrTests-Tests'
+}
+
+{ #category : #tests }
+DTMockPluginTest >> testResultTreeViews [
+	| plugin treeViews |
+	plugin := DTMockPlugin new.
+	
+	treeViews := plugin resultTreeViews.
+	
+	self assert: treeViews size equals: 2.
+	
+	self assert: treeViews first name equals: 'test result'.
+	self assert: treeViews second name equals: 'test another result'.
+]

--- a/src/DrTests-TestsProfiling/DTTestsProfiling.class.st
+++ b/src/DrTests-TestsProfiling/DTTestsProfiling.class.st
@@ -33,7 +33,7 @@ DTTestsProfiling >> firstListLabel [
 
 { #category : #accessing }
 DTTestsProfiling >> pragmaForResultTrees [
-	^ #'dTTestsProfilingResultTreeNamed:'
+	^ #'drTestsProfilingResultTreeNamed:order:'
 ]
 
 { #category : #api }

--- a/src/DrTests-TestsProfiling/DTTestsProfilingResult.class.st
+++ b/src/DrTests-TestsProfiling/DTTestsProfilingResult.class.st
@@ -19,7 +19,7 @@ Class {
 
 { #category : #accessing }
 DTTestsProfilingResult >> buildTreeForUI [
-	<dTTestsProfilingResultTreeNamed: 'Grouped by type of result'>
+	<dtTestsProfilingResultTreeNamed: 'Grouped by type of result' order: 1>
 	^ DTTreeNode new
 		subResults:
 			{(self buildTreeNode
@@ -71,7 +71,7 @@ DTTestsProfilingResult >> buildTreeForUI [
 
 { #category : #accessing }
 DTTestsProfilingResult >> buildTreeGroupedByClass [
-	<dTTestsProfilingResultTreeNamed: 'Grouped by class'>
+	<dtTestsProfilingResultTreeNamed: 'Grouped by class' order: 2>
 	^ self buildTreeNode
 		subResults: ((self testResults groupedBy: [ :d | d testCase class ]) associations collect: [ :assoc |
 			self buildTreeNode

--- a/src/DrTests-TestsRunner/DTTestsRunner.class.st
+++ b/src/DrTests-TestsRunner/DTTestsRunner.class.st
@@ -85,7 +85,7 @@ DTTestsRunner >> label: aString forSuite: aTestSuite [
 
 { #category : #accessing }
 DTTestsRunner >> pragmaForResultTrees [
-	^ #'dTTestRunnerResultTreeNamed:'
+	^ #'dtTestRunnerResultTreeNamed:order:'
 ]
 
 { #category : #private }

--- a/src/DrTests-TestsRunner/DTTestsRunnerResult.class.st
+++ b/src/DrTests-TestsRunner/DTTestsRunnerResult.class.st
@@ -50,7 +50,7 @@ DTTestsRunnerResult >> buildNodeGroupedByTypeClassAndProtocol: anOrderedColletio
 
 { #category : #accessing }
 DTTestsRunnerResult >> buildTreeForUI [
-	<dTTestRunnerResultTreeNamed: 'Grouped by type of result'>
+	<dtTestRunnerResultTreeNamed: 'Grouped by type of result' order: 1>
 	^ DTTreeNode new
 		subResults:
 			{DTTreeNode new
@@ -72,7 +72,7 @@ DTTestsRunnerResult >> buildTreeForUI [
 
 { #category : #accessing }
 DTTestsRunnerResult >> buildTreeForUIByClasses [
-	<dTTestRunnerResultTreeNamed: 'Grouped by type of result and classes'>
+	<dtTestRunnerResultTreeNamed: 'Grouped by type of result and classes' order: 2>
 
 	| errors failures skipped passed |
 	errors := self buildNodeGroupedByTypeAndClass: self testResults errors type: DTTestResultType error.
@@ -90,7 +90,7 @@ DTTestsRunnerResult >> buildTreeForUIByClasses [
 
 { #category : #accessing }
 DTTestsRunnerResult >> buildTreeForUIByClassesAndProtocol [
-	<dTTestRunnerResultTreeNamed: 'Grouped by type of result, classes, and protocol'>
+	<dtTestRunnerResultTreeNamed: 'Grouped by type of result, classes, and protocol' order: 3>
 
 	| errors failures skipped passed |
 	errors := self buildNodeGroupedByTypeClassAndProtocol: self testResults errors type: DTTestResultType error.

--- a/src/DrTests/DrTestsPlugin.class.st
+++ b/src/DrTests/DrTestsPlugin.class.st
@@ -123,7 +123,7 @@ DrTestsPlugin >> resultButtonHelp [
 
 { #category : #accessing }
 DrTestsPlugin >> resultTreeViews [
-	"Return result tree views available
+	"Return result tree views available.
 	 This method might signal a deprecation exception in case it found an old pragma BUT the method itself is
 	 NOT deprecated. Do not remove it.
 	 The code generating the deprecation exception will be removed once we decide to totally remove the old pragmas support.

--- a/src/DrTests/DrTestsPlugin.class.st
+++ b/src/DrTests/DrTestsPlugin.class.st
@@ -123,11 +123,21 @@ DrTestsPlugin >> resultButtonHelp [
 
 { #category : #accessing }
 DrTestsPlugin >> resultTreeViews [
-	| pragmas |
+	"Return result tree views available
+	 This method might signal a deprecation exception in case it found an old pragma BUT the method itself is
+	 NOT deprecated. Do not remove it.
+	 The code generating the deprecation exception will be removed once we decide to totally remove the old pragmas support.
+	"
+	| pragmas oldPragmas |
 	pragmas := Pragma allNamed: self pragmaForResultTrees in: self pluginResultClass.
-	
-	^ pragmas collect: [ :pragma |
-		DTResultTreeView name: (pragma argumentAt: 1) blockToExtractViewFromResult: pragma methodSelector ]
+	"Note The two following statements need to be removed once the old pragmas are gone."
+	oldPragmas := Pragma allNamed: self oldPragmaForResultTrees in: self pluginResultClass.
+	oldPragmas ifNotEmpty: [ self deprecated: ('Your code still use the old pragma to declare a tree view. Please update it to use the new pragma described in {1}>>#pragmaForResultTrees' format: { self className }) ].
+	^ ((pragmas sorted: [ :p | p argumentAt: 2 ] asSortFunction) collect: [ :pragma |
+		DTResultTreeView name: (pragma argumentAt: 1) blockToExtractViewFromResult: pragma methodSelector ]) ,
+	"Note: The following code need to be removed once the old pragmas are gone."
+	(oldPragmas collect: [ :pragma |
+		DTResultTreeView name: (pragma argumentAt: 1) blockToExtractViewFromResult: pragma methodSelector ])
 ]
 
 { #category : #api }


### PR DESCRIPTION
Now tree view are ordered when they are declared via the pragma.
This allows to have a deterministic order in the drop-list which was not the case until now.Added test to ensure tree views are well ordered.Fix #5344