### PR TITLE
LocalVariable-declaringNode

### DIFF
--- a/src/Deprecated90/OCAbstractLocalVariable.class.st
+++ b/src/Deprecated90/OCAbstractLocalVariable.class.st
@@ -20,11 +20,6 @@ OCAbstractLocalVariable >> asString [
 	^ self name
 ]
 
-{ #category : #accessing }
-OCAbstractLocalVariable >> definingScope [
-	^ scope
-]
-
 { #category : #'read/write usage' }
 OCAbstractLocalVariable >> isRead [
 	^usage = #read

--- a/src/Deprecated90/OCAbstractVariable.class.st
+++ b/src/Deprecated90/OCAbstractVariable.class.st
@@ -23,11 +23,6 @@ OCAbstractVariable >> asString [
 	^ self name
 ]
 
-{ #category : #accessing }
-OCAbstractVariable >> definingScope [
-	^ scope
-]
-
 { #category : #'read/write usage' }
 OCAbstractVariable >> isRead [
 	^usage = #read

--- a/src/OpalCompiler-Core/ArgumentVariable.class.st
+++ b/src/OpalCompiler-Core/ArgumentVariable.class.st
@@ -13,6 +13,11 @@ ArgumentVariable class >> semanticNodeClass [
 	^RBArgumentNode 
 ]
 
+{ #category : #queries }
+ArgumentVariable >> declaringNode [
+	^ scope node arguments detect: [ :each | each name = name ]
+]
+
 { #category : #testing }
 ArgumentVariable >> isArgumentVariable [
 	^ true

--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -40,9 +40,9 @@ LocalVariable >> astNodes [
 	^scope node methodNode variableNodes select: [ :each | each binding == self]
 ]
 
-{ #category : #accessing }
-LocalVariable >> definingScope [
-	^ scope
+{ #category : #queries }
+LocalVariable >> declaringNode [
+	^ self subclassResponsibility
 ]
 
 { #category : #emitting }
@@ -245,7 +245,7 @@ LocalVariable >> readInContext: aContext [
 
 { #category : #accessing }
 LocalVariable >> scope [
-
+	"this is the scope that the variable is declared in"
 	^ scope
 ]
 

--- a/src/OpalCompiler-Core/TemporaryVariable.class.st
+++ b/src/OpalCompiler-Core/TemporaryVariable.class.st
@@ -13,6 +13,11 @@ TemporaryVariable class >> semanticNodeClass [
 	^RBTemporaryNode 
 ]
 
+{ #category : #queries }
+TemporaryVariable >> declaringNode [
+	^ scope node temporaries detect: [ :each | each name = name ]
+]
+
 { #category : #testing }
 TemporaryVariable >> isTemp [
 

--- a/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
@@ -199,7 +199,7 @@ OCASTCheckerTest >> testOptimizedBlockWrittenAfterClosedOverCase1 [
 
 	"index is not escaping as it is (due to the optimized block) defined in the same block"
 	self deny: (ast scope lookupVar: 'index') isEscaping.
-	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
+	self assert: (ast scope lookupVar: 'index') scope equals: ast scope.
 
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
 
@@ -216,7 +216,7 @@ OCASTCheckerTest >> testOptimizedBlockWrittenAfterClosedOverCase2 [
 	self assert: ast scope tempVars size equals: 1.
 
 	self deny: (ast scope lookupVar: 'index') isEscaping.
-	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
+	self assert: (ast scope lookupVar: 'index') scope equals: ast scope.
 
 	scopes := (OCScopesCollector new visitNode: ast) scopes.
 
@@ -302,7 +302,7 @@ OCASTCheckerTest >> testSingleRemoteTempVar [
 	self assert: ast scope tempVars size equals: 3.
 
 	self assert: (ast scope lookupVar: 'index') isEscaping.
-	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
+	self assert: (ast scope lookupVar: 'index') scope equals: ast scope.
 	self deny: (ast scope lookupVar: 'block') isEscaping.
 	self assert: (ast scope lookupVar: 'theCollection') isEscaping.
 	self assert: (ast scope lookupVar: 'block') isTemp.
@@ -321,7 +321,7 @@ OCASTCheckerTest >> testsingleRemoteTempVarWhileWithTempNotInlined [
 	self assert: ast scope tempVars size equals: 2.
 
 	self assert: (ast scope lookupVar: 'index') isEscaping.
-	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
+	self assert: (ast scope lookupVar: 'index') scope equals: ast scope.
 	self deny: (ast scope lookupVar: 'block') isEscaping.
 	self assert: (ast scope lookupVar: 'block') isTemp
 ]
@@ -335,7 +335,7 @@ OCASTCheckerTest >> testsingleRemoteTempVarWrittenAfterClosedOver [
 	self assert: ast scope tempVars size equals: 2.
 
 	self assert: (ast scope lookupVar: 'index') isWrite.
-	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
+	self assert: (ast scope lookupVar: 'index') scope equals: ast scope.
 	self deny: (ast scope lookupVar: 'block') isEscaping.
 	self assert: (ast scope lookupVar: 'block') isTemp
 ]

--- a/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
@@ -457,7 +457,7 @@ OCASTClosureAnalyzerTest >> testSingleRemoteTempVar [
 	self assert: ast scope tempVector size equals: 1.
 
 	self assert: (ast scope lookupVar: 'index') isRemote.
-	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
+	self assert: (ast scope lookupVar: 'index') scope equals: ast scope.
 	self deny: (ast scope lookupVar: 'block') isRemote.
 	self deny: (ast scope lookupVar: 'theCollection') isRemote
 ]
@@ -502,7 +502,7 @@ OCASTClosureAnalyzerTest >> testsingleRemoteTempVarWhileWithTempNotInlined [
 	self assert: ast scope tempVector size equals: 1.
 
 	self assert: (ast scope lookupVar: 'index') isRemote.
-	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
+	self assert: (ast scope lookupVar: 'index') scope equals: ast scope.
 	self deny: (ast scope lookupVar: 'block') isRemote
 ]
 
@@ -516,6 +516,6 @@ OCASTClosureAnalyzerTest >> testsingleRemoteTempVarWrittenAfterClosedOver [
 	self assert: ast scope tempVector size equals: 1.
 
 	self assert: (ast scope lookupVar: 'index') isRemote.
-	self assert: (ast scope lookupVar: 'index') definingScope equals: ast scope.
+	self assert: (ast scope lookupVar: 'index') scope equals: ast scope.
 	self deny: (ast scope lookupVar: 'block') isRemote
 ]

--- a/src/Slot-Tests/ArgumentVariableTest.class.st
+++ b/src/Slot-Tests/ArgumentVariableTest.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #ArgumentVariableTest,
+	#superclass : #TestCase,
+	#category : #'Slot-Tests-VariablesAndSlots'
+}
+
+{ #category : #tests }
+ArgumentVariableTest >> testDeclaringNode [
+	| method declaringNode declaringNodeViaVariable|
+	
+	method := OrderedCollection >> #do:.
+	declaringNode := method ast arguments first.
+	declaringNodeViaVariable := method ast variableReadNodes third variable variable declaringNode.
+	self assert: declaringNodeViaVariable equals: declaringNode.
+	
+	"check block argument"
+	declaringNode := method blockNodes first arguments first.
+	declaringNodeViaVariable := method ast variableReadNodes fifth variable variable declaringNode.
+	self assert: declaringNodeViaVariable equals: declaringNode.
+]

--- a/src/Slot-Tests/TemporaryVariableTest.class.st
+++ b/src/Slot-Tests/TemporaryVariableTest.class.st
@@ -8,6 +8,20 @@ Class {
 }
 
 { #category : #tests }
+TemporaryVariableTest >> testDeclaringNode [
+	| method declaringNode declaringNodeViaVariable|
+	method := self class >> #testTemporaryVariablesMethod.
+	declaringNode := method ast body temporaries first.
+	declaringNodeViaVariable := method assignmentNodes first variable variable declaringNode.
+	self assert: declaringNodeViaVariable equals: declaringNode.
+	
+	method := OrderedCollection >> #do:.
+	declaringNode := method ast arguments first.
+	declaringNodeViaVariable := method ast variableReadNodes third variable variable declaringNode.
+	self assert: declaringNodeViaVariable equals: declaringNode.
+]
+
+{ #category : #tests }
 TemporaryVariableTest >> testHasTemporaryVariablesBlock [
 	| block |
 	block := [ | b | b := 2. b +2  ].


### PR DESCRIPTION
add a query method to LocalVariable #declaringNode. It returns the AST node that declared the variables (that is, the argument in the method signature, the block arg  or the RBVariable that is in the | | temp definition in the AST.

- remove #definingScope as it is the same as scope (and just used in tests)
- add Tests