### PR TITLE
Merge-MetaLinkStyler

### DIFF
--- a/src/Reflectivity-Examples/CoverageRubricStyler.class.st
+++ b/src/Reflectivity-Examples/CoverageRubricStyler.class.st
@@ -1,10 +1,9 @@
 "
-A styler that highlight with green all executed statement.
-For simplicity we extend from MetaLinkIconStyler
+A styler that highlight with green all executed statement
 "
 Class {
 	#name : #CoverageRubricStyler,
-	#superclass : #MetalinkIconStyler,
+	#superclass : #IconStyler,
 	#category : #'Reflectivity-Examples'
 }
 
@@ -15,4 +14,24 @@ CoverageRubricStyler >> addIconStyle: aNode from: start to: stop [
 	rejectClass := { RBMethodNode . RBSequenceNode }.
 	(rejectClass includes: aNode class) ifTrue: [ ^self ]. "do nothing" 
 	aNode hasBeenExecuted ifTrue: [  super addIconStyle: aNode from: start to: stop]
+]
+
+{ #category : #defaults }
+CoverageRubricStyler >> iconBlock: aNode [
+	^[ aNode inspect]
+]
+
+{ #category : #defaults }
+CoverageRubricStyler >> iconFor: aNode [
+	^ self iconNamed: #arrowUpIcon.
+]
+
+{ #category : #defaults }
+CoverageRubricStyler >> iconLabel: aNode [
+	^ 'Metalink'
+]
+
+{ #category : #testing }
+CoverageRubricStyler >> shouldStyleNode: aNode [
+	^aNode hasMetalink
 ]

--- a/src/Reflectivity-Examples/MetalinkIconStyler.class.st
+++ b/src/Reflectivity-Examples/MetalinkIconStyler.class.st
@@ -11,23 +11,3 @@ Class {
 MetalinkIconStyler class >> shouldStyle [
 	^false
 ]
-
-{ #category : #defaults }
-MetalinkIconStyler >> iconBlock: aNode [
-	^[ aNode inspect]
-]
-
-{ #category : #defaults }
-MetalinkIconStyler >> iconFor: aNode [
-	^ self iconNamed: #arrowUpIcon.
-]
-
-{ #category : #defaults }
-MetalinkIconStyler >> iconLabel: aNode [
-	^ 'Metalink'
-]
-
-{ #category : #testing }
-MetalinkIconStyler >> shouldStyleNode: aNode [
-	^aNode hasMetalink
-]


### PR DESCRIPTION
We had both MetalinkIconStyler and MetaLnkIconStyler.

This merged MetalinkIconStyler into its only subcalss: CoverageRubricStyler.