### PR TITLE
Cleanup-selectorsAndMethodsDo

### DIFF
--- a/src/GT-SpotterExtensions-Core/Behavior.extension.st
+++ b/src/GT-SpotterExtensions-Core/Behavior.extension.st
@@ -89,7 +89,7 @@ Behavior >> spotterUsedTraitsFor: aStep [
 Behavior >> withMethodsReferTo: aLiteral do: aBlock [
 	| specialIndex |
 	specialIndex := Smalltalk specialSelectorIndexOrNil: aLiteral.
-	self selectorsAndMethodsDo: [ :selector :method | 
+	self methodsDo: [ :method | 
 		((method hasLiteral: aLiteral) 
 			or: [ specialIndex notNil and: [ method scanFor: method encoderClass firstSpecialSelectorByte + specialIndex ] ])
 				ifTrue: [ aBlock value: method ] ]
@@ -99,7 +99,7 @@ Behavior >> withMethodsReferTo: aLiteral do: aBlock [
 Behavior >> withThorougMethodsReferTo: aLiteral do: aBlock [
 	| specialIndex |
 	specialIndex := Smalltalk specialSelectorIndexOrNil: aLiteral.
-	self selectorsAndMethodsDo: [ :selector :method | 
+	self methodsDo: [ :method | 
 		(method hasSelector: aLiteral specialSelectorIndex: specialIndex)
 					ifTrue: [ aBlock value: method ] ].
 ]

--- a/src/Kernel/AdditionalMethodState.class.st
+++ b/src/Kernel/AdditionalMethodState.class.st
@@ -237,16 +237,6 @@ AdditionalMethodState >> postCopy [
 		[:i| self basicAt: i put: (self basicAt: i) shallowCopy]
 ]
 
-{ #category : #enumerating }
-AdditionalMethodState >> pragmaDo: aBlock [
-	
-	1 to: self basicSize do: [ :i | 
-		| propertyOrPragma	"<Association|Pragma>" |
-		propertyOrPragma := self basicAt: i.
-		propertyOrPragma isVariableBinding
-			ifFalse: [ aBlock value: propertyOrPragma ] ]
-]
-
 { #category : #accessing }
 AdditionalMethodState >> pragmas [
 	"Answer the raw messages comprising my pragmas."
@@ -257,6 +247,16 @@ AdditionalMethodState >> pragmas [
 		(propertyOrPragma := self basicAt: i) isVariableBinding ifFalse:
 			[pragmaStream nextPut: propertyOrPragma]].
 	^pragmaStream contents
+]
+
+{ #category : #enumerating }
+AdditionalMethodState >> pragmasDo: aBlock [
+	
+	1 to: self basicSize do: [ :i | 
+		| propertyOrPragma	"<Association|Pragma>" |
+		propertyOrPragma := self basicAt: i.
+		propertyOrPragma isVariableBinding
+			ifFalse: [ aBlock value: propertyOrPragma ] ]
 ]
 
 { #category : #printing }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -780,6 +780,13 @@ CompiledMethod >> pragmas [
 		ifFalse: [#()]
 ]
 
+{ #category : #'accessing-pragmas & properties' }
+CompiledMethod >> pragmasDo: aBlock [
+	| selectorOrProperties |
+	(selectorOrProperties := self penultimateLiteral) isMethodProperties
+		ifTrue: [selectorOrProperties pragmasDo: aBlock]
+]
+
 { #category : #'debugger support' }
 CompiledMethod >> prepareForSimulationWith: numArgs [
 	"This method changes the argument count of a CompiledMethod header to numArgs, its temporary count to numArgs + 1 and change the code handling primitive error to store the error code in the unique temporary of the method"

--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -136,7 +136,7 @@ Pragma class >> selector: aSymbol arguments: anArray [
 
 { #category : #private }
 Pragma class >> withPragmasIn: aClass do: aBlock [
-	aClass selectorsAndMethodsDo: [ :selector :method | method pragmas do: aBlock ].
+	aClass methodsDo: [ :method | method pragmasDo: aBlock ]
 ]
 
 { #category : #comparing }

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -115,8 +115,8 @@ SystemNavigation >> allMethodsSelect: aBlock [
 	| aCollection |
 	aCollection := OrderedCollection new.
 	self allBehaviorsDo: [:class | 
-		class	selectorsAndMethodsDo: [:sel :m | 
-			(aBlock value: m) ifTrue: [aCollection add: class>>sel]]].
+		class	methodsDo: [:m | 
+			(aBlock value: m) ifTrue: [aCollection add: m]]].
 	^ aCollection
 ]
 


### PR DESCRIPTION
Some senders of selectorsAndMethodsDo: actually do not reference the selector. 

using #methodsDo: is cleaner and even faster.

In addition:

- there was an usused bad named pragmaDo: on  AdditionalMathodState. rename it to #pragmasDo:
- add pragmasDo: to CompiledMethod
- use this and #methodsDo: in Pragma class withPragmasIn:do: to speed up pragma access by class