### PR TITLE
Adding deprecations that were recommended by DepMiner (accepted by 3 reviewers)

### DIFF
--- a/src/ClassParser/CDClassDefinitionParser.class.st
+++ b/src/ClassParser/CDClassDefinitionParser.class.st
@@ -76,6 +76,16 @@ CDClassDefinitionParser >> isInstanceSideDefinition: aRBMessageNode [
 	^ aRBMessageNode receiver isMessage not
 ]
 
+{ #category : #generated }
+CDClassDefinitionParser >> parseClassName: aNode [
+
+	self
+		deprecated: 'Use #handleClassName: instead'
+		transformWith:
+		'`@rec parseClassName: `@arg' -> '`@rec handleClassName: `@arg'.
+	^ self handleClassName: aNode
+]
+
 { #category : #parsing }
 CDClassDefinitionParser >> parseSelectorPart: aString withArgument: aNode [ 
 	
@@ -107,6 +117,16 @@ CDClassDefinitionParser >> parseSelectorPart: aString withArgument: aNode [
 		classDefinition: self; 
 		unrecognizedPart: aString;
 		signal
+]
+
+{ #category : #generated }
+CDClassDefinitionParser >> parseSuperclassNode: aSuperclassNode [
+
+	self
+		deprecated: 'Use #handleSuperclassNode: instead'
+		transformWith: '`@rec parseSuperclassNode: `@arg'
+			-> '`@rec handleSuperclassNode: `@arg'.
+	^ self handleSuperclassNode: aSuperclassNode
 ]
 
 { #category : #parsing }

--- a/src/ClassParser/CDSharedVariableNode.class.st
+++ b/src/ClassParser/CDSharedVariableNode.class.st
@@ -30,6 +30,17 @@ CDSharedVariableNode >> isGlobalClassNameBinding [
 	^false
 ]
 
+{ #category : #generated }
+CDSharedVariableNode >> isInstance [
+
+	"To be polymorphic to RB method nodes"
+
+	self
+		deprecated: 'Use #isInstanceVariable instead'
+		transformWith: '`@rec isInstance' -> '`@rec isInstanceVariable'.
+	^ self isInstanceVariable
+]
+
 { #category : #testing }
 CDSharedVariableNode >> isInstanceVariable [
 	"To be polymorphic to RB method nodes"

--- a/src/ClassParser/CDSlotNode.class.st
+++ b/src/ClassParser/CDSlotNode.class.st
@@ -82,6 +82,17 @@ CDSlotNode >> isGlobalVariable [
 	^false
 ]
 
+{ #category : #generated }
+CDSlotNode >> isInstance [
+
+	"To be polymorphic to RB method nodes"
+
+	self
+		deprecated: 'Use #isInstanceVariable instead'
+		transformWith: '`@rec isInstance' -> '`@rec isInstanceVariable'.
+	^ self isInstanceVariable
+]
+
 { #category : #testing }
 CDSlotNode >> isInstanceVariable [
 	"To be polymorphic to RB method nodes"
@@ -98,6 +109,17 @@ CDSlotNode >> isLiteralVariable [
 CDSlotNode >> isTempVariable [
 	"To be polymorphic to RB method nodes"
 	^false
+]
+
+{ #category : #generated }
+CDSlotNode >> isUndeclared [
+
+	"To be polymorphic to RB method nodes"
+
+	self
+		deprecated: 'Use #isUndeclaredVariable instead'
+		transformWith: '`@rec isUndeclared' -> '`@rec isUndeclaredVariable'.
+	^ self isUndeclaredVariable
 ]
 
 { #category : #testing }

--- a/src/Ring-Core/RGSlot.class.st
+++ b/src/Ring-Core/RGSlot.class.st
@@ -45,6 +45,15 @@ RGSlot >> isSlot [
 	^ true
 ]
 
+{ #category : #generated }
+RGSlot >> isSpecial [
+
+	self
+		deprecated: 'Use #needsFullDefinition instead'
+		transformWith: '`@rec isSpecial' -> '`@rec needsFullDefinition'.
+	^ self needsFullDefinition
+]
+
 { #category : #accessing }
 RGSlot >> name: aString [
 

--- a/src/Ring-Core/RGVariable.class.st
+++ b/src/Ring-Core/RGVariable.class.st
@@ -88,6 +88,15 @@ RGVariable >> isVariable [
 	^true
 ]
 
+{ #category : #generated }
+RGVariable >> isVariableDefinition [
+
+	self
+		deprecated: 'Use #isVariable instead'
+		transformWith: '`@rec isVariableDefinition' -> '`@rec isVariable'.
+	^ self isVariable
+]
+
 { #category : #testing }
 RGVariable >> isWorkspaceVariable [
 	^ false


### PR DESCRIPTION
Those methods were present in Pharo 8 but deleted in Pharo 9.
DepMiner tool (https://github.com/olekscode/DepMiner) recommended to return them with deprecations.

Each one of those recommendations was accepted by 3 of the following 4 reviewers:

- @Ducasse
- @MarcusDenker
- @tesonep
- @guillep 