### PR TITLE
Simplify-AddionalMethodState-LiteralQueries

### DIFF
--- a/src/Kernel/AdditionalMethodState.class.st
+++ b/src/Kernel/AdditionalMethodState.class.st
@@ -158,46 +158,6 @@ AdditionalMethodState >> copyWithout: aPropertyOrPragma [ "<Association|Pragma>"
 ]
 
 { #category : #testing }
-AdditionalMethodState >> hasAtLeastTheSamePropertiesAs: aMethodProperties [
-	"Answer if the recever has at least the same properties as the argument.
-	 N.B. The receiver may have additional properties and still answer true."
-	aMethodProperties keysAndValuesDo:
-		[:k :v|
-		(v isKindOf: Pragma)
-			"ifTrue: [Pragmas have already been checked]"
-			ifFalse: [
-				(self includes: k->v) ifFalse: [^false]]].
-	^true
-]
-
-{ #category : #testing }
-AdditionalMethodState >> hasLiteralSuchThat: aBlock [
-	"Answer true if litBlock returns true for any literal in this array, even if embedded in further array structure.
-	 This method is only intended for private use by CompiledMethod hasLiteralSuchThat:"
-	1 to: self basicSize do: [:i |
-		| propertyOrPragma "<Association|Pragma>" |
-		propertyOrPragma := self basicAt: i.
-		(propertyOrPragma isVariableBinding
-			ifTrue: [(aBlock value: propertyOrPragma key)
-					or: [(aBlock value: propertyOrPragma value)
-					or: [propertyOrPragma value isArray
-						and: [propertyOrPragma value hasLiteralSuchThat: aBlock]]]]
-			ifFalse: [propertyOrPragma hasLiteralSuchThat: aBlock]) ifTrue:
-			[^true]].
-	^false
-]
-
-{ #category : #testing }
-AdditionalMethodState >> hasLiteralThorough: aLiteral [
-	self 
-		deprecated: 'Use #refersToLiteral: instead.' 
-		on: '31 January 2020'
-		in: #Pharo9
-		transformWith: '`@receiver hasLiteralThorough: `@arg' -> '`@receiver refersToLiteral: `@arg'.
-	^ self refersToLiteral: aLiteral
-]
-
-{ #category : #testing }
 AdditionalMethodState >> includes: aPropertyOrPragma [ "<Association|Pragma>"
 	"Test if the property or pragma is present."
 
@@ -358,16 +318,6 @@ AdditionalMethodState >> propertyValueAt: aKey [
 AdditionalMethodState >> propertyValueAt: aKey ifAbsent: aBlock [
 	"use the version without ..Value, this methid is retained for compatibility"
 	^self propertyAt: aKey ifAbsent: aBlock
-]
-
-{ #category : #testing }
-AdditionalMethodState >> refersToLiteral: literal [
-	"Answer true if any literal in these properties is literal,
-	 even if embedded in array structure."
-	1 to: self basicSize do: [:i |
-		((self basicAt: i) hasLiteral: literal) ifTrue:
-			[^true]].
-	^false
 ]
 
 { #category : #properties }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -326,12 +326,6 @@ CompiledMethod class >> toReturnSelfTrailerBytes: trailer [
 	^self newBytes: 3 trailerBytes: trailer nArgs: 0 nTemps: 0 nStack: 0 nLits: 2 primitive: 256
 ]
 
-{ #category : #literals }
-CompiledMethod >> additionalMethodStateRefersToLiteral: literal [
-	^ self penultimateLiteral isMethodProperties
-		and: [ self penultimateLiteral refersToLiteral: literal ]
-]
-
 { #category : #'source code management' }
 CompiledMethod >> argumentNames [
 	^ self propertyAt: #argumentNames ifAbsent: [ super argumentNames ]
@@ -464,10 +458,8 @@ CompiledMethod >> hasComment [
 CompiledMethod >> hasLiteralSuchThat: litBlock [
 	"Answer true if litBlock returns true for any literal in this method, even if embedded in array structure."
 
-	(self penultimateLiteral isMethodProperties and: [ 
-		 self penultimateLiteral hasLiteralSuchThat: litBlock ]) ifTrue: [ 
-		^ true ].
-	^ super hasLiteralSuchThat: litBlock
+	^ (self pragmaHasLiteralSuchThat: litBlock) or: [ 
+		  super hasLiteralSuchThat: litBlock ]
 ]
 
 { #category : #'accessing-pragmas & properties' }
@@ -761,6 +753,20 @@ CompiledMethod >> pragmaAt: aKey [
 		ifFalse: [nil]
 ]
 
+{ #category : #literals }
+CompiledMethod >> pragmaHasLiteralSuchThat: aBlock [
+
+	^ self penultimateLiteral isMethodProperties and: [ 
+		  self pragmas anySatisfy: [ :pragma | pragma hasLiteralSuchThat: aBlock ] ]
+]
+
+{ #category : #literals }
+CompiledMethod >> pragmaRefersToLiteral: literal [
+
+	^ self penultimateLiteral isMethodProperties and: [ 
+		  self pragmas anySatisfy: [ :pragma | pragma refersToLiteral: literal ] ]
+]
+
 { #category : #'accessing-pragmas & properties' }
 CompiledMethod >> pragmas [
 	| selectorOrProperties |
@@ -941,13 +947,9 @@ CompiledMethod >> readsField: varIndex [
 
 { #category : #literals }
 CompiledMethod >> refersToLiteral: aLiteral [
-	"Answer true if any literal in this method is literal,
-	even if embedded in array structure."
-
-	(self additionalMethodStateRefersToLiteral: aLiteral)
-		ifTrue: [ ^ true ].
-
-	^super refersToLiteral: aLiteral
+	"Answer true if any literal in this method is literal, even if embedded in array structure."
+	
+	^(self pragmaRefersToLiteral: aLiteral) or: [ super refersToLiteral: aLiteral]
 ]
 
 { #category : #initialization }

--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -246,6 +246,12 @@ Pragma >> printOn: aStream [
 	aStream nextPut: $>.
 ]
 
+{ #category : #testing }
+Pragma >> refersToLiteral: aLiteral [
+	^self selector == aLiteral 
+	   or: [arguments hasLiteral: aLiteral]
+]
+
 { #category : #accessing }
 Pragma >> selector [
 	"Answer the selector of the pragma.


### PR DESCRIPTION
AdditionalMethodState should not care at all about the literal queries #hasLiteralSuchThat: and #refersToLiteral:

We just look into Pragmas, and that we can do from the CompiledMethod level by querying the pragmas directly.

This allows us to remove all the (very confusing) code related to literals from AdditionalMethodState

No deprecation needed as this is implementatoon details, not external API.