### PR TITLE
introduce-isInteractiveGraphic-method

### DIFF
--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -26,7 +26,10 @@ MorphicUIManager class >> isActiveManager [
 { #category : #testing }
 MorphicUIManager class >> isValidForCurrentSystemConfiguration [
 
-	^ Smalltalk isHeadless not or: [ Smalltalk isHeadless and: [ CommandLineArguments new hasOption: 'interactive'  ] ]
+	^ Smalltalk isHeadless not 
+		or: [ 
+			Smalltalk isHeadless 
+			and: [ Smalltalk isInteractiveGraphic ] ]
 ]
 
 { #category : #private }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -881,6 +881,22 @@ SmalltalkImage >> isInteractive [
 	^ false
 ]
 
+{ #category : #testing }
+SmalltalkImage >> isInteractiveGraphic [
+	"Check if vm were run headless and with interactive (graphics) parameter.
+	 Using the headless VM, the need of a GUI environment is indicated by sending --interactive 
+	 parameter to the image."
+	
+	"non-headless mode is always interactive"
+	self isHeadless ifFalse: [ ^ true ].
+
+	-1000 to: 1000 do: [ :n | 
+		(#('--interactive') includes: (self vm getSystemAttribute: n)) 
+			ifTrue: [ ^ true ]].
+
+	^ false
+]
+
 { #category : #'memory space' }
 SmalltalkImage >> isRoot: oop [
 	"Primitive. Answer whether the object is currently a root for youngSpace."

--- a/src/UIManager/NonInteractiveUIManager.class.st
+++ b/src/UIManager/NonInteractiveUIManager.class.st
@@ -20,7 +20,9 @@ Class {
 { #category : #testing }
 NonInteractiveUIManager class >> isValidForCurrentSystemConfiguration [
 
-	^ Smalltalk isHeadless and: [ Smalltalk isInteractive not ]
+	^ Smalltalk isHeadless 
+		and: [ Smalltalk isInteractive not
+		and: [ Smalltalk isInteractiveGraphic not ] ]
 ]
 
 { #category : #'ui requests' }

--- a/src/UIManager/UIManager.class.st
+++ b/src/UIManager/UIManager.class.st
@@ -31,11 +31,13 @@ UIManager class >> default: aUIManager [
 
 { #category : #initialization }
 UIManager class >> forCurrentSystemConfiguration [
-	^(self allSubclasses
+
+	^ (self allSubclasses
 			detect: [ :any | 
 				any isValidForCurrentSystemConfiguration
 					and: [ any subclasses noneSatisfy: #isValidForCurrentSystemConfiguration ] ]
-			ifNone: [ NonInteractiveUIManager ]) new
+			ifNone: [ NonInteractiveUIManager ]) 
+			new
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Introduces (and uses) the idiom #isInteractiveGraphic.
The purpose is to reduce hardcoded looks for --interactive flags (and to allow others to verify the graphical environment).
(And I need this to add alternative UIManagers)