### PR TITLE
Unreadable "red" marking color collide with "red" unimplemented messages text

### DIFF
--- a/src/Polymorph-Widgets/PharoDarkTheme.class.st
+++ b/src/Polymorph-Widgets/PharoDarkTheme.class.st
@@ -270,6 +270,12 @@ PharoDarkTheme >> initialize [
 	self settings preferGradientFill: false.
 ]
 
+{ #category : #testing }
+PharoDarkTheme >> isLightTheme [
+
+	^false
+]
+
 { #category : #'accessing colors' }
 PharoDarkTheme >> lessConspicuousColorFrom: aColor [
 

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -2422,6 +2422,12 @@ UITheme >> initializeForms [
 
 ]
 
+{ #category : #testing }
+UITheme >> isLightTheme [
+
+	^true
+]
+
 { #category : #'label-styles' }
 UITheme >> labelDisabledColorFor: aLabel [
 	"Answer the color to use for a label when disabled."

--- a/src/Renraku/ReAbstractCritique.class.st
+++ b/src/Renraku/ReAbstractCritique.class.st
@@ -111,9 +111,12 @@ ReAbstractCritique >> change [
 
 { #category : #accessing }
 ReAbstractCritique >> color [
-
+	| errorColor |
+	errorColor := Smalltalk ui theme isLightTheme 
+							ifTrue: [ Color pink ]
+							ifFalse: [ Color red ].
 	^ ({
-	#error -> Color pink.
+	#error -> errorColor.
 	#warning -> Color yellow.
 	#information -> Color blue
 	 } asDictionary at: rule severity ifAbsent: [ super color ]) alpha: 0.1

--- a/src/Renraku/ReAbstractCritique.class.st
+++ b/src/Renraku/ReAbstractCritique.class.st
@@ -113,8 +113,8 @@ ReAbstractCritique >> change [
 ReAbstractCritique >> color [
 
 	^ ({
-	#error -> Color red .
-	#warning -> Color yellow .
+	#error -> Color pink.
+	#warning -> Color yellow.
 	#information -> Color blue
 	 } asDictionary at: rule severity ifAbsent: [ super color ]) alpha: 0.1
 


### PR DESCRIPTION
Use pink instead of red for background marking 

Fixes #5508