### PR TITLE
Variables-deprecate-isGlobal

### DIFF
--- a/src/AST-Core-Tests/RBDumpVisitorTest.class.st
+++ b/src/AST-Core-Tests/RBDumpVisitorTest.class.st
@@ -132,7 +132,7 @@ RBDumpVisitorTest >> testGlobalNodeDump [
 	node := self parseMethod: 'foo ^ Object'.
 	dumpedNode := Smalltalk compiler evaluate: node doSemanticAnalysis dump.
 	
-	self assert: dumpedNode statements first value isGlobal.
+	self assert: dumpedNode statements first value isGlobalVariable.
 	self assert: node class equals: dumpedNode class.
 	self assert: node printString equals: dumpedNode printString.
 	

--- a/src/AST-Core-Tests/RBDumpVisitorTest.class.st
+++ b/src/AST-Core-Tests/RBDumpVisitorTest.class.st
@@ -130,7 +130,9 @@ RBDumpVisitorTest >> testGlobalNodeDump [
 	| node dumpedNode |
 	"Global nodes are only generated when a semantic analysis is triggered on a method"
 	node := self parseMethod: 'foo ^ Object'.
-	dumpedNode := Smalltalk compiler evaluate: node doSemanticAnalysis dump.
+	node doSemanticAnalysis.
+	dumpedNode := Smalltalk compiler evaluate: node dump.
+	dumpedNode doSemanticAnalysis.
 	
 	self assert: dumpedNode statements first value isGlobalVariable.
 	self assert: node class equals: dumpedNode class.

--- a/src/AST-Core/RBGlobalNode.class.st
+++ b/src/AST-Core/RBGlobalNode.class.st
@@ -19,8 +19,3 @@ Class {
 RBGlobalNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitGlobalNode: self
 ]
-
-{ #category : #testing }
-RBGlobalNode >> isGlobal [
-	^true
-]

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -61,7 +61,7 @@ RBVariableNode >> acceptVisitor: aProgramNodeVisitor [
 { #category : #converting }
 RBVariableNode >> adaptToSemanticNode [
 	
-	self primitiveChangeClassTo: self binding semanticNodeClass new
+	self primitiveChangeClassTo: variable semanticNodeClass new
 ]
 
 { #category : #matching }
@@ -80,7 +80,7 @@ RBVariableNode >> hasIncompleteIdentifier [
 	"check if there is any variable declared in my scope that starts with my name"
 
 	"declared vars are never incomplete"
-	self binding isUndeclaredVariable ifFalse: [ ^false ].
+	variable isUndeclaredVariable ifFalse: [ ^false ].
 	"for the others we have to search from the current scope"
 	^self scope hasBindingThatBeginsWith: self name
 ]
@@ -103,6 +103,11 @@ RBVariableNode >> isArgumentVariable [
 ]
 
 { #category : #testing }
+RBVariableNode >> isClassVariable [
+	^variable isClassVariable
+]
+
+{ #category : #testing }
 RBVariableNode >> isDefinition [
 	"Check if I am a Variable defintion"
 	^variable definingNode == self
@@ -121,6 +126,11 @@ RBVariableNode >> isImmediateNode [
 { #category : #testing }
 RBVariableNode >> isInstanceVariable [
 	^variable isInstanceVariable
+]
+
+{ #category : #testing }
+RBVariableNode >> isLiteralVariable [
+	^variable isLiteralVariable
 ]
 
 { #category : #testing }

--- a/src/ClassParser/CDClassDefinitionParser.class.st
+++ b/src/ClassParser/CDClassDefinitionParser.class.st
@@ -201,7 +201,7 @@ CDClassDefinitionParser >> parseSlotNode: aRBMessageNode [
 		
 		ifFalse: [  
 			"when a slot is just 'inst' => InstanceVariableSlot."
-			aRBMessageNode arguments first isGlobal
+			aRBMessageNode arguments first isGlobalVariable
 				ifTrue: [ | slot |
 					slot := self slotNodeClass
 						node: aRBMessageNode

--- a/src/Deprecated90/RBVariableNode.extension.st
+++ b/src/Deprecated90/RBVariableNode.extension.st
@@ -10,6 +10,17 @@ RBVariableNode >> isArg [
 ]
 
 { #category : #'*Deprecated90' }
+RBVariableNode >> isGlobal [
+	"isGlobal used to return true for both class variables and globals (and even undeclared Variables).
+	From Pharo9 on, #isGlobalVariable returns true only for real globals"
+	self 
+		deprecated: 'Use #isGlobalVariable, isClassVariable or isLiteralVariable instead.' 
+		transformWith: '`@receiver isGlobal' -> '`@receiver isLiteralVariable'.
+	
+	^self isLiteralVariable
+]
+
+{ #category : #'*Deprecated90' }
 RBVariableNode >> isInstance [
 	self 
 		deprecated: 'Use #isInstanceVariable instead.' 

--- a/src/GeneralRules/ReReferencesObsoleteClassRule.class.st
+++ b/src/GeneralRules/ReReferencesObsoleteClassRule.class.st
@@ -11,7 +11,7 @@ Class {
 { #category : #helpers }
 ReReferencesObsoleteClassRule >> basicCheck: aNode [
  	^ aNode isVariable 
- 		and: [aNode isGlobal
+ 		and: [aNode isGlobalVariable
  			and: [ aNode variable isGlobalClassNameBinding
  				and: [ aNode variable value isObsolete ] ] ]
 ]

--- a/src/GeneralRules/ReRefersToClassRule.class.st
+++ b/src/GeneralRules/ReRefersToClassRule.class.st
@@ -30,7 +30,7 @@ ReRefersToClassRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	
 	class := aMethod methodClass instanceSide.
 	problemLiterals := (aMethod ast allChildren 
-			select: [ :node | node isVariable and:[ node isGlobal ] ])
+			select: [ :node | node isVariable and:[ node isGlobalVariable ] ])
 			select: [ :var | var name = class name].
 		
 	problemLiterals do: [ :literal |

--- a/src/GeneralRules/ReUsesTrueRule.class.st
+++ b/src/GeneralRules/ReUsesTrueRule.class.st
@@ -25,7 +25,7 @@ ReUsesTrueRule class >> uniqueIdentifierName [
 ReUsesTrueRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	| problemUsages |
 	problemUsages := aMethod ast variableNodes select: [ :aNode | 
-			                 aNode isGlobal and: [ #( True False ) includes: aNode name ] ].
+			                 aNode isGlobalVariable and: [ #( True False ) includes: aNode name ] ].
 	problemUsages do: [ :ref | 
 		aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: ref hint: ref name asString)]
 ]

--- a/src/GeneralRules/ReUsesWorldGlobalRule.class.st
+++ b/src/GeneralRules/ReUsesWorldGlobalRule.class.st
@@ -17,7 +17,7 @@ ReUsesWorldGlobalRule class >> uniqueIdentifierName [
 
 { #category : #running }
 ReUsesWorldGlobalRule >> basicCheck: aNode [
-	^ aNode isVariable and: [ aNode isGlobal and: [ #(#World #ActiveWorld) includes: aNode name ] ]
+	^ aNode isVariable and: [ aNode isGlobalVariable and: [ #(#World #ActiveWorld) includes: aNode name ] ]
 ]
 
 { #category : #accessing }

--- a/src/Kernel-Rules/FloatReferencesRule.class.st
+++ b/src/Kernel-Rules/FloatReferencesRule.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #running }
 FloatReferencesRule >> basicCheck: node [
 	node isVariable ifFalse: [ ^ false ].
-	node isGlobal ifFalse: [ ^ false ].
+	node isGlobalVariable ifFalse: [ ^ false ].
 	^(self systemClassNames includes: node name)
 	
 ]

--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -37,7 +37,7 @@ LocalVariable >> asString [
 
 { #category : #queries }
 LocalVariable >> astNodes [
-	^scope node methodNode variableNodes select: [ :each | each binding == self]
+	^scope node methodNode variableNodes select: [ :each | each variable == self]
 ]
 
 { #category : #emitting }

--- a/src/OpalCompiler-Core/RBVariableNode.extension.st
+++ b/src/OpalCompiler-Core/RBVariableNode.extension.st
@@ -16,12 +16,6 @@ RBVariableNode >> isClean [
 ]
 
 { #category : #'*opalcompiler-core' }
-RBVariableNode >> isGlobal [
-	"the semantics here is bad: all Literal Variables are Globals on the AST Level"
-	^variable isLiteralVariable and: [ variable isUndeclaredVariable not]
-]
-
-{ #category : #'*opalcompiler-core' }
 RBVariableNode >> variable [
 	^variable
 ]

--- a/src/Refactoring-Core/RBCondition.class.st
+++ b/src/Refactoring-Core/RBCondition.class.st
@@ -259,7 +259,7 @@ RBCondition class >> isEmptyClass: anObject [
 { #category : #'instance creation' }
 RBCondition class >> isGlobal: aString in: aRBSmalltalk [ 
 	^self new 
-		type: (Array with: #isGlobal with: aString)
+		type: (Array with: #isLiteralVariable with: aString)
 		block: [aRBSmalltalk includesGlobal: aString asSymbol]
 		errorString: aString , ' is <1?:not >a class or global variable'
 ]

--- a/src/Reflectivity/Variable.extension.st
+++ b/src/Reflectivity/Variable.extension.st
@@ -38,7 +38,7 @@ Variable >> assignmentNodes [
 Variable >> astNodes [
 	"by default we search the usingMethods for all AST nodes"
 	^self usingMethods flatCollect: [ :method | 
-		method variableNodes select: [: each| each binding == self ]]
+		method variableNodes select: [: each| each variable == self ]]
 ]
 
 { #category : #'*Reflectivity' }

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -546,9 +546,10 @@ RGBehavior >> initializeUnresolved [
 ]
 
 { #category : #'queries - testing' }
-RGBehavior >> isAccessedIn: anRGMethod [ 
-
-	^ (anRGMethod ast variableNodes select: [:each | each isGlobal]) anySatisfy: [ :each | each name = self name ] 
+RGBehavior >> isAccessedIn: anRGMethod [
+	^ (anRGMethod ast variableNodes select: [ :each | 
+		   each isGlobalVariable ]) anySatisfy: [ :each | 
+		  each name = self name ]
 ]
 
 { #category : #testing }

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1024,7 +1024,9 @@ SHRBTextStyler >> resolveStyleFor: aVariableNode [
 	aVariableNode binding ifNil: [^#default].
 	aVariableNode isArgumentVariable ifTrue: [ ^#methodArg].
 	aVariableNode isTemp ifTrue: [ ^#tempVar].
-	aVariableNode isGlobal ifTrue: [ ^#globalVar].
+	aVariableNode isGlobalVariable ifTrue: [ ^#globalVar].
+	"here we should add support for #classVar"
+	aVariableNode isClassVariable ifTrue: [ ^#globalVar].
 	aVariableNode isInstanceVariable ifTrue: [ ^#instVar]. 
 	
 	(self class formatIncompleteIdentifiers and: [ aVariableNode hasIncompleteIdentifier ]) 


### PR DESCRIPTION
- Deprecate #isGlobal
- fix all senders
- add #isLiteralVariable and isClassVariable to RBVariableNode
- do not use "self binding" in RBVariableNode, but assess the variable directly