### PR TITLE
Simplify-MetalinkTargetResolver-resolvingBlocForOption

### DIFF
--- a/src/Reflectivity/MetaLinkInstaller.class.st
+++ b/src/Reflectivity/MetaLinkInstaller.class.st
@@ -323,7 +323,7 @@ MetaLinkInstaller >> registerAndInstallPermaLink: aPermaLink forTarget: aSlotOrV
 		
 	linksRegistry registerPermaLink: aPermaLink.
 	
-	nodes := MetalinkTargetResolver resolveASTLookupFor: aSlotOrVar option: aPermaLink persistenceType.
+	nodes := (aSlotOrVar accessingNodesFor: aPermaLink persistenceType) asIdentitySet.
 	aPermaLink targetObjectOrClass link: aPermaLink link toNodes: nodes
 ]
 

--- a/src/Reflectivity/MetalinkTargetResolver.class.st
+++ b/src/Reflectivity/MetalinkTargetResolver.class.st
@@ -41,7 +41,7 @@ MetalinkTargetResolver class >> classVariableNamed: aClassVariableName for: aCla
 MetalinkTargetResolver class >> classVariableNamed: aClassVariableName for: aClassOrObject option: option [
 	| var |
 	var := self lookupClassVariableNamed: aClassVariableName asSymbol in: aClassOrObject.
-	^ self resolveASTLookupFor: var option: option
+	^ (var accessingNodesFor: option) asIdentitySet
 ]
 
 { #category : #resolving }
@@ -76,11 +76,6 @@ MetalinkTargetResolver class >> methodNamed: aMethodName for: aClassOrObject [
 	^ self lookupASTForMethodNamed: aMethodName asSymbol in: aClassOrObject
 ]
 
-{ #category : #resolving }
-MetalinkTargetResolver class >> resolveASTLookupFor: varOrSlot option: option [
-	^  (varOrSlot accessingNodesFor: option) asIdentitySet
-]
-
 { #category : #api }
 MetalinkTargetResolver class >> slotNamed: aSlotName for: aClassOrObject [
 	^ self lookupSlotNamed: aSlotName asSymbol in: aClassOrObject
@@ -90,7 +85,7 @@ MetalinkTargetResolver class >> slotNamed: aSlotName for: aClassOrObject [
 MetalinkTargetResolver class >> slotNamed: aSlotName for: aClassOrObject option: option [
 	| slot |
 	slot := self lookupSlotNamed: aSlotName asSymbol in: aClassOrObject.
-	^ self resolveASTLookupFor: slot option: option
+	^ (slot accessingNodesFor: option) asIdentitySet
 ]
 
 { #category : #api }
@@ -109,5 +104,5 @@ MetalinkTargetResolver class >> temporaryNamed: aTempVarName inMethod: aMethodNa
 MetalinkTargetResolver class >> temporaryNamed: aTempVarName inMethod: aMethodName for: aClassOrObject option: option [
 	| temp |
 	temp := self lookupTemporaryNamed: aTempVarName asSymbol inMethod: aMethodName for: aClassOrObject.
-	^ self resolveASTLookupFor: temp option: option
+	^ (temp accessingNodesFor: option) asIdentitySet
 ]

--- a/src/Reflectivity/MetalinkTargetResolver.class.st
+++ b/src/Reflectivity/MetalinkTargetResolver.class.st
@@ -21,17 +21,6 @@ Class {
 	#category : #'Reflectivity-Installer'
 }
 
-{ #category : #'resolving - private' }
-MetalinkTargetResolver class >> assignmentNodesFor: aVarOrSlot [
-	(aVarOrSlot isKindOf: Slot)
-		ifFalse: [ ^ aVarOrSlot assignmentNodes asIdentitySet ].
-	^ ((self
-		usingNodesForVariable: aVarOrSlot
-		in: aVarOrSlot owningClass withAllSubclasses)
-		select: [ :each | each isWrite ]
-		thenCollect: [ :each | each parent ]) asIdentitySet
-]
-
 { #category : #resolving }
 MetalinkTargetResolver class >> classFor: aClassOrObject [
 	| class |
@@ -87,31 +76,9 @@ MetalinkTargetResolver class >> methodNamed: aMethodName for: aClassOrObject [
 	^ self lookupASTForMethodNamed: aMethodName asSymbol in: aClassOrObject
 ]
 
-{ #category : #'resolving - private' }
-MetalinkTargetResolver class >> readNodesFor: aVarOrSlot [
-	(aVarOrSlot isKindOf: Slot)
-		ifFalse: [ ^ aVarOrSlot readNodes asIdentitySet ].
-	^ ((self
-		usingNodesForVariable: aVarOrSlot
-		in: aVarOrSlot owningClass withAllSubclasses)
-		select: [ :each | each isRead ]) asIdentitySet
-]
-
 { #category : #resolving }
 MetalinkTargetResolver class >> resolveASTLookupFor: varOrSlot option: option [
-	^ (self resolvingBlocForOption: option) value: varOrSlot
-]
-
-{ #category : #'resolving - private' }
-MetalinkTargetResolver class >> resolvingBlocForOption: option [
-	option = #write
-		ifTrue: [ ^ [ :varOrSlot | self assignmentNodesFor: varOrSlot ] ].
-	option = #read
-		ifTrue: [ ^ [ :varOrSlot | self readNodesFor: varOrSlot ] ].
-	^ [ :varOrSlot | 
-	(OrderedCollection
-		with: (self assignmentNodesFor: varOrSlot)
-		with: (self readNodesFor: varOrSlot)) flattened asIdentitySet ]
+	^  (varOrSlot accessingNodesFor: option) asIdentitySet
 ]
 
 { #category : #api }
@@ -129,7 +96,7 @@ MetalinkTargetResolver class >> slotNamed: aSlotName for: aClassOrObject option:
 { #category : #api }
 MetalinkTargetResolver class >> slotOrVarNodesFor: slotOrVar inMethod: method option: option [
 	| nodes |
-	nodes := (self resolvingBlocForOption: option) value: slotOrVar.
+	nodes := (slotOrVar accessingNodesFor: option) asIdentitySet.
 	^ nodes select: [ :node | node methodNode method = method ]
 ]
 
@@ -143,10 +110,4 @@ MetalinkTargetResolver class >> temporaryNamed: aTempVarName inMethod: aMethodNa
 	| temp |
 	temp := self lookupTemporaryNamed: aTempVarName asSymbol inMethod: aMethodName for: aClassOrObject.
 	^ self resolveASTLookupFor: temp option: option
-]
-
-{ #category : #'resolving - private' }
-MetalinkTargetResolver class >> usingNodesForVariable: aVarOrSlot in: classes [
-	^ (classes flatCollect: [ :c | c variableNodes ])
-		select: [ :each | each binding == aVarOrSlot ]
 ]

--- a/src/Reflectivity/Variable.extension.st
+++ b/src/Reflectivity/Variable.extension.st
@@ -1,6 +1,23 @@
 Extension { #name : #Variable }
 
 { #category : #'*Reflectivity' }
+Variable >> accessingNodes [
+	"return all reads and all assignments. This is different to #astNodes, which returns 
+	variable nodes in case of assignment, not the assignment itself"
+	^ self readNodes, self assignmentNodes
+]
+
+{ #category : #'*Reflectivity' }
+Variable >> accessingNodesFor: option [
+	option = #write
+		ifTrue: [ ^ self assignmentNodes ].
+	option = #read
+		ifTrue: [ ^ self  readNodes ].
+	"else we return all accessing nodes"
+	^ self accessingNodes
+]
+
+{ #category : #'*Reflectivity' }
 Variable >> afterHooks [
 	^self propertyAt: #afterHooks ifAbsent: #()
 ]


### PR DESCRIPTION
With the Variable unification, lots of things can be simplified... here a small step to simplify MetalinkTargetResolver.

#resolveASTLookupFor: is not needed, we can just delegate to the Variable.