### PR TITLE
5744 introduce deprecated90 and deprecate abstract compiler

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -19,6 +19,7 @@ BaselineOfPharo >> baseline: spec [
 			spec repository: repository; loads: #('IcebergSupport'). ].
 
 		spec package: 'Deprecated80'.
+		spec package: 'Deprecated90'.
 		spec package: 'Gofer-UI'.
 	]
 ]

--- a/src/Deprecated90/AbstractCompiler.class.st
+++ b/src/Deprecated90/AbstractCompiler.class.st
@@ -1,0 +1,16 @@
+"
+Class is deprecated. 
+
+We keep it for loading compatibility for a single Pharo iteration (so one is able to load possible subclasses and then rework)
+"
+Class {
+	#name : #AbstractCompiler,
+	#superclass : #Object,
+	#category : #'Deprecated90-OpalCompiler-Core'
+}
+
+{ #category : #testing }
+AbstractCompiler class >> isDeprecated [ 
+
+	^true
+]

--- a/src/Deprecated90/ManifestDeprecated90.class.st
+++ b/src/Deprecated90/ManifestDeprecated90.class.st
@@ -1,0 +1,13 @@
+"
+I contain the deprecated code of Pharo 9. I'll be removed in Pharo 10.
+"
+Class {
+	#name : #ManifestDeprecated90,
+	#superclass : #PackageManifest,
+	#category : #'Deprecated90-Manifest'
+}
+
+{ #category : #testing }
+ManifestDeprecated90 class >> isDeprecated [
+	^ true
+]

--- a/src/Deprecated90/package.st
+++ b/src/Deprecated90/package.st
@@ -1,0 +1,1 @@
+Package { #name : #Deprecated90 }

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -60,7 +60,7 @@ SystemDependenciesTest >> knownBasicToolsDependencies [
 	"ideally this list should be empty"	
 	self flag: #todo. "The Deprecated80 dependency should soon vanish. This is just the time we finish Spec migration."
 	^ #('AST-Core-Tests' 'Athens-Cairo' 'Athens-Core' "Those are added for the development of Spec2 and should probably be removed"
-	#'Athens-Morphic' #NautilusRefactoring #'Refactoring-Critics' #'Reflectivity-Tools' #Shout 'ParametrizedTests' 'Deprecated80')
+	#'Athens-Morphic' #NautilusRefactoring #'Refactoring-Critics' #'Reflectivity-Tools' #Shout 'ParametrizedTests' 'Deprecated80' 'Deprecated90')
 ]
 
 { #category : #'known dependencies' }
@@ -84,8 +84,8 @@ SystemDependenciesTest >> knownIDEDependencies [
 
 	"ideally this list should be empty"	
 	
-	self flag: #todo. "The Deprecated80 dependency should soon vanish. This is just the time we finish Spec migration."
-	^ #(Deprecated80)
+	self flag: #todo. "The Deprecated80/Deprecated90 dependency should soon vanish. This is just the time we finish Spec migration."
+	^ #(Deprecated80 Deprecated90)
 ]
 
 { #category : #'known dependencies' }
@@ -152,7 +152,7 @@ SystemDependenciesTest >> knownUIDependencies [
 
 	self flag: #todo. "The Deprecated80 dependency should soon vanish. This is just the time we finish Spec migration."
 	^ #('AST-Core-Tests'  'Athens-Cairo' 'Athens-Core' "Those are added for the development of Spec2 and should probably be removed"
-	#'Athens-Morphic' #RecentSubmissions #'Refactoring-Critics' #'Refactoring-Environment' #'Reflectivity-Tools' #Shout #'Tool-Diff' #'Tool-FileList' #'Tool-ProcessBrowser' #'Tool-Profilers' 'Deprecated80')
+	#'Athens-Morphic' #RecentSubmissions #'Refactoring-Critics' #'Refactoring-Environment' #'Reflectivity-Tools' #Shout #'Tool-Diff' #'Tool-FileList' #'Tool-ProcessBrowser' #'Tool-Profilers' 'Deprecated80' 'Deprecated90')
 ]
 
 { #category : #utilities }


### PR DESCRIPTION
Introduce Deprecated90 and deprecate AbstractCompiler

- introduce a package for deprecated classes and methods for Pharo 9 iteration
- add and deprecated AbstractCompiler so code who used it can be loaded and reworked
(see #5740 who just removed it)

Fix #5744
