### PR TITLE
Use the SDL renderer output size in the OSAthensRenderer for creating the Athens surface

### DIFF
--- a/src/OSWindow-Core/OSWindowAthensRenderer.class.st
+++ b/src/OSWindow-Core/OSWindowAthensRenderer.class.st
@@ -42,6 +42,12 @@ OSWindowAthensRenderer >> initialize [
 	session := Smalltalk session
 ]
 
+{ #category : #'as yet unclassified' }
+OSWindowAthensRenderer >> pixelExtent [
+	self checkSession.
+	^ self athensSurface extent
+]
+
 { #category : #drawing }
 OSWindowAthensRenderer >> prepareForDrawing [
 ]

--- a/src/OSWindow-Core/OSWindowAthensRenderer.class.st
+++ b/src/OSWindow-Core/OSWindowAthensRenderer.class.st
@@ -42,8 +42,10 @@ OSWindowAthensRenderer >> initialize [
 	session := Smalltalk session
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 OSWindowAthensRenderer >> pixelExtent [
+	"The extent of the window may not be in pixels, so we have to ask to the actual
+	drawing surface for its size in pixel. This is specially true under OS X with HiDPI suppport."
 	self checkSession.
 	^ self athensSurface extent
 ]

--- a/src/OSWindow-SDL2/OSSDL2AthensRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2AthensRenderer.class.st
@@ -59,7 +59,7 @@ OSSDL2AthensRenderer >> initializeWindowHandle: aBackendWindow [
 
 { #category : #drawing }
 OSSDL2AthensRenderer >> prepareForDrawing [
-	textureExtent ~= backendWindow extent ifTrue: [ self resized ].
+	textureExtent ~= renderer outputExtent ifTrue: [ self resized ].
 ]
 
 { #category : #'updating screen' }
@@ -80,7 +80,7 @@ OSSDL2AthensRenderer >> primitiveUpdateRectangle: rectangle externalForm: extern
 OSSDL2AthensRenderer >> resetResources [
 	| extent |
 	self checkSession.
-	extent := backendWindow extent.
+	extent := renderer outputExtent.
 	self createSDLSurfaceWithExtent: extent.
 	athensSurface := AthensCairoSDLSurface fromSDLSurface: sdlSurface.
 	texture := renderer 

--- a/src/OSWindow-SDL2/SDL_Renderer.class.st
+++ b/src/OSWindow-SDL2/SDL_Renderer.class.st
@@ -116,6 +116,18 @@ SDL_Renderer >> noRenderTarget [
 ]
 
 { #category : #rendering }
+SDL_Renderer >> outputExtent [
+	| buffer |
+	buffer := ExternalAddress allocate: 8.
+	^ [
+		| result |
+		self getOutputSizeW: buffer h: buffer + 4.
+		result := (buffer unsignedLongAt: 1) @ (buffer unsignedLongAt: 5).
+		result
+	] ensure: [ buffer free ].
+]
+
+{ #category : #rendering }
 SDL_Renderer >> present [
 	^ self ffiCall: #( void SDL_RenderPresent ( self ) )
 ]


### PR DESCRIPTION
This is required for HiDPI support in OS X.