### PR TITLE
7378-Tests-often-timing-out-testFastPointersTo-testOneGWordAllocation-

### DIFF
--- a/src/Kernel-Tests/AllocationTest.class.st
+++ b/src/Kernel-Tests/AllocationTest.class.st
@@ -25,7 +25,7 @@ AllocationTest >> testOneGWordAllocation [
 	
 	| sz array failed |
 	"This takes too much time to run"
-	self timeLimit: 1 minute.
+	self timeLimit: 3 minutes.
 	
 	failed := false.
 	sz := 1024*1024*1024.

--- a/src/Kernel-Tests/ProtoObjectTest.class.st
+++ b/src/Kernel-Tests/ProtoObjectTest.class.st
@@ -13,6 +13,7 @@ Class {
 { #category : #'tests - testing' }
 ProtoObjectTest >> testFastPointersTo [
 	| myObject myArray myObject2 allObjects |
+	self timeLimit: 1 minute.
 	myObject := Object new.
 	myObject2 := Object new.
 	myArray := {myObject.


### PR DESCRIPTION
increase timeout, fixes #7378