### PR TITLE
Merge Sindarin BCOffsetCache

### DIFF
--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -30,7 +30,8 @@ Class {
 		'pragmas',
 		'replacements',
 		'nodeReplacements',
-		'compilationContext'
+		'compilationContext',
+		'bcToASTCache'
 	],
 	#category : #'AST-Core-Nodes'
 }

--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -221,21 +221,6 @@ IRMethod >> initialize [
 	numArgs := 0.
 ]
 
-{ #category : #debugging }
-IRMethod >> instructionForPC: aPC [
-	| initialPC pc |
-	"generates the compiledMethod and optimize the ir. 
-	Removes the side-effect of optimizing the IR while looking for instruction, 
-	which results in incorrect found instruction"
-	initialPC := self compiledMethod initialPC.
-	"For a given PC, the actual instruction may start N bytes ahead."
-	pc := aPC.
-	[ pc >= initialPC ] whileTrue: [ 
-		(self firstInstructionMatching: [:ir | ir bytecodeOffset = pc ]) ifNotNil: [:it |^it].
-		pc := pc - 1 ].
-	^self "if we not found anything then this method is our target instruction"
-]
-
 { #category : #decompiling }
 IRMethod >> instructionsForDecompiling [
 	"return all instructions, but skip the block bodies, as the decompiler

--- a/src/OpalCompiler-Core/OCBytecodeToASTCache.class.st
+++ b/src/OpalCompiler-Core/OCBytecodeToASTCache.class.st
@@ -1,0 +1,95 @@
+"
+I cache a mapping between possible bytecode offsets and the AST nodes they correspond to for a given compiled method.
+
+Instanciate me using my class method generateForCompiledMethod: and give me as parameter a compiled method.
+
+Use me through the node access API method nodeForPC: and give me a program counter as parameter.
+
+I store: 
+- firstBcOffset: The first bytecode pc. If you try to access a pc below that first pc, I return the method node.
+- lastBcOffset: The last bytecode pc. If you try to access a pc after this last pc, I return the node associated with the last pc.
+- bcToASTMap: A map associating each possible pc between firstBcOffset and lastBcOffset and the corresponding ast node.
+- the methode node.
+"
+Class {
+	#name : #OCBytecodeToASTCache,
+	#superclass : #Object,
+	#instVars : [
+		'firstBcOffset',
+		'lastBcOffset',
+		'bcToASTMap',
+		'methodNode'
+	],
+	#category : #'OpalCompiler-Core-Bytecode'
+}
+
+{ #category : #initialization }
+OCBytecodeToASTCache class >> generateForMethodNode: aNode [
+	^self new generateForMethodNode: aNode
+]
+
+{ #category : #accessing }
+OCBytecodeToASTCache >> bcToASTMap [
+	^ bcToASTMap
+]
+
+{ #category : #private }
+OCBytecodeToASTCache >> fillMissingBCOffsetsWithLastBCOffsetNodes [
+	"It happens that different bytecode offsets map to the same AST node.
+	These cases are detected when there is no node mapped between, for example, bcOffset 46 and bcOffset 50.
+	In that case, we take every possible bytecode index between 46 and 50 (i.e., 47, 48, 49),
+	and we map them to the same node as the last mapped bytecode offset, here 46."
+
+	| sortedBCOffsets |
+	sortedBCOffsets := bcToASTMap keys asSortedCollection.
+	1 to: sortedBCOffsets size - 1 do: [ :index | 
+		| bcAtIndex bcAtNextIndex |
+		bcAtIndex := sortedBCOffsets at: index.
+		bcAtNextIndex := sortedBCOffsets at: index + 1.
+		bcAtIndex < bcAtNextIndex ifTrue: [ 
+			bcAtIndex to: bcAtNextIndex - 1 do: [ :i | 
+			bcToASTMap at: i put: (bcToASTMap at: bcAtIndex) ] ] ]
+]
+
+{ #category : #accessing }
+OCBytecodeToASTCache >> firstBcOffset [
+	^ firstBcOffset
+]
+
+{ #category : #initialization }
+OCBytecodeToASTCache >> generateForMethodNode: aNode [
+	| methodIR currentBcOffset |
+	methodNode := aNode.
+	methodIR := methodNode ir.
+	bcToASTMap := Dictionary new.
+	firstBcOffset := methodNode compiledMethod initialPC.
+	
+	"if there is a primitive, we need to record the offset"
+	(methodIR irPrimitive num ~= 0) ifTrue: [ bcToASTMap at: firstBcOffset put: methodNode].
+	
+	currentBcOffset := firstBcOffset.
+	methodIR startSequence withAllSuccessors do: [ :seq | 
+		seq do: [ :ir | 
+			ir ifNotNil: [ 
+				bcToASTMap at: ir bytecodeOffset ifAbsentPut: [ ir sourceNode ].
+				currentBcOffset := ir bytecodeOffset + 1 ] ] ].
+	lastBcOffset := currentBcOffset - 1.
+	self fillMissingBCOffsetsWithLastBCOffsetNodes
+]
+
+{ #category : #accessing }
+OCBytecodeToASTCache >> lastBcOffset [
+	^ lastBcOffset
+]
+
+{ #category : #accessing }
+OCBytecodeToASTCache >> methodNode [
+	^ methodNode
+]
+
+{ #category : #'node access' }
+OCBytecodeToASTCache >> nodeForPC: pc [
+	pc < firstBcOffset ifTrue: [ ^ methodNode ].
+	pc > lastBcOffset ifTrue: [ ^ bcToASTMap at: lastBcOffset ].
+	^ bcToASTMap at: pc
+]

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -167,7 +167,8 @@ RBMethodNode >> rewriteTempsForContext: aContext [
 
 { #category : #'*OpalCompiler-Core' }
 RBMethodNode >> sourceNodeForPC: anInteger [
-	^(self ir instructionForPC: anInteger) sourceNode
+	bcToASTCache ifNil: [ bcToASTCache := OCBytecodeToASTCache generateForMethodNode: self].
+	^ bcToASTCache nodeForPC: anInteger
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #RBMethodNode }
 { #category : #'*OpalCompiler-Core' }
 RBMethodNode >> bcToASTCache [
 
-	 ^ bcToASTCache ifNil: [ OCBytecodeToASTCache generateForMethodNode: self].
+	 ^ bcToASTCache ifNil: [  bcToASTCache := OCBytecodeToASTCache generateForMethodNode: self]
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : #RBMethodNode }
 
 { #category : #'*OpalCompiler-Core' }
+RBMethodNode >> bcToASTCache [
+
+	 ^ bcToASTCache ifNil: [ OCBytecodeToASTCache generateForMethodNode: self].
+]
+
+{ #category : #'*OpalCompiler-Core' }
 RBMethodNode >> compiledMethod [
 	^ self ir compiledMethod
 ]
@@ -167,8 +173,7 @@ RBMethodNode >> rewriteTempsForContext: aContext [
 
 { #category : #'*OpalCompiler-Core' }
 RBMethodNode >> sourceNodeForPC: anInteger [
-	bcToASTCache ifNil: [ bcToASTCache := OCBytecodeToASTCache generateForMethodNode: self].
-	^ bcToASTCache nodeForPC: anInteger
+	^ self bcToASTCache nodeForPC: anInteger
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Tests/MethodMapExamples.class.st
+++ b/src/OpalCompiler-Tests/MethodMapExamples.class.st
@@ -150,3 +150,10 @@ MethodMapExamples >> exampleTempNamedTempVectorNestedBlock [
 		[  
 		 b := 2 . thisContext tempNamed: 'b' ] value] value
 ]
+
+{ #category : #examples }
+MethodMapExamples >> helperMethod12 [
+	| i |
+	i := 5.
+	[ i=0 ] whileFalse: [ i := i - 1 ].
+]

--- a/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
@@ -1,0 +1,80 @@
+Class {
+	#name : #OCBytecodeToASTCacheTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'cache',
+		'compiledMethod'
+	],
+	#category : #'OpalCompiler-Tests-Bytecode'
+}
+
+{ #category : #running }
+OCBytecodeToASTCacheTest >> setUp [
+	"Hooks that subclasses may override to define the fixture of test."
+	super setUp.	
+	compiledMethod := MethodMapExamples >> #helperMethod12.
+	cache := OCBytecodeToASTCache generateForMethodNode: compiledMethod ast
+]
+
+{ #category : #helpers }
+OCBytecodeToASTCacheTest >> testCacheInInterval: interval equalsNode: aNode [
+	interval do: [ :i | 
+		self assert: (cache nodeForPC: i) identicalTo: aNode ]
+]
+
+{ #category : #tests }
+OCBytecodeToASTCacheTest >> testCachedMethodNode [
+	self assert: cache methodNode identicalTo: compiledMethod ast
+]
+
+{ #category : #tests }
+OCBytecodeToASTCacheTest >> testFirstBCOffsetTest [
+	self assert: cache firstBcOffset equals: compiledMethod initialPC
+]
+
+{ #category : #tests }
+OCBytecodeToASTCacheTest >> testHigherThanLastBCOffsetAccessTest [
+	| pc |
+	pc := cache lastBcOffset + 5.
+	self
+		assert: (cache nodeForPC: pc)
+		identicalTo: (compiledMethod sourceNodeForPC: pc)
+]
+
+{ #category : #tests }
+OCBytecodeToASTCacheTest >> testLastBCOffsetTest [
+	self
+		assert: cache lastBcOffset
+		equals:
+			compiledMethod ast ir startSequence withAllSuccessors last last
+				bytecodeOffset
+]
+
+{ #category : #tests }
+OCBytecodeToASTCacheTest >> testLowerThanFirstBCOffsetAccessTest [
+	self
+		testCacheInInterval: (0 to: cache firstBcOffset - 1)
+		equalsNode: compiledMethod ast
+]
+
+{ #category : #tests }
+OCBytecodeToASTCacheTest >> testNodeForBCOffsetRangeTest [
+	"As we associate each node to each possible bytecode offset that can refer to it,
+	we have to check that associations are consistent between a range and a node"
+
+	| pcRange |
+	pcRange := 0 to: cache lastBcOffset.
+	pcRange do: [ :pc | 
+		self
+			assert: (cache nodeForPC: pc)
+			identicalTo: (compiledMethod sourceNodeForPC: pc) ]
+]
+
+{ #category : #tests }
+OCBytecodeToASTCacheTest >> testNodeForBCOffsetTest [
+	| pc |
+	pc := 51.
+	self
+		assert: (cache nodeForPC: pc)
+		identicalTo: (compiledMethod sourceNodeForPC: pc)
+]


### PR DESCRIPTION
This PR integrates the SindarinBytecodeToASTCache as OCBytecodeToASTCache

=> API changed to require a RBMethodNode, not the compiledMethod
=> improved the case when asking for start pc for methods with primitives

This is another step towards making the IR an transient datastructure that is not cached