### PR TITLE
Simplify-OCASTClosureAnalyzer

### DIFF
--- a/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
@@ -11,21 +11,6 @@ Class {
 }
 
 { #category : #variables }
-OCASTClosureAnalyzer >> doCopying [
-	| copying |
-	copying := scope tempVars select: [ :each | each isEscapingRead].	
-	copying do: [ :each | scope addCopyingTemp: each]
-]
-
-{ #category : #variables }
-OCASTClosureAnalyzer >> doRemotes [
-	| remotes |
-	remotes := scope tempVars select: [ :each | each isEscapingWrite].
-	remotes do: [ :each | scope moveToVectorTemp: each].	
-	
-]
-
-{ #category : #variables }
 OCASTClosureAnalyzer >> lookupAndFixBinding: aVariableNode [
 	| var |
 	var := scope lookupVar: aVariableNode name.
@@ -43,7 +28,8 @@ OCASTClosureAnalyzer >> visitBlockNode: aBlockNode [
 	"here look at the temps and make copying vars / tempVector out of them"
 	self visitArgumentNodes: aBlockNode arguments.
 	scope := aBlockNode scope.	
-	self doRemotes; doCopying.
+	scope moveEscapingWritesToTempVector.
+	scope copyEscapingReads.
 	self visitNode: aBlockNode body.
 	aBlockNode temporaries do: [ :each | self lookupAndFixBinding: each ].
 	scope := scope popScope.
@@ -54,7 +40,8 @@ OCASTClosureAnalyzer >> visitMethodNode: aMethodNode [
 	"here look at the temps and make copying vars / tempVector out of them"
 	self visitArgumentNodes: aMethodNode arguments.
 	scope := aMethodNode scope.	
-	self doRemotes; doCopying.
+	scope moveEscapingWritesToTempVector.
+	scope copyEscapingReads.
 	self visitNode: aMethodNode body.
 	aMethodNode temporaries do: [ :each | self lookupAndFixBinding: each ]
 ]

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -85,6 +85,14 @@ OCAbstractMethodScope >> copiedVars [
 	^ copiedVars
 ]
 
+{ #category : #'temp vars - copying' }
+OCAbstractMethodScope >> copyEscapingReads [
+
+	self tempVars
+		select: [ :each | each isEscapingRead ]
+		thenDo: [ :each | self addCopyingTemp: each ]
+]
+
 { #category : #lookup }
 OCAbstractMethodScope >> hasBindingThatBeginsWith: aString [
 	"check weather there are any temporaries defined that start with aString"
@@ -162,6 +170,14 @@ OCAbstractMethodScope >> lookupVarForDeclaration: name [
 OCAbstractMethodScope >> methodScope [
 
 	^ self outerScope methodScope
+]
+
+{ #category : #'temp vars - vector' }
+OCAbstractMethodScope >> moveEscapingWritesToTempVector [
+
+	self tempVars
+		select: [ :each | each isEscapingWrite ]
+		thenDo: [ :each | self moveToVectorTemp: each ]
 ]
 
 { #category : #'temp vars - vector' }

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -88,7 +88,7 @@ OCAbstractMethodScope >> copiedVars [
 { #category : #'temp vars - copying' }
 OCAbstractMethodScope >> copyEscapingReads [
 
-	self tempVars
+	self tempVars values 
 		select: [ :each | each isEscapingRead ]
 		thenDo: [ :each | self addCopyingTemp: each ]
 ]
@@ -175,7 +175,7 @@ OCAbstractMethodScope >> methodScope [
 { #category : #'temp vars - vector' }
 OCAbstractMethodScope >> moveEscapingWritesToTempVector [
 
-	self tempVars
+	self tempVars values
 		select: [ :each | each isEscapingWrite ]
 		thenDo: [ :each | self moveToVectorTemp: each ]
 ]


### PR DESCRIPTION
This is a simplification that is the result of a review comment that I got from another PR: OCASTClosureAnalyzer>>#doCopying looks like it should be implemented in the scope.

- implement #copyEscapingReads and #moveEscapingWritesToTempVector on the Method/Block scope

This indeed makes the code now much more readable.