### PR TITLE
DebugSession: removing "keep-alive" dead-code 

### DIFF
--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -26,9 +26,7 @@ Class {
 		'name',
 		'interruptedContext',
 		'interruptedProcess',
-		'errorWasInUIProcess',
-		'objectsThatWantToKeepMeAlive',
-		'subscribersToKeepAliveEvents'
+		'errorWasInUIProcess'
 	],
 	#classVars : [
 		'LogDebuggerStackToFile'
@@ -54,11 +52,6 @@ DebugSession class >> named: aString on: aProcess startedAt: aContext [
 		detectUIProcess
 ]
 
-{ #category : #keepAlive }
-DebugSession >> addSubscriberToKeepAliveEvents: aNewSubscriber [
-	self subscribersToKeepAliveEvents add: aNewSubscriber
-]
-
 { #category : #'debugging actions' }
 DebugSession >> clear [
 	"If after resuming the process the user does plan to reuse this session with
@@ -77,17 +70,6 @@ DebugSession >> context [
 DebugSession >> contextChanged [
 
 	self triggerEvent: #contextChanged
-]
-
-{ #category : #keepAlive }
-DebugSession >> countObjectsThatWantToKeepMeAlive [
-	"Count how many objects are in objectsThatWantToKeepMeAlive. This method does not use #size or #isEmpty, and the iteration guards against nils because objectsThatWantToKeepMeAlive is a WeakOrderedCollection, therefore some contained objects can be set to nil during garbage collection, and #size and #isEmpty do not discount them"
-
-	| count |
-	count := 0.
-	self objectsThatWantToKeepMeAlive do: [ :anObject | 
-		anObject ifNotNil: [ count := count + 1 ] ].
-	^ count
 ]
 
 { #category : #accessing }
@@ -214,16 +196,6 @@ DebugSession >> isTestObject: anObject [
 	^ anObject isKindOf: TestCase
 ]
 
-{ #category : #keepAlive }
-DebugSession >> keepAlive: anObjectThatWantsToKeepMeAlive [
-	self objectsThatWantToKeepMeAlive add: anObjectThatWantsToKeepMeAlive.
-	self subscribersToKeepAliveEvents do: [ :subscriber_ | 
-		subscriber_ ifNotNil: [ :subscriber | 
-			subscriber
-				onDebugSession: self
-				gettingKeptAliveBy: anObjectThatWantsToKeepMeAlive ] ] "Notify subscribers"
-]
-
 { #category : #logging }
 DebugSession >> logStackToFileIfNeeded [
 	self class logDebuggerStackToFile ifFalse: [ ^self ].
@@ -240,13 +212,6 @@ DebugSession >> name [
 { #category : #accessing }
 DebugSession >> name: aString [
 	name := aString
-]
-
-{ #category : #accessing }
-DebugSession >> objectsThatWantToKeepMeAlive [
-	objectsThatWantToKeepMeAlive ifNil: [ 
-		objectsThatWantToKeepMeAlive := WeakOrderedCollection new ].
-	^ objectsThatWantToKeepMeAlive
 ]
 
 { #category : #context }
@@ -320,11 +285,6 @@ DebugSession >> recompileMethodTo: text inContext: aContext notifying: aNotifyer
 	the editor can still be unaccepted. "
 	self installAlarm: #contextChanged.
 	^ true
-]
-
-{ #category : #keepAlive }
-DebugSession >> removeSubscriberToKeepAliveEvents: aCurrentSubscriber [
-	self subscribersToKeepAliveEvents remove: aCurrentSubscriber
 ]
 
 { #category : #'debugging actions' }
@@ -450,13 +410,6 @@ DebugSession >> runToSelection: selectionInterval inContext: aContext [
 DebugSession >> selectedCodeRangeForContext: selectedContext [
 
 	^ self pcRangeForContext: selectedContext
-]
-
-{ #category : #keepAlive }
-DebugSession >> shouldBeKeptAlive [
-	"Returns whether there is at least one object that wants to keep this debug session alive"
-
-	^ self countObjectsThatWantToKeepMeAlive ~= 0
 ]
 
 { #category : #testing }
@@ -626,26 +579,6 @@ DebugSession >> stepToFirstInterestingBytecodeIn: aProcess [
 	seeing any visible results."
 	
 	^ aProcess stepToSendOrReturn
-]
-
-{ #category : #keepAlive }
-DebugSession >> stopKeepingAlive: anObjectThatNoLongerWantsToKeepMeAlive [
-	self objectsThatWantToKeepMeAlive
-		remove: anObjectThatNoLongerWantsToKeepMeAlive
-		ifAbsent: [ "It's a weak collection, its elements can be nilled by the garbage collector at any time if they are not referenced elsewhere, so it can happen not to find the object to remove because it has already been nilled"
-			 ].
-	self subscribersToKeepAliveEvents do: [ :subscriber_ | 
-		subscriber_ ifNotNil: [ :subscriber | 
-			subscriber
-				onDebugSession: self
-				stoppingGettingKeptAliveBy: anObjectThatNoLongerWantsToKeepMeAlive ] ] "Notify subscribers"
-]
-
-{ #category : #accessing }
-DebugSession >> subscribersToKeepAliveEvents [
-	subscribersToKeepAliveEvents ifNil: [ 
-		subscribersToKeepAliveEvents := WeakOrderedCollection new ].
-	^ subscribersToKeepAliveEvents
 ]
 
 { #category : #'debugging actions' }


### PR DESCRIPTION
This code was inserted for compatibility with tools that are not in the image, and is not going to be put in it in the future.

In addition, this code provoked bugs while running tests, and in some cases prevents the tear down method to execute when a debugger is opened then closed during a test (e.g. if failure).