### PR TITLE
Fix Process>#isSuspended

### DIFF
--- a/src/Kernel-Tests-Extended/ProcessTest.class.st
+++ b/src/Kernel-Tests-Extended/ProcessTest.class.st
@@ -183,8 +183,48 @@ ProcessTest >> testInjectingMultipleExceptionHandlersIntoRunningProcess [
 ]
 
 { #category : #tests }
+ProcessTest >> testIsNotSuspendedWhenItIsActiveProcess [
+
+	| semaphore suspended |
+	semaphore := Semaphore new.
+	[ suspended := Processor activeProcess isSuspended. semaphore signal ] fork.
+	semaphore wait.
+	self deny: suspended
+]
+
+{ #category : #tests }
+ProcessTest >> testIsNotSuspendedWhenItIsRunningButNotActiveProcess [
+
+	| semaphore process |
+	semaphore := Semaphore new.
+	process := [ semaphore signal. Processor yield ] fork.
+	semaphore wait.
+	self deny: process isTerminated.
+	self deny: process isSuspended
+]
+
+{ #category : #tests }
+ProcessTest >> testIsNotSuspendedWhenItIsTerminated [
+
+	| semaphore process |
+	semaphore := Semaphore new.
+	process := [ semaphore signal] fork.
+	semaphore wait.
+	self assert: process isTerminated.
+	self deny: process isSuspended
+]
+
+{ #category : #tests }
 ProcessTest >> testIsSelfEvaluating [
 	self assert: Processor printString equals: 'Processor'
+]
+
+{ #category : #tests }
+ProcessTest >> testIsSuspendedWhenItIsNotStartedYet [
+
+	| process |
+	process := [  ] newProcess.
+	self assert: process isSuspended
 ]
 
 { #category : #'tests - termination' }
@@ -233,7 +273,7 @@ ProcessTest >> testIsTerminatingForcedTermination [
 	self assert: terminator identicalTo: process ].
 
 	[ process isTerminated ] whileFalse: [ 50 milliSeconds asDelay wait ].
-	self assert: process isSuspended.
+	self deny: process isSuspended.
 	self assert: process isTerminating.
 	self assert: process isTerminated.
 	self assert: started.
@@ -267,7 +307,7 @@ ProcessTest >> testIsTerminatingForcedTerminationWithoutRunning [
 	self deny: unwound.
 
 	process terminate.
-	self assert: process isSuspended.
+	self deny: process isSuspended.
 	self assert: process isTerminating.
 	self assert: process isTerminated.
 	"The process never ran"
@@ -296,7 +336,7 @@ ProcessTest >> testIsTerminatingNormalTermination [
 	sem signal.
 	self waitForProcessTermination: process.
 	"#terminate will be sent by the process itself after its context has finished (see BlockClosure>>newProcess)"
-	self assert: process isSuspended.
+	self deny: process isSuspended.
 	self assert: process isTerminating.
 	self assert: process isTerminated.
 	self assert: started.

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -290,6 +290,9 @@ Process >> isActiveProcess [
 
 { #category : #testing }
 Process >> isSuspended [
+	"Answer true if I was never scheduled yet (new process, never been sent #resume) or paused (was sent #suspend)"
+	self isActiveProcess ifTrue: [ ^false ].
+	self isTerminated ifTrue: [ ^false ].
 	^myList isNil or: [ myList isEmpty ]
 ]
 


### PR DESCRIPTION
#isSuspended method returns incorrect process state. For example:```Smalltalk[state := Processor activeProcess isSuspeded] fork.```returns true in state variable.PR describes problem cases with tests and fixes them with Cuis version.