### PR TITLE
Cleanup-unused-vars-JobProgressBarMorph

### DIFF
--- a/src/Morphic-Base/JobProgressBarMorph.class.st
+++ b/src/Morphic-Base/JobProgressBarMorph.class.st
@@ -16,8 +16,6 @@ Class {
 		'progressBar'
 	],
 	#classVars : [
-		'BarHeight',
-		'BarWidth',
 		'IsInterruptable'
 	],
 	#category : #'Morphic-Base-ProgressBar'

--- a/src/Morphic-Base/SystemProgressItemMorph.class.st
+++ b/src/Morphic-Base/SystemProgressItemMorph.class.st
@@ -15,10 +15,6 @@ Class {
 		'endValue',
 		'lastRefresh'
 	],
-	#classVars : [
-		'BarHeight',
-		'BarWidth'
-	],
 	#category : #'Morphic-Base-ProgressBar'
 }
 

--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -25,7 +25,7 @@ NoUnusedVariablesLeftTest >> testNoUnusedClassVariablesLeft [
 	
 	classes := variables collect: [ :each | each definingClass ] as: Set.
 	
-	validExceptions := { RBTransformationRuleTestData1 }.	
+	validExceptions := {  }.	
 	
 	remaining := classes asOrderedCollection removeAll: validExceptions; yourself.
 	

--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -25,11 +25,11 @@ NoUnusedVariablesLeftTest >> testNoUnusedClassVariablesLeft [
 	
 	classes := variables collect: [ :each | each definingClass ] as: Set.
 	
-	validExceptions := { }.	
+	validExceptions := { RBTransformationRuleTestData1 }.	
 	
 	remaining := classes asOrderedCollection removeAll: validExceptions; yourself.
 	
-	self assert: classes isEmpty
+	self assert: remaining isEmpty
 ]
 
 { #category : #testing }
@@ -48,7 +48,7 @@ NoUnusedVariablesLeftTest >> testNoUnusedInstanceVariablesLeft [
 	
 	remaining := classes asOrderedCollection removeAll: validExceptions; yourself.
 	
-	self assert: classes isEmpty
+	self assert: remaining isEmpty
 ]
 
 { #category : #testing }


### PR DESCRIPTION
- SystemProgressItemMorph, Cleanup JobProgressBarMorph,
- improve testNoUnusedClassVariablesLeft and testNoUnusedInstanceVariablesLeft

