### PR TITLE
`#ensureCreateDirectory` Shouldn't Resolve

### DIFF
--- a/src/FileSystem-Core/AbstractFileReference.class.st
+++ b/src/FileSystem-Core/AbstractFileReference.class.st
@@ -367,8 +367,8 @@ AbstractFileReference >> directoryNames [
 
 { #category : #operations }
 AbstractFileReference >> ensureCreateDirectory [
-	"Verifies that the directory does not exist and only creates if necessary. Do not remove files contained if they exist.Creates the parents if needed"
-	^ self resolve ensureCreateDirectory
+	"Verifies that the directory does not exist and only creates if necessary. Do not remove files contained if they exist. Creates the parents if needed"
+	self resolve ensureCreateDirectory
 ]
 
 { #category : #operations }


### PR DESCRIPTION
`#ensureCreateFile` already has the correct behavior, which is to return self. Otherwise, one may ask a FileLocator to ensure and get back a FileReference.