### PR TITLE
ManifestFuel needs to be ManifestFuelCore

### DIFF
--- a/src/Fuel-Core/ManifestFuelCore.class.st
+++ b/src/Fuel-Core/ManifestFuelCore.class.st
@@ -2,17 +2,17 @@
 The core package of Fuel - the Smalltalk object serializer
 "
 Class {
-	#name : #ManifestFuel,
+	#name : #ManifestFuelCore,
 	#superclass : #PackageManifest,
 	#category : #'Fuel-Core-Manifest'
 }
 
 { #category : #'meta data' }
-ManifestFuel class >> ruleConsistencyCheckRuleV1FalsePositive [
+ManifestFuelCore class >> ruleConsistencyCheckRuleV1FalsePositive [
 ^ #(#(#(#RGMethodDefinition #(#Float #serializeOn: #false)) #'2013-02-25T14:50:01.564000001+01:00') )
 ]
 
 { #category : #'meta data' }
-ManifestFuel class >> ruleIfTrueBlocksRuleV1FalsePositive [
+ManifestFuelCore class >> ruleIfTrueBlocksRuleV1FalsePositive [
 ^ #(#(#(#RGMethodDefinition #(#FLLightGeneralMapper #visitSubstitution:by:onRecursionDo: #false)) #'2013-02-25T14:50:01.650000001+01:00') )
 ]


### PR DESCRIPTION
to be in alignment with package name (fix for #5682)
Do we need to updated official Fuel repo too???