### PR TITLE
7598-SpPresenter-class-does-not-display-instanceVariableNames-

### DIFF
--- a/src/Kernel-Tests/OldPharoClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/OldPharoClassDefinitionPrinterTest.class.st
@@ -22,8 +22,9 @@ OldPharoClassDefinitionPrinterTest >> setUp [
 OldPharoClassDefinitionPrinterTest >> testAlignmentMorphClass [
 
 	self 
-		assert: (self forClass: AlignmentMorph class)  equals: 'AlignmentMorph class
-	uses: TAbleToRotate classTrait'
+		assert: (self forClass: AlignmentMorph class) equals: 'AlignmentMorph class
+	uses: TAbleToRotate classTrait
+	instanceVariableNames: '''''
 ]
 
 { #category : #'tests - classes' }
@@ -149,21 +150,23 @@ OldPharoClassDefinitionPrinterTest >> testTBehavior [
 { #category : #'tests - traits' }
 OldPharoClassDefinitionPrinterTest >> testTComparableClassTrait [
 
-	self assert: (self forClass: TComparable classTrait) equals: 'TComparable classTrait'
+	self assert: (self forClass: TComparable classTrait) equals: 'TComparable classTrait
+	instanceVariableNames: '''''
 ]
 
 { #category : #'tests - traits' }
 OldPharoClassDefinitionPrinterTest >> testTEventVisitorClassTrait [
 
 	self assert: (self forClass: EpTEventVisitor classTrait) equals: 'EpTEventVisitor classTrait
-	uses: EpTCodeChangeVisitor classTrait'
+	uses: EpTCodeChangeVisitor classTrait
+	instanceVariableNames: '''''
 ]
 
 { #category : #'tests - traits' }
 OldPharoClassDefinitionPrinterTest >> testTSortable [
 
-	self assert: (self forClass: TSortable classTrait) equals: 'TSortable classTrait'
-
+	self assert: (self forClass: TSortable classTrait) equals: 'TSortable classTrait
+	instanceVariableNames: '''''
 ]
 
 { #category : #'tests - classes' }
@@ -191,8 +194,8 @@ OldPharoClassDefinitionPrinterTest >> testTrait [
 OldPharoClassDefinitionPrinterTest >> testTrait3 [
 
 	self assert: (self forClass: Trait3 classTrait) equals: 'Trait3 classTrait
-	uses: Trait2 classTrait'
-
+	uses: Trait2 classTrait
+	instanceVariableNames: '''''
 ]
 
 { #category : #'tests - traits' }

--- a/src/Kernel/OldPharoClassDefinitionPrinter.class.st
+++ b/src/Kernel/OldPharoClassDefinitionPrinter.class.st
@@ -78,9 +78,6 @@ OldPharoClassDefinitionPrinter >> expandedDefinitionString [
 
 { #category : #delegating }
 OldPharoClassDefinitionPrinter >> metaclassDefinitionString [ 
-	"Next step
-		- some of the methods defined on classe will have to be moved in this class.
-		- refactor to remove duplication with metaclass,...."
 
 	^ String streamContents: [:stream |
 		stream print: forClass.

--- a/src/Kernel/OldPharoClassDefinitionPrinter.class.st
+++ b/src/Kernel/OldPharoClassDefinitionPrinter.class.st
@@ -145,9 +145,8 @@ OldPharoClassDefinitionPrinter >> traitedMetaclassDefinitionString [
 					crtab;
 					nextPutAll: 'uses: ';
 					print: forClass traitComposition ].
-			forClass instanceVariablesString ifNotEmpty: [ 
 				strm
 					crtab;
 					nextPutAll: 'instanceVariableNames: ';
-					store: forClass instanceVariablesString ] ]
+					store: forClass instanceVariablesString ]
 ]

--- a/src/Refactoring-Changes/RBAddClassTraitChange.class.st
+++ b/src/Refactoring-Changes/RBAddClassTraitChange.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #private }
 RBAddClassTraitChange class >> definitionPatterns [
-	^ #('`traitName classTrait uses: `@traitComposition' '`traitName classTrait')
+	^ #('`traitName classTrait uses: `@traitComposition' '`traitName classTrait'  '`traitName classTrait uses: `@traitComposition instanceVariableNames: `@instVars' '`traitName classTrait instanceVariableNames: `@instVars')
 ]
 
 { #category : #converting }

--- a/src/Tests/TraitTest.class.st
+++ b/src/Tests/TraitTest.class.st
@@ -344,9 +344,9 @@ TraitTest >> testPrinting [
 { #category : #testing }
 TraitTest >> testPrintingClassSide [
 	
-	self assertPrints: self t6 classSide definition
-		like: 'T6 classTrait
-	uses: T1 classTrait + T2 classTrait' 
+	self assertPrints: self t6 classSide definition like: 'T6 classTrait
+	uses: T1 classTrait + T2 classTrait
+	instanceVariableNames: '''''
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Fixes: #7598 makes sure that the old pharo syntax prints the empty instance variables.