### PR TITLE
7077-Regression-Rewriter-produce-invalid-AST

### DIFF
--- a/src/AST-Core/RBPatternBlockNode.class.st
+++ b/src/AST-Core/RBPatternBlockNode.class.st
@@ -34,14 +34,11 @@ RBPatternBlockNode >> addArgumentWithNameBasedOn: aString to: aRBBlockNode [
 ]
 
 { #category : #matching }
-RBPatternBlockNode >> constructLookupNodeFor: aString in: aRBBlockNode [ 
-	| argumentNode |
-	argumentNode := RBLiteralNode value: aString.
-	
-	^RBMessageNode 
-		receiver: (RBVariableNode named: 'self')
-		selector: #lookupMatchFor:in:
-		arguments: (Array with: argumentNode with: aRBBlockNode arguments last copy)
+RBPatternBlockNode >> constructLookupNodeFor: aString in: aRBBlockNode [
+	^ RBMessageNode
+		  receiver: RBVariableNode selfNode
+		  selector: #lookupMatchFor:in:
+		  arguments: (Array with: (RBLiteralNode value: aString) with: aRBBlockNode arguments last copy)
 ]
 
 { #category : #matching }

--- a/src/AST-Core/RBSelfNode.class.st
+++ b/src/AST-Core/RBSelfNode.class.st
@@ -19,6 +19,12 @@ RBSelfNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitSelfNode: self
 ]
 
+{ #category : #initialization }
+RBSelfNode >> initialize [
+  super initialize.
+  variable := SelfVariable instance
+]
+
 { #category : #testing }
 RBSelfNode >> isSelf [
 	^ true

--- a/src/AST-Core/RBSuperNode.class.st
+++ b/src/AST-Core/RBSuperNode.class.st
@@ -19,6 +19,12 @@ RBSuperNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitSuperNode: self
 ]
 
+{ #category : #initialization }
+RBSuperNode >> initialize [
+  super initialize.
+  variable := SuperVariable instance
+]
+
 { #category : #testing }
 RBSuperNode >> isSelfOrSuper [
 

--- a/src/AST-Core/RBThisContextNode.class.st
+++ b/src/AST-Core/RBThisContextNode.class.st
@@ -18,3 +18,9 @@ RBThisContextNode class >> new [
 RBThisContextNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitThisContextNode: self
 ]
+
+{ #category : #initialization }
+RBThisContextNode >> initialize [
+  super initialize.
+  variable := ThisContextVariable instance
+]

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -35,7 +35,7 @@ RBVariableNode class >> identifierNamed: anIdentifierName at: aPosition [
 
 { #category : #'instance creation' }
 RBVariableNode class >> named: aName [
-	^self named: aName start: 0.
+	^ self named: aName start: 0
 ]
 
 { #category : #'instance creation' }
@@ -47,17 +47,17 @@ RBVariableNode class >> named: aName start: aPosition [
 
 { #category : #'instance creation' }
 RBVariableNode class >> selfNode [
-	^ (self named: 'self') variable: SelfVariable instance
+	^ RBSelfNode new
 ]
 
 { #category : #'instance creation' }
 RBVariableNode class >> superNode [
-	^ (self named: 'super') variable: SuperVariable instance
+	^ RBSuperNode new
 ]
 
 { #category : #'instance creation' }
 RBVariableNode class >> thisContextNode [
-	^ (self named: 'thisContext') variable: ThisContextVariable instance
+	^ RBThisContextNode new
 ]
 
 { #category : #comparing }

--- a/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
@@ -137,25 +137,21 @@ RBInlineMethodRefactoring >> inlineSelector [
 ]
 
 { #category : #transforming }
-RBInlineMethodRefactoring >> inlineSourceReplacing: aParseTree [ 
+RBInlineMethodRefactoring >> inlineSourceReplacing: aParseTree [
 	| statements nodeUnderSequence |
 	statements := inlineParseTree body statements.
-	(statements size > 1 and: [aParseTree isEvaluatedFirst not]) 
-		ifTrue: 
-			[self 
-				refactoringWarning: 'To inline this method, we need to move some of its statements before the original message send.<n>This could change the order of execution, which can change the behavior.<n>Do you want to proceed?' 
-						expandMacros].
+	(statements size > 1 and: [ aParseTree isEvaluatedFirst not ]) ifTrue: [ 
+		self refactoringWarning:
+			'To inline this method, we need to move some of its statements before the original message send.<n>This could change the order of execution, which can change the behavior.<n>Do you want to proceed?'
+				expandMacros ].
 	nodeUnderSequence := aParseTree.
-	[nodeUnderSequence parent isSequence] 
-		whileFalse: [nodeUnderSequence := nodeUnderSequence parent].
-	(nodeUnderSequence parent)
-		addNodes: (statements copyFrom: 1 to: (statements size - 1 max: 0))
-			before: nodeUnderSequence;
+	[ nodeUnderSequence parent isSequence ] whileFalse: [ nodeUnderSequence := nodeUnderSequence parent ].
+	nodeUnderSequence parent
+		addNodes: (statements copyFrom: 1 to: (statements size - 1 max: 0)) before: nodeUnderSequence;
 		addTemporariesNamed: inlineParseTree body temporaryNames.
-	aParseTree parent replaceNode: aParseTree
-		withNode: (statements isEmpty 
-				ifTrue: [RBVariableNode named: 'self']
-				ifFalse: [statements last])
+	aParseTree parent replaceNode: aParseTree withNode: (statements isEmpty
+			 ifTrue: [ RBVariableNode selfNode ]
+			 ifFalse: [ statements last ])
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBMoveMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodRefactoring.class.st
@@ -131,18 +131,16 @@ RBMoveMethodRefactoring >> checkTemporaryVariableNames [
 { #category : #transforming }
 RBMoveMethodRefactoring >> compileDelegatorMethod [
 	| statementNode delegatorNode tree |
-	delegatorNode := RBMessageNode 
-				receiver: (RBVariableNode named: variable)
-				selector: parseTree selector
-				keywordsPositions: parseTree keywordsPositions
-				arguments: (parseTree argumentNames collect: 
-							[:each | 
-							RBVariableNode 
-								named: (each = selfVariableName ifTrue: ['self'] ifFalse: [each])]).
-	self hasOnlySelfReturns 
-		ifFalse: [delegatorNode := RBReturnNode value: delegatorNode].
-	statementNode := RBSequenceNode temporaries: #()
-				statements: (Array with: delegatorNode).
+	delegatorNode := RBMessageNode
+		                 receiver: (RBVariableNode named: variable)
+		                 selector: parseTree selector
+		                 keywordsPositions: parseTree keywordsPositions
+		                 arguments: (parseTree argumentNames collect: [ :each | 
+				                  each = selfVariableName
+					                  ifTrue: [ RBVariableNode selfNode ]
+					                  ifFalse: [ RBVariableNode named: each ] ]).
+	self hasOnlySelfReturns ifFalse: [ delegatorNode := RBReturnNode value: delegatorNode ].
+	statementNode := RBSequenceNode temporaries: #(  ) statements: (Array with: delegatorNode).
 	(tree := class parseTreeFor: selector) body: statementNode.
 	class compileTree: tree
 ]

--- a/src/Refactoring-Core/RBRealizeClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBRealizeClassRefactoring.class.st
@@ -34,17 +34,15 @@ RBRealizeClassRefactoring >> transform [
 { #category : #transforming }
 RBRealizeClassRefactoring >> transform: aClass [
 	| class method parseTree |
-	aClass allSelectors do: [ :selector |
+	aClass allSelectors do: [ :selector | 
 		class := aClass whoDefinesMethod: selector.
-		(class notNil and: [ class ~= aClass ]) ifTrue: [
+		(class notNil and: [ class ~= aClass ]) ifTrue: [ 
 			method := class methodFor: selector.
-			(method notNil and: [ method refersToSymbol: #subclassResponsibility ]) ifTrue: [
+			(method notNil and: [ method refersToSymbol: #subclassResponsibility ]) ifTrue: [ 
 				parseTree := method parseTree.
-				parseTree body 
-					temporaries: OrderedCollection new; 
+				parseTree body
+					temporaries: OrderedCollection new;
 					statements: OrderedCollection new;
-					addNode: (RBMessageNode 
-						receiver: (RBVariableNode named: 'self')
-						selector: #shouldBeImplemented).
+					addNode: (RBMessageNode receiver: RBVariableNode selfNode selector: #shouldBeImplemented).
 				aClass compile: parseTree newSource withAttributesFrom: method ] ] ]
 ]


### PR DESCRIPTION
Make sure Self/Super/ThisContext node have the right variable. 

In the new version of the AST, VariableNodes needs a reified variable. In case of Self/Super/ThisContext it exists a singleton for it. 
Instead of setting it by hand, those nodes are now initialized with their variables. This fix bugs where AST could have variable nodes without any variable attribute.

Fixes #7077