### PR TITLE
Deprecate-CompiledMethod-literalStrings

### DIFF
--- a/src/Deprecated90/CompiledCode.extension.st
+++ b/src/Deprecated90/CompiledCode.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : #CompiledCode }
+
+{ #category : #'*Deprecated90' }
+CompiledCode >> literalStrings [
+	
+	| litStrs |
+	self deprecated: 'Will be removed' on: ' 8 September 2020' in: 'Pharo 9'.
+	"as the implementation shows: this is very use case specific, the current implementation 
+	makes no sense and has no users"
+	litStrs := OrderedCollection new: self numLiterals.
+	self literalsDo:
+		[:lit | 
+		(lit isVariableBinding)
+			ifTrue: [litStrs addLast: lit key]
+			ifFalse: [(lit isSymbol)
+				ifTrue: [litStrs addAll: lit keywords]
+				ifFalse: [litStrs addLast: lit printString]]].
+	^ litStrs
+]

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -465,23 +465,6 @@ CompiledCode >> literalAt: index put: value [
 ]
 
 { #category : #literals }
-CompiledCode >> literalStrings [
-	"Return a list of strings or symbols corresponding to the class references and message sent.
-	The result also contains the name of the class"
-	
-	| litStrs |
-	litStrs := OrderedCollection new: self numLiterals.
-	self literalsDo:
-		[:lit | 
-		(lit isVariableBinding)
-			ifTrue: [litStrs addLast: lit key]
-			ifFalse: [(lit isSymbol)
-				ifTrue: [litStrs addAll: lit keywords]
-				ifFalse: [litStrs addLast: lit printString]]].
-	^ litStrs
-]
-
-{ #category : #literals }
 CompiledCode >> literals [
 	"Answer an Array of the literals referenced by the receiver.	
 	 Exclude superclass + selector/properties"


### PR DESCRIPTION
deprecate #literalString on CompiledMethod

as the implementation shows: this is very use case specific, the current implementation  makes no sense and has no users