### PR TITLE
Fix issue 8642: ClassTrait instance variable vanishing when defining new instance variable

### DIFF
--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -46,8 +46,7 @@ Trait class >> configureBuilder: builder withName: aName traitComposition: aTrai
 		sharedPools: '';
 		category: aPackageName;
 		traitComposition: aTraitCompositionOrCollection asTraitComposition;
-		classTraitComposition: aTraitCompositionOrCollection asTraitComposition classComposition;
-		classSlots: #()
+		classTraitComposition: aTraitCompositionOrCollection asTraitComposition classComposition
 ]
 
 { #category : #'old pharo 8 syntax' }


### PR DESCRIPTION
Remove a hard classSlots definition to an empty array, the builder knows how to find the correct definition if needed