### PR TITLE
[fix] beginsWith: deverses executable comments

### DIFF
--- a/src/Collections-Abstract/SequenceableCollection.class.st
+++ b/src/Collections-Abstract/SequenceableCollection.class.st
@@ -462,6 +462,12 @@ SequenceableCollection >> before: target ifAbsent: exceptionBlock [
 { #category : #testing }
 SequenceableCollection >> beginsWith: aSequenceableCollection [
 	"Answer true if the receiver starts with the argument collection"
+	
+	"#(1 2 3 4 5) beginsWith: #() >>> false"
+	"#(1 2 3) beginsWith: #(1 2 3 4 5) >>> false"
+	"#(1 2 3 4 5) beginsWith: #(0 1 2) >>> false"
+	"#(1 2 3 4 5) beginsWith: #(1 2 3) >>> true"
+	
 	(aSequenceableCollection isEmpty or: [self size < aSequenceableCollection size]) ifTrue: [^false].
 	aSequenceableCollection withIndexDo: [:each :index | (self at: index) ~= each ifTrue: [^false]].
 	^true

--- a/src/Collections-Strings/ByteString.class.st
+++ b/src/Collections-Strings/ByteString.class.st
@@ -171,11 +171,15 @@ ByteString >> beginsWith: prefix [
 	"Answer whether the receiver begins with the given prefix string.
 	The comparison is case-sensitive."
 
-
 	"IMPLEMENTATION NOTE:
 	following algorithm is optimized in primitive only in case self and prefix are bytes like.
 	Otherwise, if self is wide, then super outperforms,
 	Otherwise, if prefix is wide, primitive is not correct"
+	
+	"'pharo' beginsWith: '' >>> false"
+	"'pharo' beginsWith: 'pharo-project' >>> false"
+	"'pharo' beginsWith: 'phuro' >>> false"
+	"'pharo' beginsWith: 'pha' >>> true"
 	
 	prefix class isBytes ifFalse: [^super beginsWith: prefix].
 	

--- a/src/Collections-Strings/ByteSymbol.class.st
+++ b/src/Collections-Strings/ByteSymbol.class.st
@@ -57,18 +57,20 @@ ByteSymbol >> beginsWith: prefix [
 	"Answer whether the receiver begins with the given prefix string.
 	The comparison is case-sensitive."
 
-
 	"IMPLEMENTATION NOTE:
 	following algorithm is optimized in primitive only in case self and prefix are bytes like.
 	Otherwise, if self is wide, then super outperforms,
 	Otherwise, if prefix is wide, primitive is not correct"
+
+	"#pharo beginsWith: #pharoProject >>> false"
+	"#pharo beginsWith: #phuro >>> false"
+	"#pharo beginsWith: #pha >>> true"
 	
 	prefix class isBytes ifFalse: [^super beginsWith: prefix].
 	
 	self size < prefix size ifTrue: [^ false].
 	^ (self findSubstring: prefix in: self startingAt: 1
 			matchTable: CaseSensitiveOrder) = 1
-
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fix: #6120
Add executable comments to beginsWith: for SequenceableCollection, ByteString and ByteSymbol