### PR TITLE
6503-senders-of-copyAt-smells-like-dead-code

### DIFF
--- a/src/Tool-FileList/FileList.class.st
+++ b/src/Tool-FileList/FileList.class.st
@@ -287,10 +287,7 @@ FileList >> acceptDroppingMorph: aTransferMorph event: evt inMorph: dest [
 		response ifFalse: [ ^false ].
 	].
 
-	aTransferMorph shouldCopy
-		ifTrue: [ oldEntry copyAs: newEntry ]
-		ifFalse: [ oldEntry renameTo: newEntry ].
-
+   oldEntry renameTo: newEntry.
 	self updateFileList; fileListIndex: 0.
 
 	aTransferMorph source model ~= self


### PR DESCRIPTION
remove send of non-existing selector. fixes #6503