### PR TITLE
ReImplementedNotSentRule-tellmeMore

### DIFF
--- a/src/GeneralRules/ReInconsistentMethodClassificationRule.class.st
+++ b/src/GeneralRules/ReInconsistentMethodClassificationRule.class.st
@@ -37,7 +37,7 @@ ReInconsistentMethodClassificationRule >> check: aMethod forCritiquesDo: aCritiq
 			 	 superProtocol == #'as yet unclassified' or: [ 
 			 	 superProtocol first = $*	 ] ]) ifFalse: [ 
 					ownerProtocol ~= superProtocol ifTrue: [
-        aCritiqueBlock cull: (self critiqueFor: aMethod) ]] ] ].
+        aCritiqueBlock cull: ((self critiqueFor: aMethod) tinyHint: 'superclass categorizes as: ' , superProtocol) ]] ] ].
 ]
 
 { #category : #accessing }
@@ -48,11 +48,6 @@ ReInconsistentMethodClassificationRule >> group [
 { #category : #accessing }
 ReInconsistentMethodClassificationRule >> name [
 	^ 'Inconsistent method classification'
-]
-
-{ #category : #accessing }
-ReInconsistentMethodClassificationRule >> rationale [
-	^ 'All methods should be put into a protocol (method category) that is equivalent to the one of the superclass, which is a Smalltalk style convention.'
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
everytime ReImplementedNotSentRule tells me the method is not correctly classified, I do not act as I do not know the right category.

This PR adds that info in the message. Even better would be a "repair" buttond.
In additon: remove #rationale so that it shows the class comment as all the other rules.