### PR TITLE
[Disable Flaky Tests] Disable two Zinc flaky tests

### DIFF
--- a/src/Zinc-Tests/ZnEasyTest.class.st
+++ b/src/Zinc-Tests/ZnEasyTest.class.st
@@ -44,6 +44,9 @@ ZnEasyTest >> testGetJpeg [
 { #category : #testing }
 ZnEasyTest >> testGetPng [
 	| url result |
+	self flag: #flakyTest.
+	self skip.
+	
 	url := 'http://pharo.org/files/pharo.png'.
 	result := ZnEasy getPng: url.
 	self assert: result isForm

--- a/src/Zinc-Tests/ZnImageExampleDelegateTest.class.st
+++ b/src/Zinc-Tests/ZnImageExampleDelegateTest.class.st
@@ -14,6 +14,9 @@ ZnImageExampleDelegateTest >> image [
 
 { #category : #testing }
 ZnImageExampleDelegateTest >> testDefaultImage [
+	self flag: #flakyTest.
+	self skip.
+	
 	self withServerDo: [ :server |
 		| client |
 		client := ZnClient new.


### PR DESCRIPTION
Let's make it a convention to disable detected flaky tests with accompanying PR to enable them back.
The "disable PR" can be quickly merged to protect CI from new failures.
From the other side the "enable PR" will record the problem and track its state. In case of current Zinc issue it is always wailing on CI and therefore PR will have really good indication of problem.