### PR TITLE
deprecate-Context-lookupSymbol

### DIFF
--- a/src/Calypso-SystemPlugins-Reflectivity-Browser-Tests/ClyAddConditionalBreakpointCommandTest.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser-Tests/ClyAddConditionalBreakpointCommandTest.class.st
@@ -18,7 +18,7 @@ ClyAddConditionalBreakpointCommandTest >> testMessageSend_conditionBlockProducer
 		equals:
 			(self parserClass
 				parseMethod:
-					'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: ((ThisContext lookupSymbol: #val) msg: (ThisContext lookupSymbol: #arg))]')
+					'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: ((ThisContext readVariableNamed: #val) msg: (ThisContext readVariableNamed: #arg))]')
 ]
 
 { #category : #tests }
@@ -66,7 +66,7 @@ ClyAddConditionalBreakpointCommandTest >> testSuperSendWithArgs_conditionBlockPr
 		equals:
 			(self parserClass
 				parseMethod:
-					'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: (ThisContext receiver perform: #foo:bar: withArguments: {ThisContext lookupSymbol: #arg1. ThisContext lookupSymbol: #arg2.} inSuperclass: ThisContext receiver class superclass)]')
+					'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: (ThisContext receiver perform: #foo:bar: withArguments: {ThisContext readVariableNamed: #arg1. ThisContext readVariableNamed: #arg2.} inSuperclass: ThisContext receiver class superclass)]')
 ]
 
 { #category : #tests }
@@ -78,7 +78,7 @@ ClyAddConditionalBreakpointCommandTest >> testVariableLookup_conditionBlockProdu
 		equals:
 			(self parserClass
 				parseMethod:
-					'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: (ThisContext lookupSymbol: #var)]')
+					'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: (ThisContext readVariableNamed: #var)]')
 ]
 
 { #category : #tests }
@@ -90,7 +90,7 @@ ClyAddConditionalBreakpointCommandTest >> testVariableNamedThisContext_condition
 		equals:
 			(self parserClass
 				parseMethod:
-					'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: (ThisContext lookupSymbol: #ThisContext)]')
+					'conditionBlockGenerator ^[ :ThisContext | Breakpoint checkBreakConditionValue: (ThisContext readVariableNamed: #ThisContext)]')
 ]
 
 { #category : #tests }

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddConditionalBreakpointCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddConditionalBreakpointCommand.class.st
@@ -108,11 +108,11 @@ ClyAddConditionalBreakpointCommand >> rewriteASTToSimulateExecutionInADifferentC
 	The goal is to rewrite this AST so that evaluating the block by passing it a context as argument will evaluate its body as it would have been evaluated in the passed context.
 	To do this, we rewrite anAST following these three rules:
 	1) Rewriting references to variables named 'ThisContext' into context lookups to avoid conflicts with the 'ThisContext' argument of the block.
-	For example, a reference to a variable named ThisContext is rewritten into `ThisContext lookupSymbol: #ThisContext`
+	For example, a reference to a variable named ThisContext is rewritten into `ThisContext readVariableNamed: #ThisContext`
 	2) Replacing all message nodes whose receiver is super with alternative ast replicating the method lookup a message send to super has.
 		For example, 'super foo: 1' is rewritten into 'ThisContext receiver perform: #foo withArguments: 1 inSuperclass: ThisContext receiver class superclass'
 	3) Rewriting references to undeclared variables into context lookup
-		For example, a reference to a variable named flower is rewritten into `ThisContext lookupSymbol: #flower`
+		For example, a reference to a variable named flower is rewritten into `ThisContext readVariableNamed: #flower`
 	4) Rewriting references to `thisContext` into references to `ThisContext`
 	5) Rewriting references to `self` into references to `ThisContext receiver`"
 	rewriter := RBParseTreeRewriter new.
