### PR TITLE
Fix win32 library name for freetype

### DIFF
--- a/src/FreeType/FT2FFILibrary.class.st
+++ b/src/FreeType/FT2FFILibrary.class.st
@@ -148,7 +148,7 @@ FT2FFILibrary >> unixLibraryName [
 
 { #category : #'accessing platform' }
 FT2FFILibrary >> win32LibraryName [
-	#('libfreetype.dll' 'libfreetype-6.dll') 
+	#('freetype.dll' 'libfreetype.dll' 'libfreetype-6.dll') 
 		detect: [ :each | (FileLocator vmDirectory / each) exists ]
 		ifFound: [ :each | ^ each ].
 	


### PR DESCRIPTION
Windows convention conveys to not add the lib prefix.
So CMake built windows libraries builds do not have the lib prefix.