### PR TITLE
Changed ClyOldMessageBrowserAdapter>>open to using realParent to handle cases where parent is nil

### DIFF
--- a/src/Calypso-SystemTools-OldToolCompatibillity/ClyOldMessageBrowserAdapter.class.st
+++ b/src/Calypso-SystemTools-OldToolCompatibillity/ClyOldMessageBrowserAdapter.class.st
@@ -125,7 +125,7 @@ ClyOldMessageBrowserAdapter >> open [
 		thenCollect: [ :each | each compiledMethod ].
 	comments := messages 
 		select: [:each | each isRingObject and: [ each isComment  ]]
-		thenCollect: [ :each | ClyClassComment of: each parent realClass ].
+		thenCollect: [ :each | ClyClassComment of: each realParent ].
 	query := ClyOldMessageBrowserQuery named: title with: methods asOrderedCollection, comments.
 	query
 		criteriaString: autoSelect;


### PR DESCRIPTION
My proposed change to solve Issue #8778.
I am not very familiar with Pharo, so I am not 100% sure this is the correct solution.
If parent is not nil the result will be the same, given the implementation of realParent.