### PR TITLE
8467-Fuel-is-using-an-old-API-from-MultiByteFileStream

### DIFF
--- a/src/Fuel-Core/FLBufferedWriteStream.class.st
+++ b/src/Fuel-Core/FLBufferedWriteStream.class.st
@@ -138,7 +138,7 @@ FLBufferedWriteStream >> nextBytesPutAll: collection [
 		ifFalse: [
 			self flushBuffer.
 			collection size > (self buffer size / 2)
-				ifTrue: [ stream nextBytesPutAll: collection ]
+				ifTrue: [ stream nextPutAll: collection ]
 				ifFalse: [ self nextBytesPutAll: collection ] ]
 
 ]


### PR DESCRIPTION
The message nextBytesPutAll: is not implemented in streams.
It should be replaced by using nextPutAll: with a binary stream.