### PR TITLE
Reduce-Interaction-Define-Method

### DIFF
--- a/src/Debugger-Actions/DoesNotUnderstandDebugAction.class.st
+++ b/src/Debugger-Actions/DoesNotUnderstandDebugAction.class.st
@@ -20,16 +20,6 @@ DoesNotUnderstandDebugAction >> appliesToDebugger: aDebugger [
 ]
 
 { #category : #private }
-DoesNotUnderstandDebugAction >> askForCategoryIn: aClass default: aString [
-	| categoryName |
-	categoryName := AbstractTool requestProtocolNameFor: aClass initialAnswer: aString.
-	categoryName ifNil: [^aString].
-	^ categoryName isEmptyOrNil 
-		ifTrue: [^ aString] 
-		ifFalse: [ categoryName ]
-]
-
-{ #category : #private }
 DoesNotUnderstandDebugAction >> askForSuperclassOf: aClass toImplement: aSelector ifCancel: cancelBlock [
 	| classes chosenClassIndex |
 	classes := aClass withAllSuperclasses addAll: (aClass traits sort: [ :t1 :t2 | t1 asString < t2 asString ]); yourself.
@@ -95,7 +85,8 @@ DoesNotUnderstandDebugAction >> executeAction [
 		askForSuperclassOf: self interruptedContext receiver class
 		toImplement: msg selector
 		ifCancel: [^self].
-	msgCategory := (self askForCategoryIn: chosenClass default: 'as yet unclassified').
+	"we do not ask for the category here as it breaks flow"
+	msgCategory := 'as yet unclassified'.
 	self  session
 		implement: msg 
 		classified: msgCategory 

--- a/src/Tool-Base/AbstractTool.class.st
+++ b/src/Tool-Base/AbstractTool.class.st
@@ -38,19 +38,6 @@ AbstractTool class >> protocolSuggestionsFor: aClass [
 	^ interestingProtocols asOrderedCollection sort: [ :a :b | a asLowercase < b asLowercase ].
 ]
 
-{ #category : #private }
-AbstractTool class >> requestProtocolNameFor: aClass initialAnswer: aString [
-	| ui |
-	ui := ListDialogWindow new
-		getList: [ :r | (self protocolSuggestionsFor: aClass) select: [ :e | r search: e ] ];
-		displayBlock: [ :e | e ];
-		initialAnswer: aString;
-		acceptNewEntry: true;
-		title: 'New Protocol Name' ;
-		yourself.
-	^ ui chooseFromOwner: self currentWorld
-]
-
 { #category : #method }
 AbstractTool >> browseAllStoresInto: aVariableName from: aClass [ 
 	^self systemNavigation browseAllStoresInto: aVariableName from: aClass 


### PR DESCRIPTION
When doing Test-first development, the feature to "define method" from the DNU is extremely nice. But the Question to decide for a good category *just then* breaks the flow completely. Nobody wants to decide *now*. This can be done, without harm, later.

Thus: This PR removed the dialog.