### PR TITLE
6250-Transcript-shows-error-MessageNotUnderstood-Metaclass-hasBindingThatBeginsWith

### DIFF
--- a/src/Kernel-Tests/MetaClassTest.class.st
+++ b/src/Kernel-Tests/MetaClassTest.class.st
@@ -1,0 +1,14 @@
+Class {
+	#name : #MetaClassTest,
+	#superclass : #TestCase,
+	#category : #'Kernel-Tests-Classes'
+}
+
+{ #category : #tests }
+MetaClassTest >> testHasBindingThatBeginsWith [
+	self assert: (SmalltalkImage class hasBindingThatBeginsWith: 'Compiler').
+	self deny: (SmalltalkImage class hasBindingThatBeginsWith: 'Object').
+	
+	"Pools are looked up, too"
+	self assert: (TimeZone class hasBindingThatBeginsWith: 'DaysInMo')
+]

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -159,6 +159,12 @@ Metaclass >> environment [
 	^thisClass environment
 ]
 
+{ #category : #testing }
+Metaclass >> hasBindingThatBeginsWith: aString [
+	"class and pool vars are accessible from the class side the same as the instance side"
+	^self instanceSide hasBindingThatBeginsWith: aString
+]
+
 { #category : #'accessing parallel hierarchy - deprecated' }
 Metaclass >> hasClassSide [
 	^ false


### PR DESCRIPTION
we need to support #hasBindingThatBeginsWith: on the Metaclass, too.  It forwards to the instance side

fixes #6250