### PR TITLE
EpMonitor: Remove old code for subscribing to test announcer.

### DIFF
--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -9,7 +9,6 @@ Class {
 	#instVars : [
 		'systemAnnouncer',
 		'log',
-		'testAnnouncer',
 		'entryReferenceByEvent',
 		'jobAnnouncer',
 		'announcer',
@@ -349,7 +348,7 @@ EpMonitor >> disable [
 
 	self sessionStore flush.
 
-	{ systemAnnouncer. testAnnouncer. jobAnnouncer }
+	{ systemAnnouncer. jobAnnouncer }
 		do: [ :each | each ifNotNil: [ :a | a unsubscribe: self ] ].
 
 	self announceMonitorStateUpdated.
@@ -376,7 +375,6 @@ EpMonitor >> enable [
 	
 	self isEnabled ifFalse: [ 			
 		self subscribeToSystemAnnouncer.
-		self subscribeToTestAnnouncer.
 		self subscribeToJobAnnouncer. ].
 
 	self announceMonitorStateUpdated.
@@ -412,7 +410,6 @@ EpMonitor >> initializeWithLog: aLog [
 
 	log := aLog.
 	systemAnnouncer := SystemAnnouncer uniqueInstance.
-	testAnnouncer := TestCase historyAnnouncer.
 	jobAnnouncer := Job jobAnnouncer.
 	
 	entryReferenceByEvent := IdentityDictionary new.
@@ -602,16 +599,6 @@ EpMonitor >> subscribeToSystemAnnouncer [
 			send: pair value 
 			to: self ].
 
-]
-
-{ #category : #private }
-EpMonitor >> subscribeToTestAnnouncer [
-	"Hook method. Overriden in EpiceaSUnit."
-]
-
-{ #category : #accessing }
-EpMonitor >> testAnnouncer [
-	^ testAnnouncer
 ]
 
 { #category : #private }


### PR DESCRIPTION
By 2015, Epicea logged test runs and results. For example, when Test Runner run a suite, the log registered the successes and failures. At some point, that became a package extension, which is still in SmalltalkHub as "Epicea-SUnit". That package requires this code in EpMonitor that I propose to delete in this issue. Why? 1. it hasn't been used for years but it'd be easy to recover after delete; 2. AFAIR, the feedback I got was that logging test runs implied too much noise in the log of changes.

Fixes #7379.