### PR TITLE
AST-Cleanup-visitUnreachableStatement

### DIFF
--- a/src/AST-Core/RBCommentNodeVisitor.class.st
+++ b/src/AST-Core/RBCommentNodeVisitor.class.st
@@ -11,7 +11,7 @@ Class {
 	#category : #'AST-Core-Visitors'
 }
 
-{ #category : #accessing }
+{ #category : #visiting }
 RBCommentNodeVisitor >> visitNode: aNode [
 	aNode comments ifNotEmpty: [ :commentNodes |
 		commentNodes do: [ :commentNode |

--- a/src/AST-Core/RBGenericNodeVisitor.class.st
+++ b/src/AST-Core/RBGenericNodeVisitor.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'AST-Core-Visitors'
 }
 
-{ #category : #accessing }
+{ #category : #visiting }
 RBGenericNodeVisitor >> visitNode: aNode [
 	super visitNode: aNode.
 	self visitBlock value: aNode

--- a/src/AST-Core/RBParseErrorNodeVisitor.class.st
+++ b/src/AST-Core/RBParseErrorNodeVisitor.class.st
@@ -7,18 +7,12 @@ Class {
 	#category : #'AST-Core-Visitors'
 }
 
-{ #category : #accessing }
+{ #category : #visiting }
 RBParseErrorNodeVisitor >> visitEnglobingErrorNode: aNode [
 	self visitParseErrorNode: aNode
 ]
 
-{ #category : #accessing }
+{ #category : #visiting }
 RBParseErrorNodeVisitor >> visitParseErrorNode: aNode [
 	self visitBlock value: aNode
-]
-
-{ #category : #accessing }
-RBParseErrorNodeVisitor >> visitUnreachableStatement: aNode [
-
-	self visitEnglobingErrorNode: aNode
 ]

--- a/src/Reflectivity-Tools/ErrorNodeStyler.class.st
+++ b/src/Reflectivity-Tools/ErrorNodeStyler.class.st
@@ -48,9 +48,3 @@ ErrorNodeStyler >> visitEnglobingErrorNode: anEnglobingNode [
 
 	anEnglobingNode content do: [ :each | self visitNode: each ]
 ]
-
-{ #category : #visiting }
-ErrorNodeStyler >> visitUnreachableStatement: anUnreachableStatement [
-
-	^ super visitEnglobingErrorNode: anUnreachableStatement
-]

--- a/src/Reflectivity-Tools/ErrorNodeStyler.class.st
+++ b/src/Reflectivity-Tools/ErrorNodeStyler.class.st
@@ -48,3 +48,9 @@ ErrorNodeStyler >> visitEnglobingErrorNode: anEnglobingNode [
 
 	anEnglobingNode content do: [ :each | self visitNode: each ]
 ]
+
+{ #category : #visiting }
+ErrorNodeStyler >> visitUnreachableStatement: anUnreachableStatement [
+	"self overrides visitEnglobingErrorNode:"
+	^ super visitEnglobingErrorNode: anUnreachableStatement
+]


### PR DESCRIPTION
- visitUnreachableStatement: is overridden in two visitor subclasses, but both times it does the same as the superclass

- recategorize some visit methods


