### PR TITLE
Revert "5724-Improve-AdditionalMethodStaterefersToLiteral"

### DIFF
--- a/src/Collections-Support/LookupKey.class.st
+++ b/src/Collections-Support/LookupKey.class.st
@@ -32,13 +32,6 @@ LookupKey >> = aLookupKey [
 		ifFalse: [^false]
 ]
 
-{ #category : #testing }
-LookupKey >> hasLiteral: literal [
-	^ self key == literal
-		or: [ self value == literal
-				or: [ self value isArray and: [ self value hasLiteral: literal ] ] ]
-]
-
 { #category : #comparing }
 LookupKey >> hash [
 	"Hash is reimplemented because = is implemented."

--- a/src/Kernel/AdditionalMethodState.class.st
+++ b/src/Kernel/AdditionalMethodState.class.st
@@ -362,9 +362,18 @@ AdditionalMethodState >> propertyValueAt: aKey ifAbsent: aBlock [
 
 { #category : #testing }
 AdditionalMethodState >> refersToLiteral: literal [
-	"Answer true if any literal in these properties is literal, even if embedded in array structure."
+	"Answer true if any literal in these properties is literal,
+	 even if embedded in array structure."
 	1 to: self basicSize do: [:i |
-		((self basicAt: i) hasLiteral: literal) ifTrue: [^true]].
+		| propertyOrPragma "<Association|Pragma>" |
+		propertyOrPragma := self basicAt: i.
+		(propertyOrPragma isVariableBinding
+			ifTrue: [propertyOrPragma key == literal
+					or: [propertyOrPragma value == literal
+					or: [propertyOrPragma value isArray
+						and: [propertyOrPragma value hasLiteral: literal]]]]
+			ifFalse: [propertyOrPragma hasLiteral: literal]) ifTrue:
+			[^true]].
 	^false
 ]
 


### PR DESCRIPTION
Reverts pharo-project/pharo#5731

This was not a good change: semantics are a bit odd: for Bindings, we want to only look into them deeply if they are in a property. Else not. I will revert it and put a comment.

(it does not add a bug this way but it is even more confusing as before)
