### PR TITLE
RBVariable-do-not-use-Subclasses

### DIFF
--- a/src/AST-Core-Tests/ASTEvaluationTest.class.st
+++ b/src/AST-Core-Tests/ASTEvaluationTest.class.st
@@ -23,13 +23,13 @@ ASTEvaluationTest >> testEvaluateForContext [
 	self assert: (node evaluateForContext: thisContext) equals: varForTesting.
 
 	"lets check self, super"
-	node := RBVariableNode named: 'self'.
+	node := RBVariableNode selfNode.
 	self assert: (node evaluateForContext: thisContext) equals: thisContext receiver.
-	node := RBVariableNode named: 'super'.
+	node := RBVariableNode superNode.
 	self assert: (node evaluateForContext: thisContext) equals: thisContext receiver.
 
 	"thisContext is not the thisContext of this method though... it is the context of the evaluating doit"
-	node := RBVariableNode named: 'thisContext'.
+	node := RBVariableNode thisContextNode.
 	self deny: (node evaluateForContext: thisContext) equals: thisContext.	
 
 	"reading ivars works, too"
@@ -43,8 +43,8 @@ ASTEvaluationTest >> testEvaluateForReceiver [
 	receiver := 4@5.
 	node := (receiver class>>#x) variableNodes first.
 	self assert: (node evaluateForReceiver: receiver) equals: 4.
-	node := RBVariableNode named: 'self'.
+	node := RBVariableNode selfNode.
 	self assert: (node evaluateForReceiver: receiver) equals: receiver.
-	node := RBVariableNode named: 'super'.
+	node := RBVariableNode superNode.
 	self assert: (node evaluateForReceiver: receiver) equals: receiver.
 ]

--- a/src/AST-Core-Tests/RBDumpVisitorTest.class.st
+++ b/src/AST-Core-Tests/RBDumpVisitorTest.class.st
@@ -280,11 +280,10 @@ RBDumpVisitorTest >> testSelfNodeDump [
 	| node dumpedNode |
 	node := self parseExpression: 'self'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
-	
-	self assert: dumpedNode variable equals: SelfVariable instance. 
+
+	self assert: dumpedNode class equals: RBVariableNode.
 	self assert: node class equals: dumpedNode class.
-	self assert: dumpedNode isSelf.
-	
+	self assert: node printString equals: dumpedNode printString.
 ]
 
 { #category : #tests }
@@ -307,10 +306,9 @@ RBDumpVisitorTest >> testSuperNodeDump [
 	node := self parseExpression: 'super'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
-	self assert: dumpedNode variable equals: SuperVariable instance.
+	self assert: dumpedNode class equals: RBVariableNode.
 	self assert: node class equals: dumpedNode class.
-	self assert: dumpedNode isSuper.
-	
+	self assert: node printString equals: dumpedNode printString.
 ]
 
 { #category : #tests }
@@ -319,7 +317,7 @@ RBDumpVisitorTest >> testThisContextNodeDump [
 	node := self parseExpression: 'thisContext'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
-		self assert: dumpedNode variable equals: ThisContextVariable instance.
+	self assert: dumpedNode class equals: RBVariableNode.
 	self assert: node class equals: dumpedNode class.
 	self assert: node printString equals: dumpedNode printString.
 	

--- a/src/AST-Core-Tests/RBDumpVisitorTest.class.st
+++ b/src/AST-Core-Tests/RBDumpVisitorTest.class.st
@@ -281,7 +281,7 @@ RBDumpVisitorTest >> testSelfNodeDump [
 	node := self parseExpression: 'self'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
-	self assert: dumpedNode class equals: RBSelfNode. 
+	self assert: dumpedNode variable equals: SelfVariable instance. 
 	self assert: node class equals: dumpedNode class.
 	self assert: dumpedNode isSelf.
 	
@@ -307,7 +307,7 @@ RBDumpVisitorTest >> testSuperNodeDump [
 	node := self parseExpression: 'super'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
-	self assert: dumpedNode class equals: RBSuperNode. 
+	self assert: dumpedNode variable equals: SuperVariable instance.
 	self assert: node class equals: dumpedNode class.
 	self assert: dumpedNode isSuper.
 	
@@ -319,7 +319,7 @@ RBDumpVisitorTest >> testThisContextNodeDump [
 	node := self parseExpression: 'thisContext'.
 	dumpedNode := Smalltalk compiler evaluate: node dump.
 	
-	self assert: dumpedNode class equals: RBThisContextNode. 
+		self assert: dumpedNode variable equals: ThisContextVariable instance.
 	self assert: node class equals: dumpedNode class.
 	self assert: node printString equals: dumpedNode printString.
 	

--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -426,11 +426,11 @@ RBParserTest >> testCreationMessageNodeFromExpression [
 RBParserTest >> testCreationProtocol [
 	| messageNode |
 	self compare: (RBMessageNode 
-				receiver: (RBVariableNode named: 'self')
+				receiver: (RBVariableNode selfNode)
 				selector: (RBSelectorNode value: #+)
 				arguments: (Array with: (RBLiteralNode value: 0)))
 		to: (self parserClass parseExpression: 'self + 0').
-	messageNode := RBMessageNode receiver: (RBVariableNode named: 'self') selector: (RBSelectorNode value: #foo).
+	messageNode := RBMessageNode receiver: (RBVariableNode selfNode) selector: (RBSelectorNode value: #foo).
 	self compare: (RBMethodNode selector: #bar
 				body: (RBSequenceNode statements: (OrderedCollection 
 								with: (RBCascadeNode messages: (OrderedCollection with: messageNode with: messageNode)))))
@@ -440,19 +440,19 @@ RBParserTest >> testCreationProtocol [
 { #category : #testCreationProtocol }
 RBParserTest >> testCreationSelfNodeWithExpression [
 	self compare: (self parserClass parseExpression: 'self')
-		  to: RBSelfNode new.
+		  to: RBVariableNode selfNode
 ]
 
 { #category : #testCreationProtocol }
 RBParserTest >> testCreationSuperNodeWithExpression [
 	self compare: (self parserClass parseExpression: 'super')
-		  to: RBSuperNode new.
+		  to: RBVariableNode superNode.
 ]
 
 { #category : #testCreationProtocol }
 RBParserTest >> testCreationThisContexNodeWithExpression [
 	self compare: (self parserClass parseExpression: 'thisContext')
-		  to: RBThisContextNode new.
+		  to: RBVariableNode thisContextNode
 ]
 
 { #category : #testCreationProtocol }

--- a/src/AST-Core/RBArgumentNode.class.st
+++ b/src/AST-Core/RBArgumentNode.class.st
@@ -13,8 +13,3 @@ Class {
 RBArgumentNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitArgumentNode: self
 ]
-
-{ #category : #converting }
-RBArgumentNode >> adaptToSemanticNode [
-	" I can't provide more semantics "
-]

--- a/src/AST-Core/RBParseErrorNode.class.st
+++ b/src/AST-Core/RBParseErrorNode.class.st
@@ -45,11 +45,6 @@ RBParseErrorNode >> acceptVisitor: aProgramNodeVisitor [
 ]
 
 { #category : #converting }
-RBParseErrorNode >> adaptToSemanticNode [
-	" I can't provide more semantics "
-]
-
-{ #category : #converting }
 RBParseErrorNode >> asSyntaxErrorNotification [
 	^SyntaxErrorNotification new
 		setClass: self methodNode methodClass

--- a/src/AST-Core/RBSelfNode.class.st
+++ b/src/AST-Core/RBSelfNode.class.st
@@ -24,13 +24,3 @@ RBSelfNode >> initialize [
   super initialize.
   variable := SelfVariable instance
 ]
-
-{ #category : #testing }
-RBSelfNode >> isSelf [
-	^ true
-]
-
-{ #category : #testing }
-RBSelfNode >> isSelfOrSuper [
-	^ true
-]

--- a/src/AST-Core/RBSuperNode.class.st
+++ b/src/AST-Core/RBSuperNode.class.st
@@ -24,14 +24,3 @@ RBSuperNode >> initialize [
   super initialize.
   variable := SuperVariable instance
 ]
-
-{ #category : #testing }
-RBSuperNode >> isSelfOrSuper [
-
-	^ true
-]
-
-{ #category : #testing }
-RBSuperNode >> isSuper [
-	^ true
-]

--- a/src/AST-Core/RBTemporaryNode.class.st
+++ b/src/AST-Core/RBTemporaryNode.class.st
@@ -13,8 +13,3 @@ Class {
 RBTemporaryNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitTemporaryNode: self
 ]
-
-{ #category : #testing }
-RBTemporaryNode >> isTemp [
-	^ true
-]

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -25,11 +25,11 @@ Class {
 RBVariableNode class >> identifierNamed: anIdentifierName at: aPosition [
 	
 	anIdentifierName = 'self'
-		ifTrue: [ ^ RBSelfNode named: anIdentifierName start: aPosition ].
+		ifTrue: [ ^ self selfNode named: anIdentifierName start: aPosition ].
 	anIdentifierName = 'thisContext'
-		ifTrue: [ ^ RBThisContextNode named: anIdentifierName start: aPosition ].
+		ifTrue: [ ^ self thisContextNode named: anIdentifierName start: aPosition ].
 	anIdentifierName = 'super'
-		ifTrue: [ ^ RBSuperNode named: anIdentifierName start: aPosition ].
+		ifTrue: [ ^ self superNode named: anIdentifierName start: aPosition ].
 	^ self named: anIdentifierName start: aPosition.
 ]
 
@@ -47,17 +47,17 @@ RBVariableNode class >> named: aName start: aPosition [
 
 { #category : #'instance creation' }
 RBVariableNode class >> selfNode [
-	^ RBSelfNode new
+	^ RBSelfNode new variable: SelfVariable instance
 ]
 
 { #category : #'instance creation' }
 RBVariableNode class >> superNode [
-	^ RBSuperNode new
+	^ RBSuperNode new variable: SuperVariable instance
 ]
 
 { #category : #'instance creation' }
 RBVariableNode class >> thisContextNode [
-	^ RBThisContextNode new
+	^ RBThisContextNode new variable: ThisContextVariable instance
 ]
 
 { #category : #comparing }
@@ -173,10 +173,17 @@ RBVariableNode >> isReservedVariable [
 
 { #category : #testing }
 RBVariableNode >> isSelf [
-	"normally this method is not needed (if all the RBVariable creations create RBSelfNode instead but
-	since we do not control this."
-	
-	^ self name = 'self'
+	^ self isSelfVariable
+]
+
+{ #category : #testing }
+RBVariableNode >> isSelfOrSuper [
+	^ variable isSelfOrSuperVariable
+]
+
+{ #category : #testing }
+RBVariableNode >> isSelfOrSuperVariable [
+	^ variable isSelfOrSuperVariable
 ]
 
 { #category : #testing }
@@ -186,15 +193,17 @@ RBVariableNode >> isSelfVariable [
 
 { #category : #testing }
 RBVariableNode >> isSuper [
-	"normally this method is not needed (if all the RBVariable creations create RBSuperNode instead but
-	since we do not control this."
-	
-	^ self name = 'super'
+	^ self isSuperVariable
 ]
 
 { #category : #testing }
 RBVariableNode >> isSuperVariable [
 	^ variable isSuperVariable
+]
+
+{ #category : #testing }
+RBVariableNode >> isTemp [
+	^variable isTemp
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -47,17 +47,17 @@ RBVariableNode class >> named: aName start: aPosition [
 
 { #category : #'instance creation' }
 RBVariableNode class >> selfNode [
-	^ RBSelfNode new variable: SelfVariable instance
+	^ (self named: 'self') variable: SelfVariable instance
 ]
 
 { #category : #'instance creation' }
 RBVariableNode class >> superNode [
-	^ RBSuperNode new variable: SuperVariable instance
+	^ (self named: 'super') variable: SuperVariable instance
 ]
 
 { #category : #'instance creation' }
 RBVariableNode class >> thisContextNode [
-	^ RBThisContextNode new variable: ThisContextVariable instance
+	^ (self named: 'thisContext') variable: ThisContextVariable instance
 ]
 
 { #category : #comparing }

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -70,7 +70,9 @@ RBVariableNode >> = anObject [
 
 { #category : #visiting }
 RBVariableNode >> acceptVisitor: aProgramNodeVisitor [
-	^ aProgramNodeVisitor visitVariableNode: self
+	^variable 
+		ifNil: [aProgramNodeVisitor visitVariableNode: self]
+		ifNotNil: [variable acceptVisitor: aProgramNodeVisitor node: self]
 ]
 
 { #category : #converting }

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -75,12 +75,6 @@ RBVariableNode >> acceptVisitor: aProgramNodeVisitor [
 		ifNotNil: [variable acceptVisitor: aProgramNodeVisitor node: self]
 ]
 
-{ #category : #converting }
-RBVariableNode >> adaptToSemanticNode [
-	
-	self primitiveChangeClassTo: variable semanticNodeClass new
-]
-
 { #category : #matching }
 RBVariableNode >> copyInContext: aDictionary [ 
 	^ self class named: name.

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddConditionalBreakpointCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddConditionalBreakpointCommand.class.st
@@ -128,7 +128,7 @@ ClyAddConditionalBreakpointCommand >> rewriteASTToSimulateExecutionInADifferentC
 		parseExpression: 'ThisContext receiver class superclass'.
 	allMessageNodes
 		do: [ :msgNode | 
-			msgNode receiver class = RBSuperNode
+			msgNode receiver isSuper
 				ifTrue: [ rewriter
 						replaceTree: msgNode
 						withTree:

--- a/src/Deprecated90/OCLiteralVariable.class.st
+++ b/src/Deprecated90/OCLiteralVariable.class.st
@@ -16,12 +16,6 @@ OCLiteralVariable class >> isDeprecated [
 	^true
 ]
 
-{ #category : #accessing }
-OCLiteralVariable class >> semanticNodeClass [
-
-	^RBGlobalNode
-]
-
 { #category : #emitting }
 OCLiteralVariable >> emitStore: methodBuilder [
 

--- a/src/Deprecated90/OCSelfVariable.class.st
+++ b/src/Deprecated90/OCSelfVariable.class.st
@@ -7,12 +7,6 @@ Class {
 	#category : #'Deprecated90-OpalCompiler-Core'
 }
 
-{ #category : #accessing }
-OCSelfVariable class >> semanticNodeClass [
-
-	^RBSelfNode 
-]
-
 { #category : #emitting }
 OCSelfVariable >> emitValue: methodBuilder [
 

--- a/src/Deprecated90/OCSlotVariable.class.st
+++ b/src/Deprecated90/OCSlotVariable.class.st
@@ -20,12 +20,6 @@ OCSlotVariable class >> isDeprecated [
 	^true
 ]
 
-{ #category : #accessing }
-OCSlotVariable class >> semanticNodeClass [
-
-	^RBInstanceVariableNode
-]
-
 { #category : #emitting }
 OCSlotVariable >> emitStore: methodBuilder [
 

--- a/src/Deprecated90/OCSuperVariable.class.st
+++ b/src/Deprecated90/OCSuperVariable.class.st
@@ -7,12 +7,6 @@ Class {
 	#category : #'Deprecated90-OpalCompiler-Core'
 }
 
-{ #category : #accessing }
-OCSuperVariable class >> semanticNodeClass [
-
-	^RBSuperNode 
-]
-
 { #category : #emitting }
 OCSuperVariable >> emitValue: methodBuilder [
 	"super references the receiver, send that follows is a super send (the message lookup starts in the superclass)"

--- a/src/Deprecated90/OCThisContextVariable.class.st
+++ b/src/Deprecated90/OCThisContextVariable.class.st
@@ -7,12 +7,6 @@ Class {
 	#category : #'Deprecated90-OpalCompiler-Core'
 }
 
-{ #category : #accessing }
-OCThisContextVariable class >> semanticNodeClass [
-
-	^RBThisContextNode 
-]
-
 { #category : #emitting }
 OCThisContextVariable >> emitValue: methodBuilder [
 

--- a/src/Flashback-Decompiler/FBDASTBuilder.class.st
+++ b/src/Flashback-Decompiler/FBDASTBuilder.class.st
@@ -115,10 +115,10 @@ FBDASTBuilder >> codeMessage: selector receiver: rcvr arguments:args [
 
 { #category : #building }
 FBDASTBuilder >> codeMethod: selector arguments: args body: body pragmas: pragmas class: class [
-	^ (RBMethodNode selector: selector arguments: args body: body)
+	^ ((RBMethodNode selector: selector arguments: args body: body)
 		pragmas: pragmas;
 		methodClass: class;
-		yourself
+		yourself) doSemanticAnalysis
 ]
 
 { #category : #building }

--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -69,7 +69,7 @@ CoASTResultSetBuilder >> parseNode [
 
 	^ node ifNil: [ node := (completionContext isWorkspace
 		ifTrue: [ RBParser parseFaultyExpression: completionContext source ]
-		ifFalse: [ RBParser parseFaultyMethod: completionContext source ])
+		ifFalse: [ RBParser parseFaultyMethod: completionContext source ]) doSemanticAnalysis
 			nodeForOffset: completionContext position ]
 ]
 

--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -164,6 +164,12 @@ CoASTResultSetBuilder >> visitSuperNode: aRBSuperNode [
 ]
 
 { #category : #visiting }
+CoASTResultSetBuilder >> visitTemporaryNode: aRBReturnNode [ 
+	
+	^ self visitNode: aRBReturnNode
+]
+
+{ #category : #visiting }
 CoASTResultSetBuilder >> visitThisContextNode: aRBThisContextNode [
 
 	^ self visitNode: aRBThisContextNode

--- a/src/HeuristicCompletion-Tests/CoASTResultSetBuilderTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoASTResultSetBuilderTest.class.st
@@ -175,7 +175,7 @@ CoASTResultSetBuilderTest >> testBuildThisContextHeuristic [
 	builder := CoMockASTResultSetBuilder new.
 	builder
 		completionContext: self newCompletionContext;
-		node: RBThisContextNode new;
+		node: RBVariableNode thisContextNode;
 		buildCompletion.
 		
 	self assert: builder heuristic equals: #thisContext

--- a/src/HeuristicCompletion-Tests/CoSuperMessageHeuristicTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoSuperMessageHeuristicTest.class.st
@@ -28,7 +28,7 @@ CoSuperMessageHeuristicTest >> testDoesApplyForMethodNodeInContextWithSuperclass
 CoSuperMessageHeuristicTest >> testDoesApplyForSuperMessageSendNodes [
 
 	self assert: (CoSuperMessageHeuristic new
-		appliesForNode: (RBMessageNode receiver: RBSuperNode new selector: #foo)
+		appliesForNode: (RBMessageNode receiver: RBVariableNode superNode selector: #foo)
 		inContext: nil)
 ]
 
@@ -46,6 +46,6 @@ CoSuperMessageHeuristicTest >> testDoesNotApplyForMethodNodeInContextWithNoSuper
 CoSuperMessageHeuristicTest >> testDoesNotApplyForNonSuperMessageSendNodes [
 
 	self deny: (CoSuperMessageHeuristic new
-		appliesForNode: (RBMessageNode receiver: RBVariableNode new selector: #foo)
+		appliesForNode: (RBMessageNode receiver: (RBVariableNode new variable: (GlobalVariable new)) selector: #foo)
 		inContext: nil)
 ]

--- a/src/Kernel/GlobalVariable.class.st
+++ b/src/Kernel/GlobalVariable.class.st
@@ -9,6 +9,11 @@ Class {
 	#category : #'Kernel-Variables'
 }
 
+{ #category : #visiting }
+GlobalVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+		^ aProgramNodeVisitor visitGlobalNode: aNode
+]
+
 { #category : #queries }
 GlobalVariable >> definingClass [
 	"The class defining the variable. For Globals, return nil"

--- a/src/Kernel/GlobalVariable.class.st
+++ b/src/Kernel/GlobalVariable.class.st
@@ -11,7 +11,7 @@ Class {
 
 { #category : #visiting }
 GlobalVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
-		^ aProgramNodeVisitor visitGlobalNode: aNode
+	^ aProgramNodeVisitor visitGlobalNode: aNode
 ]
 
 { #category : #queries }

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -93,6 +93,11 @@ Slot class >> slotUsers [
 		select:  [ :class | class slots anySatisfy: [ :slot | slot class == self ] ]
 ]
 
+{ #category : #visiting }
+Slot >> acceptVisitor: aProgramNodeVisitor node: aNode [
+	^ aProgramNodeVisitor visitInstanceVariableNode: aNode
+]
+
 { #category : #'class building' }
 Slot >> asClassVariable [
 	self

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -63,6 +63,11 @@ Variable >> = other [
 			and: [ name = other name ]
 ]
 
+{ #category : #visiting }
+Variable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+	^ aProgramNodeVisitor visitVariableNode: aNode
+]
+
 { #category : #queries }
 Variable >> definingNode [
 	^ nil

--- a/src/OpalCompiler-Core/ArgumentVariable.class.st
+++ b/src/OpalCompiler-Core/ArgumentVariable.class.st
@@ -13,6 +13,11 @@ ArgumentVariable class >> semanticNodeClass [
 	^RBArgumentNode 
 ]
 
+{ #category : #visiting }
+ArgumentVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+	^ aProgramNodeVisitor visitArgumentNode: aNode
+]
+
 { #category : #queries }
 ArgumentVariable >> definingNode [
 	^ scope node arguments detect: [ :each | each name = name ]

--- a/src/OpalCompiler-Core/ArgumentVariable.class.st
+++ b/src/OpalCompiler-Core/ArgumentVariable.class.st
@@ -15,7 +15,7 @@ ArgumentVariable class >> semanticNodeClass [
 
 { #category : #visiting }
 ArgumentVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
-	^ aProgramNodeVisitor visitArgumentNode: aNode
+	^ aProgramNodeVisitor visitTemporaryNode: aNode
 ]
 
 { #category : #queries }

--- a/src/OpalCompiler-Core/CopiedLocalVariable.class.st
+++ b/src/OpalCompiler-Core/CopiedLocalVariable.class.st
@@ -10,6 +10,11 @@ Class {
 	#category : #'OpalCompiler-Core-Semantics'
 }
 
+{ #category : #visiting }
+CopiedLocalVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+	^ originalVar acceptVisitor: aProgramNodeVisitor node: aNode
+]
+
 { #category : #queries }
 CopiedLocalVariable >> definingNode [
 	^originalVar definingNode

--- a/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
@@ -36,7 +36,7 @@ OCASTClosureAnalyzer >> lookupAndFixBinding: aVariableNode [
 { #category : #visiting }
 OCASTClosureAnalyzer >> visitArgumentNode: aVariableNode [
 
-	aVariableNode adaptToSemanticNode
+	"aVariableNode adaptToSemanticNode"
 ]
 
 { #category : #visiting }
@@ -65,7 +65,7 @@ OCASTClosureAnalyzer >> visitVariableNode: aVariableNode [
 	"re-lookup the temorary variables..."
 	
 	| var |
-	aVariableNode adaptToSemanticNode.
+	"aVariableNode adaptToSemanticNode."
 	aVariableNode isLocalVariable ifFalse: [^self].
 	var := self lookupAndFixBinding: aVariableNode.
 	var isTempVectorTemp ifTrue: [ | vectorVar |

--- a/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
@@ -35,8 +35,7 @@ OCASTClosureAnalyzer >> lookupAndFixBinding: aVariableNode [
 
 { #category : #visiting }
 OCASTClosureAnalyzer >> visitArgumentNode: aVariableNode [
-
-	"aVariableNode adaptToSemanticNode"
+	"nothing to do for arguments"
 ]
 
 { #category : #visiting }
@@ -65,7 +64,6 @@ OCASTClosureAnalyzer >> visitVariableNode: aVariableNode [
 	"re-lookup the temorary variables..."
 	
 	| var |
-	"aVariableNode adaptToSemanticNode."
 	aVariableNode isLocalVariable ifFalse: [^self].
 	var := self lookupAndFixBinding: aVariableNode.
 	var isTempVectorTemp ifTrue: [ | vectorVar |

--- a/src/OpalCompiler-Core/OCASTSemanticCleaner.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticCleaner.class.st
@@ -31,6 +31,5 @@ OCASTSemanticCleaner >> visitMethodNode: aMethodNode [
 
 { #category : #visiting }
 OCASTSemanticCleaner >> visitVariableNode: aVariableNode [
-	aVariableNode variable: nil.
-	aVariableNode primitiveChangeClassTo: RBVariableNode new.
+	aVariableNode variable: nil
 ]

--- a/src/OpalCompiler-Core/SelfVariable.class.st
+++ b/src/OpalCompiler-Core/SelfVariable.class.st
@@ -13,6 +13,11 @@ SelfVariable class >> semanticNodeClass [
 	^RBSelfNode 
 ]
 
+{ #category : #visiting }
+SelfVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+		^ aProgramNodeVisitor visitSelfNode: aNode
+]
+
 { #category : #emitting }
 SelfVariable >> emitValue: methodBuilder [
 

--- a/src/OpalCompiler-Core/SuperVariable.class.st
+++ b/src/OpalCompiler-Core/SuperVariable.class.st
@@ -13,6 +13,11 @@ SuperVariable class >> semanticNodeClass [
 	^RBSuperNode 
 ]
 
+{ #category : #visiting }
+SuperVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+		^ aProgramNodeVisitor visitSuperNode: aNode
+]
+
 { #category : #emitting }
 SuperVariable >> emitValue: methodBuilder [
 	"super references the receiver, send that follows is a super send (the message lookup starts in the superclass)"

--- a/src/OpalCompiler-Core/TemporaryVariable.class.st
+++ b/src/OpalCompiler-Core/TemporaryVariable.class.st
@@ -15,7 +15,7 @@ TemporaryVariable class >> semanticNodeClass [
 
 { #category : #visiting }
 TemporaryVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
-	^ aProgramNodeVisitor visitTemporaryNode: self
+	^ aProgramNodeVisitor visitTemporaryNode: aNode
 ]
 
 { #category : #queries }

--- a/src/OpalCompiler-Core/TemporaryVariable.class.st
+++ b/src/OpalCompiler-Core/TemporaryVariable.class.st
@@ -13,6 +13,11 @@ TemporaryVariable class >> semanticNodeClass [
 	^RBTemporaryNode 
 ]
 
+{ #category : #visiting }
+TemporaryVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+	^ aProgramNodeVisitor visitTemporaryNode: self
+]
+
 { #category : #queries }
 TemporaryVariable >> definingNode [
 	^ scope node temporaries 

--- a/src/OpalCompiler-Core/ThisContextVariable.class.st
+++ b/src/OpalCompiler-Core/ThisContextVariable.class.st
@@ -13,6 +13,11 @@ ThisContextVariable class >> semanticNodeClass [
 	^RBThisContextNode 
 ]
 
+{ #category : #visiting }
+ThisContextVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+	^ aProgramNodeVisitor visitThisContextNode: aNode
+]
+
 { #category : #emitting }
 ThisContextVariable >> emitValue: methodBuilder [
 

--- a/src/Refactoring-Core/RBRefactoryTyper.class.st
+++ b/src/Refactoring-Core/RBRefactoryTyper.class.st
@@ -169,6 +169,7 @@ RBRefactoryTyper >> executeSearch: searcher [
 					| parseTree |
 					methodName := sel.
 					parseTree := each parseTreeFor: sel.
+					parseTree doSemanticAnalysis.
 					parseTree notNil ifTrue: [searcher executeTree: parseTree]]]
 ]
 

--- a/src/Reflectivity/RFClassReification.class.st
+++ b/src/Reflectivity/RFClassReification.class.st
@@ -35,6 +35,6 @@ RFClassReification >> genForRBProgramNode [
 { #category : #generate }
 RFClassReification >> generate [
 	^RBMessageNode 
-		receiver: (RBVariableNode named: 'self')
+		receiver: RBVariableNode selfNode
 		selector: #class
 ]

--- a/src/Reflectivity/RFObjectReification.class.st
+++ b/src/Reflectivity/RFObjectReification.class.st
@@ -19,15 +19,15 @@ RFObjectReification class >> key [
 
 { #category : #generate }
 RFObjectReification >> genForInstanceVariableSlot [
-	^RBVariableNode named: 'self'
+	^RBVariableNode selfNode
 ]
 
 { #category : #generate }
 RFObjectReification >> genForLiteralVariable [
-	^RBVariableNode named: 'self'
+	^RBVariableNode selfNode
 ]
 
 { #category : #generate }
 RFObjectReification >> genForRBProgramNode [
-	^RBVariableNode named: 'self'
+	^RBVariableNode selfNode
 ]

--- a/src/Reflectivity/RFReceiverReification.class.st
+++ b/src/Reflectivity/RFReceiverReification.class.st
@@ -24,7 +24,7 @@ RFReceiverReification >> genForRBMessageNode [
 
 { #category : #generate }
 RFReceiverReification >> genForRBMethodNode [
-	^RBVariableNode named: 'self'
+	^RBVariableNode selfNode
 	
 ]
 

--- a/src/Reflectivity/RFSenderReification.class.st
+++ b/src/Reflectivity/RFSenderReification.class.st
@@ -19,14 +19,14 @@ RFSenderReification class >> key [
 
 { #category : #generate }
 RFSenderReification >> genForRBMessageNode [
-	^RBVariableNode named: 'self'
+	^RBVariableNode selfNode
 ]
 
 { #category : #generate }
 RFSenderReification >> genForRBMethodNode [
 	^RBMessageNode 
 		receiver: (RBMessageNode 
-			receiver: (RBVariableNode named: 'thisContext')
+			receiver: RBVariableNode thisContextNode
 			selector: #sender)
 		selector: #receiver.
 		

--- a/src/Reflectivity/RFValueReification.class.st
+++ b/src/Reflectivity/RFValueReification.class.st
@@ -34,7 +34,7 @@ RFValueReification >> genForInstanceVariableSlot [
 	^ RBMessageNode
 		receiver: (RFLiteralVariableNode value: entity)
 		selector: #read:
-		arguments: {(RBVariableNode named: 'self')}
+		arguments: {RBVariableNode selfNode}
 ]
 
 { #category : #generate }

--- a/src/Ring-Core/RGSlot.class.st
+++ b/src/Ring-Core/RGSlot.class.st
@@ -9,6 +9,11 @@ RGSlot >> accept: anInterpreter assign: aValue inNode: aVariableNode [
 	self error: #TBD
 ]
 
+{ #category : #'as yet unclassified' }
+RGSlot >> acceptVisitor: aProgramNodeVisitor node: aNode [ 
+	^ aProgramNodeVisitor visitInstanceVariableNode: aNode
+]
+
 { #category : #'managing container' }
 RGSlot >> addoptToParentStub [
 

--- a/src/Ring-Core/RGVariable.class.st
+++ b/src/Ring-Core/RGVariable.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Ring-Core-Kernel'
 }
 
+{ #category : #visiting }
+RGVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+	^ aProgramNodeVisitor visitVariableNode: aNode
+]
+
 { #category : #accessing }
 RGVariable >> definitionString [
 	"non special globals are defined by the symbol"
@@ -77,7 +82,7 @@ RGVariable >> isWorkspaceVariable [
 	^ false
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 RGVariable >> isWritable [
 	"Ring2 variables are all writable, e.g. it does not model Arguments"
 	^true


### PR DESCRIPTION
- Forward all checks #isSelf and friends to the Variable, never check the name
- Visitor forwards to the Variable, too.

TODO:
- #selfNode and superNode need to not use RBVariableNode subclasses