### PR TITLE
8554-P9---Problem-with-copy-and-paste-from-Windows-to-ClassBrowser-method-panel- 

### DIFF
--- a/src/OSWindow-Core/OSWindowClipboard.class.st
+++ b/src/OSWindow-Core/OSWindowClipboard.class.st
@@ -21,7 +21,7 @@ OSWindowClipboard >> chooseRecentClipping [
 
 { #category : #accessing }
 OSWindowClipboard >> clipboardText [
-	^ self worldRenderer clipboardText
+	^ self worldRenderer clipboardText withInternalLineEndings
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Implement #clipboardText as described in the issue tracker.

fixes #8554 


