### PR TITLE
8042 deprecate and remove pointdist because there is pointdistance to with exactly the same implementation

### DIFF
--- a/src/Athens-Morphic/PolygonMorph.extension.st
+++ b/src/Athens-Morphic/PolygonMorph.extension.st
@@ -118,7 +118,7 @@ for the current vertice C.
 			next := vert atWrap: i + 1.
 			tangent := (next - prior) / 2.
 			lenpc := current distanceTo: prior.
-			lencn := next dist: current.
+			lencn := next distanceTo: current.
 			lenpc = 0 ifTrue:[
 				ctrl1 := prior]
 			ifFalse:[	ctrl1 := current - (tangent / (1 + (lencn / lenpc)))].

--- a/src/Graphics-Canvas/Canvas.class.st
+++ b/src/Graphics-Canvas/Canvas.class.st
@@ -568,7 +568,7 @@ Canvas >> line: pt1 to: pt2 width: w1 color: c1 stepWidth: s1 secondWidth: w2 se
 	"if there was no loop, offsetPoint is nil"
 	lastPoint := pt1 + ((offsetPoint ifNil: [0 @ 0])
 					+ delta2).
-	(lastPoint dist: pt2)
+	(lastPoint distanceTo: pt2)
 		<= s1
 		ifTrue: [self
 				line: lastPoint rounded

--- a/src/Graphics-Tests/PointTest.class.st
+++ b/src/Graphics-Tests/PointTest.class.st
@@ -171,16 +171,6 @@ PointTest >> testCrossProduct [
 ]
 
 { #category : #'tests - point functions' }
-PointTest >> testDist [
-	self assert: (0 @ 0 dist: 0 @ 0) equals: 0.
-	self assert: (0 @ 0 dist: 0 @ 5) equals: 5.
-	self assert: (5 @ 0 dist: 0 @ 0) equals: 5.
-	self assert: (3 @ 0 dist: 0 @ 4) equals: 5.
-	self assert: (5 @ 0 dist: 2 @ 4) equals: 5.
-	self deny: (0 @ 0 dist: 0 @ 0) equals: 1
-]
-
-{ #category : #'tests - point functions' }
 PointTest >> testDistanceTo [
 	self assert: (0 @ 0 distanceTo: 0 @ 0) equals: 0.
 	self assert: (0 @ 0 distanceTo: 0 @ 5) equals: 5.

--- a/src/Math-Operations-Extensions/Point.extension.st
+++ b/src/Math-Operations-Extensions/Point.extension.st
@@ -56,17 +56,13 @@ Point >> degrees [
 { #category : #'*Math-Operations-Extensions' }
 Point >> dist: aPoint [ 
 	"Answer the distance between aPoint and the receiver."
-	| dx dy |
+	
 	self
 		deprecated: 'Use #distanceTo: instead.'
 		on: '9 February 2021'
 		in: #Pharo9
 		transformWith: '`@receiver dist: `@arg' -> '`@receiver distanceTo: `@arg'.
-		
-	
-	dx := aPoint x - x.
-	dy := aPoint y - y.
-	^ (dx * dx + (dy * dy)) sqrt
+	^ self distanceTo: aPoint
 ]
 
 { #category : #'*Math-Operations-Extensions' }

--- a/src/Math-Operations-Extensions/Point.extension.st
+++ b/src/Math-Operations-Extensions/Point.extension.st
@@ -57,6 +57,13 @@ Point >> degrees [
 Point >> dist: aPoint [ 
 	"Answer the distance between aPoint and the receiver."
 	| dx dy |
+	self
+		deprecated: 'Use #distanceTo: instead.'
+		on: '9 February 2021'
+		in: #Pharo9
+		transformWith: '`@receiver dist: `@arg' -> '`@receiver distanceTo: `@arg'.
+		
+	
 	dx := aPoint x - x.
 	dy := aPoint y - y.
 	^ (dx * dx + (dy * dy)) sqrt


### PR DESCRIPTION
Fixes #8042 

 - Deprecated Point>>#dist: (in favour of Point>>#distanceTo:)
- Removed test PointTest>>#testDist (it was the same as PointTest>>#testDistanceTo)
- Senders of Point>>#dist: rewritten to use Point>>#distanceTo: