### PR TITLE
Clean nested block api

### DIFF
--- a/src/Kernel-Tests/BlockClosureTest.class.st
+++ b/src/Kernel-Tests/BlockClosureTest.class.st
@@ -139,6 +139,18 @@ BlockClosureTest >> testCullCullCullCull [
 		equals: 4
 ]
 
+{ #category : #'tests - evaluating' }
+BlockClosureTest >> testHasMethodReturn [
+
+	self assert: [ ^self  ] hasMethodReturn.
+	self deny: [ 1 + 2 ] hasMethodReturn.
+	self deny: [ self printString ] hasMethodReturn.
+	
+	"nested blocks"
+	self assert: [ 1 > 2 ifTrue: [ ^self ] ] hasMethodReturn.
+	self assert: [ #(1) do: [ ^self ] ] hasMethodReturn
+]
+
 { #category : #tests }
 BlockClosureTest >> testNew [
 	self	should: [Context new: 5] raise: Error.

--- a/src/Kernel/CleanBlockClosure.class.st
+++ b/src/Kernel/CleanBlockClosure.class.st
@@ -14,11 +14,6 @@ Class {
 	#category : #'Kernel-Methods'
 }
 
-{ #category : #adding }
-CleanBlockClosure >> addWithAllBlocksInto: collected [
-	^self compiledBlock addWithAllBlocksInto: collected
-]
-
 { #category : #accessing }
 CleanBlockClosure >> hasLiteral: aLiteral [
 	^self compiledBlock hasLiteral: aLiteral

--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -174,3 +174,11 @@ CompiledBlock >> sourceCode [
 CompiledBlock >> sourcePointer [
 	^self outerCode sourcePointer
 ]
+
+{ #category : #accessing }
+CompiledBlock >> withAllBlocksDo: aBlock [ 
+	
+	aBlock value: self.
+	self allBlocksDo: aBlock
+	
+]

--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -174,11 +174,3 @@ CompiledBlock >> sourceCode [
 CompiledBlock >> sourcePointer [
 	^self outerCode sourcePointer
 ]
-
-{ #category : #accessing }
-CompiledBlock >> withAllBlocksDo: aBlock [ 
-	
-	aBlock value: self.
-	self allBlocksDo: aBlock
-	
-]

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -931,6 +931,14 @@ CompiledCode >> withAllBlocks [
 ]
 
 { #category : #accessing }
+CompiledCode >> withAllBlocksDo: aBlock [ 
+	
+	aBlock value: self.
+	self allBlocksDo: aBlock
+	
+]
+
+{ #category : #accessing }
 CompiledCode >> withAllNestedLiteralsDo: aBlockClosure [ 
 	"This method traverses all the nested literals.
 	As a Block or Method can have literals in the nested blocks. 

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -933,7 +933,7 @@ CompiledCode >> withAllNestedLiteralsDo: aBlockClosure [
 	This is used to query all the selectors used in a method for example"
 	
 	self withAllBlocksDo: [ :aCompiledCode | 
-		aCompiledCode allLiterals do: aBlockClosure ]
+		aCompiledCode literals do: aBlockClosure ]
 ]
 
 { #category : #scanning }

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -106,6 +106,14 @@ CompiledCode >> addWithAllBlocksInto: collected [
 	^ collected
 ]
 
+{ #category : #accessing }
+CompiledCode >> allBlocksDo: aBlock [
+
+	self literals 
+		select: [ :aLiteral | aLiteral isEmbeddedBlock ] 
+		thenDo: [ :aLiteral | aLiteral withAllBlocksDo: aBlock  ]
+]
+
 { #category : #literals }
 CompiledCode >> allLiterals [
 	"Answer an Array of the literals referenced by the receiver.	

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -94,19 +94,6 @@ CompiledCode >> accessesSlot: aSlot [
 ]
 
 { #category : #accessing }
-CompiledCode >> addWithAllBlocksInto: collected [
-
-	(collected includes: self) ifTrue: [ ^ collected ].
-	collected add: self.
-
-	self literals 
-		select: [ :aLiteral | aLiteral isEmbeddedBlock ] 
-		thenDo: [ :aLiteral | aLiteral addWithAllBlocksInto: collected ].
-		
-	^ collected
-]
-
-{ #category : #accessing }
 CompiledCode >> allBlocksDo: aBlock [
 
 	self literals 
@@ -300,17 +287,16 @@ CompiledCode >> hasSelector: selector specialSelectorIndex: specialOrNil [
 	"Answers true if the method refers to the selector.
 	 If you don't know what's a special selector, use #hasSelector:.
 	 If you do, you may call this method directly to avoid recomputing 
-	 the special selector index all the time.
-	
-	 I traverse the method and all the compiled blocks in the literals"
-
-	
+	 the special selector index all the time.	
+	 I traverse the method and all the compiled blocks in the literals"	
 	(self refersToLiteral: selector) ifTrue: [ ^ true ].
 	"refersToLiteral: traverses all blocks, but only for non-special literals"
 	specialOrNil ifNil: [ ^ false ].
 	"if the selector is special, scan all blocks and myself"
-	^ self withAllBlocks anySatisfy: [ :aCompiledCode | aCompiledCode scanFor:
-			self encoderClass firstSpecialSelectorByte + specialOrNil ]
+	self withAllBlocksDo: [ :aCompiledCode | 
+		(aCompiledCode scanFor: self encoderClass firstSpecialSelectorByte + specialOrNil)
+			ifTrue: [ ^true ] ].
+	^false
 ]
 
 { #category : #accessing }
@@ -926,8 +912,10 @@ CompiledCode >> voidCogVMState [
 
 { #category : #accessing }
 CompiledCode >> withAllBlocks [
-
-	^ self addWithAllBlocksInto: IdentitySet new.
+	| all |
+	all := IdentitySet new.
+	self withAllBlocksDo: [ :each | all add: each ].
+	^all
 ]
 
 { #category : #accessing }
@@ -944,7 +932,7 @@ CompiledCode >> withAllNestedLiteralsDo: aBlockClosure [
 	As a Block or Method can have literals in the nested blocks. 
 	This is used to query all the selectors used in a method for example"
 	
-	self withAllBlocks do: [ :aCompiledCode | 
+	self withAllBlocksDo: [ :aCompiledCode | 
 		aCompiledCode allLiterals do: aBlockClosure ]
 ]
 

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -854,7 +854,7 @@ Context >> handleSignal: exception [
 	self evaluateSignal: exception
 ]
 
-{ #category : #query }
+{ #category : #testing }
 Context >> hasContext: aContext [ 
 	"Answer whether aContext is me or one of my senders"
 
@@ -868,12 +868,12 @@ Context >> hasInstVarRef [
 	^self compiledCode hasInstVarRef.
 ]
 
-{ #category : #accessing }
+{ #category : #testing }
 Context >> hasMethodReturn [
 	^closureOrNil hasMethodReturn
 ]
 
-{ #category : #controlling }
+{ #category : #testing }
 Context >> hasSender: context [ 
 	"Answer whether the receiver is strictly above context on the stack."
 
@@ -932,19 +932,19 @@ Context >> isBlockContext [
 	^closureOrNil isClosure
 ]
 
-{ #category : #query }
+{ #category : #testing }
 Context >> isBottomContext [
 	"Answer if this is the last context (the first context invoked) in my sender chain"
 
 	^sender isNil
 ]
 
-{ #category : #query }
+{ #category : #testing }
 Context >> isContext [
 	^true
 ]
 
-{ #category : #query }
+{ #category : #testing }
 Context >> isDead [
 	"Has self finished"
 

--- a/src/Kernel/FullBlockClosure.class.st
+++ b/src/Kernel/FullBlockClosure.class.st
@@ -62,7 +62,8 @@ FullBlockClosure >> endPC [
 { #category : #scanning }
 FullBlockClosure >> hasMethodReturn [
 	"Answer whether the receiver has a method-return ('^') in its code."
-	^ self compiledBlock hasMethodReturn
+	self withAllBlocksDo: [ :each | each hasMethodReturn ifTrue: [ ^true ] ].
+	^false
 ]
 
 { #category : #accessing }
@@ -297,4 +298,9 @@ FullBlockClosure >> valueWithArguments: anArray [
 		ifFalse: [
 			"Retrying with an array as parameter. As the primitive only supports arrays"
 			^ self valueWithArguments: anArray asArray ]
+]
+
+{ #category : #accessing }
+FullBlockClosure >> withAllBlocksDo: aBlock [
+	self compiledBlock withAllBlocksDo: aBlock
 ]

--- a/src/System-Support-Tests/MethodQueryTest.class.st
+++ b/src/System-Support-Tests/MethodQueryTest.class.st
@@ -11,8 +11,8 @@ Class {
 MethodQueryTest >> testReferencedClasses [
 	| refs |
 	refs := (CompiledMethod >> #referencedClasses) referencedClasses.
-	self assertEmpty: refs.
+	self assertCollection: refs hasSameElements: {IdentitySet}.
 
 	refs := thisContext method referencedClasses.
-	self assertCollection: refs hasSameElements: {CompiledMethod}
+	self assertCollection: refs hasSameElements: {CompiledMethod. IdentitySet}
 ]

--- a/src/System-Support/CompiledMethod.extension.st
+++ b/src/System-Support/CompiledMethod.extension.st
@@ -8,11 +8,11 @@ CompiledMethod >> implementors [
 { #category : #'*System-Support' }
 CompiledMethod >> referencedClasses [
 	"Return classes that are directly referenced by this method. It traverses all the compiled methods to get the classes"
-
-	^ self withAllBlocks flatCollect: [ :aCompiledCode | 
-			aCompiledCode literals
-				select: [ :l | l value isClass ] 
-				thenCollect: [:v | v value ]]
+	| result |
+	result := IdentitySet new.
+	self withAllNestedLiteralsDo: [:each | 
+		each value isClass ifTrue: [ result add: each value ]].
+	^result
 
 
 ]


### PR DESCRIPTION
Optimization to use withAllBlocksDo: instead of withAllBlocks to avoid collecting all blocks in an intermediate set.
It's done on top of #7321 to separate a bug fix and cleanup (which can be discussible)