### PR TITLE
RBMethodNode #pragmas is the only instance variable for AST children that has an accessor checking for nil

### DIFF
--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -100,8 +100,8 @@ RBMethodNode >> addNode: aNode [
 { #category : #'adding/removing' }
 RBMethodNode >> addPragma: aPragmaNode [
 
-	pragmas ifNil: [ self pragmas: OrderedCollection new ].
-	pragmas add: aPragmaNode
+	pragmas := pragmas copyWith: aPragmaNode.
+	aPragmaNode parent: self
 ]
 
 { #category : #replacing }
@@ -368,6 +368,7 @@ RBMethodNode >> hash [
 
 { #category : #initialization }
 RBMethodNode >> initialize [
+	pragmas := #().
 	replacements := SortedCollection sortBlock: 
 					[:a :b | 
 					a startPosition < b startPosition 
@@ -549,7 +550,7 @@ RBMethodNode >> pragmaNamed: aSymbol ifPresent: presentBlock ifAbsent: absentBlo
 
 { #category : #accessing }
 RBMethodNode >> pragmas [
-	^ pragmas ifNil: [ #() ]
+	^ pragmas
 ]
 
 { #category : #accessing }
@@ -594,7 +595,7 @@ RBMethodNode >> reformatSource [
 { #category : #'adding/removing' }
 RBMethodNode >> removePragma: aPragmaNode [
 
-	pragmas remove: aPragmaNode ifAbsent: [ ]
+	pragmas := pragmas copyWithout: aPragmaNode
 ]
 
 { #category : #'adding/removing' }

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -144,7 +144,6 @@ RBMethodNode >> owningScope [
 
 { #category : #'*OpalCompiler-Core' }
 RBMethodNode >> primitiveFromPragma [
-	pragmas ifNil: [ ^ IRPrimitive null ].
 	^ pragmas
 		detect: [ :each | each isPrimitive ]
 		ifFound: [ :aPragmaPrimitive | aPragmaPrimitive asIRPrimitive ]


### PR DESCRIPTION
The reason I think is to not waste an OrdereCollection for each method that has no Pragmas.

This PR changed it to be initialized with an empty array (which later will be shared when we enable literal sharing) 
 
It changes to use an array for storage, this is no problem as adding pragmas is not happening at afte ran AST is created (they are created bu the compiler once).