### PR TITLE
Cleanup: #hasBindingThatBeginsWith in tools

### DIFF
--- a/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
+++ b/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
@@ -201,13 +201,6 @@ ClyTextEditorToolMorph >> hasBindingOf: aString [
 	^self selectedClassOrMetaClass hasBindingOf: aString
 ]
 
-{ #category : #'rubric interaction model' }
-ClyTextEditorToolMorph >> hasBindingThatBeginsWith: aString [ 
-	^self selectedClassOrMetaClass 
-		ifNil: [ false ]
-		ifNotNil: [:c | c hasBindingThatBeginsWith: aString]
-]
-
 { #category : #testing }
 ClyTextEditorToolMorph >> hasUnacceptedEdits [
 	textMorph ifNil: [ ^false ].

--- a/src/Glamour-Morphic-Widgets/GLMRubricSmalltalkTextModel.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMRubricSmalltalkTextModel.class.st
@@ -60,11 +60,6 @@ GLMRubricSmalltalkTextModel >> hasBindingOf: aSymbol [
 	^ self variableBindings includesKey: aSymbol
 ]
 
-{ #category : #bindings }
-GLMRubricSmalltalkTextModel >> hasBindingThatBeginsWith: aString [
-	^ self variableBindings keys anySatisfy: [:each | each beginsWith: aString]
-]
-
 { #category : #shout }
 GLMRubricSmalltalkTextModel >> highlightSmalltalk [
 	^ highlightSmalltalk

--- a/src/Glamour-Morphic-Widgets/GLMSmalltalkCodeModel.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMSmalltalkCodeModel.class.st
@@ -55,11 +55,6 @@ GLMSmalltalkCodeModel >> hasBindingOf: aSymbol [
 ]
 
 { #category : #accessing }
-GLMSmalltalkCodeModel >> hasBindingThatBeginsWith: aString [
-	^ self variableBindings keys anySatisfy: [:each | each beginsWith: aString]
-]
-
-{ #category : #accessing }
 GLMSmalltalkCodeModel >> highlightSmalltalk [
 	^ highlightSmalltalk
 ]

--- a/src/Kernel/SharedPool.class.st
+++ b/src/Kernel/SharedPool.class.st
@@ -32,12 +32,10 @@ SharedPool class >> classBindingOf: varName [
 SharedPool class >> hasBindingThatBeginsWith: aString [
 	"Answer true if the receiver has a binding that begins with aString, false otherwise"
 
-	"First look in classVar dictionary."
-	(self classPool hasBindingThatBeginsWith: aString) ifTrue:[^true].
-	"Next look in shared pools."
-	self sharedPools do:[:pool | 
-		(pool hasBindingThatBeginsWith: aString) ifTrue: [^true]].
-	^false
+	"First look in classVar dictionary"
+	(self classPool hasBindingThatBeginsWith: aString) ifTrue:[^ true ].
+	"Next look in shared pools"
+	^ self sharedPools anySatisfy: [:pool | pool hasBindingThatBeginsWith: aString ]
 ]
 
 { #category : #testing }

--- a/src/ProfStef-Core/LessonView.class.st
+++ b/src/ProfStef-Core/LessonView.class.st
@@ -68,13 +68,6 @@ LessonView >> doItReceiver [
 	^ nil
 ]
 
-{ #category : #hack }
-LessonView >> hasBindingThatBeginsWith: aString [
-	"this method should not be defined here, normally when the interaction model of the RubScrolledTextModel is set to nil the hasBindingThatBeginsWith: message is not sent. Check method RubScrolledTextModel hasBindingThatBeginsWith:. Now if we remove this method, we get an error with RubScrolledTextModel  which has a LessonView as interaction model. I have no idea where it is set."
-
-	^ false
-]
-
 { #category : #initialization }
 LessonView >> initialize [
 

--- a/src/Rubric/RubScrolledTextModel.class.st
+++ b/src/Rubric/RubScrolledTextModel.class.st
@@ -111,11 +111,6 @@ RubScrolledTextModel >> hasBindingOf: aString [
 	^ interactionModel ifNil: [ false ] ifNotNil: [ interactionModel hasBindingOf: aString ]
 ]
 
-{ #category : #shout }
-RubScrolledTextModel >> hasBindingThatBeginsWith: aString [ 
-	^ interactionModel ifNil: [ false ] ifNotNil:  [ interactionModel hasBindingThatBeginsWith: aString  ]
-]
-
 { #category : #accessing }
 RubScrolledTextModel >> hasUnacceptedEdits [
 	^ hasUnacceptedEdits ifNil: [ hasUnacceptedEdits := false ]

--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -150,12 +150,6 @@ RubSmalltalkCodeMode >> hasBindingOf: aString [
 	^ self model notNil and: [ self model hasBindingOf: aString ]
 ]
 
-{ #category : #shout }
-RubSmalltalkCodeMode >> hasBindingThatBeginsWith: aString [ 
-	" For the shout styler "
-	^ self model notNil and: [ self model hasBindingThatBeginsWith: aString ]
-]
-
 { #category : #parsing }
 RubSmalltalkCodeMode >> parseExpression: aString [
 

--- a/src/Rubric/RubTextAreaExamples.class.st
+++ b/src/Rubric/RubTextAreaExamples.class.st
@@ -104,11 +104,6 @@ RubTextAreaExamples class >> hasBindingOf: aString [
 	
 ]
 
-{ #category : #shout }
-RubTextAreaExamples class >> hasBindingThatBeginsWith: aString [
-	^false
-]
-
 { #category : #accessing }
 RubTextAreaExamples class >> interactionModel [
 	^ ModelForShout 

--- a/src/Rubric/RubWorkspaceExample.class.st
+++ b/src/Rubric/RubWorkspaceExample.class.st
@@ -101,11 +101,6 @@ RubWorkspaceExample >> hasBindingOf: aString [
 	^bindings includesKey: aString asSymbol
 ]
 
-{ #category : #shout }
-RubWorkspaceExample >> hasBindingThatBeginsWith: aString [
-	^false
-]
-
 { #category : #initialization }
 RubWorkspaceExample >> initialize [
 	super initialize.

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -759,11 +759,6 @@ SmalltalkImage >> growMemoryByAtLeast: numBytes [
 	^self primitiveFailed
 ]
 
-{ #category : #'to clean later' }
-SmalltalkImage >> hasBindingThatBeginsWith: aString [
-	^globals hasBindingThatBeginsWith: aString
-]
-
 { #category : #'class and trait names' }
 SmalltalkImage >> hasClassNamed: aString [
 	"Answer whether there is a class of the given name, but don't intern aString if it's not alrady interned."

--- a/src/Tool-Workspace/Workspace.class.st
+++ b/src/Tool-Workspace/Workspace.class.st
@@ -198,11 +198,6 @@ Workspace >> hasBindingOf: aString [
 	^bindings includesKey: aString asSymbol
 ]
 
-{ #category : #'shout bindings' }
-Workspace >> hasBindingThatBeginsWith: aString [
-	^ bindings keys anySatisfy: [:each | each beginsWith: aString]
-]
-
 { #category : #initialization }
 Workspace >> initialize [
 	super initialize.


### PR DESCRIPTION
#hasBindingThatBeginsWith: is not send anymore by the tools (the mechanism uses the #hasIncompleteIdentifier on RBVariableNode instead)

(#hasIncompleteIdentifier needs another pass, too, but that is not part of this PR)

What this PR does:
- keep #hasBindingThatBeginsWith:  on the level of Dictionary and Class / Pool
- remove all the unused implementations on the tool level
- simplify #hasBindingThatBeginsWith: on SharedPool class to use anySatisfy: