### PR TITLE
Allow-Compiling-Syntax-Errors-NonInteractively

### DIFF
--- a/src/AST-Core/RBParseErrorNode.class.st
+++ b/src/AST-Core/RBParseErrorNode.class.st
@@ -48,16 +48,6 @@ RBParseErrorNode >> adaptToSemanticNode [
 	" I can't provide more semantics "
 ]
 
-{ #category : #converting }
-RBParseErrorNode >> asSyntaxErrorNotification [
-	^SyntaxErrorNotification new
-		setClass: self methodNode methodClass
-		code: self methodNode source
-		doitFlag: false
-		errorMessage: errorMessage
-		location: self start
-]
-
 { #category : #accessing }
 RBParseErrorNode >> binding: anOCTempVariable [ 
 	"only for compatibility"

--- a/src/Announcements-Core/Announcer.class.st
+++ b/src/Announcements-Core/Announcer.class.st
@@ -21,6 +21,11 @@ Announcer >> announce: anAnnouncement [
 	^ announcement
 ]
 
+{ #category : #'as yet unclassified' }
+Announcer >> badMethod [
+^
+]
+
 { #category : #private }
 Announcer >> basicSubscribe: subscription [
 	^ registry add: subscription

--- a/src/Announcements-Core/Announcer.class.st
+++ b/src/Announcements-Core/Announcer.class.st
@@ -21,11 +21,6 @@ Announcer >> announce: anAnnouncement [
 	^ announcement
 ]
 
-{ #category : #'as yet unclassified' }
-Announcer >> badMethod [
-^
-]
-
 { #category : #private }
 Announcer >> basicSubscribe: subscription [
 	^ registry add: subscription

--- a/src/Kernel/RuntimeSyntaxError.class.st
+++ b/src/Kernel/RuntimeSyntaxError.class.st
@@ -1,0 +1,10 @@
+"
+When compiling syntactically incorrect code, we compile raising this exception.
+
+This way the debugger opens and the programmer can easily fix the faulty method
+"
+Class {
+	#name : #RuntimeSyntaxError,
+	#superclass : #Halt,
+	#category : #'Kernel-Exceptions'
+}

--- a/src/Kernel/RuntimeSyntaxError.class.st
+++ b/src/Kernel/RuntimeSyntaxError.class.st
@@ -5,6 +5,24 @@ This way the debugger opens and the programmer can easily fix the faulty method
 "
 Class {
 	#name : #RuntimeSyntaxError,
-	#superclass : #Halt,
+	#superclass : #Error,
+	#instVars : [
+		'errorNode'
+	],
 	#category : #'Kernel-Exceptions'
 }
+
+{ #category : #signalling }
+RuntimeSyntaxError class >> signal: aNode [
+	^(self new errorNode: aNode) signal
+]
+
+{ #category : #accessing }
+RuntimeSyntaxError >> errorNode: aNode [
+	errorNode := aNode
+]
+
+{ #category : #accessing }
+RuntimeSyntaxError >> messageText [
+	^errorNode errorMessage
+]

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -625,10 +625,8 @@ OCASTTranslator >> visitNode: aNode [
 { #category : #'visitor-double dispatching' }
 OCASTTranslator >> visitParseErrorNode: anErrorNode [  
 	methodBuilder 
-		pushLiteralVariable: (AdditionalBinding key: #error value: anErrorNode asSyntaxErrorNotification);
-		send: #signal.
-
-
+		pushLiteralVariable: RuntimeSyntaxError binding;
+		send: #signal
 ]
 
 { #category : #'visitor-double dispatching' }

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -626,7 +626,8 @@ OCASTTranslator >> visitNode: aNode [
 OCASTTranslator >> visitParseErrorNode: anErrorNode [  
 	methodBuilder 
 		pushLiteralVariable: RuntimeSyntaxError binding;
-		send: #signal
+		pushLiteral: anErrorNode;
+		send: #signal:
 ]
 
 { #category : #'visitor-double dispatching' }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -448,6 +448,11 @@ OpalCompiler >> getSourceFromRequestorSelection [
     self source: selectionString.
 ]
 
+{ #category : #testing }
+OpalCompiler >> isInteractive [
+	^self isInteractiveFor: compilationContext requestor
+]
+
 { #category : #private }
 OpalCompiler >> isInteractiveFor: aRequestor [
 	"the requester can override if the compiler is interactive or not"
@@ -503,7 +508,7 @@ OpalCompiler >> parse: textOrString [
 
 { #category : #private }
 OpalCompiler >> parseExpression [
-	^self compilationContext optionParseErrors 
+	^ (self compilationContext optionParseErrors or: [ self isInteractive not ])
 		ifTrue: [self parserClass parseFaultyExpression: source contents]
 		ifFalse: [self parserClass parseExpression: source contents]
 ]
@@ -516,7 +521,7 @@ OpalCompiler >> parseLiterals: aString [
 { #category : #private }
 OpalCompiler >> parseMethod [
 	
-	^self compilationContext optionParseErrors 
+	^ (self compilationContext optionParseErrors or: [ self isInteractive not ])
 		ifTrue: [self parserClass parseFaultyMethod: source contents]
 		ifFalse: [self parserClass parseMethod: source contents]
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -508,7 +508,8 @@ OpalCompiler >> parse: textOrString [
 
 { #category : #private }
 OpalCompiler >> parseExpression [
-	^ (self compilationContext optionParseErrors or: [ self isInteractive not ])
+	"we should allow syntactically wrong code in evaluate, too"
+	^ (self compilationContext optionParseErrors "or: [ self isInteractive not ]")
 		ifTrue: [self parserClass parseFaultyExpression: source contents]
 		ifFalse: [self parserClass parseExpression: source contents]
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -457,8 +457,9 @@ OpalCompiler >> isInteractive [
 OpalCompiler >> isInteractiveFor: aRequestor [
 	"the requester can override if the compiler is interactive or not"
 	aRequestor ifNil: [^ false ].
-	^(aRequestor respondsTo: #interactive)
-		ifTrue: [ aRequestor interactive ]
+	
+	^ (aRequestor respondsTo: #interactive)
+		ifTrue: [ aRequestor interactive ifNil: [ false ] ]
 		ifFalse: [ true ]
 ]
 

--- a/src/OpalCompiler-Tests/MethodPragmaTest.class.st
+++ b/src/OpalCompiler-Tests/MethodPragmaTest.class.st
@@ -172,28 +172,6 @@ MethodPragmaTest >> testCompileFull [
 ]
 
 { #category : #'testing-compiler' }
-MethodPragmaTest >> testCompileInvalid [
-	"Invalid pragmas should properly raise an error."
-
-	self should: [ self compile: '<>' selector: #zork ] raise: SyntaxErrorNotification.
-	self should: [ self compile: '<1>' selector: #zork ] raise: SyntaxErrorNotification.	
-	self should: [ self compile: '<#123>' selector: #zork ] raise: SyntaxErrorNotification.
-	
-	self should: [ self compile: '<foo bar>' selector: #zork ] raise: SyntaxErrorNotification.
-	self should: [ self compile: '<foo 1>' selector: #zork ] raise: SyntaxErrorNotification.
-	self should: [ self compile: '<foo bar zork>' selector: #zork ] raise: SyntaxErrorNotification.
-	self should: [ self compile: '<foo bar 1>' selector: #zork ] raise: SyntaxErrorNotification.
-	
-	self should: [ self compile: '<foo: #bar: zork:>' selector: #zork ] raise: SyntaxErrorNotification.
-	
-	self should: [ self compile: '<<1>' selector: #zork ] raise: SyntaxErrorNotification.
-	self should: [ self compile: '<=2>' selector: #zork ] raise: SyntaxErrorNotification.
-
-	self should: [ self compile: '< =1 = >' selector: #zork ] raise: SyntaxErrorNotification.
-	self should: [ self compile: '< =1 =2 >' selector: #zork ] raise: SyntaxErrorNotification.
-]
-
-{ #category : #'testing-compiler' }
 MethodPragmaTest >> testCompileNumber [
 	self assertPragma: 'foo: 123' givesKeyword: #foo: arguments: #( 123 ).
 	self assertPragma: 'foo: -123' givesKeyword: #foo: arguments: #( -123 ).

--- a/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
@@ -23,5 +23,5 @@ OCCompileWithFailureTest >> testEvalSimpleMethodWithError [
 	self assert: ast isFaulty.
 	
 	cm := ast compiledMethod.
-	self should: [cm valueWithReceiver: nil arguments: #()] raise: SyntaxErrorNotification
+	self should: [cm valueWithReceiver: nil arguments: #()] raise: RuntimeSyntaxError
 ]


### PR DESCRIPTION
This is the first step for #6674
- add #isInteractive to easily check if a compiler instance is interactive
- use faulty parsing when non-interactive

This way we can load and compile all methods with syntax errors, the syntax error is raised at runtine

Next steps:
- add Rule to warn if a method conatins syntax errors
- raise a Halt Subclass at runtime so we can reture the syntaxerror debugger