### PR TITLE
Supervar-use-sendsToSuper

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -848,7 +848,7 @@ Behavior >> hasMethods [
 Behavior >> hasMethodsAccessingSlot: aSlot [
 	"check if aSlot is accessed in this class"
 
-	^ self methods anySatisfy: [ :method | aSlot isAccessedIn: method ]
+	^ self methods anySatisfy: [ :method | method accessesSlot: aSlot ]
 ]
 
 { #category : #'testing method dictionary' }

--- a/src/OpalCompiler-Core/SuperVariable.class.st
+++ b/src/OpalCompiler-Core/SuperVariable.class.st
@@ -35,3 +35,9 @@ SuperVariable >> isSuper [
 SuperVariable >> readInContext: aContext [
 	^aContext receiver
 ]
+
+{ #category : #queries }
+SuperVariable >> usingMethods [
+	^ SystemNavigation new allMethods select: [ :method | 
+		  method sendsToSuper ]
+]


### PR DESCRIPTION
implement #usingMethods in SuperVariable. This way 

SuperVariable instance usingMethods

is much fater.

in addition make, sure that hasMethodsAccessingSlot: and methodsAccessingSlot: should use the same code in the block