### PR TITLE
CompiledCode #sourcePointer

### DIFF
--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -148,3 +148,8 @@ CompiledBlock >> selector [
 CompiledBlock >> sourceCode [
 	^ self outerCode sourceCode
 ]
+
+{ #category : #'source code management' }
+CompiledBlock >> sourcePointer [
+	^self outerCode sourcePointer
+]


### PR DESCRIPTION
#sourcePointer is a subclassresponsability in CompiledCode.  Like #sourceCode, this PR just delegates to "self outerCode"