### PR TITLE
Missing offsets when mapping ast<->bytecode and when the first node is a fullblock

### DIFF
--- a/src/OpalCompiler-Core/OCBytecodeToASTCache.class.st
+++ b/src/OpalCompiler-Core/OCBytecodeToASTCache.class.st
@@ -35,20 +35,26 @@ OCBytecodeToASTCache >> bcToASTMap [
 
 { #category : #private }
 OCBytecodeToASTCache >> fillMissingBCOffsetsWithLastBCOffsetNodes [
-	"It happens that different bytecode offsets map to the same AST node.
+	 "It happens that different bytecode offsets map to the same AST node.
 	These cases are detected when there is no node mapped between, for example, bcOffset 46 and bcOffset 50.
 	In that case, we take every possible bytecode index between 46 and 50 (i.e., 47, 48, 49),
-	and we map them to the same node as the last mapped bytecode offset, here 46."
+	and we map them to the same node as the last mapped bytecode offset, here 46.
+	
+	When a fullblocks is the first node in a method body, it is possible (when?) the offsets do not start at the first offset of the method (why?). 
+	In that case, we also fix the missing offsets by mapping to them the first mapped node."
 
-	| sortedBCOffsets |
-	sortedBCOffsets := bcToASTMap keys asSortedCollection.
-	1 to: sortedBCOffsets size - 1 do: [ :index | 
-		| bcAtIndex bcAtNextIndex |
-		bcAtIndex := sortedBCOffsets at: index.
-		bcAtNextIndex := sortedBCOffsets at: index + 1.
-		bcAtIndex < bcAtNextIndex ifTrue: [ 
-			bcAtIndex to: bcAtNextIndex - 1 do: [ :i | 
-			bcToASTMap at: i put: (bcToASTMap at: bcAtIndex) ] ] ]
+	 | sortedBCOffsets |
+	 sortedBCOffsets := bcToASTMap keys asSortedCollection.
+	 sortedBCOffsets first = firstBcOffset ifFalse: [ 
+		 firstBcOffset to: sortedBCOffsets first - 1 do: [ :offset | 
+			 bcToASTMap at: offset put: (bcToASTMap at: sortedBCOffsets first) ] ].
+	 1 to: sortedBCOffsets size - 1 do: [ :index | 
+		 | bcAtIndex bcAtNextIndex |
+		 bcAtIndex := sortedBCOffsets at: index.
+		 bcAtNextIndex := sortedBCOffsets at: index + 1.
+		 bcAtIndex < bcAtNextIndex ifTrue: [ 
+			 bcAtIndex to: bcAtNextIndex - 1 do: [ :i | 
+			 bcToASTMap at: i put: (bcToASTMap at: bcAtIndex) ] ] ]
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Tests/MethodMapExamples.class.st
+++ b/src/OpalCompiler-Tests/MethodMapExamples.class.st
@@ -170,6 +170,13 @@ MethodMapExamples >> helperMethod13 [
 ]
 
 { #category : #examples }
+MethodMapExamples >> helperMethod14: aVisitor [
+	 [ aVisitor ]
+		 on: Error
+		 do: [ aVisitor ]
+]
+
+{ #category : #examples }
 MethodMapExamples >> ivar [
 	^ivar
 ]

--- a/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
@@ -33,6 +33,14 @@ OCBytecodeToASTCacheTest >> testFirstBCOffsetTest [
 ]
 
 { #category : #tests }
+OCBytecodeToASTCacheTest >> testFirstBCOffsetWithBlock [
+	compiledMethod := (MethodMapExamples >> #helperMethod14:).
+	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast.	
+	self assert: (cache nodeForPC: cache firstBcOffset) identicalTo: compiledMethod ast statements first receiver
+	
+]
+
+{ #category : #tests }
 OCBytecodeToASTCacheTest >> testFirstBCOffsetWithQuickReturn [
 	compiledMethod := ( MethodMapExamples >> #ivar).
 	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast.	


### PR DESCRIPTION
Fixes #7087 needs review by @MarcusDenker 

When mapping ast to bytecodes, if the first node of the method is a block, sometimes the bytecodeIndex of the block IR is 2, sometimes it is 1.
When that bytecodeIndex is 2, it shifts the first mapped node by 1, and the initialPC of the method is not mapped.
Example: 
```Smalltalk
method: arg
  [arg] on: Error do: [nil]
```
Imagine method initialPC is `40`.
The first mapped node is `[arg]`, and is computed as :  `bytecodeIndex + startpc - 1` 
Its value is 2 + 40 - 1 = 41.
As it is the first mapped node, the mapping starts at `41`and the initiaPC `40` is missing from the mapping.
When debugging and entering a method with the debugger, if the node for the initialPC is requested then there is a key not found error because it is missing.

This PR fixes the mapping by checking that all indexes  between the initialPC of a method and the first mapped offset are all mapped to the first mapped node.
In the case above, it checks that all indexes from 40 to the first mapped offset (41->`[arg]`) are mapped, if not it maps 40 to 41 to the node mapped at 41 (`[arg]`).

I am not sure it is the *right* way to do this. Maybe it should be done during the mapping rather than afterwards by fixing missing indexes.

