### PR TITLE
reduce-sends-doSemanticAnalysis

### DIFF
--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -72,7 +72,7 @@ CoASTResultSetBuilder >> parseNode [
 			source: completionContext source;
 			noPattern: completionContext isWorkspace; 
 			options: #(+ optionParseErrors + optionSkipSemanticWarnings);
-			parse) doSemanticAnalysis nodeForOffset: completionContext position ] 
+			parse) nodeForOffset: completionContext position ] 
 ]
 
 { #category : #visiting }

--- a/src/HeuristicCompletion-Model/CoGlobalSorterResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoGlobalSorterResultSetBuilder.class.st
@@ -15,7 +15,6 @@ CoGlobalSorterResultSetBuilder >> parseNode [
 
 	| aNewNode |
 	aNewNode := super parseNode.
-	aNewNode methodNode doSemanticAnalysis.
 	TypingVisitor new visitNode: aNewNode methodNode.
 	^ aNewNode
 ]

--- a/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
@@ -80,7 +80,6 @@ OCASTCheckerTest >> testExampleSelf [
 OCASTCheckerTest >> testExampleSelfReceiver [
 	| ast |
 	ast := (OCOpalExamples>>#exampleSelfReceiver) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast body statements first receiver isSelfVariable.
 ]
 
@@ -101,7 +100,6 @@ OCASTCheckerTest >> testExampleSuper [
 OCASTCheckerTest >> testExampleSuperReceiver [
 	| ast |
 	ast := (OCOpalExamples>>#exampleSuperReceiver) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast body statements first receiver isSuperVariable
 ]
 
@@ -257,8 +255,7 @@ OCASTCheckerTest >> testSemanticAnalysisOnNonMethodNode [
 	thisContext.
 	(OCOpalExamples >> #exampleReturn42)}
 		do: [ :object | 
-			ast := object sourceNode.
-			ast doSemanticAnalysis ].
+			ast := object sourceNode].
 	#('1' 'true' 'nil' '1 + 2' '^1' '1 + 2. 2 + 3' '#(1 true)' '{ #foo . 1 }' '1+2;+3')
 		do: [ :source | 
 			ast := RBParser parseExpression: source.

--- a/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
@@ -8,7 +8,6 @@ Class {
 OCASTClosureAnalyzerTest >> testBlockArgumentIsArgumentVariable [
 	| ast blockNode |
 	ast := (OCOpalExamples>>#exampleForBlockArgument) parseTree.
-	ast doSemanticAnalysis.
 	blockNode := ast body statements first value.
 	self assert: blockNode arguments notEmpty.
 	self assert: blockNode arguments first isArgumentVariable
@@ -19,7 +18,6 @@ OCASTClosureAnalyzerTest >> testBlockArgumentIsArgumentVariable [
 OCASTClosureAnalyzerTest >> testDoubleRemoteAnidatedBlocks [
 	| ast scopes |
 	ast := (OCOpalExamples >> #doubleRemoteAnidatedBlocks) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 0.
 	self assert: ast scope tempVector size equals: 2.
@@ -36,7 +34,6 @@ OCASTClosureAnalyzerTest >> testDoubleRemoteAnidatedBlocks [
 OCASTClosureAnalyzerTest >> testExampleBlockArgument [
 	| ast blockScope blockScope2 |
 	ast := (OCOpalExamples >> #exampleBlockArgument) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 3.
 	self assert: ast scope tempVector size equals: 0.
@@ -68,7 +65,6 @@ OCASTClosureAnalyzerTest >> testExampleBlockArgument [
 OCASTClosureAnalyzerTest >> testExampleSimpleBlockLocalIf [
 	| ast  assignment var |
 	ast := (OCOpalExamples>>#exampleSimpleBlockLocalIf) parseTree.
-	ast doSemanticAnalysis.
 
 	assignment := RBParseTreeSearcher treeMatching: '`var := ``@anything' in: ast. 	
 	var := assignment variable variable.
@@ -80,7 +76,6 @@ OCASTClosureAnalyzerTest >> testExampleSimpleBlockLocalIf [
 OCASTClosureAnalyzerTest >> testExampleSimpleBlockLocalWhile [
 	| ast scopes |
 	ast := (OCOpalExamples >> #exampleSimpleBlockLocalWhile) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 
 	self assert: ast scope tempVars size equals: 0.
@@ -100,7 +95,6 @@ OCASTClosureAnalyzerTest >> testExampleSimpleBlockLocalWhile [
 OCASTClosureAnalyzerTest >> testExampleSimpleBlockNested [
 	| ast scopes |
 	ast := (OCOpalExamples >> #exampleSimpleBlockNested) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 
 	self assert: ast scope tempVars size equals: 2.
@@ -123,7 +117,6 @@ OCASTClosureAnalyzerTest >> testExampleSimpleBlockNested [
 OCASTClosureAnalyzerTest >> testExampleWhileModificationBefore [
 	| ast |
 	ast := (OCOpalExamples >> #exampleWhileModificationBefore) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 0.
 	self assert: ast scope tempVector size equals: 1.
@@ -139,7 +132,6 @@ only needs to copy the tempvars. No write -> no indirection vector."
 
 	| ast |
 	ast := (OCOpalExamples >> #exampleWhileNoModification) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 3.
 	self assert: ast scope tempVector size equals: 0.
@@ -153,7 +145,6 @@ only needs to copy the tempvars. No write -> no indirection vector."
 OCASTClosureAnalyzerTest >> testInlinedBlockArgumentIsArgumentVariable [
 	| ast blockNode |
 	ast := (OCOpalExamples>>#exampleForInlinedBlockArgument) parseTree.
-	ast doSemanticAnalysis.
 	blockNode := ast body statements first arguments first.
 	self assert: blockNode arguments notEmpty.
 	self assert: blockNode arguments first isArgumentVariable
@@ -164,7 +155,6 @@ OCASTClosureAnalyzerTest >> testInlinedBlockArgumentIsArgumentVariable [
 OCASTClosureAnalyzerTest >> testMethodArgumentIsArgumentVariable [
 	| ast |
 	ast := (OCOpalExamples>>#exampleWithArgument:) parseTree.
-	ast doSemanticAnalysis .
 	self assert: ast arguments notEmpty.
 	self assert: ast arguments first isArgumentVariable
 	
@@ -174,7 +164,6 @@ OCASTClosureAnalyzerTest >> testMethodArgumentIsArgumentVariable [
 OCASTClosureAnalyzerTest >> testNestedBlocksRemoteInBlockCase1 [
 	| ast scopes |
 	ast := (OCOpalExamples >> #nestedBlocksRemoteInBlockCase1) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 
 	self assert: ast scope tempVars size equals: 1.
@@ -193,7 +182,6 @@ OCASTClosureAnalyzerTest >> testNestedBlocksRemoteInBlockCase1 [
 OCASTClosureAnalyzerTest >> testNestedBlocksRemoteInBlockCase2 [
 	| ast scopes |
 	ast := (OCOpalExamples >> #nestedBlocksRemoteInBlockCase2) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 
 	self assert: ast scope tempVars size equals: 1.
@@ -221,7 +209,6 @@ OCASTClosureAnalyzerTest >> testNestedBlocksRemoteInBlockCase2 [
 OCASTClosureAnalyzerTest >> testNestedBlocksRemoteInBlockCase3 [
 	| ast scopes |
 	ast := (OCOpalExamples >> #nestedBlocksRemoteInBlockCase3) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 
 	self assert: ast scope tempVars size equals: 0.
@@ -249,7 +236,6 @@ OCASTClosureAnalyzerTest >> testNestedBlocksRemoteInBlockCase3 [
 OCASTClosureAnalyzerTest >> testNoRemoteBlockArgument [
 	| ast |
 	ast := (OCOpalExamples >> #noRemoteBlockArgument) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 3.
 
@@ -262,7 +248,6 @@ OCASTClosureAnalyzerTest >> testNoRemoteBlockArgument [
 OCASTClosureAnalyzerTest >> testNoRemoteReadInBlock [
 	| ast |
 	ast := (OCOpalExamples >> #noRemoteReadInBlock) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 1.
 	self assert: ast scope tempVector size equals: 0.
@@ -274,7 +259,6 @@ OCASTClosureAnalyzerTest >> testNoRemoteReadInBlock [
 OCASTClosureAnalyzerTest >> testNoRemoteReadNestedBlocks [
 	| ast scopes |
 	ast := (OCOpalExamples >> #noRemoteReadNestedBlocks) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 0.
 	self assert: ast scope tempVector size equals: 0.
@@ -289,7 +273,6 @@ OCASTClosureAnalyzerTest >> testNoRemoteReadNestedBlocks [
 OCASTClosureAnalyzerTest >> testOptimizedBlockReadInBlock [
 	| ast |
 	ast := (OCOpalExamples >> #optimizedBlockReadInBlock) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 
 	self assert: ast scope tempVars size equals: 1.
@@ -301,7 +284,6 @@ OCASTClosureAnalyzerTest >> testOptimizedBlockReadInBlock [
 OCASTClosureAnalyzerTest >> testOptimizedBlockWriteInBlock [
 	| ast |
 	ast := (OCOpalExamples >> #optimizedBlockWriteInBlock) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 
 	self assert: ast scope tempVars size equals: 1.
@@ -313,7 +295,6 @@ OCASTClosureAnalyzerTest >> testOptimizedBlockWriteInBlock [
 OCASTClosureAnalyzerTest >> testOptimizedBlockWriteInNestedBlock [
 	| ast |
 	ast := (OCOpalExamples >> #optimizedBlockWriteInNestedBlock) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 
 	self assert: ast scope tempVars size equals: 0.
@@ -325,7 +306,6 @@ OCASTClosureAnalyzerTest >> testOptimizedBlockWriteInNestedBlock [
 OCASTClosureAnalyzerTest >> testOptimizedBlockWriteInNestedBlockCase2 [
 	| ast |
 	ast := (OCOpalExamples >> #optimizedBlockWriteInNestedBlockCase2) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 
 	self assert: ast scope tempVars size equals: 1.
@@ -338,7 +318,6 @@ OCASTClosureAnalyzerTest >> testOptimizedBlockWriteInNestedBlockCase2 [
 OCASTClosureAnalyzerTest >> testOptimizedBlockWriteInNestedBlockCase3 [
 	| ast scopes |
 	ast := (OCOpalExamples >> #optimizedBlockWriteInNestedBlockCase3) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 
 	self assert: ast scope tempVars size equals: 0.
@@ -358,7 +337,6 @@ OCASTClosureAnalyzerTest >> testOptimizedBlockWriteInNestedBlockCase3 [
 OCASTClosureAnalyzerTest >> testOptimizedBlockWriteInNestedBlockCase4 [
 	| ast scopes |
 	ast := (OCOpalExamples >> #optimizedBlockWriteInNestedBlockCase4) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 
 	self assert: ast scope tempVars size equals: 0.
@@ -377,7 +355,6 @@ OCASTClosureAnalyzerTest >> testOptimizedBlockWriteInNestedBlockCase4 [
 OCASTClosureAnalyzerTest >> testOptimizedBlockWrittenAfterClosedOverCase1 [
 	| ast scopes |
 	ast := (OCOpalExamples >> #optimizedBlockWrittenAfterClosedOverCase1) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 
 	self assert: ast scope tempVars size equals: 1.
@@ -397,7 +374,6 @@ OCASTClosureAnalyzerTest >> testOptimizedBlockWrittenAfterClosedOverCase1 [
 OCASTClosureAnalyzerTest >> testOptimizedBlockWrittenAfterClosedOverCase2 [
 	| ast scopes |
 	ast := (OCOpalExamples >> #optimizedBlockWrittenAfterClosedOverCase2) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 
 	self assert: ast scope tempVars size equals: 1.
@@ -412,7 +388,6 @@ OCASTClosureAnalyzerTest >> testOptimizedBlockWrittenAfterClosedOverCase2 [
 OCASTClosureAnalyzerTest >> testSingleRemoteDifferentBlocksSameArgumentName [
 	| ast |
 	ast := (OCOpalExamples >> #singleRemoteDifferentBlocksSameArgumentName) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 2.
 	self assert: ast scope tempVector size equals: 1.
@@ -426,7 +401,6 @@ OCASTClosureAnalyzerTest >> testSingleRemoteDifferentBlocksSameArgumentName [
 OCASTClosureAnalyzerTest >> testSingleRemoteMethodArgument [
 	| ast |
 	ast := (OCOpalExamples >> #singleRemoteMethodArgument) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 1.
 	self assert: ast scope tempVector size equals: 1.
@@ -439,7 +413,6 @@ OCASTClosureAnalyzerTest >> testSingleRemoteMethodArgument [
 OCASTClosureAnalyzerTest >> testSingleRemoteReadNestedBlocks [
 	| ast |
 	ast := (OCOpalExamples >> #singleRemoteReadNestedBlocks) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 0.
 	self assert: ast scope tempVector size equals: 1.
@@ -451,7 +424,6 @@ OCASTClosureAnalyzerTest >> testSingleRemoteReadNestedBlocks [
 OCASTClosureAnalyzerTest >> testSingleRemoteTempVar [
 	| ast |
 	ast := (OCOpalExamples >> #singleRemoteTempVar) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 2.
 	self assert: ast scope tempVector size equals: 1.
@@ -476,7 +448,6 @@ t1 := 1.
 [ t2 := t1 +  1.0 ] value.
 
 ^t2'.
-	ast doSemanticAnalysis.
 	self assert: ast temporaries second variable class equals: OCVectorTempVariable
 ]
 
@@ -484,7 +455,6 @@ t1 := 1.
 OCASTClosureAnalyzerTest >> testWrittenAfterClosedOver [
 	| ast |
 	ast := (OCOpalExamples >> #writtenAfterClosedOver) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 0.
 	self assert: ast scope tempVector size equals: 1.
@@ -496,7 +466,6 @@ OCASTClosureAnalyzerTest >> testWrittenAfterClosedOver [
 OCASTClosureAnalyzerTest >> testsingleRemoteTempVarWhileWithTempNotInlined [
 	| ast |
 	ast := (OCOpalExamples >> #exampleWhileWithTempNotInlined) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 1.
 	self assert: ast scope tempVector size equals: 1.
@@ -510,7 +479,6 @@ OCASTClosureAnalyzerTest >> testsingleRemoteTempVarWhileWithTempNotInlined [
 OCASTClosureAnalyzerTest >> testsingleRemoteTempVarWrittenAfterClosedOver [
 	| ast |
 	ast := (OCOpalExamples >> #singleRemoteTempVarWrittenAfterClosedOver) parseTree.
-	ast doSemanticAnalysis.
 	self assert: ast scope isMethodScope.
 	self assert: ast scope tempVars size equals: 1.
 	self assert: ast scope tempVector size equals: 1.

--- a/src/Refactoring-Core/RBRefactoryTyper.class.st
+++ b/src/Refactoring-Core/RBRefactoryTyper.class.st
@@ -169,7 +169,6 @@ RBRefactoryTyper >> executeSearch: searcher [
 					| parseTree |
 					methodName := sel.
 					parseTree := each parseTreeFor: sel.
-					parseTree doSemanticAnalysis.
 					parseTree notNil ifTrue: [searcher executeTree: parseTree]]]
 ]
 

--- a/src/Refactoring-Core/RBRefactoryTyper.class.st
+++ b/src/Refactoring-Core/RBRefactoryTyper.class.st
@@ -169,6 +169,7 @@ RBRefactoryTyper >> executeSearch: searcher [
 					| parseTree |
 					methodName := sel.
 					parseTree := each parseTreeFor: sel.
+					parseTree doSemanticAnalysis.
 					parseTree notNil ifTrue: [searcher executeTree: parseTree]]]
 ]
 


### PR DESCRIPTION
with the compiler facade (and thus #parseTree) doing semantic analysis by default, we can reduce the explicit calls to  #doSemanticAnalysis.

We still retain those where RBParser is used directly.