### PR TITLE
Cleanup Morphic Render Loop

### DIFF
--- a/src/Calypso-Browser/ClyAccrossWindowNavigationState.class.st
+++ b/src/Calypso-Browser/ClyAccrossWindowNavigationState.class.st
@@ -124,11 +124,11 @@ ClyAccrossWindowNavigationState >> restoreBrowserWindow [
 		ifNil: [
 			window isInWorld 
 				ifTrue: [ window comeToFront; activate]
-			 	ifFalse: [window openAsIs ]]
+			 	ifFalse: [window openInWorld ] ]
 		ifNotNil: [ 
 			windowGroup isInWorld 
 				ifTrue: [ windowGroup window comeToFront ]
-				ifFalse: [ windowGroup window openAsIs ].
+				ifFalse: [ windowGroup window openInWorld ].
 			windowGroup activateWindow: window]
 ]
 

--- a/src/Calypso-Browser/ClyBrowserSearchDialogWindow.class.st
+++ b/src/Calypso-Browser/ClyBrowserSearchDialogWindow.class.st
@@ -102,7 +102,7 @@ ClyBrowserSearchDialogWindow >> openOn: aQuery withTitle: dialogTitle thenDo: re
 	self showItemsOf: aQuery.
 	self title: dialogTitle.
 
