### PR TITLE
Add support for mesh gradients to Athens

### DIFF
--- a/src/Athens-Cairo/AthensAbstractMeshPaintPatch.extension.st
+++ b/src/Athens-Cairo/AthensAbstractMeshPaintPatch.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #AthensAbstractMeshPaintPatch }
+
+{ #category : #'*Athens-Cairo' }
+AthensAbstractMeshPaintPatch >> addToCairoMeshGradientPaint: meshGradientPaint [
+	self subclassResponsibility
+]

--- a/src/Athens-Cairo/AthensCairoMeshGradientPaint.class.st
+++ b/src/Athens-Cairo/AthensCairoMeshGradientPaint.class.st
@@ -1,0 +1,102 @@
+"
+I represent a mesh gradient in the Cairo backend.
+"
+Class {
+	#name : #AthensCairoMeshGradientPaint,
+	#superclass : #AthensCairoPatternPaint,
+	#pools : [
+		'AthensCairoDefinitions'
+	],
+	#category : #'Athens-Cairo-Paints'
+}
+
+{ #category : #paints }
+AthensCairoMeshGradientPaint class >> createMeshGradientWithPatches: aListOfMeshPatches [
+	| paint |
+	paint := self primCreateMesh.
+
+	"note, we do #initialize here because instance was created by primitive"
+	paint initialize; populatePatches: aListOfMeshPatches.
+	^ paint
+]
+
+{ #category : #paints }
+AthensCairoMeshGradientPaint class >> primCreateMesh [
+	^ self ffiCall: #(AthensCairoMeshGradientPaint cairo_pattern_create_mesh () )
+
+]
+
+{ #category : #'mesh pattern commands' }
+AthensCairoMeshGradientPaint >> beginPatch [
+	^ self ffiCall:#( void cairo_mesh_pattern_begin_patch ( cairo_pattern_t  self ))
+		
+]
+
+{ #category : #accessing }
+AthensCairoMeshGradientPaint >> colors: aSequenceOfColors [
+	aSequenceOfColors doWithIndex: [ :color :index |
+		self setCorner: index - 1 color: color
+	]
+]
+
+{ #category : #'mesh pattern commands' }
+AthensCairoMeshGradientPaint >> curveVia: pt1 and: lastControlPoint to: endPoint [
+	self curveViaX: pt1 x Y: pt1 y viaX: lastControlPoint x Y: lastControlPoint y toX: endPoint x Y: endPoint y
+]
+
+{ #category : #'mesh pattern commands' }
+AthensCairoMeshGradientPaint >> curveViaX: x1 Y: y1 viaX: x2 Y: y2 toX: x3 Y: y3 [
+	^ self ffiCall: #(void cairo_mesh_pattern_curve_to(cairo_pattern_t self,
+                                                         double x1,
+                                                         double y1,
+                                                         double x2,
+                                                         double y2,
+                                                         double x3,
+                                                         double y3))
+
+
+]
+
+{ #category : #'mesh pattern commands' }
+AthensCairoMeshGradientPaint >> endPatch [
+	^ self ffiCall:#( void cairo_mesh_pattern_end_patch ( cairo_pattern_t  self ))
+		
+]
+
+{ #category : #'mesh pattern commands' }
+AthensCairoMeshGradientPaint >> lineTo: aPoint [
+	self lineToX: aPoint x asFloat Y: aPoint y asFloat
+]
+
+{ #category : #'mesh pattern commands' }
+AthensCairoMeshGradientPaint >> lineToX: x Y: y [
+	^ self ffiCall:#( void cairo_mesh_pattern_line_to ( cairo_pattern_t self, double x, double y ))
+		
+]
+
+{ #category : #'mesh pattern commands' }
+AthensCairoMeshGradientPaint >> moveTo: aPoint [
+	self moveToX: aPoint x asFloat Y: aPoint y asFloat
+]
+
+{ #category : #'mesh pattern commands' }
+AthensCairoMeshGradientPaint >> moveToX: x Y: y [
+	^ self ffiCall:#( void cairo_mesh_pattern_move_to ( cairo_pattern_t self, double x, double y ))
+		
+]
+
+{ #category : #private }
+AthensCairoMeshGradientPaint >> populatePatches: aListOfMeshPatches [
+	aListOfMeshPatches do: [ :each | each addToCairoMeshGradientPaint: self ]
+]
+
+{ #category : #'mesh pattern commands' }
+AthensCairoMeshGradientPaint >> setCorner: corner_num color: color [
+	self setCorner: corner_num r: color red g: color green b: color blue a: color alpha
+]
+
+{ #category : #'mesh pattern commands' }
+AthensCairoMeshGradientPaint >> setCorner: corner_num r: red g: green b: blue a: alpha [
+	^ self ffiCall:#( void cairo_mesh_pattern_set_corner_color_rgba ( cairo_pattern_t self, uint corner_num, 	double red, double green, double blue, double alpha ))
+		
+]

--- a/src/Athens-Cairo/AthensCairoSurface.class.st
+++ b/src/Athens-Cairo/AthensCairoSurface.class.st
@@ -464,6 +464,11 @@ AthensCairoSurface >> createLinearGradient: aColorRamp start: aStartPoint stop: 
 	
 ]
 
+{ #category : #paints }
+AthensCairoSurface >> createMeshGradientWithPatches: aListOfMeshPatches [
+	^ AthensCairoMeshGradientPaint createMeshGradientWithPatches: aListOfMeshPatches
+]
+
 { #category : #creation }
 AthensCairoSurface >> createPath: aPathCreatingBlock [
 	^ builder createPath:  aPathCreatingBlock 

--- a/src/Athens-Cairo/CoonsPaintPatch.extension.st
+++ b/src/Athens-Cairo/CoonsPaintPatch.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : #CoonsPaintPatch }
+
+{ #category : #'*Athens-Cairo' }
+CoonsPaintPatch >> addToCairoMeshGradientPaint: meshGradientPaint [
+	meshGradientPaint
+		beginPatch;
+		moveTo: (controlPoints at: 1);
+		curveVia: (controlPoints at: 2) and: (controlPoints at: 3) to: (controlPoints at: 4);
+		curveVia: (controlPoints at: 5) and: (controlPoints at: 6) to: (controlPoints at: 7);
+		curveVia: (controlPoints at: 8) and: (controlPoints at: 9) to: (controlPoints at: 10);
+		curveVia: (controlPoints at: 11) and: (controlPoints at: 12) to: (controlPoints at: 1);
+		setCorner: 0 color: colors first;
+		setCorner: 1 color: colors second;
+		setCorner: 2 color: colors third;
+		setCorner: 3 color: colors fourth;
+		endPatch
+]

--- a/src/Athens-Cairo/GenericPaintPatch.extension.st
+++ b/src/Athens-Cairo/GenericPaintPatch.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #GenericPaintPatch }
+
+{ #category : #'*Athens-Cairo' }
+GenericPaintPatch >> addToCairoMeshGradientPaint: meshGradientPaint [
+	meshGradientPaint beginPatch.
+	[ 
+		buildBlock value: meshGradientPaint
+	] ensure: [ meshGradientPaint endPatch ].
+
+]

--- a/src/Athens-Cairo/TrianglePaintPatch.extension.st
+++ b/src/Athens-Cairo/TrianglePaintPatch.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #TrianglePaintPatch }
+
+{ #category : #'*Athens-Cairo' }
+TrianglePaintPatch >> addToCairoMeshGradientPaint: meshGradientPaint [
+	meshGradientPaint
+		beginPatch;
+		moveTo: controlPoints first;
+		lineTo: controlPoints second;
+		lineTo: controlPoints third;
+		setCorner: 0 color: colors first;
+		setCorner: 1 color: colors second;
+		setCorner: 2 color: colors third;
+		endPatch
+]

--- a/src/Athens-Core/AthensAbstractMeshPaintPatch.class.st
+++ b/src/Athens-Core/AthensAbstractMeshPaintPatch.class.st
@@ -1,0 +1,37 @@
+"
+I am a patch in a mesh gradient.
+"
+Class {
+	#name : #AthensAbstractMeshPaintPatch,
+	#superclass : #Object,
+	#instVars : [
+		'controlPoints',
+		'colors'
+	],
+	#category : #'Athens-Core-Paints'
+}
+
+{ #category : #constructor }
+AthensAbstractMeshPaintPatch class >> controlPoints: controlPoints colors: colors [
+	^ self new controlPoints: controlPoints; colors: colors; yourself
+]
+
+{ #category : #accessing }
+AthensAbstractMeshPaintPatch >> colors [
+	^ colors
+]
+
+{ #category : #accessing }
+AthensAbstractMeshPaintPatch >> colors: anObject [
+	colors := anObject
+]
+
+{ #category : #accessing }
+AthensAbstractMeshPaintPatch >> controlPoints [
+	^ controlPoints
+]
+
+{ #category : #accessing }
+AthensAbstractMeshPaintPatch >> controlPoints: anObject [
+	controlPoints := anObject
+]

--- a/src/Athens-Core/AthensSurface.class.st
+++ b/src/Athens-Core/AthensSurface.class.st
@@ -87,6 +87,11 @@ AthensSurface >> createLinearGradient: colorRamp start: pt1 stop: pt2 [
 	self shouldNotImplement 
 ]
 
+{ #category : #paints }
+AthensSurface >> createMeshGradientWithPatches: aListOfMeshPatches [ 
+	self subclassResponsibility.
+]
+
 { #category : #paths }
 AthensSurface >> createPath: aPathBuilder [
 	"Create a path from provided path builder instance"

--- a/src/Athens-Core/CoonsPaintPatch.class.st
+++ b/src/Athens-Core/CoonsPaintPatch.class.st
@@ -1,0 +1,8 @@
+"
+I am patch that performs bilinear interpolation along four curved vertices. I can be used for simulating more complex gradients such as conical gradients.
+"
+Class {
+	#name : #CoonsPaintPatch,
+	#superclass : #AthensAbstractMeshPaintPatch,
+	#category : #'Athens-Core-Paints'
+}

--- a/src/Athens-Core/GenericPaintPatch.class.st
+++ b/src/Athens-Core/GenericPaintPatch.class.st
@@ -1,0 +1,21 @@
+"
+I am a generic patch whose content is built through path building style commands. I have rough correspondence to SVG mesh gradient paths.
+"
+Class {
+	#name : #GenericPaintPatch,
+	#superclass : #AthensAbstractMeshPaintPatch,
+	#instVars : [
+		'buildBlock'
+	],
+	#category : #'Athens-Core-Paints'
+}
+
+{ #category : #accessing }
+GenericPaintPatch >> buildBlock [
+	^ buildBlock
+]
+
+{ #category : #accessing }
+GenericPaintPatch >> buildBlock: anObject [
+	buildBlock := anObject
+]

--- a/src/Athens-Core/MeshGradientPaint.class.st
+++ b/src/Athens-Core/MeshGradientPaint.class.st
@@ -1,0 +1,87 @@
+"
+I am a gradient that is defined by the composition of multiple patches.
+"
+Class {
+	#name : #MeshGradientPaint,
+	#superclass : #AthensAbstractPaint,
+	#instVars : [
+		'patches'
+	],
+	#category : #'Athens-Core-Paints'
+}
+
+{ #category : #adding }
+MeshGradientPaint >> addCircleSliceCenter: center radius: radius startAngle: sliceStartAngle endAngle: sliceEndAngle colors: colors [
+	| sliceStartPoint sliceEndPoint f sliceControlPoint1 sliceControlPoint2 sliceCenter |
+	sliceStartPoint := Point r: radius theta: sliceStartAngle.
+	sliceEndPoint := Point r: radius theta: sliceEndAngle.
+
+"Circle subdivision algorithm from: https://blogs.igalia.com/dpino/2020/06/11/renderization-of-conic-gradients/ [October, 2020]"
+	f := ( ((sliceEndAngle - sliceStartAngle) / 4) tan) * 4 / 3.
+	sliceControlPoint1 := (sliceStartPoint x - (f * sliceStartPoint y)) @ (sliceStartPoint y + (f * sliceStartPoint x)).
+	sliceControlPoint2 := (sliceEndPoint x + (f * sliceEndPoint y)) @ (sliceEndPoint y - (f * sliceEndPoint x)).
+	
+	"Transform the control points to the actual center."
+	sliceCenter := center.
+	sliceStartPoint := sliceStartPoint + center.
+	sliceControlPoint1 := sliceControlPoint1 + center.
+	sliceControlPoint2 := sliceControlPoint2 + center.
+	sliceEndPoint := sliceEndPoint + center.
+
+	self
+		buildPatchWith: [ :patchBuilder |
+			patchBuilder
+				moveTo: sliceCenter;
+				lineTo: sliceStartPoint;
+				curveVia: sliceControlPoint1 and: sliceControlPoint2 to: sliceEndPoint;
+				lineTo: sliceCenter;
+				colors: colors
+		].
+
+]
+
+{ #category : #adding }
+MeshGradientPaint >> addCoonsPatchWithPoints: controlPoints colors: colors [
+	self assert: controlPoints size = 12.
+	self assert: colors size = 4.
+	^ self addPatch: (CoonsPaintPatch controlPoints: controlPoints colors: colors)
+]
+
+{ #category : #adding }
+MeshGradientPaint >> addPatch: patch [
+	patches add: patch
+]
+
+{ #category : #adding }
+MeshGradientPaint >> addTriangleWithPoints: controlPoints colors: colors [
+	self assert: controlPoints size = 3.
+	self assert: colors size = 3.
+	^ self addPatch: (TrianglePaintPatch controlPoints: controlPoints colors: colors)
+]
+
+{ #category : #converting }
+MeshGradientPaint >> asAthensPaintOn: aCanvas [
+	^ aCanvas surface
+		createMeshGradientWithPatches: patches
+]
+
+{ #category : #adding }
+MeshGradientPaint >> buildPatchWith: aBlock [
+	^ self addPatch: (GenericPaintPatch new buildBlock: aBlock)
+]
+
+{ #category : #initialization }
+MeshGradientPaint >> initialize [
+	super initialize.
+	patches := OrderedCollection new.
+]
+
+{ #category : #accessing }
+MeshGradientPaint >> patches [
+	^ patches
+]
+
+{ #category : #accessing }
+MeshGradientPaint >> patches: aListOfPatches [
+	patches := aListOfPatches copy
+]

--- a/src/Athens-Core/TrianglePaintPatch.class.st
+++ b/src/Athens-Core/TrianglePaintPatch.class.st
@@ -1,0 +1,8 @@
+"
+I am a patch that interpolates linearly the colors defined along the three vertices of triangle. I am equivalent to Gouraud shading.
+"
+Class {
+	#name : #TrianglePaintPatch,
+	#superclass : #AthensAbstractMeshPaintPatch,
+	#category : #'Athens-Core-Paints'
+}

--- a/src/Athens-Examples/AthensSurfaceExamples.class.st
+++ b/src/Athens-Examples/AthensSurfaceExamples.class.st
@@ -526,6 +526,99 @@ AthensSurfaceExamples class >> exampleClip [
 ]
 
 { #category : #examples }
+AthensSurfaceExamples class >> exampleConicalGradient [
+	| surface meshGradient center radius sliceCount sliceSize colorAngleOffset |
+	surface := AthensCairoSurface extent: 512@512.
+	colorAngleOffset := -90.0.
+	sliceCount := 16.
+	sliceSize := Float twoPi / sliceCount.
+	center := 256@256.
+	radius := 256.
+	
+	meshGradient := MeshGradientPaint new.
+	0 to: sliceCount - 1 do: [ :sliceIndex |
+		| sliceStartAngle sliceEndAngle sliceStartCenterColor sliceStartRadiusColor sliceEndCenterColor sliceEndRadiusColor |
+		sliceStartAngle := sliceIndex * sliceSize.
+		sliceEndAngle := (sliceIndex + 1) * sliceSize.
+		
+		sliceStartCenterColor := Color h: sliceStartAngle radiansToDegrees + colorAngleOffset s: 0.0 v: 1.0.
+		sliceStartRadiusColor := Color h: sliceStartAngle radiansToDegrees + colorAngleOffset s: 1.0 v: 1.0.
+		sliceEndCenterColor := Color h: sliceEndAngle radiansToDegrees + colorAngleOffset s: 0.0 v: 1.0.
+		sliceEndRadiusColor := Color h: sliceEndAngle radiansToDegrees + colorAngleOffset s: 1.0 v: 1.0.
+		
+		meshGradient addCircleSliceCenter: center radius: radius startAngle: sliceStartAngle endAngle: sliceEndAngle colors: {
+			sliceStartCenterColor . sliceStartRadiusColor.
+			sliceEndRadiusColor . sliceEndCenterColor.
+		}
+	].
+			
+	surface drawDuring: [ :canvas |
+		canvas surface clear: Color white.
+		
+		canvas
+			setPaint: meshGradient;
+			setShape: (0@0 extent: 512@512);
+			draw
+	].
+
+	surface asForm asMorph openInWindow
+]
+
+{ #category : #examples }
+AthensSurfaceExamples class >> exampleCoonsPatch [
+	| surface meshPaint |
+	surface := AthensCairoSurface extent: 300@300.
+	meshPaint := MeshGradientPaint new
+		addCoonsPatchWithPoints: {
+			0@0.
+			30@ -30.  60@30. 100@0.
+			60@  30. 130@60. 100@100.
+			60@  70.  30@130.   0@100.
+			30@  70. -30@30
+		} colors: { Color red . Color green . Color blue . Color yellow}.
+			
+	surface drawDuring: [ :canvas |
+		canvas surface clear: Color white.
+		canvas pathTransform translateBy: 100@100.
+		
+		canvas
+			setPaint: meshPaint;
+			setShape: (-100 @ -100 extent: 300@300);
+			draw
+	].
+
+	surface asForm asMorph openInWindow
+]
+
+{ #category : #examples }
+AthensSurfaceExamples class >> exampleCoonsPatch2 [
+	| surface meshPaint |
+	surface := AthensCairoSurface extent: 300@300.
+	meshPaint := MeshGradientPaint new
+		buildPatchWith: [ :patchBuilder |
+			patchBuilder
+				moveTo: 0@0;
+				curveVia: 30@ -30 and: 60@30 to: 100@0;
+				curveVia: 60@  30 and: 130@60 to: 100@100;
+				curveVia: 60@  70 and: 30@130 to: 0@100;
+				curveVia: 30@  70 and: -30@30 to: 0@0;
+				colors: { Color red . Color green . Color blue . Color yellow}
+		].
+			
+	surface drawDuring: [ :canvas |
+		canvas surface clear: Color white.
+		canvas pathTransform translateBy: 100@100.
+		
+		canvas
+			setPaint: meshPaint;
+			setShape: (-100 @ -100 extent: 300@300);
+			draw
+	].
+
+	surface asForm asMorph openInWindow
+]
+
+{ #category : #examples }
 AthensSurfaceExamples class >> exampleDrawForm [
  
 	| surf surf2   |
@@ -599,6 +692,51 @@ AthensSurfaceExamples class >> exampleDrawText [
 	
 	surf asMorph openInWindow
 
+]
+
+{ #category : #examples }
+AthensSurfaceExamples class >> exampleGouraudTriangle [
+	| surface meshPaint |
+	surface := AthensCairoSurface extent: 512@512.
+	meshPaint := MeshGradientPaint new
+		addTriangleWithPoints: { 256@50 . 450@450 . 50@450 }
+			colors: { Color red . Color green . Color blue}.
+			
+	surface drawDuring: [ :canvas |
+		canvas surface clear: Color white.
+		
+		canvas
+			setPaint: meshPaint;
+			setShape: (50@50 extent: 400@400);
+			draw
+	].
+
+	surface asForm asMorph openInWindow
+]
+
+{ #category : #examples }
+AthensSurfaceExamples class >> exampleGouraudTriangle2 [
+	| surface meshPaint |
+	surface := AthensCairoSurface extent: 512@512.
+	meshPaint := MeshGradientPaint new
+		buildPatchWith: [ :patchBuilder |
+			patchBuilder
+				moveTo: 256@50;
+				lineTo: 450@450;
+				lineTo: 50@450;
+				colors: { Color red . Color green . Color blue}
+		].
+			
+	surface drawDuring: [ :canvas |
+		canvas surface clear: Color white.
+		
+		canvas
+			setPaint: meshPaint;
+			setShape: (50@50 extent: 400@400);
+			draw
+	].
+
+	surface asForm asMorph openInWindow
 ]
 
 { #category : #examples }


### PR DESCRIPTION
This PR adds support for mesh gradients to Athens. The attached screenshot shows examples of what can be drawn with this gradients:

![mesh-gradients](https://user-images.githubusercontent.com/1550655/96923817-15f45380-14b2-11eb-988c-4b0a57640a3d.png)

Some potential usages for these gradients can be: implementing a color picker, and implementing shadows.