### PR TITLE
RBRenameClassTransformationTest-defaultTimeLimit

### DIFF
--- a/src/Refactoring2-Transformations-Tests/RBRenameClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameClassTransformationTest.class.st
@@ -4,6 +4,11 @@ Class {
 	#category : #'Refactoring2-Transformations-Tests'
 }
 
+{ #category : #accessing }
+RBRenameClassTransformationTest class >> defaultTimeLimit [
+	^30 seconds
+]
+
 { #category : #testing }
 RBRenameClassTransformationTest >> testBadName [
 


### PR DESCRIPTION
If the CI slave is very slow, we get timeouts for RBRenameClassTransformationTest. This PR improves the defaultTimeLimit