### PR TITLE
8451-Wrong-over-optimization-of-mustBeBoolean-magic

### DIFF
--- a/src/OpalCompiler-Core/OCASTTranslatorForEffect.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslatorForEffect.class.st
@@ -88,14 +88,16 @@ OCASTTranslatorForEffect >> visitBlockNode: aBlockNode [
 
 { #category : #'visitor-double dispatching' }
 OCASTTranslatorForEffect >> visitLiteralArrayNode: aLiteralNode [
-	"when visiting a literal array for effect, we could push it and then pop it, but we do nothing"
-	methodBuilder addLiteral: aLiteralNode value
+
+	super visitLiteralArrayNode: aLiteralNode.
+	methodBuilder popTop
 ]
 
 { #category : #'visitor-double dispatching' }
 OCASTTranslatorForEffect >> visitLiteralNode: aLiteralNode [
-	"when visiting a literal for effect, we could push it and then pop it, but we do nothing"
-	methodBuilder addLiteral: aLiteralNode value
+
+	super visitLiteralNode: aLiteralNode.
+	methodBuilder popTop
 ]
 
 { #category : #'visitor-double dispatching' }

--- a/src/OpalCompiler-Tests/MustBeBooleanTest.class.st
+++ b/src/OpalCompiler-Tests/MustBeBooleanTest.class.st
@@ -33,10 +33,7 @@ MustBeBooleanTest >> testIfTrueEffect [
 	fakeBool := MyBooleanObject new.
 	temp := 1.
 	fakeBool ifTrue: [ temp := 5 + 3 + 1 ].
-	self assert: temp equals: 9.
-	
-	fakeBool ifTrue: [ [  ] ].
-	"fakeBool ifTrue: [ 1+ 2. [ :a | a ] value: 5. 7 ]."
+	self assert: temp equals: 9
 ]
 
 { #category : #tests }
@@ -46,6 +43,18 @@ MustBeBooleanTest >> testIfTrueValue [
 	self assert: (MyBooleanObject new ifTrue: [ 1 + 2 ]) equals: '3 sent from my boolean object'.
 	myBooleanObject := MyBooleanObject new.
 	self assert: (myBooleanObject ifTrue: [ 1 + 2 ]) equals: '3 sent from my boolean object'.
+]
+
+{ #category : #tests }
+MustBeBooleanTest >> testIfTrueValueLiteral [
+	| myBooleanObject result |
+	myBooleanObject := MyBooleanObject new.
+	"check the case where the block just returna a literal"
+	result := myBooleanObject
+		ifTrue: [ 5 ].
+	self assert: result equals: '5 sent from my boolean object'.
+	"now do it with the expression evaluate for effect"
+	self should: [self class compiler evaluate: '1 ifTrue: [ 5 ]. 1'] raise: MessageNotUnderstood.
 ]
 
 { #category : #tests }


### PR DESCRIPTION
What happens is that we visit the last literal of the block for effect, which in case of literals is opimized to do nothing.

With the block now empty, it is not generated in the case of optimizied constructs.

The best fix for now is to remove that optimization.

fixes #8451 