### PR TITLE
hasLiteralSuchThat-do-not-look-into-Pragmas

### DIFF
--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -56,11 +56,9 @@ CompiledCodeTest >> testHasLiteral [
 	"we do not into arrays in Blocks. this is different to hasLiteralSuchThat:"
 	self flag: #FIXME. "LiteralScanningMissmatch"
 	self deny: (method hasLiteral: #arrayInBlock).
-	"pragmas are NOT covered. this is different to hasLiteralSuchThat: "
-	self flag: #FIXME. "LiteralScanningMissmatch"
+	"pragmas are NOT covered."
 	self deny: (method hasLiteral: #pragma:).
-	"args of pragmas not found, too. this is different to hasLiteralSuchThat:"
-	self flag: #FIXME. "LiteralScanningMissmatch"
+	"args of pragmas not found, too."
 	self deny: (method hasLiteral: #pragma).
 	"the method selector NOT"
 	self deny: (method hasLiteral: #method).
@@ -90,10 +88,10 @@ CompiledCodeTest >> testHasLiteralSuchThat [
 	self assert: (method hasLiteralSuchThat: [:literal | literal == #array]).
 	"we look into arrays in Blocks"
 	self assert: (method hasLiteralSuchThat: [:literal | literal == #arrayInBlock]).
-	"pragmas are covered"
-	self assert: (method hasLiteralSuchThat: [:literal | literal == #pragma:]).
-	"args of pragmas are found, too"
-	self assert: (method hasLiteralSuchThat: [:literal | literal == #pragma]).
+	"pragmas are NOT covered"
+	self deny: (method hasLiteralSuchThat: [:literal | literal == #pragma:]).
+	"args of pragmas are NOT found, too"
+	self deny: (method hasLiteralSuchThat: [:literal | literal == #pragma]).
 	"the method selector NOT"
 	self deny: (method hasLiteralSuchThat: [:literal | literal == #method]).
 ]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -454,14 +454,6 @@ CompiledMethod >> hasComment [
 	^self comment isEmptyOrNil not
 ]
 
-{ #category : #literals }
-CompiledMethod >> hasLiteralSuchThat: litBlock [
-	"Answer true if litBlock returns true for any literal in this method, even if embedded in array structure."
-
-	^ (self pragmaHasLiteralSuchThat: litBlock) or: [ 
-		  super hasLiteralSuchThat: litBlock ]
-]
-
 { #category : #'accessing-pragmas & properties' }
 CompiledMethod >> hasPragmaNamed: aSymbol [
 	^ self pragmas anySatisfy: [ :pragma | pragma selector = aSymbol ]
@@ -751,13 +743,6 @@ CompiledMethod >> pragmaAt: aKey [
 	^(propertiesOrSelector := self penultimateLiteral) isMethodProperties
 		ifTrue: [propertiesOrSelector at: aKey ifAbsent: [nil]]
 		ifFalse: [nil]
-]
-
-{ #category : #literals }
-CompiledMethod >> pragmaHasLiteralSuchThat: aBlock [
-
-	^ self penultimateLiteral isMethodProperties and: [ 
-		  self pragmas anySatisfy: [ :pragma | pragma hasLiteralSuchThat: aBlock ] ]
 ]
 
 { #category : #literals }

--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -167,14 +167,6 @@ Pragma >> hasLiteral: aLiteral [
 	   or: [arguments hasLiteral: aLiteral]
 ]
 
-{ #category : #testing }
-Pragma >> hasLiteralSuchThat: aBlock [
-	"Answer true if litBlock returns true for any literal in the receiver, even if embedded in further array structure.
-	 This method is only intended for private use by CompiledMethod hasLiteralSuchThat:"
-	^(aBlock value: self selector)
-	   or: [arguments hasLiteralSuchThat: aBlock]
-]
-
 { #category : #comparing }
 Pragma >> hash [
 


### PR DESCRIPTION
hasLiteral: and hasLiteralSuchThat: are completely out of sync. 

This PR brings them one step closer together: it changes hasLiteralSuchThat: to not look into Pragmas, just as #hasLiteral:
(there is #referesToLiteral: if you want to look into Pragmas, too).

see testHasLiteral and testHasLiteralSuchThat for how they are now more in sync.