### PR TITLE
[fix] Renkaru test will not remove class twice anymore

### DIFF
--- a/src/Renraku-Test/ReTestClassNotInPackageWithTestEndingNameTest.class.st
+++ b/src/Renraku-Test/ReTestClassNotInPackageWithTestEndingNameTest.class.st
@@ -12,9 +12,9 @@ ReTestClassNotInPackageWithTestEndingNameTest >> testBasicCheck [
 		assert: (testClass critiques anySatisfy: [ :critic | critic rule class = ReTestClassNotInPackageWithTestEndingName ]).
 	
 	"move to correct package"
-	testPackage unregisterClass: testClass .
-	validTestPackage addClass: testClass.
-	validTestPackage registerClass: testClass.
+	validTestPackage moveClass: testClass 
+		fromPackage: testPackage 
+		toTag: (RPackageTag package: testPackage name: #whatever).
 	
 	self
 		assert: (testClass critiques noneSatisfy: [ :critic | critic rule class = ReTestClassNotInPackageWithTestEndingName ])


### PR DESCRIPTION
A renkaru test (ReTestClassNotInPackageWithTestEndingNameTest) was attempting to remove a class twice. 
Althought this threw a warning only, this should be fixed.

The use of a better method to move the class seems to force me to create a tag, which I don't like. 
If there's a better way, please let me know, I'm also waiting for intels on #development on discord.
