### PR TITLE
ClassParser-reduce-NewUndeclaredWarning

### DIFF
--- a/src/ClassParser/CDAbstractClassDefinitionParser.class.st
+++ b/src/ClassParser/CDAbstractClassDefinitionParser.class.st
@@ -184,7 +184,9 @@ CDAbstractClassDefinitionParser >> isInstanceSideDefinition: aRBMessageNode [
 CDAbstractClassDefinitionParser >> parse: aString [
 	| expressionTree |
 	expressionTree := self parserClass parseExpression: aString.
-	expressionTree doSemanticAnalysis.
+	[expressionTree doSemanticAnalysis] 
+		on: OCUndeclaredVariableWarning 
+		do: [ :ex | ex resume: ex declareUndefined ].
 	^ self parseRootNode: expressionTree
 ]
 


### PR DESCRIPTION
When running the tests of the ClassParser, we get  alot of NewUndeclaredWarning messages in the transcript.

This is a workaround to do what the exception does, without logging.  (the code looks not that great, but it is a nice example of a client that will allow us to improve the Exception handling in the future)

