### PR TITLE
More-PragmaCollector-Improvements

### DIFF
--- a/src/Deprecated90/PragmaCollector.extension.st
+++ b/src/Deprecated90/PragmaCollector.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #PragmaCollector }
+
+{ #category : #'*Deprecated90' }
+PragmaCollector class >> allSystemPragmas [
+	self deprecated: 'use Pragma allInstalled instead'.
+	^ Pragma allInstalled
+]

--- a/src/Keymapping-Pragmas/KMPragmaKeymapBuilder.class.st
+++ b/src/Keymapping-Pragmas/KMPragmaKeymapBuilder.class.st
@@ -125,8 +125,8 @@ KMPragmaKeymapBuilder >> pragmaCollector [
 	"Return an up-to-date pragmaCollector which contains all pragmas which keyword is self pragmaKeyword"
 
 	^ pragmaCollector
-		ifNil: [ pragmaCollector := (PragmaCollector
-				selectors: self pragmaKeywords)
+		ifNil: [ pragmaCollector := PragmaCollector
+				selectors: self pragmaKeywords
 				filter: [ :prg | prg methodSelector numArgs = 1 ].
 			self pragmaKeywords isEmptyOrNil 
 				ifFalse: [ pragmaCollector reset ].

--- a/src/Keymapping-Pragmas/KMPragmaKeymapBuilder.class.st
+++ b/src/Keymapping-Pragmas/KMPragmaKeymapBuilder.class.st
@@ -125,12 +125,11 @@ KMPragmaKeymapBuilder >> pragmaCollector [
 	"Return an up-to-date pragmaCollector which contains all pragmas which keyword is self pragmaKeyword"
 
 	^ pragmaCollector
-		ifNil: [ pragmaCollector := PragmaCollector
-				filter: [ :prg | 
-					(self pragmaKeywords includes: prg selector)
-						and: [ prg methodSelector numArgs = 1 ] ].
-			(self pragmaKeywords notNil and: [ self pragmaKeywords notEmpty ])
-				ifTrue: [ pragmaCollector reset ].
+		ifNil: [ pragmaCollector := (PragmaCollector
+				selectors: self pragmaKeywords)
+				filter: [ :prg | prg methodSelector numArgs = 1 ].
+			self pragmaKeywords isEmptyOrNil 
+				ifFalse: [ pragmaCollector reset ].
 			pragmaCollector whenChangedSend: #reset to: self.
 			pragmaCollector ]
 ]

--- a/src/MenuRegistration/PragmaMenuBuilder.class.st
+++ b/src/MenuRegistration/PragmaMenuBuilder.class.st
@@ -260,20 +260,13 @@ PragmaMenuBuilder >> pragmaCollector [
 	"Return an up-to-date pragmaCollector which contains all pragmas which keyword is self pragmaKeyword"
 
 	^ pragmaCollector
-		ifNil: [ pragmaCollector := PragmaCollector
-				filter: [ :prg | 
-					(self pragmaKeywords includes: prg selector)
-						and: [ prg methodSelector numArgs = 1 ] ].
-			(self pragmaKeywords notNil and: [ self pragmaKeywords notEmpty ])
-				ifTrue: [ pragmaCollector reset ].
+		ifNil: [ pragmaCollector := (PragmaCollector
+				selectors: self pragmaKeywords)
+				filter: [ :prg | prg methodSelector numArgs = 1 ].
+			self pragmaKeywords isEmptyOrNil 
+				ifFalse: [ pragmaCollector reset ].
 			pragmaCollector whenChangedSend: #reset to: self.
 			pragmaCollector ]
-]
-
-{ #category : #accessing }
-PragmaMenuBuilder >> pragmaKeyword [
-	"Deprecated"
-	^  pragmaKeywords isEmptyOrNil ifFalse: [pragmaKeywords first]
 ]
 
 { #category : #accessing }

--- a/src/MenuRegistration/PragmaMenuBuilder.class.st
+++ b/src/MenuRegistration/PragmaMenuBuilder.class.st
@@ -260,8 +260,8 @@ PragmaMenuBuilder >> pragmaCollector [
 	"Return an up-to-date pragmaCollector which contains all pragmas which keyword is self pragmaKeyword"
 
 	^ pragmaCollector
-		ifNil: [ pragmaCollector := (PragmaCollector
-				selectors: self pragmaKeywords)
+		ifNil: [ pragmaCollector := PragmaCollector
+				selectors: self pragmaKeywords
 				filter: [ :prg | prg methodSelector numArgs = 1 ].
 			self pragmaKeywords isEmptyOrNil 
 				ifFalse: [ pragmaCollector reset ].

--- a/src/PragmaCollector/PragmaCollector.class.st
+++ b/src/PragmaCollector/PragmaCollector.class.st
@@ -1,20 +1,42 @@
 "
+Note: In most cases it is better to use the class side methods of Pragma instead.
+
+PragmaCollector is useful if a client needs to be notified if pragmas are added or removed.
+If you do not store the PragmaCollector instance, you most likely can just use the API of Pragma directly.
+
 A PragmaCollector is used in order to collect some Pragma instances. A PragmaCollector makes use of SystemChangeNotifier event notifications in order to maintain its contents up-to-date according to its filter: when a method is added, removed or updated, if the method is defined with a pragma which is acceptable according to its filter, then the collector contents is updated. A PragmaCollector makes use of an announcer in order to notify all registered listeners when a pragma is added, removed or updated. A PragmaAnnouncement is announced when a Pragma is added, removed or updated. Corresponding announcement classes are, respectiveley, PragmaAdded, PragmaRemoved and PragmaUpdated. 
+
+The filter is applied to all Pragmas or (faster) pragmas with the selectors defined by #selectors:.
 
 Explore the result of the expression below. In the collected instance variable should be stored all pragmas of the system:
 ---------------------------
 (PragmaCollector filter: [:pragma | true]) reset
 ---------------------------
 
-In the following example, collected pragma are thoses with the 'primitive:' keyword (<primitive:>)
+In the following example, collected pragma are thoses with the 'primitive:' selector (<primitive:>)
 ---------------------------
-(PragmaCollector filter: [:prg | prg keyword = 'primitive:']) reset
+(PragmaCollector filter: [:prg | prg selector = 'primitive:']) reset.
+---------------------------
+
+In this case it is faster to specify selectors via #selector, as this avoids to iterate over all Pragmas of the system:
+
+---------------------------
+(PragmaCollector selectors: #(primitive:)) reset
+---------------------------
+
+We can specify both the selectors and an additional filter, e.g. filter for all Pragmas named primitive: in methods that have one Argument:
+ 
+---------------------------
+(PragmaCollector 
+	selectors: #(primitive:) 
+	filter: [:prg | prg methodSelector numArgs = 1] ) reset
 ---------------------------
 
 Instance Variables	
 	announcer:		<Announcer>	
 	collected:		<Collection>
 	filter:			<Block or MessageSend>
+	selector:      <Array of symbols>
 				
 announcer
 	the announcer which is used to announce the adding, the removing or the updating of a method with an acceptable pragma declaration
@@ -40,15 +62,21 @@ Class {
 
 { #category : #'instance creation' }
 PragmaCollector class >> filter: aOneArgValuable [
-	"better use selectors: to create the instance, this avoids the need to iterate over all Pragmas"
+	"Create a PragmaCollector that filters all system pragmas"
+	"Note: If you know whoch pragma selectors are interesting, better use selectors:filter: to create the instance, this avoids the need to iterate over all Pragmas"
 	^ self new filter: aOneArgValuable
 ]
 
 { #category : #'instance creation' }
 PragmaCollector class >> selectors: anArray [
-	"Create a PragmaCollector that looks for pragams with these selectors. 
-	You can call #filter: on the instance to filter them even more"
+	"Create a PragmaCollector that looks for Pragmas with the specified selectors"
 	^ self new selectors: anArray
+]
+
+{ #category : #'instance creation' }
+PragmaCollector class >> selectors: anArray filter: aBlock [
+	"Create a PragmaCollector that looks for Pragmas with the specified selectors, filter using aBlock"
+	^ (self new selectors: anArray) filter: aBlock
 ]
 
 { #category : #updating }

--- a/src/PragmaCollector/PragmaCollector.class.st
+++ b/src/PragmaCollector/PragmaCollector.class.st
@@ -161,8 +161,8 @@ PragmaCollector >> isNotEmpty [
 
 { #category : #updating }
 PragmaCollector >> keepPragma: aPragma [
+	(selectors notNil and: [(selectors includes: aPragma selector) not ]) ifTrue: [ ^ false ].
 	^ self filter value: aPragma
-
 ]
 
 { #category : #'system changes' }

--- a/src/PragmaCollector/PragmaCollector.class.st
+++ b/src/PragmaCollector/PragmaCollector.class.st
@@ -32,19 +32,23 @@ Class {
 	#instVars : [
 		'collected',
 		'filter',
-		'announcing'
+		'announcing',
+		'selectors'
 	],
 	#category : #'PragmaCollector-Base'
 }
 
-{ #category : #utilities }
-PragmaCollector class >> allSystemPragmas [
-	^ Pragma allInstalled
+{ #category : #'instance creation' }
+PragmaCollector class >> filter: aOneArgValuable [
+	"better use selectors: to create the instance, this avoids the need to iterate over all Pragmas"
+	^ self new filter: aOneArgValuable
 ]
 
 { #category : #'instance creation' }
-PragmaCollector class >> filter: aOneArgValuable [
-	^ self new filter: aOneArgValuable
+PragmaCollector class >> selectors: anArray [
+	"Create a PragmaCollector that looks for pragams with these selectors. 
+	You can call #filter: on the instance to filter them even more"
+	^ self new selectors: anArray
 ]
 
 { #category : #updating }
@@ -226,6 +230,13 @@ PragmaCollector >> pragmaWithSelector: aSelector inClass: aClass [
 		detect: [ :prag | prag methodClass = aClass and: [ prag methodSelector = aSelector ] ]
 ]
 
+{ #category : #accessing }
+PragmaCollector >> pragmas [
+	^ selectors 
+		ifNil: [ Pragma allInstalled ]
+		ifNotNil: [ selectors flatCollect: [:each | Pragma allNamed: each ] ]
+]
+
 { #category : #querying }
 PragmaCollector >> pragmasOfClass: aClass [ 
 	"return all handlers of class aClass"
@@ -269,7 +280,7 @@ PragmaCollector >> reset [
 	self
 		noMoreAnnounceWhile: [self collected copy
 				do: [:pragma | self removePragma: pragma].
-			self class allSystemPragmas
+			self pragmas
 				do: [:pragma | self addPragma: pragma]].
 	self announce: (PragmaCollectorReset collector: self)
 ]
@@ -278,6 +289,16 @@ PragmaCollector >> reset [
 PragmaCollector >> select: aBlock [
 	^ self collected select: aBlock
 	
+]
+
+{ #category : #accessing }
+PragmaCollector >> selectors [
+	^selectors
+]
+
+{ #category : #accessing }
+PragmaCollector >> selectors: anArray [
+	selectors := anArray
 ]
 
 { #category : #subscription }


### PR DESCRIPTION
PragmaCollector has just one way to create itself: by filtering all Pragmas. 

This is not a good idea, as this means that it always has to iterate over all Pragmas. For large systems, this is slow however you do it
(iterate all methods or iterate all pragmas of the cache and check if the methods are still installed)

For one, PragmaCollector is often not needed. But existing clients that rely on announcements of added / removed pragmas can benefit from a simple change: When creating PragmaCollector, we can
pre-set which Pragma selectors we are interested in.

This PR implements creating PragmaCollector with #selectors:  and changes both PragmaMenuBuilder and KMKeymapBuilder to use this new scheme.