### PR TITLE
8544 new debugger impossible to step into debugger complete to sender methods

### DIFF
--- a/src/NewTools-Debugger-Commands/StDebuggerToggleFilterStackCommand.class.st
+++ b/src/NewTools-Debugger-Commands/StDebuggerToggleFilterStackCommand.class.st
@@ -1,0 +1,24 @@
+"
+I toggle the stack filtering in the debugger on and off, and I trigger a debugger update.
+"
+Class {
+	#name : #StDebuggerToggleFilterStackCommand,
+	#superclass : #CmCommand,
+	#category : #'NewTools-Debugger-Commands'
+}
+
+{ #category : #default }
+StDebuggerToggleFilterStackCommand class >> defaultDescription [
+	^'Toggle stack filtering on and off'
+]
+
+{ #category : #default }
+StDebuggerToggleFilterStackCommand class >> defaultName [ 
+	^'Toggle stack filtering'
+]
+
+{ #category : #executing }
+StDebuggerToggleFilterStackCommand >> execute [
+	StDebuggerActionModel shouldFilterStack: StDebuggerActionModel shouldFilterStack not.
+	self context updateStep
+]

--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -182,6 +182,67 @@ StDebuggerActionModelTest >> testDefaultShouldFilterStack [
 	self assert: StDebuggerActionModel shouldFilterStack
 ]
 
+{ #category : #'tests - stack filtering' }
+StDebuggerActionModelTest >> testDynamicShouldFilterStack [
+
+	|mockDebugActionModel|
+	mockDebugActionModel := StMockDebuggerActionModel new.
+	
+	self assert: mockDebugActionModel filterStack.
+	
+	StDebuggerActionModel shouldFilterStack: true.
+	self assert: mockDebugActionModel shouldFilterStack.
+	
+	StDebuggerActionModel shouldFilterStack: false.
+	self deny: mockDebugActionModel shouldFilterStack 
+]
+
+{ #category : #'tests - stack filtering' }
+StDebuggerActionModelTest >> testDynamicShouldFilterStackUpdate [
+
+	|mockDebugActionModel context|
+	mockDebugActionModel := StMockDebuggerActionModel new.		
+	self assert: mockDebugActionModel filterStack.
+	self assert: mockDebugActionModel shouldFilterStack.
+	
+	context := Context
+		sender: nil
+		receiver: nil
+		method: Object >> #doesNotUnderstand:
+		arguments: #(#message).
+	mockDebugActionModel interruptedContext: context.
+	mockDebugActionModel stepInto: nil.
+	self deny: mockDebugActionModel filterStack.
+	self deny: mockDebugActionModel shouldFilterStack.
+	
+	mockDebugActionModel stepOver: nil.
+	self deny: mockDebugActionModel filterStack.
+	self deny: mockDebugActionModel shouldFilterStack.
+	
+	mockDebugActionModel := StMockDebuggerActionModel new.		
+	self assert: mockDebugActionModel filterStack.
+	self assert: mockDebugActionModel shouldFilterStack.
+	
+	context := Context
+		sender: nil
+		receiver: nil
+		method: Object >> #asString
+		arguments: #().
+	mockDebugActionModel interruptedContext: context.
+	mockDebugActionModel stepInto: nil.
+	self deny: mockDebugActionModel filterStack.
+	self deny: mockDebugActionModel shouldFilterStack.
+	
+	mockDebugActionModel stepOver: nil.
+	self assert: mockDebugActionModel filterStack.
+	self assert: mockDebugActionModel shouldFilterStack.
+	
+	
+	
+	
+	
+]
+
 { #category : #'tests - actions' }
 StDebuggerActionModelTest >> testFileOutMethod [
 	debugActionModel fileOutMethod: self.

--- a/src/NewTools-Debugger-Tests/StMockDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger-Tests/StMockDebuggerActionModel.class.st
@@ -5,7 +5,8 @@ Class {
 	#name : #StMockDebuggerActionModel,
 	#superclass : #StDebuggerActionModel,
 	#instVars : [
-		'tag'
+		'tag',
+		'interruptedContext'
 	],
 	#category : #'NewTools-Debugger-Tests-Utils'
 }
@@ -16,6 +17,23 @@ StMockDebuggerActionModel >> autoClassifyMessage: aMessage inClass: aClass [
 
 { #category : #context }
 StMockDebuggerActionModel >> computeInitialTopContext [
+]
+
+{ #category : #initialize }
+StMockDebuggerActionModel >> initialize [
+	super initialize.
+	self interruptedContext: (Context
+			 sender: nil
+			 receiver: nil
+			 method: Object >> #doesNotUnderstand:
+			 arguments: #( #message ))
+]
+
+{ #category : #accessing }
+StMockDebuggerActionModel >> interruptedContext: anObject [
+
+	interruptedContext := anObject.
+	topContext := anObject
 ]
 
 { #category : #accessing }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -738,7 +738,13 @@ StDebugger >> initializeStack [
 			self updateWindowTitle ] ].
 	stackHeader := self instantiate: StHeaderBar.
 	stackHeader label: 'Stack'.
-	stackHeader toolbarActions: (CmCommandGroup new register: (StDebuggerSettingsCommand forSpecWithIconNamed: #configuration); asSpecGroup)
+	stackHeader toolbarActions: (CmCommandGroup new
+			 register:
+				 ((StDebuggerToggleFilterStackCommand forSpecContext: self) 
+					  iconName: #changeSorter);
+			 register:
+				 (StDebuggerSettingsCommand forSpecWithIconNamed: #configuration);
+			 asSpecGroup)
 ]
 
 { #category : #initialization }

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -8,7 +8,8 @@ Class {
 		'debugger',
 		'session',
 		'contextPredicate',
-		'topContext'
+		'topContext',
+		'filterStack'
 	],
 	#classVars : [
 		'ShouldFilterStack'
@@ -116,10 +117,15 @@ StDebuggerActionModel >> fileOutMethod: aMethod [
 	aMethod methodClass fileOutMethod: aMethod selector
 ]
 
+{ #category : #accessing }
+StDebuggerActionModel >> filterStack [
+	^ filterStack
+]
+
 { #category : #'debug - stack' }
 StDebuggerActionModel >> filterStack: aStack [
 	| context contextsToReject |	
-	self class shouldFilterStack ifFalse: [  ^aStack ].
+	self shouldFilterStack ifFalse: [  ^aStack ].
 	context := aStack first.
 	contextsToReject := 0.
 
@@ -153,7 +159,8 @@ StDebuggerActionModel >> implement: aMessage classified: messageCategory inClass
 { #category : #initialize }
 StDebuggerActionModel >> initialize [
 	super initialize.
-	self computeInitialTopContext
+	self computeInitialTopContext.
+	filterStack := true
 ]
 
 { #category : #accessing }
@@ -302,6 +309,12 @@ StDebuggerActionModel >> session: aDebugSession [
 	session := aDebugSession
 ]
 
+{ #category : #'debug - stack' }
+StDebuggerActionModel >> shouldFilterStack [
+
+	^ self filterStack and: [ self class shouldFilterStack ]
+]
+
 { #category : #context }
 StDebuggerActionModel >> statusStringForContext [
 
@@ -310,12 +323,18 @@ StDebuggerActionModel >> statusStringForContext [
 
 { #category : #'debug - stepping' }
 StDebuggerActionModel >> stepInto: aContext [ 
+	filterStack := false.
 	self session stepInto: aContext.
-	self updateTopContext
+	self updateTopContext.
+
 ]
 
 { #category : #'debug - stepping' }
 StDebuggerActionModel >> stepOver: aContext [
+	filterStack := (self topContext method hasPragmaNamed:
+		                #debuggerCompleteToSender)
+		               ifTrue: [ false ]
+		               ifFalse: [ self class shouldFilterStack ].
 	self session stepOver: aContext.
 	self updateTopContext
 ]


### PR DESCRIPTION
Fixes #8544

Dynamic filtering of the stack:
- stepping **into** kernel code is now possible
- stepping **over** filters stack if we're not into kernel code (if we are, filtering is off)
- global disabling of stack filtering overrides the dynamic filtering
- button in the top-right side of the debugger stack to toggle stack filtering on/off

About the button:
- there is no mention if the stack is currently filtered or not
- it is not explicit what the button do, we have to look at the fly-by-help to see it
Those last two points are not perfect, but to me this can work as is for now as it should satisfies expert developers while begginners will not care. The other option was a checkbox, but it will not work as is in the spec presenter.
I suggest to merge for now and to open another usability issue for that particular point. This could make a nice introduction issue for new contributors.

Short demo:

https://user-images.githubusercontent.com/26929529/109515435-5b034480-7aa7-11eb-9397-85bc166588bd.mov

