### PR TITLE
7153-Enhance-Smalltalk-Browser-code-performance-by-not-using-PragmaCollector--allSystemPragmas

### DIFF
--- a/src/PragmaCollector/PragmaCollector.class.st
+++ b/src/PragmaCollector/PragmaCollector.class.st
@@ -39,11 +39,7 @@ Class {
 
 { #category : #utilities }
 PragmaCollector class >> allSystemPragmas [
-	^ (Array
-		streamContents: [:stream | SystemNavigation new
-				allBehaviorsDo: [:behavior | Pragma
-						withPragmasIn: behavior
-						do: [:pragma | stream nextPut: pragma]]]) 
+	^ Pragma allInstalled
 ]
 
 { #category : #'instance creation' }


### PR DESCRIPTION
this fixes #7153 by using the cached pragmas in #allSystemPragmas

This PR just does the trivial change, we can later clean up more (e.g. allSystemPragmas senders can use Pragma allInstalled directly)