### PR TITLE
Queue pending mouse events

### DIFF
--- a/src/Morphic-Base/Form.extension.st
+++ b/src/Morphic-Base/Form.extension.st
@@ -12,13 +12,13 @@ Form >> asMorph [
 ]
 
 { #category : #'*Morphic-Base' }
-Form >> floodFillTolerance [
-	^ self class floodFillTolerance
+Form class >> floodFillTolerance [
+	^ FloodFillTolerance ifNil: [FloodFillTolerance := 0.0]
 ]
 
 { #category : #'*Morphic-Base' }
-Form class >> floodFillTolerance [
-	^ FloodFillTolerance ifNil: [FloodFillTolerance := 0.0]
+Form >> floodFillTolerance [
+	^ self class floodFillTolerance
 ]
 
 { #category : #'*Morphic-Base' }

--- a/src/Morphic-Base/MouseClickState.class.st
+++ b/src/Morphic-Base/MouseClickState.class.st
@@ -120,12 +120,17 @@ MouseClickState >> handleEvent: evt from: aHand [
 				self click.
 				aHand resetClickState.
 				^true].
-			"Otherwise transfer to #firstClickUp"
-			firstClickUp := evt copy.
+
+			"Change the state to #firstClickUp.
+			Then queue the mouseUp event for later processing.
+			We will handle a click now."
 			clickState := #firstClickUp.
+			firstClickUp := evt copy.
 			"If timedOut or the client's not interested in dbl clicks get outta here"
-			aHand handleEvent: firstClickUp.
+			aHand queuePendingEvent: firstClickUp.
+			
 			self click.
+			
 			^false].
 		isDrag ifTrue:["drag start"
 			self doubleClickTimeout. "***"

--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -27,7 +27,8 @@ Class {
 		'lastKeyScanCode',
 		'combinedChar',
 		'captureBlock',
-		'recentModifiers'
+		'recentModifiers',
+		'pendingEventQueue'
 	],
 	#classVars : [
 		'DoubleClickTime',
@@ -904,6 +905,49 @@ HandMorph >> newMouseFocus: aMorph event: event [
 	^self newMouseFocus: aMorph
 ]
 
+{ #category : #'private events' }
+HandMorph >> nextEventFrom: anEventBufferQueue [
+	"Returns the next morphic event to handle.
+	Three cases may arise:
+	 - If possible, a valid morphic event is returned
+	 - If no more events are available, nil is returned
+	 - If we find an invalid event in the queue, we consume it and return the #invalid symbol
+	
+	The first morphic events available are those in the pending queue.
+	An event handling cycle should generate and manage a single event.
+	In the case a cycle needs to generate several events (see MouseClickState), only one event is handled.
+	Remaining events are queued for later processing.
+	"
+	| eventBuffer morphicEvent type pendingMorphicEvent |
+	
+	pendingMorphicEvent := self pendingEventQueue nextOrNil.
+	pendingMorphicEvent ifNotNil: [ ^ pendingMorphicEvent ].
+	
+	anEventBufferQueue ifNil: [ ^ nil ].
+	eventBuffer := anEventBufferQueue nextEvent.
+	eventBuffer ifNil: [ ^ nil ].
+	
+	morphicEvent := nil.	"for unknown event types"
+	type := eventBuffer first.
+	type = EventTypeMouse ifTrue: [ self world beCursorOwner.
+		recentModifiers := eventBuffer sixth.
+		morphicEvent := self generateMouseEvent: eventBuffer
+	].
+	type = EventTypeKeyboard ifTrue: [
+		recentModifiers := eventBuffer fifth.
+		morphicEvent := self generateKeyboardEvent: eventBuffer
+	].
+	type = EventTypeDragDropFiles ifTrue: [ 
+		morphicEvent := self generateDropFilesEvent: eventBuffer ].
+	type = EventTypeWindow ifTrue: [ 
+		morphicEvent := self generateWindowEvent: eventBuffer ].
+	
+	"If the event did not match any of the categories above, it is an invalid event"
+	( type ~= EventTypeDragDropFiles and: [ morphicEvent isNil ] )
+		ifTrue: [ ^ #invalid ].
+	^ morphicEvent
+]
+
 { #category : #accessing }
 HandMorph >> noButtonPressed [
 	"Answer whether any mouse button is not being pressed."
@@ -979,6 +1023,12 @@ HandMorph >> pasteBuffer: aMorphOrNil [
 
 ]
 
+{ #category : #'private events' }
+HandMorph >> pendingEventQueue [
+
+	^ pendingEventQueue ifNil: [ pendingEventQueue := WaitfreeQueue new ]
+]
+
 { #category : #geometry }
 HandMorph >> position [
 
@@ -1019,7 +1069,7 @@ HandMorph >> processEvents [
 ]
 
 { #category : #'private events' }
-HandMorph >> processEventsFromQueue: anEventQueue [
+HandMorph >> processEventsFromQueue: anEventBufferQueue [
 
 	"Process user input events from the local input devices."
 
@@ -1031,38 +1081,34 @@ HandMorph >> processEventsFromQueue: anEventQueue [
 		self mouseOverHandler processMouseOver: lastMouseEvent ].
 
 	hadAny := false.
-	[ anEventQueue isNotNil and: [ ( evtBuf := anEventQueue nextEvent ) isNotNil ] ]
-		whileTrue: [ evt := nil.	"for unknown event types"
-			type := evtBuf first.
-			type = EventTypeMouse
-				ifTrue: [ self world beCursorOwner.
-					recentModifiers := evtBuf sixth.
-					evt := self generateMouseEvent: evtBuf
-					].
-			type = EventTypeKeyboard
-				ifTrue: [ recentModifiers := evtBuf fifth.
-					evt := self generateKeyboardEvent: evtBuf
-					].
-			type = EventTypeDragDropFiles
-				ifTrue: [ evt := self generateDropFilesEvent: evtBuf ].
-			type = EventTypeWindow
-				ifTrue: [ evt := self generateWindowEvent: evtBuf ].	"All other events are ignored"
-			( type ~= EventTypeDragDropFiles and: [ evt isNil ] )
-				ifTrue: [ ^ self ].
-			evt
-				ifNotNil: [ "Finally, handle it"
-					self handleEvent: evt.
-					hadAny := true.	"For better user feedback, return immediately after a mouse event has been processed."
-					( evt isMouse and: [ evt isMouseWheel not ] )
-						ifTrue: [ ^ self ]
-					]
-			].	"note: if we come here we didn't have any mouse events"
-	mouseClickState notNil
-		ifTrue:
-			[ "No mouse events during this cycle. Make sure click states time out accordingly" mouseClickState handleEvent: lastMouseEvent asMouseMove from: self ].
-	hadAny
-		ifFalse:
-			[ "No pending events. Make sure z-order is up to date" self mouseOverHandler processMouseOver: lastMouseEvent ]
+	[ (evt := self nextEventFrom: anEventBufferQueue) notNil ] whileTrue: [ 
+		evt == #invalid ifTrue: [ ^ self ].
+		evt ifNotNil: [ "Finally, handle it"
+			self handleEvent: evt.
+			hadAny := true.
+			"For better user feedback, return immediately after a mouse event has been processed."
+			( evt isMouse and: [ evt isMouseWheel not ] )
+				ifTrue: [ ^ self ]
+		]
+	].
+	
+	"note: if we come here we didn't have any mouse events"
+	mouseClickState notNil ifTrue: [ 
+		"No mouse events during this cycle. Make sure click states time out accordingly"
+		mouseClickState handleEvent: lastMouseEvent asMouseMove from: self ].
+	hadAny ifFalse: [ 
+		"No pending events. Make sure z-order is up to date"
+		self mouseOverHandler processMouseOver: lastMouseEvent ]
+]
+
+{ #category : #'private events' }
+HandMorph >> queuePendingEvent: aMorphicEvent [
+	"Queue an (extra) event produced during an event handling cycle, to be processed in later cycles.
+	An event handling cycle should generate and manage a single event.
+	In the case a cycle needs to generate several events (see MouseClickState), only one event is handled.
+	Remaining events are queued for later processing.
+	"
+	self pendingEventQueue nextPut: aMorphicEvent
 ]
 
 { #category : #'focus handling' }

--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -1073,7 +1073,7 @@ HandMorph >> processEventsFromQueue: anEventBufferQueue [
 
 	"Process user input events from the local input devices."
 
-	| evt evtBuf type hadAny |
+	| evt hadAny |
 
 	self lastEvent ifNotNil: [
 		"Meaning that we were invoked from within an event response.


### PR DESCRIPTION
Fix #6003

This PR should fix #6003 without having regressions in #5945 

 - refactor processEventsFromQueue:, split obtention of events in nextEventFrom:
 - add pendingEventQueue and queuePendingEvent:
 - make nextEventFrom: give priority to pending events
 - make MouseClickState queue pending mouseUp for next cycle

# Details

This solution restores the order of events (MouseDown, Click, MouseUp) while, not blocking MouseUp if a click starts a modal loop.
Changing the order of events like I did in #5964 is not a good solution because the event order makes sense for clients, and there are clients handling both clicks and mouseUps.
Also altering the order just moves the problem to mouseUp: If somebody tries to use a modal window on mouseUp => Boom same problem but with clicks.

This solution ensures that:
1) the order of events is the right one
2) no events get "blocked", so if an artificial event (e.g., click, double click) is created it can be queued and it will be managed in the next event cycle (from the same loop of from an inner modal loop).

## Background: How Mouse Events Work

The Hand is the one managing/dispatching the events.
When the Sensor (running in a higher priority thread) finds events, it puts them into a queue.
Eventually, the hand dequeues events and treats them.

Now, the mouse events have two main flavours: mouseDown and mouseUp
There is no click, nor double click event, they are simulated by the hand morph.

When a morph is interested on a click it has to
1. subscribe to mouse down first
2. when it receives a mouse down, it has to ask the hand "Hey! I would like clicks!"
Usually done by some code like this:

```smalltalk
anEvent hand waitForClicksOrDrag: h
  event: (anEvent transformedBy: tfm)
  selectors: { nil. nil. nil. #dragTarget:. }
  threshold: 5
```

When that happens, the hand changes its state, and stores a "MouseClickState object" that implements a kind of state machine to detect clicks and double clicks.

After the mouseDown, the morph receives a mouseUp (that should be transformed into a click).
So the hand, before sending the event to the morph, it makes it pass through the state machine which has some code like this:

```smalltalk
self click.    
aHand handleEvent: firstClickUp.
```

Where
1. click  will send a click event to the morph and
2. handleEvent: will send the mouseUp

## More details on the problem

One problem happens when a morph decides to BLOCK on a modal window on the click- :smile:
That means that mouseUp event will stay blocked in the stack, because the click does not return from the modal until modality finishes.
This means `handleEvent:` is never sent

In my fix the other day, I exchanged the order.
```smalltalk
aHand handleEvent: firstClickUp.
self click.
```

That solved that first problem. But that alters the order of the events.
So morphs used to receive MouseDown, Click, MouseUp now receive a MouseDown, MouseUp, then Click. This makes FastTable event logic loose the multiple selection.