### PR TITLE
5560-string-scanning-optimization

### DIFF
--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -485,6 +485,7 @@ RBParserTest >> testParseFaultyMethod [
 		add: 'method: asd  ^ asd. n'; "invalid expresion after return"
 		add: 'method: asd  ^ {'; "Only Open a literal array"
 		add: 'selector '''; 
+		add: 'selector ''part1''''part2'; "string with escaped ' does not end"
 		add: 'selector #^';
 		add: 'selector ¿';
 		add: ':nl'.
@@ -543,6 +544,40 @@ RBParserTest >> testParseFaultyPragma [
 	self assert: node isMethod.
 	self assert: node pragmas size equals: 1.
 	self assert: node pragmas first isFaulty
+]
+
+{ #category : #'tests parsing' }
+RBParserTest >> testParseMethodWhichEndsWithUncompleteStringWithEscapedMarkAtTheEnd [
+	| node strangeMethod body statement message errorNode |
+	strangeMethod := '
+	selector  
+		|temp| 
+		temp := ''this is right'', ''wrong'''''.
+	node := self parseFaultyMethod: strangeMethod.
+
+	self assert: node isMethod.
+	self assert: node isFaulty.
+	self assertEmpty: node arguments.
+
+	body := node body.
+	self assert: body isSequence.
+	self assert: body isFaulty.
+	self assert: (body temporaries includes: (RBVariableNode named: 'temp')).
+
+	statement := body statements first.
+	self assert: statement isFaulty.
+	self assert: statement isAssignment.
+
+	message := statement value.
+	self assert: message isFaulty.
+	self assert: message arguments size equals: 1.
+
+	errorNode := message arguments at: 1.
+	self assert: errorNode isFaulty.
+	self
+		assert: errorNode value
+		equals: 'wrong'''.
+	self assert: errorNode errorMessage equals: 'Unmatched '' in string literal.' translated
 ]
 
 { #category : #'tests parsing' }

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -451,7 +451,7 @@ RBScanner >> scanLiteralCharacter [
 RBScanner >> scanLiteralString [
 	| string |
 	[string := stream upTo: $'.
-	stream peekBack = $' ifFalse: [ ^self scanError: 'test scan literal' ].
+	stream peekBack = $' ifFalse: [^ self scanError: 'Unmatched '' in string literal.'].
 	
 	self step = $'] whileTrue: [ 
 		buffer nextPutAll: string; nextPut: $'.

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -449,16 +449,18 @@ RBScanner >> scanLiteralCharacter [
 
 { #category : #'private-scanning' }
 RBScanner >> scanLiteralString [
-
-	self step.
-
-	[ currentCharacter ifNil: [ ^ self scanError: 'Unmatched '' in string literal.' ].
-	currentCharacter = $' and: [ self step ~= $' ]
-	]
-		whileFalse: [ buffer nextPut: currentCharacter.
-			self step
-			].
-	^ RBLiteralToken value: buffer contents start: tokenStart stop: self previousStepPosition
+	| string |
+	[string := stream upTo: $'.
+	stream peekBack = $' ifFalse: [ ^self scanError: 'test scan literal' ].
+	
+	self step = $'] whileTrue: [ 
+		buffer nextPutAll: string; nextPut: $'.
+		string := ''].
+	
+	buffer position = 0 ifFalse: [ 		
+		buffer nextPutAll: string.
+		string := buffer contents].	
+	^RBLiteralToken value: string start: tokenStart stop: self previousStepPosition
 ]
 
 { #category : #'private-scanning' }

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -450,10 +450,14 @@ RBScanner >> scanLiteralCharacter [
 { #category : #'private-scanning' }
 RBScanner >> scanLiteralString [
 	| string |
-	[stream atEnd ifTrue: [^ self scanError: 'Unmatched '' in string literal.'].
-	string := stream upTo: $'.
-	stream peekBack = $' ifFalse: [
+	[stream atEnd ifTrue: [
+		self step. "to handle eof"
+		^ self scanError: 'Unmatched '' in string literal.'].
+	string := stream upTo: $'. 
+	stream peekBack = $' ifFalse: [ 
+		"the peek logic here is because #upTo: does not tell if given char was found"
 		buffer nextPutAll: string.
+		self step. "to handle eof"
 		^ self scanError: 'Unmatched '' in string literal.'].
 	
 	self step = $'] whileTrue: [ 
@@ -463,7 +467,13 @@ RBScanner >> scanLiteralString [
 	buffer position = 0 ifFalse: [ 		
 		buffer nextPutAll: string.
 		string := buffer contents].	
-	^RBLiteralToken value: string start: tokenStart stop: self previousStepPosition
+	
+	"It's possible to use a plain Text for parsing.
+	In that case string here could be a Text instance but literal value must be a String"	
+	^RBLiteralToken 
+		value: string asString 
+		start: tokenStart 
+		stop: self previousStepPosition
 ]
 
 { #category : #'private-scanning' }

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -450,8 +450,11 @@ RBScanner >> scanLiteralCharacter [
 { #category : #'private-scanning' }
 RBScanner >> scanLiteralString [
 	| string |
-	[string := stream upTo: $'.
-	stream peekBack = $' ifFalse: [^ self scanError: 'Unmatched '' in string literal.'].
+	[stream atEnd ifTrue: [^ self scanError: 'Unmatched '' in string literal.'].
+	string := stream upTo: $'.
+	stream peekBack = $' ifFalse: [
+		buffer nextPutAll: string.
+		^ self scanError: 'Unmatched '' in string literal.'].
 	
 	self step = $'] whileTrue: [ 
 		buffer nextPutAll: string; nextPut: $'.


### PR DESCRIPTION
Optimization for string scanning by avoiding buffer overhead and by using optimized string implementation to lookup an element.
On my machine following test increases performance for 10 times:
```Smalltalk
source := String streamContents: [ :s | 
	s nextPutAll: 'longLiteralMethod'; cr; nextPutAll: '^'''.
	10000000 timesRepeat: [s nextPut: $1].
	s nextPutAll: ''''.
].
[10 timesRepeat: [RBParser parseMethod: source] ] timeToRun. 
"==> 0:00:00:01.282 with optimized #scanLitealString
"==> 0:00:00:11.014 without optimization"
```
The implementation uses #upTo: $' logic which is highly optimized for string based streams where  lookup for given character is performed by string primitive