### PR TITLE
8379-Debugger-Contextat-infinite-loop-when-pressing-Through-in-a-test-case-condition

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -245,38 +245,43 @@ Context class >> simulatePrimitiveNumber: num with: simulator [
 Context >> stepToHome: aContext [
 	"Resume self until the home of top context is aContext.  Top context may be a block context."
 
-	| home ctxt here error context |
+	| home ctxt here error wrapperContext |
 	here := thisContext.
-	ctxt := self step.
-	ctxt = self ifFalse: [ "Insert ensure and exception handler contexts under aSender"
-		error := nil.
-		context := aContext insertSender: (Context contextOn: UnhandledError do: [ :ex | 
+	error := nil.
+	
+	wrapperContext := aContext insertSender: (Context contextOn: Exception do: [ :ex | 
 				            error
 					            ifNil: [ 
-						            error := ex exception.
-						            ex resumeUnchecked: here jump ]
-					            ifNotNil: [ ex pass ] ]) ].
+						            			error := ex.
+												ex resumeUnchecked: here jump ]
+					            ifNotNil: [ 
+										ex pass ] ]).
 	home := aContext home.
-	home == ctxt home ifTrue: [ 
-		^ { 
-			  ctxt.
-			  nil } ].
 
-	[ 
-	ctxt := ctxt step.
-	error ifNotNil: [ "remove above inserted ensure and handler contexts"
-		context ifNotNil: [ aContext terminateTo: context sender ].
+	"A first Step to do at least one step"
+	ctxt := self step.
+
+	home == ctxt home ifTrue: [ 
 		^ { 
 			  ctxt.
 			  error } ].
 
-	home == ctxt home ] whileFalse: [ 
-		home isDead ifTrue: [ 
+	[  ctxt := ctxt step.
+		error ifNotNil: [ 
+		"remove above inserted ensure and handler contexts"
+		aContext terminateTo: wrapperContext sender.
 			^ { 
 				  ctxt.
-				  nil } ] ].
+				  error } ].
+
+		home == ctxt home ] whileFalse: [ 
+			home isDead ifTrue: [ 
+				^ { 
+					  ctxt.
+					  nil } ] ].
 	"remove above inserted ensure and handler contexts"
-	context ifNotNil: [ aContext terminateTo: context sender ].
+	aContext terminateTo: wrapperContext sender.
+	
 	^ { 
 		  ctxt.
 		  nil }

--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -253,6 +253,7 @@ Context >> stepToHome: aContext [
 				            error
 					            ifNil: [ 
 						            			error := ex.
+												ex inspect.
 												ex resumeUnchecked: here jump ]
 					            ifNotNil: [ 
 										ex pass ] ]).
@@ -262,6 +263,8 @@ Context >> stepToHome: aContext [
 	ctxt := self step.
 
 	home == ctxt home ifTrue: [ 
+		"remove above inserted ensure and handler contexts"
+		aContext terminateTo: wrapperContext sender.
 		^ { 
 			  ctxt.
 			  error } ].

--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -253,7 +253,6 @@ Context >> stepToHome: aContext [
 				            error
 					            ifNil: [ 
 						            			error := ex.
-												ex inspect.
 												ex resumeUnchecked: here jump ]
 					            ifNotNil: [ 
 										ex pass ] ]).

