### PR TITLE
5349-showWarningOnTranscript-should-show-shadowed-vars-when-compiling

### DIFF
--- a/src/OpalCompiler-Core/OCShadowVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCShadowVariableWarning.class.st
@@ -44,8 +44,6 @@ OCShadowVariableWarning >> shadowedVar: aVar [
 
 { #category : #correcting }
 OCShadowVariableWarning >> showWarningOnTranscript [
-	true
-		ifTrue: [ ^ self ].	"turned off by default"
 	SystemNotification signal: self warningMessage
 ]
 


### PR DESCRIPTION
do show shadowed var warnings in the transcript. fixes #5349