### PR TITLE
MenubarMorph-restartMethods 

### DIFF
--- a/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
+++ b/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
@@ -28,11 +28,16 @@ Class {
 }
 
 { #category : #'instance creation' }
+MenubarMorph class >> allMenubarsInWorld [
+
+	^ self currentWorld submorphs select: [ :e | 
+		  e isKindOf: MenubarMorph ]
+]
+
+{ #category : #'instance creation' }
 MenubarMorph class >> closeAll [
 
-	self currentWorld submorphs
-		select: [ :e | e isKindOf: MenubarMorph ]
-		thenDo: [ :e | e delete ].
+	self allMenubarsInWorld do: [ :e | e delete ]
 ]
 
 { #category : #'instance creation' }
@@ -90,7 +95,10 @@ MenubarMorph class >> reset [
 
 { #category : #cleanup }
 MenubarMorph class >> restartMethods [
-   self reset
+
+	self allMenubarsInWorld do: [ :mb | 
+		mb menuBarItems:
+			self currentWorld worldState menuBuilder menuSpec items ]
 ]
 
 { #category : #accessing }

--- a/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
+++ b/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
@@ -88,6 +88,11 @@ MenubarMorph class >> reset [
 	self open.
 ]
 
+{ #category : #cleanup }
+MenubarMorph class >> restartMethods [
+   self reset
+]
+
 { #category : #accessing }
 MenubarMorph class >> showMenubar [
 	^ ShowMenubar


### PR DESCRIPTION
MenubarMorph holds onto lots of methods via the menu pragmas. This PR tries to fix it by calling #reset.

We need to check if that works for the CI build.

(This is another cleaning step for #8341)