### PR TITLE
7060-CoTypeInferencer-DNU-when-editing-code-after-removing-instance-variables

### DIFF
--- a/src/HeuristicCompletion-Model/CoTypeInferencer.class.st
+++ b/src/HeuristicCompletion-Model/CoTypeInferencer.class.st
@@ -365,3 +365,9 @@ CoTypeInferencer >> visitThisContextNode: aRBThisContextNode [
 	
 	^ { Context }
 ]
+
+{ #category : #visiting }
+CoTypeInferencer >> visitVariableNode: aRBVariableNode [ 
+
+	^ self ensureTypeOfVariable: aRBVariableNode name
+]

--- a/src/HeuristicCompletion-Tests/CoInitializeTypeInferenceTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoInitializeTypeInferenceTest.class.st
@@ -39,6 +39,23 @@ CoInitializeTypeInferenceTest >> testInferInstanceVariableUsedInInitialize [
 ]
 
 { #category : #tests }
+CoInitializeTypeInferenceTest >> testInferUndefinedInstanceVariableUsedInInitialize [
+
+	| types |
+	types := CoTypeInferencer new
+		inferFrom: (CoMockClass new
+			methodAt: #initialize put: (CoMockMethod new
+				source: 'initialize
+					a'
+				yourself);
+			instanceVariables: #();
+			yourself);
+		variables.
+		
+	self assertCollection: (types at: #a) hasSameElements: Set new
+]
+
+{ #category : #tests }
 CoInitializeTypeInferenceTest >> testInferVariablesWithNoInitializeFindsNoTypes [
 
 	| types |


### PR DESCRIPTION
Fixes: #7060. Apparently trying to type an undefined variables was calling visitVariables and DNU. I provide a simple fix and a test. All the tests are green too.