### PR TITLE
ClassOrganization-does-not-need-commentStamp

### DIFF
--- a/src/CodeExport/ClassOrganization.extension.st
+++ b/src/CodeExport/ClassOrganization.extension.st
@@ -21,8 +21,7 @@ ClassOrganization >> putCommentOnFile: aFileStream forClass: aClass [
 	header := String streamContents: [:strm | 
 			strm nextPutAll: aClass name;
 			nextPutAll: ' commentStamp: '.
-			commentStamp ifNil: [commentStamp := '<historical>'].
-			commentStamp storeOn: strm.
+			self commentStamp storeOn: strm.
 			strm nextPutAll: ' prior: '; nextPutAll: '0'].
 	aFileStream nextChunkPut: header.
 	aClass organization fileOutCommentOn: aFileStream.

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -224,7 +224,7 @@ ClassDescription >> classComment: aString stamp: aStamp [
 			newComment: aString string 
 			oldStamp: oldStamp 
 			newStamp: aStamp.
-		^ self organization classComment: aString stamp: aStamp].
+		^ self organization classComment: aString].
 
 	oldCommentRemoteString := self organization commentRemoteString.
 	pointer := oldCommentRemoteString 
@@ -246,8 +246,7 @@ ClassDescription >> classComment: aString stamp: aStamp [
 		preamble: preamble
 		onSuccess: [ :newSourcePointer | 
 			self organization 
-				classComment: (SourceFiles remoteStringAt: newSourcePointer) 
-				stamp: aStamp ]
+				classComment: (SourceFiles remoteStringAt: newSourcePointer) ]
 		onFail: [ "ignore" ].
 	
 	SystemAnnouncer uniqueInstance 
@@ -375,7 +374,8 @@ ClassDescription >> comment: aStringOrText stamp: aStamp [
 
 { #category : #'file in/out' }
 ClassDescription >> commentStamp: changeStamp [
-	self organization commentStamp: changeStamp
+	"update the changeStamp"
+	self comment: self organization comment stamp: changeStamp
 ]
 
 { #category : #compiling }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -1,12 +1,10 @@
 "
-This object is in charge of system notifications.
-It manages the class comment, the class comment stamp and a protocol organizer
+This class manages the class comment and a protocol organizer
 "
 Class {
 	#name : #ClassOrganization,
 	#superclass : #Object,
 	#instVars : [
-		'commentStamp',
 		'protocolOrganizer',
 		'organizedClass',
 		'commentRemoteString'
@@ -102,14 +100,6 @@ ClassOrganization >> classComment: aString [
 ]
 
 { #category : #'backward compatibility' }
-ClassOrganization >> classComment: aString stamp: aStamp [
-
-	self
-		comment: aString;
-		commentStamp: aStamp
-]
-
-{ #category : #'backward compatibility' }
 ClassOrganization >> classify: aSymbol under: aProtocolName [
 
 	^ self 
@@ -171,18 +161,15 @@ ClassOrganization >> commentRemoteString [
 
 { #category : #accessing }
 ClassOrganization >> commentStamp [
-	^ commentStamp
-]
 
-{ #category : #accessing }
-ClassOrganization >> commentStamp: anObject [
-	commentStamp := anObject
+	^ self commentRemoteString
+		  ifNil: [ '' ]
+		  ifNotNil: [ :remoteString | SourceFiles commentTimeStampAt: remoteString sourcePointer ]
 ]
 
 { #category : #copying }
 ClassOrganization >> copyFrom: otherOrganization [
 	commentRemoteString := otherOrganization commentRemoteString.
-	commentStamp := otherOrganization commentStamp.
 	otherOrganization protocols do: [ :p | p methodSelectors do: [ :m | protocolOrganizer classify: m inProtocolNamed: p name ] ]
 ]
 

--- a/src/Slot-Tests/SlotAnnouncementsTest.class.st
+++ b/src/Slot-Tests/SlotAnnouncementsTest.class.st
@@ -204,7 +204,7 @@ SlotAnnouncementsTest >> testCreateAndChangeWithCommentDoesAnnounceBoth [
 	self assert: classCommented classCommented equals: aClass.
 	self assert: classCommented oldComment equals: ''.
 	self assert: classCommented newComment equals: 'A class Comment'.
-	self assert: classCommented oldStamp equals: nil. "why nil?" 
+	self assert: classCommented oldStamp equals: ''.
 	self assert: classCommented newStamp equals: nil. "why nil?"
 	
 	classCommented := self collectedAnnouncements second.
@@ -248,7 +248,7 @@ SlotAnnouncementsTest >> testCreateWithCommentDoesAnnounce [
 	self assert: classCommented classCommented equals: aClass.
 	self assert: classCommented oldComment equals: ''.
 	self assert: classCommented newComment equals: 'A class Comment'.
-	self assert: classCommented oldStamp equals: nil. "why nil?" 
+	self assert: classCommented oldStamp equals: ''.
 	self assert: classCommented newStamp equals: nil  "why nil?"
 ]
 

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -1,7 +1,7 @@
 "
 This is a variation on StandardSourceFileArray that provides a larger maximum changes file size.
 
-The available address space for source pointers in a traditional CompiledMethod is 16r1000000 through 16r4FFFFFF. StandardSourceFileArray maps positions in the sources file to address range 16r1000000 through 16r1FFFFFF and 16r3000000 through 16r3FFFFFF, and positions in the changes file to address range 16r2000000 through 16r2FFFFFF and 16r4000000 through 16r4FFFFFF. This permits a maximum file size of 16r2000000 (32MB) for both the sources file and the changes file. 
+The available address space for source pointers in a traditional CompiledMethod is 16r1000000 through 16r4FFFFFF. StandardSourceFileArray maps positions in the sources file to address range 16r1000000 through 16r1FFFFFF and 16r3000000 through 16r3FFFFFF, and positions in the changes file to address range 16r2000000 through 16r2FFFFFF and 16r4000000 through 16r4FFFFFF. This permits a maximum file size of 16r2000000 (32MB) for both the sources file and the changes file.
 
 This implementation extends the source pointer address space using bit 25 of the source pointer to identify the external sources and changes files, with the remaining high order bits treated as address extension. This limits the number of external file references to two (the traditional sources and changes files). If additional external file references are needed in the future, some higher order bits in the source pointer address space should be allocated for that purpose.
 
@@ -75,6 +75,17 @@ SourceFileArray >> closeFileArray: anArray [
 		thenDo: [ :file | file close ].
 		
 	^ anArray
+]
+
+{ #category : #private }
+SourceFileArray >> commentDataPointers [
+	"Retrieves the combination key to look for comments in the source file"
+	^'commentStamp:' -> #commentStamp:
+]
+
+{ #category : #'public - string reading' }
+SourceFileArray >> commentTimeStampAt: sourcePointer [
+	^self timeStampAt: sourcePointer for: self commentDataPointers
 ]
 
 { #category : #private }


### PR DESCRIPTION
ClassOrganization has both an ivar for commentStamp and one for commentRemoteString.

We can easily read the commentStamp from the .sources/.changes via the commentRemoteString. 

This is good because
- we remove one ivar from "numberofClasses * 2" objects
- we do not store the stamp string in the image 

this in addition simplfies the related code and will allow for more cleanups later