### PR TITLE
CoTypeInferencer should inherit from RBProgramNodeVisitor

### DIFF
--- a/src/HeuristicCompletion-Model/CoTypeInferencer.class.st
+++ b/src/HeuristicCompletion-Model/CoTypeInferencer.class.st
@@ -4,7 +4,7 @@ That is, I infer a method up to a certain level of the callgraph.
 "
 Class {
 	#name : #CoTypeInferencer,
-	#superclass : #Object,
+	#superclass : #RBProgramNodeVisitor,
 	#instVars : [
 		'returnType',
 		'variables',


### PR DESCRIPTION
This way it inherits backward compatible methods for e.g. #visitGlobalVariableNode: