### PR TITLE
5656-scanTokens-is-bogus

### DIFF
--- a/src/AST-Core-Tests/RBScannerTest.class.st
+++ b/src/AST-Core-Tests/RBScannerTest.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #initialize }
 RBScannerTest >> buildScannerForText: source [
-	^ self parserClass on: (ReadStream on: source)
+	^ self parserClass on: source readStream
 ]
 
 { #category : #initialize }

--- a/src/AST-Core-Tests/RBScannerTest.class.st
+++ b/src/AST-Core-Tests/RBScannerTest.class.st
@@ -9,11 +9,11 @@ Class {
 
 { #category : #initialize }
 RBScannerTest >> buildScannerForText: source [
-	^ self parserClass on: (ReadStream on: source)
+	^ self scannerClass on: source readStream
 ]
 
 { #category : #initialize }
-RBScannerTest >> parserClass [
+RBScannerTest >> scannerClass [
 	^ RBScanner
 ]
 
@@ -104,7 +104,7 @@ RBScannerTest >> testScanTokenObjects1 [
 	exp := {'Object'.
 	'subclass:'.
 	#NameOfSubclass asString}.
-	self assert: ((self parserClass scanTokenObjects: inp) collect: [ :each | each value ]) equals: exp.
+	self assert: ((self scannerClass scanTokenObjects: inp) collect: [ :each | each value ]) equals: exp.
 	
 ]
 
@@ -114,7 +114,7 @@ RBScannerTest >> testScanTokenObjects2 [
 	inp := 'classVariableNames: '''' "ha ha"
 package: ''UndefinedClasses-Experiment'.
 	exp := {'classVariableNames:' . '' . 'package:' . 'UndefinedClasses-Experiment'}.
-	self assert: ((self parserClass scanTokenObjects: inp) collect: [ :each | each value ]) equals: exp
+	self assert: ((self scannerClass scanTokenObjects: inp) collect: [ :each | each value ]) equals: exp
 ]
 
 { #category : #'tests - creation api' }
@@ -124,7 +124,7 @@ RBScannerTest >> testScanTokens1 [
 	exp := {'Object'.
 	'subclass:'.
 	#NameOfSubclass asString}.
-	self assert: (self parserClass scanTokens: inp) equals: exp.
+	self assert: (self scannerClass scanTokens: inp) equals: exp.
 	
 ]
 
@@ -134,7 +134,7 @@ RBScannerTest >> testScanTokens2 [
 	inp := 'classVariableNames: '''' "ha ha"
 package: ''UndefinedClasses-Experiment'.
 	exp := {'classVariableNames:' . '' . 'package:' . 'UndefinedClasses-Experiment'}.
-	self assert: (RBScanner scanTokens: inp) equals: exp
+	self assert: (self scannerClass scanTokens: inp) equals: exp
 ]
 
 { #category : #utilities }

--- a/src/AST-Core-Tests/RBScannerTest.class.st
+++ b/src/AST-Core-Tests/RBScannerTest.class.st
@@ -9,7 +9,12 @@ Class {
 
 { #category : #initialize }
 RBScannerTest >> buildScannerForText: source [
-	^RBScanner on: (ReadStream on: source)
+	^ self parserClass on: (ReadStream on: source)
+]
+
+{ #category : #initialize }
+RBScannerTest >> parserClass [
+	^ RBScanner
 ]
 
 { #category : #tests }
@@ -92,14 +97,40 @@ RBScannerTest >> testNextWithTwoDoubleQuotesInCommentGetError [
 		raise: SyntaxErrorNotification
 ]
 
-{ #category : #tests }
-RBScannerTest >> testScanTokens [
+{ #category : #'tests - creation api' }
+RBScannerTest >> testScanTokenObjects1 [
 	| inp exp |
 	inp := 'Object subclass: #NameOfSubclass'.
 	exp := {'Object'.
 	'subclass:'.
 	#NameOfSubclass asString}.
-	self assert: (RBScanner scanTokens: inp) equals: exp.
+	self assert: ((self parserClass scanTokenObjects: inp) collect: [ :each | each value ]) equals: exp.
+	
+]
+
+{ #category : #'tests - creation api' }
+RBScannerTest >> testScanTokenObjects2 [
+	| inp exp |
+	inp := 'classVariableNames: '''' "ha ha"
+package: ''UndefinedClasses-Experiment'.
+	exp := {'classVariableNames:' . '' . 'package:' . 'UndefinedClasses-Experiment'}.
+	self assert: ((self parserClass scanTokenObjects: inp) collect: [ :each | each value ]) equals: exp
+]
+
+{ #category : #'tests - creation api' }
+RBScannerTest >> testScanTokens1 [
+	| inp exp |
+	inp := 'Object subclass: #NameOfSubclass'.
+	exp := {'Object'.
+	'subclass:'.
+	#NameOfSubclass asString}.
+	self assert: (self parserClass scanTokens: inp) equals: exp.
+	
+]
+
+{ #category : #'tests - creation api' }
+RBScannerTest >> testScanTokens2 [
+	| inp exp |
 	inp := 'classVariableNames: '''' "ha ha"
 package: ''UndefinedClasses-Experiment'.
 	exp := {'classVariableNames:' . '' . 'package:' . 'UndefinedClasses-Experiment'}.

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -151,7 +151,18 @@ RBScanner class >> patternVariableCharacter [
 ]
 
 { #category : #'public api' }
+RBScanner class >> scanTokenObjects: aStringOrStream [
+	"Return the tokens objects."
+	
+	| scanner |
+	scanner := self on: aStringOrStream readStream.
+	^ scanner contents
+]
+
+{ #category : #'public api' }
 RBScanner class >> scanTokens: aStringOrStream [
+	"Return the tokens (and not the scanner token objects)."
+	
 	| scanner |
 	scanner := self on: aStringOrStream readStream.
 	^scanner contents collect:[ :t | t value ]


### PR DESCRIPTION
fix: #5656
Add tests, extract RBParser, clean/split tests, add new methods so that we can get access to token objects!