### PR TITLE
prevent isInstance/isGlobal to throw an error on semantically analyses nodes

### DIFF
--- a/src/AST-Core/RBArgumentNode.class.st
+++ b/src/AST-Core/RBArgumentNode.class.st
@@ -30,3 +30,13 @@ RBArgumentNode >> isBlockVar [
 
 	^ (self whoDefines: self name) isBlock
 ]
+
+{ #category : #testing }
+RBArgumentNode >> isGlobal [
+	^ false
+]
+
+{ #category : #testing }
+RBArgumentNode >> isInstance [
+	^ false
+]

--- a/src/AST-Core/RBGlobalNode.class.st
+++ b/src/AST-Core/RBGlobalNode.class.st
@@ -22,5 +22,10 @@ RBGlobalNode >> acceptVisitor: aProgramNodeVisitor [
 
 { #category : #testing }
 RBGlobalNode >> isGlobal [
-	^true
+	^ true
+]
+
+{ #category : #testing }
+RBGlobalNode >> isInstance [
+	^ false
 ]

--- a/src/AST-Core/RBInstanceVariableNode.class.st
+++ b/src/AST-Core/RBInstanceVariableNode.class.st
@@ -15,6 +15,11 @@ RBInstanceVariableNode >> acceptVisitor: aProgramNodeVisitor [
 ]
 
 { #category : #testing }
+RBInstanceVariableNode >> isGlobal [
+	^ false
+]
+
+{ #category : #testing }
 RBInstanceVariableNode >> isInstance [
-	^true
+	^ true
 ]

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -527,6 +527,11 @@ RBProgramNode >> isTemp [
 ]
 
 { #category : #testing }
+RBProgramNode >> isThisContext [
+	^ false
+]
+
+{ #category : #testing }
 RBProgramNode >> isUsed [
 	"Answer true if this node could be used as part of another expression. For example, you could use the 
 	result of this node as a receiver of a message, an argument, the right part of an assignment, or the 

--- a/src/AST-Core/RBSelfNode.class.st
+++ b/src/AST-Core/RBSelfNode.class.st
@@ -20,6 +20,16 @@ RBSelfNode >> acceptVisitor: aProgramNodeVisitor [
 ]
 
 { #category : #testing }
+RBSelfNode >> isGlobal [
+	^ false
+]
+
+{ #category : #testing }
+RBSelfNode >> isInstance [
+	^ false
+]
+
+{ #category : #testing }
 RBSelfNode >> isSelf [
 	^ true
 ]

--- a/src/AST-Core/RBSuperNode.class.st
+++ b/src/AST-Core/RBSuperNode.class.st
@@ -20,6 +20,16 @@ RBSuperNode >> acceptVisitor: aProgramNodeVisitor [
 ]
 
 { #category : #testing }
+RBSuperNode >> isGlobal [
+	^ false
+]
+
+{ #category : #testing }
+RBSuperNode >> isInstance [
+	^ false
+]
+
+{ #category : #testing }
 RBSuperNode >> isSelfOrSuper [
 
 	^ true

--- a/src/AST-Core/RBTemporaryNode.class.st
+++ b/src/AST-Core/RBTemporaryNode.class.st
@@ -22,6 +22,16 @@ RBTemporaryNode >> isBlockVar [
 ]
 
 { #category : #testing }
+RBTemporaryNode >> isGlobal [
+	^ false
+]
+
+{ #category : #testing }
+RBTemporaryNode >> isInstance [
+	^ false
+]
+
+{ #category : #testing }
 RBTemporaryNode >> isTemp [
 	^ true
 ]

--- a/src/AST-Core/RBThisContextNode.class.st
+++ b/src/AST-Core/RBThisContextNode.class.st
@@ -20,6 +20,16 @@ RBThisContextNode >> acceptVisitor: aProgramNodeVisitor [
 ]
 
 { #category : #visiting }
+RBThisContextNode >> isGlobal [
+	^ false
+]
+
+{ #category : #visiting }
+RBThisContextNode >> isInstance [
+	^ false
+]
+
+{ #category : #visiting }
 RBThisContextNode >> isThisContext [
 	^ true
 ]

--- a/src/AST-Core/RBThisContextNode.class.st
+++ b/src/AST-Core/RBThisContextNode.class.st
@@ -18,3 +18,8 @@ RBThisContextNode class >> new [
 RBThisContextNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitThisContextNode: self
 ]
+
+{ #category : #visiting }
+RBThisContextNode >> isThisContext [
+	^ true
+]

--- a/src/OpalCompiler-Core/RBVariableNode.extension.st
+++ b/src/OpalCompiler-Core/RBVariableNode.extension.st
@@ -43,11 +43,6 @@ RBVariableNode >> isSpecialVariable [
 ]
 
 { #category : #'*opalcompiler-core' }
-RBVariableNode >> isTemp [
-	^ false
-]
-
-{ #category : #'*opalcompiler-core' }
 RBVariableNode >> isUndeclared [
 
 	^self binding isUndeclared

--- a/src/OpalCompiler-Core/RBVariableNode.extension.st
+++ b/src/OpalCompiler-Core/RBVariableNode.extension.st
@@ -29,12 +29,12 @@ RBVariableNode >> isClean [
 
 { #category : #'*opalcompiler-core' }
 RBVariableNode >> isGlobal [
-	^self binding isGlobal
+	^ self binding isGlobal
 ]
 
 { #category : #'*opalcompiler-core' }
 RBVariableNode >> isInstance [
-	^self binding isInstance
+	^ self binding isInstance
 ]
 
 { #category : #'*opalcompiler-core' }


### PR DESCRIPTION
This allows to not rely on binding for instanceVariable/global nodes.
This has a minimal constant memory cost,
No time cost.
This should not impact users that were working before. (unless there's a bug in the semantic analysis)
I did not do tests, because I want to wait for people's feelings about this first, given that there is several ways to fix this issue.
Let me know :)