### PR TITLE
Compile-Empty-Blocks-as-CleanBlocks

### DIFF
--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -538,11 +538,19 @@ OCASTTranslator >> visitCascadeNode: aCascadeNode [
 
 { #category : #'visitor-double dispatching' }
 OCASTTranslator >> visitFullBlockNode: aBlockNode [
+
 	| compiledBlock |
 	compiledBlock := self compilationContext astTranslatorClass new translateFullBlock: aBlockNode.
-	(self compilationContext optionCleanBlockClosure and: [ aBlockNode isClean ])
-		ifTrue: [ methodBuilder pushLiteral: ((CleanBlockClosure new: 0) numArgs: compiledBlock numArgs; compiledBlock: compiledBlock)]
-		ifFalse: [methodBuilder pushFullClosureCompiledBlock: compiledBlock copiedValues: aBlockNode scope inComingCopiedVarNames  ]
+	"For now clean blocks are not enabled (debugger needs more tesing. But for empty blocks we use them already"
+	((self compilationContext optionCleanBlockClosure or: [ aBlockNode body statements isEmpty ]) and: [ aBlockNode isClean ])
+		ifTrue: [ 
+			methodBuilder pushLiteral: ((CleanBlockClosure new: 0)
+					 numArgs: compiledBlock numArgs;
+					 compiledBlock: compiledBlock) ]
+		ifFalse: [ 
+			methodBuilder
+				pushFullClosureCompiledBlock: compiledBlock
+				copiedValues: aBlockNode scope inComingCopiedVarNames ]
 ]
 
 { #category : #'visitor-double dispatching' }


### PR DESCRIPTION
Clean block compilation is not yet enabled due to more testing needed to be done for the debugger. But that does not mean that we can not use them already for one specific case: [] the empty block.

There are over 800 uses in the image. This, too, will allow us to find problems early with CleanBlocks if we start to use them step by step.