### PR TITLE
add String>>#copyUpToSubstring:

### DIFF
--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -963,6 +963,17 @@ String >> copyReplaceTokens: oldSubstring with: newSubstring [
 	
 ]
 
+{ #category : #copying }
+String >> copyUpToSubstring: aSubstring [
+
+	aSubstring ifEmpty: [ 
+		"preserve compatiblity with `readStream upToAll:`"
+		^ '' ].
+	
+	^ (self findString: aSubstring)
+		in: [ :index | index > 0 ifTrue: [ self copyFrom: 1 to: index-1 ] ifFalse: [ self ] ]
+]
+
 { #category : #converting }
 String >> correctAgainst: wordList [
 	"Correct the receiver: assume it is a misspelled word and return the (maximum of five) nearest words in the wordList.  Depends on the scoring scheme of alike:"

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -968,7 +968,7 @@ String >> copyUpToSubstring: aSubstring [
 
 	aSubstring ifEmpty: [ 
 		"preserve compatiblity with `readStream upToAll:`"
-		^ '' ].
+		^ String new ].
 	
 	^ (self findString: aSubstring)
 		in: [ :index | index > 0 ifTrue: [ self copyFrom: 1 to: index-1 ] ifFalse: [ self ] ]

--- a/src/Collections-Tests/StringTest.class.st
+++ b/src/Collections-Tests/StringTest.class.st
@@ -701,6 +701,22 @@ StringTest >> testCopyReplaceAllWithAsTokens [
 	self assert: ('éèàôü éèàôüt éèàôü' copyReplaceAll: ' ' with:  'ß' asTokens: false) equals: 'éèàôüßéèàôütßéèàôü'.
 ]
 
+{ #category : #'tests - copying' }
+StringTest >> testCopyUpToSubstring [ 
+
+	self assert: ('abcdef' copyUpToSubstring: '') equals: ''.
+	self assert: ('abcdef' copyUpToSubstring: 'a') equals: ''.
+	self assert: ('abcdef' copyUpToSubstring: 'b') equals: 'a'.
+	self assert: ('abcdef' copyUpToSubstring: 'de') equals: 'abc'.
+	self assert: ('abcdef' copyUpToSubstring: 'ef') equals: 'abcd'.
+	self assert: ('abcdef' copyUpToSubstring: 'f') equals: 'abcde'.
+	self assert: ('abcdef' copyUpToSubstring: 'fg') equals: 'abcdef'.
+	self assert: ('' copyUpToSubstring: 'abc') equals: ''.
+	self assert: ('abcdef' copyUpToSubstring: 'g') equals: 'abcdef'.
+	self assert: ('abcdef' copyUpToSubstring: 'gh') equals: 'abcdef'.
+
+]
+
 { #category : #'tests - comparing' }
 StringTest >> testCorrectAgainst [
 


### PR DESCRIPTION
add String>>#copyUpToSubstring: as faster and more obvious variant to `readStream upToAll:`. It is usually about 3-times faster.