### PR TITLE
RemoveAllInstancesInspector

### DIFF
--- a/src/GT-InspectorExtensions-Core/Class.extension.st
+++ b/src/GT-InspectorExtensions-Core/Class.extension.st
@@ -60,16 +60,6 @@ Class >> gtInspectorInstanceVariablesIn: composite [
 ]
 
 { #category : #'*GT-InspectorExtensions-Core' }
-Class >> gtInspectorInstancesOn: composite [
-	<gtInspectorPresentationOrder: 40>
-	^ composite table
-		title: [ 'Instances' translated ];
-		display: [ self allInstances ];
-		column: 'Hash' evaluated: [ :each | each hash asString ];
-		column: 'Object' evaluated: [ :each | each printString ]
-]
-
-{ #category : #'*GT-InspectorExtensions-Core' }
 Class >> gtInspectorMethodsIn: composite [
 	"This provides a list of all methods provided by the current class"
 


### PR DESCRIPTION
#allInstances is too slow on large images and can potentially lead to *very* large lists to be rendered. The best is to remove this tab