### PR TITLE
5990-add-variable-in-CDClassDefinition-to-keep-tokens

### DIFF
--- a/src/ClassParser/CDNode.class.st
+++ b/src/ClassParser/CDNode.class.st
@@ -12,7 +12,8 @@ Class {
 	#instVars : [
 		'parent',
 		'originalNode',
-		'children'
+		'children',
+		'tokens'
 	],
 	#category : #'ClassParser-Model'
 }
@@ -166,4 +167,14 @@ CDNode >> start [
 CDNode >> stop [
 	
 	^ originalNode stop
+]
+
+{ #category : #accessing }
+CDNode >> tokens [ 
+	^ tokens
+]
+
+{ #category : #accessing }
+CDNode >> tokens: aCollectionOfTokens [
+	tokens := aCollectionOfTokens
 ]


### PR DESCRIPTION
fixes: #5990 To be able to add tokens to classDefinition nodes.