### PR TITLE
Fix issue 7703: Build 817 has broken parser #7703

### DIFF
--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -1773,6 +1773,23 @@ RBParserTest >> testReplacingNodes [
 	self assert: tree removeDeadCode equals: (self parserClass parseMethod: '+ q | q b | self ifTrue: [] ifFalse: [b := c]. q := b. {q. b}. ^q')
 ]
 
+{ #category : #tests }
+RBParserTest >> testScopesEnclosingMatchingLiterals [
+	| tree |
+
+	tree := self parserClass parseMethod: 'tmp [ $] ]'.
+	self assert: tree statements first isBlock.
+
+	tree := self parserClass parseMethod: 'tmp ($))'.
+	self assert: tree statements first isLiteralNode.
+	
+	tree := self parserClass parseMethod: 'tmp #( $) )'.
+	self assert: tree statements first isLiteralArray.
+	
+	tree := self parserClass parseMethod: 'tmp { $} }'.
+	self assert: tree statements first isDynamicArray.
+]
+
 { #category : #testSelector }
 RBParserTest >> testSelectorFromMessageIsSelectorNode [
 	| tree |

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -1112,8 +1112,13 @@ RBParser >> parseStatementList: pragmaBoolean into: sequenceNode untilAnyCloserO
 			periods add: currentToken start.
 			self step ].
 
-	[  self atEnd or: [ aCollectionOfClosers includes: currentToken value ] ] whileFalse: [
-		self parseStatementInto: statements periodList: periods withAcceptedStatementClosers: aCollectionOfClosers ].
+	[ self atEnd or: [ currentToken isSpecial
+		and: [aCollectionOfClosers includes: currentToken value] ] ]
+			whileFalse: [
+				self 
+					parseStatementInto: statements
+					periodList: periods
+					withAcceptedStatementClosers: aCollectionOfClosers ].
 
 	statements notEmpty ifTrue: [ self addCommentsTo: statements last ].
 	sequenceNode


### PR DESCRIPTION
Scope parsing should be done only with special tokens and not normal character tokens.
Added regression tests too.

- Fixes #7703