### PR TITLE
Load Iceberg 1.8.0

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -197,7 +197,7 @@ BaselineOfIDE >> baseline: spec [
 BaselineOfIDE >> loadIceberg [
 	Metacello new
 		baseline: 'Iceberg';
-		repository: 'github://pharo-vcs/iceberg:v1.6.9';
+		repository: 'github://pharo-vcs/iceberg:v1.8.0';
 		onConflictUseLoaded;
 		load.
 	(Smalltalk classNamed: #Iceberg) enableMetacelloIntegration: true.


### PR DESCRIPTION
Iceberg 1.8.0 introduces the possibility to use libgit bindings v2.0.0, which are prepared to run against both libgit2 v0.25.1 and v.1.0.0. I've personally tested the this new version on Windows, Ubuntu 20.04 and OSX.

Iceberg Release Changes Log: https://github.com/pharo-vcs/iceberg/releases/tag/v1.8.0
Detailed Changes Log: https://github.com/pharo-vcs/iceberg/compare/v1.6.9...v1.8.0

Libgit Release Changes Log: https://github.com/pharo-vcs/libgit2-pharo-bindings/releases/tag/v2.0.0
Detailed Changes Log: https://github.com/pharo-vcs/libgit2-pharo-bindings/compare/v1.5.8...pharo-vcs:v2.0.0

Notice: This change only introduces the (backwards compatible) image changes. This version will still behave as the previous one, but it will start with the new libgit version as soon as it is shipped.

Those willing to test the new libgit version, you can
- grab the library from: https://github.com/guillep/libgit_build/releases
- install it next to the old ones
- restart your image/vm