### PR TITLE
TaRenameSlot-Use-TaRenamedSlotWrapper

### DIFF
--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -362,9 +362,8 @@ TaAbstractComposition >> name [
 { #category : #testing }
 TaAbstractComposition >> needsRecompilation: aSelector [
 	"Checks if a selector should be compiled because it uses new slots or if its code has been rewritten."
-	
-	^ self slots isEmpty not or: [ self changesSourceCode: aSelector ]
 
+	^ self slots isNotEmpty or: [ self changesSourceCode: aSelector ]
 ]
 
 { #category : #querying }

--- a/src/TraitsV2/TaRemovedSlotWrapper.class.st
+++ b/src/TraitsV2/TaRemovedSlotWrapper.class.st
@@ -1,0 +1,81 @@
+"
+When renaming Slots in a trait composition, we want to give the trait a new name but else keep the orginal semantics.
+
+This wrapper does exactly that: as a Slot subclass, it has a name. It forwards anything else to the original slot as defined
+in the trait.
+"
+Class {
+	#name : #TaRemovedSlotWrapper,
+	#superclass : #Slot,
+	#instVars : [
+		'originalSlot'
+	],
+	#category : #'TraitsV2-Compositions'
+}
+
+{ #category : #'instance creation' }
+TaRemovedSlotWrapper class >> for: aSlot [
+	^self new originalSlot: aSlot
+]
+
+{ #category : #'code generation' }
+TaRemovedSlotWrapper >> emitStore: aMethodBuilder [
+	originalSlot emitStore: aMethodBuilder
+]
+
+{ #category : #'code generation' }
+TaRemovedSlotWrapper >> emitValue: aMethodBuilder [
+	originalSlot emitValue: aMethodBuilder
+]
+
+{ #category : #accessing }
+TaRemovedSlotWrapper >> index [
+	^ originalSlot index
+]
+
+{ #category : #accessing }
+TaRemovedSlotWrapper >> index: anInteger [
+	originalSlot index: anInteger
+]
+
+{ #category : #testing }
+TaRemovedSlotWrapper >> isVirtual [
+	^originalSlot isVirtual
+]
+
+{ #category : #testing }
+TaRemovedSlotWrapper >> isVisible [
+	^originalSlot isVisible
+]
+
+{ #category : #accessing }
+TaRemovedSlotWrapper >> originalSlot [
+
+	^ originalSlot
+]
+
+{ #category : #accessing }
+TaRemovedSlotWrapper >> originalSlot: anObject [
+
+	originalSlot := anObject
+]
+
+{ #category : #printing }
+TaRemovedSlotWrapper >> printOn: aStream [
+	originalSlot printOn: aStream
+]
+
+{ #category : #'meta-object-protocol' }
+TaRemovedSlotWrapper >> read: anObject [
+	^ originalSlot read: anObject
+]
+
+{ #category : #'meta-object-protocol' }
+TaRemovedSlotWrapper >> wantsInitialization [
+	^ originalSlot wantsInitialization
+]
+
+{ #category : #'meta-object-protocol' }
+TaRemovedSlotWrapper >> write: aValue to: anObject [
+	^ originalSlot write: aValue to: anObject
+]

--- a/src/TraitsV2/TaRenameSlot.class.st
+++ b/src/TraitsV2/TaRenameSlot.class.st
@@ -48,17 +48,12 @@ TaRenameSlot >> renames: anObject [
 
 { #category : #accessing }
 TaRenameSlot >> slots [
-	| renameDict | 
-	
-	renameDict := renames asDictionary.
-	
-	^ inner slots
-		collect: [ :e | 
-			| slot |
-			slot := e asSlot copy.
-			(renameDict includesKey: slot name) 
-				ifTrue: [ slot name: (renameDict at: slot name) ].
-			slot ]
+
+	^ inner slots collect: [ :slot | 
+		  (renames asDictionary includesKey: slot name)
+			  ifTrue: [ 
+				  (TaRemovedSlotWrapper for: slot) name: (renames asDictionary at: slot name) ]
+			  ifFalse: [ slot ] ]
 ]
 
 { #category : #accessing }

--- a/src/TraitsV2/TaRenameSlot.class.st
+++ b/src/TraitsV2/TaRenameSlot.class.st
@@ -52,7 +52,7 @@ TaRenameSlot >> slots [
 	^ inner slots collect: [ :slot | 
 		  (renames asDictionary includesKey: slot name)
 			  ifTrue: [ 
-				  (TaRemovedSlotWrapper for: slot) name: (renames asDictionary at: slot name) ]
+				  (TaRenamedSlotWrapper for: slot) name: (renames asDictionary at: slot name) ]
 			  ifFalse: [ slot ] ]
 ]
 

--- a/src/TraitsV2/TaRenamedSlotWrapper.class.st
+++ b/src/TraitsV2/TaRenamedSlotWrapper.class.st
@@ -5,7 +5,7 @@ This wrapper does exactly that: as a Slot subclass, it has a name. It forwards a
 in the trait.
 "
 Class {
-	#name : #TaRemovedSlotWrapper,
+	#name : #TaRenamedSlotWrapper,
 	#superclass : #Slot,
 	#instVars : [
 		'originalSlot'
@@ -14,68 +14,68 @@ Class {
 }
 
 { #category : #'instance creation' }
-TaRemovedSlotWrapper class >> for: aSlot [
+TaRenamedSlotWrapper class >> for: aSlot [
 	^self new originalSlot: aSlot
 ]
 
 { #category : #'code generation' }
-TaRemovedSlotWrapper >> emitStore: aMethodBuilder [
+TaRenamedSlotWrapper >> emitStore: aMethodBuilder [
 	originalSlot emitStore: aMethodBuilder
 ]
 
 { #category : #'code generation' }
-TaRemovedSlotWrapper >> emitValue: aMethodBuilder [
+TaRenamedSlotWrapper >> emitValue: aMethodBuilder [
 	originalSlot emitValue: aMethodBuilder
 ]
 
 { #category : #accessing }
-TaRemovedSlotWrapper >> index [
+TaRenamedSlotWrapper >> index [
 	^ originalSlot index
 ]
 
 { #category : #accessing }
-TaRemovedSlotWrapper >> index: anInteger [
+TaRenamedSlotWrapper >> index: anInteger [
 	originalSlot index: anInteger
 ]
 
 { #category : #testing }
-TaRemovedSlotWrapper >> isVirtual [
+TaRenamedSlotWrapper >> isVirtual [
 	^originalSlot isVirtual
 ]
 
 { #category : #testing }
-TaRemovedSlotWrapper >> isVisible [
+TaRenamedSlotWrapper >> isVisible [
 	^originalSlot isVisible
 ]
 
 { #category : #accessing }
-TaRemovedSlotWrapper >> originalSlot [
+TaRenamedSlotWrapper >> originalSlot [
 
 	^ originalSlot
 ]
 
 { #category : #accessing }
-TaRemovedSlotWrapper >> originalSlot: anObject [
+TaRenamedSlotWrapper >> originalSlot: anObject [
 
 	originalSlot := anObject
 ]
 
 { #category : #printing }
-TaRemovedSlotWrapper >> printOn: aStream [
+TaRenamedSlotWrapper >> printOn: aStream [
 	originalSlot printOn: aStream
 ]
 
 { #category : #'meta-object-protocol' }
-TaRemovedSlotWrapper >> read: anObject [
+TaRenamedSlotWrapper >> read: anObject [
 	^ originalSlot read: anObject
 ]
 
 { #category : #'meta-object-protocol' }
-TaRemovedSlotWrapper >> wantsInitialization [
+TaRenamedSlotWrapper >> wantsInitialization [
 	^ originalSlot wantsInitialization
 ]
 
 { #category : #'meta-object-protocol' }
-TaRemovedSlotWrapper >> write: aValue to: anObject [
+TaRenamedSlotWrapper >> write: aValue to: anObject [
 	^ originalSlot write: aValue to: anObject
 ]


### PR DESCRIPTION
TaRenameSlot was copying the slot and then changing the name.

I think it is better to make the composition explicit by adding TaRenamedSlotWrapper. This special slot wraps the original slot and changes the name, but it forwards everything else to the original slot.

