### PR TITLE
Nilled weak reference was found in a dictionary

### DIFF
--- a/src/Reflectivity-Tests/MetaLinkAnonymousClassBuilder.extension.st
+++ b/src/Reflectivity-Tests/MetaLinkAnonymousClassBuilder.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : #MetaLinkAnonymousClassBuilder }
 
 { #category : #'*Reflectivity-Tests' }
+MetaLinkAnonymousClassBuilder >> migratedObjects [
+	^ migratedObjects
+]
+
+{ #category : #'*Reflectivity-Tests' }
 MetaLinkAnonymousClassBuilder >> requestClassOfObject: anObject [ 
 	^anObject class
 ]

--- a/src/Reflectivity-Tests/MetaLinkAnonymousClassBuilderTest.class.st
+++ b/src/Reflectivity-Tests/MetaLinkAnonymousClassBuilderTest.class.st
@@ -206,10 +206,11 @@ MetaLinkAnonymousClassBuilderTest >> testWeakMigratedObjectsRegistry [
 	self assertCollection: (builder anonSubclassesFor: originalClass) includesAll: {anonClass}.
 	
 	object := nil.	
-	Smalltalk garbageCollect.	
+	Smalltalk garbageCollect.
 	self should: [builder soleInstanceOf: anonClass] raise: ValueNotFound.
 	
 	anonClass := nil.
 	Smalltalk garbageCollect.	
-	self should: [builder soleInstanceOf: anonClass] raise: KeyNotFound.
+	self assert: (builder migratedObjects allSatisfy: [:e| e isNil]).
+	self should: [builder soleInstanceOf: nil] raise: KeyNotFound
 ]

--- a/src/Reflectivity/MetaLinkAnonymousClassBuilder.class.st
+++ b/src/Reflectivity/MetaLinkAnonymousClassBuilder.class.st
@@ -133,8 +133,21 @@ MetaLinkAnonymousClassBuilder >> removeMethodNode: aNode fromObject: anObject [
 { #category : #accessing }
 MetaLinkAnonymousClassBuilder >> soleInstanceOf: anAnonymousClass [
 	| weakArray |
+	anAnonymousClass
+		ifNil: [ 
+			"Because anonymous subclasses are weakly referenced by the builder,
+			we assume other tools could do the same and ask for the sole instance
+			of a nilled reference (e.g., recovered from a weak array).
+			In that case (anAnonymousClass isNil), we want to avoid to look into
+			the registry because it also holds weak references to anonymous classes.
+			It would then find a nil key associated to a nil object, and produce a
+			ValueNotFound error while we'rere expecting to be warn that the anonymous
+			class is not there anymore (KeyNotFound)."
+			KeyNotFound signalFor: anAnonymousClass in: migratedObjects ].
 	weakArray := migratedObjects at: anAnonymousClass.
 	(weakArray isEmpty or: [ weakArray first isNil ])
-		ifTrue: [ ^ ValueNotFound new signal ].
+		ifTrue: [ ValueNotFound
+				signalFor: anAnonymousClass
+				in: (migratedObjects at: anAnonymousClass) ].
 	^ weakArray first
 ]


### PR DESCRIPTION
Nilled weak reference was found in a dictionary, producing a ValueNotFound error instead of a KeyNotFound error.
See `MetaLinkAnonymousClassBuilder>>soleInstanceOf:` method comment.

Fixes #6677