### PR TITLE
7089-Performances-Building-of-WorldMenu-executes-two-times-the-builder

### DIFF
--- a/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
+++ b/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
@@ -76,7 +76,7 @@ MenubarMorph class >> open [
 	self showMenubar ifFalse: [ ^ self ].
 
 	self new
-		menuBarItems: WorldState new menuBuilder menuSpec items;
+		menuBarItems: self currentWorld worldState menuBuilder menuSpec items;
 		open.
 ]
 


### PR DESCRIPTION
Do not instantiate a new WorldState, fixes #7089