### PR TITLE
Variables Refactoring: isSelfVariable-Part2

### DIFF
--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -820,6 +820,7 @@ RBParserTest >> testQuerying [
 			('test: a`	| b |`	b := (self foo: a; bar) baz.`	b := super test: b.`	^[:arg1 | self foa1 + (super foo: arg1 foo: a foo: b)]'
 				copyReplaceAll: '`'
 				with: (String with: (Character value: 13))).
+	tree doSemanticAnalysis.
 	self assert: tree selfMessages asSortedCollection asArray equals: #(#bar #foa1 #foo:).
 	self assert: tree superMessages asSortedCollection asArray equals: #(#foo:foo:foo: #test:).
 	aNode := tree whichNodeIsContainedBy: (112 to: 112).

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -180,7 +180,7 @@ RBMessageNode >> isMessage [
 
 { #category : #testing }
 RBMessageNode >> isSelfSend [
-	^ self receiver isSelf
+	^ self receiver isSelfVariable
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -550,6 +550,11 @@ RBProgramNode >> isSelfOrSuper [
 ]
 
 { #category : #testing }
+RBProgramNode >> isSelfVariable [
+	^ false
+]
+
+{ #category : #testing }
 RBProgramNode >> isSequence [
 	^false
 ]
@@ -560,12 +565,17 @@ RBProgramNode >> isSuper [
 ]
 
 { #category : #testing }
+RBProgramNode >> isSuperVariable [
+	^false
+]
+
+{ #category : #testing }
 RBProgramNode >> isTemp [
 	^ false
 ]
 
 { #category : #testing }
-RBProgramNode >> isThisContext [
+RBProgramNode >> isThisContextVariable [
 	^ false
 ]
 

--- a/src/AST-Core/RBThisContextNode.class.st
+++ b/src/AST-Core/RBThisContextNode.class.st
@@ -18,8 +18,3 @@ RBThisContextNode class >> new [
 RBThisContextNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitThisContextNode: self
 ]
-
-{ #category : #testing }
-RBThisContextNode >> isThisContext [
-	^ true
-]

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -158,11 +158,26 @@ RBVariableNode >> isSelf [
 ]
 
 { #category : #testing }
+RBVariableNode >> isSelfVariable [
+	^variable isSelfVariable
+]
+
+{ #category : #testing }
 RBVariableNode >> isSuper [
 	"normally this method is not needed (if all the RBVariable creations create RBSuperNode instead but
 	since we do not control this."
 	
 	^ self name = 'super'
+]
+
+{ #category : #testing }
+RBVariableNode >> isSuperVariable [
+	^ variable isSuperVariable
+]
+
+{ #category : #testing }
+RBVariableNode >> isThisContextVariable [
+	^variable isThisContextVariable
 ]
 
 { #category : #testing }

--- a/src/Debugger-Model-Tests/StepOverTest.class.st
+++ b/src/Debugger-Model-Tests/StepOverTest.class.st
@@ -96,7 +96,7 @@ StepOverTest >> testStepOver [
 	"Checking that the execution is at the 'self stepA2' node of the stepA1 method"
 	self assert: session interruptedContext method equals: self class >>#stepA1.
 	node := self class >>#stepA1 sourceNodeForPC: session interruptedContext pc.
-	self assert: node receiver isSelf.
+	self assert: node receiver isSelfVariable.
 	self assert: node selector equals: #stepA2.
 	session stepOver.
 	"Checking if the stepOver stepped over the call to stepA2 and brought the execution to the return node of stepA1"
@@ -137,7 +137,7 @@ StepOverTest >> testStepOverComputedReturn [
 	"The initial step done by stepOver should return the stepC2 context, ending the stepOver in the stepC1 context, on the 'self stepC2' node"
 	self assert: session interruptedContext method equals: self class >>#stepC1.
 	node := self class >>#stepC1 sourceNodeForPC: session interruptedContext pc.
-	self assert: node receiver isSelf.
+	self assert: node receiver isSelfVariable.
 	self assert: node selector equals: #stepC2.
 ]
 
@@ -169,7 +169,7 @@ StepOverTest >> testStepOverLastNodeOfContext [
 	"Checking that the execution is at the 'self stepB3' node of the stepB2 method"
 	self assert: session interruptedContext method equals: self class >>#stepB2.
 	node := self class >>#stepB2 sourceNodeForPC: session interruptedContext pc.
-	self assert: node receiver isSelf.
+	self assert: node receiver isSelfVariable.
 	self assert: node selector equals: #stepB3.
 	session stepOver.
 	"Checking that after the stepOver, the execution is at the method node of the stepB2 method"

--- a/src/Debugger-Model-Tests/StepThroughTest.class.st
+++ b/src/Debugger-Model-Tests/StepThroughTest.class.st
@@ -52,7 +52,7 @@ StepThroughTest >> testStepThrough [
 	self assert: (session interruptedContext method) equals: (self class>>#stepA1).
 	node := self class>>#stepA1 sourceNodeForPC: session interruptedContext pc.
 	self assert: node isMessage.
-	self assert: node receiver isSelf.
+	self assert: node receiver isSelfVariable.
 	self assert: node selector equals: #evalBlockThenReturnOne:.
 	session stepThrough.
 
@@ -65,7 +65,7 @@ StepThroughTest >> testStepThrough [
 	self assert: (session interruptedContext method) equals: expectedMethod.
 	node := expectedMethod sourceNodeForPC: session interruptedContext pc.
 	self assert: node isMessage.
-	self assert: node receiver isSelf.
+	self assert: node receiver isSelfVariable.
 	self assert: node selector equals: #stepA2.
 	
 ]
@@ -86,7 +86,7 @@ StepThroughTest >> testStepThroughDoesTheSameThingAsStepOverWhenNoBlockIsInvolve
 	"Checking that after the step over, we reached the node 'self stepB3' of method stepB1"
 	node := self class>>#stepB1 sourceNodeForPC: session interruptedContext pc.
 	self assert: node isMessage.
-	self assert: node receiver isSelf.
+	self assert: node receiver isSelfVariable.
 	self assert: node selector equals: #stepB3.
 	
 	"Set up the debugged execution again"
@@ -100,6 +100,6 @@ StepThroughTest >> testStepThroughDoesTheSameThingAsStepOverWhenNoBlockIsInvolve
 	"Checking that after the step through, we reached the node 'self stepB3' of method stepB1 (the same node that was reached with the step over"
 	node := self class>>#stepB1 sourceNodeForPC: session interruptedContext pc.
 	self assert: node isMessage.
-	self assert: node receiver isSelf.
+	self assert: node receiver isSelfVariable.
 	self assert: node selector equals: #stepB3.
 ]

--- a/src/Deprecated90/OCThisContextVariable.class.st
+++ b/src/Deprecated90/OCThisContextVariable.class.st
@@ -26,11 +26,6 @@ OCThisContextVariable >> initialize [
 	name := 'thisContext'
 ]
 
-{ #category : #testing }
-OCThisContextVariable >> isThisContext [
-	^true
-]
-
 { #category : #debugging }
 OCThisContextVariable >> readInContext: aContext [
 	^aContext

--- a/src/Deprecated90/RBProgramNode.extension.st
+++ b/src/Deprecated90/RBProgramNode.extension.st
@@ -1,6 +1,15 @@
 Extension { #name : #RBProgramNode }
 
 { #category : #'*Deprecated90' }
+RBProgramNode >> isThisContext [
+	self 
+		deprecated: 'Use #isThisContextVariable instead.' 
+		transformWith: '`@receiver isThisContext' -> '`@receiver isThisContextVariable'.
+
+	^ self isThisContextVariable
+]
+
+{ #category : #'*Deprecated90' }
 RBProgramNode >> methodComments [
 	self
 		deprecated: 'Please use #comments instead'

--- a/src/Deprecated90/Variable.extension.st
+++ b/src/Deprecated90/Variable.extension.st
@@ -71,6 +71,15 @@ Variable >> isSuper [
 ]
 
 { #category : #'*Deprecated90' }
+Variable >> isThisContext [
+	self 
+		deprecated: 'Use #isThisContextVariable instead.' 
+		transformWith: '`@receiver isThisContext' -> '`@receiver isThisContextVariable'.
+
+	^ self isThisContextVariable
+]
+
+{ #category : #'*Deprecated90' }
 Variable >> isUndeclared [
 	self 
 		deprecated: 'Use #isUndeclaredVariable instead.' 

--- a/src/Flashback-Decompiler/FBDOptimizedMessagesRewriter.class.st
+++ b/src/Flashback-Decompiler/FBDOptimizedMessagesRewriter.class.st
@@ -250,7 +250,7 @@ FBDOptimizedMessagesRewriter >> isIfTrue: msgNode [
 
 { #category : #testing }
 FBDOptimizedMessagesRewriter >> isLastStatementReturnSelf: seq [
-	^ seq parent isMethod and: [ seq statements last isReturn and: [ seq statements last value isSelfVariable ] ]
+	^ seq parent isMethod and: [ seq statements last isReturn and: [ seq statements last value isSelf ] ]
 ]
 
 { #category : #testing }

--- a/src/Flashback-Decompiler/FBDOptimizedMessagesRewriter.class.st
+++ b/src/Flashback-Decompiler/FBDOptimizedMessagesRewriter.class.st
@@ -250,7 +250,7 @@ FBDOptimizedMessagesRewriter >> isIfTrue: msgNode [
 
 { #category : #testing }
 FBDOptimizedMessagesRewriter >> isLastStatementReturnSelf: seq [
-	^ seq parent isMethod and: [ seq statements last isReturn and: [ seq statements last value isSelf ] ]
+	^ seq parent isMethod and: [ seq statements last isReturn and: [ seq statements last value isSelfVariable ] ]
 ]
 
 { #category : #testing }

--- a/src/GeneralRules/ReCollectionMessagesToExternalObjectRule.class.st
+++ b/src/GeneralRules/ReCollectionMessagesToExternalObjectRule.class.st
@@ -43,7 +43,7 @@ ReCollectionMessagesToExternalObjectRule >> initialize [
 { #category : #helpers }
 ReCollectionMessagesToExternalObjectRule >> isNotSpecialVariable: variableNode [
 
-	variableNode isSelfOrSuper ifTrue: [ ^false ]. 
+	variableNode isReservedVariable ifTrue: [ ^false ]. 
 	(Smalltalk globals includesKey: variableNode name asSymbol) ifTrue: [ ^ false ].
 	^ true
 	

--- a/src/GeneralRules/ReReturnsBooleanAndOtherRule.class.st
+++ b/src/GeneralRules/ReReturnsBooleanAndOtherRule.class.st
@@ -50,7 +50,7 @@ ReReturnsBooleanAndOtherRule >> checkIfNodeIsBool: node [
 
 { #category : #private }
 ReReturnsBooleanAndOtherRule >> checkIfNodeIsNotBool: node [
-	^ node isSelf or:
+	^ node isSelfVariable or:
 		[ node isLiteralNode and: [ (#(true false) includes: node value) not ] ]
 ]
 

--- a/src/GeneralRules/ReSuperWithoutSend.class.st
+++ b/src/GeneralRules/ReSuperWithoutSend.class.st
@@ -15,7 +15,7 @@ Class {
 { #category : #running }
 ReSuperWithoutSend >> basicCheck: aNode [
 	aNode isVariable ifFalse: [ ^ false ].
-	aNode isSuper ifFalse: [ ^ false ].
+	aNode isSuperVariable ifFalse: [ ^ false ].
 	aNode parent isMessage ifTrue: [
 		"if we are the receiver, everything is ok"  
 		^aNode parent receiver ~= aNode

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -171,7 +171,7 @@ Variable >> isTemporaryVariable [
 ]
 
 { #category : #testing }
-Variable >> isThisContext [
+Variable >> isThisContextVariable [
 	^false
 ]
 

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -293,7 +293,7 @@ OCASTTranslator >> emitTimesRepeat: aMessageNode [
 	block := aMessageNode arguments last.
 	
 	limitEmit := [valueTranslator visitNode: limit].
-	limit isLiteral | limit isSelf | limit isSuper ifFalse: [
+	limit isLiteral | limit isSelfVariable | limit isSuperVariable ifFalse: [
 		valueTranslator visitNode: limit.
 		methodBuilder addTemp: #'0limit'.
 		methodBuilder storeTemp: #'0limit'.
@@ -349,7 +349,7 @@ OCASTTranslator >> emitToDo: aMessageNode step: step [
 	iterator := block arguments first binding.
 	
 	limitEmit := [valueTranslator visitNode: limit].
-	limit isLiteralNode | limit isSelf | limit isSuper | limit isArgumentVariable ifFalse: [
+	limit isLiteralNode | limit isSelfVariable | limit isSuperVariable | limit isArgumentVariable ifFalse: [
 		valueTranslator visitNode: limit.
 		methodBuilder addTemp: ('0limit_', iterator name).
 		methodBuilder storeTemp: ('0limit_', iterator name).

--- a/src/OpalCompiler-Core/ThisContextVariable.class.st
+++ b/src/OpalCompiler-Core/ThisContextVariable.class.st
@@ -27,7 +27,7 @@ ThisContextVariable >> initialize [
 ]
 
 { #category : #testing }
-ThisContextVariable >> isThisContext [
+ThisContextVariable >> isThisContextVariable [
 	^true
 ]
 

--- a/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
@@ -73,14 +73,15 @@ OCASTCheckerTest >> testExampleSelf [
 	self assert: (ast scope lookupVar: 'self') isSelfVariable.
 	
 	assignment := RBParseTreeSearcher treeMatching: 'self result: ``@anything' in: ast. 
-	self assert: assignment arguments first binding isSelf.
+	self assert: assignment arguments first variable isSelfVariable.
 ]
 
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testExampleSelfReceiver [
 	| ast |
 	ast := (OCOpalExamples>>#exampleSelfReceiver) parseTree.
-	self assert: ast body statements first receiver isSelf.
+	ast doSemanticAnalysis.
+	self assert: ast body statements first receiver isSelfVariable.
 ]
 
 { #category : #'testing - variables' }
@@ -100,7 +101,8 @@ OCASTCheckerTest >> testExampleSuper [
 OCASTCheckerTest >> testExampleSuperReceiver [
 	| ast |
 	ast := (OCOpalExamples>>#exampleSuperReceiver) parseTree.
-	self assert: ast body statements first receiver isSuper
+	ast doSemanticAnalysis.
+	self assert: ast body statements first receiver isSuperVariable
 ]
 
 { #category : #'testing - variables' }
@@ -110,10 +112,10 @@ OCASTCheckerTest >> testExampleThisContext [
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 0.
-	self assert: (ast scope lookupVar: 'thisContext') isThisContext.
+	self assert: (ast scope lookupVar: 'thisContext') isThisContextVariable.
 	
 	assignment := RBParseTreeSearcher treeMatching: 'self result: ``@anything' in: ast. 
-	self assert: assignment arguments first binding isThisContext.
+	self assert: assignment arguments first variable isThisContextVariable.
 ]
 
 { #category : #'testing - blocks - optimized' }

--- a/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
@@ -89,7 +89,7 @@ RBInlineMethodRefactoring >> findSelectedMessage [
 		ifTrue: [ sourceMessage := sourceMessage messages last ].
 	sourceMessage isMessage
 		ifFalse: [ self refactoringFailure: 'The selection doesn''t appear to be a message send' ].
-	sourceMessage receiver isSelfOrSuper
+	(sourceMessage receiver isSelf or: [ sourceMessage receiver isSuper ])
 		ifFalse: [ self refactoringError: 'Cannot inline non-self messages' ]
 ]
 

--- a/src/Reflectivity/MetaLinkInstaller.class.st
+++ b/src/Reflectivity/MetaLinkInstaller.class.st
@@ -196,7 +196,7 @@ MetaLinkInstaller >> installSuperJumpLinksInMethodNode: node [
 	instead of starting the lookup in the super class (wich is the original class of the object),
 	the lookup is started in the super super class (which is the intented superclass)."
 
-	(node allChildren select: [ :n | n isSuper ])
+	(node allChildren select: [ :n | n isSuperVariable ])
 		do: [ :superNode | 
 			| messageSendNode superSuperClass link |
 			messageSendNode := superNode parent.


### PR DESCRIPTION
- Implement isSelfVariable, isSuperVariable and isThisContextVariable on RBProgramNode
- do *NOT* change isSelf, isSuper  yet
- deprecate #isThisContext
- fix many users of isSelf, isSuper
- replace all users of isSelfOrSuper (there were two, one should use #isReservedVariable...)

More to follow, the other cases require more then just a trivial replacement (as they asume #isSelf to return a good result on the non-name analysed AST)