### PR TITLE
Try fix #6021 

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -49,7 +49,6 @@ BaselineOfIDE >> additionalInitialization [
 
 	PolymorphSystemSettings desktopColor:  Color veryVeryLightGray lighter.
 	SourceCodeFonts setSourceCodeFonts: 10.
-	LogicalFontManager unload.
 	FreeTypeSystemSettings loadFt2Library: true.
 	FreeTypeSettings current monitorType: #LCD.
 	FreeTypeSettings current glyphContrast: 55.
@@ -85,9 +84,7 @@ BaselineOfIDE >> additionalInitialization [
 	SDL_Event initialize.
 	
 	HiRulerBuilderTest initialize.
-	
-	LogicalFontManager current addFontProvider: FreeTypeFontProvider current.
-	
+		
 	3 timesRepeat: [
 		Smalltalk garbageCollect.
 		Undeclared removeUnreferencedKeys.].

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -317,8 +317,6 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 	ZnConstants ZnMimeType ZnNetworkingUtils ZnServer ZnSingleThreadedServer
 	) do: [:each | (Smalltalk globals at: each) initialize. ].
 
-	LogicalFontManager current addFontProvider: FreeTypeFontProvider current.
-
 	BalloonMorph setBalloonColorTo: Color yellow.
 
 	UIManager default terminateUIProcess.
@@ -348,6 +346,8 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 
 	#(#AbstractFont #BalloonMorph #CP1253TextConverter #Clipboard #EditorFindReplaceDialogWindow #EmbeddedFreeTypeFontInstaller #FLCompiledMethodCluster #FLLargeIdentityHashedCollection #FLPlatform #FreeTypeFontProvider #GB2312 #GradientFillStyle #GreekEnvironment #ISO88597TextConverter #IconicButton #JISX0208 #JapaneseEnvironment #KOI8RTextConverter #KMLog #KSX1001 #KoreanEnvironment #LogicalFont #LucidaGrandeRegular #OSEnvironment #RussianEnvironment #ScrollBar #SimplifiedChineseEnvironment "#SourceCodeProRegular #SourceSansProRegular" #StrikeFont #SystemSettingsPersistence #TabMorph #TaskbarMorph #Text #TextAction #TextConstants #TextEditor #TextStyle) do: [:each |
 		 (Smalltalk globals at: each) initialize. ].
+
+	LogicalFontManager current addFontProvider: FreeTypeFontProvider current.
 
 	array := Smalltalk specialObjectsArray copy.
 	array at: 5 put: Bitmap.


### PR DESCRIPTION
Explicitly set a taskbar to the world at initialization time, instead of depending on the chaotic order of class side `initialize` methods and their global dependencies.

This is cleaner than having global dependencies.

Let's wait until the CI finishes to see if the resulting image has the taskbar.