### PR TITLE
Remove ActiveHand and ActiveEvent

### DIFF
--- a/src/Athens-Morphic/MenuMorph.extension.st
+++ b/src/Athens-Morphic/MenuMorph.extension.st
@@ -5,7 +5,7 @@ MenuMorph >> drawOnAthensCanvas: anAthensCanvas [
 	"Draw the menu. Add keyboard-focus feedback if appropriate"
 
 	super drawOnAthensCanvas: anAthensCanvas.
-	(ActiveHand notNil and: [ ActiveHand keyboardFocus == self and: [ self rootMenu hasProperty: #hasUsedKeyboard ] ])
+	(self activeHand notNil and: [ self activeHand keyboardFocus == self and: [ self rootMenu hasProperty: #hasUsedKeyboard ] ])
 		ifTrue: [ 
 			(anAthensCanvas setStrokePaint: self theme menuKeyboardFocusColor) width: self theme menuBorderWidth.
 			anAthensCanvas drawShape: self innerBounds ]

--- a/src/BaselineOfDisplay/BaselineOfDisplay.class.st
+++ b/src/BaselineOfDisplay/BaselineOfDisplay.class.st
@@ -67,7 +67,6 @@ BaselineOfDisplay >> postload: loader package: packageSpec [
 	Smalltalk globals at: #Display put: display.
 	display beDisplay.
 
-	Cursor classPool at: #CurrentCursor put: Cursor new.
 	Cursor webLink. "set the webLink cursor shape"
 					
 	Cursor initialize.

--- a/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
+++ b/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
@@ -79,7 +79,6 @@ BaselineOfMorphicCore >> postload: loader package: packageSpec [
 
 	Smalltalk at: #World put: world.
 	Smalltalk at: #ActiveWorld put: world.
-	Smalltalk at: #ActiveEvent put: nil.
 
 	world viewBox: Display boundingBox.
 

--- a/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
+++ b/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
@@ -75,7 +75,7 @@ BaselineOfMorphicCore >> postload: loader package: packageSpec [
 	world instVarNamed: #worldState put: WorldState new.
 	hand := HandMorph new.
 	world addHand: hand.
-	world activeHand.
+	world activeHand: hand.
 
 	Smalltalk at: #World put: world.
 	Smalltalk at: #ActiveWorld put: world.

--- a/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
+++ b/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
@@ -79,7 +79,6 @@ BaselineOfMorphicCore >> postload: loader package: packageSpec [
 
 	Smalltalk at: #World put: world.
 	Smalltalk at: #ActiveWorld put: world.
-	Smalltalk at: #ActiveHand put: hand.
 	Smalltalk at: #ActiveEvent put: nil.
 
 	world viewBox: Display boundingBox.

--- a/src/Calypso-Browser/ClyBrowserToolMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserToolMorph.class.st
@@ -449,7 +449,7 @@ ClyBrowserToolMorph >> isExtraSelectionRequested [
 	"Following mouse logic ensures that we are under condition when mouseDown+cmd was produced.
 	(it should be simple #meta modifier. But we don't have it"
 	| lastEvent |
-	lastEvent := self activeHand lastEvent.
+	lastEvent := (self activeHand ifNil: [ ^ false ])lastEvent.
 	^ lastEvent isMouse and: [ lastEvent isMouseDown 
 		and: [lastEvent commandKeyPressed or: [ lastEvent controlKeyPressed ]]]
 ]

--- a/src/Calypso-Browser/ClyBrowserToolMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserToolMorph.class.st
@@ -449,7 +449,7 @@ ClyBrowserToolMorph >> isExtraSelectionRequested [
 	"Following mouse logic ensures that we are under condition when mouseDown+cmd was produced.
 	(it should be simple #meta modifier. But we don't have it"
 	| lastEvent |
-	lastEvent := ActiveHand lastEvent.
+	lastEvent := self activeHand lastEvent.
 	^ lastEvent isMouse and: [ lastEvent isMouseDown 
 		and: [lastEvent commandKeyPressed or: [ lastEvent controlKeyPressed ]]]
 ]

--- a/src/Commander-Activators-Mouse/CmdMouseCommandActivation.class.st
+++ b/src/Commander-Activators-Mouse/CmdMouseCommandActivation.class.st
@@ -137,8 +137,8 @@ CmdMouseCommandActivation >> initialize [
 { #category : #testing }
 CmdMouseCommandActivation >> isActiveInContext: aToolContext [
 	| mouseEvent |
-	mouseEvent := ActiveHand lastEvent.
-	
+	mouseEvent := aToolContext currentWorld activeHand lastEvent.
+
 	^(self matchesEvent: mouseEvent)
 		and: [super isActiveInContext: aToolContext]
 ]

--- a/src/EpiceaBrowsers/EpLogBrowserToolbarPresenter.class.st
+++ b/src/EpiceaBrowsers/EpLogBrowserToolbarPresenter.class.st
@@ -39,7 +39,7 @@ EpLogBrowserToolbarPresenter >> beHistoryMode [
 		icon: (self iconNamed: #smallFindIcon);
 		action: [
 			logBrowserPresenter filtersSubMenu
-				openWithSpecAt: ActiveHand position ]
+				openWithSpecAt: self currentWorld activeHand position ]
 ]
 
 { #category : #accessing }

--- a/src/GT-Spotter-UI/GTSpotterContentsBrick.class.st
+++ b/src/GT-Spotter-UI/GTSpotterContentsBrick.class.st
@@ -106,3 +106,9 @@ GTSpotterContentsBrick >> spotterModel: aModel [
 
 	spotterModel announcer when: GTSpotterStepAdded send: #onStepAdded to: self.
 ]
+
+{ #category : #'events-processing' }
+GTSpotterContentsBrick >> takeKeyboardFocus [
+
+	self headerBrick takeKeyboardFocus
+]

--- a/src/GT-Spotter-UI/GTSpotterDropDownMorph.class.st
+++ b/src/GT-Spotter-UI/GTSpotterDropDownMorph.class.st
@@ -39,7 +39,10 @@ GTSpotterDropDownMorph >> spotterModel [
 GTSpotterDropDownMorph >> spotterModel: aModel [ 
 	spotterModel := aModel.
 	
-	spotterModel steps do: [ :each | self pushPane: (self buildPane: each) ].
+	spotterModel steps do: [ :each | | pane |
+		pane := self buildPane: each.
+		self pushPane: pane.
+		pane initializeListeners ].
 	
 	spotterModel announcer when: GTSpotterStepAdded send: #onStepAdded: to: self.
 ]

--- a/src/GT-Spotter-UI/GTSpotterGlobalShortcut.class.st
+++ b/src/GT-Spotter-UI/GTSpotterGlobalShortcut.class.st
@@ -23,7 +23,9 @@ GTSpotterGlobalShortcut class >> openGlobalSpotter [
 		extent: (self currentWorld width / 2.4 @ (self currentWorld height / 1.6)) asIntegerPoint;
 		spotterModel: spotterModel;
 		doLayout;
-		openCenteredInWorld.
+		openCenteredInWorld;
+		initializeListeners;
+		takeKeyboardFocus.
 		
 	spotterModel class markOpened.
 ]

--- a/src/GT-Spotter-UI/GTSpotterHeaderBrick.class.st
+++ b/src/GT-Spotter-UI/GTSpotterHeaderBrick.class.st
@@ -153,11 +153,7 @@ GTSpotterHeaderBrick >> searchField [
 GTSpotterHeaderBrick >> searchField: aBrick [
 
 	searchField := aBrick.
-	
-	self themer spotterThemer searchFieldStyleFor: searchField.
-	
-	searchField morph takeKeyboardFocus.
-	
+	self themer spotterThemer searchFieldStyleFor: searchField.	
 	self addBrickBack: searchField
 ]
 
@@ -200,4 +196,11 @@ GTSpotterHeaderBrick >> spotterModel: aModel [
 	
 	self spotterModel announcer when: GTSpotterRevealHints send: #onRevealHints to: self.
 	self spotterModel announcer when: GTSpotterHideHints send: #onHideHints to: self.
+]
+
+{ #category : #'event handling' }
+GTSpotterHeaderBrick >> takeKeyboardFocus [
+	
+	searchField morph takeKeyboardFocus
+
 ]

--- a/src/GT-Spotter-UI/GTSpotterMorph.class.st
+++ b/src/GT-Spotter-UI/GTSpotterMorph.class.st
@@ -152,7 +152,6 @@ GTSpotterMorph >> initialize [
 	"setting custom brick themer for the whole spotter"
 	self themer: self themer spotterThemer themer.
 	
-	self initializeListeners.
 	self themer spotterThemer spotterStyleFor: self.
 	
 	self breadcrumbBrick: self newBreadcrumbBrick.
@@ -383,6 +382,12 @@ GTSpotterMorph >> stepScrollPageDown [
 GTSpotterMorph >> stepScrollPageUp [
 
 	self spotterModel currentStep announcer announce: (GTSpotterScrollPageUp new)
+]
+
+{ #category : #'events-processing' }
+GTSpotterMorph >> takeKeyboardFocus [
+
+	self paneBrick takeKeyboardFocus
 ]
 
 { #category : #actions }

--- a/src/GT-Spotter-UI/GTSpotterPaneBrick.class.st
+++ b/src/GT-Spotter-UI/GTSpotterPaneBrick.class.st
@@ -119,3 +119,9 @@ GTSpotterPaneBrick >> spotterModel: aSpotter [
 	self arrowBrick spotterModel: aSpotter.
 	self previewBrick spotterModel: aSpotter
 ]
+
+{ #category : #protocol }
+GTSpotterPaneBrick >> takeKeyboardFocus [
+
+	self contentsBrick takeKeyboardFocus
+]

--- a/src/Glamour-Morphic-Brick/GLMBrickGeometryTrait.trait.st
+++ b/src/Glamour-Morphic-Brick/GLMBrickGeometryTrait.trait.st
@@ -4,7 +4,6 @@ I declare api and logic to work with geometry of a Brick
 Trait {
 	#name : #GLMBrickGeometryTrait,
 	#traits : 'GLMBrickExtensionTrait',
-	#classTraits : 'GLMBrickExtensionTrait classTrait',
 	#category : #'Glamour-Morphic-Brick-Traits'
 }
 

--- a/src/Glamour-Morphic-Brick/GLMBrickLayoutTrait.trait.st
+++ b/src/Glamour-Morphic-Brick/GLMBrickLayoutTrait.trait.st
@@ -4,7 +4,6 @@ I declare api and logic to layout Bricks
 Trait {
 	#name : #GLMBrickLayoutTrait,
 	#traits : 'GLMBrickExtensionTrait',
-	#classTraits : 'GLMBrickExtensionTrait classTrait',
 	#category : #'Glamour-Morphic-Brick-Traits'
 }
 

--- a/src/Glamour-Morphic-Brick/GLMBrickPropertiesTrait.trait.st
+++ b/src/Glamour-Morphic-Brick/GLMBrickPropertiesTrait.trait.st
@@ -4,7 +4,6 @@ I declare api and logic to work with properties of a Brick, such as color, shado
 Trait {
 	#name : #GLMBrickPropertiesTrait,
 	#traits : 'GLMBrickExtensionTrait',
-	#classTraits : 'GLMBrickExtensionTrait classTrait',
 	#category : #'Glamour-Morphic-Brick-Traits'
 }
 

--- a/src/Glamour-Morphic-Brick/GLMEmptyPopupBrick.class.st
+++ b/src/Glamour-Morphic-Brick/GLMEmptyPopupBrick.class.st
@@ -55,7 +55,8 @@ GLMEmptyPopupBrick >> addCloserListener [
 		description: [ 'Closer must not be nil' ].
 	
 	self closer popup: self.
-	self activeHand addEventListener: self closer
+	self activeHand ifNotNil: [ :hand | 
+		hand addEventListener: self closer ]
 ]
 
 { #category : #accessing }
@@ -403,7 +404,8 @@ GLMEmptyPopupBrick >> removeCloserListener [
 		assert: [ self closer isNotNil ]
 		description: [ 'Closer must not be nil' ].
 	
-	self activeHand removeEventListener: self closer.
+	self activeHand ifNotNil: [ :hand |
+		hand removeEventListener: self closer ].
 	self closer popup: nil
 ]
 

--- a/src/Glamour-Morphic-Brick/GLMEmptyPopupBrick.class.st
+++ b/src/Glamour-Morphic-Brick/GLMEmptyPopupBrick.class.st
@@ -55,8 +55,7 @@ GLMEmptyPopupBrick >> addCloserListener [
 		description: [ 'Closer must not be nil' ].
 	
 	self closer popup: self.
-	self activeHand ifNotNil: [ :hand | 
-		hand addEventListener: self closer ]
+	self activeHand addEventListener: self closer
 ]
 
 { #category : #accessing }
@@ -404,8 +403,7 @@ GLMEmptyPopupBrick >> removeCloserListener [
 		assert: [ self closer isNotNil ]
 		description: [ 'Closer must not be nil' ].
 	
-	self activeHand ifNotNil: [ :hand |
-		hand removeEventListener: self closer ].
+	self activeHand removeEventListener: self closer.
 	self closer popup: nil
 ]
 

--- a/src/Glamour-Morphic-Brick/GLMScrollPaneBrick.class.st
+++ b/src/Glamour-Morphic-Brick/GLMScrollPaneBrick.class.st
@@ -203,7 +203,7 @@ GLMScrollPaneBrick >> initialize [
 GLMScrollPaneBrick >> initializeListeners [
 
 	"using the most general event subscribtion for all events spawned by the hand"
-	self activeHand addEventListener: self.
+	self activeHand ifNotNil: [ :hand | hand addEventListener: self ].
 ]
 
 { #category : #'scrollpane-testing' }

--- a/src/Glamour-Morphic-Brick/GLMScrollPaneBrick.class.st
+++ b/src/Glamour-Morphic-Brick/GLMScrollPaneBrick.class.st
@@ -194,9 +194,7 @@ GLMScrollPaneBrick >> initialize [
 
 	self useVerticalLinearLayout.
 	self band: self newBand.
-	self verticalScrollbar: self newVerticalScrollbar.	
-	"initializes listener for mouse wheel scroll on windows vm"
-	self initializeListeners
+	self verticalScrollbar: self newVerticalScrollbar.
 ]
 
 { #category : #initialization }

--- a/src/Glamour-Morphic-Widgets/GLMPopper.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMPopper.class.st
@@ -69,7 +69,6 @@ GLMPopper >> originMorphFor: aMorph [
 GLMPopper >> updateWithString: string from: aMorph [
 	textMorph textArea
 		updateTextWith: string;
-		takeKeyboardFocus;
 		on: Character escape do: [ 
 			self delete.
 			aMorph textArea removeHighlightSegment.

--- a/src/Glamour-Morphic-Widgets/GLMPrintPopper.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMPrintPopper.class.st
@@ -109,7 +109,6 @@ GLMPrintPopper >> openFromRubric: aMorph withResult: anObject [
 			aMorph editor atEndOfLineInsertAndSelect: string.
 			aMorph takeKeyboardFocus ].
 	inspectButton addUpAction: [ anObject inspect ].
-	self
-		openInWorld;
-		takeKeyboardFocus
+	self openInWorld.
+	textMorph takeKeyboardFocus
 ]

--- a/src/Glamour-Morphic-Widgets/GLMPrintPopper.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMPrintPopper.class.st
@@ -109,5 +109,7 @@ GLMPrintPopper >> openFromRubric: aMorph withResult: anObject [
 			aMorph editor atEndOfLineInsertAndSelect: string.
 			aMorph takeKeyboardFocus ].
 	inspectButton addUpAction: [ anObject inspect ].
-	self openInWorld
+	self
+		openInWorld;
+		takeKeyboardFocus
 ]

--- a/src/Glamour-Tests-Morphic/GLMPharoScriptMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMPharoScriptMorphicTest.class.st
@@ -27,10 +27,10 @@ GLMPharoScriptMorphicTest >> testExplicitAcceptDoesNotAffectTextPort [
 
 	textMorph := self find: RubScrolledTextMorph in: window.
 	textMorph simulateClick.
-	self simulateKeyStrokes: '4'.
+	self simulateKeyStrokes: '4' inWorld: textMorph world.
 	self assert: (composite pane port: #text) value equals: '1234'.
-	self simulateKeyStroke: $s meta.
-	self simulateKeyStrokes: '56'.
+	self simulateKeyStroke: $s meta inWorld: textMorph world.
+	self simulateKeyStrokes: '56' inWorld: textMorph world.
 	self assert: (composite pane port: #text) value equals: '123456'
 ]
 

--- a/src/Glamour-Tests-Morphic/GLMTextMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMTextMorphicTest.class.st
@@ -21,10 +21,10 @@ GLMTextMorphicTest >> testExplicitAcceptDoesNotAffectTextPort [
 
 	textMorph := self find: RubScrolledTextMorph in: window.
 	self simulateOnlyOneClickOn: textMorph.
-	self simulateKeyStrokes: '4'.
+	self simulateKeyStrokes: '4' inWorld: textMorph world.
 	self assert: (composite pane port: #text) value equals: '1234'.
-	self simulateKeyStroke: $s meta.
-	self simulateKeyStrokes: '56'.
+	self simulateKeyStroke: $s meta inWorld: textMorph world.
+	self simulateKeyStrokes: '56' inWorld: textMorph world.
 	self assert: (composite pane port: #text) value equals: '123456'
 ]
 

--- a/src/Glamour-Tests-Rubric/GLMRubricTextMorphicTest.class.st
+++ b/src/Glamour-Tests-Rubric/GLMRubricTextMorphicTest.class.st
@@ -39,7 +39,7 @@ GLMRubricTextMorphicTest >> noTestAcceptKeyCanBeOverriden [
 	self simulateOnlyOneClickOn: textMorph.
 	(Delay forMilliseconds: HandMorph doubleClickTime + 1) wait.
 	"self simulateOnlyOneClickOn: textMorph."
-	self assert: ActiveHand keyboardFocus equals: textMorph textArea.
+	self assert: textMorph activeHand keyboardFocus equals: textMorph textArea.
 	
 	shortcut := $s meta asKeyCombination.
 	textMorph textArea handleKeystroke: (KeyboardEvent new
@@ -60,7 +60,7 @@ GLMRubricTextMorphicTest >> noTestEnteringTextInPort [
 	window := composite openOn: 4.
 	textMorph := self find: RubScrolledTextMorph in: window.
 	self simulateOnlyOneClickOn: textMorph.
-	self simulateKeyStrokes: 'hello'.
+	self simulateKeyStrokes: 'hello' inWorld: textMorph world.
 	self assert: (composite pane port: #text) value asString equals: 'hello'
 ]
 
@@ -71,10 +71,10 @@ GLMRubricTextMorphicTest >> noTestExplicitAcceptDoesNotAffectTextPort [
 	window := composite openOn: 4.
 	textMorph := self find: RubScrolledTextMorph in: window.
 	self simulateOnlyOneClickOn: textMorph.
-	self simulateKeyStrokes: '4'.
+	self simulateKeyStrokes: '4' inWorld: textMorph world.
 	self assert: (composite pane port: #text) value asString equals: '1234'.
-	self simulateKeyStroke: $s meta.
-	self simulateKeyStrokes: '56'.
+	self simulateKeyStroke: $s meta inWorld: textMorph world.
+	self simulateKeyStrokes: '56' inWorld: textMorph world.
 	self assert: (composite pane port: #text) value asString equals: '123456'
 ]
 

--- a/src/Graphics-Display Objects/Cursor.class.st
+++ b/src/Graphics-Display Objects/Cursor.class.st
@@ -1082,7 +1082,7 @@ Cursor >> printOn: aStream [
 { #category : #displaying }
 Cursor >> show [
 	"Make the hardware's mouse cursor look like the receiver"
-	self currentWorld currentCursor: self
+	self currentWorld activeHand currentCursor: self
 ]
 
 { #category : #displaying }

--- a/src/Graphics-Display Objects/Cursor.class.st
+++ b/src/Graphics-Display Objects/Cursor.class.st
@@ -32,7 +32,6 @@ Class {
 		'BottomRightCursor',
 		'CornerCursor',
 		'CrossHairCursor',
-		'CurrentCursor',
 		'DownCursor',
 		'MarkerCursor',
 		'MenuCursor',
@@ -126,24 +125,6 @@ Cursor class >> crossHair [
 	"Answer the instance of me that is the shape of a cross."
 
 	^CrossHairCursor
-]
-
-{ #category : #'current cursor' }
-Cursor class >> currentCursor [
-	"Answer the instance of Cursor that is the one currently displayed."
-
-	^ ActiveHand ifNotNil: [ActiveHand currentCursor] ifNil: [ CurrentCursor ]
-]
-
-{ #category : #'current cursor' }
-Cursor class >> currentCursor: aCursor [ 
-	"Make the instance of cursor, aCursor, be the current cursor. Display it."
-
-	ActiveHand ifNotNil: [
-		ActiveHand currentCursor: aCursor.
-		^ self ].
-
-	CurrentCursor := aCursor	
 ]
 
 { #category : #constants }
@@ -1067,11 +1048,6 @@ Cursor >> hasMask [
 	^false
 ]
 
-{ #category : #testing }
-Cursor >> isCurrent [
-	^ self class currentCursor == self 
-]
-
 { #category : #primitives }
 Cursor >> primitiveBeCursor [
 	"Primitive. Tell the interpreter to use the receiver as the current cursor 
@@ -1106,15 +1082,14 @@ Cursor >> printOn: aStream [
 { #category : #displaying }
 Cursor >> show [
 	"Make the hardware's mouse cursor look like the receiver"
-
-	self class currentCursor: self
+	self currentWorld currentCursor: self
 ]
 
 { #category : #displaying }
 Cursor >> showWhile: aBlock [ 
 	"While evaluating the argument, aBlock, make the receiver be the cursor shape."
 	| oldcursor |
-	oldcursor := self class currentCursor.
+	oldcursor := self currentWorld currentCursor.
 	self show.
 	^aBlock ensure: [oldcursor show]
 

--- a/src/Growl/GrowlMorph.class.st
+++ b/src/Growl/GrowlMorph.class.st
@@ -372,7 +372,7 @@ GrowlMorph >> resetVanishTimer [
 { #category : #stepping }
 GrowlMorph >> step [
 
-	(self containsPoint: ActiveHand position) ifTrue: [
+	(self containsPoint: self activeHand position) ifTrue: [
 		self resetAlpha.
 		^ self].
 	vanishTime ifNotNil: [DateAndTime now < vanishTime ifTrue: [^self]].

--- a/src/Morphic-Base/MenuMorph.class.st
+++ b/src/Morphic-Base/MenuMorph.class.st
@@ -45,7 +45,7 @@ MenuMorph class >> chooseFrom: aList lines: linesArray title: queryString [
 		menu add: (aList at: i) asString target: [:v| result := v] selector: #value: argument: i.
 		(linesArray includes: i) ifTrue: [menu addLine]].
 	
-	menu invokeAt: ActiveHand position in: self currentWorld allowKeyboard: true.
+	menu invokeAt: self activeHand position in: self currentWorld allowKeyboard: true.
 	^result
 ]
 
@@ -70,7 +70,7 @@ MenuMorph class >> chooseFrom: aList values: valueList lines: linesArray title: 
 		menu add: (aList at: i) asString target: [:v| result := v] selector: #value: argument: (valueList at: i).
 		(linesArray includes: i) ifTrue:[menu addLine]].
 
-	menu invokeAt: ActiveHand position in: self currentWorld allowKeyboard: true.
+	menu invokeAt: self activeHand position in: self currentWorld allowKeyboard: true.
 	^result
 ]
 
@@ -129,7 +129,7 @@ MenuMorph class >> confirm: queryString trueChoice: trueChoice falseChoice: fals
 		selector: #value:
 		argument: false.
 	[ menu
-		invokeAt: ActiveHand position
+		invokeAt: self activeHand position
 		in: self currentWorld
 		allowKeyboard: true.
 	result isNil ] whileTrue.
@@ -765,8 +765,8 @@ MenuMorph >> drawOn: aCanvas [
 
 	super drawOn: aCanvas.
 
-	(ActiveHand notNil
-			and: [ActiveHand keyboardFocus == self
+	(self activeHand notNil
+			and: [ self activeHand keyboardFocus == self
 					and: [self rootMenu hasProperty: #hasUsedKeyboard]])
 		ifTrue: [
 			aCanvas
@@ -924,7 +924,7 @@ MenuMorph >> invokeModal [
 MenuMorph >> invokeModal: allowKeyboardControl [
 	"Invoke this menu and don't return until the user has chosen a value.  If the allowKeyboarControl boolean is true, permit keyboard control of the menu"
 
-	^ self invokeModalAt: ActiveHand position in: self currentWorld allowKeyboard: allowKeyboardControl
+	^ self invokeModalAt: self activeHand position in: self currentWorld allowKeyboard: allowKeyboardControl
 ]
 
 { #category : #'modal control' }
@@ -1263,7 +1263,7 @@ MenuMorph >> popUpEvent: evt in: aWorld [
 	"Present this menu in response to the given event."
 
 	| aHand aPosition |
-	aHand := evt ifNotNil: [evt hand] ifNil: [ActiveHand].
+	aHand := evt ifNotNil: [evt hand] ifNil: [ self activeHand ].
 	aPosition := aHand position truncated.
 	^ self popUpAt: aPosition forHand: aHand in: aWorld
 
@@ -1297,7 +1297,7 @@ MenuMorph >> popUpInWorld: aWorld [
 MenuMorph >> popUpNoKeyboard [
 	"Present this menu in the current World, *not* allowing keyboard input into the menu"
 
-	^ self popUpAt: ActiveHand position forHand: ActiveHand in: self currentWorld allowKeyboard: false
+	^ self popUpAt: self activeHand position forHand: self activeHand in: self currentWorld allowKeyboard: false
 ]
 
 { #category : #accessing }
@@ -1335,7 +1335,7 @@ MenuMorph >> positionAt: aPoint relativeTo: aMenuItem inWorld: aWorld [
 
 	"Make sure that the menu fits in the world."
 	delta := self bounds amountToTranslateWithin:
-		(aWorld worldBounds withHeight: ((aWorld worldBounds height - 18) max: (ActiveHand position y) + 1)).
+		(aWorld worldBounds withHeight: ((aWorld worldBounds height - 18) max: (self activeHand position y) + 1)).
 	delta = (0 @ 0) ifFalse: [self position: self position + delta]
 ]
 

--- a/src/Morphic-Base/MenuMorph.class.st
+++ b/src/Morphic-Base/MenuMorph.class.st
@@ -1335,7 +1335,7 @@ MenuMorph >> positionAt: aPoint relativeTo: aMenuItem inWorld: aWorld [
 
 	"Make sure that the menu fits in the world."
 	delta := self bounds amountToTranslateWithin:
-		(aWorld worldBounds withHeight: ((aWorld worldBounds height - 18) max: (self activeHand position y) + 1)).
+		(aWorld worldBounds withHeight: ((aWorld worldBounds height - 18) max: (aWorld activeHand position y) + 1)).
 	delta = (0 @ 0) ifFalse: [self position: self position + delta]
 ]
 

--- a/src/Morphic-Base/Object.extension.st
+++ b/src/Morphic-Base/Object.extension.st
@@ -62,7 +62,7 @@ Object >> currentEvent [
 Object >> currentHand [
 	"Return a usable HandMorph -- the one associated with the object's current environment.  This method will always return a hand, even if it has to conjure one up as a last resort.  If a particular hand is actually handling events at the moment (such as a remote hand or a ghost hand), it will be returned."
 
-	^ActiveHand ifNil: [ self currentWorld primaryHand ]
+	^ self currentWorld primaryHand
 ]
 
 { #category : #'*Morphic-Base' }

--- a/src/Morphic-Base/Object.extension.st
+++ b/src/Morphic-Base/Object.extension.st
@@ -55,7 +55,7 @@ Object >> asTextMorph [
 { #category : #'*Morphic-Base' }
 Object >> currentEvent [
 	"Answer the current Morphic event.  This method never returns nil."
-	^ActiveEvent ifNil:[self currentHand lastEvent]
+	^ self currentHand lastEvent
 ]
 
 { #category : #'*Morphic-Base' }

--- a/src/Morphic-Base/Paragraph.class.st
+++ b/src/Morphic-Base/Paragraph.class.st
@@ -261,7 +261,7 @@ Paragraph >> click: anEvent for: model controller: editor [
 		(attribute actOnClick: anEvent for: target in: self editor: editor) == true 	
 			ifTrue: [ ^ true ]].
 	
-	(action and: [ Cursor currentCursor == Cursor webLink]) 
+	(action and: [ self currentWorld currentCursor == Cursor webLink]) 
 		ifTrue:[ Cursor normal show ].
 	
 	^ action
@@ -645,7 +645,7 @@ Paragraph >> move: anEvent for: model controller: editor [
 		(attribute actOnMove: anEvent for: target in: self editor: editor) == true 	
 			ifTrue: [ ^ true ]].
 	
-	(action and: [ Cursor currentCursor == Cursor webLink]) 
+	(action and: [ self currentWorld currentCursor == Cursor webLink]) 
 		ifTrue:[ Cursor normal show ].
 	
 	^ action

--- a/src/Morphic-Base/Rectangle.extension.st
+++ b/src/Morphic-Base/Rectangle.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : #Rectangle }
 
 { #category : #'*Morphic-Base' }
-Rectangle class >> activeHand [
-
-	^ ActiveHand
-]
-
-{ #category : #'*Morphic-Base' }
 Rectangle >> asLayoutFrame [
 	"Answer an instance of LayoutFrame which uses fractions from receiver "
 	
@@ -35,32 +29,41 @@ Rectangle class >> fromUser [
 	designate the top left and bottom right corners. The gridding for user 
 	selection is 1@1."
 
-	^self fromUser: 1 @ 1
+	^ self fromUser: 1 @ 1
 ]
 
 { #category : #'*Morphic-Base' }
 Rectangle class >> fromUser: gridPoint [ 
+
+	^ self fromUser: gridPoint inWorld: World
+]
+
+{ #category : #'*Morphic-Base' }
+Rectangle class >> fromUser: gridPoint inWorld: aWorld [
 	"Answer a Rectangle that is determined by having the user 
 	designate the top left and bottom right corners. 
 	The cursor reamins linked with the sensor, but
 	the outline is kept gridded."
 	| originRect |
-	self activeHand showTemporaryCursor: Cursor origin.
+	aWorld activeHand showTemporaryCursor: Cursor origin.
 
-	originRect :=  ((self activeHand cursorPoint grid: gridPoint) extent: 0 @ 0) 
-					newRectFrom: [ :f :pt | (pt grid: gridPoint) extent: 0 @ 0 ].
+	originRect :=  ((aWorld activeHand cursorPoint grid: gridPoint) extent: 0 @ 0) 
+					newRectFrom: [ :f :pt | (pt grid: gridPoint) extent: 0 @ 0 ]
+					inWorld: aWorld.
 					
-	self activeHand showTemporaryCursor: Cursor bottomRight.
+	aWorld activeHand showTemporaryCursor: Cursor bottomRight.
 
-	^  originRect newRectFrom: [ :f :pt | f origin corner: (pt grid: gridPoint) ]
+	^  originRect
+			newRectFrom: [ :f :pt | f origin corner: (pt grid: gridPoint) ]
+			inWorld: aWorld
 ]
 
 { #category : #'*Morphic-Base' }
-Rectangle >> newRectButtonPressedDo: newRectBlock [ 
+Rectangle >> newRectButtonPressedDo: newRectBlock inWorld: aWorld [
 	"Track the outline of a new rectangle until mouse button changes. newFrameBlock produces each new rectangle from the previous. Only tracks while mouse is down."
 	| rect newRect buttonNow hand |
 	
-	hand := self currentWorld activeHand.
+	hand := aWorld activeHand.
 	
 	buttonNow := hand anyButtonPressed.
 	rect := self.
@@ -80,18 +83,18 @@ Rectangle >> newRectButtonPressedDo: newRectBlock [
 		].
 	
 	self drawReverseFrame: rect.
-	self currentWorld activeHand
+	aWorld activeHand
 		newMouseFocus: nil;
 		showTemporaryCursor: nil.
 	^ rect
 ]
 
 { #category : #'*Morphic-Base' }
-Rectangle >> newRectFrom: newRectBlock [ 
+Rectangle >> newRectFrom: newRectBlock inWorld: aWorld [
 	"Track the outline of a new rectangle until mouse button changes. newFrameBlock produces each new rectangle from the previous"
 	| rect newRect buttonStart buttonNow  hand |
 
-	hand := self currentWorld activeHand.
+	hand := aWorld activeHand.
 	
 	buttonStart := buttonNow := hand anyButtonPressed.
 	rect := self.

--- a/src/Morphic-Base/SelectionMorph.class.st
+++ b/src/Morphic-Base/SelectionMorph.class.st
@@ -376,7 +376,7 @@ SelectionMorph >> duplicate [
 	selectedItems :=  selectedItems collect: #duplicate.
 	selectedItems reverseDo: [:m | (owner ifNil: [self currentWorld]) addMorph: m].
 	dupLoc := self position.
-	ActiveHand grabMorph: self.
+	self activeHand grabMorph: self.
 	
 ]
 

--- a/src/Morphic-Base/TransferMorph.class.st
+++ b/src/Morphic-Base/TransferMorph.class.st
@@ -56,7 +56,7 @@ TransferMorph class >> withPassenger: anObject from: source [
 TransferMorph class >> withPassenger: anObject from: source hand: dragHand [
 	| hand |
 	
-	hand := (dragHand ifNil:[ ActiveHand ]).
+	hand := dragHand.
 	
 	^ self new
 		passenger: anObject;

--- a/src/Morphic-Base/WorldMorph.extension.st
+++ b/src/Morphic-Base/WorldMorph.extension.st
@@ -48,7 +48,6 @@ WorldMorph >> install [
 	owner := nil.	"since we may have been inside another world previously"
 	ActiveWorld := self.
 	World := self.
-	ActiveEvent := nil.
 	submorphs do: [ :ss | ss owner ifNil: [ ss privateOwner: self ] ].	"Transcript that was in outPointers and then got deleted."
 	self viewBox: Display boundingBox.
 	Sensor flushAllButDandDEvents.
@@ -85,7 +84,6 @@ WorldMorph >> installForUIProcessReinstall [
 	SystemWindow noteTopWindowIn: self.
 	World  := self.
 	ActiveWorld := self.
-	ActiveEvent := nil.
 	worldState handsDo: [ :h | h releaseCachedState ].
 	Sensor startUp.
 	self class startUp.

--- a/src/Morphic-Base/WorldMorph.extension.st
+++ b/src/Morphic-Base/WorldMorph.extension.st
@@ -48,7 +48,6 @@ WorldMorph >> install [
 	owner := nil.	"since we may have been inside another world previously"
 	ActiveWorld := self.
 	World := self.
-	ActiveHand := self hands first.	"default"
 	ActiveEvent := nil.
 	submorphs do: [ :ss | ss owner ifNil: [ ss privateOwner: self ] ].	"Transcript that was in outPointers and then got deleted."
 	self viewBox: Display boundingBox.
@@ -86,7 +85,6 @@ WorldMorph >> installForUIProcessReinstall [
 	SystemWindow noteTopWindowIn: self.
 	World  := self.
 	ActiveWorld := self.
-	ActiveHand := self hands first.	"default"
 	ActiveEvent := nil.
 	worldState handsDo: [ :h | h releaseCachedState ].
 	Sensor startUp.

--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -55,7 +55,6 @@ HandMorph class >> attach: aMorph [
 HandMorph class >> cleanUp [
 	"Called from ImageCleaner>>cleanUpForRelease --> SmalltalkImage>>cleanUp:except:confirming:"
 	self logEventStatsStop.
-	ActiveHand resetClickState.
 
 
 ]
@@ -278,15 +277,15 @@ HandMorph >> copyToPasteBuffer: aMorph [
 { #category : #cursor }
 HandMorph >> currentCursor [
 
-	^ ActiveHand world currentCursor
+	^ self world currentCursor
 ]
 
 { #category : #cursor }
 HandMorph >> currentCursor: aCursor [
 
-	ActiveHand world currentCursor: aCursor.
-		ActiveHand world isCursorOwner ifTrue: [
-			aCursor activateInCursorOwner: ActiveHand world ]
+	self world currentCursor: aCursor.
+	self world isCursorOwner ifTrue: [
+		aCursor activateInCursorOwner: self world ]
 ]
 
 { #category : #accessing }
@@ -1267,7 +1266,6 @@ HandMorph >> sendFocusEvent: anEvent to: focusHolder clear: aBlock [
 	| result w |
 	w := focusHolder world ifNil:[^ aBlock value].
 	w becomeActiveDuring:[
-		ActiveHand := self.
 		ActiveEvent := anEvent.
 		result := focusHolder handleFocusEvent: 
 			(anEvent transformedBy: (focusHolder transformedFrom: self)).

--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -1256,9 +1256,7 @@ HandMorph >> sendEvent: anEvent focus: focusHolder clear: aBlock [
 	"Send the event to the morph currently holding the focus, or if none to the owner of the hand."
 	| result |
 	focusHolder ifNotNil:[^self sendFocusEvent: anEvent to: focusHolder clear: aBlock].
-	ActiveEvent := anEvent.
 	result := owner processEvent: anEvent.
-	ActiveEvent := nil.
 	^result
 ]
 
@@ -1268,7 +1266,6 @@ HandMorph >> sendFocusEvent: anEvent to: focusHolder clear: aBlock [
 	| result w |
 	w := focusHolder world ifNil:[^ aBlock value].
 	w becomeActiveDuring:[
-		ActiveEvent := anEvent.
 		result := focusHolder handleFocusEvent: 
 			(anEvent transformedBy: (focusHolder transformedFrom: self)).
 	].

--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -1036,9 +1036,11 @@ HandMorph >> processEventsFromQueue: anEventQueue [
 
 	| evt evtBuf type hadAny |
 
-	ActiveEvent
-		ifNotNil: [ "Meaning that we were invoked from within an event response.
-		Make sure z-order is up to date" self mouseOverHandler processMouseOver: lastMouseEvent ].
+	self lastEvent ifNotNil: [
+		"Meaning that we were invoked from within an event response.
+		Make sure z-order is up to date"
+		self mouseOverHandler processMouseOver: lastMouseEvent ].
+
 	hadAny := false.
 	[ anEventQueue isNotNil and: [ ( evtBuf := anEventQueue nextEvent ) isNotNil ] ]
 		whileTrue: [ evt := nil.	"for unknown event types"

--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -881,11 +881,11 @@ HandMorph >> needsToBeDrawn [
 				]])
 		ifTrue: [
 			"using the software cursor; hide the hardware one"
-			Cursor blank isCurrent ifFalse: [Cursor blank show].
+			self currentCursor == Cursor blank ifFalse: [Cursor blank show].
 			^ true].
 	"Switch from one hardware cursor to another, if needed."
 	cursor := hardwareCursor ifNil: [Cursor normal].
-	cursor isCurrent ifFalse: [cursor show].
+	self currentCursor == cursor ifFalse: [cursor show].
 	^ false
 
 ]
@@ -1210,7 +1210,7 @@ HandMorph >> restoreSavedPatchOn: aCanvas [
 						extent: savedPatch extent + self shadowOffset)
 				from: self.
 			cursor := hardwareCursor ifNil: [Cursor normal].
-			cursor isCurrent ifFalse: [cursor show].	"show hardware cursor"
+			self currentCursor == cursor ifFalse: [cursor show].	"show hardware cursor"
 			savedPatch := nil]
 ]
 

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -230,8 +230,8 @@ Morph >> actionMap [
 { #category : #structure }
 Morph >> activeHand [
 	| world |
-   world := self world ifNil: [^ ActiveHand ].
-   ^ world activeHand ifNil: [ ^ ActiveHand  ]
+   world := self world ifNil: [^ nil ].
+   ^ world activeHand
 ]
 
 { #category : #menus }

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -2218,11 +2218,13 @@ Morph >> doFastReframe: ptName [
 
 	| newBounds |
 	"For fast display, only higlight the rectangle during loop"
-	newBounds := self boundsInWorld newRectButtonPressedDo: [:rectangle :cursorPoint | 
-		rectangle
-			withSideOrCorner: ptName
-			setToPoint: cursorPoint
-			minExtent: self minimumExtent].
+	newBounds := self boundsInWorld
+		newRectButtonPressedDo: [:rectangle :cursorPoint | 
+			rectangle
+				withSideOrCorner: ptName
+				setToPoint: cursorPoint
+				minExtent: self minimumExtent
+		] inWorld: self world.
 	Display deferUpdatesIn: Display boundingBox while: [
 		self bounds: newBounds].
 

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -6789,7 +6789,7 @@ Morph >> yellowButtonActivity: shiftState [
 				ifNil: [^ false].
 			outerOwner == self
 				ifFalse: [^ outerOwner yellowButtonActivity: shiftState]].
-	menu := self buildYellowButtonMenu: ActiveHand.
+	menu := self buildYellowButtonMenu: self activeHand.
 	menu
 		addTitle: self externalName
 		icon: (self iconOrThumbnailOfSize: 28).

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -5734,7 +5734,7 @@ Morph >> simulateKeyStroke: aCharacter [
 				position: 0@0 
 				keyValue: aCharacter charCode 
 				charCode: aCharacter charCode
-				hand: ActiveHand 
+				hand: self activeHand 
 				stamp: 0.
 	self keyStroke: event
 ]

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -1544,7 +1544,7 @@ Morph >> buildYellowButtonMenu: aHand [
 	"build the morph menu for the yellow button"
 	| menu |
 	menu := UIManager default newMenuIn: self for: self.
-	self addNestedYellowButtonItemsTo: menu event: ActiveEvent.
+	self addNestedYellowButtonItemsTo: menu event: self activeHand lastEvent.
 	^ menu
 ]
 
@@ -5336,7 +5336,7 @@ Morph >> resistsRemovalString [
 Morph >> resizeFromMenu [
 	"Commence an interaction that will resize the receiver"
 
-	self resizeMorph: ActiveEvent
+	self resizeMorph: self activeHand lastEvent
 ]
 
 { #category : #'debug and other' }

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -2116,9 +2116,11 @@ Morph >> delete [
 	new owner be nil."
 	
 	self removeHalo.
-	self activeHand 
-		releaseKeyboardFocus: self;
-		releaseMouseFocus: self.
+	self activeHand ifNotNil: [ :hand |
+		hand
+			releaseKeyboardFocus: self;
+			releaseMouseFocus: self.
+	].
 	owner ifNotNil:[ 
 		self privateDelete.
 		self announceDeleted.

--- a/src/Morphic-Core/PasteUpMorph.class.st
+++ b/src/Morphic-Core/PasteUpMorph.class.st
@@ -665,7 +665,7 @@ PasteUpMorph >> invokeWorldMenu: evt [
 
 { #category : #'world menu' }
 PasteUpMorph >> invokeWorldMenuFromEscapeKey [
-	self invokeWorldMenu: ActiveEvent
+	self invokeWorldMenu: self activeHand lastEvent
 ]
 
 { #category : #cursor }

--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -91,13 +91,11 @@ WorldMorph class >> displayScaleFactorSettingsOn: aBuilder [
 { #category : #'initialize-release' }
 WorldMorph class >> doOneCycle [
 	self extraWorldList do: [:world |
-		ActiveHand := world activeHand.
 		world doOneCycle.
 	].
 
 	(self currentWorld isNotNil and: [(self extraWorldList includes: self currentWorld) not]) ifTrue: [
 		self currentWorld doOneCycle.
-		ActiveHand := self currentWorld activeHand
 	]
 ]
 
@@ -201,19 +199,16 @@ WorldMorph >> becomeActiveDuring: aBlock [
 	Note that this method does deliberately *not* use #ensure: to prevent
 	re-installation of the world on project switches."
 
-	| priorWorld priorHand priorEvent |
+	| priorWorld priorEvent |
 	priorWorld := ActiveWorld.
-	priorHand := ActiveHand.
 	priorEvent := ActiveEvent.
 	ActiveWorld := self.
-	ActiveHand := self hands first.	"default"
 	ActiveEvent := nil.	"not in event cycle"
 	aBlock
 		on: Error
 		do: [ :ex | 
 			ActiveWorld := priorWorld.
 			ActiveEvent := priorEvent.
-			ActiveHand := priorHand.
 			ex pass ]
 ]
 

--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -199,7 +199,7 @@ WorldMorph >> becomeActiveDuring: aBlock [
 	Note that this method does deliberately *not* use #ensure: to prevent
 	re-installation of the world on project switches."
 
-	| priorWorld priorEvent |
+	| priorWorld |
 	priorWorld := ActiveWorld.
 	ActiveWorld := self.
 	aBlock

--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -201,14 +201,11 @@ WorldMorph >> becomeActiveDuring: aBlock [
 
 	| priorWorld priorEvent |
 	priorWorld := ActiveWorld.
-	priorEvent := ActiveEvent.
 	ActiveWorld := self.
-	ActiveEvent := nil.	"not in event cycle"
 	aBlock
 		on: Error
 		do: [ :ex | 
 			ActiveWorld := priorWorld.
-			ActiveEvent := priorEvent.
 			ex pass ]
 ]
 

--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -299,7 +299,6 @@ WorldState >> activeHand [
 
 { #category : #hands }
 WorldState >> activeHand: aHand [
-	ActiveHand := aHand.
 	activeHand := aHand
 ]
 
@@ -744,8 +743,6 @@ WorldState >> removeHand: aHandMorph [
 	(hands includes: aHandMorph) ifFalse: [^self].
 	hands := hands copyWithout: aHandMorph.
 	activeHand == aHandMorph ifTrue: [activeHand := nil].
-	ActiveHand == aHandMorph ifTrue: [ActiveHand := nil].
-
 ]
 
 { #category : #canvas }

--- a/src/Morphic-Widgets-Pluggable/PluggableListMorph.class.st
+++ b/src/Morphic-Widgets-Pluggable/PluggableListMorph.class.st
@@ -1534,7 +1534,7 @@ PluggableListMorph >> startDrag: evt [
 	evt hand hasSubmorphs ifTrue: [^ self]. 
 	self dragEnabled ifFalse: [^ self].
 	"Here I ensure at least one element is selected "
-	ActiveHand anyButtonPressed ifFalse: [ ^self ].
+	self activeHand anyButtonPressed ifFalse: [ ^self ].
 			
 	draggedItem := self getListItem: (self mouseDownRow ifNil: [ self lastNonZeroIndex ]).
 	draggedItem ifNil: [ ^ self ].

--- a/src/Morphic-Widgets-Pluggable/PluggableListMorph.class.st
+++ b/src/Morphic-Widgets-Pluggable/PluggableListMorph.class.st
@@ -1296,11 +1296,11 @@ PluggableListMorph >> selectAll [
 PluggableListMorph >> selectSearchedElement [
 
 	self searchedElement ifNotNil: [: index |	
-			 ActiveEvent commandKeyPressed	ifFalse: [ self resetListSelectionSilently ].
-			self changeModelSelection: index.
-			self isMultipleSelection
-				ifTrue: [ self listSelectionAt: index put: true ].
-			self vScrollValue: ((index-1)/self getListSize) ]
+		self activeHand lastEvent commandKeyPressed	ifFalse: [ self resetListSelectionSilently ].
+		self changeModelSelection: index.
+		self isMultipleSelection
+			ifTrue: [ self listSelectionAt: index put: true ].
+		self vScrollValue: ((index-1)/self getListSize) ]
 ]
 
 { #category : #selection }
@@ -1470,7 +1470,7 @@ PluggableListMorph >> specialKeyPressed: anEvent [
 	keyString := anEvent keyString.
 	keyString = '<escape>'
 		ifTrue: [" escape key"
-			^ ActiveEvent shiftPressed
+			^ self activeHand lastEvent shiftPressed
 				ifTrue:
 					[self currentWorld invokeWorldMenuFromEscapeKey]
 				ifFalse:[ 

--- a/src/Morphic-Widgets-Tabs/TabBarMorph.class.st
+++ b/src/Morphic-Widgets-Tabs/TabBarMorph.class.st
@@ -334,7 +334,7 @@ TabBarMorph >> popUpMenu [
 	| menu |
 	
 	menu := self selectedTab menu.
-	menu popUpAt: menuButton bottomRight forHand: ActiveHand in: self currentWorld
+	menu popUpAt: menuButton bottomRight forHand: self activeHand in: self currentWorld
 ]
 
 { #category : #private }

--- a/src/Morphic-Widgets-Windows/CollapsedMorph.class.st
+++ b/src/Morphic-Widgets-Windows/CollapsedMorph.class.st
@@ -79,7 +79,7 @@ CollapsedMorph >> uncollapseToHand [
 	nakedMorph setProperty: #collapsedPosition toValue: self position.
 	mustNotClose := false.  "so the delete will succeed"
 	self delete.
-	ActiveHand attachMorph: nakedMorph
+	self activeHand attachMorph: nakedMorph
 ]
 
 { #category : #'resize/collapse' }

--- a/src/Morphic-Widgets-Windows/GroupWindowMorph.class.st
+++ b/src/Morphic-Widgets-Windows/GroupWindowMorph.class.st
@@ -222,7 +222,7 @@ GroupWindowMorph >> update: aSymbol with: anObject [
 		ifTrue: [ |selectedPage|
 				selectedPage := self tabGroup pages at: anObject ifAbsent: [nil].
 				selectedPage ifNotNil: [
-						selectedPage rememberKeyboardFocus: ActiveHand keyboardFocus.
+						selectedPage rememberKeyboardFocus: self activeHand keyboardFocus.
 						self tabGroup page ifNotNil: [self tabGroup page activate].]
 				]
 ]

--- a/src/Morphic-Widgets-Windows/ProportionalSplitterMorph.class.st
+++ b/src/Morphic-Widgets-Windows/ProportionalSplitterMorph.class.st
@@ -137,7 +137,7 @@ ProportionalSplitterMorph >> initialize [
 
 { #category : #testing }
 ProportionalSplitterMorph >> isCursorOverHandle [
-	^ self class showSplitterHandles not or: [self handleRect containsPoint: ActiveHand cursorPoint]
+	^ self class showSplitterHandles not or: [self handleRect containsPoint: self activeHand cursorPoint]
 ]
 
 { #category : #accessing }

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1575,7 +1575,7 @@ SystemWindow >> privateBePassive [
 	self isInWorld ifFalse: [ ^self ].
 	
 	self 
-	rememberKeyboardFocus: ActiveHand keyboardFocus;
+	rememberKeyboardFocus: self activeHand keyboardFocus;
 	passivate;
 	announceDeActivated
 

--- a/src/NECompletion-Morphic/NECMenuMorph.class.st
+++ b/src/NECompletion-Morphic/NECMenuMorph.class.st
@@ -642,8 +642,7 @@ NECMenuMorph >> selectedEntry [
 { #category : #actions }
 NECMenuMorph >> show [
 	self resize.
-	self activeHand 
-		newMouseFocus: self.
+	self activeHand ifNotNil: [ :hand | hand newMouseFocus: self ].
 	self changed.
 ]
 

--- a/src/OSWindow-SDL2/OSSDL2WindowHandle.class.st
+++ b/src/OSWindow-SDL2/OSSDL2WindowHandle.class.st
@@ -316,14 +316,6 @@ OSSDL2WindowHandle >> releaseMouse [
 	SDL2 setRelativeMouseMode: false
 ]
 
-{ #category : #private }
-OSSDL2WindowHandle >> resetKeyboardFocus [
-		
-	ActiveHand ifNil: [ ^ self ].
-	lastKeyboardFocus := ActiveHand keyboardFocus.
-	ActiveHand keyboardFocus: nil
-]
-
 { #category : #accessing }
 OSSDL2WindowHandle >> resizable [
 	^ handle getFlags anyMask: SDL_WINDOW_RESIZABLE
@@ -338,19 +330,6 @@ OSSDL2WindowHandle >> resizable: aBoolean [
 OSSDL2WindowHandle >> restore [
 
 	handle restore
-]
-
-{ #category : #private }
-OSSDL2WindowHandle >> restoreKeyboardFocus [
-
-	(handle isNil 
-		or: [ lastKeyboardFocus isNil 
-		or: [ ActiveHand isNil ] ])
-		ifTrue: [ ^ self ].
-	
-	[ ActiveHand keyboardFocus: lastKeyboardFocus ]
-	ensure: [ 
-		lastKeyboardFocus := nil ]
 ]
 
 { #category : #'window management' }
@@ -536,10 +515,8 @@ OSSDL2WindowHandle >> visitWindowEvent: windowEvent [
 	windowEvent event = SDL_WINDOWEVENT_LEAVE ifTrue: [ 
 		^ (OSWindowMouseLeaveEvent for: osWindow) deliver ].
 	windowEvent event = SDL_WINDOWEVENT_FOCUS_GAINED ifTrue: [ 
-		self restoreKeyboardFocus.
 		^ (OSWindowFocusInEvent for: osWindow) deliver ].
 	windowEvent event = SDL_WINDOWEVENT_FOCUS_LOST ifTrue: [ 
-		self resetKeyboardFocus.		
 		^ (OSWindowFocusOutEvent for: osWindow) deliver ].
 	windowEvent event = SDL_WINDOWEVENT_MAXIMIZED ifTrue: [ 
 		^ (OSWindowMaximizedEvent for: osWindow) deliver ].

--- a/src/OSWindow-VM/OSVMWindowHandle.class.st
+++ b/src/OSWindow-VM/OSVMWindowHandle.class.st
@@ -105,8 +105,8 @@ OSVMWindowHandle >> screenDepth [
 { #category : #accessing }
 OSVMWindowHandle >> setMouseCursor: cursorWithMask [
 
-	Cursor currentCursor == cursorWithMask ifFalse: [  
-		Cursor currentCursor: cursorWithMask ].
+	World currentCursor == cursorWithMask ifFalse: [  
+		World currentCursor: cursorWithMask ].
 ]
 
 { #category : #accessing }

--- a/src/Polymorph-Widgets/Morph.extension.st
+++ b/src/Polymorph-Widgets/Morph.extension.st
@@ -333,7 +333,7 @@ Morph >> tabKey: event [
 Morph >> takeKeyboardFocus [
 	"Make the receiver the keyboard focus for the active hand."
 
-	self activeHand ifNotNil: [ :hand | hand newKeyboardFocus: self]
+	self activeHand newKeyboardFocus: self
 ]
 
 { #category : #'*Polymorph-Widgets' }

--- a/src/Polymorph-Widgets/Morph.extension.st
+++ b/src/Polymorph-Widgets/Morph.extension.st
@@ -333,7 +333,7 @@ Morph >> tabKey: event [
 Morph >> takeKeyboardFocus [
 	"Make the receiver the keyboard focus for the active hand."
 
-	self activeHand newKeyboardFocus: self
+	self activeHand ifNotNil: [ :hand | hand newKeyboardFocus: self]
 ]
 
 { #category : #'*Polymorph-Widgets' }

--- a/src/Polymorph-Widgets/Morph.extension.st
+++ b/src/Polymorph-Widgets/Morph.extension.st
@@ -333,7 +333,7 @@ Morph >> tabKey: event [
 Morph >> takeKeyboardFocus [
 	"Make the receiver the keyboard focus for the active hand."
 
-	self activeHand newKeyboardFocus: self
+	self activeHand ifNotNil: [ :hand | hand newKeyboardFocus: self ]
 ]
 
 { #category : #'*Polymorph-Widgets' }

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -432,7 +432,6 @@ MorphicUIManager >> lowSpaceWatcherDefaultAction: theInterruptedProcess [
 	| preemptedProcess projectProcess debugSession |
 	ActiveWorld := self currentWorld. "reinstall active globals"
 	self currentWorld primaryHand interrupted.
-	ActiveEvent := nil.
 
 	projectProcess := self uiProcess.	"we still need the accessor for a while"
 	preemptedProcess := theInterruptedProcess ifNil: [Processor preemptedProcess].

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -430,10 +430,8 @@ Here are some suggestions:
 MorphicUIManager >> lowSpaceWatcherDefaultAction: theInterruptedProcess [
 	"Create a Notifier on the active scheduling process with the given label."
 	| preemptedProcess projectProcess debugSession |
-	ActiveHand ifNotNil:[ActiveHand interrupted].
 	ActiveWorld := self currentWorld. "reinstall active globals"
-	ActiveHand := self currentWorld primaryHand.
-	ActiveHand interrupted. "make sure this one's interrupted too"
+	self currentWorld primaryHand interrupted.
 	ActiveEvent := nil.
 
 	projectProcess := self uiProcess.	"we still need the accessor for a while"

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -33,7 +33,7 @@ MorphicUIManager class >> isValidForCurrentSystemConfiguration [
 MorphicUIManager >> activate [
 
 	World worldState worldRenderer: (AbstractWorldRenderer detectCorrectOneforWorld: World).
-	Cursor currentCursor: Cursor currentCursor.
+	World currentCursor: World currentCursor.
 		
 	WorldMorph currentWorld ifNotNil: [:world | world restoreMorphicDisplay].
 	WorldMorph extraWorldList do: #restoreMorphicDisplay.

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -2147,6 +2147,7 @@ RubAbstractTextArea >> yellowButtonActivity: shiftKeyState [
 		ifFalse: [ ^ false ].	
 	(self getMenu: shiftKeyState)
 		ifNotNil: [ :menu|
+			menu privateOwner: self.
 			menu setInvokingView: self editor.
 			menu invokeModal. 
 			self changed.

--- a/src/Rubric/RubFloatingEditorBuilder.class.st
+++ b/src/Rubric/RubFloatingEditorBuilder.class.st
@@ -176,6 +176,7 @@ RubFloatingEditorBuilder >> handleListenEvent: anEvent [
 		ifFalse: [ ^ self ].
 	anEvent isMouseDown
 		ifFalse: [ ^ self ].
+	editor ifNil: [ ^ self ].
 	(editor boundsInWorld containsPoint: anEvent position)
 		ifFalse: [ self closeEditor ]
 ]
@@ -229,7 +230,8 @@ RubFloatingEditorBuilder >> openEditorWithContents: aText thenDo: aBlock [
 
 { #category : #'announcement handling' }
 RubFloatingEditorBuilder >> whenEditorDeleted: anAnnouncement [
-	anAnnouncement morph activeHand removeEventListener: self.
+	anAnnouncement morph activeHand ifNotNil: [ :hand | 
+		hand removeEventListener: self ].
 	anAnnouncement morph announcer unsubscribe: self.
 	editor := nil
 ]

--- a/src/Rubric/RubParagraph.class.st
+++ b/src/Rubric/RubParagraph.class.st
@@ -94,7 +94,7 @@ RubParagraph >> click: anEvent for: model controller: editor [
 		(attribute rubActOnClick: anEvent for: target in: self editor: editor) == true 	
 			ifTrue: [ ^ true ]].
 	
-	(action and: [ Cursor currentCursor == Cursor webLink]) 
+	(action and: [ self currentWorld currentCursor == Cursor webLink]) 
 		ifTrue:[ Cursor normal show ].
 	
 	^ action
@@ -443,7 +443,7 @@ RubParagraph >> move: anEvent for: model controller: editor [
 		(attribute actOnMove: anEvent for: target in: self editor: editor) == true 	
 			ifTrue: [ ^ true ]].
 	
-	(action and: [ Cursor currentCursor == Cursor webLink]) 
+	(action and: [ self currentWorld currentCursor == Cursor webLink]) 
 		ifTrue:[ Cursor normal show ].
 	
 	^ action

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -1704,7 +1704,7 @@ RubTextEditor >> offerFontMenu: aKeyboardEvent [
 { #category : #deprecated }
 RubTextEditor >> offerMenuFromEsc: aKeyboardEvent [
 	"The escape key was hit while the receiver has the keyboard focus; take action"
- 	ActiveEvent shiftPressed 
+ 	textArea activeHand lastEvent shiftPressed 
 		ifFalse: [ self raiseContextMenu: aKeyboardEvent].
 	^ false 	
 ]
@@ -1823,7 +1823,7 @@ RubTextEditor >> previousWord: position [
 { #category : #'nonediting/nontyping keys' }
 RubTextEditor >> raiseContextMenu: aKeyboardEvent [
 
-	^ textArea yellowButtonActivity: ActiveEvent shiftPressed
+	^ textArea yellowButtonActivity: textArea activeHand lastEvent shiftPressed
 ]
 
 { #category : #'accessing-selection' }

--- a/src/SUnit-Support-UITesting-Tests/SimulateKeystrokesTest.class.st
+++ b/src/SUnit-Support-UITesting-Tests/SimulateKeystrokesTest.class.st
@@ -12,8 +12,8 @@ SimulateKeystrokesTest >> testSimulateCmdKeystroke [
 
 	| ws |
 	ws := Smalltalk tools workspace open.
-	self simulateKeyStrokes: 'var := 3.'.
-	self simulateKeyStroke: $s meta.
+	self simulateKeyStrokes: 'var := 3.' inWorld: ws world.
+	self simulateKeyStroke: $s meta inWorld: ws world.
 	self assert: ws hasUnacceptedEdits equals:false.
 	ws delete.
 ]
@@ -25,7 +25,7 @@ SimulateKeystrokesTest >> testSimulateKeystroke [
 	textMorph := TextMorph new contents: ''; openInWorld.
 	self assert: textMorph canChangeText.
 	textMorph takeKeyboardFocus.
-	self simulateKeyStroke: $s.
+	self simulateKeyStroke: $s inWorld: textMorph world.
 	self assert: textMorph contents asString equals: 's'.
 	textMorph delete.
 ]
@@ -37,7 +37,7 @@ SimulateKeystrokesTest >> testSimulateKeystrokes [
 	textMorph := TextMorph new contents: ''; openInWorld.
 	self assert: textMorph canChangeText.
 	textMorph takeKeyboardFocus.
-	self simulateKeyStrokes: 'hello'.
+	self simulateKeyStrokes: 'hello' inWorld: textMorph world.
 	self assert: textMorph contents asString equals: 'hello'.
 	textMorph delete.
 ]

--- a/src/SUnit-Support-UITesting/TestCase.extension.st
+++ b/src/SUnit-Support-UITesting/TestCase.extension.st
@@ -1,13 +1,13 @@
 Extension { #name : #TestCase }
 
 { #category : #'*SUnit-Support-UITesting' }
-TestCase >> simulateKeyStroke: aCharacterOrShortcut [
+TestCase >> simulateKeyStroke: aCharacterOrShortcut inWorld: aWorld [
 
-	ActiveHand simulateKeyStroke: aCharacterOrShortcut.
+	aWorld activeHand simulateKeyStroke: aCharacterOrShortcut.
 ]
 
 { #category : #'*SUnit-Support-UITesting' }
-TestCase >> simulateKeyStrokes: aString [ 
+TestCase >> simulateKeyStrokes: aString inWorld: aWorld [
 
-	ActiveHand simulateKeyStrokes: aString.
+	aWorld activeHand simulateKeyStrokes: aString.
 ]

--- a/src/Spec-MorphicAdapters/SpecTransferMorph.class.st
+++ b/src/Spec-MorphicAdapters/SpecTransferMorph.class.st
@@ -15,7 +15,7 @@ SpecTransferMorph >> initialize [
 
 	super initialize.
 
-	dragHand := ActiveHand
+	dragHand := self activeHand
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Adapters-Morphic/SpMorphicButtonAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicButtonAdapter.class.st
@@ -169,7 +169,7 @@ SpMorphicButtonAdapter >> showSubMenu: aMenu [
 		popUpAdjacentTo: { 
 			self widget bounds bottomLeft.
 			self widget bounds bottomRight }
-		forHand: ActiveHand
+		forHand: self widget activeHand
 		from: self widget.
 	subMenuWidget popUpOwner: self
 ]

--- a/src/Spec2-Adapters-Morphic/SpTransferMorph.class.st
+++ b/src/Spec2-Adapters-Morphic/SpTransferMorph.class.st
@@ -15,7 +15,7 @@ SpTransferMorph >> initialize [
 
 	super initialize.
 
-	dragHand := ActiveHand
+	dragHand := self activeHand
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Backend-Tests/SpMockMenu.class.st
+++ b/src/Spec2-Backend-Tests/SpMockMenu.class.st
@@ -18,6 +18,12 @@ SpMockMenu >> initialize [
 	shown := false
 ]
 
+{ #category : #owner }
+SpMockMenu >> privateOwner: aRubEditingArea [ 
+	
+	"Nothing"
+]
+
 { #category : #accessing }
 SpMockMenu >> realMenu [
 	^ realMenu

--- a/src/Text-Edition/StrikeFont.extension.st
+++ b/src/Text-Edition/StrikeFont.extension.st
@@ -42,7 +42,7 @@ StrikeFont class >> fromUser: priorFont allowKeyboard: aBoolean [
 			add: label
 			subMenu: ptMenu ].
 	spec := fontMenu 
-		invokeModalAt: ActiveHand position
+		invokeModalAt: self currentWorld activeHand position
 		in: self currentWorld
 		allowKeyboard: aBoolean.
 	spec ifNil: [ ^ nil ].

--- a/src/Text-Edition/TextEditor.class.st
+++ b/src/Text-Edition/TextEditor.class.st
@@ -2292,7 +2292,7 @@ TextEditor >> offerFontMenu: aKeyboardEvent [
 { #category : #deprecated }
 TextEditor >> offerMenuFromEsc: aKeyboardEvent [
 	"The escape key was hit while the receiver has the keyboard focus; take action"
- 	ActiveEvent shiftPressed 
+ 	morph activeHand lastEvent shiftPressed 
 		ifFalse: [ self raiseContextMenu: aKeyboardEvent].
 	^ false 	
 ]
@@ -2447,7 +2447,7 @@ TextEditor >> processKeyStroke: aKeyboardEvent [
 TextEditor >> raiseContextMenu: aKeyboardEvent [
 
 	(morph respondsTo: #editView)
-		ifTrue: [ ^ morph editView yellowButtonActivity: ActiveEvent shiftPressed].
+		ifTrue: [ ^ morph editView yellowButtonActivity: morph activeHand lastEvent shiftPressed].
 	^ true
 ]
 


### PR DESCRIPTION
Fixes #5908.

Mostly, delegate the obtention to the active hand to the active world.
This raises a couple of issues:

 - some non-morph objects try to access the world => they should get it as argument
 - some morph objects try to get their world before being installed in the system

A summary of changes:
 - Remove global cursor usages. `Cursor X isCurrent` requires access to a world
 - `ActiveHand` => `self activeHand`, or `morph activeHand`
 - take care of objects trying to get keyboard focus before shown/installed in the world.
 - `ActiveEvent` => `aMorph activeHand lastEvent`

My image behaves pretty well after these changes.
We should see a bootstrapped image.