### PR TITLE
Zodiac: ZdcAbstractSocketStream and ZdcAbstractSSLSession as abstract classes

### DIFF
--- a/src/Zodiac-Core/ZdcAbstractSSLSession.class.st
+++ b/src/Zodiac-Core/ZdcAbstractSSLSession.class.st
@@ -18,6 +18,12 @@ Class {
 	#category : #'Zodiac-Core'
 }
 
+{ #category : #testing }
+ZdcAbstractSSLSession class >> isAbstract [ 
+
+	^self == ZdcAbstractSSLSession
+]
+
 { #category : #operations }
 ZdcAbstractSSLSession >> accept: srcBuf from: start to: stop into: dstBuf [
 	"Start or continue the server handshake using the given input token"

--- a/src/Zodiac-Core/ZdcAbstractSocketStream.class.st
+++ b/src/Zodiac-Core/ZdcAbstractSocketStream.class.st
@@ -18,6 +18,12 @@ Class {
 	#category : #'Zodiac-Core'
 }
 
+{ #category : #testing }
+ZdcAbstractSocketStream class >> isAbstract [
+
+	^self == ZdcAbstractSocketStream 
+]
+
 { #category : #'instance creation' }
 ZdcAbstractSocketStream class >> on: object [
 	^ (self basicNew)


### PR DESCRIPTION
 
Fix #8734