### PR TITLE
Refactoring - Add command for missing refactoring Convert temp to Inst Var

### DIFF
--- a/src/SystemCommands-SourceCodeCommands/SycConvertTempToInstVarCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycConvertTempToInstVarCommand.class.st
@@ -1,0 +1,37 @@
+"
+I am a command to convert a temp variable in instance variable.
+"
+Class {
+	#name : #SycConvertTempToInstVarCommand,
+	#superclass : #SycSourceCodeCommand,
+	#category : #'SystemCommands-SourceCodeCommands'
+}
+
+{ #category : #testing }
+SycConvertTempToInstVarCommand class >> canBeExecutedInContext: aSourceCodeContext [
+	super canBeExecutedInContext: aSourceCodeContext.
+	
+	^aSourceCodeContext isTempVariableSelected  
+]
+
+{ #category : #execution }
+SycConvertTempToInstVarCommand >> defaultMenuIconName [ 
+	^ #smallRedo
+]
+
+{ #category : #execution }
+SycConvertTempToInstVarCommand >> defaultMenuItemName [
+	^'Convert to Instance Var'
+]
+
+{ #category : #execution }
+SycConvertTempToInstVarCommand >> execute [
+	| refactoring |
+
+	refactoring := RBTemporaryToInstanceVariableRefactoring 
+		class: method origin
+		selector: method selector
+		variable: sourceNode name.
+
+	self executeRefactoring: refactoring.
+]


### PR DESCRIPTION
Add command for RBTemporaryToInstanceVariableRefactoring class

![imagen](https://user-images.githubusercontent.com/15729309/75553722-54af3800-5a0f-11ea-8239-471e0a968ab6.png)

Fixes #5796 