### PR TITLE
Update runTests.sh to use Pharo 9 vm

### DIFF
--- a/bootstrap/scripts/runTests.sh
+++ b/bootstrap/scripts/runTests.sh
@@ -20,7 +20,7 @@ find ${CACHE}
 #
 TEST_NAME_PREFIX=$(find ${CACHE} -name "Pharo*.zip" | head -n 1 | cut -d'/' -f 2 | cut -d'-' -f 1-2)
 #TEST_VM_VERSION=$(echo "${TEST_NAME_PREFIX}" | cut -d'-' -f 1| cut -c 6- | cut -d'.' -f 1-2 | sed 's/\.//')
-TEST_VM_VERSION="70"
+TEST_VM_VERSION="90"
 
 ${BOOTSTRAP_REPOSITORY:-.}/bootstrap/scripts/getPharoVM.sh ${TEST_VM_VERSION} vm ${1}
 


### PR DESCRIPTION
I change it to hard code 90, it maybe better to enable the automatic parsing