### PR TITLE
Compiler: CleanUp #sourceNodeExecutedForPC:

### DIFF
--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -816,11 +816,6 @@ CompiledCode >> sourceNode [
 ]
 
 { #category : #accessing }
-CompiledCode >> sourceNodeExecutedForPC: arg1 [ 
-	^ self subclassResponsibility
-]
-
-{ #category : #accessing }
 CompiledCode >> sourceNodeForPC: arg1 [ 
 	^ self subclassResponsibility
 ]

--- a/src/OpalCompiler-Core/CompiledBlock.extension.st
+++ b/src/OpalCompiler-Core/CompiledBlock.extension.st
@@ -11,13 +11,6 @@ CompiledBlock >> sourceNode [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-CompiledBlock >> sourceNodeExecutedForPC: aPC [
-	| blockNode |
-	blockNode := self outerCode sourceNodeExecutedForPC: self pcInOuter.
-	^blockNode sourceNodeExecutedForPC: aPC
-]
-
-{ #category : #'*OpalCompiler-Core' }
 CompiledBlock >> sourceNodeForPC: aPC [
 	| blockNode |
 	blockNode := self outerCode sourceNodeForPC: self pcInOuter.

--- a/src/OpalCompiler-Core/CompiledMethod.extension.st
+++ b/src/OpalCompiler-Core/CompiledMethod.extension.st
@@ -53,11 +53,6 @@ CompiledMethod >> sourceNode [
 ]
 
 { #category : #'*opalcompiler-core' }
-CompiledMethod >> sourceNodeExecutedForPC: aPC [
-	^self sourceNode sourceNodeExecutedForPC: aPC
-]
-
-{ #category : #'*opalcompiler-core' }
 CompiledMethod >> sourceNodeForPC: aPC [
 	^self sourceNode sourceNodeForPC: aPC
 ]

--- a/src/OpalCompiler-Core/Context.extension.st
+++ b/src/OpalCompiler-Core/Context.extension.st
@@ -51,7 +51,7 @@ Context >> sourceNode [
 { #category : #'*OpalCompiler-Core' }
 Context >> sourceNodeExecuted [
 	"When down in the stack, I return the node that executed"
-	^ (method sourceNodeExecutedForPC: self executedPC) 
+	^ (method sourceNodeForPC: self executedPC) 
 	"Uncomment the following once the pc->AST mapping is fixed"
 	"^ (method sourceNodeForPC: (previousPc ifNil: [ self startpc ])) "
 ]

--- a/src/OpalCompiler-Core/IRInstruction.class.st
+++ b/src/OpalCompiler-Core/IRInstruction.class.st
@@ -402,13 +402,6 @@ IRInstruction >> sourceNode: parseNode [
 	
 ]
 
-{ #category : #mapping }
-IRInstruction >> sourceNodeExecuted [
-
-	^ self sourceNode
-	
-]
-
 { #category : #accessing }
 IRInstruction >> successorSequences [
 	"sent to last instruction in sequence which is expected to be a jump and return instruction"

--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -354,14 +354,6 @@ IRMethod >> sourceNode: aNode [
 	sourceNode := aNode
 ]
 
-{ #category : #mapping }
-IRMethod >> sourceNodeExecuted [ 
-	"It should not be used directly. But it is needed for fallback call from RBMethodNode>>sourceNodeExecutedForPC:. 
-	Problem that IRMethod can returns itself from  instructionForPC:.
-	So it should only return sourceNode without any analyzis"
-	^sourceNode
-]
-
 { #category : #accessing }
 IRMethod >> startSequence [
 

--- a/src/OpalCompiler-Core/IRPushClosureCopy.class.st
+++ b/src/OpalCompiler-Core/IRPushClosureCopy.class.st
@@ -103,11 +103,6 @@ IRPushClosureCopy >> numArgs: aSmallInteger [
 	numArgs := aSmallInteger
 ]
 
-{ #category : #mapping }
-IRPushClosureCopy >> sourceNodeExecuted [
-	^self sourceNode parent
-]
-
 { #category : #accessing }
 IRPushClosureCopy >> successorSequences [
 

--- a/src/OpalCompiler-Core/RBBlockNode.extension.st
+++ b/src/OpalCompiler-Core/RBBlockNode.extension.st
@@ -60,14 +60,6 @@ RBBlockNode >> owningScope [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-RBBlockNode >> sourceNodeExecutedForPC: anInteger [
-	self methodNode ir.
-	(self hasProperty: #ir) ifTrue: [ "FullBlockClosure"
-		^(self ir fullBlockInstructionForPC: anInteger) sourceNodeExecuted ].
-	^ self methodNode sourceNodeExecutedForPC: anInteger
-]
-
-{ #category : #'*OpalCompiler-Core' }
 RBBlockNode >> sourceNodeForPC: anInteger [ 
 	self methodNode ir.
 	(self hasProperty: #ir) ifTrue: [ "FullBlockClosure"

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -166,11 +166,6 @@ RBMethodNode >> rewriteTempsForContext: aContext [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-RBMethodNode >> sourceNodeExecutedForPC: anInteger [
-	^(self ir instructionForPC: anInteger) sourceNodeExecuted
-]
-
-{ #category : #'*OpalCompiler-Core' }
 RBMethodNode >> sourceNodeForPC: anInteger [
 	^(self ir instructionForPC: anInteger) sourceNode
 ]


### PR DESCRIPTION
- #sourceNodeExecutedForPC: is the same code as #sourceForPC:
- on the IR level, we do not need #sourceNodeExecuted at all, we can just use #sourceNode