### PR TITLE
SmallClean-isVariableBinding

### DIFF
--- a/src/Collections-Support/Association.class.st
+++ b/src/Collections-Support/Association.class.st
@@ -40,6 +40,12 @@ Association >> isSelfEvaluating [
 	^ self class == Association and: [self key isSelfEvaluating and: [self value isSelfEvaluating]]
 ]
 
+{ #category : #'variables-toclean' }
+Association >> isVariableBinding [
+	"Can be removed as soon as all bindings are instances of LiteralVariable"
+	^true
+]
+
 { #category : #accessing }
 Association >> key: aKey value: anObject [ 
 	"Store the arguments as the variables of the receiver."
@@ -56,10 +62,11 @@ Association >> literalEqual: otherLiteral [
 	^self == otherLiteral
 ]
 
-{ #category : #testing }
+{ #category : #'variables-toclean' }
 Association >> needsFullDefinition [
 	"Implemented here so we can use simple Associations as Bindings instead of LiteralVariable
 	subclasses"
+	"Can be removed as soon as all bindings are instances of LiteralVariable"
 	^false
 ]
 

--- a/src/Collections-Support/LookupKey.class.st
+++ b/src/Collections-Support/LookupKey.class.st
@@ -38,12 +38,6 @@ LookupKey >> hash [
 	^key hash
 ]
 
-{ #category : #testing }
-LookupKey >> isVariableBinding [
-	"Return true if I represent a literal variable binding"
-	^true
-]
-
 { #category : #accessing }
 LookupKey >> key [
 	"Answer the lookup key of the receiver."

--- a/src/Collections-Support/WeakKeyAssociation.class.st
+++ b/src/Collections-Support/WeakKeyAssociation.class.st
@@ -66,12 +66,6 @@ WeakKeyAssociation >> hash [
 	^self key hash
 ]
 
-{ #category : #testing }
-WeakKeyAssociation >> isVariableBinding [
-	"Return true if I represent a literal variable binding"
-	^true
-]
-
 { #category : #accessing }
 WeakKeyAssociation >> key [
 	"Answer the lookup key of the receiver."

--- a/src/Kernel/ClassVariable.class.st
+++ b/src/Kernel/ClassVariable.class.st
@@ -71,6 +71,13 @@ ClassVariable >> isReferenced [
  		anySatisfy: [ :behavior | behavior hasSelectorReferringTo: self . behavior class hasSelectorReferringTo: self ]
 ]
 
+{ #category : #testing }
+ClassVariable >> needsFullDefinition [
+	"only ClassVariable can use a simplified definition"
+
+	^ self class ~= ClassVariable
+]
+
 { #category : #accessing }
 ClassVariable >> owningClass [
 	^ owningClass

--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -154,6 +154,7 @@ LiteralVariable >> isSelfEvaluating [
 
 { #category : #testing }
 LiteralVariable >> isVariableBinding [
+	"Maybe we should deprecate this and use isLiteralVariable instead"
 	^true
 ]
 
@@ -199,13 +200,6 @@ LiteralVariable >> literalEqual: otherLiteral [
 { #category : #accessing }
 LiteralVariable >> name: aString [ 
 	self key: aString asSymbol
-]
-
-{ #category : #testing }
-LiteralVariable >> needsFullDefinition [
-	"only ClassVariable can use a simplified definition"
-
-	^ self class ~= ClassVariable
 ]
 
 { #category : #printing }

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -256,12 +256,6 @@ Slot >> named: aSymbol [
 	self name: aSymbol
 ]
 
-{ #category : #testing }
-Slot >> needsFullDefinition [
-	"I am more than just a backward compatible ivar slot, I need a full definition "
-	^true
-]
-
 { #category : #accessing }
 Slot >> owningClass [
 	"the class that the slot is installed in"

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -198,6 +198,12 @@ Variable >> name: aSymbol [
 	name := aSymbol
 ]
 
+{ #category : #testing }
+Variable >> needsFullDefinition [
+	"all but InstanceVariableSlot and ClassVariable need to print the full definition"
+	^true
+]
+
 { #category : #properties }
 Variable >> properties [
 	^ Properties at: self ifAbsent: nil


### PR DESCRIPTION
Small cleanup 
- #isVariableBinding should be only defined on Association besides LiteralVariable,
- needsFullDefinition: implement in Variable, override in LiteralVariable and ivar slot
- needsFullDefinition in Asssociation with comment