### PR TITLE
Added a closeAllDebugger method to trait TDebugger class, that users …

### DIFF
--- a/src/Debugger-Model-Tests/TDebuggerTest.class.st
+++ b/src/Debugger-Model-Tests/TDebuggerTest.class.st
@@ -6,6 +6,13 @@ Class {
 	#category : #'Debugger-Model-Tests-Core'
 }
 
+{ #category : #accessing }
+TDebuggerTest class >> closeAllDebuggers [
+	"Do nothing. This class is a test class, not a real debugger, so it cannot stay open like real debugger. Therefore, it has nothing to do to 'close all of its debuggers'"
+
+	^ self
+]
+
 { #category : #'instance creation' }
 TDebuggerTest class >> debugSession: aDebugSession [
 	^true

--- a/src/Debugger-Model/TDebugger.trait.st
+++ b/src/Debugger-Model/TDebugger.trait.st
@@ -34,6 +34,11 @@ TDebugger classSide >> availableAutomatically: anObject [
 	availableAutomatically := anObject
 ]
 
+{ #category : #accessing }
+TDebugger classSide >> closeAllDebuggers [
+	^ self explicitRequirement
+]
+
 { #category : #'instance creation' }
 TDebugger classSide >> debugSession: aDebugSession [
 	self explicitRequirement

--- a/src/EmergencyDebugger/EDEmergencyDebugger.class.st
+++ b/src/EmergencyDebugger/EDEmergencyDebugger.class.st
@@ -75,6 +75,13 @@ EDEmergencyDebugger class >> availableAutomatically [
 	^ true
 ]
 
+{ #category : #'utilities api' }
+EDEmergencyDebugger class >> closeAllDebuggers [
+	"Do nothing, because this message does not make sense for the Emergency Debugger. If the emergencyDebugger  is open, it has the focus so the user cannot right-click on the taskbar and click on the 'close all debuggers' button anyway"
+
+	^ self
+]
+
 { #category : #'instance creation' }
 EDEmergencyDebugger class >> debug: aDebugSession [
 	self flag: 'Not good, must add and test the error too!'.


### PR DESCRIPTION
…have to implement.

This method is called when using the "close all debuggers" button in the taskbar's rightclick menu.
Added 'do nothing' implementations of this method to EDEmergencyDebugger and TDebuggerTest so that they comply with this new requirement. (These implementations do nothing on purpose, see method comments)

Fixes #7313 