### PR TITLE
Fix #7023

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -378,7 +378,8 @@ Context >> tempNamed: aName put: anObject [
 	
 	| var |
 	var := self lookupTempVar: aName.
-	var write: anObject inContext: self
+	var write: anObject inContext: self.
+	^ anObject
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/Kernel-Tests-WithCompiler/ContextTest.extension.st
+++ b/src/Kernel-Tests-WithCompiler/ContextTest.extension.st
@@ -44,8 +44,8 @@ ContextTest >> testTempNamed [
 ContextTest >> testTempNamedPut [
 	| oneTemp |
 	oneTemp := 1.
-	self assert: (thisContext tempNamed: 'oneTemp') equals: oneTemp.
 	thisContext tempNamed: 'oneTemp' put: 2.
+
 	self assert: (thisContext tempNamed: 'oneTemp') equals: 2
 ]
 
@@ -54,6 +54,13 @@ ContextTest >> testTempNamedPutShouldFailGivenNameIsNotTemp [
 	
 	self assert: (self class hasSlotNamed: #expectedFails).	
 	self should: [thisContext tempNamed: #expectedFails put: 0] raise: Error
+]
+
+{ #category : #'*Kernel-Tests-WithCompiler' }
+ContextTest >> testTempNamedPutShouldReturnAssignedValue [
+	| oneTemp |
+	oneTemp := 1.
+	self assert: (thisContext tempNamed: 'oneTemp' put: 2) equals: 2
 ]
 
 { #category : #'*Kernel-Tests-WithCompiler' }


### PR DESCRIPTION
Fixes #7023

Writing temporary variables should return the written value and not the context
 + test