### PR TITLE
Cleanup method categories in TKTAbstractExecutor

### DIFF
--- a/src/TaskIt/TKTAbstractExecutor.class.st
+++ b/src/TaskIt/TKTAbstractExecutor.class.st
@@ -33,13 +33,13 @@ TKTAbstractExecutor >> initialize [
 	exceptionHandler := TKTConfiguration errorHandler
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TKTAbstractExecutor >> isBusy [
 
 	^ busy
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TKTAbstractExecutor >> isFree [
 
 	^ busy not
@@ -57,12 +57,12 @@ TKTAbstractExecutor >> noteFree [
 	busy := false
 ]
 
-{ #category : #polimorfism }
+{ #category : #polymorphism }
 TKTAbstractExecutor >> start [
  " nothing to do "
 ]
 
-{ #category : #polimorfsms }
+{ #category : #polymorphism }
 TKTAbstractExecutor >> stop [
 
 ]

--- a/src/TaskIt/TTaskExecutor.trait.st
+++ b/src/TaskIt/TTaskExecutor.trait.st
@@ -27,18 +27,18 @@ TTaskExecutor >> executeTask: aTaskExecution [
 		do: [ :error | self exceptionHandler handleException: error ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TTaskExecutor >> isDebuggingCompatible [
 	^ false
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TTaskExecutor >> noteBusy [
 
 	self shouldBeImplemented
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TTaskExecutor >> noteFree [
 
 	self shouldBeImplemented


### PR DESCRIPTION
Fix #8740