### PR TITLE
7096-size--0-instead-of-isEmpty-tip-triggered-wrongly

### DIFF
--- a/src/GeneralRules/ReConsistencyCheckRule.class.st
+++ b/src/GeneralRules/ReConsistencyCheckRule.class.st
@@ -26,8 +26,7 @@ ReConsistencyCheckRule >> initialize [
 		'`@object size == 0'
 		'`@object size = 0'
 		'`@object size > 0'
-		'`@object size >= 1'
-		'`@collection at: `@collection size' )
+		'`@object size >= 1')
 		
 ]
 


### PR DESCRIPTION
remove a pattern from the rule that does not make sense according to the description of the rule. (It makes sense, but we need to add this as it's own rule wit the correct explanation). fixes #7096