### PR TITLE
7365-DictionaryValueHold-removeKey-calls-a-non-existing-method

### DIFF
--- a/src/NewValueHolder-Core/DictionaryValueHolder.class.st
+++ b/src/NewValueHolder-Core/DictionaryValueHolder.class.st
@@ -42,6 +42,12 @@ DictionaryValueHolder >> doesNotUnderstand: aMessage [
 		ifFalse: [ super doesNotUnderstand: aMessage ]
 ]
 
+{ #category : #private }
+DictionaryValueHolder >> errorKeyNotFound: aKey [
+
+	KeyNotFound signalFor: aKey
+]
+
 { #category : #protocol }
 DictionaryValueHolder >> fillFrom: aCollection with: aBlock [
 	"Evaluate aBlock with each of aCollections's elements as the argument.  


### PR DESCRIPTION
fix #7365