### PR TITLE
8135-When-executing-a-doit-against-a-context-the-class-is-not-correct 

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -342,7 +342,6 @@ OpalCompiler >> compileDoit [
 	offset of the original selected code. This way the #location 
 	will be correct regarding the requestor"
 	self parseDoIt.
-	self transformDoit.
 	self callPlugins.
 	cm := ast generateWithSource ]
 		on: SyntaxErrorNotification
@@ -551,7 +550,8 @@ OpalCompiler >> parse: textOrString [
 { #category : #private }
 OpalCompiler >> parseDoIt [
 	"we parse doits without doing name analysis here, it is done in #transformDoit"
-	^ ast := self parseExpression
+	ast := self parseExpression.
+	^self transformDoit
 ]
 
 { #category : #private }
@@ -616,10 +616,13 @@ OpalCompiler >> source: aString [
 OpalCompiler >> transformDoit [
 	"if we compile an expression, we wrap it in a method here"
 	self compilationContext noPattern ifFalse: [ ^ast ].
+		
 	ast := context 
 		ifNil: [ast asDoit] 
 		ifNotNil: [ast asDoitForContext: context].
 	"we need to set the compilation context in the new method node"
 	ast compilationContext: self compilationContext.
-	self doSemanticAnalysis
+	context ifNotNil: [ast methodClass: context receiver class].
+	self doSemanticAnalysis.
+	^ast
 ]

--- a/src/OpalCompiler-Tests/OCDoitTest.class.st
+++ b/src/OpalCompiler-Tests/OCDoitTest.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : #OCDoitTest,
+	#superclass : #TestCase,
+	#category : #'OpalCompiler-Tests-Misc'
+}
+
+{ #category : #tests }
+OCDoitTest >> testDoItContextReadGlobal [
+	"we can read a global from a doit when executing against a context"
+
+	|  value |	
+	value := OpalCompiler new
+		source: 'Object';
+		context: thisContext;
+		evaluate.
+		
+	self assert: value equals: Object
+]
+
+{ #category : #tests }
+OCDoitTest >> testDoItContextReadTemp [
+	| tempForTesting value |
+	"we can read this temp from a doit when executing against thisContext"
+	tempForTesting := #someValue.
+	
+	value := OpalCompiler new
+		source: 'tempForTesting';
+		context: thisContext;
+		evaluate.
+		
+	self assert: value equals: #someValue
+]
+
+{ #category : #tests }
+OCDoitTest >> testDoitContextCheckClass [
+	"if we create a parse tree for a doit in a context, the class should be correctly set"
+	
+	| ast |
+	ast := OpalCompiler new
+		source: 'tempForTesting';
+		noPattern: true;
+		context: thisContext;
+		parseDoIt.
+	"we expect that the class is set to the class of the context, which is self class"		
+	self assert: ast methodClass equals: self class
+]


### PR DESCRIPTION
DoIts executed with a context set do not create an AST with the class correctly set.

- add a test that fails: testDoitContextCheckClass 
- improve #parseDoIt to do #transformDoit  (and fix the two users)
- fix transformDoit to set the class if the context is set

fixes #8135

