### PR TITLE
MenubarMorph-Improve

### DIFF
--- a/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
+++ b/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
@@ -29,7 +29,7 @@ Class {
 
 { #category : #'instance creation' }
 MenubarMorph class >> closeAll [
-
+	<script>
 	self currentWorld submorphs
 		select: [ :e | e isKindOf: MenubarMorph ]
 		thenDo: [ :e | e delete ].
@@ -72,12 +72,7 @@ MenubarMorph class >> methodAnnouncementReceived: anAnnouncement [
 { #category : #'instance creation' }
 MenubarMorph class >> open [
 	<script>
-	
-	self showMenubar ifFalse: [ ^ self ].
-
-	self new
-		menuBarItems: self currentWorld worldState menuBuilder menuSpec items;
-		open.
+	self showMenubar ifTrue: [ self new open ]
 ]
 
 { #category : #initialization }
@@ -120,6 +115,13 @@ MenubarMorph >> drawSubmenuMarkerOn: aCanvas [
 	"Nothing"
 ]
 
+{ #category : #accessing }
+MenubarMorph >> initMenuBarItems [
+	^ (PragmaMenuBuilder
+		   pragmaKeyword: WorldState discoveredMenuPragmaKeyword
+		   model: self) menuSpec items
+]
+
 { #category : #initialization }
 MenubarMorph >> initialize [
 	super initialize.
@@ -133,7 +135,7 @@ MenubarMorph >> isMenubar [
 
 { #category : #accessing }
 MenubarMorph >> menuBarItems [
-	^ menuBarItems
+	^ menuBarItems ifNil: [ self initMenuBarItems ]
 ]
 
 { #category : #accessing }
@@ -160,6 +162,8 @@ MenubarMorph >> open [
 				keyText: each keyText.
 			each separator
 				ifTrue: [ self addSeparator ] ].
+	"we do not want to hold on to the items (e.g. Pragmas)"
+	menuBarItems := nil.
 	self
 		adhereToTop;
 		openInWorld

--- a/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
+++ b/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
@@ -28,11 +28,14 @@ Class {
 }
 
 { #category : #'instance creation' }
+MenubarMorph class >> allMenubarsInWorld [
+	^ self currentWorld submorphs select: [ :e | e isKindOf: self ]
+]
+
+{ #category : #'instance creation' }
 MenubarMorph class >> closeAll [
 	<script>
-	self currentWorld submorphs
-		select: [ :e | e isKindOf: MenubarMorph ]
-		thenDo: [ :e | e delete ].
+	self allMenubarsInWorld do: [ :e | e delete ]
 ]
 
 { #category : #'instance creation' }
@@ -83,6 +86,11 @@ MenubarMorph class >> reset [
 	self open.
 ]
 
+{ #category : #cleanup }
+MenubarMorph class >> restartMethods [
+	self allMenubarsInWorld do: [ :e | e reset ]
+]
+
 { #category : #accessing }
 MenubarMorph class >> showMenubar [
 	^ ShowMenubar
@@ -92,6 +100,23 @@ MenubarMorph class >> showMenubar [
 MenubarMorph class >> showMenubar: aBoolean [
 	ShowMenubar := aBoolean.
 	self reset
+]
+
+{ #category : #construction }
+MenubarMorph >> addMenuEntries [
+	self menuBarItems
+		do: [ :each | 
+			self
+				add: each label
+				icon: each icon
+				help: each help
+				subMenu: (each subMenu ifNotNil: #asMenubarMenuMorph)
+				action: each action
+				keyText: each keyText.
+			each separator
+				ifTrue: [ self addSeparator ] ].
+	"we do not want to hold on to the items (e.g. Pragmas)"
+	menuBarItems := nil.
 ]
 
 { #category : #construction }
@@ -115,7 +140,7 @@ MenubarMorph >> drawSubmenuMarkerOn: aCanvas [
 	"Nothing"
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 MenubarMorph >> initMenuBarItems [
 	^ (PragmaMenuBuilder
 		   pragmaKeyword: WorldState discoveredMenuPragmaKeyword
@@ -151,20 +176,8 @@ MenubarMorph >> newMenuItem [
 
 { #category : #accessing }
 MenubarMorph >> open [
-	self menuBarItems
-		do: [ :each | 
-			self
-				add: each label
-				icon: each icon
-				help: each help
-				subMenu: (each subMenu ifNotNil: #asMenubarMenuMorph)
-				action: each action
-				keyText: each keyText.
-			each separator
-				ifTrue: [ self addSeparator ] ].
-	"we do not want to hold on to the items (e.g. Pragmas)"
-	menuBarItems := nil.
 	self
+		addMenuEntries;
 		adhereToTop;
 		openInWorld
 ]
@@ -179,6 +192,12 @@ MenubarMorph >> rejectsEvent: anEvent [
 { #category : #accessing }
 MenubarMorph >> repelsMorph: aMorph event: ev [
 	^ true
+]
+
+{ #category : #construction }
+MenubarMorph >> reset [
+	self submorphs do: [ :each | each delete ].
+	self menuBarItems.
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
a small improvement for MenubarMorph:
- menuBarItems are only used in #open, we do not need to hold on to them

I tried to keep the API  the same (that is, keep the setter for menuBarItems) in case this class is used for non-world menu uses.

(This is another cleaning step for #8341)

