### PR TITLE
Deprecate-allSendersToStringDo

### DIFF
--- a/src/Deprecated90/SystemNavigation.extension.st
+++ b/src/Deprecated90/SystemNavigation.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #SystemNavigation }
+
+{ #category : #'*Deprecated90' }
+SystemNavigation >> allSendersToString: aString do: aBlock [
+	self 
+		deprecated: 'use allReferencesTo:do: instead'  
+		transformWith: '`@receiver allSendersToString: `@arg1 do: `@arg2' 
+					-> '`@receiver allReferencesTo: `@arg1 do: `@arg2'.
+
+	^ self allReferencesTo: aString asSymbol do: aBlock
+]

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -187,16 +187,6 @@ SystemNavigation >> allSendersOf: selector [
 ]
 
 { #category : #query }
-SystemNavigation >> allSendersToString: aString do: aBlock [
-	"Perform aBlock on all class which send message aString."
-	
-	aString isEmptyOrNil ifTrue: [ ^ self ].
-	aString asSymbol ifNotNil: [ :symbol |
-		self allBehaviorsDo: [ :class | 
-			class withThorougMethodsReferTo: symbol do: aBlock ] ]
-]
-
-{ #category : #query }
 SystemNavigation >> allSentMessages [
 	"Answer the set of selectors which are sent somewhere in the system."
 	| sent |


### PR DESCRIPTION
allSendersToString:do: is the same as allReferencesTo:do: with the argument being a symbol.

We can easily depcrecate it (it has no users as it does not really make sense)