### PR TITLE
8168-CompiledMethodreferencedClasses-should-not-take-class-variables-into-account 

### DIFF
--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -421,7 +421,11 @@ ClassTest >> testReferencedClasses [
 	}
 		do: [ :assoc | 
 			self assert: assoc key referencedClasses notEmpty.
-			self assert: (assoc key referencedClasses asSet includesAll: assoc value asSet)]
+			self assert: (assoc key referencedClasses asSet includesAll: assoc value asSet)].
+		
+	"classes referenced from class variables should not be seen as referenced statically"
+	self assert: (SmalltalkImage class>>#compilerClass ) referencedClasses isEmpty.
+	
 ]
 
 { #category : #tests }

--- a/src/System-Support/Behavior.extension.st
+++ b/src/System-Support/Behavior.extension.st
@@ -33,7 +33,7 @@ Behavior >> allUnsentMessages [
 
 { #category : #'*System-Support' }
 Behavior >> referencedClasses [
-	"Return the set of classes that are directly referenced by my methods"
+	"Return the set of classes that are directly referenced by my methods via global Variables"
 
-	^ self methods flatCollectAsSet: #referencedClasses
+	^ self methods flatCollectAsSet: [:each | each referencedClasses]
 ]

--- a/src/System-Support/CompiledMethod.extension.st
+++ b/src/System-Support/CompiledMethod.extension.st
@@ -7,14 +7,18 @@ CompiledMethod >> implementors [
 
 { #category : #'*System-Support' }
 CompiledMethod >> referencedClasses [
-	"Return classes that are directly referenced by this method. It traverses all the compiled methods to get the classes"
+
+	"Return classes that are directly referenced by this method. 
+	We only take globals into account, class vars are skipped.
+	It traverses all the compiled methods to get the classes"
+
 	| result |
 	result := IdentitySet new.
-	self withAllNestedLiteralsDo: [:each | 
-		each value isClass ifTrue: [ result add: each value ]].
-	^result
-
-
+	self withAllNestedLiteralsDo: [ :each | 
+		(each isVariableBinding and: [ 
+			 each isGlobalVariable and: [ each read isClass ] ]) ifTrue: [ 
+			result add: each value ] ].
+	^ result
 ]
 
 { #category : #'*System-Support' }


### PR DESCRIPTION

fixes #8168 by only taking globals into account.