### PR TITLE
CleanBlockChecker-Cleanup

### DIFF
--- a/src/Debugging-Core/CleanBlockChecker.class.st
+++ b/src/Debugging-Core/CleanBlockChecker.class.st
@@ -12,6 +12,24 @@ Class {
 	#category : #'Debugging-Core'
 }
 
+{ #category : #validation }
+CleanBlockChecker class >> check: aMethod [
+	^ self new check: aMethod
+]
+
+{ #category : #validation }
+CleanBlockChecker >> check: aMethod [
+	| scanner end |
+	
+	scanner := InstructionStream on: aMethod.
+	end := aMethod endPC.
+
+	[scanner pc <= end] whileTrue: [
+		(self interpretNextInstructionUsing: scanner) ifFalse: [^false].
+	].
+	^true
+]
+
 { #category : #initialization }
 CleanBlockChecker >> interpretNextInstructionUsing: aScanner [ 
 	

--- a/src/Debugging-Core/CompiledCode.extension.st
+++ b/src/Debugging-Core/CompiledCode.extension.st
@@ -56,16 +56,8 @@ CompiledCode >> hasInstVarRef [
 CompiledCode >> localHasInstVarRef [
 	"Answer whether the method references an instance variable."
 
-	| scanner end printer |
-
-	scanner := InstructionStream on: self.
-	printer := InstVarRefLocator new.
-	end := self endPC.
-
-	[scanner pc <= end] whileTrue: [
-		(printer interpretNextInstructionUsing: scanner) ifTrue: [^true].
-	].
-	^false
+	
+	^ InstVarRefLocator check: self
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/Debugging-Core/InstVarRefLocator.class.st
+++ b/src/Debugging-Core/InstVarRefLocator.class.st
@@ -14,6 +14,23 @@ Class {
 	#category : #'Debugging-Core'
 }
 
+{ #category : #validation }
+InstVarRefLocator class >> check: aMethod [
+	^ self new check: aMethod
+]
+
+{ #category : #validation }
+InstVarRefLocator >> check: aMethod [
+	| scanner end |
+	scanner := InstructionStream on: aMethod.
+	end := aMethod endPC.
+
+	[scanner pc <= end] whileTrue: [
+		(self interpretNextInstructionUsing: scanner) ifTrue: [^true].
+	].
+	^false
+]
+
 { #category : #initialization }
 InstVarRefLocator >> interpretNextInstructionUsing: aScanner [ 
 	

--- a/src/Kernel/BlockClosure.class.st
+++ b/src/Kernel/BlockClosure.class.st
@@ -353,18 +353,10 @@ BlockClosure >> isClean [
 	"Answer if the receiver does not close-over any variables other than globals, and does
 	 not ^-return (does not close over the home context).  Clean blocks are amenable to
 	 being created at compile-time."
-	| scanner end checker |
 	self numCopiedValues > 0 ifTrue:
 		[^false].
 
-	scanner := InstructionStream on: self method.
-	checker := CleanBlockChecker new.
-	end := self method endPC.
-
-	[scanner pc <= end] whileTrue: [
-		(checker interpretNextInstructionUsing: scanner) ifFalse: [^false].
-	].
-	^true
+	^ CleanBlockChecker check: self method
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Small cleanup: move the iterating code for both CleanBlockChecker and InstVarRefLocator to the class.

see #localHasInstVarRef and #isClean how that simplifies code

Opens up more simplificatiosn (e.g. a shared superclass might make sense)