### PR TITLE
Simplify-ReSuperSendsRule

### DIFF
--- a/src/GeneralRules/ReSuperSendsRule.class.st
+++ b/src/GeneralRules/ReSuperSendsRule.class.st
@@ -16,13 +16,9 @@ ReSuperSendsRule class >> uniqueIdentifierName [
 
 { #category : #hooks }
 ReSuperSendsRule >> afterCheck: aNode mappings: mappingDict [
-		
-	aNode methodNode ifNotNil: [ :methNode |
-		methNode compiledMethod ifNotNil: [ :method |
-			method methodClass withAllSubclassesDo: [ :class |
-			 (class includesSelector: aNode selector)
-				ifTrue: [ ^ false ] ]] ].
-	^ true
+
+	^aNode methodNode methodClass withAllSubclasses noneSatisfy: [: class | 
+		class includesSelector: aNode selector ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
ReSuperSendsRule can be much simpler

- methodNode can never me nil
- no need to access the compiledMethod for #methodClass
- use noneSatisfy: instead of re-implementing it