### PR TITLE
ManifestSpec2CommanderTests should be ManifestSpec2Commander2Tests

### DIFF
--- a/src/Spec2-Commander2-Tests/ManifestSpec2Commander2Tests.class.st
+++ b/src/Spec2-Commander2-Tests/ManifestSpec2Commander2Tests.class.st
@@ -6,7 +6,7 @@ Spec is a framework in Pharo for describing user interfaces. It allows for the c
 I contain test about the integration of Commander 2 in Spec.
 "
 Class {
-	#name : #ManifestSpec2CommanderTests,
+	#name : #ManifestSpec2Commander2Tests,
 	#superclass : #PackageManifest,
 	#category : #'Spec2-Commander2-Tests-Manifest'
 }


### PR DESCRIPTION
as it is in package "Spec2-Commander2-Tests-Manifest" and should stay in synch with package name

Fix #5728