### PR TITLE
7684-New-trait-UI-wizard-cannot-display-the-package-name-in-apostrophe

### DIFF
--- a/src/Kernel/OldPharoClassDefinitionPrinter.class.st
+++ b/src/Kernel/OldPharoClassDefinitionPrinter.class.st
@@ -172,8 +172,8 @@ OldPharoClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString [
 	^ String streamContents: [ :s |
 			s nextPutAll: 'Trait named: #TMyTraits
 	 uses: {}
-	 package: '.
-			s nextPutAll: aString ]
+	 package: '''.
+			s nextPutAll: aString; nextPut: $' ]
  
 ]
 


### PR DESCRIPTION
Fixes: #7684. Adding quoptes around package name in trait template.