### PR TITLE
remove-unused-ClassVar-FFICallbackParametersTest

### DIFF
--- a/src/UnifiedFFI-Tests/FFICallbackParametersTest.class.st
+++ b/src/UnifiedFFI-Tests/FFICallbackParametersTest.class.st
@@ -7,9 +7,6 @@ Class {
 	#instVars : [
 		'callback'
 	],
-	#classVars : [
-		'ARRAY'
-	],
 	#pools : [
 		'FFITestEnumeration'
 	],


### PR DESCRIPTION
FFICallbackParametersTest remove non-referenced clas var

