### PR TITLE
7078-remove-ReTempVarOverridesInstVarRuleTest-shadowing

### DIFF
--- a/src/GeneralRules-Tests/ReTempVarOverridesInstVarRuleTest.class.st
+++ b/src/GeneralRules-Tests/ReTempVarOverridesInstVarRuleTest.class.st
@@ -25,14 +25,9 @@ ReTempVarOverridesInstVarRuleTest >> sampleMethod: dummy1 [
 { #category : #tests }
 ReTempVarOverridesInstVarRuleTest >> testRule [
 	| critiques |
-	self class compile: 'sampleMethod: dummy1
-	"I override dummy1, dummy2, dummy3  "
-	| dummy2 |
-	dummy2 := [ :dummy3 | dummy4 := dummy1 + dummy3 ].
-	^ dummy2 value: dummy1.
-	' classified: 'test-help'.
 	critiques := self myCritiquesOnMethod: self class >> #sampleMethod:.
 	
 	self assert: critiques size equals: 2.
 	self assert: (self sourceAtChritique:  critiques second) equals: 'dummy2'.
+	
 ]


### PR DESCRIPTION
The test was compiling a new method for testing every time it was run. This is not needed as it  is never removed. fixes #7078