### PR TITLE
optionReadOnlyLiterals-cleanup

### DIFF
--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -366,13 +366,12 @@ StringTest >> secondIndex [
 
 { #category : #running }
 StringTest >> setUp [
-	<compilerOptions: #(- #optionReadOnlyLiterals)>
 	super setUp.
 	string := 'Hi, I am a String'.
 	emptyString := ''.
 	subcollection3ElementsSorted := 'bcd'.
 	nonEmpty5ElementsSorted := 'a' , subcollection3ElementsSorted , 'e'.
-	unsortedCollection := 'azsbe'.
+	unsortedCollection := 'azsbe' copy.
 	indexInNonEmptyArray := #(1 3 2 ).
 	arrayWithCharacters := #($a $b $c ).
 	nonEmpty1element := 'a'.
@@ -1832,24 +1831,22 @@ StringTest >> testSubstrings [
 
 { #category : #tests }
 StringTest >> testTranslateToLowercase [
-	<compilerOptions: #(- #optionReadOnlyLiterals)>
 	
-	self assert: 'test this string' translateToLowercase equals: 'test this string'.
-	self assert: ' Test THIS sTRing' translateToLowercase equals: ' test this string'.
-	self assert: '' translateToLowercase equals: ''.
-	self assert: 'ÔÜÖ' translateToLowercase equals: 'ôüö'.
-	self assert: '123éàôüÖẞ' translateToLowercase equals: '123éàôüöẞ'
+	self assert: 'test this string' copy translateToLowercase equals: 'test this string'.
+	self assert: ' Test THIS sTRing' copy translateToLowercase equals: ' test this string'.
+	self assert: '' copy translateToLowercase equals: ''.
+	self assert: 'ÔÜÖ' copy translateToLowercase equals: 'ôüö'.
+	self assert: '123éàôüÖẞ' copy translateToLowercase equals: '123éàôüöẞ'
 ]
 
 { #category : #tests }
 StringTest >> testTranslateToUppercase [
-	<compilerOptions: #(- #optionReadOnlyLiterals)>
 
-	self assert: 'test this string' translateToUppercase equals: 'TEST THIS STRING'.
-	self assert: ' Test THIS sTRing' translateToUppercase equals: ' TEST THIS STRING'.
-	self assert: '' translateToUppercase equals: ''.
-	self assert: 'ÔÜÖ' translateToUppercase equals: 'ÔÜÖ'.
-	self assert: '123éàôüÖẞ' translateToUppercase equals: '123ÉÀÔÜÖẞ'
+	self assert: 'test this string' copy translateToUppercase equals: 'TEST THIS STRING'.
+	self assert: ' Test THIS sTRing' copy translateToUppercase equals: ' TEST THIS STRING'.
+	self assert: '' copy translateToUppercase equals: ''.
+	self assert: 'ÔÜÖ' copy translateToUppercase equals: 'ÔÜÖ'.
+	self assert: '123éàôüÖẞ' copy translateToUppercase equals: '123ÉÀÔÜÖẞ'
 ]
 
 { #category : #'tests - converting' }

--- a/src/Flashback-Decompiler-Tests/FBDExamples.class.st
+++ b/src/Flashback-Decompiler-Tests/FBDExamples.class.st
@@ -357,10 +357,9 @@ FBDExamples >> exampleCascadeIntoBlockWithTempIntoCascade [
 { #category : #'examples - branches' }
 FBDExamples >> exampleCascadeNested [
 	<sampleInstance>
-	<compilerOptions: #(- #optionReadOnlyLiterals)>
 	| tmp1 tmp2 |
 	tmp1 := 1.
-	tmp2 := #(1 2 3).
+	tmp2 := #(1 2 3) copy.
 	tmp2 at: 2 put: 5.
 	tmp1
 		+ tmp2 size;

--- a/src/ReflectionMirrors-Primitives-Tests/MirrorPrimitivesTest.class.st
+++ b/src/ReflectionMirrors-Primitives-Tests/MirrorPrimitivesTest.class.st
@@ -71,9 +71,8 @@ MirrorPrimitivesTest >> testChangingFixedFieldOfWeakMessageSend [
 
 { #category : #'tests-fields accessing' }
 MirrorPrimitivesTest >> testChangingGeneralFieldOfArray [
-	<compilerOptions: #(- #optionReadOnlyLiterals)>
 	| object |
-	object := #(10 20).
+	object := #(10 20) copy.
 	
 	MirrorPrimitives fieldOf: object at: 1 put: 100.	
 	self assert: object first equals: 100.
@@ -122,9 +121,8 @@ MirrorPrimitivesTest >> testChangingGeneralFieldOfWeakMessageSend [
 
 { #category : #'tests-fields accessing' }
 MirrorPrimitivesTest >> testChangingIndexableFieldOfArray [
-	<compilerOptions: #(- #optionReadOnlyLiterals)>
 	| object |
-	object := #(10 20).
+	object := #(10 20) copy.
 	
 	MirrorPrimitives indexableFieldOf: object at: 1 put: 100.	
 	self assert: object first equals: 100.


### PR DESCRIPTION
There where some tests with

<compilerOptions: #(- #optionReadOnlyLiterals)>

But they can be easily rewritten to be green even with 

<compilerOptions: #(+ #optionReadOnlyLiterals)>

This PR fixes the test and then removes the compilerOptions: pragma