### PR TITLE
Fixing debugger menu shortcut that was overriding the doIt shortcut

### DIFF
--- a/src/Calypso-SystemTools-Core/SycOpenDebuggingMenuCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycOpenDebuggingMenuCommand.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #SycOpenDebuggingMenuCommand }
 SycOpenDebuggingMenuCommand class >> methodEditorShortcutActivation [
 	<classAnnotation>
 	
-	^CmdShortcutActivation by: $d meta for: ClySourceCodeContext
+	^CmdShortcutActivation by: $g meta shift for: ClySourceCodeContext 
 ]
 
 { #category : #'*Calypso-SystemTools-Core' }


### PR DESCRIPTION
Fixes #5623