### PR TITLE
Adding deprecations that were recommended by DepMiner (accepted by all 4 reviewers)

### DIFF
--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -166,6 +166,18 @@ RBVariableNode >> isReservedVariable [
 	^ variable isReservedVariable
 ]
 
+{ #category : #generated }
+RBVariableNode >> isSelf [
+
+	"normally this method is not needed (if all the RBVariable creations create RBSelfNode instead but
+	since we do not control this."
+
+	self
+		deprecated: 'Use #isSelfVariable instead'
+		transformWith: '`@rec isSelf' -> '`@rec isSelfVariable'.
+	^ self isSelfVariable
+]
+
 { #category : #testing }
 RBVariableNode >> isSelfOrSuperVariable [
 	^ variable isSelfOrSuperVariable
@@ -174,6 +186,18 @@ RBVariableNode >> isSelfOrSuperVariable [
 { #category : #testing }
 RBVariableNode >> isSelfVariable [
 	^variable isSelfVariable
+]
+
+{ #category : #generated }
+RBVariableNode >> isSuper [
+
+	"normally this method is not needed (if all the RBVariable creations create RBSuperNode instead but
+	since we do not control this."
+
+	self
+		deprecated: 'Use #isSuperVariable instead'
+		transformWith: '`@rec isSuper' -> '`@rec isSuperVariable'.
+	^ self isSuperVariable
 ]
 
 { #category : #testing }

--- a/src/FreeType/FreeTypeCache.class.st
+++ b/src/FreeType/FreeTypeCache.class.st
@@ -239,6 +239,17 @@ FreeTypeCache >> removeAllForType: typeFlag [
 	
 ]
 
+{ #category : #generated }
+FreeTypeCache >> report [
+
+	"answer a description of the current state of the cache"
+
+	self
+		deprecated: 'Use #reportCacheState instead'
+		transformWith: '`@rec report' -> '`@rec reportCacheState'.
+	^ self reportCacheState
+]
+
 { #category : #reporting }
 FreeTypeCache >> reportCacheState [
 	"Answer a description of the current state of the cache"

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -544,6 +544,15 @@ FreeTypeFont >> isRegular [
 		or: [self isSimulatedRegular]
 ]
 
+{ #category : #generated }
+FreeTypeFont >> isSimulated [
+
+	self
+		deprecated: 'Use #isSimulatedStyle instead'
+		transformWith: '`@rec isSimulated' -> '`@rec isSimulatedStyle'.
+	^ self isSimulatedStyle
+]
+
 { #category : #testing }
 FreeTypeFont >> isSimulatedBold [
 	^self simulatedEmphasis anyMask: 1

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -1226,3 +1226,15 @@ RGBehavior >> usedTraits [
 RGBehavior >> users [
 	^ #()
 ]
+
+{ #category : #generated }
+RGBehavior >> usesSpecialSlot [
+
+	"return true if we define something else than InstanceVariableSlots"
+
+	self
+		deprecated: 'Use #slotsNeedFullDefinition instead'
+		transformWith:
+		'`@rec usesSpecialSlot' -> '`@rec slotsNeedFullDefinition'.
+	^ self slotsNeedFullDefinition
+]

--- a/src/Ring-Core/RGInstanceVariableSlot.class.st
+++ b/src/Ring-Core/RGInstanceVariableSlot.class.st
@@ -4,6 +4,15 @@ Class {
 	#category : #'Ring-Core-Kernel'
 }
 
+{ #category : #generated }
+RGInstanceVariableSlot >> isSpecial [
+
+	self
+		deprecated: 'Use #needsFullDefinition instead'
+		transformWith: '`@rec isSpecial' -> '`@rec needsFullDefinition'.
+	^ self needsFullDefinition
+]
+
 { #category : #testing }
 RGInstanceVariableSlot >> needsFullDefinition [
 	"I am just a backward compatible ivar slot and can use simple definitions.


### PR DESCRIPTION
Those methods were present in Pharo 8 but deleted in Pharo 9.
DepMiner tool (https://github.com/olekscode/DepMiner) recommended to return them with deprecations.

Those recommendations were accepted by the following reviewers:
- @Ducasse
- @MarcusDenker
- @tesonep
- @guillep 