### PR TITLE
6842-May-be-we-can-drop-the-old-squeakform-format-check-in-fromBinaryStream

### DIFF
--- a/src/Graphics-Display Objects/Form.class.st
+++ b/src/Graphics-Display Objects/Form.class.st
@@ -1977,29 +1977,6 @@ Form >> readFrom: aBinaryStream [
 	self readBitsFrom: aBinaryStream
 ]
 
-{ #category : #'file in/out' }
-Form >> readFromOldFormat: aBinaryStream [
-	"Read a Form in the original ST-80 format."
-
-	| w h offsetX offsetY newForm theBits pos |
-	self error: 'this method must be updated to read into 32-bit word bitmaps'.
-	w := aBinaryStream nextWord.
-	h := aBinaryStream nextWord.
-	offsetX  := aBinaryStream nextWord.
-	offsetY := aBinaryStream nextWord.
-	offsetX > 32767 ifTrue: [offsetX := offsetX - 65536].
-	offsetY > 32767 ifTrue: [offsetY := offsetY - 65536].
-	newForm := Form extent: w @ h offset: offsetX @ offsetY.
-	theBits := newForm bits.
-	pos := 0.
-	1 to: w + 15 // 16 do: [:j |
-		1 to: h do: [:i |
-			theBits at: (pos := pos+1) put: aBinaryStream nextWord]].
-	newForm bits: theBits.
-	^ newForm
-
-]
-
 { #category : #analyzing }
 Form >> rectangleEnclosingPixelsNotOfColor: aColor [
 	"Answer the smallest rectangle enclosing all the pixels of me that are different from the given color. Useful for extracting a foreground graphic from its background."

--- a/src/Graphics-Files/Form.extension.st
+++ b/src/Graphics-Files/Form.extension.st
@@ -22,15 +22,13 @@ Form class >> fromBase64String: aBase64EncodedString [
 
 { #category : #'*Graphics-Files' }
 Form class >> fromBinaryStream: aBinaryStream [
-	"Read a Form or ColorForm from given file, using the first byte of the file to guess its format. Currently handles: GIF, uncompressed BMP, and both old and new DisplayObject writeOn: formats, JPEG, and PCX. Return nil if the file could not be read or was of an unrecognized format."
+	"Read a Form or ColorForm from given file, using the first byte of the file to guess its format. Currently handles: GIF, uncompressed BMP, and new DisplayObject writeOn: formats, JPEG, and PCX. Return nil if the file could not be read or was of an unrecognized format."
 
 	| firstByte |
 	firstByte := aBinaryStream peek.
 	firstByte = 1 ifTrue: [
-		"old Squeakform format"
-		^ self new readFromOldFormat: aBinaryStream].
+		"old ST80 format" ^ self error: 'old ST80 format not supported' ].
 	firstByte = 2 ifTrue: [
-		"new Squeak form format"
 		^ self new readFrom: aBinaryStream].
 
 	"Try for JPG, GIF, or PCX..."

--- a/src/Graphics-Files/Form.extension.st
+++ b/src/Graphics-Files/Form.extension.st
@@ -22,19 +22,17 @@ Form class >> fromBase64String: aBase64EncodedString [
 
 { #category : #'*Graphics-Files' }
 Form class >> fromBinaryStream: aBinaryStream [
+
 	"Read a Form or ColorForm from given file, using the first byte of the file to guess its format. Currently handles: GIF, uncompressed BMP, and new DisplayObject writeOn: formats, JPEG, and PCX. Return nil if the file could not be read or was of an unrecognized format."
 
 	| firstByte |
 	firstByte := aBinaryStream peek.
-	firstByte = 1 ifTrue: [
-		"old ST80 format" ^ self error: 'old ST80 format not supported' ].
-	firstByte = 2 ifTrue: [
-		^ self new readFrom: aBinaryStream].
+	firstByte = 1 ifTrue: [ ^ self error: 'old ST80 format not supported' ].
+	firstByte = 2 ifTrue: [ ^ self new readFrom: aBinaryStream ].
 
 	"Try for JPG, GIF, or PCX..."
 	"Note: The following call closes the stream."
 	^ ImageReadWriter formFromStream: aBinaryStream
-
 ]
 
 { #category : #'*Graphics-Files' }


### PR DESCRIPTION
- remove #readFromOldFormat: (it raises a hard error anyway)
- move error to #fromBinaryStream: and update comments

fixes #6842

