### PR TITLE
Name Analysis: Lookup Slots In Class

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -679,12 +679,16 @@ Class >> hasAbstractMethods [
 Class >> hasBindingThatBeginsWith: aString [
 	"Answer true if the receiver has a binding that begins with aString, false otherwise"
 
-	"First look in classVar dictionary"
-	(self classPool hasBindingThatBeginsWith: aString) ifTrue:[^true].
+	"First check the slots / instance variabless"
+	(self classLayout hasBindingThatBeginsWith: aString) ifTrue: [^ true].
+
+	"Then look in classVar dictionary"
+	(self classPool hasBindingThatBeginsWith: aString) ifTrue: [ ^true].
 	
 	"Next look in shared pools"
-	(self sharedPools anySatisfy: [:pool | pool hasBindingThatBeginsWith: aString ]) ifTrue:[^true].
+	(self sharedPools anySatisfy: [:pool | pool hasBindingThatBeginsWith: aString ]) ifTrue: [ ^true].
 	
+	"Last: go to the outer environment"
 	^ self environment hasBindingThatBeginsWith: aString
 ]
 

--- a/src/Kernel/LayoutClassScope.class.st
+++ b/src/Kernel/LayoutClassScope.class.st
@@ -67,6 +67,16 @@ LayoutClassScope >> flatten [
 	^ result
 ]
 
+{ #category : #enumerating }
+LayoutClassScope >> hasBindingThatBeginsWith: aString [
+	"Answer true if there is a Slot name that begins with aString, false otherwise"
+	
+	self allSlotsDo: [:each | 
+		(each name beginsWith: aString)
+			ifTrue:[^true]].
+	^false
+]
+
 { #category : #testing }
 LayoutClassScope >> hasFields [
 	self do: [ :slot | 

--- a/src/Kernel/LayoutEmptyScope.class.st
+++ b/src/Kernel/LayoutEmptyScope.class.st
@@ -39,6 +39,11 @@ LayoutEmptyScope >> flatten [
 ]
 
 { #category : #testing }
+LayoutEmptyScope >> hasBindingThatBeginsWith: aString [
+	^false
+]
+
+{ #category : #testing }
 LayoutEmptyScope >> hasFields [
 	^ false
 ]

--- a/src/Kernel/PointerLayout.class.st
+++ b/src/Kernel/PointerLayout.class.st
@@ -139,6 +139,13 @@ PointerLayout >> fieldSize [
 ]
 
 { #category : #testing }
+PointerLayout >> hasBindingThatBeginsWith: aString [
+	"Answer true if there is a Slot that begins with aString, false otherwise"
+	
+	^ self slotScope hasBindingThatBeginsWith: aString
+]
+
+{ #category : #testing }
 PointerLayout >> hasFields [
 	^ slotScope hasFields
 ]

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -301,6 +301,11 @@ Slot >> readInContext: aContext [
 ]
 
 { #category : #accessing }
+Slot >> scope [
+	^ definingClass
+]
+
+{ #category : #accessing }
 Slot >> scope: aScope [
 	"ignored, subclasses can override to analyze the scope they are to be installed in"
 ]

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -308,6 +308,11 @@ Variable >> removeProperty: propName ifAbsent: aBlock [
 	^ property
 ]
 
+{ #category : #accessing }
+Variable >> scope [
+	^self subclassResponsibility
+]
+
 { #category : #queries }
 Variable >> usingMethods [
 	self subclassResponsibility

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -68,7 +68,10 @@ Behavior >> evaluate: aString [
 
 { #category : #'*OpalCompiler-Core' }
 Behavior >> lookupVar: aName [
-	^ self bindingOf: aName
+	^ self classLayout 
+		resolveSlot: aName asSymbol 
+		ifFound: [:var | var] 
+		ifNone: [self bindingOf: aName]
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/OCInstanceScope.class.st
+++ b/src/OpalCompiler-Core/OCInstanceScope.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #'instance creation' }
 OCInstanceScope class >> for: aClass [
-	^ self new slots: aClass allSlots; outerScope: aClass; yourself
+	^ self new outerScope: aClass; yourself
 ]
 
 { #category : #acessing }
@@ -67,11 +67,4 @@ OCInstanceScope >> newMethodScope [
 OCInstanceScope >> scopeLevel [
 	"For debugging we print a counter for all scopes, starting from the Method as 1, so we are 0"
 	^ 0
-]
-
-{ #category : #initializing }
-OCInstanceScope >> slots: slotCollection [
-
-	slotCollection do: [ :slot |
-		vars at: slot name put: slot]
 ]

--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -26,9 +26,6 @@ OCUndeclaredVariableWarning >> declareGlobal [
 OCUndeclaredVariableWarning >> declareInstVar: name [
 	"Declare an instance variable."
 	self methodClass addInstVarNamed: name.
-	"We are changing a class after the scope hierarchy was created, so we need to update the
-	Instance Scope"
-	self methodNode scope instanceScope slots: self methodClass allSlots.
 	^ self lookUpVariable
 ]
 

--- a/src/OpalCompiler-Core/ReservedVariable.class.st
+++ b/src/OpalCompiler-Core/ReservedVariable.class.st
@@ -74,6 +74,11 @@ ReservedVariable >> printOn: stream [
 	stream nextPutAll: self name
 ]
 
+{ #category : #accessing }
+ReservedVariable >> scope [
+	^ environment
+]
+
 { #category : #queries }
 ReservedVariable >> usingMethods [
 	"first call is very slow as it creates all ASTs"

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -668,6 +668,14 @@ RGBehavior >> localSelectors [
 	^ self localMethods collect: [ :each | each name ]
 ]
 
+{ #category : #lookup }
+RGBehavior >> lookupVar: aName [
+	^ self layout 
+		resolveSlot: aName asSymbol 
+		ifFound: [:var | var] 
+		ifNone: [self bindingOf: aName]
+]
+
 { #category : #resolving }
 RGBehavior >> makeResolved [
 

--- a/src/Ring-Core/RGLayout.class.st
+++ b/src/Ring-Core/RGLayout.class.st
@@ -106,3 +106,8 @@ RGLayout >> isWordLayout [
 
 	^ false
 ]
+
+{ #category : #accessing }
+RGLayout >> resolveSlot: aName ifFound: foundBlock ifNone: exceptionBlock [
+	^exceptionBlock value
+]

--- a/src/Ring-Core/RGPointerLayout.class.st
+++ b/src/Ring-Core/RGPointerLayout.class.st
@@ -129,6 +129,14 @@ RGPointerLayout >> removeSlot: anRGSlot [
 		self backend forBehavior removeSlot: anRGSlot from: self ].
 ]
 
+{ #category : #accessing }
+RGPointerLayout >> resolveSlot: aName ifFound: foundBlock ifNone: noneBlock [
+
+	self allSlots do: [ :slot | 
+		slot name == aName ifTrue: [ ^ foundBlock cull: slot ] ].
+	^ noneBlock value
+]
+
 { #category : #'queries - slots' }
 RGPointerLayout >> slots [
 


### PR DESCRIPTION
Instead of adding all Slots to the instance scope, we can do the lookup in the Class itself (#lookupVar:).

- Improve hasBindingThatBeginsWith: on class to take slot names into account
- add #scope to Slot: the scope of a slot is the defining class