### PR TITLE
No "inconsistent method classification" for methods in deprecated method category

### DIFF
--- a/src/GeneralRules/ReInconsistentMethodClassificationRule.class.st
+++ b/src/GeneralRules/ReInconsistentMethodClassificationRule.class.st
@@ -26,8 +26,8 @@ ReInconsistentMethodClassificationRule >> check: aMethod forCritiquesDo: aCritiq
 	| ownerProtocol |
 	ownerProtocol := aMethod protocol.
 	ownerProtocol ifNil: [ ^ self ].
-	(ownerProtocol == #'as yet unclassified' or: [ 
-	 ownerProtocol first = $*	 ]) ifTrue: [ ^ self ].
+	((#('as yet unclassified' 'deprecation') includes: ownerProtocol)
+				or: [ ownerProtocol first = $*	 ]) ifTrue: [ ^ self ].
 	
 	aMethod methodClass superclass ifNotNil: [ :superclass |
 			(superclass lookupSelector: aMethod selector) ifNotNil: [ :superMethod |


### PR DESCRIPTION
 

Fix #7867