### PR TITLE
Speedup-pharoDocCommentNodes

### DIFF
--- a/src/AST-Core/RBComment.class.st
+++ b/src/AST-Core/RBComment.class.st
@@ -29,7 +29,8 @@ Class {
 	#instVars : [
 		'contents',
 		'start',
-		'parent'
+		'parent',
+		'properties'
 	],
 	#category : #'AST-Core-Nodes'
 }
@@ -57,6 +58,13 @@ RBComment >> contents [
 	^ contents
 ]
 
+{ #category : #properties }
+RBComment >> hasProperty: aKey [
+	"Test if the property aKey is present."
+	
+	^ properties notNil and: [ properties includesKey: aKey ]
+]
+
 { #category : #testing }
 RBComment >> intersectsInterval: anInterval [ 
 	"Make comments polymorphic with program nodes for hit detection"
@@ -81,6 +89,62 @@ RBComment >> printOn: aStream [
 	aStream nextPutAll: ' "'.
 	aStream nextPutAll: contents.
 	aStream nextPutAll: '" '.
+]
+
+{ #category : #properties }
+RBComment >> propertyAt: aKey [
+	"Answer the property value associated with aKey."
+	
+	^ self propertyAt: aKey ifAbsent: [ self error: 'Property not found' ]
+]
+
+{ #category : #properties }
+RBComment >> propertyAt: aKey ifAbsent: aBlock [
+	"Answer the property value associated with aKey or, if aKey isn't found, answer the result of evaluating aBlock."
+	
+	^ properties 
+		ifNil: aBlock
+		ifNotNil: [ properties at: aKey ifAbsent: aBlock ]
+]
+
+{ #category : #properties }
+RBComment >> propertyAt: aKey ifAbsentPut: aBlock [
+	"Answer the property associated with aKey or, if aKey isn't found store the result of evaluating aBlock as new value."
+	
+	^ self propertyAt: aKey ifAbsent: [ self propertyAt: aKey put: aBlock value ]
+]
+
+{ #category : #properties }
+RBComment >> propertyAt: aKey ifPresent: aPresentBlock ifAbsent: anAbsentBlock [
+	"Answer the property value associated with aKey or, if aKey is found, answer the result of evaluating aPresentBlock, else evaluates anAbsentBlock."
+
+	^ properties ifNil: anAbsentBlock ifNotNil: [ properties at: aKey ifPresent: aPresentBlock ifAbsent: anAbsentBlock ]
+]
+
+{ #category : #properties }
+RBComment >> propertyAt: aKey put: anObject [
+	"Set the property at aKey to be anObject. If aKey is not found, create a new entry for aKey and set is value to anObject. Answer anObject."
+
+	^ (properties ifNil: [ properties := SmallDictionary new: 1 ])
+		at: aKey put: anObject
+]
+
+{ #category : #properties }
+RBComment >> removeProperty: aKey [
+	"Remove the property with aKey. Answer the property or raise an error if aKey isn't found."
+	
+	^ self removeProperty: aKey ifAbsent: [ self error: 'Property not found' ].
+]
+
+{ #category : #properties }
+RBComment >> removeProperty: aKey ifAbsent: aBlock [
+	"Remove the property with aKey. Answer the value or, if aKey isn't found, answer the result of evaluating aBlock."
+	
+	| answer |
+	properties ifNil: [ ^ aBlock value ].
+	answer := properties removeKey: aKey ifAbsent: aBlock.
+	properties isEmpty ifTrue: [ properties := nil ].
+	^ answer
 ]
 
 { #category : #accessing }

--- a/src/PharoDocComment/DocCommentIconStyler.class.st
+++ b/src/PharoDocComment/DocCommentIconStyler.class.st
@@ -64,8 +64,7 @@ DocCommentIconStyler >> runExampleBlock: aNode [
 DocCommentIconStyler >> shouldStyleNode: aNode [
 	^ self stylingEnabled
 		and: [ aNode isMethod
-				and: [ aNode comments isNotEmpty
-						and: [ aNode comments anySatisfy: [ :commentNode | commentNode pharoDocCommentNodes isNotEmpty ] ] ] ]
+				and: [ aNode comments anySatisfy: [ :commentNode | commentNode hasDocComment ] ] ] 
 ]
 
 { #category : #private }

--- a/src/PharoDocComment/RBComment.extension.st
+++ b/src/PharoDocComment/RBComment.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : #RBComment }
 
 { #category : #'*PharoDocComment' }
+RBComment >> hasDocComment [
+	^ (self hasProperty: #pharoDocCommentNodes) or: [contents includesSubstring: '>>>']
+]
+
+{ #category : #'*PharoDocComment' }
 RBComment >> pharoDocCommentNodes [
-	^ PharoDocCommentNode parseDocComments: self
+	self hasDocComment ifFalse: [ ^#() ].
+	^ self propertyAt: #pharoDocCommentNodes ifAbsentPut: [PharoDocCommentNode parseDocComments: self]
 ]


### PR DESCRIPTION
- add property API to RBComment (which shows that it might be better a subclass of RBProgramNode?)
- implement #hasDocComment: quick check for >>> and check if property is alrready defined.
- #pharoDocCommentNodes checks hasDocComment, caches result in property
- DocCommentIconStyler uses hasDocComment

Benchmark: 
[(Behavior>>#methodDict) ast pharoDocCommentNodes] bench.