### PR TITLE
Remove dumpOn: method of RFLiteralVariableNode class

### DIFF
--- a/src/Reflectivity/RFLiteralVariableNode.class.st
+++ b/src/Reflectivity/RFLiteralVariableNode.class.st
@@ -32,14 +32,6 @@ RFLiteralVariableNode >> binding: anAssocation [
 	binding := anAssocation
 ]
 
-{ #category : #generation }
-RFLiteralVariableNode >> dumpOn: aStream [
-	aStream
-		nextPutAll: self class name;
-		nextPutAll: ' value: '.
-	self value printOn: aStream
-]
-
 { #category : #accessing }
 RFLiteralVariableNode >> start [
 	^0


### PR DESCRIPTION
Remove #dumpOn: method. Fix #5775 