### PR TITLE
AST-deprecate-methodComments

### DIFF
--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -473,14 +473,6 @@ RBMethodNode >> methodClass: aClass [
 ]
 
 { #category : #accessing }
-RBMethodNode >> methodComments [
-	| methodComments |
-	methodComments := OrderedCollection withAll: self comments.
-	arguments do: [:each | methodComments addAll: each comments].
-	^methodComments asSortedCollection: [:a :b | a start < b start]
-]
-
-{ #category : #accessing }
 RBMethodNode >> methodNode [
 	^self
 ]

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -656,11 +656,6 @@ RBProgramNode >> matchList: matchNodes index: matchIndex against: programNodes i
 ]
 
 { #category : #accessing }
-RBProgramNode >> methodComments [
-	^self comments
-]
-
-{ #category : #accessing }
 RBProgramNode >> methodNode [
 	^parent ifNotNil: [parent methodNode]
 ]

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -358,16 +358,6 @@ RBSequenceNode >> match: aNode inContext: aDictionary [
 					inContext: aDictionary]
 ]
 
-{ #category : #accessing }
-RBSequenceNode >> methodComments [
-	| methodComments |
-	methodComments := OrderedCollection withAll: self comments.
-	temporaries do: [:each | methodComments addAll: each comments].
-	(parent notNil and: [parent isBlock]) 
-		ifTrue: [parent arguments do: [:each | methodComments addAll: each comments]].
-	^methodComments asSortedCollection: [:a :b | a start < b start]
-]
-
 { #category : #'accessing-token' }
 RBSequenceNode >> periods [
 	^ periods

--- a/src/Deprecated90/RBMethodNode.extension.st
+++ b/src/Deprecated90/RBMethodNode.extension.st
@@ -1,6 +1,15 @@
 Extension { #name : #RBMethodNode }
 
 { #category : #'*Deprecated90' }
+RBMethodNode >> methodComments [
+	| methodComments |
+	self deprecated: 'no users, will be removed in Pharo10'.
+	methodComments := OrderedCollection withAll: self comments.
+	arguments do: [:each | methodComments addAll: each comments].
+	^methodComments asSortedCollection: [:a :b | a start < b start]
+]
+
+{ #category : #'*Deprecated90' }
 RBMethodNode >> primitiveSources [
 	self deprecated: 'please use the #pragmas directly'.
 	^ self pragmas collect: [ :each | self source copyFrom: each first to: each last ]

--- a/src/Deprecated90/RBProgramNode.extension.st
+++ b/src/Deprecated90/RBProgramNode.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #RBProgramNode }
+
+{ #category : #'*Deprecated90' }
+RBProgramNode >> methodComments [
+	self
+		deprecated: 'Please use #comments instead'
+		transformWith: '`@receiver methodComments' -> '`@receiver comments'.
+	^self comments
+]

--- a/src/Deprecated90/RBSequenceNode.extension.st
+++ b/src/Deprecated90/RBSequenceNode.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #RBSequenceNode }
+
+{ #category : #'*Deprecated90' }
+RBSequenceNode >> methodComments [
+	| methodComments |
+	self deprecated: 'no users, will be removed in Pharo10'.
+	methodComments := OrderedCollection withAll: self comments.
+	temporaries do: [:each | methodComments addAll: each comments].
+	(parent notNil and: [parent isBlock]) 
+		ifTrue: [parent arguments do: [:each | methodComments addAll: each comments]].
+	^methodComments asSortedCollection: [:a :b | a start < b start]
+]


### PR DESCRIPTION
#methodComments is a strange method... it returns all comments at the level of the method, but including comments on arguments.

There are no clients.  It is not clear why this is needed as an API method.