### PR TITLE
Fix-LocalVariable-astNodes

### DIFF
--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -37,7 +37,7 @@ LocalVariable >> asString [
 
 { #category : #queries }
 LocalVariable >> astNodes [
-	^self method variableNodes select: [ :each | each binding == self]
+	^scope node methodNode variableNodes select: [ :each | each binding == self]
 ]
 
 { #category : #accessing }
@@ -214,7 +214,7 @@ LocalVariable >> markWrite [
 
 { #category : #queries }
 LocalVariable >> method [
-	^scope node methodNode methodClass>>scope node methodNode selector
+	^scope node methodNode compiledMethod
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
#astNodes on LocalVariable was calling #method which was doing a re-lookup and use the currently installed method.

This works mostly, but it could lead to wrong answers for a new, not yet installed AST for the method.

instead, it should use the methodNode. in addition it fixes #method to use the compiledMethod that the AST was compiled for.