### PR TITLE
testWhichSelectorsAccess small cleanup

### DIFF
--- a/src/Kernel-Tests-Extended/BehaviorTest.extension.st
+++ b/src/Kernel-Tests-Extended/BehaviorTest.extension.st
@@ -15,9 +15,3 @@ BehaviorTest >> testAllReferencesTo [
 	result do: [ :each | self assert: ((each compiledMethod sendsSelector: #+) or: [ each compiledMethod refersToLiteral: #+ ]) ].
 	self assert: (result anySatisfy: [ :each | each methodClass = self class and: [ each selector = #testAllReferencesTo ] ])
 ]
-
-{ #category : #'*Kernel-Tests-Extended' }
-BehaviorTest >> testWhichSelectorsAccess [
-	self assert: ((Point whichSelectorsAccess: 'x') includes: #x).
-	self deny:  ((Point whichSelectorsAccess: 'y') includes: #x).
-]

--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -162,7 +162,7 @@ ClassDescriptionTest >> testwhichSelectorsRead [
 	self assert: ((Point whichSelectorsRead: #y) includes: #y).
 	self deny: ((Point whichSelectorsRead: #y) includes: #x).
 	
-	self assert: ((Point whichSelectorsAccess: #doesNotExist) isEmpty)
+	self assert: ((Point whichSelectorsRead: #doesNotExist) isEmpty)
 ]
 
 { #category : #'tests - instance variables' }
@@ -170,5 +170,5 @@ ClassDescriptionTest >> testwhichSelectorsWrite [
 	self assert: ((Point whichSelectorsWrite: #x) includes: #setX:setY:).
 	self deny: ((Point whichSelectorsWrite: #x) includes: #x).
 	
-	self assert: ((Point whichSelectorsAccess: #doesNotExist) isEmpty).
+	self assert: ((Point whichSelectorsWrite: #doesNotExist) isEmpty).
 ]


### PR DESCRIPTION
- testWhichSelectorsAccess in Behavior: it's a method in ClassDescription and we have a test there
- testwhichSelectorsRead / write had some copy/paste mistake