### PR TITLE
[cleanup] changed "message"  by "method" in the template method

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1587,8 +1587,8 @@ Behavior >> sourceCodeTemplate [
 	"Answer an expression to be edited and evaluated in order to define 
 	methods in this class or trait."
 
-	^ 'messageSelectorAndArgumentNames
-	"comment stating purpose of instance-side message"
+	^ 'methodSelectorAndArgumentNames
+	"comment stating purpose of instance-side method"
 	"scope: class-variables  &  instance-variables"	
 			
 	| temporary variable names |


### PR DESCRIPTION
This might be controversial, but i'm going for it !

messageSelectorAndArgumentNames
   "comment stating purpose of instance-side message"
(...)

In the current template we say we define a message, whereas as far as I understand, we're defining a method.

I therefore replaced it with
methodSelectorAndArgumentNames
   "comment stating purpose of instance-side method"

Let me know if you think this is right or not =)