### PR TITLE
Enhance Rubric's completion interaction

### DIFF
--- a/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
@@ -10,6 +10,12 @@ CoCompletionEngineTest >> newCompletionEngine [
 	^ CoCompletionEngine new
 ]
 
+{ #category : #asserting }
+CoCompletionEngineTest >> shouldInheritSelectors [
+
+	^ true
+]
+
 { #category : #'test-interaction' }
 CoCompletionEngineTest >> testInitialCompletionEngineHasNoContext [
 

--- a/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
@@ -1,0 +1,110 @@
+Class {
+	#name : #CoCompletionEngineTest,
+	#superclass : #CompletionEngineTest,
+	#category : #'HeuristicCompletion-Tests'
+}
+
+{ #category : #running }
+CoCompletionEngineTest >> newCompletionEngine [
+	
+	^ CoCompletionEngine new
+]
+
+{ #category : #'test-interaction' }
+CoCompletionEngineTest >> testInitialCompletionEngineHasNoContext [
+
+	"If we did no interaction, no completion context should be initialized"
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist'.
+	self
+		setEditorText: text;
+		selectAt: text size + 1.
+		
+	self deny: controller hasCompletionContext.
+]
+
+{ #category : #'test-interaction' }
+CoCompletionEngineTest >> testLeftWithoutResultsBroadensSelection [
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist'.
+	self
+		setEditorText: text;
+		selectAt: text size + 1.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+	
+	editor keystroke: (self keyboardEventFor: Character arrowLeft).
+	
+	self assert: controller context completionToken equals: 'mEthOdThatDoesNotExis'
+]
+
+{ #category : #'test-interaction' }
+CoCompletionEngineTest >> testLeftWithoutResultsDoesNotCloseContext [
+	
+	| text firstContext |
+	text := 'self mEthOdThatDoesNotExist'.
+	self
+		setEditorText: text;
+		selectAt: text size + 1.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+	firstContext := controller context.
+	
+	editor keystroke: (self keyboardEventFor: Character arrowLeft).
+	
+	self assert: controller context equals: firstContext
+]
+
+{ #category : #'test-interaction' }
+CoCompletionEngineTest >> testOpenMenuCreatesCompletionContext [
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist'.
+	self
+		setEditorText: text;
+		selectAt: text size + 1.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+	
+	self assert: controller hasCompletionContext
+]
+
+{ #category : #'test-interaction' }
+CoCompletionEngineTest >> testTypeCharacterWithoutResultsDoesNotCloseContext [
+	
+	| text firstContext |
+	text := 'self mEthOdThatDoesNotExist'.
+	self
+		setEditorText: text;
+		selectAt: text size + 1.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+	firstContext := controller context.
+	
+	editor keystroke: (self keyboardEventFor: $a).
+	
+	self assert: controller context equals: firstContext
+]
+
+{ #category : #'test-interaction' }
+CoCompletionEngineTest >> testTypeCharacterWithoutResultsNarrowsSelection [
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist'.
+	self
+		setEditorText: text;
+		selectAt: text size + 1.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+	
+	editor keystroke: (self keyboardEventFor: $a).
+	
+	self assert: controller context completionToken equals: 'mEthOdThatDoesNotExist' , 'a'
+]

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -126,8 +126,13 @@ CompletionEngine >> handleKeystrokeBefore: aKeyboardEvent editor: anEditor [
 		ifTrue: [ 
 			menuMorph showDetail.
 			^ true ].
+
 	(keyCharacter = Character arrowLeft  and: [commandKeyPressed and: [ self captureNavigationKeys ]])
 		ifTrue: [ ^ self leftArrow ].
+	
+	(keyCharacter = Character arrowLeft or: [ keyCharacter = Character arrowRight ])
+		ifTrue: [ "just move the caret" ^ false ].
+	
 	keyCharacter = Character arrowUp
 		ifTrue: [ 
 			menuMorph moveUp.

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -95,9 +95,7 @@ CompletionEngine >> handleKeystrokeAfter: aKeyboardEvent editor: aParagraphEdito
 		ifFalse: [ ^ self closeMenu ].
 	
 	context narrowWith: aParagraphEditor wordAtCaret.
-	menuMorph narrowCompletion.
-	(context isNil or: [ context hasEntries not])
-		ifTrue: [ ^self closeMenu ]
+	menuMorph refreshSelection.
 ]
 
 { #category : #keyboard }

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -277,13 +277,14 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 	After replacing, set the caret after the first keyword.
 	The completion context uses this API to insert text into the text editor"
 
-	| caret old positionAfterFirstKeyword offset firstKeyword |
+	| wordEnd old positionAfterFirstKeyword offset firstKeyword toReplace wordStart |
 	"Try to correctly replace the current token in the word.
 	The code editor should be able to do it by himself"
-	caret := self editor caret.
+	wordEnd := self editor nextWord: self editor caret.
+	wordStart := self editor previousWord: self editor caret - 1.
 	self editor
-		selectInvisiblyFrom: caret - context completionToken size
-		to: caret - 1.
+		selectInvisiblyFrom: wordStart
+		to: wordEnd - 1.
 	old := self editor selection.
 	self editor replaceSelectionWith: aString.
 	
@@ -291,7 +292,7 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 		ifTrue: [ 1 ]
 		ifFalse: [ 0 ].
 	firstKeyword := (aString copyUpTo: $ ) size.
-	positionAfterFirstKeyword := caret + firstKeyword + offset - old size.
+	positionAfterFirstKeyword := wordEnd + firstKeyword + offset - old size.
 	self editor selectAt: positionAfterFirstKeyword.
 	
 	self editor morph invalidRect: self editor morph bounds

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -193,6 +193,12 @@ CompletionEngine >> handleKeystrokeWithoutMenu: aKeyboardEvent [
 	^ false
 ]
 
+{ #category : #testing }
+CompletionEngine >> hasCompletionContext [
+	
+	^ context notNil
+]
+
 { #category : #keyboard }
 CompletionEngine >> invalidateEditorMorph [
 		editor morph invalidRect: editor morph bounds.
@@ -254,17 +260,13 @@ CompletionEngine >> newSmartCharacterInsertionStringForLeft: left right: right [
 CompletionEngine >> openMenu [
 	| theMenu |
 	self stopCompletionDelay.
-	
+
 	context := self createContext.
 	theMenu := self menuMorphClass
 				engine: self
 				position: (editor selectionPosition: context completionToken).
 				
-	theMenu isClosed
-		ifFalse: [ menuMorph := theMenu ].
-	
-	(context isNil or: [ context hasEntries not ])
-		ifTrue: [ ^self closeMenu ].
+	theMenu isClosed ifFalse: [ menuMorph := theMenu ]
 ]
 
 { #category : #replacement }

--- a/src/NECompletion-Morphic/NECMenuMorph.class.st
+++ b/src/NECompletion-Morphic/NECMenuMorph.class.st
@@ -414,8 +414,7 @@ NECMenuMorph >> engine: aCompletionEngine position: aPoint [
 	engine := aCompletionEngine.
 	context := engine context.
 	self position: aPoint - (20 @ 0).
-	self narrowCompletion
-		ifFalse: [ ^ self ].
+	self refreshSelection.
 	self createTitle.
 	self openInWorld
 ]
@@ -541,20 +540,6 @@ NECMenuMorph >> moveUp [
 	self changed. 
 ]
 
-{ #category : #actions }
-NECMenuMorph >> narrowCompletion [
-
-	self selected: 0.
-	firstVisible := 1.
-	context narrowWith: context completionToken.
-	(context entries size = 1 and: [ context entries first contents = context completionToken ]) ifTrue: [
-		self delete.
-		^ false ].
-	context hasEntries ifTrue: [ self selected: 1 ].
-	self show.
-	^ true
-]
-
 { #category : #paging }
 NECMenuMorph >> pageCount [
 	| count |
@@ -586,6 +571,16 @@ NECMenuMorph >> pageUp [
 { #category : #drawing }
 NECMenuMorph >> prepareRectForNextRow: aRectangle [ 
 	^aRectangle translateBy: 0 @ self class itemHeight
+]
+
+{ #category : #actions }
+NECMenuMorph >> refreshSelection [
+
+	self selected: 0.
+	firstVisible := 1.
+	context hasEntries ifTrue: [ self selected: 1 ].
+	self show.
+	^ true
 ]
 
 { #category : #drawing }

--- a/src/NECompletion-Tests/CompletionContextTest.class.st
+++ b/src/NECompletion-Tests/CompletionContextTest.class.st
@@ -19,7 +19,6 @@ CompletionContextTest >> createContextFor: aString at: anInteger [
 ]
 
 { #category : #tests }
-
 CompletionContextTest >> testReceiverArgument [
 	| text context |
 	text := 'testIt: aRectangle

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -83,6 +83,86 @@ CompletionEngineTest >> tearDown [
 	super tearDown
 ]
 
+{ #category : #'test-interaction' }
+CompletionEngineTest >> testReplaceTokenAfterMovingCaretToMiddleOfWordWithFollowingWordsReplacesEntireWord [
+
+	"If the caret is at the end of a word, replace the entire word"
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist something that follows'.
+	
+	self
+		setEditorText: text;
+		selectAt: 'self mEthOdThatDoesNotExist' size + 1.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+
+	controller context replaceTokenInEditorWith: 'toto'.
+	
+	self assert: editor text equals: 'self toto something that follows'
+]
+
+{ #category : #'test-interaction' }
+CompletionEngineTest >> testReplaceTokenWithCaretInTheMiddleOfWordReplacesEntireWord [
+
+	"If the caret is at the end of a word, replace the entire word"
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist'.
+	self
+		setEditorText: text;
+		selectAt: 'self mEthOdThatDoes' size + 1.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+
+	controller context replaceTokenInEditorWith: 'toto'.
+	
+	self assert: editor text equals: 'self toto'
+]
+
+{ #category : #'test-interaction' }
+CompletionEngineTest >> testReplaceTokenWithCaretInTheMiddleOfWordWithFollowingWordsReplacesEntireWord [
+
+	"If the caret is at the end of a word, replace the entire word"
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist something that follows'.
+	
+	self
+		setEditorText: text;
+		selectAt: 'self mEthOdThatDoes' size + 1.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+	editor keystroke: (self keyboardEventFor: Character arrowLeft).
+	editor keystroke: (self keyboardEventFor: Character arrowLeft).
+
+	controller context replaceTokenInEditorWith: 'toto'.
+	
+	self assert: editor text asString equals: 'self toto something that follows'
+]
+
+{ #category : #'test-interaction' }
+CompletionEngineTest >> testReplaceTokenWithCaretOnEndOfWordReplacesEntireWord [
+
+	"If the caret is at the end of a word, replace the entire word"
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist'.
+	self
+		setEditorText: text;
+		selectAt: text size + 1.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+
+	controller context replaceTokenInEditorWith: 'toto'.
+	
+	self assert: editor text equals: 'self toto'
+]
+
 { #category : #'tests-keyboard' }
 CompletionEngineTest >> testSmartBackspace [
 	"Pressing backspace inside paired smart characters should remove both of them"

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -28,7 +28,7 @@ CompletionEngineTest >> keyboardEventFor: char [
 	event := KeyboardEvent new.
 	event 
 		setType: #keystroke
-		buttons: nil
+		buttons: 0
 		position:  0@0
 		keyValue: char asciiValue 
 		charCode: char asciiValue
@@ -36,6 +36,12 @@ CompletionEngineTest >> keyboardEventFor: char [
 		stamp: Time now.
 		
 	^event
+]
+
+{ #category : #running }
+CompletionEngineTest >> newCompletionEngine [
+	
+	^ CompletionEngine new
 ]
 
 { #category : #'tests-keyboard' }
@@ -63,15 +69,17 @@ CompletionEngineTest >> setEditorText: aString [
 CompletionEngineTest >> setUp [
 	super setUp.
 	
-	editor := RubTextEditor forTextArea: RubTextFieldArea new.
-	controller := CompletionEngine new.
-	controller setEditor: editor
+	editor := RubSmalltalkEditor forTextArea: RubEditingArea new beForSmalltalkCode.
+	controller := self newCompletionEngine.
+	controller setEditor: editor.
+	editor completionEngine: controller.
 ]
 
 { #category : #running }
 CompletionEngineTest >> tearDown [
-	controller := nil.
-	editor := nil.
+	
+	controller closeMenu.
+	editor textArea delete.
 	super tearDown
 ]
 

--- a/src/NECompletion/AbstractCompletionEngine.class.st
+++ b/src/NECompletion/AbstractCompletionEngine.class.st
@@ -11,3 +11,9 @@ Class {
 	#superclass : #Object,
 	#category : #'NECompletion-Model'
 }
+
+{ #category : #testing }
+AbstractCompletionEngine >> hasCompletionContext [
+
+	self subclassResponsibility
+]

--- a/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceDialog.class.st
+++ b/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceDialog.class.st
@@ -204,7 +204,6 @@ SpRubFindReplaceDialog >> title [
 { #category : #initialization }
 SpRubFindReplaceDialog >> updateFindText [
 
-	#updateFindText traceCr.
 	service findText: self findInput text asString.
 ]
 

--- a/src/Rubric-Tests/RubSelectionTest.class.st
+++ b/src/Rubric-Tests/RubSelectionTest.class.st
@@ -1,0 +1,70 @@
+Class {
+	#name : #RubSelectionTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'editor'
+	],
+	#category : #'Rubric-Tests-Base'
+}
+
+{ #category : #running }
+RubSelectionTest >> setUp [
+
+	super setUp.
+	editor := RubTextEditor forTextArea: RubTextFieldArea new.
+	"Add text with three words"
+	editor addString: 'abcde fghi jklm'.
+]
+
+{ #category : #running }
+RubSelectionTest >> testCaretAtBeginningHasNoWordAtCaret [
+
+	editor selectAt: 1.
+	
+	self assert: editor wordAtCaret isEmpty
+]
+
+{ #category : #running }
+RubSelectionTest >> testCaretInBetweenTwoWordsHasNoWordAtCaret [
+
+	"Words are abcde fghi. Put caret after space, just before $f"
+	editor selectAt: 1 + 'abcde ' size.
+	
+	self assert: editor wordAtCaret isEmpty
+]
+
+{ #category : #running }
+RubSelectionTest >> testCaretInTheEndOfSecondWordHasSecondWordUpToCaret [
+
+	"Words are abcde fghi. Put caret after space, just before $i"
+	editor selectAt: 1 + 'abcde fghi' size.
+	
+	self assert: editor wordAtCaret equals: 'fghi'
+]
+
+{ #category : #running }
+RubSelectionTest >> testCaretInTheEndOfWordHasWordUpToCaret [
+
+	"Word is abcde. Put caret after $e"
+	editor selectAt: 1 + 'abcde' size.
+	
+	self assert: editor wordAtCaret equals: 'abcde'
+]
+
+{ #category : #running }
+RubSelectionTest >> testCaretInTheMiddleOfSecondWordHasSecondWordUpToCaret [
+
+	"Words are abcde fghi. Put caret after space, just before $i"
+	editor selectAt: 1 + 'abcde fgh' size.
+	
+	self assert: editor wordAtCaret equals: 'fgh'
+]
+
+{ #category : #running }
+RubSelectionTest >> testCaretInTheMiddleOfWordHasWordUpToCaret [
+
+	"Word is abcde. Put caret after $c"
+	editor selectAt: 1 + 'abc' size.
+	
+	self assert: editor wordAtCaret equals: 'abc'
+]


### PR DESCRIPTION
Partial Fix for #6311.
This PR introduces the following things:
 - arrow-left and arrow right can be used to navigate the text without losing the completion context
 - the completion context is kept alive even when completion yields no results => this is important to avoid re-scanning the system to look for results that are not there on every keystroke
 - in combination with the two above, arrow left will broaden the completion, and arrow right will re-narrow it. If moving the caret causes moving the selection outside of a word, close the selection context
 - fix string replacement on accept to replace the entire word under the caret