### PR TITLE
Variables-isGlobal-Cleanup

### DIFF
--- a/src/Kernel/GlobalVariable.class.st
+++ b/src/Kernel/GlobalVariable.class.st
@@ -27,6 +27,12 @@ GlobalVariable >> emitValue: methodBuilder [
 ]
 
 { #category : #testing }
+GlobalVariable >> isGlobal [
+
+	^ true
+]
+
+{ #category : #testing }
 GlobalVariable >> isGlobalVariable [
 	^true
 ]

--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -114,12 +114,6 @@ LiteralVariable >> installingIn: aClass [
 ]
 
 { #category : #testing }
-LiteralVariable >> isGlobal [
-
-	^ true
-]
-
-{ #category : #testing }
 LiteralVariable >> isGlobalClassNameBinding [
 	^ (self value isClass or: [ self value isTrait ])
 		and: [ name == self value name ]

--- a/src/Kernel/UndeclaredVariable.class.st
+++ b/src/Kernel/UndeclaredVariable.class.st
@@ -46,11 +46,6 @@ UndeclaredVariable >> emitValue: methodBuilder [
 ]
 
 { #category : #testing }
-UndeclaredVariable >> isGlobal [
-	^false
-]
-
-{ #category : #testing }
 UndeclaredVariable >> isReferenced [
  	"A Undeclared could be referenced from any method"
  	^Smalltalk globals allBehaviors

--- a/src/OpalCompiler-Core/RBVariableNode.extension.st
+++ b/src/OpalCompiler-Core/RBVariableNode.extension.st
@@ -29,7 +29,7 @@ RBVariableNode >> isClean [
 { #category : #'*opalcompiler-core' }
 RBVariableNode >> isGlobal [
 	"the semantics here is bad: all Literal Variables are Globals on the AST Level"
-	^self binding isLiteralVariable
+	^variable isLiteralVariable and: [ variable isUndeclared not]
 ]
 
 { #category : #'*opalcompiler-core' }

--- a/src/OpalCompiler-Core/RBVariableNode.extension.st
+++ b/src/OpalCompiler-Core/RBVariableNode.extension.st
@@ -28,7 +28,8 @@ RBVariableNode >> isClean [
 
 { #category : #'*opalcompiler-core' }
 RBVariableNode >> isGlobal [
-	^self binding isGlobal
+	"the semantics here is bad: all Literal Variables are Globals on the AST Level"
+	^self binding isLiteralVariable
 ]
 
 { #category : #'*opalcompiler-core' }

--- a/src/Reflectivity/RFOperationReification.class.st
+++ b/src/Reflectivity/RFOperationReification.class.st
@@ -36,7 +36,7 @@ RFOperationReification >> genForRBAssignmentNode [
 			object: self;
 			variableName: #{1}.' format: {entity variable name})].
 
-	entity variable isGlobal ifTrue: [ | ast |	
+	entity variable variable isLiteralVariable ifTrue: [ | ast |	
 		ast := RBParser parseExpression: ('RFGlobalWrite new
 			assignedValue: RFNewValueReificationVar;
 			variable: #toReplace.').
@@ -109,7 +109,7 @@ RFOperationReification >> genForRBVariableNode [
 			context: thisContext;
 			variableName: #{1}.' format: {entity name})].
 	
-	entity isGlobal ifTrue: [ | ast |	
+	entity variable isLiteralVariable ifTrue: [ | ast |	
 			ast := RBParser parseExpression: 'RFGlobalRead new
 				variable: #toReplace'.
 			ast arguments: {(RFLiteralVariableNode value: entity binding)}.

--- a/src/Reflectivity/RFValueReification.class.st
+++ b/src/Reflectivity/RFValueReification.class.st
@@ -91,8 +91,8 @@ RFValueReification >> genForRBReturnNode [
 
 { #category : #generate }
 RFValueReification >> genForRBVariableNode [
-	entity binding
-		ifNotNil: [ entity isGlobal
+	entity variable
+		ifNotNil: [ entity variable isLiteralVariable
 				ifTrue: [ ^ RFLiteralVariableNode value: entity binding value ] ].
 	^ RBVariableNode named: entity name
 ]

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1024,7 +1024,7 @@ SHRBTextStyler >> resolveStyleFor: aVariableNode [
 	aVariableNode binding ifNil: [^#default].
 	aVariableNode isArg ifTrue: [ ^#methodArg].
 	aVariableNode isTemp ifTrue: [ ^#tempVar].
-	aVariableNode isGlobal ifTrue: [ ^#globalVar].
+	aVariableNode binding isGlobal ifTrue: [ ^#globalVar].
 	aVariableNode isInstance ifTrue: [ ^#instVar]. 
 	
 	(self class formatIncompleteIdentifiers and: [ aVariableNode hasIncompleteIdentifier ]) 

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1024,7 +1024,7 @@ SHRBTextStyler >> resolveStyleFor: aVariableNode [
 	aVariableNode binding ifNil: [^#default].
 	aVariableNode isArg ifTrue: [ ^#methodArg].
 	aVariableNode isTemp ifTrue: [ ^#tempVar].
-	aVariableNode binding isGlobal ifTrue: [ ^#globalVar].
+	(aVariableNode isGlobal and: [ aVariableNode isUndeclared not]) ifTrue: [ ^#globalVar].
 	aVariableNode isInstance ifTrue: [ ^#instVar]. 
 	
 	(self class formatIncompleteIdentifiers and: [ aVariableNode hasIncompleteIdentifier ]) 

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1024,7 +1024,7 @@ SHRBTextStyler >> resolveStyleFor: aVariableNode [
 	aVariableNode binding ifNil: [^#default].
 	aVariableNode isArg ifTrue: [ ^#methodArg].
 	aVariableNode isTemp ifTrue: [ ^#tempVar].
-	(aVariableNode isGlobal and: [ aVariableNode isUndeclared not]) ifTrue: [ ^#globalVar].
+	aVariableNode isGlobal ifTrue: [ ^#globalVar].
 	aVariableNode isInstance ifTrue: [ ^#instVar]. 
 	
 	(self class formatIncompleteIdentifiers and: [ aVariableNode hasIncompleteIdentifier ]) 


### PR DESCRIPTION
On the level of both the AST and the Variables, #isGlobal returns true for all Literal Variables. That is not good, e.g.:

(SmalltalkImage classVariableNamed: #CompilerClass) isGlobal

- This PR checks and fixes all senders that send #isGlobal to a Variable 
- Then it changes #isGlobal to be in sync with isGlobalVariable 

The AST level is not touched! There #isGlobal still returns true for class var nodes (future work)
Another future work is to decide if we merge isGlobalVariable and isGlobal on the level of the Variables and just have one of the two.