### PR TITLE
Fixes issue #7616 implementors and senders browsing broken in the debugger

### DIFF
--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -594,7 +594,9 @@ SpCodePresenter >> selectedSelector [
 
 	"If text is selected, extract the selectors from the selected text. If there is no selection, try to extract the selectors under the caret position."
 
-	| extractor selectedText |
+	| extractor selectedText fullSource |
+	fullSource := self text.
+	fullSource ifNil: [ ^ nil ].
 	extractor := CNSelectorExtractor new.
 	selectedText := self selectedText.
 	^ selectedText
@@ -602,7 +604,7 @@ SpCodePresenter >> selectedSelector [
 		  extractor extractSelectorFromSelection: selectedText ]
 		  ifEmpty: [ 
 			  extractor
-				  extractSelectorFromSource: self text
+				  extractSelectorFromSource: fullSource
 				  atPosition: self selectionInterval first ]
 ]
 

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -591,8 +591,22 @@ SpCodePresenter >> selectedClassOrMetaClass [
 
 { #category : #'command support' }
 SpCodePresenter >> selectedSelector [
-	
-    ^ CNSelectorExtractor new extractSelectorFromSelection: self selectedTextOrLine
+
+	"If text is selected, extract the selectors from the selected text. If there is no selection, try to extract the selectors under the caret position."
+
+	| extractor selectedText |
+	extractor := CNSelectorExtractor new.
+	selectedText := self selectedText.
+	selectedText
+		ifNotEmpty: [ 
+		^ extractor extractSelectorFromSelection: selectedText ]
+		ifEmpty: [ 
+			| source ast |
+			source := self text.
+			ast := RBParser parseFaultyExpression: source.
+			^ extractor
+				  extractSelectorFromAST: ast
+				  atPosition: self selectionInterval first ]
 ]
 
 { #category : #api }

--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -597,15 +597,12 @@ SpCodePresenter >> selectedSelector [
 	| extractor selectedText |
 	extractor := CNSelectorExtractor new.
 	selectedText := self selectedText.
-	selectedText
-		ifNotEmpty: [ 
-		^ extractor extractSelectorFromSelection: selectedText ]
-		ifEmpty: [ 
-			| source ast |
-			source := self text.
-			ast := RBParser parseFaultyExpression: source.
-			^ extractor
-				  extractSelectorFromAST: ast
+	^ selectedText
+		  ifNotEmpty: [ 
+		  extractor extractSelectorFromSelection: selectedText ]
+		  ifEmpty: [ 
+			  extractor
+				  extractSelectorFromSource: self text
 				  atPosition: self selectionInterval first ]
 ]
 

--- a/src/Spec2-Tests/SpCodePresenterTest.class.st
+++ b/src/Spec2-Tests/SpCodePresenterTest.class.st
@@ -67,6 +67,39 @@ SpCodePresenterTest >> testFindClassFrom [
 ]
 
 { #category : #tests }
+SpCodePresenterTest >> testSelectedSelector [
+
+	"Testing border cases to avoid breaking execution. The selector extraction logic should be tested in the extractor class"
+
+	"Code presenter has nil text for some reason"
+
+	| selector |
+	presenter text: nil.
+	selector := presenter selectedSelector.
+	self assert: selector isNil.
+
+	"Code presenter is empty"
+	presenter text: ''.
+	selector := presenter selectedSelector.
+	self assert: selector isNil.
+
+	"Code has valid code"
+	selector := presenter text: 'anObject do: 1 with: 2'.
+	selector := presenter selectedSelector.
+	self assert: selector equals: #do:with:.
+
+	"Code has faulty code"
+	selector := presenter text: 'anObject do : 1 with: 2'.
+	selector := presenter selectedSelector.
+	self assert: selector equals: #do.
+
+	"Code has invalid code (no selectors at all)"
+	selector := presenter text: 'anObjectdo : 2'.
+	selector := presenter selectedSelector.
+	self assert: selector equals: #noMethod
+]
+
+{ #category : #tests }
 SpCodePresenterTest >> testWhenSyntaxHighlightChangedDo [
 	| count result |
 	count := 0.

--- a/src/Tools-CodeNavigation-Tests/CNSelectorExtractorTest.class.st
+++ b/src/Tools-CodeNavigation-Tests/CNSelectorExtractorTest.class.st
@@ -17,7 +17,14 @@ CNSelectorExtractorTest >> initialize [
 ]
 
 { #category : #test }
-CNSelectorExtractorTest >> testExtractSelectorFromSourceAtPosition_BorderCases_ReturnsNil [
+CNSelectorExtractorTest >> testExtractSelectorFromSourceAtPosition [
+
+	self flag: #toImplement.
+	self assert: false
+]
+
+{ #category : #test }
+CNSelectorExtractorTest >> testExtractSelectorFromSourceAtPositionBorderCasesReturnsNil [
 
    |source position|
 	"Border cases first"
@@ -45,7 +52,7 @@ CNSelectorExtractorTest >> testExtractSelectorFromSourceAtPosition_BorderCases_R
 ]
 
 { #category : #test }
-CNSelectorExtractorTest >> testExtractSelectorFromSourceAtPosition_GeneralCases_ExtractsSelector [
+CNSelectorExtractorTest >> testExtractSelectorFromSourceAtPositionGeneralCasesExtractsSelector [
 
 	"Note that the tested method (#extractSelectorFromSource:atPosition:) uses internally #extractSelectorFromAST:atPosition:"
 	"Also uses RBParser >> #parseFaultyExpression: "

--- a/src/Tools-CodeNavigation-Tests/CNSelectorExtractorTest.class.st
+++ b/src/Tools-CodeNavigation-Tests/CNSelectorExtractorTest.class.st
@@ -17,13 +17,6 @@ CNSelectorExtractorTest >> initialize [
 ]
 
 { #category : #test }
-CNSelectorExtractorTest >> testExtractSelectorFromSourceAtPosition [
-
-	self flag: #toImplement.
-	self assert: false
-]
-
-{ #category : #test }
 CNSelectorExtractorTest >> testExtractSelectorFromSourceAtPositionBorderCasesReturnsNil [
 
    |source position|

--- a/src/Tools-CodeNavigation-Tests/CNSelectorExtractorTest.class.st
+++ b/src/Tools-CodeNavigation-Tests/CNSelectorExtractorTest.class.st
@@ -1,0 +1,97 @@
+"
+A CNSelectorExtractorTest is a test class for testing the behavior of CNSelectorExtractor
+"
+Class {
+	#name : #CNSelectorExtractorTest,
+	#superclass : #TestCase,
+	#classVars : [
+		'selectorExtractor'
+	],
+	#category : #'Tools-CodeNavigation-Tests'
+}
+
+{ #category : #initialization }
+CNSelectorExtractorTest >> initialize [
+	"comment stating purpose of instance-side method"
+	"scope: class-variables  &  instance-variables"	
+			
+	selectorExtractor := CNSelectorExtractor new.
+]
+
+{ #category : #test }
+CNSelectorExtractorTest >> testExtractSelectorFromSourceAtPosition_BorderCases_ReturnsNil [
+
+   |source position|
+	"Border cases first"
+	
+	"Nil source, returns nil"
+	source := nil.
+	position := 1.
+	self assert: (selectorExtractor extractSelectorFromSource: source atPosition: position) isNil.
+	
+	"Empty source, returns nil"
+	source := ''.
+	position := 1.
+	self assert: (selectorExtractor extractSelectorFromSource: source atPosition: position) isNil.
+	
+	"nil source, invalid Position"
+	source := nil.
+	position := -1.
+	self assert: (selectorExtractor extractSelectorFromSource: source atPosition: position) isNil.
+	
+	"a string source, invalid Position"
+	source := 'astring'.
+	position := 10000.
+	self assert: (selectorExtractor extractSelectorFromSource: source atPosition: position) isNil.
+
+]
+
+{ #category : #test }
+CNSelectorExtractorTest >> testExtractSelectorFromSourceAtPosition_GeneralCases_ExtractsSelector [
+
+	"Note that the tested method (#extractSelectorFromSource:atPosition:) uses internally #extractSelectorFromAST:atPosition:"
+	"Also uses RBParser >> #parseFaultyExpression: "
+	"This means, that by covering only the border cases, there is full code coverage, assumming extractSelectorFromAST:atPosition: and RBParser >> #parseFaultyExpression:  tests are ok."
+
+	| source position |
+	"Empty source, invalid position, returns nil"
+	source := ''.
+	position := -1.
+	self assert: (selectorExtractor
+			 extractSelectorFromSource: source
+			 atPosition: position) isNil.
+
+	"Cascade"
+	source := 'foo bar: 7; fum'.
+	position := 1.
+	self
+		assert: (selectorExtractor
+				 extractSelectorFromSource: source
+				 atPosition: position)
+		equals: #bar:.
+
+	position := 12.
+	self
+		assert: (selectorExtractor
+				 extractSelectorFromSource: source
+				 atPosition: position)
+		equals: #fum.
+
+	"A good case of IfTrue if false. Should select #ifTrue:ifFalse:"
+	source := 'self isInteger ifTrue: [ #(1 2) first. self printString ] ifFalse: [ self yourself ]'.
+	position := source indexOfSubCollection: 'alse:'.
+	self
+		assert: (selectorExtractor
+				 extractSelectorFromSource: source
+				 atPosition: position)
+		equals: #ifTrue:ifFalse:.
+
+	"A good case of nesting. Should select #first"
+	source := 'self isInteger ifTrue: [ #(1 2) first. self printString ] ifFalse: [ self yourself ]'.
+	position := source indexOfSubCollection: 'irst'.
+	self
+		assert: (selectorExtractor
+				 extractSelectorFromSource: source
+				 atPosition: position)
+		equals: #first
+]

--- a/src/Tools-CodeNavigation-Tests/CNSelectorExtractorTest.class.st
+++ b/src/Tools-CodeNavigation-Tests/CNSelectorExtractorTest.class.st
@@ -12,8 +12,6 @@ Class {
 
 { #category : #initialization }
 CNSelectorExtractorTest >> initialize [
-	"comment stating purpose of instance-side method"
-	"scope: class-variables  &  instance-variables"	
 			
 	selectorExtractor := CNSelectorExtractor new.
 ]

--- a/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
+++ b/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
@@ -121,3 +121,13 @@ CNSelectorExtractor >> extractSelectorFromSelection: aString [
 	"fall back"
 	^ aString asSymbol
 ]
+
+{ #category : #'public - extraction' }
+CNSelectorExtractor >> extractSelectorFromSource: aString atPosition: aPosition [
+
+	"Receives a string with the source code, and a number which indicates the position (of the caret) where the selectors will be extracted."
+
+	^ self
+		  extractSelectorFromAST: (RBParser parseFaultyExpression: aString)
+		  atPosition: aPosition
+]

--- a/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
+++ b/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
@@ -64,21 +64,20 @@ CNSelectorExtractor >> extractSelectorFromAST: ast atPosition: aPosition [
 
 { #category : #private }
 CNSelectorExtractor >> extractSelectorFromNode: aNode [
-	
+
 	| node originalNode |
+	aNode ifNil: [ ^ nil ].
 	originalNode := node := aNode.
-	node isReturn ifTrue: [ 
-		node := node value ].
-	
-	node isCascade ifTrue: [ 
-		^ node messages first selector ].
-	
+	node isReturn ifTrue: [ node := node value ].
+
+	node isCascade ifTrue: [ ^ node messages first selector ].
+
 	node isMethod ifFalse: [ 
 		(node isValue and: [ node value isSymbol ]) ifTrue: [ ^ node value ].
-				
-		[ node isMessage or: [ node isMethod ]  ] whileFalse: [ 
-	 		(node := node parent) ifNil: [ ^ nil ] ].
-		
+
+		[ node isMessage or: [ node isMethod ] ] whileFalse: [ 
+			(node := node parent) ifNil: [ ^ nil ] ].
+
 		"This is a strange case with cascades.
 		Cascade nodes contain messages.
 		And each message contains (duplicated) the receiver.
@@ -94,12 +93,11 @@ CNSelectorExtractor >> extractSelectorFromNode: aNode [
 		However, in the first case we want cascade1 and in the latter we want cascade2.
 		
 		"
-		(node ~= originalNode
-			and: [ node parent notNil
-				and: [ node parent isCascade ] ])
-				ifTrue: [ node := node parent messages first ] ].
-	
-	^node selector
+		(node ~= originalNode and: [ 
+			 node parent notNil and: [ node parent isCascade ] ]) ifTrue: [ 
+			node := node parent messages first ] ].
+
+	^ node selector
 ]
 
 { #category : #'public - extraction' }
@@ -127,6 +125,9 @@ CNSelectorExtractor >> extractSelectorFromSource: aString atPosition: aPosition 
 
 	"Receives a string with the source code, and a number which indicates the position (of the caret) where the selectors will be extracted."
 
+	aString ifNil: [ ^ nil ].
+	aString ifEmpty: [ ^ nil ].
+	((aPosition < 0) or: (aPosition > aString size)) ifTrue: [ ^nil ].
 	^ self
 		  extractSelectorFromAST: (RBParser parseFaultyExpression: aString)
 		  atPosition: aPosition


### PR DESCRIPTION
Fixes issue #7616 - implementors and senders browsing broken in the debugger.
This correct the problem reported for the SpCodePresenter. Now it properly browses or suggests the appropriate selectors when seeking implementors.