### PR TITLE
Remove unused lastKeyboardFocus ivare from OSSDL2BackendWindow

### DIFF
--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -9,7 +9,6 @@ Class {
 	#instVars : [
 		'currentCursor',
 		'iconSurface',
-		'lastKeyboardFocus',
 		'sdl2Window',
 		'screenScaleFactor',
 		'horizontalDPI',


### PR DESCRIPTION
Fix #7945