### PR TITLE
Add missing SDL2 bindings for audio playback support

### DIFF
--- a/src/OSWindow-SDL2/SDL2.class.st
+++ b/src/OSWindow-SDL2/SDL2.class.st
@@ -54,6 +54,11 @@ SDL2 class >> clipboardText: text [
 	self primClipboardText: encoded
 ]
 
+{ #category : #audio }
+SDL2 class >> closeAudioDevice: dev [
+	^ self ffiCall: #( void SDL_CloseAudioDevice(SDL_AudioDeviceID dev) )
+]
+
 { #category : #cursor }
 SDL2 class >> createCursor: data mask: mask w: w h: h hotX: hotX hotY: hotY [
 	^ self ffiCall: #( SDL_Cursor SDL_CreateCursor ( Uint8* data, Uint8* mask, int w, int h, int hotX, int hotY ) )
@@ -127,9 +132,24 @@ SDL2 class >> gameControllerOpen: deviceIndex [
 	^ self ffiCall: #( SDL_GameController SDL_GameControllerOpen ( int deviceIndex ) )
 ]
 
+{ #category : #audio }
+SDL2 class >> getAudioDeviceName: index isCapture: isCapture [
+	^ self ffiCall: #( char* SDL_GetAudioDeviceName(int index, int isCapture) ) options: #( optStringEncodingUtf8 ).
+]
+
 { #category : #'error handling' }
 SDL2 class >> getErrorMessage [
 	^ self ffiCall: #( String SDL_GetError ( void ) )
+]
+
+{ #category : #audio }
+SDL2 class >> getNumAudioDevices: isCapture [
+	^ self ffiCall: #( int SDL_GetNumAudioDevices(int isCapture) )
+]
+
+{ #category : #audio }
+SDL2 class >> getQueuedAudioSize: dev [
+	^ self ffiCall: #( Uint32 SDL_GetQueuedAudioSize(SDL_AudioDeviceID dev) )
 ]
 
 { #category : #common }
@@ -180,6 +200,12 @@ SDL2 class >> glSwapWindow: window [
 { #category : #common }
 SDL2 class >> init: flags [
 	^ self ffiCall: #( int SDL_Init ( Uint32 flags ) )
+]
+
+{ #category : #common }
+SDL2 class >> initAudio [
+	self initLibrary;
+		 initSubSystem: SDL_INIT_AUDIO
 ]
 
 { #category : #common }
@@ -283,6 +309,16 @@ SDL2 class >> numberOfJoysticks [
 	^ self ffiCall: #( int SDL_NumJoysticks() )
 ]
 
+{ #category : #audio }
+SDL2 class >> openAudioDevice: device isCapture: isCapture desired: desired obtained: obtained allowedChanges: allowedChanges [
+	^ self ffiCall: #( SDL_AudioDeviceID SDL_OpenAudioDevice(void* device, int isCapture, SDL_AudioSpec* desired, SDL_AudioSpec* obtained, int allowedChanges) )
+]
+
+{ #category : #audio }
+SDL2 class >> pauseAudioDevice: dev pauseOn: pauseOn [
+	^ self ffiCall: #( void SDL_PauseAudioDevice(SDL_AudioDeviceID dev, int pauseOn) )
+]
+
 { #category : #event }
 SDL2 class >> pollEvent: event [
 	^ self ffiCall: #( int SDL_PollEvent ( SDL_Event event ) )
@@ -305,6 +341,11 @@ SDL2 class >> primCreateRGBSurfaceForCairoWidth: width height: height [
 	^ self ffiCall: #( SDL_Surface* SDL_CreateRGBSurface 
 						( 0 , int width , int height , 32 ,
 						  16r00FF0000 , 16r0000FF00 , 16r000000FF , 0 ) )
+]
+
+{ #category : #audio }
+SDL2 class >> queueAudio: dev data: data len: len [
+	^ self ffiCall: #( int SDL_QueueAudio(SDL_AudioDeviceID dev, void* data, Uint32 len) )
 ]
 
 { #category : #common }

--- a/src/OSWindow-SDL2/SDL2Constants.class.st
+++ b/src/OSWindow-SDL2/SDL2Constants.class.st
@@ -5,6 +5,20 @@ Class {
 	#name : #SDL2Constants,
 	#superclass : #SharedPool,
 	#classVars : [
+		'AUDIO_F32',
+		'AUDIO_F32LSB',
+		'AUDIO_F32MSB',
+		'AUDIO_S16',
+		'AUDIO_S16LSB',
+		'AUDIO_S16MSB',
+		'AUDIO_S32',
+		'AUDIO_S32LSB',
+		'AUDIO_S32MSB',
+		'AUDIO_S8',
+		'AUDIO_U16',
+		'AUDIO_U16LSB',
+		'AUDIO_U16MSB',
+		'AUDIO_U8',
 		'KMOD_ALT',
 		'KMOD_CAPS',
 		'KMOD_CTRL',
@@ -271,6 +285,12 @@ Class {
 		'SDL_ARRAYORDER_NONE',
 		'SDL_ARRAYORDER_RGB',
 		'SDL_ARRAYORDER_RGBA',
+		'SDL_AUDIO_ALLOW_ANY_CHANGE',
+		'SDL_AUDIO_ALLOW_CHANNELS_CHANGE',
+		'SDL_AUDIO_ALLOW_FORMAT_CHANGE',
+		'SDL_AUDIO_ALLOW_FREQUENCY_CHANGE',
+		'SDL_AUDIO_ALLOW_SAMPLES_CHANGE',
+		'SDL_AUDIO_MASK_BITSIZE',
 		'SDL_BITMAPORDER_1234',
 		'SDL_BITMAPORDER_4321',
 		'SDL_BITMAPORDER_NONE',
@@ -486,6 +506,7 @@ SDL2Constants class >> initialize [
 	self initialize
 	"
 	self
+		initializeAudio;
 		initializeCommon;
 		initializeEvent;
 		initializeGameController;
@@ -501,6 +522,36 @@ SDL2Constants class >> initialize [
 		initializeTexture;
 		initializeWindow;
 		initializeWM.
+]
+
+{ #category : #'class initialization' }
+SDL2Constants class >> initializeAudio [
+	SDL_AUDIO_MASK_BITSIZE := 16rFF.
+
+	AUDIO_U8        := 16r0008.
+	AUDIO_S8        := 16r8008.
+	AUDIO_U16LSB    := 16r0010.
+	AUDIO_S16LSB    := 16r8010.
+	AUDIO_U16MSB    := 16r1010.
+	AUDIO_S16MSB    := 16r9010.
+	AUDIO_U16       := AUDIO_U16LSB.
+	AUDIO_S16       := AUDIO_S16LSB.
+
+	AUDIO_S32LSB    := 16r8020.
+	AUDIO_S32MSB    := 16r9020.
+	AUDIO_S32       := AUDIO_S32LSB.
+
+	AUDIO_F32LSB    := 16r8120.
+	AUDIO_F32MSB    := 16r9120.
+	AUDIO_F32       := AUDIO_F32LSB.
+
+	"Audio allow change flags."
+	SDL_AUDIO_ALLOW_FREQUENCY_CHANGE    := 16r00000001.
+	SDL_AUDIO_ALLOW_FORMAT_CHANGE       := 16r00000002.
+	SDL_AUDIO_ALLOW_CHANNELS_CHANGE     := 16r00000004.
+	SDL_AUDIO_ALLOW_SAMPLES_CHANGE      := 16r00000008.
+	SDL_AUDIO_ALLOW_ANY_CHANGE         := (SDL_AUDIO_ALLOW_FREQUENCY_CHANGE|SDL_AUDIO_ALLOW_FORMAT_CHANGE|SDL_AUDIO_ALLOW_CHANNELS_CHANGE|SDL_AUDIO_ALLOW_SAMPLES_CHANGE).
+
 ]
 
 { #category : #'class initialization' }

--- a/src/OSWindow-SDL2/SDL2Types.class.st
+++ b/src/OSWindow-SDL2/SDL2Types.class.st
@@ -9,6 +9,9 @@ Class {
 		'Int32',
 		'Int64',
 		'Int8',
+		'SDL_AudioCallback',
+		'SDL_AudioDeviceID',
+		'SDL_AudioFormat',
 		'SDL_GLattr',
 		'SDL_Keycode',
 		'SDL_Keymod',
@@ -48,4 +51,7 @@ SDL2Types class >> initialize [
 	SDL_Scancode := Uint32.
 	
 	SDL_GLattr := #int.
+	SDL_AudioDeviceID := #uint32.
+	SDL_AudioFormat := #uint16.
+	SDL_AudioCallback := #'void*'. "FIXME: use the proper type here."
 ]

--- a/src/OSWindow-SDL2/SDL_AudioSpec.class.st
+++ b/src/OSWindow-SDL2/SDL_AudioSpec.class.st
@@ -1,0 +1,148 @@
+"
+I provide a description for opening an audio device.
+"
+Class {
+	#name : #'SDL_AudioSpec',
+	#superclass : #SDL2Structure,
+	#classVars : [
+		'OFFSET_CALLBACK',
+		'OFFSET_CHANNELS',
+		'OFFSET_FORMAT',
+		'OFFSET_FREQ',
+		'OFFSET_PADDING',
+		'OFFSET_SAMPLES',
+		'OFFSET_SILENCE',
+		'OFFSET_SIZE',
+		'OFFSET_USERDATA'
+	],
+	#category : #'OSWindow-SDL2-Bindings'
+}
+
+{ #category : #'field definition' }
+SDL_AudioSpec class >> fieldsDesc [
+	"
+	self rebuildFieldAccessors
+	"
+	^#(
+	 int freq;
+	
+	 SDL_AudioFormat format;
+	 Uint8 channels;
+	 Uint8 silence;
+
+	 Uint16 samples;
+	 Uint16 padding;
+
+	 Uint32 size;
+	 SDL_AudioCallback callback;
+	 void* userdata;
+ 	)
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> callback [
+	"This method was automatically generated"
+	^ExternalData fromHandle: (handle pointerAt: OFFSET_CALLBACK) type: ExternalType void asPointerType
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> callback: anObject [
+	"This method was automatically generated"
+	handle pointerAt: OFFSET_CALLBACK put: anObject getHandle.
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> channels [
+	"This method was automatically generated"
+	^handle unsignedByteAt: OFFSET_CHANNELS
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> channels: anObject [
+	"This method was automatically generated"
+	handle unsignedByteAt: OFFSET_CHANNELS put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> format [
+	"This method was automatically generated"
+	^handle unsignedShortAt: OFFSET_FORMAT
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> format: anObject [
+	"This method was automatically generated"
+	handle unsignedShortAt: OFFSET_FORMAT put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> freq [
+	"This method was automatically generated"
+	^handle signedLongAt: OFFSET_FREQ
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> freq: anObject [
+	"This method was automatically generated"
+	handle signedLongAt: OFFSET_FREQ put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> padding [
+	"This method was automatically generated"
+	^handle unsignedShortAt: OFFSET_PADDING
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> padding: anObject [
+	"This method was automatically generated"
+	handle unsignedShortAt: OFFSET_PADDING put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> samples [
+	"This method was automatically generated"
+	^handle unsignedShortAt: OFFSET_SAMPLES
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> samples: anObject [
+	"This method was automatically generated"
+	handle unsignedShortAt: OFFSET_SAMPLES put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> silence [
+	"This method was automatically generated"
+	^handle unsignedByteAt: OFFSET_SILENCE
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> silence: anObject [
+	"This method was automatically generated"
+	handle unsignedByteAt: OFFSET_SILENCE put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> size [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_SIZE
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> size: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_SIZE put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> userdata [
+	"This method was automatically generated"
+	^ExternalData fromHandle: (handle pointerAt: OFFSET_USERDATA) type: ExternalType void asPointerType
+]
+
+{ #category : #'accessing structure variables' }
+SDL_AudioSpec >> userdata: anObject [
+	"This method was automatically generated"
+	handle pointerAt: OFFSET_USERDATA put: anObject getHandle.
+]


### PR DESCRIPTION
This PR adds the missing SDL2 bindings that are required for playing audio samples on an audio device.