### PR TITLE
Variables-isTempVariable

### DIFF
--- a/src/AST-Core-Tests/RBVariableNodeTest.class.st
+++ b/src/AST-Core-Tests/RBVariableNodeTest.class.st
@@ -17,7 +17,7 @@ RBVariableNodeTest >> testIsDefinedByBlock [
   test.
 	[ :test2 | | test3| test2. test3].
   ^test'.
-	temps := ast allChildren select: [ :each | each isTemp ].
+	temps := ast allChildren select: [ :each | each isTempVariable ].
 	"test is defined by the method"
 	self deny: temps first isDefinedByBlock.
 	self deny: temps second isDefinedByBlock.
@@ -50,7 +50,7 @@ RBVariableNodeTest >> testIsDefinition [
   test := 2.
   test.
   ^test'.
-	temps := ast allChildren select: #isTemp.
+	temps := ast allChildren select: [:each | each isTempVariable].
 	
 	"arguments define variables"
 	self assert: ast arguments first isDefinition.

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -640,7 +640,7 @@ RBProgramNode >> isSuperVariable [
 ]
 
 { #category : #testing }
-RBProgramNode >> isTemp [
+RBProgramNode >> isTempVariable [
 	^ false
 ]
 
@@ -1039,7 +1039,7 @@ RBProgramNode >> superMessages [
 
 { #category : #querying }
 RBProgramNode >> tempVariableReadNodes [
-		^self variableReadNodes select: [:each | each isTemp]
+		^self variableReadNodes select: [:each | each isTempVariable]
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -183,8 +183,8 @@ RBVariableNode >> isSuperVariable [
 ]
 
 { #category : #testing }
-RBVariableNode >> isTemp [
-	^variable isTemp
+RBVariableNode >> isTempVariable [
+	^variable isTempVariable
 ]
 
 { #category : #testing }

--- a/src/Calypso-SystemTools-Core/ClySourceCodeContext.class.st
+++ b/src/Calypso-SystemTools-Core/ClySourceCodeContext.class.st
@@ -116,9 +116,7 @@ ClySourceCodeContext >> isMethodSelected [
 
 { #category : #testing }
 ClySourceCodeContext >> isTempVariableSelected [
-	| node |
-	node := self selectedSourceNode.
-	^node isVariable and: [ node isTemp ]
+	^ self selectedSourceNode isTempVariable
 ]
 
 { #category : #testing }

--- a/src/ClassParser-Tests/CDExistingClassDefinitionTest.class.st
+++ b/src/ClassParser-Tests/CDExistingClassDefinitionTest.class.st
@@ -34,7 +34,7 @@ CDExistingClassDefinitionTest >> testClassNameNodeIsPolymorphicToRBVariableNode 
 	| nameNode |
 	nameNode := classDefinition classNameNode.
 	self assert: nameNode isVariable. "It is polymorphic to class reference nodes in method sources"
-	self deny: nameNode isTemp
+	self deny: nameNode isTempVariable
 ]
 
 { #category : #helpers }
@@ -62,7 +62,7 @@ CDExistingClassDefinitionTest >> testSharedSlotNodeArePolymorphicToRBVariableNod
 	classVarNode := classDefinition sharedSlotNodes first.
 	
 	self assert: classVarNode isVariable.
-	self deny: classVarNode isTemp.
+	self deny: classVarNode isTempVariable.
 	self deny: classVarNode isGlobalVariable.
 	self assert: classVarNode isClassVariable.
 	self deny: classVarNode isInstanceVariable.
@@ -76,7 +76,7 @@ CDExistingClassDefinitionTest >> testSlotNodeArePolymorphicToRBVariableNodes [
 	| slotNode |
 	slotNode := classDefinition slotNodes first.
 	self assert: slotNode isVariable.
-	self deny: slotNode isTemp.
+	self deny: slotNode isTempVariable.
 	self deny: slotNode isGlobalVariable.
 	self deny: slotNode isClassVariable.
 	self assert: slotNode isInstanceVariable.

--- a/src/ClassParser/CDClassNameNode.class.st
+++ b/src/ClassParser/CDClassNameNode.class.st
@@ -41,7 +41,7 @@ CDClassNameNode >> existingClassIfAbsent: aBlock [
 ]
 
 { #category : #testing }
-CDClassNameNode >> isTemp [
+CDClassNameNode >> isTempVariable [
 	"To be polymorphic to RB method nodes"
 	^false
 ]

--- a/src/ClassParser/CDSlotNode.class.st
+++ b/src/ClassParser/CDSlotNode.class.st
@@ -95,7 +95,7 @@ CDSlotNode >> isLiteralVariable [
 ]
 
 { #category : #testing }
-CDSlotNode >> isTemp [
+CDSlotNode >> isTempVariable [
 	"To be polymorphic to RB method nodes"
 	^false
 ]

--- a/src/Deprecated90/RBProgramNode.extension.st
+++ b/src/Deprecated90/RBProgramNode.extension.st
@@ -28,6 +28,15 @@ RBProgramNode >> isSuper [
 ]
 
 { #category : #'*Deprecated90' }
+RBProgramNode >> isTemp [
+	self 
+		deprecated: 'Use #isTempVariable instead.' 
+		transformWith: '`@receiver isTemp' -> '`@receiver isTempVariable'.
+
+	^ self isTempVariable
+]
+
+{ #category : #'*Deprecated90' }
 RBProgramNode >> isThisContext [
 	self 
 		deprecated: 'Use #isThisContextVariable instead.' 

--- a/src/Deprecated90/Variable.extension.st
+++ b/src/Deprecated90/Variable.extension.st
@@ -71,6 +71,14 @@ Variable >> isSuper [
 ]
 
 { #category : #'*Deprecated90' }
+Variable >> isTemp [
+	self 
+		deprecated: 'Use #isTempVariable instead.' 
+		transformWith: '`@receiver isTemp' -> '`@receiver isTempVariable'.
+	^ self isTempVariable
+]
+
+{ #category : #'*Deprecated90' }
 Variable >> isThisContext [
 	self 
 		deprecated: 'Use #isThisContextVariable instead.' 

--- a/src/GeneralRules/ReTemporaryNeitherReadNorWrittenRule.class.st
+++ b/src/GeneralRules/ReTemporaryNeitherReadNorWrittenRule.class.st
@@ -9,8 +9,7 @@ Class {
 
 { #category : #running }
 ReTemporaryNeitherReadNorWrittenRule >> check: aNode forCritiquesDo: aBlock [
-	aNode isVariable ifFalse: [ ^ self ].
-	aNode isTemp ifFalse: [ ^ self ].
+	aNode isTempVariable ifFalse: [ ^ self ].
 	aNode isDefinition ifFalse: [ ^ self ].
 	aNode variable isReferenced ifFalse: [ 
 		aBlock cull: (self critiqueFor: aNode) ]

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -183,13 +183,7 @@ Variable >> isSuperVariable [
 ]
 
 { #category : #testing }
-Variable >> isTemp [
-
-	^ false
-]
-
-{ #category : #testing }
-Variable >> isTemporaryVariable [
+Variable >> isTempVariable [
 	^false
 ]
 

--- a/src/NECompletion/TypingVisitor.class.st
+++ b/src/NECompletion/TypingVisitor.class.st
@@ -30,7 +30,7 @@ TypingVisitor >> visitAssignmentNode: anAssignmentNode [
 	
 	| variableType |
 	super visitAssignmentNode: anAssignmentNode.
-	anAssignmentNode variable isTemp ifFalse: [ ^self ].
+	anAssignmentNode variable isTempVariable ifFalse: [ ^self ].
    (anAssignmentNode value hasProperty: #type) ifFalse: [ ^self ].
 	variableType := anAssignmentNode value propertyAt: #type.
 	typeStack top at: anAssignmentNode variable name put: variableType.

--- a/src/OpalCompiler-Core/TemporaryVariable.class.st
+++ b/src/OpalCompiler-Core/TemporaryVariable.class.st
@@ -26,13 +26,7 @@ TemporaryVariable >> definingNode [
 ]
 
 { #category : #testing }
-TemporaryVariable >> isTemp [
-
-	^ true
-]
-
-{ #category : #testing }
-TemporaryVariable >> isTemporaryVariable [
+TemporaryVariable >> isTempVariable [
 
 	^ true
 ]

--- a/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
@@ -58,7 +58,7 @@ OCASTCheckerTest >> testExamplePrimitiveErrorCode [
 	ast := (OCOpalExamples>>#examplePrimitiveErrorCode) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 
-	self assert: (ast scope lookupVar: 'code') isTemp.
+	self assert: (ast scope lookupVar: 'code') isTempVariable.
 
 	
 ]
@@ -302,8 +302,8 @@ OCASTCheckerTest >> testSingleRemoteTempVar [
 	self assert: (ast scope lookupVar: 'index') scope equals: ast scope.
 	self deny: (ast scope lookupVar: 'block') isEscaping.
 	self assert: (ast scope lookupVar: 'theCollection') isEscaping.
-	self assert: (ast scope lookupVar: 'block') isTemp.
-	self assert: (ast scope lookupVar: 'theCollection') isTemp.
+	self assert: (ast scope lookupVar: 'block') isTempVariable.
+	self assert: (ast scope lookupVar: 'theCollection') isTempVariable.
 	self deny: (ast scope lookupVar: 'theCollection') isInstanceVariable.
 	self deny: (ast scope lookupVar: 'index') isInstanceVariable.
 	self deny: (ast scope lookupVar: 'block') isInstanceVariable
@@ -320,7 +320,7 @@ OCASTCheckerTest >> testsingleRemoteTempVarWhileWithTempNotInlined [
 	self assert: (ast scope lookupVar: 'index') isEscaping.
 	self assert: (ast scope lookupVar: 'index') scope equals: ast scope.
 	self deny: (ast scope lookupVar: 'block') isEscaping.
-	self assert: (ast scope lookupVar: 'block') isTemp
+	self assert: (ast scope lookupVar: 'block') isTempVariable
 ]
 
 { #category : #'testing - variables' }
@@ -334,5 +334,5 @@ OCASTCheckerTest >> testsingleRemoteTempVarWrittenAfterClosedOver [
 	self assert: (ast scope lookupVar: 'index') isWrite.
 	self assert: (ast scope lookupVar: 'index') scope equals: ast scope.
 	self deny: (ast scope lookupVar: 'block') isEscaping.
-	self assert: (ast scope lookupVar: 'block') isTemp
+	self assert: (ast scope lookupVar: 'block') isTempVariable
 ]

--- a/src/Reflectivity-Tests/LinkInstallerTest.class.st
+++ b/src/Reflectivity-Tests/LinkInstallerTest.class.st
@@ -160,7 +160,7 @@ LinkInstallerTest >> testLinkOnTempVar [
 	self assert: link nodes size equals: 2.
 	self assert: (link nodes allSatisfy: [ :node | node isRead ]).
 	self assert: (link nodes allSatisfy: [ :node | node name = #temp ]).
-	self assert: (link nodes allSatisfy: [ :node | node isTemp ]).
+	self assert: (link nodes allSatisfy: [ :node | node isTempVariable ]).
 	link uninstall.
 	self assert: link nodes isEmpty.
 	
@@ -172,7 +172,7 @@ LinkInstallerTest >> testLinkOnTempVar [
 	self assert: link nodes size equals: 2.
 	self assert: (link nodes allSatisfy: [ :node | node isAssignment ]).
 	self assert: (link nodes allSatisfy: [ :node | node variable name = #temp ]).
-	self assert: (link nodes allSatisfy: [ :node | node variable isTemp ]).
+	self assert: (link nodes allSatisfy: [ :node | node variable isTempVariable ]).
 	link uninstall.
 	self assert: link nodes isEmpty.
 	
@@ -201,7 +201,7 @@ LinkInstallerTest >> testLinkOnTempVarForObject [
 	self assert: link nodes size equals: 2.
 	self assert: (link nodes allSatisfy: [ :node | node isRead ]).
 	self assert: (link nodes allSatisfy: [ :node | node name = #temp ]).
-	self assert: (link nodes allSatisfy: [ :node | node isTemp ]).
+	self assert: (link nodes allSatisfy: [ :node | node isTempVariable ]).
 	link uninstall.
 	self assert: link nodes isEmpty.
 	
@@ -213,7 +213,7 @@ LinkInstallerTest >> testLinkOnTempVarForObject [
 	self assert: link nodes size equals: 2.
 	self assert: (link nodes allSatisfy: [ :node | node isAssignment]).
 	self assert: (link nodes allSatisfy: [ :node | node variable name = #temp ]).
-	self assert: (link nodes allSatisfy: [ :node | node variable isTemp ]).
+	self assert: (link nodes allSatisfy: [ :node | node variable isTempVariable ]).
 	link uninstall.
 	self assert: link nodes isEmpty.
 	

--- a/src/Reflectivity/RFVariableReification.class.st
+++ b/src/Reflectivity/RFVariableReification.class.st
@@ -35,6 +35,6 @@ RFVariableReification >> genForLiteralVariable [
 { #category : #generate }
 RFVariableReification >> genForRBVariableNode [
 	
-	entity isTemp ifTrue: [ ^self error: 'Temps can not be reified yet' ]. 
+	entity isTempVariable ifTrue: [ ^self error: 'Temps can not be reified yet' ]. 
 	^RFLiteralVariableNode value: entity binding
 ]

--- a/src/Ring-Core/RGVariable.class.st
+++ b/src/Ring-Core/RGVariable.class.st
@@ -63,7 +63,7 @@ RGVariable >> isReservedVariable [
 ]
 
 { #category : #testing }
-RGVariable >> isTemp [
+RGVariable >> isTempVariable [
 	^false
 ]
 

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1022,7 +1022,7 @@ SHRBTextStyler >> privateStyle: aText [
 SHRBTextStyler >> resolveStyleFor: aVariableNode [
 	aVariableNode binding ifNil: [^#default].
 	aVariableNode isArgumentVariable ifTrue: [ ^#methodArg].
-	aVariableNode isTemp ifTrue: [ ^#tempVar].
+	aVariableNode isTempVariable ifTrue: [ ^#tempVar].
 	aVariableNode isGlobalVariable ifTrue: [ ^#globalVar].
 	"here we should add support for #classVar"
 	aVariableNode isClassVariable ifTrue: [ ^#globalVar].


### PR DESCRIPTION
This is the final renaming of the is* methods of Variables. We still had isTemp, to unify it with all the other checks, we rename is to isTempVariable

All senders are changed, the isTemp methods are deprecated where it makes sense.