### PR TITLE
saferOmbuFileAccess

### DIFF
--- a/src/Ombu/OmFileStore.class.st
+++ b/src/Ombu/OmFileStore.class.st
@@ -229,7 +229,7 @@ OmFileStore >> flushEntryBuffer [
 		self entryBuffer isEmpty ifTrue: [ ^self ].
 				
 		[ fileStream := ZnCharacterWriteStream on: fileReference binaryWriteStream encoding: #utf8. ] on: ReadOnlyFileException do: [ :anException |
-			fileStream close.
+			fileStream ifNotNil: #close.
 			^ self
 		 ].	
 	


### PR DESCRIPTION
Ombu needs safer file closing. It can cause errors if the image is started in the read-only access mode