### PR TITLE
6012-Click-outside-of-completion-pop-up-should-close-it

### DIFF
--- a/src/Morphic-Core/MorphClosePopups.class.st
+++ b/src/Morphic-Core/MorphClosePopups.class.st
@@ -1,0 +1,8 @@
+"
+Some morph can use another related morphs as popups. For example, the text editor can have open a completion menu. I am the announcement for explicit closing of such morphs.
+"
+Class {
+	#name : #MorphClosePopups,
+	#superclass : #MorphAnnouncement,
+	#category : #'Morphic-Core-Announcements'
+}

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -314,6 +314,7 @@ CompletionEngine >> setEditor: anObject [
 		editor morph ifNotNil: [:m | m announcer unsubscribe: self] ].
 	editor := anObject.
 	editor morph onAnnouncement: MorphLostFocus send: #closeMenu to: self.
+	editor morph onAnnouncement: MorphClosePopups send: #closeMenu to: self.
 ]
 
 { #category : #keyboard }

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -1307,6 +1307,8 @@ RubAbstractTextArea >> mouseDown: evt [
 	Changed to not take keyboard focus if an owner is a
 	PluggableTextMorph that doesn't want focus."
 
+	self doAnnounce: (MorphClosePopups morph: self).
+
 	(evt yellowButtonPressed and: [ evt commandKeyPressed not ])
 		ifTrue: [ ^ self yellowButtonActivity: evt shiftPressed ].	"First check for option (menu) click"
 	(self paragraph click: evt for: self model controller: self)


### PR DESCRIPTION
introduce new annoucement MorphClosePopups and use it for explicit closing of NECMenuMorph when clicking  on Rubric text areafixex #6012