### PR TITLE
Unused ivars in FTHeaderColumnCellMorph and FastTablePresenter

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTCellMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTCellMorph.class.st
@@ -34,7 +34,7 @@ Class {
 	#instVars : [
 		'topSeparator'
 	],
-	#category : #'Morphic-Widgets-FastTable'
+	#category : #'Morphic-Widgets-FastTable-Base'
 }
 
 { #category : #drawing }

--- a/src/Morphic-Widgets-FastTable/FTColumnResizerMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTColumnResizerMorph.class.st
@@ -12,7 +12,7 @@ Class {
 		'leftColumn',
 		'rightColumn'
 	],
-	#category : #'Morphic-Widgets-FastTable'
+	#category : #'Morphic-Widgets-FastTable-Base'
 }
 
 { #category : #'instance creation' }

--- a/src/Morphic-Widgets-FastTable/FTDisplayColumn.class.st
+++ b/src/Morphic-Widgets-FastTable/FTDisplayColumn.class.st
@@ -11,7 +11,7 @@ Class {
 		'column',
 		'width'
 	],
-	#category : #'Morphic-Widgets-FastTable'
+	#category : #'Morphic-Widgets-FastTable-Base'
 }
 
 { #category : #'instance creation' }

--- a/src/Morphic-Widgets-FastTable/FTHeaderColumnCellMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTHeaderColumnCellMorph.class.st
@@ -5,12 +5,9 @@ Class {
 	#name : #FTHeaderColumnCellMorph,
 	#superclass : #FTCellMorph,
 	#instVars : [
-		'column',
-		'allowSort',
-		'isColumnOrderedFromLeast',
-		'isColumnOrderedFromGreatest'
+		'column'
 	],
-	#category : #'Morphic-Widgets-FastTable'
+	#category : #'Morphic-Widgets-FastTable-Base'
 }
 
 { #category : #accessing }

--- a/src/Morphic-Widgets-FastTable/FTIndentedCellMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTIndentedCellMorph.class.st
@@ -9,7 +9,7 @@ Class {
 	#instVars : [
 		'indentation'
 	],
-	#category : #'Morphic-Widgets-FastTable'
+	#category : #'Morphic-Widgets-FastTable-Base'
 }
 
 { #category : #layout }

--- a/src/Morphic-Widgets-FastTable/FTRowLayout.class.st
+++ b/src/Morphic-Widgets-FastTable/FTRowLayout.class.st
@@ -5,7 +5,7 @@ I simplify my parent (in an attept to achieve speed), but most important, Itake 
 Class {
 	#name : #FTRowLayout,
 	#superclass : #RowLayout,
-	#category : #'Morphic-Widgets-FastTable'
+	#category : #'Morphic-Widgets-FastTable-Base'
 }
 
 { #category : #layouting }

--- a/src/Morphic-Widgets-FastTable/FTSelectableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTSelectableMorph.class.st
@@ -12,7 +12,7 @@ Class {
 	#instVars : [
 		'selectionColor'
 	],
-	#category : #'Morphic-Widgets-FastTable'
+	#category : #'Morphic-Widgets-FastTable-Base'
 }
 
 { #category : #initialization }

--- a/src/Morphic-Widgets-FastTable/FTTableContainerMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableContainerMorph.class.st
@@ -36,7 +36,7 @@ Class {
 		'exposedRows',
 		'startColumnIndex'
 	],
-	#category : #'Morphic-Widgets-FastTable'
+	#category : #'Morphic-Widgets-FastTable-Base'
 }
 
 { #category : #accessing }

--- a/src/Morphic-Widgets-FastTable/FTTableContainerRowNotHomogeneousMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableContainerRowNotHomogeneousMorph.class.st
@@ -4,7 +4,7 @@ I contain table rows, but opposite to my parent, I calculate my row heights allo
 Class {
 	#name : #FTTableContainerRowNotHomogeneousMorph,
 	#superclass : #FTTableContainerMorph,
-	#category : #'Morphic-Widgets-FastTable'
+	#category : #'Morphic-Widgets-FastTable-Base'
 }
 
 { #category : #private }

--- a/src/Morphic-Widgets-FastTable/FTTableHeaderRowMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableHeaderRowMorph.class.st
@@ -5,7 +5,7 @@ All my work is to keep header cells, but my behavior is slightly different to my
 Class {
 	#name : #FTTableHeaderRowMorph,
 	#superclass : #FTTableRowMorph,
-	#category : #'Morphic-Widgets-FastTable'
+	#category : #'Morphic-Widgets-FastTable-Base'
 }
 
 { #category : #'event handling' }

--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -50,7 +50,7 @@ Class {
 		'resizable',
 		'selectionModeStrategy'
 	],
-	#category : #'Morphic-Widgets-FastTable'
+	#category : #'Morphic-Widgets-FastTable-Base'
 }
 
 { #category : #accessing }

--- a/src/Morphic-Widgets-FastTable/FTTableRowMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableRowMorph.class.st
@@ -5,7 +5,7 @@ All my work is to keep cells.
 Class {
 	#name : #FTTableRowMorph,
 	#superclass : #FTSelectableMorph,
-	#category : #'Morphic-Widgets-FastTable'
+	#category : #'Morphic-Widgets-FastTable-Base'
 }
 
 { #category : #'instance creation' }

--- a/src/Spec-Core/FastTablePresenter.class.st
+++ b/src/Spec-Core/FastTablePresenter.class.st
@@ -6,7 +6,6 @@ Class {
 	#superclass : #ListPresenter,
 	#instVars : [
 		'iconHolder',
-		'displayBlock',
 		'handlesDoubleClick',
 		'doubleClick',
 		'columns'


### PR DESCRIPTION
Fix #8248
- remove unused ivars
- categorize uncategorized classes