### PR TITLE
Fix CalypsoBrowser window grouping

### DIFF
--- a/src/Calypso-Browser/ClyBrowserMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserMorph.class.st
@@ -504,7 +504,9 @@ ClyBrowserMorph >> open [
 
 { #category : #'opening/closing' }
 ClyBrowserMorph >> openAnotherBrowser: aBrowser [
-	aBrowser open
+	"If embedded into a grouped-window environment, openInWindow: groupwindow.. "
+	(self window ownerThatIsA: GroupWindowMorph) ifNil: [^ aBrowser open ].
+	aBrowser openInWindow: self window.
 ]
 
 { #category : #'opening/closing' }

--- a/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowser.class.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowser.class.st
@@ -262,12 +262,6 @@ ClyQueryBrowser >> newWindowTitle [
 	^title
 ]
 
-{ #category : #'opening/closing' }
-ClyQueryBrowser >> openAnotherBrowser: aBrowser [
-	(aBrowser isKindOf: ClyQueryBrowser)
-		ifTrue: [ aBrowser openInWindow: self window]
-		ifFalse: [ aBrowser open ]
-]
 
 { #category : #initialization }
 ClyQueryBrowser >> packageNameOf: aBrowserItem [


### PR DESCRIPTION
ClyBrowserMorph>>openAnotherBrowser now checks for caller being inside a group-windowed environment, and if so, opens all new browsers inside; otherwise, a new window is created.
* This is consistent with ClyBrowserMorph>>close (note how it tries to see if its owner is a GroupWindowMorph to correctly close the browser).
* This eliminates the need for ClyQueryBrowserMorph to override openAnotherBrowser and do roughly the same, except klugier.

as it stands, Calypso is unusable in group windows and cannot be integrated or embedded.