### PR TITLE
7662-Must-be-boolean-deoptimization-targeting-wrong-or-block 

### DIFF
--- a/src/OpalCompiler-Core/ProtoObject.extension.st
+++ b/src/OpalCompiler-Core/ProtoObject.extension.st
@@ -27,7 +27,7 @@ ProtoObject >> mustBeBooleanCompileExpression: context andCache: cache [
 	pcAfterJump := sendNode irInstruction nextBytecodeOffsetAfterJump.
 	method propertyAt: #mustBeBooleanJump put: pcAfterJump.
 	"cache the method we just created"
-	cache at: pc put: method.
+	cache at: context compiledCode at: pc put: method.
 	^method
 	
 	
@@ -43,7 +43,7 @@ ProtoObject >> mustBeBooleanDeOptimizeIn: context [
 
 	cache := context compiledCode method propertyAt: #mustBeBooleanCache ifAbsentPut: [ IdentityDictionary new ].
 	"compile a doit method for the unoptimized expression"
-	method := cache at: (context pc - 1) ifAbsent: [self mustBeBooleanCompileExpression: context andCache: cache ].
+	method := cache at: context compiledCode at: (context pc - 1) ifAbsent: [self mustBeBooleanCompileExpression: context andCache: cache ].
 	"Execute the generated method with the pc still at the optimzized block so that the lookUp can read variables defined in the optimized block"
 	ret := context receiver withArgs: {context} executeMethod: method.
    	"resume the context at the instruction following the send when returning from deoptimized code."

--- a/src/OpalCompiler-Tests/MustBeBooleanTest.class.st
+++ b/src/OpalCompiler-Tests/MustBeBooleanTest.class.st
@@ -62,6 +62,20 @@ MustBeBooleanTest >> testIfTrueWithClosureAfterJump [
 ]
 
 { #category : #tests }
+MustBeBooleanTest >> testMultipleOrsInMethod [
+
+	| values r1 r2 |
+	values := OrderedCollection new.
+	10 timesRepeat: [ values add: MyBooleanObject new ].
+
+	r1 := values select: [ :each | each or: [ false ] ].
+	self assert: r1 isEmpty.
+
+	r2 := values select: [ :each | each or: [ true ] ].
+	self assert: r2 size equals: 10
+]
+
+{ #category : #tests }
 MustBeBooleanTest >> testOr [
 	| myBooleanObject |
 	


### PR DESCRIPTION
We store the generated de-optimized compiled method for the expression per pc. But we do that in the method as block methods can not have properties. This leads to wrong cache hits if the pc is the same, which happens if there are multiple blocks that are similar.

Solution:  make the cache two levels: method->indexed by block -> indexed by PC

Due to  having two level dictionary lookups already with #at:at: and #at:at:put:, this is very trivial to do.

fixes #7662

