### PR TITLE
ReClassVariableNeitherReadNorWrittenRule

### DIFF
--- a/src/GeneralRules-Tests/ReAbstractRuleTestCase.class.st
+++ b/src/GeneralRules-Tests/ReAbstractRuleTestCase.class.st
@@ -26,7 +26,7 @@ ReAbstractRuleTestCase >> myCritiques [
 ReAbstractRuleTestCase >> myCritiquesOnClass: aClass [
 	| critiques |
 	critiques := OrderedCollection new.
-	self subjectUnderTest  new 
+	self subjectUnderTest new 
 		check: aClass forCritiquesDo:[:critique | critiques add: critique].
 	^critiques 
 ]

--- a/src/GeneralRules-Tests/ReClassVariableNeitherReadNorWrittenRuleTest.class.st
+++ b/src/GeneralRules-Tests/ReClassVariableNeitherReadNorWrittenRuleTest.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : #ReClassVariableNeitherReadNorWrittenRuleTest,
 	#superclass : #ReAbstractRuleTestCase,
-	#instVars : [
-		'aDummyVar'
-	],
 	#category : #'GeneralRules-Tests-Migrated'
 }
 

--- a/src/GeneralRules-Tests/ReClassVariableNeitherReadNorWrittenRuleTest.class.st
+++ b/src/GeneralRules-Tests/ReClassVariableNeitherReadNorWrittenRuleTest.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : #ReClassVariableNeitherReadNorWrittenRuleTest,
+	#superclass : #ReAbstractRuleTestCase,
+	#instVars : [
+		'aDummyVar'
+	],
+	#category : #'GeneralRules-Tests-Migrated'
+}
+
+{ #category : #tests }
+ReClassVariableNeitherReadNorWrittenRuleTest >> testRule [
+	| critiques |
+	critiques := self myCritiquesOnClass: RBLintRuleTestData.
+	self assert: critiques size equals: 1.
+
+]
+
+{ #category : #tests }
+ReClassVariableNeitherReadNorWrittenRuleTest >> testRuleDoesNotAppear [
+	| critiques |
+	critiques := self myCritiquesOnClass: self class.
+	self assert: critiques size equals: 0.
+
+]

--- a/src/GeneralRules/ReClassVariableNeitherReadNorWrittenRule.class.st
+++ b/src/GeneralRules/ReClassVariableNeitherReadNorWrittenRule.class.st
@@ -1,0 +1,45 @@
+"
+This smell arises when a class variable is not both read and written. If a class variable is only read, the reads can be replaced by nil, since it could not have been assigned a value. If the variable is only written, then it does not need to store the result since it is never used.
+"
+Class {
+	#name : #ReClassVariableNeitherReadNorWrittenRule,
+	#superclass : #ReAbstractRule,
+	#category : #'GeneralRules-Migrated'
+}
+
+{ #category : #'testing-interest' }
+ReClassVariableNeitherReadNorWrittenRule class >> checksClass [
+	^ true
+]
+
+{ #category : #enumerating }
+ReClassVariableNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
+	aClass classVariables
+		select: [ :variable | variable isReferenced not ]
+		thenDo: [ :variable | aCriticBlock cull: (self critiqueFor: aClass about: variable) ]
+]
+
+{ #category : #enumerating }
+ReClassVariableNeitherReadNorWrittenRule >> critiqueFor: aClass about: aVariable [
+
+	| crit |
+	crit := ReTrivialCritique
+		withAnchor: (ReVarSearchSourceAnchor
+			entity: aClass
+			string: aVariable name)
+		by: self.
+	
+	crit tinyHint: aVariable name.
+	^ crit
+]
+
+{ #category : #accessing }
+ReClassVariableNeitherReadNorWrittenRule >> name [
+
+	^ 'Class variable not read or not written'
+]
+
+{ #category : #accessing }
+ReClassVariableNeitherReadNorWrittenRule >> severity [
+	^ #information
+]

--- a/src/GeneralRules/ReIvarNeitherReadNorWrittenRule.class.st
+++ b/src/GeneralRules/ReIvarNeitherReadNorWrittenRule.class.st
@@ -1,5 +1,5 @@
 "
-This smell arises when an instance variable is not both read and written. If an instance variable is only read, the reads can be replaced by nil, since it could not have been assigned a value. If the variable is only written, then it does not need to store the result since it is never used. This check does not work for the data model classes since they use the #instVarAt:put: messages to set instance variables.
+This smell arises when an instance variable is not both read and written. If an instance variable is only read, the reads can be replaced by nil, since it could not have been assigned a value. If the variable is only written, then it does not need to store the result since it is never used.
 "
 Class {
 	#name : #ReIvarNeitherReadNorWrittenRule,


### PR DESCRIPTION
We have ReIvarNeitherReadNorWrittenRule, but no rule that checks if a class variable is not used.

This PR adds ReClassVariableNeitherReadNorWrittenRule and a Test