### PR TITLE
SystemHelp-no-PragmaCollector

### DIFF
--- a/src/HelpSystem-Core/SystemHelp.class.st
+++ b/src/HelpSystem-Core/SystemHelp.class.st
@@ -10,29 +10,19 @@ So ""HelpBrowser open"" is the same as ""HelpBrowser openOn: SystemHelp"".
 Class {
 	#name : #SystemHelp,
 	#superclass : #Object,
-	#classInstVars : [
-		'pragmaCollector',
-		'helpTopic'
-	],
 	#category : #'HelpSystem-Core-Utilities'
 }
 
 { #category : #'private accessing' }
 SystemHelp class >> allSystemHelpPragmas [
-	^ self pragmaCollector collected
-
+	^ Pragma allNamed: self pragmaKeyword
 ]
 
-{ #category : #accessing }
+{ #category : #'instance creation' }
 SystemHelp class >> asHelpTopic [ 
 
-	^ helpTopic ifNil: [ helpTopic := self createHelpTopic].
-
-]
-
-{ #category : #reset }
-SystemHelp class >> createHelpTopic [
 	|topic helpOnHelp sortedTopics |
+	
 	topic := HelpTopic named: 'Help'.
 	self allSystemHelpPragmas do: [:each | 
 		topic subtopics addAll: each method methodClass instanceSide asHelpTopic subtopics
@@ -44,17 +34,6 @@ SystemHelp class >> createHelpTopic [
 	sortedTopics addLast: helpOnHelp.
 	topic subtopics: sortedTopics.
 	^topic
-
-]
-
-{ #category : #accessing }
-SystemHelp class >> pragmaCollector [
-	^ pragmaCollector
-		ifNil: [ pragmaCollector := (PragmaCollector
-				filter: [ :prag | prag selector = self pragmaKeyword ])
-				reset;
-				whenChangedDo: [ self resetHelpTopic ];
-				yourself ]
 ]
 
 { #category : #'private accessing' }
@@ -62,10 +41,4 @@ SystemHelp class >> pragmaKeyword [
 
 	^#systemHelp
 
-]
-
-{ #category : #reset }
-SystemHelp class >> resetHelpTopic [
-
-	helpTopic := self createHelpTopic 
 ]


### PR DESCRIPTION
SystemHelp class does really neither need a PragmaCollector, nor cache the created instances.

[SystemHelp asHelpTopic] bench "'11.433 per second'"

(and it looks like the UI caches in addition...)