### PR TITLE
Context: simplify #executedPC

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -63,7 +63,7 @@ Context >> pcRangeContextIsActive: contextIsActive [
 	| thePC |
 
   	"make sure we have some usable value (can happen for contexts in the ProcessBrowser"		
- 	thePC := pc ifNil: [self method endPC].		
+ 	thePC := self isDead ifTrue: [self endPC] ifFalse: [pc].
 
   	"When on the top of the stack the pc is pointing to right instruction, but deeper in the stack		
  	the pc was already advanced one bytecode, so we need to go back this one bytecode, which		

--- a/src/OpalCompiler-Core/Context.extension.st
+++ b/src/OpalCompiler-Core/Context.extension.st
@@ -2,24 +2,15 @@ Extension { #name : #Context }
 
 { #category : #'*OpalCompiler-Core' }
 Context >> executedPC [
-	"If this context is already perform message send and waiting return 
-	then executed PC is previous one. So we start analazing with previous PC.
-	If there was no sends yet then we just need current pc corrected by push operations.
-	Also we should skip block returns which surround following send"
-	| executedPC |
-	self isDead ifTrue: [ ^self startpc ].
-	executedPC := self previousPc ifNil: [self startpc].
+	"Deeper in the stack the pc was already advanced one bytecode, so we need to go back 
+	this one bytecode, which can consist of multiple bytes. But on IR, we record the *last* 
+	bytecode offset as the offset of the IR instruction, which means we can just go back one"		
+			
+	"if we are at the start, return the startpc"		
+	(pc == self startpc) ifTrue: [ ^self startpc ].
 	
-	(self isReturnAt: executedPC) ifTrue: [ executedPC := executedPC + 1 ].	
-	"There is a pushLiteral: nil bytecode for each temps in a block. 
-	There is a 'pushTemp:' bytecode for each copied value of a block.
-	These bytecodes are not mapped to any IR.
-	We skip both"
-	[ self isPushLiteralNil: executedPC ] whileTrue: [ executedPC := executedPC + 1 ].
-	[ self isPushTemp: executedPC ] whileTrue: [ executedPC := executedPC + 1 ].
-
-	(self  isReturnAt: executedPC) ifTrue: [ executedPC := executedPC + 1 ].
-	^ executedPC
+	"we need to guard for dead contexts (pc is nil)"
+	^self isDead ifTrue: [ self endPC - 1] ifFalse: [ pc - 1].
 ]
 
 { #category : #'*OpalCompiler-Core' }


### PR DESCRIPTION
simplify #executedPC. The IR level takes care to do the right thing for pc - 1. We already use this (in Pharo8) for the debug highlight and it works well.