### PR TITLE
Fix-Completion-isSelfVariable

### DIFF
--- a/src/AST-Core/RBEnglobingErrorNode.class.st
+++ b/src/AST-Core/RBEnglobingErrorNode.class.st
@@ -54,9 +54,8 @@ RBEnglobingErrorNode class >> error: aToken withNodes: aCollection [
 { #category : #visiting }
 RBEnglobingErrorNode >> acceptVisitor: aVisitor [
 
-	^ [ aVisitor visitEnglobingErrorNode: self ]
-		on: Error
-		do: [super acceptVisitor: aVisitor ].
+	^ aVisitor visitEnglobingErrorNode: self
+
 ]
 
 { #category : #accessing }
@@ -74,7 +73,7 @@ RBEnglobingErrorNode >> content: aCollection [
 	content := aCollection
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 RBEnglobingErrorNode >> createValue [
 	self value: (String streamContents: [ :s |
 			content do: [ :each | s nextPutAll: each formattedCode. s nextPutAll: String space. ]])

--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -67,10 +67,12 @@ CoASTResultSetBuilder >> node: aNode [
 { #category : #'API - building' }
 CoASTResultSetBuilder >> parseNode [
 
-	^ node ifNil: [ node := (completionContext isWorkspace
-		ifTrue: [ RBParser parseFaultyExpression: completionContext source ]
-		ifFalse: [ RBParser parseFaultyMethod: completionContext source ]) doSemanticAnalysis
-			nodeForOffset: completionContext position ]
+	^ node ifNil: [
+		(completionContext completionClass compiler
+			source: completionContext source;
+			noPattern: completionContext isWorkspace; 
+			options: #(+ optionParseErrors + optionSkipSemanticWarnings);
+			parse) doSemanticAnalysis nodeForOffset: completionContext position ] 
 ]
 
 { #category : #visiting }

--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -100,6 +100,11 @@ CoASTResultSetBuilder >> visitCascadeNode: aRBCascadeNode [
 ]
 
 { #category : #visiting }
+CoASTResultSetBuilder >> visitEnglobingErrorNode: aRBVariableNode [ 
+	^ self visitNode: aRBVariableNode
+]
+
+{ #category : #visiting }
 CoASTResultSetBuilder >> visitGlobalNode: aRBVariableNode [
 
 	^ self visitVariableNode: aRBVariableNode

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -187,7 +187,6 @@ OCASTSemanticAnalyzer >> visitBlockNode: aBlockNode [
 
 { #category : #visiting }
 OCASTSemanticAnalyzer >> visitEnglobingErrorNode: anEnglobingError [
-	self visitNode: anEnglobingError value.
 	anEnglobingError content do: [ :each | self visitNode: each ]
 ]
 


### PR DESCRIPTION
This fixes a bug where #isSelfVariable is send to a RBVariableNode with a nil variable. Reason: Semantic analysis was broken and *that* was hidden behing an on: Error do: handler...

- removes the error handler
- implements parseNode of the CoASTResultSetBuilder to use the compiler facade (remove a ref to RBParser and simplify)
- remove the "self visitNode: anEnglobingError value.â