### PR TITLE
DeprecateObject-notify-at

### DIFF
--- a/src/Deprecated90/Object.extension.st
+++ b/src/Deprecated90/Object.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #Object }
+
+{ #category : #'*Deprecated90' }
+Object >> notify: aString at: location [
+	self 
+		deprecated: 'use #notify:' 
+		transformWith: '`@receiver notify: `@arg1 at: `@arg2' -> '`@receiver notify: `@arg1'.
+	self notify: aString
+]

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1450,17 +1450,6 @@ Object >> notify: aString [
 	Warning signal: aString
 ]
 
-{ #category : #'error handling' }
-Object >> notify: aString at: location [
-	"Create and schedule a Notifier with the argument as the message in 
-	order to request confirmation before a process can proceed. Subclasses can
-	override this and insert an error message at location within aString."
-
-	self notify: aString
-
-	"nil notify: 'confirmation message' at: 12"
-]
-
 { #category : #'model - updating' }
 Object >> okToChange [
 	"Allows a controller to ask this of any model"


### PR DESCRIPTION
Object>>#notify:at: just calles #notify. It is not send anywhere and makes no sense. 

The PR adds a transforming deprecation