### PR TITLE
reduce-ASTCache-reset 

### DIFF
--- a/src/Manifest-Tests/SmalllintManifestCheckerTest.class.st
+++ b/src/Manifest-Tests/SmalllintManifestCheckerTest.class.st
@@ -48,7 +48,6 @@ SmalllintManifestCheckerTest >> setUp [
 SmalllintManifestCheckerTest >> tearDown [
 	
 	self cleaningResources.
-	ASTCache reset.
 	super tearDown 
 ]
 

--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -13,12 +13,6 @@ NoUnusedVariablesLeftTest class >> defaultTimeLimit [
 	^ 2 minute
 ]
 
-{ #category : #running }
-NoUnusedVariablesLeftTest >> tearDown [
-	ASTCache reset.
-	super tearDown
-]
-
 { #category : #testing }
 NoUnusedVariablesLeftTest >> testNoUnusedInstanceVariablesLeft [
 	"Fail if there are methods who have unused temporary variables"


### PR DESCRIPTION
two tests where calling ASTCache reset in the tearDown methods, this is not really needed.


