### PR TITLE
RB - Fix ExtractMethodTransformation

### DIFF
--- a/src/Refactoring-Tests-Core/RBTransformationRuleTestData.class.st
+++ b/src/Refactoring-Tests-Core/RBTransformationRuleTestData.class.st
@@ -300,6 +300,11 @@ RBTransformationRuleTestData >> resetResult [
 	builder := RBRefactoryChangeManager changeFactory compositeRefactoryChange
 ]
 
+{ #category : #accessing }
+RBTransformationRuleTestData >> rewriteRuleAsString [
+	^ rewriteRule tree printString
+]
+
 { #category : #initialization }
 RBTransformationRuleTestData >> rewriteUsing: searchReplacer [ 
 	rewriteRule := searchReplacer.

--- a/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -11,7 +11,7 @@ RBExtractMethodTransformationTest >> sourceCodeAt: anInterval forMethod: aSelect
 		copyFrom: anInterval first to: anInterval last
 ]
 
-{ #category : #testing }
+{ #category : #'failure tests' }
 RBExtractMethodTransformationTest >> testBadInterval [
 
 	self shouldFail: (RBExtractMethodTransformation
@@ -29,7 +29,7 @@ RBExtractMethodTransformationTest >> testBadInterval [
 	
 ]
 
-{ #category : #testing }
+{ #category : #'failure tests' }
 RBExtractMethodTransformationTest >> testExtractFailure [
 
 	self shouldFail: (RBExtractMethodTransformation
@@ -55,6 +55,65 @@ RBExtractMethodTransformationTest >> testExtractFailure [
 ]
 
 { #category : #testing }
+RBExtractMethodTransformationTest >> testExtractUsingExistingMethodRefactoring [
+
+	| transformation class |
+	transformation := (RBExtractMethodTransformation
+		extract: 'rewriteRule tree printString'
+		from: #checkMethod:
+		to: #bar
+		in: #RBTransformationRuleTestData).
+	transformation setOption: #useExistingMethod toUse: [ :re :sel | true ].
+	transformation asRefactoring transform.
+	self assert: transformation model changes changes size equals: 1.
+	
+	class := transformation model classNamed: #RBTransformationRuleTestData.
+	self assert: (class parseTreeFor: #checkMethod:) 
+		  equals: (self parseMethod: 'checkMethod: aSmalllintContext
+	class := aSmalllintContext selectedClass.
+	(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: [ 
+		(RecursiveSelfRule
+			 executeTree: rewriteRule tree
+			 initialAnswer: false) ifFalse: [ 
+			builder
+				compile: self rewriteRuleAsString
+				in: class
+				classified: aSmalllintContext protocols ] ]').	
+	self deny: (class directlyDefinesMethod: #bar)
+]
+
+{ #category : #testing }
+RBExtractMethodTransformationTest >> testExtractWithoutUseExistingMethodRefactoring [
+
+	| transformation class |
+	transformation := (RBExtractMethodTransformation
+		extract: 'rewriteRule tree printString'
+		from: #checkMethod:
+		to: #bar
+		in: #RBTransformationRuleTestData).
+	transformation setOption: #useExistingMethod toUse: [ :re :sel | false ].
+	transformation asRefactoring transform.
+	self assert: transformation model changes changes size equals: 2.
+	
+	class := transformation model classNamed: #RBTransformationRuleTestData.
+	self assert: (class parseTreeFor: #checkMethod:) 
+		  equals: (self parseMethod: 'checkMethod: aSmalllintContext
+	class := aSmalllintContext selectedClass.
+	(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: [ 
+		(RecursiveSelfRule
+			 executeTree: rewriteRule tree
+			 initialAnswer: false) ifFalse: [ 
+			builder
+				compile: self bar
+				in: class
+				classified: aSmalllintContext protocols ] ]').	
+	self assert: (class parseTreeFor: #bar)
+		equals: (self parseMethod: 'bar
+		rewriteRule tree printString').
+	self assert: (class directlyDefinesMethod: #bar)
+]
+
+{ #category : #'failure tests' }
 RBExtractMethodTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBExtractMethodTransformation

--- a/src/Refactoring2-Transformations/RBExtractMethodTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBExtractMethodTransformation.class.st
@@ -28,7 +28,8 @@ Class {
 		'subtree',
 		'arguments',
 		'temporaries',
-		'assignments'
+		'assignments',
+		'existingSelector'
 	],
 	#category : #'Refactoring2-Transformations-Model'
 }
@@ -69,7 +70,14 @@ RBExtractMethodTransformation class >> model: aRBModel extract: aString from: aS
 RBExtractMethodTransformation >> buildTransformations [
 
 	subtree := self calculateSubtree.
-			
+	
+	existingSelector ifNotNil: [ 
+		^ OrderedCollection with: (self parseTreeRewriterClass 
+			replaceCode: subtree
+			byMessageSendTo: existingSelector
+			in: (self definingClass methodFor: self calculateTree selector))	
+	]
+	ifNil: [
 	^ (parseTree isNil or: [ subtree isNil ])
 		ifTrue: [ OrderedCollection new ]
 		ifFalse: [ 
@@ -110,7 +118,7 @@ RBExtractMethodTransformation >> buildTransformations [
 							variable: temporary
 							inMethod: selector
 							inClass: class ]);
-					yourself ] ]
+					yourself ] ] ]
 ]
 
 { #category : #querying }
@@ -336,14 +344,18 @@ RBExtractMethodTransformation >> preconditions [
 				reject: [ :m | m selector = selector ].
 			
 			(self parseTreeSearcherClass whichMethodIn: searchSpace matches: aSubtree)
-				ifNotEmpty: [ :opportunities |
-					self refactoringError: ('<1s> method(s) already implement this code.<n>Do you want to send a message instead?' expandMacrosWith: opportunities size asString)
-					with: [ (self parseTreeRewriterClass 
-							  replaceCode: aSubtree
-							  byMessageSendTo: opportunities anyOne
-							  in: (self definingClass methodFor: self calculateTree selector))
-							  transform ]. false ]
+				ifNotEmpty: [ :opportunities | 
+					existingSelector := opportunities anyOne.
+					(self shouldUseExistingMethod: existingSelector selector)
+					ifFalse: [ existingSelector := nil ].
+					true ]
 				ifEmpty: [ true ] ])
+]
+
+{ #category : #requesting }
+RBExtractMethodTransformation >> shouldUseExistingMethod: aSelector [ 
+
+	^(self options at: #useExistingMethod) value: self value: aSelector
 ]
 
 { #category : #printing }

--- a/src/Refactoring2-Transformations/RBTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBTransformation.class.st
@@ -141,6 +141,14 @@ RBTransformation >> defaultEnvironment [
 	^ RBBrowserEnvironment new
 ]
 
+{ #category : #execution }
+RBTransformation >> execute [
+	self primitiveExecute.
+	RBRefactoryChangeManager instance 
+		performChange: self changes; 
+		addUndoPointer: (RBRefactoryChangeManager nextCounter)
+]
+
 { #category : #initialization }
 RBTransformation >> initialize [
 	super initialize.


### PR DESCRIPTION
Update to have an option to reuse an existing method (if this have the same content than extracted code) when extracting a method