### PR TITLE
Debugger-should-show-Workspace-bindings

### DIFF
--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -376,6 +376,11 @@ RBMethodNode >> initialize [
 ]
 
 { #category : #testing }
+RBMethodNode >> isDoIt [
+	^ self selector isDoIt
+]
+
+{ #category : #testing }
 RBMethodNode >> isFaulty [
 	(self arguments anySatisfy: [:each | each isFaulty]) ifTrue:[ ^true].
 	(self pragmas anySatisfy: [:each | each isFaulty]) ifTrue:[ ^true].

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -982,6 +982,9 @@ RBProgramNode >> source [
 RBProgramNode >> sourceCode [
 
 	| interval |
+	"Doit methods have transformed ASTs, we need to pretty print"
+	self methodNode isDoIt ifTrue: [ ^ self formattedCode ].
+	
 	interval := self sourceInterval.
 	interval ifEmpty: [ ^ '' ].
 	

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -17,7 +17,8 @@ Class {
 
 { #category : #'temp vars' }
 OCRequestorScope >> allTemps [
-	^#()
+	"the requestor has the temps defined in the Requestor as WorkspaceVariables"
+	^requestor bindings associations 
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -374,6 +374,7 @@ OpalCompiler >> compileDoit [
 						in: exception errorCode.
 					^ self compilationContext failBlock value ]
 				ifNil: [ exception pass ] ].
+	ASTCache default at: cm put: ast.
 	^cm
 ]
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -604,10 +604,7 @@ OpalCompiler >> transformDoit [
 	ast := context 
 		ifNil: [ast asDoit] 
 		ifNotNil: [ast asDoitForContext: context].
-	"re-parse to make sure the ast nodes have correct start and stop information"
-	source := ast formattedCode.
-	ast := self parserClass parseMethod: source.
+	"we need to set the compilation context in the new method node"
 	ast compilationContext: self compilationContext.
 	self doSemanticAnalysis
-
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -604,7 +604,10 @@ OpalCompiler >> transformDoit [
 	ast := context 
 		ifNil: [ast asDoit] 
 		ifNotNil: [ast asDoitForContext: context].
-	"we need to set the compilation context in the new method node"
+	"re-parse to make sure the ast nodes have correct start and stop information"
+	source := ast formattedCode.
+	ast := self parserClass parseMethod: source.
 	ast compilationContext: self compilationContext.
 	self doSemanticAnalysis
+
 ]


### PR DESCRIPTION
Imagine you define a binding in a workspace:

temp := 1.

and then you "doit" this code:

self halt

you expect the variable to be shown in the debugger as a temp. 

The PR is a fix to do exactly that.
- we need to make sure to add the doit compiled method to the AST cache
- #allTemps of the Requesterscope needs to return a list of all Variables defined by the Requestor

And it works! it seems there are sometimes odd bindings for "self" generated, we need to check why but that is another PR