### PR TITLE
Added rewrite rule basic editor.

### DIFF
--- a/src/RewriteCustomRules/CustomRuleGenerator.class.st
+++ b/src/RewriteCustomRules/CustomRuleGenerator.class.st
@@ -1,0 +1,106 @@
+"
+I am in charge of saving the RewriteRules. I receive the custom rule as plain text and save it in form of a class. 
+"
+Class {
+	#name : #CustomRuleGenerator,
+	#superclass : #Object,
+	#instVars : [
+		'input',
+		'output',
+		'searchFor',
+		'replaceWith',
+		'protocolName',
+		'ruleName'
+	],
+	#category : #'RewriteCustomRules-Core'
+}
+
+{ #category : #testing }
+CustomRuleGenerator >> areRuleAndProtocolNamesValid [
+	^ protocolName isNotNil
+		and: [ protocolName isValidGlobalName
+				and: [ ruleName isNotNil and: [ ruleName isValidGlobalName ] ] ]
+]
+
+{ #category : #defaults }
+CustomRuleGenerator >> classNotCreatedAlert [
+	UIManager default alert: 'The name you enter is invalid. Please try again.' title: 'Alert'
+]
+
+{ #category : #api }
+CustomRuleGenerator >> generateCustomRewriteRule [
+	| ruleAsClass |
+	ruleName := self inputClassName.
+	protocolName := self inputPackageProtocol.
+	self areRuleAndProtocolNamesValid
+		ifFalse: [ self classNotCreatedAlert.
+			^ self ].
+	ruleAsClass := RBCustomTransformationRule
+		subclass: ruleName
+		instanceVariableNames: ''
+		classVariableNames: ''
+		package: 'RewriteToolCustomRules-' , protocolName.
+	ruleAsClass
+		compile: self ruleInitializationMethod
+		classified: 'initialization'
+]
+
+{ #category : #initialization }
+CustomRuleGenerator >> initialize [
+	super initialize.
+	input := ''.
+	output := ''.
+]
+
+{ #category : #accessing }
+CustomRuleGenerator >> input: anObject [
+	input := anObject
+]
+
+{ #category : #defaults }
+CustomRuleGenerator >> inputClassName [
+	^ UIManager default
+		request: 'Name of the rewrite rule class: '
+		initialAnswer: ''
+]
+
+{ #category : #defaults }
+CustomRuleGenerator >> inputPackageProtocol [
+	^ UIManager default
+		request: 'Name of the protocol of the rewrite rule package: '
+		initialAnswer: 'Custom'
+]
+
+{ #category : #accessing }
+CustomRuleGenerator >> output: anObject [
+	output := anObject
+]
+
+{ #category : #accessing }
+CustomRuleGenerator >> replaceWith: anObject [
+	replaceWith := anObject
+]
+
+{ #category : #accessing }
+CustomRuleGenerator >> ruleInitializationMethod [
+	^ 'initialize
+	super initialize.
+	self searchFor: ''' , searchFor
+		,
+			'''.
+	self replaceWith: ''' , replaceWith
+		,
+			'''.
+	self input: ''' , input
+		,
+			'''.
+	self output: ''' , output
+		,
+			'''.
+	rewriteRule replace: searchFor with: replaceWith'
+]
+
+{ #category : #accessing }
+CustomRuleGenerator >> searchFor: anObject [
+	searchFor := anObject
+]

--- a/src/RewriteCustomRules/DemoRule1.class.st
+++ b/src/RewriteCustomRules/DemoRule1.class.st
@@ -1,0 +1,27 @@
+"
+A custom rewrite rule
+"
+Class {
+	#name : #DemoRule1,
+	#superclass : #RBTransformationRule,
+	#category : #'RewriteCustomRules-Demo'
+}
+
+{ #category : #initialization }
+DemoRule1 >> initialize [
+	super initialize.
+	self rewriteRule
+		replace:
+			'`variable1 isNil
+	ifTrue: `@block1.
+`.Statement1'
+		with:
+			'`variable1 ifNil: `@block1.
+`.Statement1'
+]
+
+{ #category : #accessing }
+DemoRule1 >> someMethod [
+	self ifNil: [ ^ true ].
+	super size
+]

--- a/src/RewriteCustomRules/DemoRule2.class.st
+++ b/src/RewriteCustomRules/DemoRule2.class.st
@@ -1,0 +1,29 @@
+"
+A custom rewrite rule
+"
+Class {
+	#name : #DemoRule2,
+	#superclass : #RBTransformationRule,
+	#category : #'RewriteCustomRules-Demo'
+}
+
+{ #category : #accessing }
+DemoRule2 >> fooMethod [
+	true not
+		ifTrue: [ ^ 1 + 1 ]
+		ifFalse: [ ^ 1 + 0 ]
+]
+
+{ #category : #initialization }
+DemoRule2 >> initialize [
+	super initialize.
+	self rewriteRule
+		replace:
+			'true not
+		ifTrue: `@block1
+		ifFalse: `@block2'
+		with:
+			'false
+		ifTrue: `@block1
+		ifFalse: `@block2'
+]

--- a/src/RewriteCustomRules/ManifestRewriteToolCustomRules.class.st
+++ b/src/RewriteCustomRules/ManifestRewriteToolCustomRules.class.st
@@ -1,0 +1,8 @@
+"
+In this package the rewrite custom rules will be stored classfied in protocols.
+"
+Class {
+	#name : #ManifestRewriteToolCustomRules,
+	#superclass : #PackageManifest,
+	#category : #'RewriteCustomRules-Manifest'
+}

--- a/src/RewriteCustomRules/MyRule2.class.st
+++ b/src/RewriteCustomRules/MyRule2.class.st
@@ -1,0 +1,22 @@
+"
+A custom rewrite rule
+"
+Class {
+	#name : #MyRule2,
+	#superclass : #RBTransformationRule,
+	#category : #'RewriteCustomRules-Demo'
+}
+
+{ #category : #initialization }
+MyRule2 >> initialize [
+	super initialize.
+	self rewriteRule
+		replace:
+			'true not
+		ifTrue: [ ^ 1 + 1 ]
+		ifFalse: [ ^ 1 + 0 ]'
+		with: 'false
+		ifTrue: [ ^ 1 + 1 ]
+		ifFalse: [ ^ 1 + 0 ]'
+				
+]

--- a/src/RewriteCustomRules/RBCustomTransformationRule.class.st
+++ b/src/RewriteCustomRules/RBCustomTransformationRule.class.st
@@ -1,0 +1,54 @@
+"
+An extention of the RBTransformationRule to store Custom Rewrite Rules.
+"
+Class {
+	#name : #RBCustomTransformationRule,
+	#superclass : #RBTransformationRule,
+	#instVars : [
+		'input',
+		'output',
+		'searchFor',
+		'replaceWith'
+	],
+	#category : #'RewriteCustomRules-Core'
+}
+
+{ #category : #accessing }
+RBCustomTransformationRule >> input [
+	^ input
+]
+
+{ #category : #accessing }
+RBCustomTransformationRule >> input: anObject [
+	input := anObject
+]
+
+{ #category : #accessing }
+RBCustomTransformationRule >> output [
+	^ output
+]
+
+{ #category : #accessing }
+RBCustomTransformationRule >> output: anObject [
+	output := anObject
+]
+
+{ #category : #accessing }
+RBCustomTransformationRule >> replaceWith [
+	^ replaceWith
+]
+
+{ #category : #accessing }
+RBCustomTransformationRule >> replaceWith: anObject [
+	replaceWith := anObject
+]
+
+{ #category : #accessing }
+RBCustomTransformationRule >> searchFor [
+	^ searchFor
+]
+
+{ #category : #accessing }
+RBCustomTransformationRule >> searchFor: anObject [
+	searchFor := anObject
+]

--- a/src/RewriteCustomRules/package.st
+++ b/src/RewriteCustomRules/package.st
@@ -1,0 +1,1 @@
+Package { #name : #RewriteCustomRules }

--- a/src/RewriteRuleEditor/LoadRewriteRulePresenter.class.st
+++ b/src/RewriteRuleEditor/LoadRewriteRulePresenter.class.st
@@ -1,0 +1,79 @@
+"
+A simple GUI that permits to load a custom rule into RewriteBasicEditorPresenter.
+"
+Class {
+	#name : #LoadRewriteRulePresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'rulesList',
+		'buttonBar'
+	],
+	#category : #'RewriteRuleEditor-BasicEditor'
+}
+
+{ #category : #specs }
+LoadRewriteRulePresenter class >> defaultSpec [
+	^ SpBoxLayout newVertical
+		add: #rulesList;
+		addLast: #buttonBar;
+		yourself
+]
+
+{ #category : #accessing }
+LoadRewriteRulePresenter class >> icon [ 
+	^ self iconNamed: #smallFind
+]
+
+{ #category : #api }
+LoadRewriteRulePresenter class >> open [
+	<script>
+	^ self new openWithSpec
+]
+
+{ #category : #actions }
+LoadRewriteRulePresenter >> close [
+	self window close
+]
+
+{ #category : #initialization }
+LoadRewriteRulePresenter >> initializePresenters [
+	rulesList := self newList
+		items:
+			(RBCustomTransformationRule subclasses collect: [ :each | each ])
+				asOrderedCollection;
+		yourself.
+	buttonBar := self newActionBar
+		add:
+			(self newButton
+				label: 'Load';
+				icon: (self iconNamed: #smallDoIt);
+				action: [ self loadRule.
+					self close ]);
+		add:
+			(self newButton
+				label: 'Close';
+				icon: (self iconNamed: #smallCancel);
+				action: [ self close ]);
+		yourself
+]
+
+{ #category : #initialization }
+LoadRewriteRulePresenter >> initializeWindow: aWindowPresenter [
+	aWindowPresenter
+		title: 'Rewrite rule loader';
+		initialExtent: 300 @ 300;
+		windowIcon: (self class icon);
+		askOkToClose: false;
+		aboutText: 'Opens BasicTransformationPresenter with a custom rule'
+]
+
+{ #category : #actions }
+LoadRewriteRulePresenter >> loadRule [
+	| selectedRule |
+	selectedRule := rulesList selectedItems first new.
+	selectedRule ifNil: [ ^ self ].
+	RewriteBasicEditorPresenter new
+		searchForCode: selectedRule searchFor;
+		replaceWithCode: selectedRule replaceWith;
+		openWithSpec
+]

--- a/src/RewriteRuleEditor/RewriteBasicEditorPresenter.class.st
+++ b/src/RewriteRuleEditor/RewriteBasicEditorPresenter.class.st
@@ -1,0 +1,222 @@
+"
+I am a tool that allows to create and apply custom rewrite rules. I provide a simple GUI that has to code editors: searchFor and replaceWith. Also, I have a mini cheat sheet for the rewrite rules syntax, and some buttons for action.
+
+To run:
+RewriteBasicEditorPresenter open
+
+Instance Variables
+	searchForEditor:		<SearchForCodePresenter>
+	replaceWithEditor:		<ReplaceWithCodePresenter>
+	cheatSheet:				<SpTextPresenter>
+	applyButton: 			<SpButtonPresenter>
+	saveButton: 				<SpButtonPresenter>
+	loadButton: 				<SpButtonPresenter>
+	
+	
+searchForEditor
+	- The code editor for write the ""search for"" part of the rule.
+
+replaceWithEditor
+	- The code editor for write the ""replace with"" part of the rule.
+
+cheatSheet
+	- A mini cheat sheet to show the rewrite rules syntax.
+
+applyButton
+	- Opens the RewriteBrowserPresenter.
+
+saveButton
+	- A button to save the rule.
+	
+loadButton
+	- Opens the LoadRulePresenter.
+
+"
+Class {
+	#name : #RewriteBasicEditorPresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'methodCheckBox',
+		'applyButton',
+		'cheatSheet',
+		'saveButton',
+		'loadButton',
+		'searchForEditor',
+		'replaceWithEditor'
+	],
+	#category : #'RewriteRuleEditor-BasicEditor'
+}
+
+{ #category : #specs }
+RewriteBasicEditorPresenter class >> defaultSpec [
+	^ SpBoxLayout newHorizontal
+		add:
+			(SpBoxLayout newVertical
+				add: #searchForEditor
+					expand: true
+					fill: true
+					padding: 2;
+				add: #replaceWithEditor
+					expand: true
+					fill: true
+					padding: 2;
+				yourself)
+			expand: true;
+		add:
+			(SpBoxLayout newVertical
+				add: #cheatSheet expand: true;
+				addLast: #applyButton;
+				addLast: #saveButton;
+				addLast: #loadButton;
+				yourself)
+			expand: false;
+		yourself
+]
+
+{ #category : #defaults }
+RewriteBasicEditorPresenter class >> icon [
+	^ self iconNamed: #workspaceIcon
+]
+
+{ #category : #specs }
+RewriteBasicEditorPresenter class >> open [
+	<script>
+	^ self new openWithSpec
+]
+
+{ #category : #accesing }
+RewriteBasicEditorPresenter >> applierIcon [
+	^ RewriteRuleApplierPresenter icon
+]
+
+{ #category : #defaults }
+RewriteBasicEditorPresenter >> defaultRule [
+	| searchFor replaceWith |
+	searchFor := '| ``@object |
+`.@Statement1.
+``@object ifNotNil: [ `.@Statement2.
+`.@Statement3.
+`.@Statement4.
+`.@Statement5 ]'.
+	replaceWith := '| ``@object |
+`.@Statement1.
+``@object ifNil: [ ^ self ].
+`.@Statement2.
+`.@Statement3.
+`.@Statement4.
+`.@Statement5'.
+	^ Dictionary new
+		at: #searchFor put: searchFor;
+		at: #replaceWith put: replaceWith;
+		yourself
+]
+
+{ #category : #accesing }
+RewriteBasicEditorPresenter >> helpText [
+	^ '` = meta var
+			
+@ = list
+
+` = recurse into
+
+. = statement
+
+# = literal'
+]
+
+{ #category : #initialization }
+RewriteBasicEditorPresenter >> initializePresenters [
+	" Method checkbox has no functionality yet"
+
+	"	methodCheckBox := self newCheckBox
+		label: 'Method';
+		yourself.
+	searchForEditor := (self instantiate: SearchForCodePresenter)
+		codeSource: (self defaultRule at: #searchFor);
+		yourself.
+	replaceWithEditor := (self instantiate: ReplaceWithCodePresenter)
+		codeSource: (self defaultRule at: #replaceWith);
+		yourself."
+
+	cheatSheet := self newText
+		text: self helpText;
+		enabled: false;
+		yourself.
+	searchForEditor := self newCode
+		text: (self defaultRule at: #searchFor);
+		yourself.
+	replaceWithEditor := self newCode
+		text: (self defaultRule at: #replaceWith);
+		yourself.
+	loadButton := self newButton
+		label: 'Load rule';
+		icon: self loadRuleIcon;
+		action: [ self openRuleLoader ];
+		yourself.
+	saveButton := self newButton
+		label: 'Save rule';
+		icon: (self iconNamed: #smallSaveAs);
+		action: [ self saveRule ];
+		yourself.
+	applyButton := self newButton
+		label: 'Open applier';
+		icon: self applierIcon;
+		action: [ self openApplier ];
+		yourself.
+	self focusOrder
+		add: loadButton;
+		add: searchForEditor;
+		add: replaceWithEditor;
+		add: cheatSheet;
+		add: methodCheckBox;
+		add: saveButton;
+		add: applyButton
+]
+
+{ #category : #initialization }
+RewriteBasicEditorPresenter >> initializeWindow: aWindowPresenter [
+	aWindowPresenter
+		title: 'Rewrite Basic Editor';
+		initialExtent: 700 @ 500;
+		windowIcon: self class icon;
+		askOkToClose: false;
+		aboutText: 'A simple UI to create Rewrite Rules';
+		whenOpenedDo: [ cheatSheet color: self theme baseColor ]
+]
+
+{ #category : #accesing }
+RewriteBasicEditorPresenter >> loadRuleIcon [
+	^ LoadRewriteRulePresenter icon
+]
+
+{ #category : #actions }
+RewriteBasicEditorPresenter >> openApplier [
+	^ RewriteRuleApplierPresenter open
+]
+
+{ #category : #actions }
+RewriteBasicEditorPresenter >> openRuleLoader [
+	^ LoadRewriteRulePresenter open
+]
+
+{ #category : #api }
+RewriteBasicEditorPresenter >> replaceWithCode: aCode [
+	replaceWithEditor codeSource: aCode
+]
+
+{ #category : #actions }
+RewriteBasicEditorPresenter >> saveRule [
+	[ CustomRuleGenerator new
+		searchFor: searchForEditor text;
+		replaceWith: replaceWithEditor text;
+		generateCustomRewriteRule.
+	^ true ]
+		on: Error
+		do: [ :e | self error: 'Oops! ' , e className , '!' ].
+	^ false
+]
+
+{ #category : #api }
+RewriteBasicEditorPresenter >> searchForCode: aCode [
+	searchForEditor codeSource: aCode
+]

--- a/src/RewriteRuleEditor/RewriteRuleApplierPresenter.class.st
+++ b/src/RewriteRuleEditor/RewriteRuleApplierPresenter.class.st
@@ -1,0 +1,261 @@
+"
+A RewriteBrowserPresenter is a tool that provides GUI for applying rewrite rule on certain scope of classes. If you select a package, all of their classes will be added to the scope. If you select a class, the scope will contain only that class. Multiple selection in suported.
+
+To open:
+RewriteBrowserPresenter open
+"
+Class {
+	#name : #RewriteRuleApplierPresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'rules',
+		'packages',
+		'classes',
+		'methods',
+		'environment',
+		'checkbox',
+		'buttonBar'
+	],
+	#category : #'RewriteRuleEditor-Applier'
+}
+
+{ #category : #accessing }
+RewriteRuleApplierPresenter class >> buttonHeight [
+	^ 40
+]
+
+{ #category : #accessing }
+RewriteRuleApplierPresenter class >> buttonWidth [
+	^ 150
+]
+
+{ #category : #specs }
+RewriteRuleApplierPresenter class >> defaultSpec [
+	^ SpBoxLayout newVertical
+		add:
+			(SpBoxLayout newHorizontal
+				add: #packages;
+				add: #classes;
+				add: #methods;
+				yourself);
+		addLast:
+			(SpBoxLayout newHorizontal
+				add: #checkbox expand: false;
+				add: #rules expand: false;
+				add: #buttonBar;
+				yourself);
+		yourself
+]
+
+{ #category : #accessing }
+RewriteRuleApplierPresenter class >> icon [
+	^ self iconNamed: #objects
+]
+
+{ #category : #api }
+RewriteRuleApplierPresenter class >> open [
+	<script>
+	^ self new openWithSpec
+]
+
+{ #category : #accessing }
+RewriteRuleApplierPresenter class >> rulesWidth [
+	^ 225
+]
+
+{ #category : #accessing }
+RewriteRuleApplierPresenter >> allRules [
+	
+	^ OrderedCollection new
+		addAll: self demoRules;
+		addAll: self customRules;
+		yourself.
+	
+]
+
+{ #category : #testing }
+RewriteRuleApplierPresenter >> areSelectedItemsValid: items [
+	^ (items allSatisfy: [ :class | class isNotNil ])
+		and: [ items isNotEmpty ]
+]
+
+{ #category : #accessing }
+RewriteRuleApplierPresenter >> basicEditorIcon [
+	^ RewriteBasicEditorPresenter icon
+]
+
+{ #category : #actions }
+RewriteRuleApplierPresenter >> browseRule [
+	Smalltalk tools browser
+		openOnClass: (Smalltalk globals at: rules selectedItem)
+]
+
+{ #category : #actions }
+RewriteRuleApplierPresenter >> classesChanged [
+	| methodsInClasses |
+	(self areSelectedItemsValid: classes selectedItems)
+		ifFalse: [ ^ self ].
+	methodsInClasses := OrderedCollection new.
+	environment := classes selectedItems.
+	classes selectedItems
+		do: [ :eachClass | methodsInClasses addAll: eachClass selectors ].
+	methods items: methodsInClasses.
+	methods resetListSelection
+]
+
+{ #category : #initialization }
+RewriteRuleApplierPresenter >> connectPresenters [
+	packages whenSelectionChangedDo: [ self packagesChanged ].
+	classes whenSelectionChangedDo: [ self classesChanged ].
+	checkbox
+		whenActivatedDo: [ rules items: self customRules ];
+		whenDeactivatedDo: [ rules items: self allRules ]
+]
+
+{ #category : #accessing }
+RewriteRuleApplierPresenter >> customRules [
+	^ (RBCustomTransformationRule subclasses
+		collect: [ :each | each name ] )asOrderedCollection 
+]
+
+{ #category : #accessing }
+RewriteRuleApplierPresenter >> demoRules [
+	^ (RBTransformationRule subclasses collect: [ :each | each name ])
+		asOrderedCollection
+]
+
+{ #category : #initialization }
+RewriteRuleApplierPresenter >> initializeButtonBar [
+	buttonBar := self newButtonBar
+		add:
+			(self newButton
+				label: 'Apply rule';
+				icon: (self iconNamed: #smallOk);
+				action: [ self runReplace ];
+				yourself);
+		add:
+			(self newButton
+				label: 'Browse rule';
+				icon: (self iconNamed: #smallSystemBrowser);
+				action: [ self browseRule ];
+				yourself);
+		add:
+			(self newButton
+				label: 'Edit rule';
+				icon: self basicEditorIcon;
+				action: [ self openRuleInBasicEditor.
+					self window close ];
+				yourself);
+		yourself
+]
+
+{ #category : #initialization }
+RewriteRuleApplierPresenter >> initializeFocus [
+	self focusOrder
+		add: packages;
+		add: classes;
+		add: methods;
+		add: checkbox;
+		add: rules;
+		add: buttonBar
+]
+
+{ #category : #initialization }
+RewriteRuleApplierPresenter >> initializePresenters [
+	packages := self newList
+		items: RBBrowserEnvironment new packages;
+		headerTitle: 'Packages';
+		display: [ :item | item name ];
+		icons: [ self iconNamed: #packageIcon ];
+		sortingBlock: [ :a :b | a name < b name ];
+		enableItemSubstringFilter;
+		beMultipleSelection;
+		yourself.
+	classes := self newList
+		headerTitle: 'Classes';
+		display: [ :item | item name ];
+		icons: [ :elem | elem systemIcon ];
+		sortingBlock: [ :a :b | a name < b name ];
+		enableItemSubstringFilter;
+		beMultipleSelection;
+		yourself.
+	methods := self newList
+		headerTitle: 'Methods';
+		display: [ :item | '    ' , item ];
+		enableItemSubstringFilter;
+		yourself.
+	rules := self newDropList
+		display: [ :item | item asString ];
+		items: self allRules;
+		yourself.
+	checkbox := self newCheckBox
+		label: 'Only my rules';
+		yourself.
+	environment := OrderedCollection new.
+	self initializeButtonBar.
+	self initializeFocus
+]
+
+{ #category : #initialization }
+RewriteRuleApplierPresenter >> initializeWindow: aWindowPresenter [
+	aWindowPresenter
+		title: 'Rewrite Rule Applier' translated;
+		initialExtent: 750 @ 500;
+		windowIcon: (self class icon);
+		askOkToClose: false;
+		aboutText: 'Apply your custom rewrite rules to packages or classes.'
+]
+
+{ #category : #actions }
+RewriteRuleApplierPresenter >> openRuleInBasicEditor [
+	| aRule editor |
+	aRule := (self class environment at: rules selectedItem) new.
+	editor := RewriteBasicEditorPresenter new.
+	editor searchForCode: aRule searchFor.
+	editor replaceWithCode: aRule replaceWith.
+	editor openWithSpec
+]
+
+{ #category : #actions }
+RewriteRuleApplierPresenter >> openRuleInExampleBasedEditor [
+	| aRule builder |
+	self
+		flag: 'Not used method. It will modified to work on laters versions'.
+	aRule := (self class environment at: rules selectedItem) new.
+	builder := RewriteRuleBuilderPresenter new.
+	builder sourcePanel codeSource: aRule input.
+	builder resultPanel codeSource: aRule output.
+	builder transformationRule searchForPanel codeSource: aRule searchFor.
+	builder transformationRule replaceWithPanel
+		codeSource: aRule replaceWith.
+	builder transformationRule ruleName: aRule class asString.
+	builder transformationRule packageName: aRule class category asString.
+	builder openWithSpec
+]
+
+{ #category : #actions }
+RewriteRuleApplierPresenter >> packagesChanged [
+	(self areSelectedItemsValid: packages selectedItems)
+		ifFalse: [ ^ self ].
+	environment removeAll.
+	packages selectedItems
+		do: [ :each | environment addAll: each classes ].
+	classes items: environment.
+	classes resetListSelection
+]
+
+{ #category : #actions }
+RewriteRuleApplierPresenter >> runReplace [
+	| changes selectedRule |
+	selectedRule := (self class environment at: rules selectedItem) new.
+	changes := Array
+		with:
+			(RBSmalllintChecker
+				runRule: selectedRule
+				onEnvironment: (RBClassEnvironment classes: environment)) builder.
+	(RewriteRuleChangesBrowser changes: changes) open
+	"changes := RBSmalllintChecker
+		runRule: selectedRule
+		onEnvironment: (RBClassEnvironment classes: environment).
+	(ChangesBrowser changes: changes builder changes) open"
+]

--- a/src/RewriteRuleEditor/package.st
+++ b/src/RewriteRuleEditor/package.st
@@ -1,0 +1,1 @@
+Package { #name : #RewriteRuleEditor }


### PR DESCRIPTION
This is related to https://github.com/pharo-project/pharo/pull/6599
I was getting a weird error so I moved RewriteRuleChangeBrowser to NautilusRefactoring-Utilities package and done the PR again.
The next step is to add an ExampleBasedEditor (you can build a rule based on Pharo's code) and to integrate this tool with [MatchTool](https://github.com/jordanmontt/MatchTool-Spec2).

![rewrite_basic_editor](https://user-images.githubusercontent.com/33934979/84720882-4862d280-af4d-11ea-9558-01732f3a8172.png)
This is a basic editor for create, save, load and apply custom rewrite rules. The rules can be applied to one or many classes.
Is like RewriteRuleEditor in NautilusRefactoring-Utilities package tool but with more functionalities. It uses its RewriteRuleChangeBrowser class.