### PR TITLE
6104-MethodNode-should-offer-a-nice-way-to-access-primitive-number

### DIFF
--- a/src/AST-Core-Tests/RBMethodNodeTest.class.st
+++ b/src/AST-Core-Tests/RBMethodNodeTest.class.st
@@ -169,7 +169,6 @@ RBMethodNodeTest >> testPrimitiveModuleErrorIsPrimitive [
 	
 ]
 
-
 { #category : #'tests - primitives' }
 RBMethodNodeTest >> testPrimitiveModuleIsPrimitive [
 	"
@@ -189,6 +188,28 @@ RBMethodNodeTest >> testPrimitiveModuleIsPrimitive [
 	ast := (Integer >> #digitSubtract:) ast.
 	self assert: ast isPrimitive.
 
+	
+]
+
+{ #category : #'tests - primitives' }
+RBMethodNodeTest >> testPrimitiveNumber [
+	| method |
+	method := SmallInteger >> #+.
+	self assert: method primitive equals: method ast primitiveNumber.
+	method := Bitmap >> #primFill:.
+	self assert: method primitive equals: method ast primitiveNumber.
+	method := Object >> #isPinnedInMemory.
+	self assert: method primitive equals: method ast primitiveNumber.
+	method := ByteString class >> #stringHash:initialHash:.
+	self assert: method primitive equals: method ast primitiveNumber.
+	"and works on non-primitevs, too. there is returns 0"
+	method := Object >> #halt.
+	self assert: 0 equals: method ast primitiveNumber.
+	self assert: method primitive equals: method ast primitiveNumber.
+	"but we only return the numbers of real primitives defined via pragmas, not quick methods"
+	method := Object >> #yourself.
+	self assert: 0 equals: method ast primitiveNumber.
+	self deny: method primitive equals: method ast primitiveNumber.
 	
 ]
 

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -155,6 +155,11 @@ RBMethodNode >> primitiveFromPragma [
 ]
 
 { #category : #'*OpalCompiler-Core' }
+RBMethodNode >> primitiveNumber [
+	^self primitiveFromPragma num
+]
+
+{ #category : #'*OpalCompiler-Core' }
 RBMethodNode >> rewriteTempsForContext: aContext [
 	| rewriter contextOnlyTemps |
 	rewriter := RBParseTreeRewriter new.


### PR DESCRIPTION
add a small helper method to return the primitive number if the AST defines a primitive by pragma. 

Add a test to explain what it does.

fixes #6104