### PR TITLE
8146-Stepping-into-Blocks-entirely-an-image

### DIFF
--- a/src/Debugging-Core/SymbolicBytecodeBuilder.class.st
+++ b/src/Debugging-Core/SymbolicBytecodeBuilder.class.st
@@ -78,6 +78,15 @@ SymbolicBytecodeBuilder >> decode [
 ]
 
 { #category : #'instruction decoding' }
+SymbolicBytecodeBuilder >> directedSuperSend: selector numArgs: numberArguments [
+	"Print the Directed Super Send Message With Selector, selector, bytecode. 
+	The current class is located in the stack, then the arguments of the message and the receiver just 
+	below them."
+
+	self addBytecode: 'directedSuperSend: ', selector printString
+]
+
+{ #category : #'instruction decoding' }
 SymbolicBytecodeBuilder >> doDup [
 	"Print the Duplicate Top Of Stack bytecode."
 
@@ -229,7 +238,9 @@ SymbolicBytecodeBuilder >> pushFullClosure: lit numCopied: numCopied receiverOnS
 SymbolicBytecodeBuilder >> pushLiteralVariable: anAssociation [
 	"Print the Push Contents Of anAssociation On Top Of Stack bytecode."
 
-	self addBytecode: 'pushLit: ' , anAssociation key
+	self addBytecode: 'pushLit: ' , (anAssociation key 
+		ifNil: [ anAssociation value ] 
+		ifNotNil: [ anAssociation key ]) asString
 ]
 
 { #category : #'instruction decoding' }

--- a/src/Flashback-Decompiler-Tests/FBDDecompilerTest.class.st
+++ b/src/Flashback-Decompiler-Tests/FBDDecompilerTest.class.st
@@ -801,6 +801,12 @@ FBDDecompilerTest >> testSuper [
 ]
 
 { #category : #tests }
+FBDDecompilerTest >> testSuperCallInBlock [
+
+	self checkCorrectDecompilation: #superCallInBlock
+]
+
+{ #category : #tests }
 FBDDecompilerTest >> testThisContext [
 
 	self checkCorrectDecompilation: #exampleThisContext

--- a/src/Flashback-Decompiler-Tests/FBDExamples.class.st
+++ b/src/Flashback-Decompiler-Tests/FBDExamples.class.st
@@ -1839,6 +1839,13 @@ FBDExamples >> singleRemoteTempVarWrittenAfterClosedOver [
 ]
 
 { #category : #examples }
+FBDExamples >> superCallInBlock [
+
+	^ [ super yourself ] value
+
+]
+
+{ #category : #examples }
 FBDExamples >> writtenAfterClosedOver [
 
 	| a |      

--- a/src/Flashback-Decompiler/FBDDecompiler.class.st
+++ b/src/Flashback-Decompiler/FBDDecompiler.class.st
@@ -175,6 +175,17 @@ FBDDecompiler >> decompileThenRecompileClass: aClass [
 ]
 
 { #category : #'data flow instructions' }
+FBDDecompiler >> directedSuperSend: selector numArgs: numberArguments [
+
+	| args currentClass |
+
+	currentClass := self popFromStack: 1. 
+	args := self popFromStack: numberArguments.
+	simulatedStack removeLast.
+	simulatedStack addLast: (builder codeMessage: selector receiver: builder codeSuper arguments: args ).
+]
+
+{ #category : #'data flow instructions' }
 FBDDecompiler >> doDup [
 	| dupTemp |
 	simulatedStack last class == RBVariableNode

--- a/src/Kernel-Tests-Extended/ClassUsedInInstructionStreamTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassUsedInInstructionStreamTest.class.st
@@ -1,0 +1,38 @@
+Class {
+	#name : #ClassUsedInInstructionStreamTest,
+	#superclass : #SuperClassUsedInInstructionStreamTest,
+	#instVars : [
+		'expectedValue'
+	],
+	#category : #'Kernel-Tests-Extended-Methods'
+}
+
+{ #category : #example }
+ClassUsedInInstructionStreamTest >> aSuperMethod: anInteger with: anotherInteger [
+
+	^ self error
+]
+
+{ #category : #example }
+ClassUsedInInstructionStreamTest >> expectedValue [
+
+	^ expectedValue
+]
+
+{ #category : #example }
+ClassUsedInInstructionStreamTest >> methodWithASuperBlock [
+
+	^ [ super aSuperMethod: 1 with: 2 ]
+]
+
+{ #category : #example }
+ClassUsedInInstructionStreamTest >> methodWithASuperBlockWithoutArguments [
+
+	^ [ super yourself ]
+]
+
+{ #category : #example }
+ClassUsedInInstructionStreamTest >> valueOfBlockWithSupersend [
+
+	expectedValue := self methodWithASuperBlock value
+]

--- a/src/Kernel-Tests-Extended/InstructionStreamTest.class.st
+++ b/src/Kernel-Tests-Extended/InstructionStreamTest.class.st
@@ -1,0 +1,105 @@
+Class {
+	#name : #InstructionStreamTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'operations'
+	],
+	#category : #'Kernel-Tests-Extended-Methods'
+}
+
+{ #category : #testing }
+InstructionStreamTest >> classUnderTest [ 
+
+	^ ClassUsedInInstructionStreamTest
+]
+
+{ #category : #testing }
+InstructionStreamTest >> directedSuperSend: aString numArgs: anInteger [ 
+	
+	operations add: { #directSuperSend:numArgs:. aString. anInteger }
+]
+
+{ #category : #testing }
+InstructionStreamTest >> pushConstant: anInteger [ 
+
+	operations add: { #pushConstant. anInteger }
+]
+
+{ #category : #testing }
+InstructionStreamTest >> pushLiteralVariable: aLiteralVariable [ 
+
+	operations add: { #pushConstant. aLiteralVariable }
+]
+
+{ #category : #testing }
+InstructionStreamTest >> pushReceiver [
+	
+	operations add: {#pushReceiver}
+]
+
+{ #category : #testing }
+InstructionStreamTest >> send: aString super: aBoolean numArgs: anInteger [ 
+
+	operations add: { #send:super:numArgs:. aString. aBoolean. anInteger }
+]
+
+{ #category : #running }
+InstructionStreamTest >> setUp [ 
+
+	super setUp.
+	operations := OrderedCollection new
+]
+
+{ #category : #tests }
+InstructionStreamTest >> testBlockWithASuperSendHasCorrectNumberOfArguments [
+
+	| aMethod aCompiledBlock aStream |
+	aMethod := self classUnderTest >> #methodWithASuperBlock.
+	aCompiledBlock := aMethod literals at:1.
+	
+	self assert: aCompiledBlock isCompiledBlock.
+	
+	aStream := InstructionStream on: aCompiledBlock.
+
+	[ aCompiledBlock endPC > aStream pc ]
+		whileTrue: [aStream interpretNextInstructionFor: self].
+		
+	self assert: operations last equals: { #directSuperSend:numArgs:. #aSuperMethod:with:. 2 }
+]
+
+{ #category : #tests }
+InstructionStreamTest >> testBlockWithASuperWithoutArgumentsSendHasCorrectNumberOfArguments [
+
+	| aMethod aCompiledBlock aStream |
+	aMethod := self classUnderTest >> #methodWithASuperBlockWithoutArguments.
+	aCompiledBlock := aMethod literals at:1.
+	
+	self assert: aCompiledBlock isCompiledBlock.
+	
+	aStream := InstructionStream on: aCompiledBlock.
+
+	[ aCompiledBlock endPC > aStream pc ]
+		whileTrue: [aStream interpretNextInstructionFor: self].
+		
+	self assert: operations last equals: { #directSuperSend:numArgs:. #yourself. 0 }
+]
+
+{ #category : #example }
+InstructionStreamTest >> testSteppingSendsDirectSend [
+
+	| initialContext aContext receiver |
+	
+	receiver := self classUnderTest new.
+	
+	initialContext := Context 
+		sender: nil receiver: receiver 
+		method: self classUnderTest >> #valueOfBlockWithSupersend 
+		arguments: #().
+
+	aContext := initialContext.
+
+	[aContext = nil] 
+		whileFalse: [aContext := aContext step].
+		
+	self assert: receiver expectedValue equals: 42
+]

--- a/src/Kernel-Tests-Extended/SuperClassUsedInInstructionStreamTest.class.st
+++ b/src/Kernel-Tests-Extended/SuperClassUsedInInstructionStreamTest.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #SuperClassUsedInInstructionStreamTest,
+	#superclass : #Object,
+	#category : #'Kernel-Tests-Extended-Methods'
+}
+
+{ #category : #example }
+SuperClassUsedInInstructionStreamTest >> aSuperMethod: anInteger with: anotherInteger [
+
+	^ 42
+]

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -537,6 +537,22 @@ Context >> depthBelow: aContext [
 ]
 
 { #category : #'instruction decoding' }
+Context >> directedSuperSend: selector numArgs: numArgs [ 
+	
+	| lookupClass arguments currentReceiver |
+
+	lookupClass := self pop superclass.
+	
+	arguments := Array new: numArgs.
+	numArgs to: 1 by: -1 do: [ :i | 
+		arguments at: i put: self pop ].
+
+	currentReceiver := self pop.
+	
+	^ self send: selector to: currentReceiver with: arguments lookupIn: lookupClass
+]
+
+{ #category : #'instruction decoding' }
 Context >> doDup [
 	"Simulate the action of a 'duplicate top of stack' bytecode."
 

--- a/src/Kernel/InstructionStream.class.st
+++ b/src/Kernel/InstructionStream.class.st
@@ -78,11 +78,20 @@ InstructionStream >> interpretNext2ByteSistaV1Instruction: bytecode for: client 
 			[^client pushConstant: (extB bitShift: 8) + byte].
 		^client pushConstant: (Character value: (extB bitShift: 8) + byte)].
 	bytecode < 240 ifTrue: "sends, trap and jump"
-		[bytecode < 236 ifTrue: "sends"
-			[^client
+		[bytecode < 236 "sends" 
+			ifTrue: [
+			"The 64 is used as a mark to tell if the send is a direct super send"
+			extB >= 64 
+				ifTrue: [ | fixedExtB |
+					fixedExtB := extB - 64.
+					^ client 
+						 directedSuperSend: (method literalAt: (extA bitShift: 5) + (byte // 8) + 1)
+						 numArgs: (fixedExtB bitShift: 3) + (byte \\ 8)].
+			^client
 				send: (method literalAt: (extA bitShift: 5) + (byte // 8) + 1)
 				super: bytecode = 235
 				numArgs: (extB bitShift: 3) + (byte \\ 8)].
+
 		 bytecode = 236 ifTrue:
 			[^client trapIfNotInstanceOf: (method literalAt: (extA bitShift: 8) + byte + 1)].
 		bytecode = 237 ifTrue:


### PR DESCRIPTION
InstructionStream was not correctly handling the directedSuperSend bytecode.

This bytecode is used in full blocks. It has the difference that it pushed the current class in the stack.

I have:

- Added the decoding of this bytecode.
- Implemented the behavior in Context so it can be simulated in the debugger.
- Added tests for the InstructionStream and the Stepping of the context in a block with a directSuperSend.
- Added support for directed super send in the FBDDecompiler with a test
- Added support for the printing of the bytecode in the SymbolicBytecodeBuilder

Fix #8146 