### PR TITLE
Remove the implicit coercion of float indices into integers in #at: and family

### DIFF
--- a/src/Collections-Strings/WideString.class.st
+++ b/src/Collections-Strings/WideString.class.st
@@ -115,9 +115,7 @@ WideString >> at: index [
 		ifTrue:
 			[self errorSubscriptBounds: index]
 		ifFalse:
-			[index isNumber
-				ifTrue: [self at: index asInteger]
-				ifFalse: [self errorNonIntegerIndex]]
+			[self errorNonIntegerIndex]
 ]
 
 { #category : #accessing }

--- a/src/FormCanvas-Core/ShortIntegerArray.class.st
+++ b/src/FormCanvas-Core/ShortIntegerArray.class.st
@@ -47,7 +47,6 @@ ShortIntegerArray >> at: index [
 
 	<primitive: 143>
 	index isInteger ifTrue: [self errorSubscriptBounds: index].
-	index isNumber ifTrue: [^ self at: index truncated].
 	self errorNonIntegerIndex.
 
 ]
@@ -62,7 +61,6 @@ ShortIntegerArray >> at: index put: value [
 			(index between: 1 and: self size)
 				ifTrue: [ self errorImproperStore ]
 				ifFalse: [ self errorSubscriptBounds: index ] ].
-	index isNumber ifTrue: [ ^ self at: index truncated put: value ].
 	self errorNonIntegerIndex
 ]
 
@@ -76,7 +74,6 @@ ShortIntegerArray >> pvtAt: index [
 	"Private -- for swapping only"
 	<primitive: 143>
 	index isInteger ifTrue: [self errorSubscriptBounds: index].
-	index isNumber ifTrue: [^ self at: index truncated].
 	self errorNonIntegerIndex.
 
 ]
@@ -91,7 +88,6 @@ ShortIntegerArray >> pvtAt: index put: value [
 			(index between: 1 and: self size)
 				ifTrue: [ self errorImproperStore ]
 				ifFalse: [ self errorSubscriptBounds: index ] ].
-	index isNumber ifTrue: [ ^ self at: index truncated put: value ].
 	self errorNonIntegerIndex
 ]
 

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -336,9 +336,7 @@ Context >> basicAt: index [
 	<primitive: 210>
 	index isInteger ifTrue:
 		[self errorSubscriptBounds: index].
-	index isNumber
-		ifTrue: [^self at: index asInteger]
-		ifFalse: [self errorNonIntegerIndex]
+	self errorNonIntegerIndex
 ]
 
 { #category : #accessing }
@@ -352,9 +350,7 @@ Context >> basicAt: index put: value [
 	<primitive: 211>
 	index isInteger ifTrue:
 		[self errorSubscriptBounds: index].
-	index isNumber
-		ifTrue: [^self at: index asInteger put: value]
-		ifFalse: [self errorNonIntegerIndex]
+	self errorNonIntegerIndex
 ]
 
 { #category : #accessing }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -379,9 +379,7 @@ Object >> at: index [
 		[self class isVariable
 			ifTrue: [self errorSubscriptBounds: index]
 			ifFalse: [self errorNotIndexable]].
-	index isNumber
-		ifTrue: [^self at: index asInteger]
-		ifFalse: [self errorNonIntegerIndex]
+	self errorNonIntegerIndex
 ]
 
 { #category : #accessing }
@@ -398,10 +396,7 @@ Object >> at: index put: value [
 			ifTrue: [(index between: 1 and: self size)
 				ifFalse: [ ^ self errorSubscriptBounds: index]]
 			ifFalse: [ ^ self errorNotIndexable ]]
-		ifFalse: [  
-			^ index isNumber
-				ifTrue: [ self at: index asInteger put: value]
-				ifFalse: [ self errorNonIntegerIndex] ].
+		ifFalse: [ ^ self errorNonIntegerIndex ].
 	self isReadOnlyObject 
 		ifTrue: [ ^ self modificationForbiddenFor: #at:put: index: index value: value ].
 	self errorImproperStore 
@@ -429,9 +424,7 @@ Object >> basicAt: index [
 
 	<primitive: 60>
 	index isInteger ifTrue: [self errorSubscriptBounds: index].
-	index isNumber
-		ifTrue: [^self basicAt: index asInteger]
-		ifFalse: [self errorNonIntegerIndex]
+	self errorNonIntegerIndex
 ]
 
 { #category : #accessing }
@@ -449,10 +442,7 @@ Object >> basicAt: index put: value [
 			ifTrue: [(index between: 1 and: self size)
 				ifFalse: [ ^ self errorSubscriptBounds: index ]]
 			ifFalse: [ ^ self errorNotIndexable ]]
-		ifFalse: [  
-			^ index isNumber
-				ifTrue: [ self basicAt: index asInteger put: value ]
-				ifFalse: [ self errorNonIntegerIndex ] ].
+		ifFalse: [ ^ self errorNonIntegerIndex ].
 	self isReadOnlyObject 
 		ifTrue: [ ^ self modificationForbiddenFor: #basicAt:put: index: index value: value ].
 	self errorImproperStore 


### PR DESCRIPTION
We found this that looks like a really bad smell. This kind of type coercions if needed should always be done by the user.