### PR TITLE
optimize hasProperty: on Morph a little

### DIFF
--- a/src/Glamour-Morphic-Brick/GLMBrick.class.st
+++ b/src/Glamour-Morphic-Brick/GLMBrick.class.st
@@ -440,12 +440,6 @@ GLMBrick >> haloClass [
 	^ #GLMHaloBrick
 ]
 
-{ #category : #'private-extension' }
-GLMBrick >> hasProperty: aSymbol [ 
-	
-	^ super hasProperty: aSymbol
-]
-
 { #category : #initialization }
 GLMBrick >> initialize [
 	super initialize.

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -3343,8 +3343,7 @@ Morph >> hasParagraphAnchorString [
 { #category : #'accessing - properties' }
 Morph >> hasProperty: aSymbol [ 
 	"Answer whether the receiver has the property named aSymbol"
-	extension ifNil: [^ false].
-	^extension hasProperty: aSymbol
+	^ extension ifNil: [false] ifNotNil: [:ext | ext hasProperty: aSymbol]
 ]
 
 { #category : #'layout-menu' }

--- a/src/Morphic-Core/MorphExtension.class.st
+++ b/src/Morphic-Core/MorphExtension.class.st
@@ -148,10 +148,13 @@ MorphExtension >> hasProperty: aSymbol [
 	"Answer whether the receiver has the property named aSymbol"
 	| property |
 	otherProperties ifNil: [^ false].
-	property := otherProperties at: aSymbol ifAbsent: nil.
-	property ifNil: [^ false].
-	property == false ifTrue: [^ false].
-	^ true
+	"we do not return in the false block as this would require a full block to be allocated"
+	property := otherProperties at: aSymbol ifAbsent: false.
+	"here can need to explicitly check for false as it is false or some object"
+	^property == false 
+		ifTrue: [false]
+		ifFalse: [true ]
+
 ]
 
 { #category : #initialization }

--- a/src/Morphic-Core/MorphExtension.class.st
+++ b/src/Morphic-Core/MorphExtension.class.st
@@ -145,12 +145,9 @@ MorphExtension >> fillStyle: anObject [
 
 { #category : #'accessing - other properties' }
 MorphExtension >> hasProperty: aSymbol [
-
 	"Answer whether the receiver has the property named aSymbol"
 
-	^ otherProperties
-		  ifNil: [ false ]
-		  ifNotNil: [ otherProperties includesKey: aSymbol ]
+	^ otherProperties ifNil: [ false ] ifNotNil: [ : prop | prop includesKey: aSymbol ]
 ]
 
 { #category : #initialization }

--- a/src/Morphic-Core/MorphExtension.class.st
+++ b/src/Morphic-Core/MorphExtension.class.st
@@ -150,7 +150,7 @@ MorphExtension >> hasProperty: aSymbol [
 	otherProperties ifNil: [^ false].
 	"we do not return in the false block as this would require a full block to be allocated"
 	property := otherProperties at: aSymbol ifAbsent: false.
-	"here can need to explicitly check for false as it is false or some object"
+	"here we need to explicitly check for false as it is false or some object"
 	^property == false 
 		ifTrue: [false]
 		ifFalse: [true ]

--- a/src/Morphic-Core/MorphExtension.class.st
+++ b/src/Morphic-Core/MorphExtension.class.st
@@ -148,7 +148,7 @@ MorphExtension >> hasProperty: aSymbol [
 	"Answer whether the receiver has the property named aSymbol"
 	| property |
 	otherProperties ifNil: [^ false].
-	property := otherProperties at: aSymbol ifAbsent: [].
+	property := otherProperties at: aSymbol ifAbsent: nil.
 	property ifNil: [^ false].
 	property == false ifTrue: [^ false].
 	^ true

--- a/src/Morphic-Core/MorphExtension.class.st
+++ b/src/Morphic-Core/MorphExtension.class.st
@@ -144,17 +144,13 @@ MorphExtension >> fillStyle: anObject [
 ]
 
 { #category : #'accessing - other properties' }
-MorphExtension >> hasProperty: aSymbol [ 
-	"Answer whether the receiver has the property named aSymbol"
-	| property |
-	otherProperties ifNil: [^ false].
-	"we do not return in the false block as this would require a full block to be allocated"
-	property := otherProperties at: aSymbol ifAbsent: false.
-	"here we need to explicitly check for false as it is false or some object"
-	^property == false 
-		ifTrue: [false]
-		ifFalse: [true ]
+MorphExtension >> hasProperty: aSymbol [
 
+	"Answer whether the receiver has the property named aSymbol"
+
+	^ otherProperties
+		  ifNil: [ false ]
+		  ifNotNil: [ otherProperties includesKey: aSymbol ]
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
- do not allocate block in MorphExtension>>#hasProperty, just use nil
- Morph>>#hasProperty: does not need to push the ivar twice

- remove GLMBrick>>#hasProperty:, which the same as the implementation in the superclass