### PR TITLE
Skip-HiExamplesTest-testAllExamples

### DIFF
--- a/src/Hiedra-Tests/HiExamplesTest.class.st
+++ b/src/Hiedra-Tests/HiExamplesTest.class.st
@@ -25,7 +25,8 @@ HiExamplesTest >> exampleMethods [
 HiExamplesTest >> testAllExamples [
 	| exampleMethods |
 	
-	self timeLimit: 3 minutes.
+	"test runs sometimes >3 minutes"
+	self skipOnPharoCITestingEnvironment.
 	
 	exampleMethods := self exampleMethods.
 	self deny: exampleMethods isEmpty.


### PR DESCRIPTION
This PR makes sure to not rum HiExamplesTest>>#testAllExamples on the CI. It runs very slowly often.

fixes  #7256