### PR TITLE
Deprecated Slot

### DIFF
--- a/src/VariablesLibrary/DeprecatedSlot.class.st
+++ b/src/VariablesLibrary/DeprecatedSlot.class.st
@@ -1,0 +1,76 @@
+"
+Description
+--------------------
+
+I am a slot used when the usage of an instance variable should be deprecated.
+
+Examples
+--------------------
+
+	FamixMetamodelGenerator subclass: #FamixBasicInfrastructureGenerator
+	slots: { #entity => DeprecatedSlot message: 'Do not use'. 
+				#sourceAnchor. #sourceLanguage. #sourcedEntity. #comment. #namedEntity. #sourceTextAnchor. #unknownSourceLanguage }
+	classVariables: {  }
+	package: 'Famix-BasicInfrastructure'
+ 
+Internal Representation and Key Implementation Points.
+--------------------
+
+    Instance Variables
+	message:		<aString>		The deprecation message to show.
+
+"
+Class {
+	#name : #DeprecatedSlot,
+	#superclass : #IndexedSlot,
+	#instVars : [
+		'message'
+	],
+	#category : #'VariablesLibrary-DeprecatedSlot'
+}
+
+{ #category : #accessing }
+DeprecatedSlot class >> message: aString [
+	^ self new
+		message: aString;
+		yourself
+]
+
+{ #category : #accessing }
+DeprecatedSlot >> message [
+	^ message
+]
+
+{ #category : #accessing }
+DeprecatedSlot >> message: anObject [
+	message := anObject
+]
+
+{ #category : #printing }
+DeprecatedSlot >> printOn: aStream [
+	aStream
+		store: self name;
+		nextPutAll: ' => ';
+		nextPutAll: self class name.
+	aStream
+		nextPutAll: ' message: ';
+		store: self message
+]
+
+{ #category : #'meta-object-protocol' }
+DeprecatedSlot >> read: anObject [
+	SlotDeprecation new
+		context: thisContext;
+		explanation: self message;
+		signal.
+	super read: anObject
+]
+
+{ #category : #'meta-object-protocol' }
+DeprecatedSlot >> write: aValue to: anObject [
+	SlotDeprecation new
+		context: thisContext;
+		explanation: self message;
+		signal.
+	super write: aValue to: anObject
+]

--- a/src/VariablesLibrary/SlotDeprecation.class.st
+++ b/src/VariablesLibrary/SlotDeprecation.class.st
@@ -1,0 +1,21 @@
+"
+This exception is raised when accessing deprecated slots
+"
+Class {
+	#name : #SlotDeprecation,
+	#superclass : #Deprecation,
+	#category : #'VariablesLibrary-DeprecatedSlot'
+}
+
+{ #category : #accessing }
+SlotDeprecation >> messageText [
+	^ String
+		streamContents: [ :str | 
+			str
+				nextPutAll: 'The instance variable ';
+				nextPutAll: context receiver name;
+				nextPutAll: ' accessed in ';
+				nextPutAll: context sender method name;
+				nextPutAll: ' has been deprecated. ';
+				nextPutAll: explanationString ]
+]


### PR DESCRIPTION
This is the Depecated Slot from https://github.com/jecisc/Bazard/tree/master/src/DeprecatedSlot 

This for now just allows us to declare a slot as deprectated, raising a log entry at runtime just like a deprecated method.

The next step is to add transformation support to it, too.