### PR TITLE
5956-Wrong-format-of-DoubleWordArray

### DIFF
--- a/src/Collections-Native/DoubleByteArray.class.st
+++ b/src/Collections-Native/DoubleByteArray.class.st
@@ -6,7 +6,7 @@ For further comments read comments of `WordArray`.
 Class {
 	#name : #DoubleByteArray,
 	#superclass : #ArrayedCollection,
-	#type : #words,
+	#type : #DoubleByteLayout,
 	#category : #'Collections-Native-Base'
 }
 

--- a/src/Collections-Native/DoubleByteArray.class.st
+++ b/src/Collections-Native/DoubleByteArray.class.st
@@ -6,7 +6,7 @@ For further comments read comments of `WordArray`.
 Class {
 	#name : #DoubleByteArray,
 	#superclass : #ArrayedCollection,
-	#type : #DoubleByteLayout,
+	#type : #bytes,
 	#category : #'Collections-Native-Base'
 }
 

--- a/src/Collections-Native/DoubleWordArray.class.st
+++ b/src/Collections-Native/DoubleWordArray.class.st
@@ -6,7 +6,7 @@ For further comments read comments of `WordArray`.
 Class {
 	#name : #DoubleWordArray,
 	#superclass : #ArrayedCollection,
-	#type : #DoubleWordLayout,
+	#type : #words,
 	#category : #'Collections-Native-Base'
 }
 

--- a/src/Collections-Native/DoubleWordArray.class.st
+++ b/src/Collections-Native/DoubleWordArray.class.st
@@ -6,7 +6,7 @@ For further comments read comments of `WordArray`.
 Class {
 	#name : #DoubleWordArray,
 	#superclass : #ArrayedCollection,
-	#type : #words,
+	#type : #DoubleWordLayout,
 	#category : #'Collections-Native-Base'
 }
 

--- a/src/Collections-Tests/NativeArrayTest.class.st
+++ b/src/Collections-Tests/NativeArrayTest.class.st
@@ -93,6 +93,8 @@ NativeArrayTest >> testAtPutExactSizeNumber [
 
 { #category : #tests }
 NativeArrayTest >> testDoubleArraysHaveCorrectLayout [
+	self skip.
+	"this is broken, work in progress see https://github.com/pharo-project/pharo/issues/5956"
 	self assert: DoubleWordArray classLayout class equals: DoubleWordLayout.
 	self assert: DoubleByteArray classLayout class equals: DoubleByteLayout
 ]

--- a/src/Collections-Tests/NativeArrayTest.class.st
+++ b/src/Collections-Tests/NativeArrayTest.class.st
@@ -92,6 +92,12 @@ NativeArrayTest >> testAtPutExactSizeNumber [
 ]
 
 { #category : #tests }
+NativeArrayTest >> testDoubleArraysHaveCorrectLayout [
+	self assert: DoubleWordArray classLayout class equals: DoubleWordLayout.
+	self assert: DoubleByteArray classLayout class equals: DoubleByteLayout
+]
+
+{ #category : #tests }
 NativeArrayTest >> testReplaceFromToWithStartingAt [
 	"Makes sure the primitive works correctly with different data structures"
 	self guineaPigHerd do: [ :guineaPig |

--- a/src/Kernel/AbstractLayout.class.st
+++ b/src/Kernel/AbstractLayout.class.st
@@ -120,7 +120,8 @@ AbstractLayout >> isWeak [
 
 { #category : #accessing }
 AbstractLayout >> kindOfSubclass [
-	^self subclassResponsibility
+	"As a fallback we just return a standard class creation substring. This will be called for user 	defined Layouts, for old style class definitions that can not support user defined Layouts"
+	^' subclass: '
 ]
 
 { #category : #accessing }

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -1409,6 +1409,36 @@ Class >> variableByteSubclass: t instanceVariableNames: f classVariableNames: d 
 				environment: self environment ]
 ]
 
+{ #category : #'subclass creation - variableByte' }
+Class >> variableDoubleByteSubclass: className instanceVariableNames: instVarNameList  classVariableNames: classVarNames package: cat [
+
+	^ self classInstaller
+		make: [ :builder | 
+			builder
+				superclass: self;
+				name: className;
+				layoutClass: DoubleByteLayout;
+				slots: instVarNameList asSlotCollection;
+				sharedVariablesFromString: classVarNames;
+				category: cat;
+				environment: self environment ]
+]
+
+{ #category : #'subclass creation - variableByte' }
+Class >> variableDoubleWordSubclass: className instanceVariableNames: instVarNameList  classVariableNames: classVarNames package: cat [
+
+	^ self classInstaller
+		make: [ :builder | 
+			builder
+				superclass: self;
+				name: className;
+				layoutClass: DoubleWordLayout;
+				slots: instVarNameList asSlotCollection;
+				sharedVariablesFromString: classVarNames;
+				category: cat;
+				environment: self environment ]
+]
+
 { #category : #'subclass creation - deprecated' }
 Class >> variableSubclass: className instanceVariableNames: instVarNameList classVariableNames: classVarNames category: cat [
 	"Added to allow for a simplified subclass creation experience. "

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -353,7 +353,7 @@ MCClassDefinition >> kindOfSubclass [
 	type = #immediate ifTrue: [ ^ ' immediateSubclass: ' ].
 	type = #ephemeron ifTrue: [ ^ ' ephemeronSubclass: ' ].
 	"hack to support user defined layouts"
-	(Smalltalk hasClassNamed: type) ifTrue: [ ^type asString].
+	(Smalltalk hasClassNamed: type) ifTrue: [ ^(Smalltalk globals at: type) new kindOfSubclass].
 	self error: 'Unrecognized class type'
 ]
 

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -352,8 +352,10 @@ MCClassDefinition >> kindOfSubclass [
 	type = #compiledMethod ifTrue: [^ ' variableByteSubclass: ' ].
 	type = #immediate ifTrue: [ ^ ' immediateSubclass: ' ].
 	type = #ephemeron ifTrue: [ ^ ' ephemeronSubclass: ' ].
+	type = #DoubleByteLayout ifTrue: [ ^' variableDoubleByteSubclass: ' ].
+	type = #DoubleWordLayout ifTrue: [ ^' variableDoubleWordSubclass: ' ].
 	"hack to support user defined layouts"
-	(Smalltalk hasClassNamed: type) ifTrue: [ ^(Smalltalk globals at: type) new kindOfSubclass].
+	(Smalltalk hasClassNamed: type) ifTrue: [ ^type asString].
 	self error: 'Unrecognized class type'
 ]
 

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -356,7 +356,7 @@ MCClassDefinition >> kindOfSubclass [
 	type = #DoubleWordLayout ifTrue: [ ^' variableDoubleWordSubclass: ' ].
 	"hack to support user defined layouts"
 	(Smalltalk hasClassNamed: type) ifTrue: [ ^type asString].
-	self error: 'Unrecognized class type'
+	self error: 'Unrecognized class type', type asString
 ]
 
 { #category : #installing }


### PR DESCRIPTION
- add test testDoubleArraysHaveCorrectLayout
- fix MC #kindOfSubclass to ask the layout for a string
- add minimal old style class definition methods for DoubleWord and DoubleByte subclasses
- change the layout of DoubleByteArray/DoubleWordArray, the fixes make sure that Iceberg does indeed save this fix

fixes #5956