### PR TITLE
8720-RBTraitedMetaclass-has-unused-ivar

### DIFF
--- a/src/Refactoring-Core/RBTraitedMetaclass.class.st
+++ b/src/Refactoring-Core/RBTraitedMetaclass.class.st
@@ -7,11 +7,5 @@ My  namespace usally knows me and my non meta class.
 Class {
 	#name : #RBTraitedMetaclass,
 	#superclass : #RBMetaclass,
-	#instVars : [
-		'localMethods',
-		'composition',
-		'baseLocalMethods',
-		'baseComposition'
-	],
 	#category : #'Refactoring-Core-Model'
 }

--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -46,7 +46,7 @@ NoUnusedVariablesLeftTest >> testNoUnusedInstanceVariablesLeft [
 	
 	"we have 28 left, there are issue tracker entries for those.
  	By testing for these, we avoid that new cases are added"
- 	self assert: remaining size <= 28
+ 	self assert: remaining size <= 27
 ]
 
 { #category : #testing }


### PR DESCRIPTION
- remove unused ivars from RBTraitedMetaclass
- reduce count in testNoUnusedInstanceVariablesLeft

fixes #8720

