### PR TITLE
OCASTTranslator: simplify #addTemps: callers

### DIFF
--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -439,16 +439,16 @@ OCASTTranslator >> translateFullBlock: aBlockNode [
 	methodBuilder compilationContext: aBlockNode methodNode compilationContext.
 	
 	"args, then copied, then temps"
-	methodBuilder addTemps: (argumentNames := aBlockNode argumentNames asArray).
-	methodBuilder addTemps: (aBlockNode scope inComingCopiedVars asArray collect: [:each | each name]).
-	methodBuilder addTemps: ((aBlockNode scope tempVars asArray collect: [ :each | each name]) copyWithoutAll: argumentNames).
+	methodBuilder addTemps: (argumentNames := aBlockNode argumentNames).
+	methodBuilder addTemps: (aBlockNode scope inComingCopiedVarNames).
+	methodBuilder addTemps: (aBlockNode scope tempVarNames copyWithoutAll: argumentNames).
 	
 	methodBuilder numArgs: argumentNames size.
 	
 	aBlockNode scope tempVector ifNotEmpty: [
 		methodBuilder 
 			createTempVectorNamed: aBlockNode scope tempVectorName 
-			withVars: (aBlockNode scope tempVector collect: [:each| each name]) asArray.
+			withVars: aBlockNode scope tempVectorVarNames.
 	].
 	valueTranslator visitNode: aBlockNode body.
 	methodBuilder mapToNode: aBlockNode body.
@@ -479,27 +479,23 @@ OCASTTranslator >> visitAssignmentNode: anAssignmentNode [
 
 { #category : #'visitor-double dispatching' }
 OCASTTranslator >> visitBlockNode: aBlockNode [
-	| tempNames argumentNames copiedNames |
 	aBlockNode arguments size >15 ifTrue: [self backendError: 'Too many arguments' forNode: aBlockNode ].
 	
 	aBlockNode isInlined ifTrue: [^ self visitInlinedBlockNode: aBlockNode ].
 	
 	self compilationContext optionFullBlockClosure ifTrue: [ ^ self visitFullBlockNode: aBlockNode ].
 		
-	argumentNames := aBlockNode argumentNames asArray.
-	tempNames := (aBlockNode scope tempVars asArray collect: [ :each | each name]) copyWithoutAll: argumentNames.
-	copiedNames := (aBlockNode scope  inComingCopiedVars asArray collect: [:each | each name]).
 	methodBuilder
-			pushClosureCopyCopiedValues: copiedNames
-			args: argumentNames
+			pushClosureCopyCopiedValues: aBlockNode scope inComingCopiedVarNames
+			args: aBlockNode argumentNames
 			jumpTo:  #block.
 	 
 	aBlockNode scope tempVector ifNotEmpty: [
 		methodBuilder 
 			createTempVectorNamed: aBlockNode scope tempVectorName 
-			withVars: (aBlockNode scope tempVector collect: [:each| each name]) asArray.
+			withVars: aBlockNode scope tempVectorVarNames.
 	].
-	methodBuilder addTemps: tempNames.
+	methodBuilder addTemps: (aBlockNode scope tempVarNames copyWithoutAll: aBlockNode argumentNames).
 	valueTranslator visitNode: aBlockNode body.
 	methodBuilder addBlockReturnTopIfRequired.
 	self flag: 'why dont we just add a blockReturnTop here... it could be removed or ignored in IRTranslator'.
@@ -522,10 +518,9 @@ OCASTTranslator >> visitCascadeNode: aCascadeNode [
 
 { #category : #'visitor-double dispatching' }
 OCASTTranslator >> visitFullBlockNode: aBlockNode [
-	| compiledBlock copiedNames |
+	| compiledBlock |
 	compiledBlock := self compilationContext astTranslatorClass new translateFullBlock: aBlockNode.
-	copiedNames := (aBlockNode scope inComingCopiedVars asArray collect: [:each | each name]).
-	methodBuilder pushFullClosureCompiledBlock: compiledBlock copiedValues: copiedNames
+	methodBuilder pushFullClosureCompiledBlock: compiledBlock copiedValues: aBlockNode scope inComingCopiedVarNames
 ]
 
 { #category : #'visitor-double dispatching' }
@@ -537,27 +532,22 @@ OCASTTranslator >> visitInlinedBlockNode: anOptimizedBlockNode [
 			- we call IRBuilder to add temps
 	"
 	
-	| argumentNames tempNames  copiedNames  |
-	argumentNames := anOptimizedBlockNode argumentNames asArray.
-	tempNames := (anOptimizedBlockNode scope tempVars collect: [ :each | each name asSymbol]) copyWithoutAll: argumentNames.
-	copiedNames := (anOptimizedBlockNode scope inComingCopiedVars collect: [:each | each name]) asArray.
-	
+	| tempNamesNoArgs |
 	
 	anOptimizedBlockNode scope tempVector ifNotEmpty: [
 		methodBuilder 
 			createTempVectorNamed: anOptimizedBlockNode scope tempVectorName 
-			withVars: (anOptimizedBlockNode scope tempVector collect: [:each| each name]) asArray.
+			withVars: anOptimizedBlockNode scope tempVectorVarNames.
 	].
-	
-	methodBuilder addTemps: tempNames.
-	methodBuilder addTemps: copiedNames.
-	methodBuilder addTemps: argumentNames.
+	methodBuilder addTemps: (tempNamesNoArgs := anOptimizedBlockNode scope tempVarNames copyWithoutAll: anOptimizedBlockNode argumentNames).
+	methodBuilder addTemps: anOptimizedBlockNode scope inComingCopiedVarNames.
+	methodBuilder addTemps: anOptimizedBlockNode argumentNames.
 	anOptimizedBlockNode isInlinedLoop ifTrue: [
-		tempNames do: [ :tempName |
+		tempNamesNoArgs do: [ :tempName |
 			methodBuilder pushLiteral: nil.
 			methodBuilder storeTemp: tempName.
 			methodBuilder popTop.
-		 ]].
+		]].
 	
 	self visitNode: anOptimizedBlockNode body.
 ]

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -252,7 +252,7 @@ OCAbstractMethodScope >> setCopyingTempToAllScopesUpToDefTemp: aVar to: aValue f
 { #category : #'temp vars' }
 OCAbstractMethodScope >> tempVarNames [
 
-	^ self tempVars collect: [:each| each name]
+	^ self tempVars collect: [:each| each name] as: Array
 ]
 
 { #category : #'temp vars' }
@@ -279,4 +279,9 @@ OCAbstractMethodScope >> tempVectorVar [
 			name: self tempVectorName;
 			scope: self;
 			yourself]
+]
+
+{ #category : #'temp vars - vector' }
+OCAbstractMethodScope >> tempVectorVarNames [
+	^ tempVector collect: [:each| each name] as: Array
 ]

--- a/src/OpalCompiler-Core/OCBlockScope.class.st
+++ b/src/OpalCompiler-Core/OCBlockScope.class.st
@@ -13,6 +13,11 @@ OCBlockScope >> hasEscapingVars [
 ]
 
 { #category : #accessing }
+OCBlockScope >> inComingCopiedVarNames [
+	^self inComingCopiedVars collect: [:each | each name] as: Array
+]
+
+{ #category : #accessing }
 OCBlockScope >> inComingCopiedVars [
 	^ copiedVars select: [:each | outerScope copiedVars includes: each]
 ]

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -124,19 +124,14 @@ RFASTTranslator >> visitAssignmentNode: anAssignmentNode [
 
 { #category : #'visitor-double dispatching' }
 RFASTTranslator >> visitBlockNode: aBlockNode [
-	| tempNames argumentNames copiedNames |
 	aBlockNode arguments size >15 ifTrue: [self backendError: 'Too many arguments' forNode: aBlockNode ].
 	
 	aBlockNode isInlined ifTrue: [^ self visitInlinedBlockNode: aBlockNode ].
-		
-	argumentNames := aBlockNode argumentNames asArray.
-	tempNames := (aBlockNode scope tempVars asArray collect: [ :each | each name]) copyWithoutAll: argumentNames.
-	copiedNames := (aBlockNode scope  inComingCopiedVars asArray collect: [:each | each name]).
 	
 	aBlockNode hasMetalinkInstead ifFalse: [  
 	methodBuilder
-			pushClosureCopyCopiedValues: copiedNames
-			args: argumentNames
+			pushClosureCopyCopiedValues: aBlockNode scope inComingCopiedVarNames
+			args: aBlockNode argumentNames
 			jumpTo:  #block.
 	 
 	aBlockNode scope tempVector ifNotEmpty: [
@@ -144,7 +139,7 @@ RFASTTranslator >> visitBlockNode: aBlockNode [
 			createTempVectorNamed: aBlockNode scope tempVectorName 
 			withVars: (aBlockNode scope tempVector collect: [:each| each name]) asArray.
 	].
-	methodBuilder addTemps: tempNames.
+	methodBuilder addTemps: (aBlockNode scope tempVarNames copyWithoutAll: aBlockNode argumentNames).
 	self emitPreamble: aBlockNode.
 	self emitMetaLinkBefore: aBlockNode.
 	valueTranslator visitNode: aBlockNode body.
@@ -184,21 +179,15 @@ RFASTTranslator >> visitInlinedBlockNode: anOptimizedBlockNode [
 			- we call IRBuilder to add temps
 	"
 	
-	| argumentNames tempNames  copiedNames  |
-	argumentNames := anOptimizedBlockNode argumentNames asArray.
-	tempNames := (anOptimizedBlockNode scope tempVars collect: [ :each | each name asSymbol]) copyWithoutAll: argumentNames.
-	copiedNames := (anOptimizedBlockNode scope inComingCopiedVars collect: [:each | each name]) asArray.
-	
-	
+	| tempNames  |
 	anOptimizedBlockNode scope tempVector ifNotEmpty: [
 		methodBuilder 
 			createTempVectorNamed: anOptimizedBlockNode scope tempVectorName 
-			withVars: (anOptimizedBlockNode scope tempVector collect: [:each| each name]) asArray.
+			withVars: (anOptimizedBlockNode scope tempVector collect: [:each| each name]).
 	].
-	
-	methodBuilder addTemps: tempNames.
-	methodBuilder addTemps: copiedNames.
-	methodBuilder addTemps: argumentNames.
+	methodBuilder addTemps: (tempNames := anOptimizedBlockNode scope tempVarNames copyWithoutAll: anOptimizedBlockNode argumentNames).
+	methodBuilder addTemps: anOptimizedBlockNode scope inComingCopiedVarNames.
+	methodBuilder addTemps: anOptimizedBlockNode argumentNames.
 	anOptimizedBlockNode isInlinedLoop ifTrue: [
 		tempNames do: [ :tempName |
 			methodBuilder pushLiteral: nil.


### PR DESCRIPTION
- add #tempVectorVarNames and #inComingCopiedVarNames on the Block/method scope

This then allows us to use these instead of creating an array of names when we call #addTemps.