### PR TITLE
Rewrote algorithm of String>>#skipAnySubstring:start:

### DIFF
--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2203,26 +2203,28 @@ String >> sameAs: aString [
 
 { #category : #accessing }
 String >> skipAnySubstring: delimiters startingAt: start [ 
-	"Answer the index of the last character within the receiver, starting at start, that does NOT match one of the delimiters. delimiters is a Array of substrings (Characters also allowed).  If the receiver is all delimiters, answer size + 1."
-
-	| any this ind ii |
-	ii := start-1.
-	[(ii := ii + 1) <= self size] whileTrue: [ "look for char that does not match"
-		any := false.
-		delimiters do: [:delim |
-			delim isCharacter 
-				ifTrue: [(self at: ii) == delim ifTrue: [any := true]]
-				ifFalse: ["a substring"
-					delim size > (self size - ii + 1) ifFalse: "Here's where the one-off error was."
-						[ind := 0.
-						this := true.
-						delim do: [:dd | 
-							dd == (self at: ii+ind) ifFalse: [this := false].
-							ind := ind + 1].
-						this ifTrue: [ii := ii + delim size - 1.  any := true]]
-							ifTrue: [any := false] "if the delim is too big, it can't match"]].
-		any ifFalse: [^ ii]].
-	^ self size + 1
+	"Answer the index of the last character within the receiver, starting at start, that does NOT match one of the delimiters. delimiters is an Array of substrings (Characters also allowed).  If the receiver is all delimiters or empty, answer size + 1. Whenever multiple delimiters could be skipped, the largest one is skipped.
+	'abc' skipAnySubstring: #('a' 'ab') startingAt: 1 >>> 3.
+	'ababc' skipAnySubstring: #('ab') startingAt: 1 >>> 5.
+	"
+	| head size remainingString sizeOfLargestSkippableDelimiter |
+	self isEmpty ifTrue: [ ^ 1 ].
+	head := start.
+	size := self size.
+	
+	"Try every delimiters to see which match the start of the rest of the receiver, and get the size of the largest one"
+	[
+		remainingString := self last: size - head + 1. "Part of the receiver that remains to be examined"
+		sizeOfLargestSkippableDelimiter := (delimiters collect: [:delim_ | | delim|
+		delim := delim_ asString. "In case the delimiter is a character, turn it into a string"
+		(delim size > (size - head + 1)) ifTrue: [ 0 "Delimiter is larger than the remaining size of the receiver, so there is no point in trying it" ]
+			ifFalse: [ "Delimiter is smaller than the remaining size of the receiver"
+				(remainingString beginsWith: delim) ifTrue: [ delim size ] ifFalse: [ 0 ]
+			]
+		]) max.
+		head := head + sizeOfLargestSkippableDelimiter.
+	] doWhileFalse: [ sizeOfLargestSkippableDelimiter = 0 ].
+	^ head "The remaining string does not start with any of the delimiters" 
 ]
 
 { #category : #accessing }

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2202,13 +2202,14 @@ String >> sameAs: aString [
 ]
 
 { #category : #accessing }
-String >> skipAnySubstring: delimiters startingAt: start [ 
-	"Answer the index of the last character within the receiver, starting at start, that does NOT match one of the delimiters. delimiters is an Array of substrings (Characters also allowed).  If the receiver is all delimiters or empty, answer size + 1. Whenever multiple delimiters could be skipped, the largest one is skipped.
+String >> skipAnySubstring: delimiters_ startingAt: start [ 
+	"Answer the index of the last character within the receiver, starting at start, that does NOT match one of the delimiters. delimiters_ is an either a substring or an Array of substrings (Characters also allowed).  If the receiver is all delimiters or empty, answer size + 1. Whenever multiple delimiters could be skipped, the largest one is skipped.
 	'abc' skipAnySubstring: #('a' 'ab') startingAt: 1 >>> 3.
 	'ababc' skipAnySubstring: #('ab') startingAt: 1 >>> 5.
 	"
-	| head size remainingString sizeOfLargestSkippableDelimiter |
+	| head size remainingString sizeOfLargestSkippableDelimiter delimiters |
 	self isEmpty ifTrue: [ ^ 1 ].
+	delimiters := delimiters_ isString ifTrue: {delimiters_}.
 	head := start.
 	size := self size.
 	

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2209,7 +2209,7 @@ String >> skipAnySubstring: delimiters_ startingAt: start [
 	"
 	| head size remainingString sizeOfLargestSkippableDelimiter delimiters |
 	self isEmpty ifTrue: [ ^ 1 ].
-	delimiters := delimiters_ isString ifTrue: {delimiters_}.
+	delimiters := delimiters_ isString ifTrue: [{delimiters_}] ifFalse: [ delimiters_ ]. "If delimiters_ is just a string, replace it with an array containing that string."
 	head := start.
 	size := self size.
 	

--- a/src/Collections-Tests/StringTest.class.st
+++ b/src/Collections-Tests/StringTest.class.st
@@ -1796,6 +1796,8 @@ StringTest >> testSkipAnySubstringStartingAt [
 	self assert: ('abcde' skipAnySubstring: #('cd') startingAt: 3) equals: 5.
 	"Test substring appears multiple times in a row"
 	self assert: ('ababc' skipAnySubstring: #('ab') startingAt: 1) equals: 5.
+	"Test substring to skip is given directly as a string instead of in an array"
+	self assert: (',ab' skipAnySubstring: ',' startingAt: 1) equals: 2.
 ]
 
 { #category : #'tests - instance creation' }

--- a/src/Collections-Tests/StringTest.class.st
+++ b/src/Collections-Tests/StringTest.class.st
@@ -1775,6 +1775,29 @@ StringTest >> testRomanNumber [
 	self assert: '-MDCCCXCV' romanNumber equals: -1895.
 ]
 
+{ #category : #tests }
+StringTest >> testSkipAnySubstringStartingAt [
+	
+	"Simple skip"
+	self assert: ('abcd' skipAnySubstring: #('a') startingAt: 1) equals: 2. 
+	"Test multiple substrings to skip"
+	self assert: ('abcd' skipAnySubstring: #('a' 'b' 'd') startingAt: 1) equals: 3.
+	"Test skip symbol"
+	self assert: ('abcd' skipAnySubstring: #(ab) startingAt: 1) equals: 3.
+	"Test string is full of substrings to skip"
+	self assert: ('abcd' skipAnySubstring: #('ab' 'cd') startingAt: 1) equals: 5. 
+	"Test first substring matches but second substring is larger than entire string"
+	self assert: ('abcd' skipAnySubstring: #('ab' 'abcdefg') startingAt: 1) equals: 3.
+	"Test first substring is larger than entire string, and second substring matches string"
+	self assert: ('abcd' skipAnySubstring: #('abcdefg' 'ab') startingAt: 1) equals: 3.
+	"Test string is empty, return length of string + 1"
+	self assert: ('' skipAnySubstring: #('ab') startingAt: 1) equals: 1.
+	"Test starting at index > 1"
+	self assert: ('abcde' skipAnySubstring: #('cd') startingAt: 3) equals: 5.
+	"Test substring appears multiple times in a row"
+	self assert: ('ababc' skipAnySubstring: #('ab') startingAt: 1) equals: 5.
+]
+
 { #category : #'tests - instance creation' }
 StringTest >> testSpace [
 		


### PR DESCRIPTION
- Rewrote algorithm of String>>#skipAnySubstring:start: to remove bug,  use more explicit variable names, add comment and improve the structure.
- Added test method for String>>#skipAnySubstring:start

Fix #6191 