### PR TITLE
7535-Variable-Breakpoints-Wrong-Icon-in-gutter

### DIFF
--- a/src/Reflectivity-Tools/MetaLinkIconStyler.class.st
+++ b/src/Reflectivity-Tools/MetaLinkIconStyler.class.st
@@ -29,10 +29,6 @@ MetaLinkIconStyler >> iconLabel: aNode [
 
 { #category : #testing }
 MetaLinkIconStyler >> shouldStyleNode: aNode [
-	 aNode hasBreakpoint ifTrue: [ ^ false ].	
 	 ^ aNode hasLinks and: [ 
-		   aNode links anySatisfy: [ :link | 
-			   ({ 
-				    Watch.
-				    ExecutionCounter } includes: link metaObject class) not ] ]
+		   aNode links anySatisfy: [ :link | link hasOption: #optionStyler]]
 ]

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -262,7 +262,7 @@ Breakpoint >> enable [
 Breakpoint >> initialize [
 	
 	self class initializeSlots: self.
-	options := #(+ optionCompileOnLinkInstallation + optionAnnounce)
+	options := #(+ optionCompileOnLinkInstallation + optionAnnounce - optionStyler)
 ]
 
 { #category : #install }

--- a/src/Reflectivity/ExecutionCounter.class.st
+++ b/src/Reflectivity/ExecutionCounter.class.st
@@ -123,7 +123,7 @@ ExecutionCounter >> install [
 	link := MetaLink new 
 				metaObject: self;
 				selector: #increase;
-				optionAnnounce: true.
+				options: #(+ optionAnnounce - optionStyler).
 	node link: link.
 	self class allCounters at: node put: self.
 ]

--- a/src/Reflectivity/MetaLink.class.st
+++ b/src/Reflectivity/MetaLink.class.st
@@ -58,6 +58,7 @@ MetaLink class >> defaultOptions [
 	+ optionWeakAfter 						  "do not use #ensure: for #after "
 	- optionAnnounce                    "do we announce adding / removing links? Slow"
 	- argsAsArray                       "pass all arguments in one array. By default off as it adds an array creation"
+	+ optionStyler							  "should the metalink be visualized in the Tools?"
 	)
 ]
 

--- a/src/Reflectivity/Watch.class.st
+++ b/src/Reflectivity/Watch.class.st
@@ -110,7 +110,7 @@ Watch >> install [
 				arguments: #(value);
 				control: #after;
 				condition: [ recording ];
-				option: #(+ optionWeakAfter +optionAnnounce).
+				option: #(+ optionWeakAfter +optionAnnounce - optionStyler).
 	node link: link.
 	self class allWatches at: node put: self.
 ]


### PR DESCRIPTION
This improves how styling of MetaLinks vs Breakpoints is done.

- Now the Matalink has an option so we can configure if we want it to render the default gutter styler or not
- Breakpoint, Watch and ExecutionCounter now turn that off

This way we do not have to hard-code any knowledge in MetaLinkIconStyler>>#shouldStyleNode:

There is still an update problem for Variable Breakpoints (the method is not re-rendered after adding one). 
That will be fixed in anther step.