### PR TITLE
[Enh]Add pointersToAmong: that is a faster solution than multiple pointersTo

### DIFF
--- a/src/Kernel-Tests/ProtoObjectTest.class.st
+++ b/src/Kernel-Tests/ProtoObjectTest.class.st
@@ -11,6 +11,22 @@ Class {
 }
 
 { #category : #'tests - testing' }
+ProtoObjectTest >> testFastPointersTo [
+	| myObject myArray myObject2 allObjects |
+	myObject := Object new.
+	myObject2 := Object new.
+	myArray := {myObject.
+	myObject2}.
+	allObjects := SystemNavigation default allObjects.
+	self
+		assert: (myObject pointersToAmong: allObjects) asArray
+		equals: {myArray}.
+	self
+		assert: (myObject2 pointersToAmong: allObjects) asArray
+		equals: {myArray}
+]
+
+{ #category : #'tests - testing' }
 ProtoObjectTest >> testFlag [
 	ProtoObject new flag: #hallo
 ]

--- a/src/Kernel/ProtoObject.class.st
+++ b/src/Kernel/ProtoObject.class.st
@@ -274,6 +274,20 @@ ProtoObject >> pointersTo [
 ]
 
 { #category : #'pointing to' }
+ProtoObject >> pointersToAmong: aCollectionOfObjects [
+	"Meant to be used as: 
+	Smalltalk garbageCollect.
+	objs := SystemNavigation default allObjects.
+	anyObject pointersToAmong: objs.
+	otherObject pointersToAmong: objs.
+	
+	Avoid multiple calls to allObjects Primitive and multiple gcs.
+	"
+
+	^ self pointersToExcept: #() among: aCollectionOfObjects
+]
+
+{ #category : #'pointing to' }
 ProtoObject >> pointersToExcept: objectsToExclude [
 	"Find all objects in the system that hold a pointer to me, excluding those listed"
 	| c pointers objectsToAlwaysExclude |
@@ -293,6 +307,29 @@ ProtoObject >> pointersToExcept: objectsToExclude [
 		(ea == thisContext sender) or: [ "warning: this expression is dependent on closure structure of this method"
 			(objectsToAlwaysExclude identityIncludes: ea)
 				or: [objectsToExclude identityIncludes: ea ]] ]) asArray
+]
+
+{ #category : #'pointing to' }
+ProtoObject >> pointersToExcept: objectsToExclude among: aCollectionOfObjects [
+	"Find all objects in the system that hold a pointer to me, excluding those listed.
+	This method is meant to be a faster solution if used several times on several objects rather than calling the GC multiples times.
+	See pointersToExcept: for usage.
+	"
+
+	| pointers objectsToAlwaysExclude |
+	pointers := OrderedCollection new.
+	pointers := aCollectionOfObjects select: [ :e | e pointsTo: self ].
+	objectsToAlwaysExclude := {thisContext.
+	thisContext sender.
+	thisContext sender sender.
+	objectsToExclude}.
+	^ (pointers
+		removeAllSuchThat: [ :ea | 
+			ea == thisContext sender
+				or:
+					[ "warning: this expression is dependent on closure structure of this method"
+					(objectsToAlwaysExclude identityIncludes: ea)
+						or: [ objectsToExclude identityIncludes: ea ] ] ]) asArray
 ]
 
 { #category : #'pointing to' }


### PR DESCRIPTION
Meant to be used as: 

```
Smalltalk garbageCollect.
objs := SystemNavigation default allObjects.
anyObject pointersToAmong: objs.
otherObject pointersToAmong: objs.
```
	
to avoid multiple calls to allObjects Primitive and multiple gcs.
