### PR TITLE
Add backwards compatibility Pharo9 to Pharo8

### DIFF
--- a/src/OSWindow-Core/OSWindowHandle.class.st
+++ b/src/OSWindow-Core/OSWindowHandle.class.st
@@ -1,0 +1,17 @@
+"
+OSWindowHandle was deprecated in Pharo 9 in favor of OSBackendWindow.
+Replace your usages.
+
+For more information, please check the comment in OSBackendWindow.
+"
+Class {
+	#name : #OSWindowHandle,
+	#superclass : #OSBackendWindow,
+	#category : #'OSWindow-Core-Utilities'
+}
+
+{ #category : #testing }
+OSWindowHandle class >> isDeprecated [
+
+	^ true
+]

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -702,25 +702,17 @@ IRBytecodeGenerator >> send: selector [
 
 { #category : #instructions }
 IRBytecodeGenerator >> send: selector toSuperOf: behavior [
+	| index nArgs |
+	nArgs := selector numArgs.
+	stack pop: nArgs.
+	index := self literalIndexOf: selector.
 
 	(encoder class = EncoderForSistaV1 and: [ inBlock ])
 		ifTrue: [ 
-			| index nArgs |
-			behavior isTrait ifTrue: [ 
-				"Trait methods are copied to the users and only the last literal is updated. 
-				 For directed super send the literal of the super send should be updated too."
-				self error: 'not supported' ].
-			nArgs := selector numArgs.
-			stack pop: nArgs.
 			encoder genPushLiteralVar: (self literalIndexOf: behavior binding).
-			index := self literalIndexOf: selector.
 			encoder genSendDirectedSuper: index numArgs: nArgs ]
 		ifFalse: [ 
-			| index nArgs |
-			nArgs := selector numArgs.
-			stack pop: nArgs.
 			self addLastLiteral: behavior binding.  
-			index := self literalIndexOf: selector.
 			encoder genSendSuper: index numArgs: nArgs ]
 
 ]

--- a/src/System-Platforms/Key.class.st
+++ b/src/System-Platforms/Key.class.st
@@ -1,0 +1,16 @@
+"
+Key was deprecated in Pharo 9 in favor of KeyboardKey.
+Replace your usages.
+
+For more information, please check the comment in KeyboardKey.
+"
+Class {
+	#name : #Key,
+	#superclass : #KeyboardKey,
+	#category : #'System-Platforms-Utilities'
+}
+
+{ #category : #testing }
+Key class >> isDeprecated [
+	^true
+]


### PR DESCRIPTION
During development several changes made Pharo8 and Pharo9 incompatible.
We should reintroduce some deprecations to give one version of compatibility allowing migration.

 - OSWindowHandle should have been deprecated
 - Key should have been deprecated
 - send:toSuperOf: should be able to generate code for traits just as before sista compilation was the main one