### PR TITLE
7414-division-of-number-by-array-fails-with-doesNotUnderstand-isZero

### DIFF
--- a/src/Collections-Arithmetic-Tests/CollectionArithmeticTest.class.st
+++ b/src/Collections-Arithmetic-Tests/CollectionArithmeticTest.class.st
@@ -65,6 +65,14 @@ CollectionArithmeticTest >> testAverageWithEmptySet [
 ]
 
 { #category : #tests }
+CollectionArithmeticTest >> testDevision [
+	| collection |
+	collection := #(2 4).
+	self assert: collection / 2 equals: #(1 2).
+	self assert: 10 / #(20) equals: {1/2}
+]
+
+{ #category : #tests }
 CollectionArithmeticTest >> testRunningAverage [
 	| result collection |
 	collection := #(1 1 2 2 3 3).

--- a/src/Collections-Arithmetic-Tests/CollectionArithmeticTest.class.st
+++ b/src/Collections-Arithmetic-Tests/CollectionArithmeticTest.class.st
@@ -8,6 +8,14 @@ Class {
 }
 
 { #category : #tests }
+CollectionArithmeticTest >> testAdd [
+	| collection |
+	collection := #(1 2 3).
+	self assert: collection + 1 equals: #(2 3 4).
+	self assert: 1 + collection  equals: #(2 3 4)
+]
+
+{ #category : #tests }
 CollectionArithmeticTest >> testAverage [
 	| collection |
 	collection := #(1 2 3).

--- a/src/Collections-Arithmetic/Collection.extension.st
+++ b/src/Collections-Arithmetic/Collection.extension.st
@@ -109,6 +109,11 @@ Collection >> floor [
 ]
 
 { #category : #'*Collections-arithmetic-collectors' }
+Collection >> isZero [
+   ^ false
+]
+
+{ #category : #'*Collections-arithmetic-collectors' }
 Collection >> ln [
 	^self collect: [:each | each ln]
 ]


### PR DESCRIPTION
Fixes 7414- implement #isZero- add some tests