### PR TITLE
Reflectivity-LiteralVariable-Cleanup

### DIFF
--- a/src/Calypso-SystemPlugins-Undeclared-Queries/ClyUndeclaredEnvironmentPlugin.class.st
+++ b/src/Calypso-SystemPlugins-Undeclared-Queries/ClyUndeclaredEnvironmentPlugin.class.st
@@ -16,6 +16,6 @@ ClyUndeclaredEnvironmentPlugin >> collectMethodGroupProviders [
 { #category : #'item decoration' }
 ClyUndeclaredEnvironmentPlugin >> decorateBrowserItem: anItem ofMethod: aMethod [
 
-	aMethod usesUndeclares ifTrue: [ 
+	aMethod usesUndeclareds ifTrue: [ 
 		anItem markWith: ClyUndeclaresUserTag]
 ]

--- a/src/Calypso-SystemPlugins-Undeclared-Queries/ClyUndeclaredMethodsQuery.class.st
+++ b/src/Calypso-SystemPlugins-Undeclared-Queries/ClyUndeclaredMethodsQuery.class.st
@@ -15,5 +15,5 @@ ClyUndeclaredMethodsQuery >> description [
 
 { #category : #testing }
 ClyUndeclaredMethodsQuery >> selectsMethod: aMethod [
-	^aMethod usesUndeclares
+	^aMethod usesUndeclareds
 ]

--- a/src/Calypso-SystemPlugins-Undeclared-Queries/CompiledMethod.extension.st
+++ b/src/Calypso-SystemPlugins-Undeclared-Queries/CompiledMethod.extension.st
@@ -1,20 +1,10 @@
 Extension { #name : #CompiledMethod }
 
 { #category : #'*Calypso-SystemPlugins-Undeclared-Queries' }
-CompiledMethod >> usesUndeclares [
-	"Pharo 6 is supported here where UndeclaredVariables was special exception 
-	instead of LiteralVariable which explicitly represent undeclared variables"
-	(UndeclaredVariable inheritsFrom: LiteralVariable) 
-		ifTrue: [ 
-			self literalsDo: [:each | 
+CompiledMethod >> usesUndeclareds [
+	self literalsDo: [:each | 
 				each class == UndeclaredVariable ifTrue: [^true].
 				(each isBlock not and: [ 
-					each value isBehavior and: [ each value isObsolete ]]) ifTrue: [^true]]]
-		ifFalse: [
-			"To support Pharo 6"
-			self literalsDo: [:each | 
-				(each class == Association and: [
-					each key notNil and: [(each value isKindOf: Slot) not]]) ifTrue: [^true]]].
-	
+					each value isBehavior and: [ each value isObsolete ]]) ifTrue: [^true]].
 	^false
 ]

--- a/src/Reflectivity-Tests/LinkInstallerTest.class.st
+++ b/src/Reflectivity-Tests/LinkInstallerTest.class.st
@@ -106,8 +106,6 @@ LinkInstallerTest >> testLinkOnClassVar [
 { #category : #permalinks }
 LinkInstallerTest >> testLinkOnClassVarForObject [
 	| link obj |
-	self skip.
-	self flag: 'must be fixed'.
 	link := MetaLink new.
 	obj := ReflectivityExamples2 new.
 	

--- a/src/Reflectivity-Tests/MetaLinkObjectAPITest.class.st
+++ b/src/Reflectivity-Tests/MetaLinkObjectAPITest.class.st
@@ -139,9 +139,6 @@ MetaLinkObjectAPITest >> testLinkObjectToAST [
 { #category : #'object - api' }
 MetaLinkObjectAPITest >> testLinkObjectToClassVarName [
 	| link instance |
-	self skip.
-	self flag: 'must be fixed'.
-
 	link := self link.
 
 	instance := ReflectivityExamples2 new.

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -307,8 +307,7 @@ RFASTTranslator >> visitVariableNode: aVariableNode [
 
 { #category : #reflectivity }
 RFASTTranslator >> visitVariableValue: aVariable [
-	self flag: #pharoTodo. "needs to be extendend to other kinds of variables and cleaned"
-	((aVariable isKindOf: LiteralVariable) or: [ (aVariable isKindOf: Slot) ]) ifTrue: [ self emitPreamble: aVariable. self emitMetaLinkBefore: aVariable. ].
+	(aVariable isKindOf: Variable) ifTrue: [ self emitPreamble: aVariable. self emitMetaLinkBefore: aVariable. ].
 	aVariable emitValue: methodBuilder.
-	((aVariable isKindOf: LiteralVariable) or: [ (aVariable isKindOf: Slot) ]) ifTrue: [self emitMetaLinkAfterNoEnsure: aVariable].
+	(aVariable isKindOf: Variable) ifTrue: [self emitMetaLinkAfterNoEnsure: aVariable].
 ]

--- a/src/Reflectivity/RFClassReification.class.st
+++ b/src/Reflectivity/RFClassReification.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #'plugin interface' }
 RFClassReification class >> entities [
-	^{RBProgramNode. LiteralVariable. Slot}
+	^{RBProgramNode. Variable}
 ]
 
 { #category : #'plugin interface' }

--- a/src/Reflectivity/RFEntityReification.class.st
+++ b/src/Reflectivity/RFEntityReification.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #'plugin interface' }
 RFEntityReification class >> entities [
-	^{RBProgramNode. LiteralVariable. Slot}.
+	^{RBProgramNode. Variable}.
 ]
 
 { #category : #'plugin interface' }

--- a/src/Reflectivity/RFLinkReification.class.st
+++ b/src/Reflectivity/RFLinkReification.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #'plugin interface' }
 RFLinkReification class >> entities [
-	^{RBProgramNode . LiteralVariable . Slot}
+	^{RBProgramNode . Variable}
 ]
 
 { #category : #'plugin interface' }

--- a/src/Reflectivity/RFNameReification.class.st
+++ b/src/Reflectivity/RFNameReification.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #'plugin interface' }
 RFNameReification class >> entities [
-	^{RBVariableNode. RBAssignmentNode. LiteralVariable. Slot}.
+	^{RBVariableNode. RBAssignmentNode. Variable}.
 ]
 
 { #category : #'plugin interface' }

--- a/src/Reflectivity/RFObjectReification.class.st
+++ b/src/Reflectivity/RFObjectReification.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #'plugin interface' }
 RFObjectReification class >> entities [
-	^{RBProgramNode. LiteralVariable. Slot}
+	^{RBProgramNode. Variable}
 ]
 
 { #category : #'plugin interface' }

--- a/src/Reflectivity/RFThisContextReification.class.st
+++ b/src/Reflectivity/RFThisContextReification.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #'plugin interface' }
 RFThisContextReification class >> entities [
-	^{RBProgramNode . LiteralVariable . Slot}
+	^{RBProgramNode . Variable}
 ]
 
 { #category : #'plugin interface' }

--- a/src/Reflectivity/RFValueReification.class.st
+++ b/src/Reflectivity/RFValueReification.class.st
@@ -19,7 +19,7 @@ Class {
 
 { #category : #'plugin interface' }
 RFValueReification class >> entities [
-	^{RBValueNode . RBReturnNode. RBMethodNode . LiteralVariable . Slot} 
+	^{RBValueNode . RBReturnNode. RBMethodNode . Variable} 
 ]
 
 { #category : #'plugin interface' }

--- a/src/Reflectivity/RFVariableReification.class.st
+++ b/src/Reflectivity/RFVariableReification.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #'plugin interface' }
 RFVariableReification class >> entities [
-	^{RBVariableNode. LiteralVariable . Slot}
+	^{RBVariableNode. Variable}
 ]
 
 { #category : #'plugin interface' }


### PR DESCRIPTION
A small cleanup related to references to LiteralVariable, mostly touching MetaLinks (Reflectivity)

- in #entities we can now use Variable
- simplify #visitVariableValue:
- #testLinkOnClassVarForObject and testLinkObjectToClassVarName are now green! (they where on self skip)

Calypso related cleanup: 
- #usesUndeclares -> usesUndeclareds (private method, even though a canditate for an API method)
- simplify