### PR TITLE
RB - Create new refactoring, to create accessors with lazy initialization

### DIFF
--- a/src/Refactoring-Core/RBCreateAccessorsWithLazyInitializationForVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBCreateAccessorsWithLazyInitializationForVariableRefactoring.class.st
@@ -1,0 +1,59 @@
+"
+I am a refactoring for creating accessors with lazy initialization for variables.
+
+I am used by a couple of other refactorings creating new variables and accessors.
+
+My precondition is that the variable name is defined for this class.
+"
+Class {
+	#name : #RBCreateAccessorsWithLazyInitializationForVariableRefactoring,
+	#superclass : #RBCreateAccessorsForVariableRefactoring,
+	#instVars : [
+		'defaultValue'
+	],
+	#category : #'Refactoring-Core-Refactorings'
+}
+
+{ #category : #'instance creation' }
+RBCreateAccessorsWithLazyInitializationForVariableRefactoring class >> model: aRBSmalltalk variable: aVarName class: aClass classVariable: aBoolean defaultValue: aString [
+	^(self 
+		model: aRBSmalltalk
+		variable: aVarName
+		class: aClass)
+		classVariable: aBoolean;
+		defaultValue: aString;
+		yourself
+]
+
+{ #category : #'instance creation' }
+RBCreateAccessorsWithLazyInitializationForVariableRefactoring class >> variable: aVarName class: aClass classVariable: aBoolean defaultValue: aString [
+	^(self variable: aVarName class: aClass)
+		classVariable: aBoolean;
+		defaultValue: aString;
+		yourself
+]
+
+{ #category : #acccessing }
+RBCreateAccessorsWithLazyInitializationForVariableRefactoring >> defaultValue [
+	^ defaultValue ifNil: [ defaultValue := 'nil' ]
+]
+
+{ #category : #acccessing }
+RBCreateAccessorsWithLazyInitializationForVariableRefactoring >> defaultValue: aString [
+	defaultValue := aString
+]
+
+{ #category : #transforming }
+RBCreateAccessorsWithLazyInitializationForVariableRefactoring >> defineGetterMethod [
+	| selector definingClass |
+	definingClass := self definingClass.
+	selector := self safeMethodNameFor: definingClass
+				basedOn: variableName asString.
+	definingClass 
+		compile: ('<1s><r><r><t>^ <2s> ifNil: [ <2s> := <3s> ]' 
+			expandMacrosWith: selector 
+			with: variableName
+			with: self defaultValue)
+		classified: #(#accessing).
+	^selector
+]

--- a/src/Refactoring-Tests-Core/RBCreateAccessorsWithLazyInitializationForVariableTest.class.st
+++ b/src/Refactoring-Tests-Core/RBCreateAccessorsWithLazyInitializationForVariableTest.class.st
@@ -1,0 +1,76 @@
+Class {
+	#name : #RBCreateAccessorsWithLazyInitializationForVariableTest,
+	#superclass : #RBRefactoringTest,
+	#category : #'Refactoring-Tests-Core-Refactorings'
+}
+
+{ #category : #running }
+RBCreateAccessorsWithLazyInitializationForVariableTest >> setUp [
+	super setUp.
+	model := self abstractVariableTestData.
+]
+
+{ #category : #tests }
+RBCreateAccessorsWithLazyInitializationForVariableTest >> testExistingClassVariableAccessors [
+	| refactoring |
+	refactoring := RBCreateAccessorsWithLazyInitializationForVariableRefactoring 
+							variable: 'Name1' 
+							class: RBLintRuleTestData 
+							classVariable: true.
+	self executeRefactoring: refactoring.
+	self assertEmpty: refactoring changes changes.
+	self assert: refactoring setterMethod identicalTo: #name1:.
+	self assert: refactoring getterMethod identicalTo: #name1
+]
+
+{ #category : #tests }
+RBCreateAccessorsWithLazyInitializationForVariableTest >> testExistingInstanceVariableAccessors [
+	| refactoring |
+	refactoring := RBCreateAccessorsWithLazyInitializationForVariableRefactoring 
+							variable: 'name' 
+							class: RBLintRuleTestData 
+							classVariable: false.
+	self executeRefactoring: refactoring.
+	self assertEmpty: refactoring changes changes.
+	self assert: refactoring setterMethod identicalTo: #name:.
+	self assert: refactoring getterMethod identicalTo: #name
+]
+
+{ #category : #tests }
+RBCreateAccessorsWithLazyInitializationForVariableTest >> testNewClassVariableAccessors [
+	| ref class |
+	ref := RBCreateAccessorsWithLazyInitializationForVariableRefactoring variable: 'Foo1' class: RBLintRuleTestData classVariable: true defaultValue: '''someString'''.
+	self executeRefactoring: ref.
+	class := ref model metaclassNamed: #RBLintRuleTestData.
+	self denyEmpty: ref changes changes.
+	self assert: ref setterMethod identicalTo: #foo1:.
+	self assert: ref getterMethod identicalTo: #foo1.
+	self assert: (class parseTreeFor: #foo1) equals: (self parseMethod: 'foo1 ^Foo1 ifNil: [ Foo1 := ''someString'' ]').
+	self assert: (class parseTreeFor: #foo1:) equals: (self parseMethod: 'foo1: anObject ^ Foo1 := anObject')
+]
+
+{ #category : #tests }
+RBCreateAccessorsWithLazyInitializationForVariableTest >> testNewInstanceVariableAccessors [
+	| ref class |
+	ref := RBCreateAccessorsWithLazyInitializationForVariableRefactoring variable: 'foo1' class: RBLintRuleTestData classVariable: false defaultValue: '123'.
+	self executeRefactoring: ref.
+	class := ref model classNamed: #RBLintRuleTestData.
+	self denyEmpty: ref changes changes.
+	self assert: ref setterMethod identicalTo: #foo1:.
+	self assert: ref getterMethod identicalTo: #foo1.
+	self assert: (class parseTreeFor: #foo1) equals: (self parseMethod: 'foo1 ^foo1 ifNil: [foo1 := 123]').
+	self assert: (class parseTreeFor: #foo1:) equals: (self parseMethod: 'foo1: anObject foo1 := anObject')
+]
+
+{ #category : #'failure tests' }
+RBCreateAccessorsWithLazyInitializationForVariableTest >> testNonExistantName [
+	self
+		shouldFail: (RBCreateAccessorsWithLazyInitializationForVariableRefactoring 
+				variable: #Foo
+				class: RBBasicLintRuleTestData
+				classVariable: true);
+		shouldFail: (RBCreateAccessorsWithLazyInitializationForVariableRefactoring 
+				variable: 'foo'
+				class: RBBasicLintRuleTestData
+				classVariable: true)
+]


### PR DESCRIPTION
This refactoring create accessors with lazy initialization for variables, for example:
```
Object subclass: #SomeClass
	instanceVariableNames: 'stringVar'
	classVariableNames: ''
	package: 'Example'
```
we can create accessors with lazy initialization
```
SomeClass >> stringVar
    ^ stringVar ifNil: [ stringVar := '' ]

SomeClass >> stringVar: anObject
    stringVar := anObject
```
