### PR TITLE
Correctly throw a syntax error notification in unfinished statements

### DIFF
--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -1954,6 +1954,27 @@ RBParserTest >> testUnclosedTemporariesErrorNodeContainsRightValue [
 	self assert: tree formattedCode equals: '| faulty temporaries'
 ]
 
+{ #category : #'error testing' }
+RBParserTest >> testUnfinishedStatementWithLeadingBracesRaisesError [
+
+	self should: [(self parserClass parseExpression: '[]}')] 
+		  raise: SyntaxErrorNotification
+]
+
+{ #category : #'error testing' }
+RBParserTest >> testUnfinishedStatementWithLeadingBracketRaisesError [
+
+	self should: [(self parserClass parseExpression: '[]]')] 
+		  raise: SyntaxErrorNotification.
+]
+
+{ #category : #'error testing' }
+RBParserTest >> testUnfinishedStatementWithLeadingParenthesisRaisesError [
+
+	self should: [(self parserClass parseExpression: '[])')] 
+		  raise: SyntaxErrorNotification.
+]
+
 { #category : #private }
 RBParserTest >> treeWithEverything [
 	^ self parserClass

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -1003,7 +1003,8 @@ RBParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 	"If the statement is followed by closers that do not match the current scope, consume them and produce the corresponding errors wrapping the statement."
 	[(')]}' includes: currentToken value)
 		and: [ (aCollectionOfClosers includes: currentToken value) not ]]
-			whileTrue: [ 
+			whileTrue: [
+				self parserError: 'Missing opener for closer: ', currentToken value asString.
 				node := RBUnfinishedStatementErrorNode
 					content: { node }
 					start: node start


### PR DESCRIPTION
When there is an unfinished statement, it correctly generates an error node in a faulty parser, but in the case of a strict parser it is not generating the corresponding exception.

 - add tests
 -  fix the issue by throwing the notification