### PR TITLE
Using rub text decorators to show the next instruction to execute

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -161,14 +161,25 @@ StDebuggerTest >> testCodeChangeAfterContextChange [
 { #category : #'tests - code pane' }
 StDebuggerTest >> testCodeSelectionAfterStepping [
 
-	| dbg |
+	| dbg adapter segments highlightSegment pcRangeForContext |
 	dbg := self debuggerOn: session.
+	adapter := SpMorphicCodeAdapter new.
+	adapter adapt: dbg code.	
+	dbg code adapter: adapter.
+	dbg code adapter buildWidget.	
 	dbg
 		stepInto;
 		stepInto.
+	
+	pcRangeForContext := (session pcRangeForContext: dbg currentContext).
+	segments := dbg code adapter widget segments.
+	self assert: segments size equals: 1.
+	highlightSegment := segments first.	
+	
 	self
-		assert: dbg code selectionInterval
-		equals: (session pcRangeForContext: dbg currentContext)
+		assert:  (highlightSegment firstIndex to: highlightSegment lastIndex)
+		equals: (pcRangeForContext first to: pcRangeForContext last + 1)
+	"The pc range is highlighted with an additionnal index to encompass the full text of the node (why?)"
 ]
 
 { #category : #'tests - context inspector' }

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -159,6 +159,31 @@ StDebuggerTest >> testCodeChangeAfterContextChange [
 ]
 
 { #category : #'tests - code pane' }
+StDebuggerTest >> testCodeSelectionAfterRestart [
+
+	| dbg adapter segments highlightSegment pcRangeForContext |
+	dbg := self debuggerOn: session.
+	adapter := SpMorphicCodeAdapter new.
+	adapter adapt: dbg code.	
+	dbg code adapter: adapter.
+	dbg code adapter buildWidget.	
+	dbg
+		stepInto;
+		stepInto.
+	dbg restartCurrentContext.
+	
+	pcRangeForContext := (session pcRangeForContext: dbg currentContext).
+	segments := dbg code adapter widget segments.
+	self assert: segments size equals: 1.
+	highlightSegment := segments first.	
+	
+	self
+		assert:  (highlightSegment firstIndex to: highlightSegment lastIndex)
+		equals: (pcRangeForContext first to: pcRangeForContext last + 1)
+	"The pc range is highlighted with an additionnal index to encompass the full text of the node (why?)"
+]
+
+{ #category : #'tests - code pane' }
 StDebuggerTest >> testCodeSelectionAfterStepping [
 
 	| dbg adapter segments highlightSegment pcRangeForContext |
@@ -306,6 +331,28 @@ StDebuggerTest >> testDiscardCodeChangesFor [
 StDebuggerTest >> testFastTDD [
 	self debuggerClass fastTDD: nil.
 	self deny: self debuggerClass fastTDD
+]
+
+{ #category : #'tests - code pane' }
+StDebuggerTest >> testInitialCodeSelectionAfterStepping [
+
+	| dbg adapter segments highlightSegment pcRangeForContext |
+	dbg := self debuggerOn: session.
+	adapter := SpMorphicCodeAdapter new.
+	adapter adapt: dbg code.	
+	dbg code adapter: adapter.
+	dbg code adapter buildWidget.
+	dbg stackTable selectItem: dbg stackTable items first.		
+	
+	pcRangeForContext := (session pcRangeForContext: dbg currentContext).
+	segments := dbg code adapter widget segments.
+	self assert: segments size equals: 1.
+	highlightSegment := segments first.	
+	
+	self
+		assert:  (highlightSegment firstIndex to: highlightSegment lastIndex)
+		equals: (pcRangeForContext first to: pcRangeForContext last + 1)
+	"The pc range is highlighted with an additionnal index to encompass the full text of the node (why?)"
 ]
 
 { #category : #'tests - stack table' }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1123,19 +1123,18 @@ StDebugger >> updateCodeFromContext: aContext [
 	aContext sourceCode = self code text 
 		ifFalse: [ self updateSourceCodeFor: aContext ].
 	self code beForContext: aContext.
-	self code selectionInterval: selectionInterval.
+	"self code selectionInterval: selectionInterval."
 	
-	self flag: #DBG, 'the following leaves highlighted text everywhere when the code pane is not updated.'
-	"self
+	self
 		updateCodeTextSegmentDecoratorsIn: aContext
-		forInterval: selectionInterval."
+		forInterval: selectionInterval.
 	
 ]
 
 { #category : #'updating widgets' }
 StDebugger >> updateCodeTextSegmentDecoratorsIn: aContext forInterval: selectionInterval [
-	self flag: #DBG, 'this is temporarily removed for NewTools integration into Pharo 9. We need better support for this.'
-	"self code removeAllTextSegmentDecorations."
+	
+	self code removeAllTextSegmentDecorations.
 	
 	"This decorates the receiver and the next node with an underline"
 	"self code
@@ -1146,13 +1145,13 @@ StDebugger >> updateCodeTextSegmentDecoratorsIn: aContext forInterval: selection
 				yourself)."
 				
 	"This decorates the next executing node"
-	"self code
+	self code
 		addTextSegmentDecoration:
 			(SpTextPresenterDecorator new
 				highlightColor: (Color orange alpha: 0.5);
 				underlineColor: (Color white alpha: 0);
 				interval: (selectionInterval first to: selectionInterval last + 1);
-				yourself)."
+				yourself)
 				
 			"	icon: (self iconNamed: #warning);
 				iconBlock: [ :n | n inspect ];

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -942,6 +942,7 @@ StDebugger >> restartCurrentContext [
 
 	self debuggerActionModel restartContext: self currentContext.
 	self clearUnsavedCodeChanges.
+	self code text: self currentContext sourceCode.
 	self updateCodeFromContext
 ]
 

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -942,7 +942,7 @@ StDebugger >> restartCurrentContext [
 
 	self debuggerActionModel restartContext: self currentContext.
 	self clearUnsavedCodeChanges.
-	self code text: self currentContext sourceCode
+	self updateCodeFromContext
 ]
 
 { #category : #actions }
@@ -1123,7 +1123,6 @@ StDebugger >> updateCodeFromContext: aContext [
 	aContext sourceCode = self code text 
 		ifFalse: [ self updateSourceCodeFor: aContext ].
 	self code beForContext: aContext.
-	"self code selectionInterval: selectionInterval."
 	
 	self
 		updateCodeTextSegmentDecoratorsIn: aContext


### PR DESCRIPTION
This is experimental. This has also been pushed to NewTools, but if it triggers instability, then revert the PR.

![Screenshot 2021-01-13 at 09 56 27](https://user-images.githubusercontent.com/26929529/104429181-9beddb00-5585-11eb-985a-110dc2df9b97.png)
