### PR TITLE
8117-RBMethodNode>>methodClass-should-gard-for-nil

### DIFF
--- a/src/AST-Core-Tests/RBMethodNodeTest.class.st
+++ b/src/AST-Core-Tests/RBMethodNodeTest.class.st
@@ -171,6 +171,16 @@ RBMethodNodeTest >> testIsPrimitive [
 ]
 
 { #category : #tests }
+RBMethodNodeTest >> testMethodClass [
+	| ast |
+	ast :=  (OrderedCollection>>#do:) ast.
+	self assert: ast methodClass equals: OrderedCollection.
+	"if we create an AST, the class should be nil"
+	ast := RBMethodNode selector: #tt body: RBSelectorNode new. 
+	self assert: ast methodClass equals: nil
+]
+
+{ #category : #tests }
 RBMethodNodeTest >> testMethodsHasTemporaries [
 
 	| tree |

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -463,7 +463,8 @@ RBMethodNode >> method [
 
 { #category : #'accessing compiled method' }
 RBMethodNode >> methodClass [
-	^self compilationContext getClass 
+
+	^ self compilationContext ifNotNil: [ :ctxt | ctxt getClass ]
 ]
 
 { #category : #'accessing compiled method' }


### PR DESCRIPTION
- test for RBMethodNode>>#methodClass
- make sure it works when the compilationContext is not set

fixes #8117


