### PR TITLE
Deprecate-firstPrecodeCommentFor

### DIFF
--- a/src/Deprecated90/Behavior.extension.st
+++ b/src/Deprecated90/Behavior.extension.st
@@ -1,0 +1,35 @@
+Extension { #name : #Behavior }
+
+{ #category : #'*Deprecated90' }
+Behavior >> precodeCommentOrInheritedCommentFor: selector [ 
+	"Answer a string representing the first comment in the method associated 
+	with selector, considering however only comments that occur before the 
+	beginning of the actual code. If the version recorded in the receiver is 
+	uncommented, look up the inheritance chain. Return nil if none found."
+	
+	| aSuper aComment |
+	self deprecated: 'No senders, not API: will be removed in Pharo 10'.
+	
+	^ (aComment := self firstPrecodeCommentFor: selector) isEmptyOrNil
+		ifTrue: [(self == Behavior
+					or: [self superclass == nil
+							or: [(aSuper := self superclass whichClassIncludesSelector: selector) == nil]])
+				ifFalse: [aSuper precodeCommentOrInheritedCommentFor: selector]]
+		ifFalse: [aComment]
+]
+
+{ #category : #'*Deprecated90' }
+Behavior >> supermostPrecodeCommentFor: selector [ 
+	"Answer a string representing the precode comment in the most distant 
+	superclass's implementation of the selector. Return nil if none found."
+	| aSuper superComment |
+	self deprecated: 'No senders, not API: will be removed in Pharo 10'.
+	(self == Behavior
+			or: [self superclass == nil
+					or: [(aSuper := self superclass whichClassIncludesSelector: selector) == nil]])
+		ifFalse: ["There is a super implementor"
+			superComment := aSuper supermostPrecodeCommentFor: selector].
+	^ superComment
+		ifNil: [self firstPrecodeCommentFor: selector
+			"ActorState supermostPrecodeCommentFor: #printOn:"]
+]

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -712,12 +712,10 @@ Behavior >> firstCommentAt:  selector [
 
 { #category : #'accessing method dictionary' }
 Behavior >> firstPrecodeCommentFor:  selector [
-	"If there is a comment in the source code at the given selector that preceeds the body of the method, return it here, else return nil"
-
-	| method |
-	"Behavior firstPrecodeCommentFor: #firstPrecodeCommentFor:"
-	method := self compiledMethodAt: selector asSymbol ifAbsent: [^ nil].
-	^method ast firstPrecodeComment
+	self 
+		deprecated: 'use #comment on the method' 
+		transformWith: '`@receiver firstPrecodeCommentFor: `@arg' -> '(`@receiver>>`@arg) comment'.
+	^(self>>selector) comment
 	
 ]
 
@@ -1338,22 +1336,6 @@ Behavior >> postCopy [
 	self methodDict: self methodDict copy
 ]
 
-{ #category : #'accessing method dictionary' }
-Behavior >> precodeCommentOrInheritedCommentFor: selector [ 
-	"Answer a string representing the first comment in the method associated 
-	with selector, considering however only comments that occur before the 
-	beginning of the actual code. If the version recorded in the receiver is 
-	uncommented, look up the inheritance chain. Return nil if none found."
-	
-	| aSuper aComment |
-	^ (aComment := self firstPrecodeCommentFor: selector) isEmptyOrNil
-		ifTrue: [(self == Behavior
-					or: [self superclass == nil
-							or: [(aSuper := self superclass whichClassIncludesSelector: selector) == nil]])
-				ifFalse: [aSuper precodeCommentOrInheritedCommentFor: selector]]
-		ifFalse: [aComment]
-]
-
 { #category : #printing }
 Behavior >> printHierarchy [
 	"Answer a description containing the names and instance variable names 
@@ -1702,21 +1684,6 @@ Behavior >> superclass: aClass methodDictionary: mDict format: fmt [
 	self setFormat: fmt.
 	self methodDict: mDict.
 
-]
-
-{ #category : #'accessing method dictionary' }
-Behavior >> supermostPrecodeCommentFor: selector [ 
-	"Answer a string representing the precode comment in the most distant 
-	superclass's implementation of the selector. Return nil if none found."
-	| aSuper superComment |
-	(self == Behavior
-			or: [self superclass == nil
-					or: [(aSuper := self superclass whichClassIncludesSelector: selector) == nil]])
-		ifFalse: ["There is a super implementor"
-			superComment := aSuper supermostPrecodeCommentFor: selector].
-	^ superComment
-		ifNil: [self firstPrecodeCommentFor: selector
-			"ActorState supermostPrecodeCommentFor: #printOn:"]
 ]
 
 { #category : #'testing method dictionary' }


### PR DESCRIPTION
- transforming deprecation for #firstPrecodeCommentFor: (yes, the nil case is not taken into account, but it should be ok)
- deprecate #precodeCommentOrInheritedCommentFor: and #supermostPrecodeCommentFor: without replacement. Leftover of old tools that are not there anymore

The only other sender is fixed by another PR already in review.