### PR TITLE
Fix https://github.com/pharo-vcs/iceberg/issues/1331

### DIFF
--- a/src/Calypso-SystemPlugins-Monticello-Browser/ClyCommitMCPackageCommand.class.st
+++ b/src/Calypso-SystemPlugins-Monticello-Browser/ClyCommitMCPackageCommand.class.st
@@ -50,7 +50,11 @@ ClyCommitMCPackageCommand >> execute [
 	repos ifEmpty: [ ^ self inform: 'Selected packages are not managed by Iceberg' ].
 	targetRepo := repos size = 1 ifTrue: [ repos first ] ifFalse: [ UIManager default chooseFrom: (repos collect: #name) values: repos title: 'Choose repository' ].
 	targetRepo ifNil: [ ^ self ].
-	(targetRepo isMissing or: [ targetRepo isCodeMissing or: [ targetRepo isDetached or: [ targetRepo hasUnbornProject ] ] ])
+	(targetRepo isMissing or: [ 
+		targetRepo isCodeMissing or: [ 
+			targetRepo workingCopy isDetached or: [ 
+				targetRepo head isDetached or: [ 
+					targetRepo workingCopy project isUnborn ] ] ] ])
 		ifTrue: [ UIManager default
 				alert:
 					'The ' , targetRepo name


### PR DESCRIPTION
Fix pharo-vcs/iceberg#1331.
That issue is not an iceberg issue but a Calypso issue.

Calypso uses a non public API of iceberg to try to hack around and open an iceberg commit window.

This PR patches the problem though this is not a long term solution.