### PR TITLE
Fix testCreationByUnnamed

### DIFF
--- a/src/Ring-Tests-Core/RGClassDescripitonStrategyTest.class.st
+++ b/src/Ring-Tests-Core/RGClassDescripitonStrategyTest.class.st
@@ -115,9 +115,9 @@ RGClassDescripitonStrategyTest >> testCreationByParent [
 { #category : #tests }
 RGClassDescripitonStrategyTest >> testCreationByUnnamed [
 
-	| anRGBehavior parent |
+	| anRGBehavior |
 	
-	anRGBehavior := RGClass parent: parent.
+	anRGBehavior := RGClass unnamed.
 	self checkBasicPropertiesOf: anRGBehavior.
 	self assert: (anRGBehavior hasResolvedName) not.
 


### PR DESCRIPTION
`RGClassDescripitonStrategyTest>>#testCreationByUnnamed` had unused variable and wrong class creation method