### PR TITLE
7871-Proposal-Simplify-How-Pragmas-are-stored

### DIFF
--- a/src/Kernel/AdditionalMethodState.class.st
+++ b/src/Kernel/AdditionalMethodState.class.st
@@ -240,21 +240,13 @@ AdditionalMethodState >> postCopy [
 { #category : #accessing }
 AdditionalMethodState >> pragmas [
 	"Return the Pragma objects. Properties are stored as Associations"
-	^ Array new: self basicSize streamContents: [ :pragmaStream | 
-		  1 to: self basicSize do: [ :i | 
-			  | propertyOrPragma "<Association|Pragma>" |
-			  (propertyOrPragma := self basicAt: i) isAssociation ifFalse: [ 
-				  pragmaStream nextPut: propertyOrPragma ] ] ]
+	self at: #pragmas ifPresent: [ :p | ^p  ].
+	^#().
 ]
 
-{ #category : #enumerating }
-AdditionalMethodState >> pragmasDo: aBlock [
-	
-	1 to: self basicSize do: [ :i | 
-		| propertyOrPragma	"<Association|Pragma>" |
-		propertyOrPragma := self basicAt: i.
-		propertyOrPragma isAssociation
-			ifFalse: [ aBlock value: propertyOrPragma ] ]
+{ #category : #accessing }
+AdditionalMethodState >> pragmasDo: a [
+	self pragmas do: a
 ]
 
 { #category : #printing }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -754,14 +754,18 @@ CompiledMethod >> penultimateLiteral: anObject [
 
 { #category : #copying }
 CompiledMethod >> postCopy [
-	| penultimateLiteral |
-	(penultimateLiteral := self penultimateLiteral) isMethodProperties ifTrue:
-		[self penultimateLiteral: (penultimateLiteral copy
-									method: self;
-									yourself).
-		 self penultimateLiteral pragmas do:
-			[:p| p method: self]]
 
+	| penultimateLiteral pragmas |
+	(penultimateLiteral := self penultimateLiteral) isMethodProperties 
+		ifFalse: [ ^ self ].
+	
+	pragmas := self pragmas collect: [ :each | each copy ] as: Array.		
+	pragmas do: [ :p | p method: self ].
+	penultimateLiteral := pragmas 
+		ifEmpty: [ penultimateLiteral copy ]
+		ifNotEmpty: [ penultimateLiteral copyWith: (#pragmas -> pragmas) ].
+	self penultimateLiteral: (penultimateLiteral method: self)
+  
 ]
 
 { #category : #'accessing-pragmas & properties' }
@@ -779,17 +783,13 @@ CompiledMethod >> pragmaRefersToLiteral: literal [
 
 { #category : #'accessing-pragmas & properties' }
 CompiledMethod >> pragmas [
-	| selectorOrProperties |
-	^(selectorOrProperties := self penultimateLiteral) isMethodProperties
-		ifTrue: [selectorOrProperties pragmas]
-		ifFalse: [#()]
+	^ self propertyAt: #pragmas ifAbsent: [#() ]
+
 ]
 
 { #category : #'accessing-pragmas & properties' }
 CompiledMethod >> pragmasDo: aBlock [
-	| selectorOrProperties |
-	(selectorOrProperties := self penultimateLiteral) isMethodProperties
-		ifTrue: [selectorOrProperties pragmasDo: aBlock]
+	self pragmas do: aBlock
 ]
 
 { #category : #'debugger support' }

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -107,11 +107,14 @@ IRBytecodeGenerator >> addLiteral: object [
 
 { #category : #private }
 IRBytecodeGenerator >> addPragma: aPragma [
-	properties ifNil: [ properties := AdditionalMethodState new ].
-	properties := properties copyWith: aPragma. 
 
-	
-	
+	properties ifNil: [ properties := AdditionalMethodState new ].
+	properties
+		at: #pragmas
+		ifAbsent: [ properties := properties copyWith: #pragmas -> #(  ) ].
+	properties
+		at: #pragmas
+		put: ((properties at: #pragmas) copyWith: aPragma)
 ]
 
 { #category : #results }
@@ -121,7 +124,7 @@ IRBytecodeGenerator >> addProperties: cm [
 	properties
 		ifNotNil: [ cm penultimateLiteral: properties.
 			properties method: cm.
-			properties pragmas do: [ :each | each method: cm ] ]
+			properties at: #pragmas ifPresent: [ :props | props do: [:each | each method: cm ] ]]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This is a minimal change to implement the proposal to store pragmas as a property #pragmas 

- pragmasDo: is now just "pragmas do:"
- #pragmas returns the property #pragmas
- Fix CompiledMethod>>#postcopy to do the right thing

And of course change the compiler to create methods like that.

TODO in a second PR: 
- remove all knowledge about pragma from AdditionalMethodState

fixes #7871

7871-Proposal-Simplify-How-Pragmas-are-stored