### PR TITLE
extract-return-from-conditionals-for-packages-d-to-f

### DIFF
--- a/src/DeprecatedFileStream/FileStream.class.st
+++ b/src/DeprecatedFileStream/FileStream.class.st
@@ -698,10 +698,9 @@ FileStream >> name [
 
 { #category : #accessing }
 FileStream >> next [
-
-	(position >= readLimit and: [self atEnd])
-		ifTrue: [^nil]
-		ifFalse: [^collection at: (position := position + 1)]
+	^ (position >= readLimit and: [ self atEnd ])
+		ifTrue: [ nil ]
+		ifFalse: [ collection at: (position := position + 1) ]
 ]
 
 { #category : #accessing }

--- a/src/DeprecatedFileStream/RWBinaryOrTextStream.class.st
+++ b/src/DeprecatedFileStream/RWBinaryOrTextStream.class.st
@@ -75,18 +75,20 @@ RWBinaryOrTextStream >> next: anInteger [
 RWBinaryOrTextStream >> next: n into: aCollection startingAt: startIndex [
 	"Read n objects into the given collection. 
 	Return aCollection or a partial copy if less than n elements have been read."
+
 	"Overriden for efficiency"
+
 	| max |
-	max := (readLimit - position) min: n.
-	aCollection 
-		replaceFrom: startIndex 
-		to: startIndex+max-1
+	max := readLimit - position min: n.
+	aCollection
+		replaceFrom: startIndex
+		to: startIndex + max - 1
 		with: collection
-		startingAt: position+1.
+		startingAt: position + 1.
 	position := position + max.
-	max = n
-		ifTrue:[^aCollection]
-		ifFalse:[^aCollection copyFrom: 1 to: startIndex+max-1]
+	^ max = n
+		ifTrue: [ aCollection ]
+		ifFalse: [ aCollection copyFrom: 1 to: startIndex + max - 1 ]
 ]
 
 { #category : #accessing }

--- a/src/DeprecatedFileStream/StandardFileStream.class.st
+++ b/src/DeprecatedFileStream/StandardFileStream.class.st
@@ -240,19 +240,26 @@ StandardFileStream >> atEnd [
 { #category : #private }
 StandardFileStream >> basicNext [
 	"Answer the next byte from this file, or nil if at the end of the file."
-	
+
 	| count |
-	collection ifNotNil: [
-		position < readLimit 
-			ifFalse: [ 
-				readLimit := self primRead: fileID into: collection startingAt: 1 count: collection size.
-				position := 0.
-				readLimit = 0 ifTrue: [ ^nil ] ].
-		^collection at: (position := position + 1) ].	
-	count := self primRead: fileID into: buffer1 startingAt: 1 count: 1.
-	count = 1
-		ifTrue: [ ^buffer1 at: 1 ]
-		ifFalse: [ ^nil ]
+	collection
+		ifNotNil: [ position < readLimit
+				ifFalse: [ readLimit := self
+						primRead: fileID
+						into: collection
+						startingAt: 1
+						count: collection size.
+					position := 0.
+					readLimit = 0 ifTrue: [ ^ nil ] ].
+			^ collection at: (position := position + 1) ].
+	count := self
+		primRead: fileID
+		into: buffer1
+		startingAt: 1
+		count: 1.
+	^ count = 1
+		ifTrue: [ buffer1 at: 1 ]
+		ifFalse: [ nil ]
 ]
 
 { #category : #modes }

--- a/src/DrTests-CommentsToTests/CommentTestCase.class.st
+++ b/src/DrTests-CommentsToTests/CommentTestCase.class.st
@@ -18,16 +18,15 @@ Class {
 
 { #category : #'instance creation' }
 CommentTestCase class >> comment: stringComment class: aClass selector: aSymbol [
-
 	| result |
 	self flag: #todo.
 	"this method body should be moved on instance side."
 	result := [ Smalltalk compiler evaluate: stringComment ]
 		on: Exception
 		do: [ ^ self errorComment: stringComment class: aClass selector: aSymbol ].
-	(result isKindOf: Association)
-		ifFalse: [ ^ self errorComment: stringComment class: aClass selector: aSymbol ]
-		ifTrue: [ ^ self new
+	^ (result isKindOf: Association)
+		ifFalse: [ self errorComment: stringComment class: aClass selector: aSymbol ]
+		ifTrue: [ self new
 				expression: stringComment;
 				expectedValue: result key;
 				currentValue: result value;

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -1624,17 +1624,12 @@ EFFormatter >> multiLineMessages: anArray [
 EFFormatter >> needsMethodSignatureOnMultipleLinesFor: aMethodNode [
 	| cpt |
 	cpt := 0.
-	self methodSignatureOnMultipleLines
-		ifTrue:
-			[ 
-			aMethodNode selectorParts
+	^ self methodSignatureOnMultipleLines
+		ifTrue: [ aMethodNode selectorParts
 				with: aMethodNode arguments
-				do:
-					[ :key :arg | 
-					key size + arg name size > self selectorAndArgumentCombinedMaxSize
-						ifTrue: [ cpt := cpt + 1 ] ].
-			^ cpt > 1 ]
-		ifFalse: [ ^ false ]
+				do: [ :key :arg | key size + arg name size > self selectorAndArgumentCombinedMaxSize ifTrue: [ cpt := cpt + 1 ] ].
+			cpt > 1 ]
+		ifFalse: [ false ]
 ]
 
 { #category : #private }

--- a/src/FormCanvas-Core/LineSegment.class.st
+++ b/src/FormCanvas-Core/LineSegment.class.st
@@ -151,64 +151,72 @@ LineSegment >> bezierClipInterval: aCurve [
 	minimizing the iteration count. As it is, the process will slowly iterate
 	against tMax and then the curve will be split.
 	"
+
 	| nrm tStep pts eps inside tValue tMin tMax last lastV lastT lastInside next nextV nextT nextInside vMin vMax |
-	eps := 0.00001.					"distance epsilon"
-	nrm := (start y - end y) @ (end x - start x). "normal direction for (end-start)"
+	eps := 0.00001.	"distance epsilon"
+	nrm := (start y - end y) @ (end x - start x).	"normal direction for (end-start)"
 
 	"Map receiver's control point into fat line; compute vMin and vMax"
 	vMin := vMax := nil.
-	self controlPointsDo:[:pt| | vValue |
-		vValue := (nrm x * pt x) + (nrm y * pt y). "nrm dotProduct: pt."
-		vMin == nil	ifTrue:[	vMin := vMax := vValue]
-					ifFalse:[vValue < vMin ifTrue:[vMin := vValue].
-							vValue > vMax ifTrue:[vMax := vValue]]].
+	self
+		controlPointsDo: [ :pt | 
+			| vValue |
+			vValue := nrm x * pt x + (nrm y * pt y).	"nrm dotProduct: pt."
+			vMin == nil
+				ifTrue: [ vMin := vMax := vValue ]
+				ifFalse: [ vValue < vMin ifTrue: [ vMin := vValue ].
+					vValue > vMax ifTrue: [ vMax := vValue ] ] ].
 	"Map the argument into fat line; compute tMin, tMax for clip"
 	tStep := 1.0 / aCurve degree.
 	pts := aCurve controlPoints.
 	last := pts at: pts size.
-	lastV := (nrm x * last x) + (nrm y * last y). "nrm dotProduct: last."
+	lastV := nrm x * last x + (nrm y * last y).	"nrm dotProduct: last."
 	lastT := 1.0.
-	lastInside := lastV+eps < vMin ifTrue:[-1] ifFalse:[lastV-eps > vMax ifTrue:[1] ifFalse:[0]].
+	lastInside := lastV + eps < vMin
+		ifTrue: [ -1 ]
+		ifFalse: [ lastV - eps > vMax
+				ifTrue: [ 1 ]
+				ifFalse: [ 0 ] ].
 
 	"Now compute new minimal and maximal clip boundaries"
 	inside := false.	"assume we're completely outside"
-	tMin := 2.0. tMax := -1.0. 	"clip interval"
-	1 to: pts size do:[:i|
+	tMin := 2.0.
+	tMax := -1.0.	"clip interval"
+	1 to: pts size do: [ :i | 
 		next := pts at: i.
-		nextV := (nrm x * next x) + (nrm y * next y). "nrm dotProduct: next."
-		false ifTrue:[
-			(nextV - vMin / (vMax - vMin)) printString displayAt: 0@ (i-1*20)].
-		nextT := i-1 * tStep.
-		nextInside := nextV+eps < vMin ifTrue:[-1] ifFalse:[nextV-eps > vMax ifTrue:[1] ifFalse:[0]].
-		nextInside = 0 ifTrue:[
-			inside := true.
-			tValue := nextT.
-			tValue < tMin ifTrue:[tMin := tValue].
-			tValue > tMax ifTrue:[tMax := tValue].
-		].
-		lastInside = nextInside ifFalse:["At least one clip boundary"
-			inside := true.
-			"See if one is below vMin"
-			(lastInside + nextInside <= 0) ifTrue:[
-				tValue := lastT + ((nextT - lastT) * (vMin - lastV) / (nextV - lastV)).
-				tValue < tMin ifTrue:[tMin := tValue].
-				tValue > tMax ifTrue:[tMax := tValue].
-			].
-			"See if one is above vMax"
-			(lastInside + nextInside >= 0) ifTrue:[
-				tValue := lastT + ((nextT - lastT) * (vMax - lastV) / (nextV - lastV)).
-				tValue < tMin ifTrue:[tMin := tValue].
-				tValue > tMax ifTrue:[tMax := tValue].
-			].
-		].
+		nextV := nrm x * next x + (nrm y * next y).	"nrm dotProduct: next."
+		false ifTrue: [ ((nextV - vMin) / (vMax - vMin)) printString displayAt: 0 @ ((i - 1) * 20) ].
+		nextT := (i - 1) * tStep.
+		nextInside := nextV + eps < vMin
+			ifTrue: [ -1 ]
+			ifFalse: [ nextV - eps > vMax
+					ifTrue: [ 1 ]
+					ifFalse: [ 0 ] ].
+		nextInside = 0
+			ifTrue: [ inside := true.
+				tValue := nextT.
+				tValue < tMin ifTrue: [ tMin := tValue ].
+				tValue > tMax ifTrue: [ tMax := tValue ] ].
+		lastInside = nextInside
+			ifFalse: [ "At least one clip boundary"
+				inside := true.
+				"See if one is below vMin"
+				lastInside + nextInside <= 0
+					ifTrue: [ tValue := lastT + ((nextT - lastT) * (vMin - lastV) / (nextV - lastV)).
+						tValue < tMin ifTrue: [ tMin := tValue ].
+						tValue > tMax ifTrue: [ tMax := tValue ] ].
+				"See if one is above vMax"
+				lastInside + nextInside >= 0
+					ifTrue: [ tValue := lastT + ((nextT - lastT) * (vMax - lastV) / (nextV - lastV)).
+						tValue < tMin ifTrue: [ tMin := tValue ].
+						tValue > tMax ifTrue: [ tMax := tValue ] ] ].
 		last := next.
 		lastT := nextT.
 		lastV := nextV.
-		lastInside := nextInside.
-	].
-	inside
-		ifTrue:[^Array with: tMin with: tMax]
-		ifFalse:[^nil]
+		lastInside := nextInside ].
+	^ inside
+		ifTrue: [ Array with: tMin with: tMax ]
+		ifFalse: [ nil ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Extract returns from conditionals for packages starting by d to f

This makes the code more readable since we can directly know that the conditional will necessarily return something and the execution can be stoped.