### PR TITLE
8283-ClassDescriptiondefinition-called-from-GTSpotterExtensionsOnClassTesttestBasic-has-been-deprecated

### DIFF
--- a/src/GT-SpotterExtensions-Core/GTSpotterExtensionsOnClassTest.class.st
+++ b/src/GT-SpotterExtensions-Core/GTSpotterExtensionsOnClassTest.class.st
@@ -10,5 +10,5 @@ GTSpotterExtensionsOnClassTest >> testBasic [
 	| def cls |
 	cls := self class.
 	def := cls definitionForSpotter.
-	self assert: (def beginsWith: cls definition)
+	self assert: (def beginsWith: cls definitionString)
 ]


### PR DESCRIPTION

fixes #8283