### PR TITLE
Reorganize world menu

### DIFF
--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyBrowseBreakpointsCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyBrowseBreakpointsCommand.class.st
@@ -16,8 +16,8 @@ ClyBrowseBreakpointsCommand class >> worldMenuOn: aBuilder [
 	| command |
 	command := self new.
 	(aBuilder item: command defaultMenuItemName)
-		parent: #Debugging;
-		order: 0;
+		parent: #Breakpoints;
+		order: 1;
 		icon: command defaultMenuIcon;
 		help: command description;
 		action: [ command execute ]

--- a/src/DrTests/DrTests.class.st
+++ b/src/DrTests/DrTests.class.st
@@ -144,12 +144,12 @@ DrTests class >> defaultSpec [
 DrTests class >> menuCommandOn: aBuilder [
 	<worldMenu>
 	
-	(aBuilder item: #'Dr Test')
-		parent: #Tools;
+	(aBuilder item: #'Dr Test (Preview)')
+		parent: #Testing;
 		action: [ self open ];
-		order: 21;
+		order: 2;
 		"keyText: 'o, u';" "Note: Removed the shortcut to not clash with SUnitRunner keybinding."
-		help: 'Let you run and debug SUnit tests.';
+		help: '(Preview) Let you run and debug SUnit tests.';
 		icon: self taskbarIcon;
 		withSeparatorAfter	
 ]

--- a/src/EpiceaBrowsers/EpUnifiedBrowserPresenter.class.st
+++ b/src/EpiceaBrowsers/EpUnifiedBrowserPresenter.class.st
@@ -44,11 +44,11 @@ EpUnifiedBrowserPresenter class >> worldMenuItemOn: aBuilder [
 	<worldMenu>
 
 	(aBuilder item: 'Code Changes')
-		parent: #Tools;
+		parent: #Changes;
 		action: [ self open ]; 
 		icon: self taskbarIcon;
 		help: 'Browse recorded change logs during from Pharo coding sessions and replay changes.';
-		order: 401
+		order: 1
 ]
 
 { #category : #refreshing }

--- a/src/GT-Playground/GTPlayground.class.st
+++ b/src/GT-Playground/GTPlayground.class.st
@@ -112,14 +112,12 @@ GTPlayground class >> isGTPlaygroundEnabled [
 GTPlayground class >> menuCommandOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #Playground)
-		parent: #Tools;
+		parent: #InputOutput;
 		action: [ Smalltalk tools openWorkspace ];
-		order: 10;
+		order: 1;
 		keyText: 'o, w';
 		help: 'A window used as a scratchpad area where fragments of Pharo code can be entered, stored, edited, and evaluated.';
-		icon: (self iconNamed: #workspaceIcon).
-	
-	aBuilder withSeparatorAfter	
+		icon: (self iconNamed: #workspaceIcon)
 ]
 
 { #category : #'instance creation' }

--- a/src/GT-Spotter-UI/GTSpotter.extension.st
+++ b/src/GT-Spotter-UI/GTSpotter.extension.st
@@ -83,8 +83,8 @@ GTSpotter class >> menuCommandOn: aBuilder [
 	(aBuilder item: #Spotter)
 		action: [ GTSpotterGlobalShortcut openGlobalSpotter ];
 		keyText: 'Shift + Enter';
-		order: 50;
-		parent: #Tools;
+		order: 1;
+		parent: #Searching;
 		help: 'Search tool to explore Pharo system effectively.';
 		iconName: #smallFindIcon
 ]

--- a/src/HelpSystem-Core/HelpBrowser.class.st
+++ b/src/HelpSystem-Core/HelpBrowser.class.st
@@ -55,8 +55,8 @@ HelpBrowser class >> defaultHelpBrowser: aClass [
 HelpBrowser class >> menuCommandOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #'Help Browser')
-		parent: #Help;
-		order: 1.0;
+		parent: #HelpBrowser;
+		order: 1;
 		action: [ self open ];
 		iconName: #smallHelpIcon;
 		help: 'Explore a list of help topics to learn to use Pharo tools.';

--- a/src/MonticelloGUI/MCWorkingCopyBrowser.class.st
+++ b/src/MonticelloGUI/MCWorkingCopyBrowser.class.st
@@ -31,12 +31,12 @@ Class {
 { #category : #'world menu' }
 MCWorkingCopyBrowser class >> menuCommandOn: aBuilder [
 	<worldMenu>
-	(aBuilder item: #'Monticello Browser')
-		parent: #Tools;
+	(aBuilder item: #'Monticello Browser (Legacy)')
+		parent: #Versioning;
 		action: [ Smalltalk tools openMonticelloBrowser ];
-		order: 60;
+		order: 2;
 		keyText: 'o, p';
-		help: 'Source code versionning system to manage Smalltalk code.';
+		help: '(Deprecated) Source code versioning system to manage Smalltalk code.';
 		icon: Smalltalk tools monticelloBrowser taskbarIcon
 ]
 

--- a/src/Morphic-Base/Halt.extension.st
+++ b/src/Morphic-Base/Halt.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #Halt }
+
+{ #category : #'*Morphic-Base' }
+Halt class >> resetOnceMenuOn: aBuilder [
+	<worldMenu>
+	(aBuilder item: #'Enable all break/inspect once')
+		parent: #Breakpoints;
+		order: 99;
+		help: 'Reset the break/inspect once. Once restarted, the first break once encountered will stop the execution.';
+		action: [ Halt resetOnce ]
+]

--- a/src/Morphic-Base/WorldState.extension.st
+++ b/src/Morphic-Base/WorldState.extension.st
@@ -12,14 +12,48 @@ WorldState >> addAlarm: aSelector withArguments: argArray for: aTarget at: sched
 ]
 
 { #category : #'*Morphic-Base' }
+WorldState class >> browseWorldMenuOn: aBuilder [
+	<worldMenu>
+	(aBuilder item: #Browse)
+		order: 10;
+		help: 'Tools to explore and modify the image';
+		with: [ 
+			(aBuilder group: #Browsing)
+				order: 1;
+				withSeparatorAfter.
+			(aBuilder group: #InputOutput)
+				order: 2;
+				withSeparatorAfter.
+			(aBuilder group: #Testing)
+				order: 3;
+				withSeparatorAfter.
+			(aBuilder group: #Searching)
+				order: 4]
+]
+
+{ #category : #'*Morphic-Base' }
 WorldState class >> debugWorldMenuOn: aBuilder [
 	<worldMenu>
-	(aBuilder item: #Debugging)
-		order: 3.5;
-		with: [ (aBuilder item: #'Enable all break/inspect once')
-				order: 0;
-				help: 'Reset the break/inspect once. Once restarted, the first break once encountered will stop the execution.';
-				action: [ Halt resetOnce ]]
+	(aBuilder item: #Debug)
+		order: 30;
+		with: [
+			(aBuilder group: #Breakpoints)
+				order: 1;
+				withSeparatorAfter.
+			(aBuilder group: #Profiling)
+				order: 2;
+				withSeparatorAfter.
+			(aBuilder group: #Counters)
+				order: 3]
+]
+
+{ #category : #'*Morphic-Base' }
+WorldState class >> libraryWorldMenuOn: aBuilder [
+	<worldMenu>
+	(aBuilder item: #Tools)
+		label: 'Library';
+		order: 70;
+		help: 'Third party tools and applications'
 ]
 
 { #category : #'*Morphic-Base' }
@@ -30,6 +64,26 @@ WorldState >> menuBuilder [
 		   model: self)
 		  menuSpec;
 		  yourself
+]
+
+{ #category : #'*Morphic-Base' }
+WorldState class >> sourcesWorldMenuOn: aBuilder [
+	<worldMenu>
+	(aBuilder item: #Sources)
+		order: 50;
+		help: 'Source Management Tools';
+		with: [ 
+			(aBuilder group: #Versioning)
+				order: 1;
+				withSeparatorAfter.
+			(aBuilder group: #Packaging)
+				order: 2;
+				withSeparatorAfter.
+			(aBuilder group: #Changes)
+				order: 3;
+				withSeparatorAfter.
+			(aBuilder group: #Refactoring)
+				order: 4 ]
 ]
 
 { #category : #'*Morphic-Base' }
@@ -89,32 +143,49 @@ WorldState >> startThenBrowseMessageTally [
 WorldState class >> systemOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #System)
-		order: 3.0;
+		order: 60;
 		with: [
-			(aBuilder item: #'Space left')
-				help: 'Do a garbage collection, and report results about the to the user.';
-				action: [ Smalltalk informSpaceLeftAfterGarbageCollection ].
-			(aBuilder item: #'Do Image Cleanup')
-				help: 'Clean out any caches and other state that should be flushed when trying to get an image into a pristine state.';
-				action: [ Smalltalk cleanUp: true ];
+			(aBuilder group: #SystemTools)
+				order: 1;
 				withSeparatorAfter.
-			(aBuilder item: #'Start drawing again')
-				help: 'Resume the drawing after a draw error of the world.';
-				action: [ self currentWorld resumeAfterDrawError ].
-			(aBuilder item: #'Start stepping again')
-				help: 'Resume stepping of Morph after an error has occured.';
-				action: [ self currentWorld resumeAfterStepError ];
+			(aBuilder group: #Startup)
+				order: 2;
 				withSeparatorAfter.
-			(aBuilder item: #'Restore display')
-				help: 'Restore Morphic display.';
-				action: [ self currentWorld restoreMorphicDisplay ] ]
+			(aBuilder group: #Image)
+				order: 3;
+				with: [
+					(aBuilder item: #'Space left')
+						help: 'Do a garbage collection, and report results about the to the user.';
+						order: 1;
+						action: [ Smalltalk informSpaceLeftAfterGarbageCollection ].
+					(aBuilder item: #'Do Image Cleanup')
+						help: 'Clean out any caches and other state that should be flushed when trying to get an image into a pristine state.';
+						order: 2;
+						action: [ Smalltalk cleanUp: true ].
+					aBuilder 	withSeparatorAfter].
+			(aBuilder group: #World)
+				order: 4;
+				with: [
+					(aBuilder item: #'Start drawing again')
+						help: 'Resume the drawing after a draw error of the world.';
+						order: 1;
+						action: [ self currentWorld resumeAfterDrawError ].
+					(aBuilder item: #'Start stepping again')
+						help: 'Resume stepping of Morph after an error has occured.';
+						order: 2;
+						action: [ self currentWorld resumeAfterStepError ].
+					(aBuilder item: #'Restore display')
+						help: 'Restore Morphic display.';
+						order: 3;
+						action: [ self currentWorld restoreMorphicDisplay ].
+					aBuilder withSeparatorAfter ] ]
 ]
 
 { #category : #'*Morphic-Base' }
 WorldState class >> windowsOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #Windows)
-		order: 4.0;
+		order: 90;
 		with: [ (aBuilder item: #'Collapse all windows')
 				action: [ self currentWorld collapseAll ];
 				help: 'Reduce all open windows to collapsed forms that only show titles' translated.

--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -154,11 +154,20 @@ WorldState class >> easySelectingWorld: aBoolean [
 WorldState class >> helpOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #Help)
-		order: 5.0;
+		order: 99;
 		help: 'Some help tools on Pharo.';
 		with: [
+			(aBuilder group: #HelpBrowser)
+				order: 1;
+				withSeparatorAfter.
+			(aBuilder group: #PharoHelp)
+				order: 2;
+				withSeparatorAfter.
+			(aBuilder group: #SpecHelp)
+				order: 3;
+				withSeparatorAfter.
 			(aBuilder item: #'About...')
-				order: 8.0;
+				order: 99;
 				iconName: #smallInfo;
 				help: 'Informations about this version of Pharo.';
 				action: [ Smalltalk aboutThisSystem ] ]
@@ -203,32 +212,36 @@ WorldState class >> pharoItemsOn: aBuilder [
 		label: 'Pharo';
 		icon: ((self iconNamed: #pharo) scaledToSize: 16 @ 16);
 		order: 0;
-		with: [ (aBuilder item: #Save)
-				target: self;
-				selector: #saveSession;
-				help: 'Save the current version of the image on disk.';
-				order: 2;
-				keyText: 'S';
-				iconName: #smallSaveIcon.
-			(aBuilder item: #'Save as...')
-				target: self;
-				selector: #saveAs;
-				help: 'Save the current version of the image on disk under a new name.';
-				order: 3;
-				iconName: #smallSaveAsIcon.
-			(aBuilder item: #'Save and quit')
-				target: self;
-				selector: #saveAndQuit;
-				help: 'Save the current image on disk, and quit Pharo.';
-				order: 4;
-				iconName: #smallQuitIcon;
-				withSeparatorAfter. 
-			(aBuilder item: #Quit)
-				target: self;
-				selector: #quitSession;
-				help: 'Quit Pharo without saving the image on disk.';
-				order: 5;
-				iconName: #smallQuitIcon ]
+		with: [
+			(aBuilder group: #Saving)
+				order: 98;
+				with: [
+					(aBuilder item: #Save)
+						target: self;
+						selector: #saveSession;
+						help: 'Save the current version of the image on disk.';
+						order: 1;
+						keyText: 'S';
+						iconName: #smallSaveIcon.
+					(aBuilder item: #'Save as...')
+						target: self;
+						selector: #saveAs;
+						help: 'Save the current version of the image on disk under a new name.';
+						order: 2;
+						iconName: #smallSaveAsIcon.
+					(aBuilder item: #'Save and quit')
+						target: self;
+						selector: #saveAndQuit;
+						help: 'Save the current image on disk, and quit Pharo.';
+						order: 3;
+						iconName: #smallQuitIcon.
+					aBuilder	withSeparatorAfter ]. 
+				(aBuilder item: #Quit)
+					target: self;
+					selector: #quitSession;
+					help: 'Quit Pharo without saving the image on disk.';
+					order: 99;
+					iconName: #smallQuitIcon ]
 ]
 
 { #category : #'world menu items' }
@@ -280,7 +293,7 @@ WorldState class >> screenShotCommandOn: aBuilder [
 	(aBuilder item: #Screenshot)
 		parent: #System;
 		target: self currentWorld;
-		order: 501;
+		order: 99;
 		selector: #makeAScreenshot;
 		label: 'Screenshot';
 		help: 'Take a screenshot';

--- a/src/NewTools-ChangeSorter/SpDualChangeSorterPresenter.class.st
+++ b/src/NewTools-ChangeSorter/SpDualChangeSorterPresenter.class.st
@@ -29,15 +29,12 @@ SpDualChangeSorterPresenter class >> defaultSpec [
 SpDualChangeSorterPresenter class >> menuCommandOn: aBuilder [
 	<worldMenu>
 	
-	(aBuilder group: #SystemChanges)
-		parent: #Tools;
-		order: 410;
-		with: [ 
-			(aBuilder item: #'Change Sorter')
-				action: [ self open ];
-				help: 'Examine the different change set of the image.';
-				icon: self taskbarIcon ].
-	aBuilder withSeparatorAfter
+	(aBuilder item: #'Change Sorter')
+		parent: #Changes;
+		action: [ self open ];
+		order: 2;
+		help: 'Examine the different change set of the image.';
+		icon: self taskbarIcon
 ]
 
 { #category : #opening }

--- a/src/NewTools-SystemReporter/StSystemReporter.class.st
+++ b/src/NewTools-SystemReporter/StSystemReporter.class.st
@@ -19,8 +19,9 @@ StSystemReporter class >> systemReporterMenuOn: aBuilder [
 	<worldMenu>
 	
 	(aBuilder item: #'System Reporter')
-		parent: #System;
+		parent: #SystemTools;
 		action: [ self open ];
+		order: 1;
 		help: 'If you have a bug, use this tool to provide information about your system.'
 ]
 

--- a/src/Pharo-WelcomeHelp/WelcomeHelp.class.st
+++ b/src/Pharo-WelcomeHelp/WelcomeHelp.class.st
@@ -208,8 +208,8 @@ A very interesting starting point would be looking into the "Updated Pharo by Ex
 WelcomeHelp class >> menuCommandOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #'Welcome to Pharo')
-		parent: #Help;
-		order: 1.2;
+		parent: #PharoHelp;
+		order: 1;
 		action: [ self open ];
 		icon: ((self iconNamed: #pharoIcon) scaledToSize: 16@16);
 		help: 'Welcome window for Pharo' 

--- a/src/ProfStef-Core/ProfStef.class.st
+++ b/src/ProfStef-Core/ProfStef.class.st
@@ -133,12 +133,11 @@ ProfStef class >> menuCommandOn: aBuilder [
 	<worldMenu>
 	
 	(aBuilder item: #'Pharo Zen')
-		parent: #Help;
-		order: 3.0;
+		parent: #PharoHelp;
+		order: 3;
 		action: [ self openPharoZenWorkspace ];
 		icon: ((self iconNamed: #pharoIcon) scaledToSize: 16@16);
-		help: 'Pharo values.';
-		withSeparatorAfter 
+		help: 'Pharo values.' 
 ]
 
 { #category : #navigating }

--- a/src/ProfStef-Help/PharoTutorialsHelp.class.st
+++ b/src/ProfStef-Help/PharoTutorialsHelp.class.st
@@ -21,8 +21,8 @@ PharoTutorialsHelp class >> builder [
 PharoTutorialsHelp class >> menuCommandOn: aBuilder [ 
 	<worldMenu> 
 	(aBuilder item: #'Pharo Tutorials')
-			parent: #Help;
-			order: 2.0;
+			parent: #PharoHelp;
+			order: 2;
 			action:[ HelpBrowser openOn: self ]; 
 			icon: ((self iconNamed: #pharoIcon) scaledToSize: 16@16);
 			help: 'Browse and create Pharo tutorials.'.

--- a/src/Refactoring-Changes/AbstractTool.extension.st
+++ b/src/Refactoring-Changes/AbstractTool.extension.st
@@ -1,6 +1,17 @@
 Extension { #name : #AbstractTool }
 
 { #category : #'*Refactoring-Changes' }
+AbstractTool class >> menuCommandOn: aBuilder [
+	<worldMenu>
+	(aBuilder item: #'Undo last refactoring')
+				action: [self undoLastRefactoring];
+				parent: #Refactoring;
+				help: 'Undo last refactoring';
+				order: 10;
+				iconName: #smallUndo.
+]
+
+{ #category : #'*Refactoring-Changes' }
 AbstractTool class >> undoLastRefactoring [
 	| manager |
 	manager := RBRefactoryChangeManager instance.

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -83,8 +83,8 @@ Breakpoint class >> cleanUp [
 Breakpoint class >> debugWorldMenuOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #'Remove all Breakpoints')
-		parent: #Debugging;
-		order: 0;
+		parent: #Breakpoints;
+		order: 2;
 		help: 'Remove all the breakpoints of the image.';
 		action: [ Breakpoint removeAll ]
 ]

--- a/src/Reflectivity/ExecutionCounter.class.st
+++ b/src/Reflectivity/ExecutionCounter.class.st
@@ -29,8 +29,8 @@ ExecutionCounter class >> allCounters [
 ExecutionCounter class >> debugWorldMenuOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #'Reset Counters')
-		order: 0;
-		parent: #Debugging;
+		order: 1;
+		parent: #Counters;
 		help: 'Reset the counters on the executions counters.';
 		action: [ ExecutionCounter resetAll ]
 ]

--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -43,9 +43,9 @@ TestRunner class >> menuCommandOn: aBuilder [
 	<worldMenu>
 	
 	(aBuilder item: #'Test Runner')
-		parent: #Tools;
+		parent: #Testing;
 		action: [ Smalltalk tools openTestRunner ];
-		order: 20;
+		order: 1;
 		keyText: 'o, u';
 		help: 'Let you run and debug SUnit tests.';
 		icon: self taskbarIcon

--- a/src/Spec-Examples/SpecDemo.class.st
+++ b/src/Spec-Examples/SpecDemo.class.st
@@ -43,11 +43,10 @@ SpecDemo class >> menuExamplesOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #'Spec examples')
 		iconName: #smallHelpIcon;
-		parent: #Help;
-		order: 3.5;
+		parent: #SpecHelp;
+		order: 1;
 		help: 'Open Spec demo browser.';
-		action: [ self open ].
-	aBuilder withSeparatorAfter	
+		action: [ self open ]
 ]
 
 { #category : #'instance creation' }

--- a/src/Spec2-Examples/SpDemo.class.st
+++ b/src/Spec2-Examples/SpDemo.class.st
@@ -35,11 +35,10 @@ SpDemo class >> menuExamplesOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #'Spec2 examples')
 		iconName: #smallHelpIcon;
-		parent: #Help;
-		order: 3.5;
+		parent: #SpecHelp;
+		order: 2;
 		help: 'Open Spec2 demo browser.';
-		action: [ self open ].
-	aBuilder withSeparatorAfter	
+		action: [ self open ]	
 ]
 
 { #category : #'instance creation' }

--- a/src/System-Settings-Browser/StartupPreferencesLoader.extension.st
+++ b/src/System-Settings-Browser/StartupPreferencesLoader.extension.st
@@ -44,7 +44,7 @@ StartupPreferencesLoader class >> systemStartupMenuOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #SystemStartup)
 		label: 'Startup';
-		parent: #System;
+		parent: #Startup;
 		order: 2;
 		help: 'System startup related.';
 		iconName: #scriptManagerIcon

--- a/src/Tool-Base/AbstractTool.class.st
+++ b/src/Tool-Base/AbstractTool.class.st
@@ -7,21 +7,6 @@ Class {
 	#category : #'Tool-Base-Utilities'
 }
 
-{ #category : #'world menu' }
-AbstractTool class >> menuCommandOn: aBuilder [
-	<worldMenu>
-	(aBuilder item: #Tools)
-		order: 1.0;
-		target: self;
-		help: 'Set of tools to get a better Pharo experience.';
-		with: [ (aBuilder item: #'Undo last refactoring')
-				target: self;
-				selector: #undoLastRefactoring;
-				help: 'Undo last refactoring, after execute this command you can not redo this refactoring.';
-				order: 1000;
-				iconName: #smallUndo.]
-]
-
 { #category : #private }
 AbstractTool class >> protocolSuggestionsFor: aClass [
 

--- a/src/Tool-Catalog/CatalogBrowser.class.st
+++ b/src/Tool-Catalog/CatalogBrowser.class.st
@@ -31,11 +31,11 @@ CatalogBrowser class >> menuCommandOn: aBuilder [
 	"Add a custom menu item to the world menu"
 
 	<worldMenu>
-	(aBuilder item: #'Catalog Browser')
-		order: 201;
+	(aBuilder item: #'Catalog Browser (Legacy)')
+		order: 1;
 		iconName: #catalogIcon;
-		parent: #Tools;
-		help: 'Project catalog from pharo official repositories.';
+		parent: #Packaging;
+		help: '(Deprecated) Project catalog from pharo official repositories.';
 		action: [ self open ]
 ]
 

--- a/src/Tool-CriticBrowser/CriticBrowser.class.st
+++ b/src/Tool-CriticBrowser/CriticBrowser.class.st
@@ -34,8 +34,8 @@ CriticBrowser class >> criticsBrowserMenuOn: aBuilder [
 	
 	(aBuilder item: 'Critic Browser')
 		action: [ self openOnCurrentWorkingConfiguration];
-		order: 310;
-		parent: #Tools;
+		order: 2;
+		parent: #Browsing;
 		help: 'To manage rule checks.';
 		icon: self icon
 ]

--- a/src/Tool-DependencyAnalyser-UI/DAPackageDependenciesWelcome.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageDependenciesWelcome.class.st
@@ -54,8 +54,8 @@ DAPackageDependenciesWelcome class >> menuCommandOn: aBuilder [
 	<worldMenu>
 
 	(aBuilder item: #PackageDependencies)
-		order: 210;
-		parent: #Tools;
+		order: 2;
+		parent: #Packaging;
 		label: 'Dependency Analyser';
 		icon: (self iconNamed: #packageIcon);
 		help: 'Analyze dependencies between different packages in the image.';

--- a/src/Tool-FileList/FileList.class.st
+++ b/src/Tool-FileList/FileList.class.st
@@ -130,12 +130,11 @@ FileList class >> itemsForFile: file [
 FileList class >> menuCommandOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #'File Browser')
-		parent: #Tools;
-		order: 320;
+		parent: #SystemTools;
+		order: 2;
 		action: [ self open ];
 		help: 'Browse the files present on your system.';
-		icon: self taskbarIcon.
-	aBuilder withSeparatorAfter
+		icon: self taskbarIcon
 ]
 
 { #category : #'morphic ui' }

--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -26,11 +26,10 @@ Finder class >> finderMenuOn: aBuilder [
 
 	(aBuilder item: #Finder)
 		action: [self open];
-		order: 101;
-		parent: #Tools;
+		order: 2;
+		parent: #Searching;
 		help: 'Looking for something ?';
 		icon: self icon.
-	aBuilder withSeparatorAfter	
 ]
 
 { #category : #menu }

--- a/src/Tool-ProcessBrowser/ProcessBrowser.class.st
+++ b/src/Tool-ProcessBrowser/ProcessBrowser.class.st
@@ -154,8 +154,8 @@ ProcessBrowser class >> isUIProcess: aProcess [
 ProcessBrowser class >> menuCommandOn: aBuilder [ 
 	<worldMenu> 
 	(aBuilder item: #'Process Browser')
-		parent: #Tools;
-		order: 705;
+		parent: #SystemTools;
+		order: 3;
 		action:[ self open ];
 		help: 'Provides a view of all of the processes (threads) executing in Smalltalk.';
 		icon: self taskbarIcon

--- a/src/Tool-Profilers/TimeProfiler.class.st
+++ b/src/Tool-Profilers/TimeProfiler.class.st
@@ -76,7 +76,7 @@ TimeProfiler class >> menuCommandOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #'Time Profiler')
 		parent: #Profiling;  
-		order: 110;
+		order: 1;
 		icon: self taskbarIcon;
 		help: 'Profile the execution of a piece of code and navigate into the result.';
 		action: [TimeProfiler new open]
@@ -85,19 +85,16 @@ TimeProfiler class >> menuCommandOn: aBuilder [
 { #category : #'world menu' }
 TimeProfiler class >> menuProfilingOn: aBuilder [
 	<worldMenu>
-	(aBuilder item: #Profiling)
-		parent: #Tools;
-		label: 'Profiling';
-		help: 'Profiling tools';
-		order: 301.
 
 	(aBuilder item: #'Start profiling all Processes')
 		parent: #Profiling;
 		help: 'Profile all Pharo processes.';
+		order: 10;
 		action: [ self currentWorld worldState startMessageTally ].
 	(aBuilder item: #'Start profiling UI ')
 		parent: #Profiling;
 		help: 'Profile the UI process of Pharo.';
+		order: 20;
 		action: [ self currentWorld worldState startThenBrowseMessageTally ].
 ]
 

--- a/src/Tool-Registry/PharoCommonTools.class.st
+++ b/src/Tool-Registry/PharoCommonTools.class.st
@@ -99,12 +99,19 @@ PharoCommonTools class >> shutDown: aboutToQuit [
 PharoCommonTools class >> worldMenuOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #'System Browser')
-		parent: #Tools;
+		parent: #Browsing;
 		action: [ Smalltalk tools openClassBrowser ];
 		order: 0;
 		keyText: 'o, b';
 		help: 'System browser to browse and edit code.';
-		iconName: #smallSystemBrowser
+		iconName: #smallSystemBrowser.
+	(aBuilder item: #'Iceberg')
+		order: 1; 
+		icon: (self iconNamed: #komitterSmalltalkhubRemote);  
+		parent: #'Browsing';
+		keyText: 'o, i';
+		help: 'Iceberg is a set of tools that allow one to handle git repositories directly from a Pharo image.';
+		action: [ (Smalltalk at: #IceTipRepositoriesBrowser) new openWithSpec ]
 ]
 
 { #category : #'registry access' }

--- a/src/Transcript-Tool/ThreadSafeTranscript.extension.st
+++ b/src/Transcript-Tool/ThreadSafeTranscript.extension.st
@@ -11,8 +11,8 @@ ThreadSafeTranscript class >> menuCommandOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #'Transcript')
 		action: [ Smalltalk tools transcript open ];
-		order: 220;
-		parent: #Tools;
+		order: 2;
+		parent: #InputOutput;
 		help: 'Transcript';
 		keyText: 'o, t';
 		help: 'Window on the Transcript output stream, which is useful for writing log messages.';


### PR DESCRIPTION
Follow up to https://github.com/pharo-project/pharo/pull/8201 which was reverted.

See the above PR for details.

Compared to the previous attempt, this new PR keeps Iceberg in the Browse menu.

Since Iceberg is not managed as part of the pharo codebase, we need to use some `Smalltalk at: #className` to allow the preserved menu item to work.

This can be further simplified once the corresponding change in Iceberg has gone through.

Fixes #8412.