### PR TITLE
Cleanup-unused-classVar-FFIStringCalloutTest

### DIFF
--- a/src/UnifiedFFI-Tests/FFIStringCalloutTest.class.st
+++ b/src/UnifiedFFI-Tests/FFIStringCalloutTest.class.st
@@ -1,10 +1,6 @@
 Class {
 	#name : #FFIStringCalloutTest,
 	#superclass : #TestCase,
-	#classVars : [
-		'CLASSVAR',
-		'TYPEVAR'
-	],
 	#category : #'UnifiedFFI-Tests-Tests'
 }
 


### PR DESCRIPTION

remove two class vars that are not referenced from FFIStringCalloutTest