### PR TITLE
FixFailingDocComments

### DIFF
--- a/src/Collections-Strings/ByteString.class.st
+++ b/src/Collections-Strings/ByteString.class.st
@@ -176,10 +176,10 @@ ByteString >> beginsWith: prefix [
 	Otherwise, if self is wide, then super outperforms,
 	Otherwise, if prefix is wide, primitive is not correct"
 	
-	"'pharo' beginsWith: '' >>> false"
-	"'pharo' beginsWith: 'pharo-project' >>> false"
-	"'pharo' beginsWith: 'phuro' >>> false"
-	"'pharo' beginsWith: 'pha' >>> true"
+	"('pharo' beginsWith: '') >>> false"
+	"('pharo' beginsWith: 'pharo-project') >>> false"
+	"('pharo' beginsWith: 'phuro') >>> false"
+	"('pharo' beginsWith: 'pha') >>> true"
 	
 	prefix class isBytes ifFalse: [^super beginsWith: prefix].
 	

--- a/src/Collections-Strings/ByteSymbol.class.st
+++ b/src/Collections-Strings/ByteSymbol.class.st
@@ -62,9 +62,9 @@ ByteSymbol >> beginsWith: prefix [
 	Otherwise, if self is wide, then super outperforms,
 	Otherwise, if prefix is wide, primitive is not correct"
 
-	"#pharo beginsWith: #pharoProject >>> false"
-	"#pharo beginsWith: #phuro >>> false"
-	"#pharo beginsWith: #pha >>> true"
+	"(#pharo beginsWith: #pharoProject) >>> false"
+	"(#pharo beginsWith: #phuro) >>> false"
+	"(#pharo beginsWith: #pha) >>> true"
 	
 	prefix class isBytes ifFalse: [^super beginsWith: prefix].
 	

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2058,7 +2058,7 @@ String >> match: text [
 	"('foo*baz' match: 'foo23bazo') >>> false"
 	"('foo' match: 'Foo') >>> true"
 	"('foo*baz*zort' match: 'foobazort') >>> false"
-	"('foo*baz*zort' match: 'foobazzort') >>> false"
+	"('foo*baz*zort' match: 'foobazzort') >>> true"
 	"('*foo#zort' match: 'afoo3zortthenfoo3zort') >>> true"
 	"('*foo*zort' match: 'afoodezortorfoo3zort') >>> true"
 

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -2140,17 +2140,11 @@ Object >> ~~> aValueLinkOrNil [
 
 	"Code of ValueLink>>#nextLink: and ValueLink>>#value: are inline here for speed."
 
-	"
-	1 ~~> nil
-	>>> ValueLink new value: 1; yourself
+	"(1 ~~> nil) = ValueLink new value: 1"
+	"(1 ~~> 'one') value >>> 1"
+	"(1 ~~> nil) nextLink >>> nil"
 
-	(1 ~~> 'one') value
-	>>> 1
-
-	(1 ~~> nil) nextLink
-	>>> nil
-	
-	Note that `value` can be ANY object; on the other hand, `nextLink` should be either another 
+	"Note that `value` can be ANY object; on the other hand, `nextLink` should be either another 
 	ValueLink object or nil."
 
 	^ ValueLink basicNew

--- a/src/PharoDocComment/RBMethodNode.extension.st
+++ b/src/PharoDocComment/RBMethodNode.extension.st
@@ -2,7 +2,8 @@ Extension { #name : #RBMethodNode }
 
 { #category : #'*PharoDocComment' }
 RBMethodNode >> pharoDocCommentNodes [
-	"Return a collection of pharo comment nodes: expressions following the pattern expr1 >>> expr2"
+	"Return a collection of pharo comment nodes: expressions following the pattern"
+	"true >>> true"
 	
 	^ self comments flatCollect: [:each | each pharoDocCommentNodes]
 ]


### PR DESCRIPTION
When checking all exampkes (doc comments) embedded in methods using DrTest, we see some errros and failures.

- one was wrong
- most were missing ()
- one case was giving an exampel where the expressions are equal, not identical
- #pharoDocCommentNodes comment was parsed as a doc comment