### PR TITLE
5478-Inspector-on-a-ByteSymbol-should-get-the-senders-of-this-symbol-on-a-lazy-way

### DIFF
--- a/src/GT-InspectorExtensions-Core/Symbol.extension.st
+++ b/src/GT-InspectorExtensions-Core/Symbol.extension.st
@@ -6,7 +6,7 @@ Symbol >> gtInspectorImplementorsIn: composite [
 	composite list 
 		title: 'Implementors';
 		display: [ self systemNavigation allImplementorsOf: self ];
-		when: [ (self systemNavigation allImplementorsOf: self) notEmpty ];
+		format: #name;
 		showOnly: 30
 ]
 
@@ -16,7 +16,6 @@ Symbol >> gtInspectorSendersIn: composite [
 	composite list 
 		title: 'Senders';
 		display: [ self systemNavigation allSendersOf: self ];
-		when: [ (self systemNavigation allSendersOf: self) notEmpty ];
-		showOnly: 30;
-		withSmalltalkSearch 
+		format: #name;
+		showOnly: 30 
 ]


### PR DESCRIPTION
Speedup "senders" and "implementors" tab. 
- It is already faster due to not wrapping in Ring Definitions
- It was getting the lists twice, I changed that to only one time
- it was *rendering* the code for the method, not the name --> much faster without that.

It might be still too slow on large images, but we should check that before we remove.

fixes #5478