### PR TITLE
Completion: Sorter should be Instancevar in context

### DIFF
--- a/src/NECompletion/AlphabeticSorter.class.st
+++ b/src/NECompletion/AlphabeticSorter.class.st
@@ -14,7 +14,7 @@ AlphabeticSorter class >> kind [
 ]
 
 { #category : #sorting }
-AlphabeticSorter >> sortCompletionList: aList [
-
-	^ aList asOrderedCollection sort
+AlphabeticSorter >> sortCompletionList: anOrderedCollection [
+	
+	^ anOrderedCollection sort
 ]

--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -13,7 +13,8 @@ Class {
 		'isWorkspace',
 		'class',
 		'entries',
-		'editor'
+		'editor',
+		'sorter'
 	],
 	#classVars : [
 		'SorterClass'
@@ -77,6 +78,7 @@ CompletionContext >> engine: aCompletionEngine class: aClass source: aString pos
 	source := aString.
 	position := anInteger.
 	editor := aCompletionEngine editor.
+	sorter := self class sorterClass new context: self.
 	
 	isWorkspace:= aCompletionEngine 
 		ifNotNil: [ aCompletionEngine isScripting ]
@@ -152,6 +154,12 @@ CompletionContext >> parseSource [
 CompletionContext >> position [
 	"not used outside of the instance creation method, but we make it available so sorter plugins could use it"
 	^ position
+]
+
+{ #category : #accessing }
+CompletionContext >> sorter: anObject [
+	"this allows tests to change the sorter"
+	sorter := anObject
 ]
 
 { #category : #accessing }

--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -110,10 +110,7 @@ CompletionContext >> hasMessage [
 
 { #category : #entries }
 CompletionContext >> initEntries [
-	| suggestionsList sorter |
-	sorter := self class sorterClass new context: self.
-	suggestionsList := sorter sortCompletionList: (node completionEntries: position).
-	^ suggestionsList
+	^ sorter sortCompletionList: (node completionEntries: position) asOrderedCollection
 ]
 
 { #category : #accessing }

--- a/src/NECompletion/ReverseAlphabeticSorter.class.st
+++ b/src/NECompletion/ReverseAlphabeticSorter.class.st
@@ -14,7 +14,7 @@ ReverseAlphabeticSorter class >> kind [
 ]
 
 { #category : #sorting }
-ReverseAlphabeticSorter >> sortCompletionList: aList [
-
-	^ aList asOrderedCollection sort reverse
+ReverseAlphabeticSorter >> sortCompletionList: anOrderedCollection [
+	"this is just for testing, reverse sort makes no sense in practice"
+	^ anOrderedCollection sort reverse
 ]


### PR DESCRIPTION
- make the sorter a invar of the completion context. This reduces instantiation, good for sorters that prepare data.
in addition it allows tests to be written that change the sorter.

- make sure that the sorter gets an OrderedCollection handed in