### PR TITLE
add-possibility-to-do-cmd-click-on-symbols

### DIFF
--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1144,12 +1144,22 @@ at once, but for ordinary literal arrays, style every node"
 
 { #category : #visiting }
 SHRBTextStyler >> visitLiteralValueNode: aLiteralValueNode [
-	| value |
+	| value link |
 	value := aLiteralValueNode value.
-	self 
-		addStyle: (self literalStyleSymbol: value)
-		attribute: (TextClassLink class: value class)
-		forNode: aLiteralValueNode
+	
+	
+	"We can have 3 different kind of links from a literal: 
+	- In case it is a symbol representing a class, we want to return a TextClassLink to browse the class or its references
+	- In case it is another symbol, we want to return a TextMethodLink to browser the implementors or senders of this selector
+	- In case it is another literal value, we return a TextClassLink to browse the class defining this litera."
+	link := value isSymbol
+		ifTrue: [
+			self class environment
+				at: value
+				ifPresent: [ :class | TextClassLink class: class ]
+				ifAbsent: [ TextMethodLink selector: value ] ]
+		ifFalse: [ TextClassLink class: value class ].
+	self addStyle: (self literalStyleSymbol: value) attribute: link forNode: aLiteralValueNode
 ]
 
 { #category : #visiting }

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -64,8 +64,8 @@ SHRBTextStyler class >> blueStyleTable [
 	"
 	<styleTable: 'Blue'>
 								
- ^ #(
 			"(symbol color [emphasisSymbolOrArray [textStyleName [pixelHeight]]])" 
+ ^ #(
 			(default 								black)
 			(invalid 									red)
 			(excessCode 							red)
@@ -197,8 +197,8 @@ SHRBTextStyler class >> darkStyleTable [
 	"
 	<styleTable: 'Dark'>
 
- ^ #(
 			"(symbol color [emphasisSymbolOrArray [textStyleName [pixelHeight]]])" 
+ ^ #(
 			(default 								white)
 			(invalid 								'FF8A80')
 			(excessCode 							'FF8A80')
@@ -391,8 +391,8 @@ SHRBTextStyler class >> solarizedStyleTable [
 	"
 	<styleTable: 'Solarized'>
 								
- ^ #(
 			"(symbol color [emphasisSymbolOrArray [textStyleName [pixelHeight]]])" 
+ ^ #(
 			(default 								('657A81' muchDarker))
 			(invalid 									red)
 			(excessCode 							red)
@@ -540,8 +540,8 @@ SHRBTextStyler class >> tangoStyleTable [
 	"
 	<styleTable: 'Tango'>
 								
- ^ #(
 			"(symbol color [emphasisSymbolOrArray [textStyleName [pixelHeight]]])" 
+ ^ #(
 			(default 								black)
 			(invalid 									red)
 			(excessCode 							red)
@@ -684,8 +684,8 @@ SHRBTextStyler class >> vintageStyleTable [
 	"
 	<styleTable: 'Vintage'>
 								
- ^ #(
 			"(symbol color [emphasisSymbolOrArray [textStyleName [pixelHeight]]])" 
+ ^ #(
 			(default 								black)
 			(invalid 									red)
 			(excessCode 							red)

--- a/src/System-Support-Tests/SmalltalkImageTest.class.st
+++ b/src/System-Support-Tests/SmalltalkImageTest.class.st
@@ -8,6 +8,14 @@ Class {
 }
 
 { #category : #'tests-arguments' }
+SmalltalkImageTest >> testAtIfPresentIfAbsent [
+	| image |
+	image := SmalltalkImage current.
+	self assert: (image at: self class name asSymbol ifPresent: [ :c | true ] ifAbsent: [ false ]).
+	self deny: (image at: #ImprobableClassNameForTest124029 ifPresent: [ :c | true ] ifAbsent: [ false ])
+]
+
+{ #category : #'tests-arguments' }
 SmalltalkImageTest >> testExtractAllKinds [
 	| args extract keys |
 	args := #('ArgWithoutMinus1' '-ArgWithMinus1' 'ArgWithoutMinus2' 'ArgWithoutMinus3' '-ArgWithMinus2').

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -220,6 +220,13 @@ SmalltalkImage >> at: key ifPresent: aBlock [
 ]
 
 { #category : #'to clean later' }
+SmalltalkImage >> at: key ifPresent: aBlock ifAbsent: anotherBlock [
+	"Lookup the given key in the globals. If it is present, answer the value of evaluating the given block with the value associated with the key. Otherwise answer the value of the second block."
+
+	^ globals at: key ifPresent: aBlock ifAbsent: anotherBlock
+]
+
+{ #category : #'to clean later' }
 SmalltalkImage >> at: aKey put: anObject [ 
 	"Set the global at key to be anObject.  If key is not found, create a
 	new entry for key and set is value to anObject. Answer anObject."
@@ -319,8 +326,8 @@ SmalltalkImage >> changesSuffix [
 ]
 
 { #category : #'class and trait names' }
-SmalltalkImage >> classNamed: className [ 
-	^globals classOrTraitNamed: className.
+SmalltalkImage >> classNamed: className [
+	^ globals classOrTraitNamed: className
 ]
 
 { #category : #'class and trait names' }
@@ -449,12 +456,12 @@ SmalltalkImage >> compiler [
 		environment: self globals
 ]
 
-{ #category : #acccessing }
+{ #category : #accessing }
 SmalltalkImage >> compilerClass [
 	^ self class compilerClass
 ]
 
-{ #category : #acccessing }
+{ #category : #accessing }
 SmalltalkImage >> compilerClass: aClass [
 
 	self class compilerClass: aClass


### PR DESCRIPTION
Add possibility to do cmd + (shift +) click on symbols. 

Currently, when you do cmd + (shift +) click on a class or method, you can browse the class, its references, the implementors or the senders. 

With this change, when you do:
- cmd + click on a symbol representing a class, then it browse it. 
- cmd + shitf + click on a symbol representing a class, then it browse its references. 
- cmd + click on a symbol representing a selector, then it browse its implementors. 
- cmd + shift + click on a symbol representing a selector, then it browse its senders.