### PR TITLE
GTDebugger modification for DebuggerSelector

### DIFF
--- a/src/GT-Debugger/GTMoldableDebugger.class.st
+++ b/src/GT-Debugger/GTMoldableDebugger.class.st
@@ -10,6 +10,9 @@ Class {
 	#superclass : #GLMCompositePresentation,
 	#traits : 'GTBrowsingActions',
 	#classTraits : 'GTBrowsingActions classTrait',
+	#instVars : [
+		'originalSession'
+	],
 	#classVars : [
 		'EnableDebuggerWindowDistinctColor',
 		'EnableStackColoring'
@@ -313,6 +316,16 @@ GTMoldableDebugger >> openOn: anObject [
 		extent: self initialExtent;
 		title: self session name;
 		yourself
+]
+
+{ #category : #accessing }
+GTMoldableDebugger >> originalSession [
+	^ originalSession
+]
+
+{ #category : #accessing }
+GTMoldableDebugger >> originalSession: aDebugSession [
+	originalSession := aDebugSession
 ]
 
 { #category : #building }


### PR DESCRIPTION
## Disclaimer
This pull request adds an instance variable to GTMoldableDebugger that is necessary for DebuggerSelector to work.
DebuggerSelector will be added to NewTools, but it requires adding an instance variable on GTMoldableDebugger, which cannot be made using method extension.

**This instance variable is not used in the standard image and has no impact on its current behaviour, so it is safe to merge before P8's release**