### PR TITLE
Updating iceberg after deprecations in 90

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -192,7 +192,7 @@ BaselineOfIDE >> baseline: spec [
 BaselineOfIDE >> loadIceberg [
 	Metacello new
 		baseline: 'Iceberg';
-		repository: 'github://pharo-vcs/iceberg:v1.6.5';
+		repository: 'github://pharo-vcs/iceberg:v1.6.6';
 		onConflictUseLoaded;
 		load.
 	(Smalltalk classNamed: #Iceberg) enableMetacelloIntegration: true.

--- a/src/Spec-MorphicAdapters/MorphicTextInputFieldAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTextInputFieldAdapter.class.st
@@ -48,6 +48,8 @@ MorphicTextInputFieldAdapter >> buildWidget [
 		hResizing: #spaceFill;
 		vResizing: #spaceFill;
 		acceptOnCR: self acceptOnCR.
+	
+	self model whenTextChanged: [ plu setText: self model getText].
 		
 	^ plu
 ]


### PR DESCRIPTION
After removing the deprecations of Pharo 80 in Pharo 90.
We have changed the old TextInputFieldAdapter to use the Rubric TextField.

It required changes in Iceberg and in Spec events. 