### PR TITLE
TemporaryVariable: implement #isReferenced

### DIFF
--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -232,6 +232,11 @@ Slot >> isReadIn: aCompiledCode [
 ]
 
 { #category : #testing }
+Slot >> isReferenced [
+	^self usingMethods isNotEmpty
+]
+
+{ #category : #testing }
 Slot >> isSelfEvaluating [
 	^true
 ]

--- a/src/Kernel/TemporaryVariable.class.st
+++ b/src/Kernel/TemporaryVariable.class.st
@@ -79,6 +79,11 @@ TemporaryVariable >> isFromBlock [
 	^startpc isNotNil
 ]
 
+{ #category : #testing }
+TemporaryVariable >> isReferenced [
+	^self astNodes isNotEmpty
+]
+
 { #category : #accessing }
 TemporaryVariable >> method [
 	^ method

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -66,8 +66,7 @@ Variable >> hash [
 
 { #category : #testing }
 Variable >> isReferenced [
-	"Subclasses can implement optimized version avoiding all methods collections"
-	^self usingMethods isNotEmpty
+	^ self subclassResponsibility
 ]
 
 { #category : #accessing }

--- a/src/ReleaseTests/NoUnusedTemporaryVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedTemporaryVariablesLeftTest.class.st
@@ -28,7 +28,7 @@ NoUnusedTemporaryVariablesLeftTest >> testNoUnusedTemporaryVariablesLeft [
 		m ast temporaries anySatisfy: [ :x | x binding isUnused ] ] ].
 	
 	"No other exceptions beside the ones mentioned here should be allowed"	
-	validExceptions := { MFClassA>>#method. MFClassB>>#method3. MFClassB>>#method2}.	
+	validExceptions := { MFClassA>>#method. MFClassB>>#method3. MFClassB>>#method2 . TemporaryVariableTest>>#testIsReferenced }.	
 	
 	remaining := found asOrderedCollection 
 								removeAll: validExceptions;

--- a/src/Slot-Core/CompiledMethod.extension.st
+++ b/src/Slot-Core/CompiledMethod.extension.st
@@ -35,6 +35,6 @@ CompiledMethod >> temporaryVariableNamed: aName [
 
 { #category : #'*Slot-Core' }
 CompiledMethod >> temporaryVariables [
-	^self tempNames collect: [ :name | TemporaryVariable new name: name ]
+	^self tempNames collect: [ :name | TemporaryVariable name: name method: self]
 
 ]

--- a/src/Slot-Tests/TemporaryVariableTest.class.st
+++ b/src/Slot-Tests/TemporaryVariableTest.class.st
@@ -21,6 +21,15 @@ TemporaryVariableTest >> testHasTemporaryVariablesMethod [
 	self assert: (method hasTemporaryVariableNamed: #method)
 ]
 
+{ #category : #tests }
+TemporaryVariableTest >> testIsReferenced [
+	| method notReferenced |
+	"The temp notReferenced is not used as we test exactly that here"
+	method := self class >> #testIsReferenced.
+	self assert: method temporaryVariables first isReferenced.
+	self deny: method temporaryVariables second isReferenced.
+]
+
 { #category : #properties }
 TemporaryVariableTest >> testPropertyAtPut [
 


### PR DESCRIPTION
#isReferenced for TemporaryVariables need to check if the var is really accessed. This implementation does it using the AST: if there are no astNodes for this variables, it is not used.

- Implement isReferenced
- add test
- move implementation isReferenced from Variable to Slo
- add isReferenced as subclassResponsability in Variable