### PR TITLE
Fix rotation, scaling and growing halo events

### DIFF
--- a/src/Morphic-Base/HaloMorph.class.st
+++ b/src/Morphic-Base/HaloMorph.class.st
@@ -805,6 +805,7 @@ HaloMorph >> doGrow: evt with: growHandle [
 	"Called while the mouse is down in the grow handle"
 
 	| newExtent extentToUse scale |
+	growingOrRotating ifFalse: [ ^self ].
 	evt hand obtainHalo: self.
 	newExtent := (target pointFromWorld: (evt cursorPoint - positionOffset)) - target topLeft.
 	evt shiftPressed ifTrue: [
@@ -850,6 +851,8 @@ HaloMorph >> doRot: evt with: rotHandle [
 	"Update the rotation of my target if it is rotatable.  Keep the relevant command object up to date."
 
 	| degrees |
+	
+	growingOrRotating ifFalse: [^self].
 	evt hand obtainHalo: self.
 	degrees := (evt cursorPoint - (target pointInWorld: target referencePosition)) degrees.
 	degrees := degrees - angleOffset degrees.
@@ -872,6 +875,7 @@ HaloMorph >> doRot: evt with: rotHandle [
 HaloMorph >> doScale: evt with: scaleHandle [
 	"Update the scale of my target if it is scalable."
 	| newHandlePos colorToUse |
+	growingOrRotating ifFalse: [ ^self ].
 	evt hand obtainHalo: self.
 	newHandlePos := evt cursorPoint - (scaleHandle extent // 2).
 	target scaleToMatch: newHandlePos.
@@ -1287,6 +1291,7 @@ HaloMorph >> startGrow: evt with: growHandle [
 	"Initialize resizing of my target.  Launch a command representing it, to support Undo"
 
 	| botRt |
+	growingOrRotating := true.
 	self obtainHaloForEvent: evt andRemoveAllHandlesBut: growHandle.
 	botRt := target point: target bottomRight in: owner.
 	positionOffset := (self world viewBox containsPoint: botRt)


### PR DESCRIPTION
It was processing the messages to rotate and scale even if the mouseDown
event wasn't sent.

To reproduce:
1. Open a World Menu;
2. Do Alt+Shift+Click on it;
3. Move the mouse over the rotation HaloMorph (the blue one on the lower left);
4. A Debugger should appear with the message "#degrees was sent to nil".

In the case of the scaling and growing, it was simply doing them without the user having to click on them; just moving the mouse over them would trigger the action.