### PR TITLE
betterName-isSharedLiteral

### DIFF
--- a/src/Collections-Native/ByteArray.class.st
+++ b/src/Collections-Native/ByteArray.class.st
@@ -213,8 +213,7 @@ ByteArray >> isLiteral [
 ]
 
 { #category : #testing }
-ByteArray >> isSharedLiteral [
-	"Can this Literal be shared between methods when doing 'ImageCleaner shareLiterals'?"
+ByteArray >> isReadOnlyLiteral [
 	^self isLiteral
 ]
 

--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -261,15 +261,14 @@ Array >> isLiteral [
 	^self class == Array and: [self allSatisfy: [:each | each isLiteral]]
 ]
 
+{ #category : #testing }
+Array >> isReadOnlyLiteral [
+	^self isLiteral
+]
+
 { #category : #'self evaluating' }
 Array >> isSelfEvaluating [
 	^ (self allSatisfy: [:each | each isSelfEvaluating]) and: [self class == Array]
-]
-
-{ #category : #testing }
-Array >> isSharedLiteral [
-	"Can this Literal be shared between methods when doing 'ImageCleaner shareLiterals'?"
-	^self isLiteral
 ]
 
 { #category : #comparing }

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1863,8 +1863,7 @@ String >> isPatternVariable [
 ]
 
 { #category : #testing }
-String >> isSharedLiteral [
-	"Can this Literal be shared between methods when doing 'ImageCleaner shareLiterals'?"
+String >> isReadOnlyLiteral [
 	^self isLiteral
 ]
 

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1273,6 +1273,12 @@ Object >> isPoint [
 	^ false
 ]
 
+{ #category : #testing }
+Object >> isReadOnlyLiteral [
+	"Literals with a textual representation in the method source are compiled read-only"
+	^false
+]
+
 { #category : #'write barrier' }
 Object >> isReadOnlyObject [
 	"Answer if the receiver is read-only.
@@ -1293,12 +1299,6 @@ Object >> isRectangle [
 { #category : #'self evaluating' }
 Object >> isSelfEvaluating [
 	^ self isLiteral
-]
-
-{ #category : #testing }
-Object >> isSharedLiteral [
-	"Can this Literal be shared between methods when doing 'ImageCleaner shareLiterals'?"
-	^false
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Core/IRTranslator.class.st
+++ b/src/OpalCompiler-Core/IRTranslator.class.st
@@ -250,8 +250,7 @@ IRTranslator >> visitPushInstVar: instVar [
 IRTranslator >> visitPushLiteral: lit [
 	| literal |
 	literal := lit literal.
-	"all potentially shared literals are compiled read only"
-	(literal isSharedLiteral) ifFalse: [ ^ gen pushLiteral: literal ].
+	(literal isReadOnlyLiteral) ifFalse: [ ^ gen pushLiteral: literal ].
 	Smalltalk vm supportsWriteBarrier ifFalse: [ ^ gen pushLiteral: literal ].
 	"For symbol we need to set explicitly to writable or read-only. 
 	 Compilation to read-only then back to writable keep the object 

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -174,7 +174,7 @@ ImageCleaner >> literalsDo: aBlock [
 	CompiledCode allSubInstancesDo: [ :cm | 
 		cm literals do: [ :literal | 
 			"Symbols are already shared, we can skip them here"
-			(literal isSharedLiteral and: [literal isSymbol not]) ifTrue: [ 
+			(literal isReadOnlyLiteral and: [literal isSymbol not]) ifTrue: [ 
 				aBlock value: literal value: cm ] ] ]
 ]
 


### PR DESCRIPTION
Improve method names for the read-only / shared literals.

instead of having a #isSharedLiteral test, better call it #isReadOnlyLiteral

We can share literals because they are immutable.