### PR TITLE
failing-testExternalBasicToolsDependencies

### DIFF
--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -59,7 +59,7 @@ SystemDependenciesTest >> knownBasicToolsDependencies [
 
 	"ideally this list should be empty"	
 	^ #('AST-Core-Tests' 'Athens-Cairo' 'Athens-Core' 
-	#'Athens-Morphic' #NautilusRefactoring #'Refactoring-Critics' #'Reflectivity-Tools' #Shout 'ParametrizedTests' 'HeuristicCompletion-Morphic')
+	#'Athens-Morphic' #NautilusRefactoring #'Refactoring-Critics' #Reflectivity #'Reflectivity-Tools' #Shout 'ParametrizedTests' 'HeuristicCompletion-Morphic')
 ]
 
 { #category : #'known dependencies' }


### PR DESCRIPTION
testExternalBasicToolsDependencies was failing due to Reflectivity not being listed