### PR TITLE
7613-Settings-not-storing-correct-values

### DIFF
--- a/src/System-Settings-Core/AbstractStoredSetting.class.st
+++ b/src/System-Settings-Core/AbstractStoredSetting.class.st
@@ -21,15 +21,33 @@ Class {
 	#name : #AbstractStoredSetting,
 	#superclass : #Object,
 	#instVars : [
-		'settingNodeIdentifier'
+		'settingNodeIdentifier',
+		'hasDefaultValue'
 	],
 	#category : #'System-Settings-Core-Persistence-Ston-StoredSettings'
 }
+
+{ #category : #'ston-core' }
+AbstractStoredSetting class >> stonAllInstVarNames [
+
+	^ self allInstVarNames copyWithout: #hasDefaultValue
+]
 
 { #category : #comparing }
 AbstractStoredSetting >> = aStoredSetting [
 	^ self class = aStoredSetting class and: [ 
 		self settingNodeIdentifier = aStoredSetting settingNodeIdentifier ]
+]
+
+{ #category : #accessing }
+AbstractStoredSetting >> hasDefaultValue [
+	^ hasDefaultValue ifNil: [ ^ false ]
+]
+
+{ #category : #accessing }
+AbstractStoredSetting >> hasDefaultValue: aBoolean [ 
+	
+	hasDefaultValue := aBoolean
 ]
 
 { #category : #comparing }

--- a/src/System-Settings-Core/SettingsStonWriter.class.st
+++ b/src/System-Settings-Core/SettingsStonWriter.class.st
@@ -45,12 +45,17 @@ SettingsStonWriter >> initialize [
 SettingsStonWriter >> store [
 	"Write the stored setting in the stream"
 
+	| filteredStoredSettings |
 	stream ifNil: [ ^ self ].
+	
+	"The settings with default values are not stored"
+	filteredStoredSettings := storedSettings reject: [ :aStoredSetting | aStoredSetting hasDefaultValue ]. 
+
 	STON writer
 		on: stream;
 		prettyPrint: true;
 		asciiOnly: true;
-		nextPut: storedSettings asArray
+		nextPut: filteredStoredSettings asArray
 ]
 
 { #category : #accessing }

--- a/src/System-Settings-Core/StoredSettingsFactory.class.st
+++ b/src/System-Settings-Core/StoredSettingsFactory.class.st
@@ -40,7 +40,7 @@ StoredSettingsFactory >> fromSettingNodes: aCollectionOfSettingNodes [
 	
 	aCollectionOfSettingNodes 
 		select: [ :eachSettingNode | 
-			eachSettingNode item hasValue and: [ eachSettingNode item hasDefaultValue not ] ] 
+			eachSettingNode item hasValue ] 
 		thenDo: [ :eachSettingNode |
 			(self from: eachSettingNode) ifNotNil: [ :aStoredNode | storedSettings add: aStoredNode ] ].
 	
@@ -143,7 +143,10 @@ StoredSettingsFactory >> visitRelativePath: aRelativePath [
 
 { #category : #visitor }
 StoredSettingsFactory >> visitSettingDeclaration: aSettingDeclaration [ 
+
 	aSettingDeclaration realValue acceptSettings: self.
+
+	storedSetting hasDefaultValue: aSettingDeclaration hasDefaultValue
 	
 ]
 

--- a/src/System-Settings-Tests/MockSettings.class.st
+++ b/src/System-Settings-Tests/MockSettings.class.st
@@ -8,7 +8,8 @@ Class {
 		'cacheDirectory',
 		'booleanMockSetting',
 		'rangeSetting',
-		'defaultDirectoryName'
+		'defaultDirectoryName',
+		'booleanSettingWithDefault'
 	],
 	#category : #'System-Settings-Tests'
 }
@@ -33,6 +34,28 @@ MockSettings class >> booleanSettingNodeOn: aBuilder [
 	<mocksystemsettings>
 	(aBuilder setting: #booleanSetting)
 		label: 'Mock boolean setting'.
+]
+
+{ #category : #settings }
+MockSettings class >> booleanSettingWithDefault [
+
+	^ booleanSettingWithDefault ifNil: [ booleanSettingWithDefault := false ]
+]
+
+{ #category : #settings }
+MockSettings class >> booleanSettingWithDefault: aValue [
+
+	booleanSettingWithDefault := aValue
+]
+
+{ #category : #settings }
+MockSettings class >> booleanSettingWithDefaultNodeOn: aBuilder [
+	<mocksystemsettings>
+	
+	(aBuilder setting: #booleanSettingWithDefault)
+		label: 'Mock boolean setting';
+		default: false;
+		yourself.
 ]
 
 { #category : #accessing }
@@ -70,6 +93,7 @@ MockSettings class >> cleanUp [
 	self rangeSetting: nil.
 	self defaultDirectoryName: nil.
 	self cacheDirectory: nil.
+	self booleanSettingWithDefault: nil
 ]
 
 { #category : #accessing }

--- a/src/System-Settings-Tests/SystemSettingsPersistenceTest.class.st
+++ b/src/System-Settings-Tests/SystemSettingsPersistenceTest.class.st
@@ -12,6 +12,32 @@ Class {
 	#category : #'System-Settings-Tests'
 }
 
+{ #category : #asserting }
+SystemSettingsPersistenceTest >> assertStoredSettingsDoNotInclude: aIdentifier [
+
+	| nodes |
+	self assert: preferences exists.	
+	
+	nodes := preferences readStreamDo: [ :stream | STON fromStream: stream ].
+	
+	nodes detect: [ :aNode | aNode settingNodeIdentifier = aIdentifier printString ]  
+		ifFound: [ :aNode | self fail: 'The node has been found, it should not be there' ] 
+		ifNone: [ ^ self ]
+]
+
+{ #category : #asserting }
+SystemSettingsPersistenceTest >> assertStoredSettingsInclude: aIdentifier withValue: aValue [ 
+
+	| nodes |
+	self assert: preferences exists.	
+	
+	nodes := preferences readStreamDo: [ :stream | STON fromStream: stream ].
+	
+	nodes detect: [ :aNode | aNode settingNodeIdentifier = aIdentifier printString ]  
+		ifFound: [ :aNode | self assert: aNode realValue equals: aValue ] 
+		ifNone: [ self fail: 'Node with identifier ', aIdentifier printString, ' not found' ]
+]
+
 { #category : #accessing }
 SystemSettingsPersistenceTest >> booleanSettingNode [
 	^ systemSettings nodeNamed: #booleanSetting
@@ -73,7 +99,7 @@ SystemSettingsPersistenceTest >> testAllStoredSettings [
 	self assertEmpty: systemSettings allStoredSettings
 ]
 
-{ #category : #tests }
+{ #category : #'tests - storing - defaults' }
 SystemSettingsPersistenceTest >> testDefaultImageDoesNotStoreAnySetting [
 	| nodesToStore |
 	"An image with all default values should not save any setting.
@@ -82,9 +108,30 @@ SystemSettingsPersistenceTest >> testDefaultImageDoesNotStoreAnySetting [
 	Author
 		useAuthor: ''
 		during: [ 
-			nodesToStore := StoredSettingsFactory new fromSettingNodes: SettingBrowser currentTree nodeList ].
+			nodesToStore := StoredSettingsFactory new fromSettingNodes: SettingBrowser currentTree nodeList.
+			nodesToStore := nodesToStore reject: [ :aNode | aNode hasDefaultValue ] ].
 
 	self assertCollection: nodesToStore hasSameElements: #()
+]
+
+{ #category : #'tests - storing - defaults' }
+SystemSettingsPersistenceTest >> testDefaultSettingValueIsNotIncludedInTheStoredFile [
+
+	MockSettings booleanSettingWithDefault: false.
+
+	systemSettings storeSettingNodes: MockSettings settingTree nodeList.
+	
+	self assertStoredSettingsDoNotInclude: #booleanSettingWithDefault.
+]
+
+{ #category : #'tests - storing - defaults' }
+SystemSettingsPersistenceTest >> testNonDefaultSettingValueIsIncludedInTheStoredFile [
+
+	MockSettings booleanSettingWithDefault: true.
+
+	systemSettings storeSettingNodes: MockSettings settingTree nodeList.
+	
+	self assertStoredSettingsInclude: #booleanSettingWithDefault withValue: true.
 ]
 
 { #category : #tests }
@@ -216,6 +263,20 @@ SystemSettingsPersistenceTest >> testStoredValueForSettingNoStoredValue [
 	| value |
 	value := systemSettings storedValueForSettingNode: MockSettings booleanSettingNode.
 	self assert: value equals: nil.
+]
+
+{ #category : #'tests - storing - defaults' }
+SystemSettingsPersistenceTest >> testStoringNonDefaultValueAndThenStoringTheDefaultRemovesTheNode [
+
+	"Store with a non default value"
+	MockSettings booleanSettingWithDefault: true.
+	systemSettings storeSettingNodes: MockSettings settingTree nodeList.
+
+	"Store with a default value"
+	MockSettings booleanSettingWithDefault: false.
+	systemSettings storeSettingNodes: MockSettings settingTree nodeList.
+	
+	self assertStoredSettingsDoNotInclude: #booleanSettingWithDefault.
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Fix #7613

- It filters out the settings with default values when storing the values in the disk
- Adding tests for them