### PR TITLE
ReservedVariable-lookupDictionary

### DIFF
--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -40,6 +40,11 @@ LocalVariable >> astNodes [
 	^scope node methodNode variableNodes select: [ :each | each variable == self]
 ]
 
+{ #category : #accessing }
+LocalVariable >> copiedVarClass [
+	^ self subclassResponsibility
+]
+
 { #category : #emitting }
 LocalVariable >> emitStore: methodBuilder [
 

--- a/src/OpalCompiler-Core/OCInstanceScope.class.st
+++ b/src/OpalCompiler-Core/OCInstanceScope.class.st
@@ -18,7 +18,7 @@ OCInstanceScope >> allTemps [
 
 { #category : #lookup }
 OCInstanceScope >> hasBindingThatBeginsWith: aString [
-	"Answer true if true, false or any slot start with aString"
+	"Answer true if a reserved variable or any slot start with aString"
 	
 	(reservedVars hasBindingThatBeginsWith: aString) ifTrue: [ ^true ].
 	(vars hasBindingThatBeginsWith: aString) ifTrue: [ ^true ].
@@ -30,8 +30,7 @@ OCInstanceScope >> hasBindingThatBeginsWith: aString [
 OCInstanceScope >> initialize [
   
 	vars := Dictionary new.
-	reservedVars  := (ReservedVariable subclasses collect: [ :class |
-			class instance name -> class instance]) asDictionary 
+	reservedVars  := ReservedVariable lookupDictionary
 ]
 
 { #category : #acessing }

--- a/src/OpalCompiler-Core/ReservedVariable.class.st
+++ b/src/OpalCompiler-Core/ReservedVariable.class.st
@@ -20,6 +20,13 @@ ReservedVariable class >> isAbstract [
 	^self = ReservedVariable  
 ]
 
+{ #category : #compiler }
+ReservedVariable class >> lookupDictionary [
+	"create a loopup table name -> instance for Semantic Analysis"
+	^ (self subclasses collect: [ :class | 
+		   class instance name -> class instance ]) asDictionary
+]
+
 { #category : #testing }
 ReservedVariable class >> nameIsReserved: aName [
 	^self subclasses anySatisfy: [ :class | class instance name = aName ]


### PR DESCRIPTION
Some trivial cleanups from the compiler backlog:

- implement #lookupDictionary on ReservedVariable class and use it in #initialize of OCInstanceScope
- fix comment hasBindingThatBeginsWith:
- introduc copiedVarClass subclassresponsability