### PR TITLE
Compilerbased-meta-data-tagging

### DIFF
--- a/src/Debugging-Utils-Tests/HaltTest.class.st
+++ b/src/Debugging-Utils-Tests/HaltTest.class.st
@@ -127,7 +127,7 @@ HaltTest >> testHaltIf [
 HaltTest >> testHaltIfNil [
 	<haltOrBreakpointForTesting>
 
-	self should: [ nil haltIfNil] raise: Halt.
+	self should: [ nil haltIfNil] raise: Halt
 ]
 
 { #category : #tests }

--- a/src/Debugging-Utils-Tests/HaltTest.class.st
+++ b/src/Debugging-Utils-Tests/HaltTest.class.st
@@ -56,7 +56,7 @@ HaltTest >> testContainsHalt [
 	| annonClass |
 	
 	self 
-	deny: (Object >> #halt) containsHalt;
+	assert: (Object >> #halt) containsHalt;
 	deny: (Object >> #haltIfNil) containsHalt;
 	deny: (Halt class >> #once) containsHalt;
 	assert: (self class>> #testHaltIfNil) containsHalt.

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -183,12 +183,6 @@ CompiledCode >> comment [
 	^ self ast firstPrecodeComment
 ]
 
-{ #category : #testing }
-CompiledCode >> containsHalt [
-
-	^ self sendsAnySelectorOf: #( halt halt: haltIf: haltIfNil haltOnCount: haltOnce)
-]
-
 { #category : #'source code management' }
 CompiledCode >> definition [
 	"Polymorphic to class definition"

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -356,6 +356,12 @@ CompiledMethod >> codeForNoSource [
 	 ^(self compiler decompileMethod: self) formattedCode
 ]
 
+{ #category : #testing }
+CompiledMethod >> containsHalt [
+
+	^ self hasProperty: #containsHalt
+]
+
 { #category : #'source code management' }
 CompiledMethod >> copyWithSource: aString [
 	^self copyWithTrailerBytes: (CompiledMethodTrailer new sourceCode: aString) 

--- a/src/OpalCompiler-Core/OCASTMethodMetadataAnalyser.class.st
+++ b/src/OpalCompiler-Core/OCASTMethodMetadataAnalyser.class.st
@@ -1,0 +1,19 @@
+"
+This visitor analyses the AST and then adds annotations that will end up being set on the
+compild method.
+
+One example are methods that contains message send that is a #halt (and any of it's variations)
+"
+Class {
+	#name : #OCASTMethodMetadataAnalyser,
+	#superclass : #RBProgramNodeVisitor,
+	#category : #'OpalCompiler-Core-Semantics'
+}
+
+{ #category : #visiting }
+OCASTMethodMetadataAnalyser >> visitMessageNode: aNode [
+
+	super visitMessageNode: aNode.
+	aNode isHaltNode ifTrue: [ 
+		aNode methodNode methodPropertyAt: #containsHalt put: true ]
+]

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -37,7 +37,8 @@ OCASTSemanticAnalyzer >> analyseEscapingWrite: var [
 { #category : #api }
 OCASTSemanticAnalyzer >> analyze: aNode [
 	self visitNode: aNode.
-	OCASTClosureAnalyzer new visitNode: aNode
+	OCASTClosureAnalyzer new visitNode: aNode.
+	OCASTMethodMetadataAnalyser new visitNode: aNode
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This PR changes #containsHalt to not scan the bytecode but instead return a property that the compiler sets at compile time.

It adds a dedicated visitor for this, but for now calls it when we do semantic analysis (could be moved later to the compiler, but that needs some refactoring, I added it to the backlog)