### PR TITLE
deprecate-parseCompiledMethod

### DIFF
--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -33,11 +33,6 @@ RBParser class >> errorNodeBlock [
 	^ [ :aString :position :parser| parser parseErrorNode: aString ]
 ]
 
-{ #category : #accessing }
-RBParser class >> parseCompiledMethod: aCompiledMethod [
-	^ self parseMethod: aCompiledMethod sourceCode
-]
-
 { #category : #parsing }
 RBParser class >> parseExpression: aString [ 
 	^self parseExpression: aString onError: nil

--- a/src/Deprecated90/RBParser.extension.st
+++ b/src/Deprecated90/RBParser.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #RBParser }
+
+{ #category : #'*Deprecated90' }
+RBParser class >> parseCompiledMethod: aCompiledMethod [
+	self 
+		deprecated: 'use #parseMethod:'
+		transformWith:  '`@receiver parseCompiledMethod: `@arg' -> '`@receiver parseMethod: `@arg' sourceCode.
+	^ self parseMethod: aCompiledMethod sourceCode
+]


### PR DESCRIPTION
RBParser>>parseCompiledMethod: is not needed as the client can just use parseMethod:.

There are no users of it