### PR TITLE
simplify-variableValueInContext

### DIFF
--- a/src/Reflectivity-VariableBreakpoint/RBInstanceVariableNode.extension.st
+++ b/src/Reflectivity-VariableBreakpoint/RBInstanceVariableNode.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #RBInstanceVariableNode }
-
-{ #category : #'*Reflectivity-VariableBreakpoint' }
-RBInstanceVariableNode >> variableValueInContext: aContext [
-	|receiver|
-	receiver := aContext receiver.
-	^(receiver class slotNamed: self name) read: receiver
-]

--- a/src/Reflectivity-VariableBreakpoint/RBVariableNode.extension.st
+++ b/src/Reflectivity-VariableBreakpoint/RBVariableNode.extension.st
@@ -8,5 +8,5 @@ RBVariableNode >> hasBreakpoint [
 
 { #category : #'*Reflectivity-VariableBreakpoint' }
 RBVariableNode >> variableValueInContext: aContext [
-	^ aContext tempNamed: self name
+	^ variable readInContext: aContext
 ]


### PR DESCRIPTION
now that all variables (bindings) understand readInContext:, we can simplidy variableValueInContext:  (which migh in another step even be replaced by using the var or #evaluateInContext: directly, but that is another step)