### PR TITLE
Playground-Self-Bindings

### DIFF
--- a/src/HeuristicCompletion-Model/CoVariableValueMessageHeuristic.class.st
+++ b/src/HeuristicCompletion-Model/CoVariableValueMessageHeuristic.class.st
@@ -38,8 +38,10 @@ CoVariableValueMessageHeuristic >> valueOfVariable: aName inContext: completionC
 
 	"In the playground, the binding values comes in the bindings of the requestor.
 	If we find in the requestor a binding with the given name, use it, otherwise ignore it."
-	binding := (completionContext doItRequestor bindingOf: aName)
-		ifNil: [ ^ self ].
 	
+	"We check using hasBindingOf: to not create bindings that are not there"
+	(completionContext doItRequestor hasBindingOf: aName) ifFalse:  [ ^ self ].
+	
+	binding := completionContext doItRequestor bindingOf: aName.
 	^ aBlock value: binding value
 ]


### PR DESCRIPTION
The Playground got binding to #self added in some cases (e.g. "Doit" 'self halt' in the playground and then check the playground bindings).

The reason for that is that CoVariableValueMessageHeuristic was directly calling #bindingOf:, which adds the binding if it is not there.

The solution is to first check with  #hasBindingOf: