### PR TITLE
6849-Update-Microdown-packages-Try2

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -197,7 +197,10 @@ BaselineOfIDE >> baseline: spec [
 				repository: repository;
 				loads: #('Playground' 'Inspector' 'Debugger') ].
 			
-		spec package: 'BaselineOfMicrodown'.	
+		spec baseline: 'Microdown' with: [
+		spec
+			repository: repository;
+			loads: #('Microdown-RichTextComposer' 'Microdown-Tests' 'Microdown-Calypso' 'Microdown-Pillar-Tests')].
 			
 		spec package: 'Pharo-WelcomeHelp' ]
 ]

--- a/src/BaselineOfMicrodown/BaselineOfMicrodown.class.st
+++ b/src/BaselineOfMicrodown/BaselineOfMicrodown.class.st
@@ -15,7 +15,8 @@ BaselineOfMicrodown >> baseline: spec [
 	spec for: #'common' do: [
 		spec baseline: 'Pillar' with: [ spec 
 				loads: #('rich text exporter');
-				repository: 'github://pillar-markup/pillar:dev-8/src' ].
+				repository: self repository
+				"repository: 'github://pillar-markup/pillar:dev-8/src'" ].
 		spec 
 			package: #'Microdown';
 			package: #'Microdown-Tests'  with: [

--- a/src/BaselineOfMicrodown/BaselineOfMicrodown.class.st
+++ b/src/BaselineOfMicrodown/BaselineOfMicrodown.class.st
@@ -15,7 +15,7 @@ BaselineOfMicrodown >> baseline: spec [
 	spec for: #'common' do: [
 		spec baseline: 'Pillar' with: [ spec 
 				loads: #('rich text exporter');
-				repository: self repository
+				repository: self packageRepositoryURL
 				"repository: 'github://pillar-markup/pillar:dev-8/src'" ].
 		spec 
 			package: #'Microdown';

--- a/src/BaselineOfMicrodown/ManifestBaselineOfMicrodown.class.st
+++ b/src/BaselineOfMicrodown/ManifestBaselineOfMicrodown.class.st
@@ -1,0 +1,9 @@
+"
+The Microdown project is a parser and document model for Microdown a clean and lean Markdown. 
+See `#'Microdown'`
+"
+Class {
+	#name : #ManifestBaselineOfMicrodown,
+	#superclass : #PackageManifest,
+	#category : #'BaselineOfMicrodown-Manifest'
+}


### PR DESCRIPTION
Retrying but there is something that I do not understand. 
Why the newest packages of Microdown are not included in this PR?
- I took latest Pharo.
- Loaded Microdown latest baseline from my repo 
- the tests are green 
but I do not see dirty packages to be committed to Pharo. 
So I'm totally confused. 