### PR TITLE
CleanupIsPseudoVariable

### DIFF
--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -46,13 +46,18 @@ Slot class >> checkValidName: aSymbol [
 	aSymbol startsWithDigit ifTrue: [ 
 		^ InvalidSlotName signalFor: aSymbol ].
 
-	aSymbol isPseudovariableName ifTrue: [ 
+	(self isPseudovariableName: aSymbol) ifTrue: [ 
 		^ InvalidSlotName signalFor: aSymbol ].
 	
 
 	(aSymbol allSatisfy: [ :aCharacter | aCharacter isAlphaNumeric or: [ aCharacter = $_ ] ]) ifFalse: [ 
 		^ InvalidSlotName signalFor: aSymbol ]
 
+]
+
+{ #category : #testing }
+Slot class >> isPseudovariableName: aSymbol [
+	^ #('self' 'true' 'false' 'nil' 'thisContext' 'super') includes: aSymbol
 ]
 
 { #category : #testing }

--- a/src/Slot-Core/Symbol.extension.st
+++ b/src/Slot-Core/Symbol.extension.st
@@ -17,16 +17,3 @@ Symbol >> asClassVariable [
 Symbol >> asSlot [
 	^ InstanceVariableSlot named: self.
 ]
-
-{ #category : #'*Slot-Core' }
-Symbol >> isPseudovariableName [
-	"Answer true if I am a pseudo-variable name.
-	#self isPseudovariableName -> true
-	"
-	^ self class pseudovariablesNames includes: self
-]
-
-{ #category : #'*Slot-Core' }
-Symbol class >> pseudovariablesNames [
-	^#('self' 'true' 'false' 'nil' 'thisContext' 'super')
-]


### PR DESCRIPTION
The Slot package has an extension method on Symbol #isPseudoVariable. As is is only used in Slot class, it is better to be moved there.