### PR TITLE
7589-isReadOnlyObject-and-beReadOnlyObject-are-not-consistent-wrt-immediate-objects

### DIFF
--- a/src/Kernel-Tests-Extended/WriteBarrierTest.class.st
+++ b/src/Kernel-Tests-Extended/WriteBarrierTest.class.st
@@ -424,6 +424,14 @@ WriteBarrierTest >> testProxyObject: object initialState: initialState tuples: t
 ]
 
 { #category : #'tests - object' }
+WriteBarrierTest >> testReadOnlyImmediate [
+	"immediate objects like SmallIntegers are read only"
+	self assert: 1 isReadOnlyObject.
+	"we can call beReadOnlyObject on an immediate object"
+	self assert: 1 beReadOnlyObject.
+]
+
+{ #category : #'tests - object' }
 WriteBarrierTest >> testRetryingInstVarModification [
 	| guineaPig |
 	guineaPig := MessageSend new.

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1740,6 +1740,7 @@ Object >> setIsReadOnlyObject: aBoolean [
 	 Note: Some objects can't be read-only, currently contexts and objects related
 	 to process scheduling (Processor, Process instances, Semaphore instances, ...)"
 	<primitive: 164 error: ec>
+	self class isImmediateClass ifTrue: [ ^true ].
 	^self primitiveFailed
 	
 ]


### PR DESCRIPTION
1 isReadOnlyObject returns true, but calling #beReadOnlyObject raises an error.

#isReadOnlyObject has an explicit check for this case in the fallback code, we should add the same to #beReadOnlyObject.

fixes #7589