### PR TITLE
[easyReview] slightly better DNU message

### DIFF
--- a/src/Kernel/MessageNotUnderstood.class.st
+++ b/src/Kernel/MessageNotUnderstood.class.st
@@ -65,7 +65,7 @@ MessageNotUnderstood >> messageText [
 					ifNotNil: [
 						message lookupClass == UndefinedObject
 							ifTrue: ['receiver of "{1}" is nil' format: {message selector asString}]
-							ifFalse: [message lookupClass printString, '>>', message selector asString]]]
+							ifFalse: [message lookupClass printString, '>> #', message selector asString]]]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
MessageNotUnderstood: ASTCSmallInteger>> #//
instead of:
MessageNotUnderstood: ASTCSmallInteger>>//
I feel it's nicer to respect convention about selectors, and sligtly more clear for those cases, especially for neophytes (assuming they actually read error messages :p ) :

MessageNotUnderstood: ASTCSmallInteger>> #>>