### PR TITLE
5631-Improve-atRandom-

### DIFF
--- a/src/Random-Core/Bag.extension.st
+++ b/src/Random-Core/Bag.extension.st
@@ -7,12 +7,10 @@ Bag >> atRandom: aGenerator [
 	this instead of #atRandom for better uniformity of random numbers because 
 	only you use the generator. Causes an error if self has no elements."
 
-	| rand index |
+	| index |
  	self emptyCheck.
- 	rand := aGenerator nextInt: self size.
+ 	index := aGenerator nextInt: self size.
  	"overwritten to use a faster enumeration"
- 	index := 0.
  	self doWithOccurrences: [ :key :count | 
- 		index := index + count.
- 		rand <= index ifTrue: [ ^ key ] ]
+ 		(index := index - count) <= 0 ifTrue: [ ^key ] ]
 ]

--- a/src/Random-Core/Collection.extension.st
+++ b/src/Random-Core/Collection.extension.st
@@ -31,6 +31,4 @@ Collection >> atRandom: aGenerator [
 	self do: [:each |
 		index = rand ifTrue: [^each].
 		index := index + 1].
-	^ self errorEmptyCollection
-
 ]


### PR DESCRIPTION
- remove the #errorEmptyCollection in #atRandom on Collection, as we do an emptyCheck in the first line
- simplify Bag>>#atRandom: as described in the issue tracker entry

We could simplidy Collection>>#atRadom more if we would have withIndexDo: on Collection (and I really wonder why we do not have that)

fixes #5631