### PR TITLE
6412-RBComment-should-have-parent-pointer-to-node

### DIFF
--- a/src/AST-Core/RBComment.class.st
+++ b/src/AST-Core/RBComment.class.st
@@ -28,7 +28,8 @@ Class {
 	#superclass : #RBNode,
 	#instVars : [
 		'contents',
-		'start'
+		'start',
+		'parent'
 	],
 	#category : #'AST-Core-Nodes'
 }
@@ -62,6 +63,16 @@ RBComment >> intersectsInterval: anInterval [
 	
 	^(anInterval first between: self start and: self stop) 
 		or: [ self start between: anInterval first and: anInterval last ]
+]
+
+{ #category : #accessing }
+RBComment >> parent [
+	^ parent
+]
+
+{ #category : #accessing }
+RBComment >> parent: anObject [
+	parent := anObject
 ]
 
 { #category : #printing }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -129,6 +129,7 @@ RBParser class >> parseRewriteMethod: aString onError: aBlock [
 { #category : #private }
 RBParser >> addCommentsTo: aNode [
 	aNode comments: aNode comments , comments.
+	comments do: [ :each | each parent: aNode ].
 	comments := OrderedCollection new
 ]
 

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -182,6 +182,15 @@ CompiledMethodTest >> testComments [
 ]
 
 { #category : #'tests - accessing' }
+CompiledMethodTest >> testCommentsParent [
+	"Test if comment has a parent"
+	self
+		assert: (CompiledMethodTest >> #testCommentsParent) ast comments first parent selector
+		equals: #testCommentsParent.
+	
+]
+
+{ #category : #'tests - accessing' }
 CompiledMethodTest >> testComparison [
 	| method1 method2 |
 	method1 := Float class >> #nan.


### PR DESCRIPTION
RBComment should have parent pointer to node #6412