### PR TITLE
Context: #sourceNode simplify by introducing #scope

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -22,7 +22,7 @@ Context >> callPrimitive: primNumber [
 { #category : #'*Debugging-Core' }
 Context >> lookupSymbol: aSymbol [
 	| var |
-	var := self scope lookupVar: aSymbol.
+	var := self astScope lookupVar: aSymbol.
 	"Local variables"
 	var isTemp ifTrue: [^ self tempNamed: aSymbol].
 	"Instance variables"
@@ -359,7 +359,7 @@ Context >> tempNamed: aName [
 	"Returns the value of the temporaries, aName"
 
 	| scope var |
-	scope := self scope.
+	scope := self astScope.
 	var := scope lookupVar: aName.
 	^var readFromContext: self scope: scope.
 ]
@@ -369,7 +369,7 @@ Context >> tempNamed: aName put: anObject [
 	"Assign the value of the temp with name in aContext"
 	
 	| scope var |
-	scope := self scope.
+	scope := self astScope.
 	var := scope lookupVar: aName.
 	^var writeFromContext: self scope: scope value: anObject
 ]
@@ -384,7 +384,7 @@ Context >> tempNames [
 	In addition, even vars that are accessed in this context could be stored
 	in a temp vector, which itself would be a copied temp that has no name..."
 	
-	^ self scope allTempNames
+	^ self astScope allTempNames
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -22,7 +22,7 @@ Context >> callPrimitive: primNumber [
 { #category : #'*Debugging-Core' }
 Context >> lookupSymbol: aSymbol [
 	| var |
-	var := self sourceNode scope lookupVar: aSymbol.
+	var := self scope lookupVar: aSymbol.
 	"Local variables"
 	var isTemp ifTrue: [^ self tempNamed: aSymbol].
 	"Instance variables"
@@ -359,7 +359,7 @@ Context >> tempNamed: aName [
 	"Returns the value of the temporaries, aName"
 
 	| scope var |
-	scope := self sourceNode scope.
+	scope := self scope.
 	var := scope lookupVar: aName.
 	^var readFromContext: self scope: scope.
 ]
@@ -369,7 +369,7 @@ Context >> tempNamed: aName put: anObject [
 	"Assign the value of the temp with name in aContext"
 	
 	| scope var |
-	scope := self sourceNode scope.
+	scope := self scope.
 	var := scope lookupVar: aName.
 	^var writeFromContext: self scope: scope value: anObject
 ]
@@ -384,7 +384,7 @@ Context >> tempNames [
 	In addition, even vars that are accessed in this context could be stored
 	in a temp vector, which itself would be a copied temp that has no name..."
 	
-	^ self sourceNode scope allTempNames
+	^ self scope allTempNames
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/Kernel-Tests-WithCompiler/ContextTest.extension.st
+++ b/src/Kernel-Tests-WithCompiler/ContextTest.extension.st
@@ -5,14 +5,14 @@ ContextTest >> testScopeOptimizedBlock [
 	"When asking for the scope of a block that is not there at runtime, we nevertheless what to 
 	get the corresponding scope of the optimized block"
 	
-	| scope method |
+	| astScope method |
 	
 	method := Smalltalk compiler
 							  class: Object;
-							  compile:  'test 1 to: 1 do: [ :i | ^ thisContext scope ]'.
-	scope := method valueWithReceiver: nil arguments: #(). 
+							  compile:  'test 1 to: 1 do: [ :i | ^ thisContext astScope ]'.
+	astScope := method valueWithReceiver: nil arguments: #(). 
 	
-	self assert: scope class equals: OCOptimizedBlockScope .
+	self assert: astScope class equals: OCOptimizedBlockScope .
 ]
 
 { #category : #'*Kernel-Tests-WithCompiler' }

--- a/src/Kernel-Tests-WithCompiler/ContextTest.extension.st
+++ b/src/Kernel-Tests-WithCompiler/ContextTest.extension.st
@@ -1,9 +1,24 @@
 Extension { #name : #ContextTest }
 
 { #category : #'*Kernel-Tests-WithCompiler' }
+ContextTest >> testScopeOptimizedBlock [
+	"When asking for the scope of a block that is not there at runtime, we nevertheless what to 
+	get the corresponding scope of the optimized block"
+	
+	| scope method |
+	
+	method := Smalltalk compiler
+							  class: Object;
+							  compile:  'test 1 to: 1 do: [ :i | ^ thisContext scope ]'.
+	scope := method valueWithReceiver: nil arguments: #(). 
+	
+	self assert: scope class equals: OCOptimizedBlockScope .
+]
+
+{ #category : #'*Kernel-Tests-WithCompiler' }
 ContextTest >> testSourceNodeOptimizedBlock [
 	"When asking for the sourceNode of a block that is not there at runtime, we nevertheless what to 
-	get the corresponding ASTnode of the inlined Block"
+	get the corresponding ASTnode of the ASTNode that created thisContext, the method in this case"
 	
 	| sourceNode method |
 	
@@ -12,7 +27,7 @@ ContextTest >> testSourceNodeOptimizedBlock [
 							  compile:  'test 1 to: 1 do: [ :i | ^ thisContext sourceNode ]'.
 	sourceNode := method valueWithReceiver: nil arguments: #(). 
 	
-	self assert: sourceNode isBlock.
+	self assert: sourceNode isMethod.
 ]
 
 { #category : #'*Kernel-Tests-WithCompiler' }

--- a/src/OpalCompiler-Core/Context.extension.st
+++ b/src/OpalCompiler-Core/Context.extension.st
@@ -1,6 +1,17 @@
 Extension { #name : #Context }
 
 { #category : #'*OpalCompiler-Core' }
+Context >> astScope [
+	"Return the scope of the method or the block of this context. 
+	Note: we can not just use #sourceNode as this ignores optimized blocks.
+	We instead use sourceNodeExecuted and then get the the block or methodnode on the AST level.
+	For the topmost context, sourceNodeExecuted is off by one but that is not a problem as 
+	we still end up getting the scope  we want"
+
+	^ self sourceNodeExecuted methodOrBlockNode scope
+]
+
+{ #category : #'*OpalCompiler-Core' }
 Context >> executedPC [
 	"If this context is already perform message send and waiting return 
 	then executed PC is previous one. So we start analazing with previous PC.
@@ -40,17 +51,6 @@ Context >> isPushTemp: aPC [
 { #category : #'*OpalCompiler-Core' }
 Context >> isReturnAt: aPC [
 	^method encoderClass isReturnAt: aPC in: method.
-]
-
-{ #category : #'*OpalCompiler-Core' }
-Context >> scope [
-	"Return the scope of the method or the block of this context. 
-	Note: we can not just use #sourceNode as this ignores optimized blocks.
-	We instead use sourceNodeExecuted and then get the the block or methodnode on the AST level.
-	For the topmost context, sourceNodeExecuted is off by one but that is not a problem as 
-	we still end up getting the scope  we want"
-
-	^ self sourceNodeExecuted methodOrBlockNode scope
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/Context.extension.st
+++ b/src/OpalCompiler-Core/Context.extension.st
@@ -43,20 +43,27 @@ Context >> isReturnAt: aPC [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-Context >> sourceNode [
-	"Return the source node of the method or the block of this context. 
-	Note: we can not just use the startPC to find the node as this ignores optimized blocks.
-	We instead get the executed PC and then go up to the sourceNode of the block or method. 
+Context >> scope [
+	"Return the scope of the method or the block of this context. 
+	Note: we can not just use #sourceNode as this ignores optimized blocks.
+	We instead use sourceNodeExecuted and then get the the block or methodnode on the AST level.
 	For the topmost context, sourceNodeExecuted is off by one but that is not a problem as 
-	we still end up getting the node we want (via the bytecode that created it)"
+	we still end up getting the scope  we want"
 
-	^ self sourceNodeExecuted methodOrBlockNode
+	^ self sourceNodeExecuted methodOrBlockNode scope
+]
+
+{ #category : #'*OpalCompiler-Core' }
+Context >> sourceNode [
+	"Return the source node that created the method or the block of this context"
+
+	^ closureOrNil
+		ifNil: [ self method sourceNode ]
+		ifNotNil: [ closureOrNil sourceNode ]
 ]
 
 { #category : #'*OpalCompiler-Core' }
 Context >> sourceNodeExecuted [
 	"When down in the stack, I return the node that executed"
-	^ (method sourceNodeForPC: self executedPC) 
-	"Uncomment the following once the pc->AST mapping is fixed"
-	"^ (method sourceNodeForPC: (previousPc ifNil: [ self startpc ])) "
+	^ method sourceNodeForPC: self executedPC
 ]

--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -214,7 +214,7 @@ MethodMapTest >> testThisContextSourceNode [
 { #category : #'testing - ast mapping' }
 MethodMapTest >> testThisContextSourceNodeInInlinedMessage [
 	| inlinedBlockSourceNode |
+	"we get the method node as this is what created the context"
 	inlinedBlockSourceNode := self inlinedBlockSourceNode.
-	self assert: (inlinedBlockSourceNode isKindOf: RBBlockNode).
-	self assert: inlinedBlockSourceNode equals: (self parseExpression: '[ :i | ^ thisContext sourceNode ]')
+	self assert: (inlinedBlockSourceNode isKindOf: RBMethodNode).
 ]


### PR DESCRIPTION
#sourceNode on Context was returning the node of an optimized block if the context was executing this optimized block. This is not good as what you naively expect is that "thisContext sourceNode" returns the ast node of the block or method that created the context.  

It turns out that allt he users that expected the optimized block actually are interested in the *scope* of the block.

- add a method #scope
- change all senders of #sourceNode scope to #scope
- simplify #soureNode. (just looking at the code tells us that this is how it should be)

sourceNode
	"Return the source node that created the method or the block of this context"

	^ closureOrNil
		ifNil: [ self method sourceNode ]
		ifNotNil: [ closureOrNil sourceNode ]