### PR TITLE
Variables-SmallCleanups

### DIFF
--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -424,7 +424,7 @@ RBProgramNode >> intersectsInterval: anInterval [
 { #category : #testing }
 RBProgramNode >> isArgument [
 	self 
-		deprecated: 'Use #isArgument instead.' 
+		deprecated: 'Use #isArgumentVariable instead.' 
 		transformWith: '`@receiver isArgument' -> '`@receiver isArgumentVariable'.
 	
 	^ self isArgumentVariable

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -105,11 +105,7 @@ RBVariableNode >> isArgumentVariable [
 { #category : #testing }
 RBVariableNode >> isDefinition [
 	"Check if I am a Variable defintion"
-	self parent isSequence
-		ifTrue: [ ^ self parent temporaries identityIncludes: self ].
-	(self parent isMethod or: [ self parent isBlock ])
-		ifTrue: [ ^ self parent arguments identityIncludes: self ].
-	^ false
+	^variable definingNode == self
 ]
 
 { #category : #testing }

--- a/src/Calypso-Ring/RGMethod.extension.st
+++ b/src/Calypso-Ring/RGMethod.extension.st
@@ -88,9 +88,7 @@ RGMethod >> readsRef: literalAssociation [
 { #category : #'*Calypso-Ring' }
 RGMethod >> readsSlot: aSlot [
 	| nodes |
-	nodes := self ast allChildren.
-	nodes := nodes select: #isVariable.
-	nodes := nodes select: #isInstanceVariable.
+	nodes := self ast instanceVariableNodes select: [:each | each isInstanceVariable].
 	nodes := nodes reject: [ :node | node parent isAssignment and: [ node parent variable = node ] ].
 	^ nodes anySatisfy: [ :node | node binding == aSlot ]
 ]

--- a/src/Calypso-SystemTools-Core/ClySourceCodeContext.class.st
+++ b/src/Calypso-SystemTools-Core/ClySourceCodeContext.class.st
@@ -125,15 +125,12 @@ ClySourceCodeContext >> isTempVariableSelected [
 
 { #category : #testing }
 ClySourceCodeContext >> isVariableSelected [
-	| node binding |
-	self isClassSelected ifTrue: [ ^false ].
-	
+	| node |
+	self isClassSelected ifTrue: [ ^ false ].
 	node := self selectedSourceNode.
-	node isVariable ifFalse: [ ^false ].
+	node isVariable ifFalse: [ ^ false ].
 	
-	binding := node binding.
-	
-	^binding isClassVariable | binding isInstanceVariable | binding isGlobalVariable | binding isUndeclared
+	^ node variable isLiteralVariable | node variable isLiteralVariable
 ]
 
 { #category : #selection }

--- a/src/Calypso-SystemTools-Core/ClySourceCodeContext.class.st
+++ b/src/Calypso-SystemTools-Core/ClySourceCodeContext.class.st
@@ -130,7 +130,7 @@ ClySourceCodeContext >> isVariableSelected [
 	node := self selectedSourceNode.
 	node isVariable ifFalse: [ ^ false ].
 	
-	^ node variable isLiteralVariable | node variable isLiteralVariable
+	^ node variable isLiteralVariable | node variable isInstanceVariable
 ]
 
 { #category : #selection }

--- a/src/GeneralRules-Tests/ReSuperWithoutSendTest.class.st
+++ b/src/GeneralRules-Tests/ReSuperWithoutSendTest.class.st
@@ -9,10 +9,13 @@ ReSuperWithoutSendTest >> testBasicCheck [
 
 	| ast |
 	ast :=  self class compiler parse: 'testMethod ^super'.
+	ast doSemanticAnalysis.
 	self assert: (ReSuperWithoutSend new basicCheck: ast variableNodes first).
 	self deny: (ReSuperWithoutSend new basicCheck: ast statements first).
 	ast := self class compiler parse: 'testMethod ^ super doit'.
+	ast doSemanticAnalysis.
 	self deny: (ReSuperWithoutSend new basicCheck: ast variableNodes first).
 	ast := self class compiler parse: 'testMethod ^ self doit: super'.
+	ast doSemanticAnalysis.
 	self assert: (ReSuperWithoutSend new basicCheck: ast variableNodes second).
 ]

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -963,10 +963,9 @@ Behavior >> instVarNames [
 
 	| mySize superSize |
 	mySize := self instSize.
-	superSize := 
-		self superclass == nil
-			ifTrue: [0]
-			ifFalse: [self superclass instSize].
+	superSize := self superclass
+			ifNil: [0]
+			ifNotNil: [self superclass instSize].
 	mySize = superSize ifTrue: [^#()].	
 	^(superSize + 1 to: mySize) collect: [:i | 'inst' , i printString]
 ]
@@ -980,6 +979,12 @@ Behavior >> instanceCount [
 	count := 0.
 	self allInstancesDo: [:x | count := count + 1].
 	^count
+]
+
+{ #category : #'accessing instances and variables' }
+Behavior >> instanceVariables [
+	"in older version, this method was returning names, not objects"
+	^self slots
 ]
 
 { #category : #'memory usage' }

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -242,11 +242,6 @@ Slot >> isSelfEvaluating [
 ]
 
 { #category : #testing }
-Slot >> isSlot [
-	^ true
-]
-
-{ #category : #testing }
 Slot >> isVirtual [
 	"virtual slots do not take up space in the object and have size = 0"
 	^true

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -63,6 +63,11 @@ Variable >> = other [
 			and: [ name = other name ]
 ]
 
+{ #category : #queries }
+Variable >> definingNode [
+	^ nil
+]
+
 { #category : #'code generation' }
 Variable >> emitStore: methodBuilder [
 
@@ -132,6 +137,7 @@ Variable >> isInstance [
 	self 
 		deprecated: 'Use #isInstanceVariable instead.' 
 		transformWith: '`@receiver isInstance' -> '`@receiver isInstanceVariable'.
+	 ^self isInstanceVariable
 ]
 
 { #category : #testing }
@@ -180,12 +186,6 @@ Variable >> isSelf [
 Variable >> isSelfOrSuper [
 	
 	^ self isSelf or: [ self isSuper ]
-]
-
-{ #category : #testing }
-Variable >> isSlot [
-	"check if the var is an instance variable (a Slot)"
-	^false
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Core/ArgumentVariable.class.st
+++ b/src/OpalCompiler-Core/ArgumentVariable.class.st
@@ -14,7 +14,7 @@ ArgumentVariable class >> semanticNodeClass [
 ]
 
 { #category : #queries }
-ArgumentVariable >> declaringNode [
+ArgumentVariable >> definingNode [
 	^ scope node arguments detect: [ :each | each name = name ]
 ]
 

--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -40,11 +40,6 @@ LocalVariable >> astNodes [
 	^scope node methodNode variableNodes select: [ :each | each binding == self]
 ]
 
-{ #category : #queries }
-LocalVariable >> definingNode [
-	^ self subclassResponsibility
-]
-
 { #category : #emitting }
 LocalVariable >> emitStore: methodBuilder [
 

--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -41,7 +41,7 @@ LocalVariable >> astNodes [
 ]
 
 { #category : #queries }
-LocalVariable >> declaringNode [
+LocalVariable >> definingNode [
 	^ self subclassResponsibility
 ]
 

--- a/src/OpalCompiler-Core/RBVariableNode.extension.st
+++ b/src/OpalCompiler-Core/RBVariableNode.extension.st
@@ -13,7 +13,7 @@ RBVariableNode >> binding: aSemVar [
 { #category : #'*opalcompiler-core' }
 RBVariableNode >> isArg [
 	self 
-		deprecated: 'Use #isArgument instead.' 
+		deprecated: 'Use #isArgumentVariable instead.' 
 		transformWith: '`@receiver isArg' -> '`@receiver isArgumentVariable'.
 	
 	^ self isArgumentVariable

--- a/src/OpalCompiler-Core/TemporaryVariable.class.st
+++ b/src/OpalCompiler-Core/TemporaryVariable.class.st
@@ -14,7 +14,7 @@ TemporaryVariable class >> semanticNodeClass [
 ]
 
 { #category : #queries }
-TemporaryVariable >> declaringNode [
+TemporaryVariable >> definingNode [
 	^ scope node temporaries detect: [ :each | each name = name ]
 ]
 

--- a/src/Slot-Tests/ArgumentVariableTest.class.st
+++ b/src/Slot-Tests/ArgumentVariableTest.class.st
@@ -10,11 +10,11 @@ ArgumentVariableTest >> testDeclaringNode [
 	
 	method := OrderedCollection >> #do:.
 	declaringNode := method ast arguments first.
-	declaringNodeViaVariable := method ast variableReadNodes third variable variable declaringNode.
+	declaringNodeViaVariable := method ast variableReadNodes third variable variable definingNode.
 	self assert: declaringNodeViaVariable equals: declaringNode.
 	
 	"check block argument"
 	declaringNode := method blockNodes first arguments first.
-	declaringNodeViaVariable := method ast variableReadNodes fifth variable variable declaringNode.
+	declaringNodeViaVariable := method ast variableReadNodes fifth variable variable definingNode.
 	self assert: declaringNodeViaVariable equals: declaringNode.
 ]

--- a/src/Slot-Tests/TemporaryVariableTest.class.st
+++ b/src/Slot-Tests/TemporaryVariableTest.class.st
@@ -12,12 +12,12 @@ TemporaryVariableTest >> testDeclaringNode [
 	| method declaringNode declaringNodeViaVariable|
 	method := self class >> #testTemporaryVariablesMethod.
 	declaringNode := method ast body temporaries first.
-	declaringNodeViaVariable := method assignmentNodes first variable variable declaringNode.
+	declaringNodeViaVariable := method assignmentNodes first variable variable definingNode.
 	self assert: declaringNodeViaVariable equals: declaringNode.
 	
 	method := OrderedCollection >> #do:.
 	declaringNode := method ast arguments first.
-	declaringNodeViaVariable := method ast variableReadNodes third variable variable declaringNode.
+	declaringNodeViaVariable := method ast variableReadNodes third variable variable definingNode.
 	self assert: declaringNodeViaVariable equals: declaringNode.
 ]
 

--- a/src/System-Support/Class.extension.st
+++ b/src/System-Support/Class.extension.st
@@ -4,5 +4,5 @@ Extension { #name : #Class }
 Class >> allUnreferencedClassVariables [
 	"Answer a list of the names of all the receiver's unreferenced class vars, including those defined in superclasses"
 
-	^ self allClassVariables reject: [ :slot | slot isReferenced ]
+	^ self allClassVariables reject: [ :classVar | classVar isReferenced ]
 ]

--- a/src/VariablesLibrary/ObservableSlot.class.st
+++ b/src/VariablesLibrary/ObservableSlot.class.st
@@ -60,11 +60,6 @@ ObservableSlot >> initialize: anObject [
 	super write: ObservableValueHolder new to: anObject
 ]
 
-{ #category : #testing }
-ObservableSlot >> isObservable [
-	^ true
-]
-
 { #category : #'meta-object-protocol' }
 ObservableSlot >> rawRead: anObject [
 	^ super read: anObject

--- a/src/VariablesLibrary/Slot.extension.st
+++ b/src/VariablesLibrary/Slot.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #Slot }
-
-{ #category : #'*VariablesLibrary' }
-Slot >> isObservable [
-	"Return true for observable slots."
-
-	^ false
-]

--- a/src/VariablesLibrary/TObservable.trait.st
+++ b/src/VariablesLibrary/TObservable.trait.st
@@ -38,7 +38,7 @@ TObservable >> notifyPropertyChanged: aName [
 TObservable >> observablePropertyNamed: aName [
 	| slot |
 	slot := self class slotNamed: aName.
-	slot isObservable ifFalse: [ NonObservableSlotError signal: aName ].
+	(slot class == ObservableSlot) ifFalse: [ NonObservableSlotError signal: aName ].
 
 	"Obtain the raw value.
 	We need to access the underlying value holder to subscribe to it"


### PR DESCRIPTION
- fix some tiny mistakes of the last PRs
- rename declaringNode to definingNode
- implement isDefinition in terms of definingNode
- add #instanceVariables to Behavior returning Slots
- remove #isSlot introduces in the Variable hierarhchy (we have isInstanceVariable)
- remove #isObservable: Slot users should not add extension method if it an be avoided