### PR TITLE
Use-globals-for-OCEnvironmentScope

### DIFF
--- a/src/Deprecated90/OCEnvironmentScope.class.st
+++ b/src/Deprecated90/OCEnvironmentScope.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'environment'
 	],
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : #'Deprecated90-OpalCompiler-Core'
 }
 
 { #category : #'instance creation' }
@@ -39,10 +39,4 @@ OCEnvironmentScope >> lookupVar: name [
 	name isString ifFalse: [ ^nil ].
 	
 	^environment bindingOf: name
-]
-
-{ #category : #creation }
-OCEnvironmentScope >> newClassScope: aClass [
-
-	^ (OCClassScope for: aClass) outerScope: self; yourself
 ]

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -623,7 +623,7 @@ CompilationContext >> requestorScopeClass: anObject [
 CompilationContext >> scope [
 	| newScope |
 
-	newScope := (OCEnvironmentScope for: self environment) newClassScope: self getClass.
+	newScope := (OCClassScope for: self getClass) outerScope: self environment.
 	requestor ifNotNil: [
 		"the requestor is allowed to manage variables, the workspace is using it to auto-define vars"  
 		newScope := (self requestorScopeClass new

--- a/src/OpalCompiler-Tests/OCEnvironmentScopeTest.class.st
+++ b/src/OpalCompiler-Tests/OCEnvironmentScopeTest.class.st
@@ -37,10 +37,3 @@ OCEnvironmentScopeTest >> testCompileWithProductionEnvironment [
 	return := method valueWithReceiver: nil arguments: #().
 	self assert: return equals: 3.
 ]
-
-{ #category : #'tests - environment' }
-OCEnvironmentScopeTest >> testCreateEnvironmentScope [
-	| new |
-	new := OCEnvironmentScope for: Smalltalk globals.
-	self assert: (new lookupVar: #Object) identicalTo: Object binding
-]

--- a/src/Slot-Core/Dictionary.extension.st
+++ b/src/Slot-Core/Dictionary.extension.st
@@ -23,3 +23,21 @@ Dictionary >> declareVariable: newGlobal from: aDictionary [
 		ifFalse: [
 			self add: newGlobal]
 ]
+
+{ #category : #'*Slot-Core' }
+Dictionary >> hasTempVector [ 
+	^false
+]
+
+{ #category : #'*Slot-Core' }
+Dictionary >> lookupVar: name [
+	"Return a var with this name.  Return nil if none found"
+	name isString ifFalse: [ ^nil ].
+	
+	^self bindingOf: name
+]
+
+{ #category : #'*Slot-Core' }
+Dictionary >> outerScope [
+	^nil
+]


### PR DESCRIPTION
OCEnvironmentScope just wraps the environment (Smalltalk globals in the default case). This is not needed as we can just implement the API there.

- add the needed API to Dictionary
  - yes, this should be *only* on a subclass that is dedicated to be used for environments, this is future work
 - yes, we shoudl not need #hasTempVector there ==> future work
- Change code to use the enviroment as Scope
- move OCEnvironmentScope to deprecated

The extension methods are  kept as Slot extension method together with the other variable related method that needs to be cleaned with a refactoring to have a dedicated dictionary for environment (which might just be SystemDictionary)

(I can't help it but my brain rally loved doing things in a step-by-step way... I tried to have my own fork to create that *huge* change that then is perfect... It just does not work for me)