### PR TITLE
clean the class variables in RubTextSelectionColor

### DIFF
--- a/src/Rubric/RubTextSelectionColor.class.st
+++ b/src/Rubric/RubTextSelectionColor.class.st
@@ -15,6 +15,15 @@ Class {
 	#category : #'Rubric-Editing-Core'
 }
 
+{ #category : #cleanup }
+RubTextSelectionColor class >> cleanUp [
+
+	FindReplaceSelection := nil.
+	OppositeDelimiterSelection := nil.
+	PrimarySelection := nil.
+	SecondarySelection := nil
+]
+
 { #category : #'default accessing' }
 RubTextSelectionColor class >> findReplaceSelection [
 	^ FindReplaceSelection


### PR DESCRIPTION
implement #cleanUp tp reset the class variables in  RubTextSelectionColor. They are all lazy and will be initialised on first use