### PR TITLE
Changing defaults to retain blanks

### DIFF
--- a/src/AST-Core-Tests/RBDumpVisitorTest.class.st
+++ b/src/AST-Core-Tests/RBDumpVisitorTest.class.st
@@ -110,7 +110,7 @@ RBDumpVisitorTest >> testDumpOnSelfClassMethods [
 			dumpedNode := Smalltalk compiler evaluate: node dump.
 			self assert: dumpedNode class equals: RBMethodNode.
 			self assert: node class equals: dumpedNode class.
-			self assert: node formattedCode equals: dumpedNode printString ]
+			self assert: node equals: dumpedNode ]
 ]
 
 { #category : #tests }

--- a/src/EnlumineurFormatter/EFContext.class.st
+++ b/src/EnlumineurFormatter/EFContext.class.st
@@ -143,13 +143,13 @@ EFContext >> initialize [
   newLineBeforeFirstCascade := true.
   newLineBeforeFirstKeyword := true.
   numberOfNewLinesAfterMethodComment := 2.
-  newLinesAfterMethodSignature := 1.
+  newLinesAfterMethodSignature := 2.
   newLinesAfterTemporaries := 1.
   numberOfArgumentsForMultiLine := 4.
   self configureOneLineMessages.
   self periodAtEndOfBlock: false.
   self periodAtEndOfMethod: false.
-  self retainBlankLinesBetweenStatements: false.
+  self retainBlankLinesBetweenStatements: true.
   self retainBlankLinesBeforeComments: true.
   self selectorAndArgumentCombinedMaxSize: 40.
   self numberOfSpacesInsideBlock: 1.

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -655,7 +655,7 @@ EFFormatter class >> settingsNewLinesAfterMethodSignature: aBuilder [
 
 	(aBuilder setting: #numberOfNewLinesAfterMethodSignature)
 		label: 'New lines after method signature';
-		default: 1;
+		default: 2;
 		description: 'To set the number of new lines directly after the method signature.
 When numberOfNewLinesAfterMethodSignature is set to 2 new lines
 
@@ -819,7 +819,7 @@ EFFormatter class >> settingsRetainBlankLinesBetweenStatements: aBuilder [
 
 	(aBuilder setting: #retainBlankLinesBetweenStatements)
 		label: 'Retain blank lines between statements';
-		default: false;
+		default: true;
 		description: 'Keep blank lines which are between statements.
 		
 For example: when set to true the formatter will not change the following: 


### PR DESCRIPTION
The formatter should by default:
 - retain blank lines between statements (we all the time group related statements and we are losing that information)
 - add an empty line between the method signature and the body