### PR TITLE
cleanup-unused-classVar-ClySubclassLOfClass2FromP1

### DIFF
--- a/src/Calypso-SystemQueries-Tests-P1WithHierarchy/ClySubclassLOfClass2FromP1.class.st
+++ b/src/Calypso-SystemQueries-Tests-P1WithHierarchy/ClySubclassLOfClass2FromP1.class.st
@@ -16,3 +16,8 @@ ClySubclassLOfClass2FromP1 >> subclassClassVar1Reader [
 ClySubclassLOfClass2FromP1 >> subclassClassVar1Writer [
 	ClassVar1 := #subclassClassVar1Value
 ]
+
+{ #category : #'as yet unclassified' }
+ClySubclassLOfClass2FromP1 >> subclassClassVarReader [
+	^SubclassClassVar
+]


### PR DESCRIPTION

fix a unused class var by adding an accessor