### PR TITLE
Adding missing pragmas to methods with halts for test and dev purpose

### DIFF
--- a/src/Calypso-SystemPlugins-Critic-Queries-Tests/ClyClassWithProblemMethods.class.st
+++ b/src/Calypso-SystemPlugins-Critic-Queries-Tests/ClyClassWithProblemMethods.class.st
@@ -9,13 +9,14 @@ Class {
 
 { #category : #'method examples' }
 ClyClassWithProblemMethods >> methodWithHalt [
-	<haltOrBreakpointForTesting>
+	<haltOrBreakpointForTesting> 
 	self halt.
 ]
 
 { #category : #'method examples' }
 ClyClassWithProblemMethods >> methodWithHalt2 [
-	self halt.
+	<haltOrBreakpointForTesting> 
+	self halt
 ]
 
 { #category : #'method examples' }

--- a/src/Calypso-SystemPlugins-Reflectivity-Queries-Tests/ClyActiveBreakpointsQueryTest.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Queries-Tests/ClyActiveBreakpointsQueryTest.class.st
@@ -24,14 +24,16 @@ ClyActiveBreakpointsQueryTest >> installBreakpointInto: aMethod [
 ClyActiveBreakpointsQueryTest >> setUp [
 	super setUp.
 	
-	installedBreakpoints := OrderedCollection new
+	installedBreakpoints := OrderedCollection new.
+	ClyClassWithHalts compile: 'methodWithHalts1 self halt'.
+	ClyClassWithHalts compile: 'methodWithHalts2 self halt'.
 ]
 
 { #category : #running }
 ClyActiveBreakpointsQueryTest >> tearDown [
-	installedBreakpoints do: [ :each | each remove ].
-	installedBreakpoints removeAll.
-	
+	ClyClassWithHalts removeSelector: #methodWithHalts1.
+	ClyClassWithHalts removeSelector: #methodWithHalts2.
+	Breakpoint removeFromMethod: (ClyClassWithBreakpoints >> #methodWithBreakpoints).
 	super tearDown
 ]
 
@@ -53,6 +55,7 @@ ClyActiveBreakpointsQueryTest >> testCheckIfEmpty [
 
 { #category : #tests }
 ClyActiveBreakpointsQueryTest >> testComparison [
+
 	self assert: ClyActiveBreakpointsQuery new equals: ClyActiveBreakpointsQuery new.
 
 	self assert: ClyActiveBreakpointsQuery newIncludingHaltsForTesting equals: ClyActiveBreakpointsQuery newIncludingHaltsForTesting.

--- a/src/Calypso-SystemPlugins-Reflectivity-Queries-Tests/ClyClassWithHalts.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Queries-Tests/ClyClassWithHalts.class.st
@@ -9,11 +9,13 @@ Class {
 
 { #category : #methods }
 ClyClassWithHalts >> methodWithHalts1 [
+	<haltOrBreakpointForTesting> 
 	self halt
 ]
 
 { #category : #methods }
 ClyClassWithHalts >> methodWithHalts2 [
+	<haltOrBreakpointForTesting>
 	self halt
 ]
 

--- a/src/Calypso-SystemPlugins-Reflectivity-Queries-Tests/ClyClassWithHalts.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Queries-Tests/ClyClassWithHalts.class.st
@@ -8,18 +8,6 @@ Class {
 }
 
 { #category : #methods }
-ClyClassWithHalts >> methodWithHalts1 [
-	<haltOrBreakpointForTesting> 
-	self halt
-]
-
-{ #category : #methods }
-ClyClassWithHalts >> methodWithHalts2 [
-	<haltOrBreakpointForTesting>
-	self halt
-]
-
-{ #category : #methods }
 ClyClassWithHalts >> methodWithoutHalts [
 
 	self printString

--- a/src/Debugger-Tests/StepOverTest.class.st
+++ b/src/Debugger-Tests/StepOverTest.class.st
@@ -133,6 +133,7 @@ StepOverTest >> testStepOverDoesNotUnderstand [
 { #category : #tests }
 StepOverTest >> testStepOverHalt [
 	"Stepping over a self halt should not raise an unhandled exception"
+	<haltOrBreakpointForTesting> 
 	self settingUpSessionAndProcessAndContextForBlock: [ self halt. ].
 	self shouldnt: [[ session interruptedProcess isTerminated ] whileFalse: [ session stepOver. ]] raise: Exception.
 ]

--- a/src/Debugging-Utils-Tests/HaltTest.class.st
+++ b/src/Debugging-Utils-Tests/HaltTest.class.st
@@ -52,7 +52,7 @@ HaltTest >> shouldntHaltWhen: aBlock [
 
 { #category : #tests }
 HaltTest >> testContainsHalt [
-	
+	<haltOrBreakpointForTesting> 
 	| annonClass |
 	
 	self 

--- a/src/UnifiedFFI/FFIFunctionParser.class.st
+++ b/src/UnifiedFFI/FFIFunctionParser.class.st
@@ -289,8 +289,8 @@ FFIFunctionParser >> returnType: aType [
 
 { #category : #accessing }
 FFIFunctionParser >> setOn: aStreamSource [
-
-	| functionDeclarationArray |
+	<haltOrBreakpointForDevelopment>
+	| functionDeclarationArray | 
 	functionDeclarationArray := aStreamSource isString ifTrue: [ | node |
 			node := RBParser parseExpression: '#(', aStreamSource, ')'.
 			node isLiteralNode ifFalse: [ self halt ].

--- a/src/UnifiedFFI/FFIFunctionParser.class.st
+++ b/src/UnifiedFFI/FFIFunctionParser.class.st
@@ -289,11 +289,10 @@ FFIFunctionParser >> returnType: aType [
 
 { #category : #accessing }
 FFIFunctionParser >> setOn: aStreamSource [
-	<haltOrBreakpointForDevelopment>
 	| functionDeclarationArray | 
 	functionDeclarationArray := aStreamSource isString ifTrue: [ | node |
 			node := RBParser parseExpression: '#(', aStreamSource, ')'.
-			node isLiteralNode ifFalse: [ self halt ].
+			node isLiteralNode ifFalse: [FFIUnsupportedFunctionDeclarationError signalFor: node ]. 
 			node evaluate
 		] ifFalse: [ aStreamSource ].
 			

--- a/src/UnifiedFFI/FFIUnsupportedFunctionDeclarationError.class.st
+++ b/src/UnifiedFFI/FFIUnsupportedFunctionDeclarationError.class.st
@@ -1,0 +1,30 @@
+"
+I am an error indicating that an unsupported function declaration is being parsed.
+I contain the unsupported node so the user can query me
+"
+Class {
+	#name : #FFIUnsupportedFunctionDeclarationError,
+	#superclass : #Error,
+	#instVars : [
+		'node'
+	],
+	#category : #'UnifiedFFI-Exceptions'
+}
+
+{ #category : #signalling }
+FFIUnsupportedFunctionDeclarationError class >> signalFor: anRBProgramNode [
+
+	self new
+		node: anRBProgramNode;
+		signal
+]
+
+{ #category : #accessing }
+FFIUnsupportedFunctionDeclarationError >> node [
+	^ node
+]
+
+{ #category : #accessing }
+FFIUnsupportedFunctionDeclarationError >> node: anObject [
+	node := anObject
+]


### PR DESCRIPTION
Adding <haltOrBreakpointForDevelopment> and <haltOrBreakpointForTest>  pragmas to methods with halts for testing or debugging purpose.

Not having these pragmas produces tool interference when trying to know what are the halts in the base system.