### PR TITLE
Better setUp tab in the browser

### DIFF
--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestSetUpEditorTool.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestSetUpEditorTool.class.st
@@ -51,6 +51,23 @@ ClyTestSetUpEditorTool >> belongsToCurrentBrowserContext [
 	^browser isClassSelected: testClass
 ]
 
+{ #category : #building }
+ClyTestSetUpEditorTool >> buildTextMorph [
+	super buildTextMorph.
+	
+	editingMethod == (TestCase >> #setUp) ifTrue: [ 
+		self setUpDefaultTemplate ].
+]
+
+{ #category : #initialization }
+ClyTestSetUpEditorTool >> defaultTemplateForNewSetUp [
+
+	^'setUp
+	super setUp.
+	
+	"Put here a common initializiation logic for tests"'
+]
+
 { #category : #initialization }
 ClyTestSetUpEditorTool >> defaultTitle [
 	^'setUp'
@@ -65,6 +82,13 @@ ClyTestSetUpEditorTool >> editingMethod: aMethod [
 ClyTestSetUpEditorTool >> isSimilarTo: anotherBrowserTool [
 	^self class = anotherBrowserTool class
 		and: [ testClass == anotherBrowserTool testClass ]
+]
+
+{ #category : #initialization }
+ClyTestSetUpEditorTool >> setUpDefaultTemplate [
+
+	textModel setInitialText: self defaultTemplateForNewSetUp.
+	targetClasses := { testClass }
 ]
 
 { #category : #initialization }

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestSetUpEditorTool.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestSetUpEditorTool.class.st
@@ -65,7 +65,7 @@ ClyTestSetUpEditorTool >> defaultTemplateForNewSetUp [
 	^'setUp
 	super setUp.
 	
-	"Put here a common initializiation logic for tests"'
+	"Put here a common initialization logic for tests"'
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
PR implements special case for setUp tab in the browser when it shows a default TestCase>>setUp method.
Now in that case it will show a template with super call and a comment and it will not ask user where to create a method. The method will be created in selected class