### PR TITLE
MetaLinkInstaller-do-not-rely-on-MetaLinkChanged

### DIFF
--- a/src/Reflectivity/MetaLinkInstaller.class.st
+++ b/src/Reflectivity/MetaLinkInstaller.class.st
@@ -138,8 +138,7 @@ MetaLinkInstaller >> initialize [
 	linksRegistry := MetaLinkRegistry new.
 	linkToNodesMapper := MetaLinkNodesMapper new.
 	superJumpLinks := OrderedCollection new.
-
-	SystemAnnouncer uniqueInstance weak when: MetalinkChanged send: #metalinkChanged: to: self.
+	
 	SystemAnnouncer uniqueInstance weak when: MethodModified send: #methodChanged: to: self.
 	SystemAnnouncer uniqueInstance weak when: MethodRemoved send: #methodRemoved: to: self.
 	SystemAnnouncer uniqueInstance weak when: MethodAdded send: #methodAdded: to: self
@@ -244,14 +243,6 @@ MetaLinkInstaller >> linkToNodesMapper [
 { #category : #'accessing - private tests' }
 MetaLinkInstaller >> linksRegistry [
 	^ linksRegistry 
-]
-
-{ #category : #updating }
-MetaLinkInstaller >> metalinkChanged: aMetaLinkChanged [
-	aMetaLinkChanged isRemove
-		ifTrue: [ ^ self propagateLinkRemoval: aMetaLinkChanged link forNode: aMetaLinkChanged node ].
-	aMetaLinkChanged isAdd
-		ifTrue: [ self propagateLinkAddition: aMetaLinkChanged link forNode: aMetaLinkChanged node ]
 ]
 
 { #category : #updating }

--- a/src/Reflectivity/MetalinkChanged.class.st
+++ b/src/Reflectivity/MetalinkChanged.class.st
@@ -12,7 +12,7 @@ Class {
 	#category : #'Reflectivity-Core'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 MetalinkChanged class >> linkAdded: link [
 	^ self new
 		link: link;
@@ -20,14 +20,14 @@ MetalinkChanged class >> linkAdded: link [
 		yourself
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 MetalinkChanged class >> linkAdded: link toNode: aNode [
 	^ (self linkAdded: link)
 		node: aNode;
 		yourself
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 MetalinkChanged class >> linkRemoved: link [
 	^ self new
 		link: link;
@@ -35,7 +35,7 @@ MetalinkChanged class >> linkRemoved: link [
 		yourself
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 MetalinkChanged class >> linkRemoved: link fromNode: aNode [
 	^ (self linkRemoved: link)
 		node: aNode;

--- a/src/Reflectivity/RBProgramNode.extension.st
+++ b/src/Reflectivity/RBProgramNode.extension.st
@@ -147,6 +147,7 @@ RBProgramNode >> link: aMetaLink [
 	aMetaLink installOn: self.
 	self clearReflectivityAnnotations.
 	self methodNode method installLink: aMetaLink.
+	aMetaLink linkInstaller propagateLinkAddition: aMetaLink forNode: self.
 	SystemAnnouncer uniqueInstance announce: (MetalinkChanged linkAdded: aMetaLink toNode: self)
 ]
 
@@ -200,6 +201,7 @@ RBProgramNode >> removeLink: aMetaLink [
 	(self methodNode methodClass methodDict includesKey: self methodNode selector)
 		ifFalse: [ ^ self ].
 	self methodNode method removeLink: aMetaLink.
+	aMetaLink linkInstaller propagateLinkRemoval: aMetaLink forNode: self.
 	SystemAnnouncer uniqueInstance announce: (MetalinkChanged linkRemoved: aMetaLink fromNode: self)
 ]
 


### PR DESCRIPTION
The implementation of Metalinks should not rely on the MetalinkChanged announcement.

This PR refactors MetaLinkInstaller to be called explicititly.