### PR TITLE
Make temps visible in doIt scripts (debugIt command).

### DIFF
--- a/src/AST-Core/RBValueNode.class.st
+++ b/src/AST-Core/RBValueNode.class.st
@@ -43,7 +43,7 @@ RBValueNode >> evaluate [
 { #category : #evaluating }
 RBValueNode >> evaluateForContext: aContext [
 	"evaluate the AST taking variables from the context"
-	^(self asDoitForContext: aContext) 
+	^(self asReflectiveDoItForContext: aContext) 
 		generateWithSource valueWithReceiver: aContext receiver arguments: {aContext}.
 
 

--- a/src/Kernel/DoItVariable.class.st
+++ b/src/Kernel/DoItVariable.class.st
@@ -68,11 +68,6 @@ DoItVariable >> actualVariable: aVariable [
 	name := actualVariable name
 ]
 
-{ #category : #converting }
-DoItVariable >> asDoItVariableFrom: aContext [
-	^self
-]
-
 { #category : #accessing }
 DoItVariable >> doItContext [
 	^ doItContext

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -74,7 +74,12 @@ Variable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 
 { #category : #converting }
 Variable >> asDoItVariableFrom: aContext [
-	^ DoItVariable fromContext: aContext variable: self
+	"Specific kind of variables may require special logic to be visible in DoIt expressions.
+	For example local variables can't be accessed directly in DoIt expressions in the debugger:
+		- DoIt is executed using new process where there are no temps from the original context.
+	In such cases subclasses should return adapter variable here to represent receiver in DoIt method.
+	DoItVariable class is implemented with this purpose (see the class comment and tests)"
+	^ self
 ]
 
 { #category : #queries }

--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -34,6 +34,25 @@ LocalVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitLocalVariableNode: aNode
 ]
 
+{ #category : #'read/write usage' }
+LocalVariable >> analyzeRead: aVariableNode by: aSemanticAnalyzer [
+	super analyzeRead: aVariableNode by: self.
+
+	aSemanticAnalyzer analyzeLocalVariableRead: self
+]
+
+{ #category : #'read/write usage' }
+LocalVariable >> analyzeWrite: aVariableNode by: aSemanticAnalyzer [
+	super analyzeWrite: aVariableNode by: aSemanticAnalyzer.
+
+	aSemanticAnalyzer analyzeLocalVariableWrite: self
+]
+
+{ #category : #converting }
+LocalVariable >> asDoItVariableFrom: aContext [
+	^ DoItVariable fromContext: aContext variable: self
+]
+
 { #category : #converting }
 LocalVariable >> asString [
 
@@ -201,7 +220,7 @@ LocalVariable >> markEscapingRead [
 { #category : #escaping }
 LocalVariable >> markEscapingWrite [
 	escaping := #escapingWrite.
-	self isRepeatedWrite ifFalse:[usage := #write]
+	self isRepeatedWrite ifFalse: [usage := #write]
 ]
 
 { #category : #'read/write usage' }

--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -36,7 +36,7 @@ LocalVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 
 { #category : #'read/write usage' }
 LocalVariable >> analyzeRead: aVariableNode by: aSemanticAnalyzer [
-	super analyzeRead: aVariableNode by: self.
+	super analyzeRead: aVariableNode by: aSemanticAnalyzer.
 
 	aSemanticAnalyzer analyzeLocalVariableRead: self
 ]

--- a/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
@@ -14,7 +14,7 @@ Class {
 OCASTClosureAnalyzer >> lookupAndFixBinding: aVariableNode [
 	| var |
 	var := scope lookupVar: aVariableNode name.
-	aVariableNode binding: var.
+	aVariableNode variable: var.
 	^var
 ]
 
@@ -36,6 +36,17 @@ OCASTClosureAnalyzer >> visitBlockNode: aBlockNode [
 ]
 
 { #category : #visiting }
+OCASTClosureAnalyzer >> visitLocalVariableNode: aVariableNode [
+	"re-lookup local variables..."
+	| var |
+	var := self lookupAndFixBinding: aVariableNode.
+	var isTempVectorTemp ifTrue: [ | vectorVar |
+		vectorVar := scope lookupVar: var vectorName.
+		scope addCopyingTempToAllScopesUpToDefTemp: vectorVar].
+	var isCopying ifTrue: [scope addCopyingTempToAllScopesUpToDefTemp: var].
+]
+
+{ #category : #visiting }
 OCASTClosureAnalyzer >> visitMethodNode: aMethodNode [
 	"here look at the temps and make copying vars / tempVector out of them"
 	self visitArgumentNodes: aMethodNode arguments.
@@ -44,17 +55,4 @@ OCASTClosureAnalyzer >> visitMethodNode: aMethodNode [
 	scope copyEscapingReads.
 	self visitNode: aMethodNode body.
 	aMethodNode temporaries do: [ :each | self lookupAndFixBinding: each ]
-]
-
-{ #category : #visiting }
-OCASTClosureAnalyzer >> visitVariableNode: aVariableNode [
-	"re-lookup the temorary variables..."
-	
-	| var |
-	aVariableNode isLocalVariable ifFalse: [^self].
-	var := self lookupAndFixBinding: aVariableNode.
-	var isTempVectorTemp ifTrue: [ | vectorVar |
-		vectorVar := scope lookupVar: var vectorName.
-		scope addCopyingTempToAllScopesUpToDefTemp: vectorVar].
-	var isCopying ifTrue: [scope addCopyingTempToAllScopesUpToDefTemp: var].
 ]

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -7,33 +7,11 @@ Class {
 	#superclass : #RBProgramNodeVisitor,
 	#instVars : [
 		'scope',
-		'blockcounter',
-		'compilationContext'
+		'compilationContext',
+		'blockCounter'
 	],
 	#category : #'OpalCompiler-Core-Semantics'
 }
-
-{ #category : #variables }
-OCASTSemanticAnalyzer >> analyseEscapingRead: var [
-	var markRead.
-	(var scope outerNotOptimizedScope ~= scope outerNotOptimizedScope ) ifFalse: [ ^self ].
-	"only escaping when they will end up in different closures"
-	var markEscapingRead.
-	"if we read a variable in a loop that is a repeated write, it need to be marked as escaping write"	
-	(scope isInsideOptimizedLoop and: [var isRepeatedWrite])
-				ifTrue: [var markEscapingWrite]
-]
-
-{ #category : #variables }
-OCASTSemanticAnalyzer >> analyseEscapingWrite: var [
-	(var scope outerNotOptimizedScope ~= scope outerNotOptimizedScope) 
-	"only escaping when they will end up in different closures"
-			ifTrue: [ var markEscapingWrite].
-	"if we write a variable in a loop, mark it as a repeated Write"	
-	scope isInsideOptimizedLoop
-					ifTrue: [ var markRepeatedWrite ]
-					ifFalse: [ var markWrite ]
-]
 
 { #category : #api }
 OCASTSemanticAnalyzer >> analyze: aNode [
@@ -42,9 +20,31 @@ OCASTSemanticAnalyzer >> analyze: aNode [
 	OCASTMethodMetadataAnalyser new visitNode: aNode
 ]
 
+{ #category : #visiting }
+OCASTSemanticAnalyzer >> analyzeLocalVariableRead: aLocalVariable [
+	aLocalVariable markRead.
+	(aLocalVariable scope outerNotOptimizedScope ~= scope outerNotOptimizedScope ) ifFalse: [ ^self ].
+	"only escaping when they will end up in different closures"
+	aLocalVariable markEscapingRead.
+	"if we read a variable in a loop that is a repeated write, it need to be marked as escaping write"	
+	(scope isInsideOptimizedLoop and: [aLocalVariable isRepeatedWrite])
+				ifTrue: [aLocalVariable markEscapingWrite]
+]
+
+{ #category : #visiting }
+OCASTSemanticAnalyzer >> analyzeLocalVariableWrite: aLocalVariable [
+	(aLocalVariable scope outerNotOptimizedScope ~= scope outerNotOptimizedScope) 
+	"only escaping when they will end up in different closures"
+			ifTrue: [ aLocalVariable markEscapingWrite].
+	"if we write a variable in a loop, mark it as a repeated Write"	
+	scope isInsideOptimizedLoop
+					ifTrue: [ aLocalVariable markRepeatedWrite ]
+					ifFalse: [ aLocalVariable markWrite ]
+]
+
 { #category : #accessing }
-OCASTSemanticAnalyzer >> blockcounter [
-	^blockcounter ifNil: [0]
+OCASTSemanticAnalyzer >> blockCounter [
+	^blockCounter ifNil: [0]
 ]
 
 { #category : #accessing }
@@ -82,28 +82,11 @@ OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode as: anOCTempVariable
 ]
 
 { #category : #variables }
-OCASTSemanticAnalyzer >> lookupVariableForRead: aVariableNode [
-
-	| var |
-	
-	var := scope lookupVar: aVariableNode name.
-	
-	var ifNil: [^var].
-	var isLocalVariable ifTrue: [ self analyseEscapingRead: var].
-	^var
-]
-
-{ #category : #variables }
-OCASTSemanticAnalyzer >> lookupVariableForWrite: aVariableNode [
-
-	| var |
-	
-	var := scope lookupVar: aVariableNode name.
-
-	var ifNil: [^var].
-	var isReservedVariable ifTrue: [ self storeIntoReservedVariable: aVariableNode ].
-	var isWritable ifFalse: [ self storeIntoReadOnlyVariable: aVariableNode ].
-	var isLocalVariable ifTrue: [ self analyseEscapingWrite: var ].
+OCASTSemanticAnalyzer >> resolveVariableNode: aVariableNode [
+	| var |	
+	var := (scope lookupVar: aVariableNode name) 
+		ifNil: [ self undeclaredVariable: aVariableNode ].
+	aVariableNode variable: var.
 	^var
 ]
 
@@ -167,18 +150,18 @@ OCASTSemanticAnalyzer >> variable: variableNode shadows: semVar [
 { #category : #visiting }
 OCASTSemanticAnalyzer >> visitAssignmentNode: anAssignmentNode [
 	| var |
-	self visitNode: anAssignmentNode value.
-	var := (self lookupVariableForWrite: anAssignmentNode variable)
-		ifNil: [ self undeclaredVariable: anAssignmentNode variable ].
-	anAssignmentNode variable binding: var
+	self visitNode: anAssignmentNode value.	
+		
+	var := self resolveVariableNode: anAssignmentNode variable.	
+	var analyzeWrite: anAssignmentNode variable by: self
 ]
 
 { #category : #visiting }
 OCASTSemanticAnalyzer >> visitBlockNode: aBlockNode [
-	blockcounter := self blockcounter + 1.
+	blockCounter := self blockCounter + 1.
 
 	aBlockNode isInlined ifTrue: [^ self visitInlinedBlockNode: aBlockNode ].	
-	scope := scope newBlockScope: blockcounter. 
+	scope := scope newBlockScope: blockCounter. 
 	aBlockNode scope: scope. scope node: aBlockNode.
 	
 	aBlockNode arguments do: [:node | self declareArgumentNode: node ].
@@ -189,7 +172,7 @@ OCASTSemanticAnalyzer >> visitBlockNode: aBlockNode [
 { #category : #visiting }
 OCASTSemanticAnalyzer >> visitInlinedBlockNode: aBlockNode [
 
-	scope := scope newOptimizedBlockScope: blockcounter.
+	scope := scope newOptimizedBlockScope: blockCounter.
 	aBlockNode isInlinedLoop ifTrue: [scope markInlinedLoop]. 
 	aBlockNode scope: scope. scope node: aBlockNode.
 	aBlockNode arguments do: [:node | self declareArgumentNode: node ].
@@ -236,9 +219,7 @@ OCASTSemanticAnalyzer >> visitSequenceNode: aSequenceNode [
 
 { #category : #visiting }
 OCASTSemanticAnalyzer >> visitVariableNode: aVariableNode [
-	| var |
-	var := (self lookupVariableForRead: aVariableNode) 
-		ifNil: [(self undeclaredVariable: aVariableNode)].
-	aVariableNode binding: var.
-	var isUninitialized ifTrue: [self uninitializedVariable: aVariableNode].
+	| var |	
+	var := self resolveVariableNode: aVariableNode.
+	var analyzeRead: aVariableNode by: self
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -620,7 +620,7 @@ OpalCompiler >> transformDoit [
 		
 	ast := context 
 		ifNil: [ast asDoit] 
-		ifNotNil: [ast asDoitForContext: context].
+		ifNotNil: [ast asDoItForContext: context].
 	"we need to set the compilation context in the new method node"
 	ast compilationContext: self compilationContext.
 	context ifNotNil: [ast methodClass: context receiver class].

--- a/src/OpalCompiler-Core/ProtoObject.extension.st
+++ b/src/OpalCompiler-Core/ProtoObject.extension.st
@@ -15,7 +15,7 @@ ProtoObject >> mustBeBooleanCompileExpression: context andCache: cache [
 		replace: '^ ``@value' with: 'ThisContext home return: ``@value';
 		executeTree: sendNode.
 	"Build doit node to perform send unoptimized"
-	methodNode := sendNode copy asDoitForContext: context.
+	methodNode := sendNode copy asReflectiveDoItForContext: context.
 	"Keep same compilation context as the sender node's"
 	methodNode compilationContext: sendNode methodNode compilationContext copy.
 	"Disable inlining so the message send will be unoptimized"

--- a/src/OpalCompiler-Core/RBProgramNode.extension.st
+++ b/src/OpalCompiler-Core/RBProgramNode.extension.st
@@ -1,6 +1,25 @@
 Extension { #name : #RBProgramNode }
 
 { #category : #'*OpalCompiler-Core' }
+RBProgramNode >> asDoItForContext: aContext [
+	"The VM can only evaluate methods. wrap this ast in a doItIn: MethodNode to evaluate in a context"
+	| methodNode |
+	self flag: #todo.
+	"With new DoItVariable machinery this logic can be simplified by ommiting ThisContext argument:
+		- all locals are transparently visible from doIt methods.
+	The simplification requires changes in NewTools to expect no arg doIt method.
+	So for now we keep it for compatibility"	
+	methodNode := RBMethodNode 
+		selector: #DoItIn:
+		arguments: { RBVariableNode named: 'ThisContext' } 
+		body: self asSequenceNode transformLastToReturn.
+	
+	methodNode methodClass: aContext receiver class.
+	methodNode source: methodNode formattedCode.
+	^methodNode
+]
+
+{ #category : #'*OpalCompiler-Core' }
 RBProgramNode >> asDoit [
 	"The VM can only evaluate methods. wrap this ast in a doit MethodNode"
 	| methodNode |
@@ -14,10 +33,13 @@ RBProgramNode >> asDoit [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-RBProgramNode >> asDoitForContext: aContext [
-	"The VM can only evaluate methods. wrap this ast in a doitIn MethodNode to evaluate in a context"
-	| methodNode |
-	
+RBProgramNode >> asReflectiveDoItForContext: aContext [
+	"The VM can only evaluate methods. wrap this ast in a doitIn MethodNode to evaluate in a context.
+	The reflective logic here is how locals from the original context are accessed from DoIt method.
+	All locals are rewritted using following reflection calls:
+			- ThisContext readVariableNamed: #tempName.
+			- ThisContext writeVariableNamed: #tempName value: aValue"
+	| 	methodNode |	
 	methodNode := RBMethodNode 
 		selector: #DoItIn:
 		arguments: { RBVariableNode named: 'ThisContext' } 

--- a/src/OpalCompiler-Core/Variable.extension.st
+++ b/src/OpalCompiler-Core/Variable.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #Variable }
+
+{ #category : #'*OpalCompiler-Core' }
+Variable >> analyzeRead: aVariableNode by: aSemanticAnalyzer [
+
+	self isUninitialized ifTrue: [ aSemanticAnalyzer uninitializedVariable: aVariableNode ]
+]
+
+{ #category : #'*OpalCompiler-Core' }
+Variable >> analyzeWrite: aVariableNode by: aSemanticAnalyzer [ 
+
+	self isReservedVariable ifTrue: [ aSemanticAnalyzer storeIntoReservedVariable: aVariableNode ].
+	
+	self isWritable ifFalse: [ aSemanticAnalyzer storeIntoReadOnlyVariable: aVariableNode ]
+]

--- a/src/Slot-Tests/DoItVariableTest.class.st
+++ b/src/Slot-Tests/DoItVariableTest.class.st
@@ -39,6 +39,21 @@ DoItVariableTest >> testCreationFromAnotherVariable [
 ]
 
 { #category : #tests }
+DoItVariableTest >> testDoItCompilation [
+	| temp var doIt |
+	temp := 100.
+	var := DoItVariable named: #temp fromContext: thisContext.	
+	doIt := thisContext class compiler
+		source: 'temp + 2';
+		context: thisContext;
+		noPattern: true;
+		bindings: { var };
+		compile.
+		
+	self assert: (doIt valueWithReceiver: self arguments: #(nil)) equals: 102
+]
+
+{ #category : #tests }
 DoItVariableTest >> testFromInstVarVariable [
 
 	| var |


### PR DESCRIPTION
PR makes temps visible directly in all doIt scripts. 
Previously all temp users were converted to reflective calls like "ThisContext readTempVariable: #tempName". Now you will see normal variable names debugger (try debugIt command).

<img width="490" alt="Screen Shot 2021-01-11 at 00 10 12" src="https://user-images.githubusercontent.com/8149664/104139187-8750ed80-53a1-11eb-86cc-88b883539e4c.png">

Implementation details:

1. It simplifies #asDoItContext: by removal the temp rewrite stage. 
With recently introduced DoItVariable  locals are now transparently visible during compilation of doIt method using requestor context.
In future it will be possible to remove ThisContext argument from debugger DoIt method . But now I keep it for compatibility (change will require NewTools update).
2. It introduces asReflectiveDoItContext: to keep previous logic with rewritten temps in all other places: mustBeBoolean machinary and conditional breakpoints.
These places are special because doIt's there are cached: they are executed over different contexts. In future we can improve them to use special kind of variables and get transparent variables in all places
3. It refactors semantics analyzer to not rely on #isLocalVariable message and use a dispatch to the variable instead. 
It is requried to allow DoItVariable represent external temps during compilation. Otherwise compiler is trying to call some locals specific code during doIt compilation and it fails (DoItVariable is not a local for newly compiled doIt methods).
4. By default Variable>>#asDoItVariable returns self. Only locals are converted to DoItVariable 
The idea is that only variables which can't be used directly in doIts needs to be converted. And it is only local variables. 