### PR TITLE
6835-Remove-printHierarchy-methods

### DIFF
--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -92,62 +92,6 @@ ClassDescriptionTest >> testclassThatDefinesInstVarNamed [
 	
 ]
 
-{ #category : #'tests - slots' }
-ClassDescriptionTest >> testprintHierarchy [
-	| expected result |
-	expected := '
-ProtoObject #()
-	Object #()
-
-		ExampleForTest1 #()
-			ExampleForTest11 #()
-				ExampleForTest111 #()
-				ExampleForTest112 #()
-			ExampleForTest12 #()'.
-	result := ExampleForTest1 printHierarchy.
-	self assert: result equals: expected
-]
-
-{ #category : #'tests - slots' }
-ClassDescriptionTest >> testprintSubclassesOnLevelFilterA [
-	| expected result stream |
-	expected := '
-	ExampleForTest1 #()
-		ExampleForTest11 #()
-			ExampleForTest112 #()'.
-	result := String new: expected size.
-	stream := ReadWriteStream on: result.
-	ExampleForTest1 printSubclassesOn: stream level: 1 filter: {ExampleForTest1. ExampleForTest11. ExampleForTest112}.
-	self assert: result equals: expected
-]
-
-{ #category : #'tests - slots' }
-ClassDescriptionTest >> testprintSubclassesOnLevelFilterB [
-	| expected result stream |
-	expected := '
-	ExampleForTest1 #()
-		ExampleForTest12 #()'.
-	result := String new: expected size.
-	stream := ReadWriteStream on: result.
-	ExampleForTest1 printSubclassesOn: stream level: 1 filter: { ExampleForTest1. ExampleForTest12. ExampleForTest112 }.
-	self assert: result equals: expected
-]
-
-{ #category : #'tests - slots' }
-ClassDescriptionTest >> testprintSubclassesOnLevelFilterNil [
-	| expected result stream |
-	expected := '
-	ExampleForTest1 #()
-		ExampleForTest11 #()
-			ExampleForTest111 #()
-			ExampleForTest112 #()
-		ExampleForTest12 #()'.
-	result := String new: expected size.
-	stream := ReadWriteStream on: result.
-	ExampleForTest1 printSubclassesOn: stream level: 1 filter: nil.
-	self assert: result equals: expected
-]
-
 { #category : #'tests - instance variables' }
 ClassDescriptionTest >> testwhichSelectorsAccess [
 	self assert: ((Point whichSelectorsAccess: #y) includes: #y).

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1354,26 +1354,6 @@ Behavior >> postCopy [
 ]
 
 { #category : #printing }
-Behavior >> printHierarchy [
-	"Answer a description containing the names and instance variable names 
-	of all of the subclasses and superclasses of the receiver."
-
-	| aStream index |
-	index := 0.
-	aStream := (String new: 16) writeStream.
-	self allSuperclasses reverseDo: 
-		[:aClass | 
-		aStream crtab: index.
-		index := index + 1.
-		aStream nextPutAll: aClass name.
-		aStream space.
-		aStream print: aClass instVarNames].
-	aStream cr.
-	self printSubclassesOn: aStream level: index.
-	^aStream contents
-]
-
-{ #category : #printing }
 Behavior >> printOn: aStream [ 
 	"Refer to the comment in Object|printOn:." 
 

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -1076,33 +1076,6 @@ ClassDescription >> printOn: aStream [
 	aStream nextPutAll: self name
 ]
 
-{ #category : #'accessing class hierarchy' }
-ClassDescription >> printSubclassesOn: aStream level: level [ 
-
-		self printSubclassesOn: aStream level: level filter: nil
-]
-
-{ #category : #'accessing class hierarchy' }
-ClassDescription >> printSubclassesOn: aStream level: level filter: filterCollection [
-	"As part of the algorithm for printing a description of the receiver, print the
-	subclass on the file stream, aStream, indenting level times. 
-	An optional filterCollection restricts printing to contained classes only."
-	
-	| subclassNames |
-	filterCollection ifNotNil: [ (filterCollection includes: self) ifFalse: [ ^self ]].
-	aStream crtab: level.
-	aStream nextPutAll: self name.
-	aStream space; print: self instVarNames.
-	self == Class
-		ifTrue: 
-			[aStream crtab: level + 1; nextPutAll: '[ ... all the Metaclasses ... ]'.
-			^self].
-	subclassNames := self subclasses asSortedCollection:[:c1 :c2| c1 name <= c2 name].
-	"Print subclasses in alphabetical order"
-	subclassNames do:
-		[:subclass | subclass printSubclassesOn: aStream level: level + 1 filter: filterCollection]
-]
-
 { #category : #compiling }
 ClassDescription >> reformatAll [
 	"Reformat all methods in this class"


### PR DESCRIPTION
fixes: #6835 remove printHierarchy. We will reintroduce it in a separate class and in another package.