### PR TITLE
7987-Class-definition-should-not-be-evaluated-if-it-contains-a-syntax-error

### DIFF
--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -156,6 +156,7 @@ Is this really what you want to do?') asText
 	[class := classCompiler
 		source: aString;
 		requestor: aController;
+		failBlock: [ ^ nil ];
 		logged: true;
 		evaluate] on: OCUndeclaredVariableWarning do: [ :ex | 
 			"we are only interested in class definitions"


### PR DESCRIPTION
fixes #7987 by defining a fail block in the compiler eval call