### PR TITLE
Cleanups and renames in OSWindow terminology

### DIFF
--- a/src/OSWindow-Core/OSBackendWindow.class.st
+++ b/src/OSWindow-Core/OSBackendWindow.class.st
@@ -5,7 +5,7 @@ Each instance of OSWindow holds a handle, through which it communicates with und
 The implementation of OSWindowHandle (and subclasses) is highly driver-specific and therefore considered private.
 "
 Class {
-	#name : #OSWindowHandle,
+	#name : #OSBackendWindow,
 	#superclass : #Object,
 	#instVars : [
 		'osWindow',
@@ -15,186 +15,186 @@ Class {
 }
 
 { #category : #accessing }
-OSWindowHandle >> borderless [
+OSBackendWindow >> borderless [
 	^ false
 ]
 
 { #category : #accessing }
-OSWindowHandle >> borderless: aBoolean [
+OSBackendWindow >> borderless: aBoolean [
 	
 ]
 
 { #category : #accessing }
-OSWindowHandle >> bounds [
+OSBackendWindow >> bounds [
 	^ self position extent: self extent
 ]
 
 { #category : #accessing }
-OSWindowHandle >> bounds: newBounds [
+OSBackendWindow >> bounds: newBounds [
 	self subclassResponsibility 
 ]
 
 { #category : #'mouse capture' }
-OSWindowHandle >> captureMouse [
+OSBackendWindow >> captureMouse [
 ]
 
 { #category : #accessing }
-OSWindowHandle >> clipboardText [
+OSBackendWindow >> clipboardText [
 	self subclassResponsibility 
 ]
 
 { #category : #accessing }
-OSWindowHandle >> clipboardText: aString [
+OSBackendWindow >> clipboardText: aString [
 	self subclassResponsibility 
 ]
 
 { #category : #accessing }
-OSWindowHandle >> extent [
+OSBackendWindow >> extent [
 	^ self bounds extent
 ]
 
 { #category : #accessing }
-OSWindowHandle >> extent: newExtent [
+OSBackendWindow >> extent: newExtent [
 	self subclassResponsibility 
 ]
 
 { #category : #accessing }
-OSWindowHandle >> fullscreen: aBoolean [
+OSBackendWindow >> fullscreen: aBoolean [
 ]
 
 { #category : #accessing }
-OSWindowHandle >> hide [
+OSBackendWindow >> hide [
 	self subclassResponsibility 
 ]
 
 { #category : #accessing }
-OSWindowHandle >> icon: aForm [
+OSBackendWindow >> icon: aForm [
 ]
 
 { #category : #'text input' }
-OSWindowHandle >> isTextInputActive [
+OSBackendWindow >> isTextInputActive [
 	^ self subclassResponsibility
 ]
 
 { #category : #testing }
-OSWindowHandle >> isValid [
+OSBackendWindow >> isValid [
 	self subclassResponsibility 
 ]
 
 { #category : #factory }
-OSWindowHandle >> newAthensRenderer [
+OSBackendWindow >> newAthensRenderer [
 	self subclassResponsibility
 ]
 
 { #category : #factory }
-OSWindowHandle >> newFormRenderer: aForm [
+OSBackendWindow >> newFormRenderer: aForm [
 	self subclassResponsibility
 ]
 
 { #category : #factory }
-OSWindowHandle >> newGenericRenderer [
+OSBackendWindow >> newGenericRenderer [
 	self subclassResponsibility
 ]
 
 { #category : #factory }
-OSWindowHandle >> newOpenGLRenderer [
+OSBackendWindow >> newOpenGLRenderer [
 	self subclassResponsibility
 ]
 
 { #category : #accessing }
-OSWindowHandle >> osWindow [
+OSBackendWindow >> osWindow [
 	
 	^ osWindow
 ]
 
 { #category : #accessing }
-OSWindowHandle >> osWindow: anObject [
+OSBackendWindow >> osWindow: anObject [
 	
 	osWindow := anObject
 ]
 
 { #category : #accessing }
-OSWindowHandle >> platformSpecificHandle [
+OSBackendWindow >> platformSpecificHandle [
 	self subclassResponsibility
 ]
 
 { #category : #accessing }
-OSWindowHandle >> position [
+OSBackendWindow >> position [
 	^ self subclassResponsibility
 ]
 
 { #category : #accessing }
-OSWindowHandle >> position: newPosition [
+OSBackendWindow >> position: newPosition [
 	self subclassResponsibility 
 ]
 
 { #category : #accessing }
-OSWindowHandle >> prepareExternalResourceForAutoRelease [
+OSBackendWindow >> prepareExternalResourceForAutoRelease [
 	"This hook will allow just create handlers to prepate their external resources for being 
 	 releases by the GC (if needed). By default, do nothing."
 ]
 
 { #category : #'mouse capture' }
-OSWindowHandle >> releaseMouse [
+OSBackendWindow >> releaseMouse [
 ]
 
 { #category : #accessing }
-OSWindowHandle >> renderer [
+OSBackendWindow >> renderer [
 	
 	^ renderer
 ]
 
 { #category : #accessing }
-OSWindowHandle >> renderer: anObject [
+OSBackendWindow >> renderer: anObject [
 	
 	renderer := anObject
 ]
 
 { #category : #accessing }
-OSWindowHandle >> resizable [
+OSBackendWindow >> resizable [
 	^ true
 ]
 
 { #category : #accessing }
-OSWindowHandle >> resizable: aBoolean [
+OSBackendWindow >> resizable: aBoolean [
 	
 ]
 
 { #category : #cursor }
-OSWindowHandle >> setMouseCursor: cursorWithMask [
+OSBackendWindow >> setMouseCursor: cursorWithMask [
 	self setMouseCursor: cursorWithMask mask: cursorWithMask maskForm
 ]
 
 { #category : #accessing }
-OSWindowHandle >> setMouseCursor: cursor mask: mask [
+OSBackendWindow >> setMouseCursor: cursor mask: mask [
 ]
 
 { #category : #accessing }
-OSWindowHandle >> show [
+OSBackendWindow >> show [
 	self subclassResponsibility 
 ]
 
 { #category : #'text input' }
-OSWindowHandle >> startTextInput [
+OSBackendWindow >> startTextInput [
 	self subclassResponsibility
 ]
 
 { #category : #'text input' }
-OSWindowHandle >> stopTextInput [
+OSBackendWindow >> stopTextInput [
 	self subclassResponsibility
 ]
 
 { #category : #accessing }
-OSWindowHandle >> title [
+OSBackendWindow >> title [
 	self subclassResponsibility 
 ]
 
 { #category : #accessing }
-OSWindowHandle >> title: aTitle [
+OSBackendWindow >> title: aTitle [
 	self subclassResponsibility 
 ]
 
 { #category : #accessing }
-OSWindowHandle >> windowId [
+OSBackendWindow >> windowId [
 	^ nil
 ]

--- a/src/OSWindow-Core/OSNullBackendWindow.class.st
+++ b/src/OSWindow-Core/OSNullBackendWindow.class.st
@@ -2,8 +2,8 @@
 i am a handle for null window , created using OSNullWindowDriver.
 "
 Class {
-	#name : #OSNullWindowHandle,
-	#superclass : #OSWindowHandle,
+	#name : #OSNullBackendWindow,
+	#superclass : #OSBackendWindow,
 	#instVars : [
 		'attributes',
 		'isTextInputActive'
@@ -12,108 +12,108 @@ Class {
 }
 
 { #category : #'as yet unclassified' }
-OSNullWindowHandle class >> fromAttributes: attributes for: anOSWindow [ 
+OSNullBackendWindow class >> fromAttributes: attributes for: anOSWindow [ 
 	^ self new attributes: attributes
 ]
 
 { #category : #accessing }
-OSNullWindowHandle >> attributes: newAttributes [
+OSNullBackendWindow >> attributes: newAttributes [
 	attributes := newAttributes
 ]
 
 { #category : #accessing }
-OSNullWindowHandle >> bounds: aRectangle [
+OSNullBackendWindow >> bounds: aRectangle [
 ]
 
 { #category : #accessing }
-OSNullWindowHandle >> clipboardText [
+OSNullBackendWindow >> clipboardText [
 	^ ''
 ]
 
 { #category : #accessing }
-OSNullWindowHandle >> clipboardText: anObject [
+OSNullBackendWindow >> clipboardText: anObject [
 
 ]
 
 { #category : #initialize }
-OSNullWindowHandle >> destroy [
+OSNullBackendWindow >> destroy [
 ]
 
 { #category : #accessing }
-OSNullWindowHandle >> extent [
+OSNullBackendWindow >> extent [
 	^ attributes extent
 ]
 
 { #category : #accessing }
-OSNullWindowHandle >> extent: newExtent [
+OSNullBackendWindow >> extent: newExtent [
 	attributes extent: newExtent
 ]
 
 { #category : #accessing }
-OSNullWindowHandle >> hide [
+OSNullBackendWindow >> hide [
 ]
 
 { #category : #initialization }
-OSNullWindowHandle >> initialize [
+OSNullBackendWindow >> initialize [
 	super initialize.
 	
 	isTextInputActive := false
 ]
 
 { #category : #'text input' }
-OSNullWindowHandle >> isTextInputActive [
+OSNullBackendWindow >> isTextInputActive [
 	^ isTextInputActive
 ]
 
 { #category : #accessing }
-OSNullWindowHandle >> isValid [
+OSNullBackendWindow >> isValid [
 	^ true
 ]
 
 { #category : #factory }
-OSNullWindowHandle >> newFormRenderer: form [
+OSNullBackendWindow >> newFormRenderer: form [
 	^ renderer := OSNullFormRenderer new form: form
 ]
 
 { #category : #factory }
-OSNullWindowHandle >> newGenericRenderer [
+OSNullBackendWindow >> newGenericRenderer [
 	^ renderer := OSWindowNullGenericRenderer new
 ]
 
 { #category : #accessing }
-OSNullWindowHandle >> platformSpecificHandle [
+OSNullBackendWindow >> platformSpecificHandle [
 	^ nil
 ]
 
 { #category : #accessing }
-OSNullWindowHandle >> position [
+OSNullBackendWindow >> position [
 	^ attributes position
 ]
 
 { #category : #accessing }
-OSNullWindowHandle >> position: position [
+OSNullBackendWindow >> position: position [
 	attributes position: position
 ]
 
 { #category : #accessing }
-OSNullWindowHandle >> show [
+OSNullBackendWindow >> show [
 ]
 
 { #category : #'text input' }
-OSNullWindowHandle >> startTextInput [
+OSNullBackendWindow >> startTextInput [
 	isTextInputActive := true
 ]
 
 { #category : #'text input' }
-OSNullWindowHandle >> stopTextInput [
+OSNullBackendWindow >> stopTextInput [
 	isTextInputActive := false
 ]
 
 { #category : #accessing }
-OSNullWindowHandle >> title [
+OSNullBackendWindow >> title [
 	^attributes title
 ]
 
 { #category : #accessing }
-OSNullWindowHandle >> title: anObject [
+OSNullBackendWindow >> title: anObject [
 ]

--- a/src/OSWindow-Core/OSNullWindowDriver.class.st
+++ b/src/OSWindow-Core/OSNullWindowDriver.class.st
@@ -20,7 +20,7 @@ OSNullWindowDriver class >> isSupported [
 
 { #category : #'window creation' }
 OSNullWindowDriver >> createWindowWithAttributes: anOSWindowAttributes osWindow: osWindow [
-	^ OSNullWindowHandle fromAttributes: anOSWindowAttributes for: osWindow
+	^ OSNullBackendWindow fromAttributes: anOSWindowAttributes for: osWindow
 ]
 
 { #category : #testing }

--- a/src/OSWindow-Core/OSWindow.class.st
+++ b/src/OSWindow-Core/OSWindow.class.st
@@ -216,11 +216,6 @@ OSWindow >> getFlags [
 	^ self validHandle getFlags
 ]
 
-{ #category : #accessing }
-OSWindow >> handle [
-	^ backendWindow
-]
-
 { #category : #visibility }
 OSWindow >> hide [
 	self checkIsValid .

--- a/src/OSWindow-Core/OSWindow.class.st
+++ b/src/OSWindow-Core/OSWindow.class.st
@@ -43,10 +43,10 @@ Class {
 	#name : #OSWindow,
 	#superclass : #Object,
 	#instVars : [
-		'handle',
 		'initialAttributes',
 		'eventHandler',
-		'currentCursor'
+		'currentCursor',
+		'backendWindow'
 	],
 	#classVars : [
 		'TraceEvents',
@@ -96,6 +96,11 @@ OSWindow class >> traceEvents: aBoolean [
 ]
 
 { #category : #accessing }
+OSWindow >> backendWindow [
+	^ backendWindow
+]
+
+{ #category : #accessing }
 OSWindow >> borderless [
 	^ self validHandle borderless
 ]
@@ -123,7 +128,7 @@ OSWindow >> captureMouse [
 { #category : #private }
 OSWindow >> checkIsValid [
 
-	(handle isNil or: [ handle isValid not ]) ifTrue: [ self invalidHandle ].
+	(backendWindow isNil or: [ backendWindow isValid not ]) ifTrue: [ self invalidHandle ].
 ]
 
 { #category : #'clipboard handling' }
@@ -138,13 +143,13 @@ OSWindow >> clipboardText: aString [
 
 { #category : #private }
 OSWindow >> createWindow [
-	handle ifNotNil: [ self error: 'The window is already created.' ].
+	backendWindow ifNotNil: [ self error: 'The window is already created.' ].
 	
-	handle := initialAttributes createWindowHandleFor: self.
-	handle isValid ifTrue: [ 
+	backendWindow := initialAttributes createWindowHandleFor: self.
+	backendWindow isValid ifTrue: [ 
 		"Handle here points to an OSWindowHandle, its #handle message has the real 
 		 external resource. This is a bit confusing, but is better like this :)"
-		handle prepareExternalResourceForAutoRelease ]
+		backendWindow prepareExternalResourceForAutoRelease ]
 ]
 
 { #category : #'dispatching events' }
@@ -169,7 +174,7 @@ OSWindow >> deliverGlobalEvent: aGlobalEvent [
 { #category : #private }
 OSWindow >> destroy [
 	self validHandle destroy.
-	handle := nil.
+	backendWindow := nil.
 	eventHandler := nil.
 ]
 
@@ -213,13 +218,13 @@ OSWindow >> getFlags [
 
 { #category : #accessing }
 OSWindow >> handle [
-	^ handle
+	^ backendWindow
 ]
 
 { #category : #visibility }
 OSWindow >> hide [
 	self checkIsValid .
-	handle hide
+	backendWindow hide
 ]
 
 { #category : #accessing }
@@ -250,12 +255,12 @@ OSWindow >> isTextInputActive [
 
 { #category : #testing }
 OSWindow >> isValid [
-	 ^ handle notNil and: [ handle isValid ]
+	 ^ backendWindow notNil and: [ backendWindow isValid ]
 ]
 
 { #category : #testing }
 OSWindow >> isVisible [
-	^ self isValid and: [handle isVisible]
+	^ self isValid and: [backendWindow isVisible]
 ]
 
 { #category : #'window management' }
@@ -272,22 +277,22 @@ OSWindow >> minimize [
 
 { #category : #'instance creation' }
 OSWindow >> newAthensRenderer [
-	^ handle newAthensRenderer
+	^ backendWindow newAthensRenderer
 ]
 
 { #category : #factory }
 OSWindow >> newFormRenderer: form [
-	^ handle newFormRenderer: form
+	^ backendWindow newFormRenderer: form
 ]
 
 { #category : #factory }
 OSWindow >> newGenericRenderer [
-	^ handle newGenericRenderer
+	^ backendWindow newGenericRenderer
 ]
 
 { #category : #factory }
 OSWindow >> newOpenGLRenderer [
-	^ handle newOpenGLRenderer
+	^ backendWindow newOpenGLRenderer
 ]
 
 { #category : #accessing }
@@ -307,7 +312,7 @@ OSWindow >> position: newPosition [
 
 { #category : #'event handling' }
 OSWindow >> processPendingEvents [
-	handle processPendingEvents
+	backendWindow processPendingEvents
 ]
 
 { #category : #'mouse capture' }
@@ -317,12 +322,12 @@ OSWindow >> releaseMouse [
 
 { #category : #accessing }
 OSWindow >> renderer [
-	^ handle renderer
+	^ backendWindow renderer
 ]
 
 { #category : #accessing }
 OSWindow >> renderer: aRenderer [
-	handle renderer: aRenderer
+	backendWindow renderer: aRenderer
 ]
 
 { #category : #accessing }
@@ -350,7 +355,7 @@ OSWindow >> setDraggableArea: aRectangle [
 { #category : #private }
 OSWindow >> setJustCreatedHandle: aHandle [
 	"This method is to be called by a driver that needs to create the window in a critical section to prevent a race condition where some events such as expose could be missed."
-	handle := aHandle
+	backendWindow := aHandle
 ]
 
 { #category : #accessing }
@@ -371,7 +376,7 @@ OSWindow >> setMouseCursor: cursor mask: mask [
 { #category : #visibility }
 OSWindow >> show [
 	self checkIsValid .
-	handle show
+	backendWindow show
 ]
 
 { #category : #'text input' }
@@ -416,7 +421,7 @@ OSWindow >> toggleBorderOn [
 { #category : #private }
 OSWindow >> validHandle [
 	self checkIsValid.
-	^ handle
+	^ backendWindow
 ]
 
 { #category : #accessing }

--- a/src/OSWindow-Core/OSWindowGLRenderer.class.st
+++ b/src/OSWindow-Core/OSWindowGLRenderer.class.st
@@ -18,7 +18,7 @@ OSWindowGLRenderer >> asCurrentDo: aBlock [
 
 { #category : #'context activation' }
 OSWindowGLRenderer >> asCurrentDo: aBlock ifFailure: aFailureBlock [
-	^ self withWindow: window do: aBlock ifFailure: aFailureBlock
+	^ self withWindow: backendWindow do: aBlock ifFailure: aFailureBlock
 ]
 
 { #category : #misc }
@@ -29,7 +29,7 @@ OSWindowGLRenderer >> getProcAddress: procName [
 
 { #category : #misc }
 OSWindowGLRenderer >> makeCurrent [
-	^ self makeCurrent: window
+	^ self makeCurrent: backendWindow
 ]
 
 { #category : #misc }
@@ -39,7 +39,7 @@ OSWindowGLRenderer >> makeCurrent: aWindow [
 
 { #category : #misc }
 OSWindowGLRenderer >> swapBuffers [
-	^ self swapBuffers: window
+	^ self swapBuffers: backendWindow
 ]
 
 { #category : #misc }

--- a/src/OSWindow-Core/OSWindowRenderer.class.st
+++ b/src/OSWindow-Core/OSWindowRenderer.class.st
@@ -7,8 +7,8 @@ Class {
 	#name : #OSWindowRenderer,
 	#superclass : #Object,
 	#instVars : [
-		'window',
-		'lastExposeTime'
+		'lastExposeTime',
+		'backendWindow'
 	],
 	#category : #'OSWindow-Core-Renderer'
 }
@@ -16,7 +16,7 @@ Class {
 { #category : #deleting }
 OSWindowRenderer >> destroy [
 	"Called when the window associated with the renderer is destroyed"
-	window := nil.
+	backendWindow := nil.
 ]
 
 { #category : #'updating screen' }
@@ -79,11 +79,11 @@ OSWindowRenderer >> updateRectangles: aCollectionOfRectangles [
 { #category : #accessing }
 OSWindowRenderer >> window [
 	
-	^ window
+	^ backendWindow
 ]
 
 { #category : #accessing }
 OSWindowRenderer >> window: anObject [
 	
-	window := anObject
+	backendWindow := anObject
 ]

--- a/src/OSWindow-Core/OSWindowRenderer.class.st
+++ b/src/OSWindow-Core/OSWindowRenderer.class.st
@@ -13,6 +13,12 @@ Class {
 	#category : #'OSWindow-Core-Renderer'
 }
 
+{ #category : #accessing }
+OSWindowRenderer >> backendWindow: anObject [
+	
+	backendWindow := anObject
+]
+
 { #category : #deleting }
 OSWindowRenderer >> destroy [
 	"Called when the window associated with the renderer is destroyed"
@@ -74,16 +80,4 @@ OSWindowRenderer >> updateRectangle: rectangle [
 { #category : #'updating screen' }
 OSWindowRenderer >> updateRectangles: aCollectionOfRectangles [
 	aCollectionOfRectangles do: [ :rectangle | self updateRectangle: rectangle ]
-]
-
-{ #category : #accessing }
-OSWindowRenderer >> window [
-	
-	^ backendWindow
-]
-
-{ #category : #accessing }
-OSWindowRenderer >> window: anObject [
-	
-	backendWindow := anObject
 ]

--- a/src/OSWindow-SDL2/OSSDL2AthensRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2AthensRenderer.class.st
@@ -49,9 +49,9 @@ OSSDL2AthensRenderer >> destroy [
 ]
 
 { #category : #initialization }
-OSSDL2AthensRenderer >> initializeWindowHandle: aWindowHandle [ 
+OSSDL2AthensRenderer >> initializeWindowHandle: aBackendWindow [ 
 	self initialize.
-	self window: aWindowHandle.
+	self backendWindow: aBackendWindow.
 	renderer := backendWindow sdl2Window createDefaultRenderer.
 	self resetResources.
 	
@@ -81,7 +81,7 @@ OSSDL2AthensRenderer >> primitiveUpdateRectangle: rectangle externalForm: extern
 OSSDL2AthensRenderer >> resetResources [
 	| extent |
 	self checkSession.
-	extent := self window extent.
+	extent := backendWindow extent.
 	self createSDLSurfaceWithExtent: extent.
 	athensSurface := AthensCairoSDLSurface fromSDLSurface: sdlSurface.
 	texture := renderer 

--- a/src/OSWindow-SDL2/OSSDL2AthensRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2AthensRenderer.class.st
@@ -52,7 +52,7 @@ OSSDL2AthensRenderer >> destroy [
 OSSDL2AthensRenderer >> initializeWindowHandle: aWindowHandle [ 
 	self initialize.
 	self window: aWindowHandle.
-	renderer := window handle createDefaultRenderer.
+	renderer := backendWindow handle createDefaultRenderer.
 	self resetResources.
 	
 		
@@ -60,7 +60,7 @@ OSSDL2AthensRenderer >> initializeWindowHandle: aWindowHandle [
 
 { #category : #drawing }
 OSSDL2AthensRenderer >> prepareForDrawing [
-	textureExtent ~= window extent ifTrue: [ self resized ].
+	textureExtent ~= backendWindow extent ifTrue: [ self resized ].
 ]
 
 { #category : #'updating screen' }
@@ -146,7 +146,7 @@ OSSDL2AthensRenderer >> updateRectangles: allDamage [
 		externalForm := OSSDL2ExternalForm extent: textureExtent depth: 32 bits: pixels.
 		allDamage do: [ :rectangle |
 			intersection := rectangle
-				intersect: (0 @ 0 corner: window extent)
+				intersect: (0 @ 0 corner: backendWindow extent)
 				ifNone: [ nil ].
 		
 			intersection ifNotNil: [
@@ -164,6 +164,6 @@ OSSDL2AthensRenderer >> updateRectangles: allDamage [
 OSSDL2AthensRenderer >> validate [
 	self checkSession.
 	(texture isNil or: [ texture isNull ]) ifTrue: [ ^ false ].	
-	window extent ~= textureExtent ifTrue: [ ^ false ].
+	backendWindow extent ~= textureExtent ifTrue: [ ^ false ].
 	^ true
 ]

--- a/src/OSWindow-SDL2/OSSDL2AthensRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2AthensRenderer.class.st
@@ -52,7 +52,7 @@ OSSDL2AthensRenderer >> destroy [
 OSSDL2AthensRenderer >> initializeWindowHandle: aWindowHandle [ 
 	self initialize.
 	self window: aWindowHandle.
-	renderer := backendWindow handle createDefaultRenderer.
+	renderer := backendWindow sdl2Window createDefaultRenderer.
 	self resetResources.
 	
 		

--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -4,8 +4,8 @@ I am the OSWindowHandle interface implemented using SDL2 library
 my handle is an SDL_Window
 "
 Class {
-	#name : #OSSDL2WindowHandle,
-	#superclass : #OSWindowHandle,
+	#name : #OSSDL2BackendWindow,
+	#superclass : #OSBackendWindow,
 	#instVars : [
 		'handle',
 		'currentCursor',
@@ -19,43 +19,43 @@ Class {
 }
 
 { #category : #'instance creation' }
-OSSDL2WindowHandle class >> newWithHandle: handle attributes: attributes [
+OSSDL2BackendWindow class >> newWithHandle: handle attributes: attributes [
 	^ self basicNew initWithHandle: handle attributes: attributes; yourself
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> borderless [
+OSSDL2BackendWindow >> borderless [
 	^ handle getFlags anyMask: SDL_WINDOW_BORDERLESS
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> borderless: aBoolean [
+OSSDL2BackendWindow >> borderless: aBoolean [
 	handle toggleBorder: aBoolean not.
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> bounds: newBounds [
+OSSDL2BackendWindow >> bounds: newBounds [
 	self position: newBounds origin;
 		extent: newBounds extent.
 ]
 
 { #category : #'mouse capture' }
-OSSDL2WindowHandle >> captureMouse [
+OSSDL2BackendWindow >> captureMouse [
 	SDL2 setRelativeMouseMode: true
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> clipboardText [
+OSSDL2BackendWindow >> clipboardText [
 	^ SDL2 clipboardText
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> clipboardText: aText [
+OSSDL2BackendWindow >> clipboardText: aText [
 	SDL2 clipboardText: aText
 ]
 
 { #category : #'event handling' }
-OSSDL2WindowHandle >> convertButtonState: mouseState modState: modState modifiers: modifiers [
+OSSDL2BackendWindow >> convertButtonState: mouseState modState: modState modifiers: modifiers [
 	| shift ctrl alt ralt gui |
 	modifiers buttons button1: (mouseState bitAnd: SDL_BUTTON_LMASK) ~= 0.
 	modifiers buttons button2: (mouseState bitAnd: SDL_BUTTON_MMASK) ~= 0.
@@ -84,7 +84,7 @@ OSSDL2WindowHandle >> convertButtonState: mouseState modState: modState modifier
 ]
 
 { #category : #private }
-OSSDL2WindowHandle >> convertCursor: aCursor [
+OSSDL2BackendWindow >> convertCursor: aCursor [
 	| result bits|
 	aCursor unhibernate.
 	bits := aCursor bits.
@@ -97,12 +97,12 @@ OSSDL2WindowHandle >> convertCursor: aCursor [
 ]
 
 { #category : #'event handling' }
-OSSDL2WindowHandle >> deliverGlobalEvent: aGlobalEvent [
+OSSDL2BackendWindow >> deliverGlobalEvent: aGlobalEvent [
 	^ osWindow deliverGlobalEvent: aGlobalEvent
 ]
 
 { #category : #initialize }
-OSSDL2WindowHandle >> destroy [
+OSSDL2BackendWindow >> destroy [
 
 	handle ifNotNil: [ :validHandle | 
 		OSSDL2Driver current unregisterWindowWithId: validHandle windowID.
@@ -114,7 +114,7 @@ OSSDL2WindowHandle >> destroy [
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> extent [
+OSSDL2BackendWindow >> extent [
 	| w h |
 	w := ByteArray new: 4.
 	h := ByteArray new: 4.
@@ -123,12 +123,12 @@ OSSDL2WindowHandle >> extent [
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> extent: newExtent [
+OSSDL2BackendWindow >> extent: newExtent [
 	handle setSizeW: newExtent x h: newExtent y
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> fullscreen: aBoolean [
+OSSDL2BackendWindow >> fullscreen: aBoolean [
 	aBoolean ifTrue: [
 		handle fullscreen: SDL_WINDOW_FULLSCREEN_DESKTOP
 	] ifFalse: [ 
@@ -137,12 +137,12 @@ OSSDL2WindowHandle >> fullscreen: aBoolean [
 ]
 
 { #category : #private }
-OSSDL2WindowHandle >> getFlags [
+OSSDL2BackendWindow >> getFlags [
 	^ handle getFlags
 ]
 
 { #category : #private }
-OSSDL2WindowHandle >> getWMInfo [
+OSSDL2BackendWindow >> getWMInfo [
 	| wmInfo |
 	wmInfo := SDL_SysWMinfo new version: SDL_Version bindingVersion.
 	handle getWMInfo: wmInfo.
@@ -150,23 +150,23 @@ OSSDL2WindowHandle >> getWMInfo [
 ]
 
 { #category : #initialize }
-OSSDL2WindowHandle >> handle [
+OSSDL2BackendWindow >> handle [
 
 	^ handle
 ]
 
 { #category : #'event handling' }
-OSSDL2WindowHandle >> handleNewSDLEvent: sdlEvent [
+OSSDL2BackendWindow >> handleNewSDLEvent: sdlEvent [
 	^ sdlEvent accept: self
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> hide [
+OSSDL2BackendWindow >> hide [
 	handle hide
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> icon: aForm [
+OSSDL2BackendWindow >> icon: aForm [
 	| convertedIcon surface |
 	aForm ifNil: [ ^self ].
 	
@@ -184,54 +184,54 @@ OSSDL2WindowHandle >> icon: aForm [
 ]
 
 { #category : #initialize }
-OSSDL2WindowHandle >> initWithHandle: aHandle attributes: attributes [
+OSSDL2BackendWindow >> initWithHandle: aHandle attributes: attributes [
 	handle := aHandle.
 	attributes applyTo: self
 ]
 
 { #category : #initialization }
-OSSDL2WindowHandle >> initialize [
+OSSDL2BackendWindow >> initialize [
 	
 	self class initializeSlots: self.
 	super initialize.
 ]
 
 { #category : #'text input' }
-OSSDL2WindowHandle >> isTextInputActive [
+OSSDL2BackendWindow >> isTextInputActive [
 	"See https://wiki.libsdl.org/SDL_IsTextInputActive"
 
 	^ handle isTextInputActive
 ]
 
 { #category : #testing }
-OSSDL2WindowHandle >> isValid [
+OSSDL2BackendWindow >> isValid [
 	^ true
 ]
 
 { #category : #testing }
-OSSDL2WindowHandle >> isVisible [
+OSSDL2BackendWindow >> isVisible [
 	^ (self getFlags bitAnd: SDL_WINDOW_SHOWN) = SDL_WINDOW_SHOWN
 ]
 
 { #category : #'event handling' }
-OSSDL2WindowHandle >> mapSpecialCharacter: symbol [
+OSSDL2BackendWindow >> mapSpecialCharacter: symbol [
 	^ SDL2SpecialCharacterMapping mapKeySymbol: symbol ifAbsent: [ ^ nil ]
 ]
 
 { #category : #'window management' }
-OSSDL2WindowHandle >> maximize [
+OSSDL2BackendWindow >> maximize [
 
 	handle maximize.
 ]
 
 { #category : #'window management' }
-OSSDL2WindowHandle >> minimize [
+OSSDL2BackendWindow >> minimize [
 
 	handle minimize.
 ]
 
 { #category : #'event handling' }
-OSSDL2WindowHandle >> mousePosition [
+OSSDL2BackendWindow >> mousePosition [
 	| x y |
 	x := ByteArray new: 4.
 	y := ByteArray new: 4.
@@ -240,12 +240,12 @@ OSSDL2WindowHandle >> mousePosition [
 ]
 
 { #category : #'instance creation' }
-OSSDL2WindowHandle >> newAthensRenderer [
+OSSDL2BackendWindow >> newAthensRenderer [
 	^ renderer := OSSDL2AthensRenderer for: self.
 ]
 
 { #category : #'instance creation' }
-OSSDL2WindowHandle >> newFormRenderer: form [
+OSSDL2BackendWindow >> newFormRenderer: form [
 	^ renderer := OSSDL2FormRenderer new 
 		form: form;
 		window: self;
@@ -253,7 +253,7 @@ OSSDL2WindowHandle >> newFormRenderer: form [
 ]
 
 { #category : #'instance creation' }
-OSSDL2WindowHandle >> newGenericRenderer [
+OSSDL2BackendWindow >> newGenericRenderer [
 	^ renderer := OSSDL2GenericRenderer new 
 		window: self;
 		createSDL2Renderer;
@@ -261,7 +261,7 @@ OSSDL2WindowHandle >> newGenericRenderer [
 ]
 
 { #category : #'instance creation' }
-OSSDL2WindowHandle >> newOpenGLRenderer [
+OSSDL2BackendWindow >> newOpenGLRenderer [
 	^ renderer := OSSDL2GLRenderer new 
 		window: self;
 		createContext;
@@ -269,7 +269,7 @@ OSSDL2WindowHandle >> newOpenGLRenderer [
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> platformSpecificHandle [
+OSSDL2BackendWindow >> platformSpecificHandle [
 	| wmInfo platformID |
 	wmInfo := self getWMInfo.
 	platformID := wmInfo subsystem.
@@ -287,7 +287,7 @@ OSSDL2WindowHandle >> platformSpecificHandle [
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> position [
+OSSDL2BackendWindow >> position [
 	| x y |
 	x := ByteArray new: ExternalType long byteSize.
 	y := ByteArray new: ExternalType long byteSize.
@@ -296,44 +296,44 @@ OSSDL2WindowHandle >> position [
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> position: aPoint [
+OSSDL2BackendWindow >> position: aPoint [
 	handle setPositionX: aPoint x asInteger y: aPoint y asInteger
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> prepareExternalResourceForAutoRelease [
+OSSDL2BackendWindow >> prepareExternalResourceForAutoRelease [
 	handle autoRelease
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> raise [
+OSSDL2BackendWindow >> raise [
 
 	handle raise
 ]
 
 { #category : #'mouse capture' }
-OSSDL2WindowHandle >> releaseMouse [
+OSSDL2BackendWindow >> releaseMouse [
 	SDL2 setRelativeMouseMode: false
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> resizable [
+OSSDL2BackendWindow >> resizable [
 	^ handle getFlags anyMask: SDL_WINDOW_RESIZABLE
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> resizable: aBoolean [
+OSSDL2BackendWindow >> resizable: aBoolean [
 	"This is not supported."
 ]
 
 { #category : #'window management' }
-OSSDL2WindowHandle >> restore [
+OSSDL2BackendWindow >> restore [
 
 	handle restore
 ]
 
 { #category : #'window management' }
-OSSDL2WindowHandle >> setDraggableArea: aRectangle [
+OSSDL2BackendWindow >> setDraggableArea: aRectangle [
 
 	| myCallback sdlRect |
 	
@@ -347,7 +347,7 @@ OSSDL2WindowHandle >> setDraggableArea: aRectangle [
 ]
 
 { #category : #cursor }
-OSSDL2WindowHandle >> setMouseCursor: cursor mask: mask [
+OSSDL2BackendWindow >> setMouseCursor: cursor mask: mask [
 	| cursorBits maskBits extent offset sdlCursor |
 	cursorBits := self convertCursor: cursor.
 	maskBits := self convertCursor: mask.
@@ -360,53 +360,53 @@ OSSDL2WindowHandle >> setMouseCursor: cursor mask: mask [
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> show [
+OSSDL2BackendWindow >> show [
 	handle show
 ]
 
 { #category : #cursor }
-OSSDL2WindowHandle >> showCursor: aBoolean [
+OSSDL2BackendWindow >> showCursor: aBoolean [
 	SDL2 showCursor: (aBoolean ifTrue: [SDL_ENABLE] ifFalse: [SDL_DISABLE]).
 ]
 
 { #category : #'text input' }
-OSSDL2WindowHandle >> startTextInput [
+OSSDL2BackendWindow >> startTextInput [
 	"See https://wiki.libsdl.org/SDL_StartTextInput"
 
 	handle startTextInput
 ]
 
 { #category : #'text input' }
-OSSDL2WindowHandle >> stopTextInput [
+OSSDL2BackendWindow >> stopTextInput [
 	"See https://wiki.libsdl.org/SDL_StopTextInput"
 
 	handle stopTextInput
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> title [
+OSSDL2BackendWindow >> title [
 	^ handle title
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> title: aTitle [
+OSSDL2BackendWindow >> title: aTitle [
 	handle title: aTitle
 ]
 
 { #category : #'window management' }
-OSSDL2WindowHandle >> toggleBorderOff [
+OSSDL2BackendWindow >> toggleBorderOff [
 
 	handle toggleBorder: false.
 ]
 
 { #category : #'window management' }
-OSSDL2WindowHandle >> toggleBorderOn [
+OSSDL2BackendWindow >> toggleBorderOn [
 
 	handle toggleBorder: true.
 ]
 
 { #category : #'event handling' }
-OSSDL2WindowHandle >> visitKeyDownEvent: event [
+OSSDL2BackendWindow >> visitKeyDownEvent: event [
 	| osEvent keysym |
 	keysym := event keysym.
 	osEvent := OSKeyDownEvent for: osWindow.
@@ -421,7 +421,7 @@ OSSDL2WindowHandle >> visitKeyDownEvent: event [
 ]
 
 { #category : #'event handling' }
-OSSDL2WindowHandle >> visitKeyUpEvent: event [
+OSSDL2BackendWindow >> visitKeyUpEvent: event [
 	| osEvent keysym |
 	keysym := event keysym.
 	osEvent := OSKeyUpEvent for: osWindow.
@@ -435,7 +435,7 @@ OSSDL2WindowHandle >> visitKeyUpEvent: event [
 ]
 
 { #category : #'event handling' }
-OSSDL2WindowHandle >> visitMouseButtonDownEvent: event [
+OSSDL2BackendWindow >> visitMouseButtonDownEvent: event [
 	| osEvent |
 	osEvent := OSMouseButtonPressEvent for: osWindow.
 	osEvent button: event button;
@@ -446,7 +446,7 @@ OSSDL2WindowHandle >> visitMouseButtonDownEvent: event [
 ]
 
 { #category : #'event handling' }
-OSSDL2WindowHandle >> visitMouseButtonUpEvent: event [
+OSSDL2BackendWindow >> visitMouseButtonUpEvent: event [
 	| osEvent |
 	osEvent := OSMouseButtonReleaseEvent for: osWindow.
 	osEvent button: event button;
@@ -457,7 +457,7 @@ OSSDL2WindowHandle >> visitMouseButtonUpEvent: event [
 ]
 
 { #category : #'event handling' }
-OSSDL2WindowHandle >> visitMouseMotionEvent: sdlEvent [
+OSSDL2BackendWindow >> visitMouseMotionEvent: sdlEvent [
 	| osEvent |
 	osEvent := OSMouseMoveEvent for: osWindow.
 	osEvent position: sdlEvent x @ sdlEvent y;
@@ -468,7 +468,7 @@ OSSDL2WindowHandle >> visitMouseMotionEvent: sdlEvent [
 ]
 
 { #category : #'event handling' }
-OSSDL2WindowHandle >> visitMouseWheelEvent: sdlEvent [
+OSSDL2BackendWindow >> visitMouseWheelEvent: sdlEvent [
 	| osEvent |
 	osEvent := OSMouseWheelEvent for: osWindow.
 	osEvent position: self mousePosition;
@@ -480,7 +480,7 @@ OSSDL2WindowHandle >> visitMouseWheelEvent: sdlEvent [
 ]
 
 { #category : #'event handling' }
-OSSDL2WindowHandle >> visitTextInputEvent: event [
+OSSDL2BackendWindow >> visitTextInputEvent: event [
 	| osEvent |
 	
 	osEvent := OSTextInputEvent for: osWindow.
@@ -492,7 +492,7 @@ OSSDL2WindowHandle >> visitTextInputEvent: event [
 ]
 
 { #category : #'event handling' }
-OSSDL2WindowHandle >> visitWindowEvent: windowEvent [
+OSSDL2BackendWindow >> visitWindowEvent: windowEvent [
 	osWindow ifNil: [ ^self ].
 	
 	windowEvent event = SDL_WINDOWEVENT_EXPOSED ifTrue: [
@@ -525,6 +525,6 @@ OSSDL2WindowHandle >> visitWindowEvent: windowEvent [
 ]
 
 { #category : #accessing }
-OSSDL2WindowHandle >> windowId [
+OSSDL2BackendWindow >> windowId [
 	^ self handle windowID
 ]

--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -149,12 +149,6 @@ OSSDL2BackendWindow >> getWMInfo [
 	^ wmInfo
 ]
 
-{ #category : #initialize }
-OSSDL2BackendWindow >> handle [
-
-	^ sdl2Window
-]
-
 { #category : #'event handling' }
 OSSDL2BackendWindow >> handleNewSDLEvent: sdlEvent [
 	^ sdlEvent accept: self

--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -532,5 +532,5 @@ OSSDL2BackendWindow >> visitWindowEvent: windowEvent [
 
 { #category : #accessing }
 OSSDL2BackendWindow >> windowId [
-	^ self handle windowID
+	^ self sdl2Window windowID
 ]

--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -242,14 +242,14 @@ OSSDL2BackendWindow >> newAthensRenderer [
 OSSDL2BackendWindow >> newFormRenderer: form [
 	^ renderer := OSSDL2FormRenderer new 
 		form: form;
-		window: self;
+		backendWindow: self;
 		yourself
 ]
 
 { #category : #'instance creation' }
 OSSDL2BackendWindow >> newGenericRenderer [
 	^ renderer := OSSDL2GenericRenderer new 
-		window: self;
+		backendWindow: self;
 		createSDL2Renderer;
 		yourself
 ]
@@ -257,7 +257,7 @@ OSSDL2BackendWindow >> newGenericRenderer [
 { #category : #'instance creation' }
 OSSDL2BackendWindow >> newOpenGLRenderer [
 	^ renderer := OSSDL2GLRenderer new 
-		window: self;
+		backendWindow: self;
 		createContext;
 		yourself
 ]

--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -7,10 +7,10 @@ Class {
 	#name : #OSSDL2BackendWindow,
 	#superclass : #OSBackendWindow,
 	#instVars : [
-		'handle',
 		'currentCursor',
 		'iconSurface',
-		'lastKeyboardFocus'
+		'lastKeyboardFocus',
+		'sdl2Window'
 	],
 	#pools : [
 		'SDL2Constants'
@@ -25,12 +25,12 @@ OSSDL2BackendWindow class >> newWithHandle: handle attributes: attributes [
 
 { #category : #accessing }
 OSSDL2BackendWindow >> borderless [
-	^ handle getFlags anyMask: SDL_WINDOW_BORDERLESS
+	^ sdl2Window getFlags anyMask: SDL_WINDOW_BORDERLESS
 ]
 
 { #category : #accessing }
 OSSDL2BackendWindow >> borderless: aBoolean [
-	handle toggleBorder: aBoolean not.
+	sdl2Window toggleBorder: aBoolean not.
 ]
 
 { #category : #accessing }
@@ -104,12 +104,12 @@ OSSDL2BackendWindow >> deliverGlobalEvent: aGlobalEvent [
 { #category : #initialize }
 OSSDL2BackendWindow >> destroy [
 
-	handle ifNotNil: [ :validHandle | 
+	sdl2Window ifNotNil: [ :validHandle | 
 		OSSDL2Driver current unregisterWindowWithId: validHandle windowID.
 		validHandle destroy ].
 
 	renderer := nil.
-	handle := nil.
+	sdl2Window := nil.
 	osWindow := nil
 ]
 
@@ -118,41 +118,41 @@ OSSDL2BackendWindow >> extent [
 	| w h |
 	w := ByteArray new: 4.
 	h := ByteArray new: 4.
-	handle getSizeW: w h: h.
+	sdl2Window getSizeW: w h: h.
 	^ (w signedLongAt: 1) @ (h signedLongAt: 1)
 ]
 
 { #category : #accessing }
 OSSDL2BackendWindow >> extent: newExtent [
-	handle setSizeW: newExtent x h: newExtent y
+	sdl2Window setSizeW: newExtent x h: newExtent y
 ]
 
 { #category : #accessing }
 OSSDL2BackendWindow >> fullscreen: aBoolean [
 	aBoolean ifTrue: [
-		handle fullscreen: SDL_WINDOW_FULLSCREEN_DESKTOP
+		sdl2Window fullscreen: SDL_WINDOW_FULLSCREEN_DESKTOP
 	] ifFalse: [ 
-		handle fullscreen: 0
+		sdl2Window fullscreen: 0
 	]
 ]
 
 { #category : #private }
 OSSDL2BackendWindow >> getFlags [
-	^ handle getFlags
+	^ sdl2Window getFlags
 ]
 
 { #category : #private }
 OSSDL2BackendWindow >> getWMInfo [
 	| wmInfo |
 	wmInfo := SDL_SysWMinfo new version: SDL_Version bindingVersion.
-	handle getWMInfo: wmInfo.
+	sdl2Window getWMInfo: wmInfo.
 	^ wmInfo
 ]
 
 { #category : #initialize }
 OSSDL2BackendWindow >> handle [
 
-	^ handle
+	^ sdl2Window
 ]
 
 { #category : #'event handling' }
@@ -162,7 +162,7 @@ OSSDL2BackendWindow >> handleNewSDLEvent: sdlEvent [
 
 { #category : #accessing }
 OSSDL2BackendWindow >> hide [
-	handle hide
+	sdl2Window hide
 ]
 
 { #category : #accessing }
@@ -178,14 +178,14 @@ OSSDL2BackendWindow >> icon: aForm [
 			gmask: 16r000ff00
 			bmask: 16r00000ff
 			amask: 16rff000000.
-	handle icon: surface.
+	sdl2Window icon: surface.
 	iconSurface ifNotNil: [ SDL2 freeSurface: surface ].
 	iconSurface := surface.
 ]
 
 { #category : #initialize }
 OSSDL2BackendWindow >> initWithHandle: aHandle attributes: attributes [
-	handle := aHandle.
+	sdl2Window := aHandle.
 	attributes applyTo: self
 ]
 
@@ -200,7 +200,7 @@ OSSDL2BackendWindow >> initialize [
 OSSDL2BackendWindow >> isTextInputActive [
 	"See https://wiki.libsdl.org/SDL_IsTextInputActive"
 
-	^ handle isTextInputActive
+	^ sdl2Window isTextInputActive
 ]
 
 { #category : #testing }
@@ -221,13 +221,13 @@ OSSDL2BackendWindow >> mapSpecialCharacter: symbol [
 { #category : #'window management' }
 OSSDL2BackendWindow >> maximize [
 
-	handle maximize.
+	sdl2Window maximize.
 ]
 
 { #category : #'window management' }
 OSSDL2BackendWindow >> minimize [
 
-	handle minimize.
+	sdl2Window minimize.
 ]
 
 { #category : #'event handling' }
@@ -291,24 +291,24 @@ OSSDL2BackendWindow >> position [
 	| x y |
 	x := ByteArray new: ExternalType long byteSize.
 	y := ByteArray new: ExternalType long byteSize.
-	handle getPositionX: x y: y.
+	sdl2Window getPositionX: x y: y.
 	^ ( x signedLongAt: 1) @ (y signedLongAt: 1)
 ]
 
 { #category : #accessing }
 OSSDL2BackendWindow >> position: aPoint [
-	handle setPositionX: aPoint x asInteger y: aPoint y asInteger
+	sdl2Window setPositionX: aPoint x asInteger y: aPoint y asInteger
 ]
 
 { #category : #accessing }
 OSSDL2BackendWindow >> prepareExternalResourceForAutoRelease [
-	handle autoRelease
+	sdl2Window autoRelease
 ]
 
 { #category : #accessing }
 OSSDL2BackendWindow >> raise [
 
-	handle raise
+	sdl2Window raise
 ]
 
 { #category : #'mouse capture' }
@@ -318,7 +318,7 @@ OSSDL2BackendWindow >> releaseMouse [
 
 { #category : #accessing }
 OSSDL2BackendWindow >> resizable [
-	^ handle getFlags anyMask: SDL_WINDOW_RESIZABLE
+	^ sdl2Window getFlags anyMask: SDL_WINDOW_RESIZABLE
 ]
 
 { #category : #accessing }
@@ -329,7 +329,13 @@ OSSDL2BackendWindow >> resizable: aBoolean [
 { #category : #'window management' }
 OSSDL2BackendWindow >> restore [
 
-	handle restore
+	sdl2Window restore
+]
+
+{ #category : #initialize }
+OSSDL2BackendWindow >> sdl2Window [
+
+	^ sdl2Window
 ]
 
 { #category : #'window management' }
@@ -343,7 +349,7 @@ OSSDL2BackendWindow >> setDraggableArea: aRectangle [
 			(pt x > sdlRect x) & (pt x < sdlRect w) & (pt y > sdlRect y) & (pt y < sdlRect h) ifTrue: [ 1 ] ifFalse: [ 0 ].
 		].
 	
-	^handle setHitTest: myCallback.
+	^sdl2Window setHitTest: myCallback.
 ]
 
 { #category : #cursor }
@@ -361,7 +367,7 @@ OSSDL2BackendWindow >> setMouseCursor: cursor mask: mask [
 
 { #category : #accessing }
 OSSDL2BackendWindow >> show [
-	handle show
+	sdl2Window show
 ]
 
 { #category : #cursor }
@@ -373,36 +379,36 @@ OSSDL2BackendWindow >> showCursor: aBoolean [
 OSSDL2BackendWindow >> startTextInput [
 	"See https://wiki.libsdl.org/SDL_StartTextInput"
 
-	handle startTextInput
+	sdl2Window startTextInput
 ]
 
 { #category : #'text input' }
 OSSDL2BackendWindow >> stopTextInput [
 	"See https://wiki.libsdl.org/SDL_StopTextInput"
 
-	handle stopTextInput
+	sdl2Window stopTextInput
 ]
 
 { #category : #accessing }
 OSSDL2BackendWindow >> title [
-	^ handle title
+	^ sdl2Window title
 ]
 
 { #category : #accessing }
 OSSDL2BackendWindow >> title: aTitle [
-	handle title: aTitle
+	sdl2Window title: aTitle
 ]
 
 { #category : #'window management' }
 OSSDL2BackendWindow >> toggleBorderOff [
 
-	handle toggleBorder: false.
+	sdl2Window toggleBorder: false.
 ]
 
 { #category : #'window management' }
 OSSDL2BackendWindow >> toggleBorderOn [
 
-	handle toggleBorder: true.
+	sdl2Window toggleBorder: true.
 ]
 
 { #category : #'event handling' }

--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -115,7 +115,7 @@ OSSDL2Driver >> createWindowWithAttributes: attributes osWindow: osWindow [
 			height: attributes height 
 			flags: flags.
 		
-		window := OSSDL2WindowHandle newWithHandle: handle attributes: attributes.
+		window := OSSDL2BackendWindow newWithHandle: handle attributes: attributes.
 		window osWindow: osWindow.
 		self registerWindow: window.
 		

--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -76,7 +76,7 @@ OSSDL2Driver >> convertEvent: sdlEvent [
 
 { #category : #'window creation and deletion' }
 OSSDL2Driver >> createWindowWithAttributes: attributes osWindow: osWindow [
-	| flags handle window glAttributes x y |
+	| flags handle aBackendWindow glAttributes x y |
 	
 	flags := attributes visible ifTrue: [ SDL_WINDOW_SHOWN ] ifFalse: [ SDL_WINDOW_HIDDEN ].
 	attributes fullscreen ifTrue: [ flags := flags | SDL_WINDOW_FULLSCREEN_DESKTOP ].
@@ -115,14 +115,14 @@ OSSDL2Driver >> createWindowWithAttributes: attributes osWindow: osWindow [
 			height: attributes height 
 			flags: flags.
 		
-		window := OSSDL2BackendWindow newWithHandle: handle attributes: attributes.
-		window osWindow: osWindow.
-		self registerWindow: window.
+		aBackendWindow := OSSDL2BackendWindow newWithHandle: handle attributes: attributes.
+		aBackendWindow osWindow: osWindow.
+		self registerWindow: aBackendWindow.
 		
 		"The OSWindow handle has to be set inside of this critical section to avoid losing some events such as expose."
-		osWindow setJustCreatedHandle: window.
+		osWindow setJustCreatedHandle: aBackendWindow.
 	].
-	^ window
+	^ aBackendWindow
 ]
 
 { #category : #'events-processing' }
@@ -284,8 +284,8 @@ OSSDL2Driver >> registerGlobalListener: globalListener [
 ]
 
 { #category : #'window creation and deletion' }
-OSSDL2Driver >> registerWindow: window [
-	WindowMap at: window handle windowID put: window
+OSSDL2Driver >> registerWindow: aBackendWindow [
+	WindowMap at: aBackendWindow sdl2Window windowID put: aBackendWindow
 ]
 
 { #category : #'global events' }

--- a/src/OSWindow-SDL2/OSSDL2FormRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2FormRenderer.class.st
@@ -31,7 +31,7 @@ OSSDL2FormRenderer >> copyAndPresentTextureRectangle: rectangle [
 
 { #category : #private }
 OSSDL2FormRenderer >> createRenderer [
-	renderer := window handle createDefaultRenderer.
+	renderer := backendWindow handle createDefaultRenderer.
 
 ]
 
@@ -101,7 +101,7 @@ OSSDL2FormRenderer >> updateAreas: allDamage immediate: forceToScreen [
 		externalForm := OSSDL2ExternalForm extent: extent depth: 32 bits: pixels.
 		allDamage do: [ :rectangle |
 			intersection := rectangle
-				intersect: (0 @ 0 corner: window extent)
+				intersect: (0 @ 0 corner: backendWindow extent)
 				ifNone: [ nil ].
 		
 			intersection ifNotNil: [
@@ -129,7 +129,7 @@ OSSDL2FormRenderer >> updateAreas: allDamage immediate: forceToScreen [
 OSSDL2FormRenderer >> updateRectangle: rectangle [
 	| intersection pixels pitch pitchHolder externalForm |
 	intersection := rectangle
-		intersect: (0 @ 0 corner: window extent)
+		intersect: (0 @ 0 corner: backendWindow extent)
 		ifNone: [ ^ self ].
 	self validate
 		ifFalse: [ ^ self ].

--- a/src/OSWindow-SDL2/OSSDL2FormRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2FormRenderer.class.st
@@ -31,7 +31,7 @@ OSSDL2FormRenderer >> copyAndPresentTextureRectangle: rectangle [
 
 { #category : #private }
 OSSDL2FormRenderer >> createRenderer [
-	renderer := backendWindow handle createDefaultRenderer.
+	renderer := backendWindow sdl2Window createDefaultRenderer.
 
 ]
 

--- a/src/OSWindow-SDL2/OSSDL2GLRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2GLRenderer.class.st
@@ -34,11 +34,11 @@ OSWindowRenderThread isActiveThread ifFalse: [ ^ 'GL Renderer must be used insid
 { #category : #misc }
 OSSDL2GLRenderer >> createContext [
 	self onRenderThreadBlocking: [
-		context := SDL2 glCreateContext: window handle.
+		context := SDL2 glCreateContext: backendWindow handle.
 	].
 
 	(context isNotNil and: [ context isNull not ]) ifTrue: [
-		FFIExternalResourceManager addResource: self data: { window . context }
+		FFIExternalResourceManager addResource: self data: { backendWindow . context }
 	]
 ]
 

--- a/src/OSWindow-SDL2/OSSDL2GLRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2GLRenderer.class.st
@@ -34,7 +34,7 @@ OSWindowRenderThread isActiveThread ifFalse: [ ^ 'GL Renderer must be used insid
 { #category : #misc }
 OSSDL2GLRenderer >> createContext [
 	self onRenderThreadBlocking: [
-		context := SDL2 glCreateContext: backendWindow handle.
+		context := SDL2 glCreateContext: backendWindow sdl2Window .
 	].
 
 	(context isNotNil and: [ context isNull not ]) ifTrue: [
@@ -58,12 +58,12 @@ OSSDL2GLRenderer >> getProcAddress: procName [
 ]
 
 { #category : #misc }
-OSSDL2GLRenderer >> makeCurrent: aWindow [
+OSSDL2GLRenderer >> makeCurrent: aBackendWindow [
 	| windowHandle |
 	context ifNil: [ ^ false ].
 	
 	self checkThread.
-	windowHandle := aWindow handle.
+	windowHandle := aBackendWindow sdl2Window.
 	windowHandle ifNil: [ ^ false ].
 	(SDL2 glMakeCurrent: windowHandle context: context) == 0
 		ifTrue:  [ ^ true ]
@@ -74,7 +74,7 @@ OSSDL2GLRenderer >> makeCurrent: aWindow [
 { #category : #misc }
 OSSDL2GLRenderer >> swapBuffers: aWindow [
 	self checkThread.
-	SDL2 glSwapWindow: aWindow handle.
+	SDL2 glSwapWindow: aWindow sdl2Window.
 ]
 
 { #category : #'updating screen' }

--- a/src/OSWindow-SDL2/OSSDL2GenericRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2GenericRenderer.class.st
@@ -30,7 +30,7 @@ OSSDL2GenericRenderer >> color: aColor [
 
 { #category : #initialization }
 OSSDL2GenericRenderer >> createSDL2Renderer [
-	renderer := backendWindow handle createDefaultRenderer.
+	renderer := backendWindow sdl2Window createDefaultRenderer.
 ]
 
 { #category : #deleting }

--- a/src/OSWindow-SDL2/OSSDL2GenericRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2GenericRenderer.class.st
@@ -30,7 +30,7 @@ OSSDL2GenericRenderer >> color: aColor [
 
 { #category : #initialization }
 OSSDL2GenericRenderer >> createSDL2Renderer [
-	renderer := window handle createDefaultRenderer.
+	renderer := backendWindow handle createDefaultRenderer.
 ]
 
 { #category : #deleting }

--- a/src/OSWindow-VM/OSVMBackendWindow.class.st
+++ b/src/OSWindow-VM/OSVMBackendWindow.class.st
@@ -82,7 +82,7 @@ OSVMBackendWindow >> isValid [
 OSVMBackendWindow >> newFormRenderer: form [ 
 	^ renderer := OSVMFormRenderer new 
 		form: form;
-		window: self;
+		backendWindow: self;
 		yourself
 ]
 

--- a/src/OSWindow-VM/OSVMBackendWindow.class.st
+++ b/src/OSWindow-VM/OSVMBackendWindow.class.st
@@ -3,8 +3,8 @@ An OSVMWindowHandle is created by VMWindowDriver.
  
 "
 Class {
-	#name : #OSVMWindowHandle,
-	#superclass : #OSWindowHandle,
+	#name : #OSVMBackendWindow,
+	#superclass : #OSBackendWindow,
 	#instVars : [
 		'fullscreen'
 	],
@@ -12,29 +12,29 @@ Class {
 }
 
 { #category : #accessing }
-OSVMWindowHandle >> bounds [
+OSVMBackendWindow >> bounds [
 	^ self position corner: self extent
 ]
 
 { #category : #accessing }
-OSVMWindowHandle >> bounds: bounds [
+OSVMBackendWindow >> bounds: bounds [
 	self position: bounds origin.
 	self extent: bounds extent
 ]
 
 { #category : #accessing }
-OSVMWindowHandle >> clipboardText [
+OSVMBackendWindow >> clipboardText [
 	<primitive: 141>
 	^ ''
 ]
 
 { #category : #accessing }
-OSVMWindowHandle >> clipboardText: aString [
+OSVMBackendWindow >> clipboardText: aString [
 	<primitive: 141>
 ]
 
 { #category : #accessing }
-OSVMWindowHandle >> depth: depthInteger width: widthInteger height: heightInteger fullscreen: aBoolean [
+OSVMBackendWindow >> depth: depthInteger width: widthInteger height: heightInteger fullscreen: aBoolean [
 	"Force Pharo's window (if there's one) into a new size and depth."
 	"DisplayScreen depth: 8 width: 1024 height: 768 fullscreen: false"
 
@@ -43,43 +43,43 @@ OSVMWindowHandle >> depth: depthInteger width: widthInteger height: heightIntege
 ]
 
 { #category : #accessing }
-OSVMWindowHandle >> extent [
+OSVMBackendWindow >> extent [
 	<primitive: 106>
 	^ 640@480
 ]
 
 { #category : #accessing }
-OSVMWindowHandle >> extent: extent [
+OSVMBackendWindow >> extent: extent [
 	self depth: self screenDepth width: extent x height: extent y fullscreen: fullscreen
 ]
 
 { #category : #accessing }
-OSVMWindowHandle >> fullscreen: aBoolean [
+OSVMBackendWindow >> fullscreen: aBoolean [
 ]
 
 { #category : #accessing }
-OSVMWindowHandle >> hide [
+OSVMBackendWindow >> hide [
 	"Do nothing for now"
 ]
 
 { #category : #initialize }
-OSVMWindowHandle >> initWithAttributes: attributes [
+OSVMBackendWindow >> initWithAttributes: attributes [
 	self extent: attributes extent
 ]
 
 { #category : #initialization }
-OSVMWindowHandle >> initialize [
+OSVMBackendWindow >> initialize [
 	super initialize.
 	fullscreen := false
 ]
 
 { #category : #testing }
-OSVMWindowHandle >> isValid [
+OSVMBackendWindow >> isValid [
 	^ true
 ]
 
 { #category : #'instance creation' }
-OSVMWindowHandle >> newFormRenderer: form [ 
+OSVMBackendWindow >> newFormRenderer: form [ 
 	^ renderer := OSVMFormRenderer new 
 		form: form;
 		window: self;
@@ -87,39 +87,39 @@ OSVMWindowHandle >> newFormRenderer: form [
 ]
 
 { #category : #accessing }
-OSVMWindowHandle >> position [
+OSVMBackendWindow >> position [
 	"Ignored"
 ]
 
 { #category : #accessing }
-OSVMWindowHandle >> position: newPosition [
+OSVMBackendWindow >> position: newPosition [
 	"Ignored"
 ]
 
 { #category : #accessing }
-OSVMWindowHandle >> screenDepth [
+OSVMBackendWindow >> screenDepth [
 	<primitive: #primitiveScreenDepth >
 	^ self renderer form depth
 ]
 
 { #category : #accessing }
-OSVMWindowHandle >> setMouseCursor: cursorWithMask [
+OSVMBackendWindow >> setMouseCursor: cursorWithMask [
 
 	self currentWorld currentCursor == cursorWithMask ifFalse: [  
 		self currentWorld currentCursor: cursorWithMask ].
 ]
 
 { #category : #accessing }
-OSVMWindowHandle >> show [
+OSVMBackendWindow >> show [
 	"Do nothing for now"
 ]
 
 { #category : #accessing }
-OSVMWindowHandle >> title [
+OSVMBackendWindow >> title [
 	^ ''
 ]
 
 { #category : #accessing }
-OSVMWindowHandle >> title: newTitle [
+OSVMBackendWindow >> title: newTitle [
 	"Ignored"
 ]

--- a/src/OSWindow-VM/VMWindowDriver.class.st
+++ b/src/OSWindow-VM/VMWindowDriver.class.st
@@ -29,5 +29,5 @@ VMWindowDriver class >> primitiveScreenDepth [
 
 { #category : #'window creation' }
 VMWindowDriver >> createWindowWithAttributes: attributes osWindow: osWindow [
-	^ OSVMWindowHandle new initWithAttributes: attributes; osWindow: osWindow; yourself
+	^ OSVMBackendWindow new initWithAttributes: attributes; osWindow: osWindow; yourself
 ]


### PR DESCRIPTION
An OSWindow has a `handle`. The `handle` is not an FFI thing as we would think, it's more like a backend window object instance of, for example, `OSSDL2WindowHandle`.

`OSSDL2WindowHandle` is thus not really a handle, and inside it has another `handle`
which is again not an FFI handle (in the sense of an external reference)!!!

The `handle` of the `handle` is an external object, which has also a `handle`.
So the `handle` has a `handle`  with a `handle`.
Then it happens in OSWindow that we have code such as the following, and we don't know what exactly we are manipulating.

`window handle`

But that's not all! :smile:
The `OSWindow` `handle` has a renderer, which has a `window` instance variable.
But this `window` does not reference an `OSWindow`, it references an `OSWindowHandle`.
Turning the example above even more ambiguous.

`window handle`

## This PR introduces several renames on internals of `OSWindow` to be easier to deal with
 - all `handle` instance variables are renamed something more concrete => `backendWindow` for backends, `sdl2Window` for SDL external objects, `handle` is kept in the external object as is because it is consistent with FFI's terminology.
 - `window` now refers to OSWindow instances. `backendWindow` to backend window instances.
 - Backend classes have now Backend in their name instead of Handle