### PR TITLE
OCAbstractMethodScope: remove unused thisContextVar

### DIFF
--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -5,7 +5,6 @@ Class {
 	#name : #OCAbstractMethodScope,
 	#superclass : #OCAbstractScope,
 	#instVars : [
-		'thisContextVar',
 		'tempVars',
 		'copiedVars',
 		'tempVector',


### PR DESCRIPTION
thisContextVar in OCAbstractMethodScope is not needed anymore due to  a prior refactoring. Removing the var can not be done form the image, this this PR removes it by editing the source in GitHub directly.