### PR TITLE
Cleanup-Unused-Ivars

### DIFF
--- a/src/Beacon-Core-Tests/MemoryLoggerTest.class.st
+++ b/src/Beacon-Core-Tests/MemoryLoggerTest.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : #MemoryLoggerTest,
 	#superclass : #TestCase,
-	#classInstVars : [
-		'previousRecordings'
-	],
 	#category : #'Beacon-Core-Tests-Tests'
 }
 

--- a/src/GT-Spotter/GTSpotter.class.st
+++ b/src/GT-Spotter/GTSpotter.class.st
@@ -20,7 +20,6 @@ Class {
 		'text',
 		'isPreviewVisible',
 		'isShiftPressed',
-		'exceptionHandler',
 		'history',
 		'processorsFilter'
 	],

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -23,7 +23,6 @@ Class {
 		'labelArea',
 		'expandBox',
 		'embeddable',
-		'menuBuilder',
 		'isResizeable'
 	],
 	#classVars : [

--- a/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
@@ -7,7 +7,6 @@ Class {
 	#instVars : [
 		'previousBreakpoints',
 		'cls',
-		'oldObservers',
 		'oldSystemAnnouncer'
 	],
 	#category : #'Reflectivity-Tools-Tests'

--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -2,25 +2,45 @@
 Test to check if there are methods who have unused temporary variables in the image
 "
 Class {
-	#name : #NoUnusedTemporaryVariablesLeftTest,
+	#name : #NoUnusedVariablesLeftTest,
 	#superclass : #TestCase,
 	#category : #'ReleaseTests-CleanCode'
 }
 
 { #category : #accessing }
-NoUnusedTemporaryVariablesLeftTest class >> defaultTimeLimit [
+NoUnusedVariablesLeftTest class >> defaultTimeLimit [
 
 	^ 2 minute
 ]
 
 { #category : #running }
-NoUnusedTemporaryVariablesLeftTest >> tearDown [
+NoUnusedVariablesLeftTest >> tearDown [
 	ASTCache reset.
 	super tearDown
 ]
 
 { #category : #testing }
-NoUnusedTemporaryVariablesLeftTest >> testNoUnusedTemporaryVariablesLeft [
+NoUnusedVariablesLeftTest >> testNoUnusedInstanceVariablesLeft [
+	"Fail if there are methods who have unused temporary variables"
+	| variables classes validExceptions remaining |
+	
+	"turn this on when all ivars are cleaned"
+	self skip.
+	
+	variables := Smalltalk globals allBehaviors flatCollect: [ :each | each instanceVariables ].
+	variables := variables reject: [ :each | each isReferenced ].
+	
+	classes := variables collect: [ :each | each definingClass ] as: Set.
+	
+	validExceptions := { }.	
+	
+	remaining := classes asOrderedCollection removeAll: validExceptions; yourself.
+	
+	self assert: classes isEmpty
+]
+
+{ #category : #testing }
+NoUnusedVariablesLeftTest >> testNoUnusedTemporaryVariablesLeft [
 	"Fail if there are methods who have unused temporary variables"
 	| found validExceptions remaining |
 	found := SystemNavigation default allMethodsSelect: [ :m | 

--- a/src/Rubric/DummyFindReplaceService.class.st
+++ b/src/Rubric/DummyFindReplaceService.class.st
@@ -1,10 +1,6 @@
 Class {
 	#name : #DummyFindReplaceService,
 	#superclass : #FindReplaceService,
-	#instVars : [
-		'dialog',
-		'textAreaHolder'
-	],
 	#category : #'Rubric-Editing-FindReplaceService'
 }
 
@@ -39,13 +35,6 @@ DummyFindReplaceService >> findPolicyChanged [
 DummyFindReplaceService >> findText: aStringOrText [
 	
 	^ false
-]
-
-{ #category : #initialization }
-DummyFindReplaceService >> initialize [
-	super initialize.
-	
-	textAreaHolder := WeakArray new: 1 
 ]
 
 { #category : #services }

--- a/src/Tools-CodeNavigation-Tests/CNSelectorExtractionOnPositionTest.class.st
+++ b/src/Tools-CodeNavigation-Tests/CNSelectorExtractionOnPositionTest.class.st
@@ -2,8 +2,6 @@ Class {
 	#name : #CNSelectorExtractionOnPositionTest,
 	#superclass : #TestCase,
 	#instVars : [
-		'editor',
-		'editingArea',
 		'sourceCode',
 		'ast',
 		'position'

--- a/src/Tools-CodeNavigation-Tests/CNSelectorExtractionOnSelectionTest.class.st
+++ b/src/Tools-CodeNavigation-Tests/CNSelectorExtractionOnSelectionTest.class.st
@@ -2,10 +2,7 @@ Class {
 	#name : #CNSelectorExtractionOnSelectionTest,
 	#superclass : #TestCase,
 	#instVars : [
-		'editor',
-		'editingArea',
-		'sourceCode',
-		'ast'
+		'sourceCode'
 	],
 	#category : #'Tools-CodeNavigation-Tests'
 }


### PR DESCRIPTION
There are over 120 classes with instance variables that are not referenced.

This PR removes some and adds a (for now skipped) test in  NoUnusedVariablesLeftTest which we can turn on as soon as we have checked all the problematic classes.

