### PR TITLE
6890-Variablevariable-is-deprecated

### DIFF
--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -271,6 +271,27 @@ CompiledMethodTest >> tearDown [
 	super tearDown
 ]
 
+{ #category : #'tests - instance variable' }
+CompiledMethodTest >> testAccessesField [		
+	| method |
+	method := self class compiledMethodAt: #readX.
+	self assert: (method accessesField: 4).
+	
+	method := self class compiledMethodAt: #readXandY.
+	self assert: (method accessesField: 5).
+	
+	
+	"read is not write"
+	method := self class compiledMethodAt: #writeX.
+	self assert: (method accessesField: 4).
+	
+	method := self class compiledMethodAt: #writeXandY.
+	self assert: (method accessesField: 4).
+	
+	method := self class compiledMethodAt: #writeXandY.
+	self assert: (method accessesField: 5)
+]
+
 { #category : #'tests - slots' }
 CompiledMethodTest >> testAccessesSlot [
 

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -453,6 +453,12 @@ Class >> declareClassVariables: newVars [
 	^conflicts
 ]
 
+{ #category : #'pool variables' }
+Class >> definedVariables [
+	"return all the Variables defined by this class"
+	^self slots, self classVariables
+]
+
 { #category : #'class variables' }
 Class >> definesClassVariable: aGlobal [
 	"Return whether the receiver has a class variables (shared variables among its class and subclasses) named: aString"
@@ -960,7 +966,7 @@ Class >> setName: aSymbol [
 	name := aSymbol.
 ]
 
-{ #category : #accessing }
+{ #category : #'pool variables' }
 Class >> sharedPoolNames [
 	^ self sharedPools collect: [:ea |
 		ea isObsolete

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -789,15 +789,6 @@ ClassDescription >> instanceSide [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
-ClassDescription >> instanceVariables [
-	"we deprecate this due to bad naming: it returns names, not variables!"
-	self
-		deprecated: 'Please use #instVarNames or #slotNames instead'
-		transformWith: '`@receiver instanceVariables' -> '`@receiver instVarNames'.
-	^self instVarNames
-]
-
 { #category : #printing }
 ClassDescription >> instanceVariablesString [
 	"Answer a string of my instance variable names separated by spaces."

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -72,6 +72,13 @@ CompiledCode >> = aCompiledMethod [
 ]
 
 { #category : #scanning }
+CompiledCode >> accessesField: varIndex [
+	"Answer whether the receiver accesses the instance variable indexed by the argument."
+
+	^ (self readsField: varIndex) or: [ self writesField: varIndex ]
+]
+
+{ #category : #scanning }
 CompiledCode >> accessesSlot: aSlot [
 	^aSlot isAccessedIn: self
 	

--- a/src/Kernel/InstanceVariableSlot.class.st
+++ b/src/Kernel/InstanceVariableSlot.class.st
@@ -59,7 +59,7 @@ InstanceVariableSlot >> emitValue: methodBuilder [
 
 { #category : #testing }
 InstanceVariableSlot >> isAccessedIn: aCompiledCode [
-	^(aCompiledCode readsField: index) or: [aCompiledCode writesField: index]
+	^ aCompiledCode accessesField: index
 ]
 
 { #category : #testing }

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -233,7 +233,7 @@ Slot >> isReferenced [
 	^ self owningClass 
 		ifNil: [ false ] 
 		ifNotNil: [ :class | 
-		  class withAllSubclasses anySatisfy: [ :behavior | class hasMethodsAccessingSlot: self ] ]
+		  class withAllSubclasses anySatisfy: [ :subclass | subclass hasMethodsAccessingSlot: self ] ]
 ]
 
 { #category : #testing }

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -123,7 +123,7 @@ UndefinedObject >> findUndeclaredVariableIn: ast [
 	"Walk the ast of the current statment and find the undeclared variable node, or nil (if none).
 	Assumes there is only one such variable in an executing statement"
 	
-	^ast nodes detect: [:node | node isVariable and: [ node isUndeclared]] ifNone: [ nil ]
+	^ast variableNodes detect: [:node | node isUndeclared] ifNone: [ nil ]
 ]
 
 { #category : #testing }

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -123,10 +123,7 @@ UndefinedObject >> findUndeclaredVariableIn: ast [
 	"Walk the ast of the current statment and find the undeclared variable node, or nil (if none).
 	Assumes there is only one such variable in an executing statement"
 	
-	ast nodesDo: [:node |
-		(node isVariable and: [ node isUndeclared]) ifTrue: [ ^node ]].
-
-	^nil
+	^ast nodes detect: [:node | node isVariable and: [ node isUndeclared]] ifNone: [ nil ]
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Core/OCCopyingArgumentVariable.class.st
+++ b/src/OpalCompiler-Core/OCCopyingArgumentVariable.class.st
@@ -10,6 +10,11 @@ Class {
 	#category : #'OpalCompiler-Core-Semantics'
 }
 
+{ #category : #queries }
+OCCopyingArgumentVariable >> definingNode [
+	^originalVar definingNode
+]
+
 { #category : #accessing }
 OCCopyingArgumentVariable >> index: anIndex [
 	self scope == originalVar scope ifTrue: [ originalVar index: anIndex ].

--- a/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCCopyingTempVariable.class.st
@@ -12,6 +12,11 @@ Class {
 	#category : #'OpalCompiler-Core-Semantics'
 }
 
+{ #category : #queries }
+OCCopyingTempVariable >> definingNode [
+	^originalVar definingNode
+]
+
 { #category : #accessing }
 OCCopyingTempVariable >> index: anIndex [
 	self scope == originalVar scope ifTrue: [ originalVar index: anIndex ].

--- a/src/OpalCompiler-Core/TemporaryVariable.class.st
+++ b/src/OpalCompiler-Core/TemporaryVariable.class.st
@@ -20,7 +20,15 @@ TemporaryVariable >> copiedVarClass [
 
 { #category : #queries }
 TemporaryVariable >> definingNode [
-	^ scope node temporaries detect: [ :each | each name = name ]
+	^ scope node temporaries 
+		detect: [ :each | each name = name ]
+		ifNone: [ 
+			" ugly workaround to support temps defined by primitives"
+			| pragma |
+			pragma := scope node methodNode pragmas detect: [ :each | each isPrimitiveError ].
+			pragma ifNil: [ ^nil ].
+			^ RBVariableNode named: (pragma argumentAt: #error:) value asString
+			]
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Tests/OCVariableSpecialisationTest.class.st
+++ b/src/OpalCompiler-Tests/OCVariableSpecialisationTest.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #OCVariableSpecialisationTest,
-	#superclass : #TestCase,
-	#category : #'OpalCompiler-Tests-Misc'
-}

--- a/src/Slot-Tests/ArgumentVariableTest.class.st
+++ b/src/Slot-Tests/ArgumentVariableTest.class.st
@@ -10,11 +10,11 @@ ArgumentVariableTest >> testDeclaringNode [
 	
 	method := OrderedCollection >> #do:.
 	declaringNode := method ast arguments first.
-	declaringNodeViaVariable := method ast variableReadNodes third variable variable definingNode.
+	declaringNodeViaVariable := method ast variableReadNodes third variable definingNode.
 	self assert: declaringNodeViaVariable equals: declaringNode.
 	
 	"check block argument"
 	declaringNode := method blockNodes first arguments first.
-	declaringNodeViaVariable := method ast variableReadNodes fifth variable variable definingNode.
+	declaringNodeViaVariable := method ast variableReadNodes fifth variable definingNode.
 	self assert: declaringNodeViaVariable equals: declaringNode.
 ]

--- a/src/Slot-Tests/TemporaryVariableTest.class.st
+++ b/src/Slot-Tests/TemporaryVariableTest.class.st
@@ -17,7 +17,7 @@ TemporaryVariableTest >> testDeclaringNode [
 	
 	method := OrderedCollection >> #do:.
 	declaringNode := method ast arguments first.
-	declaringNodeViaVariable := method ast variableReadNodes third variable variable definingNode.
+	declaringNodeViaVariable := method ast variableReadNodes third variable definingNode.
 	self assert: declaringNodeViaVariable equals: declaringNode.
 ]
 


### PR DESCRIPTION
- fix the depcrecated call. fixes #6890
- add CompiledMethod>>#accessesField: and test, use it in InstanceVariable>>isAccessedIn:
- add #definingNode which where missed on the other PR (and yes, this is really a wrapper.. to be done later)
- remove empty OCVariableSpecialisationTest
- add #definedVariable to get all class and invars of a class
- remove deprecated #instanceVariables on ClassDescription