### PR TITLE
5562-Executing-All-Instances-in-the-startup-affects-loading-times

### DIFF
--- a/src/FFI-Kernel/ExternalAddress.class.st
+++ b/src/FFI-Kernel/ExternalAddress.class.st
@@ -30,11 +30,6 @@ ExternalAddress class >> gcallocate: byteSize [
 	^externalAddress
 ]
 
-{ #category : #'class initialization' }
-ExternalAddress class >> initialize [
-	wordSize := Smalltalk wordSize
-]
-
 { #category : #'instance creation' }
 ExternalAddress class >> loadSymbol: moduleSymbol module: module [ 
 	<primitive: 'primitiveLoadSymbolFromModule' module: 'SqueakFFIPrims'>
@@ -44,13 +39,13 @@ ExternalAddress class >> loadSymbol: moduleSymbol module: module [
 { #category : #'instance creation' }
 ExternalAddress class >> new [
 	"External addresses are either four or eight bytes long."
-	^super new: wordSize
+	^super new: self wordSize
 ]
 
 { #category : #'instance creation' }
 ExternalAddress class >> new: n [
 	"Only create ExternalAddresses of the right size."
-	^n = wordSize
+	^n = self wordSize
 		ifTrue: [super new: n]
 		ifFalse: [self shouldNotImplement]
 ]
@@ -66,7 +61,7 @@ ExternalAddress class >> startUp: resuming [
 
 { #category : #accessing }
 ExternalAddress class >> wordSize [
-	^wordSize
+	^wordSize ifNil: [ wordSize := Smalltalk wordSize ]
 ]
 
 { #category : #arithmetic }

--- a/src/FFI-Kernel/ExternalAddress.class.st
+++ b/src/FFI-Kernel/ExternalAddress.class.st
@@ -60,15 +60,8 @@ ExternalAddress class >> startUp: resuming [
 	"If starting the image afresh all external addresses should be zero.
 	 In addition, if the word size has changed then external addresses shoiuld be resized.
 	 The two steps are combined for efficiency."
-	resuming ifTrue:
-		[| instances |
-		 instances := self allInstances.
-		 wordSize ~= Smalltalk wordSize
-			ifTrue: "Implement nulling by becomming all existing instances to new (and hence null) pointers of the right size."
-				[wordSize := Smalltalk wordSize.
-				 instances elementsForwardIdentityTo: (instances collect: [:ea| self basicNew: wordSize])]
-			ifFalse:
-				[instances do: [:addr| addr beNull]]]
+	resuming ifTrue: [
+		self allInstancesDo: [ :each | each beNull ]]
 ]
 
 { #category : #accessing }

--- a/src/Hiedra/HiColumnController.class.st
+++ b/src/Hiedra/HiColumnController.class.st
@@ -12,23 +12,11 @@ Class {
 		'renderer',
 		'formByPageIndex',
 		'pageSize',
-		'cellMorphByRowIndex'
+		'cellMorphByRowIndex',
+		'session'
 	],
 	#category : #'Hiedra-UI'
 }
-
-{ #category : #'system startup' }
-HiColumnController class >> initialize [
-	SessionManager default registerGuiClassNamed: self name
-]
-
-{ #category : #'system startup' }
-HiColumnController class >> startUp: isImageStarting [
-	"Reset all instances on startup since the cached pages (athens forms) don't work in a new session."
-
-	isImageStarting
-		ifTrue: [ self allInstancesDo: #reset ]
-]
 
 { #category : #private }
 HiColumnController >> cellBoundsForRow: rowIndex inPage: pageIndex [
@@ -47,6 +35,8 @@ HiColumnController >> cellMorphAtRow: rowIndex [
 	"Answer a Morph that corresponds to a row index. The height of such Morph is given by renderer's rowHeight and the width is given by the ruler's numberOfColumns and the renderer's cellWidth.
 	This is an important method of this class, that the table widget will use to fill each Hiedra column's cell."
 
+	self checkSession.
+
 	^ cellMorphByRowIndex at: rowIndex ifAbsent: [ self newCellMorphForRow: rowIndex ]
 ]
 
@@ -58,7 +48,16 @@ HiColumnController >> cellMorphAtValue: aValue [
 ]
 
 { #category : #private }
+HiColumnController >> checkSession [
+
+	session == Smalltalk session 
+		ifFalse: [ self reset ]
+]
+
+{ #category : #private }
 HiColumnController >> formAtPage: pageIndex [
+
+	self checkSession.
 
 	^ formByPageIndex
 		at: pageIndex
@@ -74,6 +73,7 @@ HiColumnController >> initialize [
 	super initialize.
 	renderer := HiSimpleRenderer new.
 	pageSize := 30.
+	session := Smalltalk session.
 	self reset.
 ]
 

--- a/src/Ombu/OmSessionStore.class.st
+++ b/src/Ombu/OmSessionStore.class.st
@@ -16,7 +16,8 @@ Class {
 	],
 	#classInstVars : [
 		'storeNameStrategy',
-		'defaultBaseLocator'
+		'defaultBaseLocator',
+		'registry'
 	],
 	#category : #'Ombu-Stores'
 }
@@ -39,7 +40,9 @@ OmSessionStore class >> initialize [
 	"
 	self initialize
 	"
-	SessionManager default registerUserClassNamed: self name
+	registry := WeakSet new: 5.
+	SessionManager default registerUserClassNamed: self name.
+
 
 ]
 
@@ -57,11 +60,16 @@ OmSessionStore class >> newWithBaseLocator: aBaseDirectory [
 		yourself
 ]
 
-{ #category : #'system startup' }
-OmSessionStore class >> startUp [
-	"The #store accessor refreshes each instance since it will discover that the Session changed"
+{ #category : #initialization }
+OmSessionStore class >> register: aSessionStore [
 
-	self allInstancesDo: #store 
+	registry add: aSessionStore 
+]
+
+{ #category : #initialization }
+OmSessionStore class >> startUp [ 
+
+	registry do: [ :each | each store ]
 ]
 
 { #category : #accessing }
@@ -156,6 +164,8 @@ OmSessionStore >> initializeWithBaseLocator: aDirectoryFileLocator [
 	baseLocator := aDirectoryFileLocator.
 	self store. "Force initialization"
 	headReference := self store headReference.
+	
+	self class register: self.
 
 ]
 


### PR DESCRIPTION
Removing the use of allInstances during the startup of the image. In a 4GB image the startup is reduced in a 50%

Fixes #5562