### PR TITLE
[Testing] Process suspend resume terminate issue

### DIFF
--- a/src/Kernel-Tests-Extended/ProcessTest.class.st
+++ b/src/Kernel-Tests-Extended/ProcessTest.class.st
@@ -463,25 +463,22 @@ ProcessTest >> testTerminateActive [
 { #category : #'tests - termination' }
 ProcessTest >> testTerminationShouldProceedAllEnsureBlocksIfSomeWasFailed [
 
-	| ensureCalled process ensureFailure forkedFailures started |
+	| ensureCalled process ensureFailure forkedFailures started unwindError |
 	ensureFailure := Error new messageText: 'signalled inside ensure'.
 	ensureCalled := false.
 	started := false.
 	process := [ 
+		[ 
 		[[started := true. 10 seconds wait] 
 			ensure: [ ensureFailure signal ]]
 				ensure: [ ensureCalled := true ].
+		] on: UnwindError do: [ :err | unwindError := err ]
 	] fork.
 	[started] whileFalse: [ Processor yield ].
 	process terminate.	
 	Processor yield.
 	self assert: ensureCalled.
-	forkedFailures := TestExecutionEnvironment currentFailures.
-	self assert: forkedFailures size equals: 2.
-	self assert: forkedFailures first equals: ensureFailure.
-	self assert: forkedFailures last class equals: UnwindError.
-	self assert: forkedFailures last signalerContext exception equals: ensureFailure.
-	TestExecutionEnvironment resetFailures
+	self assert: unwindError signalerContext exception equals: ensureFailure
 ]
 
 { #category : #'tests - termination' }

--- a/src/Kernel-Tests-Extended/ProcessTest.class.st
+++ b/src/Kernel-Tests-Extended/ProcessTest.class.st
@@ -463,7 +463,7 @@ ProcessTest >> testTerminateActive [
 { #category : #'tests - termination' }
 ProcessTest >> testTerminationShouldProceedAllEnsureBlocksIfSomeWasFailed [
 
-	| ensureCalled process ensureFailure forkedFailures started unwindError |
+	| ensureCalled process ensureFailure started unwindError |
 	ensureFailure := Error new messageText: 'signalled inside ensure'.
 	ensureCalled := false.
 	started := false.

--- a/src/SUnit-Core/Deprecation.extension.st
+++ b/src/SUnit-Core/Deprecation.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : #Deprecation }
 
 { #category : #'*SUnit-Core' }
+Deprecation >> manageTestProcessBy: aProcessMonitorTestService [
+	"Deprecation is not considered as a test failure.
+	So we are ignoring it here just like any other notification"
+]
+
+{ #category : #'*SUnit-Core' }
 Deprecation >> sunitAnnounce: aTestCase toResult: aTestResult [
 	self resume
 ]

--- a/src/SUnit-Core/DirtyTestError.class.st
+++ b/src/SUnit-Core/DirtyTestError.class.st
@@ -1,0 +1,51 @@
+"
+I am a root of hierarchy of errors which represent the dirty state of system produced by test.
+For example the test can left the running background process or background process can raise an error.
+
+TestExecutionEnvironment checks the system state at the end of test and concrete error is raised if dirty state is detected. 
+Those errors are signalled even if test was failed due to domain error. In that case when domain error is handled by SUnit (marking the test result as failed) the another error is signaled to notify about bad system state
+"
+Class {
+	#name : #DirtyTestError,
+	#superclass : #Error,
+	#instVars : [
+		'executionEnvironment'
+	],
+	#category : #'SUnit-Core-Kernel'
+}
+
+{ #category : #'instance creation' }
+DirtyTestError class >> signalFrom: aTestExecutionEnvironment [
+	^self new 
+		executionEnvironment: aTestExecutionEnvironment;
+		signal
+]
+
+{ #category : #accessing }
+DirtyTestError >> executionEnvironment [
+	^ executionEnvironment
+]
+
+{ #category : #accessing }
+DirtyTestError >> executionEnvironment: anObject [
+	executionEnvironment := anObject
+]
+
+{ #category : #'exception handling' }
+DirtyTestError >> manageTestProcessBy: aProcessMonitorTestService [
+	"Do nothing because I am not an error during actual test execution.
+	My subclasses only represent the dirty system state at the end of test"
+]
+
+{ #category : #'exception handling' }
+DirtyTestError >> sunitAnnounce: aTestCase toResult: aTestResult [
+
+	executionEnvironment isMainTestProcessFailed ifTrue: [ 
+		"The main test process errors are handled by SUnit using same message.
+		So the actual domain test error is already counted in result"
+		^self].
+	
+	"If main test process was completed successfully
+	we should mark test as failed due to dirty system state"
+	aTestResult addError: aTestCase
+]

--- a/src/SUnit-Core/Exception.extension.st
+++ b/src/SUnit-Core/Exception.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #Exception }
 
 { #category : #'*SUnit-Core' }
+Exception >> manageTestProcessBy: aProcessMonitorTestService [
+	"By default we are recording any exception in the process monitor"
+	
+	aProcessMonitorTestService recordTestFailure: self
+]
+
+{ #category : #'*SUnit-Core' }
 Exception >> sunitExitWith: aValue [
  
 	self return: aValue

--- a/src/SUnit-Core/Halt.extension.st
+++ b/src/SUnit-Core/Halt.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #Halt }
+
+{ #category : #'*SUnit-Core' }
+Halt >> manageTestProcessBy: aProcessMonitorTestService [
+	"When halt is signaled during test it is always an user intention to debug the test.
+	Therefore we should pass all suspended failures from background processes.
+	So that we will open debugger on all exceptions raised during test"
+	
+	aProcessMonitorTestService passBackgroundFailures
+]

--- a/src/SUnit-Core/Notification.extension.st
+++ b/src/SUnit-Core/Notification.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Notification }
+
+{ #category : #'*SUnit-Core' }
+Notification >> manageTestProcessBy: aProcessMonitorTestService [
+	"Notification is not considered as interesting exception for test monitoring.
+	Normally they are resumable by default. So no break happens for the test"
+]

--- a/src/SUnit-Core/ProcessMonitorTestService.class.st
+++ b/src/SUnit-Core/ProcessMonitorTestService.class.st
@@ -1,0 +1,459 @@
+"
+I monitor all processes forked during tests and track all exceptions signaled from them.
+
+1) The main goal is to ensure that if there was an error from the background process the test will never be green. 
+For example I make following test fail:
+
+	testExample
+		[ 1/0 ] fork.
+		self assert: true.
+
+TestFailedByForkedProcess will be signaled at the end of such test. And if user will debug this test then two debuggers will be opened for each error (for main and background processes).
+		
+2) The second my purpose is to ensure that no running processes will be left after the test.
+The background process can be more tricky than example and it can be forked by domain code.
+Out of the test such processes could affect the overall system behavior. 
+They could affect other tests results. If they fail during other tests it will hide the fact that the issue is related to the original test which will make debugging hard.
+
+So at the end of every test I perform a cleanup (#cleanUpAfterTest) where I terminate all running processes. This behavior can be disabled globaly in settings (System/SUnit) or in test method and setUp:
+
+	self executionProcessMonitor disableProcessTermination 
+	
+To enable it use: 
+
+	self executionProcessMonitor terminateProcessesAfterTest
+
+In addition I implement special logic to fail the test which left running processes after run.
+So the process termination is not hidden. 
+For example following test will fail:
+
+	testExample
+		[ 10 seconds wait ] fork.
+		self assert: true.
+
+TestLeftRunningProcess will be signaled at the end of test.
+For compatibility this feature is disabled by default. And this test would not fail. But it can be enabled globaly in settings (System/SUnit) or in test and setUp:	 
+
+	self executionProcessMonitor failTestLeavingProcesses.
+
+And to disable it use: 
+
+	self executionProcessMonitor allowTestToLeaveProcesses.
+
+3) I can be completelly disabled globaly in settings (System/SUnit) or in test and setUp:
+
+	self executionProcessMonitor disable 
+	 
+Finally at the end of every test I perform a cleanup (#cleanUpAfterTest) where I restore all my default settings. So the next test will be started with default behaviour.
+
+Implementation details:
+
+1. Background failures
+
+I am a kind of TestExecutionService and therefore I intercept all processes forked during the test (#handleNewProcess:).
+I set up default exception handler for them to catch all unhandled exceptions. UnhandledException's are supposed to open a debugger at the end of processing. I postpone this logic by suspending the failing process. So when error is signaled from the background process no debugger will be opened immediately.
+At the end of test (#handleCompletedTest) I check all suspended failures and if they exist I fail the test with TestFailedByForkedProcess signal.
+In interactive mode when user debugs the test I pass all suspended failures together with this signal. So multiple debuggers will be opened to show each error.
+
+The interactive scenario is detected using UnhandledException logic: unhandled error from the main test process or halt from anywhere mean the ""debugger fallback"" and therefore it is a good time to show the rest of failures from other processes. So in that case I pass all suspended failures to debug all of them together.
+
+2. Failing strategy for left processes
+
+I collect all forked processes (#forkedProcesses) and at the end of tests I have an option (#shouldFailTestLeavingProcesses) to fail the test if these processes are still running. TestLeftRunningProcess would be a final error for the test in that case.
+I implement a little logic to make this failing strategy more usable and not break the test in trivial cases. For eaxmple following pattern is quite common in tests: 
+
+	testExample 
+		[ ""some work here"". Processor yield ] fork.
+		Processor yield.
+		self assert: true.
+
+The #yield's here are to describe what could happen in real world: processes can be preemted at any time due to various activities from other image processes (with different priorities). And a simple #fork in tests like this one will not be able to terminate at the end of test while it is ""almost done"".
+The method #allowRunningProcessesToFinish is to solve this issue. It performs own ""Processor yield"" logic to allow such background processes to take a control and finish the execution. 
+
+3. One more detail: 
+In uninteractive mode I signal TestFailedByForkedProcess even if there was a domain error from the test. So two exceptions can be signaled for single test run.
+It allows to log all errors signaled during the test: one from the main process and others from all background processes using this signal (notice that I suspend all background failures and they do not log themselves as a default feedback).
+
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	forkedProcesses:		<OrderedCollection<Process>>
+	testFailures:		<OrderedIdentityDictionary<Process, Exception>>
+	shouldFailTestLeavingProcesses:		<Boolean>
+	shouldSuspendBackgroundFailures:		<Boolean>
+"
+Class {
+	#name : #ProcessMonitorTestService,
+	#superclass : #TestExecutionService,
+	#instVars : [
+		'forkedProcesses',
+		'testFailures',
+		'shouldSuspendBackgroundFailures',
+		'shouldFailTestLeavingProcesses',
+		'shouldTerminateProcesses'
+	],
+	#classInstVars : [
+		'shouldFailTestLeavingProcesses',
+		'shouldTerminateProcesses'
+	],
+	#category : #'SUnit-Core-Kernel'
+}
+
+{ #category : #'fuel support' }
+ProcessMonitorTestService class >> fuelIgnoredInstanceVariableNames [
+    ^#('forkedProcesses' 'suspendedBackgroundFailures')
+]
+
+{ #category : #settings }
+ProcessMonitorTestService class >> settingsForFailingStrategyOn: aBuilder [
+	
+	(aBuilder setting: #shouldFailTestLeavingProcesses)
+		target: self;
+		parent: self name ;
+		default: false;
+		label: 'Fail tests which left running processes' ;
+		description: 'The test will be failed if it left running processes after the run.
+For example following test will fail:
+	testExample
+		[ 10 seconds wait ] fork.
+		self assert: true.
+Tests should not leave the system dirty.
+And this setting is to facilitate such rule relatively to background processes forked during the test.
+See ProcessMonitorTestService comment for more details'
+]
+
+{ #category : #settings }
+ProcessMonitorTestService class >> settingsForTerminationStrategyOn: aBuilder [
+	
+	(aBuilder setting: #shouldTerminateProcesses)
+		target: self;
+		parent: self name ;
+		default: false;
+		label: 'Terminate all processes after the test' ;
+		description: 'At the end of each test all forked processes will be terminated except when we are running in interractive mode under debugger. 
+When debugger opens all control is up to the user.
+But when we are running the test suite to get results it is a good practice to remove all garbage after the test. 
+This setting is about doing it in automatic way.
+See ProcessMonitorTestService comment for more details'
+]
+
+{ #category : #settings }
+ProcessMonitorTestService class >> settingsOn: aBuilder [
+	super settingsOn: aBuilder.
+	
+	self
+		settingsForFailingStrategyOn: aBuilder;
+		settingsForTerminationStrategyOn: aBuilder
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService class >> shouldFailTestLeavingProcesses [
+	^shouldFailTestLeavingProcesses ifNil: [ shouldFailTestLeavingProcesses := false ]
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService class >> shouldFailTestLeavingProcesses: aBoolean [
+	shouldFailTestLeavingProcesses := aBoolean
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService class >> shouldTerminateProcesses [
+	^ shouldTerminateProcesses ifNil: [ shouldTerminateProcesses := true ]
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService class >> shouldTerminateProcesses: anObject [
+	shouldTerminateProcesses := anObject
+]
+
+{ #category : #controlling }
+ProcessMonitorTestService >> allowRunningProcessesToFinish [
+	"The idea here is to allow most trivial processes to finish themselves.
+	So they would not be a garbage left by test.
+	For example following test would left one process at the end:
+		>>testExample
+			[ Processor yield ] fork 
+	But if we would give it a chance to finish it would do this. 
+	So in this method we give running processes a chance to finish:
+		- yield execution until number of rest processes are reduced"
+	| runningProcesses restProcesses |
+	runningProcesses := self runningProcesses.
+	runningProcesses ifEmpty: [ ^self ].
+	(runningProcesses allSatisfy: [ :each | each priority = Processor activePriority ]) ifFalse: [ 
+			"If there is any process with different priority than active one 
+			we can't do anything to allow finish all of them"
+			^self ].
+	
+	[Processor yield.
+	restProcesses := runningProcesses reject: [ :each | each isTerminated ].
+	restProcesses size = runningProcesses size or: [ restProcesses isEmpty ]] 
+		whileFalse: [ runningProcesses := restProcesses ]
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> allowTestToLeaveProcesses [
+
+	shouldFailTestLeavingProcesses := false
+
+]
+
+{ #category : #controlling }
+ProcessMonitorTestService >> cleanUpAfterTest [
+	super cleanUpAfterTest.
+	
+	shouldTerminateProcesses ifTrue: [ 
+		self terminateRunningProcesses].
+	forkedProcesses removeAll.
+	testFailures removeAll.
+	self enableBackgroudFailuresSuspension.
+	self useDefaultFailingStrategyForRunningProcesses.
+	self useDefaultTerminationStrategyForRunningProcesses 
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> disableBackgroudFailuresSuspension [
+
+	shouldSuspendBackgroundFailures := false
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> disableProcessesTermination [
+
+	shouldTerminateProcesses := false
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> enableBackgroudFailuresSuspension [
+
+	shouldSuspendBackgroundFailures := true
+]
+
+{ #category : #controlling }
+ProcessMonitorTestService >> ensureNoBackgroundFailures [
+	self isMainTestProcessFailed & self shouldPassBackgroundFailures ifTrue: [ 
+		"We don't need extra error about failed process when all errors are shown to the user: 
+			- if they were not suspended and were passed
+			- if main test process is also fail (and therefore test fails anyway)"
+		^self ].
+	self suspendedBackgroundFailures ifEmpty: [ ^self ].
+
+	"COMMENT FOR DEBUGGER STOPPED HERE:
+	TestFailedByForkedProcess notifies about background failures.
+	Test failed because forked process failed (even if main test process was completed without errors).
+	See ProcessMonitorTestService comment for more details"
+	[TestFailedByForkedProcess signalFrom: executionEnvironment] 
+		on: UnhandledError do: [ :e | 
+			self passBackgroundFailures.
+			e pass]
+]
+
+{ #category : #controlling }
+ProcessMonitorTestService >> ensureNoRunningProcesses [
+	"If test was already failed due to an error in the main test process 
+	we do not need an extra failure about left processes"
+	self isMainTestProcessFailed ifTrue: [ ^self ].	
+	self runningProcesses ifEmpty: [ ^self ].
+	shouldFailTestLeavingProcesses ifFalse: [ ^self ].
+	
+	"COMMENT FOR DEBUGGER STOPPED HERE:
+	TestLeftRunningProcess notifies that forked processes are still running when test completes.
+	Test failed because test left the system in dirty state.
+	Left runnning processes can affect the result of other tests 
+	and even the general system behavior after test run.
+	This protection can be disabled globaly in settings or in test method and setUp:
+		self executionProcessMonitor allowTestToLeaveProcesses
+	See ProcessMonitorTestService comment for more details"
+	TestLeftRunningProcess signalFrom: executionEnvironment
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> failTestLeavingProcesses [
+
+	shouldFailTestLeavingProcesses := true
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> forkedProcesses [
+	^ forkedProcesses
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> forkedProcesses: anObject [
+	forkedProcesses := anObject
+]
+
+{ #category : #controlling }
+ProcessMonitorTestService >> handleBackgroundException: anUnhandledException [
+	
+	self handleException: anUnhandledException.
+	
+	anUnhandledException pass
+]
+
+{ #category : #controlling }
+ProcessMonitorTestService >> handleCompletedTest [
+	super handleCompletedTest.
+	
+	self allowRunningProcessesToFinish.
+	self ensureNoBackgroundFailures.
+	self ensureNoRunningProcesses
+]
+
+{ #category : #controlling }
+ProcessMonitorTestService >> handleException: anException [
+	super handleException: anException.
+	
+	anException manageTestProcessBy: self
+]
+
+{ #category : #controlling }
+ProcessMonitorTestService >> handleNewProcess: aProcess [
+	super handleNewProcess: aProcess.
+	
+	forkedProcesses add: aProcess.
+	
+	aProcess on: UnhandledException do: [ :err |
+		self handleBackgroundException: err]
+]
+
+{ #category : #controlling }
+ProcessMonitorTestService >> handleUnhandledException: anUnhandledException [
+	self recordTestFailure: anUnhandledException.
+	
+	executionEnvironment isMainTestProcessActive ifTrue: [ ^self passBackgroundFailures ].
+	
+	shouldSuspendBackgroundFailures ifTrue: [
+		self suspendBackgroundFailure: anUnhandledException]
+]
+
+{ #category : #initialization }
+ProcessMonitorTestService >> initialize [
+	super initialize.
+	
+	self enableBackgroudFailuresSuspension.
+	self useDefaultFailingStrategyForRunningProcesses.
+	self useDefaultTerminationStrategyForRunningProcesses.
+	forkedProcesses := WeakSet new.
+	testFailures := OrderedIdentityDictionary new.
+	 
+]
+
+{ #category : #testing }
+ProcessMonitorTestService >> isMainTestProcessFailed [
+	^self isTestProcessFailed: executionEnvironment mainTestProcess
+]
+
+{ #category : #testing }
+ProcessMonitorTestService >> isTestProcessFailed: aProcess [
+
+	^testFailures at: aProcess ifPresent: [ true ] ifAbsent: [ false ]
+]
+
+{ #category : #controlling }
+ProcessMonitorTestService >> passBackgroundFailures [	
+	self disableBackgroudFailuresSuspension.
+	self disableProcessesTermination.
+		
+	testFailures keys 
+		select: [:each | each isSuspended ] 
+		thenDo: [:each | each resume ]
+]
+
+{ #category : #controlling }
+ProcessMonitorTestService >> recordTestFailure: anException [
+
+	| activeProcess |
+	activeProcess := Processor activeProcess.
+	activeProcess isTerminating ifTrue: [ 
+		"Do nothing for exceptions during process termination"
+		^self ]. 
+	
+	testFailures at: activeProcess put: anException
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> runningProcesses [
+	"Suspended processes are not scheduled and therefore they are not considered as running"
+	^ forkedProcesses reject: [ :each | each isTerminated or: [ each isSuspended ]]
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> shouldFailTestLeavingProcesses [
+	^ shouldFailTestLeavingProcesses
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> shouldFailTestLeavingProcesses: anObject [
+	shouldFailTestLeavingProcesses := anObject
+]
+
+{ #category : #testing }
+ProcessMonitorTestService >> shouldPassBackgroundFailures [
+	^shouldSuspendBackgroundFailures not
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> shouldSuspendBackgroundFailures [
+	^ shouldSuspendBackgroundFailures
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> shouldSuspendBackgroundFailures: anObject [
+	shouldSuspendBackgroundFailures := anObject
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> shouldTerminateProcesses [
+	^ shouldTerminateProcesses
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> shouldTerminateProcesses: anObject [
+	shouldTerminateProcesses := anObject
+]
+
+{ #category : #controlling }
+ProcessMonitorTestService >> suspendBackgroundFailure: anException [
+
+	| activeProcess |
+	activeProcess := Processor activeProcess.
+	activeProcess isTerminating ifTrue: [ 
+		"Do nothing if process is under termination"
+		^self ]. 
+	
+	self recordTestFailure: anException.
+	activeProcess suspend
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> suspendedBackgroundFailures [
+	^ testFailures associationsSelect: [ :each | each key isSuspended ]
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> terminateProcessesAfterTest [
+
+	shouldTerminateProcesses := true
+]
+
+{ #category : #controlling }
+ProcessMonitorTestService >> terminateRunningProcesses [
+	forkedProcesses do: [:each | each terminate]
+]
+
+{ #category : #accessing }
+ProcessMonitorTestService >> testFailures [
+	^ testFailures
+]
+
+{ #category : #initialization }
+ProcessMonitorTestService >> useDefaultFailingStrategyForRunningProcesses [
+
+	shouldFailTestLeavingProcesses := self class shouldFailTestLeavingProcesses.
+
+]
+
+{ #category : #initialization }
+ProcessMonitorTestService >> useDefaultTerminationStrategyForRunningProcesses [
+	shouldTerminateProcesses := self class shouldTerminateProcesses
+]

--- a/src/SUnit-Core/ProcessMonitorTestService.class.st
+++ b/src/SUnit-Core/ProcessMonitorTestService.class.st
@@ -128,7 +128,7 @@ ProcessMonitorTestService class >> settingsForTerminationStrategyOn: aBuilder [
 	(aBuilder setting: #shouldTerminateProcesses)
 		target: self;
 		parent: self name ;
-		default: false;
+		default: true;
 		label: 'Terminate all processes after the test' ;
 		description: 'At the end of each test all forked processes will be terminated except when we are running in interractive mode under debugger. 
 When debugger opens all control is up to the user.

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -211,12 +211,16 @@ TestCase class >> defaultTimeLimitSecs: aNumber [
 TestCase class >> defaultTimeLimitSettingOn: aBuilder [
 	<systemsettings>
 	
-	(aBuilder setting: #defaultTimeLimitSecs)
-		target: self;
-		parent: #pharoSystem ;
-		default: 10.0;
-		label: 'Default time limit for tests (secs)' ;
-		description: 'Detault time limit in seconds for test execution'
+	(aBuilder group: #sunit)
+		label: 'SUnit';
+		parent: #pharoSystem;
+		description: 'SUnit';
+		with: [  
+			(aBuilder setting: #defaultTimeLimitSecs)
+				target: self;
+				default: 10.0;
+				label: 'Default time limit for tests (secs)' ;
+				description: 'Detault time limit in seconds for test execution']
 ]
 
 { #category : #history }
@@ -622,6 +626,16 @@ TestCase >> executeShould: aBlock inScopeOf: anExceptionalEvent withDescriptionC
 			
 ]
 
+{ #category : #accessing }
+TestCase >> executionEnvironment [
+	^CurrentExecutionEnvironment value
+]
+
+{ #category : #accessing }
+TestCase >> executionProcessMonitor [
+	^self executionEnvironment processMonitor
+]
+
 { #category : #testing }
 TestCase >> expectedFailures [
 	| pragmas |
@@ -816,5 +830,5 @@ TestCase >> tearDown [
 
 { #category : #accessing }
 TestCase >> timeLimit: aDuration [
-	^TestExecutionEnvironment maxTimeForTest: aDuration
+	^self executionEnvironment maxTimeForTest: aDuration
 ]

--- a/src/SUnit-Core/TestExecutionEnvironment.class.st
+++ b/src/SUnit-Core/TestExecutionEnvironment.class.st
@@ -1,32 +1,72 @@
 "
-I am special environment to manage test execution. I address three problems:
-
-1) Tests should never hang. They should be executed with time limit. 
-I give them 500 milliseconds by default. It could be overriden by TestCase method #defaultTimeLimit.
-Or it could be specified directly in test method by 
-	self timeLimit: 10 seconds
-It could be changed at any time of test execution.
-
-To implement this logic I maintain special watch dog process which control execution time of tests. It is single for all test suite.
-
-2) When test completes I terminate all running processes which were forked during execution. 
-
-3) I manage all failures from forked processes by preventing spawning debuggers. I mark such tests as failed by signalling TestForkedFailedProcess error.
-When failure is signelled from forked process I suspend it and collect them together inside failedProcesses dictionary.
-TestForkedFailedProcess signal is resumable to allow debug suspended failures. When you debug test and saw this problem you can press Proceed to debug actual failures.
-
+I am a special execution environment to manage the execution of tests.	
 I am installed when test is running (or test suite) by
+
 	CurrentExecutionEnvironment runTestCase: aTestCase
+		
+My current instance for tests can be accessed with handy method directly from the test case: 
+
+	self executionEnvironment 
 	
+It simply returns the value of CurrentExecutionEnvironment.
+	
+Some tests requires completely clean and simplest environment. To disable me override #runCaseManaged on your test class: 
+
+	runCaseManaged 
+		^DefaultExecutionEnvironment beActiveDuring: [ self runCase]
+
+1) Test watchdog
+
+I implement a watchdog to ensure that tests complete in finite time and never hanged.
+I give them 10 seconds by default which can be overriden by test class using method #defaultTimeLimit.
+Or it can be specified directly in the test method:
+	self timeLimit: 10 seconds
+It can be changed at any time during the test.
+
+To implement this logic I maintain special watchdog process which controls the execution time of tests. It is a single process for overall test suite.
+
+2) Test services 
+
+In addition I provide an extandable service infrastructure to monitor the test execution.
+During the test I track all signaled exceptions from the test process and all forked processes.
+I notify registered services about these events:
+
+- #handleException:, it is executed for every exception signaled from the test 
+- #handleCompletedTest, it is executed when test is completes (successfully or due to the error)
+- #handleNewProcess:, it is executed for every process created during the test
+- #cleanUpAfterTest:, it is executed as final action when test is done and the environment needs to be prepared for the next test run.
+
+My #services are subclasses of TestExecutionService (see its comment for details).
+	
+I automatically register all service classes enabled by default (#registerDefaultServices). But users can enable required services manually for given tests:
+
+	self executionEnvironment enableService: TestServiceExample
+
+Or with configuration block: 
+
+	self executionEnvironment enableService: TestServiceExample using: [:service | ]
+	
+I lookup given service class in my registered services and use the found one if it exists. Otherwise I create and register new service instance with enabled state. 	
+At the end of test I disable services which were registered manually registed and which are disabled by default. So no other tests are affected by them.
+	
+I provide handy method to access well known service ProcessMonitorTestService:
+
+	self executionEnvironment processMonitor 
+	
+Or simply:
+
+	self executionProcessMonitor
+		 
 Internal Representation and Key Implementation Points.
 
     Instance Variables
-	failedProcesses:		<Dictionary of<Process->Error>>
-	forkedProcesses:		<OrderedCollection of<Process>>
+	services:		<OrderedCollection<TestExecutionService>>
+	mainTestProcess:		<Process>
 	maxTimeForTest:		<Duration>
 	testCase:		<TestCase>
 	watchDogProcess:		<Process>
 	watchDogSemaphore:		<Semaphore>
+	testCompleted:		<Boolean>
 "
 Class {
 	#name : #TestExecutionEnvironment,
@@ -36,97 +76,152 @@ Class {
 		'watchDogSemaphore',
 		'testCase',
 		'maxTimeForTest',
-		'forkedProcesses',
-		'failedProcesses',
-		'testCompleted'
+		'testCompleted',
+		'services',
+		'mainTestProcess'
 	],
 	#category : #'SUnit-Core-Kernel'
 }
 
-{ #category : #controlling }
-TestExecutionEnvironment class >> currentFailures [
-
-	^CurrentExecutionEnvironment value failures
-]
-
 { #category : #'fuel support' }
 TestExecutionEnvironment class >> fuelIgnoredInstanceVariableNames [
-    ^#('watchDogProcess' 'watchDogSemaphore' 'forkedProcesses' 'failedProcesses')
+    ^#('watchDogProcess' 'watchDogSemaphore' 'mainTestProcess')
 ]
 
-{ #category : #controlling }
-TestExecutionEnvironment class >> maxTimeForTest: aDuration [
+{ #category : #settings }
+TestExecutionEnvironment class >> settingsOn: aBuilder [
+	<systemsettings>	
 
-	CurrentExecutionEnvironment value maxTimeForTest: aDuration
-]
-
-{ #category : #controlling }
-TestExecutionEnvironment class >> resetFailures [
-
-	^CurrentExecutionEnvironment value resetFailures
+	TestExecutionService defaultServiceClasses do: [ :each | 
+		each settingsOn: aBuilder]
 ]
 
 { #category : #controlling }
 TestExecutionEnvironment >> activated [
 
-	| testProcess |
-	testProcess := Processor activeProcess.
-	watchDogSemaphore := Semaphore new.
-	watchDogProcess := [self watchDogLoopFor: testProcess] newProcess.
-	"Watchdog needs to run at high priority to do its job (but not at timing priority)"
-	watchDogProcess 
-		name: 'Tests execution watch dog';
-		priority: Processor timingPriority-1;
-		resume
+	mainTestProcess := Processor activeProcess.
+	self registerDefaultServices.
+	self startWatchDog
 ]
 
 { #category : #controlling }
-TestExecutionEnvironment >> checkForkedProcesses [
-
-	forkedProcesses reject: [:each | failedProcesses includesKey: each ] thenDo: #terminate.
-	failedProcesses ifEmpty: [ ^self].	
-	"Following curtailed logic ensures that we will terminate all processes only 
-	if we will not debug them"
-	[TestFailedByForkedProcess signal] ifCurtailed: [
-		failedProcesses keysDo: #terminate]. 
-	"We will be here only if user press Proceed in debugger. 
-	In that case we will allow him to debug failed processes"
-	failedProcesses keys reject: #isTerminated thenDo: #resume
+TestExecutionEnvironment >> cleanUpAfterTest [
+	"Cleanup is performed over all services (enabled and disabled) 
+	because service can change its state during test execution
+	(user can disable it in the middle of test)"
+	
+	services do: [ :each | each cleanUpAfterTest]
 ]
 
 { #category : #controlling }
 TestExecutionEnvironment >> deactivated [
 
-	watchDogProcess terminate
+	watchDogProcess ifNotNil: [watchDogProcess terminate]
+]
+
+{ #category : #private }
+TestExecutionEnvironment >> disableService: aTestExecutionServiceClass [
+
+	| service |
+	service := self findService: aTestExecutionServiceClass ifAbsent: [^self].
+	service disable 
+]
+
+{ #category : #private }
+TestExecutionEnvironment >> enableService: aTestExecutionServiceClass [
+
+	| service |
+	service := self findService: aTestExecutionServiceClass ifAbsent: [
+		self registerService: aTestExecutionServiceClass new].
+	service enable.
+	^service
+]
+
+{ #category : #private }
+TestExecutionEnvironment >> enableService: aTestExecutionServiceClass using: aBlock [
+
+	| service |
+	service := self enableService: aTestExecutionServiceClass.
+	aBlock value: service.
+	^service
+]
+
+{ #category : #accessing }
+TestExecutionEnvironment >> enabledServicesDo: aBlock [
+	
+	services select: [ :each | each isEnabled ] thenDo: aBlock
 ]
 
 { #category : #accessing }
 TestExecutionEnvironment >> failures [
-	^failedProcesses values
+	^self processMonitor testFailures
+]
+
+{ #category : #accessing }
+TestExecutionEnvironment >> findService: aTestExecutionServiceClass [
+	^services detect: [:each | each isKindOf: aTestExecutionServiceClass]
+]
+
+{ #category : #accessing }
+TestExecutionEnvironment >> findService: aTestExecutionServiceClass ifAbsent: absentBlock [
+	^services detect: [:each | each isKindOf: aTestExecutionServiceClass] ifNone: absentBlock
 ]
 
 { #category : #accessing }
 TestExecutionEnvironment >> forkedProcesses [
-	^ forkedProcesses
+	^ self processMonitor forkedProcesses
 ]
 
-{ #category : #accessing }
-TestExecutionEnvironment >> forkedProcesses: anObject [
-	forkedProcesses := anObject
+{ #category : #controlling }
+TestExecutionEnvironment >> handleCompletedTest [
+	
+	self enabledServicesDo: [ :each | each handleCompletedTest].
+]
+
+{ #category : #controlling }
+TestExecutionEnvironment >> handleException: anException [
+
+	self enabledServicesDo: [ :each | each handleException: anException].
+	
+	anException pass
+]
+
+{ #category : #controlling }
+TestExecutionEnvironment >> handleNewProcess: aProcess [
+
+	self enabledServicesDo: [ :each | each handleNewProcess: aProcess ].
 ]
 
 { #category : #initialization }
 TestExecutionEnvironment >> initialize [
 	super initialize.
-	
-	forkedProcesses := WeakSet new.
-	failedProcesses := OrderedIdentityDictionary new.
+	services := OrderedCollection new.
 	testCompleted := false
+]
+
+{ #category : #testing }
+TestExecutionEnvironment >> isMainTestProcess: aProcess [
+	^mainTestProcess = aProcess
+]
+
+{ #category : #testing }
+TestExecutionEnvironment >> isMainTestProcessActive [
+	^self isMainTestProcess: Processor activeProcess
+]
+
+{ #category : #testing }
+TestExecutionEnvironment >> isMainTestProcessFailed [
+	^self processMonitor isMainTestProcessFailed
 ]
 
 { #category : #testing }
 TestExecutionEnvironment >> isTest [
 	^true
+]
+
+{ #category : #accessing }
+TestExecutionEnvironment >> mainTestProcess [
+	^ mainTestProcess
 ]
 
 { #category : #accessing }
@@ -145,25 +240,39 @@ TestExecutionEnvironment >> maxTimeForTest: aDuration [
 { #category : #controlling }
 TestExecutionEnvironment >> prepareForNewProcess: aProcess [
 	| processBlock |
-	watchDogProcess ifNil: [ ^self ].  "we should not catch watchDogProcess"
-	forkedProcesses add: aProcess.
-	aProcess suspendedContext sender ifNotNil: [ ^self ]. "Some existing tests in system create processes on arbitrary block and then check suspendedContext state. Without this 'if' all this tests will fail"
+	watchDogProcess ifNil: [ ^self ]. "we should not catch watchDogProcess which is always the first one"
+	aProcess suspendedContext sender ifNotNil: [ ^self ]. "Some existing tests in system create processes on arbitrary block and then check suspendedContext state. Without this 'if' all these tests will fail"
 	processBlock := aProcess suspendedContext receiver.
 	processBlock isClosure ifFalse: [ ^self ]. "same case as in previous comment"
 	
-	aProcess on: Error do: [ :err | | activeProcess |
-		"It is possible to fork process with copy of stack from another process
-		It means that aProcess could be not actual active process inside this block handler.
-		So we should not reference temp aProcess and instead we should work with actual active process"
-		activeProcess := Processor activeProcess. 
-		failedProcesses at: activeProcess put: err.
-		activeProcess isTerminating ifFalse: [activeProcess suspend].
-		err pass]
+	self handleNewProcess: aProcess
+]
+
+{ #category : #accessing }
+TestExecutionEnvironment >> processMonitor [
+	^self findService: ProcessMonitorTestService
 ]
 
 { #category : #controlling }
-TestExecutionEnvironment >> resetFailures [
-	failedProcesses removeAll
+TestExecutionEnvironment >> registerDefaultServices [
+
+	TestExecutionService enabledServiceClasses do: [ :each |
+		self registerService: each new	
+	 ]
+]
+
+{ #category : #private }
+TestExecutionEnvironment >> registerService: aTestExecutionService [
+
+	aTestExecutionService executionEnvironment: self.
+	services add: aTestExecutionService.
+	^aTestExecutionService 
+]
+
+{ #category : #accessing }
+TestExecutionEnvironment >> removeAllServices [
+
+	services removeAll
 ]
 
 { #category : #controlling }
@@ -171,35 +280,53 @@ TestExecutionEnvironment >> runTestCase: aTestCase [
 	testCase := aTestCase.
 	maxTimeForTest := testCase defaultTimeLimit.
 	testCompleted := false.
-	watchDogSemaphore signal. "signal about new test case"
-
-	[[self runTestCaseSafelly: aTestCase] ensure: [
+	watchDogSemaphore signal. "signal about new test case"	
+	[self runTestCaseUnderWatchdog: aTestCase] ensure: [
 		testCompleted := true.
-		watchDogSemaphore signal]. "signal that test case completes"
-	
-	self checkForkedProcesses] ifCurtailed: [
-		forkedProcesses removeAll.
-		failedProcesses removeAll]
+		watchDogSemaphore signal.  "signal that test case is completed"	
+		self cleanUpAfterTest	].
 ]
 
 { #category : #controlling }
-TestExecutionEnvironment >> runTestCaseSafelly: aTestCase [
+TestExecutionEnvironment >> runTestCaseUnderWatchdog: aTestCase [
+	
 	[
-		[aTestCase runCase] on: Halt do: [ :halt | 
-			"if test was halted we should resume all background failures 
-			to debug all of them together with test process"
-			failedProcesses keysDo: #resume. halt pass ]
-	] on: Error, TestFailure do: [ :err | 
-		"error here means that test is failed. So we should check forked processes 
-		and be able to debug all background failures together with original error"
-		self checkForkedProcesses. 
-		err pass  ]
+		[aTestCase runCase] ensure: [
+			"Terminated test is not considered as completed (user just closed a debugger for example)"
+			mainTestProcess isTerminating ifFalse: [ 
+				self handleCompletedTest ]]
+	] on: Exception do: [ :err | 
+			self handleException: err 
+	]
+	
 ]
 
 { #category : #controlling }
 TestExecutionEnvironment >> runTestsBy: aBlock [
 
 	aBlock value
+]
+
+{ #category : #accessing }
+TestExecutionEnvironment >> services [
+	^ services
+]
+
+{ #category : #accessing }
+TestExecutionEnvironment >> services: anObject [
+	services := anObject
+]
+
+{ #category : #controlling }
+TestExecutionEnvironment >> startWatchDog [
+	
+	watchDogSemaphore := Semaphore new.
+	watchDogProcess := [self watchDogLoop] newProcess.
+	"Watchdog needs to run at high priority to do its job (but not at timing priority)"
+	watchDogProcess 
+		name: 'Tests execution watch dog';
+		priority: Processor timingPriority-1;
+		resume
 ]
 
 { #category : #accessing }
@@ -213,21 +340,26 @@ TestExecutionEnvironment >> testCase: anObject [
 ]
 
 { #category : #controlling }
-TestExecutionEnvironment >> watchDogLoopFor: testProcess [
+TestExecutionEnvironment >> watchDogLoop [
 
 	| timeIsGone |
 	[	"waiting new test case" 
 		watchDogSemaphore wait. 
 		"waiting while test completes"
-		[timeIsGone := watchDogSemaphore waitTimeoutMSecs: maxTimeForTest asMilliSeconds.
+		[timeIsGone := watchDogSemaphore wait: maxTimeForTest.
 		testCompleted] whileFalse: [ 
 			"this subloop allows to dynamically change time limit and restart watch dog"
 			timeIsGone ifTrue: [
 				"The main purpose of following condition is to ignore timeout when test is under debug.
 				Test process is suspended only when it is debugged"
-				testProcess isSuspended ifFalse: [
-					testProcess signalException: TestTookTooMuchTime new]]	].
+				mainTestProcess isSuspended ifFalse: [
+					mainTestProcess signalException: TestTookTooMuchTime new]]	].
 	] repeat
 
 
+]
+
+{ #category : #accessing }
+TestExecutionEnvironment >> watchDogProcess [
+	^ watchDogProcess
 ]

--- a/src/SUnit-Core/TestExecutionService.class.st
+++ b/src/SUnit-Core/TestExecutionService.class.st
@@ -1,0 +1,170 @@
+"
+I am a root of hierarchy of services for test execution environment.
+
+Every service registered in the environment is notified about following events:
+
+- #handleException:, it is executed for every Exception signaled from the test 
+- #handleCompletedTest, it is executed when test is completes (successfully or due to the error)
+- #handleNewProcess:, it is executed for every process created during the test
+
+I implement them as dummy methods. Subclasses can choose what exactly they need to implement.
+
+I define another method #cleanUpAfterTest to perform full cleanup of service to be prepared for the next test.
+Subclasses should extend this method to perform own specific cleanup. 
+All services must recover own default state in this method.
+
+For example every service can be enabled or disabled for concrete test: 
+
+	- enable 
+	- disble
+
+During #cleanUpAfterTest I restore the activeness according to my default configuration (class side #isEnabled). Subclasses should do the same with their own configurations.
+
+TestExecutionEnvironment queries all my subclasses to register them for tests execution: 
+
+	TestExecutionService enabledServiceClasses.
+	
+Settings browser queries all default services to collect their parameters and allow users to enable/disable services globaly:
+	
+	TestExecutionService defaultServiceClasses.
+
+Default services are not abstract classes enabled by default (#isEnabledByDefault = true).
+
+To provide configuration for setting browser subclasses should extend class side method #settingsOn:. It does not require a pragma because the actual collection of settings from all services is performed by test environment.
+		
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	executionEnvironment:		<TestExecutionEnvironment>
+	isEnabled:		<Boolean>
+
+"
+Class {
+	#name : #TestExecutionService,
+	#superclass : #Object,
+	#instVars : [
+		'executionEnvironment',
+		'isEnabled'
+	],
+	#classInstVars : [
+		'isEnabled'
+	],
+	#category : #'SUnit-Core-Kernel'
+}
+
+{ #category : #accessing }
+TestExecutionService class >> defaultServiceClasses [
+
+	^Array streamContents: [ :s |
+		self allSubclassesDo: [ :each | 
+			each isAbstract not & each isEnabledByDefault ifTrue: [s nextPut: each ]]]
+]
+
+{ #category : #settings }
+TestExecutionService class >> descriptionForSettingsBrowser [
+	^self comment
+]
+
+{ #category : #accessing }
+TestExecutionService class >> enabledServiceClasses [
+
+	^Array streamContents: [ :s |
+		self allSubclassesDo: [ :each | 
+			each isAbstract not & each isEnabled ifTrue: [s nextPut: each ]]]
+]
+
+{ #category : #accessing }
+TestExecutionService class >> isAbstract [ 
+	^self = TestExecutionService
+]
+
+{ #category : #accessing }
+TestExecutionService class >> isEnabled [ 
+	^isEnabled ifNil: [ isEnabled := self isEnabledByDefault ]
+]
+
+{ #category : #accessing }
+TestExecutionService class >> isEnabled: aBoolean [
+	isEnabled := aBoolean
+]
+
+{ #category : #testing }
+TestExecutionService class >> isEnabledByDefault [
+	^true
+]
+
+{ #category : #settings }
+TestExecutionService class >> settingsOn: aBuilder [
+	"No need for pragma <systemsettings>:
+	TestExecutionEnvironment organizes settings for all services.
+	It calls this method for every default service class.
+	Subclasses should override it to provide specific configuration options"	
+	(aBuilder setting: self name)
+		target: self;
+		parent: #sunit;
+		getSelector: #isEnabled;
+		setSelector: #isEnabled:;
+		default: false;
+		label: self name;
+		description: self descriptionForSettingsBrowser
+]
+
+{ #category : #controlling }
+TestExecutionService >> cleanUpAfterTest [
+	
+	isEnabled := self isEnabledByDefault
+]
+
+{ #category : #controlling }
+TestExecutionService >> disable [
+	isEnabled := false
+]
+
+{ #category : #controlling }
+TestExecutionService >> enable [
+	isEnabled := true
+]
+
+{ #category : #accessing }
+TestExecutionService >> executionEnvironment [
+	^ executionEnvironment
+]
+
+{ #category : #accessing }
+TestExecutionService >> executionEnvironment: anObject [
+	executionEnvironment := anObject
+]
+
+{ #category : #controlling }
+TestExecutionService >> handleCompletedTest [
+]
+
+{ #category : #controlling }
+TestExecutionService >> handleException: anUnhandledException [
+]
+
+{ #category : #controlling }
+TestExecutionService >> handleNewProcess: aProcess [
+]
+
+{ #category : #initialization }
+TestExecutionService >> initialize [ 
+	super initialize.
+	
+	isEnabled := self isEnabledByDefault
+]
+
+{ #category : #accessing }
+TestExecutionService >> isEnabled [ 
+	^isEnabled
+]
+
+{ #category : #accessing }
+TestExecutionService >> isEnabled: aBoolean [
+	isEnabled := aBoolean 
+]
+
+{ #category : #testing }
+TestExecutionService >> isEnabledByDefault [
+	^self class isEnabled
+]

--- a/src/SUnit-Core/TestExecutionService.class.st
+++ b/src/SUnit-Core/TestExecutionService.class.st
@@ -104,7 +104,7 @@ TestExecutionService class >> settingsOn: aBuilder [
 		parent: #sunit;
 		getSelector: #isEnabled;
 		setSelector: #isEnabled:;
-		default: false;
+		default: self isEnabledByDefault;
 		label: self name;
 		description: self descriptionForSettingsBrowser
 ]

--- a/src/SUnit-Core/TestFailedByForkedProcess.class.st
+++ b/src/SUnit-Core/TestFailedByForkedProcess.class.st
@@ -1,26 +1,11 @@
 "
-I am special failure which signalled that some processes was forked during tests and was failed.
-I am resumable and resume will open debuggers on failed processes (in fact they will be resumed).
+I notify users about failed processes which were forked during the test.
+I prevent the test to complete successfully when there was no errors from the main test process but some of background activities fail.
 
-I mark tests red when they produce such processes. So no green tests which spawn ""background debuggers"".
-
-Also I am signalled first when test itself is failed. By resuming it debugger will be opened on test too together with failed processes 
+In practice I ensure no green tests which ""spawn background debuggers""
 "
 Class {
 	#name : #TestFailedByForkedProcess,
-	#superclass : #Error,
+	#superclass : #DirtyTestError,
 	#category : #'SUnit-Core-Kernel'
 }
-
-{ #category : #initialization }
-TestFailedByForkedProcess >> initialize [
-	super initialize.
-	
-	messageText := 'Proceed to debug it'
-]
-
-{ #category : #testing }
-TestFailedByForkedProcess >> isResumable [
-	"users could proceed execution to debug suspended failures"
-	^true
-]

--- a/src/SUnit-Core/TestFailure.class.st
+++ b/src/SUnit-Core/TestFailure.class.st
@@ -8,14 +8,6 @@ Class {
 }
 
 { #category : #'camp smalltalk' }
-TestFailure >> defaultAction [
-
-	Processor activeProcess
-		debug: self signalerContext
-		title: self description
-]
-
-{ #category : #'camp smalltalk' }
 TestFailure >> isResumable [
 	
 	^ false

--- a/src/SUnit-Core/TestLeftRunningProcess.class.st
+++ b/src/SUnit-Core/TestLeftRunningProcess.class.st
@@ -1,0 +1,10 @@
+"
+I notify users about dirty system state when test left running background processes. 
+The process left running after the test could affect the execution of other tests and generaly it could break the system when test suite is complete
+
+"
+Class {
+	#name : #TestLeftRunningProcess,
+	#superclass : #DirtyTestError,
+	#category : #'SUnit-Core-Kernel'
+}

--- a/src/SUnit-Core/TestServiceExample.class.st
+++ b/src/SUnit-Core/TestServiceExample.class.st
@@ -1,0 +1,89 @@
+"
+I am an example of TestExecutionService created for tests.
+I am not enabled by default. So I am not really shown to users.
+
+I simply log in variables everything requested from me by test environment.
+ 
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	forkedProcesses:		<OrderedCollection<Process>>
+	isCleanUpDone:		<Boolean>
+	isCompletedTestHandled:		<Boolean>
+	signaledExceptions:		<OrderedCollection<Exception>>
+
+"
+Class {
+	#name : #TestServiceExample,
+	#superclass : #TestExecutionService,
+	#instVars : [
+		'forkedProcesses',
+		'isCleanUpDone',
+		'isCompletedTestHandled',
+		'signaledExceptions'
+	],
+	#category : #'SUnit-Core-Kernel'
+}
+
+{ #category : #testing }
+TestServiceExample class >> isEnabledByDefault [
+	^false
+]
+
+{ #category : #controlling }
+TestServiceExample >> cleanUpAfterTest [
+	super cleanUpAfterTest.
+	
+	isCleanUpDone := true
+]
+
+{ #category : #accessing }
+TestServiceExample >> forkedProcesses [
+	^ forkedProcesses
+]
+
+{ #category : #controlling }
+TestServiceExample >> handleCompletedTest [
+	super handleCompletedTest.
+	
+	isCompletedTestHandled := true
+]
+
+{ #category : #controlling }
+TestServiceExample >> handleException: anUnhandledException [
+	super handleException: anUnhandledException.
+	
+	signaledExceptions add: anUnhandledException 
+]
+
+{ #category : #controlling }
+TestServiceExample >> handleNewProcess: aProcess [
+	super handleNewProcess: aProcess.
+	
+	forkedProcesses add: aProcess
+]
+
+{ #category : #initialization }
+TestServiceExample >> initialize [ 
+	super initialize.
+	
+	forkedProcesses := OrderedCollection new.
+	signaledExceptions := OrderedCollection new.
+	isCleanUpDone := false.
+	isCompletedTestHandled := false
+]
+
+{ #category : #accessing }
+TestServiceExample >> isCleanUpDone [
+	^ isCleanUpDone
+]
+
+{ #category : #accessing }
+TestServiceExample >> isCompletedTestHandled [
+	^ isCompletedTestHandled
+]
+
+{ #category : #accessing }
+TestServiceExample >> signaledExceptions [
+	^ signaledExceptions
+]

--- a/src/SUnit-Core/TestSkip.class.st
+++ b/src/SUnit-Core/TestSkip.class.st
@@ -14,6 +14,12 @@ TestSkip >> defaultAction [
 ]
 
 { #category : #'exception handling' }
+TestSkip >> manageTestProcessBy: aProcessMonitorTestService [
+	"it is special exception which do not represent the actual test failure.
+	So we just ignoring it"
+]
+
+{ #category : #'exception handling' }
 TestSkip >> sunitAnnounce: aTestCase toResult: aTestResult [
 	aTestResult addSkip: aTestCase.
 ]

--- a/src/SUnit-Core/UnhandledException.extension.st
+++ b/src/SUnit-Core/UnhandledException.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #UnhandledException }
+
+{ #category : #'*SUnit-Core' }
+UnhandledException >> manageTestProcessBy: aProcessMonitorTestService [
+
+	aProcessMonitorTestService handleUnhandledException: self 
+]

--- a/src/SUnit-Core/Warning.extension.st
+++ b/src/SUnit-Core/Warning.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : #Warning }
 
 { #category : #'*SUnit-Core' }
+Warning >> manageTestProcessBy: aProcessMonitorTestService [
+	"Warnings are considered as a test failure.
+	So we are recording it in the process monitor"
+	
+	aProcessMonitorTestService recordTestFailure: self
+]
+
+{ #category : #'*SUnit-Core' }
 Warning >> sunitAnnounce: aTestCase toResult: aTestResult [
 	aTestResult addFailure: aTestCase.
 ]

--- a/src/SUnit-Tests/ProcessMonitorTestServiceTest.class.st
+++ b/src/SUnit-Tests/ProcessMonitorTestServiceTest.class.st
@@ -65,8 +65,6 @@ ProcessMonitorTestServiceTest >> testAllowRunningBackgroundProcessesToFinishButF
 { #category : #tests }
 ProcessMonitorTestServiceTest >> testAlwaysPassBackgroundHalt [
 	| process haltWasPassed halt |
-	self flag: 'it fails runKernelTests on bootstrap image due to Process suspend issue'.
-	self skip.
 	
 	haltWasPassed := false.
 	halt := Halt new.
@@ -185,8 +183,6 @@ ProcessMonitorTestServiceTest >> testDoesNotRaiseForkedProcessFailureWhenFailure
 ProcessMonitorTestServiceTest >> testDoesNotRaiseForkedProcessFailureWhenFailuresWerePassedAndProcessCompletes [
 
 	| process |
-	self flag: 'it fails runKernelTests on bootstrap image due to Process suspend issue'.
-	self skip.
 	process := self fork: [ testService suspendBackgroundFailure: Error new ].
 	
 	testService passBackgroundFailures.
@@ -382,8 +378,6 @@ ProcessMonitorTestServiceTest >> testIsTestProcessFailed [
 { #category : #tests }
 ProcessMonitorTestServiceTest >> testPassBackgroundFailuresWhenSuspensionLogicIsDisabled [
 	| process error errorWasPassed |
-	self flag: 'it fails runKernelTests on bootstrap image due to Process suspend issue'.
-	self skip.
 	errorWasPassed := false.
 	error := Error new messageText: 'test error'.
 	process := self fork: [ Processor activeProcess suspend. error signal ].	
@@ -521,4 +515,42 @@ ProcessMonitorTestServiceTest >> testSuspendBackgroundWarning [
 	suspendedError := testService suspendedBackgroundFailures at: process.
 	self assert: suspendedError class equals: UnhandledError. 
 	self assert: suspendedError exception identicalTo: warning.
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testSuspendResumeTerminateIssue [
+	"The test discovers the issue with Process>>isTerminated method
+	when process was suspended in the middle and then resumed.
+	During the bootstrap process on CI it fails RunKernelTests stage.
+	But it is working on full image"
+	| process ended started |
+	ended := false.
+	started := false.
+	process := [ started := true. Processor activeProcess suspend. ended := true ] newProcess.
+	process priority: Processor activePriority + 1.
+	processes add: process.	
+	process resume.
+	self assert: started description: 'process should be started'.
+	self assert: process isSuspended description: 'process should be suspended'.
+
+	process resume.
+	self assert: ended description: 'process should be ended'.
+	self assert: process isTerminated description: 'process should be terminated'
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testSuspendResumeTerminateIssueWithoutSuspend [
+	"The test proves that suspend at the middle is required condition to trigger the issue.
+	Here the suspend is not performed and test passes on every CI stage.
+	(notice that #printString call here is to have equivalent message send like #suspend)"	
+	| process ended started |
+	ended := false.
+	started := false.
+	process := [ started := true. self printString. ended := true ] newProcess.
+	process priority: Processor activePriority + 1.
+	processes add: process.	
+	process resume.
+	self assert: started description: 'process should be started'.
+	self assert: ended description: 'process should be ended'.
+	self assert: process isTerminated description: 'process should be terminated'
 ]

--- a/src/SUnit-Tests/ProcessMonitorTestServiceTest.class.st
+++ b/src/SUnit-Tests/ProcessMonitorTestServiceTest.class.st
@@ -1,0 +1,518 @@
+Class {
+	#name : #ProcessMonitorTestServiceTest,
+	#superclass : #TestExecutionEnvironmentTestCase,
+	#category : #'SUnit-Tests-Core'
+}
+
+{ #category : #running }
+ProcessMonitorTestServiceTest >> createTestService [
+
+	^ProcessMonitorTestService new
+]
+
+{ #category : #running }
+ProcessMonitorTestServiceTest >> fork: aBlock [
+	"Here we simulate fork under TestExecutionEnvironment 
+	which passes new process to all test services"
+	| newProcess |
+	newProcess := self newProcess: 'Test process' toImmediatelyExecute: aBlock.
+	testService handleNewProcess: newProcess.
+	newProcess resume.
+	^newProcess
+]
+
+{ #category : #running }
+ProcessMonitorTestServiceTest >> setUp [ 
+	super setUp.
+	
+	"Following settings ensure that we are testing full behavior independently from default settings"
+	testService failTestLeavingProcesses. 
+	testService terminateProcessesAfterTest.
+	executionEnvironment activated 
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testAllowRunningBackgroundProcessesToFinish [
+
+	| semaphore processIsDone process |
+	semaphore := Semaphore new.
+	processIsDone := false.
+	process := self fork: [ semaphore wait. processIsDone := true].
+	process priority: Processor activePriority.
+	semaphore signal.
+	self deny: processIsDone.
+	
+	testService handleCompletedTest.
+	
+	self assert: processIsDone.
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testAllowRunningBackgroundProcessesToFinishButFailTestIfItCant [
+
+	| semaphore process wasResumed |
+	semaphore := Semaphore new.
+	wasResumed := false.
+	process := self fork: [ semaphore wait. wasResumed := true. 10 seconds wait].
+	process priority: Processor activePriority.
+	semaphore signal.
+	self deny: wasResumed.
+	
+	self should: [testService handleCompletedTest] raise: TestLeftRunningProcess.
+	self assert: wasResumed
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testAlwaysPassBackgroundHalt [
+	| process haltWasPassed halt |
+	haltWasPassed := false.
+	halt := Halt new.
+	process := self fork: [ Processor activeProcess suspend. halt signal ].
+	testService handleNewProcess: process.
+	
+	process on: Halt do: [ :actual | 
+		actual == halt ifFalse: [ actual pass ]. "it allows to debug if it works wrongly"
+		self assert: actual equals: halt. haltWasPassed := true ].
+	process resume.
+	
+	self assert: process isTerminated.
+	self assert: haltWasPassed.
+	self deny: (testService suspendedBackgroundFailures includesKey: process)
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testCleanUpShouldNotTerminateAllFailedProcessesWhenSuchTerminationIsDisabled [
+	| process  |
+	process := self fork: [ testService suspendBackgroundFailure: Error new ].
+	testService disableProcessesTermination.
+	
+	testService cleanUpAfterTest.
+	
+	self deny: process isTerminated.		
+	self assert: testService suspendedBackgroundFailures isEmpty.
+	self assert: testService forkedProcesses isEmpty
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testCleanUpShouldNotTerminateAllRunningProcessesWhenSuchTerminationIsDisabled [
+	| process  |
+	process := self fork: [ 10 seconds wait ].
+	testService disableProcessesTermination.
+	
+	testService cleanUpAfterTest.
+	
+	self deny: process isTerminated.		
+	self assert: testService forkedProcesses isEmpty
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testCleanUpShouldRestoreDefaultFailingLogicForRunningProcessesCase [
+
+	testService shouldFailTestLeavingProcesses: ProcessMonitorTestService shouldFailTestLeavingProcesses not.
+	
+	testService cleanUpAfterTest.
+	
+	self assert: testService shouldFailTestLeavingProcesses equals: ProcessMonitorTestService shouldFailTestLeavingProcesses.
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testCleanUpShouldRestoreProcessTerminationLogic [
+
+	testService shouldTerminateProcesses: ProcessMonitorTestService shouldTerminateProcesses not.
+	
+	testService cleanUpAfterTest.
+	
+	self assert: testService shouldTerminateProcesses equals: ProcessMonitorTestService shouldTerminateProcesses.
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testCleanUpShouldRestoreSuspensionLogic [
+
+	testService passBackgroundFailures.
+	self deny: testService shouldSuspendBackgroundFailures.
+	
+	testService cleanUpAfterTest.
+	self assert: testService shouldSuspendBackgroundFailures
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testCleanUpShouldTerminateAllFailedProcesses [
+	| process  |
+	process := self fork: [ testService suspendBackgroundFailure: Error new ].
+	
+	testService cleanUpAfterTest.
+	
+	self assert: process isTerminated.		
+	self assert: testService suspendedBackgroundFailures isEmpty.
+	self assert: testService forkedProcesses isEmpty
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testCleanUpShouldTerminateAllRunningProcesses [
+	| process  |
+	process := self fork: [ 10 seconds wait ].
+	
+	testService cleanUpAfterTest.
+	
+	self assert: process isTerminated.		
+	self assert: testService forkedProcesses isEmpty
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testDisableRunningProcessesCleanupWhenPassBackgroundFailures [
+
+	testService passBackgroundFailures.
+	
+	self deny: testService shouldTerminateProcesses
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testDoesNotRaiseForkedProcessFailureWhenFailuresWerePassedAndMainProcessAlsoFails [
+
+	self fork: [ testService suspendBackgroundFailure: Error new. 
+		Processor activeProcess suspend "To emulate process under debugger" ].
+
+	testService passBackgroundFailures.
+	testService recordTestFailure: Error new.	
+		
+	self shouldnt: [testService handleCompletedTest] raise: TestFailedByForkedProcess
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testDoesNotRaiseForkedProcessFailureWhenFailuresWerePassedAndProcessCompletes [
+
+	| process |
+	process := self fork: [ testService suspendBackgroundFailure: Error new ].
+	
+	testService passBackgroundFailures.
+	
+	self shouldnt: [testService handleCompletedTest] raise: TestFailedByForkedProcess.
+	self assert: process isTerminated
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testDoesNotRaiseForkedProcessFailureWhenThereWasOnlyMainProcessFailure [
+
+	testService handleException: Error new.
+	
+	self shouldnt: [testService handleCompletedTest] raise: TestFailedByForkedProcess
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testDoesNotRaiseLeftRunningProcessWhenItAllowsThemToBe [
+
+	| process |
+	process := self fork: [ 10 seconds wait ].
+	self deny: process isTerminated.
+
+	testService allowTestToLeaveProcesses.	
+	self shouldnt: [testService handleCompletedTest] raise: TestLeftRunningProcess.
+	self deny: process isTerminated.
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testDoesNotRaiseLeftRunningProcessWhenProcessWasOnlyCreated [
+
+	testService handleNewProcess: [  ] newProcess.
+	
+	self shouldnt: [testService handleCompletedTest] raise: TestLeftRunningProcess 
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testDoesNotRaiseLeftRunningProcessWhenThereWasMainProcessFailure [
+
+	self fork: [ 10 seconds wait].
+	
+	testService handleException: Error new.
+	
+	self shouldnt: [testService handleCompletedTest] raise: TestLeftRunningProcess
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testFailTestWhenBackgroundFailureWasPassedButMainProcessCompletesSuccessfully [
+
+	self fork: [ testService suspendBackgroundFailure: Error new. 
+		Processor activeProcess suspend "To emulate process under debugger" ].
+	
+	testService passBackgroundFailures.
+	
+	self should: [testService handleCompletedTest] raise: TestFailedByForkedProcess
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testFailTestWhenBackgroundProcessWasFailedDuringFinalTryToFinishItAtTestCompletionTime [
+
+	| semaphore processIsDone process |
+	semaphore := Semaphore new.
+	processIsDone := false.
+	process := self fork: [ semaphore wait. processIsDone := true. 1/0 ].
+	process priority: Processor activePriority.
+	semaphore signal.
+	self deny: processIsDone.
+	
+	self should: [testService handleCompletedTest] raise: TestFailedByForkedProcess.	
+	self assert: processIsDone.
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testFailTestWhenItIsCompletedWithBackgroundFailures [
+
+	self fork: [ testService suspendBackgroundFailure: Error new ].
+	
+	self should: [testService handleCompletedTest] raise: TestFailedByForkedProcess
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testFailTestWhenItIsCompletedWithBackgroundFailuresAndRunningProcesses [
+
+	self fork: [ testService suspendBackgroundFailure: Error new ].
+	self fork: [ 10 seconds wait ].
+	
+	self 
+		should: [
+			[testService handleCompletedTest] 
+				on: TestFailedByForkedProcess do: [ :err | err resumeUnchecked: true ]]
+		raise: TestLeftRunningProcess
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testFailTestWhenItIsCompletedWithRunningProcesses [
+
+	self fork: [ 10 seconds wait ].
+	
+	self should: [testService handleCompletedTest] raise: TestLeftRunningProcess
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testGettingFailuresFromEnvironment [
+
+	self assert: executionEnvironment failures equals: testService testFailures
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testGettingForkedProcessesFromEnvironment [
+
+	self assert: executionEnvironment forkedProcesses equals: testService forkedProcesses
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testGettingServiceFromEnvironment [
+
+	self assert: executionEnvironment processMonitor identicalTo: testService 
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testGettingServiceFromTestCase [
+
+	| actual |
+	executionEnvironment beActiveDuring: [ 
+		actual := self executionProcessMonitor
+	].
+
+	self assert: actual identicalTo: testService 
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testHasDefaultFailingStrategyForRunningProcesses [
+
+	testService := ProcessMonitorTestService new.
+	
+	self assert: testService shouldFailTestLeavingProcesses notNil.
+	self assert: testService shouldFailTestLeavingProcesses equals: ProcessMonitorTestService shouldFailTestLeavingProcesses.
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testHasDefaultTerminationStrategyForRunningProcesses [
+
+	testService := ProcessMonitorTestService new.
+	
+	self assert: testService shouldTerminateProcesses notNil.
+	self assert: testService shouldTerminateProcesses equals: ProcessMonitorTestService shouldTerminateProcesses
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testHasEmptyForkedProcessesByDefault [
+
+	self assert: testService forkedProcesses isEmpty
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testHasEmptySuspendedBackgroundFailuresByDefault [
+
+	self assert: testService suspendedBackgroundFailures isEmpty
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testIgnoreDirtyTestErrors [
+	
+	testService handleException: TestLeftRunningProcess new.
+	self assert: testService testFailures isEmpty.
+	
+	testService handleException: TestFailedByForkedProcess new.
+	self assert: testService testFailures isEmpty
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testIsMainTestProcessFailed [
+
+	executionEnvironment activated.
+	
+	self deny: testService isMainTestProcessFailed.
+	
+	testService recordTestFailure: Error new.
+	self assert: executionEnvironment isMainTestProcessFailed
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testIsTestProcessFailed [
+
+	| process |
+	self deny: (testService isTestProcessFailed: #process).
+	
+	process := self fork: [testService recordTestFailure: Error new].
+	self assert: (testService isTestProcessFailed: process).
+	self deny: (testService isTestProcessFailed: #anotherProcess)
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testPassBackgroundFailuresWhenSuspensionLogicIsDisabled [
+
+	| process error errorWasPassed |
+	errorWasPassed := false.
+	error := Error new messageText: 'test error'.
+	process := self fork: [ Processor activeProcess suspend. error signal ].	
+	
+	testService disableBackgroudFailuresSuspension.
+	self deny: testService shouldSuspendBackgroundFailures.
+	
+	process on: UnhandledError do: [ :err | errorWasPassed := true ].
+	process resume.
+	
+	self assert: process isTerminated.
+	self assert: errorWasPassed
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testRecordMainTestProcessError [
+
+	| error |
+	error := Error new.
+	
+	testService handleException: error.
+
+	self 
+		assert: (testService testFailures at: Processor activeProcess) 
+		equals: error
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testRecordMainTestProcessUnhandledError [
+
+	| error |
+	error := UnhandledError new.
+	
+	testService handleException: error.
+
+	self 
+		assert: (testService testFailures at: Processor activeProcess) 
+		equals: error
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testResumeFailedProcessWhenItFailsTestWithUnhandledError [
+	"Test with background failures is failing with TestFailedByForkedProcess.
+	In case when it is unhandled (when we debug the test) it should resume all background failures"
+	| executed failedProcess |
+	executed := false.
+	failedProcess := self fork: [testService suspendBackgroundFailure: Error new. executed := true ].
+	self assert: failedProcess isSuspended.
+	
+	self runWithNoHandlers: [
+		[testService handleCompletedTest] on: UnhandledError do: [ :err |
+			self deny: failedProcess isSuspended]
+	].
+
+	self assert: executed 
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testResumeFailedProcessesWhenHaltIsSignaled [
+	| executed |
+	executed := false.
+	self fork: [ testService suspendBackgroundFailure: Error new. executed := true ].
+
+	testService handleException: Halt new. 
+	
+	self assert: executed.
+	self deny: testService shouldSuspendBackgroundFailures
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testResumeFailedProcessesWhenHaltIsSignaledInBackground [
+	| processWithHalt executed |
+	executed := false.
+	self fork: [ testService suspendBackgroundFailure: Error new. executed := true ].
+	processWithHalt := self fork: [ Processor activeProcess suspend. Halt new signal ].
+	
+	processWithHalt on: Halt do: [ :actual | ].
+	processWithHalt resume.
+	
+	self assert: executed.
+	self deny: testService shouldSuspendBackgroundFailures
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testResumeFailedProcessesWhenTestFailureIsUnhandled [
+	| executed |
+	executed := false.
+	self fork: [ testService suspendBackgroundFailure: Error new. executed := true ].
+	self deny: executed.	
+
+	testService handleException: Error new. "UnhandledError always started with original error signal"
+	testService handleException: UnhandledError new.
+	self assert: executed.
+	"Unhandled exception opens debugger and therefore any new errors should not be suspended"
+	self deny: testService shouldSuspendBackgroundFailures 
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testShouldSuspendBackgroundFailuresByDefault [
+
+	self assert: testService shouldSuspendBackgroundFailures 
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testStoreAllForkedProcesses [
+
+	| process |
+	process := self fork: [ ].
+	
+	self assert: (testService forkedProcesses includes: process)
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testSuspendBackgroundError [
+
+	| process error suspendedError |
+	error := Error new messageText: 'test error'.
+	
+	process := self fork: [ error signal ].
+	
+	self assert: process isSuspended.
+	suspendedError := testService suspendedBackgroundFailures at: process.
+	self assert: suspendedError class equals: UnhandledError. 
+	self assert: suspendedError exception identicalTo: error.
+]
+
+{ #category : #tests }
+ProcessMonitorTestServiceTest >> testSuspendBackgroundWarning [
+	
+	| process warning suspendedError |
+	warning := Warning new.
+	process := self fork: [ warning signal ].
+	
+	self assert: process isSuspended.
+	suspendedError := testService suspendedBackgroundFailures at: process.
+	self assert: suspendedError class equals: UnhandledError. 
+	self assert: suspendedError exception identicalTo: warning.
+]

--- a/src/SUnit-Tests/ProcessMonitorTestServiceTest.class.st
+++ b/src/SUnit-Tests/ProcessMonitorTestServiceTest.class.st
@@ -187,9 +187,10 @@ ProcessMonitorTestServiceTest >> testDoesNotRaiseForkedProcessFailureWhenFailure
 	
 	testService passBackgroundFailures.
 	
-	self shouldnt: [testService handleCompletedTest] raise: TestFailedByForkedProcess.
 	"Following timeout is because on CI #resume does not start higher priority process immedietely"
 	self should: [process isTerminated] notTakeMoreThan: 100 milliSeconds. 
+	self shouldnt: [testService handleCompletedTest] raise: TestFailedByForkedProcess.
+	
 ]
 
 { #category : #tests }

--- a/src/SUnit-Tests/ProcessMonitorTestServiceTest.class.st
+++ b/src/SUnit-Tests/ProcessMonitorTestServiceTest.class.st
@@ -75,8 +75,7 @@ ProcessMonitorTestServiceTest >> testAlwaysPassBackgroundHalt [
 		self assert: actual equals: halt. haltWasPassed := true ].
 	process resume.
 	
-	"Following timeout is because on CI #resume does not start higher priority process immedietely"
-	self should: [process isTerminated] notTakeMoreThan: 100 milliSeconds. 
+	self assert: process isTerminated description: 'process should be terminated now'. 
 	self assert: haltWasPassed.
 	self deny: (testService suspendedBackgroundFailures includesKey: process)
 ]
@@ -187,10 +186,8 @@ ProcessMonitorTestServiceTest >> testDoesNotRaiseForkedProcessFailureWhenFailure
 	
 	testService passBackgroundFailures.
 	
-	"Following timeout is because on CI #resume does not start higher priority process immedietely"
-	self should: [process isTerminated] notTakeMoreThan: 100 milliSeconds. 
-	self shouldnt: [testService handleCompletedTest] raise: TestFailedByForkedProcess.
-	
+	self assert: process isTerminated description: 'process should be terminated now'.
+	self shouldnt: [testService handleCompletedTest] raise: TestFailedByForkedProcess
 ]
 
 { #category : #tests }
@@ -391,8 +388,7 @@ ProcessMonitorTestServiceTest >> testPassBackgroundFailuresWhenSuspensionLogicIs
 	process on: UnhandledError do: [ :err | errorWasPassed := true ].
 	process resume.
 	
-	"Following timeout is because on CI #resume does not start higher priority process immedietely"
-	self should: [process isTerminated] notTakeMoreThan: 100 milliSeconds. 
+	self assert: process isTerminated description: 'process should be terminated now'. 
 	self assert: errorWasPassed
 ]
 

--- a/src/SUnit-Tests/ProcessMonitorTestServiceTest.class.st
+++ b/src/SUnit-Tests/ProcessMonitorTestServiceTest.class.st
@@ -65,7 +65,9 @@ ProcessMonitorTestServiceTest >> testAllowRunningBackgroundProcessesToFinishButF
 { #category : #tests }
 ProcessMonitorTestServiceTest >> testAlwaysPassBackgroundHalt [
 	| process haltWasPassed halt |
-	<expectedFailure>
+	self flag: 'it fails runKernelTests on bootstrap image due to Process suspend issue'.
+	self skip.
+	
 	haltWasPassed := false.
 	halt := Halt new.
 	process := self fork: [ Processor activeProcess suspend. halt signal ].
@@ -183,7 +185,8 @@ ProcessMonitorTestServiceTest >> testDoesNotRaiseForkedProcessFailureWhenFailure
 ProcessMonitorTestServiceTest >> testDoesNotRaiseForkedProcessFailureWhenFailuresWerePassedAndProcessCompletes [
 
 	| process |
-	<expectedFailure>
+	self flag: 'it fails runKernelTests on bootstrap image due to Process suspend issue'.
+	self skip.
 	process := self fork: [ testService suspendBackgroundFailure: Error new ].
 	
 	testService passBackgroundFailures.
@@ -379,7 +382,8 @@ ProcessMonitorTestServiceTest >> testIsTestProcessFailed [
 { #category : #tests }
 ProcessMonitorTestServiceTest >> testPassBackgroundFailuresWhenSuspensionLogicIsDisabled [
 	| process error errorWasPassed |
-	<expectedFailure>
+	self flag: 'it fails runKernelTests on bootstrap image due to Process suspend issue'.
+	self skip.
 	errorWasPassed := false.
 	error := Error new messageText: 'test error'.
 	process := self fork: [ Processor activeProcess suspend. error signal ].	

--- a/src/SUnit-Tests/ProcessMonitorTestServiceTest.class.st
+++ b/src/SUnit-Tests/ProcessMonitorTestServiceTest.class.st
@@ -75,7 +75,8 @@ ProcessMonitorTestServiceTest >> testAlwaysPassBackgroundHalt [
 		self assert: actual equals: halt. haltWasPassed := true ].
 	process resume.
 	
-	self assert: process isTerminated.
+	"Following timeout is because on CI #resume does not start higher priority process immedietely"
+	self should: [process isTerminated] notTakeMoreThan: 100 milliSeconds. 
 	self assert: haltWasPassed.
 	self deny: (testService suspendedBackgroundFailures includesKey: process)
 ]
@@ -187,7 +188,8 @@ ProcessMonitorTestServiceTest >> testDoesNotRaiseForkedProcessFailureWhenFailure
 	testService passBackgroundFailures.
 	
 	self shouldnt: [testService handleCompletedTest] raise: TestFailedByForkedProcess.
-	self assert: process isTerminated
+	"Following timeout is because on CI #resume does not start higher priority process immedietely"
+	self should: [process isTerminated] notTakeMoreThan: 100 milliSeconds. 
 ]
 
 { #category : #tests }
@@ -388,7 +390,8 @@ ProcessMonitorTestServiceTest >> testPassBackgroundFailuresWhenSuspensionLogicIs
 	process on: UnhandledError do: [ :err | errorWasPassed := true ].
 	process resume.
 	
-	self assert: process isTerminated.
+	"Following timeout is because on CI #resume does not start higher priority process immedietely"
+	self should: [process isTerminated] notTakeMoreThan: 100 milliSeconds. 
 	self assert: errorWasPassed
 ]
 

--- a/src/SUnit-Tests/ProcessMonitorTestServiceTest.class.st
+++ b/src/SUnit-Tests/ProcessMonitorTestServiceTest.class.st
@@ -65,6 +65,7 @@ ProcessMonitorTestServiceTest >> testAllowRunningBackgroundProcessesToFinishButF
 { #category : #tests }
 ProcessMonitorTestServiceTest >> testAlwaysPassBackgroundHalt [
 	| process haltWasPassed halt |
+	<expectedFailure>
 	haltWasPassed := false.
 	halt := Halt new.
 	process := self fork: [ Processor activeProcess suspend. halt signal ].
@@ -75,8 +76,8 @@ ProcessMonitorTestServiceTest >> testAlwaysPassBackgroundHalt [
 		self assert: actual equals: halt. haltWasPassed := true ].
 	process resume.
 	
-	self assert: process isTerminated description: 'process should be terminated now'. 
 	self assert: haltWasPassed.
+	self assert: process isTerminated description: 'process should be terminated now'. 
 	self deny: (testService suspendedBackgroundFailures includesKey: process)
 ]
 
@@ -182,6 +183,7 @@ ProcessMonitorTestServiceTest >> testDoesNotRaiseForkedProcessFailureWhenFailure
 ProcessMonitorTestServiceTest >> testDoesNotRaiseForkedProcessFailureWhenFailuresWerePassedAndProcessCompletes [
 
 	| process |
+	<expectedFailure>
 	process := self fork: [ testService suspendBackgroundFailure: Error new ].
 	
 	testService passBackgroundFailures.
@@ -376,8 +378,8 @@ ProcessMonitorTestServiceTest >> testIsTestProcessFailed [
 
 { #category : #tests }
 ProcessMonitorTestServiceTest >> testPassBackgroundFailuresWhenSuspensionLogicIsDisabled [
-
 	| process error errorWasPassed |
+	<expectedFailure>
 	errorWasPassed := false.
 	error := Error new messageText: 'test error'.
 	process := self fork: [ Processor activeProcess suspend. error signal ].	
@@ -388,8 +390,8 @@ ProcessMonitorTestServiceTest >> testPassBackgroundFailuresWhenSuspensionLogicIs
 	process on: UnhandledError do: [ :err | errorWasPassed := true ].
 	process resume.
 	
-	self assert: process isTerminated description: 'process should be terminated now'. 
-	self assert: errorWasPassed
+	self assert: errorWasPassed.
+	self assert: process isTerminated description: 'process should be terminated now'
 ]
 
 { #category : #tests }

--- a/src/SUnit-Tests/ProcessSuspendResumeTerminateIssueTest.class.st
+++ b/src/SUnit-Tests/ProcessSuspendResumeTerminateIssueTest.class.st
@@ -1,0 +1,49 @@
+Class {
+	#name : #ProcessSuspendResumeTerminateIssueTest,
+	#superclass : #TestExecutionEnvironmentTestCase,
+	#category : #'SUnit-Tests-Core'
+}
+
+{ #category : #running }
+ProcessSuspendResumeTerminateIssueTest >> createTestService [
+
+	^ProcessMonitorTestService new
+]
+
+{ #category : #tests }
+ProcessSuspendResumeTerminateIssueTest >> testWithSuspendInTheMiddleOfProcess [
+	"The test discovers the issue with Process>>isTerminated method
+	when process was suspended in the middle and then resumed.
+	During the bootstrap process on CI it fails RunKernelTests stage.
+	But it is working on full image"
+	| process ended started |
+	ended := false.
+	started := false.
+	process := [ started := true. Processor activeProcess suspend. ended := true ] newProcess.
+	process priority: Processor activePriority + 1.
+	processes add: process.	
+	process resume.
+	self assert: started description: 'process should be started'.
+	self assert: process isSuspended description: 'process should be suspended'.
+
+	process resume.
+	self assert: ended description: 'process should be ended'.
+	self assert: process isTerminated description: 'process should be terminated'
+]
+
+{ #category : #tests }
+ProcessSuspendResumeTerminateIssueTest >> testWithoutSuspendInTheMiddleOfProcess [
+	"The test proves that suspend at the middle is required condition to trigger the issue.
+	Here the suspend is not performed and test passes on every CI stage.
+	(notice that #printString call here is to have equivalent message send like #suspend)"	
+	| process ended started |
+	ended := false.
+	started := false.
+	process := [ started := true. self printString. ended := true ] newProcess.
+	process priority: Processor activePriority + 1.
+	processes add: process.	
+	process resume.
+	self assert: started description: 'process should be started'.
+	self assert: ended description: 'process should be ended'.
+	self assert: process isTerminated description: 'process should be terminated'
+]

--- a/src/SUnit-Tests/ProcessSuspendResumeTerminateIssueTest.class.st
+++ b/src/SUnit-Tests/ProcessSuspendResumeTerminateIssueTest.class.st
@@ -13,6 +13,17 @@ ProcessSuspendResumeTerminateIssueTest >> runCaseManaged [
 ]
 
 { #category : #tests }
+ProcessSuspendResumeTerminateIssueTest >> testMostSimpleProcess [
+	| process ended |
+	ended := false.
+	process := [ ended := true ] newProcess.
+	process priority: Processor activePriority + 1.
+	process resume.
+	self assert: ended description: 'process should be ended'.
+	self assert: process isTerminated description: 'process should be terminated'
+]
+
+{ #category : #tests }
 ProcessSuspendResumeTerminateIssueTest >> testWithSuspendInTheMiddleOfProcess [
 	"The test discovers the issue with Process>>isTerminated method
 	when process was suspended in the middle and then resumed.

--- a/src/SUnit-Tests/ProcessSuspendResumeTerminateIssueTest.class.st
+++ b/src/SUnit-Tests/ProcessSuspendResumeTerminateIssueTest.class.st
@@ -1,13 +1,15 @@
 Class {
 	#name : #ProcessSuspendResumeTerminateIssueTest,
-	#superclass : #TestExecutionEnvironmentTestCase,
+	#superclass : #TestCase,
 	#category : #'SUnit-Tests-Core'
 }
 
 { #category : #running }
-ProcessSuspendResumeTerminateIssueTest >> createTestService [
-
-	^ProcessMonitorTestService new
+ProcessSuspendResumeTerminateIssueTest >> runCaseManaged [
+	"Here we are testing the test environment logic.
+	So we should disable it for ourselves"
+	
+	^DefaultExecutionEnvironment beActiveDuring: [ self runCase]
 ]
 
 { #category : #tests }
@@ -21,7 +23,6 @@ ProcessSuspendResumeTerminateIssueTest >> testWithSuspendInTheMiddleOfProcess [
 	started := false.
 	process := [ started := true. Processor activeProcess suspend. ended := true ] newProcess.
 	process priority: Processor activePriority + 1.
-	processes add: process.	
 	process resume.
 	self assert: started description: 'process should be started'.
 	self assert: process isSuspended description: 'process should be suspended'.
@@ -41,7 +42,6 @@ ProcessSuspendResumeTerminateIssueTest >> testWithoutSuspendInTheMiddleOfProcess
 	started := false.
 	process := [ started := true. self printString. ended := true ] newProcess.
 	process priority: Processor activePriority + 1.
-	processes add: process.	
 	process resume.
 	self assert: started description: 'process should be started'.
 	self assert: ended description: 'process should be ended'.

--- a/src/SUnit-Tests/ProcessSuspendResumeTerminateIssueTest.class.st
+++ b/src/SUnit-Tests/ProcessSuspendResumeTerminateIssueTest.class.st
@@ -20,7 +20,7 @@ ProcessSuspendResumeTerminateIssueTest >> testMostSimpleProcess [
 	process priority: Processor activePriority + 1.
 	process resume.
 	self assert: ended description: 'process should be ended'.
-	self assert: process isTerminated description: 'process should be terminated'
+	self assert: process isTerminated description: 'process should be terminated; current pc=', process suspendedContext pc asString
 ]
 
 { #category : #tests }

--- a/src/SUnit-Tests/SUnitTest.class.st
+++ b/src/SUnit-Tests/SUnitTest.class.st
@@ -261,7 +261,7 @@ SUnitTest >> testException [
 SUnitTest >> testExecutionEnvironmentShouldBeInstalled [
 
 	| env |
-	env := CurrentExecutionEnvironment value.
+	env := self executionEnvironment.
 
 	self assert: env class equals: TestExecutionEnvironment.
 	self assert: env testCase equals: self
@@ -419,11 +419,33 @@ SUnitTest >> testGreenTestThenLongRunningTest [
 ]
 
 { #category : #testing }
-SUnitTest >> testHangedChildProcessTest [
+SUnitTest >> testHangedChildProcessTestWhenItIsAllowedToLeaveProcessesAfterTest [
 
 	| case result hangedProcess |
 
 	case := self class selector: #hangedChildProcessTest.	
+	case executionProcessMonitor allowTestToLeaveProcesses.
+	result := case run.
+
+	self
+		assertForTestResult: result
+		runCount: 1
+		passed: 1
+		failed: 0
+		errors: 0.
+		
+	hangedProcess := Process allInstances 
+		detect: [: each | each name = #hangedChildProcessTest] ifNone: [ ^self ].
+	self assert: hangedProcess isTerminated
+]
+
+{ #category : #testing }
+SUnitTest >> testHangedChildProcessTestWhenLeftProcessIsConsideredAsFailure [
+
+	| case result |
+
+	case := self class selector: #hangedChildProcessTest.	
+	case executionProcessMonitor failTestLeavingProcesses.
 	result := case run.
 
 	self
@@ -431,11 +453,7 @@ SUnitTest >> testHangedChildProcessTest [
 		runCount: 1
 		passed: 0
 		failed: 0
-		errors: 1.
-		
-	hangedProcess := Process allInstances 
-		detect: [: each | each name = #hangedChildProcessTest] ifNone: [ ^self ].
-	self assert: hangedProcess isTerminated
+		errors: 1
 ]
 
 { #category : #testing }
@@ -624,7 +642,7 @@ SUnitTest >> testSuite [
 { #category : #testing }
 SUnitTest >> testWatchDogProcessShouldNotBeCatchedAsForkedProcess [
 	| env |
-	env := CurrentExecutionEnvironment value.
+	env := self executionEnvironment.
 
 	self assertEmpty: env forkedProcesses
 ]

--- a/src/SUnit-Tests/SUnitTest.class.st
+++ b/src/SUnit-Tests/SUnitTest.class.st
@@ -429,9 +429,9 @@ SUnitTest >> testHangedChildProcessTest [
 	self
 		assertForTestResult: result
 		runCount: 1
-		passed: 1
+		passed: 0
 		failed: 0
-		errors: 0.
+		errors: 1.
 		
 	hangedProcess := Process allInstances 
 		detect: [: each | each name = #hangedChildProcessTest] ifNone: [ ^self ].

--- a/src/SUnit-Tests/TestExecutionEnvironmentTest.class.st
+++ b/src/SUnit-Tests/TestExecutionEnvironmentTest.class.st
@@ -1,0 +1,435 @@
+Class {
+	#name : #TestExecutionEnvironmentTest,
+	#superclass : #TestExecutionEnvironmentTestCase,
+	#instVars : [
+		'exampleTestBlock',
+		'ranTest'
+	],
+	#category : #'SUnit-Tests-Core'
+}
+
+{ #category : #accessing }
+TestExecutionEnvironmentTest class >> defaultTimeLimit [
+	^9.1 seconds
+]
+
+{ #category : #running }
+TestExecutionEnvironmentTest >> createTestService [
+	^TestServiceExample new
+]
+
+{ #category : #helpers }
+TestExecutionEnvironmentTest >> exampleTest [
+	"It is a test case to be used for testing how testCase is running by environment"
+
+	exampleTestBlock cull: self
+]
+
+{ #category : #accessing }
+TestExecutionEnvironmentTest >> exampleTestBlock: anObject [
+	exampleTestBlock := anObject
+]
+
+{ #category : #helpers }
+TestExecutionEnvironmentTest >> runTestWith: aBlock [
+
+	| currentServices |
+	ranTest := self class selector: #exampleTest.
+	currentServices := executionEnvironment services copy.
+	executionEnvironment activated. "activation registerrs all default services"
+	executionEnvironment services: currentServices.
+	
+	ranTest exampleTestBlock: aBlock.
+	executionEnvironment runTestCase: ranTest
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testActivationShouldRegisterDefaultServices [
+
+	[
+		TestServiceExample isEnabled: true.
+		executionEnvironment removeAllServices.
+		
+		executionEnvironment activated.
+		self assert: (executionEnvironment services 
+						anySatisfy: [:each | each class = TestServiceExample ])
+
+	] ensure: [TestServiceExample isEnabled: false]
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testActivationShouldSetUpMainTestProcess [
+
+	executionEnvironment activated.
+	
+	self assert: executionEnvironment mainTestProcess equals: Processor activeProcess
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testActivationShouldStartWatchDog [
+
+	executionEnvironment activated.
+	
+	self assert: executionEnvironment watchDogProcess isTerminated not
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testCleanUpAlsoDisabledTestServices [
+	| testService2 |
+	testService disable.
+	testService2 := self createTestService.
+	testService2 enable.
+	executionEnvironment registerService: testService2.
+	
+	executionEnvironment cleanUpAfterTest.
+	
+	self assert: testService isCleanUpDone.
+	self assert: testService2 isCleanUpDone
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testCleanUpTestServicesAfterFailedTest [
+
+	[ 
+		self runTestWith: [ self error: 'test error'] 
+	] ifError: [].
+
+	self assert: testService isCleanUpDone
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testCleanUpTestServicesAfterSucceedTest [
+
+	self runTestWith: [ #success].
+
+	self assert: testService isCleanUpDone
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testCleanUpTestServicesAfterTerminatedTest [
+
+	self runWithNoHandlers: [
+		self runTestWith: [ Processor terminateActive]].
+
+	self assert: testService isCleanUpDone 
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testDeactivation [
+
+	executionEnvironment activated.
+	self deny: executionEnvironment watchDogProcess isTerminated.
+	
+	executionEnvironment deactivated.
+	self assert: executionEnvironment watchDogProcess isTerminated.
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testDisableGivenServiceWhenItExists [
+
+	executionEnvironment disableService: TestServiceExample.
+
+	self deny: testService isEnabled
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testDisableGivenServiceWhenItIsNotRegistered [
+
+	executionEnvironment removeAllServices.
+	
+	executionEnvironment disableService: TestServiceExample
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testDoesNotCleanUpTestServicesUntilTestErrorIsNotHandled [
+
+	self runWithNoHandlers: [ 
+		[ self runTestWith: [ self error: 'test error'] ]
+			on: UnhandledError do: [:exc | 
+				self deny: testService isCleanUpDone.
+	]].
+
+	self assert: testService isCleanUpDone
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testDoesNotNotifyTestServicesAboutTerminatedTest [
+
+	self runWithNoHandlers: [ 
+		self runTestWith: [Processor terminateActive].
+	].
+
+	self deny: testService isCompletedTestHandled
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testEnableGivenServiceWhenItExists [
+
+	| actual |
+	testService disable.
+	
+	actual := executionEnvironment enableService: TestServiceExample.
+
+	self assert: actual identicalTo: testService.
+	self assert: testService isEnabled
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testEnableGivenServiceWhenItIsNotRegistered [
+
+	executionEnvironment removeAllServices.
+	
+	testService := executionEnvironment enableService: TestServiceExample.
+
+	self assert: testService identicalTo: (executionEnvironment findService: TestServiceExample).
+	self assert: testService isEnabled
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testEnableGivenServiceWithConfigurationBlock [
+
+	| actual |
+	executionEnvironment enableService: TestServiceExample using: [:service | actual := service] .
+
+	self assert: actual identicalTo: testService 
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testFindService [
+
+	self assert: (executionEnvironment findService: TestServiceExample) identicalTo: testService 
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testGettingEnvironmentFromTestCase [
+
+	| actual |
+	executionEnvironment beActiveDuring: [ 
+		actual := self executionEnvironment.
+	].
+
+	self assert: actual identicalTo: executionEnvironment 
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testHandleForkedProcessesByAllServices [
+
+	| process |
+	executionEnvironment activated.
+	
+	process := [  ] newProcess name: 'test process'.
+	executionEnvironment prepareForNewProcess: process.
+	
+	self assert: (testService forkedProcesses includes: process)
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testHasEmptyServicesByDefault [
+
+	executionEnvironment := TestExecutionEnvironment new.
+	
+	self assert: executionEnvironment services isEmpty
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testIgnoreLongTestWhenItIsSuspendedAsUnderDebug [
+	| timeOutSignaled testProcess |
+	timeOutSignaled := false.
+	testProcess := [
+		executionEnvironment activated.		
+		[ self runTestWith: [ 
+				executionEnvironment maxTimeForTest: 10 milliSeconds.
+				Processor activeProcess suspend "it simulates the under debugger condition"]
+		] on: TestTookTooMuchTime do: [ :err | timeOutSignaled := true ]		
+	] forkAt: Processor activePriority + 1.
+
+	200 milliSeconds wait.
+	testProcess resume.
+	self deny: timeOutSignaled
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testIgnoreWatchDogProcessAsForkedOne [
+	
+	executionEnvironment activated.
+	executionEnvironment prepareForNewProcess: executionEnvironment watchDogProcess.
+	
+	self deny: (testService forkedProcesses includes: executionEnvironment watchDogProcess)
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testIsMainTestProcess [
+
+	executionEnvironment activated.
+	
+	self assert: (executionEnvironment isMainTestProcess: Processor activeProcess).
+	
+	self deny: (executionEnvironment isMainTestProcess: [] newProcess).
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testIsMainTestProcessActive [
+
+	executionEnvironment activated.
+	
+	self assert: (executionEnvironment isMainTestProcessActive).
+	
+	self runWithNoHandlers: [ 
+		self deny: (executionEnvironment isMainTestProcessActive) ]
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testIsMainTestProcessFailed [
+
+	| processMonitor |
+	processMonitor := ProcessMonitorTestService new.
+	executionEnvironment registerService: processMonitor.		
+	executionEnvironment activated.
+	
+	self deny: executionEnvironment isMainTestProcessFailed.
+	
+	processMonitor recordTestFailure: Error new.
+	self assert: executionEnvironment isMainTestProcessFailed
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testNotifyOnlyEnabledTestServices [
+	| testService2 testService3 |
+	testService disable.
+	testService2 := self createTestService.
+	testService2 disable.
+	testService3 := self createTestService.
+	testService3 enable.
+	executionEnvironment registerService: testService2; registerService: testService3.
+	
+	self runTestWith: [ #success ].
+	
+	self deny: testService isCompletedTestHandled.
+	self deny: testService2 isCompletedTestHandled.
+	self assert: testService3 isCompletedTestHandled.
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testNotifyTestServicesAboutCompletedFailedTest [
+
+	[
+		self runTestWith: [ self error: 'test error' ]
+	] ifError: [ self deny: testService isCompletedTestHandled ].
+
+	self assert: testService isCompletedTestHandled
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testNotifyTestServicesAboutCompletedTest [
+
+	self runTestWith: [
+		self deny: testService isCompletedTestHandled].
+
+	self assert: testService isCompletedTestHandled
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testNotifyTestServicesAboutHalt [
+	| errorPassed expectedException|
+	errorPassed := false.
+	expectedException := Halt new messageText: 'test halt'.
+	self runWithNoHandlers: [	
+		[self runTestWith: [ expectedException signal]] on: Halt do: [:actualException | 
+			errorPassed := true.
+			self assert: actualException equals: expectedException.
+			self assert: (testService signaledExceptions includes: actualException)].
+	].
+
+	self assert: errorPassed
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testNotifyTestServicesAboutUnhandledError [
+	| errorPassed expectedException|
+
+	errorPassed := false.
+	expectedException := Error new messageText: 'test error'.
+	
+	self runWithNoHandlers: [	
+		[self runTestWith: [ expectedException signal]] on: UnhandledError do: [:actualException | 
+			errorPassed := true.
+			self assert: actualException exception equals: expectedException.
+			self assert: (testService signaledExceptions includes: actualException)].
+	].
+
+	self assert: errorPassed
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testNotifyTestServicesAboutWarning [
+	| errorPassed expectedException|
+	errorPassed := false.
+	expectedException := Warning new messageText: 'test halt'.
+	self runWithNoHandlers: [	
+		[self runTestWith: [ expectedException signal]] on: Warning do: [:actualException | 
+			errorPassed := true.
+			self assert: actualException equals: expectedException.
+			self assert: (testService signaledExceptions includes: actualException)].
+	].
+
+	self assert: errorPassed
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testRegisteredServiceShouldBeBoundToEnvironment [
+
+	self assert: testService executionEnvironment equals: executionEnvironment
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testResetWatchDogTimeoutBetweenFailedTests [
+
+	[self runTestWith: [ 
+		executionEnvironment maxTimeForTest: self defaultTimeLimit + 10 seconds. 
+		self error: 'test error']
+	]	ifError: [].
+	
+	self runTestWith: [ 
+		self assert: executionEnvironment maxTimeForTest equals: self defaultTimeLimit]
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testResetWatchDogTimeoutBetweenTests [
+
+	self runTestWith: [ executionEnvironment maxTimeForTest: self defaultTimeLimit + 10 seconds].
+	
+	self runTestWith: [ 
+		self assert: executionEnvironment maxTimeForTest equals: self defaultTimeLimit]
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testRunningTest [
+	| executed |
+	executed := false.
+	
+	self runTestWith: [ 
+		self assert: executionEnvironment testCase identicalTo: ranTest.
+		executed := true
+	].
+
+	self assert: executed
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testRunningTestShouldSetDefaultTimeLimit [
+
+	self runTestWith: [ 
+		self assert: executionEnvironment maxTimeForTest equals: self defaultTimeLimit
+	]
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTest >> testRunningTooLongTest [
+
+	self 
+		should: [
+			self runTestWith: [ 
+				executionEnvironment maxTimeForTest: 10 milliSeconds.
+				20 milliSeconds wait]]
+		raise: TestTookTooMuchTime 
+]

--- a/src/SUnit-Tests/TestExecutionEnvironmentTest.class.st
+++ b/src/SUnit-Tests/TestExecutionEnvironmentTest.class.st
@@ -92,7 +92,7 @@ TestExecutionEnvironmentTest >> testCleanUpTestServicesAfterFailedTest [
 
 	[ 
 		self runTestWith: [ self error: 'test error'] 
-	] ifError: [].
+	] onErrorDo: [].
 
 	self assert: testService isCleanUpDone
 ]
@@ -314,7 +314,7 @@ TestExecutionEnvironmentTest >> testNotifyTestServicesAboutCompletedFailedTest [
 
 	[
 		self runTestWith: [ self error: 'test error' ]
-	] ifError: [ self deny: testService isCompletedTestHandled ].
+	] onErrorDo: [ self deny: testService isCompletedTestHandled ].
 
 	self assert: testService isCompletedTestHandled
 ]
@@ -387,7 +387,7 @@ TestExecutionEnvironmentTest >> testResetWatchDogTimeoutBetweenFailedTests [
 	[self runTestWith: [ 
 		executionEnvironment maxTimeForTest: self defaultTimeLimit + 10 seconds. 
 		self error: 'test error']
-	]	ifError: [].
+	]	onErrorDo: [].
 	
 	self runTestWith: [ 
 		self assert: executionEnvironment maxTimeForTest equals: self defaultTimeLimit]

--- a/src/SUnit-Tests/TestExecutionEnvironmentTestCase.class.st
+++ b/src/SUnit-Tests/TestExecutionEnvironmentTestCase.class.st
@@ -1,0 +1,93 @@
+Class {
+	#name : #TestExecutionEnvironmentTestCase,
+	#superclass : #TestCase,
+	#instVars : [
+		'testService',
+		'executionEnvironment',
+		'processes'
+	],
+	#category : #'SUnit-Tests-Core'
+}
+
+{ #category : #testing }
+TestExecutionEnvironmentTestCase class >> isAbstract [ 
+	^self = TestExecutionEnvironmentTestCase 
+]
+
+{ #category : #running }
+TestExecutionEnvironmentTestCase >> createTestService [
+
+	self subclassResponsibility 
+]
+
+{ #category : #running }
+TestExecutionEnvironmentTestCase >> newProcess: aName toImmediatelyExecute: aBlock [
+	| newProcess |
+	newProcess := aBlock newProcess.
+	newProcess name: aName, (processes size + 1) asString.
+	newProcess priority: Processor activePriority + 1.
+	processes add: newProcess.
+	^newProcess
+]
+
+{ #category : #running }
+TestExecutionEnvironmentTestCase >> runCaseManaged [
+	"Here we are testing the test environment logic.
+	So we should disable it for ourselves"
+	
+	^DefaultExecutionEnvironment beActiveDuring: [ self runCase]
+]
+
+{ #category : #running }
+TestExecutionEnvironmentTestCase >> runWithNoHandlers: aBlock [
+	"Executing the given block directly would go through all handlers of SUnit machinery.
+	Here we simulate the clean environment with no outer handlers for possible block errors"
+	| newProcess synchSemaphore result |
+	synchSemaphore := Semaphore new. 
+	newProcess := self 
+		newProcess: 'Test process with no error handlers' 
+		toImmediatelyExecute: [result := aBlock ensure: [synchSemaphore signal]].
+	newProcess resume.
+	synchSemaphore wait.
+	^result
+]
+
+{ #category : #running }
+TestExecutionEnvironmentTestCase >> setUp [
+	super setUp.
+	processes := OrderedCollection new.
+	
+	testService := self createTestService.	
+	testService enable.
+	executionEnvironment := TestExecutionEnvironment new.
+	executionEnvironment registerService: testService.
+
+]
+
+{ #category : #running }
+TestExecutionEnvironmentTestCase >> tearDown [
+	
+	executionEnvironment deactivated. "for the case if we activated environment during test"
+	processes do: [ :each | each terminate ].
+	
+	super tearDown.
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTestCase >> testCleanUpShouldRevertServiceToBeEnabledByDefault [
+
+	testService isEnabled: testService isEnabledByDefault not.
+	
+	testService cleanUpAfterTest.
+	
+	self assert: testService isEnabled equals: testService isEnabledByDefault
+]
+
+{ #category : #tests }
+TestExecutionEnvironmentTestCase >> testIsEnabledByDefault [
+
+	testService := self createTestService.
+	
+	self assert: testService isEnabled equals: testService isEnabledByDefault.
+	self assert: testService isEnabledByDefault equals: testService class isEnabled
+]


### PR DESCRIPTION
PR enables skipped tests to show "the process isTerminate" issue in particular scenarious.
The explicit test is added for the issue to avoid any relation to the class under test:
- testSuspendResumeTerminateIssue discovers the issue with Process>>isTerminated method when the process is suspended in the middle and then resumed. 
- testSuspendResumeTerminateIssueWithoutSuspend proves that #suspend in the middle is required trigger for the issue

Idea to merge original PR #6280 with TestExecutionEnvironment and keep discovered issue in separate PR for the record and investigation.