### PR TITLE
7359-Spec-some-tests-modify-literal-arrays

### DIFF
--- a/src/Spec2-Tests/SpAbstractListPresenterTest.class.st
+++ b/src/Spec2-Tests/SpAbstractListPresenterTest.class.st
@@ -17,7 +17,7 @@ SpAbstractListPresenterTest class >> isAbstract [
 SpAbstractListPresenterTest >> setUp [
 
 	super setUp.
-	presenter items: #(10 20 30).
+	presenter items: #(10 20 30) copy.
 ]
 
 { #category : #'tests-activation' }
@@ -152,7 +152,7 @@ SpAbstractListPresenterTest >> testSetSortingBlockBeforeItems [
 	count := 0.
 	presenter whenSortingBlockChangedDo: [ :sortFunction | count := count + 1 ].
 	presenter sortingBlock: #yourself ascending.
-	presenter items: #(3 8 1 0).
+	presenter items: #(3 8 1 0) copy.
 	self assert: count equals: 1.
 	self assert: (presenter model at: 1) equals: 0
 ]
@@ -176,7 +176,7 @@ SpAbstractListPresenterTest >> testSortingBlock [
 	| count |
 	count := 0.
 	presenter whenSortingBlockChangedDo: [ :sortFunction | count := count + 1 ].
-	presenter items: #(3 8 1 0).
+	presenter items: #(3 8 1 0) copy.
 	presenter sortingBlock: #yourself ascending.
 	self assert: count equals: 1.
 	self assert: (presenter model at: 1) equals: 0

--- a/src/Spec2-Tests/SpComponentListPresenterTest.class.st
+++ b/src/Spec2-Tests/SpComponentListPresenterTest.class.st
@@ -142,7 +142,7 @@ SpComponentListPresenterTest >> testSetSortingBlockBeforeItems [
 	count := 0.
 	presenter whenSortingBlockChangedDo: [ :sortFunction | count := count + 1 ].
 	presenter sortingBlock: [ :each | each label asNumber ] ascending.
-	presenter items: #(3 8 1 0).
+	presenter items: #(3 8 1 0) copy.
 	self assert: count equals: 1.
 	self assert: (presenter model at: 1) label equals: '0'
 ]
@@ -153,7 +153,7 @@ SpComponentListPresenterTest >> testSortingBlock [
 	
 	count := 0.
 	presenter whenSortingBlockChangedDo: [ :sortFunction | count := count + 1 ].
-	presenter items: #(3 8 1 0).
+	presenter items: #(3 8 1 0) copy.
 	presenter sortingBlock: [ :each | each label asNumber ] ascending.
 	self assert: count equals: 1.
 	self assert: (presenter model at: 1) label equals: '0'

--- a/src/Spec2-Tests/SpDropListPresenterTest.class.st
+++ b/src/Spec2-Tests/SpDropListPresenterTest.class.st
@@ -15,7 +15,7 @@ SpDropListPresenterTest >> testSortingBlock [
 	count := 0.
 	presenter
 		whenSortingBlockChangedDo: [ :sortFunction | count := count + 1 ].
-	presenter items: #(3 8 1 0).
+	presenter items: #(3 8 1 0) copy.
 	presenter sortingBlock: [ :a :b | a model < b model ].
 	self assert: count equals: 1.
 	self assert: (presenter model at: 1) model equals: 0


### PR DESCRIPTION
Workaround for #7359: the real fix will be integrated with the next spec integration, adding copy here will unblock the work on read-only literals.