### PR TITLE
Slot-speedup-isReferenced

### DIFF
--- a/src/Kernel/AdditionalBinding.class.st
+++ b/src/Kernel/AdditionalBinding.class.st
@@ -28,3 +28,8 @@ AdditionalBinding >> emitValue: methodBuilder [
 
 	methodBuilder pushLiteralVariable: self.
 ]
+
+{ #category : #testing }
+AdditionalBinding >> isReferenced [
+	^ false
+]

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -846,6 +846,14 @@ Behavior >> hasMethods [
 ]
 
 { #category : #'testing method dictionary' }
+Behavior >> hasMethodsAccessingSlot: aSlot [
+	"check if aSlot is accessed in this class or subclasses"
+
+	^ self withAllSubclasses anySatisfy: [ :class | 
+		  class methods anySatisfy: [ :method | aSlot isAccessedIn: method ] ]
+]
+
+{ #category : #'testing method dictionary' }
 Behavior >> hasSelectorReferringTo: literal [
 	"Answer true if any of my methods access the argument as a literal"
 

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -847,10 +847,9 @@ Behavior >> hasMethods [
 
 { #category : #'testing method dictionary' }
 Behavior >> hasMethodsAccessingSlot: aSlot [
-	"check if aSlot is accessed in this class or subclasses"
+	"check if aSlot is accessed in this class"
 
-	^ self withAllSubclasses anySatisfy: [ :class | 
-		  class methods anySatisfy: [ :method | aSlot isAccessedIn: method ] ]
+	^ self methods anySatisfy: [ :method | aSlot isAccessedIn: method ]
 ]
 
 { #category : #'testing method dictionary' }

--- a/src/Kernel/ClassVariable.class.st
+++ b/src/Kernel/ClassVariable.class.st
@@ -68,7 +68,7 @@ ClassVariable >> isReferenced [
 	"A class variable can only be accessed in the defintionClass and its subclasses (both class and instance side)"
 
 	^ self definingClass withAllSubclasses anySatisfy: [ :behavior | 
-		  (behavior hasSelectorReferringTo: self) or: [ behavior class hasSelectorReferringTo: self ] ]
+		  (behavior class hasSelectorReferringTo: self) or: [ behavior hasSelectorReferringTo: self ] ]
 ]
 
 { #category : #testing }

--- a/src/Kernel/ClassVariable.class.st
+++ b/src/Kernel/ClassVariable.class.st
@@ -68,8 +68,7 @@ ClassVariable >> isReferenced [
 	"A class variable can only be accessed in the defintionClass and its subclasses (both class and instance side)"
 
 	^ self definingClass withAllSubclasses anySatisfy: [ :behavior | 
-		  behavior hasSelectorReferringTo: self.
-		  behavior class hasSelectorReferringTo: self ]
+		  (behavior hasSelectorReferringTo: self) or: [ behavior class hasSelectorReferringTo: self ] ]
 ]
 
 { #category : #testing }

--- a/src/Kernel/ClassVariable.class.st
+++ b/src/Kernel/ClassVariable.class.st
@@ -65,10 +65,11 @@ ClassVariable >> isDefinedByOwningClass [
 
 { #category : #testing }
 ClassVariable >> isReferenced [
- 	"A class variable can only be accessed in the defintionClass and its subclasses (both class and instance side)"
- 	
-	^ self definingClass withAllSubclasses
- 		anySatisfy: [ :behavior | behavior hasSelectorReferringTo: self . behavior class hasSelectorReferringTo: self ]
+	"A class variable can only be accessed in the defintionClass and its subclasses (both class and instance side)"
+
+	^ self definingClass withAllSubclasses anySatisfy: [ :behavior | 
+		  behavior hasSelectorReferringTo: self.
+		  behavior class hasSelectorReferringTo: self ]
 ]
 
 { #category : #testing }

--- a/src/Kernel/GlobalVariable.class.st
+++ b/src/Kernel/GlobalVariable.class.st
@@ -36,10 +36,3 @@ GlobalVariable >> isGlobal [
 GlobalVariable >> isGlobalVariable [
 	^true
 ]
-
-{ #category : #testing }
-GlobalVariable >> isReferenced [
- 	"A Global could be referenced from any method"
- 	^Smalltalk globals allBehaviors
- 		anySatisfy: [ :behavior | behavior hasSelectorReferringTo: self ]
-]

--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -131,8 +131,10 @@ LiteralVariable >> isReadIn: aCompiledCode [
 
 { #category : #testing }
 LiteralVariable >> isReferenced [
-	"my subclasses override this if they can be referenced in code"
-	^false
+	"my subclasses override this if they know better"
+
+	^ Smalltalk globals allBehaviors anySatisfy: [ :behavior | 
+		  behavior hasSelectorReferringTo: self ]
 ]
 
 { #category : #queries }

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -229,6 +229,13 @@ Slot >> isReadIn: aCompiledCode [
 ]
 
 { #category : #testing }
+Slot >> isReferenced [
+	^ self owningClass 
+		ifNil: [ false ]
+		ifNotNil: [:class | class hasMethodsAccessingSlot: self]
+]
+
+{ #category : #testing }
 Slot >> isSelfEvaluating [
 	^true
 ]

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -231,8 +231,9 @@ Slot >> isReadIn: aCompiledCode [
 { #category : #testing }
 Slot >> isReferenced [
 	^ self owningClass 
-		ifNil: [ false ]
-		ifNotNil: [:class | class hasMethodsAccessingSlot: self]
+		ifNil: [ false ] 
+		ifNotNil: [ :class | 
+		  class withAllSubclasses anySatisfy: [ :behavior | class hasMethodsAccessingSlot: self ] ]
 ]
 
 { #category : #testing }

--- a/src/Kernel/UndeclaredVariable.class.st
+++ b/src/Kernel/UndeclaredVariable.class.st
@@ -45,13 +45,6 @@ UndeclaredVariable >> emitValue: methodBuilder [
 	methodBuilder pushLiteralVariable: self
 ]
 
-{ #category : #testing }
-UndeclaredVariable >> isReferenced [
- 	"A Undeclared could be referenced from any method"
- 	^Smalltalk globals allBehaviors
- 		anySatisfy: [ :behavior | behavior hasSelectorReferringTo: self ]
-]
-
 { #category : #registry }
 UndeclaredVariable >> isRegistered [ 
 	^Undeclared includesKey: name

--- a/src/Kernel/WorkspaceVariable.class.st
+++ b/src/Kernel/WorkspaceVariable.class.st
@@ -20,3 +20,8 @@ WorkspaceVariable >> emitValue: methodBuilder [
 
 	methodBuilder pushLiteralVariable: self.
 ]
+
+{ #category : #testing }
+WorkspaceVariable >> isReferenced [
+	^ false
+]

--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -135,7 +135,7 @@ LocalVariable >> isRead [
 
 { #category : #testing }
 LocalVariable >> isReferenced [
-	^self isUnused not
+	^ self isUnused not
 ]
 
 { #category : #testing }

--- a/src/System-Support/Class.extension.st
+++ b/src/System-Support/Class.extension.st
@@ -4,5 +4,5 @@ Extension { #name : #Class }
 Class >> allUnreferencedClassVariables [
 	"Answer a list of the names of all the receiver's unreferenced class vars, including those defined in superclasses"
 
-	^ self allClassVariables reject: #isReferenced
+	^ self allClassVariables reject: [ :slot | slot isReferenced ]
 ]


### PR DESCRIPTION
isReferenced of Slot uses the default implementation which gets all using methods.
But we just need to detect the first one and can stop.

Test is already there (testIsReferenced)

Speedup:
	
[(Point slotNamed: #x) isReferenced] bench 

"'7979.013 per second'" 
"'204659.136 per second'"

- im additon clean up isReferenced implementations a little