### PR TITLE
Add the missing implementation of OSSDL2GLRenderer >> #pixelExtent

### DIFF
--- a/src/OSWindow-Core/OSWindowGenericRenderer.class.st
+++ b/src/OSWindow-Core/OSWindowGenericRenderer.class.st
@@ -85,11 +85,6 @@ OSWindowGenericRenderer >> getOrCreateStaticTextureFromForm: from [
 	self subclassResponsibility
 ]
 
-{ #category : #clipping }
-OSWindowGenericRenderer >> pixelExtent [
-	^ backendWindow extent
-]
-
 { #category : #rendering }
 OSWindowGenericRenderer >> present [
 	"This should present the content of an internal draw buffer"

--- a/src/OSWindow-Core/OSWindowRenderer.class.st
+++ b/src/OSWindow-Core/OSWindowRenderer.class.st
@@ -52,6 +52,11 @@ OSWindowRenderer >> onRenderThreadBlocking: aBlock [
 	OSWindowRenderThread enqueueBlockingOperation: aBlock
 ]
 
+{ #category : #clipping }
+OSWindowRenderer >> pixelExtent [
+	^ backendWindow extent
+]
+
 { #category : #'updating screen' }
 OSWindowRenderer >> present [
 	"This should present the changes to the next frame."

--- a/src/OSWindow-SDL2/OSSDL2GLRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2GLRenderer.class.st
@@ -68,6 +68,17 @@ OSSDL2GLRenderer >> makeCurrent: aBackendWindow [
 	^ (SDL2 glMakeCurrent: windowHandle context: context) == 0
 ]
 
+{ #category : #clipping }
+OSSDL2GLRenderer >> pixelExtent [
+	| w h |
+	backendWindow ifNil: [ ^ super pixelExtent ].
+	
+	w := ByteArray new: 4.
+	h := ByteArray new: 4.
+	backendWindow sdl2Window glGetDrawableSizeW: w h: h.
+	^ (w signedLongAt: 1) @ (h signedLongAt: 1)
+]
+
 { #category : #misc }
 OSSDL2GLRenderer >> swapBuffers: aWindow [
 	self checkThread.

--- a/src/OSWindow-SDL2/SDL_Window.class.st
+++ b/src/OSWindow-SDL2/SDL_Window.class.st
@@ -87,6 +87,11 @@ SDL_Window >> getWindowSurface [
 	^ self ffiCall: #( SDL_Surface* SDL_GetWindowSurface( self ) )
 ]
 
+{ #category : #accessing }
+SDL_Window >> glGetDrawableSizeW: w h: h [
+	^ self ffiCall: #( void SDL_GL_GetDrawableSize ( self , int* w , int* h ) )
+]
+
 { #category : #'window management' }
 SDL_Window >> hide [
 	^ self ffiCall: #( void SDL_HideWindow( self ) )


### PR DESCRIPTION
This missing method is required for using OpenGL with Retina display in OS X.