### PR TITLE
Fix #6472

### DIFF
--- a/src/HeuristicCompletion-Model/CoInstanceAccessibleVariablesHeuristic.class.st
+++ b/src/HeuristicCompletion-Model/CoInstanceAccessibleVariablesHeuristic.class.st
@@ -12,7 +12,7 @@ Class {
 { #category : #requests }
 CoInstanceAccessibleVariablesHeuristic >> appliesForNode: aNode inContext: aContext [
 
-	^ aContext isWorkspace not
+	^ aContext completionClass notNil
 ]
 
 { #category : #requests }


### PR DESCRIPTION
Do not activate CoInstanceAccessibleVariablesHeuristic if there is no completion class. This covers the case of both workspaces and comment panes.