### PR TITLE
6001-isTemp-might-fail-on-Pharo-AST

### DIFF
--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -70,9 +70,7 @@ RBVariableNode >> = anObject [
 
 { #category : #visiting }
 RBVariableNode >> acceptVisitor: aProgramNodeVisitor [
-	^variable 
-		ifNil: [aProgramNodeVisitor visitVariableNode: self]
-		ifNotNil: [variable acceptVisitor: aProgramNodeVisitor node: self]
+	^ variable acceptVisitor: aProgramNodeVisitor node: self
 ]
 
 { #category : #matching }
@@ -104,6 +102,7 @@ RBVariableNode >> hash [
 { #category : #initialization }
 RBVariableNode >> initialize [
 	super initialize.
+	variable := UnresolvedVariable instance.
 	name := ''.
 	start := 0
 ]

--- a/src/OpalCompiler-Core/OCASTSemanticCleaner.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticCleaner.class.st
@@ -31,5 +31,5 @@ OCASTSemanticCleaner >> visitMethodNode: aMethodNode [
 
 { #category : #visiting }
 OCASTSemanticCleaner >> visitVariableNode: aVariableNode [
-	aVariableNode variable: nil
+	aVariableNode variable: UnresolvedVariable instance
 ]

--- a/src/OpalCompiler-Core/RBVariableNode.extension.st
+++ b/src/OpalCompiler-Core/RBVariableNode.extension.st
@@ -2,12 +2,12 @@ Extension { #name : #RBVariableNode }
 
 { #category : #'*opalcompiler-core' }
 RBVariableNode >> binding [
-	^variable
+	^self variable
 ]
 
 { #category : #'*opalcompiler-core' }
 RBVariableNode >> binding: aSemVar [
-	variable := aSemVar
+	self variable: aSemVar
 ]
 
 { #category : #'*opalcompiler-core' }

--- a/src/OpalCompiler-Core/UnresolvedVariable.class.st
+++ b/src/OpalCompiler-Core/UnresolvedVariable.class.st
@@ -1,0 +1,50 @@
+"
+The parser does not now the semantic meaning of Variables. It thus sets them all to be an UnresolvedVariable.
+
+The Semantic Analysis (#doSemanticAnalysis) then gives meaning to Variables and sets them correctly.
+"
+Class {
+	#name : #UnresolvedVariable,
+	#superclass : #Variable,
+	#classInstVars : [
+		'instance'
+	],
+	#category : #'OpalCompiler-Core-Semantics'
+}
+
+{ #category : #accessing }
+UnresolvedVariable class >> instance [ 
+	^instance ifNil: [ instance := self new ]
+]
+
+{ #category : #'code generation' }
+UnresolvedVariable >> emitStore: methodBuilder [
+
+	self error: 'Can not generate code, please call #doSemanticAnalysis first'
+]
+
+{ #category : #'code generation' }
+UnresolvedVariable >> emitValue: methodBuilder [
+
+	self error: 'Can not generate code, please call #doSemanticAnalysis first'
+]
+
+{ #category : #debugging }
+UnresolvedVariable >> readInContext: aContext [
+	self error: 'Can not read variable, please call #doSemanticAnalysis first'
+]
+
+{ #category : #accessing }
+UnresolvedVariable >> scope [
+	^nil
+]
+
+{ #category : #queries }
+UnresolvedVariable >> usingMethods [
+	^#()
+]
+
+{ #category : #debugging }
+UnresolvedVariable >> write: aValue inContext: aContext [
+	self error: 'Can not write variable, please call #doSemanticAnalysis first'
+]


### PR DESCRIPTION
This PR intruduces UnresolvedVariable. When the AST is created by the parser, it sets all Variables to this kind.

This allows us to
- get a meaningful answer to all is*Variable checks: false (as it is not a temp yet)
- visitor works correctly and falls back to #visitVariable node
- no need for any ifs
- nice errror messages if you try to generate code

fixes #6001