### PR TITLE
PharoDoc-pass2 

### DIFF
--- a/src/Collections-Sequenceable/OrderedDictionary.class.st
+++ b/src/Collections-Sequenceable/OrderedDictionary.class.st
@@ -64,7 +64,7 @@ OrderedDictionary class >> newFrom: anAssociationCollection [
 OrderedDictionary class >> newFromKeys: keys andValues: values [
 	"Create a dictionary from the keys and values arguments which should have the same length."
 	
-	"(self newFromKeys: #(#x #y) andValues: #(3 6)) >>> (self new at: #x put: 3; at: #y put: 6 ;yourself)"
+	"(OrderedDictionary newFromKeys: #(#x #y) andValues: #(3 6)) >>> (OrderedDictionary new at: #x put: 3; at: #y put: 6 ;yourself)"
 	
 	| dict |
 	dict := self new.

--- a/src/Colors/Color.class.st
+++ b/src/Colors/Color.class.st
@@ -107,7 +107,7 @@ Color class >> colorFrom: parm [
 	"Color colorFrom: #(blue darker) >>> (Color r: 0.011 g: 0.23900000000000002 b: 0.795 alpha: 1.0) "
 	"(Color colorFrom: Color blue darker)>>>(Color r: 0.011 g: 0.23900000000000002 b: 0.795 alpha: 1.0)"
 	"(Color colorFrom: #blue)>>> (Color blue)"
-	"(Color colorFrom: #(0.0 0.0 1.0) >>> (Color blue)"
+	"(Color colorFrom: #(0.0 0.0 1.0)) >>> (Color blue)"
 
 	| aColor firstParm |
 	(parm isKindOf: Color)

--- a/src/Kernel/AsciiCharset.class.st
+++ b/src/Kernel/AsciiCharset.class.st
@@ -199,9 +199,9 @@ AsciiCharset class >> toLowercase: aCharacter [
 
 { #category : #casing }
 AsciiCharset class >> toUppercase: aCharacter [
-	"(AsciiCharset new toUppercase: $a) >>> $A.
-	(AsciiCharset new toUppercase: $A) >>> $A.
-	(AsciiCharset new toUppercase: $!) >>> $!"
+	"(AsciiCharset toUppercase: $a) >>> $A.
+	(AsciiCharset toUppercase: $A) >>> $A.
+	(AsciiCharset toUppercase: $!) >>> $!"
 
 	(aCharacter between: $a and: $z)
 		ifFalse: [ ^ aCharacter ].

--- a/src/PharoDocComment/CompiledMethod.extension.st
+++ b/src/PharoDocComment/CompiledMethod.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #CompiledMethod }
+
+{ #category : #'*PharoDocComment' }
+CompiledMethod >> pharoDocCommentNodes [
+	"we try to avoid to have to create the AST if we are sure that we do not need it"
+	^ (self sourceCode includesSubstring: '>>>')
+		  ifTrue: [ self ast pharoDocCommentNodes ]
+		  ifFalse: [ ^ #(  ) ]
+]

--- a/src/PharoDocComment/PharoDocCommentExpression.class.st
+++ b/src/PharoDocComment/PharoDocCommentExpression.class.st
@@ -6,7 +6,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'expressionInterval',
-		'source'
+		'source',
+		'node'
 	],
 	#category : #'PharoDocComment-Base'
 }
@@ -14,7 +15,11 @@ Class {
 { #category : #operation }
 PharoDocCommentExpression >> evaluate [
 
-	^ Smalltalk compiler evaluate: self expression
+	^ self methodClass compiler
+		  source: self expression;
+		  noPattern: true;
+		  options: #( + optionParseErrors );
+		  evaluate
 ]
 
 { #category : #accessing }
@@ -25,8 +30,9 @@ PharoDocCommentExpression >> expression [
 { #category : #accessing }
 PharoDocCommentExpression >> expressionCode [
 
-	^ Smalltalk compiler
+	^ self methodClass compiler
 		  source: self expression;
+		  noPattern: true;
 		  options: #( + optionParseErrors );
 		  parse
 ]
@@ -39,6 +45,21 @@ PharoDocCommentExpression >> expressionInterval [
 { #category : #accessing }
 PharoDocCommentExpression >> expressionInterval: anObject [
 	expressionInterval := anObject
+]
+
+{ #category : #operation }
+PharoDocCommentExpression >> methodClass [
+	^ node sourceNode methodNode methodClass
+]
+
+{ #category : #accessing }
+PharoDocCommentExpression >> node [
+	^ node
+]
+
+{ #category : #accessing }
+PharoDocCommentExpression >> node: anObject [
+	node := anObject
 ]
 
 { #category : #printing }

--- a/src/PharoDocComment/PharoDocCommentNode.class.st
+++ b/src/PharoDocComment/PharoDocCommentNode.class.st
@@ -95,7 +95,8 @@ PharoDocCommentNode >> expression [
 
 { #category : #accessing }
 PharoDocCommentNode >> expression: anObject [
-	expression := anObject
+	expression := anObject.
+	expression node: self
 ]
 
 { #category : #printing }
@@ -115,7 +116,8 @@ PharoDocCommentNode >> result [
 
 { #category : #accessing }
 PharoDocCommentNode >> result: anObject [
-	result := anObject
+	result := anObject.
+	anObject node: self
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- add a #pharoDocCommentNodes to CompiledMethod
- PharoDocCommentExpression should have a backpointer to the node
- expressionCode and evaluate need to set the class and compiled expressions

- fix some failing examples 

More to come
- Dr Test should use the code here to execute examples (it does not find any of the failing ones fixed with this PR)
- we need a release test to check that all examples pass