### PR TITLE
Fix #7219

### DIFF
--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -257,10 +257,7 @@ RubSmalltalkEditor >> bestNodeInTextAreaWithoutSelection [
 									stop >= self textArea text size ifFalse: [ end :=  self textArea string copyFrom: stop + 1 to: self textArea text size ].
 									beginning,end ]
 					 ifTrue: [ self textArea string ].
-	[node := RBParser parseMethod: intervalTrimmedText  onError: [ 
-		RBParser parseFaultyExpression: intervalTrimmedText]
-	] on: Error do: [^nil].
-	
+	node := RBParser parseFaultyMethod: intervalTrimmedText.
 	^node bestNodeFor: (start to: start).
 	
 ]

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -257,9 +257,12 @@ RubSmalltalkEditor >> bestNodeInTextAreaWithoutSelection [
 									stop >= self textArea text size ifFalse: [ end :=  self textArea string copyFrom: stop + 1 to: self textArea text size ].
 									beginning,end ]
 					 ifTrue: [ self textArea string ].
-	node := RBParser parseFaultyMethod: intervalTrimmedText.
-	^node bestNodeFor: (start to: start).
-	
+		
+	node := self isScripting
+		ifTrue: [ RBParser parseFaultyExpression: intervalTrimmedText ]
+		ifFalse: [ RBParser parseFaultyMethod: intervalTrimmedText ].
+
+	^node bestNodeFor: (start to: start)
 ]
 
 { #category : #binding }
@@ -954,18 +957,8 @@ RubSmalltalkEditor >> paste [
 	node := self bestNodeInTextAreaWithoutSelection.
 	charac := self getNestingCharacterFromAst: node.
 	nestedText := self stringNestedWith: charac.
-	"Check if it is a Symbol that needs extra apostrophes to receive"
-	"The commented code is a hint at how to nest strings in symbols. The solucion has not been found yet."
-		"(node isLiteralNode and: [ node value isSymbol ])
-				ifFalse: [" self replace: self selectionInterval with: nestedText and:
-						 	  [self selectAt: self pointIndex] "] 
-				ifTrue: [ | beginning end |
-				beginning := self textArea text copyFrom: node start to: self textArea startIndex - 1.
-				end := self textArea text copyFrom: self textArea stopIndex to: node stop + (self textArea stopIndex - self textArea startIndex) .
-				self replace: (node start to: node stop + (self textArea stopIndex - self textArea startIndex)) with: beginning, nestedText, end and:
-		[self selectAt: self pointIndex] ].
-	 ]."
-	
+	self replace: self selectionInterval with: nestedText and:
+		[self selectAt: self pointIndex]
 ]
 
 { #category : #'editing keys' }


### PR DESCRIPTION
The parsing of ASTs for copy past and others is not producing a valid AST, because they are using wrongly the parser's API.

=> Produce a valid AST (for faulty methods)