### PR TITLE
Pharo8 Backport - Fixing problem with class trait compositions with parens.

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -192,7 +192,7 @@ BaselineOfIDE >> baseline: spec [
 BaselineOfIDE >> loadIceberg [
 	Metacello new
 		baseline: 'Iceberg';
-		repository: 'github://pharo-vcs/iceberg:v1.6.5';
+		repository: 'github://pharo-vcs/iceberg:v1.6.7';
 		onConflictUseLoaded;
 		load.
 	(Smalltalk classNamed: #Iceberg) enableMetacelloIntegration: true.

--- a/src/ClassParser/CDTraitCompositionSequenceNode.class.st
+++ b/src/ClassParser/CDTraitCompositionSequenceNode.class.st
@@ -33,3 +33,12 @@ CDTraitCompositionSequenceNode >> toString [
 	^ res	
 	
 ]
+
+{ #category : #precedence }
+CDTraitCompositionSequenceNode >> withPrecedenceOf: aCDTraitNode [
+
+	^ CDTraitPrecedenceCompositionNode new
+		sequence: sequence;
+		preferedTrait: aCDTraitNode;
+		yourself
+]

--- a/src/ClassParser/CDTraitPrecedenceCompositionNode.class.st
+++ b/src/ClassParser/CDTraitPrecedenceCompositionNode.class.st
@@ -1,0 +1,22 @@
+"
+I represent the trait composition node used when an sequence of traits has to define precedence for one of the traits.
+I am a syntax sugar to declare traits, as my behavior is exactly the same than removing all the messages of the prefered trait from the rest of the composition.
+"
+Class {
+	#name : #CDTraitPrecedenceCompositionNode,
+	#superclass : #CDTraitCompositionSequenceNode,
+	#instVars : [
+		'preferedTrait'
+	],
+	#category : #'ClassParser-Model'
+}
+
+{ #category : #accessing }
+CDTraitPrecedenceCompositionNode >> preferedTrait [
+	^ preferedTrait
+]
+
+{ #category : #accessing }
+CDTraitPrecedenceCompositionNode >> preferedTrait: anObject [
+	preferedTrait := anObject
+]

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -18,6 +18,20 @@ MCTraitDefinition class >> name: classNameString traitComposition: traitComposit
 ]
 
 { #category : #'instance creation' }
+MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray classTraitComposition: classTraitCompositionString comment: commentString commentStamp: commentStamp [
+
+	^ self new
+		initializeWithName: classNameString
+		traitComposition: traitCompositionString
+		category: categoryString
+		instVarNames: ivarArray
+		classTraitComposition: classTraitCompositionString
+		classInstVarNames: civarArray
+		comment: commentString
+		commentStamp: commentStamp
+]
+
+{ #category : #'instance creation' }
 MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray comment: commentString commentStamp: commentStamp [
 	^ self new
 		initializeWithName: classNameString
@@ -38,6 +52,18 @@ MCTraitDefinition class >> name: classNameString traitComposition: traitComposit
 		instVarNames: ivarArray
 		comment: commentString
 		commentStamp: commentStamp
+]
+
+{ #category : #'instance creation' }
+MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString classTraitComposition: classTraitComposition category: categoryString comment: commentString commentStamp: commentStamp [
+
+	^ self new
+		initializeWithName: classNameString
+		traitComposition: traitCompositionString
+		classTraitComposition: classTraitComposition
+		category: categoryString
+		comment: commentString
+		commentStamp: commentStamp 
 ]
 
 { #category : #comparing }
@@ -141,6 +167,21 @@ MCTraitDefinition >> initializeWithName: classNameString
 ]
 
 { #category : #initializing }
+MCTraitDefinition >> initializeWithName: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classTraitComposition: classTraitCompositionString classInstVarNames: civarArray comment: commentString commentStamp: commentStampString [
+
+	self
+		initializeWithName: classNameString
+		traitComposition: traitCompositionString
+		category: categoryString
+		instVarNames: ivarArray
+		classInstVarNames: civarArray
+		comment: commentString
+		commentStamp: commentStampString.
+
+		classTraitComposition := classTraitCompositionString
+]
+
+{ #category : #initializing }
 MCTraitDefinition >> initializeWithName: classNameString 
 	traitComposition:  traitCompositionString
 	category:  categoryString
@@ -156,6 +197,26 @@ MCTraitDefinition >> initializeWithName: classNameString
 		variables := OrderedCollection  new.
 		self addVariables: ivarArray ofType: MCInstanceVariableDefinition.
 
+]
+
+{ #category : #initializing }
+MCTraitDefinition >> initializeWithName: classNameString 
+	traitComposition:  traitCompositionString
+	classTraitComposition: aClassTraitComposition
+	category:  categoryString
+	instVarNames: ivarArray
+	comment:  commentString  
+	commentStamp:   commentStampString [
+
+		name := classNameString asSymbol.
+		traitComposition := traitCompositionString.
+	    category := categoryString.
+		comment := commentString withInternalLineEndings.
+		commentStamp :=  commentStampString ifNil: [self defaultCommentStamp].
+		variables := OrderedCollection  new.
+		self addVariables: ivarArray ofType: MCInstanceVariableDefinition.
+
+	classTraitComposition := aClassTraitComposition
 ]
 
 { #category : #printing }
@@ -193,11 +254,13 @@ MCTraitDefinition >> requirements [
 	testing for the first character beeing an uppercase character
 	(and thus not a special character such as {, # etc.)"
 
-	| tokens traitNames |
-	self hasTraitComposition ifFalse: [ ^Array new ].
-	tokens := traitComposition parseLiterals.
-	traitNames := tokens select: [:each | each first isUppercase].
-	^traitNames asArray
+	self hasTraitComposition
+		ifFalse: [ ^Array new ].	
+			
+	^ (((RBParser parseExpression: self traitCompositionString)
+			allChildren select: [ :e | e isVariable ])
+			collect: [ :e | e name ]
+			as: Set) asArray
 ]
 
 { #category : #printing }

--- a/src/Monticello/Trait.extension.st
+++ b/src/Monticello/Trait.extension.st
@@ -2,6 +2,11 @@ Extension { #name : #Trait }
 
 { #category : #'*Monticello' }
 Trait >> asClassDefinition [
+
+	| classTraitCompositionToUse |
+
+	classTraitCompositionToUse := self class traitCompositionString.
+
 	self needsSlotClassDefinition ifFalse: [  
 		^ MCTraitDefinition
 			name: self name
@@ -9,6 +14,7 @@ Trait >> asClassDefinition [
 			category: self category 
 			instVarNames: (self localSlots collect: #name)
 			classInstVarNames: (self class localSlots collect: #name)
+			classTraitComposition: classTraitCompositionToUse
 			comment: self organization classComment asString
 			commentStamp: self organization commentStamp ].
 		
@@ -18,6 +24,7 @@ Trait >> asClassDefinition [
 			category: self category 
 			instVarNames: (self localSlots collect: #definitionString)
 			classInstVarNames: (self classSide localSlots collect: #definitionString)
+			classTraitComposition: classTraitCompositionToUse
 			comment: self organization classComment asString
 			commentStamp: self organization commentStamp.
 		

--- a/src/Ring-Definitions-Monticello/MCTraitDefinition.extension.st
+++ b/src/Ring-Definitions-Monticello/MCTraitDefinition.extension.st
@@ -27,21 +27,6 @@ MCTraitDefinition >> classDefinitionString [
 ]
 
 { #category : #'*Ring-Definitions-Monticello' }
-MCTraitDefinition >> classTraitCompositionString [
-	^self traitComposition 
-		ifNil: [ '{}' ]
-		ifNotNil: [ :source| | tokens tcs |
-			tcs := ''.
-			tokens := source parseLiterals.
-			tokens do:[ :each| 
-				each first isUppercase 
-					ifTrue: [ tcs := tcs, each, ' classTrait + ' ] ].
-			tcs isEmpty 
-				ifTrue: [ '{}' ]
-				ifFalse:[ tcs copyFrom: 1 to: tcs size - 3 ] ]
-]
-
-{ #category : #'*Ring-Definitions-Monticello' }
 MCTraitDefinition >> printMetaDefinitionOn: stream [
 
 	stream nextPutAll: self className, ' classTrait'; 

--- a/src/TraitsV2/TaPrecedenceComposition.class.st
+++ b/src/TraitsV2/TaPrecedenceComposition.class.st
@@ -28,6 +28,8 @@ TaPrecedenceComposition >> copyWithoutTrait: aTrait [
 
 	newMembers := members collect: [ :e | e copyWithoutTrait: aTrait ] thenReject: #isEmpty.
 
+	newMembers ifEmpty: [ ^ (self class withAll: newMembers) ].
+
 	^ (self class withAll: newMembers)
 		preferedTrait: (preferedTrait copyWithoutTrait: aTrait);
 		yourself


### PR DESCRIPTION
When Monticello was saving the traits, it was not able to handle complex trait compositions with parenthesis.
This was also affecting Iceberg and Tonel, as both of them relies in the MC model.

- Adding the node of withPrecedenceOf: in the Class parser
- The trait definition has to have the class trait composition.
- Improving the handling of parentheses.
- Updating the version of iceberg and Tonel

These complex expressions are affecting Moose. 