### PR TITLE
Fix #6727: Clean completion to not override text navigation

### DIFF
--- a/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
@@ -4,16 +4,157 @@ Class {
 	#category : #'HeuristicCompletion-Tests'
 }
 
+{ #category : #'as yet unclassified' }
+CoCompletionEngineTest >> doItContext [
+	
+	^ nil
+]
+
+{ #category : #'as yet unclassified' }
+CoCompletionEngineTest >> interactionModel [
+	
+	^ nil
+]
+
 { #category : #running }
 CoCompletionEngineTest >> newCompletionEngine [
 	
 	^ CoCompletionEngine new
 ]
 
+{ #category : #'as yet unclassified' }
+CoCompletionEngineTest >> selectedClassOrMetaClass [
+	
+	^ nil
+]
+
 { #category : #asserting }
 CoCompletionEngineTest >> shouldInheritSelectors [
 
 	^ true
+]
+
+{ #category : #'test-interaction' }
+CoCompletionEngineTest >> testAdvanceWordDoesNotCloseCompletionContext [
+	"Because it will still be at the end of the current word"
+	| text |
+	text := 'self mEthOdThatDoesNotExist toto'.
+	self
+		setEditorText: text;
+		selectAt: text size - 10.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+	
+	"This is the current shortcut of the completion engine... Cmd+right for all platforms"
+	editor keystroke: (self keyboardEventFor: Character arrowRight useCommand: true).
+	
+	self assert: controller hasCompletionContext.
+]
+
+{ #category : #'test-interaction' }
+CoCompletionEngineTest >> testAdvanceWordGoesToNextWord [
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist toto'.
+	self
+		setEditorText: text;
+		selectAt: text size - 10.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+	
+	"This is the current shortcut of the completion engine... Cmd+right for all platforms"
+	editor keystroke: (self keyboardEventFor: Character arrowRight useCommand: true).
+	
+	self assert: editor caret equals: text size - 'toto' size.
+]
+
+{ #category : #'test-interaction' }
+CoCompletionEngineTest >> testAdvanceWordTwiceClosesCompletionContext [
+	"Because it exists current word"
+	| text |
+	text := 'self mEthOdThatDoesNotExist toto'.
+	self
+		setEditorText: text;
+		selectAt: text size - 10.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+	
+	"This is the current shortcut of the completion engine... Cmd+right for all platforms"
+	2 timesRepeat: [
+		editor keystroke: (self keyboardEventFor: Character arrowRight useCommand: true) ].
+	
+	self deny: controller hasCompletionContext.
+]
+
+{ #category : #'test-interaction' }
+CoCompletionEngineTest >> testEndClosesCompletionContext [
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist'.
+	self
+		setEditorText: text;
+		selectAt: text size - 5.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+	
+	editor keystroke: (self keyboardEventFor: Character end).
+	
+	self deny: controller hasCompletionContext.
+]
+
+{ #category : #'test-interaction' }
+CoCompletionEngineTest >> testEndGoesToEndOfLine [
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist'.
+	self
+		setEditorText: text;
+		selectAt: text size - 5.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+	
+	editor keystroke: (self keyboardEventFor: Character end).
+	
+	self assert: editor caret equals: text size + 1
+]
+
+{ #category : #'test-interaction' }
+CoCompletionEngineTest >> testHomeClosesCompletionContext [
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist'.
+	self
+		setEditorText: text;
+		selectAt: text size - 5.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+	
+	editor keystroke: (self keyboardEventFor: Character home).
+	
+	self deny: controller hasCompletionContext.
+]
+
+{ #category : #'test-interaction' }
+CoCompletionEngineTest >> testHomeGoesToStartOfLine [
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist'.
+	self
+		setEditorText: text;
+		selectAt: text size - 5.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+	
+	editor keystroke: (self keyboardEventFor: Character home).
+	
+	self assert: editor caret equals: 1
 ]
 
 { #category : #'test-interaction' }
@@ -78,6 +219,42 @@ CoCompletionEngineTest >> testOpenMenuCreatesCompletionContext [
 	controller openMenu.
 	
 	self assert: controller hasCompletionContext
+]
+
+{ #category : #'test-interaction' }
+CoCompletionEngineTest >> testPreviousWordClosesCompletionContext [
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist toto'.
+	self
+		setEditorText: text;
+		selectAt: text size.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+	
+	"This is the current shortcut of the completion engine... Cmd+left for all platforms"
+	editor keystroke: (self keyboardEventFor: Character arrowLeft useCommand: true).
+	
+	self deny: controller hasCompletionContext
+]
+
+{ #category : #'test-interaction' }
+CoCompletionEngineTest >> testPreviousWordGoesToPreviousWord [
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist toto'.
+	self
+		setEditorText: text;
+		selectAt: text size.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+	
+	"This is the current shortcut of the completion engine... Cmd+left for all platforms"
+	editor keystroke: (self keyboardEventFor: Character arrowLeft useCommand: true).
+	
+	self assert: editor caret equals: text size - 'toto' size + 1.
 ]
 
 { #category : #'test-interaction' }

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -123,23 +123,9 @@ CompletionEngine >> handleKeystrokeBefore: aKeyboardEvent editor: anEditor [
 	keyCharacter := aKeyboardEvent keyCharacter.
 	controlKeyPressed := aKeyboardEvent controlKeyPressed.
 	commandKeyPressed := aKeyboardEvent commandKeyPressed.
+	
 	self isMenuOpen
 		ifFalse: [ ^ self handleKeystrokeWithoutMenu: aKeyboardEvent ].
-	(keyCharacter = Character home and: [ self captureNavigationKeys ])
-		ifTrue: [ 
-			menuMorph home.
-			^ true ].
-	(keyCharacter = Character end and: [ controlKeyPressed not and: [ self captureNavigationKeys ] ])
-		ifTrue: [ 
-			menuMorph end.
-			^ true ].
-	(keyCharacter = Character arrowRight and: [commandKeyPressed and: [ self captureNavigationKeys ]])
-		ifTrue: [ 
-			menuMorph showDetail.
-			^ true ].
-
-	(keyCharacter = Character arrowLeft  and: [commandKeyPressed and: [ self captureNavigationKeys ]])
-		ifTrue: [ ^ self leftArrow ].
 	
 	(keyCharacter = Character arrowLeft or: [ keyCharacter = Character arrowRight ])
 		ifTrue: [ "just move the caret" ^ false ].

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -38,6 +38,25 @@ CompletionEngineTest >> keyboardEventFor: char [
 	^event
 ]
 
+{ #category : #'tests-keyboard' }
+CompletionEngineTest >> keyboardEventFor: char useCommand: command [
+
+	| event modifier |
+	event := KeyboardEvent new.
+	modifier := 0.
+	command ifTrue: [ modifier := modifier + 64].
+	event 
+		setType: #keystroke
+		buttons: modifier
+		position:  0@0
+		keyValue: char asciiValue 
+		charCode: char asciiValue
+		hand: nil 
+		stamp: Time now.
+		
+	^event
+]
+
 { #category : #running }
 CompletionEngineTest >> newCompletionEngine [
 	
@@ -73,6 +92,7 @@ CompletionEngineTest >> setUp [
 	controller := self newCompletionEngine.
 	controller setEditor: editor.
 	editor completionEngine: controller.
+	editor textArea model: self.
 ]
 
 { #category : #running }


### PR DESCRIPTION
Fix #6727

Add tests about interaction between shortcut text navigation and completion
Clean completion to not override text navigation