### PR TITLE
Reflectivity-Cleanups-2

### DIFF
--- a/src/GeneralRules/ReGlobalVariablesUsageRule.class.st
+++ b/src/GeneralRules/ReGlobalVariablesUsageRule.class.st
@@ -25,7 +25,7 @@ ReGlobalVariablesUsageRule >> check: aMethod forCritiquesDo: aCriticBlock [
 					(self isKnownGlobal: node name) not and: [
 						(Smalltalk globals
 							at: node name
-							ifAbsent: [ Object ]) isClass not ] ] ] ]
+							ifAbsent: [ Object ]) isClassOrTrait not ] ] ] ]
 	
 		thenDo: [ :node |
 			aCriticBlock cull: (self

--- a/src/GeneralRules/ReGlobalVariablesUsageRule.class.st
+++ b/src/GeneralRules/ReGlobalVariablesUsageRule.class.st
@@ -16,17 +16,12 @@ ReGlobalVariablesUsageRule class >> checksMethod [
 
 { #category : #running }
 ReGlobalVariablesUsageRule >> check: aMethod forCritiquesDo: aCriticBlock [
-	"Beware that ClassVariables respond true to #isGlobal. 
-	 The trick with 'ifAbsent:[Object] is basically a way not select ClassVariables (or Pools)"
 	aMethod ast allChildren
 		select: [ :node |
 			node isVariable and: [ 
-				node isGlobal and: [
+				node variable isGlobalVariable and: [
 					(self isKnownGlobal: node name) not and: [
-						(Smalltalk globals
-							at: node name
-							ifAbsent: [ Object ]) isClassOrTrait not ] ] ] ]
-	
+						(Smalltalk globals hasClassOrTraitNamed: node name) not ] ] ] ]
 		thenDo: [ :node |
 			aCriticBlock cull: (self
 				createTrivialCritiqueOn: aMethod

--- a/src/Reflectivity/LiteralVariable.extension.st
+++ b/src/Reflectivity/LiteralVariable.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #LiteralVariable }
-
-{ #category : #'*Reflectivity' }
-LiteralVariable >> isCascade [
-	self flag: #hack.
-	^false
-]

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -307,7 +307,8 @@ RFASTTranslator >> visitVariableNode: aVariableNode [
 
 { #category : #reflectivity }
 RFASTTranslator >> visitVariableValue: aVariable [
-	(aVariable isKindOf: Variable) ifTrue: [ self emitPreamble: aVariable. self emitMetaLinkBefore: aVariable. ].
+	self emitPreamble: aVariable. 
+	self emitMetaLinkBefore: aVariable.
 	aVariable emitValue: methodBuilder.
-	(aVariable isKindOf: Variable) ifTrue: [self emitMetaLinkAfterNoEnsure: aVariable].
+	self emitMetaLinkAfterNoEnsure: aVariable
 ]

--- a/src/Ring-Tests-Core/RGReadOnlyImageBackendTest.class.st
+++ b/src/Ring-Tests-Core/RGReadOnlyImageBackendTest.class.st
@@ -222,10 +222,8 @@ RGReadOnlyImageBackendTest >> testMethod [
 
 	method := Point >> #x asRingMinimalDefinitionIn: env.
 
-	method author notEmpty.
-	method time > DateAndTime new.
-	method time <= DateAndTime now.
-
+	self assert: method author notEmpty.
+	self assert: (method time <= DateAndTime now).
 	self assert: method selector equals: #x.
 	self assert: (method package isRGObject and: [ method package isPackage ]).
 	self assert: method package name equals: 'Kernel'.

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -265,6 +265,16 @@ SystemDictionary >> hasClassNamed: aString [
 	^ false
 ]
 
+{ #category : #'classes and traits' }
+SystemDictionary >> hasClassOrTraitNamed: aString [
+	"Answer whether there is a class of the given name, but don't intern aString if it's not alrady interned."
+
+	Symbol 
+		hasInterned: aString 
+		ifTrue:  [:aSymbol | ^ (self at: aSymbol ifAbsent: [nil]) isClassOrTrait].
+	^ false
+]
+
 { #category : #'system attributes' }
 SystemDictionary >> maxIdentityHash [
 	"Answer the maximum identityHash value supported by the VM."


### PR DESCRIPTION
Some cleanups, most related to Reflectivity but two others, too:

- LiteralVariable>>#isCascade is not needed
- remove isKindOf: from visitVariableValue:
- Ring: testMethod exectuted code that was not part of assert:
- ReGlobalVariablesUsageRule: us #isClassOrTrait, else direct references to Traits are false positives