### PR TITLE
whichMethodsReferToCleanUp

### DIFF
--- a/src/GT-SpotterExtensions-Core/Behavior.extension.st
+++ b/src/GT-SpotterExtensions-Core/Behavior.extension.st
@@ -90,7 +90,7 @@ Behavior >> withMethodsReferTo: aLiteral do: aBlock [
 	| specialIndex |
 	specialIndex := Smalltalk specialSelectorIndexOrNil: aLiteral.
 	self selectorsAndMethodsDo: [ :selector :method | 
-		((method hasLiteral: aLiteral) 
+		((method refersToLiteral: aLiteral) 
 			or: [ specialIndex notNil and: [ method scanFor: method encoderClass firstSpecialSelectorByte + specialIndex ] ])
 				ifTrue: [ aBlock value: method ] ]
 ]

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -856,7 +856,7 @@ Behavior >> hasMethodsAccessingSlot: aSlot [
 Behavior >> hasSelectorReferringTo: literal [
 	"Answer true if any of my methods access the argument as a literal"
 
-	^self methods anySatisfy: [ :method | method hasLiteral: literal ]
+	^self methods anySatisfy: [ :method | method refersToLiteral: literal ]
 ]
 
 { #category : #'testing class hierarchy' }
@@ -1782,9 +1782,9 @@ Behavior >> whichClassIncludesSelector: aSymbol [
 
 { #category : #'testing method dictionary' }
 Behavior >> whichMethodsReferTo: aLiteral [
-	"Answer methods whose methods directly refers to the argument as a literal"
+	"Answer methods whose methods refers to the argument as a literal"
 
-	^ self methods select: [ :method | method hasLiteral: aLiteral ]
+	^ self methods select: [ :method | method refersToLiteral: aLiteral ]
 ]
 
 { #category : #'testing method dictionary' }


### PR DESCRIPTION
The story of literals on CompiledMethod is such a mess...

Therse are the demensions:

1) literals use the last two entries as poor-mans variables. Do we want to include them or not?
2) Do we want to dive into Arrays and Pragmas?
3) Do we want to dive into Blocks?
4) Do we want to check for #+ and similar who would be there if we would not just not put them?

Combined, this is nearly impossible... 

What this PR does: we can not use #hasLiteral: , as that should be the version that (nearly) shows what is real. It should *not* look into embedded blocks.
So we can no use it here. The negative point is that we now dive into Arrays and Pragmas, which makes this method slower then needed if you use is with
global variable bindings.

Why do we do this crap? Why not have a higher level model?