### PR TITLE
Speedup-RelationSlot-write

### DIFF
--- a/src/Slot-Examples/RelationSlot.class.st
+++ b/src/Slot-Examples/RelationSlot.class.st
@@ -81,9 +81,10 @@ RelationSlot >> emitStore: aMethodBuilder [
 		addTemp: tempName;
 		storeTemp: tempName;
 		popTop;
-		pushReceiver;
+ 		pushLiteral: self;
 		pushInstVar: index;
 		pushTemp: tempName;
+		pushReceiver;
 		send: #updateOld:new:in:;
 		storeInstVar: index
 ]

--- a/src/Slot-Examples/RelationSlot.class.st
+++ b/src/Slot-Examples/RelationSlot.class.st
@@ -71,7 +71,10 @@ RelationSlot >> checkValue: aValue [
 
 { #category : #'code generation' }
 RelationSlot >> emitStore: aMethodBuilder [
-	"copy of #emitStore from Slot as my superclass has overriden it"
+	"This bytecode does the following: 
+		self updateOld: (self read: anObject) new: newValue in: anObject.
+		super write: newValue to: anObject
+	"
 	| tempName |
 	tempName := '0slotTempForStackManipulation'.
 	aMethodBuilder
@@ -79,9 +82,10 @@ RelationSlot >> emitStore: aMethodBuilder [
 		storeTemp: tempName;
 		popTop;
 		pushReceiver;
-		pushLiteralVariable: (AdditionalBinding key: #slot value: self);
+		pushInstVar: index;
 		pushTemp: tempName;
-		send: #writeSlot:value:
+		send: #updateOld:new:in:;
+		storeInstVar: index
 ]
 
 { #category : #testing }

--- a/src/Slot-Examples/ToOneRelationSlot.class.st
+++ b/src/Slot-Examples/ToOneRelationSlot.class.st
@@ -18,7 +18,7 @@ ToOneRelationSlot >> updateOld: oldValue new: newValue in: anObject [
 	newValue 
 		ifNotNil: [ self checkValue: newValue ].
 	self hasInverse
-		ifFalse: [ ^ self ].
+		ifFalse: [ ^ newValue ].
 	oldValue 
 		ifNotNil: [ self removeAssociationFrom: anObject to: oldValue ].
 	newValue 

--- a/src/Slot-Examples/ToOneRelationSlot.class.st
+++ b/src/Slot-Examples/ToOneRelationSlot.class.st
@@ -15,14 +15,15 @@ ToOneRelationSlot >> isToOneSlot [
 
 { #category : #internal }
 ToOneRelationSlot >> updateOld: oldValue new: newValue in: anObject [
-
 	newValue notNil
 		ifTrue: [ self checkValue: newValue ].
-	self hasInverse ifFalse:  [^ self ]. 
+	self hasInverse
+		ifFalse: [ ^ self ].
 	oldValue notNil
-				ifTrue: [ self removeAssociationFrom: anObject to: oldValue ].
+		ifTrue: [ self removeAssociationFrom: anObject to: oldValue ].
 	newValue notNil
-				ifTrue: [ self addAssociationFrom: anObject to: newValue ]
+		ifTrue: [ self addAssociationFrom: anObject to: newValue ].
+	^newValue
 ]
 
 { #category : #'meta-object-protocol' }

--- a/src/Slot-Examples/ToOneRelationSlot.class.st
+++ b/src/Slot-Examples/ToOneRelationSlot.class.st
@@ -15,14 +15,14 @@ ToOneRelationSlot >> isToOneSlot [
 
 { #category : #internal }
 ToOneRelationSlot >> updateOld: oldValue new: newValue in: anObject [
-	newValue notNil
-		ifTrue: [ self checkValue: newValue ].
+	newValue 
+		ifNotNil: [ self checkValue: newValue ].
 	self hasInverse
 		ifFalse: [ ^ self ].
-	oldValue notNil
-		ifTrue: [ self removeAssociationFrom: anObject to: oldValue ].
-	newValue notNil
-		ifTrue: [ self addAssociationFrom: anObject to: newValue ].
+	oldValue 
+		ifNotNil: [ self removeAssociationFrom: anObject to: oldValue ].
+	newValue 
+		ifNotNil: [ self addAssociationFrom: anObject to: newValue ].
 	^newValue
 ]
 

--- a/src/Slot-Examples/ToOneRelationSlot.class.st
+++ b/src/Slot-Examples/ToOneRelationSlot.class.st
@@ -13,21 +13,21 @@ ToOneRelationSlot >> isToOneSlot [
 	^true
 ]
 
-{ #category : #'meta-object-protocol' }
-ToOneRelationSlot >> write: newValue to: anObject [
+{ #category : #internal }
+ToOneRelationSlot >> updateOld: oldValue new: newValue in: anObject [
 
-	| oldValue |
-
-	oldValue := self read: anObject.
 	newValue notNil
 		ifTrue: [ self checkValue: newValue ].
-	self hasInverse 
-		ifTrue: [ 
-			oldValue notNil
+	self hasInverse ifFalse:  [^ self ]. 
+	oldValue notNil
 				ifTrue: [ self removeAssociationFrom: anObject to: oldValue ].
-			newValue notNil
-				ifTrue: [ self addAssociationFrom: anObject to: newValue ] ].
-		
+	newValue notNil
+				ifTrue: [ self addAssociationFrom: anObject to: newValue ]
+]
+
+{ #category : #'meta-object-protocol' }
+ToOneRelationSlot >> write: newValue to: anObject [
+	self updateOld: (self read: anObject) new: newValue in: anObject.
 	super write: newValue to: anObject
 ]
 


### PR DESCRIPTION
RelationSlot was compiling a reflective write. But we can do better;

- refactor write: to:  so we do most of the stuff in another method
- implement emitStore: to call that method and use bytecodes to acces ivars

This PR was done to speed up Moose which uses RelationSlots a lot.