### PR TITLE
Compiler-use-variable-not-binding

### DIFF
--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -143,7 +143,7 @@ OCASTSemanticAnalyzer >> undeclaredVariable: variableNode [
 
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> uninitializedVariable: variableNode [
-	variableNode binding markRead.
+	variableNode variable markRead.
 	variableNode propertyAt: #semanticWarning put: #unitialized.
 ]
 
@@ -226,7 +226,7 @@ OCASTSemanticAnalyzer >> visitSequenceNode: aSequenceNode [
 	aSequenceNode temporaries do: [ :node | self declareVariableNode: node ].
 	aSequenceNode statements do: [ :each | self visitNode: each ].
 	aSequenceNode temporaries reverseDo: [ :node | 
-			node binding isUnused
+			node variable isUnused
 				ifTrue: [ self unusedVariable: node ] ]
 ]
 

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -215,7 +215,7 @@ OCASTTranslator >> emitIfNil: aMessageNode boolean: aBoolean [
 	"emits the == nil code and push correct value on stack if the ifNotNil block has an argument"
 	args := aMessageNode arguments.
 	notNilBlock := aBoolean ifTrue: [args first] ifFalse: [args last].
-	notNilBlock arguments ifNotEmpty: [ notNilBlock arguments first binding emitStore: methodBuilder ].
+	notNilBlock arguments ifNotEmpty: [ notNilBlock arguments first variable emitStore: methodBuilder ].
 	methodBuilder pushLiteral: nil.
 	methodBuilder send: #==.
 	
@@ -346,7 +346,7 @@ OCASTTranslator >> emitToDo: aMessageNode step: step [
 	
 	limit := aMessageNode arguments first.
 	block := aMessageNode arguments last.
-	iterator := block arguments first binding.
+	iterator := block arguments first variable.
 	
 	limitEmit := [valueTranslator visitNode: limit].
 	limit isLiteralNode | limit isSelfVariable | limit isSuperVariable | limit isArgumentVariable ifFalse: [
@@ -473,7 +473,7 @@ OCASTTranslator >> visitArrayNode: anArrayNode [
 OCASTTranslator >> visitAssignmentNode: anAssignmentNode [ 
 
 	valueTranslator visitNode: anAssignmentNode value.
-	anAssignmentNode variable binding emitStore: methodBuilder
+	anAssignmentNode variable variable emitStore: methodBuilder
 
 ]
 
@@ -657,7 +657,7 @@ OCASTTranslator >> visitSequenceNode: aSequenceNode [
 
 { #category : #'visitor-double dispatching' }
 OCASTTranslator >> visitVariableNode: aVariableNode [
-	aVariableNode binding emitValue: methodBuilder
+	aVariableNode variable emitValue: methodBuilder
 	
 	
 ]

--- a/src/OpalCompiler-Core/OCASTTranslatorForEffect.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslatorForEffect.class.st
@@ -29,7 +29,7 @@ OCASTTranslatorForEffect >> emitIfNotNil: aMessageNode [
 	| args |
 	valueTranslator visitNode: aMessageNode receiver.
 	args := aMessageNode arguments.
-	args first arguments ifNotEmpty: [ args first arguments first binding emitStore: methodBuilder ].
+	args first arguments ifNotEmpty: [ args first arguments first variable emitStore: methodBuilder ].
 	methodBuilder pushLiteral: nil.
 	methodBuilder send: #==.
 	methodBuilder jumpAheadTo: #end if: true.

--- a/src/OpalCompiler-Core/OCASTTranslatorForValue.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslatorForValue.class.st
@@ -24,7 +24,7 @@ OCASTTranslatorForValue >> emitIfNotNil: aMessageNode [
 	| args |
 	self visitNode: aMessageNode receiver.
 	args := aMessageNode arguments.
-	args first arguments ifNotEmpty: [ args first arguments first binding emitStore: methodBuilder ].
+	args first arguments ifNotEmpty: [ args first arguments first variable emitStore: methodBuilder ].
 	methodBuilder pushDup.
 	methodBuilder pushLiteral: nil.
 	methodBuilder send: #==.

--- a/src/OpalCompiler-Core/ReservedVariable.class.st
+++ b/src/OpalCompiler-Core/ReservedVariable.class.st
@@ -57,7 +57,7 @@ ReservedVariable >> printOn: stream [
 ReservedVariable >> usingMethods [
 	"first call is very slow as it creates all ASTs"
 	^SystemNavigation new allMethods select: [ : method |
-		method ast variableNodes anySatisfy: [ :varNode | varNode binding == self]]
+		method ast variableNodes anySatisfy: [ :varNode | varNode variable == self]]
 ]
 
 { #category : #debugging }

--- a/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
@@ -71,7 +71,7 @@ OCASTClosureAnalyzerTest >> testExampleSimpleBlockLocalIf [
 	ast doSemanticAnalysis.
 
 	assignment := RBParseTreeSearcher treeMatching: '`var := ``@anything' in: ast. 	
-	var := assignment variable binding.
+	var := assignment variable variable.
 	self assert: var isWrite.
 	self deny: var isEscaping.
 ]
@@ -477,7 +477,7 @@ t1 := 1.
 
 ^t2'.
 	ast doSemanticAnalysis.
-	self assert: ast temporaries second binding class equals: OCVectorTempVariable
+	self assert: ast temporaries second variable class equals: OCVectorTempVariable
 ]
 
 { #category : #'tests - special cases' }


### PR DESCRIPTION
Small cleanup in the Compiler code to use #variable, not #binding to access the  variables from the AST