### PR TITLE
ObjectsAsMethodsTest-move-to-Kernel-Tests

### DIFF
--- a/src/Kernel-Tests/AbstractObjectsAsMethod.class.st
+++ b/src/Kernel-Tests/AbstractObjectsAsMethod.class.st
@@ -1,7 +1,12 @@
+"
+This class shows the API that an object needs to implement if it is supposed to be used as a method.
+
+The vm calls run:with:in:, see the subclass for a simple example.
+"
 Class {
 	#name : #AbstractObjectsAsMethod,
 	#superclass : #Object,
-	#category : #'Tests-ObjectsAsMethods'
+	#category : #'Kernel-Tests-Methods'
 }
 
 { #category : #compatibility }

--- a/src/Kernel-Tests/ObjectsAsMethodsExample.class.st
+++ b/src/Kernel-Tests/ObjectsAsMethodsExample.class.st
@@ -1,7 +1,10 @@
+"
+Example for an object that is installed as a compiled method. The VM calls run:with:in:
+"
 Class {
 	#name : #ObjectsAsMethodsExample,
 	#superclass : #AbstractObjectsAsMethod,
-	#category : #'Tests-ObjectsAsMethods'
+	#category : #'Kernel-Tests-Methods'
 }
 
 { #category : #example }

--- a/src/Kernel-Tests/ObjectsAsMethodsTest.class.st
+++ b/src/Kernel-Tests/ObjectsAsMethodsTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ObjectsAsMethodsTest,
 	#superclass : #TestCase,
-	#category : #'Tests-ObjectsAsMethods'
+	#category : #'Kernel-Tests-Methods'
 }
 
 { #category : #running }


### PR DESCRIPTION
move ObjectsAsMethodsTest to Kernel tests, another step to empty out the Test package

