### PR TITLE
7755 re excessive arguments rule should exclude ffi callouts 

### DIFF
--- a/src/GeneralRules-Tests/ReExcessiveArgumentsRuleTest.class.st
+++ b/src/GeneralRules-Tests/ReExcessiveArgumentsRuleTest.class.st
@@ -1,3 +1,6 @@
+"
+This class contains tests for class `ReExcessiveArgumentsRule`
+"
 Class {
 	#name : #ReExcessiveArgumentsRuleTest,
 	#superclass : #ReAbstractRuleTestCase,

--- a/src/GeneralRules-Tests/ReExcessiveArgumentsRuleTest.class.st
+++ b/src/GeneralRules-Tests/ReExcessiveArgumentsRuleTest.class.st
@@ -1,0 +1,41 @@
+Class {
+	#name : #ReExcessiveArgumentsRuleTest,
+	#superclass : #ReAbstractRuleTestCase,
+	#category : #'GeneralRules-Tests-Migrated'
+}
+
+{ #category : #tests }
+ReExcessiveArgumentsRuleTest >> longArgMethod: arg1 with: arg2 with: arg3 with: arg4 with: arg5 [
+	"This method should be critisized due to too many arguments"
+	
+	^self  
+]
+
+{ #category : #tests }
+ReExcessiveArgumentsRuleTest >> longArgMethodCallingFFI: arg1 with: arg2 with: arg3 with: arg4 with: arg5 [
+	"This method should not be critisized as it includes an FFI call"
+	
+	^self ffiCall: #( 
+			int SomeFFI(
+     				String* arg1,
+         			String* arg2,
+     				String* arg3,
+     				String* arg4,
+        			int arg5)) module: #someModule
+]
+
+{ #category : #tests }
+ReExcessiveArgumentsRuleTest >> testRule [
+
+	| critiques|	
+	critiques := self myCritiquesOnMethod: self class >> #longArgMethod:with:with:with:with:.	
+	self assert: critiques size equals: 1 
+]
+
+{ #category : #tests }
+ReExcessiveArgumentsRuleTest >> testRuleNotApplyToFFICallingMethods [
+
+	| critiques|	
+	critiques := self myCritiquesOnMethod: self class >> #longArgMethodCallingFFI:with:with:with:with:.	
+	self assert: critiques isEmpty
+]

--- a/src/GeneralRules/ReExcessiveArgumentsRule.class.st
+++ b/src/GeneralRules/ReExcessiveArgumentsRule.class.st
@@ -30,6 +30,12 @@ ReExcessiveArgumentsRule >> argumentsCount [
 
 { #category : #running }
 ReExcessiveArgumentsRule >> basicCheck: aMethod [
+
+	"If method includes UFFI calls then it is OK to have high number of arguments"
+	(aMethod ast allChildren anySatisfy: [:node | 
+		node isMessage and: [ FFICompilerPlugin ffiCalloutSelectors includes: node selector ]]) 
+				ifTrue: [ ^false ].
+ 
 	^ aMethod numArgs >= self argumentsCount
 ]
 


### PR DESCRIPTION
Fix #7755 