### PR TITLE
simplify SubscriptionRegistry>>#subscriptionsHandling:

### DIFF
--- a/src/Announcements-Core/SubscriptionRegistry.class.st
+++ b/src/Announcements-Core/SubscriptionRegistry.class.st
@@ -133,10 +133,9 @@ SubscriptionRegistry >> subscriptionsForClass: subscriberClass [
 
 { #category : #accessing }
 SubscriptionRegistry >> subscriptionsHandling: anAnnouncement [
-	^ Array streamContents: [ :s|
-			subscriptions do: [:each| 
-				(each handlesAnnouncement: anAnnouncement)
-					ifTrue: [ s nextPut: each ]]]
+	"Returns an Array containing the subscriptions that handle anAnnouncement"
+	
+	^ subscriptions select: [ :subscription | subscription handlesAnnouncement: anAnnouncement ] as: Array
 ]
 
 { #category : #iterating }

--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -1184,6 +1184,16 @@ Collection >> select: aBlock [
 ]
 
 { #category : #enumerating }
+Collection >> select: aBlock as: aClass [
+	"Evaluate aBlock with each of the receiver's elements as argument.
+	Collect the elements for which aBlock evaluates to true in an instance of aClass. Answer the resulting collection"
+	
+	| selectedElements |
+	selectedElements := (self select: aBlock).
+	^ (aClass new: selectedElements size) fillFrom: selectedElements with: [ :each | each ] ; yourself
+]
+
+{ #category : #enumerating }
 Collection >> select: selectBlock thenCollect: collectBlock [
 	"Utility method to improve readability."
 

--- a/src/Collections-Support-Tests/CollectionTest.class.st
+++ b/src/Collections-Support-Tests/CollectionTest.class.st
@@ -83,3 +83,12 @@ CollectionTest >> testGroupedByGroupsOrderWithSortedCollectionOfDates [
 		].
 
 ]
+
+{ #category : #tests }
+CollectionTest >> testSelectAs [
+	| collection result |
+	collection := OrderedCollection new add: 1; add: 3; add: 2; yourself.
+	result  := collection select: [:i | i even not] as: Array.
+	self assert: result class equals: Array.
+	self assert: result equals: #(1 3).
+]


### PR DESCRIPTION
Fixes #7764 
- Added Collection>>#select:as:
- SubscriptionRegistry>>#subscriptionsHandling: now uses #select:as: to build the array instead of #streamContents:

Note: for Collection>>#select:as: I initially tried to use #addAll: to fill the collection to return, but Array does not support #add:. So I used the same method that is used in Collection>>#collect:as: -> #fill:from: .Even though it looks a bit strange to provide #fill:from: with a block that does nothing, it makes #select:as: work when it's asked to produce an Array