### PR TITLE
methodsInProtocol-not-extension

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -878,6 +878,13 @@ ClassDescription >> localSlots [
 	^ self slots select: [ :aSlot | aSlot isLocal ]
 ]
 
+{ #category : #organization }
+ClassDescription >> methodsInProtocol: aString [
+
+	^ (self organization listAtCategoryNamed: aString) 
+			collect: [ :each | (self compiledMethodAt: each) ]
+]
+
 { #category : #'accessing tags' }
 ClassDescription >> methodsTaggedWith: aSymbol [
 	"Any method could be tagged with multiple symbols for user purpose. 

--- a/src/Ring-Definitions-Core/ClassDescription.extension.st
+++ b/src/Ring-Definitions-Core/ClassDescription.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #ClassDescription }
-
-{ #category : #'*Ring-Definitions-Core' }
-ClassDescription >> methodsInProtocol: aString [
-
-	^ (self organization listAtCategoryNamed: aString) 
-			collect: [ :each | (self compiledMethodAt: each) ]
-]


### PR DESCRIPTION
methodsInProtocol:  is an extension method of Ring  but already used by other clients
-> should be a method of ClassDescription