### PR TITLE
[Flaky Test] Rely on SUnit time limit in recursion stopper tests. 

### DIFF
--- a/src/Kernel-Tests/LocalRecursionStopperTest.class.st
+++ b/src/Kernel-Tests/LocalRecursionStopperTest.class.st
@@ -11,6 +11,14 @@ Class {
 	#category : #'Kernel-Tests-Processes'
 }
 
+{ #category : #running }
+LocalRecursionStopperTest class >> defaultTimeout [
+	"Those tests are supposed to be fast. 
+	But with broken LocalRecursionStopper they will hang the image.
+	Therefore this small allowed time for tests to fail quickly if they are broken"
+	^100 milliSeconds 
+]
+
 { #category : #accessing }
 LocalRecursionStopperTest >> complexRecursion [
 	
@@ -76,7 +84,7 @@ LocalRecursionStopperTest >> testMixedMethod [
 
 	| result |
 
-	self should: [ result := self mixedMethod ] notTakeMoreThanMilliseconds: 3.
+	result := self mixedMethod.
 	
 	self assert: result equals: 2
 ]
@@ -92,11 +100,11 @@ LocalRecursionStopperTest >> testNoRecursion [
 { #category : #tests }
 LocalRecursionStopperTest >> testWithComplexRecursion [
 
-	self should: [ self complexRecursion ] notTakeMoreThanMilliseconds: 3.
+	self complexRecursion
 ]
 
 { #category : #tests }
 LocalRecursionStopperTest >> testWithRecursion [
 
-	self should: [ self recursion ] notTakeMoreThanMilliseconds: 3.
+	self recursion
 ]

--- a/src/Kernel-Tests/RecursionStopperTest.class.st
+++ b/src/Kernel-Tests/RecursionStopperTest.class.st
@@ -11,6 +11,14 @@ Class {
 	#category : #'Kernel-Tests-Processes'
 }
 
+{ #category : #running }
+RecursionStopperTest class >> defaultTimeout [
+	"Those tests are supposed to be fast. 
+	But with broken RecursionStopper they will hang the image.
+	Therefore this small allowed time for tests to fail quickly if they are broken"
+	^100 milliSeconds 
+]
+
 { #category : #accessing }
 RecursionStopperTest >> mixedMethod [
 
@@ -58,7 +66,7 @@ RecursionStopperTest >> testMixedMethod [
 
 	| result |
 
-	self should: [ result := self mixedMethod ] notTakeMoreThanMilliseconds: 3.
+	result := self mixedMethod.
 	
 	self assert: result equals: 2
 ]
@@ -74,7 +82,7 @@ RecursionStopperTest >> testNoRecursion [
 { #category : #tests }
 RecursionStopperTest >> testWithRecursion [
 
-	self should: [ self recursion ] notTakeMoreThanMilliseconds: 3.
+	self recursion
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Recursion stopper tests were flaky due to very small time in assertions.
Here I removed time assertions. Tests will rely on SUnit time restriction with explicit small value for these tests.