### PR TITLE
Fix updating tabs in Calypso broken by new notebook widget

### DIFF
--- a/src/Calypso-Browser/ClyNotebookManager.class.st
+++ b/src/Calypso-Browser/ClyNotebookManager.class.st
@@ -91,22 +91,16 @@ ClyNotebookManager >> addTool: aBrowserTool [
 
 { #category : #updating }
 ClyNotebookManager >> basicUpdateTools [
-	| newTools selectedTools currentTools needsNewSelection selectedIndex |
+		| newTools needsNewSelection selectedTools currentTools |
+		newTools := OrderedCollection new.	
+		browser navigationContextsDo: [ :each | self buildToolsOn: newTools for: each].
+		needsNewSelection := self requiresNewDesiredSelection.
+		selectedTools := self selectedTools.
+		currentTools := tools copy.
 
-	newTools := OrderedCollection new.
-	selectedIndex := self tabMorph selectedPageIndex.	
-	browser navigationContextsDo: [ :each | self buildToolsOn: newTools for: each ].
-	needsNewSelection := self requiresNewDesiredSelection.
-	selectedTools := self selectedTools.
-	currentTools := tools copy.
-	self updateTabsWith: newTools.
-	(needsNewSelection or: [ tools ~= currentTools ]) ifTrue: [ 
-		self restoreSelectedTools: selectedTools.
-		"if we are still in same tab, but we needs to restore tools, we need also to 
-		 force the refresh of the current tab (because sending #selectPageIndex: will 
-		 not refresh it."
-		selectedIndex = self tabMorph selectedPageIndex 
-			ifTrue: [ self tabMorph updatePageIndex: selectedIndex ] ]
+		self updateTabsWith: newTools.
+		(needsNewSelection or: [ tools ~= currentTools ]) 
+			ifTrue: [ self restoreSelectedTools: selectedTools].
 ]
 
 { #category : #accessing }

--- a/src/Calypso-Browser/ClyNotebookMorph.class.st
+++ b/src/Calypso-Browser/ClyNotebookMorph.class.st
@@ -20,7 +20,6 @@ ClyNotebookMorph >> addActions: aCollection [
 ClyNotebookMorph >> addPage: aMorph label: aStringOrMorph [
 	"Add a page and its tab."
 	| index |
-
 	aMorph
 		hResizing: #spaceFill;
 		vResizing: #spaceFill.
@@ -28,10 +27,7 @@ ClyNotebookMorph >> addPage: aMorph label: aStringOrMorph [
 	aMorph privateOwner: self.
 	
 	index := self pages indexOf: aMorph.
-	self tabSelectorMorph tabs 
-		add: (self tabSelectorMorph newLabelMorph: aStringOrMorph) 
-		beforeIndex: index.
-	self tabSelectorMorph updateTabs
+	self tabSelectorMorph addTab: aStringOrMorph beforeIndex: index
 ]
 
 { #category : #initialization }

--- a/src/Morphic-Widgets-PolyTabs/TabGroupMorph.class.st
+++ b/src/Morphic-Widgets-PolyTabs/TabGroupMorph.class.st
@@ -332,12 +332,14 @@ TabGroupMorph >> tabSelectorMorph: anObject [
 ]
 
 { #category : #updating }
-TabGroupMorph >> update: aSymbol [
+TabGroupMorph >> update: aSymbol with: anObject [
 	"Handle tab changes."
 
-	super update: aSymbol.
-	aSymbol == #selectedIndex
-		ifTrue: [self updatePageIndex: self selectedPageIndex]
+	super update: aSymbol with: anObject.
+	aSymbol == #selectedIndex ifTrue: [
+			anObject = 0 "nothing was selected before"
+				ifTrue: [ self updatePageIndex: self selectedPageIndex ]
+				ifFalse: [ self updatePageIndex: self selectedPageIndex oldIndex: anObject ]]
 ]
 
 { #category : #page }
@@ -348,4 +350,9 @@ TabGroupMorph >> updatePageIndex: index [
 	index > 0 ifTrue: [self contentMorph addMorph: (self pages at: index)].
 	self pageMorph ifNotNil: [:pm | pm layoutChanged].
 	self adoptPaneColor: self paneColor
+]
+
+{ #category : #page }
+TabGroupMorph >> updatePageIndex: index oldIndex: oldSelectedIndex [ 
+	self updatePageIndex: index
 ]

--- a/src/Morphic-Widgets-PolyTabs/TabSelectorMorph.class.st
+++ b/src/Morphic-Widgets-PolyTabs/TabSelectorMorph.class.st
@@ -32,6 +32,16 @@ TabSelectorMorph >> addTab: aStringOrMorph [
 ]
 
 { #category : #adding }
+TabSelectorMorph >> addTab: aStringOrMorph beforeIndex: index [
+
+	self tabs add: (self newLabelMorph: aStringOrMorph) beforeIndex: index.
+	selectedIndex >= index ifTrue: [ 
+		"there is now new tab before selected tab"
+		self selectedIndex: selectedIndex + 1 ]. 
+	self updateTabs
+]
+
+{ #category : #adding }
 TabSelectorMorph >> addTab: aStringOrMorph selected: selectedStringOrMorph [
 	"Add a new tab with the given text or morph and alternate for when selected."
 	

--- a/src/Spec2-Adapters-Morphic/SpNotebookMorph.class.st
+++ b/src/Spec2-Adapters-Morphic/SpNotebookMorph.class.st
@@ -255,3 +255,30 @@ SpNotebookMorph >> updatePageIndex: index [
 		oldPage: oldPage;
 		pageIndex: index)
 ]
+
+{ #category : #private }
+SpNotebookMorph >> updatePageIndex: index oldIndex: oldSelectedIndex [
+	"Change to the given page index, update the toolbar and send the announcement"
+	| oldPage newPage |
+
+	index = 0 ifTrue: [ ^ self ].
+
+	oldPage := self pages at: oldSelectedIndex.
+	self pageMorph
+		ifNotNil: [ :aPage | self updateContentMorph: aPage with: (self pageAt: index) ]
+		ifNil: [ self contentMorph addMorph: (self pageAt: index) ].
+
+	newPage := self pages at: index.
+	self postAddPage: newPage.
+
+	self headerMorph layoutChanged.
+	self pageMorph layoutChanged.
+	self adoptPaneColor: (self owner ifNil: [ self ]) paneColor.
+	self tabSelectorMorph font ifNotNil: [ :aFont |
+		(self tabSelectorMorph tabs at: index) font: aFont ].
+
+	self announcer announce: (SpNotebookPageChanged new
+		page: newPage;
+		oldPage: oldPage;
+		pageIndex: index)
+]

--- a/src/Spec2-Adapters-Morphic/SpNotebookTabSelectorMorph.class.st
+++ b/src/Spec2-Adapters-Morphic/SpNotebookTabSelectorMorph.class.st
@@ -48,11 +48,6 @@ SpNotebookTabSelectorMorph >> removeTabIndex: anInteger [
 	"Remove the tab at the given index and
 	adjust any selected (next or first if was last)."
 
-	self tabs removeAt: anInteger.
-
-	self tabs
-		ifNotEmpty: [ self selectedIndex: (self selectedIndex - 1) \\ self tabs size + 1 ]
-		ifEmpty: [ self selectedIndex: 0 ].
-
+	super removeTabIndex: anInteger.
 	self updateTabs
 ]

--- a/src/Spec2-Adapters-Morphic/SpNotebookTabSelectorMorph.class.st
+++ b/src/Spec2-Adapters-Morphic/SpNotebookTabSelectorMorph.class.st
@@ -47,7 +47,13 @@ SpNotebookTabSelectorMorph >> newLabelMorph: aStringOrMorph selected: selectedSt
 SpNotebookTabSelectorMorph >> removeTabIndex: anInteger [
 	"Remove the tab at the given index and
 	adjust any selected (next or first if was last)."
-
-	super removeTabIndex: anInteger.
+	self tabs removeAt: anInteger.
+	selectedIndex >= anInteger ifTrue: [ 
+		selectedIndex = anInteger 
+			ifTrue: [ 
+				self selectedIndex: 0. "to update new tab at current selected index"
+				self tabs ifNotEmpty: [self selectedIndex: anInteger ]]
+			ifFalse: [ self selectedIndex: selectedIndex - 1 ]
+	].	
 	self updateTabs
 ]

--- a/src/Spec2-Backend-Tests/SpNotebookAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpNotebookAdapterTest.class.st
@@ -73,3 +73,15 @@ SpNotebookAdapterTest >> testSelectedPage [
 	presenter selectPageIndex: 2.
 	self assert: self adapter selectedPageName equals: 'Mock2'
 ]
+
+{ #category : #tests }
+SpNotebookAdapterTest >> testSelectingPageShouldAnnounceChangeEvent [
+	| change |
+	self adapter widget tabSelectorMorph selectedIndex: 1.	
+	self adapter widget announcer when: SpNotebookPageChanged do: [ :ann | change := ann ].
+	
+	self adapter widget tabSelectorMorph selectedIndex: 2.
+	
+	self assert: change oldPage model title equals: 'Mock'.
+	self assert: change newPage model title equals: 'Mock2'.
+]

--- a/src/Spec2-Backend-Tests/SpNotebookAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpNotebookAdapterTest.class.st
@@ -38,6 +38,17 @@ SpNotebookAdapterTest >> testRemoveAll [
 ]
 
 { #category : #tests }
+SpNotebookAdapterTest >> testRemoveMiddlePageWhenLastIsSelected [
+	presenter addPage: (SpNotebookPage title: 'Mock3' provider: [ SpLabelPresenter new ]).
+	self assert: self adapter numberOfTabs equals: 3.
+	presenter selectPageIndex: 3.
+	self assert: self adapter selectedPageName equals: 'Mock3'.
+	presenter removePageAt: 2.
+	self assert: self adapter numberOfTabs equals: 2.
+	self assert: self adapter selectedPageName equals: 'Mock3'
+]
+
+{ #category : #tests }
 SpNotebookAdapterTest >> testRemovePage [
 	| page |
 	presenter addPage: (page := SpNotebookPage title: 'Mock3' provider: [ SpLabelPresenter new ]).
@@ -50,6 +61,8 @@ SpNotebookAdapterTest >> testRemovePage [
 SpNotebookAdapterTest >> testRemovePageAt [
 	presenter addPage: (SpNotebookPage title: 'Mock3' provider: [ SpLabelPresenter new ]).
 	self assert: self adapter numberOfTabs equals: 3.
+	presenter selectPageIndex: 1.
+	self assert: self adapter selectedPageName equals: 'Mock'.
 	presenter removePageAt: 2.
 	self assert: self adapter numberOfTabs equals: 2.
 	self assert: self adapter selectedPageName equals: 'Mock'


### PR DESCRIPTION
Try to edit setUp method in setUp tab. After accepting changes the browser will show two setUp tabs. That is the bug caused by new notebook (new widget) integration.

In the history I found that #basicUpdateTools was altered to workaround initial tab updating issue: selecting new methods in same class did not update the tab content. This workaround was wrong. At least it should be implemented in explicit place responsible for tab selections (#restoreSelectedTools). But little debugging shows that it was just an issue with new tab implementation (or superclasses which it's based on):
- tab removal and addition incorrectly update the currently selected tab

Therefore here I provide correct fix and revert Calypso method