### PR TITLE
[review needed] Repair arg renaming refactoring

### DIFF
--- a/src/Calypso-SystemTools-Core/ClySourceCodeContext.class.st
+++ b/src/Calypso-SystemTools-Core/ClySourceCodeContext.class.st
@@ -113,7 +113,7 @@ ClySourceCodeContext >> isMethodSelected [
 ClySourceCodeContext >> isTempVariableSelected [
 	| node |
 	node := self selectedSourceNode.
-	^node isVariable and: [ node isTemp]
+	^node isVariable and: [ node isArgOrTemp ]
 ]
 
 { #category : #testing }

--- a/src/Calypso-SystemTools-Core/ClySourceCodeContext.class.st
+++ b/src/Calypso-SystemTools-Core/ClySourceCodeContext.class.st
@@ -67,6 +67,13 @@ ClySourceCodeContext >> executeCommand: aCommand by: aCommandActivator [
 ]
 
 { #category : #testing }
+ClySourceCodeContext >> isArgOrTempVariableSelected [
+	| node |
+	node := self selectedSourceNode.
+	^node isVariable and: [ node isArgOrTemp ]
+]
+
+{ #category : #testing }
 ClySourceCodeContext >> isAssignmentSelected [
 	| node |
 	node := self selectedSourceNode.
@@ -113,7 +120,7 @@ ClySourceCodeContext >> isMethodSelected [
 ClySourceCodeContext >> isTempVariableSelected [
 	| node |
 	node := self selectedSourceNode.
-	^node isVariable and: [ node isArgOrTemp ]
+	^node isVariable and: [ node isTemp ]
 ]
 
 { #category : #testing }

--- a/src/Calypso-SystemTools-Core/ClySourceCodeContext.class.st
+++ b/src/Calypso-SystemTools-Core/ClySourceCodeContext.class.st
@@ -70,7 +70,7 @@ ClySourceCodeContext >> executeCommand: aCommand by: aCommandActivator [
 ClySourceCodeContext >> isArgOrTempVariableSelected [
 	| node |
 	node := self selectedSourceNode.
-	^node isVariable and: [ node isArgOrTemp ]
+	^node isVariable and: [ node isArgument or: [ node isTemp ] ]
 ]
 
 { #category : #testing }

--- a/src/Calypso-SystemTools-Core/SycRenameArgOrTempCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycRenameArgOrTempCommand.extension.st
@@ -1,14 +1,14 @@
-Extension { #name : #SycRenameTempCommand }
+Extension { #name : #SycRenameArgOrTempCommand }
 
 { #category : #'*Calypso-SystemTools-Core' }
-SycRenameTempCommand classSide >> sourceCodeMenuActivation [
+SycRenameArgOrTempCommand class >> sourceCodeMenuActivation [
 	<classAnnotation>
 	
 	^SycSourceCodeMenuActivation byRootGroupItemOrder: 1.2 for: ClyMethodSourceCodeContext
 ]
 
 { #category : #'*Calypso-SystemTools-Core' }
-SycRenameTempCommand classSide >> sourceCodeShortcutActivation [
+SycRenameArgOrTempCommand class >> sourceCodeShortcutActivation [
 	<classAnnotation>
 	
 	^CmdShortcutActivation renamingFor: ClyMethodSourceCodeContext

--- a/src/Calypso-SystemTools-Core/SycRenameTempCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycRenameTempCommand.extension.st
@@ -1,14 +1,14 @@
 Extension { #name : #SycRenameTempCommand }
 
 { #category : #'*Calypso-SystemTools-Core' }
-SycRenameTempCommand class >> sourceCodeMenuActivation [
+SycRenameTempCommand classSide >> sourceCodeMenuActivation [
 	<classAnnotation>
 	
 	^SycSourceCodeMenuActivation byRootGroupItemOrder: 1.2 for: ClyMethodSourceCodeContext
 ]
 
 { #category : #'*Calypso-SystemTools-Core' }
-SycRenameTempCommand class >> sourceCodeShortcutActivation [
+SycRenameTempCommand classSide >> sourceCodeShortcutActivation [
 	<classAnnotation>
 	
 	^CmdShortcutActivation renamingFor: ClyMethodSourceCodeContext

--- a/src/GeneralRules/ReTemporaryVariableCapitalizationRule.class.st
+++ b/src/GeneralRules/ReTemporaryVariableCapitalizationRule.class.st
@@ -42,7 +42,7 @@ ReTemporaryVariableCapitalizationRule >> critiqueFor: aNode [
 	crit	
 		tinyHint: aNode name;
 		refactoring: (
-			RBRenameTemporaryRefactoring
+			RBRenameArgumentOrTemporaryRefactoring
 				renameTemporaryFrom: aNode sourceInterval
 				to: aNode name uncapitalized
 				in: aNode methodNode methodClass

--- a/src/NautilusRefactoring/NautilusRefactoring.class.st
+++ b/src/NautilusRefactoring/NautilusRefactoring.class.st
@@ -999,7 +999,7 @@ NautilusRefactoring >> privateRenameMethodFor: aMethod withNewName: newMethodNam
 { #category : #'private-source' }
 NautilusRefactoring >> privateRenameTemporaryNamed: oldname Between: anInterval from: aMethod [
 
-	^ RBRenameTemporaryRefactoring
+	^ RBRenameArgumentOrTemporaryRefactoring
 		model: environment
 		renameTemporaryFrom: anInterval
 		to: (self request: self newVariableRequestText initialAnswer: oldname)

--- a/src/Refactoring-Core/RBRenameArgumentOrTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameArgumentOrTemporaryRefactoring.class.st
@@ -7,7 +7,7 @@ The variable declaration an all references in this method are renamed.
 My precondition verify that the new name is a valid variable name and not an existing instance or a class variable name
 "
 Class {
-	#name : #RBRenameTemporaryRefactoring,
+	#name : #RBRenameArgumentOrTemporaryRefactoring,
 	#superclass : #RBMethodRefactoring,
 	#instVars : [
 		'selector',
@@ -20,7 +20,7 @@ Class {
 }
 
 { #category : #'instance creation' }
-RBRenameTemporaryRefactoring class >> model: aRBSmalltalk renameTemporaryFrom: anInterval to: newName in: aClass selector: aSelector [ 
+RBRenameArgumentOrTemporaryRefactoring class >> model: aRBSmalltalk renameTemporaryFrom: anInterval to: newName in: aClass selector: aSelector [ 
 	^(self new)
 		model: aRBSmalltalk;
 		class: aClass
@@ -31,7 +31,7 @@ RBRenameTemporaryRefactoring class >> model: aRBSmalltalk renameTemporaryFrom: a
 ]
 
 { #category : #'instance creation' }
-RBRenameTemporaryRefactoring class >> renameTemporaryFrom: anInterval to: newName in: aClass selector: aSelector [ 
+RBRenameArgumentOrTemporaryRefactoring class >> renameTemporaryFrom: anInterval to: newName in: aClass selector: aSelector [ 
 	^self new
 		class: aClass
 		selector: aSelector
@@ -40,7 +40,7 @@ RBRenameTemporaryRefactoring class >> renameTemporaryFrom: anInterval to: newNam
 ]
 
 { #category : #initialization }
-RBRenameTemporaryRefactoring >> class: aClass selector: aSelector interval: anInterval newName: aString [ 
+RBRenameArgumentOrTemporaryRefactoring >> class: aClass selector: aSelector interval: anInterval newName: aString [ 
 	class := self classObjectFor: aClass.
 	selector := aSelector.
 	interval := anInterval.
@@ -48,7 +48,7 @@ RBRenameTemporaryRefactoring >> class: aClass selector: aSelector interval: anIn
 ]
 
 { #category : #preconditions }
-RBRenameTemporaryRefactoring >> preconditions [
+RBRenameArgumentOrTemporaryRefactoring >> preconditions [
 	^ (RBCondition
 		withBlock: [ | methodSource |
 			interval first > interval last
@@ -62,7 +62,7 @@ RBRenameTemporaryRefactoring >> preconditions [
 ]
 
 { #category : #tranforming }
-RBRenameTemporaryRefactoring >> renameNode: aParseTree [
+RBRenameArgumentOrTemporaryRefactoring >> renameNode: aParseTree [
 	(aParseTree whoDefines: newName)
 		ifNotNil: [ self refactoringError: newName asString , ' is already defined' ].
 	(aParseTree allDefinedVariables includes: newName)
@@ -71,7 +71,7 @@ RBRenameTemporaryRefactoring >> renameNode: aParseTree [
 ]
 
 { #category : #printing }
-RBRenameTemporaryRefactoring >> storeOn: aStream [ 
+RBRenameArgumentOrTemporaryRefactoring >> storeOn: aStream [ 
 	aStream nextPut: $(.
 	self class storeOn: aStream.
 	aStream nextPutAll: ' renameTemporaryFrom: '.
@@ -88,7 +88,7 @@ RBRenameTemporaryRefactoring >> storeOn: aStream [
 ]
 
 { #category : #tranforming }
-RBRenameTemporaryRefactoring >> transform [
+RBRenameArgumentOrTemporaryRefactoring >> transform [
 	| definingNode variableNode |
 	parseTree := class parseTreeFor: selector.
 	variableNode := self whichVariableNode: parseTree inInterval: interval name: oldName.

--- a/src/Refactoring-Help/RBBrowserSourceRefactoringHelp.class.st
+++ b/src/Refactoring-Help/RBBrowserSourceRefactoringHelp.class.st
@@ -93,7 +93,7 @@ RBBrowserSourceRefactoringHelp class >> pages [
 RBBrowserSourceRefactoringHelp class >> renameTemporaryRefactoring [
 	^HelpTopic
 		title: 'Rename temporary/parameter'
-		contents: RBRenameTemporaryRefactoring comment
+		contents: RBRenameArgumentOrTemporaryRefactoring comment
 
 ]
 

--- a/src/Refactoring-Tests-Core/RBRenameTemporaryTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenameTemporaryTest.class.st
@@ -8,7 +8,7 @@ Class {
 RBRenameTemporaryTest >> testBadInterval [
 	self
 		shouldFail:
-			(RBRenameTemporaryRefactoring
+			(RBRenameArgumentOrTemporaryRefactoring
 				renameTemporaryFrom: (14 to: 17)
 				to: 'asdf'
 				in: RBRefactoryTestDataApp
@@ -19,25 +19,25 @@ RBRenameTemporaryTest >> testBadInterval [
 RBRenameTemporaryTest >> testBadName [
 	self
 		shouldFail:
-			(RBRenameTemporaryRefactoring
+			(RBRenameArgumentOrTemporaryRefactoring
 				renameTemporaryFrom: (15 to: 19)
 				to: 'name'
 				in: RBLintRuleTestData
 				selector: #openEditor);
 		shouldFail:
-			(RBRenameTemporaryRefactoring
+			(RBRenameArgumentOrTemporaryRefactoring
 				renameTemporaryFrom: (15 to: 19)
 				to: 'rules'
 				in: RBLintRuleTestData
 				selector: #openEditor);
 		shouldFail:
-			(RBRenameTemporaryRefactoring
+			(RBRenameArgumentOrTemporaryRefactoring
 				renameTemporaryFrom: (15 to: 19)
 				to: 'DependentFields'
 				in: RBLintRuleTestData
 				selector: #openEditor);
 		shouldFail:
-			(RBRenameTemporaryRefactoring
+			(RBRenameArgumentOrTemporaryRefactoring
 				renameTemporaryFrom: (15 to: 19)
 				to: 'a b'
 				in: RBLintRuleTestData
@@ -53,12 +53,12 @@ RBRenameTemporaryTest >> testModelBadName [
 		compile: 'aMethod: temp1 ^[| temp2 | temp2 := [:temp3 | temp3 = 5] value: 5. temp2] value'
 		classified: #(#accessing).
 	self
-		shouldFail: (RBRenameTemporaryRefactoring 
+		shouldFail: (RBRenameArgumentOrTemporaryRefactoring 
 					renameTemporaryFrom: (20 to: 24)
 					to: 'temp3'
 					in: class
 					selector: #aMethod:);
-		shouldFail: (RBRenameTemporaryRefactoring 
+		shouldFail: (RBRenameArgumentOrTemporaryRefactoring 
 					renameTemporaryFrom: (20 to: 24)
 					to: 'temp1'
 					in: class
@@ -68,7 +68,7 @@ RBRenameTemporaryTest >> testModelBadName [
 { #category : #tests }
 RBRenameTemporaryTest >> testRenameTemporary [
 	| refactoring |
-	refactoring := RBRenameTemporaryRefactoring
+	refactoring := RBRenameArgumentOrTemporaryRefactoring
 		renameTemporaryFrom: (15 to: 19)
 		to: 'asdf'
 		in: RBLintRuleTestData

--- a/src/SystemCommands-MethodCommands-Tests/SycConvertTempToinstVarCommandTest.class.st
+++ b/src/SystemCommands-MethodCommands-Tests/SycConvertTempToinstVarCommandTest.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : #SycConvertTempToinstVarCommandTest,
+	#superclass : #TestCase,
+	#category : #'SystemCommands-MethodCommands-Tests'
+}
+
+{ #category : #tests }
+SycConvertTempToinstVarCommandTest >> testCanExecuteOnArgumentNode [
+	| argNode sourceCodeContext |
+	"we don't need to set the tools"
+	argNode := RBArgumentNode new.
+	sourceCodeContext := ClySourceCodeContext for: nil selectedNode: argNode.
+	self deny: (SycConvertTempToInstVarCommand canBeExecutedInContext: sourceCodeContext).
+
+]
+
+{ #category : #tests }
+SycConvertTempToinstVarCommandTest >> testCanExecuteOnTemporaryNode [
+	| sourceCodeContext tempNode |
+	"we don't need to set the tools"
+	tempNode := RBTemporaryNode new.
+	sourceCodeContext := ClySourceCodeContext for: nil selectedNode: tempNode.
+	self assert: (SycConvertTempToInstVarCommand canBeExecutedInContext: sourceCodeContext).
+]

--- a/src/SystemCommands-MethodCommands-Tests/SycInlineTempCommandTest.class.st
+++ b/src/SystemCommands-MethodCommands-Tests/SycInlineTempCommandTest.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : #SycInlineTempCommandTest,
+	#superclass : #TestCase,
+	#category : #'SystemCommands-MethodCommands-Tests'
+}
+
+{ #category : #tests }
+SycInlineTempCommandTest >> testCanExecuteOnArgumentNode [
+	| argNode sourceCodeContext |
+	"we don't need to set the tools"
+	argNode := RBArgumentNode new.
+	sourceCodeContext := ClySourceCodeContext for: nil selectedNode: argNode.
+	self deny: (SycInlineTempCommand canBeExecutedInContext: sourceCodeContext).
+
+]
+
+{ #category : #tests }
+SycInlineTempCommandTest >> testCanExecuteOnTemporaryNode [
+	| sourceCodeContext tempNode |
+	"we don't need to set the tools"
+	tempNode := RBTemporaryNode new.
+	sourceCodeContext := ClySourceCodeContext for: nil selectedNode: tempNode.
+	self assert: (SycInlineTempCommand canBeExecutedInContext: sourceCodeContext).
+]

--- a/src/SystemCommands-MethodCommands-Tests/SycRenameArgOrTempCommandTest.class.st
+++ b/src/SystemCommands-MethodCommands-Tests/SycRenameArgOrTempCommandTest.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #SycRenameArgOrTempCommandTest,
+	#superclass : #TestCase,
+	#category : #'SystemCommands-MethodCommands-Tests'
+}
+
+{ #category : #tests }
+SycRenameArgOrTempCommandTest >> testCanExecuteOnArgumentNode [
+	| argNode sourceCodeContext |
+	"we don't need to set the tools"
+	argNode := RBArgumentNode new.
+	sourceCodeContext := ClySourceCodeContext for: nil selectedNode: argNode.
+	self assert: (SycRenameArgOrTempCommand canBeExecutedInContext: sourceCodeContext).
+
+]
+
+{ #category : #tests }
+SycRenameArgOrTempCommandTest >> testCanExecuteOnTemporaryNode [
+	| sourceCodeContext tempNode |
+	"we don't need to set the tools"
+	tempNode := RBTemporaryNode new.
+	sourceCodeContext := ClySourceCodeContext for: nil selectedNode: tempNode.
+	self assert: (SycRenameArgOrTempCommand canBeExecutedInContext: sourceCodeContext).
+
+]

--- a/src/SystemCommands-MethodCommands-Tests/package.st
+++ b/src/SystemCommands-MethodCommands-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'SystemCommands-MethodCommands-Tests' }

--- a/src/SystemCommands-SourceCodeCommands/SycRenameArgOrTempCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycRenameArgOrTempCommand.class.st
@@ -19,7 +19,7 @@ Class {
 SycRenameArgOrTempCommand class >> canBeExecutedInContext: aSourceCodeContext [
 	super canBeExecutedInContext: aSourceCodeContext.
 	
-	^aSourceCodeContext isArgOrTempVariableSelected 
+	^ aSourceCodeContext isArgOrTempVariableSelected 
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-SourceCodeCommands/SycRenameArgOrTempCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycRenameArgOrTempCommand.class.st
@@ -7,7 +7,7 @@ Internal Representation and Key Implementation Points.
 	newName:		<String>
 "
 Class {
-	#name : #SycRenameTempCommand,
+	#name : #SycRenameArgOrTempCommand,
 	#superclass : #SycSourceCodeCommand,
 	#instVars : [
 		'newName'
@@ -16,33 +16,33 @@ Class {
 }
 
 { #category : #execution }
-SycRenameTempCommand class >> canBeExecutedInContext: aSourceCodeContext [
+SycRenameArgOrTempCommand class >> canBeExecutedInContext: aSourceCodeContext [
 	super canBeExecutedInContext: aSourceCodeContext.
 	
-	^aSourceCodeContext isTempVariableSelected 
+	^aSourceCodeContext isArgOrTempVariableSelected 
 ]
 
 { #category : #execution }
-SycRenameTempCommand >> applyResultInContext: aSourceCodeContext [
+SycRenameArgOrTempCommand >> applyResultInContext: aSourceCodeContext [
 	super applyResultInContext: aSourceCodeContext.
 	
 	aSourceCodeContext showVariableNamed: newName
 ]
 
 { #category : #accessing }
-SycRenameTempCommand >> defaultMenuIconName [ 
+SycRenameArgOrTempCommand >> defaultMenuIconName [ 
 	^ #edit
 ]
 
 { #category : #accessing }
-SycRenameTempCommand >> defaultMenuItemName [
+SycRenameArgOrTempCommand >> defaultMenuItemName [
 	^'Rename temp'
 ]
 
 { #category : #execution }
-SycRenameTempCommand >> execute [
+SycRenameArgOrTempCommand >> execute [
 	| refactoring |
-	refactoring := RBRenameTemporaryRefactoring	
+	refactoring := RBRenameArgumentOrTemporaryRefactoring	
 		renameTemporaryFrom: sourceNode sourceInterval
 		to: newName
 		in: method origin
@@ -52,7 +52,7 @@ SycRenameTempCommand >> execute [
 ]
 
 { #category : #execution }
-SycRenameTempCommand >> prepareFullExecutionInContext: aSourceCodeContext [
+SycRenameArgOrTempCommand >> prepareFullExecutionInContext: aSourceCodeContext [
 	super prepareFullExecutionInContext: aSourceCodeContext.
 	
 	newName := UIManager default 


### PR DESCRIPTION
The first commit shows the problem.
I'm offering some renaming the next three, and differentiation of the #isTempNodeSelected.
I'm arguing that we're reasoning from an AST point of view, and that nodes should be differentiated.
(We had the same problem with the compiler, making #isTemp "complicated" to modify correctly).

Also, 3 refactoring depend on #isTempNodeSelected.
1 of them is actually using #isTempOrArgNodeSelected.
2 of them actually want the right semantic that exists for #isTempNodeSelected.
(unless I'm mistaken)

On the testing part, I'm not sure of what to test.
I'd tend to test SycRenameArgOrTempCommand >> canBeExecutedInContext:
But this requires the creation of a SourceCodeContext which I'm not too sure about.
Also this is required for every refactor commands.
@guillep What do you think?

I'll complete this PR later