### PR TITLE
New emergency debugger

### DIFF
--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -26,6 +26,7 @@ BaselineOfGeneralTests >> baseline: spec [
 			package: 'ConfigurationCommandLineHandler-Tests';
 			package: 'MetacelloCommandLineHandler-Tests';
 			package: 'Debugger-Tests';
+			package: 'EmergencyDebugger-Tests';
 			package: 'EmbeddedFreeType-Tests';
 			
 			package: 'Ombu-Tests';

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -53,7 +53,6 @@ BaselineOfMorphic >> baseline: spec [
 		spec package: 'EmbeddedFreeType'.
 		spec package: 'EmergencyEvaluator'.
 		spec package: 'EmergencyDebugger'.
-		spec package: 'EmergencyDebugger-Tests'.
 		spec package: 'FileSystem-Zip'.
 		spec package: 'Fonts-Infrastructure'.
 		spec package: 'FreeType'.

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -52,6 +52,8 @@ BaselineOfMorphic >> baseline: spec [
 		
 		spec package: 'EmbeddedFreeType'.
 		spec package: 'EmergencyEvaluator'.
+		spec package: 'EmergencyDebugger'.
+		spec package: 'EmergencyDebugger-Tests'.
 		spec package: 'FileSystem-Zip'.
 		spec package: 'Fonts-Infrastructure'.
 		spec package: 'FreeType'.

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -476,16 +476,9 @@ DebugSession >> shouldDisplayOnTopContext: aContext [
 
 { #category : #logging }
 DebugSession >> signalDebuggerError: anError [
-
-	self primitiveError:
-							'Original error: ' , name asString
-								,
-									'.
-	Smalltalk tools debugger error: '
-								,
-									([ anError description ]
-										on: Error
-										do: [ 'a ' , anError class printString ]) , ':' 
+	EDEmergencyDebuggerSettings defaultEmergencyDebugger
+		debugError: anError
+		fromSession: self
 ]
 
 { #category : #accessing }

--- a/src/EmergencyDebugger-Tests/EDDebuggingAPITest.class.st
+++ b/src/EmergencyDebugger-Tests/EDDebuggingAPITest.class.st
@@ -1,0 +1,297 @@
+Class {
+	#name : #EDDebuggingAPITest,
+	#superclass : #EDTests,
+	#category : #'EmergencyDebugger-Tests'
+}
+
+{ #category : #helpers }
+EDDebuggingAPITest >> forbiddenProcesses [
+	self flag: 'This is a fixed list of processes we do not want to kill if they exist. This is too magickal, but we lack tools to have such information and we do not want to depend on process browser packages (information is taken from there).'.
+	^ {[  ].
+	[ Smalltalk lowSpaceWatcherProcess ].
+	[ WeakArray runningFinalizationProcess ].
+	[ Processor backgroundProcess ].
+	[ InputEventFetcher default fetcherProcess ].
+	[ UIManager default uiProcess ].
+	[ Delay schedulingProcess ]}
+]
+
+{ #category : #helpers }
+EDDebuggingAPITest >> injectContextWithMethodWithChanges [
+	| context |
+	self prepareMethodVersionTest.
+	context := Context
+		newForMethod: EDMockObjectForTests >> #mWithVersion.
+	context
+		setSender: nil
+		receiver: nil
+		method: EDMockObjectForTests >> #mWithVersion
+		closure: nil
+		startpc: nil.
+	debugAPI stack addFirst: context
+]
+
+{ #category : #'tests - processes' }
+EDDebuggingAPITest >> testAllRunningProcesses [
+	| processes |
+	processes := EDDebuggingAPI allRunningProcesses.
+	self assertCollection: Process allSubInstances includesAll: processes.
+	self
+		denyCollection: processes
+		includesAny: EDDebuggingAPI forbiddenProcesses.
+	processes do: [ :p | self deny: p isTerminated ]
+]
+
+{ #category : #'tests - initialization' }
+EDDebuggingAPITest >> testAttachTo [
+	self assert: debugAPI session identicalTo: session
+]
+
+{ #category : #'tests - reverting methods' }
+EDDebuggingAPITest >> testChangeRecordsForMethod [
+	| changes |
+	self prepareMethodVersionTest.
+	changes := debugAPI
+		changeRecordsForMethod: (EDMockObjectForTests >> #mWithVersion) asHistoricalRingDefinition.
+	self assert: changes size equals: 2.
+	self assert: changes first sourceCode equals: self sampleMethodSourceCodeVersion2.
+	self assert: changes second sourceCode equals: self sampleMethodSourceCodeVersion1
+]
+
+{ #category : #'tests - debugging support' }
+EDDebuggingAPITest >> testCloseEmergencySession [
+
+	|ed|
+	ed := EDEmergencyDebugger new.
+	ed basicDebug: session.
+	ed debugAPI closeEmergencySession.
+	self deny: ed isRunning
+]
+
+{ #category : #'tests - context' }
+EDDebuggingAPITest >> testContextAt [
+	1 to: session stack size do: [ :i | 
+		self
+			assert: (debugAPI contextAt: i)
+			identicalTo: (session stack at: i) ]
+]
+
+{ #category : #'tests - stack' }
+EDDebuggingAPITest >> testDisplayStackSize [
+	self
+		assert: debugAPI displayStackSize
+		equals: debugAPI class displayStackSize
+]
+
+{ #category : #'tests - processes' }
+EDDebuggingAPITest >> testForbiddenProcesses [
+	EDDebuggingAPI forbiddenProcesses
+		with: self forbiddenProcesses
+		do:
+			[ :actualProcess :expectedProcess | self assert: actualProcess value identicalTo: expectedProcess value ]
+]
+
+{ #category : #'tests - initialization' }
+EDDebuggingAPITest >> testInitialize [
+	self assert: debugAPI debugger isNil.
+	self assertEmpty: debugAPI changesForMethods
+]
+
+{ #category : #'tests - stack' }
+EDDebuggingAPITest >> testLongStack [
+	self
+		assertCollection: debugAPI longStack
+		equals: (session stackOfSize: debugAPI longStackSize)
+]
+
+{ #category : #'tests - stack' }
+EDDebuggingAPITest >> testLongStackSize [
+	self
+		assert: debugAPI longStackSize
+		equals: debugAPI class longStackSize
+]
+
+{ #category : #'tests - context' }
+EDDebuggingAPITest >> testMethodAt [
+	1 to: session stack size do: [ :i | 
+		self
+			assert: (debugAPI methodAt: i)
+			identicalTo: (session stack at: i) method ]
+]
+
+{ #category : #'tests - reverting methods' }
+EDDebuggingAPITest >> testMethodVersionAt [
+	self injectContextWithMethodWithChanges.
+	self
+		assert: (debugAPI methodVersionAt: 1)
+		equals: (debugAPI changesForMethods at: EDMockObjectForTests >> #mWithVersion)
+]
+
+{ #category : #'tests - reverting methods' }
+EDDebuggingAPITest >> testMethodVersionSizeAt [
+	self injectContextWithMethodWithChanges.
+	self assert: (debugAPI methodVersionAt: 1) size equals: 2
+]
+
+{ #category : #'tests - context' }
+EDDebuggingAPITest >> testNodeAt [
+	1 to: session stack size do: [ :i | 
+		| context |
+		context := session stack at: i.
+		self
+			assert: (debugAPI nodeAt: i)
+			identicalTo: (context method sourceNodeForPC: context pc) ]
+]
+
+{ #category : #'tests - context' }
+EDDebuggingAPITest >> testNodeForContext [
+	| context |
+	context := session stack first.
+	self
+		assert: (debugAPI nodeForContext: context)
+		identicalTo: (context method sourceNodeForPC: context pc)
+]
+
+{ #category : #'tests - stack' }
+EDDebuggingAPITest >> testResetStack [
+	debugAPI longStack removeAll.
+	debugAPI resetStack.
+	self
+		assertCollection: debugAPI longStack
+		equals: (session stackOfSize: debugAPI longStackSize)
+]
+
+{ #category : #'tests - context' }
+EDDebuggingAPITest >> testRestartContextAt [
+	| secondContext |
+	secondContext := debugAPI longStack second.
+	debugAPI restartContextAt: 2.
+	self assert: debugAPI longStack first identicalTo: secondContext
+]
+
+{ #category : #'tests - reverting methods' }
+EDDebuggingAPITest >> testRevertTo [
+	|method changes|
+	self prepareMethodVersionTest.
+	method := (EDMockObjectForTests >> #mWithVersion).
+	changes := debugAPI changeRecordsForMethod: method.
+		
+	self assert: method sourceCode equals: self sampleMethodSourceCodeVersion2.
+	debugAPI revert: (EDMockObjectForTests >> #mWithVersion) to: changes second.
+	
+	"Method version is now the reverted one"
+	method := (EDMockObjectForTests >> #mWithVersion).
+	self assert: method sourceCode equals: self sampleMethodSourceCodeVersion1.
+	
+	"Changes now include new version, equals to the first one"
+	changes := debugAPI changeRecordsForMethod: method. 
+	self assert: changes size equals: 3.
+	self assert: changes first sourceCode equals: self sampleMethodSourceCodeVersion1.
+	self assert: changes second sourceCode equals: self sampleMethodSourceCodeVersion2.
+	self assert: changes third sourceCode equals: self sampleMethodSourceCodeVersion1.
+	
+	"Changes cache should be updated: 
+	we test for source code version, as changes cannot compare otherwise than using identity check =="
+	self assert: (debugAPI versionsForMethod: method) size equals: 3.
+	self assertCollection: ((debugAPI versionsForMethod: method) collect:[:c| c sourceCode])
+				equals: (changes collect:[:c| c sourceCode])
+]
+
+{ #category : #'tests - reverting methods' }
+EDDebuggingAPITest >> testRevertToInContext [
+	|method changes|
+	self prepareMethodVersionTest.
+	method := (EDMockObjectForTests >> #mWithVersion).
+	changes := debugAPI changeRecordsForMethod: method.
+		
+	self assert: method sourceCode equals: self sampleMethodSourceCodeVersion2.
+	debugAPI revert: (EDMockObjectForTests >> #mWithVersion) 
+				to: changes second 
+				inContext: debugAPI stack first.
+	
+	"Method version is now the reverted one"
+	method := (EDMockObjectForTests >> #mWithVersion).
+	self assert: method sourceCode equals: self sampleMethodSourceCodeVersion1.
+	
+	"Stack is updated"
+	self assertCollection: debugAPI longStack 
+		  equals: (debugAPI session stackOfSize: debugAPI longStackSize).
+	
+	"Changes now include new version, equals to the first one"
+	changes := debugAPI changeRecordsForMethod: method. 
+	self assert: changes size equals: 3.
+	self assert: changes first sourceCode equals: self sampleMethodSourceCodeVersion1.
+	self assert: changes second sourceCode equals: self sampleMethodSourceCodeVersion2.
+	self assert: changes third sourceCode equals: self sampleMethodSourceCodeVersion1.
+	
+	"Changes cache should be updated: 
+	we test for source code version, as changes cannot compare otherwise than using identity check =="
+	self assert: (debugAPI versionsForMethod: method) size equals: 3.
+	self assertCollection: ((debugAPI versionsForMethod: method) collect:[:c| c sourceCode])
+				equals: (changes collect:[:c| c sourceCode])
+]
+
+{ #category : #'tests - stack' }
+EDDebuggingAPITest >> testStack [ 
+	self assert: debugAPI stack identicalTo: debugAPI longStack
+]
+
+{ #category : #'tests - stack' }
+EDDebuggingAPITest >> testStackAt [
+	1 to: session stack size do:
+		[ :i | self assert: (debugAPI stackAt: i) equals: (session stack at: i) ]
+]
+
+{ #category : #'tests - stack' }
+EDDebuggingAPITest >> testStackFromTo [
+	| stack stackExtract |
+	stack := session stack.
+	stackExtract := (stack copyFrom: 5 to: 10).
+	self
+		assertCollection: (debugAPI stackFrom: 5 to: 10)
+		equals: stackExtract.
+		
+	stackExtract := (stack copyFrom: (stack size - 2) to: (stack size)).
+	self
+		assertCollection: (debugAPI stackFrom: (stack size - 2) to: (stack size + 5))
+		equals: stackExtract.
+		
+	
+]
+
+{ #category : #'tests - stack' }
+EDDebuggingAPITest >> testStackSize [
+	self
+		assert: debugAPI stackSize
+		equals: debugAPI stack size
+]
+
+{ #category : #'tests - processes' }
+EDDebuggingAPITest >> testTerminateAllProcesses [
+	|edProcess|
+	edProcess := ed debugAPI session interruptedProcess.
+	ed debugAPI terminateAllProcesses.
+	self assert: edProcess isTerminated 
+]
+
+{ #category : #'tests - debugging support' }
+EDDebuggingAPITest >> testTerminateSession [
+
+	|ed process|
+	ed := EDEmergencyDebugger new.
+	ed basicDebug: session.
+	process := ed debugAPI session interruptedProcess.
+	ed debugAPI terminateSession.
+	self assert: ed debugAPI session interruptedProcess isNil.
+	self assert: process isTerminated
+]
+
+{ #category : #'tests - reverting methods' }
+EDDebuggingAPITest >> testVersionsForMethod [
+	|changes|
+	self prepareMethodVersionTest.
+	changes := debugAPI versionsForMethod: (EDMockObjectForTests >> #mWithVersion).	
+	self assert: debugAPI changesForMethods size equals: 1.
+	self assert: (debugAPI changesForMethods at: (EDMockObjectForTests >> #mWithVersion))
+			identicalTo: changes
+]

--- a/src/EmergencyDebugger-Tests/EDDebuggingAPITest.class.st
+++ b/src/EmergencyDebugger-Tests/EDDebuggingAPITest.class.st
@@ -267,6 +267,14 @@ EDDebuggingAPITest >> testStackSize [
 { #category : #'tests - processes' }
 EDDebuggingAPITest >> testTerminateAllProcesses [
 	|edProcess|
+	self skip.
+	self flag: #ED.
+	"Executing test kills the CI.
+	The idea is to give users the power to kill all processes, except those necessary to run the image.
+	It should kill the tests process as well (e.g. your bug is in a test or in the test framework).
+	However, in the CI, it kills the CI test process.
+	So, this test works (it kills all processes...) but it cannot work on the CI yet.
+	We're skipping for now, and raise an issue. This needs to be addressed properly."
 	edProcess := ed debugAPI session interruptedProcess.
 	ed debugAPI terminateAllProcesses.
 	self assert: edProcess isTerminated 

--- a/src/EmergencyDebugger-Tests/EDDebuggingAPITest.class.st
+++ b/src/EmergencyDebugger-Tests/EDDebuggingAPITest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #EDDebuggingAPITest,
-	#superclass : #EDTests,
+	#superclass : #EDTest,
 	#category : #'EmergencyDebugger-Tests'
 }
 

--- a/src/EmergencyDebugger-Tests/EDDebuggingAPITest.class.st
+++ b/src/EmergencyDebugger-Tests/EDDebuggingAPITest.class.st
@@ -60,8 +60,6 @@ EDDebuggingAPITest >> testChangeRecordsForMethod [
 
 { #category : #'tests - debugging support' }
 EDDebuggingAPITest >> testCloseEmergencySession [
-
-	|ed|
 	ed := EDEmergencyDebugger new.
 	ed basicDebug: session.
 	ed debugAPI closeEmergencySession.
@@ -277,7 +275,7 @@ EDDebuggingAPITest >> testTerminateAllProcesses [
 { #category : #'tests - debugging support' }
 EDDebuggingAPITest >> testTerminateSession [
 
-	|ed process|
+	|process|
 	ed := EDEmergencyDebugger new.
 	ed basicDebug: session.
 	process := ed debugAPI session interruptedProcess.

--- a/src/EmergencyDebugger-Tests/EDEmergencyDebuggerTest.class.st
+++ b/src/EmergencyDebugger-Tests/EDEmergencyDebuggerTest.class.st
@@ -1,0 +1,460 @@
+Class {
+	#name : #EDEmergencyDebuggerTest,
+	#superclass : #EDTests,
+	#category : #'EmergencyDebugger-Tests'
+}
+
+{ #category : #helpers }
+EDEmergencyDebuggerTest >> errorText: error [ 	
+	| errStream |
+	errStream := WriteStream on: Text new.
+	errStream cr.
+	ed writeSeparatorOn: errStream.
+	errStream << error description.
+	^errStream contents
+]
+
+{ #category : #helpers }
+EDEmergencyDebuggerTest >> methodDisplayTextStringExample [
+	| method expectedTextStream |
+	method := debugAPI methodAt: ed stackSelectionIndex.
+	expectedTextStream := WriteStream on: Text new.
+	ed writeSectionTitle: 'SOURCE' on: expectedTextStream.
+	expectedTextStream << method methodClass name.
+	expectedTextStream << '>>'.
+	expectedTextStream << method sourceCode.
+	expectedTextStream cr.
+	^expectedTextStream contents asString
+]
+
+{ #category : #helpers }
+EDEmergencyDebuggerTest >> resultTextStringExample [
+	| expectedTextStream |
+	expectedTextStream := WriteStream on: Text new.
+	expectedTextStream cr.
+	ed writeSectionTitle: 'RES' on: expectedTextStream.
+	expectedTextStream << 'result'.
+	^ expectedTextStream contents asString
+]
+
+{ #category : #'debug API' }
+EDEmergencyDebuggerTest >> testBasicDebug [
+	ed := EDEmergencyDebugger new.
+	ed basicDebug: session.
+	self assert: ed debugAPI debugger identicalTo: ed.
+	self assert: ed isRunning
+	
+]
+
+{ #category : #'text - composition' }
+EDEmergencyDebuggerTest >> testComposeDisplayText [
+	| displayText |
+	displayText := ed titleText , ed composeSessionTitle, ed stackText , ed methodText , ed input
+		, ed result.
+	self assert: ed composeDisplayText equals: displayText
+]
+
+{ #category : #'text - composition' }
+EDEmergencyDebuggerTest >> testComposeErrorTextFrom [
+	|error rs|
+	error := self zeroDivideErrorInstance.
+	ed composeErrorTextFrom: error.
+	rs := ed errorText readStream.
+	self assert: rs next equals: Character cr.
+	self assert: (rs next: ed separator asString size) equals: ed separator asString.
+	self assert: rs next equals: Character cr.
+	self assert: (rs next: error description size) equals: error description.
+	self assert: rs atEnd
+]
+
+{ #category : #'text - composition' }
+EDEmergencyDebuggerTest >> testComposeMethodText [
+	ed composeMethodText.
+	self
+		assert: ed methodText asString
+		equals: self methodDisplayTextStringExample
+]
+
+{ #category : #'text - composition' }
+EDEmergencyDebuggerTest >> testComposePromptWith [
+	| rs |
+	ed composePromptWith: 'prompt'.
+	rs := ed input asString readStream.
+	self assert: rs next equals: Character cr.
+	self assert: (rs upTo: Character cr) equals: ed separator asString.
+	self assert: rs next equals: $>.
+	self assert: rs next equals: Character space.
+	self assert: rs upToEnd equals: 'prompt'.
+
+]
+
+{ #category : #'text - composition' }
+EDEmergencyDebuggerTest >> testComposeResultTitle [
+	ed composeResult: 'result' title: 'RES'.
+	self assert: ed result asString equals: self resultTextStringExample
+]
+
+{ #category : #'text - composition' }
+EDEmergencyDebuggerTest >> testComposeStackTest [
+	| rs ws stack |
+	ed composeStackText.
+	rs := ed stackText asString readStream.
+	
+	self assert: rs next equals: Character cr.
+	self assert: (rs upTo: Character cr) equals: ed separator asString.
+	self
+		assert: (rs upTo: Character cr)
+		equals:
+			'STACK (' , ed stackSelectionIndex printString , '/'
+				, debugAPI stackSize printString , ')'.				
+	self assert: (rs upTo: Character cr) equals: ed separator asString.
+	
+	
+	stack := debugAPI stack copyFrom: 1 to: debugAPI displayStackSize.
+	
+	ws := WriteStream on: String new.
+	(stack at: 1) printWithArgsValueOn: ws.
+	self assert: (rs upTo: Character cr) equals: ws contents.
+	
+	ws := WriteStream on: String new.
+	(stack at: 2) printWithArgsValueOn: ws.
+	self assert: (rs upTo: Character cr) equals: ws contents.
+	
+	ws := WriteStream on: String new.
+	(stack at: 3) printWithArgsValueOn: ws.
+	self assert: (rs upTo: Character cr) equals: ws contents.
+	
+	ws := WriteStream on: String new.
+	(stack at: 4) printWithArgsValueOn: ws.
+	self assert: (rs upTo: Character cr) equals: ws contents.
+	
+	ws := WriteStream on: String new.
+	(stack at: 5) printWithArgsValueOn: ws.
+	self assert: (rs upTo: Character cr) equals: ws contents.
+	
+	self assert: rs atEnd
+	 
+]
+
+{ #category : #'text - composition' }
+EDEmergencyDebuggerTest >> testComposeStackText [
+	| rs ws stack |
+	ed composeStackText.
+	rs := ed stackText asString readStream.
+	
+	self assert: rs next equals: Character cr.
+	self assert: (rs upTo: Character cr) equals: ed separator asString.
+	self
+		assert: (rs upTo: Character cr)
+		equals:
+			'STACK (' , ed stackSelectionIndex printString , '/'
+				, debugAPI stackSize printString , ')'.				
+	self assert: (rs upTo: Character cr) equals: ed separator asString.
+	
+	
+	stack := debugAPI stack copyFrom: 1 to: debugAPI displayStackSize.
+	
+	ws := WriteStream on: String new.
+	(stack at: 1) printWithArgsValueOn: ws.
+	self assert: (rs upTo: Character cr) equals: ws contents.
+	
+	ws := WriteStream on: String new.
+	(stack at: 2) printWithArgsValueOn: ws.
+	self assert: (rs upTo: Character cr) equals: ws contents.
+	
+	ws := WriteStream on: String new.
+	(stack at: 3) printWithArgsValueOn: ws.
+	self assert: (rs upTo: Character cr) equals: ws contents.
+	
+	ws := WriteStream on: String new.
+	(stack at: 4) printWithArgsValueOn: ws.
+	self assert: (rs upTo: Character cr) equals: ws contents.
+	
+	ws := WriteStream on: String new.
+	(stack at: 5) printWithArgsValueOn: ws.
+	self assert: (rs upTo: Character cr) equals: ws contents.
+	
+	self assert: rs atEnd
+	 
+]
+
+{ #category : #'text - composition' }
+EDEmergencyDebuggerTest >> testComposeTitleText [
+	ed composeMethodText.
+	self
+		assert: ed titleText
+		equals: self titleDisplayTextStringExample
+]
+
+{ #category : #'debug API' }
+EDEmergencyDebuggerTest >> testDebugAPI [
+	|api|
+	api := EDMockObjectForTests new.
+	EDEmergencyDebugger debugAPI: api.
+	self assert: EDEmergencyDebugger debugAPI identicalTo: api
+	
+]
+
+{ #category : #'debug API' }
+EDEmergencyDebuggerTest >> testDefaultDebugAPI [
+	
+	self assert: EDEmergencyDebugger debugAPI identicalTo: EDDebuggingAPI
+	
+]
+
+{ #category : #'text - helpers' }
+EDEmergencyDebuggerTest >> testDefaultResultText [
+
+	self assert: ed defaultResultText equals: 'TYPE h FOR HELP'
+]
+
+{ #category : #setup }
+EDEmergencyDebuggerTest >> testFromError [
+	|error|
+	error := self zeroDivideErrorInstance.
+	self assert: ed originalError isNil.
+	self assert: ed errorText equals: Text new.	
+	ed fromError: error.
+	self assert: ed originalError identicalTo: error.
+	self assert: ed errorText equals: (self errorText: error)
+]
+
+{ #category : #'methods version' }
+EDEmergencyDebuggerTest >> testInitialMethodVersion [
+	self assert: ed methodVersionSelectionIndex equals: 0
+]
+
+{ #category : #setup }
+EDEmergencyDebuggerTest >> testIsRunning [
+	
+	"This is a new Ed, we did not call #debug: so it is not running"
+	self deny: EDEmergencyDebugger new isRunning.
+	"This Ed, we called #debug: in the test setup so it is running"
+	self assert: ed isRunning 
+]
+
+{ #category : #'api - stack' }
+EDEmergencyDebuggerTest >> testMoveDownInStack [ 
+	|selectionIndexBefore shortStackIndexBefore|
+	selectionIndexBefore := ed stackSelectionIndex.
+	shortStackIndexBefore := ed shortStackIndex.
+	ed moveDownInStack.
+	self assert: ed stackSelectionIndex 
+			equals: ((selectionIndexBefore + 1) min: debugAPI stackSize).
+	self assert: ed shortStackIndex equals: (shortStackIndexBefore + 1).
+	self assert: ed methodVersionSelectionIndex equals: 0		
+]
+
+{ #category : #'api - stack' }
+EDEmergencyDebuggerTest >> testMoveDownInStackFromLastElement [ 
+	|selectionIndexBefore shortStackIndexBefore|
+	ed stackSelectionIndex: debugAPI stackSize.
+	selectionIndexBefore := ed stackSelectionIndex.
+	shortStackIndexBefore := ed shortStackIndex.
+	ed moveDownInStack.
+	self assert: ed stackSelectionIndex equals: selectionIndexBefore.
+	self assert: ed shortStackIndex equals: shortStackIndexBefore
+]
+
+{ #category : #'api - stack' }
+EDEmergencyDebuggerTest >> testMoveUpInStack [ 
+	ed stackSelectionIndex: debugAPI stackSize.
+	ed shortStackIndex: debugAPI stackSize.
+	ed moveUpInStack.
+	self assert: ed stackSelectionIndex equals: (debugAPI stackSize - 1).
+	self assert: ed shortStackIndex equals: (debugAPI stackSize - 1).
+	self assert: ed methodVersionSelectionIndex equals: 0		
+]
+
+{ #category : #'api - stack' }
+EDEmergencyDebuggerTest >> testMoveUpInStackFromFirstElement [ 
+	|selectionIndexBefore shortStackIndexBefore|
+	selectionIndexBefore := ed stackSelectionIndex.
+	shortStackIndexBefore := ed shortStackIndex.
+	ed moveUpInStack.
+	self assert: ed stackSelectionIndex equals: selectionIndexBefore.
+	self assert: ed shortStackIndex equals: shortStackIndexBefore.
+	self assert: ed methodVersionSelectionIndex equals: 0		
+]
+
+{ #category : #'text - helpers' }
+EDEmergencyDebuggerTest >> testNewTextStream [
+	|str|
+	str := ed newTextStream.
+	self assert: str isStream.
+	self assert: str contents equals: Text new
+]
+
+{ #category : #'methods version' }
+EDEmergencyDebuggerTest >> testRevertCurrentMethodToSelectedVersion [
+	|secondContext originalPC newContext| 
+	secondContext := ed shortStack second.
+	originalPC := secondContext pc.	
+	ed stackSelectionIndex: 2.
+	ed shortStackIndex: 2.
+	ed methodVersionSelectionIndex: 1.
+	ed revertCurrentMethodToSelectedVersion.
+	newContext := ed shortStack first.
+	self assert: newContext identicalTo: secondContext.
+	self assert: ed stackSelectionIndex equals: 1.
+	self assert: ed shortStackIndex equals: 1.
+	self assert: ed methodVersionSelectionIndex equals: 1.
+	self assert: newContext pc < originalPC.
+	self assert: newContext method sourceCode equals: secondContext method sourceCode.
+	
+	"When the context is restarted, the interpreter automatically steps over
+	so-called uninteresting bytecodes, i.e., bytecodes that are not sends nor returns.
+	The test method, originally EDMockObjectForTests>>#m:, starts with an equality check
+	that is 2 bytecodes long, then the interpreter stops on the first send.
+	The PC should be equal to the method's initial PC + 2."  
+	self assert: ed shortStack first pc 
+	     equals: ed shortStack first method initialPC + 2
+]
+
+{ #category : #'methods version' }
+EDEmergencyDebuggerTest >> testSelectedMethodVersion [
+
+	
+]
+
+{ #category : #'methods version' }
+EDEmergencyDebuggerTest >> testSelectedMethodVersionsSize [
+	self prepareMethodVersionTest.
+	self assert: ed selectedMethodVersionsSize equals: 2
+]
+
+{ #category : #'text - helpers' }
+EDEmergencyDebuggerTest >> testSeparator [
+
+	self assert: ed separator asString equals: '--------------------'
+]
+
+{ #category : #'api - stack' }
+EDEmergencyDebuggerTest >> testShiftDownShortStack [
+	ed stackSelectionIndex: debugAPI displayStackSize.
+	ed shortStackIndex: debugAPI displayStackSize.
+	ed moveDownInStack.
+	self assert: ed shortStackIndex equals: 1.
+	self
+		assertCollection: ed shortStack
+		hasSameElements:
+			(session stack
+				copyFrom: debugAPI displayStackSize + 1
+				to: debugAPI displayStackSize * 2)
+]
+
+{ #category : #'api - stack' }
+EDEmergencyDebuggerTest >> testShiftUpShortStack [
+	ed stackSelectionIndex: debugAPI displayStackSize + 1.
+	ed shortStackIndex: 1.
+	ed moveUpInStack.
+	self assert: ed shortStackIndex equals: debugAPI displayStackSize.
+	self
+		assertCollection: ed shortStack
+		hasSameElements: (session stack copyFrom: 1 to: debugAPI displayStackSize)
+]
+
+{ #category : #'api - stack' }
+EDEmergencyDebuggerTest >> testShortStack [ 
+	self assert: ed shortStack size equals: 5.	
+	self assertCollection: (session stackOfSize: 5) hasSameElements: ed shortStack
+]
+
+{ #category : #'methods version' }
+EDEmergencyDebuggerTest >> testShowMoreRecentMethodVersion [
+	self prepareMethodVersionTest.
+	ed showMoreRecentMethodVersion.
+	self assert: ed methodVersionSelectionIndex equals: 1.
+	ed showOlderMethodVersion.
+	ed showMoreRecentMethodVersion.
+	self assert: ed methodVersionSelectionIndex equals: 1
+]
+
+{ #category : #'methods version' }
+EDEmergencyDebuggerTest >> testShowOlderMethodVersion [
+	self prepareMethodVersionTest.
+	ed showOlderMethodVersion.
+	self assert: ed methodVersionSelectionIndex equals: 1.
+	ed showOlderMethodVersion.
+	self assert: ed methodVersionSelectionIndex equals: 2
+]
+
+{ #category : #'methods version' }
+EDEmergencyDebuggerTest >> testShowSelectedMethodVersion [
+
+	
+]
+
+{ #category : #setup }
+EDEmergencyDebuggerTest >> testTerminate [
+	
+	ed terminate.
+	self deny: ed isRunning 
+]
+
+{ #category : #updating }
+EDEmergencyDebuggerTest >> testUpdateDisplay [
+	ed updateDisplay.
+	self assert: mockDisplayAPI isCleared.
+	self assert: mockDisplayAPI displayData equals: ed composeDisplayText 
+]
+
+{ #category : #updating }
+EDEmergencyDebuggerTest >> testUpdatePrompt [
+	| promptUpdate rs |
+	promptUpdate := 'PROMPT UPDATE'.
+	ed updatePrompt: promptUpdate.
+	rs := ed input readStream.
+	rs upTo: $>.
+	rs upTo: Character space.
+	self assert: (rs upTo: Character cr) equals: promptUpdate
+]
+
+{ #category : #'api - stack' }
+EDEmergencyDebuggerTest >> testUpdateShortStackForDisplay [ 
+	
+]
+
+{ #category : #'text - helpers' }
+EDEmergencyDebuggerTest >> testWriteSectionTitleOn [
+	| expectedTextStream actualTextStream |
+	
+	expectedTextStream := WriteStream on: Text new.
+	ed writeSeparatorOn: expectedTextStream.
+	expectedTextStream << 'TEST'.
+	expectedTextStream cr.
+	ed writeSeparatorOn: expectedTextStream. 
+	
+	actualTextStream := WriteStream on: Text new.	
+	ed writeSectionTitle: 'TEST' on: actualTextStream.
+
+	self assert: actualTextStream contents asString 
+		  equals: expectedTextStream contents asString
+]
+
+{ #category : #'text - helpers' }
+EDEmergencyDebuggerTest >> testWriteSeparatorOn [
+	| expectedTextStream actualTextStream |
+	
+	expectedTextStream := WriteStream on: Text new.
+	expectedTextStream << ed separator.
+	expectedTextStream cr.
+	
+	actualTextStream := WriteStream on: Text new.	
+	ed writeSeparatorOn: actualTextStream.
+
+	self assert: actualTextStream contents asString 
+		  equals: expectedTextStream contents asString
+]
+
+{ #category : #helpers }
+EDEmergencyDebuggerTest >> titleDisplayTextStringExample [
+	^ 'Hi, I''m ED - What is the nature of your debugging emergency?'
+]
+
+{ #category : #helpers }
+EDEmergencyDebuggerTest >> zeroDivideErrorInstance [
+	[ 1 / 0 ]
+		on: Error
+		do: [ :err | ^ err ]
+]

--- a/src/EmergencyDebugger-Tests/EDEmergencyDebuggerTest.class.st
+++ b/src/EmergencyDebugger-Tests/EDEmergencyDebuggerTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #EDEmergencyDebuggerTest,
-	#superclass : #EDTests,
+	#superclass : #EDTest,
 	#category : #'EmergencyDebugger-Tests'
 }
 

--- a/src/EmergencyDebugger-Tests/EDMockDisplayInterface.class.st
+++ b/src/EmergencyDebugger-Tests/EDMockDisplayInterface.class.st
@@ -1,0 +1,39 @@
+"
+I am a null display interface for testing the Ed debugger.
+I catch all message through DNU and just do nothing.
+"
+Class {
+	#name : #EDMockDisplayInterface,
+	#superclass : #Object,
+	#instVars : [
+		'clear',
+		'displayData'
+	],
+	#category : #'EmergencyDebugger-Tests'
+}
+
+{ #category : #'API - mock' }
+EDMockDisplayInterface >> clear [
+	clear := true
+]
+
+{ #category : #'API - mock' }
+EDMockDisplayInterface >> displayData [
+	^displayData ifNil:['']
+]
+
+{ #category : #'reflective operations' }
+EDMockDisplayInterface >> doesNotUnderstand: aMessage [
+	
+	"self inform: 'Ed display: ', aMessage printString"
+]
+
+{ #category : #'API - mock' }
+EDMockDisplayInterface >> isCleared [
+	^clear ifNil:[false]
+]
+
+{ #category : #'API - mock' }
+EDMockDisplayInterface >> show: aText [
+	displayData := aText
+]

--- a/src/EmergencyDebugger-Tests/EDMockObjectForTests.class.st
+++ b/src/EmergencyDebugger-Tests/EDMockObjectForTests.class.st
@@ -1,0 +1,36 @@
+"
+I implement method to build execution stacks and errors to test the Ed debugger
+"
+Class {
+	#name : #EDMockObjectForTests,
+	#superclass : #Object,
+	#category : #'EmergencyDebugger-Tests'
+}
+
+{ #category : #'as yet unclassified' }
+EDMockObjectForTests >> m [
+	self m1
+]
+
+{ #category : #'as yet unclassified' }
+EDMockObjectForTests >> m1 [
+	self m2
+]
+
+{ #category : #'as yet unclassified' }
+EDMockObjectForTests >> m2 [
+	^1
+]
+
+{ #category : #'as yet unclassified' }
+EDMockObjectForTests >> m4 [
+	|i|
+	i := 1.
+	^i squared
+]
+
+{ #category : #'as yet unclassified' }
+EDMockObjectForTests >> m: i [
+	i = 1 ifTrue:[^1].
+	^i + (self m: i - 1)
+]

--- a/src/EmergencyDebugger-Tests/EDMockREPLInterface.class.st
+++ b/src/EmergencyDebugger-Tests/EDMockREPLInterface.class.st
@@ -1,0 +1,13 @@
+"
+I am a null REPL interface for testing the Ed debugger.
+I just implement a repl method that does nothing.
+"
+Class {
+	#name : #EDMockREPLInterface,
+	#superclass : #Object,
+	#category : #'EmergencyDebugger-Tests'
+}
+
+{ #category : #'command line' }
+EDMockREPLInterface >> readEvalPrint [
+]

--- a/src/EmergencyDebugger-Tests/EDTest.class.st
+++ b/src/EmergencyDebugger-Tests/EDTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #EDTests,
+	#name : #EDTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'ed',
@@ -12,12 +12,12 @@ Class {
 }
 
 { #category : #testing }
-EDTests class >> isAbstract [ 	
-	^self == EDTests 
+EDTest class >> isAbstract [ 	
+	^self == EDTest 
 ]
 
 { #category : #running }
-EDTests >> configureDebugSession [
+EDTest >> configureDebugSession [
 
 	"Configure a debug session and moves it to the following stack:
 	EDMockObjectForTests>>m: 5
@@ -94,7 +94,7 @@ EDTests >> configureDebugSession [
 ]
 
 { #category : #'instance creation' }
-EDTests >> newEd [
+EDTest >> newEd [
 	ed := EDEmergencyDebugger new.
 	ed repl: EDMockREPLInterface new.
 	ed displayInterface: (mockDisplayAPI := EDMockDisplayInterface new).
@@ -103,7 +103,7 @@ EDTests >> newEd [
 ]
 
 { #category : #'methods version' }
-EDTests >> prepareMethodVersionTest [
+EDTest >> prepareMethodVersionTest [
 	| context process |
 	EDMockObjectForTests compile: self sampleMethodSourceCodeVersion1.
 	EDMockObjectForTests compile: self sampleMethodSourceCodeVersion2.
@@ -125,17 +125,17 @@ EDTests >> prepareMethodVersionTest [
 ]
 
 { #category : #'methods version' }
-EDTests >> sampleMethodSourceCodeVersion1 [
+EDTest >> sampleMethodSourceCodeVersion1 [
 	^ 'mWithVersion |i| i := 0. ^i + 1'
 ]
 
 { #category : #'methods version' }
-EDTests >> sampleMethodSourceCodeVersion2 [
+EDTest >> sampleMethodSourceCodeVersion2 [
 	^ 'mWithVersion |i| i := 0. ^i + 2'
 ]
 
 { #category : #running }
-EDTests >> setUp [
+EDTest >> setUp [
 	|context process|
 	super setUp.
 	currentDebuggingAPI := EDEmergencyDebugger debugAPI.
@@ -154,7 +154,7 @@ EDTests >> setUp [
 ]
 
 { #category : #running }
-EDTests >> tearDown [
+EDTest >> tearDown [
 	EDEmergencyDebugger debugAPI: currentDebuggingAPI.
 	session terminate.
 	EDMockObjectForTests removeSelector: #mWithVersion.

--- a/src/EmergencyDebugger-Tests/EDTests.class.st
+++ b/src/EmergencyDebugger-Tests/EDTests.class.st
@@ -1,0 +1,162 @@
+Class {
+	#name : #EDTests,
+	#superclass : #TestCase,
+	#instVars : [
+		'ed',
+		'session',
+		'debugAPI',
+		'mockDisplayAPI',
+		'currentDebuggingAPI'
+	],
+	#category : #'EmergencyDebugger-Tests'
+}
+
+{ #category : #testing }
+EDTests class >> isAbstract [ 	
+	^self == EDTests 
+]
+
+{ #category : #running }
+EDTests >> configureDebugSession [
+
+	"Configure a debug session and moves it to the following stack:
+	EDMockObjectForTests>>m: 5
+	EDMockObjectForTests>>m: 6
+	EDMockObjectForTests>>m: 7
+	EDMockObjectForTests>>m: 8
+	EDMockObjectForTests>>m: 9
+	EDMockObjectForTests>>m: 10
+	EDMockObjectForTests>>m: 11
+	EDMockObjectForTests>>m: 12
+	EDMockObjectForTests>>m: 13
+	EDMockObjectForTests>>m: 14
+	EDMockObjectForTests>>m: 15
+	EDMockObjectForTests>>m: 16
+	EDMockObjectForTests>>m: 17
+	EDMockObjectForTests>>m: 18
+	EDMockObjectForTests>>m: 19
+	EDMockObjectForTests>>m: 20
+	[ EDMockObjectForTests new m: 20 ] in UndefinedObject>>DoIt"
+	
+	session stepThrough.
+	session stepOver.
+	session stepInto.
+	session stepOver.
+	session stepOver.
+	session stepInto.
+	session stepOver.
+	session stepOver.
+	session stepInto.	
+	session stepOver.
+	session stepOver.
+	session stepInto.
+	
+	session stepOver.
+	session stepOver.
+	session stepInto.
+	session stepOver.
+	session stepOver.
+	session stepInto.	
+	session stepOver.
+	session stepOver.
+	session stepInto.
+	
+	session stepOver.
+	session stepOver.
+	session stepInto.
+	session stepOver.
+	session stepOver.
+	session stepInto.	
+	session stepOver.
+	session stepOver.
+	session stepInto.
+	
+	session stepOver.
+	session stepOver.
+	session stepInto.
+	session stepOver.
+	session stepOver.
+	session stepInto.	
+	session stepOver.
+	session stepOver.
+	session stepInto.
+	
+	session stepOver.
+	session stepOver.
+	session stepInto.
+	session stepOver.
+	session stepOver.
+	session stepInto.	
+	session stepOver.
+	session stepOver.
+	session stepInto.
+
+]
+
+{ #category : #'instance creation' }
+EDTests >> newEd [
+	ed := EDEmergencyDebugger new.
+	ed repl: EDMockREPLInterface new.
+	ed displayInterface: (mockDisplayAPI := EDMockDisplayInterface new).
+	ed debugAPI: debugAPI.
+	ed debug: session
+]
+
+{ #category : #'methods version' }
+EDTests >> prepareMethodVersionTest [
+	| context process |
+	EDMockObjectForTests compile: self sampleMethodSourceCodeVersion1.
+	EDMockObjectForTests compile: self sampleMethodSourceCodeVersion2.
+
+	context := [ EDMockObjectForTests new mWithVersion] asContext.
+	process := Process
+		forContext: context
+		priority: Processor userInterruptPriority.
+	session := DebugSession
+		named: 'test session'
+		on: process
+		startedAt: context.
+	session stepThrough.
+	session stepOver.
+	session stepInto.
+	session stepOver.
+	debugAPI session: session.
+	self newEd
+]
+
+{ #category : #'methods version' }
+EDTests >> sampleMethodSourceCodeVersion1 [
+	^ 'mWithVersion |i| i := 0. ^i + 1'
+]
+
+{ #category : #'methods version' }
+EDTests >> sampleMethodSourceCodeVersion2 [
+	^ 'mWithVersion |i| i := 0. ^i + 2'
+]
+
+{ #category : #running }
+EDTests >> setUp [
+	|context process|
+	super setUp.
+	currentDebuggingAPI := EDEmergencyDebugger debugAPI.
+	context := [ EDMockObjectForTests new m: 20 ] asContext.
+	process := Process
+		forContext: context
+		priority: Processor userInterruptPriority.
+	session := DebugSession
+		named: 'test session'
+		on: process
+		startedAt: context.
+	self configureDebugSession.
+	debugAPI := EDDebuggingAPI attachTo: session.
+	EDEmergencyDebugger debugAPI: nil.
+	self newEd
+]
+
+{ #category : #running }
+EDTests >> tearDown [
+	EDEmergencyDebugger debugAPI: currentDebuggingAPI.
+	session terminate.
+	EDMockObjectForTests removeSelector: #mWithVersion.
+	super tearDown
+]

--- a/src/EmergencyDebugger-Tests/package.st
+++ b/src/EmergencyDebugger-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'EmergencyDebugger-Tests' }

--- a/src/EmergencyDebugger/Context.extension.st
+++ b/src/EmergencyDebugger/Context.extension.st
@@ -1,0 +1,27 @@
+Extension { #name : #Context }
+
+{ #category : #'*EmergencyDebugger' }
+Context >> printWithArgsValueOn: aStream [
+	| keywords |
+	aStream << self method methodClass name.
+	aStream << '>>'.
+	self method numArgs = 0
+		ifTrue: [ aStream << self method name.
+			^ self ].
+	keywords := self method selector keywords.
+	1 to: keywords size do: [ :i | 
+		| keyword argName argValue |
+		keyword := keywords at: i.
+		argName := self method argumentNames at: i.
+		self flag: 'Sometimes the arguments cannot be accessed. Why?'.
+		argValue := [ self arguments at: i ]
+			on: Error
+			do: [ $? ].
+		aStream << keyword.
+		aStream space.
+		aStream << argName.
+		aStream space.
+		aStream << '('.
+		aStream << argValue printString.
+		aStream << ')' ]
+]

--- a/src/EmergencyDebugger/Context.extension.st
+++ b/src/EmergencyDebugger/Context.extension.st
@@ -6,7 +6,10 @@ Context >> printWithArgsValueOn: aStream [
 	aStream << self method methodClass name.
 	aStream << '>>'.
 	self method numArgs = 0
-		ifTrue: [ aStream << self method name.
+		ifTrue: [ 
+			"If self method is a compiled block, we ask its method.
+			The method of a method is the method itself."
+			aStream << self method method name.
 			^ self ].
 	keywords := self method selector keywords.
 	1 to: keywords size do: [ :i | 

--- a/src/EmergencyDebugger/EDDebuggingAPI.class.st
+++ b/src/EmergencyDebugger/EDDebuggingAPI.class.st
@@ -1,0 +1,239 @@
+"
+I am the default ED Debugging interface.
+I return a set of CmCommands exposing my interface.
+"
+Class {
+	#name : #EDDebuggingAPI,
+	#superclass : #Object,
+	#instVars : [
+		'session',
+		'debugger',
+		'changesForMethods',
+		'longStack'
+	],
+	#category : #'EmergencyDebugger-Core'
+}
+
+{ #category : #'API - Processes' }
+EDDebuggingAPI class >> allRunningProcesses [
+	^ Process allSubInstances
+		reject: [ :each | 
+			each isTerminated
+				or: [ self forbiddenProcesses anySatisfy: [ :block | block value == each ] ] ]
+]
+
+{ #category : #start }
+EDDebuggingAPI class >> attachTo: aDebugSession [
+	^ self new
+		session: aDebugSession;
+		yourself
+]
+
+{ #category : #accessing }
+EDDebuggingAPI class >> displayStackSize [
+	^5
+]
+
+{ #category : #'API - Processes' }
+EDDebuggingAPI class >> forbiddenProcesses [
+	^ {[  ].
+	[ Smalltalk lowSpaceWatcherProcess ].
+	[ WeakArray runningFinalizationProcess ].
+	[ Processor backgroundProcess ].
+	[ InputEventFetcher default fetcherProcess ].
+	[ UIManager default uiProcess ].
+	[ Delay schedulingProcess ]}
+]
+
+{ #category : #accessing }
+EDDebuggingAPI class >> longStackSize [
+	^100
+]
+
+{ #category : #'API - Processes' }
+EDDebuggingAPI class >> terminateAllProcesses [
+	self allRunningProcesses
+		do: [ :process | process ifNotNil: [ process terminate ] ]
+]
+
+{ #category : #'API - Revert' }
+EDDebuggingAPI >> changeRecordsForMethod: aCompiledMethod [
+	^ SourceFiles
+		changeRecordsFrom: aCompiledMethod sourcePointer
+		className: aCompiledMethod methodClass name
+		isMeta: aCompiledMethod methodClass isMeta
+]
+
+{ #category : #accessing }
+EDDebuggingAPI >> changesForMethods [
+	^changesForMethods
+]
+
+{ #category : #'API - Debugging support' }
+EDDebuggingAPI >> closeEmergencySession [
+	debugger terminate.
+	self currentWorld restoreMorphicDisplay
+]
+
+{ #category : #'API - Context' }
+EDDebuggingAPI >> contextAt: index [
+	^self stackAt: index
+]
+
+{ #category : #accessing }
+EDDebuggingAPI >> debugger [
+	^debugger
+]
+
+{ #category : #accessing }
+EDDebuggingAPI >> debugger: anObject [
+	debugger := anObject
+]
+
+{ #category : #'API - Stack' }
+EDDebuggingAPI >> displayStackSize [
+	^self class displayStackSize
+]
+
+{ #category : #initialization }
+EDDebuggingAPI >> initialize [
+	changesForMethods := Dictionary new
+]
+
+{ #category : #'API - Stack' }
+EDDebuggingAPI >> longStack [
+	^ longStack
+		ifNil: [ longStack := session stackOfSize: self longStackSize ]
+]
+
+{ #category : #'API - Stack' }
+EDDebuggingAPI >> longStackSize [
+	^self class longStackSize
+]
+
+{ #category : #'API - Context' }
+EDDebuggingAPI >> methodAt: index [
+	^(self contextAt: index) method
+]
+
+{ #category : #'API - Revert' }
+EDDebuggingAPI >> methodVersionAt: index [
+	^ self versionsForMethod: (self methodAt: index)
+]
+
+{ #category : #'API - Revert' }
+EDDebuggingAPI >> methodVersionSizeAt: index [
+	^ (self versionsForMethod: (self methodAt: index)) size
+]
+
+{ #category : #'API - Context' }
+EDDebuggingAPI >> nodeAt: index [
+	^ self nodeForContext: (self contextAt: index)
+]
+
+{ #category : #'API - Context' }
+EDDebuggingAPI >> nodeForContext: aContext [
+	^ aContext method sourceNodeForPC: aContext pc
+]
+
+{ #category : #'API - Stack' }
+EDDebuggingAPI >> resetStack [
+	longStack := nil
+]
+
+{ #category : #'API - Context' }
+EDDebuggingAPI >> restartContextAt: anIndex [
+	session restart: (self contextAt: anIndex).
+	self resetStack
+]
+
+{ #category : #'API - Debugging support' }
+EDDebuggingAPI >> resume [
+	self closeEmergencySession.
+	session resume
+]
+
+{ #category : #'API - Revert' }
+EDDebuggingAPI >> revert: aCompiledMethod to: aChangeRecord [
+	"Reverts the given method to the given change record"
+
+	aCompiledMethod methodClass
+		compile: aChangeRecord sourceCode
+		classified: aChangeRecord category
+		withStamp: aChangeRecord stamp
+		notifying: nil
+]
+
+{ #category : #'API - Revert' }
+EDDebuggingAPI >> revert: aCompiledMethod to: aChangeRecord inContext: aContext [
+	"Reverts the given method to the given change record in the given context. 
+	The cached stack is updated."
+
+	session
+		recompileMethodTo: aChangeRecord sourceCode
+		inContext: aContext
+		notifying: nil.
+	longStack := nil
+]
+
+{ #category : #accessing }
+EDDebuggingAPI >> session [
+	^session
+]
+
+{ #category : #accessing }
+EDDebuggingAPI >> session: anObject [
+	session := anObject
+]
+
+{ #category : #'API - Stack' }
+EDDebuggingAPI >> stack [ 	
+	^self longStack
+]
+
+{ #category : #'API - Stack' }
+EDDebuggingAPI >> stackAt: index [
+	^self stack at: index
+]
+
+{ #category : #'API - Stack' }
+EDDebuggingAPI >> stackFrom: start to: stop [
+	^ self longStack copyFrom: (start max: 0) to: (stop min: session stack size)
+]
+
+{ #category : #'API - Stack' }
+EDDebuggingAPI >> stackSize [
+	^ self longStack size
+]
+
+{ #category : #'API - Processes' }
+EDDebuggingAPI >> terminateAllProcesses [
+	self terminateSession.
+	self class terminateAllProcesses
+]
+
+{ #category : #'API - Debugging support' }
+EDDebuggingAPI >> terminateSession [
+	self closeEmergencySession.
+	session terminate
+]
+
+{ #category : #'API - Debugging support' }
+EDDebuggingAPI >> tryReopenSessionWithDebugger [
+	self closeEmergencySession.
+	self flag: 'This should be removed once the debugging system is in place'.
+	UIManager default
+		defer: [ [ Smalltalk tools debugger
+				openOn: session
+				withFullView: true
+				andNotification: nil ]
+				on: Error
+				do: [ :ex | session signalDebuggerError: ex ] ]
+]
+
+{ #category : #'API - Revert' }
+EDDebuggingAPI >> versionsForMethod: aCompiledMethod [
+	^ changesForMethods
+		at: aCompiledMethod
+		ifAbsentPut: [ self changeRecordsForMethod: aCompiledMethod ]
+]

--- a/src/EmergencyDebugger/EDDisplayInterface.class.st
+++ b/src/EmergencyDebugger/EDDisplayInterface.class.st
@@ -1,0 +1,98 @@
+"
+I am a simple interface to the Display screen canvas to draw text.
+"
+Class {
+	#name : #EDDisplayInterface,
+	#superclass : #Object,
+	#instVars : [
+		'frame',
+		'methodFrame'
+	],
+	#category : #'EmergencyDebugger-Core'
+}
+
+{ #category : #'display - properties' }
+EDDisplayInterface >> black [
+	^ Color black
+]
+
+{ #category : #'display - API' }
+EDDisplayInterface >> clear [
+	self displayCanvas
+		frameAndFillRectangle: self frame
+		fillColor: self white
+		borderWidth: 2
+		borderColor: self red.
+"	self displayCanvas
+		frameAndFillRectangle: self methodFrame
+		fillColor: self white
+		borderWidth: 2
+		borderColor: self red"
+]
+
+{ #category : #'text - private' }
+EDDisplayInterface >> composeParagraphWith: aText inFrame: aRect [
+	| paragraph |
+	paragraph := Paragraph new.
+	paragraph
+		compose: aText
+		style: self textStyle
+		from: 1
+		in: ((aRect insetBy: 4) withHeight: aRect height).
+	^ paragraph
+]
+
+{ #category : #'display - private' }
+EDDisplayInterface >> display: aParagraph in: aRect [
+	self displayCanvas
+		paragraph: aParagraph
+		bounds: aRect
+		color: self black
+]
+
+{ #category : #'display - properties' }
+EDDisplayInterface >> displayCanvas [
+	^Display getCanvas
+]
+
+{ #category : #'display - properties' }
+EDDisplayInterface >> frame [
+	^ frame
+		ifNil: [ frame := 0 @ 0 corner: DisplayScreen actualScreenSize * (0.3 @ 1) ]
+]
+
+{ #category : #'display - properties' }
+EDDisplayInterface >> gray [
+	^ Color gray
+]
+
+{ #category : #'display - properties' }
+EDDisplayInterface >> methodFrame [
+	^ methodFrame
+		ifNil: [ methodFrame := self frame corner corner: DisplayScreen actualScreenSize ]
+]
+
+{ #category : #'display - properties' }
+EDDisplayInterface >> red [
+	^ Color red
+]
+
+{ #category : #'display - API' }
+EDDisplayInterface >> show: aText [
+	self
+		display: (self composeParagraphWith: aText inFrame: self frame)
+		in: self frame.
+	"self
+		display: (self composeParagraphWith: aText inFrame: self frame)
+		in: self methodFrame."
+]
+
+{ #category : #'text - private' }
+EDDisplayInterface >> textStyle [
+	^ TextStyle default
+]
+
+{ #category : #'display - properties' }
+EDDisplayInterface >> white [
+	^ Color white
+]

--- a/src/EmergencyDebugger/EDEmergencyDebugger.class.st
+++ b/src/EmergencyDebugger/EDEmergencyDebugger.class.st
@@ -1,0 +1,654 @@
+"
+I am a REPL debugger and I provide an access to the Sindarin debugging API.
+I do not depend on morphic, and while I depend on Color, I can work without it.
+
+I use a ReadWriteStream to handle user input and output my results.
+I use Display and DisplayScreen to show my results.
+"
+Class {
+	#name : #EDEmergencyDebugger,
+	#superclass : #Object,
+	#instVars : [
+		'rawDisplay',
+		'stackSelectionIndex',
+		'methodVersionSelectionIndex',
+		'methodText',
+		'stackText',
+		'titleText',
+		'repl',
+		'input',
+		'result',
+		'isRunning',
+		'debugAPI',
+		'actions',
+		'actionsDescriptions',
+		'selectedMethod',
+		'shortStack',
+		'shortStackIndex',
+		'error',
+		'errorText'
+	],
+	#classVars : [
+		'DefaultDebugAPI'
+	],
+	#category : #'EmergencyDebugger-Core'
+}
+
+{ #category : #'instance creation' }
+EDEmergencyDebugger class >> debug: aDebugSession [
+	self flag: 'Not good, must add and test the error too!'.
+	^ self new emergencyDebug: aDebugSession
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger class >> debugAPI [
+	^self defaultDebugAPI
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger class >> debugAPI: aDebugAPIClass [
+	DefaultDebugAPI := aDebugAPIClass 
+]
+
+{ #category : #'instance creation' }
+EDEmergencyDebugger class >> debugError: anError fromSession: aDebugSession [
+	^ self new
+		fromError: anError;
+		emergencyDebug: aDebugSession
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger class >> defaultDebugAPI [
+	^ DefaultDebugAPI ifNil: [ DefaultDebugAPI := EDDebuggingAPI ]
+]
+
+{ #category : #actions }
+EDEmergencyDebugger >> availableActions [ 
+	^actions ifNil:[actions := self buildDefaultActions]
+]
+
+{ #category : #actions }
+EDEmergencyDebugger >> availableActionsDescriptions [ 
+	^actionsDescriptions ifNil:[actionsDescriptions := self buildDefaultActionsDescriptions]
+]
+
+{ #category : #actions }
+EDEmergencyDebugger >> availableActionsDescriptionsMap [
+	^self buildDefaultActionsDescriptionsMap 
+]
+
+{ #category : #initialization }
+EDEmergencyDebugger >> basicDebug: aDebugSession [
+	debugAPI := self class debugAPI attachTo: aDebugSession.
+	debugAPI debugger: self.
+	isRunning := true
+]
+
+{ #category : #actions }
+EDEmergencyDebugger >> buildDefaultActions [
+	|dic|
+	dic := Dictionary new.
+	dic at: 'q!' put: [ debugAPI closeEmergencySession ].
+	dic at: 'q' put: [ debugAPI terminateSession ].
+	dic at: 'showDebuggerError' put: [ self showDebuggerError ].
+	dic at: 'exit' put: [ debugAPI terminateSession ].
+	dic at: 'retry' put: [ debugAPI tryReopenSessionWithDebugger ].
+	dic at: Character arrowUp put: [ self moveUpInStack ].
+	dic at: Character arrowDown put: [ self moveDownInStack ].
+	dic at: Character arrowLeft put: [ self showMoreRecentMethodVersion ].
+	dic at: Character arrowRight put: [ self showOlderMethodVersion ].
+	dic at: 'help' put: [ self composeHelpText ].
+	dic at: 'revert' put: [ self revertCurrentMethodToSelectedVersion ].
+	dic at: 'forceRevert' put: [ self revertCurrentMethodToSelectedVersionAndQuit ].
+	dic at: 'terminateAll' put: [ debugAPI terminateAllProcesses ].
+	dic at: 'proceed' put: [ debugAPI resume ].
+	dic at: 'debug' put:[self debugDebuggerError].
+	^dic
+]
+
+{ #category : #actions }
+EDEmergencyDebugger >> buildDefaultActionsDescriptions [
+	|dic|
+	dic := Dictionary new.
+	dic at: 'exit/q' put: 'Exit the emergency debugger'.
+	dic at: 'help' put: 'Show this help.'.
+	dic at: 'retry' put: 'Retry opening a graphical debugger'.
+	dic at: '<UP/DOWN> arrows' put: 'Move up/down in the stack'.
+	dic at: '<RIGHT/LEFT> arrows' put: 'Navigate the current method versions'.
+	dic at: 'revert' put: 'Revert the current method to the selected method version in the current context'.
+	dic at: 'forceRevert' put: 'Recompiles the current method to the selected method version and quits the emergency debugger'.
+	dic at: 'terminateAll' put: 'Terminate all non-essential processes (will terminate Ed)'.
+	dic at: 'proceed' put: 'Proceeds the execution'.
+	dic at: 'showDebuggerError' put: 'Display debugger error stack, i.e., why you are here.'.
+	dic at: 'debug' put: 'Debug the debugger error.'.
+	^dic
+]
+
+{ #category : #actions }
+EDEmergencyDebugger >> buildDefaultActionsDescriptionsMap [
+	|dic|
+	dic := Dictionary new.	
+	dic at: 'exit' put: 'exit/q'.
+	dic at: 'q' put: 'exit/q'.
+	dic at: 'retry' put: 'retry'.
+	dic at: Character arrowUp put: '<UP/DOWN> arrows'.
+	dic at: Character arrowDown put: '<UP/DOWN> arrows'.
+	dic at: Character arrowLeft put: '<RIGHT/LEFT> arrows'.
+	dic at: Character arrowRight put: '<RIGHT/LEFT> arrows'.
+	dic at: 'revert' put: 'revert'.
+	dic at: 'forceRevert' put: 'forceRevert'.	
+	dic at: 'help' put: 'help'.
+	dic at: 'terminateAll' put: 'terminateAll'.
+	dic at: 'proceed' put: 'proceed'.
+	dic at: 'showDebuggerError' put: 'showDebuggerError'.	
+	dic at: 'debug' put: 'debug'.
+	^dic
+]
+
+{ #category : #'text - composing' }
+EDEmergencyDebugger >> composeDisplayText [
+	^(titleText , (self composeSessionTitle), stackText, methodText, input, result )
+
+]
+
+{ #category : #'text - composing' }
+EDEmergencyDebugger >> composeErrorTextFrom: anError [
+	| errStream |
+	errStream := WriteStream on: Text new.
+	errStream cr.
+	self writeSeparatorOn: errStream.
+	errStream << anError description.
+	errorText := errStream contents
+]
+
+{ #category : #'text - composing' }
+EDEmergencyDebugger >> composeHelpText [
+	| str |
+	str := self newTextStream.
+	self availableActionsDescriptions
+		keysAndValuesDo: [ :cmd :desc | 
+			|text|
+			text := (cmd, ': ') asText allBold, desc asText.
+			text makeAllColor: rawDisplay gray.
+			str << text.		
+			str cr ].
+	^ self composeResult: str contents title: 'HELP'
+]
+
+{ #category : #'text - composing' }
+EDEmergencyDebugger >> composeMethodText [
+	| str method node text |
+	str := self newTextStream.
+	self writeSectionTitle: 'SOURCE' on: str.
+	method := debugAPI methodAt: stackSelectionIndex.
+	node := debugAPI nodeAt: stackSelectionIndex.	
+	text := method sourceCode asText.
+	text makeColor: rawDisplay red from: node start to: node stop.
+	str << method methodClass name.
+	str << '>>'.
+	str << text.
+	str cr.
+	methodText := str contents
+]
+
+{ #category : #'text - composing' }
+EDEmergencyDebugger >> composePromptWith: aString [
+	| str  |
+	str := self newTextStream.	
+	str cr.
+	self writeSeparatorOn: str.
+	str << '> ' asText allBold.
+	str << aString trim asText.
+	input := str contents
+]
+
+{ #category : #'text - composing' }
+EDEmergencyDebugger >> composeResult: text title: title [
+	| str |
+	str := self newTextStream.
+	str cr.
+	self writeSectionTitle: title on: str.
+	str << text.
+	result := str contents
+]
+
+{ #category : #'text - composing' }
+EDEmergencyDebugger >> composeSessionTitle [
+	| errStream |
+	errStream := WriteStream on: Text new.
+	errStream cr.
+	self writeSeparatorOn: errStream.
+	errStream << debugAPI session name.
+	^errStream contents
+]
+
+{ #category : #'text - composing' }
+EDEmergencyDebugger >> composeStackText [
+	| str stack |
+	str := self newTextStream.
+	stack := self shortStack.
+	str cr.
+	self
+		writeSectionTitle:
+			'STACK (' , stackSelectionIndex printString , '/'
+				, debugAPI stackSize printString , ')'
+		on: str.
+	1 to: stack size do: [ :i | 
+		| textStream text |
+		textStream := self newTextStream.
+		(stack at: i) printWithArgsValueOn: textStream.
+		text := textStream contents.
+		i = shortStackIndex
+			ifTrue: [ text allBold ].
+		str << text.
+		str cr ].
+	stackText := str contents
+]
+
+{ #category : #'text - composing' }
+EDEmergencyDebugger >> composeTitleText [
+	titleText := 'Hi, I''m ED - What is the nature of your debugging emergency?' asText allBold
+]
+
+{ #category : #initialization }
+EDEmergencyDebugger >> debug: aDebugSession [
+	self basicDebug: aDebugSession.
+	self composeTitleText.
+	self composeStackText.
+	self composeMethodText.
+	self composeHelpText.
+	self composePromptWith: ''.
+	self updateDisplay.
+	repl readEvalPrint 
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> debugAPI [
+	^debugAPI
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> debugAPI: aDebugAPI [
+	debugAPI := aDebugAPI
+]
+
+{ #category : #private }
+EDEmergencyDebugger >> debugDebuggerError [
+	self terminate.
+	error debug
+]
+
+{ #category : #'text - helpers' }
+EDEmergencyDebugger >> defaultResultText [
+	^ 'TYPE h FOR HELP' asText
+]
+
+{ #category : #actions }
+EDEmergencyDebugger >> descriptionFromPromptCommand: aString [
+	|key|
+	key := self availableActionsDescriptionsMap at: aString.
+	^self availableActionsDescriptions at: key
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> displayInterface: aDisplayInterface [
+	rawDisplay := aDisplayInterface
+]
+
+{ #category : #initialization }
+EDEmergencyDebugger >> emergencyDebug: aDebugSession [
+	[ self debug: aDebugSession ]
+		on: Error
+		do: [ :err | self signalDebuggerError: err forSession: aDebugSession]
+]
+
+{ #category : #'error handling' }
+EDEmergencyDebugger >> errorDescriptionFrom: anError [
+	^ [ anError description ]
+		on: Error
+		do: [ 'a ' , anError class printString ]
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> errorText [
+	^errorText
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> errorText: aText [
+	errorText := aText 
+]
+
+{ #category : #evaluation }
+EDEmergencyDebugger >> eval: command [
+	self evalCommand: command.
+	self composePromptWith: ''.
+	self updateDisplay
+]
+
+{ #category : #evaluation }
+EDEmergencyDebugger >> evalCommand: aString [
+	| action |
+	action := self availableActions at: aString ifAbsent: [ ^ false ].
+	[ action value ]
+		on: Exception
+		do:
+			[ :e | self handleEmergencyDebuggerError: e description: aString ].
+	self updateDisplay.
+	^ true
+]
+
+{ #category : #initialization }
+EDEmergencyDebugger >> fromError: anError [
+	self composeErrorTextFrom: anError.
+	error := anError
+]
+
+{ #category : #'error handling' }
+EDEmergencyDebugger >> handleEmergencyDebuggerError: e description: commandString [
+	self
+		composeResult:
+			('Cannot ' , (self descriptionFromPromptCommand: commandString))
+				asText allBold
+		title: 'ERROR: ' , (self errorDescriptionFrom: e)
+	"isRunning := false.
+	[ [ e debug ]
+		on: Error
+		do: [ :err | self signalDebuggerError: err forSession: debugAPI session ] ]
+		ensure: [ isRunning := true.
+			repl readEvalPrint ]"
+]
+
+{ #category : #initialization }
+EDEmergencyDebugger >> initialize [
+	repl := EDREPLInterface forDebugger: self.
+	rawDisplay := EDDisplayInterface new.
+	stackSelectionIndex := 1.
+	shortStackIndex := 1.
+	methodVersionSelectionIndex := 0.
+	input := Text new.
+	self composeResult: Text new title: self defaultResultText.
+	isRunning := false.
+	errorText := Text new
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> input [
+	^input
+]
+
+{ #category : #testing }
+EDEmergencyDebugger >> isRunning [
+	^isRunning 
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> methodText [
+	^methodText
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> methodVersionSelectionIndex [
+	^methodVersionSelectionIndex
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> methodVersionSelectionIndex: anInteger [
+	methodVersionSelectionIndex := anInteger
+]
+
+{ #category : #stack }
+EDEmergencyDebugger >> moveDownInStack [
+	stackSelectionIndex = debugAPI stackSize
+		ifTrue: [ ^ self ].
+	stackSelectionIndex := stackSelectionIndex + 1.
+	shortStackIndex := shortStackIndex + 1.
+	shortStackIndex > debugAPI displayStackSize
+		ifTrue: [ self shiftDownShortStack ].
+	methodVersionSelectionIndex := 0.
+	self composeStackText.
+	self composeMethodText.
+	self composeHelpText
+]
+
+{ #category : #stack }
+EDEmergencyDebugger >> moveUpInStack [
+	stackSelectionIndex = 1
+		ifTrue: [ ^ self ].
+	stackSelectionIndex := stackSelectionIndex - 1.
+	shortStackIndex := shortStackIndex - 1.
+	shortStackIndex = 0
+		ifTrue: [ self shiftUpShortStack ].
+	methodVersionSelectionIndex := 0.
+	self composeStackText.
+	self composeMethodText.
+	self composeHelpText
+]
+
+{ #category : #'text - helpers' }
+EDEmergencyDebugger >> newTextStream [
+	^WriteStream on: Text new
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> originalError [
+	^error
+]
+
+{ #category : #evaluation }
+EDEmergencyDebugger >> performActionForChar: aCharacter [
+	^self evalCommand: aCharacter
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> repl: aREPLInterface [
+	repl := aREPLInterface
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> result [
+	^result
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> resultText [
+	^ result
+]
+
+{ #category : #methods }
+EDEmergencyDebugger >> revertCurrentMethodToSelectedVersion [
+	"should:
+		- revert method from the current selected context to the selected method version
+		- restart the context
+		- update texts"
+	|method methodVersion|
+	method := debugAPI methodAt: stackSelectionIndex.
+	methodVersion := (debugAPI methodVersionAt: stackSelectionIndex) at: methodVersionSelectionIndex.
+	debugAPI revert: method to: methodVersion inContext: (debugAPI contextAt: stackSelectionIndex).
+	shortStack := nil.
+	
+	stackSelectionIndex := 1.
+	shortStackIndex := 1.
+	self composeStackText.
+	self composeMethodText.
+	methodVersionSelectionIndex := 1.
+	self showSelectedMethodVersion
+]
+
+{ #category : #methods }
+EDEmergencyDebugger >> revertCurrentMethodToSelectedVersionAndQuit [
+	"should:
+		- revert method from the current selected context to the selected method version
+		- quit the emergency debugger"
+	|method methodVersion|
+	method := debugAPI methodAt: stackSelectionIndex.
+	methodVersion := (debugAPI methodVersionAt: stackSelectionIndex) at: methodVersionSelectionIndex.
+	debugAPI revert: method to: methodVersion inContext: (debugAPI contextAt: stackSelectionIndex).
+	debugAPI terminateSession
+]
+
+{ #category : #methods }
+EDEmergencyDebugger >> selectedMethodVersion [
+	|versions |	
+	versions := debugAPI methodVersionAt: stackSelectionIndex.
+	^versions at: methodVersionSelectionIndex.
+	
+]
+
+{ #category : #methods }
+EDEmergencyDebugger >> selectedMethodVersionsSize [
+	^ debugAPI methodVersionSizeAt: stackSelectionIndex
+]
+
+{ #category : #'text - helpers' }
+EDEmergencyDebugger >> separator [ 
+	^'--------------------' asText makeAllColor: rawDisplay gray
+]
+
+{ #category : #stack }
+EDEmergencyDebugger >> shiftDownShortStack [
+	"rebuilds the short stack that is displayed by shitfing down the stack view by debugAPI displayStackSize elements"
+
+	| start stop |
+	shortStackIndex := 1.
+	start := stackSelectionIndex.
+	stop := stackSelectionIndex + debugAPI displayStackSize - 1
+		min: debugAPI stackSize.
+	shortStack := debugAPI stackFrom: start to: stop
+]
+
+{ #category : #stack }
+EDEmergencyDebugger >> shiftUpShortStack [
+	"rebuilds the short stack that is displayed by shitfing up the stack view by debugAPI displayStackSize elements"
+
+	stackSelectionIndex = 1
+		ifTrue: [ ^ shortStack := debugAPI stackFrom: 1 to: debugAPI displayStackSize ].
+	shortStackIndex := debugAPI displayStackSize.
+	^ shortStack := debugAPI
+		stackFrom: (stackSelectionIndex - debugAPI displayStackSize max: 1)
+		to: stackSelectionIndex
+]
+
+{ #category : #stack }
+EDEmergencyDebugger >> shortStack [
+	^ shortStack
+		ifNil: [ shortStack := debugAPI stackFrom: 1 to: debugAPI displayStackSize ]
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> shortStackIndex [
+	^shortStackIndex
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> shortStackIndex: newIndex [
+	shortStackIndex := newIndex
+]
+
+{ #category : #private }
+EDEmergencyDebugger >> showDebuggerError [
+	| context text |
+	error
+		ifNil: [ self composeResult: '' title: 'No error.'.
+			^ self updateDisplay ].
+	context := error signalerContext.
+	text := String
+		streamContents: [ :s | 
+			20
+				timesRepeat: [ context == nil
+						ifFalse: [ s
+								cr;
+								print: (context := context sender) ] ] ].
+	self composeResult: text title: error description.
+	self updateDisplay
+]
+
+{ #category : #methods }
+EDEmergencyDebugger >> showMoreRecentMethodVersion [
+	methodVersionSelectionIndex := methodVersionSelectionIndex - 1 max: 1.
+	self showSelectedMethodVersion
+]
+
+{ #category : #methods }
+EDEmergencyDebugger >> showOlderMethodVersion [
+	methodVersionSelectionIndex := methodVersionSelectionIndex + 1
+		min: self selectedMethodVersionsSize.
+	self showSelectedMethodVersion
+]
+
+{ #category : #methods }
+EDEmergencyDebugger >> showSelectedMethodVersion [
+	| selectedVersion text |
+	selectedVersion := self selectedMethodVersion.
+	text := selectedVersion sourceCode asText.
+	text makeBoldFrom: 1 to: selectedVersion methodSelector size.
+	self
+		composeResult: text
+		title:
+			'VERSIONS (' , methodVersionSelectionIndex printString , '/'
+				, self selectedMethodVersionsSize printString , ')'.
+	self updateDisplay
+]
+
+{ #category : #'error handling' }
+EDEmergencyDebugger >> signalDebuggerError: anError forSession: aDebugSession [
+	| errDescription errStream |
+	errDescription := self errorDescriptionFrom: anError.
+	errStream := WriteStream on: String new.
+	errStream << ('Original error: ' , aDebugSession name asString , '.').
+	errStream << ('Smalltalk tools debugger error: ' , errDescription).
+	errStream cr.
+	self primitiveError: errStream contents
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> stackSelectionIndex [
+	^stackSelectionIndex
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> stackSelectionIndex: newIndex [
+	stackSelectionIndex := newIndex
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> stackText [
+	^stackText
+]
+
+{ #category : #initialization }
+EDEmergencyDebugger >> terminate [
+	isRunning := false
+]
+
+{ #category : #accessing }
+EDEmergencyDebugger >> titleText [
+	^titleText
+]
+
+{ #category : #updating }
+EDEmergencyDebugger >> updateDisplay [
+	rawDisplay clear.
+	rawDisplay show: self composeDisplayText 
+
+]
+
+{ #category : #updating }
+EDEmergencyDebugger >> updatePrompt: aString [
+	self composePromptWith: aString.
+	self updateDisplay
+]
+
+{ #category : #'text - helpers' }
+EDEmergencyDebugger >> writeSectionTitle: aString on: aStream [
+	self writeSeparatorOn: aStream.
+	aStream << (aString asText makeAllColor: rawDisplay gray).
+	aStream cr.
+	self writeSeparatorOn: aStream
+]
+
+{ #category : #'text - helpers' }
+EDEmergencyDebugger >> writeSeparatorOn: aStream [
+	aStream << self separator.
+	aStream cr
+]

--- a/src/EmergencyDebugger/EDEmergencyDebuggerSettings.class.st
+++ b/src/EmergencyDebugger/EDEmergencyDebuggerSettings.class.st
@@ -1,0 +1,39 @@
+"
+I describe and implement settings for choosing the emergency debugging tool to use
+"
+Class {
+	#name : #EDEmergencyDebuggerSettings,
+	#superclass : #Object,
+	#classVars : [
+		'defaultEmergencyDebugger'
+	],
+	#category : #'EmergencyDebugger-Core'
+}
+
+{ #category : #accessing }
+EDEmergencyDebuggerSettings class >> defaultEmergencyDebugger [
+	^defaultEmergencyDebugger ifNil:[defaultEmergencyDebugger := EDEmergencyDebugger]
+]
+
+{ #category : #accessing }
+EDEmergencyDebuggerSettings class >> defaultEmergencyDebugger: aDebugger [
+	defaultEmergencyDebugger := aDebugger value
+]
+
+{ #category : #settings }
+EDEmergencyDebuggerSettings class >> emergencyDebuggerSettingsOn: aBuilder [
+	<systemsettings>
+	(aBuilder pickOne: #defaultEmergencyDebugger)
+		label: 'Emergency Debugger';
+		parent: #debugging;
+		description: 'Debugger to use in case of emergency (debugger error)';
+		target: self;
+		default: EDEmergencyDebugger;
+		domainValues:
+			{('Ed' -> EDEmergencyDebugger).
+			('Emergency Evaluator' -> Transcripter)}
+]
+
+{ #category : #'see class side' }
+EDEmergencyDebuggerSettings >> seeClassSide [ 
+]

--- a/src/EmergencyDebugger/EDREPLInterface.class.st
+++ b/src/EmergencyDebugger/EDREPLInterface.class.st
@@ -1,0 +1,93 @@
+"
+I am a simple REPL interface for the ED emergency debugger.
+Basically I am a readwrite stream that reads character pressed events to:
+- forward them to the debugger in case it must perform special actions
+- put them in myself to build a line
+When I read the Character cr event, I send my contents (the line) to the debugger, then I reinitialize myself.
+"
+Class {
+	#name : #EDREPLInterface,
+	#superclass : #ReadWriteStream,
+	#instVars : [
+		'debugger'
+	],
+	#pools : [
+		'EventSensorConstants'
+	],
+	#category : #'EmergencyDebugger-Core'
+}
+
+{ #category : #'instance creation' }
+EDREPLInterface class >> forDebugger: aSindarinDebugger [
+	^ (self on: (String new: 100))
+		debugger: aSindarinDebugger;
+		yourself
+]
+
+{ #category : #utilities }
+EDREPLInterface class >> nextChar [
+	[| evt type | 
+		(Delay forMilliseconds: 20) wait.
+		self sensor nextEvent
+		ifNotNil: [:evtBuf | 
+			type := evtBuf first.
+			type = EventTypeKeyboard
+				ifTrue: [evt := self currentWorld currentHand generateKeyboardEvent: evtBuf.
+					evt isKeystroke
+						ifTrue: [| c |
+							c := evt keyCharacter.
+							(c asciiValue < 128
+									or: [c isSeparator
+											or: [c isSpecial
+													or: [c = Character backspace]]])
+								ifTrue: [self sensor flushKeyboard.
+									^ evt keyCharacter]]]]] repeat
+]
+
+{ #category : #accessing }
+EDREPLInterface class >> sensor [
+	^Sensor
+]
+
+{ #category : #accessing }
+EDREPLInterface >> debugger: anObject [
+	debugger := anObject
+]
+
+{ #category : #accessing }
+EDREPLInterface >> nextChar [
+	^ self class nextChar
+]
+
+{ #category : #'command line' }
+EDREPLInterface >> readEvalPrint [
+	self sensor flushKeyboard.
+	[ debugger isRunning ]
+		whileTrue: [ debugger eval: self requestLine.
+			self resetREPL ]
+]
+
+{ #category : #'command line' }
+EDREPLInterface >> requestLine [
+	| startPos char contents |
+	startPos := position.
+	self sensor flushKeyboard.
+	[ (char := self nextChar) = Character cr ]
+		whileFalse: [ (debugger performActionForChar: char)
+				ifFalse: [ char = Character backspace
+						ifTrue: [ readLimit := position := position - 1 max: startPos ]
+						ifFalse: [ self nextPut: char ].
+					debugger updatePrompt: self contents ] ].
+	contents := self contents.
+	^ contents copyFrom: startPos + 1 to: contents size
+]
+
+{ #category : #private }
+EDREPLInterface >> resetREPL [
+	self on: (String new: 100)
+]
+
+{ #category : #accessing }
+EDREPLInterface >> sensor [
+	^self class sensor
+]

--- a/src/EmergencyDebugger/ManifestEmergencyDebugger.class.st
+++ b/src/EmergencyDebugger/ManifestEmergencyDebugger.class.st
@@ -1,0 +1,13 @@
+"
+I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestEmergencyDebugger,
+	#superclass : #PackageManifest,
+	#category : #'EmergencyDebugger-Manifest'
+}
+
+{ #category : #'code-critics' }
+ManifestEmergencyDebugger class >> ruleReToDoRuleV1FalsePositive [
+	^ #(#(#(#RGMethodDefinition #(#EDEmergencyDebugger #composeStackText #false)) #'2020-04-10T12:25:37.258447+02:00') )
+]

--- a/src/EmergencyDebugger/package.st
+++ b/src/EmergencyDebugger/package.st
@@ -1,0 +1,1 @@
+Package { #name : #EmergencyDebugger }

--- a/src/EmergencyEvaluator/Transcripter.class.st
+++ b/src/EmergencyEvaluator/Transcripter.class.st
@@ -52,6 +52,22 @@ Transcripter class >> buildIcon [
 ]
 
 { #category : #launching }
+Transcripter class >> debugError: anError fromSession: aDebugSession [
+	"The emergency evaluator does not know how to use a debug session, so it is dropped"
+
+	self
+		primitiveError:
+			'Original error: ' , name asString
+				,
+					'.
+	Smalltalk tools debugger error: '
+				,
+					([ anError description ]
+						on: Error
+						do: [ 'a ' , anError class printString ]) , ':'
+]
+
+{ #category : #launching }
 Transcripter class >> emergencyEvaluator [
 	"Display and launch an evaluator"
 	


### PR DESCRIPTION
https://thepharo.dev/2020/05/13/ed-your-new-emergency-debugger/

Note that further work will be done to improve its independence (for now it too tied on Morphic), and possible bugs.

It needs to be used to highlight bugs.

Can be deactivated in settings>emergency debugger.