### PR TITLE
Restore deferredUpdateMode in case of nested render loops

### DIFF
--- a/src/Morphic-Core/VMWorldRenderer.class.st
+++ b/src/Morphic-Core/VMWorldRenderer.class.st
@@ -97,6 +97,8 @@ VMWorldRenderer >> deferUpdates: aValue [
 { #category : #operations }
 VMWorldRenderer >> deferUpdatesDuring: aBlock [
 
+	| previousDeferredUpdateMode |
+	previousDeferredUpdateMode := deferredUpdateMode.
 	[deferredUpdateMode := (self doDeferredUpdatingFor: world)
 		ifTrue: [ VMDisplayDeferredUpdateMode new ]
 		ifFalse: [ self assuredCanvas. VMDisplayDirectUpdateMode new ].
@@ -104,7 +106,7 @@ VMWorldRenderer >> deferUpdatesDuring: aBlock [
 	aBlock value
 	
 	] ensure: [ 
-		deferredUpdateMode := nil.
+		deferredUpdateMode := previousDeferredUpdateMode.
 		self deferUpdates: false.
 		self forceDisplayUpdate ]
 ]


### PR DESCRIPTION
Fix #5976.
NOT - Fix #5977 probably also.

In case of nested render loops, the deferredUpdateMode should be kept and restored correctly.

@pavel-krivanek could you check this fixes both issues?