### PR TITLE
Use-Pragma-instead-of-PragmaCollector

### DIFF
--- a/src/Clap-Core/ClapContext.class.st
+++ b/src/Clap-Core/ClapContext.class.st
@@ -49,8 +49,7 @@ ClapContext class >> defaultRoot [
 
 { #category : #accessing }
 ClapContext class >> pragmaCommands [
-	^ (PragmaCollector filter: [:prg | prg selector = #commandline]) reset
-		collect: [ :pragma |
+	^ (Pragma allNamed: #commandline) collect: [ :pragma |
 			| theClass theSelector |
 			theClass := pragma method methodClass.
 			theSelector := pragma method selector.

--- a/src/GT-Inspector/GTInspectorMethodListFilter.class.st
+++ b/src/GT-Inspector/GTInspectorMethodListFilter.class.st
@@ -124,8 +124,7 @@ GTInspectorMethodListFilter >> addSignatureFor: aMethod [
 { #category : #accessing }
 GTInspectorMethodListFilter >> allPresentationMethods [
 
-	^ (PragmaCollector allSystemPragmas select: [ :pragma | 
-		pragma key == self inspectorPragmaKey ]) collect: [ :aPragma | aPragma method ]
+	^ (Pragma allNamed: self inspectorPragmaKey) collect: [ :aPragma | aPragma method ]
 ]
 
 { #category : #accessing }

--- a/src/GT-Inspector/GTInspectorTagFilter.class.st
+++ b/src/GT-Inspector/GTInspectorTagFilter.class.st
@@ -92,7 +92,7 @@ GTInspectorTagFilter >> addTag: aSymbol [
 { #category : #accessing }
 GTInspectorTagFilter >> allPragmasWithTag [
 
-	^ PragmaCollector allSystemPragmas select: [ :pragma | pragma key == self tagPragmaKey ]
+	^ Pragma allNamed: self tagPragmaKey
 ]
 
 { #category : #accessing }

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -36,13 +36,11 @@ SystemAnnouncer class >> reset [
 
 { #category : #initialization }
 SystemAnnouncer class >> restoreAllNotifications [
+
 	"self restoreAllNotifications"
-	
-	| collector |
+
 	self reset.
-	collector := PragmaCollector filter: [ :pragma | pragma selector = #systemEventRegistration ].
-	collector reset.
-	collector do: [ :pragma |
+	(Pragma allNamed: #systemEventRegistration) do: [ :pragma | 
 		pragma methodClass instanceSide perform: pragma methodSelector ]
 ]
 

--- a/src/System-FileRegistry/FileServices.class.st
+++ b/src/System-FileRegistry/FileServices.class.st
@@ -22,7 +22,7 @@ FileServices class >> itemsForDirectory: aFileDirectory [
 
 	| services |
 	services := OrderedCollection new.
-	(PragmaCollector filter: [ :pragma | pragma selector = 'directoryService' ]) reset
+	(Pragma allNamed: #directoryService)
 		do: [ :each | services addAll: (each methodClass soleInstance perform: each methodSelector with: aFileDirectory) ].
 	^ services
 ]
@@ -34,8 +34,7 @@ FileServices class >> itemsForFile: fullName [
 	| services suffix |
 	suffix := self suffixOf: fullName.
 	services := OrderedCollection new.
-	(PragmaCollector filter: [ :pragma | pragma selector = 'fileService' ])
-		reset
+	(Pragma allNamed: #fileService)
 		do: [ :each | 
 			services
 				addAll:

--- a/src/System-Settings-Browser/SettingBrowser.class.st
+++ b/src/System-Settings-Browser/SettingBrowser.class.st
@@ -285,7 +285,7 @@ SettingBrowser class >> searchedTextList [
 
 { #category : #accessing }
 SettingBrowser class >> settingsKeywords [ 
-	^ ((PragmaCollector new filter: [:prg | prg selector = #settingPragmaProcessor]) reset) collect: [:p | p method selector].
+	^ (Pragma allNamed: #settingPragmaProcessor) collect: [:p | p method selector]
 
 ]
 

--- a/src/UnifiedFFI/FFICompilerPlugin.class.st
+++ b/src/UnifiedFFI/FFICompilerPlugin.class.st
@@ -96,11 +96,8 @@ FFICompilerPlugin class >> initializeFFICalloutSelectors [
 
 { #category : #'private - initialization' }
 FFICompilerPlugin class >> initializeFFICalloutSelectorsListUpdate [
-	| pragmaCollector |
-	pragmaCollector := PragmaCollector
-		filter: [ :pragma | pragma selector = #ffiCalloutTranslator ].
-	pragmaCollector reset
-		do: [ :pragma | self addFFICalloutSelectorFromPragma: pragma ].
+
+	(Pragma allNamed: #ffiCalloutTranslator) do: [ :pragma | self addFFICalloutSelectorFromPragma: pragma ]
 ]
 
 { #category : #installation }
@@ -119,10 +116,8 @@ FFICompilerPlugin class >> priority [
 
 { #category : #private }
 FFICompilerPlugin class >> recompileSenders [
-	| pragmaCollector |
-	pragmaCollector := PragmaCollector
-		filter: [ :pragma | pragma selector = #ffiCalloutTranslator ].
-	pragmaCollector reset do: [ :pragma | self recompileSendersOf: pragma method ]
+
+	(Pragma allNamed: #ffiCalloutTranslator) do: [ :pragma | self recompileSendersOf: pragma method ]
 ]
 
 { #category : #private }


### PR DESCRIPTION
refactor some of the usres of PragmaCollector to use Pragma allNamed: instead

There is more to be done, I would have fixed all but some of the rest are in "externally managed packages"...