### PR TITLE
RB - New move to class side method refactoring

### DIFF
--- a/src/Refactoring-Core/RBAbstractClass.class.st
+++ b/src/Refactoring-Core/RBAbstractClass.class.st
@@ -141,6 +141,15 @@ RBAbstractClass >> canUnderstand: aSelector [
 	^self definesMethod: aSelector
 ]
 
+{ #category : #printing }
+RBAbstractClass >> canonicalArgumentName [
+	| prefix |
+	prefix := self name first isVowel
+		ifTrue: [ 'an' ]
+		ifFalse: [ 'a' ].
+	^ prefix, self name
+]
+
 { #category : #accessing }
 RBAbstractClass >> classBinding [
 	^ Smalltalk globals associationAt: self name

--- a/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : #RBMoveMethodToClassSideRefactoring,
+	#superclass : #RBMoveMethodToClassRefactoring,
+	#category : #'Refactoring-Core-Refactorings'
+}
+
+{ #category : #transforming }
+RBMoveMethodToClassSideRefactoring >> addMethod: rbMethod to: aClass toProtocol: protocol [
+	aClass addMethod: rbMethod.
+	aClass compile: rbMethod source classified: {protocol}.
+]
+
+{ #category : #creating }
+RBMoveMethodToClassSideRefactoring >> metaClassOf: aClass [
+	| classModel |
+	classModel :=RBClassModelFactory rbMetaclass named: aClass name.
+	classModel model: self model.
+	^classModel
+]
+
+{ #category : #initialization }
+RBMoveMethodToClassSideRefactoring >> method: aMethod class: aClass [
+	method := aMethod.
+	class := self classObjectFor: aClass.
+]
+
+{ #category : #preconditions }
+RBMoveMethodToClassSideRefactoring >> preconditions [
+	^(RBCondition definesSelector: method selector in: (self metaClassOf: class)) not
+		& (RBCondition withBlock: [ class isMeta not ])
+]
+
+{ #category : #transforming }
+RBMoveMethodToClassSideRefactoring >> transform [
+	| oldClass newClass rbMethod rbMethod2 newSource originalProtocol |
+	oldClass := class.
+	newClass := self metaClassOf: class.
+	rbMethod := RBClassModelFactory rbMethod for: newClass source: method sourceCode selector: method selector.
+	newSource := method selector, '
+	^ self class ',  method selector.
+	rbMethod2 := RBClassModelFactory rbMethod for: oldClass source: newSource selector: method selector.
+	originalProtocol := method protocol.
+	oldClass removeMethod: method selector.
+	self addMethod: rbMethod to: newClass toProtocol: originalProtocol.
+	self addMethod: rbMethod2 to: oldClass toProtocol: originalProtocol.
+]

--- a/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
@@ -23,13 +23,73 @@ X class >> annotatedBlockMarkup
 Class {
 	#name : #RBMoveMethodToClassSideRefactoring,
 	#superclass : #RBMoveMethodToClassRefactoring,
+	#instVars : [
+		'parseTree'
+	],
 	#category : #'Refactoring-Core-Refactorings'
 }
+
+{ #category : #refactoring }
+RBMoveMethodToClassSideRefactoring >> accessorsFor: variableName [
+
+	^ RBCreateAccessorsForVariableRefactoring
+				model: self model
+				variable: variableName
+				class: class
+				classVariable: false
+]
 
 { #category : #transforming }
 RBMoveMethodToClassSideRefactoring >> addMethod: rbMethod to: aClass toProtocol: protocol [
 	aClass addMethod: rbMethod.
 	aClass compile: rbMethod source classified: {protocol}.
+]
+
+{ #category : #checking }
+RBMoveMethodToClassSideRefactoring >> checkVariableNamed: aString [
+	(class whoDefinesInstanceVariable: aString) ifNotNil: 
+			[^ true].
+	(class whoDefinesClassVariable: aString) ifNotNil: 
+			[^ true].
+	^ (self parseTree allDefinedVariables includes: aString) 
+]
+
+{ #category : #transforming }
+RBMoveMethodToClassSideRefactoring >> getNewInstSideSource [
+	| sender |
+	sender := ''.
+	(method argumentNames size > 0) ifTrue: [ 
+		(method selector keywords) with: (method argumentNames )do: [:a :b |
+		sender := sender, a, ' ', b, ' ']]
+	ifFalse: [ sender := method selector ].
+	^ sender, '
+	^ self class ', sender
+]
+
+{ #category : #transforming }
+RBMoveMethodToClassSideRefactoring >> getNewSource [
+	| newSource rewriter node temp |
+	temp := self getTempName.
+	node := (RBParser parseMethod: method source).
+	rewriter := RBParseTreeRewriter new replace: 'self' with: temp.
+	newSource := (rewriter executeTree: node)
+		ifTrue: [ rewriter tree formattedCode].
+	node := (RBParser parseMethod: newSource ).
+	node body addNodeFirst: (RBParser parseExpression: temp, ' := self new').
+	node body addTemporaryNamed: temp.
+	^ node newSource
+]
+
+{ #category : #transforming }
+RBMoveMethodToClassSideRefactoring >> getTempName [
+	| aString counter tempName |
+	counter := 0.
+	aString := class canonicalArgumentName.
+	tempName := aString.
+	[self checkVariableNamed: tempName]
+	whileTrue: [ counter := counter + 1.
+		tempName := aString , counter asString ].
+	^ tempName
 ]
 
 { #category : #initialization }
@@ -38,12 +98,37 @@ RBMoveMethodToClassSideRefactoring >> method: aMethod class: aClass [
 	class := self classObjectFor: aClass.
 ]
 
+{ #category : #accessing }
+RBMoveMethodToClassSideRefactoring >> parseTree [
+
+	parseTree
+		ifNil: [ parseTree := class parseTreeFor: method selector.
+			parseTree ifNil: [ self refactoringFailure: 'Could not parse method' ]
+			].
+	^ parseTree
+]
+
 { #category : #preconditions }
 RBMoveMethodToClassSideRefactoring >> preconditions [
 	^(RBCondition 
 		definesSelector: method selector 
 		in: (self model classNamed: class name, ' class')) not
 		& (RBCondition withBlock: [ class isMeta not ])
+]
+
+{ #category : #transforming }
+RBMoveMethodToClassSideRefactoring >> removeInstVariableReferences [
+	| rbMethod references |
+	rbMethod := (class methodFor: method selector).
+	references := class instanceVariableNames select: [:e | rbMethod refersToVariable: e].
+	references do: [ :e | |replacer accessorsRefactoring|
+		accessorsRefactoring := self accessorsFor: e.
+		self performCompositeRefactoring: accessorsRefactoring.
+		replacer := self parseTreeRewriterClass 
+				variable: e
+				getter: accessorsRefactoring getterMethod
+				setter: accessorsRefactoring setterMethod.
+	   self convertMethod: method selector for: class using: replacer ].
 ]
 
 { #category : #printing }
@@ -62,14 +147,16 @@ RBMoveMethodToClassSideRefactoring >> storeOn: aStream [
 
 { #category : #transforming }
 RBMoveMethodToClassSideRefactoring >> transform [
-	| oldClass newClass rbMethod rbMethod2 newSource originalProtocol |
-	oldClass := class.
-	newClass := self model classNamed: class name, ' class'.
-	rbMethod := RBClassModelFactory rbMethod for: newClass source: method sourceCode selector: method selector.
-	newSource := method selector, '
-	^ self class ',  method selector.
-	rbMethod2 := RBClassModelFactory rbMethod for: oldClass source: newSource selector: method selector.
+	| oldClass newClass rbMethod rbMethod2 newSource originalProtocol newSource2 |
+	newSource := self getNewInstSideSource.
 	originalProtocol := method protocol.
+	oldClass := class.
+	self removeInstVariableReferences.
+	method := class methodFor: method selector.
+	newClass := self model classNamed: class name, ' class'.
+	newSource2 := self getNewSource.
+	rbMethod := RBClassModelFactory rbMethod for: newClass source: newSource2 selector: method selector.
+	rbMethod2 := RBClassModelFactory rbMethod for: oldClass source: newSource selector: method selector.
 	oldClass removeMethod: method selector.
 	self addMethod: rbMethod to: newClass toProtocol: originalProtocol.
 	self addMethod: rbMethod2 to: oldClass toProtocol: originalProtocol.

--- a/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
@@ -1,3 +1,25 @@
+"
+I am a refactoring for move a method to class side.
+
+For example, a method 
+
+```
+X >> annotatedBlockMarkup
+	^ '@@'
+```	
+
+move this method to class side convert the method to:
+```
+X >> annotatedBlockMarkup
+  ^ self class annotatedBlockMarkup
+```
+and create a new method in class side:
+
+```
+X class >> annotatedBlockMarkup
+	^ '@@'
+```
+"
 Class {
 	#name : #RBMoveMethodToClassSideRefactoring,
 	#superclass : #RBMoveMethodToClassRefactoring,
@@ -10,14 +32,6 @@ RBMoveMethodToClassSideRefactoring >> addMethod: rbMethod to: aClass toProtocol:
 	aClass compile: rbMethod source classified: {protocol}.
 ]
 
-{ #category : #creating }
-RBMoveMethodToClassSideRefactoring >> metaClassOf: aClass [
-	| classModel |
-	classModel :=RBClassModelFactory rbMetaclass named: aClass name.
-	classModel model: self model.
-	^classModel
-]
-
 { #category : #initialization }
 RBMoveMethodToClassSideRefactoring >> method: aMethod class: aClass [
 	method := aMethod.
@@ -26,15 +40,31 @@ RBMoveMethodToClassSideRefactoring >> method: aMethod class: aClass [
 
 { #category : #preconditions }
 RBMoveMethodToClassSideRefactoring >> preconditions [
-	^(RBCondition definesSelector: method selector in: (self metaClassOf: class)) not
+	^(RBCondition 
+		definesSelector: method selector 
+		in: (self model classNamed: class name, ' class')) not
 		& (RBCondition withBlock: [ class isMeta not ])
+]
+
+{ #category : #printing }
+RBMoveMethodToClassSideRefactoring >> storeOn: aStream [ 
+	aStream nextPut: $(.
+	self class storeOn: aStream.
+	aStream
+		nextPutAll: ' method: '.
+	method storeOn: aStream.
+	aStream 
+		nextPutAll: ' class: ';
+		nextPutAll: class name.
+	aStream
+		nextPutAll: ')'
 ]
 
 { #category : #transforming }
 RBMoveMethodToClassSideRefactoring >> transform [
 	| oldClass newClass rbMethod rbMethod2 newSource originalProtocol |
 	oldClass := class.
-	newClass := self metaClassOf: class.
+	newClass := self model classNamed: class name, ' class'.
 	rbMethod := RBClassModelFactory rbMethod for: newClass source: method sourceCode selector: method selector.
 	newSource := method selector, '
 	^ self class ',  method selector.

--- a/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
@@ -68,16 +68,19 @@ RBMoveMethodToClassSideRefactoring >> getNewInstSideSource [
 
 { #category : #transforming }
 RBMoveMethodToClassSideRefactoring >> getNewSource [
-	| newSource rewriter node temp |
+
+	| rewriter node temp |
 	temp := self getTempName.
-	node := (RBParser parseMethod: method source).
+	node := RBParser parseMethod: method source.
 	rewriter := RBParseTreeRewriter new replace: 'self' with: temp.
-	newSource := (rewriter executeTree: node)
-		ifTrue: [ rewriter tree formattedCode].
-	node := (RBParser parseMethod: newSource ).
-	node body addNodeFirst: (RBParser parseExpression: temp, ' := self new').
-	node body addTemporaryNamed: temp.
-	^ node newSource
+	(rewriter executeTree: node)
+		ifTrue: [ 
+			node := RBParser parseMethod: rewriter tree formattedCode.
+			node body addNodeFirst:
+				(RBParser parseExpression: temp , ' := self new').
+			node body addTemporaryNamed: temp.
+			^ node newSource ]
+		ifFalse: [ ^ node sourceCode ] 
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Tests-Core/RBMoveMethodToClassSideTest.class.st
+++ b/src/Refactoring-Tests-Core/RBMoveMethodToClassSideTest.class.st
@@ -1,0 +1,42 @@
+Class {
+	#name : #RBMoveMethodToClassSideTest,
+	#superclass : #RBRefactoringTest,
+	#category : #'Refactoring-Tests-Core-Refactorings'
+}
+
+{ #category : #'failure tests' }
+RBMoveMethodToClassSideTest >> testClassIsNotMeta [
+	| method someClass className refactoring |
+	className := RBRefactoryTestDataApp class.
+	someClass := model classNamed: className name.
+	someClass compile: 'threeElementPoint ^ self new' classified: {#example}.
+	method := someClass methodFor: ('threeElement', 'Point') asSymbol.
+	refactoring := RBMoveMethodToClassSideRefactoring model: model method: method class: className.
+	self shouldFail: refactoring.
+]
+
+{ #category : #'failure tests' }
+RBMoveMethodToClassSideTest >> testExistsMethodInClassSide [
+	| method someClass className refactoring |
+	className := RBRefactoryTestDataApp.
+	method := className >> ('threeElement', 'Point') asSymbol.
+	refactoring := RBMoveMethodToClassSideRefactoring method: method class: className.
+	model := refactoring model.
+	someClass := model classNamed: className name, ' class'.
+	someClass compile: 'threeElementPoint ^ self new' classified: {#example}.
+	self shouldFail: refactoring.
+]
+
+{ #category : #tests }
+RBMoveMethodToClassSideTest >> testMoveMethodToClassSide [
+	| method someClass className refactoring |
+	className := RBRefactoryTestDataApp.
+	method := className >> ('threeElement', 'Point') asSymbol.
+	refactoring := RBMoveMethodToClassSideRefactoring method: method class: className.
+	self executeRefactoring: refactoring.
+	model := refactoring model.
+	someClass := model classNamed: className name.
+	self assert: (someClass parseTreeFor: ('threeElement', 'Point') asSymbol) equals: (self parseMethod: 'threeElementPoint ^ self class threeElementPoint').
+	someClass := model classNamed: className name, ' class'.
+	self assert: (someClass parseTreeFor: ('threeElement', 'Point') asSymbol) equals: (self parseMethod: 'threeElementPoint ^5 @ 5 + 6 @ 6').
+]

--- a/src/Refactoring-Tests-Core/RBMoveMethodToClassSideTest.class.st
+++ b/src/Refactoring-Tests-Core/RBMoveMethodToClassSideTest.class.st
@@ -40,3 +40,23 @@ RBMoveMethodToClassSideTest >> testMoveMethodToClassSide [
 	someClass := model classNamed: className name, ' class'.
 	self assert: (someClass parseTreeFor: ('threeElement', 'Point') asSymbol) equals: (self parseMethod: 'threeElementPoint ^5 @ 5 + 6 @ 6').
 ]
+
+{ #category : #tests }
+RBMoveMethodToClassSideTest >> testMoveMethodToClassSideWithInsAndMetReferences [
+	| method someClass className refactoring |
+	className := RBTransformationRuleTestData.
+	method := className >> ('rewrite', 'Using:') asSymbol.
+	refactoring := RBMoveMethodToClassSideRefactoring method: method class: className.
+	self executeRefactoring: refactoring.
+	model := refactoring model.
+	someClass := model classNamed: className name.
+	self assert: (someClass parseTreeFor: ('rewrite', 'Using:') asSymbol) equals: (self parseMethod: 'rewriteUsing: searchReplacer
+	^ self class rewriteUsing: searchReplacer').
+	someClass := model classNamed: className name, ' class'.
+	self assert: (someClass parseTreeFor: ('rewrite', 'Using:') asSymbol) equals: (self parseMethod: 'rewriteUsing: searchReplacer
+
+	| aRBTransformationRuleTestData |
+	aRBTransformationRuleTestData := self new.
+	aRBTransformationRuleTestData rewriteRule: searchReplacer.
+	aRBTransformationRuleTestData resetResult').
+]

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToClassCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToClassCommand.class.st
@@ -46,7 +46,7 @@ SycMoveMethodsToClassCommand >> defaultMenuItemName [
 SycMoveMethodsToClassCommand >> execute [
 	
 	methods 
-		collect: [ :each | RBMoveMethodToClassRefactoring method: each class: targetClass]
+		collect: [ :each | RBMoveMethodToClassRefactoring method: each class: targetClass ]
 		thenDo: [ :each | each execute ]
 ]
 

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToClassSideCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToClassSideCommand.class.st
@@ -44,6 +44,6 @@ SycMoveMethodsToClassSideCommand >> defaultMenuItemName [
 SycMoveMethodsToClassSideCommand >> execute [
 	
 	methods 
-		collect: [ :each | RBMoveMethodToClassSideRefactoring method: each class: each origin]
+		collect: [ :each | RBMoveMethodToClassRefactoring method: each class: each origin classSide]
 		thenDo: [ :each | each execute ]
 ]

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToClassSideCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToClassSideCommand.class.st
@@ -44,6 +44,6 @@ SycMoveMethodsToClassSideCommand >> defaultMenuItemName [
 SycMoveMethodsToClassSideCommand >> execute [
 	
 	methods 
-		collect: [ :each | RBMoveMethodToClassRefactoring method: each class: each origin classSide]
+		collect: [ :each | RBMoveMethodToClassSideRefactoring method: each class: each origin]
 		thenDo: [ :each | each execute ]
 ]


### PR DESCRIPTION
Improve "Move method to class side" Refactoring, the new version catch broken references (method senders and direct access to instVar) and fix them, for instance:

Before refactoring:
```
RBTransformationRuleTestData >> rewriteUsing: searchReplacer 
     rewriteRule := searchReplacer.
     self resetResult.
```
After refactoring:
```
RBTransformationRuleTestData >> rewriteUsing: searchReplacer
     ^ self class rewriteUsing: searchReplace.

RBTransformationRuleTestData class >> rewriteUsing: searchReplacer
    | aRBTransformationRuleTestData |
    aRBTransformationRuleTestData := self new.
    aRBTransformationRuleTestData rewriteRule: searchReplacer.
    aRBTransformationRuleTestData resetResult').
```

Fixes #6309
    
