### PR TITLE
GT Inspector: Fix Hook for Unary Presentation Generator

### DIFF
--- a/src/GT-Inspector/ProtoObject.extension.st
+++ b/src/GT-Inspector/ProtoObject.extension.st
@@ -59,7 +59,7 @@ ProtoObject >> gtInspectorPresentationsFromPragmas: aCollection In: composite in
 		do: [ :eachPragma | 
 			eachPragma methodSelector numArgs = 0
 				ifTrue: [ | presentationSource |
-					presentationSource := self perform: eachPragma selector.
+					presentationSource := self perform: eachPragma methodSelector.
 					presentationSource glmPresentation
 						cull: composite
 						cull: aGTInspector


### PR DESCRIPTION
This code is (probably only) used by Magritte to declaratively create GT Inspector presentations. I (@SeanDeNigris) [originally introduced it](https://github.com/moosetechnology/Moose/issues/1130), but it seems to have been altered (I'm assuming accidentally, possibly as a result of a system-wide method rename, but can't tell for sure because the change seems to predate the move to GH).