### PR TITLE
Clean the log file created on the disk by the test

### DIFF
--- a/src/System-Support-Tests/SmalltalkImageTest.class.st
+++ b/src/System-Support-Tests/SmalltalkImageTest.class.st
@@ -114,7 +114,10 @@ SmalltalkImageTest >> testOpenLog [
 	"Other cases where a file with the given name can not be created."
 	self 
 		writeToLogWithFileNamed: '';
-		writeToLogWithFileNamed: '.'
+		writeToLogWithFileNamed: '.'.
+		
+	"clean the created log file"	
+	File deleteFile: 'file.log'
 
 ]
 

--- a/src/System-Support-Tests/SmalltalkImageTest.class.st
+++ b/src/System-Support-Tests/SmalltalkImageTest.class.st
@@ -129,6 +129,7 @@ SmalltalkImageTest >> writeToLogWithFileNamed: filename [
 	[ 
 	| stream |
 	stream := Smalltalk image openLog.
-	stream nextPutAll: 'foobar'	"We just make sure we can write something. I don't know any reliable way to check if it has really been written" ]
+	stream nextPutAll: 'foobar'."We just make sure we can write something. I don't know any reliable way to check if it has really been written"
+	Smalltalk closeLog: stream ]
 		ensure: [ Smalltalk logFileName: oldLogFileName ]
 ]

--- a/src/System-Support-Tests/SmalltalkImageTest.class.st
+++ b/src/System-Support-Tests/SmalltalkImageTest.class.st
@@ -117,7 +117,7 @@ SmalltalkImageTest >> testOpenLog [
 		writeToLogWithFileNamed: '.'.
 		
 	"clean the created log file"	
-	File deleteFile: 'file.log'
+	'file.log' asFileReference ensureDelete
 
 ]
 


### PR DESCRIPTION
Fix testOpenLog should not let files on disk #8377

I delete the file directly in the test. The creation of the file is local to that precise test.
I consider creating a teardown to delete the file can be less readable. We could see a file delete without knowing which test created that file.