### PR TITLE
do-not-generate-initialize-method-for-slots-if-it-already-call-super

### DIFF
--- a/src/Slot-Core/Slot.class.st
+++ b/src/Slot-Core/Slot.class.st
@@ -116,23 +116,6 @@ Slot >> = other [
 			and: [ name = other name ]
 ]
 
-{ #category : #private }
-Slot >> addSlotInitToInitialize: aClass [
-	|  source |
-
-	(self sendsInitializeSlots: aClass) ifTrue: [ ^ self ].
-	
-	source := (aClass>>#initialize) sourceCode allButFirst: 10.
-	source := 'initialize
-	
-	self class initializeSlots: self.', 
-	source.
-
-	Author 
-		useAuthor: 'Generated' 
-		during: [ aClass compile: source classified: 'initialization' ]
-]
-
 { #category : #'class building' }
 Slot >> asClassVariable [
 	self
@@ -192,11 +175,15 @@ Slot >> emitValue: aMethodBuilder [
 
 { #category : #private }
 Slot >> ensureInitalizeMethodExists: aClass [
-	(aClass includesSelector:  #initialize) ifTrue: [ ^self ].
-	Author useAuthor: 'Generated' during: [
-		aClass compile: 'initialize
-	super initialize.' classified: 'initialization'.
-		] 
+	(aClass includesSelector: #initialize) ifTrue: [ ^ self ].
+
+	Author
+		useAuthor: 'Generated'
+		during: [ aClass
+				compile:
+					'initialize
+	super initialize.'
+				classified: 'initialization' ]
 ]
 
 { #category : #properties }
@@ -206,8 +193,17 @@ Slot >> ensureProperties [
 
 { #category : #private }
 Slot >> ensureSlotInitializationFor: aClass [
-	self ensureInitalizeMethodExists: aClass. 
-	self addSlotInitToInitialize: aClass.
+	| source |
+	(self sendsInitializeSlots: aClass) ifTrue: [ ^ self ].
+
+	self ensureInitalizeMethodExists: aClass.
+
+	source := (aClass >> #initialize) sourceCode allButFirst: 10.
+	source := 'initialize
+	
+	self class initializeSlots: self.' , source.
+
+	Author useAuthor: 'Generated' during: [ aClass compile: source classified: 'initialization' ]
 ]
 
 { #category : #finalization }
@@ -413,17 +409,17 @@ Slot >> scope: aScope [
 
 { #category : #private }
 Slot >> sendsInitializeSlots: aClass [
-		
-	aClass isTrait ifFalse: [ 
-		(aClass includesSelector: #initialize) ifFalse: [ 
-			^ self sendsInitializeSlots: aClass superclass ] ].
+	(aClass isTrait or: [ aClass includesSelector: #initialize ])
+		ifFalse: [ ^ self sendsInitializeSlots: aClass superclass ].
+
 	"verify implemented here"
-	((aClass>>#initialize) hasLiteral: #initializeSlots:) 
+	(aClass >> #initialize hasLiteral: #initializeSlots:)
 		ifTrue: [ ^ true ].
+
 	"if it calls superclass, verify there"
-	aClass isTrait ifFalse: [ 
-		((aClass>>#initialize) hasLiteral: #initialize) 
-			ifTrue: [ ^ self sendsInitializeSlots: aClass superclass ] ].
+	(aClass isTrait not and: [ aClass >> #initialize hasLiteral: #initialize ])
+		ifTrue: [ ^ self sendsInitializeSlots: aClass superclass ].
+
 	"is not implemented"
 	^ false
 ]

--- a/src/Slot-Core/Slot.class.st
+++ b/src/Slot-Core/Slot.class.st
@@ -413,8 +413,9 @@ Slot >> sendsInitializeSlots: aClass [
 		ifFalse: [ ^ self sendsInitializeSlots: aClass superclass ].
 
 	"verify implemented here"
-	(aClass >> #initialize hasLiteral: #initializeSlots:)
-		ifTrue: [ ^ true ].
+	aClass
+		compiledMethodAt: #initialize
+		ifPresent: [ :method | (method hasLiteral: #initializeSlots:) ifTrue: [ ^ true ] ].
 
 	"if it calls superclass, verify there"
 	(aClass isTrait not and: [ aClass >> #initialize hasLiteral: #initialize ])

--- a/src/Slot-Tests/SlotClassVariableTest.class.st
+++ b/src/Slot-Tests/SlotClassVariableTest.class.st
@@ -116,5 +116,7 @@ SlotClassVariableTest >> testWantsInitializationSkipInitializeSlotIfAlreadyInHie
 					yourself } ].
 
 	self assert: class2 slots size equals: 1.
-	self deny: ((class2 >> #initialize) hasLiteral: #initializeSlots:)
+	class2
+		compiledMethodAt: #initialize
+		ifPresent: [ self fail: 'In case the super method already call #initializeSlots:, we don''t want to generate an initialize method' ]
 ]


### PR DESCRIPTION
Do not generate useless initialize methods via slot usage.

When we use a slot, we ensure the #initialize method call #initializeSlots. But this mecanism can create useless initialize methods in case the superclass already call #initializeSlot and the subclass has nothing more to initialize. 
This change the position of #ensureInitializeMethodExists to not generate useless code.

+ Update tests