### PR TITLE
5604-improvement-fix-5603-overlayCompilerbug

### DIFF
--- a/src/OpalCompiler-Core/OCExtraBindingScope.class.st
+++ b/src/OpalCompiler-Core/OCExtraBindingScope.class.st
@@ -51,7 +51,7 @@ OCExtraBindingScope >> lookupVar: name [
 				assoc: assoc;
 				scope: self;
 				yourself ].
-	^ super lookupVar: name 
+	^ outerScope lookupVar: name
 ]
 
 { #category : #'instance creation' }


### PR DESCRIPTION
fix OCExtraBindingScope>>lookupVar: the same like in Pharo9: use outerScope, not super. fixes #5603