### PR TITLE
Make Glamour Bricks implement morphic event interface

### DIFF
--- a/src/Glamour-Morphic-Brick/GLMEmptyPopupBrick.class.st
+++ b/src/Glamour-Morphic-Brick/GLMEmptyPopupBrick.class.st
@@ -55,7 +55,6 @@ GLMEmptyPopupBrick >> addCloserListener [
 		description: [ 'Closer must not be nil' ].
 	
 	self closer popup: self.
-	self activeHand addEventListener: self closer
 ]
 
 { #category : #accessing }
@@ -188,6 +187,18 @@ GLMEmptyPopupBrick >> foundationBrick [
 		ifFalse: [ self ]
 ]
 
+{ #category : #'events-processing' }
+GLMEmptyPopupBrick >> handlesKeyStroke: anEvent [
+
+	^ true
+]
+
+{ #category : #'events-processing' }
+GLMEmptyPopupBrick >> handlesMouseOver: anEvent [
+
+	^ true
+]
+
 { #category : #initialization }
 GLMEmptyPopupBrick >> initialize [
 	super initialize.
@@ -258,6 +269,26 @@ GLMEmptyPopupBrick >> isInsideOfTriggerBrick: anEvent [
 			anEvent withHandPositionDo: [ :position | ^ aBrick globalBounds containsPoint: position ] ]
 ]
 
+{ #category : #'events-processing' }
+GLMEmptyPopupBrick >> keyStroke: anEvent [
+
+	self closer handleListenEvent: anEvent
+]
+
+{ #category : #'events-processing' }
+GLMEmptyPopupBrick >> keyboardFocusChange: gotFocus [
+
+	super keyboardFocusChange: gotFocus.
+	gotFocus ifFalse: [
+		self closer handleLostFocus ]
+]
+
+{ #category : #'events-processing' }
+GLMEmptyPopupBrick >> mouseLeave: anEvent [
+
+	self closer handleListenEvent: anEvent
+]
+
 { #category : #'instance creation' }
 GLMEmptyPopupBrick >> newContentBrick [
 	^ GLMBandBrick new
@@ -290,6 +321,8 @@ GLMEmptyPopupBrick >> onOpened [
 	"I am send after popup is opened in the world and became visible to the user.
 	Override me to perform additional actions, for example give keyboard or mouse focus
 	to me or any of my content elements"
+	
+	self takeKeyboardFocus
 ]
 
 { #category : #'popup - hooks' }
@@ -403,7 +436,6 @@ GLMEmptyPopupBrick >> removeCloserListener [
 		assert: [ self closer isNotNil ]
 		description: [ 'Closer must not be nil' ].
 	
-	self activeHand removeEventListener: self closer.
 	self closer popup: nil
 ]
 

--- a/src/Glamour-Morphic-Brick/GLMPopupBrickListener.class.st
+++ b/src/Glamour-Morphic-Brick/GLMPopupBrickListener.class.st
@@ -33,6 +33,14 @@ GLMPopupBrickListener >> handleListenEvent: anEvent [
 		ifFound: [ :aPredicate | self act ]
 ]
 
+{ #category : #'events-processing' }
+GLMPopupBrickListener >> handleLostFocus [
+
+	self predicates
+		detect: [ :aPredicate | aPredicate popupLostFocus: self popup ]
+		ifFound: [ :aPredicate | self act ]
+]
+
 { #category : #initialization }
 GLMPopupBrickListener >> initialize [
 	super initialize.

--- a/src/Glamour-Morphic-Brick/GLMPopupBrickOutisideClickPredicate.class.st
+++ b/src/Glamour-Morphic-Brick/GLMPopupBrickOutisideClickPredicate.class.st
@@ -15,3 +15,11 @@ GLMPopupBrickOutisideClickPredicate >> popup: aPopupBrick event: anEvent [
 	^ (anEvent type = #mouseDown) and: [
 		(aPopupBrick isInsideOfPopupBrick: anEvent) not ]
 ]
+
+{ #category : #predicate }
+GLMPopupBrickOutisideClickPredicate >> popupLostFocus: aPopupBrick [
+	"Return true when user clicks outside of a popup brick, false otherwise"
+	<return: #Boolean>
+
+	^ true
+]

--- a/src/Glamour-Morphic-Brick/GLMPopupBrickPredicate.class.st
+++ b/src/Glamour-Morphic-Brick/GLMPopupBrickPredicate.class.st
@@ -14,3 +14,10 @@ GLMPopupBrickPredicate >> popup: aPopupBrick event: anEvent [
 
 	self subclassResponsibility
 ]
+
+{ #category : #predicate }
+GLMPopupBrickPredicate >> popupLostFocus: aPopup [ 
+
+	"Do nothing by default. Hook for subclasses"
+	^ false
+]

--- a/src/Glamour-Morphic-Brick/GLMPopupBrickUnhoverPredicate.class.st
+++ b/src/Glamour-Morphic-Brick/GLMPopupBrickUnhoverPredicate.class.st
@@ -12,6 +12,5 @@ GLMPopupBrickUnhoverPredicate >> popup: aPopupBrick event: anEvent [
 	"Return true when mouse is moved outside of a popup brick, false otherwise"
 	<return: #Boolean>
 	
-	^ (anEvent type = #mouseMove) and: [
-		(aPopupBrick isInsideOfPopupBrick: anEvent) not ]
+	^ anEvent type = #mouseLeave
 ]


### PR DESCRIPTION
Fix #5971

Glamour bricks do handle events in a funny way.
Instead of redefining the hooks defined by morphic, they listen to all events in the system and have their own way to decide whether an event applies to them or not.

This PR makes GLM*Brick handle normal events instead of listen the hand.