### PR TITLE
Fixed #8014. Renamed Random >> nextInt: and nextIntBetween:and: to nextInteger: and nextIntegerBetween:and:

### DIFF
--- a/src/AST-Core-Tests/NumberParserTest.class.st
+++ b/src/AST-Core-Tests/NumberParserTest.class.st
@@ -165,8 +165,8 @@ NumberParserTest >> testFloatPrintString [
 	"printing a Float in base other than 10 is broken if lowercase digits are allowed"
 	bases := self areLowercaseDigitsAllowed ifTrue: [ #(10) ] ifFalse: [ #(2 8 10 16) ].
 	100
-		timesRepeat: [ f basicAt: 1 put: (r nextInt: 16r100000000) - 1.
-			f basicAt: 2 put: (r nextInt: 16r100000000) - 1.
+		timesRepeat: [ f basicAt: 1 put: (r nextInteger: 16r100000000) - 1.
+			f basicAt: 2 put: (r nextInteger: 16r100000000) - 1.
 			bases
 				do: [ :base | 
 					| str |
@@ -179,8 +179,8 @@ NumberParserTest >> testFloatPrintString [
 					self assert: (NumberParser parse: str contents) equals: f ] ].
 	"test big num near infinity"
 	10
-		timesRepeat: [ f basicAt: 1 put: 16r7FE00000 + ((r nextInt: 16r100000) - 1).
-			f basicAt: 2 put: (r nextInt: 16r100000000) - 1.
+		timesRepeat: [ f basicAt: 1 put: 16r7FE00000 + ((r nextInteger: 16r100000) - 1).
+			f basicAt: 2 put: (r nextInteger: 16r100000000) - 1.
 			bases
 				do: [ :base | 
 					| str |
@@ -193,8 +193,8 @@ NumberParserTest >> testFloatPrintString [
 					self assert: (NumberParser parse: str contents) equals: f ] ].
 	"test infinitesimal (gradual underflow)"
 	10
-		timesRepeat: [ f basicAt: 1 put: 0 + ((r nextInt: 16r100000) - 1).
-			f basicAt: 2 put: (r nextInt: 16r100000000) - 1.
+		timesRepeat: [ f basicAt: 1 put: 0 + ((r nextInteger: 16r100000) - 1).
+			f basicAt: 2 put: (r nextInteger: 16r100000000) - 1.
 			bases
 				do: [ :base | 
 					| str |

--- a/src/Collections-Abstract/SequenceableCollection.class.st
+++ b/src/Collections-Abstract/SequenceableCollection.class.st
@@ -2080,7 +2080,7 @@ SequenceableCollection >> shuffleBy: aRandom [
 	"#(1 2 3 4 5) shuffleBy: (Random seed: 42) >>> #(2 5 4 3 1)"
 
 	self size to: 2 by: -1 do: [ :i | 
-		self swap: i with: (aRandom nextInt: i) ]
+		self swap: i with: (aRandom nextInteger: i) ]
 ]
 
 { #category : #copying }

--- a/src/Files/Stdio.class.st
+++ b/src/Files/Stdio.class.st
@@ -48,7 +48,7 @@ Stdio class >> createStdioFileFor: moniker [
 		do:
 			[ "HACK: if the image is opened a second time windows barks about the already opened locked file"
 			 self createWriteStreamBlock
-				cull: moniker asString , '_' , (Random new nextInt: SmallInteger maxVal) asString ]
+				cull: moniker asString , '_' , (Random new nextInteger: SmallInteger maxVal) asString ]
 	 ] on: FileException do: [ NullStream new ] 
 ]
 

--- a/src/Hiedra-Examples/HiExampleCommit.class.st
+++ b/src/Hiedra-Examples/HiExampleCommit.class.st
@@ -24126,7 +24126,7 @@ HiExampleCommit class >> randomlyGenerated [
 		self new
 			id: value;
 			comment: 'Randomly Connected Element #', value asString;
-			parentIds: ((values copyWithout: value) intersection: { random nextInt: values max });
+			parentIds: ((values copyWithout: value) intersection: { random nextInteger: values max });
 			yourself
 		]) reversed
 ]

--- a/src/Kernel-Tests-Extended/FloatTest.extension.st
+++ b/src/Kernel-Tests-Extended/FloatTest.extension.st
@@ -393,7 +393,7 @@ FloatTest >> testFractionAsFloat [
 	r := Random new seed: 1234567.
 	m := (2 raisedTo: 54) - 1.
 	200 timesRepeat: [
-		frac := ((r nextInt: m) * (r nextInt: m) + 1) / ((r nextInt: m) * (r nextInt: m) + 1).
+		frac := ((r nextInteger: m) * (r nextInteger: m) + 1) / ((r nextInteger: m) * (r nextInteger: m) + 1).
 		err := (frac - frac asFloat asTrueFraction) * frac reciprocal * (1 bitShift: 52).
 		self assert: err < (1/2)].
 	

--- a/src/Kernel-Tests/DelayBenchmark.class.st
+++ b/src/Kernel-Tests/DelayBenchmark.class.st
@@ -87,7 +87,7 @@ DelayBenchmark >> generateDelayProcesses: numberConcurrent priority: priority ma
 	sampleDurations := Array new: 1000.  
 	1 to: sampleDurations size do:
 	[  	:index | 
-		sampleDurations at: index put: (randomGenerator nextInt: maxDuration).
+		sampleDurations at: index put: (randomGenerator nextInteger: maxDuration).
 	].
 	sampleIndex := 0.
 

--- a/src/Kernel-Tests/LargePositiveIntegerTest.class.st
+++ b/src/Kernel-Tests/LargePositiveIntegerTest.class.st
@@ -132,8 +132,8 @@ LargePositiveIntegerTest >> testReciprocalModulo [
 	r := Random seed: 46912151.
 	4691
 		timesRepeat: [ | a b c t |
-			a := (r nextInt: large) + 1.
-			b := (r nextInt: large) + 1.
+			a := (r nextInteger: large) + 1.
+			b := (r nextInteger: large) + 1.
 			a > b
 				ifTrue: [ t := a.
 					a := b.

--- a/src/Network-UUID/UUIDGenerator.class.st
+++ b/src/Network-UUID/UUIDGenerator.class.st
@@ -149,7 +149,7 @@ UUIDGenerator >> nextCounter16 [
 UUIDGenerator >> nextRandom16 [
 	"Return the next 16-bit random value from my random generator"
 
-	^ (random nextInt: 16r10000) - 1
+	^ (random nextInteger: 16r10000) - 1
 ]
 
 { #category : #private }

--- a/src/Random-Core/Bag.extension.st
+++ b/src/Random-Core/Bag.extension.st
@@ -9,7 +9,7 @@ Bag >> atRandom: aGenerator [
 
 	| index |
  	self emptyCheck.
- 	index := aGenerator nextInt: self size.
+ 	index := aGenerator nextInteger: self size.
  	"overwritten to use a faster enumeration"
  	self doWithOccurrences: [ :key :count | 
  		(index := index - count) <= 0 ifTrue: [ ^key ] ]

--- a/src/Random-Core/Collection.extension.st
+++ b/src/Random-Core/Collection.extension.st
@@ -26,6 +26,6 @@ Collection >> atRandom: aGenerator [
 	| rand |
 
 	self emptyCheck.
-	rand := aGenerator nextInt: self size.
+	rand := aGenerator nextInteger: self size.
 	self withIndexDo: [:each :index | index = rand ifTrue: [^each]]
 ]

--- a/src/Random-Core/Integer.extension.st
+++ b/src/Random-Core/Integer.extension.st
@@ -15,5 +15,5 @@ Integer >> atRandom [
 Integer >> atRandom: aGenerator [
 	"Answer a random integer from 1 to self picked from aGenerator."
 
-	^ aGenerator nextInt: self
+	^ aGenerator nextInteger: self
 ]

--- a/src/Random-Core/OrderedDictionary.extension.st
+++ b/src/Random-Core/OrderedDictionary.extension.st
@@ -3,5 +3,5 @@ Extension { #name : #OrderedDictionary }
 { #category : #'*Random-Core' }
 OrderedDictionary >> atRandom: aGenerator [
 	self emptyCheck.
-	^ self at: (self orderedKeys at: (aGenerator nextInt: self size)) 
+	^ self at: (self orderedKeys at: (aGenerator nextInteger: self size)) 
 ]

--- a/src/Random-Core/Random.class.st
+++ b/src/Random-Core/Random.class.st
@@ -117,6 +117,29 @@ Random >> nextInt: anInteger [
 	"Answer a random integer in the interval [1, anInteger].
 	Handle large numbers too (for cryptography)."
 
+	self
+		deprecated: 'Use #nextInteger: instead'
+		transformWith: '`@rec nextInt: `@arg' -> '`@rec nextInteger: `@arg'.
+		
+	^ self nextInteger: anInteger
+]
+
+{ #category : #accessing }
+Random >> nextIntBetween: lowerBound and: higherBound [
+	"Answer a random integer number from the inclusive range [lowerBound, higherBound]"
+	
+	self
+		deprecated: 'Use #nextIntegerBetween:and: instead'
+		transformWith: '`@rec nextIntBetween: `@arg1 and: `@arg2' -> '`@rec nextIntegerBetween: `@arg1 and: `@arg2'.
+		
+	^ self nextIntegerBetween: lowerBound and: higherBound
+]
+
+{ #category : #accessing }
+Random >> nextInteger: anInteger [
+	"Answer a random integer in the interval [1, anInteger].
+	Handle large numbers too (for cryptography)."
+
 	anInteger strictlyPositive ifFalse: [ self error: 'Range must be positive' ].
 	anInteger asFloat isInfinite "are we outside the range of float? - use fraction"
 		ifTrue: [^(self privateNextValue asFraction * anInteger) truncated + 1].
@@ -124,9 +147,9 @@ Random >> nextInt: anInteger [
 ]
 
 { #category : #accessing }
-Random >> nextIntBetween: lowerBound and: higherBound [
+Random >> nextIntegerBetween: lowerBound and: higherBound [
 	"Answer a random integer number from the inclusive range [lowerBound, higherBound]"
-	^ lowerBound + (self nextInt: (higherBound - lowerBound + 1)) - 1
+	^ lowerBound + (self nextInteger: (higherBound - lowerBound + 1)) - 1
 ]
 
 { #category : #private }

--- a/src/Random-Core/SequenceableCollection.extension.st
+++ b/src/Random-Core/SequenceableCollection.extension.st
@@ -8,5 +8,5 @@ SequenceableCollection >> atRandom: aGenerator [
 	because only you use the generator.  Causes an error if self has no 
 	elements."
 
-	^ self at: (aGenerator nextInt: self size)
+	^ self at: (aGenerator nextInteger: self size)
 ]

--- a/src/Random-Core/Set.extension.st
+++ b/src/Random-Core/Set.extension.st
@@ -9,7 +9,7 @@ Set >> atRandom: aGenerator [
 	| index |
 
 	self emptyCheck.
-	index := aGenerator nextInt: array size.
+	index := aGenerator nextInteger: array size.
 	[ (array at: index) isNil ] whileTrue: [ index := index \\ array size + 1 ].
 	^ array at: index.
 ]

--- a/src/Random-Core/SharedRandom.class.st
+++ b/src/Random-Core/SharedRandom.class.st
@@ -49,6 +49,6 @@ SharedRandom >> next: anInteger into: anArray [
 ]
 
 { #category : #accessing }
-SharedRandom >> nextInt: anInteger [
-    ^ mutex critical: [ super nextInt: anInteger ].
+SharedRandom >> nextInteger: anInteger [
+    ^ mutex critical: [ super nextInteger: anInteger ].
 ]

--- a/src/Random-Tests/RandomTest.class.st
+++ b/src/Random-Tests/RandomTest.class.st
@@ -72,19 +72,19 @@ RandomTest >> testNextBetweenAnd [
 ]
 
 { #category : #tests }
-RandomTest >> testNextInt [
+RandomTest >> testNextInteger [
 	| int |
-	int := gen nextInt: 256.
+	int := gen nextInteger: 256.
 	self assert: int isInteger.
 	self assert: (int between: 1 and: 256)
 ]
 
 { #category : #tests }
-RandomTest >> testNextIntBetweenAnd [
+RandomTest >> testNextIntegerBetweenAnd [
 	
 	10000 timesRepeat: [ 
 		| next | 
-		next := gen nextIntBetween: -3 and: 5.
+		next := gen nextIntegerBetween: -3 and: 5.
 		self assert: next isInteger.
 		self assert: (next between: -3 and: 5) ].
 ]

--- a/src/Spec-Tests/RGBSlidersTest.class.st
+++ b/src/Spec-Tests/RGBSlidersTest.class.st
@@ -13,9 +13,9 @@ RGBSlidersTest >> classToTest [
 RGBSlidersTest >> testColor [
 	| random red green blue |
 	random := Random new.
-	red := random nextInt: 255.
-	green := random nextInt: 255.
-	blue := random nextInt: 255.
+	red := random nextInteger: 255.
+	green := random nextInteger: 255.
+	blue := random nextInteger: 255.
 
 	testedInstance redSlider value: red.
 	testedInstance greenSlider value: green.

--- a/src/Spec2-Morphic-Tests/SpRGBSlidersTest.class.st
+++ b/src/Spec2-Morphic-Tests/SpRGBSlidersTest.class.st
@@ -13,9 +13,9 @@ SpRGBSlidersTest >> classToTest [
 SpRGBSlidersTest >> testColor [
 	| random red green blue |
 	random := Random new.
-	red := random nextInt: 255.
-	green := random nextInt: 255.
-	blue := random nextInt: 255.
+	red := random nextInteger: 255.
+	green := random nextInteger: 255.
+	blue := random nextInteger: 255.
 	
 	presenter redSlider value: red.
 	presenter greenSlider value: green.


### PR DESCRIPTION
Renamed Random >> nextInt: and nextIntBetween:and: to nextInteger: and nextIntegerBetween:and:. Fixed all senders, comments, and tests. Deprecated old methods