### PR TITLE
Proper categorization in Zodiac-Tests package #2353

### DIFF
--- a/src/Zodiac-Tests/ZdcAbstractSocketStreamTest.class.st
+++ b/src/Zodiac-Tests/ZdcAbstractSocketStreamTest.class.st
@@ -136,7 +136,7 @@ ZdcAbstractSocketStreamTest >> socketStreamTimeout [
 	^ ZnNetworkingUtils socketStreamTimeout
 ]
 
-{ #category : #testing }
+{ #category : #tests }
 ZdcAbstractSocketStreamTest >> testAddOneEcho [
 	| dataSent dataRead clientStream semaphore |
 	semaphore := self runServer: [ :serverSocket | | clientSocket stream data |
@@ -154,7 +154,7 @@ ZdcAbstractSocketStreamTest >> testAddOneEcho [
 	semaphore wait
 ]
 
-{ #category : #testing }
+{ #category : #'tests - plain' }
 ZdcAbstractSocketStreamTest >> testPlainClientRead [
 	| dataSent dataRead clientStream semaphore |
 	dataSent := #[ 6 5 4 3 2 1 ].
@@ -172,7 +172,7 @@ ZdcAbstractSocketStreamTest >> testPlainClientRead [
 	semaphore wait
 ]
 
-{ #category : #testing }
+{ #category : #'tests - plain' }
 ZdcAbstractSocketStreamTest >> testPlainClientRead10k [
 	| dataSent dataRead clientStream semaphore |
 	dataSent := self bytes: 10000.
@@ -190,7 +190,7 @@ ZdcAbstractSocketStreamTest >> testPlainClientRead10k [
 	semaphore wait
 ]
 
-{ #category : #testing }
+{ #category : #'tests - plain' }
 ZdcAbstractSocketStreamTest >> testPlainClientRead10kInPieces1 [
 	| dataSent dataRead clientStream semaphore |
 	dataSent := self bytes: 10000.
@@ -209,7 +209,7 @@ ZdcAbstractSocketStreamTest >> testPlainClientRead10kInPieces1 [
 	semaphore wait
 ]
 
-{ #category : #testing }
+{ #category : #'tests - plain' }
 ZdcAbstractSocketStreamTest >> testPlainClientRead10kInPieces2 [
 	| dataSent dataRead clientStream semaphore |
 	dataSent := self bytes: 10000.
@@ -229,7 +229,7 @@ ZdcAbstractSocketStreamTest >> testPlainClientRead10kInPieces2 [
 	semaphore wait
 ]
 
-{ #category : #testing }
+{ #category : #'tests - plain' }
 ZdcAbstractSocketStreamTest >> testPlainClientSkip [
 	| dataSent dataRead clientStream semaphore |
 	dataSent := #[ 6 5 4 3 2 1 ].
@@ -247,7 +247,7 @@ ZdcAbstractSocketStreamTest >> testPlainClientSkip [
 	semaphore wait
 ]
 
-{ #category : #testing }
+{ #category : #'tests - plain' }
 ZdcAbstractSocketStreamTest >> testPlainClientSkip10k [
 	| dataSent dataRead clientStream semaphore |
 	dataSent := #[ 6 5 4 3 2 1 ].
@@ -266,7 +266,7 @@ ZdcAbstractSocketStreamTest >> testPlainClientSkip10k [
 	semaphore wait
 ]
 
-{ #category : #testing }
+{ #category : #'tests - plain' }
 ZdcAbstractSocketStreamTest >> testPlainClientWrite [
 	| dataSent dataRead clientStream semaphore |
 	semaphore := self runServer: [ :serverSocket :mySemaphore | | clientSocket serverStream |
@@ -284,7 +284,7 @@ ZdcAbstractSocketStreamTest >> testPlainClientWrite [
 	semaphore wait
 ]
 
-{ #category : #testing }
+{ #category : #'tests - plain' }
 ZdcAbstractSocketStreamTest >> testPlainClientWrite10k [
 	| dataSent dataRead clientStream semaphore |
 	semaphore := self runServer: [ :serverSocket :mySemaphore | | clientSocket serverStream |
@@ -302,7 +302,7 @@ ZdcAbstractSocketStreamTest >> testPlainClientWrite10k [
 	semaphore wait
 ]
 
-{ #category : #testing }
+{ #category : #'tests - plain' }
 ZdcAbstractSocketStreamTest >> testPlainClientWrite10kInPieces [
 	| dataSent dataRead clientStream semaphore |
 	semaphore := self runServer: [ :serverSocket :mySemaphore | | clientSocket serverStream |
@@ -321,7 +321,7 @@ ZdcAbstractSocketStreamTest >> testPlainClientWrite10kInPieces [
 	semaphore wait
 ]
 
-{ #category : #testing }
+{ #category : #'tests - reverse echo' }
 ZdcAbstractSocketStreamTest >> testReverseEcho [
 	| dataSent dataRead clientStream semaphore data |
 	semaphore := self runServer: [ :serverSocket | | clientSocket stream |
@@ -339,7 +339,7 @@ ZdcAbstractSocketStreamTest >> testReverseEcho [
 	semaphore wait
 ]
 
-{ #category : #testing }
+{ #category : #'tests - reverse echo' }
 ZdcAbstractSocketStreamTest >> testReverseEcho10kFixed [
 	| dataSent dataRead clientStream semaphore |
 	semaphore := self runServer: [ :serverSocket | | clientSocket stream data |
@@ -357,7 +357,7 @@ ZdcAbstractSocketStreamTest >> testReverseEcho10kFixed [
 	semaphore wait
 ]
 
-{ #category : #testing }
+{ #category : #'tests - reverse echo' }
 ZdcAbstractSocketStreamTest >> testReverseEcho10kSearch [
 	| dataSent dataRead clientStream semaphore |
 	semaphore := self runServer: [ :serverSocket | | clientSocket stream data |
@@ -375,7 +375,7 @@ ZdcAbstractSocketStreamTest >> testReverseEcho10kSearch [
 	semaphore wait
 ]
 
-{ #category : #testing }
+{ #category : #'tests - reverse echo' }
 ZdcAbstractSocketStreamTest >> testReverseEchoUpToEnd [
 	| dataSent dataRead clientStream semaphore data |
 	semaphore := self runServer: [ :serverSocket :mySemaphore | | clientSocket stream |

--- a/src/Zodiac-Tests/ZdcByteArrayManagerTest.class.st
+++ b/src/Zodiac-Tests/ZdcByteArrayManagerTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'Zodiac-Tests'
 }
 
-{ #category : #testing }
+{ #category : #tests }
 ZdcByteArrayManagerTest >> testClearing [
 	| byteArrayManager one two |
 	byteArrayManager := ZdcByteArrayManager new.
@@ -20,7 +20,7 @@ ZdcByteArrayManagerTest >> testClearing [
 	self assert: two equals: (ByteArray new: 10)
 ]
 
-{ #category : #testing }
+{ #category : #tests }
 ZdcByteArrayManagerTest >> testSimple [
 	| byteArrayManager byteArray |
 	byteArrayManager := ZdcByteArrayManager new.

--- a/src/Zodiac-Tests/ZdcIOBufferTest.class.st
+++ b/src/Zodiac-Tests/ZdcIOBufferTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'Zodiac-Tests'
 }
 
-{ #category : #testing }
+{ #category : #tests }
 ZdcIOBufferTest >> testAdvanceReadPointer [
 	| ioBuffer offset |
 	ioBuffer := ZdcIOBuffer on: (ByteArray new: 10).
@@ -25,7 +25,7 @@ ZdcIOBufferTest >> testAdvanceReadPointer [
 	
 ]
 
-{ #category : #testing }
+{ #category : #tests }
 ZdcIOBufferTest >> testAdvanceWritePointer [
 	| ioBuffer offset |
 	ioBuffer := ZdcIOBuffer on: (ByteArray new: 10).
@@ -40,7 +40,7 @@ ZdcIOBufferTest >> testAdvanceWritePointer [
 	
 ]
 
-{ #category : #testing }
+{ #category : #tests }
 ZdcIOBufferTest >> testBivalentReading [
 	| data ioBuffer buffer |
 	data := 'some string'.
@@ -59,7 +59,7 @@ ZdcIOBufferTest >> testBivalentReading [
 
 ]
 
-{ #category : #testing }
+{ #category : #tests }
 ZdcIOBufferTest >> testBivalentWriting [
 	| data ioBuffer |
 	data := 'some string'.
@@ -73,7 +73,7 @@ ZdcIOBufferTest >> testBivalentWriting [
 	self assert: ioBuffer contents equals: data asByteArray
 ]
 
-{ #category : #testing }
+{ #category : #'tests - compact' }
 ZdcIOBufferTest >> testCompact [
 	| ioBuffer |
 	ioBuffer := ZdcIOBuffer on: (ByteArray new: 10).
@@ -90,7 +90,7 @@ ZdcIOBufferTest >> testCompact [
 		
 ]
 
-{ #category : #testing }
+{ #category : #'tests - compact' }
 ZdcIOBufferTest >> testCompactAtBeginning [
 	| ioBuffer |
 	ioBuffer := ZdcIOBuffer on: (ByteArray new: 10).
@@ -104,7 +104,7 @@ ZdcIOBufferTest >> testCompactAtBeginning [
 	self assert: ioBuffer gapAtFront isZero
 ]
 
-{ #category : #testing }
+{ #category : #'tests - compact' }
 ZdcIOBufferTest >> testCompactAtEnd [
 	| ioBuffer |
 	ioBuffer := ZdcIOBuffer on: (ByteArray new: 10).
@@ -119,7 +119,7 @@ ZdcIOBufferTest >> testCompactAtEnd [
 		
 ]
 
-{ #category : #testing }
+{ #category : #'tests - compact' }
 ZdcIOBufferTest >> testCompactDoNothing [
 	| ioBuffer |
 	ioBuffer := ZdcIOBuffer on: (ByteArray new: 10).
@@ -140,7 +140,7 @@ ZdcIOBufferTest >> testCompactDoNothing [
 	self assert: ioBuffer availableForWriting equals: 4.
 ]
 
-{ #category : #testing }
+{ #category : #tests }
 ZdcIOBufferTest >> testNextPutAllStartingAt [
 	| ioBuffer |
 	ioBuffer := ZdcIOBuffer on: (String new: 12).
@@ -150,7 +150,7 @@ ZdcIOBufferTest >> testNextPutAllStartingAt [
 	self assert: ioBuffer contents equals: 'abcdabcdabcd'
 ]
 
-{ #category : #testing }
+{ #category : #tests }
 ZdcIOBufferTest >> testReadIntoStartingAtCount [
 	| data ioBuffer string |
 	data := 'abcdefghijkl'.
@@ -163,7 +163,7 @@ ZdcIOBufferTest >> testReadIntoStartingAtCount [
 	self assert: string equals: data
 ]
 
-{ #category : #testing }
+{ #category : #tests }
 ZdcIOBufferTest >> testReading [
 	| ioBuffer |
 	ioBuffer := ZdcIOBuffer on: (ByteArray new: 10).
@@ -175,7 +175,7 @@ ZdcIOBufferTest >> testReading [
 	self should: [ ioBuffer next ] raise: Error
 ]
 
-{ #category : #testing }
+{ #category : #tests }
 ZdcIOBufferTest >> testString [
 	| ioBuffer |
 	ioBuffer := ZdcIOBuffer on: (String new: 10).
@@ -186,7 +186,7 @@ ZdcIOBufferTest >> testString [
 	
 ]
 
-{ #category : #testing }
+{ #category : #tests }
 ZdcIOBufferTest >> testWriting [
 	| ioBuffer |
 	ioBuffer := ZdcIOBuffer on: (ByteArray new: 10).


### PR DESCRIPTION
Fix for #2353
- method category "testing" is not for tests, use "tests"
- group some tests into "testing - xxxx" categories

