### PR TITLE
Prevent the inspector to fail on double click on an item in a collection

### DIFF
--- a/src/GT-InspectorExtensions-Core/SequenceableCollection.extension.st
+++ b/src/GT-InspectorExtensions-Core/SequenceableCollection.extension.st
@@ -14,8 +14,12 @@ SequenceableCollection >> gtInspectorItemsIn: composite [
 			"withSmalltalkSearch;
 		showOnly: 50;
 		helpMessage: 'Quick selection field. Given your INPUT, it executes: self select: [:each | INPUT ]'."
-			result
-				ifNotNil: [ result size = 1
+			result ifNotNil: [ 
+				result isCollection ifTrue: [ 
+					result size = 1
 						ifTrue: [ result anyOne ]
-						ifFalse: [ self species withAll: result ] ] ]
+						ifFalse: [ self species withAll: result ] 
+				] ifFalse: [ result ]
+			]
+		]
 ]


### PR DESCRIPTION
When you double click an item in an inspector with a collection, it causes an error. Prevent it (it does not deeply solve the issue).
```smalltalk
#(1 2 3) inspect
```