### PR TITLE
CleanBlocks-Experiment

### DIFF
--- a/src/Kernel/CleanBlockClosure.class.st
+++ b/src/Kernel/CleanBlockClosure.class.st
@@ -1,0 +1,61 @@
+"
+!!!! Highly Experimental!!!
+
+This is disabled by default.
+
+If you want to experiment, you can enable the #optionCleanBlockClosure compiler option.
+
+- This should not be a subclass of FullBlock (as it does not need the receiver ivar, for example)
+- Debugging is not yet working as #pcInOuter needs to be implemented
+"
+Class {
+	#name : #CleanBlockClosure,
+	#superclass : #FullBlockClosure,
+	#type : #variable,
+	#category : #'Kernel-Methods'
+}
+
+{ #category : #accessing }
+CleanBlockClosure >> hasLiteral: aLiteral [
+	^self compiledBlock hasLiteral: aLiteral
+]
+
+{ #category : #accessing }
+CleanBlockClosure >> hasLiteralSuchThat: aLiteral [
+	^self compiledBlock hasLiteralSuchThat: aLiteral
+]
+
+{ #category : #accessing }
+CleanBlockClosure >> innerCompiledBlocksAnySatisfy: aBlock [
+	^self compiledBlock innerCompiledBlocksAnySatisfy: aBlock
+]
+
+{ #category : #accessing }
+CleanBlockClosure >> innerCompiledBlocksDo: aBlock [
+	^self compiledBlock innerCompiledBlocksDo: aBlock
+]
+
+{ #category : #testing }
+CleanBlockClosure >> isEmbeddedBlock [
+	^ true
+]
+
+{ #category : #accessing }
+CleanBlockClosure >> messages [ 
+	^self compiledBlock messages
+]
+
+{ #category : #accessing }
+CleanBlockClosure >> outerCode: aCompiledCode [
+	self compiledBlock outerCode: aCompiledCode
+]
+
+{ #category : #accessing }
+CleanBlockClosure >> refersToLiteral: aLiteral [
+	^self compiledBlock refersToLiteral: aLiteral
+]
+
+{ #category : #accessing }
+CleanBlockClosure >> sendsAnySelectorOf: aCollection [
+	^self compiledBlock sendsAnySelectorOf: aCollection
+]

--- a/src/Kernel/CleanBlockClosure.class.st
+++ b/src/Kernel/CleanBlockClosure.class.st
@@ -15,6 +15,11 @@ Class {
 	#category : #'Kernel-Methods'
 }
 
+{ #category : #adding }
+CleanBlockClosure >> addWithAllBlocksInto: collected [
+	^self compiledBlock addWithAllBlocksInto: collected
+]
+
 { #category : #accessing }
 CleanBlockClosure >> hasLiteral: aLiteral [
 	^self compiledBlock hasLiteral: aLiteral
@@ -36,6 +41,11 @@ CleanBlockClosure >> innerCompiledBlocksDo: aBlock [
 ]
 
 { #category : #testing }
+CleanBlockClosure >> isClean [
+	^true
+]
+
+{ #category : #testing }
 CleanBlockClosure >> isEmbeddedBlock [
 	^ true
 ]
@@ -50,12 +60,28 @@ CleanBlockClosure >> outerCode: aCompiledCode [
 	self compiledBlock outerCode: aCompiledCode
 ]
 
+{ #category : #scanning }
+CleanBlockClosure >> readsField: varIndex [ 
+	^self compiledBlock readsField: varIndex
+]
+
 { #category : #accessing }
 CleanBlockClosure >> refersToLiteral: aLiteral [
 	^self compiledBlock refersToLiteral: aLiteral
 ]
 
+{ #category : #'debugger access' }
+CleanBlockClosure >> sender [
+	" clean blocks do not know the sender"
+	^nil
+]
+
 { #category : #accessing }
 CleanBlockClosure >> sendsAnySelectorOf: aCollection [
 	^self compiledBlock sendsAnySelectorOf: aCollection
+]
+
+{ #category : #scanning }
+CleanBlockClosure >> writesField: varIndex [ 
+	^self compiledBlock writesField: varIndex
 ]

--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -65,6 +65,11 @@ CompiledBlock >> isCompiledBlock [
 ]
 
 { #category : #testing }
+CompiledBlock >> isEmbeddedBlock [
+	^ true
+]
+
+{ #category : #testing }
 CompiledBlock >> isInstalled [
 	
 	^ self method isInstalled

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -100,7 +100,7 @@ CompiledCode >> addWithAllBlocksInto: collected [
 	collected add: self.
 
 	self literals 
-		select: [ :aLiteral | aLiteral isCompiledBlock ] 
+		select: [ :aLiteral | aLiteral isEmbeddedBlock ] 
 		thenDo: [ :aLiteral | aLiteral addWithAllBlocksInto: collected ].
 		
 	^ collected
@@ -249,7 +249,7 @@ CompiledCode >> hasLiteral: literal [
 		[:index |
 		| lit |
 		((lit := self literalAt: index) literalEqual: literal) ifTrue: [^true].
-		lit isCompiledBlock ifTrue: [ (lit hasLiteral: literal) ifTrue: [ ^true ] ]].
+		lit isEmbeddedBlock ifTrue: [ (lit hasLiteral: literal) ifTrue: [ ^true ] ]].
 	^false
 ]
 
@@ -262,7 +262,7 @@ CompiledCode >> hasLiteralSuchThat: litBlock [
 		((litBlock value: lit)
 		or: [lit isArray and: [lit hasLiteralSuchThat: litBlock]]) ifTrue:
 			[^true].
-		lit isCompiledBlock ifTrue: [ (lit hasLiteralSuchThat: litBlock) ifTrue: [ ^true ] ]].
+		lit isEmbeddedBlock ifTrue: [ (lit hasLiteralSuchThat: litBlock) ifTrue: [ ^true ] ]].
 	^false
 ]
 
@@ -395,7 +395,7 @@ CompiledCode >> innerCompiledBlocksDo: aBlock [
 	1 to: self numLiterals - self literalsToSkip do:
 		[:index | | lit |
 		lit := self literalAt: index.
-		lit isCompiledBlock ifTrue: [ aBlock value: lit ] ]
+		lit isEmbeddedBlock ifTrue: [ aBlock value: lit ] ]
 ]
 
 { #category : #testing }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1153,6 +1153,12 @@ Object >> isDictionary [
 ]
 
 { #category : #testing }
+Object >> isEmbeddedBlock [
+	"returns true for CleanBlockBlockClosure and CompiledBlock"
+	^ false
+]
+
+{ #category : #testing }
 Object >> isFloat [
 	"Overridden to return true in Float, natch"
 	^ false

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -126,6 +126,16 @@ CompilationContext class >> initialize [
 ]
 
 { #category : #'options - settings API' }
+CompilationContext class >> optionCleanBlockClosure [
+	^ self readDefaultOption: #optionCleanBlockClosure
+]
+
+{ #category : #'options - settings API' }
+CompilationContext class >> optionCleanBlockClosure: aBoolean [
+	^ self writeDefaultOption: #optionCleanBlockClosure value: aBoolean
+]
+
+{ #category : #'options - settings API' }
 CompilationContext class >> optionEmbeddSources [
 	^ self readDefaultOption: #optionEmbeddSources
 ]
@@ -310,6 +320,7 @@ CompilationContext class >> optionsDescription [
 	
 	(- optionReadOnlyLiterals 			'Compiler sets literals as read-only')
 	(- optionFullBlockClosure 			'Compiler compiles closure creation to use FullBlockClosure instead of BlockClosure')
+	(- optionCleanBlockClosure 			'Compiler compiles closure creation to use CleanBlockClosure instead of FullBlockClosure for clean blocks. Experimental')
 	(- optionLongIvarAccessBytecodes 	'Specific inst var accesses to Maybe context objects')
 	(+ optionOptimizeIR 					'Rewrite jumps in bytecode in a slightly more efficient way')
 	(- optionParseErrors 					'Parse syntactically wrong code')
@@ -477,6 +488,12 @@ CompilationContext >> noPattern [
 { #category : #accessing }
 CompilationContext >> noPattern: anObject [
 	noPattern := anObject
+]
+
+{ #category : #options }
+CompilationContext >> optionCleanBlockClosure [
+	^ options includes: #optionCleanBlockClosure
+
 ]
 
 { #category : #options }

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -813,8 +813,7 @@ IRBytecodeGenerator >> updateJumpOffsets [
 IRBytecodeGenerator >> updateLiterals: code [
 	"Add back pointer from compiled block to outer code"
 	code literals do: [ :each |
-		(each isKindOf: CompiledBlock) ifTrue: 
-			[ each outerCode: code. ] ] 
+		each isEmbeddedBlock ifTrue: [ each outerCode: code ] ]
 ]
 
 { #category : #results }

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -520,7 +520,9 @@ OCASTTranslator >> visitCascadeNode: aCascadeNode [
 OCASTTranslator >> visitFullBlockNode: aBlockNode [
 	| compiledBlock |
 	compiledBlock := self compilationContext astTranslatorClass new translateFullBlock: aBlockNode.
-	methodBuilder pushFullClosureCompiledBlock: compiledBlock copiedValues: aBlockNode scope inComingCopiedVarNames
+	(self compilationContext optionCleanBlockClosure and: [ aBlockNode isClean ])
+		ifTrue: [ methodBuilder pushLiteral: ((CleanBlockClosure new: 0) numArgs: compiledBlock numArgs; compiledBlock: compiledBlock)]
+		ifFalse: [methodBuilder pushFullClosureCompiledBlock: compiledBlock copiedValues: aBlockNode scope inComingCopiedVarNames  ]
 ]
 
 { #category : #'visitor-double dispatching' }

--- a/src/OpalCompiler-Tests/OCCleanBlockTest.class.st
+++ b/src/OpalCompiler-Tests/OCCleanBlockTest.class.st
@@ -9,6 +9,8 @@ Class {
 
 { #category : #tests }
 OCCleanBlockTest >> testBlockIsClean [
+	"does not work if experimental clean blocks are enabled"
+	Smalltalk compiler compilationContext optionCleanBlockClosure ifTrue: [ ^self skip ].
 	self assert: [  ] sourceNode isClean.
 	self assert: [ 1 + 2 ] sourceNode isClean.
 	self assert: [ :a | a + 2 ] sourceNode isClean.

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -105,7 +105,7 @@ OpalCompilerTest >> testCompilerUsingFullBlockClosureHasBlockAsLiteral [
 
   	method := compiler compile: 'test #(1 2 3) do: [:e | e + 1]'.
 
-  	self assert: method literals second isCompiledBlock 
+  	self assert: method literals second isEmbeddedBlock 
 ]
 
 { #category : #'tests - bindings' }


### PR DESCRIPTION
!!!! Highly Experimental!!!

This is disabled by default.

If you want to experiment, you can enable the #optionCleanBlockClosure compiler option.

What does it do? For blocks that do not access anything outside (#isClean is true), it statically creates a FullBlockClosure and pushes it with #pushLiteral.

This avoids having to create the FullBlockClosure from the CompiledBlock at runtime, which is much faster.

This is not yet complete, see the class CleanBlockClosure for more comments and TODOs.