### PR TITLE
Adding non-transforming deprecations that were suggested by DepMiner and accepted by Guille

### DIFF
--- a/src/GT-Spotter-UI/GTSpotterMorph.class.st
+++ b/src/GT-Spotter-UI/GTSpotterMorph.class.st
@@ -413,6 +413,14 @@ GTSpotterMorph >> togglePreview [
 	self spotterModel togglePreview
 ]
 
+{ #category : #generated }
+GTSpotterMorph >> unsubscribeListeners [
+
+	self deprecated: 'Use #unsubscribeListeners: instead'.
+	self activeHand removeEventListener: self.
+	Morph announcer unsubscribe: self
+]
+
 { #category : #initialization }
 GTSpotterMorph >> unsubscribeListeners: aWorld [
 

--- a/src/Glamour-Morphic-Brick/GLMEmptyPopupBrick.class.st
+++ b/src/Glamour-Morphic-Brick/GLMEmptyPopupBrick.class.st
@@ -490,6 +490,13 @@ GLMEmptyPopupBrick >> triggerBrick: aBrick [
 	self addBrickBack: self triggerBrick
 ]
 
+{ #category : #generated }
+GLMEmptyPopupBrick >> unsubscribeListeners [
+
+	self deprecated: 'Use #unsubscribeListeners: instead'.
+	self removeCloserListener
+]
+
 { #category : #'popup - listeners' }
 GLMEmptyPopupBrick >> unsubscribeListeners: anObject [
 

--- a/src/Glamour-Morphic-Brick/GLMScrollPaneBrick.class.st
+++ b/src/Glamour-Morphic-Brick/GLMScrollPaneBrick.class.st
@@ -462,6 +462,13 @@ GLMScrollPaneBrick >> scrollpaneBackgroundColor: aColor [
 	self updateStyle
 ]
 
+{ #category : #generated }
+GLMScrollPaneBrick >> unsubscribeListeners [
+
+	self deprecated: 'Use #unsubscribeListeners: instead'.
+	self activeHand removeEventListener: self
+]
+
 { #category : #initialization }
 GLMScrollPaneBrick >> unsubscribeListeners: aWorld [
 

--- a/src/Kernel/Rectangle.class.st
+++ b/src/Kernel/Rectangle.class.st
@@ -678,36 +678,6 @@ Rectangle >> merge: aRectangle [
 		corner: (corner max: aRectangle corner)
 ]
 
-{ #category : #generated }
-Rectangle >> newRectButtonPressedDo: newRectBlock [
-
-	"Track the outline of a new rectangle until mouse button changes. newFrameBlock produces each new rectangle from the previous. Only tracks while mouse is down."
-
-	| rect newRect buttonNow hand |
-	self deprecated:
-		'Use #newRectButtonPressedDo:inWorld: and #world instead'.
-	hand := self currentWorld activeHand.
-	buttonNow := hand anyButtonPressed.
-	rect := self.
-	self drawReverseFrame: rect.
-	hand captureEventsWhile: [ :evt | 
-		evt isMouse
-			ifTrue: [ 
-				buttonNow := evt anyButtonPressed.
-				newRect := newRectBlock value: rect value: evt cursorPoint.
-				newRect = rect ifFalse: [ 
-					self drawReverseFrame: rect.
-					self drawReverseFrame: newRect.
-					rect := newRect ].
-				buttonNow ]
-			ifFalse: [ true ] ].
-	self drawReverseFrame: rect.
-	self currentWorld activeHand
-		newMouseFocus: nil;
-		showTemporaryCursor: nil.
-	^ rect
-]
-
 { #category : #accessing }
 Rectangle >> origin [
 	"Answer the point at the top left corner of the receiver."

--- a/src/Kernel/Rectangle.class.st
+++ b/src/Kernel/Rectangle.class.st
@@ -678,6 +678,36 @@ Rectangle >> merge: aRectangle [
 		corner: (corner max: aRectangle corner)
 ]
 
+{ #category : #generated }
+Rectangle >> newRectButtonPressedDo: newRectBlock [
+
+	"Track the outline of a new rectangle until mouse button changes. newFrameBlock produces each new rectangle from the previous. Only tracks while mouse is down."
+
+	| rect newRect buttonNow hand |
+	self deprecated:
+		'Use #newRectButtonPressedDo:inWorld: and #world instead'.
+	hand := self currentWorld activeHand.
+	buttonNow := hand anyButtonPressed.
+	rect := self.
+	self drawReverseFrame: rect.
+	hand captureEventsWhile: [ :evt | 
+		evt isMouse
+			ifTrue: [ 
+				buttonNow := evt anyButtonPressed.
+				newRect := newRectBlock value: rect value: evt cursorPoint.
+				newRect = rect ifFalse: [ 
+					self drawReverseFrame: rect.
+					self drawReverseFrame: newRect.
+					rect := newRect ].
+				buttonNow ]
+			ifFalse: [ true ] ].
+	self drawReverseFrame: rect.
+	self currentWorld activeHand
+		newMouseFocus: nil;
+		showTemporaryCursor: nil.
+	^ rect
+]
+
 { #category : #accessing }
 Rectangle >> origin [
 	"Answer the point at the top left corner of the receiver."

--- a/src/Morphic-Core/NullWorldRenderer.class.st
+++ b/src/Morphic-Core/NullWorldRenderer.class.st
@@ -33,6 +33,12 @@ NullWorldRenderer >> actualScreenSize [
 	^ 240@120
 ]
 
+{ #category : #generated }
+NullWorldRenderer >> canvas: x [
+
+	self deprecated: 'Use #invalidate instead'
+]
+
 { #category : #'display box access' }
 NullWorldRenderer >> checkForNewScreenSize [
 

--- a/src/Spec2-Code-Morphic/SpMorphicCodeAdapter.class.st
+++ b/src/Spec2-Code-Morphic/SpMorphicCodeAdapter.class.st
@@ -198,6 +198,16 @@ SpMorphicCodeAdapter >> setEditingModeFor: textArea [
 			super setEditingModeFor: textArea ]
 ]
 
+{ #category : #generated }
+SpMorphicCodeAdapter >> setEditingModeFor: textArea withBehavior: aBehavior [
+
+	self deprecated:
+		'Use #setEditingModeFor:withBehavior:forScripting: instead'.
+	aBehavior
+		ifNotNil: [ textArea beForSmalltalkCodeInClass: aBehavior ]
+		ifNil: [ textArea beForSmalltalkScripting ]
+]
+
 { #category : #private }
 SpMorphicCodeAdapter >> setEditingModeFor: textArea withBehavior: aBehavior forScripting: aBoolean [
 	textArea model: self.


### PR DESCRIPTION
Those methods were present in Pharo 8 but deleted in Pharo 9.
DepMiner tool (https://github.com/olekscode/DepMiner) recommended to return them deprecations.

For those methods, DepMiner could not generate the transformation rules.

Those recommendations we accepted by @guillep but rejected by @Ducasse, @MarcusDenker, and @tesonep