### PR TITLE
5875-Some-TTF-Fonts-are-not-visible-in-Pharo-Windows

### DIFF
--- a/src/FreeType/FreeTypeFontProvider.class.st
+++ b/src/FreeType/FreeTypeFontProvider.class.st
@@ -309,6 +309,18 @@ FreeTypeFontProvider >> getWindowsFontFolderPath [
 ]
 
 { #category : #'file paths' }
+FreeTypeFontProvider >> getWindowsLocalPaths [
+	
+	"This values should be read from the repository in the key 
+	HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\Fonts
+	However, things happened and we don't have support of the registry in the base image.
+	So this is the best alternative... or not...??  "
+
+	^ {(FileLocator home / 'AppData' / 'Local' / 'Microsoft' / 'Windows' / 'Fonts').
+	(FileLocator home / 'AppData' / 'Roaming' / 'Microsoft' / 'Windows' / 'Fonts')}
+]
+
+{ #category : #'file paths' }
 FreeTypeFontProvider >> guessWindowsFontFolderPath [
 	"Guess the location of the Windows font folder"
 	| possibilities |
@@ -590,11 +602,20 @@ FreeTypeFontProvider >> validCachedInfoFor: aFile index: i [
 
 { #category : #'file paths' }
 FreeTypeFontProvider >> winFontDirectories [
-	| directory |
-	directory := self getWindowsFontFolderPath.
-	directory ifNil: [ ^ #() ].
-	directory := directory asFileReference.
-	directory exists 
-		ifTrue: [ ^ { directory }].
-	^ #()
+	| results |
+	
+	results := OrderedCollection new.
+	
+	self getWindowsFontFolderPath
+		ifNotNil: [ :aString | | directory |
+				directory := aString asFileReference.
+				directory exists 
+					ifTrue: [ results add: directory ]].
+	
+	self getWindowsLocalPaths
+		do: [ :directory | 
+				directory exists 
+					ifTrue: [ results add: directory ]].
+		
+	^ results
 ]


### PR DESCRIPTION
Since Windows 1809, Windows allows us to install the fonts in a local directory in the user.

This values should be read from the repository in the key 
HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\Fonts

However, things happened and we don't have the support of the registry in the base image.
So we are trying with some well-known directories.

Fixes #5875 