### PR TITLE
CompiledMethod-isFaulty

### DIFF
--- a/src/GeneralRules/ReMethodHasSyntaxErrorRule.class.st
+++ b/src/GeneralRules/ReMethodHasSyntaxErrorRule.class.st
@@ -21,7 +21,7 @@ ReMethodHasSyntaxErrorRule class >> uniqueIdentifierName [
 
 { #category : #running }
 ReMethodHasSyntaxErrorRule >> basicCheck: aMethod [
-	^aMethod ast isFaulty
+	^aMethod isFaulty
 ]
 
 { #category : #accessing }

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -469,6 +469,17 @@ CompiledMethodTest >> testIsDeprecated [
 	DeprecatedClassForTest selectorsDo: [ :each | self assert: (DeprecatedClassForTest >> each) isDeprecated ]
 ]
 
+{ #category : #'tests - testing' }
+CompiledMethodTest >> testIsFaulty [
+	|  cm |
+	cm := OpalCompiler new
+				source: 'method 3+';
+				options: #(+ optionParseErrors +optionEmbeddSources);
+				compile.
+	self assert: cm isFaulty.
+	self deny: (OCASTTranslator>>#visitParseErrorNode:) isFaulty
+]
+
 { #category : #'as yet unclassified' }
 CompiledMethodTest >> testIsInstalled [
 |  method cls |

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -572,6 +572,20 @@ CompiledMethod >> isExplicitlyRequired: marker [
 ]
 
 { #category : #testing }
+CompiledMethod >> isFaulty [
+ 	"check if this method was compiled from syntactically wrong code"
+	| ast |
+	"fast pre-check: all methods with syntax errors reference this symbol"
+  	(self refersToLiteral: #signalSyntaxError:) ifFalse: [ ^false].
+	"we have to parse the ast here as #ast does not know that this needs optionParseErrors"
+	ast := self methodClass compiler 
+				source: self sourceCode;
+				options: #(+ optionParseErrors);
+				parse.
+	^ ast isFaulty.
+]
+
+{ #category : #testing }
 CompiledMethod >> isFromTrait [
 	"Return true for methods that have been included from Traits"
 	^ self origin isTrait and: [ self origin ~= self methodClass ]

--- a/src/Kernel/RuntimeSyntaxError.class.st
+++ b/src/Kernel/RuntimeSyntaxError.class.st
@@ -13,7 +13,9 @@ Class {
 }
 
 { #category : #signalling }
-RuntimeSyntaxError class >> signal: aNode [
+RuntimeSyntaxError class >> signalSyntaxError: aNode [
+	"we use signalSyntaxError: instead of signal: so we can quickly check 
+	compiledMethods for syntax errors by checking the literals"
 	^(self new errorNode: aNode) signal
 ]
 

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -629,7 +629,7 @@ OCASTTranslator >> visitParseErrorNode: anErrorNode [
 	methodBuilder 
 		pushLiteralVariable: RuntimeSyntaxError binding;
 		pushLiteral: anErrorNode;
-		send: #signal:
+		send: #signalSyntaxError:
 ]
 
 { #category : #'visitor-double dispatching' }


### PR DESCRIPTION
- add a quick check for #isFaulty for CompiledMethod that does not need to reify the AST.
- use it in ReMethodHasSyntaxErrorRule