### PR TITLE
Fix equals method: check against anObject

### DIFF
--- a/src/Calypso-SystemQueries/ClyMergedHierarchy.class.st
+++ b/src/Calypso-SystemQueries/ClyMergedHierarchy.class.st
@@ -47,7 +47,7 @@ ClyMergedHierarchy >> = anObject [
 
 	self == anObject ifTrue: [ ^ true ].
 	super = anObject ifFalse: [ ^ false ].
-	^ mergedParts = mergedParts 
+	^ mergedParts = anObject mergedParts 
 ]
 
 { #category : #building }


### PR DESCRIPTION
The #= method did inadvertently check the instance variable #mergedParts against itself instead of anObject's value for that instance variable.