### PR TITLE
#copyFrom: in ClassOrganization should not be extension method

### DIFF
--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -179,6 +179,13 @@ ClassOrganization >> commentStamp: anObject [
 	commentStamp := anObject
 ]
 
+{ #category : #copying }
+ClassOrganization >> copyFrom: otherOrganization [
+	commentRemoteString := otherOrganization commentRemoteString.
+	commentStamp := otherOrganization commentStamp.
+	otherOrganization protocols do: [ :p | p methodSelectors do: [ :m | protocolOrganizer classify: m inProtocolNamed: p name ] ]
+]
+
 { #category : #accessing }
 ClassOrganization >> extensionProtocols [ 
 	^ self protocolOrganizer extensionProtocols.

--- a/src/Shift-ClassBuilder/ClassOrganization.extension.st
+++ b/src/Shift-ClassBuilder/ClassOrganization.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #ClassOrganization }
-
-{ #category : #'*Shift-ClassBuilder' }
-ClassOrganization >> copyFrom: otherOrganization [
-	commentRemoteString := otherOrganization commentRemoteString.
-	commentStamp := otherOrganization commentStamp.
-	otherOrganization protocols do: [ :p | p methodSelectors do: [ :m | protocolOrganizer classify: m inProtocolNamed: p name ] ]
-]


### PR DESCRIPTION
#copyFrom: in ClassOrganization is an extension method from the ClassBuilder. This is not needed, it can just be part of the Kernel package.