### PR TITLE
remove-unused-temporaries-in-packages-starting-with-H

### DIFF
--- a/src/HelpSystem-Tests/HelpBrowserTest.class.st
+++ b/src/HelpSystem-Tests/HelpBrowserTest.class.st
@@ -28,14 +28,14 @@ HelpBrowserTest >> testDefaultHelpBrowser [
 
 { #category : #testing }
 HelpBrowserTest >> testDefaultHelpBrowserIsReplacable [
-	| current replacement instance |
+	| current replacement |
 	"save the one that is registered"
 	current := self defaultTestClass defaultHelpBrowser.
 	replacement := AdvancedHelpBrowserDummy.
-	[ self defaultTestClass defaultHelpBrowser: replacement.
+	[ 
+	self defaultTestClass defaultHelpBrowser: replacement.
 	self assert: self defaultTestClass defaultHelpBrowser identicalTo: replacement.
-	instance := self defaultTestClass open ]
-		ensure: [ self defaultTestClass defaultHelpBrowser: current ]
+	self defaultTestClass open ] ensure: [ self defaultTestClass defaultHelpBrowser: current ]
 ]
 
 { #category : #testing }

--- a/src/HeuristicCompletion-Tests/CoStatisticsTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoStatisticsTest.class.st
@@ -187,49 +187,45 @@ CoStatisticsTest >> testHeuristicBuilderForSingleHeuristicWrapsNonWrapper [
 
 { #category : #'tests-heuristicbuilder' }
 CoStatisticsTest >> testHeuristicBuilderForTwoHeuristicBuildsWrapper [
-
-	| builder heuristic heuristic1 heuristic2 |
+	| builder heuristic |
 	builder := CoStatisticsHeuristicBuilder new.
-	builder add: (heuristic1 := CoGlobalVariablesHeuristic new).
-	builder add: (heuristic2 := CoGlobalVariablesHeuristic new).
+	builder add: CoGlobalVariablesHeuristic new.
+	builder add: CoGlobalVariablesHeuristic new.
 	heuristic := builder build.
-	
+
 	self assert: heuristic isStatisticsHeuristicWrapper
 ]
 
 { #category : #'tests-heuristicbuilder' }
 CoStatisticsTest >> testHeuristicBuilderForTwoHeuristicNextIsWrapper [
-
-	| builder heuristic heuristic1 heuristic2 |
+	| builder heuristic |
 	builder := CoStatisticsHeuristicBuilder new.
-	builder add: (heuristic1 := CoGlobalVariablesHeuristic new).
-	builder add: (heuristic2 := CoGlobalVariablesHeuristic new).
+	builder add: CoGlobalVariablesHeuristic new.
+	builder add: CoGlobalVariablesHeuristic new.
 	heuristic := builder build.
-	
+
 	self assert: heuristic next isStatisticsHeuristicWrapper
 ]
 
 { #category : #'tests-heuristicbuilder' }
 CoStatisticsTest >> testHeuristicBuilderForTwoHeuristicSecondWrapperWrapsNonWrapper [
-
-	| builder heuristic heuristic1 heuristic2 |
+	| builder heuristic heuristic2 |
 	builder := CoStatisticsHeuristicBuilder new.
-	builder add: (heuristic1 := CoGlobalVariablesHeuristic new).
+	builder add: CoGlobalVariablesHeuristic new.
 	builder add: (heuristic2 := CoGlobalVariablesHeuristic new).
 	heuristic := builder build.
-	
+
 	self assert: heuristic next wrapped equals: heuristic2
 ]
 
 { #category : #'tests-heuristicbuilder' }
 CoStatisticsTest >> testHeuristicBuilderForTwoHeuristicWrapsNonWrapper [
-
-	| builder heuristic heuristic1 heuristic2 |
+	| builder heuristic heuristic1 |
 	builder := CoStatisticsHeuristicBuilder new.
 	builder add: (heuristic1 := CoGlobalVariablesHeuristic new).
-	builder add: (heuristic2 := CoGlobalVariablesHeuristic new).
+	builder add: CoGlobalVariablesHeuristic new.
 	heuristic := builder build.
-	
+
 	self assert: heuristic wrapped equals: heuristic1
 ]
 


### PR DESCRIPTION
Remove unused temoraries in packages starting with H