-	browser openModal: self.
+	self openModal.
 
 	^["Following two lines should prevent special condition 
 	when filter background process modifies current table data source.

--- a/src/Calypso-Browser/ClyBrowserSearchDialogWindow.class.st
+++ b/src/Calypso-Browser/ClyBrowserSearchDialogWindow.class.st
@@ -102,7 +102,7 @@ ClyBrowserSearchDialogWindow >> openOn: aQuery withTitle: dialogTitle thenDo: re
 	self showItemsOf: aQuery.
 	self title: dialogTitle.
 
-	self openModal.
+	browser window openModal: self.
 
 	^["Following two lines should prevent special condition 
 	when filter background process modifies current table data source.

--- a/src/Calypso-Browser/ClyNotebookManager.class.st
+++ b/src/Calypso-Browser/ClyNotebookManager.class.st
@@ -271,7 +271,7 @@ ClyNotebookManager >> restoreSelectedTools: selectedTools [
 		ifFalse: [ 
 			"To allow multiple selected tabs by cmd+click on table"
 			mainTool isExtraSelectionRequested 
-				ifTrue: [ extraTools add: mainTool ] ].
+				ifTrue: [ extraTools copyWith: mainTool ] ].
 	(tools copyWithout: mainTool) do: [ :currentTool | 
 		"Generally if previously selected extra tab is found in new tools then it should be selected.
 		Other tools should be deselected"

--- a/src/Fonts-Chooser/FontChooserMorph.class.st
+++ b/src/Fonts-Chooser/FontChooserMorph.class.st
@@ -365,7 +365,7 @@ FontChooserMorph >> okButtonClicked [
 { #category : #'open/close' }
 FontChooserMorph >> open [
 
-	^ self createWindow openAsIsIn: self currentWorld.
+	^ self createWindow openInWorld.
 ]
 
 { #category : #'interface building' }

--- a/src/FormCanvas-Core/FormCanvas.class.st
+++ b/src/FormCanvas-Core/FormCanvas.class.st
@@ -166,7 +166,7 @@ FormCanvas >> drawOval: r color: c borderWidth: borderWidth borderColor: borderC
 		fill: c
 		borderWidth: borderWidth
 		borderColor: borderColor
-		transform: transform.
+		transform: self transform.
 ]
 
 { #category : #'drawing-polygons' }
@@ -185,7 +185,7 @@ FormCanvas >> drawPolygon: vertices fillStyle: aFillStyle borderWidth: borderWid
 		fill: aFillStyle
 		borderWidth: borderWidth
 		borderColor: borderColor
-		transform: transform.
+		transform: self transform.
 ]
 
 { #category : #'private - balloon engine' }
@@ -197,7 +197,7 @@ FormCanvas >> drawRectangle: r color: c borderWidth: borderWidth borderColor: bo
 		fill: c
 		borderWidth: borderWidth
 		borderColor: borderColor
-		transform: transform.
+		transform: self transform.
 ]
 
 { #category : #'drawing-text' }
@@ -275,7 +275,7 @@ FormCanvas >> ensuredEngine [
 		engine deferred: false.
 		engine].
 	engine colorTransform: colorTransform.
-	engine edgeTransform: (transform ifNil: [MatrixTransform2x3 identity]).
+	engine edgeTransform: self transform.
 	^engine
 ]
 
@@ -706,6 +706,12 @@ FormCanvas >> stencil: stencilForm at: aPoint sourceRect: sourceRect color: aCol
 	port stencil: stencilForm
 		at: aPoint + origin
 		sourceRect: sourceRect.
+]
+
+{ #category : #'private - balloon engine' }
+FormCanvas >> transform [
+
+	^ (transform ifNil: [AthensAffineTransform new])
 ]
 
 { #category : #'drawing-support' }

--- a/src/FormCanvas-Core/FormCanvas.class.st
+++ b/src/FormCanvas-Core/FormCanvas.class.st
@@ -711,7 +711,7 @@ FormCanvas >> stencil: stencilForm at: aPoint sourceRect: sourceRect color: aCol
 { #category : #'private - balloon engine' }
 FormCanvas >> transform [
 
-	^ (transform ifNil: [AthensAffineTransform new])
+	^ (transform ifNil: [MatrixTransform2x3 identity])
 ]
 
 { #category : #'drawing-support' }

--- a/src/FreeType/StringMorph.extension.st
+++ b/src/FreeType/StringMorph.extension.st
@@ -8,7 +8,7 @@ StringMorph >> changeFont [
 		for: self 
 		setSelector: #font: 
 		getSelector: self fontToUse.
-	self openModal: chooser.
+	chooser openModal.
 	newFont := chooser result.
 	newFont ifNotNil: [self font: newFont].
 ]

--- a/src/GT-Spotter-UI/GTSpotterProfiler.class.st
+++ b/src/GT-Spotter-UI/GTSpotterProfiler.class.st
@@ -29,7 +29,7 @@ GTSpotterProfiler class >> profileOneCycle [
 					openCenteredInWorld.
 		
 				spotterModel class markOpened.
-				[ done ] whileFalse: [ self currentWorld doOneCycle ] ] ]
+				MorphicRenderLoop new doOneCycleWhile: [ done not ] ] ]
 ]
 
 { #category : #shortcuts }

--- a/src/GT-Tests-Debugger/InfiniteDebuggerTest.class.st
+++ b/src/GT-Tests-Debugger/InfiniteDebuggerTest.class.st
@@ -18,7 +18,7 @@ InfiniteDebuggerTest >> testTestInfinitDebugger [
 	process := [ TestClassForTestingDebuggerTest debug: #bla ] forkAt: 41.
 
 	1000 milliSecond asDelay wait.
-	self currentWorld doOneCycle.
+	MorphicRenderLoop new doOneCycle.
 	preWindow := (self currentWorld allMorphs
 		select: [ :e | (e isKindOf: SystemWindow) and: [ e label beginsWith: 'Instance of ' ] ])
 		first.
@@ -28,7 +28,7 @@ InfiniteDebuggerTest >> testTestInfinitDebugger [
 	preWindow := nil.
 	debugButton := nil.
 	100 milliSecond asDelay wait.
-	self currentWorld doOneCycle.
+	MorphicRenderLoop new doOneCycle.
 	debugWindow := (self currentWorld allMorphs
 		select: [ :e | (e isKindOf: SystemWindow) and: [ e label beginsWith: 'Instance of Test' ] ])
 		first.

--- a/src/Glamour-Morphic-Widgets/GLMWatcherWindow.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMWatcherWindow.class.st
@@ -159,8 +159,7 @@ GLMWatcherWindow >> morphicLayerNumber [
 ]
 
 { #category : #display }
-GLMWatcherWindow >> openInWorld [
-	super openInWorld.
+GLMWatcherWindow >> postOpenInWorld: aWorld [
 	isOpen := true.
 
 ]

--- a/src/Glamour-Tests-Morphic/AbstractMorphicUITest.class.st
+++ b/src/Glamour-Tests-Morphic/AbstractMorphicUITest.class.st
@@ -40,8 +40,8 @@ AbstractMorphicUITest >> waitUntilUIRedrawed [
 	If I am running in the UI process I can directly execute a doOneCycle on the World.
 	If I am in the CI the tests and the UI run in different process. So I should not do a #doOneCycle.
 	If I do it, I am in a race condition!"
-	self isRunningInUIProcess ifTrue: [ 
-		self currentWorld doOneCycle.
+	self isRunningInUIProcess ifTrue: [
+		MorphicRenderLoop new doOneCycle.
 		^ self.	
 	]. 
 

--- a/src/Growl/GrowlMorph.class.st
+++ b/src/Growl/GrowlMorph.class.st
@@ -350,11 +350,10 @@ GrowlMorph >> nextColorStep: aColor [
 	^ aColor alpha: self alpha
 ]
 
-{ #category : #display }
-GrowlMorph >> openInWorld [
+{ #category : #opening }
+GrowlMorph >> preOpenInWorld: aWorld [
 
-	self position: self unoccupiedPosition.
-	^super openInWorld
+	self position: self unoccupiedPosition
 ]
 
 { #category : #internal }

--- a/src/Kernel-Tests/DelayBenchmark.class.st
+++ b/src/Kernel-Tests/DelayBenchmark.class.st
@@ -62,7 +62,7 @@ DelayBenchmark >> bench [
 						, String space.
 			self
 				trace: 'ExitCount: ' , (ExitCount // sampleSetSeeds size) printString.
-			self currentWorld doOneCycle	"since we are a higher priority would prevent transcript showing" ].
+			MorphicRenderLoop new doOneCycle "since we are a higher priority would prevent transcript showing" ].
 	completed signal ] forkAt: Processor userSchedulingPriority + 2.	"To avoid UI loop influencing result"
 	completed wait
 ]

--- a/src/Kernel-Tests/DelayBenchmark.class.st
+++ b/src/Kernel-Tests/DelayBenchmark.class.st
@@ -61,8 +61,7 @@ DelayBenchmark >> bench [
 					'EnterCount: ' , (EnterCount // sampleSetSeeds size) printString
 						, String space.
 			self
-				trace: 'ExitCount: ' , (ExitCount // sampleSetSeeds size) printString.
-			MorphicRenderLoop new doOneCycle "since we are a higher priority would prevent transcript showing" ].
+				trace: 'ExitCount: ' , (ExitCount // sampleSetSeeds size) printString ].
 	completed signal ] forkAt: Processor userSchedulingPriority + 2.	"To avoid UI loop influencing result"
 	completed wait
 ]

--- a/src/MonticelloGUI/MCSliceMaker.class.st
+++ b/src/MonticelloGUI/MCSliceMaker.class.st
@@ -142,7 +142,7 @@ MCSliceMaker >> okToDoSlice: aBoolean [
 { #category : #'user interface' }
 MCSliceMaker >> openFor: anotherWindow [
 	window := self window.
-	anotherWindow openModal: window.
+	window openModal.
 	^ self resultInfo
 ]
 

--- a/src/MonticelloGUI/MCTool.class.st
+++ b/src/MonticelloGUI/MCTool.class.st
@@ -342,7 +342,7 @@ MCTool >> showModally [
 	modal := true.
 	self window openInWorldExtent: 400 @ 400.
 	self setDefaultFocus.
-	[ self window world notNil ] whileTrue: [ self window outermostWorldMorph doOneCycle ].
+	MorphicRenderLoop new doOneCycleWhile: [ self window isInWorld ].
 	morph := nil.
 	^ modalValue
 ]

--- a/src/MonticelloGUI/MCTool.class.st
+++ b/src/MonticelloGUI/MCTool.class.st
@@ -340,9 +340,7 @@ MCTool >> showLabelled: labelString [
 { #category : #'morphic ui' }
 MCTool >> showModally [
 	modal := true.
-	self window openInWorldExtent: 400 @ 400.
-	self setDefaultFocus.
-	MorphicRenderLoop new doOneCycleWhile: [ self window isInWorld ].
+	self window openModal.
 	morph := nil.
 	^ modalValue
 ]

--- a/src/Morphic-Base/MenuMorph.class.st
+++ b/src/Morphic-Base/MenuMorph.class.st
@@ -885,7 +885,7 @@ MenuMorph >> invokeAt: aPoint in: aWorld allowKeyboard: aBoolean [
 	originalFocusHolder := aWorld primaryHand keyboardFocus.
 	self popUpAt: aPoint forHand: aWorld primaryHand in: aWorld allowKeyboard: aBoolean.
 	w := aWorld outermostWorldMorph. "containing hand"
-	[self isInWorld] whileTrue: [w doOneSubCycle].
+	[self isInWorld] whileTrue: [w doOneCycle].
 	self delete.
 	self restoreFocus: originalFocusHolder in: aWorld.
 	^ selectedItem ifNotNil: [selectedItem target]
@@ -936,7 +936,7 @@ MenuMorph >> invokeModalAt: aPoint in: aWorld allowKeyboard: aBoolean [
 	self popUpAt: aPoint forHand: aWorld primaryHand in: aWorld allowKeyboard: aBoolean.
 	self isModalInvokationDone: false.
 	w := aWorld outermostWorldMorph. "containing hand"
-	[self isInWorld and: [ self isModalInvokationDone not ] ] whileTrue: [w doOneSubCycle].
+	[self isInWorld and: [ self isModalInvokationDone not ] ] whileTrue: [w doOneCycle].
 	self delete.
 	self restoreFocus: originalFocusHolder in: aWorld.
 	^ self modalSelection

--- a/src/Morphic-Base/MenuMorph.class.st
+++ b/src/Morphic-Base/MenuMorph.class.st
@@ -15,7 +15,8 @@ Class {
 		'stayUp',
 		'popUpOwner',
 		'activeSubMenu',
-		'titleMorph'
+		'titleMorph',
+		'selection'
 	],
 	#classVars : [
 		'CloseBoxImage',
@@ -879,15 +880,17 @@ MenuMorph >> invokeAt: aPoint in: aWorld [
 
 { #category : #invoking }
 MenuMorph >> invokeAt: aPoint in: aWorld allowKeyboard: aBoolean [
-	"Add this menu to the given world centered at the given point. Wait for the user to make a selection and answer it. The selection value returned is an integer in keeping with PopUpMenu, if the menu is converted from an MVC-style menu."
-	"Details: This is invoked synchronously from the caller. In order to keep processing inputs and updating the screen while waiting for the user to respond, this method has its own version of the World's event loop." 
+	"Add this menu to the given world centered at the given point. Wait for the user to make a selection and answer it."
+	"Details: This is invoked synchronously from the caller.
+	In order to keep processing inputs and updating the screen while waiting for the user to respond,
+	this method has its own version of the World's event loop." 
 	| originalFocusHolder |
 	originalFocusHolder := aWorld primaryHand keyboardFocus.
 	self popUpAt: aPoint forHand: aWorld primaryHand in: aWorld allowKeyboard: aBoolean.
 	MorphicRenderLoop new doOneCycleWhile: [ self isInWorld ].
 	self delete.
 	self restoreFocus: originalFocusHolder in: aWorld.
-	^ selectedItem ifNotNil: [selectedItem target]
+	^ selection ifNil: [ selectedItem ifNotNil: [selectedItem target] ]
 
 ]
 
@@ -897,13 +900,11 @@ MenuMorph >> invokeMetaMenu: evt [
 	^super invokeMetaMenu: evt
 ]
 
-{ #category : #'modal control' }
+{ #category : #invoking }
 MenuMorph >> invokeModal [
 	"Invoke this menu and don't return until the user has chosen a value.
-	See example below on how to use modal menu morphs."
-	^ self invokeModal: self menuKeyboardControl
-
-	"Example:
+	See example below on how to use modal menu morphs.
+	Example:
 	| menu sub entry |
 	menu := MenuMorph new.
 	1 to: 3 do: [:i |
@@ -913,48 +914,17 @@ MenuMorph >> invokeModal [
 		#('Item A' 'Item B' 'Item C')  do:[:subEntry|
 			sub add: subEntry target: menu 
 				selector: #modalSelection: argument: {entry. subEntry}]].
-	menu invokeModal.
-"
+	menu invokeModal."
 
-
-]
-
-{ #category : #'modal control' }
-MenuMorph >> invokeModal: allowKeyboardControl [
-	"Invoke this menu and don't return until the user has chosen a value.  If the allowKeyboarControl boolean is true, permit keyboard control of the menu"
-
-	^ self invokeModalAt: ActiveHand position in: self currentWorld allowKeyboard: allowKeyboardControl
-]
-
-{ #category : #'modal control' }
-MenuMorph >> invokeModalAt: aPoint in: aWorld allowKeyboard: aBoolean [
-	"Invoke this menu and don't return until the user has chosen a value.
-	See senders of this method for finding out how to use modal menu morphs."
-	| originalFocusHolder |
-	originalFocusHolder := aWorld primaryHand keyboardFocus.
-	self popUpAt: aPoint forHand: aWorld primaryHand in: aWorld allowKeyboard: aBoolean.
-	self isModalInvokationDone: false.
-	MorphicRenderLoop new doOneCycleWhile: [
-		self isInWorld and: [ self isModalInvokationDone not ] ].
-	self delete.
-	self restoreFocus: originalFocusHolder in: aWorld.
-	^ self modalSelection
+	^ self
+		invokeAt: ActiveHand position
+		in: self currentWorld
+		allowKeyboard: self menuKeyboardControl.
 ]
 
 { #category : #testing }
 MenuMorph >> isMenuMorph [
 	^ true
-]
-
-{ #category : #'modal control' }
-MenuMorph >> isModalInvokationDone [
-	^self valueOfProperty: #isModalInvokationDone ifAbsent:[false]
-]
-
-{ #category : #'modal control' }
-MenuMorph >> isModalInvokationDone: aBool [
-	self setProperty: #isModalInvokationDone toValue: aBool
-
 ]
 
 { #category : #accessing }
@@ -1104,13 +1074,13 @@ MenuMorph >> menuItems [
 
 { #category : #'modal control' }
 MenuMorph >> modalSelection [
-	^self valueOfProperty: #modalSelection ifAbsent:[nil]
+	^ selection
 ]
 
 { #category : #'modal control' }
 MenuMorph >> modalSelection: anObject [
-	self setProperty: #modalSelection toValue: anObject.
-	self isModalInvokationDone: true
+	selection := anObject.
+	self deleteIfPopUp
 ]
 
 { #category : #private }

--- a/src/Morphic-Base/MenuMorph.class.st
+++ b/src/Morphic-Base/MenuMorph.class.st
@@ -874,7 +874,7 @@ MenuMorph >> invokeAt: aPoint in: aWorld [
 	"Add this menu to the given world centered at the given point. Wait for the user to make a selection and answer it. The selection value returned is an integer in keeping with PopUpMenu, if the menu is converted from an MVC-style menu."
 	"Details: This is invoked synchronously from the caller. In order to keep processing inputs and updating the screen while waiting for the user to respond, this method has its own version of the World's event loop."
 
-	^ self invokeAt: aPoint in: aWorld allowKeyboard: self  menuKeyboardControl
+	^ self invokeAt: aPoint in: aWorld allowKeyboard: self menuKeyboardControl
 ]
 
 { #category : #invoking }

--- a/src/Morphic-Base/MenuMorph.class.st
+++ b/src/Morphic-Base/MenuMorph.class.st
@@ -881,11 +881,10 @@ MenuMorph >> invokeAt: aPoint in: aWorld [
 MenuMorph >> invokeAt: aPoint in: aWorld allowKeyboard: aBoolean [
 	"Add this menu to the given world centered at the given point. Wait for the user to make a selection and answer it. The selection value returned is an integer in keeping with PopUpMenu, if the menu is converted from an MVC-style menu."
 	"Details: This is invoked synchronously from the caller. In order to keep processing inputs and updating the screen while waiting for the user to respond, this method has its own version of the World's event loop." 
-	| w originalFocusHolder |
+	| originalFocusHolder |
 	originalFocusHolder := aWorld primaryHand keyboardFocus.
 	self popUpAt: aPoint forHand: aWorld primaryHand in: aWorld allowKeyboard: aBoolean.
-	w := aWorld outermostWorldMorph. "containing hand"
-	[self isInWorld] whileTrue: [w doOneCycle].
+	MorphicRenderLoop new doOneCycleWhile: [ self isInWorld ].
 	self delete.
 	self restoreFocus: originalFocusHolder in: aWorld.
 	^ selectedItem ifNotNil: [selectedItem target]
@@ -931,12 +930,12 @@ MenuMorph >> invokeModal: allowKeyboardControl [
 MenuMorph >> invokeModalAt: aPoint in: aWorld allowKeyboard: aBoolean [
 	"Invoke this menu and don't return until the user has chosen a value.
 	See senders of this method for finding out how to use modal menu morphs."
-	| w originalFocusHolder |
+	| originalFocusHolder |
 	originalFocusHolder := aWorld primaryHand keyboardFocus.
 	self popUpAt: aPoint forHand: aWorld primaryHand in: aWorld allowKeyboard: aBoolean.
 	self isModalInvokationDone: false.
-	w := aWorld outermostWorldMorph. "containing hand"
-	[self isInWorld and: [ self isModalInvokationDone not ] ] whileTrue: [w doOneCycle].
+	MorphicRenderLoop new doOneCycleWhile: [
+		self isInWorld and: [ self isModalInvokationDone not ] ].
 	self delete.
 	self restoreFocus: originalFocusHolder in: aWorld.
 	^ self modalSelection

--- a/src/Morphic-Base/MenuMorph.class.st
+++ b/src/Morphic-Base/MenuMorph.class.st
@@ -46,7 +46,7 @@ MenuMorph class >> chooseFrom: aList lines: linesArray title: queryString [
 		menu add: (aList at: i) asString target: [:v| result := v] selector: #value: argument: i.
 		(linesArray includes: i) ifTrue: [menu addLine]].
 	
-	menu invokeAt: ActiveHand position in: self currentWorld allowKeyboard: true.
+	menu invokeModal.
 	^result
 ]
 
@@ -71,7 +71,7 @@ MenuMorph class >> chooseFrom: aList values: valueList lines: linesArray title: 
 		menu add: (aList at: i) asString target: [:v| result := v] selector: #value: argument: (valueList at: i).
 		(linesArray includes: i) ifTrue:[menu addLine]].
 
-	menu invokeAt: ActiveHand position in: self currentWorld allowKeyboard: true.
+	menu invokeModal.
 	^result
 ]
 
@@ -129,10 +129,7 @@ MenuMorph class >> confirm: queryString trueChoice: trueChoice falseChoice: fals
 		target: aBlock
 		selector: #value:
 		argument: false.
-	[ menu
-		invokeAt: ActiveHand position
-		in: self currentWorld
-		allowKeyboard: true.
+	[ menu invokeModal.
 	result isNil ] whileTrue.
 	^ result
 ]
@@ -919,7 +916,6 @@ MenuMorph >> invokeModal [
 	^ self
 		invokeAt: ActiveHand position
 		in: self currentWorld
-		allowKeyboard: self menuKeyboardControl.
 ]
 
 { #category : #testing }

--- a/src/Morphic-Base/SystemProgressMorph.class.st
+++ b/src/Morphic-Base/SystemProgressMorph.class.st
@@ -295,13 +295,11 @@ SystemProgressMorph >> morphicLayerNumber [
 
 ]
 
-{ #category : #display }
-SystemProgressMorph >> openInWorld [
+{ #category : #opening }
+SystemProgressMorph >> preOpenInWorld: aWorld [
 
-	super openInWorld.
 	self width: 200.
-	self resize.
-	
+	self resize.	
 ]
 
 { #category : #updating }

--- a/src/Morphic-Base/WorldState.extension.st
+++ b/src/Morphic-Base/WorldState.extension.st
@@ -33,11 +33,15 @@ WorldState >> menuBuilder [
 
 { #category : #'*Morphic-Base' }
 WorldState class >> startMessageTally [
+
 	(self confirm: 'MessageTally will start now,
 and stop when the cursor goes
 to the top of the screen' translated) 
-		ifTrue: [TimeProfiler spyAllOn: [[self currentWorld activeHand position y > 0] 
-					whileTrue: [self currentWorld doOneCycle]]]
+		ifFalse: [ ^ self ].
+
+	TimeProfiler spyAllOn: [
+		MorphicRenderLoop new doOneCycleWhile: [ 
+			self currentWorld activeHand position y > 0 ] ]
 ]
 
 { #category : #'*Morphic-Base' }
@@ -61,9 +65,11 @@ WorldState class >> startThenBrowseMessageTally [
 	
 	(self confirm: 'MessageTally the UI process until the
 mouse pointer goes to the top of the screen')
-		ifTrue: [TimeProfiler
-				onBlock: [[self currentWorld activeHand position y > 10]
-						whileTrue: [self currentWorld doOneCycle]]]
+		ifFalse: [ ^ self ].
+
+	TimeProfiler onBlock: [
+		MorphicRenderLoop new doOneCycleWhile: [ 
+			self currentWorld activeHand position y > 10 ] ]
 ]
 
 { #category : #'*Morphic-Base' }

--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -234,7 +234,7 @@ HandMorph >> captureEventsUntil: aBlock [
 	captureBlock := [:evt | release := aBlock value: evt ].
 	
 	[
-		[ self world doOneCycle. release ] whileFalse.
+		MorphicRenderLoop new doOneCycleWhile: [ release not ].
 	] ensure: [
 		captureBlock := nil.
 	]

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -204,16 +204,6 @@ Morph >> aboutToBeGrabbedBy: aHand [
 	^self "Grab me"
 ]
 
-{ #category : #opening }
-Morph >> aboutToOpenInWorld: aWorld [
-	"Interact with a world to decide how to position myself.
-	By default, I choose the visible area of the world.
-	Subclasses may choose different strategies or even calculate their bounds.
-	"
-	(aWorld visibleClearArea origin ~= (0@0) and: [self position = (0@0)]) ifTrue:
-		[self position: aWorld visibleClearArea origin].
-]
-
 { #category : #layout }
 Morph >> acceptDroppingMorph: aMorph event: evt [
 	"This message is sent when a morph is dropped onto a morph that has agreed to accept the dropped morph by responding 'true' to the wantsDroppedMorph:Event: message. This default implementation just adds the given morph to the receiver."
@@ -2256,6 +2246,12 @@ Morph >> doLayoutIn: layoutBounds [
 	box := self outerBounds.
 	box = priorBounds 
 		ifFalse: [self invalidRect: (priorBounds quickMerge: box)]
+]
+
+{ #category : #opening }
+Morph >> doOpenInWorld: aWorld [
+
+	aWorld addMorph: self
 ]
 
 { #category : #'submorphs-accessing' }
@@ -4535,8 +4531,8 @@ Morph >> openInWorld [
 
 { #category : #opening }
 Morph >> openInWorld: aWorld [
-	self aboutToOpenInWorld: aWorld.
-	aWorld addMorph: self.
+	self preOpenInWorld: aWorld.
+	self doOpenInWorld: aWorld.
 	self postOpenInWorld: aWorld.
 	self announceOpened.
 ]
@@ -4777,6 +4773,16 @@ Morph >> potentialTargetsAt: aPoint [
 	^ realOwner
 		morphsAt: aPoint
 		
+]
+
+{ #category : #opening }
+Morph >> preOpenInWorld: aWorld [
+	"Interact with a world to decide how to position myself.
+	By default, I choose the visible area of the world.
+	Subclasses may choose different strategies or even calculate their bounds.
+	"
+	(aWorld visibleClearArea origin ~= (0@0) and: [self position = (0@0)]) ifTrue:
+		[self position: aWorld visibleClearArea origin].
 ]
 
 { #category : #'halos and balloon help' }

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -204,6 +204,16 @@ Morph >> aboutToBeGrabbedBy: aHand [
 	^self "Grab me"
 ]
 
+{ #category : #opening }
+Morph >> aboutToOpenInWorld: aWorld [
+	"Interact with a world to decide how to position myself.
+	By default, I choose the visible area of the world.
+	Subclasses may choose different strategies or even calculate their bounds.
+	"
+	(aWorld visibleClearArea origin ~= (0@0) and: [self position = (0@0)]) ifTrue:
+		[self position: aWorld visibleClearArea origin].
+]
+
 { #category : #layout }
 Morph >> acceptDroppingMorph: aMorph event: evt [
 	"This message is sent when a morph is dropped onto a morph that has agreed to accept the dropped morph by responding 'true' to the wantsDroppedMorph:Event: message. This default implementation just adds the given morph to the receiver."
@@ -4518,19 +4528,16 @@ Morph >> openInHand [
 
 { #category : #display }
 Morph >> openInWorld [
-        "Add this morph to the world."
-
-        self openInWorld: self currentWorld
+	
+	"Add this morph to the world."
+	self openInWorld: self currentWorld
 ]
 
-{ #category : #initialize }
+{ #category : #opening }
 Morph >> openInWorld: aWorld [
-	"Add this morph to the requested World."
-	(aWorld visibleClearArea origin ~= (0@0) and: [self position = (0@0)]) ifTrue:
-		[self position: aWorld visibleClearArea origin].
+	self aboutToOpenInWorld: aWorld.
 	aWorld addMorph: self.
-	aWorld startSteppingSubmorphsOf: self.
-	
+	self postOpenInWorld: aWorld.
 	self announceOpened.
 ]
 
@@ -4734,6 +4741,12 @@ Morph >> positionInWorld [
 Morph >> positionSubmorphs [
 	self submorphsDo:
 		[:aMorph | aMorph snapToEdgeIfAppropriate]
+]
+
+{ #category : #opening }
+Morph >> postOpenInWorld: aWorld [
+
+	aWorld startSteppingSubmorphsOf: self
 ]
 
 { #category : #'meta-actions' }

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -4522,7 +4522,7 @@ Morph >> openInHand [
 	self currentHand attachMorph: self
 ]
 
-{ #category : #display }
+{ #category : #opening }
 Morph >> openInWorld [
 	
 	"Add this morph to the world."

--- a/src/Morphic-Core/MorphicCoreUIManager.class.st
+++ b/src/Morphic-Core/MorphicCoreUIManager.class.st
@@ -56,7 +56,7 @@ MorphicCoreUIManager >> resumeUIProcess: aProcess [
 MorphicCoreUIManager >> spawnNewProcess [
 
   UIProcess := [
-    [WorldMorph doOneCycle.  Processor yield.  false] whileFalse: [].
+	MorphicRenderLoop new doOneCycleWhile: [ true ]
   ] newProcess priority: Processor userSchedulingPriority.
   UIProcess name: 'Morphic UI Process'.
   UIProcess resume

--- a/src/Morphic-Core/MorphicRenderLoop.class.st
+++ b/src/Morphic-Core/MorphicRenderLoop.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #MorphicRenderLoop,
+	#superclass : #Object,
+	#category : #'Morphic-Core-Kernel'
+}
+
+{ #category : #'initialize-release' }
+MorphicRenderLoop >> doOneCycle [
+
+	WorldMorph doOneCycle
+]
+
+{ #category : #'initialize-release' }
+MorphicRenderLoop >> doOneCycleWhile: aBlock [
+
+	[ aBlock value ] whileTrue: [ 
+		self doOneCycle.
+		"Collaborate with other processes in the same priority"
+		Processor yield. ]
+]

--- a/src/Morphic-Core/PasteUpMorph.class.st
+++ b/src/Morphic-Core/PasteUpMorph.class.st
@@ -600,14 +600,6 @@ PasteUpMorph >> griddingString [
 		, 'use gridding' translated
 ]
 
-{ #category : #recategorized }
-PasteUpMorph >> handlerForMouseDown: anEvent [
-	"If we have a modal dialog then answer nil otherwise as usual.."
-	
-	^(self hasProperty: #submorphLockStates)
-		ifFalse: [super handlerForMouseDown: anEvent]
-]
-
 { #category : #'event handling' }
 PasteUpMorph >> handlesKeyboard: evt [
 	^ true "handle all not handled events"

--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -329,13 +329,6 @@ WorldMorph >> doOneCycleNow [
 
 ]
 
-{ #category : #'world state' }
-WorldMorph >> doOneSubCycle [
-	"Like doOneCycle, but preserves activeHand."
-
-	worldState doOneSubCycleFor: self
-]
-
 { #category : #geometry }
 WorldMorph >> extent: aPoint [
 	super extent: aPoint.

--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -510,16 +510,6 @@ WorldState >> doOneCycleNowFor: aWorld [
 ]
 
 { #category : #'update cycle' }
-WorldState >> doOneSubCycleFor: aWorld [
-	"Like doOneCycle, but preserves activeHand."
-
-	| currentHand |
-	currentHand := self activeHand.
-	self doOneCycleFor: aWorld.
-	self activeHand: currentHand.
-]
-
-{ #category : #'update cycle' }
 WorldState >> drawWorld: aWorld submorphs: submorphs invalidAreasOn: aCanvas [ 
 	"Redraw the damaged areas of the given canvas and clear the damage list. Return a collection of the areas that
 were redrawn."

--- a/src/Morphic-Examples/ExampleBuilderMorph.class.st
+++ b/src/Morphic-Examples/ExampleBuilderMorph.class.st
@@ -18,27 +18,3 @@ ExampleBuilderMorph >> chooseColor: aColor title: label [
 		title: (label ifNil: ['Choose Color' translated])
 		color: aColor
 ]
-
-{ #category : #'as yet unclassified' }
-ExampleBuilderMorph >> openModal: aSystemWindow [
-	"Open the given window an available position without modality.
-	Answer the system window."
-	
-	|baseArea areas searching foundRect|
-	aSystemWindow extent: aSystemWindow initialExtent.
-	areas := self currentWorld submorphs
-		select: [:m | m isKindOf: DialogWindow]
-		thenCollect: [:m | m bounds expandBy: 8].
-	baseArea := RealEstateAgent maximumUsableArea insetBy: 8.
-	searching := true.
-	baseArea allAreasOutsideList: areas do: [:rect |
-		searching ifTrue: [
-			aSystemWindow extent <= (rect insetBy: 8) extent
-				ifTrue: [foundRect := rect.
-						searching := false]]].
-	searching ifTrue: [foundRect := baseArea].
-	aSystemWindow setWindowColor: self theme windowColor.
-	aSystemWindow position: foundRect topLeft + 8.
-	aSystemWindow openAsIs.
-	^aSystemWindow
-]

--- a/src/Morphic-Examples/WidgetExamples.class.st
+++ b/src/Morphic-Examples/WidgetExamples.class.st
@@ -59,7 +59,7 @@ WidgetExamples class >> colorControls [
 					help: 'This is a hue-saturation-volume-alpha selector')
 					minHeight: 184; minWidth: 184)});
 		model: nil.
-	builder openModal: dialog
+	dialog openModal
 ]
 
 { #category : #examples }
@@ -144,7 +144,7 @@ WidgetExamples class >> exampleBasicControls [
 						getText: #value setText: #value:) disable)}})
 			vResizing: #spaceFill);
 		model: nil.
-	builder openModal: dialog
+	dialog openModal
 ]
 
 { #category : #examples }
@@ -171,7 +171,7 @@ WidgetExamples class >> exampleColorControls [
 					help: 'This is a hue-saturation-volume-alpha selector')
 					minHeight: 184; minWidth: 184)});
 		model: nil.
-	builder openModal: dialog
+	dialog openModal
 ]
 
 { #category : #examples }
@@ -274,7 +274,7 @@ WidgetExamples class >> exampleGroups [
 														help: 'This is a checkbox'))}))})})
 				vResizing: #spaceFill);
 		model: nil.
-	builder openModal: dialog
+	dialog openModal
 ]
 
 { #category : #examples }
@@ -343,7 +343,7 @@ WidgetExamples class >> exampleOtherControls [
 				cellInset: 0;
 				borderStyle: (BorderStyle inset baseColor: dialog paneColor; width: 1))});
 		model: nil.
-	builder openModal: dialog
+	dialog openModal
 ]
 
 { #category : #examples }

--- a/src/Morphic-Widgets-ColorPicker/Morph.extension.st
+++ b/src/Morphic-Widgets-ColorPicker/Morph.extension.st
@@ -7,7 +7,7 @@ Morph >> changeColor [
 	dialog := ColorSelectorDialogWindow new
 		title: 'Choose color';
 		selectedColor: self color.
-	self openModal: dialog.
+	dialog openModal.
 	dialog cancelled
 		ifFalse: [self fillStyle: dialog selectedColor]
 	

--- a/src/Morphic-Widgets-Taskbar/TaskListMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskListMorph.class.st
@@ -87,6 +87,13 @@ TaskListMorph >> defaultPreviewExtent [
 	^(320@320) scaledByDisplayScaleFactor
 ]
 
+{ #category : #'open/close' }
+TaskListMorph >> doOpenInWorld: aWorld [
+	"Update the layout after opening."
+
+	aWorld addMorphCentered: self
+]
+
 { #category : #running }
 TaskListMorph >> done [
 	"Close the tasklist and make the active task current."
@@ -195,24 +202,25 @@ TaskListMorph >> newTasksMorph [
 ]
 
 { #category : #'open/close' }
-TaskListMorph >> openAsIs [
-	"Open in the world."
-	
-	self openAsIsIn: self currentWorld
+TaskListMorph >> openInWorld: aWorld [
+
+	super openInWorld: aWorld.	
+	self wantsKeyboardFocus
+		ifTrue: [self takeKeyboardFocus]
 ]
 
 { #category : #'open/close' }
-TaskListMorph >> openAsIsIn: aWorld [
+TaskListMorph >> postOpenInWorld: aWorld [
 	"Update the layout after opening."
 
-	aWorld addMorphCentered: self.
 	self allMorphs do: [:m | m layoutChanged].
-	aWorld startSteppingSubmorphsOf: self.
-	
-	self announceOpened.
-	
-	self wantsKeyboardFocus
-		ifTrue: [self takeKeyboardFocus]
+	super postOpenInWorld: aWorld
+]
+
+{ #category : #'open/close' }
+TaskListMorph >> preOpenInWorld: aWorld [
+
+	"Do nothing"
 ]
 
 { #category : #accessing }

--- a/src/Morphic-Widgets-Taskbar/UITheme.extension.st
+++ b/src/Morphic-Widgets-Taskbar/UITheme.extension.st
@@ -42,5 +42,5 @@ UITheme >> openTaskListIn: world from: aKeyboardEvent [
 
 	| tasklistMorph |
 	tasklistMorph := TaskListMorph from: aKeyboardEvent.
-	tasklistMorph openAsIsIn: world.
+	tasklistMorph openInWorld: world.
 ]

--- a/src/Morphic-Widgets-Tree/MorphTreeModel.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeModel.class.st
@@ -322,8 +322,8 @@ MorphTreeModel >> openDialogWindowIn: aWindow title: aTitle [
 { #category : #dialog }
 MorphTreeModel >> openDialogWindowIn: aWindow title: aTitle selectedtems: aCollection [ 
 	| dialog |
-	dialog := self dialogWindowIn:  aWindow title: aTitle selectedtems: aCollection.
-	aWindow openModal: dialog.
+	dialog := self dialogWindowIn: aWindow title: aTitle selectedtems: aCollection.
+	dialog openModal.
 	^ dialog cancelled ifFalse: [self selectedItems]
 
 ]

--- a/src/Morphic-Widgets-Windows/FullscreenMorph.class.st
+++ b/src/Morphic-Widgets-Windows/FullscreenMorph.class.st
@@ -46,31 +46,18 @@ FullscreenMorph >> layoutChanged [
 	self layoutPolicy ifNotNil:[:l | l flushLayoutCache].
 ]
 
-{ #category : #'open/close' }
-FullscreenMorph >> openAsIs [
-	"Open in the current world with the current position and extent."
+{ #category : #initialize }
+FullscreenMorph >> postOpenInWorld: aWorld [
 	
-	^self openAsIsIn: self currentWorld
-
-]
-
-{ #category : #'open/close' }
-FullscreenMorph >> openAsIsIn: aWorld [
-	"Start stepping."
-	
-	aWorld addMorph: self.
-	(self submorphs notEmpty and: [self submorphs first isSystemWindow])
-		ifTrue: [self submorphs first openedFullscreen].
-	aWorld startSteppingSubmorphsOf: self.
-	
-	self announceOpened.
+	(self submorphs notEmpty and: [ self submorphs first isSystemWindow ])
+		ifTrue: [ self submorphs first openedFullscreen ].
+	super postOpenInWorld: aWorld
 ]
 
 { #category : #initialize }
-FullscreenMorph >> openInWorld: aWorld [
-	"Open as is."
-	
-	^self openAsIsIn: aWorld
+FullscreenMorph >> preOpenInWorld: aWorld [
+
+	"Do nothing"
 ]
 
 { #category : #accessing }

--- a/src/Morphic-Widgets-Windows/Morph.extension.st
+++ b/src/Morphic-Widgets-Windows/Morph.extension.st
@@ -163,17 +163,9 @@ Morph >> openModal: aSystemWindow [
 	aSystemWindow position = (0@0) ifTrue: [
 			aSystemWindow position: self activeHand position - (aSystemWindow extent // 2)
 	].
-	aSystemWindow bounds: (aSystemWindow bounds translatedToBeWithin: area).
-	
+	aSystemWindow bounds: (aSystemWindow bounds translatedToBeWithin: area).	
 	[  
-		|aWidget| 
-		
-		aWidget := aSystemWindow openAsIs.
-		
-		self activeHand mouseFocus: aWidget.
-		
-		MorphicRenderLoop new doOneCycleWhile: [ aWidget isInWorld ]
-		
+		aSystemWindow openModal.
 	] ensure: [
 		mySysWin modalUnlockFrom: aSystemWindow.
 		self activeHand newKeyboardFocus: keyboardFocus

--- a/src/Morphic-Widgets-Windows/Morph.extension.st
+++ b/src/Morphic-Widgets-Windows/Morph.extension.st
@@ -66,13 +66,6 @@ Morph >> isWindowActive: aSystemWindow [
 ]
 
 { #category : #'*Morphic-Widgets-Windows' }
-Morph >> modalLockTo: aSystemWindow [
-	"Lock the receiver as a modal owner of the given window."
-
-	self lock
-]
-
-{ #category : #'*Morphic-Widgets-Windows' }
 Morph >> nextMorphAcrossInWindow [
 	"Answer the next morph in the window. Traverse
 	from the receiver to its next sibling or owner's next sibling etc."
@@ -144,37 +137,6 @@ Morph >> openInWindowLabeled: aString inWorld: aWorld [
 ]
 
 { #category : #'*Morphic-Widgets-Windows' }
-Morph >> openModal: aSystemWindow [
-	"Open the given window locking the receiver until it is dismissed.
-	Answer the system window.
-	Restore the original keyboard focus when closed."
-
-	|area mySysWin keyboardFocus|
-	
-	keyboardFocus := self activeHand keyboardFocus.
-	
-	mySysWin := self isSystemWindow ifTrue: [self] ifFalse: [self ownerThatIsA: SystemWindow].
-	mySysWin ifNil: [mySysWin := self].
-	mySysWin modalLockTo: aSystemWindow.
-	
-	area := RealEstateAgent maximumUsableArea.
-	
-	aSystemWindow extent: aSystemWindow initialExtent.
-	aSystemWindow position = (0@0) ifTrue: [
-			aSystemWindow position: self activeHand position - (aSystemWindow extent // 2)
-	].
-	aSystemWindow bounds: (aSystemWindow bounds translatedToBeWithin: area).	
-	[  
-		aSystemWindow openModal.
-	] ensure: [
-		mySysWin modalUnlockFrom: aSystemWindow.
-		self activeHand newKeyboardFocus: keyboardFocus
-	].
-
-	^aSystemWindow
-]
-
-{ #category : #'*Morphic-Widgets-Windows' }
 Morph >> previousMorphInWindow [
 	"Answer the next morph in the window. Traverse
 	from the receiver to its previous sibling's last submorph (recursive)
@@ -213,4 +175,22 @@ Morph >> window [
 	"Answer the receiver's window."
 
 	^self ownerThatIsA: SystemWindow
+]
+
+{ #category : #'*Morphic-Widgets-Windows' }
+Morph >> wrappedInWindow [
+	"Changed to include the inset margin in the bound calculation."
+
+	| window extent |
+	window := SystemWindow new.
+	window 
+		addMorph: self frame: (0@0 extent: 1@1);
+		updatePaneColors.
+	" calculate extent after adding in case any size related attributes were changed.  Use
+	fullBounds in order to trigger re-layout of layout morphs"
+	extent := self fullBounds extent + 
+			(window borderWidth@window labelHeight) + window borderWidth +
+			(window class borderWidth * 2 @ (window class borderWidth + 1)). "include inset margin"
+	window extent: extent.
+	^ window
 ]

--- a/src/Morphic-Widgets-Windows/Morph.extension.st
+++ b/src/Morphic-Widgets-Windows/Morph.extension.st
@@ -114,26 +114,9 @@ Morph >> openInWindowLabeled: aString [
 Morph >> openInWindowLabeled: aString inWorld: aWorld [
 	"Changed to include the inset margin in the bound calculation."
 
-	| window extent |
-	window := (SystemWindow labelled: aString) model: nil.
-	window 
-		" guess at initial extent"
-		bounds:  (RealEstateAgent initialFrameFor: window initialExtent: self fullBounds extent world: aWorld);
-		addMorph: self frame: (0@0 extent: 1@1);
-		updatePaneColors.
-	" calculate extent after adding in case any size related attributes were changed.  Use
-	fullBounds in order to trigger re-layout of layout morphs"
-	extent := self fullBounds extent + 
-			(window borderWidth@window labelHeight) + window borderWidth +
-			(window class borderWidth * 2 @ (window class borderWidth + 1)). "include inset margin"
-	window extent: extent.
-	aWorld addMorph: window.
-	window activate.
-	aWorld startSteppingSubmorphsOf: window.
-	
-	window announceOpened.
-	^window
-
+	^ self wrappedInWindow
+		setLabel: aString;
+		openInWorld: aWorld
 ]
 
 { #category : #'*Morphic-Widgets-Windows' }

--- a/src/Morphic-Widgets-Windows/Morph.extension.st
+++ b/src/Morphic-Widgets-Windows/Morph.extension.st
@@ -172,9 +172,7 @@ Morph >> openModal: aSystemWindow [
 		
 		self activeHand mouseFocus: aWidget.
 		
-		[aWidget world notNil] whileTrue: [
-			aWidget outermostWorldMorph doOneCycle
-		]
+		MorphicRenderLoop new doOneCycleWhile: [ aWidget isInWorld ]
 		
 	] ensure: [
 		mySysWin modalUnlockFrom: aSystemWindow.

--- a/src/Morphic-Widgets-Windows/PasteUpMorph.extension.st
+++ b/src/Morphic-Widgets-Windows/PasteUpMorph.extension.st
@@ -22,40 +22,6 @@ PasteUpMorph >> isWindowActive: aSystemWindow [
 ]
 
 { #category : #'*Morphic-Widgets-Windows' }
-PasteUpMorph >> modalLockTo: aSystemWindow [
-	"Don't lock the world nor the aSystemWindow! Lock the submorphs."
-	
-	|lockStates|
-	
-	lockStates := IdentityDictionary new.
-	"lock all submorphs"
-	self submorphsDo: [:m |
-		lockStates at: m put: m isLocked.
-		m lock].
-	"don't lock the given window"
-	aSystemWindow unlock.
-	lockStates at: aSystemWindow put: aSystemWindow isLocked.
-	
-	self
-		setProperty: #submorphLockStates
-		toValue: lockStates
-]
-
-{ #category : #'*Morphic-Widgets-Windows' }
-PasteUpMorph >> modalUnlockFrom: aSystemWindow [
-	"Don't unlock the world! Unlock the submorphs
-	that were not originally locked."
-	
-	|lockStates|
-	lockStates := self
-		valueOfProperty: #submorphLockStates
-		ifAbsent: [^self].
-	self removeProperty: #submorphLockStates.
-	lockStates keysAndValuesDo: [:m :locked |
-		locked ifFalse: [m unlock]]
-]
-
-{ #category : #'*Morphic-Widgets-Windows' }
 PasteUpMorph >> modelWakeUpIn: aWindow [
 	"I am the model of a SystemWindow, that has just been activated"
 

--- a/src/Morphic-Widgets-Windows/PasteUpMorph.extension.st
+++ b/src/Morphic-Widgets-Windows/PasteUpMorph.extension.st
@@ -114,16 +114,6 @@ PasteUpMorph >> nextWindow [
 ]
 
 { #category : #'*Morphic-Widgets-Windows' }
-PasteUpMorph >> openModal: aSystemWindow [
-	"Open the given window locking the receiver until it is dismissed.
-	Set the pane color to match the current theme.
-	Answer the system window."
-	
-	aSystemWindow setWindowColor: self theme windowColor.
-	^ super openModal: aSystemWindow
-]
-
-{ #category : #'*Morphic-Widgets-Windows' }
 PasteUpMorph >> previousWindow [
 	"Answer the previous window to navigate to."
 

--- a/src/Morphic-Widgets-Windows/StandardWindow.class.st
+++ b/src/Morphic-Widgets-Windows/StandardWindow.class.st
@@ -170,14 +170,6 @@ StandardWindow >> open [
 ]
 
 { #category : #'open/close' }
-StandardWindow >> openAsIsIn: aWorld [
-	"Sad fixup for dodgy layout."
-
-	super openAsIsIn: aWorld.
-	self allMorphs do: [:m | m layoutChanged]
-]
-
-{ #category : #'open/close' }
 StandardWindow >> openFullscreen [
 	"Open the receiver in a FullscreenMorph."
 
@@ -192,6 +184,13 @@ StandardWindow >> openedFullscreen [
 
 	self allMorphs do: [:m | m layoutChanged].
 	self activate
+]
+
+{ #category : #'open/close' }
+StandardWindow >> postOpenInWorld: aWorld [
+
+	self allMorphs do: [:m | m layoutChanged].
+	super postOpenInWorld: aWorld
 ]
 
 { #category : #controls }

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -490,13 +490,6 @@ SystemWindow class >> windowsIn: aWorld satisfying: windowBlock [
 	^ windows
 ]
 
-{ #category : #opening }
-SystemWindow >> aboutToOpenInWorld: aWorld [
-	"This msg and its callees result in the window being activeOnlyOnTop"
-	self bounds: (RealEstateAgent initialFrameFor: self world: aWorld).
-	self playOpenSound.
-]
-
 { #category : #activation }
 SystemWindow >> activate [
 	"Activate the owner too."
@@ -1474,47 +1467,6 @@ SystemWindow >> offerWindowMenu [
 ]
 
 { #category : #'open/close' }
-SystemWindow >> openAsIs [
-	^self openAsIsIn: self currentWorld
-
-]
-
-{ #category : #'open/close' }
-SystemWindow >> openAsIsIn: aWorld [
-	"This msg and its callees result in the window being activeOnlyOnTop.
-	Play the open sound if the preference is enabled."
-	
-	self playOpenSound.
-	aWorld addMorph: self.
-	self activate.
-	aWorld startSteppingSubmorphsOf: self.
-	
-	self announceOpened.
-	
-	self currentWorld announcer 
-		announce: (WindowOpened new
-						window: self;
-						yourself).
-
-]
-
-{ #category : #'open/close' }
-SystemWindow >> openInWorld: aWorld extent: extent [
-	"This msg and its callees result in the window being activeOnlyOnTop"
-	self
-		position: (RealEstateAgent initialFrameFor: self initialExtent: extent world: aWorld) topLeft;
-		extent: extent.
-	^self openAsIsIn: aWorld
-]
-
-{ #category : #'open/close' }
-SystemWindow >> openInWorldExtent: extent [
-	"This msg and its callees result in the window being activeOnlyOnTop"
-
-	self openInWorld: self currentWorld extent: extent
-]
-
-{ #category : #'open/close' }
 SystemWindow >> openModal [
 
 	self openInWorld.
@@ -1633,6 +1585,16 @@ SystemWindow >> postOpenInWorld: aWorld [
 
 	self activate.
 	super postOpenInWorld: aWorld
+]
+
+{ #category : #opening }
+SystemWindow >> preOpenInWorld: aWorld [
+	"This msg and its callees result in the window being activeOnlyOnTop"
+	self bounds: (RealEstateAgent
+		initialFrameFor: self
+		initialExtent: self initialExtent
+		world: aWorld).
+	self playOpenSound.
 ]
 
 { #category : #printing }

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1131,7 +1131,7 @@ SystemWindow >> icon [
 SystemWindow >> initialExtent [
 	^ (self model respondsTo: #initialExtent)
 		ifTrue: [self model initialExtent]
-		ifFalse: [RealEstateAgent standardWindowExtent]
+		ifFalse: [ self extent ]
 ]
 
 { #category : #initialization }

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1468,7 +1468,7 @@ SystemWindow >> openInWorldExtent: extent [
 SystemWindow >> openModal [
 
 	self openInWorld.
-	self theme runModal: self.
+	MorphicRenderLoop new doOneCycleWhile: [ self isInWorld ]
 ]
 
 { #category : #panes }

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -490,6 +490,13 @@ SystemWindow class >> windowsIn: aWorld satisfying: windowBlock [
 	^ windows
 ]
 
+{ #category : #opening }
+SystemWindow >> aboutToOpenInWorld: aWorld [
+	"This msg and its callees result in the window being activeOnlyOnTop"
+	self bounds: (RealEstateAgent initialFrameFor: self world: aWorld).
+	self playOpenSound.
+]
+
 { #category : #activation }
 SystemWindow >> activate [
 	"Activate the owner too."
@@ -628,6 +635,16 @@ SystemWindow >> announceDeActivated [
 			window: self; 
 			yourself
 	).
+]
+
+{ #category : #announcement }
+SystemWindow >> announceOpened [
+
+	super announceOpened.
+	self currentWorld announcer
+		announce: (WindowOpened new
+						window: self;
+						yourself).
 ]
 
 { #category : #initialization }
@@ -1482,17 +1499,11 @@ SystemWindow >> openAsIsIn: aWorld [
 ]
 
 { #category : #'open/close' }
-SystemWindow >> openInWorld: aWorld [
-	"This msg and its callees result in the window being activeOnlyOnTop"
-	self bounds: (RealEstateAgent initialFrameFor: self world: aWorld).
-	^self openAsIsIn: aWorld.
-
-]
-
-{ #category : #'open/close' }
 SystemWindow >> openInWorld: aWorld extent: extent [
 	"This msg and its callees result in the window being activeOnlyOnTop"
-	self position: (RealEstateAgent initialFrameFor: self initialExtent: extent world: aWorld) topLeft; extent: extent.
+	self
+		position: (RealEstateAgent initialFrameFor: self initialExtent: extent world: aWorld) topLeft;
+		extent: extent.
 	^self openAsIsIn: aWorld
 ]
 
@@ -1615,6 +1626,13 @@ SystemWindow >> positionSubmorphs [
 	super positionSubmorphs.
 	self submorphsDo:
 		[:aMorph | aMorph positionSubmorphs]
+]
+
+{ #category : #opening }
+SystemWindow >> postOpenInWorld: aWorld [
+
+	self activate.
+	super postOpenInWorld: aWorld
 ]
 
 { #category : #printing }

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1329,6 +1329,45 @@ SystemWindow >> minimizeOrRestore [
 	self announce: windowEvent.
 ]
 
+{ #category : #'modal-windows' }
+SystemWindow >> modalChild [
+	"Answer the modal child of the receiver, if any."
+
+	^self valueOfProperty: #modalChild
+]
+
+{ #category : #'modal-windows' }
+SystemWindow >> modalLockTo: aSystemWindow [
+	"Lock the receiver as a modal owner of the given window."
+
+	aSystemWindow setProperty: #modalOwner toValue: self.
+	self setProperty: #modalChild toValue: aSystemWindow.
+	
+	closeBox ifNotNil: [ 
+		self setProperty: #preModalCloseEnabled toValue: closeBox enabled.
+		closeBox enabled: false
+	].
+
+]
+
+{ #category : #'modal-windows' }
+SystemWindow >> modalOwner [
+	"Answer the modal owner of the receiver, if any."
+
+	^self valueOfProperty: #modalOwner
+]
+
+{ #category : #'modal-windows' }
+SystemWindow >> modalUnlockFrom: aSystemWindow [
+	"Unlock the receiver as a modal owner of the given window."
+
+	aSystemWindow removeProperty: #modalOwner.
+	self removeProperty: #modalChild.
+	closeBox ifNotNil: [:cl | cl enabled: (self valueOfProperty: #preModalCloseEnabled ifAbsent: [true])].
+	self removeProperty: #preModalCloseEnabled.
+	self activate
+]
+
 { #category : #events }
 SystemWindow >> mouseDown: evt [
 	"Changed to properly process the mouse down event if passing to
@@ -1469,6 +1508,22 @@ SystemWindow >> openModal [
 
 	self openInWorld.
 	MorphicRenderLoop new doOneCycleWhile: [ self isInWorld ]
+]
+
+{ #category : #'*Morphic-Widgets-Windows' }
+SystemWindow >> openModal: aSystemWindow [
+	"Open the given window locking the receiver until it is dismissed.
+	Answer the system window.
+	Restore the original keyboard focus when closed."
+
+	| keyboardFocus |
+	
+	keyboardFocus := self activeHand keyboardFocus.
+	self modalLockTo: aSystemWindow.
+	[ aSystemWindow openModal ] ensure: [
+		self modalUnlockFrom: aSystemWindow.
+		self activeHand newKeyboardFocus: keyboardFocus ].
+	^aSystemWindow
 ]
 
 { #category : #panes }

--- a/src/Morphic-Widgets-Windows/SystemWindow.extension.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : #SystemWindow }
+
+{ #category : #'*Morphic-Widgets-Windows' }
+SystemWindow >> openModal: aSystemWindow [
+	"Open the given window locking the receiver until it is dismissed.
+	Answer the system window.
+	Restore the original keyboard focus when closed."
+
+	| keyboardFocus |
+	
+	keyboardFocus := self activeHand keyboardFocus.
+	self modalLockTo: aSystemWindow.
+	[ aSystemWindow openModal ] ensure: [
+		self modalUnlockFrom: aSystemWindow.
+		self activeHand newKeyboardFocus: keyboardFocus ].
+	^aSystemWindow
+]

--- a/src/NautilusRefactoring/MethodNameEditor.class.st
+++ b/src/NautilusRefactoring/MethodNameEditor.class.st
@@ -23,7 +23,7 @@ MethodNameEditor class >> on: aMethodName [
 
 { #category : #'instance creation' }
 MethodNameEditor class >> openOn: aMethodName [
-	^ UITheme builder openModal: (self on: aMethodName)
+	^ (self on: aMethodName) openModal
 ]
 
 { #category : #grips }

--- a/src/Polymorph-Widgets/ListDialogWindow.class.st
+++ b/src/Polymorph-Widgets/ListDialogWindow.class.st
@@ -136,7 +136,7 @@ ListDialogWindow >> cancel [
 { #category : #'instance creation' }
 ListDialogWindow >> chooseFromOwner: aMorph [
 
-	aMorph openModal: self.
+	self openModal.
 	^ self answer
 ]
 

--- a/src/Polymorph-Widgets/Morph.extension.st
+++ b/src/Polymorph-Widgets/Morph.extension.st
@@ -155,13 +155,6 @@ Morph >> minExtent [
 ]
 
 { #category : #'*Polymorph-Widgets' }
-Morph >> modalUnlockFrom: aSystemWindow [
-	"Unlock the receiver as a modal owner of the given window."
-
-	self unlock
-]
-
-{ #category : #'*Polymorph-Widgets' }
 Morph >> myDependents [
 	"Improved performance dependents."
 	

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -467,7 +467,7 @@ MorphicUIManager >> merge: merger informing: aString [
 	window := mergeMorph newWindow
 		title: aString;
 		yourself.
-	self modalMorph openModal: window.
+	window openModal.
 	^ mergeMorph merged
 ]
 

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -598,14 +598,6 @@ MorphicUIManager >> openComparisonFrom: targetMethodSource
 ]
 
 { #category : #private }
-MorphicUIManager >> openModal: aSystemWindow [ 
-	"Open the given window at an available position with modality.
-	Answer the system window."
-	
-	^self modalMorph openModal: aSystemWindow
-]
-
-{ #category : #private }
 MorphicUIManager >> openPolymorphComparisonFrom: targetMethodSource
 					to: originalMethodSource
 					belongingTo: aClass

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -732,7 +732,7 @@ MorphicUIManager >> showWaitCursorWhile: aBlock [
 MorphicUIManager >> spawnNewProcess [
 
 	UIProcess := [
-		[WorldMorph doOneCycle.  Processor yield.  false] whileFalse: [].
+		MorphicRenderLoop new doOneCycleWhile: [ true ]
 	] newProcess priority: Processor userSchedulingPriority.
 	UIProcess name: 'Morphic UI Process'.
 	UIProcess resume

--- a/src/Polymorph-Widgets/PopupChoiceDialogWindow.class.st
+++ b/src/Polymorph-Widgets/PopupChoiceDialogWindow.class.st
@@ -29,20 +29,7 @@ PopupChoiceDialogWindow class >> chooseFrom: aList lines: lines title: title [
 		model: aList.
 	"World may be not the best choice because a window may want to be in controlaList 
 	this point should be investigated based on UIManager default modalMorph"
-	^(self currentWorld openModal: pd) choice
-]
-
-{ #category : #'instance creation' }
-PopupChoiceDialogWindow class >> chooseIn: aThemedMorph title: title labels: labels values: values lines: lines [
-	"self chooseIn: World title: 'foo is the question'  labels: #('yes' 'no') values: #(true false) lines: #(1 2)"
-	"self chooseIn: World title: 'foo is the question'  labels: #('yes' 'no') values: #(true false) lines: #()"
-	| pd |
-	pd := (self newWithTheme: aThemedMorph theme)
-		title: (title isEmpty ifTrue: ['Choose' translated] ifFalse: [title asString]);
-		labels: labels;
-		lines: (lines ifNil: [#()]);
-		model: values.
-	^(aThemedMorph openModal: pd) choice
+	^pd openModal choice
 ]
 
 { #category : #icons }

--- a/src/Polymorph-Widgets/SystemWindow.extension.st
+++ b/src/Polymorph-Widgets/SystemWindow.extension.st
@@ -1056,18 +1056,6 @@ SystemWindow >> nextMorphInWindow [
 ]
 
 { #category : #'*Polymorph-Widgets' }
-SystemWindow >> openModal: aSystemWindow [
-	"Open the given window locking the receiver until it is dismissed.
-	Set the pane color to match the receiver.
-	Answer the system window."
-	
-	aSystemWindow
-		theme: self theme;
-		setWindowColor: self paneColor.
-	^super openModal: aSystemWindow
-]
-
-{ #category : #'*Polymorph-Widgets' }
 SystemWindow >> paneColor [
 
 	"Answer the basic pane color that should be used."

--- a/src/Polymorph-Widgets/SystemWindow.extension.st
+++ b/src/Polymorph-Widgets/SystemWindow.extension.st
@@ -950,46 +950,6 @@ SystemWindow >> minimize [
 ]
 
 { #category : #'*Polymorph-Widgets' }
-SystemWindow >> modalChild [
-	"Answer the modal child of the receiver, if any."
-
-	^self valueOfProperty: #modalChild
-]
-
-{ #category : #'*Polymorph-Widgets' }
-SystemWindow >> modalLockTo: aSystemWindow [
-	"Lock the receiver as a modal owner of the given window."
-
-	aSystemWindow
-		setProperty: #modalOwner toValue: self.
-	self setProperty: #modalChild toValue: aSystemWindow.
-	
-	closeBox ifNotNil: [ 
-		self setProperty: #preModalCloseEnabled toValue: closeBox enabled.
-		closeBox enabled: false
-	].
-
-]
-
-{ #category : #'*Polymorph-Widgets' }
-SystemWindow >> modalOwner [
-	"Answer the modal owner of the receiver, if any."
-
-	^self valueOfProperty: #modalOwner
-]
-
-{ #category : #'*Polymorph-Widgets' }
-SystemWindow >> modalUnlockFrom: aSystemWindow [
-	"Unlock the receiver as a modal owner of the given window."
-
-	aSystemWindow removeProperty: #modalOwner.
-	self removeProperty: #modalChild.
-	closeBox ifNotNil: [:cl | cl enabled: (self valueOfProperty: #preModalCloseEnabled ifAbsent: [true])].
-	self removeProperty: #preModalCloseEnabled.
-	self activate
-]
-
-{ #category : #'*Polymorph-Widgets' }
 SystemWindow >> model: anObject [
 	"Set the model."
 	

--- a/src/Polymorph-Widgets/TickDialogWindow.class.st
+++ b/src/Polymorph-Widgets/TickDialogWindow.class.st
@@ -84,7 +84,7 @@ TickDialogWindow >> choose [
 { #category : #display }
 TickDialogWindow >> chooseFromOwner: aMorph [
 
-	aMorph openModal: self.
+	self openModal.
 	^ resultStorage
 ]
 

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -247,12 +247,14 @@ UITheme class >> veryLightSelectionColor [
 UITheme >> abortIn: aThemedMorph text: aStringOrText title: aString [
 	"Answer the result of an error dialog (true) with the given label and title."
 
+	| window |
 	self abortSound play.
-	^(aThemedMorph openModal: (
-		(ErrorDialogWindow newWithTheme: aThemedMorph theme)
-			textFont: self textFont;
-			title: aString;
-			text: aStringOrText)) cancelled not
+	window := (ErrorDialogWindow newWithTheme: aThemedMorph theme)
+		textFont: self textFont;
+		title: aString;
+		text: aStringOrText.
+	window openModal.
+	^ window cancelled not
 ]
 
 { #category : #sounds }
@@ -273,7 +275,7 @@ UITheme >> alertIn: aThemedMorph text: aStringOrText title: aString configure: a
 		title: aString;
 		text: aStringOrText.
 	aBlock value: dialog.
-	aThemedMorph openModal: dialog.
+	dialog openModal.
 	^dialog cancelled not
 ]
 
@@ -851,7 +853,7 @@ UITheme >> centeredAlertIn: aThemedMorph text: aStringOrText title: aString conf
 	aBlock value: dialog.
 	dialog left: ((self currentWorld width / 2) - (dialog width /2)).
 	dialog top: ((self currentWorld height / 2) - (dialog height /2)).
-	aThemedMorph openModal: dialog.
+	dialog openModal.
 	^ dialog cancelled not
 ]
 
@@ -987,13 +989,12 @@ UITheme >> checkboxUnselectedForm [
 UITheme >> chooseColorIn: aThemedMorph title: aString color: aColor [
 	"Answer the result of a color selector dialog with the given title and initial color."
 
-	|d|
-	d := aThemedMorph openModal: (
-		(ColorSelectorDialogWindow newWithTheme: aThemedMorph theme)
-			title: aString;
-			selectedColor: aColor).
-	^d  cancelled
-		ifFalse: [d selectedColor]
+	|dialog|
+	dialog := (ColorSelectorDialogWindow newWithTheme: aThemedMorph theme)
+		title: aString;
+		selectedColor: aColor.
+	dialog openModal.
+	^ dialog cancelled ifFalse: [ dialog selectedColor ]
 ]
 
 { #category : #services }
@@ -1020,24 +1021,23 @@ UITheme >> chooseColorIn: aThemedMorph title: aString color: aColor for: aBlock 
 UITheme >> chooseDirectoryIn: aThemedMorph title: title path: path [
 	"Answer the result of a file dialog with the given title, choosing directories only."
 
-	| fd |
-	fd := (FileDialogWindow newWithTheme: aThemedMorph theme)
+	| dialog |
+	dialog := (FileDialogWindow newWithTheme: aThemedMorph theme)
 		title: title;
 		answerDirectory.
-	path ifNotNil: [ fd selectPath: path ].
-	^ (aThemedMorph openModal: fd) answer
+	path ifNotNil: [ dialog selectPath: path ].
+	^ dialog openModal answer
 ]
 
 { #category : #services }
 UITheme >> chooseDropListIn: aThemedMorph text: aStringOrText title: aString list: aList [
 	"Answer the result of a drop list chooser with the given label, title and list."
 
-	^(aThemedMorph openModal: (
-		(ChooseDropListDialogWindow newWithTheme: aThemedMorph theme)
+	^((ChooseDropListDialogWindow newWithTheme: aThemedMorph theme)
 			textFont: self textFont;
 			title: aString;
 			text: aStringOrText;
-			list: aList)) selectedItem
+			list: aList) openModal selectedItem
 ]
 
 { #category : #services }
@@ -1046,18 +1046,18 @@ UITheme >> chooseExistingFileReferenceIn: aThemedMorph title: title extensions: 
 	path and preview type.
 	Answer nil or a filename."
 
-	| fd pathFileReference |
+	| dialog pathFileReference |
 	pathFileReference := path asFileReference.
-	fd := FileDialogWindow basicNew
+	dialog := FileDialogWindow basicNew
 		basicTheme: aThemedMorph theme;
 		previewType: preview;
 		fileNameText: pathFileReference basename;
 		initialize;
 		title: title;
 		answerPathName.	
-	exts ifNotNil: [ fd validExtensions: exts ].
-	path ifNotNil: [ fd selectPath: pathFileReference pathString ].
-	^ (aThemedMorph openModal: fd) answer ifNotNil: #asFileReference
+	exts ifNotNil: [ dialog validExtensions: exts ].
+	path ifNotNil: [ dialog selectPath: pathFileReference pathString ].
+	^ dialog openModal answer ifNotNil: #asFileReference
 ]
 
 { #category : #services }
@@ -1065,16 +1065,16 @@ UITheme >> chooseFileIn: aThemedMorph title: title extensions: exts path: path p
 	"Answer the result of a file open dialog with the given title, extensions path and preview type.
 	Answer nil or a filename."
 
-	| fd |
-	fd := FileDialogWindow basicNew
+	| dialog |
+	dialog := FileDialogWindow basicNew
 		basicTheme: aThemedMorph theme;
 		previewType: preview;
 		initialize;
 		title: title;
 		answerFileEntry.
-	exts ifNotNil: [ fd validExtensions: exts ].
-	path ifNotNil: [ fd selectPath: path ].
-	^ (aThemedMorph openModal: fd) answer
+	exts ifNotNil: [ dialog validExtensions: exts ].
+	path ifNotNil: [ dialog selectPath: path ].
+	^ dialog openModal answer
 ]
 
 { #category : #services }
@@ -1082,32 +1082,31 @@ UITheme >> chooseFileNameIn: aThemedMorph title: title extensions: exts path: pa
 	"Answer the result of a file name chooser dialog with the given title, extensions
 	path and preview type.
 	Answer nil or a filename."
-	| fd |
+	| dialog |
 	self deprecated: 'Use UIManager default chooseExistingFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
-	fd := FileDialogWindow basicNew
+	dialog := FileDialogWindow basicNew
 		basicTheme: aThemedMorph theme;
 		previewType: preview;
 		initialize;
 		title: title;
 		answerFileName.
-	exts ifNotNil: [ fd validExtensions: exts ].
-	path ifNotNil: [ fd selectPath: path ].
-	^ (aThemedMorph openModal: fd) answer
+	exts ifNotNil: [ dialog validExtensions: exts ].
+	path ifNotNil: [ dialog selectPath: path ].
+	^ dialog openModal answer
 ]
 
 { #category : #services }
 UITheme >> chooseFontIn: aThemedMorph title: aString font: aFont [
 	"Answer the result of a font selector dialog with the given title and initial font."
 
-	|d|
-	d := aThemedMorph openModal: (
-		Cursor wait showWhile: [
-			self newFontSelector
-				basicTheme: aThemedMorph theme;
-				title: aString;
-				selectedFont: aFont]).
-	^d  cancelled
-		ifFalse: [d selectedFont]
+	| dialog |
+	dialog :=  Cursor wait showWhile: [
+		self newFontSelector
+			basicTheme: aThemedMorph theme;
+			title: aString;
+			selectedFont: aFont].
+	dialog openModal.
+	^ dialog cancelled ifFalse: [dialog selectedFont]
 ]
 
 { #category : #services }
@@ -1116,15 +1115,15 @@ UITheme >> chooseForSaveFileReferenceIn: aThemedMorph title: title extensions: e
 	path and preview type.
 	Answer nil or a filename."
 
-	| fd pathFileReference |
+	| dialog pathFileReference |
 	pathFileReference := path asFileReference.
-	fd := (FileDialogWindow newWithTheme: aThemedMorph theme)
+	dialog := (FileDialogWindow newWithTheme: aThemedMorph theme)
 		title: title;
 		fileNameText: pathFileReference basename;
 		answerSaveFile.
-	exts ifNotNil: [ fd validExtensions: exts ].
-	path ifNotNil: [ fd selectPath: path ].
-	^ (aThemedMorph openModal: fd) answer
+	exts ifNotNil: [ dialog validExtensions: exts ].
+	path ifNotNil: [ dialog selectPath: path ].
+	^ dialog openModal answer
 ]
 
 { #category : #services }
@@ -1133,17 +1132,17 @@ UITheme >> chooseFullFileNameIn: aThemedMorph title: title extensions: exts path
 	path and preview type.
 	Answer nil or a full filename."
 
-	| fd |
+	| dialog |
 	self deprecated: 'Use UIManager default chooseExistingFileReference:extensions:path:preview:. instead.' on: '26 October 2018' in: #Pharo7.
-	fd := FileDialogWindow basicNew
+	dialog := FileDialogWindow basicNew
 		basicTheme: aThemedMorph theme;
 		previewType: preview;
 		initialize;
 		title: title;
 		answerPathName.
-	exts ifNotNil: [ fd validExtensions: exts ].
-	path ifNotNil: [ fd selectPath: path ].
-	^ (aThemedMorph openModal: fd) answer
+	exts ifNotNil: [ dialog validExtensions: exts ].
+	path ifNotNil: [ dialog selectPath: path ].
+	^ dialog openModal answer
 ]
 
 { #category : #services }
@@ -1152,48 +1151,48 @@ UITheme >> chooseFullFileNameIn: aThemedMorph title: title patterns: patterns pa
 	path and preview type.
 	Answer nil or a filename."
 
-	| fd |
-	fd := FileDialogWindow basicNew
+	| dialog |
+	dialog := FileDialogWindow basicNew
 		basicTheme: aThemedMorph theme;
 		previewType: preview;
 		initialize;
 		title: title;
 		answerPathName.
 	patterns
-		ifNotNil: [ fd
+		ifNotNil: [ dialog
 				fileSelectionBlock: [ :de | 
-					(fd defaultFileSelectionBlock value: de)
+					(dialog defaultFileSelectionBlock value: de)
 						and: [ de isDirectory or: [ patterns anySatisfy: [ :pat | pat match: de name ] ] ] ] ].
-	path ifNotNil: [ fd selectPath: path ].
-	^ (aThemedMorph openModal: fd) answer
+	path ifNotNil: [ dialog selectPath: path ].
+	^ dialog openModal answer
 ]
 
 { #category : #services }
 UITheme >> chooseIn: aThemedMorph title: title labels: labels values: values lines: lines [
 	"Answer the result of a popup choice with the given title, labels, values and lines."
 
-	| pd |
-	pd := (PopupChoiceDialogWindow newWithTheme: aThemedMorph theme)
+	| dialog |
+	dialog := (PopupChoiceDialogWindow newWithTheme: aThemedMorph theme)
 		title: (title isEmpty ifTrue: ['Choose' translated] ifFalse: [title asString]);
 		labels: labels;
 		lines: (lines ifNil: [#()]);
 		model: values.
-	^(aThemedMorph openModal: pd) choice
+	^ dialog openModal choice
 ]
 
 { #category : #services }
 UITheme >> chooseIn: aThemedMorph title: title message: aMessage labels: labels values: values lines: lines [
 	"Answer the result of a popup choice with the given title, labels, values and lines."
 
-	|pd|
-	pd := (PopupChoiceDialogWindowWithMessage newWithTheme: aThemedMorph theme)
+	|dialog|
+	dialog := (PopupChoiceDialogWindowWithMessage newWithTheme: aThemedMorph theme)
 		title: (title isEmpty ifTrue: ['Choose' translated] ifFalse: [title asString]);
 		textFont: self textFont;
 		message: aMessage;
 		labels: labels;
 		lines: (lines ifNil: [#()]);
 		model: values.
-	^(aThemedMorph openModal: pd) choice
+	^dialog openModal choice
 ]
 
 { #category : #services }
@@ -1206,7 +1205,7 @@ UITheme >> chooseOrRequestIn: aThemedMorph title: title labels: labels values: v
 		labels: labels;
 		lines: (lines ifNil: [#()]);
 		model: values.
-	choice := (aThemedMorph openModal: dialog) choice.
+	choice := dialog openModal choice.
 	dialog cancelled ifTrue: [ ^nil ].
 	choice 
 		ifNotNil: [ ^choice ]
@@ -1721,15 +1720,14 @@ UITheme >> customQuestionIn: aThemedMorph text: labelText yesText: yesText noTex
 	defaultOption should be one of true, false or nil to set the default button."
 
 	self questionSound play.
-	^(aThemedMorph openModal: (
-		(CustomQuestionDialogWindow newWithTheme: aThemedMorph theme)
+	^((CustomQuestionDialogWindow newWithTheme: aThemedMorph theme)
 			textFont: self textFont;
 			title: aString;
 			text: labelText;
 			yesText: yesText help: nil;
 			noText: noText help: nil;
 			cancelText: cancelText help: nil;
-			default: defaultOption)) answer
+			default: defaultOption) openModal answer
 ]
 
 { #category : #services }
@@ -1737,13 +1735,12 @@ UITheme >> customQuestionIn: aThemedMorph text: labelText yesText: yesText noTex
 	"Answer the result of a question dialog with the given label, button labels and title."
 
 	self questionSound play.
-	^(aThemedMorph openModal: (
-		(CustomQuestionDialogWindow newWithTheme: aThemedMorph theme)
+	^((CustomQuestionDialogWindow newWithTheme: aThemedMorph theme)
 			textFont: self textFont;
 			title: aString;
 			text: labelText;
 			yesText: yesText help: nil;
-			noText: noText help: nil)) answer
+			noText: noText help: nil) dialog answer
 ]
 
 { #category : #'accessing colors' }
@@ -1809,11 +1806,10 @@ UITheme >> denyIn: aThemedMorph text: aStringOrText title: aString [
 	"Answer the result of an deny dialog (true) with the given label and title."
 
 	self denySound play.
-	^(aThemedMorph openModal: (
-		(DenyDialogWindow newWithTheme: aThemedMorph theme)
+	^((DenyDialogWindow newWithTheme: aThemedMorph theme)
 			textFont: self textFont;
 			title: aString;
-			text: aStringOrText)) cancelled not
+			text: aStringOrText) openModal cancelled not
 ]
 
 { #category : #sounds }
@@ -2212,11 +2208,11 @@ UITheme >> enterOrRequestIn: aThemedMorph title: title labels: labels values: va
 		labels: labels;
 		lines: (lines ifNil: [#()]);
 		model: values.
-	choice := (aThemedMorph openModal: dialog) choice.
+	choice := dialog openModal choice.
 	dialog cancelled ifTrue: [ ^nil ].
-	choice 
-		ifNotNil: [ ^choice ]
-		ifNil: [ ^dialog filterValue ]
+	^ choice
+		ifNotNil: [ choice ]
+		ifNil: [ dialog filterValue ]
 ]
 
 { #category : #'basic-colors' }
@@ -2533,11 +2529,10 @@ UITheme >> longMessageIn: aThemedMorph text: aStringOrText title: aString [
 	"Answer the result of a (potentially long) message dialog (true) with the given label and title."
 
 	self messageSound play.
-	^(aThemedMorph openModal: (
-		(LongMessageDialogWindow newWithTheme: aThemedMorph theme)
+	^((LongMessageDialogWindow newWithTheme: aThemedMorph theme)
 			textFont: self textFont;
 			title: aString;
-			text: aStringOrText)) cancelled not
+			text: aStringOrText) openModal cancelled not
 ]
 
 { #category : #defaults }
@@ -2762,11 +2757,10 @@ UITheme >> messageIn: aThemedMorph text: aStringOrText title: aString [
 	"Answer the result of a message dialog (true) with the given label and title."
 
 	self messageSound play.
-	^(aThemedMorph openModal: (
-		(MessageDialogWindow newWithTheme: aThemedMorph theme)
+	^((MessageDialogWindow newWithTheme: aThemedMorph theme)
 			textFont: self textFont;
 			title: aString;
-			text: aStringOrText)) cancelled not
+			text: aStringOrText) openModal cancelled not
 ]
 
 { #category : #sounds }
@@ -4727,12 +4721,11 @@ UITheme >> passwordEntryIn: aThemedMorph text: aStringOrText title: aString entr
 	"Answer the result of a password entry dialog (a string or nil if cancelled)
 	with the given label and title."
 
-	^(aThemedMorph openModal: (
-		(PasswordDialogWindow newWithTheme: aThemedMorph theme)
+	^((PasswordDialogWindow newWithTheme: aThemedMorph theme)
 			textFont: self textFont;
 			title: aString;
 			text: aStringOrText;
-			entryText: defaultEntryText)) entryText
+			entryText: defaultEntryText) openModal entryText
 ]
 
 { #category : #'basic-colors' }
@@ -4768,11 +4761,10 @@ UITheme >> proceedIn: aThemedMorph text: aStringOrText title: aString [
 	"Answer the result of a proceed dialog with the given label and title."
 
 	self questionSound play.
-	^(aThemedMorph openModal: (
-		(ProceedDialogWindow newWithTheme: aThemedMorph theme)
+	^((ProceedDialogWindow newWithTheme: aThemedMorph theme)
 			textFont: self textFont;
 			title: aString;
-			text: aStringOrText)) cancelled not
+			text: aStringOrText) openModal cancelled not
 ]
 
 { #category : #'border-styles' }
@@ -4821,11 +4813,10 @@ UITheme >> questionIn: aThemedMorph text: aStringOrText title: aString [
 	"Answer the result of a question dialog with the given label and title."
 
 	self questionSound play.
-	^(aThemedMorph openModal: (
-		(QuestionDialogWindow newWithTheme: aThemedMorph theme)
+	^((QuestionDialogWindow newWithTheme: aThemedMorph theme)
 			textFont: self textFont;
 			title: aString;
-			text: aStringOrText)) answer
+			text: aStringOrText) openModal answer
 ]
 
 { #category : #sounds }
@@ -4840,11 +4831,10 @@ UITheme >> questionWithoutCancelIn: aThemedMorph text: aStringOrText title: aStr
 	"Answer the result of a question dialog with the given label and title."
 
 	self questionSound play.
-	^(aThemedMorph openModal: (
-		(QuestionWithoutCancelDialogWindow newWithTheme: aThemedMorph theme)
+	^((QuestionWithoutCancelDialogWindow newWithTheme: aThemedMorph theme)
 			textFont: self textFont;
 			title: aString;
-			text: aStringOrText)) answer
+			text: aStringOrText) openModal answer
 ]
 
 { #category : #'border-styles-buttons' }
@@ -5792,13 +5782,12 @@ UITheme >> textEditorIn: aThemedMorph text: aStringOrText title: aString entryTe
 	with the given label and title."
 
 	self questionSound play.
-	^(aThemedMorph openModal: (
-		(TextEditorDialogWindow newWithTheme: aThemedMorph theme)
+	^((TextEditorDialogWindow newWithTheme: aThemedMorph theme)
 			textFont: self textFont;
 			title: aString;
 			text: aStringOrText;
 			entryText: defaultEntryText;
-			entryHeight: entryHeight)) entryText
+			entryHeight: entryHeight) openModal entryText
 ]
 
 { #category : #'border-styles' }
@@ -5828,12 +5817,11 @@ UITheme >> textEntryIn: aThemedMorph text: aStringOrText title: aString entryTex
 	with the given label and title."
 
 	self questionSound play.
-	^(aThemedMorph openModal: (
-		TextEntryDialogWindow new
+	^(TextEntryDialogWindow new
 			textFont: self textFont;
 			title: aString;
 			text: aStringOrText;
-			entryText: defaultEntryText)) entryText
+			entryText: defaultEntryText) openModal entryText
 ]
 
 { #category : #services }
@@ -5842,13 +5830,12 @@ UITheme >> textEntryIn: aThemedMorph text: aStringOrText title: aString entryTex
 	with the given label and title."
 
 	self questionSound play.
-	^(aThemedMorph openModal: (
-		(TextEntryDialogWindow newWithTheme: aThemedMorph theme)
+	^((TextEntryDialogWindow newWithTheme: aThemedMorph theme)
 			textFont: self textFont;
 			title: aString;
 			text: aStringOrText;
 			entryText: defaultEntryText;
-			entryCompletion: anEntryCompletion)) entryText
+			entryCompletion: anEntryCompletion) openModal entryText
 ]
 
 { #category : #'border-styles' }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -1007,8 +1007,7 @@ UITheme >> chooseColorIn: aThemedMorph title: aString color: aColor for: aBlock 
 	d extent: d initialExtent.
 	d announcer when: ColorChanged do: [:ann | 
 		aBlock value: ann newColor].
-	d openInHand.
-	self runModal: d.
+	d openModal.
 	
 	newColor := d  cancelled
 		ifTrue: [aColor]
@@ -4942,12 +4941,6 @@ UITheme >> resizerGripNormalFillStyleFor: aResizer [
 	non transparent to draw as normal."
 	
 	^Color transparent
-]
-
-{ #category : #services }
-UITheme >> runModal: aWidget [
-	
-	MorphicRenderLoop new doOneCycleWhile: [ aWidget isInWorld ]
 ]
 
 { #category : #scrollbars }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -4947,8 +4947,7 @@ UITheme >> resizerGripNormalFillStyleFor: aResizer [
 { #category : #services }
 UITheme >> runModal: aWidget [
 	
-	[aWidget world notNil] whileTrue: [
-		aWidget outermostWorldMorph doOneCycle]
+	MorphicRenderLoop new doOneCycleWhile: [ aWidget isInWorld ]
 ]
 
 { #category : #scrollbars }

--- a/src/Refactoring2-Transformations/RBMethodArgumentsSelector.class.st
+++ b/src/Refactoring2-Transformations/RBMethodArgumentsSelector.class.st
@@ -43,11 +43,10 @@ RBMethodArgumentsSelector class >> on: arguments and: values in: sourceCode [
 { #category : #'instance creation' }
 RBMethodArgumentsSelector class >> openOn: arguments and: values in: sourceCode [
 
-	^ UITheme builder
-		openModal: (self 
-						on: arguments
-						and: values
-						in: sourceCode)
+	^ (self 
+		on: arguments
+		and: values
+		in: sourceCode) openModal
 ]
 
 { #category : #actions }

--- a/src/Rubric/RubFindReplaceDialogWindow.class.st
+++ b/src/Rubric/RubFindReplaceDialogWindow.class.st
@@ -329,10 +329,7 @@ RubFindReplaceDialogWindow >> newReplacement [
 
 { #category : #action }
 RubFindReplaceDialogWindow >> open [
-	self openAsIsIn: self currentWorld.
-	self extent: self extent.
-	self activate
-
+	self openInWorld
 ]
 
 { #category : #accessing }

--- a/src/Rubric/RubFloatingEditorBuilder.class.st
+++ b/src/Rubric/RubFloatingEditorBuilder.class.st
@@ -88,7 +88,8 @@ RubFloatingEditorBuilder class >> exampleEditableStringMorph [
 			event shiftPressed
 				ifTrue: [ edBuilder openEditorWithContents: stringMorph contents ] ].
 	(pane embeddedInMorphicWindowLabeled: 'Editable sm example')
-		openInWorldExtent: (stringMorph extent translateBy:  30 @ 30)
+		extent: (stringMorph extent translateBy:  30 @ 30);
+		openInWorld
 ]
 
 { #category : #accessing }

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -447,13 +447,11 @@ RubTextEditor >> changeTextFont [
 		forceCursorVisibleWhile: [ 
 			| hadFocus |
 			hadFocus := textArea hasFocus.
-			textArea
-				openModal:
-					(FontChooser
-						openWithWindowTitle: 'Choose a Font'
-						for: self
-						setSelector: #applyTextFont:
-						getSelector: self fontToUse).
+			(FontChooser
+				openWithWindowTitle: 'Choose a Font'
+				for: self
+				setSelector: #applyTextFont:
+				getSelector: self fontToUse) openModal.
 			hadFocus
 				ifTrue: [ textArea takeKeyboardFocus ] ]
 ]

--- a/src/Spec-MorphicAdapters/Morph.extension.st
+++ b/src/Spec-MorphicAdapters/Morph.extension.st
@@ -44,13 +44,11 @@ Morph >> setModal: aSystemWindow [
 				position: self activeHand position - (aSystemWindow extent // 2)].
 	aSystemWindow
 		bounds: (aSystemWindow bounds translatedToBeWithin: area).
-	[ |aWidget | 
-	aWidget := aSystemWindow.
-	[aWidget world notNil] whileTrue: [
-		aWidget outermostWorldMorph doOneCycle]]
-		ensure: [mySysWin modalUnlockFrom: aSystemWindow.
-				self activeHand newKeyboardFocus: keyboardFocus].
-	^aSystemWindow
+	[  MorphicRenderLoop new doOneCycleWhile: [ aSystemWindow isInWorld ] ]
+		ensure: [
+			mySysWin modalUnlockFrom: aSystemWindow.
+			self activeHand newKeyboardFocus: keyboardFocus].
+	^ aSystemWindow
 ]
 
 { #category : #'*Spec-MorphicAdapters' }

--- a/src/Spec2-Adapters-Morphic/SpMorphicModalWindowAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicModalWindowAdapter.class.st
@@ -45,7 +45,6 @@ SpMorphicModalWindowAdapter >> open [
 
 	self widget
 		toggleStickiness;
-		openCenteredInWorld.
-
-	MorphicRenderLoop new doOneCycleWhile: [ self widget isInWorld ]
+		center: self currentWorld clearArea center;
+		openModal
 ]

--- a/src/Spec2-Adapters-Morphic/SpMorphicModalWindowAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicModalWindowAdapter.class.st
@@ -47,5 +47,5 @@ SpMorphicModalWindowAdapter >> open [
 		toggleStickiness;
 		openCenteredInWorld.
 
-	[ self widget world notNil ] whileTrue: [ self widget outermostWorldMorph doOneCycle ]
+	MorphicRenderLoop new doOneCycleWhile: [ self widget isInWorld ]
 ]

--- a/src/Spec2-Adapters-Morphic/SpMorphicWindowAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicWindowAdapter.class.st
@@ -227,8 +227,10 @@ SpMorphicWindowAdapter >> open [
 
 	self model isCentered 
 		ifTrue: [ self centered ].
-		
+	
 	self widget openInWorld.
+	self model initialPosition ifNotNil: [
+		self widget position: self model initialPosition ].
 	
 	self windowIsOpening
 ]

--- a/src/Spec2-Adapters-Morphic/SpMorphicWindowAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicWindowAdapter.class.st
@@ -228,9 +228,7 @@ SpMorphicWindowAdapter >> open [
 	self model isCentered 
 		ifTrue: [ self centered ].
 		
-	self model initialPosition 
-		ifNotNil: [ self widget openAsIs ]
-		ifNil: [ self widget openInWorld ].
+	self widget openInWorld.
 	
 	self windowIsOpening
 ]

--- a/src/Spec2-Backend-Tests/SpTMorphicUIRedrawer.trait.st
+++ b/src/Spec2-Backend-Tests/SpTMorphicUIRedrawer.trait.st
@@ -36,7 +36,8 @@ SpTMorphicUIRedrawer >> waitUntilUIRedrawed [
 	If I do it, I am in a race condition!"
 
 	self isRunningInUIProcess
-		ifTrue: [ self currentWorld doOneCycle.
+		ifTrue: [
+			MorphicRenderLoop new doOneCycle.
 			^ self ].
 
 	self currentWorld defer: [ uiWaitingSemaphore ifNotNil: #signal ].

--- a/src/Spec2-Morphic-Backend-Tests/SpMorphicAdapterTestCase.class.st
+++ b/src/Spec2-Morphic-Backend-Tests/SpMorphicAdapterTestCase.class.st
@@ -36,7 +36,7 @@ SpMorphicAdapterTestCase >> initializeTestedInstance [
 SpMorphicAdapterTestCase >> openInstance [
 
 	window ifNil: [ window := presenter openWithSpec ].
-	self currentWorld doOneCycle.
+	MorphicRenderLoop new doOneCycle.
 ]
 
 { #category : #private }
@@ -77,6 +77,6 @@ SpMorphicAdapterTestCase >> widget [
 	The action should have been correctly configured before
 	depending on the spec initialization strategy"
 	self openInstance.
-	self currentWorld doOneCycle.
+	MorphicRenderLoop new doOneCycle.
 	^ self adapter widget
 ]

--- a/src/Text-Edition/EditorFindReplaceDialogWindow.class.st
+++ b/src/Text-Edition/EditorFindReplaceDialogWindow.class.st
@@ -369,7 +369,7 @@ EditorFindReplaceDialogWindow >> on: aTextView [
 
 { #category : #action }
 EditorFindReplaceDialogWindow >> open [
-	self openAsIsIn: self currentWorld.
+	self openInWorld.
 	self extent: self extent.
 	self activate
 

--- a/src/Text-Edition/StrikeFont.extension.st
+++ b/src/Text-Edition/StrikeFont.extension.st
@@ -42,7 +42,7 @@ StrikeFont class >> fromUser: priorFont allowKeyboard: aBoolean [
 			add: label
 			subMenu: ptMenu ].
 	spec := fontMenu 
-		invokeModalAt: ActiveHand position
+		invokeAt: ActiveHand position
 		in: self currentWorld
 		allowKeyboard: aBoolean.
 	spec ifNil: [ ^ nil ].

--- a/src/Text-Edition/StrikeFont.extension.st
+++ b/src/Text-Edition/StrikeFont.extension.st
@@ -41,10 +41,7 @@ StrikeFont class >> fromUser: priorFont allowKeyboard: aBoolean [
 		fontMenu 
 			add: label
 			subMenu: ptMenu ].
-	spec := fontMenu 
-		invokeAt: ActiveHand position
-		in: self currentWorld
-		allowKeyboard: aBoolean.
+	spec := fontMenu invokeModal.
 	spec ifNil: [ ^ nil ].
 	style := TextStyle named: spec first.
 	style ifNil: [ ^ self ].

--- a/src/Tool-Finder/DialogItemsChooserUI.class.st
+++ b/src/Tool-Finder/DialogItemsChooserUI.class.st
@@ -445,14 +445,12 @@ DialogItemsChooserUI >> okButtonState [
 	^false
 ]
 
-{ #category : #display }
-DialogItemsChooserUI >> openInWorld [
+{ #category : #opening }
+DialogItemsChooserUI >> preOpenInWorld: aWorld [
 
-	super openInWorld.
 	self width: 500.
 	self height: 400.
 	self centering
-
 ]
 
 { #category : #'buttons creations' }

--- a/src/Tool-Profilers/AndreasSystemProfiler.class.st
+++ b/src/Tool-Profilers/AndreasSystemProfiler.class.st
@@ -107,8 +107,7 @@ AndreasSystemProfiler class >> spyOnWorldFor: seconds [
 
 	^self spyOn: [  | deadline |
 		deadline := Time totalSeconds + seconds.
-		[Time totalSeconds < deadline]
-			whileTrue: [ self currentWorld doOneCycle ]].
+		MorphicRenderLoop new doOneCycleWhile: [Time totalSeconds < deadline] ].
 ]
 
 { #category : #reporting }

--- a/src/Tools/KeyPrinterMorph.class.st
+++ b/src/Tools/KeyPrinterMorph.class.st
@@ -20,6 +20,12 @@ KeyPrinterMorph class >> open [
 	self new openInWorld
 ]
 
+{ #category : #display }
+KeyPrinterMorph >> defaultLabel [
+
+	^ 'KeyPrinter (click/activate and press a key)'
+]
+
 { #category : #'event handling' }
 KeyPrinterMorph >> handlesKeyboard: evt [
 	^ true
@@ -42,9 +48,7 @@ KeyPrinterMorph >> mouseDown: event [
 ]
 
 { #category : #display }
-KeyPrinterMorph >> openInWorld [
+KeyPrinterMorph >> preOpenInWorld: aWorld [
 
-	self
-		extent: 400@200; 
-		openInWindowLabeled: 'KeyPrinter (click/activate and press a key)'
+	self extent: 400@200
 ]

--- a/src/Tools/SyntaxErrorDebugger.class.st
+++ b/src/Tools/SyntaxErrorDebugger.class.st
@@ -49,7 +49,8 @@ SyntaxErrorDebugger class >> buildMorphicViewOn: aSyntaxError [
 				menu: #codePaneMenu:shifted:)
 		frame: (0 @ 0.15 corner: 1 @ 1).
 	aSyntaxError addDependant: window.
-	^ window openInWorldExtent: 380 @ 220
+	window extent: 380 @ 220.
+	^ window openInWorld
 ]
 
 { #category : #'instance creation' }


### PR DESCRIPTION
Fix #5892 

- extract the render loop in MorphicRenderLoop
- use it in all places
- after many removals, it is only used in
   - a couple of tests (that test render, we should see in the future how to enhance them maybe)
   - the main render loop
   - modal window support
   - menu support

I've also done several cleanups:
 - opening a morph in a world now has a template method
 - SystemWindows had all the opening repeated => made them conform to Morph
 - Unify MenuMorph opening mechanisms (there were two almost copy-pasted)
 - modal opening is a concern for windows => move it to the window class, and removed conditional code.
 - have modal support in a single place