### PR TITLE
Remove unused ivar selectedItem in deprecated TreePresenter

### DIFF
--- a/src/Spec-Core/TreePresenter.class.st
+++ b/src/Spec-Core/TreePresenter.class.st
@@ -9,7 +9,6 @@ Class {
 		'menuBlockHolder',
 		'rootsHolder',
 		'selectionHolder',
-		'selectedItem',
 		'autoMultiSelection',
 		'columnInset',
 		'doubleClick',


### PR DESCRIPTION
Fix #8226