### PR TITLE
Rewrite basic editor and tests

### DIFF
--- a/src/RewriteRule-Tests/BasicEditorTest.class.st
+++ b/src/RewriteRule-Tests/BasicEditorTest.class.st
@@ -1,0 +1,92 @@
+Class {
+	#name : #BasicEditorTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'rewriteBasicEditor'
+	],
+	#category : #'RewriteRule-Tests'
+}
+
+{ #category : #running }
+BasicEditorTest >> setUp [
+	rewriteBasicEditor := RewriteBasicEditorPresenter new.
+
+	
+]
+
+{ #category : #tests }
+BasicEditorTest >> testApplierOpens [
+	| applier |
+	applier := rewriteBasicEditor openApplier.
+	self assert: applier isBuilt.
+	applier window close
+]
+
+{ #category : #tests }
+BasicEditorTest >> testRuleLoaderOpens [
+	| loader |
+	loader := rewriteBasicEditor openRuleLoader.
+	self assert: loader isBuilt.
+	loader window close
+]
+
+{ #category : #tests }
+BasicEditorTest >> testRuleLoadsCorrectly [
+	| loaderWindow selectedRule newBasicRewriteEditorWindow loaderPresenter |
+	loaderWindow := rewriteBasicEditor openRuleLoader.
+	loaderPresenter := loaderWindow presenter.
+	loaderPresenter rulesList selectIndex: 2.
+	selectedRule := loaderPresenter rulesList selectedItems first new.
+	newBasicRewriteEditorWindow := loaderPresenter loadRule.
+	self assert: newBasicRewriteEditorWindow isBuilt.
+	self
+		assert: newBasicRewriteEditorWindow presenter searchForCode
+		equals: selectedRule searchFor.
+	self
+		assert: newBasicRewriteEditorWindow presenter replaceWithCode
+		equals: selectedRule replaceWith.
+	newBasicRewriteEditorWindow close.
+	loaderWindow close
+]
+
+{ #category : #running }
+BasicEditorTest >> testSaveDefaultRule [
+	| temporaryDefaultRuleForTesting |
+	rewriteBasicEditor
+		createRuleClass: 'TemporaryDefaultRuleForTesting'
+		forPackage: ''.
+	"The class TemporaryDefaultRuleForTesting is not created until the test runs."
+	temporaryDefaultRuleForTesting := (Smalltalk globals
+		classNamed: #TemporaryDefaultRuleForTesting) new.
+	self deny: temporaryDefaultRuleForTesting equals: nil.
+	self assert: temporaryDefaultRuleForTesting searchFor isNotEmpty.
+	self assert: temporaryDefaultRuleForTesting replaceWith isNotEmpty.
+	self assert: temporaryDefaultRuleForTesting input isNotNil.
+	self assert: temporaryDefaultRuleForTesting output isNotNil.
+	temporaryDefaultRuleForTesting class removeFromSystem
+]
+
+{ #category : #running }
+BasicEditorTest >> testSaveRule [
+	| searchForForTest replaceWithForTest temporaryCustomRule |
+	searchForForTest := '`variable1 isNil
+	ifTrue: `@block1.
+`.Statement1'.
+	replaceWithForTest := '`variable1 ifNil: `@block1.
+`.Statement1'.
+	rewriteBasicEditor
+		searchForCode: searchForForTest;
+		replaceWithCode: replaceWithForTest.
+	rewriteBasicEditor
+		createRuleClass: 'TemporaryCustomRuleForTesting'
+		forPackage: ''.
+	"The class TemporaryCustomRuleForTesting is not created until the test runs."
+	temporaryCustomRule := (Smalltalk globals
+		classNamed: 'TemporaryCustomRuleForTesting') new.
+	self deny: temporaryCustomRule equals: nil.
+	self assert: temporaryCustomRule searchFor equals: searchForForTest.
+	self
+		assert: temporaryCustomRule replaceWith
+		equals: replaceWithForTest.
+	temporaryCustomRule class removeFromSystem
+]

--- a/src/RewriteRule-Tests/package.st
+++ b/src/RewriteRule-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'RewriteRule-Tests' }

--- a/src/RewriteRuleEditor/LoadRewriteRulePresenter.class.st
+++ b/src/RewriteRuleEditor/LoadRewriteRulePresenter.class.st
@@ -1,0 +1,90 @@
+"
+A simple GUI that permits to load a custom rule into RewriteBasicEditorPresenter.
+"
+Class {
+	#name : #LoadRewriteRulePresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'rulesList',
+		'buttonBar'
+	],
+	#category : #'RewriteRuleEditor-BasicEditor'
+}
+
+{ #category : #specs }
+LoadRewriteRulePresenter class >> defaultSpec [
+	^ SpBoxLayout newVertical
+		add: #rulesList;
+		addLast: #buttonBar;
+		yourself
+]
+
+{ #category : #accessing }
+LoadRewriteRulePresenter class >> icon [ 
+	^ self iconNamed: #smallFind
+]
+
+{ #category : #api }
+LoadRewriteRulePresenter class >> open [
+	<script>
+	^ self new openWithSpec
+]
+
+{ #category : #actions }
+LoadRewriteRulePresenter >> close [
+	self window close
+]
+
+{ #category : #initialization }
+LoadRewriteRulePresenter >> initializePresenters [
+	rulesList := self newList
+		items:
+			(RBCustomTransformationRule subclasses collect: [ :each | each ])
+				asOrderedCollection;
+		yourself.
+	buttonBar := self newActionBar
+		add:
+			(self newButton
+				label: 'Load';
+				icon: (self iconNamed: #smallDoIt);
+				action: [ self loadRule. self close ]);
+		add:
+			(self newButton
+				label: 'Close';
+				icon: (self iconNamed: #smallCancel);
+				action: [ self close ]);
+		yourself
+]
+
+{ #category : #initialization }
+LoadRewriteRulePresenter >> initializeWindow: aWindowPresenter [
+	aWindowPresenter
+		title: 'Rewrite rule loader';
+		initialExtent: 300 @ 300;
+		windowIcon: (self class icon);
+		askOkToClose: false;
+		aboutText: 'Opens BasicTransformationPresenter with a custom rule'
+]
+
+{ #category : #actions }
+LoadRewriteRulePresenter >> loadRule [
+	| selectedRule |
+	rulesList selectedItems
+		ifEmpty: [ self noRuleSelectedAlert.
+			^ self ].
+	selectedRule := rulesList selectedItems first new.
+	^ RewriteBasicEditorPresenter new
+		searchForCode: selectedRule searchFor;
+		replaceWithCode: selectedRule replaceWith;
+		openWithSpec
+]
+
+{ #category : #defaults }
+LoadRewriteRulePresenter >> noRuleSelectedAlert [
+	UIManager default alert: 'You have to select a rule.'
+]
+
+{ #category : #accessing }
+LoadRewriteRulePresenter >> rulesList [
+	^ rulesList
+]

--- a/src/RewriteRuleEditor/RewriteBasicEditorPresenter.class.st
+++ b/src/RewriteRuleEditor/RewriteBasicEditorPresenter.class.st
@@ -1,0 +1,231 @@
+"
+I am a tool that allows to create and apply custom rewrite rules. I provide a simple GUI that has to code editors: searchFor and replaceWith. Also, I have a mini cheat sheet for the rewrite rules syntax, and some buttons for action.
+
+To run:
+RewriteBasicEditorPresenter open
+
+Instance Variables
+	searchForEditor:		<SearchForCodePresenter>
+	replaceWithEditor:		<ReplaceWithCodePresenter>
+	cheatSheet:				<SpTextPresenter>
+	applyButton: 			<SpButtonPresenter>
+	saveButton: 				<SpButtonPresenter>
+	loadButton: 				<SpButtonPresenter>
+	
+	
+searchForEditor
+	- The code editor for write the ""search for"" part of the rule.
+
+replaceWithEditor
+	- The code editor for write the ""replace with"" part of the rule.
+
+cheatSheet
+	- A mini cheat sheet to show the rewrite rules syntax.
+
+applyButton
+	- Opens the RewriteBrowserPresenter.
+
+saveButton
+	- A button to save the rule.
+	
+loadButton
+	- Opens the LoadRulePresenter.
+
+"
+Class {
+	#name : #RewriteBasicEditorPresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'methodCheckBox',
+		'applyButton',
+		'cheatSheet',
+		'saveButton',
+		'loadButton',
+		'searchForEditor',
+		'replaceWithEditor'
+	],
+	#category : #'RewriteRuleEditor-BasicEditor'
+}
+
+{ #category : #specs }
+RewriteBasicEditorPresenter class >> defaultSpec [
+	^ SpBoxLayout newHorizontal
+		add:
+			(SpBoxLayout newVertical
+				add: #searchForEditor
+					expand: true
+					fill: true
+					padding: 2;
+				add: #replaceWithEditor
+					expand: true
+					fill: true
+					padding: 2;
+				yourself)
+			expand: true;
+		add:
+			(SpBoxLayout newVertical
+				add: #cheatSheet expand: true;
+				addLast: #applyButton;
+				addLast: #saveButton;
+				addLast: #loadButton;
+				yourself)
+			expand: false;
+		yourself
+]
+
+{ #category : #defaults }
+RewriteBasicEditorPresenter class >> icon [
+	^ self iconNamed: #workspaceIcon
+]
+
+{ #category : #specs }
+RewriteBasicEditorPresenter class >> open [
+	<script>
+	^ self new openWithSpec
+]
+
+{ #category : #accesing }
+RewriteBasicEditorPresenter >> applierIcon [
+	^ RewriteRuleApplierPresenter icon
+]
+
+{ #category : #defaults }
+RewriteBasicEditorPresenter >> createRuleClass: aRuleName forPackage: aPackageName [
+	^ CustomRuleGenerator new
+		searchFor: searchForEditor text;
+		replaceWith: replaceWithEditor text;
+		generateRule: aRuleName forPackage: aPackageName
+]
+
+{ #category : #accesing }
+RewriteBasicEditorPresenter >> helpText [
+	^ '` = meta var
+			
+@ = list
+
+` = recurse into
+
+. = statement
+
+# = literal'
+]
+
+{ #category : #initialization }
+RewriteBasicEditorPresenter >> initializePresenters [
+	" Method checkbox has no functionality yet"
+
+	"	methodCheckBox := self newCheckBox
+		label: 'Method';
+		yourself.
+	searchForEditor := (self instantiate: SearchForCodePresenter)
+		codeSource: (self defaultRule at: #searchFor);
+		yourself.
+	replaceWithEditor := (self instantiate: ReplaceWithCodePresenter)
+		codeSource: (self defaultRule at: #replaceWith);
+		yourself."
+
+	cheatSheet := self newText
+		text: self helpText;
+		enabled: false;
+		yourself.
+	searchForEditor := self newCode
+		text: DefaultRule new searchFor;
+		yourself.
+	replaceWithEditor := self newCode
+		text: DefaultRule new replaceWith;
+		yourself.
+	loadButton := self newButton
+		label: 'Load rule';
+		icon: self loadRuleIcon;
+		action: [ self openRuleLoader ];
+		yourself.
+	saveButton := self newButton
+		label: 'Save rule';
+		icon: (self iconNamed: #smallSaveAs);
+		action: [ self saveRule ];
+		yourself.
+	applyButton := self newButton
+		label: 'Open applier';
+		icon: self applierIcon;
+		action: [ self openApplier ];
+		yourself.
+	self focusOrder
+		add: loadButton;
+		add: searchForEditor;
+		add: replaceWithEditor;
+		add: cheatSheet;
+		add: methodCheckBox;
+		add: saveButton;
+		add: applyButton
+]
+
+{ #category : #initialization }
+RewriteBasicEditorPresenter >> initializeWindow: aWindowPresenter [
+	aWindowPresenter
+		title: 'Rewrite Basic Editor';
+		initialExtent: 700 @ 500;
+		windowIcon: self class icon;
+		askOkToClose: false;
+		aboutText: 'A simple UI to create Rewrite Rules';
+		whenOpenedDo: [ cheatSheet color: self theme baseColor ]
+]
+
+{ #category : #accesing }
+RewriteBasicEditorPresenter >> loadRuleIcon [
+	^ LoadRewriteRulePresenter icon
+]
+
+{ #category : #actions }
+RewriteBasicEditorPresenter >> openApplier [
+	^ RewriteRuleApplierPresenter open
+]
+
+{ #category : #actions }
+RewriteBasicEditorPresenter >> openRuleLoader [
+	^ LoadRewriteRulePresenter open
+]
+
+{ #category : #accesing }
+RewriteBasicEditorPresenter >> replaceWithCode [
+	^ replaceWithEditor text
+]
+
+{ #category : #api }
+RewriteBasicEditorPresenter >> replaceWithCode: aCode [
+	replaceWithEditor text: aCode
+]
+
+{ #category : #defaults }
+RewriteBasicEditorPresenter >> ruleNotCreatedAlert [
+	UIManager default
+		inform: 'The name(s) you enter is invalid. Please try again.'
+]
+
+{ #category : #defaults }
+RewriteBasicEditorPresenter >> ruleSuccessfullyCreatedAlert [
+	UIManager default inform: 'The rule was successfully created!'
+]
+
+{ #category : #actions }
+RewriteBasicEditorPresenter >> saveRule [
+	| ruleName packageName |
+	ruleName := UIManager default
+		request: 'Name of the Rule: '
+		initialAnswer: ''.
+	packageName := UIManager default
+		request: 'Name of the Package: '
+		initialAnswer: 'Custom'.
+	(self createRuleClass: ruleName forPackage: packageName)
+		ifFalse: [ self ruleNotCreatedAlert ].
+	self ruleSuccessfullyCreatedAlert
+]
+
+{ #category : #accesing }
+RewriteBasicEditorPresenter >> searchForCode [
+	^ searchForEditor text
+]
+
+{ #category : #api }
+RewriteBasicEditorPresenter >> searchForCode: aCode [
+	searchForEditor text: aCode
+]

--- a/src/RewriteRuleEditor/RewriteRuleApplierPresenter.class.st
+++ b/src/RewriteRuleEditor/RewriteRuleApplierPresenter.class.st
@@ -1,0 +1,261 @@
+"
+A RewriteBrowserPresenter is a tool that provides GUI for applying rewrite rule on certain scope of classes. If you select a package, all of their classes will be added to the scope. If you select a class, the scope will contain only that class. Multiple selection in suported.
+
+To open:
+RewriteBrowserPresenter open
+"
+Class {
+	#name : #RewriteRuleApplierPresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'rules',
+		'packages',
+		'classes',
+		'methods',
+		'environment',
+		'checkbox',
+		'buttonBar'
+	],
+	#category : #'RewriteRuleEditor-Applier'
+}
+
+{ #category : #accessing }
+RewriteRuleApplierPresenter class >> buttonHeight [
+	^ 40
+]
+
+{ #category : #accessing }
+RewriteRuleApplierPresenter class >> buttonWidth [
+	^ 150
+]
+
+{ #category : #specs }
+RewriteRuleApplierPresenter class >> defaultSpec [
+	^ SpBoxLayout newVertical
+		add:
+			(SpBoxLayout newHorizontal
+				add: #packages;
+				add: #classes;
+				add: #methods;
+				yourself);
+		addLast:
+			(SpBoxLayout newHorizontal
+				add: #checkbox expand: false;
+				add: #rules expand: false;
+				add: #buttonBar;
+				yourself);
+		yourself
+]
+
+{ #category : #accessing }
+RewriteRuleApplierPresenter class >> icon [
+	^ self iconNamed: #objects
+]
+
+{ #category : #api }
+RewriteRuleApplierPresenter class >> open [
+	<script>
+	^ self new openWithSpec
+]
+
+{ #category : #accessing }
+RewriteRuleApplierPresenter class >> rulesWidth [
+	^ 225
+]
+
+{ #category : #accessing }
+RewriteRuleApplierPresenter >> allRules [
+	
+	^ OrderedCollection new
+		addAll: self demoRules;
+		addAll: self customRules;
+		yourself.
+	
+]
+
+{ #category : #testing }
+RewriteRuleApplierPresenter >> areSelectedItemsValid: items [
+	^ (items allSatisfy: [ :class | class isNotNil ])
+		and: [ items isNotEmpty ]
+]
+
+{ #category : #accessing }
+RewriteRuleApplierPresenter >> basicEditorIcon [
+	^ RewriteBasicEditorPresenter icon
+]
+
+{ #category : #actions }
+RewriteRuleApplierPresenter >> browseRule [
+	Smalltalk tools browser
+		openOnClass: (Smalltalk globals at: rules selectedItem)
+]
+
+{ #category : #actions }
+RewriteRuleApplierPresenter >> classesChanged [
+	| methodsInClasses |
+	(self areSelectedItemsValid: classes selectedItems)
+		ifFalse: [ ^ self ].
+	methodsInClasses := OrderedCollection new.
+	environment := classes selectedItems.
+	classes selectedItems
+		do: [ :eachClass | methodsInClasses addAll: eachClass selectors ].
+	methods items: methodsInClasses.
+	methods resetListSelection
+]
+
+{ #category : #initialization }
+RewriteRuleApplierPresenter >> connectPresenters [
+	packages whenSelectionChangedDo: [ self packagesChanged ].
+	classes whenSelectionChangedDo: [ self classesChanged ].
+	checkbox
+		whenActivatedDo: [ rules items: self customRules ];
+		whenDeactivatedDo: [ rules items: self allRules ]
+]
+
+{ #category : #accessing }
+RewriteRuleApplierPresenter >> customRules [
+	^ (RBCustomTransformationRule subclasses
+		collect: [ :each | each name ] )asOrderedCollection 
+]
+
+{ #category : #accessing }
+RewriteRuleApplierPresenter >> demoRules [
+	^ (RBTransformationRule subclasses collect: [ :each | each name ])
+		asOrderedCollection
+]
+
+{ #category : #initialization }
+RewriteRuleApplierPresenter >> initializeButtonBar [
+	buttonBar := self newButtonBar
+		add:
+			(self newButton
+				label: 'Apply rule';
+				icon: (self iconNamed: #smallOk);
+				action: [ self runReplace ];
+				yourself);
+		add:
+			(self newButton
+				label: 'Browse rule';
+				icon: (self iconNamed: #smallSystemBrowser);
+				action: [ self browseRule ];
+				yourself);
+		add:
+			(self newButton
+				label: 'Edit rule';
+				icon: self basicEditorIcon;
+				action: [ self openRuleInBasicEditor.
+					self window close ];
+				yourself);
+		yourself
+]
+
+{ #category : #initialization }
+RewriteRuleApplierPresenter >> initializeFocus [
+	self focusOrder
+		add: packages;
+		add: classes;
+		add: methods;
+		add: checkbox;
+		add: rules;
+		add: buttonBar
+]
+
+{ #category : #initialization }
+RewriteRuleApplierPresenter >> initializePresenters [
+	packages := self newList
+		items: RBBrowserEnvironment new packages;
+		headerTitle: 'Packages';
+		display: [ :item | item name ];
+		icons: [ self iconNamed: #packageIcon ];
+		sortingBlock: [ :a :b | a name < b name ];
+		enableItemSubstringFilter;
+		beMultipleSelection;
+		yourself.
+	classes := self newList
+		headerTitle: 'Classes';
+		display: [ :item | item name ];
+		icons: [ :elem | elem systemIcon ];
+		sortingBlock: [ :a :b | a name < b name ];
+		enableItemSubstringFilter;
+		beMultipleSelection;
+		yourself.
+	methods := self newList
+		headerTitle: 'Methods';
+		display: [ :item | '    ' , item ];
+		enableItemSubstringFilter;
+		yourself.
+	rules := self newDropList
+		display: [ :item | item asString ];
+		items: self allRules;
+		yourself.
+	checkbox := self newCheckBox
+		label: 'Only my rules';
+		yourself.
+	environment := OrderedCollection new.
+	self initializeButtonBar.
+	self initializeFocus
+]
+
+{ #category : #initialization }
+RewriteRuleApplierPresenter >> initializeWindow: aWindowPresenter [
+	aWindowPresenter
+		title: 'Rewrite Rule Applier' translated;
+		initialExtent: 750 @ 500;
+		windowIcon: (self class icon);
+		askOkToClose: false;
+		aboutText: 'Apply your custom rewrite rules to packages or classes.'
+]
+
+{ #category : #actions }
+RewriteRuleApplierPresenter >> openRuleInBasicEditor [
+	| aRule editor |
+	aRule := (self class environment at: rules selectedItem) new.
+	editor := RewriteBasicEditorPresenter new.
+	editor searchForCode: aRule searchFor.
+	editor replaceWithCode: aRule replaceWith.
+	editor openWithSpec
+]
+
+{ #category : #actions }
+RewriteRuleApplierPresenter >> openRuleInExampleBasedEditor [
+	| aRule builder |
+	self
+		flag: 'Not used method. It will modified to work on later versions'.
+	aRule := (self class environment at: rules selectedItem) new.
+	builder := RewriteRuleBuilderPresenter new.
+	builder sourcePanel codeSource: aRule input.
+	builder resultPanel codeSource: aRule output.
+	builder transformationRule searchForPanel codeSource: aRule searchFor.
+	builder transformationRule replaceWithPanel
+		codeSource: aRule replaceWith.
+	builder transformationRule ruleName: aRule class asString.
+	builder transformationRule packageName: aRule class category asString.
+	builder openWithSpec
+]
+
+{ #category : #actions }
+RewriteRuleApplierPresenter >> packagesChanged [
+	(self areSelectedItemsValid: packages selectedItems)
+		ifFalse: [ ^ self ].
+	environment removeAll.
+	packages selectedItems
+		do: [ :each | environment addAll: each classes ].
+	classes items: environment.
+	classes resetListSelection
+]
+
+{ #category : #actions }
+RewriteRuleApplierPresenter >> runReplace [
+	| changes selectedRule |
+	selectedRule := (self class environment at: rules selectedItem) new.
+	changes := Array
+		with:
+			(RBSmalllintChecker
+				runRule: selectedRule
+				onEnvironment: (RBClassEnvironment classes: environment)) builder.
+	(RewriteRuleChangesBrowser changes: changes) open
+	"changes := RBSmalllintChecker
+		runRule: selectedRule
+		onEnvironment: (RBClassEnvironment classes: environment).
+	(ChangesBrowser changes: changes builder changes) open"
+]

--- a/src/RewriteRuleEditor/RewriteRuleChangesBrowser.class.st
+++ b/src/RewriteRuleEditor/RewriteRuleChangesBrowser.class.st
@@ -12,7 +12,7 @@ Class {
 		'#buttonCancel => SpObservableSlot',
 		'#buttonOk => SpObservableSlot'
 	],
-	#category : #'NautilusRefactoring-Utilities'
+	#category : #'RewriteRuleEditor-ChangesBrowser'
 }
 
 { #category : #'instance creation' }

--- a/src/RewriteRuleEditor/package.st
+++ b/src/RewriteRuleEditor/package.st
@@ -1,0 +1,1 @@
+Package { #name : #RewriteRuleEditor }

--- a/src/RewriteRulesCreator/CustomRuleGenerator.class.st
+++ b/src/RewriteRulesCreator/CustomRuleGenerator.class.st
@@ -1,0 +1,80 @@
+"
+I am in charge of saving the RewriteRules. I receive the custom rule as plain text and save it in form of a class. 
+"
+Class {
+	#name : #CustomRuleGenerator,
+	#superclass : #Object,
+	#instVars : [
+		'input',
+		'output',
+		'searchFor',
+		'replaceWith',
+		'ruleName',
+		'packageName'
+	],
+	#category : #'RewriteRulesCreator-Core'
+}
+
+{ #category : #api }
+CustomRuleGenerator >> generateRule: aRuleName forPackage: aPackageName [
+	| ruleAsClass fullPackageName |
+	(aRuleName isValidGlobalName and: [ aPackageName isNotNil ])
+		ifFalse: [ ^ false ].
+	fullPackageName := 'CustomRewriteRules'.
+	aPackageName ifNotEmpty: [ fullPackageName := fullPackageName , '-', aPackageName  ].
+	ruleAsClass := RBCustomTransformationRule
+		subclass: aRuleName
+		instanceVariableNames: ''
+		classVariableNames: ''
+		package: fullPackageName.
+	ruleAsClass
+		compile: self ruleInitializationMethod
+		classified: 'initialization'.
+	^ true
+]
+
+{ #category : #initialization }
+CustomRuleGenerator >> initialize [
+	super initialize.
+	input := ''.
+	output := ''.
+]
+
+{ #category : #accessing }
+CustomRuleGenerator >> input: anObject [
+	input := anObject
+]
+
+{ #category : #accessing }
+CustomRuleGenerator >> output: anObject [
+	output := anObject
+]
+
+{ #category : #accessing }
+CustomRuleGenerator >> replaceWith: anObject [
+	replaceWith := anObject
+]
+
+{ #category : #accessing }
+CustomRuleGenerator >> ruleInitializationMethod [
+	^ 'initialize
+	super initialize.
+	searchFor := ''' , searchFor
+		,
+			'''.
+	replaceWith := ''' , replaceWith
+		,
+			'''.
+	input := ''' , input
+		,
+			'''.
+	output := ''' , output
+		,
+			'''.
+	rewriteRule replace: searchFor with: replaceWith'
+]
+
+{ #category : #accessing }
+CustomRuleGenerator >> searchFor: anObject [
+	searchFor := anObject
+]

--- a/src/RewriteRulesCreator/DefaultRule.class.st
+++ b/src/RewriteRulesCreator/DefaultRule.class.st
@@ -1,0 +1,29 @@
+"
+I am the default rewrite rule that is loaded when RewriteBasicEditorPresenter is opened.
+"
+Class {
+	#name : #DefaultRule,
+	#superclass : #RBCustomTransformationRule,
+	#category : #'RewriteRulesCreator-Default'
+}
+
+{ #category : #initialization }
+DefaultRule >> initialize [
+	super initialize.
+	searchFor := '| ``@object |
+`.@Statement1.
+``@object ifNotNil: [ `.@Statement2.
+`.@Statement3.
+`.@Statement4.
+`.@Statement5 ]'.
+	replaceWith := '| ``@object |
+`.@Statement1.
+``@object ifNil: [ ^ self ].
+`.@Statement2.
+`.@Statement3.
+`.@Statement4.
+`.@Statement5'.
+	input := ''.
+	output := ''.
+	rewriteRule replace: searchFor with: replaceWith
+]

--- a/src/RewriteRulesCreator/DemoRule1.class.st
+++ b/src/RewriteRulesCreator/DemoRule1.class.st
@@ -1,0 +1,27 @@
+"
+I am a demo rewrite rule.
+"
+Class {
+	#name : #DemoRule1,
+	#superclass : #RBCustomTransformationRule,
+	#category : #'RewriteRulesCreator-Demo'
+}
+
+{ #category : #initialization }
+DemoRule1 >> initialize [
+	super initialize.
+	searchFor := '`variable1 isNil
+	ifTrue: `@block1.
+`.Statement1'.
+	replaceWith := '`variable1 ifNil: `@block1.
+`.Statement1'.
+	input := ''.
+	output := ''.
+	rewriteRule replace: searchFor with: replaceWith
+]
+
+{ #category : #accessing }
+DemoRule1 >> someMethod [
+	self isNil ifTrue: [ ^ true ].
+	super size
+]

--- a/src/RewriteRulesCreator/DemoRule2.class.st
+++ b/src/RewriteRulesCreator/DemoRule2.class.st
@@ -1,0 +1,29 @@
+"
+I am a demo rewrite rule.
+"
+Class {
+	#name : #DemoRule2,
+	#superclass : #RBCustomTransformationRule,
+	#category : #'RewriteRulesCreator-Demo'
+}
+
+{ #category : #accessing }
+DemoRule2 >> fooMethod [
+	true not
+		ifTrue: [ ^ 1 + 1 ]
+		ifFalse: [ ^ 1 + 0 ]
+]
+
+{ #category : #initialization }
+DemoRule2 >> initialize [
+	super initialize.
+	searchFor := 'true not
+		ifTrue: `@block1
+		ifFalse: `@block2'.
+	replaceWith := 'false
+		ifTrue: `@block1
+		ifFalse: `@block2'.
+	input := ''.
+	output := ''.
+	rewriteRule replace: searchFor with: replaceWith
+]

--- a/src/RewriteRulesCreator/DemoRule3.class.st
+++ b/src/RewriteRulesCreator/DemoRule3.class.st
@@ -1,0 +1,22 @@
+"
+I am a demo rewrite rule.
+"
+Class {
+	#name : #DemoRule3,
+	#superclass : #RBCustomTransformationRule,
+	#category : #'RewriteRulesCreator-Demo'
+}
+
+{ #category : #initialization }
+DemoRule3 >> initialize [
+	super initialize.
+	searchFor := 'true not
+		ifTrue: [ ^ 1 + 1 ]
+		ifFalse: [ ^ 1 + 0 ]'.
+	replaceWith := 'false
+		ifTrue: [ ^ 1 + 1 ]
+		ifFalse: [ ^ 1 + 0 ]'.
+	input := ''.
+	output := ''.
+	rewriteRule replace: searchFor with: replaceWith
+]

--- a/src/RewriteRulesCreator/ManifestRewriteToolCustomRules.class.st
+++ b/src/RewriteRulesCreator/ManifestRewriteToolCustomRules.class.st
@@ -1,0 +1,8 @@
+"
+In this package the rewrite custom rules will be stored classfied in protocols.
+"
+Class {
+	#name : #ManifestRewriteToolCustomRules,
+	#superclass : #PackageManifest,
+	#category : #'RewriteRulesCreator-Manifest'
+}

--- a/src/RewriteRulesCreator/RBCustomTransformationRule.class.st
+++ b/src/RewriteRulesCreator/RBCustomTransformationRule.class.st
@@ -1,0 +1,54 @@
+"
+An extention of the RBTransformationRule to store Custom Rewrite Rules.
+"
+Class {
+	#name : #RBCustomTransformationRule,
+	#superclass : #RBTransformationRule,
+	#instVars : [
+		'input',
+		'output',
+		'searchFor',
+		'replaceWith'
+	],
+	#category : #'RewriteRulesCreator-Core'
+}
+
+{ #category : #accessing }
+RBCustomTransformationRule >> input [
+	^ input
+]
+
+{ #category : #accessing }
+RBCustomTransformationRule >> input: anObject [
+	input := anObject
+]
+
+{ #category : #accessing }
+RBCustomTransformationRule >> output [
+	^ output
+]
+
+{ #category : #accessing }
+RBCustomTransformationRule >> output: anObject [
+	output := anObject
+]
+
+{ #category : #accessing }
+RBCustomTransformationRule >> replaceWith [
+	^ replaceWith
+]
+
+{ #category : #accessing }
+RBCustomTransformationRule >> replaceWith: anObject [
+	replaceWith := anObject
+]
+
+{ #category : #accessing }
+RBCustomTransformationRule >> searchFor [
+	^ searchFor
+]
+
+{ #category : #accessing }
+RBCustomTransformationRule >> searchFor: anObject [
+	searchFor := anObject
+]

--- a/src/RewriteRulesCreator/package.st
+++ b/src/RewriteRulesCreator/package.st
@@ -1,0 +1,1 @@
+Package { #name : #RewriteRulesCreator }


### PR DESCRIPTION
This is related to #6625 
The next step is to add an ExampleBasedEditor (you can build a rule based on Pharo's code) and to integrate this tool with MatchTool.

[Stef's observations](https://github.com/pharo-project/pharo/pull/6625#issuecomment-645313804) have been attended and the following changes have been added:

- *Protocol name* has been renamed to *package name*.
- Class creation has been extracted to a different method.
- The UIManager has been separated from rule creator.
- The default template rule is not hard-coded anymore. It is loaded from a saved rule.
- Several tests have been added.
