### PR TITLE
delete-OCAbstractLocalVariableTOMERGE

### DIFF
--- a/src/OpalCompiler-Core/OCAbstractLocalVariableTOMERGE.class.st
+++ b/src/OpalCompiler-Core/OCAbstractLocalVariableTOMERGE.class.st
@@ -1,9 +1,0 @@
-Class {
-	#name : #OCAbstractLocalVariableTOMERGE,
-	#superclass : #Variable,
-	#instVars : [
-		'scope',
-		'usage'
-	],
-	#category : #'OpalCompiler-Core-Semantics'
-}


### PR DESCRIPTION
remove unused OCAbstractLocalVariableTOMERGE (there is a deprecated OCAbstractLocalVariable already)