### PR TITLE
Doit-RequestorScope

### DIFF
--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -17,7 +17,7 @@ Class {
 
 { #category : #'temp vars' }
 OCRequestorScope >> allTemps [
-	^#()
+	^ requestor bindings associations
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -17,7 +17,7 @@ Class {
 
 { #category : #'temp vars' }
 OCRequestorScope >> allTemps [
-	^ requestor bindings associations
+	^#()
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -338,7 +338,9 @@ OpalCompiler >> compile: textOrString [
 { #category : #private }
 OpalCompiler >> compileDoit [
 	| cm |
-	[ 
+	["We need to first compile with the AST having the text 
+	offset of the original selected code. This way the #location 
+	correct regarding the requestor"
 	self parseDoIt.
 	self transformDoit.
 	self callPlugins.
@@ -353,6 +355,13 @@ OpalCompiler >> compileDoit [
 						in: exception errorCode.
 					^ self compilationContext failBlock value ]
 				ifNil: [ exception pass ] ].
+
+	"We need to rep-parse so that the AST is in sync with the 
+	bytecode to be able to debug the doit. Recompile not needed"
+	ast := RBParser parseMethod: ast formattedCode.
+	ast compilationContext: self compilationContext.
+	self doSemanticAnalysis.
+	ASTCache default at: cm  put: ast. 
 	^cm
 ]
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -340,7 +340,7 @@ OpalCompiler >> compileDoit [
 	| cm |
 	["We need to first compile with the AST having the text 
 	offset of the original selected code. This way the #location 
-	correct regarding the requestor"
+	will be correct regarding the requestor"
 	self parseDoIt.
 	self transformDoit.
 	self callPlugins.
@@ -356,7 +356,7 @@ OpalCompiler >> compileDoit [
 					^ self compilationContext failBlock value ]
 				ifNil: [ exception pass ] ].
 
-	"We need to rep-parse so that the AST is in sync with the 
+	"We need to re-parse so that the AST is in sync with the 
 	bytecode to be able to debug the doit. Recompile not needed"
 	ast := RBParser parseMethod: ast formattedCode.
 	ast compilationContext: self compilationContext.


### PR DESCRIPTION
This is another try to not lose the RequestorScope for doits and to have #allTemps including the RequestorBindings.

- when you have a binding the the playground, the debugger will list it as one of the local variables
- With another change (that will be another PR), these variables can be accessed in the code, as they should be