### PR TITLE
remove unused ivar DelayBasicScheduler

### DIFF
--- a/src/Kernel/DelayBasicScheduler.class.st
+++ b/src/Kernel/DelayBasicScheduler.class.st
@@ -70,7 +70,6 @@ Class {
 		'activeDelay',
 		'suspendSemaphore',
 		'timingSemaphore',
-		'debug',
 		'delayToStart',
 		'delayToStop'
 	],


### PR DESCRIPTION
remove unused ivar DelayBasicScheduler by doing a PR directly from GitHub

fixes  #8162