### PR TITLE
Dictionary-no-hasTempVector

### DIFF
--- a/src/OpalCompiler-Core/IRTranslator.class.st
+++ b/src/OpalCompiler-Core/IRTranslator.class.st
@@ -92,7 +92,7 @@ IRTranslator >> pushOuterVectors: scope [
 	| scopesWithVector sc |
 	scopesWithVector := OrderedCollection new.
 	sc := scope.
-	[ sc outerScope isNil ] whileFalse: [ 
+	[ sc outerScope isInstanceScope ] whileFalse: [ 
 		sc := sc outerScope.
 		sc hasTempVector ifTrue: [ scopesWithVector add: sc ] ].
 	scopesWithVector reverseDo: [ :scopeWithVector |

--- a/src/Slot-Core/Dictionary.extension.st
+++ b/src/Slot-Core/Dictionary.extension.st
@@ -25,11 +25,6 @@ Dictionary >> declareVariable: newGlobal from: aDictionary [
 ]
 
 { #category : #'*Slot-Core' }
-Dictionary >> hasTempVector [ 
-	^false
-]
-
-{ #category : #'*Slot-Core' }
 Dictionary >> lookupVar: name [
 	"Return a var with this name.  Return nil if none found"
 	name isString ifFalse: [ ^nil ].


### PR DESCRIPTION
We should not need to implement hasTempVector on the level of the global scope.

This refactors pushOuterVectors: to stop checking at the level of the MethodScope.