### PR TITLE
Cleanup-kindOfSubclassDefinitionString

### DIFF
--- a/src/Calypso-Ring/RGByteLayout.extension.st
+++ b/src/Calypso-Ring/RGByteLayout.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #RGByteLayout }
-
-{ #category : #'*Calypso-Ring' }
-RGByteLayout >> kindOfSubclassDefinitionString [
-	^ ' variableByteSubclass: '
-
-
-]

--- a/src/Calypso-Ring/RGCompiledMethodLayout.extension.st
+++ b/src/Calypso-Ring/RGCompiledMethodLayout.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #RGCompiledMethodLayout }
-
-{ #category : #'*Calypso-Ring' }
-RGCompiledMethodLayout >> kindOfSubclassDefinitionString [
-	^ ' variableByteSubclass: '
-]

--- a/src/Calypso-Ring/RGEphemeronLayout.extension.st
+++ b/src/Calypso-Ring/RGEphemeronLayout.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #RGEphemeronLayout }
-
-{ #category : #'*Calypso-Ring' }
-RGEphemeronLayout >> kindOfSubclassDefinitionString [
-	^ ' ephemeronSubclass: '
-]

--- a/src/Calypso-Ring/RGFixedLayout.extension.st
+++ b/src/Calypso-Ring/RGFixedLayout.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #RGFixedLayout }
-
-{ #category : #'*Calypso-Ring' }
-RGFixedLayout >> kindOfSubclassDefinitionString [
-	^ ' subclass: '
-]

--- a/src/Calypso-Ring/RGImmediateLayout.extension.st
+++ b/src/Calypso-Ring/RGImmediateLayout.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #RGImmediateLayout }
-
-{ #category : #'*Calypso-Ring' }
-RGImmediateLayout >> kindOfSubclassDefinitionString [
-	^ ' immediateSubclass: '
-]

--- a/src/Calypso-Ring/RGVariableLayout.extension.st
+++ b/src/Calypso-Ring/RGVariableLayout.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #RGVariableLayout }
-
-{ #category : #'*Calypso-Ring' }
-RGVariableLayout >> kindOfSubclassDefinitionString [
-	^ ' variableSubclass: '
-]

--- a/src/Calypso-Ring/RGWeakLayout.extension.st
+++ b/src/Calypso-Ring/RGWeakLayout.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #RGWeakLayout }
-
-{ #category : #'*Calypso-Ring' }
-RGWeakLayout >> kindOfSubclassDefinitionString [
-	^ ' weakSubclass: '
-]

--- a/src/Calypso-Ring/RGWordLayout.extension.st
+++ b/src/Calypso-Ring/RGWordLayout.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #RGWordLayout }
-
-{ #category : #'*Calypso-Ring' }
-RGWordLayout >> kindOfSubclassDefinitionString [
-	^ ' variableWordSubclass: '
-
-
-]


### PR DESCRIPTION
Calypso-Ring adds the method kindOfSubclassDefinitionString to many RGLayout subclasses. The method is not used. As it is a private extension, we can remove it