### PR TITLE
SemanticAnalysis-Args-are-read 

### DIFF
--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -15,6 +15,7 @@ Class {
 
 { #category : #variables }
 OCASTSemanticAnalyzer >> analyseEscapingRead: var [
+	var markRead.
 	(var scope outerNotOptimizedScope ~= scope outerNotOptimizedScope ) ifFalse: [ ^self ].
 	"only escaping when they will end up in different closures"
 	var markEscapingRead.
@@ -143,7 +144,6 @@ OCASTSemanticAnalyzer >> undeclaredVariable: variableNode [
 
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> uninitializedVariable: variableNode [
-	variableNode variable markRead.
 	variableNode propertyAt: #semanticWarning put: #unitialized.
 ]
 

--- a/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
@@ -5,6 +5,14 @@ Class {
 }
 
 { #category : #'testing - variables' }
+OCASTClosureAnalyzerTest >> testArgumentIsRead [
+
+	| ast |
+	ast := (OCOpalExamples >> #exampleWithArgument:) parseTree.
+	self assert: ast arguments first variable usage equals: #read
+]
+
+{ #category : #'testing - variables' }
 OCASTClosureAnalyzerTest >> testBlockArgumentIsArgumentVariable [
 	| ast blockNode |
 	ast := (OCOpalExamples>>#exampleForBlockArgument) parseTree.

--- a/src/Slot-Tests/ArgumentVariableTest.class.st
+++ b/src/Slot-Tests/ArgumentVariableTest.class.st
@@ -18,3 +18,13 @@ ArgumentVariableTest >> testDeclaringNode [
 	declaringNodeViaVariable := method ast variableReadNodes fifth variable definingNode.
 	self assert: declaringNodeViaVariable equals: declaringNode.
 ]
+
+{ #category : #tests }
+ArgumentVariableTest >> testUsingMethods [
+
+	| method |
+	method := Integer >> #+.
+	self
+		assert: method temporaryVariables first usingMethods first
+		equals: method
+]


### PR DESCRIPTION
Small fix: the semantic analysis did not tag local arguments as #read correctly.

- tag for read in #analyseEscapingRead: by default
- no need to tag in #uninitializedVariable:
- add test testArgumentIsRead

This was making #usingMethods fail for arguments, add a test for that, too.


