### PR TITLE
Variable-accessesRef-cleanup

### DIFF
--- a/src/Calypso-SystemQueries/ClyVariable.class.st
+++ b/src/Calypso-SystemQueries/ClyVariable.class.st
@@ -120,7 +120,7 @@ ClyVariable >> isAccessedIn: aMethod [
 	
 	(self isAccessibleFrom: aMethod origin)	ifFalse: [ ^false ].
 		
-	^(actualVariable isReadIn: aMethod) or: [ actualVariable isWrittenIn: aMethod ]
+	^actualVariable isAccessedIn: aMethod
 ]
 
 { #category : #testing }

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -79,6 +79,13 @@ CompiledCode >> accessesField: varIndex [
 ]
 
 { #category : #scanning }
+CompiledCode >> accessesRef: literalVariable [
+	"Answer whether this method accesses the LiteralVariable"
+
+	^ (self readsRef: literalVariable) or: [ self writesRef: literalVariable ]
+]
+
+{ #category : #scanning }
 CompiledCode >> accessesSlot: aSlot [
 	^aSlot isAccessedIn: self
 	

--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -116,7 +116,7 @@ LiteralVariable >> installingIn: aClass [
 { #category : #queries }
 LiteralVariable >> isAccessedIn: aMethod [ 
 	
-	^(self isReadIn: aMethod) or: [ self isWrittenIn: aMethod ]
+	^aMethod accessesRef: self
 ]
 
 { #category : #testing }


### PR DESCRIPTION
- add CompiledCode>>#accessesRef: 
- use it in LiteralVariable>>#isAccessedIn:
- simplify ClyVariable>>isAccessedIn: