### PR TITLE
Move SDL_HINT_RENDER_SCALE_QUALITY setting to non-OSX platforms

### DIFF
--- a/src/OSWindow-SDL2/SDL2.class.st
+++ b/src/OSWindow-SDL2/SDL2.class.st
@@ -250,8 +250,7 @@ SDL2 class >> initLibrary [
 	
 	self
 		setHint: SDL_HINT_VIDEO_ALLOW_SCREENSAVER value: '1';
-		setHint: SDL_HINT_NO_SIGNAL_HANDLERS value: '1';
-		setHint: SDL_HINT_RENDER_SCALE_QUALITY value: '1'.
+		setHint: SDL_HINT_NO_SIGNAL_HANDLERS value: '1'.
 		
 	self init: SDL_INIT_NOPARACHUTE.
 	Session := Smalltalk session.

--- a/src/OSWindow-SDL2/SDLAbstractPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLAbstractPlatform.class.st
@@ -7,6 +7,9 @@ Get the corresponding class to use through
 Class {
 	#name : #SDLAbstractPlatform,
 	#superclass : #Object,
+	#pools : [
+		'SDL2ConstantsHint'
+	],
 	#category : #'OSWindow-SDL2-Bindings'
 }
 

--- a/src/OSWindow-SDL2/SDLNullPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLNullPlatform.class.st
@@ -14,5 +14,8 @@ SDLNullPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
 { #category : #initialization }
 SDLNullPlatform >> initPlatformSpecific [
 
+	"For windows and Unix, we activate linearization.
+	This does not work properly on OSX with retina display, blurrying the rendering"
 	
+	SDL2 setHint: SDL_HINT_RENDER_SCALE_QUALITY value: '1'
 ]


### PR DESCRIPTION
This is a workaround for https://github.com/pharo-project/pharo/issues/8688

This does not fix the pixelation when scaling, but scaling is not a main concern for Pharo9 release