### PR TITLE
Mouse events were sent twice when using an event handler

### DIFF
--- a/src/Calypso-Browser/ClyNotebookPageHeaderPresenter.class.st
+++ b/src/Calypso-Browser/ClyNotebookPageHeaderPresenter.class.st
@@ -66,14 +66,18 @@ ClyNotebookPageHeaderPresenter >> initializePresenters [
 ClyNotebookPageHeaderPresenter >> mouseDown: event [ 
 
 	"bubble up"
-	self adapter widget owner mouseDown: event
+	self adapter widget owner eventHandler 
+		mouseDown: event 
+		fromMorph: self adapter widget owner
 ]
 
 { #category : #'event processing' }
 ClyNotebookPageHeaderPresenter >> mouseUp: event [ 
 
 	"bubble up"
-	self adapter widget owner mouseUp: event
+	self adapter widget owner eventHandler 
+		mouseUp: event 
+		fromMorph: self adapter widget owner
 ]
 
 { #category : #'event handling' }

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -4341,11 +4341,7 @@ Morph >> morphsInFrontOverlapping: aRectangle do: aBlock [
 
 { #category : #'event handling' }
 Morph >> mouseDown: evt [ 
-	"Handle a mouse down event. The default response is to let my 
-	eventHandler, if any, handle it."
-	self eventHandler
-		ifNotNil: [self eventHandler mouseDown: evt fromMorph: self]
-
+	"Handle a mouse down event. It can be handled here or in the event handler"
 ]
 
 { #category : #'halos and balloon help' }
@@ -4370,11 +4366,7 @@ Morph >> mouseDownPriority [
 
 { #category : #'event handling' }
 Morph >> mouseEnter: evt [
-	"Handle a mouseEnter event, meaning the mouse just entered my bounds with no button pressed. The default response is to let my eventHandler, if any, handle it."
-
-	^ self eventHandler ifNotNil:
-		[self eventHandler mouseEnter: evt fromMorph: self].
-
+	"Handle a mouseEnter event, meaning the mouse just entered my bounds with no button pressed"
 ]
 
 { #category : #'event handling' }
@@ -4388,35 +4380,23 @@ Morph >> mouseEnterDragging: evt [
 
 { #category : #'event handling' }
 Morph >> mouseLeave: evt [
-	"Handle a mouseLeave event, meaning the mouse just left my bounds with no button pressed. The default response is to let my eventHandler, if any, handle it."
-
-	^ self eventHandler ifNotNil:
-		[self eventHandler mouseLeave: evt fromMorph: self].
-
+	"Handle a mouseLeave event, meaning the mouse just left my bounds with no button pressed."
 ]
 
 { #category : #'event handling' }
 Morph >> mouseLeaveDragging: evt [
-	"Handle a mouseLeaveLaden event, meaning the mouse just left my bounds with a button pressed or laden with submorphs. The default response is to let my eventHandler, if any, handle it; else to do nothing."
-
-	self eventHandler ifNotNil:
-		[self eventHandler mouseLeaveDragging: evt fromMorph: self]
+	"Handle a mouseLeaveLaden event, meaning the mouse just left my bounds with a button pressed or laden with submorphs."
 ]
 
 { #category : #'event handling' }
 Morph >> mouseMove: evt [
 	"Handle a mouse move event. The default response is to let my eventHandler, if any, handle it."
-	self eventHandler ifNotNil:
-		[self eventHandler mouseMove: evt fromMorph: self].
 
 ]
 
 { #category : #'event handling' }
 Morph >> mouseStillDown: evt [
 	"Handle a mouse move event. The default response is to let my eventHandler, if any, handle it."
-
-	self eventHandler ifNotNil:
-		[self eventHandler mouseStillDown: evt fromMorph: self].
 
 ]
 
@@ -4435,9 +4415,6 @@ Morph >> mouseStillDownThreshold [
 { #category : #'event handling' }
 Morph >> mouseUp: evt [
 	"Handle a mouse up event. The default response is to let my eventHandler, if any, handle it."
-
-	^ self eventHandler ifNotNil:
-		[self eventHandler mouseUp: evt fromMorph: self].
 
 ]
 

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -2969,10 +2969,11 @@ Morph >> handleMouseEnter: anEvent [
 			^ self eventHandler ifNotNil: [ :handler | handler mouseEnterDragging: anEvent fromMorph: self ] ].
 	self wantsBalloon ifTrue: [ anEvent hand triggerBalloonFor: self after: self balloonHelpDelayTime ].
 
-	^ (self handlesMouseOver: anEvent)
+	(self handlesMouseOver: anEvent)
 		ifTrue: [ anEvent wasHandled: true.
-			self mouseEnter: anEvent ]
-		ifFalse: [ self eventHandler ifNotNil: [ :handler | handler mouseEnter: anEvent fromMorph: self ] ]
+			self mouseEnter: anEvent ].
+	
+	self eventHandler ifNotNil: [ :handler | ^ handler mouseEnter: anEvent fromMorph: self ]
 ]
 
 { #category : #'events-processing' }

--- a/src/Morphic-Tests/MorphicEventHandlerTest.class.st
+++ b/src/Morphic-Tests/MorphicEventHandlerTest.class.st
@@ -171,16 +171,38 @@ MorphicEventHandlerTest >> testMouseEnterEventIsNotDuplicated [
 
 { #category : #'tests-events' }
 MorphicEventHandlerTest >> testMouseEnterFromMorph [
+	| event |
 	morph eventHandler on: #mouseEnter send: #value to: true.
 
-	self assert: (morph mouseEnter: nil) identicalTo: true
+	event := (MouseButtonEvent new 
+		setType: #mouseMove
+		position: 0@0
+		which: 0
+		buttons: 0
+		hand: (HandMorph new
+			mouseFocus: morph;
+			yourself)
+		stamp: Time millisecondClockValue).
+
+	self assert: (morph handleMouseEnter: event) identicalTo: true
 ]
 
 { #category : #'tests-events' }
 MorphicEventHandlerTest >> testMouseLeaveFromMorph [
+	| event |
 	morph eventHandler on: #mouseLeave send: #value to: true.
 
-	self assert: (morph mouseLeave: nil) identicalTo: true
+	event := (MouseButtonEvent new 
+		setType: #mouseMove
+		position: 0@0
+		which: 0
+		buttons: 0
+		hand: (HandMorph new
+			mouseFocus: morph;
+			yourself)
+		stamp: Time millisecondClockValue).
+
+	self assert: (morph handleMouseLeave: event) identicalTo: true
 ]
 
 { #category : #'tests-events' }

--- a/src/Spec2-Morphic-Backend-Tests/SpMorphicNotebookAdapter.extension.st
+++ b/src/Spec2-Morphic-Backend-Tests/SpMorphicNotebookAdapter.extension.st
@@ -3,18 +3,19 @@ Extension { #name : #SpMorphicNotebookAdapter }
 { #category : #'*Spec2-Morphic-Backend-Tests' }
 SpMorphicNotebookAdapter >> clickTab: anIndex [
 	| evt tab |
+	tab := self widget tabSelectorMorph tabs at: anIndex.
+
 	evt := MouseButtonEvent new
 		setType: nil
 		position: widget center
 		which: MouseButtonEvent redButton
 		buttons: MouseButtonEvent redButton
-		hand: nil
+		hand: tab activeHand
 		stamp: nil.
-	tab := self widget tabSelectorMorph tabs at: anIndex.
 
 	(tab handlesMouseDown: evt)
-		ifTrue: [ tab mouseDown: evt.
-			tab mouseUp: evt ]
+		ifTrue: [ tab handleMouseDown: evt.
+			tab handleMouseDown: evt ]
 ]
 
 { #category : #'*Spec2-Morphic-Backend-Tests' }


### PR DESCRIPTION
Mouse events were being handled twice. When using an event handler the notification arrives twice. One from the mouseUp: /mouseDown: event handler and other from handleMouseUp:/handleMouseDown:

Fixing the NotebookPageHeaderPresenter to correctly send the event to the parent. Even this behavior is not the best, to make the event bubble.

This was affecting the toggle labels used in Calypso (to show or hide the line numbers or to word-wrap or not)