### PR TITLE
CatalogSettings displayCatalogProjectsInSpotter:

### DIFF
--- a/src/Deprecated90/CatalogSettings.extension.st
+++ b/src/Deprecated90/CatalogSettings.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #CatalogSettings }
+
+{ #category : #'*Deprecated90' }
+CatalogSettings class >> displayCatalogProjectsInSpotter: aBoolean [
+	self deprecated: 'Now use SptCatalogProjectsProcessor #enabled: method'.
+	
+	SptCatalogProjectsProcessor enabled: aBoolean
+	
+]

--- a/src/Pharo-WelcomeHelp/WelcomeHelp.class.st
+++ b/src/Pharo-WelcomeHelp/WelcomeHelp.class.st
@@ -154,7 +154,9 @@ One chapter of particular interest is the one that provides a quick tour of the 
 { #category : #defaults }
 WelcomeHelp class >> fastNetworkDefaults [
 	"Allow to display catalog projects in spotter on regular and fast networks"
-	CatalogSettings displayCatalogProjectsInSpotter: true.
+
+	SptCatalogProjectsProcessor enabled: false.
+	
 	self inform: 'Catalog projects accessible through Spotter'
 ]
 
@@ -272,7 +274,9 @@ WelcomeHelp class >> pharoVersionString [
 { #category : #defaults }
 WelcomeHelp class >> slowNetworkDefaults [
 	"Do not display network bound catalog projects in spotter to keep it responsive."
-	CatalogSettings displayCatalogProjectsInSpotter: false.
+	
+	SptCatalogProjectsProcessor enabled: false.
+	
 	self inform: 'Catalog projects not accessible through Spotter due to slow network. Use search in catalog tool to load external packages.'
 ]
 


### PR DESCRIPTION
- use the new implementation of the settings to show catalog entries in spotter (fix broken code in #fastNetworkDefaults and #slowNetworkDefaults)
- provide old setting method #displayCatalogProjectsInSpotter: as a deprecated method in Deprecated90 package for compatibility / migration

Fix #6059