### PR TITLE
executeRenameRefactoringBy-move-to-Variable

### DIFF
--- a/src/NautilusRefactoring/ClassVariable.extension.st
+++ b/src/NautilusRefactoring/ClassVariable.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #ClassVariable }
 
 { #category : #'*NautilusRefactoring' }
-ClassVariable >> executeRenameRefactoringBy: aNautilusRefactoring inClass: aClass [
-	aNautilusRefactoring renameClassVarNamed: self name from: aClass
+ClassVariable >> executeRenameRefactoringBy: aNautilusRefactoring [
+	aNautilusRefactoring renameClassVarNamed: self name from: self definingClass
 ]

--- a/src/NautilusRefactoring/GlobalVariable.extension.st
+++ b/src/NautilusRefactoring/GlobalVariable.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #GlobalVariable }
 
 { #category : #'*NautilusRefactoring' }
-GlobalVariable >> executeRenameRefactoringBy: aNautilusRefactoring inClass: aClass [
-	aNautilusRefactoring renameClass: value 
+GlobalVariable >> executeRenameRefactoringBy: aNautilusRefactoring [
+	aNautilusRefactoring renameClass: self definingClass 
 ]

--- a/src/NautilusRefactoring/LocalVariable.extension.st
+++ b/src/NautilusRefactoring/LocalVariable.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #LocalVariable }
+
+{ #category : #'*NautilusRefactoring' }
+LocalVariable >> executeRenameRefactoringBy: aNautilusRefactoring for: aNode [
+
+	aNautilusRefactoring renameTemporaryNamed: self name asString Between: (aNode start to: aNode stop) from: aNode methodNode
+]

--- a/src/NautilusRefactoring/RBArgumentNode.extension.st
+++ b/src/NautilusRefactoring/RBArgumentNode.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #RBArgumentNode }
-
-{ #category : #'*NautilusRefactoring' }
-RBArgumentNode >> executeRenameRefactoringBy: aNautilusRefactoring [
-
-	aNautilusRefactoring renameTemporaryNamed: self name asString Between: (self start to: self stop) from: self methodNode
-]

--- a/src/NautilusRefactoring/RBGlobalNode.extension.st
+++ b/src/NautilusRefactoring/RBGlobalNode.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #RBGlobalNode }
-
-{ #category : #'*NautilusRefactoring' }
-RBGlobalNode >> executeRenameRefactoringBy: aNautilusRefactoring [
-
-	self binding executeRenameRefactoringBy: aNautilusRefactoring inClass: self methodNode methodClass
-]

--- a/src/NautilusRefactoring/RBInstanceVariableNode.extension.st
+++ b/src/NautilusRefactoring/RBInstanceVariableNode.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #RBInstanceVariableNode }
-
-{ #category : #'*NautilusRefactoring' }
-RBInstanceVariableNode >> executeRenameRefactoringBy: aNautilusRefactoring [
-
-	aNautilusRefactoring renameInstVarNamed: self name asString from: self methodNode methodClass
-]

--- a/src/NautilusRefactoring/RBTemporaryNode.extension.st
+++ b/src/NautilusRefactoring/RBTemporaryNode.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : #RBTemporaryNode }
 
 { #category : #'*NautilusRefactoring' }
-RBTemporaryNode >> executeRenameRefactoringBy: aNautilusRefactoring [
+RBTemporaryNode >> executeRenameRefactoringBy: aNautilusRefactoring for: aNode [
 
-	aNautilusRefactoring renameTemporaryNamed: self name asString Between: (self start to: self stop) from: self methodNode
+	variable executeRenameRefactoringBy: aNautilusRefactoring for: aNode
 ]

--- a/src/NautilusRefactoring/RBVariableNode.extension.st
+++ b/src/NautilusRefactoring/RBVariableNode.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #RBVariableNode }
+
+{ #category : #'*NautilusRefactoring' }
+RBVariableNode >> executeRenameRefactoringBy: aNautilusRefactoring [
+	self executeRenameRefactoringBy: aNautilusRefactoring for: self
+
+]
+
+{ #category : #'*NautilusRefactoring' }
+RBVariableNode >> executeRenameRefactoringBy: aNautilusRefactoring for: aNode [
+	variable executeRenameRefactoringBy: aNautilusRefactoring
+
+]

--- a/src/NautilusRefactoring/Slot.extension.st
+++ b/src/NautilusRefactoring/Slot.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Slot }
+
+{ #category : #'*NautilusRefactoring' }
+Slot >> executeRenameRefactoringBy: aNautilusRefactoring [
+
+	aNautilusRefactoring renameInstVarNamed: self name asString from: self definingClass
+]


### PR DESCRIPTION
move the executeRenameRefactoringBy: extensions methods from the RBVariableNode subclasses to the Variable hierarchy