### PR TITLE
hasBindingThatBeginsWith-Layouts 

### DIFF
--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -265,7 +265,11 @@ ClassTest >> testHasBindingThatBeginsWith [
 	self assert: (SmalltalkImage hasBindingThatBeginsWith: 'Object').
 	
 	"Pools are looked up, too"
-	self assert: (TimeZone hasBindingThatBeginsWith: 'DaysInMo')
+	self assert: (TimeZone hasBindingThatBeginsWith: 'DaysInMo').
+	
+	"CompiledMethodLayout works, too"
+	self deny: (CompiledMethod hasBindingThatBeginsWith: 'Compiler').
+
 ]
 
 { #category : #'tests - access' }

--- a/src/Kernel/AbstractLayout.class.st
+++ b/src/Kernel/AbstractLayout.class.st
@@ -63,6 +63,12 @@ AbstractLayout >> fieldSize [
 ]
 
 { #category : #testing }
+AbstractLayout >> hasBindingThatBeginsWith: aString [
+	"Answer true if there is a Slot that begins with aString, false otherwise"
+	^false
+]
+
+{ #category : #testing }
 AbstractLayout >> hasFields [
 	^ false
 ]


### PR DESCRIPTION
hasBindingThatBeginsWith: was only implemented in PointerLayout, but we need it for all layouts (returning false everywhere else)

This adds test for this as part of testHasBindingThatBeginsWith

