### PR TITLE
Simplify-MetaLinkInstaller

### DIFF
--- a/src/Reflectivity/MetaLink.class.st
+++ b/src/Reflectivity/MetaLink.class.st
@@ -263,26 +263,33 @@ MetaLink >> installOn: aNode [
 
 { #category : #'installing - link installer' }
 MetaLink >> installOnClassVarNamed: aClassVarName for: aClassOrObject option: option instanceSpecific: instanceSpecific [
-	| permalink |
+	| permalink variable |
+
 	permalink := self permaLinkFor: aClassOrObject option: option instanceSpecific: instanceSpecific.
-	^ self linkInstaller installPermaLink: permalink onClassVarNamed: aClassVarName
+	variable := permalink targetObjectOrClass nonAnonymousClass lookupVar: aClassVarName.
+	^ self linkInstaller installPermaLink: permalink onVariable: variable
 ]
 
 { #category : #'installing - link installer' }
 MetaLink >> installOnSlotNamed: aSlotName for: aClassOrObject option: option instanceSpecific: instanceSpecific [
-	| permalink |
+	| permalink variable |
 	permalink := self
 		permaLinkFor: aClassOrObject
 		option: option
 		instanceSpecific: instanceSpecific.
-	^ self linkInstaller installPermaLink: permalink onSlotNamed: aSlotName
+	variable := permalink targetObjectOrClass nonAnonymousClass lookupVar: aSlotName.
+	^ self linkInstaller installPermaLink: permalink onVariable: variable
 ]
 
 { #category : #'installing - link installer' }
 MetaLink >> installOnTempVarNamed: aTempName inMethod: aMethodName for: aClassOrObject option: option instanceSpecific: instanceSpecific [
-	| permalink |
+	| permalink method variable |
 	permalink := self permaLinkFor: aClassOrObject option: option instanceSpecific: instanceSpecific.
-	^ self linkInstaller installPermaLink: permalink onTempVarNamed: aTempName inMethod: aMethodName
+	
+	method := permalink targetObjectOrClass nonAnonymousClass lookupSelector: aMethodName.
+	variable := method temporaryVariableNamed: aTempName.
+	
+	^ self linkInstaller installPermaLink: permalink onVariable: variable
 ]
 
 { #category : #installing }
@@ -293,14 +300,10 @@ MetaLink >> installOnVariable: aVariable [
 { #category : #'installing - link installer' }
 MetaLink >> installOnVariableNamed: aName for: aClassOrObject option: option instanceSpecific: instanceSpecific [
 
-	| permalink |
-	permalink := self
-		             permaLinkFor: aClassOrObject
-		             option: option
-		             instanceSpecific: instanceSpecific.
-	^ self linkInstaller
-		  installPermaLink: permalink
-		  onVariableNamed: aName
+	| permalink variable |
+	permalink := self permaLinkFor: aClassOrObject option: option instanceSpecific: instanceSpecific.
+	variable := permalink targetObjectOrClass nonAnonymousClass lookupVar: aName.
+	^ self linkInstaller installPermaLink: permalink onVariable: variable
 ]
 
 { #category : #installing }

--- a/src/Reflectivity/MetaLinkInstaller.class.st
+++ b/src/Reflectivity/MetaLinkInstaller.class.st
@@ -156,46 +156,9 @@ MetaLinkInstaller >> install: aMetaLink onNode: aNode forObject: anObject [
 ]
 
 { #category : #permalinks }
-MetaLinkInstaller >> installPermaLink: aPermaLink onClassVarNamed: aClassVarName [
-	| classVar |	
-	classVar := 	aPermaLink targetObjectOrClass nonAnonymousClass classVariableNamed: aClassVarName asSymbol.
-	aPermaLink slotOrVariable: classVar.
-	
-	self registerAndInstallPermaLink: aPermaLink forTarget: classVar
-]
-
-{ #category : #permalinks }
-MetaLinkInstaller >> installPermaLink: aPermaLink onSlotNamed: aSlotName [
-	| slot |
-	slot := aPermaLink targetObjectOrClass nonAnonymousClass slotNamed: aSlotName.
-	aPermaLink slotOrVariable: slot.
-	
-	self registerAndInstallPermaLink: aPermaLink forTarget: slot
-]
-
-{ #category : #permalinks }
-MetaLinkInstaller >> installPermaLink: aPermaLink onTempVarNamed: aTempName inMethod: aMethodName [
-	| temp method |
-	
-	method := aPermaLink targetObjectOrClass nonAnonymousClass lookupSelector: aMethodName.
-	temp := method temporaryVariableNamed: aTempName.
-
-	aPermaLink slotOrVariable: temp.
-	aPermaLink slotOrVarMethod: temp method.
-	
-	self registerAndInstallPermaLink: aPermaLink forTarget: temp
-	
-
-
-
-]
-
-{ #category : #permalinks }
-MetaLinkInstaller >> installPermaLink: aPermaLink onVariableNamed: aName [
-	| variable |
-	variable := aPermaLink targetObjectOrClass lookupVar: aName.
-	aPermaLink slotOrVariable: variable.
-	self registerAndInstallPermaLink: aPermaLink forTarget: variable
+MetaLinkInstaller >> installPermaLink: aPermaLink onVariable: aVariable [
+	aPermaLink slotOrVariable: aVariable.
+	self registerAndInstallPermaLink: aPermaLink forTarget: aVariable
 ]
 
 { #category : #lookup }

--- a/src/Reflectivity/Object.extension.st
+++ b/src/Reflectivity/Object.extension.st
@@ -78,7 +78,7 @@ Object >> link: aMetaLink toClassVariableNamed: aClassVariableName [
 { #category : #'*Reflectivity' }
 Object >> link: aMetaLink toClassVariableNamed: aClassVariableName option: option [
 	aMetaLink
-		installOnClassVarNamed: aClassVariableName
+		installOnVariableNamed: aClassVariableName
 		for: self
 		option: option
 		instanceSpecific: self intanceSpecificMetaLinksAvailable
@@ -109,7 +109,7 @@ Object >> link: aMetaLink toSlotNamed: aSlotName [
 { #category : #'*Reflectivity' }
 Object >> link: aMetaLink toSlotNamed: aSlotName option: option [
 	aMetaLink
-		installOnSlotNamed: aSlotName
+		installOnVariableNamed: aSlotName
 		for: self
 		option: option
 		instanceSpecific: self intanceSpecificMetaLinksAvailable

--- a/src/Reflectivity/PermaLink.class.st
+++ b/src/Reflectivity/PermaLink.class.st
@@ -18,7 +18,6 @@ Class {
 		'persistenceType',
 		'isInstanceSpecific',
 		'slotOrVarClass',
-		'slotOrVarMethod',
 		'link'
 	],
 	#category : #'Reflectivity-Installer'
@@ -67,16 +66,6 @@ PermaLink >> slotOrVarClass [
 { #category : #accessing }
 PermaLink >> slotOrVarClass: anObject [
 	slotOrVarClass := anObject
-]
-
-{ #category : #accessing }
-PermaLink >> slotOrVarMethod [
-	^ slotOrVarMethod
-]
-
-{ #category : #accessing }
-PermaLink >> slotOrVarMethod: anObject [
-	slotOrVarMethod := anObject
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This PR simplifies MetaLinkInstaller by taking advantage of the new unified Variable hierarchy.

Instead of using names, we get the Variable object early and hand that over to the installer.

This alllows us to unify the code there for all Variables to be just #installPermaLink:onVariable:

PermaLink does not need to keep the method, as that information is already accessible from the Temporay Variable object 
(it was not used anyway)