### PR TITLE
Unification of simple form of "isAbstract" method.

### DIFF
--- a/src/AST-Core-Tests/RBParseTreeTest.class.st
+++ b/src/AST-Core-Tests/RBParseTreeTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #testing }
 RBParseTreeTest class >> isAbstract [ 
 
-	^self name = #RBParseTreeTest
+	^self == RBParseTreeTest
 ]
 
 { #category : #helpers }

--- a/src/Calypso-Browser/ClyBrowserCommand.class.st
+++ b/src/Calypso-Browser/ClyBrowserCommand.class.st
@@ -15,7 +15,7 @@ Class {
 
 { #category : #testing }
 ClyBrowserCommand class >> isAbstract [
-	^self = ClyBrowserCommand 
+	^ self == ClyBrowserCommand 
 ]
 
 { #category : #accessing }

--- a/src/Calypso-Browser/ClyBrowserNavigationCommand.class.st
+++ b/src/Calypso-Browser/ClyBrowserNavigationCommand.class.st
@@ -33,7 +33,7 @@ ClyBrowserNavigationCommand class >> defaultShortcut [
 
 { #category : #testing }
 ClyBrowserNavigationCommand class >> isAbstract [
-	^self = ClyBrowserNavigationCommand
+	^ self == ClyBrowserNavigationCommand
 ]
 
 { #category : #activation }

--- a/src/Calypso-Browser/ClyBrowserToolMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserToolMorph.class.st
@@ -149,7 +149,7 @@ ClyBrowserToolMorph class >> for: aBrowser inContext: aBrowserContext [
 
 { #category : #testing }
 ClyBrowserToolMorph class >> isAbstract [
-	^self = ClyBrowserToolMorph
+	^ self == ClyBrowserToolMorph
 ]
 
 { #category : #testing }

--- a/src/Calypso-Browser/ClySwitchBrowserModeCommand.class.st
+++ b/src/Calypso-Browser/ClySwitchBrowserModeCommand.class.st
@@ -15,7 +15,7 @@ Class {
 
 { #category : #testing }
 ClySwitchBrowserModeCommand class >> isAbstract [
-	^self = ClySwitchBrowserModeCommand 
+	^self == ClySwitchBrowserModeCommand 
 ]
 
 { #category : #execution }

--- a/src/Calypso-Browser/ClyTableDecorator.class.st
+++ b/src/Calypso-Browser/ClyTableDecorator.class.st
@@ -83,7 +83,7 @@ ClyTableDecorator class >> decorateTableCell: anItemCellMorph of: aDataSourceIte
 
 { #category : #testing }
 ClyTableDecorator class >> isAbstract [
-	^self = ClyTableDecorator 
+	^self == ClyTableDecorator 
 ]
 
 { #category : #decoration }

--- a/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
+++ b/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
@@ -33,7 +33,7 @@ Class {
 
 { #category : #testing }
 ClyTextEditorToolMorph class >> isAbstract [
-	^self = ClyTextEditorToolMorph 
+	^self == ClyTextEditorToolMorph 
 ]
 
 { #category : #accessing }

--- a/src/Calypso-NavigationModel-Tests/ClyBrowserQueryCursorTestCase.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyBrowserQueryCursorTestCase.class.st
@@ -11,7 +11,7 @@ Class {
 
 { #category : #testing }
 ClyBrowserQueryCursorTestCase class >> isAbstract [
-	^self = ClyBrowserQueryCursorTestCase 
+	^ self == ClyBrowserQueryCursorTestCase 
 ]
 
 { #category : #running }

--- a/src/Calypso-NavigationModel-Tests/ClyBrowserQueryResultTestCase.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyBrowserQueryResultTestCase.class.st
@@ -11,7 +11,7 @@ Class {
 
 { #category : #testing }
 ClyBrowserQueryResultTestCase class >> isAbstract [
-	^self == ClyBrowserQueryResultTestCase 
+	^ self == ClyBrowserQueryResultTestCase 
 ]
 
 { #category : #helpers }

--- a/src/Calypso-NavigationModel-Tests/ClyCompositeQueryTestCase.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyCompositeQueryTestCase.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 ClyCompositeQueryTestCase class >> isAbstract [
-	^self = ClyCompositeQueryTestCase
+	^ self == ClyCompositeQueryTestCase
 ]
 
 { #category : #running }

--- a/src/Calypso-NavigationModel-Tests/ClyItemFilterTestCase.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyItemFilterTestCase.class.st
@@ -9,5 +9,5 @@ Class {
 
 { #category : #testing }
 ClyItemFilterTestCase class >> isAbstract [
-	^self = ClyItemFilterTestCase 
+	^self == ClyItemFilterTestCase 
 ]

--- a/src/Calypso-NavigationModel-Tests/ClyNavigationEnvironmentTestCase.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyNavigationEnvironmentTestCase.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #testing }
 ClyNavigationEnvironmentTestCase class >> isAbstract [
-	^self = ClyNavigationEnvironmentTestCase 
+	^self == ClyNavigationEnvironmentTestCase 
 ]
 
 { #category : #running }

--- a/src/Calypso-NavigationModel-Tests/ClyQueryResultTestCase.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyQueryResultTestCase.class.st
@@ -10,7 +10,7 @@ Class {
 
 { #category : #testing }
 ClyQueryResultTestCase class >> isAbstract [
-	^self = ClyQueryResultTestCase
+	^self == ClyQueryResultTestCase
 ]
 
 { #category : #running }

--- a/src/Calypso-NavigationModel-Tests/ClySortFunctionTestCase.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClySortFunctionTestCase.class.st
@@ -9,5 +9,5 @@ Class {
 
 { #category : #'as yet unclassified' }
 ClySortFunctionTestCase class >> isAbstract [
-	^self = ClySortFunctionTestCase
+	^self == ClySortFunctionTestCase
 ]

--- a/src/Calypso-NavigationModel-Tests/ClyStringPatternTestCase.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyStringPatternTestCase.class.st
@@ -6,5 +6,5 @@ Class {
 
 { #category : #testing }
 ClyStringPatternTestCase class >> isAbstract [
-	^self = ClyStringPatternTestCase
+	^self == ClyStringPatternTestCase
 ]

--- a/src/Calypso-NavigationModel-Tests/ClyTypedQueryTestCase.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyTypedQueryTestCase.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 ClyTypedQueryTestCase class >> isAbstract [
-	^self = ClyTypedQueryTestCase 
+	^self == ClyTypedQueryTestCase 
 ]
 
 { #category : #running }

--- a/src/Calypso-NavigationModel-Tests/ClyTypedScopeTestCase.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyTypedScopeTestCase.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 ClyTypedScopeTestCase class >> isAbstract [
-	^self = ClyTypedScopeTestCase 
+	^self == ClyTypedScopeTestCase 
 ]
 
 { #category : #running }

--- a/src/Calypso-NavigationModel-Tests/ClyWrapQueryTestCase.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyWrapQueryTestCase.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 ClyWrapQueryTestCase class >> isAbstract [
-	^self = ClyWrapQueryTestCase 
+	^self == ClyWrapQueryTestCase 
 ]
 
 { #category : #tests }

--- a/src/Calypso-NavigationModel/ClyEnvironmentPlugin.class.st
+++ b/src/Calypso-NavigationModel/ClyEnvironmentPlugin.class.st
@@ -94,7 +94,7 @@ ClyEnvironmentPlugin class >> initialize [
 
 { #category : #testing }
 ClyEnvironmentPlugin class >> isAbstract [
-	^self = ClyEnvironmentPlugin 
+	^ self == ClyEnvironmentPlugin 
 ]
 
 { #category : #testing }

--- a/src/Calypso-SystemPlugins-Critic-Browser/ClyCritiqueCommand.class.st
+++ b/src/Calypso-SystemPlugins-Critic-Browser/ClyCritiqueCommand.class.st
@@ -35,7 +35,7 @@ ClyCritiqueCommand class >> criticTableIconActivation [
 
 { #category : #testing }
 ClyCritiqueCommand class >> isAbstract [
-	^self = ClyCritiqueCommand 
+	^ self == ClyCritiqueCommand 
 ]
 
 { #category : #accessing }

--- a/src/Calypso-SystemPlugins-Critic-Queries-Tests/ClyCritiqueQueryTestCase.class.st
+++ b/src/Calypso-SystemPlugins-Critic-Queries-Tests/ClyCritiqueQueryTestCase.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 ClyCritiqueQueryTestCase class >> isAbstract [
-	^self = ClyCritiqueQueryTestCase
+	^ self == ClyCritiqueQueryTestCase
 ]
 
 { #category : #examples }

--- a/src/Calypso-SystemPlugins-Critic-Queries-Tests/ClyFilteringCritiqueQueryTestCase.class.st
+++ b/src/Calypso-SystemPlugins-Critic-Queries-Tests/ClyFilteringCritiqueQueryTestCase.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 ClyFilteringCritiqueQueryTestCase class >> isAbstract [
-	^self = ClyFilteringCritiqueQueryTestCase
+	^self == ClyFilteringCritiqueQueryTestCase
 ]
 
 { #category : #tests }

--- a/src/Calypso-SystemPlugins-InheritanceAnalysis-Browser/ClyShowLocalImplementorsCommand.class.st
+++ b/src/Calypso-SystemPlugins-InheritanceAnalysis-Browser/ClyShowLocalImplementorsCommand.class.st
@@ -27,7 +27,7 @@ Class {
 
 { #category : #testing }
 ClyShowLocalImplementorsCommand class >> isAbstract [
-	^self = ClyShowLocalImplementorsCommand 
+	^self == ClyShowLocalImplementorsCommand 
 ]
 
 { #category : #execution }

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddBreakpointCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddBreakpointCommand.class.st
@@ -25,7 +25,7 @@ ClyAddBreakpointCommand class >> contextMenuOrder [
 
 { #category : #testing }
 ClyAddBreakpointCommand class >> isAbstract [
-	^self = ClyAddBreakpointCommand
+	^ self == ClyAddBreakpointCommand
 ]
 
 { #category : #execution }

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyMetalinkCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyMetalinkCommand.class.st
@@ -15,7 +15,7 @@ ClyMetalinkCommand class >> contextMenuOrder [
 
 { #category : #testing }
 ClyMetalinkCommand class >> isAbstract [
-	^self = ClyMetalinkCommand 
+	^self == ClyMetalinkCommand 
 ]
 
 { #category : #activation }

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyRemoveMetalinkCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyRemoveMetalinkCommand.class.st
@@ -16,7 +16,7 @@ Class {
 
 { #category : #testing }
 ClyRemoveMetalinkCommand class >> isAbstract [
-	^self = ClyRemoveMetalinkCommand 
+	^self == ClyRemoveMetalinkCommand 
 ]
 
 { #category : #activation }

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromMethodDataSourceCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromMethodDataSourceCommand.class.st
@@ -25,7 +25,7 @@ ClyRunTestsFromMethodDataSourceCommand class >> canBeExecutedInContext: aBrowser
 
 { #category : #testing }
 ClyRunTestsFromMethodDataSourceCommand class >> isAbstract [
-	^self = ClyRunTestsFromMethodDataSourceCommand 
+	^self == ClyRunTestsFromMethodDataSourceCommand 
 ]
 
 { #category : #activation }

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromSelectedItemsCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromSelectedItemsCommand.class.st
@@ -52,7 +52,7 @@ ClyRunTestsFromSelectedItemsCommand class >> fullBrowserTableIconActivation [
 
 { #category : #testing }
 ClyRunTestsFromSelectedItemsCommand class >> isAbstract [
-	^self = ClyRunTestsFromSelectedItemsCommand 
+	^self == ClyRunTestsFromSelectedItemsCommand 
 ]
 
 { #category : #accessing }

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestCommand.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #testing }
 ClyTestCommand class >> isAbstract [
-	^self = ClyTestCommand 
+	^self == ClyTestCommand 
 ]
 
 { #category : #execution }

--- a/src/Calypso-SystemPlugins-Traits-Browser/ClySwitchTraitHierarchyModeCommand.class.st
+++ b/src/Calypso-SystemPlugins-Traits-Browser/ClySwitchTraitHierarchyModeCommand.class.st
@@ -17,7 +17,7 @@ Class {
 
 { #category : #testing }
 ClySwitchTraitHierarchyModeCommand class >> isAbstract [
-	^self = ClySwitchTraitHierarchyModeCommand 
+	^self == ClySwitchTraitHierarchyModeCommand 
 ]
 
 { #category : #execution }

--- a/src/Calypso-SystemQueries-Tests/ClyClassGroupProviderTestCase.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyClassGroupProviderTestCase.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 ClyClassGroupProviderTestCase class >> isAbstract [
-	^self = ClyClassGroupProviderTestCase 
+	^ self == ClyClassGroupProviderTestCase 
 ]
 
 { #category : #running }

--- a/src/Calypso-SystemQueries-Tests/ClyClassHierarchyScopeTestCase.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyClassHierarchyScopeTestCase.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 ClyClassHierarchyScopeTestCase class >> isAbstract [
-	^self = ClyClassHierarchyScopeTestCase
+	^ self == ClyClassHierarchyScopeTestCase
 ]
 
 { #category : #tests }

--- a/src/Calypso-SystemQueries-Tests/ClyClassQueryTestCase.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyClassQueryTestCase.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 ClyClassQueryTestCase class >> isAbstract [
-	^self = ClyClassQueryTestCase
+	^self == ClyClassQueryTestCase
 ]
 
 { #category : #tests }

--- a/src/Calypso-SystemQueries-Tests/ClyGroupedVariablesTestCase.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyGroupedVariablesTestCase.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 ClyGroupedVariablesTestCase class >> isAbstract [
-	^self = ClyGroupedVariablesTestCase 
+	^self == ClyGroupedVariablesTestCase 
 ]
 
 { #category : #helpers }

--- a/src/Calypso-SystemQueries-Tests/ClyLocalClassScopeTestCase.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyLocalClassScopeTestCase.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 ClyLocalClassScopeTestCase class >> isAbstract [
-	^self = ClyLocalClassScopeTestCase
+	^self == ClyLocalClassScopeTestCase
 ]
 
 { #category : #tests }

--- a/src/Calypso-SystemQueries-Tests/ClyPackageQueryTestCase.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyPackageQueryTestCase.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 ClyPackageQueryTestCase class >> isAbstract [
-	^self = ClyPackageQueryTestCase 
+	^self == ClyPackageQueryTestCase 
 ]
 
 { #category : #tests }

--- a/src/Calypso-SystemQueries-Tests/ClyVariableQueryTestCase.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyVariableQueryTestCase.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 ClyVariableQueryTestCase class >> isAbstract [
-	^self = ClyVariableQueryTestCase 
+	^self == ClyVariableQueryTestCase 
 ]
 
 { #category : #tests }

--- a/src/Calypso-SystemQueries/ClySystemEnvironmentPlugin.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironmentPlugin.class.st
@@ -46,7 +46,7 @@ ClySystemEnvironmentPlugin class >> enableSlowPlugins [
 
 { #category : #testing }
 ClySystemEnvironmentPlugin class >> isAbstract [
-	^self = ClySystemEnvironmentPlugin 
+	^self == ClySystemEnvironmentPlugin 
 ]
 
 { #category : #testing }

--- a/src/Calypso-SystemTools-Core/ClyClassEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassEditorToolMorph.class.st
@@ -27,7 +27,7 @@ ClyClassEditorToolMorph class >> classTabActivation [
 
 { #category : #testing }
 ClyClassEditorToolMorph class >> isAbstract [
-	^self = ClyClassEditorToolMorph 
+	^ self == ClyClassEditorToolMorph 
 ]
 
 { #category : #testing }

--- a/src/Calypso-SystemTools-Core/ClyClassTableDecorator.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassTableDecorator.class.st
@@ -19,5 +19,5 @@ ClyClassTableDecorator class >> decorationStrategy [
 
 { #category : #testing }
 ClyClassTableDecorator class >> isAbstract [
-	^self = ClyClassTableDecorator 
+	^ self == ClyClassTableDecorator 
 ]

--- a/src/Calypso-SystemTools-Core/ClyMethodEditorCommand.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorCommand.class.st
@@ -43,7 +43,7 @@ ClyMethodEditorCommand class >> canBeExecutedInMethodEditor: aTool [
 
 { #category : #testing }
 ClyMethodEditorCommand class >> isAbstract [
-	^self = ClyMethodEditorCommand 
+	^self == ClyMethodEditorCommand 
 ]
 
 { #category : #activation }

--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -35,7 +35,7 @@ Class {
 
 { #category : #testing }
 ClyMethodEditorToolMorph class >> isAbstract [
-	^self = ClyMethodEditorToolMorph 
+	^self == ClyMethodEditorToolMorph 
 ]
 
 { #category : #accessing }

--- a/src/Calypso-SystemTools-Core/ClyMethodTableDecorator.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodTableDecorator.class.st
@@ -19,5 +19,5 @@ ClyMethodTableDecorator class >> decorationStrategy [
 
 { #category : #testing }
 ClyMethodTableDecorator class >> isAbstract [
-	^self = ClyMethodTableDecorator  
+	^self == ClyMethodTableDecorator  
 ]

--- a/src/Calypso-SystemTools-Core/ClyPackageTableDecorator.class.st
+++ b/src/Calypso-SystemTools-Core/ClyPackageTableDecorator.class.st
@@ -19,5 +19,5 @@ ClyPackageTableDecorator class >> decorationStrategy [
 
 { #category : #testing }
 ClyPackageTableDecorator class >> isAbstract [
-	^self = ClyPackageTableDecorator 
+	^self == ClyPackageTableDecorator 
 ]

--- a/src/Calypso-SystemTools-FullBrowser/ClyMethodGroupCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyMethodGroupCommand.class.st
@@ -22,7 +22,7 @@ ClyMethodGroupCommand class >> canBeExecutedInContext: aToolContext [
 
 { #category : #testing }
 ClyMethodGroupCommand class >> isAbstract [
-	^self = ClyMethodGroupCommand 
+	^self == ClyMethodGroupCommand 
 ]
 
 { #category : #accessing }

--- a/src/Calypso-SystemTools-FullBrowser/ClySwitchClassMetaLevelCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClySwitchClassMetaLevelCommand.class.st
@@ -29,7 +29,7 @@ ClySwitchClassMetaLevelCommand class >> fullBrowserToolbarActivation [
 
 { #category : #testing }
 ClySwitchClassMetaLevelCommand class >> isAbstract [
-	^self = ClySwitchClassMetaLevelCommand 
+	^self == ClySwitchClassMetaLevelCommand 
 ]
 
 { #category : #activation }

--- a/src/Calypso-SystemTools-FullBrowser/ClySwitchClassViewModeCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClySwitchClassViewModeCommand.class.st
@@ -22,5 +22,5 @@ ClySwitchClassViewModeCommand class >> fullBrowserToolbarActivation [
 
 { #category : #testing }
 ClySwitchClassViewModeCommand class >> isAbstract [
-	^self = ClySwitchClassViewModeCommand 
+	^self == ClySwitchClassViewModeCommand 
 ]

--- a/src/Calypso-SystemTools-FullBrowser/ClySwitchMethodViewModeCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClySwitchMethodViewModeCommand.class.st
@@ -26,7 +26,7 @@ ClySwitchMethodViewModeCommand class >> fullBrowserToolbarActivation [
 
 { #category : #testing }
 ClySwitchMethodViewModeCommand class >> isAbstract [
-	^self = ClySwitchMethodViewModeCommand 
+	^self == ClySwitchMethodViewModeCommand 
 ]
 
 { #category : #accessing }

--- a/src/Calypso-SystemTools-FullBrowser/ClySwitchPackageViewModeCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClySwitchPackageViewModeCommand.class.st
@@ -40,7 +40,7 @@ ClySwitchPackageViewModeCommand class >> fullBrowserToolbarActivation3 [
 
 { #category : #testing }
 ClySwitchPackageViewModeCommand class >> isAbstract [
-	^self = ClySwitchPackageViewModeCommand 
+	^self == ClySwitchPackageViewModeCommand 
 ]
 
 { #category : #activation }

--- a/src/Calypso-SystemTools-QueryBrowser/ClySwitchQueryResultCommand.class.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClySwitchQueryResultCommand.class.st
@@ -14,7 +14,7 @@ Class {
 
 { #category : #testing }
 ClySwitchQueryResultCommand class >> isAbstract [
-	^self = ClySwitchQueryResultCommand 
+	^self == ClySwitchQueryResultCommand 
 ]
 
 { #category : #activation }

--- a/src/Collections-Abstract/ArrayedCollection.class.st
+++ b/src/Collections-Abstract/ArrayedCollection.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #testing }
 ArrayedCollection class >> isAbstract [
 
-	^self name = #ArrayedCollection
+	^self == ArrayedCollection
 ]
 
 { #category : #'instance creation' }

--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -15,7 +15,7 @@ Collection class >> empty [
 { #category : #testing }
 Collection class >> isAbstract [
 
-	^self name = #Collection
+	^self == Collection
 ]
 
 { #category : #'instance creation' }

--- a/src/Collections-Abstract/HashedCollection.class.st
+++ b/src/Collections-Abstract/HashedCollection.class.st
@@ -59,7 +59,7 @@ HashedCollection class >> empty [
 { #category : #testing }
 HashedCollection class >> isAbstract [
 
-	^self name = #HashedCollection
+	^self == HashedCollection
 ]
 
 { #category : #'instance creation' }

--- a/src/Collections-Abstract/SequenceableCollection.class.st
+++ b/src/Collections-Abstract/SequenceableCollection.class.st
@@ -19,7 +19,7 @@ SequenceableCollection class >> << blockWithArg [
 { #category : #testing }
 SequenceableCollection class >> isAbstract [
 
-	^self name = #SequenceableCollection
+	^self == SequenceableCollection
 ]
 
 { #category : #'stream creation' }

--- a/src/Collections-Tests/CollectionRootTest.class.st
+++ b/src/Collections-Tests/CollectionRootTest.class.st
@@ -13,7 +13,7 @@ Class {
 { #category : #testing }
 CollectionRootTest class >> isAbstract [
 
-	^ self name = #CollectionRootTest
+	^ self == CollectionRootTest
 ]
 
 { #category : #requirements }

--- a/src/Commander-Activators-ContextMenu/CmdOpenContextMenuCommand.class.st
+++ b/src/Commander-Activators-ContextMenu/CmdOpenContextMenuCommand.class.st
@@ -20,7 +20,7 @@ Class {
 
 { #category : #testing }
 CmdOpenContextMenuCommand class >> isAbstract [
-	^self = CmdOpenContextMenuCommand 
+	^self == CmdOpenContextMenuCommand 
 ]
 
 { #category : #execution }

--- a/src/Commander-Core-Tests/CmdAbstractCommandExample.class.st
+++ b/src/Commander-Core-Tests/CmdAbstractCommandExample.class.st
@@ -13,5 +13,5 @@ CmdAbstractCommandExample class >> activationExample1 [
 
 { #category : #testing }
 CmdAbstractCommandExample class >> isAbstract [
-	^self = CmdAbstractCommandExample 
+	^self == CmdAbstractCommandExample 
 ]

--- a/src/Commander-Core-Tests/CmdRootOfCommandExamples.class.st
+++ b/src/Commander-Core-Tests/CmdRootOfCommandExamples.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #testing }
 CmdRootOfCommandExamples class >> isAbstract [
-	^self = CmdRootOfCommandExamples 
+	^self == CmdRootOfCommandExamples 
 ]
 
 { #category : #execution }

--- a/src/Commander-Core/CmdCommand.class.st
+++ b/src/Commander-Core/CmdCommand.class.st
@@ -122,7 +122,7 @@ CmdCommand class >> defaultMenuItemName [
 
 { #category : #testing }
 CmdCommand class >> isAbstract [
-	^self = CmdCommand 
+	^self == CmdCommand 
 ]
 
 { #category : #execution }

--- a/src/DrTests-Tests/DTMockPlugin.class.st
+++ b/src/DrTests-Tests/DTMockPlugin.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #testing }
 DTMockPlugin class >> isAbstract [
-	^ self = DTMockPlugin
+	^ self == DTMockPlugin
 ]
 
 { #category : #'api - accessing' }

--- a/src/DrTests/AbstractDrTestsUI.class.st
+++ b/src/DrTests/AbstractDrTestsUI.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #testing }
 AbstractDrTestsUI class >> isAbstract [
-	^ AbstractDrTestsUI = self
+	^ self == AbstractDrTestsUI
 ]
 
 { #category : #accessing }

--- a/src/DrTests/DrTestsPlugin.class.st
+++ b/src/DrTests/DrTestsPlugin.class.st
@@ -21,7 +21,7 @@ DrTestsPlugin class >> availablePlugins [
 { #category : #testing }
 DrTestsPlugin class >> isAbstract [
 	"Should return true if the plugin is abstract and should not be instantiated."
-	^ self = DrTestsPlugin
+	^ self == DrTestsPlugin
 ]
 
 { #category : #'api - accessing' }

--- a/src/EmbeddedFreeType/EmbeddedFreeTypeFontFontDescription.class.st
+++ b/src/EmbeddedFreeType/EmbeddedFreeTypeFontFontDescription.class.st
@@ -42,7 +42,7 @@ EmbeddedFreeTypeFontFontDescription class >> installFontsIn: provider [
 
 { #category : #testing }
 EmbeddedFreeTypeFontFontDescription class >> isAbstract [ 
-	^self name = #EmbeddedFreeTypeFontFontDescription 
+	^self == EmbeddedFreeTypeFontFontDescription 
 	
 ]
 

--- a/src/FileSystem-Tests-Core/AbstractEnumerationVisitorTest.class.st
+++ b/src/FileSystem-Tests-Core/AbstractEnumerationVisitorTest.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #testing }
 AbstractEnumerationVisitorTest class >> isAbstract [
-	^ self name = #AbstractEnumerationVisitorTest
+	^ self == AbstractEnumerationVisitorTest
 ]
 
 { #category : #utilities }

--- a/src/FileSystem-Tests-Core/FileSystemHandleTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemHandleTest.class.st
@@ -14,7 +14,7 @@ Class {
 
 { #category : #testing }
 FileSystemHandleTest class >> isAbstract [
-	^ self name = #FileSystemHandleTest
+	^ self == FileSystemHandleTest
 ]
 
 { #category : #testing }

--- a/src/FileSystem-Tests-Core/FileSystemResolverTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemResolverTest.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #testing }
 FileSystemResolverTest class >> isAbstract [
-	^ self = FileSystemResolverTest
+	^ self == FileSystemResolverTest
 ]
 
 { #category : #asserting }

--- a/src/FileSystem-Tests-Core/FileSystemTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemTest.class.st
@@ -21,7 +21,7 @@ FileSystemTest class >> defaultTimeLimit [
 
 { #category : #testing }
 FileSystemTest class >> isAbstract [
-	^ self name = #FileSystemTest
+	^ self == FileSystemTest
 ]
 
 { #category : #accessing }

--- a/src/FileSystem-Tests-Core/FileSystemTreeTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemTreeTest.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #testing }
 FileSystemTreeTest class >> isAbstract [
-	^ self name = #FileSystemTreeTest
+	^ self == FileSystemTreeTest
 ]
 
 { #category : #running }

--- a/src/FileSystem-Tests-Core/GuideTest.class.st
+++ b/src/FileSystem-Tests-Core/GuideTest.class.st
@@ -13,7 +13,7 @@ Class {
 
 { #category : #testing }
 GuideTest class >> isAbstract [
-	^ self name = #GuideTest
+	^ self == GuideTest
 ]
 
 { #category : #asserting }

--- a/src/FileSystem-Tests-Core/SingleTreeTest.class.st
+++ b/src/FileSystem-Tests-Core/SingleTreeTest.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #testing }
 SingleTreeTest class >> isAbstract [
-	^ self name = #SingleTreeTest
+	^ self == SingleTreeTest
 ]
 
 { #category : #running }

--- a/src/GT-Tests-Debugger/GTDebuggerSmokeTest.class.st
+++ b/src/GT-Tests-Debugger/GTDebuggerSmokeTest.class.st
@@ -11,7 +11,7 @@ Class {
 
 { #category : #testing }
 GTDebuggerSmokeTest class >> isAbstract [
-	^ self name = #GTDebuggerSmokeTest
+	^ self == GTDebuggerSmokeTest
 ]
 
 { #category : #asserting }

--- a/src/Gofer-Tests/GoferTest.class.st
+++ b/src/Gofer-Tests/GoferTest.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #testing }
 GoferTest class >> isAbstract [
-	^ self name = #GoferTest
+	^ self == GoferTest
 ]
 
 { #category : #testing }

--- a/src/Kernel/Integer.class.st
+++ b/src/Kernel/Integer.class.st
@@ -42,7 +42,7 @@ Integer class >> byte1: byte1 byte2: byte2 byte3: byte3 byte4: byte4 [
 { #category : #testing }
 Integer class >> isAbstract [
 
-	^self name = #Integer
+	^self == Integer
 ]
 
 { #category : #'instance creation' }

--- a/src/Keymapping-Tests/AbstractKeymappingTest.class.st
+++ b/src/Keymapping-Tests/AbstractKeymappingTest.class.st
@@ -20,7 +20,7 @@ Class {
 { #category : #testing }
 AbstractKeymappingTest class >> isAbstract [
 
-	^self name = #AbstractKeymappingTest
+	^self == AbstractKeymappingTest
 ]
 
 { #category : #utilities }

--- a/src/Metacello-TestsCore/MetacelloCommonVersionNumberTestCase.class.st
+++ b/src/Metacello-TestsCore/MetacelloCommonVersionNumberTestCase.class.st
@@ -9,7 +9,7 @@ MetacelloCommonVersionNumberTestCase class >> isAbstract [
     "Override to true if a TestCase subclass is Abstract and should not have
 	TestCase instances built from it"
 
-    ^ self name = #'MetacelloCommonVersionNumberTestCase'
+    ^ self == MetacelloCommonVersionNumberTestCase
 ]
 
 { #category : #private }

--- a/src/Monticello-Tests/MCRepositoryTest.class.st
+++ b/src/Monticello-Tests/MCRepositoryTest.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #testing }
 MCRepositoryTest class >> isAbstract [
-	^ self = MCRepositoryTest
+	^ self == MCRepositoryTest
 ]
 
 { #category : #actions }

--- a/src/Monticello-Tests/MCTestCase.class.st
+++ b/src/Monticello-Tests/MCTestCase.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #'as yet unclassified' }
 MCTestCase class >> isAbstract [
-	^ self = MCTestCase
+	^ self == MCTestCase
 ]
 
 { #category : #testing }

--- a/src/Morphic-Widgets-FastTable-Tests/FTAbstractColumnSortingStrategyTest.class.st
+++ b/src/Morphic-Widgets-FastTable-Tests/FTAbstractColumnSortingStrategyTest.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #testing }
 FTAbstractColumnSortingStrategyTest class >> isAbstract [
-	^ self = FTAbstractColumnSortingStrategyTest
+	^ self == FTAbstractColumnSortingStrategyTest
 ]
 
 { #category : #testing }

--- a/src/Morphic-Widgets-FastTable-Tests/FTAbstractSortingStateTest.class.st
+++ b/src/Morphic-Widgets-FastTable-Tests/FTAbstractSortingStateTest.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #testing }
 FTAbstractSortingStateTest class >> isAbstract [
-	^ self = FTAbstractSortingStateTest
+	^ self == FTAbstractSortingStateTest
 ]
 
 { #category : #testing }

--- a/src/Morphic-Widgets-FastTable-Tests/FTSelectionModeStrategyTest.class.st
+++ b/src/Morphic-Widgets-FastTable-Tests/FTSelectionModeStrategyTest.class.st
@@ -13,7 +13,7 @@ Class {
 
 { #category : #testing }
 FTSelectionModeStrategyTest class >> isAbstract [
-	^ self = FTSelectionModeStrategyTest
+	^ self == FTSelectionModeStrategyTest
 ]
 
 { #category : #testing }

--- a/src/Morphic-Widgets-FastTable/FTFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTFunction.class.st
@@ -42,7 +42,7 @@ Class {
 
 { #category : #testing }
 FTFunction class >> isAbstract [
-	^ self = FTFunction
+	^ self == FTFunction
 ]
 
 { #category : #'instance creation' }

--- a/src/Morphic-Widgets-FastTable/FTFunctionWithField.class.st
+++ b/src/Morphic-Widgets-FastTable/FTFunctionWithField.class.st
@@ -33,7 +33,7 @@ Class {
 
 { #category : #testing }
 FTFunctionWithField class >> isAbstract [
-	^ self = FTFunctionWithField
+	^ self == FTFunctionWithField
 ]
 
 { #category : #accessing }

--- a/src/Ombu-Tests/OmSessionStoreNameStrategyTest.class.st
+++ b/src/Ombu-Tests/OmSessionStoreNameStrategyTest.class.st
@@ -14,7 +14,7 @@ Class {
 { #category : #testing }
 OmSessionStoreNameStrategyTest class >> isAbstract [
 
-	^ self name = #OmSessionStoreNameStrategyTest
+	^ self == OmSessionStoreNameStrategyTest
 ]
 
 { #category : #private }

--- a/src/Ombu-Tests/OmStoreTest.class.st
+++ b/src/Ombu-Tests/OmStoreTest.class.st
@@ -15,7 +15,7 @@ Class {
 
 { #category : #testing }
 OmStoreTest class >> isAbstract [
-	^ self name = #OmStoreTest
+	^ self == OmStoreTest
 ]
 
 { #category : #running }

--- a/src/ParametrizedTests/PaAbstractExampleTest.class.st
+++ b/src/ParametrizedTests/PaAbstractExampleTest.class.st
@@ -13,7 +13,7 @@ Class {
 
 { #category : #private }
 PaAbstractExampleTest class >> isAbstract [
-	^ self name = #PaAbstractExampleTest
+	^ self == PaAbstractExampleTest
 ]
 
 { #category : #accessing }

--- a/src/ParametrizedTests/ParametrizedTestCase.class.st
+++ b/src/ParametrizedTests/ParametrizedTestCase.class.st
@@ -62,7 +62,7 @@ ParametrizedTestCase class >> buildSuite [
 
 { #category : #private }
 ParametrizedTestCase class >> isAbstract [
-	^ self name = #ParametrizedTestCase 
+	^ self == ParametrizedTestCase 
 ]
 
 { #category : #'building suites' }

--- a/src/Refactoring-Changes/RBRefactoryClassChange.class.st
+++ b/src/Refactoring-Changes/RBRefactoryClassChange.class.st
@@ -16,7 +16,7 @@ Class {
 
 { #category : #testing }
 RBRefactoryClassChange class >> isAbstract [ 
-	^self name = #RBRefactoryClassChange
+	^self == RBRefactoryClassChange
 ]
 
 { #category : #comparing }

--- a/src/Refactoring-Tests-Core/RBRefactoringBrowserTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRefactoringBrowserTest.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 RBRefactoringBrowserTest class >> isAbstract [
-	^ self name = #RBRefactoringBrowserTest
+	^ self == RBRefactoringBrowserTest
 ]
 
 { #category : #private }

--- a/src/SUnit-Core/ClassTestCase.class.st
+++ b/src/SUnit-Core/ClassTestCase.class.st
@@ -24,8 +24,8 @@ ClassTestCase class >> isAbstract [
 	"Override to true if a TestCase subclass is Abstract and should not have
 	TestCase instances built from it"
 
-	^self name = #ClassTestCase
-			
+	^ self == ClassTestCase
+
 ]
 
 { #category : #testing }

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -307,8 +307,8 @@ TestCase class >> isAbstract [
 	"Override to true if a TestCase subclass is Abstract and should not have
 	TestCase instances built from it"
 
-	^self name = #TestCase
-			
+	^self == TestCase
+
 ]
 
 { #category : #testing }

--- a/src/SUnit-Core/TestResource.class.st
+++ b/src/SUnit-Core/TestResource.class.st
@@ -65,7 +65,7 @@ TestResource class >> isAbstract [
 	"Override to true if a TestResource subclass is Abstract and should not have
 	TestCase instances built from it"
 
-	^self name = #TestResource
+	^self == TestResource
 			
 ]
 

--- a/src/Spec-Core/SpecAdapterBindings.class.st
+++ b/src/Spec-Core/SpecAdapterBindings.class.st
@@ -15,7 +15,7 @@ Class {
 { #category : #testing }
 SpecAdapterBindings class >> isAbstract [ 
 
-	^ self name = #SpecAdapterBindings
+	^ self == SpecAdapterBindings
 ]
 
 { #category : #initialize }

--- a/src/Spec-Tests/SpecTestCase.class.st
+++ b/src/Spec-Tests/SpecTestCase.class.st
@@ -20,7 +20,7 @@ Class {
 
 { #category : #testing }
 SpecTestCase class >> isAbstract [
-	^ self name = #SpecTestCase
+	^ self == SpecTestCase
 ]
 
 { #category : #testing }

--- a/src/Spec2-Adapters-Morphic/SpAbstractMorphicListAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpAbstractMorphicListAdapter.class.st
@@ -10,7 +10,7 @@ Class {
 
 { #category : #testing }
 SpAbstractMorphicListAdapter class >> isAbstract [
-	^ self = SpAbstractMorphicListAdapter
+	^ self == SpAbstractMorphicListAdapter
 ]
 
 { #category : #scrolling }

--- a/src/Spec2-Backend-Tests/SpAbstractLayoutTest.class.st
+++ b/src/Spec2-Backend-Tests/SpAbstractLayoutTest.class.st
@@ -11,7 +11,7 @@ Class {
 
 { #category : #testing }
 SpAbstractLayoutTest class >> isAbstract [ 
-	^ self = SpAbstractLayoutTest
+	^ self == SpAbstractLayoutTest
 ]
 
 { #category : #testing }

--- a/src/Spec2-Backend-Tests/SpAbstractTextAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpAbstractTextAdapterTest.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 SpAbstractTextAdapterTest class >> isAbstract [
-	^ self = SpAbstractTextAdapterTest
+	^ self == SpAbstractTextAdapterTest
 ]
 
 { #category : #testing }

--- a/src/Spec2-Backend-Tests/SpAbstractTreeTableAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpAbstractTreeTableAdapterTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #testing }
 SpAbstractTreeTableAdapterTest class >> isAbstract [ 
 	
-	^ self = SpAbstractTreeTableAdapterTest
+	^ self == SpAbstractTreeTableAdapterTest
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Backend-Tests/SpAbstractWidgetAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpAbstractWidgetAdapterTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #testing }
 SpAbstractWidgetAdapterTest class >> isAbstract [ 
 
-	^ self name = #SpAbstractWidgetAdapterTest 
+	^ self == SpAbstractWidgetAdapterTest 
 ]
 
 { #category : #running }

--- a/src/Spec2-Core/SpAbstractAdapter.class.st
+++ b/src/Spec2-Core/SpAbstractAdapter.class.st
@@ -50,7 +50,7 @@ SpAbstractAdapter class >> allAdapters [
 
 { #category : #testing }
 SpAbstractAdapter class >> isAbstract [
-	^ self = SpAbstractAdapter
+	^ self == SpAbstractAdapter
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Core/SpAbstractFormButtonPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractFormButtonPresenter.class.st
@@ -29,7 +29,7 @@ Class {
 
 { #category : #testing }
 SpAbstractFormButtonPresenter class >> isAbstract [
-	^ self = SpAbstractFormButtonPresenter
+	^ self == SpAbstractFormButtonPresenter
 ]
 
 { #category : #api }

--- a/src/Spec2-Core/SpAbstractPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractPresenter.class.st
@@ -43,7 +43,7 @@ SpAbstractPresenter class >> inputTextHeight [
 
 { #category : #testing }
 SpAbstractPresenter class >> isAbstract [
-	^ self = SpAbstractPresenter
+	^ self == SpAbstractPresenter
 ]
 
 { #category : #TOREMOVE }

--- a/src/Spec2-Core/SpAbstractTextPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractTextPresenter.class.st
@@ -20,7 +20,7 @@ Class {
 
 { #category : #testing }
 SpAbstractTextPresenter class >> isAbstract [
-	^ self = SpAbstractTextPresenter
+	^ self == SpAbstractTextPresenter
 ]
 
 { #category : #api }

--- a/src/Spec2-Core/SpAbstractWidgetPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractWidgetPresenter.class.st
@@ -57,7 +57,7 @@ SpAbstractWidgetPresenter class >> defaultSpec [
 
 { #category : #testing }
 SpAbstractWidgetPresenter class >> isAbstract [
-	^ self = SpAbstractWidgetPresenter
+	^ self == SpAbstractWidgetPresenter
 ]
 
 { #category : #'drag and drop' }

--- a/src/Spec2-Core/SpAdapterBindings.class.st
+++ b/src/Spec2-Core/SpAdapterBindings.class.st
@@ -15,7 +15,7 @@ Class {
 { #category : #testing }
 SpAdapterBindings class >> isAbstract [ 
 
-	^ self name = #SpAdapterBindings
+	^ self == SpAdapterBindings
 ]
 
 { #category : #initialize }

--- a/src/Spec2-Core/SpPresenter.class.st
+++ b/src/Spec2-Core/SpPresenter.class.st
@@ -120,7 +120,7 @@ SpPresenter class >> iconWidth [
 
 { #category : #testing }
 SpPresenter class >> isAbstract [
-	^ self = SpPresenter
+	^ self == SpPresenter
 ]
 
 { #category : #'labelled-presenters' }

--- a/src/Spec2-Tests/SpAbstractButtonPresenterTest.class.st
+++ b/src/Spec2-Tests/SpAbstractButtonPresenterTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #testing }
 SpAbstractButtonPresenterTest class >> isAbstract [
 
-	^ super isAbstract or: [ self = SpAbstractButtonPresenterTest ]
+	^ super isAbstract or: [ self == SpAbstractButtonPresenterTest ]
 ]
 
 { #category : #tests }

--- a/src/Spec2-Tests/SpAbstractSelectionModeTest.class.st
+++ b/src/Spec2-Tests/SpAbstractSelectionModeTest.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #testing }
 SpAbstractSelectionModeTest class >> isAbstract [
-	^ self = SpAbstractSelectionModeTest
+	^ self == SpAbstractSelectionModeTest
 ]
 
 { #category : #testing }

--- a/src/Spec2-Tests/SpAbstractTextPresenterTest.class.st
+++ b/src/Spec2-Tests/SpAbstractTextPresenterTest.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 SpAbstractTextPresenterTest class >> isAbstract [
-	^ self = SpAbstractTextPresenterTest
+	^ self == SpAbstractTextPresenterTest
 ]
 
 { #category : #testing }

--- a/src/Spec2-Tests/SpCodeCommandTest.class.st
+++ b/src/Spec2-Tests/SpCodeCommandTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #testing }
 SpCodeCommandTest class >> isAbstract [
 
-	^ self = SpCodeCommandTest
+	^ self == SpCodeCommandTest
 ]
 
 { #category : #testing }

--- a/src/Spec2-Tests/SpSmokeTest.class.st
+++ b/src/Spec2-Tests/SpSmokeTest.class.st
@@ -16,7 +16,7 @@ Class {
 
 { #category : #testing }
 SpSmokeTest class >> isAbstract [
-	^ self name = #SpSmokeTest
+	^ self == SpSmokeTest
 ]
 
 { #category : #testing }

--- a/src/Spec2-Tests/SpTest.class.st
+++ b/src/Spec2-Tests/SpTest.class.st
@@ -10,7 +10,7 @@ Class {
 
 { #category : #testing }
 SpTest class >> isAbstract [
-	^ self = SpTest
+	^ self == SpTest
 ]
 
 { #category : #assertions }

--- a/src/System-BasicCommandLineHandler/CommandLineHandler.class.st
+++ b/src/System-BasicCommandLineHandler/CommandLineHandler.class.st
@@ -64,7 +64,7 @@ CommandLineHandler class >> description [
 
 { #category : #accessing }
 CommandLineHandler class >> isAbstract [
-	^ self = CommandLineHandler
+	^ self == CommandLineHandler
 ]
 
 { #category : #'handler selection' }

--- a/src/System-Identification-Tests/GlobalIdentifierPersistenceTest.class.st
+++ b/src/System-Identification-Tests/GlobalIdentifierPersistenceTest.class.st
@@ -14,7 +14,7 @@ Class {
 
 { #category : #testing }
 GlobalIdentifierPersistenceTest class >> isAbstract [
-	^ self name = GlobalIdentifierPersistenceTest name
+	^ self == GlobalIdentifierPersistenceTest
 ]
 
 { #category : #accessing }

--- a/src/System-Identification-Tests/GlobalIdentifierTest.class.st
+++ b/src/System-Identification-Tests/GlobalIdentifierTest.class.st
@@ -13,7 +13,7 @@ Class {
 
 { #category : #testing }
 GlobalIdentifierTest class >> isAbstract [
-	^ self = GlobalIdentifierTest 
+	^ self == GlobalIdentifierTest
 ]
 
 { #category : #accessing }

--- a/src/SystemCommands-ClassCommands/SycClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycClassCommand.class.st
@@ -22,7 +22,7 @@ SycClassCommand class >> canBeExecutedInContext: aToolContext [
 
 { #category : #testing }
 SycClassCommand class >> isAbstract [
-	^self = SycClassCommand 
+	^self == SycClassCommand 
 ]
 
 { #category : #accessing }

--- a/src/SystemCommands-ClassCommands/SycNewClassCreationCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycNewClassCreationCommand.class.st
@@ -18,7 +18,7 @@ Class {
 
 { #category : #testing }
 SycNewClassCreationCommand class >> isAbstract [
-	^self = SycNewClassCreationCommand 
+	^self == SycNewClassCreationCommand 
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-ClassCommands/SycSingleClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycSingleClassCommand.class.st
@@ -22,7 +22,7 @@ SycSingleClassCommand class >> canBeExecutedInContext: aToolContext [
 
 { #category : #testing }
 SycSingleClassCommand class >> isAbstract [
-	^self = SycSingleClassCommand 
+	^self == SycSingleClassCommand 
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-MessageCommands/SycChangeMessageSignatureCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycChangeMessageSignatureCommand.class.st
@@ -30,7 +30,7 @@ SycChangeMessageSignatureCommand class >> canBeExecutedInContext: aToolContext [
 
 { #category : #testing }
 SycChangeMessageSignatureCommand class >> isAbstract [
-	^self = SycChangeMessageSignatureCommand 
+	^self == SycChangeMessageSignatureCommand 
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-MessageCommands/SycMessageCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycMessageCommand.class.st
@@ -36,7 +36,7 @@ SycMessageCommand class >> forMethods: methods [
 
 { #category : #testing }
 SycMessageCommand class >> isAbstract [
-	^self = SycMessageCommand
+	^self == SycMessageCommand
 ]
 
 { #category : #accessing }

--- a/src/SystemCommands-MethodCommands/SycMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMethodCommand.class.st
@@ -28,7 +28,7 @@ SycMethodCommand class >> for: methods [
 
 { #category : #testing }
 SycMethodCommand class >> isAbstract [
-	^self = SycMethodCommand 
+	^self == SycMethodCommand 
 ]
 
 { #category : #accessing }

--- a/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
@@ -15,7 +15,7 @@ Class {
 
 { #category : #testing }
 SycMethodRepackagingCommand class >> isAbstract [
-	^self = SycMethodRepackagingCommand 
+	^self == SycMethodRepackagingCommand 
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-PackageCommands/SycPackageCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycPackageCommand.class.st
@@ -22,7 +22,7 @@ SycPackageCommand class >> canBeExecutedInContext: aToolContext [
 
 { #category : #testing }
 SycPackageCommand class >> isAbstract [
-	^self = SycPackageCommand 
+	^self == SycPackageCommand 
 ]
 
 { #category : #accessing }

--- a/src/SystemCommands-SourceCodeCommands/SycSourceCodeCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycSourceCodeCommand.class.st
@@ -19,7 +19,7 @@ Class {
 
 { #category : #testing }
 SycSourceCodeCommand class >> isAbstract [
-	^self = SycSourceCodeCommand 
+	^self == SycSourceCodeCommand 
 ]
 
 { #category : #'instance creation' }

--- a/src/SystemCommands-VariableCommands/SycRefactorVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycRefactorVariableCommand.class.st
@@ -28,7 +28,7 @@ SycRefactorVariableCommand class >> canBeExecutedInContext: aToolContext [
 
 { #category : #testing }
 SycRefactorVariableCommand class >> isAbstract [
-	^self = SycRefactorVariableCommand 
+	^self == SycRefactorVariableCommand 
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-VariableCommands/SycVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycVariableCommand.class.st
@@ -23,7 +23,7 @@ SycVariableCommand class >> canBeExecutedInContext: aToolContext [
 
 { #category : #testing }
 SycVariableCommand class >> isAbstract [
-	^self = SycVariableCommand 
+	^self == SycVariableCommand 
 ]
 
 { #category : #execution }

--- a/src/Tests/BaseStreamTest.class.st
+++ b/src/Tests/BaseStreamTest.class.st
@@ -6,7 +6,8 @@ Class {
 
 { #category : #testing }
 BaseStreamTest class >> isAbstract [
-	^ self = BaseStreamTest.
+
+	^self == BaseStreamTest.
 ]
 
 { #category : #testing }

--- a/src/Tools/AbstractDebugger.class.st
+++ b/src/Tools/AbstractDebugger.class.st
@@ -20,7 +20,7 @@ AbstractDebugger class >> beCurrent [
 
 { #category : #testing }
 AbstractDebugger class >> isAbstract [
-	^ self = AbstractDebugger
+	^ self == AbstractDebugger
 ]
 
 { #category : #'opening api' }

--- a/src/Tools/LogDebugger.class.st
+++ b/src/Tools/LogDebugger.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #testing }
 LogDebugger class >> isAbstract [
-	^ self = LogDebugger
+	^ self == LogDebugger
 ]
 
 { #category : #'opening api' }

--- a/src/UnifiedFFI/FFIArchitecture.class.st
+++ b/src/UnifiedFFI/FFIArchitecture.class.st
@@ -19,7 +19,7 @@ FFIArchitecture class >> forCurrentArchitecture [
 { #category : #testing }
 FFIArchitecture class >> isAbstract [ 
 
-	^self name = #FFIArchitecture
+	^self == FFIArchitecture
 ]
 
 { #category : #testing }

--- a/src/UnifiedFFI/FFI_x86_64.class.st
+++ b/src/UnifiedFFI/FFI_x86_64.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #testing }
 FFI_x86_64 class >> isAbstract [ 
 
-	^self name = #FFI_x86_64
+	^self == FFI_x86_64
 ]
 
 { #category : #types }


### PR DESCRIPTION
Among three most common implementations:
1. self = SomeClass
2. self == SomeClass
3. self name = #SomeClass

second one is the most fastest.

See original FogBugz [case #22771](https://pharo.fogbugz.com/f/cases/22771/isAbstract-for-classes-should-be-unified).