### PR TITLE
Small cleanup OCASTSemanticAnalyzer: #declareVariableNode:

### DIFF
--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -59,12 +59,12 @@ OCASTSemanticAnalyzer >> compilationContext: aCompilationContext [
 
 { #category : #variables }
 OCASTSemanticAnalyzer >> declareArgumentNode: aVariableNode [
-	^self declareVariableNode: aVariableNode as: ArgumentVariable new
+	^self declareVariableNode: aVariableNode as: (ArgumentVariable named: aVariableNode name) 
 ]
 
 { #category : #variables }
-OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode [
-	^self declareVariableNode: aVariableNode as: TemporaryVariable new
+OCASTSemanticAnalyzer >> declareTemporaryNode: aVariableNode [
+	^self declareVariableNode: aVariableNode as: (TemporaryVariable named: aVariableNode name)
 ]
 
 { #category : #variables }
@@ -76,7 +76,7 @@ OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode as: anOCTempVariable
 		"Another variable with same name is visible from current scope.
 		Warn about the name clash and if proceed add new temp to shadow existing var" 
 		self variable: aVariableNode shadows: var ].
-	var := scope addTemp: anOCTempVariable withName: name.
+	var := scope addTemp: anOCTempVariable.
 	aVariableNode binding: var.
 	^ var
 ]
@@ -227,7 +227,7 @@ OCASTSemanticAnalyzer >> visitPragmaNode: aPragmaNode [
 { #category : #visiting }
 OCASTSemanticAnalyzer >> visitSequenceNode: aSequenceNode [
 	
-	aSequenceNode temporaries do: [ :node | self declareVariableNode: node ].
+	aSequenceNode temporaries do: [ :node | self declareTemporaryNode: node ].
 	aSequenceNode statements do: [ :each | self visitNode: each ].
 	aSequenceNode temporaries reverseDo: [ :node | 
 			node variable isUsed

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -30,18 +30,11 @@ OCAbstractMethodScope >> addCopyingTempToAllScopesUpToDefTemp: aVar [
 ]
 
 { #category : #'temp vars' }
-OCAbstractMethodScope >> addTemp: name [
-	^self addTemp: TemporaryVariable new withName: name
-]
-
-{ #category : #'temp vars' }
-OCAbstractMethodScope >> addTemp: aTempVariable withName: aString [
+OCAbstractMethodScope >> addTemp: aTempVar [	
+	aTempVar scope: self.
 	^ tempVars
-		at: aString
-		put: (aTempVariable
-				name: aString;
-				scope: self;
-				yourself)
+		at: aTempVar name
+		put: aTempVar
 ]
 
 { #category : #'temp vars - vector' }

--- a/src/Reflectivity/RFSemanticAnalyzer.class.st
+++ b/src/Reflectivity/RFSemanticAnalyzer.class.st
@@ -72,7 +72,7 @@ RFSemanticAnalyzer >> visitMethodNode: aMethodNode [
 	aMethodNode scope: scope.  scope node: aMethodNode.
 	aMethodNode arguments do: [:node | self declareArgumentNode: node ].
 	aMethodNode pragmas do: [:each | self visitNode: each].
-	self declareVariableNode: (RBVariableNode named: #RFReifyValueVar).
+	self declareTemporaryNode: (RBVariableNode named: #RFReifyValueVar).
 	self analyseForLinksForNodes: aMethodNode.
 	self visitNode: aMethodNode body.
 
@@ -91,7 +91,7 @@ RFSemanticAnalyzer >> visitStoreIntoTempNode: aNode [
 	name := aNode name.
 	var := scope lookupVarForDeclaration: name.
 	var	ifNil: [ 
-			var := scope addTemp: name ].
+			var := scope addTemp: (TemporaryVariable named: aNode name) ].
 	aNode binding: var.
 ]
 
@@ -101,7 +101,7 @@ RFSemanticAnalyzer >> visitStorePopIntoTempNode: aNode [
 	name := aNode name.
 	var := scope lookupVarForDeclaration: name.
 	var	ifNil: [ 
-			var := scope addTemp: name ].
+			var := scope addTemp: (TemporaryVariable named: aNode name) ].
 	aNode binding: var.
 ]
 


### PR DESCRIPTION
- #addTemp: instead of #addTemp:withName:
- #declareVariableNode: is  too general: declareTemporaryNode: is better as we have already #declareArgumentNode: