### PR TITLE
Pragma: cache Pragmas in the Pragma class

### DIFF
--- a/src/Kernel-Tests/PragmaTest.class.st
+++ b/src/Kernel-Tests/PragmaTest.class.st
@@ -29,6 +29,11 @@ PragmaTest >> setUp [
 
 ]
 
+{ #category : #'tests - cache' }
+PragmaTest >> testAllNamed [
+	self assert: ((Pragma allNamed: #primitive:) first selector) equals: #primitive:
+]
+
 { #category : #tests }
 PragmaTest >> testArgumentAt [
 	| pragma |
@@ -87,4 +92,9 @@ PragmaTest >> testHash [
 	self assert: atPragma hash equals: anotherAtPragma hash.
 	self assert: anotherAtPragma hash equals: yetAnotherAtPragma hash.
 	self assert: yetAnotherAtPragma hash equals: atPragma hash
+]
+
+{ #category : #'tests - cache' }
+PragmaTest >> testallInstalled [
+	self assert: ((Pragma allInstalled) first class ) equals: Pragma
 ]

--- a/src/Kernel-Tests/PragmaTest.class.st
+++ b/src/Kernel-Tests/PragmaTest.class.st
@@ -31,7 +31,9 @@ PragmaTest >> setUp [
 
 { #category : #'tests - cache' }
 PragmaTest >> testAllNamed [
-	self assert: ((Pragma allNamed: #primitive:) first selector) equals: #primitive:
+	self assert: ((Pragma allNamed: #primitive:) first selector) equals: #primitive:.
+	"does it work when asking for a non existing Pragma?"
+	self assert: (Pragma allNamed: #nonExistingPragma) isEmpty
 ]
 
 { #category : #tests }
@@ -96,5 +98,5 @@ PragmaTest >> testHash [
 
 { #category : #'tests - cache' }
 PragmaTest >> testallInstalled [
-	self assert: ((Pragma allInstalled) first class ) equals: Pragma
+	self assert: Pragma allInstalled first class equals: Pragma
 ]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -331,6 +331,12 @@ CompiledMethod >> argumentNames [
 	^ self propertyAt: #argumentNames ifAbsent: [ super argumentNames ]
 ]
 
+{ #category : #'accessing-pragmas & properties' }
+CompiledMethod >> cachePragmas [
+
+	self pragmas do: [ :pragma | pragma class addToCache: pragma ]
+]
+
 { #category : #'accessing-backward compatible' }
 CompiledMethod >> category [
 	"Please favor protocol instead of category. We want to have method protocol and class package and tag = a category"

--- a/src/Kernel/MethodDictionary.class.st
+++ b/src/Kernel/MethodDictionary.class.st
@@ -130,6 +130,7 @@ MethodDictionary >> at: key put: value [
 	array at: index put: value.
 	key flushCache. "flush the vm cache by selector"
 	self fullCheck.
+	value cachePragmas.
 	^ value
 ]
 

--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -20,8 +20,41 @@ Class {
 		'arguments',
 		'selector'
 	],
+	#classInstVars : [
+		'pragmaCache'
+	],
 	#category : #'Kernel-Pragmas'
 }
+
+{ #category : #cache }
+Pragma class >> addToCache: aPragma [
+	"when a method is added to a class, the Pragma is added the cache"
+	self pragmaCache
+		at: aPragma selector
+		ifAbsentPut: [ WeakIdentitySet new ].
+	(self pragmaCache at: aPragma selector) add: aPragma
+]
+
+{ #category : #cache }
+Pragma class >> allInstalled [
+	"all pragmas whose methods are currently installed in the system"
+	^ self pragmaCache values flattened select: [ :each | 
+		  each method isInstalled ]
+]
+
+{ #category : #cache }
+Pragma class >> allNamed: aSymbol [
+
+	"Answer a collection of all pragmas whose selector is aSymbol."
+
+	| pragmas |
+	pragmas := self pragmaCache at: aSymbol ifAbsent: [ ^ #(  ) ].
+	"if there are none, we can remove the entry in the cache"
+	pragmas ifEmpty: [ self pragmaCache removeKey: aSymbol ifAbsent: [  ] ].
+	"we check if the pragma is really from an installed method 
+	(others will be cleaned up by the gc when the method is garbadge collected)"
+	^ (pragmas select: [ :each | each method isInstalled ]) asArray
+]
 
 { #category : #finding }
 Pragma class >> allNamed: aSymbol from: aSubClass to: aSuperClass [
@@ -85,6 +118,12 @@ Pragma class >> for: aMethod selector: aSelector arguments: anArray [
 		selector: aSelector;
 		arguments: anArray;
 		yourself
+]
+
+{ #category : #cache }
+Pragma class >> pragmaCache [
+
+	^ pragmaCache ifNil: [ pragmaCache := Dictionary new ]
 ]
 
 { #category : #private }

--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -28,7 +28,7 @@ Class {
 
 { #category : #cache }
 Pragma class >> addToCache: aPragma [
-	"when a method is added to a class, the Pragma is added the cache"
+	"when a method is added to a class, the Pragma is added to the cache"
 	self pragmaCache
 		at: aPragma selector
 		ifAbsentPut: [ WeakIdentitySet new ].
@@ -42,7 +42,7 @@ Pragma class >> allInstalled [
 		  each method isInstalled ]
 ]
 
-{ #category : #cache }
+{ #category : #finding }
 Pragma class >> allNamed: aSymbol [
 
 	"Answer a collection of all pragmas whose selector is aSymbol."

--- a/src/Tests/AbstractObjectsAsMethod.class.st
+++ b/src/Tests/AbstractObjectsAsMethod.class.st
@@ -5,6 +5,10 @@ Class {
 }
 
 { #category : #compatibility }
+AbstractObjectsAsMethod >> cachePragmas [
+]
+
+{ #category : #compatibility }
 AbstractObjectsAsMethod >> flushCache [
 ]
 


### PR DESCRIPTION
This is a first idea how to cache pragmas
-> Pragma class has a Dictionary with one entry per selector 
-> It references the Pragmas weakly

CompiledMethods add their pragmas to the cache when they are added in a class.

Speed to get all pragmas:

[Pragma allInstalled] bench "'799.320 per second'".
[PragmaCollector allSystemPragmas] bench  "'54.923 per second'"

But it will now grow with the number of pragmas, not number of methods.

Pragma allNamed: aSymbol can replace the use of the PragmaCollector in many cases (to be explored)

This PR just adds the Cache and tests, it is not yet used. The next step is to test it a bit, compare it with #allSystemPragmas and
the implement allSystemPragmas to use the cache.