### PR TITLE
7240-PRRichTextComposer-does-not-need-to-use-PragmaCollector

### DIFF
--- a/src/Pillar-ExporterRichText/PRRichTextComposer.class.st
+++ b/src/Pillar-ExporterRichText/PRRichTextComposer.class.st
@@ -171,8 +171,7 @@ PRRichTextComposer class >> initialize [
 PRRichTextComposer class >> languageStylerFor: aLanguage [
 	| stylers |
 	stylers := Dictionary
-		newFromAssociations: ((PragmaCollector
-						filter: [ :prg | prg selector = 'codeblockStylerFor:' ]) reset
+		newFromAssociations: ((Pragma allNamed: #codeblockStylerFor:)
 						collected collect: [ :p | p arguments first -> p method ]).
 	^ stylers
 		at: aLanguage

--- a/src/Pillar-ExporterRichText/PRRichTextComposer.class.st
+++ b/src/Pillar-ExporterRichText/PRRichTextComposer.class.st
@@ -171,8 +171,8 @@ PRRichTextComposer class >> initialize [
 PRRichTextComposer class >> languageStylerFor: aLanguage [
 	| stylers |
 	stylers := Dictionary
-		newFromAssociations: ((Pragma allNamed: #codeblockStylerFor:)
-						collected collect: [ :p | p arguments first -> p method ]).
+		newFromAssociations: ((Pragma allNamed: #codeblockStylerFor:) collect: [ :p | 
+			p arguments first -> p method ]).
 	^ stylers
 		at: aLanguage
 		ifAbsent: [ self languageStylerFor: 'default' ]


### PR DESCRIPTION
use Pragma>>#allNamed: instead of PragmaCollector in #languageStylerFor:, fixes #7240 