### PR TITLE
5601-Enhance-support-of-pipewildcard-notation-for-searching-in-DrTests-lists

### DIFF
--- a/src/DrTests-Tests/DTFilterableListPresenterTest.class.st
+++ b/src/DrTests-Tests/DTFilterableListPresenterTest.class.st
@@ -20,10 +20,18 @@ DTFilterableListPresenterTest >> setUp [
 ]
 
 { #category : #test }
-DTFilterableListPresenterTest >> testFilterString [
-	filterableList filterTextInput text: 'foo'.
+DTFilterableListPresenterTest >> testFilterStrings [
+	filterableList filterTextInput text: 'foo|bar'.
 	
-	self assert: filterableList filterString equals: '*foo*'
+	self assertCollection: filterableList filterStrings hasSameElements: #('foo*' 'bar*').
+	
+	filterableList filterTextInput text: '|bar'.
+	
+	self assertCollection: filterableList filterStrings hasSameElements: #('bar*').
+	
+	filterableList filterTextInput text: 'foo|'.
+	
+	self assertCollection: filterableList filterStrings hasSameElements: #('foo*').
 ]
 
 { #category : #tests }
@@ -34,7 +42,11 @@ DTFilterableListPresenterTest >> testFilterWorks [
 	filterableList filterTextInput text: '2'.
 	
 	self assertCollection: filterableList allItems equals: (1 to: 20).
-	self assertCollection: filterableList visibleItems equals: #(2 12 20).
+	self assertCollection: filterableList visibleItems equals: #(2 20).
+	
+	filterableList filterTextInput text: ''.
+	
+	self assertCollection: filterableList allItems equals: filterableList visibleItems. "We want to show everything if no filter is written."
 ]
 
 { #category : #running }

--- a/src/DrTests/DTFilterableListPresenter.class.st
+++ b/src/DrTests/DTFilterableListPresenter.class.st
@@ -63,15 +63,14 @@ DTFilterableListPresenter >> filterList [
 		items:
 			(initialItems
 				select:
-					[ :each | self filterString match: (self listPresenter display value: each) ])
+					[ :each | self filterStrings anySatisfy: [ :any | any match: (self listPresenter display value: each) ] ])
 ]
 
 { #category : #accessing }
-DTFilterableListPresenter >> filterString [
-	^ String streamContents: [ :stream |
-		stream nextPut: $*.
-		stream nextPutAll: self filterTextInput text.
-		stream nextPut: $* ]
+DTFilterableListPresenter >> filterStrings [
+	^ (self filterTextInput text splitOn: $|)
+		reject: #isEmpty
+		thenCollect: [ :pattern | pattern , '*' ]
 ]
 
 { #category : #accessing }
@@ -102,6 +101,7 @@ DTFilterableListPresenter >> initializeWidgets [
 	filterTextInput := self newTextInput
 								placeholder: 'Filter...';
 								whenTextChangedDo: [ self filterList ];
+								autoAccept: true;
 								yourself
 ]
 

--- a/src/DrTests/DTFilterableListPresenter.class.st
+++ b/src/DrTests/DTFilterableListPresenter.class.st
@@ -59,11 +59,17 @@ DTFilterableListPresenter >> filterList [
 	"Filters the list according to the filterTextInput."
 
 	self unselectAll.
+	self filterStrings
+		ifEmpty: [ 
+			self listPresenter
+				items: initialItems.
+			^ self ].
 	self listPresenter
 		items:
 			(initialItems
-				select:
-					[ :each | self filterStrings anySatisfy: [ :any | any match: (self listPresenter display value: each) ] ])
+				select: [ :each | 
+					self filterStrings
+						anySatisfy: [ :any | any match: (self listPresenter display value: each) ] ])
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Now allows user to use pipe notation in the search bar.
Fixed usage of wildcard.
Made the search bar auto-accept for immediate feedback on what one writes.
Updated test.

Fix #5601 