### PR TITLE
Revert "About-Processor-yield--Object--yield-2Version"

### DIFF
--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -2101,13 +2101,6 @@ Object >> writeSlotNamed: aName value: anObject [
 	^(self class slotNamed: aName) write: anObject to: self
 ]
 
-{ #category : #'process termination handling' }
-Object >> yieldProcessor [
-	"Suspend the active process and give back control to the scheduler. It gives a chance to other pending processes to be scheduled."
-	
-	Processor yield
-]
-
 { #category : #accessing }
 Object >> yourself [
 	"Answer self. The message yourself deserves a bit of explanation.


### PR DESCRIPTION
Reverts pharo-project/pharo#5412

Hi Stef, we need to revert the PR. It was for the Pharo 8 branch, it should be Pharo 9.