### PR TITLE
Introduce UnhandledException hierarchy

### DIFF
--- a/src/Flashback-Decompiler/CannotDecompileNativeBoostCalls.class.st
+++ b/src/Flashback-Decompiler/CannotDecompileNativeBoostCalls.class.st
@@ -6,8 +6,3 @@ Class {
 	#superclass : #Exception,
 	#category : #'Flashback-Decompiler-Exceptions'
 }
-
-{ #category : #accessing }
-CannotDecompileNativeBoostCalls >> defaultAction [
-	UnhandledError signalForException: self
-]

--- a/src/Kernel/Abort.class.st
+++ b/src/Kernel/Abort.class.st
@@ -6,10 +6,3 @@ Class {
 	#superclass : #Exception,
 	#category : #'Kernel-Exceptions'
 }
-
-{ #category : #accessing }
-Abort >> defaultAction [
-	"No one has handled this error, but now give them a chance to decide how to debug it. If none handle this either then open debugger (see UnhandledError>>#defaultAction)"
-
-	UnhandledError signalForException: self
-]

--- a/src/Kernel/Error.class.st
+++ b/src/Kernel/Error.class.st
@@ -12,13 +12,6 @@ Class {
 	#category : #'Kernel-Exceptions'
 }
 
-{ #category : #exceptiondescription }
-Error >> defaultAction [
-	"No one has handled this error, but now give them a chance to decide how to debug it.  If none handle this either then open debugger (see UnhandedError-defaultAction)"
-
-	UnhandledError signalForException: self
-]
-
 { #category : #private }
 Error >> isResumable [
 	"Determine whether an exception is resumable."

--- a/src/Kernel/Exception.class.st
+++ b/src/Kernel/Exception.class.st
@@ -114,11 +114,15 @@ Exception >> debug [
 		debug: self signalerContext title: self description
 ]
 
-{ #category : #accessing }
+{ #category : #handling }
 Exception >> defaultAction [
-	"The default action taken if the exception is signaled."
+	"No one has handled this error, but now give them a chance to decide how to debug it. 
+	If none handles this either then open debugger (see UnhandedError-defaultAction).
+	
+	Note about naming here: 
+	Even if not all exceptions are errors the absence of a handler for signaled exception is considered as an error by default. Therefore #defaultAction for Exception raises an error, an UnhandledError"
 
-	self subclassResponsibility
+	self raiseUnhandledError
 ]
 
 { #category : #private }
@@ -225,6 +229,13 @@ Exception >> privHandlerContext [
 Exception >> privHandlerContext: aContextTag [
 
 	handlerContext := aContextTag
+]
+
+{ #category : #handling }
+Exception >> raiseUnhandledError [
+	"No one has handled this error, but now give them a chance to decide how to debug it.  If none handle this either then open debugger (see UnhandedError>>#defaultAction)"
+
+	UnhandledError signalForException: self
 ]
 
 { #category : #accessing }
@@ -358,4 +369,13 @@ Exception >> tag: t [
 	"This message is not specified in the ANSI protocol, but that looks like an oversight because #tag is specified, and the spec states that the signaler may store the tag value."
 
 	tag := t
+]
+
+{ #category : #handling }
+Exception >> unhandledErrorAction [
+	"No one has handled this error, then I gave them a chance to decide how to debug it and I raise an UnhandledError. But it was not handled by anybody so that we are here (see nhandedError-defaultAction).
+	It is the final action an exception can do which is normally a debugger in interactive image"
+
+	<reflective: #unhandledErrorDefaultAction:message:>
+ 	^ UIManager default unhandledErrorDefaultAction: self
 ]

--- a/src/Kernel/Halt.class.st
+++ b/src/Kernel/Halt.class.st
@@ -64,11 +64,14 @@ Halt resetOnce
 ]]]
 
 
+!! Implementation details
 
+In past Halt was a normal exception (not a kind of UnhandledException) and it was processed through UnhandledError indirection. 
+But it such design did not allow to debug the unhandled logic itself. For example halt in UnhandledError>>#defaultAction leaded to infinite recursion
 "
 Class {
 	#name : #Halt,
-	#superclass : #Exception,
+	#superclass : #UnhandledException,
 	#category : #'Kernel-Exceptions'
 }
 
@@ -220,14 +223,6 @@ Halt >> completeProcess: aProcess with: aContext [
 		pragmaNamed: #debuggerCompleteToSender
 		ifPresent: [ aProcess completeTo: aContext sender ]
 		ifAbsent: [ super completeProcess: aProcess with: aContext ]
-]
-
-{ #category : #'priv handling' }
-Halt >> defaultAction [
-	"No one has handled this error, but now give them a chance to decide how to debug it.  If none handle this either then open debugger (see UnhandedError-defaultAction)"
-
-	^ UIManager default unhandledErrorDefaultAction: self
-	"^ UnhandledError signalForException: self" 
 ]
 
 { #category : #private }

--- a/src/Kernel/IllegalResumeAttempt.class.st
+++ b/src/Kernel/IllegalResumeAttempt.class.st
@@ -8,13 +8,6 @@ Class {
 }
 
 { #category : #comment }
-IllegalResumeAttempt >> defaultAction [
-	"No one has handled this error, but now give them a chance to decide how to debug it.  If none handle this either then open debugger (see UnhandedError-defaultAction)"
-
-	UnhandledError signalForException: self
-]
-
-{ #category : #comment }
 IllegalResumeAttempt >> isResumable [
 	
 	^ false

--- a/src/Kernel/UnhandledError.class.st
+++ b/src/Kernel/UnhandledError.class.st
@@ -1,6 +1,6 @@
 "
 I am the ultimate error. 
-By default if an Error or Exception is not handled by the code the default action is to raise an UnhandledError which in interactive mode triggers the UIManager to open a debugger.
+By default if an Exception is not handled by the code the default action is to raise an UnhandledError (#raiseUnhandledError) which in interactive mode triggers the UIManager to open a debugger.
 
 	Error signal
 	...
@@ -8,10 +8,19 @@ By default if an Error or Exception is not handled by the code the default actio
 	...
 	UIManager opens a debugger
 	
+The UI action here can be specialied for different kind of exceptions. The actual logic is implemented by exceptions themselves as #unhandledErrorAction:
+
+	UnhandledError>>defaultAction 
+		^ exception unhandledErrorAction
+
+For example It allows to have specific debugger for Warning while it still processed through same UnhandledError machinery.
+
+The logic behind my class name and methods: 
+Not all exceptions are errors. But by default the absence of any handler for signaled exception is considered as an error. Therefore #defaultAction for Exception raises an error, an UnhandledError. And because exception should be able to specify default action for UnhandledError it implements #unhandledErrorAction
 "
 Class {
 	#name : #UnhandledError,
-	#superclass : #Exception,
+	#superclass : #UnhandledException,
 	#instVars : [
 		'exception'
 	],
@@ -28,8 +37,7 @@ UnhandledError class >> signalForException: anError [
 
 { #category : #'priv handling' }
 UnhandledError >> defaultAction [
-	<reflective: #unhandledErrorDefaultAction:message:>
- 	^ UIManager default unhandledErrorDefaultAction: self exception
+	^ exception unhandledErrorAction
 ]
 
 { #category : #accessing }

--- a/src/Kernel/UnhandledException.class.st
+++ b/src/Kernel/UnhandledException.class.st
@@ -1,0 +1,25 @@
+"
+I am a root of hierarchy of various kinds of ultimate exceptions. 
+The ultimate meaning here is that such exceptions execute the UI action to interrupt the process execution as the result of not being handled. So no other exceptions are be raisen there. 
+
+In interactive mode whey will trigger the UIManager to open a debugger.
+
+There are two main subclasses:
+- Halt to break and debug execution.
+- UnhandledError to give a last chance to handle given exception 
+See comments for details
+"
+Class {
+	#name : #UnhandledException,
+	#superclass : #Exception,
+	#category : #'Kernel-Exceptions'
+}
+
+{ #category : #'priv handling' }
+UnhandledException >> defaultAction [
+	"If none handles this either then open debugger.
+	
+	Note about naming here: 
+	Even if not all exceptions are errors the absence of a handler for signaled exception is considered as an error by default. Therefore #defaultAction for UnhandledException performs the #unhandledErrorAction"
+ 	^ self unhandledErrorAction
+]

--- a/src/Kernel/Warning.class.st
+++ b/src/Kernel/Warning.class.st
@@ -8,7 +8,9 @@ Class {
 }
 
 { #category : #exceptionDescription }
-Warning >> defaultAction [
-	
-	UIManager default warningDefaultAction: self
+Warning >> unhandledErrorAction [
+	"No one has handled this error, then I gave them a chance to decide how to debug it and I raise an UnhandledError. But it was not handled by anybody so that we are here (see UnhandedError-defaultAction).
+	It is the final action an exception can do which is normally a debugger in interactive image"
+
+	^UIManager default warningDefaultAction: self
 ]

--- a/src/SUnit-Core/TestFailure.class.st
+++ b/src/SUnit-Core/TestFailure.class.st
@@ -8,14 +8,6 @@ Class {
 }
 
 { #category : #'camp smalltalk' }
-TestFailure >> defaultAction [
-
-	Processor activeProcess
-		debug: self signalerContext
-		title: self description
-]
-
-{ #category : #'camp smalltalk' }
 TestFailure >> isResumable [
 	
 	^ false


### PR DESCRIPTION
- Introduce UnhandledException as a root for ultimate exceptions like Halt and UnhandledError.

The ultimate meaning here is that such exceptions execute the UI action to interrupt the process execution as the result of not being handled. So they do not raise any other extra exception. And in interactive mode they trigger the UIManager to open a debugger.

Now with common hierarchy for Halt and UnhandledError we can simplify many places where we now write UnhandledError, Halt.

- raise an UnhandledError as default implementation for #defaultAction.

There are already several duplicated #defaultAction's in the hierarchy (removed here). It is better to have it as default implementation with following description: 
Even if not all exceptions are errors the absence of a handler for signalled exception is considered as an error by default. Therefore #defaultAction for Exception raises an error, an UnhandledError. 

- UnhandledError delegates its own default action to underlying exception using #unhandledErrorAction.

For example It allows to have specific debugger for Warning while it still processed through same UnhandledError machinery.

- Warning is processed through UnhandledError logic (see previous point)
- TestFailure is processed through UnhandledError logic

Last two changes fix Step Through in the debugger over "Warning signal" and "TestCase new assert: false" (or any assert in the test").