### PR TITLE
5420-Menus-not-accessible-when-SHIFT-is-pressed

### DIFF
--- a/src/Morphic-Base/MenuItemMorph.class.st
+++ b/src/Morphic-Base/MenuItemMorph.class.st
@@ -533,7 +533,8 @@ MenuItemMorph >> minWidth [
 MenuItemMorph >> mouseDown: evt [
 	"Handle a mouse down event. Menu items get activated when the mouse is over them."
 
-	evt shiftPressed ifTrue: [^ super mouseDown: evt].  "enable label editing"
+	(evt shiftPressed and: [ self isEditable ])
+		ifTrue: [^ super mouseDown: evt].  "enable label editing"
 	evt hand newMouseFocus: owner. "Redirect to menu for valid transitions"
 	owner selectItem: self event: evt. 
 

--- a/src/Morphic-Widgets-Extra/DockingBarMenuItemMorph.class.st
+++ b/src/Morphic-Widgets-Extra/DockingBarMenuItemMorph.class.st
@@ -44,7 +44,8 @@ DockingBarMenuItemMorph >> deselectTimeOut: evt [
 DockingBarMenuItemMorph >> mouseDown: evt [
 	"Handle a mouse down event. Menu items get activated when the mouse is over them."
 
-	evt shiftPressed ifTrue: [^ super mouseDown: evt].  "enable label editing"
+	(evt shiftPressed and: [ self isEditable ])
+		ifTrue: [^ super mouseDown: evt].  "enable label editing"
 	isSelected
 		ifTrue: [ owner selectItem: nil event: evt ]
 		ifFalse: [ owner activate: evt.	"Redirect to menu for valid transitions"

--- a/src/Morphic-Widgets-Extra/DockingBarToggleMenuItemMorph.class.st
+++ b/src/Morphic-Widgets-Extra/DockingBarToggleMenuItemMorph.class.st
@@ -91,7 +91,9 @@ DockingBarToggleMenuItemMorph >> drawSubMenuMarker: aForm on: aCanvas in: aRecta
 DockingBarToggleMenuItemMorph >> mouseDown: evt [
 	"Handle a mouse down event. Menu items get activated when the mouse is over them."
 
-	evt shiftPressed ifTrue: [^ super mouseDown: evt].  "enable label editing"
+	(evt shiftPressed and: [self isEditable ]) 
+		ifTrue: [ ^ super mouseDown: evt ].  "enable label editing"
+
 	isSelected
 		ifTrue: [
 			evt hand newMouseFocus: nil.


### PR DESCRIPTION
The mouse buttons should only try to handle the editting of the label if the menu item is editable.
Fixes #5420 