### PR TITLE
7259-RBProgramNode--parserClass-should-be-packaged-out-of-GT-extensions

### DIFF
--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -782,6 +782,11 @@ RBProgramNode >> parents [
 						-> '`@receiver withALlParents'.
 ]
 
+{ #category : #hook }
+RBProgramNode >> parserClass [
+	^ RBParser
+]
+
 { #category : #copying }
 RBProgramNode >> postCopy [
 	super postCopy.

--- a/src/GT-InspectorExtensions-Core/RBProgramNode.extension.st
+++ b/src/GT-InspectorExtensions-Core/RBProgramNode.extension.st
@@ -29,8 +29,3 @@ RBProgramNode >> gtInspectorTreeIn: composite [
 	^ (GTSimpleRBTreeBrowser new treeIn: composite)
 		title: [ 'Tree' translated ]
 ]
-
-{ #category : #'*GT-InspectorExtensions-Core' }
-RBProgramNode >> parserClass [
-	^ RBParser
-]


### PR DESCRIPTION
fixes: #7259 just packaging parserClass in RBProgramNode