### PR TITLE
Fix typo in name of a test of OCPragmaTest class

### DIFF
--- a/src/OpalCompiler-Tests/OCPragmaTest.class.st
+++ b/src/OpalCompiler-Tests/OCPragmaTest.class.st
@@ -80,7 +80,7 @@ OCPragmaTest >> testDoublePragma [
 ]
 
 { #category : #testing }
-OCPragmaTest >> testIsPrimitve [
+OCPragmaTest >> testIsPrimitive [
 	| aRBMethode |
 
 	aRBMethode := OpalCompiler new parse: self methodPrimitive.


### PR DESCRIPTION
Fix typo in name of a test of OCPragmaTest class