### PR TITLE
6862-ASTCacheMissStrategy-requires-a-class-comment

### DIFF
--- a/src/AST-Core/ASTCacheMissStrategy.class.st
+++ b/src/AST-Core/ASTCacheMissStrategy.class.st
@@ -1,3 +1,13 @@
+"
+The ASTCache is queried when we request the ast (via #ast) of a CompiledMethod.
+If the AST has already been requested before, the cache will return it.
+
+To create the AST for a method the first time, the cache uses a strategy pattern. 
+This class is the simple strategy: call #parseTree, so semantic analysis. 
+
+If Reflectivity is loaded, the RFReflectivityASTCacheStrategy is used instead which
+will take the AST from the ReflectiveMethod, should it have been created.
+"
 Class {
 	#name : #ASTCacheMissStrategy,
 	#superclass : #Object,

--- a/src/Reflectivity/RFReflectivityASTCacheStrategy.class.st
+++ b/src/Reflectivity/RFReflectivityASTCacheStrategy.class.st
@@ -1,3 +1,13 @@
+"
+The ASTCache is queried when we request the ast (via #ast) of a CompiledMethod.
+If the AST has already been requested before, the cache will return it.
+
+To create the AST for a method initially, the cache uses a strategy pattern. 
+
+This RF strategy will take the AST from the ReflectiveMethod, should it have been created (due to MetaLinks installed on the AST).
+
+The side effect is that the AST of these methods will survive a ASTCache reset and thus image restart.
+"
 Class {
 	#name : #RFReflectivityASTCacheStrategy,
 	#superclass : #Object,


### PR DESCRIPTION
comment ASTCacheMissStrategy and RFReflectivityASTCacheStrategy.

fixes #6862