### PR TITLE
Decompiler-test-and-fix-super-inBlock-classSide

### DIFF
--- a/src/Flashback-Decompiler-Tests/FBDDecompilerTest.class.st
+++ b/src/Flashback-Decompiler-Tests/FBDDecompilerTest.class.st
@@ -815,6 +815,12 @@ FBDDecompilerTest >> testSuper [
 { #category : #tests }
 FBDDecompilerTest >> testSuperCallInBlock [
 
+	self checkCorrectDecompilation: #superCallInBlock
+]
+
+{ #category : #tests }
+FBDDecompilerTest >> testSuperCallInBlockClassSide [
+
 	self checkCorrectDecompilationClassSide: #superCallInBlock
 ]
 

--- a/src/Flashback-Decompiler-Tests/FBDDecompilerTest.class.st
+++ b/src/Flashback-Decompiler-Tests/FBDDecompilerTest.class.st
@@ -14,6 +14,12 @@ FBDDecompilerTest >> checkCorrectDecompilation: aSelector [
 ]
 
 { #category : #verification }
+FBDDecompilerTest >> checkCorrectDecompilationClassSide: aSelector [
+
+	self checkCorrectMethodDecompilation: (self getMethodClassSide: aSelector)
+]
+
+{ #category : #verification }
 FBDDecompilerTest >> checkCorrectMethodDecompilation: originalMethod [
 
 	| newMethod |
@@ -64,6 +70,12 @@ FBDDecompilerTest >> exampleClass [
 FBDDecompilerTest >> getMethod: selector [
 
 	^ self exampleClass >> selector
+]
+
+{ #category : #private }
+FBDDecompilerTest >> getMethodClassSide: selector [
+
+	^ self exampleClass class >> selector
 ]
 
 { #category : #tests }
@@ -803,7 +815,7 @@ FBDDecompilerTest >> testSuper [
 { #category : #tests }
 FBDDecompilerTest >> testSuperCallInBlock [
 
-	self checkCorrectDecompilation: #superCallInBlock
+	self checkCorrectDecompilationClassSide: #superCallInBlock
 ]
 
 { #category : #tests }

--- a/src/Flashback-Decompiler-Tests/FBDExamples.class.st
+++ b/src/Flashback-Decompiler-Tests/FBDExamples.class.st
@@ -15,6 +15,13 @@ Class {
 }
 
 { #category : #examples }
+FBDExamples class >> superCallInBlock [
+
+	^ [ super yourself ] value
+
+]
+
+{ #category : #examples }
 FBDExamples >> doubleRemoteAnidatedBlocks [
 
 	| val last |	

--- a/src/Flashback-Decompiler/FBDASTBuilder.class.st
+++ b/src/Flashback-Decompiler/FBDASTBuilder.class.st
@@ -20,8 +20,11 @@ FBDASTBuilder class >> newFor: class [
 ]
 
 { #category : #constructor }
-FBDASTBuilder >> codeAnyLitInd: anAssociation [ 
-	^ (RBVariableNode named: anAssociation key)
+FBDASTBuilder >> codeAnyLitInd: anAssociation [
+	| varName |
+	"class binding on the class side has nil as key"
+	varName := anAssociation key ifNil: [ 'class binding' ] ifNotNil: [ anAssociation key ].
+	^ (RBVariableNode named: varName)
 		binding: anAssociation;
 		yourself
 ]


### PR DESCRIPTION
This fixes a decompile problem: when a super is in a full block on the class side, the decompiler can not create an intermediate variable for it.

This PR adds a test and a workaround for that problem.

This is one of the 3 problems shown by https://github.com/pharo-project/pharo/issues/7952

