### PR TITLE
7591-We-have-isImmediateClass-add-isImmediateObject

### DIFF
--- a/src/Kernel-Tests/ProtoObjectTest.class.st
+++ b/src/Kernel-Tests/ProtoObjectTest.class.st
@@ -171,6 +171,15 @@ ProtoObjectTest >> testIfNotNilIfNil [
 ]
 
 { #category : #'tests - testing' }
+ProtoObjectTest >> testIsImmediateObject [
+	self deny: Object new isImmediateObject.
+	self deny: Array new isImmediateObject.
+	self assert: 1 isImmediateObject.
+	self assert: 1.2 isImmediateObject.
+	self assert: $a isImmediateObject.
+]
+
+{ #category : #'tests - testing' }
 ProtoObjectTest >> testIsNil [
 
 	self deny: ProtoObject new isNil

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1288,7 +1288,7 @@ Object >> isReadOnlyObject [
 	 An attempt to modify a read-only object in a primitive will cause the
 	 primitive to fail with a #'no modification' error code."
 	<primitive: 163 error: ec>
-	^self class isImmediateClass 
+	^self isImmediateObject
 ]
 
 { #category : #testing }
@@ -1740,7 +1740,7 @@ Object >> setIsReadOnlyObject: aBoolean [
 	 Note: Some objects can't be read-only, currently contexts and objects related
 	 to process scheduling (Processor, Process instances, Semaphore instances, ...)"
 	<primitive: 164 error: ec>
-	self class isImmediateClass ifTrue: [ ^true ].
+	self isImmediateObject ifTrue: [ ^true ].
 	^self primitiveFailed
 	
 ]

--- a/src/Kernel/ProtoObject.class.st
+++ b/src/Kernel/ProtoObject.class.st
@@ -190,6 +190,11 @@ ProtoObject >> instVarsInclude: anObject [
 ]
 
 { #category : #testing }
+ProtoObject >> isImmediateObject [
+	^ self class isImmediateClass
+]
+
+{ #category : #testing }
 ProtoObject >> isNil [
 	"Coerces nil to true and everything else to false."
 

--- a/src/Kernel/SmallFloat64.class.st
+++ b/src/Kernel/SmallFloat64.class.st
@@ -220,6 +220,12 @@ SmallFloat64 >> identityHash [
 ]
 
 { #category : #testing }
+SmallFloat64 >> isImmediateObject [
+	"This is needed for the boostrap"
+	^ true
+]
+
+{ #category : #testing }
 SmallFloat64 >> isReadOnlyLiteral [ 
 	"Immediate objects are read-only by design, we can not call #beReadOnlyObject"
 	^ false

--- a/src/Kernel/SmallInteger.class.st
+++ b/src/Kernel/SmallInteger.class.st
@@ -477,6 +477,12 @@ SmallInteger >> identityHash [
 ]
 
 { #category : #testing }
+SmallInteger >> isImmediateObject [
+	"This is needed for the boostrap"
+	^ true
+]
+
+{ #category : #testing }
 SmallInteger >> isLarge [
 	^false
 ]


### PR DESCRIPTION
- add #isImmediateObject
- add test
- use in #isReadOnlyObject and #setIsReadOnlyObject:

this will alow us to (in a second step) simplify #isReadOnlyLiteral, as with this we can just call #beReadOnlyLiteral on all literals

fixes #7591