### PR TITLE
Several fixes to the parser and syntax feedback

### DIFF
--- a/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
+++ b/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
@@ -12,10 +12,7 @@ RBErrorNodeParserTest >> testFaultyBinaryMessageSendArgumentShouldHaveTheCorrect
 	
 	self assert: node isMessage.
 	self assert: node receiver isParseError.
-	self assert: node selector equals: #+.
-	self assert: node arguments first isVariable.
-	self assert: node arguments first name equals: #arg.
-
+	self assert: node selector equals: #arg.
 ]
 
 { #category : #tests }
@@ -24,11 +21,13 @@ RBErrorNodeParserTest >> testFaultyBinaryMessageSendWithLiteralArgumentShouldHav
 	| node |
 	node := self parserClass parseFaultyExpression: '+ 12'.
 	
-	self assert: node isMessage.
-	self assert: node receiver isParseError.
-	self assert: node selector equals: #+.
-	self assert: node arguments first isLiteralNode.
-	self assert: node arguments first value equals: 12.
+	self assert: node isSequence.
+	
+	self assert: node statements first isUnfinishedStatement.
+	self assert: node statements first statement isParseError.
+	
+	self assert: node statements second isLiteralNode.
+	self assert: node statements second value equals: 12.
 
 ]
 
@@ -40,10 +39,7 @@ RBErrorNodeParserTest >> testFaultyMessageSendShouldHaveTheCorrectMessage [
 	
 	self assert: node isMessage.
 	self assert: node receiver isParseError.
-	self assert: node selector equals: #msg:.
-	self assert: node arguments first isVariable.
-	self assert: node arguments first name equals: #arg.
-
+	self assert: node selector equals: #arg.
 ]
 
 { #category : #tests }
@@ -52,11 +48,12 @@ RBErrorNodeParserTest >> testFaultyMessageSendWithLiteralArgumentShouldHaveTheCo
 	| node |
 	node := self parserClass parseFaultyExpression: 'msg: 12'.
 	
-	self assert: node isMessage.
-	self assert: node receiver isParseError.
-	self assert: node selector equals: #msg:.
-	self assert: node arguments first isLiteralNode.
-	self assert: node arguments first value equals: 12.
+	self assert: node isSequence.
+	
+	self assert: node statements first isParseError.
+
+	self assert: node statements second isLiteralNode.
+	self assert: node statements second value equals: 12.
 
 ]
 
@@ -66,20 +63,41 @@ RBErrorNodeParserTest >> testFaultyMessageSendWithSymbolsArgumentShouldHaveTheCo
 	| node |
 	node := self parserClass parseFaultyExpression: 'msg: #lala: and:12'.
 	
-	self assert: node isMessage.
-	self assert: node receiver isParseError.
-	self assert: node selector equals: #msg:and:.
+	self assert: node isSequence.
+	self assert: node statements first isUnfinishedStatement.
+	self assert: node statements first statement isParseError.
 
