### PR TITLE
MetaLinks-Cleanup-Variables2

### DIFF
--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -697,6 +697,11 @@ CompiledMethod >> localReadsSelf [
 	^self isFFIMethod or: [ super localReadsSelf ]
 ]
 
+{ #category : #lookup }
+CompiledMethod >> lookupVar: aString [ 
+	^self ast scope lookupVar: aString
+]
+
 { #category : #private }
 CompiledMethod >> markerOrNil [
 	^ self encoderClass markerOrNilFor: self

--- a/src/Reflectivity-Tests/LinkInstallerTest.class.st
+++ b/src/Reflectivity-Tests/LinkInstallerTest.class.st
@@ -81,21 +81,21 @@ LinkInstallerTest >> testLinkOnClassVar [
 	| link|
 	link := MetaLink new.
 	
-	link installOnClassVarNamed: #classVar for: ReflectivityExamples2 option: #read instanceSpecific: false.
+	link installOnVariableNamed: #classVar for: ReflectivityExamples2 option: #read instanceSpecific: false.
 	self assert: link nodes size equals: 2.
 	self assert: (link nodes allSatisfy: [:node| node isRead]).
 	self assert: (link nodes allSatisfy: [:node| node name = #classVar]).		
 	link uninstall.
 	self assert: link nodes isEmpty.
 	
-	link installOnClassVarNamed: #classVar for: ReflectivityExamples2 option: #write instanceSpecific: false.
+	link installOnVariableNamed: #classVar for: ReflectivityExamples2 option: #write instanceSpecific: false.
 	self assert: link nodes size equals: 2.
 	self assert: (link nodes allSatisfy: [:node| node isAssignment]).
 	self assert: (link nodes allSatisfy: [:node| node variable name = #classVar]).			
 	link uninstall.
 	self assert: link nodes isEmpty.
 	
-	link installOnClassVarNamed: #classVar for: ReflectivityExamples2 option: #all instanceSpecific: false.
+	link installOnVariableNamed: #classVar for: ReflectivityExamples2 option: #all instanceSpecific: false.
 	self assert: link nodes size equals: 4.	
 	link uninstall.
 	self assert: link nodes isEmpty.
@@ -109,21 +109,21 @@ LinkInstallerTest >> testLinkOnClassVarForObject [
 	link := MetaLink new.
 	obj := ReflectivityExamples2 new.
 	
-	link installOnClassVarNamed: #classVar for: obj option: #read instanceSpecific: false.
+	link installOnVariableNamed: #classVar for: obj option: #read instanceSpecific: false.
 	self assert: link nodes size equals: 2.
 	self assert: (link nodes allSatisfy: [:node| node isRead]).
 	self assert: (link nodes allSatisfy: [:node| node name = #classVar]).		
 	link uninstall.
 	self assert: link nodes isEmpty.
 	
-	link installOnClassVarNamed:  #classVar for: obj option: #write instanceSpecific: false.
+	link installOnVariableNamed:  #classVar for: obj option: #write instanceSpecific: false.
 	self assert: link nodes size equals: 2.
 	self assert: (link nodes allSatisfy: [:node| node isAssignment]).
 	self assert: (link nodes allSatisfy: [:node| node variable name = #classVar]).			
 	link uninstall.
 	self assert: link nodes isEmpty.
 	
-	link installOnClassVarNamed: #classVar for: obj option: #all instanceSpecific: false.
+	link installOnVariableNamed: #classVar for: obj option: #all instanceSpecific: false.
 	self assert: link nodes size equals: 4.	
 	link uninstall.
 	self assert: link nodes isEmpty.
@@ -148,12 +148,12 @@ LinkInstallerTest >> testLinkOnRBProgramNode [
 
 { #category : #permalinks }
 LinkInstallerTest >> testLinkOnTempVar [
-	| methodNode link |
+	| methodNode link variable |
 	methodNode := (ReflectivityExamples2 >> #methodWithTempVarAccess) ast.
 	link := MetaLink new.
+	variable := (ReflectivityExamples2 >> #methodWithTempVarAccess) temporaryVariableNamed: #temp.
 	
-	link installOnTempVarNamed: #temp
-		inMethod: #methodWithTempVarAccess
+	link installOnVariable: variable
 		for: ReflectivityExamples2
 		option: #read
 		instanceSpecific: false.
@@ -164,8 +164,8 @@ LinkInstallerTest >> testLinkOnTempVar [
 	link uninstall.
 	self assert: link nodes isEmpty.
 	
-	link installOnTempVarNamed: #temp
-		inMethod: #methodWithTempVarAccess
+	variable := (ReflectivityExamples2 >> #methodWithTempVarAccess) temporaryVariableNamed: #temp.
+	link installOnVariable: variable
 		for: ReflectivityExamples2
 		option: #write
 		instanceSpecific: false.
@@ -176,8 +176,8 @@ LinkInstallerTest >> testLinkOnTempVar [
 	link uninstall.
 	self assert: link nodes isEmpty.
 	
-	link installOnTempVarNamed: #temp
-		inMethod: #methodWithTempVarAccess
+	variable := (ReflectivityExamples2 >> #methodWithTempVarAccess) temporaryVariableNamed: #temp.
+	link installOnVariable: variable
 		for: ReflectivityExamples2
 		option: #all
 		instanceSpecific: false.
@@ -188,13 +188,13 @@ LinkInstallerTest >> testLinkOnTempVar [
 
 { #category : #permalinks }
 LinkInstallerTest >> testLinkOnTempVarForObject [
-	|  link obj |
+	|  link obj temp |
 	
 	link := MetaLink new.
 	obj := ReflectivityExamples2 new.
+	temp := (ReflectivityExamples2>>#methodWithTempVarAccess) lookupVar: #temp.
 	
-	link installOnTempVarNamed: #temp
-		inMethod: #methodWithTempVarAccess
+	link installOnVariable: temp
 		for: obj
 		option: #read
 		instanceSpecific: false.
@@ -204,9 +204,9 @@ LinkInstallerTest >> testLinkOnTempVarForObject [
 	self assert: (link nodes allSatisfy: [ :node | node isTempVariable ]).
 	link uninstall.
 	self assert: link nodes isEmpty.
+	temp := (ReflectivityExamples2>>#methodWithTempVarAccess) lookupVar: #temp.
 	
-	link installOnTempVarNamed: #temp
-		inMethod: #methodWithTempVarAccess
+	link installOnVariable: temp
 		for: obj
 		option: #write
 		instanceSpecific: false.
@@ -217,8 +217,9 @@ LinkInstallerTest >> testLinkOnTempVarForObject [
 	link uninstall.
 	self assert: link nodes isEmpty.
 	
-	link installOnTempVarNamed: #temp
-		inMethod: #methodWithTempVarAccess
+	temp := (ReflectivityExamples2>>#methodWithTempVarAccess) lookupVar: #temp.
+	
+	link installOnVariable: temp
 		for: obj
 		option: #all
 		instanceSpecific: false.
@@ -346,7 +347,7 @@ LinkInstallerTest >> testNodesRemovedFromLinkWhenMethodRemoved [
 	methodNode := (ReflectivityExamples2 >> #methodWithInstVarAccess) ast.
 	
 	link := MetaLink new.	 
-	link installOnSlotNamed: #instVar for: ReflectivityExamples2 option: #all instanceSpecific: false.	
+	link installOnVariableNamed: #instVar for: ReflectivityExamples2 option: #all instanceSpecific: false.	
 	self assert: link nodes size equals: 8.
 	
 	ReflectivityExamples2 new removeNewMethodWithInstVarAccess.	
@@ -368,7 +369,7 @@ LinkInstallerTest >> testNodesRemovedFromLinkWhenMethodRemovedFromObject [
 	
 	link := MetaLink new.	
 
-	link installOnSlotNamed: #instVar for: obj option: #all instanceSpecific: true.	
+	link installOnVariableNamed: #instVar for: obj option: #all instanceSpecific: true.	
 	
 	self assert: link nodes size equals: 8.	
 	self assert: (link nodes allSatisfy: [:node| (obj class >> #newMethodWithInstVarAccess) ast allChildren includes: node]) .
@@ -480,10 +481,10 @@ LinkInstallerTest >> testPermaLinkNotInstalledOnObjectIfExistsInClass [
 	
 	link := MetaLink new.	
 
-	link installOnSlotNamed: #instVar for: ReflectivityExamples2 option: #all instanceSpecific: true.
+	link installOnVariableNamed: #instVar for: ReflectivityExamples2 option: #all instanceSpecific: true.
 	self assert: link nodes size equals: 8.	
 			
-	link installOnSlotNamed: #instVar for: obj option: #all instanceSpecific: true.
+	link installOnVariableNamed: #instVar for: obj option: #all instanceSpecific: true.
 	self assert: link nodes size equals: 8.		
 	
 	link uninstall.
@@ -750,7 +751,7 @@ LinkInstallerTest >> testSlotOrVarLinksAddedAfterMethodAddition [
 	ReflectivityExamples2 new removeNewMethodWithInstVarAccess.
 	
 	link := MetaLink new.	
-	link installOnSlotNamed: #instVar for: ReflectivityExamples2 option: #all instanceSpecific: false.
+	link installOnVariableNamed: #instVar for: ReflectivityExamples2 option: #all instanceSpecific: false.
 
 	self assert: link nodes size equals: 4.
 	
@@ -774,7 +775,7 @@ LinkInstallerTest >> testSlotOrVarLinksAddedAfterMethodAdditionForObject [
 	ReflectivityExamples2 new removeNewMethodWithInstVarAccess.
 	
 	link := MetaLink new.	
-	link installOnSlotNamed: #instVar for: obj option: #all instanceSpecific: true.
+	link installOnVariableNamed: #instVar for: obj option: #all instanceSpecific: true.
 
 	self assert: link nodes size equals: 4.
 	
@@ -796,7 +797,7 @@ LinkInstallerTest >> testSlotOrVarLinksRemainAfterMethodModification [
 	methodNode := (ReflectivityExamples2 >> #modifiedMethodWithInstVarAccess) ast.
 	
 	link := MetaLink new.	
-	link installOnSlotNamed: #instVar for: ReflectivityExamples2 option: #all instanceSpecific: false.
+	link installOnVariableNamed: #instVar for: ReflectivityExamples2 option: #all instanceSpecific: false.
 
 	self assert: link nodes size equals: 12.
 	
@@ -817,7 +818,7 @@ LinkInstallerTest >> testSlotOrVarLinksRemainAfterMethodModificationForObject [
 	methodNode := (ReflectivityExamples2 >> #modifiedMethodWithInstVarAccess) ast.
 	
 	link := MetaLink new.	
-	link installOnSlotNamed: #instVar for: obj option: #all instanceSpecific: true.
+	link installOnVariableNamed: #instVar for: obj option: #all instanceSpecific: true.
 
 	self assert: link nodes size equals: 12.
 	"self halt."
@@ -915,7 +916,7 @@ LinkInstallerTest >> testUninstallLinkOnSlotOrVar [
 	link := MetaLink new.
 	linkRegistry := link linkInstaller linksRegistry.
 	
-	link installOnSlotNamed: #instVar
+	link installOnVariableNamed: #instVar
 		for: ReflectivityExamples2
 		option: #all
 		instanceSpecific: false.
@@ -934,7 +935,7 @@ LinkInstallerTest >> testUninstallLinkOnSlotOrVar [
 	self assertEmpty: (linkRegistry registeredClassesAt: ReflectivityExamples2).
 	self assertEmpty: (linkRegistry registeredTargetsAt: permalink slotOrVariable).
 	
-	link installOnClassVarNamed: #classVar
+	link installOnVariableNamed: #classVar
 		for: ReflectivityExamples2 new
 		option: #all
 		instanceSpecific: false.

--- a/src/Reflectivity/Behavior.extension.st
+++ b/src/Reflectivity/Behavior.extension.st
@@ -1,6 +1,18 @@
 Extension { #name : #Behavior }
 
 { #category : #'*Reflectivity' }
+Behavior >> link: aMetaLink toTemporaryNamed: aTempVarName inMethod: aMethodName option: option [
+	| variable |
+	
+	variable := (self lookupSelector: aMethodName) lookupVar: aTempVarName.
+	aMetaLink
+		installOnVariable: variable
+		for:  self nonAnonymousClass
+		option: option
+		instanceSpecific: false
+]
+
+{ #category : #'*Reflectivity' }
 Behavior >> metaLinkOptions [
 	^{
 	#methodDict -> #( + optionCompileOnLinkInstallation).

--- a/src/Reflectivity/Class.extension.st
+++ b/src/Reflectivity/Class.extension.st
@@ -41,10 +41,10 @@ Class >> link: aMetaLink toTemporary: aTempVar [
 { #category : #'*Reflectivity' }
 Class >> link: aMetaLink toVariableNamed: vName option: accessStrategy [
 	^aMetaLink
-		installOnVariableNamed: vName
+		installOnVariable: (self lookupVar: vName)
 		for: self
 		option: accessStrategy
-		instanceSpecific: self intanceSpecificMetaLinksAvailable
+		instanceSpecific: false
 ]
 
 { #category : #'*Reflectivity' }

--- a/src/Reflectivity/CompiledMethod.extension.st
+++ b/src/Reflectivity/CompiledMethod.extension.st
@@ -72,11 +72,11 @@ CompiledMethod >> invalidate [
 
 { #category : #'*Reflectivity' }
 CompiledMethod >> link: aMetaLink toVariableNamed: vName option: accessStrategy [
-	^ self methodClass
-		link: aMetaLink
-		toTemporaryNamed: vName
-		inMethod: self selector
+	^aMetaLink
+		installOnVariable: (self lookupVar: vName)
+		for: self methodClass
 		option: accessStrategy
+		instanceSpecific: false
 ]
 
 { #category : #'*Reflectivity' }

--- a/src/Reflectivity/MetaLink.class.st
+++ b/src/Reflectivity/MetaLink.class.st
@@ -271,40 +271,17 @@ MetaLink >> installOn: aNode [
 	
 ]
 
-{ #category : #'installing - link installer' }
-MetaLink >> installOnClassVarNamed: aClassVarName for: aClassOrObject option: option instanceSpecific: instanceSpecific [
-	| permalink variable |
-
-	permalink := self permaLinkFor: aClassOrObject option: option instanceSpecific: instanceSpecific.
-	variable := permalink targetObjectOrClass nonAnonymousClass lookupVar: aClassVarName.
-	^ self linkInstaller installPermaLink: permalink onVariable: variable
-]
-
-{ #category : #'installing - link installer' }
-MetaLink >> installOnSlotNamed: aSlotName for: aClassOrObject option: option instanceSpecific: instanceSpecific [
-	| permalink variable |
-	permalink := self
-		permaLinkFor: aClassOrObject
-		option: option
-		instanceSpecific: instanceSpecific.
-	variable := permalink targetObjectOrClass nonAnonymousClass lookupVar: aSlotName.
-	^ self linkInstaller installPermaLink: permalink onVariable: variable
-]
-
-{ #category : #'installing - link installer' }
-MetaLink >> installOnTempVarNamed: aTempName inMethod: aMethodName for: aClassOrObject option: option instanceSpecific: instanceSpecific [
-	| permalink method variable |
-	permalink := self permaLinkFor: aClassOrObject option: option instanceSpecific: instanceSpecific.
-	
-	method := permalink targetObjectOrClass nonAnonymousClass lookupSelector: aMethodName.
-	variable := method temporaryVariableNamed: aTempName.
-	
-	^ self linkInstaller installPermaLink: permalink onVariable: variable
-]
-
 { #category : #installing }
 MetaLink >> installOnVariable: aVariable [
 	nodes add: aVariable
+]
+
+{ #category : #'installing - link installer' }
+MetaLink >> installOnVariable: aVariable for: aClassOrObject option: option instanceSpecific: instanceSpecific [
+
+	| permalink |
+	permalink := self permaLinkFor: aClassOrObject option: option instanceSpecific: instanceSpecific.
+	^ self linkInstaller installPermaLink: permalink onVariable: aVariable
 ]
 
 { #category : #'installing - link installer' }

--- a/src/Reflectivity/Object.extension.st
+++ b/src/Reflectivity/Object.extension.st
@@ -133,10 +133,13 @@ Object >> link: aMetaLink toTemporaryNamed: aTempVarName inMethod: aMethodName [
 
 { #category : #'*Reflectivity' }
 Object >> link: aMetaLink toTemporaryNamed: aTempVarName inMethod: aMethodName option: option [
+	| variable |
+	
+	variable := (self nonAnonymousClass lookupSelector: aMethodName) lookupVar: aTempVarName.
+
 	aMetaLink
-		installOnTempVarNamed: aTempVarName
-		inMethod: aMethodName
+		installOnVariable: variable
 		for: self
 		option: option
-		instanceSpecific: self intanceSpecificMetaLinksAvailable
+		instanceSpecific: true
 ]


### PR DESCRIPTION
another step to rely less on names of variables and instead use the variable objects directly:

- MetaLink: add #installOnVariable:... 
- MetaLink: remove the specialized methods for slots/class and temp var
- add CompiledMethod>>#lookupVar: to easily query for variables from a method