### PR TITLE
Proposed fix for: Issue #5906

### DIFF
--- a/src/MonticelloGUI/MCCodeTool.class.st
+++ b/src/MonticelloGUI/MCCodeTool.class.st
@@ -183,3 +183,9 @@ MCCodeTool >> selectedMessageName [
 	"Answer the name of the selected message"
 	self subclassResponsibility
 ]
+
+{ #category : #'morphic ui' }
+MCCodeTool >> textMorph: aSymbol [
+	"The text areas of Code Tools should be customised for SmallTalk code"
+	^ self textMorph: aSymbol specializedFor: #beForSmalltalkScripting 
+]

--- a/src/MonticelloGUI/MCTool.class.st
+++ b/src/MonticelloGUI/MCTool.class.st
@@ -354,6 +354,13 @@ MCTool >> summary: aString [
 
 { #category : #'morphic ui' }
 MCTool >> textMorph: aSymbol [
+	"Tools that are not Code Tools should have plain text editing areas"
+	^ self textMorph: aSymbol specializedFor: #beForPlainText 
+]
+
+{ #category : #'morphic ui' }
+MCTool >> textMorph: aSymbol specializedFor: anEditingMode [
+	"Customise a textMorph for a particular editing mode, eg: plain text or Smalltalk code"
 	| textMorph |
 	textMorph := RubPluggableTextMorph new
 		getTextSelector: aSymbol;
@@ -361,8 +368,8 @@ MCTool >> textMorph: aSymbol [
 		on: self;
 		beWrapped;
 		hScrollbarShowNever;
-		beForSmalltalkScripting;
 		yourself.
+	textMorph perform: anEditingMode.
 	textMorph announcer when: RubTextAcceptRequest send: #accept to: self.
 	textMorph hasUnacceptedEdits: false.
 	^ textMorph


### PR DESCRIPTION
Proposes a fix for Issue #5906. It assumes that Monticello tools derived directly from MCTool are not intended as Code tools so their text areas shouldn't support code completion.