### PR TITLE
Introduce-LocalVariable

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -30,7 +30,7 @@ Context >> lookupSymbol: aSymbol [
 Context >> lookupTempVar: aSymbol [
 	| var |
 	var := self lookupVar: aSymbol.
-	var isTemp ifFalse: [ ^self error: var name, ' is not a temp but, ', var class name].
+	var isLocalVariable ifFalse: [ ^self error: var name, ' is not a temp but, ', var class name].
 	^var
 ]
 

--- a/src/Deprecated90/OCArgumentVariable.class.st
+++ b/src/Deprecated90/OCArgumentVariable.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #OCArgumentVariable,
+	#superclass : #ArgumentVariable,
+	#category : #'Deprecated90-OpalCompiler-Core'
+}

--- a/src/Deprecated90/OCTempVariable.class.st
+++ b/src/Deprecated90/OCTempVariable.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #OCTempVariable,
+	#superclass : #TemporaryVariable,
+	#category : #'Deprecated90-OpalCompiler-Core'
+}

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -875,7 +875,7 @@ ClassDescription >> linesOfCode [
 { #category : #slots }
 ClassDescription >> localSlots [
 
-	^ self slots select: [ :aSlot | aSlot isLocal ]
+	^ self slots select: [ :aSlot | aSlot isDefinedByOwningClass ]
 ]
 
 { #category : #'accessing tags' }

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -212,14 +212,14 @@ Slot >> isAccessedIn: aCompiledCode [
 ]
 
 { #category : #testing }
-Slot >> isInstance [
-	^ true
+Slot >> isDefinedByOwningClass [
+
+	^ self owningClass = self definingClass
 ]
 
 { #category : #testing }
-Slot >> isLocal [
-
-	^ self owningClass = self definingClass
+Slot >> isInstance [
+	^ true
 ]
 
 { #category : #testing }

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -125,6 +125,11 @@ Variable >> isLiteralVariable [
 ]
 
 { #category : #testing }
+Variable >> isLocalVariable [
+	^false
+]
+
+{ #category : #testing }
 Variable >> isReferenced [
 	^ self usingMethods isNotEmpty
 ]

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -125,6 +125,11 @@ Variable >> isLiteralVariable [
 ]
 
 { #category : #testing }
+Variable >> isLocal [
+	^false
+]
+
+{ #category : #testing }
 Variable >> isLocalVariable [
 	^false
 ]

--- a/src/OpalCompiler-Core/ArgumentVariable.class.st
+++ b/src/OpalCompiler-Core/ArgumentVariable.class.st
@@ -2,36 +2,36 @@
 I model argument variables. By definition, an argument variable is always initialized, and can't be written to.
 "
 Class {
-	#name : #OCArgumentVariable,
-	#superclass : #OCTempVariable,
+	#name : #ArgumentVariable,
+	#superclass : #LocalVariable,
 	#category : #'OpalCompiler-Core-Semantics'
 }
 
 { #category : #accessing }
-OCArgumentVariable class >> semanticNodeClass [
+ArgumentVariable class >> semanticNodeClass [
 
 	^RBArgumentNode 
 ]
 
 { #category : #testing }
-OCArgumentVariable >> isArg [
+ArgumentVariable >> isArg [
 
 	^ true
 ]
 
 { #category : #testing }
-OCArgumentVariable >> isUninitialized [
+ArgumentVariable >> isUninitialized [
 
 	^ false
 ]
 
 { #category : #testing }
-OCArgumentVariable >> isWritable [
+ArgumentVariable >> isWritable [
 
 	^ false
 ]
 
 { #category : #debugging }
-OCArgumentVariable >> writeFromContext: aContext scope: contextScope value: aValue [
+ArgumentVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 	self error: 'Arguments are read only'
 ]

--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -1,8 +1,8 @@
 "
-I model temp variables. With Closures, there are two kinds: Copying and those that are stored in a so called temp vector, a heap allocated array that itself is stored in a copying temp variable.
+I model local Variables
 "
 Class {
-	#name : #OCTempVariable,
+	#name : #LocalVariable,
 	#superclass : #Variable,
 	#instVars : [
 		'escaping',
@@ -13,14 +13,13 @@ Class {
 	#category : #'OpalCompiler-Core-Semantics'
 }
 
-{ #category : #accessing }
-OCTempVariable class >> semanticNodeClass [
-
-	^RBTemporaryNode 
+{ #category : #testing }
+LocalVariable class >> isAbstract [ 
+	^ self = LocalVariable  
 ]
 
 { #category : #comparing }
-OCTempVariable >> = aTempVar [
+LocalVariable >> = aTempVar [
 
 	^aTempVar class = self class 
 		and: [aTempVar scope = self scope 
@@ -31,51 +30,51 @@ OCTempVariable >> = aTempVar [
 ]
 
 { #category : #converting }
-OCTempVariable >> asString [
+LocalVariable >> asString [
 
 	^ self name
 ]
 
 { #category : #queries }
-OCTempVariable >> astNodes [
+LocalVariable >> astNodes [
 	^self method variableNodes select: [ :each | each binding == self]
 ]
 
 { #category : #accessing }
-OCTempVariable >> definingScope [
+LocalVariable >> definingScope [
 	^ scope
 ]
 
 { #category : #emitting }
-OCTempVariable >> emitStore: methodBuilder [
+LocalVariable >> emitStore: methodBuilder [
 
 	methodBuilder storeTemp: name. 
 ]
 
 { #category : #emitting }
-OCTempVariable >> emitValue: methodBuilder [
+LocalVariable >> emitValue: methodBuilder [
 
 	methodBuilder pushTemp: name.
 ]
 
 { #category : #escaping }
-OCTempVariable >> escaping [
+LocalVariable >> escaping [
 	^escaping
 ]
 
 { #category : #escaping }
-OCTempVariable >> escaping: anObject [
+LocalVariable >> escaping: anObject [
 	escaping := anObject
 ]
 
 { #category : #comparing }
-OCTempVariable >> hash [
+LocalVariable >> hash [
 
 	^ name hash bitXor: (usage hash bitXor: scope hash).
 ]
 
 { #category : #accessing }
-OCTempVariable >> index [
+LocalVariable >> index [
 	^ index ifNil: [ 
 		"if the index is nil, we are in an AST after name analysis but before
 		IR generation. To fill the the index, we generate the ir."
@@ -84,127 +83,127 @@ OCTempVariable >> index [
 ]
 
 { #category : #accessing }
-OCTempVariable >> index: anObject [
+LocalVariable >> index: anObject [
 	index := anObject
 ]
 
 { #category : #initialization }
-OCTempVariable >> initialize [
+LocalVariable >> initialize [
 	super initialize.
 	escaping := false.
 ]
 
 { #category : #testing }
-OCTempVariable >> isCopying [
+LocalVariable >> isCopying [
 	^false
 ]
 
 { #category : #escaping }
-OCTempVariable >> isEscaping [
+LocalVariable >> isEscaping [
 	^escaping = #escapingRead or: [escaping = #escapingWrite]
 ]
 
 { #category : #escaping }
-OCTempVariable >> isEscapingRead [
+LocalVariable >> isEscapingRead [
 	^escaping = #escapingRead
 
 ]
 
 { #category : #escaping }
-OCTempVariable >> isEscapingWrite [
+LocalVariable >> isEscapingWrite [
 	^escaping = #escapingWrite
 
 ]
 
 { #category : #testing }
-OCTempVariable >> isLocal [
+LocalVariable >> isLocal [
+
+	^true
+]
+
+{ #category : #testing }
+LocalVariable >> isLocalVariable [
 
 	^true
 ]
 
 { #category : #'read/write usage' }
-OCTempVariable >> isRead [
+LocalVariable >> isRead [
 	^usage = #read
 
 ]
 
 { #category : #testing }
-OCTempVariable >> isReferenced [
+LocalVariable >> isReferenced [
 	^self isUnused not
 ]
 
 { #category : #testing }
-OCTempVariable >> isRemote [
+LocalVariable >> isRemote [
 	^false
 ]
 
 { #category : #'read/write usage' }
-OCTempVariable >> isRepeatedWrite [
+LocalVariable >> isRepeatedWrite [
 	^usage = #repeatedWrite
 
 ]
 
 { #category : #testing }
-OCTempVariable >> isStoringTempVector [
+LocalVariable >> isStoringTempVector [
 	"I am a temp that stores a temp vector. Those generated temps have a invalid name starting with 0"
 	^name first = $0.
 ]
 
 { #category : #testing }
-OCTempVariable >> isTemp [
-
-	^ true
-]
-
-{ #category : #testing }
-OCTempVariable >> isTempVectorTemp [
+LocalVariable >> isTempVectorTemp [
 	^false
 ]
 
 { #category : #'read/write usage' }
-OCTempVariable >> isUninitialized [
+LocalVariable >> isUninitialized [
 
 	^ self isWrite not
 ]
 
 { #category : #'read/write usage' }
-OCTempVariable >> isUnused [
+LocalVariable >> isUnused [
 	"when the var is never read or written, it is not used.
 	Note: we have a special #arg use which means arguments are never unused"
 	^ usage isNil
 ]
 
 { #category : #'read/write usage' }
-OCTempVariable >> isWrite [
+LocalVariable >> isWrite [
 	^ usage = #write or: [ self isRepeatedWrite ]
 ]
 
 { #category : #escaping }
-OCTempVariable >> markEscapingRead [
+LocalVariable >> markEscapingRead [
 	escaping = #escapingWrite ifFalse: [escaping := #escapingRead]
 ]
 
 { #category : #escaping }
-OCTempVariable >> markEscapingWrite [
+LocalVariable >> markEscapingWrite [
 	escaping := #escapingWrite.
 	self isRepeatedWrite ifFalse:[usage := #write]
 ]
 
 { #category : #'read/write usage' }
-OCTempVariable >> markRead [
+LocalVariable >> markRead [
 	"reading does not change a #write, nor an #arg"
 	usage ifNil: [usage := #read]
 ]
 
 { #category : #escaping }
-OCTempVariable >> markRepeatedWrite [
+LocalVariable >> markRepeatedWrite [
 	"same as write"
 	self markWrite.
 	usage := #repeatedWrite
 ]
 
 { #category : #escaping }
-OCTempVariable >> markWrite [
+LocalVariable >> markWrite [
 
 	"if an escaping var is wrote to later, it needs to be remote"
 	self isEscaping 
@@ -214,36 +213,36 @@ OCTempVariable >> markWrite [
 ]
 
 { #category : #queries }
-OCTempVariable >> method [
+LocalVariable >> method [
 	^scope node methodNode methodClass>>scope node methodNode selector
 ]
 
 { #category : #accessing }
-OCTempVariable >> originalVar [
+LocalVariable >> originalVar [
 	^ self
 ]
 
 { #category : #printing }
-OCTempVariable >> printOn: stream [
+LocalVariable >> printOn: stream [
 
 	stream nextPutAll: self name
 ]
 
 { #category : #debugging }
-OCTempVariable >> readFromContext: aContext scope: contextScope [
+LocalVariable >> readFromContext: aContext scope: contextScope [
 	| definitionContext |
 	definitionContext := contextScope lookupDefiningContextForVariable: self startingFrom: aContext.
 	^ self readFromLocalContext: definitionContext
 ]
 
 { #category : #debugging }
-OCTempVariable >> readFromLocalContext: aContext [
+LocalVariable >> readFromLocalContext: aContext [
 
 	^ aContext tempAt: self index
 ]
 
 { #category : #debugging }
-OCTempVariable >> readInContext: aContext [
+LocalVariable >> readInContext: aContext [
 
 	| contextScope |
 	contextScope := aContext astScope.
@@ -251,37 +250,37 @@ OCTempVariable >> readInContext: aContext [
 ]
 
 { #category : #accessing }
-OCTempVariable >> scope [
+LocalVariable >> scope [
 
 	^ scope
 ]
 
 { #category : #initializing }
-OCTempVariable >> scope: aLexicalScope [
+LocalVariable >> scope: aLexicalScope [
 
 	scope := aLexicalScope
 ]
 
 { #category : #accessing }
-OCTempVariable >> usage [
+LocalVariable >> usage [
 
 	^ usage
 ]
 
 { #category : #accessing }
-OCTempVariable >> usage: anObject [
+LocalVariable >> usage: anObject [
 
 	usage := anObject
 ]
 
 { #category : #queries }
-OCTempVariable >> usingMethods [
+LocalVariable >> usingMethods [
 	self isUnused ifTrue: [ ^#() ].
 	^{self method}
 ]
 
 { #category : #debugging }
-OCTempVariable >> write: aValue inContext: aContext [
+LocalVariable >> write: aValue inContext: aContext [
 
 	| contextScope |
 	contextScope := aContext astScope.
@@ -289,7 +288,7 @@ OCTempVariable >> write: aValue inContext: aContext [
 ]
 
 { #category : #debugging }
-OCTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
+LocalVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 
 	| definitionContext |
 	definitionContext := contextScope lookupDefiningContextForVariable: self startingFrom: aContext.
@@ -297,7 +296,7 @@ OCTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 ]
 
 { #category : #debugging }
-OCTempVariable >> writeFromLocalContext: aContext put: aValue [
+LocalVariable >> writeFromLocalContext: aContext put: aValue [
 
 	^ aContext tempAt: self index put: aValue
 ]

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -57,12 +57,12 @@ OCASTSemanticAnalyzer >> compilationContext: aCompilationContext [
 
 { #category : #variables }
 OCASTSemanticAnalyzer >> declareArgumentNode: aVariableNode [
-	^self declareVariableNode: aVariableNode as: OCArgumentVariable new
+	^self declareVariableNode: aVariableNode as: ArgumentVariable new
 ]
 
 { #category : #variables }
 OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode [
-	^self declareVariableNode: aVariableNode as: OCTempVariable new
+	^self declareVariableNode: aVariableNode as: TemporaryVariable new
 ]
 
 { #category : #variables }
@@ -87,7 +87,7 @@ OCASTSemanticAnalyzer >> lookupVariableForRead: aVariableNode [
 	var := scope lookupVar: aVariableNode name.
 	
 	var ifNil: [^var].
-	var isTemp ifTrue: [ self analyseEscapingRead: var].
+	var isLocalVariable ifTrue: [ self analyseEscapingRead: var].
 	^var
 ]
 
@@ -101,7 +101,7 @@ OCASTSemanticAnalyzer >> lookupVariableForWrite: aVariableNode [
 	var ifNil: [^var].
 	var isReservedVariable ifTrue: [ self storeIntoReservedVariable: aVariableNode ].
 	var isWritable ifFalse: [ self storeIntoReadOnlyVariable: aVariableNode ].
-	var isTemp ifTrue: [ self analyseEscapingWrite: var ].
+	var isLocalVariable ifTrue: [ self analyseEscapingWrite: var ].
 	^var
 ]
 

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -37,7 +37,7 @@ OCAbstractMethodScope >> addCopyingTempToAllScopesUpToDefTemp: aVar [
 
 { #category : #'temp vars' }
 OCAbstractMethodScope >> addTemp: name [
-	^self addTemp: OCTempVariable new withName: name
+	^self addTemp: TemporaryVariable new withName: name
 ]
 
 { #category : #'temp vars' }
@@ -278,7 +278,7 @@ OCAbstractMethodScope >> tempVectorName [
 
 { #category : #'temp vars - vector' }
 OCAbstractMethodScope >> tempVectorVar [
-	^ tempVectorVar ifNil: [ tempVectorVar := OCTempVariable new
+	^ tempVectorVar ifNil: [ tempVectorVar := TemporaryVariable new
 			name: self tempVectorName;
 			scope: self;
 			yourself]

--- a/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
@@ -5,7 +5,7 @@ Not: the temp vector is passed as a copying temp, too.
 "
 Class {
 	#name : #OCCopyingTempVariable,
-	#superclass : #OCTempVariable,
+	#superclass : #TemporaryVariable,
 	#instVars : [
 		'originalVar'
 	],

--- a/src/OpalCompiler-Core/OCVectorTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCVectorTempVariable.class.st
@@ -14,7 +14,7 @@ reading and writing thus is a multi step process:
 "
 Class {
 	#name : #OCVectorTempVariable,
-	#superclass : #OCTempVariable,
+	#superclass : #TemporaryVariable,
 	#instVars : [
 		'vectorName'
 	],

--- a/src/OpalCompiler-Core/RBVariableNode.extension.st
+++ b/src/OpalCompiler-Core/RBVariableNode.extension.st
@@ -18,7 +18,7 @@ RBVariableNode >> isArg [
 
 { #category : #'*opalcompiler-core' }
 RBVariableNode >> isArgOrTemp [
-	^self binding isTemp
+	^self binding isTemp or: [ self binding isArg ]
 ]
 
 { #category : #'*opalcompiler-core' }

--- a/src/OpalCompiler-Core/TemporaryVariable.class.st
+++ b/src/OpalCompiler-Core/TemporaryVariable.class.st
@@ -1,0 +1,20 @@
+"
+I model temp variables. With Closures, there are two kinds: Copying and those that are stored in a so called temp vector, a heap allocated array that itself is stored in a copying temp variable.
+"
+Class {
+	#name : #TemporaryVariable,
+	#superclass : #LocalVariable,
+	#category : #'OpalCompiler-Core-Semantics'
+}
+
+{ #category : #accessing }
+TemporaryVariable class >> semanticNodeClass [
+
+	^RBTemporaryNode 
+]
+
+{ #category : #testing }
+TemporaryVariable >> isTemp [
+
+	^ true
+]

--- a/src/Ring-Core/RGVariable.class.st
+++ b/src/Ring-Core/RGVariable.class.st
@@ -18,6 +18,11 @@ RGVariable >> definitionString [
 ]
 
 { #category : #testing }
+RGVariable >> isArg [
+	^false
+]
+
+{ #category : #testing }
 RGVariable >> isClassInstanceVariable [
 
 	^false
@@ -26,6 +31,11 @@ RGVariable >> isClassInstanceVariable [
 { #category : #testing }
 RGVariable >> isClassVariable [
 
+	^false
+]
+
+{ #category : #testing }
+RGVariable >> isLocalVariable [
 	^false
 ]
 

--- a/src/Shift-ClassBuilder/ShLayoutDefinition.class.st
+++ b/src/Shift-ClassBuilder/ShLayoutDefinition.class.st
@@ -59,7 +59,7 @@ ShLayoutDefinition >> copy: slotCollection ifUsedIn: aClass [
 ShLayoutDefinition >> copyClassSlotsIfNeeded: oldSlots [ 
 
 	classSlots ifNotNil: [ ^ self ].
-	classSlots := (oldSlots select: #isLocal thenCollect: [ :e | e copy index: nil; yourself ])
+	classSlots := (oldSlots select: #isDefinedByOwningClass thenCollect: [ :e | e copy index: nil; yourself ])
 ]
 
 { #category : #accessing }

--- a/src/Slot-Tests/TemporaryVariableTest.class.st
+++ b/src/Slot-Tests/TemporaryVariableTest.class.st
@@ -60,7 +60,7 @@ TemporaryVariableTest >> testReadTemporaryVariablesMethod [
 	| tempVar |
 	tempVar := thisContext temporaryVariableNamed: #tempVar.
 
-	self assert: (tempVar readInContext: thisContext) class equals: OCTempVariable
+	self assert: (tempVar readInContext: thisContext) class equals: TemporaryVariable
 ]
 
 { #category : #tests }
@@ -80,7 +80,7 @@ TemporaryVariableTest >> testTemporaryVariablesMethod [
 	method := OrderedCollection >> #do:.
 	self assert: method temporaryVariables first name equals: #aBlock.
 	self assert: (method hasTemporaryVariableNamed: #aBlock).
-	self assert: (method temporaryVariableNamed: #aBlock) class equals: OCArgumentVariable.
+	self assert: (method temporaryVariableNamed: #aBlock) class equals: ArgumentVariable.
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Instead of the old structure with OCTemVariable with a subclass OCArgumentVariable, this now tries to model the level of the name analysis the same as what we have on the AST:

-> We have an abstract class LocalVariable with subclasses ArgumentVariable and TemporaryVariable
-> #isTemp now answers false for ArgumentVariable

compieler tests are green... this will allow us to clean up the #isArg, isTemp and #isArgOrTemp on the ast level easier, I hope...

Needs a careful review