### PR TITLE
Morphics #closestPointTo: has no senders - should be deprecated

### DIFF
--- a/src/Deprecated90/BorderedMorph.extension.st
+++ b/src/Deprecated90/BorderedMorph.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #BorderedMorph }
+
+{ #category : #'*Deprecated90' }
+BorderedMorph >> closestPointTo: aPoint [
+	"account for round corners. Still has a couple of glitches at upper left and right corners"
+	| pt |
+	self deprecated: 'No senders in default image, removed in issue #6282.' on: '2020-05-02' in: #Pharo9.  
+	pt := self bounds pointNearestTo: aPoint.
+	self wantsRoundedCorners ifFalse: [ ^pt ].
+	self bounds corners with: (self bounds insetBy: 6) corners do: [ :out :in |
+		(pt - out) abs < (6@6)
+			ifTrue: [ ^(in + (Point r: 5.0 degrees: (pt - in) degrees)) asIntegerPoint ].
+	].
+	^pt.
+]

--- a/src/Deprecated90/EllipseMorph.extension.st
+++ b/src/Deprecated90/EllipseMorph.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #EllipseMorph }
+
+{ #category : #'*Deprecated90' }
+EllipseMorph >> closestPointTo: aPoint [
+	self deprecated: 'No senders in default image, removed in issue #6282.' on: '2020-05-02' in: #Pharo9.  
+	^self intersectionWithLineSegmentFromCenterTo: aPoint
+]

--- a/src/Deprecated90/PolygonMorph.extension.st
+++ b/src/Deprecated90/PolygonMorph.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : #PolygonMorph }
+
+{ #category : #'*Deprecated90' }
+PolygonMorph >> closestPointTo: aPoint [ 
+	| closestPoint minDist |
+	self deprecated: 'No senders in default image, removed in issue #6282.' on: '2020-05-02' in: #Pharo9.  
+	closestPoint := minDist := nil.
+	self lineSegmentsDo: 
+			[:p1 :p2 | | dist curvePoint | 
+			curvePoint := aPoint nearestPointOnLineFrom: p1 to: p2.
+			dist := curvePoint distanceTo: aPoint.
+			(closestPoint isNil or: [dist < minDist]) 
+				ifTrue: 
+					[closestPoint := curvePoint.
+					minDist := dist]].
+	^closestPoint
+]

--- a/src/Morphic-Base/EllipseMorph.class.st
+++ b/src/Morphic-Base/EllipseMorph.class.st
@@ -37,11 +37,6 @@ EllipseMorph >> canDrawBorder: aBorderStyle [
 	^aBorderStyle style == #simple
 ]
 
-{ #category : #geometry }
-EllipseMorph >> closestPointTo: aPoint [
-	^self intersectionWithLineSegmentFromCenterTo: aPoint
-]
-
 { #category : #'geometry testing' }
 EllipseMorph >> containsPoint: aPoint [
 

--- a/src/Morphic-Base/Form.extension.st
+++ b/src/Morphic-Base/Form.extension.st
@@ -12,13 +12,13 @@ Form >> asMorph [
 ]
 
 { #category : #'*Morphic-Base' }
-Form >> floodFillTolerance [
-	^ self class floodFillTolerance
+Form class >> floodFillTolerance [
+	^ FloodFillTolerance ifNil: [FloodFillTolerance := 0.0]
 ]
 
 { #category : #'*Morphic-Base' }
-Form class >> floodFillTolerance [
-	^ FloodFillTolerance ifNil: [FloodFillTolerance := 0.0]
+Form >> floodFillTolerance [
+	^ self class floodFillTolerance
 ]
 
 { #category : #'*Morphic-Base' }

--- a/src/Morphic-Base/PolygonMorph.class.st
+++ b/src/Morphic-Base/PolygonMorph.class.st
@@ -589,21 +589,6 @@ PolygonMorph >> closedCubicSlopesOf: knots [
 ]
 
 { #category : #geometry }
-PolygonMorph >> closestPointTo: aPoint [ 
-	| closestPoint minDist |
-	closestPoint := minDist := nil.
-	self lineSegmentsDo: 
-			[:p1 :p2 | | dist curvePoint | 
-			curvePoint := aPoint nearestPointOnLineFrom: p1 to: p2.
-			dist := curvePoint distanceTo: aPoint.
-			(closestPoint isNil or: [dist < minDist]) 
-				ifTrue: 
-					[closestPoint := curvePoint.
-					minDist := dist]].
-	^closestPoint
-]
-
-{ #category : #geometry }
 PolygonMorph >> closestSegmentTo: aPoint [
 	"Answer the starting index of my (big) segment nearest to aPoint"
 	| closestPoint minDist vertexIndex closestVertexIndex |

--- a/src/Morphic-Core/BorderedMorph.class.st
+++ b/src/Morphic-Core/BorderedMorph.class.st
@@ -155,19 +155,6 @@ BorderedMorph >> borderWidth: anInteger [
 	self changed
 ]
 
-{ #category : #geometry }
-BorderedMorph >> closestPointTo: aPoint [
-	"account for round corners. Still has a couple of glitches at upper left and right corners"
-	| pt |
-	pt := self bounds pointNearestTo: aPoint.
-	self wantsRoundedCorners ifFalse: [ ^pt ].
-	self bounds corners with: (self bounds insetBy: 6) corners do: [ :out :in |
-		(pt - out) abs < (6@6)
-			ifTrue: [ ^(in + (Point r: 5.0 degrees: (pt - in) degrees)) asIntegerPoint ].
-	].
-	^pt.
-]
-
 { #category : #accessing }
 BorderedMorph >> colorForInsets [
 	"Return the color to be used for shading inset borders."


### PR DESCRIPTION
- deprecate all #closestPointTo: methods
- fix #6282