### PR TITLE
Improve UITestCase

### DIFF
--- a/src/Deprecated90/UITestCase.class.st
+++ b/src/Deprecated90/UITestCase.class.st
@@ -1,0 +1,8 @@
+"
+Please use AbstractUITestCase now
+"
+Class {
+	#name : #UITestCase,
+	#superclass : #AbstractUITestCase,
+	#category : #Deprecated90
+}

--- a/src/SUnit-Support-UITesting-Tests/SimulateKeystrokesTest.class.st
+++ b/src/SUnit-Support-UITesting-Tests/SimulateKeystrokesTest.class.st
@@ -3,8 +3,8 @@ SUnit tests to simulate and test key strokes
 "
 Class {
 	#name : #SimulateKeystrokesTest,
-	#superclass : #UITestCase,
-	#category : #'SUnit-Support-UITesting-Tests'
+	#superclass : #AbstractUITestCase,
+	#category : #'SUnit-Support-UITesting-Tests-Base'
 }
 
 { #category : #tests }

--- a/src/SUnit-Support-UITesting-Tests/SimulateMouseTest.class.st
+++ b/src/SUnit-Support-UITesting-Tests/SimulateMouseTest.class.st
@@ -3,11 +3,11 @@ SUnit tests to simulate and test mouse behavior
 "
 Class {
 	#name : #SimulateMouseTest,
-	#superclass : #UITestCase,
+	#superclass : #AbstractUITestCase,
 	#instVars : [
 		'morph'
 	],
-	#category : #'SUnit-Support-UITesting-Tests'
+	#category : #'SUnit-Support-UITesting-Tests-Base'
 }
 
 { #category : #helpers }

--- a/src/SUnit-Support-UITesting/AbstractUITestCase.class.st
+++ b/src/SUnit-Support-UITesting/AbstractUITestCase.class.st
@@ -1,14 +1,20 @@
 "
-All instances of UITestCase are skipped in headless mode.
+This is an abstract superclass for all tests requiring a user interface (UI). These tests are skipped when Pharo runs in headless mode
 "
 Class {
-	#name : #UITestCase,
+	#name : #AbstractUITestCase,
 	#superclass : #TestCase,
-	#category : #'SUnit-Support-UITesting'
+	#category : #'SUnit-Support-UITesting-Base'
 }
 
+{ #category : #testing }
+AbstractUITestCase class >> isAbstract [ 
+
+	^self == AbstractUITestCase
+]
+
 { #category : #running }
-UITestCase >> runCase [
+AbstractUITestCase >> runCase [
 	| result |
 	"Skip the test if we're in headless mode"
 	self flag: 'Use skip feature once it is ready'.

--- a/src/SUnit-Support-UITesting/MenuCapturingMorph.class.st
+++ b/src/SUnit-Support-UITesting/MenuCapturingMorph.class.st
@@ -9,7 +9,7 @@ Class {
 	#instVars : [
 		'menu'
 	],
-	#category : #'SUnit-Support-UITesting'
+	#category : #'SUnit-Support-UITesting-Morphic'
 }
 
 { #category : #menu }

--- a/src/SUnit-Support-UITesting/MorphHandlingMiddleButton.class.st
+++ b/src/SUnit-Support-UITesting/MorphHandlingMiddleButton.class.st
@@ -8,7 +8,7 @@ Class {
 		'receivedBlueButtonUp',
 		'receivedBlueButtonDown'
 	],
-	#category : #'SUnit-Support-UITesting'
+	#category : #'SUnit-Support-UITesting-Morphic'
 }
 
 { #category : #'meta-actions' }

--- a/src/Tools-Test/OpenToolTest.class.st
+++ b/src/Tools-Test/OpenToolTest.class.st
@@ -3,7 +3,7 @@ SUnit tests for opening of tools
 "
 Class {
 	#name : #OpenToolTest,
-	#superclass : #UITestCase,
+	#superclass : #AbstractUITestCase,
 	#category : #'Tools-Test-Base'
 }
 


### PR DESCRIPTION
- rename the class UITestCase into AbstractUITestCase
- implement #isAbstract to return true
- tag the classes in SUnit-Support-UITesting and SUnit-Support-UITesting-Tests
- provide a better class comment
- provide a "deprecated" class UITestCase in Deprecated90 package for migration possibility (and to avoid loading problems)
- the deprecated class includes a class comment to now use AbstractUITestCase in the future

Fix #6083