### PR TITLE
emitStore-do-not-use-Object-new

### DIFF
--- a/src/Slot-Core/GlobalVariable.class.st
+++ b/src/Slot-Core/GlobalVariable.class.st
@@ -17,9 +17,8 @@ GlobalVariable >> definingClass [
 
 { #category : #'code generation' }
 GlobalVariable >> emitStore: methodBuilder [
-	methodBuilder storeIntoLiteralVariable: self.
 
-
+	methodBuilder storeIntoLiteralVariable: self
 ]
 
 { #category : #'code generation' }

--- a/src/Slot-Core/LiteralVariable.class.st
+++ b/src/Slot-Core/LiteralVariable.class.st
@@ -74,7 +74,7 @@ LiteralVariable >> definitionString [
 { #category : #'code generation' }
 LiteralVariable >> emitStore: aMethodBuilder [
 	| tempName |
-	tempName := Object new.
+	tempName := '0TempForStackManipulation'.
 	aMethodBuilder
 		addTemp: tempName;
 		storeTemp: tempName;

--- a/src/VariablesLibrary/ObservableSlot.class.st
+++ b/src/VariablesLibrary/ObservableSlot.class.st
@@ -36,7 +36,7 @@ ObservableSlot >> emitStore: aMethodBuilder [
 	"generate bytecode for 'varName value: <stackTop>'"
 
 	| temp |
-	temp := Object new.	"we need a unique Object as a temp name"
+	temp := '0slotTempForStackManipulation'.
 	"We pop the value from the stack into a temp to push it back in the right order"
 	aMethodBuilder addTemp: temp.
 	aMethodBuilder storeTemp: temp.

--- a/src/VariablesLibrary/WeakClassVariable.class.st
+++ b/src/VariablesLibrary/WeakClassVariable.class.st
@@ -19,7 +19,7 @@ Class {
 WeakClassVariable >> emitStore: aMethodBuilder [
 	"generate bytecode for 'varname at: 1 put: <stackTop>'"
 	| temp |
-	temp := '0slotTempForStackManipulation'.
+	temp := '0TempForStackManipulation'.
 	"Pop the value to store into a temp to push it back in the right order"
 	aMethodBuilder addTemp: temp.
 	aMethodBuilder storeTemp: temp.


### PR DESCRIPTION
We should not use "Object new" as temp name in emitStore:, better use a string that starts with a number, this way it can not clash with other temps but is a string, which allows things to be simpler in the compiler.