### PR TITLE
Fixes #4011 Character nextObject crashes Pharo too

### DIFF
--- a/src/Kernel-Tests/ProtoObjectTest.class.st
+++ b/src/Kernel-Tests/ProtoObjectTest.class.st
@@ -192,6 +192,20 @@ ProtoObjectTest >> testIsNil [
 	self deny: ProtoObject new isNil
 ]
 
+{ #category : #tests }
+ProtoObjectTest >> testNextObject [
+	"In issue 4011 (https://github.com/pharo-project/pharo/issues/4011), "
+	"the image crashed if nextObject was called on a Character, SmallInteger or a SmallFloat64"
+	
+	self assert: (nil nextObject notNil).
+	self assert: ('test' nextObject notNil).
+	
+	self should: [42 nextObject notNil] raise: ShouldNotImplement .
+	self should: [$x nextObject notNil] raise: ShouldNotImplement .
+	self should: [3.14 nextObject notNil] raise: ShouldNotImplement .
+
+]
+
 { #category : #'tests - testing' }
 ProtoObjectTest >> testNotTheSame [
 

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -812,7 +812,7 @@ Character >> lowercase [
 
 { #category : #'memory scanning' }
 Character >> nextObject [
-	"SmallIntegers are immediate objects, and, as such, do not have successors in object memory."
+	"Characters are immediate objects, and, as such, do not have successors in object memory."
 
 	self shouldNotImplement 
 ]

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -810,6 +810,13 @@ Character >> lowercase [
 	^ self asLowercase
 ]
 
+{ #category : #'memory scanning' }
+Character >> nextObject [
+	"SmallIntegers are immediate objects, and, as such, do not have successors in object memory."
+
+	self shouldNotImplement 
+]
+
 { #category : #printing }
 Character >> printOn: aStream [
 	| name |

--- a/src/Kernel/SmallFloat64.class.st
+++ b/src/Kernel/SmallFloat64.class.st
@@ -268,7 +268,7 @@ SmallFloat64 >> ln [
 
 { #category : #'memory scanning' }
 SmallFloat64 >> nextObject [
-	"SmallIntegers are immediate objects, and, as such, do not have successors in object memory."
+	"SmallFloat64 are immediate objects, and, as such, do not have successors in object memory."
 
 	self shouldNotImplement 
 ]

--- a/src/Kernel/SmallFloat64.class.st
+++ b/src/Kernel/SmallFloat64.class.st
@@ -266,6 +266,13 @@ SmallFloat64 >> ln [
 	"2.718284 ln 1.0"
 ]
 
+{ #category : #'memory scanning' }
+SmallFloat64 >> nextObject [
+	"SmallIntegers are immediate objects, and, as such, do not have successors in object memory."
+
+	self shouldNotImplement 
+]
+
 { #category : #copying }
 SmallFloat64 >> shallowCopy [
 	"Answer the receiver, because SmallFloat64s are unique."


### PR DESCRIPTION
A very simple PR, which just prevent the image from crashing in two very unlikely and specific cases.
A test was added as well, to make sure nothing bad is happening. Before this PR, this test would crash the image.