### PR TITLE
OupsDebuggerSystem now calls DebugSession>>#logStackToFileIfNeeded be…

### DIFF
--- a/src/Debugger-Oups/OupsDebuggerSystem.class.st
+++ b/src/Debugger-Oups/OupsDebuggerSystem.class.st
@@ -75,6 +75,7 @@ OupsDebuggerSystem >> openDebuggerOnRequest: aDebugRequest [
 
 	<debuggerCompleteToSender>
 	| debuggerOpeningStrategy |
+	aDebugRequest debugSession logStackToFileIfNeeded.
 	self performPreDebugActionsIn: aDebugRequest.
 	self spawnNewUIProcessIfNecessary: aDebugRequest.
 	self ensureExceptionIn: aDebugRequest debugSession.


### PR DESCRIPTION
…fore opening a debugger on a debug request.

This was done by MorphicUIManager prior to the integration of Oups.

Fixes #7312 