### PR TITLE
CompiledMethod-deprecate-old-propertiesAPI

### DIFF
--- a/src/Deprecated90/CompiledMethod.extension.st
+++ b/src/Deprecated90/CompiledMethod.extension.st
@@ -23,3 +23,32 @@ CompiledMethod >> hasLinks [
 		transformWith:  '`@receiver hasLinks' -> '`@receiver hasMetaLinks'.
 	^self hasMetaLinks
 ]
+
+{ #category : #'*Deprecated90' }
+CompiledMethod >> propertyValueAt: propName [
+
+	"the is the old API, we unified the API over all structure (Classes, Methods, AST Nodes)"
+
+	self
+		deprecated: 'use #propertyAt:'
+		transformWith: '`@receiver propertyValueAt: `@arg' -> '`@receiver propertyAt: `@arg'.
+	^ self propertyAt: propName
+]
+
+{ #category : #'*Deprecated90' }
+CompiledMethod >> propertyValueAt: propName ifAbsent: aBlock [
+	"the is the old API, we unified the API over all structure (Classes, Methods, AST Nodes)"
+	self
+		deprecated: 'use #propertyAt:ifAbsent:'
+		transformWith: '`@receiver propertyValueAt: `@arg1 ifAbsent: `@arg2' -> '`@receiver propertyAt: `@arg1 ifAbsent: `@arg2'.
+	^self propertyAt: propName ifAbsent: aBlock
+]
+
+{ #category : #'*Deprecated90' }
+CompiledMethod >> propertyValueAt: propName put: propValue [
+	"the is the old API, we unified the API over all structure (Classes, Methods, AST Nodes)"
+	self
+		deprecated: 'use #propertyAt:put:'
+		transformWith: '`@receiver propertyValueAt: `@arg1 put: `@arg2' -> '`@receiver propertyAt: `@arg1 put: `@arg2'.
+	^self propertyAt: propName put: propValue
+]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -917,24 +917,6 @@ CompiledMethod >> propertyKeysAndValuesDo: aBlock [
 		[propertiesOrSelector propertyKeysAndValuesDo: aBlock]
 ]
 
-{ #category : #'accessing-properties - compatibility' }
-CompiledMethod >> propertyValueAt: propName [
-	"use the version without ..Value, this methid is retained for compatibility"
-	^self propertyAt: propName
-]
-
-{ #category : #'accessing-properties - compatibility' }
-CompiledMethod >> propertyValueAt: propName ifAbsent: aBlock [
-	"use the version without ..Value, this method is retained for compatibility"
-	^self propertyAt: propName ifAbsent: aBlock
-]
-
-{ #category : #'accessing-properties - compatibility' }
-CompiledMethod >> propertyValueAt: propName put: propValue [
-	"use the version without ..Value, this method is retained for compatibility"
-	^self propertyAt: propName put: propValue
-]
-
 { #category : #accessing }
 CompiledMethod >> protocol [
 	"Return in which protocol (conceptual groups of methods) the receiver is grouped into."


### PR DESCRIPTION
On CompiledMethod, the is the old property API.

We unified the API over all structure  (Classes, Methods, AST Nodes), we shoudl deprecate it.