### PR TITLE
Compiler: Small Test Cleanup

### DIFF
--- a/src/Flashback-Decompiler-Tests/FBDDecompilerTest.class.st
+++ b/src/Flashback-Decompiler-Tests/FBDDecompilerTest.class.st
@@ -50,7 +50,6 @@ FBDDecompilerTest >> decompileThenRecompile: originalMethod [
 
 { #category : #accessing }
 FBDDecompilerTest >> exampleClass [
-	<sampleInstance>
 	^ FBDExamples 
 ]
 

--- a/src/OpalCompiler-Tests/OCBytecodeDecompilerExamplesTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeDecompilerExamplesTest.class.st
@@ -549,14 +549,13 @@ OCBytecodeDecompilerExamplesTest >> testExampleToDoValue [
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleWhileModificationAfterNotInlined [
-	| ir method newMethod instance |
+	| ir method newMethod |
 	method := (OCOpalExamples >> #exampleWhileModificationAfterNotInlined) parseTree generate.
-	instance := OCOpalExamples new.
-
+	
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleWhileModificationAfterNotInlined
+	self assert: (newMethod valueWithReceiver: OCOpalExamples new arguments: #()) equals: OCOpalExamples new exampleWhileModificationAfterNotInlined
 ]
 
 { #category : #'tests-blocks-optimized' }
@@ -573,38 +572,35 @@ OCBytecodeDecompilerExamplesTest >> testExampleWhileModificationBefore [
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleWhileModificationBeforeNotInlined [
-	| ir method newMethod instance |
+	| ir method newMethod |
 	method := (OCOpalExamples >> #exampleWhileModificationBeforeNotInlined) parseTree generate.
-	instance := OCOpalExamples new.
 
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleWhileModificationBeforeNotInlined
+	self assert: (newMethod valueWithReceiver: OCOpalExamples new arguments: #()) equals:  OCOpalExamples new exampleWhileModificationBeforeNotInlined
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleWhileWithTemp [
-	| ir method newMethod instance |
+	| ir method newMethod |
 	method := (OCOpalExamples >> #exampleWhileWithTemp) parseTree generate.
-	instance := OCOpalExamples new.
 
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleWhileWithTemp
+	self assert: (newMethod valueWithReceiver: OCOpalExamples new arguments: #()) equals: OCOpalExamples new exampleWhileWithTemp
 ]
 
 { #category : #'tests-blocks-optimized' }
 OCBytecodeDecompilerExamplesTest >> testExampleWhileWithTempNotInlined [
-	| ir method newMethod instance |
+	| ir method newMethod |
 	method := (OCOpalExamples >> #exampleWhileWithTempNotInlined) parseTree generate.
-	instance := OCOpalExamples new.
 
 	ir := IRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
-	self assert: (newMethod valueWithReceiver: instance arguments: #()) equals: instance exampleWhileWithTempNotInlined
+	self assert: (newMethod valueWithReceiver: OCOpalExamples new arguments: #()) equals: OCOpalExamples new exampleWhileWithTempNotInlined
 ]
 
 { #category : #'tests-variables' }

--- a/src/OpalCompiler-Tests/OCOpalExamples.class.st
+++ b/src/OpalCompiler-Tests/OCOpalExamples.class.st
@@ -69,7 +69,6 @@ OCOpalExamples >> exampleAndValueWithShortcircuitEffect [
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleBlockArgument [
-	<sampleInstance>
 	| block block1 block2 |
 	block := [ :arg | | temp | temp := arg. [ temp ] ].
 	block1 := block value: 1.
@@ -81,7 +80,6 @@ OCOpalExamples >> exampleBlockArgument [
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleBlockExternal [
-	<sampleInstance>
 	| t |
 	t := 1.
 	^[t] value.
@@ -89,7 +87,6 @@ OCOpalExamples >> exampleBlockExternal [
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleBlockExternal2 [
-	<sampleInstance>
 	| t1 t2 |
 	t1 :=  t2 := 1.
 	^[t1 + t2] value.
@@ -97,7 +94,6 @@ OCOpalExamples >> exampleBlockExternal2 [
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleBlockExternalArg [
-	<sampleInstance>
 	| t  |
 	t := 1.
 	^[:a | t + a] value: 1.
@@ -105,7 +101,6 @@ OCOpalExamples >> exampleBlockExternalArg [
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleBlockExternalNested [
-	<sampleInstance>
 	| t s |
 	t := s := 1.
 	^[[s] value +   t   ] value.
@@ -113,14 +108,11 @@ OCOpalExamples >> exampleBlockExternalNested [
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleBlockInternal [
-	<sampleInstance>
-	
 	^[ | t | t := 1. t] value
 ]
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleBlockMethodArgument: arg [
-	<sampleInstance>
 	|  block |
 	block := [ :blockarg | blockarg + arg].
 	self assert: ((block value: 2) = (arg + 2)).
@@ -129,14 +121,13 @@ OCOpalExamples >> exampleBlockMethodArgument: arg [
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleBlockNested [
-	<sampleInstance>
 	
 	^[ [1] value] value
 ]
 
 { #category : #'examples-variables' }
 OCOpalExamples >> exampleClassVariableAssignment [
-	<sampleInstance>
+
 	ClassVariable := 1
 ]
 
@@ -159,55 +150,46 @@ OCOpalExamples >> exampleEmptyMethod [
 
 { #category : #'examples-andor' }
 OCOpalExamples >> exampleFalseAndAnything: anything [
-	<sampleInstance>
 	^ false and: [ anything ]
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleFalseIfFalse [
-	<sampleInstance>
 	^false ifFalse: [1]
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleFalseIfFalseIfTrue [
-	<sampleInstance>
 	^false ifFalse: [iVar := 'false'] ifTrue: [ self error ]
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleFalseIfFalseWithEffect [
-	<sampleInstance>
 	^false ifFalse: [iVar := 17]
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleFalseIfTrue [
-	<sampleInstance>
 	^false ifTrue: [1]
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleFalseIfTrueIfFalse [
-	<sampleInstance>
 	^false ifTrue: [ self error ] ifFalse: [iVar := 'false'] 
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleFalseIfTrueWithEffect [
-	<sampleInstance>
 	^false ifTrue: [iVar := 17]
 ]
 
 { #category : #'examples-andor' }
 OCOpalExamples >> exampleFalseOrAnything: anything [
-	<sampleInstance>
 	^ false or: [ anything ]
 ]
 
 { #category : #'examples-variables' }
 OCOpalExamples >> exampleForBlockArgument [
-	<sampleInstance>
 	|b|
 	b:= [ :blockArg | 1 ].
 	^ b
@@ -215,15 +197,12 @@ OCOpalExamples >> exampleForBlockArgument [
 
 { #category : #'examples-variables' }
 OCOpalExamples >> exampleForInlinedBlockArgument [
-	<sampleInstance>
-	
 	1 ifNotNil:[ :value | ^ value ].
 
 ]
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleIfFalse [
-	<sampleInstance>
 	true
 		ifTrue: [  ]
 		ifFalse: [ ^ 1 ].
@@ -232,19 +211,16 @@ OCOpalExamples >> exampleIfFalse [
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleIfFalseIfTrue [
-	<sampleInstance>
 	true ifFalse: [^1] ifTrue: [^2].
 ]
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleIfNotNilArg [
-	<sampleInstance>
 	^1 even ifNotNil: [ :arg | arg not ]
 ]
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleIfNotNilReturnNil [
-	<sampleInstance>
 	^nil ifNotNil: [ :arg | arg not ]
 ]
 
@@ -256,13 +232,11 @@ OCOpalExamples >> exampleIfTrue [
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleIfTrueIfFalse [
-	<sampleInstance>
 	 1 <2 ifTrue: [^'result'] ifFalse: [2].
 ]
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleInlineBlockCollectionLR3 [
-	<sampleInstance>
 	| col |
 	col := OrderedCollection new.
 	1 to: 11 do: [ :each | | i | i := each. col add: [ i ]. i := i + 1 ].
@@ -272,83 +246,61 @@ OCOpalExamples >> exampleInlineBlockCollectionLR3 [
 
 { #category : #'examples-variables' }
 OCOpalExamples >> exampleInstanceVariableAssignment [
-	<sampleInstance>
 	iVar := 1
 ]
 
 { #category : #'examples-literals' }
 OCOpalExamples >> exampleLiteralArray [
-	<sampleInstance>
-
 	^ #( 1 2 3)
 ]
 
 { #category : #'examples-literals' }
 OCOpalExamples >> exampleLiteralBoxedFloat [
-	<sampleInstance>
-
 	^ 9.999999999999996e157
 ]
 
 { #category : #'examples-literals' }
 OCOpalExamples >> exampleLiteralByteArray [
-	<sampleInstance>
-
 	^ #[ 1 2 3 ]
 ]
 
 { #category : #'examples-literals' }
 OCOpalExamples >> exampleLiteralByteString [
-	<sampleInstance>
-
 	^ 'bytestring'
 ]
 
 { #category : #'examples-literals' }
 OCOpalExamples >> exampleLiteralByteSymbol [
-	<sampleInstance>
-
 	^ #bytesymbol
 ]
 
 { #category : #'examples-literals' }
 OCOpalExamples >> exampleLiteralCharacter [
-	<sampleInstance>
-
 	^ $H
 ]
 
 { #category : #'examples-literals' }
 OCOpalExamples >> exampleLiteralFloat [
-	<sampleInstance>
-
 	^ 1.2
 ]
 
 { #category : #'examples-literals' }
 OCOpalExamples >> exampleLiteralLargeInteger [
-	<sampleInstance>
-
 	^ 16rFFFFFFFFFFFFFFFF
 ]
 
 { #category : #'examples-literals' }
 OCOpalExamples >> exampleLiteralWideString [
-	<sampleInstance>
-
 	^ 'áèîöÑü'
 ]
 
 { #category : #'examples-literals' }
 OCOpalExamples >> exampleLiteralWideSymbol [
-	<sampleInstance>
-
 	^ #'áèîöÑü'
 ]
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleMethodTempInNestedBlock [
-	<sampleInstance>
 	| temp block |
 	temp := 0.
 	block := [ [ temp ] ].
@@ -361,7 +313,6 @@ OCOpalExamples >> exampleMethodTempInNestedBlock [
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleMethodWithOptimizedBlocksA [
-	<sampleInstance>
 	| s c |
 	s := self isNil
 			ifTrue: [| a | a := 'isNil'. a]
@@ -374,8 +325,6 @@ OCOpalExamples >> exampleMethodWithOptimizedBlocksA [
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleNestedBlockScoping [
-	<sampleInstance>
-
 	| b c z |
 	b := [:a | 
 			z := 2.
@@ -387,8 +336,6 @@ OCOpalExamples >> exampleNestedBlockScoping [
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleNewArray [
-	<sampleInstance>
-
 	| temp |
 	
 	temp := Array new: 3.
@@ -397,44 +344,36 @@ OCOpalExamples >> exampleNewArray [
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleNilIfNil [
-	<sampleInstance>
 	^nil ifNil: [ iVar := 17 ]
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleNilIfNotNil [
-	<sampleInstance>
 	^nil ifNotNil: [ self error ]
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleNilIfNotNilWithArgument [
-	<sampleInstance>
 	^nil ifNotNil: [ :arg | self error ]
 ]
 
 { #category : #'examples-literals' }
 OCOpalExamples >> exampleNonSpecialLiteralInteger [
-	<sampleInstance>
-
 	^ 10
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleNotNilIfNil [
-	<sampleInstance>
 	^1 ifNil: [ self error ]
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleNotNilIfNotNil [
-	<sampleInstance>
 	^1 ifNotNil: [ iVar := 17 ]
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleNotNilIfNotNilWithArgument [
-	<sampleInstance>
 	^1 ifNotNil: [ :arg | iVar := arg ]
 ]
 
@@ -452,8 +391,6 @@ OCOpalExamples >> exampleOrValueWithShortcircuitEffect [
 
 { #category : #'examples-pragmas' }
 OCOpalExamples >> examplePrimitiveErrorCode [
-	<sampleInstance>
-	
 	<primitive: 60 error: code >
 	
 	^ code
@@ -463,7 +400,6 @@ OCOpalExamples >> examplePrimitiveErrorCode [
 
 { #category : #'examples-pragmas' }
 OCOpalExamples >> examplePrimitiveErrorCodeModule [
-	<sampleInstance>
 	"Primitive. Attempt to load a module of the given name.
 	Fail if module cannot be found, or cannot be loaded,
 	or failed to initialize"
@@ -474,29 +410,23 @@ OCOpalExamples >> examplePrimitiveErrorCodeModule [
 
 { #category : #'examples-pragmas' }
 OCOpalExamples >> examplePrimitiveErrorModule [
-	<sampleInstance>
-	
 	<primitive: 'primFunction' error: errorCode module: 'primModule'>
 	^ errorCode
 ]
 
 { #category : #'examples-pragmas' }
 OCOpalExamples >> examplePrimitiveModuleError [
-	<sampleInstance>
 	<primitive: 'primFunction'  module: 'primModule' error: errorCode >
 	^ errorCode
 ]
 
 { #category : #'examples-variables' }
 OCOpalExamples >> examplePushArgumentVariable: argument [
-	<sampleInstance>
-	
 	self message: argument
 ]
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> examplePushArray [
-	<sampleInstance>
 	| t |
 
 	{1 .t:=1}.
@@ -505,41 +435,32 @@ OCOpalExamples >> examplePushArray [
 
 { #category : #'examples-misc' }
 OCOpalExamples >> examplePushBigDynamicLiteralArray [
-	<sampleInstance>
 	"This array should have a size more than 127 elements"
 	self message: { 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 .  255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 }
 ]
 
 { #category : #'examples-variables' }
 OCOpalExamples >> examplePushClassVariable [
-	<sampleInstance>
-	
 	self result: ClassVariable
 ]
 
 { #category : #'examples-misc' }
 OCOpalExamples >> examplePushDynamicLiteralArray [
-	<sampleInstance>
 	^  { 1 . 1+2 }
 ]
 
 { #category : #'examples-variables' }
 OCOpalExamples >> examplePushInstanceVariable [
-	<sampleInstance>
-	
 	self result: iVar
 ]
 
 { #category : #'examples-literals' }
 OCOpalExamples >> examplePushNonSpecialSmallInteger [
-	<sampleInstance>
 	self result: 10
 ]
 
 { #category : #'examples-variables' }
 OCOpalExamples >> examplePushTemporaryVariable [
-	<sampleInstance>
-	
 	| temporary |
 	temporary := iVar.
 	self result: temporary
@@ -547,7 +468,6 @@ OCOpalExamples >> examplePushTemporaryVariable [
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleRepeatEffect [
-	<sampleInstance>
 	<compilerOptions: #(+ #optionInlineRepeat)>
 	| i |
 	i := 1.
@@ -559,7 +479,6 @@ OCOpalExamples >> exampleRepeatEffect [
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleRepeatValue [
-	<sampleInstance>
 	<compilerOptions: #(+ #optionInlineRepeat)>
 	| i |
 	i := 1.
@@ -571,13 +490,11 @@ OCOpalExamples >> exampleRepeatValue [
 
 { #category : #'examples-simple' }
 OCOpalExamples >> exampleReturn1plus2 [
-	<sampleInstance>
 	^1+2
 ]
 
 { #category : #'examples-simple' }
 OCOpalExamples >> exampleReturn42 [
-	<sampleInstance>
 	^42
 ]
 
@@ -589,81 +506,68 @@ OCOpalExamples >> exampleSelf [
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleSelfReceiver [
-	<sampleInstance>
-	self foo.
+	self foo
 ]
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleSimpleBlock [
-	<sampleInstance>
-	^[1].
+	^[1]
 ]
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleSimpleBlockArgument1 [
-	<sampleInstance>
-	^[:a | a ] value: 1.
+	^[:a | a ] value: 1
 ]
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleSimpleBlockArgument2 [
-	<sampleInstance>
-	^[:a :b | a + b ] value: 1 value: 1.
+	^[:a :b | a + b ] value: 1 value: 1
 ]
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleSimpleBlockArgument3 [
-	<sampleInstance>
-	^[:a :b :c | a + b + c ] value: 1 value: 1 value: 1.
+	^[:a :b :c | a + b + c ] value: 1 value: 1 value: 1
 ]
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleSimpleBlockArgument4 [
-	<sampleInstance>
-	^[:a :b :c :d | a + b + c  + d] value: 1 value: 1 value: 1 value: 1. 
+	^[:a :b :c :d | a + b + c  + d] value: 1 value: 1 value: 1 value: 1
 ]
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleSimpleBlockArgument5 [
-	<sampleInstance>
-	^[:a :b :c :d :e| a + b + c  + d + e] valueWithArguments: #(1 1 1 1 1). 
+	^[:a :b :c :d :e| a + b + c  + d + e] valueWithArguments: #(1 1 1 1 1)
 ]
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleSimpleBlockEmpty [
-	<sampleInstance>
-	^[] value.
+	^[] value
 ]
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleSimpleBlockLocal [
-	<sampleInstance>
-	^[ :each | | t |  t:= each. t   ] value: 5.
+	^[ :each | | t |  t:= each. t   ] value: 5
 ]
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleSimpleBlockLocalIf [
-	<sampleInstance>
-	^true ifTrue: [ | hallo |  hallo := 1 . hallo].
+	^true ifTrue: [ | hallo |  hallo := 1 . hallo]
 ]
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleSimpleBlockLocalIfNested [
-	<sampleInstance>
-	^true ifTrue: [| hallo |  [  hallo := 1 . hallo] value] .
+	^true ifTrue: [| hallo |  [  hallo := 1 . hallo] value]
 ]
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleSimpleBlockLocalWhile [
-	<sampleInstance>
 	|a|
 	a := true.
-	^[: b | [a] whileTrue: [ | hallo |  a := false. hallo := 1 . hallo]]value: 1.
+	^[: b | [a] whileTrue: [ | hallo |  a := false. hallo := 1 . hallo]] value: 1
 ]
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleSimpleBlockNested [
-	<sampleInstance>
 	| a match dict | 
 
 	a  := #(a b c d).
@@ -674,38 +578,31 @@ OCOpalExamples >> exampleSimpleBlockNested [
 		(match := a indexOf: each) > 0 ifTrue:
 			[dict at: index put: (a at: match)]].
 
-	^ dict.
+	^ dict
 ]
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleSimpleBlockReturn [
-	<sampleInstance>
-	[^1] value.
+	[^1] value
 ]
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleSimpleBlockiVar [
-	<sampleInstance>
-	^[iVar] value.
+	^[iVar] value
 ]
 
 { #category : #'examples-variables' }
 OCOpalExamples >> exampleSuper [
-	<sampleInstance>
-	
 	self result: super
 ]
 
 { #category : #'examples-blocks' }
 OCOpalExamples >> exampleSuperReceiver [
-	<sampleInstance>
-	super foo.
+	super foo
 ]
 
 { #category : #'examples-variables' }
 OCOpalExamples >> exampleTemporaryVariableAssignment [
-	<sampleInstance>
-	
 	| temporary |
 	temporary := 17.
 	self message: temporary
@@ -713,14 +610,11 @@ OCOpalExamples >> exampleTemporaryVariableAssignment [
 
 { #category : #'examples-variables' }
 OCOpalExamples >> exampleThisContext [
-	<sampleInstance>
-	
 	self result: thisContext
 ]
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleTimesRepeatEffect [
-	<sampleInstance>
 	| foo |
 	foo := 1.
 	5 timesRepeat: [ foo := foo + 3 ] . 
@@ -729,13 +623,11 @@ OCOpalExamples >> exampleTimesRepeatEffect [
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleTimesRepeatValue [
-	<sampleInstance>
 	^ 5 timesRepeat: [ 1 + 2 ]   
 ]
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleToDoArgument [
-	<sampleInstance>
 	collection := OrderedCollection new.
 	1 to: 5 do: [ :index |
 		collection add:  [index]  ].
@@ -745,7 +637,6 @@ OCOpalExamples >> exampleToDoArgument [
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleToDoArgumentLimitIsExpression [
-	<sampleInstance>
 	| count sum |
 	count := 10.
 	sum := 0.
@@ -755,7 +646,6 @@ OCOpalExamples >> exampleToDoArgumentLimitIsExpression [
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleToDoArgumentNotInlined [
-	<sampleInstance>
 	| block |
 	block := [ :index |
 		collection add: [ index ] ].
@@ -765,7 +655,6 @@ OCOpalExamples >> exampleToDoArgumentNotInlined [
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleToDoInsideTemp [
-	<sampleInstance>
 	1 to: 5 do: [ :index | 
 		| temp | 
 		temp := index. 
@@ -775,7 +664,6 @@ OCOpalExamples >> exampleToDoInsideTemp [
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleToDoInsideTempNotInlined [
-	<sampleInstance>
 	| block |
 	block := [ :index | 
 		| temp | 
@@ -787,7 +675,6 @@ OCOpalExamples >> exampleToDoInsideTempNotInlined [
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleToDoOutsideTemp [
-	<sampleInstance>
 	| temp |
 	1 to: 5 do: [ :index | 
 		temp := index. 
@@ -797,7 +684,6 @@ OCOpalExamples >> exampleToDoOutsideTemp [
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleToDoOutsideTempNotInlined [
-	<sampleInstance>
 	| block temp |
 	block := [ :index | 
 		temp := index. 
@@ -808,8 +694,6 @@ OCOpalExamples >> exampleToDoOutsideTempNotInlined [
 
 { #category : #'examples-misc' }
 OCOpalExamples >> exampleToDoValue [
-	<sampleInstance>
-
 	^ 1 to: 2 do: [:each | each]
 	
 
@@ -817,8 +701,6 @@ OCOpalExamples >> exampleToDoValue [
 
 { #category : #'examples-misc' }
 OCOpalExamples >> exampleToDoValueLimitExpression [
-	<sampleInstance>
-
 	^ 2 to: 3+4 do: [:each | each]
 	
 
@@ -826,87 +708,77 @@ OCOpalExamples >> exampleToDoValueLimitExpression [
 
 { #category : #'examples-andor' }
 OCOpalExamples >> exampleTrueAndAnything: argument [
-	<sampleInstance>
 	^ true and: [ argument ]
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleTrueIfFalse [
-	<sampleInstance>
 	^true ifFalse: [1]
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleTrueIfFalseIfTrue [
-	<sampleInstance>
 	^true ifFalse: [ self error ] ifTrue: [iVar := 'true']
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleTrueIfFalseWithEffect [
-	<sampleInstance>
 	^true ifFalse: [iVar := 17]
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleTrueIfTrue [
-	<sampleInstance>
 	^true ifTrue: [1]
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleTrueIfTrueIfFalse [
-	<sampleInstance>
 	^true ifTrue: [iVar := 'true'] ifFalse: [ self error ]
 ]
 
 { #category : #'examples-conditionals' }
 OCOpalExamples >> exampleTrueIfTrueWithEffect [
-	<sampleInstance>
 	^true ifTrue: [iVar := 17]
 ]
 
 { #category : #'examples-andor' }
 OCOpalExamples >> exampleTrueOrAnything: anything [
-	<sampleInstance>
 	^ true or: [ anything ]
 ]
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleWhileModificationAfterNotInlined [
-	<sampleInstance>
 	| index block |
 	index := 0.
 	block := [ 
 		collection add: [ index ].
 		index := index + 1 ].
 	[ index < 5 ] whileTrue: block.
-	^collection "#(5 5 5 5 5)"
+	^collection collect: #value.
+	"#(5 5 5 5 5)"
 ]
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleWhileModificationBefore [
-	<sampleInstance>
 	| index |
 	collection := OrderedCollection new.
 	index := 0.
 	[ index < 5 ] whileTrue: [ 
 		index := index + 1.
 		collection add: [ index ] ].
-	 ^collection collect: #value.
+	^collection collect: #value.
 	"#(5 5 5 5 5)"
 ]
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleWhileModificationBeforeNotInlined [
-	<sampleInstance>
 	| index block |
 	index := 0.
 	block := [ 
 		index := index + 1.
 		collection add: [ index ] ].
 	[ index < 5 ] whileTrue: block.
-	^collection.
+	^collection collect: #value.
 	"#(5 5 5 5 5)"
 ]
 
@@ -928,19 +800,18 @@ OCOpalExamples >> exampleWhileNoModification [
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleWhileWithTemp [
-	<sampleInstance>
 	| index |
 	index := 0.
 	[ index < 5 ] whileTrue: [
 		| temp |
 		temp := index := index + 1.
 		collection add: [ temp ] ].
-	^collection "#(1 2 3 4 5)"
+	^collection collect: #value.
+	"#(1 2 3 4 5)"
 ]
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleWhileWithTempNotInlined [
-	<sampleInstance>
 	| index block |
 	index := 0.
 	block := [
@@ -948,18 +819,17 @@ OCOpalExamples >> exampleWhileWithTempNotInlined [
 		temp := index := index + 1.
 		collection add: [ temp ] ].
 	[ index < 5 ] whileTrue: block.
-	^collection "#(1 2 3 4 5)"
+	^collection collect: #value.
+	"#(1 2 3 4 5)"
 ]
 
 { #category : #'examples-variables' }
 OCOpalExamples >> exampleWithArgument: anArg [
-	<sampleInstance>
 	^ anArg
 ]
 
 { #category : #'examples-blocks-optimized' }
 OCOpalExamples >> exampleiVar [
-	<sampleInstance>
 	iVar := 1.
 	^iVar.
 ]


### PR DESCRIPTION
Small cleanup:
- improve some tests to return evaluated values
- remove #sampleIntance pragma from test data (as these are not exampke instances)