### PR TITLE
Bug in the comparison of CompiledMethods

### DIFF
--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -632,6 +632,16 @@ CompiledMethodTest >> testMethodClass [
 	self assert: method methodClass equals: cls
 ]
 
+{ #category : #'as yet unclassified' }
+CompiledMethodTest >> testMethodsThatHaveOnlyDifferentSelectorsShouldBeDifferent [
+	| method1 method2 |
+	method1 := TestCase compiler compile: 'aMethod'.
+	method2 := TestCase compiler compile: 'aMethod2'.
+
+	self assert: (method1 literalAt: method1 numLiterals) identicalTo: (method2 literalAt: method2 numLiterals).
+	self deny: method1 equals: method2
+]
+
 { #category : #'tests - accessing' }
 CompiledMethodTest >> testOrigin [
 	| regularMethod methodFromTrait |

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -632,7 +632,7 @@ CompiledMethodTest >> testMethodClass [
 	self assert: method methodClass equals: cls
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'tests - comparing' }
 CompiledMethodTest >> testMethodsThatHaveOnlyDifferentSelectorsShouldBeDifferent [
 	| method1 method2 |
 	method1 := TestCase compiler compile: 'aMethod'.

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -725,8 +725,10 @@ CompiledCode >> sameLiteralsAs: method [
 							ifTrue: [ 
 								"properties"
 								"don't create properties if they don't exist"
-								(literal1 isSymbol and: [ literal2 isSymbol ]) ifFalse: [
-									(self properties analogousCodeTo: method properties) ifFalse: [ ^false ] ] ]
+								(literal1 isSymbol and: [ literal2 isSymbol ]) 
+									ifTrue: [ ^ false ]
+									ifFalse: [
+										(self properties analogousCodeTo: method properties) ifFalse: [ ^false ] ] ]
 							ifFalse: [ ^ false ] ] ] ].
 	"Class side methods have non unique (nil -> a Metaclass) as literal and cannot be compared equal"
 	literal1 := self literalAt: numLits.


### PR DESCRIPTION
There is an error in the comparison when two methods are exactly the same but only differ in the selector.