### PR TITLE
Moving debugging actions creation mechanism to GT-Debugger package

### DIFF
--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -36,54 +36,6 @@ Class {
 	#category : #'Debugger-Model-Base'
 }
 
-{ #category : #'actions registration' }
-DebugSession class >> debuggingActionsForPragma: aSymbol for: aDebugger [
-	^ (DebugAction allSubclasses reject: [ :each | each hasAbstractMethods ])
-		inject: OrderedCollection new
-		into: [ :currentActions :aClass | 
-			currentActions
-				addAll: (self debuggingActionsFromClass: aClass forPragma: aSymbol forDebugger: aDebugger);
-				yourself ]
-]
-
-{ #category : #'actions registration' }
-DebugSession class >> debuggingActionsForPragmas: aSymbolsCollection for: aDebugger [
-	self flag: 'split me'.
-	^ (((aSymbolsCollection 
-		inject: OrderedCollection new
-		into: [ :currentActions :aSymbol | 
-			currentActions 
-				addAll: (self debuggingActionsForPragma: aSymbol for: aDebugger);
-				yourself ]) 
-					select: [ :aDebugAction | 
-						aDebugAction appliesToDebugger: aDebugger ]) 
-					collect: [ :aDebugAction | 
-						aDebugAction
-							forDebugger: aDebugger;
-							yourself ]) 
-					sort: [ :action1 :action2 | 
-						action1 order < action2 order ]
-]
-
-{ #category : #'actions registration' }
-DebugSession class >> debuggingActionsFromClass: aClass forPragma: aSymbol forDebugger: aDebugger [
-	| pragmas actions |
-	pragmas := Pragma
-		allNamed: aSymbol
-		from: aClass class
-		to: aClass class.
-	actions := OrderedCollection new.
-	pragmas
-		do: [ :aPragma | 
-			actions
-				addAll:
-					((aPragma methodClass soleInstance
-						perform: aPragma methodSelector
-						withEnoughArguments: {aDebugger}) asOrderedCollection
-						collect: [ :each | each asDebugAction ]) ].
-	^ actions
-]
-
 { #category : #settings }
 DebugSession class >> logDebuggerStackToFile [
 	^ LogDebuggerStackToFile ifNil: [LogDebuggerStackToFile := true]

--- a/src/GT-Debugger/DebugSession.extension.st
+++ b/src/GT-Debugger/DebugSession.extension.st
@@ -1,5 +1,53 @@
 Extension { #name : #DebugSession }
 
+{ #category : #'*GT-Debugger' }
+DebugSession class >> debuggingActionsForPragma: aSymbol for: aDebugger [
+	^ (DebugAction allSubclasses reject: [ :each | each hasAbstractMethods ])
+		inject: OrderedCollection new
+		into: [ :currentActions :aClass | 
+			currentActions
+				addAll: (self debuggingActionsFromClass: aClass forPragma: aSymbol forDebugger: aDebugger);
+				yourself ]
+]
+
+{ #category : #'*GT-Debugger' }
+DebugSession class >> debuggingActionsForPragmas: aSymbolsCollection for: aDebugger [
+	self flag: 'split me'.
+	^ (((aSymbolsCollection 
+		inject: OrderedCollection new
+		into: [ :currentActions :aSymbol | 
+			currentActions 
+				addAll: (self debuggingActionsForPragma: aSymbol for: aDebugger);
+				yourself ]) 
+					select: [ :aDebugAction | 
+						aDebugAction appliesToDebugger: aDebugger ]) 
+					collect: [ :aDebugAction | 
+						aDebugAction
+							forDebugger: aDebugger;
+							yourself ]) 
+					sort: [ :action1 :action2 | 
+						action1 order < action2 order ]
+]
+
+{ #category : #'*GT-Debugger' }
+DebugSession class >> debuggingActionsFromClass: aClass forPragma: aSymbol forDebugger: aDebugger [
+	| pragmas actions |
+	pragmas := Pragma
+		allNamed: aSymbol
+		from: aClass class
+		to: aClass class.
+	actions := OrderedCollection new.
+	pragmas
+		do: [ :aPragma | 
+			actions
+				addAll:
+					((aPragma methodClass soleInstance
+						perform: aPragma methodSelector
+						withEnoughArguments: {aDebugger}) asOrderedCollection
+						collect: [ :each | each asDebugAction ]) ].
+	^ actions
+]
+
 { #category : #'*gt-debugger' }
 DebugSession >> isActive: aContext [
 


### PR DESCRIPTION
Moving debugging actions creation mechanism from Debugger-Model package to GT-Debugger package.

Only the GTDebugger is using this now, and NewTools debugger will not.
It should not be in core packages.