### PR TITLE
Cleaning integer division

### DIFF
--- a/src/Collections-Arithmetic/Collection.extension.st
+++ b/src/Collections-Arithmetic/Collection.extension.st
@@ -109,11 +109,6 @@ Collection >> floor [
 ]
 
 { #category : #'*Collections-arithmetic-collectors' }
-Collection >> isZero [
-   ^ false
-]
-
-{ #category : #'*Collections-arithmetic-collectors' }
 Collection >> ln [
 	^self collect: [:each | each ln]
 ]

--- a/src/Kernel/SmallInteger.class.st
+++ b/src/Kernel/SmallInteger.class.st
@@ -106,10 +106,8 @@ SmallInteger >> / aNumber [
 	No Lookup. See Object documentation whatIsAPrimitive."
 
 	<primitive: 10>
-	aNumber isZero ifTrue: [^(ZeroDivide dividend: self) signal].
-	^(aNumber isMemberOf: SmallInteger)
-		ifTrue: [(Fraction numerator: self denominator: aNumber) reduced]
-		ifFalse: [super / aNumber]
+	aNumber = 0 ifTrue: [^(ZeroDivide dividend: self) signal].
+	^super / aNumber
 ]
 
 { #category : #arithmetic }


### PR DESCRIPTION
 - zero division with non-numbers is checked in superclass (and it's already a slow case... No need for optimization)
 - removing special fraction case, it's managed by superclass

Improvement over #7425