### PR TITLE
RB - Expose variable refactoring commands in source context

### DIFF
--- a/src/Calypso-SystemTools-Core/SycRenameVariableCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycRenameVariableCommand.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #SycRenameVariableCommand }
 SycRenameVariableCommand class >> sourceCodeMenuActivation [
 	<classAnnotation>
 	
-	^SycSourceCodeMenuActivation byRootGroupItemOrder: 1.2 for: ClySourceCodeContext
+	^SycSourceCodeMenuActivation byRootGroupItemOrder: 1.1 for: ClySourceCodeContext
 ]
 
 { #category : #'*Calypso-SystemTools-Core' }

--- a/src/SystemCommands-VariableCommands/SycProtectVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycProtectVariableCommand.class.st
@@ -4,6 +4,13 @@ Class {
 	#category : #'SystemCommands-VariableCommands'
 }
 
+{ #category : #activation }
+SycProtectVariableCommand class >> sourceCodeMenuActivation [
+	<classAnnotation>
+	
+	^SycSourceCodeMenuActivation byRootGroupItemOrder: 1.2 for: ClySourceCodeContext 
+]
+
 { #category : #execution }
 SycProtectVariableCommand >> asRefactorings [
 

--- a/src/SystemCommands-VariableCommands/SycRemoveVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycRemoveVariableCommand.class.st
@@ -7,6 +7,13 @@ Class {
 	#category : #'SystemCommands-VariableCommands'
 }
 
+{ #category : #activation }
+SycRemoveVariableCommand class >> sourceCodeMenuActivation [
+	<classAnnotation>
+	
+	^SycSourceCodeMenuActivation byRootGroupItemOrder: 1.5 for: ClySourceCodeContext
+]
+
 { #category : #execution }
 SycRemoveVariableCommand >> asRefactorings [
 	


### PR DESCRIPTION
Fixes #8345

Now we have exposed all variable refactoring commands in source context.

<img width="625" alt="imagen" src="https://user-images.githubusercontent.com/15729309/106475940-e4116680-647c-11eb-90a2-051d79773819.png">
<img width="570" alt="imagen" src="https://user-images.githubusercontent.com/15729309/106475975-ec69a180-647c-11eb-8c42-a360d03565c4.png">
