### PR TITLE
Fix enclosing and adding comment to KeyboardKey

### DIFF
--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -804,10 +804,6 @@ RubTextEditor >> defaultCommandKeymapping [
 	(KeyboardKey tab -> #tab:).
 	(KeyboardKey delete -> #forwardDelete:) } do: [ :assoc | 
 		cmdMap at: assoc key  put: assoc value ].
-	"I am not convinced the following smart characters are used - see NecPreferences>>smartCharactersMapping"
-	{ KeyboardKey parenthesisLeft . KeyboardKey bracketLeft . KeyboardKey braceLeft .
-		KeyboardKey singleQuote . KeyboardKey doubleQuote . KeyboardKey lessThan } 
-			do: [ :key | cmdMap at: key put: #encloseWith: ].
 	^ cmdMap
 ]
 
@@ -902,34 +898,6 @@ RubTextEditor >> emphasisChoices [
 { #category : #accessing }
 RubTextEditor >> emphasisHere [
 	^ textArea emphasisHere
-]
-
-{ #category : #'editing keys' }
-RubTextEditor >> enclose: aKeyboardEvent [
-	"Insert or remove bracket characters around the current selection."
-
-	| left right startIndex stopIndex oldSelection which text |
-	self deprecated: '***** should be using #encloseWith: and extracting values from NECController>>smartCharactersMapping*****'.
-	self closeTypeIn.
-	startIndex := self startIndex.
-	stopIndex := self stopIndex.
-	oldSelection := self selection.
-	which := '([<{"''' indexOf: aKeyboardEvent keyCharacter ifAbsent: [ ^true ].
-	left := '([<{"''' at: which.
-	right := ')]>}"''' at: which.
-	text := self text.
-	((startIndex > 1 and: [stopIndex <= text size])
-			and: [ (text at: startIndex-1) = left and: [(text at: stopIndex) = right]])
-		ifTrue: [
-			"already enclosed; strip off brackets"
-			self selectFrom: startIndex-1 to: stopIndex.
-			self replaceSelectionWith: oldSelection]
-		ifFalse: [
-			"not enclosed; enclose by matching brackets"
-			self replaceSelectionWith:
-				(Text string: (String with: left), oldSelection string, (String with: right) attributes: self emphasisHere).
-			self selectFrom: startIndex+1 to: stopIndex].
-	^true
 ]
 
 { #category : #'editing keys' }

--- a/src/System-Platforms/KeyboardKey.class.st
+++ b/src/System-Platforms/KeyboardKey.class.st
@@ -1,5 +1,32 @@
 "
-I represent a keyboard Key. I am mapped from the platform specific keycodes into a common keycode base, by using my class side methods.
+I represent a keyboard Key, I am independent from the text issued from myself.
+That is, when you press e.g., the combination Alt + A, you get the Character å (as in ""an instance of Character"") in a text event, but in the KeyDown/Up events you get an instance of the myself, the KeyboardKey A (see section Keys vs Characters below).
+
+# Implementation details
+
+I keep a flyweight of Keys that can be accessed by id or name.
+
+```
+KeyboardKey value: anID.
+KeyboardKey named: 'RETURN'.
+```
+
+The ID of a key corresponds to the keycodes in Unix's X11 key mapping.
+Such ID was chosen because Unix X11 is a super set of the keys supported in Win32 and Cocoa.
+
+Internally I also keep a mapping between Win32 and Cocoa keycodes to X11's keycodes.
+See my class side:
+```
+valueForWindowsPlatform:
+valueForUnixPlatform:
+valueForMacOSXPlatform:
+```
+
+# Keys vs Characters
+
+KeyboardKeys and characters do not have a 1 to 1 mapping. Be careful that keys and Characters do not represent the same thing, specially when we are outside of the english alphabet. In such cases, a Key like E could trigger a Character like e or € depending on the configured keyboard layout and key combinations done. This is specially trickier in asian alphabets.
+
+For backwards compatibility, I provide a helper method that tries to do a mapping in the direction Character -> key (see fromCharacter:) but should be used sparingly and it will be deprecated in the future.
 "
 Class {
 	#name : #KeyboardKey,


### PR DESCRIPTION
Somehow this code did not go through my PR of yesterday.
 - remove unused enclose: (same behavior is covered by smart characters)
 - add comments to keyboard key