### PR TITLE
RB - Fix issue replace message send by another message send

### DIFF
--- a/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
+++ b/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
@@ -126,6 +126,11 @@ RBChangeMethodNameRefactoring >> renameMessageSends [
 	self convertAllReferencesTo: oldSelector using: self parseTreeRewriter
 ]
 
+{ #category : #transforming }
+RBChangeMethodNameRefactoring >> renameMessageSendsIn: classes [
+	self convertAllReferencesTo: oldSelector of: classes using: self parseTreeRewriter
+]
+
 { #category : #initialization }
 RBChangeMethodNameRefactoring >> renameMethod: aSelector in: aClass to: newSel permutation: aMap [ 
 	oldSelector := aSelector asSymbol.

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -135,6 +135,13 @@ RBNamespace >> allReferencesTo: aSymbol do: aBlock [
 ]
 
 { #category : #accessing }
+RBNamespace >> allReferencesTo: aSymbol in: classes [
+	| classNames |
+	classNames := classes collect: [ :cls | cls name ].
+	^ (self allReferencesTo: aSymbol) select: [ :ref | classNames includes: ref modelClass name ]
+]
+
+{ #category : #accessing }
 RBNamespace >> allReferencesToClass: aRBClass do: aBlock [ 
 	self allClassesDo: 
 			[:each |
@@ -374,6 +381,17 @@ RBNamespace >> privateReferencesTo: aSelector [
 	| methods |
 	methods := OrderedCollection new.
 	self allClassesDo: [ :class |
+		(class whichSelectorsReferToSymbol: aSelector)
+			do: [ :selector |
+				methods add: (class methodFor: selector) ] ].
+	^ methods
+]
+
+{ #category : #private }
+RBNamespace >> privateReferencesTo: aSelector in: classes [
+	| methods |
+	methods := OrderedCollection new.
+	classes do: [ :class |
 		(class whichSelectorsReferToSymbol: aSelector)
 			do: [ :selector |
 				methods add: (class methodFor: selector) ] ].

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -155,6 +155,17 @@ RBRefactoring >> classObjectFor: anObject [
 ]
 
 { #category : #support }
+RBRefactoring >> convertAllReferencesTo: aSymbol of: classes using: searchReplacer [ 
+	(self model allReferencesTo: aSymbol in: classes)
+		do: 
+			[:method | 
+			self 
+				convertMethod: method selector
+				for: method modelClass
+				using: searchReplacer]
+]
+
+{ #category : #support }
 RBRefactoring >> convertAllReferencesTo: aSymbol using: searchReplacer [ 
 	self model allReferencesTo: aSymbol
 		do: 

--- a/src/Refactoring-Core/RBReplaceMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBReplaceMethodRefactoring.class.st
@@ -8,6 +8,9 @@ All senders of this method are changed by the other
 Class {
 	#name : #RBReplaceMethodRefactoring,
 	#superclass : #RBChangeMethodNameRefactoring,
+	#instVars : [
+		'replaceInAllClasses'
+	],
 	#category : #'Refactoring-Core-Refactorings'
 }
 
@@ -22,12 +25,33 @@ RBReplaceMethodRefactoring class >> model: aRBSmalltalk replaceMethod: aSelector
 		yourself
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
+RBReplaceMethodRefactoring class >> model: aRBSmalltalk replaceMethod: aSelector in: aClass to: newSelector permutation: aMap inAllClasses: aBoolean [
+	^ self new
+		model: aRBSmalltalk;
+		replaceCallMethod: aSelector
+			in: aClass
+			to: newSelector
+			permutation: aMap
+			inAllClasses: aBoolean;
+		yourself
+]
+
+{ #category : #'instance creation' }
 RBReplaceMethodRefactoring class >> replaceCallMethod: aSelector in: aClass to: newSelector permutation: aMap [ 
 	^self new replaceCallMethod: aSelector
 		in: aClass
 		to: newSelector
 		permutation: aMap
+]
+
+{ #category : #'instance creation' }
+RBReplaceMethodRefactoring class >> replaceCallMethod: aSelector in: aClass to: newSelector permutation: aMap inAllClasses: aBoolean [
+	^self new replaceCallMethod: aSelector
+		in: aClass
+		to: newSelector
+		permutation: aMap
+		inAllClasses: aBoolean
 ]
 
 { #category : #transforming }
@@ -50,7 +74,9 @@ RBReplaceMethodRefactoring >> preconditions [
 	
 	^ conditions & (RBCondition withBlock: 
 		[ |senders|
-		senders := self model allReferencesTo: oldSelector.
+		senders := self replaceInAllClasses 
+			ifTrue: [ self model allReferencesTo: oldSelector ]
+			ifFalse: [ self model allReferencesTo: oldSelector in: {class} ].
 		senders size > 1 
 			ifTrue: 
 				[self refactoringWarning: ('This will modify all <1p> senders.' 
@@ -63,10 +89,26 @@ RBReplaceMethodRefactoring >> replaceCallMethod: aSelector in: aClass to: newSel
 	oldSelector := aSelector asSymbol.
 	newSelector := newSel asSymbol.
 	class := self classObjectFor: aClass.
-	permutation := aMap
+	permutation := aMap.
+]
+
+{ #category : #'as yet unclassified' }
+RBReplaceMethodRefactoring >> replaceCallMethod: aSelector in: aClass to: newSel permutation: aMap inAllClasses: aBoolean [
+	oldSelector := aSelector asSymbol.
+	newSelector := newSel asSymbol.
+	class := self classObjectFor: aClass.
+	permutation := aMap.
+	replaceInAllClasses := aBoolean.
+]
+
+{ #category : #'as yet unclassified' }
+RBReplaceMethodRefactoring >> replaceInAllClasses [
+	^ replaceInAllClasses ifNil: [ replaceInAllClasses := false ]
 ]
 
 { #category : #transforming }
 RBReplaceMethodRefactoring >> transform [
-	self renameMessageSends
+	self replaceInAllClasses 
+		ifTrue: [ self renameMessageSends ]
+		ifFalse: [ self renameMessageSendsIn: {class} ]
 ]

--- a/src/Refactoring-Core/RBReplaceMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBReplaceMethodRefactoring.class.st
@@ -60,7 +60,7 @@ RBReplaceMethodRefactoring >> haveSameNumberOfArgs [
 		ifFalse: [ self refactoringFailure: 'The new selector does not have the same number of parameters.']
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #actions }
 RBReplaceMethodRefactoring >> numberOfArgs: aSymbol [
 	^ (aSymbol asString splitOn: ':' ) size
 ]
@@ -84,7 +84,7 @@ RBReplaceMethodRefactoring >> preconditions [
 		true])
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 RBReplaceMethodRefactoring >> replaceCallMethod: aSelector in: aClass to: newSel permutation: aMap [
 	oldSelector := aSelector asSymbol.
 	newSelector := newSel asSymbol.
@@ -92,7 +92,7 @@ RBReplaceMethodRefactoring >> replaceCallMethod: aSelector in: aClass to: newSel
 	permutation := aMap.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 RBReplaceMethodRefactoring >> replaceCallMethod: aSelector in: aClass to: newSel permutation: aMap inAllClasses: aBoolean [
 	oldSelector := aSelector asSymbol.
 	newSelector := newSel asSymbol.
@@ -101,7 +101,7 @@ RBReplaceMethodRefactoring >> replaceCallMethod: aSelector in: aClass to: newSel
 	replaceInAllClasses := aBoolean.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 RBReplaceMethodRefactoring >> replaceInAllClasses [
 	^ replaceInAllClasses ifNil: [ replaceInAllClasses := false ]
 ]

--- a/src/Refactoring-Tests-Core/RBReplaceMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBReplaceMethodTest.class.st
@@ -4,6 +4,44 @@ Class {
 	#category : #'Refactoring-Tests-Core-Refactorings'
 }
 
+{ #category : #tests }
+RBReplaceMethodTest >> testModelReplaceMethodInAllClasses [
+	| refactoring sendersNewSelector sendersLastSelector selector newSelector |
+	selector := ('an', 'InstVar:') asSymbol.
+	newSelector := ('new', 'ResultClass:') asSymbol.
+	sendersNewSelector := (model allReferencesTo: newSelector) size.
+	sendersLastSelector := (model allReferencesTo: selector) size.
+	refactoring := RBReplaceMethodRefactoring  
+				model: model
+				replaceMethod: selector
+				in: RBBasicLintRuleTestData
+				to: newSelector 
+				permutation: (1 to: 1)
+				inAllClasses: true.
+	self proceedThroughWarning: [ refactoring primitiveExecute ].
+	self assert: sendersNewSelector + sendersLastSelector 
+		equals: (model allReferencesTo: newSelector) size
+]
+
+{ #category : #tests }
+RBReplaceMethodTest >> testModelReplaceMethodOnlyInClass [
+	| refactoring sendersNewSelector sendersLastSelector selector newSelector |
+	selector := ('result', 'Class:') asSymbol.
+	newSelector := ('method', 'Block:') asSymbol.
+	sendersNewSelector := (model allReferencesTo: newSelector) size.
+	sendersLastSelector := ((model allReferencesTo: selector) select: [ :e | e modelClass name = 'RBBasicLintRuleTestData' ] ) size.
+	refactoring := RBReplaceMethodRefactoring  
+				model: model
+				replaceMethod: selector
+				in: RBBasicLintRuleTestData
+				to: newSelector 
+				permutation: (1 to: 1)
+				inAllClasses: false.
+	self proceedThroughWarning: [ refactoring primitiveExecute ].
+	self assert: sendersNewSelector + sendersLastSelector 
+		equals: (model allReferencesTo: newSelector) size
+]
+
 { #category : #'failure tests' }
 RBReplaceMethodTest >> testNotUnderstandNewSelector [
 	self shouldFail: (RBReplaceMethodRefactoring 
@@ -23,22 +61,39 @@ RBReplaceMethodTest >> testNotUnderstandSelector [
 ]
 
 { #category : #tests }
-RBReplaceMethodTest >> testReplaceMethod [
-	| refactoring count |
-	count := (model allReferencesTo: #newResultClass:) size.
-	model allReferencesTo: #anInstVar: do: [:method | count := count + 1].
-	refactoring := RBReplaceMethodRefactoring  
-				model: model
-				replaceMethod: #anInstVar:
+RBReplaceMethodTest >> testReplaceMethodInAllClasses [
+	| refactoring sendersNewSelector sendersLastSelector selector newSelector |
+	selector := ('an', 'InstVar:') asSymbol.
+	newSelector := ('new', 'ResultClass:') asSymbol.
+	refactoring := RBReplaceMethodRefactoring
+				replaceCallMethod: selector
 				in: RBBasicLintRuleTestData
-				to: #newResultClass:
-				permutation: (1 to: 1).
+				to: newSelector 
+				permutation: (1 to: 1)
+				inAllClasses: true.
+	sendersNewSelector := (refactoring model allReferencesTo: newSelector) size.
+	sendersLastSelector := (refactoring model allReferencesTo: selector) size.
 	self proceedThroughWarning: [ refactoring primitiveExecute ].
-	model allReferencesTo: #newResultClass:
-		do: 
-			[:method | 
-			count := count - 1].
-	self assert: count equals: (model allReferencesTo: #anInstVar:) size
+	self assert: sendersNewSelector + sendersLastSelector 
+		equals: (refactoring model allReferencesTo: newSelector) size
+]
+
+{ #category : #tests }
+RBReplaceMethodTest >> testReplaceMethodOnlyInClass [
+	| refactoring sendersNewSelector sendersLastSelector selector newSelector |
+	selector := ('result', 'Class:') asSymbol.
+	newSelector := ('method', 'Block:') asSymbol.
+	refactoring := RBReplaceMethodRefactoring 
+				replaceCallMethod: selector
+				in: RBBasicLintRuleTestData
+				to: newSelector 
+				permutation: (1 to: 1)
+				inAllClasses: false.
+	sendersNewSelector := (refactoring model allReferencesTo: newSelector) size.
+	sendersLastSelector := ((refactoring model allReferencesTo: selector) select: [ :e | e modelClass name = 'RBBasicLintRuleTestData' ]) size.
+	self proceedThroughWarning: [ refactoring primitiveExecute ].
+	self assert: sendersNewSelector + sendersLastSelector 
+		equals: (refactoring model allReferencesTo: newSelector) size
 ]
 
 { #category : #'failure tests' }

--- a/src/Refactoring-Tests-Core/RBSplitCascadeRefactoringTest.class.st
+++ b/src/Refactoring-Tests-Core/RBSplitCascadeRefactoringTest.class.st
@@ -22,7 +22,7 @@ RBSplitCascadeRefactoringTest >> testMethodWithoutCascade [
 	self
 		shouldFail: (RBSplitCascadeRefactoring
 		split: (54 to: 55)
-		from: #anInstVar:
+		from: ('an', 'InstVar:') asSymbol
 		in: RBBasicLintRuleTestData)
 ]
 

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -175,6 +175,13 @@ SystemNavigation >> allReferencesTo: aLiteral do: aBlock [
 ]
 
 { #category : #query }
+SystemNavigation >> allReferencesTo: aLiteral in: classes [
+	"Answer all the methods that refer to aLiteral even deeply embedded in literal array."
+
+	^ classes flatCollect: [ :class | class thoroughWhichMethodsReferTo: aLiteral]
+]
+
+{ #category : #query }
 SystemNavigation >> allReferencesToBinding: aVariablesBinding [
 	"Answer all the methods that refer to aVariableBinding, do not go into nested Arrays"
 

--- a/src/SystemCommands-MessageCommands/SycRemoveMessageArgumentCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycRemoveMessageArgumentCommand.class.st
@@ -10,7 +10,8 @@ Class {
 	#name : #SycRemoveMessageArgumentCommand,
 	#superclass : #SycChangeMessageSignatureCommand,
 	#instVars : [
-		'argumentName'
+		'argumentName',
+		'newSignature'
 	],
 	#category : #'SystemCommands-MessageCommands'
 }

--- a/src/SystemCommands-MessageCommands/SycReplaceMessageCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycReplaceMessageCommand.class.st
@@ -25,6 +25,7 @@ SycReplaceMessageCommand >> createRefactoring [
 		in: originalMessage contextUser origin
 		to: newSelector
 		permutation: (1 to: originalMessage argumentNames size)
+		inAllClasses: self replaceInAllClasses
 ]
 
 { #category : #accessing }
@@ -50,4 +51,9 @@ SycReplaceMessageCommand >> prepareFullExecutionInContext: aToolContext [
 		request: 'Update senders of ', originalMessage selector, ' with:' initialAnswer: originalMessage selector title: 'Replace senders of method'.
 		
 	newSelector isEmptyOrNil | (newSelector = originalMessage selector) ifTrue: [ CmdCommandAborted signal]
+]
+
+{ #category : #execution }
+SycReplaceMessageCommand >> replaceInAllClasses [
+	^ self confirm: 'Do you want replace senders of method in all classes?'
 ]


### PR DESCRIPTION
Fixes #8087

Now the refactoring has the option to change senders in all classes or just in the method class. When we execute command, open a dialog asking 'Do you want replace senders of method in all classes?', if you press OK all senders will be changed and if you press NO only senders of method class will be changed.

@Ducasse 