### PR TITLE
Removing-Deprecated80

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -18,7 +18,6 @@ BaselineOfPharo >> baseline: spec [
 		spec baseline: 'Calypso' with: [ 
 			spec repository: repository; loads: #('IcebergSupport'). ].
 
-		spec package: 'Deprecated80'.
 		spec package: 'Deprecated90'.
 		spec package: 'Gofer-UI'.
 	]

--- a/src/DrTests/DrTestsPlugin.class.st
+++ b/src/DrTests/DrTestsPlugin.class.st
@@ -139,21 +139,13 @@ DrTestsPlugin >> resultButtonHelp [
 
 { #category : #accessing }
 DrTestsPlugin >> resultTreeViews [
-	"Return result tree views available.
-	 This method might signal a deprecation exception in case it found an old pragma BUT the method itself is
-	 NOT deprecated. Do not remove it.
-	 The code generating the deprecation exception will be removed once we decide to totally remove the old pragmas support.
-	"
-	| pragmas oldPragmas |
+	"Return result tree views available."
+	
+	| pragmas |
 	pragmas := Pragma allNamed: self pragmaForResultTrees in: self pluginResultClass.
-	"Note The two following statements need to be removed once the old pragmas are gone."
-	oldPragmas := Pragma allNamed: self oldPragmaForResultTrees in: self pluginResultClass.
-	oldPragmas ifNotEmpty: [ self deprecated: ('Your code still use the old pragma to declare a tree view. Please update it to use the new pragma described in {1}>>#pragmaForResultTrees' format: { self className }) ].
+
 	^ ((pragmas sorted: [ :p | p argumentAt: 2 ] asSortFunction) collect: [ :pragma |
-		DTResultTreeView name: (pragma argumentAt: 1) blockToExtractViewFromResult: pragma methodSelector ]) ,
-	"Note: The following code need to be removed once the old pragmas are gone."
-	(oldPragmas collect: [ :pragma |
-		DTResultTreeView name: (pragma argumentAt: 1) blockToExtractViewFromResult: pragma methodSelector ])
+		DTResultTreeView name: (pragma argumentAt: 1) blockToExtractViewFromResult: pragma methodSelector ]) 
 ]
 
 { #category : #api }

--- a/src/Morphic-Widgets-Pluggable/ManifestMorphicWidgetsPluggable.class.st
+++ b/src/Morphic-Widgets-Pluggable/ManifestMorphicWidgetsPluggable.class.st
@@ -6,13 +6,3 @@ Class {
 	#superclass : #PackageManifest,
 	#category : #'Morphic-Widgets-Pluggable-Manifest'
 }
-
-{ #category : #'code-critics' }
-ManifestMorphicWidgetsPluggable class >> ruleEmptyExceptionHandlerRuleV1FalsePositive [
-	^ #(#(#(#RGMethodDefinition #(#PluggableTextMorph #acceptBasic #false)) #'2016-07-01T16:07:25.941995+02:00') )
-]
-
-{ #category : #'code-critics' }
-ManifestMorphicWidgetsPluggable class >> ruleSentNotImplementedRuleV1FalsePositive [
-	^ #(#(#(#RGMethodDefinition #(#PluggableTextMorph #acceptBasic #false)) #'2016-07-01T16:07:25.953189+02:00') )
-]

--- a/src/Refactoring-Environment/RBNotEnvironment.class.st
+++ b/src/Refactoring-Environment/RBNotEnvironment.class.st
@@ -33,10 +33,11 @@ RBNotEnvironment >> includesPackage: aRPackage [
 ]
 
 { #category : #testing }
-RBNotEnvironment >> includesProtocol: aProtocol in: aClass [ 
-	^(aClass organization protocolOrganizer getProtocolNamed: aProtocol ifNone: [ ^ false ])
-		methods anySatisfy: [ :selector | 
-			self includesSelector: selector in: aClass ]
+RBNotEnvironment >> includesProtocol: aProtocol in: aClass [
+	^ (aClass organization protocolOrganizer
+		getProtocolNamed: aProtocol
+		ifNone: [ ^ false ]) methodSelectors
+		anySatisfy: [ :selector | self includesSelector: selector in: aClass ]
 ]
 
 { #category : #testing }

--- a/src/Ring-Core/RGMethod.class.st
+++ b/src/Ring-Core/RGMethod.class.st
@@ -246,6 +246,12 @@ RGMethod >> isFromTrait [
 ]
 
 { #category : #testing }
+RGMethod >> isLiteralMethod [
+	"Ring methods does not know how to detect if they are literal"
+	^ false
+]
+
+{ #category : #testing }
 RGMethod >> isMetaSide [
 
 	^ self parent isMeta

--- a/src/Rubric/RubTextFieldArea.class.st
+++ b/src/Rubric/RubTextFieldArea.class.st
@@ -48,6 +48,5 @@ RubTextFieldArea >> wrapFlag: aBoolean [
 { #category : #'compatibility-toBeDeprecated' }
 RubTextFieldArea >> wrapped: aBoolean [
 
-	self deprecated: 'Obsolete'
-		 transformWith: '`@receiver wrapped: `@statements' -> ''
+	" not effect for a text field because such a morph is never wrapped "
 ]

--- a/src/Rubric/RubTextFieldMorph.class.st
+++ b/src/Rubric/RubTextFieldMorph.class.st
@@ -83,6 +83,11 @@ RubTextFieldMorph >> configureGhostText: aTextArea [
 	aTextArea left: self scrollBounds left 
 ]
 
+{ #category : #compatibility }
+RubTextFieldMorph >> cursorEnd: aKeyboardEvent [ 
+	^ self textMorph editor cursorEnd: aKeyboardEvent 
+]
+
 { #category : #defaults }
 RubTextFieldMorph >> defaultGhostTextMorph [
 	^ super defaultGhostTextMorph beNotWrapped 

--- a/src/Spec-Core/TextInputFieldPresenter.class.st
+++ b/src/Spec-Core/TextInputFieldPresenter.class.st
@@ -190,6 +190,12 @@ TextInputFieldPresenter >> removeEntryCompletion [
 	self entryCompletion: nil
 ]
 
+{ #category : #'api-events' }
+TextInputFieldPresenter >> text [ 
+	
+	^ self getText asString
+]
+
 { #category : #accessing }
 TextInputFieldPresenter >> textHolder [
 

--- a/src/Spec-MorphicAdapters/MorphicTextInputFieldAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTextInputFieldAdapter.class.st
@@ -29,8 +29,7 @@ MorphicTextInputFieldAdapter >> adapt: aModel [
 { #category : #factory }
 MorphicTextInputFieldAdapter >> buildWidget [
 	| plu |
-	plu := PluggableTextFieldMorph new
-		convertTo: String;
+	plu := RubTextFieldMorph new
 		on: self
 			text: #getText
 			accept: #accept:
@@ -48,8 +47,8 @@ MorphicTextInputFieldAdapter >> buildWidget [
 		dropEnabled: self dropEnabled;
 		hResizing: #spaceFill;
 		vResizing: #spaceFill;
-		acceptOnCR: self acceptOnCR;
-		hideScrollBarsIndefinitely.
+		acceptOnCR: self acceptOnCR.
+		
 	^ plu
 ]
 

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -58,9 +58,8 @@ SystemDependenciesTest >> externalDependendiesOf: packagesCollection [
 SystemDependenciesTest >> knownBasicToolsDependencies [
 
 	"ideally this list should be empty"	
-	self flag: #todo. "The Deprecated80 dependency should soon vanish. This is just the time we finish Spec migration."
-	^ #('AST-Core-Tests' 'Athens-Cairo' 'Athens-Core' "Those are added for the development of Spec2 and should probably be removed"
-	#'Athens-Morphic' #NautilusRefactoring #'Refactoring-Critics' #'Reflectivity-Tools' #Shout 'ParametrizedTests' 'Deprecated80' 'Deprecated90')
+	^ #('AST-Core-Tests' 'Athens-Cairo' 'Athens-Core' 
+	#'Athens-Morphic' #NautilusRefactoring #'Refactoring-Critics' #'Reflectivity-Tools' #Shout 'ParametrizedTests')
 ]
 
 { #category : #'known dependencies' }
@@ -84,8 +83,7 @@ SystemDependenciesTest >> knownIDEDependencies [
 
 	"ideally this list should be empty"	
 	
-	self flag: #todo. "The Deprecated80/Deprecated90 dependency should soon vanish. This is just the time we finish Spec migration."
-	^ #(Deprecated80 Deprecated90)
+	^ #()
 ]
 
 { #category : #'known dependencies' }
@@ -150,9 +148,8 @@ SystemDependenciesTest >> knownUIDependencies [
 
 	"ideally this list should be empty"	
 
-	self flag: #todo. "The Deprecated80 dependency should soon vanish. This is just the time we finish Spec migration."
-	^ #('AST-Core-Tests'  'Athens-Cairo' 'Athens-Core' "Those are added for the development of Spec2 and should probably be removed"
-	#'Athens-Morphic' #RecentSubmissions #'Refactoring-Critics' #'Refactoring-Environment' #'Reflectivity-Tools' #Shout #'Tool-Diff' #'Tool-FileList' #'Tool-ProcessBrowser' #'Tool-Profilers' 'Deprecated80' 'Deprecated90')
+	^ #('AST-Core-Tests'  'Athens-Cairo' 'Athens-Core' 
+	#'Athens-Morphic' #RecentSubmissions #'Refactoring-Critics' #'Refactoring-Environment' #'Reflectivity-Tools' #Shout #'Tool-Diff' #'Tool-FileList' #'Tool-ProcessBrowser' #'Tool-Profilers')
 ]
 
 { #category : #utilities }


### PR DESCRIPTION
- Removing Deprecated80 from the Baseline of Pharo
- Removing the references to deprecated classes from manifests.
- Adding compatibility messages to RubTextFieldArea so it can be used instead of the PluggableTextField
- Changing the old spec to remove dependency to a deprecated morph.