### PR TITLE
6564-Mac-slave-very-slow-RBRemoveClassTransformationTest-timeout

### DIFF
--- a/src/Refactoring2-Transformations-Tests/RBRemoveClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveClassTransformationTest.class.st
@@ -4,6 +4,11 @@ Class {
 	#category : #'Refactoring2-Transformations-Tests'
 }
 
+{ #category : #accessing }
+RBRemoveClassTransformationTest class >> defaultTimeLimit [
+	^20 seconds
+]
+
 { #category : #private }
 RBRemoveClassTransformationTest >> resumeIfCannotRemove: error [
 


### PR DESCRIPTION
fixes #6564.