### PR TITLE
DebuggerMethodMapOpal-Cleanup1

### DIFF
--- a/src/OpalCompiler-Core/DebuggerMethodMapOpal.class.st
+++ b/src/OpalCompiler-Core/DebuggerMethodMapOpal.class.st
@@ -32,21 +32,24 @@ DebuggerMethodMapOpal >> forMethod: aCompiledMethod [
 { #category : #public }
 DebuggerMethodMapOpal >> namedTempAt: index in: aContext [
 	"please use #namedTempAt: on Context"
+	self deprecated: 'Please use aContext namedTempAt: index'.
 	^aContext namedTempAt: index
 ]
 
 { #category : #public }
 DebuggerMethodMapOpal >> namedTempAt: index put: aValue in: aContext [
 	"please use #namedTempAt:put: on Context"
+	self deprecated: 'Please use aContext namedTempAt: index put: aValue'.
 	^aContext namedTempAt: index put: aValue
 ]
 
 { #category : #initialization }
 DebuggerMethodMapOpal >> rangeForPC: aPC contextIsActiveContext: aBoolean [
 	"please use pcRangeContextIsActive: on Context"
+
 	"return the debug highlight for aPC"		
 	| pc | 			
-
+	self deprecated: 'please use pcRangeContextIsActive: on Context'.
   	"When on the top of the stack the pc is pointing to right instruction, but deeper in the stack		
  	the pc was already advanced one bytecode, so we need to go back this one bytecode, which		
  	can consist of multiple bytes. But on IR, we record the *last* bytecode offset as the offset of the		
@@ -59,6 +62,7 @@ DebuggerMethodMapOpal >> rangeForPC: aPC contextIsActiveContext: aBoolean [
 { #category : #public }
 DebuggerMethodMapOpal >> tempNamed: name in: aContext [
 	"please use #tempNamed: on Context"
+	self deprecated: 'please use #tempNamed: on Context'.
 	^aContext tempNamed: name
 		
 ]
@@ -66,11 +70,13 @@ DebuggerMethodMapOpal >> tempNamed: name in: aContext [
 { #category : #public }
 DebuggerMethodMapOpal >> tempNamed: name in: aContext put: aValue [
 	"please use #tempNamed:put: on Context"
+	self deprecated: 'please use #tempNamed:put: on Context'.
 	^aContext tempNamed: name put: aValue
 ]
 
 { #category : #public }
 DebuggerMethodMapOpal >> tempNamesForContext: aContext [
 	"use tempNames on Context"
+	self deprecated: 'use tempNames on Context'.
 	^ aContext tempNames 
 ]


### PR DESCRIPTION
This is the first step for cleaning up DebuggerMethodMapOpal: we deprecate the methods with a clear description what to use instead.
Normally they are not API methods, only used by tools like the debugger.

After this is int the image, we can be sure that the clients all changed and *then* we can clean up more easily.