### PR TITLE
7208-sharePools-is-defined-in-Class-but-called-from-superclass

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -892,13 +892,6 @@ Behavior >> includesSelector: aSymbol [
 	^ self methodDict includesKey: aSymbol
 ]
 
-{ #category : #'accessing instances and variables' }
-Behavior >> includesSharedPoolNamed:  aSharedPoolString [ 
-	"Answer whether the receiver uses the shared pool named aSharedPoolString"
-	
-	^ (self sharedPools anySatisfy: [:each | each name = aSharedPoolString])
-]
-
 { #category : #'testing class hierarchy' }
 Behavior >> inheritsFrom: aClass [ 
 	"Answer whether the argument, aClass, is on the receiver's superclass 

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -473,6 +473,113 @@ Class >> definesClassVariableNamed: aString [
 	^ self classVarNames includes: aString
 ]
 
+{ #category : #'file in/out' }
+Class >> definitionWithSlots [
+	"The class definition with a way to specify slots. Shown when the class defines special Slot"
+	
+	| stream poolString|
+	poolString := self sharedPoolsString.
+
+	stream := (String new: 800) writeStream.
+	superclass 
+		ifNotNil: [stream nextPutAll: superclass name]
+		ifNil: [stream nextPutAll: 'ProtoObject'].
+	stream 
+		nextPutAll: ' subclass: '; 
+		store: self name.
+	self hasTraitComposition ifTrue: [
+		stream 
+			crtab; 
+			nextPutAll: 'uses: ';
+			nextPutAll: self traitCompositionString ].
+			
+	self classLayout isFixedLayout ifFalse: [
+		stream 
+			crtab; 
+			nextPutAll: 'layout: ';
+			nextPutAll: self classLayout class name ].
+	
+	stream 
+		crtab; 
+		nextPutAll: 'slots: ';
+		nextPutAll: self slotDefinitionString.
+		
+	stream 
+		crtab; 
+		nextPutAll: 'classVariables: ';
+		nextPutAll: self classVariableDefinitionString.
+	
+	poolString = '' ifFalse: [
+		stream 
+			crtab; 
+			nextPutAll: 'poolDictionaries: ';
+			store: poolString ].
+		
+	stream 
+		crtab; 
+		nextPutAll: 'package: ';
+		store: self category asString.
+
+	superclass ifNil: [ 
+		stream nextPutAll: '.'; cr.
+		stream nextPutAll: self name.
+		stream space; nextPutAll: 'superclass: nil'. ].
+
+	^ stream contents
+]
+
+{ #category : #'file in/out' }
+Class >> definitionWithoutSlots [
+
+	| poolString stream |
+	poolString := self sharedPoolsString.
+	stream := (String new: 800) writeStream.
+	superclass
+		ifNotNil: [ stream nextPutAll: superclass name ]
+		ifNil: [ stream nextPutAll: 'ProtoObject' ].
+	
+	stream
+		nextPutAll: self kindOfSubclass;
+		store: self name.
+	self hasTraitComposition ifTrue: [ 
+		stream
+			crtab;
+			nextPutAll: 'uses: ';
+			nextPutAll: self traitCompositionString ].
+	stream
+		crtab;
+		nextPutAll: 'instanceVariableNames: ';
+		store: self instanceVariablesString.
+	stream
+		crtab;
+		nextPutAll: 'classVariableNames: ';
+		store: self classVariablesString.
+	
+	poolString = '' ifFalse: [ 
+		stream 
+			crtab;
+			nextPutAll: 'poolDictionaries: ';
+			store: poolString ].
+	
+	stream
+		crtab;
+		nextPutAll: 'package: ';
+		store: self category asString.
+		
+	superclass ifNil: [ 
+		stream
+			nextPutAll: '.';
+			cr.
+		stream 
+			nextPutAll: self name.
+		stream
+			space;
+			nextPutAll: 'superclass: nil' ].
+
+	^ stream contents
+	
+]
+
 { #category : #deprecation }
 Class >> deprecationRefactorings [
 
@@ -778,6 +885,37 @@ Class >> obsolete [
 	self hasClassSide ifTrue: [ self classSide obsolete].
 	self propertyAt: #obsolete put: true.
 	super obsolete.
+]
+
+{ #category : #'file in/out' }
+Class >> oldDefinition [
+	"Answer a String that defines the receiver."
+
+	| aStream |
+	aStream := (String new: 800) writeStream.
+	superclass 
+		ifNil: [aStream nextPutAll: 'ProtoObject']
+		ifNotNil: [aStream nextPutAll: superclass name].
+	aStream nextPutAll: self kindOfSubclass;
+			store: self name.
+	(self hasTraitComposition) ifTrue: [
+		aStream cr; tab; nextPutAll: 'uses: ';
+			nextPutAll: self traitCompositionString].
+	aStream cr; tab; nextPutAll: 'instanceVariableNames: ';
+			store: self instanceVariablesString.
+	aStream cr; tab; nextPutAll: 'classVariableNames: ';
+			store: self classVariablesString.
+	aStream cr; tab; nextPutAll: 'poolDictionaries: ';
+			store: self sharedPoolsString.
+	aStream cr; tab; nextPutAll: 'category: ';
+			store: self category asString.
+
+	superclass ifNil: [ 
+		aStream nextPutAll: '.'; cr.
+		aStream nextPutAll: self name.
+		aStream space; nextPutAll: 'superclass: nil'. ].
+
+	^ aStream contents
 ]
 
 { #category : #compiling }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -586,113 +586,6 @@ ClassDescription >> definition [
 	
 ]
 
-{ #category : #'file in/out' }
-ClassDescription >> definitionWithSlots [
-	"The class definition with a way to specify slots. Shown when the class defines special Slot"
-	
-	| stream poolString|
-	poolString := self sharedPoolsString.
-
-	stream := (String new: 800) writeStream.
-	superclass 
-		ifNotNil: [stream nextPutAll: superclass name]
-		ifNil: [stream nextPutAll: 'ProtoObject'].
-	stream 
-		nextPutAll: ' subclass: '; 
-		store: self name.
-	self hasTraitComposition ifTrue: [
-		stream 
-			crtab; 
-			nextPutAll: 'uses: ';
-			nextPutAll: self traitCompositionString ].
-			
-	self classLayout isFixedLayout ifFalse: [
-		stream 
-			crtab; 
-			nextPutAll: 'layout: ';
-			nextPutAll: self classLayout class name ].
-	
-	stream 
-		crtab; 
-		nextPutAll: 'slots: ';
-		nextPutAll: self slotDefinitionString.
-		
-	stream 
-		crtab; 
-		nextPutAll: 'classVariables: ';
-		nextPutAll: self classVariableDefinitionString.
-	
-	poolString = '' ifFalse: [
-		stream 
-			crtab; 
-			nextPutAll: 'poolDictionaries: ';
-			store: poolString ].
-		
-	stream 
-		crtab; 
-		nextPutAll: 'package: ';
-		store: self category asString.
-
-	superclass ifNil: [ 
-		stream nextPutAll: '.'; cr.
-		stream nextPutAll: self name.
-		stream space; nextPutAll: 'superclass: nil'. ].
-
-	^ stream contents
-]
-
-{ #category : #'file in/out' }
-ClassDescription >> definitionWithoutSlots [
-
-	| poolString stream |
-	poolString := self sharedPoolsString.
-	stream := (String new: 800) writeStream.
-	superclass
-		ifNotNil: [ stream nextPutAll: superclass name ]
-		ifNil: [ stream nextPutAll: 'ProtoObject' ].
-	
-	stream
-		nextPutAll: self kindOfSubclass;
-		store: self name.
-	self hasTraitComposition ifTrue: [ 
-		stream
-			crtab;
-			nextPutAll: 'uses: ';
-			nextPutAll: self traitCompositionString ].
-	stream
-		crtab;
-		nextPutAll: 'instanceVariableNames: ';
-		store: self instanceVariablesString.
-	stream
-		crtab;
-		nextPutAll: 'classVariableNames: ';
-		store: self classVariablesString.
-	
-	poolString = '' ifFalse: [ 
-		stream 
-			crtab;
-			nextPutAll: 'poolDictionaries: ';
-			store: poolString ].
-	
-	stream
-		crtab;
-		nextPutAll: 'package: ';
-		store: self category asString.
-		
-	superclass ifNil: [ 
-		stream
-			nextPutAll: '.';
-			cr.
-		stream 
-			nextPutAll: self name.
-		stream
-			space;
-			nextPutAll: 'superclass: nil' ].
-
-	^ stream contents
-	
-]
-
 { #category : #private }
 ClassDescription >> errorCategoryName [
 	self error: 'Category name must be a String'
@@ -749,6 +642,13 @@ ClassDescription >> hasSlotNamed: aString [
 	this includes non-visible slots"
 	
 	^ self classLayout hasSlotNamed: aString
+]
+
+{ #category : #'pool variable' }
+ClassDescription >> includesSharedPoolNamed:  aSharedPoolString [ 
+	"Answer whether the receiver uses the shared pool named aSharedPoolString"
+	
+	^ self sharedPools anySatisfy: [:each | each name = aSharedPoolString]
 ]
 
 { #category : #'instance variables' }
@@ -1007,37 +907,6 @@ ClassDescription >> obsolete [
 	super obsolete.
 ]
 
-{ #category : #'file in/out' }
-ClassDescription >> oldDefinition [
-	"Answer a String that defines the receiver."
-
-	| aStream |
-	aStream := (String new: 800) writeStream.
-	superclass 
-		ifNil: [aStream nextPutAll: 'ProtoObject']
-		ifNotNil: [aStream nextPutAll: superclass name].
-	aStream nextPutAll: self kindOfSubclass;
-			store: self name.
-	(self hasTraitComposition) ifTrue: [
-		aStream cr; tab; nextPutAll: 'uses: ';
-			nextPutAll: self traitCompositionString].
-	aStream cr; tab; nextPutAll: 'instanceVariableNames: ';
-			store: self instanceVariablesString.
-	aStream cr; tab; nextPutAll: 'classVariableNames: ';
-			store: self classVariablesString.
-	aStream cr; tab; nextPutAll: 'poolDictionaries: ';
-			store: self sharedPoolsString.
-	aStream cr; tab; nextPutAll: 'category: ';
-			store: self category asString.
-
-	superclass ifNil: [ 
-		aStream nextPutAll: '.'; cr.
-		aStream nextPutAll: self name.
-		aStream space; nextPutAll: 'superclass: nil'. ].
-
-	^ aStream contents
-]
-
 { #category : #organization }
 ClassDescription >> organization [
 	"Answer the instance of ClassOrganizer that represents the organization 
@@ -1151,7 +1020,12 @@ ClassDescription >> sharedPoolOfVarNamed: aString [
 	^ nil
 ]
 
-{ #category : #printing }
+{ #category : #'pool variable' }
+ClassDescription >> sharedPools [
+	^ OrderedCollection new
+]
+
+{ #category : #'pool variable' }
 ClassDescription >> sharedPoolsString [
 	"Answer a string of my shared pool names separated by spaces."
 


### PR DESCRIPTION
This is a first step to clean it up

- move includesSharedPoolNamed: from behavior to ClassDescription
- move all the definition methods to Class (they have their own version in Metaclass already)
  These where the methods that send e.g.  sharedPoolsString in ClassDescription even though pools are only defined in Class
- add #sharedPool to ClassDescription for sharedPoolsString
- recategorize sharedPoolsString

We should check what the API for pools should be on Metaclass... I think we should move all the API to Class, but I am not sure.

This PR is a good first step for both directions and it should not introduce any backward compatibility problems.