### PR TITLE
LiteralSharing-Optional

### DIFF
--- a/src/Collections-Native/ByteArray.class.st
+++ b/src/Collections-Native/ByteArray.class.st
@@ -212,6 +212,12 @@ ByteArray >> isLiteral [
 	^ self class == ByteArray
 ]
 
+{ #category : #testing }
+ByteArray >> isSharedLiteral [
+	"Can this Literal be shared between methods when doing 'ImageCleaner shareLiterals'?"
+	^self isLiteral
+]
+
 { #category : #'platform independent access' }
 ByteArray >> longAt: index bigEndian: aBool [
 	"Return a 32bit integer quantity starting from the given byte index"

--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -266,6 +266,12 @@ Array >> isSelfEvaluating [
 	^ (self allSatisfy: [:each | each isSelfEvaluating]) and: [self class == Array]
 ]
 
+{ #category : #testing }
+Array >> isSharedLiteral [
+	"Can this Literal be shared between methods when doing 'ImageCleaner shareLiterals'?"
+	^self isLiteral
+]
+
 { #category : #comparing }
 Array >> literalEqual: other [
 

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1865,7 +1865,7 @@ String >> isPatternVariable [
 { #category : #testing }
 String >> isSharedLiteral [
 	"Can this Literal be shared between methods when doing 'ImageCleaner shareLiterals'?"
-	^true
+	^self isLiteral
 ]
 
 { #category : #testing }

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1863,6 +1863,12 @@ String >> isPatternVariable [
 ]
 
 { #category : #testing }
+String >> isSharedLiteral [
+	"Can this Literal be shared between methods when doing 'ImageCleaner shareLiterals'?"
+	^true
+]
+
+{ #category : #testing }
 String >> isString [
 	^ true
 ]

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -541,6 +541,13 @@ Symbol >> isSelectorSymbol [
 ]
 
 { #category : #testing }
+Symbol >> isSharedLiteral [
+	"Can this Literal be shared between methods when doing 'ImageCleaner shareLiterals'?"
+	"Symbols are shared, but this is done because Symbols are shared system wide, not by the ImageCleaner"
+	^false
+]
+
+{ #category : #testing }
 Symbol >> isSymbol [
 	^ true 
 ]

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -541,13 +541,6 @@ Symbol >> isSelectorSymbol [
 ]
 
 { #category : #testing }
-Symbol >> isSharedLiteral [
-	"Can this Literal be shared between methods when doing 'ImageCleaner shareLiterals'?"
-	"Symbols are shared, but this is done because Symbols are shared system wide, not by the ImageCleaner"
-	^false
-]
-
-{ #category : #testing }
 Symbol >> isSymbol [
 	^ true 
 ]

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1306,6 +1306,12 @@ Object >> isSelfEvaluating [
 ]
 
 { #category : #testing }
+Object >> isSharedLiteral [
+	"Can this Literal be shared between methods when doing 'ImageCleaner shareLiterals'?"
+	^false
+]
+
+{ #category : #testing }
 Object >> isStream [
 	"Return true if the receiver responds to the stream protocol"
 	^false

--- a/src/OpalCompiler-Core/IRTranslator.class.st
+++ b/src/OpalCompiler-Core/IRTranslator.class.st
@@ -250,14 +250,13 @@ IRTranslator >> visitPushInstVar: instVar [
 IRTranslator >> visitPushLiteral: lit [
 	| literal |
 	literal := lit literal.
-	"During bootstrap script 1, 1 class isImmediateClass answers false, so we 
-	 cannot rely on literal class isImmediateClass here or it breaks the bootstrap."
-	({Character.SmallInteger.SmallFloat64} includes: literal class) ifTrue: [ ^ gen pushLiteral: literal ].
+	"all potentially shared literals are compiled read only"
+	(literal isSharedLiteral) ifFalse: [ ^ gen pushLiteral: literal ].
 	Smalltalk vm supportsWriteBarrier ifFalse: [ ^ gen pushLiteral: literal ].
 	"For symbol we need to set explicitly to writable or read-only. 
 	 Compilation to read-only then back to writable keep the object 
 	 read-only if we don't set it back to writable."
-	compilationContext optionReadOnlyLiterals
+	compilationContext optionReadOnlyLiterals 
 		ifTrue: [ literal beReadOnlyObject ]
 		ifFalse: [ literal beWritableObject ].
 	^ gen pushLiteral: literal

--- a/src/OpalCompiler-Core/IRTranslator.class.st
+++ b/src/OpalCompiler-Core/IRTranslator.class.st
@@ -256,7 +256,7 @@ IRTranslator >> visitPushLiteral: lit [
 	"For symbol we need to set explicitly to writable or read-only. 
 	 Compilation to read-only then back to writable keep the object 
 	 read-only if we don't set it back to writable."
-	compilationContext optionReadOnlyLiterals 
+	compilationContext optionReadOnlyLiterals
 		ifTrue: [ literal beReadOnlyObject ]
 		ifFalse: [ literal beWritableObject ].
 	^ gen pushLiteral: literal

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -207,7 +207,7 @@ ImageCleaner >> removeEmptyPackages [
 { #category : #'literal sharing' }
 ImageCleaner >> shareLiterals [
 	"Experimental Image Shrinker: We go over all methods and replace all the literals that are equal by one copy"
-	"Note: as thse literals can be changed, a bug that was localized could now have a global effect"
+	"Note: as thse literals can be changed, it is adviced to set #optionReadOnlyLiterals to true and recompile the system before using this in production"
 	self createLiteralTable.
 	self literalsDo: [ :literal :cm |
 			cm literalAt: (cm indexOfLiteral: literal) put: (literalTable at: literal)  ].

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -22,6 +22,9 @@ You can use one of my 2 methods:
 Class {
 	#name : #ImageCleaner,
 	#superclass : #Object,
+	#instVars : [
+		'literalTable'
+	],
 	#category : #'Tool-ImageCleaner'
 }
 
@@ -49,6 +52,12 @@ ImageCleaner class >> helpPackages [
 	<script: 'self helpPackages inspect'>
 	
 	^RPackageOrganizer default packageNames select: [ :each | each endsWith: '-Help' ]
+]
+
+{ #category : #'instance creation' }
+ImageCleaner class >> shareLiterals [
+	<script>
+	self new shareLiterals
 ]
 
 { #category : #accessing }
@@ -137,6 +146,12 @@ ImageCleaner >> cleanUpProcesses [
 				terminate ]
 ]
 
+{ #category : #'literal sharing' }
+ImageCleaner >> createLiteralTable [
+	literalTable := Dictionary new.
+	self literalsDo: [ :literal : method | literalTable at: literal put: literal]
+]
+
 { #category : #cleaning }
 ImageCleaner >> examplePackages [
 	^RPackageOrganizer default packageNames select: [ :each | each endsWith: 'Examples' ]
@@ -145,6 +160,15 @@ ImageCleaner >> examplePackages [
 { #category : #cleaning }
 ImageCleaner >> helpPackages [
 	^RPackageOrganizer default packageNames select: [ :each | each endsWith: '-Help' ]
+]
+
+{ #category : #'literal sharing' }
+ImageCleaner >> literalsDo: aBlock [
+
+	CompiledCode allSubInstancesDo: [ :cm | 
+		cm literals do: [ :literal | 
+			literal isSharedLiteral ifTrue: [ 
+				aBlock value: literal value: cm ] ] ]
 ]
 
 { #category : #cleaning }
@@ -177,6 +201,24 @@ ImageCleaner >> removeEmptyPackages [
 	| empty |
 	empty := RPackageOrganizer default packages select: #isEmpty.
 	empty do: #unregister.
+]
+
+{ #category : #'literal sharing' }
+ImageCleaner >> shareLiterals [
+	"Experimental Image Shrinker: We go over all methods and replace all the literals that are equal by one copy"
+	"Note: as thse literals can be changed, a bug that was localized could now have a global effect"
+	self createLiteralTable.
+	self literalsDo: [ :literal :cm |
+			cm literalAt: (cm indexOfLiteral: literal) put: (literalTable at: literal)  ].
+	literalTable := nil.
+		
+
+]
+
+{ #category : #'literal sharing' }
+ImageCleaner >> statistics [
+	"run this before and after"
+	^(CompiledCode allSubInstances flatCollect: #literals) asIdentitySet size
 ]
 
 { #category : #cleaning }

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -152,6 +152,12 @@ ImageCleaner >> createLiteralTable [
 	self literalsDo: [ :literal : method | literalTable at: literal put: literal]
 ]
 
+{ #category : #'literal sharing' }
+ImageCleaner >> detroyLiteralTable [
+	"in case someone keeps in instance of ImageCleaner, make sure the table gets GCed"
+	literalTable := nil
+]
+
 { #category : #cleaning }
 ImageCleaner >> examplePackages [
 	^RPackageOrganizer default packageNames select: [ :each | each endsWith: 'Examples' ]
@@ -211,14 +217,14 @@ ImageCleaner >> shareLiterals [
 	self createLiteralTable.
 	self literalsDo: [ :literal :cm |
 			cm literalAt: (cm indexOfLiteral: literal) put: (literalTable at: literal)  ].
-	literalTable := nil.
+	self detroyLiteralTable
 		
 
 ]
 
 { #category : #'literal sharing' }
 ImageCleaner >> statistics [
-	"run this before and after"
+	"run this before and after, this is just there while testing, will be removed"
 	^(CompiledCode allSubInstances flatCollect: #literals) asIdentitySet size
 ]
 

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -167,7 +167,8 @@ ImageCleaner >> literalsDo: aBlock [
 
 	CompiledCode allSubInstancesDo: [ :cm | 
 		cm literals do: [ :literal | 
-			literal isSharedLiteral ifTrue: [ 
+			"Symbols are already shared, we can skip them here"
+			(literal isSharedLiteral and: [literal isSymbol not]) ifTrue: [ 
 				aBlock value: literal value: cm ] ] ]
 ]
 


### PR DESCRIPTION
Lots of methods and blocks refer to literals that are equal. 

This is not yet turned on by default as literals can be changed... which leads to bugs that are now local, but with this change get to have a potential global effect. (making exactly those literals read only that are shared here is a future step).


ImageCleaner new statistics "141930" 

ImageCleaner shareLiterals

ImageCleaner new statistics "118979"