### PR TITLE
2138 Rubric cleanup

### DIFF
--- a/src/Rubric/RubParagraphDecorator.class.st
+++ b/src/Rubric/RubParagraphDecorator.class.st
@@ -25,6 +25,11 @@ RubParagraphDecorator class >> next: aDecoratorOrAParagraph [
 	^ self new next: aDecoratorOrAParagraph 
 ]
 
+{ #category : #delegating }
+RubParagraphDecorator >> aboutToBeUnplugged [ 
+	^self paragraph aboutToBeUnplugged 
+]
+
 { #category : #drawing }
 RubParagraphDecorator >> canDrawDecoratorsOn: aCanvas [
 
@@ -36,11 +41,65 @@ RubParagraphDecorator >> canDrawDecoratorsOn: aCanvas [
 	
 ]
 
+{ #category : #delegating }
+RubParagraphDecorator >> characterBlockAtPoint: aPoint [
+
+	^self paragraph characterBlockAtPoint: aPoint 
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> characterBlockForIndex: index [
+	^self paragraph characterBlockForIndex: index
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> click: anEvent for: model controller: editor [
+
+	^self paragraph click: anEvent for: model controller: editor
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> closingDelimiters [
+
+	^self paragraph closingDelimiters
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> compose [ 
+	^self paragraph compose 
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> container [
+	^self paragraph container 
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> container: atextContainerOrRectangle [
+	^self paragraph container: atextContainerOrRectangle 
+]
+
 { #category : #querying }
 RubParagraphDecorator >> decoratorNamed: aKey [
 	^ self key = aKey
 		ifTrue: [ self ]
 		ifFalse: [ next decoratorNamed: aKey ]
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> defaultCharacterBlock [ 
+	^self paragraph defaultCharacterBlock 
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> defaultFontChange [
+
+	^self paragraph defaultFontChange
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> disableDrawingWhile: aBlock [
+	^self paragraph disableDrawingWhile: aBlock
 ]
 
 { #category : #'error handling' }
@@ -78,6 +137,17 @@ RubParagraphDecorator >> drawOnAthensCanvas: aCanvas bounds: aRectangle color: a
 	next drawOnAthensCanvas: aCanvas bounds: aRectangle color: aColor
 ]
 
+{ #category : #delegating }
+RubParagraphDecorator >> drawingEnabled [
+
+	^self paragraph drawingEnabled
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> extent [ 
+	^self paragraph extent 
+]
+
 { #category : #querying }
 RubParagraphDecorator >> hasDecorator: aDecorator [
 	^ self = aDecorator or: [ next hasDecorator: aDecorator ]
@@ -93,6 +163,51 @@ RubParagraphDecorator >> key [
 	^self class key
 ]
 
+{ #category : #delegating }
+RubParagraphDecorator >> lineIndexForPoint: aPoint [
+
+	^self paragraph lineIndexForPoint: aPoint 
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> lineIndexOfCharacterIndex: characterIndex [ 
+	^self paragraph lineIndexOfCharacterIndex: characterIndex 
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> lines [ 
+	^self paragraph lines 
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> margins [
+
+	^self paragraph margins
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> minimumExtent [
+
+	^self paragraph minimumExtent
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> model [
+	^self paragraph model 
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> move: anEvent for: model controller: editor [
+
+	^self paragraph move: anEvent for: model controller: editor
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> moveBy: aPoint [
+
+	^self paragraph moveBy: aPoint 
+]
+
 { #category : #accessing }
 RubParagraphDecorator >> next [
 	^ next
@@ -103,27 +218,103 @@ RubParagraphDecorator >> next: anObject [
 	next := anObject
 ]
 
-{ #category : #'instead of DNU' }
-RubParagraphDecorator >> paragraph [
-	"this method is here to find the paragraph in the chain, instead of relying on implementing #doesNotUnderstand: !!!"
-
-	| p |
-	
-	p := next.
-	
-	[ p  isNotNil and: [ p isKindOf: RubParagraph ] ] whileFalse: [ 
-		p := p next.
-	].
-
-	^p
-	
-	
+{ #category : #delegating }
+RubParagraphDecorator >> numberOfLines [ 
+	^self paragraph numberOfLines 
 ]
 
-{ #category : #'instead of DNU' }
+{ #category : #delegating }
+RubParagraphDecorator >> numberOfPhysicalLines [
+
+	^self paragraph numberOfPhysicalLines
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> openingDelimiters [
+
+	^self paragraph openingDelimiters
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> paragraph [
+	^next paragraph 
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> replaceFrom: start to: stop with: aText [
+	^self paragraph replaceFrom: start to: stop with: aText 
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> selection [
+
+	^self paragraph selection
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> selectionRects [
+
+	^self paragraph selectionRects
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> selectionStart [
+
+	^self paragraph selectionStart
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> selectionStop [
+
+	^self paragraph selectionStop
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> string [
+
+	^self paragraph string
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> tabWidth: anInteger [
+
+	^self paragraph tabWidth: anInteger
+]
+
+{ #category : #delegating }
 RubParagraphDecorator >> text [ 
 
 	^self paragraph text
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> text: aText [
+
+	^self paragraph text: aText
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> textArea [
+
+	^self paragraph textArea
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> textArea: aClient [
+
+	^self paragraph textArea: aClient
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> textStyle [
+
+	^self paragraph textStyle
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> theme [
+
+	^self paragraph theme
 ]
 
 { #category : #initialization }
@@ -133,6 +324,12 @@ RubParagraphDecorator >> unplug [
 			next unplug.
 			next := nil ].
 	super unplug
+]
+
+{ #category : #delegating }
+RubParagraphDecorator >> verticesFrom: firstIndex to: lastIndex [
+
+	^self paragraph verticesFrom: firstIndex to: lastIndex
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Partially fixes #2138.

Add a bunch of methods to RubParagraphDecorator to delegate to the decorator object (in the #next instance variable). This is to limit the use of #doesNotUnderstand: .

I have kept RubParagraphDecorator>>doesNotUnderstand: as I am not sure I have covered all possible methods.

Tested as follows:
1) add Transcript-logging logic to RubParagraphDecorator>>doesNotUnderstand:
2) With the Transcript open, perform manual testing by playing around with the Transcript and System Browser windows; adding new methods to RubParagraphDecorator as required, and then trying to commit all the changes.
3) With the Transcript open, run all test cases to see what methods are still missing.