### PR TITLE
DebugSession modification for DebuggerSelector

### DIFF
--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -26,7 +26,9 @@ Class {
 		'name',
 		'interruptedContext',
 		'interruptedProcess',
-		'errorWasInUIProcess'
+		'errorWasInUIProcess',
+		'objectsThatWantToKeepMeAlive',
+		'subscribersToKeepAliveEvents'
 	],
 	#classVars : [
 		'LogDebuggerStackToFile'
@@ -100,6 +102,11 @@ DebugSession class >> named: aString on: aProcess startedAt: aContext [
 		detectUIProcess
 ]
 
+{ #category : #keepAlive }
+DebugSession >> addSubscriberToKeepAliveEvents: aNewSubscriber [
+	self subscribersToKeepAliveEvents add: aNewSubscriber
+]
+
 { #category : #'debugging actions' }
 DebugSession >> clear [
 	"If after resuming the process the user does plan to reuse this session with
@@ -118,6 +125,17 @@ DebugSession >> context [
 DebugSession >> contextChanged [
 
 	self triggerEvent: #contextChanged
+]
+
+{ #category : #keepAlive }
+DebugSession >> countObjectsThatWantToKeepMeAlive [
+	"Count how many objects are in objectsThatWantToKeepMeAlive. This method does not use #size or #isEmpty, and the iteration guards against nils because objectsThatWantToKeepMeAlive is a WeakOrderedCollection, therefore some contained objects can be set to nil during garbage collection, and #size and #isEmpty do not discount them"
+
+	| count |
+	count := 0.
+	self objectsThatWantToKeepMeAlive do: [ :anObject | 
+		anObject ifNotNil: [ count := count + 1 ] ].
+	^ count
 ]
 
 { #category : #accessing }
@@ -244,6 +262,16 @@ DebugSession >> isTestObject: anObject [
 	^ anObject isKindOf: TestCase
 ]
 
+{ #category : #keepAlive }
+DebugSession >> keepAlive: anObjectThatWantsToKeepMeAlive [
+	self objectsThatWantToKeepMeAlive add: anObjectThatWantsToKeepMeAlive.
+	self subscribersToKeepAliveEvents do: [ :subscriber_ | 
+		subscriber_ ifNotNil: [ :subscriber | 
+			subscriber
+				onDebugSession: self
+				gettingKeptAliveBy: anObjectThatWantsToKeepMeAlive ] ] "Notify subscribers"
+]
+
 { #category : #logging }
 DebugSession >> logStackToFileIfNeeded [
 	self class logDebuggerStackToFile ifFalse: [ ^self ].
@@ -260,6 +288,13 @@ DebugSession >> name [
 { #category : #accessing }
 DebugSession >> name: aString [
 	name := aString
+]
+
+{ #category : #accessing }
+DebugSession >> objectsThatWantToKeepMeAlive [
+	objectsThatWantToKeepMeAlive ifNil: [ 
+		objectsThatWantToKeepMeAlive := WeakOrderedCollection new ].
+	^ objectsThatWantToKeepMeAlive
 ]
 
 { #category : #context }
@@ -333,6 +368,11 @@ DebugSession >> recompileMethodTo: text inContext: aContext notifying: aNotifyer
 	the editor can still be unaccepted. "
 	self installAlarm: #contextChanged.
 	^ true
+]
+
+{ #category : #keepAlive }
+DebugSession >> removeSubscriberToKeepAliveEvents: aCurrentSubscriber [
+	self subscribersToKeepAliveEvents remove: aCurrentSubscriber
 ]
 
 { #category : #'debugging actions' }
@@ -458,6 +498,13 @@ DebugSession >> runToSelection: selectionInterval inContext: aContext [
 DebugSession >> selectedCodeRangeForContext: selectedContext [
 
 	^ self pcRangeForContext: selectedContext
+]
+
+{ #category : #keepAlive }
+DebugSession >> shouldBeKeptAlive [
+	"Returns whether there is at least one object that wants to keep this debug session alive"
+
+	^ self countObjectsThatWantToKeepMeAlive ~= 0
 ]
 
 { #category : #testing }
@@ -627,6 +674,26 @@ DebugSession >> stepToFirstInterestingBytecodeIn: aProcess [
 	seeing any visible results."
 	
 	^ aProcess stepToSendOrReturn
+]
+
+{ #category : #keepAlive }
+DebugSession >> stopKeepingAlive: anObjectThatNoLongerWantsToKeepMeAlive [
+	self objectsThatWantToKeepMeAlive
+		remove: anObjectThatNoLongerWantsToKeepMeAlive
+		ifAbsent: [ "It's a weak collection, its elements can be nilled by the garbage collector at any time if they are not referenced elsewhere, so it can happen not to find the object to remove because it has already been nilled"
+			 ].
+	self subscribersToKeepAliveEvents do: [ :subscriber_ | 
+		subscriber_ ifNotNil: [ :subscriber | 
+			subscriber
+				onDebugSession: self
+				stoppingGettingKeptAliveBy: anObjectThatNoLongerWantsToKeepMeAlive ] ] "Notify subscribers"
+]
+
+{ #category : #accessing }
+DebugSession >> subscribersToKeepAliveEvents [
+	subscribersToKeepAliveEvents ifNil: [ 
+		subscribersToKeepAliveEvents := WeakOrderedCollection new ].
+	^ subscribersToKeepAliveEvents
 ]
 
 { #category : #'debugging actions' }


### PR DESCRIPTION
## Disclaimer
This pull request adds code to DebugSession that is necessary for DebuggerSelector to work.
**This code is not called by the standard image and has no impact on its current behaviour, so it is safe to merge before P8's release**
DebuggerSelector will be added to NewTools, but it requires some changes on the DebugSession class that cannot be made via extension methods because they include adding instance variables.

## For the details
This code adds a reference counting mechanism to DebugSession, so that debuggers can manually keep them alive. DebugSession with no debuggers keeping them alive can be terminated by DebuggerSelector.
This PR also includes an observer pattern on DebugSession, so that objects can be notified when a debugger wants to keep alive or stop keeping alive a DebugSession.