### PR TITLE
Move old definition printing to a the legacy printer

### DIFF
--- a/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
@@ -164,16 +164,19 @@ EpApplyPreviewerTest >> testCategoryRenameWithPreviousRollback [
 
 { #category : #tests }
 EpApplyPreviewerTest >> testClassAdditionWithClassRemoved [
+
 	| aClass classDefinition |
 	aClass := classFactory newClass.
-	classDefinition := aClass definition.
+	classDefinition := aClass definitionString.
 	self setHeadAsInputEntry.
 
 	aClass removeFromSystem.
 
 	self assertOutputsAnEventWith: [ :output | 
 		self assert: output class equals: EpClassAddition.
-		self assert: output behaviorAffected definitionSource equals: classDefinition ]
+		self
+			assert: output behaviorAffected definitionSource
+			equals: classDefinition ]
 ]
 
 { #category : #tests }
@@ -181,16 +184,18 @@ EpApplyPreviewerTest >> testClassAdditionWithInstanceVariablesChanged [
 
 	| aClass classDefinition |
 	aClass := classFactory newClass.
-	classDefinition := aClass definition.
+	classDefinition := aClass definitionString.
 	self setHeadAsInputEntry.
 	aClass addInstVarNamed: #x.
 
-	self assertOutputsAnEventWith: [:output | 
+	self assertOutputsAnEventWith: [ :output | 
 		self assert: output class equals: EpClassModification.
-		self assert: output oldClass definitionSource equals: aClass definition.
-		self assert: output newClass definitionSource equals: classDefinition.
-		]
-
+		self
+			assert: output oldClass definitionSource
+			equals: aClass definition.
+		self
+			assert: output newClass definitionSource
+			equals: classDefinition ]
 ]
 
 { #category : #tests }
@@ -198,22 +203,25 @@ EpApplyPreviewerTest >> testClassAdditionWithSuperclassChanged [
 
 	| aClass classDefinition |
 	aClass := classFactory newClass.
-	classDefinition := aClass definition.
+	classDefinition := aClass definitionString.
 	self setHeadAsInputEntry.
 	aClass superclass: Array.
 
-	self assertOutputsAnEventWith: [:output | 
+	self assertOutputsAnEventWith: [ :output | 
 		self assert: output class equals: EpClassModification.
-		self assert: output oldClass definitionSource equals: aClass definition.
-		self assert: output newClass definitionSource equals: classDefinition.
-		].
+		self
+			assert: output oldClass definitionSource
+			equals: aClass definitionString.
+		self
+			assert: output newClass definitionSource
+			equals: classDefinition ].
 
-	aClass superclass: Object. "Restore original superclass else something in hierarchy stays wrong (and ClassHierarchyTest>>testSubclassInstVar fails)"
-
+	aClass superclass: Object "Restore original superclass else something in hierarchy stays wrong (and ClassHierarchyTest>>testSubclassInstVar fails)"
 ]
 
 { #category : #tests }
 EpApplyPreviewerTest >> testClassRemovalWithClassAdded [
+
 	| aClass className |
 	aClass := classFactory newClass.
 	className := aClass name.
@@ -226,7 +234,9 @@ EpApplyPreviewerTest >> testClassRemovalWithClassAdded [
 
 	self assertOutputsAnEventWith: [ :output | 
 		self assert: output class equals: EpClassRemoval.
-		self assert: output behaviorAffected definitionSource equals: aClass definition ]
+		self
+			assert: output behaviorAffected definitionSource
+			equals: aClass definitionString ]
 ]
 
 { #category : #tests }
@@ -630,15 +640,16 @@ EpApplyPreviewerTest >> testTraitAdditionWithTraitRemoved [
 
 	| aTrait traitDefinition |
 	aTrait := classFactory newTrait.
-	traitDefinition := aTrait definition.
+	traitDefinition := aTrait definitionString.
 	self setHeadAsInputEntry.
 
 	aTrait removeFromSystem.
 
-	self assertOutputsAnEventWith: [:output | 
+	self assertOutputsAnEventWith: [ :output | 
 		self assert: output class equals: EpTraitAddition.
-		self assert: output behaviorAffected definitionSource equals: traitDefinition.
-		]
+		self
+			assert: output behaviorAffected definitionSource
+			equals: traitDefinition ]
 ]
 
 { #category : #tests }
@@ -654,16 +665,16 @@ EpApplyPreviewerTest >> testTraitRemovalWithTraitAdded [
 	| aTrait traitName traitDefinition |
 	aTrait := classFactory newTrait.
 	traitName := aTrait name.
-	traitDefinition := aTrait definition.
+	traitDefinition := aTrait definitionString.
 	aTrait removeFromSystem.
 	self setHeadAsInputEntry.
 
 	aTrait := classFactory newTrait.
 	aTrait rename: traitName.
 
-	self assertOutputsAnEventWith: [:output | 
+	self assertOutputsAnEventWith: [ :output | 
 		self assert: output class equals: EpTraitRemoval.
-		self assert: output behaviorAffected definitionSource equals: traitDefinition.
-		]
-
+		self
+			assert: output behaviorAffected definitionSource
+			equals: traitDefinition ]
 ]

--- a/src/EpiceaBrowsers/EpApplyPreviewer.class.st
+++ b/src/EpiceaBrowsers/EpApplyPreviewer.class.st
@@ -119,13 +119,15 @@ EpApplyPreviewer >> visitClassChange: aChange [
 
 	self
 		behaviorNamed: aChange behaviorAffectedName
-		ifPresent: [ :aClass |
-			^ aClass definition = aChange behaviorAffected definition
-				ifTrue: [ #() ]
-				ifFalse: [ { EpClassModification oldClass: aClass newClass: aChange behaviorAffected } ]
-			].
-	
-	^ { EpClassAddition class: aChange behaviorAffected }
+		ifPresent: [ :aClass | 
+			^ aClass definitionString = aChange behaviorAffected definition
+				  ifTrue: [ #(  ) ]
+				  ifFalse: [ 
+					  { (EpClassModification
+						   oldClass: aClass
+						   newClass: aChange behaviorAffected) } ] ].
+
+	^ { (EpClassAddition class: aChange behaviorAffected) }
 ]
 
 { #category : #visitor }

--- a/src/Kernel-Tests/AbstractOldPrinterTest.class.st
+++ b/src/Kernel-Tests/AbstractOldPrinterTest.class.st
@@ -1,25 +1,25 @@
 Class {
-	#name : #OldPharoClassDefinitionPrinterTest,
+	#name : #AbstractOldPrinterTest,
 	#superclass : #CommonClassDefinitionPrinterTest,
 	#category : #'Kernel-Tests-Fluid'
 }
 
 { #category : #helpers }
-OldPharoClassDefinitionPrinterTest >> forClass: aClass [
+AbstractOldPrinterTest >> forClass: aClass [
 	^ (OldPharoClassDefinitionPrinter for: aClass) definitionString 
 
 
 ]
 
 { #category : #running }
-OldPharoClassDefinitionPrinterTest >> setUp [
+AbstractOldPrinterTest >> setUp [
 
 	super setUp.
 	ClassDefinitionPrinter showFluidClassDefinition: false
 ]
 
 { #category : #'tests - classes' }
-OldPharoClassDefinitionPrinterTest >> testArray [
+AbstractOldPrinterTest >> testArray [
 
 	self 
 		assert: (self forClass: Array) 
@@ -30,7 +30,7 @@ OldPharoClassDefinitionPrinterTest >> testArray [
 ]
 
 { #category : #'tests - classes' }
-OldPharoClassDefinitionPrinterTest >> testArrayedCollectionWithPoolDictionary [
+AbstractOldPrinterTest >> testArrayedCollectionWithPoolDictionary [
 
 	self assert: (self forClass: ExampleForTestWithSharedPool) equals: 'ArrayedCollection subclass: #ExampleForTestWithSharedPool
 	instanceVariableNames: ''aSlot anotherSlot''
@@ -40,7 +40,7 @@ OldPharoClassDefinitionPrinterTest >> testArrayedCollectionWithPoolDictionary [
 ]
 
 { #category : #'tests - classes' }
-OldPharoClassDefinitionPrinterTest >> testByteString [
+AbstractOldPrinterTest >> testByteString [
 
 	self 
 		assert: (self forClass: ByteString) 
@@ -51,7 +51,7 @@ OldPharoClassDefinitionPrinterTest >> testByteString [
 ]
 
 { #category : #'tests - classes' }
-OldPharoClassDefinitionPrinterTest >> testChronologyConstants [
+AbstractOldPrinterTest >> testChronologyConstants [
 	
 	self 
 		assert: (self forClass: ChronologyConstants) 
@@ -62,14 +62,14 @@ OldPharoClassDefinitionPrinterTest >> testChronologyConstants [
 ]
 
 { #category : #'tests - metaclasses' }
-OldPharoClassDefinitionPrinterTest >> testClassSideDoesNotShowPackage [
+AbstractOldPrinterTest >> testClassSideDoesNotShowPackage [
 
 	self assert: (self forClass: ContextTest class) equals: 'ContextTest class
 	instanceVariableNames: '''''
 ]
 
 { #category : #'tests - metaclasses' }
-OldPharoClassDefinitionPrinterTest >> testMetaclass [
+AbstractOldPrinterTest >> testMetaclass [
 	
 	self assert: (self forClass: Metaclass) equals:  'ClassDescription subclass: #Metaclass
 	instanceVariableNames: ''thisClass''
@@ -78,7 +78,7 @@ OldPharoClassDefinitionPrinterTest >> testMetaclass [
 ]
 
 { #category : #'tests - metaclasses' }
-OldPharoClassDefinitionPrinterTest >> testMetaclassClass [
+AbstractOldPrinterTest >> testMetaclassClass [
 	
 	self 
 		assert: (self forClass: Metaclass class) 
@@ -87,7 +87,7 @@ OldPharoClassDefinitionPrinterTest >> testMetaclassClass [
 ]
 
 { #category : #'tests - classes' }
-OldPharoClassDefinitionPrinterTest >> testPoint [
+AbstractOldPrinterTest >> testPoint [
 
 	self 
 		assert: (self forClass: Point) 
@@ -98,7 +98,7 @@ OldPharoClassDefinitionPrinterTest >> testPoint [
 ]
 
 { #category : #'tests - classes' }
-OldPharoClassDefinitionPrinterTest >> testProtoObject [
+AbstractOldPrinterTest >> testProtoObject [
 	
 	self assert: (self forClass: ProtoObject) equals: 'ProtoObject subclass: #ProtoObject
 	instanceVariableNames: ''''
@@ -110,7 +110,7 @@ ProtoObject superclass: nil'
 ]
 
 { #category : #'tests - metaclasses' }
-OldPharoClassDefinitionPrinterTest >> testSystemAnnouncerClass [
+AbstractOldPrinterTest >> testSystemAnnouncerClass [
 	
 	self 
 		assert: (self forClass: SystemAnnouncer class) 

--- a/src/Kernel-Tests/LegacyClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/LegacyClassDefinitionPrinterTest.class.st
@@ -1,0 +1,121 @@
+Class {
+	#name : #LegacyClassDefinitionPrinterTest,
+	#superclass : #CommonClassDefinitionPrinterTest,
+	#category : #'Kernel-Tests-Fluid'
+}
+
+{ #category : #helpers }
+LegacyClassDefinitionPrinterTest >> forClass: aClass [
+	^ (ClassDefinitionPrinter legacy for: aClass) definitionString 
+
+
+]
+
+{ #category : #'tests - classes' }
+LegacyClassDefinitionPrinterTest >> testArray [
+
+	self 
+		assert: (self forClass: Array) 
+		equals: 'ArrayedCollection variableSubclass: #Array
+	instanceVariableNames: ''''
+	classVariableNames: ''''
+	poolDictionaries: ''''
+	category: ''Collections-Sequenceable-Base'''
+]
+
+{ #category : #'tests - classes' }
+LegacyClassDefinitionPrinterTest >> testArrayedCollectionWithPoolDictionary [
+
+	self assert: (self forClass: ExampleForTestWithSharedPool)
+		equals: 'ArrayedCollection subclass: #ExampleForTestWithSharedPool
+	instanceVariableNames: ''aSlot anotherSlot''
+	classVariableNames: ''''
+	poolDictionaries: ''ChronologyConstants''
+	category: ''Kernel-Tests-Classes'''
+]
+
+{ #category : #'tests - classes' }
+LegacyClassDefinitionPrinterTest >> testByteString [
+
+	self 
+		assert: (self forClass: ByteString) 
+		equals: 'String variableByteSubclass: #ByteString
+	instanceVariableNames: ''''
+	classVariableNames: ''NonAsciiMap''
+	poolDictionaries: ''''
+	category: ''Collections-Strings-Base'''
+]
+
+{ #category : #'tests - classes' }
+LegacyClassDefinitionPrinterTest >> testChronologyConstants [
+	
+	self 
+		assert: (self forClass: ChronologyConstants) 
+		equals: 'SharedPool subclass: #ChronologyConstants
+	instanceVariableNames: ''''
+	classVariableNames: ''DayNames DaysInMonth MicrosecondsInDay MonthNames NanosInMillisecond NanosInSecond SecondsInDay SecondsInHour SecondsInMinute SqueakEpoch''
+	poolDictionaries: ''''
+	category: ''Kernel-Chronology'''
+]
+
+{ #category : #'tests - metaclasses' }
+LegacyClassDefinitionPrinterTest >> testClassSideDoesNotShowPackage [
+
+	self assert: (self forClass: ContextTest class) equals: 'ContextTest class
+	instanceVariableNames: '''''
+]
+
+{ #category : #'tests - metaclasses' }
+LegacyClassDefinitionPrinterTest >> testMetaclass [
+	
+	self
+		assert: (self forClass: Metaclass)
+		equals: 'ClassDescription subclass: #Metaclass
+	instanceVariableNames: ''thisClass''
+	classVariableNames: ''''
+	poolDictionaries: ''''
+	category: ''Kernel-Classes'''
+]
+
+{ #category : #'tests - metaclasses' }
+LegacyClassDefinitionPrinterTest >> testMetaclassClass [
+	
+	self 
+		assert: (self forClass: Metaclass class) 
+		equals: 'Metaclass class
+	instanceVariableNames: '''''	
+]
+
+{ #category : #'tests - classes' }
+LegacyClassDefinitionPrinterTest >> testPoint [
+
+	self 
+		assert: (self forClass: Point)
+		equals: 'Object subclass: #Point
+	instanceVariableNames: ''x y''
+	classVariableNames: ''''
+	poolDictionaries: ''''
+	category: ''Kernel-BasicObjects'''
+]
+
+{ #category : #'tests - classes' }
+LegacyClassDefinitionPrinterTest >> testProtoObject [
+	
+	self
+		assert: (self forClass: ProtoObject)
+		equals: 'ProtoObject subclass: #ProtoObject
+	instanceVariableNames: ''''
+	classVariableNames: ''''
+	poolDictionaries: ''''
+	category: ''Kernel-Objects''.
+ProtoObject superclass: nil'
+]
+
+{ #category : #'tests - metaclasses' }
+LegacyClassDefinitionPrinterTest >> testSystemAnnouncerClass [
+	
+	self 
+		assert: (self forClass: SystemAnnouncer class) 
+		equals: 'SystemAnnouncer class
+	instanceVariableNames: ''announcer'''
+]

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -479,61 +479,6 @@ Class >> definitionStringFor: aConfiguredPrinter [
 	^ aConfiguredPrinter classDefinitionString 
 ]
 
-{ #category : #'file in/out' }
-Class >> definitionWithSlots [
-	"The class definition with a way to specify slots. Shown when the class defines special Slot"
-	
-	| stream poolString|
-	poolString := self sharedPoolsString.
-
-	stream := (String new: 800) writeStream.
-	superclass 
-		ifNotNil: [stream nextPutAll: superclass name]
-		ifNil: [stream nextPutAll: 'ProtoObject'].
-	stream 
-		nextPutAll: ' subclass: '; 
-		store: self name.
-	self hasTraitComposition ifTrue: [
-		stream 
-			crtab; 
-			nextPutAll: 'uses: ';
-			nextPutAll: self traitCompositionString ].
-			
-	self classLayout isFixedLayout ifFalse: [
-		stream 
-			crtab; 
-			nextPutAll: 'layout: ';
-			nextPutAll: self classLayout class name ].
-	
-	stream 
-		crtab; 
-		nextPutAll: 'slots: '.
-	self slotDefinitionsOn: stream.
-		
-	stream 
-		crtab; 
-		nextPutAll: 'classVariables: ';
-		nextPutAll: self classVariableDefinitionString.
-	
-	poolString = '' ifFalse: [
-		stream 
-			crtab; 
-			nextPutAll: 'poolDictionaries: ';
-			store: poolString ].
-		
-	stream 
-		crtab; 
-		nextPutAll: 'package: ';
-		store: self category asString.
-
-	superclass ifNil: [ 
-		stream nextPutAll: '.'; cr.
-		stream nextPutAll: self name.
-		stream space; nextPutAll: 'superclass: nil'. ].
-
-	^ stream contents
-]
-
 { #category : #deprecation }
 Class >> deprecationRefactorings [
 
@@ -850,44 +795,6 @@ Class >> obsolete [
 	self hasClassSide ifTrue: [ self classSide obsolete].
 	self propertyAt: #obsolete put: true.
 	super obsolete.
-]
-
-{ #category : #'file in/out' }
-Class >> oldDefinition [
-	"Answer a String that defines the receiver in the old format using poolDictionaries and category.
-	e.g,  
-	'Object subclass: #Point
-		instanceVariableNames: ''x y''
-		classVariableNames: ''''
-		poolDictionaries: ''''
-		category: ''Kernel-BasicObjects'''
-	"
-
-	| aStream |
-	aStream := (String new: 800) writeStream.
-	superclass 
-		ifNil: [aStream nextPutAll: 'ProtoObject']
-		ifNotNil: [aStream nextPutAll: superclass name].
-	aStream nextPutAll: self kindOfSubclass;
-			store: self name.
-	(self hasTraitComposition) ifTrue: [
-		aStream cr; tab; nextPutAll: 'uses: ';
-			nextPutAll: self traitCompositionString].
-	aStream cr; tab; nextPutAll: 'instanceVariableNames: ';
-			store: self instanceVariablesString.
-	aStream cr; tab; nextPutAll: 'classVariableNames: ';
-			store: self classVariablesString.
-	aStream cr; tab; nextPutAll: 'poolDictionaries: ';
-			store: self sharedPoolsString.
-	aStream cr; tab; nextPutAll: 'category: ';
-			store: self category asString.
-
-	superclass ifNil: [ 
-		aStream nextPutAll: '.'; cr.
-		aStream nextPutAll: self name.
-		aStream space; nextPutAll: 'superclass: nil'. ].
-
-	^ aStream contents
 ]
 
 { #category : #compiling }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -573,7 +573,9 @@ ClassDescription >> definesSlotNamed: aString [
 { #category : #'file in/out' }
 ClassDescription >> definition [
 	"Answer a String that defines the receiver."
-
+	self
+		deprecated: #definition
+		transformWith: '`@receiver definition' -> '`@receiver definitionString'.
 	^ self definitionString
 ]
 
@@ -588,7 +590,7 @@ ClassDescription >> definitionPrinter [
 ClassDescription >> definitionString [
 	"Return the string of the class definition, each of my subclass may tell the printer how to printer it. A kind of double dispatch since we have multiple printers and multiple entities to be printed."
 
-	^ self definitionStringFor: self definitionPrinter
+	^ self definitionPrinter definitionString
 ]
 
 { #category : #fileout }
@@ -938,6 +940,14 @@ ClassDescription >> obsolete [
 	super obsolete.
 ]
 
+{ #category : #'file in/out' }
+ClassDescription >> oldDefinition [
+	
+	^ ClassDefinitionPrinter legacy
+		for: self;
+		definitionString
+]
+
 { #category : #organization }
 ClassDescription >> organization [
 	"Answer the instance of ClassOrganizer that represents the organization 
@@ -1100,35 +1110,6 @@ ClassDescription >> sharedPoolsString [
 							ifTrue: [ each name ] "obsolete classes should be visible"
 							ifFalse: [ 'private' ] ]) ] "if class is from different environment, mark it as private"
 			separatedBy: [ stream space ] ]
-]
-
-{ #category : #printing }
-ClassDescription >> slotDefinitionString [
-	"Answer a string that represents an executable description of my Slots"
-	
-	^String streamContents: [ :str | self slotDefinitionsOn: str]
-]
-
-{ #category : #printing }
-ClassDescription >> slotDefinitionsOn: aStream [
-	"Write on the arg aStream an executable description of my Slots on the argument, aStream"
-
-	| useFull |
-	aStream nextPutAll: '{ '.
-	self localSlots
-		do: [ :slot | 
-			slot definitionOn: aStream.
-			useFull := slot needsFullDefinition ]
-		separatedBy: [ 
-			aStream nextPutAll: ' . '.
-			useFull ifTrue: [ 
-				aStream
-					cr;
-					tab;
-					tab;
-					tab;
-					tab ] ].
-	aStream nextPutAll: ' }'
 ]
 
 { #category : #slots }

--- a/src/Kernel/FluidClassDefinitionPrinter.class.st
+++ b/src/Kernel/FluidClassDefinitionPrinter.class.st
@@ -286,6 +286,13 @@ FluidClassDefinitionPrinter >> sharedVariablesOn: s [
 ]
 
 { #category : #'elementary operations' }
+FluidClassDefinitionPrinter >> slotDefinitionString [
+	"Answer a string that represents an executable description of my Slots"
+	
+	^String streamContents: [ :str | self slotDefinitionsOn: str]
+]
+
+{ #category : #'elementary operations' }
 FluidClassDefinitionPrinter >> slotDefinitionsOn: aStream [
 	"Write on the arg aStream an executable description of my Slots"
 

--- a/src/Kernel/LegacyClassDefinitionPrinter.class.st
+++ b/src/Kernel/LegacyClassDefinitionPrinter.class.st
@@ -4,6 +4,45 @@ Class {
 	#category : #'Kernel-ClassDefinitionPrinter'
 }
 
+{ #category : #'public API' }
+LegacyClassDefinitionPrinter >> classDefinitionString [
+
+	"Answer a String that defines the receiver in the old format using poolDictionaries and category.
+	e.g,  
+	'Object subclass: #Point
+		instanceVariableNames: ''x y''
+		classVariableNames: ''''
+		poolDictionaries: ''''
+		category: ''Kernel-BasicObjects'''
+	"
+
+	| aStream |
+	aStream := (String new: 800) writeStream.
+	forClass superclass
+		ifNil: [aStream nextPutAll: 'ProtoObject']
+		ifNotNil: [aStream nextPutAll: forClass superclass name].
+	aStream nextPutAll: forClass kindOfSubclass;
+			store: forClass name.
+	(forClass hasTraitComposition) ifTrue: [
+		aStream cr; tab; nextPutAll: 'uses: ';
+			nextPutAll: forClass traitCompositionString].
+	aStream cr; tab; nextPutAll: 'instanceVariableNames: ';
+			store: forClass instanceVariablesString.
+	aStream cr; tab; nextPutAll: 'classVariableNames: ';
+			store: forClass classVariablesString.
+	aStream cr; tab; nextPutAll: 'poolDictionaries: ';
+			store: forClass sharedPoolsString.
+	aStream cr; tab; nextPutAll: 'category: ';
+			store: forClass category asString.
+
+	forClass superclass ifNil: [ 
+		aStream nextPutAll: '.'; cr.
+		aStream nextPutAll: forClass name.
+		aStream space; nextPutAll: 'superclass: nil'. ].
+
+	^ aStream contents
+]
+
 { #category : #template }
 LegacyClassDefinitionPrinter >> classDefinitionTemplateInPackage: aString [
 
@@ -16,12 +55,41 @@ LegacyClassDefinitionPrinter >> classDefinitionTemplateInPackage: aString [
 ]
 
 { #category : #delegating }
-LegacyClassDefinitionPrinter >> definitionString [
-	^ forClass oldDefinition
-]
-
-{ #category : #delegating }
 LegacyClassDefinitionPrinter >> expandedDefinitionString [
 	"We do not support expansion on legacy syntax so we shortcut the double dispatch call."
 	^ self definitionString
+]
+
+{ #category : #'public API' }
+LegacyClassDefinitionPrinter >> metaclassDefinitionString [
+
+	^ String streamContents: [:stream |
+		stream print: forClass.
+		stream
+			crtab;
+			nextPutAll: 'instanceVariableNames: ';
+			store: forClass instanceVariablesString ]
+]
+
+{ #category : #'public API' }
+LegacyClassDefinitionPrinter >> traitDefinitionString [
+
+	^ String streamContents: [ :s | 
+		s 
+			nextPutAll: 'Trait named: ';
+			nextPutAll:	forClass name printString;
+			cr; tab; 
+			nextPutAll: ' uses: ';
+			nextPutAll: forClass traitComposition traitCompositionExpression; 
+			cr;
+			tab;
+			nextPutAll: ' package: ';
+			nextPutAll: forClass category asString printString
+	]
+]
+
+{ #category : #'public API' }
+LegacyClassDefinitionPrinter >> traitedMetaclassDefinitionString [
+
+	^ self metaclassDefinitionString
 ]

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -126,18 +126,6 @@ Metaclass >> definitionStringFor: aConfiguredPrinter [
 	^ aConfiguredPrinter metaclassDefinitionString 
 ]
 
-{ #category : #'file in/out' }
-Metaclass >> definitionWithSlots [
-	"Refer to the comment in ClassDescription|definition."
-
-	^ String streamContents: [:stream |
-		stream print: self.
-		stream
-			crtab;
-			nextPutAll: 'slots: '.
-		self slotDefinitionsOn: stream ]
-]
-
 { #category : #accessing }
 Metaclass >> environment [
 
@@ -256,14 +244,6 @@ Metaclass >> obsoleteSubclasses [
 
 	self isMetaclassOfClassOrNil ifTrue: [ ^ #() ].
 	^ self instanceSide obsoleteSubclasses collect: [ :aSubclass | aSubclass classSide ]
-]
-
-{ #category : #'file in/out' }
-Metaclass >> oldDefinition [
-	"Refer to the comment of Class. 
-	 This method is for compatibility with Class>>#oldDefinition"
-
-	^ self definition
 ]
 
 { #category : #compiling }

--- a/src/Kernel/OldPharoClassDefinitionPrinter.class.st
+++ b/src/Kernel/OldPharoClassDefinitionPrinter.class.st
@@ -56,20 +56,11 @@ OldPharoClassDefinitionPrinter >> basicTraitDefinitionString [
 			  nextPutAll: 'Trait named: ';
 			  nextPutAll: forClass name printString.
 		  self traitCompositionOn: s.
-		  "Important"
-		  self flag: #todo.
-		  "this class definition should NOT use slots: 
-			either this is a simple slot and we use instance variable names
-			or this is a complex slot and we use the fluid definition.
-			we could have forClass neslotsNeedFullDefinition
-					ifTrue: [ (self class fluid forClass: self) traitDefinitionString ] "
+
 		  forClass classLayout visibleSlots ifNotEmpty: [ 
-			  s
-				  tab;
-				  nextPutAll: ' slots: ';
-				  nextPutAll: forClass slotDefinitionString;
-				  cr ].
-		  "End of important"
+			  self error:
+				  'Invalid Printer for stateful traits. Please detect and use a more modern printer' ].
+
 		  self packageOn: s ]
 ]
 

--- a/src/Kernel/UndefinedSlot.class.st
+++ b/src/Kernel/UndefinedSlot.class.st
@@ -36,7 +36,7 @@ UndefinedSlot >> checkClassRebuild [
 	(self definingClass environment hasClassNamed: self slotClassName) ifFalse: [ ^ self ].
 	classIsRebuild := true.
 	"we rebuild the class, this triggers instance migration"
-	self definingClass compiler evaluate: self definingClass definitionWithSlots.
+	self definingClass compiler evaluate: self definingClass definitionString.
 	"recompile all methods that access me to generat code for the loaded definition"
 	self usingMethods do: [:each | each recompile].
 ]

--- a/src/Ring-Definitions-Core/Trait.extension.st
+++ b/src/Ring-Definitions-Core/Trait.extension.st
@@ -2,24 +2,25 @@ Extension { #name : #Trait }
 
 { #category : #'*Ring-Definitions-Core' }
 Trait >> asRingDefinition [
+
 	"A triat is converted to a ring class. Only the receiver is converted.
 	Methods, superclasses, subclasses are not generated"
 
 	| ring |
-	ring:= (RGTraitDefinition named: self name)
-		category: self category;
-		superclassName: #Trait;  
-		traitCompositionSource: self traitCompositionString;
-		comment: self organization classComment;
-		stamp: self organization commentStamp;
-		definitionSource: self definition;
-		withMetaclass.
-		
-	ring classSide 
-		traitCompositionSource: self classSide traitCompositionString;
-		definitionSource: self classSide definition.
+	ring := (RGTraitDefinition named: self name)
+		        category: self category;
+		        superclassName: #Trait;
+		        traitCompositionSource: self traitCompositionString;
+		        comment: self organization classComment;
+		        stamp: self organization commentStamp;
+		        definitionSource: self definitionString;
+		        withMetaclass.
 
-	^ring
+	ring classSide
+		traitCompositionSource: self classSide traitCompositionString;
+		definitionSource: self classSide definitionString.
+
+	^ ring
 ]
 
 { #category : #'*Ring-Definitions-Core' }

--- a/src/Slot-Tests/ExampleSlotWithStateTest.class.st
+++ b/src/Slot-Tests/ExampleSlotWithStateTest.class.st
@@ -7,10 +7,11 @@ Class {
 { #category : #tests }
 ExampleSlotWithStateTest >> testExampleClassSide [
 	" can we install a slot on the class side?"
+	| slot |
 	aClass := self make: [ :builder | builder classSlots: {#slot1 =>ExampleSlotWithState}].
 
-	self assert: (aClass class hasSlotNamed: #slot1).
-	self assert: aClass class slotDefinitionString equals:  '{ #slot1 => ExampleSlotWithState }'
+	slot := aClass class slotNamed: #slot1.
+	self assert: slot class equals: ExampleSlotWithState
 ]
 
 { #category : #tests }

--- a/src/Tests/Trait4.trait.st
+++ b/src/Tests/Trait4.trait.st
@@ -1,0 +1,6 @@
+Trait {
+	#name : #Trait4,
+	#traits : 'Trait1 + (Trait2 - {#c})',
+	#classTraits : 'Trait1 classTrait + Trait2 classTrait',
+	#category : #'Tests-Traits-MOP'
+}

--- a/src/TraitsV2-Tests/T2LegacyPharoClassDefinitionPrinterTest.class.st
+++ b/src/TraitsV2-Tests/T2LegacyPharoClassDefinitionPrinterTest.class.st
@@ -1,0 +1,120 @@
+Class {
+	#name : #T2LegacyPharoClassDefinitionPrinterTest,
+	#superclass : #T2CommonClassDefinitionPrinterTest,
+	#category : #'TraitsV2-Tests'
+}
+
+{ #category : #helpers }
+T2LegacyPharoClassDefinitionPrinterTest >> forClass: aClass [
+	^ (ClassDefinitionPrinter legacy for: aClass) definitionString 
+
+
+]
+
+{ #category : #running }
+T2LegacyPharoClassDefinitionPrinterTest >> setUp [
+
+	super setUp.
+	ClassDefinitionPrinter showFluidClassDefinition: false
+]
+
+{ #category : #'tests - traits' }
+T2LegacyPharoClassDefinitionPrinterTest >> testAlignmentMorphClass [
+
+	self 
+		assert: (self forClass: AlignmentMorph class) equals: 'AlignmentMorph class
+	instanceVariableNames: '''''
+]
+
+{ #category : #'tests - traits' }
+T2LegacyPharoClassDefinitionPrinterTest >> testClassUsingComplexTrait [
+
+	self
+		assert: (self forClass: MOPTestClassD)
+		equals: 'Object subclass: #MOPTestClassD
+	uses: Trait2 @ {#c3->#c2}
+	instanceVariableNames: ''''
+	classVariableNames: ''''
+	poolDictionaries: ''''
+	category: ''Tests-Traits-MOP'''
+]
+
+{ #category : #'tests - traits' }
+T2LegacyPharoClassDefinitionPrinterTest >> testComplexTrait [
+
+	self
+		assert: (self forClass: Trait4)
+		equals: 'Trait named: #Trait4
+	 uses: Trait1 + (Trait2 - {#c})
+	 package: ''Tests-Traits-MOP'''
+]
+
+{ #category : #'tests - traits' }
+T2LegacyPharoClassDefinitionPrinterTest >> testMultiPools [
+
+	self
+		assert: (self forClass: ClassMultiplePoolUser)
+		equals: 'Object subclass: #ClassMultiplePoolUser
+	instanceVariableNames: ''''
+	classVariableNames: ''''
+	poolDictionaries: ''PoolDefiner PoolDefiner2''
+	category: ''Kernel-Tests-Classes'''
+]
+
+{ #category : #'tests - traits' }
+T2LegacyPharoClassDefinitionPrinterTest >> testTBehavior [
+	"to me this looks strange to have empty uses here when empty instancevariablenames are not displayed."
+	self 
+		assert: (self forClass: TBehavior)  equals: 'Trait named: #TBehavior
+	 uses: {}
+	 package: ''TraitsV2-Compatibility-Traits'''
+]
+
+{ #category : #'tests - traits' }
+T2LegacyPharoClassDefinitionPrinterTest >> testTComparableClassTrait [
+
+	self assert: (self forClass: TComparable classTrait) equals: 'TComparable classTrait
+	instanceVariableNames: '''''
+]
+
+{ #category : #'tests - traits' }
+T2LegacyPharoClassDefinitionPrinterTest >> testTEventVisitorClassTrait [
+
+	self assert: (self forClass: EpTEventVisitor classTrait) equals: 'EpTEventVisitor classTrait
+	instanceVariableNames: '''''
+]
+
+{ #category : #'tests - traits' }
+T2LegacyPharoClassDefinitionPrinterTest >> testTSortable [
+
+	self assert: (self forClass: TSortable classTrait) equals: 'TSortable classTrait
+	instanceVariableNames: '''''
+]
+
+{ #category : #'tests - traits' }
+T2LegacyPharoClassDefinitionPrinterTest >> testTrait [
+	
+	self assert: (self forClass: RubScrolledTextModel) equals: 'Object subclass: #RubScrolledTextModel
+	uses: TViewModel
+	instanceVariableNames: ''hasUnacceptedEdits announcer text primarySelectionInterval interactionModel''
+	classVariableNames: ''''
+	poolDictionaries: ''''
+	category: ''Rubric-Editing-Widgets'''
+]
+
+{ #category : #'tests - traits' }
+T2LegacyPharoClassDefinitionPrinterTest >> testTrait3 [
+
+	self assert: (self forClass: Trait3 classTrait) equals: 'Trait3 classTrait
+	instanceVariableNames: '''''
+]
+
+{ #category : #'tests - traits' }
+T2LegacyPharoClassDefinitionPrinterTest >> testTrait3AndTag [
+
+	self 
+		assert: (self forClass: Trait3) 
+		equals: 'Trait named: #Trait3
+	 uses: Trait2
+	 package: ''Tests-Traits-MOP'''
+]

--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -245,12 +245,6 @@ Trait >> notifyOfRecategorizedSelector: selector from: oldCategory to: newCatego
 	self traitUsers do: [ :e | e recategorizeSelector: selector from: oldCategory to: newCategory ].
 ]
 
-{ #category : #'file in/out' }
-Trait >> oldDefinition [
-
-	^ self definition
-]
-
 { #category : #'accessing method dictionary' }
 Trait >> rebuildMethodDictionary [
 	"I extend the behavior in TraitedMetaclass propagating the changes to my users"


### PR DESCRIPTION
Make the system use the legacy printer
Remove redundant/unused methods