### PR TITLE
8595 enhance debugger to show the dnu call in the stack

### DIFF
--- a/src/NewTools-Debugger-Extensions/Exception.extension.st
+++ b/src/NewTools-Debugger-Extensions/Exception.extension.st
@@ -7,13 +7,7 @@ Exception >> signalContext [
 ]
 
 { #category : #'*NewTools-Debugger-Extensions' }
-Exception >> stDebuggerInspectorNodes [
+Exception >> stDebuggerInspectorNodesFor: aStDebuggerContext [
 
-	| nodes |
-	nodes := OrderedCollection new.
-	nodes add: (StInspectorDynamicNode
-			 hostObject: self
-			 label: 'Exception'
-			 value: self).
-	^ nodes
+	^ aStDebuggerContext exceptionNodesFor: self
 ]

--- a/src/NewTools-Debugger-Extensions/Exception.extension.st
+++ b/src/NewTools-Debugger-Extensions/Exception.extension.st
@@ -5,3 +5,15 @@ Exception >> signalContext [
 
 	^ signalContext
 ]
+
+{ #category : #'*NewTools-Debugger-Extensions' }
+Exception >> stDebuggerInspectorNodes [
+
+	| nodes |
+	nodes := OrderedCollection new.
+	nodes add: (StInspectorDynamicNode
+			 hostObject: self
+			 label: 'Exception'
+			 value: self).
+	^ nodes
+]

--- a/src/NewTools-Debugger-Extensions/MessageNotUnderstood.extension.st
+++ b/src/NewTools-Debugger-Extensions/MessageNotUnderstood.extension.st
@@ -1,13 +1,7 @@
 Extension { #name : #MessageNotUnderstood }
 
 { #category : #'*NewTools-Debugger-Extensions' }
-MessageNotUnderstood >> stDebuggerInspectorNodes [
+MessageNotUnderstood >> stDebuggerInspectorNodesFor: aStDebuggerContext [
 
-	| nodes |
-	nodes := super stDebuggerInspectorNodes.
-	nodes add: (StInspectorDynamicNode
-			 hostObject: self receiver
-			 label: 'DNU receiver'
-			 value: self receiver).
-	^ nodes
+	^ aStDebuggerContext doesNotUnderstandNodesFor: self
 ]

--- a/src/NewTools-Debugger-Extensions/MessageNotUnderstood.extension.st
+++ b/src/NewTools-Debugger-Extensions/MessageNotUnderstood.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #MessageNotUnderstood }
+
+{ #category : #'*NewTools-Debugger-Extensions' }
+MessageNotUnderstood >> stDebuggerInspectorNodes [
+
+	| nodes |
+	nodes := super stDebuggerInspectorNodes.
+	nodes add: (StInspectorDynamicNode
+			 hostObject: self receiver
+			 label: 'DNU receiver'
+			 value: self receiver).
+	^ nodes
+]

--- a/src/NewTools-Debugger-Extensions/OupsNullException.extension.st
+++ b/src/NewTools-Debugger-Extensions/OupsNullException.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #OupsNullException }
+
+{ #category : #'*NewTools-Debugger-Extensions' }
+OupsNullException >> stDebuggerInspectorNodesFor: aStDebuggerContext [
+
+	^ aStDebuggerContext nullExceptionNodesFor: self
+]

--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -491,6 +491,19 @@ StDebuggerActionModelTest >> testStepThrough [
 		identicalTo: method ast statements second
 ]
 
+{ #category : #'tests - predicates' }
+StDebuggerActionModelTest >> testUpdateDebugSession [
+
+	| exception |
+	self changeSession:
+		StTestDebuggerProvider new debuggerWithErrorContext session.
+	exception := session exception.
+	session exception: nil.
+	debugActionModel updateDebugSession.
+	self assert: session exception notNil.
+	self assert: session exception identicalTo: exception
+]
+
 { #category : #'tests - contexts' }
 StDebuggerActionModelTest >> testUpdateTopContext [
 	

--- a/src/NewTools-Debugger-Tests/StDebuggerContextTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerContextTest.class.st
@@ -134,6 +134,30 @@ StDebuggerContextTest >> testContext [
 ]
 
 { #category : #tests }
+StDebuggerContextTest >> testExceptionNodes [
+
+	| nodes object exception |
+	object := Object new.
+	[ object toto ]
+		on: Error
+		do: [ :e | 
+			exception := e freeze.
+			debuggerContext context: e signalerContext.
+			debuggerContext exception: e ].
+	nodes := debuggerContext exceptionNodes.
+	self assert: nodes size equals: 2.
+	self assert: nodes first key equals: 'Exception'.
+	self assert: nodes first rawValue equals: exception.
+	self assert: nodes first variableTag equals: 'implicit'.
+	self
+		assert: nodes first rawValue class
+		identicalTo: MessageNotUnderstood.
+	self assert: nodes second key equals: 'DNU receiver'.
+	self assert: nodes second rawValue identicalTo: object.
+	self assert: nodes first variableTag equals: 'implicit'.
+]
+
+{ #category : #tests }
 StDebuggerContextTest >> testNoDuplicatesBetweenArgsAndTemps [
 	|nodes nodesNamesArray nodesNamesSet|
 	debuggerContext context: self contextWithArgs.

--- a/src/NewTools-Debugger-Tests/StDebuggerContextTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerContextTest.class.st
@@ -168,6 +168,12 @@ StDebuggerContextTest >> testNoDuplicatesBetweenArgsAndTemps [
 ]
 
 { #category : #tests }
+StDebuggerContextTest >> testNullExceptionNodes [
+
+	self assertEmpty: debuggerContext exceptionNodes
+]
+
+{ #category : #tests }
 StDebuggerContextTest >> testReceiverNodes [
 
 	| nodes |

--- a/src/NewTools-Debugger-Tests/StDebuggerContextTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerContextTest.class.st
@@ -120,6 +120,23 @@ StDebuggerContextTest >> testBuildInspectorNodes [
 ]
 
 { #category : #tests }
+StDebuggerContextTest >> testBuildInspectorNodesForException [
+	| nodes object exception |
+	object := Object new.
+	[ object toto ]
+		on: Error
+		do: [ :e | 
+			exception := e freeze.
+			debuggerContext context: e signalerContext.
+			debuggerContext exception: e ].
+	nodes := debuggerContext buildInspectorNodes.
+	self assert: (nodes at: (nodes size - 1)) key equals: 'Exception'.
+	self assert: (nodes at: (nodes size - 1)) rawValue identicalTo: exception.
+	self assert: (nodes last) key equals: 'DNU receiver'. 
+	self assert: (nodes last) rawValue identicalTo: object
+]
+
+{ #category : #tests }
 StDebuggerContextTest >> testContext [
 
 	| closure contextSource ctx |

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -355,6 +355,26 @@ StDebuggerTest >> testInitialCodeSelectionAfterStepping [
 	"The pc range is highlighted with an additionnal index to encompass the full text of the node (why?)"
 ]
 
+{ #category : #'tests - context inspector' }
+StDebuggerTest >> testNewDebuggerContext [
+	|debuggerContext|
+	debugger := (self debuggerOn: session).
+	debuggerContext := debugger newDebuggerContext.
+	self assert: debuggerContext class identicalTo: debugger class debuggerContextClass.
+	self assert: debuggerContext exception equals: session exception
+]
+
+{ #category : #'tests - context inspector' }
+StDebuggerTest >> testNewDebuggerContextFor [
+	|debuggerContext ctx|
+	debugger := (self debuggerOn: session).
+	ctx := [  ] asContext.
+	debuggerContext := debugger newDebuggerContextFor: ctx.
+	self assert: debuggerContext class identicalTo: debugger class debuggerContextClass.
+	self assert: debuggerContext exception equals: session exception.
+	self assert: debuggerContext context identicalTo: ctx
+]
+
 { #category : #'tests - stack table' }
 StDebuggerTest >> testPrintReceiverClassInContext [
 	|ctx result|

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -158,6 +158,11 @@ StDebugger class >> debugSession: aDebugSession [
 	^ debugger
 ]
 
+{ #category : #accessing }
+StDebugger class >> debuggerContextClass [
+	^ StDebuggerContext
+]
+
 { #category : #settings }
 StDebugger class >> debuggerLayoutSettingsOn: aBuilder [
 	<systemsettings>
@@ -524,11 +529,6 @@ StDebugger >> debuggerActionModel [
 ]
 
 { #category : #accessing }
-StDebugger >> debuggerContextClass [
-	^ StDebuggerContext
-]
-
-{ #category : #accessing }
 StDebugger >> debuggerInspectorClass [
 	^ StDebuggerInspector
 ]
@@ -661,7 +661,7 @@ StDebugger >> initializeInspector [
 	inspector := self
 		             instantiate: self debuggerInspectorClass
 		             on:
-		             (self debuggerInspectorModelClass on: self debuggerContextClass new).
+		             (self debuggerInspectorModelClass on: self newDebuggerContext).
 	inspector label: 'Receiver'
 ]
 
@@ -780,6 +780,22 @@ StDebugger >> interruptedContext [
 StDebugger >> interruptedProcess [
 
 	^ self session interruptedProcess
+]
+
+{ #category : #'instance creation' }
+StDebugger >> newDebuggerContext [
+
+	^ self class debuggerContextClass new
+		  exception: self session exception;
+		  yourself
+]
+
+{ #category : #'instance creation' }
+StDebugger >> newDebuggerContextFor: aContext [
+
+	^ self newDebuggerContext
+		  context: aContext;
+		  yourself
 ]
 
 { #category : #'accessing context' }
@@ -1186,7 +1202,7 @@ StDebugger >> updateInspectorFromContext: aContext [
 		updateLayoutForContexts: self session interruptedContext
 		isAssertionFailure:
 		self debuggerActionModel isInterruptedContextAnAssertEqualsFailure.
-	inspector updateWith: (self debuggerContextClass context: aContext).
+	inspector updateWith: (self newDebuggerContextFor: aContext).
 	self flag: #DBG_INSPECTOR_UPDATE_BUG.
 	inspector getRawInspectorPresenterOrNil ifNotNil: [ :p | p update ]
 ]

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1255,6 +1255,7 @@ StDebugger >> updateStep [
 	self flag: #DBG_UPDATE_OF_MODEL_SHOULD_BE_AUTOMATED.
 	debuggerActionModel updateTopContext.
 	debuggerActionModel updateContextPredicate.	
+	debuggerActionModel updateDebugSession.
 		
 	self updateStackFromSession: self session.
 	self updateWindowTitle.

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -83,13 +83,13 @@ StDebuggerActionModel >> contextPredicate [
 StDebuggerActionModel >> contextPredicateFor: aContext [
 
 	| postMortem ex |
-	
 	postMortem := self isContextPostMortem: aContext.
 
-	(self contextSignalsAnException: aContext) ifFalse:[^ self predicateFor: aContext postMortem: postMortem].
-	
+	(self contextSignalsAnException: aContext) ifFalse: [ 
+		^ self predicateFor: aContext postMortem: postMortem ].
+
 	ex := aContext receiver.
-	((ex isKindOf: TestFailure) ) ifTrue: [ 
+	(ex isKindOf: TestFailure) ifTrue: [ 
 		^ self predicateFor: aContext failure: ex postMortem: postMortem ].
 
 	^ self predicateFor: aContext exception: ex postMortem: postMortem
@@ -340,6 +340,18 @@ StDebuggerActionModel >> updateContextPredicate [
 StDebuggerActionModel >> updateContextPredicateFor: aContext [    
 	contextPredicate := self contextPredicateFor: aContext.
 	^contextPredicate
+]
+
+{ #category : #'debug - session' }
+StDebuggerActionModel >> updateDebugSession [
+	self contextPredicate updateSessionForModel: self 
+		
+]
+
+{ #category : #'debug - session' }
+StDebuggerActionModel >> updateDebugSessionException: e [
+
+	self session exception: e
 ]
 
 { #category : #context }

--- a/src/NewTools-Debugger/StDebuggerContext.class.st
+++ b/src/NewTools-Debugger/StDebuggerContext.class.st
@@ -86,6 +86,12 @@ StDebuggerContext >> exceptionNodesFor: anException [
 		  yourself
 ]
 
+{ #category : #building }
+StDebuggerContext >> nullExceptionNodesFor: anException [
+
+	^ #(  )
+]
+
 { #category : #printing }
 StDebuggerContext >> printOn: aStream [
 	aStream nextPutAll: context asString 

--- a/src/NewTools-Debugger/StDebuggerContext.class.st
+++ b/src/NewTools-Debugger/StDebuggerContext.class.st
@@ -34,6 +34,7 @@ StDebuggerContext >> buildInspectorNodes [
 	nodes addAll: self receiverNodes.
 	nodes add: self stackTopNode.
 	nodes add: self thisContextNode.
+	nodes addAll: self exceptionNodes.
 	^ nodes
 ]
 

--- a/src/NewTools-Debugger/StDebuggerContext.class.st
+++ b/src/NewTools-Debugger/StDebuggerContext.class.st
@@ -48,6 +48,17 @@ StDebuggerContext >> context: anObject [
 	context := anObject
 ]
 
+{ #category : #building }
+StDebuggerContext >> doesNotUnderstandNodesFor: anException [
+
+	^ (self exceptionNodesFor: anException)
+		  add: (StInspectorDynamicNode
+				   hostObject: anException receiver
+				   label: 'DNU receiver'
+				   value: anException receiver);
+		  yourself
+]
+
 { #category : #accessing }
 StDebuggerContext >> exception [
 	^ exception ifNil:[exception := OupsNullException new]
@@ -60,7 +71,19 @@ StDebuggerContext >> exception: anException [
 
 { #category : #nodes }
 StDebuggerContext >> exceptionNodes [
-	^self exception stDebuggerInspectorNodes
+
+	^ self exception stDebuggerInspectorNodesFor: self
+]
+
+{ #category : #building }
+StDebuggerContext >> exceptionNodesFor: anException [
+
+	^ OrderedCollection new
+		  add: (StInspectorDynamicNode
+				   hostObject: anException
+				   label: 'Exception'
+				   value: anException);
+		  yourself
 ]
 
 { #category : #printing }

--- a/src/NewTools-Debugger/StDebuggerContext.class.st
+++ b/src/NewTools-Debugger/StDebuggerContext.class.st
@@ -6,7 +6,8 @@ Class {
 	#name : #StDebuggerContext,
 	#superclass : #Object,
 	#instVars : [
-		'context'
+		'context',
+		'exception'
 	],
 	#category : #'NewTools-Debugger-Model'
 }
@@ -45,6 +46,21 @@ StDebuggerContext >> context [
 { #category : #accessing }
 StDebuggerContext >> context: anObject [
 	context := anObject
+]
+
+{ #category : #accessing }
+StDebuggerContext >> exception [
+	^ exception ifNil:[exception := OupsNullException new]
+]
+
+{ #category : #accessing }
+StDebuggerContext >> exception: anException [
+	exception := anException 
+]
+
+{ #category : #nodes }
+StDebuggerContext >> exceptionNodes [
+	^self exception stDebuggerInspectorNodes
 ]
 
 { #category : #printing }

--- a/src/NewTools-Debugger/StDebuggerContextPredicate.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextPredicate.class.st
@@ -115,3 +115,9 @@ StDebuggerContextPredicate >> printPostMortemDescriptionOn: str [
 	str << '[Post-mortem]'.
 	str space
 ]
+
+{ #category : #updating }
+StDebuggerContextPredicate >> updateSessionForModel: aStDebuggerActionModel [
+	aStDebuggerActionModel updateDebugSessionException: OupsNullException new
+	
+]

--- a/src/NewTools-Debugger/StDebuggerErrorContextPredicate.class.st
+++ b/src/NewTools-Debugger/StDebuggerErrorContextPredicate.class.st
@@ -89,3 +89,9 @@ StDebuggerErrorContextPredicate >> printDescription [
 		 ifFalse: [ exception description ]).
 	^ str contents
 ]
+
+{ #category : #updating }
+StDebuggerErrorContextPredicate >> updateSessionForModel: aStDebuggerActionModel [
+
+	aStDebuggerActionModel updateDebugSessionException: exception
+]


### PR DESCRIPTION
Fixes #8595

When the debugger opens on an exception, now provides helper contextual objects to see:
- the exception
- relevant objects provided by the exception (*e.g.*, the receiver of a MNU in case of a DNU)

![Screenshot 2021-02-26 at 16 31 52](https://user-images.githubusercontent.com/26929529/109320287-23e72600-7850-11eb-9a2f-f1d65a50733f.png)
