### PR TITLE
maxTimeForTest

### DIFF
--- a/src/SUnit-Core/DefaultExecutionEnvironment.extension.st
+++ b/src/SUnit-Core/DefaultExecutionEnvironment.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : #DefaultExecutionEnvironment }
 
 { #category : #'*SUnit-Core' }
+DefaultExecutionEnvironment >> maxTimeForTest: aDuration [
+
+	"just for compatibility with TestExecutionEnvironment, do nothing"
+]
+
+{ #category : #'*SUnit-Core' }
 DefaultExecutionEnvironment >> runTestCase: aTestCase [
 
 	| testEnv |


### PR DESCRIPTION
Add maxTimeForTest: to the DefaultExecutionEnvironment for compatibiity when you run code of tests that set time-out outside of testing environment (CurrentExecutionEnvironment value is called so all possible execution environment should know this message)