### PR TITLE
add-asForm-transform-to-morph

### DIFF
--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -1115,7 +1115,7 @@ Morph >> asForm [
 
 { #category : #converting }
 Morph >> asFormOfSize: extent [
-	"Answer a new task thumbnail for the receiver."
+	"Answer a new thumbnail for the receiver."
 	| form transform rect |
 
 	rect := self bounds scaledAndCenteredIn: (0@0 extent: extent).

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -1116,17 +1116,20 @@ Morph >> asForm [
 { #category : #converting }
 Morph >> asFormOfSize: extent [
 	"Answer a new task thumbnail for the receiver."
-	|f t r|
+	| form transform rect |
 
-	r := self bounds scaledAndCenteredIn: (0@0 extent: extent).
-	f := Form extent: r extent depth: Display depth.
-	t := MatrixTransform2x3 withScale: f extent / self extent.
-	f getCanvas
-		transformBy: t
-		clippingTo: f boundingBox
-		during: [:c | c translateBy: self topLeft negated during: [:ct | self fullDrawOn: ct]]
+	rect := self bounds scaledAndCenteredIn: (0@0 extent: extent).
+	form := Form extent: rect extent depth: Display depth.
+	transform := MatrixTransform2x3 withScale: form extent / self extent.
+	form getCanvas
+		transformBy: transform
+		clippingTo: form boundingBox
+		during: [ :canvas | 
+			canvas 
+				translateBy: self topLeft negated 
+				during: [ :translatedCanvas | self fullDrawOn: translatedCanvas ] ]
 		smoothing: 2.
-	^ f
+	^ form
 ]
 
 { #category : #creation }

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -1107,6 +1107,28 @@ Morph >> asDraggableMorph [
 	^self
 ]
 
+{ #category : #converting }
+Morph >> asForm [
+	
+	^ self asFormOfSize: self extent
+]
+
+{ #category : #converting }
+Morph >> asFormOfSize: extent [
+	"Answer a new task thumbnail for the receiver."
+	|f t r|
+
+	r := self bounds scaledAndCenteredIn: (0@0 extent: extent).
+	f := Form extent: r extent depth: Display depth.
+	t := MatrixTransform2x3 withScale: f extent / self extent.
+	f getCanvas
+		transformBy: t
+		clippingTo: f boundingBox
+		during: [:c | c translateBy: self topLeft negated during: [:ct | self fullDrawOn: ct]]
+		smoothing: 2.
+	^ f
+]
+
 { #category : #creation }
 Morph >> asMorph [
 	^ self

--- a/src/Morphic-Widgets-Taskbar/Morph.extension.st
+++ b/src/Morphic-Widgets-Taskbar/Morph.extension.st
@@ -17,18 +17,10 @@ Morph >> isTaskbar [
 { #category : #'*Morphic-Widgets-Taskbar' }
 Morph >> taskThumbnailOfSize: thumbExtent [
 	"Answer a new task thumbnail for the receiver."
-
-	|f t r|
-	r := self bounds scaledAndCenteredIn: (0@0 extent: thumbExtent).
-	f := Form extent: r extent depth: Display depth.
-	t := MatrixTransform2x3 withScale: f extent / self extent.
-	f getCanvas
-		transformBy: t
-		clippingTo: f boundingBox
-		during: [:c | c translateBy: self topLeft negated during: [:ct | self fullDrawOn: ct]]
-		smoothing: 2.
-	^ImageMorph new
-		form: f
+	
+	^ ImageMorph new
+		form: (self asFormOfSize: thumbExtent);
+		yourself
 ]
 
 { #category : #'*Morphic-Widgets-Taskbar' }


### PR DESCRIPTION
add asForm/asFormOfSize: methods (and maje taskThumbnailOfSize: use them, no point on having duplicated logic)