### PR TITLE
SemanticAnalysisSmallCleanup

### DIFF
--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -164,7 +164,7 @@ OCAbstractMethodScope >> lookupVar: name [
 	copiedVars at: name ifPresent: [:v | ^ v].
 	tempVector at: name ifPresent: [:v | ^ v].
 	tempVars at: name ifPresent: [:v | ^ v].
-	name = 'thisContext' ifTrue: [^ thisContextVar].
+	name = thisContextVar name ifTrue: [^ thisContextVar].
 	name = self tempVectorName ifTrue: [ ^ self tempVectorVar ].
 	^self outerScope lookupVar: name
 	
@@ -172,8 +172,9 @@ OCAbstractMethodScope >> lookupVar: name [
 
 { #category : #lookup }
 OCAbstractMethodScope >> lookupVarForDeclaration: name [
+	"This is a version of #lookupVar: that skips the OCRequestorScope"
 	tempVars at: name ifPresent: [:v | ^ v].
-	name = 'thisContext' ifTrue: [^ thisContextVar].
+	name = thisContextVar name ifTrue: [^ thisContextVar].
 	^self outerScope lookupVarForDeclaration: name
 ]
 

--- a/src/OpalCompiler-Core/OCAbstractVariable.class.st
+++ b/src/OpalCompiler-Core/OCAbstractVariable.class.st
@@ -122,6 +122,11 @@ OCAbstractVariable >> isTemp [
 ]
 
 { #category : #testing }
+OCAbstractVariable >> isThisContext [
+	^false
+]
+
+{ #category : #testing }
 OCAbstractVariable >> isUndeclared [
 
 	^ false

--- a/src/OpalCompiler-Core/OCClassScope.class.st
+++ b/src/OpalCompiler-Core/OCClassScope.class.st
@@ -64,6 +64,7 @@ OCClassScope >> lookupVar: name [
 
 { #category : #lookup }
 OCClassScope >> lookupVarForDeclaration: name [
+	"This is a version of #lookupVar: that skips the OCRequestorScope"
 	^self lookupVar: name
 ]
 

--- a/src/OpalCompiler-Core/OCInstanceScope.class.st
+++ b/src/OpalCompiler-Core/OCInstanceScope.class.st
@@ -55,16 +55,16 @@ OCInstanceScope >> isInstanceScope [
 OCInstanceScope >> lookupVar: name [
 	"Return a ScopeVar for my inst var with this name.  Return nil if none found"
 
-	name = 'self' ifTrue: [^ selfVar].
-	name = 'super' ifTrue: [^ superVar].
+	name = selfVar name ifTrue: [^ selfVar].
+	name = superVar name ifTrue: [^ superVar].
 	^ vars at: name ifAbsent: [self outerScope lookupVar: name]
 ]
 
 { #category : #lookup }
 OCInstanceScope >> lookupVarForDeclaration: name [
-	"Return a ScopeVar for my inst var with this name.  Return nil if none found"
-	name = 'self' ifTrue: [^ selfVar].
-	name = 'super' ifTrue: [^ superVar].
+	"This is a version of #lookupVar: that skips the OCRequestorScope"
+	name = selfVar name ifTrue: [^ selfVar].
+	name = superVar name ifTrue: [^ superVar].
 	^ vars at: name ifAbsent: [self outerScope lookupVarForDeclaration: name]
 ]
 

--- a/src/OpalCompiler-Core/OCSpecialVariable.class.st
+++ b/src/OpalCompiler-Core/OCSpecialVariable.class.st
@@ -26,11 +26,6 @@ OCSpecialVariable >> isSpecialVariable [
 ]
 
 { #category : #testing }
-OCSpecialVariable >> isThisContext [
-	^false
-]
-
-{ #category : #testing }
 OCSpecialVariable >> isUninitialized [
 
 	^ false

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -2,8 +2,7 @@ Extension { #name : #RBMethodNode }
 
 { #category : #'*OpalCompiler-Core' }
 RBMethodNode >> bcToASTCache [
-
-	 ^ bcToASTCache ifNil: [  bcToASTCache := OCBytecodeToASTCache generateForMethodNode: self]
+	^ bcToASTCache ifNil: [ bcToASTCache := OCBytecodeToASTCache generateForMethodNode: self ]
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Tests/ASTtoIRMappingTest.class.st
+++ b/src/OpalCompiler-Tests/ASTtoIRMappingTest.class.st
@@ -1,8 +1,0 @@
-"
-test related to AST -> IR mapping and back
-"
-Class {
-	#name : #ASTtoIRMappingTest,
-	#superclass : #TestCase,
-	#category : #'OpalCompiler-Tests-Mapping'
-}


### PR DESCRIPTION
- move isThisContext to AbstractVariable
- ASTtoIRMappingTest is empty and can be removed
- formatting bcToASTCache
- lookupVar: do not hard code variable names if possible
- add an explanation to all lookupVarForDeclaration: methods