### PR TITLE
Casing in Debugger step labels should be aligned

### DIFF
--- a/src/Debugger-Actions/StepThroughDebugAction.class.st
+++ b/src/Debugger-Actions/StepThroughDebugAction.class.st
@@ -23,7 +23,7 @@ StepThroughDebugAction >> defaultKeymap [
 { #category : #accessing }
 StepThroughDebugAction >> defaultLabel [
 
-	^ 'Step Through'
+	^ 'Step through'
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- Fix #6070