### PR TITLE
6277-RBTemporaryNode-does-not-return-the-right-info-when-in-a-sequence-node

### DIFF
--- a/src/AST-Core-Tests/RBMethodNodeTest.class.st
+++ b/src/AST-Core-Tests/RBMethodNodeTest.class.st
@@ -169,7 +169,6 @@ RBMethodNodeTest >> testPrimitiveModuleErrorIsPrimitive [
 	
 ]
 
-
 { #category : #'tests - primitives' }
 RBMethodNodeTest >> testPrimitiveModuleIsPrimitive [
 	"

--- a/src/AST-Core-Tests/RBVariableNodeTest.class.st
+++ b/src/AST-Core-Tests/RBVariableNodeTest.class.st
@@ -8,6 +8,29 @@ Class {
 }
 
 { #category : #tests }
+RBVariableNodeTest >> testIsDefinition [
+	| ast temps |
+	ast := self class compiler
+		parse:
+			'myMethod: arg
+  | test |
+  test := 2.
+  test.
+  ^test'.
+	ast doSemanticAnalysis.
+	temps := ast allChildren select: #isTemp.
+	
+	"arguments define variables"
+	self assert: ast arguments first isDefinition.
+	"this is the || definition"
+	self assert: temps first isDefinition.
+	"all the rest are just uses"
+	self deny: temps second isDefinition.
+	self deny: temps third isDefinition.
+	self deny: temps fourth isDefinition
+]
+
+{ #category : #tests }
 RBVariableNodeTest >> testStartForReplacement [
 
 	| source tree dTemporary |

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -286,8 +286,7 @@ RBMethodNode >> decompileString [
 
 { #category : #testing }
 RBMethodNode >> defines: aName [
-^ (arguments anySatisfy: [ :each | each name = aName ])
-
+	^ (arguments anySatisfy: [ :each | each name = aName ])
 		or: [ self pragmas anySatisfy: [ :pragma | pragma defines: aName ] ]
 ]
 

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -98,7 +98,12 @@ RBVariableNode >> initialize [
 
 { #category : #testing }
 RBVariableNode >> isDefinition [
-	^self parent isSequence and: [ self parent defines: name ]
+	"Check if I am a Variable defintion"
+	self parent isSequence
+		ifTrue: [ ^ self parent temporaries identityIncludes: self ].
+	(self parent isMethod or: [ self parent isBlock ])
+		ifTrue: [ ^ self parent arguments identityIncludes: self ].
+	^ false
 ]
 
 { #category : #testing }


### PR DESCRIPTION
- implement isDefinition to not use #defines but instead check if the objects is a variable definition
- format #defines better
- add test 

fixes #6277