--- a/src/Kernel-Tests-Extended/ClassUsedInInstructionStreamTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassUsedInInstructionStreamTest.class.st
@@ -20,6 +20,20 @@ ClassUsedInInstructionStreamTest >> aMethodSuspendedBeforeTheTerminateOfAnotherP
 ]
 
 { #category : #example }
+ClassUsedInInstructionStreamTest >> aMethodWithHalt [
+
+	Processor activeProcess suspend.
+	self halt.
+]
+
+{ #category : #example }
+ClassUsedInInstructionStreamTest >> aMethodWithSuspendAndReturnANumber [
+
+	Processor activeProcess suspend.
+	^ 42.
+]
+
+{ #category : #example }
 ClassUsedInInstructionStreamTest >> aSuperMethod: anInteger with: anotherInteger [
 
 	^ self error
@@ -29,6 +43,18 @@ ClassUsedInInstructionStreamTest >> aSuperMethod: anInteger with: anotherInteger
 ClassUsedInInstructionStreamTest >> callingAMethodSuspendedBeforeTheTerminateOfAnotherProcess [
 
 	self aMethodSuspendedBeforeTheTerminateOfAnotherProcess
+]
+
+{ #category : #example }
+ClassUsedInInstructionStreamTest >> callingAMethodWithHalt [
+
+	self aMethodWithHalt
+]
+
+{ #category : #example }
+ClassUsedInInstructionStreamTest >> callingAMethodWithSuspendAndReturnANumber [
+
+	^ self aMethodWithSuspendAndReturnANumber
 ]
 
 { #category : #example }

--- a/src/Kernel-Tests-Extended/ClassUsedInInstructionStreamTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassUsedInInstructionStreamTest.class.st
@@ -27,6 +27,13 @@ ClassUsedInInstructionStreamTest >> aMethodWithHalt [
 ]
 
 { #category : #example }
+ClassUsedInInstructionStreamTest >> aMethodWithMNU [
+
+	Processor activeProcess suspend.
+	self iAmAnMNUMessage.
+]
+
+{ #category : #example }
 ClassUsedInInstructionStreamTest >> aMethodWithSuspendAndReturnANumber [
 
 	Processor activeProcess suspend.
@@ -49,6 +56,12 @@ ClassUsedInInstructionStreamTest >> callingAMethodSuspendedBeforeTheTerminateOfA
 ClassUsedInInstructionStreamTest >> callingAMethodWithHalt [
 
 	self aMethodWithHalt
+]
+
+{ #category : #example }
+ClassUsedInInstructionStreamTest >> callingAMethodWithMNU [
+
+	self aMethodWithMNU
 ]
 
 { #category : #example }

--- a/src/Kernel-Tests-Extended/ClassUsedInInstructionStreamTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassUsedInInstructionStreamTest.class.st
@@ -22,6 +22,8 @@ ClassUsedInInstructionStreamTest >> aMethodSuspendedBeforeTheTerminateOfAnotherP
 { #category : #example }
 ClassUsedInInstructionStreamTest >> aMethodWithHalt [
 
+	<haltOrBreakpointForTesting>
+
 	Processor activeProcess suspend.
 	self halt.
 ]

--- a/src/Kernel-Tests-Extended/ClassUsedInInstructionStreamTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassUsedInInstructionStreamTest.class.st
@@ -34,6 +34,14 @@ ClassUsedInInstructionStreamTest >> aMethodWithMNU [
 ]
 
 { #category : #example }
+ClassUsedInInstructionStreamTest >> aMethodWithMustBeBooleanMNU [
+
+	Processor activeProcess suspend.
+
+	^ 2 ifTrue: [ 5 ] ifFalse: [ 7 ]
+]
+
+{ #category : #example }
 ClassUsedInInstructionStreamTest >> aMethodWithSuspendAndReturnANumber [
 
 	Processor activeProcess suspend.
@@ -62,6 +70,12 @@ ClassUsedInInstructionStreamTest >> callingAMethodWithHalt [
 ClassUsedInInstructionStreamTest >> callingAMethodWithMNU [
 
 	self aMethodWithMNU
+]
+
+{ #category : #example }
+ClassUsedInInstructionStreamTest >> callingAMethodWithMustBeBooleanMNU [
+
+	self aMethodWithMustBeBooleanMNU
 ]
 
 { #category : #example }

--- a/src/Kernel-Tests-Extended/ClassUsedInInstructionStreamTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassUsedInInstructionStreamTest.class.st
@@ -2,15 +2,33 @@ Class {
 	#name : #ClassUsedInInstructionStreamTest,
 	#superclass : #SuperClassUsedInInstructionStreamTest,
 	#instVars : [
-		'expectedValue'
+		'expectedValue',
+		'aProcess'
 	],
 	#category : #'Kernel-Tests-Extended-Methods'
 }
 
 { #category : #example }
+ClassUsedInInstructionStreamTest >> aMethodSuspendedBeforeTheTerminateOfAnotherProcess [
+
+	Processor activeProcess suspend.
+
+	aProcess terminate.
+	
+	expectedValue := 42.
+
+]
+
+{ #category : #example }
 ClassUsedInInstructionStreamTest >> aSuperMethod: anInteger with: anotherInteger [
 
 	^ self error
+]
+
+{ #category : #example }
+ClassUsedInInstructionStreamTest >> callingAMethodSuspendedBeforeTheTerminateOfAnotherProcess [
+
+	self aMethodSuspendedBeforeTheTerminateOfAnotherProcess
 ]
 
 { #category : #example }
@@ -29,6 +47,12 @@ ClassUsedInInstructionStreamTest >> methodWithASuperBlock [
 ClassUsedInInstructionStreamTest >> methodWithASuperBlockWithoutArguments [
 
 	^ [ super yourself ]
+]
+
+{ #category : #accessing }
+ClassUsedInInstructionStreamTest >> process: aValue [ 
+	
+	aProcess := aValue
 ]
 
 { #category : #example }

--- a/src/Kernel-Tests-Extended/InstructionStreamTest.class.st
+++ b/src/Kernel-Tests-Extended/InstructionStreamTest.class.st
@@ -107,6 +107,44 @@ InstructionStreamTest >> testSimulatedTerminationOfProcessDoNotCorruptTheContext
 ]
 
 { #category : #example }
+InstructionStreamTest >> testSimulatingAMethodWithHaltHasCorrectContext [
+
+	| initialContext aContext receiver suspendedProcess return |
+	
+	receiver := self classUnderTest new.
+	suspendedProcess := [ receiver callingAMethodWithHalt ] forkAt: Processor activePriority + 1.
+
+	initialContext := aContext := suspendedProcess suspendedContext.
+	[ initialContext method = (self classUnderTest >> #callingAMethodWithHalt) ] 
+		whileFalse: [ initialContext := initialContext sender].
+	
+	return := suspendedProcess stepToHome: initialContext.
+	
+	"Suspended process should stop in the exception"	
+	self assert: return method equals: (Object >> #halt).
+	self assert: return size equals: 1.
+]
+
+{ #category : #example }
+InstructionStreamTest >> testStepThroughInAMethodWithoutError [
+
+	| initialContext aContext receiver suspendedProcess return |
+	
+	receiver := self classUnderTest new.
+	suspendedProcess := [ receiver callingAMethodWithSuspendAndReturnANumber ] forkAt: Processor activePriority + 1.
+
+	initialContext := aContext := suspendedProcess suspendedContext.
+	[ initialContext method = (self classUnderTest >> #callingAMethodWithSuspendAndReturnANumber) ] 
+		whileFalse: [ initialContext := initialContext sender].
+	
+	return := suspendedProcess stepToHome: initialContext.
+	
+	"Suspended process should stop in the exception"	
+	self assert: return method equals: (self classUnderTest >> #callingAMethodWithSuspendAndReturnANumber).
+	self assert: return top equals: 42.
+]
+
+{ #category : #example }
 InstructionStreamTest >> testSteppingSendsDirectSend [
 
 	| initialContext aContext receiver |

--- a/src/Kernel-Tests-Extended/InstructionStreamTest.class.st
+++ b/src/Kernel-Tests-Extended/InstructionStreamTest.class.st
@@ -145,6 +145,24 @@ InstructionStreamTest >> testStepThroughInAMethodWithMNU [
 ]
 
 { #category : #example }
+InstructionStreamTest >> testStepThroughInAMethodWithMNUInMustBeBoolean [
+
+	| initialContext aContext receiver suspendedProcess return |
+	
+	receiver := self classUnderTest new.
+	suspendedProcess := [ receiver callingAMethodWithMustBeBooleanMNU ] forkAt: Processor activePriority + 1.
+
+	initialContext := aContext := suspendedProcess suspendedContext.
+	[ initialContext method = (self classUnderTest >> #callingAMethodWithMustBeBooleanMNU) ] 
+		whileFalse: [ initialContext := initialContext sender].
+	
+	return := suspendedProcess stepToHome: initialContext.
+	
+	"Suspended process should stop in the exception"	
+	self assert: return method equals: (self classUnderTest lookupSelector: #doesNotUnderstand:).
+]
+
+{ #category : #example }
 InstructionStreamTest >> testStepThroughInAMethodWithoutError [
 
 	| initialContext aContext receiver suspendedProcess return |

--- a/src/Kernel-Tests-Extended/InstructionStreamTest.class.st
+++ b/src/Kernel-Tests-Extended/InstructionStreamTest.class.st
@@ -126,6 +126,25 @@ InstructionStreamTest >> testSimulatingAMethodWithHaltHasCorrectContext [
 ]
 
 { #category : #example }
+InstructionStreamTest >> testStepThroughInAMethodWithMNU [
+
+	| initialContext aContext receiver suspendedProcess return |
+	
+	receiver := self classUnderTest new.
+	suspendedProcess := [ receiver callingAMethodWithMNU ] forkAt: Processor activePriority + 1.
+
+	initialContext := aContext := suspendedProcess suspendedContext.
+	[ initialContext method = (self classUnderTest >> #callingAMethodWithMNU) ] 
+		whileFalse: [ initialContext := initialContext sender].
+	
+	return := suspendedProcess stepToHome: initialContext.
+	
+	"Suspended process should stop in the exception"	
+	self assert: return method equals: (self classUnderTest lookupSelector: #doesNotUnderstand:).
+
+]
+
+{ #category : #example }
 InstructionStreamTest >> testStepThroughInAMethodWithoutError [
 
 	| initialContext aContext receiver suspendedProcess return |

--- a/src/Kernel-Tests-Extended/InstructionStreamTest.class.st
+++ b/src/Kernel-Tests-Extended/InstructionStreamTest.class.st
@@ -85,6 +85,28 @@ InstructionStreamTest >> testBlockWithASuperWithoutArgumentsSendHasCorrectNumber
 ]
 
 { #category : #example }
+InstructionStreamTest >> testSimulatedTerminationOfProcessDoNotCorruptTheContext [
+
+	| initialContext aContext receiver semaphore process suspendedProcess return errorThatHappen |
+	
+	receiver := self classUnderTest new.
+	semaphore := Semaphore new.
+	process := [ semaphore wait ] forkAt: Processor activePriority + 1.
+	receiver process: process.
+	suspendedProcess := [ receiver callingAMethodSuspendedBeforeTheTerminateOfAnotherProcess ] forkAt: Processor activePriority + 1.
+
+	initialContext := aContext := suspendedProcess suspendedContext.
+	[ initialContext method = (self classUnderTest >> #callingAMethodSuspendedBeforeTheTerminateOfAnotherProcess) ] 
+		whileFalse: [ initialContext := initialContext sender].
+	
+	[return := suspendedProcess stepToHome: initialContext] 
+		on: Exception do: [:e | errorThatHappen := e ].
+
+	self assert: errorThatHappen isNil.
+	self assert: receiver expectedValue equals: 42
+]
+
+{ #category : #example }
 InstructionStreamTest >> testSteppingSendsDirectSend [
 
 	| initialContext aContext receiver |

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -94,7 +94,9 @@ Context class >> contextEnsure: block [
 		
 		"As the jump will return to the current context inside the context ensure:
 		It is needed to emulate the return value of sending the message ensure:
-		If this is not done, the context will do an additional pop, affecting the temporary variables. "
+		If this is not done, the context will do an additional pop, affecting the temporary variables. 
+		This is required because we are breaking a condition on Context >> jump.
+		The receiver of jump should be a Top context, in this case it is not. "
 		ctxt push: nil. 
 		ctxt jump] ensure: block.
 	"jump above will resume here without unwinding chain"
@@ -111,7 +113,9 @@ Context class >> contextOn: exceptionClass do: block [
 	
 		"As the jump will return to the current context inside the context on:do:
 		It is needed to emulate the return value of sending the message on:do:
-		If this is not done, the context will do an additional pop, affecting the temporary variables. "
+		If this is not done, the context will do an additional pop, affecting the temporary variables. 
+		This is required because we are breaking a condition on Context >> jump.
+		The receiver of jump should be a Top context, in this case it is not. "
 		ctxt push:nil. 
 		ctxt jump] on: exceptionClass do: block.
 	"jump above will resume here without unwinding chain"
@@ -1015,7 +1019,9 @@ Context >> isUnwindContext [
 { #category : #controlling }
 Context >> jump [
 	"Abandon thisContext and resume self instead (using the same current process).  You may want to save thisContext's sender before calling this so you can jump back to it.
-	Self MUST BE a top context (ie. a suspended context or a abandoned context that was jumped out of).  A top context already has its return value on its stack (see Interpreter>>primitiveSuspend and other suspending primitives).
+	Self MUST BE a top context (ie. a suspended context or an abandoned context that was jumped out of).  A top context already has its return value on its stack (see Interpreter>>primitiveSuspend and other suspending primitives).
+	If self is not a top context is the responsibility of the caller to push something in the context. If this is not guarantee an error when accessing the values in the context is produced. Pay special attention to the implementation of Context class >> #contextOn: exceptionClass do: block and Context class >> #contextEnsure:. 
+	
 	thisContext's sender is converted to a top context (by pushing a nil return value on its stack) so it can be jump back to."
 
 	| top |

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -90,7 +90,13 @@ Context class >> contextEnsure: block [
 
 	| ctxt chain |
 	ctxt := thisContext.
-	[chain := thisContext sender cut: ctxt. ctxt jump] ensure: block.
+	[chain := thisContext sender cut: ctxt. 
+		
+		"As the jump will return to the current context inside the context ensure:
+		It is needed to emulate the return value of sending the message ensure:
+		If this is not done, the context will do an additional pop, affecting the temporary variables. "
+		ctxt push: nil. 
+		ctxt jump] ensure: block.
 	"jump above will resume here without unwinding chain"
 	^ chain
 ]
@@ -101,7 +107,13 @@ Context class >> contextOn: exceptionClass do: block [
 
 	| ctxt chain |
 	ctxt := thisContext.
-	[chain := thisContext sender cut: ctxt. ctxt jump] on: exceptionClass do: block.
+	[chain := thisContext sender cut: ctxt. 
+	
+		"As the jump will return to the current context inside the context on:do:
+		It is needed to emulate the return value of sending the message on:do:
+		If this is not done, the context will do an additional pop, affecting the temporary variables. "
+		ctxt push:nil. 
+		ctxt jump] on: exceptionClass do: block.
 	"jump above will resume here without unwinding chain"
 	^ chain
 ]

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -647,11 +647,16 @@ Process >> stepToHome: aContext [
 				onBehalfOf: self.
 	suspendedContext := pair first.
 	error := pair second.
+
 	"error class = Halt ifTrue: [ 
 		aContext methodNode 
 			pragmaNamed: #debuggerCompleteToSender 
 			ifPresent: [ ^ self completeTo: aContext sender ] ]."
-	error ifNotNil: [^ suspendedContext := error signalerContext].
+	error ifNotNil: [
+		suspendedContext := error signalerContext.
+		"As we are activating a context that has been interrupted in the signal of the exception,
+		we need to push a receiver of the signal message"
+		suspendedContext push: nil].
 	^ suspendedContext
 ]
 

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -648,14 +648,18 @@ Process >> stepToHome: aContext [
 	suspendedContext := pair first.
 	error := pair second.
 
-	"error class = Halt ifTrue: [ 
-		aContext methodNode 
-			pragmaNamed: #debuggerCompleteToSender 
-			ifPresent: [ ^ self completeTo: aContext sender ] ]."
 	error ifNotNil: [
 		suspendedContext := error signalerContext.
 		"As we are activating a context that has been interrupted in the signal of the exception,
-		we need to push a receiver of the signal message"
+		we need to push a receiver of the signal message.
+		A suspended context should always be a top context.
+		A top context has the return value of the message in the stack.
+		As this context has been suspended while sending a message the return value should be pushed. 
+		This is maybe not the expected return value (the #signal message returns the value with the 
+		one the exception is resumed).
+		But this allows the debugger to continue executing and does not crash the interpreter nor 
+		the VM
+		"
 		suspendedContext push: nil].
 	^ suspendedContext
 ]

--- a/src/ReleaseTests/ObsoleteTest.class.st
+++ b/src/ReleaseTests/ObsoleteTest.class.st
@@ -10,6 +10,12 @@ Class {
 	#category : #'ReleaseTests-Tests'
 }
 
+{ #category : #accessing }
+ObsoleteTest >> defaultTimeLimit [ 
+
+	^ 30 seconds
+]
+
 { #category : #running }
 ObsoleteTest >> setUp [
 	super setUp.


### PR DESCRIPTION
When doing a jump in inside a method (in this case on:do: and ensure:) we need to guarantee that the return value of the method is pushed in the original context.

Fix #8379
Fix #2410 
Fix #7394