### PR TITLE
6184-Cursor-doesnt-blink-in-the-inspector

### DIFF
--- a/src/Rubric/RubCursor.class.st
+++ b/src/Rubric/RubCursor.class.st
@@ -195,14 +195,6 @@ RubCursor >> noteNewOwner: aMorph [
 
 ]
 
-{ #category : #private }
-RubCursor >> outOfWorld: aWorld [
-
-	super outOfWorld: aWorld.
-	
-	aWorld removeAlarm: #hideShow for: self.
-]
-
 { #category : #accessing }
 RubCursor >> period [
 	^ period ifNil: [ period := self class period ]


### PR DESCRIPTION
Removing superfluous alarm remove, this was preventing the cursor from blinking in the inspector.
The remove alarm is handled in the lost focus.
Fixes #6184