### PR TITLE
7980-fix-checkClassRebuild

### DIFF
--- a/src/Epicea/Class.extension.st
+++ b/src/Epicea/Class.extension.st
@@ -2,25 +2,26 @@ Extension { #name : #Class }
 
 { #category : #'*Epicea' }
 Class >> asEpiceaRingDefinition [
-	
+
 	| ring |
 	ring := (RGClassDefinition named: self name)
-		category: self category;
-		superclassName: self superclass asString; "Note it's nil for ProtoObject"
-		traitCompositionSource: self traitCompositionString;
-		addInstanceVariables: self instVarNames;
-		addClassVariables: self classVarNames;
-		addSharedPools: self sharedPoolNames;
-		comment: self organization classComment;
-		stamp: self organization commentStamp;
-		definitionSource: self definition;
-		package: (EpPlatform current packageNameFor: self);
-		withMetaclass.
+		        category: self category;
+		        superclassName: self superclass asString;
+		        "Note it's nil for ProtoObject"traitCompositionSource:
+			        self traitCompositionString;
+		        addInstanceVariables: self instVarNames;
+		        addClassVariables: self classVarNames;
+		        addSharedPools: self sharedPoolNames;
+		        comment: self organization classComment;
+		        stamp: self organization commentStamp;
+		        definitionSource: self definitionString;
+		        package: (EpPlatform current packageNameFor: self);
+		        withMetaclass.
 
-	ring classSide 
+	ring classSide
 		traitCompositionSource: self classSide traitCompositionString;
-		definitionSource: self classSide definition;
-		addInstanceVariables: self classSide instVarNames.  
+		definitionSource: self classSide definitionString;
+		addInstanceVariables: self classSide instVarNames.
 
 	^ ring
 ]

--- a/src/Epicea/Metaclass.extension.st
+++ b/src/Epicea/Metaclass.extension.st
@@ -4,11 +4,11 @@ Extension { #name : #Metaclass }
 Metaclass >> asEpiceaRingDefinition [
 
 	| baseClassDefinition |
-	baseClassDefinition  := self instanceSide asEpiceaRingDefinition.
+	baseClassDefinition := self instanceSide asEpiceaRingDefinition.
 
-	^ baseClassDefinition withMetaclass classSide 
-		traitCompositionSource: self classSide traitCompositionString;
-		definitionSource: self classSide definition;
-		addInstanceVariables: self classSide instVarNames;
-		yourself
+	^ baseClassDefinition withMetaclass classSide
+		  traitCompositionSource: self classSide traitCompositionString;
+		  definitionSource: self classSide definitionString;
+		  addInstanceVariables: self classSide instVarNames;
+		  yourself
 ]

--- a/src/Kernel/UndefinedSlot.class.st
+++ b/src/Kernel/UndefinedSlot.class.st
@@ -36,7 +36,7 @@ UndefinedSlot >> checkClassRebuild [
 	(self definingClass environment hasClassNamed: self slotClassName) ifFalse: [ ^ self ].
 	classIsRebuild := true.
 	"we rebuild the class, this triggers instance migration"
-	self definingClass compiler evaluate: self definingClass definitionString.
+	(self definingClass compiler evaluate: self definingClass definitionString) install.
 	"recompile all methods that access me to generat code for the loaded definition"
 	self usingMethods do: [:each | each recompile].
 ]


### PR DESCRIPTION
- fix checkClassRebuild
- commit a deprecation transform in asEpiceaRingDefinition that comes from running all Slot tests

fixes #7980

