### PR TITLE
ReNodeRewriteRule subclasses might change the AST

### DIFF
--- a/src/Renraku/ReAbstractRule.class.st
+++ b/src/Renraku/ReAbstractRule.class.st
@@ -225,6 +225,11 @@ ReAbstractRule >> isComposite [
 	^ false
 ]
 
+{ #category : #testing }
+ReAbstractRule >> isRewriteRule [
+	^false
+]
+
 { #category : #accessing }
 ReAbstractRule >> name [
 	"Answer a human readable name of the rule."

--- a/src/Renraku/ReCriticEngine.class.st
+++ b/src/Renraku/ReCriticEngine.class.st
@@ -116,7 +116,7 @@ ReCriticEngine >> nodeCritiquesOf: aMethod [
 			| ast |
 			ast := aMethod ast.
 			"for rewrite rules, we run every rule on a copy of the ast"
-			ast := rule isRewriteRule ifTrue: [ ast copy  ].
+			rule isRewriteRule ifTrue: [ ast := ast copy  ].
 			aMethod ast copy nodesDo: [ :node |
 			[
 			  rule

--- a/src/Renraku/ReCriticEngine.class.st
+++ b/src/Renraku/ReCriticEngine.class.st
@@ -117,7 +117,7 @@ ReCriticEngine >> nodeCritiquesOf: aMethod [
 			ast := aMethod ast.
 			"for rewrite rules, we run every rule on a copy of the ast"
 			rule isRewriteRule ifTrue: [ ast := ast copy  ].
-			aMethod ast copy nodesDo: [ :node |
+			ast nodesDo: [ :node |
 			[
 			  rule
 				  check: node

--- a/src/Renraku/ReCriticEngine.class.st
+++ b/src/Renraku/ReCriticEngine.class.st
@@ -112,9 +112,12 @@ ReCriticEngine >> nodeCritiquesOf: aMethod [
 			[ aMethod banChecksForValidation
 				anySatisfy: [ :banLevel |
 					builder bansRule: rule for: banLevel ] ] ].
-		
-		aMethod ast nodesDo: [ :node |
-			rules do: [ :rule |
+		rules do: [ :rule |
+			| ast |
+			ast := aMethod ast.
+			"for rewrite rules, we run every rule on a copy of the ast"
+			ast := rule isRewriteRule ifTrue: [ ast copy  ].
+			aMethod ast copy nodesDo: [ :node |
 			[
 			  rule
 				  check: node

--- a/src/Renraku/ReNodeRewriteRule.class.st
+++ b/src/Renraku/ReNodeRewriteRule.class.st
@@ -104,6 +104,11 @@ ReNodeRewriteRule >> initialize [
 	matches := Dictionary new.
 ]
 
+{ #category : #testing }
+ReNodeRewriteRule >> isRewriteRule [
+	^true
+]
+
 { #category : #deprecated }
 ReNodeRewriteRule >> replace: aString by: aBlock [
 	


### PR DESCRIPTION
-> in #nodeCritiquesOf: switch around the check: run all checks on one method after the other. This is possible as we cache the AST.
-> for Rewrite rules, make a copy of the AST for each rule run. Coypying the AST is faster then re=parsing.

fixes #6201  ( I hope)