### PR TITLE
ReLiteralArrayContainsCommaRule-Improve

### DIFF
--- a/src/GeneralRules/ReLiteralArrayContainsCommaRule.class.st
+++ b/src/GeneralRules/ReLiteralArrayContainsCommaRule.class.st
@@ -16,17 +16,12 @@ ReLiteralArrayContainsCommaRule class >> uniqueIdentifierName [
 
 { #category : #running }
 ReLiteralArrayContainsCommaRule >> basicCheck: aNode [
-	^ aNode isLiteralArray and: [ aNode value includes: #, ]
-]
 
-{ #category : #private }
-ReLiteralArrayContainsCommaRule >> doesLiteralArrayContainComma: aLiteral [ 
-	aLiteral class = Array 
-		ifFalse: [ ^ false ].
-	(aLiteral includes: #,)
-		ifTrue: [ ^ true ].
-	^ aLiteral 
-		anySatisfy: [ :each | self doesLiteralArrayContainComma: each ]
+	aNode isLiteralArray ifFalse: [ ^ false ].
+	"ffiCall: parameters contain , do not warn in this case"
+	(aNode parent parent isMessage and: [ 
+		 aNode parent parent selector == #ffiCall: ]) ifTrue: [ ^ false ].
+	^ aNode value includes: #,
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- remove dead code doesLiteralArrayContainComma:
- improve the rule to ignore commas in a #ffiCall: message, as it is perfectly fine to have , there