### PR TITLE
5899-ZnHTTPSTest--testGetPharoVersion-is-failing-because-is-using-a-Jenkins-that-is-Down

### DIFF
--- a/src/Zinc-Zodiac/ZnHTTPSTest.class.st
+++ b/src/Zinc-Zodiac/ZnHTTPSTest.class.st
@@ -126,16 +126,18 @@ ZnHTTPSTest >> testGForceInria [
 
 { #category : #testing }
 ZnHTTPSTest >> testGetPharoVersion [
-	| client lastBuildVersion version |
+	| lastBuildVersion version url versionName |
 	self ensureSocketStreamFactory.
 	self isNativeSSLPluginPresent ifFalse: [ ^ self ].
 	self runningOnWindowsInriaCI ifTrue: [ ^ self ].
-	lastBuildVersion := (client := ZnClient new)
+	
+	versionName := SystemVersion current versionWithoutPatch.
+	
+	url := 'https://ci.inria.fr/pharo-ci-jenkins2/job/Test%20pending%20pull%20request%20and%20branch%20Pipeline/job/{version}/api/xml?xpath=/*/fullDisplayName' format: { #version -> versionName } asDictionary.
+
+	lastBuildVersion := ZnClient new
 		beOneShot;
-		get: 'https://ci.inria.fr/pharo/job/Pharo-6.0/lastSuccessfulBuild/api/xml?xpath=/*/fullDisplayName'.
-	self assert: client isSuccess.
-	self assert: (client response contentType matches: ZnMimeType applicationXml).
-	self assert: client response contentLength > 0.
+		get: url.
 	self assert: lastBuildVersion notNil.
 	self assert: lastBuildVersion isString.
 	self assert: lastBuildVersion size > 0.

--- a/src/Zinc-Zodiac/ZnHTTPSTest.class.st
+++ b/src/Zinc-Zodiac/ZnHTTPSTest.class.st
@@ -131,7 +131,7 @@ ZnHTTPSTest >> testGetPharoVersion [
 	self isNativeSSLPluginPresent ifFalse: [ ^ self ].
 	self runningOnWindowsInriaCI ifTrue: [ ^ self ].
 	
-	versionName := SystemVersion current versionWithoutPatch.
+	versionName := SystemVersion current type , SystemVersion current dottedMajorMinor.
 
 	url := ZnUrl new 
 		scheme: #https;

--- a/src/Zinc-Zodiac/ZnHTTPSTest.class.st
+++ b/src/Zinc-Zodiac/ZnHTTPSTest.class.st
@@ -132,9 +132,17 @@ ZnHTTPSTest >> testGetPharoVersion [
 	self runningOnWindowsInriaCI ifTrue: [ ^ self ].
 	
 	versionName := SystemVersion current versionWithoutPatch.
-	
-	url := 'https://ci.inria.fr/pharo-ci-jenkins2/job/Test%20pending%20pull%20request%20and%20branch%20Pipeline/job/{version}/api/xml?xpath=/*/fullDisplayName' format: { #version -> versionName } asDictionary.
 
+	url := ZnUrl new 
+		scheme: #https;
+		host: 'ci.inria.fr';
+		addPathSegments: #('pharo-ci-jenkins2' 'job' 
+			'Test pending pull request and branch Pipeline' 'job');
+		addPathSegment: versionName;
+		addPathSegments: #('api' 'xml');
+		queryAt: 'xpath' add: '/*/fullDisplayName';
+		yourself.
+	
 	lastBuildVersion := ZnClient new
 		beOneShot;
 		get: url.


### PR DESCRIPTION
Fixing the get Pharo test to use the version from the  system version.
Fixes #5899