### PR TITLE
Hiedra: Integrate latest version

### DIFF
--- a/src/EpiceaBrowsers/EpLogNodeGraphPresenter.class.st
+++ b/src/EpiceaBrowsers/EpLogNodeGraphPresenter.class.st
@@ -79,9 +79,10 @@ EpLogNodeGraphPresenter >> initializeHiedraController [
 	hiedraColumnController renderer
 		rowHeight: self rowHeight;
 		cellWidth: self rowHeight // 3;
-		arrowSize: 2.0;
-		nodeConnectionOffset: 2.5
+		arrowSize: 1.0;
+		nodeConnectionOffset: 2.5.
 
+	hiedraColumnController renderer rowHeight: FTTableMorph defaultRowHeight floor.
 ]
 
 { #category : #initialization }

--- a/src/Hiedra-Examples/HiExampleCommit.class.st
+++ b/src/Hiedra-Examples/HiExampleCommit.class.st
@@ -31,7 +31,7 @@ Class {
 		'comment',
 		'parentIds'
 	],
-	#category : #'Hiedra-Examples'
+	#category : #'Hiedra-Examples-Model'
 }
 
 { #category : #examples }
@@ -24122,13 +24122,13 @@ HiExampleCommit class >> randomlyGenerated [
 	| values random |
 	values := 60 to: 1 by: -1.
 	random := Random new.
-	^ values collect: [ :value | 
+	^ (values collect: [ :value | 
 		self new
 			id: value;
-			comment: 'Value ', value asString;
+			comment: 'Randomly Connected Element #', value asString;
 			parentIds: ((values copyWithout: value) intersection: { random nextInt: values max });
 			yourself
-		]
+		]) reversed
 ]
 
 { #category : #accessing }

--- a/src/Hiedra-Examples/HiFastTableExample.class.st
+++ b/src/Hiedra-Examples/HiFastTableExample.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'hiedraColumnController'
 	],
-	#category : #'Hiedra-Examples'
+	#category : #'Hiedra-Examples-FastTable'
 }
 
 { #category : #examples }
@@ -34,8 +34,8 @@ HiFastTableExample class >> openExample: selector [
 
 	table := FTTableMorph new
 		extent: 500 @ 700;
-		addColumn: (FTColumn id: ' ');
-		addColumn: (FTColumn id: 'Comment');
+		addColumn: (FTColumn id: #'Comment');
+		hideColumnHeaders;
 		dataSource: dataSource;
 		beResizable;
 		yourself.
@@ -50,16 +50,15 @@ HiFastTableExample class >> openExample: selector [
 HiFastTableExample >> cellColumn: column row: rowIndex [
 	"Answer a morph with the cell view."
 	
-	column id = ' ' ifTrue: [ 
+	column id = #'Comment' ifTrue: [
+		| hiedraMorph commentMorph |
+		hiedraMorph := hiedraColumnController cellMorphAtRow: rowIndex.
+		commentMorph := (self elementAt: rowIndex) comment asMorph.
 		^ FTCellMorph new
-			addMorphBack: (hiedraColumnController cellMorphAtRow: rowIndex);
+			addMorphBack: hiedraMorph;
+			addMorphBack: commentMorph;
 			yourself
 		].
-
-	column id = 'Comment' ifTrue: [ 
-		| commit |
-		commit := self elementAt: rowIndex.
-		^ commit comment asMorph ].
 
 	^ self error
 ]
@@ -81,9 +80,6 @@ HiFastTableExample >> elements: commits [
 	"Reset the visualization"
 	hiedraColumnController reset.
 
-	"Adjust the column width in the table"
-	self table columns first width: hiedraColumnController rulerWidth.
-
 ]
 
 { #category : #initialization }
@@ -91,7 +87,7 @@ HiFastTableExample >> initialize [
 	super initialize.
 	hiedraColumnController := HiColumnController new.
 	hiedraColumnController renderer
-		arrowSize: 2;
+		arrowSize: 1;
 		nodeConnectionOffset: 2;
 		cellWidth: 7.
 

--- a/src/Hiedra-Examples/HiSpecExample.class.st
+++ b/src/Hiedra-Examples/HiSpecExample.class.st
@@ -6,15 +6,17 @@ Class {
 	#superclass : #SpPresenter,
 	#instVars : [
 		'hiedraColumnController',
-		'table'
+		'table',
+		'actionBar'
 	],
-	#category : #'Hiedra-Examples'
+	#category : #'Hiedra-Examples-Spec2'
 }
 
 { #category : #specs }
 HiSpecExample class >> defaultSpec [
 	^ SpBoxLayout newVertical
 		add: #table;
+		add: #actionBar withConstraints: [ :constraints | constraints height: self toolbarHeight ];
 		yourself
 ]
 
@@ -60,24 +62,62 @@ HiSpecExample >> close [
 HiSpecExample >> commits: commits [ 
 
 	table items: commits.
+
 	hiedraColumnController ruler: (HiRulerBuilder 
 		newRulerValues: commits
 		linksBlock: [:aCommit |
 			aCommit parentIds collect: [:id | 
 				commits detect: [:each | each id = id ] ] ]).
+
 	hiedraColumnController reset.
-	"After #reset, we can know the width of the column."
+	
+	"After #reset, we know the desired width for the column."
 	table columns first width: hiedraColumnController rulerWidth.
 ]
 
 { #category : #initialization }
-HiSpecExample >> initializeWidgets [
+HiSpecExample >> forceRefreshHiedra [
+	hiedraColumnController reset.
+	table withAdapterDo: #refreshList.
+]
+
+{ #category : #initialization }
+HiSpecExample >> initializeActionBar [
+
+	| refreshButton inspectButton |
+	refreshButton := self newButton
+		label: 'Redraw';
+		help: 'Refresh the table (and redraw all Hiedra cells with current rendering parameters).';
+		action: [ UIManager default defer: [ self forceRefreshHiedra ] ];
+		yourself.
+	inspectButton := self newButton
+		label: 'Renderer'; 
+		help: ('Inspect the Hiedra renderer, that has the rendering parameters. Press on {1} button to see the effect of any change on the renderer.' format: { refreshButton label });
+		action: [ UIManager default defer: [ hiedraColumnController renderer inspect ] ];
+		yourself.
+
+	actionBar := self newActionBar
+		add: inspectButton;
+		add: refreshButton;
+		yourself.
+
+]
+
+{ #category : #initialization }
+HiSpecExample >> initializePresenters [
+	self initializeTable.
+	self initializeActionBar.
+]
+
+{ #category : #initialization }
+HiSpecExample >> initializeTable [
 	table := self newTable.
 
 	"Configure hiedra controller"
 	hiedraColumnController := HiColumnController new.
 
 	hiedraColumnController renderer
+		linkWidth: 3.5;
 		nodeRadius: 1.5;
 		nodeBorderWidth: 3.0;
 		arrowSize: 0;
@@ -90,6 +130,8 @@ HiSpecExample >> initializeWidgets [
 
 	"Configure columns"
 	table
-		addColumn: (SpImageTableColumn evaluated: [ :item | hiedraColumnController cellMorphAtValue: item ]);
-		addColumn: (SpStringTableColumn evaluated: #comment)
+		addColumn: (SpImageTableColumn evaluated: [ :item |
+			hiedraColumnController cellMorphAtValue: item ]);
+		addColumn: (SpStringTableColumn evaluated: [ :item |
+			item comment ])
 ]

--- a/src/Hiedra-Tests/HiExamplesTest.class.st
+++ b/src/Hiedra-Tests/HiExamplesTest.class.st
@@ -4,28 +4,28 @@ Class {
 	#category : #'Hiedra-Tests-Model'
 }
 
-{ #category : #accessing }
-HiExamplesTest class >> defaultTimeLimit [ 
-
-	^ 30 seconds
+{ #category : #testing }
+HiExamplesTest class >> isAbstract [
+	^ self = HiExamplesTest
 ]
 
 { #category : #tests }
-HiExamplesTest >> exampleMethods [ 
-	^ (((RPackage organizer packages
-		select: [ :each | each name beginsWith: 'Hiedra' ])
-		flatCollect: #classes)
-		flatCollect: [ :each | each classSide methods ])
-		select: [ :each | 
-			(each selector beginsWith: 'example') and: [ each numArgs = 0 ] ]
+HiExamplesTest >> exampleClassToTest [
+	^ self subclassResponsibility
+]
+
+{ #category : #tests }
+HiExamplesTest >> exampleMethods [
+
+	^ self exampleClassToTest classSide methods select: [ :each | 
+		  (each selector beginsWith: 'example') and: [ each numArgs = 0 ] ]
 ]
 
 { #category : #tests }
 HiExamplesTest >> testAllExamples [
 	| exampleMethods |
 	
-	self skip: 'This test fails randomly in the CI in different OS due a timeout, even with an increased time limit of 30 seconds'.
-	self timeLimit: 30 seconds.
+	self timeLimit: 1 minute.
 	
 	exampleMethods := self exampleMethods.
 	self deny: exampleMethods isEmpty.

--- a/src/Hiedra-Tests/HiFastTableExampleTest.class.st
+++ b/src/Hiedra-Tests/HiFastTableExampleTest.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #HiFastTableExampleTest,
+	#superclass : #HiExamplesTest,
+	#category : #'Hiedra-Tests-Model'
+}
+
+{ #category : #tests }
+HiFastTableExampleTest >> exampleClassToTest [
+	^ HiFastTableExample
+]

--- a/src/Hiedra-Tests/HiSpecExampleTest.class.st
+++ b/src/Hiedra-Tests/HiSpecExampleTest.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #HiSpecExampleTest,
+	#superclass : #HiExamplesTest,
+	#category : #'Hiedra-Tests-Model'
+}
+
+{ #category : #tests }
+HiSpecExampleTest >> exampleClassToTest [
+	^ HiSpecExample
+]

--- a/src/Hiedra/HiAbstractRenderer.class.st
+++ b/src/Hiedra/HiAbstractRenderer.class.st
@@ -52,6 +52,14 @@ HiAbstractRenderer >> rowHeight [
 ]
 
 { #category : #accessing }
+HiAbstractRenderer >> rowWidthAt: rowIndex [
+	"Answer the width in pixels required by a row to be rendered."
+
+	"The +2 represents the left and right margin."
+	^ ((ruler numberOfColumnsAt: rowIndex) + 2) * self cellWidth
+]
+
+{ #category : #accessing }
 HiAbstractRenderer >> rowsInterval [
 	^ rowsInterval
 ]

--- a/src/Hiedra/HiColumnController.class.st
+++ b/src/Hiedra/HiColumnController.class.st
@@ -27,7 +27,7 @@ HiColumnController >> cellBoundsForRow: rowIndex inPage: pageIndex [
 	rowIndexRelativeToPage := rowIndexRelativeToRuler - rowIndexOfFirstNodeInPage.
 
 	^ 0 @ (rowIndexRelativeToPage * renderer rowHeight)
-		corner: self rulerWidth @ ((rowIndexRelativeToPage + 1) * renderer rowHeight)
+		corner: (renderer rowWidthAt: rowIndex) @ ((rowIndexRelativeToPage + 1) * renderer rowHeight)
 ]
 
 { #category : #API }
@@ -93,7 +93,7 @@ HiColumnController >> newCellMorphForRow: rowIndex [
 	aForm getCanvas
 		translucentImage: (self formAtPage: pageIndex)
 		at: 0 @ 0
-		sourceRect: cellBoundsInPage truncated.
+		sourceRect: cellBoundsInPage.
 	^ aForm asMorph
 ]
 

--- a/src/Hiedra/HiRuler.class.st
+++ b/src/Hiedra/HiRuler.class.st
@@ -177,6 +177,12 @@ HiRuler >> numberOfColumns [
 ]
 
 { #category : #accessing }
+HiRuler >> numberOfColumnsAt: rowIndex [
+
+	^ (elementsByRow at: rowIndex) size
+]
+
+{ #category : #accessing }
 HiRuler >> numberOfRows [
 
 	^ elementsByRow size

--- a/src/Hiedra/HiSimpleRenderer.class.st
+++ b/src/Hiedra/HiSimpleRenderer.class.st
@@ -1,11 +1,15 @@
 "
-I render a Hiedra visualization (HiRuler) in a Form using Athens. The nodes and links of the ruler will occupy the cells of a grid in the Athens canvas. 
+I render a Hiedra visualization (HiRuler) in a Form using Athens. The nodes and links of the ruler will occupy the cells of an imaginary grid in the Athens canvas. 
 
 Decisions to render the ruler:
 
 * All nodes have the same appearance (radius, color, etc.).
 * All links have the same appearance (width, color, etc.).
 * All cells have same dimensions (width and height).
+
+The #accessing methods provide a way to customize the renderization.
+
+IMPORTANT: The #rowHeight is only rendering parameter that HAS NO DEFAULT VALUE and the user must set it with the pixel height of rows (an integer number).
 
 "
 Class {
@@ -120,16 +124,19 @@ HiSimpleRenderer >> athensPathForAscendingLink: aHiLink on: athensCanvas [
 		fragmentStart := (self cellCenterFor: aHiLink target rulerPoint) + nodeConnectionYOffset.
 		athensPathBuilder absolute; moveTo: fragmentStart.
 
+		"The arrow (if enabled) is connected to target node"
 		self addArrowInto: athensPathBuilder descending: false.
 
 		"Add all fragments except last (in reversed order)"
 		aHiLink intermediatePoints reverseDo: [ :rulerPoint | 
-			| fragmentEnd |
+			| fragmentEnd offset |
 			fragmentEnd := self cellCenterFor: rulerPoint.
+			offset := fragmentStart x > fragmentEnd x
+				ifTrue: [ linkWidth negated ] ifFalse: [ linkWidth ].
 			self
 				addLinkFragmentFrom: fragmentStart
 				to: fragmentEnd
-				intermediateY: (self cellOriginFor: rulerPoint) y
+				intermediateY: (self cellOriginFor: rulerPoint) y + offset
 				into: athensPathBuilder.
 			fragmentStart := fragmentEnd
 			].
@@ -151,29 +158,32 @@ HiSimpleRenderer >> athensPathForDescendingLink: aHiLink on: athensCanvas [
 		| nodeConnectionYOffset fragmentStart |
 		nodeConnectionYOffset := self nodeBottomRelativeConnectionPoint.
 
-		"Start of first fragment (that connects BELOW of the origin node)"
+		"Start of first fragment (that connects at BOTTOM of the origin node)"
 		fragmentStart := (self cellCenterFor: aHiLink origin rulerPoint) + nodeConnectionYOffset.
 		athensPathBuilder absolute; moveTo: fragmentStart.
 
 		"Add all fragments except last"
 		aHiLink intermediatePoints do: [ :rulerPoint |
-			| fragmentEnd |
+			| fragmentEnd offset |
 			fragmentEnd := self cellCenterFor: rulerPoint.
+			offset := fragmentStart x > fragmentEnd x
+				ifTrue: [ linkWidth negated ] ifFalse: [ linkWidth ].
 			self
 				addLinkFragmentFrom: fragmentStart
 				to: fragmentEnd
-				intermediateY: (self cellOriginFor: rulerPoint) y
+				intermediateY: (self cellOriginFor: rulerPoint) y + offset
 				into: athensPathBuilder.
 			fragmentStart := fragmentEnd
 			].
 
-		"Add last fragment (that connects ABOVE of the target node)"
+		"Add last fragment (that connects at TOP of the target node)"
 		self
 			addLinkFragmentFrom: fragmentStart
 			to: (self cellCenterFor: aHiLink target rulerPoint) - nodeConnectionYOffset
 			intermediateY: (self cellOriginFor: aHiLink target rulerPoint) y
 			into: athensPathBuilder.
 
+		"The arrow (if enabled) is connected to target node"
 		self addArrowInto: athensPathBuilder descending: true.
 		]
 ]
@@ -239,8 +249,8 @@ HiSimpleRenderer >> colorStrategy [
 ]
 
 { #category : #accessing }
-HiSimpleRenderer >> colorStrategy: anObject [
-	colorStrategy := anObject
+HiSimpleRenderer >> colorStrategy: aHiColorStrategy [
+	colorStrategy := aHiColorStrategy
 ]
 
 { #category : #rendering }
@@ -256,17 +266,16 @@ HiSimpleRenderer >> initialize [
 
 	self useWheelColorStrategy.
 
-	nodeRadio := 2.2.
-	nodeBorderWidth := 1.75.
+	nodeRadio := 3.0.
+	nodeBorderWidth := 1.1.
 	nodeConnectionOffset := 0.
 
-	linkWidth := nodeBorderWidth.
+	linkWidth := 1.3.
 	linkDashes := #().
 	linkCurveAngle := 45 degreesToRadians.
 
 	arrowSize := linkWidth * 0.75.
 
-	"Important: the user must set the height of rows (integers worked better than a floats)"
 	cellWidth := linkWidth * 3
 ]
 
@@ -343,9 +352,9 @@ HiSimpleRenderer >> nodeBottomRelativeConnectionPoint [
 ]
 
 { #category : #accessing }
-HiSimpleRenderer >> nodeColor: anObject [
+HiSimpleRenderer >> nodeColor: aColor [
 	self useUniformColorStrategy.
-	colorStrategy nodeColor: anObject
+	colorStrategy nodeColor: aColor
 ]
 
 { #category : #accessing }
@@ -425,8 +434,11 @@ HiSimpleRenderer >> rowHeight [
 ]
 
 { #category : #accessing }
-HiSimpleRenderer >> rowHeight: aNumber [
-	rowHeight := aNumber
+HiSimpleRenderer >> rowHeight: anInteger [
+	"Set the pixel height for rows (an integer number).
+	Note this assumes there is a unique height for all rows."
+
+	rowHeight := anInteger
 ]
 
 { #category : #accessing }

--- a/src/Hiedra/HiWheelColorStrategy.class.st
+++ b/src/Hiedra/HiWheelColorStrategy.class.st
@@ -41,7 +41,10 @@ HiWheelColorStrategy >> colorWheel: aCollectionOfColors [
 HiWheelColorStrategy >> defaultColorWheel [
 	| referenceColor |
 	referenceColor := Smalltalk ui theme textColor.
+
+	"Little workaround: The wheel is being reversed to avoid having red at first (it's a color associated with danger)"
 	^ (Color wheel: self defaultColorWheelSize saturation: 0.95 brightness: 0.95)
+		reversed
 		collect: [ :each | each mixed: 0.75 with: referenceColor ]
 ]
 


### PR DESCRIPTION
Fixes #7046 

Change log:
* Optimize space usage: as screenshot shows, text can now follow the hiedra cells (before, there was only a global hiedra width that the column show adjust to, and the text had to go in a different column). (See screenshot).
* Improve Spec2 example with an action bar that helps user to play with rendering parameters.
* Un-skip test and split them to better spot a CI failure.

![screenshotB](https://user-images.githubusercontent.com/3044265/89344336-b84f2880-d673-11ea-89de-55a87f05ef7f.png)
