### PR TITLE
use-OCBytecodeToASTCache-instead-of-fullBlockInstructionForPC

### DIFF
--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -24,7 +24,8 @@ Class {
 		'arguments',
 		'bar',
 		'body',
-		'scope'
+		'scope',
+		'bcToASTCache'
 	],
 	#category : #'AST-Core-Nodes'
 }

--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -159,16 +159,6 @@ IRMethod >> forceLongForm [
 		
 ]
 
-{ #category : #debugging }
-IRMethod >> fullBlockInstructionForPC: aPC [
-	| pc |
-	"For a given PC, the actual instruction may start N bytes ahead."
-	pc := aPC.
-	[ pc >= 0 ] whileTrue: [ 
-		(self firstInstructionMatching: [:ir | ir bytecodeOffset = pc ]) ifNotNil: [:it |^it].
-		pc := pc - 1 ].
-]
-
 { #category : #translating }
 IRMethod >> generate [
 	^self generate: CompiledMethodTrailer empty

--- a/src/OpalCompiler-Core/OCBytecodeToASTCache.class.st
+++ b/src/OpalCompiler-Core/OCBytecodeToASTCache.class.st
@@ -58,19 +58,19 @@ OCBytecodeToASTCache >> firstBcOffset [
 
 { #category : #initialization }
 OCBytecodeToASTCache >> generateForNode: aNode [
-	| blockIR currentBcOffset |
+	| methodOrBlockIr currentBcOffset |
 	methodOrBlockNode := aNode.
-	blockIR := aNode ir.
+	methodOrBlockIr := aNode ir.
 	bcToASTMap := Dictionary new.
-	firstBcOffset := blockIR compiledMethod initialPC.
+	firstBcOffset := methodOrBlockIr compiledMethod initialPC.
 
 	"if there is a primitive, we need to record the offset"
-	(blockIR irPrimitive num ~= 0
-		or: [ blockIR compiledMethod isQuick ])
+	(methodOrBlockIr irPrimitive num ~= 0
+		or: [ methodOrBlockIr compiledMethod isQuick ])
 		ifTrue: [ bcToASTMap at: firstBcOffset put: methodOrBlockNode ]. 
 
 	currentBcOffset := firstBcOffset.
-	blockIR startSequence withAllSuccessors
+	methodOrBlockIr startSequence withAllSuccessors
 		do: [ :seq | 
 			seq
 				do: [ :ir | 

--- a/src/OpalCompiler-Core/OCBytecodeToASTCache.class.st
+++ b/src/OpalCompiler-Core/OCBytecodeToASTCache.class.st
@@ -18,14 +18,14 @@ Class {
 		'firstBcOffset',
 		'lastBcOffset',
 		'bcToASTMap',
-		'methodNode'
+		'methodOrBlockNode'
 	],
 	#category : #'OpalCompiler-Core-Bytecode'
 }
 
 { #category : #initialization }
-OCBytecodeToASTCache class >> generateForMethodNode: aNode [
-	^self new generateForMethodNode: aNode
+OCBytecodeToASTCache class >> generateForNode: aNode [
+	^self new generateForNode: aNode
 ]
 
 { #category : #accessing }
@@ -57,20 +57,20 @@ OCBytecodeToASTCache >> firstBcOffset [
 ]
 
 { #category : #initialization }
-OCBytecodeToASTCache >> generateForMethodNode: aNode [
-	| methodIR currentBcOffset |
-	methodNode := aNode.
-	methodIR := methodNode ir.
+OCBytecodeToASTCache >> generateForNode: aNode [
+	| blockIR currentBcOffset |
+	methodOrBlockNode := aNode.
+	blockIR := aNode ir.
 	bcToASTMap := Dictionary new.
-	firstBcOffset := methodNode compiledMethod initialPC.
+	firstBcOffset := blockIR compiledMethod initialPC.
 
 	"if there is a primitive, we need to record the offset"
-	(methodIR irPrimitive num ~= 0
-		or: [ methodIR compiledMethod isQuick ])
-		ifTrue: [ bcToASTMap at: firstBcOffset put: methodNode ]. 
-		
+	(blockIR irPrimitive num ~= 0
+		or: [ blockIR compiledMethod isQuick ])
+		ifTrue: [ bcToASTMap at: firstBcOffset put: methodOrBlockNode ]. 
+
 	currentBcOffset := firstBcOffset.
-	methodIR startSequence withAllSuccessors
+	blockIR startSequence withAllSuccessors
 		do: [ :seq | 
 			seq
 				do: [ :ir | 
@@ -88,12 +88,17 @@ OCBytecodeToASTCache >> lastBcOffset [
 
 { #category : #accessing }
 OCBytecodeToASTCache >> methodNode [
-	^ methodNode
+	^ methodOrBlockNode
+]
+
+{ #category : #accessing }
+OCBytecodeToASTCache >> methodOrBlockNode [
+	^ methodOrBlockNode
 ]
 
 { #category : #'node access' }
 OCBytecodeToASTCache >> nodeForPC: pc [
-	pc < firstBcOffset ifTrue: [ ^ methodNode ].
+	pc < firstBcOffset ifTrue: [ ^ methodOrBlockNode ].
 	pc > lastBcOffset ifTrue: [ ^ bcToASTMap at: lastBcOffset ].
 	^ bcToASTMap at: pc
 ]

--- a/src/OpalCompiler-Core/RBBlockNode.extension.st
+++ b/src/OpalCompiler-Core/RBBlockNode.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : #RBBlockNode }
 
 { #category : #'*OpalCompiler-Core' }
+RBBlockNode >> bcToASTCache [
+	^ bcToASTCache ifNil: [ bcToASTCache := OCBytecodeToASTCache generateForNode: self ]
+]
+
+{ #category : #'*OpalCompiler-Core' }
 RBBlockNode >> ir [
 
 	^ self propertyAt: #ir ifAbsent: [ self parent methodOrBlockNode ir ]
@@ -58,6 +63,6 @@ RBBlockNode >> owningScope [
 RBBlockNode >> sourceNodeForPC: anInteger [ 
 	self methodNode ir.
 	(self hasProperty: #ir) ifTrue: [ "FullBlockClosure"
-		^(self ir fullBlockInstructionForPC: anInteger) sourceNode ].
+		^ self bcToASTCache nodeForPC: anInteger].
 	^ self methodNode sourceNodeForPC: anInteger
 ]

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #RBMethodNode }
 
 { #category : #'*OpalCompiler-Core' }
 RBMethodNode >> bcToASTCache [
-	^ bcToASTCache ifNil: [ bcToASTCache := OCBytecodeToASTCache generateForMethodNode: self ]
+	^ bcToASTCache ifNil: [ bcToASTCache := OCBytecodeToASTCache generateForNode: self ]
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Tests/MethodMapExamples.class.st
+++ b/src/OpalCompiler-Tests/MethodMapExamples.class.st
@@ -162,6 +162,14 @@ MethodMapExamples >> helperMethod12 [
 ]
 
 { #category : #examples }
+MethodMapExamples >> helperMethod13 [
+	| i |
+	i := 5.
+	[ i=0 ] whileFalse: [ i := i - 1 ].
+	^[ 1 + 2 ]
+]
+
+{ #category : #examples }
 MethodMapExamples >> ivar [
 	^ivar
 ]

--- a/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
@@ -77,7 +77,25 @@ OCBytecodeToASTCacheTest >> testNodeForBCOffsetTest [
 	Smalltalk vm is32bit ifTrue: [ self skip ]. 
 	pc := compiledMethod encoderClass = EncoderForSistaV1 ifTrue: [50] ifFalse: [51].
 	mappedNode := (cache nodeForPC: pc).
-	expectedNode := compiledMethod ast statements last arguments first statements first.
+	expectedNode := compiledMethod ast statements second arguments first statements first.
+	self assert: mappedNode sourceCode equals: expectedNode sourceCode.	
+	self assert: mappedNode start equals: expectedNode start.
+	self assert: mappedNode stop equals: expectedNode stop
+]
+
+{ #category : #tests }
+OCBytecodeToASTCacheTest >> testNodeForBCOffsetTestFull [
+	| pc mappedNode expectedNode |
+	self flag: #TODO. "we skip for now on 32 bit"
+	Smalltalk vm is32bit ifTrue: [ self skip ]. 
+	compiledMethod := MethodMapExamples >> #helperMethod13.
+	
+	"this is a test for full blocks only"
+	compiledMethod encoderClass = EncoderForSistaV1 ifFalse: [self skip].
+	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast statements last value.
+	pc := compiledMethod encoderClass = EncoderForSistaV1 ifTrue: [28] ifFalse: [56].
+	mappedNode := (cache nodeForPC: pc).
+	expectedNode := compiledMethod ast statements last value body.
 	self assert: mappedNode sourceCode equals: expectedNode sourceCode.	
 	self assert: mappedNode start equals: expectedNode start.
 	self assert: mappedNode stop equals: expectedNode stop

--- a/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
@@ -93,7 +93,7 @@ OCBytecodeToASTCacheTest >> testNodeForBCOffsetTestFull [
 	"this is a test for full blocks only"
 	compiledMethod encoderClass = EncoderForSistaV1 ifFalse: [self skip].
 	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast statements last value.
-	pc := compiledMethod encoderClass = EncoderForSistaV1 ifTrue: [28] ifFalse: [56].
+	pc := 27.
 	mappedNode := (cache nodeForPC: pc).
 	expectedNode := compiledMethod ast statements last value body.
 	self assert: mappedNode sourceCode equals: expectedNode sourceCode.	

--- a/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
@@ -85,17 +85,18 @@ OCBytecodeToASTCacheTest >> testNodeForBCOffsetTest [
 
 { #category : #tests }
 OCBytecodeToASTCacheTest >> testNodeForBCOffsetTestFull [
-	| pc mappedNode expectedNode |
+	| pc mappedNode expectedNode blockNode |
 	self flag: #TODO. "we skip for now on 32 bit"
 	Smalltalk vm is32bit ifTrue: [ self skip ]. 
 	compiledMethod := MethodMapExamples >> #helperMethod13.
 	
 	"this is a test for full blocks only"
 	compiledMethod encoderClass = EncoderForSistaV1 ifFalse: [self skip].
-	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast statements last value.
+	blockNode := compiledMethod ast statements last value.
+	cache := OCBytecodeToASTCache generateForNode: blockNode.
 	pc := 27.
 	mappedNode := (cache nodeForPC: pc).
-	expectedNode := compiledMethod ast statements last value body.
+	expectedNode := blockNode body.
 	self assert: mappedNode sourceCode equals: expectedNode sourceCode.	
 	self assert: mappedNode start equals: expectedNode start.
 	self assert: mappedNode stop equals: expectedNode stop

--- a/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
@@ -13,7 +13,7 @@ OCBytecodeToASTCacheTest >> setUp [
 	"Hooks that subclasses may override to define the fixture of test."
 	super setUp.	
 	compiledMethod := MethodMapExamples >> #helperMethod12.
-	cache := OCBytecodeToASTCache generateForMethodNode: compiledMethod ast
+	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast
 ]
 
 { #category : #helpers }
@@ -24,7 +24,7 @@ OCBytecodeToASTCacheTest >> testCacheInInterval: interval equalsNode: aNode [
 
 { #category : #tests }
 OCBytecodeToASTCacheTest >> testCachedMethodNode [
-	self assert: cache methodNode identicalTo: compiledMethod ast
+	self assert: cache methodOrBlockNode identicalTo: compiledMethod ast
 ]
 
 { #category : #tests }
@@ -35,7 +35,7 @@ OCBytecodeToASTCacheTest >> testFirstBCOffsetTest [
 { #category : #tests }
 OCBytecodeToASTCacheTest >> testFirstBCOffsetWithQuickReturn [
 	compiledMethod := ( MethodMapExamples >> #ivar).
-	cache := OCBytecodeToASTCache generateForMethodNode: compiledMethod ast.	
+	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast.	
 	self assert: cache firstBcOffset equals: compiledMethod initialPC.
 	self assert: (cache nodeForPC: cache firstBcOffset) identicalTo: compiledMethod ast.
 	self assert: (cache nodeForPC: cache lastBcOffset) identicalTo: compiledMethod ast statements last.

--- a/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
@@ -93,9 +93,8 @@ OCBytecodeToASTCacheTest >> testNodeForBCOffsetTestFull [
 	"this is a test for full blocks only"
 	compiledMethod encoderClass = EncoderForSistaV1 ifFalse: [self skip].
 	blockNode := compiledMethod ast statements last value.
-	cache := OCBytecodeToASTCache generateForNode: blockNode.
 	pc := 27.
-	mappedNode := (cache nodeForPC: pc).
+	mappedNode := (blockNode sourceNodeForPC: pc).
 	expectedNode := blockNode body.
 	self assert: mappedNode sourceCode equals: expectedNode sourceCode.	
 	self assert: mappedNode start equals: expectedNode start.


### PR DESCRIPTION
This PR removes #fullBlockInstructionForPC: and instead uses the OCBytecodeToASTCache in this case just as we use it for Methods.

OCBytecodeToASTCache has been slightly changed that it can build the cache for both cases