### PR TITLE
Calypso: Don't Show "Should Implement" Protocol for Abstract Classes

### DIFF
--- a/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyUnimplementedMethodsQuery.class.st
+++ b/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyUnimplementedMethodsQuery.class.st
@@ -63,7 +63,8 @@ ClyUnimplementedMethodsQuery >> isAffectedByChangedMethod: aMethod [
 ClyUnimplementedMethodsQuery >> isClass: aClass shouldImplement: aSelector [
 
 	| inheritedMethod |
-	aClass isRootInEnvironment ifTrue: [ ^false].
+	aClass isRootInEnvironment ifTrue: [ ^false ].
+	aClass isAbstract ifTrue: [ ^false ].
 	
 	inheritedMethod := aClass superclass lookupSelector: aSelector.
 	inheritedMethod ifNil: [ ^false ].


### PR DESCRIPTION
A  false positive scenario was reported on Discord today because there is no way to tell Calypso not to warn about "should be implemented" for abstract classes.

Here is the behavior with the fix in place:
![2020-11-24T084035343244-0500](https://user-images.githubusercontent.com/184176/100106044-0c099b80-2e36-11eb-85d0-a0b55191200e.gif)
