### PR TITLE
8698-Failing-on-CI-ReleaseTesttestThatAllMethodsArePackaged

### DIFF
--- a/src/TraitsV2-Tests/T2TraitTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitTest.class.st
@@ -46,6 +46,31 @@ T2TraitTest >> createT2 [
 ]
 
 { #category : #tests }
+T2TraitTest >> createT3 [
+	| t3 |
+	
+	"This is a trait with a method with a pragma"
+	t3 := self newTrait: #T3 with: #().
+	t3
+		compile:
+			'aMethod
+			<aPragma>
+			
+			^ 42
+				'.
+
+	t3 class
+		compile:
+			'aClassMethod
+			<aPragma>
+			
+			^ 42
+				'.
+
+	^ t3
+]
+
+{ #category : #tests }
 T2TraitTest >> testClassHavingAnInstanceVariableUsersDifferenThanUsers [
 	| t1 aClass |
 
@@ -56,6 +81,22 @@ T2TraitTest >> testClassHavingAnInstanceVariableUsersDifferenThanUsers [
 	
 	self assert: (aClass class allSlots anySatisfy: [:e | e name = #users]).
 	self assert: (aClass class slotNamed: #users) definingClass equals: t1
+
+]
+
+{ #category : #tests }
+T2TraitTest >> testClassTraitThatHasAPragmaHasCorrectTraitSourceAfterRecompile [
+	| t3 aClass |
+
+	t3 := self createT3.
+
+	aClass := self newClass: #C1 superclass: Object with: #() uses: {t3}.
+	
+	self assert: (aClass class >> #aClassMethod) traitSource equals: t3 class asTraitComposition.
+	
+	(aClass class >> #aClassMethod) recompile.
+	
+	self assert: (aClass class >> #aClassMethod) traitSource equals: t3 class asTraitComposition.
 
 ]
 
@@ -352,6 +393,21 @@ T2TraitTest >> testTraitHaveUsersInstanceVariable [
 	self assert: (aClass allSlots anySatisfy: [:e | e name = #users]).
 	self assert: (aClass slotNamed: #users) definingClass equals: t1
 
+]
+
+{ #category : #tests }
+T2TraitTest >> testTraitThatHasAPragmaHasCorrectTraitSourceAfterRecompile [
+	| t3 aClass |
+
+	t3 := self createT3.
+
+	aClass := self newClass: #C1 superclass: Object with: #() uses: {t3}.
+	
+	self assert: (aClass >> #aMethod) traitSource equals: t3 asTraitComposition.
+	
+	(aClass >> #aMethod) recompile.
+	
+	self assert: (aClass >> #aMethod) traitSource equals: t3 asTraitComposition.
 ]
 
 { #category : #tests }

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -106,6 +106,9 @@ TraitedClass >> addSelector: selector withMethod: compiledMethod [
 { #category : #'accessing method dictionary' }
 TraitedClass >> addSelector: selector withRecompiledMethod: compiledMethod [ 
 	"When a new selector is installed in a class I insert the selector in the local methodDict and propagate the changes to my users"
+
+	compiledMethod isFromTrait 
+		ifTrue: [ ^ super addSelector: selector withRecompiledMethod: compiledMethod ].
 	
 	self localMethodDict at: selector put: compiledMethod.
 	super addSelector: selector withRecompiledMethod: compiledMethod.
@@ -275,6 +278,27 @@ TraitedClass >> recategorizeSelector: selector from: oldCategory to: newCategory
 		self notifyOfRecategorizedSelector: e from: oldCategory to: newCategory ].
 	
 	self organization removeEmptyCategories
+]
+
+{ #category : #recompilation }
+TraitedClass >> recompile: selector from: oldClass [
+	"Compile the method associated with selector in the receiver's method dictionary."
+
+	| method newMethod |
+	method := oldClass compiledMethodAt: selector.
+	newMethod := self compiler
+				source: (oldClass sourceCodeAt: selector);
+				class: self;
+				failBlock: [^ self];
+				compiledMethodTrailer: method trailer;
+				compile.   "Assume OK after proceed from SyntaxError"
+	selector == newMethod selector ifFalse: [self error: 'selector changed!'].
+	
+	method properties 
+		at: #traitSource 
+		ifPresent: [ :aSource | newMethod propertyAt: #traitSource put: aSource].
+	
+	self addSelector: selector withRecompiledMethod: newMethod.
 ]
 
 { #category : #'trait-composition' }

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -47,6 +47,9 @@ TraitedMetaclass >> addSelector: selector withMethod: compiledMethod [
 { #category : #'accessing method dictionary' }
 TraitedMetaclass >> addSelector: selector withRecompiledMethod: compiledMethod [ 
 
+	compiledMethod isFromTrait 
+		ifTrue: [ ^ super addSelector: selector withRecompiledMethod: compiledMethod ].
+
 	self localMethodDict at: selector put: compiledMethod.
 	super addSelector: selector withRecompiledMethod: compiledMethod.
 	TraitChange addSelector: selector on: self
@@ -304,6 +307,27 @@ TraitedMetaclass >> recategorizeSelector: selector from: oldCategory to: newCate
 		self notifyOfRecategorizedSelector: e from: oldCategory to: newCategory ].
 	
 	self organization removeEmptyCategories
+]
+
+{ #category : #recompilation }
+TraitedMetaclass >> recompile: selector from: oldClass [
+	"Compile the method associated with selector in the receiver's method dictionary."
+
+	| method newMethod |
+	method := oldClass compiledMethodAt: selector.
+	newMethod := self compiler
+				source: (oldClass sourceCodeAt: selector);
+				class: self;
+				failBlock: [^ self];
+				compiledMethodTrailer: method trailer;
+				compile.   "Assume OK after proceed from SyntaxError"
+	selector == newMethod selector ifFalse: [self error: 'selector changed!'].
+	
+	method properties 
+		at: #traitSource 
+		ifPresent: [ :aSource | newMethod propertyAt: #traitSource put: aSource].
+	
+	self addSelector: selector withRecompiledMethod: newMethod.
 ]
 
 { #category : #traits }


### PR DESCRIPTION
Fix #8698
Fix #8697

The recompilation should keep the properties set by the trait infrastructure.