### PR TITLE
 8086-RSLabelTest-Could-not-find-accessor-for-variable-named-anUTF8EncodedString

### DIFF
--- a/src/Athens-Cairo/AthensCairoCanvas.class.st
+++ b/src/Athens-Cairo/AthensCairoCanvas.class.st
@@ -471,7 +471,7 @@ void                cairo_text_extents                  (cairo_t *cr,
 ]
 
 { #category : #drawing }
-AthensCairoCanvas >> textPath: anUTF8String [
+AthensCairoCanvas >> textPath: anUTF8EncodedString [
 	"A drawing operator that generates the shape from a string of UTF-8 characters, rendered according to the current font_face, font_size (font_matrix), and font_options. "
 	
 	^ self ffiCall: #(void cairo_text_path (self, void* anUTF8EncodedString ))


### PR DESCRIPTION
in #textPath: the argument name was not in sync with the symbol used in the FFI call

fixes #8086


