### PR TITLE
5898-Intersection-of-SortedCollection-forgets-the-sorting-block-in-the-new-collection

### DIFF
--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -319,7 +319,7 @@ Collection >> asSortedCollection [
 
 { #category : #converting }
 Collection >> asSortedCollection: aSortBlock [ 
-	"Answer a SortedCollection whose elements are the elements of the receiver. The sort order is defined by the argument, aSortBlock. Note that this is better to use #sorted: if you don't really need a SortedCollection, but a sorted collection!!"
+	"Answer a SortedCollection whose elements are the elements of the receiver. The sort order is defined by the argument, aSortBlock. Note that it is better to use #sorted: if you don't really need a SortedCollection, but a sorted collection!!"
 
 	| aSortedCollection |
 	aSortedCollection := SortedCollection new: self size.

--- a/src/Collections-Sequenceable/SortedCollection.class.st
+++ b/src/Collections-Sequenceable/SortedCollection.class.st
@@ -249,6 +249,13 @@ SortedCollection >> insert: anObject before: spot [
 	self shouldNotImplement
 ]
 
+{ #category : #enumerating }
+SortedCollection >> intersection: aCollection [
+	^ (self class sortBlock: sortBlock)
+		addAll: (self asSet intersection: aCollection);
+		yourself.
+]
+
 { #category : #splitjoin }
 SortedCollection >> join: aCollection [ 
 	"Append the elements of the argument, aSequenceableCollection, separating them by the receiver."

--- a/src/Collections-Tests/SortedCollectionTest.class.st
+++ b/src/Collections-Tests/SortedCollectionTest.class.st
@@ -713,6 +713,19 @@ SortedCollectionTest >> testIndexOfSubCollectionStartingAtIfAbsent [
 	self assert: absent equals: true
 ]
 
+{ #category : #'tests - set arithmetic' }
+SortedCollectionTest >> testIntersection [
+	| sortedCollection anotherCollection intersection |
+	sortedCollection := { Number . Object . Collection } asSortedCollection: [ :a :b | a name > b name ].
+	anotherCollection := { Number . Object }.
+
+	intersection := sortedCollection intersection: anotherCollection.
+	
+	self assert: (intersection isKindOf: SortedCollection).
+	self deny: intersection sortBlock isNil.
+	self assert: intersection asArray equals: { Object . Number }.
+]
+
 { #category : #'tests - index access' }
 SortedCollectionTest >> testLastIndexOf [
 	


### PR DESCRIPTION
Fixed #5898