### PR TITLE
Fix broken (deprecated) UTF8TextConverter

### DIFF
--- a/src/Deprecated90/Character.extension.st
+++ b/src/Deprecated90/Character.extension.st
@@ -1,6 +1,22 @@
 Extension { #name : #Character }
 
 { #category : #'*Deprecated90' }
+Character >> asUnicodeForTextConverter [
+	| table charset value |
+	self leadingChar = 0
+		ifTrue: [ ^ self asInteger ].
+	charset := self characterSet.
+	charset isCharset
+		ifFalse: [ ^ self charCode ].
+	table := charset ucsTable.
+	table ifNil: [ ^ 65533 ].
+	value := table at: self charCode + 1.
+	value = -1
+		ifTrue: [ ^ 65533 ].
+	^ value
+]
+
+{ #category : #'*Deprecated90' }
 Character >> leadingChar [
 	^ (self asInteger bitAnd: 1069547520) bitShift: -22
 ]

--- a/src/Deprecated90/UTF8TextConverter.class.st
+++ b/src/Deprecated90/UTF8TextConverter.class.st
@@ -87,7 +87,7 @@ UTF8TextConverter >> nextPut: aCharacter toStream: aStream [
 
 	"leadingChar > 3 ifTrue: [^ aStream]."
 
-	ucs2code := aCharacter asUnicode.
+	ucs2code := aCharacter asUnicodeForTextConverter.
 	ucs2code ifNil: [^ aStream].
 
 	nBytes := ucs2code highBit + 3 // 5.

--- a/src/Deprecated90/UTF8TextConverterTest.class.st
+++ b/src/Deprecated90/UTF8TextConverterTest.class.st
@@ -8,6 +8,24 @@ Class {
 }
 
 { #category : #testing }
+UTF8TextConverterTest >> testLeadingChar [
+
+	| leading hiraA hiraO hiraAO converter |
+	leading := (Smalltalk classNamed: #JapaneseEnvironment) leadingChar.
+	hiraA := (Character leadingChar: leading code: 12354) asString. "HIRAGANA LETTER A"
+	hiraO := (Character leadingChar: leading code: 12362) asString. "HIRAGANA LETTER O"
+	hiraAO := hiraA , hiraO.
+	
+	converter := [ :arg | String
+		streamContents: [ :stream | 
+			(UTF8TextConverter new) nextPutAll: arg toStream: stream. ] ].
+	
+	self assert: (converter value: hiraA) asByteArray equals: #[227 129 130].
+	self assert: (converter value: hiraO) asByteArray equals: #[227 129 138].
+	self assert: (converter value: hiraAO) asByteArray equals: #[227 129 130 227 129 138]
+]
+
+{ #category : #testing }
 UTF8TextConverterTest >> testNextPutAllStartingAt [
 	"Test that non-ascii ByteString characters are converted correctly when using next:putAll:startingAt:"
 


### PR DESCRIPTION
Fix for issue #8175 such that Grease/Seaside keeps working correctly in Pharo 9 while we address the deprecation (broken test: https://github.com/SeasideSt/Grease/issues/114)