### PR TITLE
5605-Provide-hooks-to-DrTests-plugins-in-order-to-allow-one-to-do-dynamic-configuration

### DIFF
--- a/src/DrTests/AbstractDrTestsUI.class.st
+++ b/src/DrTests/AbstractDrTestsUI.class.st
@@ -24,13 +24,9 @@ AbstractDrTestsUI >> currentPlugin [
 AbstractDrTestsUI >> currentPlugin: anObject [
 	"If a plugin was set before, unsubscribe first."
 
-	currentPlugin ifNotNil: [ currentPlugin announcer unsubscribe: self ].
+	currentPlugin ifNotNil: [ currentPlugin unconfigureUI: self ].
 	currentPlugin := anObject.
-	currentPlugin announcer
-		when: DTStatusUpdate
-		send: #handlePluginStatusUpdate:
-		to: self.
-	self updateUI
+	currentPlugin configureUI: self
 ]
 
 { #category : #'announcement handling' }
@@ -148,8 +144,7 @@ AbstractDrTestsUI >> updateStatus: aString [
 
 { #category : #updating }
 AbstractDrTestsUI >> updateUI [
-	^ self subclassResponsibility
-
+	self withWindowDo: [ :window | window title: self title ]
 ]
 
 { #category : #updating }

--- a/src/DrTests/DrTests.class.st
+++ b/src/DrTests/DrTests.class.st
@@ -479,11 +479,7 @@ DrTests >> updateSwitchButton: itemsSelected [
 
 { #category : #updating }
 DrTests >> updateUI [
-	self
-		startButtonLabel: self currentPlugin startButtonLabel;
-		startButtonHelp: self currentPlugin startButtonHelp;
-		updateStatus: self currentPlugin pluginName , ' plugin is ready to work!' translated.
-	self withWindowDo: [ :window | window title: self title ].
+	super updateUI.
 	self packagesList resetFilter.
 	self updatePackagesList.
 	self resultTree: DTTreeNode empty.

--- a/src/DrTests/DrTestsPlugin.class.st
+++ b/src/DrTests/DrTestsPlugin.class.st
@@ -70,6 +70,22 @@ DrTestsPlugin >> buildContextualMenuGroupWith: presenterIntance [
 	^ CmCommandGroup new
 ]
 
+{ #category : #api }
+DrTestsPlugin >> configureUI: aDrTestsUI [
+	"This hook is used by plugins to configure the UI (e.g. set labels, list contents, etc).
+	 It is called just after the user selected the plugin from the UI.
+	"
+	self announcer
+		when: DTStatusUpdate
+		send: #handlePluginStatusUpdate:
+		to: aDrTestsUI.
+	aDrTestsUI
+		startButtonLabel: self startButtonLabel;
+		startButtonHelp: self startButtonHelp;
+		updateStatus: self pluginName , ' plugin is ready to work!' translated;
+		updateUI.
+]
+
 { #category : #accessing }
 DrTestsPlugin >> firstListLabel [
 	^ 'items'
@@ -173,4 +189,13 @@ DrTestsPlugin >> startButtonLabel [
 { #category : #api }
 DrTestsPlugin >> title [
 	^ self pluginName
+]
+
+{ #category : #api }
+DrTestsPlugin >> unconfigureUI: aDrTestsUI [
+	"This hook is used by plugins to unconfigure the UI (e.g. unregister announcers).
+	 It is called just before the UI switch to another plugin.
+	 By default it does nothing.
+	"
+	self announcer unsubscribe: aDrTestsUI
 ]

--- a/src/DrTests/MiniDrTests.class.st
+++ b/src/DrTests/MiniDrTests.class.st
@@ -81,7 +81,7 @@ MiniDrTests >> title [
 
 { #category : #accessing }
 MiniDrTests >> updateUI [
-	self withWindowDo: [ :window | window title: self title ].
+	super updateUI.
 	startButton color: self evaluateColor.
 	startButton label: pluginResult summarizeInfo
 ]


### PR DESCRIPTION
Refactoring to create #configureUI: and #unconfigureUI: hooks, give them responsibility and let DrTests UI call them.
Some refactoring on #updateUI as well.Fixes #5605