### PR TITLE
Nice-testing-Methods-for-Variable

### DIFF
--- a/src/Deprecated90/OCAbstractLocalVariable.class.st
+++ b/src/Deprecated90/OCAbstractLocalVariable.class.st
@@ -25,12 +25,6 @@ OCAbstractLocalVariable >> definingScope [
 	^ scope
 ]
 
-{ #category : #testing }
-OCAbstractLocalVariable >> isLocal [
-
-	^true
-]
-
 { #category : #'read/write usage' }
 OCAbstractLocalVariable >> isRead [
 	^usage = #read

--- a/src/Deprecated90/OCAbstractVariable.class.st
+++ b/src/Deprecated90/OCAbstractVariable.class.st
@@ -28,12 +28,6 @@ OCAbstractVariable >> definingScope [
 	^ scope
 ]
 
-{ #category : #testing }
-OCAbstractVariable >> isLocal [
-
-	^false
-]
-
 { #category : #'read/write usage' }
 OCAbstractVariable >> isRead [
 	^usage = #read

--- a/src/Deprecated90/OCLiteralVariable.class.st
+++ b/src/Deprecated90/OCLiteralVariable.class.st
@@ -51,12 +51,6 @@ OCLiteralVariable >> isFromSharedPool [
 ]
 
 { #category : #testing }
-OCLiteralVariable >> isGlobal [
-
-	^ true
-]
-
-{ #category : #testing }
 OCLiteralVariable >> isGlobalClassNameBinding [
 	^ (self value isClass or: [ self value isTrait ])
 		and: [ self variable key == self value name ]

--- a/src/Deprecated90/OCSlotVariable.class.st
+++ b/src/Deprecated90/OCSlotVariable.class.st
@@ -38,11 +38,6 @@ OCSlotVariable >> emitValue: methodBuilder [
 	slot emitValue: methodBuilder
 ]
 
-{ #category : #testing }
-OCSlotVariable >> isInstance [
-	^ true
-]
-
 { #category : #accessing }
 OCSlotVariable >> name [
 	^ slot name

--- a/src/Kernel/GlobalVariable.class.st
+++ b/src/Kernel/GlobalVariable.class.st
@@ -27,12 +27,6 @@ GlobalVariable >> emitValue: methodBuilder [
 ]
 
 { #category : #testing }
-GlobalVariable >> isGlobal [
-
-	^ true
-]
-
-{ #category : #testing }
 GlobalVariable >> isGlobalVariable [
 	^true
 ]

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -218,7 +218,7 @@ Slot >> isDefinedByOwningClass [
 ]
 
 { #category : #testing }
-Slot >> isInstance [
+Slot >> isInstanceVariable [
 	^ true
 ]
 
@@ -231,6 +231,11 @@ Slot >> isReadIn: aCompiledCode [
 { #category : #testing }
 Slot >> isSelfEvaluating [
 	^true
+]
+
+{ #category : #testing }
+Slot >> isSlot [
+	^ true
 ]
 
 { #category : #testing }

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -114,8 +114,9 @@ Variable >> isClassVariable [
 ]
 
 { #category : #testing }
-Variable >> isGlobal [ 
-	^false
+Variable >> isGlobal [
+	"this will be deprecated"
+	^self isGlobalVariable
 ]
 
 { #category : #testing }
@@ -125,21 +126,32 @@ Variable >> isGlobalVariable [
 
 { #category : #testing }
 Variable >> isInstance [
-	^ false
+	"this will be deprecated"
+	^ self isInstanceVariable
+]
+
+{ #category : #testing }
+Variable >> isInstanceVariable [
+	"check if the var is an instance variable (a Slot)"
+	^false
 ]
 
 { #category : #testing }
 Variable >> isLiteralVariable [
+	"returns true for Global Variables, Class Variables and some others 
+	(e.g. Workspace bindings and Undeclared variables, see subclasses)"
 	^false
 ]
 
 { #category : #testing }
 Variable >> isLocal [
-	^false
+	"this will be deprecated"
+	^self isLocalVariable
 ]
 
 { #category : #testing }
 Variable >> isLocalVariable [
+	"temporary variables and arguments are local variables"
 	^false
 ]
 
@@ -150,6 +162,7 @@ Variable >> isReferenced [
 
 { #category : #testing }
 Variable >> isReservedVariable [
+	"thisContext, super, self are reserved variables (true, false and nil are literals)"
 	^false
 ]
 
@@ -165,6 +178,12 @@ Variable >> isSelfOrSuper [
 ]
 
 { #category : #testing }
+Variable >> isSlot [
+	"check if the var is an instance variable (a Slot)"
+	^false
+]
+
+{ #category : #testing }
 Variable >> isSuper [
 	^false
 ]
@@ -173,6 +192,11 @@ Variable >> isSuper [
 Variable >> isTemp [
 
 	^ false
+]
+
+{ #category : #testing }
+Variable >> isTemporaryVariable [
+	^false
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -116,12 +116,6 @@ LocalVariable >> isEscapingWrite [
 ]
 
 { #category : #testing }
-LocalVariable >> isLocal [
-
-	^true
-]
-
-{ #category : #testing }
 LocalVariable >> isLocalVariable [
 
 	^true

--- a/src/OpalCompiler-Core/TemporaryVariable.class.st
+++ b/src/OpalCompiler-Core/TemporaryVariable.class.st
@@ -18,3 +18,9 @@ TemporaryVariable >> isTemp [
 
 	^ true
 ]
+
+{ #category : #testing }
+TemporaryVariable >> isTemporaryVariable [
+
+	^ true
+]


### PR DESCRIPTION
The names of the testing methods for Variables (and VariableNodes) are not good. #isGlobal works, but it breakes down with #isInstance... 

As one step, this PR just makes sure that all the "nice" variable check methos exist on the Variable hierarchy

- add missing (e.g. isTemporaryVariable)
- the short versions forward to the new and have a comment that they will be deprecated
- add comments to the version on Variable for those that are not obvious (eg isLiteralVariable, the term is not nice but that is what they are called on the Bytecode level)

This PR does *not*
- change any senders
- modify the AST level
- isSelf/isSuper are skiped for now (they should be isSelfVariable, too)