### PR TITLE
6409-Two-Zinc-tests-have-timeOut-on-the-CI

### DIFF
--- a/src/Zinc-HTTP-Examples/ZnImageExampleDelegate.class.st
+++ b/src/Zinc-HTTP-Examples/ZnImageExampleDelegate.class.st
@@ -37,7 +37,7 @@ ZnImageExampleDelegate class >> installInDefaultServer [
 { #category : #accessing }
 ZnImageExampleDelegate >> downloadPharoLogo [
 	^ ZnClient new beOneShot
-		get: 'http://pharo.org/files/pharo.png';
+		get: 'https://pharo.org/files/pharo.png';
 		entity
 ]
 

--- a/src/Zinc-HTTP-Examples/ZnImageExampleDelegate.class.st
+++ b/src/Zinc-HTTP-Examples/ZnImageExampleDelegate.class.st
@@ -25,6 +25,11 @@ Class {
 	#category : #'Zinc-HTTP-Examples'
 }
 
+{ #category : #accessing }
+ZnImageExampleDelegate class >> defaultTimeLimit [
+	^10 seconds
+]
+
 { #category : #public }
 ZnImageExampleDelegate class >> installInDefaultServer [
 	"Assuming the default server has the default delegate, 

--- a/src/Zinc-Tests/ZnEasyTest.class.st
+++ b/src/Zinc-Tests/ZnEasyTest.class.st
@@ -44,7 +44,7 @@ ZnEasyTest >> testGetJpeg [
 { #category : #testing }
 ZnEasyTest >> testGetPng [
 	| url result |
-	url := 'http://pharo.org/files/pharo.png'.
+	url := 'https://pharo.org/files/pharo.png'.
 	result := ZnEasy getPng: url.
 	self assert: result isForm
 ]

--- a/src/Zinc-Tests/ZnEasyTest.class.st
+++ b/src/Zinc-Tests/ZnEasyTest.class.st
@@ -5,6 +5,11 @@ Class {
 }
 
 { #category : #accessing }
+ZnEasyTest class >> defaultTimeLimit [
+	^10 seconds
+]
+
+{ #category : #accessing }
 ZnEasyTest >> smallHtmlUrl [
 	^ 'http://zn.stfx.eu/zn/small.html' asZnUrl
 ]


### PR DESCRIPTION
Change the URL to be https: as it seems we else do not follow the redirect. fixes #6409  (I hope)