### PR TITLE
remove-halt-visitEnglobingErrorNode

### DIFF
--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -186,11 +186,6 @@ OCASTSemanticAnalyzer >> visitBlockNode: aBlockNode [
 ]
 
 { #category : #visiting }
-OCASTSemanticAnalyzer >> visitEnglobingErrorNode: anEnglobingError [
-	anEnglobingError content do: [ :each | self visitNode: each ]
-]
-
-{ #category : #visiting }
 OCASTSemanticAnalyzer >> visitInlinedBlockNode: aBlockNode [
 
 	scope := scope newOptimizedBlockScope: blockcounter.

--- a/src/Reflectivity-Tools/ErrorNodeStyler.class.st
+++ b/src/Reflectivity-Tools/ErrorNodeStyler.class.st
@@ -34,8 +34,6 @@ ErrorNodeStyler >> shouldStyleNode: aNode [
 ErrorNodeStyler >> visitEnglobingErrorNode: anEnglobingNode [
 
 	| conf |
-	(anEnglobingNode isKindOf: RBUnreachableStatementErrorNode)
-		ifTrue: [ self haltOnce ].
 	conf := RubConfigurationChange new.
 	conf configurationBlock: [ :text | 
 		| r |


### PR DESCRIPTION
- visitEnglobingErrorNode: in OCASTSemanticAnalyzer is the same as the superclass

- in ErrorNodeStyler there was a haltOnce left (code left from debugging, can be removed)


