### PR TITLE
isClean-using-CleanBlockChecker

### DIFF
--- a/src/Debugging-Core/CleanBlockChecker.class.st
+++ b/src/Debugging-Core/CleanBlockChecker.class.st
@@ -1,0 +1,56 @@
+"
+My job is to scan bytecodes to determine if a block is clean or not.
+
+See #isClean
+"
+Class {
+	#name : #CleanBlockChecker,
+	#superclass : #InstructionClient,
+	#instVars : [
+		'isClean'
+	],
+	#category : #'Debugging-Core'
+}
+
+{ #category : #initialization }
+CleanBlockChecker >> interpretNextInstructionUsing: aScanner [ 
+	
+	isClean := true.
+	aScanner interpretNextInstructionFor: self.
+	^isClean
+]
+
+{ #category : #'instruction decoding' }
+CleanBlockChecker >> methodReturnConstant: offset [
+	isClean := false
+]
+
+{ #category : #'instruction decoding' }
+CleanBlockChecker >> methodReturnReceiver [
+	isClean := false
+]
+
+{ #category : #'instruction decoding' }
+CleanBlockChecker >> methodReturnTop [
+	isClean := false
+]
+
+{ #category : #'instruction decoding' }
+CleanBlockChecker >> popIntoReceiverVariable: offset [
+	isClean := false
+]
+
+{ #category : #'instruction decoding' }
+CleanBlockChecker >> pushReceiver [
+	isClean := false
+]
+
+{ #category : #'instruction decoding' }
+CleanBlockChecker >> pushReceiverVariable: offset [
+	isClean := false
+]
+
+{ #category : #'instruction decoding' }
+CleanBlockChecker >> storeIntoReceiverVariable: offset [
+	isClean := false
+]

--- a/src/Kernel-Tests/BlockClosureTest.class.st
+++ b/src/Kernel-Tests/BlockClosureTest.class.st
@@ -152,6 +152,21 @@ BlockClosureTest >> testHasMethodReturn [
 	self assert: [ #(1) do: [ ^self ] ] hasMethodReturn
 ]
 
+{ #category : #'test -testing' }
+BlockClosureTest >> testIsClean [
+	| local |
+	local := #testIsClean.
+	self assert: [] isClean. "closes over nothing at all"
+	self assert: [thisContext] isClean. "we can access the context"
+	self assert: [:a :b| a < b] isClean. "accesses only arguments"
+	self assert: [:a :b| | s | s := a + b. s even] isClean. "accesses only local variables"
+	self deny: [^nil] isClean. "closes over home (^-return)"
+	self deny: [self] isClean. "closes over the receiver"
+	self deny: [super testIsClean] isClean. "closes over the receiver"
+	self deny: [contextOfaBlockContext] isClean. "closes over the receiver (to access the inst var contextOfaBlockContext)"
+	self deny: [local] isClean. "closes over local variable of outer context"
+]
+
 { #category : #tests }
 BlockClosureTest >> testNew [
 	self	should: [Context new: 5] raise: Error.

--- a/src/Kernel/BlockClosure.class.st
+++ b/src/Kernel/BlockClosure.class.st
@@ -353,25 +353,18 @@ BlockClosure >> isClean [
 	"Answer if the receiver does not close-over any variables other than globals, and does
 	 not ^-return (does not close over the home context).  Clean blocks are amenable to
 	 being created at compile-time."
+	| scanner end checker |
 	self numCopiedValues > 0 ifTrue:
 		[^false].
-	self abstractBytecodeMessagesDo:
-		[:msg|
-		(#(	pushReceiver
-			pushReceiverVariable: popIntoReceiverVariable: storeIntoReceiverVariable:
-			methodReturnConstant: methodReturnReceiver methodReturnTop)
-				includes: msg selector) ifTrue:
-					[^false]].
-	^true
 
-	"clean:"
-		"[] isClean"
-		"[:a :b| a < b] isClean"
-	"unclean"
-		"[^nil] isClean"
-		"[self class] isClean"
-		"| v | v := 0.
-		 [v class] isClean"
+	scanner := InstructionStream on: self method.
+	checker := CleanBlockChecker new.
+	end := self method endPC.
+
+	[scanner pc <= end] whileTrue: [
+		(checker interpretNextInstructionUsing: scanner) ifFalse: [^false].
+	].
+	^true
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Tests/OCClosureTest.class.st
+++ b/src/OpalCompiler-Tests/OCClosureTest.class.st
@@ -105,21 +105,6 @@ OCClosureTest >> testEmptyBlockZeroArguments [
 ]
 
 { #category : #testing }
-OCClosureTest >> testIsClean [
-	| local |
-	local := #testIsClean.
-	self assert: [] isClean. "closes over nothing at all"
-	self assert: [thisContext] isClean. "we can access the context"
-	self assert: [:a :b| a < b] isClean. "accesses only arguments"
-	self assert: [:a :b| | s | s := a + b. s even] isClean. "accesses only local variables"
-	self deny: [^nil] isClean. "closes over home (^-return)"
-	self deny: [self] isClean. "closes over the receiver"
-	self deny: [super testIsClean] isClean. "closes over the receiver"
-	self deny: [collection] isClean. "closes over the receiver (to access the inst var collection)"
-	self deny: [local] isClean. "closes over local variable of outer context"
-]
-
-{ #category : #testing }
 OCClosureTest >> testMethodArgument [
 	| temp block |
 	temp := 0.


### PR DESCRIPTION
#isClean was implemented using abstractBytecodeMessagesDo: which is slow due to trapping MessageNotUnderstood and creating messages for every bytecode.

This PR adds a dedicated CleanBlockChecker that checks for the bytecodes and stops scanning as soon as it determines a block to not be clean.

In addition, we move the testIsClean from OCClosureTest to BlockClosureTest and remove the example code from #isClean (the test now has that).