### PR TITLE
extract-assignations-from-conditionals-for-packages-s

### DIFF
--- a/src/System-Hashing/ThirtyTwoBitRegister.class.st
+++ b/src/System-Hashing/ThirtyTwoBitRegister.class.st
@@ -132,27 +132,24 @@ ThirtyTwoBitRegister >> hi [
 { #category : #'accumulator ops' }
 ThirtyTwoBitRegister >> leftRotateBy: bits [
 	"Rotate my contents left by the given number of bits, retaining exactly 32 bits."
+
 	"Details: Perform this operation with as little LargeInteger arithmetic as possible."
 
 	| bitCount s1 s2 newHi |
 	"ensure bitCount is in range [0..32]"
 	bitCount := bits \\ 32.
-	bitCount < 0 ifTrue: [bitCount := bitCount + 32].
-
-	bitCount > 16
-		ifTrue: [
-			s1 := bitCount - 16.
+	bitCount < 0 ifTrue: [ bitCount := bitCount + 32 ].
+	hi := bitCount > 16
+		ifTrue: [ s1 := bitCount - 16.
 			s2 := s1 - 16.
 			newHi := ((low bitShift: s1) bitAnd: 16rFFFF) bitOr: (hi bitShift: s2).
 			low := ((hi bitShift: s1) bitAnd: 16rFFFF) bitOr: (low bitShift: s2).
-			hi := newHi]
-		ifFalse: [
-			s1 := bitCount.
+			newHi ]
+		ifFalse: [ s1 := bitCount.
 			s2 := s1 - 16.
 			newHi := ((hi bitShift: s1) bitAnd: 16rFFFF) bitOr: (low bitShift: s2).
 			low := ((low bitShift: s1) bitAnd: 16rFFFF) bitOr: (hi bitShift: s2).
-			hi := newHi]
-
+			newHi ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Extract assignations from conditionals for packages starting by s

This makes the code more readable since we can directly know that the conditional will necessarily return something and the execution can be stoped.