### PR TITLE
8354-SycRemoveMessageArgumentCommand-with-unused-ivar 

### DIFF
--- a/src/SystemCommands-MessageCommands/SycRemoveMessageArgumentCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycRemoveMessageArgumentCommand.class.st
@@ -10,8 +10,7 @@ Class {
 	#name : #SycRemoveMessageArgumentCommand,
 	#superclass : #SycChangeMessageSignatureCommand,
 	#instVars : [
-		'argumentName',
-		'newSignature'
+		'argumentName'
 	],
 	#category : #'SystemCommands-MessageCommands'
 }


### PR DESCRIPTION

fix #8354