### PR TITLE
Fix #8630: Traits with State: #allInstVarNames not in sync with #allSlots 

### DIFF
--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -112,6 +112,14 @@ TraitedClass >> addSelector: selector withRecompiledMethod: compiledMethod [
 	TraitChange addSelector: selector on: self
 ]
 
+{ #category : #accessing }
+TraitedClass >> allInstVarNames [
+
+	"This is an intermdiary fix to issue #8630"
+
+	^ self allSlots collect: [ :each | each names ]
+]
+
 { #category : #querying }
 TraitedClass >> allTraits [
 	^ self traitComposition allTraits


### PR DESCRIPTION
Intermediary fix for issue #8630
I redefined allInstVarNames in TraitedClass by reusing allSlots to get properly all the instVar (even the ones comming from the Trait).