### PR TITLE
optionalFindThePig

### DIFF
--- a/src/Debugging-Settings/DebugSystemSettings.class.st
+++ b/src/Debugging-Settings/DebugSystemSettings.class.st
@@ -79,6 +79,12 @@ DebugSystemSettings class >> debugSettingsOn: aBuilder [
 				target: CPUWatcher;
 				default: false;
 				description: 'If true, Pharo processes will be monitored for CPU usage. If they take too much CPU, you will get a notification menu that will allow you to debug, resume, or terminate the process' .
+				
+			(aBuilder setting: #pigFinding)
+				label: 'Find the most CPU demanding processes';
+				target: CPUWatcher;
+				default: false;
+				description: 'Try to identify CPU demanding processes during CPU monitoring and offer their termination' .
 			
 			(aBuilder setting: #debugShowDamage)
 				label: 'Flash damaged morphic region';

--- a/src/Tool-ProcessBrowser/CPUWatcher.class.st
+++ b/src/Tool-ProcessBrowser/CPUWatcher.class.st
@@ -23,7 +23,8 @@ Class {
 	],
 	#classVars : [
 		'CpuWatcherEnabled',
-		'CurrentCPUWatcher'
+		'CurrentCPUWatcher',
+		'PigFinding'
 	],
 	#category : #'Tool-ProcessBrowser'
 }
@@ -78,6 +79,17 @@ CPUWatcher class >> monitorPreferenceChanged [
 	self cpuWatcherEnabled
 		ifTrue: [ self startMonitoring ]
 		ifFalse: [ self stopMonitoring ]
+]
+
+{ #category : #setting }
+CPUWatcher class >> pigFinding [
+	^ PigFinding ifNil: [PigFinding := false]
+]
+
+{ #category : #setting }
+CPUWatcher class >> pigFinding: aBoolean [
+	PigFinding := aBoolean.
+
 ]
 
 { #category : #'system startup' }
@@ -178,7 +190,8 @@ CPUWatcher >> monitorProcessPeriod: secs sampleRate: msecs [
 		promise := Processor tallyCPUUsageFor: secs every: msecs.
 		tally := promise value.
 		promise := nil.
-		self findThePig.
+		self class pigFinding ifTrue: [
+			self findThePig ]
 	] repeat ] forkAt: Processor highestPriority.
 	Processor yield 
 ]


### PR DESCRIPTION
The CPU Watcher can be dangerous because may suspend processes that it expects to be too much CPU demaning but they may be needed for proper image function. Make this "pig finding" optoinal and make a setting for it