### PR TITLE
6817-testUnixRandomGeneratorSeed-run-on-Linux-CI-takes-nearly-3-minutes

### DIFF
--- a/src/Random-Tests/RandomTest.class.st
+++ b/src/Random-Tests/RandomTest.class.st
@@ -73,6 +73,8 @@ RandomTest >> testNextInto [
 
 { #category : #tests }
 RandomTest >> testUnixRandomGeneratorSeed [
+	"the test is very slow on the CI (>2 minutes)"
+	self skipOnPharoCITestingEnvironment.
 	gen useUnixRandomGeneratorSeed.
 	100 timesRepeat: [ | next |
 			next := gen next.


### PR DESCRIPTION
skip testUnixRandomGeneratorSeed on the CI. fixes #6817