### PR TITLE
Image side changes to use the new memory accessor primitives.

### DIFF
--- a/src/FFI-Kernel/ByteArray.extension.st
+++ b/src/FFI-Kernel/ByteArray.extension.st
@@ -7,47 +7,158 @@ ByteArray >> asExternalPointer [
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> booleanAt: byteOffset [
+ByteArray >> boolean8AtOffset: zeroBasedOffset [
+	<primitive: 600>
+	^ (self integerAt: zeroBasedOffset + 1 size: 1 signed: false) ~= 0
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> boolean8AtOffset: zeroBasedOffset put: value [
+	<primitive: 615>
+	^ self integerAt: zeroBasedOffset + 1 put: (value ifTrue:[1] ifFalse:[0]) size: 1 signed: false
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> booleanAt: byteIndex [
 	"Returns the boolean the byte at index byteOffset of this ByteArray represents in the C convention ( A byte representing the 0 integer corresponds to false, while all other integers corresponds to true)."
 	
 	"(#[1 2 0 4] booleanAt: 2) >>> true."
 	"(#[1 2 0 4] booleanAt: 3) >>> false."
 	
-	^(self integerAt: byteOffset size: 1 signed: false) ~= 0
+	^ self boolean8AtOffset: byteIndex - 1
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> booleanAt: byteOffset put: value [
-	"Booleans are just integers in C word"
-	^self integerAt: byteOffset put: (value ifTrue:[1] ifFalse:[0]) size: 1 signed: false
+ByteArray >> booleanAt: byteIndex put: value [
+	^ self boolean8AtOffset: byteIndex - 1 put: value
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> doubleAt: byteOffset [
-	<primitive:'primitiveFFIDoubleAt' module:'SqueakFFIPrims'>
-	^self primitiveFailed
+ByteArray >> char16AtOffset: zeroBasedOffset [
+	<primitive: 611>
+	^ (self integerAt: zeroBasedOffset + 1 size: 2 signed: false) asCharacter
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> doubleAt: byteOffset put: value [
-	<primitive:'primitiveFFIDoubleAtPut' module:'SqueakFFIPrims'>
-	self isReadOnlyObject 
-		ifTrue: [ ^ self modificationForbiddenFor: #doubleAt:put: index: byteOffset value: value ].
-	^self primitiveFailed
+ByteArray >> char16AtOffset: zeroBasedOffset put: value [
+	<primitive: 626>
+	^ self integerAt: zeroBasedOffset + 1 put: value asInteger size: 2 signed: false
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> floatAt: byteOffset [
-	<primitive:'primitiveFFIFloatAt' module:'SqueakFFIPrims'>
-	^self primitiveFailed
+ByteArray >> char32AtOffset: zeroBasedOffset [
+	<primitive: 612>
+	^ (self integerAt: zeroBasedOffset + 1 size: 4 signed: false) asCharacter
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> floatAt: byteOffset put: value [
-	<primitive:'primitiveFFIFloatAtPut' module:'SqueakFFIPrims'>
-	self isReadOnlyObject 
-		ifTrue: [ ^ self modificationForbiddenFor: #floatAt:put: index: byteOffset value: value ].
-	^self primitiveFailed
+ByteArray >> char32AtOffset: zeroBasedOffset put: value [
+	<primitive: 627>
+	^ self integerAt: zeroBasedOffset + 1 put: value asInteger size: 4 signed: false
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> char8AtOffset: zeroBasedOffset [
+	<primitive: 610>
+	^ (self integerAt: zeroBasedOffset + 1 size: 1 signed: false) asCharacter
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> char8AtOffset: zeroBasedOffset put: value [
+	<primitive: 625>
+	^ self integerAt: zeroBasedOffset + 1 put: value asInteger size: 1 signed: false
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> doubleAt: byteIndex [
+	^ self float64AtOffset: byteIndex - 1
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> doubleAt: byteIndex put: value [
+	^ self float64AtOffset: byteIndex - 1 put: value
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> float32AtOffset: zeroBasedOffset [
+	<primitive: 613>
+	^ self oldFFIPrimFloat32At: zeroBasedOffset + 1
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> float32AtOffset: zeroBasedOffset put: value [
+	<primitive: 628>
+	^ self oldFFIPrimFloat32At: zeroBasedOffset + 1 put: value
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> float64AtOffset: zeroBasedOffset [
+	<primitive: 614>
+	^ self oldFFIPrimFloat64At: zeroBasedOffset + 1
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> float64AtOffset: zeroBasedOffset put: value [
+	<primitive: 629>
+	^ self oldFFIPrimFloat64At: zeroBasedOffset + 1 put: value
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> floatAt: byteIndex [
+	^ self float32AtOffset: byteIndex - 1
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> floatAt: byteIndex put: value [
+	^ self float32AtOffset: byteIndex - 1 put: value
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> int16AtOffset: zeroBasedOffset [
+	<primitive: 604>
+	^ self integerAt: zeroBasedOffset + 1 size: 2 signed: true
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> int16AtOffset: zeroBasedOffset put: value [
+	<primitive: 619>
+	^ self integerAt: zeroBasedOffset + 1 put: value size: 2 signed: true
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> int32AtOffset: zeroBasedOffset [
+	<primitive: 606>
+	^ self integerAt: zeroBasedOffset + 1 size: 4 signed: true
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> int32AtOffset: zeroBasedOffset put: value [
+	<primitive: 621>
+	^ self integerAt: zeroBasedOffset + 1 put: value size: 4 signed: true
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> int64AtOffset: zeroBasedOffset [
+	<primitive: 608>
+	^ self integerAt: zeroBasedOffset + 1 size: 8 signed: true
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> int64AtOffset: zeroBasedOffset put: value [
+	<primitive: 623>
+	^ self integerAt: zeroBasedOffset + 1 put: value size: 8 signed: true
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> int8AtOffset: zeroBasedOffset [
+	<primitive: 602>
+	^ self integerAt: zeroBasedOffset + 1 size: 1 signed: true
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> int8AtOffset: zeroBasedOffset put: value [
+	<primitive: 617>
+	^ self integerAt: zeroBasedOffset + 1 put: value size: 1 signed: true
 ]
 
 { #category : #'*FFI-Kernel' }
@@ -82,118 +193,149 @@ ByteArray >> isNull [
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> longPointerAt: byteOffset [
+ByteArray >> longPointerAt: byteIndex [
 	"Answer an 8-byte pointer object stored at the given byte address"
 	| addr |
 	addr := ExternalAddress basicNew: 8.
 	1 to: 8 do:
 		[:i|
-		addr basicAt: i put: (self unsignedByteAt: byteOffset+i-1)].
+		addr basicAt: i put: (self unsignedByteAt: byteIndex+i-1)].
 	^addr
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> longPointerAt: byteOffset put: value [
+ByteArray >> longPointerAt: byteIndex put: value [
 	"Store an 8-byte pointer object at the given byte address"
 	value isExternalAddress ifFalse:
 		[^self error:'Only external addresses can be stored'].
 	1 to: 8 do:
 		[:i|
-		self unsignedByteAt: byteOffset+i-1 put: (value basicAt: i)].
+		self unsignedByteAt: byteIndex+i-1 put: (value basicAt: i)].
 	^value
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> pointerAt: byteOffset [
+ByteArray >> oldFFIPrimFloat32At: byteOffset [
+	<primitive:'primitiveFFIFloatAt' module:'SqueakFFIPrims'>
+	^self primitiveFailed
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> oldFFIPrimFloat32At: byteOffset put: value [
+	<primitive:'primitiveFFIFloatAtPut' module:'SqueakFFIPrims'>
+	self isReadOnlyObject 
+		ifTrue: [ ^ self modificationForbiddenFor: #oldFFIPrimFloat32At:put: index: byteOffset value: value ].
+	^self primitiveFailed
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> oldFFIPrimFloat64At: byteOffset [
+	<primitive:'primitiveFFIDoubleAt' module:'SqueakFFIPrims'>
+	^self primitiveFailed
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> oldFFIPrimFloat64At: byteOffset put: value [
+	<primitive:'primitiveFFIDoubleAtPut' module:'SqueakFFIPrims'>
+	self isReadOnlyObject 
+		ifTrue: [ ^ self modificationForbiddenFor: #oldFFIPrimFloat64At:put: index: byteOffset value: value ].
+	^self primitiveFailed
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> pointerAt: byteIndex [
+	^ self pointerAtOffset: byteIndex - 1
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> pointerAt: byteIndex put: value [
+	^ self pointerAtOffset: byteIndex - 1 put: value
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> pointerAtOffset: zeroBasedOffset [
+	<primitive: 609>
 	"Answer a pointer object stored at the given byte address"
 	| addr |
 	addr := ExternalAddress new.
 	1 to: ExternalAddress wordSize do:
 		[:i|
-		addr basicAt: i put: (self unsignedByteAt: byteOffset+i-1)].
+		addr basicAt: i put: (self unsignedByteAt: zeroBasedOffset+i)].
 	^addr
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> pointerAt: byteOffset put: value [
+ByteArray >> pointerAtOffset: zeroBasedOffset put: value [
+	<primitive: 624>
 	"Store a pointer object at the given byte address"
 	value isExternalAddress ifFalse:
 		[^self error:'Only external addresses can be stored'].
 	1 to: ExternalAddress wordSize do:
 		[:i|
-		self unsignedByteAt: byteOffset+i-1 put: (value basicAt: i)].
+		self unsignedByteAt: zeroBasedOffset+i put: (value basicAt: i)].
 	^value
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> shortPointerAt: byteOffset [
+ByteArray >> shortPointerAt: byteIndex [
 	"Answer a 4-byte pointer object stored at the given byte address"
 	| addr |
 	addr := ExternalAddress basicNew: 4.
 	1 to: 4 do:
 		[:i|
-		addr basicAt: i put: (self unsignedByteAt: byteOffset+i-1)].
+		addr basicAt: i put: (self unsignedByteAt: byteIndex+i-1)].
 	^addr
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> shortPointerAt: byteOffset put: value [
+ByteArray >> shortPointerAt: byteIndex put: value [
 	"Store a 4-byte pointer object at the given byte address"
 	value isExternalAddress ifFalse:
 		[^self error:'Only external addresses can be stored'].
 	1 to: 4 do:
 		[:i|
-		self unsignedByteAt: byteOffset+i-1 put: (value basicAt: i)].
+		self unsignedByteAt: byteIndex+i-1 put: (value basicAt: i)].
 	^value
 ]
 
 { #category : #'*FFI-Kernel' }
 ByteArray >> signedCharAt: byteOffset [
-	^(self unsignedByteAt: byteOffset) asCharacter
+	^ self char8AtOffset: byteOffset - 1
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> signedCharAt: byteOffset put: aCharacter [
-	^self unsignedByteAt: byteOffset put: aCharacter asciiValue
+ByteArray >> signedCharAt: byteIndex put: aCharacter [
+	^ self char8AtOffset: byteIndex - 1 put: aCharacter
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> signedLongAt: byteOffset [
-	"Return a 32bit signed integer starting at the given byte offset"
-	^self integerAt: byteOffset size: 4 signed: true
+ByteArray >> signedLongAt: byteIndex [
+	^ self int32AtOffset: byteIndex - 1
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> signedLongAt: byteOffset put: value [
-	"Store a 32bit signed integer starting at the given byte offset"
-	^self integerAt: byteOffset put: value size: 4 signed: true
+ByteArray >> signedLongAt: byteIndex put: value [
+	^ self int32AtOffset: byteIndex - 1 put: value
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> signedLongLongAt: byteOffset [
-	| int |
-	int := self unsignedLongLongAt: byteOffset.
-	int > 16r7FFFFFFFFFFFFFFF ifTrue: [^int - 16r10000000000000000].
-	^int
+ByteArray >> signedLongLongAt: byteIndex [
+	^ self int64AtOffset: byteIndex - 1
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> signedLongLongAt: byteOffset put: value [
-	self unsignedLongLongAt: byteOffset put: (value < 0
-		ifTrue: [ value + 16r10000000000000000 ]
-		ifFalse: [ value ])
+ByteArray >> signedLongLongAt: byteIndex put: value [
+	^ self int64AtOffset: byteIndex - 1 put: value
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> signedShortAt: byteOffset [
-	"Return a 16bit signed integer starting at the given byte offset"
-	^self integerAt: byteOffset size: 2 signed: true
+ByteArray >> signedShortAt: byteIndex [
+	^ self int16AtOffset: byteIndex - 1
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> signedShortAt: byteOffset put: value [
-	"Store a 16bit signed integer starting at the given byte offset"
-	^self integerAt: byteOffset put: value size: 2 signed: true
+ByteArray >> signedShortAt: byteIndex put: value [
+	^ self int16AtOffset: byteIndex - 1 put: value
 ]
 
 { #category : #'*FFI-Kernel' }
@@ -215,61 +357,101 @@ ByteArray >> structAt: byteOffset put: value length: length [
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> unsignedByteAt: byteOffset [
-	"Return a 8bit unsigned integer starting at the given byte offset"
-	^self integerAt: byteOffset size: 1 signed: false
+ByteArray >> uint16AtOffset: zeroBasedOffset [
+	<primitive: 603>
+	^ self integerAt: zeroBasedOffset + 1 size: 2 signed: false
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> unsignedByteAt: byteOffset put: value [
-	"Store a 8bit unsigned integer starting at the given byte offset"
-	^self integerAt: byteOffset put: value size: 1 signed: false
+ByteArray >> uint16AtOffset: zeroBasedOffset put: value [
+	<primitive: 618>
+	^ self integerAt: zeroBasedOffset + 1 put: value size: 2 signed: false
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> unsignedCharAt: byteOffset [
-	^(self unsignedByteAt: byteOffset) asCharacter
+ByteArray >> uint32AtOffset: zeroBasedOffset [
+	<primitive: 605>
+	^ self integerAt: zeroBasedOffset + 1 size: 4 signed: false
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> unsignedCharAt: byteOffset put: aCharacter [
-	^self unsignedByteAt: byteOffset put: aCharacter asciiValue
+ByteArray >> uint32AtOffset: zeroBasedOffset put: value [
+	<primitive: 620>
+	^ self integerAt: zeroBasedOffset + 1 put: value size: 4 signed: false
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> unsignedLongAt: byteOffset [
-	"Return a 32bit unsigned integer starting at the given byte offset"
-	^self integerAt: byteOffset size: 4 signed: false
+ByteArray >> uint64AtOffset: zeroBasedOffset [
+	<primitive: 607>
+	^ self integerAt: zeroBasedOffset + 1 size: 8 signed: false
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> unsignedLongAt: byteOffset put: value [
-	"Store a 32bit signed integer starting at the given byte offset"
-	^self integerAt: byteOffset put: value size: 4 signed: false
+ByteArray >> uint64AtOffset: zeroBasedOffset put: value [
+	<primitive: 622>
+	^ self integerAt: zeroBasedOffset + 1 put: value size: 8 signed: false
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> unsignedLongLongAt: byteOffset [
-	"Answer a 64-bit integer in Smalltalk order (little-endian)."
-	^self integerAt: byteOffset size: 8 signed: false
+ByteArray >> uint8AtOffset: zeroBasedOffset [
+	<primitive: 601>
+	^ self integerAt: zeroBasedOffset + 1 size: 1 signed: false
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> unsignedLongLongAt: byteOffset put: value [
-	"I store 64-bit integers in Smalltalk (little-endian) order."
-	^self integerAt: byteOffset put: value size: 8 signed: false
+ByteArray >> uint8AtOffset: zeroBasedOffset put: value [
+	<primitive: 616>
+	^ self integerAt: zeroBasedOffset + 1 put: value size: 1 signed: false
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> unsignedShortAt: byteOffset [
-	"Return a 16bit unsigned integer starting at the given byte offset"
-	^self integerAt: byteOffset size: 2 signed: false
+ByteArray >> unsignedByteAt: byteIndex [
+	^ self uint8AtOffset: byteIndex - 1
 ]
 
 { #category : #'*FFI-Kernel' }
-ByteArray >> unsignedShortAt: byteOffset put: value [
-	"Store a 16bit unsigned integer starting at the given byte offset"
-	^self integerAt: byteOffset put: value size: 2 signed: false
+ByteArray >> unsignedByteAt: byteIndex put: value [
+	^ self uint8AtOffset: byteIndex - 1 put: value
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> unsignedCharAt: byteIndex [
+	^ self char8AtOffset: byteIndex - 1
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> unsignedCharAt: byteIndex put: aCharacter [
+	^ self char8AtOffset: byteIndex - 1 put: aCharacter
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> unsignedLongAt: byteIndex [
+	^ self uint32AtOffset: byteIndex - 1
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> unsignedLongAt: byteIndex put: value [
+	^ self uint32AtOffset: byteIndex - 1 put: value
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> unsignedLongLongAt: byteIndex [
+	^ self uint64AtOffset: byteIndex - 1
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> unsignedLongLongAt: byteIndex put: value [
+	^ self uint64AtOffset: byteIndex - 1 put: value
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> unsignedShortAt: byteIndex [
+	^ self uint16AtOffset: byteIndex - 1
+]
+
+{ #category : #'*FFI-Kernel' }
+ByteArray >> unsignedShortAt: byteIndex put: value [
+	^ self uint16AtOffset: byteIndex - 1 put: value
 ]
 
 { #category : #'*FFI-Kernel' }

--- a/src/UnifiedFFI-Tests/FFITypesTest.class.st
+++ b/src/UnifiedFFI-Tests/FFITypesTest.class.st
@@ -148,6 +148,15 @@ FFITypesTest >> testSignedAtWithDiferentSizes [
 ]
 
 { #category : #tests }
+FFITypesTest >> testSignedByteAtPutIntegers [
+	self signed1ByteNumbers do: [ :int |
+		|ref|
+		ref := ByteArray new: 1.
+		ref signedByteAt: 1 put: int.
+		self assert: (ref signedByteAt: 1) equals: int ]
+]
+
+{ #category : #tests }
 FFITypesTest >> testSignedLong [
 	self signed4ByteNumbers do: [ :int |
 		|ref|
@@ -163,6 +172,15 @@ FFITypesTest >> testSignedLongLong [
 		ref := ByteArray new: FFIInt64 externalTypeSize.
 		ref signedLongLongAt: 1 put: int.
 		self assert: (ref signedLongLongAt: 1) equals: int ]
+]
+
+{ #category : #tests }
+FFITypesTest >> testSignedShortAtPutIntegers [
+	self signed2ByteNumbers do: [ :int |
+		|ref|
+		ref := ByteArray new: 2.
+		ref signedShortAt: 1 put: int.
+		self assert: (ref signedShortAt: 1) equals: int ]
 ]
 
 { #category : #tests }
@@ -193,6 +211,15 @@ FFITypesTest >> testUnsigned4ByteIntegers [
 ]
 
 { #category : #tests }
+FFITypesTest >> testUnsignedByteAtPutIntegers [
+	self unsigned1ByteNumbers do: [ :int |
+		|ref|
+		ref := ByteArray new: 1.
+		ref unsignedByteAt: 1 put: int.
+		self assert: (ref unsignedByteAt: 1) equals: int ]
+]
+
+{ #category : #tests }
 FFITypesTest >> testUnsignedLong [
 	self unsigned4ByteNumbers do: [ :int |
 		|ref|
@@ -208,6 +235,15 @@ FFITypesTest >> testUnsignedLongLong [
 		ref := ByteArray new: FFIUInt64 externalTypeSize.
 		ref unsignedLongLongAt: 1 put: int.
 		self assert: (ref unsignedLongLongAt: 1) equals: int ]
+]
+
+{ #category : #tests }
+FFITypesTest >> testUnsignedShortAtPutIntegers [
+	self unsigned2ByteNumbers do: [ :int |
+		|ref|
+		ref := ByteArray new: 2.
+		ref unsignedShortAt: 1 put: int.
+		self assert: (ref unsignedShortAt: 1) equals: int ]
 ]
 
 { #category : #ranges }

--- a/src/UnifiedFFI/Alien.extension.st
+++ b/src/UnifiedFFI/Alien.extension.st
@@ -7,7 +7,151 @@ Alien >> asExternalAddress [
 ]
 
 { #category : #'*UnifiedFFI' }
+Alien >> boolean8AtOffset: zeroBasedOffset [
+	^ (self unsignedByteAt: zeroBasedOffset + 1) ~= 0
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> boolean8AtOffset: zeroBasedOffset put: value [
+	^ self unsignedByteAt: zeroBasedOffset + 1 put: (value ifTrue: [ 1 ] ifFalse: [ 0 ])
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> booleanAt: byteIndex [
+	^ (self unsignedByteAt: byteIndex) ~= 0
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> booleanAt: byteIndex put: value [
+	^ self unsignedByteAt: byteIndex put: (value ifTrue: [ 1 ] ifFalse: [ 0 ])
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> char16AtOffset: zeroBasedOffset [
+	^ (self unsignedShortAt: zeroBasedOffset + 1) asCharacter
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> char16AtOffset: zeroBasedOffset put: value [
+	^ self unsignedShortAt: zeroBasedOffset + 1 put: value asInteger
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> char32AtOffset: zeroBasedOffset [
+	^ (self unsignedLongAt: zeroBasedOffset + 1) asCharacter
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> char32AtOffset: zeroBasedOffset put: value [
+	^ self unsignedLongAt: zeroBasedOffset + 1 put: value asInteger
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> char8AtOffset: zeroBasedOffset [
+	^ (self unsignedByteAt: zeroBasedOffset + 1) asCharacter
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> char8AtOffset: zeroBasedOffset put: value [
+	^ self unsignedByteAt: zeroBasedOffset + 1 put: value asInteger
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> float32AtOffset: zeroBasedOffset [
+	^ self floatAt: zeroBasedOffset + 1
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> float32AtOffset: zeroBasedOffset put: value [
+	^ self floatAt: zeroBasedOffset + 1 put: value
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> float64AtOffset: zeroBasedOffset [
+	^ self doubleAt: zeroBasedOffset + 1
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> float64AtOffset: zeroBasedOffset put: value [
+	^ self doubleAt: zeroBasedOffset + 1 put: value
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> int16AtOffset: zeroBasedOffset [
+	^ self signedShortAt: zeroBasedOffset + 1
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> int32AtOffset: zeroBasedOffset [
+	^ self signedLongAt: zeroBasedOffset + 1
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> int64AtOffset: zeroBasedOffset [
+	^ self signedLongLongAt: zeroBasedOffset + 1
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> int8AtOffset: zeroBasedOffset [
+	^ self signedByteAt: zeroBasedOffset + 1
+]
+
+{ #category : #'*UnifiedFFI' }
 Alien >> integerAt: byteOffset size: size signed: signed [
 
 	^ (ExternalAddress fromAddress: self address) integerAt: byteOffset size: size signed: signed
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> pointerAt: byteIndex [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self pointerAtOffset: byteIndex - 1
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> pointerAt: byteIndex put: value [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self pointerAtOffset: byteIndex - 1 put: value
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> pointerAtOffset: zeroBasedOffset [
+	"Answer a pointer object stored at the given byte address"
+	| addr |
+	addr := ExternalAddress new.
+	1 to: ExternalAddress wordSize do:
+		[:i|
+		addr basicAt: i put: (self unsignedByteAt: zeroBasedOffset+i)].
+	^addr
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> pointerAtOffset: zeroBasedOffset put: value [
+	"Store a pointer object at the given byte address"
+	value isExternalAddress ifFalse:
+		[^self error:'Only external addresses can be stored'].
+	1 to: ExternalAddress wordSize do:
+		[:i|
+		self unsignedByteAt: zeroBasedOffset+i put: (value basicAt: i)].
+	^value
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> uint16AtOffset: zeroBasedOffset [
+	^ self unsignedShortAt: zeroBasedOffset + 1
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> uint32AtOffset: zeroBasedOffset [
+	^ self unsignedLongAt: zeroBasedOffset + 1
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> uint64AtOffset: zeroBasedOffset [
+	^ self unsignedLongLongAt: zeroBasedOffset + 1
+]
+
+{ #category : #'*UnifiedFFI' }
+Alien >> uint8AtOffset: zeroBasedOffset [
+	^ self unsignedByteAt: zeroBasedOffset + 1
 ]

--- a/src/UnifiedFFI/ExternalAddress.extension.st
+++ b/src/UnifiedFFI/ExternalAddress.extension.st
@@ -19,6 +19,66 @@ ExternalAddress >> autoRelease [
 ]
 
 { #category : #'*UnifiedFFI' }
+ExternalAddress >> boolean8AtOffset: zeroBasedOffset [
+	<primitive: 630>
+	^ (self integerAt: zeroBasedOffset + 1 size: 1 signed: false) ~= 0
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> boolean8AtOffset: zeroBasedOffset put: value [
+	<primitive: 645>
+	^ self integerAt: zeroBasedOffset + 1 put: (value ifTrue:[1] ifFalse:[0]) size: 1 signed: false
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> booleanAt: byteIndex [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self boolean8AtOffset: byteIndex - 1
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> booleanAt: byteIndex put: value [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self boolean8AtOffset: byteIndex - 1 put: value
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> char16AtOffset: zeroBasedOffset [
+	<primitive: 641>
+	^ (self integerAt: zeroBasedOffset + 1 size: 2 signed: false) asCharacter
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> char16AtOffset: zeroBasedOffset put: value [
+	<primitive: 656>
+	^ self integerAt: zeroBasedOffset + 1 put: value asInteger size: 2 signed: false
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> char32AtOffset: zeroBasedOffset [
+	<primitive: 642>
+	^ (self integerAt: zeroBasedOffset + 1 size: 4 signed: false) asCharacter
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> char32AtOffset: zeroBasedOffset put: value [
+	<primitive: 657>
+	^ self integerAt: zeroBasedOffset + 1 put: value asInteger size: 4 signed: false
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> char8AtOffset: zeroBasedOffset [
+	<primitive: 640>
+	^ (self integerAt: zeroBasedOffset + 1 size: 1 signed: false) asCharacter
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> char8AtOffset: zeroBasedOffset put: value [
+	<primitive: 655>
+	^ self integerAt: zeroBasedOffset + 1 put: value asInteger size: 1 signed: false
+]
+
+{ #category : #'*UnifiedFFI' }
 ExternalAddress >> copyFrom: startIndex to: endIndex [
 	| result size |
 	size := endIndex - startIndex + 1.
@@ -28,14 +88,62 @@ ExternalAddress >> copyFrom: startIndex to: endIndex [
 ]
 
 { #category : #'*UnifiedFFI' }
-ExternalAddress >> fromAddress: aNumber [
-	^ self fromInteger: aNumber
+ExternalAddress >> doubleAt: byteIndex [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self float64AtOffset: byteIndex - 1
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> doubleAt: byteIndex put: value [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self float64AtOffset: byteIndex - 1 put: value
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> float32AtOffset: zeroBasedOffset [
+	<primitive: 643>
+	^ self oldFFIPrimFloat32At: zeroBasedOffset + 1
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> float32AtOffset: zeroBasedOffset put: value [
+	<primitive: 658>
+	^ self oldFFIPrimFloat32At: zeroBasedOffset + 1 put: value
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> float64AtOffset: zeroBasedOffset [
+	<primitive: 644>
+	^ self oldFFIPrimFloat64At: zeroBasedOffset + 1
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> float64AtOffset: zeroBasedOffset put: value [
+	<primitive: 659>
+	^ self oldFFIPrimFloat64At: zeroBasedOffset + 1 put: value
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> floatAt: byteIndex [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self float32AtOffset: byteIndex - 1
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> floatAt: byteIndex put: value [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self float32AtOffset: byteIndex - 1 put: value
 ]
 
 { #category : #'*UnifiedFFI' }
 ExternalAddress class >> fromAddress: aNumber [
 	"Answers an external address who points to aNumber"
 	^ self new fromAddress: aNumber
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> fromAddress: aNumber [
+	^ self fromInteger: aNumber
 ]
 
 { #category : #'*UnifiedFFI' }
@@ -62,6 +170,54 @@ ExternalAddress >> gcpointer [
 ExternalAddress >> getHandle [
 	
 	^ self
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> int16AtOffset: zeroBasedOffset [
+	<primitive: 634>
+	^ self integerAt: zeroBasedOffset + 1 size: 2 signed: true
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> int16AtOffset: zeroBasedOffset put: value [
+	<primitive: 649>
+	^ self integerAt: zeroBasedOffset + 1 put: value size: 2 signed: true
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> int32AtOffset: zeroBasedOffset [
+	<primitive: 636>
+	^ self integerAt: zeroBasedOffset + 1 size: 4 signed: true
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> int32AtOffset: zeroBasedOffset put: value [
+	<primitive: 651>
+	^ self integerAt: zeroBasedOffset + 1 put: value size: 4 signed: true
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> int64AtOffset: zeroBasedOffset [
+	<primitive: 638>
+	^ self integerAt: zeroBasedOffset + 1 size: 8 signed: true
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> int64AtOffset: zeroBasedOffset put: value [
+	<primitive: 653>
+	^ self integerAt: zeroBasedOffset + 1 put: value size: 8 signed: true
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> int8AtOffset: zeroBasedOffset [
+	<primitive: 632>
+	^ self integerAt: zeroBasedOffset + 1 size: 1 signed: true
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> int8AtOffset: zeroBasedOffset put: value [
+	<primitive: 647>
+	^ self integerAt: zeroBasedOffset + 1 put: value size: 1 signed: true
 ]
 
 { #category : #'*UnifiedFFI' }
@@ -141,6 +297,42 @@ ExternalAddress >> pointer [
 ]
 
 { #category : #'*UnifiedFFI' }
+ExternalAddress >> pointerAt: byteIndex [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self pointerAtOffset: byteIndex - 1
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> pointerAt: byteIndex put: value [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self pointerAtOffset: byteIndex - 1 put: value
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> pointerAtOffset: zeroBasedOffset [
+	<primitive: 639>
+	"Answer a pointer object stored at the given byte address"
+	| addr |
+	addr := ExternalAddress new.
+	1 to: ExternalAddress wordSize do:
+		[:i|
+		addr basicAt: i put: (self unsignedByteAt: zeroBasedOffset+i)].
+	^addr
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> pointerAtOffset: zeroBasedOffset put: value [
+	<primitive: 654>
+	"Store a pointer object at the given byte address"
+	value isExternalAddress ifFalse:
+		[^self error:'Only external addresses can be stored'].
+	1 to: ExternalAddress wordSize do:
+		[:i|
+		self unsignedByteAt: zeroBasedOffset+i put: (value basicAt: i)].
+	^value
+]
+
+{ #category : #'*UnifiedFFI' }
 ExternalAddress >> pointerAutoRelease [
 	"Same as #pointer (see its comment for detals), but contents are garbage collected automatically"
 	^ self pointer autoRelease
@@ -197,6 +389,94 @@ ExternalAddress >> replaceFrom: start to: stop with: replacement startingAt: rep
 	LibC memCopy: srcAddress to: dstAddress size: repSize
 ]
 
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> signedCharAt: byteOffset [
+	^ self char8AtOffset: byteOffset - 1
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> signedCharAt: byteIndex put: aCharacter [
+	^ self char8AtOffset: byteIndex - 1 put: aCharacter
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> signedLongAt: byteIndex [
+	^ self int32AtOffset: byteIndex - 1
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> signedLongAt: byteIndex put: value [
+	^ self int32AtOffset: byteIndex - 1 put: value
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> signedLongLongAt: byteIndex [
+	^ self int64AtOffset: byteIndex - 1
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> signedLongLongAt: byteIndex put: value [
+	^ self int64AtOffset: byteIndex - 1 put: value
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> signedShortAt: byteIndex [
+	^ self int16AtOffset: byteIndex - 1
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> signedShortAt: byteIndex put: value [
+	^ self int16AtOffset: byteIndex - 1 put: value
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> uint16AtOffset: zeroBasedOffset [
+	<primitive: 633>
+	^ self integerAt: zeroBasedOffset + 1 size: 2 signed: false
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> uint16AtOffset: zeroBasedOffset put: value [
+	<primitive: 648>
+	^ self integerAt: zeroBasedOffset + 1 put: value size: 2 signed: false
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> uint32AtOffset: zeroBasedOffset [
+	<primitive: 635>
+	^ self integerAt: zeroBasedOffset + 1 size: 4 signed: false
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> uint32AtOffset: zeroBasedOffset put: value [
+	<primitive: 650>
+	^ self integerAt: zeroBasedOffset + 1 put: value size: 4 signed: false
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> uint64AtOffset: zeroBasedOffset [
+	<primitive: 637>
+	^ self integerAt: zeroBasedOffset + 1 size: 8 signed: false
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> uint64AtOffset: zeroBasedOffset put: value [
+	<primitive: 652>
+	^ self integerAt: zeroBasedOffset + 1 put: value size: 8 signed: false
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> uint8AtOffset: zeroBasedOffset [
+	<primitive: 631>
+	^ self integerAt: zeroBasedOffset + 1 size: 1 signed: false
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> uint8AtOffset: zeroBasedOffset put: value [
+	<primitive: 646>
+	^ self integerAt: zeroBasedOffset + 1 put: value size: 1 signed: false
+]
+
 { #category : #'*UnifiedFFI-private' }
 ExternalAddress >> unpackFromArity: arity [
 	"This will 'unpack' a pointer from a certain arity. See #unpackToArity: for a better explanation."
@@ -212,6 +492,66 @@ ExternalAddress >> unpackFromArity: arity [
 ExternalAddress >> unpackHandleFromArity: arity [
 	^ (self unpackFromArity: arity) unsignedLongAt: 1
 	
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> unsignedByteAt: byteIndex [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self uint8AtOffset: byteIndex - 1
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> unsignedByteAt: byteIndex put: value [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self uint8AtOffset: byteIndex - 1 put: value
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> unsignedCharAt: byteIndex [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self char8AtOffset: byteIndex - 1
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> unsignedCharAt: byteIndex put: aCharacter [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self char8AtOffset: byteIndex - 1 put: aCharacter
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> unsignedLongAt: byteIndex [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self uint32AtOffset: byteIndex - 1
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> unsignedLongAt: byteIndex put: value [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self uint32AtOffset: byteIndex - 1 put: value
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> unsignedLongLongAt: byteIndex [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self uint64AtOffset: byteIndex - 1
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> unsignedLongLongAt: byteIndex put: value [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self uint64AtOffset: byteIndex - 1 put: value
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> unsignedShortAt: byteIndex [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self uint16AtOffset: byteIndex - 1
+]
+
+{ #category : #'*UnifiedFFI' }
+ExternalAddress >> unsignedShortAt: byteIndex put: value [
+	"This method is duplicated in this subclass with the purpose of ensuring a monomorphic inline cache in the following message send."
+	^ self uint16AtOffset: byteIndex - 1 put: value
 ]
 
 { #category : #'*UnifiedFFI' }


### PR DESCRIPTION
This PR includes the image side changes to take advantage of the JIT compiled memory accessing primitives that introduced in the following PR in the VM: https://github.com/pharo-project/opensmalltalk-vm/pull/90

Since these changes introduce new primitives, on the primitve failure path there is support to use the old primitives with a slight performance penalty (an additional message send), but allowing the usage of a VM without the new primitives.