### PR TITLE
6505-AbstractFileReference--directories-invokes-subclass-method-

### DIFF
--- a/src/FileSystem-Core/AbstractFileReference.class.st
+++ b/src/FileSystem-Core/AbstractFileReference.class.st
@@ -4,6 +4,9 @@ I am an abstract superclass for FileLocator and FileReference. By implementing m
 Class {
 	#name : #AbstractFileReference,
 	#superclass : #Object,
+	#instVars : [
+		'path'
+	],
 	#category : #'FileSystem-Core-Public'
 }
 

--- a/src/FileSystem-Core/AbstractFileReference.class.st
+++ b/src/FileSystem-Core/AbstractFileReference.class.st
@@ -715,6 +715,11 @@ AbstractFileReference >> parentUpTo: aParentDirName [
 ]
 
 { #category : #accessing }
+AbstractFileReference >> path [
+	^ path
+]
+
+{ #category : #accessing }
 AbstractFileReference >> pathSegments [
 	^ self fullPath segments
 ]

--- a/src/FileSystem-Core/FileLocator.class.st
+++ b/src/FileSystem-Core/FileLocator.class.st
@@ -35,8 +35,7 @@ Class {
 	#name : #FileLocator,
 	#superclass : #AbstractFileReference,
 	#instVars : [
-		'origin',
-		'path'
+		'origin'
 	],
 	#classVars : [
 		'Resolver'

--- a/src/FileSystem-Core/FileLocator.class.st
+++ b/src/FileSystem-Core/FileLocator.class.st
@@ -452,11 +452,6 @@ FileLocator >> origin [
 	^ origin
 ]
 
-{ #category : #accessing }
-FileLocator >> path [
-	^ path
-]
-
 { #category : #printing }
 FileLocator >> printOn: aStream [
 	| fs |

--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -470,12 +470,6 @@ FileReference >> openWritable: aBoolean [
 	^ filesystem open: path writable: aBoolean
 ]
 
-{ #category : #accessing }
-FileReference >> path [
-	"Return the path internal representation that denotes the receiver in the context of its filesystem. "
-	^ path
-]
-
 { #category : #printing }
 FileReference >> pathString [
 	"Return the full path name of the receiver."

--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -20,8 +20,7 @@ Class {
 	#name : #FileReference,
 	#superclass : #AbstractFileReference,
 	#instVars : [
-		'filesystem',
-		'path'
+		'filesystem'
 	],
 	#category : #'FileSystem-Core-Public'
 }


### PR DESCRIPTION
Move `path` up to AbstractFileReference and out of sublcasses FileReference and FileLocator

Fixes #6505