### PR TITLE
Care on unreferenced variables in OpalCompiler packages

### DIFF
--- a/src/OpalCompiler-Tests/OCMockCompilationClass.class.st
+++ b/src/OpalCompiler-Tests/OCMockCompilationClass.class.st
@@ -6,3 +6,9 @@ Class {
 	],
 	#category : #'OpalCompiler-Tests-Misc'
 }
+
+{ #category : #accessing }
+OCMockCompilationClass >> collection [
+
+	^ collection
+]

--- a/src/OpalCompiler-Tests/OCScopeTest.class.st
+++ b/src/OpalCompiler-Tests/OCScopeTest.class.st
@@ -10,6 +10,18 @@ Class {
 	#category : #'OpalCompiler-Tests-Semantic'
 }
 
+{ #category : #accessing }
+OCScopeTest class >> myClassVarForTesting [
+
+	^MyClassVarForTesting
+]
+
+{ #category : #accessing }
+OCScopeTest >> ivarForTesting [
+
+	^ ivarForTesting
+]
+
 { #category : #tests }
 OCScopeTest >> testHasBindingThatBeginsWithClassVar [
 	self assert: (thisContext astScope hasBindingThatBeginsWith: 'MyClass').

--- a/src/OpalCompiler-Tests/OCSourceCode2BytecodeTest.class.st
+++ b/src/OpalCompiler-Tests/OCSourceCode2BytecodeTest.class.st
@@ -13,6 +13,13 @@ Class {
 	#category : #'OpalCompiler-Tests-Source'
 }
 
+{ #category : #accessing }
+OCSourceCode2BytecodeTest class >> classVar [
+
+	 ^ClassVar
+
+]
+
 { #category : #compiling }
 OCSourceCode2BytecodeTest >> compile2method: sourceStream [ 
 			"Compile code without logging the source in the changes file"
@@ -21,6 +28,12 @@ OCSourceCode2BytecodeTest >> compile2method: sourceStream [
 						class: self class;			
 						compile.
 		
+]
+
+{ #category : #accessing }
+OCSourceCode2BytecodeTest >> instVar [
+
+	^ instVar
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Fix #7942