### PR TITLE
6351-SyntaxErrorDebugger-messes-up-display-state-when-closed

### DIFF
--- a/src/Tools/SyntaxErrorDebugger.class.st
+++ b/src/Tools/SyntaxErrorDebugger.class.st
@@ -126,7 +126,7 @@ SyntaxErrorDebugger >> checkForUnprintableCharacters: aString [
 
 { #category : #other }
 SyntaxErrorDebugger >> closeWindow [
-
+	debugSession ifNotNil: [ debugSession terminate ].
 	self topView close
 
 ]
@@ -234,7 +234,7 @@ SyntaxErrorDebugger >> listMenu: aMenu [
 	^aMenu addList: {
 		{'Proceed' . #proceed}.
 		{'Debug calling process' . #debug}.
-		{'Browse full translated' . #browseMethodFull}}.
+		{'Browse full' . #browseMethodFull}}.
 ]
 
 { #category : #accessing }
@@ -249,15 +249,6 @@ SyntaxErrorDebugger >> proceed [
 	debugSession 
 			resume;
 			clear
-]
-
-{ #category : #initialization }
-SyntaxErrorDebugger >> release [
-	"Prevent that syntaxError window lets a suspended compiler process running, when the window is closed."
-
-	debugSession ifNotNil: [ debugSession terminate ].
-	self releaseActionMap. "we are not sure if we need it"
-	super release.
 ]
 
 { #category : #menu }
@@ -303,8 +294,7 @@ SyntaxErrorDebugger >> setClass: aClass code: aString error: errorMessage locati
 	contents := self checkForUnprintableCharacters: aString.
 	self highlightError.
 		
-	category ifNil: [ category := aClass organization categoryOfElement: selector ].
-	category ifNil: [ category := Protocol unclassified ].
+ 	category := category ifNil: [ (aClass organization categoryOfElement: selector) ifNil: [ Protocol unclassified ] ].
 	doitFlag := flag
 ]
 


### PR DESCRIPTION
SyntaxErrorDebugger, if we close it, messes up the state of the morphic rendering.

The reason is that it suspends the morphic process and creates a debugger, but when closing it does not terminate the debugger so the rendering is left in a bad state.

It used to be that #release was called to do that, but it is not anymore.

Fix: call it in #closeWindow.

In addition, this PR contains two trivial cleanups. fixes #6351