### PR TITLE
2854-Pharo-7-Saving-the-settings-breaks-local-directory

### DIFF
--- a/src/FileSystem-Core/SystemResolver.class.st
+++ b/src/FileSystem-Core/SystemResolver.class.st
@@ -35,8 +35,10 @@ SystemResolver class >> userLocalDirectory [
 ]
 
 { #category : #accessing }
-SystemResolver class >> userLocalDirectory: aFileReference [
-	UserLocalDirectory := aFileReference
+SystemResolver class >> userLocalDirectory: aFileReferenceOrPathName [
+	|aDirReference| 
+	aDirReference := aFileReferenceOrPathName asFileReference.
+	aDirReference isDirectory ifTrue: [UserLocalDirectory := aDirReference ]
 ]
 
 { #category : #origins }

--- a/src/FileSystem-Tests-Core/SystemResolverTest.class.st
+++ b/src/FileSystem-Tests-Core/SystemResolverTest.class.st
@@ -4,12 +4,37 @@ SUnit tests for SystemResolver
 Class {
 	#name : #SystemResolverTest,
 	#superclass : #FileSystemResolverTest,
+	#instVars : [
+		'originalUserLocalDir'
+	],
 	#category : #'FileSystem-Tests-Core-Resolver'
 }
 
 { #category : #running }
 SystemResolverTest >> createResolver [
 	^ SystemResolver new
+]
+
+{ #category : #running }
+SystemResolverTest >> resetToOriginalUserLocalDirectory [
+
+	resolver class userLocalDirectory: originalUserLocalDir
+	
+]
+
+{ #category : #running }
+SystemResolverTest >> setUp [ 
+	
+	super setUp.
+	originalUserLocalDir := resolver class userLocalDirectory.
+]
+
+{ #category : #running }
+SystemResolverTest >> tearDown [ 
+	
+	super tearDown.
+	self resetToOriginalUserLocalDirectory.
+	
 ]
 
 { #category : #testing }
@@ -32,6 +57,24 @@ SystemResolverTest >> testLocalDirectory [
 	| reference |
 	reference := resolver resolve: #localDirectory.
 	self assert: (reference isKindOf: FileReference)
+]
+
+{ #category : #testing }
+SystemResolverTest >> testUserLocalDirectory [
+	| newReference originalReference |
+	originalReference := resolver class userLocalDirectory.
+	
+	"test if setting to invalid directory reference is ignored"
+	newReference	 := 'someRandomString345239' asFileReference.
+	resolver class userLocalDirectory: newReference.	
+	self assert: resolver class userLocalDirectory equals: originalReference.
+	
+	"test on VM path if setting to existing directory is properly assigned"
+	newReference := resolver vmDirectory.
+	resolver class userLocalDirectory:  newReference.
+	self assert: resolver class userLocalDirectory equals: newReference.
+	
+	
 ]
 
 { #category : #testing }

--- a/src/FileSystem-Tests-Core/SystemResolverTest.class.st
+++ b/src/FileSystem-Tests-Core/SystemResolverTest.class.st
@@ -32,9 +32,8 @@ SystemResolverTest >> setUp [
 { #category : #running }
 SystemResolverTest >> tearDown [ 
 	
-	super tearDown.
 	self resetToOriginalUserLocalDirectory.
-	
+	super tearDown.	
 ]
 
 { #category : #testing }

--- a/src/System-Settings-Core/PragmaSetting.class.st
+++ b/src/System-Settings-Core/PragmaSetting.class.st
@@ -92,8 +92,8 @@ PragmaSetting >> asString [
 { #category : #'user interface' }
 PragmaSetting >> chooseFileDirectory [
 	| result |
-	result := self theme chooseDirectoryIn: self currentWorld title: 'Choose a file' path: nil.
-	result ifNotNil: [ self realValue: result fullName ].
+	result := self theme chooseDirectoryIn: self currentWorld title: 'Choose a directory' path: nil.
+	result ifNotNil: [ self realValue: result  ].
 ]
 
 { #category : #'user interface' }


### PR DESCRIPTION
fixes #2854

- PragmaSetting>>chooseFileDirectory returned string path before this fix instead of file reference instance. This caused problem, when FileLocator>>resolve tried to resolve local directory and file reference was expected. 
- fix will prevent from entering invalid directory directly by typing, so only valid directory setting is accepted (SystemResolver class>> userLocalDirectory:)
- test was added