### PR TITLE
OrderedDictionary >> at:ifPresent:ifAbsentPut: doesn't touch the ordered keys array

### DIFF
--- a/src/Collections-Sequenceable/OrderedDictionary.class.st
+++ b/src/Collections-Sequenceable/OrderedDictionary.class.st
@@ -14,7 +14,7 @@ Insertion, update, and inclusion testing have O(1) complexity while removing has
 Public API and Key Messages
 --------------------
 
-- #at: aKey put: aValue / #at: aKey ifAbsentPut: aValue 		allow to add an element.
+- #at: aKey put: aValue / #at: aKey ifAbsentPut: aValue / #at: aKey ifPresent: aBlock ifAbsent: aBlock		allow to add an element.
   
 - #at: aKey / #at: aKey ifAbsent: aBlock / #at: aKey ifPresent: aBlock ifAbsent: aBlock 		allow to access my values.
 
@@ -252,7 +252,7 @@ OrderedDictionary >> at: aKey ifPresent: aPresentBlock ifAbsentPut: anAbsentBloc
 	^ dictionary
 		at: aKey
 		ifPresent: aPresentBlock
-		ifAbsentPut: anAbsentBlock
+		ifAbsent: [ self at: aKey put: anAbsentBlock value ]
 ]
 
 { #category : #accessing }

--- a/src/Collections-Tests/OrderedDictionaryTest.class.st
+++ b/src/Collections-Tests/OrderedDictionaryTest.class.st
@@ -498,7 +498,7 @@ OrderedDictionaryTest >> testAtIfAbsentPut [
 	| dictionary |
 
 	dictionary := self emptyDictionary.
-	self orderedAssociations do: [:each |
+	self orderedAssociations withIndexDo: [:each :i |
 		self assert:
 			(dictionary
 				at: each key
@@ -506,7 +506,10 @@ OrderedDictionaryTest >> testAtIfAbsentPut [
 		self assert:
 			(dictionary
 				at: each key
-				ifAbsentPut: [self fail]) equals: each value].
+				ifAbsentPut: [self fail]) equals: each value.
+		self
+			assertIsArray: dictionary keys
+			withElements: (self orderedKeysFirst: i) ]
 ]
 
 { #category : #tests }
@@ -547,6 +550,27 @@ OrderedDictionaryTest >> testAtIfPresentIfAbsent [
 				at: each key
 				ifPresent: [self newValue]
 				ifAbsent: [self fail]) equals: self newValue].
+]
+
+{ #category : #tests }
+OrderedDictionaryTest >> testAtIfPresentIfAbsentPut [
+	| dictionary |
+
+	dictionary := self emptyDictionary.
+	self orderedAssociations withIndexDo: [:each :i |
+		self assert:
+			(dictionary
+				at: each key
+				ifPresent: [ self fail ]
+				ifAbsentPut: [ each value ]) equals: each value.
+		self assert:
+			(dictionary
+				at: each key
+				ifPresent: [ :it | self newValue -> it ]
+				ifAbsentPut: [self fail]) equals: (self newValue -> each value).
+		self
+			assertIsArray: dictionary keys
+			withElements: (self orderedKeysFirst: i) ]
 ]
 
 { #category : #tests }
@@ -1198,7 +1222,7 @@ OrderedDictionaryTest >> testNewFromPairs [
 ]
 
 { #category : #tests }
-OrderedDictionaryTest >> testOccurancesOf [
+OrderedDictionaryTest >> testOccurencesOf [
 	| dictionary |
 
 	dictionary := self emptyDictionary.


### PR DESCRIPTION
**Describe the bug**
`OrderedDictionary >> at:ifPresent:ifAbsentPut:` only delegates to the underlying dictionary without adding the key to the `orderedKeys` array if the *absent* branch is taken.

**To Reproduce**
Inspect `OrderedDictionary new at: #foo ifPresent: [  ] ifAbsentPut: [ 42 ]; yourself`

**Expected behavior**
`orderedKeys` should include `#foo`

**Version information**
Pharo-8.0.0+build.1134.sha.5173b0271894727189f261cb9eb9beaa3db3f205
Pharo-9.0.0+build.179.sha.deda42a6ba668299a1e378faa0c20039476185fe

**Additional context**
self-explanatory