### PR TITLE
7470 fluid class a class definition can be expanded

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyClassDefinitionContext.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassDefinitionContext.class.st
@@ -3,28 +3,3 @@ Class {
 	#superclass : #ClySourceCodeContext,
 	#category : #'Calypso-SystemTools-Core-Editors-Classes'
 }
-
-{ #category : #testing }
-ClyClassDefinitionContext >> isClassSelected [
-
-	^ true
-]
-
-{ #category : #testing }
-ClyClassDefinitionContext >> isMessageSelected [
-	"this is bad because we may want to have implementor in this pane!"
-	^ false
-]
-
-{ #category : #testing }
-ClyClassDefinitionContext >> isMethodSelected [
-
-	^ false
-]
-
-{ #category : #testing }
-ClyClassDefinitionContext >> selectedClass [
-	
-	^ self tool editingClass 
-
-]

--- a/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
@@ -26,8 +26,8 @@ ClyClassDefinitionEditorToolMorph >> applyChanges [
 { #category : #'to sort' }
 ClyClassDefinitionEditorToolMorph >> createTextContext [
 	^self selectedSourceNode
-		ifNil: [ ClyClassDefinitionContext for: self ]
-		ifNotNil: [ :astNode | ClySourceCodeContext for: self selectedNode: astNode]
+		ifNil: [ super createTextContext ]
+		ifNotNil: [ :astNode | ClyClassDefinitionContext for: self selectedNode: astNode]
 ]
 
 { #category : #building }

--- a/src/Calypso-SystemTools-Core/ClyExpandClassDefinitionCommand.class.st
+++ b/src/Calypso-SystemTools-Core/ClyExpandClassDefinitionCommand.class.st
@@ -5,11 +5,6 @@ Class {
 }
 
 { #category : #activation }
-ClyExpandClassDefinitionCommand class >> canBeExecutedInContext: aToolContext [
-	^aToolContext isClassSelected 
-]
-
-{ #category : #activation }
 ClyExpandClassDefinitionCommand class >> sourceCodeMenuActivation [
    <classAnnotation>
    ^SycSourceCodeMenuActivation byRootGroupItemOrder: 1.2 for: ClyClassDefinitionContext


### PR DESCRIPTION
The problem was that new context was not used for selected AST nodes of class definition. 
Here it replaces ClySourceCodeContext in #createTextContext method. 
In addition I cleaned overriding methods of new context class.  ClySourceCodeContext implements them based on AST and it was working fine for class AST. No extra logic needed there (at least not for previous changes)
