### PR TITLE
Rules-Cleanup-excludedRuleNames

### DIFF
--- a/src/GeneralRules/ReImplementedNotSentRule.class.st
+++ b/src/GeneralRules/ReImplementedNotSentRule.class.st
@@ -43,8 +43,15 @@ ReImplementedNotSentRule class >> cleanUp [
 	self reset
 ]
 
+{ #category : #accessing }
+ReImplementedNotSentRule class >> enabled [
+	^false
+]
+
 { #category : #initialization }
 ReImplementedNotSentRule class >> initialize [
+	"we do not want to register if the rule is disabled"
+	self enabled ifFalse: [ ^self ].
 	self reset.
 	self subscribe.
 	SessionManager default 

--- a/src/GeneralRules/ReImplementedNotSentRule.class.st
+++ b/src/GeneralRules/ReImplementedNotSentRule.class.st
@@ -45,7 +45,7 @@ ReImplementedNotSentRule class >> cleanUp [
 
 { #category : #accessing }
 ReImplementedNotSentRule class >> enabled [
-	^false
+	^ enabled ifNil: [ enabled := false ]
 ]
 
 { #category : #initialization }

--- a/src/Renraku/ReRuleManager.class.st
+++ b/src/Renraku/ReRuleManager.class.st
@@ -63,27 +63,14 @@ ReRuleManager class >> default [
 { #category : #helpers }
 ReRuleManager class >> defaultRules [
 	^ self visibleRuleClasses
-			reject: [ :ruleClass |
-				ruleClass enabled not or: [ 
-				self excludedRuleNames includes: ruleClass name ] ] 
-			thenCollect: #new
-]
-
-{ #category : #helpers }
-ReRuleManager class >> excludedRuleNames [
-	"here rules can be excluded, but it is better to implement #enabled on the rule to return false to disable it. Do not forget to call #reset on this class after changing this method!"
-	^ #(#ReImplementedNotSentRule)
+			select: [ :ruleClass | ruleClass enabled ] 
+			thenCollect: [:ruleClass | ruleClass new]
 ]
 
 { #category : #'class initialization' }
 ReRuleManager class >> initialize [
-	self allInstances do: [ :inst |
-		self flag: 'remove in future. this is just to stop
-		            the announcements from choaking old instances'.
-		SystemAnnouncer uniqueInstance unsubscribe: inst ].
-
 	self reset.
-	self subscribe.
+	self subscribe
 ]
 
 { #category : #'instance creation' }
@@ -253,16 +240,10 @@ ReRuleManager class >> unsubscribe [
 ]
 
 { #category : #utilities }
-ReRuleManager class >> visibleLintRuleClasses [
-
-	^ RBLintRule withAllSubclasses select: #isVisible
-]
-
-{ #category : #utilities }
 ReRuleManager class >> visibleRuleClasses [
 
-	^ (ReAbstractRule withAllSubclasses select: #isVisible)
-	"remove this in the future ->", self visibleLintRuleClasses
+	^ (ReAbstractRule withAllSubclasses select: [:each | each isVisible])
+	"remove this in the future ->", RBLintRule withAllSubclasses select: [:each | each isVisible]
 ]
 
 { #category : #accessing }

--- a/src/Renraku/ReRuleManager.class.st
+++ b/src/Renraku/ReRuleManager.class.st
@@ -173,7 +173,7 @@ ReRuleManager class >> ruleToggleSettingsOn: aBuilder [
 					(aBuilder setting: rule enabledSettingID)
 					selector: #enabled;
 					target: rule;
-					default: true;
+					default: rule enabled;
 					label: inst name;
 					description: inst rationale ] ]
 ]


### PR DESCRIPTION
now that all rule classes can use the #enabled mechanism, we do not need the #excludedRuleNames mechanism anymore. 

In addition, make sure that ReImplementedNotSentRule does not register to be notified of changes if it is disabled.