### PR TITLE
6509-MessageBrowser-handleClassRenamed-use-undefined-code

### DIFF
--- a/src/Spec2-Tools/MessageBrowser.class.st
+++ b/src/Spec2-Tools/MessageBrowser.class.st
@@ -198,7 +198,7 @@ MessageBrowser >> handleClassRenamed: anAnnouncement [
 			method  methodClass isClassSide
 				ifTrue: [ interestedClassName := interestedClassName , ' class'.
 					interestedClass := interestedClass classSide ].
-			method  class = interestedClassName
+			method methodClass name = interestedClassName
 				ifTrue: [ (interestedClass >> method  selector) ]
 				ifFalse: [ method  ] ].
 	selectedIndex := messageList selectedIndex.

--- a/src/Spec2-Tools/MessageBrowser.class.st
+++ b/src/Spec2-Tools/MessageBrowser.class.st
@@ -191,19 +191,18 @@ MessageBrowser >> findFirstOccurrenceOf: searchedString in: textToSearchIn [
 MessageBrowser >> handleClassRenamed: anAnnouncement [
 	| items selectedIndex |
 	items := self messages
-		collect: [ :rgMethod | 
+		collect: [ :method | 
 			| interestedClassName interestedClass |
 			interestedClassName := anAnnouncement oldName.
 			interestedClass := anAnnouncement classRenamed.
-			rgMethod isMetaSide
+			method  methodClass isClassSide
 				ifTrue: [ interestedClassName := interestedClassName , ' class'.
 					interestedClass := interestedClass classSide ].
-			rgMethod parentName = interestedClassName
-				ifTrue: [ (interestedClass >> rgMethod selector) asFullRingDefinition ]
-				ifFalse: [ rgMethod ] ].
+			method  class = interestedClassName
+				ifTrue: [ (interestedClass >> method  selector) ]
+				ifFalse: [ method  ] ].
 	selectedIndex := messageList selectedIndex.
-	self messages: items.
-	self setSelectedIndex: selectedIndex
+	self messages: items
 ]
 
 { #category : #announcements }


### PR DESCRIPTION
rewrite #handleClassRenamed: to use class API (which is compatible if Ring entities should be used)

fixes #6509 and #4268