### PR TITLE
5597-EFFormatter-should-not-use-start-and-stop-to-print-comments

### DIFF
--- a/src/BlueInk-Core/BIConfigurableFormatter.class.st
+++ b/src/BlueInk-Core/BIConfigurableFormatter.class.st
@@ -489,10 +489,7 @@ BIConfigurableFormatter >> addSpaceIfNeededForLastArgument: aPragmaNode [
 
 { #category : #private }
 BIConfigurableFormatter >> basicFormatCommentFor: aComment [
-	codeStream
-		nextPut: $";
-		nextPutAll: aComment contents;
-		nextPut: $"
+	codeStream nextPutAll: (originalSource copyFrom: aComment start to: aComment stop).
 ]
 
 { #category : #private }

--- a/src/BlueInk-Core/BIConfigurableFormatter.class.st
+++ b/src/BlueInk-Core/BIConfigurableFormatter.class.st
@@ -489,7 +489,10 @@ BIConfigurableFormatter >> addSpaceIfNeededForLastArgument: aPragmaNode [
 
 { #category : #private }
 BIConfigurableFormatter >> basicFormatCommentFor: aComment [
-	codeStream nextPutAll: (originalSource copyFrom: aComment start to: aComment stop).
+	codeStream
+		nextPut: $";
+		nextPutAll: aComment contents;
+		nextPut: $"
 ]
 
 { #category : #private }

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -971,7 +971,10 @@ EFFormatter >> areArgumentsTooLong: anArray [
 
 { #category : #private }
 EFFormatter >> basicFormatCommentFor: aComment [
-	codeStream nextPutAll: aComment contents
+	codeStream
+		nextPut: $";
+		nextPutAll: aComment contents;
+		nextPut: $"
 ]
 
 { #category : #private }

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -971,7 +971,7 @@ EFFormatter >> areArgumentsTooLong: anArray [
 
 { #category : #private }
 EFFormatter >> basicFormatCommentFor: aComment [
-	codeStream nextPutAll: (originalSource copyFrom: aComment start to: aComment stop).
+	codeStream nextPutAll: aComment contents
 ]
 
 { #category : #private }
@@ -1157,7 +1157,6 @@ EFFormatter >> formatBlockArgumentsFor: aBlockNode [
 
 { #category : #'private-formatting' }
 EFFormatter >> formatBlockCommentFor: aBlockNode [
-  originalSource ifNil: [ ^ self ].
   aBlockNode comments do: [:each |  self basicFormatCommentFor: each.
         (self isNonEmptySingleLineBlock: aBlockNode) ifTrue: [ self space ] ]
 ]
@@ -1174,7 +1173,6 @@ EFFormatter >> formatCommentCloseToStatements: aBoolean [
 
 { #category : #'private-formatting' }
 EFFormatter >> formatCommentsFor: aNode [
-  originalSource ifNil: [ ^ self ].
   aNode comments do: [:each |  self basicFormatCommentFor: each ]
 ]
 
@@ -1199,9 +1197,7 @@ EFFormatter >> formatMethodBodyFor: aMethodNode [
 
 { #category : #'private-formatting' }
 EFFormatter >> formatMethodCommentFor: aMethodNode [
-  originalSource ifNil: [ ^ self ].
-  aMethodNode comments 
-		do: [:each |  
+  aMethodNode comments do: [:each |  
 				self useBasicCommentFormat 
 					ifTrue: [ self basicFormatCommentFor: each ] 
 					ifFalse: [ self resizeCommentFor: each startingAt: 0 ].
@@ -1296,7 +1292,6 @@ EFFormatter >> formatSingleArrayElement: aRBNode [
 
 { #category : #'private-formatting' }
 EFFormatter >> formatStatementCommentsFor: aStatementNode [
-	originalSource ifNil: [ ^ self ].
 	self formatCommentCloseToStatements
 		ifFalse: [ ^ self ].
 	aStatementNode statementComments


### PR DESCRIPTION
fix #5597: do not use orginalSource to print comments. This way we can print comments even when we do not have source originally