### PR TITLE
Handle normal mouse events before artificial click

### DIFF
--- a/src/Morphic-Base/MouseClickState.class.st
+++ b/src/Morphic-Base/MouseClickState.class.st
@@ -124,8 +124,8 @@ MouseClickState >> handleEvent: evt from: aHand [
 			firstClickUp := evt copy.
 			clickState := #firstClickUp.
 			"If timedOut or the client's not interested in dbl clicks get outta here"
-			self click.
 			aHand handleEvent: firstClickUp.
+			self click.
 			^false].
 		isDrag ifTrue:["drag start"
 			self doubleClickTimeout. "***"


### PR DESCRIPTION
Fix #5945

The hand (which is the event dispatcher) handles some internal state to capture clicks and double clicks.
That state should be coherent every time an event is dispatched. Otherwise, an error in the dispatched could provoke a malfunction of the hand.

#handleEvent: should be done before #click.
#handleEvent: does not only handle the event but also makes sure that the state of the hand is correct before handling the event.
Like this, both events handled in #handleMouseDown/Up: and #click do not break the event dispatcher if they, for example, block in a modal window.