### PR TITLE
Fixing mem leak after debugger proceeding

### DIFF
--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -378,19 +378,16 @@ StDebugger >> canExecuteRestartCommand [
 
 { #category : #actions }
 StDebugger >> clear [
-	
-	extensionToolsNotebook pages
-		do: [ :page | page activePresenter windowIsClosing ].
+
+	extensionToolsNotebook pages do: [ :page | 
+		page activePresenter windowIsClosing ].
 	extensionTools := nil.
+	self unsubscribeFromSystemAnnouncer.
 	self removeActionsForSession: self session.
 
-	"If I have been proceeded the window has been closed programmatically and I do not need to do this".
-	programmaticallyClosed 
-		ifTrue: [ ^self ].
-
-	self debuggerActionModel clearDebugSession.
-	self unsubscribeFromSystemAnnouncer
-	
+	"When we programmatically close the window, we do not need to terminate the session as it was already cleared"
+	programmaticallyClosed ifTrue: [ ^ self ].
+	debuggerActionModel clearDebugSession
 ]
 
 { #category : #'updating widgets' }
@@ -410,8 +407,10 @@ StDebugger >> clearUnsavedCodeChanges [
 
 { #category : #opening }
 StDebugger >> close [
-	self unsubscribeFromSystemAnnouncer.
-	self withWindowDo: #close
+
+	programmaticallyClosed := true.
+	[ self withWindowDo: #close ] ensure: [ 
+		self debuggerActionModel clearDebugSession ]
 ]
 
 { #category : #'accessing widgets' }
@@ -804,9 +803,9 @@ StDebugger >> printReceiverClassInContext: aContext [
 ]
 
 { #category : #actions }
-StDebugger >> proceedDebugSession [ 
+StDebugger >> proceedDebugSession [
 
-	programmaticallyClosed := true.
+	self removeActionsForSession: self session.
 	self debuggerActionModel proceedDebugSession.
 	self close
 ]

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -87,7 +87,7 @@ Class {
 		'toolbarCommandGroup',
 		'debuggerActionModel',
 		'unsavedCodeChanges',
-		'hasProceeded'
+		'programmaticallyClosed'
 	],
 	#classVars : [
 		'ActivateDebuggerExtensions',
@@ -385,7 +385,7 @@ StDebugger >> clear [
 	self removeActionsForSession: self session.
 
 	"If I have been proceeded the window has been closed programmatically and I do not need to do this".
-	hasProceeded 
+	programmaticallyClosed 
 		ifTrue: [ ^self ].
 
 	self debuggerActionModel clearDebugSession.
@@ -598,7 +598,7 @@ StDebugger >> initialize [
 	self forceSessionUpdate.
 	self subscribeToMethodAddedAnnouncement.
 	
-	hasProceeded := false.
+	programmaticallyClosed := false.
 ]
 
 { #category : #initialization }
@@ -806,7 +806,7 @@ StDebugger >> printReceiverClassInContext: aContext [
 { #category : #actions }
 StDebugger >> proceedDebugSession [ 
 
-	hasProceeded := true.
+	programmaticallyClosed := true.
 	self debuggerActionModel proceedDebugSession.
 	self close
 ]

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -32,8 +32,11 @@ StDebuggerActionModel >> autoClassifyMessage: aMessage inClass: aClass [
 
 { #category : #'debug - execution' }
 StDebuggerActionModel >> clearDebugSession [
+
 	contextPredicate := nil.
-	self session terminate
+	self session
+		terminate;
+		clear
 ]
 
 { #category : #context }


### PR DESCRIPTION
This is a NewTools mirror fix, fixing memory leaks issues with the debugger:
- https://github.com/pharo-spec/NewTools/issues/136
- https://github.com/pharo-spec/NewTools/issues/125 (for real)

Basically, when a debugger is opened to debug a UI process, another ui process is spawned so that we can debug the first one and we need to terminate this process after debuggging. This is done by terminating the debug session. 

However:
- Proceeding the execution programmatically closes the debugger, first by resuming the debug session then by terminating it, which happens in a function called by the spec window closing mechanism through a callback. This somehow prevents the spec mechanism to go through the end of its closing procedure, and leaks instances of `SpWindow` (https://github.com/pharo-spec/NewTools/issues/125). I still do not understand the details of that problem.
- If we do not terminate the session in the callback (for instance when using the close button), the ui process created for debugging is never terminated and haunts the image (https://github.com/pharo-spec/NewTools/issues/136).

The problem is solved by:
- Separating the closing from the proceed button and the close button, and not terminating the session in the first case,
- ensuring that when we programmatically close the debugger with the proceed button, the debug session is terminated.

I am not super happy by this fix, and it will be further investigated to produce a nice solution --- but for now it is needed.