### PR TITLE
Better way to design HiExamplesTest

### DIFF
--- a/src/Hiedra-Tests/HiExamplesTest.class.st
+++ b/src/Hiedra-Tests/HiExamplesTest.class.st
@@ -1,8 +1,16 @@
 Class {
 	#name : #HiExamplesTest,
 	#superclass : #TestCase,
+	#instVars : [
+		'example'
+	],
 	#category : #'Hiedra-Tests-Model'
 }
+
+{ #category : #tests }
+HiExamplesTest class >> classWithExamplesToTest [
+	^ self
+]
 
 { #category : #testing }
 HiExamplesTest class >> isAbstract [
@@ -10,30 +18,29 @@ HiExamplesTest class >> isAbstract [
 ]
 
 { #category : #tests }
-HiExamplesTest >> exampleClassToTest [
-	^ self subclassResponsibility
+HiExamplesTest class >> testSelectors [
+
+	^ self classWithExamplesToTest classSide methods 
+			select: [ :each |  (each selector beginsWith: 'example') and: [ each numArgs = 0 ] ]
+			thenCollect: [ :each | each selector ]
+	
+
 ]
 
 { #category : #tests }
-HiExamplesTest >> exampleMethods [
-
-	^ self exampleClassToTest classSide methods select: [ :each | 
-		  (each selector beginsWith: 'example') and: [ each numArgs = 0 ] ]
+HiExamplesTest class >> whichClassIncludesTestSelector: aSymbol [
+	^self classWithExamplesToTest classSide whichClassIncludesSelector: aSymbol
 ]
 
-{ #category : #tests }
-HiExamplesTest >> testAllExamples [
-	| exampleMethods |
+{ #category : #private }
+HiExamplesTest >> performTest [
+	example := self class classWithExamplesToTest perform: testSelector asSymbol
+]
+
+{ #category : #private }
+HiExamplesTest >> tearDown [ 
 	
-	"test runs sometimes >3 minutes"
-	self skipOnPharoCITestingEnvironment.
+	example ifNotNil: [ example close ].
 	
-	exampleMethods := self exampleMethods.
-	self deny: exampleMethods isEmpty.
-	
-	exampleMethods do: [ :each | | anExample |
-		self
-			shouldnt: [ anExample := each methodClass instanceSide perform: each selector ]
-			raise: Error.
-		anExample ifNotNil: [ anExample close ] ]
+	super tearDown
 ]

--- a/src/Hiedra-Tests/HiFastTableExampleTest.class.st
+++ b/src/Hiedra-Tests/HiFastTableExampleTest.class.st
@@ -5,6 +5,6 @@ Class {
 }
 
 { #category : #tests }
-HiFastTableExampleTest >> exampleClassToTest [
+HiFastTableExampleTest class >> classWithExamplesToTest [
 	^ HiFastTableExample
 ]

--- a/src/Hiedra-Tests/HiSpecExampleTest.class.st
+++ b/src/Hiedra-Tests/HiSpecExampleTest.class.st
@@ -5,6 +5,6 @@ Class {
 }
 
 { #category : #tests }
-HiSpecExampleTest >> exampleClassToTest [
+HiSpecExampleTest class >> classWithExamplesToTest [
 	^ HiSpecExample
 ]

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -549,6 +549,11 @@ TestCase class >> testSelectors [
 	^(self selectors select: [ :each | (each beginsWith: 'test') and: [each numArgs isZero]])
 ]
 
+{ #category : #'as yet unclassified' }
+TestCase class >> whichClassIncludesTestSelector: aSymbol [
+	^self whichClassIncludesSelector: aSymbol
+]
+
 { #category : #dependencies }
 TestCase >> addDependentToHierachy: anObject [ 
 	"an empty method. for Composite compability with TestSuite"
@@ -723,7 +728,7 @@ TestCase >> printTestSelectorOn: aStream [
 	testSelector
 		ifNotNil: [ 
 			| class |
-			class := self class whichClassIncludesSelector: testSelector.
+			class := self class whichClassIncludesTestSelector: testSelector.
 			class ~= self class
 				ifTrue: [ self printTestSelectorDefiningClass: class on: aStream ].
 			aStream


### PR DESCRIPTION
This is an example of how we can use a flexible SUnit design for cases like HiExamplesTest. 
SUnit allows to override a logic how to build a test suite for specific test class. Instead of running a collection of "custom validation rules" inside a single test we can represent them as a separate test instances for each rule.   

So here #testSelectors is overridden to return selectors of target example class. And #performTest is overridden to execute corresponding example methods instead of a methods of test class.

Check a suite of those tests:
```Smalltalk
HiSpecExampleTest buildSuite tests
```
<img width="497" alt="Screen Shot 2020-10-11 at 19 08 19" src="https://user-images.githubusercontent.com/8149664/95686365-3fc99280-0bf5-11eb-954a-b18a8beab039.png">

With this approach the time to run HiExamplesTest should not exceed any limit because each example is running as a separate test which is quite fast. 
