### PR TITLE
WikiStyleHelpBuilder-allHelpPragmas-simplify

### DIFF
--- a/src/HelpSystem-Core/WikiStyleHelpBuilder.class.st
+++ b/src/HelpSystem-Core/WikiStyleHelpBuilder.class.st
@@ -29,8 +29,7 @@ Class {
 
 { #category : #'private accessing' }
 WikiStyleHelpBuilder class >> allHelpPragmas [
-	 ^(PragmaCollector filter: [:pragma | self pragmaKeywords includes: pragma selector]) reset collected
-
+	^ self pragmaKeywords flatCollect: [ :keyword | Pragma allNamed: keyword ]
 ]
 
 { #category : #help }

--- a/src/Kernel-Tests-Extended/ContextTest.extension.st
+++ b/src/Kernel-Tests-Extended/ContextTest.extension.st
@@ -57,7 +57,7 @@ ContextTest >> testSourceNodeExecutedWhenContextIsJustAtStartpc [
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
-ContextTest >> testWrtireVariableNamedValue [
+ContextTest >> testWriteVariableNamedValue [
 	|localVar|
 	localVar := 2.
 	instVarForTestLookupSymbol := 3.

--- a/src/OpalCompiler-Core/CopiedLocalVariable.class.st
+++ b/src/OpalCompiler-Core/CopiedLocalVariable.class.st
@@ -1,5 +1,5 @@
 "
-A copying variable is an arg or temp var that is copied into a block that later reads this variable
+A copied variable is an arg or temp var that is copied into a block that later reads this variable
 "
 Class {
 	#name : #CopiedLocalVariable,


### PR DESCRIPTION
- simplify #allHelpPragmas to not use PragmaCollector
- fix typo in method name: testWriteVariableNamedValue
- update comment in CopiedLocalVariable