### PR TITLE
RPackageSet-no-Ring1

### DIFF
--- a/src/Deprecated90/CompiledMethod.extension.st
+++ b/src/Deprecated90/CompiledMethod.extension.st
@@ -1,0 +1,25 @@
+Extension { #name : #CompiledMethod }
+
+{ #category : #'*Deprecated90' }
+CompiledMethod >> actualClass [
+	self 
+		deprecated: 'use #methodClass'
+		transformWith:  '`@receiver actualClass' -> '`@receiver methodClass'.
+	^self methodClass
+]
+
+{ #category : #'*Deprecated90' }
+CompiledMethod >> classIsMeta [
+	self 
+		deprecated: 'use methodClass isClassSide'
+		transformWith:  '`@receiver classIsMeta' -> '`@receiver methodClass isClassSide'.
+	^self methodClass isClassSide
+]
+
+{ #category : #'*Deprecated90' }
+CompiledMethod >> hasLinks [
+	self 
+		deprecated: 'use #hasMetaLinks'
+		transformWith:  '`@receiver hasLinks' -> '`@receiver hasMetaLinks'.
+	^self hasMetaLinks
+]

--- a/src/Gofer-Core/GoferRecompile.class.st
+++ b/src/Gofer-Core/GoferRecompile.class.st
@@ -16,5 +16,5 @@ GoferRecompile >> execute [
 { #category : #running }
 GoferRecompile >> execute: aWorkingCopy [
 	aWorkingCopy packageSet methods
-		do: [ :each | each actualClass recompile: each selector ]
+		do: [ :each | each methodClass recompile: each selector ]
 ]

--- a/src/Gofer-Core/GoferReinitialize.class.st
+++ b/src/Gofer-Core/GoferReinitialize.class.st
@@ -16,6 +16,6 @@ GoferReinitialize >> execute [
 { #category : #running }
 GoferReinitialize >> execute: aWorkingCopy [
 	aWorkingCopy packageSet methods do: [ :each |
-		(each classIsMeta and: [ each selector = #initialize ])
+		(each methodClass isClassSide and: [ each selector = #initialize ])
 			ifTrue: [ each methodClass instanceSide initialize ] ]
 ]

--- a/src/Gofer-Core/GoferReinitialize.class.st
+++ b/src/Gofer-Core/GoferReinitialize.class.st
@@ -17,5 +17,5 @@ GoferReinitialize >> execute [
 GoferReinitialize >> execute: aWorkingCopy [
 	aWorkingCopy packageSet methods do: [ :each |
 		(each classIsMeta and: [ each selector = #initialize ])
-			ifTrue: [ each actualClass instanceSide initialize ] ]
+			ifTrue: [ each methodClass instanceSide initialize ] ]
 ]

--- a/src/Gofer-Core/GoferUnload.class.st
+++ b/src/Gofer-Core/GoferUnload.class.st
@@ -32,7 +32,7 @@ GoferUnload >> unload: aWorkingCopy [
 { #category : #unloading }
 GoferUnload >> unloadClasses: aWorkingCopy [
 	aWorkingCopy packageSet methods do: [ :each |
-		(each classIsMeta and: [ each selector = #unload ])
+		(each methodClass isClassSide and: [ each selector = #unload ])
 			ifTrue: [ each methodClass instanceSide unload ] ]
 ]
 

--- a/src/Gofer-Core/GoferUnload.class.st
+++ b/src/Gofer-Core/GoferUnload.class.st
@@ -33,7 +33,7 @@ GoferUnload >> unload: aWorkingCopy [
 GoferUnload >> unloadClasses: aWorkingCopy [
 	aWorkingCopy packageSet methods do: [ :each |
 		(each classIsMeta and: [ each selector = #unload ])
-			ifTrue: [ each actualClass instanceSide unload ] ]
+			ifTrue: [ each methodClass instanceSide unload ] ]
 ]
 
 { #category : #unloading }

--- a/src/Monticello-Tests/MCChangeNotificationTest.class.st
+++ b/src/Monticello-Tests/MCChangeNotificationTest.class.st
@@ -50,10 +50,10 @@ MCChangeNotificationTest >> testCoreMethodModified [
 
 { #category : #tests }
 MCChangeNotificationTest >> testExtMethodModified [
-	| event mref |
+	| event method |
 	workingCopy modified: false.
-	mref := workingCopy packageSet extensionMethods first.
-	event := self modifiedEventFor: mref selector ofClass: mref actualClass.
+	method := workingCopy packageSet extensionMethods first.
+	event := self modifiedEventFor: method selector ofClass: method methodClass.
 	MCWorkingCopy methodModified: event.
 	self assert: workingCopy modified
 ]

--- a/src/Monticello-Tests/MCMethodDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCMethodDefinitionTest.class.st
@@ -111,19 +111,19 @@ MCMethodDefinitionTest >> testPartiallyRevertOverrideMethod [
 	self class compile: 'override ^ 2' classified: '*foobarbaz'.
 	self class compile: 'override ^ 3' classified: self mockOverrideMethodCategory.
 	self class compile: 'override ^ 4' classified: self mockOverrideMethodCategory.
-	definition := (RGMethodDefinition realClass: self class selector: #override) asMCMethodDefinition.
+	definition := (self class>>#override) asMCMethodDefinition.
 	self assert: definition isOverrideMethod.
 	self assert: self override equals: 4.
 	definition unload.
 	self assert: self override equals: 2.
-	self assert: (RGMethodDefinition realClass: self class selector: #override) category equals: '*foobarbaz'
+	self assert: (self class>>#override) category equals: '*foobarbaz'
 ]
 
 { #category : #testing }
 MCMethodDefinitionTest >> testRevertOldMethod [
 	| definition changeRecord |
 	Object compile: 'yourself ^ self' classified: '*MonticelloMocks'.
-	definition := (RGMethodDefinition realClass: Object selector: #yourself) asMCMethodDefinition.
+	definition := (Object>>#yourself) asMCMethodDefinition.
 	changeRecord := definition overridenMethodOrNil.
 	self assert: changeRecord notNil.
 	self assert: changeRecord category equals: 'accessing'.
@@ -134,7 +134,7 @@ MCMethodDefinitionTest >> testRevertOldMethod [
 MCMethodDefinitionTest >> testRevertOverrideMethod [
 	| definition |
 	self class compile: 'override ^ 2' classified: self mockOverrideMethodCategory.
-	definition := (RGMethodDefinition realClass: self class selector: #override) asMCMethodDefinition.
+	definition := (self class>>#override) asMCMethodDefinition.
 	self assert: definition isOverrideMethod.
 	self assert: self override equals: 2.
 	definition unload.

--- a/src/Monticello/CompiledMethod.extension.st
+++ b/src/Monticello/CompiledMethod.extension.st
@@ -1,0 +1,48 @@
+Extension { #name : #CompiledMethod }
+
+{ #category : #'*Monticello' }
+CompiledMethod >> asMCMethodDefinition [
+   "Creates a MCMethodDefinition from the receiver"
+	| cached |
+	cached := MCMethodDefinition cachedDefinitions
+		at: self compiledMethod
+		ifAbsent: [ nil ].
+
+	"we compare that the cached version is in sync with the version 
+	the receiver represents because it is an identity structure and the container (here the method definition may have changed internally: different packages, protocol.... )"
+	(cached notNil and: [ self sameAsMCDefinition: cached ]) ifFalse: [
+		cached := self basicAsMCMethodDefinition.
+		MCMethodDefinition cachedDefinitions 
+			at: self compiledMethod 
+			put: cached ].
+
+	^ cached
+]
+
+{ #category : #'*Monticello' }
+CompiledMethod >> basicAsMCMethodDefinition [
+   "Creates a MCMethodDefinition from the receiver"
+   
+		   ^ MCMethodDefinition
+				className: self methodClass instanceSide name
+		 	   	classIsMeta: self methodClass isClassSide
+				selector: self selector
+				category: self protocol
+				timeStamp: self stamp
+				source: self sourceCode 
+]
+
+{ #category : #'*Monticello' }
+CompiledMethod >> sameAsMCDefinition: anMCMethodDefinition [
+	^ anMCMethodDefinition selector = self selector
+		and:
+			[ 
+			anMCMethodDefinition className = self className
+				and:
+					[ 
+					anMCMethodDefinition classIsMeta = self methodClass isClassSide
+						and:
+							[ 
+							anMCMethodDefinition category = self protocol
+								and: [ anMCMethodDefinition source = self sourceCode ] ] ] ]
+]

--- a/src/Monticello/CompiledMethod.extension.st
+++ b/src/Monticello/CompiledMethod.extension.st
@@ -5,7 +5,7 @@ CompiledMethod >> asMCMethodDefinition [
    "Creates a MCMethodDefinition from the receiver"
 	| cached |
 	cached := MCMethodDefinition cachedDefinitions
-		at: self compiledMethod
+		at: self
 		ifAbsent: [ nil ].
 
 	"we compare that the cached version is in sync with the version 
@@ -13,7 +13,7 @@ CompiledMethod >> asMCMethodDefinition [
 	(cached notNil and: [ self sameAsMCDefinition: cached ]) ifFalse: [
 		cached := self basicAsMCMethodDefinition.
 		MCMethodDefinition cachedDefinitions 
-			at: self compiledMethod 
+			at: self 
 			put: cached ].
 
 	^ cached
@@ -21,15 +21,16 @@ CompiledMethod >> asMCMethodDefinition [
 
 { #category : #'*Monticello' }
 CompiledMethod >> basicAsMCMethodDefinition [
-   "Creates a MCMethodDefinition from the receiver"
-   
-		   ^ MCMethodDefinition
-				className: self methodClass instanceSide name
-		 	   	classIsMeta: self methodClass isClassSide
-				selector: self selector
-				category: self protocol
-				timeStamp: self stamp
-				source: self sourceCode 
+
+	"Creates a MCMethodDefinition from the receiver"
+
+	^ MCMethodDefinition
+		  className: self methodClass instanceSide name
+		  classIsMeta: self methodClass isClassSide
+		  selector: self selector
+		  category: self protocol
+		  timeStamp: self stamp
+		  source: self sourceCode
 ]
 
 { #category : #'*Monticello' }

--- a/src/RPackage-Core/RPackageSet.class.st
+++ b/src/RPackage-Core/RPackageSet.class.st
@@ -121,7 +121,7 @@ RPackageSet >> extensionCategoriesForClass: aClass [
 RPackageSet >> extensionMethods [
 	^ extensionMethods ifNil: [
 		extensionMethods :=
-		((self packages flatCollect: [ :p | p extensionMethods ] as: Set) collect: [:each | each asRingDefinition]) asArray ]
+		(self packages flatCollect: [ :p | p extensionMethods ] as: Set) asArray ]
 ]
 
 { #category : #testing }
@@ -169,7 +169,7 @@ RPackageSet >> methodCategoryPrefix [
 
 { #category : #accessing }
 RPackageSet >> methods [
-	^ methods ifNil: [ methods := (self packages flatCollect: [ :p | p methods ]) collect: [:each | each asRingDefinition] ]
+	^ methods ifNil: [ methods := (self packages flatCollect: [ :p | p methods ]) ]
 ]
 
 { #category : #accessing }

--- a/src/Reflectivity/CompiledMethod.extension.st
+++ b/src/Reflectivity/CompiledMethod.extension.st
@@ -33,14 +33,6 @@ CompiledMethod >> hasBreakpoint [
 ]
 
 { #category : #'*Reflectivity' }
-CompiledMethod >> hasLinks [
-	self 
-		deprecated: 'use #hasMetaLinks'
-		transformWith:  '`@receiver hasLinks' -> '`@receiver hasMetaLinks'.
-	^self hasMetaLinks
-]
-
-{ #category : #'*Reflectivity' }
 CompiledMethod >> hasMetaLinks [
 	self reflectiveMethod ifNil: [ ^false ].
 	^self reflectiveMethod hasMetaLinks. 

--- a/src/Tool-DependencyAnalyser/DAPackageRelationGraph.class.st
+++ b/src/Tool-DependencyAnalyser/DAPackageRelationGraph.class.st
@@ -40,12 +40,12 @@ DAPackageRelationGraph class >> onPackagesNamed: packageNames [
 DAPackageRelationGraph >> addExtensionDependencies: aPDPackage [	
 	aPDPackage rPackageSet extensionMethods
 		do: [ :method | | packageOfExtendedClass |
-			packageOfExtendedClass := self packageForBehavior: method actualClass.
+			packageOfExtendedClass := self packageForBehavior: method methodClass.
 			self addPackage: packageOfExtendedClass.
 			aPDPackage
 				add:
 					((DAExtensionDependency from: aPDPackage to: packageOfExtendedClass)
-						theClass: method actualClass;
+						theClass: method methodClass;
 						selector: method selector asSymbol;
 						method: method).
 			 ]
@@ -288,7 +288,7 @@ DAPackageRelationGraph >> findReferencesIn: aMethod for: aPackage [
 							aPackage
 								add:
 									((DAReferenceDependency from: aPackage to: package)
-										theClass: aMethod actualClass;
+										theClass: aMethod methodClass;
 										selector: aMethod method selector asSymbol;
 										reference: literal value;
 										method: aMethod;


### PR DESCRIPTION
- implement #asMCMethodDefinition on CompiledMethod
- test it in MCMethodDefinitionTest
- change RPackageSet to not use Ring Methods, as clients can now call asMCMethodDefinition on the compiledMethods