### PR TITLE
5633-Speedup-implementors-and-senders-do-not-wrap-in-Ring1-entity

### DIFF
--- a/src/Kernel-Tests-Extended/BehaviorTest.extension.st
+++ b/src/Kernel-Tests-Extended/BehaviorTest.extension.st
@@ -5,15 +5,15 @@ BehaviorTest >> testAllReferencesTo [
 	| result |
 	result := SystemNavigation new allReferencesTo: Point binding.
 	result do: [ :each | self assert: (each compiledMethod hasLiteral: Point binding) ].
-	self assert: (result anySatisfy: [ :each | each actualClass = self class and: [ each selector = #testAllReferencesTo ] ]).
+	self assert: (result anySatisfy: [ :each | each methodClass = self class and: [ each selector = #testAllReferencesTo ] ]).
 		
 	result := SystemNavigation new allReferencesTo: #printOn:.
 	result do: [ :each | self assert: (each compiledMethod refersToLiteral: #printOn:) ].
-	self assert: (result anySatisfy: [ :each | each actualClass = self class and: [ each selector = #testAllReferencesTo ] ]).
+	self assert: (result anySatisfy: [ :each | each methodClass = self class and: [ each selector = #testAllReferencesTo ] ]).
 	
 	result := SystemNavigation new allReferencesTo: #+.
 	result do: [ :each | self assert: ((each compiledMethod sendsSelector: #+) or: [ each compiledMethod refersToLiteral: #+ ]) ].
-	self assert: (result anySatisfy: [ :each | each actualClass = self class and: [ each selector = #testAllReferencesTo ] ])
+	self assert: (result anySatisfy: [ :each | each methodClass = self class and: [ each selector = #testAllReferencesTo ] ])
 ]
 
 { #category : #'*Kernel-Tests-Extended' }

--- a/src/Kernel-Tests-Extended/SharedPoolTest.extension.st
+++ b/src/Kernel-Tests-Extended/SharedPoolTest.extension.st
@@ -12,9 +12,9 @@ SharedPoolTest >> testmethodsAccessingPoolVariables [
 	| result |
 	result := ChronologyConstants methodsAccessingPoolVariables.
 	"we find accesses to the vars of the shared pool"
-	self assert: (result includes: (Duration>>#asNanoSeconds) methodReference).
+	self assert: (result includes: Duration>>#asNanoSeconds).
 	"but we do not include references to the pool itself"
-	self deny: (result includes: (ClassTest>>#testSharedPoolOfVarNamed) methodReference)
+	self deny: (result includes: ClassTest>>#testSharedPoolOfVarNamed)
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
@@ -22,8 +22,7 @@ SharedPoolTest >> testusingMethods [
 	| result |
 	result := ChronologyConstants usingMethods.
 	"we find accesses to the vars of the shared pool"
-	self assert: (result includes: (Duration>>#asNanoSeconds) methodReference).
+	self assert: (result includes: Duration>>#asNanoSeconds).
 	"and we find references to the pool itself"
-	self assert: (result includes: (ClassTest>>#testSharedPoolOfVarNamed) methodReference)
-		 
+	self assert: (result includes: ClassTest>>#testSharedPoolOfVarNamed)
 ]

--- a/src/System-Support-Tests/SystemNavigationTest.class.st
+++ b/src/System-Support-Tests/SystemNavigationTest.class.st
@@ -97,31 +97,6 @@ SystemNavigationTest >> testAllSendersOfASelector [
 ]
 
 { #category : #testing }
-SystemNavigationTest >> testAllSendersOfReturnsExistingMethods [
-	"Non-regression test for
-	http://code.google.com/p/pharo/issues/detail?id=2593 "
-	| senders |
-	senders := self systemNavigationToTest allSendersOf: #methodsFor:.
-	senders
-		do: [:aReference | self
-				assert: (aReference actualClass canUnderstand: aReference selector)]
-]
-
-{ #category : #testing }
-SystemNavigationTest >> testIsMessageSentInSystemAnswersMethodReference [
-	| classesSendingMessage sentMessageSelector anyOne |
-	sentMessageSelector := 'MessageSentOnlyByTestClassesXXXShouldNotBeRealyDefined' asSymbol.
-	5 timesRepeat: [self classFactory newClassInCategory: #One].
-	5 timesRepeat: [self classFactory newClassInCategory: #Two].
-	classesSendingMessage := (self classFactory createdClasses asArray first: 2), (self classFactory createdClasses asArray last: 3).
-	classesSendingMessage do: [:class|	
-		class compileSilently: 'meth self ', sentMessageSelector].
-	anyOne :=(self systemNavigationToTest allSendersOf: sentMessageSelector) anyOne.
-
-	self assert: (anyOne isKindOf: RGMethodDefinition) 
-]
-
-{ #category : #testing }
 SystemNavigationTest >> testIsMessageSentInSystemWithClassesActuallySendngTheMessage [
 	| classesSendingMessage sentMessageSelector |
 	sentMessageSelector := 'MessageSentOnlyByTestClassesXXXShouldNotBeRealyDefined' asSymbol.

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -99,7 +99,7 @@ SystemNavigation >> allImplementorsOf: aSelector [
 
 	^ self allBehaviors
 		select: [ :class | class includesSelector: aSelector ]
-		thenCollect: [ :class | (class >> aSelector) methodReference ]
+		thenCollect: [ :class | class >> aSelector ]
 ]
 
 { #category : #query }
@@ -116,7 +116,7 @@ SystemNavigation >> allMethodsSelect: aBlock [
 	aCollection := OrderedCollection new.
 	self allBehaviorsDo: [:class | 
 		class	selectorsAndMethodsDo: [:sel :m | 
-			(aBlock value: m) ifTrue: [aCollection add: (class>>sel) methodReference]]].
+			(aBlock value: m) ifTrue: [aCollection add: class>>sel]]].
 	^ aCollection
 ]
 
@@ -159,8 +159,7 @@ SystemNavigation >> allPrimitiveMethods [
 SystemNavigation >> allReferencesTo: aLiteral [
 	"Answer all the methods that refer to aLiteral even deeply embedded in literal array."
 
-	^ self allBehaviors flatCollect: [ :class | 
-			(class thoroughWhichMethodsReferTo: aLiteral) collect: [ :method | method methodReference ] ]
+	^ self allBehaviors flatCollect: [ :class | class thoroughWhichMethodsReferTo: aLiteral]
 ]
 
 { #category : #query }
@@ -177,10 +176,9 @@ SystemNavigation >> allReferencesTo: aLiteral do: aBlock [
 
 { #category : #query }
 SystemNavigation >> allReferencesToBinding: aVariablesBinding [
-	"Answer all the methods that refer to aVariableBinding, do not go into netsted Arrays"
+	"Answer all the methods that refer to aVariableBinding, do not go into nested Arrays"
 
-	^ self allBehaviors flatCollect: [ :class | 
-			(class whichMethodsReferTo: aVariablesBinding) collect: [ :method | method methodReference ] ]
+	^ self allBehaviors flatCollect: [ :class | class whichMethodsReferTo: aVariablesBinding ]
 ]
 
 { #category : #'message sends' }

--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -6,7 +6,7 @@ SystemNavigation >> allMethodsWithSourceString: aString matchCase: caseSensitive
 
 	| list addMethod addComment |
 	list := OrderedCollection new.
-	addMethod := [ :mrClass :mrSel | list add: (mrClass>>mrSel) methodReference].									
+	addMethod := [ :mrClass :mrSel | list add: (mrClass>>mrSel)].									
 	addComment := [ :mrClass | list add: (RGCommentDefinition realClass: mrClass)].										
 	self allBehaviorsDo: [:each |
 		each selectorsDo: [:sel | 
@@ -25,8 +25,7 @@ SystemNavigation >> browseAllAccessesTo: instVarName from: aClass [
 
 	| methods slot |
 	slot := aClass slotNamed: instVarName.
-	methods := (aClass allMethodsAccessingSlot: slot) 
-		collect: [:meth | meth methodReference].
+	methods := aClass allMethodsAccessingSlot: slot.
 	
 	^ self
 		browseMessageList: methods
@@ -121,8 +120,7 @@ SystemNavigation >> browseAllStoresInto: instVarName from: aClass [
 
 	| methods slot |
 	slot := aClass slotNamed: instVarName.
-	methods := (aClass allMethodsWritingSlot: slot) 
-		collect: [:meth | meth methodReference].
+	methods := aClass allMethodsWritingSlot: slot.
 	
 	^ self
 		browseMessageList: methods
@@ -493,12 +491,12 @@ SystemNavigation >> methodHierarchyBrowserForClass: aClass selector: sel [
 
 	aClass allSuperclasses reverseDo: [:cl |
 		(cl includesSelector: sel) ifTrue: [
-			list addLast: (cl>>sel) methodReference]].
+			list addLast: (cl>>sel)]].
 	aClass allSubclassesDo: [:cl | 
 		(cl includesSelector: sel) ifTrue: [
-			list addLast: (cl>>sel) methodReference ]].
+			list addLast: (cl>>sel) ]].
 
-	list addLast: (aClass>>sel) methodReference.
+	list addLast: (aClass>>sel).
 	^ self browseMessageList: list name: 'Inheritance of ' , sel
 
 


### PR DESCRIPTION
do not wrap senders and implementors in Ring1 entities. Fixes #5633