### PR TITLE
This changes doIt expressions to be compiled with runtime syntax errr…

### DIFF
--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -268,8 +268,7 @@ DebugSession >> recompileMethodTo: text inContext: aContext notifying: aNotifyer
 	canRewind := (self isContextPostMortem: self interruptedContext) not.
 	"Do not try to recompile a doIt method"
 	aContext method isDoIt
-		ifTrue: [ UIManager default alert:  'Can not modify a DoIt-Method.'.
-			^ false ].
+		ifTrue: [ self returnValue: ((Smalltalk compiler compile: text) valueWithReceiver: nil arguments: #()) from: aContext sender. ^false].
 	(recompilationContext := (self createModelForContext: aContext) locateClosureHomeWithContent: text) ifNil: [ ^ false ].
 	canRewind
 		ifFalse: [ (self confirm: 'Can not rewind post mortem context for new method.\ Accept anyway ?' withCRs) or: [ ^ false ] ].

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -509,8 +509,7 @@ OpalCompiler >> parse: textOrString [
 
 { #category : #private }
 OpalCompiler >> parseExpression [
-	"we should allow syntactically wrong code in evaluate, too"
-	^ (self compilationContext optionParseErrors "or: [ self isInteractive not ]")
+	^ (self compilationContext optionParseErrors or: [ self isInteractive not ])
 		ifTrue: [self parserClass parseFaultyExpression: source contents]
 		ifFalse: [self parserClass parseExpression: source contents]
 ]

--- a/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
@@ -96,6 +96,11 @@ OCCompilerNotifyingTest >> initializeTextWithoutError [
 ]
 
 { #category : #private }
+OCCompilerNotifyingTest >> notify: message at: location in: code [
+	"requestor api: ignore"
+]
+
+{ #category : #private }
 OCCompilerNotifyingTest >> numberOfSelections [
 	^(text occurrencesOf: $%) + 1
 ]
@@ -346,4 +351,9 @@ OCCompilerNotifyingTest >> testUnmatchedStringQuote [
 
 	self setUpForErrorsIn: '^nil printString ,  ''unfinished string` Unmatched '' in string literal. ->`'.
 	self enumerateAllSelections
+]
+
+{ #category : #private }
+OCCompilerNotifyingTest >> text [
+	"requestor api: ignore"
 ]

--- a/src/OpalCompiler-Tests/OCCompilerSyntaxErrorNotifyingTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerSyntaxErrorNotifyingTest.class.st
@@ -40,5 +40,6 @@ OCCompilerSyntaxErrorNotifyingTest >> evaluateSelection [
 		"Note subtle difference versus  (morph editor selectionAsStream). 
 		The later does not answer the same contents and would raise a SyntaxErrorNotification with wrong sub-selection"
 		failBlock: [^failure];
+		requestor: self;
 		evaluate
 ]

--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -88,9 +88,9 @@ Finder >> computeWithMethodFinder: aString [
 	data := aString trimRight: [ :char | char isSeparator or: [ char = $. ] ].
 
 	[ dataObjects := Smalltalk compiler evaluate: '{' , data , '}' ]
-		on: SyntaxErrorNotification
+		on: RuntimeSyntaxError 
 		do: [ :e | 
-			self inform: 'Syntax Error: ' , e errorMessage.
+			self inform: 'Syntax Error: ' , e messageText.
 			^ #() ].	"#( data1 data2 result )"
 	
 	dataObjects size < 2


### PR DESCRIPTION
…os. As for methods, this only affects non-interactive use.

A problem is that you can not actually change the DoIt method.