### PR TITLE
Improve-isHaltNode

### DIFF
--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -176,8 +176,10 @@ RBMessageNode >> isHaltNode [
 
 	^ (#( #halt #halt: #haltIf: #haltOnce #haltIfNil #haltOnCount: ) 
 		   includes: self selector) or: [ 
-		  self receiver isVariable and: [ 
-			  self receiver variable value = Halt ] ]
+		  self receiver isGlobalVariable and: [ 
+			  self receiver variable value = Halt and: [ 
+				  (Halt class selectorsInCategory: #halting) includes:
+					  self selector ] ] ]
 ]
 
 { #category : #testing }

--- a/src/Debugging-Utils-Tests/HaltTest.class.st
+++ b/src/Debugging-Utils-Tests/HaltTest.class.st
@@ -65,12 +65,16 @@ HaltTest >> testContainsHalt [
 	annonClass 
 	compile: 'm1 self halt';
 	compile: 'm2 self haltIfNil';
-	compile: 'm3 self yourself'.
+	compile: 'm3 self yourself';
+	compile: 'm4 Halt yourself';
+	compile: 'm5 Halt once'.
 	
 	self
 	assert: (annonClass >> #m1) containsHalt;
 	assert: (annonClass >> #m2) containsHalt;
-	deny: (annonClass >> #m3) containsHalt.
+	deny: (annonClass >> #m3) containsHalt;
+	deny: (annonClass >> #m4) containsHalt;
+	assert: (annonClass >> #m5) containsHalt
 	
 	
 ]


### PR DESCRIPTION
#isHaltNode was not taking into account that there are messages send to Halt that do not lead to a halt.

- fix isHaltNode to check the category
- test it in testContainsHalt


