### PR TITLE
ReadStream optimization for #upToAll:

### DIFF
--- a/src/Collections-Streams/PositionableStream.class.st
+++ b/src/Collections-Streams/PositionableStream.class.st
@@ -193,19 +193,15 @@ the receiver are empty. Otherwise returns false"
 { #category : #positioning }
 PositionableStream >> match: subCollection [ 
 	"Set the access position of the receiver to be past the next occurrence of the subCollection. Answer whether subCollection is found.  No wildcards, and case does matter."
-	| pattern startMatch |
+	| pattern |
 	pattern := subCollection readStream.
-	startMatch := nil.
-	[ pattern atEnd ] whileFalse: 
-		[ self atEnd ifTrue: [ ^ false ].
-		self next = pattern next 
-			ifTrue: [ pattern position = 1 ifTrue: [ startMatch := self position ] ]
-			ifFalse: 
-				[ pattern position: 0.
-				startMatch ifNotNil: 
-					[ self position: startMatch.
-					startMatch := nil ] ] ].
-	^ true
+	[ self atEnd or: [pattern atEnd] ] whileFalse: 
+		[self skip: pattern position negated.
+		pattern setToStart. 
+		(self skipTo: pattern next) ifFalse: [ ^false ].
+		[pattern atEnd not and: [self next = pattern peek]] whileTrue: [pattern next]
+	].
+	^ pattern atEnd
 ]
 
 { #category : #accessing }
@@ -623,6 +619,13 @@ PositionableStream >> setToEnd [
 	"Set the position of the receiver to the end of the sequence of objects."
 
 	position := readLimit
+]
+
+{ #category : #positioning }
+PositionableStream >> setToStart [
+	"Set the position of the receiver to the start of the sequence of objects."
+
+	self reset
 ]
 
 { #category : #positioning }

--- a/src/Collections-Streams/ReadStream.class.st
+++ b/src/Collections-Streams/ReadStream.class.st
@@ -90,6 +90,17 @@ ReadStream >> size [
 ]
 
 { #category : #accessing }
+ReadStream >> skipTo: anObject [
+	"fast version using indexOf:"
+	| end |
+	end := collection indexOf: anObject startingAt: position+1 ifAbsent: [ 0 ].
+
+	^(end = 0 or: [end > readLimit]) 
+		ifTrue: [ self setToEnd. false ]
+		ifFalse: [ position := end. true]
+]
+
+{ #category : #accessing }
 ReadStream >> upTo: anObject [
 	"fast version using indexOf:"
 	| start end |


### PR DESCRIPTION
Optimization for ReadStream  #match: and #skipTo: methods based on #upTo: logic.
My bench shows up to 40 times better performance for #upToAll: (based on #match: method):
```Smalltalk
string := String streamContents: [ :s | 100000 timesRepeat: [ s nextPut:$1 ]. s nextPut: $2. ].
[string readStream upToAll: '2'] bench.
"==> 207.434 per second without optimization"
"==> 8109.534 per second with optimization"
```
And it makes #upToAll: and #upTo: behave on same speed for single character.