### PR TITLE
Smalltalk-restartMethods

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1391,6 +1391,12 @@ Behavior >> removeSelectorSilently: selector [
 	^ SystemAnnouncer uniqueInstance suspendAllWhile: [self removeSelector: selector].
 ]
 
+{ #category : #cleanup }
+Behavior >> restartMethods [
+	"Clean up. Long running loops or stored closures can lead to methods that are out if sync with the recompiled code. Subclasses should override this method if they need to restart methods"
+
+]
+
 { #category : #enumerating }
 Behavior >> selectSubclasses: aBlock [ 
 	"Evaluate the argument, aBlock, with each of the receiver's (next level) 

--- a/src/Morphic-Core/MorphicCoreUIManager.class.st
+++ b/src/Morphic-Core/MorphicCoreUIManager.class.st
@@ -12,7 +12,11 @@ Class {
 
 { #category : #cleanup }
 MorphicCoreUIManager class >> restartMethods [
-   UIProcess ifNotNil: [self default spawnNewProcess ]
+   UIProcess ifNotNil: [
+	| process |
+	process := UIProcess.
+	self new spawnNewProcess.
+	process terminate. ]
 ]
 
 { #category : #'ui requests' }

--- a/src/Morphic-Core/MorphicCoreUIManager.class.st
+++ b/src/Morphic-Core/MorphicCoreUIManager.class.st
@@ -10,6 +10,11 @@ Class {
 	#category : #'Morphic-Core-Support'
 }
 
+{ #category : #cleanup }
+MorphicCoreUIManager class >> restartMethods [
+   UIProcess ifNotNil: [self default spawnNewProcess ]
+]
+
 { #category : #'ui requests' }
 MorphicCoreUIManager >> currentWorld [
 

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -32,6 +32,11 @@ MorphicUIManager class >> isValidForCurrentSystemConfiguration [
 			and: [ Smalltalk isInteractiveGraphic ] ]
 ]
 
+{ #category : #cleanup }
+MorphicUIManager class >> restartMethods [
+   UIProcess ifNotNil: [self default spawnNewProcess ]
+]
+
 { #category : #'ui process' }
 MorphicUIManager class >> uiProcess [ 
 

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -34,7 +34,11 @@ MorphicUIManager class >> isValidForCurrentSystemConfiguration [
 
 { #category : #cleanup }
 MorphicUIManager class >> restartMethods [
-   UIProcess ifNotNil: [self default spawnNewProcess ]
+   UIProcess ifNotNil: [
+	| process |
+	process := UIProcess.
+	self new spawnNewProcess.
+	process terminate. ]
 ]
 
 { #category : #'ui process' }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1580,6 +1580,21 @@ SmalltalkImage >> renameClassNamed: oldName as: newName [
 	^ globals renameClassNamed: oldName as: newName
 ]
 
+{ #category : #cleanup }
+SmalltalkImage >> restartMethods [
+
+	"Clean up. Long running loops or stored closures can lead to methods that are out if sync with the recompiled code"
+
+	| classes |
+	"Find all classes implementing #restartMethods"
+	classes := self allClasses select: [ :aClass | 
+		           aClass class includesSelector: #restartMethods ].
+	"Arrange classes in superclass order, superclasses before subclasses"
+	classes := Class superclassOrder: classes.
+	"Run the cleanup code"
+	classes do: [ :aClass | aClass restartMethods ]
+]
+
 { #category : #saving }
 SmalltalkImage >> saveAs [
 	"Put up the 'saveAs' prompt, obtain a name, and save the image  under that new name."

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -127,6 +127,8 @@ ImageCleaner >> cleanUpMethods [
 		
 	ProcessBrowser initialize.
 	Delay restartTimerEventLoop.
+	"We are moving all the restart code to the classes"
+	Smalltalk restartMethods.
 ]
 
 { #category : #cleaning }


### PR DESCRIPTION
This PR does two things:
- we add #restartMethods to SmalltalkImage
- implement a fall back in Behavior
- implement it in MorphicCoreUIManager and MorphicUIManager which spawn a new morphic process]

For now we call this in ImageCleaner>>#cleanupMethods

The goal of this PR is to make sure that the morphic main loop is restarted so that the method MorphicRenderLoop>>#doOneCycleWhile: on stack is in sync with the code.

Later we need to add #cleanupMethods to more classes to make sure that all methods are restarted.