### PR TITLE
execution counters sometimes produce errors when uninstalling

### DIFF
--- a/src/Reflectivity-Tools-Tests/ExecutionCounterTest.class.st
+++ b/src/Reflectivity-Tools-Tests/ExecutionCounterTest.class.st
@@ -38,6 +38,30 @@ ExecutionCounterTest >> testCountingAfterReset [
 ]
 
 { #category : #adding }
+ExecutionCounterTest >> testGlobalCounterReferenceAfterInstallation [
+	counter := ExecutionCounter installOn: node.
+	self assert: (ExecutionCounter allCounters includesKey: node).
+	self assert: (ExecutionCounter allCounters at: node) identicalTo: counter.
+	self assert: (counter link methods includes: node methodNode compiledMethod)
+]
+
+{ #category : #removing }
+ExecutionCounterTest >> testGlobalCounterReferenceAfterRemovingFromMethod [
+	counter := ExecutionCounter installOn: node.
+	ExecutionCounter removeFromMethod: node methodNode compiledMethod.
+	self deny: (ExecutionCounter allCounters includesKey: node).
+	self assertEmpty: counter link methods
+]
+
+{ #category : #removing }
+ExecutionCounterTest >> testGlobalCounterReferenceAfterUninstallInstallation [
+	counter := ExecutionCounter installOn: node.
+	counter uninstall.
+	self deny: (ExecutionCounter allCounters includesKey: node).
+	self assertEmpty: counter link methods
+]
+
+{ #category : #adding }
 ExecutionCounterTest >> testInstallCounter [
 	counter := ExecutionCounter installOn: node.
 	self assert: node hasExecutionCounter

--- a/src/Reflectivity-Tools-Tests/ExecutionCounterTest.class.st
+++ b/src/Reflectivity-Tools-Tests/ExecutionCounterTest.class.st
@@ -3,7 +3,9 @@ Class {
 	#superclass : #TestCase,
 	#instVars : [
 		'counter',
-		'node'
+		'counter2',
+		'node',
+		'node2'
 	],
 	#category : #'Reflectivity-Tools-Tests'
 }
@@ -13,11 +15,13 @@ ExecutionCounterTest >> setUp [
 	"Hooks that subclasses may override to define the fixture of test."
 	super setUp.
 	node := (ReflectivityExamples >> #exampleAssignment) ast body children second.
+	node2 := (ReflectivityExamples >> #exampleAssignment) ast body children last
 ]
 
 { #category : #running }
 ExecutionCounterTest >> tearDown [ 	
 	counter ifNotNil:[counter uninstall].
+	counter2 ifNotNil:[counter2 uninstall].
 	super tearDown
 ]
 
@@ -48,9 +52,12 @@ ExecutionCounterTest >> testGlobalCounterReferenceAfterInstallation [
 { #category : #removing }
 ExecutionCounterTest >> testGlobalCounterReferenceAfterRemovingFromMethod [
 	counter := ExecutionCounter installOn: node.
+	counter2 := ExecutionCounter installOn: node2.
 	ExecutionCounter removeFromMethod: node methodNode compiledMethod.
 	self deny: (ExecutionCounter allCounters includesKey: node).
-	self assertEmpty: counter link methods
+	self deny: (ExecutionCounter allCounters includesKey: node2).
+	self assertEmpty: counter link methods.
+	self assertEmpty: counter2 link methods
 ]
 
 { #category : #removing }
@@ -65,6 +72,15 @@ ExecutionCounterTest >> testGlobalCounterReferenceAfterUninstallInstallation [
 ExecutionCounterTest >> testInstallCounter [
 	counter := ExecutionCounter installOn: node.
 	self assert: node hasExecutionCounter
+]
+
+{ #category : #counting }
+ExecutionCounterTest >> testMultipleCounters [
+	counter := ExecutionCounter installOn: node.
+	counter2 := ExecutionCounter installOn: node2.
+	10 timesRepeat:[ReflectivityExamples new exampleAssignment].
+	self assert: counter count equals: 10.
+	self assert: counter2 count equals: 10
 ]
 
 { #category : #removing }

--- a/src/Reflectivity-Tools-Tests/ExecutionCounterTest.class.st
+++ b/src/Reflectivity-Tools-Tests/ExecutionCounterTest.class.st
@@ -1,0 +1,66 @@
+Class {
+	#name : #ExecutionCounterTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'counter',
+		'node'
+	],
+	#category : #'Reflectivity-Tools-Tests'
+}
+
+{ #category : #running }
+ExecutionCounterTest >> setUp [
+	"Hooks that subclasses may override to define the fixture of test."
+	super setUp.
+	node := (ReflectivityExamples >> #exampleAssignment) ast body children second.
+]
+
+{ #category : #running }
+ExecutionCounterTest >> tearDown [ 	
+	counter ifNotNil:[counter uninstall].
+	super tearDown
+]
+
+{ #category : #counting }
+ExecutionCounterTest >> testCounting [
+	counter := ExecutionCounter installOn: node.
+	10 timesRepeat:[ReflectivityExamples new exampleAssignment].
+	self assert: counter count equals: 10
+]
+
+{ #category : #counting }
+ExecutionCounterTest >> testCountingAfterReset [
+	counter := ExecutionCounter installOn: node.
+	10 timesRepeat:[ReflectivityExamples new exampleAssignment].
+	counter reset.
+	ReflectivityExamples new exampleAssignment.
+	self assert: counter count equals: 1
+]
+
+{ #category : #adding }
+ExecutionCounterTest >> testInstallCounter [
+	counter := ExecutionCounter installOn: node.
+	self assert: node hasExecutionCounter
+]
+
+{ #category : #removing }
+ExecutionCounterTest >> testRemoveCounterFromMethod [
+	counter := ExecutionCounter installOn: node.
+	ExecutionCounter removeFromMethod: node methodNode compiledMethod.
+	self deny: node hasExecutionCounter
+]
+
+{ #category : #counting }
+ExecutionCounterTest >> testReseting [
+	counter := ExecutionCounter installOn: node.
+	10 timesRepeat:[ReflectivityExamples new exampleAssignment].
+	counter reset.
+	self assert: counter count equals: 0
+]
+
+{ #category : #removing }
+ExecutionCounterTest >> testUninstallCounter [
+	counter := ExecutionCounter installOn: node.
+	counter uninstall.
+	self deny: node hasExecutionCounter 
+]

--- a/src/Reflectivity/ExecutionCounter.class.st
+++ b/src/Reflectivity/ExecutionCounter.class.st
@@ -129,6 +129,11 @@ ExecutionCounter >> install [
 ]
 
 { #category : #accessing }
+ExecutionCounter >> link [
+	^ link
+]
+
+{ #category : #accessing }
 ExecutionCounter >> node [
 	^ node
 ]

--- a/src/Reflectivity/ExecutionCounter.class.st
+++ b/src/Reflectivity/ExecutionCounter.class.st
@@ -92,7 +92,7 @@ ExecutionCounter class >> removeFromMethod: aMethod [
 	self allCounters copy do: [ :counter |
 		counter link methods
 			detect: [ :m | m == aMethod ]
-			ifFound: [ self allCounters remove: counter ] ]
+			ifFound: [ counter uninstall] ]
 ]
 
 { #category : #cleanup }


### PR DESCRIPTION
Added tests and fixing bugs in exec counter.
Basically missing method and erroneous uninstall.
fixes #5381 