### PR TITLE
CleanBlock-pcInOuter

### DIFF
--- a/src/Debugging-Core/CompiledBlock.extension.st
+++ b/src/Debugging-Core/CompiledBlock.extension.st
@@ -10,5 +10,16 @@ CompiledBlock >> pcInOuter [
 		[ (self encoderClass isCreateFullBlock: self code: outer at: instructionStream pc)
 			ifTrue: [ ^ instructionStream pc ].
 			instructionStream pc: (instructionStream nextPc: (outer at: instructionStream pc))].
+	"scan for clean block"	
+	instructionStream := InstructionStream on: outer.
+	[instructionStream pc <= end] whileTrue: [
+			| literalOffset |
+			literalOffset := self encoderClass literalIndexOfBytecodeAt: instructionStream pc in: outer.
+			literalOffset ifNotNil: [
+				| literal |
+				literal := (self outerCode literalAt: literalOffset + 1).
+				(literal class == CleanBlockClosure and: [literal compiledBlock = self  ])ifTrue: [ ^ instructionStream pc ].  ].
+			instructionStream pc: (instructionStream nextPc: (outer at: instructionStream pc))].	
+		
 	self error: 'block not installed in outer code'.
 ]

--- a/src/Kernel/CleanBlockClosure.class.st
+++ b/src/Kernel/CleanBlockClosure.class.st
@@ -1,12 +1,11 @@
 "
-!!!! Highly Experimental!!!
+Experimental
 
 This is disabled by default.
 
 If you want to experiment, you can enable the #optionCleanBlockClosure compiler option.
 
 - This should not be a subclass of FullBlock (as it does not need the receiver ivar, for example)
-- Debugging is not yet working as #pcInOuter needs to be implemented
 "
 Class {
 	#name : #CleanBlockClosure,

--- a/src/OpalCompiler-Core/RBVariableNode.extension.st
+++ b/src/OpalCompiler-Core/RBVariableNode.extension.st
@@ -12,7 +12,7 @@ RBVariableNode >> binding: aSemVar [
 
 { #category : #'*opalcompiler-core' }
 RBVariableNode >> isClean [
-	^ (self isInstanceVariable | self isReservedVariable) not
+	^ (self isInstanceVariable | self isSelfVariable | self isSuperVariable) not
 ]
 
 { #category : #'*opalcompiler-core' }

--- a/src/OpalCompiler-Tests/OCCleanBlockTest.class.st
+++ b/src/OpalCompiler-Tests/OCCleanBlockTest.class.st
@@ -10,6 +10,7 @@ Class {
 { #category : #tests }
 OCCleanBlockTest >> testBlockIsClean [
 	self assert: [  ] sourceNode isClean.
+	self assert: [ thisContext ] sourceNode isClean.
 	self assert: [ 1 + 2 ] sourceNode isClean.
 	self assert: [ :a | a + 2 ] sourceNode isClean.
 	self assert: [ :a :b | a + b + 3 ] sourceNode isClean.

--- a/src/OpalCompiler-Tests/OCCleanBlockTest.class.st
+++ b/src/OpalCompiler-Tests/OCCleanBlockTest.class.st
@@ -10,7 +10,6 @@ Class {
 { #category : #tests }
 OCCleanBlockTest >> testBlockIsClean [
 	"does not work if experimental clean blocks are enabled"
-	Smalltalk compiler compilationContext optionCleanBlockClosure ifTrue: [ ^self skip ].
 	self assert: [  ] sourceNode isClean.
 	self assert: [ 1 + 2 ] sourceNode isClean.
 	self assert: [ :a | a + 2 ] sourceNode isClean.

--- a/src/OpalCompiler-Tests/OCCleanBlockTest.class.st
+++ b/src/OpalCompiler-Tests/OCCleanBlockTest.class.st
@@ -9,7 +9,6 @@ Class {
 
 { #category : #tests }
 OCCleanBlockTest >> testBlockIsClean [
-	"does not work if experimental clean blocks are enabled"
 	self assert: [  ] sourceNode isClean.
 	self assert: [ 1 + 2 ] sourceNode isClean.
 	self assert: [ :a | a + 2 ] sourceNode isClean.

--- a/src/OpalCompiler-Tests/OCClosureTest.class.st
+++ b/src/OpalCompiler-Tests/OCClosureTest.class.st
@@ -106,13 +106,15 @@ OCClosureTest >> testEmptyBlockZeroArguments [
 
 { #category : #testing }
 OCClosureTest >> testIsClean [
-	 | local |
-	 local := #testIsClean.
+	| local |
+	local := #testIsClean.
 	self assert: [] isClean. "closes over nothing at all"
+	self assert: [thisContext] isClean. "we can access the context"
 	self assert: [:a :b| a < b] isClean. "accesses only arguments"
 	self assert: [:a :b| | s | s := a + b. s even] isClean. "accesses only local variables"
 	self deny: [^nil] isClean. "closes over home (^-return)"
 	self deny: [self] isClean. "closes over the receiver"
+	self deny: [super testIsClean] isClean. "closes over the receiver"
 	self deny: [collection] isClean. "closes over the receiver (to access the inst var collection)"
 	self deny: [local] isClean. "closes over local variable of outer context"
 ]


### PR DESCRIPTION
this implements #pcInOuter for gfhe case that #optionCleanBlockClosure is enabled.

This makes #sourceNode work for clean blocks:

CompilationContext optionCleanBlockClosure: true.
[ 1 + 2 ] sourceNode