### PR TITLE
Improving debugger infrastructure step 1: a Trait to unify the debugger API used by the system to open debuggers

### DIFF
--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -25,6 +25,7 @@ BaselineOfGeneralTests >> baseline: spec [
 			package: 'Collections-Arithmetic-Tests';
 			package: 'ConfigurationCommandLineHandler-Tests';
 			package: 'MetacelloCommandLineHandler-Tests';
+			package: 'Debugger-Filters-Tests';
 			package: 'Debugger-Model-Tests';
 			package: 'EmergencyDebugger-Tests';
 			package: 'EmbeddedFreeType-Tests';

--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -25,7 +25,7 @@ BaselineOfGeneralTests >> baseline: spec [
 			package: 'Collections-Arithmetic-Tests';
 			package: 'ConfigurationCommandLineHandler-Tests';
 			package: 'MetacelloCommandLineHandler-Tests';
-			package: 'Debugger-Tests';
+			package: 'Debugger-Model-Tests';
 			package: 'EmergencyDebugger-Tests';
 			package: 'EmbeddedFreeType-Tests';
 			

--- a/src/Debugger-Filters-Tests/FilterTest.class.st
+++ b/src/Debugger-Filters-Tests/FilterTest.class.st
@@ -12,7 +12,7 @@ Class {
 		'otherProcess',
 		'otherSession'
 	],
-	#category : #'Debugger-Model-Tests-Filter'
+	#category : #'Debugger-Filters-Tests'
 }
 
 { #category : #running }

--- a/src/Debugger-Filters-Tests/package.st
+++ b/src/Debugger-Filters-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Debugger-Filters-Tests' }

--- a/src/Debugger-Model-Tests/AssignmentAndLiteralDebuggerTest.class.st
+++ b/src/Debugger-Model-Tests/AssignmentAndLiteralDebuggerTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #AssignmentAndLiteralDebuggerTest,
 	#superclass : #DebuggerTest,
-	#category : #'Debugger-Tests-Base'
+	#category : #'Debugger-Model-Tests-Base'
 }
 
 { #category : #running }

--- a/src/Debugger-Model-Tests/AssignmentAndLiteralDebuggerTest.class.st
+++ b/src/Debugger-Model-Tests/AssignmentAndLiteralDebuggerTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #AssignmentAndLiteralDebuggerTest,
 	#superclass : #DebuggerTest,
-	#category : #'Debugger-Model-Tests-Base'
+	#category : #'Debugger-Model-Tests-Core'
 }
 
 { #category : #running }

--- a/src/Debugger-Model-Tests/DebugSessionContexts2Test.class.st
+++ b/src/Debugger-Model-Tests/DebugSessionContexts2Test.class.st
@@ -4,7 +4,7 @@ Class {
 	#classVars : [
 		'debugSession'
 	],
-	#category : #'Debugger-Model-Tests-Base'
+	#category : #'Debugger-Model-Tests-Core'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Debugger-Model-Tests/DebugSessionContexts2Test.class.st
+++ b/src/Debugger-Model-Tests/DebugSessionContexts2Test.class.st
@@ -4,7 +4,7 @@ Class {
 	#classVars : [
 		'debugSession'
 	],
-	#category : #'Debugger-Tests-Base'
+	#category : #'Debugger-Model-Tests-Base'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Debugger-Model-Tests/DebugSessionContextsTest.class.st
+++ b/src/Debugger-Model-Tests/DebugSessionContextsTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'debuggedThisContext'
 	],
-	#category : #'Debugger-Tests-Base'
+	#category : #'Debugger-Model-Tests-Base'
 }
 
 { #category : #running }

--- a/src/Debugger-Model-Tests/DebugSessionContextsTest.class.st
+++ b/src/Debugger-Model-Tests/DebugSessionContextsTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'debuggedThisContext'
 	],
