### PR TITLE
Deprecation-transform-execute-transformedAST

### DIFF
--- a/src/Kernel/Deprecation.class.st
+++ b/src/Kernel/Deprecation.class.st
@@ -228,7 +228,7 @@ Deprecation >> signal [
 
 { #category : #handling }
 Deprecation >> transform [
-	| node rewriteRule aMethod |
+	| node transformedNode rewriteRule aMethod |
 	self shouldTransform ifFalse: [ ^ self signal].
 	self rewriterClass ifNil:[ ^ self signal ].
 	aMethod := self contextOfSender compiledCode method.
@@ -239,12 +239,13 @@ Deprecation >> transform [
 			replace: rule key with: rule value.
 		(rewriteRule executeTree: node)
 			ifFalse: [ ^ self signal ].
-		node replaceWith: rewriteRule tree. 
+		node replaceWith: (transformedNode := rewriteRule tree). 
 		Author 
 			useAuthor: 'AutoDeprecationRefactoring'
 			during: [aMethod origin compile: aMethod ast formattedCode classified: aMethod protocol].	
 		Log  ifNotNil: [:log | log add: self].
-		self logTranscript]
+		self logTranscript].
+	context return: (transformedNode evaluateForContext: context)
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
The transforming deprecations rely on the deprecated method to call the new method (the transformation is just a side-effect).

But we can do better:

- we can return from the context here, this will then not execute the rest of the deprecated method

-  as we can evaluate ASTs in a context with #evaluateForContext:, we can "run" the AST of the transfromed expression (this is the message send node that 
triggered the deprecated method to be executed which now has been rewritten)