### PR TITLE
5617-LazyListMorph-missing-theme-hook

### DIFF
--- a/src/Morphic-Widgets-Pluggable/LazyListMorph.class.st
+++ b/src/Morphic-Widgets-Pluggable/LazyListMorph.class.st
@@ -47,11 +47,12 @@ LazyListMorph >> bottomVisibleRowForCanvas: aCanvas [
 ]
 
 { #category : #'row management' }
-LazyListMorph >> colorForRow: row [ 
+LazyListMorph >> colorForRow: row [
 	"Answer the color for the row text."
+
 	^ (self isRowSelected: row )
-		ifTrue: [ self theme selectionTextColor ]
-		ifFalse: [ self color ]
+		ifTrue: [ self theme selectedItemListTextColor  ]
+		ifFalse: [ self theme listTextColor ]
 ]
 
 { #category : #'row management' }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -5322,6 +5322,13 @@ UITheme >> selectedFillStyleFor: aMorph height: anInteger [
 ]
 
 { #category : #'accessing colors' }
+UITheme >> selectedItemListTextColor [
+	"Answer the color for the selected item in a list text."
+
+	^ Color black
+]
+
+{ #category : #'accessing colors' }
 UITheme >> selectionBarColor [
 
 	^ self settings selectionBarColor

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -5325,7 +5325,7 @@ UITheme >> selectedFillStyleFor: aMorph height: anInteger [
 UITheme >> selectedItemListTextColor [
 	"Answer the color for the selected item in a list text."
 
-	^ Color black
+	^ self textColor
 ]
 
 { #category : #'accessing colors' }


### PR DESCRIPTION
Fixes: #5617 make sure that we can control the color of non/selected list item.