### PR TITLE
7993-Completion-broken-while-editing

### DIFF
--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -124,7 +124,7 @@ CoASTResultSetBuilder >> visitGlobalVariableNode: aRBVariableNode [
 
 { #category : #visiting }
 CoASTResultSetBuilder >> visitInstanceVariableNode: aRBVariableNode [ 
-	^ self visitNode: aRBVariableNode
+	^ self visitVariableNode: aRBVariableNode
 ]
 
 { #category : #visiting }

--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -75,10 +75,10 @@ CoASTResultSetBuilder >> parseNode [
 			parse) nodeForOffset: completionContext position ] 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #visiting }
 CoASTResultSetBuilder >> visitArgumentVariableNode: anArgumentNode [
 
-	^ self visitTemporaryNode: anArgumentNode
+	^ self visitVariableNode: anArgumentNode
 ]
 
 { #category : #visiting }
@@ -105,10 +105,10 @@ CoASTResultSetBuilder >> visitCascadeNode: aRBCascadeNode [
 	^ self visitNode: aRBCascadeNode
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #visiting }
 CoASTResultSetBuilder >> visitClassVariableNode: aRBVariableNode [
 
-	^ self visitGlobalNode: aRBVariableNode
+	^ self visitVariableNode: aRBVariableNode
 ]
 
 { #category : #visiting }
@@ -117,7 +117,7 @@ CoASTResultSetBuilder >> visitEnglobingErrorNode: aRBVariableNode [
 ]
 
 { #category : #visiting }
-CoASTResultSetBuilder >> visitGlobalNode: aRBVariableNode [
+CoASTResultSetBuilder >> visitGlobalVariableNode: aRBVariableNode [
 
 	^ self visitVariableNode: aRBVariableNode
 ]
@@ -139,9 +139,9 @@ CoASTResultSetBuilder >> visitLiteralValueNode: aRBLiteralValueNode [
 	^ self visitNode: aRBLiteralValueNode
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #visiting }
 CoASTResultSetBuilder >> visitLiteralVariableNode: aRBVariableNode [
-	^ self visitGlobalNode: aRBVariableNode
+	^ self visitVariableNode: aRBVariableNode
 ]
 
 { #category : #visiting }
@@ -199,15 +199,9 @@ CoASTResultSetBuilder >> visitSuperNode: aRBSuperNode [
 ]
 
 { #category : #visiting }
-CoASTResultSetBuilder >> visitTemporaryNode: aRBReturnNode [ 
-	
-	^ self visitNode: aRBReturnNode
-]
-
-{ #category : #'as yet unclassified' }
 CoASTResultSetBuilder >> visitTemporaryVariableNode: anArgumentNode [
 
-	^ self visitTemporaryNode: anArgumentNode
+	^ self visitVariableNode: anArgumentNode
 ]
 
 { #category : #visiting }

--- a/src/HeuristicCompletion-Tests/CoASTResultSetBuilderTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoASTResultSetBuilderTest.class.st
@@ -182,6 +182,32 @@ CoASTResultSetBuilderTest >> testBuildThisContextHeuristic [
 ]
 
 { #category : #tests }
+CoASTResultSetBuilderTest >> testBuildVariableClassVariableHeuristic [
+
+	| builder |
+	builder := CoMockASTResultSetBuilder new.
+	builder
+		completionContext: self newCompletionContext;
+		node: ((RBVariableNode named: 'ClassVar') variable: (ClassVariable named: 'ClassVar'));
+		buildCompletion.
+		
+	self assert: builder heuristic equals: #variable
+]
+
+{ #category : #tests }
+CoASTResultSetBuilderTest >> testBuildVariableGlobalHeuristic [
+
+	| builder |
+	builder := CoMockASTResultSetBuilder new.
+	builder
+		completionContext: self newCompletionContext;
+		node: ((RBVariableNode named: 'Object') variable: Object binding);
+		buildCompletion.
+		
+	self assert: builder heuristic equals: #variable
+]
+
+{ #category : #tests }
 CoASTResultSetBuilderTest >> testBuildVariableHeuristic [
 
 	| builder |
@@ -189,6 +215,45 @@ CoASTResultSetBuilderTest >> testBuildVariableHeuristic [
 	builder
 		completionContext: self newCompletionContext;
 		node: RBVariableNode new;
+		buildCompletion.
+		
+	self assert: builder heuristic equals: #variable
+]
+
+{ #category : #tests }
+CoASTResultSetBuilderTest >> testBuildVariableInstanceVariableHeuristic [
+
+	| builder |
+	builder := CoMockASTResultSetBuilder new.
+	builder
+		completionContext: self newCompletionContext;
+		node: ((RBVariableNode named: 'ivar') variable: (Slot named: 'ivar'));
+		buildCompletion.
+		
+	self assert: builder heuristic equals: #variable
+]
+
+{ #category : #tests }
+CoASTResultSetBuilderTest >> testBuildVariableTempVariableHeuristic [
+
+	| builder |
+	builder := CoMockASTResultSetBuilder new.
+	builder
+		completionContext: self newCompletionContext;
+		node: ((RBVariableNode named: 'temp') variable: (TemporaryVariable named: 'temp'));
+		buildCompletion.
+		
+	self assert: builder heuristic equals: #variable
+]
+
+{ #category : #tests }
+CoASTResultSetBuilderTest >> testBuildVariableUndeclaredHeuristic [
+
+	| builder |
+	builder := CoMockASTResultSetBuilder new.
+	builder
+		completionContext: self newCompletionContext;
+		node: ((RBVariableNode named: 'ClassVar') variable: (UndeclaredVariable named: 'ClassVar'));
 		buildCompletion.
 		
 	self assert: builder heuristic equals: #variable


### PR DESCRIPTION
- Make sure that CoASTResultSetBuilder implements the new visitor methods for Global/Temp/Arg variables.
- #visitGlobalNode: and #visitTemporaryNode: can be removed

fixes #7993

