### PR TITLE
extract-assignations-from-conditionals-for-packages-t

### DIFF
--- a/src/Text-Scanning/DisplayScanner.class.st
+++ b/src/Text-Scanning/DisplayScanner.class.st
@@ -121,6 +121,7 @@ DisplayScanner >> displayEmbeddedForm: aForm [
 { #category : #scanning }
 DisplayScanner >> displayLine: textLine offset: offset leftInRun: leftInRun [
 	"The call on the primitive (scanCharactersFrom:to:in:rightX:) will be interrupted according to an array of stop conditions passed to the scanner at which time the code to handle the stop condition is run and the call on the primitive continued until a stop condition returns true (which means the line has terminated).  leftInRun is the # of characters left to scan in the current run; when 0, it is time to call setStopConditions."
+
 	| stopCondition nowLeftInRun startIndex string lastPos lineHeight stop |
 	line := textLine.
 	morphicOffset := offset.
@@ -128,44 +129,45 @@ DisplayScanner >> displayLine: textLine offset: offset leftInRun: leftInRun [
 	lineHeight := line lineHeight.
 	rightMargin := line rightMargin + offset x.
 	lastIndex := line first.
-	leftInRun <= 0 ifTrue: [self setStopConditions].
+	leftInRun <= 0 ifTrue: [ self setStopConditions ].
 	leftMargin := (line leftMarginForAlignment: alignment) + offset x.
 	destX := leftMargin.
 	self fillTextBackground.
 	lastDisplayableIndex := lastIndex := line first.
-	leftInRun <= 0
-		ifTrue: [nowLeftInRun := text runLengthFor: lastIndex]
-		ifFalse: [nowLeftInRun := leftInRun].
+	nowLeftInRun := leftInRun <= 0
+		ifTrue: [ text runLengthFor: lastIndex ]
+		ifFalse: [ leftInRun ].
 	destY := lineY + line baseline - font ascent.
 	runStopIndex := lastIndex + (nowLeftInRun - 1) min: line last.
 	spaceCount := 0.
 	string := text string.
-	[
-		"reset the stopping conditions of this displaying loop, and also the font."
-		stopConditionsMustBeReset
-			ifTrue:[self setStopConditions].
-		
-		"remember where this portion of the line starts"
-		startIndex := lastIndex.
-		lastPos := destX@destY.
-		
-		"find the end of this portion of the line"
-		stopCondition := self scanCharactersFrom: lastIndex to: runStopIndex
-						in: string rightX: rightMargin.
-		"handle the stop condition - this will also set lastDisplayableIndex"
-		stop := self perform: stopCondition.
-		
-		"display that portion of the line"
-		lastDisplayableIndex >= startIndex ifTrue:[
-			self displayString: string
-				from: startIndex 
-				to: lastDisplayableIndex 
-				at: lastPos].
-		
-		"if the stop condition were true, stop the loop"
-		stop
-	] whileFalse.
-	^ runStopIndex - lastIndex   "Number of characters remaining in the current run"
+	[ "reset the stopping conditions of this displaying loop, and also the font."
+	stopConditionsMustBeReset ifTrue: [ self setStopConditions ].
+
+	"remember where this portion of the line starts"
+	startIndex := lastIndex.
+	lastPos := destX @ destY.
+
+	"find the end of this portion of the line"
+	stopCondition := self
+		scanCharactersFrom: lastIndex
+		to: runStopIndex
+		in: string
+		rightX: rightMargin.
+	"handle the stop condition - this will also set lastDisplayableIndex"
+	stop := self perform: stopCondition.
+
+	"display that portion of the line"
+	lastDisplayableIndex >= startIndex
+		ifTrue: [ self
+				displayString: string
+				from: startIndex
+				to: lastDisplayableIndex
+				at: lastPos ].
+
+	"if the stop condition were true, stop the loop"
+	stop ] whileFalse.
+	^ runStopIndex - lastIndex	"Number of characters remaining in the current run"
 ]
 
 { #category : #displaying }

--- a/src/Tool-DependencyAnalyser-UI/DAPackageAnalyzerTreeModel.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageAnalyzerTreeModel.class.st
@@ -171,13 +171,13 @@ DAPackageAnalyzerTreeModel >> actionWhenTextFieldChanged [
 { #category : #actions }
 DAPackageAnalyzerTreeModel >> buildRoots [
 	| matching roots |
-	self filter
-		ifNotNil: [ 
-			matching := '*' , self filter , '*'.
-			roots := (self nodesFor: (relationGraph seenPackagesWithFilter: matching)) ]
-		ifNil: [ roots := (self nodesFor: relationGraph seenPackages) ].
+	roots := self filter
+		ifNotNil: [ :f | 
+			matching := '*' , f , '*'.
+			self nodesFor: (relationGraph seenPackagesWithFilter: matching) ]
+		ifNil: [ self nodesFor: relationGraph seenPackages ].
 	self tree roots: roots.
-	self updatePackageLabel.
+	self updatePackageLabel
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Extract assignations from conditionals for packages starting by t

This makes the code more readable since we can directly know that the conditional will necessarily return something and the execution can be stoped.