### PR TITLE
enable-testInsteadVariableReadTemp

### DIFF
--- a/src/Reflectivity-Tests/ReflectivityControlTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityControlTest.class.st
@@ -1206,8 +1206,6 @@ ReflectivityControlTest >> testInsteadVariableReadIvar [
 { #category : #'tests - instead' }
 ReflectivityControlTest >> testInsteadVariableReadTemp [
 	| varNode instance |
-	self skip.
-	"skip for now as #usingMethods of the variable gets confused with instead"
 	varNode := (ReflectivityExamples >> #exampleAssignment) variableReadNodes first.
 	link := MetaLink new
 		metaObject: #context;


### PR DESCRIPTION
The improved model of temps now fixes the problem we had with testInsteadVariableReadTemp