### PR TITLE
RB - Fix rename shortcut

### DIFF
--- a/src/Calypso-SystemTools-Core/SycRenameMessageInSomePackagesCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycRenameMessageInSomePackagesCommand.extension.st
@@ -1,0 +1,20 @@
+Extension { #name : #SycRenameMessageInSomePackagesCommand }
+
+{ #category : #'*Calypso-SystemTools-Core' }
+SycRenameMessageInSomePackagesCommand class >> browserMenuOrder [
+	^ 3
+]
+
+{ #category : #'*Calypso-SystemTools-Core' }
+SycRenameMessageInSomePackagesCommand class >> methodShortcutActivation [
+	<classAnnotation>
+	
+	^CmdShortcutActivation by: $k meta for: ClyMethod asCalypsoItemContext
+]
+
+{ #category : #'*Calypso-SystemTools-Core' }
+SycRenameMessageInSomePackagesCommand class >> sourceCodeShortcutActivation [
+	<classAnnotation>
+	
+	^CmdShortcutActivation  by: $k meta for: ClyMethodSourceCodeContext
+]


### PR DESCRIPTION
I fixed the duplication of a shortcut of two different commands. I put Cmd + k as provisional command for the second command 

<img width="259" alt="imagen" src="https://user-images.githubusercontent.com/15729309/109468806-88b6a200-7a43-11eb-81a3-acd96779346a.png">
