### PR TITLE
Correctly decode file names from SDL2, at SDL2

### DIFF
--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -49,20 +49,6 @@ FileReference class >> newTempFilePrefix: prefix suffix: suffix [
 	^ tmpDir / fileName
 ]
 
-{ #category : #'instance creation' }
-FileReference class >> primDropRequestFileName: dropIndex [
-	"Primitive. Return the file name for some file that was just dropped onto the application.
-	Fail if dropIndex is out of range or the primitive is not supported."
-	<primitive: 'primitiveDropRequestFileName' module:'DropPlugin'>
-	^ self primitiveFail 
-]
-
-{ #category : #'drag-and-drop' }
-FileReference class >> requestDropReference: anInteger [ 
-	
-	^ (FilePathEncoder decode: (self primDropRequestFileName: anInteger)) asFileReference 
-]
-
 { #category : #navigating }
 FileReference >> , extension [
 	^ self withPath: self path, extension

--- a/src/Morphic-Base/DropFilesEvent.class.st
+++ b/src/Morphic-Base/DropFilesEvent.class.st
@@ -32,15 +32,9 @@ DropFilesEvent >> fileNames: anObject [
 { #category : #dispatching }
 DropFilesEvent >> requestDropReference: i [
 
-	| fileName |
-
-	fileNames ifNil: [ 
-		"The file names are not stored in the event, they need to be obtained by a VM primitive"
-		^ FileReference requestDropReference: i ].
-	
-	"The event already knows the files (case of events transformed from OSWindow events)"
+	| fileName |	
 	fileName := self fileNames at: i.
-	^ (FilePathEncoder decode: fileName) asFileReference
+	^ fileName asFileReference
 
 
 ]

--- a/src/Morphic-Base/Form.extension.st
+++ b/src/Morphic-Base/Form.extension.st
@@ -12,13 +12,13 @@ Form >> asMorph [
 ]
 
 { #category : #'*Morphic-Base' }
-Form >> floodFillTolerance [
-	^ self class floodFillTolerance
+Form class >> floodFillTolerance [
+	^ FloodFillTolerance ifNil: [FloodFillTolerance := 0.0]
 ]
 
 { #category : #'*Morphic-Base' }
-Form class >> floodFillTolerance [
-	^ FloodFillTolerance ifNil: [FloodFillTolerance := 0.0]
+Form >> floodFillTolerance [
+	^ self class floodFillTolerance
 ]
 
 { #category : #'*Morphic-Base' }

--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -446,9 +446,18 @@ OSSDL2Driver >> visitControllerDeviceRemovedEvent: controllerEvent [
 { #category : #'global events' }
 OSSDL2Driver >> visitDropEvent: dropEvent [
 
+	"The dragged file name comes as a C-string of utf8 encoded bytes.
+	Get the string, and decode it to a string using a utf8 decoder"
+	| fileName |
+	fileName := dropEvent file readString asByteArray utf8Decoded.
+	
+	"Free the file handle after it has been read, as specified by SDL2
+	https://wiki.libsdl.org/SDL_DropEvent"
+	dropEvent file free.
+	
 	^ OSWindowDropEvent new
 		timestamp: dropEvent timestamp;
-		filePath: dropEvent file readString
+		filePath: fileName
 ]
 
 { #category : #'events-processing' }


### PR DESCRIPTION
- DropFilePlugin is not used nor built in Pharo9 anymore (remove the associated code)
- Correctly decode file names from SDL2, at SDL2
  => users receive already decoded strings, no need to decode them