### PR TITLE
Add rendering time profiling support to AbstractWorldRenderer

### DIFF
--- a/src/Morphic-Core/AbstractWorldRenderer.class.st
+++ b/src/Morphic-Core/AbstractWorldRenderer.class.st
@@ -10,10 +10,22 @@ Class {
 		'alreadyActivated'
 	],
 	#classVars : [
-		'MainWorldRenderer'
+		'IsLoggingRenderingProfileToFile',
+		'IsProfilingRenderingTime',
+		'MainWorldRenderer',
+		'RenderingProfilingLogOutput'
 	],
 	#category : #'Morphic-Core-Worlds'
 }
+
+{ #category : #profiling }
+AbstractWorldRenderer class >> closeRenderingProfileLogFile [
+	RenderingProfilingLogOutput ifNotNil: [
+		RenderingProfilingLogOutput close.
+		RenderingProfilingLogOutput := nil.
+	]
+
+]
 
 { #category : #accessing }
 AbstractWorldRenderer class >> detectCorrectOneforWorld: aWorld [
@@ -29,6 +41,18 @@ AbstractWorldRenderer class >> detectCorrectOneforWorld: aWorld [
 	^ MainWorldRenderer := aRenderer
 ]
 
+{ #category : #profiling }
+AbstractWorldRenderer class >> disableRenderingProfileLogFile [
+	<script>
+	self isLoggingRenderingProfileToFile: false
+]
+
+{ #category : #profiling }
+AbstractWorldRenderer class >> enableRenderingProfileLogFile [
+	<script>
+	self isLoggingRenderingProfileToFile: true
+]
+
 { #category : #accessing }
 AbstractWorldRenderer class >> forWorld: aWorld [
 
@@ -41,6 +65,48 @@ AbstractWorldRenderer class >> forWorld: aWorld [
 AbstractWorldRenderer class >> initialize [
 
 	SessionManager default registerSystemClassNamed: self name	
+]
+
+{ #category : #profiling }
+AbstractWorldRenderer class >> isLoggingRenderingProfileToFile [
+	^ IsLoggingRenderingProfileToFile ifNil: [ IsLoggingRenderingProfileToFile := false ]
+]
+
+{ #category : #profiling }
+AbstractWorldRenderer class >> isLoggingRenderingProfileToFile: aBoolean [
+	IsLoggingRenderingProfileToFile := aBoolean.
+	IsLoggingRenderingProfileToFile ifFalse: [ self closeRenderingProfileLogFile ].
+]
+
+{ #category : #profiling }
+AbstractWorldRenderer class >> isProfilingRenderingTime [
+	^ IsProfilingRenderingTime ifNil: [IsProfilingRenderingTime := false]
+]
+
+{ #category : #profiling }
+AbstractWorldRenderer class >> isProfilingRenderingTime: aBoolean [
+	"
+	self isProfilingRenderingTime: true.
+	self isProfilingRenderingTime: false.
+	"
+	IsProfilingRenderingTime := aBoolean.
+	IsProfilingRenderingTime ifFalse: [ self closeRenderingProfileLogFile ].
+]
+
+{ #category : #profiling }
+AbstractWorldRenderer class >> logRenderingTimeMeasurements: measurements [
+	self isLoggingRenderingProfileToFile ifFalse: [ ^ self ].
+	RenderingProfilingLogOutput ifNil: [
+		RenderingProfilingLogOutput := (FileSystem workingDirectory / 'rendering-profile-log.csv') writeStream.
+		RenderingProfilingLogOutput truncate.
+		RenderingProfilingLogOutput nextPutAll: 'Class,Measurement,Time'; lf.
+	].
+	measurements do: [ :each |
+		RenderingProfilingLogOutput nextPutAll: self name asString;
+			nextPut: $,; nextPutAll: each key asString;
+			nextPut: $,; nextPutAll: each value asString;
+			lf
+	]
 ]
 
 { #category : #accessing }
@@ -63,11 +129,23 @@ AbstractWorldRenderer class >> shutDown: quitting [
 		ensure: [ MainWorldRenderer := nil ]
 ]
 
+{ #category : #profiling }
+AbstractWorldRenderer class >> startProfilingRenderingTime [
+	<script>
+	self isProfilingRenderingTime: true
+]
+
 { #category : #accessing }
 AbstractWorldRenderer class >> startUp: isANewSession [
 
 	isANewSession
 		ifTrue: [ MainWorldRenderer := nil ]
+]
+
+{ #category : #profiling }
+AbstractWorldRenderer class >> stopProfilingRenderingTime [
+	<script>
+	self isProfilingRenderingTime: false
 ]
 
 { #category : #activation }
@@ -152,6 +230,11 @@ AbstractWorldRenderer >> drawDuring: aBlock [
 	self subclassResponsibility
 ]
 
+{ #category : #profiling }
+AbstractWorldRenderer >> formatRenderingTimeMeasurement: measurement [	
+	^ '[{1}]{2}: {3} ms' format: {self class name . measurement key . measurement value printPaddedWith: Character space to: 5}.
+]
+
 { #category : #accessing }
 AbstractWorldRenderer >> icon: aForm [ 
 
@@ -168,6 +251,16 @@ AbstractWorldRenderer >> initialize [
 AbstractWorldRenderer >> invalidate [
 	"Invalidate the entire render"
 	"Each subclass should define me properly"
+]
+
+{ #category : #testing }
+AbstractWorldRenderer >> isProfilingRenderingTime [
+	^ self class isProfilingRenderingTime
+]
+
+{ #category : #profiling }
+AbstractWorldRenderer >> logRenderingTimeMeasurements: measurements [
+	self class logRenderingTimeMeasurements: measurements
 ]
 
 { #category : #operations }

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -8,7 +8,8 @@ Class {
 		'driver',
 		'osWindow',
 		'display',
-		'windowCloseAction'
+		'windowCloseAction',
+		'previousFrameRenderingTime'
 	],
 	#category : #'OSWindow-Core-Morphic'
 }
@@ -107,11 +108,47 @@ OSWorldRenderer >> doActivate [
 
 { #category : #operations }
 OSWorldRenderer >> drawDuring: aBlock [
-
 	osWindow ifNil: [ ^ self ].
+	self isProfilingRenderingTime ifTrue: [ ^ self drawWhileProfilingRenderingTimeDuring: aBlock ].
 	self osWindowRenderer deferUpdatesWhile: [
 		self osWindowRenderer drawDuring: aBlock
-	].	
+	].
+]
+
+{ #category : #profiling }
+OSWorldRenderer >> drawWhileProfilingRenderingTimeDuring: aBlock [
+	| measurements |
+	previousFrameRenderingTime := [
+		self osWindowRenderer deferUpdatesWhile: [
+			self osWindowRenderer drawDuring: [ :canvas |
+				| frameCanvasRenderingTime displayRectangle |
+				frameCanvasRenderingTime := [ aBlock value: canvas ] timeToRunWithoutGC.
+					
+				measurements := {
+					'Content' -> frameCanvasRenderingTime
+				}.
+				previousFrameRenderingTime ifNotNil: [
+					measurements := measurements , {
+						'Previous frame' -> previousFrameRenderingTime.
+					}
+				].
+				
+				displayRectangle := (0@0 extent: 250@40).
+				canvas
+					fillRectangle: displayRectangle color: Color white.
+				measurements doWithIndex: [ :each :index |
+					| line |
+					line := self formatRenderingTimeMeasurement: each.
+					canvas drawString: line at: 10@(10*index) font: nil color: Color black.
+				].
+				
+				self osWindowRenderer updateRectangle: displayRectangle.
+			]
+		]
+	] timeToRunWithoutGC.
+	
+	self logRenderingTimeMeasurements: measurements
+
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
These changes add support for profiling the rendering time of a morphic world, and logging the time taken by the different frames into a .csv file.

For starting and stopping the profiling, the following methods are added into AbstractWorldRenderer:
- AbstractWorldRenderer startProfilingRenderingTime
- AbstractWorldRenderer stopProfilingRenderingTime

For logging the frame rendering times into a file, the following methods are provided:
- AbstractWorldRenderer enableRenderingProfileLogFile
- AbstractWorldRenderer disableRenderingProfileLogFile

These class side methods are tagged with the <script> pragma, so they can executed by just clicking on them in the browser.
