### PR TITLE
RB - Add rename package refactoring

### DIFF
--- a/src/Refactoring-Changes/RBRefactoryChangeFactory.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeFactory.class.st
@@ -127,3 +127,8 @@ RBRefactoryChangeFactory >> renameClassVariable: oldName to: newName in: aClass 
 RBRefactoryChangeFactory >> renameInstanceVariable: oldName to: newName in: aClass [
 	^ RBRenameInstanceVariableChange rename: oldName to: newName in: aClass 
 ]
+
+{ #category : #'refactory-changes-packages' }
+RBRefactoryChangeFactory >> renamePackage: aRBPackage to: newName [
+	^ RBRenamePackageChange rename: aRBPackage name to: newName
+]

--- a/src/Refactoring-Changes/RBRefactoryChangeFactory.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeFactory.class.st
@@ -132,3 +132,8 @@ RBRefactoryChangeFactory >> renameInstanceVariable: oldName to: newName in: aCla
 RBRefactoryChangeFactory >> renamePackage: aRBPackage to: newName [
 	^ RBRenamePackageChange rename: aRBPackage name to: newName
 ]
+
+{ #category : #'refactory-changes-packages' }
+RBRefactoryChangeFactory >> renamePackageNamed: aRBPackage to: newName [
+	^ RBRenamePackageChange rename: aRBPackage to: newName
+]

--- a/src/Refactoring-Changes/RBRefactoryPackageChange.class.st
+++ b/src/Refactoring-Changes/RBRefactoryPackageChange.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #RBRefactoryPackageChange,
+	#superclass : #RBRefactoryChange,
+	#category : #'Refactoring-Changes'
+}
+
+{ #category : #converting }
+RBRefactoryPackageChange >> asUndoOperation [
+	self subclassResponsibility 
+]
+
+{ #category : #private }
+RBRefactoryPackageChange >> executeNotifying: aBlock [
+	| undo |
+	undo := self asUndoOperation.
+	undo name: self name.
+	self primitiveExecute.
+	aBlock value.
+	^ undo
+]
+
+{ #category : #private }
+RBRefactoryPackageChange >> primitiveExecute [
+	self subclassResponsibility
+]

--- a/src/Refactoring-Changes/RBRenamePackageChange.class.st
+++ b/src/Refactoring-Changes/RBRenamePackageChange.class.st
@@ -1,0 +1,41 @@
+Class {
+	#name : #RBRenamePackageChange,
+	#superclass : #RBRefactoryPackageChange,
+	#instVars : [
+		'oldName',
+		'newName'
+	],
+	#category : #'Refactoring-Changes'
+}
+
+{ #category : #'instance creation' }
+RBRenamePackageChange class >> rename: oldString to: newString [ 
+	^ self new
+		rename: oldString to: newString;
+		yourself
+]
+
+{ #category : #converting }
+RBRenamePackageChange >> asUndoOperation [
+	^ changeFactory renamePackage: self changePackage to: oldName
+]
+
+{ #category : #accessing }
+RBRenamePackageChange >> changePackage [
+	^ (RBBrowserEnvironment default packageAt: oldName ifAbsent: [nil]) 
+		ifNil: [ RBBrowserEnvironment default packageAt: newName ifAbsent: [nil] ]
+]
+
+{ #category : #private }
+RBRenamePackageChange >> primitiveExecute [
+	self changePackage renameTo: newName.
+]
+
+{ #category : #printing }
+RBRenamePackageChange >> printOn: aStream [ 
+	aStream
+		nextPutAll: self oldName;
+		nextPutAll: ' renameTo: ';
+		print: self newName;
+		nextPut: $!
+]

--- a/src/Refactoring-Changes/RBRenamePackageChange.class.st
+++ b/src/Refactoring-Changes/RBRenamePackageChange.class.st
@@ -17,7 +17,7 @@ RBRenamePackageChange class >> rename: oldString to: newString [
 
 { #category : #converting }
 RBRenamePackageChange >> asUndoOperation [
-	^ changeFactory renamePackage: self changePackage to: oldName
+	^ changeFactory renamePackageNamed: newName to: oldName
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Changes/RBRenamePackageChange.class.st
+++ b/src/Refactoring-Changes/RBRenamePackageChange.class.st
@@ -34,8 +34,8 @@ RBRenamePackageChange >> primitiveExecute [
 { #category : #printing }
 RBRenamePackageChange >> printOn: aStream [ 
 	aStream
-		nextPutAll: self oldName;
+		nextPutAll: oldName;
 		nextPutAll: ' renameTo: ';
-		print: self newName;
+		print: newName;
 		nextPut: $!
 ]

--- a/src/Refactoring-Changes/RBRenamePackageChange.class.st
+++ b/src/Refactoring-Changes/RBRenamePackageChange.class.st
@@ -39,3 +39,9 @@ RBRenamePackageChange >> printOn: aStream [
 		print: newName;
 		nextPut: $!
 ]
+
+{ #category : #'instance creation' }
+RBRenamePackageChange >> rename: oldString to: newString [ 
+	oldName := oldString.
+	newName := newString
+]

--- a/src/Refactoring-Core/RBClassModelFactory.class.st
+++ b/src/Refactoring-Core/RBClassModelFactory.class.st
@@ -99,3 +99,9 @@ RBClassModelFactory >> rbNamespace [
 
 	^ self class rbNamespace
 ]
+
+{ #category : #'factory access' }
+RBClassModelFactory >> rbPackage [
+
+	^ self class rbPackage
+]

--- a/src/Refactoring-Core/RBClassModelFactory.class.st
+++ b/src/Refactoring-Core/RBClassModelFactory.class.st
@@ -10,7 +10,8 @@ Class {
 		'RBclass',
 		'RBmetaclass',
 		'RBmethod',
-		'RBnamespace'
+		'RBnamespace',
+		'RBpackage'
 	],
 	#category : #'Refactoring-Core-Model'
 }
@@ -39,6 +40,12 @@ RBClassModelFactory class >> rbNamespace [
 	^ RBnamespace ifNil: [ RBnamespace := RBNamespace ]
 ]
 
+{ #category : #'factory access' }
+RBClassModelFactory class >> rbPackage [
+ 
+	^ RBpackage ifNil: [ RBpackage := RBPackage ]
+]
+
 { #category : #'factory customisation' }
 RBClassModelFactory class >> setRBClass: aClass [
 
@@ -61,6 +68,12 @@ RBClassModelFactory class >> setRBMethod: aClass [
 RBClassModelFactory class >> setRBNamespace: aClass [
  
 	RBnamespace := aClass
+]
+
+{ #category : #'factory customisation' }
+RBClassModelFactory class >> setRBPackage: aClass [
+ 
+	RBpackage := aClass
 ]
 
 { #category : #'factory access' }

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -511,6 +511,21 @@ RBNamespace >> renameInstanceVariable: oldName to: newName in: aRBClass around: 
 ]
 
 { #category : #changes }
+RBNamespace >> renamePackage: aRBPackage to: aSymbol [
+	| change value dict |
+	change := changeFactory renamePackage: aRBPackage to: aSymbol.
+	self flushCaches.
+	dict := changedPackages.
+	"self markAsRemoved: aRBClass name.
+	self unmarkAsRemoved: aSymbol."
+	value := dict at: aRBPackage name.
+	dict removeKey: aRBPackage name.
+	dict at: aSymbol put: value.
+	value first name: aSymbol.
+	^ change
+]
+
+{ #category : #changes }
 RBNamespace >> reparentClasses: aRBClassCollection to: newClass [ 
 	aRBClassCollection do: 
 			[:aClass | 

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -46,7 +46,8 @@ Class {
 		'rootClasses',
 		'implementorsCache',
 		'sendersCache',
-		'changedPackages'
+		'changedPackages',
+		'removedPackages'
 	],
 	#category : #'Refactoring-Core-Model'
 }
@@ -297,6 +298,11 @@ RBNamespace >> hasCreatedClassFor: aBehavior [
 ]
 
 { #category : #testing }
+RBNamespace >> hasPackageRemoved: aSymbol [ 
+	^removedPackages includes: aSymbol
+]
+
+{ #category : #testing }
 RBNamespace >> hasRemoved: aSymbol [ 
 	^removedClasses includes: aSymbol
 ]
@@ -314,6 +320,11 @@ RBNamespace >> includesGlobal: aSymbol [
 	^true
 ]
 
+{ #category : #testing }
+RBNamespace >> includesPackageNamed: aSymbol [ 
+	^(self packageNamed: aSymbol) notNil
+]
+
 { #category : #initialization }
 RBNamespace >> initialize [
 	super initialize.
@@ -322,6 +333,7 @@ RBNamespace >> initialize [
 	changedClasses := IdentityDictionary new.
 	changedPackages := IdentityDictionary new.
 	removedClasses := Set new.
+	removedPackages := Set new.
 	implementorsCache := IdentityDictionary new.
 	sendersCache := IdentityDictionary new
 ]
@@ -332,6 +344,13 @@ RBNamespace >> markAsRemoved: aClassName [
 	removedClasses
 		add: aClassName;
 		add: aClassName, ' class'
+]
+
+{ #category : #private }
+RBNamespace >> markPackageAsRemoved: aPackageName [
+
+	removedPackages
+		add: aPackageName
 ]
 
 { #category : #'accessing-classes' }
@@ -366,6 +385,7 @@ RBNamespace >> name: aString [
 { #category : #'accessing-classes' }
 RBNamespace >> packageNamed: aSymbol [
 	aSymbol ifNil: [ ^ nil ].
+	(self hasPackageRemoved: aSymbol) ifTrue: [ ^ nil ].
 	(changedPackages includesKey: aSymbol) ifTrue: [ ^ (changedPackages at: aSymbol) first ].
 	^ (self createNewPackageFor: aSymbol) first
 ]
@@ -517,6 +537,8 @@ RBNamespace >> renamePackage: aRBPackage to: aSymbol [
 	self performChange: change around: [].
 	self flushCaches.
 	dict := changedPackages.
+	self markPackageAsRemoved: aRBPackage name.
+	self unmarkPackageAsRemoved: aSymbol.
 	"self markAsRemoved: aRBClass name.
 	self unmarkAsRemoved: aSymbol."
 	value := dict at: aRBPackage name.
@@ -552,6 +574,12 @@ RBNamespace >> unmarkAsRemoved: newClassName [
 	removedClasses
 		remove: newClassName ifAbsent: [  ];
 		remove: newClassName , ' class' ifAbsent: [  ]
+]
+
+{ #category : #private }
+RBNamespace >> unmarkPackageAsRemoved: newPackageName [
+	removedPackages
+		remove: newPackageName ifAbsent: [  ]
 ]
 
 { #category : #'accessing-classes' }

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -45,7 +45,8 @@ Class {
 		'changedClasses',
 		'rootClasses',
 		'implementorsCache',
-		'sendersCache'
+		'sendersCache',
+		'changedPackages'
 	],
 	#category : #'Refactoring-Core-Model'
 }
@@ -223,6 +224,13 @@ RBNamespace >> createNewClassFor: aBehavior [
 	^changedClasses at: className put: (Array with: nonMeta with: meta)
 ]
 
+{ #category : #'accessing-classes' }
+RBNamespace >> createNewPackageFor: aPackage [
+	| package |
+	package := modelFactory rbPackage existingNamed: aPackage model: self.
+	^changedClasses at: package put: (Array with: package)
+]
+
 { #category : #changes }
 RBNamespace >> defineClass: aString [
 
@@ -312,6 +320,7 @@ RBNamespace >> initialize [
 	changes := changeFactory compositeRefactoryChange onSystemDictionary: self environment.
 	newClasses := IdentityDictionary new.
 	changedClasses := IdentityDictionary new.
+	changedPackages := IdentityDictionary new.
 	removedClasses := Set new.
 	implementorsCache := IdentityDictionary new.
 	sendersCache := IdentityDictionary new
@@ -352,6 +361,13 @@ RBNamespace >> name [
 { #category : #accessing }
 RBNamespace >> name: aString [
 	^changes name: aString
+]
+
+{ #category : #'accessing-classes' }
+RBNamespace >> packageNamed: aSymbol [
+	aSymbol ifNil: [ ^ nil ].
+	(changedPackages includesKey: aSymbol) ifTrue: [ ^ (changedPackages at: aSymbol) first ].
+	^ (self createNewPackageFor: aSymbol) first
 ]
 
 { #category : #'private-changes' }

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -228,7 +228,7 @@ RBNamespace >> createNewClassFor: aBehavior [
 RBNamespace >> createNewPackageFor: aPackage [
 	| package |
 	package := modelFactory rbPackage existingNamed: aPackage model: self.
-	^changedClasses at: package put: (Array with: package)
+	^changedPackages at: aPackage put: (Array with: package)
 ]
 
 { #category : #changes }
@@ -514,6 +514,7 @@ RBNamespace >> renameInstanceVariable: oldName to: newName in: aRBClass around: 
 RBNamespace >> renamePackage: aRBPackage to: aSymbol [
 	| change value dict |
 	change := changeFactory renamePackage: aRBPackage to: aSymbol.
+	self performChange: change around: [].
 	self flushCaches.
 	dict := changedPackages.
 	"self markAsRemoved: aRBClass name.

--- a/src/Refactoring-Core/RBPackage.class.st
+++ b/src/Refactoring-Core/RBPackage.class.st
@@ -1,0 +1,77 @@
+"
+I represent a package for the refactoring framework.
+
+"
+Class {
+	#name : #RBPackage,
+	#superclass : #RBEntity,
+	#instVars : [
+		'model',
+		'name',
+		'realPackage'
+	],
+	#category : #'Refactoring-Core-Model'
+}
+
+{ #category : #'instance creation' }
+RBPackage class >> existingNamed: aSymbol [ 
+	^(self named: aSymbol)
+		realPackageFor: aSymbol;
+		yourself
+]
+
+{ #category : #'instance creation' }
+RBPackage class >> existingNamed: aSymbol model: aRBNamespace [ 
+	^ (self named: aSymbol)
+		model: aRBNamespace;
+		realPackageFor: aSymbol;
+		yourself
+]
+
+{ #category : #'instance creation' }
+RBPackage class >> named: aSymbol [ 
+	^(self new)
+		name: aSymbol;
+		yourself
+]
+
+{ #category : #accessing }
+RBPackage >> model [
+
+	^ model
+]
+
+{ #category : #accessing }
+RBPackage >> model: anObject [
+
+	model := anObject
+]
+
+{ #category : #accessing }
+RBPackage >> name [
+
+	^ name
+]
+
+{ #category : #accessing }
+RBPackage >> name: anObject [
+
+	name := anObject
+]
+
+{ #category : #accessing }
+RBPackage >> realPackage [
+
+	^ realPackage
+]
+
+{ #category : #accessing }
+RBPackage >> realPackage: anObject [
+
+	realPackage := anObject
+]
+
+{ #category : #accessing }
+RBPackage >> realPackageFor: aSymbol [ 
+	self realPackage: (self model environment packageAt: aSymbol)
+]

--- a/src/Refactoring-Core/RBPackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBPackageRefactoring.class.st
@@ -1,0 +1,38 @@
+"
+I am an abstract base class for package refactorings.
+
+All that I provide is the package name, my subclass refactorings are operating on, and a instance creation method for setting the package name and an initial namespace model.
+"
+Class {
+	#name : #RBPackageRefactoring,
+	#superclass : #RBRefactoring,
+	#instVars : [
+		'packageName'
+	],
+	#category : #'Refactoring-Core-Refactorings'
+}
+
+{ #category : #'as yet unclassified' }
+RBPackageRefactoring class >> model: aRBModel packageName: aName [ 
+	^ self new
+		model: aRBModel;
+		packageName: aName;
+		yourself
+]
+
+{ #category : #accessing }
+RBPackageRefactoring class >> packageName: aName [
+	^self new packageName: aName
+]
+
+{ #category : #accessing }
+RBPackageRefactoring >> packageName [
+
+	^ packageName
+]
+
+{ #category : #accessing }
+RBPackageRefactoring >> packageName: anObject [
+
+	packageName := anObject
+]

--- a/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
@@ -1,0 +1,57 @@
+Class {
+	#name : #RBRenamePackageRefactoring,
+	#superclass : #RBPackageRefactoring,
+	#instVars : [
+		'package',
+		'newName'
+	],
+	#category : #'Refactoring-Core-Refactorings'
+}
+
+{ #category : #'instance creation' }
+RBRenamePackageRefactoring class >> model: aRBSmalltalk rename: aPkg to: aNewName [ 
+	^(self new)
+		model: aRBSmalltalk;
+		packageName: aPkg name newName: aNewName;
+		yourself
+]
+
+{ #category : #'instance creation' }
+RBRenamePackageRefactoring class >> rename: aClass to: aNewName [
+	^self new packageName: aClass name newName: aNewName
+]
+
+{ #category : #initialization }
+RBRenamePackageRefactoring >> packageName: aName newName: aNewName [ 
+	packageName := aName asSymbol.
+	package := self model packageNamed: packageName.
+	newName := aNewName asSymbol
+]
+
+{ #category : #preconditions }
+RBRenamePackageRefactoring >> preconditions [ 
+	^ self emptyCondition
+]
+
+{ #category : #transforming }
+RBRenamePackageRefactoring >> renameManifestClass [ 
+	|refactoring manifest|
+	manifest := package packageManifestOrNil.
+	refactoring := RBRenameClassRefactoring 
+		rename: manifest
+		to: (TheManifestBuilder manifestClassNameFor: newName).
+	self performCompositeRefactoring: refactoring
+]
+
+{ #category : #transforming }
+RBRenamePackageRefactoring >> renamePackage [
+
+	self model renamePackage: package to: newName
+]
+
+{ #category : #transforming }
+RBRenamePackageRefactoring >> transform [
+
+	self renamePackage.
+	self renameManifestClass.
+]

--- a/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
@@ -21,6 +21,13 @@ RBRenamePackageRefactoring class >> rename: aClass to: aNewName [
 	^self new packageName: aClass name newName: aNewName
 ]
 
+{ #category : #transforming }
+RBRenamePackageRefactoring >> manifestClassNameFor: aPackageName [
+	"Returns a symbol representing a suitable name for a Manifest class for the given package"
+	
+	^('Manifest', (aPackageName select: [:each | each isAlphaNumeric ])) asSymbol
+]
+
 { #category : #initialization }
 RBRenamePackageRefactoring >> packageName: aName newName: aNewName [ 
 	packageName := aName asSymbol.
@@ -48,7 +55,7 @@ RBRenamePackageRefactoring >> renameManifestClass [
 	refactoring := RBRenameClassRefactoring 
 		model: self model
 		rename: manifest
-		to: (TheManifestBuilder manifestClassNameFor: newName).
+		to: (self manifestClassNameFor: newName).
 	self performCompositeRefactoring: refactoring]
 ]
 

--- a/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
@@ -30,23 +30,43 @@ RBRenamePackageRefactoring >> packageName: aName newName: aNewName [
 
 { #category : #preconditions }
 RBRenamePackageRefactoring >> preconditions [ 
-	^ self emptyCondition
+	^ (RBCondition withBlock: [ newName = package name ifTrue: 
+		[ self refactoringError: 'Use a different name' ].
+		true ]) &
+	(RBCondition withBlock: [ [RPackage organizer validatePackageDoesNotExist: newName. true]
+			on: Error 
+			do: [ :e | self refactoringError: e messageText ]
+		])
+	
 ]
 
 { #category : #transforming }
 RBRenamePackageRefactoring >> renameManifestClass [ 
 	|refactoring manifest|
 	manifest := package realPackage packageManifestOrNil.
+	manifest ifNotNil: [
 	refactoring := RBRenameClassRefactoring 
 		model: self model
 		rename: manifest
 		to: (TheManifestBuilder manifestClassNameFor: newName).
-	self performCompositeRefactoring: refactoring
+	self performCompositeRefactoring: refactoring]
 ]
 
 { #category : #transforming }
 RBRenamePackageRefactoring >> renamePackage [
 	self model renamePackage: package to: newName
+]
+
+{ #category : #printing }
+RBRenamePackageRefactoring >> storeOn: aStream [ 
+	aStream nextPut: $(.
+	self class storeOn: aStream.
+	aStream nextPutAll: ' rename: '.
+	aStream nextPutAll: package name.
+	aStream
+		nextPutAll: ' to: #';
+		nextPutAll: newName;
+		nextPut: $)
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
@@ -36,8 +36,9 @@ RBRenamePackageRefactoring >> preconditions [
 { #category : #transforming }
 RBRenamePackageRefactoring >> renameManifestClass [ 
 	|refactoring manifest|
-	manifest := package packageManifestOrNil.
+	manifest := package realPackage packageManifestOrNil.
 	refactoring := RBRenameClassRefactoring 
+		model: self model
 		rename: manifest
 		to: (TheManifestBuilder manifestClassNameFor: newName).
 	self performCompositeRefactoring: refactoring
@@ -45,7 +46,6 @@ RBRenamePackageRefactoring >> renameManifestClass [
 
 { #category : #transforming }
 RBRenamePackageRefactoring >> renamePackage [
-
 	self model renamePackage: package to: newName
 ]
 

--- a/src/Refactoring-Tests-Core/RBRenamePackageTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenamePackageTest.class.st
@@ -1,0 +1,40 @@
+Class {
+	#name : #RBRenamePackageTest,
+	#superclass : #RBRefactoringTest,
+	#category : #'Refactoring-Tests-Core-Refactorings'
+}
+
+{ #category : #tests }
+RBRenamePackageTest >> getPackageNamed: aSymbol [
+	^ RBBrowserEnvironment default packageAt: aSymbol
+]
+
+{ #category : #'failure tests' }
+RBRenamePackageTest >> testBadName [
+	self
+		shouldFail: (RBRenamePackageRefactoring 
+				rename: (self getPackageNamed: #'Refactoring-Tests-Core')
+				to: #'Refactoring-Tests-Core')
+]
+
+{ #category : #'failure tests' }
+RBRenamePackageTest >> testExistingPackage [
+	self
+		shouldFail: (RBRenamePackageRefactoring 
+				rename: (self getPackageNamed: #'Refactoring-Tests-Core')
+				to: #'Refactoring-Tests-Changes')
+]
+
+{ #category : #tests }
+RBRenamePackageTest >> testRenamePackage [
+	| refactoring aModel |
+	
+	refactoring := (RBRenamePackageRefactoring 
+				rename: (self getPackageNamed: #'Refactoring-Tests-Core')
+				to: #'Refactoring-Tests-Core1').
+	aModel := refactoring model.
+	self executeRefactoring: refactoring.
+	self assert: (aModel packageNamed: #'Refactoring-Tests-Core') isNil.
+	self assert: (aModel packageNamed: #'Refactoring-Tests-Core1') isNotNil.
+	
+]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
@@ -135,13 +135,15 @@ RBRemoveDirectAccessToVariableTransformationTest >> testRefactoring [
 			^ true').
 	self assert: (class parseTreeFor: #initialize) 
 		equals: (self parseMethod: 'initialize
-			super initialize.
-			changes := changeFactory compositeRefactoryChange onSystemDictionary: self environment.
-			newClasses := IdentityDictionary new.
-			changedClasses := IdentityDictionary new.
-			removedClasses := Set new.
-			implementorsCache := IdentityDictionary new.
-			sendersCache := IdentityDictionary new')
+	super initialize.
+	changes := changeFactory compositeRefactoryChange onSystemDictionary: self environment.
+	newClasses := IdentityDictionary new.
+	changedClasses := IdentityDictionary new.
+	changedPackages := IdentityDictionary new.
+	removedClasses := Set new.
+	removedPackages := Set new.
+	implementorsCache := IdentityDictionary new.
+	sendersCache := IdentityDictionary new')
 ]
 
 { #category : #testing }

--- a/src/SystemCommands-PackageCommands/SycRenamePackageCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycRenamePackageCommand.class.st
@@ -30,7 +30,7 @@ SycRenamePackageCommand >> defaultMenuItemName [
 { #category : #execution }
 SycRenamePackageCommand >> execute [
 	
-	package renameTo: newName
+	(RBRenamePackageRefactoring rename: package to: newName) execute
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fixes #3604

Renaming the package from a refactoring helped to handle other operations accordingly to these changes, such as renaming the manifest according to the new package name 