### PR TITLE
Global-and-Class-Var-add-scope

### DIFF
--- a/src/Kernel/GlobalVariable.class.st
+++ b/src/Kernel/GlobalVariable.class.st
@@ -30,3 +30,9 @@ GlobalVariable >> emitValue: methodBuilder [
 GlobalVariable >> isGlobalVariable [
 	^true
 ]
+
+{ #category : #accessing }
+GlobalVariable >> scope [
+	"The scope of Globals is Smalltalk globals"
+	^ Smalltalk globals
+]

--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -216,6 +216,11 @@ LiteralVariable >> readInContext: aContext [
 	^self value
 ]
 
+{ #category : #accessing }
+LiteralVariable >> scope [
+	^self definingClass
+]
+
 { #category : #printing }
 LiteralVariable >> storeOn: aStream [
 	"Store in the format (key->value)"

--- a/src/Slot-Tests/ClassVariableTest.class.st
+++ b/src/Slot-Tests/ClassVariableTest.class.st
@@ -88,6 +88,13 @@ ClassVariableTest >> testRemoveProperty [
 	self assert: classVariable properties isNil.
 ]
 
+{ #category : #tests }
+ClassVariableTest >> testScope [
+	self
+		assert: (SmalltalkImage classVariableNamed: #CompilerClass) scope
+		equals: SmalltalkImage
+]
+
 { #category : #'tests  - properties' }
 ClassVariableTest >> testWritingToContext [
 

--- a/src/Slot-Tests/GlobalVariableTest.class.st
+++ b/src/Slot-Tests/GlobalVariableTest.class.st
@@ -47,3 +47,9 @@ GlobalVariableTest >> testRemoveProperty [
 		
 	self assert: self class binding properties isNil.
 ]
+
+{ #category : #'tests  - properties' }
+GlobalVariableTest >> testScope [
+
+	self assert: Object binding scope equals: Object environment
+]

--- a/src/Slot-Tests/TemporaryVariableTest.class.st
+++ b/src/Slot-Tests/TemporaryVariableTest.class.st
@@ -78,6 +78,15 @@ TemporaryVariableTest >> testReadTemporaryVariablesMethod [
 ]
 
 { #category : #tests }
+TemporaryVariableTest >> testScope [
+	| method |
+	method := self class >> #testTemporaryVariablesMethod.
+	self assert: method temporaryVariables first scope isMethodScope
+	
+
+]
+
+{ #category : #tests }
 TemporaryVariableTest >> testTemporaryVariablesBlock [
 	| block |
 	block := [ | b | b +2  ].


### PR DESCRIPTION
add #scope methods to LiteralVariable
- return Smalltalk globals for Global vars
- return the class for Class Vars

LocalVariable have already a #scope accessor