### PR TITLE
Rules checking Tests should be in package SUnit-Rules

### DIFF
--- a/src/ReleaseTests/ProperlyImplementedSUnitClassesTest.class.st
+++ b/src/ReleaseTests/ProperlyImplementedSUnitClassesTest.class.st
@@ -18,7 +18,7 @@ ProperlyImplementedSUnitClassesTest >> testAndMakeSureSuperSetupIsCalledAsFirstM
 			each
 				compiledMethodAt: #setUp
 				ifPresent: [ :method | 
-					(ShouldSendSuperSetUpAsFirstMessage superSetUpNotCalledFirstIn: method)
+					(ReShouldSendSuperSetUpAsFirstMessage superSetUpNotCalledFirstIn: method)
 						ifTrue: [ violating add: method ] ] ].
 	self assertEmpty: violating
 ]
@@ -34,7 +34,7 @@ ProperlyImplementedSUnitClassesTest >> testAndMakeSureSuperTearDownIsCalledAsLas
 			each
 				compiledMethodAt: #tearDown
 				ifPresent: [ :method | 
-					(ShouldSendSuperTearDownAsLastMessage
+					(ReShouldSendSuperTearDownAsLastMessage
 						superTearDownNotCalledLastIn: method)
 						ifTrue: [ violating add: method ] ] ].
 	self assertEmpty: violating

--- a/src/SUnit-Rules-Tests/ReTestBasedTestCase.class.st
+++ b/src/SUnit-Rules-Tests/ReTestBasedTestCase.class.st
@@ -4,8 +4,14 @@ Class {
 	#instVars : [
 		'validTestPackage'
 	],
-	#category : #'Renraku-Tests'
+	#category : #'SUnit-Rules-Tests-Base'
 }
+
+{ #category : #testing }
+ReTestBasedTestCase class >> isAbstract [
+
+	^self == ReTestBasedTestCase 
+]
 
 { #category : #running }
 ReTestBasedTestCase >> setUp [

--- a/src/SUnit-Rules-Tests/ReTestClassNameShouldEndWithTestTest.class.st
+++ b/src/SUnit-Rules-Tests/ReTestClassNameShouldEndWithTestTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ReTestClassNameShouldEndWithTestTest,
 	#superclass : #ReTestBasedTestCase,
-	#category : #'Renraku-Tests'
+	#category : #'SUnit-Rules-Tests-Base'
 }
 
 { #category : #tests }

--- a/src/SUnit-Rules-Tests/ReTestClassNameShouldNotEndWithTestsTest.class.st
+++ b/src/SUnit-Rules-Tests/ReTestClassNameShouldNotEndWithTestsTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ReTestClassNameShouldNotEndWithTestsTest,
 	#superclass : #ReTestBasedTestCase,
-	#category : #'Renraku-Tests'
+	#category : #'SUnit-Rules-Tests-Base'
 }
 
 { #category : #tests }

--- a/src/SUnit-Rules-Tests/ReTestClassNotInPackageWithTestEndingNameTest.class.st
+++ b/src/SUnit-Rules-Tests/ReTestClassNotInPackageWithTestEndingNameTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ReTestClassNotInPackageWithTestEndingNameTest,
 	#superclass : #ReTestBasedTestCase,
-	#category : #'Renraku-Tests'
+	#category : #'SUnit-Rules-Tests-Base'
 }
 
 { #category : #tests }

--- a/src/SUnit-Rules-Tests/package.st
+++ b/src/SUnit-Rules-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'SUnit-Rules-Tests' }

--- a/src/SUnit-Rules/ReAssertEqualSignIntoAssertEqualsRule.class.st
+++ b/src/SUnit-Rules/ReAssertEqualSignIntoAssertEqualsRule.class.st
@@ -4,7 +4,9 @@ Using assert:equals: produces better context on rule failure
 Class {
 	#name : #ReAssertEqualSignIntoAssertEqualsRule,
 	#superclass : #ReNodeRewriteRule,
-	#category : #'SUnit-Rules'
+	#traits : 'ReTSUnitGroupedRule',
+	#classTraits : 'ReTSUnitGroupedRule classTrait',
+	#category : #'SUnit-Rules-Base'
 }
 
 { #category : #accessing }
@@ -22,12 +24,6 @@ ReAssertEqualSignIntoAssertEqualsRule >> afterCheck: aNode mappings: mappingDict
 	^ [ aNode methodNode methodClass canUnderstand: #assert:equals: ]
 		on: MessageNotUnderstood "methodNode or methodClass may be nil"
 		do: [ false ]
-]
-
-{ #category : #accessing }
-ReAssertEqualSignIntoAssertEqualsRule >> group [
-
-	^ 'SUnit'
 ]
 
 { #category : #initialization }

--- a/src/SUnit-Rules/ReShouldSendSuperSetUpAsFirstMessage.class.st
+++ b/src/SUnit-Rules/ReShouldSendSuperSetUpAsFirstMessage.class.st
@@ -2,24 +2,26 @@
 In a test case the setUp method should call super setUp as first message
 "
 Class {
-	#name : #ShouldSendSuperSetUpAsFirstMessage,
+	#name : #ReShouldSendSuperSetUpAsFirstMessage,
 	#superclass : #ReAbstractRule,
-	#category : #'SUnit-Rules'
+	#traits : 'ReTSUnitGroupedRule',
+	#classTraits : 'ReTSUnitGroupedRule classTrait',
+	#category : #'SUnit-Rules-Base'
 }
 
 { #category : #'testing-interest' }
-ShouldSendSuperSetUpAsFirstMessage class >> checksMethod [
+ReShouldSendSuperSetUpAsFirstMessage class >> checksMethod [
 
 	^ true
 ]
 
 { #category : #utilities }
-ShouldSendSuperSetUpAsFirstMessage class >> parseTreeSearcher [
+ReShouldSendSuperSetUpAsFirstMessage class >> parseTreeSearcher [
 	^ RBParseTreeSearcher new
 ]
 
 { #category : #utilities }
-ShouldSendSuperSetUpAsFirstMessage class >> superSetUpNotCalledFirstIn: aCompiledMethod [
+ReShouldSendSuperSetUpAsFirstMessage class >> superSetUpNotCalledFirstIn: aCompiledMethod [
 	"Return true if the method is a setUp method and a call to super setUp is not the first message send."
 
 	| searcher |
@@ -34,18 +36,12 @@ ShouldSendSuperSetUpAsFirstMessage class >> superSetUpNotCalledFirstIn: aCompile
 ]
 
 { #category : #running }
-ShouldSendSuperSetUpAsFirstMessage >> basicCheck: aMethod [
+ReShouldSendSuperSetUpAsFirstMessage >> basicCheck: aMethod [
 	^ (aMethod methodClass inheritsFrom: TestCase) and: [ aMethod selector = #setUp and: [ self class superSetUpNotCalledFirstIn: aMethod ] ]
 ]
 
 { #category : #accessing }
-ShouldSendSuperSetUpAsFirstMessage >> group [
-
-	^ 'SUnit'
-]
-
-{ #category : #accessing }
-ShouldSendSuperSetUpAsFirstMessage >> name [
+ReShouldSendSuperSetUpAsFirstMessage >> name [
 
 	^ 'Provide a call to super setUp as the first message in the setUp method'
 ]

--- a/src/SUnit-Rules/ReShouldSendSuperTearDownAsLastMessage.class.st
+++ b/src/SUnit-Rules/ReShouldSendSuperTearDownAsLastMessage.class.st
@@ -2,24 +2,26 @@
 In a test case the tearDown method should call super tearDown as last message
 "
 Class {
-	#name : #ShouldSendSuperTearDownAsLastMessage,
+	#name : #ReShouldSendSuperTearDownAsLastMessage,
 	#superclass : #ReAbstractRule,
-	#category : #'SUnit-Rules'
+	#traits : 'ReTSUnitGroupedRule',
+	#classTraits : 'ReTSUnitGroupedRule classTrait',
+	#category : #'SUnit-Rules-Base'
 }
 
 { #category : #'testing-interest' }
-ShouldSendSuperTearDownAsLastMessage class >> checksMethod [
+ReShouldSendSuperTearDownAsLastMessage class >> checksMethod [
 
 	^ true
 ]
 
 { #category : #utilities }
-ShouldSendSuperTearDownAsLastMessage class >> parseTreeSearcher [
+ReShouldSendSuperTearDownAsLastMessage class >> parseTreeSearcher [
 	^ RBParseTreeSearcher new
 ]
 
 { #category : #utilities }
-ShouldSendSuperTearDownAsLastMessage class >> superTearDownNotCalledLastIn: aCompiledMethod [
+ReShouldSendSuperTearDownAsLastMessage class >> superTearDownNotCalledLastIn: aCompiledMethod [
 	"Return true if the method is a tearDown method and a call to super tearDown is not the last message send."
 
 	| searcher |
@@ -34,18 +36,12 @@ ShouldSendSuperTearDownAsLastMessage class >> superTearDownNotCalledLastIn: aCom
 ]
 
 { #category : #running }
-ShouldSendSuperTearDownAsLastMessage >> basicCheck: aMethod [
+ReShouldSendSuperTearDownAsLastMessage >> basicCheck: aMethod [
 	^ (aMethod methodClass inheritsFrom: TestCase) and: [ aMethod selector = #tearDown and: [ self class superTearDownNotCalledLastIn: aMethod ] ]
 ]
 
 { #category : #accessing }
-ShouldSendSuperTearDownAsLastMessage >> group [
-
-	^ 'SUnit'
-]
-
-{ #category : #accessing }
-ShouldSendSuperTearDownAsLastMessage >> name [
+ReShouldSendSuperTearDownAsLastMessage >> name [
 
 	^ 'Provide a call to super tearDown as the last message in the tearDown method'
 ]

--- a/src/SUnit-Rules/ReShouldTransformedIntoAssertRule.class.st
+++ b/src/SUnit-Rules/ReShouldTransformedIntoAssertRule.class.st
@@ -4,19 +4,15 @@ should: will be deprecated sooner or leater. Use assert: instead
 Class {
 	#name : #ReShouldTransformedIntoAssertRule,
 	#superclass : #ReNodeRewriteRule,
-	#category : #'SUnit-Rules'
+	#traits : 'ReTSUnitGroupedRule',
+	#classTraits : 'ReTSUnitGroupedRule classTrait',
+	#category : #'SUnit-Rules-Base'
 }
 
 { #category : #accessing }
 ReShouldTransformedIntoAssertRule class >> uniqueIdentifierName [
 	
 	^'ShouldTransformedIntoAssert'
-]
-
-{ #category : #accessing }
-ReShouldTransformedIntoAssertRule >> group [
-
-	^ 'SUnit'
 ]
 
 { #category : #initialization }

--- a/src/SUnit-Rules/ReTSUnitGroupedRule.trait.st
+++ b/src/SUnit-Rules/ReTSUnitGroupedRule.trait.st
@@ -1,0 +1,12 @@
+"
+Marker Trait for rules within SUnit group
+"
+Trait {
+	#name : #ReTSUnitGroupedRule,
+	#category : #'SUnit-Rules-Traits'
+}
+
+{ #category : #running }
+ReTSUnitGroupedRule >> group [
+	^ 'SUnit'
+]

--- a/src/SUnit-Rules/ReTestClassNameShouldEndWithTestRule.class.st
+++ b/src/SUnit-Rules/ReTestClassNameShouldEndWithTestRule.class.st
@@ -4,7 +4,9 @@ Check if a subclass of TestCase ends with 'Test' or 'TestCase'.
 Class {
 	#name : #ReTestClassNameShouldEndWithTestRule,
 	#superclass : #ReAbstractRule,
-	#category : #'Renraku-Rules'
+	#traits : 'ReTSUnitGroupedRule',
+	#classTraits : 'ReTSUnitGroupedRule classTrait',
+	#category : #'SUnit-Rules-Base'
 }
 
 { #category : #'testing-interest' }
@@ -18,11 +20,6 @@ ReTestClassNameShouldEndWithTestRule >> basicCheck: aClass [
 	| suffixes |
 	suffixes := #('Test' 'TestCase').
 	^ (aClass inheritsFrom: TestCase) and: [ suffixes noneSatisfy: [ :suffix | aClass name asString endsWith: suffix ] ]
-]
-
-{ #category : #running }
-ReTestClassNameShouldEndWithTestRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : #accessing }

--- a/src/SUnit-Rules/ReTestClassNameShouldNotEndWithTests.class.st
+++ b/src/SUnit-Rules/ReTestClassNameShouldNotEndWithTests.class.st
@@ -4,7 +4,9 @@ Check if a test class' name ends with 'Tests' instead of 'Test'
 Class {
 	#name : #ReTestClassNameShouldNotEndWithTests,
 	#superclass : #ReAbstractRule,
-	#category : #'Renraku-Rules'
+	#traits : 'ReTSUnitGroupedRule',
+	#classTraits : 'ReTSUnitGroupedRule classTrait',
+	#category : #'SUnit-Rules-Base'
 }
 
 { #category : #'testing-interest' }
@@ -17,11 +19,6 @@ ReTestClassNameShouldNotEndWithTests class >> checksClass [
 ReTestClassNameShouldNotEndWithTests >> basicCheck: aClass [
 
 	^ (aClass inheritsFrom: TestCase) and: [aClass name asString endsWith: 'Tests'].
-]
-
-{ #category : #running }
-ReTestClassNameShouldNotEndWithTests >> group [
-	^ 'Optimization'
 ]
 
 { #category : #accessing }

--- a/src/SUnit-Rules/ReTestClassNotInPackageWithTestEndingNameRule.class.st
+++ b/src/SUnit-Rules/ReTestClassNotInPackageWithTestEndingNameRule.class.st
@@ -4,7 +4,9 @@ A subclass of TestCase should be in package which name is ending with '-Tests'
 Class {
 	#name : #ReTestClassNotInPackageWithTestEndingNameRule,
 	#superclass : #ReAbstractRule,
-	#category : #'Renraku-Rules'
+	#traits : 'ReTSUnitGroupedRule',
+	#classTraits : 'ReTSUnitGroupedRule classTrait',
+	#category : #'SUnit-Rules-Base'
 }
 
 { #category : #'testing-interest' }
@@ -17,11 +19,6 @@ ReTestClassNotInPackageWithTestEndingNameRule class >> checksClass [
 ReTestClassNotInPackageWithTestEndingNameRule >> basicCheck: aClass [
 
 	^ (aClass inheritsFrom: TestCase) and: [(aClass package name asString endsWith: '-Tests') not].
-]
-
-{ #category : #running }
-ReTestClassNotInPackageWithTestEndingNameRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- move ReTestClassNameShouldEndWithTestRule into "SUnit-Rules" package
- move ReTestClassNameShouldNotEndWithTests into "SUnit-Rules" package
- move ReTestClassNotInPackageWithTestEndingNameRule into "SUnit-Rules" package
- add a trait ReTSUnitGroupedRule to have a single implementation of #group and use this traiit
- give ShouldSendSuperSetUpAsFirstMessage also the rules engine "Re" prefix
- give ReShouldTransformedIntoAssertRule also the rules engine "Re" prefix

Fix #6303