### PR TITLE
BytecodeEncoderDeadCode

### DIFF
--- a/src/Kernel-BytecodeEncoders/BytecodeEncoder.class.st
+++ b/src/Kernel-BytecodeEncoders/BytecodeEncoder.class.st
@@ -6,9 +6,7 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'stream',
-		'position',
-		'rootNode',
-		'blockExtentsToLocals'
+		'position'
 	],
 	#category : #'Kernel-BytecodeEncoders'
 }
@@ -74,32 +72,6 @@ BytecodeEncoder class >> stackDeltaForPrimitive: primitiveIndex in: method [
 	^ 0
 ]
 
-{ #category : #temps }
-BytecodeEncoder >> blockExtentsToTempsMap [
-	"Answer a Dictionary of blockExtent to temp locations for the current method.
-	 This is used by the debugger to locate temp vars in contexts.  A temp map
-	 entry is a pair of the temp's name and its index, where an index is either an
-	 integer for a normal temp or a pair of the index of the indirect temp vector
-	 containing  the temp and the index of the temp in its indirect temp vector."
-	| blockExtentsToTempsMap |
-	blockExtentsToLocals ifNil:
-		[^nil].
-	blockExtentsToTempsMap := Dictionary new.
-	blockExtentsToLocals keysAndValuesDo:
-		[:blockExtent :locals|
-		blockExtentsToTempsMap
-			at: blockExtent
-			put: (Array streamContents:
-					[:str|
-					locals withIndexDo:
-						[:local :index|
-						local isIndirectTempVector
-							ifTrue: [local remoteTemps withIndexDo:
-										[:remoteLocal :innerIndex| str nextPut: { remoteLocal key. { index. innerIndex } }]]
-							ifFalse: [str nextPut: { local key. index }]]])].
-	^blockExtentsToTempsMap
-]
-
 { #category : #'bytecode generation' }
 BytecodeEncoder >> genPushNClosureTemps: numTemps [
 	numTemps timesRepeat: [ self genPushSpecialLiteral: nil ]
@@ -109,11 +81,6 @@ BytecodeEncoder >> genPushNClosureTemps: numTemps [
 BytecodeEncoder >> genPushSpecialLiteral: aLiteral [
 
 	self subclassResponsibility
-]
-
-{ #category : #testing }
-BytecodeEncoder >> hasGeneratedMethod [
-	^blockExtentsToLocals notNil
 ]
 
 { #category : #accessing }
@@ -128,29 +95,12 @@ BytecodeEncoder >> nextPut: aByte [
 	position := position + 1
 ]
 
-{ #category : #temps }
-BytecodeEncoder >> noteBlockExtent: blockExtent hasLocals: tempNodes [
-	blockExtentsToLocals ifNil:
-		[blockExtentsToLocals := Dictionary new].
-	blockExtentsToLocals at: blockExtent put: tempNodes asArray
-]
-
 { #category : #'bytecode generation' }
 BytecodeEncoder >> outOfRangeError: string index: index range: rangeStart to: rangeEnd [
 	"For now..."
 	^self error: thisContext sender method selector, ' ', string
 				, ' index ', index printString
 				, ' is out of range ', rangeStart printString, ' to ', rangeEnd printString
-]
-
-{ #category : #accessing }
-BytecodeEncoder >> rootNode [ "^<BlockNode>"
-	^rootNode
-]
-
-{ #category : #accessing }
-BytecodeEncoder >> rootNode: node [ "<BlockNode>"
-	rootNode := node
 ]
 
 { #category : #'opcode sizing' }


### PR DESCRIPTION
- remove the two unused ivars in BytecodeEncoder: rootNode blockExtentsToTempsMap
- remove the unsent methods that reference them