### PR TITLE
7374-DNU-isDynamicArray-when-editing-code

### DIFF
--- a/src/OpalCompiler-Core/RBBlockNode.extension.st
+++ b/src/OpalCompiler-Core/RBBlockNode.extension.st
@@ -43,6 +43,8 @@ RBBlockNode >> isInlined [
 
 { #category : #'*opalcompiler-core' }
 RBBlockNode >> isInlinedLoop [
+	parent parent ifNil: [ ^false ]. "Workaround: make it more robust against broken ASTs"
+	
 	parent isMessage ifFalse: [ ^ false ].
 	parent isInlineToDo ifTrue: [^ true].
 	parent isInlineWhile ifTrue: [^ true].


### PR DESCRIPTION
Workaround. Can be removed when the AST is not created with nil parent anymore. fixes #7374