### PR TITLE
cleanup-unused-classvar-RBTransformationRuleTestData1

### DIFF
--- a/src/Refactoring-Tests-Core/RBTransformationRuleTestData1.class.st
+++ b/src/Refactoring-Tests-Core/RBTransformationRuleTestData1.class.st
@@ -10,6 +10,11 @@ Class {
 	#category : #'Refactoring-Tests-Core-Data'
 }
 
+{ #category : #'as yet unclassified' }
+RBTransformationRuleTestData1 >> classVarA [
+	^A
+]
+
 { #category : #accessing }
 RBTransformationRuleTestData1 >> foo [ 
 	^ foo


### PR DESCRIPTION
cleanup the unused class var in RBTransformationRuleTestData1 by adding an accessor (the ivar has one already)


