### PR TITLE
isFaulty-useBlocksWithAnySatisFy

### DIFF
--- a/src/AST-Core/RBArrayNode.class.st
+++ b/src/AST-Core/RBArrayNode.class.st
@@ -154,7 +154,7 @@ RBArrayNode >> isDynamicArray [
 
 { #category : #testing }
 RBArrayNode >> isFaulty [
-	^self statements anySatisfy: #isFaulty
+	^self statements anySatisfy: [:each | each isFaulty]
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -228,7 +228,7 @@ RBBlockNode >> isBlock [
 
 { #category : #testing }
 RBBlockNode >> isFaulty [
-	^(self arguments anySatisfy:  #isFaulty ) or: [ self body isFaulty]
+	^(self arguments anySatisfy: [:each | each isFaulty] ) or: [ self body isFaulty]
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBCascadeNode.class.st
+++ b/src/AST-Core/RBCascadeNode.class.st
@@ -93,7 +93,7 @@ RBCascadeNode >> isCascade [
 
 { #category : #testing }
 RBCascadeNode >> isFaulty [
-	^self messages anySatisfy: #isFaulty
+	^self messages anySatisfy: [:each | each isFaulty]
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBLiteralArrayNode.class.st
+++ b/src/AST-Core/RBLiteralArrayNode.class.st
@@ -90,7 +90,7 @@ RBLiteralArrayNode >> equalTo: anObject withMapping: aDictionary [
 
 { #category : #testing }
 RBLiteralArrayNode >> isFaulty [
-	^self contents anySatisfy: #isFaulty
+	^self contents anySatisfy: [:each | each isFaulty]
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -160,7 +160,7 @@ RBMessageNode >> isContainmentReplacement: aNode [
 
 { #category : #testing }
 RBMessageNode >> isFaulty [
-	^self receiver isFaulty or: [self arguments anySatisfy: #isFaulty]
+	^self receiver isFaulty or: [self arguments anySatisfy: [:each | each isFaulty]]
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -377,8 +377,8 @@ RBMethodNode >> initialize [
 
 { #category : #testing }
 RBMethodNode >> isFaulty [
-	(self arguments anySatisfy: #isFaulty) ifTrue:[ ^true].
-	(self pragmas anySatisfy: #isFaulty) ifTrue:[ ^true].
+	(self arguments anySatisfy: [:each | each isFaulty]) ifTrue:[ ^true].
+	(self pragmas anySatisfy: [:each | each isFaulty]) ifTrue:[ ^true].
 	^self body isFaulty
 ]
 

--- a/src/AST-Core/RBPragmaNode.class.st
+++ b/src/AST-Core/RBPragmaNode.class.st
@@ -127,7 +127,7 @@ RBPragmaNode >> isBinary [
 
 { #category : #testing }
 RBPragmaNode >> isFaulty [
-	^self arguments anySatisfy: #isFaulty
+	^self arguments anySatisfy: [:each | each isFaulty]
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -304,7 +304,7 @@ RBSequenceNode >> initialize [
 
 { #category : #testing }
 RBSequenceNode >> isFaulty [
-	^self statements anySatisfy: #isFaulty
+	^self statements anySatisfy: [:each | each isFaulty]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
isFaulty implementations should use anySatisfy: with a block, not a symbol