### PR TITLE
NameAnalysis-Test-Cleanup

### DIFF
--- a/src/OpalCompiler-Tests/MethodMapExamples.class.st
+++ b/src/OpalCompiler-Tests/MethodMapExamples.class.st
@@ -90,7 +90,7 @@ MethodMapExamples >> exampleTempNamedTempCopyingNestedBlock [
 ]
 
 { #category : #examples }
-MethodMapExamples >> exampleTempNamedTempCopyingNestedBlockPROBLEM [
+MethodMapExamples >> exampleTempNamedTempCopyingNestedBlock2 [
 	 | a |
 		 a := 2. 
 	^[| b | 

--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -193,12 +193,16 @@ MethodMapTest >> testPrimitiveMethodSourceNodeAtInitialPC [
 
 { #category : #'testing - temp access' }
 MethodMapTest >> testTempNamedTempCopyingNestedBlock [
-	self assert: (self compileAndRunExample:  #exampleTempNamedTempCopyingNestedBlock) equals: 1.
+	self
+		assert: (self compileAndRunExample: #exampleTempNamedTempCopyingNestedBlock)
+		equals: 1
 ]
 
 { #category : #'testing - temp access' }
-MethodMapTest >> testTempNamedTempCopyingNestedBlockPROBLEM [
-	self assert:  (self compileAndRunExample:  #exampleTempNamedTempCopyingNestedBlockPROBLEM) equals: 1.
+MethodMapTest >> testTempNamedTempCopyingNestedBlock2 [
+	self
+		assert: (self compileAndRunExample: #exampleTempNamedTempCopyingNestedBlock2)
+		equals: 1
 ]
 
 { #category : #'testing - ast mapping' }

--- a/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
@@ -197,6 +197,7 @@ OCASTCheckerTest >> testOptimizedBlockWrittenAfterClosedOverCase1 [
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 1.
 
+	"index is not escaping as it is (due to the optimized block) defined in the same block"
 	self deny: (ast scope lookupVar: 'index') isEscaping.
 	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
 

--- a/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
@@ -364,7 +364,7 @@ OCASTClosureAnalyzerTest >> testOptimizedBlockWriteInNestedBlockCase4 [
 	self assert: ast scope tempVars size equals: 0.
 	self assert: ast scope tempVector size equals: 1.
 	self assert: (ast scope lookupVar: 't1') isRemote.
-	self assert: ast scope copiedVars size equals: 1.	"Is this correct, I think that the copied vars should be empty."
+	self assert: ast scope copiedVars size equals: 1.	 "this one copying var is the tempVector"
 
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
 	self assert: scopes second tempVars size equals: 0.
@@ -389,7 +389,7 @@ OCASTClosureAnalyzerTest >> testOptimizedBlockWrittenAfterClosedOverCase1 [
 	self assert: scopes third tempVector size equals: 1.
 
 	self deny: (scopes third lookupVar: 'index') isRemote.
-	"problem: as block is optimized, this var does not need to be remote"
+	"as we are in an optimized loop, the var is considered a remote write"
 	self assert: (scopes third tempVector at: 'temp') isRemote
 ]
 

--- a/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
@@ -77,8 +77,6 @@ OCCompiledMethodIntegrityTest >> testPrimitive [
 { #category : #test }
 OCCompiledMethodIntegrityTest >> testRemoteTempInVector [
 	| newCompiledMethod |
-	"Here the problem was that the Scope kept both the remote temp answer and the new remote <?> this caused
-	that the number of temps were more than the correnct"
 	newCompiledMethod := OpalCompiler new
 		source:
 			'value


### PR DESCRIPTION
Small cleanup / improvement of comments in the tests

- exampleTempNamedTempCopyingNestedBlockPROBLEM --> not a problem anymore (renamed)
- comments testOptimizedBlockWrittenAfterClosedOverCase1
- remove comment not needed in testRemoteTempInVector
- fix comment in testOptimizedBlockWriteInNestedBlockCase4