### PR TITLE
Fix minimal Pharo on Window

### DIFF
--- a/src/System-Platforms-Tests/Win32WideStringTest.class.st
+++ b/src/System-Platforms-Tests/Win32WideStringTest.class.st
@@ -1,0 +1,71 @@
+Class {
+	#name : #Win32WideStringTest,
+	#superclass : #TestCase,
+	#category : #'System-Platforms-Tests-Win32'
+}
+
+{ #category : #tests }
+Win32WideStringTest >> exampleString [
+
+	^ 'áéíóúñÑâîôûêèàìòù©¢ßðöäå®þü¼¡²³¤€¼½¾‘’¥'
+]
+
+{ #category : #testing }
+Win32WideStringTest >> isWindows [
+
+	^ OSPlatform current isWindows 
+]
+
+{ #category : #tests }
+Win32WideStringTest >> testCharactersAreEncodedInUnicode16Bits [
+
+	| bytes index |
+	
+	self isWindows 
+		ifFalse: [ ^self skip ].
+	
+	bytes := self exampleString asWin32WideString getHandle.
+	index := 1.
+	
+	self exampleString do: [ :aCharacter |  
+		self assert: (bytes at: index) equals: (aCharacter codePoint bitAnd: 255).
+		self assert: (bytes at: index+1) equals: (aCharacter codePoint >> 8).		
+		index := index + 2.
+	]
+]
+
+{ #category : #tests }
+Win32WideStringTest >> testConvertingInBothDirectionsGaveSameString [
+
+	self isWindows 
+		ifFalse: [ ^self skip ].
+
+	self assert: self exampleString asWin32WideString asString equals: self exampleString
+]
+
+{ #category : #tests }
+Win32WideStringTest >> testHandleIsAByteArray [
+
+	self isWindows 
+		ifFalse: [ ^self skip ].
+
+	self assert: (self exampleString asWin32WideString getHandle isKindOf: ByteArray)
+]
+
+{ #category : #tests }
+Win32WideStringTest >> testUnderlayingByteArrayEndsInTwoZeros [
+
+	self isWindows 
+		ifFalse: [ ^self skip ].
+
+	self assert: (self exampleString asWin32WideString getHandle last:2) equals: #[00 00]
+]
+
+{ #category : #tests }
+Win32WideStringTest >> testUnderlayingByteArrayIsMultipleOf2 [
+
+	self isWindows 
+		ifFalse: [ ^self skip ].
+
+	self assert: (self exampleString asWin32WideString getHandle size) % 2 equals: 0
+]

--- a/src/System-Platforms/WinPlatform.class.st
+++ b/src/System-Platforms/WinPlatform.class.st
@@ -148,13 +148,32 @@ WinPlatform >> virtualKey: virtualKeyCode [
 
 { #category : #'string-manipulation' }
 WinPlatform >> wideCharacterToMultiByteCodepage: codepage flags: flags input: input inputLen: inputLen output: output outputLen: outputLen [
-	^self ffiCall: #(int WideCharToMultiByte(uint codepage,
-    ulong flags,
-    Win32WideString input,
-    int inputLen,
-    String output,
-    int outputLen,
-    0,
-    0
- ))
+
+	"To be independent on UnifiedFFI package, we must use low-level FFI call. The following code is based on this FFI call:
+
+	^self ffiCall: #(int WideCharToMultiByte(uint codepage, ulong flags, Win32WideString input, int inputLen, String output, int outputLen, 0, 0 ))"
+
+	^(ExternalLibraryFunction
+		name: 'WideCharToMultiByte'
+		module: 'Kernel32'
+		callType: 0
+		returnType: ExternalType signedLong
+		argumentTypes:
+			{ExternalType unsignedLong.
+			ExternalType unsignedLong.
+			ExternalType void asPointerType.
+			ExternalType signedLong.
+			ExternalType char asPointerType.
+			ExternalType signedLong.
+			ExternalType unsignedLong.
+			ExternalType unsignedLong.})
+		invokeWithArguments:
+			{codepage.
+			flags.
+			input getHandle.
+			inputLen.
+			output.
+			outputLen.
+			0.
+			0}
 ]


### PR DESCRIPTION
The minimal Pharo is not able to do nor load anything useful on Windows becaues its start-up code is dependent of UnifiedFFI and fails immediatelly. 

Use low-level FFI call for WideCharToMultiByte