### PR TITLE
Deprecate-isSelf-isSuper

### DIFF
--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -590,27 +590,12 @@ RBProgramNode >> isSelector [
 ]
 
 { #category : #testing }
-RBProgramNode >> isSelf [
-	^ false
-]
-
-{ #category : #testing }
-RBProgramNode >> isSelfOrSuper [
-	^ false
-]
-
-{ #category : #testing }
 RBProgramNode >> isSelfVariable [
 	^ false
 ]
 
 { #category : #testing }
 RBProgramNode >> isSequence [
-	^false
-]
-
-{ #category : #testing }
-RBProgramNode >> isSuper [
 	^false
 ]
 

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -168,16 +168,6 @@ RBVariableNode >> isReservedVariable [
 ]
 
 { #category : #testing }
-RBVariableNode >> isSelf [
-	^ self isSelfVariable
-]
-
-{ #category : #testing }
-RBVariableNode >> isSelfOrSuper [
-	^ variable isSelfOrSuperVariable
-]
-
-{ #category : #testing }
 RBVariableNode >> isSelfOrSuperVariable [
 	^ variable isSelfOrSuperVariable
 ]
@@ -185,11 +175,6 @@ RBVariableNode >> isSelfOrSuperVariable [
 { #category : #testing }
 RBVariableNode >> isSelfVariable [
 	^variable isSelfVariable
-]
-
-{ #category : #testing }
-RBVariableNode >> isSuper [
-	^ self isSuperVariable
 ]
 
 { #category : #testing }

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddConditionalBreakpointCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddConditionalBreakpointCommand.class.st
@@ -128,7 +128,7 @@ ClyAddConditionalBreakpointCommand >> rewriteASTToSimulateExecutionInADifferentC
 		parseExpression: 'ThisContext receiver class superclass'.
 	allMessageNodes
 		do: [ :msgNode | 
-			msgNode receiver isSuper
+			msgNode receiver isSuperVariable
 				ifTrue: [ rewriter
 						replaceTree: msgNode
 						withTree:

--- a/src/Deprecated90/RBProgramNode.extension.st
+++ b/src/Deprecated90/RBProgramNode.extension.st
@@ -1,6 +1,33 @@
 Extension { #name : #RBProgramNode }
 
 { #category : #'*Deprecated90' }
+RBProgramNode >> isSelf [
+	self 
+		deprecated: 'Use #isSelfVariable instead.' 
+		transformWith: '`@receiver isSelf' -> '`@receiver isSelfVariable'.
+
+	^self isSelfVariable
+]
+
+{ #category : #'*Deprecated90' }
+RBProgramNode >> isSelfOrSuper [
+	self 
+		deprecated: 'Use #isSelfOrSuperVariable instead.' 
+		transformWith: '`@receiver isSelfOrSuper' -> '`@receiver isSelfOrSuperVariable'.
+
+	^ self isSelfOrSuperVariable
+]
+
+{ #category : #'*Deprecated90' }
+RBProgramNode >> isSuper [
+	self 
+		deprecated: 'Use #isSuperVariable instead.' 
+		transformWith: '`@receiver isSuper' -> '`@receiver isSuperVariable'.
+		
+	^ self isSuperVariable
+]
+
+{ #category : #'*Deprecated90' }
 RBProgramNode >> isThisContext [
 	self 
 		deprecated: 'Use #isThisContextVariable instead.' 

--- a/src/Flashback-Decompiler/FBDOptimizedMessagesRewriter.class.st
+++ b/src/Flashback-Decompiler/FBDOptimizedMessagesRewriter.class.st
@@ -250,7 +250,7 @@ FBDOptimizedMessagesRewriter >> isIfTrue: msgNode [
 
 { #category : #testing }
 FBDOptimizedMessagesRewriter >> isLastStatementReturnSelf: seq [
-	^ seq parent isMethod and: [ seq statements last isReturn and: [ seq statements last value isSelf ] ]
+	^ seq parent isMethod and: [ seq statements last isReturn and: [ seq statements last value isSelfVariable ] ]
 ]
 
 { #category : #testing }

--- a/src/HeuristicCompletion-Model/CoSelfMessageHeuristic.class.st
+++ b/src/HeuristicCompletion-Model/CoSelfMessageHeuristic.class.st
@@ -13,7 +13,7 @@ Class {
 { #category : #requests }
 CoSelfMessageHeuristic >> appliesForNode: aNode inContext: aContext [
 
-	^ aNode receiver isSelf
+	^ aNode receiver isSelfVariable
 ]
 
 { #category : #requests }

--- a/src/HeuristicCompletion-Model/CoSuperMessageHeuristic.class.st
+++ b/src/HeuristicCompletion-Model/CoSuperMessageHeuristic.class.st
@@ -14,7 +14,7 @@ Class {
 CoSuperMessageHeuristic >> appliesForNode: aNode inContext: aContext [
 
 	^ (aNode isMessage
-		and: [ aNode receiver isSuper ])
+		and: [ aNode receiver isSuperVariable ])
 			or: [ aNode isMethod
 				and: [ 
 					"This heuristic is not valid for traits and nil subclasses"

--- a/src/HeuristicCompletion-Model/CoTypeInferencer.class.st
+++ b/src/HeuristicCompletion-Model/CoTypeInferencer.class.st
@@ -83,7 +83,7 @@ CoTypeInferencer >> inferFrom: aClass typeGetters: aBoolean [
 CoTypeInferencer >> inferMessageReturn: aRBMessageNode receiverType: type argumentTypes: argumentTypes [
 
 	| lookupClass inferer |
-	lookupClass := aRBMessageNode receiver isSuper
+	lookupClass := aRBMessageNode receiver isSuperVariable
 		ifTrue: [ method methodClass superclass ]
 		ifFalse: [ type ].
 	method := lookupClass lookupSelector: aRBMessageNode selector.

--- a/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
@@ -89,7 +89,7 @@ RBInlineMethodRefactoring >> findSelectedMessage [
 		ifTrue: [ sourceMessage := sourceMessage messages last ].
 	sourceMessage isMessage
 		ifFalse: [ self refactoringFailure: 'The selection doesn''t appear to be a message send' ].
-	(sourceMessage receiver isSelf or: [ sourceMessage receiver isSuper ])
+	(sourceMessage receiver isSelfVariable or: [ sourceMessage receiver isSuperVariable ])
 		ifFalse: [ self refactoringError: 'Cannot inline non-self messages' ]
 ]
 

--- a/src/Refactoring-Core/RBRefactoryTyper.class.st
+++ b/src/Refactoring-Core/RBRefactoryTyper.class.st
@@ -408,7 +408,7 @@ RBRefactoryTyper >> processNode: aNode [
 	(aNode isVariable and: [class instanceVariableNames includes: aNode name]) 
 		ifTrue: [^self merge: aNode name].
 	(aNode isMessage 
-		and: [aNode receiver isSelf]) 
+		and: [aNode receiver isSelfVariable]) 
 			ifTrue: [^self merge: aNode selector].
 	aNode isAssignment 
 		ifTrue: 

--- a/src/Refactoring-Core/RBRemoveMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveMethodRefactoring.class.st
@@ -131,7 +131,7 @@ RBRemoveMethodRefactoring >> justSendsSuper: aSelector [
 				yourself
 			].
 	matcher executeTree: parseTree initialAnswer: Set new.
-	^ ( matcher answer anySatisfy: [ :each | each isSelf not ]) not
+	^ ( matcher answer anySatisfy: [ :each | each isSelfVariable not ]) not
 ]
 
 { #category : #preconditions }


### PR DESCRIPTION
This continues to cleanup of the isVariable tests on the AST.

- change all senders of isSelf, isSuper to call isSelfVariable, isSuperVariable
- deprecate isSuper, isSelf and isSelfOrSuper