### PR TITLE
5960-ENH-add-first-simple-hoook-in-RBParser

### DIFF
--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -253,7 +253,7 @@ RBParser >> methodNodeClass [
 
 { #category : #private }
 RBParser >> nextToken [
-	^nextToken ifNil: [nextToken := scanner next] ifNotNil: [nextToken]
+	^nextToken ifNil: [nextToken := self scannerNext] ifNotNil: [nextToken]
 ]
 
 { #category : #'private-parsing' }
@@ -1069,6 +1069,12 @@ RBParser >> scannerClass [
 	^RBScanner
 ]
 
+{ #category : #private }
+RBParser >> scannerNext [
+
+	^ scanner next
+]
+
 { #category : #'private-classes' }
 RBParser >> sequenceNodeClass [
 	^ RBSequenceNode
@@ -1082,7 +1088,7 @@ RBParser >> step [
 		ifTrue: 
 			[currentToken := nextToken.
 			nextToken := nil]
-		ifFalse: [currentToken := scanner next].
+		ifFalse: [currentToken := self scannerNext].
 ]
 
 { #category : #'private-classes' }


### PR DESCRIPTION
fixes: #5960 introduce a simple hook. the real solution could be to have a strategy token providers and that we can plug what we want.