### PR TITLE
5551-Inspecting-a-CompiledMethod-should-allow-update

### DIFF
--- a/src/GT-InspectorExtensions-Core/CompiledBlock.extension.st
+++ b/src/GT-InspectorExtensions-Core/CompiledBlock.extension.st
@@ -4,3 +4,15 @@ Extension { #name : #CompiledBlock }
 CompiledBlock >> gtDisplayOn: stream [
 	self printOn: stream
 ]
+
+{ #category : #'*GT-InspectorExtensions-Core' }
+CompiledBlock >> gtInspectorSourceIn: composite [
+	<gtInspectorPresentationOrder: 30>
+	^ composite pharoMethod
+		title: 'Source';
+		smalltalkClass: [ self methodClass ];
+		display: [ self sourceCode ];
+		act: [ self browse ]
+			icon: GLMUIThemeExtraIcons glamorousBrowse
+			entitled: 'Browse'
+]

--- a/src/GT-InspectorExtensions-Core/CompiledCode.extension.st
+++ b/src/GT-InspectorExtensions-Core/CompiledCode.extension.st
@@ -76,18 +76,6 @@ CompiledCode >> gtInspectorPragmasIn: composite [
 ]
 
 { #category : #'*GT-InspectorExtensions-Core' }
-CompiledCode >> gtInspectorSourceIn: composite [
-	<gtInspectorPresentationOrder: 30>
-	^ composite pharoMethod
-		title: 'Source';
-		smalltalkClass: [ self methodClass ];
-		display: [ self sourceCode ];
-		act: [ self browse ]
-			icon: GLMUIThemeExtraIcons glamorousBrowse
-			entitled: 'Browse'
-]
-
-{ #category : #'*GT-InspectorExtensions-Core' }
 CompiledCode >> gtInspectorVariableNodesIn: aCollection [
 
 	aCollection addAll: (self literals collectWithIndex: [ :aLiteral :anIndex | 

--- a/src/GT-InspectorExtensions-Core/CompiledMethod.extension.st
+++ b/src/GT-InspectorExtensions-Core/CompiledMethod.extension.st
@@ -4,3 +4,19 @@ Extension { #name : #CompiledMethod }
 CompiledMethod >> gtDisplayOn: aStream [
 	aStream print: self methodClass; nextPutAll: '>>'; store: self selector.
 ]
+
+{ #category : #'*GT-InspectorExtensions-Core' }
+CompiledMethod >> gtInspectorSourceIn: composite [
+	<gtInspectorPresentationOrder: 00>
+	^ composite pharoMethod 
+		title: 'Source';
+		smalltalkClass: [ self methodClass ];
+		display: [ self sourceCode ];
+		act: [ :text | self methodClass compile: text text notifying: nil ]
+			icon: GLMUIThemeExtraIcons glamorousAccept
+			on: $s
+			entitled: 'Accept';
+		act: [ self browse ] 
+			icon: GLMUIThemeExtraIcons glamorousBrowse 
+			entitled: 'Browse'
+]


### PR DESCRIPTION
Make a source editing view the default for CompiledMethod, keep the old style for CompiledBlock. Fixes #5551