### PR TITLE
Clean screen size computation

### DIFF
--- a/src/OSWindow-Core/OSWindowFormRenderer.class.st
+++ b/src/OSWindow-Core/OSWindowFormRenderer.class.st
@@ -51,6 +51,11 @@ OSWindowFormRenderer >> newExtent: newExtent [
 	form setExtent: newExtent depth: form depth
 ]
 
+{ #category : #accessing }
+OSWindowFormRenderer >> pixelExtent [
+	^ form ifNotNil: [ form extent ] ifNil: [ 1@1 ]
+]
+
 { #category : #'morphic integration' }
 OSWindowFormRenderer >> updateAreas: allDamage immediate: forceToScreen [
 	"Force all the damage rects to the screen."

--- a/src/OSWindow-Core/OSWindowGenericRenderer.class.st
+++ b/src/OSWindow-Core/OSWindowGenericRenderer.class.st
@@ -85,6 +85,11 @@ OSWindowGenericRenderer >> getOrCreateStaticTextureFromForm: from [
 	self subclassResponsibility
 ]
 
+{ #category : #clipping }
+OSWindowGenericRenderer >> pixelExtent [
+	^ backendWindow extent
+]
+
 { #category : #rendering }
 OSWindowGenericRenderer >> present [
 	"This should present the content of an internal draw buffer"

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -35,7 +35,7 @@ OSWorldRenderer >> activateCursor: aCursor withMask: maskForm [
 { #category : #initialization }
 OSWorldRenderer >> actualScreenSize [
 
-	^ osWindow ifNil: [ 240@120 ] ifNotNil: [ osWindow extent ]
+	^ self windowExtent
 ]
 
 { #category : #initialization }
@@ -218,6 +218,12 @@ OSWorldRenderer >> windowCloseAction [
 { #category : #accessing }
 OSWorldRenderer >> windowCloseAction: anObject [
 	windowCloseAction := anObject
+]
+
+{ #category : #initialization }
+OSWorldRenderer >> windowExtent [
+
+	^ osWindow ifNil: [ 240@120 ] ifNotNil: [ osWindow extent ]
 ]
 
 { #category : #initialization }

--- a/src/OSWindow-SDL2/OSSDL2AthensRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2AthensRenderer.class.st
@@ -201,7 +201,8 @@ OSSDL2AthensRenderer >> updateRectangles: allDamage [
 { #category : #'updating screen' }
 OSSDL2AthensRenderer >> validate [
 	self checkSession.
-	(texture isNil or: [ texture isNull ]) ifTrue: [ ^ false ].	
-	backendWindow extent ~= textureExtent ifTrue: [ ^ false ].
+	(texture isNil or: [ texture isNull ]) ifTrue: [ ^ false ].
+	(renderer isNil or: [ renderer isNull ]) ifTrue: [ ^ false ].
+	renderer outputExtent ~= textureExtent ifTrue: [ ^ false ].
 	^ true
 ]

--- a/src/OSWindow-SDL2/OSSDL2GenericRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2GenericRenderer.class.st
@@ -192,6 +192,13 @@ OSSDL2GenericRenderer >> mapColorChannel: colorChannel [
 	^ colorChannel * 255 asInteger min: 255 max: 0
 ]
 
+{ #category : #clipping }
+OSSDL2GenericRenderer >> pixelExtent [
+	^ renderer
+		ifNotNil: [ renderer outputExtent ]
+		ifNil: [ super pixelExtent ]
+]
+
 { #category : #rendering }
 OSSDL2GenericRenderer >> present [
 	renderer present


### PR DESCRIPTION
These changes facilitate the computation of the actual screen size by moving the window extent into a separate method. Under retina display in OS X, the window extent and the drawing surface extent are different, but the mouse events are still relative to the window extent.
These changes also fix an issue in the validation of the OSWindow Athens renderer, where the Cairo surface extent was being compared with the window extent, when it should actually be compared with the actual output surface extent.