### PR TITLE
[WIP] ImageCleaner-share-literals

### DIFF
--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -110,7 +110,7 @@ ImageCleaner >> cleanUpForRelease [
 		cleanUp: true except: #() confirming: false.
 		
 	FreeTypeFontProvider current prepareForRelease.	
-	
+	self shareLiterals.
 	HashedCollection rehashAll.		
 	Author reset
 ]


### PR DESCRIPTION
This calls the #shareLiterals in ImageCleaner>>#cleanupForRelease.

We should merge this PR only *after* making the shared Literals read-only!