### PR TITLE
[Disable Flaky Tests] Disable continuation flaky test

### DIFF
--- a/src/Kernel-Tests/ContinuationTest.class.st
+++ b/src/Kernel-Tests/ContinuationTest.class.st
@@ -267,6 +267,8 @@ ContinuationTest >> remove: anObj uptoLastValueLink: aValueLink continuation: sk
 { #category : #tests }
 ContinuationTest >> testBlockEscape [
 	| x |
+	self flag: #flakyTest.
+	self skip.
 	tmp := 0.
 	x := [ tmp := tmp + 1.
 	tmp2 value ].


### PR DESCRIPTION
PR should improve the stability of our CI by disabling flaky #testBlockEscape test.
The issue for the problem #6052 is accompanied with tracking "enable PR" #6768.
