### PR TITLE
8450-ChangeSorter-should-open-and-work-with-new-Spec2

### DIFF
--- a/src/NewTools-ChangeSorter/SpChangeSorterPresenter.class.st
+++ b/src/NewTools-ChangeSorter/SpChangeSorterPresenter.class.st
@@ -378,8 +378,8 @@ SpChangeSorterPresenter >> forgetMessage [
 { #category : #initialization }
 SpChangeSorterPresenter >> initialize [
 
-	super initialize.
 	model := ChangeSorterModel new.
+	super initialize.
 	SystemAnnouncer uniqueInstance weak 
 		when: CurrentChangeSetChanged 
 		send: #updateTitle 
@@ -521,7 +521,7 @@ SpChangeSorterPresenter >> newSet [
 	aSet := self model createNewSet.
 	aSet
 		ifNotNil: [ self updateChangesList.
-			changesListPresenter setSelectedItem: aSet.
+			changesListPresenter selectItem: aSet.
 			self updateWindowTitle ]
 ]
 

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -576,46 +576,6 @@ MorphicUIManager >> onPrimitiveError: aString [
 
 ]
 
-{ #category : #'ui requests' }
-MorphicUIManager >> openComparisonFrom: targetMethodSource
-					to: originalMethodSource
-					belongingTo: aClass
-					from: aChange 
-					labeled: aLabel 
-					inWindowLabeled: aWindowLabel [ 
-	| diffBuilder difference  |
-	PSMCPatchMorph usedByDefault 
-		ifTrue: [ ^ self openPolymorphComparisonFrom: originalMethodSource 
-					to: targetMethodSource
-					belongingTo: aClass
-					from: aChange
-					labeled: aLabel
-					inWindowLabeled: aWindowLabel   ].
-	diffBuilder :=  TextDiffBuilder
-			from: originalMethodSource 
-			to: targetMethodSource.
-	difference := diffBuilder buildDisplayPatch.
-	self edit: difference label: aLabel.
-				
-]
-
-{ #category : #private }
-MorphicUIManager >> openPolymorphComparisonFrom: targetMethodSource
-					to: originalMethodSource
-					belongingTo: aClass
-					from: aChange 
-					labeled: aLabel 
-					inWindowLabeled: aWindowLabel [ 
-	| diffMorph |
-	diffMorph := DiffChangeMorph
-		from: targetMethodSource
-		label: aChange stamp
-		to: originalMethodSource
-		label: (aClass compiledMethodAt: aChange methodSelector) timeStamp
-		contextClass: aClass.
-	diffMorph openInWindowLabeled: aWindowLabel.
-]
-
 { #category : #accessing }
 MorphicUIManager >> preferredCornerStyle [
 	^ self theme preferredCornerStyle

--- a/src/System-Changes-FileServices/ChangeSet.extension.st
+++ b/src/System-Changes-FileServices/ChangeSet.extension.st
@@ -29,7 +29,7 @@ ChangeSet class >> serviceFileIntoNewChangeSet [
 
 	^ SimpleServiceEntry 
 		provider: self 
-		label: 'Install into new change set'
+		label: 'Install into the image'
 		selector: #fileIntoNewChangeSet:
 		description: 'Install the file as a body of code in the image: create a new change set and file-in the selected file into it'
 		buttonLabel: 'Install'

--- a/src/System-Platforms/KeyboardKey.class.st
+++ b/src/System-Platforms/KeyboardKey.class.st
@@ -311,7 +311,8 @@ KeyboardKey class >> initializeKeyFromCharacterCompatibilityTable [
 		$) 							. #parenright.
 		$< 							. #less.
 		$< 							. #greater.
-		$| 							. #bar}
+		$| 							. #bar.
+		$- 							. #minus}
 			pairsDo: [ :character :keyname |
 				KeyFromCharacterTable at: character put: (self named: keyname asUppercase) ].
 ]

--- a/src/Tool-ExternalBrowser/ExternalChangesBrowser.class.st
+++ b/src/Tool-ExternalBrowser/ExternalChangesBrowser.class.st
@@ -195,7 +195,8 @@ ExternalChangesBrowser >> compareToCurrent: aMethodDeclaration [
 	| class sourceString |
 	class := aMethodDeclaration targetClass.
 	sourceString := (class >> aMethodDeclaration methodSelector) sourceCode.
-	UIManager default
+	
+	self
 		openComparisonFrom: aMethodDeclaration contents
 		to: sourceString
 		belongingTo: class
@@ -259,6 +260,54 @@ ExternalChangesBrowser >> initializeWidgets [
 		label: 'file in selected'.
 
 	codePane := self newCode.
+]
+
+{ #category : #private }
+ExternalChangesBrowser >> openComparisonFrom: targetMethodSource
+					to: originalMethodSource
+					belongingTo: aClass
+					from: aChange 
+					labeled: aLabel 
+					inWindowLabeled: aWindowLabel [ 
+
+	| diffBuilder difference  |
+
+	PSMCPatchMorph usedByDefault 
+		ifTrue: [ ^ self openPolymorphComparisonFrom: originalMethodSource 
+					to: targetMethodSource
+					belongingTo: aClass
+					from: aChange
+					labeled: aLabel
+					inWindowLabeled: aWindowLabel   ].
+
+	diffBuilder :=  TextDiffBuilder
+			from: originalMethodSource 
+			to: targetMethodSource.
+
+	difference := diffBuilder buildDisplayPatch.
+	
+	UIManager default edit: difference label: aLabel.
+				
+]
+
+{ #category : #private }
+ExternalChangesBrowser >> openPolymorphComparisonFrom: targetMethodSource
+					to: originalMethodSource
+					belongingTo: aClass
+					from: aChange 
+					labeled: aLabel 
+					inWindowLabeled: aWindowLabel [ 
+
+	| diffMorph |
+
+	diffMorph := DiffChangeMorph
+		from: targetMethodSource
+		label: aChange stamp
+		to: originalMethodSource
+		label: (aClass compiledMethodAt: aChange methodSelector) timeStamp
+		contextClass: aClass.
+
+	diffMorph openInWindowLabeled: aWindowLabel.
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fixing the ExternalCodeBrowser and the ChangeSorter to use the new version of Spec2.