### PR TITLE
8242 has package matching extension name uses symbol concatenation

### DIFF
--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -667,9 +667,16 @@ RPackageOrganizer >> packageMatchingExtensionName: anExtensionName [
 	
 	"if no package was found, we try to find one matching the begining of the name specified"
 	tmpPackageName := ''.
-	packages keysDo: [:aSymbol |
-		(anExtensionName beginsWithEmpty: (aSymbol asString, '-') caseSensitive: false)
-			ifTrue: [
+	packages keysDo: [:aSymbol | | aSymbolIndex aMinusIndex hasPrefix |
+		aSymbolIndex := anExtensionName
+			                findString: aSymbol
+			                startingAt: 1
+			                caseSensitive: false.
+		aMinusIndex := aSymbolIndex + aSymbol size.
+		hasPrefix := aSymbolIndex > 0 and: [ 
+			             aMinusIndex <= anExtensionName size and: [ 
+				             (anExtensionName at: aMinusIndex) = $- ] ].
+		hasPrefix ifTrue: [ 
 				"we keep the longest package name found"
 				(aSymbol size > tmpPackageName size) 
 					ifTrue: [ tmpPackageName := aSymbol ]]].

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -449,14 +449,22 @@ RPackageOrganizer >> hasPackageForProtocol: aProtocolName inClass: aClass [
 { #category : #'system integration' }
 RPackageOrganizer >> hasPackageMatchingExtensionName: anExtensionName [
 
-	(self hasPackageExactlyMatchingExtensionName: anExtensionName)
-		ifTrue: [ ^true ].
-		
+	(self hasPackageExactlyMatchingExtensionName: anExtensionName) 
+		ifTrue: [ ^ true ].
+
 	packages keysDo: [ :aSymbol | 
-		(anExtensionName beginsWithEmpty: aSymbol, '-' caseSensitive: false)
-			ifTrue: [ ^ true]].
+		| aSymbolIndex aMinusIndex hasPrefix |
+		"we avoid string concatenation and check directly"
+		aSymbolIndex := anExtensionName
+			                findString: aSymbol
+			                startingAt: 1
+			                caseSensitive: false.
+		aMinusIndex := aSymbolIndex + aSymbol size.
+		hasPrefix := aSymbolIndex > 0 and: [ 
+			             aMinusIndex <= anExtensionName size and: [ 
+				             (anExtensionName at: aMinusIndex) = $- ] ].
+		hasPrefix ifTrue: [ ^ true ] ].
 	^ false
-	
 ]
 
 { #category : #testing }


### PR DESCRIPTION
This removes the string concatenation in both methods using the idea to check directly