### PR TITLE
Skip Epicea fleaky test

### DIFF
--- a/src/Hiedra-Tests/HiExamplesTest.class.st
+++ b/src/Hiedra-Tests/HiExamplesTest.class.st
@@ -24,6 +24,7 @@ HiExamplesTest >> exampleMethods [
 HiExamplesTest >> testAllExamples [
 	| exampleMethods |
 	
+	self skip: 'This test fails randomly in the CI in different OS due a timeout, even with an increased time limit of 30 seconds'.
 	self timeLimit: 30 seconds.
 	
 	exampleMethods := self exampleMethods.


### PR DESCRIPTION
Fix #5938.

testAllExamples fails in the CI randomly in different oss even with an increased 30 seconds time limit.