### PR TITLE
ReUtilityMethodsRule-speedup-and-test

### DIFF
--- a/src/GeneralRules-Tests/ReUtilityMethodsRuleTest.class.st
+++ b/src/GeneralRules-Tests/ReUtilityMethodsRuleTest.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : #ReUtilityMethodsRuleTest,
+	#superclass : #ReAbstractRuleTestCase,
+	#category : #'GeneralRules-Tests-Migrated'
+}
+
+{ #category : #'test-support' }
+ReUtilityMethodsRuleTest >> myCritiques [
+	| critiques |
+	critiques := OrderedCollection new.
+	self subjectUnderTest  new 
+		check: (self class >> #sampleMethod: ) forCritiquesDo:[:critique | critiques add: critique].
+	^critiques 
+]
+
+{ #category : #'test-help' }
+ReUtilityMethodsRuleTest >> sampleMethod: arg [
+	^arg
+]
+
+{ #category : #tests }
+ReUtilityMethodsRuleTest >> testRule [
+	| critiques|
+ 	critiques := self myCritiques .
+
+ 	self assert: critiques size equals: 1.
+ 	self assert: critiques first rule class equals: ReUtilityMethodsRule
+]

--- a/src/GeneralRules/ReUtilityMethodsRule.class.st
+++ b/src/GeneralRules/ReUtilityMethodsRule.class.st
@@ -21,10 +21,13 @@ ReUtilityMethodsRule class >> uniqueIdentifierName [
 
 { #category : #running }
 ReUtilityMethodsRule >> basicCheck: aMethod [
-	^ (aMethod methodClass isMeta or: [ aMethod selector numArgs == 0 or: [ self utilityProtocols includes: aMethod protocol ] ]) not
-		and: [ (self subclassOf: aMethod methodClass overrides: aMethod selector) not
-				and: [ aMethod superMessages isEmpty
-						and: [ aMethod selfMessages isEmpty and: [ aMethod methodClass allInstVarNames , aMethod methodClass allClassVarNames asArray , #('self') noneSatisfy: [ :each | aMethod ast references: each ] ] ] ] ]
+	aMethod methodClass isMeta ifTrue: [ ^false ].
+	aMethod selector isUnary ifTrue: [ ^false ].
+	(self utilityProtocols includes: aMethod protocol) ifTrue: [ ^false ].
+	aMethod isOverridden ifTrue: [ ^ false ].
+   aMethod sendsToSuper ifTrue: [ ^ false ].
+	aMethod selfMessages isEmpty ifFalse: [ ^ false ].
+	^aMethod methodClass definedVariables noneSatisfy: [ :variable | variable isAccessedIn: aMethod ]
 ]
 
 { #category : #accessing }
@@ -38,14 +41,7 @@ ReUtilityMethodsRule >> name [
 ]
 
 { #category : #private }
-ReUtilityMethodsRule >> subclassOf: aClass overrides: aSelector [ 
-	^aClass subclasses anySatisfy:  
-			[:each | (each includesSelector: aSelector)
-				or: [self subclassOf: each overrides: aSelector]]
-
-]
-
-{ #category : #private }
 ReUtilityMethodsRule >> utilityProtocols [
-	^ #('*utilit*')
+	"If a method is defined in one of these protocols, then don't check if its a utility method."
+	^ #('utility' 'visiting' 'visitor')
 ]


### PR DESCRIPTION
- speedup ReUtilityMethodsRule by implementing it using better APIs
- add visitor methods to the ones that do not raise it
- add test