### PR TITLE
5193-Running-Executable-Comments-Checker-on-200-000-Classes-images-should-work-faster

### DIFF
--- a/src/DrTests-CommentsToTests/DTCommentTestConfiguration.class.st
+++ b/src/DrTests-CommentsToTests/DTCommentTestConfiguration.class.st
@@ -9,17 +9,14 @@ Class {
 
 { #category : #converting }
 DTCommentTestConfiguration >> asTestSuite [
-	| suite |
+	| suite methods |
 	suite := TestSuite new.
 	suite := TestSuite named: 'Test Generated From Comments'.
-	self items
-		reject: [ :each | each isAbstract ]
-		thenDo: [ :c | 
-			c methods
-				do: [ :m | 
-					(m methodClass compiledMethodAt: m selector) comments
-						do: [ :com | 
-							(com includesSubstring: '>>>')
-								ifTrue: [ suite addTest: (CommentTestCase comment: com class: c selector: m selector) ] ] ] ].
+	methods := (self items reject: [ :each | each isAbstract ]) flatCollect: [ :each | each methods ].
+	methods := methods select: [:each | each sourceCode includesSubstring: '>>>' ].
+	methods do: [ :m | m comments do: [ :com | 
+					(com includesSubstring: '>>>')
+						ifTrue: [ suite addTest: 
+							(CommentTestCase comment: com class: m methodClass selector: m selector) ] ] ].
 	^ suite
 ]

--- a/src/DrTests-CommentsToTests/DTCommentToTest.class.st
+++ b/src/DrTests-CommentsToTests/DTCommentToTest.class.st
@@ -43,8 +43,8 @@ DTCommentToTest >> itemsToBeAnalysedFor: packagesSelected [
 				select: [ :c | 
 					c methods
 						anySatisfy: [ :m | 
-							(m methodClass compiledMethodAt: m selector) comments
-								anySatisfy: [ :com | com includesSubstring: '>>>' ] ] ] ]
+							( m sourceCode includesSubstring: '>>>') and: [
+								m comments anySatisfy: [ :com | com includesSubstring: '>>>' ] ] ] ]]
 ]
 
 { #category : #api }


### PR DESCRIPTION
This speeds up both selecting packages and then running the tests by pre-checking of the sourceCode of the method contains a string >>>

This avoids to call #comments on the method which is  very slow due to creating the AST.

fixes #5193 at least to some extent: It is now quite usable for the image, which means it should be *much* faster for a larger image.