### PR TITLE
7338-Epicea-should-not-use-oldDefinition-for-class

### DIFF
--- a/src/Calypso-Ring/RGBehavior.extension.st
+++ b/src/Calypso-Ring/RGBehavior.extension.st
@@ -96,7 +96,14 @@ RGBehavior >> methodDict [
 
 { #category : #'*Calypso-Ring' }
 RGBehavior >> oldDefinition [
-	"Answer a String that defines the receiver."
+	"Answer a String that defines the receiver in the old format using poolDictionaries and category.
+	e.g,  
+	'Object subclass: #Point
+		instanceVariableNames: ''x y''
+		classVariableNames: ''''
+		poolDictionaries: ''''
+		category: ''Kernel-BasicObjects'''
+	"
 
 	| aStream |
 	aStream := (String new: 800) writeStream.

--- a/src/Epicea/Class.extension.st
+++ b/src/Epicea/Class.extension.st
@@ -13,13 +13,13 @@ Class >> asEpiceaRingDefinition [
 		addSharedPools: self sharedPoolNames;
 		comment: self organization classComment;
 		stamp: self organization commentStamp;
-		definitionSource: self oldDefinition;
+		definitionSource: self definition;
 		package: (EpPlatform current packageNameFor: self);
 		withMetaclass.
 
 	ring classSide 
 		traitCompositionSource: self classSide traitCompositionString;
-		definitionSource: self classSide oldDefinition;
+		definitionSource: self classSide definition;
 		addInstanceVariables: self classSide instVarNames.  
 
 	^ ring

--- a/src/Epicea/Metaclass.extension.st
+++ b/src/Epicea/Metaclass.extension.st
@@ -8,7 +8,7 @@ Metaclass >> asEpiceaRingDefinition [
 
 	^ baseClassDefinition withMetaclass classSide 
 		traitCompositionSource: self classSide traitCompositionString;
-		definitionSource: self classSide oldDefinition;
+		definitionSource: self classSide definition;
 		addInstanceVariables: self classSide instVarNames;
 		yourself
 ]

--- a/src/Epicea/MetaclassForTraits.extension.st
+++ b/src/Epicea/MetaclassForTraits.extension.st
@@ -8,6 +8,6 @@ MetaclassForTraits >> asEpiceaRingDefinition [
 
 	^ baseClassDefinition withMetaclass classSide 
 		traitCompositionSource: self classSide traitCompositionString;
-		definitionSource: self classSide oldDefinition;
+		definitionSource: self classSide definition;
 		yourself
 ]

--- a/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
@@ -166,7 +166,7 @@ EpApplyPreviewerTest >> testCategoryRenameWithPreviousRollback [
 EpApplyPreviewerTest >> testClassAdditionWithClassRemoved [
 	| aClass classDefinition |
 	aClass := classFactory newClass.
-	classDefinition := aClass oldDefinition.
+	classDefinition := aClass definition.
 	self setHeadAsInputEntry.
 
 	aClass removeFromSystem.
@@ -181,13 +181,13 @@ EpApplyPreviewerTest >> testClassAdditionWithInstanceVariablesChanged [
 
 	| aClass classDefinition |
 	aClass := classFactory newClass.
-	classDefinition := aClass oldDefinition.
+	classDefinition := aClass definition.
 	self setHeadAsInputEntry.
 	aClass addInstVarNamed: #x.
 
 	self assertOutputsAnEventWith: [:output | 
 		self assert: output class equals: EpClassModification.
-		self assert: output oldClass definitionSource equals: aClass oldDefinition.
+		self assert: output oldClass definitionSource equals: aClass definition.
 		self assert: output newClass definitionSource equals: classDefinition.
 		]
 
@@ -198,13 +198,13 @@ EpApplyPreviewerTest >> testClassAdditionWithSuperclassChanged [
 
 	| aClass classDefinition |
 	aClass := classFactory newClass.
-	classDefinition := aClass oldDefinition.
+	classDefinition := aClass definition.
 	self setHeadAsInputEntry.
 	aClass superclass: Array.
 
 	self assertOutputsAnEventWith: [:output | 
 		self assert: output class equals: EpClassModification.
-		self assert: output oldClass definitionSource equals: aClass oldDefinition.
+		self assert: output oldClass definitionSource equals: aClass definition.
 		self assert: output newClass definitionSource equals: classDefinition.
 		].
 
@@ -226,7 +226,7 @@ EpApplyPreviewerTest >> testClassRemovalWithClassAdded [
 
 	self assertOutputsAnEventWith: [ :output | 
 		self assert: output class equals: EpClassRemoval.
-		self assert: output behaviorAffected definitionSource equals: aClass oldDefinition ]
+		self assert: output behaviorAffected definitionSource equals: aClass definition ]
 ]
 
 { #category : #tests }

--- a/src/EpiceaBrowsers/EpApplyPreviewer.class.st
+++ b/src/EpiceaBrowsers/EpApplyPreviewer.class.st
@@ -120,7 +120,7 @@ EpApplyPreviewer >> visitClassChange: aChange [
 	self
 		behaviorNamed: aChange behaviorAffectedName
 		ifPresent: [ :aClass |
-			^ aClass oldDefinition = aChange behaviorAffected definition
+			^ aClass definition = aChange behaviorAffected definition
 				ifTrue: [ #() ]
 				ifFalse: [ { EpClassModification oldClass: aClass newClass: aChange behaviorAffected } ]
 			].

--- a/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
+++ b/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
@@ -49,8 +49,8 @@ EpHasImpactVisitor >> visitBehaviorCategoryChange: aChange [
 { #category : #visitor }
 EpHasImpactVisitor >> visitBehaviorChange: aChange [
 	self behaviorNamed: aChange behaviorAffectedName ifPresent: [ :behavior | 
-		^ behavior oldDefinition ~= aChange behaviorAffected definitionSource or: [
-			behavior classSide oldDefinition ~= aChange behaviorAffected classSide definitionSource ] ].
+		^ behavior definition ~= aChange behaviorAffected definitionSource or: [
+			behavior classSide definition ~= aChange behaviorAffected classSide definitionSource ] ].
 
 	^ true
 ]

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -889,7 +889,14 @@ Class >> obsolete [
 
 { #category : #'file in/out' }
 Class >> oldDefinition [
-	"Answer a String that defines the receiver."
+	"Answer a String that defines the receiver in the old format using poolDictionaries and category.
+	e.g,  
+	'Object subclass: #Point
+		instanceVariableNames: ''x y''
+		classVariableNames: ''''
+		poolDictionaries: ''''
+		category: ''Kernel-BasicObjects'''
+	"
 
 	| aStream |
 	aStream := (String new: 800) writeStream.
@@ -1142,7 +1149,7 @@ Class >> sharedPoolsDo: aBlockClosure [
 	self sharedPools do: aBlockClosure
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #initialization }
 Class >> sharing: poolString [ 
 	"Set up sharedPools. Answer whether recompilation is advisable."
 	| oldPools |

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -269,7 +269,7 @@ Metaclass >> obsoleteSubclasses [
 
 { #category : #'file in/out' }
 Metaclass >> oldDefinition [
-	"Refer to the comment in ClassDescription|definition.
+	"Refer to the comment of Class. 
 	 This method is for compatibility with Class>>#oldDefinition"
 
 	^ self definition

--- a/src/Ring-Definitions-Core/Class.extension.st
+++ b/src/Ring-Definitions-Core/Class.extension.st
@@ -54,12 +54,12 @@ Class >> asRingDefinition [
 		addSharedPools: self sharedPoolNames;
 		comment: self organization classComment;
 		stamp: self organization commentStamp;
-		definitionSource: self oldDefinition;
+		definitionSource: self definition;
 		package: self package asRingDefinition;
 		withMetaclass.
 	ring classSide 
 		traitCompositionSource: self classSide traitCompositionString;
-		definitionSource: self classSide oldDefinition;
+		definitionSource: self classSide definition;
 		addInstanceVariables: self classSide instVarNames.  
 	^ ring
 ]

--- a/src/Ring-Definitions-Core/Trait.extension.st
+++ b/src/Ring-Definitions-Core/Trait.extension.st
@@ -12,12 +12,12 @@ Trait >> asRingDefinition [
 		traitCompositionSource: self traitCompositionString;
 		comment: self organization classComment;
 		stamp: self organization commentStamp;
-		definitionSource: self oldDefinition;
+		definitionSource: self definition;
 		withMetaclass.
 		
 	ring classSide 
 		traitCompositionSource: self classSide traitCompositionString;
-		definitionSource: self classSide oldDefinition.
+		definitionSource: self classSide definition.
 
 	^ring
 ]

--- a/src/Ring-Definitions-Tests-Core/RGClassDefinitionTest.class.st
+++ b/src/Ring-Definitions-Tests-Core/RGClassDefinitionTest.class.st
@@ -81,14 +81,13 @@ RGClassDefinitionTest >> testAsClassDefinitionSourceDefinition [
 	| newClass |
 	newClass := MOPTestClassC asRingDefinition.
 	self
-		assert: newClass definitionSource
+		assert: newClass definitionSource 
 		equals:
 			'Object subclass: #MOPTestClassC
 	uses: Trait2
 	instanceVariableNames: ''''
 	classVariableNames: ''''
-	poolDictionaries: ''''
-	category: ''Tests-Traits-MOP'''.
+	package: ''Tests-Traits-MOP'''.
 
 	self
 		assert: newClass classSide definitionSource


### PR DESCRIPTION
fixes: #7338 make epicea works on definition and not old definition. 
Rigth now one test is failing: testClassRemoval and I may need help from Martin.