### PR TITLE
validate callback failure on exit

### DIFF
--- a/src/ThreadedFFI/FFICallback.extension.st
+++ b/src/ThreadedFFI/FFICallback.extension.st
@@ -1,6 +1,24 @@
 Extension { #name : #FFICallback }
 
 { #category : #'*ThreadedFFI' }
+FFICallback >> beFailed [
+
+	^ self backendCallback beFailed
+]
+
+{ #category : #'*ThreadedFFI' }
+FFICallback >> beSuccess [
+
+	^ self backendCallback beSuccess
+]
+
+{ #category : #'*ThreadedFFI' }
+FFICallback >> isSuccess [
+
+	^ self backendCallback isSuccess
+]
+
+{ #category : #'*ThreadedFFI' }
 FFICallback >> tfPointerAddress [
 
 	^ self getHandle tfPointerAddress

--- a/src/ThreadedFFI/TFCallback.class.st
+++ b/src/ThreadedFFI/TFCallback.class.st
@@ -12,7 +12,8 @@ Class {
 		'parameterTypes',
 		'returnType',
 		'frontendCallback',
-		'runStrategy'
+		'runStrategy',
+		'success'
 	],
 	#category : #'ThreadedFFI-Callbacks'
 }
@@ -47,10 +48,22 @@ TFCallback class >> primUnregister: callbackHandle [
 ]
 
 { #category : #accessing }
+TFCallback >> beFailed [
+
+	success := false
+]
+
+{ #category : #accessing }
 TFCallback >> beNull [
 
 	self setHandle: ExternalAddress null
 
+]
+
+{ #category : #accessing }
+TFCallback >> beSuccess [
+
+	success := true
 ]
 
 { #category : #accessing }
@@ -78,6 +91,7 @@ TFCallback >> frontendCallback: anObject [
 TFCallback >> initialize [
 
 	super initialize.
+	success := true.
 	callbackData := ExternalAddress new.
 	parameterHandlers := #()
 ]
@@ -100,6 +114,12 @@ TFCallback >> invokeAsFunctionWithArguments: aCollection [
 		collect: [ :anArgument :aType | aType marshallToPrimitive: anArgument ].
 
 	^ self returnType marshallFromPrimitive: (self runner invokeFunction: function withArguments: preparedArguments)
+]
+
+{ #category : #testing }
+TFCallback >> isSuccess [
+
+	^ success == true
 ]
 
 { #category : #accessing }

--- a/src/ThreadedFFI/TFCallbackInvocation.class.st
+++ b/src/ThreadedFFI/TFCallbackInvocation.class.st
@@ -49,22 +49,25 @@ TFCallbackInvocation >> callbackData [
 
 { #category : #operations }
 TFCallbackInvocation >> execute [ 
-	|  returnValue transformedArguments |
+	| returnValue transformedArguments |
 
 	transformedArguments := [ self arguments 
-			with: callback parameterTypes 
-			collect: [:anArgument :aType | aType marshallFromPrimitive: anArgument]] 
-		on: Exception fork: [:e | e debug ] return: [ self arguments ].
+		with: callback parameterTypes 
+		collect: [ :anArgument :aType | aType marshallFromPrimitive: anArgument ] ] 
+	on: Exception 
+	fork: [ :e | e debug ] 
+	return: [ self arguments ].
 
-	returnValue := callback returnType marshallToPrimitive: (callback frontendCallback valueWithArguments: transformedArguments).
-	
-	self isNull 
-		ifTrue: [ ^ self  ].
-	
-	callback returnType isVoid 
-		ifFalse: [ self writeReturnValue: returnValue ].
+	[ returnValue := callback frontendCallback valueWithArguments: transformedArguments ] 
+	ensure: [ 
+		returnValue := callback returnType marshallToPrimitive: (callback isSuccess 
+			ifTrue: [ returnValue ]
+			ifFalse: [ callback frontendCallback returnOnError ]).
 
-	self runner returnCallback: self
+		self isNull ifFalse: [ 
+			callback returnType isVoid 
+				ifFalse: [ self writeReturnValue: returnValue ].
+			self runner returnCallback: self ] ]
 ]
 
 { #category : #private }


### PR DESCRIPTION
... and try to answer default value if callback failed.

this improves TFFI stability but it does not prevents all crashes (because a default answer can be a wrong answer a lot of times)