### PR TITLE
6506-Behavior--methodsInProtocol-invokes-subclass-only-defined-method

### DIFF
--- a/src/Ring-Definitions-Core/Behavior.extension.st
+++ b/src/Ring-Definitions-Core/Behavior.extension.st
@@ -7,13 +7,6 @@ Behavior >> methodNamed: aSelector [
 ]
 
 { #category : #'*Ring-Definitions-Core' }
-Behavior >> methodsInProtocol: aString [
-
-	^ (self organization listAtCategoryNamed: aString) 
-			collect: [ :each | (self compiledMethodAt: each) ]
-]
-
-{ #category : #'*Ring-Definitions-Core' }
 Behavior >> protocols [
 	
 	^ self organization categories copy

--- a/src/Ring-Definitions-Core/ClassDescription.extension.st
+++ b/src/Ring-Definitions-Core/ClassDescription.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #ClassDescription }
+
+{ #category : #'*Ring-Definitions-Core' }
+ClassDescription >> methodsInProtocol: aString [
+
+	^ (self organization listAtCategoryNamed: aString) 
+			collect: [ :each | (self compiledMethodAt: each) ]
+]

--- a/src/Ring-Definitions-Core/RGBehaviorDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGBehaviorDefinition.class.st
@@ -128,6 +128,11 @@ RGBehaviorDefinition >> addSubclass: aRGBehaviorDefinition [
 		ifFalse:[ self subclasses add: aRGBehaviorDefinition ]
 ]
 
+{ #category : #accessing }
+RGBehaviorDefinition >> allInstVarNames [
+	^ self subclassResponsibility
+]
+
 { #category : #'accessing methods' }
 RGBehaviorDefinition >> allSelectors [
 	"Retrieves all the selectos of the receiver in the chain hierarchy"
@@ -369,13 +374,6 @@ RGBehaviorDefinition >> methods [
 RGBehaviorDefinition >> methods: aDictionary [
 
 	methods:= aDictionary
-]
-
-{ #category : #'accessing methods' }
-RGBehaviorDefinition >> methodsInProtocol: aString [
-	"Retrieves the methods classified in protocol named aString"
-
-	^methods select: [ :each | each protocol = aString ]
 ]
 
 { #category : #accessing }

--- a/src/Ring-Definitions-Core/RGClassDescriptionDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGClassDescriptionDefinition.class.st
@@ -126,6 +126,13 @@ RGClassDescriptionDefinition >> isSameRevisionAs: aRGClassDescriptionDefinition 
 		and:[ self instVarNames sort = aRGClassDescriptionDefinition instVarNames sort ]
 ]
 
+{ #category : #'accessing methods' }
+RGClassDescriptionDefinition >> methodsInProtocol: aString [
+	"Retrieves the methods classified in protocol named aString"
+
+	^methods select: [ :each | each protocol = aString ]
+]
+
 { #category : #organization }
 RGClassDescriptionDefinition >> organization [
 	"Answer the instance of ClassOrganizer that represents the organization 


### PR DESCRIPTION
- move #methodsInProtocol: down to ClassDescription in both Ring and Kernel
- add #allInstVarNames as subclassresponsibility in RGBehavioDefinition to fix one more rule 

fixes #6506