### PR TITLE
MetaLink-LiteralArray-Fix

### DIFF
--- a/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
@@ -857,6 +857,26 @@ ReflectivityReificationTest >> testReifyIvarVariable [
 ]
 
 { #category : #'tests - misc' }
+ReflectivityReificationTest >> testReifyLiteralArrayContext [
+	| literalArrayNode instance |
+	literalArrayNode := (ReflectivityExamples >> #exampleLiteralArray) ast body statements first value.
+	link := MetaLink new
+		metaObject: self;
+		selector: #tagExec:;
+		control: #before;
+		arguments: #(context).
+	literalArrayNode link: link.
+	self assert: literalArrayNode hasMetalink.
+	self
+		assert: (ReflectivityExamples >> #exampleLiteralArray) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+	instance := ReflectivityExamples new.
+	self assert: instance exampleLiteralArray equals: #(1).
+	self assert: tag class identicalTo: Context.
+]
+
+{ #category : #'tests - misc' }
 ReflectivityReificationTest >> testReifyLiteralArrayOperation [
 	| sendNode instance |
 	sendNode := (ReflectivityExamples >> #exampleLiteralArray) ast body statements first value.
@@ -878,15 +898,15 @@ ReflectivityReificationTest >> testReifyLiteralArrayOperation [
 
 { #category : #'tests - misc' }
 ReflectivityReificationTest >> testReifyLiteralArrayValue [
-	| sendNode instance |
-	sendNode := (ReflectivityExamples >> #exampleLiteralArray) ast body statements first value.
+	| literalArrayNode instance |
+	literalArrayNode := (ReflectivityExamples >> #exampleLiteralArray) ast body statements first value.
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
 		control: #after;
 		arguments: #(value).
-	sendNode link: link.
-	self assert: sendNode hasMetalink.
+	literalArrayNode link: link.
+	self assert: literalArrayNode hasMetalink.
 	self
 		assert: (ReflectivityExamples >> #exampleLiteralArray) class
 		equals: ReflectiveMethod.

--- a/src/Reflectivity/RFReification.class.st
+++ b/src/Reflectivity/RFReification.class.st
@@ -106,6 +106,11 @@ RFReification >> genForRBInstanceVariableNode [
 ]
 
 { #category : #generate }
+RFReification >> genForRBLiteralArrayNode [
+	^self genForRBProgramNode
+]
+
+{ #category : #generate }
 RFReification >> genForRBLiteralNode [
 	^self genForRBProgramNode
 ]


### PR DESCRIPTION
This PR fixes a part of issue  #8575: putting breakpoints on literal arrays

- add missing #genForRBLiteralArrayNode
- add test  #testReifyLiteralArrayContext

