### PR TITLE
accessesRef-test-andspeedup

### DIFF
--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -19,6 +19,17 @@ CompiledCodeTest >> method1 [
 	#(#add #at: #remove) do: #printOn:
 ]
 
+{ #category : #'tests - scanning' }
+CompiledCodeTest >> testAccessesRef [
+	| readMethod writeMethod classVar |
+	readMethod := SmalltalkImage class>>#compilerClass.
+	writeMethod := SmalltalkImage class>>#compilerClass:.
+	classVar := SmalltalkImage classVariableNamed: #CompilerClass.
+	
+	self assert: (readMethod accessesRef: classVar).
+	self assert: (writeMethod accessesRef: classVar).
+]
+
 { #category : #accessing }
 CompiledCodeTest >> testLiteralsDoesNotContainMethodClass [
 	

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -81,8 +81,10 @@ CompiledCode >> accessesField: varIndex [
 { #category : #scanning }
 CompiledCode >> accessesRef: literalVariable [
 	"Answer whether this method accesses the LiteralVariable"
+	"we do not need to call readsRef: or #writesRef:, as if the variable 
+	is stored as a Literal, it will be accessed. This check is much faster"
 
-	^ (self readsRef: literalVariable) or: [ self writesRef: literalVariable ]
+	^ self hasLiteral: literalVariable
 ]
 
 { #category : #scanning }


### PR DESCRIPTION
- add a test for accessesRef:
- speedup the method by scanning literals, add comment