### PR TITLE
SDL Driver - Clean and Document; DO NOT INTEGRATE YET

### DIFF
--- a/src/OSWindow-Core/OSWindowDriver.class.st
+++ b/src/OSWindow-Core/OSWindowDriver.class.st
@@ -1,15 +1,13 @@
 "
 I am a basic (abstract) class, which represents an OS window driver.
-The driver connects an OSWindow instances with underlaying operating system window(s) through managing OSWindowHandle(s). Driver provides an implemenation of all OSWindow functionality, starting from its creation, setting/retrieving its attributes, and finishing with event handling and/or rendering window's contents on screen.
+The driver connects OSWindow instances with underlying operating system window(s) by managing OSWindowHandle(s). I provide an implemenation of all OSWindow functionality - window creation, setting/retrieving attributes, and event handling and/or rendering its contents on the screen.
 
-The driver connects OSWindow(s) with operating system windows by providing the handle (see OSWindowHandle). The way how various OSWindow features and API are implemented is up to the concrete driver and thus considered private.
+The implementation of OSWindow features and API is up to the concrete driver and is considered private.
 
-The driver(s) responsible for initial window creation , proper setup and and managing external resources. 
-Again, most of driver's functionality is considered private and application-level code should not rely on any of its features. 
+The driver(s) are responsible for initial window creation, proper setup and managing external resources. 
+Again, most of a driver's functionality is considered private and application-level code should not rely on any of its features. 
 
