### PR TITLE
merge-numberOfReservedLiterals-literalsToSkip

### DIFF
--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -99,12 +99,6 @@ CompiledBlock >> methodNode [
 ]
 
 { #category : #accessing }
-CompiledBlock >> numberOfReservedLiterals [
-
-	^ 1
-]
-
-{ #category : #accessing }
 CompiledBlock >> outerCode [
 	"answer the compiled code that I am installed in, or nil if none."
 	^self literalAt: self numLiterals

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -479,7 +479,7 @@ CompiledCode >> literals [
 	"Answer an Array of the literals referenced by the receiver.	
 	 Exclude superclass + selector/properties"
 	| literals numberLiterals |
-	literals := Array new: (numberLiterals := self numLiterals - self numberOfReservedLiterals).
+	literals := Array new: (numberLiterals := self numLiterals - self literalsToSkip).
 	1 to: numberLiterals do: [:index |
 		literals at: index put: (self objectAt: index + 1)].
 	^literals
@@ -600,12 +600,6 @@ CompiledCode >> numTemps [
 	"Answer the number of temporary variables used by the receiver."
 	
 	^ (self header bitShift: -18) bitAnd: 16r3F
-]
-
-{ #category : #accessing }
-CompiledCode >> numberOfReservedLiterals [
-
-	^ self subclassResponsibility
 ]
 
 { #category : #literals }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -705,12 +705,6 @@ CompiledMethod >> name [
 	^ self printString
 ]
 
-{ #category : #accessing }
-CompiledMethod >> numberOfReservedLiterals [
-
-	^ 2
-]
-
 { #category : #private }
 CompiledMethod >> penultimateLiteral [
 	"Answer the penultimate literal of the receiver, which holds either


### PR DESCRIPTION
There was both numberOfReservedLiterals and literalsToSkip. Keep literalsToSkip as the other had just one sender.

no deprecation as it is really private