### PR TITLE
Small-RemoteString-Cleanup

### DIFF
--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -136,17 +136,12 @@ ClassOrganization >> cleanUpCategoriesForClass: aClass [
 { #category : #accessing }
 ClassOrganization >> comment [
 
-	^ commentSourcePointer ifNil: [''] ifNotNil: [:ptr | SourceFiles sourceCodeAt: commentSourcePointer ]
+	^ commentSourcePointer ifNil: [''] ifNotNil: [:ptr | SourceFiles sourceCodeAt: ptr ]
 ]
 
 { #category : #accessing }
 ClassOrganization >> comment: aString [
 	organizedClass comment: aString
-]
-
-{ #category : #'backward compatibility' }
-ClassOrganization >> commentRemoteString [
-	^ commentSourcePointer ifNotNil: [SourceFiles remoteStringAt: commentSourcePointer]
 ]
 
 { #category : #accessing }
@@ -162,9 +157,9 @@ ClassOrganization >> commentSourcePointer: anObject [
 { #category : #accessing }
 ClassOrganization >> commentStamp [
 
-	^ self commentRemoteString
+	^ commentSourcePointer
 		  ifNil: [ '' ]
-		  ifNotNil: [ :remoteString | SourceFiles commentTimeStampAt: commentSourcePointer]
+		  ifNotNil: [ SourceFiles commentTimeStampAt: commentSourcePointer]
 ]
 
 { #category : #copying }
@@ -180,7 +175,7 @@ ClassOrganization >> extensionProtocols [
 
 { #category : #testing }
 ClassOrganization >> hasComment [
-	^ self commentRemoteString isNotNil
+	^ commentSourcePointer isNotNil
 ]
 
 { #category : #'backward compatibility' }

--- a/src/Ring-Definitions-Core/RGCommentDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGCommentDefinition.class.st
@@ -37,13 +37,11 @@ RGCommentDefinition >> asActive [
 RGCommentDefinition >> asHistorical [
 
 	"Sets the receiver as historical object, which will allow itself to retrieve its data using the sourcePointer"
-	| realClass |
+
 	self annotationNamed: self class statusKey put: #historical.
-	self sourcePointer ifNil:[
-		realClass := self realClass.
-		realClass notNil ifTrue: [ 
-			realClass organization commentRemoteString
-				ifNotNil: [:str | self sourcePointer: str sourcePointer ] ] ]
+	self sourcePointer ifNil: [ 
+		self realClass ifNotNil: [ :realClass | 
+			self sourcePointer: realClass organization commentSourcePointer ] ]
 ]
 
 { #category : #'type of comments' }

--- a/src/System-Sources/Object.extension.st
+++ b/src/System-Sources/Object.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #Object }
-
-{ #category : #'*System-Sources' }
-Object >> isRemoteString [
-
-	^ false
-]

--- a/src/System-Sources/RemoteString.class.st
+++ b/src/System-Sources/RemoteString.class.st
@@ -66,12 +66,6 @@ RemoteString >> fileNumber: fileNumber position: position [
 	filePositionHi := position
 ]
 
-{ #category : #testing }
-RemoteString >> isRemoteString [
-
-	^ true
-]
-
 { #category : #accessing }
 RemoteString >> last [
 	^self string ifNotNil: [ :s | s last ] 

--- a/src/System-SourcesCondenser/PharoChangesCondenser.class.st
+++ b/src/System-SourcesCondenser/PharoChangesCondenser.class.st
@@ -38,6 +38,11 @@ PharoChangesCondenser >> basicCondense [
   stream flush.
 ]
 
+{ #category : #private }
+PharoChangesCondenser >> commentRemoteStringFor: org [
+	^ org commentSourcePointer ifNotNil: [:ptr | SourceFiles remoteStringAt: ptr]
+]
+
 { #category : #public }
 PharoChangesCondenser >> condense [
 	job := [ 
@@ -188,7 +193,7 @@ PharoChangesCondenser >> writeClassComment: aClass [
 	| organizer commentRemoteString stamp |
 	
 	organizer := aClass organization.
-	commentRemoteString := organizer commentRemoteString.
+	commentRemoteString := self commentRemoteStringFor: organizer.
 	
 	(commentRemoteString isNil or: [ commentRemoteString sourceFileNumber = 1 ])
 		ifTrue: [ ^ self ].

--- a/src/System-SourcesCondenser/PharoSourcesCondenser.class.st
+++ b/src/System-SourcesCondenser/PharoSourcesCondenser.class.st
@@ -92,7 +92,7 @@ PharoSourcesCondenser >> writeClassComment: aClass [
 	| organizer commentRemoteString stamp |
 
 	organizer := aClass organization.
-	commentRemoteString := organizer commentRemoteString.
+	commentRemoteString := self commentRemoteStringFor: organizer.
 
 	commentRemoteString ifNil: [ ^ self ].
 


### PR DESCRIPTION
Another small cleanup related to RemoteString:

ClassOrganization
- simplify #comment
- #commentStamp - use commentSourcePointer, not commentRemoteString
- #hasComment -> use commentSourcePointer, , not commentRemoteString
- remove #commentRemoteString

Ring: #asHistorical can be much simpler accessing sourcePointer instead of remote string

PharoChangesCondenser
- implement #commentRemoteStringFor: so we do not need to expose commentRemoteString in the API of the class organizer