### PR TITLE
CleanBlock-accessVariables-ForDebugger

### DIFF
--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1233,9 +1233,9 @@ Context >> objectSize: anObject [
 { #category : #accessing }
 Context >> outerContext [
 	"Answer the context within which the receiver is nested."
-
+	
 	^closureOrNil ifNotNil:
-		[closureOrNil outerContext]
+		[closureOrNil outerContext ifNil: ["if the outer is nil, this is a CleanBlock" self sender]]
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Tests/MethodMapExamples.class.st
+++ b/src/OpalCompiler-Tests/MethodMapExamples.class.st
@@ -15,6 +15,14 @@ MethodMapExamples >> defineCopiedVarBecomeDeadContext [
 ]
 
 { #category : #examples }
+MethodMapExamples >> exampleAccessOuterFromCleanBlock [ 
+	<compilerOptions: #(+ optionCleanBlockClosure)>
+	| b |
+	b := 1. 
+	^[ thisContext tempNamed: 'b' ] value
+]
+
+{ #category : #examples }
 MethodMapExamples >> exampleCopiedVarFromDeadContext [
 	^ self defineCopiedVarBecomeDeadContext value
 ]

--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -95,6 +95,11 @@ MethodMapTest >> testDeadContextSourceNode [
 ]
 
 { #category : #'testing - temp access' }
+MethodMapTest >> testExampleAccessOuterFromCleanBlock [
+	self assert: (self compileAndRunExample: #exampleAccessOuterFromCleanBlock) equals: 1
+]
+
+{ #category : #'testing - temp access' }
 MethodMapTest >> testExampleSimpleTemp [
 	self assert: (self compileAndRunExample: #exampleSimpleTemp) equals: 1
 ]


### PR DESCRIPTION
The debugger needs to be able to access temps that are actually defined in the outerContext (and migh not even exist in the context itself).

For CleanBlocks, we can easily detect the case in Context>>#outerContext (outerContext is nil only in this case).

- implement #outerContext for the clean case
- testExampleAccessOuterFromCleanBlock tests it (example forces clean block comiplation using compiler options pragma)

With this the old Debugger works with Clean Blocks!