### PR TITLE
6505-AbstractFileReference--directories-invokes-subclass-method-

### DIFF
--- a/src/FileSystem-Core/AbstractFileReference.class.st
+++ b/src/FileSystem-Core/AbstractFileReference.class.st
@@ -4,6 +4,9 @@ I am an abstract superclass for FileLocator and FileReference. By implementing m
 Class {
 	#name : #AbstractFileReference,
 	#superclass : #Object,
+	#instVars : [
+		'path'
+	],
 	#category : #'FileSystem-Core-Public'
 }
 
@@ -709,6 +712,11 @@ AbstractFileReference >> parent [
 { #category : #delegated }
 AbstractFileReference >> parentUpTo: aParentDirName [
 	^ self withPath: (self path parentUpTo: aParentDirName)
+]
+
+{ #category : #accessing }
+AbstractFileReference >> path [
+	^ path
 ]
 
 { #category : #accessing }

--- a/src/FileSystem-Core/FileLocator.class.st
+++ b/src/FileSystem-Core/FileLocator.class.st
@@ -35,8 +35,7 @@ Class {
 	#name : #FileLocator,
 	#superclass : #AbstractFileReference,
 	#instVars : [
-		'origin',
-		'path'
+		'origin'
 	],
 	#classVars : [
 		'Resolver'
@@ -451,11 +450,6 @@ FileLocator >> isRelative [
 { #category : #accessing }
 FileLocator >> origin [
 	^ origin
-]
-
-{ #category : #accessing }
-FileLocator >> path [
-	^ path
 ]
 
 { #category : #printing }

--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -20,8 +20,7 @@ Class {
 	#name : #FileReference,
 	#superclass : #AbstractFileReference,
 	#instVars : [
-		'filesystem',
-		'path'
+		'filesystem'
 	],
 	#category : #'FileSystem-Core-Public'
 }
@@ -469,12 +468,6 @@ FileReference >> numberOfHardLinks [
 { #category : #streams }
 FileReference >> openWritable: aBoolean [ 
 	^ filesystem open: path writable: aBoolean
-]
-
-{ #category : #accessing }
-FileReference >> path [
-	"Return the path internal representation that denotes the receiver in the context of its filesystem. "
-	^ path
 ]
 
 { #category : #printing }


### PR DESCRIPTION
Move `path` up to `AbstractFileReference` and out of sublcasses `FileReference` and `FileLocator`

Fixes #6505

### Note:
This is a duplicate PR from #7309 (which I closed)
Please check comments in that PR for historical purposes
Created this new PR as I wanted to clean up how I performed this task, and to also clear out tests that are failing that should not be failing
