### PR TITLE
Clean cyclic dependencies between Keymapping packages

### DIFF
--- a/src/Keymapping-Core/KMKeymap.class.st
+++ b/src/Keymapping-Core/KMKeymap.class.st
@@ -83,12 +83,6 @@ KMKeymap >> description: aDescription [
 	description := aDescription asString
 ]
 
-{ #category : #'enabling/disabling' }
-KMKeymap >> disable [
-
-	self shortcut: KMNoShortcut new.
-]
-
 { #category : #executing }
 KMKeymap >> executeActionTargetting: target [
 	^ self action cull: target cull: target

--- a/src/Keymapping-Core/KMNoKeymap.class.st
+++ b/src/Keymapping-Core/KMNoKeymap.class.st
@@ -6,8 +6,3 @@ Class {
 	#superclass : #Object,
 	#category : #'Keymapping-Core-Base'
 }
-
-{ #category : #accessing }
-KMNoKeymap >> shortcut [
-	^ KMNoShortcut new
-]

--- a/src/Keymapping-Core/KMRepository.class.st
+++ b/src/Keymapping-Core/KMRepository.class.st
@@ -18,11 +18,6 @@ Class {
 	#category : #'Keymapping-Core-Base'
 }
 
-{ #category : #cleanup }
-KMRepository class >> cleanUp [
-	self reset
-]
-
 { #category : #'instance creation' }
 KMRepository class >> default [
 	^ Singleton ifNil: [ Singleton := self new ]
@@ -31,20 +26,6 @@ KMRepository class >> default [
 { #category : #'instance creation' }
 KMRepository class >> default: aDefault [
 	^ Singleton := aDefault
-]
-
-{ #category : #initialization }
-KMRepository class >> reset [
-	"Do not reset KMDispatchers instances, it may make the image unusable or force the user to close all the windows."
-	
-	"TODO: a better reset, allowing the KMDispatcher instances to reload all named, updated, keymaps from the resetted KMRepository."
-
-	self currentWorld setProperty: #kmDispatcher toValue: nil.
-	self default: self new.
-	KMCategory allSubclasses
-		select: [ :c | c isGlobalCategory ]
-		thenDo: [ :c | c new installAsGlobalCategory ].
-	KMPragmaKeymapBuilder uniqueInstance reset.
 ]
 
 { #category : #associating }

--- a/src/Keymapping-KeyCombinations/KMKeymap.extension.st
+++ b/src/Keymapping-KeyCombinations/KMKeymap.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #KMKeymap }
+
+{ #category : #'*Keymapping-KeyCombinations' }
+KMKeymap >> disable [
+
+	self shortcut: KMNoShortcut new.
+]

--- a/src/Keymapping-KeyCombinations/KMNoKeymap.extension.st
+++ b/src/Keymapping-KeyCombinations/KMNoKeymap.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #KMNoKeymap }
+
+{ #category : #'*Keymapping-KeyCombinations' }
+KMNoKeymap >> shortcut [
+	^ KMNoShortcut new
+]

--- a/src/Keymapping-Pragmas/KMRepository.extension.st
+++ b/src/Keymapping-Pragmas/KMRepository.extension.st
@@ -1,0 +1,20 @@
+Extension { #name : #KMRepository }
+
+{ #category : #'*Keymapping-Pragmas' }
+KMRepository class >> cleanUp [
+	self reset
+]
+
+{ #category : #'*Keymapping-Pragmas' }
+KMRepository class >> reset [
+	"Do not reset KMDispatchers instances, it may make the image unusable or force the user to close all the windows."
+	
+	"TODO: a better reset, allowing the KMDispatcher instances to reload all named, updated, keymaps from the resetted KMRepository."
+
+	self currentWorld setProperty: #kmDispatcher toValue: nil.
+	self default: self new.
+	KMCategory allSubclasses
+		select: [ :c | c isGlobalCategory ]
+		thenDo: [ :c | c new installAsGlobalCategory ].
+	KMPragmaKeymapBuilder uniqueInstance reset.
+]


### PR DESCRIPTION
Clean cyclic dependencies between Keymapping packages.  They are, of course, still logically dependent on each other but now they do not require atomic loading