### PR TITLE
Adding callout string encoding support

### DIFF
--- a/src/UnifiedFFI-Tests/FFIFunctionResolutionTest.class.st
+++ b/src/UnifiedFFI-Tests/FFIFunctionResolutionTest.class.st
@@ -171,7 +171,7 @@ FFIFunctionResolutionTest >> testResolveConstantFalseShouldSetConstantZeroLoader
 		yourself.
 	
 	argument resolveUsing: FFICallout new.
-	argument loader emitArgument: self context: nil.
+	argument loader emitArgument: self context: nil inCallout: nil.
 
 	self assert: stack pop equals: { #literal . 0 }.
 ]
@@ -198,7 +198,7 @@ FFIFunctionResolutionTest >> testResolveConstantIntegerShouldSetConstantLoader [
 		yourself.
 	
 	argument resolveUsing: FFICallout new.
-	argument loader emitArgument: self context: nil.
+	argument loader emitArgument: self context: nil inCallout: nil.
 
 	self assert: stack pop equals: { #literal . 1}.
 ]
@@ -226,7 +226,7 @@ FFIFunctionResolutionTest >> testResolveConstantNULLShouldSetConstantNullLoader 
 		yourself.
 	
 	argument resolveUsing: FFICallout new.
-	argument loader emitArgument: self context: nil.
+	argument loader emitArgument: self context: nil inCallout: nil.
 
 	self assert: stack pop equals: { #literal . ExternalAddress null}.
 ]
@@ -254,7 +254,7 @@ FFIFunctionResolutionTest >> testResolveConstantNilShouldSetConstantNullLoader [
 		yourself.
 	
 	argument resolveUsing: FFICallout new.
-	argument loader emitArgument: self context: nil.
+	argument loader emitArgument: self context: nil inCallout: nil.
 
 	self assert: stack pop equals: { #literal . ExternalAddress null }.
 ]
@@ -279,7 +279,7 @@ FFIFunctionResolutionTest >> testResolveConstantSelfOfExternalObjectShouldSetCon
 		yourself.
 	
 	argument resolveUsing: resolver.
-	argument loader emitArgument: self context: context.
+	argument loader emitArgument: self context: context inCallout: nil.
 
 	self assert: stack pop equals: #(#ivar 1).
 ]
@@ -331,7 +331,7 @@ FFIFunctionResolutionTest >> testResolveConstantSelfStringShouldSetConstantLoade
 		yourself.
 
 	argument resolveUsing: FFICallout new.
-	argument loader emitArgument: self context: nil.
+	argument loader emitArgument: self context: nil inCallout: nil.
 
 	self assert: stack pop equals: { #literal . 'self' }.
 ]
@@ -362,7 +362,7 @@ FFIFunctionResolutionTest >> testResolveConstantTrueShouldSetConstantOneLoader [
 		yourself.
 	
 	argument resolveUsing: FFICallout new.
-	argument loader emitArgument: self context: nil.
+	argument loader emitArgument: self context: nil inCallout: nil.
 
 	self assert: stack pop equals: { #literal . 1 }.
 ]

--- a/src/UnifiedFFI-Tests/FFIMockCalloutMethodBuilder.class.st
+++ b/src/UnifiedFFI-Tests/FFIMockCalloutMethodBuilder.class.st
@@ -1,0 +1,54 @@
+"
+I am a callout method builder that creates a mock ExternalLibraryFunction invoking a block instead of a function.
+Useful for testing, avoiding the actual external call.
+"
+Class {
+	#name : #FFIMockCalloutMethodBuilder,
+	#superclass : #FFICalloutMethodBuilder,
+	#instVars : [
+		'block'
+	],
+	#category : #'UnifiedFFI-Tests-Tests'
+}
+
+{ #category : #compatibility }
+FFIMockCalloutMethodBuilder >> createFFICalloutLiteralFromSpec: functionSpec [
+
+	^ self
+]
+
+{ #category : #accessing }
+FFIMockCalloutMethodBuilder >> doing: aBlockClosure [ 
+	
+	block := aBlockClosure
+]
+
+{ #category : #'type-resolution' }
+FFIMockCalloutMethodBuilder >> ffiBindingOf: aString [ 
+	
+	^ self class ffiBindingOf: aString
+]
+
+{ #category : #invoking }
+FFIMockCalloutMethodBuilder >> invokeWithArguments: aCollection [ 
+	
+	^ block valueWithArguments: aCollection
+]
+
+{ #category : #compatibility }
+FFIMockCalloutMethodBuilder >> method [
+	"To mock the creation of the IR..."
+	^ block
+]
+
+{ #category : #compatibility }
+FFIMockCalloutMethodBuilder >> methodProperties [
+	"To mock the creation of the IR..."
+	^ nil
+]
+
+{ #category : #compatibility }
+FFIMockCalloutMethodBuilder >> methodTrailer [
+
+	^ CompiledMethodTrailer empty
+]

--- a/src/UnifiedFFI-Tests/FFIStringCalloutTest.class.st
+++ b/src/UnifiedFFI-Tests/FFIStringCalloutTest.class.st
@@ -1,0 +1,187 @@
+Class {
+	#name : #FFIStringCalloutTest,
+	#superclass : #TestCase,
+	#classVars : [
+		'CLASSVAR',
+		'TYPEVAR'
+	],
+	#category : #'UnifiedFFI-Tests-Tests'
+}
+
+{ #category : #tests }
+FFIStringCalloutTest >> newFFIMethodWithSignature: signature doing: aBlock [
+	
+	^ self newFFIMethodWithSignature: signature doing: aBlock options: #()
+]
+
+{ #category : #tests }
+FFIStringCalloutTest >> newFFIMethodWithSignature: signature doing: aBlock options: options [
+	
+	| calloutAPI methodBuilder |
+	calloutAPI := FFICalloutAPI inUFFIContext: nil.
+	methodBuilder := FFIMockCalloutMethodBuilder calloutAPI: calloutAPI.
+	methodBuilder doing: aBlock.
+	methodBuilder requestor: (FFICallout new
+		methodArgs: aBlock argumentNames;
+		requestor: methodBuilder;
+		options: options;
+		yourself).
+	
+	^ methodBuilder build: [ :builder | 
+			builder
+				signature: signature;
+				sender: methodBuilder ]
+]
+
+{ #category : #tests }
+FFIStringCalloutTest >> testCalloutShouldHaveLegacyStringEncodingStrategyByDefault [
+	|generator|
+	generator := FFICallout new.
+	
+	self assert: generator stringEncodingStrategy isLegacy
+]
+
+{ #category : #tests }
+FFIStringCalloutTest >> testConflictingEncodingOptionShouldRaiseError [
+	|generator|
+	generator := FFICallout new.
+	generator options: #( optStringEncodingUtf8 optStringEncodingUtf16 ).
+
+	[generator stringEncodingStrategy.
+	self fail]
+		on: Error
+		do: [ :error | self assert: error messageText equals: 'Conflicting string encoding options' ]
+]
+
+{ #category : #tests }
+FFIStringCalloutTest >> testEncodingOptionSetsStringEncodingStrategy [
+	|generator|
+	generator := FFICallout new.
+	generator options: #( optStringEncodingUtf8 ).
+	self assert: generator stringEncodingStrategy encoding equals: 'Utf8'
+]
+
+{ #category : #tests }
+FFIStringCalloutTest >> testLegacyCalloutShouldReturnStringArgument [
+	| method return |
+	
+	method := self
+		newFFIMethodWithSignature: #( char* f ( void ) )
+		doing: [ 'string' ].	
+	
+	return := method valueWithReceiver: nil arguments: #( ).
+	
+	self assert: return equals: 'string'
+]
+
+{ #category : #tests }
+FFIStringCalloutTest >> testLegacyCalloutShouldSendStringArgument [
+	| ffiInvocationArgument method |
+	
+	method := self
+		newFFIMethodWithSignature: #( void f (char* aString) )
+		doing: [ :aString | ffiInvocationArgument := aString ].	
+	method valueWithReceiver: nil arguments: #( 'string' ).
+	
+	self assert: ffiInvocationArgument equals: 'string'
+]
+
+{ #category : #tests }
+FFIStringCalloutTest >> testMandatoryEncodingWithSpecifiedEncodingShouldNotFail [
+	| ffiInvocationArgument method |
+	
+	method := self
+		newFFIMethodWithSignature: #( void f (char* aString) )
+		doing: [ :aString | ffiInvocationArgument := aString ]
+		options: #( optStringEncodingUtf8 optStringEncodingMandatory ).
+	method valueWithReceiver: nil arguments: #( 'string' ).
+	
+	self assert: ffiInvocationArgument equals: ('string' nullTerminatedEncodeWith: #utf8)
+]
+
+{ #category : #tests }
+FFIStringCalloutTest >> testMandatoryEncodingWithoutExplicitEncodingShouldRaiseError [
+	[self
+		newFFIMethodWithSignature: #( void f (char* 'string') )
+		doing: [ :aString | "nothing" ]
+		options: #( optStringEncodingMandatory ).
+	self fail]
+		on: Error
+		do: [ :error | self assert: error messageText equals: 'String encoding option not specified' ]
+]
+
+{ #category : #tests }
+FFIStringCalloutTest >> testStringEncodingWithMandatoryEncodingWithSpecifiedEncodingShouldNotFail [
+	| result method |
+	
+	method := self
+		newFFIMethodWithSignature: #( char* f ( ) )
+		doing: [ 'test' ]
+		options: #( optStringEncodingUtf8 optStringEncodingMandatory ).
+	result := method valueWithReceiver: nil arguments: #( ).
+
+	self assert: result equals: 'test'
+]
+
+{ #category : #tests }
+FFIStringCalloutTest >> testStringReturnWithMandatoryEncodingWithoutExplicitEncodingShouldRaiseError [
+	[self
+		newFFIMethodWithSignature: #( char* f (void) )
+		doing: [ 'asd' utf8Encoded ]
+		options: #( optStringEncodingMandatory ).
+	self fail]
+		on: Error
+		do: [ :error | self assert: error messageText equals: 'String encoding option not specified' ]
+]
+
+{ #category : #tests }
+FFIStringCalloutTest >> testUtf8CalloutShouldReturnDecodeUtf8EncodedString [
+	| return method |
+	"The FFI backend returns a byte string instead of a byte array. We should gracefully transform it to byte array and decode it"
+	method := self
+		newFFIMethodWithSignature: #( char* f ( ) )
+		doing: [ 	ByteString withAll: 'les élèves français' utf8Encoded ]
+		options: #( optStringEncodingUtf8 ).
+	return := method valueWithReceiver: nil arguments: #( ).
+	
+	self assert: return equals: 'les élèves français'
+]
+
+{ #category : #tests }
+FFIStringCalloutTest >> testUtf8CalloutShouldSendUtf8EncodedLiteralStringArgument [
+	| ffiInvocationArgument method |
+	
+	method := self
+		newFFIMethodWithSignature: #( void f (char* 'string') )
+		doing: [ :aString | ffiInvocationArgument := aString ]
+		options: #( optStringEncodingUtf8 ).
+	method valueWithReceiver: nil arguments: #( nil ).
+	
+	self assert: ffiInvocationArgument equals: ('string' nullTerminatedEncodeWith: #utf8)
+]
+
+{ #category : #tests }
+FFIStringCalloutTest >> testUtf8CalloutShouldSendUtf8EncodedStringArgument [
+	| ffiInvocationArgument method |
+	
+	method := self
+		newFFIMethodWithSignature: #( void f (char* aString) )
+		doing: [ :aString | ffiInvocationArgument := aString ]
+		options: #( optStringEncodingUtf8 ).
+	method valueWithReceiver: nil arguments: #( 'string' ).
+	
+	self assert: ffiInvocationArgument equals: ('string' nullTerminatedEncodeWith: #utf8)
+]
+
+{ #category : #tests }
+FFIStringCalloutTest >> testUtf8EncodedStringShouldHaveNullTerminator [
+	| ffiInvocationArgument method |
+	
+	method := self
+		newFFIMethodWithSignature: #( void f (char* 'string') )
+		doing: [ :aString | ffiInvocationArgument := aString ]
+		options: #( optStringEncodingUtf8 ).
+	method valueWithReceiver: nil arguments: #( nil ).
+	
+	self assert: ffiInvocationArgument utf8Decoded equals: 'string', Character null asString
+]

--- a/src/UnifiedFFI/FFICallbackType.class.st
+++ b/src/UnifiedFFI/FFICallbackType.class.st
@@ -13,7 +13,7 @@ Class {
 }
 
 { #category : #'emitting code' }
-FFICallbackType >> basicEmitArgument: aBuilder context: aContext [
+FFICallbackType >> basicEmitArgument: aBuilder context: aContext inCallout: aCallout [
 
  	self loader emitArgument: aBuilder context: aContext.
 

--- a/src/UnifiedFFI/FFICallout.class.st
+++ b/src/UnifiedFFI/FFICallout.class.st
@@ -25,7 +25,8 @@ Class {
 		'methodArgs',
 		'receiver',
 		'method',
-		'resolutionMode'
+		'resolutionMode',
+		'stringEncodingStrategy'
 	],
 	#classVars : [
 		'TypeAliases'
@@ -162,6 +163,12 @@ FFICallout >> initialize [
 	options := Dictionary new.
 ]
 
+{ #category : #configuration }
+FFICallout >> isMandatoryStringEncoding [
+
+	^ self optionAt: #optStringEncodingMandatory
+]
+
 { #category : #testing }
 FFICallout >> isStrict [
 
@@ -199,7 +206,6 @@ FFICallout >> loaderForArgNamed: argName indirectIndex: anIndex [
 { #category : #'argument loaders' }
 FFICallout >> loaderFromMethodArgsNamed: argName [
 	| index |
-
 	methodArgs ifNil: [ ^ nil ].
 	index := methodArgs indexOf: argName ifAbsent: [ nil ].
 	^ index ifNotNil: [ 
@@ -329,6 +335,27 @@ FFICallout >> resolveExternalType: anObject [
 	^ (self resolveType: anObject) externalType 
 ]
 
+{ #category : #configuration }
+FFICallout >> resolveStringEncodingStrategy [
+
+	| encodingOptions |
+	encodingOptions := (self options associations
+		select: [ :e | (e key beginsWith: 'optStringEncoding') and: [ e value ] ]
+		thenCollect: [ :e | e key allButFirst: 'optStringEncoding' size ]) asSet.
+	
+	"Do not take into account optStringEncodingMandatory as an encoding"
+	encodingOptions remove: 'Mandatory' ifAbsent: [  ].
+	
+	encodingOptions size > 1 ifTrue: [ self error: 'Conflicting string encoding options' ].
+	
+	(self isMandatoryStringEncoding and: [ encodingOptions isEmpty ])
+		ifTrue: [ self error: 'String encoding option not specified' ].
+	
+	^ encodingOptions isEmpty
+		ifTrue: [ FFILegacyStringEncodingStrategy new ]
+		ifFalse: [ FFIStringEncodingStrategy forEncoding: encodingOptions anyOne ]
+]
+
 { #category : #accessing }
 FFICallout >> resolveType: aTypeName [
 	" a type name could be
@@ -379,6 +406,19 @@ FFICallout >> sender: aSenderContext [
 	self receiver: aSenderContext receiver.
 	self assert: (methodArgs size = nArgs).
 
+]
+
+{ #category : #configuration }
+FFICallout >> stringEncodingStrategy [
+
+	^ stringEncodingStrategy ifNil: [ 
+		stringEncodingStrategy := self resolveStringEncodingStrategy ]
+]
+
+{ #category : #configuration }
+FFICallout >> stringEncodingStrategy: aStringEncodingStrategy [
+
+	stringEncodingStrategy := aStringEncodingStrategy
 ]
 
 { #category : #private }

--- a/src/UnifiedFFI/FFICalloutMethodBuilder.class.st
+++ b/src/UnifiedFFI/FFICalloutMethodBuilder.class.st
@@ -28,6 +28,12 @@ FFICalloutMethodBuilder >> addFunctionResolveStrategy: aStrategy [
 	functionResolutionStrategies add: aStrategy
 ]
 
+{ #category : #private }
+FFICalloutMethodBuilder >> argumentNames [
+
+	^ self method argumentNames
+]
+
 { #category : #building }
 FFICalloutMethodBuilder >> build: aBlock [ 
 	aBlock value: self.
@@ -91,22 +97,27 @@ FFICalloutMethodBuilder >> generateFFICallout: builder spec: functionSpec [
 		ifNotNil: [ properties := sender methodProperties copy.
 			properties method: nil.
 			builder properties: properties ].
+
 	builder
-		numArgs: self method argumentNames size;
-		addTemps: (self method argumentNames copyWith: #result).
+		numArgs: self argumentNames size;
+		addTemps: (self argumentNames copyWith: #result).
 
 	"Builds a method call"
 	"save ffi call as literal"
 	builder pushLiteral: (self createFFICalloutLiteralFromSpec: functionSpec).
 	"iterate arguments in order (in the function) to create the function call"
-	functionSpec arguments do: [ :each | each emitArgument: builder context: sender ].
+	functionSpec arguments do: [ :each | each emitArgument: builder context: sender inCallout: self requestor ].
 	"create the array"
 	builder pushConsArray: functionSpec arguments size.
 	"send call and store into result"
 	builder send: #invokeWithArguments:.
 	functionSpec arguments do: [ :each | each emitReturnArgument: builder context: sender ].
 	"convert in case return type needs it. And return reseult"
-	^ functionSpec returnType emitReturn: builder resultTempVar: #result context: sender
+	^ functionSpec returnType
+		emitReturn: builder
+		resultTempVar: #result
+		context: sender
+		inCallout: self requestor
 ]
 
 { #category : #private }
@@ -115,7 +126,7 @@ FFICalloutMethodBuilder >> generateMethodFromSpec: functionSpec [
 	functionSpec resolveUsing: self requestor.
 	ir := IRBuilder buildIR: [ :builder | 
 		self generateFFICallout: builder spec: functionSpec ].
-	^ ir generate: self method trailer
+	^ ir generate: self methodTrailer
 ]
 
 { #category : #initialization }
@@ -155,6 +166,12 @@ FFICalloutMethodBuilder >> libraryName [
 { #category : #accessing }
 FFICalloutMethodBuilder >> method [
 	^ self sender method
+]
+
+{ #category : #accessing }
+FFICalloutMethodBuilder >> methodTrailer [
+	
+	^ self method trailer
 ]
 
 { #category : #private }

--- a/src/UnifiedFFI/FFICharacterType.class.st
+++ b/src/UnifiedFFI/FFICharacterType.class.st
@@ -23,6 +23,18 @@ FFICharacterType class >> externalTypeSize [
 	^ 1
 ]
 
+{ #category : #'emitting code' }
+FFICharacterType >> basicEmitArgument: aBuilder context: aContext inCallout: aCallout [
+
+	| isString |
+	isString := self pointerArity = 1.
+	isString
+		ifTrue: [
+			aCallout stringEncodingStrategy
+				emitIRForFunctionArgument: self inIRBuilder: aBuilder context: aContext ]
+		ifFalse: [ super basicEmitArgument: aBuilder context: aContext inCallout: aCallout ]
+]
+
 { #category : #private }
 FFICharacterType >> basicHandle: aHandle at: index [
 	^ aHandle signedCharAt: index
@@ -37,6 +49,18 @@ FFICharacterType >> basicHandle: aHandle at: index put: value [
 FFICharacterType >> defaultReturnOnError [
 
 	^ Character null
+]
+
+{ #category : #'emitting code' }
+FFICharacterType >> emitReturn: aBuilder resultTempVar: resultVar context: aContext inCallout: aCallout [
+
+	| isString |
+	isString := self pointerArity = 1.
+	^ isString
+		ifTrue: [
+			aCallout stringEncodingStrategy
+				emitIRForFunctionReturn: self inIRBuilder: aBuilder context: aContext ]
+		ifFalse: [ super emitReturn: aBuilder resultTempVar: resultVar context: aContext inCallout: aCallout ]
 ]
 
 { #category : #callbacks }

--- a/src/UnifiedFFI/FFIConst.class.st
+++ b/src/UnifiedFFI/FFIConst.class.st
@@ -26,11 +26,6 @@ FFIConst class >> value: anObject type: aType [
 		yourself
 ]
 
-{ #category : #'emitting code' }
-FFIConst >> emitArgument: aBuilder context: aContext [ 
-	aBuilder pushLiteral: self value
-]
-
 { #category : #unpacking }
 FFIConst >> emitPointerArityUnpack: anIRBuilder type: aFFIVoid context: aContext [ 
 	

--- a/src/UnifiedFFI/FFIConstantArgument.class.st
+++ b/src/UnifiedFFI/FFIConstantArgument.class.st
@@ -36,12 +36,6 @@ FFIConstantArgument >> asOldArraySpec [
 ]
 
 { #category : #'emitting code' }
-FFIConstantArgument >> emitArgument: aBuilder context: aContext [
-	
-	self loader emitArgument: aBuilder context: aContext
-]
-
-{ #category : #'emitting code' }
 FFIConstantArgument >> emitArgument: aBuilder context: aContext objectClass: objectClass instVarName: aName [
 	
 	self shouldNotImplement
@@ -64,17 +58,17 @@ FFIConstantArgument >> initialize [
 FFIConstantArgument >> resolveUsing: aResolver [
 
 	value = false ifTrue: [ 
-		loader := FFIConst value: 0 type: (aResolver resolveType: #bool).
+		loader := FFILiteralArgument value: 0 type: (aResolver resolveType: #bool).
 		resolvedType := type resolveUsing: aResolver forArgument: self.
 		resolvedType loader: loader.
 		^ self ].
 	value = true ifTrue: [ 
-		loader := FFIConst value: 1 type: (aResolver resolveType: #bool).
+		loader := FFILiteralArgument value: 1 type: (aResolver resolveType: #bool).
 		resolvedType := type resolveUsing: aResolver forArgument: self.
 		resolvedType loader: loader.
 		^ self ].
 	(value isNil or: [ value = 'NULL' ]) ifTrue: [ 
-		loader := FFIConst value: ExternalAddress null type: (aResolver resolveType: #'void *').
+		loader := FFILiteralArgument value: ExternalAddress null type: (aResolver resolveType: #'void *').
 		resolvedType := type resolveUsing: aResolver forArgument: self.
 		resolvedType loader: loader.
 		^ self ].
@@ -82,7 +76,7 @@ FFIConstantArgument >> resolveUsing: aResolver [
 		loader := resolvedType := type resolveUsing: aResolver forArgument: self.
 		loader loader: FFISelfArgument new.
 		^ self ].
-	loader := FFIConst value: value.
+	loader := FFILiteralArgument value: value.
 	resolvedType := type resolveUsing: aResolver forArgument: self.
 	resolvedType loader: loader.
 ]

--- a/src/UnifiedFFI/FFIExternalReferenceType.class.st
+++ b/src/UnifiedFFI/FFIExternalReferenceType.class.st
@@ -42,6 +42,15 @@ FFIExternalReferenceType >> basicEmitArgument: aBuilder context: aContext [
 		instVarName: self instanceVariableName
 ]
 
+{ #category : #'emitting code' }
+FFIExternalReferenceType >> basicEmitArgument: aBuilder context: aContext inCallout: aCallout [
+ 	self loader
+		emitArgument: aBuilder 
+		context: aContext 
+		objectClass: self objectClass	
+		instVarName: self instanceVariableName
+]
+
 { #category : #private }
 FFIExternalReferenceType >> basicHandle: aHandle at: index [
 	^ self objectClass fromHandle: (aHandle pointerAt: index)

--- a/src/UnifiedFFI/FFIExternalString.class.st
+++ b/src/UnifiedFFI/FFIExternalString.class.st
@@ -18,6 +18,14 @@ FFIExternalString class >> externalTypeAlignment [
 	^ self pointerSize
 ]
 
+{ #category : #'emitting code' }
+FFIExternalString >> basicEmitArgument: aBuilder context: aContext inCallout: aCallout [
+
+	self loader 
+		emitArgument: aBuilder 
+		context: aContext
+]
+
 { #category : #private }
 FFIExternalString >> basicHandle: aHandle at: index [
 	| data |

--- a/src/UnifiedFFI/FFIExternalType.class.st
+++ b/src/UnifiedFFI/FFIExternalType.class.st
@@ -100,8 +100,8 @@ FFIExternalType class >> sizeOf: aTypeName [
 ]
 
 { #category : #'emitting code' }
-FFIExternalType >> basicEmitArgument: aBuilder context: aContext [
-	self loader 
+FFIExternalType >> basicEmitArgument: aBuilder context: aContext inCallout: aCallout [
+	self loader
 		emitArgument: aBuilder 
 		context: aContext
 ]
@@ -142,8 +142,8 @@ FFIExternalType >> defaultReturnOnError [
 ]
 
 { #category : #'emitting code' }
-FFIExternalType >> emitArgument: aBuilder context: aContext [ 
-	self basicEmitArgument: aBuilder context: aContext.
+FFIExternalType >> emitArgument: aBuilder context: aContext inCallout: aCallout [
+	self basicEmitArgument: aBuilder context: aContext inCallout: aCallout.
 	self needsArityPacking 
 		ifTrue: [ self  emitPointerArityRoll: aBuilder context: aContext ]
 ]
@@ -164,6 +164,12 @@ FFIExternalType >> emitPointerArityRoll: aBuilder context: aContext [
 { #category : #'emitting code' }
 FFIExternalType >> emitReturn: aBuilder resultTempVar: resultVar context: aContext [ 
 	^ aBuilder returnTop	
+]
+
+{ #category : #'emitting code' }
+FFIExternalType >> emitReturn: aBuilder resultTempVar: resultVar context: aContext inCallout: aCallout [
+	
+	^ self emitReturn: aBuilder resultTempVar: resultVar context: aContext 
 ]
 
 { #category : #'emitting code' }

--- a/src/UnifiedFFI/FFIFunctionArgument.class.st
+++ b/src/UnifiedFFI/FFIFunctionArgument.class.st
@@ -1,3 +1,7 @@
+"
+I am an abstract class representing a call-out argument, having a value and a type.
+See my subclasses for the concrete kind of arguments.
+"
 Class {
 	#name : #FFIFunctionArgument,
 	#superclass : #Object,
@@ -19,6 +23,12 @@ FFIFunctionArgument >> asOldArraySpec [
 FFIFunctionArgument >> defaultReturnOnError [
 
 	^ self resolvedType defaultReturnOnError
+]
+
+{ #category : #'emitting code' }
+FFIFunctionArgument >> emitArgument: anIRBuilder context: aContext inCallout: aCallout [
+
+	self resolvedType emitArgument: anIRBuilder context: aContext inCallout: aCallout
 ]
 
 { #category : #resolution }

--- a/src/UnifiedFFI/FFIFunctionArgumentLoader.class.st
+++ b/src/UnifiedFFI/FFIFunctionArgumentLoader.class.st
@@ -24,6 +24,12 @@ FFIFunctionArgumentLoader >> emitArgument: aBuilder context: aContext [
 ]
 
 { #category : #'emitting code' }
+FFIFunctionArgumentLoader >> emitArgument: aBuilder context: aContext inCallout: aCallout [
+	
+	self emitArgument: aBuilder context: aContext
+]
+
+{ #category : #'emitting code' }
 FFIFunctionArgumentLoader >> emitArgument: aBuilder context: aContext objectClass: objectClass instVarName: aName [
 	self subclassResponsibility
 ]

--- a/src/UnifiedFFI/FFILegacyStringEncodingStrategy.class.st
+++ b/src/UnifiedFFI/FFILegacyStringEncodingStrategy.class.st
@@ -1,0 +1,29 @@
+"
+I am a string encoding strategy that sends strings as they are to the callout primitive.
+I am used for the legacy and backwards compatibility behavior that just copies the bytes of the ByteString to the C string.
+"
+Class {
+	#name : #FFILegacyStringEncodingStrategy,
+	#superclass : #Object,
+	#category : #'UnifiedFFI-Strings'
+}
+
+{ #category : #emitting }
+FFILegacyStringEncodingStrategy >> emitIRForFunctionArgument: aFFICharacterType inIRBuilder: anIRBuilder context: aContext [ 
+
+	aFFICharacterType loader
+		emitArgument: anIRBuilder
+		context: aContext
+]
+
+{ #category : #emitting }
+FFILegacyStringEncodingStrategy >> emitIRForFunctionReturn: aFFICharacterType inIRBuilder: aBuilder context: aContext [
+
+	^ aBuilder returnTop
+]
+
+{ #category : #testing }
+FFILegacyStringEncodingStrategy >> isLegacy [
+
+	^ true
+]

--- a/src/UnifiedFFI/FFILiteralArgument.class.st
+++ b/src/UnifiedFFI/FFILiteralArgument.class.st
@@ -1,0 +1,101 @@
+"
+I implement the push strategy for literal objects specified in a callout.
+"
+Class {
+	#name : #FFILiteralArgument,
+	#superclass : #FFIFunctionArgumentLoader,
+	#instVars : [
+		'value',
+		'type'
+	],
+	#category : #'UnifiedFFI-Arguments'
+}
+
+{ #category : #'instance creation' }
+FFILiteralArgument class >> value: aValue [
+	^ self new value: aValue
+]
+
+{ #category : #'instance creation' }
+FFILiteralArgument class >> value: anObject type: aType [
+	^ self new 
+		value: anObject;
+		type: aType;
+		yourself
+]
+
+{ #category : #'emitting code' }
+FFILiteralArgument >> emitArgument: aBuilder context: aContext [
+
+	aBuilder pushLiteral: self value
+]
+
+{ #category : #unpacking }
+FFILiteralArgument >> emitPointerArityUnpack: anIRBuilder type: aFFIVoid context: aContext [ 
+	
+	"Nothing to do here"
+]
+
+{ #category : #'emitting code' }
+FFILiteralArgument >> emitReturn: aBuilder resultTempVar: resultVar context: aContext [ 
+	self error: 'Literals cannot be used as return'
+]
+
+{ #category : #'emitting code' }
+FFILiteralArgument >> emitReturnArgument: builder context: aContext [
+	"Nothing to do here"
+]
+
+{ #category : #accessing }
+FFILiteralArgument >> externalType [ 
+
+	^ self type externalType
+]
+
+{ #category : #accessing }
+FFILiteralArgument >> externalTypeAlignment [
+
+	^ self externalType externalTypeAlignment
+]
+
+{ #category : #accessing }
+FFILiteralArgument >> externalTypeSize [
+
+	^ self externalType byteSize
+]
+
+{ #category : #accessing }
+FFILiteralArgument >> loader [ 
+	^ self
+]
+
+{ #category : #accessing }
+FFILiteralArgument >> pointerArity: additionalArity [
+	additionalArity > 0 ifTrue: [ self error: 'passing pointer to constant' ]
+]
+
+{ #category : #'stack parameter classification' }
+FFILiteralArgument >> stackValueParameterClass [
+	^ value isFloat ifTrue: [#float] ifFalse: [#integer]
+
+]
+
+{ #category : #accessing }
+FFILiteralArgument >> type [
+	^ type
+]
+
+{ #category : #accessing }
+FFILiteralArgument >> type: anObject [
+	type := anObject
+]
+
+{ #category : #accessing }
+FFILiteralArgument >> value [
+	^ value
+]
+
+{ #category : #accessing }
+FFILiteralArgument >> value: anObject [
+	value := anObject
+]

--- a/src/UnifiedFFI/FFIStringEncodingStrategy.class.st
+++ b/src/UnifiedFFI/FFIStringEncodingStrategy.class.st
@@ -1,0 +1,50 @@
+"
+I am a string encoding strategy that explicitly encodes a string into bytes before sending it to the callout.
+I know how to emit the necessary IR code to push a string argument and encode it.
+"
+Class {
+	#name : #FFIStringEncodingStrategy,
+	#superclass : #Object,
+	#instVars : [
+		'encoding'
+	],
+	#category : #'UnifiedFFI-Strings'
+}
+
+{ #category : #'instance creation' }
+FFIStringEncodingStrategy class >> forEncoding: aString [
+
+	^ self new
+		encoding: aString;
+		yourself
+]
+
+{ #category : #emitting }
+FFIStringEncodingStrategy >> emitIRForFunctionArgument: aFFICharacterType inIRBuilder: anIRBuilder context: aContext [ 
+	
+	aFFICharacterType loader emitArgument: anIRBuilder context: aContext.
+	anIRBuilder pushLiteral: encoding asSymbol.
+	anIRBuilder send: #nullTerminatedEncodeWith:.
+]
+
+{ #category : #emitting }
+FFIStringEncodingStrategy >> emitIRForFunctionReturn: aFFICharacterType inIRBuilder: anIRBuilder context: aContext [
+	
+	"The top of the stack should contain a ByteString with the bytes of the returned char*.
+	The FFI backend assumes (correctly) that it is a null terminated string, and (incorrectly) that the encoding is the same of the image.
+	We should transform the byte string into a byte array and then decode it"
+	anIRBuilder send: #asByteArray.
+	anIRBuilder pushLiteral: encoding asSymbol.
+	anIRBuilder send: #decodeWith:.
+	^ anIRBuilder returnTop
+]
+
+{ #category : #accessing }
+FFIStringEncodingStrategy >> encoding [
+	^ encoding
+]
+
+{ #category : #accessing }
+FFIStringEncodingStrategy >> encoding: aString [ 
+	encoding := aString
+]

--- a/src/UnifiedFFI/FFITypeDeclaration.class.st
+++ b/src/UnifiedFFI/FFITypeDeclaration.class.st
@@ -45,9 +45,9 @@ FFITypeDeclaration >> defaultReturnOnError [
 ]
 
 { #category : #'emitting code' }
-FFITypeDeclaration >> emitReturn: anIRBuilder resultTempVar: aString context: aContext [
+FFITypeDeclaration >> emitReturn: anIRBuilder resultTempVar: aString context: aContext inCallout: aCallout [
 	
-	^ resolvedType emitReturn: anIRBuilder resultTempVar: aString context: aContext
+	^ resolvedType emitReturn: anIRBuilder resultTempVar: aString context: aContext inCallout: aCallout
 ]
 
 { #category : #accessing }

--- a/src/UnifiedFFI/FFIVariableArgument.class.st
+++ b/src/UnifiedFFI/FFIVariableArgument.class.st
@@ -30,12 +30,6 @@ FFIVariableArgument >> asOldArraySpec [
 	^ { name . nil . type name . type arity }
 ]
 
-{ #category : #'emitting code' }
-FFIVariableArgument >> emitArgument: anIRBuilder context: aContext [
-
-	self resolvedType emitArgument: anIRBuilder context: aContext.
-]
-
 { #category : #accessing }
 FFIVariableArgument >> name [
 	^ name

--- a/src/UnifiedFFI/LibC.class.st
+++ b/src/UnifiedFFI/LibC.class.st
@@ -75,7 +75,8 @@ LibC >> macLibraryName [
 
 { #category : #'api - misc' }
 LibC >> memCopy: src to: dest size: n [
-	^ self ffiCall: #(#void #* #memcpy #(#void #* #dest #, #const #void #* #src #, #size_t #n))
+	^ self
+		ffiCall: #(#void #* #memcpy #(#void #* #dest #, #const #void #* #src #, #size_t #n))
 ]
 
 { #category : #'api - processes' }

--- a/src/UnifiedFFI/String.extension.st
+++ b/src/UnifiedFFI/String.extension.st
@@ -1,18 +1,31 @@
 Extension { #name : #String }
 
 { #category : #'*UnifiedFFI' }
-String >> asExternalTypeOn: generator [
-	^ generator resolveType: self
-]
-
-{ #category : #'*UnifiedFFI' }
 String class >> asExternalTypeOn: generator [ 
 	^ generator resolveType: #FFIExternalString
 ]
 
 { #category : #'*UnifiedFFI' }
+String >> asExternalTypeOn: generator [
+	^ generator resolveType: self
+]
+
+{ #category : #'*UnifiedFFI' }
 String >> asFFILibrary [ 
 	^ FFIUnknownLibrary name: self
+]
+
+{ #category : #'*UnifiedFFI' }
+String >> nullTerminatedEncodeWith: encoding [
+	"Produce a ByteArray that encodes the receiver, using a specified encoding and adding a null terminator.
+	Encoding is either a ZnCharacterEncoder instance or an identifier for one.
+	Useful extension for FFI and C integration"
+	
+	" 'Les élèves français' nullTerminatedEncodeWith: #utf8 "
+	
+	^ ByteArray streamContents: [ :stream |
+		encoding asZnCharacterEncoder next: self size putAll: self startingAt: 1 toStream: stream.
+		stream nextPut: 0 "Null terminator" ]
 ]
 
 { #category : #'*UnifiedFFI' }


### PR DESCRIPTION
Sending strings in FFI should support encoding them e.g.,  utf8, utf16, utf32...

 - add an option to make encoding specification mandatory
 - add options to specify encodings
 - handle string encodings when using char* on return and arguments
 - manage variable and literal strings

+ tests
+ backwards compatible