### PR TITLE
8158-ContextquickStep-is-unused-and-strange 

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -80,40 +80,6 @@ Context >> pcRangeContextIsActive: contextIsActive [
 ]
 
 { #category : #'*Debugging-Core' }
-Context >> quickSend: selector to: aReceiver with: arguments super: superFlag [
-	"Send the given selector with arguments in an environment which closely resembles the non-simulating environment, with an interjected unwind-protected block to catch nonlocal returns.
-	Attention: don't get lost!"
-	| lookupClass contextToReturnTo result |
-	contextToReturnTo := self.
-	lookupClass := superFlag
-					ifTrue: [(self compiledCode literalAt: self compiledCode numLiterals) value superclass]
-					ifFalse: [self objectClass: aReceiver].
-	[ | oldSender |
-	oldSender := thisContext sender swapSender: self.
-	result := self object: aReceiver perform: selector withArguments: arguments inClass: lookupClass.
-	thisContext sender swapSender: oldSender] ifCurtailed: [
-		contextToReturnTo := thisContext sender receiver.	"The block context returning nonlocally"
-		contextToReturnTo jump: -1.	"skip to front of return bytecode causing this unwind"
-		contextToReturnTo nextByte = 16r7C ifTrue: [
-			"If it was a returnTop, push the value to be returned.
-			Otherwise the value is implicit in the bytecode"
-			contextToReturnTo push: (thisContext sender tempAt: 1)].
-		thisContext swapSender: thisContext home sender.	"Make this block return to the method's sender"
-		contextToReturnTo].
-	contextToReturnTo push: result.
-	^contextToReturnTo
-]
-
-{ #category : #'*Debugging-Core' }
-Context >> quickStep [
-	"If the next instruction is a send, just perform it.
-	Otherwise, do a normal step."
-
-	self willSend ifTrue: [ QuickStep := self ].
-	^self step
-]
-
-{ #category : #'*Debugging-Core' }
 Context >> readVariableNamed: aName [
 	^ (self lookupVar: aName) readInContext: self
 ]
@@ -235,9 +201,6 @@ Context >> send: selector super: superFlag numArgs: numArgs [
 					args: (arguments at: 4).
 				self push: answer.
 				^self]. "
-	QuickStep == self ifTrue: [
-		QuickStep := nil.
-		^ self quickSend: selector to: currentReceiver with: arguments super: superFlag].
 	^ self send: selector to: currentReceiver with: arguments super: superFlag
 ]
 

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -27,7 +27,6 @@ Class {
 	],
 	#classVars : [
 		'PrimitiveFailToken',
-		'QuickStep',
 		'SpecialPrimitiveSimulators',
 		'TryNamedPrimitiveTemplateMethod'
 	],
@@ -113,8 +112,7 @@ Context class >> initialize [
 	"A unique object to be returned when a primitive fails during simulation"
 	PrimitiveFailToken := Object new.
 	self initializeTryNamedPrimitiveTemplateMethod.
-	SpecialPrimitiveSimulators := nil.
-	QuickStep := nil.
+	SpecialPrimitiveSimulators := nil
 ]
 
 { #category : #simulation }


### PR DESCRIPTION
Context>>#quickStep is not used. It is not clear what it does (and why it is needed).

A real problem is that the state of being in this "QuickStep mode" is modelled as a class variable. This means that two
instances of Context (e.g. two open debuggers using quicksStep) would interfere with each other.

this PR removes the code

fixes #8158


