### PR TITLE
RBPragmaNode-accessor-simpler 

### DIFF
--- a/src/AST-Core/RBPragmaNode.class.st
+++ b/src/AST-Core/RBPragmaNode.class.st
@@ -68,7 +68,7 @@ RBPragmaNode >> argumentAt: keywordSelector ifAbsent: absentBlock [
 
 { #category : #accessing }
 RBPragmaNode >> arguments [
-	^ arguments ifNil: [ #() ]
+	^ arguments
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
RBPragmaNode>>#arguments was implementing a lazu accessor. But we set it to #() in initialize and the setter does not allow nil.

