### PR TITLE
Renaming packages leads to out of synch manifest names

### DIFF
--- a/src/Manifest-Core/TheManifestBuilder.class.st
+++ b/src/Manifest-Core/TheManifestBuilder.class.st
@@ -13,27 +13,27 @@ Class {
 	#category : #'Manifest-Core-Base'
 }
 
-{ #category : #utilities }
+{ #category : #accessing }
 TheManifestBuilder class >> allManifestClasses [
 
 	^ PackageManifest subclasses
 ]
 
-{ #category : #utilities }
+{ #category : #'accessing - tags' }
 TheManifestBuilder class >> falsePositiveBeginningTag [
 	"the string that identifies uniquely the beginning of a selector who give  the set of false positive for a rule"
 	
 	^ 'rule'
 ]
 
-{ #category : #utilities }
+{ #category : #'accessing - tags' }
 TheManifestBuilder class >> falsePositiveEndTag [
 	"the string that identifies uniquely the end of a selector who give  the set of false positive for a rule"
 	
 	^ 'FalsePositive'
 ]
 
-{ #category : #utilities }
+{ #category : #'accessing - tags' }
 TheManifestBuilder class >> falsePositiveMiddleTag [
 	"the string that identifies uniquely the middle of a selector who give  the set of false positive for a rule"
 	
@@ -55,15 +55,29 @@ TheManifestBuilder class >> hasPackageNamed: aPackageName [
 	
 ]
 
-{ #category : #utilities }
+{ #category : #'accessing - manifest' }
 TheManifestBuilder class >> manifestClassComment [
 	
 	^ 'I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser'
 ]
 
-{ #category : #utilities }
+{ #category : #'accessing - manifest' }
+TheManifestBuilder class >> manifestClassNameFor: aPackageName [
+	"Returns a symbol representing a suitable name for a Manifest class for the given package"
+	
+	^(self manifestTag, (aPackageName select: [:each | each isAlphaNumeric ])) asSymbol
+]
+
+{ #category : #'accessing - manifest' }
+TheManifestBuilder class >> manifestClassPrefix [
+	"Return a string that serves as a prefix for Manifest classes (identifies uniquely the beginning of a Manifest class name)"
+	
+	^ 'Manifest'
+]
+
+{ #category : #'accessing - manifest' }
 TheManifestBuilder class >> manifestTag [
-	"the string that identifies uniquely the beginning of a Manifest class name"
+	"Return a string that serves as a tag within a package for Manifest classes"
 	
 	^ 'Manifest'
 ]
@@ -90,42 +104,42 @@ TheManifestBuilder class >> ofPackageNamed: aPackageName [
 	^ builder
 ]
 
-{ #category : #utilities }
+{ #category : #'accessing - tags' }
 TheManifestBuilder class >> rejectClassesTag [
 	"the string that identifies uniquely the beginning of a selector who give  the set of rejected classes"
 	
 	^ 'rejectClasses'
 ]
 
-{ #category : #utilities }
+{ #category : #'accessing - tags' }
 TheManifestBuilder class >> rejectRulesTag [
 	"the string that identifies uniquely the beginning of a selector who give  the set of rejected rules"
 	
 	^ 'rejectRules'
 ]
 
-{ #category : #utilities }
+{ #category : #'accessing - tags' }
 TheManifestBuilder class >> toDoBeginningTag [
 	"the string that identifies uniquely the beginning of a selector who give  the set of TODO for a rule"
 	
 	^ 'rule'
 ]
 
-{ #category : #utilities }
+{ #category : #'accessing - tags' }
 TheManifestBuilder class >> toDoEndTag [
 	"the string that identifies uniquely the end of a selector who give  the set of TODO for a rule"
 	
 	^ 'TODO'
 ]
 
-{ #category : #utilities }
+{ #category : #'accessing - tags' }
 TheManifestBuilder class >> toDoMiddleTag [
 	"the string that identifies uniquely the middle of a selector who give  the set of TODO for a rule"
 	
 	^ 'V'
 ]
 
-{ #category : #utilities }
+{ #category : #'accessing - tags' }
 TheManifestBuilder class >> truePositiveEndTag [
 	"the string that identifies uniquely the end of a selector who give  the set of false positive for a rule"
 	
@@ -331,15 +345,15 @@ TheManifestBuilder >> containsTruePositive: aItem onRule: ruleId version: versio
 
 { #category : #manifest }
 TheManifestBuilder >> createManifestNamed: packageName [
-	|tag|
-	tag := self class manifestTag.
-	manifestClass := PackageManifest subclass: (tag, packageName onlyLetters) asSymbol
-			instanceVariableNames: ''
-			classVariableNames: ''
-			poolDictionaries: ''
-			package: packageName.
+	 
+	manifestClass := PackageManifest 
+							subclass: (self class manifestClassNameFor: packageName) 
+							instanceVariableNames: ''
+							classVariableNames: ''
+							poolDictionaries: ''
+							package: packageName.
 	manifestClass 
-		tagWith: tag;
+		tagWith: self class manifestTag;
 		comment: self class manifestClassComment.
 	^ manifestClass
 ]

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -171,8 +171,7 @@ ReleaseTest >> testManifestNamesAccordingToPackageNames [
 	"Make sure package name and manifest name are in synch"
 	
 	|manifestClasses actualManifestNames expectedManifestNames |
-	manifestClasses := Smalltalk allClasses select: [:each |
-								(each name beginsWith: 'Manifest') ].
+	manifestClasses := self class environment allClasses select: [:each | each isManifest ].
 	actualManifestNames := (manifestClasses collect: [:each | each name ]) sorted.
 	expectedManifestNames := manifestClasses 
 										collect: [:each | TheManifestBuilder manifestClassNameFor: each package name ].

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -167,6 +167,19 @@ ReleaseTest >> testLocalMethodsOfTheClassShouldNotBeRepeatedInItsTraits [
 ]
 
 { #category : #tests }
+ReleaseTest >> testManifestNamesAccordingToPackageNames [
+	"Make sure package name and manifest name are in synch"
+	
+	|manifestClasses actualManifestNames expectedManifestNames |
+	manifestClasses := Smalltalk allClasses select: [:each |
+								(each name beginsWith: 'Manifest') ].
+	actualManifestNames := (manifestClasses collect: [:each | each name ]) sorted.
+	expectedManifestNames := manifestClasses 
+										collect: [:each | TheManifestBuilder manifestClassNameFor: each package name ].
+	self assert: actualManifestNames equals: expectedManifestNames 
+]
+
+{ #category : #tests }
 ReleaseTest >> testMethodsWithUnboundGlobals [
 	| methodsWithUnboundGlobals |
 	"Ensure the environment is clean"


### PR DESCRIPTION
- proper categorization of "accessing methods" on class side
- refactor so that we have a proper #manifestClassNameFor: aPackageName on class side instead of hiding the name
  building within a method
- use #isAlphaNumeric instead of #onlyLetters as we have packages like "Spec" and "Spec2" which now would
   have different manifest names (instead of a bad collision)
- add a release test that checks that package name and manifest names are in synch

- Fixes #5725