### PR TITLE
WorldState-no-menuBuilder-cache

### DIFF
--- a/src/Morphic-Base/WorldState.extension.st
+++ b/src/Morphic-Base/WorldState.extension.st
@@ -24,11 +24,12 @@ WorldState class >> debugWorldMenuOn: aBuilder [
 
 { #category : #'*Morphic-Base' }
 WorldState >> menuBuilder [
-	^ menuBuilder ifNil: [
-		menuBuilder := (PragmaMenuBuilder pragmaKeyword: self discoveredMenuPragmaKeyword model: self)
-				menuSpec;
-				yourself
-	]
+
+	^ (PragmaMenuBuilder
+		   pragmaKeyword: self discoveredMenuPragmaKeyword
+		   model: self)
+		  menuSpec;
+		  yourself
 ]
 
 { #category : #'*Morphic-Base' }

--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -475,13 +475,6 @@ WorldMorph >> removeHand: aHandMorph [
 	worldState removeHand: aHandMorph
 ]
 
-{ #category : #'world menu' }
-WorldMorph >> resetWorldMenu [
-	
-	worldState resetWorldMenu
-
-]
-
 { #category : #'world state' }
 WorldMorph >> restoreMorphicDisplay [
 

--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -16,7 +16,6 @@ Class {
 		'lastCycleTime',
 		'alarms',
 		'lastAlarmTime',
-		'menuBuilder',
 		'activeHand',
 		'currentCursor',
 		'worldRenderer',
@@ -97,8 +96,7 @@ WorldState class >> desktopMenuPragmaKeyword [
 
 { #category : #settings }
 WorldState class >> desktopMenuPragmaKeyword: aString [
-	DesktopMenuPragmaKeyword := aString.
-	self currentWorld resetWorldMenu.
+	DesktopMenuPragmaKeyword := aString
 
 ]
 
@@ -759,13 +757,6 @@ WorldState >> resetDamageRecorder [
 
 ]
 
-{ #category : #'worldmenu building' }
-WorldState >> resetWorldMenu [
-	menuBuilder 
-		ifNotNil: [menuBuilder reset.
-			menuBuilder := nil]
-]
-
 { #category : #stepping }
 WorldState >> runLocalStepMethodsIn: aWorld [ 
 	"Run morph 'step' methods (LOCAL TO THIS WORLD) whose time has come. Purge any morphs that are no longer in this world.
@@ -876,7 +867,7 @@ WorldState >> viewBox [
 
 { #category : #'worldmenu building' }
 WorldState >> worldMenu [
-	^self  menuBuilder menuEntitled: self discoveredMenuTitle.
+	^self menuBuilder menuEntitled: self discoveredMenuTitle
 ]
 
 { #category : #hands }

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -105,8 +105,6 @@ ThemeIcons class >> current [
 ThemeIcons class >> current: aPack [
 	aPack hasIcons ifFalse: [ aPack loadIconsFromUrl ].
 	Current := aPack.
-	"Polymorph depends on Morphic, so coupling with WorldState is ok, the problem is with 
-	 other tools (like Nautilus), that may need to refresh its icon caches"
 	SystemAnnouncer uniqueInstance announce: IconSetChanged
 ]
 

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -107,7 +107,6 @@ ThemeIcons class >> current: aPack [
 	Current := aPack.
 	"Polymorph depends on Morphic, so coupling with WorldState is ok, the problem is with 
 	 other tools (like Nautilus), that may need to refresh its icon caches"
-	self currentWorld resetWorldMenu.
 	SystemAnnouncer uniqueInstance announce: IconSetChanged
 ]
 

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -113,8 +113,7 @@ ImageCleaner >> cleanUpMethods [
 	WeakArray restartFinalizationProcess.
 	
 	WorldState 
-		allInstancesDo: [ :ws | ws convertAlarms; cleanStepList; resetWorldMenu];
-		allInstancesDo: [ :ws | ws instVarNamed: 'menuBuilder' put: nil ].
+		allInstancesDo: [ :ws | ws convertAlarms; cleanStepList].
 		
 	ProcessBrowser initialize.
 	Delay restartTimerEventLoop.


### PR DESCRIPTION
With the improved Praga and PragmaCollector, there is not need to WorldState to keep the menuBuilder instance around.