### PR TITLE
6092-Fleaky-Reflectivity-test

### DIFF
--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -457,8 +457,8 @@ RBMethodNode >> matchPragmas: matchNodes against: pragmaNodes inContext: aDictio
 { #category : #'accessing compiled method' }
 RBMethodNode >> method [
 	"return the method that I have been compiled for"
-	self compilationContext ifNil: [ ^nil ].
-	^self compilationContext getClass >> self selector
+	^self compilationContext ifNotNil: [ :ccntx |
+		 ccntx compiledMethod ifNil: [ccntx getClass >> self selector]]
 ]
 
 { #category : #'accessing compiled method' }


### PR DESCRIPTION
it was failing in RBMethodNode #method. Now that we store the method in the CompilationContext, we can make that method use that
first, relying less on re-lookup. fixes #6092