### PR TITLE
MetaLink-DoNotAnnounceByDefault

### DIFF
--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -266,9 +266,10 @@ Breakpoint >> install [
 	self setAsNodeProperty.
 	self isObjectCentric
 		ifTrue: [ self targetInstance link: self link toAST: self node.
+			self class addBreakpoint: self.
 			^ self ].
 	self node link: self link.
-	self class addBreakpoint: self
+	self class addBreakpoint: self 
 ]
 
 { #category : #testing }

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -258,18 +258,17 @@ Breakpoint >> enable [
 Breakpoint >> initialize [
 	
 	self class initializeSlots: self.
-	options := #(+ optionCompileOnLinkInstallation - optionStyler)
+	options := #(+ optionCompileOnLinkInstallation)
 ]
 
 { #category : #install }
 Breakpoint >> install [
-	
-	self class addBreakpoint: self.
+	self setAsNodeProperty.
 	self isObjectCentric
 		ifTrue: [ self targetInstance link: self link toAST: self node.
 			^ self ].
-	self setAsNodeProperty.
-	self node link: self link
+	self node link: self link.
+	self class addBreakpoint: self
 ]
 
 { #category : #testing }

--- a/src/Reflectivity/CompiledMethod.extension.st
+++ b/src/Reflectivity/CompiledMethod.extension.st
@@ -44,9 +44,7 @@ CompiledMethod >> installLink: aMetaLink [
 	self reflectiveMethod increaseLinkCount.
 	(aMetaLink optionCompileOnLinkInstallation or: [ self isRealPrimitive ])
 		ifTrue: [ self reflectiveMethod compileAndInstallCompiledMethod ]
-		ifFalse: [ self invalidate ].
-	aMetaLink announceChange.
-	
+		ifFalse: [ self invalidate ]
 ]
 
 { #category : #'*Reflectivity' }

--- a/src/Reflectivity/ExecutionCounter.class.st
+++ b/src/Reflectivity/ExecutionCounter.class.st
@@ -123,7 +123,7 @@ ExecutionCounter >> install [
 	link := MetaLink new 
 				metaObject: self;
 				selector: #increase;
-				options: #(+ optionAnnounce - optionStyler).
+				options: #(+ optionAnnounce).
 	node link: link.
 	self class allCounters at: node put: self.
 ]

--- a/src/Reflectivity/MetaLink.class.st
+++ b/src/Reflectivity/MetaLink.class.st
@@ -58,7 +58,7 @@ MetaLink class >> defaultOptions [
 	+ optionWeakAfter 						  "do not use #ensure: for #after "
 	- optionAnnounce                    "do we announce adding / removing links? Slow"
 	- argsAsArray                       "pass all arguments in one array. By default off as it adds an array creation"
-	+ optionStyler							  "should the metalink be visualized in the Tools?"
+	- optionStyler							  "should the metalink be visualized in the Tools?"
 	)
 ]
 
@@ -94,6 +94,16 @@ MetaLink >> allReifications [
 { #category : #installing }
 MetaLink >> announceChange [
 	self optionAnnounce ifTrue: [SystemAnnouncer uniqueInstance announce: (MetalinkChanged new link: self)]
+]
+
+{ #category : #installing }
+MetaLink >> announceInstall: node [
+	self optionAnnounce ifTrue: [SystemAnnouncer uniqueInstance announce: (MetalinkChanged linkAdded: self toNode: node)]
+]
+
+{ #category : #installing }
+MetaLink >> announceRemove: node [
+	self optionAnnounce ifTrue: [SystemAnnouncer uniqueInstance announce: (MetalinkChanged linkRemoved: self fromNode: node)]
 ]
 
 { #category : #accessing }

--- a/src/Reflectivity/RBProgramNode.extension.st
+++ b/src/Reflectivity/RBProgramNode.extension.st
@@ -148,7 +148,7 @@ RBProgramNode >> link: aMetaLink [
 	self clearReflectivityAnnotations.
 	self methodNode method installLink: aMetaLink.
 	aMetaLink linkInstaller propagateLinkAddition: aMetaLink forNode: self.
-	SystemAnnouncer uniqueInstance announce: (MetalinkChanged linkAdded: aMetaLink toNode: self)
+	aMetaLink announceInstall: self
 ]
 
 { #category : #'*Reflectivity' }
@@ -202,7 +202,7 @@ RBProgramNode >> removeLink: aMetaLink [
 		ifFalse: [ ^ self ].
 	self methodNode method removeLink: aMetaLink.
 	aMetaLink linkInstaller propagateLinkRemoval: aMetaLink forNode: self.
-	SystemAnnouncer uniqueInstance announce: (MetalinkChanged linkRemoved: aMetaLink fromNode: self)
+	aMetaLink announceRemove: self
 ]
 
 { #category : #'*Reflectivity' }

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -163,8 +163,7 @@ ReflectiveMethod >> installCompiledMethod [
 ReflectiveMethod >> installLink: aMetaLink [
 	self increaseLinkCount.
 	(self ast hasOption: #optionCompileOnLinkInstallation for: aMetaLink) 
-		ifTrue: [ self compileAndInstallCompiledMethod ].
-	aMetaLink announceChange
+		ifTrue: [ self compileAndInstallCompiledMethod ]
 ]
 
 { #category : #invalidate }
@@ -256,8 +255,7 @@ ReflectiveMethod >> removeLink: aMetaLink [
 		ifTrue: [ self compileAndInstallCompiledMethod ]
 		ifFalse: [ compiledMethod invalidate ].
 	self decreaseLinkCount.
-	self linkCount = 0 ifTrue: [ self destroyTwin ].
-	aMetaLink announceChange		
+	self linkCount = 0 ifTrue: [ self destroyTwin ]
 ]
 
 { #category : #evaluation }

--- a/src/Reflectivity/Watch.class.st
+++ b/src/Reflectivity/Watch.class.st
@@ -110,7 +110,7 @@ Watch >> install [
 				arguments: #(value);
 				control: #after;
 				condition: [ recording ];
-				option: #(+ optionWeakAfter +optionAnnounce - optionStyler).
+				option: #(+ optionWeakAfter +optionAnnounce).
 	node link: link.
 	self class allWatches at: node put: self.
 ]


### PR DESCRIPTION
This PR does two things:

- make sure we do not announce MetaLink changes double
- all announcing is now governed by the #optionAnnounce which is false by default
- make #optionStyler false by default, too.