### PR TITLE
Deprecate-namedTempAt-namedTempAtput

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -44,7 +44,10 @@ Context >> methodReturnConstant: value [
 Context >> namedTempAt: index [
 	"Answer the value of the temp at index in the receiver's sequence of tempNames."
 	"NOTE: this list of temp names is completely virtual! It omits temp vectors but 
-	adds every variable that could be acccessed from a source perspective but might not be"
+	adds every variable that could be acccessed from a source perspective but might not be.
+	Do *not* use this!"
+	
+	self deprecated: 'Please access temps by name using #tempNamed:'.
 	^self tempNamed: (self tempNames at: index)
 ]
 
@@ -53,6 +56,9 @@ Context >> namedTempAt: index put: aValue [
 	"Set the value of the temp at index in the receiver's sequence of tempNames"
 	"NOTE: this list of temp names is completely virtual! It omits temp vectors but 
 	adds every variable that could be acccessed from a source perspective but might not be"
+	"Do *not* use this!"
+	self deprecated: 'Please access temps by name using #tempNamed:put:'.
+	
 	self tempNamed: (self tempNames at: index) put: aValue
 ]
 

--- a/src/Deprecated90/DebuggerMethodMapOpal.extension.st
+++ b/src/Deprecated90/DebuggerMethodMapOpal.extension.st
@@ -2,16 +2,16 @@ Extension { #name : #DebuggerMethodMapOpal }
 
 { #category : #'*Deprecated90' }
 DebuggerMethodMapOpal >> namedTempAt: index in: aContext [
-	"please use #namedTempAt: on Context"
-	self deprecated: 'Please use aContext namedTempAt: index'.
-	^aContext namedTempAt: index
+	"Please access temps by name using #tempNamed: on Context"
+	self deprecated: 'Please access temps by name using #tempNamed: on Context'.
+	^aContext tempNamed: (aContext tempNames at: index)
 ]
 
 { #category : #'*Deprecated90' }
 DebuggerMethodMapOpal >> namedTempAt: index put: aValue in: aContext [
-	"please use #namedTempAt:put: on Context"
-	self deprecated: 'Please use aContext namedTempAt: index put: aValue'.
-	aContext namedTempAt: index put: aValue
+	"Please access temps by name using #tempNamed:put:"
+	self deprecated: 'Please access temps by name using #tempNamed:put:'.
+	aContext tempNamed: (aContext tempNames at: index) put: aValue
 ]
 
 { #category : #'*Deprecated90' }


### PR DESCRIPTION
With closures, the idea that a temp variable has just an offset in the context is not true anymore. The story is *much* more complex!
To simplify it, we have added meta-objects that know how to read and write temps: we have made temps into first class variables.

The old "DebuggerMethodMap" API was providing some "virtual" offset based accessign scheme which now makes no sense at all anymore.

This PR thus deprecates namedTempAt:/namedTempAt:put:, the methods are not used anymore in the system and just by being there are highly confusing.