### PR TITLE
Fix a regression from earlier pharo that used to perserve order in 

### DIFF
--- a/src/Collections-Abstract/SequenceableCollection.class.st
+++ b/src/Collections-Abstract/SequenceableCollection.class.st
@@ -789,6 +789,12 @@ SequenceableCollection >> detectIndex: aBlock ifNone: exceptionBlock [
 ]
 
 { #category : #enumerating }
+SequenceableCollection >> difference: aCollection [
+	"Answer the difference of two sequences preserving order and collection type."
+	^ self reject: [:each | aCollection includes: each]
+]
+
+{ #category : #enumerating }
 SequenceableCollection >> do: aBlock [ 
 	"Refer to the comment in Collection|do:."
 	1 to: self size do:

--- a/src/Collections-Sequenceable-Tests/ArrayTest.class.st
+++ b/src/Collections-Sequenceable-Tests/ArrayTest.class.st
@@ -624,6 +624,16 @@ ArrayTest >> testCopyNonEmptyWithoutAllNotIncluded [
 	
 ]
 
+{ #category : #'tests - enumerating' }
+ArrayTest >> testDifferencePreservesOrder [
+	| n even odd odd2 |
+	n := #(5 3 4).
+	even := #(4).
+	odd := n difference: even.
+	odd2 := n reject: [ :i | i even ].
+	self assert: odd equals: odd2
+]
+
 { #category : #'tests - iterate' }
 ArrayTest >> testDo [
 	| res |

--- a/src/Collections-Sequenceable-Tests/OrderedCollectionTest.class.st
+++ b/src/Collections-Sequenceable-Tests/OrderedCollectionTest.class.st
@@ -911,6 +911,18 @@ OrderedCollectionTest >> testCopyWith [
 
 ]
 
+{ #category : #'tests - enumerating' }
+OrderedCollectionTest >> testDifferencePreservesOrder [
+	| n even odd odd2 |
+	n := OrderedCollection with: 5 with: 3 with: 4.
+	even := OrderedCollection with: 4.
+	odd := n difference: even.
+	odd2 := n reject: [ :i | i even ].
+	self assert: odd equals: odd2
+
+	
+]
+
 { #category : #'tests - begin' }
 OrderedCollectionTest >> testEndsWithAnyOf [
 	"We can't test SequenceableCollection directly. However, we can test a sampling of its descendants."


### PR DESCRIPTION
sequences.

My first PR in Pharo created from web console.  This was not possible from the Iceberg panel - refused my credentials.  I have that problem a lot. 