### PR TITLE
Cleanup-NautilusRefactoring-Shortcuts

### DIFF
--- a/src/NautilusRefactoring/NautilusRefactoring.class.st
+++ b/src/NautilusRefactoring/NautilusRefactoring.class.st
@@ -20,68 +20,6 @@ Class {
 	#category : #'NautilusRefactoring-Base'
 }
 
-{ #category : #shortcuts }
-NautilusRefactoring class >> buildRefactoringMethodShortcutsOn: aBuilder [
-	<keymap>	
-
-	(aBuilder shortcut: #rename)
-		category: #NautilusGlobalShortcuts
-		default: $r meta,  $m meta
-		do: [:target || scroll |
-				scroll := target methodWidget vScrollValue.
-				target refactor renameMethodFor: target selectedMethod.
-				target methodWidget vScrollValue: scroll]
-		description: 'Rename the seleted method'
-		
-]
-
-{ #category : #shortcuts }
-NautilusRefactoring class >> buildRefactoringShortcutsOn: aBuilder [
-	<keymap>	
-
-	(aBuilder shortcut: #generateAccessors)
-		category: #NautilusGlobalShortcuts
-		default: $h meta,  $a meta
-		do: [:target | target refactor generateAccessors ]
-		description: 'Generate the accessors for the selected class'.
-		
-	(aBuilder shortcut: #generateSubclass)
-		category: #NautilusGlobalShortcuts
-		default: $h meta,  $n meta, $s meta
-		do: [:target | target refactor generateSubclass ]
-		description: 'Generate a subclass for the selected class'.
-]
-
-{ #category : #shortcuts }
-NautilusRefactoring class >> buildSourceCodeShortcutsOn: aBuilder [
-	<keymap>
-	(aBuilder shortcut: #rename)
-		category: #NautilusSourceCodeShortcuts
-		default: $r meta
-		do: [ :target | 
-			target sourceTextModel hasUnacceptedEdits not
-				ifTrue: [ target refactor renameTextSelection ] ]
-		description: 'Rename the current selection'.
-	(aBuilder shortcut: #extractToTemp)
-		category: #NautilusSourceCodeShortcuts
-		default: $x meta shift
-		do: [ :target | 
-			target sourceTextModel hasUnacceptedEdits not
-				ifTrue: [ target refactor extractToTempTextSelection ] ]
-		description: 'Extract to temp the current selection'.
-	(aBuilder shortcut: #extractToMethod)
-		category: #NautilusSourceCodeShortcuts
-		default: $m meta shift
-		do: [ :target | 
-			target sourceTextModel hasUnacceptedEdits not
-				ifTrue: [ target refactor extractToMethodTextSelection ] ]
-		description: 'Extract to method the current selection'.
-	(aBuilder shortcut: #format)
-		category: #NautilusSourceCodeShortcuts
-		default: PharoShortcuts current formatCodeShortcut
-		do: [ :target | target refactor formatSourceCode ]
-]
-
 { #category : #'instance creation' }
 NautilusRefactoring class >> model: model [
 

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -59,7 +59,7 @@ SystemDependenciesTest >> knownBasicToolsDependencies [
 
 	"ideally this list should be empty"	
 	^ #('AST-Core-Tests' 'Athens-Cairo' 'Athens-Core' 
-	#'Athens-Morphic' #NautilusRefactoring #'Refactoring-Critics' #'Reflectivity' #'Reflectivity-Tools' #Shout 'ParametrizedTests' 'HeuristicCompletion-Model')
+	#'Athens-Morphic' #'Refactoring-Critics' #'Reflectivity' #'Reflectivity-Tools' #Shout 'ParametrizedTests' 'HeuristicCompletion-Model')
 ]
 
 { #category : #'known dependencies' }

--- a/src/Tool-Finder/FinderUI.class.st
+++ b/src/Tool-Finder/FinderUI.class.st
@@ -841,11 +841,6 @@ FinderUI >> packagesSelection: aCollection [
 	self finder packagesSelection: aCollection
 ]
 
-{ #category : #accessing }
-FinderUI >> refactor [
-	^ NautilusRefactoring model: self
-]
-
 { #category : #private }
 FinderUI >> resetEnvironment [
 	self triggerEvent: #resetEnvironment

--- a/src/Tool-ProcessBrowser/ProcessBrowser.class.st
+++ b/src/Tool-ProcessBrowser/ProcessBrowser.class.st
@@ -930,12 +930,6 @@ ProcessBrowser >> processNameList [
 			percent , (self prettyNameForProcess: each) ]
 ]
 
-{ #category : #views }
-ProcessBrowser >> refactor [
-
-	^ NautilusRefactoring model: self
-]
-
 { #category : #'process actions' }
 ProcessBrowser >> resumeProcess [
 	selectedProcess


### PR DESCRIPTION
NautilusRefactoring has keyboard shortcut definitons on the class side.

But they are not needed: they require the target tool to implement #refactor, which is implemented only in ProcessBrowser and Finder.

- remove #refactor from those tools
- remove the keyboard defining methods

After this, there are just two references left to NautilusRefactoring