### PR TITLE
6256-MacRomanUnicode-char-converter-methods-are-backwards

### DIFF
--- a/src/Multilingual-Tests/ByteTextConverterTest.class.st
+++ b/src/Multilingual-Tests/ByteTextConverterTest.class.st
@@ -33,6 +33,16 @@ ByteTextConverterTest >> testLatin2ToUnicodeConversion [
 ]
 
 { #category : #testing }
+ByteTextConverterTest >> testMacRomanToUnicodeShorthand [
+	| macRomanCharacter  unicodeCharacter   |
+	macRomanCharacter := Character value: 16r80.
+	unicodeCharacter := $Ä.
+
+	self assert: macRomanCharacter macRomanToUnicode  equals: unicodeCharacter.
+	self assert: macRomanCharacter equals: unicodeCharacter unicodeToMacRoman.
+]
+
+{ #category : #testing }
 ByteTextConverterTest >> testUnicodeToLatin2Conversion [
 	| latin2Bytes internalString encodingStream encodedBytes |
 	latin2Bytes := #[16rBE 16rFD 16rE1 16rC8].

--- a/src/Multilingual-TextConversion/Character.extension.st
+++ b/src/Multilingual-TextConversion/Character.extension.st
@@ -4,12 +4,12 @@ Extension { #name : #Character }
 Character >> macRomanToUnicode [
 	"Convert the receiver from MacRoman Unicode."
 
-	^MacRomanTextConverter new unicodeToByte: self
+	^MacRomanTextConverter new byteToUnicode: self
 ]
 
 { #category : #'*Multilingual-TextConversion' }
 Character >> unicodeToMacRoman [
 	"Convert the receiver from Unicode to MacRoman encoding."
 
-	^MacRomanTextConverter new byteToUnicode: self
+	^MacRomanTextConverter new unicodeToByte: self
 ]


### PR DESCRIPTION
Reverse incorrect conversion order in these methods - document with test.