### PR TITLE
Context-printOn-no-isClean

### DIFF
--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1344,7 +1344,8 @@ Context >> printDetails: stream [
 
 { #category : #printing }
 Context >> printOn: aStream [
-	(closureOrNil isNotNil and: [closureOrNil isClean]) ifTrue: 
+	(self methodClass compiler optionCleanBlockClosure and: [
+		closureOrNil isNotNil and: [closureOrNil isClean]]) ifTrue: 
 		[ | selector |
 			selector := self selector ifNil: [ self compiledCode defaultSelector ].
 			aStream 


### PR DESCRIPTION
#isClean is quite slow as it traps DoesNotUnderstand for each bytecode. 

This PR adds a check that we do not use it as long as we are not compiling with clean blocks enabled.

I will add a faster scanner for clean blocks to the backlog (I really do not like this DNU handler based bytecode scanning...)