### PR TITLE
generator-should-validate-if-context-isDead

### DIFF
--- a/src/Collections-Streams/Generator.class.st
+++ b/src/Collections-Streams/Generator.class.st
@@ -98,7 +98,7 @@ Generator class >> somePrimes [
 Generator >> atEnd [
 	"Answer whether the receiver can access any more objects."
 
-	^ continue isNil
+	^ continue isNil or: [ continue isDead ]
 ]
 
 { #category : #'open/close' }


### PR DESCRIPTION
Generators should validate if the continuation context is dead or not.
This might happens when a generator is executed from different processes