### PR TITLE
Categorize GlyphRenderer>>initForFont:

### DIFF
--- a/src/Athens-Text/GlyphRenderer.class.st
+++ b/src/Athens-Text/GlyphRenderer.class.st
@@ -12,7 +12,7 @@ GlyphRenderer class >> forFont: aFont [
 	^ self basicNew initForFont: aFont
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'private - initialization' }
 GlyphRenderer >> initForFont: aFont [
 
 	self subclassResponsibility 


### PR DESCRIPTION
- categorize the method #initForFont: to fix #5676