### PR TITLE
CompiledCode-refersToLiteral

### DIFF
--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -116,11 +116,6 @@ CompiledBlock >> outerCode: aCompiledCode [
 ]
 
 { #category : #accessing }
-CompiledBlock >> penultimateLiteral [
-	^ nil
-]
-
-{ #category : #accessing }
 CompiledBlock >> pragmas [
 	^ #()
 ]

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -98,12 +98,6 @@ CompiledCode >> addWithAllBlocksInto: collected [
 ]
 
 { #category : #literals }
-CompiledCode >> additionalMethodStateRefersToLiteral: literal [
-	^ self penultimateLiteral isMethodProperties
-		and: [ self penultimateLiteral refersToLiteral: literal ]
-]
-
-{ #category : #literals }
 CompiledCode >> allLiterals [
 	"Answer an Array of the literals referenced by the receiver.	
 	 including superclass + selector/properties"
@@ -642,11 +636,6 @@ CompiledCode >> originMethod [
 ]
 
 { #category : #accessing }
-CompiledCode >> penultimateLiteral [
-	^ self subclassResponsibility
-]
-
-{ #category : #accessing }
 CompiledCode >> pragmas [
 	^ self subclassResponsibility
 ]
@@ -717,17 +706,14 @@ CompiledCode >> referredInstVars [
 	"Dictionary fromPairs: (Point selectors collect: [:s| { s. (Point >> s) referredInstVars}])".
 ]
 
-{ #category : #literals }
+{ #category : #testing }
 CompiledCode >> refersToLiteral: aLiteral [
 	"Answer true if any literal in this method is literal,
 	even if embedded in array structure."
 
-	(self additionalMethodStateRefersToLiteral: aLiteral)
-		ifTrue: [ ^ true ].
-
-	"exclude selector or additional method state (penultimate slot) 
-	and methodClass or outerCode (last slot)"
 	1 to: self numLiterals - self literalsToSkip do: [ :index | 
+		"exclude selector or additional method state (penultimate slot) 
+		and methodClass or outerCode (last slot)"
 		((self literalAt: index) refersToLiteral: aLiteral)
 			ifTrue: [ ^ true ] ].
 

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -326,6 +326,12 @@ CompiledMethod class >> toReturnSelfTrailerBytes: trailer [
 	^self newBytes: 3 trailerBytes: trailer nArgs: 0 nTemps: 0 nStack: 0 nLits: 2 primitive: 256
 ]
 
+{ #category : #literals }
+CompiledMethod >> additionalMethodStateRefersToLiteral: literal [
+	^ self penultimateLiteral isMethodProperties
+		and: [ self penultimateLiteral refersToLiteral: literal ]
+]
+
 { #category : #'source code management' }
 CompiledMethod >> argumentNames [
 	^ self propertyAt: #argumentNames ifAbsent: [ super argumentNames ]
@@ -928,6 +934,17 @@ CompiledMethod >> readsField: varIndex [
 	"Answer whether the receiver loads the instance variable indexed by the argument."
 	self isReturnField ifTrue: [^self returnField = (varIndex - 1)].
 	^ super readsField: varIndex 
+]
+
+{ #category : #literals }
+CompiledMethod >> refersToLiteral: aLiteral [
+	"Answer true if any literal in this method is literal,
+	even if embedded in array structure."
+
+	(self additionalMethodStateRefersToLiteral: aLiteral)
+		ifTrue: [ ^ true ].
+
+	^super refersToLiteral: aLiteral
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
refersToLiteral: was implemented on CompiledCode and thus checking #additionalMethodStateRefersToLiteral: for every embedded block.
blocks never answer tru for additionalMethodStateRefersToLiteral:
- implement the version without this check on CompiledCode
- implement on CompiledMethod doing the check, then super
- move penultimateLiteral and additionalMethodStateRefersToLiteral: to CompiledMethod only