### PR TITLE
Fixing the installation of a different world.

### DIFF
--- a/src/Graphics-Display Objects/Cursor.class.st
+++ b/src/Graphics-Display Objects/Cursor.class.st
@@ -1082,7 +1082,7 @@ Cursor >> printOn: aStream [
 { #category : #displaying }
 Cursor >> show [
 	"Make the hardware's mouse cursor look like the receiver"
-	self currentWorld activeHand currentCursor: self
+	self currentWorld activeHand ifNotNil: [:aHand | aHand currentCursor: self ]
 ]
 
 { #category : #displaying }

--- a/src/Morphic-Base/TextMorph.class.st
+++ b/src/Morphic-Base/TextMorph.class.st
@@ -1311,7 +1311,7 @@ TextMorph >> paragraph [
 	wrapFlag ifFalse:
 		["Was given huge container at first... now adjust"
 		newParagraph adjustRightX].
-	newParagraph focused: (self currentHand keyboardFocus == self).
+	newParagraph focused: self hasFocus.
 	paragraph := newParagraph.
 	self fit.
 	self removeProperty: #CreatingParagraph.

--- a/src/Morphic-Base/WorldMorph.extension.st
+++ b/src/Morphic-Base/WorldMorph.extension.st
@@ -41,18 +41,26 @@ WorldMorph >> dispatchKeystroke: anEvent [
 { #category : #'*Morphic-Base' }
 WorldMorph >> install [
 
-	"this method was used to be invoked from onPrimitiveError: 
-	the problem is that it cannot be used to recreate the world instance.
-	For this have a look class side installNewWorld."
-
+	"This method should not be used. This is for backward compatibility and will be replaced
+	with a newer solution"
+   
 	owner := nil.	"since we may have been inside another world previously"
 	ActiveWorld := self.
 	World := self.
-	submorphs do: [ :ss | ss owner ifNil: [ ss privateOwner: self ] ].	"Transcript that was in outPointers and then got deleted."
-	self viewBox: Display boundingBox.
-	Sensor flushAllButDandDEvents.
+	
+	self hands ifEmpty: [self addHand: HandMorph new].
+
+	self worldState worldRenderer: AbstractWorldRenderer mainWorldRenderer.
+	AbstractWorldRenderer mainWorldRenderer world: self.  
+	
+	submorphs do: [ :ss | ss owner ifNil: [ ss privateOwner: self ] ].	
+		
 	worldState handsDo: [ :h | h initForEvents ].
-	self borderWidth: 0.	"default"
+	self borderWidth: 0.	
 	SystemWindow noteTopWindowIn: self.
-	self displayWorldSafely
+	self displayWorldSafely.
+	self extent: self worldState worldRenderer actualScreenSize.
+	self viewBox: self worldState worldRenderer viewBox.
+	Sensor flushAllButDandDEvents.
+
 ]

--- a/src/Morphic-Core/AbstractWorldRenderer.class.st
+++ b/src/Morphic-Core/AbstractWorldRenderer.class.st
@@ -44,6 +44,11 @@ AbstractWorldRenderer class >> initialize [
 ]
 
 { #category : #accessing }
+AbstractWorldRenderer class >> mainWorldRenderer [
+	^ MainWorldRenderer 
+]
+
+{ #category : #accessing }
 AbstractWorldRenderer class >> priority [ 
 
 	^ 0


### PR DESCRIPTION
This method is for backward compatibility and should not be used as it will be replaced.
New tools should not use it, and old should be migrated.
Once, we have the complete change we will provide a deprecation and a replacement.
This is to keep working the tools that are using it, as now there is no replacement yet.