### PR TITLE
7692-Deprecation-exception-when-use-Open-Directory-Chooser-button-dialog-of-Iceberg-Settings-UI

### DIFF
--- a/src/System-Settings-Core/PragmaSetting.class.st
+++ b/src/System-Settings-Core/PragmaSetting.class.st
@@ -99,8 +99,8 @@ PragmaSetting >> chooseFileDirectory [
 { #category : #'user interface' }
 PragmaSetting >> chooseFilePath [
     | result |
-    result := self theme chooseFullFileNameIn: self currentWorld title: 'Choose a file' extensions: nil path: nil preview: true.
-    result ifNotNil: [ self realValue: result.]
+    result := self theme chooseFileIn: self currentWorld title: 'Choose a file' extensions: nil path: nil preview: true.
+    result ifNotNil: [ self realValue: result fullName.]
 ]
 
 { #category : #'user interface' }


### PR DESCRIPTION
fixes #7692 by using the non-deprecated method to get the file name

