### PR TITLE
7367-pragmas-not-needed-textEditorShiftedMenu-fileListContentMenu

### DIFF
--- a/src/Text-Edition/TextEditor.class.st
+++ b/src/Text-Edition/TextEditor.class.st
@@ -2928,7 +2928,7 @@ TextEditor >> setSelectorSearch: aStringOrText [
 
 { #category : #'menu declaration' }
 TextEditor >> shiftedMenuKeyword [
-	^ 'textEditorShiftedMenu'
+	^ #textEditorShiftedMenu
 
 ]
 

--- a/src/Tool-FileList/FileList.class.st
+++ b/src/Tool-FileList/FileList.class.st
@@ -593,7 +593,7 @@ FileList >> fileContentsMenu: aMenu shifted: shifted [
 			for: self reference
 			extraLines: #()].
 
-	aMenu addAllFromPragma: 'fileListContentMenu' target: self.
+	aMenu addAllFromPragma: #fileListContentMenu target: self.
 
 	^ aMenu
 


### PR DESCRIPTION
Both pragmas are actually used, but they are queried using a string. Thus senders of did not find the pragma users...

This PR just changes the users to use a Symbol instead

fixes #7367