### PR TITLE
5779 - Setting Display Scale Factor Changing

### DIFF
--- a/src/Morphic-Widgets-Scrolling/Slider.class.st
+++ b/src/Morphic-Widgets-Scrolling/Slider.class.st
@@ -7,7 +7,8 @@ Class {
 		'setValueSelector',
 		'sliderShadow',
 		'sliderColor',
-		'descending'
+		'descending',
+		'dragging'
 	],
 	#category : #'Morphic-Widgets-Scrolling'
 }
@@ -64,6 +65,16 @@ Slider >> descending: aBoolean [
 	self value: value
 ]
 
+{ #category : #access }
+Slider >> dragging [
+	^ dragging.
+]
+
+{ #category : #access }
+Slider >> dragging: aBoolean [
+	dragging := aBoolean.
+]
+
 { #category : #geometry }
 Slider >> extent: newExtent [
 	newExtent = bounds extent ifTrue: [^ self].
@@ -80,6 +91,7 @@ Slider >> initialize [
 	super initialize.
 	value := 0.0.
 	descending := false.
+	dragging := false.
 	self initializeSlider
 ]
 
@@ -110,19 +122,20 @@ Slider >> initializeSlider [
 Slider >> mouseDownInSlider: event [ 
 
 	slider borderStyle style == #raised
-		ifTrue: [slider borderColor: #inset].
+		ifTrue: [slider borderColor: #inset. self dragging: true].
 	
 	sliderShadow color: self sliderShadowColor.
 	sliderShadow cornerStyle: slider cornerStyle.
 	sliderShadow bounds: slider bounds.
-	sliderShadow show
+	sliderShadow show.
+	
 ]
 
 { #category : #'other events' }
 Slider >> mouseUpInSlider: event [ 
 
 	slider borderStyle style == #inset
-		ifTrue: [slider borderColor: #raised].
+		ifTrue: [slider borderColor: #raised. self dragging: false].
 	
 	sliderShadow hide
 ]
@@ -140,9 +153,9 @@ Slider >> roomToMove [
 { #category : #scrolling }
 Slider >> scrollAbsolute: event [
 	| r p |
-	"There is no state variable, but we know it's draggin the slider by it color if the style is not #inset there nothing to do."
-	slider borderStyle style == #inset
-		ifFalse: [ ^ self ].
+	"If I'm not dragging I will do nothing."
+	self dragging ifFalse: [ ^ self ].
+
 	r := self roomToMove.
 	bounds isWide
 		ifTrue: [ r width = 0

--- a/src/Morphic-Widgets-Scrolling/Slider.class.st
+++ b/src/Morphic-Widgets-Scrolling/Slider.class.st
@@ -140,20 +140,27 @@ Slider >> roomToMove [
 { #category : #scrolling }
 Slider >> scrollAbsolute: event [
 	| r p |
+	"There is no state variable, but we know it's draggin the slider by it color if the style is not #inset there nothing to do."
+	slider borderStyle style == #inset
+		ifFalse: [ ^ self ].
 	r := self roomToMove.
 	bounds isWide
-		ifTrue: [r width = 0 ifTrue: [^ self]]
-		ifFalse: [r height = 0 ifTrue: [^ self]].
+		ifTrue: [ r width = 0
+				ifTrue: [ ^ self ] ]
+		ifFalse: [ r height = 0
+				ifTrue: [ ^ self ] ].
 	p := event targetPoint adhereTo: r.
 	self descending
-		ifFalse:
-			[self setValue: (bounds isWide 
-				ifTrue: [(p x - r left) asFloat / r width]
-				ifFalse: [(p y - r top) asFloat / r height])]
-		ifTrue:
-			[self setValue: (bounds isWide
-				ifTrue: [(r right - p x) asFloat / r width]
-				ifFalse:	[(r bottom - p y) asFloat / r height])]
+		ifFalse: [ self
+				setValue:
+					(bounds isWide
+						ifTrue: [ (p x - r left) asFloat / r width ]
+						ifFalse: [ (p y - r top) asFloat / r height ]) ]
+		ifTrue: [ self
+				setValue:
+					(bounds isWide
+						ifTrue: [ (r right - p x) asFloat / r width ]
+						ifFalse: [ (r bottom - p y) asFloat / r height ]) ]
 ]
 
 { #category : #initialization }

--- a/src/Morphic-Widgets-Scrolling/Slider.class.st
+++ b/src/Morphic-Widgets-Scrolling/Slider.class.st
@@ -119,25 +119,30 @@ Slider >> initializeSlider [
 ]
 
 { #category : #'other events' }
-Slider >> mouseDownInSlider: event [ 
-
-	slider borderStyle style == #raised
-		ifTrue: [slider borderColor: #inset. self dragging: true].
+Slider >> mouseDownInSlider: event [
+	"When mouse down I start dragging, and change the border colors and show a shadow
+	on the original position."
+		
+	slider borderColor: #inset.
 	
 	sliderShadow color: self sliderShadowColor.
 	sliderShadow cornerStyle: slider cornerStyle.
 	sliderShadow bounds: slider bounds.
 	sliderShadow show.
 	
+	self dragging: true
 ]
 
 { #category : #'other events' }
-Slider >> mouseUpInSlider: event [ 
+Slider >> mouseUpInSlider: event [
+	"When mouse up, the dragging ends and the color is reseted to it's orignal
+	value and the shadow of original position is hidden."
 
-	slider borderStyle style == #inset
-		ifTrue: [slider borderColor: #raised. self dragging: false].
+	slider borderColor: #raised.
+				
+	sliderShadow hide.
 	
-	sliderShadow hide
+	self dragging: false.
 ]
 
 { #category : #access }


### PR DESCRIPTION
fixes #5779 

An if clause is used to return if it's not dragging the slider. MacOS and Windows, seems fixed.

Also a little comment in code and reformating for better readability.

-----

Please I made this change to correct a problem with Pharo 8 and Pharo 9 on Windows 10 and MacOS (not tested on Linux), but I don't have a complete vision of Morphic and Spec, Spec2.

The problem was that when movin the mouse over the slider it changes magically it's position, but not alwas. I saw that there was no "draggin" state, but instead the style of the slider is diferent and determines the state and used it to determine if slider is dragging.

I think adding a "dragging" and "dragging:" messages to set and retrieve the dragging state should be a cleaner way so I added that in a second commit.