### PR TITLE
Fixes changes file flushing issue

### DIFF
--- a/src/System-Sources/SourceFileBufferedReadWriteStream.class.st
+++ b/src/System-Sources/SourceFileBufferedReadWriteStream.class.st
@@ -104,12 +104,16 @@ SourceFileBufferedReadWriteStream >> defaultBufferSize [
 
 { #category : #writing }
 SourceFileBufferedReadWriteStream >> ensureWrittenPosition: aPosition [
-
 	isDirty ifFalse: [ ^ false ].
-	
-	(self isPositionInBuffer: aPosition)
-		ifTrue: [ self flush. ^ true ].
-		
+
+	((self isPositionInBuffer: aPosition) or: [
+		"The position has been written to disk but
+		the buffer is dirty, so there is potentially
+		data in the buffer that we need."
+		aPosition <= bufferOffset ]) ifTrue: [
+			self flush.
+			^ true ].
+
 	^ false
 ]
 


### PR DESCRIPTION
SourceFileBufferedReadWriteStream>>ensureWrittenPosition: now performs an extra check to see whether the requested position has been written to the file if the buffer is dirty, since in that case the file may not contain the complete chunk that will be looked up.

Fixes #6063 for Pharo 9