### PR TITLE
6008-Two-methods-to-test-if-a-node-is-an-argument

### DIFF
--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyVariableBreakpointCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyVariableBreakpointCommand.class.st
@@ -35,7 +35,7 @@ ClyVariableBreakpointCommand >> execute [
 	| methodOrClass |
 	sourceNode isVariable
 		ifFalse: [ ^ self ].
-	methodOrClass := (sourceNode isArg or: [ sourceNode isTemp ])
+	methodOrClass := sourceNode isArgOrTemp
 		ifTrue: [ method ]
 		ifFalse: [ method methodClass ].
 	self installVariableBreakpointOn: sourceNode name in: methodOrClass

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -96,6 +96,15 @@ Variable >> hash [
 
 { #category : #testing }
 Variable >> isArg [
+	self 
+		deprecated: 'Use #isArgumentVariable instead.' 
+		transformWith: '`@receiver isArg' -> '`@receiver isArgumentVariable'.
+	
+	^ self isArgumentVariable
+]
+
+{ #category : #testing }
+Variable >> isArgumentVariable [
 	^false
 ]
 

--- a/src/OpalCompiler-Core/ArgumentVariable.class.st
+++ b/src/OpalCompiler-Core/ArgumentVariable.class.st
@@ -14,8 +14,7 @@ ArgumentVariable class >> semanticNodeClass [
 ]
 
 { #category : #testing }
-ArgumentVariable >> isArg [
-
+ArgumentVariable >> isArgumentVariable [
 	^ true
 ]
 

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -255,7 +255,7 @@ OCAbstractMethodScope >> tempVarNames [
 { #category : #'temp vars' }
 OCAbstractMethodScope >> tempVarNamesWithoutArguments [
 
-	^ tempVars values reject: [ :each | each isArg ] thenCollect: [ :each | each name ]
+	^ tempVars values reject: [ :each | each isArgumentVariable ] thenCollect: [ :each | each name ]
 ]
 
 { #category : #'temp vars' }

--- a/src/OpalCompiler-Core/RBVariableNode.extension.st
+++ b/src/OpalCompiler-Core/RBVariableNode.extension.st
@@ -12,13 +12,16 @@ RBVariableNode >> binding: aSemVar [
 
 { #category : #'*opalcompiler-core' }
 RBVariableNode >> isArg [
-
-	^self binding isArg
+	self 
+		deprecated: 'Use #isArgument instead.' 
+		transformWith: '`@receiver isArg' -> '`@receiver isArgumentVariable'.
+	
+	^ self isArgument
 ]
 
 { #category : #'*opalcompiler-core' }
 RBVariableNode >> isArgOrTemp [
-	^self binding isTemp or: [ self binding isArg ]
+	^self binding isTemp or: [ self binding isArgumentVariable ]
 ]
 
 { #category : #'*opalcompiler-core' }

--- a/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
@@ -92,7 +92,7 @@ OCASTClosureAnalyzerTest >> testExampleSimpleBlockLocalWhile [
 	self assert: scopes second tempVars size equals: 1.
 	self assert: scopes second tempVector size equals: 0.
 	self deny: (scopes second lookupVar: 'b') isRemote.
-	self assert: (scopes second lookupVar: 'b') isArg.
+	self assert: (scopes second lookupVar: 'b') isArgumentVariable.
 	self deny: (scopes fourth lookupVar: 'hallo') isRemote
 ]
 

--- a/src/Ring-Core/RGVariable.class.st
+++ b/src/Ring-Core/RGVariable.class.st
@@ -18,7 +18,7 @@ RGVariable >> definitionString [
 ]
 
 { #category : #testing }
-RGVariable >> isArg [
+RGVariable >> isArgumentVariable [
 	^false
 ]
 

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1022,7 +1022,7 @@ SHRBTextStyler >> privateStyle: aText [
 { #category : #private }
 SHRBTextStyler >> resolveStyleFor: aVariableNode [
 	aVariableNode binding ifNil: [^#default].
-	aVariableNode isArg ifTrue: [ ^#methodArg].
+	aVariableNode isArgument ifTrue: [ ^#methodArg].
 	aVariableNode isTemp ifTrue: [ ^#tempVar].
 	aVariableNode isGlobal ifTrue: [ ^#globalVar].
 	aVariableNode isInstance ifTrue: [ ^#instVar]. 


### PR DESCRIPTION
Now that the semantics of arguments vs temps are the same on the AST and the Variables, we can get rid of #isArg 
(prior cleanups already removed almost all users on the AST level)

- add #isArgumentVariable on the Variable Hierarchy
- fix all users of isArg to use that, deprecate the method

- fix users of #isArg on the AST level to use #isArgument
- deprecate the method

- fix Ring to use isArgumentVariable, too

fixes #6008