### PR TITLE
ScaledDecimal-readOnlyLiteral

### DIFF
--- a/src/Kernel/ScaledDecimal.class.st
+++ b/src/Kernel/ScaledDecimal.class.st
@@ -132,6 +132,11 @@ ScaledDecimal >> isLiteral [
 			(10 raisedTo: scale) \\ denominator = 0]
 ]
 
+{ #category : #testing }
+ScaledDecimal >> isReadOnlyLiteral [
+	^self isLiteral
+]
+
 { #category : #accessing }
 ScaledDecimal >> isSelfEvaluating [
     "Not all scaled decimal are self evaluating, because they print rounded digits."


### PR DESCRIPTION
Scaled Decimals that are literals should be read only