### PR TITLE
ExternalBrowserTest should be in a test package

### DIFF
--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -64,6 +64,7 @@ BaselineOfGeneralTests >> baseline: spec [
 			package: 'System-Settings-Tests';
 			package: 'System-Support-Tests';
 			package: 'Text-Edition-Tests';
+			package: 'Tool-ExternalBrowser-Tests';			
 			package: 'Tool-FileList-Tests';
 			package: 'Tools-Test';
 			package: 'Zinc-Resource-Meta-FileSystem';

--- a/src/Tool-ExternalBrowser-Tests/ExternalBrowserTest.class.st
+++ b/src/Tool-ExternalBrowser-Tests/ExternalBrowserTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'initialWindows',
 		'file'
 	],
-	#category : #'Tool-ExternalBrowser-Test'
+	#category : #'Tool-ExternalBrowser-Tests-Browsers'
 }
 
 { #category : #running }

--- a/src/Tool-ExternalBrowser-Tests/package.st
+++ b/src/Tool-ExternalBrowser-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Tool-ExternalBrowser-Tests' }


### PR DESCRIPTION
- add "Tool-ExternalBrowser-Tests" package
- move test class ExternalBrowserTest  into this new test package
- adopt BaselineOfGeneralTests to load the new test package

Fix #6068 