### PR TITLE
TRBProgramNodeVisitor-methods-missing 

### DIFF
--- a/src/AST-Core-Traits/TRBProgramNodeVisitor.trait.st
+++ b/src/AST-Core-Traits/TRBProgramNodeVisitor.trait.st
@@ -45,6 +45,12 @@ TRBProgramNodeVisitor >> visitCascadeNode: aCascadeNode [
 ]
 
 { #category : #visiting }
+TRBProgramNodeVisitor >> visitEnglobingErrorNode: anEnglobingErrorNode [
+
+	anEnglobingErrorNode content do: [ :each | self visitNode: each ]
+]
+
+{ #category : #visiting }
 TRBProgramNodeVisitor >> visitGlobalNode: aSelfNode [
 	^ self visitVariableNode: aSelfNode
 ]
@@ -63,7 +69,7 @@ TRBProgramNodeVisitor >> visitLiteralArrayNode: aRBLiteralArrayNode [
 TRBProgramNodeVisitor >> visitLiteralNode: aLiteralNode [
 ]
 
-{ #category : #'visiting - reflectivity' }
+{ #category : #visiting }
 TRBProgramNodeVisitor >> visitLiteralValueNode: aNode [
 	"Redirect the message by default to #visitLiteralNode: for retrocompatibility (pharo 8)"
 
@@ -171,6 +177,12 @@ TRBProgramNodeVisitor >> visitTemporaryNodes: aNodeCollection [
 { #category : #visiting }
 TRBProgramNodeVisitor >> visitThisContextNode: aThisContextNode [
 	^ self visitVariableNode: aThisContextNode
+]
+
+{ #category : #visiting }
+TRBProgramNodeVisitor >> visitUnreachableStatement: anUnreachableStatement [
+	
+	^ self visitEnglobingErrorNode: anUnreachableStatement
 ]
 
 { #category : #visiting }


### PR DESCRIPTION
TRBProgramNodeVisitor was missing two visit methods: #visitEnglobingErrorNode: and #visitUnreachableStatement:

