### PR TITLE
remove-necompletion-morphic-dependency

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -69,6 +69,7 @@ BaselineOfBasicTools >> baseline: spec [
 		spec package: 'Tool-SystemReporter'.
 		spec package: 'NECompletion'.
 		spec package: 'NECompletion-Morphic'.
+		spec package: 'NECompletion-Preferences'.
 		spec package: 'Announcements-Help'.
 		spec package: 'Metacello-FileTree'.
 		spec package: 'Metacello-Cypress'.

--- a/src/HeuristicCompletion-Model/CoCompletionContext.class.st
+++ b/src/HeuristicCompletion-Model/CoCompletionContext.class.st
@@ -53,7 +53,7 @@ CoCompletionContext >> completionAt: aNumber [
 	| entry |
 	
 	entry := (self entries at: aNumber) contents asSymbol separateKeywords.
-	^ NECPreferences spaceAfterCompletion 
+	^ NECEntry spaceAfterCompletion 
 		ifTrue: [ entry, ' ' ]
 		ifFalse: [ entry ]
 ]

--- a/src/NECompletion-Preferences/NECPreferences.class.st
+++ b/src/NECompletion-Preferences/NECPreferences.class.st
@@ -298,6 +298,12 @@ NECPreferences class >> smartCharactersWithSingleSpace: aString [
 ]
 
 { #category : #accessing }
+NECPreferences class >> spaceAfterCompletion [
+	
+	^ NECEntry spaceAfterCompletion
+]
+
+{ #category : #accessing }
 NECPreferences class >> theme [
 	self flag: #SmalltalkReference.
 	^ Smalltalk ui theme

--- a/src/NECompletion-Preferences/NECPreferences.class.st
+++ b/src/NECompletion-Preferences/NECPreferences.class.st
@@ -19,7 +19,6 @@ Class {
 		'popupShowAutomatic',
 		'popupAutomaticDelay',
 		'popupShowWithShortcut',
-		'spaceAfterCompletion',
 		'smartCharactersWithSingleSpace',
 		'smartCharactersWithDoubleSpace'
 	],
@@ -147,7 +146,7 @@ NECPreferences class >> initialize [
 	popupShowWithShortcut := self defaultPopupShortcut.
 	popupShowAutomatic := self defaultPopupShowAutomatic.
 	popupAutomaticDelay := self defaultPopupDelay.
-	spaceAfterCompletion := true
+	NECEntry spaceAfterCompletion: true
 ]
 
 { #category : #accessing }
@@ -252,6 +251,7 @@ NECPreferences class >> settingsOn: aBuilder [
 						label: 'Popup appears with this shortcut';
 						domainValues: self availablePopupShortcuts.
 					(aBuilder setting: #spaceAfterCompletion)
+						target: NECEntry;
 						default: self defaultSpaceAfterCompletion;
 						label: 'Put a space after completion'
 					 ].
@@ -295,16 +295,6 @@ NECPreferences class >> smartCharactersWithSingleSpace [
 { #category : #accessing }
 NECPreferences class >> smartCharactersWithSingleSpace: aString [
 	smartCharactersWithSingleSpace := aString
-]
-
-{ #category : #accessing }
-NECPreferences class >> spaceAfterCompletion [
-	^ spaceAfterCompletion
-]
-
-{ #category : #accessing }
-NECPreferences class >> spaceAfterCompletion: anObject [
-	spaceAfterCompletion := anObject
 ]
 
 { #category : #accessing }

--- a/src/NECompletion-Preferences/package.st
+++ b/src/NECompletion-Preferences/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'NECompletion-Preferences' }

--- a/src/NECompletion/ManifestNECompletion.class.st
+++ b/src/NECompletion/ManifestNECompletion.class.st
@@ -9,5 +9,5 @@ Class {
 
 { #category : #'meta-data - dependency analyser' }
 ManifestNECompletion class >> manuallyResolvedDependencies [
-	^ #(#'Tool-Registry' #'OpalCompiler-Core' #'System-Settings-Browser' #'Polymorph-Widgets' #'Keymapping-KeyCombinations' #'Tool-Base' #'Text-Core' #'Collections-Abstract')
+	^ #(#'Tool-Registry' #'OpalCompiler-Core' #'Tool-Base' #'Text-Core' #'Collections-Abstract')
 ]

--- a/src/NECompletion/NECEntry.class.st
+++ b/src/NECompletion/NECEntry.class.st
@@ -11,12 +11,27 @@ Class {
 		'node',
 		'description'
 	],
+	#classInstVars : [
+		'spaceAfterCompletion'
+	],
 	#category : #'NECompletion-Model'
 }
 
 { #category : #'instance creation' }
 NECEntry class >> contents: aString node: aNode [
 	^ self new contents: aString node: aNode
+]
+
+{ #category : #accessing }
+NECEntry class >> spaceAfterCompletion [
+	
+	^ spaceAfterCompletion
+]
+
+{ #category : #accessing }
+NECEntry class >> spaceAfterCompletion: aBoolean [
+
+	spaceAfterCompletion := aBoolean
 ]
 
 { #category : #operations }
@@ -30,7 +45,7 @@ NECEntry >> activateOn: aCompletionContext [
 	| entryContents |
 	"By default insert the contents of the entry instead of the token in the text editor"
 	entryContents := self contents asSymbol separateKeywords.
-	entryContents := (NECPreferences spaceAfterCompletion
+	entryContents := (self class spaceAfterCompletion
 				ifTrue: [ entryContents , ' ' ]
 				ifFalse: [ entryContents ]).
 	aCompletionContext replaceTokenInEditorWith: entryContents

--- a/src/NECompletion/NECEntry.class.st
+++ b/src/NECompletion/NECEntry.class.st
@@ -11,8 +11,8 @@ Class {
 		'node',
 		'description'
 	],
-	#classInstVars : [
-		'spaceAfterCompletion'
+	#classVars : [
+		'SpaceAfterCompletion'
 	],
 	#category : #'NECompletion-Model'
 }
@@ -25,13 +25,13 @@ NECEntry class >> contents: aString node: aNode [
 { #category : #accessing }
 NECEntry class >> spaceAfterCompletion [
 	
-	^ spaceAfterCompletion
+	^ SpaceAfterCompletion
 ]
 
 { #category : #accessing }
 NECEntry class >> spaceAfterCompletion: aBoolean [
 
-	spaceAfterCompletion := aBoolean
+	SpaceAfterCompletion := aBoolean
 ]
 
 { #category : #operations }


### PR DESCRIPTION
NECPreferences has dependencies pointing to Rubric (Morphic).Extract preferences to its own package to avoid dependencies those dependences.