### PR TITLE
Removing suspicious update code in the debugger inspector, and fixing variable update problem with recursive call

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerInspectorTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerInspectorTest.class.st
@@ -52,6 +52,21 @@ StDebuggerInspectorTest >> testSetDefaultLayoutSpec [
 ]
 
 { #category : #tests }
+StDebuggerInspectorTest >> testShouldUpdateContext [
+
+	| debugger |
+	debugger := StTestDebuggerProvider new
+		            debuggerWithFailingAssertionContext.
+	session := debugger session.
+	self assert: (inspector
+			 shouldUpdateContext: session interruptedContext sender
+			 with: session interruptedContext).
+	self deny: (inspector
+			 shouldUpdateContext: session interruptedContext
+			 with: session interruptedContext)
+]
+
+{ #category : #tests }
 StDebuggerInspectorTest >> testUpdateLayoutForContextsWithAssertionFailure [
 	| debugger assertionFailure |
 	debugger := StTestDebuggerProvider new

--- a/src/NewTools-Debugger/StDebuggerInspector.class.st
+++ b/src/NewTools-Debugger/StDebuggerInspector.class.st
@@ -183,6 +183,12 @@ StDebuggerInspector >> setModelBeforeInitialization: aModel [
 	model := aModel
 ]
 
+{ #category : #updating }
+StDebuggerInspector >> shouldUpdateContext: oldContext with: newContext [
+
+	^ oldContext ~~ newContext
+]
+
 { #category : #stepping }
 StDebuggerInspector >> step [
 	inspector step
@@ -218,14 +224,12 @@ StDebuggerInspector >> updateLayoutForContexts: aContext isAssertionFailure: isT
 
 { #category : #updating }
 StDebuggerInspector >> updateWith: inspectedObject [
+
 	| oldContext newContext |
 	oldContext := self model inspectedObject ifNotNil: [ :dbgCtx | 
 		              dbgCtx context ].
 	newContext := inspectedObject ifNotNil: [ :dbgCtx | dbgCtx context ].
-	(oldContext notNil and: [ newContext notNil ]) ifTrue: [ 
-		(oldContext receiver == newContext receiver and: [ 
-			 oldContext selector == newContext selector ]) ifTrue: [ ^ self ] ].
-
+	(self shouldUpdateContext: oldContext with: newContext) ifFalse: [ ^ self ].
 	self saveRawInspectionSelectionForContext: oldContext.
 	self model: (self debuggerInspectorModelClass on: inspectedObject).
 	self updateEvaluationPaneReceiver.


### PR DESCRIPTION
Mirror change pushed in NewTools.
Fixes #7286
Suspicious code has been removed, so it remains to be seen how the debugger bottom inspector behaves in the next days after that PR is merged.