### PR TITLE
5368 the debugger should not rely on the formatter

### DIFF
--- a/src/Calypso-NavigationModel/ClyNavigationEnvironment.class.st
+++ b/src/Calypso-NavigationModel/ClyNavigationEnvironment.class.st
@@ -176,6 +176,11 @@ ClyNavigationEnvironment >> announceChangesOf: aQueryResult [
 	updateStrategy announceChangesOf: aQueryResult
 ]
 
+{ #category : #converting }
+ClyNavigationEnvironment >> asRBEnvironment [ 
+	^ self system environment
+]
+
 { #category : #'system subscription' }
 ClyNavigationEnvironment >> attachToSystem [
 	system subscribe: self.

--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -66,6 +66,11 @@ ClySystemEnvironment >> asGlobalScopeIn: aNavigationEnvironment [
 	^ClySystemEnvironmentScope of: self in: aNavigationEnvironment named: name
 ]
 
+{ #category : #converting }
+ClySystemEnvironment >> asRBEnvironment [
+	^ self environment asRBEnvironment
+]
+
 { #category : #'class management' }
 ClySystemEnvironment >> bindingOf: aSymbol [
 	^globals bindingOf: aSymbol
@@ -169,6 +174,11 @@ ClySystemEnvironment >> defaultClassCompiler [
 { #category : #'package management' }
 ClySystemEnvironment >> ensureExistAndRegisterPackageNamed: packageName [
 	^packageOrganizer ensureExistAndRegisterPackageNamed: packageName
+]
+
+{ #category : #accessing }
+ClySystemEnvironment >> environment [
+	^ RBBrowserEnvironment new
 ]
 
 { #category : #accessing }

--- a/src/Calypso-SystemQueries/ClySystemEnvironmentScope.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironmentScope.class.st
@@ -17,7 +17,7 @@ Class {
 { #category : #'refactoring support' }
 ClySystemEnvironmentScope >> asRBEnvironment [
 
-	^RBBrowserEnvironment new
+	^self environment asRBEnvironment
 ]
 
 { #category : #queries }

--- a/src/Kernel/BlockClosure.class.st
+++ b/src/Kernel/BlockClosure.class.st
@@ -549,12 +549,7 @@ BlockClosure >> outerContext: aContext startpc: aStartpc numArgs: argCount copie
 
 { #category : #printing }
 BlockClosure >> printOn: aStream [
-
-	aStream nextPutAll: ((self method hasSourceCode
-		or: [ "There is a decompiler"
-			self class environment includesKey: #FBDDecompiler ])
-				ifTrue: [ self sourceNode formattedCode ]
-				ifFalse: [ 'aBlockClosure(no source code or decompiler available)' ])
+	^ aStream nextPutAll: (self method ast sourceNodeForPC: self endPC) sourceCode 
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Changes/RGBehavior.extension.st
+++ b/src/Refactoring-Changes/RGBehavior.extension.st
@@ -1,0 +1,38 @@
+Extension { #name : #RGBehavior }
+
+{ #category : #'*Refactoring-Changes' }
+RGBehavior >> oldDefinition [
+	"Answer a String that defines the receiver."
+
+	| aStream |
+	aStream := (String new: 800) writeStream.
+	superclass 
+		ifNil: [aStream nextPutAll: 'ProtoObject']
+		ifNotNil: [aStream nextPutAll: superclass name].
+	aStream nextPutAll: self kindOfSubclass;
+			store: self name.
+	(self hasTraitComposition) ifTrue: [
+		aStream cr; tab; nextPutAll: 'uses: ';
+			nextPutAll: self traitCompositionString].
+	aStream cr; tab; nextPutAll: 'instanceVariableNames: ';
+			store: self instanceVariablesString.
+	aStream cr; tab; nextPutAll: 'classVariableNames: ';
+			store: self classVariablesString.
+	aStream cr; tab; nextPutAll: 'poolDictionaries: ';
+			store: self sharedPoolsString.
+	aStream cr; tab; nextPutAll: 'category: ';
+			store: self category asString.
+
+	superclass ifNil: [ 
+		aStream nextPutAll: '.'; cr.
+		aStream nextPutAll: self name.
+		aStream space; nextPutAll: 'superclass: nil'. ].
+
+	^ aStream contents
+]
+
+{ #category : #'*Refactoring-Changes' }
+RGBehavior >> removeFromSystem [
+
+	self parent removeBehavior: self
+]

--- a/src/Refactoring-Core/RGBehavior.extension.st
+++ b/src/Refactoring-Core/RGBehavior.extension.st
@@ -6,7 +6,7 @@ RGBehavior >> sourceCodeAt: aSymbol [
 	| method |
 	method :=  self localMethodNamed: aSymbol 
 						 ifAbsent: [ self error: 'Selector #', aSymbol asString, ' not found in RGClass "', self name, '"' ].
-	^ method first sourceCode 
+	^ method sourceCode 
 ]
 
 { #category : #'*Refactoring-Core' }

--- a/src/Refactoring-Core/RGBehavior.extension.st
+++ b/src/Refactoring-Core/RGBehavior.extension.st
@@ -1,0 +1,18 @@
+Extension { #name : #RGBehavior }
+
+{ #category : #'*Refactoring-Core' }
+RGBehavior >> sourceCodeAt: aSymbol [
+
+	| method |
+	method :=  self localMethodNamed: aSymbol 
+						 ifAbsent: [ self error: 'Selector #', aSymbol asString, ' not found in RGClass "', self name, '"' ].
+	^ method first sourceCode 
+]
+
+{ #category : #'*Refactoring-Core' }
+RGBehavior >> withAllSubclasses [
+
+	^ self subclasses asOrderedCollection 
+		add: self; 
+		yourself
+]

--- a/src/Refactoring-Core/RGEnvironment.extension.st
+++ b/src/Refactoring-Core/RGEnvironment.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #RGEnvironment }
+
+{ #category : #'*Refactoring-Core' }
+RGEnvironment >> at: aString ifAbsent: aBlockClosure [ 
+	| association |
+	association := self bindingOf: aString.
+	^ association 
+		ifNotNil: [ association value ]
+		ifNil: aBlockClosure
+]

--- a/src/Refactoring-Environment/RGBehavior.extension.st
+++ b/src/Refactoring-Environment/RGBehavior.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #RGBehavior }
+
+{ #category : #'*Refactoring-Environment' }
+RGBehavior >> categoryOfElement: aSymbol ifAbsent: aBlockClosure [
+	
+	| aMethod |
+	
+	aMethod := (self localMethodNamed: aSymbol ifAbsent: nil).
+	^ aMethod 
+		ifNotNil: [ aMethod protocol ]
+		ifNil: aBlockClosure
+]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
@@ -124,7 +124,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testRefactoring [
 						class: #RBNamespace)
 						asRefactoring transform.
 	
-	self assert: refactoring model changes changes size equals: 6.
+	self assert: refactoring model changes changes size equals: 5.
 
 	class := refactoring model classNamed: #RBNamespace.
 	self assert: (class parseTreeFor: #includesGlobal:)
@@ -136,8 +136,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testRefactoring [
 	self assert: (class parseTreeFor: #initialize) 
 		equals: (self parseMethod: 'initialize
 			super initialize.
-			changes := changeFactory compositeRefactoryChange.
-			self environment: RBBrowserEnvironment new.
+			changes := changeFactory compositeRefactoryChange onSystemDictionary: self environment.
 			newClasses := IdentityDictionary new.
 			changedClasses := IdentityDictionary new.
 			removedClasses := Set new.

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -1205,6 +1205,11 @@ RGBehavior >> usedTraits [
 	^ self traitComposition usedTraits
 ]
 
+{ #category : #accessing }
+RGBehavior >> users [
+	^ #()
+]
+
 { #category : #slots }
 RGBehavior >> usesSpecialSlot [
 	"return true if we define something else than InstanceVariableSlots"

--- a/src/Ring-Core/RGEnvironmentAnnouncer.class.st
+++ b/src/Ring-Core/RGEnvironmentAnnouncer.class.st
@@ -116,7 +116,7 @@ RGEnvironmentAnnouncer >> methodAdded: aMethod [
 RGEnvironmentAnnouncer >> methodRemoved: aMethod [ 
 
 	"TODO:"
-	self announce: (MethodRemoved methodRemoved: aMethod protocol: nil origin: nil)
+	self announce: (MethodRemoved methodRemoved: aMethod protocol: aMethod protocol origin: aMethod parent)
 ]
 
 { #category : #accessing }

--- a/src/SystemCommands-RefactoringSupport-Test/SycMockRBRefactoring.class.st
+++ b/src/SystemCommands-RefactoringSupport-Test/SycMockRBRefactoring.class.st
@@ -5,6 +5,11 @@ Class {
 }
 
 { #category : #accessing }
+SycMockRBRefactoring >> environment [
+	^ self
+]
+
+{ #category : #accessing }
 SycMockRBRefactoring >> environment: anEnvironement [
 	^ self
 ]
@@ -12,6 +17,11 @@ SycMockRBRefactoring >> environment: anEnvironement [
 { #category : #accessing }
 SycMockRBRefactoring >> model [
 	^ self
+]
+
+{ #category : #accessing }
+SycMockRBRefactoring >> model: aRBNamespace [ 
+	^ self 	
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Removing dependency on the formatter for printing Blocks.
This solution depends on the bytecode generator and on the bytecode encoder.