### PR TITLE
7387-typeOfClass-should-delegate-to-the-Layout-Hierarchy

### DIFF
--- a/src/Kernel/AbstractLayout.class.st
+++ b/src/Kernel/AbstractLayout.class.st
@@ -109,11 +109,6 @@ AbstractLayout >> isBits [
 ]
 
 { #category : #testing }
-AbstractLayout >> isCustomLayout [
-	^false
-]
-
-{ #category : #testing }
 AbstractLayout >> isFixedLayout [
 	^false
 ]
@@ -151,6 +146,12 @@ AbstractLayout >> slotScope [
 { #category : #accessing }
 AbstractLayout >> slots [
 	^ {}
+]
+
+{ #category : #accessing }
+AbstractLayout >> typeOfClass [
+	"The type is the class name of the layout. But for ST80 layouts, we define some special symbols to stay backward compatible"
+	^self class name asSymbol
 ]
 
 { #category : #accessing }

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1713,19 +1713,7 @@ Behavior >> thoroughWhichSelectorsReferTo: literal [
 { #category : #accessing }
 Behavior >> typeOfClass [
 	"Answer a symbol uniquely describing the type of the receiver. c.f. kindOfSubclass"
-	self classLayout isCustomLayout ifTrue: [ ^self classLayout class name asSymbol].
-	self isBytes ifTrue:
-		[^self instSpec = CompiledMethod instSpec
-			ifTrue: [#compiledMethod] "Very special!"
-			ifFalse: [#bytes]].
-	(self isWords and: [self isPointers not]) ifTrue:
-		[^self instSpec = SmallInteger instSpec
-			ifTrue: [#immediate] "Very special!"
-			ifFalse: [#words]].
-	self isWeak ifTrue: [^#weak].
-	self isVariable ifTrue: [^#variable].
-	self isEphemeronClass ifTrue: [^#ephemeron].
-	^#normal
+	^self classLayout typeOfClass
 ]
 
 { #category : #'user interface' }

--- a/src/Kernel/ByteLayout.class.st
+++ b/src/Kernel/ByteLayout.class.st
@@ -39,3 +39,8 @@ ByteLayout >> isBytes [
 ByteLayout >> kindOfSubclass [
 	^' variableByteSubclass: '
 ]
+
+{ #category : #accessing }
+ByteLayout >> typeOfClass [
+	^#bytes
+]

--- a/src/Kernel/CompiledMethodLayout.class.st
+++ b/src/Kernel/CompiledMethodLayout.class.st
@@ -27,3 +27,8 @@ CompiledMethodLayout >> kindOfSubclass [
 	"not really true but this is what is shows now"
 	^' variableByteSubclass: '
 ]
+
+{ #category : #accessing }
+CompiledMethodLayout >> typeOfClass [
+	^#compiledMethod
+]

--- a/src/Kernel/EphemeronLayout.class.st
+++ b/src/Kernel/EphemeronLayout.class.st
@@ -24,3 +24,8 @@ EphemeronLayout >> instanceSpecification [
 EphemeronLayout >> kindOfSubclass [
 	^' ephemeronSubclass: '
 ]
+
+{ #category : #accessing }
+EphemeronLayout >> typeOfClass [
+	^#ephemeron
+]

--- a/src/Kernel/FixedLayout.class.st
+++ b/src/Kernel/FixedLayout.class.st
@@ -33,3 +33,8 @@ FixedLayout >> isFixedLayout [
 FixedLayout >> kindOfSubclass [
 	^' subclass: '
 ]
+
+{ #category : #accessing }
+FixedLayout >> typeOfClass [
+	^#normal
+]

--- a/src/Kernel/ImmediateLayout.class.st
+++ b/src/Kernel/ImmediateLayout.class.st
@@ -36,3 +36,8 @@ ImmediateLayout >> instanceSpecification [
 ImmediateLayout >> kindOfSubclass [
 	^' immediateSubclass: '
 ]
+
+{ #category : #accessing }
+ImmediateLayout >> typeOfClass [
+	^#immediate
+]

--- a/src/Kernel/VariableLayout.class.st
+++ b/src/Kernel/VariableLayout.class.st
@@ -33,3 +33,8 @@ VariableLayout >> isVariable [
 VariableLayout >> kindOfSubclass [
 	^' variableSubclass: '
 ]
+
+{ #category : #accessing }
+VariableLayout >> typeOfClass [
+	^#variable
+]

--- a/src/Kernel/WeakLayout.class.st
+++ b/src/Kernel/WeakLayout.class.st
@@ -38,3 +38,8 @@ WeakLayout >> isWeak [
 WeakLayout >> kindOfSubclass [
 	^' weakSubclass: '
 ]
+
+{ #category : #accessing }
+WeakLayout >> typeOfClass [
+	^#weak
+]

--- a/src/Kernel/WordLayout.class.st
+++ b/src/Kernel/WordLayout.class.st
@@ -39,3 +39,8 @@ WordLayout >> isWords [
 WordLayout >> kindOfSubclass [
 	^' variableWordSubclass: '
 ]
+
+{ #category : #accessing }
+WordLayout >> typeOfClass [
+	^#words
+]


### PR DESCRIPTION
#typeOfClass is a huge "IF" that actually misses cases: DoubleWordArray and DoubleByteArray even if the layout is correct will answer wrongly.

Solution: forward to the layout, implement #typeOfClass there. Then it will for DoubleByteArray automatically return the default case, the name of the layout class (#DoubleByteLayout), which should make it then possible to save classes like that with Git.

we can remove #isCustomLayout now, too. Custom layout now use the name of the layout class by default.