### PR TITLE
CompilationContext: remove DNU Handler

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -397,15 +397,6 @@ CompilationContext >> compilerOptions: anArray [
 	self parseOptions: anArray
 ]
 
-{ #category : #options }
-CompilationContext >> doesNotUnderstand: message [
-
-	(message selector isUnary and: [ message selector beginsWith: 'opt'] )
-		ifTrue: [ ^ options includes: message selector ].
-		
-	^ super doesNotUnderstand: message
-]
-
 { #category : #accessing }
 CompilationContext >> encoderClass [
 	^ encoderClass ifNil: [ encoderClass := self class bytecodeBackend ]


### PR DESCRIPTION
We do not need the #doesNotUnderstand: Handler on the CompilationContext.

The ideas was to have some ultra dynamic way that options can be set and then reacted on by plugins without the need to add code.

But for that we do not need the DNU: plugins just have to query the options using the API instead of just calling #optionSomething.