### PR TITLE
5840-FT2Error-reading-new-face-from-file

### DIFF
--- a/src/FreeType/FreeTypeFontProvider.class.st
+++ b/src/FreeType/FreeTypeFontProvider.class.st
@@ -392,6 +392,17 @@ FreeTypeFontProvider >> platformVMRelativeDirectories [
 ]
 
 { #category : #'loading and updating' }
+FreeTypeFontProvider >> prepareForRelease [
+
+	"When releasing an image, we should only include the embedded fonts"
+
+	self initialize.
+	self updateEmbeddedFreeTypeFonts
+
+
+]
+
+{ #category : #'loading and updating' }
 FreeTypeFontProvider >> prepareForUpdating [
 	
 	tempFileInfos := fileInfos. "tempFileInfos will be used during update"

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -98,7 +98,10 @@ ImageCleaner >> cleanUpForRelease [
 		garbageCollect;
 		cleanOutUndeclared; 
 		fixObsoleteReferences;
-		cleanUp: true except: #() confirming: false.	
+		cleanUp: true except: #() confirming: false.
+		
+	FreeTypeFontProvider current prepareForRelease.	
+	
 	HashedCollection rehashAll.		
 	Author reset
 ]


### PR DESCRIPTION
During the release process the image should be clean of the fonts that are not embedded.
Fixes #5840