### PR TITLE
offsetIsComment-easy-check-if-inside-comment

### DIFF
--- a/src/AST-Core-Tests/RBMethodNodeTest.class.st
+++ b/src/AST-Core-Tests/RBMethodNodeTest.class.st
@@ -136,6 +136,17 @@ RBMethodNodeTest >> testNodeForOffsetVar [
 	self assert: foundNode class identicalTo: RBVariableNode
 ]
 
+{ #category : #tests }
+RBMethodNodeTest >> testOffsetIsComment [
+	self deny: ((OrderedCollection>>#do:) ast offsetIsComment: 3).
+
+	self assert: ((OrderedCollection>>#do:) ast offsetIsComment: 13).
+	self assert: ((OrderedCollection>>#do:) ast offsetIsComment: 62).
+
+	self deny: ((OrderedCollection>>#do:) ast offsetIsComment: 63).
+	self deny: ((OrderedCollection>>#do:) ast offsetIsComment: 70).
+]
+
 { #category : #'tests - primitives' }
 RBMethodNodeTest >> testPrimitiveErrorIsPrimitive [
 

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -487,6 +487,14 @@ RBMethodNode >> numArgs [
 	^self selector numArgs
 ]
 
+{ #category : #testing }
+RBMethodNode >> offsetIsComment: anOffset [
+	"check is the offset in the source part of a comment"
+
+	^ self allComments
+		anySatisfy: [ :comment | anOffset between: comment start and: comment stop ]
+]
+
 { #category : #'tree accessing' }
 RBMethodNode >> parentOfSubtree: subtree [
 


### PR DESCRIPTION
add a method offsetIsComment: that returns true of the text offset in the method is inside of a comment.

(we should later integrate comments better in the AST, e.g. bestNodeFor: could return a comment.. this is just a simple solution without any impact as an intermediate step)