### PR TITLE
8036-Spotter-uses-definition-for-class-instead-of-definitionString

### DIFF
--- a/src/CodeExport/ClassDescription.extension.st
+++ b/src/CodeExport/ClassDescription.extension.st
@@ -71,7 +71,7 @@ ClassDescription >> fileOutMethod: selector on: aStream [
 ClassDescription >> fileOutOn: aFileStream [
 	"File a description of the receiver on aFileStream."
 
-	aFileStream nextChunkPut: self definition.
+	aFileStream nextChunkPut: self definitionString.
 	self organization putCommentOnFile: aFileStream forClass: self.
 	self organization categories 
 		do: [ :heading | self fileOutLocalMethodsInCategory: heading on: aFileStream ]

--- a/src/Epicea/MetaclassForTraits.extension.st
+++ b/src/Epicea/MetaclassForTraits.extension.st
@@ -8,6 +8,6 @@ MetaclassForTraits >> asEpiceaRingDefinition [
 
 	^ baseClassDefinition withMetaclass classSide 
 		traitCompositionSource: self classSide traitCompositionString;
-		definitionSource: self classSide definition;
+		definitionSource: self classSide definitionString;
 		yourself
 ]

--- a/src/GT-SpotterExtensions-Core/Class.extension.st
+++ b/src/GT-SpotterExtensions-Core/Class.extension.st
@@ -47,7 +47,7 @@ Class >> spotterPreviewIn: aComposite [
 	<spotterPreview: 10>
 	aComposite pharoMethod
 		title: [self name];
-		display: #definition;
+		display: [:each | each definitionString];
 		smalltalkClass: [ nil ];
 		entity: self.
 		

--- a/src/GT-SpotterExtensions-Core/Class.extension.st
+++ b/src/GT-SpotterExtensions-Core/Class.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #Class }
 Class >> definitionForSpotter [
 	| str |
 	str := WriteStream on: String new.
-	str nextPutAll: self definition.
+	str nextPutAll: self definitionString.
 	str cr; cr.
 	str nextPut: $".
 	str nextPutAll: 'Hierarchy: '.

--- a/src/NewTools-Inspector-Extensions/Class.extension.st
+++ b/src/NewTools-Inspector-Extensions/Class.extension.st
@@ -46,6 +46,6 @@ Class >> inspectionClassDefinition [
 	
 	^ SpCodePresenter new
 		beForScripting;
-		text: self definition;
+		text: self definitionString;
 		beNotEditable
 ]


### PR DESCRIPTION
fixes: #8036 tryingt o fix spotter using definition instead of definitionString