### PR TITLE
Update UnhandledError to reflect the ability for the underlying Exception to resume.

### DIFF
--- a/src/Kernel-Tests/ExceptionTest.class.st
+++ b/src/Kernel-Tests/ExceptionTest.class.st
@@ -53,6 +53,20 @@ ExceptionTest >> runWithNoHandlers: aBlock [
 ]
 
 { #category : #test }
+ExceptionTest >> testDefaultAction [
+	"Ensure that the resuming an UnhandledError when the underlying
+	Exception is resumable, results in the resumption value serving
+	as the result of the original #signal."
+
+	| expected result |
+	expected := #marker.
+	[ result := MyResumableTestError signal ]
+		on: UnhandledError
+		do: [ :ex | ex resume: expected ].
+	self assert: result equals: expected
+]
+
+{ #category : #test }
 ExceptionTest >> testDefaultDescription [
    "Tests that the description of an Exception, is the defaultDescription"
    |anException|
@@ -319,6 +333,19 @@ ExceptionTest >> testResumablePass [
 			ex pass.
 			ex return: 5 ].
 	self assert: result equals: 4
+]
+
+{ #category : #test }
+ExceptionTest >> testResumeUnresumableUnhandledError [
+	"Ensure that the resuming an UnhandledError results in
+	an IllegalResumeAttempt."
+
+	self
+		should: [
+	[ MyTestError signal ]
+		on: UnhandledError
+		do: [ :ex | ex resume: nil ]]
+		raise: IllegalResumeAttempt
 ]
 
 { #category : #'tests - exceptiontester' }

--- a/src/Kernel-Tests/ExceptionTest.class.st
+++ b/src/Kernel-Tests/ExceptionTest.class.st
@@ -60,9 +60,10 @@ ExceptionTest >> testDefaultAction [
 
 	| expected result |
 	expected := #marker.
-	[ result := MyResumableTestError signal ]
-		on: UnhandledError
-		do: [ :ex | ex resume: expected ].
+	self runWithNoHandlers: [ 
+		[ result := MyResumableTestError signal ]
+			on: UnhandledError
+			do: [ :ex | ex resume: expected ] ].
 	self assert: result equals: expected
 ]
 
@@ -341,12 +342,15 @@ ExceptionTest >> testResumeNonresumableUnhandledError [
 	"Ensure that the resuming an UnhandledError results in
 	an IllegalResumeAttempt."
 
+	| signalOccurred |
 	self
-		should: [ 
-			[ MyTestError signal ]
+		runWithNoHandlers: [ 
+			[[ MyTestError signal ]
 				on: UnhandledError
-				do: [ :ex | ex resume: nil ] ]
-		raise: IllegalResumeAttempt
+				do: [ :ex | ex resume: nil ]]
+			on: IllegalResumeAttempt
+			do: [:ex | signalOccurred := true. ex return ]].
+	self assert: signalOccurred
 ]
 
 { #category : #'tests - exceptiontester' }

--- a/src/Kernel-Tests/ExceptionTest.class.st
+++ b/src/Kernel-Tests/ExceptionTest.class.st
@@ -336,15 +336,16 @@ ExceptionTest >> testResumablePass [
 ]
 
 { #category : #test }
-ExceptionTest >> testResumeUnresumableUnhandledError [
+ExceptionTest >> testResumeNonresumableUnhandledError [
+
 	"Ensure that the resuming an UnhandledError results in
 	an IllegalResumeAttempt."
 
 	self
-		should: [
-	[ MyTestError signal ]
-		on: UnhandledError
-		do: [ :ex | ex resume: nil ]]
+		should: [ 
+			[ MyTestError signal ]
+				on: UnhandledError
+				do: [ :ex | ex resume: nil ] ]
 		raise: IllegalResumeAttempt
 ]
 

--- a/src/Kernel/Exception.class.st
+++ b/src/Kernel/Exception.class.st
@@ -123,7 +123,7 @@ Exception >> defaultAction [
 	Note about naming here: 
 	Even if not all exceptions are errors the absence of a handler for signaled exception is considered as an error by default. Therefore #defaultAction for Exception raises an error, an UnhandledError"
 
-	self raiseUnhandledError
+	^ self raiseUnhandledError
 ]
 
 { #category : #default }
@@ -261,7 +261,7 @@ Exception >> privHandlerContext: aContextTag [
 Exception >> raiseUnhandledError [
 	"No one has handled this error, but now give them a chance to decide how to debug it.  If none handle this either then open debugger (see UnhandedError>>#defaultAction)"
 
-	UnhandledError signalForException: self
+	^ UnhandledError signalForException: self
 ]
 
 { #category : #accessing }

--- a/src/Kernel/UnhandledError.class.st
+++ b/src/Kernel/UnhandledError.class.st
@@ -55,5 +55,5 @@ UnhandledError >> exception: anError [
 { #category : #testing }
 UnhandledError >> isResumable [
 	
-	^ false
+	^ true
 ]

--- a/src/Kernel/UnhandledError.class.st
+++ b/src/Kernel/UnhandledError.class.st
@@ -54,6 +54,10 @@ UnhandledError >> exception: anError [
 
 { #category : #testing }
 UnhandledError >> isResumable [
-	
-	^ true
+
+	"UnhandledError can be signaled for more than non-resumable Errors.
+	If UnhandledError reflects the underlying Exception, we are able to
+	resume the underlying Exception."
+
+	^ self exception isResumable
 ]


### PR DESCRIPTION
The changes in this pull request were suggested by @martinmcclure on Pharo's discord server. The changes enable unhandled exception processing techniques used in https://github.com/GemTalk/RemoteServiceReplication to function GemStone and Pharo.