### PR TITLE
Fixed #7800. Removed unused instance variable traitDefinition in CDTraitParserTest

### DIFF
--- a/src/ClassParser-Tests/CDTraitParserTest.class.st
+++ b/src/ClassParser-Tests/CDTraitParserTest.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : #CDTraitParserTest,
 	#superclass : #TestCase,
-	#instVars : [
-		'traitDefinition'
-	],
 	#category : #'ClassParser-Tests'
 }
 


### PR DESCRIPTION
Removed unused instance variable traitDefinition in CDTraitParserTest. This fixes #7800.