### PR TITLE
Rule based cleanup for RBCompositeRefactoryChange

### DIFF
--- a/src/NautilusRefactoring/NautilusRefactoring.class.st
+++ b/src/NautilusRefactoring/NautilusRefactoring.class.st
@@ -12,9 +12,6 @@ Class {
 	#instVars : [
 		'model'
 	],
-	#classVars : [
-		'PromptOnRefactoring'
-	],
 	#category : #'NautilusRefactoring-Base'
 }
 
@@ -63,11 +60,6 @@ NautilusRefactoring >> model [
 { #category : #accessing }
 NautilusRefactoring >> model: aNautilusUI [
 	model := aNautilusUI
-]
-
-{ #category : #option }
-NautilusRefactoring >> promptOnRefactoring [
-	^ self class promptOnRefactoring
 ]
 
 { #category : #option }

--- a/src/NautilusRefactoring/NautilusRefactoring.class.st
+++ b/src/NautilusRefactoring/NautilusRefactoring.class.st
@@ -23,12 +23,6 @@ NautilusRefactoring class >> model: model [
 		yourself
 ]
 
-{ #category : #accessing }
-NautilusRefactoring class >> promptOnRefactoring [
-
-	^ PromptOnRefactoring ifNil: [ PromptOnRefactoring := true ]
-]
-
 { #category : #display }
 NautilusRefactoring >> chooseFrom: anArray title: aString lines: aCollection [ 
 	anArray isEmpty

--- a/src/Refactoring-Changes/RBCompositeRefactoryChange.class.st
+++ b/src/Refactoring-Changes/RBCompositeRefactoryChange.class.st
@@ -9,7 +9,9 @@ Class {
 	#name : #RBCompositeRefactoryChange,
 	#superclass : #RBRefactoryChange,
 	#instVars : [
-		'changes'
+		'changes',
+		'newName',
+		'oldName'
 	],
 	#category : #'Refactoring-Changes'
 }
@@ -52,6 +54,11 @@ RBCompositeRefactoryChange >> addInstanceVariable: variableName to: aClass [
 { #category : #'refactory-changes' }
 RBCompositeRefactoryChange >> addPool: aPoolVariable to: aClass [ 
 	^ self addChange: (changeFactory addPoolVariable: aPoolVariable to: aClass)
+]
+
+{ #category : #accessing }
+RBCompositeRefactoryChange >> changeClass [
+	^ self subclassResponsibility
 ]
 
 { #category : #accessing }
@@ -125,6 +132,16 @@ RBCompositeRefactoryChange >> hash [
 RBCompositeRefactoryChange >> initialize [
 	super initialize.
 	changes := OrderedCollection new
+]
+
+{ #category : #accessing }
+RBCompositeRefactoryChange >> newName [
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+RBCompositeRefactoryChange >> oldName [
+	^ self subclassResponsibility
 ]
 
 { #category : #copying }

--- a/src/Refactoring-Changes/RBRenameClassChange.class.st
+++ b/src/Refactoring-Changes/RBRenameClassChange.class.st
@@ -5,10 +5,6 @@ Executing this change will rename the (global) defined ""oldName"" class to ""ne
 Class {
 	#name : #RBRenameClassChange,
 	#superclass : #RBCompositeRefactoryChange,
-	#instVars : [
-		'oldName',
-		'newName'
-	],
 	#category : #'Refactoring-Changes'
 }
 

--- a/src/Refactoring-Changes/RBRenameVariableChange.class.st
+++ b/src/Refactoring-Changes/RBRenameVariableChange.class.st
@@ -10,9 +10,7 @@ Class {
 	#superclass : #RBCompositeRefactoryChange,
 	#instVars : [
 		'className',
-		'isMeta',
-		'oldName',
-		'newName'
+		'isMeta'
 	],
 	#category : #'Refactoring-Changes'
 }


### PR DESCRIPTION
- add #subclassResponsibility
- move ivars here that are defined in all subclasses

In addition remove dead code from NautilusRefactoring
