### PR TITLE
ReservedVariable-nameIsReserved

### DIFF
--- a/src/Kernel/ReservedVariable.class.st
+++ b/src/Kernel/ReservedVariable.class.st
@@ -7,7 +7,7 @@ Class {
 	#classInstVars : [
 		'instance'
 	],
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : #'Kernel-Variables'
 }
 
 { #category : #accessing }
@@ -23,7 +23,6 @@ ReservedVariable class >> isAbstract [
 { #category : #testing }
 ReservedVariable class >> nameIsReserved: aName [
 	^self subclasses anySatisfy: [ :class | class instance name = aName ]
-	
 ]
 
 { #category : #converting }

--- a/src/Kernel/SelfVariable.class.st
+++ b/src/Kernel/SelfVariable.class.st
@@ -4,7 +4,7 @@ I model ""self"" keyword
 Class {
 	#name : #SelfVariable,
 	#superclass : #ReservedVariable,
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : #'Kernel-Variables'
 }
 
 { #category : #accessing }

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -46,18 +46,15 @@ Slot class >> checkValidName: aSymbol [
 	aSymbol startsWithDigit ifTrue: [ 
 		^ InvalidSlotName signalFor: aSymbol ].
 
-	(self isPseudovariableName: aSymbol) ifTrue: [ 
+	(#('nil' 'true' 'false') includes: aSymbol) ifTrue: [ 
 		^ InvalidSlotName signalFor: aSymbol ].
 	
-
+	(ReservedVariable nameIsReserved: aSymbol) ifTrue: [ 
+		^ InvalidSlotName signalFor: aSymbol ].
+	
 	(aSymbol allSatisfy: [ :aCharacter | aCharacter isAlphaNumeric or: [ aCharacter = $_ ] ]) ifFalse: [ 
 		^ InvalidSlotName signalFor: aSymbol ]
 
-]
-
-{ #category : #testing }
-Slot class >> isPseudovariableName: aSymbol [
-	^ #('self' 'true' 'false' 'nil' 'thisContext' 'super') includes: aSymbol
 ]
 
 { #category : #testing }

--- a/src/Kernel/SuperVariable.class.st
+++ b/src/Kernel/SuperVariable.class.st
@@ -4,7 +4,7 @@ I model ""super"" keyword
 Class {
 	#name : #SuperVariable,
 	#superclass : #ReservedVariable,
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : #'Kernel-Variables'
 }
 
 { #category : #accessing }

--- a/src/Kernel/ThisContextVariable.class.st
+++ b/src/Kernel/ThisContextVariable.class.st
@@ -4,7 +4,7 @@ I model thisContext keyword
 Class {
 	#name : #ThisContextVariable,
 	#superclass : #ReservedVariable,
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : #'Kernel-Variables'
 }
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/ReservedVariable.class.st
+++ b/src/OpalCompiler-Core/ReservedVariable.class.st
@@ -20,6 +20,12 @@ ReservedVariable class >> isAbstract [
 	^self = ReservedVariable  
 ]
 
+{ #category : #testing }
+ReservedVariable class >> nameIsReserved: aName [
+	^self subclasses anySatisfy: [ :class | class instance name = aName ]
+	
+]
+
 { #category : #converting }
 ReservedVariable >> asString [
 

--- a/src/OpalCompiler-Tests/ReservedVariableTest.class.st
+++ b/src/OpalCompiler-Tests/ReservedVariableTest.class.st
@@ -1,0 +1,21 @@
+"
+A ReservedVariableTest is a test class for testing the behavior of ReservedVariable
+"
+Class {
+	#name : #ReservedVariableTest,
+	#superclass : #TestCase,
+	#category : #'OpalCompiler-Tests-Semantic'
+}
+
+{ #category : #tests }
+ReservedVariableTest >> testNameIsReserved [
+	"we have these reserved vars: self, super, thisContext"
+	self assert: (ReservedVariable nameIsReserved: 'self').
+	self assert: (ReservedVariable nameIsReserved: 'super').
+	self assert: (ReservedVariable nameIsReserved: 'thisContext').
+	
+	"true and false and nil are compiled as lierals, not reserved vars"
+	self deny: (ReservedVariable nameIsReserved: 'true').
+	self deny: (ReservedVariable nameIsReserved: 'false').
+	self deny: (ReservedVariable nameIsReserved: 'nil').
+]


### PR DESCRIPTION
We need an easy way to check if a name is the name of a Rerverved var in a way that it does not hardcode the string. This wil (after we use this everywhere) allow us to define new reserved vars (e.g. thisProcess to use the new bytecode) by just adding a subclass to ReserverdVariable.