### PR TITLE
spec1-clean-ivars

### DIFF
--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -44,7 +44,7 @@ NoUnusedVariablesLeftTest >> testNoUnusedInstanceVariablesLeft [
 	
 	classes := variables collect: [ :each | each definingClass ] as: Set.
 	
-	validExceptions := { }.	
+	validExceptions := { RBFooLintRuleTestData . RBLintRuleTestData }.	
 	
 	remaining := classes asOrderedCollection removeAll: validExceptions; yourself.
 	

--- a/src/Spec-Core/SpecLayoutFrame.class.st
+++ b/src/Spec-Core/SpecLayoutFrame.class.st
@@ -9,7 +9,6 @@ Class {
 	#instVars : [
 		'bottomFraction',
 		'bottomOffset',
-		'layout',
 		'leftFraction',
 		'leftOffset',
 		'rightFraction',

--- a/src/Spec-Core/SpecPragmaCollector.class.st
+++ b/src/Spec-Core/SpecPragmaCollector.class.st
@@ -9,9 +9,6 @@ Class {
 	#instVars : [
 		'behavior'
 	],
-	#classInstVars : [
-		'behavior'
-	],
 	#category : #'Spec-Core-Support'
 }
 

--- a/src/Spec-Layout/SpecTableLayoutAddSpacer.class.st
+++ b/src/Spec-Layout/SpecTableLayoutAddSpacer.class.st
@@ -12,7 +12,6 @@ Class {
 	#name : #SpecTableLayoutAddSpacer,
 	#superclass : #SpecTableLayoutAdd,
 	#instVars : [
-		'commands',
 		'spaceFillWeight',
 		'size',
 		'orientation'


### PR DESCRIPTION
- remove unused iVars from spec1 classes (deprecated, but they should be clean)

-  changed test to not care about RBFooLintRuleTestData  and RBLintRuleTestData

Now we have just 35 classes left with ivars that are not needed

