### PR TITLE
2679-Fix-RxmBranch-to-do-greedy-matching-instead-of-first-match-passes

### DIFF
--- a/src/Regex-Core-Tests/RxMatcherTest.class.st
+++ b/src/Regex-Core-Tests/RxMatcherTest.class.st
@@ -1207,6 +1207,25 @@ RxMatcherTest >> testStringCopyWithRegexMatchesTranslatedUsing [
 			'X' ]) equals: 'aaXcc'
 ]
 
+{ #category : #tests }
+RxMatcherTest >> testStringGreedyMatchesRegex [
+
+	self assert: ('199' matchesRegex: '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])').
+	self assert: ('25' matchesRegex: '([0-9]|[1-9][0-9])').
+	self assert: ('25' matchesRegex: '([1-9][0-9]|[0-9])').
+	self assert: ('25' matchesRegex: '(\d\d|\d)').
+	self assert: ('25' matchesRegex: '(\d|\d\d)').
+	self assert: ('bb' matchesRegex: '([a-z]|[b-z][a-z])').
+	self assert: ('b' matchesRegex: '([b-z][a-z]|[a-z])').
+	self assert: ('15' matchesRegex: '[1-9]|1[0-9]').
+	self assert: ('b' matchesRegex: '(b|bb)').
+	self assert: ('b' matchesRegex: '(bb|b)').
+	self assert: ('fooABCD' matchesRegex: '.*(ABCD|BC)').
+	self assert: ('fooBC' matchesRegex: '.*(ABCD|BC)').
+	self assert: ('fooB' matchesRegex: '.*(ABC|B)').
+	self assert: ('fooABC' matchesRegex: '.*(ABC|B)').	
+]
+
 { #category : #'testing-extensions' }
 RxMatcherTest >> testStringMatchesRegex [
 	self deny: ('aabbcc' matchesRegex: 'a+').

--- a/src/Regex-Core/RxMatcher.class.st
+++ b/src/Regex-Core/RxMatcher.class.st
@@ -217,11 +217,14 @@ RxMatcher >> copyStream: aStream to: writeStream translatingMatchesUsing: aBlock
 { #category : #privileged }
 RxMatcher >> currentState [
 	"Answer an opaque object that can later be used to restore the
-	matcher's state (for backtracking)."
-
-	| origPosition |
+	matcher's state (for backtracking)"
+	
+	| origPosition origMarkerPositions |
+	
 	origPosition := stream position.
-	^	[stream position: origPosition]
+	origMarkerPositions := markerPositions collect: [ :collection | collection copy ].
+	^[ stream position: origPosition.
+		markerPositions := origMarkerPositions ]
 ]
 
 { #category : #private }

--- a/src/Regex-Core/RxmBranch.class.st
+++ b/src/Regex-Core/RxmBranch.class.st
@@ -41,11 +41,27 @@ RxmBranch >> initialize [
 
 { #category : #matching }
 RxmBranch >> matchAgainst: aMatcher [
-	"Match either `next' or `alternative'. Fail if the alternative is nil."
+	"Match the longest match of `next' or `alternative'. Fail the alternative if the alternative is nil."
 
-	^(next matchAgainst: aMatcher)
-		or: [alternative notNil
-			and: [alternative matchAgainst: aMatcher]]
+	| original firstMatch firstMatchPos |
+
+	original := aMatcher currentState.
+	(next matchAgainst: aMatcher)
+		ifFalse: [^alternative notNil and: [alternative matchAgainst: aMatcher]].
+	alternative ifNil: [^true].
+	firstMatch := aMatcher currentState.
+	firstMatchPos := aMatcher position.
+	aMatcher restoreState: original.
+	(alternative matchAgainst: aMatcher)
+		ifFalse: [
+			aMatcher restoreState: firstMatch.
+			^true].
+	firstMatchPos >= aMatcher position
+		ifTrue: [
+			aMatcher restoreState: firstMatch.
+			^true].
+	^true			
+
 ]
 
 { #category : #building }


### PR DESCRIPTION
Fixes #2679 as per VW Regex 1.3.1 patch
Includes unit tests by marianopeck