### PR TITLE
Guard-ReservedVariable-name-setter

### DIFF
--- a/src/OpalCompiler-Core/ReservedVariable.class.st
+++ b/src/OpalCompiler-Core/ReservedVariable.class.st
@@ -47,6 +47,12 @@ ReservedVariable >> isWritable [
 	^ false
 ]
 
+{ #category : #accessing }
+ReservedVariable >> name: aSymbol [
+	"names of ReservedVariables are fixed and can not be changed"
+	self shouldNotImplement
+]
+
 { #category : #printing }
 ReservedVariable >> printOn: stream [
 


### PR DESCRIPTION
ReservedVariable subclasses set the name in #initialize. As there is just one instance, changing the name would break all ASTs. 
This PR makes sure that #name: can not be used to change the name of the ReservedVariable by accident.