### PR TITLE
remove-unused-temporaries-in-packages-starting-with-C

### DIFF
--- a/src/Calypso-NavigationModel-Tests/ClyAsyncQueryResultTest.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyAsyncQueryResultTest.class.st
@@ -17,15 +17,14 @@ ClyAsyncQueryResultTest >> createQueryResult [
 
 { #category : #tests }
 ClyAsyncQueryResultTest >> testBuildCompletionShouldNotifyItemObservers [
-
-	| observer cursor |
+	| observer |
 	observer := ClyItemObserverExample new.
-	cursor := queryResult openBrowserCursorFor: observer.
+	queryResult openBrowserCursorFor: observer.
 
 	queryResult rebuild.
 	query passExecution.
 	self waitBuildComplete.
-	
+
 	self assert: observer wasNotified
 ]
 

--- a/src/Collections-Abstract-Tests/TIndexAccess.trait.st
+++ b/src/Collections-Abstract-Tests/TIndexAccess.trait.st
@@ -26,7 +26,7 @@ TIndexAccess >> elementNotInForIndexAccessing [
 
 { #category : #'tests - fixture' }
 TIndexAccess >> test0FixtureIndexAccessTest [
-	| res collection element |
+	| res |
 	self collectionMoreThan1NoDuplicates.
 	self assert: self collectionMoreThan1NoDuplicates size > 1.
 	res := true.
@@ -35,8 +35,7 @@ TIndexAccess >> test0FixtureIndexAccessTest [
 		ifNone: [ res := false ].
 	self assert: res = false.
 	self elementInForIndexAccessing.
-	self
-		assert: ((collection := self collectionMoreThan1NoDuplicates) includes: (element := self elementInForIndexAccessing)).
+	self assert: (self collectionMoreThan1NoDuplicates includes: self elementInForIndexAccessing).
 	self elementNotInForIndexAccessing.
 	self deny: (self collectionMoreThan1NoDuplicates includes: self elementNotInForIndexAccessing)
 ]

--- a/src/Collections-Abstract-Tests/TOccurrencesForMultiplinessTest.trait.st
+++ b/src/Collections-Abstract-Tests/TOccurrencesForMultiplinessTest.trait.st
@@ -39,18 +39,15 @@ TOccurrencesForMultiplinessTest >> empty [
 
 { #category : #'tests - fixture' }
 TOccurrencesForMultiplinessTest >> test0FixtureOccurrencesForMultiplinessTest [
-
-	| cpt anElement collection |
+	| cpt |
 	self collectionWithEqualElements.
 	self collectionWithEqualElements.
 	self elementTwiceInForOccurrences.
-	anElement := self elementTwiceInForOccurrences.
-	collection := self collectionWithEqualElements.
-	cpt := 0.	" testing with identity check ( == ) so that identy collections can use this trait : "
-	self collectionWithEqualElements
-		do: [ :each | 
-			each == self elementTwiceInForOccurrences
-				ifTrue: [ cpt := cpt + 1 ] ].
+	self elementTwiceInForOccurrences.
+	self collectionWithEqualElements.
+	cpt := 0. " testing with identity check ( == ) so that identy collections can use this trait : "
+	self collectionWithEqualElements do: [ :each | 
+		each == self elementTwiceInForOccurrences ifTrue: [ cpt := cpt + 1 ] ].
 	self assert: cpt = 2
 ]
 

--- a/src/Collections-Abstract-Tests/TRemoveForMultiplenessTest.trait.st
+++ b/src/Collections-Abstract-Tests/TRemoveForMultiplenessTest.trait.st
@@ -47,34 +47,29 @@ TRemoveForMultiplenessTest >> test0FixtureTRemoveTest [
 
 { #category : #'tests - remove' }
 TRemoveForMultiplenessTest >> testRemoveAll [
-
-	| el aSubCollection collection res |
+	| el aSubCollection collection |
 	collection := self nonEmptyWithoutEqualElements.
 	el := collection anyOne.
 	aSubCollection := collection copyWithout: el.
-	res := collection removeAll: aSubCollection.
+	collection removeAll: aSubCollection.
 	self assert: collection size = 1.
 	self nonEmptyWithoutEqualElements do: [ :each | self assert: each = el ]
 ]
 
 { #category : #'tests - remove' }
 TRemoveForMultiplenessTest >> testRemoveAllError [
-
 	| el aSubCollection |
 	el := self elementNotIn.
 	aSubCollection := self nonEmptyWithoutEqualElements copyWith: el.
-	self 
-		should: [ | res | res := self nonEmptyWithoutEqualElements removeAll: aSubCollection ]
-		raise: Error
+	self should: [ self nonEmptyWithoutEqualElements removeAll: aSubCollection ] raise: Error
 ]
 
 { #category : #'tests - remove' }
 TRemoveForMultiplenessTest >> testRemoveAllFoundIn [
-
-	| el aSubCollection res |
+	| el aSubCollection |
 	el := self nonEmptyWithoutEqualElements anyOne.
 	aSubCollection := (self nonEmptyWithoutEqualElements copyWithout: el) copyWith: self elementNotIn.
-	res := self nonEmptyWithoutEqualElements removeAllFoundIn: aSubCollection.
+	self nonEmptyWithoutEqualElements removeAllFoundIn: aSubCollection.
 	self assert: self nonEmptyWithoutEqualElements size = 1.
 	self nonEmptyWithoutEqualElements do: [ :each | self assert: each = el ]
 ]

--- a/src/Collections-Abstract-Tests/TRemoveTest.trait.st
+++ b/src/Collections-Abstract-Tests/TRemoveTest.trait.st
@@ -40,26 +40,22 @@ TRemoveTest >> test0FixtureTRemoveTest [
 
 { #category : #'tests - remove' }
 TRemoveTest >> testRemoveAll [
-
-	| el aSubCollection collection res |
+	| el aSubCollection collection |
 	collection := self nonEmptyWithoutEqualElements.
 	el := collection anyOne.
 	aSubCollection := collection copyWithout: el.
-	res := collection removeAll: aSubCollection.
+	collection removeAll: aSubCollection.
 	self assert: collection size = 1.
 	self nonEmptyWithoutEqualElements do: [ :each | self assert: each = el ]
 ]
 
 { #category : #'tests - remove' }
 TRemoveTest >> testRemoveAllError [
-
 	| el aSubCollection |
 	el := self elementNotIn.
 	aSubCollection := self nonEmptyWithoutEqualElements copyWith: el.
-	
-	self 
-		should: [ | res | res := self nonEmptyWithoutEqualElements removeAll: aSubCollection ]
-		raise: Error
+
+	self should: [ self nonEmptyWithoutEqualElements removeAll: aSubCollection ] raise: Error
 ]
 
 { #category : #'tests - remove' }

--- a/src/Collections-Tests/ByteSymbolTest.class.st
+++ b/src/Collections-Tests/ByteSymbolTest.class.st
@@ -9,14 +9,13 @@ Class {
 
 { #category : #'tests - creation' }
 ByteSymbolTest >> testAs [
-	| tStr tAs1 tAs2 |
+	| tStr |
 	tStr := DateAndTime now asString.
-	tAs1 := tStr as: ByteSymbol.
+	tStr as: ByteSymbol.
 	self assert: (Symbol allSymbols select: [ :e | e asString = tStr ]) size equals: 1.
 	self assert: (ByteSymbol allInstances select: [ :e | e asString = tStr ]) size equals: 1.
 	self assert: (ByteSymbol allInstances select: [ :e | e asString = tStr ]) equals: (Symbol allSymbols select: [ :e | e asString = tStr ]).
-
-	tAs2 := tStr as: ByteSymbol.
+	tStr as: ByteSymbol.
 	self assert: (Symbol allSymbols select: [ :e | e asString = tStr ]) size equals: 1.
 	self assert: (ByteSymbol allInstances select: [ :e | e asString = tStr ]) size equals: 1
 ]
@@ -29,31 +28,30 @@ ByteSymbolTest >> testNew [
 
 { #category : #'tests - creation' }
 ByteSymbolTest >> testNewFrom [
-	| dt newFrom1 newFrom2 |
+	| dt |
 	dt := DateAndTime now asString.
-	newFrom1 := ByteSymbol newFrom: dt.
+	ByteSymbol newFrom: dt.
 	self assert: (Symbol allSymbols select: [ :e | e asString = dt ]) size equals: 1.
 	self assert: (ByteSymbol allInstances select: [ :e | e = dt ]) size equals: 1.
 	self assert: (Symbol allSymbols select: [ :e | e asString = dt ]) equals: (ByteSymbol allInstances select: [ :e | e = dt ]).
-	newFrom2 := ByteSymbol newFrom: dt.
+	ByteSymbol newFrom: dt.
 	self assert: (Symbol allSymbols select: [ :e | e asString = dt ]) size equals: 1.
 	self assert: (ByteSymbol allInstances select: [ :e | e = dt ]) size equals: 1
 ]
 
 { #category : #'tests - creation' }
 ByteSymbolTest >> testReadFromString [
-	| str strWithPound readFrom1 readFrom2 |
+	| str strWithPound |
 	Smalltalk garbageCollect.
 	str := 'notYetExisting'.
 	self assert: (Symbol allSymbols select: [ :e | e asString = str ]) size equals: 0.
 	self assert: (ByteSymbol allInstances select: [ :e | e asString = str ]) size equals: 0.
 	strWithPound := '#' , str.
-	readFrom1 := ByteSymbol readFromString: strWithPound.
+	ByteSymbol readFromString: strWithPound.
 	self assert: (Symbol allSymbols select: [ :e | e asString = str ]) size equals: 1.
 	self assert: (ByteSymbol allInstances select: [ :e | e = str ]) size equals: 1.
 	self assert: (Symbol allSymbols select: [ :e | e asString = str ]) equals: (ByteSymbol allInstances select: [ :e | e = str ]).
-
-	readFrom2 := ByteSymbol readFromString: strWithPound.
+	ByteSymbol readFromString: strWithPound.
 	self assert: (Symbol allSymbols select: [ :e | e asString = str ]) size equals: 1.
 	self assert: (ByteSymbol allInstances select: [ :e | e = str ]) size equals: 1
 ]

--- a/src/Collections-Tests/SymbolTest.class.st
+++ b/src/Collections-Tests/SymbolTest.class.st
@@ -170,13 +170,11 @@ SymbolTest >> empty [
 
 { #category : #accessing }
 SymbolTest >> expectedBehavior [
-	| result |
-	
-	^result := { 
-		[Symbol readFromString: '#''abc'''] -> #abc.
-		[Symbol readFromString: '#ab-C'] -> #ab.
-	 	[Symbol readFromString: '#abC'] -> #abC. 
-		[Symbol readFromString: '#ab@c'] -> #ab}.
+	^ { 
+		  ([ Symbol readFromString: '#''abc''' ] -> #abc).
+		  ([ Symbol readFromString: '#ab-C' ] -> #ab).
+		  ([ Symbol readFromString: '#abC' ] -> #abC).
+		  ([ Symbol readFromString: '#ab@c' ] -> #ab) }
 ]
 
 { #category : #requirements }
@@ -490,10 +488,9 @@ SymbolTest >> testReadFrom [
 
 { #category : #tests }
 SymbolTest >> testUncapitalized [
-	| uc lc empty |
+	| uc lc |
 	uc := #MElViN.
 	lc := #mElViN.
-	empty := #' '.
 	self assert: uc uncapitalized equals: lc.
 	self assert: lc uncapitalized equals: lc
 ]

--- a/src/Collections-Unordered-Tests/MethodDictionaryTest.class.st
+++ b/src/Collections-Unordered-Tests/MethodDictionaryTest.class.st
@@ -223,8 +223,7 @@ MethodDictionaryTest >> testIdentityKeyAtExistantValueReturnsOkKey [
 
 { #category : #'tests - others' }
 MethodDictionaryTest >> testIdentityKeyAtNonExistantValueReturnsFailBlock [
-	| methodSelector result error |
-	methodSelector := #testAssociationAtExistantKeyReturnsOkAssociation.
+	| result error |
 	error := #error.
 
 	result := self class methodDict keyAtIdentityValue: self ifAbsent: [ error ].
@@ -260,8 +259,7 @@ MethodDictionaryTest >> testKeyAtExistantValueReturnsOkKey [
 
 { #category : #'tests - others' }
 MethodDictionaryTest >> testKeyAtNonexistantValueExecutesFailBlock [
-	| methodSelector result error |
-	methodSelector := #inexistant:method:larala:.
+	| result error |
 	error := #error.
 	result := self class methodDict keyAtValue: self ifAbsent: [ error ].
 

--- a/src/Collections-Unordered-Tests/TDictionaryAssociationAccessTest.trait.st
+++ b/src/Collections-Unordered-Tests/TDictionaryAssociationAccessTest.trait.st
@@ -89,16 +89,14 @@ TDictionaryAssociationAccessTest >> testAssociationAtIfPresent [
 
 { #category : #'tests - dictionary assocition access' }
 TDictionaryAssociationAccessTest >> testAssociationAtIfPresentifAbsent [
-
-	| collection keyIn result found |
+	| collection keyIn found |
 	found := false.
 	collection := self nonEmpty.
 	keyIn := collection keys anyOne.
-
-	result := collection associationAt: keyIn ifPresent: [found := true ] ifAbsent: [888].
+	collection associationAt: keyIn ifPresent: [ found := true ] ifAbsent: [ 888 ].
 	self assert: found.
 
-	self assert: (collection associationAt: self keyNotIn  ifAbsent: [888] ) = 888.
-	
-	self assert: (collection associationAt: self keyNotIn  ifPresent: [666] ifAbsent: [888] ) = 888
+	self assert: (collection associationAt: self keyNotIn ifAbsent: [ 888 ]) = 888.
+
+	self assert: (collection associationAt: self keyNotIn ifPresent: [ 666 ] ifAbsent: [ 888 ]) = 888
 ]

--- a/src/Collections-Weak/WeakKeyDictionary.class.st
+++ b/src/Collections-Weak/WeakKeyDictionary.class.st
@@ -387,19 +387,14 @@ WeakKeyDictionary >> valueAtNewKey: aKey put: anObject atIndex: index declareFro
 ]
 
 { #category : #enumerating }
-WeakKeyDictionary >> valuesDo: aBlock [ 
-	"See comments in Dictionary>>valuesDo:.  The code keeps the key so it's
-	not collected during the evaluation of aBlock"
+WeakKeyDictionary >> valuesDo: aBlock [
+	"See comments in Dictionary>>valuesDo:"
 
-	tally = 0 ifTrue: [ ^self ].
-	1 to: array size do:
-		[ :eachIndex | 
-			| eachAssociation eachKey |
-			eachAssociation := array at: eachIndex.
-			nil == eachAssociation ifFalse:
-				[
-					eachKey := eachAssociation key.
-					aBlock value: eachAssociation value
-				]
-		]
+	tally = 0 ifTrue: [ ^ self ].
+	1 to: array size do: [ :eachIndex | 
+		(array at: eachIndex) ifNotNil: [ :eachAssociation | 
+			| eachKey |
+			"The code keeps the key so it's not collected during the evaluation of aBlock"
+			eachKey := eachAssociation key.
+			aBlock value: eachAssociation value ] ]
 ]


### PR DESCRIPTION
Remove unused temoraries in packages starting with C