### PR TITLE
OpalCompiler-parse-should-doSemanticAnalysis

### DIFF
--- a/src/AST-Core-Tests/RBVariableNodeTest.class.st
+++ b/src/AST-Core-Tests/RBVariableNodeTest.class.st
@@ -17,7 +17,6 @@ RBVariableNodeTest >> testIsDefinedByBlock [
   test.
 	[ :test2 | | test3| test2. test3].
   ^test'.
-	ast doSemanticAnalysis.
 	temps := ast allChildren select: [ :each | each isTemp ].
 	"test is defined by the method"
 	self deny: temps first isDefinedByBlock.
@@ -51,7 +50,6 @@ RBVariableNodeTest >> testIsDefinition [
   test := 2.
   test.
   ^test'.
-	ast doSemanticAnalysis.
 	temps := ast allChildren select: #isTemp.
 	
 	"arguments define variables"

--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -138,12 +138,10 @@ ClyMethodEditorToolMorph >> formatTextIfNeeded [
 
 { #category : #'events handling' }
 ClyMethodEditorToolMorph >> getASTFor: aString [
-	| ast |
-	ast := self methodClass compiler
+	^ self methodClass compiler
 		source: aString;
 		options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
-		parse.				
-	^ast doSemanticAnalysis
+		parse
 ]
 
 { #category : #initialization }

--- a/src/GeneralRules-Tests/ReSuperWithoutSendTest.class.st
+++ b/src/GeneralRules-Tests/ReSuperWithoutSendTest.class.st
@@ -9,13 +9,10 @@ ReSuperWithoutSendTest >> testBasicCheck [
 
 	| ast |
 	ast :=  self class compiler parse: 'testMethod ^super'.
-	ast doSemanticAnalysis.
 	self assert: (ReSuperWithoutSend new basicCheck: ast variableNodes first).
 	self deny: (ReSuperWithoutSend new basicCheck: ast statements first).
 	ast := self class compiler parse: 'testMethod ^ super doit'.
-	ast doSemanticAnalysis.
 	self deny: (ReSuperWithoutSend new basicCheck: ast variableNodes first).
 	ast := self class compiler parse: 'testMethod ^ self doit: super'.
-	ast doSemanticAnalysis.
 	self assert: (ReSuperWithoutSend new basicCheck: ast variableNodes second).
 ]

--- a/src/Monticello-Tests/MCStWriterTest.class.st
+++ b/src/Monticello-Tests/MCStWriterTest.class.st
@@ -21,7 +21,7 @@ MCStWriterTest >> assertChunkIsWellFormed: chunk [
 		class: UndefinedObject;
 		noPattern: true;
 		failBlock:  [self assert: false];
-		compile.
+		compileDoit.
 ]
 
 { #category : #asserting }

--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -127,7 +127,6 @@ CompletionContext >> parseSource [
 		noPattern: self isWorkspace;
 		options: #(+ optionParseErrors + optionSkipSemanticWarnings);
 		parse.
-	ast doSemanticAnalysis.
 	TypingVisitor new visitNode: ast
 ]
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -324,7 +324,6 @@ OpalCompiler >> compilationContextClass: aClass [
 OpalCompiler >> compile [
 	| cm |
 	[ 	[	self parse.
-			self transformDoit.
 			self callPlugins.  
 		] 	on: ReparseAfterSourceEditing 
 			do: 
@@ -355,6 +354,27 @@ OpalCompiler >> compile: textOrString [
 	^self
 		source: textOrString;
 		compile.
+]
+
+{ #category : #private }
+OpalCompiler >> compileDoit [
+	| cm |
+	[ 
+	self parseDoIt.
+	self transformDoit.
+	self callPlugins.
+	cm := ast generateWithSource ]
+		on: SyntaxErrorNotification
+		do: [ :exception | 
+			self compilationContext requestor
+				ifNotNil: [ 
+					self compilationContext requestor
+						notify: exception errorMessage , ' ->'
+						at: exception location
+						in: exception errorCode.
+					^ self compilationContext failBlock value ]
+				ifNil: [ exception pass ] ].
+	^cm
 ]
 
 { #category : #accessing }
@@ -410,7 +430,7 @@ OpalCompiler >> evaluate [
 	self noPattern: true.
 	self getSourceFromRequestorSelection.
 	self class: (context ifNil: [ receiver class ] ifNotNil: [ context compiledCode methodClass ]).
-	value := receiver withArgs: (context ifNil: [ #() ] ifNotNil: [ {context} ]) executeMethod: self compile.
+	value := receiver withArgs: (context ifNil: [ #() ] ifNotNil: [ {context} ]) executeMethod: self compileDoit.
 	self logDoIt.
 	^ value
 ]
@@ -510,6 +530,12 @@ OpalCompiler >> parse: textOrString [
 	^self
 		source: textOrString;
 		parse
+]
+
+{ #category : #private }
+OpalCompiler >> parseDoIt [
+	"we parse doits without doing name analysis here, it is done in #transformDoit"
+	^ ast := self parseExpression
 ]
 
 { #category : #private }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -325,7 +325,6 @@ OpalCompiler >> compile [
 	| cm |
 	[ 	[	self parse.
 			self transformDoit.
-			self doSemanticAnalysis. 
 			self callPlugins.  
 		] 	on: ReparseAfterSourceEditing 
 			do: 
@@ -579,5 +578,6 @@ OpalCompiler >> transformDoit [
 		ifNil: [ast asDoit] 
 		ifNotNil: [ast asDoitForContext: context].
 	"we need to set the compilation context in the new method node"
-	^ast compilationContext: self compilationContext
+	ast compilationContext: self compilationContext.
+	self doSemanticAnalysis
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -501,6 +501,7 @@ OpalCompiler >> parse [
 		ifTrue: [ self parseExpression ]
 		ifFalse: [ self parseMethod ].
 	ast methodNode compilationContext: self compilationContext.
+	self doSemanticAnalysis.
 	^ast
 ]
 

--- a/src/Shout-Tests/SHRBTextStylerTest.class.st
+++ b/src/Shout-Tests/SHRBTextStylerTest.class.st
@@ -27,8 +27,6 @@ SHRBTextStylerTest >> style: aText [
 		options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
 		requestor: nil;
 		parse.				
-	ast doSemanticAnalysis.
-
 	styler style: aText ast: ast.
 	
 	^ ast

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1015,7 +1015,6 @@ SHRBTextStyler >> privateStyle: aText [
 		options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
 		requestor: workspace;
 		parse.				
-	ast doSemanticAnalysis.
 	^ self style: aText ast: ast
 ]
 


### PR DESCRIPTION
if we call #doSemanticAnalysis in #parse of OpalCompiler, we can remove the calls from the users.