### PR TITLE
fixes #8434 SpStringTableColumn sorting is cumbersome to get right

### DIFF
--- a/src/Spec2-Core/SpStringTableColumn.class.st
+++ b/src/Spec2-Core/SpStringTableColumn.class.st
@@ -67,6 +67,15 @@ SpStringTableColumn >> beSortable [
 ]
 
 { #category : #api }
+SpStringTableColumn >> compareFunction: aBlock [
+	"sets the sorting of this column to use the two argument aBlock for comparing (aBlock should return a boolean) "
+	"it is often simpler to use a boolean compare than the threeway compare required by sortFunction: "
+
+	super sortFunction: [ :i1 :i2| (aBlock value: i1 value: i2) ifTrue:[-1] ifFalse:[1]] asSortFunction .
+	self isSortable: aBlock notNil
+]
+
+{ #category : #api }
 SpStringTableColumn >> displayBackgroundColor [
 
 	^ backgroundColorAction
@@ -165,10 +174,10 @@ SpStringTableColumn >> onAcceptEdition: aBlock [
 
 { #category : #api }
 SpStringTableColumn >> sortFunction: aBlockOrSortFunction [
-	"Set the sort function to apply to the values of this column in order to sort elements.
+	"Set the THREEWAY sort function to apply to the values of this column in order to sort elements.
 	 `aBlockOrSortFunction` is a block that receives two arguments to compare or an instace of 
 	 `SortFunction`. "
 
-	super sortFunction: aBlockOrSortFunction.
+	super sortFunction: aBlockOrSortFunction asSortFunction .
 	self isSortable: aBlockOrSortFunction notNil
 ]

--- a/src/Spec2-Examples/SpTablePresenter.extension.st
+++ b/src/Spec2-Examples/SpTablePresenter.extension.st
@@ -12,6 +12,26 @@ SpTablePresenter class >> example [
 ]
 
 { #category : #'*Spec2-Examples' }
+SpTablePresenter class >> exampleSorting [
+	"Example shows the two kinds of sorting, using a boolean compare, or a threeway sorting"
+	| classNameCompare methodCountSorter |
+	
+	classNameCompare := [ :c1 :c2 | c1 name < c2 name ].
+	methodCountSorter := [ :c1 :c2 | 
+	                     c1 methodDictionary size threeWayCompareTo:
+		                     c2 methodDictionary size ].
+
+	self new
+		addColumn: ((SpStringTableColumn title: 'Name' evaluated: #name) 
+				 compareFunction: classNameCompare);
+		addColumn: ((SpStringTableColumn
+				  title: 'Methods' evaluated: [ :c | c methodDictionary size ]) 
+				sortFunction: methodCountSorter);
+		items: Smalltalk globals allClasses;
+		openWithSpec
+]
+
+{ #category : #'*Spec2-Examples' }
 SpTablePresenter class >> exampleWithColumnHeaders [
 	<sampleInstance>
 


### PR DESCRIPTION
Added a possibility for using a boolean compare for sorting, added an example, and changed the comment of sortFunction: