### PR TITLE
[cleanup] remove comment following #5244 and #6147

### DIFF
--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -240,7 +240,6 @@ Object class >> whatIsAPrimitive [
 { #category : #associating }
 Object >> -> anObject [
 	"Answer an Association between self and anObject"
-	"the code of Association>>#key:value: is inline here for speed"
 	"The following example creates an association whose key is number 1 and value string 'one'."
 
 	"(1 -> 'one') key >>> 1"


### PR DESCRIPTION
I am fixing it because it's in a incoherent state.

But #-> has several usages in collection, and I think it should be removed.
I think that when defining the runtime of the language, I don't think we can be fast enough.
This is kind of what we're doing with collections
Maybe that's a optimisation that is too small though.
Anyway.