### PR TITLE
Update download_vm.sh: Use Pharo9 VM

### DIFF
--- a/bootstrap/scripts/download_vm.sh
+++ b/bootstrap/scripts/download_vm.sh
@@ -9,6 +9,6 @@ mkdir vm
 cd vm
 echo `pwd`
 
-../bootstrap/scripts/getPharoVM.sh 70 vm $BOOTSTRAP_ARCH
+../bootstrap/scripts/getPharoVM.sh 90 vm $BOOTSTRAP_ARCH
 
 cd ..


### PR DESCRIPTION
We are downloading the Pharo 7 vm. Let's try to download the Pharo9 VM. This then will use the pharo 9 vm to run all tests on the CI