### PR TITLE
6836-DefinitionForNautilus-is-deprecated-so-we-should-remove-it-

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -467,20 +467,6 @@ Class >> definesClassVariableNamed: aString [
 	^ self classVarNames includes: aString
 ]
 
-{ #category : #accessing }
-Class >> definitionForNautilus [
-	"Answer a String that defines the receiver."
-
-	self 
-		deprecated: 'Use #definition instead.' 
-		on: '2019-05-14'
-		in: #Pharo8
-		transformWith: '`@receiver definitionForNautilus' 
-						-> '`@receiver definition'.
-						
-	^ self definition
-]
-
 { #category : #deprecation }
 Class >> deprecationRefactorings [
 

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -582,12 +582,6 @@ ClassDescription >> definition [
 	
 ]
 
-{ #category : #accessing }
-ClassDescription >> definitionForNautilus [
-
-	^ self definition
-]
-
 { #category : #'file in/out' }
 ClassDescription >> definitionWithSlots [
 	"The class definition with a way to specify slots. Shown when the class defines special Slot"

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -432,12 +432,6 @@ RGBehavior >> defaultTraitComposition [
 	^ self defaultTraitCompositionStubIn: self.
 ]
 
-{ #category : #'accessing - definition' }
-RGBehavior >> definitionForNautilus [
-
-	^ self definition
-]
-
 { #category : #'queries - methods' }
 RGBehavior >> ensureLocalMethodNamed: aSymbol [
 

--- a/src/Ring-Tests-Core/RGClassStrategyTest.class.st
+++ b/src/Ring-Tests-Core/RGClassStrategyTest.class.st
@@ -65,18 +65,6 @@ RGClassStrategyTest >> testDefinition [
 ]
 
 { #category : #tests }
-RGClassStrategyTest >> testDefinitionForNautilus [
-
-	| aClass |
-	
-	aClass := RGClass named: #SomeClass.
-	aClass superclass name: #Object.
-	
-	self assert: (aClass definitionForNautilus beginsWith: 'Object subclass: #SomeClass')	
-
-]
-
-{ #category : #tests }
 RGClassStrategyTest >> testDefinitionWithSlots [
 
 	| aClass slot expression |


### PR DESCRIPTION
- remove testDefinitionForNautilus
- remove definitionForNautilus

The API method was alrady deprecated in Pharo8, so we can just delete all implementors. fixes #6836



definitionForNautilus
	"Answer a String that defines the receiver."

	self 
		deprecated: 'Use #definition instead.' 
		on: '2019-05-14'
		in: #Pharo8
		transformWith: '`@receiver definitionForNautilus' 
						-> '`@receiver definition'.
						
	^ self definition