### PR TITLE
7653-Removal-of-SystemReporter-breaks-smalltalkCI

### DIFF
--- a/src/NewTools-SystemReporter/SystemReporter.class.st
+++ b/src/NewTools-SystemReporter/SystemReporter.class.st
@@ -1,0 +1,9 @@
+"
+I'm just a placeholder to support migration to never version. 
+In particular SmalltalkCI should not depend on user interface class. 
+"
+Class {
+	#name : #SystemReporter,
+	#superclass : #StSystemReporter,
+	#category : #'NewTools-SystemReporter'
+}


### PR DESCRIPTION
Fixes: #7653 Just create a subclass to support backward compatibility for SmalltalkCI