### PR TITLE
testNoUnusedClassVariablesLeft-improve

### DIFF
--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -25,7 +25,7 @@ NoUnusedVariablesLeftTest >> testNoUnusedClassVariablesLeft [
 	
 	classes := variables collect: [ :each | each definingClass ] as: Set.
 	
-	validExceptions := #(OSKeySymbols FooSharedPool SDL2Constants AthensCairoDefinitions BalloonEngineConstants ShTestSharedPool RBLintRuleTestData RBDummyLintRuleTest MCMockClassF RBTransformationRuleTestData1 Unicode).	
+	validExceptions := #(OSKeySymbols FooSharedPool SDL2Constants AthensCairoDefinitions BalloonEngineConstants ShTestSharedPool RBLintRuleTestData RBDummyLintRuleTest MCMockClassF Unicode).	
 	
 	remaining := classes asOrderedCollection reject: [ :each  | validExceptions includes: each name].
 	

--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -25,9 +25,9 @@ NoUnusedVariablesLeftTest >> testNoUnusedClassVariablesLeft [
 	
 	classes := variables collect: [ :each | each definingClass ] as: Set.
 	
-	validExceptions := {  }.	
+	validExceptions := #(OSKeySymbols FooSharedPool SDL2Constants AthensCairoDefinitions BalloonEngineConstants ShTestSharedPool RBLintRuleTestData RBDummyLintRuleTest MCMockClassF RBTransformationRuleTestData1 Unicode).	
 	
-	remaining := classes asOrderedCollection removeAll: validExceptions; yourself.
+	remaining := classes asOrderedCollection reject: [ :each  | validExceptions includes: each name].
 	
 	self assert: remaining isEmpty
 ]


### PR DESCRIPTION
This improves #testNoUnusedClassVariablesLeft

- do filtering based on names to not add a reference to classes
- add all these classes with unused class vars: Test Data classes, Symbol definining classes (and pools) like OSKeySymbols 

With this improvement, we are down to 12 unused class variables

