### PR TITLE
Remove unused environment ivar from BuilderManifestTest

### DIFF
--- a/src/Manifest-Tests/BuilderManifestTest.class.st
+++ b/src/Manifest-Tests/BuilderManifestTest.class.st
@@ -4,9 +4,6 @@ A ManifestBuilderTest is a class to test the behavior of ManifestBuilder
 Class {
 	#name : #BuilderManifestTest,
 	#superclass : #AbstractEnvironmentTestCase,
-	#instVars : [
-		'environment'
-	],
 	#category : #'Manifest-Tests-Base'
 }
 


### PR DESCRIPTION
Fix  #7939