### PR TITLE
5427 debugger into on dead process hangs image

### DIFF
--- a/src/NewTools-Debugger-Commands/StReturnValueCommand.class.st
+++ b/src/NewTools-Debugger-Commands/StReturnValueCommand.class.st
@@ -36,9 +36,10 @@ StReturnValueCommand class >> defaultShortcut [
 ]
 
 { #category : #accessing }
-StReturnValueCommand >> canBeExecuted [
-	"I can always return from a context, for ex. if I'm stuck because of a DNU."
-	^ true
+StReturnValueCommand >> appliesTo: aDebugger [
+	"I can always return from a context, for ex. if I'm stuck because of a DNU.
+	Except from dead contexts"
+	^ aDebugger canExecuteReturnCommand
 ]
 
 { #category : #actions }

--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -329,6 +329,12 @@ StDebuggerActionModelTest >> testIsInterruptedContextAnAssertEqualsFailure [
 ]
 
 { #category : #'tests - predicates' }
+StDebuggerActionModelTest >> testIsInterruptedContextDead [
+	session interruptedContext pc: nil.
+	self assert: debugActionModel isInterruptedContextDead
+]
+
+{ #category : #'tests - predicates' }
 StDebuggerActionModelTest >> testIsInterruptedContextDoesNotUnderstand [
 	self changeSession: StTestDebuggerProvider new debuggerWithDNUContext session.
 	self assert: debugActionModel isInterruptedContextDoesNotUnderstand.

--- a/src/NewTools-Debugger-Tests/StDebuggerCommandTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerCommandTest.class.st
@@ -54,6 +54,35 @@ StDebuggerCommandTest >> testCommandsInDNUContext [
 ]
 
 { #category : #tests }
+StDebuggerCommandTest >> testCommandsInDeadContext [
+
+	|debugger|
+
+	debugger := debuggerProvider debuggerWithErrorContext.
+	debugger debuggerActionModel contextPredicate context pc: nil.
+		
+	"Non-executable commands relative to context"
+	self deny: (StRestartCommand forContext: debugger) canBeExecuted. 
+	self deny: (StReturnValueCommand forContext: debugger) canBeExecuted. 
+	self deny: (StStepIntoCommand forContext: debugger) canBeExecuted. 
+	self deny: (StStepOverCommand forContext: debugger) canBeExecuted. 
+	self deny: (StStepThroughCommand forContext: debugger) canBeExecuted. 
+	self deny: (StRunToSelectionCommand forContext: debugger) canBeExecuted.
+	self deny: (StProceedCommand forContext: debugger) canBeExecuted.
+	self deny: (StDefineClassCommand forContext: debugger) canBeExecuted.  
+	self deny: (StDefineSubclassResponsabilityCommand forContext: debugger) canBeExecuted.  
+	self deny: (StDefineMethodCommand forContext: debugger) canBeExecuted.
+	self deny: (StDefineMissingEntityCommand forContext: debugger) canBeExecuted.  
+	
+	"Executable commands, whatever the context"
+	self assert: (StCopyStackToClipboardCommand forContext: debugger) canBeExecuted. 
+	self assert: (StFileOutMethodCommand forContext: debugger) canBeExecuted. 
+	self assert: (StPeelToFirstCommand forContext: debugger) canBeExecuted. 
+	self assert: (StShowFullStackCommand forContext: debugger) canBeExecuted.	
+	self assert: (StWhereIsCommand forContext: debugger) canBeExecuted. 
+]
+
+{ #category : #tests }
 StDebuggerCommandTest >> testCommandsInErrorContext [
 
 	|debugger|

--- a/src/NewTools-Debugger-Tests/StDebuggerContextPredicateTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerContextPredicateTest.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : #StDebuggerContextPredicateTest,
 	#superclass : #TestCase,
 	#instVars : [
-		'predicate'
+		'predicate',
+		'context'
 	],
 	#category : #'NewTools-Debugger-Tests-Model'
 }
@@ -10,20 +11,34 @@ Class {
 { #category : #running }
 StDebuggerContextPredicateTest >> setUp [
 	super setUp.
-	
-	predicate := (StDebuggerContextPredicate context: 0)
+	context := [  ] asContext.
+	predicate := (StDebuggerContextPredicate context: context)
 ]
 
 { #category : #tests }
 StDebuggerContextPredicateTest >> testContext [
-	self assert: predicate context equals: 0
+	self assert: predicate context identicalTo: context
+]
+
+{ #category : #tests }
+StDebuggerContextPredicateTest >> testIsContextDead [
+	
+	self deny: predicate isContextDead.
+	context pc: nil.
+	self assert: predicate isContextDead
 ]
 
 { #category : #tests }
 StDebuggerContextPredicateTest >> testIsSteppable [
-	
+
 	self assert: predicate isSteppable.
 	predicate postMortem: true.
+	self deny: predicate isSteppable.
+
+	predicate postMortem: false.
+	self assert: predicate isSteppable.
+	context pc: nil.
+	self assert: context isDead.
 	self deny: predicate isSteppable
 ]
 

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -373,7 +373,15 @@ StDebugger >> canExecuteDebugCommand [
 
 { #category : #'command support' }
 StDebugger >> canExecuteRestartCommand [
-	^ self debuggerActionModel isInterruptedContextPostMortem not
+
+	^ (self debuggerActionModel isInterruptedContextPostMortem or: [ 
+		   self debuggerActionModel isInterruptedContextDead ]) not
+]
+
+{ #category : #'command support' }
+StDebugger >> canExecuteReturnCommand [
+
+	^ self debuggerActionModel isInterruptedContextDead not
 ]
 
 { #category : #actions }

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -166,6 +166,11 @@ StDebuggerActionModel >> isInterruptedContextAnAssertEqualsFailure [
 ]
 
 { #category : #'debug - predicates' }
+StDebuggerActionModel >> isInterruptedContextDead [
+	^ self contextPredicate isContextDead
+]
+
+{ #category : #'debug - predicates' }
 StDebuggerActionModel >> isInterruptedContextDoesNotUnderstand [
 	^self contextPredicate isContextDoesNotUnderstand
 

--- a/src/NewTools-Debugger/StDebuggerContextPredicate.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextPredicate.class.st
@@ -49,6 +49,11 @@ StDebuggerContextPredicate >> isContextAnAssertionFailure [
 ]
 
 { #category : #predicates }
+StDebuggerContextPredicate >> isContextDead [
+	^context isDead
+]
+
+{ #category : #predicates }
 StDebuggerContextPredicate >> isContextDoesNotUnderstand [
 	^false
 ]
@@ -70,7 +75,8 @@ StDebuggerContextPredicate >> isContextSubclassResponsibilityException [
 
 { #category : #predicates }
 StDebuggerContextPredicate >> isSteppable [
-	^self isContextPostMortem not
+
+	^ self isContextPostMortem not and: [ self isContextDead not ]
 ]
 
 { #category : #accessing }

--- a/src/NewTools-Sindarin-Tools/StSindarinBytecodeDebuggerPresenter.class.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinBytecodeDebuggerPresenter.class.st
@@ -108,5 +108,6 @@ StSindarinBytecodeDebuggerPresenter >> updateBytecode [
 { #category : #updating }
 StSindarinBytecodeDebuggerPresenter >> updatePresenter [
 	super updatePresenter.
+	self debugger interruptedContext isDead ifTrue:[ ^self ].
 	self updateBytecode
 ]


### PR DESCRIPTION
Fixes #5427
Step commands and context manipulation commands are disabled when the debugger reaches a dead context.
Basically prevents accidental clicking on the step button when in a dead context, which makes the image hang indefinetely. 