### PR TITLE
Remake PR 5412

### DIFF
--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -2102,7 +2102,7 @@ Object >> writeSlotNamed: aName value: anObject [
 ]
 
 { #category : #'process termination handling' }
-Object >> yield [ 
+Object >> yieldProcessor [
 	"Suspend the active process and give back control to the scheduler. It gives a chance to other pending processes to be scheduled."
 	
 	Processor yield

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -2101,6 +2101,13 @@ Object >> writeSlotNamed: aName value: anObject [
 	^(self class slotNamed: aName) write: anObject to: self
 ]
 
+{ #category : #'process termination handling' }
+Object >> yield [ 
+	"Suspend the active process and give back control to the scheduler. It gives a chance to other pending processes to be scheduled."
+	
+	Processor yield
+]
+
 { #category : #accessing }
 Object >> yourself [
 	"Answer self. The message yourself deserves a bit of explanation.


### PR DESCRIPTION
The original PR #5412 had to be reverted because it got integrated in the Pharo 8 branch, it should be Pharo 9.

Fixes #5409: add `Object>>yieldProcess`