### PR TITLE
Cleanup-referredInstVars

### DIFF
--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -695,24 +695,6 @@ CompiledCode >> readsThisContext [
 	^ self innerCompiledBlocksAnySatisfy: [ :cb | cb readsThisContext]
 ]
 
-{ #category : #accessing }
-CompiledCode >> referredInstVars [
-	| allInstVarNames instVarNames |
-	allInstVarNames := self methodClass allInstVarNames.
-	self isReturnField ifTrue:
-		[^Set with: (allInstVarNames at: self returnField + 1)].
-	instVarNames := Set new.
-	self abstractBytecodeMessagesDo:
-		[:msg|
-		(#(#popIntoReceiverVariable:
-		    #pushReceiverVariable:
-		    #storeIntoReceiverVariable:) includes: msg selector) ifTrue:
-			[instVarNames add: (allInstVarNames at: msg argument + 1)]].
-	^instVarNames
-
-	"Dictionary fromPairs: (Point selectors collect: [:s| { s. (Point >> s) referredInstVars}])".
-]
-
 { #category : #testing }
 CompiledCode >> refersToLiteral: aLiteral [
 	"Answer true if any literal in this method is literal,


### PR DESCRIPTION
referredInstVars has no senders

everything that you might want to do with this is much better done on the level of the First Class Variables that we have now.

referredInstanceVariables
 ^self methodClass  instanceVariables select: [ :each | each usingMethods includes:  self ]

Which then takes into account all kinds of self defined ivars... and returns *objects*, not strings.

Thus we can add a method for this as soon as we have any need...I am sceptical if we really need it, though.