### PR TITLE
8566-CtrlShiftEnd-runs-Debug-it-keybinding-instead-of-selecting-text 

### DIFF
--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -15,23 +15,6 @@ Class {
 }
 
 { #category : #keymapping }
-RubSmalltalkEditor class >> buildPatchShortcutsForDoItInWindowsOn: aBuilder [
-	"this is because for some reason Ctrl+d means Ctrl+end on Windows"
-	<keymap>
-	(aBuilder shortcut: #doItPatchForWindows) 
-		category: RubSmalltalkEditor name
-		default: Character end ctrl win
-		do: [ :target | target editor doIt: nil ]
-		description: 'Do it'.
-	
-	(aBuilder shortcut: #debugItPatchForWindows) 
-		category: RubSmalltalkEditor name
-		default: Character end shift ctrl win
-		do: [ :target | target editor debugIt: nil ]
-		description: 'Debug it'
-]
-
-{ #category : #keymapping }
 RubSmalltalkEditor class >> buildShortcutsOn: aBuilder [
 	"We are defining the bindings twice because we want to support 
 	both Cmd and meta for Windows and Linux. This should happen at least as long as in the development environment


### PR DESCRIPTION
remove #buildPatchShortcutsForDoItInWindowsOn: as described in the issue

fixes #8566


