### PR TITLE
CompiledMethod-comments-simpler

### DIFF
--- a/src/AST-Core/CompiledMethod.extension.st
+++ b/src/AST-Core/CompiledMethod.extension.st
@@ -10,7 +10,7 @@ CompiledMethod >> ast [
 CompiledMethod >> comments [
 	"Answer a collection of strings representing the comments in the method. Return an empty collection if the method's source code does not contain a comment."
 
-	^ self ast allComments flatCollect: [:c| c contents]
+	^ self ast allComments collect: [:c| c contents]
 ]
 
 { #category : #'*AST-Core' }

--- a/src/AST-Core/CompiledMethod.extension.st
+++ b/src/AST-Core/CompiledMethod.extension.st
@@ -10,7 +10,7 @@ CompiledMethod >> ast [
 CompiledMethod >> comments [
 	"Answer a collection of strings representing the comments in the method. Return an empty collection if the method's source code does not contain a comment."
 
-	^ self ast allChildren flatCollect: [:el| el comments collect: [:c| c contents]]
+	^ self ast allComments flatCollect: [:c| c contents]
 ]
 
 { #category : #'*AST-Core' }


### PR DESCRIPTION
now that we have #allComments, CompiledMethod>>comments can be simplifies. This now makes now obvious that the API needs to be improved as #comments on the method and the AST now have different meaning.  This PR does not fix that, it's goal is just to simplify the code.