### PR TITLE
isInteractiveFor-Small-Cleanup

### DIFF
--- a/src/CodeImport/FileCompilerRequestor.class.st
+++ b/src/CodeImport/FileCompilerRequestor.class.st
@@ -45,7 +45,7 @@ FileCompilerRequestor >> initialize [
 
 { #category : #testing }
 FileCompilerRequestor >> interactive [
-	^ interactive
+	^ interactive ifNil: [ false ]
 ]
 
 { #category : #accessing }

--- a/src/CodeImport/MethodChunkCompilerRequestor.class.st
+++ b/src/CodeImport/MethodChunkCompilerRequestor.class.st
@@ -24,7 +24,7 @@ MethodChunkCompilerRequestor >> fileCompileRequestor: anObject [
 
 { #category : #accessing }
 MethodChunkCompilerRequestor >> interactive [
-	^ interactive
+	^ interactive ifNil: [ false ]
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -464,7 +464,7 @@ OpalCompiler >> isInteractiveFor: aRequestor [
 	aRequestor ifNil: [^ false ].
 	
 	^ (aRequestor respondsTo: #interactive)
-		ifTrue: [ aRequestor interactive ifNil: [ false ] ]
+		ifTrue: [ aRequestor interactive ]
 		ifFalse: [ true ]
 ]
 


### PR DESCRIPTION
The compiler is doing far too much magic in #isInteractiveFor:

It allows #isInteractive to not be implemented on the requestor. But even if it is, it does a nil check.

As a first improvement, we require that #interactive has to return a boolean if it exists.