### PR TITLE
TextAction-do-not-share-block

### DIFF
--- a/src/Text-Core/TextAction.class.st
+++ b/src/Text-Core/TextAction.class.st
@@ -48,7 +48,8 @@ TextAction class >> actOnClickBlock: aBlock [
 
 { #category : #'class initialization' }
 TextAction class >> initialize [
-	ActOnClickBlock := [ ]
+	"nil value and [] value are both nil, but sharing a block would hold on to its outer method"
+	ActOnClickBlock := nil
 ]
 
 { #category : #evaluating }


### PR DESCRIPTION
Issue  #7059 shows that TextAction class #intialize can not be GCed after recompiling the methods, as shown by this code:

CompiledMethod allInstances 
	select: [ :each | 
		[ each methodClass >> each selector ~~ each ] 
			on: Error
			do: [ :ex | ex return: true ] ]
		
The reason is that the [] is referenced by all instances, which in turn references the method. 

Solution: use nil, as "nil value" and [] value are both nil.