### PR TITLE
[Bug in bootstrap image] Test to show a bug with process completion in bootstrap image 

### DIFF
--- a/src/SUnit-Tests/ProcessTerminationBugTest.class.st
+++ b/src/SUnit-Tests/ProcessTerminationBugTest.class.st
@@ -25,3 +25,16 @@ ProcessTerminationBugTest >> testHighPriorityProcessDoesNotFinishCorrectly [
 		description: 'process should be terminated; current pc='
 			, process suspendedContext pc asString, ' in ', process suspendedContext printString
 ]
+
+{ #category : #tests }
+ProcessTerminationBugTest >> testSamePriorityProcessDoesNotFinishCorrectly [
+	| process ended |
+	ended := false.
+	process := [ ended := true ] fork.
+	2 seconds wait.
+	self assert: ended description: 'process should be ended'.
+	self 
+		assert: process isTerminated 
+		description: 'process should be terminated; current pc='
+			, process suspendedContext pc asString, ' in ', process suspendedContext printString
+]

--- a/src/SUnit-Tests/ProcessTerminationBugTest.class.st
+++ b/src/SUnit-Tests/ProcessTerminationBugTest.class.st
@@ -1,0 +1,27 @@
+Class {
+	#name : #ProcessTerminationBugTest,
+	#superclass : #TestCase,
+	#category : #'SUnit-Tests-Core'
+}
+
+{ #category : #running }
+ProcessTerminationBugTest >> runCaseManaged [
+	"Here we are testing the test environment logic.
+	So we should disable it for ourselves"
+	
+	^DefaultExecutionEnvironment beActiveDuring: [ self runCase]
+]
+
+{ #category : #tests }
+ProcessTerminationBugTest >> testHighPriorityProcessDoesNotFinishCorrectly [
+	| process ended |
+	ended := false.
+	process := [ ended := true ] newProcess.
+	process priority: Processor activePriority + 1.
+	process resume.
+	self assert: ended description: 'process should be ended'.
+	self 
+		assert: process isTerminated 
+		description: 'process should be terminated; current pc='
+			, process suspendedContext pc asString, ' in ', process suspendedContext printString
+]


### PR DESCRIPTION
Processes in bootstrap image does not finish execution correctly.
They never return true from #isTerminate check. Never is my guess but scenario in the test (in this PR) looks quite general:
```Smalltalk
	| process ended |
	ended := false.
	process := [ ended := true ] newProcess.
	process priority: Processor activePriority + 1.
	process resume.
	self assert: ended description: 'process should be ended'.
	self 
		assert: process isTerminated 
		description: 'process should be terminated; current pc='
			, process suspendedContext pc asString, ' in ', process suspendedContext printString
```
Test fails on last assertion due to zero pc in last context of process (one of termination methods). 
According to Eliot zero pc is a sign of VM bug in the mapping between jitted code and bytecode. But I can't make test fail on full image. I even refactored process #terminate method (#6328) to affect the jitted code but it does not help. 

Notice that the CI runs tests twice:
- it runs SUnit tests on bootstrap image. Here the test fails.
- it runs all tests on full image. Here the test passes.