### PR TITLE
Returning default error value only on Error

### DIFF
--- a/src/UnifiedFFI/FFICallback.class.st
+++ b/src/UnifiedFFI/FFICallback.class.st
@@ -175,7 +175,7 @@ FFICallback >> thunk [
 FFICallback >> valueWithArguments: args [
 
 	^ [ block valueWithArguments: args ]
-		on: Exception 
+		on: Error 
 		fork: [ :e | e debug ]
 		return: [ self returnOnError ]
 ]


### PR DESCRIPTION
- Changing to Error so it is possible to Halt on Callbacks.
- Also, this affects the opening of modal windows, as they rely on the exception mechanism

Fix https://github.com/pharo-project/opensmalltalk-vm/issues/118
Fix #7678

