### PR TITLE
7763-Does-BlockClosurecull-need-the-pragma-debuggerCompleteToSender

### DIFF
--- a/src/Kernel/BlockClosure.class.st
+++ b/src/Kernel/BlockClosure.class.st
@@ -150,7 +150,6 @@ BlockClosure >> cull: anArg [
 	"([:x | x + 12] cull: 3)
 	>>> 15
 	"
-	<debuggerCompleteToSender>
 	^numArgs = 0 
 		ifTrue: [self value]
 		ifFalse: [self value: anArg]


### PR DESCRIPTION
I could not find why we need this in #cull: --> remove

fixes #7763

