### PR TITLE
Do not send Ctrl events as text events on windows or linux

### DIFF
--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -508,8 +508,10 @@ HandMorph >> generateKeyboardEvent: evtBuf [
 		stamp: stamp.
 	
 	"If a modifier key is pressed the keystroke event is handled by #visitMouseDownEvent:"
-	(type == #keystroke and: [ keyEvent commandKeyPressed ])
-		ifTrue: [ ^ #invalid ].
+	(type == #keystroke
+		and: [ keyEvent commandKeyPressed
+			or: [ keyEvent controlKeyPressed ] ])
+				ifTrue: [ ^ #invalid ].
 	
 	keyEvent scanCode: lastKeyScanCode.
 	^keyEvent


### PR DESCRIPTION
Fixes #8368 

Ctrl modified events should not send text events on windows or linux.