### PR TITLE
Switch to the light theme

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -80,7 +80,7 @@ BaselineOfIDE >> additionalInitialization [
 	
 	RubAbstractTextArea highlightMessageSend: true.
 	
-	PharoDarkTheme beCurrent.
+	PharoLightTheme beCurrent.
 	
 	SDL_Event initialize.
 	

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -332,7 +332,7 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 	World displayWorldSafely.
 
 	UIManager default uiProcess resume.
-	PharoDarkTheme beCurrent.
+	PharoLightTheme beCurrent.
 	(World windowsSatisfying: [:w | w model canDiscardEdits]) do: [:w | w delete].
 	self cleanUpAfterMorphicInitialization.
 


### PR DESCRIPTION
Following the theme switching policy (to be sure that none of the default themes is abandoned), let's switch to the ligth theme in Pharo 9.0.Switching  to the dark theme (if it is your favourite one) is literally SINGLE click operation.