### PR TITLE
Hiding the methods from TraitedClass in Calypso.

### DIFF
--- a/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateTraitCommand.class.st
+++ b/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateTraitCommand.class.st
@@ -47,21 +47,21 @@ ClyCreateTraitCommand >> defaultMenuItemName [
 { #category : #execution }
 ClyCreateTraitCommand >> execute [
 	| traitDefinition category resultTrait |
-	category := package categoryName.
-	classTag ifNotNil: [ category := category , '-', classTag ].
+	category := package name.
+	classTag ifNotNil: [ category := category , '-' , classTag ].
 	traitDefinition := 'Trait named: #TNameOfTrait
 	uses: {}
-	package: ''', category, ''''.
-
-	traitDefinition := UIManager default 
-		multiLineRequest: 'Define trait definition:'
-		initialAnswer: traitDefinition
-		answerHeight: 250.
+	package: ''' , category , ''''.
+	traitDefinition := UIManager default
+		                   multiLineRequest: 'Define trait definition:'
+		                   initialAnswer: traitDefinition
+		                   answerHeight: 250.
 	traitDefinition isEmptyOrNil ifTrue: [ ^ self ].
-	resultTrait := browser 
-		compileANewClassFrom: traitDefinition notifying: nil startingFrom: nil.
-	resultTrait ifNotNil: [
-		browser selectClass: resultTrait]
+	resultTrait := browser
+		               compileANewClassFrom: traitDefinition
+		               notifying: nil
+		               startingFrom: nil.
+	resultTrait ifNotNil: [ browser selectClass: resultTrait ]
 ]
 
 { #category : #execution }

--- a/src/Calypso-SystemQueries-Tests/ClyClassSideScopeTest.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyClassSideScopeTest.class.st
@@ -64,3 +64,25 @@ ClyClassSideScopeTest >> testMethodsEnumerationWhenBasisIsMetaclass [
 	expected := ClyClass1FromP1 classSide localMethods collect: #selector.
 	self assert: result sorted asArray equals: expected sorted asArray
 ]
+
+{ #category : #tests }
+ClyClassSideScopeTest >> testMethodsEnumerationWhenBasisIsTraitedClass [
+	| expected |
+	scope := ClyClassSideScope of: ClyClassWithTraits.
+	
+	scope methodsDo: [ :each | result add: each selector ].
+	
+	expected := ClyClassWithTraits class methods reject: [ :e | e origin = TraitedClass ] thenCollect: #selector.
+	self assert: result sorted asArray equals: expected sorted asArray
+]
+
+{ #category : #tests }
+ClyClassSideScopeTest >> testMethodsEnumerationWhenBasisIsTraitedClassClassSide [
+	| expected |
+	scope := ClyClassSideScope of: ClyClassWithTraits classSide.
+	
+	scope methodsDo: [ :each | result add: each selector ].
+	
+	expected := ClyClassWithTraits class methods reject: [ :e | e origin = TraitedClass ] thenCollect: #selector.
+	self assert: result sorted asArray equals: expected sorted asArray
+]

--- a/src/Calypso-SystemQueries-Tests/ClyInstanceSideScopeTest.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyInstanceSideScopeTest.class.st
@@ -40,3 +40,25 @@ ClyInstanceSideScopeTest >> testMethodsEnumerationWhenBasisIsMetaclass [
 	expected := ClyClass1FromP1 localMethods collect: #selector.
 	self assert: result sorted asArray equals: expected sorted asArray
 ]
+
+{ #category : #tests }
+ClyInstanceSideScopeTest >> testMethodsEnumerationWhenBasisIsTraitedClass [
+	| expected |
+	scope := ClyInstanceSideScope of: ClyClassWithTraits.
+	
+	scope methodsDo: [ :each | result add: each selector ].
+	
+	expected := ClyClassWithTraits methods collect: #selector.
+	self assert: result sorted asArray equals: expected sorted asArray
+]
+
+{ #category : #tests }
+ClyInstanceSideScopeTest >> testMethodsEnumerationWhenBasisIsTraitedClassClasSide [
+	| expected |
+	scope := ClyInstanceSideScope of: ClyClassWithTraits classSide.
+	
+	scope methodsDo: [ :each | result add: each selector ].
+	
+	expected := ClyClassWithTraits methods collect: #selector.
+	self assert: result sorted asArray equals: expected sorted asArray
+]

--- a/src/Calypso-SystemQueries/ClyAllMethodsQuery.class.st
+++ b/src/Calypso-SystemQueries/ClyAllMethodsQuery.class.st
@@ -15,5 +15,6 @@ ClyAllMethodsQuery >> description [
 
 { #category : #testing }
 ClyAllMethodsQuery >> selectsMethod: aMethod [
+
 	^true
 ]

--- a/src/Calypso-SystemQueries/ClyClassSideScope.class.st
+++ b/src/Calypso-SystemQueries/ClyClassSideScope.class.st
@@ -16,3 +16,11 @@ ClyClassSideScope class >> defaultName [
 ClyClassSideScope class >> metaLevelOf: aClass [
 	^aClass classSide
 ]
+
+{ #category : #queries }
+ClyClassSideScope >> methodsDo: aBlock [
+
+	self classesDo: [ :eachClass | 
+		self metaLevelsOf: eachClass do: [ :concreteMetaLevelClass |
+			concreteMetaLevelClass visibleMethods do: aBlock ] ]
+]

--- a/src/Calypso-SystemQueries/Metaclass.extension.st
+++ b/src/Calypso-SystemQueries/Metaclass.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Metaclass }
+
+{ #category : #'*Calypso-SystemQueries' }
+Metaclass >> visibleMethods [
+
+	^ self methods
+]

--- a/src/Calypso-SystemQueries/TraitedMetaclass.extension.st
+++ b/src/Calypso-SystemQueries/TraitedMetaclass.extension.st
@@ -1,0 +1,26 @@
+Extension { #name : #TraitedMetaclass }
+
+{ #category : #'*Calypso-SystemQueries' }
+TraitedMetaclass >> tagsForAllMethods [
+	"I act as #tagsForMethods but I also takes into account methods comming from traits"
+
+	| allProtocols selectors |
+
+	allProtocols := self organization protocols 
+		reject: [ :each | each name = Protocol unclassified | each isExtensionProtocol ].
+
+	selectors := self visibleMethods collect: #selector.
+
+	^ allProtocols
+		select: [ :protocol | 
+			protocol methodSelectors 
+				ifEmpty: [ true ] 
+				ifNotEmpty: [ :methods | methods anySatisfy: [ :method | selectors includes: method ] ] ]
+		thenCollect: #name
+]
+
+{ #category : #'*Calypso-SystemQueries' }
+TraitedMetaclass >> visibleMethods [
+
+	^ self methods reject: [ :e | e origin = TraitedClass ]
+]


### PR DESCRIPTION
The methods for TraitedClass are added to all the classSide of classes using Traits or being traits. 
This behavior is implicit by the traits implementation, and should not be seen in the system browser.
A better way of showing it is required, but this is better not to confuse people.