### PR TITLE
6778-ShiftClassBuilder-does-not-recompile-SharedPool-users-when-it-changes

### DIFF
--- a/src/Commander2/CmCommandGroup.class.st
+++ b/src/Commander2/CmCommandGroup.class.st
@@ -131,8 +131,10 @@ CmCommandGroup >> register: aCommandOrGroup before: anotherCommandOrGroup [
 CmCommandGroup >> register: aCommandOrGroup insteadOf: anotherCommandOrGroup [
 	| commandToReplaceIndex |
 	commandToReplaceIndex := self entriesIndexOf: anotherCommandOrGroup.
-	((self commands collect: [:each | each name]) \ { (entries at: commandToReplaceIndex) } includes: aCommandOrGroup name)
+	
+	((self commands collect: #name) \ { (entries at: commandToReplaceIndex) } includes: aCommandOrGroup name)
 		ifTrue: [ CmDuplicatedEntryName signalEntryNamed: aCommandOrGroup name ].
+	
 	entries at: commandToReplaceIndex put: aCommandOrGroup
 ]
 

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -55,6 +55,40 @@ ShClassInstallerTest >> tearDown [
 ]
 
 { #category : #tests }
+ShClassInstallerTest >> testChangingASharedPoolUpdatesCorrectlyUsers [
+	
+	newClass := ShiftClassInstaller
+		make: [ :builder | 
+			builder
+				name: #ShCITestSharedPool;
+				superclass: SharedPool;
+				sharedVariables: #(A B C);
+				category: 'Shift-ClassInstaller-Tests' ].
+			
+	newClass2 := ShiftClassInstaller
+		make: [ :builder | 
+			builder
+				name: #ShCITestClass;
+				sharedPools: 'ShCITestSharedPool';
+				category: 'Shift-ClassInstaller-Tests' ].
+	
+	newClass2 compile: 'a ^A'.
+	
+	self assert: ((newClass2 >> #a) literals at: 1) identicalTo: (newClass classPool associationAt: #A).
+	
+	newClass := ShiftClassInstaller
+		make: [ :builder | 
+			builder
+				name: #ShCITestSharedPool;
+				superclass: SharedPool;
+				sharedVariables: #(A B C D);
+				category: 'Shift-ClassInstaller-Tests' ].
+
+	self assert: ((newClass2 >> #a) literals at: 1) identicalTo: (newClass classPool associationAt: #A).
+
+]
+
+{ #category : #tests }
 ShClassInstallerTest >> testChangingHierarchy [
 	"Testing that the changes in the superclasses are propagated to the subclasses"
 

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -231,7 +231,7 @@ ShiftClassInstaller >> migrateClassTo: newClass [
 		(newClass classPool includesKey: oldAssociation key)
 			ifTrue: [ 
 				newAssociation := newClass classPool associationAt: oldAssociation key.
-				newAssociation value: oldAssociation value.
+				newClass classVarNamed: oldAssociation key put: oldAssociation value.
 				newClassVariableBindings add: newAssociation.
 				oldClassVariableBindings add: oldAssociation. ]].
 	

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -130,8 +130,7 @@ ShiftClassInstaller >> installInEnvironment: newClass [
 
 	"I only install in the environment if there is not oldClass installed."
 	(self installingEnvironment hasClassNamed: builder name) ifFalse:[
-		self installingEnvironment installClass: newClass withName: builder name.
-	].
+		self installingEnvironment installClass: newClass withName: builder name ].
 
 	self
 		updateBindings: (self installingEnvironment bindingAt: builder name)
@@ -213,7 +212,8 @@ ShiftClassInstaller >> make: aBlock [
 
 { #category : #migrating }
 ShiftClassInstaller >> migrateClassTo: newClass [
-	| slotsToMigrate |
+	| slotsToMigrate oldClassVariableBindings newClassVariableBindings|
+
 	oldClass ifNil:[^ self].
 	self assert: newClass isNotNil.
 		
@@ -224,15 +224,25 @@ ShiftClassInstaller >> migrateClassTo: newClass [
 	slotsToMigrate := newClass class allSlots reject:[:e | builder builderEnhancer hasToSkipSlot: e ].
 	slotsToMigrate do: [ :newSlot | oldClass class slotNamed: newSlot name ifFound: [ :oldSlot | newSlot write: (oldSlot read: oldClass) to: newClass ] ].
 	
-	oldClass classVarNames do: [ :aClassVar |
-		(newClass hasClassVarNamed: aClassVar) ifTrue:[ newClass classVarNamed: aClassVar put: (oldClass classVarNamed: aClassVar) ].
-	].
+	oldClassVariableBindings := OrderedCollection new.
+	newClassVariableBindings := OrderedCollection new.
+	
+	oldClass classPool associations do: [ :oldAssociation | | newAssociation |
+		(newClass classPool includesKey: oldAssociation key)
+			ifTrue: [ 
+				newAssociation := newClass classPool associationAt: oldAssociation key.
+				newAssociation value: oldAssociation value.
+				newClassVariableBindings add: newAssociation.
+				oldClassVariableBindings add: oldAssociation. ]].
 	
 	[ 	
 		(self builder hasToMigrateInstances) 
 			ifTrue: [ builder builderEnhancer migrateInstancesTo: newClass installer: self ].
 
-		{ oldClass. builder oldMetaclass } elementsForwardIdentityTo: { newClass. builder newMetaclass }.	
+		{ oldClass. builder oldMetaclass } , oldClassVariableBindings asArray
+			elementsForwardIdentityTo: { newClass. builder newMetaclass }, newClassVariableBindings asArray.	
+
+		newClass classPool rehash.
 	] valueUninterruptably
 
 ]


### PR DESCRIPTION
When creating a SharedPool the associations should become from the old to the new associations.
As they don't share the same hierarchy.