### PR TITLE
Variables defined with #primitive:error: are shown as undefined, fixes 7748

### DIFF
--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -214,15 +214,19 @@ OCASTSemanticAnalyzer >> visitMethodNode: aMethodNode [
 
 { #category : #visiting }
 OCASTSemanticAnalyzer >> visitPragmaNode: aPragmaNode [
+
+	| var |
 	super visitPragmaNode: aPragmaNode.
+	aPragmaNode selector = #compilerOptions: ifTrue: [ 
+		aPragmaNode asPragma sendTo:
+			aPragmaNode methodNode compilationContext ].
 	
-	"we parse compiler options here so the rest of the compilation can react to them"
-	(aPragmaNode selector = #compilerOptions:)
-		ifTrue: [ aPragmaNode asPragma sendTo: aPragmaNode methodNode compilationContext ].
-	
-	"primitives with a primitive error define a variable that can be referenced in the body"
-	aPragmaNode isPrimitiveError ifTrue: [  
-		self declareVariableNode: (RBVariableNode named: (aPragmaNode argumentAt: #error:) value asString) ]
+	"if the pragma is a primitive that defines an error variable, we need to declare a temp
+	for it"	
+	aPragmaNode isPrimitiveError ifFalse: [ ^ self ].
+	var := RBVariableNode named: aPragmaNode primitiveErrorVariableName.
+	self declareVariableNode: var.
+	var variable markWrite
 ]
 
 { #category : #visiting }

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -215,7 +215,7 @@ OCASTSemanticAnalyzer >> visitMethodNode: aMethodNode [
 { #category : #visiting }
 OCASTSemanticAnalyzer >> visitPragmaNode: aPragmaNode [
 
-	| var |
+	| varNode |
 	super visitPragmaNode: aPragmaNode.
 	aPragmaNode selector = #compilerOptions: ifTrue: [ 
 		aPragmaNode asPragma sendTo:
@@ -224,9 +224,8 @@ OCASTSemanticAnalyzer >> visitPragmaNode: aPragmaNode [
 	"if the pragma is a primitive that defines an error variable, we need to declare a temp
 	for it"	
 	aPragmaNode isPrimitiveError ifFalse: [ ^ self ].
-	var := RBVariableNode named: aPragmaNode primitiveErrorVariableName.
-	self declareVariableNode: var.
-	var variable markWrite
+	varNode := RBVariableNode named: aPragmaNode primitiveErrorVariableName.
+	self declareVariableNode: varNode as: (PrimitiveErrorVariable node: varNode).
 ]
 
 { #category : #visiting }

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -654,10 +654,15 @@ OCASTTranslator >> visitParseErrorNode: anErrorNode [
 
 { #category : #'visitor-double dispatching' }
 OCASTTranslator >> visitPragmaNode: aPragmaNode [
-	methodBuilder addPragma: aPragmaNode asPragma.
-	aPragmaNode isPrimitiveError ifTrue: [
-		methodBuilder storeTemp: (aPragmaNode argumentAt: #error:) value].
 
+	| var |
+	methodBuilder addPragma: aPragmaNode asPragma.
+	
+	"if the pragma is a primitive that defines an error variable, we need to store error value 
+	which is on the stack"
+	aPragmaNode isPrimitiveError ifFalse: [ ^ self ].
+	var := aPragmaNode methodNode scope lookupVar: aPragmaNode primitiveErrorVariableName.
+	var emitStore: methodBuilder.
 ]
 
 { #category : #'visitor-double dispatching' }

--- a/src/OpalCompiler-Core/PrimitiveErrorVariable.class.st
+++ b/src/OpalCompiler-Core/PrimitiveErrorVariable.class.st
@@ -1,0 +1,35 @@
+"
+Primitives can declare a local variable that will hold the error code.
+"
+Class {
+	#name : #PrimitiveErrorVariable,
+	#superclass : #LocalVariable,
+	#instVars : [
+		'node'
+	],
+	#category : #'OpalCompiler-Core-Semantics'
+}
+
+{ #category : #'instance creation' }
+PrimitiveErrorVariable class >> node: aVariableNode [
+	^self new 
+		name: aVariableNode name;
+		node: aVariableNode;
+		markWrite;
+		yourself
+]
+
+{ #category : #visiting }
+PrimitiveErrorVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+	^ aProgramNodeVisitor visitTemporaryNode: aNode
+]
+
+{ #category : #queries }
+PrimitiveErrorVariable >> definingNode [
+	^node
+]
+
+{ #category : #accessing }
+PrimitiveErrorVariable >> node: anObject [
+	node := anObject
+]

--- a/src/OpalCompiler-Core/RBPragmaNode.extension.st
+++ b/src/OpalCompiler-Core/RBPragmaNode.extension.st
@@ -34,3 +34,8 @@ RBPragmaNode >> asPragma [
 RBPragmaNode >> isPrimitiveError [
 	^ #( primitive:error: primitive:module:error: primitive:error:module:) includes: self selector
 ]
+
+{ #category : #'*OpalCompiler-Core' }
+RBPragmaNode >> primitiveErrorVariableName [
+	^(self argumentAt: #error:) value
+]

--- a/src/OpalCompiler-Core/TemporaryVariable.class.st
+++ b/src/OpalCompiler-Core/TemporaryVariable.class.st
@@ -16,13 +16,7 @@ TemporaryVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 TemporaryVariable >> definingNode [
 	^ scope node temporaries 
 		detect: [ :each | each name = name ]
-		ifNone: [ 
-			" ugly workaround to support temps defined by primitives"
-			| pragma |
-			pragma := scope node methodNode pragmas detect: [ :each | each isPrimitiveError ].
-			pragma ifNil: [ ^nil ].
-			^ RBVariableNode named: (pragma argumentAt: #error:) value asString
-			]
+		ifNone: [ nil ]
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
@@ -58,7 +58,9 @@ OCASTCheckerTest >> testExamplePrimitiveErrorCode [
 	ast := (OCOpalExamples>>#examplePrimitiveErrorCode) parseTree.
 	self nameAnalysisNoClosureIn: OCOpalExamples for: ast.
 
-	self assert: (ast scope lookupVar: 'code') isTempVariable.
+	self assert: (ast scope lookupVar: 'code') isLocalVariable.
+	self deny: (ast scope lookupVar: 'code') isUninitialized.
+	
 
 	
 ]


### PR DESCRIPTION
- The error variable has to be added as a variable with write status
- delegate code generation to the variable when storing the TOS.
- factor out primitiveErrorVariableName

fixes #7748


