### PR TITLE
Compiler-OCAbstractMethodScope-push-node-down

### DIFF
--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -10,7 +10,8 @@ Class {
 		'copiedVars',
 		'tempVector',
 		'id',
-		'tempVectorVar'
+		'tempVectorVar',
+		'node'
 	],
 	#category : #'OpalCompiler-Core-Semantics'
 }
@@ -198,6 +199,16 @@ OCAbstractMethodScope >> newOptimizedBlockScope: int [
 { #category : #lookup }
 OCAbstractMethodScope >> nextOuterScopeContextOf: aContext [
 	^aContext
+]
+
+{ #category : #accessing }
+OCAbstractMethodScope >> node [
+	^node
+]
+
+{ #category : #accessing }
+OCAbstractMethodScope >> node: aNode [
+	node := aNode
 ]
 
 { #category : #scope }

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -5,8 +5,7 @@ Class {
 	#name : #OCAbstractScope,
 	#superclass : #Object,
 	#instVars : [
-		'outerScope',
-		'node'
+		'outerScope'
 	],
 	#category : #'OpalCompiler-Core-Semantics'
 }
@@ -65,16 +64,6 @@ OCAbstractScope >> lookupVarForDeclaration: name [
 	create that variable. Subclasses override if they do not skip but do a lookup"
 
 	^ self outerScope lookupVarForDeclaration: name
-]
-
-{ #category : #accessing }
-OCAbstractScope >> node [
-	^node
-]
-
-{ #category : #accessing }
-OCAbstractScope >> node: aNode [
-	node := aNode
 ]
 
 { #category : #lookup }

--- a/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
@@ -66,15 +66,14 @@ OCASTCheckerTest >> testExamplePrimitiveErrorCode [
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testExampleSelf [
 	| ast assignment |
-	ast := (OCOpalExamples >> #exampleSelf) parseTree.
+	ast := (OCOpalExamples>>#exampleSelf) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 0.
 	self assert: (ast scope lookupVar: 'self') isSelfVariable.
-	assignment := RBParseTreeSearcher
-		              treeMatching: 'self result: ``@anything'
-		              in: ast.
-	self assert: assignment arguments first binding isSelfVariable
+	
+	assignment := RBParseTreeSearcher treeMatching: 'self result: ``@anything' in: ast. 
+	self assert: assignment arguments first binding isSelf.
 ]
 
 { #category : #'testing - variables' }

--- a/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
@@ -66,14 +66,15 @@ OCASTCheckerTest >> testExamplePrimitiveErrorCode [
 { #category : #'testing - variables' }
 OCASTCheckerTest >> testExampleSelf [
 	| ast assignment |
-	ast := (OCOpalExamples>>#exampleSelf) parseTree.
+	ast := (OCOpalExamples >> #exampleSelf) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 0.
 	self assert: (ast scope lookupVar: 'self') isSelfVariable.
-	
-	assignment := RBParseTreeSearcher treeMatching: 'self result: ``@anything' in: ast. 
-	self assert: assignment arguments first binding isSelf.
+	assignment := RBParseTreeSearcher
+		              treeMatching: 'self result: ``@anything'
+		              in: ast.
+	self assert: assignment arguments first binding isSelfVariable
 ]
 
 { #category : #'testing - variables' }


### PR DESCRIPTION
we have the node ivar on OCAbstractScope, but it makes only sense on OCAbstractMethodScope