### PR TITLE
 Bugfix: object-centric metalinks were not able to distinguish object

### DIFF
--- a/src/Reflectivity-Tests/LinkInstallerTest.class.st
+++ b/src/Reflectivity-Tests/LinkInstallerTest.class.st
@@ -225,6 +225,21 @@ LinkInstallerTest >> testLinkOnTempVarForObject [
 ]
 
 { #category : #'links - installing' }
+LinkInstallerTest >> testLinkTargetsObjectsByIdentity [
+	|link ast set|
+	link := MetaLink new metaObject: Halt; selector: #now.
+	ast := (Set >> #add:) ast.
+	
+	set := Set new.
+	set link: link toAST: ast.
+	self should:[set add: 1] raise: Halt.
+	
+	set := Set new.
+	set link: link toAST: ast.
+	self should:[set add: 1] raise: Halt.
+]
+
+{ #category : #'links - installing' }
 LinkInstallerTest >> testMetaLinkOnOneObject [
 	"Only one metalink for on object of a particular class. Other instances of this class must remain unaffected."
 

--- a/src/Reflectivity/MetaLinkAnonymousClassBuilder.class.st
+++ b/src/Reflectivity/MetaLinkAnonymousClassBuilder.class.st
@@ -71,7 +71,7 @@ MetaLinkAnonymousClassBuilder >> compiledMethodsOfSelector: selector inClasses: 
 { #category : #initialize }
 MetaLinkAnonymousClassBuilder >> initialize [
 	classes := Dictionary new.
-	migratedObjects := WeakKeyDictionary new
+	migratedObjects := WeakIdentityKeyDictionary new
 ]
 
 { #category : #migration }

--- a/src/Reflectivity/MetaLinkNodesMapper.class.st
+++ b/src/Reflectivity/MetaLinkNodesMapper.class.st
@@ -34,8 +34,8 @@ MetaLinkNodesMapper >> findNodesForObject: anObject [
 
 { #category : #initialize }
 MetaLinkNodesMapper >> initialize [
-	objectsForNodes := WeakKeyDictionary new.
-	nodesForObjects := WeakKeyDictionary new
+	objectsForNodes := WeakIdentityKeyDictionary new.
+	nodesForObjects := WeakIdentityKeyDictionary new
 ]
 
 { #category : #mapping }


### PR DESCRIPTION
For objects which equality is redefined (e.g. instances of Set, MetaLinks are not able to find on which object to install themselves.

Object-centric MetaLink machinery now uses WeakIdentityKeyDictionary to solve this problem.
Fixes #6572