### PR TITLE
increasing-number-of-initial-stack-pages

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -222,6 +222,11 @@ ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "Metacello new ba
 
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "CompilationContext bytecodeBackend: EncoderForSistaV1. CompilationContext optionFullBlockClosure: true. OpalCompiler recompileAll."
 
+#Extending the default number of stack pages.
+#The VM is divorcing all frames to free a stackPage if there is not a free one.
+#We can check the statistics of number of pages free using the "Smalltalk vm parameterAt: 61"
+${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "Smalltalk vm parameterAt: 43 put: 32"
+
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "MCCacheRepository uniqueInstance enable. FFIMethodRegistry resetAll. PharoSourcesCondenser condenseNewSources. Smalltalk garbageCollect"
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" clean --release
 


### PR DESCRIPTION
Increasing the number of stack pages. The number of stack pages is fixed and does not grow. The number of stack pages limits the current number of processes in the image. As each running process requires a stack page, every time a page need to be allocated and there is not freed one, all the contexts have to be divorced. The previous value was 8, and we can check that there is a lot of free pages. It can be checked with "Smalltalk vm parameterAt: 61"

This has an impact in the execution of an interactive image.