### PR TITLE
use-OrderedDictionary-for-copiedVars

### DIFF
--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -116,8 +116,8 @@ OCAbstractMethodScope >> id: int [
 OCAbstractMethodScope >> initialize [
 
 	tempVars :=  OrderedDictionary new.
-	tempVector  := Dictionary new.
-	copiedVars := Dictionary new.
+	tempVector  := OrderedDictionary new.
+	copiedVars := OrderedDictionary new.
 	id := 0.
 	
 	thisContextVar := ThisContextVariable instance


### PR DESCRIPTION
copiedVars and tempVector are using normal dictionaries. But it is better to use OrderedDictionary, this way the order they have will be always the same. (tempVars was doing that already).