### PR TITLE
More-CleanBlock-Fixes

### DIFF
--- a/src/Debugger-Filters/KernelClassesFilter.class.st
+++ b/src/Debugger-Filters/KernelClassesFilter.class.st
@@ -47,5 +47,9 @@ KernelClassesFilter >> kernelClassesToExclude [
 
 { #category : #testing }
 KernelClassesFilter >> shouldDisplay: aContext [
-	^ (kernelClasses includes: aContext receiver class) not
+	"Clean blocks do not know the receiver, but they statically know the executed method 
+	(which might be in a superclass)"
+	^ aContext receiver 
+		ifNil: [ 	(kernelClasses includes: aContext method methodClass) not ]
+		ifNotNil: [ (kernelClasses includes: aContext receiver class) not ]
 ]

--- a/src/Debugger-Model-Tests/DebugSessionContexts2Test.class.st
+++ b/src/Debugger-Model-Tests/DebugSessionContexts2Test.class.st
@@ -38,7 +38,11 @@ DebugSessionContexts2Test >> testContextsAfterStepInto [
 	"With fullblocks the method of the suspended context is a compiledBlock, not the method having it"
 	expectedMethod := (self class >> #setUp) encoderClass = EncoderForV3PlusClosures
 		ifTrue: [ self class >> #setUp ]
-		ifFalse: [ (self class >> #setUp) literalAt: 2 ].
+		ifFalse: [ 
+			| block |
+			block := (self class >> #setUp) literalAt: 2.
+			block isBlock ifTrue: [ block compiledBlock ] ifFalse: [ block ]
+			 ].
 
 	self
 		assert: session interruptedProcess suspendedContext method
@@ -57,7 +61,10 @@ DebugSessionContexts2Test >> testInterruptedContext [
 	| expectedMethod |
 	expectedMethod := (self class >> #setUp) encoderClass = EncoderForV3PlusClosures
 		ifTrue: [ self class >> #setUp ]
-		ifFalse: [ (self class >> #setUp) literalAt: 2 ].
+		ifFalse: [ 
+			| block |
+			block := (self class >> #setUp) literalAt: 2.
+			block isBlock ifTrue: [ block compiledBlock ] ifFalse: [ block ] ].
 
 	self assert: (session interruptedContext method) equals: expectedMethod.
 ]

--- a/src/Kernel-Tests-Extended/BlockClosureTest.extension.st
+++ b/src/Kernel-Tests-Extended/BlockClosureTest.extension.st
@@ -48,7 +48,7 @@ BlockClosureTest >> testTallyInstructions [
 	"We test class name and not the class because there are multiple versions of the encoders depending on the compiler used."
 	| expectedResult |
 	expectedResult := (aBlockContext method encoderClass = EncoderForSistaV1) ifTrue: [
-		aBlockContext isClean ifTrue: [ 25 ] ifFalse: [ 26 ]] ifFalse: [27].
+		Smalltalk compiler compilationContext optionCleanBlockClosure ifTrue: [ 25 ] ifFalse: [ 26 ]] ifFalse: [27].
 	
 	self assert: (Context tallyInstructions: aBlockContext ) size equals: expectedResult
 ]

--- a/src/Kernel-Tests-Extended/BlockClosureTest.extension.st
+++ b/src/Kernel-Tests-Extended/BlockClosureTest.extension.st
@@ -47,7 +47,9 @@ BlockClosureTest >> testTallyInstructions [
 	
 	"We test class name and not the class because there are multiple versions of the encoders depending on the compiler used."
 	| expectedResult |
-	expectedResult := (aBlockContext method encoderClass = EncoderForSistaV1) ifTrue: [26] ifFalse: [27].
+	expectedResult := (aBlockContext method encoderClass = EncoderForSistaV1) ifTrue: [
+		aBlockContext isClean ifTrue: [ 25 ] ifFalse: [ 26 ]] ifFalse: [27].
+	
 	self assert: (Context tallyInstructions: aBlockContext ) size equals: expectedResult
 ]
 

--- a/src/Kernel-Tests/BlockClosureTest.class.st
+++ b/src/Kernel-Tests/BlockClosureTest.class.st
@@ -20,7 +20,8 @@ BlockClosureTest >> blockWithNonLocalReturn: resultObject [
 { #category : #running }
 BlockClosureTest >> setUp [
 	super setUp.
-	aBlockContext := [100@100 corner: 200@200].
+	"we reference self to force a full block"
+	aBlockContext := [self . 100@100 corner: 200@200].
 	contextOfaBlockContext := thisContext.
 ]
 

--- a/src/Kernel-Tests/ContextTest.class.st
+++ b/src/Kernel-Tests/ContextTest.class.st
@@ -38,7 +38,8 @@ ContextTest class >> contextWithTempForTesting [
 
 { #category : #helper }
 ContextTest class >> createBlock [
-	^ [ thisContext ].
+	"we reference self to force a full block"
+	^ [ self . thisContext ]
 ]
 
 { #category : #helper }

--- a/src/Kernel/CleanBlockClosure.class.st
+++ b/src/Kernel/CleanBlockClosure.class.st
@@ -54,6 +54,12 @@ CleanBlockClosure >> outerCode: aCompiledCode [
 	self compiledBlock outerCode: aCompiledCode
 ]
 
+{ #category : #printing }
+CleanBlockClosure >> printOn: aStream [
+
+	aStream nextPutAll: self sourceNode value sourceCode 
+]
+
 { #category : #scanning }
 CleanBlockClosure >> readsField: varIndex [ 
 	^self compiledBlock readsField: varIndex

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1343,11 +1343,22 @@ Context >> printDetails: stream [
 
 { #category : #printing }
 Context >> printOn: aStream [
+	(closureOrNil isNotNil and: [closureOrNil isClean]) ifTrue: 
+		[ | selector |
+			selector := self selector ifNil: [ self compiledCode defaultSelector ].
+			aStream 
+			 print: closureOrNil;
+			 nextPutAll: ' in ';
+			 nextPutAll: self methodClass name;
+			 nextPutAll: '>>';
+			 nextPutAll: selector.
+			 ^self].
+	
 	self outerContext
 		ifNil:
 			[ | selector class mclass |
-			self compiledCode == nil
-				ifTrue: [ ^ super printOn: aStream ].
+			self compiledCode
+				ifNil: [ ^ super printOn: aStream ].
 			class := self receiver class.
 			mclass := self methodClass.
 			selector := self selector ifNil: [ self compiledCode defaultSelector ].
@@ -1365,7 +1376,8 @@ Context >> printOn: aStream [
 					(self tempAt: 1) selector printOn: aStream ] ]
 		ifNotNil:
 			[ :outerContext | 
-			aStream nextPutAll: closureOrNil printString , ' in '.
+			closureOrNil printOn: aStream.
+			aStream nextPutAll: ' in '.
 			outerContext printOn: aStream ]
 ]
 


### PR DESCRIPTION
More changes to make an image compiled with clean blocks more usable.

- force some clean blocks in tests
- some other test fixes
- fix #printOn:

KernelClassFilter is not used, we should remove the whole package

With this, the  new debugger can debug clean blocks. What is not yet working is the new emergency debugger