### PR TITLE
Fix Exception #pass semantics

### DIFF
--- a/src/Kernel-Tests/ExceptionTest.class.st
+++ b/src/Kernel-Tests/ExceptionTest.class.st
@@ -392,6 +392,7 @@ ExceptionTest >> testUnhandledErrorWhenNoHandlers [
 	executed := false.
 	semaphore := Semaphore new.
 	[[ 1/0 ] on: UnhandledError do: [ :e | executed := true ]. semaphore signal] fork.
+	"we should not wait forever in case of wrong behaviour (general test timeout is disabled in #runCaseManaged)"
 	semaphore wait: 2 seconds.
 	self assert: executed
 ]

--- a/src/Kernel-Tests/ExceptionTest.class.st
+++ b/src/Kernel-Tests/ExceptionTest.class.st
@@ -379,9 +379,10 @@ ExceptionTest >> testUnhandledErrorWhenHandlerPassesOriginalException [
 	semaphore := Semaphore new.
 	[ [ 
 			[ 1/0 ] on: UnhandledError do: [ :e | executed := true ]
-		] on: ZeroDivide do: [:z | z pass]
-		. semaphore signal] fork.
-	"we should not wait forever in case of wrong behaviour (general test timeout is disabled in #runCaseManaged)"
+		] on: ZeroDivide do: [:z | z pass].
+		semaphore signal] fork. "fork allows to avoid any handlers from the SUnit"
+	"we should not wait forever in case of wrong behaviour 
+	(general test timeout is disabled in #runCaseManaged)"
 	semaphore wait: 2 seconds.
 	self assert: executed
 ]
