### PR TITLE
7648-Fluid-rescue-test-for-compactClassDefinition-and-compactTraitDefinition

### DIFF
--- a/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
@@ -65,6 +65,20 @@ FluidClassDefinitionPrinterTest >> testChronologyConstants [
 	package: ''Kernel'''
 ]
 
+{ #category : #'tests - complex slots' }
+FluidClassDefinitionPrinterTest >> testClassDefinitionWithComplexSlotShouldBeDisplay [
+
+	ClassDefinitionPrinter showFluidClassDefinition: false.
+	self assert: MockWithComplexSlot needsSlotClassDefinition.
+
+	self 
+		assert: (self forClass: MockWithComplexSlot) 
+		equals: 'Object << #MockWithComplexSlot
+	slots: { #aComplexSlot => PropertySlot };
+	tag: ''Fluid'';
+	package: ''Kernel-Tests''' 
+]
+
 { #category : #'tests - template' }
 FluidClassDefinitionPrinterTest >> testCompactClassTemplate [
 
@@ -74,6 +88,15 @@ FluidClassDefinitionPrinterTest >> testCompactClassTemplate [
 	slots: {};
 	sharedVariables: {};
 	package: ''Kernel'''
+]
+
+{ #category : #'tests - complex slots' }
+FluidClassDefinitionPrinterTest >> testDefinitionWithComplexSlot [
+
+	self assert: (self forClass: MockWithComplexSlot) equals: 'Object << #MockWithComplexSlot
+	slots: { #aComplexSlot => PropertySlot };
+	tag: ''Fluid'';
+	package: ''Kernel-Tests''' 
 ]
 
 { #category : #'tests - expanded' }

--- a/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
@@ -65,19 +65,6 @@ FluidClassDefinitionPrinterTest >> testChronologyConstants [
 	package: ''Kernel'''
 ]
 
-{ #category : #'tests - complex slots' }
-FluidClassDefinitionPrinterTest >> testClassDefinitionWithComplexSlotShouldBeDisplay [
-
-	ClassDefinitionPrinter showFluidClassDefinition: false.
-	self assert: MockWithComplexSlot needsSlotClassDefinition.
-
-	self 
-		assert: (self forClass: MockWithComplexSlot) 
-		equals: 'Object << #MockWithComplexSlot
-	slots: { #aComplexSlot => PropertySlot };
-	tag: ''Fluid'';
-	package: ''Kernel-Tests''' 
-]
 
 { #category : #'tests - template' }
 FluidClassDefinitionPrinterTest >> testCompactClassTemplate [

--- a/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
@@ -90,15 +90,6 @@ FluidClassDefinitionPrinterTest >> testCompactClassTemplate [
 	package: ''Kernel'''
 ]
 
-{ #category : #'tests - complex slots' }
-FluidClassDefinitionPrinterTest >> testDefinitionWithComplexSlot [
-
-	self assert: (self forClass: MockWithComplexSlot) equals: 'Object << #MockWithComplexSlot
-	slots: { #aComplexSlot => PropertySlot };
-	tag: ''Fluid'';
-	package: ''Kernel-Tests''' 
-]
-
 { #category : #'tests - expanded' }
 FluidClassDefinitionPrinterTest >> testExpandedEmptyLayoutClass [
 

--- a/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
@@ -65,6 +65,16 @@ FluidClassDefinitionPrinterTest >> testChronologyConstants [
 	package: ''Kernel'''
 ]
 
+{ #category : #'tests - template' }
+FluidClassDefinitionPrinterTest >> testCompactClassTemplate [
+
+	self 
+		assert: (FluidClassDefinitionPrinter new compactClassDefinitionTemplateInPackage: 'Kernel') 
+		equals:  'Object << #MyClass
+	slots: {};
+	sharedVariables: {};
+	package: ''Kernel'''
+]
 
 { #category : #'tests - expanded' }
 FluidClassDefinitionPrinterTest >> testExpandedEmptyLayoutClass [
@@ -201,4 +211,3 @@ FluidClassDefinitionPrinterTest >> testSystemAnnouncerClass [
 	self assert: (self forClass: SystemAnnouncer class) equals: 'SystemAnnouncer class
 	slots: { #announcer }'
 ]
-

--- a/src/Kernel-Tests/MockWithComplexSlot.class.st
+++ b/src/Kernel-Tests/MockWithComplexSlot.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #MockWithComplexSlot,
+	#superclass : #Object,
+	#instVars : [
+		'#aComplexSlot => PropertySlot'
+	],
+	#category : #'Kernel-Tests-Fluid'
+}
+
+{ #category : #initialization }
+MockWithComplexSlot >> initialize [
+	
+	self class initializeSlots: self.
+	super initialize.
+]

--- a/src/Kernel-Tests/MockWithComplexSlot.class.st
+++ b/src/Kernel-Tests/MockWithComplexSlot.class.st
@@ -2,7 +2,7 @@ Class {
 	#name : #MockWithComplexSlot,
 	#superclass : #Object,
 	#instVars : [
-		'#aComplexSlot => PropertySlot'
+		'#aComplexSlot => ObservableSlot'
 	],
 	#category : #'Kernel-Tests-Fluid'
 }

--- a/src/Kernel/OldPharoClassDefinitionPrinter.class.st
+++ b/src/Kernel/OldPharoClassDefinitionPrinter.class.st
@@ -7,46 +7,41 @@ Class {
 { #category : #delegating }
 OldPharoClassDefinitionPrinter >> classDefinitionString [
 
-	| poolString stream |
+	^ forClass needsSlotClassDefinition 
+		ifTrue: [ (ClassDefinitionPrinter fluid for: forClass) classDefinitionString ]
+		ifFalse: [  	| poolString stream |
 	poolString := forClass sharedPoolsString.
 	stream := (String new: 800) writeStream.
 	forClass superclass
 		ifNotNil: [ stream nextPutAll: forClass superclass name ]
 		ifNil: [ stream nextPutAll: 'ProtoObject' ].
-	
 	stream
 		nextPutAll: forClass kindOfSubclass;
-		store: forClass name.
-		
+		store: forClass name.		
 	forClass hasTraitComposition ifTrue: [ 
 		stream
 			crtab;
 			nextPutAll: 'uses: ';
 			nextPutAll: forClass traitCompositionString ].
-	
 	stream
 		crtab;
 		nextPutAll: 'instanceVariableNames: '''.
 	forClass instanceVariablesOn: stream.
 	stream nextPut: $'.
-	
 	stream
 		crtab;
 		nextPutAll: 'classVariableNames: '''.
 	forClass classVariablesOn: stream.
 	stream nextPut: $'.
-	
 	poolString = '' ifFalse: [ 
 		stream 
 			crtab;
 			nextPutAll: 'poolDictionaries: ';
 			store: poolString ].
-	
 	stream
 		crtab;
 		nextPutAll: 'package: ';
 		store: forClass category asString.
-		
 	forClass superclass ifNil: [ 
 		stream
 			nextPutAll: '.';
@@ -56,8 +51,7 @@ OldPharoClassDefinitionPrinter >> classDefinitionString [
 		stream
 			space;
 			nextPutAll: 'superclass: nil' ].
-
-	^ stream contents
+	stream contents ]
 ]
 
 { #category : #template }

--- a/src/TraitsV2-Tests/T2FluidClassDefinitionPrinterTest.class.st
+++ b/src/TraitsV2-Tests/T2FluidClassDefinitionPrinterTest.class.st
@@ -39,6 +39,16 @@ T2FluidClassDefinitionPrinterTest >> testClassSideDoesNotShowPackage [
 	self assert: (self forClass: MOPTraitTest class) equals: 'MOPTraitTest class'
 ]
 
+{ #category : #'tests - template' }
+T2FluidClassDefinitionPrinterTest >> testCompactTraitFullTemplate [ 
+
+	self 
+		assert: (FluidClassDefinitionPrinter new compactTraitDefinitionTemplateInPackage: 'TraitsV2') equals: 'Trait << #TMyTrait
+	uses: {};
+	slots: {};
+	package: ''TraitsV2'''
+]
+
 { #category : #'tests - traits' }
 T2FluidClassDefinitionPrinterTest >> testComplexTrait [
 
@@ -88,8 +98,8 @@ T2FluidClassDefinitionPrinterTest >> testExpandedTrait3ClassTrait [
 		
 ]
 
-{ #category : #'tests - fully expanded' }
-T2FluidClassDefinitionPrinterTest >> testFullyExpandedTrait [
+{ #category : #'tests - template' }
+T2FluidClassDefinitionPrinterTest >> testFullTraitTemplate [
 
 	self 
 		assert: (FluidClassDefinitionPrinter new traitDefinitionTemplateInPackage: 'TraitsV2') equals: 'Trait << #TMyTrait


### PR DESCRIPTION
Fixes: #7648 Just rescue two lost tests