### PR TITLE
Cleanup: #vectorOffset

### DIFF
--- a/src/OpalCompiler-Core/OCVectorTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCVectorTempVariable.class.st
@@ -80,13 +80,6 @@ OCVectorTempVariable >> vectorName: anObject [
 	vectorName := anObject
 ]
 
-{ #category : #accessing }
-OCVectorTempVariable >> vectorOffset [
-	"Temps that are stored in a temp vector have a unique index in the vector.
-	 We first lookup the temp vector sem var by name and then get the index from the IR"
-	^index ifNil: [index := (scope lookupVar: vectorName) originalVar indexInTempVectorFromIR: name]
-]
-
 { #category : #debugging }
 OCVectorTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 

--- a/src/OpalCompiler-Tests/ASTtoIRMappingTest.class.st
+++ b/src/OpalCompiler-Tests/ASTtoIRMappingTest.class.st
@@ -6,24 +6,3 @@ Class {
 	#superclass : #TestCase,
 	#category : #'OpalCompiler-Tests-Mapping'
 }
-
-{ #category : #tests }
-ASTtoIRMappingTest >> testOffsetVectorTemp [
-	| ast var |
-	"Temps that are stored in a temp vector have a unique index in the vector"
-	ast := Smalltalk compiler
-		parse:
-			'm04_two_temps_one_temp_in_remote_vector
-
-| t1 t2 |
-
-t1 := 1.
-[ t2 := t1 +  1.0 ] value.
-
-^t2'.
-
-	ast doSemanticAnalysis.
-	var := ast blockNodes first variableNodes second binding.
-	
-	self assert: var vectorOffset equals: 1
-]


### PR DESCRIPTION
Small cleanup in preparation for the offset caching PR to be done later
- remove unused accessor #vectorOffset and the one test that called it