### PR TITLE
Remove unused vars in HandMorph

### DIFF
--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -25,14 +25,12 @@ Class {
 		'savedPatch',
 		'lastEventBuffer',
 		'lastKeyScanCode',
-		'combinedChar',
 		'captureBlock',
 		'recentModifiers',
 		'pendingEventQueue'
 	],
 	#classVars : [
 		'DoubleClickTime',
-		'EventSource',
 		'EventStats',
 		'NormalCursor',
 		'PasteBuffer',


### PR DESCRIPTION
Fix #8250