### PR TITLE
Behavior: add #pragmas and #pragmasDo:

### DIFF
--- a/src/Alien-Core/Callback.class.st
+++ b/src/Alien-Core/Callback.class.st
@@ -219,8 +219,7 @@ Callback >> block: aBlock "<BlockClosure>" thunk: thunkWrapper "<FFICallbackThun
 Callback >> evaluatorForSignature: signature [ "<String|Array>"
 	"Search the methods marked with the signature: primtiive for those that match signature.
 	 signature is typically a literal Array for the function's C signature, e.g. #(int (*)(int, char *))."
-	Pragma withPragmasIn: self class do:
-		[:pragma|
+	 self class pragmasDo: [:pragma|
 		 (pragma key == #signature:
 		  and: [(pragma argumentAt: 1) = signature]) ifTrue:
 			[^pragma method]].

--- a/src/ClassAnnotation/ClassAnnotationRegistry.class.st
+++ b/src/ClassAnnotation/ClassAnnotationRegistry.class.st
@@ -66,7 +66,7 @@ ClassAnnotationRegistry class >> annotationPragmaName [
 { #category : #'pragma collecting' }
 ClassAnnotationRegistry class >> annotationPragmasIn: aClass do: aBlock [
 
-	Pragma withPragmasIn: aClass do: [ :pragma |
+	aClass pragmasDo: [ :pragma |
 		pragma selector == self annotationPragmaName ifTrue: [aBlock value: pragma]]
 ]
 

--- a/src/Deprecated90/Pragma.extension.st
+++ b/src/Deprecated90/Pragma.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #Pragma }
+
+{ #category : #'*Deprecated90' }
+Pragma class >> withPragmasIn: aClass do: aBlock [
+	self 
+		deprecated: 'use #pragmasDo: on the class' 
+		transformWith: 	'`@receiver withPragmasIn: `@statements1 do: `@statements2'
+		   					-> '`@statements1 pragmasDo: `@statements2'.
+	aClass pragmasDo: aBlock
+]

--- a/src/Fuel-Platform-Core/FLPlatform.class.st
+++ b/src/Fuel-Platform-Core/FLPlatform.class.st
@@ -63,7 +63,7 @@ FLPlatform class >> extensionPragmas [
 			stop := false.
 			self class withAllSuperclassesDo: [ :class |
 				stop ifFalse: [
-					Pragma withPragmasIn: class do:  [ :pragma |
+					 class pragmasDo:  [ :pragma |
 						(pragma selector = selector and: [
 							"don't collect overridden methods"
 							(pragmas includesKey: pragma selector) not ]) ifTrue: [

--- a/src/GT-InspectorExtensions-Core/Pragma.extension.st
+++ b/src/GT-InspectorExtensions-Core/Pragma.extension.st
@@ -18,7 +18,7 @@ Pragma class >> gtInspectorAnnotatedMethodsIn: composite [
 			| pragmas |
 			pragmas := OrderedCollection new.
 			Object withAllSubclassesDo: [:each |
-				Pragma withPragmasIn: each do: [:p |
+				 each pragmasDo: [:p |
 					pragmas add: p]].
 			(pragmas groupedBy: #selector) associations sorted: [ :a :b | 
 				a key < b key ]

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1359,6 +1359,16 @@ Behavior >> postCopy [
 	self methodDict: self methodDict copy
 ]
 
+{ #category : #queries }
+Behavior >> pragmas [
+	^ self methods flatCollect: [ :method | method pragmas ]
+]
+
+{ #category : #queries }
+Behavior >> pragmasDo: aBlock [
+	self methodsDo: [ :method | method pragmasDo: aBlock ]
+]
+
 { #category : #printing }
 Behavior >> printOn: aStream [ 
 	"Refer to the comment in Object|printOn:." 

--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -64,9 +64,7 @@ Pragma class >> allNamed: aSymbol from: aSubClass to: aSuperClass [
 		streamContents: [ :stream | 
 			aSubClass
 				withAllSuperclassesDo: [ :class | 
-					self
-						withPragmasIn: class
-						do: [ :pragma | 
+					class pragmasDo: [ :pragma | 
 							pragma selector = aSymbol
 								ifTrue: [ stream nextPut: pragma ] ].
 					aSuperClass = class
@@ -92,9 +90,9 @@ Pragma class >> allNamed: aSymbol in: aClass [
 	"Answer a collection of all pragmas found in methods of aClass whose selector is aSymbol."
 	
 	^ Array streamContents: [ :stream |
-		self withPragmasIn: aClass do: [ :pragma |
+		 aClass pragmasDo: [ :pragma |
 			pragma selector = aSymbol
-				ifTrue: [ stream nextPut: pragma ] ] ].
+				ifTrue: [ stream nextPut: pragma ] ] ]
 ]
 
 { #category : #finding }
@@ -132,11 +130,6 @@ Pragma class >> selector: aSymbol arguments: anArray [
 		selector: aSymbol;
 		arguments: anArray;
 		yourself
-]
-
-{ #category : #private }
-Pragma class >> withPragmasIn: aClass do: aBlock [
-	aClass methodsDo: [ :method | method pragmasDo: aBlock ]
 ]
 
 { #category : #comparing }

--- a/src/PragmaCollector/PragmaCollector.class.st
+++ b/src/PragmaCollector/PragmaCollector.class.st
@@ -205,9 +205,7 @@ PragmaCollector >> modifiedEventOccurs: anEvent [
 	acceptable pragma in it, then the handler is removed.
 	"
 
-	Pragma
-		withPragmasIn: anEvent methodClass
-		do: [ :pragma | 
+	anEvent methodClass pragmasDo: [ :pragma | 
 			pragma methodSelector = anEvent selector
 				ifTrue: [ (self
 						detect: [ :oldprag | 

--- a/src/Spec-Core/SpecPragmaCollector.class.st
+++ b/src/Spec-Core/SpecPragmaCollector.class.st
@@ -32,10 +32,7 @@ SpecPragmaCollector >> allPragmas [
 { #category : #private }
 SpecPragmaCollector >> allPragmasIn: aClass [
 
-	^ (Array
-		streamContents: [:stream | Pragma
-									withPragmasIn: aClass
-									do: [:pragma | stream nextPut: pragma ]]) 
+	^ Array streamContents: [:stream | aClass pragmasDo: [:pragma | stream nextPut: pragma ]]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
There is a (private) method withPragmasIn:do: that is used externally.

- this means that the feature makes sense to have
- but why not just implement it in Behevior as pragmas / pragmasDo: ?

This PR does exactly that.