### PR TITLE
Rename Ring Manifests to follow package names

### DIFF
--- a/src/Ring-Definitions-Containers/ManifestRingDefinitionsContainers.class.st
+++ b/src/Ring-Definitions-Containers/ManifestRingDefinitionsContainers.class.st
@@ -2,12 +2,12 @@
 Deprecated package for Ring Core containerss
 "
 Class {
-	#name : #ManifestRingCoreContainers,
+	#name : #ManifestRingDefinitionsContainers,
 	#superclass : #PackageManifest,
 	#category : #'Ring-Definitions-Containers-Manifest'
 }
 
 { #category : #'meta-data - dependency analyser' }
-ManifestRingCoreContainers class >> manuallyResolvedDependencies [
+ManifestRingDefinitionsContainers class >> manuallyResolvedDependencies [
 	^ #(#'Collections-Streams' #'Collections-Abstract' #'Collections-Strings' #'System-Support')
 ]

--- a/src/Ring-Definitions-Core/ManifestRingDefinitionsCore.class.st
+++ b/src/Ring-Definitions-Core/ManifestRingDefinitionsCore.class.st
@@ -2,12 +2,12 @@
 Manifest for DEPRECATED package of Ring
 "
 Class {
-	#name : #ManifestRingCoreKernel,
+	#name : #ManifestRingDefinitionsCore,
 	#superclass : #PackageManifest,
 	#category : #'Ring-Definitions-Core-Manifest'
 }
 
 { #category : #'meta-data - dependency analyser' }
-ManifestRingCoreKernel class >> manuallyResolvedDependencies [
+ManifestRingDefinitionsCore class >> manuallyResolvedDependencies [
 	^ #(#'Collections-Abstract' #'Collections-Strings' #'Collections-Streams' #'System-Sources')
 ]

--- a/src/Ring-Definitions-Monticello/ManifestRingDefinitionsMonticello.class.st
+++ b/src/Ring-Definitions-Monticello/ManifestRingDefinitionsMonticello.class.st
@@ -2,12 +2,12 @@
 Deprecated ring extensions for Monticello.
 "
 Class {
-	#name : #ManifestRingMonticello,
+	#name : #ManifestRingDefinitionsMonticello,
 	#superclass : #PackageManifest,
 	#category : #'Ring-Definitions-Monticello-Manifest'
 }
 
 { #category : #'meta-data - dependency analyser' }
-ManifestRingMonticello class >> manuallyResolvedDependencies [
+ManifestRingDefinitionsMonticello class >> manuallyResolvedDependencies [
 	^ #(#'Collections-Streams' #'Collections-Abstract')
 ]

--- a/src/Ring-Definitions-Tests-Containers/ManifestRingDefinitionsTestsContainers.class.st
+++ b/src/Ring-Definitions-Tests-Containers/ManifestRingDefinitionsTestsContainers.class.st
@@ -2,7 +2,7 @@
 Manifest for DEPRECATED package for Ring containers tests
 "
 Class {
-	#name : #ManifestRingTestsContainers,
+	#name : #ManifestRingDefinitionsTestsContainers,
 	#superclass : #PackageManifest,
 	#category : #'Ring-Definitions-Tests-Containers-Manifest'
 }

--- a/src/Ring-Definitions-Tests-Core/ManifestRingDefinitionsTestsCore.class.st
+++ b/src/Ring-Definitions-Tests-Core/ManifestRingDefinitionsTestsCore.class.st
@@ -2,7 +2,7 @@
 Manifest for DEPRECATED package of Ring tests
 "
 Class {
-	#name : #ManifestRingCoreTestsKernel,
+	#name : #ManifestRingDefinitionsTestsCore,
 	#superclass : #PackageManifest,
 	#category : #'Ring-Definitions-Tests-Core-Manifest'
 }

--- a/src/Ring-Definitions-Tests-Monticello/ManifestRingDefinitionsTestsMonticello.class.st
+++ b/src/Ring-Definitions-Tests-Monticello/ManifestRingDefinitionsTestsMonticello.class.st
@@ -2,7 +2,7 @@
 Manifest for DEPRECATED package for Ring monticello tests
 "
 Class {
-	#name : #ManifestRingTestsMonticello,
+	#name : #ManifestRingDefinitionsTestsMonticello,
 	#superclass : #PackageManifest,
 	#category : #'Ring-Definitions-Tests-Monticello-Manifest'
 }

--- a/src/Ring-OldChunkImporter/ManifestRingOldChunkImporter.class.st
+++ b/src/Ring-OldChunkImporter/ManifestRingOldChunkImporter.class.st
@@ -2,12 +2,12 @@
 Manifest for deprecated Ring-Deprecated-ChunkImporter package
 "
 Class {
-	#name : #ManifestRingChunkImporter,
+	#name : #ManifestRingOldChunkImporter,
 	#superclass : #PackageManifest,
 	#category : #'Ring-OldChunkImporter-Manifest'
 }
 
 { #category : #'meta-data - dependency analyser' }
-ManifestRingChunkImporter class >> manuallyResolvedDependencies [
+ManifestRingOldChunkImporter class >> manuallyResolvedDependencies [
 	^ #(#'OpalCompiler-Core' #'FileSystem-Core' #'Collections-Abstract' #'Collections-Strings' #'System-Support')
 ]


### PR DESCRIPTION
ManifestRingChunkImporter -> ManifestRingOldChunkImporter
ManifestRingCoreContainers -> ManifestRingDefinitionsContainers
ManifestRingCoreKernel -> ManifestRingDefinitionsCore
ManifestRingCoreTestsKernel -> ManifestRingDefinitionsTestsCore
ManifestRingMonticello -> ManifestRingDefinitionsMonticello
ManifestRingTestsContainers -> ManifestRingDefinitionsTestsContainers
ManifestRingTestsMonticello -> ManifestRingDefinitionsTestsMonticello

to follow package name and fix #5685