### PR TITLE
Improve Compiler Overlay

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -42,6 +42,17 @@ Class {
 	#category : #'OpalCompiler-Core-FrontEnd'
 }
 
+{ #category : #overlay }
+OpalCompiler class >> compilerClasses [
+	"here the classes for the overlay can changed. the default is just the compiler"
+	^self package definedClasses
+	
+	"Compiler and AST:
+	self package definedClasses, RBProgramNode package definedClasses, {TRBProgramNodeVisitor}
+	"
+	
+]
+
 { #category : #options }
 OpalCompiler class >> compilerSettingsOn: aBuilder [
 	<systemsettings>
@@ -169,24 +180,54 @@ OpalCompiler class >> isActive [
 ]
 
 { #category : #overlay }
-OpalCompiler class >> overlayClasses [
-	"here the classes for the overlay can changed. the default is just the compiler"
-	^self package definedClasses
-	
-	"Compiler and AST:
-	self package definedClasses, RBProgramNode package definedClasses, {TRBProgramNodeVisitor}
-	"
-	
-]
-
-{ #category : #overlay }
 OpalCompiler class >> overlayEnvironment [
-	^overlayEnvironment
+	^overlayEnvironment ifNil: [ overlayEnvironment := Dictionary new ]
 ]
 
 { #category : #overlay }
 OpalCompiler class >> overlayIsActive [
 	^overlayEnvironment notNil
+]
+
+{ #category : #overlay }
+OpalCompiler class >> overlayStep1CopyClasses [
+	"now we put a copy of all the classes into the environment"
+	self compilerClasses do: [ :class | self overlayEnvironment at: class name put: class copy ]
+]
+
+{ #category : #overlay }
+OpalCompiler class >> overlayStep2Recompile [
+	"now we recompile the classes in the environment with itself as an overlay"
+	self overlayEnvironment valuesDo: [ :class | 
+			class methodsDo: [ :method | 
+					| newMethod |
+					newMethod := class compiler
+						bindings: self overlayEnvironment;
+						compile: method sourceCode.
+					class addSelectorSilently: method selector withMethod: newMethod ] ]
+]
+
+{ #category : #overlay }
+OpalCompiler class >> overlayStep3FixSuperclassPointers [
+	"make sure superclass pointers are correct"
+    self overlayEnvironment valuesDo: [ :class | 
+        (class isTrait not and: [self overlayEnvironment includesKey: class superclass name]) 
+				ifTrue: [ class superclass: (self overlayEnvironment at: class superclass name)]]
+]
+
+{ #category : #overlay }
+OpalCompiler class >> overlayStep4SetImageCompiler [
+	"make the copy the default compiler for the image"
+	SmalltalkImage compilerClass: (self overlayEnvironment at: #OpalCompiler).
+	ASTCache reset.
+]
+
+{ #category : #overlay }
+OpalCompiler class >> overlayStep5UpdateInstances [
+	"transform existing instances to be instances of the overlay"
+	self compilerClasses do: [ :class |
+		class allInstances do: [ :object | 
+			(self overlayEnvironment at: class name) adoptInstance: object ]]
 ]
 
 { #category : #public }
@@ -210,28 +251,14 @@ OpalCompiler class >> startUsingOverlayForDevelopment [
 	"this method sets up an overlay so we can change the compiler package without breaking the compiler"
 
 	<script>
-	overlayEnvironment := Dictionary new.
-
-	"now we put a copy of all the classes into the environment"
-	self overlayClasses do: [ :class | overlayEnvironment at: class name put: class copy ].
-
-	"now we recompile the classes in the environment with itself as an overlay"
-	overlayEnvironment valuesDo: [ :class | 
-			class methodsDo: [ :method | 
-					| newMethod |
-					newMethod := class compiler
-						bindings: overlayEnvironment;
-						compile: method sourceCode.
-					class addSelectorSilently: method selector withMethod: newMethod ] ].
-	
-	"make sure superclass pointers are correct"
-    overlayEnvironment valuesDo: [ :class | 
-        (class isTrait not and: [overlayEnvironment includesKey: class superclass name]) ifTrue: [  
-            class superclass: (overlayEnvironment at: class superclass name)]].
-	
-	"make the copy the default compiler for the image"
-	SmalltalkImage compilerClass: (overlayEnvironment at: #OpalCompiler).
-	ASTCache reset.
+	"We copy all compiler classes into the overlayEnvironment, recompile to update referenced classes,
+	fix the superclasses and finaly set the compiler overlay as the image default compiler."
+	self 
+		overlayStep1CopyClasses;
+		overlayStep2Recompile;
+		overlayStep3FixSuperclassPointers;
+		overlayStep4SetImageCompiler;
+		overlayStep5UpdateInstances
 ]
 
 { #category : #overlay }


### PR DESCRIPTION
Improve the compiler overlay code a little:- Split the overlay creation into multiple steps, each has it's own method

- add a fifth step: existing instances should use the overlay classes, too.