### PR TITLE
Fixing how undefined objects test for undefined variable

### DIFF
--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -98,7 +98,7 @@ UndefinedObject >> doesNotUnderstand: aMessage [
 	| exception resumeValue node |
 	[ 
 	node := self findUndeclaredVariableIn:
-		        thisContext sender sourceNodeExecuted ] onErrorDo: [ :ex | 
+		        thisContext outerContext sender sourceNodeExecuted ] onErrorDo: [ :ex | 
 				"This is ugly, but we have a dependency with Opal compiler and 
 				it should be extracted. If there is a failure during the bootstrap, this
 				dependency produces an infinite loop"

--- a/src/NewTools-Debugger/StDebuggerErrorContextPredicate.class.st
+++ b/src/NewTools-Debugger/StDebuggerErrorContextPredicate.class.st
@@ -47,17 +47,15 @@ StDebuggerErrorContextPredicate >> isContextDoesNotUnderstand [
 	^ exception class = MessageNotUnderstood and: [ 
 		  | message |
 		  message := exception message.
-		  exception receiver notNil and: [ 
+		  
 			  (exception receiver respondsTo: message selector) not and: [ 
-				  exception signalerContext method methodClass == Object ] ] ]
+				  exception signalerContext method methodClass == Object ] ]
 ]
 
 { #category : #predicates }
 StDebuggerErrorContextPredicate >> isContextMissingClassException [
 
-	^ exception class == VariableNotDeclared or: [ 
-		  exception receiver isNil and: [ 
-			  exception class == MessageNotUnderstood ] ]
+	^ exception class == VariableNotDeclared
 ]
 
 { #category : #predicates }


### PR DESCRIPTION
Fixed the recovering of the correct context with full blocks.

Fixed how the StDebugger detects variable not defined and message not understood exceptions.

Fixes #8636 