### PR TITLE
ReservedVariable-Environment

### DIFF
--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -111,6 +111,11 @@ CoASTResultSetBuilder >> visitGlobalNode: aRBVariableNode [
 ]
 
 { #category : #visiting }
+CoASTResultSetBuilder >> visitInstanceVariableNode: aRBVariableNode [ 
+	^ self visitNode: aRBVariableNode
+]
+
+{ #category : #visiting }
 CoASTResultSetBuilder >> visitLiteralArrayNode: aRBLiteralArrayNode [ 
 
 	^ self visitNode: aRBLiteralArrayNode

--- a/src/OpalCompiler-Core/ReservedVariable.class.st
+++ b/src/OpalCompiler-Core/ReservedVariable.class.st
@@ -4,6 +4,9 @@ I model self, thisContext and super
 Class {
 	#name : #ReservedVariable,
 	#superclass : #Variable,
+	#instVars : [
+		'environment'
+	],
 	#classInstVars : [
 		'instance'
 	],
@@ -44,6 +47,11 @@ ReservedVariable >> emitStore: methodBuilder [
 	self shouldNotImplement
 ]
 
+{ #category : #initialization }
+ReservedVariable >> initialize [
+	environment := Smalltalk globals
+]
+
 { #category : #testing }
 ReservedVariable >> isReservedVariable [
 	^true
@@ -69,7 +77,7 @@ ReservedVariable >> printOn: stream [
 { #category : #queries }
 ReservedVariable >> usingMethods [
 	"first call is very slow as it creates all ASTs"
-	^SystemNavigation new allMethods select: [ : method |
+	^environment allMethods select: [ : method |
 		method ast variableNodes anySatisfy: [ :varNode | varNode variable == self]]
 ]
 

--- a/src/OpalCompiler-Core/SelfVariable.class.st
+++ b/src/OpalCompiler-Core/SelfVariable.class.st
@@ -9,7 +9,8 @@ Class {
 
 { #category : #visiting }
 SelfVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
-		^ aProgramNodeVisitor visitSelfNode: aNode
+
+	^ aProgramNodeVisitor visitSelfNode: aNode
 ]
 
 { #category : #emitting }
@@ -39,7 +40,7 @@ SelfVariable >> readInContext: aContext [
 SelfVariable >> usingMethods [
 	"as super sends are doing a pushSelf, too, we need to still check the AST level sometimes"
 
-	^ SystemNavigation new allMethods select: [ :method | 
+	^ environment allMethods select: [ :method | 
 		  method readsSelf and: [ 
 			  method sendsToSuper not or: [ 
 				  method ast variableNodes anySatisfy: [ :varNode | 

--- a/src/OpalCompiler-Core/SuperVariable.class.st
+++ b/src/OpalCompiler-Core/SuperVariable.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #visiting }
 SuperVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
-		^ aProgramNodeVisitor visitSuperNode: aNode
+	^ aProgramNodeVisitor visitSuperNode: aNode
 ]
 
 { #category : #emitting }
@@ -39,6 +39,6 @@ SuperVariable >> readInContext: aContext [
 SuperVariable >> usingMethods [
 	"as super is just a push Self, this detects real super sends, not accesses to super which 
 	should never happen"
-	^ SystemNavigation new allMethods select: [ :method | 
+	^ environment allMethods select: [ :method | 
 		  method sendsToSuper ]
 ]

--- a/src/OpalCompiler-Core/ThisContextVariable.class.st
+++ b/src/OpalCompiler-Core/ThisContextVariable.class.st
@@ -37,6 +37,6 @@ ThisContextVariable >> readInContext: aContext [
 
 { #category : #queries }
 ThisContextVariable >> usingMethods [
-	^ SystemNavigation new allMethods select: [ :method | 
+	^ environment allMethods select: [ :method | 
 		  method readsThisContext ]
 ]


### PR DESCRIPTION
The classes modeling self, super and thisContext reference the global environment directly (via SystemNavigation new).

This PR instead adds the environment as state. This will allow us to later have different instances for different environments. For now the envrionment remains hardcodes, but just in #initialize instead of all #usingMethods implementations.

(The idea is that all subclasses of Variable should implement #scope. They should know the scope that will return them when looking up by name using #lookupVar:. The scope for self, super and thisContext will be the global environment)

The PR in addition adds a missing visitor methid to the completion builder.