### PR TITLE
unify implementation of #doWithIndex: and withIndexDo

### DIFF
--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -645,6 +645,13 @@ Collection >> do: aBlock without: anItem [
 	^ self do: [:each | anItem = each ifFalse: [aBlock value: each]]
 ]
 
+{ #category : #enumerating }
+Collection >> doWithIndex: elementAndIndexBlock [
+	"Use the new version with consistent naming"
+
+	^ self withIndexDo: elementAndIndexBlock
+]
+
 { #category : #private }
 Collection >> emptyCheck [
 
@@ -1268,6 +1275,15 @@ Collection >> union: aCollection [
 	| set |
 	set := self asSet addAll: aCollection; yourself.
 	^ self species withAll: set asArray
+]
+
+{ #category : #enumerating }
+Collection >> withIndexDo: elementAndIndexBlock [
+	"Just like do: except that the iteration index supplies the second argument to the block"
+	"Support Set enumeration with a counter, even though not ordered"
+	| index |
+	index := 0.
+	self do: [:item | elementAndIndexBlock value: item value: (index := index+1)]
 ]
 
 { #category : #deprecated }

--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -1280,7 +1280,7 @@ Collection >> union: aCollection [
 { #category : #enumerating }
 Collection >> withIndexDo: elementAndIndexBlock [
 	"Just like do: except that the iteration index supplies the second argument to the block"
-	"Support Set enumeration with a counter, even though not ordered"
+	"Support collection enumeration with a counter, even though not ordered"
 	| index |
 	index := 0.
 	self do: [:item | elementAndIndexBlock value: item value: (index := index+1)]

--- a/src/Collections-Abstract/HashedCollection.class.st
+++ b/src/Collections-Abstract/HashedCollection.class.st
@@ -140,14 +140,6 @@ HashedCollection >> compact [
 	self growTo: newCapacity
 ]
 
-{ #category : #enumerating }
-HashedCollection >> doWithIndex: aBlock2 [
-	"Support Set enumeration with a counter, even though not ordered"
-	| index |
-	index := 0.
-	self do: [:item | aBlock2 value: item value: (index := index+1)]
-]
-
 { #category : #private }
 HashedCollection >> errorNoFreeSpace [
 

--- a/src/Collections-Abstract/SequenceableCollection.class.st
+++ b/src/Collections-Abstract/SequenceableCollection.class.st
@@ -782,16 +782,6 @@ SequenceableCollection >> do: aBlock without: anItem [
 		[:index | anItem = (self at: index) ifFalse:[aBlock value: (self at: index)]]
 ]
 
-{ #category : #enumerating }
-SequenceableCollection >> doWithIndex: elementAndIndexBlock [
-	"Just like do: except that the iteration index supplies the second argument to the block"
-	"Use the new version with consistent naming"
-
-	"(Array streamContents: [:stream | #(11 22 13) doWithIndex: [ :each :i | stream nextPut: (each * each + i)]]) >>> #(122 486 172)"
-
-	^ self withIndexDo: elementAndIndexBlock
-]
-
 { #category : #accessing }
 SequenceableCollection >> eighth [
 	"Answer the eighth element of the receiver.


### PR DESCRIPTION
we have both doWithIndex: and withIndexDo:. This PR does *not* try to solve that problem. Instead it just unifies the implementation
- doWithIndex: was implemented on HashedCollection, the other not --> implement withIndexDo: on Collection.
- implement doWithIndex: just in Collection to forward to #withIndexDo: