### PR TITLE
Use hashMultiply for SmallInteger>>hash

### DIFF
--- a/src/Collections-Unordered-Tests/DictionaryTest.class.st
+++ b/src/Collections-Unordered-Tests/DictionaryTest.class.st
@@ -647,18 +647,21 @@ DictionaryTest >> testNewFromPairs [
 
 { #category : #tests }
 DictionaryTest >> testNilHashCollision [
-	"Ensures that fixCollisionsFrom: does the right thing in the presence of a nil key"
+
+	"Ensures that fixCollisionsFrom: does the right thing in the presence of a nil key.
+	To do that, we must have a key with the same hash as nil."
+
 	| dict key |
-	self supportsNilKey
-		ifFalse: [ ^ self ].
+	self supportsNilKey ifFalse: [ ^ self ].
 	dict := self collectionClass new.
-	key := nil hash. "any key with same hash as nil"
-	dict at: key hash put: 1.
+	key := ObjectWithSettableHash new.
+	key hash: nil hash.
+	self assert: key hash equals: nil hash.
+	dict at: key put: 1.
 	dict at: nil put: 2.
 	self assert: (dict includesKey: nil).
 	dict removeKey: key.
-	self assert: (dict includesKey: nil).
-
+	self assert: (dict includesKey: nil)
 ]
 
 { #category : #'tests - testing' }

--- a/src/Collections-Unordered-Tests/ObjectWithSettableHash.class.st
+++ b/src/Collections-Unordered-Tests/ObjectWithSettableHash.class.st
@@ -10,7 +10,7 @@ Class {
 	#category : #'Collections-Unordered-Tests-Dictionaries'
 }
 
-{ #category : #accessing }
+{ #category : #comparing }
 ObjectWithSettableHash >> hash [
 
 	^ hash

--- a/src/Collections-Unordered-Tests/ObjectWithSettableHash.class.st
+++ b/src/Collections-Unordered-Tests/ObjectWithSettableHash.class.st
@@ -1,0 +1,32 @@
+"
+Used to create intentional hash collisions in tests, to test that collision handling is done correctly.
+"
+Class {
+	#name : #ObjectWithSettableHash,
+	#superclass : #Object,
+	#instVars : [
+		'hash'
+	],
+	#category : #'Collections-Unordered-Tests-Dictionaries'
+}
+
+{ #category : #accessing }
+ObjectWithSettableHash >> hash [
+
+	^ hash
+]
+
+{ #category : #accessing }
+ObjectWithSettableHash >> hash: anObject [
+
+	hash := anObject
+]
+
+{ #category : #initialization }
+ObjectWithSettableHash >> initialize [
+
+	"Make sure hash answers a SmallInteger, even if we haven't set it yet."
+
+	super initialize.
+	hash := 0
+]

--- a/src/Collections-Unordered-Tests/SetTest.class.st
+++ b/src/Collections-Unordered-Tests/SetTest.class.st
@@ -442,21 +442,27 @@ SetTest >> testIntersection [
 
 { #category : #'tests - integrity' }
 SetTest >> testIsHealthy [
+
 	"we use associations as keys on purpose, because they changing
 	hash depending on the key"
-	| a1 a2 set |
 
-	set := Set new.
-	[
-		a1 := 3 -> nil.
-		a2 := nil -> 3.
-		set add: a1; add: a2.
-		self assert: set isHealthy.
-		a1 key: 0.
-		a2 key: 0.
-		self assert: set isHealthy not
-	
-	] ensure: [set removeAll]
+	| a1 a2 set |
+	"There is a probability that nil will hash to 0 in some builds,
+	so the nil key will still be in the correct position after
+	it is changed to 0. The larger the set's capacity, the lower the
+	probability of this failure. Also, the default size of a set
+	happens to have the same correct position for 3 and 0."
+	set := Set new: 50000.
+	[ 
+	a1 := 3 -> nil.
+	a2 := nil -> 3.
+	set
+		add: a1;
+		add: a2.
+	self assert: set isHealthy.
+	a1 key: 0.
+	a2 key: 0.
+	self assert: set isHealthy not ] ensure: [ set removeAll ]
 ]
 
 { #category : #'tests - some' }

--- a/src/Collections-Weak-Tests/WeakSetTest.class.st
+++ b/src/Collections-Weak-Tests/WeakSetTest.class.st
@@ -117,7 +117,7 @@ WeakSetTest >> testCollisions [
 	o1 := (2 to: 100) select: [:i | (ws scanFor: 1 / i) = 1].
 	o2 := (2 to: 100) select: [:i | (ws scanFor: 1 / i) = 2].
 	o5 := (2 to: 100) select: [:i | (ws scanFor: 1 / i) = 5].
-	on := (2 to: 100) select: [:i | (ws scanFor: 1 / i) = (ws array size - 1)].
+	on := (2 to: 200) select: [:i | (ws scanFor: 1 / i) = (ws array size - 1)].
 	
 	"Add some fractions to the weak set, and remember a pointer for a few of them"
 	remember := OrderedCollection new.

--- a/src/Kernel/SmallInteger.class.st
+++ b/src/Kernel/SmallInteger.class.st
@@ -397,7 +397,10 @@ SmallInteger >> gcd: anInteger [
 { #category : #comparing }
 SmallInteger >> hash [
 
-	^self
+    "Spread consecutive integers or integers related by some other pattern
+    throughout the hash table, reducing the length of scans required."
+    
+    ^ self hashMultiply
 ]
 
 { #category : #'bit manipulation' }

--- a/src/System-Caching-Tests/BlockClosureTest.extension.st
+++ b/src/System-Caching-Tests/BlockClosureTest.extension.st
@@ -2,14 +2,24 @@ Extension { #name : #BlockClosureTest }
 
 { #category : #'*System-Caching-Tests' }
 BlockClosureTest >> testMemoizedDictionary [
+
 	| cache factorial result |
 	cache := Dictionary new.
 	factorial := 0. "avoid not-initialised warning when saving method source"
-	factorial := [ :n | n = 1 ifTrue: [1] ifFalse: [(factorial value: n - 1) * n] ] memoizedUsing: cache.
+	factorial := [ :n | 
+	             n = 1
+		             ifTrue: [ 1 ]
+		             ifFalse: [ (factorial value: n - 1) * n ] ] 
+		             memoizedUsing: cache.
 	result := (1 to: 5) collect: factorial.
-	self assert: result equals: #(1 2 6 24 120).
-	self assert: cache associations equals: { 1->1.   2->2.   3->6.   4->24.   5->120 }.
-
+	self assert: result equals: #( 1 2 6 24 120 ).
+	"Compare sets since order of associations in a dictionary is not guaranteed."
+	self assert: cache associations asSet equals: { 
+			(1 -> 1).
+			(2 -> 2).
+			(3 -> 6).
+			(4 -> 24).
+			(5 -> 120) } asSet
 ]
 
 { #category : #'*System-Caching-Tests' }


### PR DESCRIPTION
A few days ago, Nikhil Marathe made a blog post [1] about experiences with Pharo, asserting that "Dictionary access seems to be really slow in Pharo." Later discussion on Discord found that in Nikhil's application using an IdentityDictionary made the application perform ~100X faster (2009msec vs 188664 msec).

This did not sound right to me, so I took a look. It turns out that Nikhil's application uses integer keys. SmallInteger>>hash just returns self, whereas SmallInteger>>identityHash is returns self hashMultiply. This seemed likely to explain the huge performance difference. 

I asked Nikhil to try adding hashMultiply to SmallInteger>>hash, and sure enough, with that change IdentityDictionary and Dictionary perform similarly in Nikhil's application.

So here's the PR to make that one-word change.

[1] https://nikhilism.com/post/2021/experiencing-smalltalk/