### PR TITLE
Adding the nesting of the comments and strings with smart characters …

### DIFF
--- a/src/AST-Core/RBComment.class.st
+++ b/src/AST-Core/RBComment.class.st
@@ -64,6 +64,11 @@ RBComment >> intersectsInterval: anInterval [
 		or: [ self start between: anInterval first and: anInterval last ]
 ]
 
+{ #category : #testing }
+RBComment >> isCommentNode [ 
+	^true.
+]
+
 { #category : #printing }
 RBComment >> printOn: aStream [
 	super printOn: aStream.

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -446,6 +446,11 @@ RBProgramNode >> isCascade [
 ]
 
 { #category : #testing }
+RBProgramNode >> isCommentNode [
+	^false.
+]
+
+{ #category : #testing }
 RBProgramNode >> isDirectlyUsed [
 	"This node is directly used as an argument, receiver, or part of an assignment."
 

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -242,6 +242,29 @@ RubSmalltalkEditor >> bestNodeInTextAreaOnError: aBlock [
 		onError: aBlock
 ]
 
+{ #category : #'as yet unclassified' }
+RubSmalltalkEditor >> bestNodeInTextAreaWithoutSelection [
+	"Find the best node in the editor text area trimming the selection to prepare for eventual deletion"
+	
+	| node start stop intervalTrimmedText |
+	
+	start := self textArea startIndex.
+	stop := self textArea stopIndex.
+	intervalTrimmedText := start = stop 
+					ifFalse: [ 	| beginning end |
+									beginning := end := ''.
+									start <= 1 ifFalse: [ beginning := self textArea string copyFrom: 1 to: start - 1 ].
+									stop >= self textArea text size ifFalse: [ end :=  self textArea string copyFrom: stop + 1 to: self textArea text size ].
+									beginning,end ]
+					 ifTrue: [ self textArea string ].
+	[node := RBParser parseMethod: intervalTrimmedText  onError: [ 
+		RBParser parseFaultyExpression: intervalTrimmedText]
+	] on: Error do: [^nil].
+	
+	^node bestNodeFor: (start to: start).
+	
+]
+
 { #category : #binding }
 RubSmalltalkEditor >> bindingOf: aString [
 	^ self textArea bindingOf: aString
@@ -394,6 +417,21 @@ RubSmalltalkEditor >> computeSelectionIntervalFromCommentIn: aString at: anInter
 	comment ifNil: [ ^ 0 to: -1 ].
 	commentInterval := comment first.
 	^ commentInterval first + 1 to: commentInterval last - 1
+]
+
+{ #category : #'menu messages' }
+RubSmalltalkEditor >> copySelection [
+	"Copy the current selection and store it in the paste buffer, unless a caret.  Undoer & Redoer: undoCutCopy"
+
+	| node charac |
+	"Research of selected node for eventual nesting of comment or string."
+	self lineSelectAndEmptyCheck: [^ self].
+	node := self bestNodeInTextAreaWithoutSelection.
+	charac := self getNestingCharacterFromAst: node.
+	charac ifNil: [ self clipboardTextPut: self selection ]
+		    ifNotNil: [ self clipboardTextPut: (self unNesting: self selection with: charac) ].
+	self editingState previousInterval: self selectionInterval.
+
 ]
 
 { #category : #'do-its' }
@@ -909,6 +947,29 @@ RubSmalltalkEditor >> notify: aString at: anInteger in: aStream [
 		at: anInteger 
 		in: aStream 
 
+]
+
+{ #category : #'menu messages' }
+RubSmalltalkEditor >> paste [
+	"Paste the text from the shared buffer over the current selection and 
+	redisplay if necessary.  Undoer & Redoer: undoAndReselect."
+	| node charac nestedText |
+	"Research of selected node for eventual nesting of comment or string."
+	node := self bestNodeInTextAreaWithoutSelection.
+	charac := self getNestingCharacterFromAst: node.
+	nestedText := self stringNestedWith: charac.
+	"Check if it is a Symbol that needs extra apostrophes to receive"
+	"The commented code is a hint at how to nest strings in symbols. The solucion has not been found yet."
+		"(node isLiteralNode and: [ node value isSymbol ])
+				ifFalse: [" self replace: self selectionInterval with: nestedText and:
+						 	  [self selectAt: self pointIndex] "] 
+				ifTrue: [ | beginning end |
+				beginning := self textArea text copyFrom: node start to: self textArea startIndex - 1.
+				end := self textArea text copyFrom: self textArea stopIndex to: node stop + (self textArea stopIndex - self textArea startIndex) .
+				self replace: (node start to: node stop + (self textArea stopIndex - self textArea startIndex)) with: beginning, nestedText, end and:
+		[self selectAt: self pointIndex] ].
+	 ]."
+	
 ]
 
 { #category : #'editing keys' }

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -2390,7 +2390,7 @@ RubTextEditor >> shiftEnclose: aKeyboardEvent [
 ]
 
 { #category : #nesting }
-RubTextEditor >> shouldNestCar: aChar [
+RubTextEditor >> shouldNestCharacter: aChar [
 	^'"''' includes: aChar.
 ]
 

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -1000,14 +1000,14 @@ RubTextEditor >> encloseWith: aMatchingPair [
 			and: [ (text at: startIndex-1) = left and: [(text at: stopIndex) = right]])
 		ifTrue: [
 			"already enclosed; strip off brackets"
-			newString := (self shouldNestCar: left)
+			newString := (self shouldNestCharacter: left)
 						 ifTrue: [ self unNesting: oldSelection with: left ] 
 						 ifFalse: [ oldSelection ].
 			self selectFrom: startIndex-1 to: stopIndex.
 			self replaceSelectionWith: newString ]
 		ifFalse: [
 			" Checks if the characters inside the selection need to be escaped or not. "
-			newString := (self shouldNestCar: left)
+			newString := (self shouldNestCharacter: left)
 						 ifTrue: [ self nesting: oldSelection with: left ] 
 						 ifFalse: [ "not enclosed; enclose by matching brackets"
 									  (String with: left), oldSelection string, (String with: right) ].
@@ -2452,7 +2452,7 @@ RubTextEditor >> string [
 
 { #category : #nesting }
 RubTextEditor >> stringNestedWith: aCharac [
-	^(self shouldNestCar: aCharac) 
+	^(self shouldNestCharacter: aCharac) 
 		ifTrue: [ self nestingForPaste: self clipboardText with: aCharac. ]
 		ifFalse: [ self clipboardText ] 
 ]

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -987,7 +987,7 @@ RubTextEditor >> enclose: aKeyboardEvent [
 RubTextEditor >> encloseWith: aMatchingPair [
 	"Insert or remove bracket characters around the current selection."
 
-	| left right startIndex stopIndex oldSelection text |
+	| left right startIndex stopIndex oldSelection text newString |
 	self closeTypeIn.
 	startIndex := self startIndex.
 	stopIndex := self stopIndex.
@@ -1000,13 +1000,21 @@ RubTextEditor >> encloseWith: aMatchingPair [
 			and: [ (text at: startIndex-1) = left and: [(text at: stopIndex) = right]])
 		ifTrue: [
 			"already enclosed; strip off brackets"
+			newString := (self shouldNestCar: left)
+						 ifTrue: [ self unNesting: oldSelection with: left ] 
+						 ifFalse: [ oldSelection ].
 			self selectFrom: startIndex-1 to: stopIndex.
-			self replaceSelectionWith: oldSelection]
+			self replaceSelectionWith: newString ]
 		ifFalse: [
-			"not enclosed; enclose by matching brackets"
+			" Checks if the characters inside the selection need to be escaped or not. "
+			newString := (self shouldNestCar: left)
+						 ifTrue: [ self nesting: oldSelection with: left ] 
+						 ifFalse: [ "not enclosed; enclose by matching brackets"
+									  (String with: left), oldSelection string, (String with: right) ].
 			self replaceSelectionWith:
-				(Text string: (String with: left), oldSelection string, (String with: right) attributes: self emphasisHere).
-			self selectFrom: startIndex+1 to: stopIndex].
+				(Text string: newString attributes: self emphasisHere).
+			"we add the difference of the newString and the oldSelection, here, to ajust to eventual nesting. The 2 corrsponds to se left and right characters added which are not in oldSelection."
+			self selectFrom: startIndex+1 to: stopIndex+(newString size - oldSelection size - 2)].
 	^true
 ]
 
@@ -1286,6 +1294,15 @@ RubTextEditor >> getHighlightInterval [
 	^ self hasSelection 
 		ifTrue: [ self selectionInterval ]
 		ifFalse: [ self computeSelectionIntervalForCurrentLine ]
+]
+
+{ #category : #nesting }
+RubTextEditor >> getNestingCharacterFromAst: anAST [
+	"If there is no node (empty textArea) there is no nesting to be had."
+	anAST ifNil: [ ^nil ].
+	anAST isCommentNode ifTrue: [ ^$" ].
+	(anAST isLiteralNode and: [anAST value isString]) ifTrue: [ ^$' ].
+	^nil.
 ]
 
 { #category : #'accessing-selection' }
@@ -1629,6 +1646,34 @@ RubTextEditor >> moveCursor: directionBlock forward: forward specialBlock: speci
 		ifTrue: [self selectMark: (indices at: #fixed) point: newPosition - 1]
 		ifFalse: [self selectAt: newPosition].
 	self setEmphasisHereFromTextForward: forward
+]
+
+{ #category : #nesting }
+RubTextEditor >> nesting: aString with: aCharacter [ 
+	" To escape them, we double the character every time it's encountered"
+	| result stream |
+	result := WriteStream with: ''.
+	stream := ReadStream on: aString string.
+	result nextPut: aCharacter.
+	[ stream atEnd ] whileFalse: 
+		[ result nextPutAll: (stream upTo: aCharacter).
+		stream peekBack = aCharacter ifTrue: [result nextPut: aCharacter]. 
+		result nextPut: aCharacter.].
+	stream peekBack = aCharacter ifTrue: [result nextPut: aCharacter].
+	^result contents.
+]
+
+{ #category : #nesting }
+RubTextEditor >> nestingForPaste: aString with: aCharacter [ 
+	" To escape them, we double the character every time it's encountered"
+	| result stream |
+	result := WriteStream with: ''.
+	stream := ReadStream on: aString string.
+	[ stream atEnd ] whileFalse: 
+		[ result nextPutAll: (stream upTo: aCharacter).
+		stream peekBack = aCharacter ifTrue: [result nextPut: aCharacter]. 
+		stream atEnd ifFalse: [ result nextPut: aCharacter ].].
+	^result contents.
 ]
 
 { #category : #keymapping }
@@ -2343,6 +2388,11 @@ RubTextEditor >> shiftEnclose: aKeyboardEvent [
 	^true
 ]
 
+{ #category : #nesting }
+RubTextEditor >> shouldNestCar: aChar [
+	^'"''' includes: aChar.
+]
+
 { #category : #keymapping }
 RubTextEditor >> specialShiftCmdKeys [
 
@@ -2397,6 +2447,13 @@ RubTextEditor >> storeSelectionInText [
 RubTextEditor >> string [
 
 	^self text string
+]
+
+{ #category : #nesting }
+RubTextEditor >> stringNestedWith: aCharac [
+	^(self shouldNestCar: aCharac) 
+		ifTrue: [ self nestingForPaste: self clipboardText with: aCharac. ]
+		ifFalse: [ self clipboardText ] 
 ]
 
 { #category : #'editing keys' }
@@ -2483,6 +2540,18 @@ RubTextEditor >> tripleClick: evt [
 	self selectLine.
 	self setEmphasisHereFromText.
 	self storeSelectionInText.
+]
+
+{ #category : #nesting }
+RubTextEditor >> unNesting: aString with: aCharacter [ 
+	" To escape them, we double the character every time it's encountered"
+	| result stream |
+	result := WriteStream with: ''.
+	stream := ReadStream on: aString.
+	[ stream atEnd ] whileFalse: 
+			[ result nextPutAll: (stream upTo: aCharacter).
+			  stream peek ifNotNil: [result nextPut: stream next]].
+	^result contents.
 ]
 
 { #category : #'menu messages' }

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -1672,7 +1672,8 @@ RubTextEditor >> nestingForPaste: aString with: aCharacter [
 	[ stream atEnd ] whileFalse: 
 		[ result nextPutAll: (stream upTo: aCharacter).
 		stream peekBack = aCharacter ifTrue: [result nextPut: aCharacter]. 
-		stream atEnd ifFalse: [ result nextPut: aCharacter ].].
+		stream atEnd ifFalse: [ result nextPut: aCharacter ]
+						 ifTrue: [ stream peekBack = aCharacter ifTrue: [result nextPut: aCharacter] ].].
 	^result contents.
 ]
 


### PR DESCRIPTION
Adding the nesting of the comments and strings with smart charachters and copySelection.
Adding the unnesting of the comments and strings with smart characters and copySelection.
Paste and copySelection are dependent of RBProgramNode's 'bestNodeFor:' which does not yet include comment nodes.

bestNodeFor: will be taken care of in an other PR
The absence of modification only renders the changes useless for comments
but does not break the previous implementation of paste and copySelection.

Inside paste, there is commented code which hints at a potential nesting inside symbols.