### PR TITLE
Reduce users of current world

### DIFF
--- a/src/BlueInk-Extras/BISettingPreviewer.class.st
+++ b/src/BlueInk-Extras/BISettingPreviewer.class.st
@@ -48,7 +48,7 @@ BISettingPreviewer class >> defaultSpec [
 { #category : #settings }
 BISettingPreviewer class >> dialogOpenBIPreviewer [
 	^ self theme
-		newRowIn: self currentWorld
+		newRowIn: self
 		for:
 			{(self theme buttonLabelForText: 'Open Blue Ink Setting Previewer ').
 			self buildOpenBIInspectorButton}
@@ -159,7 +159,7 @@ BISettingPreviewer >> compiledMethodFromSearchFields [
 BISettingPreviewer >> displayNodeFor: aNode [
 	| nodeMorphLeft nodeMorphRight |
 	nodeMorphLeft := StringMorph contents: aNode item label.
-	nodeMorphRight := (self theme newRowIn: self currentWorld for: {aNode settingDeclaration inputWidget})
+	nodeMorphRight := (self theme newRowIn: self for: {aNode settingDeclaration inputWidget})
 		clipSubmorphs: true;
 		cellInset: 0;
 		width: 570;

--- a/src/Calypso-Browser/ClyBrowserModeSwitchMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserModeSwitchMorph.class.st
@@ -37,7 +37,7 @@ ClyBrowserModeSwitchMorph >> beBoldIfActive [
 { #category : #accessing }
 ClyBrowserModeSwitchMorph >> build [
 	radioButton := self theme 
-		newRadioButtonIn: World 
+		newRadioButtonIn: self
 		for: self 
 		getSelected: #isModeActive 
 		setSelected: #toggleMode:

--- a/src/Calypso-SystemTools-QueryBrowser/ClyScopeCompoBox.class.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyScopeCompoBox.class.st
@@ -45,7 +45,7 @@ ClyScopeCompoBox >> browser: aMethodBrowser [
 { #category : #initialization }
 ClyScopeCompoBox >> build [
 	dropList := self theme 
-		newDropListIn: World
+		newDropListIn: self
 		for: self 
 		list: #scopeNames
 		getSelected: #currentScopeIndex 

--- a/src/EmbeddedFreeType/SourceCodeFonts.class.st
+++ b/src/EmbeddedFreeType/SourceCodeFonts.class.st
@@ -20,7 +20,7 @@ SourceCodeFonts class >> defaultFontName [
 { #category : #accessing }
 SourceCodeFonts class >> fontButton: aString size: size [ 
 	^ (Smalltalk ui theme 
-		newButtonIn: self currentWorld
+		newButtonIn: self
 			for: self
 			getState: nil 
 			action: #setSourceCodeFonts:	
@@ -42,7 +42,7 @@ SourceCodeFonts class >> fontSourceCodeRow [
 	| theme |
 	
 	theme := Smalltalk ui theme.
-	^ theme newRowIn: self currentWorld for: {
+	^ theme newRowIn: self for: {
 		theme buttonLabelForText: 'Predefined styles: ' translated.
 		self fontButton: 'Small' size: self sizeSmall.
 		self fontButton: 'Medium' size: self sizeMedium.

--- a/src/EnlumineurFormatterUI/EFSettingPreviewer2.class.st
+++ b/src/EnlumineurFormatterUI/EFSettingPreviewer2.class.st
@@ -155,7 +155,7 @@ EFSettingPreviewer2 class >> defaultSpec [
 { #category : #settings }
 EFSettingPreviewer2 class >> dialogOpenBIPreviewer [
 	^ Smalltalk ui theme
-		newRowIn: World
+		newRowIn: self
 		for:
 			{(Smalltalk ui theme buttonLabelForText: 'Open Setting Previewer ').
 			self buildOpenBIInspectorButton}

--- a/src/FreeType/FreeTypeSystemSettings.class.st
+++ b/src/FreeType/FreeTypeSystemSettings.class.st
@@ -97,7 +97,7 @@ o NONE: use the original glyph shapes without snapping their features to pixel b
 { #category : #settings }
 FreeTypeSystemSettings class >> ft2LibraryVersion [
 	^ Smalltalk ui theme 
-		newLabelIn: self currentWorld 
+		newLabelIn: self 
 		for: self 
 		label: 'Available version: ', FT2Version current asString 
 		getEnabled: nil.

--- a/src/Glamour-FastTable/GLMFastListDataSource.class.st
+++ b/src/Glamour-FastTable/GLMFastListDataSource.class.st
@@ -128,7 +128,7 @@ GLMFastListDataSource >> rowMorphForElement: element [
 	rowElements
 		add: (self formatedDisplayValueOf: element) asMorph asReadOnlyMorph;
 		addAll: (self tagMorphsFrom: self glamourPresentation for: element).
-	^ self theme newRowIn: self currentWorld for: rowElements
+	^ self theme newRowIn: self for: rowElements
 ]
 
 { #category : #selecting }

--- a/src/Glamour-FastTable/GLMFastListOutlineDataSource.class.st
+++ b/src/Glamour-FastTable/GLMFastListOutlineDataSource.class.st
@@ -102,7 +102,7 @@ GLMFastListOutlineDataSource >> rowMorphForElement: element [
 	rowElements
 		add: (self formatedDisplayValueOf: element) asMorph;
 		addAll: (self tagMorphsFrom: self glamourPresentation for: element).
-	^ self theme newRowIn: self currentWorld for: rowElements
+	^ self theme newRowIn: self for: rowElements
 ]
 
 { #category : #accessing }

--- a/src/Glamour-FastTable/GLMFastTreeDataSource.class.st
+++ b/src/Glamour-FastTable/GLMFastTreeDataSource.class.st
@@ -161,7 +161,7 @@ GLMFastTreeDataSource >> rowMorphForItem: anItem [
 	rowElements
 		add: (self formatedDisplayValueOf: anItem data) asMorph asReadOnlyMorph;
 		addAll: (self tagMorphsFrom: self glamourPresentation for: anItem data).
-	^ Smalltalk ui theme newRowIn: self currentWorld for: rowElements
+	^ Smalltalk ui theme newRowIn: self for: rowElements
 ]
 
 { #category : #selecting }

--- a/src/Glamour-FastTable/TGLMFastTableColumnsRenderer.trait.st
+++ b/src/Glamour-FastTable/TGLMFastTableColumnsRenderer.trait.st
@@ -104,7 +104,7 @@ TGLMFastTableColumnsRenderer >> rowMorphForColumn: aColumn item: anItem withInde
 			node: (self dataFromPresentationItem: anItem)
 			withIndex: aRowIndex ).
 		
-	^ Smalltalk ui theme newRowIn: self currentWorld for: rowElements
+	^ Smalltalk ui theme newRowIn: self for: rowElements
 ]
 
 { #category : #'accessing - cache' }

--- a/src/Glamour-Morphic-Brick-Tests/GLMBrickTest.class.st
+++ b/src/Glamour-Morphic-Brick-Tests/GLMBrickTest.class.st
@@ -65,6 +65,12 @@ GLMBrickTest >> assertWidthDirty: aBrick [
 	self assert: aBrick wrappedBounds isWidthClean not
 ]
 
+{ #category : #defaults }
+GLMBrickTest >> displayScaleFactor [
+
+	^ self currentWorld displayScaleFactor
+]
+
 { #category : #'instance creation' }
 GLMBrickTest >> markFullyClean: aBrick [ 
 
@@ -138,7 +144,7 @@ GLMBrickTest >> staticExtent [
 { #category : #defaults }
 GLMBrickTest >> staticHeight [
 
-	^ 100 * self currentWorld displayScaleFactor
+	^ 100 * self displayScaleFactor
 ]
 
 { #category : #defaults }
@@ -150,19 +156,19 @@ GLMBrickTest >> staticSmallExtent [
 { #category : #defaults }
 GLMBrickTest >> staticSmallHeight [
 
-	^ 50 * self currentWorld displayScaleFactor
+	^ 50 * self displayScaleFactor
 ]
 
 { #category : #defaults }
 GLMBrickTest >> staticSmallWidth [
 
-	^ 50 * self currentWorld displayScaleFactor
+	^ 50 * self displayScaleFactor
 ]
 
 { #category : #defaults }
 GLMBrickTest >> staticWidth [
 
-	^ 100 * self currentWorld displayScaleFactor
+	^ 100 * self displayScaleFactor
 ]
 
 { #category : #'tests-layouter' }

--- a/src/Glamour-Morphic-Brick-Tests/GLMBrickTest.class.st
+++ b/src/Glamour-Morphic-Brick-Tests/GLMBrickTest.class.st
@@ -68,7 +68,7 @@ GLMBrickTest >> assertWidthDirty: aBrick [
 { #category : #defaults }
 GLMBrickTest >> displayScaleFactor [
 
-	^ self currentWorld displayScaleFactor
+	^ 1 "Scale factor for test"
 ]
 
 { #category : #'instance creation' }

--- a/src/Glamour-Morphic-Brick/GLMBrickButtonStyle.trait.st
+++ b/src/Glamour-Morphic-Brick/GLMBrickButtonStyle.trait.st
@@ -27,7 +27,7 @@ GLMBrickButtonStyle >> buttonBorderWidth [
 { #category : #'brick-button' }
 GLMBrickButtonStyle >> buttonMinHeight [
 
-	^ 26 * self currentWorld displayScaleFactor
+	^ 26
 ]
 
 { #category : #'brick-button' }

--- a/src/Glamour-Morphic-Brick/GLMBrickGeometryTrait.trait.st
+++ b/src/Glamour-Morphic-Brick/GLMBrickGeometryTrait.trait.st
@@ -4,7 +4,6 @@ I declare api and logic to work with geometry of a Brick
 Trait {
 	#name : #GLMBrickGeometryTrait,
 	#traits : 'GLMBrickExtensionTrait',
-	#classTraits : 'GLMBrickExtensionTrait classTrait',
 	#category : #'Glamour-Morphic-Brick-Traits'
 }
 

--- a/src/Glamour-Morphic-Brick/GLMBrickLayoutTrait.trait.st
+++ b/src/Glamour-Morphic-Brick/GLMBrickLayoutTrait.trait.st
@@ -4,7 +4,6 @@ I declare api and logic to layout Bricks
 Trait {
 	#name : #GLMBrickLayoutTrait,
 	#traits : 'GLMBrickExtensionTrait',
-	#classTraits : 'GLMBrickExtensionTrait classTrait',
 	#category : #'Glamour-Morphic-Brick-Traits'
 }
 

--- a/src/Glamour-Morphic-Brick/GLMBrickPropertiesTrait.trait.st
+++ b/src/Glamour-Morphic-Brick/GLMBrickPropertiesTrait.trait.st
@@ -4,7 +4,6 @@ I declare api and logic to work with properties of a Brick, such as color, shado
 Trait {
 	#name : #GLMBrickPropertiesTrait,
 	#traits : 'GLMBrickExtensionTrait',
-	#classTraits : 'GLMBrickExtensionTrait classTrait',
 	#category : #'Glamour-Morphic-Brick-Traits'
 }
 

--- a/src/Glamour-Morphic-Brick/GLMButtonBrick.class.st
+++ b/src/Glamour-Morphic-Brick/GLMButtonBrick.class.st
@@ -135,8 +135,8 @@ GLMButtonBrick >> updateStyle [
 	self normalColor: self themer buttonBackgroundColor.
 	self selectedColor: self themer buttonSelectedColor.
 	self pressedColor: self themer buttonPressedColor.
-	self minWidth: self themer buttonMinWidth.
-	self minHeight: self themer buttonMinHeight.
+	self minWidth: self themer buttonMinWidth * self displayScaleFactor.
+	self minHeight: self themer buttonMinHeight * self displayScaleFactor.
 	self doLayoutForce
 	
 ]

--- a/src/Glamour-Morphic-Widgets/GLMExpanderContentsNodeModel.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMExpanderContentsNodeModel.class.st
@@ -26,7 +26,7 @@ GLMExpanderContentsNodeModel >> elementColumn [
 		borderStyle: (UITheme current buttonSelectedBorderStyleFor: morph).
 
 	row := OrderedCollection with: morph.
-	^ UITheme current newRowIn: self currentWorld for: row
+	^ UITheme current newRowIn: self for: row
 ]
 
 { #category : #accessing }

--- a/src/Glamour-Morphic-Widgets/GLMExpanderLabelNodeModel.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMExpanderLabelNodeModel.class.st
@@ -35,8 +35,9 @@ GLMExpanderLabelNodeModel >> contents [
 
 { #category : #accessing }
 GLMExpanderLabelNodeModel >> displayText [
+
 	^ UITheme current 
-		newTextIn: self currentWorld
+		newTextIn: self
 		text: (self item presentations titleValue ifNil: ['noname']) 
 ]
 
@@ -50,7 +51,7 @@ GLMExpanderLabelNodeModel >> elementColumn [
 	tags withIndexDo:[ :each :index | 
 			row addLast: (self buttonForTag: each 
 									  filter: (tagsFilter at: index ifAbsentPut:[ each ])) ].
-"	^ (UITheme current newRowIn: self currentWorld for: row) fillStyle: Color veryLightGray
+"	^ (UITheme current newRowIn: self for: row) fillStyle: Color veryLightGray
 ]
 
 { #category : #accessing }

--- a/src/Glamour-Morphic-Widgets/GLMTreeMorphNodeModel.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMTreeMorphNodeModel.class.st
@@ -62,7 +62,7 @@ GLMTreeMorphNodeModel >> contents [
 { #category : #accessing }
 GLMTreeMorphNodeModel >> displayText [
 	^ (UITheme current 
-		newTextIn: self currentWorld
+		newTextIn: self
 		text: (self containerTree glamourPresentation formatedDisplayValueOf: self item))
 			backgroundColor: self textBackgroundColor;
 			yourself
@@ -77,7 +77,7 @@ GLMTreeMorphNodeModel >> elementColumn [
 		addAll: (self tagMorphsFrom: self containerTree glamourPresentation);
 		yourself.
 	
-	^ (UITheme current newRowIn: self currentWorld for: rowElements).
+	^ (UITheme current newRowIn: self for: rowElements).
 ]
 
 { #category : #testing }
@@ -230,7 +230,7 @@ GLMTreeMorphNodeModel >> rowMorphForColumn: aGlamourColumn [
 		add: contentMorph;
 		addAll: tagMorphs;
 		yourself.			
-	^ (UITheme current newRowIn: self currentWorld for: rowElements)
+	^ (UITheme current newRowIn: self for: rowElements)
 ]
 
 { #category : #actions }

--- a/src/Graphics-Files/Form.extension.st
+++ b/src/Graphics-Files/Form.extension.st
@@ -54,7 +54,7 @@ Form class >> openImageInWindow: fullName [
 	
 	| image |
 	image := self fromFileNamed: fullName.
-	(self currentWorld drawingClass withForm: image) openInWorld
+	(ImageMorph withForm: image) openInWorld
 ]
 
 { #category : #'*Graphics-Files' }

--- a/src/Keymapping-Settings/KMCatcherMorph.class.st
+++ b/src/Keymapping-Settings/KMCatcherMorph.class.st
@@ -143,7 +143,7 @@ KMCatcherMorph >> mouseDown: event [
 	super mouseDown: event.
 	event yellowButtonPressed 
 		ifTrue: [ self showContextMenu ]
-		ifFalse: [ self currentWorld activeHand newKeyboardFocus: self ]
+		ifFalse: [ self activeHand newKeyboardFocus: self ]
 ]
 
 { #category : #accessing }

--- a/src/Morphic-Base/BorderedMorph.extension.st
+++ b/src/Morphic-Base/BorderedMorph.extension.st
@@ -43,5 +43,5 @@ BorderedMorph class >> exampleGradient [
 	fs direction: (morph bounds width // 2) @ 0.
 	fs radial: true.
 	morph fillStyle: fs.
-	self currentWorld primaryHand attachMorph: morph.
+	morph openInWindow
 ]

--- a/src/Morphic-Base/Morph.extension.st
+++ b/src/Morphic-Base/Morph.extension.st
@@ -349,7 +349,7 @@ Morph >> justDroppedInto: aMorph event: anEvent [
 
 	"An object launched by certain parts-launcher mechanisms should end up fully visible..."
 	(self hasProperty: #beFullyVisibleAfterDrop) 
-		ifTrue: [aMorph == self currentWorld 
+		ifTrue: [aMorph == self world 
 			ifTrue: [self goHome].
 			self removeProperty: #beFullyVisibleAfterDrop].
 

--- a/src/Morphic-Base/PasteUpMorph.extension.st
+++ b/src/Morphic-Base/PasteUpMorph.extension.st
@@ -11,12 +11,6 @@ PasteUpMorph >> dragThroughOnDesktop: evt [
 ]
 
 { #category : #'*Morphic-Base' }
-PasteUpMorph >> drawingClass [
-
-	^ ImageMorph
-]
-
-{ #category : #'*Morphic-Base' }
 PasteUpMorph >> makeAScreenshot [
 	| filePrefix |
 	filePrefix := 'PharoScreenshot'.

--- a/src/Morphic-Base/PasteUpMorph.extension.st
+++ b/src/Morphic-Base/PasteUpMorph.extension.st
@@ -27,7 +27,7 @@ PasteUpMorph >> makeAScreenshot [
 		title: 'Make a screenshot')
 		ifNotNil: [ :choice | 
 			| form name |
-			form := choice = #world ifTrue: [ self currentWorld imageForm ] ifFalse: [ Form fromUser ].
+			form := choice = #world ifTrue: [ self world imageForm ] ifFalse: [ Form fromUser ].
 			name := (FileSystem workingDirectory / filePrefix , 'png') nextVersion.
 			PNGReadWriter putForm: form onFileNamed: (FileSystem workingDirectory / filePrefix , 'png') nextVersion.
 			UIManager default

--- a/src/Morphic-Base/SelectionMorph.class.st
+++ b/src/Morphic-Base/SelectionMorph.class.st
@@ -374,7 +374,7 @@ SelectionMorph >> duplicate [
 	"Make a duplicate of the receiver and havbe the hand grab it"
 
 	selectedItems :=  selectedItems collect: #duplicate.
-	selectedItems reverseDo: [:m | (owner ifNil: [self currentWorld]) addMorph: m].
+	selectedItems reverseDo: [:m | (owner ifNil: [self world]) addMorph: m].
 	dupLoc := self position.
 	ActiveHand grabMorph: self.
 	

--- a/src/Morphic-Base/TextMorph.class.st
+++ b/src/Morphic-Base/TextMorph.class.st
@@ -1361,14 +1361,11 @@ TextMorph >> predecessorChanged [
 TextMorph >> preferredKeyboardPosition [
 
 	| default rects |
-	default  := (self bounds: self bounds in: self currentWorld) topLeft.
+	default  := super preferredKeyboardPosition.
 	paragraph ifNil: [^ default].
 	rects := paragraph selectionRects.
 	rects size = 0 ifTrue: [^ default].
 	^ rects first topLeft.
-
-	"^ (self bounds: self bounds in: World) topLeft."
-
 ]
 
 { #category : #geometry }

--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -300,12 +300,8 @@ HandMorph >> cursorBounds [
 
 { #category : #'event handling' }
 HandMorph >> cursorPoint [
-	"Implemented for allowing embedded worlds in an event cycle to query a hand's position and get it in its coordinates. The same can be achieved by #point:from: but this is simply much more convenient since it will look as if the hand is in the lower world."
 
-	| pos |
-	pos := self position.
-	(self currentWorld isNil or: [self currentWorld == owner]) ifTrue: [^pos].
-	^self currentWorld point: pos from: owner
+	^ self position
 ]
 
 { #category : #'balloon help' }
@@ -609,7 +605,7 @@ HandMorph >> grabMorph: aMorph [
 	"Grab the given morph (i.e., add it to this hand and remove it from its current owner) without changing its position. This is used to pick up a morph under the hand's current position, versus attachMorph: which is used to pick up a morph that may not be near this hand."
 	
 	| grabbed |
-	aMorph = self currentWorld ifTrue: [^ self].
+	aMorph = self world ifTrue: [^ self].
 	self releaseMouseFocus.
 	grabbed := aMorph aboutToBeGrabbedBy: self.
 	grabbed ifNil: [^self].

--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -44,13 +44,6 @@ Class {
 	#category : #'Morphic-Core-Kernel'
 }
 
-{ #category : #utilities }
-HandMorph class >> attach: aMorph [
-	"Attach aMorph the current world's primary hand."
-
-	self currentWorld primaryHand attachMorph: aMorph
-]
-
 { #category : #cleanup }
 HandMorph class >> cleanUp [
 	"Called from ImageCleaner>>cleanUpForRelease --> SmalltalkImage>>cleanUp:except:confirming:"

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -1231,8 +1231,8 @@ Morph >> beUnsticky [
 
 { #category : #'user interface' }
 Morph >> becomeModal [
-	self currentWorld
-		ifNotNil: [self currentWorld modalWindow: self]
+
+	self world modalWindow: self
 ]
 
 { #category : #'base-widgets' }
@@ -4518,9 +4518,9 @@ Morph >> openInHand [
 
 { #category : #display }
 Morph >> openInWorld [
-        "Add this morph to the world."
-
-        self openInWorld: self currentWorld
+	
+	"Add this morph to the current world."
+	self openInWorld: self currentWorld
 ]
 
 { #category : #initialize }
@@ -4776,14 +4776,14 @@ Morph >> preferredDuplicationHandleSelector [
 { #category : #'event handling' }
 Morph >> preferredKeyboardBounds [
 
-	^ self bounds: self bounds in: self currentWorld.
+	^ self bounds: self bounds in: self world
 
 ]
 
 { #category : #'event handling' }
 Morph >> preferredKeyboardPosition [
 
-	^ (self bounds: self bounds in: self currentWorld) topLeft.
+	^ self preferredKeyboardBounds topLeft.
 
 ]
 

--- a/src/Morphic-Core/PasteUpMorph.class.st
+++ b/src/Morphic-Core/PasteUpMorph.class.st
@@ -225,11 +225,11 @@ PasteUpMorph >> cleanseOtherworldlySteppers [
 	those morphs that are not really in the world"
 	"Utilities cleanseOtherworldlySteppers"
 	| old delta |
-	old := self currentWorld stepListSize.
-	self currentWorld steppingMorphsNotInWorld
+	old := self world stepListSize.
+	self world steppingMorphsNotInWorld
 		do: [:m | m delete].
-	self currentWorld cleanseStepList.
-	(delta := old - self currentWorld stepListSize) > 0
+	self world cleanseStepList.
+	(delta := old - self world stepListSize) > 0
 		ifTrue: [ self crTrace: delta asString , ' morphs removed from steplist' ]
 ]
 
@@ -241,7 +241,7 @@ PasteUpMorph >> closeAllUnchangedWindows [
 
 { #category : #'Morphic-Base-Windows' }
 PasteUpMorph >> closeAllWindowsDiscardingChanges [
-	self currentWorld systemWindows do: [:w | [w delete] valueSupplyingAnswer: false]
+	self world systemWindows do: [:w | [w delete] valueSupplyingAnswer: false]
 ]
 
 { #category : #'Morphic-Base-Windows' }
@@ -901,7 +901,7 @@ PasteUpMorph >> resizeToFitString [
 { #category : #'world state' }
 PasteUpMorph >> restoreDisplay [
 
-	self currentWorld restoreMorphicDisplay.	"I don't actually expect this to be called"
+	self world restoreMorphicDisplay.	"I don't actually expect this to be called"
 ]
 
 { #category : #'world state' }
@@ -978,7 +978,7 @@ PasteUpMorph >> toggleResizeToFit [
 PasteUpMorph >> useRoundedCorners [
 	"Somewhat special cased because we do have to fill Display for this"
 	super useRoundedCorners.
-	self == self currentWorld ifTrue:[Display bits primFill: 0]. "done so that we *don't* get a flash"
+	self == self world ifTrue:[Display bits primFill: 0]. "done so that we *don't* get a flash"
 ]
 
 { #category : #'project state' }

--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -366,7 +366,7 @@ WorldMorph >> fullRepaintNeeded [
 { #category : #'event handling' }
 WorldMorph >> fullscreenChanged: fullscreenAnnouncement [
 
-	self currentWorld worldState worldRenderer fullscreenMode: fullscreenAnnouncement fullscreen
+	self worldState worldRenderer fullscreenMode: fullscreenAnnouncement fullscreen
 	
 ]
 

--- a/src/Morphic-Examples/ClassListNodeExample.class.st
+++ b/src/Morphic-Examples/ClassListNodeExample.class.st
@@ -14,22 +14,26 @@ ClassListNodeExample >> browseItem [
 
 { #category : #menu }
 ClassListNodeExample >> classButton [
-	^ ( self theme 
-				newButtonIn: self currentWorld
-				for: self
-				getState: nil
-				action: #browseItem
-				arguments: {}
-				getEnabled: #enabled
-				getLabel: nil
-				help: 'Open a browser on ' translated , self item name)
-				label: (self theme windowLabelForText: (self item name) , '...');
-				yourself
+	^ (self theme 
+		newButtonIn: self
+		for: self
+		getState: nil
+		action: #browseItem
+		arguments: {}
+		getEnabled: #enabled
+		getLabel: nil
+		help: 'Open a browser on ' translated , self item name)
+			label: (self theme windowLabelForText: (self item name) , '...');
+			yourself
 ]
 
 { #category : #menu }
 ClassListNodeExample >> commentText [
-	^ ( self theme  newTextIn: self currentWorld text: self item comment) unlock; wrapFlag: true; yourself
+
+	^ (self theme newTextIn: self text: self item comment)
+		unlock;
+		wrapFlag: true;
+		yourself
 ]
 
 { #category : #accessing }

--- a/src/Morphic-Examples/ClassTreeNodeExample.class.st
+++ b/src/Morphic-Examples/ClassTreeNodeExample.class.st
@@ -23,22 +23,26 @@ ClassTreeNodeExample >> childrenItems [
 
 { #category : #menu }
 ClassTreeNodeExample >> classButton [
-	^ ( self theme 
-				newButtonIn: self currentWorld
-				for: self
-				getState: nil
-				action: #browseItem
-				arguments: {}
-				getEnabled: #enabled
-				getLabel: nil
-				help: 'Open a browser on ' translated , self item name)
+	^ (self theme 
+			newButtonIn: self
+			for: self
+			getState: nil
+			action: #browseItem
+			arguments: {}
+			getEnabled: #enabled
+			getLabel: nil
+			help: 'Open a browser on ' translated , self item name)
 				label: (self theme  windowLabelForText: (self item name) , '...');
 				yourself
 ]
 
 { #category : #menu }
 ClassTreeNodeExample >> commentText [
-	^ ( self theme  newTextIn: self currentWorld text: self item comment) unlock; wrapFlag: true; yourself
+
+	^ (self theme newTextIn: self text: self item comment)
+		unlock;
+		wrapFlag: true;
+		yourself
 ]
 
 { #category : #menu }

--- a/src/Morphic-Examples/SimpleGridNodeExample.class.st
+++ b/src/Morphic-Examples/SimpleGridNodeExample.class.st
@@ -20,14 +20,14 @@ SimpleGridNodeExample >> age: anInteger [
 
 { #category : #'accessing - morphs' }
 SimpleGridNodeExample >> ageMorph [
-	^ ( self theme  
-				newTextEntryIn: self currentWorld
-				for: self 
-				get: #age
-				set: #age:
-				class: Integer
-				getEnabled: nil
-				help: nil) color: Color transparent
+	^ (self theme  
+		newTextEntryIn: self
+		for: self 
+		get: #age
+		set: #age:
+		class: Integer
+		getEnabled: nil
+		help: nil) color: Color transparent
 ]
 
 { #category : #accessing }
@@ -43,14 +43,14 @@ SimpleGridNodeExample >> firstName: aString [
 
 { #category : #'accessing - morphs' }
 SimpleGridNodeExample >> firstNameMorph [
-	^ ( self theme  
-				newTextEntryIn: self currentWorld
-				for: self 
-				get: #firstName
-				set: #firstName:
-				class: String
-				getEnabled: nil
-				help: nil) color: Color transparent
+	^ (self theme  
+		newTextEntryIn: self
+		for: self 
+		get: #firstName
+		set: #firstName:
+		class: String
+		getEnabled: nil
+		help: nil) color: Color transparent
 ]
 
 { #category : #accessing }
@@ -67,7 +67,7 @@ SimpleGridNodeExample >> married: aBoolean [
 { #category : #'accessing - morphs' }
 SimpleGridNodeExample >> marriedMorph [
 	^ ( self theme  
-			newCheckboxIn: self currentWorld
+			newCheckboxIn: self
 			for: self 
 			getSelected: #married
 			setSelected: #married:
@@ -89,12 +89,12 @@ SimpleGridNodeExample >> secondName: aString [
 
 { #category : #'accessing - morphs' }
 SimpleGridNodeExample >> secondNameMorph [
-	^ ( self theme  
-				newTextEntryIn: self currentWorld
-				for: self 
-				get: #secondName
-				set: #secondName:
-				class: String
-				getEnabled: nil
-				help: nil) color: Color transparent
+	^ (self theme  
+		newTextEntryIn: self
+		for: self 
+		get: #secondName
+		set: #secondName:
+		class: String
+		getEnabled: nil
+		help: nil) color: Color transparent
 ]

--- a/src/Morphic-Tests/PaginatedMorphTreeMorphTest.class.st
+++ b/src/Morphic-Tests/PaginatedMorphTreeMorphTest.class.st
@@ -10,7 +10,7 @@ PaginatedMorphTreeMorphTest >> testPager [
 
 	| treeMorph aWindow aModel |
 	aModel := PaginatedMorphTreeModel itemsList: (1 to: 100) asArray.
-	aWindow := aModel theme newWindowIn: self currentWorld for: aModel title: 'test'.
+	aWindow := aModel theme newWindowIn: self for: aModel title: 'test'.
 	treeMorph := aModel defaultTreeMorph.
 	treeMorph pageSize: 30.
 	treeMorph buildContents.

--- a/src/Morphic-Widgets-FastTable/FTBasicTreeListDataSource.class.st
+++ b/src/Morphic-Widgets-FastTable/FTBasicTreeListDataSource.class.st
@@ -28,12 +28,12 @@ FTBasicTreeListDataSource class >> exampleBasicInspect: anObject [
 	
 	ds	root: #ROOT->anObject;
 		children: [ :item | item value gtInspectorVariableValuePairs ];
-		sortChildrenBy: [ :a :b | a key name <= b key name ];
+		sortChildrenBy: [ :a :b | a key asString <= b key asString ];
 		display: [ :item :cell | cell addMorphBack: item printString asMorph ];
 		yourself.
 	
 	ft := FTTableMorph new 
-		extent: 600@(self currentWorld clearArea height - 80);
+		extent: 600@500;
 		dataSource: ds.
 	
 	ft openInWindow position: 20@10.
@@ -51,7 +51,7 @@ FTBasicTreeListDataSource class >> exampleInspect: anObject [
 	
 	ds	root: #ROOT->anObject;
 		children: [ :item | item value gtInspectorVariableValuePairs ];
-		sortChildrenBy: [ :a :b | a key name <= b key name ];
+		sortChildrenBy: [ :a :b | a key asString <= b key asString ];
 		display: [ :item :cell | cell 
 			addMorphBack: item value class systemIcon asMorph;
 			addMorphBack: (item key asStringMorph emphasis: 1; yourself);
@@ -62,7 +62,7 @@ FTBasicTreeListDataSource class >> exampleInspect: anObject [
 	ds expand: 1.
 	
 	ft := FTTableMorph new 
-		extent: 800@(self currentWorld clearArea height // 2);
+		extent: 800@500;
 		dataSource: ds.
 	
 	ft openInWindow position: 20@10.
@@ -117,7 +117,7 @@ FTBasicTreeListDataSource class >> exampleStateTree [
 	
 	ds	roots: { #self -> ds } ;
 		children: [ :item | item value gtInspectorVariableValuePairs ];
-		sortChildrenBy: [ :a :b | a key name <= b key name ];
+		sortChildrenBy: [ :a :b | a key asString <= b key asString ];
 		display: [ :item :cell | cell 
 			addMorphBack: item value systemIcon asMorph;
 			addMorphBack: (item key printString asMorph emphasis: 1; yourself);
@@ -128,7 +128,7 @@ FTBasicTreeListDataSource class >> exampleStateTree [
 	ds expand: 3.
 	
 	ft := FTTableMorph new 
-		extent: 600@(self currentWorld clearArea height - 80);
+		extent: 600@500;
 		dataSource: ds.
 	
 	ft openInWindow position: 20@10
@@ -140,14 +140,14 @@ FTBasicTreeListDataSource class >> exampleWorldSubmorphTree [
 	| ds ft |
 
 	ds := FTBasicTreeListDataSource new 
-		root: self currentWorld;
+		root: World;
 		children: [ :item | item submorphs ];
 		expand: 2;
 		display: [ :item :cell | cell addMorphBack: item printString asMorph ];
 		yourself.
 
 	ft := FTTableMorph new 
-		extent: 400@(self currentWorld clearArea height - 80);
+		extent: 400@500;
 		dataSource: ds.
 	
 	ft openInWindow position: 20@10

--- a/src/Morphic-Widgets-Pluggable/PluggableListMorph.class.st
+++ b/src/Morphic-Widgets-Pluggable/PluggableListMorph.class.st
@@ -1472,7 +1472,7 @@ PluggableListMorph >> specialKeyPressed: anEvent [
 		ifTrue: [" escape key"
 			^ ActiveEvent shiftPressed
 				ifTrue:
-					[self currentWorld invokeWorldMenuFromEscapeKey]
+					[self world invokeWorldMenuFromEscapeKey]
 				ifFalse:[ 
 					(self yellowButtonActivity: false) 
 						ifTrue: [ ^ self ]]].

--- a/src/Morphic-Widgets-Pluggable/TextMorphForEditView.class.st
+++ b/src/Morphic-Widgets-Pluggable/TextMorphForEditView.class.st
@@ -338,7 +338,7 @@ TextMorphForEditView >> preferredKeyboardPosition [
 
 	| pos |
 	pos := super preferredKeyboardPosition.
-	^ pos + (self bounds: self bounds in: self currentWorld) topLeft.
+	^ pos + self preferredKeyboardBounds topLeft.
 
 ]
 

--- a/src/Morphic-Widgets-Tabs/TabMorph.class.st
+++ b/src/Morphic-Widgets-Tabs/TabMorph.class.st
@@ -85,7 +85,7 @@ TabMorph class >> closeOverIconContents [
 
 { #category : #accessing }
 TabMorph class >> defaultHeight [
-	^ 22 * self currentWorld displayScaleFactor 
+	^ 22
 ]
 
 { #category : #initialize }

--- a/src/Morphic-Widgets-Tree/PaginatedMorphTreeModel.class.st
+++ b/src/Morphic-Widgets-Tree/PaginatedMorphTreeModel.class.st
@@ -18,7 +18,7 @@ PaginatedMorphTreeModel class >> example [
 
 	| treeMorph aWindow aModel |
 	aModel := self itemsList: (1 to: 100) asArray.
-	aWindow := aModel theme newWindowIn: self currentWorld for: aModel title: 'Example'.
+	aWindow := aModel theme newWindowIn: self for: aModel title: 'Example'.
 	treeMorph := aModel defaultTreeMorph.
 	treeMorph pageSize: 30.
 	treeMorph buildContents.

--- a/src/Morphic-Widgets-Windows/CollapsedMorph.class.st
+++ b/src/Morphic-Widgets-Windows/CollapsedMorph.class.st
@@ -63,7 +63,7 @@ CollapsedMorph >> collapseOrExpand [
 			labelString ifNotNil: [uncollapsedMorph setNameTo: labelString].
 			mustNotClose := false.	"We're not closing but expanding"
 			self delete.
-			(aWorld := self currentWorld) addMorphFront: uncollapsedMorph.
+			(aWorld := self world) addMorphFront: uncollapsedMorph.
 			aWorld startSteppingSubmorphsOf: uncollapsedMorph]
 		ifFalse:
 			[super collapseOrExpand]

--- a/src/Morphic-Widgets-Windows/CollapsedMorph.class.st
+++ b/src/Morphic-Widgets-Windows/CollapsedMorph.class.st
@@ -56,17 +56,15 @@ CollapsedMorph >> buildWindowMenu [
 CollapsedMorph >> collapseOrExpand [
 	"Toggle the expand/collapsd state of the receiver.  If expanding, copy the window title back to the name of the expanded morph"
 
-	| aWorld |
-	isCollapsed
-		ifTrue: 
-			[uncollapsedMorph setProperty: #collapsedPosition toValue: self position.
-			labelString ifNotNil: [uncollapsedMorph setNameTo: labelString].
-			mustNotClose := false.	"We're not closing but expanding"
-			self delete.
-			(aWorld := self world) addMorphFront: uncollapsedMorph.
-			aWorld startSteppingSubmorphsOf: uncollapsedMorph]
-		ifFalse:
-			[super collapseOrExpand]
+	isCollapsed ifTrue: [ | aWorld |
+		uncollapsedMorph setProperty: #collapsedPosition toValue: self position.
+		labelString ifNotNil: [uncollapsedMorph setNameTo: labelString].
+		mustNotClose := false.	"We're not closing but expanding"
+		aWorld := self world.
+		self delete.
+		aWorld addMorphFront: uncollapsedMorph.
+		aWorld startSteppingSubmorphsOf: uncollapsedMorph ]
+	ifFalse: [ super collapseOrExpand ]
 ]
 
 { #category : #'collapse/expand' }

--- a/src/Morphic-Widgets-Windows/PasteUpMorph.extension.st
+++ b/src/Morphic-Widgets-Windows/PasteUpMorph.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #PasteUpMorph }
 PasteUpMorph >> fitAllVisibleWindows [
 	"Fit all windows as visible"
 	|allowedArea|
-	allowedArea := RealEstateAgent maximumUsableAreaInWorld: self currentWorld.
+	allowedArea := RealEstateAgent maximumUsableAreaInWorld: self world.
 	(self  windowsSatisfying: [:w | w isCollapsed not])
 		reverseDo:[:w | 
 			w extent: w initialExtent.  

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1435,7 +1435,7 @@ SystemWindow >> openAsIsIn: aWorld [
 	
 	self announceOpened.
 	
-	self currentWorld announcer 
+	self world announcer 
 		announce: (WindowOpened new
 						window: self;
 						yourself).

--- a/src/Network-Mail/MailMessage.class.st
+++ b/src/Network-Mail/MailMessage.class.st
@@ -931,5 +931,5 @@ MailMessage >> viewImageInBody [
 	| stream image |
 	stream := self body contentStream.
 	image := Form fromBinaryStream: stream.
-	(self currentWorld drawingClass withForm: image) openInWorld
+	(ImageMorph withForm: image) openInWorld
 ]

--- a/src/Polymorph-Widgets/PharoDarkTheme.class.st
+++ b/src/Polymorph-Widgets/PharoDarkTheme.class.st
@@ -308,7 +308,7 @@ PharoDarkTheme >> menuBorderColor [
 
 { #category : #'accessing colors' }
 PharoDarkTheme >> menuBorderWidth [
-	^ self borderWidth * self currentWorld displayScaleFactor
+	^ self borderWidth * self displayScaleFactor
 ]
 
 { #category : #defaults }

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -53,7 +53,7 @@ ThemeIcons class >> baseUrl [
 { #category : #settings }
 ThemeIcons class >> createFetchButtonUpdating: listMorph [
 	^ (Smalltalk ui theme 
-		newButtonIn: self currentWorld
+		newButtonIn: self
 		for: self
 		getState: nil 
 		action: nil
@@ -71,7 +71,7 @@ ThemeIcons class >> createFetchButtonUpdating: listMorph [
 { #category : #settings }
 ThemeIcons class >> createIconPackList [
 	^ (Smalltalk ui theme 
-		newDropListIn: self currentWorld
+		newDropListIn: self
 		for: self
 		list: #availablePacks
 		getSelected: #current
@@ -89,7 +89,7 @@ ThemeIcons class >> createIconPackList [
 ThemeIcons class >> createSettingRow [
 	| list |
 	^ Smalltalk ui theme 
-		newRowIn: self currentWorld 
+		newRowIn: self 
 		for: {
 			list := self createIconPackList.
 			self createFetchButtonUpdating: list }

--- a/src/Polymorph-Widgets/ThemeSettings.class.st
+++ b/src/Polymorph-Widgets/ThemeSettings.class.st
@@ -332,7 +332,7 @@ ThemeSettings >> menuBorderColor [
 ThemeSettings >> menuBorderWidth [
 	"Answer the value of menuColor"
 
-	^ 2 * self currentWorld displayScaleFactor
+	^ 2
 ]
 
 { #category : #menu }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -380,7 +380,7 @@ UITheme >> borderColor [
 
 { #category : #accessing }
 UITheme >> borderWidth [
-	^ 1 * self currentWorld displayScaleFactor
+	^ 1 * self displayScaleFactor
 ]
 
 { #category : #accessing }
@@ -555,7 +555,7 @@ UITheme >> buttonMiddleRightForm [
 UITheme >> buttonMinHeight [
 	"Answer the minumum height of a button for this theme."
 	
-	^ 18 * self currentWorld displayScaleFactor
+	^ 18 * self displayScaleFactor
 ]
 
 { #category : #defaults }
@@ -1938,6 +1938,12 @@ UITheme >> disabledTextColor [
 ]
 
 { #category : #accessing }
+UITheme >> displayScaleFactor [
+	
+	^ self currentWorld displayScaleFactor
+]
+
+{ #category : #accessing }
 UITheme >> dockingBarBorderWidth [ 
 	^ 0
 ]
@@ -2555,7 +2561,7 @@ UITheme >> menuBorderColor [
 
 { #category : #accessing }
 UITheme >> menuBorderWidth [ 
-	^  self settings menuBorderWidth
+	^  self settings menuBorderWidth * self displayScaleFactor
 ]
 
 { #category : #'label-styles' }
@@ -5029,7 +5035,7 @@ UITheme >> scrollbarMinimumThumbThickness [
 	"Answer the minumum width or height of a scrollbar thumb 
 	as appropriate to its orientation."
 	
-	^15 * self currentWorld displayScaleFactor
+	^15 * self displayScaleFactor
 ]
 
 { #category : #'border-styles-scrollbars' }
@@ -5256,7 +5262,7 @@ UITheme >> scrollbarThickness [
 	"Answer the width or height of a scrollbar as appropriate to
 	its orientation."
 	
-	^13 * self currentWorld displayScaleFactor
+	^13 * self displayScaleFactor
 ]
 
 { #category : #'fill-styles' }
@@ -5367,7 +5373,7 @@ UITheme >> setSystemProgressMorphDefaultParameters: aProgressMorph [
 	aProgressMorph color: self settings derivedMenuColor.
 	self settings preferRoundCorner
 		ifTrue: [aProgressMorph useRoundedCorners].
-	aProgressMorph borderWidth: self menuBorderWidth.
+	aProgressMorph borderWidth: self menuBorderWidth * self displayScaleFactor.
 	aProgressMorph borderColor: self menuBorderColor.
 	aProgressMorph updateColor.
 ]
@@ -6130,7 +6136,7 @@ UITheme >> windowActiveTitleFillStyleFor: aWindow [
 { #category : #defaults }
 UITheme >> windowBorderWidthFor: aWindow [
 
-	^ 4 * self currentWorld displayScaleFactor
+	^ 4 * self displayScaleFactor
 ]
 
 { #category : #defaults }

--- a/src/Rubric/RubFloatingEditorBuilder.class.st
+++ b/src/Rubric/RubFloatingEditorBuilder.class.st
@@ -118,7 +118,6 @@ RubFloatingEditorBuilder >> buildEditor [
 	editor
 		autoAccept: autoAccept;
 		setTextWith: self initialContents.
-	self currentWorld activeHand addEventListener: self.
 	editor announcer
 		when: MorphLostFocus send: #whenEditorLostFocus: to: self;
 		when: RubTextAccepted send: #whenTextAccepted: to: self;
@@ -229,7 +228,6 @@ RubFloatingEditorBuilder >> openEditorWithContents: aText thenDo: aBlock [
 
 { #category : #'announcement handling' }
 RubFloatingEditorBuilder >> whenEditorDeleted: anAnnouncement [
-	anAnnouncement morph activeHand removeEventListener: self.
 	anAnnouncement morph announcer unsubscribe: self.
 	editor := nil
 ]

--- a/src/Settings-Graphics/GraphicFontSettings.class.st
+++ b/src/Settings-Graphics/GraphicFontSettings.class.st
@@ -23,7 +23,7 @@ GraphicFontSettings class >> fontChoiceButtonForStyle: aSymbol label: aLabel [
 				contents: aLabel asString 
 				font: (TextStyle default fontOfPointSize: (StandardFonts pointSizeForStyleNamed: aSymbol)).
 	^ (self theme 
-		newButtonIn: self currentWorld
+		newButtonIn: self
 		for: self
 		getState: nil 
 		action: #setFontsToStyleNamed:
@@ -38,7 +38,7 @@ GraphicFontSettings class >> fontChoiceButtonForStyle: aSymbol label: aLabel [
 
 { #category : #fonts }
 GraphicFontSettings class >> fontSizeRow [
-	^ self theme newRowIn: self currentWorld for: {
+	^ self theme newRowIn: self for: {
 			self theme buttonLabelForText: 'Predefined styles: ' translated.
 			self fontChoiceButtonForStyle: #small label: 'Small' translated.
 			self fontChoiceButtonForStyle: #medium label: 'Medium' translated.
@@ -60,7 +60,7 @@ GraphicFontSettings class >> resetAllFontToDefault [
 { #category : #fonts }
 GraphicFontSettings class >> resetAllFontToDefaultButton [
 	^ (self theme
-		newButtonIn: self currentWorld
+		newButtonIn: self
 		for: self
 		getState: nil
 		action: #resetAllFontToDefault
@@ -70,7 +70,7 @@ GraphicFontSettings class >> resetAllFontToDefaultButton [
 		help: 'Force all system fonts to be the default one' translated)
 		label:
 			(self theme
-				newRowIn: self currentWorld
+				newRowIn: self
 				for:
 					{(AlphaImageMorph new
 						image: (self iconNamed: #smallRedoIcon)).

--- a/src/Shout/SHPreferences.class.st
+++ b/src/Shout/SHPreferences.class.st
@@ -253,21 +253,21 @@ SHPreferences class >> styleTableRow [
 	
 	allStyles := Pragma  allNamed: #styleTable: in: SHRBTextStyler class.
 	^Smalltalk ui theme 
-		newRowIn: self currentWorld 
+		newRowIn: self 
 		for: (
 			{ Smalltalk ui theme buttonLabelForText: 'Predefined styles: ' translated }, 
 			(allStyles collect: [ :eachPragma | 
 				(Smalltalk ui theme 
-					newButtonIn: self currentWorld 
-						for:  self
-						getState: nil 
-						action: #setStyleTableNamed:  
-						arguments:  { eachPragma argumentAt: 1 }
-						getEnabled: nil 
-						getLabel: nil
-						help: ('Change style table to ', (eachPragma argumentAt: 1)) translated)
-					label: (eachPragma argumentAt: 1);
-					yourself ] ))
+					newButtonIn: self
+					for:  self
+					getState: nil 
+					action: #setStyleTableNamed:  
+					arguments:  { eachPragma argumentAt: 1 }
+					getEnabled: nil 
+					getLabel: nil
+					help: ('Change style table to ', (eachPragma argumentAt: 1)) translated)
+						label: (eachPragma argumentAt: 1);
+						yourself ] ))
 ]
 
 { #category : #'accessing-styles' }

--- a/src/System-Settings-Core/PickOneSettingDeclaration.class.st
+++ b/src/System-Settings-Core/PickOneSettingDeclaration.class.st
@@ -50,9 +50,9 @@ PickOneSettingDeclaration >> index: anInteger [
 { #category : #'user interface' }
 PickOneSettingDeclaration >> inputWidget [
 	| widget row |
-	row := self theme newRowIn: self currentWorld for: {
+	row := self theme newRowIn: self for: {
 				widget := (self theme 
-						newDropListIn: self currentWorld
+						newDropListIn: self
 						for: self
 						list: #domainValuesLabels
 						getSelected: #index

--- a/src/System-Settings-Core/PragmaSetting.class.st
+++ b/src/System-Settings-Core/PragmaSetting.class.st
@@ -206,7 +206,7 @@ PragmaSetting >> icon: aForm [
 PragmaSetting >> inputMorphFor: aContainer [ 
 	^ self inputWidget
 		ifNotNil: [:iw | 
-			( self theme newRowIn: self currentWorld for: {iw})
+			( self theme newRowIn: self for: {iw})
 				 clipSubmorphs: true;
 				 hResizing: #shrinkWrap;
 				 cellInset: 0;

--- a/src/System-Settings-Core/RangeSettingDeclaration.class.st
+++ b/src/System-Settings-Core/RangeSettingDeclaration.class.st
@@ -24,29 +24,33 @@ RangeSettingDeclaration >> hasEditableList [
 
 { #category : #'user interface' }
 RangeSettingDeclaration >> inputWidget [
-	^ (self theme newRowIn: self currentWorld for: {(self theme 
-							newTextEntryIn: self currentWorld 
-							for: self
-							get: #realValue
-							set: #realValue:
-							class: (Smalltalk globals at: self type)
-							getEnabled: #enabled
-							help: nil) hResizing: #rigid;
-							width: 80;
-							wantsFrameAdornments: true;
-							yourself. 
-						(PluggableSliderMorph new max: self range last;
-							 min: self range first;
-							 quantum: self range increment;
-							on: self
-							getValue: #realValue
-							setValue: #realValue:) hResizing: #spaceFill;
-							 vResizing: #spaceFIll;
-							 setBalloonText: self description;
-							 minWidth: 300; height: 20;
-							 yourself}) 
-				cellInset: 10;
-				yourself
+	^ (self theme
+			newRowIn: self
+			for: {
+				(self theme 
+					newTextEntryIn: self
+					for: self
+					get: #realValue
+					set: #realValue:
+					class: (Smalltalk globals at: self type)
+					getEnabled: #enabled
+					help: nil)
+						hResizing: #rigid;
+						width: 80;
+						wantsFrameAdornments: true;
+						yourself. 
+				(PluggableSliderMorph new max: self range last;
+					 min: self range first;
+					 quantum: self range increment;
+					on: self
+					getValue: #realValue
+					setValue: #realValue:) hResizing: #spaceFill;
+					 vResizing: #spaceFIll;
+					 setBalloonText: self description;
+					 minWidth: 300; height: 20;
+					 yourself}) 
+		cellInset: 10;
+		yourself
 ]
 
 { #category : #accessing }

--- a/src/System-Settings-Core/SettingDeclaration.class.st
+++ b/src/System-Settings-Core/SettingDeclaration.class.st
@@ -270,14 +270,14 @@ SettingDeclaration >> inputWidget [
 		  ifTrue: [inputWidget model ifNil: [inputWidget model: self]]].
 	xtraDialogWidget 
 		ifNotNil: [inputWidget := inputWidget ifNil: [xtraDialogWidget] 
-			ifNotNil: [ self theme  newRowIn: self currentWorld for: {inputWidget. xtraDialogWidget}]].
+			ifNotNil: [ self theme  newRowIn: self for: {inputWidget. xtraDialogWidget}]].
 	^ inputWidget 
 ]
 
 { #category : #'user interface' }
 SettingDeclaration >> inputWidgetForBoolean [
 	^  self theme  
-			newCheckboxIn: self currentWorld
+			newCheckboxIn: self
 			for: self
 			getSelected: #realValue
 			setSelected: #realValue:
@@ -290,7 +290,7 @@ SettingDeclaration >> inputWidgetForBoolean [
 SettingDeclaration >> inputWidgetForColor [
 	^ (  
 	 self theme 
-		newColorChooserIn: self currentWorld
+		newColorChooserIn: self
 		for: self
 		getColor: #realValue
 		setColor: #realValue:
@@ -323,7 +323,7 @@ SettingDeclaration >> inputWidgetForFileOrDirectoryWithAction: aSymbol [
 		width: 450;
 		wantsFrameAdornments: true.
 	button := self theme
-		newButtonIn: self currentWorld
+		newButtonIn: self
 		for: self
 		getState: nil
 		action: aSymbol
@@ -334,7 +334,7 @@ SettingDeclaration >> inputWidgetForFileOrDirectoryWithAction: aSymbol [
 				image: (self iconNamed: #smallOpenIcon))
 		help: 'Open directory chooser dialog' translated.
 	^ self theme
-		newRowIn: self currentWorld
+		newRowIn: self
 		for:
 			{list.
 			button}
@@ -342,8 +342,8 @@ SettingDeclaration >> inputWidgetForFileOrDirectoryWithAction: aSymbol [
 
 { #category : #'user interface' }
 SettingDeclaration >> inputWidgetForFont [
-	^ (  self theme 
-		newButtonIn: self currentWorld
+	^ (self theme 
+		newButtonIn: self
 		for: self
 		getState: nil 
 		action: #getFont
@@ -357,7 +357,7 @@ SettingDeclaration >> inputWidgetForFont [
 { #category : #'user interface' }
 SettingDeclaration >> inputWidgetForLabel [
 	| widget |
-	widget := self theme newLabelIn: self currentWorld for: self label: '' getEnabled: nil.
+	widget := self theme newLabelIn: self for: self label: '' getEnabled: nil.
 	widget getTextSelector: #preferenceValue.
 	widget width: 450.
 	^ widget
@@ -373,7 +373,7 @@ SettingDeclaration >> inputWidgetForNumber [
 SettingDeclaration >> inputWidgetForPassword [
 	| widget |
 	widget :=  self theme  
-				newTextEntryIn: self currentWorld
+				newTextEntryIn: self
 				for: self
 				get: #realValue
 				set: #realValue:

--- a/src/System-Settings-Core/SystemSettingLauncher.class.st
+++ b/src/System-Settings-Core/SystemSettingLauncher.class.st
@@ -18,7 +18,7 @@ SystemSettingLauncher >> defaultIcon [
 { #category : #accessing }
 SystemSettingLauncher >> inputWidget [
 	^ (self theme
-		newButtonIn: self currentWorld
+		newButtonIn: self
 		for: self
 		getState: nil
 		action: #launch
@@ -28,7 +28,7 @@ SystemSettingLauncher >> inputWidget [
 		help: self description)
 		label:
 			(self theme
-				newRowIn: self currentWorld
+				newRowIn: self
 				for:
 					{(AlphaImageMorph new
 						image: (self iconNamed: #smallRedoIcon)).

--- a/src/Tool-Base/PasteUpMorph.extension.st
+++ b/src/Tool-Base/PasteUpMorph.extension.st
@@ -9,7 +9,7 @@ that will provide the default desktop command key handlers.  If the selector tak
 	"there is clearly a problem because not all the tools can be loaded."
  
 	^ {
-		{ $r.	self currentWorld.						#restoreMorphicDisplay.					'Redraw the screen'}.		
+		{ $r.	self world.						#restoreMorphicDisplay.					'Redraw the screen'}.		
 		{ $b.	Smalltalk tools browser.			#open.										'Open a new System Browser'}.
 		{ $k.	Smalltalk tools workspace.			#open.										'Open a new, blank Workspace'}.
 		{ $t.	Smalltalk tools transcript.			#open.										'Make a System Transcript visible'}.

--- a/src/Tool-FileList/FileList.class.st
+++ b/src/Tool-FileList/FileList.class.st
@@ -1069,7 +1069,7 @@ FileList >> openImageInWindow [
 	self reference streamWritable: false do: [ :stream|
 		image := Form fromBinaryStream: stream].
 	
-	(self currentWorld drawingClass withForm: image) openInWorld
+	(ImageMorph withForm: image) openInWorld
 ]
 
 { #category : #initialization }

--- a/src/Tool-Finder/DialogItemsChooserUI.class.st
+++ b/src/Tool-Finder/DialogItemsChooserUI.class.st
@@ -342,8 +342,8 @@ DialogItemsChooserUI >> cancelButtonState [
 
 { #category : #display }
 DialogItemsChooserUI >> centering [
-	self left: ((self currentWorld width / 2) - (self width /2)) rounded.
-	self top: ((self currentWorld height / 2) - (self height /2)) rounded
+	self left: ((self world width / 2) - (self width /2)) rounded.
+	self top: ((self world height / 2) - (self height /2)) rounded
 ]
 
 { #category : #accessing }

--- a/src/Tool-Finder/FinderUI.class.st
+++ b/src/Tool-Finder/FinderUI.class.st
@@ -436,15 +436,16 @@ FinderUI >> buildSearchButton [
 
 { #category : #'items creation' }
 FinderUI >> buildSearchModeDropListIn: aWindow [
-			^(self theme 
-				newDropListIn: aWindow
-				for:self				
-				list: #searchModesList
-				getSelected: #currentSearchMode
-				setSelected: #currentSearchMode:
-				getEnabled: nil
-				useIndex: false 
-				help: self searchModeHelpText) hResizing: #rigid; width: 120; yourself
+	
+	^ (self theme 
+		newDropListIn: aWindow
+		for:self				
+		list: #searchModesList
+		getSelected: #currentSearchMode
+		setSelected: #currentSearchMode:
+		getEnabled: nil
+		useIndex: false 
+		help: self searchModeHelpText) hResizing: #rigid; width: 120; yourself
 
 ]
 

--- a/src/Tool-Profilers/TimeProfiler.class.st
+++ b/src/Tool-Profilers/TimeProfiler.class.st
@@ -688,7 +688,7 @@ TimeProfiler >> toolBarOn: aWindow [
 	toolBar := toolBar := aWindow
 		newToolbar:
 			{((uiTheme
-				newButtonIn: self currentWorld
+				newButtonIn: self
 				for: self
 				getState: nil
 				action: #profileIt
@@ -698,7 +698,7 @@ TimeProfiler >> toolBarOn: aWindow [
 				help: nil)
 				label:
 					(uiTheme
-						newRowIn: self currentWorld
+						newRowIn: self
 						for:
 							{(AlphaImageMorph new
 								image: (self iconNamed: #smallDoItIcon)).
@@ -739,7 +739,7 @@ TimeProfiler >> toolBarOn: aWindow [
 			aWindow newToolSpacer.
 			aWindow newToolSpacer.
 			(uiTheme
-				newCheckboxIn: self currentWorld
+				newCheckboxIn: self
 				for: self
 				getSelected: #reportOtherProcesses
 				setSelected: #reportOtherProcesses:

--- a/src/Tools/KeyPrinterMorph.class.st
+++ b/src/Tools/KeyPrinterMorph.class.st
@@ -38,7 +38,7 @@ KeyPrinterMorph >> keyDown: anEvent [
 { #category : #'event handling' }
 KeyPrinterMorph >> mouseDown: event [ 
 	super mouseDown: event.
-	self currentWorld activeHand newKeyboardFocus: self
+	self activeHand newKeyboardFocus: self
 ]
 
 { #category : #display }


### PR DESCRIPTION
Partial fix of #5917 harvesting easily dropping fruit.

Getting down to 178 references.
- About half of the removed ones are non-necessary usages of currentWorld for theming (see #5923).
- Others were simple refactorings of repeated accessors to `displayScaleFactor`
- Others were `currentWorld` => `world`

On the 178 remaining references, I've identified several families. They should be easy to solve in isolation.