### PR TITLE
Safer completion class access

### DIFF
--- a/src/HeuristicCompletion-Model/CoClassBasedFetcher.class.st
+++ b/src/HeuristicCompletion-Model/CoClassBasedFetcher.class.st
@@ -54,7 +54,7 @@ CoClassBasedFetcher >> forHierarchy [
 { #category : #'hierarchy-fetching' }
 CoClassBasedFetcher >> onSuperclass [
 	
-	completionClass superclass
+	(completionClass ifNotNil: [completionClass superclass])
 		ifNil: [ ^ CoEmptyFetcher new ].
 
 	^ self copy

--- a/src/HeuristicCompletion-Model/CoClassVariableFetcher.class.st
+++ b/src/HeuristicCompletion-Model/CoClassVariableFetcher.class.st
@@ -10,6 +10,6 @@ Class {
 { #category : #enumerating }
 CoClassVariableFetcher >> entriesDo: aBlock [
 	
-	self completionClass instanceSide classVarNames do: [ :e |
-		aBlock value: (NECClassVarEntry contents: e node: astNode)]
+	self completionClass ifNotNil: [:cc | cc instanceSide classVarNames do: [ :e |
+		aBlock value: (NECClassVarEntry contents: e node: astNode)]]
 ]

--- a/src/HeuristicCompletion-Model/CoInstanceVariableFetcher.class.st
+++ b/src/HeuristicCompletion-Model/CoInstanceVariableFetcher.class.st
@@ -10,6 +10,6 @@ Class {
 { #category : #enumerating }
 CoInstanceVariableFetcher >> entriesDo: aBlock [
 	
-	self completionClass instVarNames do: [ :e |
-		aBlock value: (NECInstVarEntry contents: e node: astNode)]
+	self completionClass ifNotNil:[ :cc | cc instVarNames do: [ :e |
+		aBlock value: (NECInstVarEntry contents: e node: astNode)]]
 ]

--- a/src/HeuristicCompletion-Model/CoSuperMessageHeuristic.class.st
+++ b/src/HeuristicCompletion-Model/CoSuperMessageHeuristic.class.st
@@ -18,8 +18,7 @@ CoSuperMessageHeuristic >> appliesForNode: aNode inContext: aContext [
 			or: [ aNode isMethod
 				and: [ 
 					"This heuristic is not valid for traits and nil subclasses"
-					aContext completionClass notNil 
-					and: [ aContext completionClass superclass notNil ] ] ]
+					(aContext completionClass ifNotNil: [ :cc | cc superclass]) notNil ] ]
 ]
 
 { #category : #requests }


### PR DESCRIPTION
Editing of package comments can cause DNUs. Use safer access to the completion class.
(Problem reported and patch provided by the Richard Uttner)