### PR TITLE
Fix #5958

### DIFF
--- a/src/Morphic-Base/TransferMorph.class.st
+++ b/src/Morphic-Base/TransferMorph.class.st
@@ -43,27 +43,17 @@ TransferMorph class >> initialize [
 ]
 
 { #category : #'instance creation' }
-TransferMorph class >> withPassenger: anObject [ 
-	^ self withPassenger: anObject from: nil
-]
-
-{ #category : #'instance creation' }
-TransferMorph class >> withPassenger: anObject from: source [ 
-	^self withPassenger: anObject from: source hand: nil
+TransferMorph class >> withPassenger: anObject from: source [
+	^self withPassenger: anObject from: source hand: source currentHand
 ]
 
 { #category : #'instance creation' }
 TransferMorph class >> withPassenger: anObject from: source hand: dragHand [
-	| hand |
-	
-	hand := dragHand.
-	
 	^ self new
 		passenger: anObject;
 		source: source;
-		"If the client hasn't provided a hand use the currently active hand"
-		dragHand: hand;
-		shouldCopy: hand shiftPressed;
+		dragHand: dragHand;
+		shouldCopy: dragHand shiftPressed;
 		position: source positionInWorld;
 		yourself
 ]


### PR DESCRIPTION
Transfer morph needs a hand.
However, a hand is never available globally.

- Since a hand is always required, use the hand of the source (The transfer morph may not have been installed in the world yet).
- Remove the #withPassenger: variant since it is not used and creates an incorrect TransferMorph.