### PR TITLE
Cleanup: namedTempAt: and namedTempAt:put:

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -42,22 +42,6 @@ Context >> methodReturnConstant: value [
 ]
 
 { #category : #'*Debugging-Core' }
-Context >> namedTempAt: index [
-	"Answer the value of the temp at index in the receiver's sequence of tempNames."
-	"NOTE: this list of temp names is completely virtual! It omits temp vectors but 
-	adds every variable that could be acccessed from a source perspective but might not be"
-	^self tempNamed: (self tempNames at: index)
-]
-
-{ #category : #'*Debugging-Core' }
-Context >> namedTempAt: index put: aValue [
-	"Set the value of the temp at index in the receiver's sequence of tempNames"
-	"NOTE: this list of temp names is completely virtual! It omits temp vectors but 
-	adds every variable that could be acccessed from a source perspective but might not be"
-	^self tempNamed: (self tempNames at: index) put: aValue
-]
-
-{ #category : #'*Debugging-Core' }
 Context >> pcRangeContextIsActive: contextIsActive [
  	"return the debug highlight for aPC"		 
 	| thePC |

--- a/src/OpalCompiler-Core/DebuggerMethodMapOpal.class.st
+++ b/src/OpalCompiler-Core/DebuggerMethodMapOpal.class.st
@@ -29,20 +29,6 @@ DebuggerMethodMapOpal >> forMethod: aCompiledMethod [
 	methodNode := aCompiledMethod ast
 ]
 
-{ #category : #public }
-DebuggerMethodMapOpal >> namedTempAt: index in: aContext [
-	"please use #namedTempAt: on Context"
-	self deprecated: 'Please use aContext namedTempAt: index'.
-	^aContext namedTempAt: index
-]
-
-{ #category : #public }
-DebuggerMethodMapOpal >> namedTempAt: index put: aValue in: aContext [
-	"please use #namedTempAt:put: on Context"
-	self deprecated: 'Please use aContext namedTempAt: index put: aValue'.
-	^aContext namedTempAt: index put: aValue
-]
-
 { #category : #initialization }
 DebuggerMethodMapOpal >> rangeForPC: aPC contextIsActiveContext: aBoolean [
 	"please use pcRangeContextIsActive: on Context"


### PR DESCRIPTION
Next step in the methodMap cleanup: remove the method related to "namedTempAt:". 

the debugger methodmap has two kinds of offsets for temps: the real one (tempAt:) and a "virtual" offset for all real temps that are accessible by name.
This makes the whole thing quite difficult to understand and is better removed. There are no senders in the image, the methods where private to the debugger.