### PR TITLE
CompiledMethod-hasProperty-use-includesProperty 

### DIFF
--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -475,8 +475,11 @@ CompiledMethod >> hasProperties [
 
 { #category : #'accessing-pragmas & properties' }
 CompiledMethod >> hasProperty: aKey [
-	self propertyAt: aKey ifAbsent: [ ^false ].
-	^true.
+
+	| extendedMethodState |
+	^ (extendedMethodState := self penultimateLiteral) isMethodProperties
+		  ifTrue: [  extendedMethodState includesProperty: aKey ]
+		  ifFalse: [ false ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
speedup #hasProperty: a little by using includesProperty: instead of #propertyAt:ifAbsent:


