### PR TITLE
Codegeneration: generate  code for Blocks for effect

### DIFF
--- a/src/OpalCompiler-Core/OCASTTranslatorForEffect.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslatorForEffect.class.st
@@ -80,9 +80,10 @@ OCASTTranslatorForEffect >> visitAssignmentNode: anAssignmentNode [
 
 { #category : #'visitor-double dispatching' }
 OCASTTranslatorForEffect >> visitBlockNode: aBlockNode [ 
-
-	"A block has no side effect, so a block translated for effect just doesn't generate anything" 
-
+	"even though the code is never executed, we generate it to make sure that we 
+	can map bytecode and access temps"
+	super visitBlockNode: aBlockNode.
+	methodBuilder popTop
 ]
 
 { #category : #'visitor-double dispatching' }

--- a/src/Reflectivity/RFASTTranslatorForEffect.class.st
+++ b/src/Reflectivity/RFASTTranslatorForEffect.class.st
@@ -82,9 +82,10 @@ RFASTTranslatorForEffect >> visitAssignmentNode: anAssignmentNode [
 
 { #category : #'visitor-double dispatching' }
 RFASTTranslatorForEffect >> visitBlockNode: aBlockNode [ 
-
-	"A block has no side effect, so a block translated for effect just doesn't generate anything" 
-
+	"even though the code is never executed, we generate it to make sure that we 
+	can map bytecode and access temps"
+	super visitBlockNode: aBlockNode.
+	methodBuilder popTop
 ]
 
 { #category : #'visitor-double dispatching' }


### PR DESCRIPTION
We do not generate code for blocks that are just visited for effect (as there is none). Example would be just a line like

["this does nothing as we do not store it nor assign it" |temp| temp := 1].

But this is not a good idea as the compiler creates meta data that we need to access temps and map to the bytecode.

This PR thus enables compiling code for blocks visited for effect only.