### PR TITLE
6320-RBExtraBlockRule-does-not-check-for-cull--co

### DIFF
--- a/src/GeneralRules/ReExtraBlockRule.class.st
+++ b/src/GeneralRules/ReExtraBlockRule.class.st
@@ -25,7 +25,10 @@ ReExtraBlockRule >> basicCheck: node [
 
 { #category : #enumerating }
 ReExtraBlockRule >> blockEvaluatingMessages [
-	^ #(#value #value: #value:value: #value:value:value: #valueWithArguments:)
+	^ #(value 
+	value: value:value: value:value:value: value:value:value:value:
+	cull: cull:cull: cull:cull:cull: cull:cull:cull:cull:
+	#valueWithArguments: valueWithPossibleArgs: valueWithPossibleArgument)
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
add cull: .. #valueWithPossibleArgs: and #valueWithPossibleArgument:. fixes #6320