### PR TITLE
Merge Iceberg v1.8.4 in Pharo 9

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -215,7 +215,7 @@ BaselineOfIDE >> baseline: spec [
 BaselineOfIDE >> loadIceberg [
 	Metacello new
 		baseline: 'Iceberg';
-		repository: 'github://pharo-vcs/iceberg:v1.8.3';
+		repository: 'github://pharo-vcs/iceberg:v1.8.4';
 		onConflictUseLoaded;
 		load.
 	(Smalltalk classNamed: #Iceberg) enableMetacelloIntegration: true.


### PR DESCRIPTION
**HOT-FIX**: Support GitHub Personal Access Tokens.

Personal access tokens are an alternative to using passwords for authentication. This is important for GitHub users, since using passwords on API calls [is not supported anymore](https://developer.github.com/changes/2/#--deprecating-password-authentication).

Note: this hot-fix is a patch over v1.8.3 and aims at being merge in Pharo 9 (in development). 
[Discussed here](https://github.com/pharo-vcs/iceberg/issues/1390) and [here](https://github.com/pharo-vcs/iceberg/pull/1393).

Refer to [this page](https://github.com/pharo-vcs/iceberg/blob/1cc1f45d13d1aca5c1a32269afad962ee539bacc/docs/Authentication-Credentials.md) about how to use this new credentials in Iceberg.


More information:
https://github.com/pharo-vcs/iceberg/releases/tag/v1.8.4