### PR TITLE
cleanup-ExternalObject-class-initialize 

### DIFF
--- a/src/FFI-Kernel/ExternalObject.class.st
+++ b/src/FFI-Kernel/ExternalObject.class.st
@@ -15,13 +15,10 @@ Class {
 
 { #category : #'class initialization' }
 ExternalObject class >> initialize [
-	"ExternalObject initialize"
-	(Smalltalk classNamed: #SessionManager)
-		ifNotNil: [:sessionManagerClass|
-			sessionManagerClass default
-				registerSystemClassNamed: self name
-				atPriority: 60]
-		ifNil: [Smalltalk addToStartUpList: self after: (Smalltalk classNamed: #ShortRunArray)].	
+	<script>
+	SessionManager default
+		registerSystemClassNamed: self name
+		atPriority: 60
 ]
 
 { #category : #'system startup' }


### PR DESCRIPTION
ExternalObject class>>#initialize was sending a non-existing selector #addToStartUpList:after:

We cleaned that up everywhere else already, so we can do it here, too.


