### PR TITLE
RB - Remove unnecessary initialization

### DIFF
--- a/src/Refactoring-Changes/RBRemoveClassChange.class.st
+++ b/src/Refactoring-Changes/RBRemoveClassChange.class.st
@@ -48,8 +48,8 @@ RBRemoveClassChange >> changeString [
 
 { #category : #printing }
 RBRemoveClassChange >> initialize [ 
-	super initialize.
-	onSystemDictionary ifNil: [ onSystemDictionary := Smalltalk globals ].
+	super initialize."
+	onSystemDictionary ifNil: [ onSystemDictionary := Smalltalk globals ]."
 	changeFactory := RBRefactoryChangeManager changeFactory
 ]
 

--- a/src/Refactoring-Changes/RBRemoveClassChange.class.st
+++ b/src/Refactoring-Changes/RBRemoveClassChange.class.st
@@ -48,8 +48,7 @@ RBRemoveClassChange >> changeString [
 
 { #category : #printing }
 RBRemoveClassChange >> initialize [ 
-	super initialize."
-	onSystemDictionary ifNil: [ onSystemDictionary := Smalltalk globals ]."
+	super initialize.
 	changeFactory := RBRefactoryChangeManager changeFactory
 ]
 


### PR DESCRIPTION
Fixes #3175

this issue was already fixed, just modify an unnecessary initialization because its superclass already initialized that instance variable 