### PR TITLE
8694-Instance-of-DoItVariable-did-not-understand-markRead 

### DIFF
--- a/src/Kernel/DoItVariable.class.st
+++ b/src/Kernel/DoItVariable.class.st
@@ -179,6 +179,31 @@ DoItVariable >> key [
 	^self name
 ]
 
+{ #category : #'read/write usage' }
+DoItVariable >> markEscapingRead [
+	actualVariable markEscapingRead
+]
+
+{ #category : #'read/write usage' }
+DoItVariable >> markEscapingWrite [
+	actualVariable markEscapingWrite
+]
+
+{ #category : #'read/write usage' }
+DoItVariable >> markRead [
+	actualVariable markRead
+]
+
+{ #category : #'read/write usage' }
+DoItVariable >> markRepeatedWrite [
+	actualVariable markRepeatedWrite
+]
+
+{ #category : #'read/write usage' }
+DoItVariable >> markWrite [
+	actualVariable markWrite
+]
+
 { #category : #printing }
 DoItVariable >> printOn: aStream [ 
 	super printOn: aStream.

--- a/src/Kernel/DoItVariable.class.st
+++ b/src/Kernel/DoItVariable.class.st
@@ -181,27 +181,27 @@ DoItVariable >> key [
 
 { #category : #'read/write usage' }
 DoItVariable >> markEscapingRead [
-	actualVariable markEscapingRead
+	"ignored, the escape status of the actualVariable does not change"
 ]
 
 { #category : #'read/write usage' }
 DoItVariable >> markEscapingWrite [
-	actualVariable markEscapingWrite
+	"ignored, the escape status of the actualVariable does not change"
 ]
 
 { #category : #'read/write usage' }
 DoItVariable >> markRead [
-	actualVariable markRead
+	"ignored, the escape status of the actualVariable does not change"
 ]
 
 { #category : #'read/write usage' }
 DoItVariable >> markRepeatedWrite [
-	actualVariable markRepeatedWrite
+	"ignored, the escape status of the actualVariable does not change"
 ]
 
 { #category : #'read/write usage' }
 DoItVariable >> markWrite [
-	actualVariable markWrite
+	"ignored, the escape status of the actualVariable does not change"
 ]
 
 { #category : #printing }

--- a/src/Slot-Tests/DoItVariableTest.class.st
+++ b/src/Slot-Tests/DoItVariableTest.class.st
@@ -71,7 +71,9 @@ DoItVariableTest >> testReadCompilation [
 	| temp var ast doIt |
 	temp := 100.
 	var := DoItVariable named: #temp fromContext: thisContext.
-	ast := [ temp + 2 ] sourceNode body asDoit doSemanticAnalysis.
+	[ast := [ temp + 2 ] sourceNode body asDoit doSemanticAnalysis]
+		on: OCUndeclaredVariableWarning 
+		do: [ :ex |  ex resume: ex declareUndefined].
 	ast variableNodes first variable: var.
 	doIt := ast generateWithSource.
 	
@@ -103,7 +105,9 @@ DoItVariableTest >> testWriteCompilation [
 	| temp var ast doIt |
 	temp := 100.
 	var := DoItVariable named: #temp fromContext: thisContext.
-	ast := [ temp := 500 ] sourceNode body asDoit doSemanticAnalysis.
+	[ast := [ temp := 500 ] sourceNode body asDoit doSemanticAnalysis] 
+		on: OCUndeclaredVariableWarning 
+		do: [ :ex |  ex resume: ex declareUndefined].
 	ast variableNodes first variable: var.
 	doIt := ast generateWithSource.
 	doIt valueWithReceiver: self arguments: #().


### PR DESCRIPTION
DoItVariable needs to forward the read/write usage messages as it can wrap a temporary variable.

fixes #8694

