### PR TITLE
Fixes #6993 against P9: Incorrect error message on failed parsing of a number with high radix

### DIFF
--- a/src/NumberParser/NumberParser.class.st
+++ b/src/NumberParser/NumberParser.class.st
@@ -377,11 +377,12 @@ NumberParser >> nextScaledDecimal [
 NumberParser >> nextUnsignedIntegerBase: aRadix [ 
 	"Form an unsigned integer with incoming digits from sourceStream.
 	Fail if no digit found.
+	Since only characters $A - $Z are supported, limit the character range shown on error.
 	Count the number of digits and the lastNonZero digit and store int in instVar "
 	
 	| value |
 	value := self nextUnsignedIntegerOrNilBase: aRadix.
-	value ifNil: [^self expected: ('a digit between 0 and ' copyWith: (Character digitValue: aRadix - 1))].
+	value ifNil: [^self expected: ('a digit between 0 and ' copyWith: (Character digitValue: (aRadix min: 36) - 1))].
 	^value
 ]
 


### PR DESCRIPTION
This is a fix for the incorrect error message on failed parsing number with high radix.
This is PR against P8 branch.