### PR TITLE
MemoryFileWriteStream fix

### DIFF
--- a/src/FileSystem-Memory/MemoryFileWriteStream.class.st
+++ b/src/FileSystem-Memory/MemoryFileWriteStream.class.st
@@ -52,7 +52,7 @@ MemoryFileWriteStream >> isBinary [
 { #category : #writing }
 MemoryFileWriteStream >> next: anInteger putAll: aCollection startingAt: anInteger3 [ 
 	
-	stream next: anInteger putAll: aCollection startingAt: anInteger3 
+	self stream next: anInteger putAll: aCollection startingAt: anInteger3 
 ]
 
 { #category : #writing }
@@ -76,13 +76,13 @@ MemoryFileWriteStream >> position: anInteger [
 	as anInteger is within the bounds of the receiver's contents. If it is not, 
 	create an error notification."
 
-	stream position: anInteger
+	self stream position: anInteger
 ]
 
 { #category : #reading }
 MemoryFileWriteStream >> readInto: aCollection startingAt: anInteger count: anInteger3 [ 
 
-	^ stream readInto: aCollection startingAt: anInteger count: anInteger3 
+	^ self stream readInto: aCollection startingAt: anInteger count: anInteger3 
 ]
 
 { #category : #positioning }

--- a/src/FileSystem-Memory/MemoryFileWriteStream.class.st
+++ b/src/FileSystem-Memory/MemoryFileWriteStream.class.st
@@ -79,12 +79,6 @@ MemoryFileWriteStream >> position: anInteger [
 	self stream position: anInteger
 ]
 
-{ #category : #reading }
-MemoryFileWriteStream >> readInto: aCollection startingAt: anInteger count: anInteger3 [ 
-
-	^ self stream readInto: aCollection startingAt: anInteger count: anInteger3 
-]
-
 { #category : #positioning }
 MemoryFileWriteStream >> setToEnd [
 	^ self stream setToEnd

--- a/src/FileSystem-Tests-Memory/MemoryFileSystemTest.class.st
+++ b/src/FileSystem-Tests-Memory/MemoryFileSystemTest.class.st
@@ -216,3 +216,25 @@ MemoryFileSystemTest >> testNotEqualWhenRequestingMemoryFileSystem [
 	other := self createFileSystem.
 	self deny: other equals: filesystem
 ]
+
+{ #category : #tests }
+MemoryFileSystemTest >> testStreamWriteAndRead [
+	"Test writing custom collection and reading it [partially] back."
+	
+	| writer reader testData |
+	testData := ByteArray new: 50 streamContents: [ :out |
+						1 to: 50 do: [ :i | out nextPut: i ]
+					].
+	writer := (filesystem / 'test.out') binaryWriteStream.
+	writer next: 20 putAll: testData startingAt: 10.
+	writer position: 10; nextPutAll: #[1 2 3 4 5].
+	self assert: writer position equals: 15.
+	writer close.
+
+	reader := (filesystem / 'test.out') binaryReadStream.
+	self assert: reader size equals: 15.
+	self assert: (reader next: 15)
+			equals: #[10 11 12 13 14 15 16 17 18 19 1 2 3 4 5].
+
+	^ self
+]


### PR DESCRIPTION
In some methods `stream` instance variable was used directly. This should resolve #2335 issue.