### PR TITLE
merge spec 0.7.6

### DIFF
--- a/src/Calypso-SystemPlugins-Reflectivity-Browser-Tests/ClyInstallMetaLinkPresenterTest.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser-Tests/ClyInstallMetaLinkPresenterTest.class.st
@@ -72,7 +72,7 @@ ClyInstallMetaLinkPresenterTest >> testInstallSelectedMetalinkActionButton [
 	list := presenter metalinkListPresenter.
 	list clickItem: 1.	
 	self deny: self nodeInRealMethod hasLinks.
-	presenter toolbarButtons first execute.
+	presenter toolbarButtons first click.
 	self assert: self nodeInRealMethod hasLinks.
 	self assert: self nodeInRealMethod links asArray first identicalTo: list items first 
 ]
@@ -137,6 +137,6 @@ ClyInstallMetaLinkPresenterTest >> testUninstallSelectedMetalinkActionButton [
 	list := presenter metalinkListPresenter.
 	list clickItem: 1.	
 	self assert: self nodeInRealMethod hasLinks.
-	presenter toolbarButtons first execute.
+	presenter toolbarButtons first click.
 	self deny: self nodeInRealMethod hasLinks
 ]

--- a/src/Spec2-Adapters-Morphic-Tests/SpStylePropertyTest.class.st
+++ b/src/Spec2-Adapters-Morphic-Tests/SpStylePropertyTest.class.st
@@ -9,16 +9,18 @@ SpStylePropertyTest >> testMergeWith [
 	| p1 p2 p3 |
 	
 	p1 := SpStyleGeometry new
-		extent: 20@20;
+		width: 20;
+		height: 20;
 		yourself.
 	p2 := SpStyleGeometry new
-		extent: 40@40;
+		width: 40;
+		height: 40;
 		yourself.
 		
 	p3 := p1, p2.
 	
-	self assert: p3 extent equals: 40@40.
-	
+	self assert: p3 width equals: 40.
+	self assert: p3 height equals: 40	
 ]
 
 { #category : #tests }

--- a/src/Spec2-Adapters-Morphic-Tests/SpStylePropertyTest.class.st
+++ b/src/Spec2-Adapters-Morphic-Tests/SpStylePropertyTest.class.st
@@ -20,3 +20,59 @@ SpStylePropertyTest >> testMergeWith [
 	self assert: p3 extent equals: 40@40.
 	
 ]
+
+{ #category : #tests }
+SpStylePropertyTest >> testMergeWithFontDoNotRemovePredefinedFontWhenNoFontIsDefined [
+	| p1 p2 p3 |
+	
+	p1 := SpStyleFont new
+		predefinedFont: #default;
+		yourself.
+	p2 := SpStyleFont new
+		name: nil;
+		color: Color white;
+		yourself.
+		
+	p3 := p1, p2.
+	
+	self deny: p3 predefinedFont isNil.
+	self assert: p3 color equals: Color white
+]
+
+{ #category : #tests }
+SpStylePropertyTest >> testMergeWithFontRemovePredefinedFont [
+	| p1 p2 p3 |
+	
+	p1 := SpStyleFont new
+		predefinedFont: #default;
+		yourself.
+	p2 := SpStyleFont new
+		name: 'Source Code Pro';
+		size: 10;
+		yourself.
+		
+	p3 := p1, p2.
+	
+	self assert: p3 predefinedFont isNil.
+	
+]
+
+{ #category : #tests }
+SpStylePropertyTest >> testMergeWithPredefinedFontCanBeDecorated [
+	| p1 p2 p3 |
+	
+	p1 := SpStyleFont new
+		predefinedFont: #default;
+		yourself.
+	p2 := SpStyleFont new
+		name: nil;
+		color: Color white;
+		size: 42;
+		yourself.
+	
+	p3 := p1, p2.
+	
+	self deny: p3 predefinedFont isNil.
+	self assert: p3 color equals: Color white.
+	self assert: p3 definedFont pointSize equals: 42
+]

--- a/src/Spec2-Adapters-Morphic-Tests/SpStyleVariableTest.class.st
+++ b/src/Spec2-Adapters-Morphic-Tests/SpStyleVariableTest.class.st
@@ -1,0 +1,54 @@
+Class {
+	#name : #SpStyleVariableTest,
+	#superclass : #TestCase,
+	#category : #'Spec2-Adapters-Morphic-Tests'
+}
+
+{ #category : #tests }
+SpStyleVariableTest >> testParseBasicValue [
+	| property |
+
+	property := SpStyleVariableSTONReader fromString: 'Geometry { #height: 25 }'.
+	self assert: property height class equals: SpStyleVariable.
+	self assert: property height value equals: 25
+]
+
+{ #category : #tests }
+SpStyleVariableTest >> testParseColorVariable [
+	| property |
+
+	property := SpStyleVariableSTONReader fromString: 'Container { #borderColor: #red }'.
+	self assert: property borderColor class equals: SpStyleVariable.
+	self assert: property borderColor value equals: #red.
+	self assert: property borderColor valueAsColor equals: Color red.
+	
+	property := SpStyleVariableSTONReader fromString: 'Container { 
+		#borderColor: Color { #red:1, #green:0, #blue:0, #alpha:1 } }'.
+	self assert: property borderColor class equals: SpStyleVariable.
+	self assert: property borderColor value equals: Color red.
+	self assert: property borderColor valueAsColor equals: Color red
+
+]
+
+{ #category : #tests }
+SpStyleVariableTest >> testParseFontVariable [
+	| property |
+
+	property := SpStyleVariableSTONReader fromString: 'Font { #name: EnvironmentFont(#default) }'.
+	self assert: property name class equals: SpStyleVariableEnvironmentFont.
+	self assert: property name value equals: StandardFonts defaultFont.	
+	
+	property := SpStyleVariableSTONReader fromString: 'Font { #name: EnvironmentFont(#code) }'.
+	self assert: property name class equals: SpStyleVariableEnvironmentFont.
+	self assert: property name value equals: StandardFonts codeFont.	
+
+]
+
+{ #category : #tests }
+SpStyleVariableTest >> testParseResetVariable [
+	| property |
+
+	property := SpStyleVariableSTONReader fromString: 'Geometry { #vResizing: Reset }'.
+	self assert: property vResizing class equals: SpStyleVariableReset.
+	self assert: property vResizing value isNil
+]

--- a/src/Spec2-Adapters-Morphic-Tests/SpStyleVariableTest.class.st
+++ b/src/Spec2-Adapters-Morphic-Tests/SpStyleVariableTest.class.st
@@ -9,8 +9,8 @@ SpStyleVariableTest >> testParseBasicValue [
 	| property |
 
 	property := SpStyleVariableSTONReader fromString: 'Geometry { #height: 25 }'.
-	self assert: property height class equals: SpStyleVariable.
-	self assert: property height value equals: 25
+	self assert: property height equals: 25.
+	self assert: property heightVariable value equals: 25
 ]
 
 { #category : #tests }
@@ -18,16 +18,15 @@ SpStyleVariableTest >> testParseColorVariable [
 	| property |
 
 	property := SpStyleVariableSTONReader fromString: 'Container { #borderColor: #red }'.
-	self assert: property borderColor class equals: SpStyleVariable.
-	self assert: property borderColor value equals: #red.
-	self assert: property borderColor valueAsColor equals: Color red.
+	self assert: property borderColor equals: #red.
+	self assert: property borderColorVariable value equals: #red.
+	self assert: property borderColorVariable valueAsColor equals: Color red.
 	
 	property := SpStyleVariableSTONReader fromString: 'Container { 
 		#borderColor: Color { #red:1, #green:0, #blue:0, #alpha:1 } }'.
-	self assert: property borderColor class equals: SpStyleVariable.
-	self assert: property borderColor value equals: Color red.
-	self assert: property borderColor valueAsColor equals: Color red
-
+	self assert: property borderColor equals: Color red.
+	self assert: property borderColorVariable value equals: Color red.
+	self assert: property borderColorVariable valueAsColor equals: Color red
 ]
 
 { #category : #tests }
@@ -49,6 +48,6 @@ SpStyleVariableTest >> testParseResetVariable [
 	| property |
 
 	property := SpStyleVariableSTONReader fromString: 'Geometry { #vResizing: Reset }'.
-	self assert: property vResizing class equals: SpStyleVariableReset.
-	self assert: property vResizing value isNil
+	self assert: property vResizing isNil.
+	self assert: property vResizingVariable value isNil
 ]

--- a/src/Spec2-Adapters-Morphic-Tests/SpStyleVariableTest.class.st
+++ b/src/Spec2-Adapters-Morphic-Tests/SpStyleVariableTest.class.st
@@ -32,14 +32,10 @@ SpStyleVariableTest >> testParseColorVariable [
 { #category : #tests }
 SpStyleVariableTest >> testParseFontVariable [
 	| property |
-
-	property := SpStyleVariableSTONReader fromString: 'Font { #name: EnvironmentFont(#default) }'.
-	self assert: property name class equals: SpStyleVariableEnvironmentFont.
-	self assert: property name value equals: StandardFonts defaultFont.	
 	
 	property := SpStyleVariableSTONReader fromString: 'Font { #name: EnvironmentFont(#code) }'.
-	self assert: property name class equals: SpStyleVariableEnvironmentFont.
-	self assert: property name value equals: StandardFonts codeFont.	
+	self assert: property nameVariable class equals: SpStyleVariableEnvironmentFont.
+	self assert: property nameVariable value equals: StandardFonts codeFont.	
 
 ]
 

--- a/src/Spec2-Adapters-Morphic/MillerScrollPane.class.st
+++ b/src/Spec2-Adapters-Morphic/MillerScrollPane.class.st
@@ -72,8 +72,8 @@ MillerScrollPane >> onLayoutChange: aBlock [
 { #category : #accessing }
 MillerScrollPane >> showMorph: aMorph [
 	
-	keepShowingPage ifTrue: [ 
-		firstShowingMorph := aMorph ].
+	keepShowingPage 
+		ifTrue: [ firstShowingMorph := aMorph ].
 	self basicShowMorph: aMorph
 ]
 

--- a/src/Spec2-Adapters-Morphic/Object.extension.st
+++ b/src/Spec2-Adapters-Morphic/Object.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Object }
+
+{ #category : #'*Spec2-Adapters-Morphic' }
+Object >> asStyleVariable [
+
+	^ SpStyleVariable newValue: self
+]

--- a/src/Spec2-Adapters-Morphic/PharoDarkTheme.extension.st
+++ b/src/Spec2-Adapters-Morphic/PharoDarkTheme.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #PharoDarkTheme }
+
+{ #category : #'*Spec2-Adapters-Morphic' }
+PharoDarkTheme >> popoverButtonColor [
+
+	^ self lightBaseColor
+]

--- a/src/Spec2-Adapters-Morphic/SpAbstractMorphicAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpAbstractMorphicAdapter.class.st
@@ -102,6 +102,12 @@ SpAbstractMorphicAdapter >> application [
 ]
 
 { #category : #styling }
+SpAbstractMorphicAdapter >> applyStyle [
+
+	self applyStyle: self widget
+]
+
+{ #category : #styling }
 SpAbstractMorphicAdapter >> applyStyle: morph [
 	"this will apply general properties to the built morph"
 	

--- a/src/Spec2-Adapters-Morphic/SpMorphStyle.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphStyle.class.st
@@ -70,8 +70,8 @@ SpMorphStyle class >> newStyles: anArray [
 SpMorphStyle >> applyTo: aMorph [ 
 
 	aMorph setProperty: #style toValue: self.
-	self mergedProperties do: [ :each |
-		each applyTo: aMorph ]
+	self mergedProperties 
+		do: [ :each | each applyTo: aMorph ]
 ]
 
 { #category : #'accessing container' }

--- a/src/Spec2-Adapters-Morphic/SpMorphicActionBarAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicActionBarAdapter.class.st
@@ -21,9 +21,9 @@ SpMorphicActionBarAdapter >> addModelTo: aMorph [
 
 	self flag: #TODO. "Maybe validate they are just buttons inside?"
 	(self model items at: #start ifAbsent: [ #() ]) do: [ :each |
-		aMorph submorphs first addMorphBack: (self buildActionButton: each) ].
+		aMorph addItemLeft: (self buildActionButton: each) ].
 	(self model items at: #end ifAbsent: [ #() ]) reverseDo: [ :each |
-		aMorph submorphs second addMorphBack: (self buildActionButton: each) ]
+		aMorph addItemRight: (self buildActionButton: each) ]
 ]
 
 { #category : #factory }

--- a/src/Spec2-Adapters-Morphic/SpMorphicBoxAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicBoxAdapter.class.st
@@ -283,9 +283,8 @@ SpMorphicBoxAdapter >> replace: aPresenter with: otherPresenter withConstraints:
 { #category : #private }
 SpMorphicBoxAdapter >> verifyBoxExtent [
 
-	(startPanel hasSubmorphs 
-		and: [ endPanel hasSubmorphs ])
-	ifFalse: [ widget extent: 0@0 ]
+	(startPanel hasSubmorphs not and: [ endPanel hasSubmorphs not ])
+		ifTrue: [ widget extent: 0@0 ]
 ]
 
 { #category : #private }

--- a/src/Spec2-Adapters-Morphic/SpMorphicBoxAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicBoxAdapter.class.st
@@ -136,7 +136,7 @@ SpMorphicBoxAdapter >> basicAdd: aPresenter constraints: constraints to: aPanel 
 	childMorph := self buildMorph: aPresenter constraints: constraints.	
 
 	self applyAlignmentToChild: childMorph.
-	aPanel extent: (aPanel width max: childMorph width)@(aPanel height max: childMorph height).
+	self verifyBoxExtentOf: aPanel withChild: childMorph.
 
 	constraints isPlacedAtStart
 		ifTrue: [ startPanel addMorphBack: childMorph ]
@@ -286,4 +286,14 @@ SpMorphicBoxAdapter >> verifyBoxExtent [
 	(startPanel hasSubmorphs 
 		and: [ endPanel hasSubmorphs ])
 	ifFalse: [ widget extent: 0@0 ]
+]
+
+{ #category : #private }
+SpMorphicBoxAdapter >> verifyBoxExtentOf: aPanel withChild: childMorph [
+	| width height |
+	
+	width := childMorph width + (widget borderWidth * 2).
+	height := childMorph height + (widget borderWidth * 2).
+	
+	aPanel extent: (aPanel width max: width)@(aPanel height max: height)
 ]

--- a/src/Spec2-Adapters-Morphic/SpMorphicBoxAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicBoxAdapter.class.st
@@ -97,35 +97,36 @@ SpMorphicBoxAdapter >> addVerticalPadding: aNumber toMorph: aMorph [
 
 { #category : #private }
 SpMorphicBoxAdapter >> applyAlignmentTo: aWidget [
-	| alignmentWidget |
-	
-	aWidget changeTableLayout.
-	
-	alignmentWidget := Morph new
-		extent: aWidget extent;
-		changeTableLayout; 
-		color: Color transparent;
-		addMorphBack: widget.
-		
+
 	layout isVertical 
 		ifTrue: [
-			aWidget 
-				hResizing: #spaceFill; 
-				vResizing: #shrinkWrap.
 			layout vAlign ifNotNil: [ :align |
-				alignmentWidget wrapCentering: align asMorphicAlign ].
+				startPanel vResizing: #shrinkWrap.
+				aWidget listCentering: align asMorphicAlign ].
 			layout hAlign ifNotNil: [ :align |
-				alignmentWidget listCentering: align asMorphicAlign ] ]
+				startPanel hResizing: #shrinkWrap.
+				aWidget wrapCentering: align asMorphicAlign.
+				aWidget cellPositioning: align asMorphicAlign ] ]
 		ifFalse: [ 
-			aWidget 
-				hResizing: #shrinkWrap; 
-				vResizing: #spaceFill.
 			layout vAlign ifNotNil: [ :align |
-				alignmentWidget listCentering: align asMorphicAlign ].
+				startPanel vResizing: #shrinkWrap.
+				aWidget wrapCentering: align asMorphicAlign.
+				aWidget cellPositioning: align asMorphicAlign ].
 			layout hAlign ifNotNil: [ :align |
-				alignmentWidget wrapCentering: align asMorphicAlign ] ].
-		
-	^ alignmentWidget
+				startPanel hResizing: #shrinkWrap.
+				aWidget listCentering: align asMorphicAlign ] ].
+
+	^ aWidget
+]
+
+{ #category : #private }
+SpMorphicBoxAdapter >> applyAlignmentToChild: aWidget [
+
+	layout vAlign 
+		ifNotNil: [ aWidget vResizing: #rigid ].
+	layout hAlign 
+		ifNotNil: [ aWidget hResizing: #rigid ]
+
 ]
 
 { #category : #private }
@@ -134,6 +135,7 @@ SpMorphicBoxAdapter >> basicAdd: aPresenter constraints: constraints to: aPanel 
 
 	childMorph := self buildMorph: aPresenter constraints: constraints.	
 
+	self applyAlignmentToChild: childMorph.
 	aPanel extent: (aPanel width max: childMorph width)@(aPanel height max: childMorph height).
 
 	constraints isPlacedAtStart
@@ -230,14 +232,17 @@ SpMorphicBoxAdapter >> remove: aPresenter [
 
 	morph := aPresenter adapter widget.	
 	startPanel removeMorph: morph.
-	endPanel removeMorph: morph
+	endPanel removeMorph: morph.
+	self verifyBoxExtent
+	
 ]
 
 { #category : #accessing }
 SpMorphicBoxAdapter >> removeAll [
 
 	startPanel removeAllMorphs.
-	endPanel removeAllMorphs
+	endPanel removeAllMorphs.
+	self verifyBoxExtent
 ]
 
 { #category : #factory }
@@ -273,4 +278,12 @@ SpMorphicBoxAdapter >> replace: aPresenter with: otherPresenter withConstraints:
 	
 	newMorph := self buildMorph: otherPresenter constraints: constraints.
 	panel replaceSubmorph: oldMorph by: newMorph
+]
+
+{ #category : #private }
+SpMorphicBoxAdapter >> verifyBoxExtent [
+
+	(startPanel hasSubmorphs 
+		and: [ endPanel hasSubmorphs ])
+	ifFalse: [ widget extent: 0@0 ]
 ]

--- a/src/Spec2-Adapters-Morphic/SpMorphicButtonAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicButtonAdapter.class.st
@@ -31,14 +31,19 @@ SpMorphicButtonAdapter >> askBeforeChanging [
 
 { #category : #private }
 SpMorphicButtonAdapter >> buildLabel: text withIcon: icon [
+	| iconLabel |
 
-	icon ifNil: [ ^ (text localizedForPresenter: self presenter)
-			ifNil: [ '' ] ].
+	icon ifNil: [ 
+		^ (text localizedForPresenter: self presenter) ifNil: [ '' ] ].
 	
-	^ IconicListItem 
-		text: text 
-		icon: icon
-
+	iconLabel := IconicListItem new.
+	iconLabel icon: icon.
+	text isEmptyOrNil ifFalse: [ 
+		iconLabel morph: (text asMorph 
+			lock;
+			yourself) ].
+		
+	^ iconLabel
 ]
 
 { #category : #factory }

--- a/src/Spec2-Adapters-Morphic/SpMorphicGridLayoutComputation.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicGridLayoutComputation.class.st
@@ -291,9 +291,10 @@ SpMorphicGridLayoutComputation >> layout [
 	^ layout
 ]
 
-{ #category : #private }
+{ #category : #TOREMOVE }
 SpMorphicGridLayoutComputation >> maxWidthOf: aCollection [
 
+	self flag: #REMOVE. "I think noone uses it?"
 	^ (aCollection collect: [ :each | (each valueOfProperty: #style) width ]) max
 ]
 

--- a/src/Spec2-Adapters-Morphic/SpMorphicPopoverAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicPopoverAdapter.class.st
@@ -37,6 +37,12 @@ SpMorphicPopoverAdapter >> buildWidget [
 	^ panelMorph
 ]
 
+{ #category : #factory }
+SpMorphicPopoverAdapter >> contentPresenter [
+	
+	^ self presenter presenter
+]
+
 { #category : #api }
 SpMorphicPopoverAdapter >> dismiss [ 
 
@@ -46,20 +52,25 @@ SpMorphicPopoverAdapter >> dismiss [
 { #category : #api }
 SpMorphicPopoverAdapter >> popup [
 
-	self widgetDo: [ :w | w popup ]
+	self widgetDo: [ :w | 
+		self applyStyle: w.
+		w popup ]
 ]
 
 { #category : #api }
 SpMorphicPopoverAdapter >> popupPointingTo: aRectangle [
 
-	self widgetDo: [ :w | 
+	self widgetDo: [ :w |
+		self applyStyle: w.
 		w popupPointingTo: aRectangle ]
 ]
 
 { #category : #factory }
 SpMorphicPopoverAdapter >> presenterWidget [
 
-	^ self presenter presenter buildWithSpec
+	self contentPresenter buildWithSpec.
+	self contentPresenter adapter applyStyle.
+	^ self contentPresenter adapter widget
 ]
 
 { #category : #factory }

--- a/src/Spec2-Adapters-Morphic/SpMorphicTableCellBuilder.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTableCellBuilder.class.st
@@ -73,7 +73,6 @@ SpMorphicTableCellBuilder >> addCellMorph: morph column: aTableColumn [
 			width: aTableColumn width ].
 	
 	cell addMorphBack: morph
-	
 ]
 
 { #category : #private }
@@ -178,8 +177,21 @@ SpMorphicTableCellBuilder >> visitCompositeColumn: aTableColumn [
 
 { #category : #visiting }
 SpMorphicTableCellBuilder >> visitImageColumn: aTableColumn [
+	| morph imageMorph image |
 	
-	self addCellColumn: aTableColumn
+	image := aTableColumn readObject: self item.
+	image ifNil: [ ^ self ].
+	
+	imageMorph := image asMorph.
+	morph := 	Morph new 
+		color: Color transparent;
+		addMorphBack: imageMorph;
+		extent: imageMorph extent;
+		yourself.
+
+	self 
+		addCellMorph: morph 
+		column: aTableColumn
 ]
 
 { #category : #visiting }

--- a/src/Spec2-Adapters-Morphic/SpMorphicToolbarAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicToolbarAdapter.class.st
@@ -35,7 +35,7 @@ SpMorphicToolbarAdapter >> configureItem: itemModel morph: itemMorph toolBar: to
 	
 	itemMorph 
 		font: toolBarMorph toolbarItemFont;
-		width: toolBarMorph toolbarItemSize.
+		minWidth: toolBarMorph displayMode width.
 	
 	toolBarMorph displayMode 
 		configureMorph: itemMorph 

--- a/src/Spec2-Adapters-Morphic/SpMorphicToolbarButtonAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicToolbarButtonAdapter.class.st
@@ -28,7 +28,7 @@ SpMorphicToolbarButtonAdapter >> button [
 { #category : #execution }
 SpMorphicToolbarButtonAdapter >> execute [
 
-	self presenter action cull: self
+	self presenter action cull: self presenter
 ]
 
 { #category : #factory }

--- a/src/Spec2-Adapters-Morphic/SpMorphicToolbarButtonAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicToolbarButtonAdapter.class.st
@@ -25,6 +25,12 @@ SpMorphicToolbarButtonAdapter >> button [
 	^ widget
 ]
 
+{ #category : #execution }
+SpMorphicToolbarButtonAdapter >> execute [
+
+	self presenter action cull: self
+]
+
 { #category : #factory }
 SpMorphicToolbarButtonAdapter >> morphClass [
 
@@ -38,9 +44,9 @@ SpMorphicToolbarButtonAdapter >> newButton [
 			on: self presenter
 			getState: nil 
 			action: #execute)
-		helpText: self model help;
+		helpText: self presenter help;
 		beIconTop;
-		hResizing: #rigid;
+		hResizing: #shrinkWrap;
 		vResizing: #spaceFill;
 		borderWidth: 0;
 		borderColor: Color transparent;		

--- a/src/Spec2-Adapters-Morphic/SpMorphicToolbarPopoverButtonAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicToolbarPopoverButtonAdapter.class.st
@@ -1,0 +1,14 @@
+Class {
+	#name : #SpMorphicToolbarPopoverButtonAdapter,
+	#superclass : #SpMorphicToolbarButtonAdapter,
+	#category : #'Spec2-Adapters-Morphic-Base'
+}
+
+{ #category : #execution }
+SpMorphicToolbarPopoverButtonAdapter >> execute [
+
+	self presenter newPopover
+		addStyle: 'popoverButton';
+		presenter: self presenter content value;
+		popup
+]

--- a/src/Spec2-Adapters-Morphic/SpMorphicTreeTableAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTreeTableAdapter.class.st
@@ -167,6 +167,12 @@ SpMorphicTreeTableAdapter >> ensureAtLeastOneColumnIn: tableMorph [
 ]
 
 { #category : #accessing }
+SpMorphicTreeTableAdapter >> expandAll [
+
+	widget dataSource expandAll
+]
+
+{ #category : #accessing }
 SpMorphicTreeTableAdapter >> expandPath: anArray [  
 
 	widget dataSource expandPath: anArray

--- a/src/Spec2-Adapters-Morphic/SpPaginatorMorph.class.st
+++ b/src/Spec2-Adapters-Morphic/SpPaginatorMorph.class.st
@@ -61,7 +61,7 @@ SpPaginatorMorph >> adjustSelectionToClosestPage [
 SpPaginatorMorph >> adjustShownPages [
 	| newShownPages |
 
-	newShownPages := (selectionMorph width / self baseWidth) asInteger.
+	newShownPages := (selectionMorph width / self baseWidth) asInteger max: 1.
 	self numberOfPagesShown = newShownPages 
 		ifFalse: [ self numberOfPagesShown: newShownPages ]
 ]

--- a/src/Spec2-Adapters-Morphic/SpPopoverDeleteListenerMorph.class.st
+++ b/src/Spec2-Adapters-Morphic/SpPopoverDeleteListenerMorph.class.st
@@ -1,0 +1,29 @@
+"
+A morph that acts EXCLUSIVELY as a listener of mouse events. 
+The purpose is to listen to mouse events and send them back to a `SpPopoverMorph`.
+
+See `SpPopoverMorph>>#registerToDeleteEvents`.
+"
+Class {
+	#name : #SpPopoverDeleteListenerMorph,
+	#superclass : #Morph,
+	#category : #'Spec2-Adapters-Morphic-Support'
+}
+
+{ #category : #'events-processing' }
+SpPopoverDeleteListenerMorph >> handleMouseDown: evt [
+
+	^ self eventHandler ifNotNil: [:handler | handler mouseDown: evt fromMorph: self ]
+]
+
+{ #category : #'events-processing' }
+SpPopoverDeleteListenerMorph >> handleMouseMove: evt [
+
+	^ self eventHandler ifNotNil: [:handler | handler mouseMove: evt fromMorph: self ]
+]
+
+{ #category : #'events-processing' }
+SpPopoverDeleteListenerMorph >> handleMouseUp: evt [
+
+	^ self eventHandler ifNotNil: [:handler | handler mouseUp: evt fromMorph: self ]
+]

--- a/src/Spec2-Adapters-Morphic/SpPopoverMorph.class.st
+++ b/src/Spec2-Adapters-Morphic/SpPopoverMorph.class.st
@@ -1,12 +1,96 @@
+"
+I am a popover morph, which is a morph who will pop in relation to another morph (or/and in a relative position). 
+It has a position: top, left, bottom and right (default is right).
+It will be dismissed if click outside or keyboard focus translate to another place other than its children.
+"
 Class {
 	#name : #SpPopoverMorph,
-	#superclass : #PanelMorph,
+	#superclass : #Morph,
 	#instVars : [
 		'position',
-		'relativeTo'
+		'relativeTo',
+		'showArrow',
+		'arrowSize',
+		'deleteMorph'
 	],
 	#category : #'Spec2-Adapters-Morphic-Support'
 }
+
+{ #category : #private }
+SpPopoverMorph >> arrowBottomVertices [
+	| rect |
+	
+	rect := ((self left + (self width / 2)) - self borderWidth)@(self top) extent: self arrowSize@(self borderWidth / 2).
+	^ { 
+		rect bottomLeft. 
+		rect topCenter.
+		rect bottomRight.
+	 }
+]
+
+{ #category : #private }
+SpPopoverMorph >> arrowLeftVertices [
+	| rect |
+	
+	"rect := (self right - (self borderWidth / 2))@((self top + (self height / 2)) - (self arrowSize / 2)) extent: (self borderWidth / 2)@self arrowSize."
+	rect := (self right - (self borderWidth / 2))@(self top + (self borderWidth * 1.5)) extent: (self borderWidth / 2)@self arrowSize.
+	
+	^ { 
+		rect topLeft. 
+		rect rightCenter.
+		rect bottomLeft.
+	 }
+]
+
+{ #category : #private }
+SpPopoverMorph >> arrowRightVertices [
+	| rect |
+	
+	"rect := self left@((self top + (self height / 2)) - (self arrowSize / 2)) extent: (self borderWidth / 2)@self arrowSize."
+	rect := self left@(self top + (self borderWidth * 1.5)) extent: (self borderWidth / 2)@self arrowSize.
+
+	
+	^ { 
+		rect topRight. 
+		rect leftCenter.
+		rect bottomRight.
+	 }
+]
+
+{ #category : #accessing }
+SpPopoverMorph >> arrowSize [
+
+	^ arrowSize ifNil: [ 20 ]
+]
+
+{ #category : #accessing }
+SpPopoverMorph >> arrowSize: aNumber [
+
+	arrowSize := aNumber
+]
+
+{ #category : #private }
+SpPopoverMorph >> arrowTopVertices [
+	| rect |
+	
+	rect := ((self left + (self width / 2)) - self borderWidth)@(self bottom - (self borderWidth / 2)) extent: self arrowSize@(self borderWidth / 2).
+	^ { 
+		rect topLeft. 
+		rect bottomCenter.
+		rect topRight.
+	 }
+]
+
+{ #category : #private }
+SpPopoverMorph >> arrowVertices [
+
+	position = #bottom ifTrue: [ ^ self arrowBottomVertices ].
+	position = #right ifTrue: [ ^ self arrowRightVertices ].
+	position = #top ifTrue: [ ^ self arrowTopVertices ].
+	position = #left ifTrue: [ ^ self arrowLeftVertices ].
+	
+	self error: 'Should not arrive here'
+]
 
 { #category : #accessing }
 SpPopoverMorph >> bePositionBottom [
@@ -68,7 +152,7 @@ SpPopoverMorph >> calculatePositionLeftFrom: aRect [
 	| x y |
 	
 	x := aRect origin x - self separatatedBy - self width.
-	y := aRect origin y.
+	y := aRect origin y - self borderWidth.
 
 	^ x @ y	
 ]
@@ -78,7 +162,7 @@ SpPopoverMorph >> calculatePositionRightFrom: aRect [
 	| x y |
 	
 	x := aRect corner x + self separatatedBy.
-	y := aRect origin y.
+	y := aRect origin y - self borderWidth.
 
 	^ x @ y
 ]
@@ -97,17 +181,53 @@ SpPopoverMorph >> calculatePositionTopFrom: aRect [
 SpPopoverMorph >> contentMorph: aMorph [ 
 
 	self removeAllMorphs.
-	self extent: aMorph extent + (self borderWidth * 2) + (aMorph borderWidth * 2).
-	self addMorphBack: aMorph.
-	 "I need this to calculate properly the size (otherwise I cannot position 
-	  the popover correctly"
-	self computeFullBounds
+	self addMorphBack: aMorph
 ]
 
-{ #category : #initialization }
+{ #category : #accessing }
 SpPopoverMorph >> defaultColor [
 
 	^ self theme lightBaseColor
+]
+
+{ #category : #'submorphs-add/remove' }
+SpPopoverMorph >> delete [
+
+	self activeHand ifNotNil: [ :hand | 
+		deleteMorph ifNotNil: [ 
+			hand removeMouseListener: deleteMorph ] ].
+	super delete
+]
+
+{ #category : #drawing }
+SpPopoverMorph >> drawArrowOn: canvas [
+		
+	canvas 
+		drawPolygon: self arrowVertices
+		fillStyle: self color
+]
+
+{ #category : #drawing }
+SpPopoverMorph >> drawBorderOn: canvas [
+	
+	canvas 
+		fillRectangle: (self bounds insetBy: self borderWidth / 2) 
+		color: self color
+]
+
+{ #category : #drawing }
+SpPopoverMorph >> drawOn: canvas [
+
+	self drawBorderOn: canvas.
+	super drawOn: canvas.
+	showArrow ifTrue: [ 
+		self drawArrowOn: canvas ]
+]
+
+{ #category : #accessing }
+SpPopoverMorph >> hideArrow [
+
+	showArrow := false
 ]
 
 { #category : #initialization }
@@ -119,9 +239,12 @@ SpPopoverMorph >> initialize [
 		listDirection: #leftToRight;
 		hResizing: #shrinkWrap;
 		vResizing: #shrinkWrap;
-		"onAnnouncement: MorphLostFocus do: [ :ann | ann morph popdown ];"
+		borderWidth: 10;
+		borderColor: Color transparent;
+		listCentering: #center;
 		beSticky.
-	self bePositionBottom
+	self bePositionBottom.
+	self showArrow
 ]
 
 { #category : #api }
@@ -133,15 +256,27 @@ SpPopoverMorph >> popdown [
 { #category : #api }
 SpPopoverMorph >> popup [
 
-	self popupPointingTo: self relativeTo bounds
+	self popupPointingTo: self relativeTo boundsInWorld
 ]
 
 { #category : #api }
 SpPopoverMorph >> popupPointingTo: aRectangle [
 
+	self setSize.
 	self setPositionFrom: aRectangle.
 	self openInWorld.
-	self takeKeyboardFocus
+	self takeKeyboardFocus.
+	self registerToDeleteEvents
+]
+
+{ #category : #private }
+SpPopoverMorph >> registerToDeleteEvents [
+
+	deleteMorph ifNotNil: [ self activeHand removeMouseListener: deleteMorph ].
+	self activeHand addMouseListener: (deleteMorph := SpPopoverDeleteListenerMorph new 
+		on: #mouseDown send: #validateMousePosition: to: self;
+		on: #mouseUp send: #validateMousePosition: to: self;
+		yourself)
 ]
 
 { #category : #accessing }
@@ -153,7 +288,7 @@ SpPopoverMorph >> relativeTo [
 { #category : #private }
 SpPopoverMorph >> separatatedBy [
 
-	^ 5
+	^ 0
 ]
 
 { #category : #private }
@@ -162,4 +297,36 @@ SpPopoverMorph >> setPositionFrom: aRect [
 	self position: (self calculatePositionFrom: aRect)
 
 	
+]
+
+{ #category : #private }
+SpPopoverMorph >> setSize [
+	| morph |
+	
+	morph := self submorphs first.
+	self extent: morph extent 
+		+ (self borderWidth * 2) 
+		+ (morph borderWidth * 2) 
+		+ (self cellInset * 2)
+		+ (4@0) "a magic to correctly display (otherwise it will add an horizontal 
+		scrollbar to contents)".
+	 "I need this to calculate properly the size (otherwise I cannot position 
+	  the popover correctly"
+	self computeFullBounds
+]
+
+{ #category : #accessing }
+SpPopoverMorph >> showArrow [
+
+	showArrow := true
+]
+
+{ #category : #private }
+SpPopoverMorph >> validateMousePosition: evt [
+	"Handle a mouse up event."
+	
+	(self fullContainsPoint: evt position) ifTrue: [ ^ self ].
+	"Mouse up outside. Release eventual focus and delete if pop up."
+	"evt hand releaseMouseFocus: self."
+	self currentWorld defer: [ self delete ]
 ]

--- a/src/Spec2-Adapters-Morphic/SpStyle.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyle.class.st
@@ -73,7 +73,7 @@ SpStyle class >> defaultStyleSheetData [
 	.link [ Geometry { #hResizing: true } ],
 	.button [  
 		Geometry { #width: 100 },
-		.small [ Geometry { #width: 20 } ]
+		.small [ Geometry { #width: 25, #height: 25 } ]
 	],
 	.checkBox [  
 		Geometry { #hResizing: true },

--- a/src/Spec2-Adapters-Morphic/SpStyle.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyle.class.st
@@ -40,7 +40,7 @@ Class {
 { #category : #private }
 SpStyle class >> createDefaultStyleSheet [
 
-	^ SpStyleSTONReader fromString: self defaultStyleSheetData
+	^ SpStyleVariableSTONReader fromString: self defaultStyleSheetData
 	
 ]
 
@@ -59,12 +59,12 @@ SpStyle class >> defaultStyleSheetData [
 
 	^'
 .application [
-	Font { #predefinedFont: #default },
+	Font { #name : EnvironmentFont(#default) },
 	Geometry { #height: 25 },
 	.label [
 		Geometry { #hResizing: true, #height: 18 },
-		.headerError [ Draw { #color:  Color{ #red: 1, #green: 0, #blue: 0, #alpha: 1}}  ],
-		.headerSuccess [ Draw { #color: Color{ #red: 0, #green: 1, #blue: 0, #alpha: 1}}  ],
+		.headerError [ Draw { #color:  #red }  ],
+		.headerSuccess [ Draw { #color: #green } ],
 		.header [ Draw { #color: Color{ #rgb: 622413393 } } ],
 		.shortcut [ Draw { #color: Color{ #rgb: 622413393 } } ],
 		.fixed [ Geometry { #hResizing: false, #width: 100 } ],
@@ -73,7 +73,7 @@ SpStyle class >> defaultStyleSheetData [
 	.link [ Geometry { #hResizing: true } ],
 	.button [  
 		Geometry { #width: 100 },
-		.small [ Geometry { #width: 26 } ]
+		.small [ Geometry { #width: 20 } ]
 	],
 	.checkBox [  
 		Geometry { #hResizing: true },
@@ -81,7 +81,7 @@ SpStyle class >> defaultStyleSheetData [
 	],
 	.radioButton [ Geometry { #hResizing: true } ],
 	.dropList [ Geometry { #width: 150, #hResizing: true } ],
-	.list [ Geometry { #width: 150, #hResizing: true, #vResizing: true } ],
+	.list [ Geometry { #width: 150, #minHeight: 125, #hResizing: true, #vResizing: true } ],
 	.slider [ Geometry { #width: 150, #hResizing: true } ],
 	.actionBar [  
 		Container { #borderWidth: 0, #padding: 5 },
@@ -92,13 +92,13 @@ SpStyle class >> defaultStyleSheetData [
 		Geometry { #width: 60, #hResizing: false },
 		.showIcon [ Geometry { #width: 25 } ]
 	],
-	.toolBar [ 
+	.toolbar [ 
 		Geometry { #hResizing: true },
 		.icons [ Geometry { #height: 30 } ],
 		.iconsAndLabel [ Geometry { #height: 45 } ]
 	],
 	.text [ Geometry { #height: 0 } ],
-	.code [ Font { #predefinedFont: #code } ],
+	.code [ Font { #name: EnvironmentFont(#code) } ],
 	.codePopover [ 
 		Draw { #color : #transparent },
 		.button [ Geometry { #width : 25 } ]
@@ -108,6 +108,10 @@ SpStyle class >> defaultStyleSheetData [
 		Font { #color: #white } 
 	],
 	.scrollbarPopoverLarge [ Geometry { #height: 350 } ],
+	.popover [
+		.print [ Draw { #color: EnvironmentColor(#balloonBackground) } ],
+		.error [ Draw { #color: #C20000 } ],
+		.popoverButton [ Draw { #color: EnvironmentColor(#popoverButton) } ] ],
 	.paginator [ Geometry { #height: 20 } ] ]
 '
 ]

--- a/src/Spec2-Adapters-Morphic/SpStyleAbstractVariable.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleAbstractVariable.class.st
@@ -1,0 +1,32 @@
+"
+An abstract variable to be used for style properties (values will be expressed in instance of `SpStyleAbstractVariable` children instead its _atomic_ values.
+"
+Class {
+	#name : #SpStyleAbstractVariable,
+	#superclass : #Object,
+	#category : #'Spec2-Adapters-Morphic-StyleSheet'
+}
+
+{ #category : #converting }
+SpStyleAbstractVariable >> asStyleVariable [
+
+	^ self
+]
+
+{ #category : #testing }
+SpStyleAbstractVariable >> isEnvironmentVariable [
+
+	^ false
+]
+
+{ #category : #evaluating }
+SpStyleAbstractVariable >> preferredValueWith: anObject [
+
+	^ self value
+]
+
+{ #category : #evaluating }
+SpStyleAbstractVariable >> value [
+
+	^ self subclassResponsibility
+]

--- a/src/Spec2-Adapters-Morphic/SpStyleClass.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleClass.class.st
@@ -47,10 +47,11 @@ SpStyleClass >> , joinStyle [
 ]
 
 { #category : #adding }
-SpStyleClass >> addClass: aName with: aBlock [ 
+SpStyleClass >> addClass: aName with: aBlock [
 	| class |
 	
-	class := SpStyleClass new 
+	class := self class new
+		parent: self;
 		name: aName;
 		yourself.
 	
@@ -178,7 +179,7 @@ SpStyleClass >> parent: aStyle [
 SpStyleClass >> printOn: stream [ 
 
 	super printOn: stream.
-	stream << '(' << self name << ')'
+	stream << '(' << self fullName << ')'
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Adapters-Morphic/SpStyleContainer.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleContainer.class.st
@@ -40,9 +40,9 @@ SpStyleContainer class >> stonName [
 { #category : #operations }
 SpStyleContainer >> applyTo: aMorph [ 
 
-	self borderColor ifNotNil: [ :aColor | aMorph borderColor: aColor ].
-	self borderWidth ifNotNil: [ :aNumber | aMorph borderWidth: aNumber ].
-	self padding ifNotNil: [ :aNumber | aMorph cellInset: aNumber ]
+	self borderColorVariable ifNotNil: [ :aVariable | aMorph borderColor: aVariable valueAsColor ].
+	self borderWidthVariable ifNotNil: [ :aVariable | aMorph borderWidth: aVariable value ].
+	self paddingVariable ifNotNil: [ :aVariable | aMorph cellInset: aVariable value ]
 ]
 
 { #category : #accessing }
@@ -52,35 +52,57 @@ SpStyleContainer >> borderColor [
 	- a named selector: ==#red==
 	- an hex string: =='FF0000'=="
 
-	^ borderColor
+	^ self borderColorVariable value
 ]
 
 { #category : #accessing }
 SpStyleContainer >> borderColor: aColor [
 
-	borderColor := aColor
+	borderColor := aColor asStyleVariable
+]
+
+{ #category : #'accessing variables' }
+SpStyleContainer >> borderColorVariable [
+  "This property can be expressed as 
+	- a STON map: ==Color { #red : 1., #green : 0, #blue : 0, #alpha : 1 }==
+	- a named selector: ==#red==
+	- an hex string: =='FF0000'=="
+
+	^ self toVariable: borderColor
 ]
 
 { #category : #accessing }
 SpStyleContainer >> borderWidth [
 
-	^ borderWidth
+	^ self borderWidthVariable value
 ]
 
 { #category : #accessing }
 SpStyleContainer >> borderWidth: aNumber [
 
-	borderWidth := aNumber
+	borderWidth := aNumber asStyleVariable
+]
+
+{ #category : #'accessing variables' }
+SpStyleContainer >> borderWidthVariable [
+
+	^ self toVariable: borderWidth
 ]
 
 { #category : #accessing }
 SpStyleContainer >> padding [
 
-	^ padding
+	^ self paddingVariable value
 ]
 
 { #category : #accessing }
 SpStyleContainer >> padding: aNumber [
 
-	padding := aNumber
+	padding := aNumber asStyleVariable
+]
+
+{ #category : #'accessing variables' }
+SpStyleContainer >> paddingVariable [
+
+	^ self toVariable: padding
 ]

--- a/src/Spec2-Adapters-Morphic/SpStyleDraw.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleDraw.class.st
@@ -38,14 +38,13 @@ SpStyleDraw class >> stonName [
 { #category : #operations }
 SpStyleDraw >> applyTo: aMorph [ 
 
-	self color ifNotNil: [ :aColor | aMorph color: aColor ].
+	self color ifNotNil: [ :aColor | aMorph color: aColor asStyleVariable valueAsColor ].
 	self backgroundColor ifNotNil: [ :aColor |
 		"hack to be able to decorate components that does not understand 
 		 backgroundColor" 
 		(aMorph respondsTo: #backgroundColor:)
-			ifTrue: [ aMorph backgroundColor: aColor ]
-			ifFalse: [ aMorph fillStyle: aColor ] ].
-	
+			ifTrue: [ aMorph backgroundColor: aColor asStyleVariable valueAsColor ]
+			ifFalse: [ aMorph fillStyle: aColor asStyleVariable valueAsColor ] ]
 ]
 
 { #category : #accessing }
@@ -55,13 +54,23 @@ SpStyleDraw >> backgroundColor [
 	- a named selector: ==#red==
 	- an hex string: =='FF0000'=="
 
-	^ backgroundColor
+	^ self backgroundColorVariable value
 ]
 
 { #category : #accessing }
 SpStyleDraw >> backgroundColor: aColorOrSymbol [
 
-	backgroundColor := self toColor: aColorOrSymbol
+	backgroundColor := aColorOrSymbol asStyleVariable
+]
+
+{ #category : #'accessing variables' }
+SpStyleDraw >> backgroundColorVariable [
+  "This property can be expressed as 
+	- a STON map: ==Color { #red : 1., #green : 0, #blue : 0, #alpha : 1 }==
+	- a named selector: ==#red==
+	- an hex string: =='FF0000'=="
+
+	^ self toVariable: backgroundColor
 ]
 
 { #category : #accessing }
@@ -71,11 +80,21 @@ SpStyleDraw >> color [
 	- a named selector: ==#red==
 	- an hex string: =='FF0000'=="
 
-	^ color
+	^ self colorVariable value
 ]
 
 { #category : #accessing }
 SpStyleDraw >> color: aColorOrSymbol [
 
-	color := self toColor: aColorOrSymbol
+	color := aColorOrSymbol asStyleVariable
+]
+
+{ #category : #'accessing variables' }
+SpStyleDraw >> colorVariable [
+  "This property can be expressed as 
+	- a STON map: ==Color { #red : 1., #green : 0, #blue : 0, #alpha : 1 }==
+	- a named selector: ==#red==
+	- an hex string: =='FF0000'=="
+
+	^ self toVariable: color
 ]

--- a/src/Spec2-Adapters-Morphic/SpStyleFont.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleFont.class.st
@@ -252,7 +252,7 @@ SpStyleFont >> mergeWith: otherProperty [
 		ifNotNil: [
 			merged 
 				writeSlotNamed: 'predefinedFont' value: nil;
-				writeSlotNamed: 'name' value: self nameVariable ].
+				writeSlotNamed: 'name' value: (otherProperty readSlotNamed: 'name') ].
 		
 	^ merged
 ]

--- a/src/Spec2-Adapters-Morphic/SpStyleFont.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleFont.class.st
@@ -167,7 +167,7 @@ SpStyleFont >> color [
 	- a named selector: ==#red==
 	- an hex string: =='FF0000'=="
 
-	^ color
+	^ self colorVariable value
 ]
 
 { #category : #accessing }
@@ -223,7 +223,8 @@ SpStyleFont >> isItalic [
 
 { #category : #accessing }
 SpStyleFont >> italic [
-	^ italic
+
+	^ self italicVariable value
 ]
 
 { #category : #accessing }
@@ -257,7 +258,7 @@ SpStyleFont >> mergeWith: otherProperty [
 { #category : #accessing }
 SpStyleFont >> name [
 
-	^ name
+	^ self nameVariable value
 ]
 
 { #category : #accessing }
@@ -293,7 +294,7 @@ SpStyleFont >> predefinedFont: aSymbol [
 { #category : #accessing }
 SpStyleFont >> size [
 
-	^ size
+	^ self sizeVariable value
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Adapters-Morphic/SpStyleFont.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleFont.class.st
@@ -152,7 +152,9 @@ SpStyleFont >> calculateFontName [
 { #category : #private }
 SpStyleFont >> calculateFontSize [
 	
-	self sizeVariable ifNotNil: [ ^ self sizeVariable value ].
+	self sizeVariable ifNotNil: [ :aVariable |
+		aVariable value ifNotNil: [ 
+			^ self sizeVariable value ] ].
 	self nameVariable isEnvironmentVariable ifTrue: [ ^ self nameVariable pointSize ].
 	self hasPredefinedFont ifTrue: [ ^ self obtainPredefinedFont pointSize ].
 
@@ -246,11 +248,11 @@ SpStyleFont >> mergeWith: otherProperty [
 	merged := super mergeWith: otherProperty.
 
 	"Ensure predefined font will be overriden even if nil."
-	otherProperty name 
+	otherProperty nameVariable 
 		ifNotNil: [ :aName |
 			merged 
-				predefinedFont: nil;
-				name: aName ].
+				writeSlotNamed: 'predefinedFont' value: nil;
+				writeSlotNamed: 'name' value: aName ].
 		
 	^ merged
 ]

--- a/src/Spec2-Adapters-Morphic/SpStyleFont.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleFont.class.st
@@ -248,7 +248,7 @@ SpStyleFont >> mergeWith: otherProperty [
 	merged := super mergeWith: otherProperty.
 
 	"Ensure predefined font will be overriden even if nil."
-	otherProperty nameVariable 
+	otherProperty name 
 		ifNotNil: [ :aName |
 			merged 
 				writeSlotNamed: 'predefinedFont' value: nil;

--- a/src/Spec2-Adapters-Morphic/SpStyleFont.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleFont.class.st
@@ -249,10 +249,10 @@ SpStyleFont >> mergeWith: otherProperty [
 
 	"Ensure predefined font will be overriden even if nil."
 	otherProperty name 
-		ifNotNil: [ :aName |
+		ifNotNil: [
 			merged 
 				writeSlotNamed: 'predefinedFont' value: nil;
-				writeSlotNamed: 'name' value: aName ].
+				writeSlotNamed: 'name' value: self nameVariable ].
 		
 	^ merged
 ]
@@ -272,7 +272,7 @@ SpStyleFont >> name: aString [
 { #category : #'accessing variables' }
 SpStyleFont >> nameVariable [
 
-	^ name
+	^ self toVariable: name
 ]
 
 { #category : #private }

--- a/src/Spec2-Adapters-Morphic/SpStyleFont.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleFont.class.st
@@ -83,6 +83,15 @@ SpStyleFont >> addFontToCache: aFont [
 	self class addFontToCache: aFont
 ]
 
+{ #category : #private }
+SpStyleFont >> anyFontDecorator [
+	
+	^ color notNil 
+		or: [ size notNil 
+		or: [ bold notNil 
+		or: [ italic notNil ] ] ]
+]
+
 { #category : #operations }
 SpStyleFont >> applyTo: aMorph [
 
@@ -95,17 +104,25 @@ SpStyleFont >> applyTo: aMorph [
 	self color ifNil: [ ^ self ].
 	"Again, not all morphs understand #textColor: and I need to verify it is there."
 	(aMorph respondsTo: #textColor:) ifFalse: [ ^ self ].
-	aMorph textColor: self color
+	aMorph textColor: self colorVariable valueAsColor
 ]
 
 { #category : #accessing }
 SpStyleFont >> bold [
-	^ bold
+
+	^ self boldVariable value
 ]
 
 { #category : #accessing }
-SpStyleFont >> bold: anObject [
-	bold := anObject
+SpStyleFont >> bold: aBoolean [
+
+	bold := aBoolean asStyleVariable
+]
+
+{ #category : #'accessing variables' }
+SpStyleFont >> boldVariable [
+
+	^ self toVariable: bold
 ]
 
 { #category : #private }
@@ -113,13 +130,33 @@ SpStyleFont >> calculateDefinedFont [
 	| font |
 	
 	font := LogicalFont
-		familyName: self name 
-		pointSize: self size.
+		familyName: self calculateFontName
+		pointSize: self calculateFontSize.
 
 	self isItalic ifTrue: [ font forceItalicOrOblique ].
 	self isBold ifTrue: [ font forceBold ].
 
 	^ font
+]
+
+{ #category : #private }
+SpStyleFont >> calculateFontName [
+	| var |
+	
+	var := self nameVariable.
+	^ var isEnvironmentVariable 
+		ifTrue: [ var familyName ] 
+		ifFalse: [ var value ]
+]
+
+{ #category : #private }
+SpStyleFont >> calculateFontSize [
+	
+	self sizeVariable ifNotNil: [ ^ self sizeVariable value ].
+	self nameVariable isEnvironmentVariable ifTrue: [ ^ self nameVariable pointSize ].
+	self hasPredefinedFont ifTrue: [ ^ self obtainPredefinedFont pointSize ].
+
+	^ nil
 ]
 
 { #category : #accessing }
@@ -136,14 +173,26 @@ SpStyleFont >> color [
 { #category : #accessing }
 SpStyleFont >> color: aColorOrSymbol [
 
-	color := self toColor: aColorOrSymbol
+	color := aColorOrSymbol asStyleVariable
+]
+
+{ #category : #'accessing variables' }
+SpStyleFont >> colorVariable [
+  "This is meant to set the text color.
+	This property can be expressed as 
+	- a STON map: ==Color { #red : 1., #green : 0, #blue : 0, #alpha : 1 }==
+	- a named selector: ==#red==
+	- an hex string: =='FF0000'=="
+
+	^ self toVariable: color
 ]
 
 { #category : #private }
 SpStyleFont >> definedFont [
 	| definedFont |
 
-	self predefinedFont ifNotNil: [ :aSymbol | ^ StandardFonts perform: aSymbol ].
+	(self predefinedFont notNil and: [ self anyFontDecorator not ]) ifTrue: [ 
+		^ self obtainPredefinedFont  ].
 
 	self withCachedFontDo: [ :aFont | ^ aFont ].
 	
@@ -152,18 +201,24 @@ SpStyleFont >> definedFont [
 	^ definedFont
 ]
 
-{ #category : #initialization }
+{ #category : #private }
+SpStyleFont >> hasPredefinedFont [
+
+	^ self predefinedFont notNil
+]
+
+{ #category : #testing }
 SpStyleFont >> isBold [
 	"property may be nil, we verify with strict comparisson"
 	
-	^ bold == true 
+	^ self boldVariable value == true
 ]
 
-{ #category : #initialization }
+{ #category : #testing }
 SpStyleFont >> isItalic [
 	"property may be nil, we verify with strict comparisson"
 	
-	^ italic == true 
+	^ self italicVariable value == true 
 ]
 
 { #category : #accessing }
@@ -172,8 +227,31 @@ SpStyleFont >> italic [
 ]
 
 { #category : #accessing }
-SpStyleFont >> italic: anObject [
-	italic := anObject
+SpStyleFont >> italic: aBoolean [
+
+	italic := aBoolean asStyleVariable
+]
+
+{ #category : #'accessing variables' }
+SpStyleFont >> italicVariable [
+
+	^ italic
+]
+
+{ #category : #operations }
+SpStyleFont >> mergeWith: otherProperty [
+	| merged |
+
+	merged := super mergeWith: otherProperty.
+
+	"Ensure predefined font will be overriden even if nil."
+	otherProperty name 
+		ifNotNil: [ :aName |
+			merged 
+				predefinedFont: nil;
+				name: aName ].
+		
+	^ merged
 ]
 
 { #category : #accessing }
@@ -185,7 +263,19 @@ SpStyleFont >> name [
 { #category : #accessing }
 SpStyleFont >> name: aString [
 
-	name := aString
+	name := aString asStyleVariable
+]
+
+{ #category : #'accessing variables' }
+SpStyleFont >> nameVariable [
+
+	^ name
+]
+
+{ #category : #private }
+SpStyleFont >> obtainPredefinedFont [
+
+	^ StandardFonts perform: (self predefinedFont value, 'Font') asSymbol
 ]
 
 { #category : #accessing }
@@ -197,7 +287,7 @@ SpStyleFont >> predefinedFont [
 { #category : #accessing }
 SpStyleFont >> predefinedFont: aSymbol [
 
-	predefinedFont := (aSymbol, 'Font') asSymbol
+	predefinedFont := aSymbol
 ]
 
 { #category : #accessing }
@@ -209,7 +299,13 @@ SpStyleFont >> size [
 { #category : #accessing }
 SpStyleFont >> size: aNumber [
 
-	size := aNumber
+	size := aNumber asStyleVariable
+]
+
+{ #category : #'accessing variables' }
+SpStyleFont >> sizeVariable [
+
+	^ size
 ]
 
 { #category : #private }

--- a/src/Spec2-Adapters-Morphic/SpStyleGeometry.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleGeometry.class.st
@@ -36,8 +36,6 @@ Class {
 		'height',
 		'minWidth',
 		'minHeight',
-		'maxWidth',
-		'maxHeight',
 		'hResizing',
 		'vResizing'
 	],
@@ -53,14 +51,18 @@ SpStyleGeometry class >> stonName [
 { #category : #operations }
 SpStyleGeometry >> applyTo: aMorph [
 
-	aMorph
-		width: (self geometryValueBetween: self width and: aMorph width);		
-		height: (self geometryValueBetween: self height and: aMorph height).
-		
-	self hResizing ifNotNil: [ :aBoolean | 
-		aMorph hResizing: (self resizingStringFor: aBoolean) ].
-	self vResizing ifNotNil: [ :aBoolean |
-		aMorph vResizing: (self resizingStringFor: aBoolean) ]
+	(self widthVariable preferredValueWith: aMorph width) 
+		ifNotNil: [ :aNumber | aMorph width: aNumber ].
+	(self heightVariable preferredValueWith: aMorph height) 
+		ifNotNil: [ :aNumber | aMorph height: aNumber ].
+	self minWidthVariable
+		ifNotNil: [ :aVariable | aMorph minWidth: aVariable value ].
+	self minHeightVariable
+		ifNotNil: [ :aVariable | aMorph minHeight: aVariable value ].
+	self hResizingVariable 
+		ifNotNil: [ :aVariable | aMorph hResizing: (self resizingStringFor: aVariable value) ].
+	self vResizingVariable 
+		ifNotNil: [ :aVariable | aMorph vResizing: (self resizingStringFor: aVariable value) ]
 ]
 
 { #category : #private }
@@ -70,19 +72,6 @@ SpStyleGeometry >> calculatedExtent [
 	self minExtent ifNotNil: [ :aPoint | aPoint ].
 	
 	^ 10@10
-]
-
-{ #category : #accessing }
-SpStyleGeometry >> extent [
-
-	^ self width @ self height
-]
-
-{ #category : #accessing }
-SpStyleGeometry >> extent: aPoint [ 
-
-	width := aPoint x.
-	height := aPoint y
 ]
 
 { #category : #private }
@@ -96,107 +85,73 @@ SpStyleGeometry >> geometryValueBetween: baseNumber and: otherNumber [
 { #category : #accessing }
 SpStyleGeometry >> hResizing [
 
-	^ hResizing
+	^ self hResizingVariable value
 ]
 
 { #category : #accessing }
 SpStyleGeometry >> hResizing: aBoolean [
 
-	hResizing := aBoolean
+	hResizing := aBoolean asStyleVariable
+]
+
+{ #category : #'accessing variables' }
+SpStyleGeometry >> hResizingVariable [
+
+	^ self toVariable: hResizing
 ]
 
 { #category : #accessing }
 SpStyleGeometry >> height [
 
-	^ height ifNil: [ 0 ]
+	^ self heightVariable value
 ]
 
 { #category : #accessing }
 SpStyleGeometry >> height: aNumber [
 	
-	height := aNumber
+	height := aNumber asStyleVariable
 ]
 
-{ #category : #initialization }
-SpStyleGeometry >> initialize [
+{ #category : #'accessing variables' }
+SpStyleGeometry >> heightVariable [
 
-	super initialize.
-	self hResizing: nil.
-	self vResizing: nil
-]
-
-{ #category : #accessing }
-SpStyleGeometry >> maxExtent [
-
-	^ self maxWidth @ self maxHeight
-]
-
-{ #category : #accessing }
-SpStyleGeometry >> maxExtent: aPoint [
-
-	maxWidth := aPoint x.
-	maxHeight := aPoint y
-]
-
-{ #category : #accessing }
-SpStyleGeometry >> maxHeight [
-
-	^ maxHeight ifNil: [ 0 ]
-]
-
-{ #category : #accessing }
-SpStyleGeometry >> maxHeight: aNumber [
-	
-	maxHeight := aNumber
-]
-
-{ #category : #accessing }
-SpStyleGeometry >> maxWidth [
-
-	^ maxWidth ifNil: [ 0 ]
-]
-
-{ #category : #accessing }
-SpStyleGeometry >> maxWidth: aNumber [
-
-	maxWidth := aNumber
-]
-
-{ #category : #accessing }
-SpStyleGeometry >> minExtent [
-
-	^ self minWidth @ self minHeight
-]
-
-{ #category : #accessing }
-SpStyleGeometry >> minExtent: aPoint [
-
-	minWidth := aPoint x.
-	minHeight := aPoint y
+	^ self toVariable: (height ifNil: [ 0 ])
 ]
 
 { #category : #accessing }
 SpStyleGeometry >> minHeight [
 
-	^ minHeight ifNil: [ 0 ]
+	^ self minHeightVariable value
 ]
 
 { #category : #accessing }
 SpStyleGeometry >> minHeight: aNumber [
 	
-	minHeight := aNumber
+	minHeight := aNumber asStyleVariable
+]
+
+{ #category : #'accessing variables' }
+SpStyleGeometry >> minHeightVariable [
+
+	^ self toVariable: minHeight
 ]
 
 { #category : #accessing }
 SpStyleGeometry >> minWidth [
 
-	^ minWidth ifNil: [ 0 ]
+	^ self minWidthVariable value
 ]
 
 { #category : #accessing }
 SpStyleGeometry >> minWidth: aNumber [
 
-	minWidth := aNumber
+	minWidth := aNumber asStyleVariable
+]
+
+{ #category : #'accessing variables' }
+SpStyleGeometry >> minWidthVariable [
+
+	^ self toVariable: minWidth
 ]
 
 { #category : #private }
@@ -210,23 +165,35 @@ SpStyleGeometry >> resizingStringFor: expand [
 { #category : #accessing }
 SpStyleGeometry >> vResizing [
 
-	^ vResizing
+	^ self vResizingVariable value
 ]
 
 { #category : #accessing }
 SpStyleGeometry >> vResizing: aBoolean [
 
-	vResizing := aBoolean
+	vResizing := aBoolean asStyleVariable
+]
+
+{ #category : #'accessing variables' }
+SpStyleGeometry >> vResizingVariable [
+
+	^ self toVariable: vResizing
 ]
 
 { #category : #accessing }
 SpStyleGeometry >> width [
 
-	^ width ifNil: [ 0 ]
+	^ self widthVariable value
 ]
 
 { #category : #accessing }
 SpStyleGeometry >> width: aNumber [
 
-	width := aNumber
+	width := aNumber asStyleVariable
+]
+
+{ #category : #'accessing variables' }
+SpStyleGeometry >> widthVariable [
+
+	^ self toVariable: (width ifNil: [ 0 ])
 ]

--- a/src/Spec2-Adapters-Morphic/SpStyleProperty.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleProperty.class.st
@@ -32,7 +32,7 @@ SpStyleProperty >> fromSton: stonReader [
 	stonReader parseMapDo: [ :message :value |
 		self 
 			perform: message asMutator 
-			with: value ]
+			with: (value ifNotNil: [ value asStyleVariable ]) ]
 ]
 
 { #category : #testing }
@@ -53,7 +53,7 @@ SpStyleProperty >> mergeWith: otherProperty [
 		"other property will have precedence over this one"
 		merged 
 			writeSlot: eachSlot 
-			value: ((otherProperty readSlot: eachSlot) ifNil:[ self readSlot: eachSlot ]) ].
+			value: ((otherProperty readSlot: eachSlot) ifNil: [ self readSlot: eachSlot ]) ].
 		
 	^ merged
 ]
@@ -67,4 +67,11 @@ SpStyleProperty >> toColor: aColorOrSymbol [
 	(Color named: aColorOrSymbol) ifNotNil: [ :aColor | ^ aColor ]. 
 	"Try by HEX (CSS style)"				
 	^ Color fromHexString: aColorOrSymbol
+]
+
+{ #category : #private }
+SpStyleProperty >> toVariable: anObject [
+
+	^ anObject ifNotNil: [ anObject asStyleVariable ].
+	
 ]

--- a/src/Spec2-Adapters-Morphic/SpStyleSTONReader.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleSTONReader.class.st
@@ -37,11 +37,10 @@ SpStyleSTONReader >> lookupClass: name [
 	
 	^ classes 
 		at: name 
-		ifAbsentPut: [
-			(SpStyle allSubclasses , Color withAllSubclasses) 
+		ifAbsentPut: [ 
+			self styleClasses 
 				detect: [ :class | class isMeta not and: [ class stonName = name ]  ]
 				ifNone: [ NotFound signalFor: name ] ]
-	
 ]
 
 { #category : #parsing }
@@ -111,4 +110,10 @@ SpStyleSTONReader >> pushStyle: aStyle during: aBlock [
 SpStyleSTONReader >> styleClass [
 
 	^ SpStyleClass
+]
+
+{ #category : #private }
+SpStyleSTONReader >> styleClasses [
+
+	^ SpStyle allSubclasses, Color withAllSubclasses
 ]

--- a/src/Spec2-Adapters-Morphic/SpStyleVariable.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleVariable.class.st
@@ -1,0 +1,63 @@
+"
+A holder for an attribute `atomic` value.
+It holds numbers, strings, symbols.
+"
+Class {
+	#name : #SpStyleVariable,
+	#superclass : #SpStyleAbstractVariable,
+	#instVars : [
+		'value'
+	],
+	#category : #'Spec2-Adapters-Morphic-StyleSheet'
+}
+
+{ #category : #'instance creation' }
+SpStyleVariable class >> newValue: anObject [
+
+	^ self new 
+		value: anObject;
+		yourself
+]
+
+{ #category : #'ston-core' }
+SpStyleVariable class >> stonName [
+
+	^ 'Variable'
+]
+
+{ #category : #evaluating }
+SpStyleVariable >> preferredValueWith: anObject [
+
+	^ self value = 0 
+		ifTrue: [ anObject ]
+		ifFalse: [ self value ]
+]
+
+{ #category : #private }
+SpStyleVariable >> toColor: aColorOrSymbol [
+
+	"Try if color"
+	aColorOrSymbol isSymbol ifFalse: [ ^ aColorOrSymbol ].
+	"Try by name"
+	(Color named: aColorOrSymbol) ifNotNil: [ :aColor | ^ aColor ]. 
+	"Try by HEX (CSS style)"				
+	^ Color fromHexString: aColorOrSymbol
+]
+
+{ #category : #evaluating }
+SpStyleVariable >> value [
+
+	^ value
+]
+
+{ #category : #accessing }
+SpStyleVariable >> value: anObject [
+
+	value := anObject
+]
+
+{ #category : #evaluating }
+SpStyleVariable >> valueAsColor [
+
+	^ self toColor: self value
+]

--- a/src/Spec2-Adapters-Morphic/SpStyleVariableEnvironment.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleVariableEnvironment.class.st
@@ -1,0 +1,81 @@
+"
+A base for environment variables (values that point to values in the environment).
+"
+Class {
+	#name : #SpStyleVariableEnvironment,
+	#superclass : #SpStyleAbstractVariable,
+	#instVars : [
+		'name'
+	],
+	#category : #'Spec2-Adapters-Morphic-StyleSheet'
+}
+
+{ #category : #documentation }
+SpStyleVariableEnvironment class >> addDocumentExample: aBuilder [
+
+	aBuilder newLine.
+	aBuilder header: [ :builder | builder text: 'Example' ] withLevel: 2.
+	aBuilder newLine.
+	aBuilder monospace: self documentExampleCode
+]
+
+{ #category : #documentation }
+SpStyleVariableEnvironment class >> addDocumentValidValues: aBuilder [	
+
+	aBuilder newLine.
+	aBuilder header: [ :builder | builder text: 'Valid values' ] withLevel: 2.
+	aBuilder newLine.
+	aBuilder unorderedListDuring: [  
+		(self documentValidValues sorted) do: [ :each |
+			aBuilder item: [
+				aBuilder monospace: '#', each asString ] ] ]	
+]
+
+{ #category : #documentation }
+SpStyleVariableEnvironment class >> buildMicroDownUsing: aBuilder withComment: aString [
+	
+	super buildMicroDownUsing: aBuilder withComment: aString.
+	self addDocumentExample: aBuilder.
+	self addDocumentValidValues: aBuilder	
+
+]
+
+{ #category : #documentation }
+SpStyleVariableEnvironment class >> documentExampleCode [
+
+	^ '(none)'
+]
+
+{ #category : #documentation }
+SpStyleVariableEnvironment class >> documentValidValues [
+	
+	^ #()
+]
+
+{ #category : #'ston-core' }
+SpStyleVariableEnvironment class >> stonName [
+
+	^ 'Environment'
+]
+
+{ #category : #'instance creation' }
+SpStyleVariableEnvironment >> fromSton: stonReader [
+
+	self name: stonReader parseContainedValue
+]
+
+{ #category : #testing }
+SpStyleVariableEnvironment >> isEnvironmentVariable [
+
+	^ true
+]
+
+{ #category : #accessing }
+SpStyleVariableEnvironment >> name [
+	^ name
+]
+
+{ #category : #accessing }
+SpStyleVariableEnvironment >> name: anObject [
+	name := anObject
+]

--- a/src/Spec2-Adapters-Morphic/SpStyleVariableEnvironmentColor.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleVariableEnvironmentColor.class.st
@@ -1,0 +1,43 @@
+"
+A variable to access environment colors (defined in `UITheme` and subclasses) 
+"
+Class {
+	#name : #SpStyleVariableEnvironmentColor,
+	#superclass : #SpStyleVariableEnvironment,
+	#category : #'Spec2-Adapters-Morphic-StyleSheet'
+}
+
+{ #category : #documentation }
+SpStyleVariableEnvironmentColor class >> documentExampleCode [
+
+	^ 'Draw { #color: EnvironmentColor(#background) }'
+]
+
+{ #category : #documentation }
+SpStyleVariableEnvironmentColor class >> documentValidValues [
+
+	^ UITheme selectors
+		select: [ :each | 
+			(each endsWith: 'Color') 
+				and: [ ((UITheme current perform: each) isKindOf: Color) ] ]
+		thenCollect: [ :each | each allButLast: 5 ]
+]
+
+{ #category : #'ston-core' }
+SpStyleVariableEnvironmentColor class >> stonName [
+
+	^ 'EnvironmentColor'
+]
+
+{ #category : #evaluating }
+SpStyleVariableEnvironmentColor >> value [
+
+	self name ifNil: [ ^ nil ].
+	^ Smalltalk ui theme perform: (self name, 'Color') asSymbol
+]
+
+{ #category : #evaluating }
+SpStyleVariableEnvironmentColor >> valueAsColor [
+	
+	^ self value
+]

--- a/src/Spec2-Adapters-Morphic/SpStyleVariableEnvironmentFont.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleVariableEnvironmentFont.class.st
@@ -1,0 +1,53 @@
+"
+A variable to access environment fonts (defined in `StandardFonts class`).
+This variable must be used to assign the attribute `name` of a `SpStyleFont` property.
+"
+Class {
+	#name : #SpStyleVariableEnvironmentFont,
+	#superclass : #SpStyleVariableEnvironment,
+	#category : #'Spec2-Adapters-Morphic-StyleSheet'
+}
+
+{ #category : #documentation }
+SpStyleVariableEnvironmentFont class >> documentExampleCode [
+
+	^ 'Font { #name: EnvironmentFont(#default) }'
+]
+
+{ #category : #documentation }
+SpStyleVariableEnvironmentFont class >> documentValidValues [
+
+	^ StandardFonts class selectors 
+		select: [ :each | each endsWith: 'Font' ]
+		thenCollect: [ :each | each allButLast: 4 ]
+]
+
+{ #category : #'ston-core' }
+SpStyleVariableEnvironmentFont class >> stonName [
+
+	^ 'EnvironmentFont'
+]
+
+{ #category : #accessing }
+SpStyleVariableEnvironmentFont >> familyName [
+
+	^ self value familyName
+]
+
+{ #category : #accessing }
+SpStyleVariableEnvironmentFont >> name [
+
+	^ super name ifNil: [ #default ]
+]
+
+{ #category : #accessing }
+SpStyleVariableEnvironmentFont >> pointSize [
+
+	^ self value pointSize
+]
+
+{ #category : #evaluating }
+SpStyleVariableEnvironmentFont >> value [
+
+	^ StandardFonts perform: (self name, 'Font') asSymbol
+]

--- a/src/Spec2-Adapters-Morphic/SpStyleVariableReset.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleVariableReset.class.st
@@ -1,0 +1,35 @@
+"
+A variable to reset previous values. 
+This variable has to be used when user want to override the value of a parent property and replace it for the default value.
+
+## Example
+
+`Geometry { #height: Reset }`
+"
+Class {
+	#name : #SpStyleVariableReset,
+	#superclass : #SpStyleAbstractVariable,
+	#category : #'Spec2-Adapters-Morphic-StyleSheet'
+}
+
+{ #category : #'ston-core' }
+SpStyleVariableReset class >> stonName [
+
+	^ 'Reset'
+]
+
+{ #category : #'instance creation' }
+SpStyleVariableReset >> fromSton: stonReader [
+]
+
+{ #category : #evaluating }
+SpStyleVariableReset >> preferredValueWith: anObject [
+
+	^ nil
+]
+
+{ #category : #evaluating }
+SpStyleVariableReset >> value [
+
+	^ nil
+]

--- a/src/Spec2-Adapters-Morphic/SpStyleVariableSTONReader.class.st
+++ b/src/Spec2-Adapters-Morphic/SpStyleVariableSTONReader.class.st
@@ -1,0 +1,60 @@
+Class {
+	#name : #SpStyleVariableSTONReader,
+	#superclass : #SpStyleSTONReader,
+	#category : #'Spec2-Adapters-Morphic-StyleSheet'
+}
+
+{ #category : #parsing }
+SpStyleVariableSTONReader >> isContainedValueChar: char [
+
+	^ char = $(
+]
+
+{ #category : #parsing }
+SpStyleVariableSTONReader >> parseContainedValue [
+	| result | 
+
+	self parseContainedValueDo: [ :aValue | result := aValue ].
+
+	^ result
+
+]
+
+{ #category : #parsing }
+SpStyleVariableSTONReader >> parseContainedValueDo: block [
+
+	self expectChar: $(.
+	(self matchChar: $)) ifTrue: [ ^ self ]. "short cut for empty value"
+	[ readStream atEnd ] whileFalse: [
+		block cull: self parseValue.
+		(self matchChar: $)) ifTrue: [ ^ self ]  ].
+
+	self error: 'end of contained value expected'
+]
+
+{ #category : #parsing }
+SpStyleVariableSTONReader >> parseNamedInstVarsFor: anObject [
+
+	self parseMapDo: [ :instVarName :value |
+		anObject 
+			instVarNamed: instVarName asString 
+			put: value asStyleVariable ]
+]
+
+{ #category : #parsing }
+SpStyleVariableSTONReader >> parseSimpleValue [
+	| char |
+
+	readStream atEnd ifFalse: [ 
+		char := readStream peek.
+		(self isContainedValueChar: char) ifTrue: [ 
+			^ self parseContainedValue ] ].
+
+	^ super parseSimpleValue
+]
+
+{ #category : #private }
+SpStyleVariableSTONReader >> styleClasses [
+
+	^ super styleClasses, SpStyleAbstractVariable allSubclasses
+]

--- a/src/Spec2-Adapters-Morphic/SpTMorphicTableDataSourceCommons.trait.st
+++ b/src/Spec2-Adapters-Morphic/SpTMorphicTableDataSourceCommons.trait.st
@@ -10,7 +10,7 @@ Trait {
 { #category : #accessing }
 SpTMorphicTableDataSourceCommons >> headerColumn: column [
 
-	column id ifNil: [ ^ nil ].
+	(column id isNil and: [ self model isShowingColumnHeaders not ]) ifTrue: [ ^ nil ].
 	^ self headerForColumn: column
 ]
 
@@ -56,7 +56,7 @@ SpTMorphicTableDataSourceCommons >> newHeaderColumn: column [
 	| headerMorph |
 	
 	headerMorph := SpHeaderCellMorph new 
-		addMorph: column id asMorph asReadOnlyMorph;
+		addMorph: (column id ifNil: [ '' ]) asMorph asReadOnlyMorph;
 		yourself.
 		
 	column isSortable ifTrue: [ 

--- a/src/Spec2-Adapters-Morphic/SpTableLayout.class.st
+++ b/src/Spec2-Adapters-Morphic/SpTableLayout.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #SpTableLayout,
+	#superclass : #TableLayout,
+	#category : #'Spec2-Adapters-Morphic-Base'
+}
+
+{ #category : #layout }
+SpTableLayout >> layout: aMorph in: box [
+
+	^ super layout: aMorph in: box
+]

--- a/src/Spec2-Adapters-Morphic/SpToolbarButtonMorph.class.st
+++ b/src/Spec2-Adapters-Morphic/SpToolbarButtonMorph.class.st
@@ -105,9 +105,8 @@ SpToolbarButtonMorph >> hasBadge [
 
 { #category : #style }
 SpToolbarButtonMorph >> mouseOverBorderStyle [
-	^ BorderStyle simple
-		width: 0;
-		baseColor: Color transparent
+
+	^ self normalBorderStyle
 ]
 
 { #category : #accessing }
@@ -122,12 +121,12 @@ SpToolbarButtonMorph >> newBadgeFont [
 
 { #category : #style }
 SpToolbarButtonMorph >> normalBorderStyle [
-	^ BorderStyle simple
-		width: 0;
-		baseColor: Color transparent
+
+	^ BorderStyle width: 0 color: Color transparent
 ]
 
 { #category : #style }
 SpToolbarButtonMorph >> normalFillStyle [
+
 	^ Color transparent
 ]

--- a/src/Spec2-Adapters-Morphic/SpToolbarMorph.class.st
+++ b/src/Spec2-Adapters-Morphic/SpToolbarMorph.class.st
@@ -5,7 +5,7 @@ I can display toolbar items in left side or right side panels.
 "
 Class {
 	#name : #SpToolbarMorph,
-	#superclass : #PanelMorph,
+	#superclass : #Morph,
 	#instVars : [
 		'leftPanel',
 		'rightPanel',
@@ -55,7 +55,9 @@ SpToolbarMorph >> addItem: aToolbarItem [
 SpToolbarMorph >> addItem: aToolbarItem position: aPosition [
 
 	aPosition addItem: aToolbarItem into: self.
-	self width: self width + aToolbarItem width.
+	self computeFullBounds.
+	self minWidth: self calculateWidth.
+	self width: self minWidth.
 	self refresh
 ]
 
@@ -70,9 +72,13 @@ SpToolbarMorph >> addItemLeft: aMorph [
 { #category : #accessing }
 SpToolbarMorph >> addItemRight: aMorph [
 
+	self hasRightPanel
+		ifFalse: [ self addMorphBack: rightPanel ]. 
+
 	rightPanel addMorphBack: (aMorph
 		vResizing: #spaceFill;
-		yourself)
+		yourself).
+	rightPanel width: (rightPanel submorphs sum: #width)
 ]
 
 { #category : #'as yet unclassified' }
@@ -87,6 +93,13 @@ SpToolbarMorph >> addItemsFromContext: aContext [
 
 ]
 
+{ #category : #private }
+SpToolbarMorph >> calculateWidth [
+
+	^ (leftPanel submorphs sum: #width) 
+		+ (self hasRightPanel ifTrue: [ rightPanel submorphs sum: #width ] ifFalse: [ 0 ])
+]
+
 { #category : #updating }
 SpToolbarMorph >> clearItems [
 	
@@ -95,13 +108,13 @@ SpToolbarMorph >> clearItems [
 ]
 
 { #category : #accessing }
-SpToolbarMorph >> color [
-	^ color ifNil: [ Color transparent ]
+SpToolbarMorph >> color: aColor [
+	color := aColor
 ]
 
 { #category : #accessing }
-SpToolbarMorph >> color: aColor [
-	color := aColor
+SpToolbarMorph >> defaultColor [
+	^ Color transparent
 ]
 
 { #category : #accessing }
@@ -114,6 +127,12 @@ SpToolbarMorph >> displayMode: anObject [
 	displayMode := anObject
 ]
 
+{ #category : #private }
+SpToolbarMorph >> hasRightPanel [
+
+	^ self submorphs includes: rightPanel
+]
+
 { #category : #initialization }
 SpToolbarMorph >> initialize [
 	super initialize.
@@ -121,9 +140,10 @@ SpToolbarMorph >> initialize [
 	self
 		changeTableLayout;
 		listDirection: #leftToRight;
-		hResizing: #spaceFill;
-		vResizing: #spaceFill;
-		color: self color;
+		hResizing: #shrinkWrap;
+		vResizing: #shrinkWrap;
+		wrapCentering: #center; 
+		color: self defaultColor;
 		extent: 0@0.
 	
 	self initializePanels
@@ -137,18 +157,15 @@ SpToolbarMorph >> initializePanels [
 		listDirection: #rightToLeft;
 		hResizing: #spaceFill.
 
-	self
-		addMorphBack: leftPanel;
-		addMorphBack: rightPanel
-
+	self addMorphBack: leftPanel
 ]
 
-{ #category : #'private accessing' }
+{ #category : #private }
 SpToolbarMorph >> leftPanel [
 	^ leftPanel
 ]
 
-{ #category : #'private accessing' }
+{ #category : #private }
 SpToolbarMorph >> leftPanel: anObject [
 	leftPanel := anObject
 ]
@@ -156,14 +173,14 @@ SpToolbarMorph >> leftPanel: anObject [
 { #category : #'private factory' }
 SpToolbarMorph >> newPanelMorph [
 
-	^ PanelMorph new 
+	^ Morph new
 		changeTableLayout;
 		listDirection: #leftToRight;
-		hResizing: #spaceFill;
-		vResizing: #spaceFill;
+		hResizing: #shrinkWrap;
+		vResizing: #shrinkWrap;
 		cellInset: self class defaultItemSeparation@0;
 		extent: 0@0;
-		color: self color;
+		color: Color transparent;
 		yourself
 ]
 
@@ -183,12 +200,12 @@ SpToolbarMorph >> refresh [
 	self flag: #TODO. "Maybe remove?"
 ]
 
-{ #category : #'private accessing' }
+{ #category : #private }
 SpToolbarMorph >> rightPanel [
 	^ rightPanel
 ]
 
-{ #category : #'private accessing' }
+{ #category : #private }
 SpToolbarMorph >> rightPanel: anObject [
 	rightPanel := anObject
 ]

--- a/src/Spec2-Adapters-Morphic/UITheme.extension.st
+++ b/src/Spec2-Adapters-Morphic/UITheme.extension.st
@@ -6,3 +6,9 @@ UITheme >> modalBackdropColor [
 
 	^ Color black alpha: 0.2
 ]
+
+{ #category : #'*Spec2-Adapters-Morphic' }
+UITheme >> popoverButtonColor [
+
+	^ self darkBaseColor
+]

--- a/src/Spec2-Code-Morphic/SpMorphicCodeAdapter.class.st
+++ b/src/Spec2-Code-Morphic/SpMorphicCodeAdapter.class.st
@@ -113,7 +113,7 @@ SpMorphicCodeAdapter >> hasSyntaxHighlightEnabled [
 ]
 
 { #category : #'widget API' }
-SpMorphicCodeAdapter >> insertPopoverAfterCurrentSelection: aPresenter [
+SpMorphicCodeAdapter >> insertPopoverAfterCurrentSelection: aPresenter style: styleName [
 	| popover pos |
 
 	self widgetDo: [ :w |
@@ -121,12 +121,15 @@ SpMorphicCodeAdapter >> insertPopoverAfterCurrentSelection: aPresenter [
 		popover := self presenter newPopover
 			bePositionRight;
 			presenter: aPresenter;
-			buildWithSpec;
 			yourself.
+			
+		styleName ifNotNil: [ 
+			popover addStyle: styleName ].
+		popover buildWithSpec.
 	
 		pos := self computeOriginFor: w.
-		"(16@ -5) is a magic number to position correctly the popover"
-		popover popupPointingTo: (pos corner: (pos + (16@ -5))).
+		"(20@0) is a magic number to position correctly the popover"
+		popover popupPointingTo: (pos corner: (pos + (20@0))).
 		popover takeKeyboardFocus ]
 ]
 

--- a/src/Spec2-Code/SpCodeInteractionModel.class.st
+++ b/src/Spec2-Code/SpCodeInteractionModel.class.st
@@ -85,7 +85,7 @@ SpCodeInteractionModel >> notify: message at: location in: code [
 
 	currentSelection := self owner selectionInterval.
 	self owner 
-		insertPopover: (SpCodePopoverErrorPresenter 
+		insertErrorPopover: (SpCodePopoverErrorPresenter 
 			newCode: self owner 
 			message: stripMessage) 
 		atIndex: (currentSelection isEmptyOrNil

--- a/src/Spec2-Code/SpCodePopoverPrintPresenter.class.st
+++ b/src/Spec2-Code/SpCodePopoverPrintPresenter.class.st
@@ -86,8 +86,6 @@ SpCodePopoverPrintPresenter >> initializePresenters [
 	self initializeText.
 
 	layout := SpBoxLayout newHorizontal
-		spacing: 5;
-		borderWidth: 5;
 		add: text;
 		yourself.
 

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -452,6 +452,13 @@ SpCodePresenter >> initialize [
 ]
 
 { #category : #api }
+SpCodePresenter >> insertErrorPopover: aPresenter atIndex: location [
+
+	self selectionInterval: ((location + 1) to: location).
+	self insertPopoverAfterCurrentSelection: aPresenter style: 'error'.  
+]
+
+{ #category : #api }
 SpCodePresenter >> insertPopover: aPresenter atIndex: location [
 
 	self selectionInterval: ((location + 1) to: location).
@@ -461,8 +468,18 @@ SpCodePresenter >> insertPopover: aPresenter atIndex: location [
 { #category : #api }
 SpCodePresenter >> insertPopoverAfterCurrentSelection: aPresenter [
 
+	self 
+		insertPopoverAfterCurrentSelection: aPresenter
+		style: nil
+]
+
+{ #category : #api }
+SpCodePresenter >> insertPopoverAfterCurrentSelection: aPresenter style: styleName [
+	"Popups a popover with contents `aPresenter` after current text selection. 
+	 It adds `styleName` to the popover style."
+
 	self withAdapterDo: [ :anAdapter |
-		anAdapter insertPopoverAfterCurrentSelection: aPresenter ]
+		anAdapter insertPopoverAfterCurrentSelection: aPresenter style: styleName ]
 ]
 
 { #category : #api }
@@ -470,9 +487,11 @@ SpCodePresenter >> insertPrintPopoverAfterCurrentSelection: anObject [
 	"Inserts a print-it result popover. 
 	 This is for use of SpCodePrintItCommand"
 	
-	self insertPopoverAfterCurrentSelection: (SpCodePopoverPrintPresenter 
-		newCode: self
-		object: anObject)
+	self 
+		insertPopoverAfterCurrentSelection: (SpCodePopoverPrintPresenter 
+			newCode: self
+			object: anObject)
+		style: 'print'
 ]
 
 { #category : #api }
@@ -555,16 +574,8 @@ SpCodePresenter >> selectedClassOrMetaClass [
 
 { #category : #'command support' }
 SpCodePresenter >> selectedSelector [
-	| node textSelection |
 	
-	textSelection := self selectedTextOrLine.
-	node := RBParser parseFaultyExpression: textSelection.
-	node nodesDo: [ :n | 
-		n isMessage ifTrue: [ ^ n selector ].
-		n isVariable ifTrue: [ ^ n name ].
-		n isLiteralNode ifTrue: [ ^ n value ] ].
-	"fall back"
-	^ textSelection trimmed asSymbol
+    ^ CNSelectorExtractor new extractSelectorFromSelection: self selectedTextOrLine
 ]
 
 { #category : #api }

--- a/src/Spec2-Commander2/SpCommandGroup.class.st
+++ b/src/Spec2-Commander2/SpCommandGroup.class.st
@@ -8,6 +8,9 @@ Basically, I add:
 Class {
 	#name : #SpCommandGroup,
 	#superclass : #CmUICommandGroup,
+	#instVars : [
+		'toolbarPopoverButton'
+	],
 	#category : #'Spec2-Commander2-Core'
 }
 
@@ -74,6 +77,18 @@ SpCommandGroup >> asToolbarPresenterWith: aBlock [
 		toolbarPresenter
 ]
 
+{ #category : #configuring }
+SpCommandGroup >> beToolbarGroup [
+
+	toolbarPopoverButton := false
+]
+
+{ #category : #configuring }
+SpCommandGroup >> beToolbarPopoverButton [
+
+	toolbarPopoverButton := true
+]
+
 { #category : #displaying }
 SpCommandGroup >> displayIn: aMenuPresenter do: aBlock [
 
@@ -83,9 +98,22 @@ SpCommandGroup >> displayIn: aMenuPresenter do: aBlock [
 		do: aBlock
 ]
 
+{ #category : #initialization }
+SpCommandGroup >> initialize [
+
+	super initialize.
+	toolbarPopoverButton := false
+]
+
 { #category : #'shortcuts installation' }
 SpCommandGroup >> installShortcutsIn: aPresenter [ 
 	SpShortcutInstaller new
 		presenter: aPresenter;
 		visit: self
+]
+
+{ #category : #testing }
+SpCommandGroup >> isToolbarPopoverButton [
+
+	^ toolbarPopoverButton
 ]

--- a/src/Spec2-Commander2/SpPresenter.extension.st
+++ b/src/Spec2-Commander2/SpPresenter.extension.st
@@ -10,17 +10,23 @@ SpPresenter class >> buildCommandsGroupWith: presenter forRoot: aCmCommandsGroup
 ]
 
 { #category : #'*Spec2-Commander2' }
-SpPresenter class >> buildRootCommandsGroupFor: presenterInstance [
-	| rootCommandGroup |
-	rootCommandGroup := CmCommandGroup forSpec beRoot.
-	"Register default commands."
-	self buildCommandsGroupWith: presenterInstance forRoot: rootCommandGroup.
+SpPresenter class >> buildExtensionCommandsWith: aPresenter forRoot: rootCommandGroup [
 	
-	"Register extension commands."
 	(Pragma allNamed: #extensionCommands in: self class) do: [ :pragma | 
 		(self 
 			perform: pragma methodSelector 
-			withArguments: { presenterInstance . rootCommandGroup }) ].
+			withArguments: { aPresenter . rootCommandGroup }) ]
+]
+
+{ #category : #'*Spec2-Commander2' }
+SpPresenter class >> buildRootCommandsGroupFor: aPresenter [
+	| rootCommandGroup |
+	
+	rootCommandGroup := CmCommandGroup forSpec beRoot.
+	"Register default commands."
+	self buildCommandsGroupWith: aPresenter forRoot: rootCommandGroup.
+	"Register extension commands."
+	self buildExtensionCommandsWith: aPresenter forRoot: rootCommandGroup.
 	
 	^ rootCommandGroup
 ]

--- a/src/Spec2-Commander2/SpToolbarPresenterBuilder.class.st
+++ b/src/Spec2-Commander2/SpToolbarPresenterBuilder.class.st
@@ -12,6 +12,20 @@ Class {
 	#category : #'Spec2-Commander2-Visitors'
 }
 
+{ #category : #private }
+SpToolbarPresenterBuilder >> addPopoverButtonFrom: aCommandsGroup [
+	| button |
+
+	self toolbarPresenter addItem: ((button := self toolbarPresenter newToolbarPopoverButton) 
+		label: aCommandsGroup name;
+		icon: aCommandsGroup icon;
+		content: [ 
+			self class new
+				visit: aCommandsGroup copy beToolbarGroup;
+				toolbarPresenter ];
+		yourself)	
+]
+
 { #category : #initialization }
 SpToolbarPresenterBuilder >> initialize [
 	super initialize.
@@ -33,4 +47,12 @@ SpToolbarPresenterBuilder >> visitCommand: aCmCommandEntry [
 	aCmCommandEntry positionStrategy
 		addButton: aCmCommandEntry buildPresenter
 		toToolbar: self toolbarPresenter
+]
+
+{ #category : #visiting }
+SpToolbarPresenterBuilder >> visitCommandGroup: aCmCommandsGroup [
+	
+	aCmCommandsGroup isToolbarPopoverButton 
+		ifTrue: [ self addPopoverButtonFrom: aCmCommandsGroup ]
+		ifFalse: [ super visitCommandGroup: aCmCommandsGroup ]
 ]

--- a/src/Spec2-Core/SpFilteringListPresenter.class.st
+++ b/src/Spec2-Core/SpFilteringListPresenter.class.st
@@ -13,10 +13,10 @@ Class {
 	#name : #SpFilteringListPresenter,
 	#superclass : #SpPresenter,
 	#instVars : [
-		'itemFilter',
 		'unfilteredItems',
 		'listPresenter',
-		'filterInputPresenter'
+		'filterInputPresenter',
+		'itemFilterBlock'
 	],
 	#category : #'Spec2-Core-Widgets-Advanced'
 }
@@ -83,18 +83,20 @@ SpFilteringListPresenter >> filterInputPresenter [
 
 { #category : #private }
 SpFilteringListPresenter >> filterListItems: pattern [
-	| filteredItems |
 
+	| filteredItems |
 	unfilteredItems ifNil: [ unfilteredItems := self items ].
+	(unfilteredItems includesAll: self items) ifFalse: [ 
+		unfilteredItems := self items ].
 	pattern ifEmpty: [ 
 		self items: unfilteredItems.
 		^ self ].
-	
-	filteredItems := unfilteredItems select: [ :item |
-		itemFilter 
-			value: (self display value: item)
-			value: pattern ].
-	
+
+	filteredItems := unfilteredItems select: [ :item | 
+		                 itemFilterBlock
+			                 value: (self display value: item)
+			                 value: pattern ].
+
 	self items: filteredItems
 ]
 
@@ -107,7 +109,9 @@ SpFilteringListPresenter >> filterText [
 { #category : #initialization }
 SpFilteringListPresenter >> initializePresenters [
 
-	filterInputPresenter := self newTextInput placeholder: 'Filter...'; yourself.
+	filterInputPresenter := self newTextInput
+		                        placeholder: 'Filter...';
+		                        yourself.
 	listPresenter := self newListToFilter.
 	self matchSubstring
 ]
@@ -115,13 +119,13 @@ SpFilteringListPresenter >> initializePresenters [
 { #category : #private }
 SpFilteringListPresenter >> itemFilter [
 
-	^ itemFilter
+	^ itemFilterBlock
 ]
 
 { #category : #api }
 SpFilteringListPresenter >> itemFilter: aBlock [
 
-	itemFilter := aBlock
+	itemFilterBlock := aBlock
 ]
 
 { #category : #api }
@@ -144,17 +148,15 @@ SpFilteringListPresenter >> listPresenter [
 { #category : #initialization }
 SpFilteringListPresenter >> matchBeginOfString [
 
-	itemFilter := [ :each :pattern | 
+	itemFilterBlock := [ :each :pattern | 
 	              each asLowercase beginsWith: pattern asLowercase ]
 ]
 
 { #category : #initialization }
 SpFilteringListPresenter >> matchSubstring [
 
-	itemFilter := [ :each :pattern | 
-		each 
-			includesSubstring: pattern asLowercase 
-			caseSensitive: false ]
+	itemFilterBlock := [ :each :pattern | 
+	              each asLowercase includesSubstring: pattern asLowercase ]
 ]
 
 { #category : #initialization }

--- a/src/Spec2-Core/SpFilteringSelectableListPresenter.class.st
+++ b/src/Spec2-Core/SpFilteringSelectableListPresenter.class.st
@@ -22,7 +22,8 @@ SpFilteringSelectableListPresenter >> display [
 { #category : #api }
 SpFilteringSelectableListPresenter >> display: aBlock [
 
-	displayBlock := aBlock
+	displayBlock := aBlock.
+	listPresenter columns: self listColumns
 ]
 
 { #category : #api }

--- a/src/Spec2-Core/SpMillerColumnPresenter.class.st
+++ b/src/Spec2-Core/SpMillerColumnPresenter.class.st
@@ -110,6 +110,16 @@ SpMillerColumnPresenter >> pushModel: aModel [
 	self addPresenter: (self newPresenterFor: aModel)
 ]
 
+{ #category : #api }
+SpMillerColumnPresenter >> removeAllFrom: aPage [
+	"remove all columns starting by this page."
+	| index |
+
+	index := (self pages indexOf: aPage) - 1.
+	self resetTo: index.
+	self selectPage: index
+]
+
 { #category : #private }
 SpMillerColumnPresenter >> resetTo: anIndex [
 	"Remove all presenters up to anIndex.

--- a/src/Spec2-Core/SpMillerPaginatorPresenter.class.st
+++ b/src/Spec2-Core/SpMillerPaginatorPresenter.class.st
@@ -54,6 +54,13 @@ SpMillerPaginatorPresenter >> paginatorPresenter [
 	^ paginator
 ]
 
+{ #category : #api }
+SpMillerPaginatorPresenter >> removeAllFrom: aPresenter [
+
+	millerList removeAllFrom: aPresenter.
+	self updatePaginator: ((millerList pages size - millerList visiblePages + 1) max: 1)
+]
+
 { #category : #private }
 SpMillerPaginatorPresenter >> updatePaginator: pageSelected [
 

--- a/src/Spec2-Core/SpPresenter.class.st
+++ b/src/Spec2-Core/SpPresenter.class.st
@@ -453,12 +453,12 @@ SpPresenter >> ensureExtentFor: widget [
 	
 ]
 
-{ #category : #TOMOVE }
+{ #category : #TOREMOVE }
 SpPresenter >> extent [
 	^ extent
 ]
 
-{ #category : #TOMOVE }
+{ #category : #TOREMOVE }
 SpPresenter >> extent: aPoint [
 	^ extent := aPoint
 ]
@@ -915,7 +915,13 @@ SpPresenter >> newToolbarButton [
 { #category : #widgets }
 SpPresenter >> newToolbarMenuButton [
 
-	^ self instantiate: SpToolbarToggleButtonPresenter
+	^ self instantiate: SpToolbarMenuButtonPresenter
+]
+
+{ #category : #widgets }
+SpPresenter >> newToolbarPopoverButton [
+
+	^ self instantiate: SpToolbarPopoverButtonPresenter
 ]
 
 { #category : #widgets }

--- a/src/Spec2-Core/SpToolbarButtonPresenter.class.st
+++ b/src/Spec2-Core/SpToolbarButtonPresenter.class.st
@@ -61,7 +61,7 @@ SpToolbarButtonPresenter >> badge: aString [
 { #category : #simulating }
 SpToolbarButtonPresenter >> click [
 	
-	self execute
+	self action cull: self
 ]
 
 { #category : #execution }

--- a/src/Spec2-Core/SpToolbarButtonPresenter.class.st
+++ b/src/Spec2-Core/SpToolbarButtonPresenter.class.st
@@ -66,7 +66,8 @@ SpToolbarButtonPresenter >> click [
 
 { #category : #execution }
 SpToolbarButtonPresenter >> execute [
-	self action cull: self
+
+	self withAdapterDo: [ :anAdapter | anAdapter execute ]
 ]
 
 { #category : #api }

--- a/src/Spec2-Core/SpToolbarPopoverButtonPresenter.class.st
+++ b/src/Spec2-Core/SpToolbarPopoverButtonPresenter.class.st
@@ -1,0 +1,41 @@
+"
+A presenter to create a popover button (a button who exposes a popover instead having an action) in a `SpToolbarPresenter`.
+"
+Class {
+	#name : #SpToolbarPopoverButtonPresenter,
+	#superclass : #SpToolbarButtonPresenter,
+	#instVars : [
+		'content'
+	],
+	#category : #'Spec2-Core-Widgets-Toolbar'
+}
+
+{ #category : #specs }
+SpToolbarPopoverButtonPresenter class >> adapterName [
+
+	^ #ToolbarPopoverButtonAdapter
+]
+
+{ #category : #documentation }
+SpToolbarPopoverButtonPresenter class >> documentFactoryMethodSelector [
+
+	^ #newToolbarPopoverButton
+]
+
+{ #category : #api }
+SpToolbarPopoverButtonPresenter >> content [
+	"Answer the content presenter associated to this popover button. 
+	 It can also be a block (or valuable) which will answer an instance of `SpPresenter`
+	 when evaluated. "
+
+	^ content
+]
+
+{ #category : #api }
+SpToolbarPopoverButtonPresenter >> content: aPresenterOrBlock [
+	"Set the presenter associated to this popover button. 
+	 It can also be a block (or valuable) which will answer an instance of `SpPresenter`
+	 when evaluated. "
+
+	content := aPresenterOrBlock
+]

--- a/src/Spec2-Core/SpTreePresenter.class.st
+++ b/src/Spec2-Core/SpTreePresenter.class.st
@@ -204,6 +204,15 @@ SpTreePresenter >> doubleClickAtPath: aPath [
 ]
 
 { #category : #api }
+SpTreePresenter >> expandAll [
+	"Expand all nodes of the tree. 
+	 WARNING: If your tree is big, this operation can be slow."
+
+	self withAdapterPerformOrDefer: [ :anAdapter | 
+		anAdapter expandAll ]
+]
+
+{ #category : #api }
 SpTreePresenter >> expandPath: aPath [
 	"Expand the tree path.
 	`aPath` is the path to expand. A path is an array of node indexes (e.g. #(1 2 3))"

--- a/src/Spec2-Core/SpTreeTablePresenter.class.st
+++ b/src/Spec2-Core/SpTreeTablePresenter.class.st
@@ -198,6 +198,15 @@ SpTreeTablePresenter >> doubleClickAtPath: aPath [
 ]
 
 { #category : #api }
+SpTreeTablePresenter >> expandAll [
+	"Expand all nodes of the tree. 
+	 WARNING: If your tree is big, this operation can be slow."
+
+	self withAdapterPerformOrDefer: [ :anAdapter | 
+		anAdapter expandAll ]
+]
+
+{ #category : #api }
 SpTreeTablePresenter >> expandPath: aPath [
 	"Expand the tree path.
 	`aPath` is the path to expand. A path is an array of node indexes (e.g. #(1 2 3))"

--- a/src/Spec2-Examples/SpDemoStandaloneFormPresenter.class.st
+++ b/src/Spec2-Examples/SpDemoStandaloneFormPresenter.class.st
@@ -67,11 +67,11 @@ SpDemoStandaloneFormPresenter class >> defaultSpec [
 				add: 'Items:' at: 1 @ 10;
 				add: #itemsInput at: 2 @ 10;
 				yourself);
-		add:
-			(SpBoxLayout newHorizontal
+		add: (SpBoxLayout newHorizontal
 				add: #submitButton;
 				add: #restoreButton;
-				yourself);
+				yourself)
+			expand: false;
 		yourself
 ]
 
@@ -195,8 +195,7 @@ SpDemoStandaloneFormPresenter >> initializePresenters [
 	scaleInput := self newSlider.
 
 	passwordLabel := self newLabel label: 'password:'.
-	passwordInput := self newTextInput
-		bePassword.
+	passwordInput := self newTextInput bePassword.
 	checkboxLabel := self newLabel label: 'remember me'.
 	checkboxInput := self newCheckBox state: true.
 
@@ -207,7 +206,9 @@ SpDemoStandaloneFormPresenter >> initializePresenters [
 	maleButton := self newRadioButton label: 'male'.
 	femaleButton := self newRadioButton label: 'female'.
 	maleButton associatedRadioButtons: {femaleButton}.
-	genderButtons := Dictionary newFrom: {(#male -> maleButton) . (#female -> femaleButton)}.
+	genderButtons := Dictionary newFrom: {
+		(#male -> maleButton). 
+		(#female -> femaleButton)}.
 
 	genderLabel := self newLabel label: 'gender:'.
 	itemsLabel := self newLabel label: 'items:'.
@@ -216,16 +217,7 @@ SpDemoStandaloneFormPresenter >> initializePresenters [
 	itemsInput items: self model items.
 
 	submitButton := self newButton label: 'Submit'.
-	restoreButton := self newButton label: 'Restore'.
-
-	self focusOrder
-		add: nameTextInput;
-		add: surnameTextInput;
-		add: number1Input;
-		add: number2Input;
-		add: scaleInput;
-		add: passwordInput;
-		add: checkboxInput
+	restoreButton := self newButton label: 'Restore'
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Examples/SpDemoTreeTablePresenter.class.st
+++ b/src/Spec2-Examples/SpDemoTreeTablePresenter.class.st
@@ -26,20 +26,22 @@ SpDemoTreeTablePresenter class >> defaultSpec [
 
 { #category : #initialization }
 SpDemoTreeTablePresenter >> initializePresenters [
-	table1 := self newTreeTable.
 
+	table1 := self newTreeTable.
 	table1
-		addColumn:
-			(SpCompositeTableColumn new
-				title: 'Classes';
-				addColumn:
-					((SpImageTableColumn evaluated: #systemIcon)
-						width: 20;
-						yourself);
-				addColumn: (SpStringTableColumn evaluated: #name);
+		addColumn: (SpCompositeTableColumn new
+			title: 'Classes';
+			addColumn: ((SpImageTableColumn evaluated: #systemIcon)
+				width: 20;
 				yourself);
-		addColumn: (SpStringTableColumn title: 'Number of subclasses' evaluated: [ :class | class subclasses size asString ]);
-		addColumn: (SpStringTableColumn title: 'Number of methods' evaluated: [ :class | class methods size asString ]);
+			addColumn: (SpStringTableColumn evaluated: #name);
+			yourself);
+		addColumn: (SpStringTableColumn 
+			title: 'Number of subclasses' 
+			evaluated: [ :class | class subclasses size asString ]);
+		addColumn: (SpStringTableColumn 
+			title: 'Number of methods' 
+			evaluated: [ :class | class methods size asString ]);
 		roots: {Object};
 		children: [ :aClass | aClass subclasses ];
 		beResizable;

--- a/src/Spec2-Examples/SpInitializeWindowExample.class.st
+++ b/src/Spec2-Examples/SpInitializeWindowExample.class.st
@@ -6,7 +6,7 @@ You can choose which one(s) you want to add.
 self show.
 "
 Class {
-	#name : #SpPrepareWindowExample,
+	#name : #SpInitializeWindowExample,
 	#superclass : #SpPresenter,
 	#instVars : [
 		'menu',
@@ -19,21 +19,21 @@ Class {
 }
 
 { #category : #specs }
-SpPrepareWindowExample class >> defaultSpec [
+SpInitializeWindowExample class >> defaultSpec [
 	^ SpBoxLayout newVertical
 		add: #text;
 		yourself
 ]
 
 { #category : #showing }
-SpPrepareWindowExample class >> show [
+SpInitializeWindowExample class >> show [
 	<script>
 
 	self new openWithSpec
 ]
 
 { #category : #'private building' }
-SpPrepareWindowExample >> buildFileMenu [
+SpInitializeWindowExample >> buildFileMenu [
 
 	^ self newMenu
 		addItem: [ :item | item name: 'Push message'; action: [ self pushMessage ] ];
@@ -42,7 +42,7 @@ SpPrepareWindowExample >> buildFileMenu [
 ]
 
 { #category : #'private building' }
-SpPrepareWindowExample >> buildMenuBar [
+SpInitializeWindowExample >> buildMenuBar [
 
 	^ self newMenuBar
 		addGroup: [ :group | group
@@ -50,7 +50,7 @@ SpPrepareWindowExample >> buildMenuBar [
 ]
 
 { #category : #'private building' }
-SpPrepareWindowExample >> buildPopMessageToolBarItem [
+SpInitializeWindowExample >> buildPopMessageToolBarItem [
 		
 	^ SpToolbarButtonPresenter new
 		label: 'Pop';
@@ -61,7 +61,7 @@ SpPrepareWindowExample >> buildPopMessageToolBarItem [
 ]
 
 { #category : #'private building' }
-SpPrepareWindowExample >> buildPushMessageToolBarItem [
+SpInitializeWindowExample >> buildPushMessageToolBarItem [
 		
 	^ SpToolbarButtonPresenter new
 		label: 'Push';
@@ -72,13 +72,13 @@ SpPrepareWindowExample >> buildPushMessageToolBarItem [
 ]
 
 { #category : #'private building' }
-SpPrepareWindowExample >> buildStatusBar [
+SpInitializeWindowExample >> buildStatusBar [
 
 	^ SpStatusBarPresenter new
 ]
 
 { #category : #'private building' }
-SpPrepareWindowExample >> buildToolbar [
+SpInitializeWindowExample >> buildToolbar [
 	
 	^ self newToolbar 
 		addItem: self buildPushMessageToolBarItem;
@@ -88,28 +88,28 @@ SpPrepareWindowExample >> buildToolbar [
 ]
 
 { #category : #api }
-SpPrepareWindowExample >> initialExtent [
+SpInitializeWindowExample >> initialExtent [
  
 	^ 600@400
 ]
 
 { #category : #initialization }
-SpPrepareWindowExample >> initialize [
+SpInitializeWindowExample >> initialize [
 
 	super initialize.
 	count := 0
 ]
 
 { #category : #initialization }
-SpPrepareWindowExample >> initializePresenters [
+SpInitializeWindowExample >> initializePresenters [
 	
-	text := self newText text: 'Implementing #prepareWindow:, you can add a menu, toolbar and statusBar to your component.
+	text := self newText text: 'Implementing #initializeWindow:, you can add a menu, toolbar and statusBar to your component.
 
 BEWARE: This elements will be added just when you will open the presenter as a window or dialog. Otherwise, your component will behave just as another composable presenter.'
 ]
 
 { #category : #initialization }
-SpPrepareWindowExample >> initializeWindow: aWindowPresenter [
+SpInitializeWindowExample >> initializeWindow: aWindowPresenter [
 	"I'm called whenever the component will be displayed in a window (or dialog). 
 	 This is usually attained sending #openWithSpec or #openDialogWithSpec."
 	
@@ -121,32 +121,32 @@ SpPrepareWindowExample >> initializeWindow: aWindowPresenter [
 ]
 
 { #category : #actions }
-SpPrepareWindowExample >> popMessage [
+SpInitializeWindowExample >> popMessage [
 
 	statusBar popMessage
 ]
 
 { #category : #actions }
-SpPrepareWindowExample >> pushMessage [
+SpInitializeWindowExample >> pushMessage [
 	
 	count := count + 1.
 	statusBar pushMessage: ('StatusBar message {1}...' format: { count })
 ]
 
 { #category : #'accessing ui' }
-SpPrepareWindowExample >> text [ 
+SpInitializeWindowExample >> text [ 
 
 	^ text
 ]
 
 { #category : #actions }
-SpPrepareWindowExample >> text: aPresenter [
+SpInitializeWindowExample >> text: aPresenter [
 
 	text := aPresenter
 ]
 
 { #category : #api }
-SpPrepareWindowExample >> title [ 
+SpInitializeWindowExample >> title [ 
 
 	^ 'Example of using #prepareWindow:'
 ]

--- a/src/Spec2-Examples/SpPopoverExample.class.st
+++ b/src/Spec2-Examples/SpPopoverExample.class.st
@@ -32,6 +32,13 @@ SpPopoverExample class >> defaultSpec [
 		yourself
 ]
 
+{ #category : #showing }
+SpPopoverExample class >> open [
+	<script>
+
+	^ self new openWithSpec
+]
+
 { #category : #initialization }
 SpPopoverExample >> initializePresenters [
 

--- a/src/Spec2-Layout/SpBoxLayout.class.st
+++ b/src/Spec2-Layout/SpBoxLayout.class.st
@@ -158,12 +158,6 @@ SpBoxLayout >> direction [
 	^ direction
 ]
 
-{ #category : #testing }
-SpBoxLayout >> hasAlignment [
-
-	^ self hasVAlign or: [ self hasHAlign ]
-]
-
 { #category : #private }
 SpBoxLayout >> homogeneous: aBoolean [
 

--- a/src/Spec2-Layout/SpBoxLayout.class.st
+++ b/src/Spec2-Layout/SpBoxLayout.class.st
@@ -158,6 +158,12 @@ SpBoxLayout >> direction [
 	^ direction
 ]
 
+{ #category : #testing }
+SpBoxLayout >> hasAlignment [
+
+	^ self hasVAlign or: [ self hasHAlign ]
+]
+
 { #category : #private }
 SpBoxLayout >> homogeneous: aBoolean [
 

--- a/src/Spec2-Layout/SpGridAxisConstraints.class.st
+++ b/src/Spec2-Layout/SpGridAxisConstraints.class.st
@@ -32,6 +32,12 @@ SpGridAxisConstraints >> expand: anObject [
 ]
 
 { #category : #testing }
+SpGridAxisConstraints >> hasAlignment [
+
+	^ self hasVAlign or: [ self hasHAlign ]
+]
+
+{ #category : #testing }
 SpGridAxisConstraints >> isExpand [
 
 	^ expand == true

--- a/src/Spec2-Layout/SpGridAxisConstraints.class.st
+++ b/src/Spec2-Layout/SpGridAxisConstraints.class.st
@@ -32,12 +32,6 @@ SpGridAxisConstraints >> expand: anObject [
 ]
 
 { #category : #testing }
-SpGridAxisConstraints >> hasAlignment [
-
-	^ self hasVAlign or: [ self hasHAlign ]
-]
-
-{ #category : #testing }
 SpGridAxisConstraints >> isExpand [
 
 	^ expand == true

--- a/src/Spec2-Layout/SpGridConstraints.class.st
+++ b/src/Spec2-Layout/SpGridConstraints.class.st
@@ -43,6 +43,12 @@ SpGridConstraints >> columnSpan [
 	^ self span x
 ]
 
+{ #category : #testing }
+SpGridConstraints >> hasAlignment [
+
+	^ self hasVAlign or: [ self hasHAlign ]
+]
+
 { #category : #initialization }
 SpGridConstraints >> initialize [
 

--- a/src/Spec2-Layout/SpGridConstraints.class.st
+++ b/src/Spec2-Layout/SpGridConstraints.class.st
@@ -43,12 +43,6 @@ SpGridConstraints >> columnSpan [
 	^ self span x
 ]
 
-{ #category : #testing }
-SpGridConstraints >> hasAlignment [
-
-	^ self hasVAlign or: [ self hasHAlign ]
-]
-
 { #category : #initialization }
 SpGridConstraints >> initialize [
 

--- a/src/Spec2-Layout/SpTAlignable.trait.st
+++ b/src/Spec2-Layout/SpTAlignable.trait.st
@@ -13,9 +13,9 @@ Trait {
 
 { #category : #accessing }
 SpTAlignable >> hAlign [
-	"I define the vertical alignment of the widgets in the layout.
+	"I define the horizontal alignment of the widgets in the layout.
 	 aligns can be start, center and end. 
-	 To set this value, you can use vAlignStart, vAlignCenter, vAlignEnd"
+	 To set this value, you can use hAlignStart, hAlignCenter, hAlignEnd"
 
 	^ hAlign
 ]
@@ -48,7 +48,19 @@ SpTAlignable >> hAlignStart [
 { #category : #testing }
 SpTAlignable >> hasAlignment [
 
-	^ vAlign notNil or: [ hAlign notNil ]
+	^ self hasVAlign or: [ self hasHAlign ]
+]
+
+{ #category : #testing }
+SpTAlignable >> hasHAlign [
+
+	^ hAlign notNil
+]
+
+{ #category : #testing }
+SpTAlignable >> hasVAlign [
+
+	^ vAlign notNil
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Morphic-Tests/SpPaginatorMorphTest.class.st
+++ b/src/Spec2-Morphic-Tests/SpPaginatorMorphTest.class.st
@@ -1,0 +1,61 @@
+Class {
+	#name : #SpPaginatorMorphTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'morph'
+	],
+	#category : #'Spec2-Morphic-Tests'
+}
+
+{ #category : #running }
+SpPaginatorMorphTest >> setUp [
+
+	super setUp.
+	morph := SpPaginatorMorph new 
+		color: Color white;
+		hResizing: #shrinkWrap;
+		yourself.
+	1 to: 10 do: [ :index | 
+		morph addPage: index ].
+	morph openInWorld.
+
+]
+
+{ #category : #running }
+SpPaginatorMorphTest >> tearDown [
+
+	morph delete.
+	super tearDown
+]
+
+{ #category : #tests }
+SpPaginatorMorphTest >> testSelectPage [
+
+	self assert: morph selectedPages equals: #(1 2).
+	morph selectPage: 5.
+	self assert: morph selectedPages equals: #(5 6).
+	"10 is last, I cannot select 10, 11... then I select 9, 10"
+	morph selectPage: 10.
+	self assert: morph selectedPages equals: #(9 10)
+]
+
+{ #category : #tests }
+SpPaginatorMorphTest >> testWhenNumberOfPagesShownChangedDo [
+	| numberShown |
+
+	morph whenNumberOfPagesShownChangedDo: [ :aNumber | numberShown := aNumber ].
+	morph selectPage: 5.
+	morph numberOfPagesShown: 3.
+
+	self assert: numberShown equals: 3
+]
+
+{ #category : #tests }
+SpPaginatorMorphTest >> testWhenSelectedPageChangedDo [
+	| selectedPage |
+
+	morph whenSelectedPageChangedDo: [ :pageNumber | selectedPage := pageNumber ].
+	morph selectPage: 5.
+
+	self assert: selectedPage equals: 5	
+]

--- a/src/Spec2-Tests/SpFilteringListPresenterTest.class.st
+++ b/src/Spec2-Tests/SpFilteringListPresenterTest.class.st
@@ -82,17 +82,37 @@ SpFilteringListPresenterTest >> testFilterListItems [
 		             Set.
 		             Dictionary }.
 	listWithFilter items: listItems.
-	listWithFilter applyFilter: 'collection'.
+	listWithFilter filterListItems: 'collection'.
 	self assertCollection: listWithFilter items hasSameElements: { 
 			OrderedCollection.
 			SequenceableCollection }.
-	listWithFilter applyFilter: 'xyz'.
+	listWithFilter filterListItems: 'xyz'.
 	self assertEmpty: listWithFilter items.
-	listWithFilter applyFilter: 'array'.
+	listWithFilter filterListItems: 'array'.
 	self
 		assertCollection: listWithFilter items
 		hasSameElements: { Array }.
-	listWithFilter applyFilter: ''.
+	listWithFilter filterListItems: ''.
+	self
+		assertCollection: listWithFilter items
+		hasSameElements: listItems.
+	listItems := 1 to: 10.
+	listWithFilter items: listItems.
+	listWithFilter filterListItems: 'collection'.
+	self assertEmpty: listWithFilter items.
+	listWithFilter filterListItems: '5'.
+	self assertCollection: listWithFilter items hasSameElements: #( 5 ).
+	listWithFilter filterListItems: ''.
+	self
+		assertCollection: listWithFilter items
+		hasSameElements: listItems.
+	listItems := #( 'a' 'e' 'i' 'o' 'u' ).
+	listWithFilter listPresenter items: listItems.
+	listWithFilter filterListItems: '5'.
+	self assertEmpty: listWithFilter items.
+	listWithFilter filterListItems: 'a'.
+	self assertCollection: listWithFilter items hasSameElements: #( 'a' ).
+	listWithFilter filterListItems: ''.
 	self
 		assertCollection: listWithFilter items
 		hasSameElements: listItems

--- a/src/Spec2-Tools/AbstractMessageCentricBrowser.class.st
+++ b/src/Spec2-Tools/AbstractMessageCentricBrowser.class.st
@@ -27,7 +27,8 @@ AbstractMessageCentricBrowser >> initializePresenters [
 
 { #category : #initialization }
 AbstractMessageCentricBrowser >> initializeWindow: aWindowPresenter [
-	aWindowPresenter initialExtent: (900 min: self currentWorld extent x) @ (550 min: self currentWorld extent y)
+
+	aWindowPresenter initialExtent: RealEstateAgent standardWindowExtent
 ]
 
 { #category : #private }

--- a/src/Spec2-Tools/MessageBrowser.class.st
+++ b/src/Spec2-Tools/MessageBrowser.class.st
@@ -80,13 +80,13 @@ MessageBrowser class >> browseSendersOf: aSymbol [
 
 { #category : #specs }
 MessageBrowser class >> defaultSpec [
+
 	^ SpPanedLayout newVertical
 		add: #messageList;
-		add:
-			(SpBoxLayout newVertical
-				add: #toolbarPresenter withConstraints: [ :constraints | constraints height: self buttonHeight ];
-				add: #textModel;
-				yourself);
+		add: (SpBoxLayout newVertical
+			add: #toolbarPresenter expand: false;
+			add: #textModel;
+			yourself);
 		yourself
 ]
 

--- a/src/Spec2-Tools/MessageList.class.st
+++ b/src/Spec2-Tools/MessageList.class.st
@@ -29,6 +29,7 @@ Class {
 
 { #category : #specs }
 MessageList class >> defaultSpec [
+
 	^ SpBoxLayout newVertical
 		add: #listModel;
 		yourself

--- a/src/Spec2-Tools/SpChangeSorterPresenter.class.st
+++ b/src/Spec2-Tools/SpChangeSorterPresenter.class.st
@@ -21,18 +21,18 @@ Class {
 { #category : #specs }
 SpChangeSorterPresenter class >> defaultSpec [
 	<spec>
+	
 	^ SpPanedLayout newVertical
 		position: 35 percent;
-		add:
-			(SpPanedLayout newHorizontal
-				add: #changesListPresenter;
-				add: #classesListPresenter;
-				yourself);
-		add:
-			(SpPanedLayout newVertical
-				add: #methodsListPresenter;
-				add: #textPresenter;
-				yourself)
+		add: (SpPanedLayout newHorizontal
+			add: #changesListPresenter;
+			add: #classesListPresenter;
+			yourself);
+		add: (SpPanedLayout newVertical
+			add: #methodsListPresenter;
+			add: #textPresenter;
+			yourself);
+		yourself
 ]
 
 { #category : #specs }

--- a/src/Spec2-Tools/SpKeymapPresenter.class.st
+++ b/src/Spec2-Tools/SpKeymapPresenter.class.st
@@ -17,12 +17,13 @@ Class {
 { #category : #specs }
 SpKeymapPresenter class >> defaultSpec [
 	<spec>
+
 	^ SpBoxLayout newVertical
-		add:
-			(SpBoxLayout newHorizontal
+		add: (SpBoxLayout newHorizontal
 				add: #filterField;
-				add: #clearFilterButton withConstraints: [ :constraints | constraints width: 25 ])
-			withConstraints: [ :constraints | constraints height: self toolbarHeight ];
+				add: #clearFilterButton expand: false;
+				yourself)
+			expand: false;
 		add: #kmTable;
 		yourself
 ]

--- a/src/Spec2-Tools/WorkingCopyToolbar.class.st
+++ b/src/Spec2-Tools/WorkingCopyToolbar.class.st
@@ -2,7 +2,7 @@
 WorkingCopyToolBar new openWithSpec
 "
 Class {
-	#name : #WorkingCopyToolBar,
+	#name : #WorkingCopyToolbar,
 	#superclass : #SpPresenter,
 	#instVars : [
 		'browseButton',
@@ -14,7 +14,7 @@ Class {
 }
 
 { #category : #specs }
-WorkingCopyToolBar class >> defaultSpec [ 
+WorkingCopyToolbar class >> defaultSpec [ 
 
 	^ {#SpContainerPresenter.
 			#add: . {{#presenter . #packageButton.} . #layout: .  #(FrameLayout
@@ -45,18 +45,18 @@ WorkingCopyToolBar class >> defaultSpec [
 ]
 
 { #category : #accessing }
-WorkingCopyToolBar >> browseButton [
+WorkingCopyToolbar >> browseButton [
 	^ browseButton
 ]
 
 { #category : #accessing }
-WorkingCopyToolBar >> configButton [
+WorkingCopyToolbar >> configButton [
 	
 	^ configButton
 ]
 
 { #category : #initialization }
-WorkingCopyToolBar >> createPackage [
+WorkingCopyToolbar >> createPackage [
 	| name |
 	name := UIManager default request: 'Name of package:'.
 	name isEmptyOrNil
@@ -66,7 +66,7 @@ WorkingCopyToolBar >> createPackage [
 ]
 
 { #category : #initialization }
-WorkingCopyToolBar >> initializePresenters [
+WorkingCopyToolbar >> initializePresenters [
 
 	browseButton := self newButton.
 	configButton := self newButton.
@@ -79,13 +79,13 @@ WorkingCopyToolBar >> initializePresenters [
 ]
 
 { #category : #accessing }
-WorkingCopyToolBar >> packageButton [
+WorkingCopyToolbar >> packageButton [
 
 	^ packageButton
 ]
 
 { #category : #initialization }
-WorkingCopyToolBar >> setBrowseButton [
+WorkingCopyToolbar >> setBrowseButton [
 
 	browseButton
 		state: false;
@@ -96,7 +96,7 @@ WorkingCopyToolBar >> setBrowseButton [
 ]
 
 { #category : #initialization }
-WorkingCopyToolBar >> setConfigButton [
+WorkingCopyToolbar >> setConfigButton [
 
 	configButton
 		state: false;
@@ -106,7 +106,7 @@ WorkingCopyToolBar >> setConfigButton [
 ]
 
 { #category : #initialization }
-WorkingCopyToolBar >> setPackageButton [
+WorkingCopyToolbar >> setPackageButton [
 
 	packageButton
 		state: false;
@@ -116,7 +116,7 @@ WorkingCopyToolBar >> setPackageButton [
 ]
 
 { #category : #initialization }
-WorkingCopyToolBar >> setSliceButton [
+WorkingCopyToolbar >> setSliceButton [
 	sliceButton := self instantiate: SpButtonPresenter.
 	sliceButton
 		state: false;
@@ -126,7 +126,7 @@ WorkingCopyToolBar >> setSliceButton [
 ]
 
 { #category : #accessing }
-WorkingCopyToolBar >> sliceButton [
+WorkingCopyToolbar >> sliceButton [
 	
 	^ sliceButton
 ]


### PR DESCRIPTION
https://github.com/pharo-spec/Spec/releases/tag/v0.7.6

- several enhancements and bugfixes to `SpPopoverPresenter`.
- in `SpStyle`, introduced the concept of environment variables. Now we can define EnvirontmentFont and EnvironmentColor to reference environment defined variables.
- fixed usage of minWidth/minHeight in styles.
- fix https://github.com/pharo-spec/Spec/issues/960
- fixed in how `SpBoxLayout` calculates widths and heights, allowing the toolbar to take its real place.
- fixed alignments in `SpBoxLayout` (hAlign* and vAlign* options now work properly).
- added `SpToolbarPopoverButtonPresenter`.
- `SpMillerColumnPresenter` now understands `removeAllFrom:`
- in tables, fixed the usage of showColumnHeaders (now it show headers even if headers are nil).
- in tables, fixed image columns with fixed widths (now calculate correctly the width).
- `SpCodePresenter` commands  use new selector extractor.
