### PR TITLE
reduce-usage-RBVariableNode-subclasses

### DIFF
--- a/src/AST-Core-Tests/RBDumpVisitorTest.class.st
+++ b/src/AST-Core-Tests/RBDumpVisitorTest.class.st
@@ -132,7 +132,7 @@ RBDumpVisitorTest >> testGlobalNodeDump [
 	node := self parseMethod: 'foo ^ Object'.
 	dumpedNode := Smalltalk compiler evaluate: node doSemanticAnalysis dump.
 	
-	self assert: dumpedNode statements first value class equals: RBGlobalNode. 
+	self assert: dumpedNode statements first value isGlobal.
 	self assert: node class equals: dumpedNode class.
 	self assert: node printString equals: dumpedNode printString.
 	
@@ -279,7 +279,7 @@ RBDumpVisitorTest >> testSelfNodeDump [
 	node := self parseExpression: 'self'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
-	self assert: dumpedNode class equals: RBSelfNode. 
+	self assert: dumpedNode isSelf.
 	self assert: node class equals: dumpedNode class.
 	self assert: node printString equals: dumpedNode printString.
 	
@@ -305,7 +305,7 @@ RBDumpVisitorTest >> testSuperNodeDump [
 	node := self parseExpression: 'super'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
-	self assert: dumpedNode class equals: RBSuperNode. 
+	self assert: dumpedNode isSuper.
 	self assert: node class equals: dumpedNode class.
 	self assert: node printString equals: dumpedNode printString.
 	

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser-Tests/ClyInstallMetaLinkPresenterTest.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser-Tests/ClyInstallMetaLinkPresenterTest.class.st
@@ -36,7 +36,7 @@ ClyInstallMetaLinkPresenterTest >> presenterForMetalinkUninstallation [
 ClyInstallMetaLinkPresenterTest >> setUp [
 	super setUp.
 	MetaLink uninstallAll.
-	node := RBTemporaryNode named: 'test'.
+	node := RBVariableNode named: 'test'.
 	metalink := MetaLink new.
 	metalink2 := MetaLink new.
 	breakpoint := MetaLink new metaObject: Break; yourself.

--- a/src/OpalCompiler-Tests/OCVariableSpecialisationTest.class.st
+++ b/src/OpalCompiler-Tests/OCVariableSpecialisationTest.class.st
@@ -3,19 +3,3 @@ Class {
 	#superclass : #TestCase,
 	#category : #'OpalCompiler-Tests-Misc'
 }
-
-{ #category : #tests }
-OCVariableSpecialisationTest >> testVarTemp [
-	| sequenceNode returnNode |
-	sequenceNode := RBParser parseExpression: '| t1 t2 t3 | t1 := 1. t2 := 2. t3 := 3. ^t2'.
-	returnNode := sequenceNode statements last.
-
-	"before semantic analysis, this is just a variableNode"
-	self assert: returnNode value class identicalTo: RBVariableNode.
-	self deny: returnNode value class identicalTo: RBTemporaryNode.
-
-	sequenceNode doSemanticAnalysis.
-	"after, it is specialized to a temporary"
-	returnNode := sequenceNode statements last.
-	self assert: returnNode value class identicalTo: RBTemporaryNode
-]

--- a/src/Reflectivity/RFArgumentsReification.class.st
+++ b/src/Reflectivity/RFArgumentsReification.class.st
@@ -19,17 +19,17 @@ RFArgumentsReification class >> key [
 
 { #category : #generate }
 RFArgumentsReification >> genForRBMessageNode [
-	^RBTemporaryNode named: self varName.
+	^RBVariableNode named: self varName.
 ]
 
 { #category : #generate }
 RFArgumentsReification >> genForRBMethodNode [
-	^RBTemporaryNode named: self varName.
+	^RBVariableNode named: self varName.
 ]
 
 { #category : #generate }
 RFArgumentsReification >> genForRBSequenceNode [
-	^RBTemporaryNode named: self varName.
+	^RBVariableNode named: self varName.
 ]
 
 { #category : #preamble }
@@ -47,7 +47,7 @@ RFArgumentsReification >> preambleForMessage: aNode [
 	(1 to: aNode numArgs) withIndexDo: [:each :index |  
 			| name |
 			name := 'RFArg', index asString, 'RFReification'.
-			arguments add:  (RBTemporaryNode named: name).
+			arguments add:  (RBVariableNode named: name).
 	].
 	preamble addAll: (RBArrayNode statements: arguments).
 	preamble add: (RFStorePopIntoTempNode named: self varName).
@@ -59,7 +59,7 @@ RFArgumentsReification >> preambleForMessage: aNode [
 RFArgumentsReification >> preambleForMethod: aNode [
 	| preamble arguments |
 	preamble := OrderedCollection new.
-	arguments := aNode argumentNames collect: [ :name | RBTemporaryNode named: name].
+	arguments := aNode argumentNames collect: [ :name | RBVariableNode named: name].
 	preamble addAll: (RBArrayNode statements: arguments).
 	preamble add: (RFStorePopIntoTempNode named: self varName).
 	^ preamble 
@@ -69,7 +69,7 @@ RFArgumentsReification >> preambleForMethod: aNode [
 RFArgumentsReification >> preambleSequence: aNode [
 	| preamble arguments |
 	preamble := OrderedCollection new.
-	arguments := aNode parent argumentNames collect: [ :name | RBTemporaryNode named: name].
+	arguments := aNode parent argumentNames collect: [ :name | RBVariableNode named: name].
 	preamble addAll: (RBArrayNode statements: arguments).
 	preamble add: (RFStorePopIntoTempNode named: self varName).
 	^ preamble 

--- a/src/Reflectivity/RFMethodToExecuteReification.class.st
+++ b/src/Reflectivity/RFMethodToExecuteReification.class.st
@@ -22,7 +22,7 @@ RFMethodToExecuteReification class >> key [
 { #category : #generate }
 RFMethodToExecuteReification >> genForRBMessageNode [
 	^RBMessageNode
-		receiver: (RBMessageNode receiver: (RBTemporaryNode named: #RFReceiverReificationVar) selector: #class)
+		receiver: (RBMessageNode receiver: (RBVariableNode named: #RFReceiverReificationVar) selector: #class)
 		selector: #lookupSelector:
 		arguments: (RBLiteralValueNode value: entity selector)
 ]
@@ -42,7 +42,7 @@ RFMethodToExecuteReification >> preambleForMessage: aNode [
 		(1 to: aNode numArgs) withIndexDo: [:each :index |  
 			| name |
 			name := 'RFArg', index asString, 'RFReification'.
-			preamble add:  (RBTemporaryNode named: name).
+			preamble add:  (RBVariableNode named: name).
 	].
 
 	^ preamble

--- a/src/Reflectivity/RFNewValueReification.class.st
+++ b/src/Reflectivity/RFNewValueReification.class.st
@@ -19,13 +19,13 @@ RFNewValueReification class >> key [
 
 { #category : #generate }
 RFNewValueReification >> genForRBAssignmentNode [
-	^RBTemporaryNode named: #RFNewValueReificationVar.
+	^RBVariableNode named: #RFNewValueReificationVar.
 ]
 
 { #category : #generate }
 RFNewValueReification >> genForRBVariableNode [
 	"same as #value for variableNodes"
-	^RBTemporaryNode named: #RFNewValueReificationVar.
+	^RBVariableNode named: #RFNewValueReificationVar.
 ]
 
 { #category : #preamble }

--- a/src/Reflectivity/RFOperationReification.class.st
+++ b/src/Reflectivity/RFOperationReification.class.st
@@ -138,7 +138,7 @@ RFOperationReification >> preambleForArray: aNode [
 	(1 to: aNode size) withIndexDo: [:each :index |  
 			| name |
 			name := 'RFArg', index asString, 'RFReification'.
-			arguments add:  (RBTemporaryNode named: name).
+			arguments add:  (RBVariableNode named: name).
 	].
 	preamble addAll: (RBArrayNode statements: arguments).
 	preamble add: (RFStorePopIntoTempNode named: 'RFReifyValueVar').
@@ -170,7 +170,7 @@ RFOperationReification >> preambleForMessage: aNode [
 	(1 to: aNode numArgs) withIndexDo: [:each :index |  
 			| name |
 			name := 'RFArg', index asString, 'RFReification'.
-			arguments add:  (RBTemporaryNode named: name).
+			arguments add:  (RBVariableNode named: name).
 	].
 	preamble addAll: (RBArrayNode statements: arguments).
 	preamble add: (RFStorePopIntoTempNode named: 'RFArgumentsReificationVar').
@@ -182,7 +182,7 @@ RFOperationReification >> preambleForMessage: aNode [
 RFOperationReification >> preambleForMethod: aNode [
 	| preamble arguments |
 	preamble := OrderedCollection new.
-	arguments := aNode argumentNames collect: [ :name | RBTemporaryNode named: name].
+	arguments := aNode argumentNames collect: [ :name | RBVariableNode named: name].
 	preamble addAll: (RBArrayNode statements: arguments).
 	preamble add: (RFStorePopIntoTempNode named: 'RFArgumentsReificationVar').
 	^ preamble 

--- a/src/Reflectivity/RFReceiverReification.class.st
+++ b/src/Reflectivity/RFReceiverReification.class.st
@@ -19,7 +19,7 @@ RFReceiverReification class >> key [
 
 { #category : #generate }
 RFReceiverReification >> genForRBMessageNode [
-	^RBTemporaryNode named: #RFReceiverReificationVar.
+	^RBVariableNode named: #RFReceiverReificationVar.
 ]
 
 { #category : #generate }
@@ -43,7 +43,7 @@ RFReceiverReification >> preambleForMessage: aNode [
 		(1 to: aNode numArgs) withIndexDo: [:each :index |  
 			| name |
 			name := 'RFArg', index asString, 'RFReification'.
-			preamble add:  (RBTemporaryNode named: name).
+			preamble add:  (RBVariableNode named: name).
 	].
 
 	^ preamble

--- a/src/Reflectivity/RFValueReification.class.st
+++ b/src/Reflectivity/RFValueReification.class.st
@@ -81,7 +81,7 @@ RFValueReification >> genForRBMessageNode [
 
 { #category : #generate }
 RFValueReification >> genForRBMethodNode [
-	^RBTemporaryNode named: self varName
+	^RBVariableNode named: self varName
 ]
 
 { #category : #generate }
@@ -123,7 +123,7 @@ RFValueReification >> preambleForArray: aNode [
 	(1 to: aNode size) withIndexDo: [:each :index |  
 			| name |
 			name := 'RFArg', index asString, 'RFReification'.
-			arguments add:  (RBTemporaryNode named: name).
+			arguments add:  (RBVariableNode named: name).
 	].
 	preamble addAll: (RBArrayNode statements: arguments).
 	preamble add: (RFStorePopIntoTempNode named: self varName).


### PR DESCRIPTION
reduce references to RBVariableNode subclasses

The AST should only know variables. Givign meaning to it is done by semantic analysis.