### PR TITLE
7375-AST-with-syntax-error-compiled-with-nil-parent-pointer

### DIFF
--- a/src/AST-Core/RBEnglobingErrorNode.class.st
+++ b/src/AST-Core/RBEnglobingErrorNode.class.st
@@ -70,7 +70,8 @@ RBEnglobingErrorNode >> content [
 
 { #category : #accessing }
 RBEnglobingErrorNode >> content: aCollection [
-	content := aCollection
+	content := aCollection.
+	aCollection do: [:each | each parent: self ]
 ]
 
 { #category : #initialization }

--- a/src/OpalCompiler-Core/RBBlockNode.extension.st
+++ b/src/OpalCompiler-Core/RBBlockNode.extension.st
@@ -43,8 +43,7 @@ RBBlockNode >> isInlined [
 
 { #category : #'*opalcompiler-core' }
 RBBlockNode >> isInlinedLoop [
-	parent parent ifNil: [ ^false ]. "Workaround: make it more robust against broken ASTs"
-	
+
 	parent isMessage ifFalse: [ ^ false ].
 	parent isInlineToDo ifTrue: [^ true].
 	parent isInlineWhile ifTrue: [^ true].


### PR DESCRIPTION
This fixes #7375, it sets the Parent pointer correctly and removes a workaround introduced before