### PR TITLE
Adding deprecations that were recommended by DepMiner (accepted by 2 reviewers)

### DIFF
--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -181,6 +181,15 @@ RBVariableNode >> isSuperVariable [
 	^ variable isSuperVariable
 ]
 
+{ #category : #generated }
+RBVariableNode >> isTemp [
+
+	self
+		deprecated: 'Use #isTempVariable instead'
+		transformWith: '`@rec isTemp' -> '`@rec isTempVariable'.
+	^ self isTempVariable
+]
+
 { #category : #testing }
 RBVariableNode >> isTempVariable [
 	^variable isTempVariable

--- a/src/ClassParser/CDClassNameNode.class.st
+++ b/src/ClassParser/CDClassNameNode.class.st
@@ -40,6 +40,17 @@ CDClassNameNode >> existingClassIfAbsent: aBlock [
 	^binding value
 ]
 
+{ #category : #generated }
+CDClassNameNode >> isTemp [
+
+	"To be polymorphic to RB method nodes"
+
+	self
+		deprecated: 'Use #isTempVariable instead'
+		transformWith: '`@rec isTemp' -> '`@rec isTempVariable'.
+	^ self isTempVariable
+]
+
 { #category : #testing }
 CDClassNameNode >> isTempVariable [
 	"To be polymorphic to RB method nodes"

--- a/src/ClassParser/CDSlotNode.class.st
+++ b/src/ClassParser/CDSlotNode.class.st
@@ -94,6 +94,17 @@ CDSlotNode >> isLiteralVariable [
 	^false
 ]
 
+{ #category : #generated }
+CDSlotNode >> isTemp [
+
+	"To be polymorphic to RB method nodes"
+
+	self
+		deprecated: 'Use #isTempVariable instead'
+		transformWith: '`@rec isTemp' -> '`@rec isTempVariable'.
+	^ self isTempVariable
+]
+
 { #category : #testing }
 CDSlotNode >> isTempVariable [
 	"To be polymorphic to RB method nodes"

--- a/src/Deprecated90/RBArgumentNode.class.st
+++ b/src/Deprecated90/RBArgumentNode.class.st
@@ -11,3 +11,12 @@ Class {
 RBArgumentNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitArgumentNode: self
 ]
+
+{ #category : #generated }
+RBArgumentNode >> isArgument [
+
+	self
+		deprecated: 'Use #isArgumentVariable instead'
+		transformWith: '`@rec isArgument' -> '`@rec isArgumentVariable'.
+	^ self isArgumentVariable
+]

--- a/src/Deprecated90/RBGlobalNode.class.st
+++ b/src/Deprecated90/RBGlobalNode.class.st
@@ -11,3 +11,12 @@ Class {
 RBGlobalNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitGlobalNode: self
 ]
+
+{ #category : #generated }
+RBGlobalNode >> isGlobal [
+
+	self
+		deprecated: 'Use #isGlobalVariable instead'
+		transformWith: '`@rec isGlobal' -> '`@rec isGlobalVariable'.
+	^ self isGlobalVariable
+]

--- a/src/Deprecated90/RBInstanceVariableNode.class.st
+++ b/src/Deprecated90/RBInstanceVariableNode.class.st
@@ -11,3 +11,12 @@ Class {
 RBInstanceVariableNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitInstanceVariableNode: self
 ]
+
+{ #category : #generated }
+RBInstanceVariableNode >> isInstance [
+
+	self
+		deprecated: 'Use #isInstanceVariable instead'
+		transformWith: '`@rec isInstance' -> '`@rec isInstanceVariable'.
+	^ self isInstanceVariable
+]

--- a/src/Deprecated90/RBSelfNode.class.st
+++ b/src/Deprecated90/RBSelfNode.class.st
@@ -24,3 +24,12 @@ RBSelfNode >> initialize [
   super initialize.
   variable := SelfVariable instance
 ]
+
+{ #category : #generated }
+RBSelfNode >> isSelf [
+
+	self
+		deprecated: 'Use #isSelfVariable instead'
+		transformWith: '`@rec isSelf' -> '`@rec isSelfVariable'.
+	^ self isSelfVariable
+]

--- a/src/Deprecated90/RBSuperNode.class.st
+++ b/src/Deprecated90/RBSuperNode.class.st
@@ -24,3 +24,12 @@ RBSuperNode >> initialize [
   super initialize.
   variable := SuperVariable instance
 ]
+
+{ #category : #generated }
+RBSuperNode >> isSuper [
+
+	self
+		deprecated: 'Use #isSuperVariable instead'
+		transformWith: '`@rec isSuper' -> '`@rec isSuperVariable'.
+	^ self isSuperVariable
+]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -942,10 +942,13 @@ ClassDescription >> obsolete [
 
 { #category : #'file in/out' }
 ClassDescription >> oldDefinition [
-	
-	^ ClassDefinitionPrinter legacy
-		for: self;
-		definitionString
+
+	"Answer a String that defines the receiver."
+
+	self
+		deprecated: 'Use #definition instead'
+		transformWith: '`@rec oldDefinition' -> '`@rec definition'.
+	^ self definition
 ]
 
 { #category : #organization }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -942,13 +942,10 @@ ClassDescription >> obsolete [
 
 { #category : #'file in/out' }
 ClassDescription >> oldDefinition [
-
-	"Answer a String that defines the receiver."
-
-	self
-		deprecated: 'Use #definition instead'
-		transformWith: '`@rec oldDefinition' -> '`@rec definition'.
-	^ self definition
+	
+	^ ClassDefinitionPrinter legacy
+		for: self;
+		definitionString
 ]
 
 { #category : #organization }

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -120,6 +120,17 @@ Metaclass >> classVariables [
 		ifNotNil: [ :class | class classVariables ]
 ]
 
+{ #category : #generated }
+Metaclass >> definition [
+
+	"Refer to the comment in ClassDescription|definition."
+
+	self
+		deprecated: 'Use #definitionString instead'
+		transformWith: '`@rec definition' -> '`@rec definitionString'.
+	^ self definitionString
+]
+
 { #category : #fileout }
 Metaclass >> definitionStringFor: aConfiguredPrinter [
 

--- a/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
+++ b/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
@@ -166,6 +166,32 @@ RubSmalltalkEditorTest >> assertWidensToRegex: aString playground: isPlayground 
 	self assert: false description: 'Did not find a selection node for, "' , aString , '"'
 ]
 
+{ #category : #generated }
+RubSmalltalkEditorTest >> exectuteBestNodeFor: aSelector [
+
+	self
+		deprecated: 'Use #executeBestNodeFor: instead'
+		transformWith: '`@rec exectuteBestNodeFor: `@arg'
+			-> '`@rec executeBestNodeFor: `@arg'.
+	^ self executeBestNodeFor: aSelector
+]
+
+{ #category : #generated }
+RubSmalltalkEditorTest >> exectuteFindNextKeywordDirection: isFwd editingMode: aRubEditingMode onFound: aBlock [
+
+	self
+		deprecated:
+		'Use #executeFindNextKeywordDirection:editingMode:onFound: instead'
+		transformWith:
+			'`@rec exectuteFindNextKeywordDirection: `@arg1 editingMode: `@arg2 onFound: `@arg3'
+			->
+			'`@rec executeFindNextKeywordDirection: `@arg1 editingMode: `@arg2 onFound: `@arg3'.
+	^ self
+		  executeFindNextKeywordDirection: isFwd
+		  editingMode: aRubEditingMode
+		  onFound: aBlock
+]
+
 { #category : #helpers }
 RubSmalltalkEditorTest >> executeBestNodeFor: aSelector [
 	^ self executeBestNodeFor: aSelector editingMode: RubSmalltalkCodeMode new

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -206,6 +206,26 @@ RubSmalltalkEditor >> bestNodeInString: source at: selectionInterval editingMode
 
 ]
 
+{ #category : #generated }
+RubSmalltalkEditor >> bestNodeInString: source at: selectionInterval edittingMode: aRubEdittingMode shouldFavourExpressions: isFavouringExpressions onError: aBlock [
+
+	"Find the best node in the source text in the identified selection area"
+
+	self
+		deprecated:
+		'Use #bestNodeInString:at:editingMode:shouldFavourExpressions:onError: instead'
+		transformWith:
+			'`@rec bestNodeInString: `@arg1 at: `@arg2 edittingMode: `@arg3 shouldFavourExpressions: `@arg4 onError: `@arg5'
+			->
+			'`@rec bestNodeInString: `@arg1 at: `@arg2 editingMode: `@arg3 shouldFavourExpressions: `@arg4 onError: `@arg5'.
+	^ self
+		  bestNodeInString: source
+		  at: selectionInterval
+		  editingMode: aRubEdittingMode
+		  shouldFavourExpressions: isFavouringExpressions
+		  onError: aBlock
+]
+
 { #category : #'source navigation' }
 RubSmalltalkEditor >> bestNodeInTextArea [
 	"Find the best node in the editor text area at the current pointer location"

--- a/src/Spec2-Core/SpAbstractListPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractListPresenter.class.st
@@ -128,6 +128,16 @@ SpAbstractListPresenter >> doubleClickAtIndex: anIndex [
 	self doActivateAtIndex: anIndex
 ]
 
+{ #category : #generated }
+SpAbstractListPresenter >> enableItemSubstringFilter [
+
+	self
+		deprecated: 'Use #matchSubstring instead'
+		transformWith:
+		'`@rec enableItemSubstringFilter' -> '`@rec matchSubstring'.
+	^ self matchSubstring
+]
+
 { #category : #initialization }
 SpAbstractListPresenter >> initialize [
 

--- a/src/Spec2-Core/SpCheckBoxTableColumn.class.st
+++ b/src/Spec2-Core/SpCheckBoxTableColumn.class.st
@@ -55,3 +55,22 @@ SpCheckBoxTableColumn >> onDeactivation: aBlock [
 
 	onDeactivation := aBlock
 ]
+
+{ #category : #generated }
+SpCheckBoxTableColumn >> onDesactivation [
+
+	self
+		deprecated: 'Use #onDeactivation instead'
+		transformWith: '`@rec onDesactivation' -> '`@rec onDeactivation'.
+	^ self onDeactivation
+]
+
+{ #category : #generated }
+SpCheckBoxTableColumn >> onDesactivation: anObject [
+
+	self
+		deprecated: 'Use #onDeactivation: instead'
+		transformWith:
+		'`@rec onDesactivation: `@arg' -> '`@rec onDeactivation: `@arg'.
+	^ self onDeactivation: anObject
+]

--- a/src/Spec2-Core/SpListPresenter.class.st
+++ b/src/Spec2-Core/SpListPresenter.class.st
@@ -100,6 +100,16 @@ SpListPresenter >> displayValueFor: anObject [
 	^ self display value: anObject
 ]
 
+{ #category : #generated }
+SpListPresenter >> displayValueOf: anObject [
+
+	self
+		deprecated: 'Use #displayValueFor: instead'
+		transformWith:
+		'`@rec displayValueOf: `@arg' -> '`@rec displayValueFor: `@arg'.
+	^ self displayValueFor: anObject
+]
+
 { #category : #testing }
 SpListPresenter >> hasHeaderTitle [
 	"Answer true if the list has a title (See `SpListPresenter>>#headerTitle:`)."

--- a/src/Spec2-Morphic-Examples/SpMethodBrowser.class.st
+++ b/src/Spec2-Morphic-Examples/SpMethodBrowser.class.st
@@ -42,6 +42,16 @@ SpMethodBrowser class >> title [
 	^ 'Method Browser'
 ]
 
+{ #category : #generated }
+SpMethodBrowser >> acceptBlock: aBlock [
+
+	self
+		deprecated: 'Use #whenSubmitDo: instead'
+		transformWith:
+		'`@rec acceptBlock: `@arg' -> '`@rec whenSubmitDo: `@arg'.
+	^ self whenSubmitDo: aBlock
+]
+
 { #category : #accessing }
 SpMethodBrowser >> action [
 	^ textModel acceptBlock

--- a/src/Text-Edition/TextEditor.class.st
+++ b/src/Text-Edition/TextEditor.class.st
@@ -1658,6 +1658,16 @@ TextEditor >> findAndSelect: aRegex startingAt: anIndex searchBackwards: searchB
 	^ where
 ]
 
+{ #category : #generated }
+TextEditor >> findAndSelectNextOccurenceOf: aRegex [
+
+	self
+		deprecated: 'Use #findAndSelectPreviousOccurrenceOf: instead'
+		transformWith: '`@rec findAndSelectNextOccurenceOf: `@arg'
+			-> '`@rec findAndSelectPreviousOccurrenceOf: `@arg'.
+	^ self findAndSelectPreviousOccurrenceOf: aRegex
+]
+
 { #category : #'find-select' }
 TextEditor >> findAndSelectNextOccurrenceOf: aRegex [
 	| where |

--- a/src/TraitsV2/MetaclassForTraits.class.st
+++ b/src/TraitsV2/MetaclassForTraits.class.st
@@ -41,6 +41,15 @@ MetaclassForTraits >> asTraitComposition [
 	^ TaClassCompositionElement for: self
 ]
 
+{ #category : #generated }
+MetaclassForTraits >> definition [
+
+	self
+		deprecated: 'Use #definitionString instead'
+		transformWith: '`@rec definition' -> '`@rec definitionString'.
+	^ self definitionString
+]
+
 { #category : #testing }
 MetaclassForTraits >> isBaseTrait [
 	

--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -238,6 +238,15 @@ Trait >> classTrait [
 	^ self class
 ]
 
+{ #category : #generated }
+Trait >> definition [
+
+	self
+		deprecated: 'Use #definitionString instead'
+		transformWith: '`@rec definition' -> '`@rec definitionString'.
+	^ self definitionString
+]
+
 { #category : #fileout }
 Trait >> definitionStringFor: aConfiguredPrinter [
 

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -78,6 +78,17 @@ TraitedMetaclass >> baseLocalMethods: anObject [
 	baseLocalMethods := anObject
 ]
 
+{ #category : #generated }
+TraitedMetaclass >> definition [
+
+	"Refer to the comment in ClassDescription|definition."
+
+	self
+		deprecated: 'Use #definitionString instead'
+		transformWith: '`@rec definition' -> '`@rec definitionString'.
+	^ self definitionString
+]
+
 { #category : #fileout }
 TraitedMetaclass >> definitionStringFor: aConfiguredPrinter [
 


### PR DESCRIPTION
Those methods were present in Pharo 8 but deleted in Pharo 9.
DepMiner tool (https://github.com/olekscode/DepMiner) recommended to return them with deprecations.

Each one of those recommendations was accepted by 2 of the following 4 reviewers:

- @Ducasse
- @MarcusDenker
- @tesonep
- @guillep 

Pay attention to `ClassDescription >> oldDefinition` because  that one was changed for some reason