### PR TITLE
add-Slot-and-Variable-tooDangerousClasses

### DIFF
--- a/src/Shift-ClassBuilder/DangerousClassNotifier.class.st
+++ b/src/Shift-ClassBuilder/DangerousClassNotifier.class.st
@@ -95,5 +95,7 @@ DangerousClassNotifier class >> tooDangerousClasses [
 		#InstructionStream #Context #BlockClosure #CompiledMethod #CompiledCode #CompiledBlock
 		"UndefinedObject crashes the VM"
 		#UndefinedObject
+		"Variables"
+		#Slot #Variable
 	)
 ]


### PR DESCRIPTION
Slot and Variable have to warn when someone wants to change the class layout (e.g. adding ivars)

Variable can not get more ivars as the second has to the value (so it can be used in Dictionaries).