### PR TITLE
Fix slider broken tests

### DIFF
--- a/src/Spec-PolyWidgets/SliderInput.class.st
+++ b/src/Spec-PolyWidgets/SliderInput.class.st
@@ -95,9 +95,11 @@ SliderInput >> initializePresenter [
 	slider
 		whenValueChangedDo: [ :sliderValue | 
 			| inputValue |
-			inputValue := input text asNumber. " ifNotNil: [ :text | text asNumber ]"
+			inputValue := input text
+				ifEmpty: [ 0 ]
+				ifNotEmpty: [ :text | text asNumber ].
 			sliderValue == inputValue
-				ifFalse: [ input text: sliderValue asString ] ].
+				ifFalse: [ input text: sliderValue asFloat asString ] ].
 	input
 		whenTextChanged: [ :text | 
 			| inputValue |


### PR DESCRIPTION
Issue #5897 broke a couple of spec1 tests.
I integrated a bit carelessly because the change looked simple.
So here's a fix.

 - the text can be empty (handle that case)
 - the value can be a fraction: convert it to float before transforming it to string => otherwise asNumber will fail later