### PR TITLE
Regex-Core-Exceptions is not an API Package

### DIFF
--- a/src/Regex-Help/RegexAPIDocumentation.class.st
+++ b/src/Regex-Help/RegexAPIDocumentation.class.st
@@ -20,5 +20,5 @@ RegexAPIDocumentation class >> builder [
 
 { #category : #accessing }
 RegexAPIDocumentation class >> helpPackages [
-	^#('Regex-Core' 'Regex-Core-Exceptions' 'Regex-Core-Tests')
+	^#('Regex-Core' 'Regex-Core-Tests')
 ]


### PR DESCRIPTION
Fix #6588