### PR TITLE
OCInstanceScope-merge-vars-and-reservedVars

### DIFF
--- a/src/OpalCompiler-Core/OCInstanceScope.class.st
+++ b/src/OpalCompiler-Core/OCInstanceScope.class.st
@@ -5,8 +5,7 @@ Class {
 	#name : #OCInstanceScope,
 	#superclass : #OCAbstractScope,
 	#instVars : [
-		'vars',
-		'reservedVars'
+		'vars'
 	],
 	#category : #'OpalCompiler-Core-Semantics'
 }
@@ -19,8 +18,6 @@ OCInstanceScope >> allTemps [
 { #category : #lookup }
 OCInstanceScope >> hasBindingThatBeginsWith: aString [
 	"Answer true if a reserved variable or any slot start with aString"
-	
-	(reservedVars hasBindingThatBeginsWith: aString) ifTrue: [ ^true ].
 	(vars hasBindingThatBeginsWith: aString) ifTrue: [ ^true ].
 	
 	^ self outerScope hasBindingThatBeginsWith: aString
@@ -28,9 +25,8 @@ OCInstanceScope >> hasBindingThatBeginsWith: aString [
 
 { #category : #initialization }
 OCInstanceScope >> initialize [
-  
-	vars := Dictionary new.
-	reservedVars  := ReservedVariable lookupDictionary
+ 	"we pre-fill the reserved vars, more get added by the semantic analysis"
+	vars := ReservedVariable lookupDictionary
 ]
 
 { #category : #acessing }
@@ -46,15 +42,13 @@ OCInstanceScope >> isInstanceScope [
 
 { #category : #lookup }
 OCInstanceScope >> lookupVar: name [
-	"Return a ScopeVar for my inst var with this name.  Return nil if none found"
-	reservedVars at: name ifPresent: [:v | ^ v].
+	"Return a ScopeVar for my inst var with this name. Return nil if none found"
 	^ vars at: name ifAbsent: [self outerScope lookupVar: name]
 ]
 
 { #category : #lookup }
 OCInstanceScope >> lookupVarForDeclaration: name [
 	"This is a version of #lookupVar: that skips the OCRequestorScope"
-	reservedVars at: name ifPresent: [:v | ^ v].
 	^ vars at: name ifAbsent: [self outerScope lookupVarForDeclaration: name]
 ]
 


### PR DESCRIPTION
Another one from the compiler backlog:

- OCInstanceScope can put all it's vars into the vars ivar. There is no need to have an explicit reservedVars dictionary.