### PR TITLE
improve-win32-platform-specific-implementations

### DIFF
--- a/src/FFI-Kernel/ExternalAddress.class.st
+++ b/src/FFI-Kernel/ExternalAddress.class.st
@@ -162,12 +162,12 @@ ExternalAddress >> free [
 ExternalAddress >> fromCString [
 	| index aByte |
 
-	^ (OrderedCollection streamContents: [ :aStream |
+	^ (ByteArray streamContents: [ :aStream |
 			index := 1.
 			[(aByte := self unsignedByteAt: index) = 0] 
 				whileFalse: [
 					aStream nextPut: aByte.
-					index := index + 1]]) asByteArray utf8Decoded
+					index := index + 1]]) utf8Decoded
 
 ]
 

--- a/src/FFI-Kernel/ExternalAddress.class.st
+++ b/src/FFI-Kernel/ExternalAddress.class.st
@@ -159,6 +159,19 @@ ExternalAddress >> free [
 ]
 
 { #category : #converting }
+ExternalAddress >> fromCString [
+	| index aByte |
+
+	^ (OrderedCollection streamContents: [ :aStream |
+			index := 1.
+			[(aByte := self unsignedByteAt: index) = 0] 
+				whileFalse: [
+					aStream nextPut: aByte.
+					index := index + 1]]) asByteArray utf8Decoded
+
+]
+
+{ #category : #converting }
 ExternalAddress >> fromInteger: address [
 	"set my handle to point at address."
 	"Do we really need this? bf 2/21/2001 23:48"

--- a/src/FFI-Kernel/ExternalData.class.st
+++ b/src/FFI-Kernel/ExternalData.class.st
@@ -49,14 +49,9 @@ ExternalData class >> new [
 ExternalData >> fromCString [
 	"Assume that the receiver represents a C string and convert it to a Smalltalk string. hg 2/25/2000 14:18"
 
-	| stream index char |
 	type isPointerType ifFalse: [self error: 'External object is not a pointer type.'].
-	stream := WriteStream on: String new.
-	index := 1.
-	[(char := handle unsignedCharAt: index) = 0 asCharacter] whileFalse: [
-		stream nextPut: char.
-		index := index + 1].
-	^stream contents
+
+	^ handle fromCString
 ]
 
 { #category : #conversion }

--- a/src/FFI-Kernel/ExternalObject.class.st
+++ b/src/FFI-Kernel/ExternalObject.class.st
@@ -39,6 +39,12 @@ ExternalObject class >> installSubclasses [
 	self withAllSubclassesDo:[:cls| cls install].
 ]
 
+{ #category : #'instance creation' }
+ExternalObject class >> null [
+	
+	^ self fromHandle: (ExternalAddress null).
+]
+
 { #category : #'system startup' }
 ExternalObject class >> startUp: resuming [
 	"The system is coming up. If it is on a new platform, clear out the existing handles."

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1522,17 +1522,6 @@ RPackage >> tagsForClasses [
 	^self classTags reject: [:each | each isRoot] thenCollect: [:each | each name]
 ]
 
-{ #category : #testing }
-RPackage >> testSuite [
-
-	| suite |
-	
-	suite := TestSuite named: self packageName.
-	suite addTests: ((self classes select: #isTestCase) flatCollect: [:aTestClass | aTestClass suite tests]).
-	
-	^ suite 
-]
-
 { #category : #private }
 RPackage >> toTagName: aSymbol [
 	^ (aSymbol beginsWith: self name, '-')

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1522,6 +1522,17 @@ RPackage >> tagsForClasses [
 	^self classTags reject: [:each | each isRoot] thenCollect: [:each | each name]
 ]
 
+{ #category : #testing }
+RPackage >> testSuite [
+
+	| suite |
+	
+	suite := TestSuite named: self packageName.
+	suite addTests: ((self classes select: #isTestCase) flatCollect: [:aTestClass | aTestClass suite tests]).
+	
+	^ suite 
+]
+
 { #category : #private }
 RPackage >> toTagName: aSymbol [
 	^ (aSymbol beginsWith: self name, '-')

--- a/src/SUnit-Core/TestSuite.class.st
+++ b/src/SUnit-Core/TestSuite.class.st
@@ -23,6 +23,15 @@ TestSuite class >> named: aString [
 		yourself
 ]
 
+{ #category : #composing }
+TestSuite >> , aTestSuite [ 
+
+		^ TestSuite new
+			addTests: self tests;
+			addTests: aTestSuite tests;
+			yourself
+]
+
 { #category : #dependencies }
 TestSuite >> addDependentToHierachy: anObject [
 	self addDependent: anObject.

--- a/src/SUnit-Tests/RPackage.extension.st
+++ b/src/SUnit-Tests/RPackage.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #RPackage }
+
+{ #category : #'*SUnit-Tests' }
+RPackage >> testSuite [
+
+	| suite |
+	
+	suite := TestSuite named: self packageName.
+	suite addTests: ((self classes select: #isTestCase) flatCollect: [:aTestClass | aTestClass suite tests]).
+	
+	^ suite 
+]

--- a/src/System-Platforms/Win32WideString.class.st
+++ b/src/System-Platforms/Win32WideString.class.st
@@ -29,10 +29,24 @@ Win32WideString class >> fromHandle: handle [
 
 { #category : #'instance creation' }
 Win32WideString class >> fromString: aString [
-	| r wideString anUTF8String codepage |
-	wideString := self new: aString size.
-	anUTF8String := aString utf8Encoded asString.
+	| requestedSize r wideString anUTF8String codepage |
+
+	anUTF8String := aString utf8Encoded.
 	codepage := 65001.
+
+	requestedSize := OSPlatform current
+		multiByteToWideCharacterCodepage: codepage
+		flags: 0
+		input: anUTF8String
+		inputLen: anUTF8String size + 1
+		output: self null
+		outputLen: 0.
+
+	requestedSize = 0 
+		ifTrue: [ self error: 'Error while transforming utf8 string ', 
+				aString, ' using codepage ', codepage asString  ].
+
+	wideString := self new: requestedSize.
 
 	r := OSPlatform current
 		multiByteToWideCharacterCodepage: codepage
@@ -41,6 +55,7 @@ Win32WideString class >> fromString: aString [
 		inputLen: anUTF8String size + 1
 		output: wideString
 		outputLen: wideString byteSize.
+
 
 	r = 0 ifTrue: [ self error: 'Error while transforming utf8 string ', aString, ' using codepage ', codepage asString  ].
 	
@@ -59,8 +74,22 @@ Win32WideString class >> new: size [
 Win32WideString >> asString [
 	| out r codepage |
 
+	(handle isNil or: [ handle isNull ])
+		ifTrue: [ ^ '' ].
+	
 	codepage := 65001.
-	out := ByteArray new: (self size * 4) + 1.
+
+	r := OSPlatform current
+		wideCharacterToMultiByteCodepage: codepage
+		flags: 0
+		input: self
+		inputLen: self size + 1
+		output: ExternalAddress null
+		outputLen: 0.
+
+	r = 0 ifTrue: [ self error: 'Error while transforming windows wide string using codepage ', codepage asString ].
+
+	out := ByteArray new: r.
 	out pinInMemory.
 
 	r := OSPlatform current
@@ -73,7 +102,7 @@ Win32WideString >> asString [
 		
 	r = 0 ifTrue: [ self error: 'Error while transforming windows wide string using codepage ', codepage asString ].
 
-	^ (out first: r - 1) utf8Decoded
+	^ out allButLast utf8Decoded
 ]
 
 { #category : #converting }

--- a/src/System-Platforms/WinPlatform.class.st
+++ b/src/System-Platforms/WinPlatform.class.st
@@ -121,7 +121,7 @@ WinPlatform >> menuShortcutString [
 { #category : #'string-manipulation' }
 WinPlatform >> multiByteToWideCharacterCodepage: codepage flags: flags input: input inputLen: inputLen output: output outputLen: outputLen [
 
-	^self ffiCall: #(int MultiByteToWideChar(uint codepage, ulong flags, String input, int inputLen, Win32WideString output, int outputLen ))
+	^self ffiCall: #(int MultiByteToWideChar(uint codepage, ulong flags, void* input, int inputLen, Win32WideString output, int outputLen ))
 ]
 
 { #category : #'environment-variables' }
@@ -145,5 +145,5 @@ WinPlatform >> virtualKey: virtualKeyCode [
 { #category : #'string-manipulation' }
 WinPlatform >> wideCharacterToMultiByteCodepage: codepage flags: flags input: input inputLen: inputLen output: output outputLen: outputLen [
 
-	^self ffiCall: #(int WideCharToMultiByte(uint codepage, ulong flags, Win32WideString input, int inputLen, ByteArray output, int outputLen, int 0, int 0))
+	^self ffiCall: #(int WideCharToMultiByte(uint codepage, ulong flags, Win32WideString input, int inputLen, void* output, int outputLen, int 0, int 0))
 ]


### PR DESCRIPTION
- Implementing fromCString in a correct way, as it is using the encoder as UTF8
- Adding support for easing the command line testing.
- Improving the implementation of Win32WideString and its conversion to/from Pharo Strings.