### PR TITLE
8037-Scrolling-messages-leads-to-red-square-of-death

### DIFF
--- a/src/Calypso-SystemQueries/ClyItemDefinitionProperty.class.st
+++ b/src/Calypso-SystemQueries/ClyItemDefinitionProperty.class.st
@@ -112,6 +112,11 @@ ClyItemDefinitionProperty >> printDefiningClass [
 		ifFalse: [ definingClassItem name, ' class']
 ]
 
+{ #category : #printing }
+ClyItemDefinitionProperty >> printDefiningProtocol [
+	^ 'no protocol'
+]
+
 { #category : #'printing items' }
 ClyItemDefinitionProperty >> printDefinition [
 


### PR DESCRIPTION
fixes: #8037 well probably due to the support to display protocol introduced some months ago.