### PR TITLE
Issue 7092: Better HaloMorph Handles

### DIFF
--- a/src/Morphic-Base/HaloMorph.class.st
+++ b/src/Morphic-Base/HaloMorph.class.st
@@ -700,10 +700,12 @@ HaloMorph >> createHandleAt: aPoint color: aColor iconName: iconName [
 		ifTrue: [ handle := Morph newBounds: bou color: aColor.
 			handle borderWidth: 1.
 			handle useRoundedCorners.
+			handle borderColor: aColor muchDarker.
 			self setColor: aColor toHandle: handle
 			]
-		ifFalse: [ handle := EllipseMorph newBounds: bou color: aColor ].
-	handle borderColor: aColor muchDarker.
+		ifFalse: [ 
+			handle := EllipseMorph newBounds: bou color: aColor.
+			handle borderWidth: 0 ].
 	handle wantsYellowButtonMenu: false.
 	iconName
 		ifNotNil: [ ( self iconNamed: iconName )
@@ -926,7 +928,7 @@ HaloMorph >> endInteraction [
 
 { #category : #settings }
 HaloMorph >> gradientHalo [
-	^ true
+	^ false
 ]
 
 { #category : #accessing }
@@ -956,7 +958,7 @@ HaloMorph >> handleListenEvent: anEvent [
 
 { #category : #private }
 HaloMorph >> handleSize [
-	^ 20
+	^ 30
 ]
 
 { #category : #'meta-actions' }


### PR DESCRIPTION
Updating HaloMorph handles (the buttons around the halo) to look cleaner.
  
This entails:
- A slightly larger size for the handles (30px, was 20px);
- Completely circular handles (was rounded corners);
- Solid color background (was gradient, which was causing issues);
- No border (looks more cartoonish with the border)  The halos will now look like this:  ![HaloMorphNew](https://user-images.githubusercontent.com/1640299/90197667-47a7ba80-dd9d-11ea-8f6b-2da36ee5df94.png)