### PR TITLE
5793-Add-test-for-shuffle-and-shuffleBy

### DIFF
--- a/src/Collections-Abstract/SequenceableCollection.class.st
+++ b/src/Collections-Abstract/SequenceableCollection.class.st
@@ -1971,12 +1971,15 @@ SequenceableCollection >> seventh [
 
 { #category : #shuffling }
 SequenceableCollection >> shuffle [
+	"Modify the receiver shuffling its elements."
+	
 	^ self shuffleBy: Random new
 ]
 
 { #category : #shuffling }
 SequenceableCollection >> shuffleBy: aRandom [
 	"Durstenfeld's version of the Fisher-Yates shuffle"
+	"#(1 2 3 4 5) shuffleBy: (Random seed: 42) >>> #(2 5 4 3 1)"
 
 	self size to: 2 by: -1 do: [ :i | 
 		self swap: i with: (aRandom nextInt: i) ]

--- a/src/Collections-Tests/ArrayTest.class.st
+++ b/src/Collections-Tests/ArrayTest.class.st
@@ -749,6 +749,38 @@ ArrayTest >> testPrinting [
 	self assert: nonSEarray2 printString equals: '{#Array->Array}'
 ]
 
+{ #category : #'tests - shuffling' }
+ArrayTest >> testShuffleBy [
+
+	| base random shuffleByResult |
+	base := #(1 2 3 4 5).
+	random := (Random seed: 42).
+	shuffleByResult := #(2 5 4 3 1).
+	
+	self assert: ((base shuffleBy: random) hasEqualElements: shuffleByResult).
+	
+]
+
+{ #category : #'tests - shuffling' }
+ArrayTest >> testShuffleChangeOrder [
+
+	| array shuffled |
+	array := #( 1 2 3 4 5).
+	shuffled := array copy shuffle.
+	array do: [ :e | self assert: (shuffled includes: e) ]
+	
+]
+
+{ #category : #'tests - shuffling' }
+ArrayTest >> testShuffleModifyTheReceiver [
+
+	| array shuffled |
+	array := #( 1 2 3 4 5).
+	shuffled := array shuffle.
+	self assert: array == shuffled. 
+	
+]
+
 { #category : #'tests - arithmetic' }
 ArrayTest >> testSumNumberItemsWithoutBlock [
 	


### PR DESCRIPTION
fix: #5793
Test on shuffle and shuffleBy (executable comment and testcase)