### PR TITLE
7135-Logic-of-testManifestNamesAccordingToPackageNames-should-improve-the-identification-of-problems

### DIFF
--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -178,9 +178,14 @@ ReleaseTest >> testManifestNamesAccordingToPackageNames [
 	|manifestClasses actualManifestNames expectedManifestNames |
 	manifestClasses := self class environment allClasses select: [:each | each isManifest ].
 	actualManifestNames := (manifestClasses collect: [:each | each name ]) sorted.
-	expectedManifestNames := manifestClasses 
-										collect: [:each | TheManifestBuilder manifestClassNameFor: each package name ].
-	self assert: actualManifestNames equals: expectedManifestNames 
+	expectedManifestNames := (manifestClasses collect: [:each | TheManifestBuilder manifestClassNameFor: each package name ]) sorted.
+	
+	self 
+		assert: actualManifestNames size 
+		equals: expectedManifestNames size.
+	
+	actualManifestNames do: [:each |
+		 self assert: (expectedManifestNames includes: each)] 
 ]
 
 { #category : #tests }


### PR DESCRIPTION
fixes: #7135 - the test will be red but we can understand.