### PR TITLE
7652-What-is-the-purpose-of-testObjectFormatInstSize

### DIFF
--- a/src/Kernel-Tests/ClassHierarchyTest.class.st
+++ b/src/Kernel-Tests/ClassHierarchyTest.class.st
@@ -35,16 +35,11 @@ ClassHierarchyTest class >> fixSubclasses [
 
 { #category : #tests }
 ClassHierarchyTest >> testObjectFormatInstSize [
-	| classes offending |
-	"check that #instSize is in sync with #allInstVarNames"
-	offending := SystemNavigation default allBehaviors reject: [ :cls | cls instSize = (cls allSlots reject: #isVirtual) size ].
+	| offending |
+	"check that #instSize is in sync with the layout of the class"
+	offending := SystemNavigation default allBehaviors reject: [ :cls | 
+		cls instSize = cls classLayout fieldSize].
 	self assertCollection: offending hasSameElements: {}.
-
-	"instSpec is only 0 for classes without any inst vars or variable fields"
-	classes := SystemNavigation default allBehaviors select: [ :cls | cls isTrait not and: [ cls instSpec = 0 ] ].
-	offending := classes reject: [ :each | each instVarNames isEmpty or: [ each isVariable not ] ].
-	self assertCollection: offending hasSameElements: {}.
-
 ]
 
 { #category : #tests }


### PR DESCRIPTION
This PR changes the test testObjectFormatInstSize to check #instSize against the meta data of the class contained in the layout.

This test used to check the consistency of the instance var names which used to be cached in the class object. Today this 
is handled by the layout of the class.

fixes #7652