### PR TITLE
Monticello-support-UndefinedSlot

### DIFF
--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -191,6 +191,19 @@ MCClassDefinition >> createClass [
 		do: [ :ex | ex resume ]
 ]
 
+{ #category : #installing }
+MCClassDefinition >> createVariableFromString: aString [
+	^[ Smalltalk compiler evaluate: aString ] 
+		on: Error 
+		do: [ 
+			"if an error happens, we parse the slot definition to an ast.
+			and create a UndefinedSlot"
+			| ast slotName |
+			ast := RBParser parseExpression: aString. 
+			slotName := ast receiver value. 
+			UndefinedSlot named: slotName ast: ast  ]
+]
+
 { #category : #initializing }
 MCClassDefinition >> defaultCommentStamp [
 	^ String new
@@ -557,6 +570,7 @@ MCClassDefinition >> variables [
 { #category : #installing }
 MCClassDefinition >> variablesOfType: aSymbol [
 	"version for complex vars, { definition . definition }"
-	^(((self selectVariables: aSymbol) collect: [:each | Smalltalk compiler evaluate: each])) asArray.
-		
+	^((self selectVariables: aSymbol) 
+		collect: [:each | self createVariableFromString: each])
+		as: Array
 ]

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -570,7 +570,7 @@ MCClassDefinition >> variables [
 { #category : #installing }
 MCClassDefinition >> variablesOfType: aSymbol [
 	"version for complex vars, { definition . definition }"
-	^((self selectVariables: aSymbol) 
-		collect: [:each | self createVariableFromString: each])
+	^(self selectVariables: aSymbol) 
+		collect: [:each | self createVariableFromString: each]
 		as: Array
 ]


### PR DESCRIPTION
This adds an error handler to try to create an UndefinedSlot in case something goes wrong when loading a class that uses a slot where the slot class is not yet loaded.

This PR is needed to load Ronnie's SmartData experiment.