### PR TITLE
7966-Temporary-Variables-Cannot-be-used-in-loops-in-a-playground

### DIFF
--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -293,7 +293,7 @@ OCASTTranslator >> emitTimesRepeat: aMessageNode [
 	
 	limitEmit := [valueTranslator visitNode: limit].
 	"if the limit is not just a literal or a non-writable variable, make a temp store it there"
-	(limit isLiteralNode or: [limit isVariable and: [limit isWritable not]]) ifFalse: [
+	(limit isLiteralNode or: [limit isVariable and: [limit variable isWritable not]]) ifFalse: [
 		valueTranslator visitNode: limit.
 		methodBuilder addTemp: #'0limit'.
 		methodBuilder storeTemp: #'0limit'.

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -292,8 +292,8 @@ OCASTTranslator >> emitTimesRepeat: aMessageNode [
 	block := aMessageNode arguments last.
 	
 	limitEmit := [valueTranslator visitNode: limit].
-	"if the limit is not just a literal or variable, make a temp store it there"
-	(limit isLiteralNode or: [limit isVariable]) ifFalse: [
+	"if the limit is not just a literal or a non-writable variable, make a temp store it there"
+	(limit isLiteralNode or: [limit isVariable and: [limit isWritable not]]) ifFalse: [
 		valueTranslator visitNode: limit.
 		methodBuilder addTemp: #'0limit'.
 		methodBuilder storeTemp: #'0limit'.
@@ -349,8 +349,8 @@ OCASTTranslator >> emitToDo: aMessageNode step: step [
 	iterator := block arguments first variable.
 	
 	limitEmit := [valueTranslator visitNode: limit].
-	"if the limit is not just a literal or variable, make a temp store it there"
-	(limit isLiteralNode or: [limit isVariable]) ifFalse: [
+	"if the limit is not just a literal or a non-writable variable, make a temp store it there"
+	(limit isLiteralNode or: [limit isVariable and: [limit variable isWritable not]]) ifFalse: [
 		valueTranslator visitNode: limit.
 		methodBuilder addTemp: ('0limit_', iterator name).
 		methodBuilder storeTemp: ('0limit_', iterator name).

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -292,7 +292,8 @@ OCASTTranslator >> emitTimesRepeat: aMessageNode [
 	block := aMessageNode arguments last.
 	
 	limitEmit := [valueTranslator visitNode: limit].
-	limit isLiteral | limit isSelfVariable | limit isSuperVariable ifFalse: [
+	"if the limit is not just a literal or variable, make a temp store it there"
+	(limit isLiteralNode or: [limit isVariable]) ifFalse: [
 		valueTranslator visitNode: limit.
 		methodBuilder addTemp: #'0limit'.
 		methodBuilder storeTemp: #'0limit'.
@@ -348,7 +349,8 @@ OCASTTranslator >> emitToDo: aMessageNode step: step [
 	iterator := block arguments first variable.
 	
 	limitEmit := [valueTranslator visitNode: limit].
-	limit isLiteralNode | limit isSelfVariable | limit isSuperVariable | limit isArgumentVariable ifFalse: [
+	"if the limit is not just a literal or variable, make a temp store it there"
+	(limit isLiteralNode or: [limit isVariable]) ifFalse: [
 		valueTranslator visitNode: limit.
 		methodBuilder addTemp: ('0limit_', iterator name).
 		methodBuilder storeTemp: ('0limit_', iterator name).

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -36,6 +36,9 @@ OCRequestorScope >> lookupVar: name [
 	"reserved Variables are defined by the instance scope"
 	(ReservedVariable nameIsReserved: name) ifTrue: [ ^ outerScope lookupVar: name ].
 	
+	"generated temps (e.g. for limits in to:do: should not create bindings"
+	name first = $0 ifTrue: [ ^ outerScope lookupVar: name ].
+	
 	"We do not want to auto define bindings for unknown Globals"
 	(name isString and: [name first isUppercase]) ifTrue: [ ^ outerScope lookupVar: name].
 	


### PR DESCRIPTION
- Requestor scope should not define a variable if the name asked is that of a generated limit
- improve code for optimized #to:do: and #timesRepeat:

TODO: add tests, especially for the case of evaluating with a requestor that defines variables


