### PR TITLE
DelayBasicScheduler had debug code left from review

### DIFF
--- a/src/Kernel-Tests/DelayBasicSchedulerMicrosecondTickerTest.class.st
+++ b/src/Kernel-Tests/DelayBasicSchedulerMicrosecondTickerTest.class.st
@@ -22,9 +22,6 @@ Class {
 		'scheduler',
 		'suspendedDelaysHeap'
 	],
-	#classVars : [
-		'DebugMe'
-	],
 	#category : #'Kernel-Tests-Delays'
 }
 
@@ -38,13 +35,6 @@ DelayBasicSchedulerMicrosecondTickerTest >> classForTicker [
 	^ DelayMicrosecondTickerSimulation
 ]
 
-{ #category : #tests }
-DelayBasicSchedulerMicrosecondTickerTest >> setDebugOnOff [
-	"highlight and evaluate either of the following lines as needed" 
-		DebugMe := true.
-		DebugMe := false.
-]
-
 { #category : #running }
 DelayBasicSchedulerMicrosecondTickerTest >> setUp [
 	"Event loop priority takes So it takes priority over following code"
@@ -53,18 +43,6 @@ DelayBasicSchedulerMicrosecondTickerTest >> setUp [
 	suspendedDelaysHeap := self classForScheduler defaultSuspendedDelaysHeap.
 	scheduler := self classForScheduler onTicker: ticker suspendedDelaysHeap: suspendedDelaysHeap.
 	scheduler startTimerEventLoopPriority: Processor activePriority + 1. "So its slightly above normal priority of tests"
-	DebugMe ifNil: [ DebugMe := false ]. 
-	scheduler debug: DebugMe.
-
-]
-
-{ #category : #running }
-DelayBasicSchedulerMicrosecondTickerTest >> tearDown [
-"	scheduler debug: false."
-	scheduler debug: false.
-	super tearDown.
-	"scheduler stopTimerEventLoop."
-
 ]
 
 { #category : #tests }

--- a/src/Kernel/DelayBasicScheduler.class.st
+++ b/src/Kernel/DelayBasicScheduler.class.st
@@ -97,14 +97,6 @@ DelayBasicScheduler >> anyActive [
 	^activeDelay notNil
 ]
 
-{ #category : #'support - test cases' }
-DelayBasicScheduler >> debug: aBoolean [ 
-	"Guard against enabling halts in the system's active delay scheduler, which would lock the system"
-	(self  schedulingProcess == Delay schedulingProcess) ifTrue: [ ^self ].
-
-	debug := aBoolean
-]
-
 { #category : #initialization }
 DelayBasicScheduler >> initialize [
 	"Default configuration."
@@ -118,9 +110,7 @@ DelayBasicScheduler >> initialize [
 DelayBasicScheduler >> initializeTicker: aDelayTicker suspendedDelaysHeap: aHeap [
 	ticker := aDelayTicker.
 	suspendedDelays := aHeap.
-	timingSemaphore := Semaphore new.
-	debug := false.
-
+	timingSemaphore := Semaphore new
 ]
 
 { #category : #deprecated }
@@ -173,17 +163,10 @@ DelayBasicScheduler >> runBackendLoopAtTimingPriority [
 	 Invoked by api-system #startTimerEventLoop"
 
 	"Unit tests may run this at a lower priority" 
-
-	"Debug lines to help code review. Could be removed after a settling in period"
-	<haltOrBreakpointForTesting>
-
 	[  [runTimerEventLoop] whileTrue: 
 		[	|nowTick|
 			"Warning! Stepping <Over> the following line may lock the Image. Use <Into> or <Proceed>."
 		 	ticker waitForUserSignalled: timingSemaphore orExpired: activeDelay. 
-
-			"When two debuggers appear, step/proceed through this higher priority one first."
-			debug ifTrue: [ self halt ].		
 
 			"Invoke the api back-ends, which set the transfer-variable to nil" 		
 			suspendSemaphore ifNotNil: [ self suspendAtTimingPriority    ].
@@ -198,7 +181,6 @@ DelayBasicScheduler >> runBackendLoopAtTimingPriority [
 						activeDelay := suspendedDelays removeFirstOrNil ].
 		]
 	] ensure: [ "When timer event loop exits, expire remaining delays."
-		debug ifTrue: [ self halt ].
 		[activeDelay notNil] whileTrue: [
 				activeDelay timingPrioritySignalExpired.
 				activeDelay := suspendedDelays removeFirstOrNil ]].
@@ -206,12 +188,8 @@ DelayBasicScheduler >> runBackendLoopAtTimingPriority [
 
 { #category : #'user-api' }
 DelayBasicScheduler >> schedule: aDelay [
-	<haltOrBreakpointForTesting>
 	"This is the front-half of scheduling a delay. Invoked from user processes. 
 	 For back-half see #scheduleAtTimingPriority"
-
-	"Debug lines to help review. Could be removed after a settling in period"
-	debug ifTrue: [ self halt ].
 	
 	"Only one signal is sent when delay expires, and if that is already spoken for"
 	aDelay beingWaitedOn ifTrue: [^self error: 'This Delay has already been scheduled.'].
@@ -223,9 +201,6 @@ DelayBasicScheduler >> schedule: aDelay [
 	 Subclasses provide addition protections to lessen the importance of these semantics."
 	delayToStart := aDelay.
 	timingSemaphore signal. "Transfer execution to back-end #scheduleAtTimingPriority"
-	
-	debug ifTrue: [ self halt. "If debugger appeared for timingPriority thread, step through that first" ]
-
 ]
 
 { #category : #'private - timing priority process' }
@@ -307,7 +282,7 @@ DelayBasicScheduler >> stopTimerEventLoop [
 	but things can get out of order with multi-threaded debuggin. Ensure its terminated." 
 	timerEventLoop isTerminated  
 		ifFalse: [ 
-			debug ifFalse: [ self error: 'Expected timing priority event loop terminated already'].
+			self error: 'Expected timing priority event loop terminated already'.
 			timerEventLoop terminate ].
 	timerEventLoop := nil.
 ]
@@ -328,17 +303,12 @@ DelayBasicScheduler >> suspend [
 
 { #category : #'private - timing priority process' }
 DelayBasicScheduler >> suspendAtTimingPriority [
-	<haltOrBreakpointForTesting>
 	"Private! This is the front-half for suspending the delay scheduler to prevent
 	 wake-up of delayed threads in the middle of snapshotting. For front-half see #suspend"
-	debug ifTrue: [ self halt ].
 	
 	ticker saveResumptionTimes: suspendedDelays asArray, {activeDelay}.
-	
 	"Warning! Stepping <Over> the following line may lock the Image. Use <Proceed>."
 	suspendSemaphore wait.
-	
-	debug ifTrue: [ self halt ].
 	
 	ticker restoreResumptionTimes: suspendedDelays asArray, {activeDelay}.  
 	suspendSemaphore := nil
@@ -352,12 +322,8 @@ DelayBasicScheduler >> ticker [
 
 { #category : #'user-api' }
 DelayBasicScheduler >> unschedule: aDelay [
-	<haltOrBreakpointForTesting>
 	"This is the front-half of unscheduling a delay. Invoked from user processes. 
 	 For back-half see #unscheduleAtTimingPriority"
-
-	"Debug lines to help review. Could be removed after a settling in period"
-	debug ifTrue: [ self halt ].
 
 	"The basic scheduler is highly dependant on semantics of cooperative multitasking and 
 	 bytecode inlining such that interuption *cannot* occur between the assignment and the signal.
@@ -366,10 +332,6 @@ DelayBasicScheduler >> unschedule: aDelay [
 	 Subclasses add protection against this."
 	delayToStop := aDelay.
 	timingSemaphore signal. "Transfer execution to #unscheduleAtTimingPriority"
-	
-	debug ifTrue: [ self halt. "If timingPriority thread debugger appears, step through it first" ]
-
-
 ]
 
 { #category : #'private - timing priority process' }


### PR DESCRIPTION
"Debug lines to help review. Could be removed after a settling in period"

- This PR removes all the references to the debug ivar (and the related halt sends)
- It cleans up the test 

What needs to be done later is to remove the debug ivar, that can not be done in a running image.