### PR TITLE
#isReadOnlyLiteral is not needed anymore

### DIFF
--- a/src/Collections-Native/ByteArray.class.st
+++ b/src/Collections-Native/ByteArray.class.st
@@ -212,11 +212,6 @@ ByteArray >> isLiteral [
 	^ self class == ByteArray
 ]
 
-{ #category : #testing }
-ByteArray >> isReadOnlyLiteral [
-	^self isLiteral
-]
-
 { #category : #'platform independent access' }
 ByteArray >> longAt: index bigEndian: aBool [
 	"Return a 32bit integer quantity starting from the given byte index"

--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -261,11 +261,6 @@ Array >> isLiteral [
 	^self class == Array and: [self allSatisfy: [:each | each isLiteral]]
 ]
 
-{ #category : #testing }
-Array >> isReadOnlyLiteral [
-	^self isLiteral
-]
-
 { #category : #'self evaluating' }
 Array >> isSelfEvaluating [
 	^ (self allSatisfy: [:each | each isSelfEvaluating]) and: [self class == Array]

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1863,11 +1863,6 @@ String >> isPatternVariable [
 ]
 
 { #category : #testing }
-String >> isReadOnlyLiteral [
-	^self isLiteral
-]
-
-{ #category : #testing }
 String >> isString [
 	^ true
 ]

--- a/src/Kernel/Float.class.st
+++ b/src/Kernel/Float.class.st
@@ -919,12 +919,6 @@ Float >> isPowerOfTwo [
 ]
 
 { #category : #testing }
-Float >> isReadOnlyLiteral [ 
-	"Immediate objects are read-only by design, we can not call #beReadOnlyObject"
-	^ self isLiteral
-]
-
-{ #category : #testing }
 Float >> isSelfEvaluating [
     ^true
 ]

--- a/src/Kernel/Integer.class.st
+++ b/src/Kernel/Integer.class.st
@@ -1092,11 +1092,6 @@ Integer >> isPowerOfTwo [
 	^ self ~= 0 and: [(self bitAnd: self-1) = 0]
 ]
 
-{ #category : #testing }
-Integer >> isReadOnlyLiteral [ 
-	^ self isLiteral
-]
-
 { #category : #'system primitives' }
 Integer >> lastDigit [
 	"Answer the last digit of the integer base 256.  LargePositiveInteger uses bytes of base two number, and each is a 'digit'."

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1283,12 +1283,6 @@ Object >> isPoint [
 	^ false
 ]
 
-{ #category : #testing }
-Object >> isReadOnlyLiteral [
-	"Literals with a textual representation in the method source are compiled read-only"
-	^false
-]
-
 { #category : #'write barrier' }
 Object >> isReadOnlyObject [
 	"Answer if the receiver is read-only.

--- a/src/Kernel/ScaledDecimal.class.st
+++ b/src/Kernel/ScaledDecimal.class.st
@@ -132,11 +132,6 @@ ScaledDecimal >> isLiteral [
 			(10 raisedTo: scale) \\ denominator = 0]
 ]
 
-{ #category : #testing }
-ScaledDecimal >> isReadOnlyLiteral [
-	^self isLiteral
-]
-
 { #category : #accessing }
 ScaledDecimal >> isSelfEvaluating [
     "Not all scaled decimal are self evaluating, because they print rounded digits."

--- a/src/Kernel/SmallFloat64.class.st
+++ b/src/Kernel/SmallFloat64.class.st
@@ -225,12 +225,6 @@ SmallFloat64 >> isImmediateObject [
 	^ true
 ]
 
-{ #category : #testing }
-SmallFloat64 >> isReadOnlyLiteral [ 
-	"Immediate objects are read-only by design, we can not call #beReadOnlyObject"
-	^ false
-]
-
 { #category : #'mathematical functions' }
 SmallFloat64 >> ln [
 	"Answer the natural logarithm of the receiver.

--- a/src/Kernel/SmallInteger.class.st
+++ b/src/Kernel/SmallInteger.class.st
@@ -487,12 +487,6 @@ SmallInteger >> isLarge [
 	^false
 ]
 
-{ #category : #testing }
-SmallInteger >> isReadOnlyLiteral [ 
-	"Immediate objects are read-only by design, we can not call #beReadOnlyObject"
-	^ false
-]
-
 { #category : #'bit manipulation' }
 SmallInteger >> lowBit [
 	" Answer the index of the low order one bit.

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -174,8 +174,8 @@ ImageCleaner >> literalsDo: aBlock [
 	CompiledCode allSubInstancesDo: [ :cm | 
 		cm literals do: [ :literal | 
 			"Symbols are already shared, we can skip them here"
-			(literal isReadOnlyLiteral and: [literal isSymbol not]) ifTrue: [ 
-				aBlock value: literal value: cm ] ] ]
+			(literal isLiteral and: [literal isSymbol not and: [literal isImmediateObject not]]) 
+				ifTrue: [ aBlock value: literal value: cm ] ] ]
 ]
 
 { #category : #cleaning }


### PR DESCRIPTION
We now can remove the isReadOnlyLiteral that was added during development.

We now just add *all* literals to the literal frame as readOnly.