### PR TITLE
Fixed #7420. Added transformation rules to some non-transforming deprecations that were identified as automatable in the Deprewriter paper

### DIFF
--- a/src/Glamour-Rubric-Presentations/GLMCompositePresentation.extension.st
+++ b/src/Glamour-Rubric-Presentations/GLMCompositePresentation.extension.st
@@ -7,7 +7,10 @@ GLMCompositePresentation >> pharoMethod [
 
 { #category : #'*glamour-rubric-presentations' }
 GLMCompositePresentation >> pharoPlayground [
-	self deprecated: 'Use #pharoScript instead'.
+	self
+		deprecated: 'Use #pharoScript instead'
+		transformWith: '`@rec pharoPlayground' -> '`@rec pharoScript'.
+	
 	^ self custom: GLMPharoScriptPresentation new
 ]
 
@@ -18,6 +21,9 @@ GLMCompositePresentation >> pharoScript [
 
 { #category : #'*glamour-rubric-presentations' }
 GLMCompositePresentation >> rubricText [
-	self deprecated: 'Use #text instead'.
+	self
+		deprecated: 'Use #text instead'
+		transformWith: '`@rec rubricText' -> '`@rec text'.
+	
 	^ self custom: GLMRubricTextPresentation new
 ]

--- a/src/Metacello-Core/MetacelloGenericProjectSpec.class.st
+++ b/src/Metacello-Core/MetacelloGenericProjectSpec.class.st
@@ -148,11 +148,13 @@ MetacelloGenericProjectSpec >> repositories: aBlock constructor: aVersionConstru
 
 { #category : #querying }
 MetacelloGenericProjectSpec >> repository [
-    | specs |
-    self deprecated: 'Use repositories or repositorySpecs'.
-    (specs := self repositorySpecs) isEmpty
-        ifTrue: [ ^ nil ].
-    ^ specs first
+	self
+		deprecated: 'Use repositories or repositorySpecs'
+		transformWith: '`@rec repository' -> '`@rec repositorySpecs first'.
+
+	^ self repositorySpecs
+		ifEmpty: [ nil ]
+		ifNotEmpty: [ self repositorySpecs first ]
 ]
 
 { #category : #accessing }

--- a/src/Metacello-Core/MetacelloMethodSection.class.st
+++ b/src/Metacello-Core/MetacelloMethodSection.class.st
@@ -9,20 +9,28 @@ Class {
 
 { #category : #accessing }
 MetacelloMethodSection >> attribute [
-    self deprecated: 'Use attributes instead'.
-    self attributes size > 1
-        ifTrue: [ self error: 'invalid use of attribute' ].
-    self attributes isEmpty
-        ifTrue: [ ^ nil ].
-    ^ self attributes first
+	self
+		deprecated: 'Use attributes instead'
+		transformWith: '`@rec attribute' -> '`@rec attributes first'.
+	
+	self attributes size > 1
+		ifTrue: [ self error: 'invalid use of attribute' ].
+
+	^ self attributes 
+		ifEmpty: [ nil ]
+		ifNotEmpty: [ self attributes first ].
 ]
 
 { #category : #accessing }
 MetacelloMethodSection >> attribute: anObject [
-    self deprecated: 'Use attributes: instead'.
-    self attributes size > 1
-        ifTrue: [ self error: 'invalid use of attribute:' ].
-    attributes := OrderedCollection with: anObject
+	self
+		deprecated: 'Use attributes: instead'
+		transformWith: '`@rec attribute: `@arg' -> '`@rec attributes: (OrderedCollection with: `@arg)'.
+	
+	self attributes size > 1
+		ifTrue: [ self error: 'invalid use of attribute:' ].
+	
+	attributes := OrderedCollection with: anObject
 ]
 
 { #category : #printing }

--- a/src/Metacello-Core/MetacelloPlatform.class.st
+++ b/src/Metacello-Core/MetacelloPlatform.class.st
@@ -392,13 +392,14 @@ MetacelloPlatform >> parentDirectoryOf: aFileHandler [
 
 { #category : #caching }
 MetacelloPlatform >> primeStackCacheFor: cacheName doing: noArgBlock defaultDictionary: aDictionary [
-
-	self deprecated: 'use #primeStackCacheWith:doing:'.
+	self
+		deprecated: 'use #primeStackCacheWith:doing:'
+		transformWith: '`@rec primeStackCacheFor: `@arg1 doing: `@arg2 defaultDictionary: `@arg3' -> '`@rec primeStackCacheWith: `@arg3 doing: `@arg2'.
+	
 	self 
 		useStackCacheDuring: [:dict | | cache |
 			cache := dict at: cacheName ifAbsent: [].
-			cache == nil
-				ifTrue: [ 
+			cache ifNil: [ 
 					cache := Dictionary new.
 					dict at: cacheName put: cache ].
 			^noArgBlock value ] 

--- a/src/Metacello-MC/MetacelloAbstractPackageSpec.extension.st
+++ b/src/Metacello-MC/MetacelloAbstractPackageSpec.extension.st
@@ -39,8 +39,13 @@ MetacelloAbstractPackageSpec >> packagesNeedSavingVisited: visitedProjects using
 
 { #category : #'*metacello-mc-querying' }
 MetacelloAbstractPackageSpec >> repository [
-    self deprecated: 'Use repositories or repositorySpecs'.
-    ^ nil
+	self
+		deprecated: 'Use repositories or repositorySpecs'
+		transformWith: '`@rec repository' -> '`@rec repositorySpecs first'.
+
+	^ self repositorySpecs
+		ifEmpty: [ nil ]
+		ifNotEmpty: [ self repositorySpecs first ]
 ]
 
 { #category : #'*metacello-mc' }

--- a/src/Metacello-MC/MetacelloPackageSpec.class.st
+++ b/src/Metacello-MC/MetacelloPackageSpec.class.st
@@ -551,10 +551,13 @@ MetacelloPackageSpec >> repositories: aBlock constructor: aVersionConstructor [
 
 { #category : #querying }
 MetacelloPackageSpec >> repository [
-    self deprecated: 'Use repositories or repositorySpecs'.
-    self repositorySpecs isEmpty
-        ifTrue: [ ^ nil ].
-    ^ self repositorySpecs first
+	self
+		deprecated: 'Use repositories or repositorySpecs'
+		transformWith: '`@rec repository' -> '`@rec repositorySpecs first'.
+	
+	^ self repositorySpecs
+		ifEmpty: [ nil ]
+		ifNotEmpty: [ self repositorySpecs first ].
 ]
 
 { #category : #accessing }

--- a/src/Metacello-ToolBox/MetacelloToolBox.class.st
+++ b/src/Metacello-ToolBox/MetacelloToolBox.class.st
@@ -211,18 +211,19 @@ MetacelloToolBox class >> createBaseline: baselineVersionString for: configurati
 	"
 
     <apiDocumentation>
-    self
-        deprecated:
-            'Use createBaseline:for: repository:requiredProjects:packages:repositories:dependencies:groups: instead'.
-    ^ self
-        createBaseline: baselineVersionString
-        for: configurationBasename
-        repository: repositoryDescription
-        requiredProjects: projectList
-        packages: packageList
-        repositories: #()
-        dependencies: dependencies
-        groups: groups
+	self
+		deprecated: 'Use createBaseline:for:repository:requiredProjects:packages:repositories:dependencies:groups: instead'
+		transformWith: '`@rec createBaseline: `@arg1 for: `@arg2 repository: `@arg3 requiredProjects: `@arg4 packages: `@arg5 dependencies: `@arg6 groups: `@arg7' -> '`@rec createBaseline: `@arg1 for: `@arg2 repository: `@arg3 requiredProjects: `@arg4 packages: `@arg5 repositories: #() dependencies: `@arg6 groups: `@arg7'.
+	
+	^ self
+		createBaseline: baselineVersionString
+		for: configurationBasename
+		repository: repositoryDescription
+		requiredProjects: projectList
+		packages: packageList
+		repositories: #()
+		dependencies: dependencies
+		groups: groups
 ]
 
 { #category : #scripts }

--- a/src/UnifiedFFI-Legacy/Object.extension.st
+++ b/src/UnifiedFFI-Legacy/Object.extension.st
@@ -4,7 +4,10 @@ Extension { #name : #Object }
 Object >> nbCall: fnSpec [
 	"You can override this method if you need to"
 	<ffiCalloutTranslator>
-	self deprecated: 'use ffiCall: instead'.
+	self
+		deprecated: 'use ffiCall: instead'
+		transformWith: '`@rec nbCall: `@arg' -> '`@rec ffiCall: `@arg'.
+	
 	^ (self ffiCalloutIn: thisContext sender)
 		convention: self ffiCallingConvention;
 		function: fnSpec library: self ffiLibraryName
@@ -14,7 +17,10 @@ Object >> nbCall: fnSpec [
 Object >> nbCall: fnSpec module: aModuleNameOrHandle [
 	"You can override this method if you need to"
 	<ffiCalloutTranslator>
-	self deprecated: 'use ffiCall:module: instead'.
+	self
+		deprecated: 'use ffiCall:module: instead'
+		transformWith: '`@rec nbCall: `@arg1 module: `@arg2' -> '`@rec ffiCall: `@arg1 module: `@arg2'.
+	
 	^ (self ffiCalloutIn: thisContext sender)
 		convention: self ffiCallingConvention;
 		function: fnSpec library: aModuleNameOrHandle
@@ -24,7 +30,10 @@ Object >> nbCall: fnSpec module: aModuleNameOrHandle [
 Object >> nbCall: fnSpec module: aModuleNameOrHandle options: callOptions [
 	"You can override this method if you need to"
 	<ffiCalloutTranslator>
-	self deprecated: 'use ffiCall:module:options: instead'.
+	self
+		deprecated: 'use ffiCall:module:options: instead'
+		transformWith: '`@rec nbCall: `@arg1 module: `@arg2 options: `@arg3' -> '`@rec ffiCall: `@arg1 module: `@arg2 options: `@arg3'.
+	
 	^ (self ffiCalloutIn: thisContext sender)
 		convention: self ffiCallingConvention;
 		options: callOptions;
@@ -35,7 +44,10 @@ Object >> nbCall: fnSpec module: aModuleNameOrHandle options: callOptions [
 Object >> nbCall: fnSpec options: callOptions [
 	"You can override this method if you need to"
 	<ffiCalloutTranslator>
-	self deprecated: 'use ffiCall:options: instead'.
+	self
+		deprecated: 'use ffiCall:options: instead'
+		transformWith: '`@rec nbCall: `@arg1 options: `@arg2' -> '`@rec ffiCall: `@arg1 options: `@arg2'.
+	
 	^ (self ffiCalloutIn: thisContext sender)
 		convention: self ffiCallingConvention;
 		options: callOptions;

--- a/src/UnifiedFFI/ExternalAddress.extension.st
+++ b/src/UnifiedFFI/ExternalAddress.extension.st
@@ -370,7 +370,12 @@ ExternalAddress >> readArrayOf: aType until: aBlock [
 
 { #category : #'*UnifiedFFI-Deprecated50' }
 ExternalAddress >> registerAsExternalResource [
-	self deprecated: 'Use #autoRelease instead.' on: '2016-01-22' in: #Pharo5.  
+	self
+		deprecated: 'Use #autoRelease instead.'
+		on: '2016-01-22'
+		in: #Pharo5
+		transformWith: '`@rec registerAsExternalResource' -> '`@rec autoRelease'.
+	  
 	^ self class finalizationRegistry add: self
 ]
 

--- a/src/UnifiedFFI/FFIExternalReference.class.st
+++ b/src/UnifiedFFI/FFIExternalReference.class.st
@@ -58,7 +58,12 @@ FFIExternalReference >> printOn: aStream [
 FFIExternalReference >> registerAsExternalResource [
 	"Note, subclasses should implement #resourceData
 	and #finalizeResourceData: on class side"
-	self deprecated: 'Use #autoRelease instead.' on: '2016-01-22' in: #Pharo5.  
+	self
+		deprecated: 'Use #autoRelease instead.'
+		on: '2016-01-22'
+		in: #Pharo5
+		transformWith: '`@rec registerAsExternalResource' -> '`@rec autoRelease'.
+	 
 	FFIExternalResourceManager addResource: self
 ]
 

--- a/src/UnifiedFFI/FFIStructure.class.st
+++ b/src/UnifiedFFI/FFIStructure.class.st
@@ -379,7 +379,12 @@ FFIStructure class >> structureSize [
 
 { #category : #accessing }
 FFIStructure >> address [
-	self deprecated: 'Use #getHandle' on: '27 October 2015' in: 'Pharo5'. 
+	self
+		deprecated: 'Use #getHandle'
+		on: '27 October 2015'
+		in: 'Pharo5'
+		transformWith: '`@rec address' -> '`@rec getHandle'.
+	
 	^ self getHandle
 ]
 


### PR DESCRIPTION
I have added transformation rules to the deprecation messages of the following 16 methods:

* GLMCompositePresentation >> pharoPlayground
* GLMCompositePresentation >> rubricText
* MetacelloGenericProjectSpec >> repository
* MetacelloMethodSection >> attribute
* MetacelloMethodSection >> attribute:
* MetacelloPlatform >> primeStackCacheFor: doing: defaultDictionary:
* MetacelloAbstractPackageSpec >> repository
* MetacelloPackageSpec >> repository
* MetacelloToolBox class >> createBaseline: for: repository: requiredProjects: packages: dependencies: groups:
* Object >> nbCall:
* Object >> nbCall: module:
* Object >> nbCall: module: options:
* Object >> nbCall: options:
* ExternalAddress >> registerAsExternalResource
* FFIExternalReference >> registerAsExternalResource
* FFIStructure >> address

Out of 42 deprecated methods of Pharo 8 that were identified as automatable in our Deprewriter paper, only those 16 had to be edited in Pharo 9. The other 26 methods were already fixed.

6 methods were already supplied with transformation rules:

* GLMTransmission >> fromOutside:
* GLMTransmission >> toOutside:
* GTSpotter >> isEmpty
* SignalLogger >> handle:
* StringSignal class >> log:
* WrapperSignal class >> log:

19 methods were deprecated in Pharo 8 and removed in Pharo 9:

* Archive >> canWriteToFileNamed:
* Archive >> writeToFileNamed:
* Base64MimeConverter class >> mimeDecodeToBytes:
* Class >> subclass:layout:slots:classVariables:category:
* Class >> subclass:layout:slots:classVariables:poolDictionaries:category:
* Class >> subclass:slots:classVariables:category:
* Class >> subclass:slots:classVariables:poolDictionaries:category:
* ExternalObject >> registerAsExternalResource
* GTSpotterStep >> isEmpty
* Morph >> asSpAdapter
* SpDropListPresenter >> whenSelectionIndexChangedDo:
* SpPresenter >> newMultiColumnList
* SpPresenter >> newTab
* SpPresenter >> newTabManager
* SystemNavigation >> allCallsOn:from:
* SystemNavigation >> allLocalCallsOn:ofClass:
* SystemNavigation >> allReferencesToPool:
* SystemNavigation >> allUnreferencedClassVariablesOf:
* SystemNavigation >> isUsedClass:

And there is 1 method the deprecation message of which was removed in Pharo 9:

* SpPresenter >> newTree

-------------

**Total:** 16 + 6 + 19 + 1 =42