### PR TITLE
Variables-variable-not-binding

### DIFF
--- a/src/ClassParser/CDClassDefinitionNode.class.st
+++ b/src/ClassParser/CDClassDefinitionNode.class.st
@@ -23,8 +23,7 @@ CDClassDefinitionNode class >> on: aRBMessageNode [
 
 { #category : #accessing }
 CDClassDefinitionNode >> binding [ 
-	self trace: '.'.
-	^ self class environment associationAt: self className ifAbsent: [LiteralVariable key: nil value: self].
+	^self variable
 ]
 
 { #category : #testing }
@@ -122,4 +121,10 @@ CDClassDefinitionNode >> tag [
 CDClassDefinitionNode >> tag: aString [
 
 	tag := aString
+]
+
+{ #category : #accessing }
+CDClassDefinitionNode >> variable [ 
+	self trace: '.'.
+	^ self class environment associationAt: self className ifAbsent: [LiteralVariable key: nil value: self].
 ]

--- a/src/ClassParser/CDClassNameNode.class.st
+++ b/src/ClassParser/CDClassNameNode.class.st
@@ -8,8 +8,8 @@ Class {
 }
 
 { #category : #accessing }
-CDClassNameNode >> binding [
-	^self existingBindingIfAbsent: [LiteralVariable key: className value: nil]
+CDClassNameNode >> binding [ 
+	^self variable
 ]
 
 { #category : #accessing }
@@ -65,4 +65,9 @@ CDClassNameNode >> name [
 CDClassNameNode >> value [
 	
 	^ className
+]
+
+{ #category : #accessing }
+CDClassNameNode >> variable [
+	^self existingBindingIfAbsent: [LiteralVariable key: className value: nil]
 ]

--- a/src/ClassParser/CDSlotNode.class.st
+++ b/src/ClassParser/CDSlotNode.class.st
@@ -46,9 +46,8 @@ CDSlotNode >> asSlot [
 ]
 
 { #category : #accessing }
-CDSlotNode >> binding [
-	"To be polymorphic to RB method nodes"
-	^self
+CDSlotNode >> binding [ 
+	^self variable
 ]
 
 { #category : #accessing }
@@ -194,4 +193,10 @@ CDSlotNode >> stop [
 CDSlotNode >> stop: anInteger [ 
 	
 	stop := anInteger
+]
+
+{ #category : #accessing }
+CDSlotNode >> variable [
+	"To be polymorphic to RB method nodes"
+	^self
 ]

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -455,7 +455,7 @@ Behavior >> becomeUncompact [
 
 { #category : #accessing }
 Behavior >> binding [
-	^ LiteralVariable key: nil value: self
+	^ self variable
 ]
 
 { #category : #'accessing instances and variables' }
@@ -1750,6 +1750,11 @@ Behavior >> usingMethods [
 	"all methods that reference me"
 	self isAnonymous ifTrue: [ ^#() ].
 	^self binding usingMethods
+]
+
+{ #category : #accessing }
+Behavior >> variable [
+	^ LiteralVariable key: nil value: self
 ]
 
 { #category : #queries }

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -238,14 +238,6 @@ Class >> basicDeclareClassVariable: aClassVariable [
 ]
 
 { #category : #compiling }
-Class >> binding [
-   "Answer a binding for the receiver, sharing if possible"
-   | binding |
-	binding := self environment associationAt: self name ifAbsent: [LiteralVariable key: nil value: self].
-   ^binding value == self ifTrue: [binding] ifFalse: [LiteralVariable key: nil value: self]
-]
-
-{ #category : #compiling }
 Class >> bindingOf: varName [
 	"Answer the binding of some variable resolved in the scope of the receiver, or nil
 	if variable with such name is not defined"
@@ -1336,6 +1328,14 @@ Class >> usesPoolVarNamed: aString [
 	"Return whether the receiver has a pool variable named: aString, taking into account superclasses too"
 	
 	^self allSharedPools anySatisfy: [:each | each usesClassVarNamed: aString]
+]
+
+{ #category : #compiling }
+Class >> variable [
+   "Answer a binding for the receiver, sharing if possible"
+   | binding |
+	binding := self environment associationAt: self name ifAbsent: [LiteralVariable key: nil value: self].
+   ^binding value == self ifTrue: [binding] ifFalse: [LiteralVariable key: nil value: self]
 ]
 
 { #category : #'subclass creation - deprecated' }

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -67,15 +67,6 @@ Metaclass >> adoptInstance: oldInstance from: oldMetaClass [
 ]
 
 { #category : #compiling }
-Metaclass >> binding [
-	"return an association that can be used as the binding
-	 To share it between methods, reuse an existing one if possible"
-	^self methodDict 
-		ifEmpty: [LiteralVariable key: nil value: self]
-		ifNotEmpty: [:dict | dict anyOne classBinding]
-]
-
-{ #category : #compiling }
 Metaclass >> bindingOf: varName [
 
 	^self instanceSide classBindingOf: varName
@@ -359,6 +350,15 @@ Metaclass >> subclassesDo: aBlock [
 	
 	self isMetaclassOfClassOrNil ifTrue: [ ^ self ].
 	self instanceSide subclasses do: [ :each | aBlock value: each classSide ]
+]
+
+{ #category : #compiling }
+Metaclass >> variable [
+	"return an association that can be used as the binding
+	 To share it between methods, reuse an existing one if possible"
+	^self methodDict 
+		ifEmpty: [LiteralVariable key: nil value: self]
+		ifNotEmpty: [:dict | dict anyOne classBinding]
 ]
 
 { #category : #copying }

--- a/src/Reflectivity/RFLiteralVariableNode.class.st
+++ b/src/Reflectivity/RFLiteralVariableNode.class.st
@@ -41,3 +41,8 @@ RFLiteralVariableNode >> start [
 RFLiteralVariableNode >> stop [
 	^1
 ]
+
+{ #category : #accessing }
+RFLiteralVariableNode >> variable [ 
+	^binding
+]

--- a/src/Ring-RuntimeSupport/RGBehavior.extension.st
+++ b/src/Ring-RuntimeSupport/RGBehavior.extension.st
@@ -128,6 +128,12 @@ RGBehavior >> traits [
 ]
 
 { #category : #'*Ring-RuntimeSupport' }
+RGBehavior >> variable [
+
+	^ self environment bindingOf: self name
+]
+
+{ #category : #'*Ring-RuntimeSupport' }
 RGBehavior >> withAllSuperclasses [
 	"Answer an OrderedCollection of the receiver and the receiver's 
 	superclasses. The first element is the receiver, 


### PR DESCRIPTION
Historically, sending #binding to a Class gives you the association in the systemDictionary.

We have now changed this so that those objects are the Variables representing the concept of accessing the global variable.

That is, 

OrderedCollection variable

now returns the *Variable* that references OrderedCollection.

To be in sync everywhere, we should use the selector #variable to get Variables. We did that already on the AST node level, this PR does the same change on the level of Behaviors.

-> the implemetation is now #variable
-> binding is retained as a compatibility method.

A later PR then can change all users of binding to use #variable instead