### PR TITLE
Speedup-containsHalt

### DIFF
--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -183,12 +183,6 @@ CompiledCode >> comment [
 	^ self ast firstPrecodeComment
 ]
 
-{ #category : #testing }
-CompiledCode >> containsHalt [
-
-	^ self sendsAnySelectorOf: #( halt halt: haltIf: haltIfNil haltOnCount: haltOnce)
-]
-
 { #category : #'source code management' }
 CompiledCode >> definition [
 	"Polymorphic to class definition"

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -356,6 +356,12 @@ CompiledMethod >> codeForNoSource [
 	 ^(self compiler decompileMethod: self) formattedCode
 ]
 
+{ #category : #testing }
+CompiledMethod >> containsHalt [
+
+	^ self hasProperty: #containsHalt
+]
+
 { #category : #'source code management' }
 CompiledMethod >> copyWithSource: aString [
 	^self copyWithTrailerBytes: (CompiledMethodTrailer new sourceCode: aString) 

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -202,6 +202,14 @@ OCASTSemanticAnalyzer >> visitInlinedBlockNode: aBlockNode [
 ]
 
 { #category : #visiting }
+OCASTSemanticAnalyzer >> visitMessageNode: aNode [
+
+	super visitMessageNode: aNode.
+	aNode isHaltNode ifTrue: [ 
+		aNode methodNode methodPropertyAt: #containsHalt put: true ]
+]
+
+{ #category : #visiting }
 OCASTSemanticAnalyzer >> visitMethodNode: aMethodNode [
 
 	scope := compilationContext scope newMethodScope. 


### PR DESCRIPTION
Speed up #containsHalt by tagging methods with halts in Semantic Analysis.

As halts are not very common (and should never be commited), it is ok to pay for the overhead in terms of memory
(we pay only for methods containing a halt).

Slow down of compile time in minimal (just a fast check while already visiting the AST).

Next steps:
- this now can repalce #hasHalts use in Newtools
- maybe we could treat the #haltOrBreakpointForTesting  at this level, not sure.