### PR TITLE
Compiler-compile-all-Literals-readOnly

### DIFF
--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -647,6 +647,12 @@ Character >> isFormatOther [
 	^ self characterSet isFormatOther: self
 ]
 
+{ #category : #testing }
+Character >> isImmediateObject [
+	"This is needed for the boostrap"
+	^ true
+]
+
 { #category : #'testing unicode' }
 Character >> isInitialQuote [
 	"Return whether the receiver is https://www.compart.com/en/unicode/category/Pi"

--- a/src/OpalCompiler-Core/IRTranslator.class.st
+++ b/src/OpalCompiler-Core/IRTranslator.class.st
@@ -250,8 +250,8 @@ IRTranslator >> visitPushInstVar: instVar [
 IRTranslator >> visitPushLiteral: lit [
 	| literal |
 	literal := lit literal.
-	(literal isReadOnlyLiteral) ifFalse: [ ^ gen pushLiteral: literal ].
-	Smalltalk vm supportsWriteBarrier ifFalse: [ ^ gen pushLiteral: literal ].
+	"all objects that are not literals we keep writable"
+	literal isLiteral ifFalse: [ ^ gen pushLiteral: literal ].
 	"For symbol we need to set explicitly to writable or read-only. 
 	 Compilation to read-only then back to writable keep the object 
 	 read-only if we don't set it back to writable."


### PR DESCRIPTION
after making sure that #beReadOnlyObject can be called even on immediate objects, we do not need anymore to check using
#isReadOnlyLiteral.

This PR only changes the compiler, #isReadOnlyLiteral will be removed later.