### PR TITLE
extract-assignations-from-conditionals-for-packages-a

### DIFF
--- a/src/AST-Core/RBParseTreeRewriter.class.st
+++ b/src/AST-Core/RBParseTreeRewriter.class.st
@@ -131,19 +131,17 @@ RBParseTreeRewriter class >> replaceLiteral: literal with: newLiteral [
 ]
 
 { #category : #accessing }
-RBParseTreeRewriter class >> replaceStatements: code with: newCode in: aParseTree onInterval: anInterval [ 
+RBParseTreeRewriter class >> replaceStatements: code with: newCode in: aParseTree onInterval: anInterval [
 	| tree replaceStmt |
 	tree := self buildTree: code method: false.
-	tree isSequence 
-		ifFalse: [tree := RBSequenceNode statements: (Array with: tree)].
+	tree isSequence ifFalse: [ tree := RBSequenceNode statements: (Array with: tree) ].
 	tree temporaries: (Array with: (RBPatternVariableNode named: '`@temps')).
 	tree addNodeFirst: (RBPatternVariableNode named: '`@.S1').
-	tree lastIsReturn 
-		ifTrue: [replaceStmt := '| `@temps | `@.S1. ^' , newCode]
-		ifFalse: 
-			[tree addNode: (RBPatternVariableNode named: '`@.S2').
-			replaceStmt := '| `@temps | `@.S1. ' , newCode , '. `@.S2'].
-	^self 
+	replaceStmt := tree lastIsReturn
+		ifTrue: [ '| `@temps | `@.S1. ^' , newCode ]
+		ifFalse: [ tree addNode: (RBPatternVariableNode named: '`@.S2').
+			'| `@temps | `@.S1. ' , newCode , '. `@.S2' ].
+	^ self
 		replace: tree formattedCode
 		with: replaceStmt
 		in: aParseTree


### PR DESCRIPTION
Extract assignations from conditionals for packages starting by a

This makes the code more readable since we can directly know that the conditional will necessarily return something and the execution can be stoped.