### PR TITLE
8575-IRTempVector-issue-when-installing-breakpoints-on-some-methods

### DIFF
--- a/src/OpalCompiler-Core/IRTempVector.class.st
+++ b/src/OpalCompiler-Core/IRTempVector.class.st
@@ -24,11 +24,6 @@ IRTempVector >> indexForVarNamed: aName [
 
 ]
 
-{ #category : #initialization }
-IRTempVector >> initialize [ 
-	vars := Dictionary new
-]
-
 { #category : #testing }
 IRTempVector >> isTempVector [
 	^true

--- a/src/Reflectivity-Tests/ReflectivityControlTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityControlTest.class.st
@@ -515,6 +515,23 @@ ReflectivityControlTest >> testBeforeBlockSequenceNoValue [
 ]
 
 { #category : #'tests - before' }
+ReflectivityControlTest >> testBeforeBlockSequenceOptimized [
+	| sequence |
+	"we should be able to set a link on the sequence of an optimzied block with escaping vars"
+	sequence := (ReflectivityExamples >> #exampleBlockOptimized) ast blockNodes first body.
+	self assert: sequence isSequence.
+	link := MetaLink new
+		metaObject: self;
+		selector: #tagExec.
+	sequence link: link.
+	self assert: sequence hasMetalinkBefore.
+	self assert: tag isNil.
+	ReflectivityExamples new exampleBlockOptimized.
+	self assert: tag equals: 'yes'.
+	self assert: (ReflectivityExamples >> #exampleBlockNoValue) class equals: CompiledMethod
+]
+
+{ #category : #'tests - before' }
 ReflectivityControlTest >> testBeforeCascade [
 	| cascadeNode |
 	cascadeNode := (ReflectivityExamples >> #exampleCascade) ast statements first value.

--- a/src/Reflectivity-Tests/ReflectivityExamples.class.st
+++ b/src/Reflectivity-Tests/ReflectivityExamples.class.st
@@ -76,6 +76,18 @@ ReflectivityExamples >> exampleBlockNoValue [
 ]
 
 { #category : #examples }
+ReflectivityExamples >> exampleBlockOptimized [
+	"block with temp vector inside a optized block"
+	^ 1==1 ifTrue: [ 
+		  | var1 var2 |
+		
+		  #( 1 2 ) collect: [ :each | 
+			  var1 := 1.
+			  var2 := 1.
+			  var1 + var2 ] ] 
+]
+
+{ #category : #examples }
 ReflectivityExamples >> exampleBlockWithArg [
 	^ [:a | a + 3] value: 2 
 ]

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -183,7 +183,7 @@ RFASTTranslator >> visitInlinedBlockNode: anOptimizedBlockNode [
 	anOptimizedBlockNode scope tempVector ifNotEmpty: [
 		methodBuilder 
 			createTempVectorNamed: anOptimizedBlockNode scope tempVectorName 
-			withVars: (anOptimizedBlockNode scope tempVector collect: [:each| each name]).
+			withVars: anOptimizedBlockNode scope tempVectorVarNames.
 	].
 	methodBuilder addTemps: anOptimizedBlockNode scope tempVarNamesWithoutArguments.
 	methodBuilder addTemps: anOptimizedBlockNode scope inComingCopiedVarNames.


### PR DESCRIPTION
- turn the example from the issue into #exampleBlockOptimized and write #testBeforeBlockSequenceOptimized

- fix problem in #visitInlinedBlockNode: (so dumb...)
- cleanup not needed initialize method

fixes #8575

