### PR TITLE
Add-a-validation-rule-stating-that-TestCase-should-not-rely-on-initialize

### DIFF
--- a/src/GeneralRules-Tests/ReAbstractRuleTestCase.class.st
+++ b/src/GeneralRules-Tests/ReAbstractRuleTestCase.class.st
@@ -14,20 +14,29 @@ ReAbstractRuleTestCase >> critiguesFor: ruleClass onMethod: method [
 ]
 
 { #category : #'test-support' }
-ReAbstractRuleTestCase >> myCritiguesOnMethod: method [
-	| critiques |
-	critiques := OrderedCollection new.
-	self subjectUnderTest  new 
-		check: method forCritiquesDo:[:critique | critiques add: critique].
-	^critiques 
-]
-
-{ #category : #'test-support' }
 ReAbstractRuleTestCase >> myCritiques [
 	| critiques |
 	critiques := OrderedCollection new.
 	self subjectUnderTest  new 
 		check: (self class >> #sampleMethod ) forCritiquesDo:[:critique | critiques add: critique].
+	^critiques 
+]
+
+{ #category : #'test-support' }
+ReAbstractRuleTestCase >> myCritiquesOnClass: aClass [
+	| critiques |
+	critiques := OrderedCollection new.
+	self subjectUnderTest  new 
+		check: aClass forCritiquesDo:[:critique | critiques add: critique].
+	^critiques 
+]
+
+{ #category : #'test-support' }
+ReAbstractRuleTestCase >> myCritiquesOnMethod: method [
+	| critiques |
+	critiques := OrderedCollection new.
+	self subjectUnderTest  new 
+		check: method forCritiquesDo:[:critique | critiques add: critique].
 	^critiques 
 ]
 

--- a/src/GeneralRules-Tests/ReRefersToClassRuleTest.class.st
+++ b/src/GeneralRules-Tests/ReRefersToClassRuleTest.class.st
@@ -25,7 +25,7 @@ ReRefersToClassRuleTest >> referToClassName [
 { #category : #tests }
 ReRefersToClassRuleTest >> testIsAbstractNotDetected [
 	| critiques|
- 	critiques := self myCritiguesOnMethod: self class class >> #isAbstract.
+ 	critiques := self myCritiquesOnMethod: self class class >> #isAbstract.
 
  	self assert: critiques size equals: 0.
 ]
@@ -33,7 +33,7 @@ ReRefersToClassRuleTest >> testIsAbstractNotDetected [
 { #category : #tests }
 ReRefersToClassRuleTest >> testRuleDetectHardCodedClass [
 	| critiques|
- 	critiques := self myCritiguesOnMethod: self class >> #referToClassName.
+ 	critiques := self myCritiquesOnMethod: self class >> #referToClassName.
 
  	self assert: critiques size equals: 2.
  	self assert: (self sourceAtChritique:  critiques first) equals: ReRefersToClassRuleTest name asString.

--- a/src/GeneralRules-Tests/ReTempVarOverridesInstVarRuleTest.class.st
+++ b/src/GeneralRules-Tests/ReTempVarOverridesInstVarRuleTest.class.st
@@ -31,7 +31,7 @@ ReTempVarOverridesInstVarRuleTest >> testRule [
 	dummy2 := [ :dummy3 | dummy4 := dummy1 + dummy3 ].
 	^ dummy2 value: dummy1.
 	' classified: 'test-help'.
-	critiques := self myCritiguesOnMethod: self class >> #sampleMethod:.
+	critiques := self myCritiquesOnMethod: self class >> #sampleMethod:.
 	
 	self assert: critiques size equals: 2.
 	self assert: (self sourceAtChritique:  critiques second) equals: 'dummy2'.

--- a/src/GeneralRules-Tests/ReTestCaseShouldNotUseInitializeTest.class.st
+++ b/src/GeneralRules-Tests/ReTestCaseShouldNotUseInitializeTest.class.st
@@ -1,0 +1,40 @@
+Class {
+	#name : #ReTestCaseShouldNotUseInitializeTest,
+	#superclass : #ReAbstractRuleTestCase,
+	#instVars : [
+		'aDummyVar'
+	],
+	#category : #'GeneralRules-Tests-Migrated'
+}
+
+{ #category : #'test-help' }
+ReTestCaseShouldNotUseInitializeTest >> tearDown [ 
+
+	self class removeSelector: #initialize.
+	super tearDown.
+]
+
+{ #category : #tests }
+ReTestCaseShouldNotUseInitializeTest >> testRule [
+	| critiques |
+	self class compile: 'initialize
+		super initialize.
+		aDummyVar := 2 ' classified: 'test-help'.
+
+	critiques := self myCritiquesOnClass: self class.
+	
+	self assert: critiques size equals: 1.
+
+]
+
+{ #category : #tests }
+ReTestCaseShouldNotUseInitializeTest >> testRuleDoesNotAppear [
+	| critiques |
+	self class compile: 'initialize
+		super initialize. ' classified: 'test-help'.
+
+	critiques := self myCritiquesOnClass: self class.
+	
+	self assert: critiques size equals: 0.
+
+]

--- a/src/GeneralRules/ReTestCaseShouldNotUseInitialize.class.st
+++ b/src/GeneralRules/ReTestCaseShouldNotUseInitialize.class.st
@@ -1,0 +1,45 @@
+"
+The testing framework nil out all the instance variables but it does not reinvoke the initialize method. 
+It means that you can get a test breaking and when you rerun your test you get the environment of the test broken full of nil while you are thinking that the initialize should have been executed.
+
+Initialize should only use variables defined in #instanceVariablesToKeep.
+"
+Class {
+	#name : #ReTestCaseShouldNotUseInitialize,
+	#superclass : #ReAbstractRule,
+	#category : #GeneralRules
+}
+
+{ #category : #'testing-interest' }
+ReTestCaseShouldNotUseInitialize class >> checksClass [
+
+	^ true
+]
+
+{ #category : #accessing }
+ReTestCaseShouldNotUseInitialize >> basicCheck: aClass [
+
+	| alteredVariables expectedVariables |
+	
+	aClass isTestCase 
+		ifFalse: [ ^ false ].
+		
+	(aClass selectors includes: #initialize)
+		ifFalse: [ ^ false ].
+	
+	alteredVariables := (aClass >> #initialize) ast allChildren 
+					select: [ :e | e isAssignment and: [ e variable isInstance ] ]
+					thenCollect: [ :e | e variable ].
+	
+	expectedVariables := aClass new instanceVariablesToKeep.
+					
+	^ alteredVariables anySatisfy: [ :e | (expectedVariables includes: e name) not ].
+		
+
+]
+
+{ #category : #accessing }
+ReTestCaseShouldNotUseInitialize >> name [
+	
+	^ 'Tests should not use initialize'
+]

--- a/src/Tests/TimeMeasuringTest.class.st
+++ b/src/Tests/TimeMeasuringTest.class.st
@@ -23,6 +23,12 @@ TimeMeasuringTest >> initialize [
 	shouldProfile := false.
 ]
 
+{ #category : #private }
+TimeMeasuringTest >> instanceVariablesToKeep [
+
+	^ super instanceVariablesToKeep , #(shouldProfile)
+]
+
 { #category : #performance }
 TimeMeasuringTest >> measure: measuredBlock [ 
 	shouldProfile 


### PR DESCRIPTION
Adding a Rule to test if a TestCase is using initialize.
A test should not use initiliaze.