### PR TITLE
Fix side-effect in MCOrganizationDefinition

### DIFF
--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #'instance creation' }
 MCOrganizationDefinition class >> categories: aCollection [
-	^ self new aCollection: aCollection
+	^ self new categories: aCollection
 ]
 
 { #category : #comparing }

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -11,8 +11,8 @@ Class {
 }
 
 { #category : #'instance creation' }
-MCOrganizationDefinition class >> categories: anArray [
-	^ self new categories: anArray
+MCOrganizationDefinition class >> categories: aCollection [
+	^ self new aCollection: aCollection
 ]
 
 { #category : #comparing }
@@ -46,13 +46,13 @@ MCOrganizationDefinition >> basicCommonPrefix [
 
 { #category : #accessing }
 MCOrganizationDefinition >> categories [
-	"ensure the categories are sorted alphabetically, so the merge don't take it as a conflict"
 	^ categories
 ]
 
 { #category : #accessing }
-MCOrganizationDefinition >> categories: anArray [
-	categories := anArray sort
+MCOrganizationDefinition >> categories: aCollection [
+	"ensure the categories are sorted alphabetically, so the merge don't take it as a conflict"
+	categories := aCollection sorted asArray
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
The usage of `#sort` instead of `#sorted` manipulates the passed category array, which not only restricts the argument type to Array but also is very unexpected and confusing behavior. Furthermore, this led to recent test failures in smalltalkCI [1] because the passed array could not be a read-only object.

With this PR, the parameter is #sorted into a copy instead so both bugs should be resolved.

Please review! This is my first contribution to Pharo, so I hope I did not miss any formalities.
Please squash this PR when merging.

[1] https://travis-ci.org/github/hpi-swa/smalltalkCI/jobs/742264299#L457