### PR TITLE
Variable-writeInContext-should-return-Value

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -380,8 +380,7 @@ Context >> tempNamed: aName [
 Context >> tempNamed: aName put: anObject [
 	"Assign the value of the temp with name in aContext"
 	
-	(self lookupTempVar: aName) write: anObject inContext: self.
-	^ anObject
+	^(self lookupTempVar: aName) write: anObject inContext: self
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -257,5 +257,5 @@ LiteralVariable >> write: aValue inContext: aContext [
 	self isWritable ifFalse: [ 
 		^self error: 'Variable ' , name, ' is read only'].
 
-	value := aValue
+	^value := aValue
 ]

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -345,7 +345,7 @@ Slot >> wantsInitialization [
 
 { #category : #debugging }
 Slot >> write: aValue inContext: aContext [
-	self write: aValue to: aContext receiver
+	^self write: aValue to: aContext receiver
 ]
 
 { #category : #'meta-object-protocol' }

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -303,5 +303,7 @@ Variable >> usingMethods [
 
 { #category : #debugging }
 Variable >> write: aValue inContext: aContext [
-	self subclassResponsibility 
+	"write the value in aContext. All #write:inContext: methods need to return the assigned value,
+	as this is the reflective version of assignment which has the assigned value as a value"
+	^self subclassResponsibility 
 ]

--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -277,9 +277,7 @@ LocalVariable >> usingMethods [
 { #category : #debugging }
 LocalVariable >> write: aValue inContext: aContext [
 
-	| contextScope |
-	contextScope := aContext astScope.
-	self writeFromContext: aContext scope: contextScope value: aValue
+	^self writeFromContext: aContext scope: aContext astScope value: aValue
 ]
 
 { #category : #debugging }

--- a/src/Reflectivity/RFTempWrite.class.st
+++ b/src/Reflectivity/RFTempWrite.class.st
@@ -22,8 +22,7 @@ RFTempWrite >> context: anObject [
 
 { #category : #evaluating }
 RFTempWrite >> value [
-	variable write: assignedValue inContext: context.
-	^assignedValue
+	^variable write: assignedValue inContext: context
 ]
 
 { #category : #accessing }

--- a/src/Slot-Examples/ExampleSlotWithState.class.st
+++ b/src/Slot-Examples/ExampleSlotWithState.class.st
@@ -56,5 +56,5 @@ ExampleSlotWithState >> read: anObject [
 
 { #category : #'meta-object-protocol' }
 ExampleSlotWithState >> write: aValue to: anObject [
-	value := aValue
+	^value := aValue
 ]

--- a/src/Slot-Examples/ToOneRelationSlot.class.st
+++ b/src/Slot-Examples/ToOneRelationSlot.class.st
@@ -29,7 +29,7 @@ ToOneRelationSlot >> updateOld: oldValue new: newValue in: anObject [
 { #category : #'meta-object-protocol' }
 ToOneRelationSlot >> write: newValue to: anObject [
 	self updateOld: (self read: anObject) new: newValue in: anObject.
-	super write: newValue to: anObject
+	^super write: newValue to: anObject
 ]
 
 { #category : #internal }


### PR DESCRIPTION
#write:inContext: is a reflective version of a variable assignment. The value of "var := aValue" is aValue, thus the return of the reflective operation should do the same.

The clients (e.g. tempNamed:put:) show that this is indeed what we should do.