### PR TITLE
6758-OrderedCollectionremoveDuplicates-is-really-long

### DIFF
--- a/src/Collections-Sequenceable/OrderedCollection.class.st
+++ b/src/Collections-Sequenceable/OrderedCollection.class.st
@@ -713,17 +713,16 @@ OrderedCollection >> removeDuplicates [
 	"#(7 42 7 42 9) asOrderedCollection removeDuplicates asArray >>> #(7 42 9)"
 	"#(1 2 3) asOrderedCollection removeDuplicates asArray >>> #(1 2 3)"
 
-	| iterator |
+	| iterator seen |
 	self ifEmpty: [ ^ self ].
 	iterator := 1.
+	seen := Set new.
 	[ iterator <= self size ]
-		whileTrue: [ | each newIndex |
+		whileTrue: [ | each |
 			each := self at: iterator.
-			newIndex := iterator + 1.
-			[ newIndex := (self indexOf: each startingAt: newIndex).
-			newIndex > 0 ]
-				whileTrue: [ self removeAt: newIndex ].
-			iterator := iterator + 1.
+			(seen includes: each)
+				ifTrue: [ self removeAt: iterator ]
+				ifFalse: [ seen add: each. iterator := iterator + 1. ].
 	 ]
 ]
 

--- a/src/Collections-Tests/OrderedCollectionTest.class.st
+++ b/src/Collections-Tests/OrderedCollectionTest.class.st
@@ -996,6 +996,12 @@ OrderedCollectionTest >> testRemoveAt [
 ]
 
 { #category : #'tests - removing' }
+OrderedCollectionTest >> testRemoveDuplicates [
+	self assert: #(7 42 7 42 9) asOrderedCollection removeDuplicates equals: #(7 42 9) asOrderedCollection.
+	self assert: #(1 2 3) asOrderedCollection removeDuplicates equals: #(1 2 3) asOrderedCollection
+]
+
+{ #category : #'tests - removing' }
 OrderedCollectionTest >> testRemoveFirst [
 	"Allows one to remove n element of a collection at the first"
 	


### PR DESCRIPTION
Possible fix #6758

Changes removeDuplicate complexity from O(N^2) to O(N) by keeping track of the elements already seen.Timings uging issue's example: before "0:00:00:08.277" / after "0:00:00:00.572" (Windows 10 1909 x64)