### PR TITLE
Issue with loading Source Code

### DIFF
--- a/src/System-Sources/SourceFile.class.st
+++ b/src/System-Sources/SourceFile.class.st
@@ -49,12 +49,18 @@ SourceFile >> cr [
 	stream cr
 ]
 
+{ #category : #buffering }
+SourceFile >> discardBuffer [
+
+	stream wrappedStream discardBuffer
+]
+
 { #category : #accessing }
 SourceFile >> ensureWrittenPosition: aPosition [
 
-	self isReadOnly ifTrue: [ ^ self ].
+	self isReadOnly ifTrue: [ ^ false ].
 	
-	stream ensureWrittenPosition: aPosition
+	^ stream ensureWrittenPosition: aPosition
 ]
 
 { #category : #accessing }

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -313,9 +313,10 @@ SourceFileArray >> readStreamAtFileIndex: index atPosition: position ifPresent: 
 	"If the file has been flushed, I am discarding the readonly stream's buffer.
 	This is to avoid a problem where the readOnly buffer is missing data that was in 
 	the writer buffer."	
-	(file ensureWrittenPosition: position)
-		ifTrue: [
-			stream discardBuffer].
+	file ensureWrittenPosition: position.
+
+	"I am discarding the buffer of the readonly stream, because if not is out-of-sync."
+	stream discardBuffer.
 	
    stream position: position.
    result := presentBlock value: stream.

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -287,7 +287,14 @@ SourceFileArray >> readStreamAt: sourcePointer ifPresent: presentBlock ifAbsent:
 SourceFileArray >> readStreamAtFileIndex: index atPosition: position ifPresent: presentBlock ifAbsent: absentBlock [
  
    | queue stream rofa result file |
-       
+   
+	"This method is really ugly. 
+	It uses different readers over the same file that is beeing writing. 
+	This can lead to buffer problems. 
+	This should be rethougth to a better way.
+	
+	Maybe an unification of all the accesses using the same buffer could be nice."
+    
   	queue := readOnlyQueue.
   	rofa := queue nextOrNil ifNil: [ self createReadOnlyFiles ].
        
@@ -302,8 +309,13 @@ SourceFileArray >> readStreamAtFileIndex: index atPosition: position ifPresent: 
 		self finishedReading: rofa from: queue. 
 		^ absentBlock value 
 	].
-	
-	file ensureWrittenPosition: position.
+
+	"If the file has been flushed, I am discarding the readonly stream's buffer.
+	This is to avoid a problem where the readOnly buffer is missing data that was in 
+	the writer buffer."	
+	(file ensureWrittenPosition: position)
+		ifTrue: [
+			stream discardBuffer].
 	
    stream position: position.
    result := presentBlock value: stream.

--- a/src/System-Sources/SourceFileBufferedReadWriteStream.class.st
+++ b/src/System-Sources/SourceFileBufferedReadWriteStream.class.st
@@ -105,9 +105,12 @@ SourceFileBufferedReadWriteStream >> defaultBufferSize [
 { #category : #writing }
 SourceFileBufferedReadWriteStream >> ensureWrittenPosition: aPosition [
 
-	isDirty ifFalse: [ ^ self ].
+	isDirty ifFalse: [ ^ false ].
+	
 	(self isPositionInBuffer: aPosition)
-		ifTrue: [ self flush ]
+		ifTrue: [ self flush. ^ true ].
+		
+	^ false
 ]
 
 { #category : #writing }

--- a/src/System-Sources/SourceFileCharacterReadWriteStream.class.st
+++ b/src/System-Sources/SourceFileCharacterReadWriteStream.class.st
@@ -49,7 +49,7 @@ SourceFileCharacterReadWriteStream >> cr [
 
 { #category : #accessing }
 SourceFileCharacterReadWriteStream >> ensureWrittenPosition: aPosition [
-	writeStream wrappedStream ensureWrittenPosition: aPosition
+	^ writeStream wrappedStream ensureWrittenPosition: aPosition
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Discarding read-only buffer that is used for accessing the source code. As it can be out-of-sync with the file in the disk, that is written by another buffered writer.