### PR TITLE
RB - Introduce Extract setUp refactoring

### DIFF
--- a/src/Refactoring-Core/RBExtractSetUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractSetUpMethodRefactoring.class.st
@@ -26,7 +26,8 @@ RBExtractSetUpMethodRefactoring >> nameNewMethod: aSymbol [
 { #category : #preconditions }
 RBExtractSetUpMethodRefactoring >> preconditions [
 	^(RBCondition definesSelector: selector in: class) &
-	(RBCondition definesSelector: #setUp in: class) not
+	(RBCondition definesSelector: #setUp in: class) not &
+	(RBCondition withBlock: [ class allSuperclasses anySatisfy: [ :e | e name = #TestCase ] ])
 		& (RBCondition withBlock: 
 					[self extractMethod.
 					self checkSpecialExtractions.

--- a/src/Refactoring-Core/RBExtractSetUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractSetUpMethodRefactoring.class.st
@@ -1,0 +1,51 @@
+"
+I am a refactoring for creating a setUp method from a code fragment.
+
+You can select an interval of some code in a test method and call this refactoring to create a setUp method implementing that code and replace the code by nothing. 
+The selected class need to be a subclass of TestCase.
+
+The preconditions are quite complex.
+	- The code needs to be parseable valid code. 
+	- The class must not implement setUp method.
+	- Class must inherit from testCase class 
+"
+Class {
+	#name : #RBExtractSetUpMethodRefactoring,
+	#superclass : #RBExtractMethodRefactoring,
+	#category : #'Refactoring-Core-Refactorings'
+}
+
+{ #category : #transforming }
+RBExtractSetUpMethodRefactoring >> nameNewMethod: aSymbol [
+	| args |
+	args := parameters collect: [ :parm | RBVariableNode named: parm ].
+	extractedParseTree renameSelector: aSymbol andArguments: args asArray.
+	modifiedParseTree := RBParseTreeRewriter replace: self methodDelimiter with: '#callToSetUp' in: modifiedParseTree.
+]
+
+{ #category : #preconditions }
+RBExtractSetUpMethodRefactoring >> preconditions [
+	^(RBCondition definesSelector: selector in: class) &
+	(RBCondition definesSelector: #setUp in: class) not
+		& (RBCondition withBlock: 
+					[self extractMethod.
+					self checkSpecialExtractions.
+					self checkReturn.
+					needsReturn ifTrue: [extractedParseTree addReturn].
+					self checkTemporaries.
+					true])
+]
+
+{ #category : #transforming }
+RBExtractSetUpMethodRefactoring >> transform [
+	| existingSelector |
+	existingSelector := self existingSelector.
+	self nameNewMethod: #setUp.
+	existingSelector ifNil: 
+		[ self renameAllParameters.
+		extractedParseTree body addNodeFirst: (RBParser parseExpression: 'super setUp').
+		class compile: extractedParseTree newSource
+			withAttributesFrom: (class methodFor: selector)].
+	modifiedParseTree body removeNode: (modifiedParseTree body statements at: 1).
+	class compileTree: modifiedParseTree
+]

--- a/src/Refactoring-Tests-Core/RBDataTest.class.st
+++ b/src/Refactoring-Tests-Core/RBDataTest.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : #RBDataTest,
+	#superclass : #TestCase,
+	#category : #'Refactoring-Tests-Core-Data'
+}
+
+{ #category : #tests }
+RBDataTest >> someMethod [
+	#'some.initializations'
+]
+
+{ #category : #tests }
+RBDataTest >> testExample [
+	self someMethod.
+	self assert: true
+]

--- a/src/Refactoring-Tests-Core/RBExtractSetUpMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBExtractSetUpMethodTest.class.st
@@ -5,6 +5,16 @@ Class {
 }
 
 { #category : #'failure tests' }
+RBExtractSetUpMethodTest >> testBadClass [
+	self
+		shouldFail:
+			(RBExtractSetUpMethodRefactoring
+				extract: (78 to: 197)
+				from: #displayName
+				in: RBLintRuleTestData)
+]
+
+{ #category : #'failure tests' }
 RBExtractSetUpMethodTest >> testBadInterval [
 	self
 		shouldFail:

--- a/src/Refactoring-Tests-Core/RBExtractSetUpMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBExtractSetUpMethodTest.class.st
@@ -1,0 +1,47 @@
+Class {
+	#name : #RBExtractSetUpMethodTest,
+	#superclass : #RBRefactoringTest,
+	#category : #'Refactoring-Tests-Core-Refactorings'
+}
+
+{ #category : #'failure tests' }
+RBExtractSetUpMethodTest >> testBadInterval [
+	self
+		shouldFail:
+			(RBExtractSetUpMethodRefactoring
+				extract: (14 to: 35)
+				from: #testExample
+				in: RBDataTest)
+]
+
+{ #category : #tests }
+RBExtractSetUpMethodTest >> testExtractSetUp [
+	| class refactoring |
+	refactoring := RBExtractSetUpMethodRefactoring
+				extract: (14 to: 29)
+				from: #testExample
+				in: RBDataTest.
+	self executeRefactoring: refactoring.
+	class := refactoring model classNamed: #RBDataTest.
+
+	self assert: (class parseTreeFor: #testExample) equals: (self parseMethod: 'testExample
+	self assert: true').
+	self assert: (class parseTreeFor: #setUp) equals: (self parseMethod: 'setUp
+	super setUp.
+	self someMethod')
+]
+
+{ #category : #'failure tests' }
+RBExtractSetUpMethodTest >> testModelExistingSetUpMethod [
+	| class refactoring |
+	model := RBClassModelFactory rbNamespace new.
+	class := model classNamed: #RBDataTest.
+	class compile: 'setUp #setUp'
+		classified: #(#accessing).
+	refactoring := RBExtractSetUpMethodRefactoring 
+				model: model
+				extract: (14 to: 29)
+				from: #testExample
+				in: RBDataTest.
+	self shouldFail: refactoring.
+]


### PR DESCRIPTION
Introduce Extract Setup (for testCase)
- extract method
- remove the call to the extracted method

Before refactoring:
```
SomeTest >>testFoo
     self x
     self assert: 
```
```
SomeTest >>  self x
```
After refactoring:
```
SomeTest >> testFoo
     self assert: 
```
```
SomeTest >> setUp
    super setUp.
    self x.
```