### PR TITLE
Add variable ivar to RBVariableNode

### DIFF
--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -15,6 +15,7 @@ Class {
 	#superclass : #RBValueNode,
 	#instVars : [
 		'name',
+		'variable',
 		'start'
 	],
 	#category : #'AST-Core-Nodes'


### PR DESCRIPTION
RBVariableNode holds onto the semantic vars using a property.

Now that we seldomly use the AST without doing name analysis, this is not really good: we pay for the dictionary both in space and speed.

This PR adds the ivar (as it can not be done form the image) but does not yet hook it up.