### PR TITLE
fixes #4856 - print on methods should avoid calling blindly print string on their elements

### DIFF
--- a/src/Clap-Core/ClapValidationReport.class.st
+++ b/src/Clap-Core/ClapValidationReport.class.st
@@ -45,6 +45,6 @@ ClapValidationReport >> isSuccess [
 ClapValidationReport >> printOn: aStream [
 	problems do: [ :each |
 		aStream
-			nextPutAll: each printString;
+			print: each;
 			cr ]
 ]

--- a/src/ClassParser/RBSlotInitializationNode.class.st
+++ b/src/ClassParser/RBSlotInitializationNode.class.st
@@ -95,7 +95,7 @@ RBSlotInitializationNode >> printOn: aStream [
 				size := selectorParts size. 
 				selectorParts withIndexDo: [ :each :i |
 							aStream 
-								print: each  ;
+								nextPutAll:  each asString  ;
 								<< ' ';
 								print: (argumentParts at: i) .
 							i = size ifFalse: [ aStream	<< ' ']]]

--- a/src/ClassParser/RBSlotInitializationNode.class.st
+++ b/src/ClassParser/RBSlotInitializationNode.class.st
@@ -95,9 +95,9 @@ RBSlotInitializationNode >> printOn: aStream [
 				size := selectorParts size. 
 				selectorParts withIndexDo: [ :each :i |
 							aStream 
-								<< each asString ;
+								print: each  ;
 								<< ' ';
-								<< (argumentParts at: i) printString.
+								print: (argumentParts at: i) .
 							i = size ifFalse: [ aStream	<< ' ']]]
 ]
 

