### PR TITLE
5369-stepToSendOrReturn-causes-an-error-on-a-dead-context

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -336,9 +336,8 @@ Context >> stepToSendOrReturn [
 	returning a value to the receiver (that is, until switching contexts)."
 
 	| context |
-	[ self willSend or: [  self willReturn or: [ self willStore or: [self willCreateBlock ] ] ] ]
+	[ self isDead or: [ self willSend or: [  self willReturn or: [ self willStore or: [self willCreateBlock ] ] ] ] ]
 		whileFalse: [
-			self isDead ifTrue: [ ^ self ].
 			context := self step.
 			context == self ifFalse: [
 				"Caused by mustBeBoolean handling"

--- a/src/Debugging-Utils-Tests/ContextDebuggingTest.class.st
+++ b/src/Debugging-Utils-Tests/ContextDebuggingTest.class.st
@@ -6,11 +6,10 @@ Class {
 
 { #category : #tests }
 ContextDebuggingTest >> deadContext [
-	| semaphore context |
-	semaphore := Semaphore new.
-	[ context := thisContext.
-	semaphore signal ] fork.
-	semaphore wait.
+	| process context |
+	process := [  ] newProcess.
+	context := process suspendedContext.
+	context pc: nil.
 	^ context
 ]
 

--- a/src/Debugging-Utils-Tests/ContextDebuggingTest.class.st
+++ b/src/Debugging-Utils-Tests/ContextDebuggingTest.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : #ContextDebuggingTest,
+	#superclass : #TestCase,
+	#category : #'Debugging-Utils-Tests'
+}
+
+{ #category : #tests }
+ContextDebuggingTest >> deadContext [
+	| semaphore context |
+	semaphore := Semaphore new.
+	[ context := thisContext.
+	semaphore signal ] fork.
+	semaphore wait.
+	^ context
+]
+
+{ #category : #tests }
+ContextDebuggingTest >> testStepToSendOrReturn [
+	| context |
+	context := self deadContext.
+	self assert: context isDead.
+	context := context stepToSendOrReturn.
+	self assert: context isDead
+]


### PR DESCRIPTION
fix and test for sending stepToSendOrReturn to a dead context -- issue #5369