### PR TITLE
Object centric installer reflective view on objects

### DIFF
--- a/src/Reflectivity-Tests/LinkInstallerTest.class.st
+++ b/src/Reflectivity-Tests/LinkInstallerTest.class.st
@@ -386,6 +386,21 @@ LinkInstallerTest >> testNodesRemovedFromLinkWhenMethodRemovedFromObject [
 ]
 
 { #category : #'links - installing' }
+LinkInstallerTest >> testObjectsAreWeakReferenced [
+
+	| metalink weakArray |
+	metalink := MetaLink new.
+	(obj1 class >> #exampleMethod) ast link: metalink forObject: obj1.
+	weakArray := WeakArray with: obj1.
+	
+	self assert: weakArray first identicalTo: obj1.
+	obj1 := nil.
+	Smalltalk garbageCollect.	
+	self assert: weakArray first equals: nil
+
+]
+
+{ #category : #'links - installing' }
 LinkInstallerTest >> testOneMetaLinkClassAndObjects [
 	"Installs a MetaLink on one class. Installs another MetaLink on one instance of this class.
 	- all instances of the class must be affected by the first MetaLink

--- a/src/Reflectivity-Tests/LinkInstallerTest.class.st
+++ b/src/Reflectivity-Tests/LinkInstallerTest.class.st
@@ -11,6 +11,11 @@ Class {
 }
 
 { #category : #running }
+LinkInstallerTest >> removeClassAccessControlForTests: anObject [
+	anObject realClass removeSelector: #class
+]
+
+{ #category : #running }
 LinkInstallerTest >> setUp [
 	super setUp.
 	Smalltalk garbageCollectMost.
@@ -273,7 +278,8 @@ LinkInstallerTest >> testMetaLinkWithAnonymousClasses [
 	"We just need to link a MetaLink to an object"
 	metalink := MetaLink new.
 	(obj1 class >> #exampleMethod) ast link: metalink forObject: obj1.
-
+	self removeClassAccessControlForTests: obj1.
+	
 	"One of the 2 objects must have migrated to another class"
 	self assert: obj1 class ~= obj2 class.
 	self assert: obj1 class superclass identicalTo: ReflectivityExamples.
@@ -297,6 +303,7 @@ LinkInstallerTest >> testMethodModified [
 	"Putting a link on a random node should migrate the object to an anonymous subclass"
 	metalink := MetaLink new.
 	node link: metalink forObject: obj1.
+	self removeClassAccessControlForTests: obj1.
 	self assert: obj1 class isAnonymous.
 
 	"Modifyinh the original method should remove all object specific links and
@@ -320,6 +327,7 @@ LinkInstallerTest >> testMethodRemoved [
 	"Putting a link on a random node should migrate the object to an anonymous subclass"
 	metalink := MetaLink new.
 	node link: metalink forObject: obj1.
+	self removeClassAccessControlForTests: obj1.
 	self assert: obj1 class isAnonymous.
 
 	"Removing the original method should remove all object specific links and
@@ -483,6 +491,7 @@ LinkInstallerTest >> testPropagateClassScopedLinks [
 	
 	metalink2 := MetaLink new.
 	node link: metalink2 forObject: obj1.
+	self removeClassAccessControlForTests: obj1.
 	
 	anonNode := metalink linkInstaller findSubNode: node in: (obj1 class >> #exampleIfTrueIfFalse) ast.
 	
@@ -653,11 +662,12 @@ LinkInstallerTest >> testRemovingMethodNodes [
 	
 	(ReflectivityExamples >> #exampleIfTrueIfFalse) ast link: metalink forObject: obj1.
 	(ReflectivityExamples >> #exampleIfTrueIfFalse) ast allChildren last link: metalink2 forObject: obj1.
+	self removeClassAccessControlForTests: obj1.
 	
 	node1 := (ReflectivityExamples >> #exampleIfTrueIfFalse)ast.
 	node2 := (ReflectivityExamples >> #exampleIfTrueIfFalse) ast allChildren last.
 	
-	node1 removeLink: metalink forObject: obj1.
+	node1 removeLink: metalink forObject: obj1.	
 	self assert: obj1 class isAnonymous.
 	
 	node2 removeLink: metalink2 forObject: obj1.
@@ -673,6 +683,7 @@ LinkInstallerTest >> testRemovingNodeFromObject [
 	(obj1 class lookupSelector: #exampleMethod) ast link: metalink forObject: obj1.
 	metalink2 := MetaLink new.
 	(obj1 class lookupSelector: #exampleSendNoReturn) ast link: metalink2 forObject: obj1.
+	self removeClassAccessControlForTests: obj1.
 
 	"The two nodes must now exist in the anon subclass"
 	self shouldnt: [ obj1 class >> #exampleSendNoReturn ] raise: KeyNotFound.
@@ -693,6 +704,7 @@ LinkInstallerTest >> testRemovingNodes [
 	
 	(ReflectivityExamples >> #exampleIfTrueIfFalse) ast allChildren first link: metalink forObject: obj1.
 	(ReflectivityExamples >> #exampleIfTrueIfFalse) ast allChildren fourth link: metalink2 forObject: obj1.
+	self removeClassAccessControlForTests: obj1.
 	
 	node1 := (ReflectivityExamples >> #exampleIfTrueIfFalse) ast allChildren first.
 	node2 := (ReflectivityExamples >> #exampleIfTrueIfFalse) ast allChildren fourth.
@@ -711,6 +723,7 @@ LinkInstallerTest >> testRemovingNodesWithSuper [
 	node := (ReflectivityExamples2Subclass >> #methodWithOverrides) ast.
 	link := MetaLink new.
 	node link: link forObject: obj.
+	self removeClassAccessControlForTests: obj.
 	self assert: obj class isAnonymous.
 	node removeLink: link forObject: obj.
 	self deny: obj class isAnonymous
@@ -868,6 +881,7 @@ LinkInstallerTest >> testUninstallLinkFromNode [
 	
 	(ReflectivityExamples >> #exampleIfTrueIfFalse) ast link: metalink.
 	(ReflectivityExamples >> #exampleIfTrueIfFalse) ast link: metalink forObject: obj1.
+	self removeClassAccessControlForTests: obj1.
 	
 	node := (ReflectivityExamples >> #exampleIfTrueIfFalse) ast.
 	self assert: obj1 class isAnonymous.

--- a/src/Reflectivity-Tests/MetaLinkAnonymousClassBuilder.extension.st
+++ b/src/Reflectivity-Tests/MetaLinkAnonymousClassBuilder.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #MetaLinkAnonymousClassBuilder }
+
+{ #category : #'*Reflectivity-Tests' }
+MetaLinkAnonymousClassBuilder >> requestClassOfObject: anObject [ 
+	^anObject class
+]

--- a/src/Reflectivity-Tests/MetaLinkAnonymousClassBuilderTest.class.st
+++ b/src/Reflectivity-Tests/MetaLinkAnonymousClassBuilderTest.class.st
@@ -205,9 +205,11 @@ MetaLinkAnonymousClassBuilderTest >> testWeakMigratedObjectsRegistry [
 	self assert: (builder soleInstanceOf: anonClass) identicalTo: object.
 	self assertCollection: (builder anonSubclassesFor: originalClass) includesAll: {anonClass}.
 	
-	object := nil.
-	anonClass := nil.
-	Smalltalk garbageCollect.
+	object := nil.	
+	Smalltalk garbageCollect.	
+	self should: [builder soleInstanceOf: anonClass] raise: ValueNotFound.
 	
-	self should: [builder soleInstanceOf: anonClass] raise: KeyNotFound
+	anonClass := nil.
+	Smalltalk garbageCollect.	
+	self should: [builder soleInstanceOf: anonClass] raise: KeyNotFound.
 ]

--- a/src/Reflectivity-Tests/MetaLinkAnonymousClassBuilderTest.class.st
+++ b/src/Reflectivity-Tests/MetaLinkAnonymousClassBuilderTest.class.st
@@ -54,6 +54,22 @@ MetaLinkAnonymousClassBuilderTest >> testAnonymousClassForObject [
 ]
 
 { #category : #tests }
+MetaLinkAnonymousClassBuilderTest >> testClassAccessFromClassBuilder [
+	|class subclass realClass|
+	class := object class.
+	subclass := builder newAnonymousSubclassFor: class.
+	builder migrateObject: object toAnonymousClass: subclass.
+	
+	"Anonymous class is hidden from the system: `object class` returns the original class"
+	self assert: object class identicalTo: class.
+	
+	"The metalink class builder, however, sees the anonymous class when calling `object class`"
+	realClass := object realClass.
+	self assert: realClass identicalTo: subclass.
+	self assert: (builder requestClassOfObject: object) identicalTo: realClass
+]
+
+{ #category : #tests }
 MetaLinkAnonymousClassBuilderTest >> testCompileClassAccessorForAnonymousClass [
 	| class |
 	class := ReflectivityExamples newAnonymousSubclass.

--- a/src/Reflectivity-Tests/MetaLinkAnonymousClassBuilderTest.class.st
+++ b/src/Reflectivity-Tests/MetaLinkAnonymousClassBuilderTest.class.st
@@ -1,0 +1,197 @@
+Class {
+	#name : #MetaLinkAnonymousClassBuilderTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'builder',
+		'object'
+	],
+	#category : #'Reflectivity-Tests-Base'
+}
+
+{ #category : #running }
+MetaLinkAnonymousClassBuilderTest >> setUp [
+	"Hooks that subclasses may override to define the fixture of test."
+	super setUp.
+	builder := MetaLinkAnonymousClassBuilder new.
+	object := ReflectivityExamples new
+]
+
+{ #category : #tests }
+MetaLinkAnonymousClassBuilderTest >> testAllSubclassesOfWithSelector [
+	| anonClass1 anonClass2 compiledMethods |
+	anonClass1 := builder newAnonymousSubclassFor: ReflectivityExamples.
+	anonClass2 := builder newAnonymousSubclassFor: ReflectivityExamples.
+	
+	anonClass1 compile: 'exampleAssignment ^self'.
+	compiledMethods := builder 
+		allSubclassesOf: ReflectivityExamples 
+		withSelector: #exampleAssignment.
+		
+	self assert: compiledMethods size equals: 1.
+	self assert: compiledMethods asArray first identicalTo: anonClass1
+]
+
+{ #category : #tests }
+MetaLinkAnonymousClassBuilderTest >> testAnonSubclassesRegistering [
+	|subclasses|
+	subclasses := WeakSet with: (builder newAnonymousSubclassFor: ReflectivityExamples).
+	self assertCollection: (builder anonSubclassesFor: ReflectivityExamples) equals: subclasses
+
+]
+
+{ #category : #tests }
+MetaLinkAnonymousClassBuilderTest >> testAnonymousClassForObject [
+	
+	|originalClass anonClass|
+	originalClass := object class.
+	anonClass := builder anonymousClassForObject: object.	
+	
+	self assert: anonClass superclass identicalTo: originalClass.
+	self assert: anonClass isAnonymous.
+	self assert: (builder anonymousClassForObject: anonClass new) identicalTo: anonClass
+	 
+
+]
+
+{ #category : #tests }
+MetaLinkAnonymousClassBuilderTest >> testCompileClassAccessorForAnonymousClass [
+	| class |
+	class := ReflectivityExamples newAnonymousSubclass.
+	builder compileClassAccessorForAnonymousClass: class.
+	self
+		assert: (class methodDict at: #class) sourceCode
+		equals: builder classAccessorsForAnonymousClasses first.
+	self
+		assert: (class methodDict at: #originalClass) sourceCode
+		equals: builder classAccessorsForAnonymousClasses second.
+	self
+		assert: (class methodDict at: #realClass) sourceCode
+		equals: builder classAccessorsForAnonymousClasses third.
+]
+
+{ #category : #tests }
+MetaLinkAnonymousClassBuilderTest >> testCompileMethodFromIn [
+	|node anonClass compiledMethod|
+	node := (ReflectivityExamples >> #exampleAssignment) ast statements first.
+	anonClass := ReflectivityExamples newAnonymousSubclass.
+	compiledMethod := builder compileMethodFrom: node in: anonClass.
+	
+	self assert: compiledMethod methodClass identicalTo: anonClass.
+	self assert: compiledMethod sourceCode equals: node methodNode sourceCode
+	 
+
+]
+
+{ #category : #tests }
+MetaLinkAnonymousClassBuilderTest >> testCompiledMethodsOfSelectorInAnonSubClassesOf [
+	| anonClass compiledMethods |
+	anonClass := builder newAnonymousSubclassFor: ReflectivityExamples.
+	anonClass compile: 'exampleAssignment ^self'.
+	compiledMethods := builder
+		compiledMethodsOfSelector: #exampleAssignment
+		inAnonSubClassesOf: ReflectivityExamples.
+		
+	self assert: compiledMethods size equals: 1.
+	self assert: compiledMethods asArray first methodClass identicalTo: anonClass 
+]
+
+{ #category : #tests }
+MetaLinkAnonymousClassBuilderTest >> testCompiledMethodsOfSelectorinClasses [
+	| anonClass1 anonClass2 compiledMethods |
+	anonClass1 := ReflectivityExamples newAnonymousSubclass.
+	anonClass2 := ReflectivityExamples newAnonymousSubclass.
+	
+	anonClass1 compile: 'exampleAssignment ^self'.
+	compiledMethods := builder
+		compiledMethodsOfSelector: #exampleAssignment
+		inClasses: {anonClass1. anonClass2}.
+		
+	self assert: compiledMethods size equals: 1.
+	self assert: compiledMethods asArray first methodClass identicalTo: anonClass1
+]
+
+{ #category : #tests }
+MetaLinkAnonymousClassBuilderTest >> testEmptyAnonSubclasses [
+	self assertCollection: (builder anonSubclassesFor: ReflectivityExamples) equals: Array new
+
+]
+
+{ #category : #tests }
+MetaLinkAnonymousClassBuilderTest >> testMigrateObjectToAnonymousClass [
+	|class subclass realClass originalClass currentClass|
+	class := object class.
+	subclass := builder newAnonymousSubclassFor: class.
+	builder migrateObject: object toAnonymousClass: subclass.
+	
+	realClass := object realClass.
+	self assert: realClass identicalTo: subclass.
+	self assert: (builder soleInstanceOf: realClass) identicalTo: object.
+	
+	originalClass := object originalClass.	
+	currentClass := object class.	
+	self assert: currentClass identicalTo: class.
+	self assert: currentClass identicalTo: originalClass
+	
+]
+
+{ #category : #tests }
+MetaLinkAnonymousClassBuilderTest >> testMigrateObjectToOriginalClass [
+	|class subclass|
+	class := object class.
+	subclass := builder newAnonymousSubclassFor: class.
+	builder migrateObject: object toAnonymousClass: subclass.	
+	builder migrateObjectToOriginalClass: object.
+	
+	self should: [ object realClass ] raise: MessageNotUnderstood.
+	self should: [ object originalClass ] raise: MessageNotUnderstood.
+	self assert: object class identicalTo: class.
+	
+	
+]
+
+{ #category : #tests }
+MetaLinkAnonymousClassBuilderTest >> testNewAnonymousSubclass [
+	|class|
+	class := (builder newAnonymousSubclassFor: ReflectivityExamples).
+	self assert: class isAnonymous.
+	self assert: class superclass identicalTo: ReflectivityExamples.
+	self assert: class new class identicalTo: ReflectivityExamples
+
+]
+
+{ #category : #tests }
+MetaLinkAnonymousClassBuilderTest >> testRemoveMethodNodeFromObject [
+	|node anonClass|
+	node := (object class >> #exampleAssignment) ast.
+	
+	builder removeMethodNode: node fromObject: object.	
+	self deny: object class isAnonymous.
+	self assertCollection: object class selectors includesAll: {#exampleAssignment}.
+	
+	anonClass := object class newAnonymousSubclass.
+	anonClass compile: 'exampleAssignment ^self'.
+	anonClass adoptInstance: object.
+	
+	self assert: object class isAnonymous.
+	self assertCollection: object class selectors includesAll: {#exampleAssignment}.
+	
+	builder removeMethodNode: node fromObject: object.
+	self denyCollection: object class selectors includesAll: {#exampleAssignment}
+]
+
+{ #category : #tests }
+MetaLinkAnonymousClassBuilderTest >> testWeakMigratedObjectsRegistry [	 
+	|originalClass anonClass|
+	originalClass := object class.
+	anonClass := builder anonymousClassForObject: object.	
+	builder migrateObject: object toAnonymousClass: anonClass.
+	
+	self assert: (builder soleInstanceOf: anonClass) identicalTo: object.
+	self assertCollection: (builder anonSubclassesFor: originalClass) includesAll: {anonClass}.
+	
+	object := nil.
+	anonClass := nil.
+	Smalltalk garbageCollect.
+	
+	self should: [builder soleInstanceOf: anonClass] raise: KeyNotFound
+]

--- a/src/Reflectivity/MetaLinkAnonymousClassBuilder.class.st
+++ b/src/Reflectivity/MetaLinkAnonymousClassBuilder.class.st
@@ -45,6 +45,27 @@ MetaLinkAnonymousClassBuilder >> anonymousClassForObject: anObject [
 		ifFalse: [ self newAnonymousSubclassFor: class ]
 ]
 
+{ #category : #accessing }
+MetaLinkAnonymousClassBuilder >> classAccessorsForAnonymousClasses [
+	^{'class
+		thisContext sender methodClass == MetaLinkAnonymousClassBuilder 
+			ifTrue:[^self realClass].
+		^self originalClass'.
+		
+	'originalClass
+		^super class superclass'.
+		
+	'realClass
+		^super class'				
+	}
+]
+
+{ #category : #compiling }
+MetaLinkAnonymousClassBuilder >> compileClassAccessorForAnonymousClass: anAnonymousClass [
+	self classAccessorsForAnonymousClasses
+		do: [ :sourceCode | anAnonymousClass compile: sourceCode ]
+]
+
 { #category : #compiling }
 MetaLinkAnonymousClassBuilder >> compileMethodFrom: aNode in: anAnonymousClass [
 	| selector source |
@@ -96,6 +117,7 @@ MetaLinkAnonymousClassBuilder >> newAnonymousSubclassFor: aClass [
 	anonSubclass := aClass newAnonymousSubclass.
 	(classes at: aClass ifAbsentPut: WeakSet new)
 		add: anonSubclass.
+	self compileClassAccessorForAnonymousClass: anonSubclass.
 	^ anonSubclass
 ]
 

--- a/src/Reflectivity/MetaLinkAnonymousClassBuilder.class.st
+++ b/src/Reflectivity/MetaLinkAnonymousClassBuilder.class.st
@@ -98,8 +98,9 @@ MetaLinkAnonymousClassBuilder >> initialize [
 { #category : #migration }
 MetaLinkAnonymousClassBuilder >> migrateObject: anObject toAnonymousClass: anonClass [
 	anObject class == anonClass
-		ifFalse: [ anonClass adoptInstance: anObject.
-			migratedObjects at: anonClass put: anObject ]
+		ifTrue: [ ^ self ].
+	anonClass adoptInstance: anObject.
+	migratedObjects at: anonClass put: anObject
 ]
 
 { #category : #migration }
@@ -107,8 +108,9 @@ MetaLinkAnonymousClassBuilder >> migrateObjectToOriginalClass: anObject [
 	| class |
 	class := anObject class.
 	class isAnonymous
-		ifTrue: [ migratedObjects removeKey: class.
-			class superclass adoptInstance: anObject ]
+		ifFalse: [ ^ self ].
+	migratedObjects removeKey: class.
+	class superclass adoptInstance: anObject
 ]
 
 { #category : #creation }

--- a/src/Reflectivity/MetaLinkAnonymousClassBuilder.class.st
+++ b/src/Reflectivity/MetaLinkAnonymousClassBuilder.class.st
@@ -100,7 +100,7 @@ MetaLinkAnonymousClassBuilder >> migrateObject: anObject toAnonymousClass: anonC
 	anObject class == anonClass
 		ifTrue: [ ^ self ].
 	anonClass adoptInstance: anObject.
-	migratedObjects at: anonClass put: anObject
+	migratedObjects at: anonClass put: (WeakArray with: anObject)
 ]
 
 { #category : #migration }
@@ -132,5 +132,9 @@ MetaLinkAnonymousClassBuilder >> removeMethodNode: aNode fromObject: anObject [
 
 { #category : #accessing }
 MetaLinkAnonymousClassBuilder >> soleInstanceOf: anAnonymousClass [
-	^ migratedObjects at: anAnonymousClass
+	| weakArray |
+	weakArray := migratedObjects at: anAnonymousClass.
+	(weakArray isEmpty or: [ weakArray first isNil ])
+		ifTrue: [ ^ ValueNotFound new signal ].
+	^ weakArray first
 ]

--- a/src/Reflectivity/MetaLinkInstaller.class.st
+++ b/src/Reflectivity/MetaLinkInstaller.class.st
@@ -334,7 +334,8 @@ MetaLinkInstaller >> reinstallPermaLink: permalink onNode: node [
 	permalink isInstanceSpecific
 		ifFalse: [ node link: link.
 			^ self ].
-	instances := (linksRegistry objectsForLink: link) select: [ :i | i class superclass = permalink slotOrVarClass ].
+	instances := (linksRegistry objectsForLink: link)
+		select: [ :i | i originalClass = permalink slotOrVarClass ].
 	instances do: [ :instance | node link: link forObject: instance ]
 ]
 

--- a/src/Reflectivity/MetaLinkRegistry.class.st
+++ b/src/Reflectivity/MetaLinkRegistry.class.st
@@ -84,7 +84,7 @@ MetaLinkRegistry >> isNodeWithInstanceSpecificLinks: node [
 
 { #category : #'registry access' }
 MetaLinkRegistry >> objectsForLink: aMetaLink [
-	^ links at: aMetaLink ifAbsent: [ Array new ]
+	^ links at: aMetaLink ifAbsent: [ WeakSet new ]
 ]
 
 { #category : #permalinks }
@@ -138,7 +138,7 @@ MetaLinkRegistry >> registeredClassesAt: aClass ifAbsentPut: aBlock [
 
 { #category : #'registry access' }
 MetaLinkRegistry >> registeredTargetsAt: slotOrVariable [
-	^ permanentTargets at: slotOrVariable ifAbsent: [ Set new ]
+	^ permanentTargets at: slotOrVariable ifAbsent: [ WeakSet new ]
 ]
 
 { #category : #'registry access' }


### PR DESCRIPTION
When object-centric metalinks are installed on an object, this object is migrated to an anonymous class.
This anonymous class may interfere with tools, and in addition the syste should not be aware that the object was migrated.

This modification (commit 1703b4a) hides the anonymous class from the system (you always interact with your object as an instance of its original class). 
However it is important that the metalink machinery knows about that anonymous class.
Here, we compile methods to access the real class depending on the context when migrating the object to its anon class.

Research is needed (possibly more scientific than technical) to solve this problem in a clean way. 
Having this now is important to use object-centric metalinks transparently and to develop and integrate tools using them without inteference (at least, the less possible).

In addition, I added a test class (first commit) for one of the object-centric metalink machinery class which was not tested.
One or more classes are not tested, and the `MetalinkInstallerTest` class should be simplified and improved (tests not unitary enough). The metalink machinery itself should be simplified and improved regarding the object-centric implementation. I'm opening new issues for these two points.



