### PR TITLE
Dictionary-move-scope-methods

### DIFF
--- a/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
@@ -153,7 +153,7 @@ OCASTTranslatorTest >> setUp [
 
 	super setUp.
 	instance := OCOpalExamples new.
-	globals := Dictionary new.
+	globals := SystemDictionary new.
 ]
 
 { #category : #running }

--- a/src/Slot-Core/Dictionary.extension.st
+++ b/src/Slot-Core/Dictionary.extension.st
@@ -23,16 +23,3 @@ Dictionary >> declareVariable: newGlobal from: aDictionary [
 		ifFalse: [
 			self add: newGlobal]
 ]
-
-{ #category : #'*Slot-Core' }
-Dictionary >> lookupVar: name [
-	"Return a var with this name.  Return nil if none found"
-	name isString ifFalse: [ ^nil ].
-	
-	^self bindingOf: name
-]
-
-{ #category : #'*Slot-Core' }
-Dictionary >> outerScope [
-	^nil
-]

--- a/src/Slot-Core/SystemDictionary.extension.st
+++ b/src/Slot-Core/SystemDictionary.extension.st
@@ -15,3 +15,11 @@ SystemDictionary >> declare: key from: aDictionary [
 		ifFalse: 
 			[self add: (GlobalVariable key: key)]
 ]
+
+{ #category : #'*Slot-Core' }
+SystemDictionary >> lookupVar: name [
+	"Return a var with this name.  Return nil if none found"
+	name isString ifFalse: [ ^nil ].
+	
+	^self bindingOf: name
+]


### PR DESCRIPTION
Dictionary had two methods related to Variables (scope lookup)
- fix the Opal tests to use SystemDictionary
- #outerscope is not needed
- lookupVar: move to SystemDictionary