### PR TITLE
Introduce #readFromContext: for all variables

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -60,7 +60,7 @@ Context >> namedTempAt: index put: aValue [
 	"Set the value of the temp at index in the receiver's sequence of tempNames"
 	"NOTE: this list of temp names is completely virtual! It omits temp vectors but 
 	adds every variable that could be acccessed from a source perspective but might not be"
-	^self tempNamed: (self tempNames at: index) put: aValue
+	self tempNamed: (self tempNames at: index) put: aValue
 ]
 
 { #category : #'*Debugging-Core' }
@@ -375,7 +375,7 @@ Context >> tempNamed: aName put: anObject [
 	
 	| var |
 	var := self lookupTempVar: aName.
-	^var write: anObject inContext: self
+	var write: anObject inContext: self
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -27,6 +27,14 @@ Context >> lookupSymbol: aSymbol [
 ]
 
 { #category : #'*Debugging-Core' }
+Context >> lookupTempVar: aSymbol [
+	| var |
+	var := self lookupVar: aSymbol.
+	var isTemp ifFalse: [ ^self error: var name, ' is not a temp but, ', var class name].
+	^var
+]
+
+{ #category : #'*Debugging-Core' }
 Context >> lookupVar: aSymbol [
 	^ self astScope lookupVar: aSymbol
 ]
@@ -357,8 +365,7 @@ Context >> tempNamed: aName [
 	"Returns the value of the temporaries, aName"
 
 	| var |
-	var := self lookupVar: aName.
-	var isTemp ifFalse: [ ^self error: aName, ' is not a temp but, ', var class name].
+	var := self lookupTempVar: aName.
 	^var readFromContext: self
 ]
 
@@ -366,10 +373,9 @@ Context >> tempNamed: aName [
 Context >> tempNamed: aName put: anObject [
 	"Assign the value of the temp with name in aContext"
 	
-	| scope var |
-	scope := self astScope.
-	var := scope lookupVar: aName.
-	^var writeFromContext: self scope: scope value: anObject
+	| var |
+	var := self lookupTempVar: aName.
+	^var write: anObject toContext: self
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -22,15 +22,13 @@ Context >> callPrimitive: primNumber [
 { #category : #'*Debugging-Core' }
 Context >> lookupSymbol: aSymbol [
 	| var |
-	var := self astScope lookupVar: aSymbol.
-	"Local variables"
-	var isTemp ifTrue: [^ self tempNamed: aSymbol].
-	"Instance variables"
-	var isInstance ifTrue: [^ self receiver instVarNamed: aSymbol].
-	"Class variables and globals"
-	var isGlobal ifTrue: [ ^ var variable value ].
-	^ nil.
-	
+	var := self lookupVar: aSymbol.
+	^ var readFromContext: self
+]
+
+{ #category : #'*Debugging-Core' }
+Context >> lookupVar: aSymbol [
+	^ self astScope lookupVar: aSymbol
 ]
 
 { #category : #'*Debugging-Core' }
@@ -358,10 +356,10 @@ Context class >> tallyMethods: aBlock [
 Context >> tempNamed: aName [
 	"Returns the value of the temporaries, aName"
 
-	| scope var |
-	scope := self astScope.
-	var := scope lookupVar: aName.
-	^var readFromContext: self scope: scope.
+	| var |
+	var := self lookupVar: aName.
+	var isTemp ifFalse: [ ^self error: aName, ' is not a temp but, ', var class name].
+	^var readFromContext: self
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -23,7 +23,7 @@ Context >> callPrimitive: primNumber [
 Context >> lookupSymbol: aSymbol [
 	| var |
 	var := self lookupVar: aSymbol.
-	^ var readFromContext: self
+	^ var readInContext: self
 ]
 
 { #category : #'*Debugging-Core' }
@@ -366,7 +366,7 @@ Context >> tempNamed: aName [
 
 	| var |
 	var := self lookupTempVar: aName.
-	^var readFromContext: self
+	^var readInContext: self
 ]
 
 { #category : #'*Debugging-Core' }
@@ -375,7 +375,7 @@ Context >> tempNamed: aName put: anObject [
 	
 	| var |
 	var := self lookupTempVar: aName.
-	^var write: anObject toContext: self
+	^var write: anObject inContext: self
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/Deprecated90/DebuggerMethodMapOpal.extension.st
+++ b/src/Deprecated90/DebuggerMethodMapOpal.extension.st
@@ -11,7 +11,7 @@ DebuggerMethodMapOpal >> namedTempAt: index in: aContext [
 DebuggerMethodMapOpal >> namedTempAt: index put: aValue in: aContext [
 	"please use #namedTempAt:put: on Context"
 	self deprecated: 'Please use aContext namedTempAt: index put: aValue'.
-	^aContext namedTempAt: index put: aValue
+	aContext namedTempAt: index put: aValue
 ]
 
 { #category : #'*Deprecated90' }
@@ -42,7 +42,7 @@ DebuggerMethodMapOpal >> tempNamed: name in: aContext [
 DebuggerMethodMapOpal >> tempNamed: name in: aContext put: aValue [
 	"please use #tempNamed:put: on Context"
 	self deprecated: 'please use #tempNamed:put: on Context'.
-	^aContext tempNamed: name put: aValue
+	aContext tempNamed: name put: aValue
 ]
 
 { #category : #'*Deprecated90' }

--- a/src/HeuristicCompletion-Model/CoVariableValueMessageHeuristic.class.st
+++ b/src/HeuristicCompletion-Model/CoVariableValueMessageHeuristic.class.st
@@ -31,9 +31,9 @@ CoVariableValueMessageHeuristic >> valueOfVariable: aName inContext: completionC
 	| binding |
 	"In the debugger, the binding values comes in the doItContext.
 	If we find in the doItContext has a variable with the given name, use it, otherwise ignore it."
-	(completionContext doItContext ifNotNil: [ :c | 
-		(c astScope lookupVar: aName)
-			ifNotNil: [ c lookupSymbol: aName ] ])
+	(completionContext doItContext ifNotNil: [ :context | 
+		(context lookupVar: aName)
+			ifNotNil: [:var | var readFromContext: context ] ])
 		ifNotNil: [ :value | ^ aBlock value: value ].
 
 	"In the playground, the binding values comes in the bindings of the requestor.

--- a/src/HeuristicCompletion-Model/CoVariableValueMessageHeuristic.class.st
+++ b/src/HeuristicCompletion-Model/CoVariableValueMessageHeuristic.class.st
@@ -33,7 +33,7 @@ CoVariableValueMessageHeuristic >> valueOfVariable: aName inContext: completionC
 	If we find in the doItContext has a variable with the given name, use it, otherwise ignore it."
 	(completionContext doItContext ifNotNil: [ :context | 
 		(context lookupVar: aName)
-			ifNotNil: [:var | var readFromContext: context ] ])
+			ifNotNil: [:var | var readInContext: context ] ])
 		ifNotNil: [ :value | ^ aBlock value: value ].
 
 	"In the playground, the binding values comes in the bindings of the requestor.

--- a/src/Kernel-Tests-WithCompiler/ContextTest.extension.st
+++ b/src/Kernel-Tests-WithCompiler/ContextTest.extension.st
@@ -48,3 +48,17 @@ ContextTest >> testTempNamedPut [
 	thisContext tempNamed: 'oneTemp' put: 2.
 	self assert: (thisContext tempNamed: 'oneTemp') equals: 2
 ]
+
+{ #category : #'*Kernel-Tests-WithCompiler' }
+ContextTest >> testTempNamedPutShouldFailGivenNameIsNotTemp [
+	
+	self assert: (self class hasSlotNamed: #expectedFails).	
+	self should: [thisContext tempNamed: #expectedFails put: 0] raise: Error
+]
+
+{ #category : #'*Kernel-Tests-WithCompiler' }
+ContextTest >> testTempNamedShouldFailGivenNameIsNotTemp [
+
+	self assert: (self class hasSlotNamed: #testSelector).
+	self should: [thisContext tempNamed: #testSelector] raise: Error
+]

--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -261,3 +261,11 @@ LiteralVariable >> write: anObject [
 	self value: anObject.
 	^anObject
 ]
+
+{ #category : #debugging }
+LiteralVariable >> write: aValue toContext: aContext [
+	self isWritable ifFalse: [ 
+		^self error: 'Variable ' , name, ' is read only'].
+
+	value := aValue
+]

--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -227,7 +227,7 @@ LiteralVariable >> read [
 ]
 
 { #category : #debugging }
-LiteralVariable >> readFromContext: aContext [
+LiteralVariable >> readInContext: aContext [
 	^self value
 ]
 
@@ -263,7 +263,7 @@ LiteralVariable >> write: anObject [
 ]
 
 { #category : #debugging }
-LiteralVariable >> write: aValue toContext: aContext [
+LiteralVariable >> write: aValue inContext: aContext [
 	self isWritable ifFalse: [ 
 		^self error: 'Variable ' , name, ' is read only'].
 

--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -130,11 +130,6 @@ LiteralVariable >> isGlobalClassNameBinding [
 		and: [ name == self value name ]
 ]
 
-{ #category : #testing }
-LiteralVariable >> isGlobalVariable [
-	^false
-]
-
 { #category : #OCVARIABLE }
 LiteralVariable >> isLiteralVariable [
 	^true
@@ -228,6 +223,11 @@ LiteralVariable >> printOn: aStream [
 
 { #category : #'meta-object-protocol' }
 LiteralVariable >> read [
+	^self value
+]
+
+{ #category : #debugging }
+LiteralVariable >> readFromContext: aContext [
 	^self value
 ]
 

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -293,7 +293,7 @@ Slot >> read: anObject [
 ]
 
 { #category : #debugging }
-Slot >> readFromContext: aContext [
+Slot >> readInContext: aContext [
 	^self read: aContext receiver
 ]
 
@@ -346,12 +346,12 @@ Slot >> wantsInitialization [
 	^false
 ]
 
+{ #category : #debugging }
+Slot >> write: aValue inContext: aContext [
+	self write: aValue to: aContext receiver
+]
+
 { #category : #'meta-object-protocol' }
 Slot >> write: aValue to: anObject [
 	^self subclassResponsibility
-]
-
-{ #category : #debugging }
-Slot >> write: aValue toContext: aContext [
-	self write: aValue to: aContext receiver
 ]

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -292,6 +292,11 @@ Slot >> read: anObject [
 	^ self subclassResponsibility
 ]
 
+{ #category : #debugging }
+Slot >> readFromContext: aContext [
+	^self read: aContext receiver
+]
+
 { #category : #accessing }
 Slot >> scope: aScope [
 	"ignored, subclasses can override to analyze the scope they are to be installed in"

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -350,3 +350,8 @@ Slot >> wantsInitialization [
 Slot >> write: aValue to: anObject [
 	^self subclassResponsibility
 ]
+
+{ #category : #debugging }
+Slot >> write: aValue toContext: aContext [
+	self write: aValue to: aContext receiver
+]

--- a/src/Kernel/TemporaryVariable.class.st
+++ b/src/Kernel/TemporaryVariable.class.st
@@ -134,7 +134,7 @@ TemporaryVariable >> usingMethods [
 
 { #category : #'reflecive api' }
 TemporaryVariable >> write: aValue InContext: aContext [
-	^aContext tempNamed: name put: aValue
+	aContext tempNamed: name put: aValue
 ]
 
 { #category : #'saved temps' }

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -274,3 +274,8 @@ Variable >> variable [
 	"I return the first class variable that I model in the case of globals and ivars"
 	^self
 ]
+
+{ #category : #debugging }
+Variable >> write: aValue toContext: aContext [
+	self subclassResponsibility 
+]

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -231,7 +231,7 @@ Variable >> propertyAt: propName put: propValue [
 ]
 
 { #category : #debugging }
-Variable >> readFromContext: aContext [
+Variable >> readInContext: aContext [
 	self subclassResponsibility 
 ]
 
@@ -276,6 +276,6 @@ Variable >> variable [
 ]
 
 { #category : #debugging }
-Variable >> write: aValue toContext: aContext [
+Variable >> write: aValue inContext: aContext [
 	self subclassResponsibility 
 ]

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -230,6 +230,11 @@ Variable >> propertyAt: propName put: propValue [
 		put: propValue
 ]
 
+{ #category : #debugging }
+Variable >> readFromContext: aContext [
+	self subclassResponsibility 
+]
+
 { #category : #properties }
 Variable >> removePropertiesIfEmpty [
 	^ Properties at: self ifPresent: [ :dict |

--- a/src/OpalCompiler-Core/OCSelfVariable.class.st
+++ b/src/OpalCompiler-Core/OCSelfVariable.class.st
@@ -37,6 +37,6 @@ OCSelfVariable >> isSelfOrSuper [
 ]
 
 { #category : #debugging }
-OCSelfVariable >> readFromContext: aContext [
+OCSelfVariable >> readInContext: aContext [
 	^aContext receiver
 ]

--- a/src/OpalCompiler-Core/OCSelfVariable.class.st
+++ b/src/OpalCompiler-Core/OCSelfVariable.class.st
@@ -35,3 +35,8 @@ OCSelfVariable >> isSelf [
 OCSelfVariable >> isSelfOrSuper [
 	^true
 ]
+
+{ #category : #debugging }
+OCSelfVariable >> readFromContext: aContext [
+	^aContext receiver
+]

--- a/src/OpalCompiler-Core/OCSpecialVariable.class.st
+++ b/src/OpalCompiler-Core/OCSpecialVariable.class.st
@@ -28,3 +28,9 @@ OCSpecialVariable >> isUninitialized [
 OCSpecialVariable >> isWritable [
 	^ false
 ]
+
+{ #category : #debugging }
+OCSpecialVariable >> write: aValue toContext: aContext [
+	
+	self error: name, ' is reserved word and cant be modified'
+]

--- a/src/OpalCompiler-Core/OCSpecialVariable.class.st
+++ b/src/OpalCompiler-Core/OCSpecialVariable.class.st
@@ -30,7 +30,7 @@ OCSpecialVariable >> isWritable [
 ]
 
 { #category : #debugging }
-OCSpecialVariable >> write: aValue toContext: aContext [
+OCSpecialVariable >> write: aValue inContext: aContext [
 	
 	self error: name, ' is reserved word and cant be modified'
 ]

--- a/src/OpalCompiler-Core/OCSuperVariable.class.st
+++ b/src/OpalCompiler-Core/OCSuperVariable.class.st
@@ -38,6 +38,6 @@ OCSuperVariable >> isSuper [
 ]
 
 { #category : #debugging }
-OCSuperVariable >> readFromContext: aContext [
+OCSuperVariable >> readInContext: aContext [
 	^aContext receiver
 ]

--- a/src/OpalCompiler-Core/OCSuperVariable.class.st
+++ b/src/OpalCompiler-Core/OCSuperVariable.class.st
@@ -36,3 +36,8 @@ OCSuperVariable >> isSelfOrSuper [
 OCSuperVariable >> isSuper [
 	^true
 ]
+
+{ #category : #debugging }
+OCSuperVariable >> readFromContext: aContext [
+	^aContext receiver
+]

--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -143,14 +143,6 @@ OCTempVariable >> markWrite [
 ]
 
 { #category : #debugging }
-OCTempVariable >> readFromContext: aContext [
-
-	| contextScope |
-	contextScope := aContext astScope.
-	^self readFromContext: aContext scope: contextScope
-]
-
-{ #category : #debugging }
 OCTempVariable >> readFromContext: aContext scope: contextScope [
 	| definitionContext |
 	definitionContext := contextScope lookupDefiningContextForVariable: self startingFrom: aContext.
@@ -164,7 +156,15 @@ OCTempVariable >> readFromLocalContext: aContext [
 ]
 
 { #category : #debugging }
-OCTempVariable >> write: aValue toContext: aContext [
+OCTempVariable >> readInContext: aContext [
+
+	| contextScope |
+	contextScope := aContext astScope.
+	^self readFromContext: aContext scope: contextScope
+]
+
+{ #category : #debugging }
+OCTempVariable >> write: aValue inContext: aContext [
 
 	| contextScope |
 	contextScope := aContext astScope.

--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -143,6 +143,14 @@ OCTempVariable >> markWrite [
 ]
 
 { #category : #debugging }
+OCTempVariable >> readFromContext: aContext [
+
+	| contextScope |
+	contextScope := aContext astScope.
+	^self readFromContext: aContext scope: contextScope
+]
+
+{ #category : #debugging }
 OCTempVariable >> readFromContext: aContext scope: contextScope [
 	| definitionContext |
 	definitionContext := contextScope lookupDefiningContextForVariable: self startingFrom: aContext.

--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -164,6 +164,14 @@ OCTempVariable >> readFromLocalContext: aContext [
 ]
 
 { #category : #debugging }
+OCTempVariable >> write: aValue toContext: aContext [
+
+	| contextScope |
+	contextScope := aContext astScope.
+	self writeFromContext: aContext scope: contextScope value: aValue
+]
+
+{ #category : #debugging }
 OCTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 
 	| definitionContext |

--- a/src/OpalCompiler-Core/OCThisContextVariable.class.st
+++ b/src/OpalCompiler-Core/OCThisContextVariable.class.st
@@ -32,6 +32,6 @@ OCThisContextVariable >> isThisContext [
 ]
 
 { #category : #debugging }
-OCThisContextVariable >> readFromContext: aContext [
+OCThisContextVariable >> readInContext: aContext [
 	^aContext
 ]

--- a/src/OpalCompiler-Core/OCThisContextVariable.class.st
+++ b/src/OpalCompiler-Core/OCThisContextVariable.class.st
@@ -30,3 +30,8 @@ OCThisContextVariable >> initialize [
 OCThisContextVariable >> isThisContext [
 	^true
 ]
+
+{ #category : #debugging }
+OCThisContextVariable >> readFromContext: aContext [
+	^aContext
+]

--- a/src/Reflectivity/RFTempWrite.class.st
+++ b/src/Reflectivity/RFTempWrite.class.st
@@ -22,7 +22,8 @@ RFTempWrite >> context: anObject [
 
 { #category : #evaluating }
 RFTempWrite >> value [
-	^variable write: assignedValue InContext: context
+	variable write: assignedValue InContext: context.
+	^assignedValue
 ]
 
 { #category : #accessing }

--- a/src/Slot-Tests/ClassVariableTest.class.st
+++ b/src/Slot-Tests/ClassVariableTest.class.st
@@ -64,6 +64,18 @@ ClassVariableTest >> testPropertyAtPut [
 ]
 
 { #category : #'tests  - properties' }
+ClassVariableTest >> testReadingFromContext [
+
+	| classVariable |
+	TestVariable := #testValue.
+	classVariable := self class classVariableNamed: #TestVariable.
+	
+	self
+		assert: (classVariable readFromContext: thisContext)
+		equals: #testValue
+]
+
+{ #category : #'tests  - properties' }
 ClassVariableTest >> testRemoveProperty [
 	| classVariable |
 	classVariable := self class classVariableNamed: #TestVariable.
@@ -74,4 +86,14 @@ ClassVariableTest >> testRemoveProperty [
 		assert: (classVariable propertyAt: #testKeySelector)
 		equals: nil.
 	self assert: classVariable properties isNil.
+]
+
+{ #category : #'tests  - properties' }
+ClassVariableTest >> testWritingToContext [
+
+	| classVariable |
+	classVariable := self class classVariableNamed: #TestVariable.
+	classVariable write: #testValue toContext: thisContext.
+	
+	self assert: TestVariable equals: #testValue
 ]

--- a/src/Slot-Tests/ClassVariableTest.class.st
+++ b/src/Slot-Tests/ClassVariableTest.class.st
@@ -71,7 +71,7 @@ ClassVariableTest >> testReadingFromContext [
 	classVariable := self class classVariableNamed: #TestVariable.
 	
 	self
-		assert: (classVariable readFromContext: thisContext)
+		assert: (classVariable readInContext: thisContext)
 		equals: #testValue
 ]
 
@@ -93,7 +93,7 @@ ClassVariableTest >> testWritingToContext [
 
 	| classVariable |
 	classVariable := self class classVariableNamed: #TestVariable.
-	classVariable write: #testValue toContext: thisContext.
+	classVariable write: #testValue inContext: thisContext.
 	
 	self assert: TestVariable equals: #testValue
 ]

--- a/src/Slot-Tests/SlotTest.class.st
+++ b/src/Slot-Tests/SlotTest.class.st
@@ -80,6 +80,16 @@ SlotTest >> testPropertyAtPut [
 	self assert: ivar properties isNil
 ]
 
+{ #category : #'tests - read/write' }
+SlotTest >> testReadFromContext [ 
+	
+	| slot |
+	ivarForTesting := #testValue.
+	slot := self class slotNamed: #ivarForTesting.
+	
+	self assert: (slot readFromContext: thisContext) equals: #testValue
+]
+
 { #category : #'tests - properties' }
 SlotTest >> testRemoveProperty [
 	| ivar | 
@@ -99,6 +109,16 @@ SlotTest >> testRemoveProperty [
 SlotTest >> testSlotUsers [
 	self assert: (ToOneRelationSlot slotUsers includes: SlotExampleMovie).
 	self deny: (ToOneRelationSlot slotUsers includes: SlotExamplePerson)
+]
+
+{ #category : #'tests - read/write' }
+SlotTest >> testWriteToContext [ 
+	
+	| slot |
+	slot := self class slotNamed: #ivarForTesting.
+	slot write: #testValue toContext: thisContext.
+	
+	self assert: ivarForTesting equals: #testValue
 ]
 
 { #category : #'tests - misc' }

--- a/src/Slot-Tests/SlotTest.class.st
+++ b/src/Slot-Tests/SlotTest.class.st
@@ -87,7 +87,7 @@ SlotTest >> testReadFromContext [
 	ivarForTesting := #testValue.
 	slot := self class slotNamed: #ivarForTesting.
 	
-	self assert: (slot readFromContext: thisContext) equals: #testValue
+	self assert: (slot readInContext: thisContext) equals: #testValue
 ]
 
 { #category : #'tests - properties' }
@@ -116,7 +116,7 @@ SlotTest >> testWriteToContext [
 	
 	| slot |
 	slot := self class slotNamed: #ivarForTesting.
-	slot write: #testValue toContext: thisContext.
+	slot write: #testValue inContext: thisContext.
 	
 	self assert: ivarForTesting equals: #testValue
 ]


### PR DESCRIPTION
- introduces #readInContext: for all variables and refactors #lookupSymbol:.
As result it fixes #lookupSymbol: to work with all kind of slots (it was only working for simple inst vars).
- introduce write:inContext for all variables.

Having pair of those methods we can get read and write any kind of variable having context instance.
