### PR TITLE
6046-Fleaky-RBBrowserEnvironmentTest-test

### DIFF
--- a/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
+++ b/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
@@ -22,6 +22,11 @@ RBBrowserEnvironmentTest class >> accessFromClassSideOnlyVariable [
 ]
 
 { #category : #accessing }
+RBBrowserEnvironmentTest class >> defaultTimeLimit [
+	^30 seconds
+]
+
+{ #category : #accessing }
 RBBrowserEnvironmentTest class >> packageNamesUnderTest [
 	^ #('Refactoring-Environment')
 ]


### PR DESCRIPTION
increase the timeout for RBBrowserEnvironmentTest. If the slave is very slow (due to virtualisation this can happen), this test times out as it is quite long running even if run on a fast machine locally.

fixes #6046