### PR TITLE
7777-Could-we-have-isTestMethod-on-Symbol-too

### DIFF
--- a/src/Ring-Definitions-Core/RGMethodDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGMethodDefinition.class.st
@@ -441,7 +441,8 @@ RGMethodDefinition >> isSameRevisionAs: aRGMethodDefinition [
 
 { #category : #'SUnit-support' }
 RGMethodDefinition >> isTestMethod [
-	^ self selector isTestSelector and: [self methodClass isTestCase]
+
+	^ self methodClass isTestCase and: [ self selector isTestSelector ]
 ]
 
 { #category : #'to remove as soon as possible' }

--- a/src/Ring-Definitions-Core/RGMethodDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGMethodDefinition.class.st
@@ -441,17 +441,7 @@ RGMethodDefinition >> isSameRevisionAs: aRGMethodDefinition [
 
 { #category : #'SUnit-support' }
 RGMethodDefinition >> isTestMethod [
-	| selectorString |
-	self numArgs isZero
-		ifFalse: [ ^ false ].
-	selectorString := self selector asString.
-	"unary selectors starting with 'should' are supposed to be treated as test methods too"
-	((selectorString beginsWith: 'test') or: [ selectorString beginsWith: 'should' ])
-		ifFalse: [ ^ false ].
-	"Is the receiver a TestCase test method?"
-	self methodClass isTestCase
-		ifFalse: [ ^ false ].
-	^true
+	^ self selector isTestSelector and: [self methodClass isTestCase]
 ]
 
 { #category : #'to remove as soon as possible' }

--- a/src/SUnit-Core/ByteSymbol.extension.st
+++ b/src/SUnit-Core/ByteSymbol.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #ByteSymbol }
+
+{ #category : #'*SUnit-Core' }
+ByteSymbol >> isTestSelector [
+	self numArgs isZero
+		ifFalse: [ ^ false ].
+	"unary selectors starting with 'should' are supposed to be treated as test methods too"
+	^(self beginsWith: 'test') or: [ self beginsWith: 'should' ]
+]

--- a/src/SUnit-Core/ByteSymbol.extension.st
+++ b/src/SUnit-Core/ByteSymbol.extension.st
@@ -1,9 +1,0 @@
-Extension { #name : #ByteSymbol }
-
-{ #category : #'*SUnit-Core' }
-ByteSymbol >> isTestSelector [
-	self numArgs isZero
-		ifFalse: [ ^ false ].
-	"unary selectors starting with 'should' are supposed to be treated as test methods too"
-	^(self beginsWith: 'test') or: [ self beginsWith: 'should' ]
-]

--- a/src/SUnit-Core/CompiledMethod.extension.st
+++ b/src/SUnit-Core/CompiledMethod.extension.st
@@ -27,5 +27,5 @@ CompiledMethod >> isPassedTest [
 { #category : #'*SUnit-Core' }
 CompiledMethod >> isTestMethod [
 
-	^ self selector isTestSelector and: [self methodClass isTestCase]
+	^ self methodClass isTestCase and: [ self selector isTestSelector ]
 ]

--- a/src/SUnit-Core/CompiledMethod.extension.st
+++ b/src/SUnit-Core/CompiledMethod.extension.st
@@ -27,13 +27,5 @@ CompiledMethod >> isPassedTest [
 { #category : #'*SUnit-Core' }
 CompiledMethod >> isTestMethod [
 
-	self numArgs isZero
-		ifFalse: [ ^ false ].
-	"unary selectors starting with 'should' are supposed to be treated as test methods too"
-	((self selector beginsWith: 'test') or: [ self selector beginsWith: 'should' ])
-		ifFalse: [ ^ false ].
-	"Is the receiver a TestCase test method?"
-	self methodClass isTestCase
-		ifFalse: [ ^ false ].
-	^true
+	^ self selector isTestSelector and: [self methodClass isTestCase]
 ]

--- a/src/SUnit-Core/Symbol.extension.st
+++ b/src/SUnit-Core/Symbol.extension.st
@@ -16,3 +16,10 @@ Symbol >> asTestSelector [
 	
 	^ (#test, (((self copyReplaceAll: ':' with: ' ') substrings collect: #capitalized) joinUsing: '')) asSymbol
 ]
+
+{ #category : #'*SUnit-Core' }
+Symbol >> isTestSelector [
+
+	^ self isUnary and: [ 
+		  (self beginsWith: 'test') or: [ self beginsWith: 'should' ] ]
+]


### PR DESCRIPTION
I suggest using #isTestSelector 

- add #isTestSelector to Symbol
- use it to simplify isTestMethod

fixes #7777 


