### PR TITLE
isReadOnlyLiteral-Float-Integer

### DIFF
--- a/src/Kernel/Float.class.st
+++ b/src/Kernel/Float.class.st
@@ -919,6 +919,12 @@ Float >> isPowerOfTwo [
 ]
 
 { #category : #testing }
+Float >> isReadOnlyLiteral [ 
+	"Immediate objects are read-only by design, we can not call #beReadOnlyObject"
+	^ self isLiteral and: [ self class isImmediateClass not ]
+]
+
+{ #category : #testing }
 Float >> isSelfEvaluating [
     ^true
 ]

--- a/src/Kernel/Float.class.st
+++ b/src/Kernel/Float.class.st
@@ -921,7 +921,7 @@ Float >> isPowerOfTwo [
 { #category : #testing }
 Float >> isReadOnlyLiteral [ 
 	"Immediate objects are read-only by design, we can not call #beReadOnlyObject"
-	^ self isLiteral and: [ self class isImmediateClass not ]
+	^ self isLiteral
 ]
 
 { #category : #testing }

--- a/src/Kernel/Integer.class.st
+++ b/src/Kernel/Integer.class.st
@@ -1094,8 +1094,7 @@ Integer >> isPowerOfTwo [
 
 { #category : #testing }
 Integer >> isReadOnlyLiteral [ 
-	"Immediate objects are read-only by design, we can not call #beReadOnlyObject"
-	^ self isLiteral and: [ self class isImmediateClass not ]
+	^ self isLiteral
 ]
 
 { #category : #'system primitives' }

--- a/src/Kernel/Integer.class.st
+++ b/src/Kernel/Integer.class.st
@@ -1092,6 +1092,12 @@ Integer >> isPowerOfTwo [
 	^ self ~= 0 and: [(self bitAnd: self-1) = 0]
 ]
 
+{ #category : #testing }
+Integer >> isReadOnlyLiteral [ 
+	"Immediate objects are read-only by design, we can not call #beReadOnlyObject"
+	^ self isLiteral and: [ self class isImmediateClass not ]
+]
+
 { #category : #'system primitives' }
 Integer >> lastDigit [
 	"Answer the last digit of the integer base 256.  LargePositiveInteger uses bytes of base two number, and each is a 'digit'."

--- a/src/Kernel/SmallFloat64.class.st
+++ b/src/Kernel/SmallFloat64.class.st
@@ -219,6 +219,12 @@ SmallFloat64 >> identityHash [
 	^ self basicIdentityHash
 ]
 
+{ #category : #testing }
+SmallFloat64 >> isReadOnlyLiteral [ 
+	"Immediate objects are read-only by design, we can not call #beReadOnlyObject"
+	^ false
+]
+
 { #category : #'mathematical functions' }
 SmallFloat64 >> ln [
 	"Answer the natural logarithm of the receiver.

--- a/src/Kernel/SmallInteger.class.st
+++ b/src/Kernel/SmallInteger.class.st
@@ -481,6 +481,12 @@ SmallInteger >> isLarge [
 	^false
 ]
 
+{ #category : #testing }
+SmallInteger >> isReadOnlyLiteral [ 
+	"Immediate objects are read-only by design, we can not call #beReadOnlyObject"
+	^ false
+]
+
 { #category : #'bit manipulation' }
 SmallInteger >> lowBit [
 	" Answer the index of the low order one bit.


### PR DESCRIPTION
This implements isReadOnlyLiteral for float and integer. subclasses are read only if they are a literal *and* if they are not immediate
(mayeb we should fix #beReadOnlyObject to not raise an error for immediate classes? They are read-only after all...)