### PR TITLE
New icon styler for disabled breakpoints

### DIFF
--- a/src/Reflectivity-Tools/BreakpointIconStyler.class.st
+++ b/src/Reflectivity-Tools/BreakpointIconStyler.class.st
@@ -1,5 +1,5 @@
 "
-I'm in charge to style an ast when there are breakpoints
+I'm in charge to style an ast when there are breakpoints that are enabled
 "
 Class {
 	#name : #BreakpointIconStyler,
@@ -31,5 +31,5 @@ BreakpointIconStyler >> iconLabel: aNode [
 
 { #category : #testing }
 BreakpointIconStyler >> shouldStyleNode: aNode [
-	^aNode hasBreakpoint
+	^aNode hasBreakpoint and: [ aNode breakpoints anySatisfy: [:brkpt | brkpt isEnabled ]]
 ]

--- a/src/Reflectivity-Tools/DisabledBreakpointIconStyler.class.st
+++ b/src/Reflectivity-Tools/DisabledBreakpointIconStyler.class.st
@@ -1,0 +1,35 @@
+"
+I'm in charge to style an ast when there are breakpoints that are disabled
+"
+Class {
+	#name : #DisabledBreakpointIconStyler,
+	#superclass : #IconStyler,
+	#category : #'Reflectivity-Tools-Breakpoints'
+}
+
+{ #category : #defaults }
+DisabledBreakpointIconStyler >> highlightColor [
+	^(Color darkGray alpha: 0.1)
+]
+
+{ #category : #defaults }
+DisabledBreakpointIconStyler >> iconBlock: aNode [
+	 ^ [ :seg | 
+	   aNode breakpoints do: [ :breakpoint | breakpoint enable ].
+	   seg delete ]
+]
+
+{ #category : #defaults }
+DisabledBreakpointIconStyler >> iconFor: aNode [
+	^ self iconNamed: #smallInfo 
+]
+
+{ #category : #defaults }
+DisabledBreakpointIconStyler >> iconLabel: aNode [
+	^ 'Breakpoint (disabled)'
+]
+
+{ #category : #testing }
+DisabledBreakpointIconStyler >> shouldStyleNode: aNode [
+	^aNode hasBreakpoint and: [ aNode breakpoints noneSatisfy: [:brkpt | brkpt isEnabled ]]
+]

--- a/src/Reflectivity-Tools/IconStyler.class.st
+++ b/src/Reflectivity-Tools/IconStyler.class.st
@@ -22,7 +22,7 @@ IconStyler class >> withStaticStylers [
 	"
 	
 	^ self new 
-		stylerClasses:  {BreakpointIconStyler. CounterIconStyler. DoOnlyOnceIconStyler. FlagIconStyler. HaltIconStyler. MetaLinkIconStyler. SemanticWarningIconStyler. WatchIconStyler. DocCommentIconStyler}; 
+		stylerClasses:  {BreakpointIconStyler. CounterIconStyler. DisabledBreakpointIconStyler. FlagIconStyler. HaltIconStyler. MetaLinkIconStyler. SemanticWarningIconStyler. WatchIconStyler. DocCommentIconStyler}; 
 		yourself
 
 ]


### PR DESCRIPTION
Fixes #8529 

- new icon styler class for disabled breakpoints: DisabledBreakpointIconStyler
- modified BreakpointIconStyler not to style disabled breakpoints
- added DisabledBreakpointIconStyler to the "staticStylers" list of the IconStyler class

What a disabled breakpoint looks like:
![image](https://user-images.githubusercontent.com/32486709/107152509-a3c45380-6968-11eb-90b6-62f06f59669c.png)
![image](https://user-images.githubusercontent.com/32486709/107152518-ade65200-6968-11eb-8964-fa42be3fa060.png)

Clicking on the gutter icon re-enables the breakpoint.

**MISSING:** mechanism to auto-update open code browsers when a breakpoint gets disabled/enabled.
Right now, if a method with a breakpoint is opened in a browser, and a breakpoint in it is disabled, the browser does not update (the breakpoint is still marked in red) and you have to re-open the method to see the correct marking.
This behavior is already in place for when breakpoints get installed/removed. Does someone know where it is implemented so I can copy it?
