### PR TITLE
Improve-ReSendsMethodDictRule

### DIFF
--- a/src/GeneralRules/ReSendsMethodDictRule.class.st
+++ b/src/GeneralRules/ReSendsMethodDictRule.class.st
@@ -22,7 +22,7 @@ ReSendsMethodDictRule class >> uniqueIdentifierName [
 { #category : #running }
 ReSendsMethodDictRule >> basicCheck: aMethod [
 	"in the Behavior classes we want to use the accessor (see comment #methodDict)"
-	({Behavior . ClassDescription . Class. Metaclass} includes: aMethod methodClass) 
+	({Behavior . ClassDescription . Class. Metaclass. TraitedMetaclass. MetaclassForTraits} includes: aMethod methodClass) 
 		ifTrue: [ ^ false ].
 	^(aMethod refersToLiteral: #methodDict) and: [aMethod messages includes: #methodDict]
 ]


### PR DESCRIPTION
add TraitedMetaclass. MetaclassForTraits as the classes where we do not complain about using the accessor.

(the idea is that it is not to be used by client code (they should talk about methods and use good APIs). The classes of Behavior and subclasses that need to mannipulate it *should* use the accessor as it might be nil)