-	#category : #'Debugger-Model-Tests-Base'
+	#category : #'Debugger-Model-Tests-Core'
 }
 
 { #category : #running }

--- a/src/Debugger-Model-Tests/DebuggerModelTest.class.st
+++ b/src/Debugger-Model-Tests/DebuggerModelTest.class.st
@@ -9,7 +9,7 @@ Class {
 		'process',
 		'context'
 	],
-	#category : #'Debugger-Tests-Model'
+	#category : #'Debugger-Model-Tests-Model'
 }
 
 { #category : #running }

--- a/src/Debugger-Model-Tests/DebuggerTest.class.st
+++ b/src/Debugger-Model-Tests/DebuggerTest.class.st
@@ -10,7 +10,7 @@ Class {
 		'session',
 		'process'
 	],
-	#category : #'Debugger-Model-Tests-Base'
+	#category : #'Debugger-Model-Tests-Core'
 }
 
 { #category : #utilities }

--- a/src/Debugger-Model-Tests/DebuggerTest.class.st
+++ b/src/Debugger-Model-Tests/DebuggerTest.class.st
@@ -10,7 +10,7 @@ Class {
 		'session',
 		'process'
 	],
-	#category : #'Debugger-Tests-Base'
+	#category : #'Debugger-Model-Tests-Base'
 }
 
 { #category : #utilities }

--- a/src/Debugger-Model-Tests/DynamicMessageImplementorTest.class.st
+++ b/src/Debugger-Model-Tests/DynamicMessageImplementorTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'instVar'
 	],
-	#category : #'Debugger-Model-Tests-Base'
+	#category : #'Debugger-Model-Tests-Core'
 }
 
 { #category : #testing }

--- a/src/Debugger-Model-Tests/DynamicMessageImplementorTest.class.st
+++ b/src/Debugger-Model-Tests/DynamicMessageImplementorTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'instVar'
 	],
-	#category : #'Debugger-Tests-Base'
+	#category : #'Debugger-Model-Tests-Base'
 }
 
 { #category : #testing }

--- a/src/Debugger-Model-Tests/ErrorWasInUIProcessTest.class.st
+++ b/src/Debugger-Model-Tests/ErrorWasInUIProcessTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ErrorWasInUIProcessTest,
 	#superclass : #DebuggerTest,
-	#category : #'Debugger-Tests-Base'
+	#category : #'Debugger-Model-Tests-Base'
 }
 
 { #category : #tests }

--- a/src/Debugger-Model-Tests/ErrorWasInUIProcessTest.class.st
+++ b/src/Debugger-Model-Tests/ErrorWasInUIProcessTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ErrorWasInUIProcessTest,
 	#superclass : #DebuggerTest,
-	#category : #'Debugger-Model-Tests-Base'
+	#category : #'Debugger-Model-Tests-Core'
 }
 
 { #category : #tests }

--- a/src/Debugger-Model-Tests/FilterTest.class.st
+++ b/src/Debugger-Model-Tests/FilterTest.class.st
@@ -12,7 +12,7 @@ Class {
 		'otherProcess',
 		'otherSession'
 	],
-	#category : #'Debugger-Tests-Filter'
+	#category : #'Debugger-Model-Tests-Filter'
 }
 
 { #category : #running }

--- a/src/Debugger-Model-Tests/IsContextPostMortemTest.class.st
+++ b/src/Debugger-Model-Tests/IsContextPostMortemTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #IsContextPostMortemTest,
 	#superclass : #DebuggerTest,
-	#category : #'Debugger-Tests-Base'
+	#category : #'Debugger-Model-Tests-Base'
 }
 
 { #category : #helper }

--- a/src/Debugger-Model-Tests/IsContextPostMortemTest.class.st
+++ b/src/Debugger-Model-Tests/IsContextPostMortemTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #IsContextPostMortemTest,
 	#superclass : #DebuggerTest,
-	#category : #'Debugger-Model-Tests-Base'
+	#category : #'Debugger-Model-Tests-Core'
 }
 
 { #category : #helper }

--- a/src/Debugger-Model-Tests/MyHalt.class.st
+++ b/src/Debugger-Model-Tests/MyHalt.class.st
@@ -4,7 +4,7 @@ A custom exception used in halts
 Class {
 	#name : #MyHalt,
 	#superclass : #Exception,
-	#category : #'Debugger-Tests-Exceptions'
+	#category : #'Debugger-Model-Tests-Exceptions'
 }
 
 { #category : #accessing }

--- a/src/Debugger-Model-Tests/RestartTest.class.st
+++ b/src/Debugger-Model-Tests/RestartTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #RestartTest,
 	#superclass : #DebuggerTest,
-	#category : #'Debugger-Model-Tests-Base'
+	#category : #'Debugger-Model-Tests-Core'
 }
 
 { #category : #tests }

--- a/src/Debugger-Model-Tests/RestartTest.class.st
+++ b/src/Debugger-Model-Tests/RestartTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #RestartTest,
 	#superclass : #DebuggerTest,
-	#category : #'Debugger-Tests-Base'
+	#category : #'Debugger-Model-Tests-Base'
 }
 
 { #category : #tests }

--- a/src/Debugger-Model-Tests/StepIntoTest.class.st
+++ b/src/Debugger-Model-Tests/StepIntoTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #StepIntoTest,
 	#superclass : #DebuggerTest,
-	#category : #'Debugger-Tests-Base'
+	#category : #'Debugger-Model-Tests-Base'
 }
 
 { #category : #helper }

--- a/src/Debugger-Model-Tests/StepIntoTest.class.st
+++ b/src/Debugger-Model-Tests/StepIntoTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #StepIntoTest,
 	#superclass : #DebuggerTest,
-	#category : #'Debugger-Model-Tests-Base'
+	#category : #'Debugger-Model-Tests-Core'
 }
 
 { #category : #helper }

--- a/src/Debugger-Model-Tests/StepOverTest.class.st
+++ b/src/Debugger-Model-Tests/StepOverTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #StepOverTest,
 	#superclass : #DebuggerTest,
-	#category : #'Debugger-Tests-Base'
+	#category : #'Debugger-Model-Tests-Base'
 }
 
 { #category : #helper }

--- a/src/Debugger-Model-Tests/StepOverTest.class.st
+++ b/src/Debugger-Model-Tests/StepOverTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #StepOverTest,
 	#superclass : #DebuggerTest,
-	#category : #'Debugger-Model-Tests-Base'
+	#category : #'Debugger-Model-Tests-Core'
 }
 
 { #category : #helper }

--- a/src/Debugger-Model-Tests/StepThroughTest.class.st
+++ b/src/Debugger-Model-Tests/StepThroughTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'assistant'
 	],
-	#category : #'Debugger-Model-Tests-Base'
+	#category : #'Debugger-Model-Tests-Core'
 }
 
 { #category : #helper }

--- a/src/Debugger-Model-Tests/StepThroughTest.class.st
+++ b/src/Debugger-Model-Tests/StepThroughTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'assistant'
 	],