-Driver selection mechanism:
-
- - on session change, i scan all of my subclasses to pick a most suitable driver which will be used on current platform (see #current on my class side)
+Driver selection mechanism: on session change, I scan all of my subclasses to pick the most suitable driver for the current platform (see #current on my class side)
 "
 Class {
 	#name : #OSWindowDriver,

--- a/src/OSWindow-SDL2/OSSDL2BackendWindowForTesting.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindowForTesting.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #OSSDL2BackendWindowForTesting,
+	#superclass : #OSSDL2BackendWindow,
+	#instVars : [
+		'receivedMessages'
+	],
+	#category : #'OSWindow-SDL2-Tests'
+}
+
+{ #category : #'event handling' }
+OSSDL2BackendWindowForTesting >> deliverGlobalEvent: e [
+	self receivedMessages add: (Message selector: #deliverGlobalEvent: argument: e)
+]
+
+{ #category : #'as yet unclassified' }
+OSSDL2BackendWindowForTesting >> receivedMessages [
+	^ receivedMessages ifNil: [ receivedMessages := Dictionary new ]
+]

--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -1,5 +1,5 @@
 "
-A window driver used for running things using SDL2 library
+A window driver for the SDL2 library
 "
 Class {
 	#name : #OSSDL2Driver,
@@ -62,11 +62,11 @@ OSSDL2Driver >> closeRemovedJoystick: index [
 OSSDL2Driver >> convertEvent: sdlEvent [
 	| mappedEvent window |
 	
-	mappedEvent := sdlEvent mapped ifNil: [ ^ nil ].
+	mappedEvent := sdlEvent mapped.
 	mappedEvent windowID ifNil: [ ^ self sendEventWithoutWindow: mappedEvent ].
 	
-	WindowMapMutex critical: [ 
-		window := WindowMap at: mappedEvent windowID ifAbsent: [ ^ nil ].
+	self windowMapMutex critical: [ 
+		window := self windowMap at: mappedEvent windowID ifAbsent: [ ^ nil ].
 	].
 
 	^ window handleNewSDLEvent: mappedEvent.
@@ -135,6 +135,16 @@ OSSDL2Driver >> evaluateUserInterrupt: anSDLEvent [
 		and: [(anSDLEvent keysym mod anyMask: 1344) 
 		and: [ anSDLEvent keysym scancode = 55 ] ]])
 		ifTrue: [ UserInterruptHandler new handleUserInterrupt ]
+]
+
+{ #category : #private }
+OSSDL2Driver >> eventLoopBlock [
+	^ self class isVMDisplayUsingSDL2 
+			ifTrue: [ [ self eventLoopProcessWithVMWindow ] ] 
+			ifFalse: [ 
+				self class hasPlugin 
+					ifTrue: [ [ self eventLoopProcessWithPlugin ] ]
+					ifFalse: [ [ self eventLoopProcessWithoutPlugin ] ] ].
 ]
 
 { #category : #'events-processing' }
@@ -259,12 +269,12 @@ OSSDL2Driver >> primitiveSetVMSDL2Input: semaIndex [
 ]
 
 { #category : #'events-processing' }
-OSSDL2Driver >> processEvent: sdlEvent [
+OSSDL2Driver >> processEvent: anSDL_Event [
 	| event |
 			
 	[  
-		event := self convertEvent: sdlEvent.	
-		self evaluateUserInterrupt: sdlEvent mapped.
+		event := self convertEvent: anSDL_Event.	
+		self evaluateUserInterrupt: anSDL_Event mapped.
 		event ifNotNil: [ eventQueue nextPut: event ].
 	] on: Error do: [ :err | 
 		"It is critical, that event handling keep running despite errors.
@@ -288,6 +298,14 @@ OSSDL2Driver >> registerWindow: aBackendWindow [
 	WindowMap at: aBackendWindow sdl2Window windowID put: aBackendWindow
 ]
 
+{ #category : #private }
+OSSDL2Driver >> resetEventLoopProcess [
+	(EventLoopProcess isNil or: [ EventLoopProcess isTerminating ]) ifTrue: [ ^ self ].
+	
+	EventLoopProcess terminate. 
+	EventLoopProcess := nil
+]
+
 { #category : #'global events' }
 OSSDL2Driver >> sendEventWithoutWindow: event [
 	| converted |
@@ -295,8 +313,8 @@ OSSDL2Driver >> sendEventWithoutWindow: event [
 	converted ifNil: [ ^ self ].
 	globalListeners do: [ :list | list handleEvent: converted ].
 	self flag: #pharoFixMe. "Avoid holding the mutex for so long".	
-	WindowMapMutex critical: [
-		WindowMap valuesDo: [ :window | window deliverGlobalEvent: converted ].
+	self windowMapMutex critical: [
+		self windowMap valuesDo: [ :window | window deliverGlobalEvent: converted ].
 	]
 ]
 
@@ -321,23 +339,12 @@ OSSDL2Driver >> setGLAttributes: glAttributes [
 
 { #category : #'events-processing' }
 OSSDL2Driver >> setupEventLoop [
-	EventLoopProcess ifNotNil: [ 
-		EventLoopProcess isTerminating ifFalse: [EventLoopProcess terminate. EventLoopProcess := nil] ].
-	EventLoopProcess := self class isVMDisplayUsingSDL2 ifTrue: [ 
-		[ self eventLoopProcessWithVMWindow ] 
-		forkAt: Processor lowIOPriority
-	] ifFalse: [ 
-		self class hasPlugin ifTrue: [ 
-			[ self eventLoopProcessWithPlugin ] 
-			forkAt: Processor lowIOPriority ]
-		ifFalse: [ 
-			[ self eventLoopProcessWithoutPlugin ] 
-			forkAt: Processor lowIOPriority ].
-	].
+	self resetEventLoopProcess.
 
-	EventLoopProcess
+	EventLoopProcess := (self eventLoopBlock forkAt: Processor lowIOPriority)
 		name: 'SDL2 Event loop';
-		resume
+		resume;
+		yourself
 ]
 
 { #category : #'system startup' }
@@ -347,7 +354,7 @@ OSSDL2Driver >> shutDown [
 
 	WindowMap := nil.
 	JoystickMap := nil.
-	EventLoopProcess ifNotNil: [ EventLoopProcess terminate ].	
+	self resetEventLoopProcess
 ]
 
 { #category : #'global events' }
@@ -532,4 +539,14 @@ OSSDL2Driver >> visitJoyDeviceRemovedEvent: joyEvent [
 { #category : #'global events' }
 OSSDL2Driver >> visitQuitEvent: quitEvent [
 	^ nil
+]
+
+{ #category : #private }
+OSSDL2Driver >> windowMap [
+	^ WindowMap
+]
+
+{ #category : #'as yet unclassified' }
+OSSDL2Driver >> windowMapMutex [
+	^ WindowMapMutex
 ]

--- a/src/OSWindow-SDL2/OSSDL2DriverForTesting.class.st
+++ b/src/OSWindow-SDL2/OSSDL2DriverForTesting.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : #OSSDL2DriverForTesting,
+	#superclass : #OSSDL2Driver,
+	#instVars : [
+		'windowMap'
+	],
+	#category : #'OSWindow-SDL2-Tests'
+}
+
+{ #category : #private }
+OSSDL2DriverForTesting >> critical: aBlock [
+	^ aBlock value
+]
+
+{ #category : #private }
+OSSDL2DriverForTesting >> windowMap [
+	^ windowMap ifNil: [ windowMap := Dictionary new ]
+]
+
+{ #category : #private }
+OSSDL2DriverForTesting >> windowMapMutex [
+	^ self
+]

--- a/src/OSWindow-SDL2/OSSDL2DriverTest.class.st
+++ b/src/OSWindow-SDL2/OSSDL2DriverTest.class.st
@@ -1,0 +1,76 @@
+Class {
+	#name : #OSSDL2DriverTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'mockedClasses'
+	],
+	#category : #'OSWindow-SDL2-Tests'
+}
+
+{ #category : #'as yet unclassified' }
+OSSDL2DriverTest >> mock: anOSSDL2BackendWindowForTesting [ 
+	
+	self mockedClasses add: anOSSDL2BackendWindowForTesting class.
+	anOSSDL2BackendWindowForTesting class methods do: [ :cm |
+		| link |
+		link := MetaLink new
+			metaObject: self;
+			selector: #message:withArguments:receivedBy:;
+			arguments: #(selector arguments receiver);
+			control: #before;
+			yourself.
+		cm ast link: link ]
+]
+
+{ #category : #'as yet unclassified' }
+OSSDL2DriverTest >> mockedClasses [
+	^ mockedClasses ifNil: [ mockedClasses := Set new ]
+]
+
+{ #category : #'as yet unclassified' }
+OSSDL2DriverTest >> tearDown [
+	self mockedClasses do: [ :e | e recompile ]
+]
+
+{ #category : #tests }
+OSSDL2DriverTest >> testConvertEvent [
+	| sdlEvent driver window result |
+	sdlEvent := SDL_Event exampleKeyDownEvent.
+	driver := OSSDL2DriverForTesting basicNew.
+	window := OSSDL2BackendWindowForTesting new.
+	self mock: window.
+	driver windowMap at: sdlEvent mapped windowID put: window.
+	result := driver convertEvent: sdlEvent.
+	self assert: (window receivedMessages includes: (1)).
+]
+
+{ #category : #tests }
+OSSDL2DriverTest >> testConvertEventWithInvalidWindowID [
+	| sdlEvent driver window result |
+	sdlEvent := SDL_Event exampleKeyDownEventInvalidWindowID.
+	driver := OSSDL2DriverForTesting basicNew.
+	window := OSSDL2BackendWindowForTesting new.
+	driver windowMap at: sdlEvent mapped windowID + 1 put: window.
+	result := driver convertEvent: sdlEvent.
+	self assert: result isNil.
+	self assert: (window receivedMessages includes: (1)).
+]
+
+{ #category : #tests }
+OSSDL2DriverTest >> testProcessEvent [
+	| sdlEvent driver |
+	sdlEvent := SDL_Event exampleKeyDownEvent.
+	driver := OSSDL2DriverForTesting basicNew.
+	driver processEvent: sdlEvent.
+	self assert: false.
+]
+
+{ #category : #tests }
+OSSDL2DriverTest >> testProcessEventWithInvalidWindowID [
+	| sdlEvent driver |
+	sdlEvent := SDL_Event exampleKeyDownEventInvalidWindowID.
+	driver := OSSDL2Driver basicNew.
+	(driver convertEvent: sdlEvent) inspect.
+	driver processEvent: sdlEvent.
+	self assert: false.
+]

--- a/src/OSWindow-SDL2/SDL_Event.class.st
+++ b/src/OSWindow-SDL2/SDL_Event.class.st
@@ -1,5 +1,11 @@
 "
-This is a raw SDL2 event
+I am a raw SDL2 event. 
+
+To understand my purpose, it's important to know that, in SDL2, multiple related ""event types"" often reuse the same struct to represent their event. For example, both the SDL_KEYDOWN and SDL_KEYUP types use the SDL_KeyboardEvent structure. Fundamentally, I map such an event type to its appropriate structure.
+
+From the Pharo perspective, my SDL2 implementation might seem a bit odd. I am an external C union with one field for each and every type of SDL2 event, so although I'm called an ""event"", I'm really a collection containing an instance of every event type. Since only one of my elements is relevant for any particular event (the rest can be ignored), I also provide the event ""type"" code (a C uint) to specify that element. In SDL2, the user would usually then have to take that code and manually map it to my correct element (the documentation suggests a giant switch statement - yay!), but luckily, in Pharo, I can be #mapped, which will return an instance of the correct event struct that will represent my individual ""event"".
+
+For further information, see the documentation at https://wiki.libsdl.org/SDL_Event of which this comment is a synopsis.
 "
 Class {
 	#name : #'SDL_Event',
@@ -9,6 +15,26 @@ Class {
 	],
 	#category : #'OSWindow-SDL2-Bindings'
 }
+
+{ #category : #examples }
+SDL_Event class >> exampleKeyDownEvent [
+	<sampleInstance>
+	^ SDL_KeyDownEvent example
+]
+
+{ #category : #examples }
+SDL_Event class >> exampleKeyDownEventInvalidWindowID [
+	<sampleInstance>
+	^ SDL_KeyDownEvent exampleWithInvalidWindowID
+]
+
+{ #category : #examples }
+SDL_Event class >> exampleUnknownEvent [
+	<sampleInstance>
+	^ self new
+		type: 0;
+		yourself
+]
 
 { #category : #'class initialization' }
 SDL_Event class >> initialize [
@@ -37,15 +63,18 @@ SDL_Event >> initialize [
 
 { #category : #accessing }
 SDL_Event >> mapped [
-	^ (EventTypeMap at: self type ifAbsent: [ ^ self unknownEvent ]) fromSdlEvent: self
+	| eventClass |
+	eventClass := EventTypeMap at: self type ifAbsent: [ SDL_CommonEvent ].
+	^ eventClass fromSdlEvent: self
 ]
 
 { #category : #accessing }
 SDL_Event >> type [
-	^self getHandle nbUInt32AtOffset: 0
+	^self getHandle uint32AtOffset: 0
 ]
 
-{ #category : #accessing }
-SDL_Event >> unknownEvent [
-	^ SDL_CommonEvent fromSdlEvent: self
+{ #category : #private }
+SDL_Event >> type: anInteger [
+	"Useful for testing e.g. creating dummy events"
+	^ self getHandle uint32AtOffset: 0 put: anInteger
 ]

--- a/src/OSWindow-SDL2/SDL_EventTest.class.st
+++ b/src/OSWindow-SDL2/SDL_EventTest.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #'SDL_EventTest',
+	#superclass : #TestCase,
+	#category : #'OSWindow-SDL2-Tests'
+}
+
+{ #category : #tests }
+SDL_EventTest >> testMapEvent [
+	self assert: SDL_Event exampleKeyDownEvent mapped class equals: SDL_KeyDownEvent.
+]
+
+{ #category : #tests }
+SDL_EventTest >> testMapUnknownEvent [
+	self assert: SDL_Event exampleUnknownEvent mapped class equals: SDL_CommonEvent
+]

--- a/src/OSWindow-SDL2/SDL_KeyDownEvent.class.st
+++ b/src/OSWindow-SDL2/SDL_KeyDownEvent.class.st
@@ -12,6 +12,29 @@ SDL_KeyDownEvent class >> eventType [
 	^ SDL_KEYDOWN
 ]
 
+{ #category : #examples }
+SDL_KeyDownEvent class >> example [
+	<sampleInstance>
+	^ self exampleWithWindowID: 1
+]
+
+{ #category : #examples }
+SDL_KeyDownEvent class >> exampleWithInvalidWindowID [
+	<sampleInstance>
+	^ self exampleWithWindowID: 0
+]
+
+{ #category : #examples }
+SDL_KeyDownEvent class >> exampleWithWindowID: anInteger [
+	
+	| rawEvent |
+	rawEvent := SDL_Event new
+		type: self eventType;
+		yourself.
+	rawEvent mapped windowID: anInteger.
+	^ rawEvent
+]
+
 { #category : #visitor }
 SDL_KeyDownEvent >> accept: aVisitor [
 	^ aVisitor visitKeyDownEvent: self


### PR DESCRIPTION
## Questions
1. How are FFIStructures like SDL_QuitEvent "automatically generated as per the method comments? That's pretty cool, @Esteban Lorenzano!!
1. For OSSDL2Driver, what is the purpose of the eventQueue? Events are (sometimes) stored there, but don't ever seem to be accessed. In fact there are not even any other references to that instVar...
1. Related to 2 above, the event is not placed in the queue if convertEvent: returns nil. Two ways that could apparently happen:
    1. The window map doesn't have a window with the ID specified by the event, but under what circumstances would an event arrive in that condition?
    1. window handleNewSDLEvent: mappedEvent returns nil, but why would a window do that? Does that signify something in the domain?

## Documentation Stubs
OSSDL2Driver is the primary “behind the scenes” object that connects Pharo to the SDL2 library (SDL). During its initialization, it starts an event loop (ultimately by sending itself a variant of eventLoopProcessXYZ). This event loop receives an SDL_Event structure from SDL and maps it to a SDL2MappedEvent subclass, using SDL_CommonEvent for “unknown” events i.e. those with no specific mapping (so in convertEvent:, how could the nil check be reached?). If the event does not specify a target window, sendEventWithoutWindow: then further converts it to anOSEvent before sending it to all windows, as well as any registered global listeners.

Why is SDL_TouchFingerDownEvent translated to OSTouchActionPointerDownEvent? What, if anything, is the distinction between “finger” and “action pointer”?

Individual gestures could register themselves and pass interesting events to their own handler, but much duplicated effort would be done e.g. keeping track of fingers. Another way, is to just register a single OSWindowGestureHandler instance, which then registers gestures via registerGesture:.


