### PR TITLE
Integrate Heuristic Completion v3.0.2

### DIFF
--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -147,6 +147,12 @@ CoASTResultSetBuilder >> visitParseErrorNode: aRBParseErrorNode [
 ]
 
 { #category : #visiting }
+CoASTResultSetBuilder >> visitPragmaNode: aRBPragmaNode [
+
+	^ self visitNode: aRBPragmaNode
+]
+
+{ #category : #visiting }
 CoASTResultSetBuilder >> visitReturnNode: aRBReturnNode [ 
 	
 	^ self visitNode: aRBReturnNode

--- a/src/HeuristicCompletion-Model/CoSuperMessageHeuristic.class.st
+++ b/src/HeuristicCompletion-Model/CoSuperMessageHeuristic.class.st
@@ -15,7 +15,10 @@ CoSuperMessageHeuristic >> appliesForNode: aNode inContext: aContext [
 
 	^ (aNode isMessage
 		and: [ aNode receiver isSuper ])
-			or: [ aNode isMethod ]
+			or: [ aNode isMethod
+				and: [ 
+					"This heuristic is not valid for traits and nil subclasses"
+					aContext completionClass superclass notNil ] ]
 ]
 
 { #category : #requests }

--- a/src/HeuristicCompletion-Model/CoTypeInferencer.class.st
+++ b/src/HeuristicCompletion-Model/CoTypeInferencer.class.st
@@ -69,14 +69,13 @@ CoTypeInferencer >> inferFrom: aClass typeGetters: aBoolean [
 	receiverClass := aClass.
 	aClass allInstVarNames do: [ :each |
 		self ensureTypeOfVariable: each ].
-	self inferMethod: (aClass lookupSelector: #initialize).
+	self tryInferSelector: #initialize.
 	aClass isTestCase ifTrue: [
-		self inferMethod: (aClass lookupSelector: #setUp) ].
+		self tryInferSelector: #setUp ].
 	
 	aBoolean ifTrue: [ 
 		aClass allInstVarNames do: [ :each |
-			(aClass lookupSelector: each) ifNotNil: [ :getter |
-				self inferMethod: getter ] ] ].
+			self tryInferSelector: each ] ].
 	self cleanupTypes
 ]
 
@@ -180,6 +179,18 @@ CoTypeInferencer >> stackMessage: aBlock level: aNewLevel [
 		method := previousMethod.
 		temporaryVariables := previousTemporaries.
 		argumentVariables := previousArguments ]
+]
+
+{ #category : #inference }
+CoTypeInferencer >> tryInferSelector: aSelector [
+
+	"Try to infer types from a selector in the current class.
+	If the class has no such selector, do nothing."
+	
+	| foundMethod |
+	foundMethod := (receiverClass lookupSelector: #initialize).
+	foundMethod ifNil: [ ^ self ].
+	self inferMethod: foundMethod
 ]
 
 { #category : #accessing }

--- a/src/HeuristicCompletion-Tests/CoASTResultSetBuilderTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoASTResultSetBuilderTest.class.st
@@ -122,6 +122,19 @@ CoASTResultSetBuilderTest >> testBuildParseErrorHeuristic [
 ]
 
 { #category : #tests }
+CoASTResultSetBuilderTest >> testBuildPragmaHeuristic [
+
+	| builder |
+	builder := CoMockASTResultSetBuilder new.
+	builder
+		completionContext: CoCompletionContext new;
+		node: RBPragmaNode new;
+		buildCompletion.
+		
+	self assert: builder heuristic equals: #pragma
+]
+
+{ #category : #tests }
 CoASTResultSetBuilderTest >> testBuildReturnHeuristic [
 
 	| builder |

--- a/src/HeuristicCompletion-Tests/CoInitializeTypeInferenceTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoInitializeTypeInferenceTest.class.st
@@ -1,0 +1,52 @@
+Class {
+	#name : #CoInitializeTypeInferenceTest,
+	#superclass : #TestCase,
+	#category : #'HeuristicCompletion-Tests-Core'
+}
+
+{ #category : #tests }
+CoInitializeTypeInferenceTest >> testInferInstanceVariableNotUsedInInitializeHasNoType [
+
+	| types |
+	types := CoTypeInferencer new
+		inferFrom: (CoMockClass new
+			methodAt: #initialize put: (CoMockMethod new
+				source: 'initialize
+					a := 1'
+				yourself);
+			instanceVariables: #(a b c);
+			yourself);
+		variables.
+		
+	self assert: (types at: #b) isEmpty
+]
+
+{ #category : #tests }
+CoInitializeTypeInferenceTest >> testInferInstanceVariableUsedInInitialize [
+
+	| types |
+	types := CoTypeInferencer new
+		inferFrom: (CoMockClass new
+			methodAt: #initialize put: (CoMockMethod new
+				source: 'initialize
+					a := 1'
+				yourself);
+			instanceVariables: #(a b c);
+			yourself);
+		variables.
+		
+	self assertCollection: (types at: #a) hasSameElements: { SmallInteger }
+]
+
+{ #category : #tests }
+CoInitializeTypeInferenceTest >> testInferVariablesWithNoInitializeFindsNoTypes [
+
+	| types |
+	types := CoTypeInferencer new
+		inferFrom: (CoMockClass new
+			instanceVariables: #(a b c);
+			yourself);
+		variables.
+		
+	self assert: (types values allSatisfy: [ :e | e isEmpty ]).
+]

--- a/src/HeuristicCompletion-Tests/CoMockASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Tests/CoMockASTResultSetBuilder.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'heuristic'
 	],
-	#category : #'HeuristicCompletion-Tests'
+	#category : #'HeuristicCompletion-Tests-Core'
 }
 
 { #category : #accessing }
@@ -74,6 +74,13 @@ CoMockASTResultSetBuilder >> visitParseErrorNode: aNode [
 
 	heuristic := #error.
 	^ super visitParseErrorNode: aNode
+]
+
+{ #category : #visiting }
+CoMockASTResultSetBuilder >> visitPragmaNode: aRBPragmaNode [ 
+
+	heuristic := #pragma.
+	^ super visitPragmaNode: aRBPragmaNode
 ]
 
 { #category : #accessing }

--- a/src/HeuristicCompletion-Tests/CoMockClass.class.st
+++ b/src/HeuristicCompletion-Tests/CoMockClass.class.st
@@ -8,7 +8,8 @@ Class {
 		'instanceVariables',
 		'selectors',
 		'classVariables',
-		'superclass'
+		'superclass',
+		'methodDictionary'
 	],
 	#category : #'HeuristicCompletion-Tests-Core'
 }
@@ -17,6 +18,16 @@ Class {
 CoMockClass >> addInstanceVariable: aString [ 
 	
 	instanceVariables := instanceVariables copyWith: aString
+]
+
+{ #category : #accessing }
+CoMockClass >> allInstVarNames [
+	
+	| superclassVarNames |
+	superclassVarNames := superclass
+		ifNil: [ #() ]
+		ifNotNil: [ superclass allInstVarNames ].
+	^ superclassVarNames , instanceVariables 
 ]
 
 { #category : #accessing }
@@ -35,7 +46,7 @@ CoMockClass >> classVariables: aCollection [
 CoMockClass >> initialize [
 
 	super initialize.
-	selectors := OrderedCollection new
+	methodDictionary := OrderedDictionary new
 ]
 
 { #category : #accessing }
@@ -60,20 +71,47 @@ CoMockClass >> instanceVariables: anObject [
 	instanceVariables := anObject
 ]
 
+{ #category : #testing }
+CoMockClass >> isTestCase [
+	
+	^ false
+]
+
+{ #category : #methods }
+CoMockClass >> lookupSelector: aString [ 
+	
+	^ methodDictionary
+		at: aString
+		ifAbsent: [ 
+			superclass ifNil: [ ^ nil ].
+			superclass lookupSelector: aString ]
+]
+
+{ #category : #methods }
+CoMockClass >> methodAt: aString put: aCoMockMethod [ 
+	
+	methodDictionary at: aString asSymbol put: aCoMockMethod.
+	aCoMockMethod methodClass: self
+]
+
 { #category : #accessing }
 CoMockClass >> selectors [
-	^ selectors
+	^ methodDictionary keys
 ]
 
 { #category : #accessing }
 CoMockClass >> selectors: aCollection [ 
-	selectors := aCollection
+
+	"Install nil methods just for compatibility"
+	aCollection do: [ :k |
+		methodDictionary at: k put: nil
+	]
 ]
 
 { #category : #enumerating }
 CoMockClass >> selectorsDo: aBlockClosure [ 
 	
-	selectors do: aBlockClosure
+	self selectors do: aBlockClosure
 ]
 
 { #category : #accessing }

--- a/src/HeuristicCompletion-Tests/CoMockMethod.class.st
+++ b/src/HeuristicCompletion-Tests/CoMockMethod.class.st
@@ -1,0 +1,31 @@
+Class {
+	#name : #CoMockMethod,
+	#superclass : #Object,
+	#instVars : [
+		'ast',
+		'methodClass'
+	],
+	#category : #'HeuristicCompletion-Tests-Core'
+}
+
+{ #category : #accessing }
+CoMockMethod >> ast [
+	^ ast
+]
+
+{ #category : #accessing }
+CoMockMethod >> methodClass [
+	
+	^ methodClass
+]
+
+{ #category : #accessing }
+CoMockMethod >> methodClass: aCoMockClass [ 
+	methodClass := aCoMockClass
+]
+
+{ #category : #accessing }
+CoMockMethod >> source: aString [ 
+	
+	ast := RBParser parseMethod: aString 
+]

--- a/src/HeuristicCompletion-Tests/CoSuperMessageHeuristicTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoSuperMessageHeuristicTest.class.st
@@ -1,0 +1,41 @@
+Class {
+	#name : #CoSuperMessageHeuristicTest,
+	#superclass : #TestCase,
+	#category : #'HeuristicCompletion-Tests-Heuristics'
+}
+
+{ #category : #test }
+CoSuperMessageHeuristicTest >> testDoesApplyForMethodNodeInContextWithSuperclass [
+
+	self assert: (CoSuperMessageHeuristic new
+		appliesForNode: RBMethodNode new
+		inContext: (CoCompletionContext new
+			completionClass: (CoMockClass new superclass: CoMockClass new);
+			yourself))
+]
+
+{ #category : #test }
+CoSuperMessageHeuristicTest >> testDoesApplyForSuperMessageSendNodes [
+
+	self assert: (CoSuperMessageHeuristic new
+		appliesForNode: (RBMessageNode receiver: RBSuperNode new selector: #foo)
+		inContext: nil)
+]
+
+{ #category : #test }
+CoSuperMessageHeuristicTest >> testDoesNotApplyForMethodNodeInContextWithNoSuperclass [
+
+	self deny: (CoSuperMessageHeuristic new
+		appliesForNode: RBMethodNode new
+		inContext: (CoCompletionContext new
+			completionClass: (CoMockClass new superclass: nil);
+			yourself))
+]
+
+{ #category : #test }
+CoSuperMessageHeuristicTest >> testDoesNotApplyForNonSuperMessageSendNodes [
+
+	self deny: (CoSuperMessageHeuristic new
+		appliesForNode: (RBMessageNode receiver: RBVariableNode new selector: #foo)
+		inContext: nil)
+]


### PR DESCRIPTION
Fix https://github.com/pharo-project/pharo/issues/6180
Fix https://github.com/pharo-project/pharo/issues/6163
Fix https://github.com/pharo-project/pharo/issues/6181

From tag v3.0.2 in https://github.com/guillep/complishon/

In detail:
- Completion works now on classes without superclasses
- Completion works in classes not defining initialize methods
- Completion works on pragmas

With tests