### PR TITLE
SyntaxHighLight-test-argstyling

### DIFF
--- a/src/Shout-Tests/SHRBTextStylerTest.class.st
+++ b/src/Shout-Tests/SHRBTextStylerTest.class.st
@@ -43,6 +43,40 @@ SHRBTextStylerTest >> tearDown [
 ]
 
 { #category : #tests }
+SHRBTextStylerTest >> testArgumentStylingBlock [
+	
+	| aText index1 index2 attribute |
+
+	aText := 'm1 self do: [:each | each ]' asText.
+	self style: aText.
+	
+	index1 := 15. "fixrst each"
+	attribute := aText attributesAt: index1.
+	self assert: attribute equals: (SHRBTextStyler  attributesFor: #blockPatternArg pixelHeight: 10).
+	
+	index2 := 22. "second each"
+	attribute := aText attributesAt: index2.
+	self assert: attribute equals: (SHRBTextStyler  attributesFor: #blockArg pixelHeight: 10)
+]
+
+{ #category : #tests }
+SHRBTextStylerTest >> testArgumentStylingMethod [
+	
+	| aText index1 index2 attribute |
+
+	aText := 'm1: arg self do: [:each | arg ]' asText.
+	self style: aText.
+	
+	index1 := 5. "first each"
+	attribute := aText attributesAt: index1.
+	self assert: attribute equals: (SHRBTextStyler  attributesFor: #methodArg pixelHeight: 10).
+	
+	index2 := 27. "second each"
+	attribute := aText attributesAt: index2.
+	self assert: attribute equals: (SHRBTextStyler  attributesFor: #tempVar pixelHeight: 10)
+]
+
+{ #category : #tests }
 SHRBTextStylerTest >> testClassAfterMessageToASymbolLowercaseShouldBeColored [
 	
 	| aText index attributes |


### PR DESCRIPTION
add two tests that test the argument styling of methods and blocks.

Fails before https://github.com/pharo-project/pharo/pull/6947, but should be green after the fix.