### PR TITLE
5571-testDefaultImageDoesNotStoreAnySetting-failing-in-Pharo9-on-CI-all-plattforms

### DIFF
--- a/src/NECompletion/NECPreferences.class.st
+++ b/src/NECompletion/NECPreferences.class.st
@@ -213,7 +213,10 @@ NECPreferences class >> settingsOn: aBuilder [
 								setSelector: #sorterClass:;
 								domainValues: availableSorters ].
 					(aBuilder setting: #backgroundColor)
-						default: Color veryDarkGray;
+						default: (Color 
+							r: 0.823069403714565 
+							g: 0.823069403714565 
+							b: 0.823069403714565 alpha: 1.0);
 						label: 'Background Color'.
 					(aBuilder setting: #expandPrefixes)
 						default: true;

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -349,13 +349,13 @@ RubAbstractTextArea class >> rubricSettingsOn: aBuilder [
 		parent: #codeEditing;
 		with: [ (aBuilder setting: #backgroundColor)
 				target: self;
-				default: (Color r: 0.1300097751710655 g: 0.1300097751710655 b: 0.1300097751710655 alpha: 1.0);
+				default: Color white;
 				description: 'The default editor background color';
 				label: 'Background'.
 			(aBuilder setting: #textColor)
 				target: self;
 				description: 'The default editor text color';
-				default: Color white;
+				default: Color black;
 				label: 'Text color'.
 			(aBuilder group: #LineNumbers)
 				target: self;
@@ -368,12 +368,12 @@ RubAbstractTextArea class >> rubricSettingsOn: aBuilder [
 						label: 'Line numbers font'.
 					(aBuilder setting: #lineNumbersTextColor)
 						target: self;
-						default: (Color r: 0.6608015640273704 g: 0.656891495601173 b: 0.656891495601173 alpha: 1.0);
+						default: Color veryDarkGray;
 						description: 'Color used for line numbers';
 						label: 'Line numbers color'.
 					(aBuilder setting: #lineNumbersBackgroundColor)
 						target: self;
-						default: (Color r: 0.04985337243401759 g: 0.04985337243401759 b: 0.04985337243401759 alpha: 1.0);
+						default: (Color r: 0.9198435972629521 g: 0.9198435972629521 b: 0.9198435972629521 alpha: 1.0);
 						description: 'Color used for line numbers background';
 						label: 'Line numbers background color' ].
 			(aBuilder setting: #highlightMessageSend)

--- a/src/Settings-Polymorph/PolymorphSystemSettings.class.st
+++ b/src/Settings-Polymorph/PolymorphSystemSettings.class.st
@@ -29,7 +29,7 @@ PolymorphSystemSettings class >> appearanceSettingsOn: aBuilder [
 			(aBuilder pickOne: #uiThemeClass)
 				label: 'User interface theme';
 				target: self;
-				default: PharoDarkTheme;
+				default: (Smalltalk at: #PharoLightTheme);
 				order: 1;
 				domainValues: self uiThemeClassChoices.
 			self morphicSettingsOn: aBuilder.
@@ -299,7 +299,7 @@ PolymorphSystemSettings class >> morphicMenuSettingsOn: aBuilder [
 				description: 'If true, then the menu color will be computed from world dressing.' .
 			(aBuilder setting: #menuColor)
 				label: 'Menu color';
-				default: Color veryDarkGray;
+				default: (Color r: 0.823069403714565 g: 0.823069403714565 b: 0.823069403714565 alpha: 1.0);
 				description: 'The menu color to use if it is not computed automatically (see the ''Computed color'' setting)' .
 			(aBuilder setting: #menuSelectionColor)
 				label: 'Menu selection color' ;

--- a/src/Text-Edition/TextEditor.class.st
+++ b/src/Text-Edition/TextEditor.class.st
@@ -209,7 +209,7 @@ TextEditor class >> editingSettingsOn: aBuilder [
 					(aBuilder setting: #secondarySelectionTextColor)
 						target: UITheme;
 						targetSelector: #currentSettings;
-						default: Color white;
+						default: Color black;
 						label: 'Secondary selection text color'].
 			(aBuilder setting: #useFindReplaceSelection)
 				target: TextEditor;


### PR DESCRIPTION
Fixing colors in the settings of Pharo9

Fixes #5571