### PR TITLE
FFI-use-new-propertyAPI

### DIFF
--- a/src/UnifiedFFI/CompiledMethod.extension.st
+++ b/src/UnifiedFFI/CompiledMethod.extension.st
@@ -5,11 +5,10 @@ CompiledMethod >> ffiArgumentNames [
 	"Answer the method's argument names. We using a separate method, 
 	to get arg names not from source code directly, but from method properties, collected at
 	compile time. Useful, when there is no source code available (for some reason)"
-	
-	^ self 
-		propertyValueAt: #ffiArgumentNames 
-		ifAbsent: [ self  propertyValueAt: #ffiArgumentNames put: self argumentNames ]
 
+	^ self
+		  propertyAt: #ffiArgumentNames
+		  ifAbsent: [ self propertyAt: #ffiArgumentNames put: self argumentNames ]
 ]
 
 { #category : #'*UnifiedFFI' }

--- a/src/UnifiedFFI/FFICalloutAPI.class.st
+++ b/src/UnifiedFFI/FFICalloutAPI.class.st
@@ -110,9 +110,9 @@ FFICalloutAPI >> function: functionSignature library: moduleNameOrLibrary [
 		selector: sender selector;
 		methodClass: sender methodClass.	"Replace with generated ffi method, but save old one for future use"
 	ffiMethod
-		propertyValueAt: #ffiNonCompiledMethod
+		propertyAt: #ffiNonCompiledMethod
 		put: (sender methodClass methodDict at: sender selector).	"For senders search, one need to keep the selector in the properties"
-	ffiMethod propertyValueAt: #ffiMethodSelector put: ffiMethodSelector.
+	ffiMethod propertyAt: #ffiMethodSelector put: ffiMethodSelector.
 	sender methodClass methodDict at: sender selector put: ffiMethod.	"Register current method as compiled for ffi"
 	FFIMethodRegistry uniqueInstance registerMethod: ffiMethod.	"Resend"
 	sender

--- a/src/UnifiedFFI/FFIMethodRegistry.class.st
+++ b/src/UnifiedFFI/FFIMethodRegistry.class.st
@@ -89,7 +89,7 @@ FFIMethodRegistry >> removeMethod: aMethod [
 
 	aMethod methodClass methodDict
 		at: aMethod selector
-		put: (aMethod propertyValueAt: #ffiNonCompiledMethod)
+		put: (aMethod propertyAt: #ffiNonCompiledMethod)
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
FFI was using still the old API (we standardized the API over all propery implementations)