### PR TITLE
Unused-ClassVar-CleanUp-Deprecated

### DIFF
--- a/src/Deprecated90/CP1253TextConverter.class.st
+++ b/src/Deprecated90/CP1253TextConverter.class.st
@@ -4,9 +4,6 @@ Text converter for CP1253.  Windows code page used for Greek.
 Class {
 	#name : #CP1253TextConverter,
 	#superclass : #ByteTextConverter,
-	#classVars : [
-		'FromTable'
-	],
 	#category : #Deprecated90
 }
 

--- a/src/Deprecated90/LanguageEnvironment.class.st
+++ b/src/Deprecated90/LanguageEnvironment.class.st
@@ -15,10 +15,7 @@ Class {
 		'id'
 	],
 	#classVars : [
-		'ClipboardInterpreterClass',
-		'Current',
 		'FileNameConverter',
-		'InputInterpreterClass',
 		'KnownEnvironments',
 		'SystemConverter'
 	],


### PR DESCRIPTION
remove unused class vars from CP1253TextConverter and LanguageEnvironment

