### PR TITLE
Improving metalink printing and visualization in Calypso

### DIFF
--- a/src/Reflectivity-Tools/MetaLinkIconStyler.class.st
+++ b/src/Reflectivity-Tools/MetaLinkIconStyler.class.st
@@ -1,0 +1,38 @@
+"
+I'm in charge to style an ast when there are metalink in the ast
+"
+Class {
+	#name : #MetaLinkIconStyler,
+	#superclass : #IconStyler,
+	#category : #'Reflectivity-Tools-Breakpoints'
+}
+
+{ #category : #defaults }
+MetaLinkIconStyler >> highlightColor [
+	^(Color orange alpha: 0.1)
+]
+
+{ #category : #defaults }
+MetaLinkIconStyler >> iconBlock: aNode [
+	^ [ aNode links inspect ]
+]
+
+{ #category : #defaults }
+MetaLinkIconStyler >> iconFor: aNode [
+	^ self iconNamed: #smallDebugIcon 
+]
+
+{ #category : #defaults }
+MetaLinkIconStyler >> iconLabel: aNode [
+	^ 'Metalinks...'
+]
+
+{ #category : #testing }
+MetaLinkIconStyler >> shouldStyleNode: aNode [
+	^ aNode hasLinks and: [ 
+		  aNode links anySatisfy: [ :link | 
+			  (link metaObject == Break or: [ 
+				   { 
+					   Watchpoint.
+					   ExecutionCounter } includes: link metaObject class ]) not ] ]
+]

--- a/src/Reflectivity/MetaLink.class.st
+++ b/src/Reflectivity/MetaLink.class.st
@@ -477,16 +477,29 @@ MetaLink >> permaLinkFor: aClassOrObject option: option instanceSpecific: instan
 	^ permaLink
 ]
 
-{ #category : #'link api' }
+{ #category : #printing }
 MetaLink >> printString [
-	|ws|
+	| ws keywords |
 	ws := WriteStream on: String new.
-	ws nextPutAll: (self control ifNil:['']).
+	ws nextPutAll: 'Link'.
+	ws space.
+	ws nextPutAll: (self control ifNil: [ '' ]).
 	ws space.
 	ws nextPutAll: metaObject printString.
 	ws space.
-	ws nextPutAll: selector asString.
-	^ws contents
+	selector isKeyword ifFalse: [ 
+		ws nextPutAll: selector asString.
+		^ ws contents ].
+	keywords := selector separateKeywords splitOn: '  '.
+	(arguments isEmpty or: [ keywords size ~= arguments size ]) ifTrue: [ 
+		ws nextPutAll: 'Error: wrong number of arguments'.
+		^ ws contents ].
+	keywords with: arguments do: [ :keyword :argument | 
+		ws nextPutAll: keyword.
+		ws space.
+		ws nextPutAll: argument printString.
+		ws space ].
+	^ ws contents
 ]
 
 { #category : #private }


### PR DESCRIPTION
Added icon styler to indicate installed metalinks in Calypso.
Clicking in the gutter icon will inspect the set of links installed on the highlighted node.

![Screenshot 2020-01-07 at 21 41 24](https://user-images.githubusercontent.com/26929529/71928305-92be7700-3197-11ea-9fc0-bd73f604761c.png)

Enhanced printString behavior.
The link defined as:
```Smalltalk
MetaLink new
	metaObject: [ :o :l :n | o crTrace ];
	selector: #value:value:value:;
	arguments: #(#object #link #node);
	control: #instead;
	options: #(#optionInlineMetaObject #optionInlineCondition #optionWeakAfter).
```

will print as:
`Link instead [ :o :l :n | o crTrace ] value: #object value: #link value: #node `