### PR TITLE
Variables-isReferenced-cleanup

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -838,17 +838,17 @@ Behavior >> hasAbstractMethods [
 ]
 
 { #category : #'testing method dictionary' }
+Behavior >> hasMethodAccessingVariable: aVariable [
+	"Answer true if any of my methods access the variable"
+
+	^self methods anySatisfy: [ :method | aVariable isAccessedIn: method ]
+]
+
+{ #category : #'testing method dictionary' }
 Behavior >> hasMethods [
 	"Answer whether the receiver has any methods in its method dictionary."
 
 	^ self methodDict notEmpty
-]
-
-{ #category : #'testing method dictionary' }
-Behavior >> hasMethodsAccessingSlot: aSlot [
-	"check if aSlot is accessed in this class"
-
-	^ self methods anySatisfy: [ :method | method accessesSlot: aSlot ]
 ]
 
 { #category : #'testing method dictionary' }
@@ -1143,11 +1143,7 @@ Behavior >> isPool [
 { #category : #testing }
 Behavior >> isReferenced [
 	"Returns true if the class is referenced from a method."
-	"This method should just forward to the binding, this can be done when we do not use
- 	Association for the binding on the class side"
-
-	^ self environment allBehaviors
-		anySatisfy: [ :behavior | behavior hasSelectorReferringTo: self binding ]
+	^ self binding isReferenced
 ]
 
 { #category : #'testing class hierarchy' }

--- a/src/Kernel/ClassVariable.class.st
+++ b/src/Kernel/ClassVariable.class.st
@@ -68,7 +68,7 @@ ClassVariable >> isReferenced [
 	"A class variable can only be accessed in the defintionClass and its subclasses (both class and instance side)"
 
 	^ self definingClass withAllSubclasses anySatisfy: [ :behavior | 
-		  (behavior class hasSelectorReferringTo: self) or: [ behavior hasSelectorReferringTo: self ] ]
+		  (behavior class hasMethodAccessingVariable: self) or: [ behavior hasMethodAccessingVariable: self ] ]
 ]
 
 { #category : #testing }

--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -113,7 +113,7 @@ LiteralVariable >> installingIn: aClass [
 	"I am called by the class builder. This way a class variable can change the class it is installed in"
 ]
 
-{ #category : #queries }
+{ #category : #testing }
 LiteralVariable >> isAccessedIn: aMethod [ 
 	
 	^aMethod accessesRef: self
@@ -140,7 +140,7 @@ LiteralVariable >> isReferenced [
 	"my subclasses override this if they know better"
 
 	^ Smalltalk globals allBehaviors anySatisfy: [ :behavior | 
-		  behavior hasSelectorReferringTo: self ]
+		  behavior hasMethodAccessingVariable: self ]
 ]
 
 { #category : #testing }

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -225,6 +225,12 @@ Metaclass >> isObsolete [
 ]
 
 { #category : #testing }
+Metaclass >> isReferenced [
+	"Metaclasses are never directly referenced in code"
+	^false
+]
+
+{ #category : #testing }
 Metaclass >> isSelfEvaluating [
 	^self isObsolete not
 ]

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -233,7 +233,7 @@ Slot >> isReferenced [
 	^ self owningClass 
 		ifNil: [ false ] 
 		ifNotNil: [ :class | 
-		  class withAllSubclasses anySatisfy: [ :subclass | subclass hasMethodsAccessingSlot: self ] ]
+		  class withAllSubclasses anySatisfy: [ :subclass | subclass hasMethodAccessingVariable: self ] ]
 ]
 
 { #category : #testing }

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -100,6 +100,11 @@ Variable >> hash [
 ]
 
 { #category : #testing }
+Variable >> isAccessedIn: aMethod [
+	^self usingMethods includes: aMethod
+]
+
+{ #category : #testing }
 Variable >> isArgumentVariable [
 	^false
 ]
@@ -131,6 +136,12 @@ Variable >> isLiteralVariable [
 Variable >> isLocalVariable [
 	"temporary variables and arguments are local variables"
 	^false
+]
+
+{ #category : #testing }
+Variable >> isReadIn: aCompiledCode [
+	^aCompiledCode ast readNodes
+		 anySatisfy: [ :node | node binding == self ]
 ]
 
 { #category : #testing }
@@ -190,6 +201,12 @@ Variable >> isUninitialized [
 { #category : #testing }
 Variable >> isWritable [
 	^ true
+]
+
+{ #category : #testing }
+Variable >> isWrittenIn: aCompiledCode [
+	^aCompiledCode ast variableWriteNodes
+		anySatisfy: [ :node | node binding == self ]
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -89,6 +89,12 @@ LocalVariable >> initialize [
 ]
 
 { #category : #testing }
+LocalVariable >> isAccessedIn: aMethod [
+	self isUnused ifTrue: [ ^ false ].
+	^ aMethod == self method
+]
+
+{ #category : #testing }
 LocalVariable >> isCopying [
 	^false
 ]


### PR DESCRIPTION
- Implement isAccessedIn: , isReadIn: and #isWrittenIn: on the whole Variable hierachy

- behavior #hasMethodsAccessingSlot: can now be generalised to hasMethodAccessingVariable:

- isReferenced on the LiteralVariable Hierachy can now use #hasMethodAccessingVariable:

- simplify #isReferenced on Behavior, implement it on MetaClass