### PR TITLE
#5693 use printString to simplify drTestName

### DIFF
--- a/src/DrTests-TestCoverage/CompiledMethod.extension.st
+++ b/src/DrTests-TestCoverage/CompiledMethod.extension.st
@@ -2,5 +2,5 @@ Extension { #name : #CompiledMethod }
 
 { #category : #'*DrTests-TestCoverage' }
 CompiledMethod >> drTestsName [
-	^ self methodClass asString, '>>#', self selector asString
+	^ self printString
 ]


### PR DESCRIPTION
fixes #5693

- we can just call #printString, as noted by Denis in the review of the already merged PR