### PR TITLE
ReInconsistentMethodClassificationRule-add-repair

### DIFF
--- a/src/GeneralRules/ReInconsistentMethodClassificationRule.class.st
+++ b/src/GeneralRules/ReInconsistentMethodClassificationRule.class.st
@@ -40,6 +40,20 @@ ReInconsistentMethodClassificationRule >> check: aMethod forCritiquesDo: aCritiq
         aCritiqueBlock cull: ((self critiqueFor: aMethod) tinyHint: 'superclass categorizes as: ' , superProtocol) ]] ] ].
 ]
 
+{ #category : #helpers }
+ReInconsistentMethodClassificationRule >> critiqueFor: aMethod [
+	| supercategory |
+	supercategory := (aMethod methodClass superclass lookupSelector:
+		                  aMethod selector) protocol.
+		
+	^ (ReRefactoringCritique
+		   withAnchor: (self anchorFor: aMethod)
+		   by: self) refactoring: (RBMethodProtocolTransformation
+			   protocol: { supercategory }
+			   inMethod: aMethod selector
+			   inClass: aMethod methodClass name) asRefactoring
+]
+
 { #category : #accessing }
 ReInconsistentMethodClassificationRule >> group [
 	^ 'Design Flaws'

--- a/src/Refactoring2-Transformations/RBTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBTransformation.class.st
@@ -227,7 +227,7 @@ RBTransformation >> preconditions [
 
 { #category : #executing }
 RBTransformation >> primitiveExecute [
-	"compatibility to Refacorings"
+	"compatibility method RBRefactoring"
 	self transform
 ]
 

--- a/src/Refactoring2-Transformations/RBTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBTransformation.class.st
@@ -226,6 +226,12 @@ RBTransformation >> preconditions [
 ]
 
 { #category : #executing }
+RBTransformation >> primitiveExecute [
+	"compatibility to Refacorings"
+	self transform
+]
+
+{ #category : #executing }
 RBTransformation >> privateTransform [
 
 	self subclassResponsibility


### PR DESCRIPTION
the ReInconsistentMethodClassificationRule tells us that the category is wrong, but there is no repair button.

- This Rule addes the repair button using the RBTransformation subclass RBMethodProtocolTransformation/
- add a compatibility method to RBTransformation to make them easily usable in the Rules