### PR TITLE
CompiledMethod-hasComment

### DIFF
--- a/src/AST-Core-Tests/RBMethodNodeTest.class.st
+++ b/src/AST-Core-Tests/RBMethodNodeTest.class.st
@@ -43,7 +43,15 @@ RBMethodNodeTest >> testCachingMethodArguments [
 ]
 
 { #category : #'testing-comments' }
-RBMethodNodeTest >> testCommentedMethodHasComments [
+RBMethodNodeTest >> testCommentsParent [
+	"Test if comment has a parent"
+	self
+		assert: (self class >> #testCommentsParent) ast comments first parent selector
+		equals: #testCommentsParent.
+]
+
+{ #category : #'testing-comments' }
+RBMethodNodeTest >> testHasComments [
 
 	| tree |
 	tree := self parseMethod: 'foo: abd bar: cde  
@@ -53,15 +61,12 @@ RBMethodNodeTest >> testCommentedMethodHasComments [
 
 	self assert: tree hasComments.
 	
+	tree := self parseMethod: 'foo: abd bar: cde  
+^ abd + cde'.
 
-]
+	self deny: tree hasComments.
+	
 
-{ #category : #'testing-comments' }
-RBMethodNodeTest >> testCommentsParent [
-	"Test if comment has a parent"
-	self
-		assert: (self class >> #testCommentsParent) ast comments first parent selector
-		equals: #testCommentsParent.
 ]
 
 { #category : #'tests - primitives' }
@@ -246,16 +251,4 @@ RBMethodNodeTest >> testSizeOfSignatureOfUnaryMethod [
 	self assert: tree conceptualSelectorSize equals: 'foo' size.
 	self assert: tree conceptualArgumentSize isZero.
 	self assert: tree conceptualSignatureSize equals: 'foo' size
-]
-
-{ #category : #'testing-comments' }
-RBMethodNodeTest >> testUncommentMethodDoesNotHaveComments [
-
-	| tree |
-	tree := self parseMethod: 'foo: abd bar: cde  
-^ abd + cde'.
-
-	self deny: tree hasComments.
-	
-
 ]

--- a/src/AST-Core-Tests/RBMethodNodeTest.class.st
+++ b/src/AST-Core-Tests/RBMethodNodeTest.class.st
@@ -56,6 +56,14 @@ RBMethodNodeTest >> testCommentedMethodHasComments [
 
 ]
 
+{ #category : #'testing-comments' }
+RBMethodNodeTest >> testCommentsParent [
+	"Test if comment has a parent"
+	self
+		assert: (CompiledMethodTest >> #testCommentsParent) ast comments first parent selector
+		equals: #testCommentsParent.
+]
+
 { #category : #'tests - primitives' }
 RBMethodNodeTest >> testIsPrimitive [
 	"see other testPrimitive... tests"

--- a/src/AST-Core-Tests/RBMethodNodeTest.class.st
+++ b/src/AST-Core-Tests/RBMethodNodeTest.class.st
@@ -60,7 +60,7 @@ RBMethodNodeTest >> testCommentedMethodHasComments [
 RBMethodNodeTest >> testCommentsParent [
 	"Test if comment has a parent"
 	self
-		assert: (CompiledMethodTest >> #testCommentsParent) ast comments first parent selector
+		assert: (self class >> #testCommentsParent) ast comments first parent selector
 		equals: #testCommentsParent.
 ]
 

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -405,6 +405,11 @@ CompiledMethodTest >> testEqualityInstanceSideMethod [
 	self assert: method1 equals: method2
 ]
 
+{ #category : #'tests - testing' }
+CompiledMethodTest >> testHasComment [
+	self assert: (CompiledMethod>>#hasComment) hasComment
+]
+
 { #category : #'tests - instance variable' }
 CompiledMethodTest >> testHasInstVarRef [
 		

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -313,15 +313,6 @@ CompiledMethodTest >> testComments [
 ]
 
 { #category : #'tests - accessing' }
-CompiledMethodTest >> testCommentsParent [
-	"Test if comment has a parent"
-	self
-		assert: (CompiledMethodTest >> #testCommentsParent) ast comments first parent selector
-		equals: #testCommentsParent.
-	
-]
-
-{ #category : #'tests - accessing' }
 CompiledMethodTest >> testComparison [
 	| method1 method2 |
 	method1 := Float class >> #nan.

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -448,6 +448,12 @@ CompiledMethod >> getSourceReplacingSelectorWith: newSelector [
 	^newSource
 ]
 
+{ #category : #testing }
+CompiledMethod >> hasComment [
+	"check if this method has a method comment"
+	^self comment isEmptyOrNil not
+]
+
 { #category : #'accessing-pragmas & properties' }
 CompiledMethod >> hasPragmaNamed: aSymbol [
 	^ self pragmas anySatisfy: [ :pragma | pragma selector = aSymbol ]

--- a/src/System-Changes/ChangeSet.class.st
+++ b/src/System-Changes/ChangeSet.class.st
@@ -1206,7 +1206,7 @@ ChangeSet >> methodsWithoutComments [
 		(self methodChangesAtClass: aClass name) associationsDo: 
 				[:mAssoc | (#(remove addedThenRemoved) includes: mAssoc value) ifFalse:
 					[(aClass includesSelector:  mAssoc key) ifTrue:
-						[(aClass firstPrecodeCommentFor: mAssoc key) isEmptyOrNil
+						[(aClass>>mAssoc key) hasComment
 								ifTrue: [slips add: aClass name , ' ' , mAssoc key]]]]].
 	^ slips
 


### PR DESCRIPTION
ChangeSet>>#methodsWithoutComments was using #firstPrecodeCommentFor: just for testing if the method has a comment.

It is much nicer to add a method that checks if a method has a method comment and use that. This way we can easily deprecate #firstPrecodeCommentFor:  later