### PR TITLE
Variables-better-name-for-isBlockVar

### DIFF
--- a/src/AST-Core-Tests/RBVariableNodeTest.class.st
+++ b/src/AST-Core-Tests/RBVariableNodeTest.class.st
@@ -8,6 +8,40 @@ Class {
 }
 
 { #category : #tests }
+RBVariableNodeTest >> testIsDefinedByBlock [
+
+	| ast temps args |
+	ast := self class compiler parse: 'myMethod: arg
+  | test |
+  test := 2.
+  test.
+	[ :test2 | | test3| test2. test3].
+  ^test'.
+	ast doSemanticAnalysis.
+	temps := ast allChildren select: [ :each | each isTemp ].
+	"test is defined by the method"
+	self deny: temps first isDefinedByBlock.
+	self deny: temps second isDefinedByBlock.
+	self deny: temps third isDefinedByBlock.
+
+	"test3 definition"
+	self assert: ast blockNodes first arguments first isDefinedByBlock.
+	"test3 definition"
+	self assert: temps fourth isDefinedByBlock.
+	"test 3 use"
+	self assert: temps fifth isDefinedByBlock.
+	"and we are out if the block"
+	self deny: temps sixth isDefinedByBlock.
+
+	args := ast allChildren select: [ :each | each isArgumentVariable ].
+	"method arg"
+	self deny: args first isDefinedByBlock.
+	self assert: args second isDefinedByBlock.
+	"use of test3"
+	self assert: args third isDefinedByBlock
+]
+
+{ #category : #tests }
 RBVariableNodeTest >> testIsDefinition [
 	| ast temps |
 	ast := self class compiler

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -125,8 +125,8 @@ RBVariableNode >> isClassVariable [
 
 { #category : #testing }
 RBVariableNode >> isDefinedByBlock [
-	"true if a variable node is defined by a block node"
-	^variable scope isBlockScope
+	"true if a variable node is defined by a block"
+	^variable isDefinedByBlock
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -118,15 +118,15 @@ RBVariableNode >> isArgumentVariable [
 ]
 
 { #category : #testing }
-RBVariableNode >> isBlockVar [
-	"true if a variable node is defined by a block node"
-	^variable scope isBlockScope
-]
-
-{ #category : #testing }
 RBVariableNode >> isClassVariable [
 	^variable isClassVariable
 
+]
+
+{ #category : #testing }
+RBVariableNode >> isDefinedByBlock [
+	"true if a variable node is defined by a block node"
+	^variable scope isBlockScope
 ]
 
 { #category : #testing }

--- a/src/Deprecated90/RBVariableNode.extension.st
+++ b/src/Deprecated90/RBVariableNode.extension.st
@@ -10,6 +10,15 @@ RBVariableNode >> isArg [
 ]
 
 { #category : #'*Deprecated90' }
+RBVariableNode >> isBlockVar [
+	self 
+		deprecated: 'use #isDefinedByBlock instead' 
+		transformWith: '`@receiver isBlockVar' -> '`@receiver isDefinedByBlock'.
+	
+	^self isDefinedByBlock
+]
+
+{ #category : #'*Deprecated90' }
 RBVariableNode >> isGlobal [
 	"isGlobal used to return true for both class variables and globals (and even undeclared Variables).
 	From Pharo9 on, #isGlobalVariable returns true only for real globals"

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -115,6 +115,13 @@ Variable >> isClassVariable [
 ]
 
 { #category : #testing }
+Variable >> isDefinedByBlock [
+	"true if a variable node is defined by a block"
+	^false
+
+]
+
+{ #category : #testing }
 Variable >> isGlobalVariable [
 	^ false
 ]

--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -109,6 +109,12 @@ LocalVariable >> isCopying [
 	^false
 ]
 
+{ #category : #testing }
+LocalVariable >> isDefinedByBlock [
+	"true if a variable node is defined by a block"
+	^scope isBlockScope
+]
+
 { #category : #escaping }
 LocalVariable >> isEscaping [
 	^escaping = #escapingRead or: [escaping = #escapingWrite]

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -979,7 +979,7 @@ SHRBTextStyler >> literalStyleSymbol: aValue [
 
 { #category : #private }
 SHRBTextStyler >> methodOrBlockArgStyleFor: anArgumentNode [
-	^ anArgumentNode isBlockVar
+	^ anArgumentNode isDefinedByBlock
 		ifTrue: [ anArgumentNode isDefinition 
 				ifTrue: [ #blockPatternArg ]
 				ifFalse: [ #blockArg ] ]
@@ -995,7 +995,7 @@ SHRBTextStyler >> methodOrBlockTempDeclStyleFor: aSequenceNode [
 
 { #category : #private }
 SHRBTextStyler >> methodOrBlockTempStyleFor: aTemporaryNode [
-	^ aTemporaryNode isBlockVar
+	^ aTemporaryNode isDefinedByBlock
 		ifTrue: [ #blockTempVar ]
 		ifFalse: [ #tempVar ]
 ]


### PR DESCRIPTION
#isBlockVar is a bad name. It implies that it checks if a node is some kind of Variable, but instead it checks if a Variable is defined by a block.

- use #isDefinedByBlock
- deprecated isBlockVar
- add test
- fix the two senders