### PR TITLE
[Enable Flaky Tests] Enable two Zinc flaky tests

### DIFF
--- a/src/Zinc-Tests/ZnEasyTest.class.st
+++ b/src/Zinc-Tests/ZnEasyTest.class.st
@@ -44,6 +44,9 @@ ZnEasyTest >> testGetJpeg [
 { #category : #testing }
 ZnEasyTest >> testGetPng [
 	| url result |
+	self flag: #flakyTest.
+	self skip.
+	
 	url := 'http://pharo.org/files/pharo.png'.
 	result := ZnEasy getPng: url.
 	self assert: result isForm

--- a/src/Zinc-Tests/ZnEasyTest.class.st
+++ b/src/Zinc-Tests/ZnEasyTest.class.st
@@ -44,8 +44,6 @@ ZnEasyTest >> testGetJpeg [
 { #category : #testing }
 ZnEasyTest >> testGetPng [
 	| url result |
-	self flag: #flakyTest.
-	self skip.
 	
 	url := 'http://pharo.org/files/pharo.png'.
 	result := ZnEasy getPng: url.

--- a/src/Zinc-Tests/ZnImageExampleDelegateTest.class.st
+++ b/src/Zinc-Tests/ZnImageExampleDelegateTest.class.st
@@ -14,6 +14,9 @@ ZnImageExampleDelegateTest >> image [
 
 { #category : #testing }
 ZnImageExampleDelegateTest >> testDefaultImage [
+	self flag: #flakyTest.
+	self skip.
+	
 	self withServerDo: [ :server |
 		| client |
 		client := ZnClient new.

--- a/src/Zinc-Tests/ZnImageExampleDelegateTest.class.st
+++ b/src/Zinc-Tests/ZnImageExampleDelegateTest.class.st
@@ -14,8 +14,6 @@ ZnImageExampleDelegateTest >> image [
 
 { #category : #testing }
 ZnImageExampleDelegateTest >> testDefaultImage [
-	self flag: #flakyTest.
-	self skip.
 	
 	self withServerDo: [ :server |
 		| client |


### PR DESCRIPTION
it is accompanying PR for #6497 to record and track the state of flaky zinc tests. 