### PR TITLE
Fix AthensCairoCanvas to support nested transformed clipBy:during:

### DIFF
--- a/src/Athens-Cairo/AthensCairoCanvas.class.st
+++ b/src/Athens-Cairo/AthensCairoCanvas.class.st
@@ -38,21 +38,25 @@ AthensCairoCanvas class >> primCreate: cairoSurface [
 
 { #category : #clipping }
 AthensCairoCanvas >> clipBy: aRectangle during: aBlock [
-	| oldClip newClip |
+	| oldClip transformedClipRectangle newClip |
 
 	oldClip := currentClipRect.
-	newClip := oldClip ifNil: [ aRectangle ] ifNotNil: [ oldClip intersect: aRectangle ifNone:[^ self] ]. 
+	transformedClipRectangle := pathTransform transformRectangle: aRectangle.
+	newClip := oldClip
+		ifNil: [ transformedClipRectangle ]
+		ifNotNil: [ oldClip intersect: transformedClipRectangle ifNone:[^ self] ]. 
 	
-	self setPathMatrix; resetClip; setClipRect: newClip.
+	self
+		setPathMatrix;
+		primSaveState;
+		pushClipRect: aRectangle.
 	
 	currentClipRect := newClip.
 
-	[aBlock value] ensure: [ 
-		self 
-		setPathMatrix;
-		resetClip;
-		setClipRect: oldClip. 
-		currentClipRect := oldClip. ].
+	[aBlock value] ensure: [
+		self primRestoreState.
+		currentClipRect := oldClip
+	].
 	
 
 ]
@@ -221,6 +225,18 @@ AthensCairoCanvas >> primResetDashes: anOffset [
 ]
 
 { #category : #private }
+AthensCairoCanvas >> primRestoreState [
+	^ self ffiCall: #(void cairo_restore (self))
+
+]
+
+{ #category : #private }
+AthensCairoCanvas >> primSaveState [
+	^ self ffiCall: #(void cairo_save (self))
+
+]
+
+{ #category : #private }
 AthensCairoCanvas >> primSetDashesLengths: dashesLengths count: dashesCount offset: anOffset [
 	^ self ffiCall: #(void cairo_set_dash (self,
 			double * dashesLengths,
@@ -246,6 +262,17 @@ AthensCairoCanvas >> primSetLineWidth: width [
 { #category : #private }
 AthensCairoCanvas >> primSetSource: aPattern [
 	^ self ffiCall: #(void cairo_set_source ( self, AthensCairoPatternPaint aPattern))
+]
+
+{ #category : #private }
+AthensCairoCanvas >> pushClipRect: aRectangle [
+	self newPath;
+		rectangleX: aRectangle left
+		y: aRectangle top
+		width: aRectangle width
+		height: aRectangle height;
+		primClip
+
 ]
 
 { #category : #private }
@@ -286,18 +313,9 @@ Note that this option does not affect text rendering, instead see cairo_font_opt
 
 { #category : #private }
 AthensCairoCanvas >> setClipRect: aRectOrNil [
-	
-
 	aRectOrNil 
 		ifNil: [ self resetClip ]
-		ifNotNil: [
-			self newPath;
-				rectangleX: aRectOrNil left
-				y: aRectOrNil top
-				width: aRectOrNil width
-				height: aRectOrNil height;
-				primClip
-			]
+		ifNotNil: [ self pushClipRect: aRectOrNil ]
 ]
 
 { #category : #initialization }

--- a/src/Athens-Cairo/AthensCairoMatrix.class.st
+++ b/src/Athens-Cairo/AthensCairoMatrix.class.st
@@ -284,6 +284,16 @@ AthensCairoMatrix >> transform: aPoint [
 ]
 
 { #category : #transformations }
+AthensCairoMatrix >> transformRectangle: aRectangle [
+	^ Rectangle encompassing: {
+		self transform: aRectangle bottomLeft.
+		self transform: aRectangle bottomRight.
+		self transform: aRectangle topLeft.
+		self transform: aRectangle topRight.
+	}
+]
+
+{ #category : #transformations }
 AthensCairoMatrix >> translateBy: aPoint [
 	self translateX: aPoint x Y: aPoint y
 ]

--- a/src/Athens-Core/AthensTransform.class.st
+++ b/src/Athens-Core/AthensTransform.class.st
@@ -110,6 +110,16 @@ AthensTransform >> transform: aPoint [
 	self subclassResponsibility
 ]
 
+{ #category : #transformations }
+AthensTransform >> transformRectangle: aRectangle [
+	^ Rectangle encompassing: {
+		self transform: aRectangle bottomLeft.
+		self transform: aRectangle bottomRight.
+		self transform: aRectangle topLeft.
+		self transform: aRectangle topRight.
+	}
+]
+
 { #category : #'vector-transform' }
 AthensTransform >> transformX: px Y: py [ 
 	self subclassResponsibility

--- a/src/Athens-Examples/AthensSurfaceExamples.class.st
+++ b/src/Athens-Examples/AthensSurfaceExamples.class.st
@@ -602,6 +602,37 @@ AthensSurfaceExamples class >> exampleDrawText [
 ]
 
 { #category : #examples }
+AthensSurfaceExamples class >> exampleNestedClip [
+
+	| surf |
+	surf := self newSurface: 100@100.
+	
+	surf drawDuring: [:can |
+		surf clear.
+		can pathTransform loadIdentity.
+		can setPaint: (Color blue).
+		can drawShape: (0@0 corner: 100@ 100).
+
+		can pathTransform translateX: -20 Y: -20.
+		can clipBy: (20@20 corner: 80@80) during: [
+			can pathTransform
+				translateX: 20 Y: 20;
+				rotateByDegrees: -20.
+			can setPaint: (Color red).
+			can drawShape: (0@0 corner: 100@ 100).
+
+			can clipBy: (20@20 corner: 80@80) during: [
+				can pathTransform translateX: 20 Y: 20.
+				can setPaint: (Color green).
+				can drawShape: (0@0 corner: 100@ 100).
+			]
+		]
+	].
+
+	surf asMorph openInWindow
+]
+
+{ #category : #examples }
 AthensSurfaceExamples class >> exampleStrokeRect [
 	"Draw a frame rectangle, rotate & transform it in a loop"
 


### PR DESCRIPTION
The current implementation of clipBy:during in AthensCairoCanvas is wrong because it does not respect completely the current path transform, and in the nested case it produces wrong results.