### PR TITLE
7416-Fileout-a-protocol-raises-a-DNU

### DIFF
--- a/src/Calypso-SystemPlugins-FileOut-Queries/ClyMethodGroup.extension.st
+++ b/src/Calypso-SystemPlugins-FileOut-Queries/ClyMethodGroup.extension.st
@@ -5,11 +5,9 @@ ClyMethodGroup >> fileOut [
 	| internalStream class |
 	internalStream := (String new: 1000) writeStream.
 	internalStream
-		header;
 		timeStamp;
 		cr.
 	self methods do: [ :each | each origin printMethodChunk: each selector on: internalStream ].
-	internalStream trailer.
 	class := methodQuery scope basisObjects anyOne.
 	^ CodeExporter writeSourceCodeFrom: internalStream baseName: class name , '-' , self name isSt: true
 ]

--- a/src/CodeExport/ClassDescription.extension.st
+++ b/src/CodeExport/ClassDescription.extension.st
@@ -3,13 +3,7 @@ Extension { #name : #ClassDescription }
 { #category : #'*CodeExport' }
 ClassDescription >> fileOutCategory: catName [ 
 
-	| internalStream |
-	internalStream := (String new: 1000) writeStream.
-	internalStream header; timeStamp.
-	self fileOutCategory: catName on: internalStream.
-	internalStream trailer.
-
-	^ CodeExporter writeSourceCodeFrom: internalStream baseName: (self name , '-' , catName) isSt: true.
+	self organization fileOutCategory: catName 
 ]
 
 { #category : #'*CodeExport' }


### PR DESCRIPTION
- ClassDescription>>fileOutCategory: can just call the version in the class organizer. That one is actually tested!
- remove #header and #trailer send from Calypso #fileOut

fixes #7416