### PR TITLE
shouldDisplayOnTopContext-seems-to-be-not-needed

### DIFF
--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -432,12 +432,6 @@ DebugSession >> shouldDisplayContext: aContext basedOnFilters: stackFilters [
 	
 ]
 
-{ #category : #context }
-DebugSession >> shouldDisplayOnTopContext: aContext [
-	
-	^ aContext method selector ~= #halt
-]
-
 { #category : #logging }
 DebugSession >> signalDebuggerError: anError [
 


### PR DESCRIPTION
fixes #7838

- remove the methods. Deprecation not needed


