### PR TITLE
SyntaxErrorDebuggerDepentsClean

### DIFF
--- a/src/Tools/SyntaxErrorDebugger.class.st
+++ b/src/Tools/SyntaxErrorDebugger.class.st
@@ -11,14 +11,13 @@ Class {
 		'contents',
 		'class',
 		'selector',
-		'category',
 		'debugSession',
-		'doitFlag',
 		'window',
+		'editor',
 		'location',
-		'error',
 		'announcer',
-		'syntaxError'
+		'syntaxError',
+		'errorMessage'
 	],
 	#category : #'Tools-Debugger'
 }
@@ -27,8 +26,8 @@ Class {
 SyntaxErrorDebugger class >> buildMorphicViewOn: aSyntaxErrorDebugger [
 	"Answer an Morphic view on the given SyntaxError."
 
-	| window |
-	window := (SystemWindow labelled: 'Syntax Error: ' , aSyntaxErrorDebugger error)
+	| window editor |
+	window := (SystemWindow labelled: 'Syntax Error: ' , aSyntaxErrorDebugger errorMessage)
 		model: aSyntaxErrorDebugger.
 	window
 		addMorph:
@@ -41,7 +40,7 @@ SyntaxErrorDebugger class >> buildMorphicViewOn: aSyntaxErrorDebugger [
 		frame: (0 @ 0 corner: 1 @ 0.15).
 	window
 		addMorph:
-			(RubScrolledTextMorph new
+			(editor := RubScrolledTextMorph new
 				on: aSyntaxErrorDebugger
 				text: #contents
 				accept: #contents:notifying:
@@ -49,6 +48,7 @@ SyntaxErrorDebugger class >> buildMorphicViewOn: aSyntaxErrorDebugger [
 				menu: #codePaneMenu:shifted:)
 		frame: (0 @ 0.15 corner: 1 @ 1).
 	aSyntaxErrorDebugger window: window.
+	aSyntaxErrorDebugger editor: editor.
 	window extent: 380 @ 220.
 	^ window openInWorld
 ]
@@ -98,12 +98,9 @@ SyntaxErrorDebugger >> browseMethodFull [
 			openOnClass: myClass selector: self selectedMessageName]
 ]
 
-{ #category : #accessing }
-SyntaxErrorDebugger >> category: aSymbol [
-	"Record the message category of method being compiled. This is used when the user corrects the error and accepts."
-
-	category := aSymbol.
-
+{ #category : #other }
+SyntaxErrorDebugger >> category [
+	^(class organization categoryOfElement: selector) ifNil: [ Protocol unclassified ]
 ]
 
 { #category : #initialization }
@@ -133,7 +130,7 @@ SyntaxErrorDebugger >> codePaneMenu: aMenu shifted: shifted [
 	text pane"
 
 	| donorMenu |
-	donorMenu := (PragmaMenuBuilder pragmaKeyword: RubSmalltalkCodeMode menuKeyword model: self)
+	donorMenu := (PragmaMenuBuilder pragmaKeyword: RubSmalltalkCodeMode menuKeyword model: editor)
 		menu.
 	^ aMenu addAllFrom: donorMenu
 ]
@@ -154,7 +151,7 @@ SyntaxErrorDebugger >> contents: aString notifying: aController [
 
 	aController hasUnacceptedEdits: false.
 	
-	doitFlag
+	syntaxError doitFlag
 		ifTrue: [ self class compiler evaluate: aString ]
 		ifFalse: [ self resume: aString ].
 	self closeWindow
@@ -177,8 +174,13 @@ SyntaxErrorDebugger >> debug [
 ]
 
 { #category : #accessing }
-SyntaxErrorDebugger >> error [
-	^ error
+SyntaxErrorDebugger >> editor: anEditor [
+	editor := anEditor
+]
+
+{ #category : #accessing }
+SyntaxErrorDebugger >> errorMessage [
+	^ errorMessage
 ]
 
 { #category : #initialization }
@@ -200,9 +202,9 @@ SyntaxErrorDebugger >> highlightError [
 SyntaxErrorDebugger >> list [
 	"Answer an array of one element made up of the class name, message category, and message selector in which the syntax error was found. This is the single item in the message list of a view/browser on the receiver."
 
-	selector ifNil: [^ Array with: (class name, '  ', (category ifNil: ['']), '  ', '<none>')].
-	category ifNil: [^ Array with: (class name, '    ', '<none>')].
-	^ Array with: (class name, '  ', category, '  ', selector)
+	selector ifNil: [^ Array with: (class name, '  ', (self category ifNil: ['']), '  ', '<none>')].
+	self category ifNil: [^ Array with: (class name, '    ', '<none>')].
+	^ Array with: (class name, '  ', self category, '  ', selector)
 
 ]
 
@@ -280,7 +282,7 @@ SyntaxErrorDebugger >> shoutAboutToStyle: aPluggableShoutMorphOrView [
 
 { #category : #accessing }
 SyntaxErrorDebugger >> sourceErrorString [
-	^ error , ' -> '
+	^ errorMessage , ' -> '
 ]
 
 { #category : #initialization }
@@ -289,15 +291,12 @@ SyntaxErrorDebugger >> syntaxError: aSyntaxError [
 	
 	syntaxError := aSyntaxError.
 	class :=  aSyntaxError errorClass.
-	error := aSyntaxError errorMessage.
+	errorMessage := aSyntaxError errorMessage.
 	location := aSyntaxError location.	
 	debugSession := (Processor activeProcess newDebugSessionNamed: 'Stack of the Syntax Error' startedAt: aSyntaxError signalerContext).
 	contents := self checkForUnprintableCharacters: aSyntaxError errorCode.
 	selector := class compiler parseSelector: contents.	
-	self highlightError.
-
- 	category := (class organization categoryOfElement: selector) ifNil: [ Protocol unclassified ].
-	doitFlag := aSyntaxError doitFlag
+	self highlightError
 ]
 
 { #category : #accessing }

--- a/src/Tools/SyntaxErrorDebugger.class.st
+++ b/src/Tools/SyntaxErrorDebugger.class.st
@@ -14,7 +14,7 @@ Class {
 		'category',
 		'debugSession',
 		'doitFlag',
-		'dependents',
+		'window',
 		'location',
 		'error',
 		'announcer',
@@ -24,16 +24,16 @@ Class {
 }
 
 { #category : #'instance creation' }
-SyntaxErrorDebugger class >> buildMorphicViewOn: aSyntaxError [
+SyntaxErrorDebugger class >> buildMorphicViewOn: aSyntaxErrorDebugger [
 	"Answer an Morphic view on the given SyntaxError."
 
 	| window |
-	window := (SystemWindow labelled: 'Syntax Error: ' , aSyntaxError error)
-		model: aSyntaxError.
+	window := (SystemWindow labelled: 'Syntax Error: ' , aSyntaxErrorDebugger error)
+		model: aSyntaxErrorDebugger.
 	window
 		addMorph:
 			((PluggableListMorph
-				on: aSyntaxError
+				on: aSyntaxErrorDebugger
 				list: #list
 				selected: #listIndex
 				changeSelected: nil
@@ -42,19 +42,19 @@ SyntaxErrorDebugger class >> buildMorphicViewOn: aSyntaxError [
 	window
 		addMorph:
 			(RubScrolledTextMorph new
-				on: aSyntaxError
+				on: aSyntaxErrorDebugger
 				text: #contents
 				accept: #contents:notifying:
 				readSelection: #contentsSelection
 				menu: #codePaneMenu:shifted:)
 		frame: (0 @ 0.15 corner: 1 @ 1).
-	aSyntaxError addDependant: window.
+	aSyntaxErrorDebugger window: window.
 	window extent: 380 @ 220.
 	^ window openInWorld
 ]
 
 { #category : #'instance creation' }
-SyntaxErrorDebugger class >> open: aSyntaxError [ 
+SyntaxErrorDebugger class >> open: aSyntaxErrorDebugger [
 	"Answer a standard system view whose model is an instance of me."
 	<primitive: 19>
 	"Simulation guard"
@@ -62,7 +62,7 @@ SyntaxErrorDebugger class >> open: aSyntaxError [
 	process := Processor activeProcess.
 	UIManager default spawnNewProcessIfThisIsUI: process.
 	UIManager default defer: [
-		self buildMorphicViewOn: aSyntaxError.
+		self buildMorphicViewOn: aSyntaxErrorDebugger.
 	].
 	^ process suspend
 ]
@@ -81,11 +81,6 @@ SyntaxErrorDebugger class >> syntaxError: aSyntaxError [
 		syntaxError: aSyntaxError;
 		yourself
 		
-]
-
-{ #category : #'dependents access' }
-SyntaxErrorDebugger >> addDependant: aDependant [
-	dependents add: aDependant
 ]
 
 { #category : #accessing }
@@ -127,7 +122,7 @@ SyntaxErrorDebugger >> checkForUnprintableCharacters: aString [
 { #category : #other }
 SyntaxErrorDebugger >> closeWindow [
 	debugSession ifNotNil: [ debugSession terminate ].
-	self topView close
+	window close
 
 ]
 
@@ -199,11 +194,6 @@ SyntaxErrorDebugger >> highlightError [
 	location ifNil: [ ^ self ].	
 	contents addAttribute: TextColor red from: location to: location + self sourceErrorString size - 1.
 	contents addAttribute: TextEmphasis bold from: location to: location + self sourceErrorString size - 1.
-]
-
-{ #category : #initialization }
-SyntaxErrorDebugger >> initialize [
-	dependents := Set new.
 ]
 
 { #category : #'message list' }
@@ -283,21 +273,6 @@ SyntaxErrorDebugger >> selectedMessageName [
 
 ]
 
-{ #category : #initialization }
-SyntaxErrorDebugger >> setClass: aClass code: aString error: errorMessage location: anErrorPosition debugSession: aDebugSession doitFlag: flag [
-
-	class := aClass.
-	error := errorMessage.
-	location := anErrorPosition.	
-	debugSession := aDebugSession.
-	selector := aClass compiler parseSelector: aString.
-	contents := self checkForUnprintableCharacters: aString.
-	self highlightError.
-		
- 	category := category ifNil: [ (aClass organization categoryOfElement: selector) ifNil: [ Protocol unclassified ] ].
-	doitFlag := flag
-]
-
 { #category : #other }
 SyntaxErrorDebugger >> shoutAboutToStyle: aPluggableShoutMorphOrView [
 	^ true
@@ -313,25 +288,24 @@ SyntaxErrorDebugger >> syntaxError: aSyntaxError [
 	"extract the instance properties from a SyntaxErrorNotification"
 	
 	syntaxError := aSyntaxError.
-	self 
-		setClass: aSyntaxError errorClass
-		code: aSyntaxError errorCode
-		error: aSyntaxError errorMessage
-		location: aSyntaxError location
-		debugSession: (Processor activeProcess newDebugSessionNamed: 'Stack of the Syntax Error' startedAt: aSyntaxError signalerContext)
-		doitFlag: aSyntaxError doitFlag.
+	class :=  aSyntaxError errorClass.
+	error := aSyntaxError errorMessage.
+	location := aSyntaxError location.	
+	debugSession := (Processor activeProcess newDebugSessionNamed: 'Stack of the Syntax Error' startedAt: aSyntaxError signalerContext).
+	contents := self checkForUnprintableCharacters: aSyntaxError errorCode.
+	selector := class compiler parseSelector: contents.	
+	self highlightError.
+
+ 	category := (class organization categoryOfElement: selector) ifNil: [ Protocol unclassified ].
+	doitFlag := aSyntaxError doitFlag
 ]
 
 { #category : #accessing }
-SyntaxErrorDebugger >> topView [
-	"Find the first top view on me. Is there any danger of their being two
-	with the same model? Any danger from ungarbage collected old views?
-	Ask if schedulled?"
-	dependents
-		ifNil: [^ nil].
-	dependents
-		do: [:v | (v isSystemWindow
-					and: [v isInWorld])
-				ifTrue: [^ v]].
-	^ nil
+SyntaxErrorDebugger >> window [
+	^window
+]
+
+{ #category : #accessing }
+SyntaxErrorDebugger >> window: aWindow [
+	window := aWindow
 ]


### PR DESCRIPTION
- replace the #addDependant: and #topView by just having a "window" ivar
-  inline setClass: aClass code: aString error: errorMessage location: anErrorPosition
- make sure the arguments are named aSyntaxErrorDebugger, not aSyntaxError when it is the debugger.