### PR TITLE
8120-RPackageOrganizer-and-RPackage-should-report-about-if-a-package-is-a-test-package

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -957,6 +957,19 @@ RPackage >> isForeignClassExtension: categoryName [
 	^ categoryName first = $* and: [(self isYourClassExtension: categoryName) not]
 ]
 
+{ #category : #testing }
+RPackage >> isTestPackage [
+	"1. Test package ends with suffix -Tests. Suffix is case sensitive.
+	 2. Or test package contains '-Tests-' in middle.
+	Some examples: "
+	"RPackage named: 'MockPackage-Tests' isTestPackage >>> true"
+	"RPackage named: 'MockPackage-tests' isTestPackage >>> false"
+	"RPackage named: 'MockPackage' isTestPackage >>> false"
+	"RPackage named: 'MockPackage-Tests-Package' isTestPackage >>> true"
+	
+	^ (self name endsWith: '-Tests') or: [self name includesSubstring: '-Tests-']
+]
+
 { #category : #'system compatibility' }
 RPackage >> isYourClassExtension: categoryName [
 	^ categoryName notNil and: [self category: categoryName asLowercase matches: self methodCategoryPrefix]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -962,10 +962,10 @@ RPackage >> isTestPackage [
 	"1. Test package ends with suffix -Tests. Suffix is case sensitive.
 	 2. Or test package contains '-Tests-' in middle.
 	Some examples: "
-	"RPackage named: 'MockPackage-Tests' isTestPackage >>> true"
-	"RPackage named: 'MockPackage-tests' isTestPackage >>> false"
-	"RPackage named: 'MockPackage' isTestPackage >>> false"
-	"RPackage named: 'MockPackage-Tests-Package' isTestPackage >>> true"
+	"(RPackage named: 'MockPackage-Tests') isTestPackage >>> true"
+	"(RPackage named: 'MockPackage-tests') isTestPackage >>> false"
+	"(RPackage named: 'MockPackage') isTestPackage >>> false"
+	"(RPackage named: 'MockPackage-Tests-Package') isTestPackage >>> true"
 	
 	^ (self name endsWith: '-Tests') or: [self name includesSubstring: '-Tests-']
 ]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -1215,6 +1215,18 @@ RPackageOrganizer >> systemProtocolRemovedActionFrom: ann [
 	
 ]
 
+{ #category : #accessing }
+RPackageOrganizer >> testPackageNames [
+	
+	^ packages keys select: [:nameSymbol | (self packageNamed: nameSymbol) isTestPackage]
+]
+
+{ #category : #accessing }
+RPackageOrganizer >> testPackages [
+	
+	^ packages values select: #isTestPackage
+]
+
 { #category : #initialization }
 RPackageOrganizer >> unregister [
 	SystemAnnouncer uniqueInstance unsubscribe: self.

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -398,6 +398,34 @@ RPackageOrganizerTest >> testSilentlyRenameCategoryToBe [
 ]
 
 { #category : #tests }
+RPackageOrganizerTest >> testTestPackageNames [
+
+	| packages |
+	packages := self createMockTestPackages.
+	packages do: [:aPackage | self packageOrganizer registerPackage: aPackage].
+	
+	"Only 2 mock package names are test packages:  'MockPackage-Tests' 'MockPackage-Tests-Package'"
+	self assert: self packageOrganizer testPackageNames size equals: 2.
+	
+	"Names of test packages are symbols."
+	self assert: (self packageOrganizer testPackageNames allSatisfy: #isSymbol) equals: true.
+]
+
+{ #category : #tests }
+RPackageOrganizerTest >> testTestPackages [
+
+	| packages |
+	packages := self createMockTestPackages.
+	packages do: [:aPackage | self packageOrganizer registerPackage: aPackage].
+	
+	"Only 2 mock packages are test packages:  'MockPackage-Tests' 'MockPackage-Tests-Package'."
+	self assert: self packageOrganizer testPackages size equals: 2.
+	
+	"all items from resulting collection are test packages."
+	self assert: (self packageOrganizer testPackages allSatisfy: #isTestPackage) equals: true.
+]
+
+{ #category : #tests }
 RPackageOrganizerTest >> testUnregisterBasedOnNames [
 	| p1 p2 p3 |
 	p1 := self createNewPackageNamed: 'P1'.

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -229,6 +229,26 @@ RPackageTest >> testHierarchyRoots [
 		do: [ :each | roots includes: each ]
 ]
 
+{ #category : #test }
+RPackageTest >> testIsTestPackage [
+
+	|packages |
+	packages := self createMockTestPackages.
+	"Happy case: test package 'MockPackage-Tests' must contain -Tests suffix."
+	self assert: packages first isTestPackage equals: true.
+	
+	"Package 'MockPackage-tests' is not test package, since it has lowercase suffix."
+	self assert: packages second isTestPackage  equals: false.
+	
+	"Happy case: regular package 'MockPackage' without -Tests suffix is not a test package."
+	self assert: packages third isTestPackage  equals: false.
+
+	"Package 'MockPackage-Tests-Package' containting -Tests- in middle, so it is test package."
+	self assert: packages fourth isTestPackage equals: true.
+	
+	"cleanup of inst.vars should be done in tearDown"
+]
+
 { #category : #'tests-MC' }
 RPackageTest >> testMcPackage [
 

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -21,6 +21,12 @@ RPackageTestCase >> allManagers [
 ]
 
 { #category : #utilities }
+RPackageTestCase >> createMockTestPackages [
+
+	^ self namesOfMockTestPackages collect: [:pName | self createNewPackageNamed: pName]
+]
+
+{ #category : #utilities }
 RPackageTestCase >> createNewClassNamed: aName [
 	^ self createNewClassNamed: aName inCategory: 'RPackageTest'
 ]
@@ -89,6 +95,13 @@ RPackageTestCase >> initializeAnnouncers [
 	oldSystemAnnouncer := SystemAnnouncer uniqueInstance.
 
 	SystemAnnouncer announcer: (announcerForTest := SystemAnnouncer new).
+]
+
+{ #category : #utilities }
+RPackageTestCase >> namesOfMockTestPackages [
+	
+	^ #( 'MockPackage-Tests' 'MockPackage-tests' 'MockPackage' 'MockPackage-Tests-Package')
+
 ]
 
 { #category : #accessing }

--- a/src/Tool-ImageCleaner-Tests/ImageCleanerTest.class.st
+++ b/src/Tool-ImageCleaner-Tests/ImageCleanerTest.class.st
@@ -1,0 +1,30 @@
+"
+An ImageCleanerTest is a test class for testing the behavior of ImageCleaner
+"
+Class {
+	#name : #ImageCleanerTest,
+	#superclass : #TestCase,
+	#category : #'Tool-ImageCleaner-Tests'
+}
+
+{ #category : #accessing }
+ImageCleanerTest >> imageCleanerClass [ 
+	"returns the class that represents image cleaner"
+	^ ImageCleaner
+]
+
+{ #category : #test }
+ImageCleanerTest >> testTestPackages [
+
+	"ImageCleaner testPackages method returns just symbols. Maybe it should be renamed."
+
+	self
+		assert: (self imageCleanerClass testPackages allSatisfy: #isSymbol)
+		equals: true.
+
+	"All test package names are candidates for cleanup, except ReleaseTests package"
+	self
+		assert: (self imageCleanerClass testPackages noneSatisfy: [ :aSymbol | 
+				 aSymbol = #'ReleaseTests' ])
+		equals: true
+]

--- a/src/Tool-ImageCleaner-Tests/package.st
+++ b/src/Tool-ImageCleaner-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Tool-ImageCleaner-Tests' }

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -62,11 +62,11 @@ ImageCleaner class >> shareLiterals [
 
 { #category : #accessing }
 ImageCleaner class >> testPackages [
+
 	<script: 'self testPackages inspect'>
-	
-	^ (RPackageOrganizer default packageNames
-		select: [ :each | (each endsWith: '-Tests') or: [ each includesSubstring: '-Tests-' ] ])
-		copyWithout: 'ReleaseTests'
+	"All test packages to wipe out, except ReleeaseTests package."
+	^ RPackageOrganizer default testPackageNames copyWithout:
+		  'ReleaseTests'
 ]
 
 { #category : #api }
@@ -230,7 +230,6 @@ ImageCleaner >> statistics [
 
 { #category : #cleaning }
 ImageCleaner >> testPackages [
-	^ (RPackageOrganizer default packageNames
-		select: [ :each | (each endsWith: '-Tests') or: [ each includesSubstring: '-Tests-' ] ])
-		copyWithout: 'ReleaseTests'
+
+	^ self class testPackages 
 ]


### PR DESCRIPTION
added method for determining test packages, based on package name
added method for selecting testing packages from package organizer
added unit test methods for package organizer and package 
refactored image cleaner method for obtaining test package names
added test method for image cleaner