### PR TITLE
Fixes in the Parser

### DIFF
--- a/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
+++ b/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
@@ -31,6 +31,17 @@ RBErrorNodeParserTest >> testFaultyBinaryMessageSendWithLiteralArgumentShouldHav
 ]
 
 { #category : #tests }
+RBErrorNodeParserTest >> testFaultyCascade [
+
+	| node |
+	node := self parserClass parseFaultyExpression: '; ]'.
+	
+	self assert: node isUnfinishedStatement.
+	self assert: node children first isCascade.
+	self assert: node children first messages first isParseError.
+]
+
+{ #category : #tests }
 RBErrorNodeParserTest >> testFaultyMessageSendShouldHaveTheCorrectMessage [
 
 	| node |

--- a/src/AST-Core-Tests/RBFormatterTest.class.st
+++ b/src/AST-Core-Tests/RBFormatterTest.class.st
@@ -86,10 +86,9 @@ RBFormatterTest >> testParseError [
 RBFormatterTest >> testParseError2 [
 	| inputSource errorNode |
 	"parse error nodes should have the faulty code"
-	inputSource := '( 1 + 2 '.
+	inputSource := '( 1 + 2'.
    errorNode := self parseFaultyExpression: inputSource.
 	self assert: errorNode source equals: errorNode formattedCode
-
 ]
 
 { #category : #testing }

--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -1921,7 +1921,7 @@ RBParserTest >> testUnclosedArrayErrorNodeContainsRightValue [
 	| tree |
 	tree := self parseFaultyExpression: '{ faulty parentheses message node'.
 	self assert: tree isParseError.
-	self assert: tree value equals: '{ faulty parentheses message node '
+	self assert: tree formattedCode equals: '{ faulty parentheses message node'
 ]
 
 { #category : #'error testing' }
@@ -1929,7 +1929,7 @@ RBParserTest >> testUnclosedBracketErrorNodeContainsRightValue [
 	| tree |
 	tree := self parseFaultyExpression: '[ faulty parentheses message node'.
 	self assert: tree isEnglobingError.
-	self assert: tree value equals: '[ faulty parentheses message node '
+	self assert: tree formattedCode equals: '[ faulty parentheses message node'
 ]
 
 { #category : #'error testing' }
@@ -1937,7 +1937,7 @@ RBParserTest >> testUnclosedParenthesesErrorNodeContainsRightValue [
 	| tree |
 	tree := self parseFaultyExpression: '( faulty parentheses message node'.
 	self assert: tree isEnglobingError.
-	self assert: tree value equals: '( faulty parentheses message node '
+	self assert: tree formattedCode equals: '( faulty parentheses message node'
 ]
 
 { #category : #'garbage tests' }
@@ -1951,7 +1951,7 @@ RBParserTest >> testUnclosedTemporariesErrorNodeContainsRightValue [
 	| tree |
 	tree := self parseFaultyExpression: '| faulty temporaries'.
 	self assert: tree isEnglobingError.
-	self assert: tree value equals: '| faulty temporaries '
+	self assert: tree formattedCode equals: '| faulty temporaries'
 ]
 
 { #category : #private }

--- a/src/AST-Core/RBArrayErrorNode.class.st
+++ b/src/AST-Core/RBArrayErrorNode.class.st
@@ -23,8 +23,8 @@ RBArrayErrorNode class >> error: aToken withNodes: aCollection [
 		ifTrue: [ ^self new content: aCollection; start: aToken start; stop: aToken stop; errorMessage: message ].
 	"If the collection is not empty, we have to sort where the node begins and where it ends."
 	^message = '''}'' expected'
-		ifTrue: [ self new content: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: message; createValue ]
-		ifFalse: [ self new content: aCollection; start: aCollection first start; stop: aToken stop; errorMessage: message; createValue ]
+		ifTrue: [ self new content: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: message ]
+		ifFalse: [ self new content: aCollection; start: aCollection first start; stop: aToken stop; errorMessage: message ]
 ]
 
 { #category : #testing }
@@ -83,10 +83,4 @@ RBArrayErrorNode >> repairCollectionFromStop [
 	^collection.
 	
 	
-]
-
-{ #category : #testing }
-RBArrayErrorNode >> value [
-	^  self errorMessage = '''{'' expected' ifTrue: [ super value, '}' ] 
-														ifFalse: [ '{ ', super value ] 
 ]

--- a/src/AST-Core/RBBlockErrorNode.class.st
+++ b/src/AST-Core/RBBlockErrorNode.class.st
@@ -23,8 +23,8 @@ RBBlockErrorNode class >> error: aToken withNodes: aCollection [
 		ifTrue: [ ^self new content: aCollection; start: aToken start; stop: aToken stop; errorMessage: message ].
 	"If the collection is not empty, we have to sort where the node begins and where it ends."
 	^message = ''']'' expected'
-		ifTrue: [ self new content: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: message; createValue ]
-		ifFalse: [ self new content: aCollection; start: aCollection first start; stop: aToken stop; errorMessage: message; createValue ]
+		ifTrue: [ self new content: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: message ]
+		ifFalse: [ self new content: aCollection; start: aCollection first start; stop: aToken stop; errorMessage: message ]
 ]
 
 { #category : #testing }
@@ -53,10 +53,4 @@ RBBlockErrorNode >> repairCollectionFromStart [
 	result add: removedStatements.
 	^collection.
 	
-]
-
-{ #category : #accessing }
-RBBlockErrorNode >> value [
-	^  self errorMessage = '''['' expected' ifTrue: [ super value, ']' ] 
-														ifFalse: [ '[ ', super value ] 
 ]

--- a/src/AST-Core/RBDumpVisitor.class.st
+++ b/src/AST-Core/RBDumpVisitor.class.st
@@ -84,6 +84,7 @@ RBDumpVisitor >> visitCascadeNode:aCascadeNode [
 { #category : #visiting }
 RBDumpVisitor >> visitEnglobingErrorNode: anEnglobingErrorNode [
 	stream
+		nextPutAll: '(';
 		nextPutAll: anEnglobingErrorNode class name;
 		nextPutAll: ' content: {'.
 	anEnglobingErrorNode content
@@ -97,6 +98,9 @@ RBDumpVisitor >> visitEnglobingErrorNode: anEnglobingErrorNode [
 	anEnglobingErrorNode stop printOn: stream.
 	stream nextPutAll: ' errorMessage: '.
 	anEnglobingErrorNode errorMessage printOn: stream.
+	stream
+		nextPutAll: ') value: ';
+		nextPutAll: anEnglobingErrorNode value printString.
 ]
 
 { #category : #visiting }

--- a/src/AST-Core/RBEnglobingErrorNode.class.st
+++ b/src/AST-Core/RBEnglobingErrorNode.class.st
@@ -26,8 +26,7 @@ RBEnglobingErrorNode class >> content: aCollection start: aStart stop: aStop err
 		content: aCollection; 
 		start: aStart; 
 		stop: aStop; 
-		errorMessage: message;
-		createValue.
+		errorMessage: message
 ]
 
 { #category : #construction }
@@ -72,12 +71,6 @@ RBEnglobingErrorNode >> content [
 RBEnglobingErrorNode >> content: aCollection [
 	content := aCollection.
 	aCollection do: [:each | each parent: self ]
-]
-
-{ #category : #initialization }
-RBEnglobingErrorNode >> createValue [
-	self value: (String streamContents: [ :s |
-			content do: [ :each | s nextPutAll: each formattedCode. s nextPutAll: String space. ]])
 ]
 
 { #category : #initialization }

--- a/src/AST-Core/RBLiteralArrayErrorNode.class.st
+++ b/src/AST-Core/RBLiteralArrayErrorNode.class.st
@@ -19,15 +19,10 @@ RBLiteralArrayErrorNode class >> error: aToken withNodes: aCollection [
 	"If the collection is empty, there is only the token in the error."
 	^aCollection isEmpty
 		ifTrue: [ self new content: aCollection; start: aToken start; stop: aToken stop; errorMessage: ''')'' expected' ]
-		ifFalse: [ self new content: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: ''')'' expected'; createValue ]
+		ifFalse: [ self new content: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: ''')'' expected' ]
 ]
 
 { #category : #testing }
 RBLiteralArrayErrorNode >> isLiteralArrayError [
 	^true
-]
-
-{ #category : #testing }
-RBLiteralArrayErrorNode >> value [
-	^  '#( ', super value 
 ]

--- a/src/AST-Core/RBLiteralByteArrayErrorNode.class.st
+++ b/src/AST-Core/RBLiteralByteArrayErrorNode.class.st
@@ -19,15 +19,10 @@ RBLiteralByteArrayErrorNode class >> error: aToken withNodes: aCollection [
 	"If the collection is empty, there is only the token in the error."
 	^aCollection isEmpty
 		ifTrue: [ self new content: aCollection; start: aToken start; stop: aToken stop; errorMessage: ''']'' expected' ]
-		ifFalse: [ self new content: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: ''']'' expected'; createValue ]
+		ifFalse: [ self new content: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: ''']'' expected' ]
 ]
 
 { #category : #testing }
 RBLiteralByteArrayErrorNode >> isLiteralByteArrayError [
 	^true
-]
-
-{ #category : #testing }
-RBLiteralByteArrayErrorNode >> value [
-	^  '#[ ', super value 
 ]

--- a/src/AST-Core/RBParenthesesErrorNode.class.st
+++ b/src/AST-Core/RBParenthesesErrorNode.class.st
@@ -23,17 +23,11 @@ RBParenthesesErrorNode class >> error: aToken withNodes: aCollection [
 		ifTrue: [ ^self new content: aCollection; start: aToken start; stop: aToken stop; errorMessage: message ].
 	"If the collection is not empty, we have to sort where the node begins and where it ends."
 	^message = ''')'' expected'
-		ifTrue: [ self new content: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: message; createValue ]
-		ifFalse: [ self new content: aCollection; start: aCollection first start; stop: aToken stop; errorMessage: message; createValue ]
+		ifTrue: [ self new content: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: message ]
+		ifFalse: [ self new content: aCollection; start: aCollection first start; stop: aToken stop; errorMessage: message ]
 ]
 
 { #category : #testing }
 RBParenthesesErrorNode >> isParenthesesError [
 	^true
-]
-
-{ #category : #testing }
-RBParenthesesErrorNode >> value [
-	^  self errorMessage = '''('' expected' ifTrue: [ super value, ')' ] 
-														ifFalse: [ '( ', super value ] 
 ]

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -522,20 +522,11 @@ RBParser >> parseCascadeMessageWithReceiver: receiver [
 ]
 
 { #category : #'private-classes' }
-RBParser >> parseEnglobingError: aCollection with: aToken [
-	| firstParse |
-	firstParse := self parserError: aToken value asString, ' counterpart missing'.
-	^[firstParse isParseError
-		ifTrue: [ self englobingErrorNodeClass error: aToken withNodes: aCollection ]
-		ifFalse: [ firstParse ]] on: Error do: [ firstParse ].
-]
-
-{ #category : #'private-classes' }
 RBParser >> parseEnglobingError: aCollection with: aToken errorMessage: anErrorMessage [
 	| firstParse |
 	firstParse := self parserError: anErrorMessage.
 	^[firstParse isParseError
-		ifTrue: [ self englobingErrorNodeClass error: aToken withNodes: aCollection ]
+		ifTrue: [ (self englobingErrorNodeClass error: aToken withNodes: aCollection) value: aToken value asString ]
 		ifFalse: [ firstParse ]] on: Error do: [ firstParse ].
 ]
 

--- a/src/AST-Core/RBPragmaErrorNode.class.st
+++ b/src/AST-Core/RBPragmaErrorNode.class.st
@@ -18,15 +18,10 @@ RBPragmaErrorNode class >> error: aToken withNodes: aCollection [
 	"If the collection is empty, there is only the token in the error."
 	^aCollection isEmpty
 		ifTrue: [ self new content: aCollection; start: aToken start; stop: aToken stop; errorMessage: '''>'' expected' ]
-		ifFalse: [ self new content: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: '''>'' expected'; createValue ]
+		ifFalse: [ self new content: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: '''>'' expected' ]
 ]
 
 { #category : #testing }
 RBPragmaErrorNode >> isPragmaError [
 	^true
-]
-
-{ #category : #testing }
-RBPragmaErrorNode >> value [
-	^   '< ', super value 
 ]

--- a/src/AST-Core/RBTemporariesErrorNode.class.st
+++ b/src/AST-Core/RBTemporariesErrorNode.class.st
@@ -18,15 +18,10 @@ RBTemporariesErrorNode class >> error: aToken withNodes: aCollection [
 	"If the collection is empty, there is only the token in the error."
 	^aCollection isEmpty
 		ifTrue: [ self new content: aCollection; start: aToken start; stop: aToken stop; errorMessage: '''|'' expected' ]
-		ifFalse: [ self new content: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: '''|'' expected'; createValue ]
+		ifFalse: [ self new content: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: '''|'' expected' ]
 ]
 
 { #category : #testing }
 RBTemporariesErrorNode >> isTemporariesError [
 	^true
-]
-
-{ #category : #testing }
-RBTemporariesErrorNode >> value [
-	^  '| ', super value 
 ]

--- a/src/EnlumineurFormatter-Tests/EFParseErrorExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFParseErrorExpressionTest.class.st
@@ -22,7 +22,7 @@ EFParseErrorExpressionTest >> testParseError [
 	expr := RBParser parseFaultyExpression: '#(1 3 4'.
 	configurationSelector := #basicConfiguration.
 	source := self formatter format: expr.
-	self assert: source equals: '#( 1 3 4 '
+	self assert: source equals: '#( 1 3 4'
 ]
 
 { #category : #tests }
@@ -33,5 +33,5 @@ EFParseErrorExpressionTest >> testParseError2 [
 	configurationSelector := #basicConfiguration.
 	source := self formatter format: expr.
 	self assert: source equals:
-'1 . :='
+' 1. :='
 ]

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -2086,7 +2086,10 @@ EFFormatter >> visitCascadeNode: aCascadeNode [
 
 { #category : #visiting }
 EFFormatter >> visitEnglobingErrorNode: aNode [
-	self writeString: aNode value
+	self writeString: aNode value.
+	aNode children do: [ :e |
+		codeStream space.
+		self visitNode: e ]
 ]
 
 { #category : #visiting }


### PR DESCRIPTION
Fix #8134
Fix #7694

Remove createValue. Do not use the pretty printer at parse time.
Cleanup all this unused code.
Added tests and make existing tests still pass.