### PR TITLE
8775-Press-red-exclamation-mark-on-the-middle--raises-an-error

### DIFF
--- a/src/SystemCommands-ClassCommands/SycOpenClassMenuCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycOpenClassMenuCommand.class.st
@@ -44,12 +44,3 @@ SycOpenClassMenuCommand >> cmCommandClass [
 SycOpenClassMenuCommand >> defaultMenuItemName [
 	^'Refactorings'
 ]
-
-{ #category : #execution }
-SycOpenClassMenuCommand >> execute [
-
-	context selectedTextInterval ifEmpty: [ 
-		context showSourceNode].
-	
-	super execute
-]


### PR DESCRIPTION
The context does not implement #selectedTextInterval or #showSourceNode, just removing the test seems to make it work

fixes #8775


