### PR TITLE
Fix rotten DebuggerTest

### DIFF
--- a/src/Debugger-Tests/AssignmentAndLiteralDebuggerTest.class.st
+++ b/src/Debugger-Tests/AssignmentAndLiteralDebuggerTest.class.st
@@ -20,7 +20,7 @@ AssignmentAndLiteralDebuggerTest >> testInterruptedContextEqualsSuspendedContext
 
 { #category : #tests }
 AssignmentAndLiteralDebuggerTest >> testNewDebugSession [
-	self assert: context size equals: 0.
+	self assert: context size equals: 1.
 	self assert: session interruptedContext equals: context.
 ]
 

--- a/src/Debugger-Tests/DebuggerTest.class.st
+++ b/src/Debugger-Tests/DebuggerTest.class.st
@@ -34,9 +34,13 @@ DebuggerTest >> setUp [
 
 { #category : #utilities }
 DebuggerTest >> settingUpSessionAndProcessAndContextForBlock: aBlock [
-	context := aBlock asContext.
-	process := Process 
-	    forContext: context 
-	    priority: Processor userInterruptPriority.
+	process := Process
+		forContext: 
+			[aBlock value.
+			Processor terminateActive] asContext
+		priority: Processor userInterruptPriority.
+	[process step closure == aBlock] whileFalse.
+	process step.
+	context := process suspendedContext.
 	session:= process newDebugSessionNamed: 'test session' startedAt: context.
 ]

--- a/src/Debugger-Tests/DebuggerTest.class.st
+++ b/src/Debugger-Tests/DebuggerTest.class.st
@@ -34,11 +34,7 @@ DebuggerTest >> setUp [
 
 { #category : #utilities }
 DebuggerTest >> settingUpSessionAndProcessAndContextForBlock: aBlock [
-	process := Process
-		forContext: 
-			[aBlock value.
-			Processor terminateActive] asContext
-		priority: Processor userInterruptPriority.
+	process := aBlock newProcess.
 	[process step closure == aBlock] whileFalse.
 	process step.
 	context := process suspendedContext.

--- a/src/Debugger-Tests/RestartTest.class.st
+++ b/src/Debugger-Tests/RestartTest.class.st
@@ -28,7 +28,6 @@ RestartTest >> testStepRestartAndRestepTopContext [
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepA1 ].
 	session stepInto.
 	session stepInto.
-	session stepInto.
 	"Check that the execution is at the 'a:=1' node of method stepA2"
 	self assert: session interruptedContext method equals: self class >>#stepA2.
 	node := self class >>#stepA2 sourceNodeForPC: session interruptedContext pc.

--- a/src/Debugger-Tests/StepIntoTest.class.st
+++ b/src/Debugger-Tests/StepIntoTest.class.st
@@ -25,20 +25,6 @@ StepIntoTest >> stepA1 [
 ]
 
 { #category : #tests }
-StepIntoTest >> testDetectionOfExecutionEnd [
-	self settingUpSessionAndProcessAndContextForBlock: [  ].
-	session stepInto.
-	"These ways do not detect that the execution ended"
-	self assert: session interruptedContext isDead not.
-	self assert: (session isContextPostMortem: (session interruptedContext)) not.
-	self assert: session interruptedProcess suspendedContext isNil not.
-	self assert: session interruptedProcess suspendedContext isDead not.
-	"This way seems to detect that an execution ended"
-	self assert: session interruptedProcess isTerminated.
-
-]
-
-{ #category : #tests }
 StepIntoTest >> testStepIntoDeadContextShouldRaiseException [
 	self settingUpSessionAndProcessAndContextForBlock: [  ].
 	session stepInto. "The first step into executes the (empty) body of the block and returns from it. From this point on, the context is dead since it returned."
@@ -59,7 +45,6 @@ StepIntoTest >> testStepIntoMethodCallShouldActivateIt [
 	"Stepping into a method call should create a context for it at the top of the context stack"
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepA1].
 	session stepInto.
-	session stepInto.
 	self
 		assert: process suspendedContext method
 		equals: self class >> #stepA1
@@ -69,7 +54,6 @@ StepIntoTest >> testStepIntoMethodCallShouldActivateIt [
 StepIntoTest >> testStepIntoQuickMethodCallNotReturnedShouldLeaveTheValueStackEmpty [
 	"Stepping into a quick method whose result is not used should leave the value stack empty"
 	self settingUpSessionAndProcessAndContextForBlock: [ self callQuickMethodWithoutReturningItsResult].
-	session stepInto.
 	session stepInto.
 	session stepInto.
 	self
@@ -84,7 +68,6 @@ StepIntoTest >> testStepIntoQuickMethodCallNotReturnedShouldLeaveTheValueStackEm
 StepIntoTest >> testStepIntoQuickMethodCallReturnedShouldPushReturnValueToTheStack [
 	"Stepping into a call to a quick method whose result is used should push its return value to the stack"
 	self settingUpSessionAndProcessAndContextForBlock: [ self returnQuickMethodResult].
-	session stepInto.
 	session stepInto.
 	session stepInto.
 	self

--- a/src/Debugger-Tests/StepOverTest.class.st
+++ b/src/Debugger-Tests/StepOverTest.class.st
@@ -89,7 +89,6 @@ StepOverTest >> testStepOver [
 	| node |
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepA1 ].
 	session stepInto.
-	session stepInto.
 	"Reached stepA1"
 	"Checking that the execution is at the 'self stepA2' node of the stepA1 method"
 	self assert: session interruptedContext method equals: self class >>#stepA1.
@@ -118,7 +117,7 @@ StepOverTest >> testStepOverComputedReturn [
 	"
 	| node |
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepC1 ].
-	session stepInto.	session stepInto.
+	session stepInto.
 	"Reached stepC1"
 	self assert: session interruptedContext method equals: self class >>#stepC1.
 	session stepInto.
@@ -156,7 +155,6 @@ StepOverTest >> testStepOverLastNodeOfContext [
 	| node |
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepB1 ].
 	session stepInto.
-	session stepInto.
 	"Reached stepB1"
 	session stepInto.
 	"Reached stepB2"
@@ -184,7 +182,6 @@ StepOverTest >> testStepOverNonErrorExceptionSignalWithHandlerDeeperInTheContext
 	The Notification exception was used because it is an exception that is not a subclass of Error, and iis therefore not caught by the handler context stepOver inserts between step2 and 3 (which handles Error)
 	"
 	self settingUpSessionAndProcessAndContextForBlock: [ self step1 ].
-	session stepInto.
 	session stepInto.
 	session stepInto.
 	session stepInto.

--- a/src/Debugger-Tests/StepOverTest.class.st
+++ b/src/Debugger-Tests/StepOverTest.class.st
@@ -71,6 +71,19 @@ StepOverTest >> testErrorSignalledDuringStepOverShouldBeCaught [
 ]
 
 { #category : #tests }
+StepOverTest >> testSimulatedProcessIsInCorrectState [
+	"This test verifies that simulated process is created correctly using given block.
+	Step over should execute first block instruction when it is correct"
+	| executed |
+	executed := false.
+	self settingUpSessionAndProcessAndContextForBlock: [executed := true ].
+	
+	session stepOver.
+	
+	self assert: executed
+]
+
+{ #category : #tests }
 StepOverTest >> testStepOver [
 	"Stepping over a message node brings the execution to the next node in the same method."
 	| node |

--- a/src/Debugger-Tests/StepThroughTest.class.st
+++ b/src/Debugger-Tests/StepThroughTest.class.st
@@ -47,7 +47,6 @@ StepThroughTest >> testStepThrough [
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepA1 ].
 	session stepInto.
 	session stepInto.
-	session stepInto.
 	"Reached node 'self evalBlockThenReturnOne: [self stepA2]' of method stepA1"
 	"Checking that the execution is indeed at this node"
 	self assert: (session interruptedContext method) equals: (self class>>#stepA1).
@@ -71,7 +70,6 @@ StepThroughTest >> testStepThroughDoesTheSameThingAsStepOverWhenNoBlockIsInvolve
 	| node |
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepB1 ].
 	session stepInto.
-	session stepInto.
 	"Reached node 'self stepB2' of method stepB1"
 	self assert: session interruptedContext method equals: self class>>#stepB1.
 	session stepOver.
@@ -84,7 +82,6 @@ StepThroughTest >> testStepThroughDoesTheSameThingAsStepOverWhenNoBlockIsInvolve
 	
 	"Set up the debugged execution again"
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepB1 ].
-	session stepInto.
 	session stepInto.
 	"Reached node 'self stepB2' of method stepB1"
 	self assert: session interruptedContext method equals: self class>>#stepB1.


### PR DESCRIPTION
Fix the simulation of process in DebuggerTest to correctly setup the top context to behave like a real process (created by #newProcess method).
It fixes rotten tests which did not run given process block while tests were passing successfully.
For example put #here trace into the process block in #testStepOverHalt: 
```Smalltalk
StepOverTest>>testStepOverHalt
	"Stepping over a self halt should not raise an unhandled exception"
	self settingUpSessionAndProcessAndContextForBlock: [ #here trace. self halt. ].
	self shouldnt: [[ session interruptedProcess isTerminated ] whileFalse: [ session stepOver. ]] raise: Exception.
```
This test will not write anything into Transcript which proves that halt is not executed.
Here the test machinery is fixed and separate test covers the state of simulated process.

The problem was that process methods (and maybe even VM) relies on particular form of top context and it should not be the context of given process block (receiver of #newProcess). 
For example check the implementation of Process>>#isTerminated. It detects the termination when the top context is executed (pc > startPc).