### PR TITLE
5824-remove-class-var-that-is-still-referenced-change-is-not-saved

### DIFF
--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -148,7 +148,9 @@ Is this really what you want to do?') asText
 		source: aString;
 		requestor: aController;
 		logged: true;
-		evaluate] on: OCUndeclaredVariableWarning do: [ 
+		evaluate] on: OCUndeclaredVariableWarning do: [ :ex | 
+			"we are only interested in class definitions"
+			ex compilationContext noPattern ifFalse: [ex pass ].
  			"Undeclared Vars should not lead to the standard dialog to define them but instead should not accept"
  			self inform: 'Undeclared Variable in Class Definition' . ^nil ].
 	^ class isBehavior


### PR DESCRIPTION
add check that we are indeed compiling a class defintion. fixes #5824