### PR TITLE
Cleanup-ClassVars-Metacello

### DIFF
--- a/src/Metacello-MC/MetacelloConfigTemplate.class.st
+++ b/src/Metacello-MC/MetacelloConfigTemplate.class.st
@@ -32,9 +32,6 @@ Class {
 	#instVars : [
 		'project'
 	],
-	#classVars : [
-		'LastVersionLoad'
-	],
 	#category : #'Metacello-MC-Model'
 }
 

--- a/src/Metacello-MC/MetacelloConfigTemplateExample.class.st
+++ b/src/Metacello-MC/MetacelloConfigTemplateExample.class.st
@@ -32,9 +32,6 @@ Class {
 	#instVars : [
 		'project'
 	],
-	#classVars : [
-		'LastVersionLoad'
-	],
 	#category : #'Metacello-MC-Model'
 }
 


### PR DESCRIPTION
remove non-referenced class vars from MetacelloConfigTemplate and MetacelloConfigTemplateExample

