### PR TITLE
ResetBC-2-AST-Mapping-on-Recompile

### DIFF
--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -58,6 +58,8 @@ RBMethodNode >> generate [
 
 { #category : #'*OpalCompiler-Core' }
 RBMethodNode >> generate: trailer [
+	"if the bytecode is regenerated, we need to reset the cache"
+	bcToASTCache := nil.
 	^ self generateIR compiledMethodWith: trailer.
 ]
 


### PR DESCRIPTION
With the BC->AST mapping cache, we need to make sure to reset it as soon as we regenerate the bytecode (as it could be regenerated with a modiefied AST or e.g. metalinks added)

This fixes the mapping for example when doing a "Debug test" from the browser menu