### PR TITLE
Slots: Unify Api Layout and Scope

### DIFF
--- a/src/Slot-Core/LayoutAbstractScope.class.st
+++ b/src/Slot-Core/LayoutAbstractScope.class.st
@@ -22,26 +22,6 @@ LayoutAbstractScope >> allSlotsReverseDo: aBlock [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
-LayoutAbstractScope >> atName: aName [
-	^ self atName: aName ifAbsent: [ SlotNotFound signalForName: aName ].
-]
-
-{ #category : #accessing }
-LayoutAbstractScope >> atName: aName ifAbsent: aBlock [
-	self allSlotsDo: [ :slot | 
-		slot name == aName ifTrue: [ ^ slot ]].
-	^ aBlock value
-]
-
-{ #category : #accessing }
-LayoutAbstractScope >> atName: aName ifFound: foundBlock ifNone: exceptionBlock [
-	self allSlotsDo: [ :slot | 
-		slot name == aName ifTrue: [ ^ foundBlock cull: slot ]].
-	^ exceptionBlock value
-	
-]
-
 { #category : #extending }
 LayoutAbstractScope >> extend [
 	^ self extend: { }
@@ -131,6 +111,21 @@ LayoutAbstractScope >> ownFieldSize [
 { #category : #reshaping }
 LayoutAbstractScope >> rebase: originalScope to: newScope [
 	self error: 'Should not happen'
+]
+
+{ #category : #accessing }
+LayoutAbstractScope >> resolveSlot: aName [
+	^ self 
+		resolveSlot: aName 
+		ifFound: [:slot | slot ] 
+		ifNone: [ SlotNotFound signalForName: aName ].
+]
+
+{ #category : #accessing }
+LayoutAbstractScope >> resolveSlot: aName ifFound: foundBlock ifNone: exceptionBlock [
+	self allSlotsDo: [ :slot | 
+		slot name == aName ifTrue: [ ^ foundBlock cull: slot ]].
+	^ exceptionBlock value
 ]
 
 { #category : #accessing }

--- a/src/Slot-Core/PointerLayout.class.st
+++ b/src/Slot-Core/PointerLayout.class.st
@@ -178,12 +178,12 @@ PointerLayout >> postCopy [
 
 { #category : #accessing }
 PointerLayout >> resolveSlot: aName [
-	^ slotScope atName: aName
+	^ slotScope resolveSlot: aName
 ]
 
 { #category : #accessing }
 PointerLayout >> resolveSlot: aName ifFound: foundBlock ifNone: noneBlock [
-	^ slotScope atName: aName ifFound: foundBlock ifNone: noneBlock
+	^ slotScope resolveSlot: aName ifFound: foundBlock ifNone: noneBlock
 ]
 
 { #category : #testing }


### PR DESCRIPTION
on a  class we ask for #slotNamed, then on the Layput it is #resolveSlot:, to then be #atName: on the Layout.

As a frist step, we unify the API of Layout and Scope to both use #resolveSlot:, this can be done without deprecation as it is not a public API.

In a later step, we might unify everthing to be #slotNamed: