### PR TITLE
Simplify-ReUnaryAccessingMethodWithoutReturnRule

### DIFF
--- a/src/GeneralRules/ReUnaryAccessingMethodWithoutReturnRule.class.st
+++ b/src/GeneralRules/ReUnaryAccessingMethodWithoutReturnRule.class.st
@@ -20,11 +20,10 @@ ReUnaryAccessingMethodWithoutReturnRule class >> uniqueIdentifierName [
 
 { #category : #running }
 ReUnaryAccessingMethodWithoutReturnRule >> basicCheck: aMethod [
-	(aMethod numArgs > 0 or: [ aMethod isAbstract ]) ifTrue: [ ^ false ].
-	((aMethod methodClass organization categoryOfElement: aMethod selector) asString beginsWith: 'accessing') ifFalse: [ ^ false ].
-	aMethod ast nodesDo: [ :each | each isReturn ifTrue: [ ^ false ] ].
 
-	^ true
+	(aMethod numArgs > 0 or: [ aMethod isAbstract ]) ifTrue: [ ^ false ].
+	(aMethod category beginsWith: 'accessing') ifFalse: [ ^ false ].
+	^ aMethod ast allChildren noneSatisfy: [ :each | each isReturn ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- use #category instead of #categoryOfElement: on the class organizer
- use noneSatisfy:

