### PR TITLE
Fix restart of Tests with tests

### DIFF
--- a/src/Debugger-Model-Tests/DebuggerTest.class.st
+++ b/src/Debugger-Model-Tests/DebuggerTest.class.st
@@ -41,5 +41,5 @@ DebuggerTest >> settingUpSessionAndProcessAndContextForBlock: aBlock [
 	process step.
 
 	context := process suspendedContext.
-	session:= process newDebugSessionNamed: 'test session' startedAt: context.
+	session := process newDebugSessionNamed: 'test session' startedAt: context.
 ]

--- a/src/Debugger-Model-Tests/DebuggerTestCaseForRestartTest.class.st
+++ b/src/Debugger-Model-Tests/DebuggerTestCaseForRestartTest.class.st
@@ -1,0 +1,38 @@
+Class {
+	#name : #DebuggerTestCaseForRestartTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'testedValue'
+	],
+	#category : #'Debugger-Model-Tests-Core'
+}
+
+{ #category : #running }
+DebuggerTestCaseForRestartTest >> setUp [
+	super setUp.
+	
+	"Initialize the test with some object.
+	This value will change if the test is restarted.
+	We use just a new object because we care about its identity"
+	testedValue := Object new.
+]
+
+{ #category : #running }
+DebuggerTestCaseForRestartTest >> testPushingValuesOnActivation [
+
+	| oldValue |
+	"Test case to test the debugger restart.
+	
+	This test will run ok if run normally.
+	However, if we step into this method and restart it, the debugger will re-execute the setUp, changing the value of testedValue.
+	The test should be also be green after restarting."
+
+	oldValue := testedValue.
+	self assert: oldValue == testedValue.
+]
+
+{ #category : #running }
+DebuggerTestCaseForRestartTest >> testedValue [
+
+	^ testedValue
+]

--- a/src/Debugger-Model-Tests/RestartTest.class.st
+++ b/src/Debugger-Model-Tests/RestartTest.class.st
@@ -18,6 +18,44 @@ RestartTest >> stepA2 [
 ]
 
 { #category : #tests }
+RestartTest >> testRestartTestShouldKeepTestGreen [
+
+	| testCaseForRestart failed finished |
+	failed := false.
+	finished := Semaphore new.
+
+	testCaseForRestart := DebuggerTestCaseForRestartTest selector: #testPushingValuesOnActivation.
+	testCaseForRestart setUp.
+	self settingUpSessionAndProcessAndContextForBlock: [ 
+		[ [testCaseForRestart testPushingValuesOnActivation]
+				on: TestFailure do: [ failed := true ] ]
+					ensure: [ finished signal ] ].
+	
+	[session interruptedContext selector = #testPushingValuesOnActivation]
+		whileFalse: [ session stepInto ].
+	session restart: session interruptedContext.
+	session resume.
+
+	finished wait.	
+	self deny: failed
+]
+
+{ #category : #tests }
+RestartTest >> testRestartTestShouldPushNewValuesToTheStack [
+
+	| testCaseForRestart |
+	testCaseForRestart := DebuggerTestCaseForRestartTest selector: #testPushingValuesOnActivation.
+	testCaseForRestart setUp.
+	self settingUpSessionAndProcessAndContextForBlock: [ 
+		testCaseForRestart testPushingValuesOnActivation ].
+
+	session stepInto.
+	session restart: session interruptedContext.
+
+	self assert: session interruptedContext top == testCaseForRestart testedValue.
+]
+
+{ #category : #tests }
 RestartTest >> testStepRestartAndRestepTopContext [
 	"Get the execution to a context on method stepA2.
 	Step over in it to reach the end (and check that the temporary variable assignement works)

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -304,11 +304,11 @@ DebugSession >> restart: aContext [
 	"Closing now depends on a setting (RestartAlsoProceeds class variable) --> not supported in this version"
 
 	(self isContextPostMortem: aContext) ifTrue: [^ self].
-	self unwindAndRestartToContext: aContext.
-	
+
 	"Issue 3015 - Hernan"
 	self isInterruptedContextATest ifTrue: [ self prepareTestToRunAgain ].
-	
+	self unwindAndRestartToContext: aContext.	
+
 	self triggerEvent: #restart		
 	
 ]


### PR DESCRIPTION
Restart in the debugger does not only restart, it also executes until the next bytecode that is "interesting" for debugging (usually a message send).
For example, we do not manually step into variables (which push to the operand stack), this is done automatically.

In addition, when we restart the context of a test case, the setup is re-executed.
However, this causes strange behaviour:

## To reproduce

If we create a test case as follows:

```smalltalk
setUp
   var := Object new.

testRestart
    | oldObject |
    oldObject := var.
    self assert: oldObject == var.
    self fail.
```

We execute the test, the first time it fails in `self fail`.
If we then restart the test and proceed, the second time it will fail in the `self assert: oldObject == var`.

## The bug

The bug comes from the fact that the restart is done before the re-execution of the setup. Then, restart will (wrongly) execute some "uninteresting" bytecodes using the old values, before the setup is re-executed.

The reason for mortals in the example: when the restart is executed the value of var is pushed to the operand stack, which is the old value. Then the execution is suspended, the test setup is re-executed, and now var points to a different object.
When the execution resumes, the assignment is performed using the stack top (old value), thus oldValue points to the old object and the assertion fails.

## The Fix

```smalltalk
restart: aContext
    "Proceed from the initial state of selectedContext." 
    "Closing now depends on a setting (RestartAlsoProceeds class variable) --> not supported in this version"

    (self isContextPostMortem: aContext) ifTrue: [^ self].

    self unwindAndRestartToContext: aContext.    

    "Issue 3015 - Hernan"
    self isInterruptedContextATest ifTrue: [ self prepareTestToRunAgain ].

    self triggerEvent: #restart 
```
     
The fix is to revert the order of restart and setup: 👇 

```smalltalk
restart: aContext
    "Proceed from the initial state of selectedContext." 
    "Closing now depends on a setting (RestartAlsoProceeds class variable) --> not supported in this version"

    (self isContextPostMortem: aContext) ifTrue: [^ self].

    "Issue 3015 - Hernan"
    self isInterruptedContextATest ifTrue: [ self prepareTestToRunAgain ].
    self unwindAndRestartToContext: aContext.    

    self triggerEvent: #restart   
```