### PR TITLE
7481-testSharedSlotNodeArePolymorphicToRBVariableNodes-is-failing-in-default-image

### DIFF
--- a/src/ClassParser-Tests/CDExistingClassDefinitionTest.class.st
+++ b/src/ClassParser-Tests/CDExistingClassDefinitionTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #helpers }
 CDExistingClassDefinitionTest >> classDefinitionString [
 
-	^ CDClassWithFullDefinitionExample definition 
+	^ (ClassDefinitionPrinter oldPharo for: CDClassWithFullDefinitionExample) definitionString
 ]
 
 { #category : #helpers }


### PR DESCRIPTION
Fixes: #7481 using the correct class parser is definitively a must.