### PR TITLE
ThisContextVariable-fast-usingMethods

### DIFF
--- a/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
+++ b/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
@@ -795,6 +795,15 @@ EncoderForSistaV1 class >> pushNilByte [
 	^ 79
 ]
 
+{ #category : #'instruction stream support' }
+EncoderForSistaV1 class >> readsThisContextFor: compiledMethod [
+	"Answer whether compiledMethod reads thisContext"
+	| scanner |
+	scanner := InstructionStream on: compiledMethod.
+	^ scanner scanFor: 
+		[:instr |  instr = 82 ]
+]
+
 { #category : #'bytecode decoding' }
 EncoderForSistaV1 class >> selectorToSendOrItselfFor: anInstructionStream in: method at: pc [
 	"If anInstructionStream is at a send bytecode then answer the send's selector,

--- a/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
+++ b/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
@@ -797,7 +797,7 @@ EncoderForSistaV1 class >> pushNilByte [
 
 { #category : #'compiled method support' }
 EncoderForSistaV1 class >> readsSelfFor: compiledMethod [
-	"Answer whether compiledMethod reads thisContext"
+	"Answer whether compiledMethod reads self"
 	| scanner |
 	scanner := InstructionStream on: compiledMethod.
 	^ scanner scanFor: 

--- a/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
+++ b/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
@@ -795,6 +795,15 @@ EncoderForSistaV1 class >> pushNilByte [
 	^ 79
 ]
 
+{ #category : #'compiled method support' }
+EncoderForSistaV1 class >> readsSelfFor: compiledMethod [
+	"Answer whether compiledMethod reads thisContext"
+	| scanner |
+	scanner := InstructionStream on: compiledMethod.
+	^ scanner scanFor: 
+		[:instr |  instr = 76 or: [ instr = 88 ] ]
+]
+
 { #category : #'instruction stream support' }
 EncoderForSistaV1 class >> readsThisContextFor: compiledMethod [
 	"Answer whether compiledMethod reads thisContext"

--- a/src/Kernel-BytecodeEncoders/EncoderForV3PlusClosures.class.st
+++ b/src/Kernel-BytecodeEncoders/EncoderForV3PlusClosures.class.st
@@ -337,7 +337,7 @@ EncoderForV3PlusClosures class >> pushNilByte [
 
 { #category : #'compiled method support' }
 EncoderForV3PlusClosures class >> readsSelfFor: compiledMethod [
-	"Answer whether compiledMethod reads thisContext"
+	"Answer whether compiledMethod reads self"
 	| scanner |
 	scanner := InstructionStream on: compiledMethod.
 	^ scanner scanFor: 

--- a/src/Kernel-BytecodeEncoders/EncoderForV3PlusClosures.class.st
+++ b/src/Kernel-BytecodeEncoders/EncoderForV3PlusClosures.class.st
@@ -335,6 +335,15 @@ EncoderForV3PlusClosures class >> pushNilByte [
 	^ 115
 ]
 
+{ #category : #'compiled method support' }
+EncoderForV3PlusClosures class >> readsThisContextFor: compiledMethod [
+	"Answer whether compiledMethod reads thisContext"
+	| scanner |
+	scanner := InstructionStream on: compiledMethod.
+	^ scanner scanFor: 
+		[:instr |  instr = 137 ]
+]
+
 { #category : #'instruction stream support' }
 EncoderForV3PlusClosures class >> selectorToSendOrItselfFor: anInstructionStream in: method at: pc [
 	"If anInstructionStream is at a send bytecode then answer the send's selector,

--- a/src/Kernel-BytecodeEncoders/EncoderForV3PlusClosures.class.st
+++ b/src/Kernel-BytecodeEncoders/EncoderForV3PlusClosures.class.st
@@ -336,6 +336,15 @@ EncoderForV3PlusClosures class >> pushNilByte [
 ]
 
 { #category : #'compiled method support' }
+EncoderForV3PlusClosures class >> readsSelfFor: compiledMethod [
+	"Answer whether compiledMethod reads thisContext"
+	| scanner |
+	scanner := InstructionStream on: compiledMethod.
+	^ scanner scanFor: 
+		[:instr |  instr = 112 ]
+]
+
+{ #category : #'compiled method support' }
 EncoderForV3PlusClosures class >> readsThisContextFor: compiledMethod [
 	"Answer whether compiledMethod reads thisContext"
 	| scanner |

--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -119,6 +119,17 @@ CompiledCodeTest >> testLiteralsDoesNotContainMethodName [
 ]
 
 { #category : #'tests - scanning' }
+CompiledCodeTest >> testReadsSelf [
+	| method |
+	method := self class compiler compile: 'method self doit'.
+	self assert: method readsSelf.
+	method := self class compiler compile: 'method ^self'.
+	self assert: method readsSelf.
+	method := self class compiler compile: 'method ^thisContext'.
+	self deny: method readsSelf.
+]
+
+{ #category : #'tests - scanning' }
 CompiledCodeTest >> testReadsThisContext [
 	| method |
 	method := self class compiler compile: 'method ^thisContext'.

--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -19,6 +19,17 @@ CompiledCodeTest >> method1 [
 	#(#add #at: #remove) do: #printOn:
 ]
 
+{ #category : #'tests - scanning' }
+CompiledCodeTest >> testAccessesRef [
+	| readMethod writeMethod classVar |
+	readMethod := SmalltalkImage class>>#compilerClass.
+	writeMethod := SmalltalkImage class>>#compilerClass:.
+	classVar := SmalltalkImage classVariableNamed: #CompilerClass.
+	
+	self assert: (readMethod accessesRef: classVar).
+	self assert: (writeMethod accessesRef: classVar).
+]
+
 { #category : #'tests-literals' }
 CompiledCodeTest >> testHasSelector [
 
@@ -92,17 +103,6 @@ CompiledCodeTest >> testHasSelectorSpecialSelectorIndex [
 	self deny: (method hasSelector: #method specialSelectorIndex: specialIndex).
 ]
 
-{ #category : #'tests - scanning' }
-CompiledCodeTest >> testAccessesRef [
-	| readMethod writeMethod classVar |
-	readMethod := SmalltalkImage class>>#compilerClass.
-	writeMethod := SmalltalkImage class>>#compilerClass:.
-	classVar := SmalltalkImage classVariableNamed: #CompilerClass.
-	
-	self assert: (readMethod accessesRef: classVar).
-	self assert: (writeMethod accessesRef: classVar).
-]
-
 { #category : #'tests-literals' }
 CompiledCodeTest >> testLiteralsDoesNotContainMethodClass [
 	
@@ -116,6 +116,15 @@ CompiledCodeTest >> testLiteralsDoesNotContainMethodClass [
 CompiledCodeTest >> testLiteralsDoesNotContainMethodName [
 
 	self deny: (self compiledMethod1 refersToLiteral: #method1)
+]
+
+{ #category : #'tests - scanning' }
+CompiledCodeTest >> testReadsThisContext [
+	| method |
+	method := self class compiler compile: 'method ^thisContext'.
+	self assert: method readsThisContext.
+	method := self class compiler compile: 'method ^self'.
+	self deny: method readsThisContext.
 ]
 
 { #category : #'tests-literals' }

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -440,6 +440,13 @@ CompiledCode >> isRealPrimitive [
 	^self isPrimitive and: [ self isQuick not ]
 ]
 
+{ #category : #testing }
+CompiledCode >> isReturnSelf [
+	"Answer whether the receiver is a quick return of self."
+
+	^ self primitive = 256
+]
+
 { #category : #accessing }
 CompiledCode >> isTestMethod [
 	^ self subclassResponsibility
@@ -515,6 +522,11 @@ CompiledCode >> localReadsRef: literalAssociation [
 		[^false].
 	litIndex := litIndex - 1.
 	^(scanner := InstructionStream on: self) scanFor: (self encoderClass bindingReadScanBlockFor: litIndex using: scanner)
+]
+
+{ #category : #scanning }
+CompiledCode >> localReadsSelf [
+	^ self encoderClass readsSelfFor: self
 ]
 
 { #category : #scanning }
@@ -689,6 +701,14 @@ CompiledCode >> readsRef: literalAssociation [
 	"Answer whether the receiver loads the argument."
 	(self localReadsRef: literalAssociation) ifTrue: [ ^ true ].
 	^ self innerCompiledBlocksAnySatisfy: [ :cb | cb readsRef: literalAssociation ]
+]
+
+{ #category : #scanning }
+CompiledCode >> readsSelf [
+	"Answer whether compiledMethod reads self, look into embedded blocks, too"
+	self isReturnSelf ifTrue: [ ^ true ].
+	self localReadsSelf ifTrue: [ ^ true ].
+	^ self innerCompiledBlocksAnySatisfy: [ :cb | cb readsSelf]
 ]
 
 { #category : #scanning }

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -517,6 +517,11 @@ CompiledCode >> localReadsRef: literalAssociation [
 	^(scanner := InstructionStream on: self) scanFor: (self encoderClass bindingReadScanBlockFor: litIndex using: scanner)
 ]
 
+{ #category : #scanning }
+CompiledCode >> localReadsThisContext [
+	^ self encoderClass readsThisContextFor: self
+]
+
 { #category : #testing }
 CompiledCode >> localSendsAnySelectorOf: aCollection [
 	
@@ -689,6 +694,13 @@ CompiledCode >> readsRef: literalAssociation [
 { #category : #scanning }
 CompiledCode >> readsSlot: aSlot [
 	^aSlot isReadIn: self
+]
+
+{ #category : #scanning }
+CompiledCode >> readsThisContext [
+	"Answer whether compiledMethod reads thisContext, look into embedded blocks, too"
+	self localReadsThisContext ifTrue: [ ^ true ].
+	^ self innerCompiledBlocksAnySatisfy: [ :cb | cb readsThisContext]
 ]
 
 { #category : #accessing }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -629,13 +629,6 @@ CompiledMethod >> isReturnField [
 ]
 
 { #category : #testing }
-CompiledMethod >> isReturnSelf [
-	"Answer whether the receiver is a quick return of self."
-
-	^ self primitive = 256
-]
-
-{ #category : #testing }
 CompiledMethod >> isReturnSpecial [
 	"Answer whether the receiver is a quick return of self or constant."
 
@@ -679,6 +672,12 @@ CompiledMethod >> linesOfCode [
 CompiledMethod >> literalsToSkip [
 
 	^ 2
+]
+
+{ #category : #scanning }
+CompiledMethod >> localReadsSelf [
+	"methods that are compiled with FFI have a self in the source but not in the bytecode"
+	^self isFFIMethod or: [ super localReadsSelf ]
 ]
 
 { #category : #private }

--- a/src/OpalCompiler-Core/SelfVariable.class.st
+++ b/src/OpalCompiler-Core/SelfVariable.class.st
@@ -35,3 +35,14 @@ SelfVariable >> isSelfVariable [
 SelfVariable >> readInContext: aContext [
 	^aContext receiver
 ]
+
+{ #category : #queries }
+SelfVariable >> usingMethods [
+	"as super sends are doing a pushSelf, too, we need to still check the AST level sometimes"
+
+	^ SystemNavigation new allMethods select: [ :method | 
+		  method readsSelf and: [ 
+			  method sendsToSuper not or: [ 
+				  method ast variableNodes anySatisfy: [ :varNode | 
+					  varNode variable == self ] ] ] ]
+]

--- a/src/OpalCompiler-Core/SuperVariable.class.st
+++ b/src/OpalCompiler-Core/SuperVariable.class.st
@@ -38,6 +38,8 @@ SuperVariable >> readInContext: aContext [
 
 { #category : #queries }
 SuperVariable >> usingMethods [
+	"as super is just a push Self, this detects real super sends, not accesses to super which 
+	should never happen"
 	^ SystemNavigation new allMethods select: [ :method | 
 		  method sendsToSuper ]
 ]

--- a/src/OpalCompiler-Core/ThisContextVariable.class.st
+++ b/src/OpalCompiler-Core/ThisContextVariable.class.st
@@ -35,3 +35,9 @@ ThisContextVariable >> isThisContextVariable [
 ThisContextVariable >> readInContext: aContext [
 	^aContext
 ]
+
+{ #category : #queries }
+ThisContextVariable >> usingMethods [
+	^ SystemNavigation new allMethods select: [ :method | 
+		  method readsThisContext ]
+]


### PR DESCRIPTION
speed up #usingMethods of ThisContextVar the same as we have for super: scan bytecode instead of AST (which is slow if we have to create all the ASTs)

- add #readsThisContext to CompiledCode with Test
- implement usingMethods

This is now much faster:
ThisContextVariable instance usingMethods size