-	self assert: node arguments first isLiteralNode.
-	self assert: node arguments first value equals: #lala:.
-
-	self assert: node arguments second isLiteralNode.
-	self assert: node arguments second value equals: 12.
+	self assert: node statements second isMessage.
+	self assert: node statements second receiver value equals: #lala:.
+	self assert: node statements second selector equals: #and:.
+	self assert: node statements second arguments first isLiteralNode.
+	self assert: node statements second arguments first value equals: 12.
 
 ]
 
 { #category : #tests }
-RBErrorNodeParserTest >> testFaultyMethodHasAnErrorNodeAndContinueParsing [
+RBErrorNodeParserTest >> testFaultyMethodConsumesEntireStream [
+
+	| parser |
+	parser := self parserClass newFaulty.
+	parser initializeParserWith: 'ret ^ 1 ^ 2'.
+	parser parseMethod.
+	
+	self assert: parser atEnd
+]
+
+{ #category : #tests }
+RBErrorNodeParserTest >> testFaultyMethodWithSignatureKeepsSignature [
+
+	| node |
+	node := self parserClass parseFaultyMethod: 'ret ^ 1 ^ 2'.
+	
+	self assert: node isMethod.
+	self assert: node selector equals: #ret
+]
+
+{ #category : #tests }
+RBErrorNodeParserTest >> testFaultyMethodWithoutSignatureHasAnErrorNodeAndContinueParsing [
 
 	| node |
 	node := self parserClass parseFaultyMethod: '1 between: 2 and: 3'.

--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -283,7 +283,7 @@ RBParserTest >> testCascadeWithInvalidSelectorRaisesError [
 	self assert: tree messages second selectorNode equals: (RBSelectorNode value: #repared).
 	
 	self assert: tree messages third isFaulty.
-	self assert: tree messages third errorMessage equals: 'Message expected'.
+	self assert: tree messages third errorMessage equals: 'Cascade message expected'.
 	
 	self assert: tree messages last isMessage.
 	self assert: tree messages last receiver name equals: #faulty.
@@ -307,7 +307,7 @@ RBParserTest >> testCascadeWithMissingSelectorRaisesError [
 	self assert: tree messages second selectorNode equals: (RBSelectorNode value: #repared).
 	
 	self assert: tree messages third isFaulty.
-	self assert: tree messages third errorMessage equals: 'Message expected'.
+	self assert: tree messages third errorMessage equals: 'Cascade message expected'.
 	
 	self assert: tree messages last isMessage.
 	self assert: tree messages last receiver name equals: #faulty.

--- a/src/AST-Core/RBParseErrorNode.class.st
+++ b/src/AST-Core/RBParseErrorNode.class.st
@@ -44,6 +44,13 @@ RBParseErrorNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitParseErrorNode: self
 ]
 
+{ #category : #'as yet unclassified' }
+RBParseErrorNode >> arguments [
+	
+	"A parse error node has no arguments"
+	^ #()
+]
+
 { #category : #converting }
 RBParseErrorNode >> asSyntaxErrorNotification [
 	^SyntaxErrorNotification new
@@ -90,6 +97,12 @@ RBParseErrorNode >> isParseError [
 	^true
 ]
 
+{ #category : #'as yet unclassified' }
+RBParseErrorNode >> isUnary [
+	
+	^ false
+]
+
 { #category : #accessing }
 RBParseErrorNode >> name [
 	"be polymorphic with variable nodes"
@@ -100,6 +113,18 @@ RBParseErrorNode >> name [
 { #category : #testing }
 RBParseErrorNode >> needsParenthesis [
 	^ false
+]
+
+{ #category : #'as yet unclassified' }
+RBParseErrorNode >> selector [
+	"A parse error node has an empty selector"
+	^ #''
+]
+
+{ #category : #'as yet unclassified' }
+RBParseErrorNode >> selectorParts [
+	
+	^ #()
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBParseErrorNodeVisitor.class.st
+++ b/src/AST-Core/RBParseErrorNodeVisitor.class.st
@@ -8,6 +8,11 @@ Class {
 }
 
 { #category : #accessing }
+RBParseErrorNodeVisitor >> visitEnglobingErrorNode: aNode [
+	self visitParseErrorNode: aNode
+]
+
+{ #category : #accessing }
 RBParseErrorNodeVisitor >> visitParseErrorNode: aNode [
 	self visitBlock value: aNode
 ]

--- a/src/AST-Core/RBParseErrorNodeVisitor.class.st
+++ b/src/AST-Core/RBParseErrorNodeVisitor.class.st
@@ -16,3 +16,9 @@ RBParseErrorNodeVisitor >> visitEnglobingErrorNode: aNode [
 RBParseErrorNodeVisitor >> visitParseErrorNode: aNode [
 	self visitBlock value: aNode
 ]
+
+{ #category : #accessing }
+RBParseErrorNodeVisitor >> visitUnreachableStatement: aNode [
+
+	self visitEnglobingErrorNode: aNode
+]

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -1092,7 +1092,7 @@ RBParser >> patchLiteralArrayToken [
 				value: currentToken value asSymbol
 				start: currentToken start
 				stop: currentToken stop
-				source: (source copyFrom: currentToken start to: currentToken stop).
+				source: currentToken value asString.
 ]
 
 { #category : #private }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -474,6 +474,7 @@ RBParser >> parseCascadeMessage [
 { #category : #'private-parsing' }
 RBParser >> parseCascadeMessageWithReceiver: receiver [
 	
+	| errorNode |
 	currentToken isIdentifier 
 		ifTrue: [ ^ self parseUnaryMessageWith: receiver].
 		
@@ -486,7 +487,16 @@ RBParser >> parseCascadeMessageWithReceiver: receiver [
 	currentToken isBinary ifTrue: [ 
 		^ self parseBinaryMessageWith: receiver ].
 	
-	^ self parserError: 'Message expected'
+	"At this point we know this is an invalid cascade.
+	Many things can happen next: it could be a closer parenthesis or bracket, the end of the stream, a non-identifier or an empty cascade.
+	For now, if it is a closer return an empty error node.
+	If it is not a closer, consume it"
+	errorNode := self parserError: 'Cascade message expected'.
+	(currentToken value ~= $.
+		and: [ ('])};' includes: currentToken value) not
+			and: [ currentToken isEOF not ] ] )
+				ifTrue: [ self step ].
+	^ errorNode
 ]
 
 { #category : #'private-classes' }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -1036,6 +1036,17 @@ RBParser >> parseStatements: pragmaBoolean into: aSequenceNode [
 
 { #category : #'private-parsing' }
 RBParser >> parseStatements: pragmaBoolean into: aSequenceNode until: aBlock [
+	
+	self parseTemporariesInto: aSequenceNode.
+	
+	^self
+		parseStatementList: pragmaBoolean
+		into: aSequenceNode
+		until: aBlock
+]
+
+{ #category : #'private-parsing' }
+RBParser >> parseTemporariesInto: aSequenceNode [
 	| temps leftBar rightBar errorNode startToken |
 	temps := OrderedCollection new.
 	leftBar := rightBar := nil.
@@ -1061,11 +1072,7 @@ RBParser >> parseStatements: pragmaBoolean into: aSequenceNode until: aBlock [
 							[rightBar := (leftBar := currentToken start) + 1.
 							self step]]].
 				
-	aSequenceNode leftBar: leftBar temporaries: temps rightBar: rightBar.
-	^self
-		parseStatementList: pragmaBoolean
-		into: aSequenceNode
-		until: aBlock
+	aSequenceNode leftBar: leftBar temporaries: temps rightBar: rightBar
 ]
 
 { #category : #'private-parsing' }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -74,12 +74,7 @@ RBParser class >> parseFaultyExpression: aString [
 RBParser class >> parseFaultyMethod: aString [
 	"parse aString even if syntactically incorrect. Instead of raising an error, we create an AST with RB RBParseErrorNode"
 
-	| ast |
-	ast := self parseMethod: aString onError: self errorNodeBlock.
-	"make sure to return a RBMethodNode"
-	^ ast class == RBMethodNode
-		ifFalse: [ (RBMethodNode selector: #faulty body: ast asSequenceNode) source: aString ]
-		ifTrue: [ ast ]
+	^ self parseMethod: aString onError: self errorNodeBlock
 ]
 
 { #category : #parsing }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -998,40 +998,10 @@ RBParser >> parseStatementList: pragmaBoolean into: sequenceNode until: aBlock [
 
 { #category : #'private-parsing' }
 RBParser >> parseStatements: pragmaBoolean [
-	^ self parseStatements: pragmaBoolean into: self sequenceNodeClass new
-]
-
-{ #category : #'private-parsing' }
-RBParser >> parseStatements: pragmaBoolean into: aSequenceNode [
-	| temps leftBar rightBar errorNode startToken |
-	temps := OrderedCollection new.
-	leftBar := rightBar := nil.
-	currentToken isBinary 
-		ifTrue: 
-			[currentToken value = #| 
-				ifTrue: 
-					[ startToken := currentToken.
-					leftBar := currentToken start.
-					self step.
-					temps := self parseTemps.
-					(currentToken isBinary and: [currentToken value = #|]) 
-						ifFalse: [ errorNode :=  self parseEnglobingError: temps with: startToken errorMessage: '''|'' expected'.
-									 aSequenceNode addFaultyNode: errorNode.
-									 temps := OrderedCollection new.
-									 leftBar := nil.
-								    ]
-						ifTrue: [ rightBar := currentToken start ].
-					self step]
-				ifFalse: 
-					[currentToken value = #'||' 
-						ifTrue: 
-							[rightBar := (leftBar := currentToken start) + 1.
-							self step]]].
-	^self parseStatementList: pragmaBoolean
-		into: (aSequenceNode 
-				leftBar: leftBar
-				temporaries: temps
-				rightBar: rightBar)
+	^ self
+		parseStatements: pragmaBoolean
+		into: self sequenceNodeClass new
+		until: [ false "No extra condition, just until the end of the stream" ]
 ]
 
 { #category : #'private-parsing' }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -33,6 +33,20 @@ RBParser class >> errorNodeBlock [
 	^ [ :aString :position :parser| parser parseErrorNode: aString ]
 ]
 
+{ #category : #'instance creation' }
+RBParser class >> newFaulty [
+	
+	^ self newWithErrorBlock: self errorNodeBlock
+]
+
+{ #category : #'instance creation' }
+RBParser class >> newWithErrorBlock: aBlock [
+	
+	^ self new
+		errorBlock: aBlock;
+		yourself
+]
+
 { #category : #parsing }
 RBParser class >> parseExpression: aString [ 
 	^self parseExpression: aString onError: nil

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -399,7 +399,12 @@ RBParser >> parseBlock [
 	self addCommentsTo: node.		
 	node left: startToken start.
 	node body: self sequenceNodeClass new.
-	(self parseStatements: false into: node body).
+	
+	self
+		parseStatements: false
+		into: node body
+		until: [ currentToken isSpecial
+			and: [ currentToken value = $] ] ].
 	
 	(currentToken isSpecial and: [currentToken value = $]])
 		ifFalse: [ ^ self parseEnglobingError: node body statements with: startToken errorMessage: ''']'' expected'].
@@ -721,7 +726,7 @@ RBParser >> parseMethod [
 		sequenceNode := self sequenceNodeClass new.
 		methodNode body: sequenceNode ].
 	
-	(self parseStatements: true into: methodNode body).
+	self parseStatements: true into: methodNode body until: [ false ].
 		
 	pragmas ifNotNil: [ methodNode pragmas: pragmas ].
 	^methodNode
@@ -857,7 +862,7 @@ RBParser >> parsePrimitiveObject [
 			currentToken value = $( ifTrue: [^self parseParenthesizedExpression].
 			currentToken value = ${ ifTrue: [^self parseArray]].
 	errorNode := self parserError: 'Variable or expression expected'.
-	errorNode isParseError ifFalse: [ self step ]. 
+	self step. 
 	^errorNode.
 ]
 

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -878,53 +878,122 @@ RBParser >> parsePrimitiveValueLiteral [
 ]
 
 { #category : #'private-parsing' }
-RBParser >> parseStatementList: pragmaBoolean into: sequenceNode [ 
-	| statements return periods returnPosition node |
+RBParser >> parseStatementInto: statementList periodList: periods [
+
+	| returnPosition node |
+	"If the current statement starts with ^, parse it as a return + an expression.
+	Otherwise just parse it as an expression.
+	Expressions start with assignments, which have lower precedence"
+	(currentToken isSpecial and: [ currentToken value = $^ ])
+		ifTrue: [ 
+			returnPosition := currentToken start.
+			self step.
+			node := self returnNodeClass
+				        return: returnPosition
+				        value: self parseAssignment ]
+		ifFalse: [ node := self parseAssignment ].
+
+	"At this point we have parsed a full statement.
+	Next we should have the end of the statement
+	  - a dot or
+	  - a scope closer e.g., )]} or
+	  -  or the end of the stream.
+	If it is neither, we should mark our statement as unfinished statement."
+	(currentToken value ~= $. 
+		and: [ ('])}' includes: currentToken value) not
+			and: [ currentToken isEOF not ] ] ) ifTrue: [
+		self parserError: 'End of statement expected'.
+		node := RBUnfinishedStatementErrorNode
+			content: { node }
+			start: node start
+			stop: node stop
+			errorMessage: 'End of statement expected'
+	].
+
+	"Then consume all dots and comments coming after this well formed statement, if there was any"
+	(currentToken isSpecial and: [ currentToken value = $. ]) ifTrue: [ 
+		periods add: currentToken start.
+		self step.
+		self addCommentsTo: node ].
+
+	[ currentToken isSpecial and: [ currentToken value = $. ] ] 
+		whileTrue: [ 
+			periods add: currentToken start.
+			self step ].
+
+	"If the previous node in the statement list is a return node, mark this node as unreachable"
+	
+	(statementList notEmpty and: [ statementList last isReturn ]) ifTrue: [
+		self parserError: 'Unreachable code'.
+		node := RBUnreachableStatementErrorNode
+			content: { node }
+			start: node start
+			stop: node stop
+			errorMessage: 'Unreachable code' ].
+
+	"Commit the statement to the statements list"
+	statementList add: node
+	
+]
+
+{ #category : #'private-parsing' }
+RBParser >> parseStatementList: pragmaBoolean into: sequenceNode [
+
+	| statements return periods |
 	return := false.
 	statements := sequenceNode statements.
 	periods := OrderedCollection new.
+
 	self addCommentsTo: sequenceNode.
-	pragmaBoolean ifTrue: [self parsePragmas].
-	[currentToken isSpecial and: [currentToken value = $.]] whileTrue: 
-		[periods add: currentToken start.
-		self step].
-	[self atEnd 
-		or: [currentToken isSpecial and: ['])}' includes: currentToken value] ]] 
-			whileFalse: [
-				return ifTrue: [ 
-					(self parserError: 'End of statement list encountered') 
-						ifNotNil: [ :errorNode | 
-								statements add: errorNode. 
-								sequenceNode statements: statements.
-								sequenceNode periods: periods.
-								self step.
-								^sequenceNode]
-					].
-				(currentToken isSpecial and: [currentToken value = $^]) 
-					ifTrue: 
-						[returnPosition := currentToken start.
-						self step.
-						node := self returnNodeClass return: returnPosition
-									value: self parseAssignment.
-						statements add: node.
-						return := true]
-					ifFalse: [node := self parseAssignment.
-								statements add: node ].
-				(currentToken isSpecial and: [currentToken value = $.]) 
-					ifTrue: 
-						[periods add: currentToken start.
-						self step.
-						self addCommentsTo: node]
-					ifFalse: [return := true].
-				[currentToken isSpecial and: [currentToken value = $.]] whileTrue: 
-					[periods add: currentToken start.
-					self step]
-				].
-	statements notEmpty ifTrue: [self addCommentsTo: statements last].
+
+	pragmaBoolean ifTrue: [ self parsePragmas ].
+
+	[ currentToken isSpecial and: [ currentToken value = $. ] ] 
+		whileTrue: [ 
+			periods add: currentToken start.
+			self step ].
+
+	[  self atEnd or: [ 
+		currentToken isSpecial and: [ '])}' includes: currentToken value ] ] ] 
+			whileFalse: [ 
+				self parseStatementInto: statements periodList: periods ].
+
+	statements notEmpty ifTrue: [ self addCommentsTo: statements last ].
 	sequenceNode
 		statements: statements;
 		periods: periods.
-	^sequenceNode
+	^ sequenceNode
+]
+
+{ #category : #'private-parsing' }
+RBParser >> parseStatementList: pragmaBoolean into: sequenceNode until: aBlock [
+
+	"Parse a list of statements and set those statetements to a sequence node.
+	Stop parsing when we finish the current scope.
+	Different scopes such as blocks or methods can decide different stop conditions."
+
+	| statements return periods |
+	return := false.
+	statements := sequenceNode statements.
+	periods := OrderedCollection new.
+
+	self addCommentsTo: sequenceNode.
+
+	pragmaBoolean ifTrue: [ self parsePragmas ].
+
+	[ currentToken isSpecial and: [ currentToken value = $. ] ] 
+		whileTrue: [ 
+			periods add: currentToken start.
+			self step ].
+
+	[  self atEnd or: [ aBlock value ] ] whileFalse: [ 
+		self parseStatementInto: statements periodList: periods ].
+
+	statements notEmpty ifTrue: [ self addCommentsTo: statements last ].
+	sequenceNode
+		statements: statements;
+		periods: periods.
+	^ sequenceNode
 ]
 
 { #category : #'private-parsing' }
@@ -963,6 +1032,40 @@ RBParser >> parseStatements: pragmaBoolean into: aSequenceNode [
 				leftBar: leftBar
 				temporaries: temps
 				rightBar: rightBar)
+]
+
+{ #category : #'private-parsing' }
+RBParser >> parseStatements: pragmaBoolean into: aSequenceNode until: aBlock [
+	| temps leftBar rightBar errorNode startToken |
+	temps := OrderedCollection new.
+	leftBar := rightBar := nil.
+	currentToken isBinary 
+		ifTrue: 
+			[currentToken value = #| 
+				ifTrue: 
+					[ startToken := currentToken.
+					leftBar := currentToken start.
+					self step.
+					temps := self parseTemps.
+					(currentToken isBinary and: [currentToken value = #|]) 
+						ifFalse: [ errorNode :=  self parseEnglobingError: temps with: startToken errorMessage: '''|'' expected'.
+									 aSequenceNode addFaultyNode: errorNode.
+									 temps := OrderedCollection new.
+									 leftBar := nil.
+								    ]
+						ifTrue: [ rightBar := currentToken start ].
+					self step]
+				ifFalse: 
+					[currentToken value = #'||' 
+						ifTrue: 
+							[rightBar := (leftBar := currentToken start) + 1.
+							self step]]].
+				
+	aSequenceNode leftBar: leftBar temporaries: temps rightBar: rightBar.
+	^self
+		parseStatementList: pragmaBoolean
+		into: aSequenceNode
+		until: aBlock
 ]
 
 { #category : #'private-parsing' }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -464,28 +464,29 @@ RBParser >> parseCascadeMessage [
 			newMessage := nil.
 			self step.
 			self saveCommentsDuring:[
-			newMessage := currentToken isIdentifier 
-						ifTrue: [self parseUnaryMessageWith: receiver]
-						ifFalse: 
-							[currentToken isKeyword 
-								ifTrue: [self parseKeywordMessageWith: receiver]
-								ifFalse: 
-									[| temp |
-									currentToken isLiteralToken ifTrue: [self patchNegativeLiteral].
-			"Upon encountering an error in the cascade, it stores an error node as it would store a message node and continues the parsing of the cascade.
-			 This can allow the possibility of fixing the cascade simply by replacing the false node by another."
-									currentToken isBinary ifFalse: 
-										[ temp := self parserError: 'Message expected'.
-										  (currentToken isSpecial and: [currentToken value = $;]) ifFalse: [self step.].
-										  temp.]
-									ifTrue: 
-										[temp := self parseBinaryMessageWith: receiver.
-										 temp == receiver ifTrue: 
-											[ self parserError: 'Message expected']. temp]]]].
-					
+				newMessage := self parseCascadeMessageWithReceiver: receiver ].
+				
 		self addCommentsTo: newMessage.
 		messages add: newMessage].
 	^self cascadeNodeClass messages: messages semicolons: semicolons
+]
+
+{ #category : #'private-parsing' }
+RBParser >> parseCascadeMessageWithReceiver: receiver [
+	
+	currentToken isIdentifier 
+		ifTrue: [ ^ self parseUnaryMessageWith: receiver].
+		
+	currentToken isKeyword 
+		ifTrue: [ ^ self parseKeywordMessageWith: receiver].
+
+	currentToken isLiteralToken ifTrue: [ self patchNegativeLiteral ].
+	"Upon encountering an error in the cascade, it stores an error node as it would store a message node and continues the parsing of the cascade.
+	This can allow the possibility of fixing the cascade simply by replacing the false node by another."
+	currentToken isBinary ifTrue: [ 
+		^ self parseBinaryMessageWith: receiver ].
+	
+	^ self parserError: 'Message expected'
 ]
 
 { #category : #'private-classes' }

--- a/src/AST-Core/RBPatternParser.class.st
+++ b/src/AST-Core/RBPatternParser.class.st
@@ -47,7 +47,11 @@ RBPatternParser >> parsePatternBlock: aClass [
 	node left: position.
 	
 	node body: self sequenceNodeClass new.
-	(self parseStatements: false into: node body).
+	self
+		parseStatements: false
+		into: node body
+		until: [ currentToken isSpecial
+			and: [ currentToken value = $} ] ].
 	
 	(currentToken isSpecial and: [currentToken value = $}]) 
 		ifFalse: [ self addParserError: '''}'' expected' to: node body.

--- a/src/AST-Core/RBProgramNodeVisitor.class.st
+++ b/src/AST-Core/RBProgramNodeVisitor.class.st
@@ -170,6 +170,12 @@ RBProgramNodeVisitor >> visitThisContextNode: aThisContextNode [
 ]
 
 { #category : #visiting }
+RBProgramNodeVisitor >> visitUnreachableStatement: anUnreachableStatement [
+	
+	^ self visitEnglobingErrorNode: anUnreachableStatement
+]
+
+{ #category : #visiting }
 RBProgramNodeVisitor >> visitVariableNode: aVariableNode [
 	^ aVariableNode
 ]

--- a/src/AST-Core/RBUnfinishedStatementErrorNode.class.st
+++ b/src/AST-Core/RBUnfinishedStatementErrorNode.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #RBUnfinishedStatementErrorNode,
+	#superclass : #RBEnglobingErrorNode,
+	#category : #'AST-Core-Nodes'
+}
+
+{ #category : #'as yet unclassified' }
+RBUnfinishedStatementErrorNode >> isUnfinishedStatement [
+	
+	^ true
+]
+
+{ #category : #'as yet unclassified' }
+RBUnfinishedStatementErrorNode >> statement [
+	
+	^ content first
+]

--- a/src/AST-Core/RBUnreachableStatementErrorNode.class.st
+++ b/src/AST-Core/RBUnreachableStatementErrorNode.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #RBUnreachableStatementErrorNode,
+	#superclass : #RBEnglobingErrorNode,
+	#category : #'AST-Core-Nodes'
+}

--- a/src/AST-Core/RBUnreachableStatementErrorNode.class.st
+++ b/src/AST-Core/RBUnreachableStatementErrorNode.class.st
@@ -3,3 +3,9 @@ Class {
 	#superclass : #RBEnglobingErrorNode,
 	#category : #'AST-Core-Nodes'
 }
+
+{ #category : #visiting }
+RBUnreachableStatementErrorNode >> acceptVisitor: aVisitor [
+
+	^ aVisitor visitUnreachableStatement: self
+]

--- a/src/EnlumineurFormatter-Tests/EFParseErrorExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFParseErrorExpressionTest.class.st
@@ -33,5 +33,5 @@ EFParseErrorExpressionTest >> testParseError2 [
 	configurationSelector := #basicConfiguration.
 	source := self formatter format: expr.
 	self assert: source equals:
-'1. :='
+'1 . :='
 ]

--- a/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
@@ -140,7 +140,7 @@ OCCompilerNotifyingTest >> testEmptyCaseStatement [
 { #category : #testing }
 OCCompilerNotifyingTest >> testExpectedExpressionInBraceArray [
 	
-	self setUpForErrorsIn: '{ 1. 2 ` End of statement list encountered ->`3 }'.
+	self setUpForErrorsIn: '{ 1. 2 ` End of statement expected ->`3 }'.
 	self enumerateAllSelections.
 	self setUpForErrorsIn: '{ 1. 2. ` Variable or expression expected ->`| x | x}'.
 	self enumerateAllSelections.
@@ -148,7 +148,7 @@ OCCompilerNotifyingTest >> testExpectedExpressionInBraceArray [
 
 { #category : #testing }
 OCCompilerNotifyingTest >> testExtraneousStatementAfterAReturnInABlock [
-	self setUpForErrorsIn: '[ ^1 ` End of statement list encountered ->`2]'.
+	self setUpForErrorsIn: '[ ^1 ` End of statement expected ->`2]'.
 	self enumerateAllSelections.
 ]
 
@@ -228,14 +228,14 @@ OCCompilerNotifyingTest >> testMissingExpressionAfterAReturn [
 { #category : #testing }
 OCCompilerNotifyingTest >> testMissingMessageAfterACascade [
 	
-	self setUpForErrorsIn: 'nil yourself; ` Message expected ->`^ 2'.
+	self setUpForErrorsIn: 'nil yourself; ` Cascade message expected ->`^ 2'.
 	self enumerateAllSelections
 ]
 
 { #category : #testing }
 OCCompilerNotifyingTest >> testMissingPeriodSeparatorBetweenStatements [
 
-	self setUpForErrorsIn: '1 + 2 ` End of statement list encountered ->`^nil'.
+	self setUpForErrorsIn: '1 + 2 ` End of statement expected ->`^nil'.
 	self enumerateAllSelections.
 ]
 

--- a/src/OpalCompiler-Tests/OCCompilerSyntaxErrorNotifyingTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerSyntaxErrorNotifyingTest.class.st
@@ -28,8 +28,8 @@ OCCompilerSyntaxErrorNotifyingTest >> enumerateAllSelections [
 			| expectedNotification expectedNotificationLocation |
 			expectedNotification := (expectedErrors at: n) allButFirst allButLast: 3.
 			expectedNotificationLocation := (expectedErrorPositions at: n) - (morph editor startIndex - 1).
-			self assert: expectedNotificationLocation equals: exc location.
-			self assert: expectedNotification equals: exc errorMessage asString.
+			self assert: exc location equals: expectedNotificationLocation.
+			self assert: exc errorMessage asString equals: expectedNotification.
 			exc return: nil]].
 ]
 

--- a/src/Reflectivity-Tools/ErrorNodeStyler.class.st
+++ b/src/Reflectivity-Tools/ErrorNodeStyler.class.st
@@ -34,6 +34,8 @@ ErrorNodeStyler >> shouldStyleNode: aNode [
 ErrorNodeStyler >> visitEnglobingErrorNode: anEnglobingNode [
 
 	| conf |
+	(anEnglobingNode isKindOf: RBUnreachableStatementErrorNode)
+		ifTrue: [ self haltOnce ].
 	conf := RubConfigurationChange new.
 	conf configurationBlock: [ :text | 
 		| r |
@@ -47,4 +49,10 @@ ErrorNodeStyler >> visitEnglobingErrorNode: anEnglobingNode [
 	textModel announce: conf.
 
 	anEnglobingNode content do: [ :each | self visitNode: each ]
+]
+
+{ #category : #visiting }
+ErrorNodeStyler >> visitUnreachableStatement: anUnreachableStatement [
+
+	^ super visitEnglobingErrorNode: anUnreachableStatement
 ]

--- a/src/Reflectivity-Tools/ErrorNodeStyler.class.st
+++ b/src/Reflectivity-Tools/ErrorNodeStyler.class.st
@@ -5,16 +5,6 @@ Class {
 }
 
 { #category : #defaults }
-ErrorNodeStyler >> borderColor [ 
-	^Color red
-]
-
-{ #category : #'for demo' }
-ErrorNodeStyler >> demo [
-	"statements mes; 2; isNil".
-]
-
-{ #category : #defaults }
 ErrorNodeStyler >> highlightColor [
 	^nil
 ]
@@ -38,4 +28,23 @@ ErrorNodeStyler >> segmentMorphClass [
 { #category : #visiting }
 ErrorNodeStyler >> shouldStyleNode: aNode [
 	^ aNode isParseError
+]
+
+{ #category : #visiting }
+ErrorNodeStyler >> visitEnglobingErrorNode: anEnglobingNode [
+
+	| conf |
+	conf := RubConfigurationChange new.
+	conf configurationBlock: [ :text | 
+		| r |
+		r := self segmentMorphClass from: anEnglobingNode stop to: anEnglobingNode stop + 1.
+		text addSegment: r.
+		r label: (self iconLabelBlock: anEnglobingNode).
+		r icon: (self iconFor: anEnglobingNode).
+		r iconBlock: (self iconBlock: anEnglobingNode).
+		r color: self highlightColor.
+		r borderColor: self borderColor ].
+	textModel announce: conf.
+
+	anEnglobingNode content do: [ :each | self visitNode: each ]
 ]

--- a/src/Reflectivity-Tools/SemanticVariableIconStyler.class.st
+++ b/src/Reflectivity-Tools/SemanticVariableIconStyler.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #defaults }
 SemanticVariableIconStyler >> borderColor [ 
-	^Color red
+	^nil
 ]
 
 { #category : #defaults }

--- a/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
+++ b/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
@@ -388,23 +388,6 @@ RubSmalltalkEditorTest >> testBestNodeWithInvalidPlaygroundParsableError [
 ]
 
 { #category : #'tests-bestNodeIn' }
-RubSmalltalkEditorTest >> testBestNodeWithInvalidPlaygroundUnParsableError [
-	
-	self source: 'fallbackBlock := [^self].
-	node := self bestNodeInTextAreaOnError: fallbackBlock.
-	
-	node isMethod ifFalse: [ 
-		node isValue and: [  node isSymbol ]
-		[ node isMessage ] whileFalse: [ false ]].'.
-	
-	self 
-		positionAfter: 'isMessage ]';
-		assertPlaygroundNodeValue: '''fallbackBlock := [ ^ self ] node := self bestNodeInTextAreaOnError: fallbackBlock node isMethod ifFalse:
-	[ node isValue and: [ node isSymbol ] [  node isMessage ]'''.
-
-]
-
-{ #category : #'tests-bestNodeIn' }
 RubSmalltalkEditorTest >> testBestNodeWithValidBinaryOperation [
 	
 	self source: 'testMethod

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1170,6 +1170,13 @@ SHRBTextStyler >> visitCascadeNode: aCascadeNode [
 ]
 
 { #category : #visiting }
+SHRBTextStyler >> visitEnglobingErrorNode: anEnglobingErrorNode [
+
+	self addStyle: #invalid from: anEnglobingErrorNode stop to: anEnglobingErrorNode stop + 1.
+	anEnglobingErrorNode content do: [:each | self visitNode: each ]
+]
+
+{ #category : #visiting }
 SHRBTextStyler >> visitLiteralArrayNode: aRBLiteralArrayNode [
 	"In a (valid) byte array all elements are of the same type, style the whole contents
 at once, but for ordinary literal arrays, style every node"


### PR DESCRIPTION
This PR introduces several enhancements, fixes and cleanups.
 - refactoring big methods into small ones (specially taking out code from loops to make debugging easier)
 - fixing the parser so it correctly consumes all the stream of tokens
 - fixing the parser so each scope (methods, blocks, curly braces) stop consuming statements as soon as they find the right token

 - extended the faulty parser mode to recognize unfinished statements (e.g., missing dots)
 - extended the faulty parser mode to recognize unreachable statements (i.e., statements following a return)

On the icon style side:
 - englobing errors (unfinished statements, missing closers/openers of parenthesis) only underline the last character
   => less noise
 - unreachable statements are completely underlined
 - fixed the SHOUT syntax highlighter to highlight inside error nodes that wrap normal nodes

A taste of it:
![image](https://user-images.githubusercontent.com/708322/94971459-5c840d00-0507-11eb-8353-91d4ac4af110.png)

Compare to Pharo 8:

![image](https://user-images.githubusercontent.com/708322/94987707-90434f00-0568-11eb-9751-22a686240323.png)

And to Pharo9 previous to this change:

![image](https://user-images.githubusercontent.com/708322/94987710-9afde400-0568-11eb-8316-882080429f59.png)
