### PR TITLE
6943-Syntax-highlighter-doesnt-like-blocks-with-arguments

### DIFF
--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -980,7 +980,7 @@ SHRBTextStyler >> literalStyleSymbol: aValue [
 { #category : #private }
 SHRBTextStyler >> methodOrBlockArgStyleFor: anArgumentNode [
 	^ anArgumentNode isBlockVar
-		ifTrue: [ anArgumentNode variable isDefinition 
+		ifTrue: [ anArgumentNode isDefinition 
 				ifTrue: [ #blockPatternArg ]
 				ifFalse: [ #blockArg ] ]
 		ifFalse: [ #methodArg ]


### PR DESCRIPTION
fixes #6943