### PR TITLE
5481-Metacello-logs-now-prints-lots-of-new-lines

### DIFF
--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1079,17 +1079,11 @@ SmalltalkImage >> logStdOutDuring: aBlock [
 	"install the line end conversion and force initialize the converter"
 	stderr := ZnNewLineWriterStream
 		on: (ZnCharacterWriteStream on: Stdio stdout encoding: 'utf8').
-
-	"reset coloring"
-	stderr
-		nextPut: Character escape;
-		nextPutAll: '[0m'.
-	"rund the loggin block"
 	
 	[aBlock value: stderr.] 
 		on: Error do: [ "If the block fails we don't do nothing. This can lead to recursive errors" ].
 
-	stderr flush; close.
+	stderr flush.
 ]
 
 { #category : #'memory space' }

--- a/src/UIManager/CommandLineUIManager.class.st
+++ b/src/UIManager/CommandLineUIManager.class.st
@@ -391,7 +391,10 @@ CommandLineUIManager >> stdout [
 CommandLineUIManager >> systemNotificationDefaultAction: aNotification [
 	
 	Smalltalk logStdOutDuring: [:logger |
-		logger cr; nextPutAll: aNotification class name, ': ',  aNotification messageText; cr ].
+		logger nextPutAll: aNotification class name;
+				 nextPutAll: ': ';  
+				 nextPutAll: aNotification messageText; 
+				 cr ].
 	
 	aNotification resume.
 


### PR DESCRIPTION
Improving the logging of system notifications.
Removing extra escape characters and cr.
Also not closing Stderr