### PR TITLE
Fixed #7400. Added a visitSelectorNode to RBProgramNodeVisitor and fixed RBMessageNode >> selector

### DIFF
--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -402,7 +402,7 @@ RBMessageNode >> replaceSourceWithMessageNode: aNode [
 
 { #category : #accessing }
 RBMessageNode >> selector [
-	^ [ selector value ] on: Error do: [selector].
+	^ selector value
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBProgramNodeVisitor.class.st
+++ b/src/AST-Core/RBProgramNodeVisitor.class.st
@@ -81,7 +81,8 @@ RBProgramNodeVisitor >> visitLiteralValueNode: aRBLiteralValueNode [
 RBProgramNodeVisitor >> visitMessageNode: aMessageNode [
 	(aMessageNode isCascaded not or: [ aMessageNode isFirstCascaded ])
 		ifTrue: [ self visitNode: aMessageNode receiver ].
-	aMessageNode arguments do: [ :each | self visitNode: each ]
+	aMessageNode arguments do: [ :each | self visitNode: each ].
+	self visitNode: aMessageNode selectorNode.
 ]
 
 { #category : #visiting }
@@ -122,6 +123,11 @@ RBProgramNodeVisitor >> visitPragmaNode: aPragmaNode [
 { #category : #visiting }
 RBProgramNodeVisitor >> visitReturnNode: aReturnNode [
 	^ self visitNode: aReturnNode value
+]
+
+{ #category : #visiting }
+RBProgramNodeVisitor >> visitSelectorNode: aSelectorNode [
+	^ aSelectorNode
 ]
 
 { #category : #visiting }


### PR DESCRIPTION
## Problem

`RBSelectorNode` implemented the following method:
```Smalltalk
RBSelectorNode >> acceptVisitor: aProgramNodeVisitor
	^ aProgramNodeVisitor visitSelectorNode: self
```
However, the `visitSelectorNode:` was not implemented by `RBProgramNodeVisitor`.

## What we did

So we added a simple implementation (inspired by `RBProgramNodeVisitor>>visitVariableNode:`) which returns the node itself.
We also modified `RBProgramNodeVisitor >> visitMessageNode:` to make sure that it calls `visitSelectorNode:`.

Additionally, we have improved the implementation of `RBMessageNode >> selector` from this:

```Smalltalk
RBMessageNode >> selector
	^ [ selector value ] on: Error do: [selector].
```
To this:
```Smalltalk
RBMessageNode >> selector
	^ selector value
```
Because the selector variable should *always* contain an `RBSelectorNode` and not a `ByteString`.