### PR TITLE
6811-Block-arguments-and-local-should-be-used-to-solve-unresolved-variables

### DIFF
--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -210,13 +210,12 @@ OCUndeclaredVariableWarning >> possibleVariablesFor: proposedVariable [
 	| results class |
 	class := node methodNode methodClass .
 	
-	results := proposedVariable correctAgainst: node temporaryVariables
+	results := proposedVariable correctAgainst: node methodOrBlockNode scope allTempNames 
 								continuedFrom: nil.
 	proposedVariable first canBeGlobalVarInitial ifTrue:
 		[ results := class possibleVariablesFor: proposedVariable
 						continuedFrom: results ].
-	^ proposedVariable correctAgainst: nil continuedFrom: results.
-
+	^ proposedVariable correctAgainst: nil continuedFrom: results
 ]
 
 { #category : #correcting }


### PR DESCRIPTION
when suggesting a temp, use all possible args and temps accessible in  the block, not just the temps of the method

fixes #6811