### PR TITLE
Ring2-cleanup-remove-isVariableDefinition

### DIFF
--- a/src/Ring-Core/RGClassStrategy.class.st
+++ b/src/Ring-Core/RGClassStrategy.class.st
@@ -555,7 +555,7 @@ RGClassStrategy >> sharedPools [
 		each isSymbol 
 			ifTrue: [ self environment ask behaviorNamed: each name ]
 			ifFalse: [ 
-				(each isVariableDefinition and: [each isPoolVariable ])
+				(each isVariable and: [each isPoolVariable ])
 					ifTrue: [ 
 						| beh | 
 						beh := self environment ask behaviorNamed: each name.

--- a/src/Ring-Core/RGObject.class.st
+++ b/src/Ring-Core/RGObject.class.st
@@ -462,8 +462,11 @@ RGObject >> isVariable [
 
 { #category : #'testing types' }
 RGObject >> isVariableDefinition [
-
-	^ false
+	self 
+		deprecated: 'Use #isVariable instead.' 
+		transformWith: '`@receiver isVariableDefinition' -> '`@receiver isVariable'.
+	
+	^ self isVariable
 ]
 
 { #category : #resolving }

--- a/src/Ring-Core/RGTraitV2Strategy.class.st
+++ b/src/Ring-Core/RGTraitV2Strategy.class.st
@@ -550,7 +550,7 @@ RGTraitV2Strategy >> sharedPools [
 		each isSymbol 
 			ifTrue: [ self environment ask behaviorNamed: each name ]
 			ifFalse: [ 
-				(each isVariableDefinition and: [each isPoolVariable ])
+				(each isVariable and: [each isPoolVariable ])
 					ifTrue: [ 
 						| beh | 
 						beh := self environment ask behaviorNamed: each name.

--- a/src/Ring-Core/RGVariable.class.st
+++ b/src/Ring-Core/RGVariable.class.st
@@ -61,12 +61,6 @@ RGVariable >> isUninitialized [
 	^false
 ]
 
-{ #category : #testing }
-RGVariable >> isVariableDefinition [
-
-	^ true
-]
-
 { #category : #accessing }
 RGVariable >> name: aString [
 

--- a/src/Ring-Core/RGVariable.class.st
+++ b/src/Ring-Core/RGVariable.class.st
@@ -61,6 +61,11 @@ RGVariable >> isUninitialized [
 	^false
 ]
 
+{ #category : #testing }
+RGVariable >> isVariable [
+	^true
+]
+
 { #category : #accessing }
 RGVariable >> name: aString [
 

--- a/src/Ring-Tests-Core/RGClassVariableTest.class.st
+++ b/src/Ring-Tests-Core/RGClassVariableTest.class.st
@@ -29,7 +29,7 @@ RGClassVariableTest >> testNewClassVariable [
 	classVariable  := RGClassVariable unnamed.
 	self assert: (classVariable isRingResolved).
 	self assert: (classVariable hasUnresolved: #name).
-	self assert: (classVariable isVariableDefinition).
+	self assert: (classVariable isVariable).
 	self assert: (classVariable isClassVariable).	
 	self deny: (classVariable isPoolVariable).	
 

--- a/src/Ring-Tests-Core/RGObjectTest.class.st
+++ b/src/Ring-Tests-Core/RGObjectTest.class.st
@@ -143,7 +143,7 @@ RGObjectTest >> testTypes [
 	self deny: def isTraitComposition.
 	self deny: def isTraitExclusion.
 	self deny: def isTraitTransformation.
-	self deny: def isVariableDefinition.
+	self deny: def isVariable.
 
 ]
 


### PR DESCRIPTION
Ring2 has #isVariableDefinition, which is the same as #isVariable. To unify the API with the main system, this PR deprecates isVariableDefinition