### PR TITLE
6541-defaultTimeout-has-no-senders-The-method-for-tests-is-called-defaultTimeLimit

### DIFF
--- a/src/Kernel-Tests/LocalRecursionStopperTest.class.st
+++ b/src/Kernel-Tests/LocalRecursionStopperTest.class.st
@@ -12,7 +12,7 @@ Class {
 }
 
 { #category : #running }
-LocalRecursionStopperTest class >> defaultTimeout [
+LocalRecursionStopperTest class >> defaultTimeLimit [
 	"Those tests are supposed to be fast. 
 	But with broken LocalRecursionStopper they will hang the image.
 	Therefore this small allowed time for tests to fail quickly if they are broken"

--- a/src/Kernel-Tests/RecursionStopperTest.class.st
+++ b/src/Kernel-Tests/RecursionStopperTest.class.st
@@ -12,7 +12,7 @@ Class {
 }
 
 { #category : #running }
-RecursionStopperTest class >> defaultTimeout [
+RecursionStopperTest class >> defaultTimeLimit [
 	"Those tests are supposed to be fast. 
 	But with broken RecursionStopper they will hang the image.
 	Therefore this small allowed time for tests to fail quickly if they are broken"

--- a/src/Metacello-Core/MetacelloPlatform.class.st
+++ b/src/Metacello-Core/MetacelloPlatform.class.st
@@ -245,12 +245,6 @@ MetacelloPlatform >> defaultRepositoryDescription [
     ^ 'http://www.squeaksource.com/MetacelloRepository'
 ]
 
-{ #category : #tests }
-MetacelloPlatform >> defaultTimeout [
-	"squeak compatability"
-	^60
-]
-
 { #category : #'file system' }
 MetacelloPlatform >> deleteFileNamed: filePath [
 	(self fileDirectoryClass on: filePath) containingDirectory deleteFileNamed: (self fileDirectoryClass localNameFor: filePath)

--- a/src/Metacello-TestsMC/MetacelloDictionaryRepositoryTest.class.st
+++ b/src/Metacello-TestsMC/MetacelloDictionaryRepositoryTest.class.st
@@ -24,12 +24,6 @@ MetacelloDictionaryRepositoryTest >> configurationRepository [
 ]
 
 { #category : #running }
-MetacelloDictionaryRepositoryTest >> defaultTimeout [
-	"I don't want no stkinkin' timeouts"
-	^60000
-]
-
-{ #category : #running }
 MetacelloDictionaryRepositoryTest >> doSilently [
 
 	^true

--- a/src/Metacello-TestsMC/MetacelloScriptingStdTstHarnessTestCase.class.st
+++ b/src/Metacello-TestsMC/MetacelloScriptingStdTstHarnessTestCase.class.st
@@ -10,12 +10,6 @@ Class {
 }
 
 { #category : #running }
-MetacelloScriptingStdTstHarnessTestCase >> defaultTimeout [
-	"I don't want no stkinkin' timeouts"
-	^60000
-]
-
-{ #category : #running }
 MetacelloScriptingStdTstHarnessTestCase >> disableUndefinedSymbolTracking [
   "significant perfomance improvement"
 


### PR DESCRIPTION
- remove all defaultTimeLimit that make no sense, change the ones in tests to be #defaultTimeLimit

fixes #6541