### PR TITLE
Signalling a VariableNotDeclared whenever we attempt to read or to write an undeclared variable

### DIFF
--- a/src/Kernel/UndeclaredVariable.class.st
+++ b/src/Kernel/UndeclaredVariable.class.st
@@ -37,11 +37,22 @@ UndeclaredVariable >> definingClass [
 { #category : #'code generation' }
 UndeclaredVariable >> emitStore: methodBuilder [
 
+	methodBuilder pushLiteralVariable: VariableNotDeclared binding.
+	methodBuilder pushLiteralVariable: self.
+	methodBuilder send: #signal:.
+	methodBuilder popTop.	
+	
 	methodBuilder storeIntoLiteralVariable: self
 ]
 
 { #category : #'code generation' }
 UndeclaredVariable >> emitValue: methodBuilder [
+	
+	methodBuilder pushLiteralVariable: VariableNotDeclared binding.
+	methodBuilder pushLiteralVariable: self.
+	methodBuilder send: #signal:.
+	methodBuilder popTop.
+	
 	methodBuilder pushLiteralVariable: self
 ]
 


### PR DESCRIPTION
Fixes https://github.com/pharo-project/pharo/issues/7083

Instead of transparently writing and reading undeclared variables, we signal a variable not declared exception. The idea is to give a chance to the debugger to catch it and propose the user to define it.

If we do not do that, the code continues its execution and it was (and can still be) the cause of bugs super hard to understand.

Now, this is a suggestion and works remains:
- how to test that code?
- what's the impact?
- if merged, the debugger will not be able to know what to define (a class? a variable?) and maybe it requires a simple heuristic to do that (or simply ask the user)