### PR TITLE
add deprecated #isSpecial

### DIFF
--- a/src/Ring-Core/RGVariable.class.st
+++ b/src/Ring-Core/RGVariable.class.st
@@ -63,6 +63,17 @@ RGVariable >> isReservedVariable [
 ]
 
 { #category : #testing }
+RGVariable >> isSpecial [
+	^ self
+		deprecated: 'Please use #needsFullDefinition instead '
+		on: '03/11/2020'
+		in: #Pharo8
+		transformWith: '`@receiver isSpecial' 
+						-> '`@receiver needsFullDefinition'.
+
+]
+
+{ #category : #testing }
 RGVariable >> isTempVariable [
 	^false
 ]


### PR DESCRIPTION
In Pharo 8, RGSlot and RGRGInstanceVariableSlot have the method #isSpecial.
It has been replaced by the method #needsFullDefinition in Pharo 9.

I propose to add a deprecation, thus it is easier for people to move from P8 to P9.