@@ -391,8 +392,27 @@ ExceptionTest >> testUnhandledErrorWhenNoHandlers [
 	| executed semaphore |
 	executed := false.
 	semaphore := Semaphore new.
-	[[ 1/0 ] on: UnhandledError do: [ :e | executed := true ]. semaphore signal] fork.
-	"we should not wait forever in case of wrong behaviour (general test timeout is disabled in #runCaseManaged)"
+	[
+		[ 1/0 ] on: UnhandledError do: [ :e | executed := true ]. 
+		semaphore signal] fork. "fork allows to avoid any handlers from the SUnit"
+	"we should not wait forever in case of wrong behaviour 
+	(general test timeout is disabled in #runCaseManaged)"
+	semaphore wait: 2 seconds.
+	self assert: executed
+]
+
+{ #category : #'tests - handling' }
+ExceptionTest >> testUnhandledErrorWhenTwoHandlersPassOriginalException [
+	| executed semaphore |
+	executed := false.
+	semaphore := Semaphore new.
+	[ [ [  
+				[ 1/0 ] on: UnhandledError do: [ :e | executed := true ]
+			] on: ZeroDivide do: [:z | z pass]
+		] on: ZeroDivide do: [:z | z pass].
+		semaphore signal] fork. "fork allows to avoid any handlers from the SUnit"
+	"we should not wait forever in case of wrong behaviour 
+	(general test timeout is disabled in #runCaseManaged)"
 	semaphore wait: 2 seconds.
 	self assert: executed
 ]

--- a/src/Kernel-Tests/ExceptionTest.class.st
+++ b/src/Kernel-Tests/ExceptionTest.class.st
@@ -381,6 +381,7 @@ ExceptionTest >> testUnhandledErrorWhenHandlerPassesOriginalException [
 			[ 1/0 ] on: UnhandledError do: [ :e | executed := true ]
 		] on: ZeroDivide do: [:z | z pass]
 		. semaphore signal] fork.
+	"we should not wait forever in case of wrong behaviour (general test timeout is disabled in #runCaseManaged)"
 	semaphore wait: 2 seconds.
 	self assert: executed
 ]

--- a/src/Kernel-Tests/ExceptionTest.class.st
+++ b/src/Kernel-Tests/ExceptionTest.class.st
@@ -30,6 +30,14 @@ ExceptionTest >> assertSuccess: anExceptionTester [
 	self should: [ ( anExceptionTester suiteLog first) endsWith:  'succeeded'].
 ]
 
+{ #category : #private }
+ExceptionTest >> runCaseManaged [
+	"We should disable TestEnvironment to avoid any logic for unhandled errors from background processes.
+	Some tests fork processes to ensure clean no handlers (SUnit catches errors for example)"
+	
+	^DefaultExecutionEnvironment beActiveDuring: [ self runCase]
+]
+
 { #category : #'tests - exceptiontester' }
 ExceptionTest >> testDoubleOuterPass [
 	self assertSuccess: (ExceptionTester new runTest: #doubleOuterPassTest ) 
@@ -196,7 +204,7 @@ ExceptionTest >> testHandlingWithSeveralExclusionsAndExceptionSetsHandling [
 		assert: result isNil.	
 ]
 
-{ #category : #tests }
+{ #category : #'tests - exceptiontester' }
 ExceptionTest >> testNoTimeout [
 	self assertSuccess: (ExceptionTester new runTest: #simpleNoTimeoutTest ) 
 ]
@@ -226,6 +234,30 @@ ExceptionTest >> testNonResumablePass [
 			do: [:ex | ex pass. ex return: 5]
 		] raise: Error
 
+]
+
+{ #category : #'tests - resignal' }
+ExceptionTest >> testResignalAs [
+
+	| answer |
+	answer := [
+		[3 zork]
+			on: ZeroDivide
+			do: [:ex | ex return: 5]
+	] on: Error do: [:ex | ex resignalAs: ZeroDivide].
+	self assert: answer == 5
+]
+
+{ #category : #'tests - resignal' }
+ExceptionTest >> testResignalAsUnwinds [
+
+	| unwound answer |
+	unwound := false.
+	answer := [
+		[3 zork]
+			on: ZeroDivide do: [:ex | self assert: unwound.  ex return: 5]
+	] on: Error do: [:ex | [ex resignalAs: ZeroDivide] ifCurtailed: [unwound := true]].
+	self assert: answer == 5
 ]
 
 { #category : #'tests - exceptiontester' }
@@ -321,11 +353,44 @@ ExceptionTest >> testSimpleResume [
 ]
 
 { #category : #'tests - exceptiontester' }
+ExceptionTest >> testSimpleRetry [
+	self assertSuccess: (ExceptionTester new runTest: #simpleRetryTest ) 
+]
+
+{ #category : #'tests - exceptiontester' }
+ExceptionTest >> testSimpleRetryUsing [
+	self assertSuccess: (ExceptionTester new runTest: #simpleRetryUsingTest ) 
+]
+
+{ #category : #'tests - exceptiontester' }
 ExceptionTest >> testSimpleReturn [
 	self assertSuccess: (ExceptionTester new runTest: #simpleReturnTest ) 
 ]
 
-{ #category : #tests }
+{ #category : #'tests - exceptiontester' }
 ExceptionTest >> testTimeoutWithZeroDuration [
 	self assertSuccess: (ExceptionTester new runTest: #simpleTimeoutWithZeroDurationTest ) 
+]
+
+{ #category : #'tests - handling' }
+ExceptionTest >> testUnhandledErrorWhenHandlerPassesOriginalException [
+	| executed semaphore |
+	executed := false.
+	semaphore := Semaphore new.
+	[ [ 
+			[ 1/0 ] on: UnhandledError do: [ :e | executed := true ]
+		] on: ZeroDivide do: [:z | z pass]
+		. semaphore signal] fork.
+	semaphore wait: 2 seconds.
+	self assert: executed
+]
+
+{ #category : #'tests - handling' }
+ExceptionTest >> testUnhandledErrorWhenNoHandlers [
+	| executed semaphore |
+	executed := false.
+	semaphore := Semaphore new.
+	[[ 1/0 ] on: UnhandledError do: [ :e | executed := true ]. semaphore signal] fork.
+	semaphore wait: 2 seconds.
+	self assert: executed
 ]

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -770,19 +770,17 @@ Context >> findContextSuchThat: testBlock [
 
 { #category : #'private-exceptions' }
 Context >> findNextHandlerContext [
-
-	"Return the next handler marked context, returning nil if there is none.  Search starts with self and proceeds up to nil."
-
-	| context |
-
+	"Return the next handler marked context, returning nil if there is none.  
+	Search starts with self and proceeds up to nil."
+	| context searchStartContext |
 	context := self findNextHandlerOrSignalingContext.
 	context ifNil: [ ^ nil ].
-	context isHandlerContext
-		ifTrue: [ ^ context ].	"If it isn't a handler context, it must be a signaling context.
+	context isHandlerContext ifTrue: [ ^ context ].	
+	"If it isn't a handler context, it must be a signaling context.
 	When we reach a signaling context we must skip over any handlers
-	that might be on the stack between the signaling context and the handler
-	context for that signal."
-	^ context exception privHandlerContext nextHandlerContext
+	that might be on the stack between the signaling context and the handler context for that signal"
+	searchStartContext := context exception privHandlerContext ifNil: [ context ].
+	^searchStartContext nextHandlerContext
 ]
 
 { #category : #'private-exceptions' }
@@ -1616,6 +1614,29 @@ Context >> resume: value through: firstUnwindContext [
 		context := context findNextUnwindContextUpTo: self].
 	thisContext terminateTo: self.
 	^value
+
+]
+
+{ #category : #controlling }
+Context >> resumeEvaluating: aBlock [
+	"Unwind thisContext to self and resume with aBlock value as result of last send.  
+	Execute unwind blocks when unwinding.  
+	ASSUMES self is a sender of thisContext"
+	| context unwindBlock |
+	self isDead ifTrue: [self cannotReturn: aBlock value to: self].
+	context := thisContext.
+	[
+		context := context findNextUnwindContextUpTo: self.
+		context isNil
+	] whileFalse: [	
+		context unwindComplete ifNil:[
+			context unwindComplete: true.
+			unwindBlock := context unwindBlock.
+			thisContext terminateTo: context.
+			unwindBlock value]
+	].
+	thisContext terminateTo: self.
+	^aBlock value
 
 ]
 

--- a/src/Kernel/Exception.class.st
+++ b/src/Kernel/Exception.class.st
@@ -190,20 +190,23 @@ Exception >> messageText: signalerText [
 { #category : #handling }
 Exception >> outer [
 	"Evaluate the enclosing exception action and return to here instead of signal if it resumes (see #resumeUnchecked:)."
-
-	| prevOuterContext |
+	| prevOuterContext currentHandler |
 	self isResumable 
 		ifTrue: [
 			prevOuterContext := outerContext. "required and accessed in resumeUnchecked:"
 			outerContext := thisContext contextTag ].
-	self pass.
+	currentHandler := handlerContext.
+	[self pass] ensure: [handlerContext := currentHandler].
 ]
 
 { #category : #handling }
 Exception >> pass [
 	"Yield control to the enclosing exception action for the receiver."
 
-	handlerContext nextHandlerContext handleSignal: self
+	| nextHandler |
+	nextHandler := handlerContext nextHandlerContext.
+	handlerContext := nil.
+	nextHandler handleSignal: self
 ]
 
 { #category : #printing }
@@ -232,8 +235,7 @@ Exception >> receiver [
 { #category : #handling }
 Exception >> resignalAs: replacementException [
 	"Signal an alternative exception in place of the receiver."
-	
-	^ replacementException signalIn: signalContext
+	signalContext resumeEvaluating: [replacementException signal]
 ]
 
 { #category : #handling }


### PR DESCRIPTION
Exception should reset #handlerContext during #pass operation because #pass  should be equivalent to no handler scenario. 
It solves the bug with UnhandledError:```Smalltalk
 [ [ MyTestError signal ]
             on: UnhandledError
             do: [ :e | self halt ] ]
         on: MyTestError
         do: [ :z | z pass ].```
The fix is influenced by Cuis implementation but it avoids keeping all processed handlers in collection. 
In addition #resignalAs: and couple of Exception tests are added from Cuis 
(#resignalAs: should unwinds the stack up to signaler context according to ANSI)