### PR TITLE
ReflectivityExamples: do not do compileTemporaryMethods in #initialize

### DIFF
--- a/src/Reflectivity-Tests/ReflectivityExamples.class.st
+++ b/src/Reflectivity-Tests/ReflectivityExamples.class.st
@@ -194,9 +194,7 @@ ReflectivityExamples >> exampleWithArg: anArg [
 { #category : #initialization }
 ReflectivityExamples >> initialize [
 	ivar := 33.
-	ClassVar := #AClassVar.
-	self removeTemporaryMethods.
-	self compileTemporaryMethods
+	ClassVar := #AClassVar
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
ReflectivityExamples removes and adds two methods in #initialize. This is not really needed as the tests that use it already treat it correctly.

The side effect was that executing the tests added these methods, leading to uncommited code.