### PR TITLE
7059-obsolete-method-reference-to-WorldMorphinitialize

### DIFF
--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -111,7 +111,9 @@ ImageCleaner >> cleanUpMethods [
 	"Make sure that all methods in use are restarted"
 	<script: 'self new cleanUpMethods'>
 	WeakArray restartFinalizationProcess.
-	
+	MenubarMorph reset.
+	ToolRegistry allSubInstances do: [:each | each resetAnnouncer].
+
 	WorldState 
 		allInstancesDo: [ :ws | ws convertAlarms; cleanStepList].
 		

--- a/src/Tool-Registry/ToolRegistry.class.st
+++ b/src/Tool-Registry/ToolRegistry.class.st
@@ -211,6 +211,7 @@ ToolRegistry >> remove: aName [
 ToolRegistry >> resetAnnouncer [
 
 	"unregister all current weak subscriptions because it can cause a memory leak"
+	announcer ifNil: [ ^self ].
 	announcer subscriptions subscriptions
  		select: [:each | each isKindOf: WeakAnnouncementSubscription] 
 		thenDo: [:each | each weakRegistry remove: each subscriber ifAbsent: []]. 


### PR DESCRIPTION
when doing #cleanUpMethod, do

MenubarMorph reset.
ToolRegistry allSubInstances do: [:each | each resetAnnouncer].

this reduces the number of CompiledMethod instances handing around after a recompile.
More needs to be done, I will open a new issue for that.

fixes #7059