### PR TITLE
RBGenericNodeVisitor-tests 

### DIFF
--- a/src/AST-Core-Tests/RBCommentNodeVisitorTest.class.st
+++ b/src/AST-Core-Tests/RBCommentNodeVisitorTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for RBCommentNodeVisitor
 Class {
 	#name : #RBCommentNodeVisitorTest,
 	#superclass : #RBParseTreeTest,
-	#category : #'AST-Core-Tests-Nodes'
+	#category : #'AST-Core-Tests-Visitors'
 }
 
 { #category : #tests }

--- a/src/AST-Core-Tests/RBGenericNodeVisitorTest.class.st
+++ b/src/AST-Core-Tests/RBGenericNodeVisitorTest.class.st
@@ -1,0 +1,50 @@
+Class {
+	#name : #RBGenericNodeVisitorTest,
+	#superclass : #RBParseTreeTest,
+	#category : #'AST-Core-Tests-Visitors'
+}
+
+{ #category : #tests }
+RBGenericNodeVisitorTest >> testVisitAnySatisfy [
+	| result tree |
+	tree := self parseExpression: 'Object new'.
+	result := RBGenericNodeVisitor visit: tree anySatisfy: [ :n | n isMessage ].
+	self assert: result.
+	result := RBGenericNodeVisitor visit: tree anySatisfy: [ :n | n isReturn ].
+	self deny: result
+]
+
+{ #category : #tests }
+RBGenericNodeVisitorTest >> testVisitDetect [
+	| node tree |
+	tree := self parseExpression: 'Object new'.
+	node := RBGenericNodeVisitor  visit: tree detect: [ :n | n isMessage ].
+	self  assert: node isMessage
+]
+
+{ #category : #tests }
+RBGenericNodeVisitorTest >> testVisitDetectIfNone [
+	| result tree |
+	tree := self parseExpression: 'Object new'.
+	result := RBGenericNodeVisitor visit: tree detect: [ :n | n isReturn ] ifNone: [ #none ].
+	self assert: result equals: #none
+]
+
+{ #category : #tests }
+RBGenericNodeVisitorTest >> testVisitNoneSatisfy [
+	| result tree |
+	tree := self parseExpression: 'Object new'.
+	result := RBGenericNodeVisitor visit: tree noneSatisfy: [ :n | n isMessage ].
+	self deny: result.
+	result := RBGenericNodeVisitor visit: tree noneSatisfy: [ :n | n isReturn ].
+	self assert: result
+]
+
+{ #category : #tests }
+RBGenericNodeVisitorTest >> testVisitSelect [
+	| result tree |
+	tree := self parseExpression: 'Object new'.
+	result := RBGenericNodeVisitor visit: tree select: [ :n | n isMessage ].
+	self assert: result size equals: 1.
+	self assert: result first selector equals: #new
+]

--- a/src/AST-Core/RBAbstractBlockVisitor.class.st
+++ b/src/AST-Core/RBAbstractBlockVisitor.class.st
@@ -13,6 +13,14 @@ Class {
 }
 
 { #category : #enumerating }
+RBAbstractBlockVisitor class >> visit: aTree anySatisfy: aBlock [
+	self
+		visit: aTree
+		do: [ :node | (aBlock value: node) ifTrue: [ ^ true ] ].
+	^ false
+]
+
+{ #category : #enumerating }
 RBAbstractBlockVisitor class >> visit: aTree detect: aBlock [
 	
 	^self visit: aTree detect: aBlock ifNone: [ NotFound signalFor: aBlock ]
@@ -31,6 +39,14 @@ RBAbstractBlockVisitor class >> visit: aTree do: aBlock [
 	^self new 
 		visitBlock: aBlock;
 		visitNode: aTree
+]
+
+{ #category : #enumerating }
+RBAbstractBlockVisitor class >> visit: aTree noneSatisfy: aBlock [
+	self
+		visit: aTree
+		do: [ :node | (aBlock value: node) ifTrue: [ ^ false ] ].
+	^ true
 ]
 
 { #category : #enumerating }


### PR DESCRIPTION
- This PR adds tests for RBGenericNodeVisitor
- adds #visit:anySatisfy: and #visit:noneSatify: 
- move RBCommentNodeVisitorTest close to the other visitor tests