### PR TITLE
#sharedPoolNames : move to Class

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1532,14 +1532,6 @@ Behavior >> setFormat: aFormatInstanceDescription [
 
 ]
 
-{ #category : #accessing }
-Behavior >> sharedPoolNames [
-	^ self sharedPools collect: [:ea |
-		ea isObsolete
-			ifTrue: [ ea name ]
-			ifFalse: [ self environment keyAtIdentityValue: ea ] ]
-]
-
 { #category : #testing }
 Behavior >> shouldNotBeRedefined [
 	"Answer if the receiver should not be redefined.

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -926,6 +926,14 @@ Class >> setName: aSymbol [
 	name := aSymbol.
 ]
 
+{ #category : #accessing }
+Class >> sharedPoolNames [
+	^ self sharedPools collect: [:ea |
+		ea isObsolete
+			ifTrue: [ ea name ]
+			ifFalse: [ self environment keyAtIdentityValue: ea ] ]
+]
+
 { #category : #'pool variables' }
 Class >> sharedPoolOfVarNamed: aString [
 	"Returns the SharedPool or nil from which the pool variable named aString is coming from."

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -298,6 +298,11 @@ Metaclass >> removeSubclass: aClass [
 ]
 
 { #category : #'pool variables' }
+Metaclass >> sharedPoolNames [
+	^#()
+]
+
+{ #category : #'pool variables' }
 Metaclass >> sharedPools [
 	^OrderedCollection new.
 ]


### PR DESCRIPTION
#sharedPoolNames was implemented on Behavior. But that is not a good idea as only class knows about the concept of sharedPools.
- move #sharedPoolNames down to Class
- add a return empty array version to Metaclass (similar to #sharedPools)