### PR TITLE
PharoCommonTools-noAllInstancesDo

### DIFF
--- a/src/Tool-Registry/PharoCommonTools.class.st
+++ b/src/Tool-Registry/PharoCommonTools.class.st
@@ -104,7 +104,8 @@ PharoCommonTools class >> settingsOn: aBuilder [
 
 { #category : #'system startup' }
 PharoCommonTools class >> shutDown: aboutToQuit [
-	self allInstancesDo: #cleanUp
+	Smalltalk image tools cleanUp.
+	Smalltalk image resetTools
 ]
 
 { #category : #'world menu' }

--- a/src/Tool-Registry/PharoCommonTools.class.st
+++ b/src/Tool-Registry/PharoCommonTools.class.st
@@ -104,8 +104,7 @@ PharoCommonTools class >> settingsOn: aBuilder [
 
 { #category : #'system startup' }
 PharoCommonTools class >> shutDown: aboutToQuit [
-	Smalltalk image tools cleanUp.
-	Smalltalk image resetTools
+	Smalltalk image tools cleanUp
 ]
 
 { #category : #'world menu' }


### PR DESCRIPTION
This PR removes one #allInstancesDo: from the image shutdown code. (see issue #5538, which is not fixed by this, it's just one tiny step)