### PR TITLE
DeadCode-Cleanup-Finder

### DIFF
--- a/src/Tool-Finder/DialogItemsChooser.class.st
+++ b/src/Tool-Finder/DialogItemsChooser.class.st
@@ -5,12 +5,9 @@ Class {
 	#name : #DialogItemsChooser,
 	#superclass : #Object,
 	#instVars : [
-		'methodNameUI',
-		'choicesList',
 		'selection',
 		'unselectedItems',
 		'selectedItems',
-		'resultList',
 		'model',
 		'title',
 		'selectedItemsSetterSelector',
@@ -41,35 +38,12 @@ DialogItemsChooser class >> open [
 	^self new open
 ]
 
-{ #category : #accessing }
-DialogItemsChooser >> choicesList [
-	^ choicesList ifNil: [ choicesList := OrderedCollection new ]
-]
-
-{ #category : #accessing }
-DialogItemsChooser >> choicesList: anObject [
-
-	choicesList := anObject
-]
-
 { #category : #initialization }
 DialogItemsChooser >> initialize [
 	super initialize.
 	selection := OrderedCollection new.
 	unselectedItems := OrderedCollection new.
 	selectedItems := OrderedCollection new
-]
-
-{ #category : #accessing }
-DialogItemsChooser >> methodNameUI [
-
-	^ methodNameUI
-]
-
-{ #category : #accessing }
-DialogItemsChooser >> methodNameUI: anObject [
-
-	methodNameUI := anObject
 ]
 
 { #category : #accessing }
@@ -89,16 +63,6 @@ DialogItemsChooser >> open [
 	^(DialogItemsChooserUI on: self)
 			title: self title;
 			openInWorld
-]
-
-{ #category : #accessing }
-DialogItemsChooser >> resultList [
-	^ resultList
-]
-
-{ #category : #accessing }
-DialogItemsChooser >> resultList: aList [
-	resultList := aList
 ]
 
 { #category : #accessing }

--- a/src/Tool-Finder/DialogItemsChooserUI.class.st
+++ b/src/Tool-Finder/DialogItemsChooserUI.class.st
@@ -9,80 +9,16 @@ Class {
 	#instVars : [
 		'dialogItemsChooser',
 		'selectedItems',
-		'selectedItemsModel',
 		'unselectedItems',
-		'unselectedItemsModel',
 		'unselectedItemsSearchingString',
 		'selectedItemsSearchingString',
-		'unselectedItemsTextArea',
-		'selectedItemsTextArea',
-		'unselectedSelection',
 		'selectedSelectionIndex',
 		'selectedSelectionList',
 		'unselectedSelectionList',
 		'unselectedSelectionIndex'
 	],
-	#classVars : [
-		'AlreadySearchedSelectedItemsList',
-		'AlreadySearchedUnselectedItemsList'
-	],
-	#classInstVars : [
-		'alreadySearchedSelectedItemsListMaxSize',
-		'alreadySearchedUnselectedItemsListMaxSize'
-	],
 	#category : #'Tool-Finder-UI'
 }
-
-{ #category : #accessing }
-DialogItemsChooserUI class >> alreadySearchedSelectedItemsListMaxSize [
-
-	^ alreadySearchedSelectedItemsListMaxSize
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI class >> alreadySearchedSelectedItemsListMaxSize: anObject [
-
-	anObject ifNil: [ ^self ].
-	alreadySearchedSelectedItemsListMaxSize := anObject.
-	self allInstancesDo: [:each | each alreadySearchedSelectedItemsListMaxSize: anObject ]
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI class >> alreadySearchedUnselectedItemsListMaxSize [
-
-	^ alreadySearchedUnselectedItemsListMaxSize
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI class >> alreadySearchedUnselectedItemsListMaxSize: anObject [
-
-	anObject ifNil: [ ^self ].
-	alreadySearchedUnselectedItemsListMaxSize := anObject.
-	self allInstancesDo: [:each | each alreadySearchedUnselectedItemsListMaxSize: anObject ]
-]
-
-{ #category : #settings }
-DialogItemsChooserUI class >> dialogItemsChooserSettingsOn: aBuilder [
-	<systemsettings>
-		(aBuilder group: #dialogItemsChooser)
-		target: self;
-		label: 'Items Chooser Dialog Window';
-		parent: #morphic;
-		description: 'Settings related to the Dialog Window for choosing elements among a list';
-			with: [
-				(aBuilder setting: #alreadySearchedUnselectedItemsListMaxSize)
-					default: 15;
-					label: 'Number of the Unselected Items in History'.
-				(aBuilder setting: #alreadySearchedSelectedItemsListMaxSize)
-					default: 15;
-					label: 'Number of the Selected Items in History']
-]
-
-{ #category : #'class initialization' }
-DialogItemsChooserUI class >> initialize [
-	alreadySearchedUnselectedItemsListMaxSize := 15.
-	alreadySearchedSelectedItemsListMaxSize := 15
-]
 
 { #category : #'instance creation' }
 DialogItemsChooserUI class >> on: aDialogItemsChooser [
@@ -157,54 +93,6 @@ DialogItemsChooserUI >> addSelectedItems [
 		changed: #unselectedItemsProbablyRestricted;
 		changed: #hasUnselectedItems;
 		changed: #hasUnselectedSelections
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI >> addToAlreadySearchedSelectedItemsList: aString [
-	self alreadySearchedSelectedItemsList size = self alreadySearchedSelectedItemsListMaxSize
-		ifTrue: [self alreadySearchedSelectedItemsList removeLast ].
-	self alreadySearchedSelectedItemsList addFirst: aString
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI >> addToAlreadySearchedUnselectedItemsList: aString [
-	self alreadySearchedUnselectedItemsList size = self alreadySearchedUnselectedItemsListMaxSize
-		ifTrue: [self alreadySearchedUnselectedItemsList removeLast ].
-	self alreadySearchedUnselectedItemsList addFirst: aString
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI >> alreadySearchedSelectedItemsList [
-	^AlreadySearchedSelectedItemsList ifNil: [ AlreadySearchedSelectedItemsList := OrderedCollection new ]
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI >> alreadySearchedSelectedItemsListMaxSize [
-	^self class alreadySearchedSelectedItemsListMaxSize
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI >> alreadySearchedSelectedItemsListMaxSize: anInteger [
-
-	[ self alreadySearchedSelectedItemsList size > anInteger ]
-		whileTrue: [ self alreadySearchedSelectedItemsList removeLast ]
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI >> alreadySearchedUnselectedItemsList [
-	^AlreadySearchedUnselectedItemsList ifNil: [ AlreadySearchedUnselectedItemsList := OrderedCollection new ]
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI >> alreadySearchedUnselectedItemsListMaxSize [
-	^self class alreadySearchedUnselectedItemsListMaxSize
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI >> alreadySearchedUnselectedItemsListMaxSize: anInteger [
-
-	[ self alreadySearchedUnselectedItemsList size > anInteger ]
-		whileTrue: [ self alreadySearchedUnselectedItemsList removeLast ]
 ]
 
 { #category : #private }
@@ -330,16 +218,6 @@ DialogItemsChooserUI >> buildUnselectedItemsSearchingTextArea: aWindow [
 		help: 'Enter the name of a package' translated
 ]
 
-{ #category : #'buttons creations' }
-DialogItemsChooserUI >> cancelButtonLabel [
-	^'Cancel'
-]
-
-{ #category : #'buttons creations' }
-DialogItemsChooserUI >> cancelButtonState [
-	^false
-]
-
 { #category : #display }
 DialogItemsChooserUI >> centering [
 
@@ -431,21 +309,6 @@ DialogItemsChooserUI >> newContentMorph [
 
 ]
 
-{ #category : #'buttons creations' }
-DialogItemsChooserUI >> okButtonAction [
-	self valid.
-]
-
-{ #category : #'buttons creations' }
-DialogItemsChooserUI >> okButtonLabel [
-	^'Ok'
-]
-
-{ #category : #'buttons creations' }
-DialogItemsChooserUI >> okButtonState [
-	^false
-]
-
 { #category : #opening }
 DialogItemsChooserUI >> preOpenInWorld: aWorld [
 
@@ -520,14 +383,6 @@ DialogItemsChooserUI >> removeSelectedItems [
 		changed: #hasUnselectedItems
 ]
 
-{ #category : #private }
-DialogItemsChooserUI >> roots: aTree [
-	aTree == unselectedItemsModel
-		ifTrue: [ ^ self unselectedItemsProbablyRestricted ].
-	aTree == selectedItemsModel
-		ifTrue: [ ^ self selectedItemsProbablyRestricted ]
-]
-
 { #category : #'buttons creations' }
 DialogItemsChooserUI >> searchButtonLabel [
 	^'Search'
@@ -546,18 +401,6 @@ DialogItemsChooserUI >> selectedItems [
 { #category : #accessing }
 DialogItemsChooserUI >> selectedItems: aList [
 	selectedItems := aList.
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI >> selectedItemsModel [
-
-	^ selectedItemsModel
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI >> selectedItemsModel: anObject [
-
-	selectedItemsModel := anObject
 ]
 
 { #category : #private }
@@ -594,18 +437,6 @@ DialogItemsChooserUI >> selectedItemsSearchingString: anObject [
 ]
 
 { #category : #accessing }
-DialogItemsChooserUI >> selectedItemsTextArea [
-
-	^ selectedItemsTextArea
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI >> selectedItemsTextArea: anObject [
-
-	selectedItemsTextArea := anObject
-]
-
-{ #category : #accessing }
 DialogItemsChooserUI >> selectedLabel [
 
 	^ self dialogItemsChooser
@@ -629,8 +460,7 @@ DialogItemsChooserUI >> selectedSelectionAt: index put: aBoolean [
 
 { #category : #selectedList }
 DialogItemsChooserUI >> selectedSelectionIndex [
-	selectedSelectionIndex ifNil: [selectedSelectionIndex := 0].
-	^selectedSelectionIndex
+	^ selectedSelectionIndex ifNil: [selectedSelectionIndex := 0]
 ]
 
 { #category : #selectedList }
@@ -660,18 +490,6 @@ DialogItemsChooserUI >> unselectedItems [
 DialogItemsChooserUI >> unselectedItems: anOrderedCollection [ 
 	
 	unselectedItems := anOrderedCollection.
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI >> unselectedItemsModel [
-
-	^ unselectedItemsModel
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI >> unselectedItemsModel: anObject [
-
-	unselectedItemsModel := anObject
 ]
 
 { #category : #private }
@@ -708,17 +526,6 @@ DialogItemsChooserUI >> unselectedItemsSearchingString: anObject [
 ]
 
 { #category : #accessing }
-DialogItemsChooserUI >> unselectedItemsTextArea [
-	^unselectedItemsTextArea
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI >> unselectedItemsTextArea: anObject [
-
-	unselectedItemsTextArea := anObject
-]
-
-{ #category : #accessing }
 DialogItemsChooserUI >> unselectedLabel [
 
 	^ self dialogItemsChooser
@@ -726,28 +533,10 @@ DialogItemsChooserUI >> unselectedLabel [
 		ifNotNil: [ self dialogItemsChooser unselectedLabel ]
 ]
 
-{ #category : #accessing }
-DialogItemsChooserUI >> unselectedSelection [
-	unselectedSelection ifNil: [unselectedSelection := 0].
-	^unselectedSelection
-]
-
-{ #category : #accessing }
-DialogItemsChooserUI >> unselectedSelection: anObject [
-
-	unselectedSelection := anObject
-]
-
 { #category : #unselectedList }
 DialogItemsChooserUI >> unselectedSelectionAt: index [
 
 	^unselectedSelectionList at: index ifAbsent: [false]
-]
-
-{ #category : #unselectedList }
-DialogItemsChooserUI >> unselectedSelectionAt: index Put: anObject [
-
-	unselectedSelectionList at: index put: anObject
 ]
 
 { #category : #unselectedList }
@@ -760,8 +549,7 @@ DialogItemsChooserUI >> unselectedSelectionAt: index put: aBoolean [
 
 { #category : #unselectedList }
 DialogItemsChooserUI >> unselectedSelectionIndex [
-	unselectedSelectionIndex ifNil: [unselectedSelectionIndex := 0].
-	^unselectedSelectionIndex
+	^unselectedSelectionIndex ifNil: [unselectedSelectionIndex := 0]
 ]
 
 { #category : #unselectedList }

--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -338,16 +338,6 @@ Finder >> isSourceSymbol [
 	^self currentSearchMode = #Source
 ]
 
-{ #category : #private }
-Finder >> listFromResult: resultOC [
-	"The argument, resultOC, is of the form #('(data1 op data2)' '(...)'). Answer a sorted array."
-
-	(resultOC first beginsWith: 'no single method') ifTrue: [^ #()].
-	^ resultOC sort: [:a :b | 
-		(a copyFrom: 6 to: a size) < (b copyFrom: 6 to: b size)]
-
-]
-
 { #category : #'private-selector' }
 Finder >> messageSearchBlockFrom: aString [
 	| exactMatch |

--- a/src/Tool-Finder/FinderPragmaNode.class.st
+++ b/src/Tool-Finder/FinderPragmaNode.class.st
@@ -45,20 +45,6 @@ FinderPragmaNode >> displayString [
 ]
 
 { #category : #private }
-FinderPragmaNode >> foundReceiverOf: aString [
-	"It's ugly, but I haven't found a method that allows me to do that easily"
-
-	| selector index firstPart |
-	selector := (self model finder findSelector: aString).
-	index := selector indexOf: $:.
-	firstPart := selector.
-	(index = 0)
-		ifFalse: [firstPart := selector copyFrom: 1 to: index].
-	index :=  aString findString: firstPart.
-	^ aString copyFrom: 1 to: (index-1)
-]
-
-{ #category : #private }
 FinderPragmaNode >> inspectItem [
 	(RBBrowserEnvironment default forPragmas: {self item}) methods inspect
 ]

--- a/src/Tool-Finder/FinderUI.class.st
+++ b/src/Tool-Finder/FinderUI.class.st
@@ -257,37 +257,6 @@ FinderUI >> allClassesButtonState [
 	^ false
 ]
 
-{ #category : #private }
-FinderUI >> autoSelection [
-	| aString firstIndex interval string size |
-
-	(self searchingString isEmpty or: [ self useRegEx] )
-		ifTrue: [^ 0 to:0 ].
-	
-	self isSourceSymbol ifFalse: [^ 0 to: 0].
-		
-	aString := self sourceTextModel getString asLowercase.
-	
-	aString = self defaultExplanation asLowercase
-		ifTrue: [ ^ 0 to: 0].
-	
-	string := self searchingString asLowercase.
-	(string includes: $*)
-		ifTrue: [| list lastIndex|
-			list := string substrings: '*'.
-			firstIndex := aString findString: list first.
-			lastIndex := (aString findString: list last startingAt: firstIndex) + list last size - 1.
-			interval := firstIndex to: lastIndex ]
-		ifFalse: [
-			firstIndex := aString findString: string.
-			size := string size.
-			interval := firstIndex to: (firstIndex + size - 1) ].
-		
-	^ firstIndex = 0 
-		ifTrue: [ 0 to:0 ]
-		ifFalse: [ interval ]
-]
-
 { #category : #'buttons behavior' }
 FinderUI >> browseButtonAction [
 
@@ -316,12 +285,6 @@ FinderUI >> buildAllClassesButton [
 			getState: #allClassesButtonState 
 			action: #allClassesButtonAction 
 			label: #allClassesButtonLabel
-]
-
-{ #category : #'items creation' }
-FinderUI >> buildAllTextArea [
-	self buildSearchingTextArea.
-	self buildSourceTextArea
 ]
 
 { #category : #'items creation' }
@@ -846,11 +809,6 @@ FinderUI >> resetEnvironment [
 	self triggerEvent: #resetEnvironment
 ]
 
-{ #category : #private }
-FinderUI >> resetSearchedTextList [
-	self searchedTextList removeAll
-]
-
 { #category : #'tree behavior' }
 FinderUI >> resultDictionary [ 
 	^self finder resultDictionary 
@@ -1054,11 +1012,6 @@ FinderUI >> updateSourceCode [
 { #category : #private }
 FinderUI >> useRegEx [
 	^ self finder useRegEx
-]
-
-{ #category : #'items creation' }
-FinderUI >> useRegExCheckbox [
-	^ useRegExCheckbox ifNil: [ self buildRegExChooser ]
 ]
 
 { #category : #'buttons behavior' }

--- a/src/Tool-Finder/Object.extension.st
+++ b/src/Tool-Finder/Object.extension.st
@@ -15,27 +15,3 @@ Object >> closeTo: anObject [
 
 	^[self = anObject] onErrorDo: [false]
 ]
-
-{ #category : #'*Tool-Finder' }
-Object >> copyTwoLevel [
-	"one more level than a shallowCopy"
-	"do not use this method we will deprecated soon"
-
-	| newObject class index |
-	class := self class.
-	newObject := self shallowCopy.
-	newObject == self ifTrue: [^ self].
-	class isVariable
-		ifTrue: 
-			[index := self basicSize.
-			[index > 0]
-				whileTrue: 
-					[newObject basicAt: index put: (self basicAt: index) shallowCopy.
-					index := index - 1]].
-	index := class instSize.
-	[index > 0]
-		whileTrue: 
-			[newObject instVarAt: index put: (self instVarAt: index) shallowCopy.
-			index := index - 1].
-	^newObject
-]


### PR DESCRIPTION
This is a pass over all unsent methods in the Tool-Finder package.
This seems to be the result of a wrong merge in the past, there were lots of variables with accessors that were not at all used.