-	#category : #'Debugger-Tests-Base'
+	#category : #'Debugger-Model-Tests-Base'
 }
 
 { #category : #helper }

--- a/src/Debugger-Model-Tests/TDebuggerTest.class.st
+++ b/src/Debugger-Model-Tests/TDebuggerTest.class.st
@@ -1,0 +1,50 @@
+Class {
+	#name : #TDebuggerTest,
+	#superclass : #TestCase,
+	#traits : 'TDebugger',
+	#classTraits : 'TDebugger classTrait',
+	#category : #'Debugger-Model-Tests-Core'
+}
+
+{ #category : #tests }
+TDebuggerTest >> testAvailableAutomatically [
+	self class availableAutomatically: nil.
+	self
+		assert: self class availableAutomatically
+		equals: DebuggerSettings defaultAvailability.
+	self class availableAutomatically: true.
+	self assert: self class availableAutomatically.
+	self class availableAutomatically: false.
+	self deny: self class availableAutomatically
+]
+
+{ #category : #tests }
+TDebuggerTest >> testDebugSession [
+	self should: [ self class debugSession: nil ] raise: Error.
+	[ self class debugSession: nil ]
+		on: Error
+		do: [ :err | 
+		self assert: err description equals: 'Error: Explicitly required method' ]
+]
+
+{ #category : #tests }
+TDebuggerTest >> testHandlesContext [
+	"By default handles any context"
+	self assert: (self class handlesContext: nil)
+]
+
+{ #category : #tests }
+TDebuggerTest >> testRank [
+	self class rank: nil.
+	self assert: self class rank equals: DebuggerSettings defaultDebuggerRank.
+	self class rank: 1.
+	self assert: self class rank equals: 1
+]
+
+{ #category : #tests }
+TDebuggerTest >> testSystemDebuggers [
+	|debuggers|
+	debuggers := DebuggerSettings systemDebuggers.
+	self assert: (debuggers allSatisfy: [:dbg| TDebugger users includes: dbg]).
+	self deny: (debuggers anySatisfy: [:dbg| dbg isTestCase]).
+]

--- a/src/Debugger-Model-Tests/TDebuggerTest.class.st
+++ b/src/Debugger-Model-Tests/TDebuggerTest.class.st
@@ -6,6 +6,11 @@ Class {
 	#category : #'Debugger-Model-Tests-Core'
 }
 
+{ #category : #'instance creation' }
+TDebuggerTest class >> debugSession: aDebugSession [
+	^true
+]
+
 { #category : #tests }
 TDebuggerTest >> testAvailableAutomatically [
 	self class availableAutomatically: nil.
@@ -20,11 +25,7 @@ TDebuggerTest >> testAvailableAutomatically [
 
 { #category : #tests }
 TDebuggerTest >> testDebugSession [
-	self should: [ self class debugSession: nil ] raise: Error.
-	[ self class debugSession: nil ]
-		on: Error
-		do: [ :err | 
-		self assert: err description equals: 'Error: Explicitly required method' ]
+	self assert: (self class debugSession: nil)
 ]
 
 { #category : #tests }

--- a/src/Debugger-Model-Tests/package.st
+++ b/src/Debugger-Model-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Debugger-Model-Tests' }

--- a/src/Debugger-Model/DebugContext.class.st
+++ b/src/Debugger-Model/DebugContext.class.st
@@ -36,7 +36,7 @@ Class {
 		'context',
 		'topContext'
 	],
-	#category : #'Debugger-Model-Base'
+	#category : #'Debugger-Model-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -31,7 +31,7 @@ Class {
 	#classVars : [
 		'LogDebuggerStackToFile'
 	],
-	#category : #'Debugger-Model-Base'
+	#category : #'Debugger-Model-Core'
 }
 
 { #category : #settings }

--- a/src/Debugger-Model/DebuggerSettings.class.st
+++ b/src/Debugger-Model/DebuggerSettings.class.st
@@ -1,0 +1,50 @@
+"
+General debugger settings with default values for TDebugger users
+"
+Class {
+	#name : #DebuggerSettings,
+	#superclass : #Object,
+	#category : #'Debugger-Model-Core'
+}
+
+{ #category : #settings }
+DebuggerSettings class >> debuggerRankSettingsOn: aBuilder [
+	<systemsettings>
+	(aBuilder group: #debuggers)
+		label: 'Debuggers';
+		parent: #debugging.
+	self systemDebuggers do: [ :debuggerClass | 
+		(aBuilder group: debuggerClass name asSymbol)
+			label: debuggerClass name;
+			parent: #debuggers;
+			with: [ 
+				(aBuilder pickOne: #rank)
+					label: 'Priority';
+					target: debuggerClass;
+					default: self defaultDebuggerRank;
+					domainValues: (1 to: 10);
+					description:
+						'Debugger priority: a debugger with a high priority will be chosen for debugging over a debugger with a low priority. 
+Lowest priority: 1. Highest priority: 10'.
+				(aBuilder setting: #availableAutomatically)
+					label: 'Available';
+					target: debuggerClass;
+					default: self defaultAvailability;
+					description:
+						'(De)activates the debugger. A deactivated debugger will not be used by the system.' ] ]
+]
+
+{ #category : #accessing }
+DebuggerSettings class >> defaultAvailability [
+	^true
+]
+
+{ #category : #accessing }
+DebuggerSettings class >> defaultDebuggerRank [
+	^10
+]
+
+{ #category : #settings }
+DebuggerSettings class >> systemDebuggers [
+	^ TDebugger users reject: [ :class | class isTestCase ]
+]

--- a/src/Debugger-Model/TDebugger.trait.st
+++ b/src/Debugger-Model/TDebugger.trait.st
@@ -1,0 +1,57 @@
+"
+Use me if you want to be recognized as a debugger.
+I specify the interface that all debuggers must implement to be used as debuggers.
+Conversely, classes recognized as debuggers are all able to start debugging from a given debug session.
+
+The API that all debuggers will expose by using me is:
+
+availableAutomatically: a boolean telling if the debugger is (de)activated
+rank: an integer giving a priority to the debugger (against other debuggers priorities)
+
+handlesContext: aContext
+=> returns a boolean, tells if the debugger can handle the given context (e.g., a SUnit debugger will be able to handle test cases contexts). By default, any context is handleable.
+
+debugSession: aDebugSession
+Explicit requirement that must be implemented by all debuggers.
+This API method is the entry point to open a debugger on a DebugSession instance.
+It is the preferred debugger opening entry point used by the system to open a debugger.
+"
+Trait {
+	#name : #TDebugger,
+	#classInstVars : [
+		'rank',
+		'availableAutomatically'
+	],
+	#category : #'Debugger-Model-Core'
+}
+
+{ #category : #accessing }
+TDebugger classSide >> availableAutomatically [
+	^ availableAutomatically ifNil: [ 
+		  availableAutomatically := DebuggerSettings defaultAvailability ]
+]
+
+{ #category : #accessing }
+TDebugger classSide >> availableAutomatically: anObject [
+	availableAutomatically := anObject
+]
+
+{ #category : #'instance creation' }
+TDebugger classSide >> debugSession: aDebugSession [
+	self explicitRequirement
+]
+
+{ #category : #debugging }
+TDebugger classSide >> handlesContext: aContext [
+	^true
+]
+
+{ #category : #accessing }
+TDebugger classSide >> rank [
+	^rank ifNil:[rank := DebuggerSettings defaultDebuggerRank]
+]
+
+{ #category : #accessing }
+TDebugger classSide >> rank: anInteger [
+	rank := anInteger
+]

--- a/src/Debugger-Model/TDebugger.trait.st
+++ b/src/Debugger-Model/TDebugger.trait.st
@@ -5,14 +5,12 @@ Conversely, classes recognized as debuggers are all able to start debugging from
 
 The API that all debuggers will expose by using me is:
 
-availableAutomatically: a boolean telling if the debugger is (de)activated
-rank: an integer giving a priority to the debugger (against other debuggers priorities)
+`availableAutomatically:` a boolean telling if the debugger is (de)activated.
+`rank:` an integer giving a priority to the debugger (against other debuggers priorities). A high priority debugger will be preferably opened by the system rather than a low priority debugger.
 
-handlesContext: aContext
-=> returns a boolean, tells if the debugger can handle the given context (e.g., a SUnit debugger will be able to handle test cases contexts). By default, any context is handleable.
+`handlesContext: aContext`: returns a boolean, tells if the debugger can handle the given context (e.g., a SUnit debugger will be able to handle test cases contexts). By default, any context is handleable.
 
-debugSession: aDebugSession
-Explicit requirement that must be implemented by all debuggers.
+`debugSession: aDebugSession`: Explicit requirement that must be implemented by all debuggers.
 This API method is the entry point to open a debugger on a DebugSession instance.
 It is the preferred debugger opening entry point used by the system to open a debugger.
 "

--- a/src/Debugger-Tests/package.st
+++ b/src/Debugger-Tests/package.st
@@ -1,1 +1,0 @@
-Package { #name : #'Debugger-Tests' }


### PR DESCRIPTION
This PR is an intermediate step of a general improvement of the debugger infrastructure.

This work is about decoupling the debugger opening from the UI (for now, the logic of opening debuggers and handling debugger errors is in `UIMorphicManager`), unifying debuggers API to open them (for now, there at least 3 different ways of requesting the opening of a debugger, and many different users of those 3 ways), and finally cleaning the debugger infrastructure to start further work and improvements on the debugging model.

Instead of a super huge PR, we chose to introduce some independant parts of this work first in order to get early feedback.
Therefore, the introduced features are not to be used by the system yet.

In this PR, you will find:
- Some package renaming and reorganization for consistency
- A Trait `TDebugger`, which all debuggers must (soon) use to be recognized by the system as a debugger.

**`TDebugger` class comment:**

Use me if you want to be recognized as a debugger.
I specify the interface that all debuggers must implement to be used as debuggers.
Conversely, classes recognized as debuggers are all able to start debugging from a given debug session.

The API that all debuggers will expose by using me is:

`availableAutomatically:` a boolean telling if the debugger is (de)activated.
`rank:` an integer giving a priority to the debugger (against other debuggers priorities). A high priority debugger will be preferably opened by the system rather than a low priority debugger.

`handlesContext: aContext`: returns a boolean, tells if the debugger can handle the given context (e.g., a SUnit debugger will be able to handle test cases contexts). By default, any context is handleable.

`debugSession: aDebugSession`: Explicit requirement that must be implemented by all debuggers.
This API method is the entry point to open a debugger on a DebugSession instance.
It is the preferred debugger opening entry point used by the system to open a debugger.