### PR TITLE
ClassVariable>>#asRingMinimalDefinitionIn: should use Smalltalk globals

### DIFF
--- a/src/Ring-Core/ClassVariable.extension.st
+++ b/src/Ring-Core/ClassVariable.extension.st
@@ -5,7 +5,7 @@ ClassVariable >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [
 		| def realClass |
-		realClass := Smalltalk allClasses detect: [ :each | each classVariables includes: self ].
+		realClass := Smalltalk globals allClasses detect: [ :each | each classVariables includes: self ].
 		def := RGClassVariable named: self key asSymbol parent: (realClass asRingMinimalDefinitionIn: anRGEnvironment).
 		def ].
 ]


### PR DESCRIPTION
Fix #5522