### PR TITLE
[fix] remove itemFilterName for the spotter, as it seems to be unused…

### DIFF
--- a/src/GT-Spotter/GTSpotterCandidatesListProcessor.class.st
+++ b/src/GT-Spotter/GTSpotterCandidatesListProcessor.class.st
@@ -13,7 +13,6 @@ Class {
 		'actBlock',
 		'wantsToDisplayOnEmptyQuery',
 		'filterBlock',
-		'itemFilterNameBlock',
 		'keyBinding',
 		'sortBlock'
 	],
@@ -100,24 +99,6 @@ GTSpotterCandidatesListProcessor >> filterUsing: aFilter [
 { #category : #testing }
 GTSpotterCandidatesListProcessor >> hasDynamicItems [
 	^ allCandidatesBlock hasDynamicItems
-]
-
-{ #category : #accessing }
-GTSpotterCandidatesListProcessor >> itemFilterName [
-	^ itemFilterNameBlock
-]
-
-{ #category : #scripting }
-GTSpotterCandidatesListProcessor >> itemFilterName: aBlockWithOneArgument [
-	itemFilterNameBlock := aBlockWithOneArgument
-]
-
-{ #category : #private }
-GTSpotterCandidatesListProcessor >> itemFilterNameFor: anObject [
-
-	^ itemFilterNameBlock
-		ifNil: [ super itemFilterNameFor: anObject ]
-		ifNotNil: [ itemFilterNameBlock cull: anObject ]
 ]
 
 { #category : #accessing }

--- a/src/GT-SpotterExtensions-Core/Collection.extension.st
+++ b/src/GT-SpotterExtensions-Core/Collection.extension.st
@@ -12,8 +12,7 @@ Collection >> spotterItemsFor: aStep [
 		items: [ self collect: [ :each | each asSpotterCandidateLink value] as: OrderedCollection ];
 		itemName: processor itemName;
 		itemIcon: processor itemIcon;
-		actLogic: processor actLogic;
-		itemFilterName: processor itemFilterName;
+		actLogic: processor actLogic; 
 		filter: processor filter gtListFilter;
 		wantsToDisplayOnEmptyQuery: true
 ]

--- a/src/GT-SpotterExtensions-Core/HelpTopic.extension.st
+++ b/src/GT-SpotterExtensions-Core/HelpTopic.extension.st
@@ -41,7 +41,6 @@ HelpTopic >> spotterForHelpTopicFor: aStep [
 		items: [ self subtopics ];
 		itemName: [ :helpTopic | helpTopic title ];
 		itemIcon: [ :helpTopic | helpTopic gtTopicIcon ];
-		itemFilterName: [ :helpTopic | helpTopic contents asString ]; " the filter should only scan the contents / maybe title too ? "
 		filter: GTFilterSubstrings;
 		wantsToDisplayOnEmptyQuery: true
 ]


### PR DESCRIPTION
…. see #6403 for a bit more detail.

GT Spotter tests are passing locally, and I do not know how to create a test for that.