### PR TITLE
6544-ReImplementedNotSentRule-has-false-positives

### DIFF
--- a/src/Calypso-SystemPlugins-Critic-Queries-Tests/ClyClassWithProblemMethods.class.st
+++ b/src/Calypso-SystemPlugins-Critic-Queries-Tests/ClyClassWithProblemMethods.class.st
@@ -11,6 +11,7 @@ Class {
 ClyClassWithProblemMethods >> methodWithHalt [
 	<haltOrBreakpointForTesting>
 	self halt.
+	self methodWithHalt2.
 ]
 
 { #category : #'method examples' }

--- a/src/GeneralRules/ReImplementedNotSentRule.class.st
+++ b/src/GeneralRules/ReImplementedNotSentRule.class.st
@@ -6,6 +6,11 @@ This smell arises when a method is implemented but never sent. If a method is no
 		self deprecated: ''Use bar instead ''. 
 		^ self bar
 		 
+NOTE: the rule updates its data with messages send in new methods, but does not remove messages till the next image startup. The reason is that it would be to slow to re-calculate the data at each method removal.
+
+It can be forced to update by executing:
+
+	ReImplementedNotSentRule reset
 "
 Class {
 	#name : #ReImplementedNotSentRule,
@@ -22,11 +27,9 @@ ReImplementedNotSentRule class >> allMessages [
 
 	^allMessages ifNil: [
 		allMessages := IdentitySet new.
-	
 		Smalltalk globals allBehaviors do: [ :behavior | 
 				behavior methodsDo: [ :method |
-					self forApproxMessagesOf: method do: [ :mes |
-						allMessages add: mes ] ] ].
+						allMessages addAll: method messages ] ].
 		allMessages	]
 ]
 
@@ -37,50 +40,38 @@ ReImplementedNotSentRule class >> checksMethod [
 
 { #category : #cleanup }
 ReImplementedNotSentRule class >> cleanUp [
-
-	allMessages := nil
-]
-
-{ #category : #accessing }
-ReImplementedNotSentRule class >> forApproxMessagesOf: aMethod do: aBlock [
-	"this is so ugly purely for performance reasons"
-	"as oposed to the #messages method of the CompiledCode class
-	this approach is 11 times faster and had 87% precision and
-	100% recall in the standard pharo image upon method creation"
-
-	"literals are shifted by 1 right (that's why we start from 2"
-	"2 last literalls are method name and class name
-	(that's why we go to num - 1 (had to be -2 but mind the shift))"
-	2 to: aMethod numLiterals - 1 do: [ :i |
-		| l |
-		l := aMethod objectAt: i.
-		"besides symbols literals may be associations for class reffs
-		or other types of the actual literals"
-		l isSymbol ifTrue: [ aBlock value: l ] ]
+	self reset
 ]
 
 { #category : #initialization }
 ReImplementedNotSentRule class >> initialize [
-	
-	self subscribe
+	self reset.
+	self subscribe.
+	SessionManager default 
+		registerToolClassNamed: self name
 ]
 
 { #category : #'system announcements' }
 ReImplementedNotSentRule class >> methodAdded: anAnnouncement [
 
-	allMessages := nil
+	self allMessages addAll: anAnnouncement methodAdded messages
 ]
 
 { #category : #'system announcements' }
 ReImplementedNotSentRule class >> methodModified: anAnnouncement [
 
+	self allMessages addAll: anAnnouncement newMethod messages
+]
+
+{ #category : #cleanup }
+ReImplementedNotSentRule class >> reset [
+	<script>
 	allMessages := nil
 ]
 
-{ #category : #'system announcements' }
-ReImplementedNotSentRule class >> methodRemoved: anAnnouncement [
-
-	allMessages := nil
+{ #category : #cleanup }
+ReImplementedNotSentRule class >> shutDown [	
+	self reset
 ]
 
 { #category : #announcement }
@@ -90,7 +81,6 @@ ReImplementedNotSentRule class >> subscribe [
 	
 	SystemAnnouncer uniqueInstance weak
 		when: MethodAdded    send: #methodAdded: to: self;
-		when: MethodRemoved  send: #methodRemoved: to: self;
 		when: MethodModified send: #methodModified: to: self
 ]
 
@@ -104,7 +94,7 @@ ReImplementedNotSentRule class >> uniqueIdentifierName [
 { #category : #announcement }
 ReImplementedNotSentRule class >> unsubscribe [
 
-	SystemAnnouncer uniqueInstance unsubscribe: self.
+	SystemAnnouncer uniqueInstance unsubscribe: self
 ]
 
 { #category : #running }


### PR DESCRIPTION
This PR changes how the rule work in two ways:

- The "fast" way does not work anymore as we would need to check all nested blocks, too.
- We use #messages instead. This is slow, so we change when we update:
     - when a method is added or changed, we add the messages of the new method
     - if a method is removed, we do nothing

This means that this new scheme slowly accumulates false negatives. But every image startup will make sure the data is completely recalculated.

- I added a comment in the rule description of this and how to reset on demand.

NOTE: this is not meant to be the perfect fix! There is much more we can do (e.g. the data should be  moved to the environment, maybe even with some process updating it in the background. But that can be the next step)