### PR TITLE
RequestorScopeHardenNonStringVarname

### DIFF
--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -35,15 +35,16 @@ OCRequestorScope >> lookupVar: name [
 
 	name = 'self' ifTrue: [ ^ outerScope lookupVar: name ].
 	name = 'super' ifTrue: [ ^ outerScope lookupVar: name ].
-	name first isUppercase ifTrue: [ ^ outerScope lookupVar: name].
+	"We do not want to auto define bindings for unknown Globals"
+	(name isString and: [name first isUppercase]) ifTrue: [ ^ outerScope lookupVar: name].
 	
 	"do not 'create bindings' in requestor scope if we just want to style a possible unknown variable"
 	(compilationContext optionSkipSemanticWarnings
-		and: [ (requestor hasBindingOf: name asSymbol) not ])
+		and: [ (requestor hasBindingOf: name) not ])
 		ifTrue: [ ^ outerScope lookupVar: name ].
 
 	"the requestors #bindingOf may create a binding for not yet existing variables"
-	(requestor bindingOf: name asSymbol)
+	(requestor bindingOf: name)
 		ifNotNil: [ :assoc | 
 			^ OCLiteralVariable new
 				assoc: assoc;


### PR DESCRIPTION
We are using in some cases non-Strings/Symols as varnames when creating temps for stack manipulation in Slots (see e.g. emitStore: in ObservableSlot). We should move towards always using symbols. But until we do, we need harden the lookupVar: of requestors to work with non strings.

-> check for strings when checking upper case
-> remove #asSymbol (the cases where this is needed this would be done in the called method anyway)