### PR TITLE
6188-add unit test for announcemen covering issuance from exception handler block

### DIFF
--- a/src/Announcements-Core-Tests/AnnouncerTest.class.st
+++ b/src/Announcements-Core-Tests/AnnouncerTest.class.st
@@ -64,6 +64,19 @@ AnnouncerTest >> testAnnounceInstance [
 	self assert: (announcer announce: instance) equals: instance
 ]
 
+{ #category : #'tests - subscribing' }
+AnnouncerTest >> testAnnounceWorkWithinExceptionHandlerBlocks [
+	|  found |
+	
+	announcer when: Announcement do: [ found := true ].
+	
+	[ NotFound signal ]
+		on: NotFound
+		do: [ announcer announce: Announcement new ].
+		
+	self assert: found
+]
+
 { #category : #tests }
 AnnouncerTest >> testAnnouncingReentrant [
 	"Test that it is safe to announce when handling announcement,


### PR DESCRIPTION
experimenting with contributing to Pharo by pushing a borrowed Sunit for AnnouncementsNote, could not figure how to get past the "INVALID-ISSSUE" title being assigned , obviously the lookup is failing for some reason