### PR TITLE
ReservedVariable-nameIsReserved-and-Test

### DIFF
--- a/src/OpalCompiler-Core/ReservedVariable.class.st
+++ b/src/OpalCompiler-Core/ReservedVariable.class.st
@@ -20,6 +20,11 @@ ReservedVariable class >> isAbstract [
 	^self = ReservedVariable  
 ]
 
+{ #category : #testing }
+ReservedVariable class >> nameIsReserved: aName [
+	^self subclasses anySatisfy: [ :class | class instance name = aName ]
+]
+
 { #category : #converting }
 ReservedVariable >> asString [
 

--- a/src/Slot-Tests/ReservedVariableTest.class.st
+++ b/src/Slot-Tests/ReservedVariableTest.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #ReservedVariableTest,
+	#superclass : #TestCase,
+	#category : #'Slot-Tests-VariablesAndSlots'
+}
+
+{ #category : #tests }
+ReservedVariableTest >> testNameIsReserved [
+ 	"we have these reserved vars: self, super, thisContext"
+ 	self assert: (ReservedVariable nameIsReserved: 'self').
+ 	self assert: (ReservedVariable nameIsReserved: 'super').
+ 	self assert: (ReservedVariable nameIsReserved: 'thisContext').
+
+  	"true and false and nil are compiled as lierals, not reserved vars"
+ 	self deny: (ReservedVariable nameIsReserved: 'true').
+ 	self deny: (ReservedVariable nameIsReserved: 'false').
+ 	self deny: (ReservedVariable nameIsReserved: 'nil')
+]

--- a/src/Slot-Tests/ReservedVariableTest.class.st
+++ b/src/Slot-Tests/ReservedVariableTest.class.st
@@ -11,7 +11,7 @@ ReservedVariableTest >> testNameIsReserved [
  	self assert: (ReservedVariable nameIsReserved: 'super').
  	self assert: (ReservedVariable nameIsReserved: 'thisContext').
 
-  	"true and false and nil are compiled as lierals, not reserved vars"
+  	"true and false and nil are compiled as literals, not reserved vars"
  	self deny: (ReservedVariable nameIsReserved: 'true').
  	self deny: (ReservedVariable nameIsReserved: 'false').
  	self deny: (ReservedVariable nameIsReserved: 'nil')


### PR DESCRIPTION
This adds a nameIsReserved: check to ReservedVariable plus a test.

The idea is to use that in the compiler and e.g. when we check variable name validity. If we do that, we can add new Reserved Variables by just adding a subclass.

(this is not as simple to do to use it in Slot class as it has implications for dependencies, ReservedVariable is for now in the compiler package,
therefore this PR does not do that change yet. The Compiler change will be done im combination with removing all hard-coded references to the variable names)