### PR TITLE
Fix #5947

### DIFF
--- a/src/System-Settings-Core/PickOneSettingDeclaration.class.st
+++ b/src/System-Settings-Core/PickOneSettingDeclaration.class.st
@@ -52,7 +52,7 @@ PickOneSettingDeclaration >> inputWidget [
 	| widget row |
 	row := self theme newRowIn: self for: {
 				widget := (self theme 
-						newDropListIn: self
+						newDropListIn: self currentWorld
 						for: self
 						list: #domainValuesLabels
 						getSelected: #index


### PR DESCRIPTION
A droplist needs a morph to be created. Use the current world for now.