### PR TITLE
AST-unify-children

### DIFF
--- a/src/AST-Core/RBArrayNode.class.st
+++ b/src/AST-Core/RBArrayNode.class.st
@@ -104,7 +104,7 @@ RBArrayNode >> allStatements [
 
 { #category : #accessing }
 RBArrayNode >> children [
-	^ self statements
+	^ statements
 ]
 
 { #category : #matching }

--- a/src/AST-Core/RBAssignmentNode.class.st
+++ b/src/AST-Core/RBAssignmentNode.class.st
@@ -75,7 +75,7 @@ RBAssignmentNode >> assigns: aVariableName [
 
 { #category : #accessing }
 RBAssignmentNode >> children [
-	^Array with: value with: variable
+	^ { value . variable }
 ]
 
 { #category : #matching }

--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -128,7 +128,7 @@ RBBlockNode >> body: stmtsNode [
 
 { #category : #accessing }
 RBBlockNode >> children [
-	^self arguments copyWith: self body
+	^ arguments copyWith: body
 ]
 
 { #category : #'accessing-token' }

--- a/src/AST-Core/RBCascadeNode.class.st
+++ b/src/AST-Core/RBCascadeNode.class.st
@@ -56,7 +56,7 @@ RBCascadeNode >> bestNodeFor: anInterval [
 
 { #category : #accessing }
 RBCascadeNode >> children [
-	^self messages
+	^ messages
 ]
 
 { #category : #matching }

--- a/src/AST-Core/RBEnglobingErrorNode.class.st
+++ b/src/AST-Core/RBEnglobingErrorNode.class.st
@@ -59,7 +59,7 @@ RBEnglobingErrorNode >> acceptVisitor: aVisitor [
 
 { #category : #accessing }
 RBEnglobingErrorNode >> children [
-	^self content.
+	^ content
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBLiteralArrayNode.class.st
+++ b/src/AST-Core/RBLiteralArrayNode.class.st
@@ -54,7 +54,7 @@ RBLiteralArrayNode >> acceptVisitor: aProgramNodeVisitor [
 
 { #category : #accessing }
 RBLiteralArrayNode >> children [
-	^contents
+	^ contents
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -104,8 +104,8 @@ RBMessageNode >> bestNodeFor: anInterval [
 
 { #category : #accessing }
 RBMessageNode >> children [
-	^(OrderedCollection with: self receiver)
-		addAll: self arguments;
+	^(OrderedCollection with: receiver)
+		addAll: arguments;
 		yourself
 ]
 

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -217,9 +217,9 @@ ase try to rewrite the signature as a whole, what unfortunately drops the commen
 { #category : #accessing }
 RBMethodNode >> children [
 	^ OrderedCollection new
-		addAll: self arguments;
-		addAll: self pragmas;
-		add: self body;
+		addAll: arguments;
+		addAll: pragmas;
+		add: body;
 		yourself
 ]
 

--- a/src/AST-Core/RBPragmaNode.class.st
+++ b/src/AST-Core/RBPragmaNode.class.st
@@ -79,7 +79,7 @@ RBPragmaNode >> arguments: aLiteralCollection [
 
 { #category : #accessing }
 RBPragmaNode >> children [
-	^ self arguments
+	^ arguments
 ]
 
 { #category : #matching }

--- a/src/AST-Core/RBReturnNode.class.st
+++ b/src/AST-Core/RBReturnNode.class.st
@@ -43,7 +43,7 @@ RBReturnNode >> acceptVisitor: aProgramNodeVisitor [
 
 { #category : #accessing }
 RBReturnNode >> children [
-	^ Array with: value
+	^ { value }
 ]
 
 { #category : #testing }


### PR DESCRIPTION
a small cleanup to make all the #children methods work the same:
- directly access the variable instead of using accessor
- use {} instead of "Array with:"

