### PR TITLE
Improve-SendsDeprecatedMethodToGlobalRule

### DIFF
--- a/src/Kernel-Rules/SendsDeprecatedMethodToGlobalRule.class.st
+++ b/src/Kernel-Rules/SendsDeprecatedMethodToGlobalRule.class.st
@@ -20,7 +20,7 @@ SendsDeprecatedMethodToGlobalRule >> basicCheck: aNode [
 	aNode isMessage ifFalse: [ ^ false ].
 	aNode receiver isVariable ifFalse: [ ^ false ].
 	aNode receiver variable isLiteralVariable ifFalse: [ ^ false ].
-	value := aNode receiver variable value .
+	value := aNode receiver variable value.
 	^value class classAndMethodFor: aNode selector
 		do: [ :class :method | method isDeprecated ]
 		ifAbsent: [ false ]

--- a/src/Kernel-Rules/SendsDeprecatedMethodToGlobalRule.class.st
+++ b/src/Kernel-Rules/SendsDeprecatedMethodToGlobalRule.class.st
@@ -16,22 +16,12 @@ SendsDeprecatedMethodToGlobalRule class >> uniqueIdentifierName [
 
 { #category : #running }
 SendsDeprecatedMethodToGlobalRule >> basicCheck: aNode [
-	| messageReceiver |
+	| value |
 	aNode isMessage ifFalse: [ ^ false ].
-
-	messageReceiver := aNode receiver.
-	messageReceiver isVariable ifFalse: [ ^ false ].
-	messageReceiver isGlobal ifFalse: [ ^ false ].
-	(self check: aNode selector forDeprecationIn: messageReceiver name) ifFalse: [ ^ false ].
-
-	^ true
-]
-
-{ #category : #running }
-SendsDeprecatedMethodToGlobalRule >> check: aSelector forDeprecationIn: aGlobalName [
-
-	^ (Smalltalk globals at: aGlobalName ifAbsent: [ ^ false ]) class
-		classAndMethodFor: aSelector
+	aNode receiver isVariable ifFalse: [ ^ false ].
+	aNode receiver variable isLiteralVariable ifFalse: [ ^ false ].
+	value := aNode receiver variable value .
+	^value class classAndMethodFor: aNode selector
 		do: [ :class :method | method isDeprecated ]
 		ifAbsent: [ false ]
 ]

--- a/src/Kernel-Tests-Rules/SendsDeprecatedMethodToGlobalRuleTest.class.st
+++ b/src/Kernel-Tests-Rules/SendsDeprecatedMethodToGlobalRuleTest.class.st
@@ -17,7 +17,12 @@ SendsDeprecatedMethodToGlobalRuleTest >> deprecatedMethodName [
 { #category : #properties }
 SendsDeprecatedMethodToGlobalRuleTest >> globalName [
 
-	^ globalName ifNil: [ globalName := ('TestGlobal', 1e10 atRandom asString) asSymbol ]
+	^ globalName ifNil: [ 
+		[ globalName :=
+			('TestGlobal', 1e10 atRandom asString) asSymbol
+		] doWhileTrue: [ 
+			"if the name already exists, we generate anotherone"
+			testingEnvironment includesKey: globalName ] ]
 ]
 
 { #category : #properties }

--- a/src/Kernel-Tests-Rules/SendsDeprecatedMethodToGlobalRuleTest.class.st
+++ b/src/Kernel-Tests-Rules/SendsDeprecatedMethodToGlobalRuleTest.class.st
@@ -21,7 +21,7 @@ SendsDeprecatedMethodToGlobalRuleTest >> globalName [
 		[ globalName :=
 			('TestGlobal', 1e10 atRandom asString) asSymbol
 		] doWhileTrue: [ 
-			"if the name already exists, we generate anotherone"
+			"if the name already exists, we generate another one"
 			testingEnvironment includesKey: globalName ] ]
 ]
 

--- a/src/Kernel-Tests-Rules/SendsDeprecatedMethodToGlobalRuleTest.class.st
+++ b/src/Kernel-Tests-Rules/SendsDeprecatedMethodToGlobalRuleTest.class.st
@@ -17,11 +17,7 @@ SendsDeprecatedMethodToGlobalRuleTest >> deprecatedMethodName [
 { #category : #properties }
 SendsDeprecatedMethodToGlobalRuleTest >> globalName [
 
-	^ globalName ifNil: [ 
-		[ globalName :=
-			('TestGlobal', 1e10 atRandom asString) asSymbol
-		] doWhileTrue: [ 
-			testingEnvironment includesKey: globalName ] ]
+	^ globalName ifNil: [ globalName := ('TestGlobal', 1e10 atRandom asString) asSymbol ]
 ]
 
 { #category : #properties }


### PR DESCRIPTION
Simplify SendsDeprecatedMethodToGlobalRule

- do not use Smalltalk globals but read the var directly
- simplify test