### PR TITLE
4950-Add a new test for withUnixLineEndings

### DIFF
--- a/src/Collections-Tests/StringLineEndingsTest.class.st
+++ b/src/Collections-Tests/StringLineEndingsTest.class.st
@@ -14,16 +14,21 @@ Class {
 { #category : #'building suites' }
 StringLineEndingsTest class >> testParameters [
 	^ ParametrizedTestMatrix new
-		forSelector: #targetLineEnding addOptions: {String cr . String lf . String crlf};
-		forSelector: #originLineEnding addOptions: {String cr . String lf . String crlf};
-		forSelector: #templateString addOptions: {'I am a String{1}'. '{1}I am a String' . 'I am a{1}String'. '{1}I am{1}a String{1}'};
-		
-		
-		
+		forSelector: #targetLineEnding
+			addOptions:
+			{String cr.
+			String lf.
+			String crlf};
+		forSelector: #originLineEnding
+			addOptions:
+			{String cr.
+			String lf.
+			String crlf};
+		forSelector: #templateString
+			addOptions:
+			{'I am a String{1}' . '{1}I am a String' . 'I am a{1}String'.
+			'{1}I am{1}a String{1}'};
 		yourself
-		
-	
- 
 ]
 
 { #category : #running }
@@ -31,7 +36,7 @@ StringLineEndingsTest >> newTestingSubject [
 	^ templateString format: {originLineEnding}
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 StringLineEndingsTest >> originLineEnding: aString [ 
 	originLineEnding := aString
 ]
@@ -44,7 +49,7 @@ StringLineEndingsTest >> setUp [
 	testingSubjectWithTargetLineEnding := testingSubjectWithOriginLineEnding withLineEndings: targetLineEnding.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 StringLineEndingsTest >> targetLineEnding: aString [ 
 	targetLineEnding := aString
 ]
@@ -54,7 +59,7 @@ StringLineEndingsTest >> templateString: aString [
 	templateString := aString
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 StringLineEndingsTest >> testLineEndinglessStringShouldBeEquals [
 	| originWithoutLineEnding targetWithoutLineEnding |
 	originWithoutLineEnding := testingSubjectWithOriginLineEnding
@@ -64,15 +69,16 @@ StringLineEndingsTest >> testLineEndinglessStringShouldBeEquals [
 	self assert: originWithoutLineEnding equals: targetWithoutLineEnding
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 StringLineEndingsTest >> testOriginStringCanBeProducedFromTargetStringAndOriginalLineEnding [
+	
+	" This test is for testing that we can tranform a string with certain line ending to a another line ending, and then transform it back to the original line ending. "
 	
 	| testingSubjectWithTargetLineEndingTransformedWithOriginalLineEnding |
 	testingSubjectWithTargetLineEndingTransformedWithOriginalLineEnding := testingSubjectWithTargetLineEnding withLineEndings: originLineEnding .
 	self assert: testingSubjectWithTargetLineEndingTransformedWithOriginalLineEnding equals: testingSubjectWithOriginLineEnding 
 	
-	" transformedString := 'I'm a string <<lf>>' withLineEnding: <<cr>> 
-	>>> assert: I'm a string <<cr>> (transformedString) equals: I'm a string <<cr>> ( subjectWithOriginLineEnding )"
+	
 ]
 
 { #category : #tests }

--- a/src/Collections-Tests/StringLineEndingsTest.class.st
+++ b/src/Collections-Tests/StringLineEndingsTest.class.st
@@ -1,0 +1,85 @@
+Class {
+	#name : #StringLineEndingsTest,
+	#superclass : #ParametrizedTestCase,
+	#instVars : [
+		'targetLineEnding',
+		'originLineEnding',
+		'testingSubjectWithTargetLineEnding',
+		'testingSubjectWithOriginLineEnding',
+		'templateString'
+	],
+	#category : #'Collections-Tests-Strings'
+}
+
+{ #category : #'building suites' }
+StringLineEndingsTest class >> testParameters [
+	^ ParametrizedTestMatrix new
+		forSelector: #targetLineEnding addOptions: {String cr . String lf . String crlf};
+		forSelector: #originLineEnding addOptions: {String cr . String lf . String crlf};
+		forSelector: #templateString addOptions: {'I am a String{1}'. '{1}I am a String' . 'I am a{1}String'. '{1}I am{1}a String{1}'};
+		
+		
+		
+		yourself
+		
+	
+ 
+]
+
+{ #category : #running }
+StringLineEndingsTest >> newTestingSubject [
+	^ templateString format: {originLineEnding}
+]
+
+{ #category : #'as yet unclassified' }
+StringLineEndingsTest >> originLineEnding: aString [ 
+	originLineEnding := aString
+]
+
+{ #category : #running }
+StringLineEndingsTest >> setUp [
+	
+	super setUp.
+	testingSubjectWithOriginLineEnding := self newTestingSubject. 
+	testingSubjectWithTargetLineEnding := testingSubjectWithOriginLineEnding withLineEndings: targetLineEnding.
+]
+
+{ #category : #'as yet unclassified' }
+StringLineEndingsTest >> targetLineEnding: aString [ 
+	targetLineEnding := aString
+]
+
+{ #category : #running }
+StringLineEndingsTest >> templateString: aString [
+	templateString := aString
+]
+
+{ #category : #'as yet unclassified' }
+StringLineEndingsTest >> testLineEndinglessStringShouldBeEquals [
+	| originWithoutLineEnding targetWithoutLineEnding |
+	originWithoutLineEnding := testingSubjectWithOriginLineEnding
+		copyReplaceAll: originLineEnding with: ''.
+	targetWithoutLineEnding := testingSubjectWithTargetLineEnding
+		copyReplaceAll: targetLineEnding with: ''.
+	self assert: originWithoutLineEnding equals: targetWithoutLineEnding
+]
+
+{ #category : #'as yet unclassified' }
+StringLineEndingsTest >> testOriginStringCanBeProducedFromTargetStringAndOriginalLineEnding [
+	
+	| testingSubjectWithTargetLineEndingTransformedWithOriginalLineEnding |
+	testingSubjectWithTargetLineEndingTransformedWithOriginalLineEnding := testingSubjectWithTargetLineEnding withLineEndings: originLineEnding .
+	self assert: testingSubjectWithTargetLineEndingTransformedWithOriginalLineEnding equals: testingSubjectWithOriginLineEnding 
+	
+	" transformedString := 'I'm a string <<lf>>' withLineEnding: <<cr>> 
+	>>> assert: I'm a string <<cr>> (transformedString) equals: I'm a string <<cr>> ( subjectWithOriginLineEnding )"
+]
+
+{ #category : #tests }
+StringLineEndingsTest >> testTargetLineEndingStringWithoutOriginLineEnding [
+	self
+		assert:
+			((targetLineEnding includesSubstring: originLineEnding) 
+				xor: [ (testingSubjectWithTargetLineEnding
+						includesSubstring: originLineEnding) not ])
+]


### PR DESCRIPTION
StirngLineEndingTest Class added.
It does test line endings in general, not only unixLineEndings, but unixLineEndings are included.

tests Line Endingless String to Be Equals
tests origin string to be reproduced From Target String And OriginLineEnding
tests TargetLine does not contain OriginLineEnding .
The test case is a subclass of parametrized tests, and it provides a matrix with the folowing cases 
 #targetLineEnding addOptions:
			{String cr.
			String lf.
			String crlf};
 #originLineEnding addOptions:
			{String cr.
			String lf.
			String crlf};
#templateString addOptions:
			{'I am a String{1}' . 
			'{1}I am a String' . 
			'I am a{1}String'.
			'{1}I am{1}a String{1}'};
The test case adds 108 new tests to the suit of string tests .