### PR TITLE
refactor-spanNewSessionFrom

### DIFF
--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -489,6 +489,17 @@ DebugSession >> signalDebuggerError: anError [
 ]
 
 { #category : #accessing }
+DebugSession >> spanNewSession [
+
+	^ (self class 
+			named: self name 
+			on: self interruptedProcess 
+			startedAt: self interruptedContext)
+		errorWasInUIProcess: self errorWasInUIProcess;
+		yourself
+]
+
+{ #category : #accessing }
 DebugSession >> stack [
 
 	^ interruptedContext stack

--- a/src/GT-Debugger/GTMoldableDebugger.class.st
+++ b/src/GT-Debugger/GTMoldableDebugger.class.st
@@ -125,15 +125,10 @@ GTMoldableDebugger class >> spanNewSessionForContext: aContext fromProcess: aPro
 		named: 'temporary name' on: aProcess startedAt: aContext
 ]
 
-{ #category : #accessing }
+{ #category : #private }
 GTMoldableDebugger class >> spanNewSessionFrom: anotherSession [
 
-	^ (self sessionClass 
-		named: anotherSession name 
-		on: anotherSession interruptedProcess 
-		startedAt: anotherSession interruptedContext)
-			errorWasInUIProcess: anotherSession errorWasInUIProcess;
-			yourself
+	^ anotherSession spanNewSession 
 ]
 
 { #category : #private }


### PR DESCRIPTION
this refactor allows the extension of #spanNewSession by subclasses maybe this has to be cleaned in the future instead? anyway while GTDebugger is still around, this is needed.