### PR TITLE
6049-It-should-not-be-possible-to-use-super-as-something-else-than-the-receiver-of-a-message

### DIFF
--- a/src/GeneralRules-Tests/ReSuperWithoutSendTest.class.st
+++ b/src/GeneralRules-Tests/ReSuperWithoutSendTest.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #ReSuperWithoutSendTest,
+	#superclass : #TestCase,
+	#category : #'GeneralRules-Tests-Migrated'
+}
+
+{ #category : #tests }
+ReSuperWithoutSendTest >> testBasicCheck [
+
+	| ast |
+	ast :=  self class compiler parse: 'testMethod ^super'.
+	self assert: (ReSuperWithoutSend new basicCheck: ast variableNodes first).
+	self deny: (ReSuperWithoutSend new basicCheck: ast statements first).
+	ast := self class compiler parse: 'testMethod ^ super doit'.
+	self deny: (ReSuperWithoutSend new basicCheck: ast variableNodes first).
+	ast := self class compiler parse: 'testMethod ^ self doit: super'.
+	self assert: (ReSuperWithoutSend new basicCheck: ast variableNodes second).
+]

--- a/src/GeneralRules/ReSuperWithoutSend.class.st
+++ b/src/GeneralRules/ReSuperWithoutSend.class.st
@@ -17,7 +17,7 @@ ReSuperWithoutSend >> basicCheck: aNode [
 	aNode isVariable ifFalse: [ ^ false ].
 	aNode isSuper ifFalse: [ ^ false ].
 	aNode parent isMessage ifTrue: [
-		"if we are the reveiver, everything is ok"  
+		"if we are the receiver, everything is ok"  
 		^aNode parent receiver ~= aNode
 	].
 	^true.

--- a/src/GeneralRules/ReSuperWithoutSend.class.st
+++ b/src/GeneralRules/ReSuperWithoutSend.class.st
@@ -1,0 +1,34 @@
+"
+""super"" only makes sense when used as the receiver of a message.
+
+	super doSomething.
+	
+For every other use, it is just the same as ""self"".
+
+"
+Class {
+	#name : #ReSuperWithoutSend,
+	#superclass : #ReNodeBasedRule,
+	#category : #'GeneralRules-Migrated'
+}
+
+{ #category : #running }
+ReSuperWithoutSend >> basicCheck: aNode [
+	aNode isVariable ifFalse: [ ^ false ].
+	aNode isSuper ifFalse: [ ^ false ].
+	aNode parent isMessage ifTrue: [
+		"if we are the reveiver, everything is ok"  
+		^aNode parent receiver ~= aNode
+	].
+	^true.
+]
+
+{ #category : #accessing }
+ReSuperWithoutSend >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : #accessing }
+ReSuperWithoutSend >> name [
+	^ 'super makes only sense as the receiver of a message'
+]


### PR DESCRIPTION
add a rule to check for wrong uses of super. fixes #6049