### PR TITLE
6892-SUnitTestdeprecatedMessage-called-by-testIgnoreDeprecationWarnings

### DIFF
--- a/src/SUnit-Tests/SUnitTest.class.st
+++ b/src/SUnit-Tests/SUnitTest.class.st
@@ -458,12 +458,13 @@ SUnitTest >> testHangedTestDueToFailedChildProcess [
 
 { #category : #testing }
 SUnitTest >> testIgnoreDeprecationWarnings [
-	| oldRaiseWarning |
+	| oldRaiseWarning oldShowWarning|
 	oldRaiseWarning := Deprecation raiseWarning.
+	oldShowWarning := Deprecation showWarning.
 	[ Deprecation raiseWarning: false.
 	self deprecatedMessage.
 	self assert: true ]
-		ensure: [ Deprecation raiseWarning: oldRaiseWarning ]
+		ensure: [ Deprecation raiseWarning: oldRaiseWarning. Deprecation showWarning: oldShowWarning]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
I think #showWarning is enabled on the CI, too. if we turn this off in the test, it should be silent. fixes #6892