### PR TITLE
Bootstrapper in 64 and 32 bits

### DIFF
--- a/bootstrap/scripts/1-clean.sh
+++ b/bootstrap/scripts/1-clean.sh
@@ -9,7 +9,7 @@ SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 
 . ${SCRIPTS}/envvars.sh
 
-rm -f bootstrapImage.zip
+rm -f bootstrapImage*.zip
 rm -f Pharo.image Pharo.changes pharo pharo-ui
 rm -rf pharo-vm
 rm -rf pharo-local

--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -13,13 +13,19 @@ SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 
 mkdir -p "${BOOTSTRAP_CACHE}" #required to generate hermes files
 
-${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/getPharoVM.sh 70
-wget --progress=dot:mega https://github.com/carolahp/PharoBootstrap/releases/download/v1.7.0/bootstrapImage.zip
-unzip bootstrapImage.zip
+${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/getPharoVM.sh 70 vm $BOOTSTRAPPER_ARCH
+if [ ${BOOTSTRAPPER_ARCH} = 64 ] 
+	then SUFFIX=${BOOTSTRAPPER_ARCH} 
+fi
+
+wget --progress=dot:mega https://github.com/carolahp/PharoBootstrap/releases/download/v1.7.0/bootstrapImage${SUFFIX}.zip
+
+unzip bootstrapImage${SUFFIX}.zip
 
 cd "${BOOTSTRAP_CACHE}"
 #We need the old sources file next to the image because of sources condensation step
 wget --progress=dot:mega http://files.pharo.org/sources/PharoV60.sources
+
 echo "Prepare icons"
 mkdir icon-packs
 cd icon-packs
@@ -37,4 +43,3 @@ then
     cd -
 fi
 echo "Target VM: $(${VM} --version | grep Hash)"
-

--- a/bootstrap/scripts/envvars.sh
+++ b/bootstrap/scripts/envvars.sh
@@ -15,6 +15,7 @@
 # - BOOTSTRAP_VMTARGET		# Location of the target VM
 #				  This can be set when a custom VM is to be 
 #				  used during bootstrap.
+# - BOOTSTRAPPER_ARCH   # The architecture of the VM and image used to execute the bootstrap process
 #
 if [ -z ${BUILD_NUMBER+x} ]
 then
@@ -50,7 +51,7 @@ else
     VM="${BOOTSTRAP_VMTARGET}/pharo --headless"
 fi
 
-# This is the VM used to bootstrap, i.e. the target VM
+# The architecture of the VM and image used to execute the bootstrap process
 if [ -z ${BOOTSTRAPPER_ARCH+x} ]
 then
     BOOTSTRAPPER_ARCH=32

--- a/bootstrap/scripts/envvars.sh
+++ b/bootstrap/scripts/envvars.sh
@@ -50,6 +50,13 @@ else
     VM="${BOOTSTRAP_VMTARGET}/pharo --headless"
 fi
 
+# This is the VM used to bootstrap, i.e. the target VM
+if [ -z ${BOOTSTRAPPER_ARCH+x} ]
+then
+    BOOTSTRAPPER_ARCH=32
+fi
+export BOOTSTRAPPER_ARCH
+
 # Flags to run the image
 IMAGE_FLAGS="--no-default-preferences"
 

--- a/bootstrap/scripts/envvars.sh
+++ b/bootstrap/scripts/envvars.sh
@@ -54,7 +54,7 @@ fi
 # The architecture of the VM and image used to execute the bootstrap process
 if [ -z ${BOOTSTRAPPER_ARCH+x} ]
 then
-    BOOTSTRAPPER_ARCH=32
+    BOOTSTRAPPER_ARCH=64
 fi
 export BOOTSTRAPPER_ARCH
 


### PR DESCRIPTION
Implementing the optional argument BOOTSTRAPPER_ARCH to define the architecture of the Pharo system that runs the bootstrap process (32 or 64 bits).
When not specified, its default value is 64 bits.

Use as follows: 
```BUILD_NUMBER=42 BOOTSTRAP_ARCH=32 BOOTSTRAPPER_ARCH=32 bash ./bootstrap/scripts/bootstrap.sh```

