### PR TITLE
5443-Reading-out-of-range-Float-exponents-is-inconsistent

### DIFF
--- a/src/Kernel-Tests/FloatTest.class.st
+++ b/src/Kernel-Tests/FloatTest.class.st
@@ -407,6 +407,19 @@ FloatTest >> testReadFromManyDigits [
 	self assert: (Number readFrom: s2) equals: 1 
 ]
 
+{ #category : #'tests - conversion' }
+FloatTest >> testReadingTooLargeExponents [
+	self assert: (Float readFrom: '7.5e333') equals: Float infinity.
+	self assert: (Float readFrom: '7.5e-333') equals: Float zero.
+	self assert: (Float readFrom: '-7.5e333') equals: Float infinity negated.
+	self assert: (Float readFrom: '-7.5e-333') equals: Float zero.
+
+	self assert: (Float readFrom: '7.5e3333') equals: Float infinity.
+	self assert: (Float readFrom: '7.5e-3333') equals: Float zero.
+	self assert: (Float readFrom: '-7.5e3333') equals: Float infinity negated.
+	self assert: (Float readFrom: '-7.5e-3333') equals: Float zero.
+]
+
 { #category : #'tests - NaN behavior' }
 FloatTest >> testReciprocal [
 

--- a/src/NumberParser/NumberParser.class.st
+++ b/src/NumberParser/NumberParser.class.st
@@ -461,31 +461,20 @@ NumberParser >> readExponent [
 
 	| eneg epos |
 	exponent := 0.
-	sourceStream atEnd
-		ifTrue: [ ^ false ].
-	(self exponentLetters includes: sourceStream peek)
-		ifFalse: [ ^ false ].
+	sourceStream atEnd ifTrue: [ ^ false ].
+	(self exponentLetters includes: sourceStream peek) ifFalse: [ ^ false ].
 	sourceStream next.
 	eneg := sourceStream peekFor: $-.
 	epos := eneg not
 		and: [ self allowPlusSignInExponent and: [ sourceStream peekFor: $+ ] ].
 	exponent := self nextUnsignedIntegerOrNilBase: 10.
 	exponent
-		ifNil:
-			[ "Oops, there was no digit after the exponent letter.Ungobble the letter"
+		ifNil: [ 
+			"Oops, there was no digit after the exponent letter.Ungobble the letter"
 			exponent := 0.
-			sourceStream
-				skip:
-					((eneg or: [ epos ])
-						ifTrue: [ -2 ]
-						ifFalse: [ -1 ]).
+			sourceStream skip: ((eneg or: [ epos ]) ifTrue: [ -2 ] ifFalse: [ -1 ]).
 			^ false ].
-	eneg
-		ifTrue: [ exponent := exponent negated ].
-	exponent abs > 1023
-		ifTrue:
-			[ "Number literals should have a maximun of 1023 and a minumum of -1022 as exponent, in exponential notation"
-			self fail ].
+	eneg ifTrue: [ exponent := exponent negated ].
 	^ true
 ]
 


### PR DESCRIPTION
Remove a bogus test from NumberParser>>#readExponent that resulted in inconsistent behavior
Added FloatText>>#testReadingTooLargeExponents to cover the issue

https://github.com/pharo-project/pharo/issues/5443