### PR TITLE
6812-When-executing-a-method-should-not-get-a-IRPopIntoTemp-did-not-undersand-nextByteCideOffsetAfterJump

### DIFF
--- a/src/OpalCompiler-Core/IRJump.class.st
+++ b/src/OpalCompiler-Core/IRJump.class.st
@@ -41,6 +41,11 @@ IRJump >> isJump [
 	^ true
 ]
 
+{ #category : #acessing }
+IRJump >> nextBytecodeOffsetAfterJump [
+	^ destination last destination first bytecodeOffset
+]
+
 { #category : #accessing }
 IRJump >> successor [
 	^successor

--- a/src/OpalCompiler-Core/IRPopIntoTemp.class.st
+++ b/src/OpalCompiler-Core/IRPopIntoTemp.class.st
@@ -11,3 +11,9 @@ Class {
 IRPopIntoTemp >> accept: aVisitor [
 	^ aVisitor visitPopIntoTemp: self
 ]
+
+{ #category : #acessing }
+IRPopIntoTemp >> nextBytecodeOffsetAfterJump [
+	"if we are in to:do: answers the next byte code offset"
+	^ self sequence last destination last destination first bytecodeOffset
+]

--- a/src/OpalCompiler-Core/ProtoObject.extension.st
+++ b/src/OpalCompiler-Core/ProtoObject.extension.st
@@ -19,7 +19,7 @@ ProtoObject >> mustBeBooleanCompileExpression: context andCache: cache [
 	"Keep same compilation context as the sender node's"
 	methodNode compilationContext: sendNode methodNode compilationContext copy.
 	"Disable inlining so the message send will be unoptimized"
-	methodNode compilationContext compilerOptions: #(- optionInlineIf optionInlineAndOr optionInlineWhile).
+	methodNode compilationContext compilerOptions: #(- optionInlineIf optionInlineAndOr optionInlineWhile optionInlineToDo).
 	"Generate the method"	
 	OCASTSemanticCleaner clean: methodNode.
 	method := methodNode generate.

--- a/src/OpalCompiler-Tests/MustBeBooleanTest.class.st
+++ b/src/OpalCompiler-Tests/MustBeBooleanTest.class.st
@@ -92,6 +92,15 @@ MustBeBooleanTest >> testSemanticAnalysisCleaned [
 ]
 
 { #category : #tests }
+MustBeBooleanTest >> testToDo [
+	| variable |
+	
+	variable := #(1 2 3).
+	"in this case, we end up sending #ifTrue: to the Array"
+	self should: [(1 to: variable do: [:index |])] raise: MessageNotUnderstood
+]
+
+{ #category : #tests }
 MustBeBooleanTest >> testWhile [
 	| myFlag |
 	self should: [[ nil ] whileFalse: [myFlag := true ]] raise: MessageNotUnderstood.


### PR DESCRIPTION
- add a test case for the problem: #testToDo
- check what would happen in this case if #to:do: would not be optmized and makes sure we do the same

fixes #6812

