### PR TITLE
PoolVariable-merge-in-ClassVariable

### DIFF
--- a/src/Kernel/ClassVariable.class.st
+++ b/src/Kernel/ClassVariable.class.st
@@ -5,6 +5,8 @@ The compiler forwards bytecode generation to me for accessing the variable.
 
 You can subclass me and implement #read and #write: for creating special kinds of globals that can be used as special class Variables (similar to special Slots).
 
+Note: PoolVariable is not modeled as it's own subclass to allow all special kinds of globals to be used
+as pool variables.
 "
 Class {
 	#name : #ClassVariable,

--- a/src/Kernel/PoolVariable.class.st
+++ b/src/Kernel/PoolVariable.class.st
@@ -1,8 +1,0 @@
-"
-This subclass will model the class variables of SharedPool subclasses and thus pool variables
-"
-Class {
-	#name : #PoolVariable,
-	#superclass : #ClassVariable,
-	#category : #'Kernel-Variables'
-}


### PR DESCRIPTION
ClassVariable was there as a sublass of ClassVariable, with the idea to implement queries (e.g. #usingMethods) there.

But this is not a good idea, as it would mean that we could not use any sublasses (e.g. WeakClassVariable) as pools.

We therefore remove the class (it was not used) and yes, will have to deal with queries in the methods of ClassVariable to treat pool vars specially  (as we do now)