### PR TITLE
6186-System-end-up-in-a-bad-state-when-adding-a-class-in-a-trait-composition-instead-of-a-trait

### DIFF
--- a/src/TraitsV2-Tests/T2TraitTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitTest.class.st
@@ -288,6 +288,17 @@ T2TraitTest >> testSequence [
 ]
 
 { #category : #tests }
+T2TraitTest >> testSettingAClassInAClassTraitCompositionShouldRaiseAnError [
+
+	| t1 c1 |
+	t1 :=  self newTrait: #T1 with: 'a' asSlotCollection.
+	c1 := self newClass: #C1 with: '' asSlotCollection uses: #().
+
+	self should: [ t1 traitComposition: c1 ] raise: Error.
+	self should: [ t1 classTrait traitComposition: c1 ] raise: Error.	
+]
+
+{ #category : #tests }
 T2TraitTest >> testSlotsAreNotDuplicated [
 	| t1 t2 c1 |
 	t1 :=  self newTrait: #T1 with: 'a' asSlotCollection.

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -312,9 +312,13 @@ TraitedClass >> traitComposition [
 ]
 
 { #category : #accessing }
-TraitedClass >> traitComposition: anObject [
+TraitedClass >> traitComposition: aComposition [
 	
-	self class baseComposition: anObject
+	aComposition asTraitComposition allTraits do: [ :aMaybeTrait |
+		aMaybeTrait isTrait ifFalse: [ 
+			self error: 'All the members of the trait composition should be traits' ]].
+		
+	self class baseComposition: aComposition
 ]
 
 { #category : #accessing }

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -337,6 +337,10 @@ TraitedMetaclass >> traitComposition [
 { #category : #accessing }
 TraitedMetaclass >> traitComposition: aComposition [
 
+	aComposition asTraitComposition allTraits do: [ :aMaybeTrait |
+		aMaybeTrait isTrait ifFalse: [ 
+			self error: 'All the members of the trait composition should be traits' ]].
+
 	composition := aComposition
 ]
 


### PR DESCRIPTION
Adding validation that the members of a trait composition are traits.
Fixes issue 6186