### PR TITLE
Test-and-Fix-ReLiteralArrayContainsSuspiciousTrueFalseOrNilRule

### DIFF
--- a/src/GeneralRules-Tests/ReSmalllintTest.class.st
+++ b/src/GeneralRules-Tests/ReSmalllintTest.class.st
@@ -357,6 +357,11 @@ ReSmalllintTest >> testLiteralArrayContainsComma [
 ]
 
 { #category : #tests }
+ReSmalllintTest >> testLiteralArrayContainsSuspiciousTrueFalseOrNil [
+	self ruleFor: self currentSelector
+]
+
+{ #category : #tests }
 ReSmalllintTest >> testLocalMethodsSameThanTrait [
 	self classAndMetaClassRuleFor: self currentSelector
 ]

--- a/src/GeneralRules/ReLiteralArrayContainsSuspiciousTrueFalseOrNilRule.class.st
+++ b/src/GeneralRules/ReLiteralArrayContainsSuspiciousTrueFalseOrNilRule.class.st
@@ -21,7 +21,8 @@ ReLiteralArrayContainsSuspiciousTrueFalseOrNilRule class >> uniqueIdentifierName
 
 { #category : #running }
 ReLiteralArrayContainsSuspiciousTrueFalseOrNilRule >> basicCheck: aNode [
-	^ aNode isLiteralArray and: [ aNode value includesAny: #(#true #false #nil) ]
+	^ aNode isLiteralArray and: [ #(#true #false #nil) anySatisfy: [ :each | aNode value identityIncludes: each]]
+
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Tests-Critics/RBSmalllintTestObject.class.st
+++ b/src/Refactoring-Tests-Critics/RBSmalllintTestObject.class.st
@@ -228,6 +228,11 @@ RBSmalllintTestObject >> literalArrayContainsComma [
 	^ #(#,)
 ]
 
+{ #category : #'accessing - bad' }
+RBSmalllintTestObject >> literalArrayContainsSuspiciousTrueFalseOrNil [
+	^#(#nil)
+]
+
 { #category : #methods }
 RBSmalllintTestObject >> longMethods [
 	self printString.


### PR DESCRIPTION
ReLiteralArrayContainsSuspiciousTrueFalseOrNilRule was showing false posities when there where explicit strings like 'false' in a literal array.
- fix it to only warn for symbols
- add test