### PR TITLE
3236-isInstance-is-not-consistent-with-isClassVariable

### DIFF
--- a/src/AST-Core/RBInstanceVariableNode.class.st
+++ b/src/AST-Core/RBInstanceVariableNode.class.st
@@ -13,8 +13,3 @@ Class {
 RBInstanceVariableNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitInstanceVariableNode: self
 ]
-
-{ #category : #testing }
-RBInstanceVariableNode >> isInstance [
-	^true
-]

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -402,17 +402,17 @@ RBProgramNode >> hashForCollection: aCollection [
 
 { #category : #querying }
 RBProgramNode >> instanceVariableNodes [
-		^self variableNodes select: [:each | each isInstance]
+		^self variableNodes select: [:each | each isInstanceVariable]
 ]
 
 { #category : #querying }
 RBProgramNode >> instanceVariableReadNodes [
-		^self variableReadNodes select: [:each | each isInstance]
+		^self variableReadNodes select: [:each | each isInstanceVariable]
 ]
 
 { #category : #querying }
 RBProgramNode >> instanceVariableWriteNodes [
-		^self variableWriteNodes select: [:each | each isInstance]
+		^self variableWriteNodes select: [:each | each isInstanceVariable]
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -108,8 +108,18 @@ RBVariableNode >> isDefinition [
 ]
 
 { #category : #testing }
+RBVariableNode >> isGlobalVariable [
+	^variable isGlobalVariable
+]
+
+{ #category : #testing }
 RBVariableNode >> isImmediateNode [
 	^true
+]
+
+{ #category : #testing }
+RBVariableNode >> isInstanceVariable [
+	^variable isInstanceVariable
 ]
 
 { #category : #testing }

--- a/src/Calypso-Ring/RGMethod.extension.st
+++ b/src/Calypso-Ring/RGMethod.extension.st
@@ -90,7 +90,7 @@ RGMethod >> readsSlot: aSlot [
 	| nodes |
 	nodes := self ast allChildren.
 	nodes := nodes select: #isVariable.
-	nodes := nodes select: #isInstance.
+	nodes := nodes select: #isInstanceVariable.
 	nodes := nodes reject: [ :node | node parent isAssignment and: [ node parent variable = node ] ].
 	^ nodes anySatisfy: [ :node | node binding == aSlot ]
 ]
@@ -129,7 +129,7 @@ RGMethod >> writesSlot: aSlot [
 		node isVariable and: [
 			node parent isAssignment and: [  
 				(node parent variable = node) and: [  
-					node isInstance and: [
+					node isInstanceVariable and: [
 						(node binding ==  aSlot)
 					 		ifTrue: [^true]]]]]]. 
 	^false

--- a/src/Calypso-SystemTools-Core/ClySourceCodeContext.class.st
+++ b/src/Calypso-SystemTools-Core/ClySourceCodeContext.class.st
@@ -133,7 +133,7 @@ ClySourceCodeContext >> isVariableSelected [
 	
 	binding := node binding.
 	
-	^binding isClassVariable | binding isInstance | binding isGlobalVariable | binding isUndeclared
+	^binding isClassVariable | binding isInstanceVariable | binding isGlobalVariable | binding isUndeclared
 ]
 
 { #category : #selection }

--- a/src/ClassParser-Tests/CDExistingClassDefinitionTest.class.st
+++ b/src/ClassParser-Tests/CDExistingClassDefinitionTest.class.st
@@ -64,7 +64,7 @@ CDExistingClassDefinitionTest >> testSharedSlotNodeArePolymorphicToRBVariableNod
 	self deny: classVarNode isTemp.
 	self deny: classVarNode isGlobalVariable.
 	self assert: classVarNode isClassVariable.
-	self deny: classVarNode isInstance.
+	self deny: classVarNode isInstanceVariable.
 	self deny: classVarNode isLiteralVariable.
 	self deny: classVarNode isUndeclared.
 ]
@@ -78,7 +78,7 @@ CDExistingClassDefinitionTest >> testSlotNodeArePolymorphicToRBVariableNodes [
 	self deny: slotNode isTemp.
 	self deny: slotNode isGlobalVariable.
 	self deny: slotNode isClassVariable.
-	self assert: slotNode isInstance.
+	self assert: slotNode isInstanceVariable.
 	self deny: slotNode isLiteralVariable.
 	self deny: slotNode isUndeclared.
 ]

--- a/src/ClassParser/CDSharedVariableNode.class.st
+++ b/src/ClassParser/CDSharedVariableNode.class.st
@@ -25,7 +25,7 @@ CDSharedVariableNode >> isClassVariable [
 ]
 
 { #category : #testing }
-CDSharedVariableNode >> isInstance [
+CDSharedVariableNode >> isInstanceVariable [
 	"To be polymorphic to RB method nodes"
 	^false
 ]

--- a/src/ClassParser/CDSlotNode.class.st
+++ b/src/ClassParser/CDSlotNode.class.st
@@ -83,7 +83,7 @@ CDSlotNode >> isGlobalVariable [
 ]
 
 { #category : #testing }
-CDSlotNode >> isInstance [
+CDSlotNode >> isInstanceVariable [
 	"To be polymorphic to RB method nodes"
 	^true
 ]

--- a/src/GeneralRules/ReTestCaseShouldNotUseInitializeRule.class.st
+++ b/src/GeneralRules/ReTestCaseShouldNotUseInitializeRule.class.st
@@ -28,7 +28,7 @@ ReTestCaseShouldNotUseInitializeRule >> basicCheck: aClass [
 		ifFalse: [ ^ false ].
 	
 	alteredVariables := (aClass >> #initialize) ast allChildren 
-					select: [ :e | e isAssignment and: [ e variable isInstance ] ]
+					select: [ :e | e isAssignment and: [ e variable isInstanceVariable ] ]
 					thenCollect: [ :e | e variable ].
 	
 	expectedVariables := aClass new instanceVariablesToKeep.

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -115,7 +115,10 @@ Variable >> isClassVariable [
 
 { #category : #testing }
 Variable >> isGlobal [
-	"this will be deprecated"
+	self 
+		deprecated: 'Use #isGlobalVariable instead.' 
+		transformWith: '`@receiver isGlobal' -> '`@receiver isGlobalVariable'.
+	
 	^self isGlobalVariable
 ]
 
@@ -126,8 +129,9 @@ Variable >> isGlobalVariable [
 
 { #category : #testing }
 Variable >> isInstance [
-	"this will be deprecated"
-	^ self isInstanceVariable
+	self 
+		deprecated: 'Use #isInstanceVariable instead.' 
+		transformWith: '`@receiver isInstance' -> '`@receiver isInstanceVariable'.
 ]
 
 { #category : #testing }
@@ -145,8 +149,9 @@ Variable >> isLiteralVariable [
 
 { #category : #testing }
 Variable >> isLocal [
-	"this will be deprecated"
-	^self isLocalVariable
+	self 
+		deprecated: 'Use #isLocalVariable instead.' 
+		transformWith: '`@receiver isLocal' -> '`@receiver isLocalVariable'.
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Core/RBVariableNode.extension.st
+++ b/src/OpalCompiler-Core/RBVariableNode.extension.st
@@ -21,7 +21,7 @@ RBVariableNode >> isArg [
 
 { #category : #'*opalcompiler-core' }
 RBVariableNode >> isClean [
-	^ (self isInstance | self isReservedVariable) not
+	^ (self isInstanceVariable | self isReservedVariable) not
 ]
 
 { #category : #'*opalcompiler-core' }
@@ -32,7 +32,10 @@ RBVariableNode >> isGlobal [
 
 { #category : #'*opalcompiler-core' }
 RBVariableNode >> isInstance [
-	^self binding isInstance
+	self 
+		deprecated: 'Use #isInstanceVariable instead.' 
+		transformWith: '`@receiver isInstance' -> '`@receiver isInstanceVariable'.
+	^variable isInstanceVariable
 ]
 
 { #category : #'*opalcompiler-core' }

--- a/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
@@ -136,10 +136,10 @@ OCASTCheckerTest >> testInstanceVar [
 	self assertEmpty: ast scope tempVars.
 
 	self assert: ast scope outerScope isInstanceScope.
-	self assert: (ast scope outerScope lookupVar: 'iVar') isInstance.
+	self assert: (ast scope outerScope lookupVar: 'iVar') isInstanceVariable.
 
 	assignment := RBParseTreeSearcher treeMatching: '`var := ``@anything' in: ast.
-	self assert: assignment variable isInstance
+	self assert: assignment variable isInstanceVariable
 ]
 
 { #category : #'testing - variables' }
@@ -307,9 +307,9 @@ OCASTCheckerTest >> testSingleRemoteTempVar [
 	self assert: (ast scope lookupVar: 'theCollection') isEscaping.
 	self assert: (ast scope lookupVar: 'block') isTemp.
 	self assert: (ast scope lookupVar: 'theCollection') isTemp.
-	self deny: (ast scope lookupVar: 'theCollection') isInstance.
-	self deny: (ast scope lookupVar: 'index') isInstance.
-	self deny: (ast scope lookupVar: 'block') isInstance
+	self deny: (ast scope lookupVar: 'theCollection') isInstanceVariable.
+	self deny: (ast scope lookupVar: 'index') isInstanceVariable.
+	self deny: (ast scope lookupVar: 'block') isInstanceVariable
 ]
 
 { #category : #'testing - variables' }

--- a/src/Reflectivity/RFOperationReification.class.st
+++ b/src/Reflectivity/RFOperationReification.class.st
@@ -30,7 +30,7 @@ RFOperationReification >> genForRBAssignmentNode [
 			context: thisContext;
 			variableName: #{1}.' format: {entity variable name})].
 		
-	entity variable isInstance ifTrue: [  
+	entity variable isInstanceVariable ifTrue: [  
 		^RBParser parseExpression: ('RFSlotWrite new
 			assignedValue: RFNewValueReificationVar; 
 			object: self;
@@ -99,7 +99,7 @@ RFOperationReification >> genForRBReturnNode [
 
 { #category : #generate }
 RFOperationReification >> genForRBVariableNode [
-	entity isInstance ifTrue: [  
+	entity isInstanceVariable ifTrue: [  
 		^RBParser parseExpression: ('RFSlotRead new 
 			object: self;
 			variableName: #{1}.' format: {entity name})].

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1025,7 +1025,7 @@ SHRBTextStyler >> resolveStyleFor: aVariableNode [
 	aVariableNode isArgument ifTrue: [ ^#methodArg].
 	aVariableNode isTemp ifTrue: [ ^#tempVar].
 	aVariableNode isGlobal ifTrue: [ ^#globalVar].
-	aVariableNode isInstance ifTrue: [ ^#instVar]. 
+	aVariableNode isInstanceVariable ifTrue: [ ^#instVar]. 
 	
 	(self class formatIncompleteIdentifiers and: [ aVariableNode hasIncompleteIdentifier ]) 
 		ifTrue:[ ^#incompleteIdentifier] .


### PR DESCRIPTION
- add isInstanceVariable and isGlobalVariable to RBVariable
- fix all senders of isInstance to call isInstanceVariable
- deprecate isInstance on RBVariableNode
- deprecate isInstance, isGlobal and isLocal on Variable

fixes #3236