### PR TITLE
SettingsTree-optimize-PragmaCollector

### DIFF
--- a/src/Deprecated90/PragmaCollector.extension.st
+++ b/src/Deprecated90/PragmaCollector.extension.st
@@ -2,6 +2,6 @@ Extension { #name : #PragmaCollector }
 
 { #category : #'*Deprecated90' }
 PragmaCollector class >> allSystemPragmas [
-	self deprecated: 'use Pragma allInstalled instead'.
-	^ Pragma allInstalled
+	self deprecated: 'use Pragma all instead'.
+	^ Pragma all
 ]

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -449,6 +449,17 @@ CompiledMethodTest >> testHasLiteralSuchThat [
 	self assert: (Object >> #halt hasLiteralSuchThat: [ :lit | lit == #now ]).
 ]
 
+{ #category : #'tests - testing' }
+CompiledMethodTest >> testHasPragma [
+
+	| methodWithPragma methodWithOutPragma |
+	methodWithPragma := (SmallInteger >> #+).
+	methodWithOutPragma := thisContext method.
+	
+	self assert: methodWithPragma hasPragma.
+	self deny: methodWithOutPragma hasPragma
+]
+
 { #category : #'tests - abstract' }
 CompiledMethodTest >> testIsAbstract [
 

--- a/src/Kernel-Tests/PragmaTest.class.st
+++ b/src/Kernel-Tests/PragmaTest.class.st
@@ -97,6 +97,6 @@ PragmaTest >> testHash [
 ]
 
 { #category : #'tests - cache' }
-PragmaTest >> testallInstalled [
-	self assert: Pragma allInstalled first class equals: Pragma
+PragmaTest >> testall [
+	self assert: Pragma all first class equals: Pragma
 ]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -460,6 +460,11 @@ CompiledMethod >> hasComment [
 	^self comment isEmptyOrNil not
 ]
 
+{ #category : #testing }
+CompiledMethod >> hasPragma [
+	^ self hasProperties and: [self pragmas isNotEmpty]
+]
+
 { #category : #'accessing-pragmas & properties' }
 CompiledMethod >> hasPragmaNamed: aSymbol [
 	^ self pragmas anySatisfy: [ :pragma | pragma selector = aSymbol ]

--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -36,7 +36,7 @@ Pragma class >> addToCache: aPragma [
 ]
 
 { #category : #cache }
-Pragma class >> allInstalled [
+Pragma class >> all [
 	"all pragmas whose methods are currently installed in the system"
 	^ self pragmaCache values flattened select: [ :each | 
 		  each method isInstalled ]

--- a/src/PragmaCollector/PragmaCollector.class.st
+++ b/src/PragmaCollector/PragmaCollector.class.st
@@ -261,7 +261,7 @@ PragmaCollector >> pragmaWithSelector: aSelector inClass: aClass [
 { #category : #accessing }
 PragmaCollector >> pragmas [
 	^ selectors 
-		ifNil: [ Pragma allInstalled ]
+		ifNil: [ Pragma all ]
 		ifNotNil: [ selectors flatCollect: [:each | Pragma allNamed: each ] ]
 ]
 

--- a/src/System-Settings-Browser/SettingTree.class.st
+++ b/src/System-Settings-Browser/SettingTree.class.st
@@ -31,10 +31,11 @@ SettingTree class >> acceptableKeywords: aCollectionOfStrings [
 
 { #category : #accessing }
 SettingTree >> acceptableKeywords: keywords [
-	self collector filter: [:prg | prg methodClass isMeta and: [keywords includes: prg selector]].
+	self collector 
+		selectors: keywords;
+		filter: [:prg | prg methodClass isMeta].
 	nodeList := nil.
-	self collector reset.
-
+	self collector reset
 ]
 
 { #category : #checking }

--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -415,7 +415,7 @@ Finder >> pragmaSearch: aString [
 		ifTrue: [[ :pragma | pragma selector matchesRegexIgnoringCase: aString ]]
 		ifFalse: [[ :pragma | pragma selector includesSubstring: aString caseSensitive: false ]].
 	
-	(Pragma allInstalled select: byCondition)
+	(Pragma all select: byCondition)
 		do: [ :pragma |
 			(result at: (pragma selector) ifAbsentPut: OrderedCollection new)				
 				add: pragma method ].


### PR DESCRIPTION
- do not iterate over all Pragmas when opening the Settings Browser
- use "Pragma all" instead of allInstalled, this way we have #all, allNamed:... and so on
- add #hasPragma to CompiledMethod to easily check for pragmas