### PR TITLE
Do not use #as: and #instVarNamed:put: in the initialization of OCASTTranslator

### DIFF
--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -404,11 +404,10 @@ OCASTTranslator >> emitWhileTrue: aMessageNode [
 OCASTTranslator >> initialize [
 
 	methodBuilder := IRBuilder new.
-	effectTranslator := self as: self classForEffect.
-	valueTranslator := self as: self classForValue.
-	effectTranslator instVarNamed: #effectTranslator put: effectTranslator.
-	effectTranslator instVarNamed: #valueTranslator put: valueTranslator.
-	valueTranslator instVarNamed: #valueTranslator put: valueTranslator.
+	effectTranslator := self classForEffect basicNew.
+	valueTranslator := self classForValue basicNew.
+	effectTranslator setFromSimilar: self.
+	valueTranslator setFromSimilar: self.
 
 ]
 
@@ -426,6 +425,28 @@ OCASTTranslator >> isEffectTranslator [
 { #category : #testing }
 OCASTTranslator >> isValueTranslator [
 	^self == valueTranslator
+]
+
+{ #category : #private }
+OCASTTranslator >> privateEffectTranslator [
+	^ effectTranslator
+]
+
+{ #category : #private }
+OCASTTranslator >> privateMethodBuilder [
+	^ methodBuilder
+]
+
+{ #category : #private }
+OCASTTranslator >> privateValueTranslator [
+	^ valueTranslator
+]
+
+{ #category : #initialization }
+OCASTTranslator >> setFromSimilar: aSimilarTranslator [
+	methodBuilder := aSimilarTranslator privateMethodBuilder.
+	effectTranslator := aSimilarTranslator privateEffectTranslator.
+	valueTranslator := aSimilarTranslator privateValueTranslator.
 ]
 
 { #category : #errors }


### PR DESCRIPTION
The #as: ends calling the following method for creating the similar subclass:

```smalltalk
copySameFrom: otherObject
	"Copy to myself all instance variables named the same in otherObject.
	This ignores otherObject's control over its own inst vars."

	| myInstVars otherInstVars |
	myInstVars := self class allInstVarNames.
	otherInstVars := otherObject class allInstVarNames.
	myInstVars doWithIndex: [:each :index | | match |
		(match := otherInstVars indexOf: each) > 0 ifTrue:
			[self instVarAt: index put: (otherObject instVarAt: match)]].
	1 to: (self basicSize min: otherObject basicSize) do: [:i |
		self basicAt: i put: (otherObject basicAt: i)].
```

This way of initializing the subclass instances look very suspicious. Also, this way of initializing the compiler is slow, it has O(n^2) on comparing the instance variable by name,  and it also looks like this is the only user in the system for this implementation of as:. The refactor adds accessor with the private prefix, and a method just copy what it needs by invoking these accessors.