### PR TITLE
Fixing-Cairo-FontMetrics

### DIFF
--- a/src/Athens-Cairo/CairoFontFace.class.st
+++ b/src/Athens-Cairo/CairoFontFace.class.st
@@ -24,7 +24,7 @@ CairoFontFace class >> countReferences: handle [
 "
 unsigned int  cairo_font_face_get_reference_count             (cairo_font_face_t *font_face);
 "
-	^ self ffiCall: #( unsigned int cairo_font_face_get_reference_count (size_t handle)) 
+	^ self ffiCall: #( uint cairo_font_face_get_reference_count (size_t handle)) 
 ]
 
 { #category : #finalizing }

--- a/src/Athens-Cairo/CairoScaledFont.class.st
+++ b/src/Athens-Cairo/CairoScaledFont.class.st
@@ -9,7 +9,8 @@ Class {
 	#traits : 'TCairoLibrary',
 	#classTraits : 'TCairoLibrary classTrait',
 	#instVars : [
-		'face'
+		'face',
+		'freeTypeFont'
 	],
 	#pools : [
 		'AthensCairoDefinitions'
@@ -31,13 +32,10 @@ CairoScaledFont class >> fromFreetypeFont: aFont [
 	| ftFace face |
 	^ CairoBackendCache soleInstance at: aFont ifAbsentPut: [ | emphasis |
 			emphasis := aFont simulatedEmphasis.
-			ftFace := aFont face.
-			face := CairoBackendCache soleInstance 
-				at: {ftFace.	emphasis} 
-				ifAbsentPut: [ | cff |
-					cff := CairoFontFace fromFreetypeFace: ftFace.
-					emphasis ifNotNil: [ cff synthesizeEmphasis: emphasis ].
-					cff ].
+			"I will copy it, as it used by cairo"
+			ftFace := aFont face copy.
+			face := CairoFontFace fromFreetypeFace: ftFace.
+			emphasis ifNotNil: [ face synthesizeEmphasis: emphasis ].
 			self fromFreetypeFont: aFont cairoFace: face ]
 ]
 
@@ -56,7 +54,9 @@ CairoScaledFont class >> fromFreetypeFont: aFont cairoFace: face [
 	font := self primCreate: face fontMatrix: fontMatrix  userToDeviceMatrix: deviceMatrix options: options. 
 	
 	"to keep a reference to cairo face in instance"
-	^ font initWithFace: face.
+	^ (font initWithFace: face)
+			freeTypeFont: aFont;
+			yourself.
 	
 
 ]
@@ -107,6 +107,12 @@ CairoScaledFont >> extents [
 ]
 
 { #category : #accessing }
+CairoScaledFont >> freeTypeFont: aFreeTypeFont [ 
+	
+	freeTypeFont := aFreeTypeFont
+]
+
+{ #category : #accessing }
 CairoScaledFont >> getExtents: cairoFontExtents [
 	"void                cairo_scaled_font_extents           (cairo_scaled_font_t *scaled_font,
                                                          cairo_font_extents_t *extents);
@@ -140,6 +146,22 @@ CairoScaledFont >> getExtentsOfGlyphs: glyphs ofLength: num into: extents [
                                             int num,
                                             cairo_text_extents_t *extents))
 		
+]
+
+{ #category : #accessing }
+CairoScaledFont >> getFontMatrixInto: cairoFontMatrix [
+	^ self ffiCall: #(
+		void
+		cairo_scaled_font_get_font_matrix (self,
+ 	                                  AthensCairoMatrix *cairoFontMatrix))
+]
+
+{ #category : #accessing }
+CairoScaledFont >> getFontScaleMatrixInto: cairoFontMatrix [
+	^ self ffiCall: #(
+		void
+		cairo_scaled_font_get_scale_matrix (self,
+ 	                                  AthensCairoMatrix *cairoFontMatrix))
 ]
 
 { #category : #initialization }

--- a/src/FreeType/FreeTypeFace.class.st
+++ b/src/FreeType/FreeTypeFace.class.st
@@ -129,6 +129,15 @@ FreeTypeFace >> index: anInteger [
 	index := anInteger
 ]
 
+{ #category : #copying }
+FreeTypeFace >> postCopy [ 
+
+	handle beNull.
+	self validate.
+	self autoRelease.
+	^ self
+]
+
 { #category : #caching }
 FreeTypeFace >> releaseCachedState [
 


### PR DESCRIPTION
We need to create a copy of the freeTypeFont so it does not mix with the use it has from Cairo.