### PR TITLE
fixing ring version

### DIFF
--- a/bootstrap/src/BaselineOfPharoBootstrapProcess/BaselineOfPharoBootstrapProcess.class.st
+++ b/bootstrap/src/BaselineOfPharoBootstrapProcess/BaselineOfPharoBootstrapProcess.class.st
@@ -25,7 +25,7 @@ BaselineOfPharoBootstrapProcess >> baseline: spec [
 		spec
 			 package: 'Pharo30Bootstrap'.
 		spec baseline: 'Ring2' with: [ spec
-			repository: 'github://carolahp/Ring2:master/src';
+			repository: 'github://carolahp/Ring2:v1.2.2/src';
   			loads: 'bootstrap' ].  			
 ]
 ]


### PR DESCRIPTION
changing the ring version in the PharoBootstrapProcess baseline from pointing to "master" to point a fixed version