### PR TITLE
Compiler: remove old deprecated Compiler API

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -317,54 +317,6 @@ OpalCompiler >> compile: textOrString [
 		compile.
 ]
 
-{ #category : #'old - deprecated' }
-OpalCompiler >> compile: textOrStream in: aClass classified: aCategory notifying: aRequestor ifFail: aFailBlock [
-	self
-		deprecated: 'Please use new compiler API instead'
-		transformWith:
-			'`@receiver compile: `@statements1 in: `@statements2 classified: `@statements3 notifying: `@statements4 ifFail: `@statements5'
-				-> '`@receiver 	source:  `@statements1; class: `@statements2; requestor: `@statements4; failBlock: `@statements5; parse'.
-	^ self
-		source: textOrStream;
-		class: aClass;
-		requestor: aRequestor;
-		failBlock: aFailBlock;
-		parse
-]
-
-{ #category : #'old - deprecated' }
-OpalCompiler >> compile: textOrStream in: aClass notifying: aRequestor ifFail: aFailBlock [
-	self
-		deprecated: 'Please use new compiler API instead'
-		transformWith:
-			'`@receiver compile: `@statements1 in: `@statements2 notifying: `@statements3 ifFail: `@statements4'
-				-> '`@receiver source: `@statements1; class: `@statements2; requestor: `@statements3; failBlock: `@statements4; parse'.
-	^ self
-		source: textOrStream;
-		class: aClass;
-		requestor: aRequestor;
-		failBlock: aFailBlock;
-		parse
-]
-
-{ #category : #'old - deprecated' }
-OpalCompiler >> compileNoPattern: textOrStream in: aClass context: aContext notifying: aRequestor ifFail: aFailBlock [
-	self
-		deprecated: 'Please use new compiler API instead'
-		transformWith:
-			'`@receiver compileNoPattern: `@statements1 in: `@statements2 context: `@statements3 notifying: `@statements4 ifFail: `@statements5'
-				-> '`@receiver source: `@statements1; class: `@statements2; context: `@statements3; requestor: `@statements4; noPattern: true; failBlock: `@statements5; parse'.
-
-	^self 
-		source: textOrStream;
-		class: aClass;
-		context: aContext;
-		requestor: aRequestor;
-		noPattern: true;
-		failBlock: aFailBlock;
-		parse
-]
-
 { #category : #accessing }
 OpalCompiler >> compiledMethodTrailer: bytes [
 	self compilationContext compiledMethodTrailer: bytes
@@ -431,112 +383,6 @@ OpalCompiler >> evaluate: textOrString [
 		evaluate
 ]
 
-{ #category : #'old - deprecated' }
-OpalCompiler >> evaluate: textOrString for: anObject logged: logFlag [
-	self
-		deprecated: 'Please use new compiler API instead'
-		transformWith:
-			'`@receiver evaluate: `@statements1 for: `@statements2 logged: `@statements3'
-				->
-					'`@receiver source: `@statements1; logged: `@statements3; receiver: `@statements2; evaluate'.
-	^ self
-		source: textOrString;
-		logged: logFlag;
-		receiver: anObject;
-		evaluate
-]
-
-{ #category : #'old - deprecated' }
-OpalCompiler >> evaluate: textOrString for: anObject notifying: aController logged: logFlag [
-	self
-		deprecated: 'Please use new compiler API instead'
-		transformWith:
-			'`@receiver evaluate: `@statements1 for: `@statements2 notifying: `@statements3 logged: `@statements4'
-				-> '`@receiver source: `@statements1; logged: `@statements2; receiver: `@statements3; requestor: `@statements4; evaluate'.
-	^ self
-		source: textOrString;
-		logged: logFlag;
-		receiver: anObject;
-		requestor: aController;
-		evaluate
-]
-
-{ #category : #'old - deprecated' }
-OpalCompiler >> evaluate: aString in: aContext to: aReceiver [
-	self
-		deprecated: 'Please use new compiler API instead'
-		transformWith: '`@receiver evaluate: `@statements1 in: `@statements2 to: `@statements3' 
-						-> '`@receiver source: `@statements1; context: `@statements2; receiver: `@statements3;  parse.'.
-	
-	^self
-		source: aString;
-		context: aContext;
-		receiver: aReceiver;
-		failBlock: [^ #failedDoit];
-		evaluate
-]
-
-{ #category : #'old - deprecated' }
-OpalCompiler >> evaluate: textOrStream in: aContext to: aReceiver notifying: aRequestor ifFail: aFailBlock [
-	self
-		deprecated: 'Please use new compiler API instead'
-		transformWith:
-			'`@receiver evaluate: `@statements1 in: `@statements2 to: `@statements3 notifying: `@statements4 ifFail: `@statements5'
-				->
-					'`@receiver source: `@statements1; context: `@statements2; receiver: `@statements3; requestor: `@statements4; failBlock: `@statements5; evaluate'.
-	^ self
-		source: textOrStream;
-		context: aContext;
-		receiver: aReceiver;
-		requestor: aRequestor;
-		failBlock: aFailBlock;
-		evaluate
-]
-
-{ #category : #'old - deprecated' }
-OpalCompiler >> evaluate: textOrStream in: aContext to: aReceiver notifying: aRequestor ifFail: aFailBlock logged: logFlag [
-	self
-		deprecated: 'Please use new compiler API instead'
-		transformWith:
-			'`@receiver evaluate: `@statements1 in: `@statements2 to: `@statements3 notifying: `@statements4 ifFail: `@statements5 logged:  `@statements6'
-				-> '`@receiver source: `@statements1; context: `@statements2; receiver: `@statements3; requestor: `@statements4; failBlock: `@statements5; logged: `@statements6; evaluate'.
-	^ self
-		source: textOrStream;
-		context: aContext;
-		receiver: aReceiver;
-		requestor: aRequestor;
-		failBlock: aFailBlock;
-		logged: logFlag;
-		evaluate
-]
-
-{ #category : #'old - deprecated' }
-OpalCompiler >> evaluate: textOrString logged: logFlag [
-	self
-		deprecated: 'Please use new compiler API instead'
-		transformWith: '`@receiver evaluate: `@statements1 logged: `@statements2' 
-			-> '`@receiver source: `@statements1; logged: `@statements2; evaluate'.
-	^ self
-		source: textOrString;
-		logged: logFlag;
-		evaluate
-]
-
-{ #category : #'old - deprecated' }
-OpalCompiler >> evaluate: textOrString notifying: aController logged: logFlag [ 
-	self
-		deprecated: 'Please use new compiler API instead'
-		transformWith: '`@receiver evaluate: `@statements1 notifying: `@statements2 logged: `@statements3' 
-						-> '`@receiver source: `@statements1; logged: `@statements2; requestor:  `@statements3; evaluate'.
-
-	^ self
-		source: textOrString;
-		logged: logFlag;
-		requestor: aController;
-		evaluate
-	
-]
-
 { #category : #accessing }
 OpalCompiler >> failBlock: aBlock [
 	self compilationContext failBlock: aBlock.
@@ -552,19 +398,6 @@ OpalCompiler >> format: textOrString [
 	
 	^self
 		source: textOrString;
-		format
-]
-
-{ #category : #'old - deprecated' }
-OpalCompiler >> format: textOrStream in: aClass notifying: aRequestor [
-	self
-		deprecated: 'Please use new compiler API instead'
-		transformWith: '`@receiver format: `@statements1 in: `@statements2 notifying: `@statements3' 
-					-> '`@receiver source:  `@statements1; class: `@statements2; requestor: `@statements3; format'.
-	^ self
-		source: textOrStream;
-		class: aClass;
-		requestor: aRequestor;
 		format
 ]
 
@@ -629,48 +462,6 @@ OpalCompiler >> parse: textOrString [
 	
 	^self
 		source: textOrString;
-		parse
-]
-
-{ #category : #'old - deprecated' }
-OpalCompiler >> parse: aString class: aClass [
-	self
-		deprecated: 'Please use new compiler API instead'
-		transformWith: '`@receiver parse: `@statements1 class: `@statements2' 
-						-> '`@receiver source: `@statements1; class: `@statements2; parse.'.
-	^self 
-		source: aString;
-		class: aClass;
-		parse
-]
-
-{ #category : #'old - deprecated' }
-OpalCompiler >> parse: aString class: aClass noPattern: aBoolean context: aContext notifying: req ifFail: aBlock [
-	self
-		deprecated: 'Please use new compiler API instead'
-		transformWith:
-			'`@receiver parse: `@statements1 class: `@statements2 noPattern: `@statements3 context: `@statements4 notifying: `@statements5 ifFail: `@statements6'
-				->'`@receiver source: `@statements1; class: `@statements2; noPattern: `@statements3; context: `@statements4; requestor: `@statements5; failBlock: `@statements6; parse.'.
-	^ self
-		source: aString;
-		class: aClass;
-		noPattern: aBoolean;
-		context: aContext;
-		requestor: req;
-		failBlock: aBlock;
-		parse
-]
-
-{ #category : #'old - deprecated' }
-OpalCompiler >> parse: textOrStream in: aClass notifying: req [
-	self
-		deprecated: 'Please use new compiler API instead'
-		transformWith:
-			'`@receiver parse: `@statements1 in: `@statements2 notifying: `@statements3' -> '`@receiver source: `@statements1; class: `@statements2; requestor: `@statements3; parse.'.
-	^ self
-		source: textOrStream;
-		class: aClass;
-		requestor: req;
 		parse
 ]
 
@@ -742,12 +533,4 @@ OpalCompiler >> transformDoit [
 		ifNotNil: [ast asDoitForContext: context].
 	"we need to set the compilation context in the new method node"
 	^ast compilationContext: self compilationContext
-]
-
-{ #category : #'old - deprecated' }
-OpalCompiler >> translate [
-	self
-		deprecated: 'Please use #parse instead'
-		transformWith: '`@receiver translate' -> '`@receiver parse'.
-	^self parse.
 ]


### PR DESCRIPTION
finally remove the old API. all the method where deprecated since a while, but we have to remove then eventually... lets do that now