### PR TITLE
Remove-unused-Classvar-GTGenericStackDebugger

### DIFF
--- a/src/GT-Debugger/GTGenericStackDebugger.class.st
+++ b/src/GT-Debugger/GTGenericStackDebugger.class.st
@@ -11,7 +11,6 @@ Class {
 		'cache'
 	],
 	#classVars : [
-		'ErrorRecursion',
 		'FilterCommonMessageSends',
 		'LogDebuggerStackToFile',
 		'LogFileName'


### PR DESCRIPTION
remove an used class variable in GTGenericStackDebugger:
one step to make #testNoUnusedClassVariablesLeft green


