### PR TITLE
Minimal failing tests for peculiar ASTs where metalinks break

### DIFF
--- a/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
+++ b/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
@@ -152,6 +152,35 @@ ReflectiveMethodTest >> testSetLinkOnClassVariableAndUninstall [
 
 ]
 
+{ #category : #tests }
+ReflectiveMethodTest >> testSetLinkOnDynamicArrayArgument [
+
+	| link a b |
+	link := MetaLink new
+		        metaObject: #node;
+		        selector: #tagExecuted;
+		        yourself.
+	(ReflectivityExamples >> #exampleDynamicArrayArgument)
+		compiledMethod recompile.
+	a := ReflectivityExamples new exampleDynamicArrayArgument.
+	(ReflectivityExamples >> #exampleDynamicArrayArgument) ast 
+		nodesDo: [ :n | 
+			n removeProperty: #tagExecuted ifAbsent: [  ].
+			n isDynamicArray ifTrue: [ 
+				n
+					propertyAt: #tagExecuted put: false;
+					link: link ] ].
+	b := [ ReflectivityExamples new exampleDynamicArrayArgument ]
+		     on: Error
+		     do: #yourself.
+	link uninstall.
+	self assert: a equals: b.
+	(ReflectivityExamples >> #exampleDynamicArrayArgument) ast 
+		nodesDo: [ :n | 
+			n isDynamicArray ifTrue: [ 
+				self assert: (n propertyAt: #tagExecuted) ] ]
+]
+
 { #category : #'tests - variables' }
 ReflectiveMethodTest >> testSetLinkOnGlobalVariable [
 	| globalVar link |
@@ -210,6 +239,60 @@ ReflectiveMethodTest >> testSetLinkOnInstanceVariableAndUninstall [
 	self assertEmpty: ivar links
 ]
 
+{ #category : #tests }
+ReflectiveMethodTest >> testSetLinkOnLongNestedLiteralArray [
+
+	| link a b |
+	link := MetaLink new
+		        metaObject: #node;
+		        selector: #tagExecuted;
+		        yourself.
+	(ReflectivityExamples >> #exampleLongNestedLiteralArray)
+		compiledMethod recompile.
+	a := ReflectivityExamples new exampleLongNestedLiteralArray.
+	(ReflectivityExamples >> #exampleLongNestedLiteralArray) ast 
+		nodesDo: [ :n | 
+			n removeProperty: #tagExecuted ifAbsent: [  ].
+			n isLiteralArray ifTrue: [ 
+				n
+					propertyAt: #tagExecuted put: false;
+					link: link ] ].
+	b := [ ReflectivityExamples new exampleLongNestedLiteralArray ]
+		     on: Error
+		     do: #yourself.
+	link uninstall.
+	self assert: a equals: b.
+	(ReflectivityExamples >> #exampleLongNestedLiteralArray) ast 
+		nodesDo: [ :n | 
+			n isLiteralArray ifTrue: [ 
+				self assert: (n propertyAt: #tagExecuted) ] ]
+]
+
+{ #category : #tests }
+ReflectiveMethodTest >> testSetLinkOnPragma [
+
+	| link a b |
+	link := MetaLink new
+		        metaObject: #node;
+		        selector: #tagExecuted;
+		        yourself.
+	(ReflectivityExamples >> #examplePragma) compiledMethod recompile.
+	a := ReflectivityExamples new examplePragma.
+	(ReflectivityExamples >> #examplePragma) ast nodesDo: [ :n | 
+		n removeProperty: #tagExecuted ifAbsent: [  ].
+		n isPragma ifTrue: [ 
+			n
+				propertyAt: #tagExecuted put: false;
+				link: link ] ].
+	b := [ ReflectivityExamples new examplePragma ]
+		     on: Error
+		     do: #yourself.
+	link uninstall.
+	self assert: a equals: b.
+	(ReflectivityExamples >> #examplePragma) ast nodesDo: [ :n | 
+		n isPragma ifTrue: [ self assert: (n propertyAt: #tagExecuted) ] ]
+]
+
 { #category : #'tests - links' }
 ReflectiveMethodTest >> testSetLinkOnPrimitive [
 	| methodNode link |
@@ -227,6 +310,93 @@ ReflectiveMethodTest >> testSetLinkOnPrimitive [
 	self assert: (ReflectivityExamples>>#examplePrimitiveMethod) isRealPrimitive.
 	self assert: (ReflectivityExamples>>#examplePrimitiveMethod) reflectiveMethod isNil.
 	
+]
+
+{ #category : #tests }
+ReflectiveMethodTest >> testSetLinkOnProblematicMessage1 [
+
+	| link a b |
+	link := MetaLink new
+		        metaObject: #node;
+		        selector: #tagExecuted;
+		        yourself.
+	(ReflectivityExamples >> #exampleProblematicMessage1) compiledMethod
+		recompile.
+	a := ReflectivityExamples new exampleProblematicMessage1.
+	(ReflectivityExamples >> #exampleProblematicMessage1) ast nodesDo: [ 
+		:n | 
+		n removeProperty: #tagExecuted ifAbsent: [  ].
+		(n isMessage and: [ n selector = #== ]) ifTrue: [ 
+			n
+				propertyAt: #tagExecuted put: false;
+				link: link ] ].
+	b := [ ReflectivityExamples new exampleProblematicMessage1 ]
+		     on: Error
+		     do: #yourself.
+	link uninstall.
+	self assert: a equals: b.
+	(ReflectivityExamples >> #exampleProblematicMessage1) ast nodesDo: [ 
+		:n | 
+		(n isMessage and: [ n selector = #== ]) ifTrue: [ 
+			self assert: (n propertyAt: #tagExecuted) ] ]
+]
+
+{ #category : #tests }
+ReflectiveMethodTest >> testSetLinkOnProblematicMessage2 [
+
+	| link a b |
+	link := MetaLink new
+		        metaObject: #node;
+		        selector: #tagExecuted;
+		        yourself.
+	(ReflectivityExamples >> #exampleProblematicMessage2) compiledMethod
+		recompile.
+	a := ReflectivityExamples new exampleProblematicMessage2.
+	(ReflectivityExamples >> #exampleProblematicMessage2) ast nodesDo: [ 
+		:n | 
+		n removeProperty: #tagExecuted ifAbsent: [  ].
+		(n isMessage and: [ n selector = #= ]) ifTrue: [ 
+			n
+				propertyAt: #tagExecuted put: false;
+				link: link ] ].
+	b := [ ReflectivityExamples new exampleProblematicMessage2 ]
+		     on: Error
+		     do: #yourself.
+	link uninstall.
+	self assert: a equals: b.
+	(ReflectivityExamples >> #exampleProblematicMessage2) ast nodesDo: [ 
+		:n | 
+		(n isMessage and: [ n selector = #= ]) ifTrue: [ 
+			self assert: (n propertyAt: #tagExecuted) ] ]
+]
+
+{ #category : #tests }
+ReflectiveMethodTest >> testSetLinkOnProblematicMessage3 [
+
+	| link a b |
+	link := MetaLink new
+		        metaObject: #node;
+		        selector: #tagExecuted;
+		        yourself.
+	(ReflectivityExamples >> #exampleProblematicMessage3) compiledMethod
+		recompile.
+	a := ReflectivityExamples new exampleProblematicMessage3.
+	(ReflectivityExamples >> #exampleProblematicMessage3) ast nodesDo: [ 
+		:n | 
+		n removeProperty: #tagExecuted ifAbsent: [  ].
+		(n isMessage and: [ n selector = #> ]) ifTrue: [ 
+			n
+				propertyAt: #tagExecuted put: false;
+				link: link ] ].
+	b := [ ReflectivityExamples new exampleProblematicMessage3 ]
+		     on: Error
+		     do: #yourself.
+	link uninstall.
+	self assert: a equals: b.
+	(ReflectivityExamples >> #exampleProblematicMessage3) ast nodesDo: [ 
+		:n | 
+		(n isMessage and: [ n selector = #> ]) ifTrue: [ 
+			self assert: (n propertyAt: #tagExecuted) ] ]
 ]
 
 { #category : #'tests - links' }

--- a/src/Reflectivity-Tests/ReflectivityExamples.class.st
+++ b/src/Reflectivity-Tests/ReflectivityExamples.class.st
@@ -90,6 +90,11 @@ ReflectivityExamples >> exampleClassVarRead [
 	^ClassVar
 ]
 
+{ #category : #'as yet unclassified' }
+ReflectivityExamples >> exampleDynamicArrayArgument [
+	^ OrderedCollection new , {self}
+]
+
 { #category : #examples }
 ReflectivityExamples >> exampleGlobalRead [
 	^GlobalForTesting
@@ -124,6 +129,11 @@ ReflectivityExamples >> exampleLiteralArray [
 	^ #(1)
 ]
 
+{ #category : #'as yet unclassified' }
+ReflectivityExamples >> exampleLongNestedLiteralArray [
+	^ #(#[1 0 9 0 1 0 13 0 9 0 17 0 10 0 21 0 13 0 25 0 15 0 29 0 17 0 33 0 18 0 33 0 19 0 33 0 20 0 33 0 21 0 33 0 22 0 33 0 23 0 33 0 24 0 33 0 25 0 65 0 27] #[0 0 6 0 3 0 4 0 8 0 12 0 14 0 28] #[0 0 10 0 3 0 4 0 8 0 12 0 14 0 28] #[1 0 25 0 15 0 69 0 27] #[1 0 9 0 1 0 13 0 9 0 17 0 10 0 21 0 13 0 25 0 15 0 73 0 17 0 33 0 18 0 33 0 19 0 33 0 20 0 33 0 21 0 33 0 22 0 33 0 23 0 33 0 24 0 33 0 25 0 65 0 27] #[0 0 14 0 2 0 3 0 4 0 6 0 7 0 8 0 11 0 12 0 14 0 28] #[1 0 77 0 4 0 0 0 28] #[0 0 18 0 3 0 4 0 8 0 12 0 14 0 28] #[0 0 22 0 3 0 4 0 8 0 12 0 14 0 28] #[0 0 26 0 3 0 4 0 8 0 12 0 14 0 28] #[0 0 30 0 3 0 4 0 8 0 12 0 14 0 28] #[0 0 34 0 3 0 4 0 8 0 12 0 14 0 28] #[0 0 38 0 3 0 4 0 8 0 12 0 14 0 28] #[0 0 42 0 3 0 4 0 8 0 12 0 14 0 28] #[0 0 46 0 3 0 4 0 8 0 12 0 14 0 28] #[1 0 81 0 2 0 50 0 3 0 50 0 4 0 85 0 6 0 50 0 8 0 89 0 11 0 50 0 12 0 50 0 14 0 50 0 28] #[1 0 54 0 3 0 54 0 4 0 93 0 7 0 54 0 8 0 54 0 12 0 54 0 14 0 54 0 28] #[1 0 77 0 4 0 97 0 14] #[1 0 9 0 1 0 13 0 9 0 17 0 10 0 21 0 13 0 25 0 15 0 101 0 18 0 101 0 19 0 101 0 20 0 101 0 21 0 101 0 22 0 101 0 23 0 101 0 24 0 101 0 25 0 65 0 27] #[1 0 9 0 1 0 58 0 3 0 13 0 9 0 17 0 10 0 21 0 13 0 25 0 15 0 105 0 17 0 33 0 18 0 33 0 19 0 33 0 20 0 33 0 21 0 33 0 22 0 33 0 23 0 33 0 24 0 33 0 25 0 109 0 26 0 65 0 27] #[1 0 9 0 1 0 13 0 9 0 17 0 10 0 21 0 13 0 25 0 15 0 113 0 17 0 33 0 18 0 33 0 19 0 33 0 20 0 33 0 21 0 33 0 22 0 33 0 23 0 33 0 24 0 33 0 25 0 65 0 27] #[1 0 9 0 1 0 13 0 9 0 17 0 10 0 58 0 12 0 21 0 13 0 25 0 15 0 105 0 17 0 33 0 18 0 33 0 19 0 33 0 20 0 33 0 21 0 33 0 22 0 33 0 23 0 33 0 24 0 33 0 25 0 117 0 26 0 65 0 27] #[1 0 9 0 1 0 13 0 9 0 17 0 10 0 21 0 13 0 25 0 15 0 121 0 18 0 121 0 19 0 121 0 20 0 121 0 21 0 121 0 22 0 121 0 23 0 121 0 24 0 121 0 25 0 65 0 27] #[0 0 62 0 3 0 4 0 8 0 12 0 14 0 28] #[0 0 66 0 3 0 4 0 8 0 12 0 14 0 28] #[1 0 70 0 3 0 77 0 4 0 70 0 12] #[0 0 125 0 3] #[1 0 77 0 4 0 129 0 8] #[0 0 133 0 12] #[0 0 74 0 3 0 4 0 8 0 12 0 14 0 28] #[0 0 137 0 5] #[0 0 78 0 3 0 4 0 8 0 12 0 14 0 28] #[0 0 141 0 5] #[1 0 9 0 1 0 13 0 9 0 17 0 10 0 21 0 13 0 25 0 15 0 145 0 18 0 145 0 19 0 145 0 20 0 145 0 21 0 145 0 22 0 145 0 23 0 145 0 24 0 145 0 25 0 65 0 27] #[1 0 9 0 1 0 13 0 9 0 17 0 10 0 21 0 13 0 25 0 15 0 149 0 18 0 149 0 19 0 149 0 20 0 149 0 21 0 149 0 22 0 149 0 23 0 149 0 24 0 149 0 25 0 65 0 27] #[0 0 82 0 3 0 4 0 8 0 12 0 14 0 28] #[0 0 86 0 3 0 4 0 8 0 12 0 14 0 28])
+]
+
 { #category : #examples }
 ReflectivityExamples >> exampleMessageSend [
 	self tagExec: #yes
@@ -153,11 +163,40 @@ ReflectivityExamples >> exampleMethodWithMetaLinkOptions [
 	^ 2 + 3
 ]
 
+{ #category : #'as yet unclassified' }
+ReflectivityExamples >> examplePragma [
+	<tudelu>
+	^ 4
+]
+
 { #category : #examples }
 ReflectivityExamples >> examplePrimitiveMethod [
 	"returns image path"
 	<primitive: 121>
 	^ 2 + 3
+]
+
+{ #category : #'as yet unclassified' }
+ReflectivityExamples >> exampleProblematicMessage1 [
+	^ {} == 2
+]
+
+{ #category : #'as yet unclassified' }
+ReflectivityExamples >> exampleProblematicMessage2 [
+
+	| c |
+	c := { 1. 3. 4 } asSet.
+	c ifEmpty: [ ^ Set new ].
+	c size = 1 ifTrue: [ ^ c anyOne ].
+	^ c
+]
+
+{ #category : #'as yet unclassified' }
+ReflectivityExamples >> exampleProblematicMessage3 [
+
+	| c |
+	c := { 1 } asOrderedCollection.
+	^ c size > -1 and: [ c = c ]
 ]
 
 { #category : #examples }


### PR DESCRIPTION
I was trying to collect coverage of one of my packages by instrumenting every node with metalinks. Compared to the last time I touched metalinks, the time overhead has been greatly reduced. Instrumenting hundreds of methods and running more than one hundred examples is now possible within seconds, no longer minutes or hours *tip of the hat*. But I noticed certain ASTs for which metalinks, that should not change the result of the execution, do actually change the result of the execution (either by errors, or in some cases actually changing values on the stack). Searching my soup of nodes by types and binary search on hashes, allowed me to find the culprits. I tried reducing them to minimal code and added them as tests, which are currently failing. The tests instrument the problematic nodes only, then compares the result of the execution with and without instrumentation, as well as the side-effect of the metalink. I have no concrete idea on how to make the tests pass, Marcus probably has, just a few hints:
 - pragma nodes: no clue how metalinks on them make sense, but the raised error seems to be too late in the pipeline, I think it should fail way earlier, with a more actionable message
 - literal array nodes: not sure if the size or the nesting or the combination causes the problem
 - dynamic array nodes: seem to cause problems when used as arguments
 - ==, =, > message nodes: those seem to be weird edge cases, reducing my convoluted code to a minimal example was quite hard, maybe it has to do with special messages like size, or optimizations?
