### PR TITLE
Compiler-donot-hardcode-ReservedVariables

### DIFF
--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -98,7 +98,6 @@ OCAbstractMethodScope >> hasBindingThatBeginsWith: aString [
 	(copiedVars hasBindingThatBeginsWith: aString) ifTrue: [ ^true ].
 	(tempVector hasBindingThatBeginsWith: aString) ifTrue: [ ^true ].
 	(tempVars hasBindingThatBeginsWith: aString) ifTrue: [ ^true ].
-	(thisContextVar name  beginsWith: aString) ifTrue: [ ^true ].
 	
 	^ self outerScope hasBindingThatBeginsWith: aString
 ]
@@ -119,9 +118,7 @@ OCAbstractMethodScope >> initialize [
 	tempVars :=  OrderedDictionary new.
 	tempVector  := OrderedDictionary new.
 	copiedVars := OrderedDictionary new.
-	id := 0.
-	
-	thisContextVar := ThisContextVariable instance
+	id := 0
 ]
 
 { #category : #'temp vars' }
@@ -156,7 +153,6 @@ OCAbstractMethodScope >> lookupVar: name [
 	copiedVars at: name ifPresent: [:v | ^ v].
 	tempVector at: name ifPresent: [:v | ^ v].
 	tempVars at: name ifPresent: [:v | ^ v].
-	name = thisContextVar name ifTrue: [^ thisContextVar].
 	name = self tempVectorName ifTrue: [ ^ self tempVectorVar ].
 	^self outerScope lookupVar: name
 	
@@ -166,7 +162,6 @@ OCAbstractMethodScope >> lookupVar: name [
 OCAbstractMethodScope >> lookupVarForDeclaration: name [
 	"This is a version of #lookupVar: that skips the OCRequestorScope"
 	tempVars at: name ifPresent: [:v | ^ v].
-	name = thisContextVar name ifTrue: [^ thisContextVar].
 	^self outerScope lookupVarForDeclaration: name
 ]
 

--- a/src/OpalCompiler-Core/OCExtraBindingScope.class.st
+++ b/src/OpalCompiler-Core/OCExtraBindingScope.class.st
@@ -36,8 +36,8 @@ OCExtraBindingScope >> bindings: anObject [
 
 { #category : #lookup }
 OCExtraBindingScope >> lookupVar: name [
-	name = 'self' ifTrue: [ ^ outerScope lookupVar: name ].
-	name = 'super' ifTrue: [ ^ outerScope lookupVar: name ].
+	"reserved Variables are defined by the instance scope"
+	(ReservedVariable nameIsReserved: name) ifTrue: [ ^ outerScope lookupVar: name ].
 	
 	^(bindings bindingOf: name asSymbol)
 		ifNotNil: [ :var | var ]

--- a/src/OpalCompiler-Core/OCInstanceScope.class.st
+++ b/src/OpalCompiler-Core/OCInstanceScope.class.st
@@ -6,8 +6,7 @@ Class {
 	#superclass : #OCAbstractScope,
 	#instVars : [
 		'vars',
-		'selfVar',
-		'superVar'
+		'reservedVars'
 	],
 	#category : #'OpalCompiler-Core-Semantics'
 }
@@ -20,9 +19,8 @@ OCInstanceScope >> allTemps [
 { #category : #lookup }
 OCInstanceScope >> hasBindingThatBeginsWith: aString [
 	"Answer true if true, false or any slot start with aString"
-
-	(selfVar name beginsWith: aString) ifTrue: [ ^true ].
-	(superVar name beginsWith: aString) ifTrue: [ ^true ].
+	
+	(reservedVars hasBindingThatBeginsWith: aString) ifTrue: [ ^true ].
 	(vars hasBindingThatBeginsWith: aString) ifTrue: [ ^true ].
 	
 	^ self outerScope hasBindingThatBeginsWith: aString
@@ -32,8 +30,8 @@ OCInstanceScope >> hasBindingThatBeginsWith: aString [
 OCInstanceScope >> initialize [
   
 	vars := Dictionary new.
-	selfVar := SelfVariable instance.
-	superVar := SuperVariable instance
+	reservedVars  := (ReservedVariable subclasses collect: [ :class |
+			class instance name -> class instance]) asDictionary 
 ]
 
 { #category : #acessing }
@@ -50,17 +48,14 @@ OCInstanceScope >> isInstanceScope [
 { #category : #lookup }
 OCInstanceScope >> lookupVar: name [
 	"Return a ScopeVar for my inst var with this name.  Return nil if none found"
-
-	name = selfVar name ifTrue: [^ selfVar].
-	name = superVar name ifTrue: [^ superVar].
+	reservedVars at: name ifPresent: [:v | ^ v].
 	^ vars at: name ifAbsent: [self outerScope lookupVar: name]
 ]
 
 { #category : #lookup }
 OCInstanceScope >> lookupVarForDeclaration: name [
 	"This is a version of #lookupVar: that skips the OCRequestorScope"
-	name = selfVar name ifTrue: [^ selfVar].
-	name = superVar name ifTrue: [^ superVar].
+	reservedVars at: name ifPresent: [:v | ^ v].
 	^ vars at: name ifAbsent: [self outerScope lookupVarForDeclaration: name]
 ]
 

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -33,8 +33,9 @@ OCRequestorScope >> compilationContext: anObject [
 { #category : #lookup }
 OCRequestorScope >> lookupVar: name [
 
-	name = 'self' ifTrue: [ ^ outerScope lookupVar: name ].
-	name = 'super' ifTrue: [ ^ outerScope lookupVar: name ].
+	"reserved Variables are defined by the instance scope"
+	(ReservedVariable nameIsReserved: name) ifTrue: [ ^ outerScope lookupVar: name ].
+	
 	"We do not want to auto define bindings for unknown Globals"
 	(name isString and: [name first isUppercase]) ifTrue: [ ^ outerScope lookupVar: name].
 	


### PR DESCRIPTION
Now that we have ReservedVariable and subclasses modeling what self, super and thisContext are named, we do not need to hardcode any of thas info in the Name Analyzer.

- this unifies how Reserved Variables are looked up and defined. They are now all defined in the InstanceScope.
- simplify the code, remove hardcoded 'self' 'super' 'thisContext'

OCAbstractMethodScope has still the unused var, this can not be changed in the runnning system and will be done directly as a code change on the repository later.