### PR TITLE
SlotScope-DeadCode-Clean

### DIFF
--- a/src/Kernel/LayoutAbstractScope.class.st
+++ b/src/Kernel/LayoutAbstractScope.class.st
@@ -17,11 +17,6 @@ LayoutAbstractScope >> allSlotsDo: aBlock [
 	self subclassResponsibility
 ]
 
-{ #category : #enumerating }
-LayoutAbstractScope >> allSlotsReverseDo: aBlock [
-	self subclassResponsibility
-]
-
 { #category : #extending }
 LayoutAbstractScope >> extend [
 	^ self extend: { }
@@ -108,11 +103,6 @@ LayoutAbstractScope >> ownFieldSize [
 	self subclassResponsibility
 ]
 
-{ #category : #reshaping }
-LayoutAbstractScope >> rebase: originalScope to: newScope [
-	self error: 'Should not happen'
-]
-
 { #category : #accessing }
 LayoutAbstractScope >> resolveSlot: aName [
 	^ self 
@@ -135,10 +125,5 @@ LayoutAbstractScope >> visibleSlotNames [
 
 { #category : #accessing }
 LayoutAbstractScope >> visibleSlots [
-	self subclassResponsibility
-]
-
-{ #category : #enumerating }
-LayoutAbstractScope >> withParentScopesDo: aBlock [
 	self subclassResponsibility
 ]

--- a/src/Kernel/LayoutClassScope.class.st
+++ b/src/Kernel/LayoutClassScope.class.st
@@ -32,12 +32,6 @@ LayoutClassScope >> allSlotsDo: aBlock [
 	self do: aBlock
 ]
 
-{ #category : #enumerating }
-LayoutClassScope >> allSlotsReverseDo: aBlock [
-	self reverseDo: aBlock.
-	parentScope allSlotsReverseDo: aBlock.
-]
-
 { #category : #accessing }
 LayoutClassScope >> allVisibleSlots [
 	| result |
@@ -139,25 +133,6 @@ LayoutClassScope >> printOn: aStream [
 	self allVisibleSlots printElementsOn: aStream.
 ]
 
-{ #category : #reshaping }
-LayoutClassScope >> rebase: originalScope to: newScope [
-	| newParent result fieldIndex |
-	newParent := parentScope == originalScope
-		ifTrue: [ newScope ]
-		ifFalse: [ parentScope rebase: originalScope to: newScope ].
-		
-	result := self copy.
-	result parentScope: newParent.
-	
-	fieldIndex := newParent firstFieldIndex.
-	result do: [ :slot | 
-		slot isVirtual ifFalse: [slot index: fieldIndex].
-		fieldIndex := fieldIndex + slot size ].
-	
-	^ result
-	
-]
-
 { #category : #enumerating }
 LayoutClassScope >> reverseDo: aBlock [
 	|size|
@@ -192,10 +167,4 @@ LayoutClassScope >> withIndexDo: elementAndIndexBlock [
 		elementAndIndexBlock
 			value: (self at: index)
 			value: index]
-]
-
-{ #category : #enumerating }
-LayoutClassScope >> withParentScopesDo: aBlock [
-	aBlock value: self.
-	parentScope withParentScopesDo: aBlock.
 ]

--- a/src/Kernel/LayoutEmptyScope.class.st
+++ b/src/Kernel/LayoutEmptyScope.class.st
@@ -19,10 +19,6 @@ LayoutEmptyScope class >> instance [
 LayoutEmptyScope >> allSlotsDo: aBlock [
 ]
 
-{ #category : #enumerating }
-LayoutEmptyScope >> allSlotsReverseDo: aBlock [
-]
-
 { #category : #accessing }
 LayoutEmptyScope >> allVisibleSlots [
 	^ OrderedCollection new
@@ -66,9 +62,4 @@ LayoutEmptyScope >> ownFieldSize [
 { #category : #accessing }
 LayoutEmptyScope >> visibleSlots [
 	^ #()
-]
-
-{ #category : #enumerating }
-LayoutEmptyScope >> withParentScopesDo: aBlock [
-	aBlock value: self.
 ]


### PR DESCRIPTION
This PR removes some not needed methods from the LayoutAbstractScope hierarchy.

No deprecation need: internal private implementation methods.

