### PR TITLE
redo-5464-Bug-Slot-template-add-variable-without-hash-Crash-on-accept

### DIFF
--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -140,16 +140,17 @@ Is this really what you want to do?') asText
 						makeBoldFrom: 1
 						to: newClassName size))
 				ifFalse: [ ^ nil ] ].
-	"ar 8/29/1999: Use oldClass superclass for defining oldClass
-	since oldClass superclass knows the definerClass of oldClass."
+	"Use oldClass superclass for defining oldClass since oldClass superclass knows the definerClass of oldClass."
 	oldClass
 		ifNil: [ classCompiler := self defaultClassCompiler ]
 		ifNotNil: [ classCompiler := oldClass superclass subclassDefinerClass new ].
-	class := classCompiler
+	[class := classCompiler
 		source: aString;
 		requestor: aController;
 		logged: true;
-		evaluate.
+		evaluate] on: OCUndeclaredVariableWarning do: [ 
+ 			"Undeclared Vars should not lead to the standard dialog to define them but instead should not accept"
+ 			self inform: 'Undeclared Variable in Class Definition' . ^nil ].
 	^ class isBehavior
 		ifTrue: [ class ]
 		ifFalse: [ nil ]


### PR DESCRIPTION
fixes #5464 by checking for the OCUndeclaredVariableWarning and warning in that case