### PR TITLE
Menu morph should open on the active hand of the opening world

### DIFF
--- a/src/Morphic-Base/MenuMorph.class.st
+++ b/src/Morphic-Base/MenuMorph.class.st
@@ -914,7 +914,7 @@ MenuMorph >> invokeModal [
 	menu invokeModal."
 	
   ^ self
-		invokeAt: self activeHand position
+		invokeAt: self currentWorld activeHand position
 		in: self currentWorld
 ]
 


### PR DESCRIPTION
Fix #5975

Use the active hand of the same world we are spawning into.
Menu morph does not have an active hand, since it has not been open in a world yet.