### PR TITLE
Proper method category names in TKTRunner and subclasses

### DIFF
--- a/src/TaskIt/TKTAbstractExecutor.class.st
+++ b/src/TaskIt/TKTAbstractExecutor.class.st
@@ -45,13 +45,13 @@ TKTAbstractExecutor >> isFree [
 	^ busy not
 ]
 
-{ #category : #accessing }
+{ #category : #'as yet unclassified' }
 TKTAbstractExecutor >> noteBusy [
 
 	busy := true
 ]
 
-{ #category : #accessing }
+{ #category : #'as yet unclassified' }
 TKTAbstractExecutor >> noteFree [
 
 	busy := false

--- a/src/TaskIt/TKTLocalProcessTaskRunner.class.st
+++ b/src/TaskIt/TKTLocalProcessTaskRunner.class.st
@@ -28,17 +28,17 @@ Class {
 	#category : #'TaskIt-Kernel'
 }
 
-{ #category : #schedulling }
+{ #category : #scheduling }
 TKTLocalProcessTaskRunner >> isLocalThreadRunner [
 	^ true
 ]
 
-{ #category : #schedulling }
+{ #category : #scheduling }
 TKTLocalProcessTaskRunner >> scheduleTaskExecution: aTaskExecution [
 	self executeTask: aTaskExecution
 ]
 
-{ #category : #polimorfism }
+{ #category : #polymorphism }
 TKTLocalProcessTaskRunner >> start [
 
 ]

--- a/src/TaskIt/TKTNewProcessTaskRunner.class.st
+++ b/src/TaskIt/TKTNewProcessTaskRunner.class.st
@@ -51,7 +51,7 @@ Class {
 	#category : #'TaskIt-Kernel'
 }
 
-{ #category : #schedulling }
+{ #category : #scheduling }
 TKTNewProcessTaskRunner >> scheduleTaskExecution: aTaskExecution [
 	TKTConfiguration processProvider
 		createProcessDoing:

--- a/src/TaskIt/TKTUIProcessTaskRunner.class.st
+++ b/src/TaskIt/TKTUIProcessTaskRunner.class.st
@@ -4,17 +4,17 @@ Class {
 	#category : #'TaskIt-Kernel'
 }
 
-{ #category : #schedulling }
+{ #category : #scheduling }
 TKTUIProcessTaskRunner >> isUIRunner [
 	^ true 
 ]
 
-{ #category : #schedulling }
+{ #category : #scheduling }
 TKTUIProcessTaskRunner >> scheduleTaskExecution: aTaskExecution [
 	WorldState addDeferredUIMessage: [ self executeTask: aTaskExecution ]
 ]
 
-{ #category : #polimorfsms }
+{ #category : #polymorphism }
 TKTUIProcessTaskRunner >> start [
 
 ]


### PR DESCRIPTION
Fix #8742