### PR TITLE
Configuring the spec debugger to force contexts stepping into quick methods

### DIFF
--- a/src/Kernel-Tests/ContextTest.class.st
+++ b/src/Kernel-Tests/ContextTest.class.st
@@ -265,6 +265,16 @@ ContextTest >> testStepIntoQuickMethodBoolean [
 ]
 
 { #category : #tests }
+ContextTest >> testStepIntoQuickMethodInCompiledBlock [
+
+	|newContext|
+	newContext := [ ] asContext.
+	self deny: newContext method stepIntoQuickMethods.
+	newContext stepIntoQuickMethod: true.
+	self deny: newContext method stepIntoQuickMethods
+]
+
+{ #category : #tests }
 ContextTest >> testStepIntoReturnSelfMethod [
 
 	|newContext quickMethod|

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -2049,7 +2049,7 @@ Context >> stepIntoQuickMethod [
 
 { #category : #'debugger access' }
 Context >> stepIntoQuickMethod: aBoolean [ 
-	self compiledCode isBlock ifTrue: [ ^self ].
+	self compiledCode isCompiledBlock ifTrue: [ ^self ].
 	self compiledCode stepIntoQuickMethods: aBoolean
 ]
 

--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -516,6 +516,7 @@ StDebuggerActionModelTest >> testStepInto [
 	|ctx|
 	ctx := session interruptedContext.
 	debugActionModel stepInto: ctx.
+	self assert: ctx stepIntoQuickMethod.
 	self assert: session interruptedContext sender identicalTo: ctx.
 	self assert: session stack second identicalTo: ctx
 ]

--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -211,11 +211,11 @@ StDebuggerActionModelTest >> testDynamicShouldFilterStackUpdate [
 		method: Object >> #doesNotUnderstand:
 		arguments: #(#message).
 	mockDebugActionModel interruptedContext: context.
-	mockDebugActionModel stepInto: nil.
+	mockDebugActionModel stepInto: context.
 	self deny: mockDebugActionModel filterStack.
 	self deny: mockDebugActionModel shouldFilterStack.
 	
-	mockDebugActionModel stepOver: nil.
+	mockDebugActionModel stepOver: context.
 	self deny: mockDebugActionModel filterStack.
 	self deny: mockDebugActionModel shouldFilterStack.
 	
@@ -229,11 +229,11 @@ StDebuggerActionModelTest >> testDynamicShouldFilterStackUpdate [
 		method: Object >> #asString
 		arguments: #().
 	mockDebugActionModel interruptedContext: context.
-	mockDebugActionModel stepInto: nil.
+	mockDebugActionModel stepInto: context.
 	self deny: mockDebugActionModel filterStack.
 	self deny: mockDebugActionModel shouldFilterStack.
 	
-	mockDebugActionModel stepOver: nil.
+	mockDebugActionModel stepOver: context.
 	self assert: mockDebugActionModel filterStack.
 	self assert: mockDebugActionModel shouldFilterStack.
 	
@@ -580,21 +580,22 @@ StDebuggerActionModelTest >> testUpdateTopContext [
 
 { #category : #'tests - contexts' }
 StDebuggerActionModelTest >> testUpdateTopContextAfterSessionOperation [
-	|mockDebugActionModel|
+	|mockDebugActionModel context|
+	context := [  ] asContext.
 	mockDebugActionModel := StMockDebuggerActionModel new.
-	mockDebugActionModel stepInto: nil.
+	mockDebugActionModel stepInto: context.
 	self assert: mockDebugActionModel tag equals: #updateTopContext.
 	
 	mockDebugActionModel := StMockDebuggerActionModel new.
-	mockDebugActionModel stepOver: nil.
+	mockDebugActionModel stepOver: context.
 	self assert: mockDebugActionModel tag equals: #updateTopContext.
 	
 	mockDebugActionModel := StMockDebuggerActionModel new.
-	mockDebugActionModel stepThrough: nil.
+	mockDebugActionModel stepThrough: context.
 	self assert: mockDebugActionModel tag equals: #updateTopContext.
 	
 	mockDebugActionModel := StMockDebuggerActionModel new.
-	mockDebugActionModel restartContext: nil.
+	mockDebugActionModel restartContext: context.
 	self assert: mockDebugActionModel tag equals: #updateTopContext.
 	
 	mockDebugActionModel := StMockDebuggerActionModel new.

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -324,6 +324,7 @@ StDebuggerActionModel >> statusStringForContext [
 { #category : #'debug - stepping' }
 StDebuggerActionModel >> stepInto: aContext [ 
 	filterStack := false.
+	aContext stepIntoQuickMethod: true.
 	self session stepInto: aContext.
 	self updateTopContext.
 


### PR DESCRIPTION
Just configuring the debugger model to correctly perform step into into contexts