### PR TITLE
kindOfSubclass-ask-Layout

### DIFF
--- a/src/Kernel/AbstractLayout.class.st
+++ b/src/Kernel/AbstractLayout.class.st
@@ -129,6 +129,11 @@ AbstractLayout >> isWeak [
 ]
 
 { #category : #accessing }
+AbstractLayout >> kindOfSubclass [
+	^self subclassResponsibility
+]
+
+{ #category : #accessing }
 AbstractLayout >> resolveSlot: aName [
 	^SlotNotFound signalForName: aName
 ]

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1197,28 +1197,8 @@ Behavior >> isWords [
 
 { #category : #'testing class hierarchy' }
 Behavior >> kindOfSubclass [
-	"Answer a String that is the keyword that describes the receiver's kind of subclass,
-	 either a regular subclass, a variableSubclass, a variableByteSubclass,
-	 a variableWordSubclass, a weakSubclass, an ephemeronSubclass or an immediateSubclass.
-	 c.f. typeOfClass"
-	^self isVariable
-		ifTrue:
-			[self isBits
-				ifTrue:
-					[self isBytes
-						ifTrue: [' variableByteSubclass: ']
-						ifFalse: [' variableWordSubclass: ']]
-				ifFalse:
-					[self isWeak
-						ifTrue: [' weakSubclass: ']
-						ifFalse: [' variableSubclass: ']]]
-		ifFalse:
-			[self isImmediateClass
-				ifTrue: [' immediateSubclass: ']
-				ifFalse:
-					[self isEphemeronClass
-						ifTrue: [' ephemeronSubclass: ']
-						ifFalse: [' subclass: ']]]
+	"Answer a String that is the keyword that describes the receiver's kind of subclass"
+	^ self classLayout kindOfSubclass
 ]
 
 { #category : #printing }

--- a/src/Kernel/ByteLayout.class.st
+++ b/src/Kernel/ByteLayout.class.st
@@ -34,3 +34,8 @@ ByteLayout >> instanceSpecification [
 ByteLayout >> isBytes [
 	^ true
 ]
+
+{ #category : #accessing }
+ByteLayout >> kindOfSubclass [
+	^' variableByteSubclass: '
+]

--- a/src/Kernel/CompiledMethodLayout.class.st
+++ b/src/Kernel/CompiledMethodLayout.class.st
@@ -21,3 +21,9 @@ CompiledMethodLayout class >> extending: superLayout scope: aScope host: aClass 
 CompiledMethodLayout >> instanceSpecification [
 	 ^ 24
 ]
+
+{ #category : #accessing }
+CompiledMethodLayout >> kindOfSubclass [
+	"not really true but this is what is shows now"
+	^' variableByteSubclass: '
+]

--- a/src/Kernel/DoubleByteLayout.class.st
+++ b/src/Kernel/DoubleByteLayout.class.st
@@ -34,3 +34,8 @@ DoubleByteLayout >> instanceSpecification [
 DoubleByteLayout >> isDoubleBytes [
 	^ true
 ]
+
+{ #category : #accessing }
+DoubleByteLayout >> kindOfSubclass [
+	^' variableDoubleByteSubclass: '
+]

--- a/src/Kernel/DoubleWordLayout.class.st
+++ b/src/Kernel/DoubleWordLayout.class.st
@@ -28,3 +28,8 @@ DoubleWordLayout >> instanceSpecification [
 DoubleWordLayout >> isDoubleWords [
 	^ true
 ]
+
+{ #category : #accessing }
+DoubleWordLayout >> kindOfSubclass [
+	^' variableDoubleWordSubclass: '
+]

--- a/src/Kernel/EmptyLayout.class.st
+++ b/src/Kernel/EmptyLayout.class.st
@@ -51,3 +51,8 @@ EmptyLayout >> extendWeak [
 EmptyLayout >> extendWord [
 	^ WordLayout new
 ]
+
+{ #category : #accessing }
+EmptyLayout >> kindOfSubclass [
+	^self shouldNotImplement
+]

--- a/src/Kernel/EphemeronLayout.class.st
+++ b/src/Kernel/EphemeronLayout.class.st
@@ -19,3 +19,8 @@ EphemeronLayout class >> extending: superLayout scope: aScope host: aClass [
 EphemeronLayout >> instanceSpecification [
 	^ 5
 ]
+
+{ #category : #accessing }
+EphemeronLayout >> kindOfSubclass [
+	^' ephemeronSubclass: '
+]

--- a/src/Kernel/FixedLayout.class.st
+++ b/src/Kernel/FixedLayout.class.st
@@ -28,3 +28,8 @@ FixedLayout >> instanceSpecification [
 FixedLayout >> isFixedLayout [
 	^true
 ]
+
+{ #category : #accessing }
+FixedLayout >> kindOfSubclass [
+	^' subclass: '
+]

--- a/src/Kernel/ImmediateLayout.class.st
+++ b/src/Kernel/ImmediateLayout.class.st
@@ -31,3 +31,8 @@ ImmediateLayout >> initialize [
 ImmediateLayout >> instanceSpecification [
 	^ 7
 ]
+
+{ #category : #accessing }
+ImmediateLayout >> kindOfSubclass [
+	^' immediateSubclass: '
+]

--- a/src/Kernel/VariableLayout.class.st
+++ b/src/Kernel/VariableLayout.class.st
@@ -28,3 +28,8 @@ VariableLayout >> instanceSpecification [
 VariableLayout >> isVariable [
 	^ true
 ]
+
+{ #category : #accessing }
+VariableLayout >> kindOfSubclass [
+	^' variableSubclass: '
+]

--- a/src/Kernel/WeakLayout.class.st
+++ b/src/Kernel/WeakLayout.class.st
@@ -33,3 +33,8 @@ WeakLayout >> isVariable [
 WeakLayout >> isWeak [
 	^ true
 ]
+
+{ #category : #accessing }
+WeakLayout >> kindOfSubclass [
+	^' weakSubclass: '
+]

--- a/src/Kernel/WordLayout.class.st
+++ b/src/Kernel/WordLayout.class.st
@@ -34,3 +34,8 @@ WordLayout >> instanceSpecification [
 WordLayout >> isWords [
 	^ true
 ]
+
+{ #category : #accessing }
+WordLayout >> kindOfSubclass [
+	^' variableWordSubclass: '
+]


### PR DESCRIPTION
#kindOfSubclass has a huge if... and misses cases. e.g. there is no variableDoubleWordSubclass: and no variableDoubleByteSubclass (and the case for compiledmethod is missing, too).

This PR implements kindOfSubclass on the AbstractLayoyt hierarchy instead. This is a first step for solving #6318 and #5956