### PR TITLE
SimplifyOCASTTranslater-by-tempVarNamesWithoutArguments

### DIFF
--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -435,16 +435,15 @@ OCASTTranslator >> shouldBeSentToValueOrEffectTranslator [
 
 { #category : #'visitor-double dispatching' }
 OCASTTranslator >> translateFullBlock: aBlockNode [
-	| argumentNames |
+
 	methodBuilder mapToNode: aBlockNode.
 	methodBuilder compilationContext: aBlockNode methodNode compilationContext.
 	
 	"args, then copied, then temps"
-	methodBuilder addTemps: (argumentNames := aBlockNode argumentNames).
-	methodBuilder addTemps: (aBlockNode scope inComingCopiedVarNames).
-	methodBuilder addTemps: (aBlockNode scope tempVarNames copyWithoutAll: argumentNames).
-	
-	methodBuilder numArgs: argumentNames size.
+	methodBuilder addTemps: aBlockNode argumentNames.
+	methodBuilder addTemps: aBlockNode scope inComingCopiedVarNames.
+	methodBuilder addTemps: aBlockNode scope tempVarNamesWithoutArguments.
+	methodBuilder numArgs: aBlockNode arguments size.
 	
 	aBlockNode scope tempVector ifNotEmpty: [
 		methodBuilder 
@@ -496,7 +495,7 @@ OCASTTranslator >> visitBlockNode: aBlockNode [
 			createTempVectorNamed: aBlockNode scope tempVectorName 
 			withVars: aBlockNode scope tempVectorVarNames.
 	].
-	methodBuilder addTemps: (aBlockNode scope tempVarNames copyWithoutAll: aBlockNode argumentNames).
+	methodBuilder addTemps: aBlockNode scope tempVarNamesWithoutArguments.
 	valueTranslator visitNode: aBlockNode body.
 	methodBuilder addBlockReturnTopIfRequired.
 	self flag: 'why dont we just add a blockReturnTop here... it could be removed or ignored in IRTranslator'.
@@ -533,19 +532,17 @@ OCASTTranslator >> visitInlinedBlockNode: anOptimizedBlockNode [
 			- we call IRBuilder to add temps
 	"
 	
-	| tempNamesNoArgs |
-	
 	methodBuilder mapToNode: anOptimizedBlockNode.
 	anOptimizedBlockNode scope tempVector ifNotEmpty: [
 		methodBuilder 
 			createTempVectorNamed: anOptimizedBlockNode scope tempVectorName 
 			withVars: anOptimizedBlockNode scope tempVectorVarNames.
 	].
-	methodBuilder addTemps: (tempNamesNoArgs := anOptimizedBlockNode scope tempVarNames copyWithoutAll: anOptimizedBlockNode argumentNames).
+	methodBuilder addTemps: anOptimizedBlockNode scope tempVarNamesWithoutArguments.
 	methodBuilder addTemps: anOptimizedBlockNode scope inComingCopiedVarNames.
 	methodBuilder addTemps: anOptimizedBlockNode argumentNames.
 	anOptimizedBlockNode isInlinedLoop ifTrue: [
-		tempNamesNoArgs do: [ :tempName |
+		anOptimizedBlockNode scope tempVarNamesWithoutArguments do: [ :tempName |
 			methodBuilder pushLiteral: nil.
 			methodBuilder storeTemp: tempName.
 			methodBuilder popTop.
@@ -611,7 +608,7 @@ OCASTTranslator >> visitMethodNode: aMethodNode [
 	aMethodNode scope tempVector ifNotEmpty: [
 		methodBuilder 
 			createTempVectorNamed: aMethodNode scope tempVectorName 
-			withVars: (aMethodNode scope tempVector collect: [:each| each name]) asArray.
+			withVars: aMethodNode scope tempVectorVarNames
 	].
 	effectTranslator visitNode: aMethodNode body.
 	aMethodNode body lastIsReturn ifFalse:  [methodBuilder pushReceiver; returnTop]

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -251,7 +251,7 @@ OCAbstractMethodScope >> tempVarNames [
 { #category : #'temp vars' }
 OCAbstractMethodScope >> tempVarNamesWithoutArguments [
 
-	^ tempVars values select: [ :each | each isArg not ] thenCollect: [ :each | each name ]
+	^ tempVars values reject: [ :each | each isArg ] thenCollect: [ :each | each name ]
 ]
 
 { #category : #'temp vars' }

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -249,6 +249,12 @@ OCAbstractMethodScope >> tempVarNames [
 ]
 
 { #category : #'temp vars' }
+OCAbstractMethodScope >> tempVarNamesWithoutArguments [
+
+	^ tempVars values select: [ :each | each isArg not ] thenCollect: [ :each | each name ]
+]
+
+{ #category : #'temp vars' }
 OCAbstractMethodScope >> tempVars [
 
 	^ tempVars

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -137,9 +137,9 @@ RFASTTranslator >> visitBlockNode: aBlockNode [
 	aBlockNode scope tempVector ifNotEmpty: [
 		methodBuilder 
 			createTempVectorNamed: aBlockNode scope tempVectorName 
-			withVars: (aBlockNode scope tempVector collect: [:each| each name]) asArray.
+			withVars: aBlockNode scope tempVectorVarNames.
 	].
-	methodBuilder addTemps: (aBlockNode scope tempVarNames copyWithoutAll: aBlockNode argumentNames).
+	methodBuilder addTemps: aBlockNode scope tempVarNamesWithoutArguments.
 	self emitPreamble: aBlockNode.
 	self emitMetaLinkBefore: aBlockNode.
 	valueTranslator visitNode: aBlockNode body.
@@ -179,18 +179,17 @@ RFASTTranslator >> visitInlinedBlockNode: anOptimizedBlockNode [
 			- we call IRBuilder to add temps
 	"
 	
-	| tempNames  |
 	methodBuilder mapToNode: anOptimizedBlockNode.
 	anOptimizedBlockNode scope tempVector ifNotEmpty: [
 		methodBuilder 
 			createTempVectorNamed: anOptimizedBlockNode scope tempVectorName 
 			withVars: (anOptimizedBlockNode scope tempVector collect: [:each| each name]).
 	].
-	methodBuilder addTemps: (tempNames := anOptimizedBlockNode scope tempVarNames copyWithoutAll: anOptimizedBlockNode argumentNames).
+	methodBuilder addTemps: anOptimizedBlockNode scope tempVarNamesWithoutArguments.
 	methodBuilder addTemps: anOptimizedBlockNode scope inComingCopiedVarNames.
 	methodBuilder addTemps: anOptimizedBlockNode argumentNames.
 	anOptimizedBlockNode isInlinedLoop ifTrue: [
-		tempNames do: [ :tempName |
+		anOptimizedBlockNode scope tempVarNamesWithoutArguments do: [ :tempName |
 			methodBuilder pushLiteral: nil.
 			methodBuilder storeTemp: tempName.
 			methodBuilder popTop.
@@ -255,7 +254,7 @@ RFASTTranslator >> visitMethodNode: aMethodNode [
 	aMethodNode scope tempVector ifNotEmpty: [
 		methodBuilder 
 			createTempVectorNamed: aMethodNode scope tempVectorName 
-			withVars: (aMethodNode scope tempVector collect: [:each| each name]) asArray.
+			withVars: aMethodNode scope tempVectorVarNames.
 	].
 	effectTranslator visitNode: aMethodNode body.
 	aMethodNode isPrimitive ifFalse: [self emitMetaLinkAfterNoEnsure: aMethodNode].


### PR DESCRIPTION
This PR adds #tempVarNamesWithoutArguments on the semantic scope for methods and blocks. This then allows us to simplify some code on the OCASTTranslator

In addition, make sure to use #tempVectorVarNames