### PR TITLE
Variable-isSelf-isSuper-deprecation

### DIFF
--- a/src/Deprecated90/OCSelfVariable.class.st
+++ b/src/Deprecated90/OCSelfVariable.class.st
@@ -26,16 +26,6 @@ OCSelfVariable >> initialize [
 	name := 'self'
 ]
 
-{ #category : #testing }
-OCSelfVariable >> isSelf [
-	^true
-]
-
-{ #category : #testing }
-OCSelfVariable >> isSelfOrSuper [
-	^true
-]
-
 { #category : #debugging }
 OCSelfVariable >> readInContext: aContext [
 	^aContext receiver

--- a/src/Deprecated90/OCSuperVariable.class.st
+++ b/src/Deprecated90/OCSuperVariable.class.st
@@ -26,17 +26,6 @@ OCSuperVariable >> initialize [
 	name := 'super'
 ]
 
-{ #category : #testing }
-OCSuperVariable >> isSelfOrSuper [
-	
-	^ true
-]
-
-{ #category : #testing }
-OCSuperVariable >> isSuper [
-	^true
-]
-
 { #category : #debugging }
 OCSuperVariable >> readInContext: aContext [
 	^aContext receiver

--- a/src/Deprecated90/Variable.extension.st
+++ b/src/Deprecated90/Variable.extension.st
@@ -34,12 +34,40 @@ Variable >> isLocal [
 ]
 
 { #category : #'*Deprecated90' }
+Variable >> isSelf [
+	self 
+		deprecated: 'Use #isSelfVariable instead.' 
+		transformWith: '`@receiver isSelf' -> '`@receiver isSelfVariable'.
+
+	^self isSelfVariable
+]
+
+{ #category : #'*Deprecated90' }
+Variable >> isSelfOrSuper [
+	self 
+		deprecated: 'Use #isSelfOrSuperVariable instead.' 
+		transformWith: '`@receiver isSelfOrSuper' -> '`@receiver isSelfOrSuperVariable'.
+
+	^ self isSelfOrSuperVariable
+]
+
+{ #category : #'*Deprecated90' }
 Variable >> isSpecialVariable [
 	self 
 		deprecated: 'Use #isReservedVariable instead.' 
 		transformWith: '`@receiver isSpecialVariable' -> '`@receiver isReservedVariable'.
 	
 	^ self isReservedVariable
+]
+
+{ #category : #'*Deprecated90' }
+Variable >> isSuper [
+	self 
+		deprecated: 'Use #isSuperVariable instead.' 
+		transformWith: '`@receiver isSuper' -> '`@receiver isSuperVariable'.
+		
+	^ self isSuperVariable
+
 ]
 
 { #category : #'*Deprecated90' }

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -145,18 +145,17 @@ Variable >> isReservedVariable [
 ]
 
 { #category : #testing }
-Variable >> isSelf [
+Variable >> isSelfOrSuperVariable [
+	^ self isSelfVariable or: [ self isSuperVariable ]
+]
+
+{ #category : #testing }
+Variable >> isSelfVariable [
 	^false
 ]
 
 { #category : #testing }
-Variable >> isSelfOrSuper [
-	
-	^ self isSelf or: [ self isSuper ]
-]
-
-{ #category : #testing }
-Variable >> isSuper [
+Variable >> isSuperVariable [
 	^false
 ]
 

--- a/src/OpalCompiler-Core/SelfVariable.class.st
+++ b/src/OpalCompiler-Core/SelfVariable.class.st
@@ -27,7 +27,7 @@ SelfVariable >> initialize [
 ]
 
 { #category : #testing }
-SelfVariable >> isSelf [
+SelfVariable >> isSelfVariable [
 	^true
 ]
 

--- a/src/OpalCompiler-Core/SuperVariable.class.st
+++ b/src/OpalCompiler-Core/SuperVariable.class.st
@@ -27,7 +27,7 @@ SuperVariable >> initialize [
 ]
 
 { #category : #testing }
-SuperVariable >> isSuper [
+SuperVariable >> isSuperVariable [
 	^true
 ]
 

--- a/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
@@ -70,7 +70,7 @@ OCASTCheckerTest >> testExampleSelf [
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 0.
-	self assert: (ast scope lookupVar: 'self') isSelf.
+	self assert: (ast scope lookupVar: 'self') isSelfVariable.
 	
 	assignment := RBParseTreeSearcher treeMatching: 'self result: ``@anything' in: ast. 
 	self assert: assignment arguments first binding isSelf.
@@ -81,7 +81,6 @@ OCASTCheckerTest >> testExampleSelfReceiver [
 	| ast |
 	ast := (OCOpalExamples>>#exampleSelfReceiver) parseTree.
 	self assert: ast body statements first receiver isSelf.
-	self assert: ast body statements first receiver isSelfOrSuper.
 ]
 
 { #category : #'testing - variables' }
@@ -91,18 +90,17 @@ OCASTCheckerTest >> testExampleSuper [
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 0.
-	self assert: (ast scope lookupVar: 'super') isSuper.
+	self assert: (ast scope lookupVar: 'super') isSuperVariable.
 	
 	assignment := RBParseTreeSearcher treeMatching: 'self result:``@anything' in: ast. 
-	self assert: assignment arguments first binding isSuper.
+	self assert: assignment arguments first variable isSuperVariable.
 ]
 
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testExampleSuperReceiver [
 	| ast |
 	ast := (OCOpalExamples>>#exampleSuperReceiver) parseTree.
-	self assert: ast body statements first receiver isSuper.
-	self assert: ast body statements first receiver isSelfOrSuper.
+	self assert: ast body statements first receiver isSuper
 ]
 
 { #category : #'testing - variables' }


### PR DESCRIPTION
- On the level of the Variable hierarchy, deprecate isSelf, isSuper and isSelfOrSuper --> *Variable
- reduce senders of isSelfOrSuper (I think we should remove it)
-