### PR TITLE
CompiledBlock-reallyNoTrailer

### DIFF
--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -15,6 +15,12 @@ Class {
 	#category : #'Kernel-Methods'
 }
 
+{ #category : #accessing }
+CompiledBlock >> endPC [
+	"Answer the index of the last bytecode."
+	^ self size
+]
+
 { #category : #scanning }
 CompiledBlock >> hasMethodReturn [
 	"Answer whether the receiver has a method-return ('^') in its code."

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -210,9 +210,7 @@ CompiledCode >> encoderClass [
 
 { #category : #accessing }
 CompiledCode >> endPC [
-	"Answer the index of the last bytecode."
-	^ self trailer endPC
-
+	^ self subclassResponsibility
 ]
 
 { #category : #comparing }
@@ -884,13 +882,6 @@ CompiledCode >> timeStamp [
 	"(CompiledMethod compiledMethodAt: #timeStamp) timeStamp"
 
 	^ SourceFiles timeStampAt: self sourcePointer.
-]
-
-{ #category : #accessing }
-CompiledCode >> trailer [
-	"Answer the receiver's trailer"
-	^ CompiledMethodTrailer new method: self
-
 ]
 
 { #category : #testing }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -409,6 +409,12 @@ CompiledMethod >> embeddSourceInTrailer [
 ]
 
 { #category : #accessing }
+CompiledMethod >> endPC [
+	"Answer the index of the last bytecode."
+	^ self trailer endPC
+]
+
+{ #category : #accessing }
 CompiledMethod >> flushCache [
 	"Tell the virtual machine to remove all references to this method from its method lookup caches, and to discard any optimized version 	of the method, if it has any of these.  This must be done whenever a method is modified in place, such as modifying its literals or 	machine code, to reflect the revised code.  c.f. Behavior>>flushCache & Symbol>>flushCache.  Essential.	 See MethodDictionary class 	comment."
 
@@ -1106,6 +1112,12 @@ CompiledMethod >> tags [
 CompiledMethod >> tempNames [
 	"on the level of the compiled method, tempNames includes argument names"
 	^self ast argumentNames, self ast temporaryNames
+]
+
+{ #category : #accessing }
+CompiledMethod >> trailer [
+	"Answer the receiver's trailer"
+	^ CompiledMethodTrailer new method: self
 ]
 
 { #category : #'accessing-tags' }

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -180,7 +180,7 @@ IRBytecodeGenerator >> compiledBlockWith: trailer [
 	| lits header cb |
 	lits := self literals allButLast "1 free only for compiledBlock".
 	header := self spurVMHeader: lits size.
-	cb := trailer createMethod: self bytecodes size class: CompiledBlock header: header.
+	cb := CompiledBlock newMethod: self bytecodes size header: header.
 	(WriteStream with: cb)
 		position: cb initialPC - 1;
 		nextPutAll: self bytecodes.


### PR DESCRIPTION
We are creating CompiledBlock instances like methods: with an empty trailer. But that wastes 4 bytes per CompiledBlock, as the trailer is never set (only Methods store the source pointer there).

This PR creates CompiledBlock without trailing bytes