### PR TITLE
IRBuilder-fill-TempOffsets

### DIFF
--- a/src/OpalCompiler-Core/IRBuilder.class.st
+++ b/src/OpalCompiler-Core/IRBuilder.class.st
@@ -97,9 +97,10 @@ IRBuilder >> addTemp: tempKey [
 	tempMap := self currentScope tempMap.
 	
 	"adding the same var multiple times reuses the same offset"
-	(tempMap includesKey: tempKey) ifTrue: [ ^ self ].
+	(tempMap includesKey: tempKey) ifTrue: [ ^ 	self cacheIndex: tempKey ].
 	
-	tempMap at: tempKey put: tempMap size + 1
+	tempMap at: tempKey put: tempMap size + 1.
+	self cacheIndex: tempKey.
 ]
 
 { #category : #initialize }
@@ -125,6 +126,16 @@ IRBuilder >> blockReturnTop [
 	self popScope.
 ]
 
+{ #category : #initialize }
+IRBuilder >> cacheIndex: tempKey [
+	"if we have the ast, we can store the temp offset"
+	self sourceNode ifNotNil: [ :sourceNode | 
+		| var |
+		var := sourceNode scope lookupVar: tempKey.
+		"some vars (e.g. limits in loops) do not exist on the AST level"
+		var ifNotNil: [ var index: (self currentScope tempMap at: tempKey) ] ].
+]
+
 { #category : #accessing }
 IRBuilder >> compilationContext [
 	^ir compilationContext 
@@ -138,10 +149,13 @@ IRBuilder >> compilationContext: aCompilationContext [
 { #category : #initialize }
 IRBuilder >> createTempVectorNamed: name withVars: anArray [
 	
-	"self addVectorTemps: anArray."
 	self addTemp: name.
 	self add: (IRInstruction createTempVectorNamed: name withVars: anArray).
-
+	
+	"if we have the ast, we can store the temp offsets"
+	self sourceNode ifNotNil: [ :sourceNode |
+		anArray doWithIndex: [ :varName :i|
+			(sourceNode scope lookupVar: varName) index: i]]
 ]
 
 { #category : #scopes }

--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -377,8 +377,3 @@ IRMethod >> tempKeys [
 IRMethod >> tempMap [
 	^ tempMap
 ]
-
-{ #category : #enumerating }
-IRMethod >> tempVectorNamed: aName [
-	^startSequence tempVectorNamed: aName
-]

--- a/src/OpalCompiler-Core/IRPushClosureCopy.class.st
+++ b/src/OpalCompiler-Core/IRPushClosureCopy.class.st
@@ -124,8 +124,3 @@ IRPushClosureCopy >> tempVectorName [
 	self blockSequence do:[:irNode | irNode isTempVector ifTrue:[^irNode name]].
 	^nil.
 ]
-
-{ #category : #accessing }
-IRPushClosureCopy >> tempVectorNamed: aName [
-	^ blockSequence tempVectorNamed: aName
-]

--- a/src/OpalCompiler-Core/IRSequence.class.st
+++ b/src/OpalCompiler-Core/IRSequence.class.st
@@ -374,11 +374,6 @@ IRSequence >> successorSequences [
 	^ sequence last successorSequences
 ]
 
-{ #category : #accessing }
-IRSequence >> tempVectorNamed: aSymbol [
-	^sequence detect: [:irNode | irNode isTempVector and: [irNode name = aSymbol]].
-]
-
 { #category : #'successor sequences' }
 IRSequence >> withAllSuccessors [
 	"Return me and all my successors sorted by sequence orderNumber"

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -436,6 +436,7 @@ OCASTTranslator >> shouldBeSentToValueOrEffectTranslator [
 { #category : #'visitor-double dispatching' }
 OCASTTranslator >> translateFullBlock: aBlockNode [
 	| argumentNames |
+	methodBuilder mapToNode: aBlockNode.
 	methodBuilder compilationContext: aBlockNode methodNode compilationContext.
 	
 	"args, then copied, then temps"
@@ -534,6 +535,7 @@ OCASTTranslator >> visitInlinedBlockNode: anOptimizedBlockNode [
 	
 	| tempNamesNoArgs |
 	
+	methodBuilder mapToNode: anOptimizedBlockNode.
 	anOptimizedBlockNode scope tempVector ifNotEmpty: [
 		methodBuilder 
 			createTempVectorNamed: anOptimizedBlockNode scope tempVectorName 
@@ -550,6 +552,7 @@ OCASTTranslator >> visitInlinedBlockNode: anOptimizedBlockNode [
 		]].
 	
 	self visitNode: anOptimizedBlockNode body.
+	methodBuilder popMap
 ]
 
 { #category : #'visitor-double dispatching' }

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -113,11 +113,6 @@ OCAbstractMethodScope >> id: int [
 	id := int
 ]
 
-{ #category : #'temp vars' }
-OCAbstractMethodScope >> indexFromIRForVarNamed: aName [
-	^self outerNotOptimizedScope node irInstruction indexForVarNamed: aName
-]
-
 { #category : #initialization }
 OCAbstractMethodScope >> initialize [
 

--- a/src/OpalCompiler-Core/OCClassScope.class.st
+++ b/src/OpalCompiler-Core/OCClassScope.class.st
@@ -54,7 +54,7 @@ OCClassScope >> instanceScope [
 OCClassScope >> lookupVar: name [
 	"Return a SemVar for my pool var with this name.  Return nil if none found"
 
-	^(class innerBindingOf: name asSymbol) 
+	^(class innerBindingOf: name) 
 		ifNotNil: [:assoc | OCLiteralVariable new 
 			assoc: assoc; 
 			scope: self; 

--- a/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
@@ -12,6 +12,12 @@ Class {
 	#category : #'OpalCompiler-Core-Semantics'
 }
 
+{ #category : #accessing }
+OCCopyingTempVariable >> index: anIndex [
+	self scope == originalVar scope ifTrue: [ originalVar index: anIndex ].
+	super index: anIndex
+]
+
 { #category : #testing }
 OCCopyingTempVariable >> isCopying [
 	^true

--- a/src/OpalCompiler-Core/OCEnvironmentScope.class.st
+++ b/src/OpalCompiler-Core/OCEnvironmentScope.class.st
@@ -36,8 +36,9 @@ OCEnvironmentScope >> hasBindingThatBeginsWith: aString [
 { #category : #lookup }
 OCEnvironmentScope >> lookupVar: name [
 	"Return a var with this name.  Return nil if none found"
-
-	^(environment bindingOf: name asSymbol) ifNotNil: [:assoc | 
+	name isString ifFalse: [ ^nil ].
+	
+	^(environment bindingOf: name) ifNotNil: [:assoc | 
 		OCLiteralVariable new 
 			assoc: assoc; 
 			scope: self; 

--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -56,15 +56,18 @@ OCTempVariable >> hash [
 	^ name hash bitXor: (usage hash bitXor: scope hash).
 ]
 
-{ #category : #debugging }
-OCTempVariable >> indexFromIR [
-	^index ifNil: [index := scope indexFromIRForVarNamed: name]
+{ #category : #accessing }
+OCTempVariable >> index [
+	^ index ifNil: [ 
+		"if the index is nil, we are in an AST after name analysis but before
+		IR generation. To fill the the index, we generate the ir."
+		scope node methodNode ir. 
+		index ifNil: [ self error: 'no temp index, should never happen' ] ]
 ]
 
-{ #category : #debugging }
-OCTempVariable >> indexInTempVectorFromIR: aName [
-	"if I am storing  temp vector, return the index of var name"
-	^(scope node irInstruction tempVectorNamed: name) indexForVarNamed: aName
+{ #category : #accessing }
+OCTempVariable >> index: anObject [
+	index := anObject
 ]
 
 { #category : #initialization }
@@ -149,7 +152,7 @@ OCTempVariable >> readFromContext: aContext scope: contextScope [
 { #category : #debugging }
 OCTempVariable >> readFromLocalContext: aContext [
 
-	^ aContext tempAt: self indexFromIR
+	^ aContext tempAt: self index
 ]
 
 { #category : #debugging }
@@ -163,5 +166,5 @@ OCTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 { #category : #debugging }
 OCTempVariable >> writeFromLocalContext: aContext put: aValue [
 
-	^ aContext tempAt: self indexFromIR put: aValue
+	^ aContext tempAt: self index put: aValue
 ]

--- a/src/OpalCompiler-Core/OCVectorTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCVectorTempVariable.class.st
@@ -48,7 +48,7 @@ OCVectorTempVariable >> readFromContext: aContext scope: contextScope [
 
 	| theVector |
 	theVector := self readVectorFromContext: aContext scope: contextScope.
-	^theVector at: index
+	^theVector at: self index
 ]
 
 { #category : #debugging }
@@ -60,8 +60,6 @@ OCVectorTempVariable >> readVectorFromContext: aContext scope: contextScope [
 	"We might be called from the debugger for a context that actually does not access the temp vector, 
 	so we need to read possibly from a context above aContext"
 	theVector := tempVectorVar readFromContext: aContext scope: contextScope.
-	"Cache the index in the temp vecor (for speed and easy debugging)"
-	index := index ifNil: [ tempVectorVar originalVar indexInTempVectorFromIR: name ].
 	"We can call this method on a context in any state, e.g. even when the copied var is not yet initialized.
 	In this case, we lookup in the outer context with the corresponding outer scope"
 	^ theVector ifNil: [ aContext outerContext 
@@ -85,5 +83,5 @@ OCVectorTempVariable >> writeFromContext: aContext scope: contextScope value: aV
 
 	| theVector |
 	theVector := self readVectorFromContext: aContext scope: contextScope.
-	^theVector at: index put: aValue.
+	^theVector at: self index put: aValue.
 ]

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -180,6 +180,7 @@ RFASTTranslator >> visitInlinedBlockNode: anOptimizedBlockNode [
 	"
 	
 	| tempNames  |
+	methodBuilder mapToNode: anOptimizedBlockNode.
 	anOptimizedBlockNode scope tempVector ifNotEmpty: [
 		methodBuilder 
 			createTempVectorNamed: anOptimizedBlockNode scope tempVectorName 
@@ -198,6 +199,7 @@ RFASTTranslator >> visitInlinedBlockNode: anOptimizedBlockNode [
 	self emitMetaLinkBefore: anOptimizedBlockNode.
 	self visitNode: anOptimizedBlockNode body.
 	self emitMetaLinkAfterNoEnsure: anOptimizedBlockNode.
+	methodBuilder popMap.
 ]
 
 { #category : #'visitor-double dispatching' }


### PR DESCRIPTION
The OCTempVariables used to cache the index after the first access. The index itself was taken from the IR.

We can do it differently: every time a temp is created on the IR level, we can backfill the offset in the OCTempVariables.

This PR:

- IRBuilder now fills the index of semantic variables on #addTemp:
- This allows to not search for the offsets in the IR when accesing temps reflectively (#readFromLocalContext: and similar)

Fixes:
- some improvements to #lookupVar: (so we can call it with non-string var names)
- map the node correctly when generating inlined blocks and full blocks

Cleanups:
- remove #tempVectorNamed: #indexFromIRForVarNamed: #indexFromIR and #indexInTempVectorFromIR:

Accessing the index of OCTempVariables continues to do a nil check. This allows us to call it even if the IR has not yet
been generated.