### PR TITLE
Announcements: Small Cleanup

### DIFF
--- a/src/Announcements-Core/Announcer.class.st
+++ b/src/Announcements-Core/Announcer.class.st
@@ -1,7 +1,5 @@
 "
 The implementation uses a threadsafe subscription registry, in the sense that registering, unregistering, and announcing from an announcer at the same time in different threads should never cause failures.
-
-For security reasons, registry is kept private, and has no accessor like in other implementations
 "
 Class {
 	#name : #Announcer,
@@ -30,8 +28,9 @@ Announcer >> basicSubscribe: subscription [
 
 { #category : #testing }
 Announcer >> handleSubscriberClass: eventClass [
-	self subscriptions ifNil: [ ^ false ].
-	^ self subscriptions handleSubscriberClass: eventClass
+	^ self subscriptions 
+		ifNil: [ false ]
+		ifNotNil: [:subscriptions | subscriptions handleSubscriberClass: eventClass]
 ]
 
 { #category : #testing }
@@ -136,7 +135,8 @@ Announcer >> when: anAnnouncementClass do: aValuable for: aSubscriber [
 Announcer >> when: anAnnouncementClass send: aSelector to: anObject [
 	"Declare that when anAnnouncementClass is raised, anObject should receive the message aSelector.
     When the message expects one argument (eg #fooAnnouncement:) the announcement is passed as argument.
-    When the message expects two arguments (eg #fooAnnouncement:announcer:) both the announcement and the announcer are passed as argument"
+    When the message expects two arguments (eg #fooAnnouncement:announcer:) both the announcement and 
+    the announcer are passed as argument"
 
 	^ self
 		when: anAnnouncementClass

--- a/src/Announcements-Help/AnnouncementsHelp.class.st
+++ b/src/Announcements-Help/AnnouncementsHelp.class.st
@@ -25,25 +25,7 @@ AnnouncementsHelp class >> introduction [
 An event someone might want to announce, such as a button click or an attribute change, is defined as a subclass of the abstract superclass Announcement. The subclass can have instance variables for additional information to pass along, such as a timestamp, or mouse coordinates at the time of the event, or the old value of the parameter that has changed. To signal the actual occurrence of an event, the "announcer" creates and configures an instance of an appropriate announcement, then broadcasts that instance. Objects subscribed to receive such broadcasts from the announcer receive a broadcast notification together with the instance. They can talk to the instance to find out any additional information about the event that has occurred.!'  
 ]
 
-{ #category : #pages }
-AnnouncementsHelp class >> links [
-	"This method was automatically generated. Edit it using:"
-	"AnnouncementsHelp edit: #links"
-	^HelpTopic
-		title: 'Links'
-		contents: 'You can get more informations on the framework on the following websites:
-
-http://book.pharo-project.org/book/announcements
-				
-http://www.cincomsmalltalk.com/userblogs/vbykov/blogView?searchCategory=Announcements%20Framework
-
-http://www.cincomsmalltalk.com/userblogs/vbykov/blogView?entry=3310034894
-
-http://dougedmunds.com/pmwiki.php?n=Pharo.AnnouncementsTutorial
-'
-]
-
 { #category : #accessing }
 AnnouncementsHelp class >> pages [
-	^#(introduction AnnouncementsTutorial AnnouncementsAPIDocumentation links)
+	^#(introduction AnnouncementsTutorial AnnouncementsAPIDocumentation)
 ]


### PR DESCRIPTION
- tiny cleanup in Annuncer class
- fix the comment as we do have an accessor
- remove the links page in the Tutorial as the are all not working