### PR TITLE
SmallFixes-Rules

### DIFF
--- a/src/GeneralRules/ReEmptyExceptionHandlerRule.class.st
+++ b/src/GeneralRules/ReEmptyExceptionHandlerRule.class.st
@@ -26,7 +26,7 @@ ReEmptyExceptionHandlerRule >> afterCheck: aNode mappings: mappingDict [
 	exception := mappingDict at: '`exception'.
 	
 	exception isVariable ifFalse: [ ^ false ].
-	(class := Smalltalk classNamed: exception name) ifNil: [ ^ false ].
+	(class := aNode methodNode methodClass environment classNamed: exception name) ifNil: [ ^ false ].
 	(class includesBehavior: Exception) ifFalse: [ ^ false ].
 	(class includesBehavior: Notification) ifTrue: [ ^false ].
 	

--- a/src/GeneralRules/ReVariableAssignedLiteralRule.class.st
+++ b/src/GeneralRules/ReVariableAssignedLiteralRule.class.st
@@ -16,12 +16,12 @@ ReVariableAssignedLiteralRule class >> checksClass [
 { #category : #running }
 ReVariableAssignedLiteralRule >> check: aClass forCritiquesDo: aCriticBlock [
 
-	(aClass slots, aClass classVariables) do: [ :variable | 
+	aClass definedVariables do: [ :variable | 
 		|  assignmentNodes |
 		assignmentNodes := variable  assignmentNodes.
 		assignmentNodes size = 1 ifFalse: [ ^ self ].
 		assignmentNodes first value isLiteralNode ifTrue: [ 
-		aCriticBlock cull: (self critiqueFor: aClass about: variable  name) ]].
+		aCriticBlock cull: (self critiqueFor: aClass about: variable  name) ]]
 ]
 
 { #category : #'running-helpers' }


### PR DESCRIPTION
- use definedVariables in ReVariableAssignedLiteralRule
- ReEmptyExceptionHandlerRule should not hardcode the environment