### PR TITLE
7731-OCUndeclaredVariableWarning-isUninitialized-with-NonInteractiveUIManager

### DIFF
--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -198,7 +198,7 @@ OCUndeclaredVariableWarning >> openMenuIn: aBlock [
 	labels add: 'Cancel'.
 	caption := 'Unknown variable: ' , name , ' please correct, or cancel:'.
 	choice := aBlock value: labels value: lines value: caption.
-	choice ifNotNil: [ self resume: (actions at: choice ifAbsent: [ compilationContext failBlock value ]) value ]
+	^choice ifNotNil: [ self resume: (actions at: choice ifAbsent: [ compilationContext failBlock value ]) value ]
 ]
 
 { #category : #correcting }


### PR DESCRIPTION
fix #7731: adde the return so that the undeclared var gets returned