--- a/src/Collections-Sequenceable/Array2D.class.st
+++ b/src/Collections-Sequenceable/Array2D.class.st
@@ -604,7 +604,7 @@ Array2D >> printOn: aStream [
 	(1 to: self numberOfRows) 
 		do: [ :r | 
 				(self atRow: r) 
-					do: [ :each | aStream print: each  ] 
+					do: [ :each | aStream print: each ] 
 					separatedBy: [ aStream space ]]
 		separatedBy: [ aStream cr ].
 	aStream nextPutAll: ' )'.

--- a/src/Collections-Sequenceable/Array2D.class.st
+++ b/src/Collections-Sequenceable/Array2D.class.st
@@ -604,7 +604,7 @@ Array2D >> printOn: aStream [
 	(1 to: self numberOfRows) 
 		do: [ :r | 
 				(self atRow: r) 
-					do: [ :each | aStream nextPutAll: each printString ] 
+					do: [ :each | aStream print: each  ] 
 					separatedBy: [ aStream space ]]
 		separatedBy: [ aStream cr ].
 	aStream nextPutAll: ' )'.

--- a/src/FileSystem-Core/FileSystemDirectoryEntry.class.st
+++ b/src/FileSystem-Core/FileSystemDirectoryEntry.class.st
@@ -353,8 +353,8 @@ FileSystemDirectoryEntry >> printLongFormOn: aStream [
 { #category : #printing }
 FileSystemDirectoryEntry >> printOn: aStream [
 
-	aStream nextPutAll: 'DirectoryEntry: '.
-	reference ifNotNil: [:ref | aStream nextPutAll: reference printString].
+	aStream << 'DirectoryEntry: '.
+	reference ifNotNil: [:ref | ref printOn: aStream].
 ]
 
 { #category : #delegate }

--- a/src/Glamour-Announcements/GLMContextChanged.class.st
+++ b/src/Glamour-Announcements/GLMContextChanged.class.st
@@ -53,7 +53,7 @@ GLMContextChanged >> printOn: aStream [
 	super printOn: aStream.
 	aStream 
 		nextPutAll: ' (presentation = ';
-		nextPutAll: self presentation printString;
+		print: self presentation ;
 		nextPutAll: ', property = #';
 		nextPutAll: self property;
 		nextPutAll: ', oldValue = ';

--- a/src/Glamour-Announcements/GLMMatchingPresentationsChanged.class.st
+++ b/src/Glamour-Announcements/GLMMatchingPresentationsChanged.class.st
@@ -48,5 +48,5 @@ GLMMatchingPresentationsChanged >> pane: aPane [
 { #category : #printing }
 GLMMatchingPresentationsChanged >> printOn: aStream [
 	super printOn: aStream.
-	aStream nextPutAll: ' (pane = ', self pane printString , ')'
+	aStream nextPutAll: ' (pane = '; print: self pane  ; nextPut: $)
 ]

--- a/src/Glamour-Announcements/GLMPresentationsChanged.class.st
+++ b/src/Glamour-Announcements/GLMPresentationsChanged.class.st
@@ -49,5 +49,5 @@ GLMPresentationsChanged >> presentations [
 { #category : #printing }
 GLMPresentationsChanged >> printOn: aStream [
 	super printOn: aStream.
-	aStream nextPutAll: ' (pane = ', self pane printString , ')'
+	aStream nextPutAll: ' (pane = '; print: self pane  ; nextPut: $)
 ]

--- a/src/Glamour-Core/GLMPane.class.st
+++ b/src/Glamour-Core/GLMPane.class.st
@@ -267,7 +267,7 @@ GLMPane >> printOn: aStream [
 	super printOn: aStream.
 	aStream
 		nextPut: $(;
-		nextPutAll: self identityHash printString;
+		print: self identityHash ;
 		space;
 		nextPutAll: self name;
 		nextPut: $)

--- a/src/Glamour-Core/GLMPanePort.class.st
+++ b/src/Glamour-Core/GLMPanePort.class.st
@@ -54,11 +54,11 @@ GLMPanePort >> printOn: aStream [
 	 
 	aStream 
 		nextPutAll: 'Port (pane='; 
-		nextPutAll: self pane name printString; 
+		print: self pane name ; 
 		nextPutAll: ' name='; 
-		nextPutAll: self name printString; 
+		print: self name ; 
 		nextPutAll: ' value='; 
-		nextPutAll: self value printString; 
+		print: self value ; 
 		nextPut: $)
 ]
 

--- a/src/Glamour-Core/GLMPort.class.st
+++ b/src/Glamour-Core/GLMPort.class.st
@@ -52,11 +52,11 @@ GLMPort >> printOn: aStream [
 	super printOn: aStream.
 	aStream 
 		nextPut: Character space;
-		nextPutAll: self identityHash printString;
+		print: self identityHash ;
 		nextPutAll: ' (name='; 
-		nextPutAll: self name printString; 
+		print: self name ; 
 		nextPutAll: ' value='; 
-		nextPutAll: self value printString; 
+		print: self value ; 
 		nextPut: $)
 ]
 

--- a/src/Glamour-Core/GLMPortEvent.class.st
+++ b/src/Glamour-Core/GLMPortEvent.class.st
@@ -89,7 +89,7 @@ GLMPortEvent >> printOn: aStream [
 	aStream 
 		nextPutAll: '(port='.
 	self port printOn: aStream.
-	aStream nextPutAll: ' oldValue='; nextPutAll: self oldValue printString; nextPut: $)
+	aStream nextPutAll: ' oldValue='; print: self oldValue ; nextPut: $)
 		
 ]
 

--- a/src/Glamour-Core/GLMPortReference.class.st
+++ b/src/Glamour-Core/GLMPortReference.class.st
@@ -31,8 +31,8 @@ GLMPortReference >> printOn: aStream [
 	super printOn: aStream.
 	aStream 
 		nextPut: Character space;
-		nextPutAll: self identityHash printString;
-		nextPutAll: ' ('.
-	port printOn: aStream.
-	aStream nextPut: $)
+		print: self identityHash;
+		nextPutAll: ' (';
+		print: port;
+	   nextPut: $)
 ]

--- a/src/Glamour-Core/GLMTransmission.class.st
+++ b/src/Glamour-Core/GLMTransmission.class.st
@@ -299,9 +299,9 @@ GLMTransmission >> printOn: aStream [
 	aStream 
 		nextPutAll: self class name;
 		nextPutAll: ' (origins='; 
-		nextPutAll: self origins printString; 
+		print: self origins ; 
 		nextPutAll: ' destination='; 
-		nextPutAll: self destination printString; 
+		print: self destination; 
 		nextPut: $)
 	 
 	

--- a/src/Glamour-Morphic-Widgets/GLMTreeMorphNodeModel.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMTreeMorphNodeModel.class.st
@@ -177,7 +177,7 @@ GLMTreeMorphNodeModel >> pathIn: aCollection [
 { #category : #printing }
 GLMTreeMorphNodeModel >> printOn: aStream [
 	aStream nextPutAll: 'a NodeModel with '.
-	aStream nextPutAll: self item printString.
+	aStream print: self item .
 ]
 
 { #category : #actions }

--- a/src/Hermes/HEMethod.class.st
+++ b/src/Hermes/HEMethod.class.st
@@ -88,7 +88,7 @@ HEMethod >> name: anObject [
 HEMethod >> printOn: aStream [
 	aStream
 		nextPutAll: 'HEMethod ( ';
-		nextPutAll: name printString;
+		print: name ;
 		nextPutAll: ' )'
 ]
 

--- a/src/Kernel-Chronology-Extras/Month.class.st
+++ b/src/Kernel-Chronology-Extras/Month.class.st
@@ -197,7 +197,7 @@ Month >> previous [
 { #category : #printing }
 Month >> printOn: aStream [ 
 
-	aStream nextPutAll: self monthName, ' ', self year printString.
+	aStream nextPutAll: self monthName; space; print: self year .
 ]
 
 { #category : #private }

--- a/src/Kernel/DelayBasicScheduler.class.st
+++ b/src/Kernel/DelayBasicScheduler.class.st
@@ -129,7 +129,7 @@ DelayBasicScheduler >> printOn: aStream [
 	super printOn: aStream.
 	aStream 
 		nextPutAll: '(';
-		nextPutAll: self identityHash printString;
+		print: self identityHash ;
 		nextPutAll: ') on ' ;
 		nextPutAll: ticker className.
 		 

--- a/src/Kernel/Duration.class.st
+++ b/src/Kernel/Duration.class.st
@@ -413,7 +413,7 @@ Duration >> printOn: aStream [
 	n = 0 ifFalse:
 		[ | z ps |
 		aStream nextPut: $..
-		ps := n printString padLeftTo: 9 with: $0. 
+		ps := n asString padLeftTo: 9 with: $0. 
 		z := ps findLast: [ :c | c asciiValue > $0 asciiValue ].
 		ps from: 1 to: z do: [ :c | aStream nextPut: c ] ].
 

--- a/src/Keymapping-Core/KMCategoryBinding.class.st
+++ b/src/Keymapping-Core/KMCategoryBinding.class.st
@@ -76,11 +76,11 @@ KMCategoryBinding >> partialMatch [
 
 { #category : #printing }
 KMCategoryBinding >> printOn: aStream [
-
+	super printOn: aStream.
 	aStream
-		nextPutAll: 'aKMCategoryTarget(';
-		nextPutAll: (category name ifNil: 'nil' ifNotNil: [ :n | n printString ]);
-		nextPutAll: ')'.
+		nextPut: $(;
+		print: category name;
+		nextPut: $).
 ]
 
 { #category : #accessing }

--- a/src/Keymapping-Core/KMCategoryTarget.class.st
+++ b/src/Keymapping-Core/KMCategoryTarget.class.st
@@ -70,11 +70,11 @@ KMCategoryTarget >> partialMatch [
 
 { #category : #printing }
 KMCategoryTarget >> printOn: aStream [
-
+	super printOn: aStream.
 	aStream
-		nextPutAll: 'aKMCategoryTarget(';
-		nextPutAll: (category name ifNil: 'nil' ifNotNil: [ :n | n printString ]);
-		nextPutAll: ')'.
+		nextPut: $(;
+		print: category name;
+		nextPut: $).
 ]
 
 { #category : #accessing }

--- a/src/Keymapping-Core/KMKeymap.class.st
+++ b/src/Keymapping-Core/KMKeymap.class.st
@@ -157,11 +157,11 @@ KMKeymap >> onMatchWith: anEventBuffer notify: aMatchListener andDo: anAction [
 { #category : #printing }
 KMKeymap >> printOn: aStream [
 	aStream 
-		nextPutAll: self name printString;
+		print: self name ;
 		nextPutAll: ' on ';
-		nextPutAll: self shortcut printString;
+		print: self shortcut ;
 		nextPutAll: ' do ' ;
-		nextPutAll: self action printString;
+		print: self action ;
 		cr.    
 ]
 

--- a/src/Manifest-Core/TheManifestBuilder.class.st
+++ b/src/Manifest-Core/TheManifestBuilder.class.st
@@ -503,7 +503,7 @@ TheManifestBuilder >> printOn: aStream [
 
 	aStream
 		nextPutAll: 'ManifestBuilder of ';
-		nextPutAll: manifestClass printString.
+		print: manifestClass .
 ]
 
 { #category : #manifest }

--- a/src/Metacello-Core/MetacelloVersionDiffReport.class.st
+++ b/src/Metacello-Core/MetacelloVersionDiffReport.class.st
@@ -56,38 +56,40 @@ MetacelloVersionDiffReport >> modifications: anObject [
 
 { #category : #printing }
 MetacelloVersionDiffReport >> printOn: aStream [
+
 	| printBlock |
 	printBlock := [ :pkgName :ar | 
-	aStream
-		tab: 2;
-		nextPutAll: pkgName asString;
-		cr.
-	aStream
-		tab: 3;
-		nextPutAll: (ar at: 1) asString printString;
-		nextPutAll: ' to ';
-		nextPutAll: (ar at: 2) asString printString;
-		cr ].
-	aStream
-		nextPutAll: self configuration asString;
+	              aStream
+		              tab: 2;
+		              print: pkgName;
+		              cr.
+	              aStream
+		              tab: 3;
+		              print: (ar at: 1);
+		              print: ' to ';
+		              print: (ar at: 2);
+		              cr ].
+
+	aStream 
+		print: self configuration;
 		space;
-		nextPutAll: from asString printString;
-		nextPutAll: ' to ';
-		nextPutAll: to asString printString;
+		print: from;
+		print: ' to ';
+		print: to;
 		cr.
 	aStream
 		tab;
-		nextPutAll: 'Additions:';
+		print: 'Additions:';
 		cr.
 	self additions keysAndValuesDo: printBlock.
 	aStream
 		tab;
-		nextPutAll: 'Modifications:';
+		print: 'Modifications:';
 		cr.
 	self modifications keysAndValuesDo: printBlock.
 	aStream
 		tab;
-		nextPutAll: 'Removals:';
+		print: 'Removals:';
 		cr.
 	self removals keysAndValuesDo: printBlock
 ]

--- a/src/Metacello-Core/MetacelloVersionDiffReport.class.st
+++ b/src/Metacello-Core/MetacelloVersionDiffReport.class.st
@@ -56,40 +56,38 @@ MetacelloVersionDiffReport >> modifications: anObject [
 
 { #category : #printing }
 MetacelloVersionDiffReport >> printOn: aStream [
-
 	| printBlock |
 	printBlock := [ :pkgName :ar | 
-	              aStream
-		              tab: 2;
-		              print: pkgName;
-		              cr.
-	              aStream
-		              tab: 3;
-		              print: (ar at: 1);
-		              print: ' to ';
-		              print: (ar at: 2);
-		              cr ].
-
-	aStream 
-		print: self configuration;
+	aStream
+		tab: 2;
+		nextPutAll: pkgName asString;
+		cr.
+	aStream
+		tab: 3;
+		print: (ar at: 1) asString ;
+		nextPutAll: ' to ';
+		print: (ar at: 2) asString ;
+		cr ].
+	aStream
+		nextPutAll: self configuration asString;
 		space;
-		print: from;
-		print: ' to ';
-		print: to;
+		print: from asString ;
+		nextPutAll: ' to ';
+		print: to asString ;
 		cr.
 	aStream
 		tab;
-		print: 'Additions:';
+		nextPutAll: 'Additions:';
 		cr.
 	self additions keysAndValuesDo: printBlock.
 	aStream
 		tab;
-		print: 'Modifications:';
+		nextPutAll: 'Modifications:';
 		cr.
 	self modifications keysAndValuesDo: printBlock.
 	aStream
 		tab;
-		print: 'Removals:';
+		nextPutAll: 'Removals:';
 		cr.
 	self removals keysAndValuesDo: printBlock
 ]

--- a/src/Monticello/MCVersion.class.st
+++ b/src/Monticello/MCVersion.class.st
@@ -201,9 +201,7 @@ MCVersion >> package [
 { #category : #printing }
 MCVersion >> printOn: aStream [
 	super printOn: aStream.
-	aStream nextPut: $(.
-	aStream nextPutAll: self info printString.
-	aStream nextPut: $).
+	aStream print: $(; print: self info; print: $).
 ]
 
 { #category : #initialization }

--- a/src/Monticello/MCVersion.class.st
+++ b/src/Monticello/MCVersion.class.st
@@ -201,7 +201,7 @@ MCVersion >> package [
 { #category : #printing }
 MCVersion >> printOn: aStream [
 	super printOn: aStream.
-	aStream print: $(; print: self info; print: $).
+	aStream nextPut: $(; print: self info; nextPut: $).
 ]
 
 { #category : #initialization }

--- a/src/MonticelloMocks/MCMockClassA.class.st
+++ b/src/MonticelloMocks/MCMockClassA.class.st
@@ -44,7 +44,8 @@ MCMockClassA class >> touchCVar [
 ]
 
 { #category : #numeric }
-MCMockClassA >> a [ ^ 'a2'
+MCMockClassA >> a [
+	^ 'a2'
 ]
 
 { #category : #numeric }

--- a/src/MonticelloMocks/MCMockClassA.class.st
+++ b/src/MonticelloMocks/MCMockClassA.class.st
@@ -44,8 +44,7 @@ MCMockClassA class >> touchCVar [
 ]
 
 { #category : #numeric }
-MCMockClassA >> a [
-	^ 'a2'
+MCMockClassA >> a [ ^ 'a2'
 ]
 
 { #category : #numeric }

--- a/src/Morphic-Core/DropEvent.class.st
+++ b/src/Morphic-Core/DropEvent.class.st
@@ -56,9 +56,9 @@ DropEvent >> position [
 DropEvent >> printOn: aStream [
 
 	aStream nextPut: $[.
-	aStream nextPutAll: self position printString; space.
+	aStream print: self position ; space.
 	aStream nextPutAll: self type; space.
-	aStream	 nextPutAll: self windowIndex printString.
+	aStream print: self windowIndex .
 	aStream nextPut: $].
 ]
 

--- a/src/Morphic-Core/MorphExtension.class.st
+++ b/src/Morphic-Core/MorphExtension.class.st
@@ -263,33 +263,34 @@ MorphExtension >> printOn: aStream [
 	super printOn: aStream.
 	aStream
 		space;
-		print: $(;
+		nextPut: $(;
 		print: self identityHash;
-		print: $).
+		nextPut: $).
 	locked == true
-		ifTrue: [ aStream print: ' [locked] ' ].
+		ifTrue: [ aStream nextPutAll: ' [locked] ' ].
 	visible == false
-		ifTrue: [ aStream print: '[not visible] ' ].
+		ifTrue: [ aStream nextPutAll: '[not visible] ' ].
 	sticky == true
-		ifTrue: [ aStream print: ' [sticky] ' ].
-	balloonText ifNotNil: [ aStream print: ' [balloonText] ' ].
+		ifTrue: [ aStream nextPutAll: ' [sticky] ' ].
+	balloonText ifNotNil: [ aStream nextPutAll: ' [balloonText] ' ].
 	externalName
 		ifNotNil: [ 
 			aStream
-				print: ' [externalName = ' ; print: externalName;
-				print: ' ] ' ].
+				nextPutAll: ' [externalName = ' , externalName;
+				nextPutAll: ' ] ' ].
 	eventHandler
 		ifNotNil: [ 
 			aStream
-				print: ' [eventHandler = ' ; print: eventHandler;
-				print: '] ' ].
+				print: ' [eventHandler = ' , eventHandler ;
+				nextPutAll: '] ' ].
 	(otherProperties isNil or: [ otherProperties isEmpty ])
 		ifTrue: [ ^ self ].
-	aStream print: ' [other: '.
+	aStream nextPutAll: ' [other: '.
 	self otherProperties
 		keysDo: [ :aKey | 
 			aStream
-				print: ' (' ; print: aKey ; print: ' -> ' ; print: (self otherProperties at: aKey) ;
+				nextPutAll: ' (' ; 
+					nextPutAll:  aKey; nextPutAll:  ' -> ' ; print: (self otherProperties at: aKey) ;
 				nextPutAll: ')' ].
 	aStream nextPut: $]
 ]

--- a/src/Morphic-Core/MorphExtension.class.st
+++ b/src/Morphic-Core/MorphExtension.class.st
@@ -276,12 +276,14 @@ MorphExtension >> printOn: aStream [
 	externalName
 		ifNotNil: [ 
 			aStream
-				nextPutAll: ' [externalName = ' , externalName;
+				nextPutAll: ' [externalName = ' ; 
+					nextPutAll:  externalName;
 				nextPutAll: ' ] ' ].
 	eventHandler
 		ifNotNil: [ 
 			aStream
-				print: ' [eventHandler = ' , eventHandler ;
+				nextPutAll:  ' [eventHandler = ' ; 
+				print: eventHandler ;
 				nextPutAll: '] ' ].
 	(otherProperties isNil or: [ otherProperties isEmpty ])
 		ifTrue: [ ^ self ].

--- a/src/Morphic-Core/MorphExtension.class.st
+++ b/src/Morphic-Core/MorphExtension.class.st
@@ -263,33 +263,33 @@ MorphExtension >> printOn: aStream [
 	super printOn: aStream.
 	aStream
 		space;
-		nextPut: $(;
+		print: $(;
 		print: self identityHash;
-		nextPut: $).
+		print: $).
 	locked == true
-		ifTrue: [ aStream nextPutAll: ' [locked] ' ].
+		ifTrue: [ aStream print: ' [locked] ' ].
 	visible == false
-		ifTrue: [ aStream nextPutAll: '[not visible] ' ].
+		ifTrue: [ aStream print: '[not visible] ' ].
 	sticky == true
-		ifTrue: [ aStream nextPutAll: ' [sticky] ' ].
-	balloonText ifNotNil: [ aStream nextPutAll: ' [balloonText] ' ].
+		ifTrue: [ aStream print: ' [sticky] ' ].
+	balloonText ifNotNil: [ aStream print: ' [balloonText] ' ].
 	externalName
 		ifNotNil: [ 
 			aStream
-				nextPutAll: ' [externalName = ' , externalName;
-				nextPutAll: ' ] ' ].
+				print: ' [externalName = ' ; print: externalName;
+				print: ' ] ' ].
 	eventHandler
 		ifNotNil: [ 
 			aStream
-				nextPutAll: ' [eventHandler = ' , eventHandler printString;
-				nextPutAll: '] ' ].
+				print: ' [eventHandler = ' ; print: eventHandler;
+				print: '] ' ].
 	(otherProperties isNil or: [ otherProperties isEmpty ])
 		ifTrue: [ ^ self ].
-	aStream nextPutAll: ' [other: '.
+	aStream print: ' [other: '.
 	self otherProperties
 		keysDo: [ :aKey | 
 			aStream
-				nextPutAll: ' (' , aKey , ' -> ' , (self otherProperties at: aKey) printString;
+				print: ' (' ; print: aKey ; print: ' -> ' ; print: (self otherProperties at: aKey) ;
 				nextPutAll: ')' ].
 	aStream nextPut: $]
 ]

--- a/src/Morphic-Core/MouseEvent.class.st
+++ b/src/Morphic-Core/MouseEvent.class.st
@@ -139,12 +139,12 @@ MouseEvent >> isMouseWheel [
 MouseEvent >> printOn: aStream [
 
 	aStream nextPut: $[.
-	aStream nextPutAll: self cursorPoint printString; space.
+	aStream print: self cursorPoint ; space.
 	aStream nextPutAll: type; space.
 	aStream nextPutAll: self modifierString.
 	aStream nextPutAll: self buttonString.
-	aStream nextPutAll: timeStamp printString; space.
-	aStream	 nextPutAll: self windowIndex printString.
+	aStream print: timeStamp ; space.
+	aStream print: self windowIndex .
 	aStream nextPut: $].
 ]
 

--- a/src/Morphic-Core/MouseMoveEvent.class.st
+++ b/src/Morphic-Core/MouseMoveEvent.class.st
@@ -41,13 +41,13 @@ MouseMoveEvent >> isMove [
 MouseMoveEvent >> printOn: aStream [
 
 	aStream nextPut: $[.
-	aStream nextPutAll: self startPoint printString; space.
-	aStream nextPutAll: self endPoint printString; space.
+	aStream print: self startPoint ; space.
+	aStream print: self endPoint ; space.
 	aStream nextPutAll: self type; space.
 	aStream nextPutAll: self modifierString.
 	aStream nextPutAll: self buttonString.
-	aStream nextPutAll: timeStamp printString; space.
-	aStream	 nextPutAll: self windowIndex printString.
+	aStream print: timeStamp ; space.
+	aStream print: self windowIndex .
 	aStream nextPut: $].
 ]
 

--- a/src/Morphic-Core/MouseWheelEvent.class.st
+++ b/src/Morphic-Core/MouseWheelEvent.class.st
@@ -71,13 +71,13 @@ MouseWheelEvent >> isUp [
 MouseWheelEvent >> printOn: aStream [
 
 	aStream nextPut: $[.
-	aStream nextPutAll: self cursorPoint printString; space.
+	aStream print: self cursorPoint; space.
 	aStream nextPutAll: type; space.
 	aStream print: self direction; space.
 	aStream nextPutAll: self modifierString.
 	aStream nextPutAll: self buttonString.
-	aStream nextPutAll: timeStamp printString; space.
-	aStream	 nextPutAll: self windowIndex printString.
+	aStream print: timeStamp; space.
+	aStream print: self windowIndex.
 	aStream nextPut: $].
 ]
 

--- a/src/Morphic-Core/TransformationMorph.class.st
+++ b/src/Morphic-Core/TransformationMorph.class.st
@@ -173,7 +173,7 @@ TransformationMorph >> printOn: aStream [
 	super printOn: aStream.
 	submorphs isEmpty 
 		ifTrue: [aStream nextPutAll: ' with no transformee!']
-		ifFalse: [aStream nextPutAll: ' on ' , submorphs first printString]
+		ifFalse: [aStream nextPutAll: ' on ' ; print: submorphs first ]
 ]
 
 { #category : #'geometry etoy' }

--- a/src/OSWindow-Core/OSEvent.class.st
+++ b/src/OSWindow-Core/OSEvent.class.st
@@ -50,7 +50,11 @@ OSEvent >> performDefaultAction [
 { #category : #printing }
 OSEvent >> printOn: aStream [
 	super printOn: aStream. 
-	window ifNotNil: [ aStream << ' (WindowId=' << window windowId printString << ')' ]
+	window ifNotNil: [ 
+		aStream 
+			nextPutAll:  ' (WindowId='; 
+			print: window windowId;  
+			nextPut:  $) ]
 
 ]
 

--- a/src/Pillar-Core/PRCascadingCounter.class.st
+++ b/src/Pillar-Core/PRCascadingCounter.class.st
@@ -54,7 +54,8 @@ PRCascadingCounter >> isValidCounter [
 
 { #category : #printing }
 PRCascadingCounter >> printOn: aStream [
-	self elements do: [ :each | aStream nextPutAll: each printString ] separatedBy: [ aStream nextPut: $. ]
+	self elements do: [ :each | 
+		aStream print: each ] separatedBy: [ aStream nextPut: $. ]
 ]
 
 { #category : #initialization }

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -712,7 +712,7 @@ TestCase >> prepareToRunAgain [
 
 { #category : #printing }
 TestCase >> printOn: aStream [
-	aStream nextPutAll: self class printString.
+	aStream nextPutAll: self class name asString.
 	self printTestSelectorOn: aStream
 ]
 

--- a/src/SUnit-Core/TestResource.class.st
+++ b/src/SUnit-Core/TestResource.class.st
@@ -198,7 +198,7 @@ TestResource >> name: aString [
 { #category : #printing }
 TestResource >> printOn: aStream [
 
-	aStream nextPutAll: self class printString
+	aStream nextPutAll: self class name asString
 ]
 
 { #category : #accessing }

--- a/src/Shout/SHStyleElement.class.st
+++ b/src/Shout/SHStyleElement.class.st
@@ -131,17 +131,17 @@ SHStyleElement >> printOn: aStream [
 	color
 		ifNotNil: [ aStream
 				nextPutAll: ' color: ';
-				nextPutAll: color printString
+				print: color 
 			].
 	emphasis
 		ifNotNil: [ aStream
 				nextPutAll: ' emphasis: ';
-				nextPutAll: emphasis printString
+				print: emphasis 
 			].
 	tokens
 		ifNotNil: [ aStream
 				nextPutAll: ' tokens: ';
-				nextPutAll: tokens printString
+				print: tokens 
 			]
 ]
 

--- a/src/Spec2-Morphic-Tests/SpRGBSlidersTest.class.st
+++ b/src/Spec2-Morphic-Tests/SpRGBSlidersTest.class.st
@@ -11,23 +11,21 @@ SpRGBSlidersTest >> classToTest [
 
 { #category : #tests }
 SpRGBSlidersTest >> testColor [
+
 	| random red green blue |
 	random := Random new.
-	red := random nextInt: 255.
-	green := random nextInt: 255.
-	blue := random nextInt: 255.
-	
+	red := random nextInteger: 255.
+	green := random nextInteger: 255.
+	blue := random nextInteger: 255.
+
 	presenter redSlider value: red.
 	presenter greenSlider value: green.
 	presenter blueSlider value: blue.
-	self
-		assert: presenter color
-		equals:
-			(Color
-				r: red
-				g: green
-				b: blue
-				range: 255)
+	self assert: presenter color equals: (Color
+			 r: red
+			 g: green
+			 b: blue
+			 range: 255)
 ]
 
 { #category : #tests }

--- a/src/System-Changes/ChangeRecord.class.st
+++ b/src/System-Changes/ChangeRecord.class.st
@@ -193,9 +193,9 @@ ChangeRecord >> position [
 { #category : #printing }
 ChangeRecord >> printOn: aStream [
 
-	aStream 
-		nextPutAll: self type printString.
-	self stamp ifNotNil: [ aStream nextPutAll: self stamp ]
+	self type printOn: aStream.
+	self stamp ifNotNil: [ :s | s printOn: aStream ].
+	
 ]
 
 { #category : #access }

--- a/src/System-Localization/Locale.class.st
+++ b/src/System-Localization/Locale.class.st
@@ -414,5 +414,5 @@ Locale >> primVMOffsetToUTC [
 { #category : #printing }
 Locale >> printOn: aStream [ 
 	super printOn: aStream.
-	aStream print: '(' ; print: id ; print: ')'
+	aStream nextPutAll:  '(' ; print: id ; nextPutAll:  ')'
 ]

--- a/src/System-Localization/Locale.class.st
+++ b/src/System-Localization/Locale.class.st
@@ -414,5 +414,5 @@ Locale >> primVMOffsetToUTC [
 { #category : #printing }
 Locale >> printOn: aStream [ 
 	super printOn: aStream.
-	aStream nextPutAll: '(' , id printString , ')'
+	aStream print: '(' ; print: id ; print: ')'
 ]

--- a/src/ThreadedFFI/TFPool.class.st
+++ b/src/ThreadedFFI/TFPool.class.st
@@ -85,7 +85,10 @@ TFPool >> populate: anArray [
 TFPool >> printOn: stream [
 
 	super printOn: stream.
-	stream << '(' << self size printString << ' elements)'
+	stream 
+		nextPut: $( ; 
+		print: self size  ; 
+		nextPutAll: ' elements)'
 ]
 
 { #category : #initialization }

--- a/src/Tools-Test/OpenToolTest.class.st
+++ b/src/Tools-Test/OpenToolTest.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #helpers }
 OpenToolTest >> openInspectorOn: anObject [
 
-	^ Smalltalk tools inspector inspector: anObject
+	^ Smalltalk tools inspector inspect: anObject
 ]
 
 { #category : #'test inspect' }

--- a/src/UnifiedFFI/FFIEnumeration.class.st
+++ b/src/UnifiedFFI/FFIEnumeration.class.st
@@ -323,7 +323,7 @@ FFIEnumeration >> item [
 FFIEnumeration >> printOn: stream [
 	super printOn: stream.
 	stream nextPut: $(;
-		 nextPutAll: self item printString;
+		 print: self item ;
 		 nextPut: $)
 ]
 

--- a/src/VariablesLibrary/ComputedSlot.class.st
+++ b/src/VariablesLibrary/ComputedSlot.class.st
@@ -54,7 +54,7 @@ ComputedSlot >> printOn: aStream [
 		nextPutAll: ' => ';
 		nextPutAll: self class name;
 		nextPutAll: ' with: ';
-		nextPutAll: block printString
+		print: block 
 ]
 
 { #category : #'meta-object-protocol' }


### PR DESCRIPTION
fixes #4856. There is a rule (`ReNoPrintStringInPrintOnRule`) which marks printString inside printOn: as bad style, so there is hope for the future. Almost all cases could be fixed by changing `aStream nextPutAll: obj printString` into `aStream print: obj`.