### PR TITLE
scanTokens-can-call-scanTokensObjects

### DIFF
--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -102,6 +102,15 @@ RBParser class >> parseMethodPattern: aString [
 ]
 
 { #category : #parsing }
+RBParser class >> parsePragma: aString [
+
+	| parser |
+	parser := self new.
+	parser initializeParserWith: aString.
+	^ parser parsePragmaAndReturn
+]
+
+{ #category : #parsing }
 RBParser class >> parseRewriteExpression: aString [ 
 	^self parseRewriteExpression: aString onError: nil
 ]

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -165,10 +165,8 @@ RBScanner class >> scanTokenObjects: aStringOrStream [
 { #category : #'public api' }
 RBScanner class >> scanTokens: aStringOrStream [
 	"Return the tokens (and not the scanner token objects)."
-	
-	| scanner |
-	scanner := self on: aStringOrStream readStream.
-	^scanner contents collect:[ :t | t value ]
+
+	^ (self scanTokenObjects: aStringOrStream) collect: [ :t | t value ]
 ]
 
 { #category : #testing }

--- a/src/Refactoring2-Transformations/RBParser.extension.st
+++ b/src/Refactoring2-Transformations/RBParser.extension.st
@@ -1,15 +1,6 @@
 Extension { #name : #RBParser }
 
 { #category : #'*Refactoring2-Transformations' }
-RBParser class >> parsePragma: aString [
-
-	| parser |
-	parser := self new.
-	parser initializeParserWith: aString.
-	^ parser parsePragmaAndReturn
-]
-
-{ #category : #'*Refactoring2-Transformations' }
 RBParser >> parsePragmaAndReturn [
 
 	self parsePragma.


### PR DESCRIPTION
- Implement scanTokens: in terms of #scanObjectTokens:
- RBParser class>>#parsePragma is an extenion method but already used elsewhere --> move to API