### PR TITLE
ReSendsUnknownMessageToGlobalRule laments wrongly on class variables

### DIFF
--- a/src/GeneralRules/ReSendsUnknownMessageToGlobalRule.class.st
+++ b/src/GeneralRules/ReSendsUnknownMessageToGlobalRule.class.st
@@ -20,6 +20,8 @@ ReSendsUnknownMessageToGlobalRule >> basicCheck: aNode [
 
 	aNode receiver isLiteralVariable ifFalse: [ ^ false ].
 	aNode receiver isUndeclaredVariable ifTrue: [ ^false ].
+	aNode receiver isClassVariable ifTrue: [ ^false ].
+	
 	^ (aNode receiver variable value respondsTo: aNode selector) not
 ]
 


### PR DESCRIPTION
Fix #8030