### PR TITLE
2608-PathprintOn-is-overriden-by-all-its-subclasses-and-none-call-super-printOn

### DIFF
--- a/src/FileSystem-Path/Path.class.st
+++ b/src/FileSystem-Path/Path.class.st
@@ -478,12 +478,6 @@ Path >> pathString [
 ]
 
 { #category : #printing }
-Path >> printOn: aStream [ 
-	self printOn: aStream delimiter: self delimiter.
-
-]
-
-{ #category : #printing }
 Path >> printOn: aStream delimiter: aCharacter [
 	(1 to: self size)
 		do: [:index | aStream nextPutAll: (self at: index)]


### PR DESCRIPTION
Fixes #2608 : Removed unused #printOn: method from abstract class Path.