### PR TITLE
Cleanup-enclosingMethodOrBlockNode

### DIFF
--- a/src/OpalCompiler-Core/RBBlockNode.extension.st
+++ b/src/OpalCompiler-Core/RBBlockNode.extension.st
@@ -1,10 +1,5 @@
 Extension { #name : #RBBlockNode }
 
-{ #category : #'*opalcompiler-core' }
-RBBlockNode >> enclosingMethodOrBlockNode [
-	^ parent ifNotNil: [ parent methodOrBlockNode ]
-]
-
 { #category : #'*OpalCompiler-Core' }
 RBBlockNode >> ir [
 

--- a/src/OpalCompiler-Core/RBProgramNode.extension.st
+++ b/src/OpalCompiler-Core/RBProgramNode.extension.st
@@ -44,11 +44,6 @@ RBProgramNode >> doSemanticAnalysisIn: aClass [
 ]
 
 { #category : #'*opalcompiler-core' }
-RBProgramNode >> enclosingMethodOrBlockNode [
-	^ self methodOrBlockNode 
-]
-
-{ #category : #'*opalcompiler-core' }
 RBProgramNode >> irInstruction [
 	^ self methodOrBlockNode ir firstInstructionMatching: [:instr | instr sourceNode == self ]
 ]


### PR DESCRIPTION
enclosingMethodOrBlockNode is an extension method from the compiler, not used anymore. As it is not an API method --> remove without deprecation