### PR TITLE
SptSpotterProcessor has an ivar "order" that is not used

### DIFF
--- a/src/GT-Spotter-Processors/SptSpotterProcessor.class.st
+++ b/src/GT-Spotter-Processors/SptSpotterProcessor.class.st
@@ -15,7 +15,6 @@ Class {
 	#name : #SptSpotterProcessor,
 	#superclass : #AbstractSpotterProcessor,
 	#instVars : [
-		'order',
 		'filter',
 		'results',
 		'query',


### PR DESCRIPTION
Fix #8722