### PR TITLE
Only open completion menu if in a completion position

### DIFF
--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -112,11 +112,10 @@ CompletionEngine >> handleKeyDownBefore: aKeyboardEvent editor: anEditor [
 	controlKeyPressed := aKeyboardEvent controlKeyPressed.
 	commandKeyPressed := aKeyboardEvent commandKeyPressed.
 	
-	(self editor atCompletionPosition and: [ 
-		(NECPreferences popupShowWithShortcut matches: {aKeyboardEvent})])
-			ifTrue: [
-				self openMenu.
-				^true ].
+	(self isMenuOpen not and: [
+		self editor atCompletionPosition and: [ 
+			NECPreferences popupShowWithShortcut matches: {aKeyboardEvent}]])
+				ifTrue: [ self openMenu. ^ true ].
 	
 	key = KeyboardKey backspace
 		ifTrue: [ 

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -112,10 +112,11 @@ CompletionEngine >> handleKeyDownBefore: aKeyboardEvent editor: anEditor [
 	controlKeyPressed := aKeyboardEvent controlKeyPressed.
 	commandKeyPressed := aKeyboardEvent commandKeyPressed.
 	
-	(NECPreferences popupShowWithShortcut matches: {aKeyboardEvent})
-		 ifTrue: [
-			self openMenu.
-			^true ].
+	(self editor atCompletionPosition and: [ 
+		(NECPreferences popupShowWithShortcut matches: {aKeyboardEvent})])
+			ifTrue: [
+				self openMenu.
+				^true ].
 	
 	key = KeyboardKey backspace
 		ifTrue: [ 

--- a/src/NECompletion-Morphic/NECMenuMorph.class.st
+++ b/src/NECompletion-Morphic/NECMenuMorph.class.st
@@ -480,9 +480,9 @@ NECMenuMorph >> initialize [
 
 { #category : #actions }
 NECMenuMorph >> insertSelected [
+	self delete.
 	context hasEntries ifFalse: [^ false].
 	context activateEntryAt: self selected.
-	self delete.
 	^ true
 ]
 


### PR DESCRIPTION
- Only open completion menu if in a completion position and no menu is already open.
- Fixes the typing of `tab`.
- Correctly close the completion menu if pressing `tab` or `enter`.
   - if there is a selected entry in the completion menu, insert that entry as before
   - if there are no entries in the completion menu, insert the `enter` or `tab`