### PR TITLE
Adding scopeLevel to requestor scope: it returns 0.

### DIFF
--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -64,3 +64,8 @@ OCRequestorScope >> requestor [
 OCRequestorScope >> requestor: anObject [
 	requestor := anObject
 ]
+
+{ #category : #accessing }
+OCRequestorScope >> scopeLevel [
+	^ 0
+]


### PR DESCRIPTION
Fixes a bug that we see in the nwe debugger.
There is no issue related, we've seen that problem with marcus.