### PR TITLE
windowMenuCleanup

### DIFF
--- a/src/MenuRegistration/BlockMenuBuilder.class.st
+++ b/src/MenuRegistration/BlockMenuBuilder.class.st
@@ -1,0 +1,29 @@
+"
+Please, do not use me. 
+
+I serve for building of Menus (mostly in Morphic) without collecting pragmas which makes me faster but less flexible. End-user applications should use Spec and Commander2.
+"
+Class {
+	#name : #BlockMenuBuilder,
+	#superclass : #PragmaMenuBuilder,
+	#instVars : [
+		'buildingBlock'
+	],
+	#category : #'MenuRegistration-Core'
+}
+
+{ #category : #accessing }
+BlockMenuBuilder >> buildingBlock [
+	^ buildingBlock
+]
+
+{ #category : #accessing }
+BlockMenuBuilder >> buildingBlock: anObject [
+	buildingBlock := anObject
+]
+
+{ #category : #'registrations handling' }
+BlockMenuBuilder >> collectRegistrations [
+
+	self buildingBlock value: self
+]

--- a/src/Morphic-Base/Form.extension.st
+++ b/src/Morphic-Base/Form.extension.st
@@ -12,13 +12,13 @@ Form >> asMorph [
 ]
 
 { #category : #'*Morphic-Base' }
-Form class >> floodFillTolerance [
-	^ FloodFillTolerance ifNil: [FloodFillTolerance := 0.0]
+Form >> floodFillTolerance [
+	^ self class floodFillTolerance
 ]
 
 { #category : #'*Morphic-Base' }
-Form >> floodFillTolerance [
-	^ self class floodFillTolerance
+Form class >> floodFillTolerance [
+	^ FloodFillTolerance ifNil: [FloodFillTolerance := 0.0]
 ]
 
 { #category : #'*Morphic-Base' }

--- a/src/Morphic-Base/MenuRegistration.extension.st
+++ b/src/Morphic-Base/MenuRegistration.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #MenuRegistration }
+
+{ #category : #'*Morphic-Base' }
+MenuRegistration >> iconName: aSymbol [
+	"instead of forcing clients to refer to an icon builder such Smalltalk ui icons 
+	this message encapsulates it inside the builder itself. When removing uses of Smalltalk ui icons it avoid to force to subclass class with menu to inherit from Model."
+	
+	self icon: (Smalltalk ui icons iconNamed: aSymbol)
+]

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -6094,6 +6094,87 @@ Morph >> themeChanged [
 	self changed
 ]
 
+{ #category : #tiling }
+Morph >> tileBottom [
+
+	| max |
+	max := RealEstateAgent maximumUsableArea.
+	self bounds: (max leftCenter corner: max corner)
+]
+
+{ #category : #tiling }
+Morph >> tileBottomLeft [
+
+	| max |
+	max := RealEstateAgent maximumUsableArea.
+	self bounds: (max leftCenter corner: max bottomCenter)
+]
+
+{ #category : #tiling }
+Morph >> tileBottomRight [
+
+	| max |
+	max := RealEstateAgent maximumUsableArea.
+	self bounds: (max center corner: max corner)
+]
+
+{ #category : #tiling }
+Morph >> tileCenter [
+
+	| max initial |
+	max := RealEstateAgent maximumUsableArea.
+	initial := self initialExtent.
+	self bounds: ((max center - (initial/2)) extent: initial)
+]
+
+{ #category : #tiling }
+Morph >> tileFull [
+
+	| max |
+	max := RealEstateAgent maximumUsableArea.
+	self bounds: max
+]
+
+{ #category : #tiling }
+Morph >> tileLeft [
+
+	| max |
+	max := RealEstateAgent maximumUsableArea.
+	self bounds: (max topLeft corner: max bottomCenter)
+]
+
+{ #category : #tiling }
+Morph >> tileRight [
+
+	| max |
+	max := RealEstateAgent maximumUsableArea.
+	self bounds: (max topCenter corner: max corner)
+]
+
+{ #category : #tiling }
+Morph >> tileTop [
+
+	| max |
+	max := RealEstateAgent maximumUsableArea.
+	self bounds: (max topLeft corner: max rightCenter)
+]
+
+{ #category : #tiling }
+Morph >> tileTopLeft [
+
+	| max |
+	max := RealEstateAgent maximumUsableArea.
+	self bounds: (max topLeft corner: max center)
+]
+
+{ #category : #tiling }
+Morph >> tileTopRight [
+
+	| max |
+	max := RealEstateAgent maximumUsableArea.
+	self bounds: (max topCenter corner: max rightCenter)
+]
+
 { #category : #rounding }
 Morph >> toggleCornerRounding [
 	self cornerStyle == #rounded

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1326,12 +1326,17 @@ SystemWindow >> maximumExtent: aPoint [
 { #category : #api }
 SystemWindow >> menu [
 
-	| aMenuBuilder |
-	aMenuBuilder := (PragmaMenuBuilder pragmaKeyword: self discoveredMenuPragmaKeyword model: self)
-		menuSpec;
-		yourself.
-				
-	^ aMenuBuilder menu
+	| aMenuBuilder res |
+
+	aMenuBuilder := BlockMenuBuilder owner: self.
+	aMenuBuilder model: self.
+	aMenuBuilder buildingBlock: [ :aBuilder |
+		self class windowMenuOn: aMenuBuilder.
+		self class tilingMenuOn: aBuilder.
+		self class tilingMenuItemsOn: aBuilder ].
+	aMenuBuilder menuSpec.
+	res := aMenuBuilder menu.
+	^ res.
 ]
 
 { #category : #'resize/collapse' }

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1277,10 +1277,12 @@ SystemWindow >> maximumExtent: aPoint [
 { #category : #api }
 SystemWindow >> menu [
 
-	| aMenu |
-	aMenu := MenuMorph new.
-	self windowMenuOn: aMenu.
-	^ aMenu
+	| aMenuBuilder |
+	aMenuBuilder := (PragmaMenuBuilder pragmaKeyword: self discoveredMenuPragmaKeyword model: self)
+		menuSpec;
+		yourself.
+				
+	^ aMenuBuilder menu
 ]
 
 { #category : #'resize/collapse' }
@@ -1944,49 +1946,4 @@ SystemWindow >> wantsYellowButtonMenu [
 { #category : #label }
 SystemWindow >> widthOfFullLabelText [
 	^StandardFonts windowTitleFont widthOfString: labelString
-]
-
-{ #category : #'menu items' }
-SystemWindow >> windowMenuOn: aMenuMorph [
-
-	| closableLabel draggableLabel maximizeLabel |
-	
-	(aMenuMorph add: #Close target: self selector: #closeBoxHit iconName: #windowCloseForm)
-		enabled: self allowedToClose.
-		
-	aMenuMorph addSeparator.	
-	
-	aMenuMorph add: #About target: self selector: #showAbout iconName: #smallHelpIcon.
-	aMenuMorph addSeparator.	
-
-	aMenuMorph add: #'Change title' target: self selector: #relabel.
-	aMenuMorph add: #'Copy title' target: self selector: #copyTitle.
-	aMenuMorph addSeparator.	
-
-	aMenuMorph add: #'Send to back' target: self selector: #sendToBack.
-	aMenuMorph add: #'Make next-to-topmost' target: self selector: #makeSecondTopmost.
-	aMenuMorph addSeparator.	
-
-	aMenuMorph add: #'Create window group' target: self selector: #createWindowGroup.
-	aMenuMorph addSeparator.	
-
-	closableLabel := self mustNotClose
-		ifFalse: [ #'Make unclosable' ]
-		ifTrue: [ #'Make closable' ].
-
-	aMenuMorph add: closableLabel target: self selector: closableLabel asCamelCase uncapitalized.
-
-	draggableLabel := self isSticky
-		ifTrue: [ #'Make draggable' ]
-		ifFalse: [ #'Make undraggable' ].
-
-	aMenuMorph add: draggableLabel target: self selector: #toggleStickiness.
-	aMenuMorph addSeparator.	
-
-	maximizeLabel := self isMaximized
-		ifTrue: [ #Restore ]
-		ifFalse: [ #Maximize ].
-
-	aMenuMorph add: maximizeLabel target: self selector: #expandBoxHit iconName: #windowMaximizeForm.
-
 ]

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -178,101 +178,67 @@ SystemWindow class >> buildWindowTilingShortcutsOn: aBuilder [
 	(aBuilder shortcut: #windowTopLeft)
 		category: #WindowShortcuts
 		default: PharoShortcuts current windowTopLeftShortcut
-		do: [ :target | 
-			| max |
-			max := RealEstateAgent maximumUsableArea.
-			target bounds: (max topLeft corner: max center)]
+		do: [ :target | target tileTopLeft]
 		description: 'Move the window to the top left corner of the display'.
 
 	(aBuilder shortcut: #windowLeft)
 		category: #WindowShortcuts
 		default: PharoShortcuts current windowLeftShortcut
-		do: [ :target | 
-			| max |
-			max := RealEstateAgent maximumUsableArea.
-			target bounds: (max topLeft corner: max bottomCenter)]
+		do: [ :target | target tileLeft ]
 		description: 'Move the window to the left half of the display'.
 	
 	(aBuilder shortcut: #windowBottomLeft)
 		category: #WindowShortcuts
 		default: PharoShortcuts current windowBottomLeftShortcut
-		do: [ :target | 
-			| max |
-			max := RealEstateAgent maximumUsableArea.
-			target bounds: (max leftCenter corner: max bottomCenter)]
+		do: [ :target | target tileBottomLeft ]
 		description: 'Move the window to the bottom left corner of the display'.
 
 	(aBuilder shortcut: #windowTop)
 		category: #WindowShortcuts
 		default: PharoShortcuts current windowTopShortcut
-		do: [ :target | 
-			| max |
-			max := RealEstateAgent maximumUsableArea.
-			target bounds: (max topLeft corner: max rightCenter)]
+		do: [ :target | target tileTop ]
 		description: 'Move the window to the top half of the display'.
 
 	(aBuilder shortcut: #windowTopRight)
 		category: #WindowShortcuts
 		default: PharoShortcuts current windowTopRightShortcut
-		do: [ :target | 
-			| max |
-			max := RealEstateAgent maximumUsableArea.
-			target bounds: (max topCenter corner: max rightCenter)]
+		do: [ :target | target tileTopRight ]
 		description: 'Move the window to the top right corner of the display'.
 
 	(aBuilder shortcut: #windowRight)
 		category: #WindowShortcuts
 		default: PharoShortcuts current windowRightShortcut
-		do: [ :target | 
-			| max |
-			max := RealEstateAgent maximumUsableArea.
-			target bounds: (max topCenter corner: max corner)]
+		do: [ :target | target tileRight ]
 		description: 'Move the window to the right half of the display'.
 
 	(aBuilder shortcut: #windowRightBottom)
 		category: #WindowShortcuts
 		default: PharoShortcuts current windowRightBottomShortcut
-		do: [ :target | 
-			| max |
-			max := RealEstateAgent maximumUsableArea.
-			target bounds: (max center corner: max corner)]
+		do: [ :target | target tileBottomRight ]
 		description: 'Move the window to the right bottom corner of the display'.
 
 	(aBuilder shortcut: #windowBottom)
 		category: #WindowShortcuts
 		default: PharoShortcuts current windowBottomShortcut
-		do: [ :target | 
-			| max |
-			max := RealEstateAgent maximumUsableArea.
-			target bounds: (max leftCenter corner: max corner)]
+		do: [ :target | target tileBottom ]
 		description: 'Move the window to the bottom half of the display'.
 
 	(aBuilder shortcut: #windowMaximize)
 		category: #WindowShortcuts
 		default: PharoShortcuts current windowMaximizeShortcut
-		do: [ :target | 
-			| max |
-			max := RealEstateAgent maximumUsableArea.
-			target bounds: max]
+		do: [ :target | target tileFull ]
 		description: 'Maximize the window'.
 
 	(aBuilder shortcut: #windowMinimize)
 		category: #WindowShortcuts
 		default: PharoShortcuts current windowMinimizeShortcut
-		do: [ :target | 
-			| max |
-			max := RealEstateAgent maximumUsableArea.
-			target minimize]
+		do: [ :target | target minimize]
 		description: 'Miminimze the window'.
 
 	(aBuilder shortcut: #windowCenter)
 		category: #WindowShortcuts
 		default: PharoShortcuts current windowCenterShortcut
-		do: [ :target | 
-			| max initial |
-			max := RealEstateAgent maximumUsableArea.
-			initial :=  target initialExtent.
-			target bounds: ((max center - (initial/2)) extent: initial )]
+		do: [ :target | target tileCenter]
 		description: 'Center the window with a default extent'.
 
 ]
@@ -407,6 +373,89 @@ SystemWindow class >> taskbarIconName [
 	"Answer the icon for the receiver in a task bar."
 
 	^#smallWindowIcon
+]
+
+{ #category : #'menu items - tiling' }
+SystemWindow class >> tilingMenuItemsOn: aBuilder [
+
+	<windowMenu>
+		
+	(aBuilder item: #tileLeft)
+		action: [ :target | target tileLeft ];
+		label: 'Left';
+		parent: #Tile;
+		icon: (self iconNamed: #blank); 
+		order: 1;
+		help: 'Move the window to the left half of the display'.
+
+	(aBuilder item: #tileRight)
+		action: [ :target | target tileRight ];
+		label: 'Right';
+		parent: #Tile;
+		help: 'Move the window to the right half of the display'.
+
+	(aBuilder item: #tileTop)
+		action: [ :target | target tileTop ];
+		label: 'Top';
+		parent: #Tile;
+		help: 'Move the window to the top half of the display'.
+
+	(aBuilder item: #tileBottom)
+		action: [ :target | target tileBottom ];
+		label: 'Bottom';
+		parent: #Tile;
+		help: 'Move the window to the bottom half of the display'.
+
+	(aBuilder item: #tileTopLeft)
+		action: [ :target | target tileTopLeft ];
+		label: 'Top left';
+		parent: #Tile;
+		help: 'Move the window to the top left corner of the display'.
+		
+	(aBuilder item: #tileTopRight)
+		action: [ :target | target tileTopRight ];
+		label: 'Top right';
+		parent: #Tile;
+		help: 'Move the window to the top right corner of the display'.
+
+	(aBuilder item: #tileBottomLeft)
+		action: [ :target | target tileBottomLeft ];
+		label: 'Bottom left';
+		parent: #Tile;
+		help: 'Move the window to the bottom left corner of the display'.
+
+	(aBuilder item: #tileBottomRight)
+		action: [ :target | target tileBottomRight ];
+		label: 'Bottom right';
+		parent: #Tile;
+		help: 'Move the window to the right bottom corner of the display'.
+
+	(aBuilder item: #tileFull)
+		action: [ :target | target tileFull ];
+		label: 'Full';
+		parent: #Tile;
+		help: 'Maximize the window'.
+
+	(aBuilder item: #tileCenter)
+		action: [ :target | target tileCenter ];
+		label: 'Center';
+		parent: #Tile;
+		help: 'Center the window with a default extent'.
+
+
+
+
+
+
+]
+
+{ #category : #'menu items - tiling' }
+SystemWindow class >> tilingMenuOn: aBuilder [
+
+	<windowMenu>
+
+	(aBuilder item: #Tile)
+		order: 10.5.
 ]
 
 { #category : #'top window' }


### PR DESCRIPTION
windowMenuOn: cleanupWe have two implementations of windows menu definition. One uses pragma and allows windows menus to be extended by other packages, the other is hardcoded. Unfortunately, the pragma version is not used. This PR changes it