### PR TITLE
7200-Keyboard-Input-events-are-lost-after-clicking-in-the-world

### DIFF
--- a/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
+++ b/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
@@ -279,7 +279,7 @@ OSWindowMorphicEventHandler >> visitMouseButtonReleaseEvent: anEvent [
 		setType: #mouseUp
 		position: anEvent position 
 		which: (self convertButtonFromEvent: anEvent)
-		buttons: (self convertModifiers: anEvent modifiers) | (self convertButtonFromEvent: anEvent)
+		buttons: (self convertModifiers: anEvent modifiers)
 		hand: self activeHand
 		stamp: Time millisecondClockValue
 ]


### PR DESCRIPTION
The mouse up morphic event should not have the configured mouse button in buttons.

Having it, prevents the correct handling of keyboard input events (?)