### PR TITLE
6002-Generate-accessors-on-inst-var-does-not-work

### DIFF
--- a/src/SystemCommands-RefactoringSupport/SycRefactoringPreview.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycRefactoringPreview.class.st
@@ -128,7 +128,7 @@ SycRefactoringPreview >> generateChanges [
 	changes := command asRefactorings.
 	rbEnvironment := self activeRBEnvironment.
 	changes do: [ :each | 
-		each model: ( RBClassModelFactory rbNamespace onEnvironment: rbEnvironment ).
+		each model environment: rbEnvironment.
 		each primitiveExecute ]
 ]
 


### PR DESCRIPTION
Setting the environment for the existent change model instead of instantiating a new model