### PR TITLE
TaRenameSlot-TestAndFix

### DIFF
--- a/src/ClassParser/CDAbstractTraitCompositionNode.class.st
+++ b/src/ClassParser/CDAbstractTraitCompositionNode.class.st
@@ -31,6 +31,14 @@ CDAbstractTraitCompositionNode >> @ aCollection [
 		aliases: aCollection
 ]
 
+{ #category : #composing }
+CDAbstractTraitCompositionNode >> @@ aCollection [ 
+	
+	^ CDTraitSlotRenameNode new
+		subject: self;
+		renames: aCollection
+]
+
 { #category : #testing }
 CDAbstractTraitCompositionNode >> isTraitComposition [
 	

--- a/src/ClassParser/CDTraitSlotRenameNode.class.st
+++ b/src/ClassParser/CDTraitSlotRenameNode.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #CDTraitSlotRenameNode,
+	#superclass : #CDTraitCompositionNode,
+	#instVars : [
+		'renames'
+	],
+	#category : #'ClassParser-Model'
+}
+
+{ #category : #accessing }
+CDTraitSlotRenameNode >> renames [
+
+	^ renames
+]
+
+{ #category : #accessing }
+CDTraitSlotRenameNode >> renames: anObject [
+
+	renames := anObject
+]

--- a/src/TraitsV2-Tests/T2TraitWithAliasTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithAliasTest.class.st
@@ -38,3 +38,51 @@ T2TraitWithAliasTest >> testChangingAnAliasedMethodIsUpdated [
 	self assert: obj m2 equals: 2.
 
 ]
+
+{ #category : #tests }
+T2TraitWithAliasTest >> testChangingAnAliasedSlot [
+
+	| t1 c1 |
+	
+	t1 := self newTrait: #T1 with: #(ivar).
+	t1 compile: 'ivar ^ ivar'.
+	
+	c1 := self newClass: #C1 with: #(ivar2) uses: t1 @@ { #ivar -> #ivar2 }.
+
+	self assert: (c1 includesSelector: #ivar).
+	self assert: (c1>>#ivar) decompile printString equals: 'ivar
+
+	^ ivar2'.
+]
+
+{ #category : #tests }
+T2TraitWithAliasTest >> testChangingRenamedSlot [
+
+	| t1 c1 |
+	
+	t1 := self newTrait: #T1 with: #(ivar).
+	t1 compile: 'ivar ^ ivar'.
+	
+	c1 := self newClass: #C1 with: #(ivar2) uses: t1 @@ { #ivar -> #ivar2 }.
+
+	self assert: (c1 includesSelector: #ivar).
+	self assert: (c1>>#ivar) decompile printString equals: 'ivar
+
+	^ ivar2'.
+]
+
+{ #category : #tests }
+T2TraitWithAliasTest >> testChangingRenamedSlot2Slots [
+
+	| t1 c1 |
+	
+	t1 := self newTrait: #T1 with: #(ivar1 ivar2).
+	t1 compile: 'ivar ^ ivar2'.
+	
+	c1 := self newClass: #C1 with: #(rvar1 rvar2) uses: t1 @@ { #ivar2 -> #rvar2 }.
+
+	self assert: (c1 includesSelector: #ivar).
+	self assert: (c1>>#ivar) decompile printString equals: 'ivar
+
+	^ rvar2'.
+]

--- a/src/TraitsV2-Tests/T2TraitWithAliasTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithAliasTest.class.st
@@ -47,12 +47,19 @@ T2TraitWithAliasTest >> testChangingRenamedSlot [
 	t1 := self newTrait: #T1 with: #(ivar).
 	t1 compile: 'ivar ^ ivar'.
 	
-	c1 := self newClass: #C1 with: #(ivar2) uses: t1 @@ { #ivar -> #ivar2 }.
+	c1 := self newClass: #C1 with: #() uses: t1 @@ { #ivar -> #ivar2 }.
 
+	"we got the method #ivar from the Trait"
 	self assert: (c1 includesSelector: #ivar).
+	"the slot that we got from the trait is now called ivar2"
+	self assert: c1 slotNames equals: #(ivar2).
+	"was the code rewritten?"
 	self assert: (c1>>#ivar) decompile printString equals: 'ivar
 
 	^ ivar2'.
+	
+	"make sure to not modify the Trait"
+	self assert: t1 slotNames equals: #(ivar).
 ]
 
 { #category : #tests }
@@ -61,12 +68,20 @@ T2TraitWithAliasTest >> testChangingRenamedSlot2Slots [
 	| t1 c1 |
 	
 	t1 := self newTrait: #T1 with: #(ivar1 ivar2).
-	t1 compile: 'ivar ^ ivar2'.
+	t1 compile: 'ivar2 ^ ivar2'.
+	t1 compile: 'ivar1 ^ ivar1'.
 	
-	c1 := self newClass: #C1 with: #(rvar1 rvar2) uses: t1 @@ { #ivar2 -> #rvar2 }.
+	c1 := self newClass: #C1 with: #() uses: t1 @@ {  #ivar1 -> #rvar1 . #ivar2 -> #rvar2 }.
 
-	self assert: (c1 includesSelector: #ivar).
-	self assert: (c1>>#ivar) decompile printString equals: 'ivar
+	"we got the methods from the Trait"
+	self assert: (c1 includesSelector: #ivar1).
+	self assert: (c1 includesSelector: #ivar2).
+	"but the code got rewritten to access the renamed variable"
+	self assert: (c1>>#ivar1) decompile printString equals: 'ivar1
+
+	^ rvar1'.
+	
+	self assert: (c1>>#ivar2) decompile printString equals: 'ivar2
 
 	^ rvar2'.
 ]

--- a/src/TraitsV2-Tests/T2TraitWithAliasTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithAliasTest.class.st
@@ -40,22 +40,6 @@ T2TraitWithAliasTest >> testChangingAnAliasedMethodIsUpdated [
 ]
 
 { #category : #tests }
-T2TraitWithAliasTest >> testChangingAnAliasedSlot [
-
-	| t1 c1 |
-	
-	t1 := self newTrait: #T1 with: #(ivar).
-	t1 compile: 'ivar ^ ivar'.
-	
-	c1 := self newClass: #C1 with: #(ivar2) uses: t1 @@ { #ivar -> #ivar2 }.
-
-	self assert: (c1 includesSelector: #ivar).
-	self assert: (c1>>#ivar) decompile printString equals: 'ivar
-
-	^ ivar2'.
-]
-
-{ #category : #tests }
 T2TraitWithAliasTest >> testChangingRenamedSlot [
 
 	| t1 c1 |

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -69,7 +69,7 @@ TaAbstractComposition >> @= anAssociation [
 TaAbstractComposition >> @@ anArrayOfAssociations [
 
 	"This operation creates a new trait composition element with a slot renamed.
-	The parameter is an association, where the key is the old name and the value the new name."
+	The parameter is an array of association, where the key is the old name and the value the new name."
 	
 	^ TaRenameSlot rename: anArrayOfAssociations on: self
 ]

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -54,15 +54,6 @@ TaAbstractComposition >> = anotherTrait [
 ]
 
 { #category : #operations }
-TaAbstractComposition >> >> anAssociation [
-
-	"This operation creates a new trait composition element with a slot renamed.
-	The parameter is an association, where the key is the old name and the value the new name."
-	
-	^ TaRenameSlot from:anAssociation key to: anAssociation value on: self.
-]
-
-{ #category : #operations }
 TaAbstractComposition >> @ anArrayOfAssociations [
 	"I return a new trait composition with the aliases passed as parameters. It is an array of associations, the keys are the new selectors and the values are the original selectors"
 	^ TaAliasMethod alias: anArrayOfAssociations to: self.
@@ -72,6 +63,15 @@ TaAbstractComposition >> @ anArrayOfAssociations [
 TaAbstractComposition >> @= anAssociation [
 	"This performs a deep alias, rewriting all the sendings of this message. The association has its key as the new alias selector and the value as the original selector."
 	^ TaDeepAliasMethod alias:anAssociation to: self.
+]
+
+{ #category : #operations }
+TaAbstractComposition >> @@ anArrayOfAssociations [
+
+	"This operation creates a new trait composition element with a slot renamed.
+	The parameter is an association, where the key is the old name and the value the new name."
+	
+	^ TaRenameSlot rename: anArrayOfAssociations on: self
 ]
 
 { #category : #operations }

--- a/src/TraitsV2/TaEmptyComposition.class.st
+++ b/src/TraitsV2/TaEmptyComposition.class.st
@@ -24,17 +24,17 @@ TaEmptyComposition >> = anotherTrait [
 ]
 
 { #category : #operations }
-TaEmptyComposition >> >> anAssociation [
-	self error:'Could not perform on empty composition'
-]
-
-{ #category : #operations }
 TaEmptyComposition >> @ anAssociation [
 	self error:'Could not perform on empty composition'
 ]
 
 { #category : #operations }
 TaEmptyComposition >> @= anAssociation [
+	self error:'Could not perform on empty composition'
+]
+
+{ #category : #operations }
+TaEmptyComposition >> @@ anAssociation [
 	self error:'Could not perform on empty composition'
 ]
 

--- a/src/TraitsV2/TaRemoveSlot.class.st
+++ b/src/TraitsV2/TaRemoveSlot.class.st
@@ -7,7 +7,8 @@ Class {
 	#name : #TaRemoveSlot,
 	#superclass : #TaSingleComposition,
 	#instVars : [
-		'slotName'
+		'slotName',
+		'renames'
 	],
 	#category : #'TraitsV2-Compositions'
 }

--- a/src/TraitsV2/TaRenameSlot.class.st
+++ b/src/TraitsV2/TaRenameSlot.class.st
@@ -55,7 +55,7 @@ TaRenameSlot >> slots [
 	^ inner slots
 		collect: [ :e | 
 			| slot |
-			slot := e asSlot.
+			slot := e asSlot copy.
 			(renameDict includesKey: slot name) 
 				ifTrue: [ slot name: (renameDict at: slot name) ].
 			slot ]

--- a/src/TraitsV2/TaRenameSlot.class.st
+++ b/src/TraitsV2/TaRenameSlot.class.st
@@ -80,5 +80,5 @@ TaRenameSlot >> sourceCodeAt: aSelector [
 { #category : #printing }
 TaRenameSlot >> traitCompositionExpression [
 	
-	^ self inner traitCompositionExpressionWithParens , ' @@ ' , renames associations printString
+	^ self inner traitCompositionExpressionWithParens , ' @@ ' , renames printString
 ]

--- a/src/TraitsV2/TaRenameSlot.class.st
+++ b/src/TraitsV2/TaRenameSlot.class.st
@@ -7,8 +7,7 @@ Class {
 	#name : #TaRenameSlot,
 	#superclass : #TaSingleComposition,
 	#instVars : [
-		'oldName',
-		'newName'
+		'renames'
 	],
 	#category : #'TraitsV2-Compositions'
 }
@@ -22,51 +21,64 @@ TaRenameSlot class >> from:oldName to: newName on: aTrait [
 		yourself.
 ]
 
+{ #category : #'instance creation' }
+TaRenameSlot class >> rename: anArrayOfAssociations on: aTrait [
+	^ self new 
+		renames: anArrayOfAssociations;
+		inner: aTrait;
+		yourself.
+]
+
 { #category : #copying }
 TaRenameSlot >> copyTraitExpression [
-	^ self class from: oldName to: newName on: inner
+	^ self class rename: renames on: inner
 ]
 
 { #category : #accessing }
-TaRenameSlot >> newName [
-	^ newName
+TaRenameSlot >> renames [
+
+	^ renames
 ]
 
 { #category : #accessing }
-TaRenameSlot >> newName: anObject [
-	newName := anObject
-]
+TaRenameSlot >> renames: anObject [
 
-{ #category : #accessing }
-TaRenameSlot >> oldName [
-	^ oldName
-]
-
-{ #category : #accessing }
-TaRenameSlot >> oldName: anObject [
-	oldName := anObject
+	renames := anObject
 ]
 
 { #category : #accessing }
 TaRenameSlot >> slots [
+	| renameDict | 
+	
+	renameDict := renames asDictionary.
+	
 	^ inner slots
 		collect: [ :e | 
 			| slot |
 			slot := e asSlot.
-			slot name = oldName
-				ifTrue: [ slot name: newName ].
+			(renameDict includesKey: slot name) 
+				ifTrue: [ slot name: (renameDict at: slot name) ].
 			slot ]
 ]
 
 { #category : #accessing }
 TaRenameSlot >> sourceCodeAt: aSelector [
-	| originalSourceCode parseTree |
+	| originalSourceCode parseTree rewriter |
 	originalSourceCode := super sourceCodeAt: aSelector.
 
 	parseTree := RBParser parseMethod: originalSourceCode.
-
-	^ (RBParseTreeRewriter new
-		replace: oldName asString with: newName asString;
+	rewriter := RBParseTreeRewriter new.
+	
+	renames do: [:rename |
+		rewriter replace: rename key asString with: rename value asString ].
+	
+	^(rewriter	
 		executeTree: parseTree;
-		tree) formattedCode
+		tree) formattedCode.
+]
+
+{ #category : #printing }
+TaRenameSlot >> traitCompositionExpression [
+	
+	^ self inner traitCompositionExpressionWithParens , ' @@ ' , renames associations printString
 ]

--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -211,6 +211,12 @@ Trait >> @ anArray [
 	^ self asTraitComposition @ anArray
 ]
 
+{ #category : #accessing }
+Trait >> @@ anArray [
+	"I return myself with an aliased method. Check TaAbstractComposition >> #@ for more details"
+	^ self asTraitComposition @@ anArray
+]
+
 { #category : #users }
 Trait >> addUser: aClass [ 
 


### PR DESCRIPTION
- add tests for slot renaming. I added them to T2TraitWithAliasTest to be close to the method alias tests

- change the selector to @@. We can not use >> as that one returns compiledMethod on a Trait (like it does on a class)
- implement @@ on Trait
- change TaRenameSlot to support multiple renames. This way TaRenameSlot works like TaAliasMethod

This is one step for #8205

