### PR TITLE
Cleanup-ClassOrganization-listAtCategoryNumber

### DIFF
--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -208,12 +208,6 @@ ClassOrganization >> listAtCategoryNamed: aName [
 	^ (self protocolOrganizer methodsInProtocolNamed: aName) asArray
 ]
 
-{ #category : #'backward compatibility' }
-ClassOrganization >> listAtCategoryNumber: aSmallInteger [ 
-	
-	^ (protocolOrganizer allProtocols at: aSmallInteger ifAbsent: [ ^ {} ]) methods asArray
-]
-
 { #category : #notifications }
 ClassOrganization >> notifyOfAddedCategory: protocolName [
 	


### PR DESCRIPTION
ClassOrganization>>#listAtCategoryNumber: can be removed: it is a api that used to be
inherited from Categorizer, but there it is *private*.


