### PR TITLE
6663-hasSpecificLayout-should-delegate-with-dispatch-to-layout

### DIFF
--- a/src/Kernel/AbstractLayout.class.st
+++ b/src/Kernel/AbstractLayout.class.st
@@ -114,6 +114,11 @@ AbstractLayout >> isCustomLayout [
 ]
 
 { #category : #testing }
+AbstractLayout >> isFixedLayout [
+	^false
+]
+
+{ #category : #testing }
 AbstractLayout >> isVariable [
 	^ false
 ]

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -858,7 +858,7 @@ Behavior >> hasSpecificLayout [
 	"Point hasSpecificLayout >>> false"
 	"Array hasSpecificLayout >>> true"
 	
-	^ (self classLayout isKindOf: FixedLayout) not
+	^ self classLayout isFixedLayout not
 	
 
 ]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -608,7 +608,7 @@ ClassDescription >> definitionWithSlots [
 			nextPutAll: 'uses: ';
 			nextPutAll: self traitCompositionString ].
 			
-	(self classLayout isKindOf: FixedLayout) ifFalse: [
+	self classLayout isFixedLayout ifFalse: [
 		stream 
 			crtab; 
 			nextPutAll: 'layout: ';

--- a/src/Kernel/FixedLayout.class.st
+++ b/src/Kernel/FixedLayout.class.st
@@ -23,3 +23,8 @@ FixedLayout >> instanceSpecification [
 		ifTrue: [ 1 ]
 		ifFalse: [ 0 ]
 ]
+
+{ #category : #testing }
+FixedLayout >> isFixedLayout [
+	^true
+]


### PR DESCRIPTION
- add isFixedLayout tests (this only existed on the Ring level)
- use it in definitionWithSlots instead of isKindOf:
- #hasSpecificLayout now uses isFixedLayout

fixes #6663