### PR TITLE
5584-enabling-pharo9x-in-pharo90

### DIFF
--- a/src/BaselineOfSpec2/BaselineOfSpec2.class.st
+++ b/src/BaselineOfSpec2/BaselineOfSpec2.class.st
@@ -51,7 +51,7 @@ BaselineOfSpec2 >> baseline: spec [
 				package: 'Spec2-Morphic-Backend-Tests' with: [ spec requires: #('ParametrizedTests' 'Spec2-Adapters-Morphic') ];
 				package: 'Spec2-Tests' with: [ spec requires: #('Spec2-Examples' 'ParametrizedTests') ] ].
 	spec
-		for: #'pharo8.x'
+		for: #('pharo8.x' 'pharo9.x')
 		do: [ spec
 				package: 'Spec2-Tools' with: [ spec requires: #('Spec2-Core') ];
 				package: 'Spec2-Tools-Tests' with: [ spec requires: #('Spec2-Tests' 'Spec2-Tools') ];

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1155,7 +1155,7 @@ SmalltalkImage >> memoryHogs [
 SmalltalkImage >> metacelloPlatformAttributes [
     "Returns the tags for the conditional platform loading in Metacello. Pay attention the order is important: from most  to least general." 
     "For release integrators, we should not have #'pharo1.3x' **and** #'pharo1.4.x'"
-   ^ #(#squeakCommon #pharo #'pharo8.x' #'pharo8.0.x')
+   ^ #(#squeakCommon #pharo #'pharo9.x' #'pharo9.0.x')
 ]
 
 { #category : #'special objects' }


### PR DESCRIPTION
Fixes: #5584 like that we can start differentiating 8.0 from 9.0!