### PR TITLE
RPackage-AllUnsentMessages-Shouldbe-Set

### DIFF
--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -87,12 +87,13 @@ RPackageTest >> testAllUnsentMessages [
 		compile: 'nonexistingMethodName2 42'.
 		
 	class2
+		compile: 'nonexistingMethodName1 42';
 		compile: 'nonexistingMethodName3 42';
 		compile: 'nonexistingMethodName4 class1 new nonexistingMethodName2'.
 		
 	self assert: package allUnsentMessages size equals: 3.
 	
-	self assert: package allUnsentMessages asSet equals: (#('nonexistingMethodName1' 'nonexistingMethodName3' 'nonexistingMethodName4') collect: #asSymbol) asSet.
+	self assert: package allUnsentMessages equals: (#('nonexistingMethodName1' 'nonexistingMethodName3' 'nonexistingMethodName4') collect: #asSymbol) asSet.
 ]
 
 { #category : #tests }

--- a/src/System-Support/RPackage.extension.st
+++ b/src/System-Support/RPackage.extension.st
@@ -2,5 +2,5 @@ Extension { #name : #RPackage }
 
 { #category : #'*System-Support' }
 RPackage >> allUnsentMessages [
-	^SystemNavigation new allUnsentMessagesIn: (self methods collect: [ :cm | cm selector ])
+	^SystemNavigation new allUnsentMessagesIn: (self methods collect: [ :cm | cm selector ]) asSet
 ]


### PR DESCRIPTION
when  using #allUnsentMessages on a Package, selectors that are the same in different classes are reported multiple times. This is not what we want.