### PR TITLE
7928-halt-left-in-FBDDecompilerpushFullClosurenumCopiedreceiverOnStackignoreOuterContext 

### DIFF
--- a/src/Flashback-Decompiler/FBDDecompiler.class.st
+++ b/src/Flashback-Decompiler/FBDDecompiler.class.st
@@ -537,7 +537,7 @@ FBDDecompiler >> pushFullClosure: aCompiledBlock numCopied: numCopied receiverOn
 	savedSimStack := simulatedStack.
 	savedSequence := currentSequence.
 
-	receiverOnStack ifTrue: [ 1 halt ].
+	receiverOnStack ifTrue: [ self error: 'not yet supported, please open issue' ].
 
 	simulatedStack addLast: (self
 		extractFullBlock: aCompiledBlock numCopied: numCopied).


### PR DESCRIPTION
fixes #7928 

- replace the halt with an error


(The goal is to remove halts so we can add a release test)