### PR TITLE
8613-Unused-class-Variable-in-ZnConstants

### DIFF
--- a/src/Zinc-HTTP/ZnConstants.class.st
+++ b/src/Zinc-HTTP/ZnConstants.class.st
@@ -7,7 +7,6 @@ Class {
 	#name : #ZnConstants,
 	#superclass : #Object,
 	#classVars : [
-		'DefaultMaximumEntitySize',
 		'HTTPStatusCodes'
 	],
 	#category : #'Zinc-HTTP-Support'


### PR DESCRIPTION

remove unused class var. fixes #8613