### PR TITLE
2560-CairoFreetypeFontRenderer-ivar-cache-is-initialized---but-nowhere-used

### DIFF
--- a/src/Athens-Cairo/CairoFreetypeFontRenderer.class.st
+++ b/src/Athens-Cairo/CairoFreetypeFontRenderer.class.st
@@ -17,7 +17,6 @@ Class {
 		'canvas',
 		'advance',
 		'originalFont',
-		'cache',
 		'fontExtents',
 		'glyphExtents'
 	],
@@ -155,7 +154,6 @@ CairoFreetypeFontRenderer >> glyphsOf: aString from: start to: end [
 CairoFreetypeFontRenderer >> initialize [ 
 	utfConverter := CairoUTF8Converter new.
 	advance := 0@0.
-	cache := CairoBackendCache soleInstance.
 	glyphExtents := CairoTextExtents new.
 ]
 


### PR DESCRIPTION
remove unused ivar. We can add it back if is used. fixes #2560