### PR TITLE
TestCase-use-classCommentBlank

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -263,7 +263,7 @@ ClassDescription >> classCommentBlank [
 	"Classes can override this method to show another template."
 	"There are two use cases: a class hierarchy can give information about what kind of comment is 
 	useful (see 'PackageManifest class'). If in addition, '#hasComment ^true' can be implemented in 
-	cases where the class does not need a dedeciated comment. See 'TestCase class'for an example"
+	cases where the class does not need a dedicated comment. See 'TestCase class'for an example"
 
 	| stream |
 	stream := (String new: 100) writeStream.
@@ -285,17 +285,17 @@ Public API and Key Messages
  
 Internal Representation and Key Implementation Points.'.
 			
-	(self instanceVariables isEmpty)
+	(self instanceVariables isNotEmpty)
 		 ifTrue: [stream cr; cr; nextPutAll: '    Instance Variables'.  ].
 		
-	self instVarNames asSortedCollection do: [:each |
+	self instVarNames sorted do: [:each |
 		stream
 			cr; tab; nextPutAll: each;
 			nextPut: $:;
 			tab; tab;
 			nextPutAll: '<Object>'].
 	stream cr.
-stream cr; cr; nextPutAll: '    Implementation Points'.
+	stream cr; cr; nextPutAll: '    Implementation Points'.
 	^stream contents
 ]
 

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -260,6 +260,10 @@ ClassDescription >> classComment: aString stamp: aStamp [
 
 { #category : #'accessing comment' }
 ClassDescription >> classCommentBlank [
+	"Classes can override this method to show another template."
+	"There are two use cases: a class hierarchy can give information about what kind of comment is 
+	useful (see 'PackageManifest class'). If in addition, '#hasComment ^true' can be implemented in 
+	cases where the class does not need a dedeciated comment. See 'TestCase class'for an example"
 
 	| stream |
 	stream := (String new: 100) writeStream.
@@ -281,7 +285,7 @@ Public API and Key Messages
  
 Internal Representation and Key Implementation Points.'.
 			
-	(self instVarNames size > 0)
+	(self instanceVariables isEmpty)
 		 ifTrue: [stream cr; cr; nextPutAll: '    Instance Variables'.  ].
 		
 	self instVarNames asSortedCollection do: [:each |

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -120,10 +120,8 @@ TestCase class >> buildSuiteFromSelectors [
 ]
 
 { #category : #'accessing comment' }
-TestCase class >> comment [
-	^super hasComment
-		ifTrue: [ super comment ] 
-		ifFalse: ['This class contains tests'].
+TestCase class >> classCommentBlank [
+	^'This class contains tests'
 ]
 
 { #category : #coverage }


### PR DESCRIPTION
unify the mechanism used in two class hierarchies that change the comment.
 We had one class overriding #classCommentBlank, and TestCase overriding #comment.
-> use classCommentBlank and document the mechanism