### PR TITLE
Variables: is*Variable on RBProgramNode

### DIFF
--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -449,7 +449,7 @@ RBProgramNode >> isArgument [
 
 { #category : #testing }
 RBProgramNode >> isArgumentVariable [
-	^false
+	^ false
 ]
 
 { #category : #testing }
@@ -473,8 +473,13 @@ RBProgramNode >> isCascade [
 ]
 
 { #category : #testing }
+RBProgramNode >> isClassVariable [
+	^ false
+]
+
+{ #category : #testing }
 RBProgramNode >> isCommentNode [
-	^false.
+	^false
 ]
 
 { #category : #testing }
@@ -507,6 +512,11 @@ RBProgramNode >> isFaulty [
 	^false
 ]
 
+{ #category : #testing }
+RBProgramNode >> isGlobalVariable [
+	^false
+]
+
 { #category : #deprecated }
 RBProgramNode >> isImmediate [
 	^self isImmediateNode
@@ -514,6 +524,11 @@ RBProgramNode >> isImmediate [
 
 { #category : #testing }
 RBProgramNode >> isImmediateNode [
+	^false
+]
+
+{ #category : #testing }
+RBProgramNode >> isInstanceVariable [
 	^false
 ]
 
@@ -541,6 +556,16 @@ RBProgramNode >> isLiteralArrayError [
 
 { #category : #testing }
 RBProgramNode >> isLiteralNode [
+	^false
+]
+
+{ #category : #testing }
+RBProgramNode >> isLiteralVariable [
+	^false
+]
+
+{ #category : #testing }
+RBProgramNode >> isLocalVariable [
 	^false
 ]
 
@@ -580,12 +605,22 @@ RBProgramNode >> isPragmaError [
 ]
 
 { #category : #testing }
+RBProgramNode >> isReservedVariable [
+	^false
+]
+
+{ #category : #testing }
 RBProgramNode >> isReturn [
 	^false
 ]
 
 { #category : #testing }
 RBProgramNode >> isSelector [
+	^false
+]
+
+{ #category : #testing }
+RBProgramNode >> isSelfOrSuperVariable [
 	^false
 ]
 
@@ -620,6 +655,11 @@ RBProgramNode >> isThisContextVariable [
 ]
 
 { #category : #testing }
+RBProgramNode >> isUndeclaredVariable [
+	^false
+]
+
+{ #category : #testing }
 RBProgramNode >> isUsed [
 	"Answer true if this node could be used as part of another expression. For example, you could use the 
 	result of this node as a receiver of a message, an argument, the right part of an assignment, or the 
@@ -636,6 +676,11 @@ RBProgramNode >> isValue [
 
 { #category : #testing }
 RBProgramNode >> isVariable [
+	^false
+]
+
+{ #category : #testing }
+RBProgramNode >> isWorkspaceVariable [
 	^false
 ]
 

--- a/src/Calypso-SystemTools-Core/ClySourceCodeContext.class.st
+++ b/src/Calypso-SystemTools-Core/ClySourceCodeContext.class.st
@@ -68,9 +68,7 @@ ClySourceCodeContext >> executeCommand: aCommand by: aCommandActivator [
 
 { #category : #testing }
 ClySourceCodeContext >> isArgOrTempVariableSelected [
-	| node |
-	node := self selectedSourceNode.
-	^node isVariable and: [ node isLocalVariable ]
+	^ self selectedSourceNode isLocalVariable
 ]
 
 { #category : #testing }

--- a/src/GeneralRules/ReGlobalVariablesUsageRule.class.st
+++ b/src/GeneralRules/ReGlobalVariablesUsageRule.class.st
@@ -19,7 +19,7 @@ ReGlobalVariablesUsageRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	aMethod ast allChildren
 		select: [ :node |
 				node isGlobalVariable and: [
-					node isGlobalClassNameBinding not and: [
+					node variable isGlobalClassNameBinding not and: [
 					(self isKnownGlobal: node name) not ] ] ]
 		thenDo: [ :node |
 			aCriticBlock cull: (self

--- a/src/GeneralRules/ReGlobalVariablesUsageRule.class.st
+++ b/src/GeneralRules/ReGlobalVariablesUsageRule.class.st
@@ -18,10 +18,9 @@ ReGlobalVariablesUsageRule class >> checksMethod [
 ReGlobalVariablesUsageRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	aMethod ast allChildren
 		select: [ :node |
-			node isVariable and: [ 
-				node variable isGlobalVariable and: [
-					node variable isGlobalClassNameBinding not and: [
-					(self isKnownGlobal: node name) not ] ] ] ] 
+				node isGlobalVariable and: [
+					node isGlobalClassNameBinding not and: [
+					(self isKnownGlobal: node name) not ] ] ]
 		thenDo: [ :node |
 			aCriticBlock cull: (self
 				createTrivialCritiqueOn: aMethod

--- a/src/GeneralRules/ReReferencesObsoleteClassRule.class.st
+++ b/src/GeneralRules/ReReferencesObsoleteClassRule.class.st
@@ -10,10 +10,9 @@ Class {
 
 { #category : #helpers }
 ReReferencesObsoleteClassRule >> basicCheck: aNode [
- 	^ aNode isVariable 
- 		and: [aNode isGlobalVariable
+ 	^ aNode isGlobalVariable
  			and: [ aNode variable isGlobalClassNameBinding
- 				and: [ aNode variable value isObsolete ] ] ]
+ 				and: [ aNode variable value isObsolete ] ] 
 ]
 
 { #category : #helpers }

--- a/src/GeneralRules/ReRefersToClassRule.class.st
+++ b/src/GeneralRules/ReRefersToClassRule.class.st
@@ -30,7 +30,7 @@ ReRefersToClassRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	
 	class := aMethod methodClass instanceSide.
 	problemLiterals := (aMethod ast allChildren 
-			select: [ :node | node isVariable and:[ node isGlobalVariable ] ])
+			select: [ :node | node isGlobalVariable ])
 			select: [ :var | var name = class name].
 		
 	problemLiterals do: [ :literal |

--- a/src/GeneralRules/ReTemporaryVariableCapitalizationRule.class.st
+++ b/src/GeneralRules/ReTemporaryVariableCapitalizationRule.class.st
@@ -9,7 +9,6 @@ Class {
 
 { #category : #running }
 ReTemporaryVariableCapitalizationRule >> basicCheck: aNode [
-	aNode isVariable ifFalse: [ ^false ].
 	aNode isLocalVariable ifFalse: [ ^false ].
 	aNode isDefinition ifFalse: [ ^false ].
 	^aNode name first isUppercase

--- a/src/GeneralRules/ReUsesWorldGlobalRule.class.st
+++ b/src/GeneralRules/ReUsesWorldGlobalRule.class.st
@@ -17,7 +17,7 @@ ReUsesWorldGlobalRule class >> uniqueIdentifierName [
 
 { #category : #running }
 ReUsesWorldGlobalRule >> basicCheck: aNode [
-	^ aNode isVariable and: [ aNode isGlobalVariable and: [ #(#World #ActiveWorld) includes: aNode name ] ]
+	^ aNode isGlobalVariable and: [ #(#World #ActiveWorld) includes: aNode name ]
 ]
 
 { #category : #accessing }

--- a/src/Kernel-Rules/FloatReferencesRule.class.st
+++ b/src/Kernel-Rules/FloatReferencesRule.class.st
@@ -9,7 +9,6 @@ Class {
 
 { #category : #running }
 FloatReferencesRule >> basicCheck: node [
-	node isVariable ifFalse: [ ^ false ].
 	node isGlobalVariable ifFalse: [ ^ false ].
 	^(self systemClassNames includes: node name)
 	

--- a/src/Kernel-Rules/SendsDeprecatedMethodToGlobalRule.class.st
+++ b/src/Kernel-Rules/SendsDeprecatedMethodToGlobalRule.class.st
@@ -18,8 +18,7 @@ SendsDeprecatedMethodToGlobalRule class >> uniqueIdentifierName [
 SendsDeprecatedMethodToGlobalRule >> basicCheck: aNode [
 	| value |
 	aNode isMessage ifFalse: [ ^ false ].
-	aNode receiver isVariable ifFalse: [ ^ false ].
-	aNode receiver variable isLiteralVariable ifFalse: [ ^ false ].
+	aNode receiver isLiteralVariable ifFalse: [ ^ false ].
 	value := aNode receiver variable value.
 	^value class classAndMethodFor: aNode selector
 		do: [ :class :method | method isDeprecated ]

--- a/src/Ring-Tests-Core/RGGlobalVariableTest.class.st
+++ b/src/Ring-Tests-Core/RGGlobalVariableTest.class.st
@@ -17,7 +17,7 @@ RGGlobalVariableTest >> testGlobalVariableImplicitEnvironment [
 RGGlobalVariableTest >> testNewGlobalVariable [
 
 	| classVariable | 
-	classVariable  := RGGlobalVariable named: #SomeGlobalVariable..
+	classVariable  := RGGlobalVariable named: #SomeGlobalVariable.
 	self assert: (classVariable isRingResolved).
 	self assert: (classVariable hasResolvedName).
 	self assert: (classVariable isGlobalVariable).


### PR DESCRIPTION
#isSelf and #isSuper could always be asked to any AST node. isGlobal and all the others where just defined on RBVariableNode.

This PR unifies the situation:

- make sure that *all* variable tests are defined on RBProgramNode to return false
-  simplify some users