### PR TITLE
7923-Broken-traits-definitions 

### DIFF
--- a/src/Kernel/OldPharoClassDefinitionPrinter.class.st
+++ b/src/Kernel/OldPharoClassDefinitionPrinter.class.st
@@ -65,10 +65,9 @@ OldPharoClassDefinitionPrinter >> basicTraitDefinitionString [
 					ifTrue: [ (self class fluid forClass: self) traitDefinitionString ] "
 		  forClass classLayout visibleSlots ifNotEmpty: [ 
 			  s
-				  tab;
-				  nextPutAll: ' slots: ';
-				  nextPutAll: forClass slotDefinitionString;
-				  cr ].
+				  crtab;
+				  nextPutAll: 'slots: ';
+				  nextPutAll: forClass slotDefinitionString ].
 		  "End of important"
 		  self packageOn: s ]
 ]

--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -56,6 +56,16 @@ Trait class >> named: aSymbol package: aString [
 ]
 
 { #category : #'instance creation' }
+Trait class >> named: aName slots: someSlots package: aPackageName [
+
+	^ self named: aName 
+		uses: {} 
+		slots: someSlots 
+		package: aPackageName 
+		env: self environment 
+]
+
+{ #category : #'instance creation' }
 Trait class >> named: aSymbol uses: aCompositionOrArray [
 	^ self named: aSymbol uses: aCompositionOrArray package: 'Unclassified'
 ]


### PR DESCRIPTION
I did not try to fix the underlyin problem that Traits with state only have a slot defintion. Instead this fixes the smaller problem if making the definition work.

- add Trait named: slots: package:
- fix formatting

This fixes #7923
