### PR TITLE
Compiler: Use better names for syntetic temps

### DIFF
--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -295,28 +295,28 @@ OCASTTranslator >> emitTimesRepeat: aMessageNode [
 	limitEmit := [valueTranslator visitNode: limit].
 	limit isLiteral | limit isSelf | limit isSuper ifFalse: [
 		valueTranslator visitNode: limit.
-		methodBuilder addTemp: #limit.
-		methodBuilder storeTemp: #limit.
+		methodBuilder addTemp: #'0limit'.
+		methodBuilder storeTemp: #'0limit'.
 		methodBuilder popTop.
-		limitEmit := [methodBuilder pushTemp: #limit]].
+		limitEmit := [methodBuilder pushTemp: #'0limit']].
 
 	"push start. allocate and initialize iterator"
 	self isValueTranslator ifTrue: [ limitEmit value ].
 	methodBuilder pushLiteral: 1.
-	methodBuilder addTemp: #iterator.
-	methodBuilder storeTemp: #iterator.
+	methodBuilder addTemp: #'0iterator'.
+	methodBuilder storeTemp: #'0iterator'.
 	methodBuilder popTop. 
 	methodBuilder jumpBackTarget: #start.
-	methodBuilder pushTemp: #iterator.
+	methodBuilder pushTemp: #'0iterator'.
 	limitEmit value.
 	methodBuilder send: #<=.
 	methodBuilder jumpAheadTo: #done if: false.
 
 	effectTranslator visitInlinedBlockNode: block.
-	methodBuilder pushTemp: #iterator.
+	methodBuilder pushTemp: #'0iterator'.
 	methodBuilder pushLiteral: 1.
 	methodBuilder send: #+.
-	methodBuilder storeTemp: #iterator.
+	methodBuilder storeTemp: #'0iterator'.
 	methodBuilder popTop.
 	methodBuilder jumpBackTo: #start.
 	methodBuilder jumpAheadTarget: #done.
@@ -351,10 +351,10 @@ OCASTTranslator >> emitToDo: aMessageNode step: step [
 	limitEmit := [valueTranslator visitNode: limit].
 	limit isLiteralNode | limit isSelf | limit isSuper | limit isArgument ifFalse: [
 		valueTranslator visitNode: limit.
-		methodBuilder addTemp: (iterator name, #limit).
-		methodBuilder storeTemp: (iterator name, #limit).
+		methodBuilder addTemp: ('0limit_', iterator name).
+		methodBuilder storeTemp: ('0limit_', iterator name).
 		methodBuilder popTop.
-		limitEmit := [methodBuilder pushTemp: (iterator name, #limit)]].
+		limitEmit := [methodBuilder pushTemp: ('0limit_', iterator name)]].
 
 	"push start. allocate and initialize iterator"
 	valueTranslator visitNode: aMessageNode receiver.


### PR DESCRIPTION
compiling #timesRepeat: and to:do: adds temps (to store the limit, for example).

This PR unifies the names to all start with $0 and limits to start with '0limit'. This simplifies debugging and makes it clearer and avoids name mixup with vars defined in the code.