### PR TITLE
restore-wrongly-removed-method

### DIFF
--- a/src/UnifiedFFI/FFIVariableArgument.class.st
+++ b/src/UnifiedFFI/FFIVariableArgument.class.st
@@ -30,6 +30,12 @@ FFIVariableArgument >> asOldArraySpec [
 	^ { name . nil . type name . type arity }
 ]
 
+{ #category : #'emitting code' }
+FFIVariableArgument >> emitArgument: anIRBuilder context: aContext [
+
+	self resolvedType emitArgument: anIRBuilder context: aContext.
+]
+
 { #category : #accessing }
 FFIVariableArgument >> name [
 	^ name


### PR DESCRIPTION
this method was lost in last integration (no idea why). Restoring it.