### PR TITLE
8204-MCPackageLoaderbasicLoadDefinitions-loads-classes-twice 

### DIFF
--- a/src/Monticello/MCPackageLoader.class.st
+++ b/src/Monticello/MCPackageLoader.class.st
@@ -208,7 +208,9 @@ MCPackageLoader >> sorterForItems: aCollection [
 
 { #category : #private }
 MCPackageLoader >> tryToLoad: aDefinition [
-	[aDefinition addMethodAdditionTo: methodAdditions] on: Error do: [errorDefinitions add: aDefinition].
+	"no need to load class definitions again"
+	aDefinition isClassDefinition ifTrue: [ ^ self ].
+	[aDefinition addMethodAdditionTo: methodAdditions] on: Error do: [errorDefinitions add: aDefinition]
 ]
 
 { #category : #public }


### PR DESCRIPTION
As suggested in #8204, do not load the class definition twice

