### PR TITLE
8540-TFFI-should-support-passing-a-ByteArray-in-a-char-parameter-a-TFStringType

### DIFF
--- a/src/ThreadedFFI-UFFI-Tests/TFUFFIDerivedTypeMarshallingTest.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFUFFIDerivedTypeMarshallingTest.class.st
@@ -75,6 +75,17 @@ TFUFFIDerivedTypeMarshallingTest >> sum_ulonglong:a with: b [
 ]
 
 { #category : #tests }
+TFUFFIDerivedTypeMarshallingTest >> testMarshallingByteArrayAsStringArgument [
+
+	| stringToMarshall byteArray cString |
+	[	stringToMarshall := 'áèïô å∫'.
+		byteArray := stringToMarshall utf8Encoded.
+		cString := self stringToPointer: byteArray.
+		self assert: cString readStringUTF8 equals: stringToMarshall.
+	] ensure: [ cString free ]
+]
+
+{ #category : #tests }
 TFUFFIDerivedTypeMarshallingTest >> testMarshallingFalseArgument [
 
 	self assert: (self booleanToInt: false) equals: 0

--- a/src/ThreadedFFI/TFStringType.class.st
+++ b/src/ThreadedFFI/TFStringType.class.st
@@ -94,11 +94,30 @@ TFStringType >> marshallToPrimitive: aValue [
 { #category : #writting }
 TFStringType >> prepareStringForMarshalling: aStringOrExternalAddress [
 
-	^ aStringOrExternalAddress isString
-		ifTrue: [ 
-			self allocateString: aStringOrExternalAddress ]
-		ifFalse: [ 
-			aStringOrExternalAddress ifNil: [ ExternalAddress null ] ]
+	"The TFString type supports four possible parameters.
+	
+	- A String: this is allocated as an external string, encoded and passed the pointer to the allocated space. 
+	- A ByteArray: this will be passed as a pointer to the external call. It should be pinned and dereferenced to get the address.
+	- An ExternalAddress: this is directly passed to the external call.
+	- nil: An ExternalAddress null is passed in this case "
+	
+	"Maybe this code should be implemented delegating to the objects to handle the different cases"
+
+	"Handling Strings"
+	aStringOrExternalAddress isString
+		ifTrue: [ ^ self allocateString: aStringOrExternalAddress ].
+	
+	"Handling nil"	
+		aStringOrExternalAddress 
+			ifNil: [ ^ ExternalAddress null ].
+
+	"Handling ByteArray"
+		(aStringOrExternalAddress isKindOf: ByteArray) 
+			ifTrue: [ aStringOrExternalAddress pinInMemory.
+            ^ PointerUtils oopForObject: aStringOrExternalAddress ].
+	
+	"Handling ExternalAddress"
+		^ aStringOrExternalAddress
 ]
 
 { #category : #writting }

--- a/src/ThreadedFFI/TFStringType.class.st
+++ b/src/ThreadedFFI/TFStringType.class.st
@@ -111,13 +111,17 @@ TFStringType >> prepareStringForMarshalling: aStringOrExternalAddress [
 		aStringOrExternalAddress 
 			ifNil: [ ^ ExternalAddress null ].
 
-	"Handling ByteArray"
+	"Handling ExternalAddress"
+		aStringOrExternalAddress isExternalAddress
+			ifTrue: [ ^ aStringOrExternalAddress ].
+	
+	"Handling ByteArray - We have to first check for ExternalAddress, as ExternalAddress are ByteArray"
 		(aStringOrExternalAddress isKindOf: ByteArray) 
 			ifTrue: [ aStringOrExternalAddress pinInMemory.
             ^ PointerUtils oopForObject: aStringOrExternalAddress ].
 	
 	"Handling ExternalAddress"
-		^ aStringOrExternalAddress
+		^ self error: 'Could not handle this object'
 ]
 
 { #category : #writting }


### PR DESCRIPTION
Adding support for marshalling ByteArrays for char* parameters.
Fix #8540
