### PR TITLE
whichCategoryIncludesSelectorNoCheckNeeded

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -1358,9 +1358,7 @@ ClassDescription >> whichCategoryIncludesSelector: aSelector [
 	"Answer the category of the argument, aSelector, in the organization of 
 	the receiver, or answer nil if the receiver does not inlcude this selector."
 
-	^(self includesSelector: aSelector)
-		ifTrue: [self organization categoryOfElement: aSelector]
-		ifFalse: [nil]
+	^self organization categoryOfElement: aSelector
 ]
 
 { #category : #queries }


### PR DESCRIPTION
whichCategoryIncludesSelector: does not need to check for #includesSelector:, the method it calls returns nil for non existing selectors