### PR TITLE
Spec code completion

### DIFF
--- a/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
+++ b/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
@@ -244,7 +244,7 @@ RubSmalltalkEditorTest >> selection: anInterval [
 	selection := anInterval
 ]
 
-{ #category : #'tests-completion' }
+{ #category : #running }
 RubSmalltalkEditorTest >> setUp [
 
 	super setUp.
@@ -261,7 +261,7 @@ RubSmalltalkEditorTest >> source: aString [
 	source := aString
 ]
 
-{ #category : #'tests-completion' }
+{ #category : #running }
 RubSmalltalkEditorTest >> tearDown [
 
 	RubSmalltalkEditor completionEngineClass: currentCompletion.

--- a/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
+++ b/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
@@ -6,7 +6,8 @@ Class {
 	#superclass : #TestCase,
 	#instVars : [
 		'source',
-		'selection'
+		'selection',
+		'currentCompletion'
 	],
 	#category : #'Rubric-Tests'
 }
@@ -243,6 +244,13 @@ RubSmalltalkEditorTest >> selection: anInterval [
 	selection := anInterval
 ]
 
+{ #category : #'tests-completion' }
+RubSmalltalkEditorTest >> setUp [
+
+	super setUp.
+	currentCompletion := RubSmalltalkEditor completionEngineClass
+]
+
 { #category : #accessing }
 RubSmalltalkEditorTest >> source [
 	^ source
@@ -251,6 +259,13 @@ RubSmalltalkEditorTest >> source [
 { #category : #accessing }
 RubSmalltalkEditorTest >> source: aString [
 	source := aString
+]
+
+{ #category : #'tests-completion' }
+RubSmalltalkEditorTest >> tearDown [
+
+	RubSmalltalkEditor completionEngineClass: currentCompletion.
+	super tearDown.
 ]
 
 { #category : #'tests-bestNodeIn' }
@@ -576,29 +591,39 @@ RubSmalltalkEditorTest >> testBestNodeWithValidValueMidSource [
 ]
 
 { #category : #'tests-completion' }
-RubSmalltalkEditorTest >> testInstanceVersusSharedCompletionEngine [
+RubSmalltalkEditorTest >> testDefaultCompletionEngineUsesGlobalClass [
 
-	| textEditor currentCompletion |
-	[ currentCompletion := RubSmalltalkEditor completionEngineClass.
+	| textEditor |
 	textEditor := RubSmalltalkEditor new.
-	self assert: textEditor completionEngine class equals: currentCompletion.
-	
+	self assert: textEditor completionEngine class equals: currentCompletion
+]
+
+{ #category : #'tests-completion' }
+RubSmalltalkEditorTest >> testDefaultCompletionIsNilIfNoGlobalClass [
+
+	| textEditor |
+	textEditor := RubSmalltalkEditor new.
 	RubSmalltalkEditor noCompletion.
-	"here we show that an existing editor is not impacted by the shared behavior"
-	self assert: textEditor completionEngine class equals: currentCompletion.
+	self assert: textEditor completionEngine isNil
+]
+
+{ #category : #'tests-completion' }
+RubSmalltalkEditorTest >> testExplicitCompletionEngineIgnoresAbsenceOfGlobalClass [
+
+	| textEditor |
 	textEditor := RubSmalltalkEditor new.
-	self assert: textEditor completionEngine isNil.
-	
-	RubSmalltalkEditor completionEngineClass: CompletionEngine.
-	self assert: textEditor completionEngine isNil.
-	
-	"but now when we create a new one it gets the correct engine"
+	RubSmalltalkEditor noCompletion.
+	textEditor completionEngine: 17.
+	self assert: textEditor completionEngine equals: 17
+]
+
+{ #category : #'tests-completion' }
+RubSmalltalkEditorTest >> testExplicitCompletionEngineIgnoresGlobalClass [
+
+	| textEditor |
 	textEditor := RubSmalltalkEditor new.
-	self assert: textEditor completionEngine class equals: CompletionEngine.
-	
-	
-	] ensure: [ RubSmalltalkEditor completionEngineClass: currentCompletion ]
-	
+	textEditor completionEngine: 17.
+	self assert: textEditor completionEngine equals: 17
 ]
 
 { #category : #'tests-jumpFind' }

--- a/src/Rubric/RubScrolledTextMorph.class.st
+++ b/src/Rubric/RubScrolledTextMorph.class.st
@@ -267,6 +267,12 @@ RubScrolledTextMorph >> columnRuler [
 	^ self rulerNamed: #column
 ]
 
+{ #category : #accessing }
+RubScrolledTextMorph >> completionEngine: aCompletionEngine [
+	
+	self textArea editor completionEngine: aCompletionEngine
+]
+
 { #category : #configure }
 RubScrolledTextMorph >> configureGhostText: aTextArea [
 	aTextArea width: self scrollBounds width.

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -357,7 +357,10 @@ RubSmalltalkEditor >> completionAround: aBlock keyStroke: anEvent [
 
 { #category : #'completion engine' }
 RubSmalltalkEditor >> completionEngine [
-	^ completionEngine
+
+	^ completionEngine ifNil: [
+		self completionEngine: CompletionEngineClass new.
+		completionEngine ]
 ]
 
 { #category : #'completion engine' }
@@ -735,8 +738,7 @@ RubSmalltalkEditor >> implementorsOfIt: aKeyboardEvent [
 { #category : #initialization }
 RubSmalltalkEditor >> initialize [
 	super initialize.
-	notificationStrategy := RubTextInsertionStrategy new editor: self.
-	CompletionEngineClass ifNotNil: [self completionEngine: CompletionEngineClass new]
+	notificationStrategy := RubTextInsertionStrategy new editor: self
 ]
 
 { #category : #keymapping }

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -359,8 +359,9 @@ RubSmalltalkEditor >> completionAround: aBlock keyStroke: anEvent [
 RubSmalltalkEditor >> completionEngine [
 
 	^ completionEngine ifNil: [
-		self completionEngine: CompletionEngineClass new.
-		completionEngine ]
+		CompletionEngineClass ifNotNil: [
+			self completionEngine: CompletionEngineClass new.
+			completionEngine ] ]
 ]
 
 { #category : #'completion engine' }

--- a/src/Spec2-Adapters-Morphic/SpMorphicCodeAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicCodeAdapter.class.st
@@ -18,6 +18,9 @@ SpMorphicCodeAdapter >> buildWidget [
 	self presenter whenSyntaxHighlightChangedDo: [ :hasSyntaxHighlight | 
 		self setEditingModeFor: newWidget ].
 	
+	self presenter completionEngine ifNotNil: [ :engine | newWidget completionEngine: engine ].
+	self presenter whenCompletionEngineChangedDo: [ :engine | newWidget completionEngine: engine ].
+	
 	^ newWidget
 ]
 

--- a/src/Spec2-Adapters-Morphic/SpMorphicTextAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTextAdapter.class.st
@@ -41,8 +41,6 @@ SpMorphicTextAdapter >> buildWidget [
 		yourself.
 	
 	self setEditingModeFor: newWidget.
-	self presenter completionEngine ifNotNil: [ :engine | newWidget completionEngine: engine ].
-	self presenter whenCompletionEngineChangedDo: [ :engine | newWidget completionEngine: engine ].
 	self presenter whenTextChangedDo: [ :text | self setText: text to: newWidget ].
 	self presenter whenPlaceholderChangedDo: [ :text | self setGhostText: text to: newWidget ].
 	

--- a/src/Spec2-Adapters-Morphic/SpMorphicTextAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTextAdapter.class.st
@@ -41,7 +41,8 @@ SpMorphicTextAdapter >> buildWidget [
 		yourself.
 	
 	self setEditingModeFor: newWidget.
-	
+	self presenter completionEngine ifNotNil: [ :engine | newWidget completionEngine: engine ].
+	self presenter whenCompletionEngineChangedDo: [ :engine | newWidget completionEngine: engine ].
 	self presenter whenTextChangedDo: [ :text | self setText: text to: newWidget ].
 	self presenter whenPlaceholderChangedDo: [ :text | self setGhostText: text to: newWidget ].
 	

--- a/src/Spec2-Core/SpCodePresenter.class.st
+++ b/src/Spec2-Core/SpCodePresenter.class.st
@@ -9,7 +9,8 @@ Class {
 		'#doItContext => SpObservableSlot',
 		'#doItReceiver => SpObservableSlot',
 		'#behavior => SpObservableSlot',
-		'#syntaxHighlight => SpObservableSlot'
+		'#syntaxHighlight => SpObservableSlot',
+		'#completionEngine => SpObservableSlot'
 	],
 	#category : #'Spec2-Core-Widgets-Text'
 }
@@ -116,6 +117,18 @@ SpCodePresenter >> behavior: aClass [
 	behavior := aClass
 ]
 
+{ #category : #accessing }
+SpCodePresenter >> completionEngine [
+
+	^ completionEngine
+]
+
+{ #category : #api }
+SpCodePresenter >> completionEngine: aCompletionEngine [
+
+	completionEngine := aCompletionEngine
+]
+
 { #category : #'api-doIt' }
 SpCodePresenter >> doItContext [
 
@@ -215,6 +228,13 @@ SpCodePresenter >> whenBehaviorChangedDo: aBlock [
 	self 
 		property: #behavior 
 		whenChangedDo: aBlock
+]
+
+{ #category : #'api-events' }
+SpCodePresenter >> whenCompletionEngineChangedDo: aBlock [
+	"Set a block to perform when the syntax highlight is enabled/disabled"
+
+	self property: #completionEngine whenChangedDo: aBlock
 ]
 
 { #category : #'api-events' }


### PR DESCRIPTION
Extend rubric and Spec to be able to set the code completion engine from the outside.
- Code completion should be initialized lazily to the global one only.
- Extended Code presenter and adaptor to set it in widget if available in presenter