### PR TITLE
ScopeLevel-only-MethodScope

### DIFF
--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -227,6 +227,12 @@ OCAbstractMethodScope >> removeTemp: tempVar [
 	tempVars removeKey: tempVar name
 ]
 
+{ #category : #printing }
+OCAbstractMethodScope >> scopeLevel [
+	"For debugging we print a counter for all Method and Block scopes"
+	^ outerScope scopeLevel + 1
+]
+
 { #category : #'temp vars - copying' }
 OCAbstractMethodScope >> setCopyingTempToAllScopesUpToDefTemp: aVar to: aValue from: aContext [
 	"we need to update all the copies if we change the value of a copied temp"

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -77,7 +77,7 @@ OCAbstractScope >> node: aNode [
 	node := aNode
 ]
 
-{ #category : #levels }
+{ #category : #lookup }
 OCAbstractScope >> outerScope [
 
 	^ outerScope
@@ -87,11 +87,4 @@ OCAbstractScope >> outerScope [
 OCAbstractScope >> outerScope: aSemScope [
 
 	outerScope := aSemScope
-]
-
-{ #category : #levels }
-OCAbstractScope >> scopeLevel [
-
-	outerScope ifNil: [^ 0].
-	^ outerScope scopeLevel + 1
 ]

--- a/src/OpalCompiler-Core/OCInstanceScope.class.st
+++ b/src/OpalCompiler-Core/OCInstanceScope.class.st
@@ -70,6 +70,12 @@ OCInstanceScope >> newMethodScope [
 	^ OCMethodScope new outerScope: self
 ]
 
+{ #category : #acessing }
+OCInstanceScope >> scopeLevel [
+	"For debugging we print a counter for all scopes, starting from the Method as 1, so we are 0"
+	^ 0
+]
+
 { #category : #initializing }
 OCInstanceScope >> slots: slotCollection [
 


### PR DESCRIPTION
#scopeLevel simplification

#scopeLevel is just use to print all scoped under methodscope with a number so one can see the nesting level. This used to go up to the toplevel, but that makes no sense
(e.g it would print something else depending on if a requestor scope was present or not)

In addition, we do not want to have to implement this on the "Smalltalk globals"  where it would be missing with the old implementation