### PR TITLE
backportIfErrorDo

### DIFF
--- a/src/Kernel/BlockClosure.class.st
+++ b/src/Kernel/BlockClosure.class.st
@@ -345,6 +345,21 @@ BlockClosure >> ifError: errorHandlerBlock [
 		errorHandlerBlock cull: ex description cull: ex receiver]
 ]
 
+{ #category : #evaluating }
+BlockClosure >> ifErrorDo: errorHandlerBlock [
+	"Evaluate the block represented by the receiver, and normally return it's value.  If an error occurs, the errorHandlerBlock is evaluated, and it's value is instead returned.  The errorHandlerBlock must accept zero or one parameter (the error object)."
+	"Examples:
+		[1 whatsUpDoc] ifErrorDo: [:err | 'huh?'].
+		[1 / 0] ifErrorDo: [:err |
+			ZeroDivide = err class
+				ifTrue: [Float infinity]
+				ifFalse: [self error: err]]
+"
+
+	^ self on: Error do: [:ex |
+		errorHandlerBlock cull: ex]
+]
+
 { #category : #accessing }
 BlockClosure >> isBlock [
 


### PR DESCRIPTION
backport ifErrorDo: from Pharo 9.0 to Pharo 8.0 to allow us to write code working in both versions