### PR TITLE
isArgOrTemp-Cleanup

### DIFF
--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyVariableBreakpointCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyVariableBreakpointCommand.class.st
@@ -35,7 +35,7 @@ ClyVariableBreakpointCommand >> execute [
 	| methodOrClass |
 	sourceNode isVariable
 		ifFalse: [ ^ self ].
-	methodOrClass := sourceNode isArgOrTemp
+	methodOrClass := sourceNode isLocalVariable
 		ifTrue: [ method ]
 		ifFalse: [ method methodClass ].
 	self installVariableBreakpointOn: sourceNode name in: methodOrClass

--- a/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
@@ -66,7 +66,7 @@ OCASTClosureAnalyzer >> visitVariableNode: aVariableNode [
 	
 	| var |
 	aVariableNode adaptToSemanticNode.
-	aVariableNode isArgOrTemp ifFalse: [^self].
+	aVariableNode isLocalVariable ifFalse: [^self].
 	var := self lookupAndFixBinding: aVariableNode.
 	var isTempVectorTemp ifTrue: [ | vectorVar |
 		vectorVar := scope lookupVar: var vectorName.

--- a/src/OpalCompiler-Core/RBVariableNode.extension.st
+++ b/src/OpalCompiler-Core/RBVariableNode.extension.st
@@ -20,11 +20,6 @@ RBVariableNode >> isArg [
 ]
 
 { #category : #'*opalcompiler-core' }
-RBVariableNode >> isArgOrTemp [
-	^self binding isTemp or: [ self binding isArgumentVariable ]
-]
-
-{ #category : #'*opalcompiler-core' }
 RBVariableNode >> isClean [
 	^ (self isInstance | self isReservedVariable) not
 ]
@@ -38,6 +33,12 @@ RBVariableNode >> isGlobal [
 { #category : #'*opalcompiler-core' }
 RBVariableNode >> isInstance [
 	^self binding isInstance
+]
+
+{ #category : #'*opalcompiler-core' }
+RBVariableNode >> isLocalVariable [
+	"returns true for temporary variables and arguments"
+	^variable isLocalVariable
 ]
 
 { #category : #'*opalcompiler-core' }

--- a/src/Reflectivity/RFOperationReification.class.st
+++ b/src/Reflectivity/RFOperationReification.class.st
@@ -24,7 +24,7 @@ RFOperationReification >> genForRBArrayNode [
 
 { #category : #generate }
 RFOperationReification >> genForRBAssignmentNode [
-	entity variable isArgOrTemp ifTrue: [  
+	entity variable isLocalVariable ifTrue: [  
 		^RBParser parseExpression: ('RFTempWrite new
 			assignedValue: RFNewValueReificationVar; 
 			context: thisContext;
@@ -104,7 +104,7 @@ RFOperationReification >> genForRBVariableNode [
 			object: self;
 			variableName: #{1}.' format: {entity name})].
 		
-	entity isArgOrTemp ifTrue: [
+	entity isLocalVariable ifTrue: [
 		^RBParser parseExpression: ('RFTempRead new 
 			context: thisContext;
 			variableName: #{1}.' format: {entity name})].


### PR DESCRIPTION
clean up #isArgOrTemp

- add #isLocalVariable to RBVariableNode (with comment!) delegating to the variable
- fix all senders
- remove method. No deprecation as we added this in Pharo9 as an intermediate step