### PR TITLE
2146-Hardcode-class-searcher-in-RB-class

### DIFF
--- a/src/Refactoring-Tests-Core/RBAbstractClassVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBAbstractClassVariableTest.class.st
@@ -24,7 +24,7 @@ RBAbstractClassVariableTest >> testAbstractClassVariable [
 	self assert: (meta parseTreeFor: #nuke) equals: (self parseMethod: 'nuke
 							self recursiveSelfRule: nil').
 	self assert: (meta parseTreeFor: #initializeAfterLoad1) equals: (self parseMethod: 'initializeAfterLoad1
-							self recursiveSelfRule: RBParseTreeSearcher new.
+							self recursiveSelfRule: self parseTreeSearcher.
 							self recursiveSelfRule
 								addMethodSearches: #(''`@methodName: `@args | `@temps | self `@methodName: `@args'' ''`@methodName: `@args | `@temps | ^self `@methodName: `@args'')
 										-> [:aNode :answer | true]').

--- a/src/Refactoring-Tests-Core/RBBasicLintRuleTestData.class.st
+++ b/src/Refactoring-Tests-Core/RBBasicLintRuleTestData.class.st
@@ -29,7 +29,7 @@ RBBasicLintRuleTestData class >> classShouldNotOverride [
 { #category : #private }
 RBBasicLintRuleTestData class >> createMatcherFor: codeStrings method: aBoolean [ 
 	| matcher |
-	matcher := RBParseTreeSearcher new.
+	matcher := self parseTreeSearcher.
 	aBoolean
 		ifTrue: [matcher addMethodSearches: codeStrings -> [:aNode :answer | true]]
 		ifFalse: [matcher addSearches: codeStrings -> [:aNode :answer | true]].
@@ -61,7 +61,7 @@ RBBasicLintRuleTestData class >> justSendsSuper [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Method just sends super message'.
-	matcher := RBParseTreeSearcher justSendsSuper.
+	matcher := self parseTreeSearcherClass justSendsSuper.
 	detector methodBlock: 
 			[:context :result | 
 			(context parseTree tag isNil
@@ -104,7 +104,7 @@ RBBasicLintRuleTestData class >> precedence [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Inspect instances of "A + B * C" might be "A + (B * C)"'.
-	matcher := RBParseTreeSearcher new.
+	matcher := self parseTreeSearcher.
 	matcher addSearches: #('``@A + ``@B * ``@C' '``@A - ``@B * ``@C')
 				-> [:aNode :answer | answer or: [aNode receiver parentheses isEmpty]].
 	detector methodBlock: 
@@ -212,14 +212,14 @@ RBBasicLintRuleTestData class >> toDo [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Uses to:do: instead of do:, with:do: or timesRepeat:'.
-	matcher := RBParseTreeSearcher new.
+	matcher := self parseTreeSearcher.
 	matcher
 		addSearch: '1 to: ``@object size do: [:`each | | `@temps | `@.Statements]' -> 
 					[:aNode :answer | 
 					answer or: 
 							[| varName variableMatcher |
 							varName := aNode arguments last arguments first name. "`each"
-							variableMatcher := RBParseTreeSearcher new.
+							variableMatcher := self parseTreeSearcher.
 							variableMatcher addSearch: varName
 										-> [:node :ans | ans and: [node parent isMessage and: [node parent selector == #at:]]].
 							variableMatcher executeTree: aNode arguments last body initialAnswer: true]].
@@ -247,7 +247,7 @@ RBBasicLintRuleTestData class >> utilityMethods [
 					[(self subclassOf: context selectedClass overrides: context selector)
 						ifFalse: 
 							[(context superMessages isEmpty and: [context selfMessages isEmpty]) ifTrue: 
-									[(RBParseTreeSearcher
+									[(self parseTreeSearcherClass
 										references: context selectedClass allInstVarNames
 												, context selectedClass allClassVarNames asArray , #('self')
 										in: context parseTree) isEmpty

--- a/src/Refactoring-Tests-Core/RBLintRuleTestData.class.st
+++ b/src/Refactoring-Tests-Core/RBLintRuleTestData.class.st
@@ -18,6 +18,16 @@ Class {
 	#category : #'Refactoring-Tests-Core-Data'
 }
 
+{ #category : #parsing }
+RBLintRuleTestData class >> parseTreeSearcher [ 
+	^ self parseTreeSearcherClass new
+]
+
+{ #category : #parsing }
+RBLintRuleTestData class >> parseTreeSearcherClass [
+	^ RBParseTreeSearcher 
+]
+
 { #category : #foo }
 RBLintRuleTestData class >> someFooMethod [
 	^ 'does nothing here:)'

--- a/src/Refactoring-Tests-Core/RBRenameClassVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenameClassVariableTest.class.st
@@ -42,7 +42,7 @@ RBRenameClassVariableTest >> testRenameClassVar [
 			(self
 				parseMethod:
 					'initializeAfterLoad1
-								RSR := RBParseTreeSearcher new.
+								RSR := self parseTreeSearcher.
 								RSR
 									addMethodSearches: #(''`@methodName: `@args | `@temps | self `@methodName: `@args'' ''`@methodName: `@args | `@temps | ^self `@methodName: `@args'')
 											-> [:aNode :answer | true]').

--- a/src/Refactoring-Tests-Core/RBTransformationRuleTestData.class.st
+++ b/src/Refactoring-Tests-Core/RBTransformationRuleTestData.class.st
@@ -146,7 +146,7 @@ RBTransformationRuleTestData class >> guardClause [
 
 { #category : #'class initialization' }
 RBTransformationRuleTestData class >> initializeAfterLoad1 [
-	RecursiveSelfRule := RBParseTreeSearcher new.
+	RecursiveSelfRule := self parseTreeSearcher.
 	RecursiveSelfRule
 		addMethodSearches: #('`@methodName: `@args | `@temps | self `@methodName: `@args' '`@methodName: `@args | `@temps | ^self `@methodName: `@args')
 				-> [:aNode :answer | true]

--- a/src/Refactoring2-Transformations-Tests/RBBasicDummyLintRuleTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBBasicDummyLintRuleTest.class.st
@@ -173,7 +173,7 @@ RBBasicDummyLintRuleTest class >> collectionMessagesToExternalObject [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Sends add:/remove: to external collection'.
-	matcher := RBParseTreeSearcher new.
+	matcher := self parseTreeSearcher.
 	matcher
 		addSearches: (#(#add: #remove: #addAll: #removeAll:)
 				collect: [:each | ('(`@Object `@message: `@args) <1s> `@Arg' expandMacrosWith: each) asString])
@@ -243,7 +243,7 @@ RBBasicDummyLintRuleTest class >> contains [
 { #category : #private }
 RBBasicDummyLintRuleTest class >> createMatcherFor: codeStrings method: aBoolean [ 
 	| matcher |
-	matcher := RBParseTreeSearcher new.
+	matcher := self parseTreeSearcher.
 	aBoolean
 		ifTrue: [matcher addMethodSearches: codeStrings -> [:aNode :answer | true]]
 		ifFalse: [matcher addSearches: codeStrings -> [:aNode :answer | true]].
@@ -319,7 +319,7 @@ RBBasicDummyLintRuleTest class >> endTrueFalse [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Check for same statements at end of ifTrue:ifFalse: blocks'.
-	matcher := (RBParseTreeSearcher new) addSearches: 
+	matcher := (self parseTreeSearcher) addSearches: 
 				#('`@object 
 						ifTrue: [| `@temps1 | `@.Statements1. `.Statement] 
 						ifFalse: [| `@temps2 | `@.Statements2. `.Statement]' 
@@ -347,7 +347,7 @@ RBBasicDummyLintRuleTest class >> equalsTrue [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Unnecessary "= true"'.
-	matcher := (RBParseTreeSearcher new) addSearches: #('true' 'false') -> 
+	matcher := (self parseTreeSearcher) addSearches: #('true' 'false') -> 
 								[:aNode :answer | 
 								answer or: 
 										[aNode parent isMessage
@@ -440,7 +440,7 @@ RBBasicDummyLintRuleTest class >> ifTrueBlocks [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Non-blocks in ifTrue:/ifFalse: messages'.
-	matcher := RBParseTreeSearcher new.
+	matcher := self parseTreeSearcher.
 	matcher
 		addSearches: #('``@condition ifTrue: ``@block' '``@condition ifFalse: ``@block' '``@condition ifTrue: ``@block1 ifFalse: ``@block2' '``@condition ifFalse: ``@block1 ifTrue: ``@block2')
 				-> 
@@ -459,7 +459,7 @@ RBBasicDummyLintRuleTest class >> ifTrueReturns [
 	| detector matcher |
 	detector := self new.
 	detector name: 'ifTrue:/ifFalse: returns instead of and:/or:''s'.
-	matcher := RBParseTreeSearcher new.
+	matcher := self parseTreeSearcher.
 	matcher addSearches:
 		#('| `@temps | ``@.Statements. ``@object ifTrue: [^``@value1]. ^``@value2' 
 		'| `@temps | ``@.Statements. ``@object ifFalse: [^``@value1]. ^``@value2') 
@@ -514,7 +514,7 @@ RBBasicDummyLintRuleTest class >> justSendsSuper [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Method just sends super message'.
-	matcher := RBParseTreeSearcher justSendsSuper.
+	matcher := self parseTreeSearcherClass justSendsSuper.
 	detector methodBlock: 
 			[:context :result | 
 			(context parseTree tag isNil
@@ -533,7 +533,7 @@ RBBasicDummyLintRuleTest class >> longMethods [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Long methods'.
-	matcher := RBParseTreeSearcher new.
+	matcher := self parseTreeSearcher.
 	matcher
 		addSearch: '`.Stmt' -> 
 					[:aNode :answer | 
@@ -557,7 +557,7 @@ RBBasicDummyLintRuleTest class >> minMax [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Uses ifTrue:/ifFalse: instead of min: or max:'.
-	matcher := RBParseTreeSearcher new.
+	matcher := self parseTreeSearcher.
 	matcher
 		addSearches: #('(`x `message: `@y) `ifTrue: [`x := `@y]' '(`@x `message: `@y) `ifTrue: [`@x] `ifFalse: [`@y]')
 				-> 
@@ -606,7 +606,7 @@ RBBasicDummyLintRuleTest class >> missingYourself [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Possible missing "; yourself"'.
-	matcher := RBParseTreeSearcher new.
+	matcher := self parseTreeSearcher.
 	matcher
 		addSearch: '``@xobject `@messages: ``@args' -> 
 					[:aNode :answer | 
@@ -683,11 +683,6 @@ RBBasicDummyLintRuleTest class >> overridesSpecialMessage [
 ]
 
 { #category : #miscellaneous }
-RBBasicDummyLintRuleTest class >> parseTreeSearcher [
-	^ RBParseTreeSearcher new
-]
-
-{ #category : #miscellaneous }
 RBBasicDummyLintRuleTest class >> precedence [
 	| detector matcher |
 	detector := self new.
@@ -732,7 +727,7 @@ RBBasicDummyLintRuleTest class >> returnsBooleanAndOther [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Returns a boolean and non boolean'.
-	matcher := RBParseTreeSearcher new.
+	matcher := self parseTreeSearcher.
 	matcher addSearch: '^``@xObject' -> 
 					[:aNode :answer | 
 					answer add: aNode value;
@@ -867,8 +862,8 @@ RBBasicDummyLintRuleTest class >> stringConcatenation [
 	| detector matcher concatenationMatcher |
 	detector := self new.
 	detector name: 'String concatenation instead of streams'.
-	matcher := RBParseTreeSearcher new.
-	concatenationMatcher := RBParseTreeSearcher new.
+	matcher := self parseTreeSearcher.
+	concatenationMatcher := self parseTreeSearcher.
 	concatenationMatcher
 		addSearch: '`@receiver , `@argument' -> [:aNode :answer | true].
 	matcher
@@ -949,7 +944,7 @@ RBBasicDummyLintRuleTest class >> tempVarOverridesInstVar [
 	| detector matcher vars varName |
 	detector := self new.
 	detector name: 'Instance variable overridden by temporary variable'.
-	matcher := (RBParseTreeSearcher new) addArgumentSearch: '`xxxvar' -> 
+	matcher := (self parseTreeSearcher) addArgumentSearch: '`xxxvar' -> 
 								[:aNode :answer | 
 								answer or: 
 										[varName := aNode name.
@@ -972,7 +967,7 @@ RBBasicDummyLintRuleTest class >> tempsReadBeforeWritten [
 	detector methodBlock: 
 			[:context :result | 
 			| variables |
-			variables := RBParseTreeSearcher nonBlockTempsIn: context parseTree.
+			variables := self parseTreeSearcherClass nonBlockTempsIn: context parseTree.
 			variables isEmpty 
 				ifFalse: 
 					[(RBReadBeforeWrittenTester variablesReadBeforeWrittenIn: context parseTree) 
@@ -988,7 +983,7 @@ RBBasicDummyLintRuleTest class >> threeElementPoint [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Possible three element point (e.g., x @ y + q @ r)'.
-	matcher := (RBParseTreeSearcher new) addSearch: '``@x @ ``@y' -> 
+	matcher := (self parseTreeSearcher) addSearch: '``@x @ ``@y' -> 
 								[:aNode :answer | 
 								answer or: 
 										[| current |
@@ -1012,14 +1007,14 @@ RBBasicDummyLintRuleTest class >> toDo [
 	| detector matcher |
 	detector := self new.
 	detector name: 'Uses to:do: instead of do:, with:do: or timesRepeat:'.
-	matcher := RBParseTreeSearcher new.
+	matcher := self parseTreeSearcher.
 	matcher
 		addSearch: '1 to: ``@object size do: [:`each | | `@temps | `@.Statements]' -> 
 					[:aNode :answer | 
 					answer or: 
 							[| varName variableMatcher |
 							varName := aNode arguments last arguments first name. "`each"
-							variableMatcher := RBParseTreeSearcher new.
+							variableMatcher := self parseTreeSearcher.
 							variableMatcher addSearch: varName
 										-> [:node :ans | ans and: [node parent isMessage and: [node parent selector == #at:]]].
 							variableMatcher executeTree: aNode arguments last body initialAnswer: true]].
@@ -1057,7 +1052,7 @@ RBBasicDummyLintRuleTest class >> usesAdd [
 	| detector addSearcher |
 	detector := self new.
 	detector name: 'Uses the result of an add: message'.
-	addSearcher := RBParseTreeSearcher usesResultOfAdd.
+	addSearcher := self parseTreeSearcherClass usesResultOfAdd.
 	detector methodBlock: 
 			[:context :result | 
 			(addSearcher executeTree: context parseTree initialAnswer: false)
@@ -1100,7 +1095,7 @@ RBBasicDummyLintRuleTest class >> utilityMethods [
 					[(self subclassOf: context selectedClass overrides: context selector)
 						ifFalse: 
 							[(context superMessages isEmpty and: [context selfMessages isEmpty]) ifTrue: 
-									[(RBParseTreeSearcher
+									[(self parseTreeSearcherClass
 										references: context selectedClass allInstVarNames
 												, context selectedClass allClassVarNames asArray , #('self')
 										in: context parseTree) isEmpty
@@ -1139,7 +1134,7 @@ RBBasicDummyLintRuleTest class >> variableAssignedLiteral [
 							sum + sels size])
 							== 1 ifTrue: 
 								[| tree searcher |
-								searcher := RBParseTreeSearcher new.
+								searcher := self parseTreeSearcher.
 								searcher addSearch: (each , ' := ``@object')
 											-> [:aNode :answer | answer isNil and: [aNode value isLiteralNode]].
 								tree := defClass parseTreeFor: selector.
@@ -1229,7 +1224,7 @@ RBBasicDummyLintRuleTest class >> yourselfNotUsed [
 	| detector addSearcher |
 	detector := self new.
 	detector name: 'Doesn''t use the result of a yourself message'.
-	addSearcher := RBParseTreeSearcher new.
+	addSearcher := self parseTreeSearcher.
 	addSearcher addSearch: '`@object yourself'
 				-> [:aNode :answer | answer or: [aNode isUsed not]].
 	detector methodBlock: 

--- a/src/Refactoring2-Transformations-Tests/RBDummyLintRuleTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBDummyLintRuleTest.class.st
@@ -14,6 +14,16 @@ Class {
 	#category : #'Refactoring2-Transformations-Tests'
 }
 
+{ #category : #parsing }
+RBDummyLintRuleTest class >> parseTreeSearcher [
+	^ self parseTreeSearcherClass new
+]
+
+{ #category : #parsing }
+RBDummyLintRuleTest class >> parseTreeSearcherClass [ 
+	^ RBParseTreeSearcher 
+]
+
 { #category : #foo }
 RBDummyLintRuleTest class >> someFooMethod [
 	^ 'does nothing here:)'

--- a/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
@@ -56,7 +56,7 @@ RBProtectVariableTransformationTest >> testClassVariable [
 			equals: (self parseMethod: 'nuke self recursiveSelfRule: nil').
 	self assert: (class parseTreeFor: #initializeAfterLoad1) 
 			equals: (self parseMethod: 'initializeAfterLoad1
-				self recursiveSelfRule: RBParseTreeSearcher new.
+				self recursiveSelfRule: self parseTreeSearcher.
 				self recursiveSelfRule
 					addMethodSearches: #(''`@methodName: `@args | `@temps | self `@methodName: `@args'' ''`@methodName: `@args | `@temps | ^self `@methodName: `@args'')
 					-> [:aNode :answer | true]').

--- a/src/Refactoring2-Transformations-Tests/RBRenameVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameVariableTransformationTest.class.st
@@ -20,7 +20,7 @@ RBRenameVariableTransformationTest >> testClassVariable [
 	self assert: (class theMetaClass parseTreeFor: #initializeAfterLoad1) 
 		  equals: (self parseMethod: 
 				'initializeAfterLoad1
-					RSR := RBParseTreeSearcher new.
+					RSR := self parseTreeSearcher.
 					RSR addMethodSearches: #(''`@methodName: `@args | `@temps | self `@methodName: `@args'' ''`@methodName: `@args | `@temps | ^self `@methodName: `@args'')
 						-> [:aNode :answer | true]').
 	self assert: (class theMetaClass parseTreeFor: #nuke) 

--- a/src/Refactoring2-Transformations-Tests/RBTransformationDummyRuleTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBTransformationDummyRuleTest.class.st
@@ -146,7 +146,7 @@ RBTransformationDummyRuleTest class >> guardClause [
 
 { #category : #'class initialization' }
 RBTransformationDummyRuleTest class >> initializeAfterLoad1 [
-	RecursiveSelfRule := RBParseTreeSearcher new.
+	RecursiveSelfRule := self parseTreeSearcher.
 	RecursiveSelfRule
 		addMethodSearches: #('`@methodName: `@args | `@temps | self `@methodName: `@args' '`@methodName: `@args | `@temps | ^self `@methodName: `@args')
 				-> [:aNode :answer | true]

--- a/src/Refactoring2-Transformations/RBExtractMethodTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBExtractMethodTransformation.class.st
@@ -146,7 +146,7 @@ RBExtractMethodTransformation >> calculateAssignments [
 RBExtractMethodTransformation >> calculateIfReturnIsNeeded [
 
 	| searcher |
-	searcher := RBParseTreeSearcher new.
+	searcher := self parseTreeSearcher.
 	searcher
 		matches: '^self' do: [:aNode :answer | answer];
 		matches: '^`@anything' do: [:aNode :answer | true].
@@ -335,7 +335,7 @@ RBExtractMethodTransformation >> preconditions [
 				allMethodsInHierarchyOf: self definingClass)
 				reject: [ :m | m selector = selector ].
 			
-			(RBParseTreeSearcher whichMethodIn: searchSpace matches: aSubtree)
+			(self parseTreeSearcherClass whichMethodIn: searchSpace matches: aSubtree)
 				ifNotEmpty: [ :opportunities |
 					self refactoringError: ('<1s> method(s) already implement this code.<n>Do you want to send a message instead?' expandMacrosWith: opportunities size asString)
 					with: [ (RBParseTreeRewriter

--- a/src/Refactoring2-Transformations/RBTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBTransformation.class.st
@@ -189,7 +189,7 @@ RBTransformation >> options: aDictionary [
 
 { #category : #private }
 RBTransformation >> parseTreeSearcher [
-	^ RBParseTreeSearcher new
+	^ self parseTreeSearcherClass new
 ]
 
 { #category : #private }


### PR DESCRIPTION
fix: #2146
From 58 to 28 references to RBParseTreeSearcher with good name: #parseTreeSearcherClass