### PR TITLE
6247-asPrimitive-deverses-a-comment-and-some-inline-comment-too

### DIFF
--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -149,7 +149,7 @@ RBMethodNode >> primitiveFromPragma [
 	pragmas ifNil: [ ^ IRPrimitive null ].
 	^ pragmas
 		detect: [ :each | each isPrimitive ]
-		ifFound: [ :aPragmaPrimitive | aPragmaPrimitive asPrimitive ]
+		ifFound: [ :aPragmaPrimitive | aPragmaPrimitive asIRPrimitive ]
 		ifNone: [ IRPrimitive null ]
 ]
 

--- a/src/OpalCompiler-Core/RBPragmaNode.extension.st
+++ b/src/OpalCompiler-Core/RBPragmaNode.extension.st
@@ -1,20 +1,16 @@
 Extension { #name : #RBPragmaNode }
 
 { #category : #'*opalcompiler-core' }
-RBPragmaNode >> asPragma [
-	^ Pragma
-		selector: selector
-		arguments: (arguments collect: [ :each | each value ]) asArray
-]
-
-{ #category : #'*opalcompiler-core' }
-RBPragmaNode >> asPrimitive [
+RBPragmaNode >> asIRPrimitive [
+	"return a IRPrimitive for this method to be used in the compiler intermediate representation"
 	| args module name spec  |
 	args := (self arguments collect: [ :each | each value ]) asArray.
+	"normal methods have primitive number 0"
 	self isPrimitive
 		ifFalse: [ IRPrimitive null ].
 	args first isString
 		ifTrue: [ 
+			"named primitives have number 117, the spec describes what to call"
 			name := args first.
 			module := self argumentAt: #module: ifAbsent: [ nil ].
 			spec := {(module ifNotNil: [ module value asSymbol ]). (name asSymbol). 0. 0}.
@@ -23,10 +19,18 @@ RBPragmaNode >> asPrimitive [
 				spec: spec;
 				yourself ]
 		ifFalse: [ 
+			"these are standard numbered primitives"
 			^ IRPrimitive new
 				num: args first;
 				spec: nil;
 				yourself ]
+]
+
+{ #category : #'*opalcompiler-core' }
+RBPragmaNode >> asPragma [
+	^ Pragma
+		selector: selector
+		arguments: (arguments collect: [ :each | each value ]) asArray
 ]
 
 { #category : #'*opalcompiler-core' }


### PR DESCRIPTION
- rename #asPrimitve to #asIRPrimitive as it is a method that returns a IRPrimitive
- add comments 

fixes #6247