### PR TITLE
Cleanup-unused-classvars-FT2Handle 

### DIFF
--- a/src/FreeType/FT2Handle.class.st
+++ b/src/FreeType/FT2Handle.class.st
@@ -4,11 +4,6 @@ handle holds a (typically 32-bit) pointer to an externally managed object.
 Class {
 	#name : #FT2Handle,
 	#superclass : #FFIExternalObject,
-	#classVars : [
-		'DestroyMutex',
-		'Registry',
-		'Session'
-	],
 	#pools : [
 		'FT2Constants'
 	],


### PR DESCRIPTION
remove a class var that is not referenced in FT2Handle