### PR TITLE
Do not allocate a block when executing #isInstalled

### DIFF
--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -607,7 +607,7 @@ CompiledMethod >> isInstalled [
 		[:class|
 		self selector ifNotNil:
 			[:selector|
-			^self == (class compiledMethodAt: selector ifAbsent: [])]].
+			^self == (class compiledMethodAt: selector ifAbsent: nil)]].
 	^false
 ]
 


### PR DESCRIPTION
Do not allocate a block when executing #isInstalled 