### PR TITLE
ReservedVariable-usingMethods-isReferenced

### DIFF
--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -229,11 +229,6 @@ Slot >> isReadIn: aCompiledCode [
 ]
 
 { #category : #testing }
-Slot >> isReferenced [
-	^self usingMethods isNotEmpty
-]
-
-{ #category : #testing }
 Slot >> isSelfEvaluating [
 	^true
 ]

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -126,7 +126,7 @@ Variable >> isLiteralVariable [
 
 { #category : #testing }
 Variable >> isReferenced [
-	^ self subclassResponsibility
+	^ self usingMethods isNotEmpty
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Core/ReservedVariable.class.st
+++ b/src/OpalCompiler-Core/ReservedVariable.class.st
@@ -48,6 +48,13 @@ ReservedVariable >> printOn: stream [
 	stream nextPutAll: self name
 ]
 
+{ #category : #queries }
+ReservedVariable >> usingMethods [
+	"first call is very slow as it creates all ASTs"
+	^SystemNavigation new allMethods select: [ : method |
+		method ast variableNodes anySatisfy: [ :varNode | varNode binding == self]]
+]
+
 { #category : #debugging }
 ReservedVariable >> write: aValue inContext: aContext [
 	


### PR DESCRIPTION
- Implement #usingMethods for ReserverdVariables. It is slow when the AST does not exist for all methods, so no test for now
- move isReferenced from Slot to Variable, it implements it in terms of #usingMethods