### PR TITLE
8572-Cannot-run-newly-created-Pharo-9-images

### DIFF
--- a/src/System-OSEnvironments/Win32Environment.class.st
+++ b/src/System-OSEnvironments/Win32Environment.class.st
@@ -76,7 +76,7 @@ Win32Environment >> doGetEnvVariable: aVariableName bufferSize: aSize ifAbsent: 
 	
 	"From MSDN: If lpBuffer is not large enough to hold the data, the return value is the buffer size, in characters,
 	required to hold the string and its terminating null character and the contents of lpBuffer are undefined."
-	return > aSize ifTrue: [ ^ self doGetEnvVariable: aVariableName bufferSize: aSize ifAbsent: aBlock isRetry: false ].
+	return > aSize ifTrue: [ ^ self doGetEnvVariable: aVariableName bufferSize: return ifAbsent: aBlock isRetry: false ].
 	
 	^ buffer asString
 ]

--- a/src/System-Platforms-Tests/Win32EnvironmentTest.class.st
+++ b/src/System-Platforms-Tests/Win32EnvironmentTest.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : #Win32EnvironmentTest,
+	#superclass : #TestCase,
+	#category : #'System-Platforms-Tests-Win32'
+}
+
+{ #category : #tests }
+Win32EnvironmentTest >> testExistingEnvironmentVariableLongerThanBufferShouldReturnValue [
+
+	| value aExpectedValue |
+	
+	OSPlatform current isWindows 
+		ifFalse: [ ^self skip ].
+
+	aExpectedValue := String loremIpsum: 1500.
+
+	OSEnvironment current at: 'ExistingNonEmpty' put: aExpectedValue.
+		
+	value := OSEnvironment current at: 'ExistingNonEmpty'.
+	
+	self assert: value equals: aExpectedValue
+]
+
+{ #category : #tests }
+Win32EnvironmentTest >> testExistingEnvironmentVariableShouldReturnValue [
+
+	| value |
+	
+	OSPlatform current isWindows 
+		ifFalse: [ ^self skip ].
+
+	OSEnvironment current at: 'ExistingNonEmpty' put: 'IamAValue'.
+		
+	value := OSEnvironment current at: 'ExistingNonEmpty'.
+	
+	self assert: value equals: 'IamAValue'
+]
+
+{ #category : #tests }
+Win32EnvironmentTest >> testNonExistingEnvironmentVariableShouldGenerateException [
+
+	OSPlatform current isWindows 
+		ifFalse: [ ^self skip ].
+		
+	self should: [ OSEnvironment current at: 'NonExistingVariable' ] raise: NotFound.
+]

--- a/src/System-Platforms/Win32WideString.class.st
+++ b/src/System-Platforms/Win32WideString.class.st
@@ -31,7 +31,7 @@ Win32WideString class >> fromHandle: handle [
 Win32WideString class >> fromString: aString [
 	| requestedSize r wideString anUTF8String codepage |
 
-	anUTF8String := aString utf8Encoded.
+	anUTF8String := aString utf8Encoded copyWith: 0.
 	codepage := 65001.
 
 	requestedSize := OSPlatform current


### PR DESCRIPTION
Handling correctly the recursive step when the size of the buffer is not the correct one.

Fix #8572