### PR TITLE
2873-Critiques---Temporaries-read-before-written-versus-nil-checking-messages

### DIFF
--- a/src/AST-Core/RBReadBeforeWrittenTester.class.st
+++ b/src/AST-Core/RBReadBeforeWrittenTester.class.st
@@ -188,7 +188,7 @@ RBReadBeforeWrittenTester >> visitBlockNode: aBlockNode [
 
 { #category : #visiting }
 RBReadBeforeWrittenTester >> visitMessageNode: aMessageNode [ 
-	((#(#whileTrue: #whileFalse: #whileTrue #whileFalse) 
+	((#(#whileTrue: #whileFalse: #whileTrue #whileFalse #whileNil:) 
 		includes: aMessageNode selector) and: [aMessageNode receiver isBlock]) 
 		ifTrue: [self executeTree: aMessageNode receiver body]
 		ifFalse: 


### PR DESCRIPTION
add #whileNil: to the list of filtered messages in RBReadBeforeWrittenTester. fixes #2873