### PR TITLE
Disable the dpi based computation screen scale factor computation in OS X

### DIFF
--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -509,6 +509,11 @@ WorldMorph >> runStepMethods [
 
 ]
 
+{ #category : #accessing }
+WorldMorph >> scaleFactor: newScaleFactor [
+	self setProperty: #scaleFactor toValue: newScaleFactor
+]
+
 { #category : #stepping }
 WorldMorph >> startStepping: aMorph at: scheduledTime selector: aSelector arguments: args stepTime: stepTime [
 	worldState startStepping: aMorph at: scheduledTime selector: aSelector arguments: args stepTime: stepTime.

--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -145,6 +145,16 @@ OSSDL2BackendWindow >> extent: newExtent [
 { #category : #private }
 OSSDL2BackendWindow >> fetchDPI [
 	| displayIndex ddpi hdpi vdpi newDiagonalDPI newScreenScaleFactor |
+	"In OS X disable the computation of a DPI based scale factor. These values
+	are completely wrong and we are getting scale factors that are very large
+	even in non-retina display. This workaround does not affect the support for
+	retina display because that is handled by fetching the size of the drawing surface."
+	Smalltalk os isMacOSX ifTrue: [ 
+		diagonalDPI := verticalDPI := horizontalDPI := self screenScaleFactorBaseDPI.
+		screenScaleFactor := 1.0.
+		^ false
+	].
+
 	displayIndex := sdl2Window getDisplayIndex.
 	displayIndex < 0 ifTrue: [ ^ false ].
 	


### PR DESCRIPTION
The screen scale factor that is computed through the screen DPI provided by SDL2 is producing wrong results in OS X, which ends making the UI very large and blurry.