### PR TITLE
8127-FFICalloutAPITestmethod2-sends-non-implemented-call

### DIFF
--- a/src/UnifiedFFI-Tests/FFICalloutAPITest.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutAPITest.class.st
@@ -70,18 +70,6 @@ FFICalloutAPITest >> method1 [
 	^ object instVarAt: index.
 ]
 
-{ #category : #accessing }
-FFICalloutAPITest >> method2 [
-	| result tmpResult |
-	
-	result := self call: {1. 2. 3. 4}.
-	tmpResult := result.
-	result := FFICalloutObjectForTest basicNew.
-	result instVarAt: 1 put: tmpResult.	
-	^ result 
-	
-]
-
 { #category : #'primitives pointer' }
 FFICalloutAPITest >> primFromByteArray: src toExternalAddress: dest size: n [
 	^ self 


### PR DESCRIPTION
Removed FFICalloutAPITest>>method2, since it has no senders in this package (UnifiedFFI-Tests). Also this method sent #call:, which is not implemented on this test.