### PR TITLE
Fix broken test after notebook fixes

### DIFF
--- a/src/Spec2-Backend-Tests/SpNotebookAdapterTest.class.st
+++ b/src/Spec2-Backend-Tests/SpNotebookAdapterTest.class.st
@@ -83,5 +83,5 @@ SpNotebookAdapterTest >> testSelectingPageShouldAnnounceChangeEvent [
 	self adapter widget tabSelectorMorph selectedIndex: 2.
 	
 	self assert: change oldPage model title equals: 'Mock'.
-	self assert: change newPage model title equals: 'Mock2'.
+	self assert: change page model title equals: 'Mock2'.
 ]


### PR DESCRIPTION
The always red CI really breaks reviewers attention to tests.
We should really fix its state