### PR TITLE
fast-isFaulty-CompiledMethod

### DIFF
--- a/src/GeneralRules/ReMethodHasSyntaxErrorRule.class.st
+++ b/src/GeneralRules/ReMethodHasSyntaxErrorRule.class.st
@@ -21,7 +21,7 @@ ReMethodHasSyntaxErrorRule class >> uniqueIdentifierName [
 
 { #category : #running }
 ReMethodHasSyntaxErrorRule >> basicCheck: aMethod [
-	^aMethod ast isFaulty
+	^aMethod isFaulty
 ]
 
 { #category : #accessing }

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -469,6 +469,19 @@ CompiledMethodTest >> testIsDeprecated [
 	DeprecatedClassForTest selectorsDo: [ :each | self assert: (DeprecatedClassForTest >> each) isDeprecated ]
 ]
 
+{ #category : #'tests - testing' }
+CompiledMethodTest >> testIsFaulty [
+	| method  |
+	method := Smalltalk compiler 	
+		options:  #(+ optionParseErrors +optionEmbeddSources);
+		compile: 'method ^1+'.
+		
+	self assert: method isFaulty.
+	self assert: method ast isFaulty.
+	
+	self deny: (Object>>#halt) isFaulty
+]
+
 { #category : #'as yet unclassified' }
 CompiledMethodTest >> testIsInstalled [
 |  method cls |

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -580,6 +580,13 @@ CompiledMethod >> isExplicitlyRequired: marker [
 ]
 
 { #category : #testing }
+CompiledMethod >> isFaulty [
+	"check if this method was compiled from syntactically wrong code"
+	
+	^(self refersToLiteral: #signalSyntaxError:) and: [ self ast isFaulty ]
+]
+
+{ #category : #testing }
 CompiledMethod >> isFromTrait [
 	"Return true for methods that have been included from Traits"
 	^ self origin isTrait and: [ self origin ~= self methodClass ]

--- a/src/Kernel/RuntimeSyntaxError.class.st
+++ b/src/Kernel/RuntimeSyntaxError.class.st
@@ -13,7 +13,8 @@ Class {
 }
 
 { #category : #signalling }
-RuntimeSyntaxError class >> signal: aNode [
+RuntimeSyntaxError class >> signalSyntaxError: aNode [
+	"we use signalSyntaxError: instead of signal: so we can quickly pre-check compiledMethods for syntax 	errors by checking the literals"
 	^(self new errorNode: aNode) signal
 ]
 

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -627,7 +627,7 @@ OCASTTranslator >> visitParseErrorNode: anErrorNode [
 	methodBuilder 
 		pushLiteralVariable: RuntimeSyntaxError binding;
 		pushLiteral: anErrorNode;
-		send: #signal:
+		send: #signalSyntaxError:
 ]
 
 { #category : #'visitor-double dispatching' }


### PR DESCRIPTION
-  add a quick check for #isFaulty for CompiledMethod that does not need to reify the AST.
- use it in ReMethodHasSyntaxErrorRule