### PR TITLE
Fix ZnBufferedReadStream>>#setToEnd for ZipArchive usage

### DIFF
--- a/src/Zinc-Character-Encoding-Core/ZnBufferedReadStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnBufferedReadStream.class.st
@@ -314,7 +314,7 @@ ZnBufferedReadStream >> readInto: collection startingAt: offset count: requested
 { #category : #accessing }
 ZnBufferedReadStream >> setToEnd [
 	
-	stream setToEnd
+	self position: stream size
 ]
 
 { #category : #private }


### PR DESCRIPTION
Fixes #8657 