### PR TITLE
7257-Copy-pasting-pragma-body-with-argument-inside-another-pragma-raises-error

### DIFF
--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -994,11 +994,9 @@ RBParserTest >> testMessageWithFaultySelectorIsFaulty [
 { #category : #testIntervals }
 RBParserTest >> testMethodNodeEndAtTheEndOfTheString [
 	| tree |
-	"Expressions have an odd way of handling their stop position. The string is reformated to give a new source corresponding to the method #noMethod.
-	 It seems the method node take this new source into account instead of the original one."
 	tree := (self parserClass parseExpression: 'foo kung foo. 1+2+3. #''alabama''.  ').
 	self assert: tree parent source equals: 'foo kung foo. 1+2+3. #''alabama''.  '.
-	self assert: tree parent stop equals: tree parent newSource size.
+	self assert: tree parent stop equals: tree parent sourceCode size.
 	
 	tree := (self parserClass parseMethod: 'foo kung foo. 1+2+3. #''alabama''.  ').
 	self assert: tree source equals: 'foo kung foo. 1+2+3. #''alabama''.  '.

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -708,7 +708,7 @@ RBMethodNode >> statements: aCollection [
 
 { #category : #accessing }
 RBMethodNode >> stop [
-	^ self newSource size
+	^(self sourceCode ifNotNil: [self sourceCode] ifNil: [ self formattedCode ]) size
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -708,7 +708,7 @@ RBMethodNode >> statements: aCollection [
 
 { #category : #accessing }
 RBMethodNode >> stop [
-	^(self sourceCode ifNotNil: [self sourceCode] ifNil: [ self formattedCode ]) size
+	^(self sourceCode ifNotNil: [:src | src] ifNil: [ self formattedCode ]) size
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- change #stop in RBMethodNode to only fall back on decompiled code if the source is nil
- fix a test

fixes #7257