### PR TITLE
7500-Remove-argument-refactoring-from-Calypso-hangs-forever

### DIFF
--- a/src/SystemCommands-MessageCommands/SycMessageDescription.class.st
+++ b/src/SystemCommands-MessageCommands/SycMessageDescription.class.st
@@ -90,6 +90,12 @@ SycMessageDescription >> describesSelector: someSelector withArguments: someArgu
 	^selector = someSelector & (argumentNames = someArgumentNames) 
 ]
 
+{ #category : #accessing }
+SycMessageDescription >> methodClass [
+
+	^ contextUser methodClass
+]
+
 { #category : #operations }
 SycMessageDescription >> requestNewSignature [
 	| methodName dialog |

--- a/src/SystemCommands-MessageCommands/SycMessageOriginHack.class.st
+++ b/src/SystemCommands-MessageCommands/SycMessageOriginHack.class.st
@@ -16,6 +16,7 @@ Class {
 
 { #category : #'instance creation' }
 SycMessageOriginHack class >> of: aMessageDescription [
+
 	^self new 
 		message: aMessageDescription 
 ]
@@ -43,4 +44,10 @@ SycMessageOriginHack >> name [
 { #category : #'hacked methods' }
 SycMessageOriginHack >> parseTreeFor: aSelector [
 	^message
+]
+
+{ #category : #'hacked methods' }
+SycMessageOriginHack >> storeOn: aStream [
+
+	^ message methodClass storeOn: aStream
 ]

--- a/src/SystemCommands-RefactoringSupport-Tests/SycRefactoringStoreOnTest.class.st
+++ b/src/SystemCommands-RefactoringSupport-Tests/SycRefactoringStoreOnTest.class.st
@@ -1,0 +1,51 @@
+Class {
+	#name : #SycRefactoringStoreOnTest,
+	#superclass : #TestCase,
+	#category : #'SystemCommands-RefactoringSupport-Tests'
+}
+
+{ #category : #tests }
+SycRefactoringStoreOnTest >> testRemoveMessageArgumentCommandIsProperlyStoreOn [
+
+	| refactorings |
+	refactorings := SycRemoveMessageArgumentCommand new
+		originalMessage: (MockTreeTableItem >> #title:) ast;
+		argumentName: 'anObject';
+		asRefactorings.
+	
+	self 
+		assert: (String streamContents: [ :s | refactorings storeOn: s ])
+		equals: '((Array new: 1) at: 1 put: (RBRemoveParameterRefactoring removeParameter: ''anObject'' in: MockTreeTableItem selector: #title:); yourself)'
+]
+
+{ #category : #tests }
+SycRefactoringStoreOnTest >> testSSycRenameMessageCommandIsProperlyStoreOn [
+
+	| refactorings node |
+	
+	node := (MockTreeTableItem >> #title:) ast.
+	
+	refactorings := SycRenameMessageCommand new
+		originalMessage: (SycMessageDescription ofMessageNode: node);
+		newSignature: (SycMessageDescription ofMessageNode: node) ;
+		asRefactorings.
+	
+	self 
+		assert: (String streamContents: [ :s | refactorings storeOn: s ])
+		equals: '((Array new: 1) at: 1 put: (RBRenameMethodRefactoring renameMethod: #title: in: MockTreeTableItem to: #title: permutation: ((OrderedCollection new) add: 1; yourself)); yourself)'
+]
+
+{ #category : #tests }
+SycRefactoringStoreOnTest >> testSycAddMessageArgumentCommandIsProperlyStoreOn [
+
+	| refactorings |
+	refactorings := SycAddMessageArgumentCommand new
+		originalMessage: (MockTreeTableItem >> #title:) ast;
+		newSelector: #title:lala:;
+		argumentDefaultValue: 'nil';
+		asRefactorings.
+	
+	self 
+		assert: (String streamContents: [ :s | refactorings storeOn: s ])
+		equals: '((Array new: 1) at: 1 put: (RBAddParameterRefactoring addParameterToMethod: #title: in: MockTreeTableItem newSelector: #title:lala: initializer: ''nil''); yourself)'
+]


### PR DESCRIPTION
Fix issue #7500
The storeOn: of SycMessageOriginHack should not print everything.
The question of the usage of SycMessageOriginHack is still open