### PR TITLE
Cleanup-ManifestSystemAnnouncements-ignoredDependencies

### DIFF
--- a/src/System-Announcements/ManifestSystemAnnouncements.class.st
+++ b/src/System-Announcements/ManifestSystemAnnouncements.class.st
@@ -6,8 +6,3 @@ Class {
 	#superclass : #PackageManifest,
 	#category : #'System-Announcements-Manifest'
 }
-
-{ #category : #'meta-data - dependency analyser' }
-ManifestSystemAnnouncements class >> ignoredDependencies [
-	^ #(#PragmaCollector)
-]


### PR DESCRIPTION
PragmaCollector is listed in the ignoredDependencies of SystemAnnouncer.

As we replaced it with a direct call to a class method of Pragma, this is not needed anymore.
(at least I think  so,  that  is  why I  do this as a tiny tiny PR... instead of as a part of a bigger PR)