### PR TITLE
6952 debugger line location is uncorrect when using a breakonce

### DIFF
--- a/src/NewTools-Debugger-Breakpoints-Tools/StHaltAndBreakpointController.class.st
+++ b/src/NewTools-Debugger-Breakpoints-Tools/StHaltAndBreakpointController.class.st
@@ -45,7 +45,8 @@ StHaltAndBreakpointController >> areHaltsAndBreakpoinsEnabledFor: aProgramNode [
 
 { #category : #control }
 StHaltAndBreakpointController >> disableBreakpointNode: aProgramNode [
-	aProgramNode allBreakpointLinks do: [ :link | link condition: [false]; disable ].
+	self flag: 'Fix for PR 6952: should be removed in newtools merge 4.2.2'.
+	aProgramNode breakpoints do: [ :bp | bp disable ].
 	self skipNode: aProgramNode
 ]
 
@@ -80,7 +81,8 @@ StHaltAndBreakpointController >> disableObjectCentricBreakpoint: anObjectCentric
 
 { #category : #control }
 StHaltAndBreakpointController >> enableBreakpointNode: aProgramNode [
-	aProgramNode allBreakpointLinks do: [ :link | link condition: [true]; enable ].
+	self flag: 'Fix for PR 6952: should be removed in newtools merge 4.2.2'.
+	aProgramNode breakpoints do: [ :bp | bp enable ].
 	self removeSkipLinksFor: aProgramNode
 ]
 

--- a/src/Reflectivity-Tests/MetaLinkTest.class.st
+++ b/src/Reflectivity-Tests/MetaLinkTest.class.st
@@ -36,7 +36,7 @@ MetaLinkTest >> testConditionLink [
 ]
 
 { #category : #'tests - simple' }
-MetaLinkTest >> testCotrolInstead [
+MetaLinkTest >> testControlInstead [
 	| link |
 	link := MetaLink new
 		metaObject: [ 1 + 2 ];
@@ -48,7 +48,7 @@ MetaLinkTest >> testCotrolInstead [
 ]
 
 { #category : #'tests - simple' }
-MetaLinkTest >> testCotrolLink [
+MetaLinkTest >> testControlLink [
 	| link |
 	link := MetaLink new
 		metaObject: [ 1 + 2 ];

--- a/src/Reflectivity-Tests/ReflectivityControlTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityControlTest.class.st
@@ -1233,7 +1233,8 @@ ReflectivityControlTest >> testLinkOneShot [
 	self assert: tag isNil.
 	self assert: ReflectivityExamples new exampleMethod equals: 5.
 	self assert: tag equals: #yes.
-	self deny: sendNode hasMetalink.
+	self assert: sendNode hasMetalink.
+	self assert: link condition value equals: false.
 	tag := nil.
 	self assert: ReflectivityExamples new exampleMethod equals: 5.
 	self assert: tag isNil

--- a/src/Reflectivity-Tests/ReflectivityControlTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityControlTest.class.st
@@ -1233,8 +1233,7 @@ ReflectivityControlTest >> testLinkOneShot [
 	self assert: tag isNil.
 	self assert: ReflectivityExamples new exampleMethod equals: 5.
 	self assert: tag equals: #yes.
-	self assert: sendNode hasMetalink.
-	self assert: link condition value equals: false.
+	self deny: sendNode hasMetalink.	
 	tag := nil.
 	self assert: ReflectivityExamples new exampleMethod equals: 5.
 	self assert: tag isNil

--- a/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
@@ -53,6 +53,12 @@ BreakpointTest >> testAddRemoveBreakpoint [
 ]
 
 { #category : #tests }
+BreakpointTest >> testBreakLinkOnce [
+	self assert: (Breakpoint new once link optionOneShot).
+	self assert: (Breakpoint new breakLinkOneShot optionOneShot)
+]
+
+{ #category : #tests }
 BreakpointTest >> testBreakpointInitialization [
 	|bp|	
 	bp := Breakpoint new.

--- a/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
@@ -138,6 +138,18 @@ BreakpointTest >> testBreakpointNodeProperty [
 ]
 
 { #category : #tests }
+BreakpointTest >> testDisableEnableBreakpoint [
+	| breakpoint |
+	breakpoint := Breakpoint new.	
+	self should: [breakpoint breakInContext: self node: #node] raise: Break.
+	breakpoint disable.
+	self shouldnt: [breakpoint breakInContext: self node: #node] raise: Break.
+	breakpoint enable.
+	self should: [breakpoint breakInContext: self node: #node] raise: Break
+
+]
+
+{ #category : #tests }
 BreakpointTest >> testModifyMethodWithBreakpoint [
 	cls compile: 'dummy ^42'.
 	self assertEmpty: Breakpoint all.

--- a/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
@@ -53,6 +53,17 @@ BreakpointTest >> testAddRemoveBreakpoint [
 ]
 
 { #category : #tests }
+BreakpointTest >> testBreakLink [
+	|breakpoint link|
+	breakpoint := Breakpoint new.
+	link := breakpoint link.
+	self assert: link metaObject identicalTo: breakpoint.
+	self assert: link selector equals: #breakInContext:node:.
+	self assertCollection: link options equals: (MetaLink new parseOptions: breakpoint options) options.
+	self assertCollection: link arguments equals: #(#context #node) 
+]
+
+{ #category : #tests }
 BreakpointTest >> testBreakLinkOnce [
 	|breakpoint|
 	breakpoint := Breakpoint new.

--- a/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
@@ -6,7 +6,8 @@ Class {
 	#superclass : #TestCase,
 	#instVars : [
 		'previousBreakpoints',
-		'cls'
+		'cls',
+		'oldObservers'
 	],
 	#category : #'Reflectivity-Tools-Tests'
 }
@@ -25,6 +26,8 @@ BreakpointTest >> setUp [
 	super setUp.
 	cls := self newDummyClass.
 	previousBreakpoints := Breakpoint all copy.
+	oldObservers := Breakpoint observers copy.
+	Breakpoint observers removeAll.
 	Breakpoint all removeAll.
 ]
 
@@ -33,6 +36,8 @@ BreakpointTest >> tearDown [
 	| pkg |
 	Breakpoint removeAll.	
 	Breakpoint all addAll: previousBreakpoints.
+	Breakpoint observers removeAll.
+	Breakpoint observers addAll: oldObservers.
 	cls ifNotNil: [ cls isObsolete ifFalse: [ cls removeFromSystem ] ].
 	pkg := 'DummyPackage' asPackageIfAbsent: [ ]. 
 	pkg ifNotNil: [ pkg removeFromSystem ].
@@ -53,6 +58,20 @@ BreakpointTest >> testAddRemoveBreakpoint [
 ]
 
 { #category : #tests }
+BreakpointTest >> testBreakInContextNode [
+
+	|observer breakpoint|
+	observer := DummyBreakpointObserver new.
+	Breakpoint registerObserver: observer.
+	breakpoint := Breakpoint new.	
+	self should: [breakpoint breakInContext: self node: #node] raise: Break.
+	self assert: observer tag notNil.
+	self assert: observer tag breakpoint identicalTo: breakpoint.
+	self assertCollection: observer tag nodes equals: #(#node).
+	
+]
+
+{ #category : #tests }
 BreakpointTest >> testBreakLink [
 	|breakpoint link|
 	breakpoint := Breakpoint new.
@@ -70,6 +89,19 @@ BreakpointTest >> testBreakLinkOnce [
 	self deny: breakpoint oneShot.
 	breakpoint once.
 	self assert: breakpoint oneShot
+]
+
+{ #category : #tests }
+BreakpointTest >> testBreakOnceInContext [
+
+	|observer breakpoint|
+	observer := DummyBreakpointObserver new.
+	Breakpoint registerObserver: observer.
+	breakpoint := Breakpoint new once.	
+	self assert: breakpoint isEnabled.
+	self should: [breakpoint breakInContext: self node: #node] raise: Break.
+	self deny: breakpoint isEnabled.
+	self shouldnt: [breakpoint breakInContext: self node: #node] raise: Break.
 ]
 
 { #category : #tests }

--- a/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
@@ -124,6 +124,20 @@ BreakpointTest >> testBreakpointInitialization [
 ]
 
 { #category : #tests }
+BreakpointTest >> testBreakpointNodeProperty [
+	|breakpoint|
+	cls compile: 'dummy ^42'.
+	breakpoint := Breakpoint new
+		node: (cls >> #dummy) ast;
+		once.
+	breakpoint install.
+	self assert: (cls >> #dummy) ast hasBreakpoint.
+	self assertCollection: (cls >> #dummy) ast breakpoints equals: {breakpoint} asSet.
+	breakpoint remove.
+	self deny: (cls >> #dummy) ast hasBreakpoint.
+]
+
+{ #category : #tests }
 BreakpointTest >> testModifyMethodWithBreakpoint [
 	cls compile: 'dummy ^42'.
 	self assertEmpty: Breakpoint all.
@@ -229,6 +243,28 @@ BreakpointTest >> testScopeTo [
 	
 	self assert: bp targetInstance identicalTo: object.
 	self assert: bp isObjectCentric
+]
+
+{ #category : #tests }
+BreakpointTest >> testSetAsBreakpointProperty [
+	| node breakpoint breakpoint2 |
+	node := RBProgramNode new.
+	breakpoint := Breakpoint new.
+	breakpoint2 := Breakpoint new.
+	breakpoint node: node.
+	breakpoint2 node: node.
+	
+	breakpoint setAsNodeProperty.
+	breakpoint2 setAsNodeProperty.
+	self assert: node hasBreakpoint.
+	self assertCollection: node breakpoints equals: { breakpoint. breakpoint2 } asSet.
+	
+	breakpoint setAsNodeProperty.
+	self assertCollection: node breakpoints equals: { breakpoint. breakpoint2 } asSet.
+	
+	breakpoint removeFromNodeProperty.
+	breakpoint2 removeFromNodeProperty.
+	self deny: node hasBreakpoint
 ]
 
 { #category : #tests }

--- a/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
@@ -54,8 +54,22 @@ BreakpointTest >> testAddRemoveBreakpoint [
 
 { #category : #tests }
 BreakpointTest >> testBreakLinkOnce [
-	self assert: (Breakpoint new once link optionOneShot).
-	self assert: (Breakpoint new breakLinkOneShot optionOneShot)
+	|breakpoint|
+	breakpoint := Breakpoint new.
+	self deny: breakpoint oneShot.
+	breakpoint once.
+	self assert: breakpoint oneShot
+]
+
+{ #category : #tests }
+BreakpointTest >> testBreakpointEnabled [
+	| breakpoint |
+	breakpoint := Breakpoint new.
+	self assert: breakpoint isEnabled.
+	breakpoint disable.
+	self deny: breakpoint isEnabled.
+	breakpoint enable.
+	self assert: breakpoint isEnabled
 ]
 
 { #category : #tests }

--- a/src/Reflectivity-Tools/BreakpointIconStyler.class.st
+++ b/src/Reflectivity-Tools/BreakpointIconStyler.class.st
@@ -14,9 +14,9 @@ BreakpointIconStyler >> highlightColor [
 
 { #category : #defaults }
 BreakpointIconStyler >> iconBlock: aNode [
-	^[ :seg | 
-		Breakpoint removeFrom: aNode.
-		seg delete]
+	 ^ [ :seg | 
+	   aNode breakpoints do: [ :breakpoint | breakpoint remove ].
+	   seg delete ]
 ]
 
 { #category : #defaults }

--- a/src/Reflectivity-Tools/MetaLinkIconStyler.class.st
+++ b/src/Reflectivity-Tools/MetaLinkIconStyler.class.st
@@ -29,10 +29,10 @@ MetaLinkIconStyler >> iconLabel: aNode [
 
 { #category : #testing }
 MetaLinkIconStyler >> shouldStyleNode: aNode [
-	^ aNode hasLinks and: [ 
-		  aNode links anySatisfy: [ :link | 
-			  (link metaObject == Break or: [ 
-				   { 
-					   Watch.
-					   ExecutionCounter } includes: link metaObject class ]) not ] ]
+	 aNode hasBreakpoint ifTrue: [ ^ false ].	
+	 ^ aNode hasLinks and: [ 
+		   aNode links anySatisfy: [ :link | 
+			   ({ 
+				    Watch.
+				    ExecutionCounter } includes: link metaObject class) not ] ]
 ]

--- a/src/Reflectivity-VariableBreakpoint/RBVariableNode.extension.st
+++ b/src/Reflectivity-VariableBreakpoint/RBVariableNode.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : #RBVariableNode }
 
 { #category : #'*Reflectivity-VariableBreakpoint' }
-RBVariableNode >> hasBreakpoint [
-	^ (self afterLinks anySatisfy: [ :link | link metaObject = Break ])
-		or: [ super hasBreakpoint ]
-]
-
-{ #category : #'*Reflectivity-VariableBreakpoint' }
 RBVariableNode >> variableValueInContext: aContext [
 	^ variable readInContext: aContext
 ]

--- a/src/Reflectivity-VariableBreakpoint/VariableBreakpoint.class.st
+++ b/src/Reflectivity-VariableBreakpoint/VariableBreakpoint.class.st
@@ -163,7 +163,8 @@ VariableBreakpoint >> install [
 				toVariableNamed: vName
 				option: self accessStrategy ].
 	isInstalled := true.
-	self class addBreakpoint: self
+	self class addBreakpoint: self.
+	self setAsNodeProperty 
 ]
 
 { #category : #testing }
@@ -191,10 +192,20 @@ VariableBreakpoint >> remove [
 	isInstalled := false
 ]
 
+{ #category : #install }
+VariableBreakpoint >> removeFromNodeProperty [
+	 self link nodes do: [ :n | n removeBreakpoint: self ]
+]
+
 { #category : #api }
 VariableBreakpoint >> scopeTo: anInstance [
 	super scopeTo: anInstance.
 	self condition: [ :ctx | ctx receiver == targetInstance ]
+]
+
+{ #category : #install }
+VariableBreakpoint >> setAsNodeProperty [
+	 self link nodes do: [ :n | n addBreakpoint: self ]
 ]
 
 { #category : #accessing }

--- a/src/Reflectivity-VariableBreakpoint/VariableBreakpointTest.class.st
+++ b/src/Reflectivity-VariableBreakpoint/VariableBreakpointTest.class.st
@@ -472,6 +472,20 @@ VariableBreakpointTest >> testScopeTo [
 		deny: (wp link condition value: (testContext receiver: Object new))
 ]
 
+{ #category : #'tests - installation' }
+VariableBreakpointTest >> testSetAsBreakpointProperty [
+	 | nodes |
+	 wp := VariableBreakpoint
+		       watchVariable: #v1
+		       inClass: VariableBreakpointMockClass.
+	 nodes := wp link nodes.
+	 nodes do: [ :n | 
+		 self assert: n hasBreakpoint.
+		 self assertCollection: n breakpoints equals: { wp } asSet ].
+	 wp remove.
+	 nodes do: [ :n | self deny: n hasBreakpoint ]
+]
+
 { #category : #'tests - class wide watchpoints' }
 VariableBreakpointTest >> testWatchVariableInClass [ 	
 

--- a/src/Reflectivity/Break.class.st
+++ b/src/Reflectivity/Break.class.st
@@ -14,16 +14,3 @@ Break class >> break [
 	<debuggerCompleteToSender>
 	self signal
 ]
-
-{ #category : #break }
-Break class >> break: aBreakpoint inContext: aContext node: node [
-	<debuggerCompleteToSender>
-	aBreakpoint class
-		notifyBreakpointHit: aBreakpoint
-		inContext: aContext
-		node: node.
-	aBreakpoint oneShot ifTrue: [ 
-		aBreakpoint disabled ifTrue: [ ^ self ].
-		aBreakpoint disable ].
-	self break
-]

--- a/src/Reflectivity/Break.class.st
+++ b/src/Reflectivity/Break.class.st
@@ -18,6 +18,12 @@ Break class >> break [
 { #category : #break }
 Break class >> break: aBreakpoint inContext: aContext node: node [
 	<debuggerCompleteToSender>
-	aBreakpoint class notifyBreakpointHit: aBreakpoint inContext: aContext node: node.	
+	aBreakpoint class
+		notifyBreakpointHit: aBreakpoint
+		inContext: aContext
+		node: node.
+	aBreakpoint oneShot ifTrue: [ 
+		aBreakpoint disabled ifTrue: [ ^ self ].
+		aBreakpoint disable ].
 	self break
 ]

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -277,7 +277,8 @@ Breakpoint >> install [
 	self isObjectCentric
 		ifTrue: [ self targetInstance link: self link toAST: self node.
 			^ self ].
-	self node link: self link
+	self node link: self link.
+	self setAsNodeProperty
 ]
 
 { #category : #testing }
@@ -342,13 +343,26 @@ Breakpoint >> options: anArray [
 
 { #category : #install }
 Breakpoint >> remove [
+	self removeFromNodeProperty.
 	self class removeBreakpoint: self.
 	link uninstall
+]
+
+{ #category : #install }
+Breakpoint >> removeFromNodeProperty [
+	self node removeBreakpoint: self
+	
 ]
 
 { #category : #api }
 Breakpoint >> scopeTo: anInstance [
 	self targetInstance: anInstance
+]
+
+{ #category : #install }
+Breakpoint >> setAsNodeProperty [
+	self node addBreakpoint: self
+	
 ]
 
 { #category : #accessing }

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -227,23 +227,15 @@ Breakpoint >> breakLink [
 	"for now it should just halt in base level"
 
 	^ MetaLink new
-		metaObject: Break;
-		selector: #break:inContext:node:;
-		options: options;
-		arguments:
-			{(RFLiteralVariableNode value: self).
-			#context.
-			#node}
+		  metaObject: self;
+		  selector: #breakInContext:node:;
+		  options: options;
+		  arguments: #(#context #node)
 ]
 
 { #category : #links }
 Breakpoint >> breakLinkConditional [	
 	^self breakLink condition: condition arguments: #(context)
-]
-
-{ #category : #links }
-Breakpoint >> breakLinkOneShot [
-	^ self breakLink optionOneShot: true
 ]
 
 { #category : #api }
@@ -326,6 +318,11 @@ Breakpoint >> once [
 { #category : #accessing }
 Breakpoint >> oneShot [
 	^oneShot ifNil:[oneShot := false]
+]
+
+{ #category : #accessing }
+Breakpoint >> options [
+	^options
 ]
 
 { #category : #accessing }

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -22,7 +22,9 @@ Class {
 		'#node',
 		'#level',
 		'#options',
-		'#targetInstance => WeakSlot'
+		'#targetInstance => WeakSlot',
+		'#oneShot',
+		'#enabled'
 	],
 	#classVars : [
 		'#AllBreakpoints',
@@ -250,6 +252,16 @@ Breakpoint >> condition: aCondition [
 	self link: self breakLinkConditional
 ]
 
+{ #category : #api }
+Breakpoint >> disable [
+	enabled := false
+]
+
+{ #category : #api }
+Breakpoint >> enable [
+	enabled := true
+]
+
 { #category : #initialization }
 Breakpoint >> initialize [
 	
@@ -264,6 +276,11 @@ Breakpoint >> install [
 		ifTrue: [ self targetInstance link: self link toAST: self node.
 			^ self ].
 	self node link: self link
+]
+
+{ #category : #testing }
+Breakpoint >> isEnabled [
+	^enabled ifNil:[enabled := true]
 ]
 
 { #category : #testing }
@@ -303,8 +320,12 @@ Breakpoint >> node: aNode [
 
 { #category : #api }
 Breakpoint >> once [
-	self link: self breakLinkOneShot
-	
+	oneShot := true
+]
+
+{ #category : #accessing }
+Breakpoint >> oneShot [
+	^oneShot ifNil:[oneShot := false]
 ]
 
 { #category : #accessing }

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -199,7 +199,7 @@ Breakpoint class >> removeFrom: aNode [
 	links addAll: (aNode beforeLinks select: [ :link | link metaObject = Break]).
 	links addAll: (aNode afterLinks select: [ :link | link metaObject = Break]).
 	breakpointsToRemove := self all select: [ :br | links includes: br link].
-	breakpointsToRemove asSet do: #remove
+	breakpointsToRemove asSet do: [:breakpoint| breakpoint remove]
 ]
 
 { #category : #cleanup }

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -224,12 +224,11 @@ Breakpoint >> always [
 
 { #category : #api }
 Breakpoint >> breakInContext: aContext node: aNode [
-	<debuggerCompleteToSender>
-	self class notifyBreakpointHit: self inContext: aContext node: aNode.
-	self oneShot ifTrue: [ 
-		self isEnabled ifFalse: [ ^ self ].
-		self disable ].
-	Break break
+	 <debuggerCompleteToSender>
+	 self class notifyBreakpointHit: self inContext: aContext node: aNode.
+	 self isEnabled ifFalse: [ ^ self ].
+	 self oneShot ifTrue: [ self disable ].
+	 Break break
 ]
 
 { #category : #links }

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -222,6 +222,16 @@ Breakpoint >> always [
 
 ]
 
+{ #category : #api }
+Breakpoint >> breakInContext: aContext node: aNode [
+	<debuggerCompleteToSender>
+	self class notifyBreakpointHit: self inContext: aContext node: aNode.
+	self oneShot ifTrue: [ 
+		self isEnabled ifFalse: [ ^ self ].
+		self disable ].
+	Break break
+]
+
 { #category : #links }
 Breakpoint >> breakLink [
 	"for now it should just halt in base level"

--- a/src/Reflectivity/HookGenerator.class.st
+++ b/src/Reflectivity/HookGenerator.class.st
@@ -112,11 +112,12 @@ HookGenerator >> hookFor: aLink [
 		selector: aLink selector 
 		arguments: arguments.
 	
-	(self hasOption: #optionOneShot for: aLink) ifTrue: [
+	(self hasOption: #optionOneShot for: aLink) ifTrue: [	
+			aLink condition: (RFCondition for: [true]) enable.			
 			hook := RBSequenceNode statements: {
 				RBMessageNode
 					receiver: (RFLiteralVariableNode value: aLink)
-					selector: #uninstall.
+					selector: #disable.
 				hook }].
 	aLink hasCondition ifTrue: [hook := self wrapCondition: hook link: aLink].
 	(aLink hasMetaLevel or: [self hasOption: #optionMetalevel for: aLink]) ifTrue: [hook := self wrapInContext: hook link: aLink].		

--- a/src/Reflectivity/HookGenerator.class.st
+++ b/src/Reflectivity/HookGenerator.class.st
@@ -112,12 +112,11 @@ HookGenerator >> hookFor: aLink [
 		selector: aLink selector 
 		arguments: arguments.
 	
-	(self hasOption: #optionOneShot for: aLink) ifTrue: [	
-			aLink condition: (RFCondition for: [true]) enable.			
+	(self hasOption: #optionOneShot for: aLink) ifTrue: [			
 			hook := RBSequenceNode statements: {
 				RBMessageNode
 					receiver: (RFLiteralVariableNode value: aLink)
-					selector: #disable.
+					selector: #uninstall.
 				hook }].
 	aLink hasCondition ifTrue: [hook := self wrapCondition: hook link: aLink].
 	(aLink hasMetaLevel or: [self hasOption: #optionMetalevel for: aLink]) ifTrue: [hook := self wrapInContext: hook link: aLink].		

--- a/src/Reflectivity/RBProgramNode.extension.st
+++ b/src/Reflectivity/RBProgramNode.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : #RBProgramNode }
 
 { #category : #'*Reflectivity' }
+RBProgramNode >> addBreakpoint: aBreakpoint [
+	self breakpoints add: aBreakpoint 
+]
+
+{ #category : #'*Reflectivity' }
 RBProgramNode >> afterHooks [
 	^self propertyAt: #afterHooks ifAbsent: #()
 ]
@@ -36,6 +41,11 @@ RBProgramNode >> beforeLinks [
 ]
 
 { #category : #'*Reflectivity' }
+RBProgramNode >> breakpoints [
+	^ self propertyAt: #breakpoints ifAbsentPut: [ Set new ]
+]
+
+{ #category : #'*Reflectivity' }
 RBProgramNode >> clearReflectivityAnnotations [
 	self removeProperty: #preambles ifAbsent: [ ].
 	self removeProperty: #beforeHooks ifAbsent: [ ].
@@ -57,9 +67,7 @@ RBProgramNode >> hasBeenExecuted [
 
 { #category : #'*Reflectivity' }
 RBProgramNode >> hasBreakpoint [
-	
-	self hasMetalinkBefore ifFalse: [ ^false ].
-	^self beforeLinks anySatisfy: [ :link | link metaObject = Break ]
+	^ (self hasProperty: #breakpoints) and: [ self breakpoints notEmpty ]
 ]
 
 { #category : #'*Reflectivity' }
@@ -175,6 +183,11 @@ RBProgramNode >> postambles [
 { #category : #'*Reflectivity' }
 RBProgramNode >> preambles [
 	^self propertyAt: #preambles ifAbsent: #()
+]
+
+{ #category : #'*Reflectivity' }
+RBProgramNode >> removeBreakpoint: aBreakpoint [
+	self breakpoints remove: aBreakpoint ifAbsent: []
 ]
 
 { #category : #'*Reflectivity' }


### PR DESCRIPTION
Fixes #6952.
This fix looks simple but that is not because it has implications:

- Breakpoints once do not remove themselves after hitting, which fixes the highlight bug in the debugger
- Breakpoint now include (de)activation logic
- Breakpoints are now a property of the nodes on which they are installed
- Breakpoint icon styler has been fixed accordingly

Not that commit 5f4cbf3 is reverted by d408f74 (don't bother to review).

@VincentBlondeau please review.
@dionisiydk could you have a look?
