### PR TITLE
Fix: exporting only non empty RGPackages to Tonel

### DIFF
--- a/src/Ring-Monticello/RGEnvironment.extension.st
+++ b/src/Ring-Monticello/RGEnvironment.extension.st
@@ -18,8 +18,8 @@ RGEnvironment >> writeIntoFileTree: aMCFileTreeRepository [
 
 { #category : #'*Ring-Monticello' }
 RGEnvironment >> writeIntoTonel: aFileReference [
-
-	(self ask packages select: #isRingResolved) do: [ :aPackage |
+self halt.
+	(self ask packages select: [ :package | package isRingResolved and: package isEmpty not ]) do: [ :aPackage |
 		| aSnapshot info aVersion |
 		aSnapshot := aPackage asMCSnapshot.
 

--- a/src/Ring-Monticello/RGEnvironment.extension.st
+++ b/src/Ring-Monticello/RGEnvironment.extension.st
@@ -18,7 +18,6 @@ RGEnvironment >> writeIntoFileTree: aMCFileTreeRepository [
 
 { #category : #'*Ring-Monticello' }
 RGEnvironment >> writeIntoTonel: aFileReference [
-self halt.
 	(self ask packages select: [ :package | package isRingResolved and: package isEmpty not ]) do: [ :aPackage |
 		| aSnapshot info aVersion |
 		aSnapshot := aPackage asMCSnapshot.


### PR DESCRIPTION
The export was failing when trying to export an empty RGPackage, this happened when the Extensions package is empty. Now only non-empty RGPackages are exported