### PR TITLE
added a comparisson to KeyboardKey

### DIFF
--- a/src/System-Platforms-Tests/KeyboardKeyTest.class.st
+++ b/src/System-Platforms-Tests/KeyboardKeyTest.class.st
@@ -8,6 +8,16 @@ Class {
 }
 
 { #category : #tests }
+KeyboardKeyTest >> testEqual [ 
+
+	self 
+		assert: (KeyboardKey fromCharacter: Character arrowUp) 
+		equals: (KeyboardKey new 
+			withValue: 65362;
+			yourself)
+]
+
+{ #category : #tests }
 KeyboardKeyTest >> testNamed [
 	"These assertions have been written using data available in KeyboardKey class>>#initializeKeyTable"
 	self assert: (KeyboardKey named: 'SHIFT_L') equals: (KeyboardKey value: 65505).

--- a/src/System-Platforms/KeyboardKey.class.st
+++ b/src/System-Platforms/KeyboardKey.class.st
@@ -1088,6 +1088,19 @@ KeyboardKey class >> windowsVirtualKeyTable [
 	^WindowsVirtualKeyTable
 ]
 
+{ #category : #comparing }
+KeyboardKey >> = other [
+
+	^ self species = other species
+		and: [ self value = other value ]
+]
+
+{ #category : #comparing }
+KeyboardKey >> hash [
+
+	^ self species hash bitXor: self value hash
+]
+
 { #category : #testing }
 KeyboardKey >> isArrowDown [
 


### PR DESCRIPTION
 because otherway `Character down alt` = `Character down alt` gives false (since they are not the same object).