### PR TITLE
Association-remove-needsFullDefinition

### DIFF
--- a/src/Collections-Support/Association.class.st
+++ b/src/Collections-Support/Association.class.st
@@ -62,14 +62,6 @@ Association >> literalEqual: otherLiteral [
 	^self == otherLiteral
 ]
 
-{ #category : #'variables-toclean' }
-Association >> needsFullDefinition [
-	"Implemented here so we can use simple Associations as Bindings instead of LiteralVariable
-	subclasses"
-	"Can be removed as soon as all bindings are instances of LiteralVariable"
-	^false
-]
-
 { #category : #printing }
 Association >> printOn: aStream [
 


### PR DESCRIPTION
in all cases where we used to call #needsFullDefinition on Association, we are now using subclasses of Variable.

We can therefore remove this method. It does not need to be deprecated, as sending it to Associations outside if them playing the role of a Variable makes no sense.