### PR TITLE
speedup-ReVariableReferencedOnceRule

### DIFF
--- a/src/GeneralRules/ReVariableReferencedOnceRule.class.st
+++ b/src/GeneralRules/ReVariableReferencedOnceRule.class.st
@@ -21,21 +21,13 @@ ReVariableReferencedOnceRule class >> uniqueIdentifierName [
 
 { #category : #running }
 ReVariableReferencedOnceRule >> basicCheck: aClass [
-	^ aClass instVarNames
-		anySatisfy: [ :each | 
-			| defClass selector |
-			(aClass withAllSubclasses
-				inject: 0
-				into: [ :sum :class | 
-					| sels |
-					sels := class whichSelectorsAccess: each.
-					sels size == 1
-						ifTrue: [ selector := sels asArray first.
-							defClass := class ].
-					sum + sels size ]) == 1
-				and: [ | tree |
-					tree := defClass parseTreeFor: selector.
-					tree notNil and: [ RBReadBeforeWrittenTester isVariable: each writtenBeforeReadIn: tree ] ] ]
+	^ aClass slots anySatisfy: [ :slot | 
+		  | usingMethods |
+		  usingMethods := slot usingMethods.
+		  usingMethods size = 1 and: [ 
+			  RBReadBeforeWrittenTester
+				  isVariable: slot name
+				  writtenBeforeReadIn: usingMethods first ast ] ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
simpify ReVariableReferencedOnceRule by using #usingMethods. Faster even though we iterate to find all methods, not just the first.