### PR TITLE
[improvement] change name of 'paste...' command to be clearer

### DIFF
--- a/src/Rubric/RubPlainTextMode.class.st
+++ b/src/Rubric/RubPlainTextMode.class.st
@@ -89,7 +89,7 @@ RubPlainTextMode class >> menuOn: aBuilder [
 				keyText: 'v';
 				selector: #paste;
 				iconName: #smallPasteIcon.
-			(aBuilder item: #'Paste...' translated)
+			(aBuilder item: #'Paste Recent' translated)
 				selector: #pasteRecent;
 				iconName: #smallCopyIcon;
 				withSeparatorAfter.

--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -103,7 +103,7 @@ RubSmalltalkCodeMode class >> menuOn: aBuilder [
 		selector: #paste;
 		help: nil;
 		iconName: #smallPasteIcon.
-	(aBuilder item: #'Paste...' translated)
+	(aBuilder item: #'Paste Recent' translated)
 		selector: #pasteRecent;
 		help: nil;
 		iconName: #smallCopyIcon;

--- a/src/Text-Edition/TextEditor.class.st
+++ b/src/Text-Edition/TextEditor.class.st
@@ -490,7 +490,7 @@ TextEditor class >> textEditorMenuOn: aBuilder [
 		keyText: 'v';
 		selector: #paste;
 		iconName: #smallPasteIcon.
-	(aBuilder item: #'Paste...' translated)
+	(aBuilder item: #'Paste recent' translated)
 		selector: #pasteRecent;
 		iconName: #smallCopyIcon;
 		withSeparatorAfter.

--- a/src/Tool-FileList/FileList.class.st
+++ b/src/Tool-FileList/FileList.class.st
@@ -78,7 +78,7 @@ FileList class >> contentMenu: aBuilder [
 		keyText: 'v';
 		selector: #paste;
 		iconName: #smallPasteIcon.
-	(aBuilder item: #'Paste...' translated)
+	(aBuilder item: #'Paste Recent' translated)
 		selector: #pasteRecent;
 		iconName: #smallPasteIcon;
 		withSeparatorAfter .


### PR DESCRIPTION
Current command name for the pasteRecent is "Paste..." which I thought was a double entry before I looked.
Paste Recent is actual a lot more clear to me, even thought it might not be the ideal name.

Does anyone agree? :)