### PR TITLE
Fix-unused-classvars-CDClassWithFullDefinitionExample

### DIFF
--- a/src/ClassParser-Tests/CDClassWithFullDefinitionExample.class.st
+++ b/src/ClassParser-Tests/CDClassWithFullDefinitionExample.class.st
@@ -29,6 +29,16 @@ CDClassWithFullDefinitionExample class >> classSideVar2 [
 ]
 
 { #category : #accessing }
+CDClassWithFullDefinitionExample >> classVar1 [
+	^ClassVar1
+]
+
+{ #category : #accessing }
+CDClassWithFullDefinitionExample >> classVar2 [
+	^ClassVar2
+]
+
+{ #category : #accessing }
 CDClassWithFullDefinitionExample >> instVar1 [
 
 	^ instVar1


### PR DESCRIPTION
fix the problem of unused class vars in CDClassWithFullDefinitionExample by adding accessors

