### PR TITLE
Fix race conditions and bugs in OSWindow

### DIFF
--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -10,7 +10,8 @@ Class {
 	#classVars : [
 		'AllowDropFiles',
 		'CursorOwnerWorld',
-		'ExtraWorldList'
+		'ExtraWorldList',
+		'ExtraWorldListMutex'
 	],
 	#classInstVars : [
 		'displayScaleFactor'
@@ -20,7 +21,10 @@ Class {
 
 { #category : #'extra worlds' }
 WorldMorph class >> addExtraWorld: aWorld [
-	ExtraWorldList := self extraWorldList copyWith: aWorld
+	ExtraWorldListMutex critical: [
+		ExtraWorldList := self extraWorldList copyWith: aWorld
+	]
+
 ]
 
 { #category : #accessing }
@@ -90,13 +94,18 @@ WorldMorph class >> displayScaleFactorSettingsOn: aBuilder [
 
 { #category : #'initialize-release' }
 WorldMorph class >> doOneCycle [
-	self extraWorldList do: [:world |
-		world doOneCycle.
+	WorldState doDrawCycleWith: [
+		| extraWorldsToDraw |
+		extraWorldsToDraw := ExtraWorldListMutex critical: [ self extraWorldList ].
+		extraWorldsToDraw do: [:world |
+			world doOneCycle.
+		].
+
+		(self currentWorld isNotNil and: [(extraWorldsToDraw includes: self currentWorld) not]) ifTrue: [
+			self currentWorld doOneCycle.
+		]
 	].
 
-	(self currentWorld isNotNil and: [(self extraWorldList includes: self currentWorld) not]) ifTrue: [
-		self currentWorld doOneCycle.
-	]
 ]
 
 { #category : #'extra worlds' }
@@ -105,11 +114,17 @@ WorldMorph class >> extraWorldList [
 	^ ExtraWorldList
 ]
 
+{ #category : #'initialize-release' }
+WorldMorph class >> initialize [
+	ExtraWorldListMutex := Semaphore forMutualExclusion.
+]
+
 { #category : #'extra worlds' }
 WorldMorph class >> removeExtraWorld: aWorld [
-	ExtraWorldList := self extraWorldList copyWithout: aWorld.
-	CursorOwnerWorld == aWorld ifTrue: [ CursorOwnerWorld := nil ]
-	
+	ExtraWorldListMutex critical: [
+		ExtraWorldList := self extraWorldList copyWithout: aWorld.
+	].
+	CursorOwnerWorld == aWorld ifTrue: [ CursorOwnerWorld := nil ].	
 ]
 
 { #category : #cursor }
@@ -309,15 +324,13 @@ WorldMorph >> displayWorldSafely [
 
 { #category : #'world state' }
 WorldMorph >> doOneCycle [
-	"see the comment in doOneCycleFor:"
-
-	worldState doOneCycleFor: self
+	self doOneCycleNow
 ]
 
 { #category : #'interaction loop' }
 WorldMorph >> doOneCycleNow [
 	"see the comment in doOneCycleNowFor:"
-	worldState doOneCycleNowFor: self.
+	worldState doOneCycleFor: self.
 
 ]
 

--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -115,6 +115,32 @@ WorldState class >> discoveredMenuTitle [
 	^ DesktopMenuTitle ifNil: [DesktopMenuTitle := 'World']
 ]
 
+{ #category : #'drawing cycle' }
+WorldState class >> doDrawCycleWith: aBlock [
+	aBlock ensure: [
+		self doInterCycleWait
+	]
+]
+
+{ #category : #'drawing cycle' }
+WorldState class >> doInterCycleWait [
+	| waitTime newCycleTime |
+	newCycleTime := Time millisecondClockValue.
+	waitTime := self serverMode
+		ifTrue: [ 50 ]
+		ifFalse: [
+			| expectedEndTime lapse |
+			lapse := self interCycleLapse.
+			expectedEndTime := self lastDrawCycleTime + self interCycleLapse.
+			"This minimum is required to prevent freezing the system during startup.
+			The times two in the lapse is to allow some slack due to precision issues."
+			expectedEndTime - newCycleTime min: (lapse*2).
+		].
+	waitTime > 0 ifTrue: [ (Delay forMilliseconds: waitTime) wait ].
+	LastCycleTime := newCycleTime.
+	
+]
+
 { #category : #settings }
 WorldState class >> easySelectingWorld [
 	^ EasySelectingWorld ifNil: [EasySelectingWorld := false]
@@ -143,14 +169,24 @@ WorldState class >> helpOn: aBuilder [
 WorldState class >> initialize [
 	"WorldState initialize"
 
-	MinCycleLapse := 20.		"allows 50 frames per second..."
+	MinCycleLapse := 16.		"allows 60 frames per second..."
 	DeferredUIMessages := nil.
+]
+
+{ #category : #'drawing cycle' }
+WorldState class >> interCycleLapse [
+	^ MinCycleLapse ifNil: [ MinCycleLapse := 16 ]
 ]
 
 { #category : #accessing }
 WorldState class >> lastCycleTime [
 
 	^LastCycleTime
+]
+
+{ #category : #'drawing cycle' }
+WorldState class >> lastDrawCycleTime [
+	^ LastCycleTime ifNil: [ LastCycleTime := Time millisecondClockValue ]
 ]
 
 { #category : #'world menu items' }
@@ -495,21 +531,12 @@ WorldState >> doFullRepaint [
 
 { #category : #'update cycle' }
 WorldState >> doOneCycleFor: aWorld [
-	"Do one cycle of the interaction loop. This method is called repeatedly when the world is running. This is a moderately private method; a better alternative is usually either to wait for events or to check the state of things from #step methods."
-
-	self interCyclePause: MinCycleLapse.
-	self doOneCycleNowFor: aWorld.
-]
-
-{ #category : #'update cycle' }
-WorldState >> doOneCycleNowFor: aWorld [
 	"Immediately do one cycle of the interaction loop.
 	This should not be called directly, but only via doOneCycleFor:"
 
 	self worldRenderer checkForNewScreenSize.
 
 	"process user input events"
-	LastCycleTime := Time millisecondClockValue.
 	self handsDo: [:h |
 		self activeHand: h.
 		h processEvents.
@@ -642,31 +669,6 @@ WorldState >> initialize [
 	lastStepTime := 0.
 	lastAlarmTime := 0.
 
-]
-
-{ #category : #'update cycle' }
-WorldState >> interCyclePause: milliSecs [
-	"delay enough that the previous cycle plus the amount of delay will equal milliSecs.  If the cycle is already expensive, then no delay occurs.  However, if the system is idly waiting for interaction from the user, the method will delay for a proportionally long time and cause the overall CPU usage of Pharo to be low.
-	If self serverMode returns true then, always do a complete delay of 50ms, independant of my argument. This prevents the freezing problem described in Mantis #6581"
-
-	| wait wait2 |
-	wait := self serverMode
-    	ifTrue: [ 50 ]
-    	ifFalse: 
-		[	wait2 := (lastCycleTime notNil and: [CanSurrenderToOS ~~ false]) 
-        		ifFalse: [ 0 ]
-        		ifTrue: [ lastCycleTime + milliSecs - Time millisecondClockValue ].
- 
-      		self flag: 'Issue 14754 - wait2>millisecs is only True for clock rollover. Remove it once delay scheduler is based on microsecondClock - Ben Coman 19.01.2015'.
-      		wait2 > milliSecs 
-        		ifTrue: [ 0 ]
-        		ifFalse: [ wait2 ]. 
-		].
-		
-	wait > 0 ifTrue: [	(Delay forMilliseconds: wait) wait ].
-
-	lastCycleTime := Time millisecondClockValue.
-	CanSurrenderToOS := true.
 ]
 
 { #category : #canvas }

--- a/src/OSWindow-Core/OSWindow.class.st
+++ b/src/OSWindow-Core/OSWindow.class.st
@@ -288,22 +288,22 @@ OSWindow >> minimize [
 
 { #category : #'instance creation' }
 OSWindow >> newAthensRenderer [
-	^ backendWindow newAthensRenderer
+	^ backendWindow ifNotNil: [backendWindow newAthensRenderer]
 ]
 
 { #category : #factory }
 OSWindow >> newFormRenderer: form [
-	^ backendWindow newFormRenderer: form
+	^ backendWindow ifNotNil: [backendWindow newFormRenderer: form]
 ]
 
 { #category : #factory }
 OSWindow >> newGenericRenderer [
-	^ backendWindow newGenericRenderer
+	^ backendWindow ifNotNil: [backendWindow newGenericRenderer]
 ]
 
 { #category : #factory }
 OSWindow >> newOpenGLRenderer [
-	^ backendWindow newOpenGLRenderer
+	^ backendWindow ifNotNil: [backendWindow newOpenGLRenderer]
 ]
 
 { #category : #accessing }

--- a/src/OSWindow-Core/OSWindowAthensRenderer.class.st
+++ b/src/OSWindow-Core/OSWindowAthensRenderer.class.st
@@ -42,6 +42,11 @@ OSWindowAthensRenderer >> initialize [
 	session := Smalltalk session
 ]
 
+{ #category : #'as yet unclassified' }
+OSWindowAthensRenderer >> pixelExtent [
+	^ self surface extent
+]
+
 { #category : #drawing }
 OSWindowAthensRenderer >> prepareForDrawing [
 ]

--- a/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
+++ b/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
@@ -8,8 +8,7 @@ Class {
 	#name : #OSWindowMorphicEventHandler,
 	#superclass : #OSWindowEventVisitor,
 	#instVars : [
-		'morphicWorld',
-		'eventQueue'
+		'morphicWorld'
 	],
 	#classVars : [
 		'SimulateMiddleButton',
@@ -149,21 +148,6 @@ OSWindowMorphicEventHandler >> dispatchMorphicEvent: anEvent [
 ]
 
 { #category : #events }
-OSWindowMorphicEventHandler >> enqueue: aMorphicEvent [
-	"Put morphic event into receiver's internal queue. 
-	All events in queue will be processed later, by UI process, once it will get there."
-	
-	self eventQueue nextPut: aMorphicEvent.
-]
-
-{ #category : #accessing }
-OSWindowMorphicEventHandler >> eventQueue [
-	"using lazy-initialize here to deal with bootstrapping issues,
-	since existing instances originally has no queue"
-	^ eventQueue ifNil: [ eventQueue := WaitfreeQueue new ]
-]
-
-{ #category : #events }
 OSWindowMorphicEventHandler >> handleEvent: anEvent [
 	
 	"convert the event to morphic one, and dispatch it whatever..."
@@ -174,11 +158,6 @@ OSWindowMorphicEventHandler >> handleEvent: anEvent [
 		
 	self dispatchMorphicEvent: morphicEvent
 	
-]
-
-{ #category : #initialization }
-OSWindowMorphicEventHandler >> initialize [
-	eventQueue := WaitfreeQueue new.
 ]
 
 { #category : #visiting }
@@ -212,7 +191,7 @@ OSWindowMorphicEventHandler >> visitKeyDownEvent: anEvent [
 		hand:  self activeHand
 		stamp: Time millisecondClockValue.
 	keyEvent scanCode: anEvent scanCode.
-	self enqueue: keyEvent.
+	self dispatchMorphicEvent: keyEvent.
 	
 	"This is for ctrl/alt held alone makes morphic think that null character is good text input"
 	keyEvent keyValue = 0 ifTrue: [ ^ self ]. 

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -79,7 +79,7 @@ OSWorldRenderer >> deactivate [
 { #category : #operations }
 OSWorldRenderer >> deferUpdatesDuring: aBlock [
 
-	self osWindowRenderer deferUpdatesWhile: aBlock
+	self osWindowRenderer ifNotNil: [:renderer | renderer deferUpdatesWhile: aBlock ]
 ]
 
 { #category : #initialization }
@@ -188,7 +188,7 @@ OSWorldRenderer >> initialize [
 
 { #category : #initialization }
 OSWorldRenderer >> osWindowRenderer [
-		
+	osWindow ifNil: [ ^ nil ].
 	^ osWindow renderer ifNil: [
 		osWindow newFormRenderer: display.
 		osWindow renderer

--- a/src/OSWindow-SDL2/OSSDL2AthensRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2AthensRenderer.class.st
@@ -11,7 +11,8 @@ Class {
 		'pitch',
 		'sdlSurface',
 		'textureExtent',
-		'surfaceForm'
+		'surfaceForm',
+		'mutex'
 	],
 	#pools : [
 		'SDL2Constants'
@@ -31,6 +32,11 @@ OSSDL2AthensRenderer class >> new [
 	self error: 'Use #for:'
 ]
 
+{ #category : #accessing }
+OSSDL2AthensRenderer >> athensSurface [
+	^ mutex critical: [super athensSurface]
+]
+
 { #category : #private }
 OSSDL2AthensRenderer >> createSDLSurfaceWithExtent: extent [
 	surfaceForm ifNotNil: [ surfaceForm destroySurface ].
@@ -42,10 +48,28 @@ OSSDL2AthensRenderer >> createSDLSurfaceWithExtent: extent [
 { #category : #deleting }
 OSSDL2AthensRenderer >> destroy [
 	
+	mutex critical: [
+		(texture isNotNil and: [texture isNull not]) ifTrue: [
+			texture destroy
+		].
+		texture := nil.
+
+		(renderer isNotNil and: [renderer isNull not]) ifTrue: [
+			renderer destroy
+		].
+		renderer := nil.
+		sdlSurface := nil.
+	].
+
 	super destroy.
-	sdlSurface := nil.
-	texture := nil.
-	renderer := nil.
+	
+
+]
+
+{ #category : #initialization }
+OSSDL2AthensRenderer >> initialize [
+	super initialize.
+	mutex := Mutex new.
 ]
 
 { #category : #initialization }
@@ -59,16 +83,20 @@ OSSDL2AthensRenderer >> initializeWindowHandle: aBackendWindow [
 
 { #category : #drawing }
 OSSDL2AthensRenderer >> prepareForDrawing [
-	textureExtent ~= backendWindow extent ifTrue: [ self resized ].
+	mutex critical: [
+		textureExtent ~= backendWindow extent ifTrue: [ self resized ].
+	].
 ]
 
 { #category : #'updating screen' }
 OSSDL2AthensRenderer >> present [
-	self validate ifFalse: [ ^ self ].
-	renderer
-		clear;
-		copy: texture;
-		present
+	mutex critical: [
+		self validate ifFalse: [ ^ self ].
+		renderer
+			clear;
+			copy: texture;
+			present
+	]
 ]
 
 { #category : #private }
@@ -93,70 +121,81 @@ OSSDL2AthensRenderer >> resetResources [
 
 { #category : #'updating screen' }
 OSSDL2AthensRenderer >> resized [
-	self resetResources.
-	super resized
+	mutex critical: [
+		self resetResources.
+		super resized
+	]
+]
+
+{ #category : #accessing }
+OSSDL2AthensRenderer >> surface [
+	^ mutex critical: [super surface]
 ]
 
 { #category : #'updating screen' }
 OSSDL2AthensRenderer >> updateAll [
-	self validate ifFalse: [ ^ self ].
-	texture updateTexturePixels: sdlSurface pixels pitch: sdlSurface pitch.
+	mutex critical: [
+		self validate ifFalse: [ ^ self ].
+		texture updateTexturePixels: sdlSurface pixels pitch: sdlSurface pitch.
+	]
 ]
 
 { #category : #'updating screen' }
 OSSDL2AthensRenderer >> updateRectangle: aRectangle [
 	| intersection pitchHolder externalForm |
-	self validate ifFalse: [ ^ self ].
-	intersection := aRectangle
-		intersect: (0 @ 0 corner: textureExtent)
-		ifNone: [ ^ self ].
+	mutex critical: [
+		self validate ifFalse: [ ^ self ].
+		intersection := aRectangle
+			intersect: (0 @ 0 corner: textureExtent)
+			ifNone: [ ^ self ].
 	
-	pixels := ExternalAddress new.
-	pitchHolder := ExternalAddress allocate: 4.
-	[
-		texture lockPixels: pixels pitch: pitchHolder.
-		pitch := pitchHolder signedLongAt: 1.
-	] ensure: [ pitchHolder free ].
+		pixels := ExternalAddress new.
+		pitchHolder := ExternalAddress allocate: 4.
+		[
+			texture lockPixels: pixels pitch: pitchHolder.
+			pitch := pitchHolder signedLongAt: 1.
+		] ensure: [ pitchHolder free ].
 
-	externalForm := OSSDL2ExternalForm extent: textureExtent depth: 32 bits: pixels.
-	[
-		self primitiveUpdateRectangle: intersection externalForm: externalForm
-	] ensure: [
-		texture unlock.
-		externalForm destroySurface
-	].
-
+		externalForm := OSSDL2ExternalForm extent: textureExtent depth: 32 bits: pixels.
+		[
+			self primitiveUpdateRectangle: intersection externalForm: externalForm
+		] ensure: [
+			texture unlock.
+			externalForm destroySurface
+		].
+	]
 ]
 
 { #category : #'updating screen' }
 OSSDL2AthensRenderer >> updateRectangles: allDamage [
 	| pitchHolder externalForm intersection |
-	self validate
-		ifFalse: [ ^ self ].
+	mutex critical: [
+		self validate
+			ifFalse: [ ^ self ].
 		
-	pixels := ExternalAddress new.
-	pitchHolder := ExternalAddress allocate: 4.
-	[
-		texture lockPixels: pixels pitch: pitchHolder.
-		pitch := pitchHolder signedLongAt: 1.
-	] ensure: [ pitchHolder free ].
+		pixels := ExternalAddress new.
+		pitchHolder := ExternalAddress allocate: 4.
+		[
+			texture lockPixels: pixels pitch: pitchHolder.
+			pitch := pitchHolder signedLongAt: 1.
+		] ensure: [ pitchHolder free ].
 	
-	[
-		externalForm := OSSDL2ExternalForm extent: textureExtent depth: 32 bits: pixels.
-		allDamage do: [ :rectangle |
-			intersection := rectangle
-				intersect: (0 @ 0 corner: backendWindow extent)
-				ifNone: [ nil ].
+		[
+			externalForm := OSSDL2ExternalForm extent: textureExtent depth: 32 bits: pixels.
+			allDamage do: [ :rectangle |
+				intersection := rectangle
+					intersect: (0 @ 0 corner: backendWindow extent)
+					ifNone: [ nil ].
 		
-			intersection ifNotNil: [
-				self primitiveUpdateRectangle: rectangle externalForm: externalForm.
-			]
+				intersection ifNotNil: [
+					self primitiveUpdateRectangle: rectangle externalForm: externalForm.
+				]
+			].
+		] ensure: [
+			texture unlock.
+			externalForm destroySurface
 		].
-	] ensure: [
-		texture unlock.
-		externalForm destroySurface
-	].
-
+	]
 ]
 
 { #category : #'updating screen' }

--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -113,7 +113,9 @@ OSSDL2BackendWindow >> destroy [
 
 	sdl2Window ifNotNil: [ :validHandle | 
 		OSSDL2Driver current unregisterWindowWithId: validHandle windowID.
-		validHandle destroy ].
+		renderer ifNotNil: [ renderer destroy ].
+		validHandle destroy
+	].
 
 	renderer := nil.
 	sdl2Window := nil.

--- a/src/OSWindow-SDL2/OSSDL2FormRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2FormRenderer.class.st
@@ -8,7 +8,8 @@ Class {
 		'texture',
 		'renderer',
 		'extent',
-		'deferUpdates'
+		'deferUpdates',
+		'mutex'
 	],
 	#pools : [
 		'SDL2Constants'
@@ -52,16 +53,22 @@ OSSDL2FormRenderer >> deferUpdatesWhile: aBlock [
 
 { #category : #deleting }
 OSSDL2FormRenderer >> destroy [
-	(texture isNil or: [ renderer isNil ])
-		ifTrue: [ ^ self ].
-	texture destroy.
-	renderer destroy
+	mutex critical: [
+		(texture isNil or: [ renderer isNil ])
+			ifTrue: [ ^ self ].
+		texture destroy.
+		renderer destroy.
+		texture := nil.
+		renderer := nil.
+	]
+
 ]
 
 { #category : #initialization }
 OSSDL2FormRenderer >> initialize [
 	super initialize.
 	deferUpdates := false.
+	mutex := Mutex new.
 ]
 
 { #category : #private }
@@ -72,92 +79,99 @@ OSSDL2FormRenderer >> primitiveUpdateRectangle: rectangle externalForm: external
 
 { #category : #'updating screen' }
 OSSDL2FormRenderer >> updateAll [
-	self validate
-		ifFalse: [ ^ self ].
+	mutex critical: [
+		self validate
+			ifFalse: [ ^ self ].
 	
-	texture updateTexturePixels: form bits pitch: form width * 4.
+		texture updateTexturePixels: form bits pitch: form width * 4.
 	
-	deferUpdates
-		ifTrue: [ ^ self ].
-	renderer copy: texture.
-	renderer present
+		deferUpdates
+			ifTrue: [ ^ self ].
+		renderer copy: texture.
+		renderer present
+	]
 ]
 
 { #category : #'updating screen' }
 OSSDL2FormRenderer >> updateAreas: allDamage immediate: forceToScreen [
 	| pixels pitchHolder pitch intersection updateUnion externalForm |
-	self validate
-		ifFalse: [ ^ self ].
+	mutex critical: [
+		self validate
+			ifFalse: [ ^ self ].
 		
-	pixels := ExternalAddress new.
-	pitchHolder := ExternalAddress allocate: 4.
-	[
-		texture lockPixels: pixels pitch: pitchHolder.
-		pitch := pitchHolder signedLongAt: 1.
-	] ensure: [ pitchHolder free ].
+		pixels := ExternalAddress new.
+		pitchHolder := ExternalAddress allocate: 4.
+		[
+			texture lockPixels: pixels pitch: pitchHolder.
+			pitch := pitchHolder signedLongAt: 1.
+		] ensure: [ pitchHolder free ].
 	
-	updateUnion := nil.
-	[
-		externalForm := OSSDL2ExternalForm extent: extent depth: 32 bits: pixels.
-		allDamage do: [ :rectangle |
-			intersection := rectangle
-				intersect: (0 @ 0 corner: backendWindow extent)
-				ifNone: [ nil ].
+		updateUnion := nil.
+		[
+			externalForm := OSSDL2ExternalForm extent: extent depth: 32 bits: pixels.
+			allDamage do: [ :rectangle |
+				intersection := rectangle
+					intersect: (0 @ 0 corner: backendWindow extent)
+					ifNone: [ nil ].
 		
-			intersection ifNotNil: [
-				self primitiveUpdateRectangle: rectangle externalForm: externalForm.
-				updateUnion ifNil: [
-					updateUnion := intersection 
-				] ifNotNil: [
-					updateUnion := updateUnion merge: intersection
+				intersection ifNotNil: [
+					self primitiveUpdateRectangle: rectangle externalForm: externalForm.
+					updateUnion ifNil: [
+						updateUnion := intersection 
+					] ifNotNil: [
+						updateUnion := updateUnion merge: intersection
+					]
 				]
-			]
+			].
+		] ensure: [
+			texture unlock.
+			externalForm destroySurface
 		].
-	] ensure: [
-		texture unlock.
-		externalForm destroySurface
-	].
 
-	updateUnion ifNotNil: [
-		self copyAndPresentTextureRectangle: updateUnion
-	].
+		updateUnion ifNotNil: [
+			self copyAndPresentTextureRectangle: updateUnion
+		].
 
-	
+	]
 ]
 
 { #category : #'updating screen' }
 OSSDL2FormRenderer >> updateRectangle: rectangle [
 	| intersection pixels pitch pitchHolder externalForm |
-	intersection := rectangle
-		intersect: (0 @ 0 corner: backendWindow extent)
-		ifNone: [ ^ self ].
-	self validate
-		ifFalse: [ ^ self ].
+	mutex critical: [
+		intersection := rectangle
+			intersect: (0 @ 0 corner: backendWindow extent)
+			ifNone: [ ^ self ].
+		self validate
+			ifFalse: [ ^ self ].
 		
-	pixels := ExternalAddress new.
-	pitchHolder := ExternalAddress allocate: 4.
-	[
-		texture lockPixels: pixels pitch: pitchHolder.
-		pitch := pitchHolder signedLongAt: 1.
-	] ensure: [ pitchHolder free ].
+		pixels := ExternalAddress new.
+		pitchHolder := ExternalAddress allocate: 4.
+		[
+			texture lockPixels: pixels pitch: pitchHolder.
+			pitch := pitchHolder signedLongAt: 1.
+		] ensure: [ pitchHolder free ].
 	
-	[
-		externalForm := OSSDL2ExternalForm extent: extent depth: 32 bits: pixels.
-		self primitiveUpdateRectangle: intersection externalForm: externalForm
-	] ensure: [
-		texture unlock.
-		externalForm destroySurface
-	].
+		[
+			externalForm := OSSDL2ExternalForm extent: extent depth: 32 bits: pixels.
+			self primitiveUpdateRectangle: intersection externalForm: externalForm
+		] ensure: [
+			texture unlock.
+			externalForm destroySurface
+		].
 
-	self copyAndPresentTextureRectangle: intersection.
-
+		self copyAndPresentTextureRectangle: intersection.
+	]
 ]
 
 { #category : #private }
 OSSDL2FormRenderer >> useDeferredUpdates [
-	renderer
-		copy: texture;
-		present
+	mutex critical: [ 
+		renderer
+			copy: texture;
+			present
+	]
+
 ]
 
 { #category : #private }

--- a/src/OSWindow-SDL2/OSSDL2GenericRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2GenericRenderer.class.st
@@ -96,7 +96,11 @@ OSSDL2GenericRenderer >> createTextureAtlasFontCacheFor: font [
 
 { #category : #deleting }
 OSSDL2GenericRenderer >> destroy [
-	renderer destroy
+	(renderer isNotNil and: [renderer isNull not]) ifTrue: [ 
+		renderer destroy
+	].
+	renderer := nil.
+
 ]
 
 { #category : #rendering }

--- a/src/OSWindow-SDL2/SDL_Window.class.st
+++ b/src/OSWindow-SDL2/SDL_Window.class.st
@@ -31,7 +31,7 @@ SDL_Window class >> finalizeResourceData: aTuple [
 
 { #category : #rendering }
 SDL_Window >> createAcceleratedRenderer [
-	^ self createRenderer: -1 flags: SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_ACCELERATED
+	^ self createRenderer: -1 flags: SDL_RENDERER_ACCELERATED
 ]
 
 { #category : #rendering }


### PR DESCRIPTION
This PR fixes race conditions in OSWindow that are typically triggered when closing an OSWindow. Additional related bugs were  found in the process:
- The per world cycle delay is refactored into a single delay per frame for all windows in the Morphic render loop. And the default default is changed from 50 fps (which ends being running in 30 fps) which makes the UI much more responsive.
- The keyDown event generated by the OSWindowMorphicEventHandler is sent into an event queue that nobody is consuming. This PR removes the event queue, and delivers this event to Morphic.
