### PR TITLE
ReNotOptimizedIfRule

### DIFF
--- a/src/GeneralRules-Tests/ReSmalllintTest.class.st
+++ b/src/GeneralRules-Tests/ReSmalllintTest.class.st
@@ -389,6 +389,11 @@ ReSmalllintTest >> testNoClassComment [
 ]
 
 { #category : #tests }
+ReSmalllintTest >> testNotOptimizedIf [
+	self ruleFor: self currentSelector plusSelectors: {#ifTrueBlocks}
+]
+
+{ #category : #tests }
 ReSmalllintTest >> testPrecedence [
 	self ruleFor: self currentSelector
 ]

--- a/src/GeneralRules/ReNotOptimizedIfRule.class.st
+++ b/src/GeneralRules/ReNotOptimizedIfRule.class.st
@@ -1,0 +1,30 @@
+"
+ifTrue: ifFalse: ifTrue:ifFalse: ifFalse:ifTrue: is used in a way that it can not be optimized.
+
+This can be fixed by making sure that all arguments are static blocks.
+
+See the method RBMessageNode>>#isInlineIf for the exact implementation of the check that the compiler uses
+"
+Class {
+	#name : #ReNotOptimizedIfRule,
+	#superclass : #ReNodeBasedRule,
+	#category : #'GeneralRules-Migrated'
+}
+
+{ #category : #running }
+ReNotOptimizedIfRule >> check: aNode forCritiquesDo: aBlock [
+	aNode isMessage ifFalse: [  ^ self ].
+	(#(ifTrue: ifFalse: ifTrue:ifFalse: ifFalse:ifTrue:) includes: aNode selector) ifFalse: [^ self].
+	aNode isInlineIf ifFalse: [
+		aBlock cull: (self critiqueFor: aNode) ]
+]
+
+{ #category : #accessing }
+ReNotOptimizedIfRule >> group [
+	^ 'Optimization'
+]
+
+{ #category : #accessing }
+ReNotOptimizedIfRule >> name [
+	^ 'ifTrue: ifFalse: ifTrue:ifFalse: ifFalse:ifTrue: is used in a way that it can not be optimized'
+]

--- a/src/Refactoring-Tests-Critics/RBSmalllintTestObject.class.st
+++ b/src/Refactoring-Tests-Critics/RBSmalllintTestObject.class.st
@@ -328,6 +328,11 @@ RBSmalllintTestObject >> nonUnaryAccessingMethodWithoutReturn: anObject [
 ]
 
 { #category : #methods }
+RBSmalllintTestObject >> notOptimizedIf [
+	^ true ifFalse: 1
+]
+
+{ #category : #methods }
 RBSmalllintTestObject >> onlyReadOrWrittenTemporary [
 	| a |
 	a := 1


### PR DESCRIPTION
First step of a Rule that warns if you use ifTrue: ifFalse: ifTrue:ifFalse: ifFalse:ifTrue:  in a way that it can not be optimized.

- need a test
- need to run it on the whole image to see if we get any false positives