### PR TITLE
6415-RBMethodNode-should-have-allComments #6415

### DIFF
--- a/src/AST-Core-Tests/RBProgramNodeTest.class.st
+++ b/src/AST-Core-Tests/RBProgramNodeTest.class.st
@@ -170,6 +170,18 @@ RBProgramNodeTest >> testAddTemporaryNamed [
 	self assert: tree temporaries last equals: variable
 ]
 
+{ #category : #'tests - accessing' }
+RBProgramNodeTest >> testAllComments [
+	"Testing the AST comments objects. I am the first comment to be found in this test"
+	self
+		assert: (RBProgramNodeTest >> #testAllComments) ast allComments first contents
+		equals: 'Testing the AST comments objects. I am the first comment to be found in this test'.
+	"Next test assumes this comment it's not a string like in #testComments..."
+	self 
+		assert: (RBProgramNodeTest >> #testAllComments) ast allComments second isString
+		equals: false
+]
+
 { #category : #tests }
 RBProgramNodeTest >> testAllParents [
 	"check that we get all parents of a program node"

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -94,9 +94,9 @@ RBProgramNode >> allChildren [
 
 { #category : #accessing }
 RBProgramNode >> allComments [
-	"Answer a collection of strings representing the comments in the method. Return an empty collection if the method's source code does not contain a comment."
+	"Answer a collection of objects representing the comments in the method. Return an empty collection if the method's source code does not contain a comment."
 
-	^ self allChildren flatCollect: [:el| el comments]
+	^ self ast allChildren flatCollect: [:el| el comments]
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -96,7 +96,7 @@ RBProgramNode >> allChildren [
 RBProgramNode >> allComments [
 	"Answer a collection of objects representing the comments in the method. Return an empty collection if the method's source code does not contain a comment."
 
-	^ self ast allChildren flatCollect: [:el| el comments]
+	^ self allChildren flatCollect: [:el| el comments]
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -93,6 +93,13 @@ RBProgramNode >> allChildren [
 ]
 
 { #category : #accessing }
+RBProgramNode >> allComments [
+	"Answer a collection of strings representing the comments in the method. Return an empty collection if the method's source code does not contain a comment."
+
+	^ self allChildren flatCollect: [:el| el comments]
+]
+
+{ #category : #accessing }
 RBProgramNode >> allDefinedVariables [
 	| children |
 	children := self children.

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -286,6 +286,18 @@ CompiledMethodTest >> testAccessesSlot [
 ]
 
 { #category : #'tests - accessing' }
+CompiledMethodTest >> testAllComments [
+	"Testing the AST comments objects. I am the first comment to be found in this test"
+	self
+		assert: (CompiledMethodTest >> #testAllComments) ast allComments first contents
+		equals: 'Testing the AST comments objects. I am the first comment to be found in this test'.
+	"Next test assumes this comment it's not a string like in #testComments..."
+	self 
+		assert: (CompiledMethodTest >> #testAllComments) ast allComments second isString
+		equals: false
+]
+
+{ #category : #'tests - accessing' }
 CompiledMethodTest >> testBytecode [
 	"The result of this test depends on the used bytecode set. 
 	

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -286,18 +286,6 @@ CompiledMethodTest >> testAccessesSlot [
 ]
 
 { #category : #'tests - accessing' }
-CompiledMethodTest >> testAllComments [
-	"Testing the AST comments objects. I am the first comment to be found in this test"
-	self
-		assert: (CompiledMethodTest >> #testAllComments) ast allComments first contents
-		equals: 'Testing the AST comments objects. I am the first comment to be found in this test'.
-	"Next test assumes this comment it's not a string like in #testComments..."
-	self 
-		assert: (CompiledMethodTest >> #testAllComments) ast allComments second isString
-		equals: false
-]
-
-{ #category : #'tests - accessing' }
 CompiledMethodTest >> testBytecode [
 	"The result of this test depends on the used bytecode set. 
 	


### PR DESCRIPTION
Added #allComments to RBProgramNode issue #6415 https://github.com/pharo-project/pharo/issues/6415