### PR TITLE
[Code cleaning] Replaced 'Character tab asString' to 'String tab'

### DIFF
--- a/src/GT-Debugger/GTDebugActionButton.class.st
+++ b/src/GT-Debugger/GTDebugActionButton.class.st
@@ -34,9 +34,11 @@ GTDebugActionButton >> initialize [
 { #category : #updating }
 GTDebugActionButton >> update [
 
-	self debugAction ifNotNil:  [ :aDebugAction | 
+	self debugAction ifNotNil: [ :aDebugAction | 
 		self label: aDebugAction label.
-		self help: aDebugAction help, Character tab asString, (aDebugAction keymap ifNil: [ '' ] ifNotNil: [ :k | k   printString]).
+		self help: aDebugAction help , String tab
+			,
+			(aDebugAction keymap ifNil: [ '' ] ifNotNil: [ :k | k printString ]).
 		self icon: aDebugAction icon.
 		self enabled: aDebugAction enabled.
 		self state: false.

--- a/src/Glamour-Morphic-Renderer/GLMMorphicActionRenderer.class.st
+++ b/src/Glamour-Morphic-Renderer/GLMMorphicActionRenderer.class.st
@@ -16,30 +16,36 @@ GLMMorphicActionRenderer >> actionSelector [
 
 { #category : #rendering }
 GLMMorphicActionRenderer >> render: anAction [
-	|b|
+
+	| b |
 	b := GLMPluggableButtonMorph
-			on: anAction getState: nil action: self actionSelector.
+		     on: anAction
+		     getState: nil
+		     action: self actionSelector.
 	b
 		theme: UITheme current;
-		arguments: (self actionArguments ifNil: [{b}]);
+		arguments: (self actionArguments ifNil: [ { b } ]);
 		cornerStyle: (UITheme current buttonCornerStyleIn: nil);
 		hResizing: #shrinkWrap;
 		vResizing: #shrinkWrap;
 		getEnabledSelector: nil;
-		setBalloonText: ((anAction help ifNil: [ anAction title]) , Character tab asString , anAction shortcutAsString) trimBoth;
+		setBalloonText:
+			((anAction help ifNil: [ anAction title ]) , String tab
+			 , anAction shortcutAsString) trimBoth;
 		extent: b minExtent;
 		removeProperty: #theme.
-	anAction shouldShowTitle 
-		ifTrue: [ b 
-				icon: anAction icon ;
+	anAction shouldShowTitle
+		ifTrue: [ 
+			b
+				icon: anAction icon;
 				label: anAction title font: UITheme current buttonFont ]
 		ifFalse: [ b label: (AlphaImageMorph new image: anAction icon) ].
-	
+
 	"this is a hack to tell the GLMUITheme to not draw the border and the fill, and to disable the focus"
-	b 
+	b
 		valueOfProperty: #noBorder ifAbsentPut: [ true ];
 		valueOfProperty: #noFill ifAbsentPut: [ true ];
 		setProperty: #wantsKeyboardFocusNavigation toValue: false;
 		borderWidth: 0.
-	^ b	
+	^ b
 ]

--- a/src/System-Clipboard/Clipboard.class.st
+++ b/src/System-Clipboard/Clipboard.class.st
@@ -69,7 +69,7 @@ Clipboard >> chooseRecentClipping [
 		  chooseFrom: (recent collect: [ :txt | 
 				   ((txt asString contractTo: 50)
 					    copyReplaceAll: String cr
-					    with: '\') copyReplaceAll: Character tab asString with: '|' ])
+					    with: '\') copyReplaceAll: String tab with: '|' ])
 		  values: recent
 ]
 

--- a/src/Zinc-Character-Encoding-Tests/ZnPercentEncoderTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnPercentEncoderTest.class.st
@@ -28,12 +28,21 @@ ZnPercentEncoderTest >> testDecodingErrors [
 
 { #category : #testing }
 ZnPercentEncoderTest >> testLeadingZero [
+
 	| encoder |
 	encoder := ZnPercentEncoder new.
-	self assert: (encoder encode: 'foo', Character tab asString, 'bar') equals: 'foo%09bar'.
-	self assert: (encoder decode: 'foo%09bar') equals: 'foo', Character tab asString, 'bar'.
-	self assert: (encoder encode: 'foo', Character lf asString, 'bar') equals: 'foo%0Abar'.
-	self assert: (encoder decode: 'foo%0Abar') equals: 'foo', Character lf asString, 'bar'
+	self
+		assert: (encoder encode: 'foo' , String tab , 'bar')
+		equals: 'foo%09bar'.
+	self
+		assert: (encoder decode: 'foo%09bar')
+		equals: 'foo' , String tab , 'bar'.
+	self
+		assert: (encoder encode: 'foo' , Character lf asString , 'bar')
+		equals: 'foo%0Abar'.
+	self
+		assert: (encoder decode: 'foo%0Abar')
+		equals: 'foo' , Character lf asString , 'bar'
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Replaced all calls of `Character tab asString` to `String tab` in order to have a more clean and clear code.