### PR TITLE
6821-BlockClosureTest-should-not-compare-string-but-use-the-dumpVisitor

### DIFF
--- a/src/Kernel-Tests/BlockClosureTest.class.st
+++ b/src/Kernel-Tests/BlockClosureTest.class.st
@@ -283,8 +283,7 @@ BlockClosureTest >> testOneArgument [
 
 { #category : #'tests - printing' }
 BlockClosureTest >> testPrintOn [
-
-	self assert: [ 1 + 2 ] printString equals: '[ 1 + 2 ]'
+	self assert: (RBParser parseExpression: [ 1 + 2 ] printString) equals: (RBParser parseExpression: '[ 1 + 2 ]')
 ]
 
 { #category : #'tests - printing' }
@@ -300,7 +299,7 @@ BlockClosureTest >> testPrintOnBlockDefinedInMethodWithoutSourceCode [
 		block := nil method.
 		
 		self deny: method hasSourceCode.
-		self assert: block asString equals: [ 1 + 2 ] asString.
+		self assert: (RBParser parseExpression: block printString) equals: (RBParser parseExpression: '[ 1 + 2 ]').
 	] ensure: [ method removeFromSystem ]
 ]
 


### PR DESCRIPTION
we can just compare the ASTs in this case. fixes #6821