### PR TITLE
Compiler-use-variable-not-assoc

### DIFF
--- a/src/Calypso-SystemTools-Core/OCLiteralVariable.extension.st
+++ b/src/Calypso-SystemTools-Core/OCLiteralVariable.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #OCLiteralVariable }
 OCLiteralVariable >> asCalypsoVariableOf: declarationClass [
 	"it is variable compatible object. Generally variable objects should have declaring class.
 	Then it will be not needed and simplified"
-	self isGlobalVariable ifTrue: [ ^ClyGlobalVariable on: assoc ]. 
+	self isGlobalVariable ifTrue: [ ^ClyGlobalVariable on: variable ]. 
 	
-	^ClyClassVariable on: assoc visibleFrom: scope getClass
+	^ClyClassVariable on: variable visibleFrom: scope getClass
 ]

--- a/src/Calypso-SystemTools-Core/OCUndeclaredVariable.extension.st
+++ b/src/Calypso-SystemTools-Core/OCUndeclaredVariable.extension.st
@@ -4,5 +4,5 @@ Extension { #name : #OCUndeclaredVariable }
 OCUndeclaredVariable >> asCalypsoVariableOf: declarationClass [
 	
 	"Undeclared variable behaves like a global. It is shared in all places in system"	
-	^ClyGlobalVariable on: self assoc
+	^ClyGlobalVariable on: self variable
 ]

--- a/src/ClassParser-Tests/CDExistingClassDefinitionTest.class.st
+++ b/src/ClassParser-Tests/CDExistingClassDefinitionTest.class.st
@@ -52,7 +52,7 @@ CDExistingClassDefinitionTest >> testGettingExistingClassNameBinding [
 	binding := classDefinition classNameNode binding.
 	
 	self assert: binding class equals: OCLiteralVariable. "to be compatible to bindings in RB nodes".
-	self assert: binding assoc equals: CDClassWithFullDefinitionExample binding
+	self assert: binding variable equals: CDClassWithFullDefinitionExample binding
 ]
 
 { #category : #helpers }

--- a/src/ClassParser/CDClassNameNode.class.st
+++ b/src/ClassParser/CDClassNameNode.class.st
@@ -13,7 +13,7 @@ CDClassNameNode >> binding [
 	classBinding := self existingBindingIfAbsent: [LiteralVariable key: className value: nil].
 	^OCLiteralVariable new 
 		scope: originalNode scope;
-		assoc: classBinding
+		variable: classBinding
 ]
 
 { #category : #accessing }

--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -28,7 +28,7 @@ Context >> lookupSymbol: aSymbol [
 	"Instance variables"
 	var isInstance ifTrue: [^ self receiver instVarNamed: aSymbol].
 	"Class variables and globals"
-	var isGlobal ifTrue: [ ^ var assoc value ].
+	var isGlobal ifTrue: [ ^ var variable value ].
 	^ nil.
 	
 ]

--- a/src/OpalCompiler-Core/OCASTTranslatorForEffect.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslatorForEffect.class.st
@@ -117,5 +117,5 @@ OCASTTranslatorForEffect >> visitVariableNode: aVariableNode [
 	| binding |
 	binding := aVariableNode binding.
 	(binding isLiteralVariable or: [ binding isUndeclared ])
-		ifTrue: [ methodBuilder addLiteral: binding assoc ]
+		ifTrue: [ methodBuilder addLiteral: binding variable ]
 ]

--- a/src/OpalCompiler-Core/OCClassScope.class.st
+++ b/src/OpalCompiler-Core/OCClassScope.class.st
@@ -55,8 +55,8 @@ OCClassScope >> lookupVar: name [
 	"Return a SemVar for my pool var with this name.  Return nil if none found"
 
 	^(class innerBindingOf: name) 
-		ifNotNil: [:assoc | OCLiteralVariable new 
-			assoc: assoc; 
+		ifNotNil: [:var | OCLiteralVariable new 
+			variable: var; 
 			scope: self; 
 			yourself]
 		ifNil: [ outerScope lookupVar: name] 

--- a/src/OpalCompiler-Core/OCEnvironmentScope.class.st
+++ b/src/OpalCompiler-Core/OCEnvironmentScope.class.st
@@ -38,9 +38,9 @@ OCEnvironmentScope >> lookupVar: name [
 	"Return a var with this name.  Return nil if none found"
 	name isString ifFalse: [ ^nil ].
 	
-	^(environment bindingOf: name) ifNotNil: [:assoc | 
+	^(environment bindingOf: name) ifNotNil: [:var | 
 		OCLiteralVariable new 
-			assoc: assoc; 
+			variable: var; 
 			scope: self; 
 			yourself]
 

--- a/src/OpalCompiler-Core/OCExtraBindingScope.class.st
+++ b/src/OpalCompiler-Core/OCExtraBindingScope.class.st
@@ -40,9 +40,9 @@ OCExtraBindingScope >> lookupVar: name [
 	name = 'super' ifTrue: [ ^ outerScope lookupVar: name ].
 	
 	(bindings bindingOf: name asSymbol)
-		ifNotNil: [ :assoc | 
+		ifNotNil: [ :var | 
 			^ OCLiteralVariable new
-				assoc: assoc;
+				variable: var;
 				scope: self;
 				yourself ].
 	^ outerScope lookupVar: name 

--- a/src/OpalCompiler-Core/OCLiteralVariable.class.st
+++ b/src/OpalCompiler-Core/OCLiteralVariable.class.st
@@ -5,7 +5,7 @@ Class {
 	#name : #OCLiteralVariable,
 	#superclass : #OCAbstractVariable,
 	#instVars : [
-		'assoc'
+		'variable'
 	],
 	#category : #'OpalCompiler-Core-Semantics'
 }
@@ -16,33 +16,22 @@ OCLiteralVariable class >> semanticNodeClass [
 	^RBGlobalNode
 ]
 
-{ #category : #accessing }
-OCLiteralVariable >> assoc [
-	^ assoc
-]
-
-{ #category : #initializing }
-OCLiteralVariable >> assoc: anAssociation [
-
-	assoc := anAssociation
-]
-
 { #category : #emitting }
 OCLiteralVariable >> emitStore: methodBuilder [
 
-	 assoc emitStore: methodBuilder
+	 variable emitStore: methodBuilder
 
 
 ]
 
 { #category : #emitting }
 OCLiteralVariable >> emitValue: methodBuilder [
-	assoc emitValue: methodBuilder
+	variable emitValue: methodBuilder
 ]
 
 { #category : #testing }
 OCLiteralVariable >> isClassVariable [
-	^ assoc isClassVariable
+	^ variable isClassVariable
 ]
 
 { #category : #testing }
@@ -50,7 +39,7 @@ OCLiteralVariable >> isFromSharedPool [
 	| sharedPools |
 	sharedPools := scope getClass instanceSide sharedPools.
 	^ sharedPools 
-		detect: [ :pool | pool classVarNames includes: assoc key ]
+		detect: [ :pool | pool classVarNames includes: variable key ]
 		ifFound: [ true ]
 		ifNone: [ false ]
 ]
@@ -69,7 +58,7 @@ OCLiteralVariable >> isGlobalClassNameBinding [
 
 { #category : #testing }
 OCLiteralVariable >> isGlobalVariable [
-	^ assoc isGlobalVariable
+	^ variable isGlobalVariable
 ]
 
 { #category : #testing }
@@ -88,20 +77,26 @@ OCLiteralVariable >> isWritable [
 { #category : #accessing }
 OCLiteralVariable >> name [
 
-	^ assoc name
+	^ variable name
 ]
 
 { #category : #reading }
 OCLiteralVariable >> read [
-	^ assoc read 
+	^ variable read 
 ]
 
 { #category : #accessing }
 OCLiteralVariable >> value [
-	^assoc value
+	^variable value
 ]
 
 { #category : #accessing }
 OCLiteralVariable >> variable [
-	^assoc
+	^ variable
+]
+
+{ #category : #initializing }
+OCLiteralVariable >> variable: aLiteralVariable [
+
+	variable := aLiteralVariable
 ]

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -45,9 +45,9 @@ OCRequestorScope >> lookupVar: name [
 
 	"the requestors #bindingOf may create a binding for not yet existing variables"
 	(requestor bindingOf: name)
-		ifNotNil: [ :assoc | 
+		ifNotNil: [ :var | 
 			^ OCLiteralVariable new
-				assoc: assoc;
+				variable: var;
 				scope: self;
 				yourself ].
 	^ outerScope lookupVar: name

--- a/src/OpalCompiler-Core/OCUndeclaredVariable.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariable.class.st
@@ -17,15 +17,10 @@ OCUndeclaredVariable class >> semanticNodeClass [
 	^RBVariableNode
 ]
 
-{ #category : #accessing }
-OCUndeclaredVariable >> assoc [
-	^Undeclared associationAt: name
-]
-
 { #category : #emitting }
 OCUndeclaredVariable >> emitStore: methodBuilder [
 
-	methodBuilder storeIntoLiteralVariable:  self assoc
+	methodBuilder storeIntoLiteralVariable: self variable
 
 
 ]
@@ -33,7 +28,7 @@ OCUndeclaredVariable >> emitStore: methodBuilder [
 { #category : #emitting }
 OCUndeclaredVariable >> emitValue: methodBuilder [
 
-	methodBuilder pushLiteralVariable: self assoc.
+	methodBuilder pushLiteralVariable: self variable
 
 ]
 
@@ -51,4 +46,9 @@ OCUndeclaredVariable >> name [
 { #category : #accessing }
 OCUndeclaredVariable >> name: anObject [
 	name := anObject
+]
+
+{ #category : #accessing }
+OCUndeclaredVariable >> variable [
+	^Undeclared associationAt: name
 ]

--- a/src/Reflectivity/RFASTTranslatorForEffect.class.st
+++ b/src/Reflectivity/RFASTTranslatorForEffect.class.st
@@ -137,7 +137,7 @@ RFASTTranslatorForEffect >> visitVariableNode: aVariableNode [
 	"when visiting a variable for effect, we could push it and then pop it, but we do nothing"
 	binding := aVariableNode binding.
 	(binding isLiteralVariable or: [ binding isUndeclared ])
-		ifTrue: [ methodBuilder addLiteral: binding assoc ].
+		ifTrue: [ methodBuilder addLiteral: binding variable ].
 		
 	self emitMetaLinkAfterNoEnsure: aVariableNode.
 


### PR DESCRIPTION
Now that LiteralVariables are not subclasses of Associations anymore, we need to update the use  of "assoc" as it is misleading. We use "variable" instead.

As this is deep in the compiler, no depreaction. (not part of the public API)