### PR TITLE
7166-Calypso-Class-definition-mode-is-wrong-should-not-be-a-comment-mode

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyClassCommentEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassCommentEditorToolMorph.class.st
@@ -43,6 +43,12 @@ ClyClassCommentEditorToolMorph >> defaultTitle [
 ]
 
 { #category : #accessing }
+ClyClassCommentEditorToolMorph >> editingMode [
+	^ RubSmalltalkCommentMode new
+	
+]
+
+{ #category : #accessing }
 ClyClassCommentEditorToolMorph >> editingText [
 	^editingClass comment
 ]

--- a/src/Calypso-SystemTools-Core/ClyClassEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassEditorToolMorph.class.st
@@ -75,12 +75,6 @@ ClyClassEditorToolMorph >> editingClass: anObject [
 	editingClass := anObject
 ]
 
-{ #category : #accessing }
-ClyClassEditorToolMorph >> editingMode [
-	^ RubSmalltalkCommentMode new
-	
-]
-
 { #category : #testing }
 ClyClassEditorToolMorph >> isSimilarTo: anotherBrowserTool [
 


### PR DESCRIPTION
Fixes: #7166 placed method on superclass too high.