### PR TITLE
fixes #8416: SpStringTableColumn beEditable and acceptAction has not effect

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicTableCellBuilder.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTableCellBuilder.class.st
@@ -32,7 +32,7 @@ SpMorphicTableCellBuilder >> addBackgroundColorColumn: aTableColumn item: item t
 { #category : #private }
 SpMorphicTableCellBuilder >> addBoldColumn: aTableColumn item: item to: content [
 
-	aTableColumn displayItalic ifNotNil: [ :block |
+	aTableColumn displayBold ifNotNil: [ :block |
 		(block cull: item) ifTrue: [ 
 			^ content asText addAttribute: TextEmphasis bold ] ].
 	
@@ -226,8 +226,8 @@ SpMorphicTableCellBuilder >> visitLinkColumn: aTableColumn [
 
 { #category : #visiting }
 SpMorphicTableCellBuilder >> visitStringColumn: aTableColumn [
+
 	| content item |
-	
 	item := self item.
 
 	content := aTableColumn readObject: item.
@@ -235,10 +235,39 @@ SpMorphicTableCellBuilder >> visitStringColumn: aTableColumn [
 	content := self addColorColumn: aTableColumn item: item to: content.
 	content := self addItalicColumn: aTableColumn item: item to: content.
 	content := self addBoldColumn: aTableColumn item: item to: content.
-	content := self addUnderlineColumn: aTableColumn item: item to: content.
+	content := self
+		           addUnderlineColumn: aTableColumn
+		           item: item
+		           to: content.
+
+	aTableColumn isEditable
+		ifTrue: [ self visitStringColumnEditable: aTableColumn on: content ]
+		ifFalse: [ "add cell"
+			self addCell: content column: aTableColumn.
+			"add background (this is a special case of properties, 
+			since background needs to be applied to the cell and not to the text)"
+			self
+				addBackgroundColorColumn: aTableColumn
+				item: item
+				toMorph: cell ]
+]
+
+{ #category : #visiting }
+SpMorphicTableCellBuilder >> visitStringColumnEditable: aTableColumn on: content [
+
+	| presenter morph |
+	presenter := SpTextInputFieldPresenter new
+		             addStyle: 'compact';
+		             text: content;
+		             yourself.
+
+	aTableColumn acceptAction ifNotNil: [ :valuable | 
+		presenter whenSubmitDo: [ 
+			valuable cull: self item cull: presenter text ] ].
 	"add cell"
-	self addCell: content column: aTableColumn.
-	"add background (this is a special case of properties, since background needs to be 
-	 applied to the cell and not to the text)"
-	self addBackgroundColorColumn: aTableColumn item: item toMorph: cell
+
+	morph := presenter buildWithSpec.
+	presenter adapter applyStyle: morph.
+
+	self addCellMorph: morph column: aTableColumn 
 ]

--- a/src/Spec2-Core/SpAbstractTextPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractTextPresenter.class.st
@@ -311,8 +311,18 @@ SpAbstractTextPresenter >> text [
 { #category : #api }
 SpAbstractTextPresenter >> text: aString [
 	"Set the text of the text presenter"
+	"Attempts to keep text attributes (formatting) of the field"
 
-	text := aString
+	| attributes newValue |
+	aString isText ifTrue: [ 
+		text := aString.
+		^ self ].
+	newValue := aString.
+	self text isText ifTrue: [ 
+		attributes := self text attributesAt: 1 forStyle: TextStyle default.
+		newValue := newValue asText.
+		attributes do: [ :attr | newValue addAttribute: attr ] ].
+	text := newValue
 ]
 
 { #category : #simulating }

--- a/src/Spec2-Core/SpTablePresenter.class.st
+++ b/src/Spec2-Core/SpTablePresenter.class.st
@@ -41,6 +41,27 @@ SpTablePresenter class >> documentFactoryMethodSelector [
 	^ #newTable
 ]
 
+{ #category : #'as yet unclassified' }
+SpTablePresenter class >> exampleWriteableTable [
+	"The selector names are NOT stored, but serves merely to have something one can edit"
+	| example items|
+	items := String methods.
+	example := self new.
+	example
+		addColumn: (SpStringTableColumn new 
+					title: 'Editable selector name';
+					evaluated: [:m | m selector  ];
+					displayBold: [ :m | m selector isKeyword  ];
+					beEditable ;
+					onAcceptEdition: [ :m :t | Transcript nextPutAll: t;cr;endEntry ];
+					yourself ) ;
+		addColumn: (SpStringTableColumn title: 'Size' evaluated: #size) beSortable;
+		showColumnHeaders;
+		items: items;
+		openWithSpec.
+	^ example
+]
+
 { #category : #api }
 SpTablePresenter >> addColumn: aColumn [
 	"Add a column to the table. A column should be an instance of `SpTableColumn`"


### PR DESCRIPTION
There is one aspect of this I am less certain about, namely the change in `SpAbstractTextPresenter >> text:`. It fixes what I consider a bug, as the formatting (bold etc) is lost in the previous implementation. This keeps it.