### PR TITLE
Adding deprecations for Opal Compiler that were recommended by DepMiner and accepted by Pablo

### DIFF
--- a/src/Deprecated90/OCAbstractVariable.class.st
+++ b/src/Deprecated90/OCAbstractVariable.class.st
@@ -23,6 +23,24 @@ OCAbstractVariable >> asString [
 	^ self name
 ]
 
+{ #category : #generated }
+OCAbstractVariable >> isGlobal [
+
+	self
+		deprecated: 'Use #isGlobalVariable instead'
+		transformWith: '`@rec isGlobal' -> '`@rec isGlobalVariable'.
+	^ self isGlobalVariable
+]
+
+{ #category : #generated }
+OCAbstractVariable >> isInstance [
+
+	self
+		deprecated: 'Use #isInstanceVariable instead'
+		transformWith: '`@rec isInstance' -> '`@rec isInstanceVariable'.
+	^ self isInstanceVariable
+]
+
 { #category : #'read/write usage' }
 OCAbstractVariable >> isRead [
 	^usage = #read
@@ -38,6 +56,42 @@ OCAbstractVariable >> isRemote [
 OCAbstractVariable >> isRepeatedWrite [
 	^usage = #repeatedWrite
 
+]
+
+{ #category : #generated }
+OCAbstractVariable >> isSelf [
+
+	self
+		deprecated: 'Use #isSelfVariable instead'
+		transformWith: '`@rec isSelf' -> '`@rec isSelfVariable'.
+	^ self isSelfVariable
+]
+
+{ #category : #generated }
+OCAbstractVariable >> isSuper [
+
+	self
+		deprecated: 'Use #isSuperVariable instead'
+		transformWith: '`@rec isSuper' -> '`@rec isSuperVariable'.
+	^ self isSuperVariable
+]
+
+{ #category : #generated }
+OCAbstractVariable >> isTemp [
+
+	self
+		deprecated: 'Use #isTempVariable instead'
+		transformWith: '`@rec isTemp' -> '`@rec isTempVariable'.
+	^ self isTempVariable
+]
+
+{ #category : #generated }
+OCAbstractVariable >> isUndeclared [
+
+	self
+		deprecated: 'Use #isUndeclaredVariable instead'
+		transformWith: '`@rec isUndeclared' -> '`@rec isUndeclaredVariable'.
+	^ self isUndeclaredVariable
 ]
 
 { #category : #'read/write usage' }

--- a/src/Deprecated90/OCLiteralVariable.class.st
+++ b/src/Deprecated90/OCLiteralVariable.class.st
@@ -44,6 +44,15 @@ OCLiteralVariable >> isFromSharedPool [
 		ifNone: [ false ]
 ]
 
+{ #category : #generated }
+OCLiteralVariable >> isGlobal [
+
+	self
+		deprecated: 'Use #isGlobalVariable instead'
+		transformWith: '`@rec isGlobal' -> '`@rec isGlobalVariable'.
+	^ self isGlobalVariable
+]
+
 { #category : #testing }
 OCLiteralVariable >> isGlobalClassNameBinding [
 	^ (self value isClass or: [ self value isTrait ])

--- a/src/Deprecated90/OCSelfVariable.class.st
+++ b/src/Deprecated90/OCSelfVariable.class.st
@@ -20,6 +20,15 @@ OCSelfVariable >> initialize [
 	name := 'self'
 ]
 
+{ #category : #generated }
+OCSelfVariable >> isSelf [
+
+	self
+		deprecated: 'Use #isSelfVariable instead'
+		transformWith: '`@rec isSelf' -> '`@rec isSelfVariable'.
+	^ self isSelfVariable
+]
+
 { #category : #debugging }
 OCSelfVariable >> readInContext: aContext [
 	^aContext receiver

--- a/src/Deprecated90/OCSlotVariable.class.st
+++ b/src/Deprecated90/OCSlotVariable.class.st
@@ -32,6 +32,15 @@ OCSlotVariable >> emitValue: methodBuilder [
 	slot emitValue: methodBuilder
 ]
 
+{ #category : #generated }
+OCSlotVariable >> isInstance [
+
+	self
+		deprecated: 'Use #isInstanceVariable instead'
+		transformWith: '`@rec isInstance' -> '`@rec isInstanceVariable'.
+	^ self isInstanceVariable
+]
+
 { #category : #accessing }
 OCSlotVariable >> name [
 	^ slot name

--- a/src/Deprecated90/OCSuperVariable.class.st
+++ b/src/Deprecated90/OCSuperVariable.class.st
@@ -20,6 +20,15 @@ OCSuperVariable >> initialize [
 	name := 'super'
 ]
 
+{ #category : #generated }
+OCSuperVariable >> isSuper [
+
+	self
+		deprecated: 'Use #isSuperVariable instead'
+		transformWith: '`@rec isSuper' -> '`@rec isSuperVariable'.
+	^ self isSuperVariable
+]
+
 { #category : #debugging }
 OCSuperVariable >> readInContext: aContext [
 	^aContext receiver

--- a/src/Deprecated90/OCUndeclaredVariable.class.st
+++ b/src/Deprecated90/OCUndeclaredVariable.class.st
@@ -30,6 +30,15 @@ OCUndeclaredVariable >> emitValue: methodBuilder [
 
 ]
 
+{ #category : #generated }
+OCUndeclaredVariable >> isUndeclared [
+
+	self
+		deprecated: 'Use #isUndeclaredVariable instead'
+		transformWith: '`@rec isUndeclared' -> '`@rec isUndeclaredVariable'.
+	^ self isUndeclaredVariable
+]
+
 { #category : #accessing }
 OCUndeclaredVariable >> name [
 	^ name


### PR DESCRIPTION
Those methods were present in the Opal Compiler of Pharo 8 but deleted in Pharo 9.
DepMiner tool (https://github.com/olekscode/DepMiner) recommended to return them with deprecations.

Those recommendations were rejected by @Ducasse, @MarcusDenker, and @guillep.
However, they were accepted by @tesonep.

As far as I remember, @guillep did not want to accept those methods because they are "private" and therefore should not be deprecated.