### PR TITLE
7925-halt-left-in-FFIFunctionParsersetOn

### DIFF
--- a/src/UnifiedFFI/FFIFunctionParser.class.st
+++ b/src/UnifiedFFI/FFIFunctionParser.class.st
@@ -293,7 +293,6 @@ FFIFunctionParser >> setOn: aStreamSource [
 	| functionDeclarationArray |
 	functionDeclarationArray := aStreamSource isString ifTrue: [ | node |
 			node := RBParser parseExpression: '#(', aStreamSource, ')'.
-			node isLiteralNode ifFalse: [ self halt ].
 			node evaluate
 		] ifFalse: [ aStreamSource ].
 			


### PR DESCRIPTION
I removed it as it looks like a left over from debugging. But maybe it needs a real error handling instead?

fixes #7925


