### PR TITLE
8520-TwoWay-Become-should-not-loop-infinite-when-out-of-space

### DIFF
--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -184,6 +184,7 @@ Array >> elementsExchangeIdentityWith: otherArray [
 	 should still be properly indexed after the mutation."
 
 	<primitive: 128 error: ec>
+	| minimalRequiredSize |
 	ec == #'bad receiver' ifTrue:
 		[^self error: 'receiver must be of class Array'].
 	ec == #'bad argument' ifTrue:
@@ -197,8 +198,15 @@ Array >> elementsExchangeIdentityWith: otherArray [
 	ec == #'object is pinned' ifTrue:
 		[^self error: 'can''t become pinned objects'].
 	ec == #'insufficient object memory' ifTrue:
-		[Smalltalk garbageCollect < 1048576 ifTrue:
-			[Smalltalk growMemoryByAtLeast: 1048576].
+		[
+			minimalRequiredSize := 
+				(self sumNumbers: [ :anElement | anElement sizeInMemory ]) 
+				+ (otherArray sumNumbers: [ :anElement | anElement sizeInMemory ]).
+			
+			Smalltalk garbageCollect < minimalRequiredSize ifTrue:
+				[ (Smalltalk growMemoryByAtLeast: minimalRequiredSize) < minimalRequiredSize ifTrue:[
+					self error: 'Could not allocate enought memory for two way become']].
+		
 		 ^self elementsExchangeIdentityWith: otherArray].
 	self primitiveFailed
 ]


### PR DESCRIPTION
Retrying after a memory not enough error should be done in a way that does not produce an infinite loop.

Also, the memory requested should be related with the objects trying to become.
In a two way become,  the objects are copied and the original ones are used as forwarders to the new ones (but crossed).

Fix #8520