### PR TITLE
DeprecatedSlot-fixEmptyMessage

### DIFF
--- a/src/VariablesLibrary/SlotDeprecation.class.st
+++ b/src/VariablesLibrary/SlotDeprecation.class.st
@@ -8,6 +8,11 @@ Class {
 }
 
 { #category : #accessing }
+SlotDeprecation >> explanationString [
+	^explanationString ifNil: [ '' ]
+]
+
+{ #category : #accessing }
 SlotDeprecation >> messageText [
 	^ String
 		streamContents: [ :str | 
@@ -17,5 +22,5 @@ SlotDeprecation >> messageText [
 				nextPutAll: ' accessed in ';
 				nextPutAll: context sender method name;
 				nextPutAll: ' has been deprecated. ';
-				nextPutAll: explanationString ]
+				nextPutAll: self explanationString ]
 ]


### PR DESCRIPTION
Small fix to make DeprecatedSlot work if you do not specify a messageText. (This is not adviced, but this way it does not break if you forget to add the explanation)