### PR TITLE
Improve Tests OCBytecodeToASTCache

### DIFF
--- a/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
@@ -36,9 +36,10 @@ OCBytecodeToASTCacheTest >> testFirstBCOffsetTest [
 OCBytecodeToASTCacheTest >> testHigherThanLastBCOffsetAccessTest [
 	| pc |
 	pc := cache lastBcOffset + 5.
+	"if we are beyond the last bc, we map to the whole method"
 	self
 		assert: (cache nodeForPC: pc)
-		identicalTo: (compiledMethod sourceNodeForPC: pc)
+		identicalTo: compiledMethod ast
 ]
 
 { #category : #tests }
@@ -60,21 +61,17 @@ OCBytecodeToASTCacheTest >> testLowerThanFirstBCOffsetAccessTest [
 { #category : #tests }
 OCBytecodeToASTCacheTest >> testNodeForBCOffsetRangeTest [
 	"As we associate each node to each possible bytecode offset that can refer to it,
-	we have to check that associations are consistent between a range and a node"
+	we have to check that associations are all pointing to a node"
 
 	| pcRange |
 	pcRange := 0 to: cache lastBcOffset.
-	pcRange do: [ :pc | 
-		self
-			assert: (cache nodeForPC: pc)
-			identicalTo: (compiledMethod sourceNodeForPC: pc) ]
+	pcRange do: [ :pc | self assert: ((cache nodeForPC: pc) isKindOf: RBProgramNode)]
 ]
 
 { #category : #tests }
 OCBytecodeToASTCacheTest >> testNodeForBCOffsetTest [
 	| pc |
+	"there should be an assignment at pc 51"
 	pc := 51.
-	self
-		assert: (cache nodeForPC: pc)
-		identicalTo: (compiledMethod sourceNodeForPC: pc)
+	self assert: (cache nodeForPC: pc) isAssignment
 ]

--- a/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
@@ -74,4 +74,6 @@ OCBytecodeToASTCacheTest >> testNodeForBCOffsetTest [
 	"there should be an assignment at pc 51"
 	pc := 51.
 	self assert: (cache nodeForPC: pc) sourceCode equals: 'i := i - 1'.
+	self assert: (cache nodeForPC: pc) start equals: 55.
+	self assert: (cache nodeForPC: pc) stop equals: 64.
 ]

--- a/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
@@ -73,5 +73,5 @@ OCBytecodeToASTCacheTest >> testNodeForBCOffsetTest [
 	| pc |
 	"there should be an assignment at pc 51"
 	pc := 51.
-	self assert: (cache nodeForPC: pc) isAssignment
+	self assert: (cache nodeForPC: pc) sourceCode equals: 'i := i - 1'.
 ]


### PR DESCRIPTION
OCBytecodeToASTCacheTest had some tests that tested against the old implementation. As we replaced this with the cache, we need to rewite the tests to compare something else (e.g which kind of node)