### PR TITLE
5895-Flaky-Calypso-tests

### DIFF
--- a/src/Calypso-SystemQueries-Tests/ClyClassSideScopeTest.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyClassSideScopeTest.class.st
@@ -27,8 +27,8 @@ ClyClassSideScopeTest >> testClassEnumeration [
 	scope classesDo: [ :each | result add: each ].
 	
 	self
-		assert: result asArray
-		equals: {ClyClass1FromP1 classSide. ClyClass2FromP1 classSide}
+		assertCollection: result asArray
+		hasSameElements: {ClyClass1FromP1 classSide. ClyClass2FromP1 classSide}
 ]
 
 { #category : #tests }
@@ -51,7 +51,7 @@ ClyClassSideScopeTest >> testMethodsEnumerationWhenBasisIsClass [
 	scope methodsDo: [ :each | result add: each selector ].
 	
 	expected := ClyClass1FromP1 classSide localMethods collect: #selector.
-	self assert: result sorted asArray equals: expected sorted asArray
+	self assertCollection: result sorted asArray equals: expected sorted
 ]
 
 { #category : #tests }

--- a/src/Calypso-SystemQueries-Tests/ClyMethodScopeTest.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyMethodScopeTest.class.st
@@ -34,5 +34,5 @@ ClyMethodScopeTest >> testMethodsEnumeration [
 		
 	scope methodsDo: [ :each | result add: each ].
 	
-	self assert: result asArray equals: scope basisObjects asArray
+	self assertCollection: result asArray hasSameElements: scope basisObjects
 ]


### PR DESCRIPTION
Fixing some flaky tests that appearing after fixing the comparison of methods.