### PR TITLE
8169 - Compiled code 'literals' do not behave the same that compiled code  'hasLiteral'

### DIFF
--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -170,6 +170,36 @@ CompiledCodeTest >> testHasSelectorSpecialSelectorIndex [
 ]
 
 { #category : #'tests-literals' }
+CompiledCodeTest >> testLiteralsDoNotConsiderTheInnerBlockLiterals [
+
+	"Bug or feature , I do not know..."
+
+	| method block |
+	method := self class compiler compile: 'method 
+		<pragma: #pragma>
+		test := 1+2.
+		Class.
+		self doIt: [ 
+		test := 1 - 2.
+		test := #(arrayInBlock).
+		Object.
+		self name ].
+		^#(#array) '.
+	block := (self class compiler evaluate: '[ 
+		test := 1 - 2.
+		test := #(arrayInBlock).
+		Object.
+		self name ]') compiledBlock.
+	self assertCollection: method literals equals: { 
+			2.
+			(UndeclaredVariable key: #test value: nil).
+			block.
+			#doIt:.
+			#( #array ).
+			(GlobalVariable key: #Class value: Class) }
+]
+
+{ #category : #'tests-literals' }
 CompiledCodeTest >> testLiteralsDoesNotContainMethodClass [
 	
 	self
@@ -182,6 +212,37 @@ CompiledCodeTest >> testLiteralsDoesNotContainMethodClass [
 CompiledCodeTest >> testLiteralsDoesNotContainMethodName [
 
 	self deny: (self compiledMethod1 refersToLiteral: #method1)
+]
+
+{ #category : #'tests-literals' }
+CompiledCodeTest >> testLiteralsEvenTheOnesInTheInnerBlocks [
+	"The behavior is different than literals. Bug or feature?"
+	| method |
+	method := self class compiler compile: 'method 
+		<pragma: #pragma>
+		test := 1+2.
+		Class.
+		self doIt: [ 
+		test := 1 - 2.
+		test := #(arrayInBlock).
+		Object.
+		self name ].
+		^#(#array) '.
+	"Can remove the test if the assertion is failing"
+	self deny: method literalsEvenTheOnesInTheInnerBlocks equals: method literals.
+	self
+		assertCollection: method literalsEvenTheOnesInTheInnerBlocks
+		equals: { 
+				2.
+				(UndeclaredVariable key: #test value: nil).
+				2.
+				(UndeclaredVariable key: #test value: nil).
+				#( #arrayInBlock ).
+				#name.
+				(GlobalVariable key: #Object value: Object).
+				#doIt:.
+				#( #array ).
+				(GlobalVariable key: #Class value: Class) }
 ]
 
 { #category : #'tests - scanning' }

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -452,13 +452,17 @@ CompiledCode >> literalAt: index put: value [
 
 { #category : #literals }
 CompiledCode >> literals [
+
 	"Answer an Array of the literals referenced by the receiver.	
 	 Exclude superclass + selector/properties"
+
 	| literals numberLiterals |
-	literals := Array new: (numberLiterals := self numLiterals - self literalsToSkip).
-	1 to: numberLiterals do: [:index |
-		literals at: index put: (self objectAt: index + 1)].
-	^literals
+	literals := Array new:
+		            (numberLiterals := self numLiterals
+		                               - self literalsToSkip).
+	1 to: numberLiterals do: [ :index | 
+	literals at: index put: (self literalAt: index) ].
+	^ literals
 ]
 
 { #category : #literals }

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -478,6 +478,22 @@ CompiledCode >> literalsDo: aBlock [
 		[:index | aBlock value: (self literalAt: index)]
 ]
 
+{ #category : #accessing }
+CompiledCode >> literalsEvenTheOnesInTheInnerBlocks [
+
+	| literals numberLiterals |
+	literals := OrderedCollection new:
+		            (numberLiterals := self numLiterals
+		                               - self literalsToSkip).
+	1 to: numberLiterals do: [ :index | 
+		| lit |
+		lit := self literalAt: index.
+		lit isEmbeddedBlock
+			ifTrue: [ literals addAll: lit literalsEvenTheOnesInTheInnerBlocks ]
+			ifFalse: [ literals addLast: lit ] ].
+	^ literals asArray
+]
+
 { #category : #literals }
 CompiledCode >> literalsToSkip [
 


### PR DESCRIPTION
Add method 'literalsEvenTheOnesInTheInnerBlocks' that returns the literals also included in the inner blocks of the method.

Temporary fixes #8169.