### PR TITLE
6634-testNoUnusedTemporaryVariablesLeft-is-failing-in-Pharo9

### DIFF
--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -277,7 +277,7 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 	After replacing, set the caret after the first keyword.
 	The completion context uses this API to insert text into the text editor"
 
-	| wordEnd old positionAfterFirstKeyword offset firstKeyword toReplace wordStart |
+	| wordEnd old positionAfterFirstKeyword offset firstKeyword wordStart |
 	"Try to correctly replace the current token in the word.
 	The code editor should be able to do it by himself"
 	wordEnd := self editor nextWord: self editor caret.


### PR DESCRIPTION
remove unused temp definition. fixes #6634