### PR TITLE
Reduce-References-RBVariableNode-subclasses2

### DIFF
--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -176,7 +176,7 @@ RBSequenceNode >> addSelfReturn [
 	| node |
 	self lastIsReturn
 		ifTrue: [ ^ self statements last ].
-	node := RBReturnNode value: (RBSelfNode new).
+	node := RBReturnNode value: (RBVariableNode named: 'self').
 	^ self addNode: node
 ]
 

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -176,7 +176,7 @@ RBSequenceNode >> addSelfReturn [
 	| node |
 	self lastIsReturn
 		ifTrue: [ ^ self statements last ].
-	node := RBReturnNode value: (RBVariableNode named: 'self').
+	node := RBReturnNode value: RBVariableNode selfNode.
 	^ self addNode: node
 ]
 

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -45,6 +45,21 @@ RBVariableNode class >> named: aName start: aPosition [
 		yourself.
 ]
 
+{ #category : #'instance creation' }
+RBVariableNode class >> selfNode [
+	^ (self named: 'self') variable: SelfVariable instance
+]
+
+{ #category : #'instance creation' }
+RBVariableNode class >> superNode [
+	^ (self named: 'super') variable: SuperVariable instance
+]
+
+{ #category : #'instance creation' }
+RBVariableNode class >> thisContextNode [
+	^ (self named: 'thisContext') variable: ThisContextVariable instance
+]
+
 { #category : #comparing }
 RBVariableNode >> = anObject [ 
 	self == anObject ifTrue: [^true].

--- a/src/Flashback-Decompiler/FBDASTBuilder.class.st
+++ b/src/Flashback-Decompiler/FBDASTBuilder.class.st
@@ -123,7 +123,7 @@ FBDASTBuilder >> codeMethod: selector arguments: args body: body pragmas: pragma
 
 { #category : #building }
 FBDASTBuilder >> codeReceiver [
-	^ RBVariableNode named: 'self'
+	^ RBVariableNode selfNode
 ]
 
 { #category : #building }
@@ -143,7 +143,7 @@ FBDASTBuilder >> codeReturn: value [
 
 { #category : #building }
 FBDASTBuilder >> codeSelf [
-	^ RBVariableNode named: 'self'
+	^ RBVariableNode selfNode
 ]
 
 { #category : #building }
@@ -153,7 +153,7 @@ FBDASTBuilder >> codeSequence: temps [
 
 { #category : #building }
 FBDASTBuilder >> codeSuper [
-	^ RBVariableNode named: 'super'
+	^ RBVariableNode superNode
 ]
 
 { #category : #building }
@@ -163,7 +163,7 @@ FBDASTBuilder >> codeTemp: tempName [
 
 { #category : #building }
 FBDASTBuilder >> codeThisContext [
-	^ RBVariableNode named: 'thisContext'
+	^ RBVariableNode thisContextNode
 ]
 
 { #category : #building }

--- a/src/Flashback-Decompiler/FBDASTBuilder.class.st
+++ b/src/Flashback-Decompiler/FBDASTBuilder.class.st
@@ -28,7 +28,7 @@ FBDASTBuilder >> codeAnyLitInd: anAssociation [
 
 { #category : #building }
 FBDASTBuilder >> codeArgument: tempName [
-	^ RBArgumentNode named: tempName
+	^ RBVariableNode named: tempName
 ]
 
 { #category : #building }
@@ -123,7 +123,7 @@ FBDASTBuilder >> codeMethod: selector arguments: args body: body pragmas: pragma
 
 { #category : #building }
 FBDASTBuilder >> codeReceiver [
-	^ RBSelfNode new
+	^ RBVariableNode named: 'self'
 ]
 
 { #category : #building }
@@ -143,7 +143,7 @@ FBDASTBuilder >> codeReturn: value [
 
 { #category : #building }
 FBDASTBuilder >> codeSelf [
-	^ RBSelfNode new
+	^ RBVariableNode named: 'self'
 ]
 
 { #category : #building }
@@ -153,17 +153,17 @@ FBDASTBuilder >> codeSequence: temps [
 
 { #category : #building }
 FBDASTBuilder >> codeSuper [
-	^ RBSuperNode new
+	^ RBVariableNode named: 'super'
 ]
 
 { #category : #building }
 FBDASTBuilder >> codeTemp: tempName [
-	^ RBTemporaryNode named: tempName
+	^ RBVariableNode named: tempName
 ]
 
 { #category : #building }
 FBDASTBuilder >> codeThisContext [
-	^ RBThisContextNode new
+	^ RBVariableNode named: 'thisContext'
 ]
 
 { #category : #building }

--- a/src/Flashback-Decompiler/FBDDecompiler.class.st
+++ b/src/Flashback-Decompiler/FBDDecompiler.class.st
@@ -177,7 +177,7 @@ FBDDecompiler >> decompileThenRecompileClass: aClass [
 { #category : #'data flow instructions' }
 FBDDecompiler >> doDup [
 	| dupTemp |
-	simulatedStack last class == RBTemporaryNode
+	simulatedStack last class == RBVariableNode
 		ifTrue: [ ^ simulatedStack addLast: simulatedStack last ].
 	self incrTempCount.
 	dupTemp := self newTemp.
@@ -252,7 +252,7 @@ FBDDecompiler >> generateNativeBoostCallErrorMethodFrom: aCompiledMethod [
 		statements:
 			{RBMessageNode receiver: (RBVariableNode named: #CannotDecompileNativeBoostCalls) selector: #signal arguments: #()}.
 	args := OrderedCollection new.
-	1 to: aCompiledMethod numArgs do: [ :i | args add: (RBArgumentNode named: 'arg' , i asString) ].
+	1 to: aCompiledMethod numArgs do: [ :i | args add: (RBVariableNode named: 'arg' , i asString) ].
 	^ builder
 		codeMethod: aCompiledMethod selector
 		arguments: args

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -38,7 +38,7 @@ RBMethodNode >> ensureCachedArgumentNames [
 RBMethodNode class >> errorMethodNode: selector errorMessage: messageText [	
 	| message |
 	message := RBMessageNode 
-		receiver: (RBVariableNode named: self)
+		receiver: (RBVariableNode named: 'self')
 		selector: #error: 
 		arguments: {RBLiteralNode value: messageText}.
 	^ self 

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -38,12 +38,12 @@ RBMethodNode >> ensureCachedArgumentNames [
 RBMethodNode class >> errorMethodNode: selector errorMessage: messageText [	
 	| message |
 	message := RBMessageNode 
-		receiver: RBSelfNode new
+		receiver: (RBVariableNode named: self)
 		selector: #error: 
 		arguments: {RBLiteralNode value: messageText}.
 	^ self 
 		selector: selector 
-		arguments: ((1 to: selector numArgs) collect: [ :i | RBArgumentNode named: 't' , i asString ]) 
+		arguments: ((1 to: selector numArgs) collect: [ :i | RBVariableNode named: 't' , i asString ]) 
 		body: (RBSequenceNode statements: {message}) 
 ]
 

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -38,7 +38,7 @@ RBMethodNode >> ensureCachedArgumentNames [
 RBMethodNode class >> errorMethodNode: selector errorMessage: messageText [	
 	| message |
 	message := RBMessageNode 
-		receiver: (RBVariableNode named: 'self')
+		receiver: RBVariableNode selfNode
 		selector: #error: 
 		arguments: {RBLiteralNode value: messageText}.
 	^ self 

--- a/src/Reflectivity/RFThisContextReification.class.st
+++ b/src/Reflectivity/RFThisContextReification.class.st
@@ -19,15 +19,15 @@ RFThisContextReification class >> key [
 
 { #category : #generate }
 RFThisContextReification >> genForInstanceVariableSlot [
-	^RBVariableNode named: 'thisContext'
+	^RBVariableNode thisContextNode
 ]
 
 { #category : #generate }
 RFThisContextReification >> genForLiteralVariable [
-	^RBVariableNode named: 'thisContext'
+	^RBVariableNode thisContextNode
 ]
 
 { #category : #generate }
 RFThisContextReification >> genForRBProgramNode [
-	^RBVariableNode named: 'thisContext'
+	^RBVariableNode thisContextNode
 ]

--- a/src/Reflectivity/RFThisContextReification.class.st
+++ b/src/Reflectivity/RFThisContextReification.class.st
@@ -19,15 +19,15 @@ RFThisContextReification class >> key [
 
 { #category : #generate }
 RFThisContextReification >> genForInstanceVariableSlot [
-	^RBThisContextNode new
+	^RBVariableNode named: 'thisContext'
 ]
 
 { #category : #generate }
 RFThisContextReification >> genForLiteralVariable [
-	^RBThisContextNode new
+	^RBVariableNode named: 'thisContext'
 ]
 
 { #category : #generate }
 RFThisContextReification >> genForRBProgramNode [
-	^RBThisContextNode new
+	^RBVariableNode named: 'thisContext'
 ]

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -92,7 +92,7 @@ ReflectiveMethod >> generatePrimitiveWrapper [
 	wrappedMethod := ast generate: compiledMethod trailer.
 	
 	send := RBMessageNode
-		receiver: RBSelfNode new
+		receiver: (RBVariableNode named: 'self')
 		selector:  #rFwithArgs:executeMethod:
 		arguments: {RBArrayNode statements: ast arguments . (RFLiteralVariableNode value: wrappedMethod)}.
 	

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -92,7 +92,7 @@ ReflectiveMethod >> generatePrimitiveWrapper [
 	wrappedMethod := ast generate: compiledMethod trailer.
 	
 	send := RBMessageNode
-		receiver: (RBVariableNode named: 'self')
+		receiver: RBVariableNode selfNode
 		selector:  #rFwithArgs:executeMethod:
 		arguments: {RBArrayNode statements: ast arguments . (RFLiteralVariableNode value: wrappedMethod)}.
 	


### PR DESCRIPTION
another pass to reduce the users of RBVariableNode references. Instead, use RBVariableNode. The name analysis takes care of the rest 


There are some left that will be done in following PRs:

RBSelfNode
		- NewTools: testShouldConsiderHaltNode
		- identifierNamed:at: 
		
RBSuperNode
		- identifierNamed:at: 
		- rewriteASTToSimulateExecutionInADifferentContext:
		- testDoesApplyForSuperMessageSendNodes
		
RBThisContextNode
		identifierNamed:at: 
		testThisContextNodeDump -> needs visitor
		testBuildThisContextHeuristic -> needs visitor