### PR TITLE
DoIt-access-with-ReadVariable

### DIFF
--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -161,8 +161,8 @@ RBMethodNode >> rewriteTempsForContext: aContext [
 			(contextOnlyTemps includes: tempName)
 				ifTrue:
 					[ rewriter
-						replace: tempName , ' := ``@object' with: 'ThisContext tempNamed: ', tempName asString printString  , ' put: ``@object';
-						replace: tempName with: 'ThisContext tempNamed: ' , tempName asString printString ] ].
+						replace: tempName , ' := ``@object' with: 'ThisContext writeVariableNamed: ', tempName asString printString  , ' value: ``@object';
+						replace: tempName with: 'ThisContext readVariableNamed: ' , tempName asString printString ] ].
 	^ rewriter
 		executeTree: self;
 		tree


### PR DESCRIPTION
We right now use #tempNamed: to read variables in the doit. If we change that to read/write variableNamed, we can use the same
machanism we use now to read outer temps to read the variables defined in the Requestor.

Together with https://github.com/pharo-project/pharo/pull/7511  this will make bindings define by  the requestor readable just
like any other variable if you are in the debugger.