### PR TITLE
methodOrBlockNode-not-commented

### DIFF
--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -268,7 +268,7 @@ RBBlockNode >> match: aNode inContext: aDictionary [
 
 { #category : #accessing }
 RBBlockNode >> methodOrBlockNode [
-	"^ self"
+	^ self
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -479,7 +479,7 @@ RBMethodNode >> methodNode [
 
 { #category : #accessing }
 RBMethodNode >> methodOrBlockNode [
-	"^ self"
+	^ self
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -756,17 +756,6 @@ RBProgramNode >> parent: aRBProgramNode [
 	parent := aRBProgramNode
 ]
 
-{ #category : #accessing }
-RBProgramNode >> parents [
-	"see discussion in https://github.com/pharo-project/pharo/issues/6278"
-		self
-		deprecated: 'Use #withAllParents instead'
-		on: '25 may 2020'
-		in: #Pharo9
-		transformWith: '`@receiver parents' 
-						-> '`@receiver withALlParents'.
-]
-
 { #category : #hook }
 RBProgramNode >> parserClass [
 	^ RBParser

--- a/src/Deprecated90/RBProgramNode.extension.st
+++ b/src/Deprecated90/RBProgramNode.extension.st
@@ -43,3 +43,15 @@ RBProgramNode >> methodComments [
 		transformWith: '`@receiver methodComments' -> '`@receiver comments'.
 	^self comments
 ]
+
+{ #category : #'*Deprecated90' }
+RBProgramNode >> parents [
+	"see discussion in https://github.com/pharo-project/pharo/issues/6278"
+		self
+		deprecated: 'Use #withAllParents instead'
+		on: '25 may 2020'
+		in: #Pharo9
+		transformWith: '`@receiver parents' 
+						-> '`@receiver withAllParents'.
+	^self withAllParents
+]


### PR DESCRIPTION
- methodOrBlockNode has the code "^self" commented out. That is off course the same (methods return self by default), but very odd.
- fix deprecetd #parents and move it to deprecated90