### PR TITLE
7316-Autocompletion-bug-with-global-variable-in-large-image-

### DIFF
--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -98,6 +98,12 @@ CoASTResultSetBuilder >> visitCascadeNode: aRBCascadeNode [
 ]
 
 { #category : #visiting }
+CoASTResultSetBuilder >> visitGlobalNode: aRBVariableNode [
+
+	^ self visitVariableNode: aRBVariableNode
+]
+
+{ #category : #visiting }
 CoASTResultSetBuilder >> visitLiteralArrayNode: aRBLiteralArrayNode [ 
 
 	^ self visitNode: aRBLiteralArrayNode

--- a/src/Kernel/GlobalVariable.class.st
+++ b/src/Kernel/GlobalVariable.class.st
@@ -9,11 +9,6 @@ Class {
 	#category : #'Kernel-Variables'
 }
 
-{ #category : #visiting }
-GlobalVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
-	^ aProgramNodeVisitor visitGlobalNode: aNode
-]
-
 { #category : #queries }
 GlobalVariable >> definingClass [
 	"The class defining the variable. For Globals, return nil"

--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -59,6 +59,12 @@ LiteralVariable >> = anAssociation [
 	^ super = anAssociation and: [value = anAssociation value]
 ]
 
+{ #category : #visiting }
+LiteralVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+	"to be compatible to the old visitor implementation"
+	^ aProgramNodeVisitor visitGlobalNode: aNode
+]
+
 { #category : #testing }
 LiteralVariable >> analogousCodeTo: anAssociation [
 	^ self = anAssociation


### PR DESCRIPTION
- make sure to visit all the kind of Variables that used to be model by RBGlobalVariable use visitGlobalNode:
(this is intermediate, I think I found a way to do this much nicer that will stay backward compatible)

- CoASTResultSetBuilder needs a #visitGlobalNode: method now which calls #visitVariableNode: (the visitor and the Trait always had that method, but CoASTResultSetBuilder implements the visitor API without using the Trait)

fixes #7316