### PR TITLE
enhance-externaladdress-compare

### DIFF
--- a/src/FFI-Kernel/ExternalAddress.class.st
+++ b/src/FFI-Kernel/ExternalAddress.class.st
@@ -81,6 +81,17 @@ ExternalAddress >> + offset [
 	^bytes asExternalPointer
 ]
 
+{ #category : #comparing }
+ExternalAddress >> = other [
+
+	self == other ifTrue: [ ^ true ].
+	self species == other species ifFalse: [ ^ false ].
+	1 to: self size do: [ :index | 
+		(self at: index) = (other at: index) ifFalse: [ ^ false ] ].
+	
+	^ true
+]
+
 { #category : #private }
 ExternalAddress >> asByteArrayPointer [
 	"Answer a ByteArray containing a copy of pointer to the contents of the receiver."


### PR DESCRIPTION
simplifying comparisson by skipping one #isKindOf: when we know we are comparing two ExternalAddress.
Benchmark show an improvement of x3 in speed of lookup by address.