### PR TITLE
Adding transformation rules for two deprecated methods of Context. One of them was recommended by DepMiner but had to be modified

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -42,13 +42,18 @@ Context >> methodReturnConstant: value [
 
 { #category : #'*Debugging-Core' }
 Context >> namedTempAt: index [
+
 	"Answer the value of the temp at index in the receiver's sequence of tempNames."
+
 	"NOTE: this list of temp names is completely virtual! It omits temp vectors but 
 	adds every variable that could be acccessed from a source perspective but might not be.
 	Do *not* use this!"
+
+	self
+		deprecated: 'Please access temps by name using #tempNamed:'
+		transformWith: '`@rec namedTempAt: `@arg' -> '`@rec tempNamed: (`@rec tempNames at: `@arg)'.
 	
-	self deprecated: 'Please access temps by name using #tempNamed:'.
-	^self tempNamed: (self tempNames at: index)
+	^ self tempNamed: (self tempNames at: index)
 ]
 
 { #category : #'*Debugging-Core' }
@@ -57,7 +62,10 @@ Context >> namedTempAt: index put: aValue [
 	"NOTE: this list of temp names is completely virtual! It omits temp vectors but 
 	adds every variable that could be acccessed from a source perspective but might not be"
 	"Do *not* use this!"
-	self deprecated: 'Please access temps by name using #tempNamed:put:'.
+	self
+		deprecated: 'Please access temps by name using #tempNamed:put:'
+		transformWith: '`@rec namedTempAt: `@arg1 put: `@arg2' ->
+		               '`@rec tempNamed: (`@rec tempNames at: `@arg1) put: `@arg2'.
 	
 	self tempNamed: (self tempNames at: index) put: aValue
 ]


### PR DESCRIPTION
`Context >> namedTempAt:` and `Context >> namedTempAt:put:` are deprecated without transformation rules.

[DepMiner](https://github.com/olekscode/DepMiner) suggested to add the following transformation rule:
```Smalltalk
Context >> namedTempAt: index

	"Answer the value of the temp at index in the receiver's sequence of tempNames."

	"NOTE: this list of temp names is completely virtual! It omits temp vectors but 
	adds every variable that could be accessed from a source perspective but might not be.
	Do *not* use this!"

	self
		deprecated: 'Please access temps by name using #tempNamed:'
		transformWith:
		'`@rec namedTempAt: `@arg' -> '`@rec tempNamed: `@arg'.
	^ self tempNamed: (self tempNames at: index)
```

It was accepted by @Ducasse and @MarcusDenker and rejected by @tesonep and @guillep.
I have noticed that this rule is wrong because first message expects index as argument and second message expects name.

So I have fixed the rule and added one more for `Context >> namedTempAt:put:`