### PR TITLE
Context-writeVariableNamedValue

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -441,3 +441,8 @@ Context >> tempsAndValuesLimitedTo: sizeLimit indent: indent [
 Context >> unusedBytecode [
 	^ self respondsToUnknownBytecode 
 ]
+
+{ #category : #'*Debugging-Core' }
+Context >> writeVariableNamed: aName value: anObject [ 
+	^ (self lookupVar: aName) write: anObject inContext: self
+]

--- a/src/Kernel-Tests-Extended/ContextTest.extension.st
+++ b/src/Kernel-Tests-Extended/ContextTest.extension.st
@@ -55,3 +55,17 @@ ContextTest >> testSourceNodeExecutedWhenContextIsJustAtStartpc [
 	sourceNode := context sourceNodeExecuted.
 	self assert: sourceNode equals: (self class >> testSelector) ast sendNodes first receiver
 ]
+
+{ #category : #'*Kernel-Tests-Extended' }
+ContextTest >> testWrtireVariableNamedValue [
+	|localVar|
+	localVar := 2.
+	instVarForTestLookupSymbol := 3.
+	classVarForTestLookupSymbol := 4.
+	thisContext writeVariableNamed: #localVar value: #changed1.
+	self assert: (thisContext readVariableNamed: #localVar) equals: #changed1.
+	thisContext writeVariableNamed: #instVarForTestLookupSymbol value: #changed2.
+	self assert: (thisContext readVariableNamed: #instVarForTestLookupSymbol) equals: #changed2.
+	thisContext writeVariableNamed: #classVarForTestLookupSymbol value: #changed3.
+	self assert: (thisContext readVariableNamed: #classVarForTestLookupSymbol) equals: #changed3
+]


### PR DESCRIPTION
we have Context>>#readVariableNamed:

This PR adds a method to write any variable from a context: #writeVariableNamed:value: