### PR TITLE
use-OCTempVariable-insteadof-TemporaryVariable

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -395,13 +395,13 @@ Context >> tempNames [
 Context >> temporaryVariableNamed: aName [
 	(self hasTemporaryVariableNamed: aName)
 		ifFalse: [ ^ nil ].
-	^TemporaryVariable name: aName context: self
+	^self lookupTempVar: aName
 
 ]
 
 { #category : #'*Debugging-Core' }
 Context >> temporaryVariables [
-	^self tempNames collect: [ :name | TemporaryVariable new name: name ]
+	^self sourceNode temporaries collect: [ :each | each binding ] 
 
 ]
 

--- a/src/Kernel/TemporaryVariable.class.st
+++ b/src/Kernel/TemporaryVariable.class.st
@@ -119,6 +119,6 @@ TemporaryVariable >> usingMethods [
 ]
 
 { #category : #'reflecive api' }
-TemporaryVariable >> write: aValue InContext: aContext [
+TemporaryVariable >> write: aValue inContext: aContext [
 	aContext tempNamed: name put: aValue
 ]

--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -28,6 +28,11 @@ OCTempVariable >> = aTempVar [
 	
 ]
 
+{ #category : #queries }
+OCTempVariable >> astNodes [
+	^self method variableNodes select: [ :each | each binding == self]
+]
+
 { #category : #emitting }
 OCTempVariable >> emitStore: methodBuilder [
 

--- a/src/OpalCompiler-Core/OCTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCTempVariable.class.st
@@ -99,6 +99,11 @@ OCTempVariable >> isEscapingWrite [
 ]
 
 { #category : #testing }
+OCTempVariable >> isReferenced [
+	^self isUnused not
+]
+
+{ #category : #testing }
 OCTempVariable >> isStoringTempVector [
 	"I am a temp that stores a temp vector. Those generated temps have a invalid name starting with 0"
 	^name first = $0.
@@ -142,6 +147,11 @@ OCTempVariable >> markWrite [
 	super markWrite.
 ]
 
+{ #category : #queries }
+OCTempVariable >> method [
+	^scope node methodNode methodClass>>scope node methodNode selector
+]
+
 { #category : #accessing }
 OCTempVariable >> originalVar [
 	^ self
@@ -166,6 +176,12 @@ OCTempVariable >> readInContext: aContext [
 	| contextScope |
 	contextScope := aContext astScope.
 	^self readFromContext: aContext scope: contextScope
+]
+
+{ #category : #queries }
+OCTempVariable >> usingMethods [
+	self isUnused ifTrue: [ ^#() ].
+	^{self method}
 ]
 
 { #category : #debugging }

--- a/src/Reflectivity/RFTempWrite.class.st
+++ b/src/Reflectivity/RFTempWrite.class.st
@@ -22,7 +22,7 @@ RFTempWrite >> context: anObject [
 
 { #category : #evaluating }
 RFTempWrite >> value [
-	variable write: assignedValue InContext: context.
+	variable write: assignedValue inContext: context.
 	^assignedValue
 ]
 

--- a/src/Slot-Core/BlockClosure.extension.st
+++ b/src/Slot-Core/BlockClosure.extension.st
@@ -8,14 +8,11 @@ BlockClosure >> hasTemporaryVariableNamed: aName [
 { #category : #'*Slot-Core' }
 BlockClosure >> temporaryVariableNamed: aName [
 	(self hasTemporaryVariableNamed: aName) ifFalse: [ ^nil ].
-	^TemporaryVariable 
-		name: aName 
-		block: self 
-
+	^self sourceNode scope lookupVar: aName
 ]
 
 { #category : #'*Slot-Core' }
 BlockClosure >> temporaryVariables [
-	^self tempNames collect: [ :name | TemporaryVariable new name: name ]
+	^self sourceNode temporaries collect: [ :each | each binding ] 
 
 ]

--- a/src/Slot-Core/CompiledMethod.extension.st
+++ b/src/Slot-Core/CompiledMethod.extension.st
@@ -15,5 +15,8 @@ CompiledMethod >> temporaryVariableNamed: aName [
 
 { #category : #'*Slot-Core' }
 CompiledMethod >> temporaryVariables [
-	^self sourceNode temporaries collect: [ :each | each binding ] 
+	"on the level of compiledMethod, temps include the arguments"
+	self flag: #TODO. "we need to revist temps vs args"
+	^(self sourceNode arguments collect: [ :each | each binding ]), 
+		(self sourceNode temporaries collect: [ :each | each binding ])
 ]

--- a/src/Slot-Core/CompiledMethod.extension.st
+++ b/src/Slot-Core/CompiledMethod.extension.st
@@ -8,15 +8,12 @@ CompiledMethod >> hasTemporaryVariableNamed: aName [
 { #category : #'*Slot-Core' }
 CompiledMethod >> temporaryVariableNamed: aName [
 	(self hasTemporaryVariableNamed: aName) ifFalse: [ ^nil ].
-	^TemporaryVariable 
-		name: aName 
-		method: self 
+	^self sourceNode scope lookupVar: aName
 
 
 ]
 
 { #category : #'*Slot-Core' }
 CompiledMethod >> temporaryVariables [
-	^self tempNames collect: [ :name | TemporaryVariable name: name method: self]
-
+	^self sourceNode temporaries collect: [ :each | each binding ] 
 ]

--- a/src/Slot-Tests/TemporaryVariableTest.class.st
+++ b/src/Slot-Tests/TemporaryVariableTest.class.st
@@ -52,7 +52,7 @@ TemporaryVariableTest >> testReadTemporaryVariablesMethod [
 	| tempVar |
 	tempVar := thisContext temporaryVariableNamed: #tempVar.
 
-	self assert: (tempVar readInContext: thisContext) class equals: TemporaryVariable
+	self assert: (tempVar readInContext: thisContext) class equals: OCTempVariable
 ]
 
 { #category : #tests }
@@ -74,6 +74,6 @@ TemporaryVariableTest >> testWriteTemporaryVariablesMethod [
 	| tempVar |
 	tempVar := thisContext temporaryVariableNamed: #tempVar.
 
-	tempVar write: 5 InContext: thisContext.
+	tempVar write: 5 inContext: thisContext.
 	self assert: tempVar equals: 5
 ]

--- a/src/Slot-Tests/TemporaryVariableTest.class.st
+++ b/src/Slot-Tests/TemporaryVariableTest.class.st
@@ -48,6 +48,14 @@ TemporaryVariableTest >> testPropertyAtPut [
 ]
 
 { #category : #tests }
+TemporaryVariableTest >> testReadNodes [
+	| method |
+	"On the level of CompiledMethod, args include temps. This needs to be fixed"
+	method := OrderedCollection >> #do:.
+	self assert: (method temporaryVariableNamed: #aBlock) astNodes notEmpty
+]
+
+{ #category : #tests }
 TemporaryVariableTest >> testReadTemporaryVariablesMethod [
 	| tempVar |
 	tempVar := thisContext temporaryVariableNamed: #tempVar.
@@ -66,7 +74,13 @@ TemporaryVariableTest >> testTemporaryVariablesBlock [
 TemporaryVariableTest >> testTemporaryVariablesMethod [
 	| method |
 	method := self class >> #testTemporaryVariablesMethod.
-	self assert: method temporaryVariables first name equals: #method
+	self assert: method temporaryVariables first name equals: #method.
+	
+	"On the level of CompiledMethod, args include temps. This needs to be fixed"
+	method := OrderedCollection >> #do:.
+	self assert: method temporaryVariables first name equals: #aBlock.
+	self assert: (method hasTemporaryVariableNamed: #aBlock).
+	self assert: (method temporaryVariableNamed: #aBlock) class equals: OCArgumentVariable.
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Hook up OCTempVariable in all the places where we used TemporaryVariable. 

- This shows lots of possibilities for further cleanups, e.g. do we need temporaryVariableNamed: if we have lookupTempVar:  ? 
- lots of duplicated code in e.g. temporaryVariables
- #method is strange

But that could be a next PR