### PR TITLE
Cleanup: #lookUpForDeclaration: in the Compiler

### DIFF
--- a/src/OpalCompiler-Core/LookupForDeclaration.class.st
+++ b/src/OpalCompiler-Core/LookupForDeclaration.class.st
@@ -1,0 +1,15 @@
+"
+When looking up temp var declarations, we do not want the Requestor scope to automatically create that variable. OCRequestorScope is skipped if this variable is set.
+
+See #lookupVarForDeclaration: how it is used.
+"
+Class {
+	#name : #LookupForDeclaration,
+	#superclass : #DynamicVariable,
+	#category : #'OpalCompiler-Core-Semantics'
+}
+
+{ #category : #accessing }
+LookupForDeclaration >> default [
+	^false
+]

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -171,13 +171,6 @@ OCAbstractMethodScope >> lookupVar: name [
 	
 ]
 
-{ #category : #lookup }
-OCAbstractMethodScope >> lookupVarForDeclaration: name [
-	tempVars at: name ifPresent: [:v | ^ v].
-	name = 'thisContext' ifTrue: [^ thisContextVar].
-	^self outerScope lookupVarForDeclaration: name
-]
-
 { #category : #scope }
 OCAbstractMethodScope >> methodScope [
 

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -63,11 +63,13 @@ OCAbstractScope >> lookupVar: name [
 
 { #category : #lookup }
 OCAbstractScope >> lookupVarForDeclaration: name [
-	"This is a version of #lookupVar: that skips the OCRequestorScope.
-	When looking temp var declarations, we do not want the Requestor scope to automatically
-	create that variable. Subclasses override if they do not skip but do a lookup"
+	"This is a version of #lookupVar: that skips defining vars the OCRequestorScope.
+	When looking up a temp var declarations, we do not want the Requestor scope to automatically
+	create that variable."
 
-	^ self outerScope lookupVarForDeclaration: name
+	^ LookupForDeclaration 
+		value: true 
+		during: [ self lookupVar: name ]
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCClassScope.class.st
+++ b/src/OpalCompiler-Core/OCClassScope.class.st
@@ -60,11 +60,6 @@ OCClassScope >> lookupVar: name [
 		ifNil: [ outerScope lookupVar: name] 
 ]
 
-{ #category : #lookup }
-OCClassScope >> lookupVarForDeclaration: name [
-	^self lookupVar: name
-]
-
 { #category : #levels }
 OCClassScope >> newMethodScope [
 	^ self instanceScope newMethodScope

--- a/src/OpalCompiler-Core/OCInstanceScope.class.st
+++ b/src/OpalCompiler-Core/OCInstanceScope.class.st
@@ -60,14 +60,6 @@ OCInstanceScope >> lookupVar: name [
 	^ vars at: name ifAbsent: [self outerScope lookupVar: name]
 ]
 
-{ #category : #lookup }
-OCInstanceScope >> lookupVarForDeclaration: name [
-	"Return a ScopeVar for my inst var with this name.  Return nil if none found"
-	name = 'self' ifTrue: [^ selfVar].
-	name = 'super' ifTrue: [^ superVar].
-	^ vars at: name ifAbsent: [self outerScope lookupVarForDeclaration: name]
-]
-
 { #category : #scope }
 OCInstanceScope >> newMethodScope [
 

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -39,6 +39,9 @@ OCRequestorScope >> findVariable: aBlock ifNone: aNotFound [
 { #category : #lookup }
 OCRequestorScope >> lookupVar: name [
 
+	"do not create bindings if we lookup for declaration"
+	LookupForDeclaration value ifTrue: [ ^ outerScope lookupVar: name ].
+
 	name = 'self' ifTrue: [ ^ outerScope lookupVar: name ].
 	name = 'super' ifTrue: [ ^ outerScope lookupVar: name ].
 	name first isUppercase ifTrue: [ ^ outerScope lookupVar: name].


### PR DESCRIPTION
#lookupVarForDeclaration: was was duplicating the lookupVar: logic just to skip the OCRequestorScope lookup when in interactive use.

Instead of re-implemeting the lookup, the new version uses a dynamic variable LookupForDeclaration that is set to true in #lookupVarForDeclaration: and then checked in OCRequestorScope>>#lookupVar:

This way we can reuse the implementation of #lookupVar: instead of copying it.