### PR TITLE
UndefinedSlot

### DIFF
--- a/src/Kernel/UndefinedSlot.class.st
+++ b/src/Kernel/UndefinedSlot.class.st
@@ -56,7 +56,7 @@ UndefinedSlot >> read: anObject [
 
 { #category : #accessing }
 UndefinedSlot >> slotClassName [
-	^ast arguments first binding name 
+	^ast arguments first variable name 
 ]
 
 { #category : #'meta-object-protocol' }

--- a/src/Kernel/UndefinedSlot.class.st
+++ b/src/Kernel/UndefinedSlot.class.st
@@ -1,0 +1,67 @@
+"
+When loading a class where a Slot is used that is not present in the System, we need to model
+this slot somehow.
+
+The UndefinedSlot ingores reads and write (it returns nil like undeclared variables). But on
+access, it checks if the Slot has been loaded and if yes, it rebuilds the class definition.
+"
+Class {
+	#name : #UndefinedSlot,
+	#superclass : #Slot,
+	#instVars : [
+		'ast',
+		'classIsRebuild'
+	],
+	#classInstVars : [
+		'undeclaredSlots'
+	],
+	#category : #'Kernel-Variables'
+}
+
+{ #category : #'instance creation' }
+UndefinedSlot class >> named: aName ast: aSlotClassName [
+	^ (self named: aName) ast: aSlotClassName
+]
+
+{ #category : #accessing }
+UndefinedSlot >> ast: aMessageNode [
+	classIsRebuild := false.
+	ast := aMessageNode
+]
+
+{ #category : #private }
+UndefinedSlot >> checkClassRebuild [
+	"break the recursion while rebuilding"
+	classIsRebuild ifTrue: [ ^ self].
+	(self definingClass environment hasClassNamed: self slotClassName) ifFalse: [ ^ self ].
+	classIsRebuild := true.
+	"we rebuild the class, this triggers instance migration"
+	self definingClass compiler evaluate: self definingClass definitionWithSlots.
+	"recompile all methods that access me to generat code for the loaded definition"
+	self usingMethods do: [:each | each recompile].
+]
+
+{ #category : #printing }
+UndefinedSlot >> printOn: aStream [
+	"we print as the definition that could not be loaded"
+	aStream nextPutAll: ast formattedCode
+]
+
+{ #category : #'meta-object-protocol' }
+UndefinedSlot >> read: anObject [
+	"Undeclared slots read nil always, but check if they can repair the class"
+	 self checkClassRebuild.
+	^ nil
+]
+
+{ #category : #accessing }
+UndefinedSlot >> slotClassName [
+	^ast arguments first binding name 
+]
+
+{ #category : #'meta-object-protocol' }
+UndefinedSlot >> write: aValue to: anObject [
+	"Undeclared slots ignore writes, but check if they can repair the class"
+	 self checkClassRebuild.
+	^ aValue
+]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -83,6 +83,8 @@ ShiftClassBuilder >> build [
 
 	self createSharedVariables.
 
+	self installSlotsAndVariables.
+
 	self oldClass ifNotNil: [ 
 			self newClass basicCategory: self oldClass basicCategory.
 			self copyOrganization.
@@ -90,7 +92,7 @@ ShiftClassBuilder >> build [
 
 	self builderEnhancer afterMethodsCompiled: self.
 	
-	self installSlotsAndVariables.
+	
 	
 	^ newClass
 ]

--- a/src/Slot-Core/Symbol.extension.st
+++ b/src/Slot-Core/Symbol.extension.st
@@ -2,8 +2,9 @@ Extension { #name : #Symbol }
 
 { #category : #'*Slot-Core' }
 Symbol >> => aVariable [
-	"If the slot we give as argument is not present in the image, we will get a nil. In that case we should throw an explicit error to the user saying a slot is missing."
+	"If the slot we give as argument is not present in the image, we create an UndefinedSlot with the AST of the slot definition"
 
-	aVariable ifNil: [ SlotNotFound signalForName: self ].
-	^ aVariable named: self
+	^ aVariable 
+		ifNil: [ UndefinedSlot named: self ast: thisContext sender sourceNodeExecuted]
+		ifNotNil: [ aVariable named: self ]
 ]

--- a/src/Slot-Tests/SlotErrorsTest.class.st
+++ b/src/Slot-Tests/SlotErrorsTest.class.st
@@ -197,6 +197,64 @@ SlotErrorsTest >> testSlotWithReservedName [
 ]
 
 { #category : #tests }
+SlotErrorsTest >> testUndeclareSlot [
+	| slot instance |
+
+	aClass := self make: [ :builder | 
+		builder slots: { UndefinedSlot named: #a ast: ((RBParser parseExpression: '#a => MySlot') doSemanticAnalysis;yourself) } ].
+
+	slot := aClass slotNamed: #a.
+
+	self assert: slot class equals: UndefinedSlot.
+	self assert: slot name equals: #a.
+	self assert: slot slotClassName equals: #MySlot.
+	
+	instance := aClass new.
+	
+	self assert: (slot read: instance) equals: nil.
+	slot write: 1 to: instance.
+	self assert: (slot read: instance) equals: nil.
+
+]
+
+{ #category : #tests }
+SlotErrorsTest >> testUndeclareSlotFixWhenSlotIsLoaded [
+	| slot instance mySlot |
+
+	aClass := self make: [ :builder | 
+		builder slots: { UndefinedSlot named: #a ast: ((RBParser parseExpression: '#a => ', self anotherClassName) doSemanticAnalysis;yourself) } ].
+
+	slot := aClass slotNamed: #a.
+
+	self assert: slot class equals: UndefinedSlot.
+	self assert: slot name equals: #a.
+	self assert: slot slotClassName equals: self anotherClassName.
+	
+	instance := aClass new.
+	
+	self assert: (slot read: instance) equals: nil.
+	slot write: 1 to: instance.
+	self assert: (slot read: instance) equals: nil.
+
+	PropertySlot  
+		subclass: self anotherClassName
+		instanceVariableNames: ''
+		classVariableNames: ''
+		poolDictionaries: ''
+		package: self aCategory.
+	
+	self assert: (slot read: instance) equals: nil.
+	
+	mySlot := aClass slotNamed: #a.
+	
+	self assert: mySlot name equals: #a.
+	
+	self assert: (mySlot read: instance) equals: nil.
+	mySlot write: 1 to: instance.
+	self assert: (mySlot read: instance) equals: 1.
+]
+
+{ #category : #tests }
 SlotErrorsTest >> testValidateClassName [		
 		
 	Smalltalk classInstaller 

--- a/src/Slot-Tests/SlotTest.class.st
+++ b/src/Slot-Tests/SlotTest.class.st
@@ -44,13 +44,6 @@ SlotTest >> testIsWrittenInMethod [
 	self assert: ((self class slotNamed: #ivarForTesting) isWrittenIn: self class >> testSelector)
 ]
 
-{ #category : #'tests - misc' }
-SlotTest >> testNotFoundSlotRaiseExplicitError [
-	"When a slot is not present in the image, we will try to build the slot with nil. In that case we should return an error."
-
-	self should: [ #test => nil ] raise: SlotNotFound
-]
-
 { #category : #'tests - read/write' }
 SlotTest >> testNotReadInMethod [
 	


### PR DESCRIPTION
- FIx classbuilder:  move #installSlotsAndVariables to before recompiling methods
- add UndefinedSlot

The idea of UndefinedSlot is that for the cast a class is loaded where the slot definition does not exist, we create this special UndefinedSlot.
-  It has the same name
- has the definition of the slot (the AST) 
- prints itself as the definition (the AST). This might be slightly different then the prefered printout for the slot, but contains all infos to create the correct slot later
- reads return nil
- writes are ignored

On read and write, the UndefindedSlot will check if the class of the original definition now has been loaded and if yes, will rebuild the class.