### PR TITLE
Fix for #hasMethodReturn in FullBlockClosure

### DIFF
--- a/src/Kernel-Tests/BlockClosureTest.class.st
+++ b/src/Kernel-Tests/BlockClosureTest.class.st
@@ -139,6 +139,18 @@ BlockClosureTest >> testCullCullCullCull [
 		equals: 4
 ]
 
+{ #category : #'tests - evaluating' }
+BlockClosureTest >> testHasMethodReturn [
+
+	self assert: [ ^self  ] hasMethodReturn.
+	self deny: [ 1 + 2 ] hasMethodReturn.
+	self deny: [ self printString ] hasMethodReturn.
+	
+	"nested blocks"
+	self assert: [ 1 > 2 ifTrue: [ ^self ] ] hasMethodReturn.
+	self assert: [ #(1) do: [ ^self ] ] hasMethodReturn
+]
+
 { #category : #tests }
 BlockClosureTest >> testNew [
 	self	should: [Context new: 5] raise: Error.

--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -174,3 +174,11 @@ CompiledBlock >> sourceCode [
 CompiledBlock >> sourcePointer [
 	^self outerCode sourcePointer
 ]
+
+{ #category : #accessing }
+CompiledBlock >> withAllBlocksDo: aBlock [ 
+	
+	aBlock value: self.
+	self allBlocksDo: aBlock
+	
+]

--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -174,11 +174,3 @@ CompiledBlock >> sourceCode [
 CompiledBlock >> sourcePointer [
 	^self outerCode sourcePointer
 ]
-
-{ #category : #accessing }
-CompiledBlock >> withAllBlocksDo: aBlock [ 
-	
-	aBlock value: self.
-	self allBlocksDo: aBlock
-	
-]

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -931,6 +931,14 @@ CompiledCode >> withAllBlocks [
 ]
 
 { #category : #accessing }
+CompiledCode >> withAllBlocksDo: aBlock [ 
+	
+	aBlock value: self.
+	self allBlocksDo: aBlock
+	
+]
+
+{ #category : #accessing }
 CompiledCode >> withAllNestedLiteralsDo: aBlockClosure [ 
 	"This method traverses all the nested literals.
 	As a Block or Method can have literals in the nested blocks. 

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -106,6 +106,14 @@ CompiledCode >> addWithAllBlocksInto: collected [
 	^ collected
 ]
 
+{ #category : #accessing }
+CompiledCode >> allBlocksDo: aBlock [
+
+	self literals 
+		select: [ :aLiteral | aLiteral isEmbeddedBlock ] 
+		thenDo: [ :aLiteral | aLiteral withAllBlocksDo: aBlock  ]
+]
+
 { #category : #literals }
 CompiledCode >> allLiterals [
 	"Answer an Array of the literals referenced by the receiver.	

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -854,7 +854,7 @@ Context >> handleSignal: exception [
 	self evaluateSignal: exception
 ]
 
-{ #category : #query }
+{ #category : #testing }
 Context >> hasContext: aContext [ 
 	"Answer whether aContext is me or one of my senders"
 
@@ -868,12 +868,12 @@ Context >> hasInstVarRef [
 	^self compiledCode hasInstVarRef.
 ]
 
-{ #category : #accessing }
+{ #category : #testing }
 Context >> hasMethodReturn [
 	^closureOrNil hasMethodReturn
 ]
 
-{ #category : #controlling }
+{ #category : #testing }
 Context >> hasSender: context [ 
 	"Answer whether the receiver is strictly above context on the stack."
 
@@ -932,19 +932,19 @@ Context >> isBlockContext [
 	^closureOrNil isClosure
 ]
 
-{ #category : #query }
+{ #category : #testing }
 Context >> isBottomContext [
 	"Answer if this is the last context (the first context invoked) in my sender chain"
 
 	^sender isNil
 ]
 
-{ #category : #query }
+{ #category : #testing }
 Context >> isContext [
 	^true
 ]
 
-{ #category : #query }
+{ #category : #testing }
 Context >> isDead [
 	"Has self finished"
 

--- a/src/Kernel/FullBlockClosure.class.st
+++ b/src/Kernel/FullBlockClosure.class.st
@@ -62,7 +62,8 @@ FullBlockClosure >> endPC [
 { #category : #scanning }
 FullBlockClosure >> hasMethodReturn [
 	"Answer whether the receiver has a method-return ('^') in its code."
-	^ self compiledBlock hasMethodReturn
+	self withAllBlocksDo: [ :each | each hasMethodReturn ifTrue: [ ^true ] ].
+	^false
 ]
 
 { #category : #accessing }
@@ -297,4 +298,9 @@ FullBlockClosure >> valueWithArguments: anArray [
 		ifFalse: [
 			"Retrying with an array as parameter. As the primitive only supports arrays"
 			^ self valueWithArguments: anArray asArray ]
+]
+
+{ #category : #accessing }
+FullBlockClosure >> withAllBlocksDo: aBlock [
+	self compiledBlock withAllBlocksDo: aBlock
 ]


### PR DESCRIPTION
It fixes #hasMethodReturn in FullBlockClosure when the return is performed in one of embedded blocks.
The implementation introduces withAllBlocksDo: and allBlocksDo: methods to have similar API to subclasses query (withAllSubclassesDo:)