### PR TITLE
8241-Warning-PotentialOutDatedDependencyWarning-Kernel-FFI-Kernel-dependency-declared-in-the-package-Manifest-as-manuallyResolvedDependencies-not-detected-as-a-dependency 

### DIFF
--- a/src/Collections-Tests/ManifestCollectionsTests.class.st
+++ b/src/Collections-Tests/ManifestCollectionsTests.class.st
@@ -14,7 +14,7 @@ ManifestCollectionsTests class >> dependencies [
 
 { #category : #'meta-data - dependency analyser' }
 ManifestCollectionsTests class >> manuallyResolvedDependencies [
-	^ #(#'Kernel-Chronology-Extras' #'Math-Operations-Extensions' #'OpalCompiler-Core')
+	^ #(#'Math-Operations-Extensions')
 ]
 
 { #category : #'meta-data' }

--- a/src/Kernel/ManifestKernel.class.st
+++ b/src/Kernel/ManifestKernel.class.st
@@ -19,7 +19,7 @@ ManifestKernel class >> ignoredDependencies [
 
 { #category : #'meta-data - dependency analyser' }
 ManifestKernel class >> manuallyResolvedDependencies [
-	^ #(#'System-Settings-Core' #'System-Sources' #'System-Platforms' #'Shift-ClassBuilder' #'Regex-Core' #'RPackage-Core' #'Zinc-Character-Encoding-Core' #Reflectivity #'Shift-ClassInstaller' #'FFI-Kernel' #'FFI-OldFFIBackend')
+	^ #(#'System-Settings-Core' #'System-Sources' #'System-Platforms' #'Shift-ClassBuilder' #'Regex-Core' #'RPackage-Core' #'Zinc-Character-Encoding-Core' #Reflectivity #'Shift-ClassInstaller' #'FFI-OldFFIBackend')
 ]
 
 { #category : #'meta-data' }


### PR DESCRIPTION
I executed the tests of the Dependency Analyzer and fixed the warnings
fixes #8241


