### PR TITLE
7953 huge debugger st pharo application memory leak

### DIFF
--- a/src/Debugger-Model-Tests/DebuggerModelTest.class.st
+++ b/src/Debugger-Model-Tests/DebuggerModelTest.class.st
@@ -24,6 +24,15 @@ DebuggerModelTest >> setUp [
 ]
 
 { #category : #tests }
+DebuggerModelTest >> testClearDebugSession [
+
+	session clear.
+	self assert: session exception equals: nil.
+	self assert: session interruptedContext equals: nil.
+	self assert: session interruptedProcess equals: nil
+]
+
+{ #category : #tests }
 DebuggerModelTest >> testCorrectlyCreateDebugSession [
 
 	self assert: session isNotNil.	

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -57,6 +57,7 @@ DebugSession class >> named: aString on: aProcess startedAt: aContext [
 DebugSession >> clear [
 	"If after resuming the process the user does plan to reuse this session with
 	the same process, it should call this method."
+	exception := nil.
 	interruptedProcess := nil.
 	self updateContextTo: nil
 ]

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -32,6 +32,7 @@ StDebuggerActionModel >> autoClassifyMessage: aMessage inClass: aClass [
 
 { #category : #'debug - execution' }
 StDebuggerActionModel >> clearDebugSession [
+	contextPredicate := nil.
 	self session terminate
 ]
 
@@ -219,6 +220,8 @@ StDebuggerActionModel >> predicateFor: aContext postMortem: isContextPostMortem 
 
 { #category : #'debug - execution' }
 StDebuggerActionModel >> proceedDebugSession [
+
+	contextPredicate := nil.
 	self session
 		resume;
 		clear


### PR DESCRIPTION
Fixes #7953
I believe this is due to the fact that:
- debug sessions and other debugger model objects holds a reference to the exception that provoked a debugger opening
- the exceptions references the interrupted process and context that prevent garbage collection

This may be a side effect of https://github.com/pharo-spec/NewTools/issues/136 where the debugging processes are never released after closing a debugger (under investigation).

With this fix, now the reproduction example of the issue gives the following result:

![Screenshot 2020-12-04 at 14 09 40](https://user-images.githubusercontent.com/26929529/101167562-5b23ad80-363a-11eb-91b1-b5ad655af143.png)

Trying the same on instances of `StDebugger` returns nil.
