### PR TITLE
6751-Syntactically-wrong-code-can-be-compiled-without-Error

### DIFF
--- a/src/Kernel/RuntimeSyntaxError.class.st
+++ b/src/Kernel/RuntimeSyntaxError.class.st
@@ -18,11 +18,16 @@ RuntimeSyntaxError class >> signal: aNode [
 ]
 
 { #category : #accessing }
+RuntimeSyntaxError >> errorMessage [
+	^errorNode errorMessage
+]
+
+{ #category : #accessing }
 RuntimeSyntaxError >> errorNode: aNode [
 	errorNode := aNode
 ]
 
 { #category : #accessing }
 RuntimeSyntaxError >> messageText [
-	^errorNode errorMessage
+	^self errorMessage
 ]

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -269,6 +269,16 @@ CompilationContext class >> optionParseErrors: aBoolean [
 ]
 
 { #category : #'options - settings API' }
+CompilationContext class >> optionParseErrorsNonInteractiveOnly [
+	^ self readDefaultOption: #optionParseErrorsNonInteractiveOnly
+]
+
+{ #category : #'options - settings API' }
+CompilationContext class >> optionParseErrorsNonInteractiveOnly: aBoolean [
+	^ self writeDefaultOption: #optionParseErrorsNonInteractiveOnly value: aBoolean
+]
+
+{ #category : #'options - settings API' }
 CompilationContext class >> optionReadOnlyLiterals [
 	^ self readDefaultOption: #optionReadOnlyLiterals
 ]
@@ -312,7 +322,8 @@ CompilationContext class >> optionsDescription [
 	(- optionFullBlockClosure 			'Compiler compiles closure creation to use FullBlockClosure instead of BlockClosure')
 	(- optionLongIvarAccessBytecodes 	'Specific inst var accesses to Maybe context objects')
 	(+ optionOptimizeIR 					'Rewrite jumps in bytecode in a slightly more efficient way')
-	(- optionParseErrors 					'Parse syntactically wrong code')
+	(- optionParseErrors 					'Parse syntactically wrong code (interactive and non-interactive')
+	(- optionParseErrorsNonInteractiveOnly 	'Parse syntactically wrong code in non-interactive mode only')
 	(- optionSkipSemanticWarnings 		'Do not warn about semantic problems (e.g. undeclared vars). Used for syntax highlight parsing')
 		
 	) 
@@ -560,6 +571,11 @@ CompilationContext >> optionOptimizeIR [
 { #category : #options }
 CompilationContext >> optionParseErrors [
 	^ options includes: #optionParseErrors
+]
+
+{ #category : #options }
+CompilationContext >> optionParseErrorsNonInteractiveOnly [
+	^ options includes: #optionParseErrorsNonInteractiveOnly
 ]
 
 { #category : #options }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -276,6 +276,11 @@ OpalCompiler >> addPlugin: aClass [
 	compilationContext addASTTransformationPlugin: aClass
 ]
 
+{ #category : #private }
+OpalCompiler >> allowParseErrorsNonInteractive [
+	^self compilationContext optionParseErrorsNonInteractiveOnly and: [ self isInteractive not ]
+]
+
 { #category : #accessing }
 OpalCompiler >> bindings: aDictionary [
 	"allows to define additional binding, note: Globals are not shadowed"
@@ -509,8 +514,7 @@ OpalCompiler >> parse: textOrString [
 
 { #category : #private }
 OpalCompiler >> parseExpression [
-	"we should allow syntactically wrong code in evaluate, too"
-	^ (self compilationContext optionParseErrors "or: [ self isInteractive not ]")
+	^ (self compilationContext optionParseErrors or: [ self allowParseErrorsNonInteractive ])
 		ifTrue: [self parserClass parseFaultyExpression: source contents]
 		ifFalse: [self parserClass parseExpression: source contents]
 ]
@@ -522,8 +526,7 @@ OpalCompiler >> parseLiterals: aString [
 
 { #category : #private }
 OpalCompiler >> parseMethod [
-	
-	^ (self compilationContext optionParseErrors or: [ self isInteractive not ])
+	^ (self compilationContext optionParseErrors or: [ self allowParseErrorsNonInteractive ])
 		ifTrue: [self parserClass parseFaultyMethod: source contents]
 		ifFalse: [self parserClass parseMethod: source contents]
 ]

--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -88,7 +88,7 @@ Finder >> computeWithMethodFinder: aString [
 	data := aString trimRight: [ :char | char isSeparator or: [ char = $. ] ].
 
 	[ dataObjects := Smalltalk compiler evaluate: '{' , data , '}' ]
-		on: SyntaxErrorNotification
+		on: SyntaxErrorNotification, RuntimeSyntaxError
 		do: [ :e | 
 			self inform: 'Syntax Error: ' , e errorMessage.
 			^ #() ].	"#( data1 data2 result )"


### PR DESCRIPTION
add a new compiler option #optionParseErrorsNonInteractiveOnly. Only if that one is enabled (or the more general optionParseErrors), we allow syntax errros in non-interactive mode

This includes two simple fixes that are relevant if you enable the option:

- implement #errorMessage on RuntimeSyntaxError to be compatible to SyntaxErrorNotification
- fix the one user that traps SyntaxErrorNotification to react to RuntimeSyntaxError

fixes #6751