### PR TITLE
6172-Syntax-highlighter-doesnt-work-with-capitalised-symbols

### DIFF
--- a/src/Shout-Tests/SHRBTextStylerTest.class.st
+++ b/src/Shout-Tests/SHRBTextStylerTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'styler',
 		'oldSetting'
 	],
-	#category : #'Shout-Tests'
+	#category : #'Shout-Tests-Styling'
 }
 
 { #category : #running }
@@ -40,6 +40,54 @@ SHRBTextStylerTest >> tearDown [
 	SHRBTextStyler formatIncompleteIdentifiers: oldSetting.
 	super tearDown.
 	
+]
+
+{ #category : #running }
+SHRBTextStylerTest >> testClassAfterMessageToASymbolLowercaseShouldBeColored [
+	
+	| aText index attributes ast node |
+
+	SHRBTextStyler formatIncompleteIdentifiers: true.
+
+	aText := 'm1
+		#world traceCr.
+		Object new.' asText.
+
+	index := aText string indexOfSubCollection: 'Object'.
+	
+	ast := self style: aText.
+	
+	attributes := aText attributesAt: index.
+
+	node := ast allChildren detect: [:e | e isMessage ].
+	
+	self assertCollection: attributes hasSameElements: { 
+		TextClassLink className: #Object. 
+		TextColor color: SHPreferences globalVarStyle color }.
+]
+
+{ #category : #running }
+SHRBTextStylerTest >> testClassAfterMessageToASymbolUppercaseShouldBeColored [
+	
+	| aText index attributes ast node |
+
+	SHRBTextStyler formatIncompleteIdentifiers: true.
+
+	aText := 'm1
+		#World traceCr.
+		Object new.' asText.
+
+	index := aText string indexOfSubCollection: 'Object'.
+	
+	ast := self style: aText.
+	
+	attributes := aText attributesAt: index.
+
+	node := ast allChildren detect: [:e | e isMessage ].
+	
+	self assertCollection: attributes hasSameElements: { 
+		TextClassLink className: #Object. 
+		TextColor color: SHPreferences globalVarStyle color}.
 ]
 
 { #category : #running }

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1196,7 +1196,7 @@ SHRBTextStyler >> visitLiteralValueNode: aLiteralValueNode [
 		ifTrue: [
 			self class environment
 				at: value
-				ifPresent: [ :class | TextClassLink class: class ]
+				ifPresent: [ :aGlobal | TextClassLink className: value ]
 				ifAbsent: [ TextMethodLink selector: value ] ]
 		ifFalse: [ TextClassLink class: value class ].
 	self addStyle: (self literalStyleSymbol: value) attribute: link forNode: aLiteralValueNode


### PR DESCRIPTION
Fixes issue #6172
The global variables maybe do not point to a class, it is the example of World.