@@ -120,7 +120,7 @@ ClyAddConditionalBreakpointCommand >> rewriteASTToSimulateExecutionInADifferentC
 	rewriter
 		replace: (RBVariableNode named: #ThisContext) name
 		with:
-			'(ThisContext lookupSymbol: #'
+			'(ThisContext readVariableNamed: #'
 				, (RBVariableNode named: #ThisContext) name , ')'.
 	allMessageNodes := semanticallyAnalysedMethodAST allChildren
 		select: [ :astElem | astElem isMessage ].
@@ -152,7 +152,7 @@ ClyAddConditionalBreakpointCommand >> rewriteASTToSimulateExecutionInADifferentC
 		withIndexDo: [ :tempName :index | 
 			rewriter2
 				replace: tempName
-				with: '(ThisContext lookupSymbol: #' , tempName , ')' ].
+				with: '(ThisContext readVariableNamed: #' , tempName , ')' ].
 	rewriter2 replace: 'thisContext' with: 'ThisContext'.
 	rewriter2 replace: 'self' with: 'ThisContext receiver'.
 	rewrittenConditionBlockProducerAST := rewriter2

--- a/src/Debugger-Model-Tests/DebugSessionContextsTest.class.st
+++ b/src/Debugger-Model-Tests/DebugSessionContextsTest.class.st
@@ -22,11 +22,11 @@ DebugSessionContextsTest >> setUp [
 { #category : #tests }
 DebugSessionContextsTest >> testInitialContentOfInterruptedContext [
 	"Checks that the interruptedContext of the DebugSession is the thisContext of the code where the DebugSession was created"
-	self assert: ((process suspendedContext lookupSymbol: #debugSession) interruptedContext ) identicalTo: debuggedThisContext.
+	self assert: ((process suspendedContext readVariableNamed: #debugSession) interruptedContext ) identicalTo: debuggedThisContext.
 ]
 
 { #category : #tests }
 DebugSessionContextsTest >> testInitialContentOfSuspendedContext [
 	"Checks that the interruptedContext of the DebugSession is the thisContext of the code where the DebugSession was created"
-	self assert: ((process suspendedContext lookupSymbol: #debugSession) interruptedProcess suspendedContext) identicalTo: debuggedThisContext.
+	self assert: ((process suspendedContext readVariableNamed: #debugSession) interruptedProcess suspendedContext) identicalTo: debuggedThisContext.
 ]

--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -20,13 +20,6 @@ Context >> callPrimitive: primNumber [
 ]
 
 { #category : #'*Debugging-Core' }
-Context >> lookupSymbol: aSymbol [
-	| var |
-	var := self lookupVar: aSymbol.
-	^ var readInContext: self
-]
-
-{ #category : #'*Debugging-Core' }
 Context >> lookupTempVar: aSymbol [
 	| var |
 	var := self lookupVar: aSymbol.
@@ -112,6 +105,11 @@ Context >> quickStep [
 
 	self willSend ifTrue: [ QuickStep := self ].
 	^self step
+]
+
+{ #category : #'*Debugging-Core' }
+Context >> readVariableNamed: aName [
+	^ (self lookupVar: aName) readInContext: self
 ]
 
 { #category : #'*Debugging-Core' }
@@ -376,9 +374,7 @@ Context >> tempNamed: aName [
 Context >> tempNamed: aName put: anObject [
 	"Assign the value of the temp with name in aContext"
 	
-	| var |
-	var := self lookupTempVar: aName.
-	var write: anObject inContext: self.
+	(self lookupTempVar: aName) write: anObject inContext: self.
 	^ anObject
 ]
 

--- a/src/Deprecated90/Context.extension.st
+++ b/src/Deprecated90/Context.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #Context }
+
+{ #category : #'*Deprecated90' }
+Context >> lookupSymbol: aSymbol [
+	self 
+		deprecated: 'use #readVariableNamed:' 
+		transformWith: '`@receiver lookupSymbol: `@arg' -> '`@receiver readVariableNamed: `@arg'.
+	^ self readVariableNamed: aSymbol
+]

--- a/src/Kernel-Tests-Extended/ContextTest.extension.st
+++ b/src/Kernel-Tests-Extended/ContextTest.extension.st
@@ -29,15 +29,15 @@ ContextTest >> testJump [
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
-ContextTest >> testLookupSymbol [
+ContextTest >> testReadVariableNamed [
 	|localVar|
 	localVar := 2.
 	instVarForTestLookupSymbol := 3.
 	classVarForTestLookupSymbol := 4.
-	self assert: (thisContext lookupSymbol: #localVar) equals: 2.
-	self assert: (thisContext lookupSymbol: #instVarForTestLookupSymbol) equals: 3.
-	self assert: (thisContext lookupSymbol: #classVarForTestLookupSymbol) equals: 4.
-	self assert: (thisContext lookupSymbol: #Smalltalk) equals: Smalltalk.
+	self assert: (thisContext readVariableNamed: #localVar) equals: 2.
+	self assert: (thisContext readVariableNamed: #instVarForTestLookupSymbol) equals: 3.
+	self assert: (thisContext readVariableNamed: #classVarForTestLookupSymbol) equals: 4.
+	self assert: (thisContext readVariableNamed: #Smalltalk) equals: Smalltalk.
 ]
 
 { #category : #'*Kernel-Tests-Extended' }


### PR DESCRIPTION
Context>>#lookupSymbol: is not well named... the name implies that it would do somehting similar as lookupVar:, but it actually reads the variable content.
- add #readVariableNamed: 
- fix the users (just in testss) of #lookupSymbol: to use #readVariableNamed:
- simplify #tempNamed: put: