### PR TITLE
Added Fuel-Tools-Pharo as external dependency

### DIFF
--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -315,7 +315,7 @@ SystemDependenciesTest >> testExternalIDEDependencies [
 	BaselineOfKernelTests.
 	 } do: [ :baseline | packages := packages , {baseline name} , baseline allPackageNames ].
 
-	packages := packages , { BaselineOfFuel name } , (BaselineOfFuel packagesOfGroupNamed: #Core).
+	packages := packages , { BaselineOfFuel name } , (BaselineOfFuel packagesOfGroupNamed: #Core), #('Fuel-Tools-Pharo').
 	packages := packages , { BaselineOfFuelPlatform name } , BaselineOfFuelPlatform allPackageNames.
 
 	packages := packages ,  { BaselineOfCommander name} , (self packagesOfGroupNamed: 'default' on: BaselineOfCommander).


### PR DESCRIPTION
Added Fuel-Tools-Pharo as external dependency to SystemDependenciesTest>>testExternalIDEDependencies.
Fixes #6144.