### PR TITLE
Modification of bestNodeFor: to include comments

### DIFF
--- a/src/AST-Core-Tests/RBProgramNodeTest.class.st
+++ b/src/AST-Core-Tests/RBProgramNodeTest.class.st
@@ -16,6 +16,37 @@ RBProgramNodeTest class >> packageNamesUnderTest [
 ]
 
 { #category : #accessing }
+RBProgramNodeTest >> getAllNodesFromAST [
+	| methodText |
+	methodText :=
+	'toto
+		"First comment"
+		| temp varaibles |
+		"Second comment"
+		assignement := " Third comment " #node. 
+		"Fourth comment"
+		message "Fifth comment", ''node''.
+		"Sixth comment" cascade node; nodeux "Seventh comment"; notrois.
+		^ "return" nil
+		'.
+	^ RBParser parseMethod: methodText.
+]
+
+{ #category : #accessing }
+RBProgramNodeTest >> getMethodString [
+	^'toto
+		"First comment"
+		| temp varaibles |
+		"Second comment"
+		assignement := " Third comment " #node. 
+		"Fourth comment"
+		message "Fifth comment", ''node''.
+		"Sixth comment" cascade node; nodeux "Seventh comment"; notrois.
+		^ "return" nil
+		'.
+]
+
+{ #category : #accessing }
 RBProgramNodeTest >> node [
 	^ node ifNil: [ node := RBProgramNode new ]
 ]
@@ -290,6 +321,124 @@ RBProgramNodeTest >> testAllStatementsTwoMessages [
 				1 send1 send2'.
 	stats := tree allStatements.
 	self assert: stats size equals: 1.
+]
+
+{ #category : #'tests-bestNodeFor' }
+RBProgramNodeTest >> testBestNodeFirstTempsAndFirstCommentGivesVariableNode [
+	| ast string start |
+	string := '"First comment"'.
+	start := self getMethodString findString: string.
+	ast := (RBParser parseMethod: self getMethodString) bestNodeFor: (start to: start + string size + 6).
+	self assert: ast isVariable.
+]
+
+{ #category : #'tests-bestNodeFor' }
+RBProgramNodeTest >> testBestNodeForCommentInbetweenStatements [
+	| ast string start |
+	string := '"Fourth comment"'.
+	start := self getMethodString findString: string.
+	ast := (RBParser parseMethod: self getMethodString) bestNodeFor: (start to: start + string size - 1).
+	self assert: ast isCommentNode.
+	self assert: ast contents equals: 'Fourth comment'.
+]
+
+{ #category : #'tests-bestNodeFor' }
+RBProgramNodeTest >> testBestNodeForCommentInsideACascadeNodeOnMessageNode [
+	| ast string start |
+	string := '"Seventh comment"'.
+	start := self getMethodString findString: string.
+	ast := (RBParser parseMethod: self getMethodString) bestNodeFor: (start to: start + string size - 1).
+	self assert: ast isCommentNode.
+	self assert: ast contents equals: 'Seventh comment'.
+]
+
+{ #category : #'tests-bestNodeFor' }
+RBProgramNodeTest >> testBestNodeForCommentInsideACascadeNodeOnReceiver [
+	| ast string start |
+	string := '"Sixth comment"'.
+	start := self getMethodString findString: string.
+	ast := (RBParser parseMethod: self getMethodString) bestNodeFor: (start to: start + string size - 1).
+	self assert: ast isCommentNode.
+	self assert: ast contents equals: 'Sixth comment'.
+]
+
+{ #category : #'tests-bestNodeFor' }
+RBProgramNodeTest >> testBestNodeForCommentInsideAssignementNode [
+	| ast string start |
+	string := '" Third comment "'.
+	start := self getMethodString findString: string.
+	ast := (RBParser parseMethod: self getMethodString) bestNodeFor: (start to: start + string size - 1).
+	self assert: ast isCommentNode.
+	self assert: ast contents equals: ' Third comment '.
+]
+
+{ #category : #'tests-bestNodeFor' }
+RBProgramNodeTest >> testBestNodeForCommentInsideMessageNode [
+	| ast string start |
+	string := '"Fifth comment"'.
+	start := self getMethodString findString: string.
+	ast := (RBParser parseMethod: self getMethodString) bestNodeFor: (start to: start + string size - 1).
+	self assert: ast isCommentNode.
+	self assert: ast contents equals: 'Fifth comment'.
+]
+
+{ #category : #'tests-bestNodeFor' }
+RBProgramNodeTest >> testBestNodeForCommentInsideMethodNode [
+	| ast string start |
+	string := '"First comment"'.
+	start := self getMethodString findString: string.
+	ast := (RBParser parseMethod: self getMethodString) bestNodeFor: (start to: start + string size - 1).
+	self assert: ast isCommentNode.
+	self assert: ast contents equals: 'First comment'.
+]
+
+{ #category : #'tests-bestNodeFor' }
+RBProgramNodeTest >> testBestNodeForCommentInsideReturnNode [
+	| ast string start |
+	string := '"return"'.
+	start := self getMethodString findString: string.
+	ast := (RBParser parseMethod: self getMethodString) bestNodeFor: (start to: start + string size - 1).
+	self assert: ast isCommentNode.
+	self assert: ast contents equals: 'return'.
+]
+
+{ #category : #'tests-bestNodeFor' }
+RBProgramNodeTest >> testBestNodeForCommentInsideSequenceNode [
+	| ast string start |
+	string := '"Second comment"'.
+	start := self getMethodString findString: string.
+	ast := (RBParser parseMethod: self getMethodString) bestNodeFor: (start to: start + string size - 1).
+	self assert: ast isCommentNode.
+	self assert: ast contents equals: 'Second comment'.
+]
+
+{ #category : #'tests-bestNodeFor' }
+RBProgramNodeTest >> testBestNodeInsideAssignementGivesSelectedValue [
+	| ast string start |
+	string := '#node'.
+	start := self getMethodString findString: string.
+	ast := (RBParser parseMethod: self getMethodString) bestNodeFor: (start to: start + string size - 1).
+	self assert: ast isLiteralNode.
+	self assert: ast value equals: #node.
+]
+
+{ #category : #'tests-bestNodeFor' }
+RBProgramNodeTest >> testBestNodeInsideAssignementGivesSelectedVariable [
+	| ast string start |
+	string := 'assignement'.
+	start := self getMethodString findString: string.
+	ast := (RBParser parseMethod: self getMethodString) bestNodeFor: (start to: start + string size - 1).
+	self assert: ast isVariable.
+	self assert: ast name equals: 'assignement'.
+]
+
+{ #category : #'tests-bestNodeFor' }
+RBProgramNodeTest >> testBestNodeWithMethodSelectorGivesCommentNode [
+	| ast string start |
+	string := '"First comment"'.
+	start := self getMethodString findString: string.
+	ast := (RBParser parseMethod: self getMethodString) bestNodeFor: (1 to: start + string size - 1).
+	self assert: ast isCommentNode.
 ]
 
 { #category : #'testing-properties' }

--- a/src/AST-Core/RBAssignmentNode.class.st
+++ b/src/AST-Core/RBAssignmentNode.class.st
@@ -73,21 +73,6 @@ RBAssignmentNode >> assigns: aVariableName [
 	^variable name = aVariableName or: [value assigns: aVariableName]
 ]
 
-{ #category : #querying }
-RBAssignmentNode >> bestNodeFor: anInterval [ 
-	(self intersectsInterval: anInterval) ifFalse: [^nil].
-	(self containedBy: anInterval) ifTrue: [^self].
-	assignment ifNil: [^super bestNodeFor: anInterval].
-	((anInterval first between: assignment and: assignment + 1) 
-		or: [assignment between: anInterval first and: anInterval last]) 
-			ifTrue: [^self].
-	self children do: 
-			[:each | 
-			| node |
-			node := each bestNodeFor: anInterval.
-			node notNil ifTrue: [^node]]
-]
-
 { #category : #accessing }
 RBAssignmentNode >> children [
 	^Array with: value with: variable

--- a/src/AST-Core/RBCascadeNode.class.st
+++ b/src/AST-Core/RBCascadeNode.class.st
@@ -44,7 +44,7 @@ RBCascadeNode >> acceptVisitor: aProgramNodeVisitor [
 { #category : #querying }
 RBCascadeNode >> bestNodeFor: anInterval [ 
 	| selectedChildren |
-	(self intersectsInterval: anInterval) ifFalse: [^nil].
+	anInterval ifNil: [ ^nil ].
 	(self containedBy: anInterval) ifTrue: [^self].
 	messages 
 		reverseDo: [:each | (each containedBy: anInterval) ifTrue: [^each]].

--- a/src/AST-Core/RBCascadeNode.class.st
+++ b/src/AST-Core/RBCascadeNode.class.st
@@ -44,7 +44,7 @@ RBCascadeNode >> acceptVisitor: aProgramNodeVisitor [
 { #category : #querying }
 RBCascadeNode >> bestNodeFor: anInterval [ 
 	| selectedChildren |
-	anInterval ifNil: [ ^nil ].
+	(self intersectsInterval: anInterval) ifFalse: [ ^nil ] .
 	(self containedBy: anInterval) ifTrue: [^self].
 	messages 
 		reverseDo: [:each | (each containedBy: anInterval) ifTrue: [^each]].

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -86,7 +86,7 @@ RBMessageNode >> arguments: argCollection [
 { #category : #querying }
 RBMessageNode >> bestNodeFor: anInterval [ 
 	| comments |
-	anInterval ifNil: [ ^nil ].
+	(self intersectsInterval: anInterval) ifFalse: [ ^nil ] .
 	(self containedBy: anInterval) ifTrue: [^self].
 	self keywordsIntervals do:
 			[:each | 

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -85,7 +85,8 @@ RBMessageNode >> arguments: argCollection [
 
 { #category : #querying }
 RBMessageNode >> bestNodeFor: anInterval [ 
-	(self intersectsInterval: anInterval) ifFalse: [^nil].
+	| comments |
+	anInterval ifNil: [ ^nil ].
 	(self containedBy: anInterval) ifTrue: [^self].
 	self keywordsIntervals do:
 			[:each | 
@@ -95,8 +96,10 @@ RBMessageNode >> bestNodeFor: anInterval [
 	self children do: 
 			[:each | 
 			| node |
-			node := each bestNodeFor: anInterval.
-			node notNil ifTrue: [^node]]
+			(each intersectsInterval: anInterval) ifTrue: [node := each bestNodeFor: anInterval.
+			node notNil ifTrue: [^node]]].
+	comments := self methodNode getCommentsFor: anInterval.
+	^comments size ~= 1 ifTrue: [ self ] ifFalse: [ comments first ]
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -180,7 +180,7 @@ RBProgramNode >> bestNodeFor: anInterval [
 	| selectedChildren selectedComments |
 	anInterval ifNil: [^nil ].
 	selectedComments := self getCommentsFor: anInterval.
-	(self intersectsInterval: anInterval) ifFalse: [^selectedComments ifNil: [ nil ] ifNotNil: [ selectedComments size = 1 ifTrue: [ selectedComments first ] ifFalse: [ self ] ] ].
+	(self intersectsInterval: anInterval) ifFalse: [^selectedComments ifNil: [ nil ] ifNotNil: [ selectedComments size = 1 ifTrue: [ selectedComments first ] ifFalse: [ nil ] ] ].
 	(self containedBy: anInterval) ifTrue: [^self].
 	
 	selectedChildren := self children select: [:each | 

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -177,12 +177,10 @@ RBProgramNode >> assigns: aVariableName [
 
 { #category : #querying }
 RBProgramNode >> bestNodeFor: anInterval [ 
-
-	| selectedChildren |
-	
-	anInterval ifNil: [ ^ nil ].
-	
-	(self intersectsInterval: anInterval) ifFalse: [^nil].
+	| selectedChildren selectedComments |
+	anInterval ifNil: [^nil ].
+	selectedComments := self getCommentsFor: anInterval.
+	(self intersectsInterval: anInterval) ifFalse: [^selectedComments ifNil: [ nil ] ifNotNil: [ selectedComments size = 1 ifTrue: [ selectedComments first ] ifFalse: [ self ] ] ].
 	(self containedBy: anInterval) ifTrue: [^self].
 	
 	selectedChildren := self children select: [:each | 
@@ -191,7 +189,9 @@ RBProgramNode >> bestNodeFor: anInterval [
 
 	^ selectedChildren size = 1 
 		ifTrue: [ selectedChildren first bestNodeFor: anInterval ]
-		ifFalse: [ self ]
+		ifFalse: [ (selectedChildren isEmpty and: [ selectedComments size = 1 ])
+							ifTrue: [ selectedComments first ]
+							ifFalse: [ self ] ]
 ]
 
 { #category : #querying }
@@ -370,6 +370,23 @@ RBProgramNode >> formattedCode [
 { #category : #accessing }
 RBProgramNode >> formatterClass [
 	^ self class formatterClass
+]
+
+{ #category : #querying }
+RBProgramNode >> getCommentsFor: anInterval [
+	| selectedComments |
+	selectedComments := OrderedCollection new.
+	self nodesDo: 
+		[ :each | 
+			| comments | 
+			comments := each comments select: 
+				[ :com | com intersectsInterval: anInterval ]. 
+	"This precaution is taken to deal with cascades multiple visit of the receiver."
+			(selectedComments isNotEmpty 
+				and: [ comments isNotEmpty 
+				and: [ comments last = selectedComments last ]]) 
+					ifFalse: [selectedComments addAll: comments ] ].
+	^ selectedComments
 ]
 
 { #category : #testing }

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -701,10 +701,7 @@ RubSmalltalkEditor >> findValidKeywordIn: sourceCode at: locationIndex ifFound: 
 		ifNotNil: [ 
 			node isLiteralNode
 				ifTrue: [ validLocation := false ].
-			node nodesDo: [ :subNode |
-				subNode comments
-					detect: [ :c | c intersectsInterval: locationInterval ]
-					ifFound: [ validLocation := false ] ] ].
+			node isCommentNode ifTrue: [ validLocation := false ] ].
 			
 	validLocation ifTrue: aBlock 
 			


### PR DESCRIPTION
Including the comments inside bestNodeFor: without affecting previous implementation for node research.
If an other node is selected with the comment, it is this node which will be returned.
If multiple comments are chosen, it will be the containing node returned.