### PR TITLE
RBLiteralNode-evaluate

### DIFF
--- a/src/AST-Core-Tests/ASTEvaluationTest.class.st
+++ b/src/AST-Core-Tests/ASTEvaluationTest.class.st
@@ -9,7 +9,8 @@ Class {
 
 { #category : #tests }
 ASTEvaluationTest >> testEvaluate [
-	self assert: (RBLiteralNode value: 5) evaluate equals: 5
+	self assert: (RBLiteralNode value: 5) evaluate equals: 5.
+	self assert: (RBMessageNode receiver: 5 asLiteralNode selector: #class ) evaluate equals: 5 class
 ]
 
 { #category : #tests }

--- a/src/AST-Core/RBLiteralValueNode.class.st
+++ b/src/AST-Core/RBLiteralValueNode.class.st
@@ -54,6 +54,18 @@ RBLiteralValueNode >> copyInContext: aDictionary [
 	^ self class value: self value
 ]
 
+{ #category : #evaluating }
+RBLiteralValueNode >> evaluateForContext: aContext [
+
+	^ value
+]
+
+{ #category : #evaluating }
+RBLiteralValueNode >> evaluateForReceiver: aReceicer [
+
+	^ value
+]
+
 { #category : #accessing }
 RBLiteralValueNode >> sourceText [
 	^ sourceText ifNil: [

--- a/src/AST-Core/RBValueNode.class.st
+++ b/src/AST-Core/RBValueNode.class.st
@@ -36,10 +36,8 @@ RBValueNode >> containedBy: anInterval [
 
 { #category : #evaluating }
 RBValueNode >> evaluate [
-	"evaluate the AST without taking variables into account"
-	^self asDoit generateWithSource valueWithReceiver: nil arguments: #().
-
-
+	"evaluate the AST with a nil  receiver"
+	^ self evaluateForReceiver: nil
 ]
 
 { #category : #evaluating }


### PR DESCRIPTION
Small improvement for AST evaluation:

- RBValueNode>>#evaluate can reuse evaluateForReceiver:
- improve testEvaluate
- Implement evaluateForContext: and evaluateForReceiver: for RBLiteralValueNode to just return the value

This is tested by ASTEvaluationTest