### PR TITLE
Update to Iceberg 1.6.8

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -192,7 +192,7 @@ BaselineOfIDE >> baseline: spec [
 BaselineOfIDE >> loadIceberg [
 	Metacello new
 		baseline: 'Iceberg';
-		repository: 'github://pharo-vcs/iceberg:v1.6.7';
+		repository: 'github://pharo-vcs/iceberg:v1.6.8';
 		onConflictUseLoaded;
 		load.
 	(Smalltalk classNamed: #Iceberg) enableMetacelloIntegration: true.


### PR DESCRIPTION
Upgrate to Iceberg 1.6.8

 => less references to World global