### PR TITLE
ClassOrganization: store sourcePointer, not RemoteString instances

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -211,25 +211,14 @@ ClassDescription >> classComment: aString [
 ClassDescription >> classComment: aString stamp: aStamp [
 	"Store the comment, aString or Text or RemoteString, associated with the class we are organizing.  Empty string gets stored only if had a non-empty one before."
 
-	| pointer header oldCommentRemoteString oldComment oldStamp preamble |
+	| pointer header oldComment oldStamp preamble |
 	oldComment := self organization classComment.
 	oldStamp := self organization commentStamp.
 
 	aString string = oldComment string ifTrue: [ ^ self ].
 
-	aString isRemoteString ifTrue: [
-		SystemAnnouncer uniqueInstance 
-			class: self 
-			oldComment: oldComment 
-			newComment: aString string 
-			oldStamp: oldStamp 
-			newStamp: aStamp.
-		^ self organization classComment: aString].
-
-	oldCommentRemoteString := self organization commentRemoteString.
-	pointer := oldCommentRemoteString 
-			ifNil: [0] 
-			ifNotNil: [oldCommentRemoteString sourcePointer].
+	pointer := self organization commentSourcePointer ifNil: [0]. 
+		
 	
 	preamble := String streamContents: [ :file |
 		file cr; nextPut: $!.
@@ -246,7 +235,7 @@ ClassDescription >> classComment: aString stamp: aStamp [
 		preamble: preamble
 		onSuccess: [ :newSourcePointer | 
 			self organization 
-				classComment: (SourceFiles remoteStringAt: newSourcePointer) ]
+				commentSourcePointer: newSourcePointer]
 		onFail: [ "ignore" ].
 	
 	SystemAnnouncer uniqueInstance 

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'protocolOrganizer',
 		'organizedClass',
-		'commentRemoteString'
+		'commentSourcePointer'
 	],
 	#category : #'Kernel-Protocols'
 }
@@ -136,27 +136,27 @@ ClassOrganization >> cleanUpCategoriesForClass: aClass [
 { #category : #accessing }
 ClassOrganization >> comment [
 
-	commentRemoteString ifNil: [^ ''].
-	^ commentRemoteString string ifNil: ['']
+	^ commentSourcePointer ifNil: [''] ifNotNil: [:ptr | SourceFiles sourceCodeAt: commentSourcePointer ]
 ]
 
 { #category : #accessing }
 ClassOrganization >> comment: aString [
-	"Store the comment, aString, associated with the object that refers to the 
-	receiver."
-
-	commentRemoteString := aString isRemoteString
-		ifTrue: [ aString ]
-		ifFalse: [ 
-			aString isEmptyOrNil
-				ifTrue: [ nil ]
-				ifFalse: [ SourceFiles remoteStringForNewString: aString ] ]
+	organizedClass comment: aString
 ]
 
 { #category : #'backward compatibility' }
 ClassOrganization >> commentRemoteString [
+	^ commentSourcePointer ifNotNil: [SourceFiles remoteStringAt: commentSourcePointer]
+]
 
-	^ commentRemoteString
+{ #category : #accessing }
+ClassOrganization >> commentSourcePointer [
+	^ commentSourcePointer
+]
+
+{ #category : #accessing }
+ClassOrganization >> commentSourcePointer: anObject [
+	commentSourcePointer := anObject
 ]
 
 { #category : #accessing }
@@ -164,12 +164,12 @@ ClassOrganization >> commentStamp [
 
 	^ self commentRemoteString
 		  ifNil: [ '' ]
-		  ifNotNil: [ :remoteString | SourceFiles commentTimeStampAt: remoteString sourcePointer ]
+		  ifNotNil: [ :remoteString | SourceFiles commentTimeStampAt: commentSourcePointer]
 ]
 
 { #category : #copying }
 ClassOrganization >> copyFrom: otherOrganization [
-	commentRemoteString := otherOrganization commentRemoteString.
+	commentSourcePointer  := otherOrganization commentSourcePointer.
 	otherOrganization protocols do: [ :p | p methodSelectors do: [ :m | protocolOrganizer classify: m inProtocolNamed: p name ] ]
 ]
 

--- a/src/System-SourcesCondenser/PharoChangesCondenser.class.st
+++ b/src/System-SourcesCondenser/PharoChangesCondenser.class.st
@@ -138,7 +138,7 @@ PharoChangesCondenser >> swapClassComment: classOrTrait [
 	remoteStringMap 
 		at: classOrTrait
 		ifPresent: [ :remoteString | 
-			classOrTrait organization comment: remoteString ]
+			classOrTrait organization commentSourcePointer:  remoteString sourcePointer]
 ]
 
 { #category : #'private - 2 swapping' }


### PR DESCRIPTION
ClassOrganization stores RemoteString instances. But that is not needed: we can store instead the sourcepointer (as we do with CompiledMethod).

Why is this better? it removes one instance of RemoteString per class comment from the image, saving memory espeically for images with many well documented classes.