### PR TITLE
CleanBlockClosure-missing-scanning-methods

### DIFF
--- a/src/Kernel/CleanBlockClosure.class.st
+++ b/src/Kernel/CleanBlockClosure.class.st
@@ -64,6 +64,16 @@ CleanBlockClosure >> readsField: varIndex [
 	^self compiledBlock readsField: varIndex
 ]
 
+{ #category : #scanning }
+CleanBlockClosure >> readsSelf [
+	^self compiledBlock readsSelf
+]
+
+{ #category : #scanning }
+CleanBlockClosure >> readsThisContext [
+	^self compiledBlock readsThisContext
+]
+
 { #category : #accessing }
 CleanBlockClosure >> refersToLiteral: aLiteral [
 	^self compiledBlock refersToLiteral: aLiteral


### PR DESCRIPTION
add two more forwarding method... they are used when scanning the whole system for self and thisContext (which is a bit slow thus I am hesitent to add tests)