### PR TITLE
Fix #6721: Do not take the completion token from the AST

### DIFF
--- a/src/HeuristicCompletion-Model/CoASTHeuristicsResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTHeuristicsResultSetBuilder.class.st
@@ -62,7 +62,6 @@ CoASTHeuristicsResultSetBuilder >> visitMessageNode: aRBMessageNode [
 	^ self
 		configureFetcherForNode: aRBMessageNode
 		usingHeuristicAvoidingRepetitions: self messageHeuristic
-		narrowingWith: aRBMessageNode selector
 ]
 
 { #category : #visiting }
@@ -71,7 +70,6 @@ CoASTHeuristicsResultSetBuilder >> visitMethodNode: aRBMethodNode [
 	^ self
 		configureFetcherForNode: aRBMethodNode
 		usingHeuristicAvoidingRepetitions: self methodNodeHeuristic
-		narrowingWith: aRBMethodNode selector
 ]
 
 { #category : #visiting }
@@ -80,5 +78,4 @@ CoASTHeuristicsResultSetBuilder >> visitVariableNode: aRBVariableNode [
 	^ self
 		configureFetcherForNode: aRBVariableNode
 		usingHeuristicAvoidingRepetitions: self variablesHeuristic
-		narrowingWith: aRBVariableNode name
 ]

--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -37,38 +37,25 @@ CoASTResultSetBuilder >> configureEmptyFetcherForNode: aNode [
 	^ self
 		configureFetcher: CoEmptyFetcher new
 		forNode: aNode
-		narrowingWith: ''
 ]
 
 { #category : #'private-building' }
-CoASTResultSetBuilder >> configureFetcher: aFetcher forNode: aNode narrowingWith: aString [
+CoASTResultSetBuilder >> configureFetcher: aFetcher forNode: aNode [
 	
 	| completion |
 	completion := CoResultSet fetcher: aFetcher.
-	completion filterWithString: aString.
+	completion filterWithString: completionContext completionToken.
 	^ completion
 ]
 
 { #category : #'private-building' }
-CoASTResultSetBuilder >> configureFetcherForNode: aNode usingHeuristic: heuristic narrowingWith: aString [
-	
-	| fetcher |
-	fetcher := heuristic fetcherFor: aNode inContext: completionContext.
-	^ self
-		configureFetcher: fetcher
-		forNode: aNode
-		narrowingWith: aString
-]
-
-{ #category : #'private-building' }
-CoASTResultSetBuilder >> configureFetcherForNode: aNode usingHeuristicAvoidingRepetitions: heuristic narrowingWith: aString [
+CoASTResultSetBuilder >> configureFetcherForNode: aNode usingHeuristicAvoidingRepetitions: heuristic [
 	
 	| fetcher |
 	fetcher := heuristic fetcherFor: aNode inContext: completionContext.
 	^ self
 		configureFetcher: fetcher withoutRepetition
 		forNode: aNode
-		narrowingWith: aString
 ]
 
 { #category : #accessing }

--- a/src/HeuristicCompletion-Model/CoCompletionContext.class.st
+++ b/src/HeuristicCompletion-Model/CoCompletionContext.class.st
@@ -89,7 +89,7 @@ CoCompletionContext >> completionEnvironment [
 { #category : #accessing }
 CoCompletionContext >> completionToken [
 
-	^ self completion completionToken
+	^ self engine completionToken
 ]
 
 { #category : #accessing }

--- a/src/HeuristicCompletion-Model/CoGlobalSorterResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoGlobalSorterResultSetBuilder.class.st
@@ -44,5 +44,4 @@ CoGlobalSorterResultSetBuilder >> visitNode: aNode [
 	^ self
 		configureFetcher: fetcher
 		forNode: aNode
-		narrowingWith: (aNode completionToken: completionContext position)
 ]

--- a/src/HeuristicCompletion-Tests/CoASTResultSetBuilderTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoASTResultSetBuilderTest.class.st
@@ -5,12 +5,20 @@ Class {
 }
 
 { #category : #tests }
+CoASTResultSetBuilderTest >> newCompletionContext [
+
+	^ CoCompletionContext new
+		engine: CoMockEngine new;
+		yourself
+]
+
+{ #category : #tests }
 CoASTResultSetBuilderTest >> testBuildArrayHeuristic [
 
 	| builder |
 	builder := CoMockASTResultSetBuilder new.
 	builder
-		completionContext: CoCompletionContext new;
+		completionContext: self newCompletionContext;
 		node: RBArrayNode new;
 		buildCompletion.
 		
@@ -23,7 +31,7 @@ CoASTResultSetBuilderTest >> testBuildAssignmentHeuristic [
 	| builder |
 	builder := CoMockASTResultSetBuilder new.
 	builder
-		completionContext: CoCompletionContext new;
+		completionContext: self newCompletionContext;
 		node: RBAssignmentNode new;
 		buildCompletion.
 		
@@ -36,7 +44,7 @@ CoASTResultSetBuilderTest >> testBuildBlockHeuristic [
 	| builder |
 	builder := CoMockASTResultSetBuilder new.
 	builder
-		completionContext: CoCompletionContext new;
+		completionContext: self newCompletionContext;
 		node: RBBlockNode new;
 		buildCompletion.
 		
@@ -49,7 +57,7 @@ CoASTResultSetBuilderTest >> testBuildCascadeHeuristic [
 	| builder |
 	builder := CoMockASTResultSetBuilder new.
 	builder
-		completionContext: CoCompletionContext new;
+		completionContext: self newCompletionContext;
 		node: RBCascadeNode new;
 		buildCompletion.
 		
@@ -62,7 +70,7 @@ CoASTResultSetBuilderTest >> testBuildLiteralArrayHeuristic [
 	| builder |
 	builder := CoMockASTResultSetBuilder new.
 	builder
-		completionContext: CoCompletionContext new;
+		completionContext: self newCompletionContext;
 		node: RBLiteralArrayNode new;
 		buildCompletion.
 		
@@ -75,7 +83,7 @@ CoASTResultSetBuilderTest >> testBuildLiteralHeuristic [
 	| builder |
 	builder := CoMockASTResultSetBuilder new.
 	builder
-		completionContext: CoCompletionContext new;
+		completionContext: self newCompletionContext;
 		node: RBLiteralValueNode new;
 		buildCompletion.
 		
@@ -88,7 +96,7 @@ CoASTResultSetBuilderTest >> testBuildMessageHeuristic [
 	| builder |
 	builder := CoMockASTResultSetBuilder new.
 	builder
-		completionContext: CoCompletionContext new;
+		completionContext: self newCompletionContext;
 		node: RBMessageNode new;
 		buildCompletion.
 		
@@ -101,7 +109,7 @@ CoASTResultSetBuilderTest >> testBuildMethodHeuristic [
 	| builder |
 	builder := CoMockASTResultSetBuilder new.
 	builder
-		completionContext: CoCompletionContext new;
+		completionContext: self newCompletionContext;
 		node: RBMethodNode new;
 		buildCompletion.
 		
@@ -114,7 +122,7 @@ CoASTResultSetBuilderTest >> testBuildParseErrorHeuristic [
 	| builder |
 	builder := CoMockASTResultSetBuilder new.
 	builder
-		completionContext: CoCompletionContext new;
+		completionContext: self newCompletionContext;
 		node: RBParseErrorNode new;
 		buildCompletion.
 		
@@ -127,7 +135,7 @@ CoASTResultSetBuilderTest >> testBuildPragmaHeuristic [
 	| builder |
 	builder := CoMockASTResultSetBuilder new.
 	builder
-		completionContext: CoCompletionContext new;
+		completionContext: self newCompletionContext;
 		node: RBPragmaNode new;
 		buildCompletion.
 		
@@ -140,7 +148,7 @@ CoASTResultSetBuilderTest >> testBuildReturnHeuristic [
 	| builder |
 	builder := CoMockASTResultSetBuilder new.
 	builder
-		completionContext: CoCompletionContext new;
+		completionContext: self newCompletionContext;
 		node: RBReturnNode new;
 		buildCompletion.
 		
@@ -153,7 +161,7 @@ CoASTResultSetBuilderTest >> testBuildSequenceHeuristic [
 	| builder |
 	builder := CoMockASTResultSetBuilder new.
 	builder
-		completionContext: CoCompletionContext new;
+		completionContext: self newCompletionContext;
 		node: RBSequenceNode new;
 		buildCompletion.
 		
@@ -166,7 +174,7 @@ CoASTResultSetBuilderTest >> testBuildThisContextHeuristic [
 	| builder |
 	builder := CoMockASTResultSetBuilder new.
 	builder
-		completionContext: CoCompletionContext new;
+		completionContext: self newCompletionContext;
 		node: RBThisContextNode new;
 		buildCompletion.
 		
@@ -179,7 +187,7 @@ CoASTResultSetBuilderTest >> testBuildVariableHeuristic [
 	| builder |
 	builder := CoMockASTResultSetBuilder new.
 	builder
-		completionContext: CoCompletionContext new;
+		completionContext: self newCompletionContext;
 		node: RBVariableNode new;
 		buildCompletion.
 		

--- a/src/HeuristicCompletion-Tests/CoMockEngine.class.st
+++ b/src/HeuristicCompletion-Tests/CoMockEngine.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #CoMockEngine,
+	#superclass : #Object,
+	#category : #'HeuristicCompletion-Tests-Core'
+}
+
+{ #category : #accessing }
+CoMockEngine >> completionToken [
+	"This is the token used to autocomplete"
+	^ 'token'
+]

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -53,6 +53,19 @@ CompletionEngine >> closeMenu [
 	menuMorph := nil.
 ]
 
+{ #category : #replacement }
+CompletionEngine >> completionToken [
+
+	"Return the word just before the caret"
+	^ (self editor text copyFrom: self completionTokenStart to: self editor caret - 1) asString
+]
+
+{ #category : #replacement }
+CompletionEngine >> completionTokenStart [
+	"This is the position in the editor where the completion token starts"
+	^ self editor previousWord: self editor caret - 1
+]
+
 { #category : #accessing }
 CompletionEngine >> context [
 	^context


### PR DESCRIPTION
Fixes #6721

The completion context should take the completionToken from the engine.
The engine takes it from the editor.

This avoids glitches when the AST is not entirely valid, or when typing inside comments