### PR TITLE
pushOuterVectors-use-tempVectorVarNames

### DIFF
--- a/src/OpalCompiler-Core/IRTranslator.class.st
+++ b/src/OpalCompiler-Core/IRTranslator.class.st
@@ -98,7 +98,7 @@ IRTranslator >> pushOuterVectors: scope [
 	scopesWithVector reverseDo: [ :scopeWithVector |
 		tempVectorStack push: (IRInstruction 
 			createTempVectorNamed: scopeWithVector tempVectorName
-			withVars: (scopeWithVector tempVector collect: [:each| each name]) asArray ) ].
+			withVars: scopeWithVector tempVectorVarNames)].
 	gen inBlock: true.
 ]
 

--- a/src/OpalCompiler-Core/RBPragmaNode.extension.st
+++ b/src/OpalCompiler-Core/RBPragmaNode.extension.st
@@ -6,7 +6,7 @@ RBPragmaNode >> asIRPrimitive [
 	| args module name spec |
 	args := (self arguments collect: [ :each | each value ]) asArray.
 	"normal methods have primitive number 0"
-	self isPrimitive ifFalse: [ IRPrimitive null ].
+	self isPrimitive ifFalse: [ ^ IRPrimitive null ].
 	^ args first isString
 		ifTrue: [ name := args first.
 			module := self argumentAt: #module: ifAbsent: [ nil ].


### PR DESCRIPTION
simplify pushOuterVectors: by using #tempVectorVarNames