### PR TITLE
RB - Introduce new refactoring "Copy package"

### DIFF
--- a/src/Calypso-SystemTools-FullBrowser/SycCopyPackageCommand.extension.st
+++ b/src/Calypso-SystemTools-FullBrowser/SycCopyPackageCommand.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #SycCopyPackageCommand }
+
+{ #category : #'*Calypso-SystemTools-FullBrowser' }
+SycCopyPackageCommand class >> fullBrowserMenuActivation [
+	<classAnnotation>
+	
+	^CmdContextMenuActivation byRootGroupItemOrder: 1.1 for: ClyFullBrowserPackageContext 
+]
+
+{ #category : #'*Calypso-SystemTools-FullBrowser' }
+SycCopyPackageCommand class >> fullBrowserShortcutActivation [
+	<classAnnotation>
+	
+	^CmdShortcutActivation by: $c meta for: ClyFullBrowserPackageContext
+]

--- a/src/Refactoring-Changes/RBAddPackageChange.class.st
+++ b/src/Refactoring-Changes/RBAddPackageChange.class.st
@@ -1,0 +1,40 @@
+"
+I am a refactory change for a package creating. The RBRefactory api is implemented in my super class, I just define the concrete ""package"" creating.
+"
+Class {
+	#name : #RBAddPackageChange,
+	#superclass : #RBRefactoryPackageChange,
+	#instVars : [
+		'packageName'
+	],
+	#category : #'Refactoring-Changes'
+}
+
+{ #category : #adding }
+RBAddPackageChange class >> addPackageNamed: aString [
+	^ self new addPackageNamed: aString
+]
+
+{ #category : #adding }
+RBAddPackageChange >> addPackageNamed: aString [
+	packageName := aString
+]
+
+{ #category : #converting }
+RBAddPackageChange >> asUndoOperation [
+	^ changeFactory removePackageNamed: packageName
+]
+
+{ #category : #private }
+RBAddPackageChange >> primitiveExecute [
+	RPackageOrganizer default createPackageNamed: packageName
+]
+
+{ #category : #printing }
+RBAddPackageChange >> printOn: aStream [ 
+	aStream
+		nextPutAll: 'RPackageOrganizer default ';
+		nextPutAll: #createPackageNamed:;
+		nextPutAll: packageName;
+		nextPut: $!
+]

--- a/src/Refactoring-Changes/RBCompositeRefactoryChange.class.st
+++ b/src/Refactoring-Changes/RBCompositeRefactoryChange.class.st
@@ -52,6 +52,11 @@ RBCompositeRefactoryChange >> addInstanceVariable: variableName to: aClass [
 ]
 
 { #category : #'refactory-changes' }
+RBCompositeRefactoryChange >> addPackageNamed: aString [
+	^ self addChange: (changeFactory addPackageNamed: aString)
+]
+
+{ #category : #'refactory-changes' }
 RBCompositeRefactoryChange >> addPool: aPoolVariable to: aClass [ 
 	^ self addChange: (changeFactory addPoolVariable: aPoolVariable to: aClass)
 ]

--- a/src/Refactoring-Changes/RBRefactoryChangeFactory.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeFactory.class.st
@@ -63,6 +63,11 @@ RBRefactoryChangeFactory >> addMethodSource: sourceCode in: aClass for: aControl
 			compile: sourceCode in: aClass for: aController
 ]
 
+{ #category : #'refactory-changes-packages' }
+RBRefactoryChangeFactory >> addPackageNamed: aString [
+	^ RBAddPackageChange addPackageNamed: aString
+]
+
 { #category : #'refactory-changes-variables' }
 RBRefactoryChangeFactory >> addPoolVariable: variableName to: aClass [
 	^ RBAddPoolVariableChange add: variableName to: aClass
@@ -106,6 +111,11 @@ RBRefactoryChangeFactory >> removeInstanceVariable: variableName from: aClass [
 { #category : #'refactory-changes-methods' }
 RBRefactoryChangeFactory >> removeMethod: aSelector from: aClass [
 	^ RBRemoveMethodChange remove: aSelector from: aClass
+]
+
+{ #category : #'refactory-changes-packages' }
+RBRefactoryChangeFactory >> removePackageNamed: aString [
+	^ RBRemovePackageChange removePackageNamed: aString
 ]
 
 { #category : #'refactory-changes-variables' }

--- a/src/Refactoring-Changes/RBRefactoryPackageChange.class.st
+++ b/src/Refactoring-Changes/RBRefactoryPackageChange.class.st
@@ -4,6 +4,9 @@ I am the baseclass for all refactoring changes for all kind of package changes.
 Class {
 	#name : #RBRefactoryPackageChange,
 	#superclass : #RBRefactoryChange,
+	#instVars : [
+		'browserEnvironment'
+	],
 	#category : #'Refactoring-Changes'
 }
 
@@ -20,6 +23,12 @@ RBRefactoryPackageChange >> executeNotifying: aBlock [
 	self primitiveExecute.
 	aBlock value.
 	^ undo
+]
+
+{ #category : #initialization }
+RBRefactoryPackageChange >> initialize [ 
+	super initialize.
+	browserEnvironment := RBBrowserEnvironment default.
 ]
 
 { #category : #private }

--- a/src/Refactoring-Changes/RBRemovePackageChange.class.st
+++ b/src/Refactoring-Changes/RBRemovePackageChange.class.st
@@ -1,0 +1,38 @@
+"
+I am a refactory change for a package removing. The RBRefactory api is implemented in my super class, I just define the concrete ""package"" removing.
+"
+Class {
+	#name : #RBRemovePackageChange,
+	#superclass : #RBRefactoryPackageChange,
+	#instVars : [
+		'packageName'
+	],
+	#category : #'Refactoring-Changes'
+}
+
+{ #category : #removing }
+RBRemovePackageChange class >> removePackageNamed: aString [
+	^ self new removePackageNamed: aString
+]
+
+{ #category : #converting }
+RBRemovePackageChange >> asUndoOperation [
+	^ changeFactory addPackageNamed: packageName
+]
+
+{ #category : #accessing }
+RBRemovePackageChange >> package [
+	^ (browserEnvironment packageAt: packageName ifAbsent: [nil]) 
+]
+
+{ #category : #private }
+RBRemovePackageChange >> primitiveExecute [
+	| pkg |
+	pkg := self package.
+	pkg ifNotNil: [ pkg removeFromSystem ]
+]
+
+{ #category : #removing }
+RBRemovePackageChange >> removePackageNamed: aString [
+	packageName := aString
+]

--- a/src/Refactoring-Changes/RBRenamePackageChange.class.st
+++ b/src/Refactoring-Changes/RBRenamePackageChange.class.st
@@ -25,8 +25,8 @@ RBRenamePackageChange >> asUndoOperation [
 
 { #category : #accessing }
 RBRenamePackageChange >> changePackage [
-	^ (RBBrowserEnvironment default packageAt: oldName ifAbsent: [nil]) 
-		ifNil: [ RBBrowserEnvironment default packageAt: newName ifAbsent: [nil] ]
+	^ (browserEnvironment packageAt: oldName ifAbsent: [nil]) 
+		ifNil: [ browserEnvironment packageAt: newName ifAbsent: [nil] ]
 ]
 
 { #category : #private }

--- a/src/Refactoring-Core/RBCondition.class.st
+++ b/src/Refactoring-Core/RBCondition.class.st
@@ -26,6 +26,7 @@ Class {
 
 { #category : #'instance creation' }
 RBCondition class >> canUnderstand: aSelector in: aClass [
+
 	^self new
 		type: (Array with: #understandsSelector with: aClass with: aSelector)
 		block: [aClass canUnderstand: aSelector]

--- a/src/Refactoring-Core/RBCopyClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBCopyClassRefactoring.class.st
@@ -1,0 +1,111 @@
+"
+I am a refactoring for copy a class.
+
+My preconditions verify, that the copied class exists (in  the current namespace) and that the new copy class name is valid and not yet used as a global variable name 
+
+The refactoring transformation create a new class and copy all instance and class methods of copied class.
+
+Example
+---------------
+```
+	(RBCopyClassRefactoring 
+		copyClass: #RBFooLintRuleTestData 
+		withName: #RBFooLintRuleTestData1 in: #Example1) execute. 
+```
+"
+Class {
+	#name : #RBCopyClassRefactoring,
+	#superclass : #RBClassRefactoring,
+	#instVars : [
+		'aClass',
+		'category'
+	],
+	#category : #'Refactoring-Core-Refactorings'
+}
+
+{ #category : #copying }
+RBCopyClassRefactoring class >> copyClass: cls withName: aSymbol [
+	^ self new copyClass: cls withName: aSymbol
+]
+
+{ #category : #copying }
+RBCopyClassRefactoring class >> copyClass: cls withName: copyName in: aSymbol [
+	^ self new
+		category: aSymbol;
+		copyClass: cls withName: copyName
+]
+
+{ #category : #copying }
+RBCopyClassRefactoring class >> model: aRBSmalltalk copyClass: cls withName: aSymbol [
+	^ self new
+		model: aRBSmalltalk;
+		copyClass: cls withName: aSymbol
+]
+
+{ #category : #copying }
+RBCopyClassRefactoring class >> model: aRBSmalltalk copyClass: cls withName: copyName in: aSymbol [
+	^ self new
+		model: aRBSmalltalk;
+		category: aSymbol;
+		copyClass: cls withName: copyName
+]
+
+{ #category : #accessing }
+RBCopyClassRefactoring >> category [
+
+	^ category ifNil: [ category := aClass category ]
+]
+
+{ #category : #accessing }
+RBCopyClassRefactoring >> category: aSymbol [
+	category := aSymbol 
+]
+
+{ #category : #transforming }
+RBCopyClassRefactoring >> copyClass [
+	self performCompositeRefactoring: (RBAddClassRefactoring
+		model: self model
+		addClass: className
+		superclass: aClass superclass
+		subclasses: #()
+		category: self category).
+]
+
+{ #category : #copying }
+RBCopyClassRefactoring >> copyClass: cls withName: aName [
+	self className: aName.
+	aClass := self classObjectFor: cls.
+]
+
+{ #category : #transforming }
+RBCopyClassRefactoring >> copyMethods [
+	| newClass |
+	newClass := (self model classNamed: className).
+	self copyMethodsOf: aClass in: newClass.
+	self copyMethodsOf: aClass classSide in: newClass classSide
+]
+
+{ #category : #copying }
+RBCopyClassRefactoring >> copyMethodsOf: rbClass1 in: rbClass2 [
+	rbClass1 selectors do: [ :symbol | | rbMethod |
+		rbMethod := rbClass1 methodFor: symbol.
+		self performCompositeRefactoringThroughWarning:
+			(RBAddMethodRefactoring 
+				model: self model
+				addMethod: rbMethod source 
+				toClass: rbClass2
+				inProtocols: rbMethod protocols)
+	]
+]
+
+{ #category : #preconditions }
+RBCopyClassRefactoring >> preconditions [ 
+	^ (RBCondition isValidClassName: className) 
+		& (RBCondition isGlobal: className in: self model) not
+]
+
+{ #category : #transforming }
+RBCopyClassRefactoring >> transform [
+	self copyClass.
+	self copyMethods.
+]

--- a/src/Refactoring-Core/RBCopyPackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBCopyPackageRefactoring.class.st
@@ -73,7 +73,7 @@ RBCopyPackageRefactoring >> copyNameFor: symbol [
 RBCopyPackageRefactoring >> copyPackage: aString1 in: aString2 [
 	packageName := aString1 asSymbol.
 	package := self model packageNamed: packageName.
-	newName := aString2.
+	newName := aString2 asSymbol.
 ]
 
 { #category : #preconditions }

--- a/src/Refactoring-Core/RBCopyPackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBCopyPackageRefactoring.class.st
@@ -1,0 +1,147 @@
+"
+I am a refactoring for copy a package.
+
+My preconditions verify, that the copied package exists (in  the current environment) and that the new copy package name is valid and not yet used as a global variable name 
+
+The refactoring transformation create a new package and copy defined classes of origin package (exclude all class' extensions)
+
+Example
+---------------
+```
+	(RBCopyPackageRefactoring 
+		copyPackage: #'Refactoring-Help' 
+		in: #'Refactoring-Help1') execute. 
+```
+"
+Class {
+	#name : #RBCopyPackageRefactoring,
+	#superclass : #RBPackageRefactoring,
+	#instVars : [
+		'package',
+		'newName'
+	],
+	#category : #'Refactoring-Core-Refactorings'
+}
+
+{ #category : #copying }
+RBCopyPackageRefactoring class >> copyPackage: aString1 in: aString2 [
+	^ self new copyPackage: aString1 in: aString2; yourself
+]
+
+{ #category : #copying }
+RBCopyPackageRefactoring class >> model: aRBSmalltalk copyPackage: aString1 in: aString2 [
+	^ self new 
+		model: aRBSmalltalk;
+		copyPackage: aString1 in: aString2; yourself
+]
+
+{ #category : #preconditions }
+RBCopyPackageRefactoring >> changeReferencesOf: classes with: copyClasses [
+	classes with: copyClasses do: [ :cls :cp | | rbClass |
+		rbClass := self model classNamed: cls.
+		self renameReferencesOf: rbClass with: cp.
+	]
+]
+
+{ #category : #preconditions }
+RBCopyPackageRefactoring >> copyAllClasses: classes [
+	^ classes collect: [ :symbol | | copyClassName |
+		copyClassName := self copyNameFor: symbol.
+		self performCompositeRefactoring: 
+			(RBCopyClassRefactoring
+				model: self model
+				copyClass: symbol 
+				withName: copyClassName
+				in: newName).
+		copyClassName
+	]
+]
+
+{ #category : #preconditions }
+RBCopyPackageRefactoring >> copyNameFor: symbol [
+	| string counter copyName |
+	string := 'Copy'.
+	counter := 1.
+	copyName := symbol, string.
+	[ self model includesGlobal: copyName ] 
+		whileTrue: [ copyName := symbol, string, counter asString.
+			counter := counter + 1 ].
+	^ copyName
+]
+
+{ #category : #copying }
+RBCopyPackageRefactoring >> copyPackage: aString1 in: aString2 [
+	packageName := aString1 asSymbol.
+	package := self model packageNamed: packageName.
+	newName := aString2.
+]
+
+{ #category : #preconditions }
+RBCopyPackageRefactoring >> preconditions [ 
+	^ super preconditions & (RBCondition withBlock: [ newName = packageName ifTrue: 
+		[ self refactoringError: 'Use a different name' ].
+		true ]) &
+	(RBCondition withBlock: [ [RPackage organizer validatePackageDoesNotExist: newName. true]
+			on: Error 
+			do: [ :e | self refactoringError: e messageText ]
+		])
+]
+
+{ #category : #'as yet unclassified' }
+RBCopyPackageRefactoring >> renameReferencesOf: aClass1 with: aClass2 [
+	| replacer |
+	replacer := (self parseTreeRewriterClass replaceLiteral: aClass1 name with: aClass2)
+				replace: aClass1 name with: aClass2;
+				replaceArgument: aClass2
+					withValueFrom: 
+						[:aNode | 
+						self 
+							refactoringFailure: aClass2 , ' already exists within the reference scope'];
+				yourself.
+	self model allReferencesToClass: aClass1 inPackages: { newName }
+		do: 
+			[:method | 
+			(method modelClass hierarchyDefinesVariable: aClass2) 
+				ifTrue: 
+					[self refactoringFailure: aClass2 , ' is already defined in hierarchy of ' 
+								, method modelClass printString].
+			self 
+				convertMethod: method selector
+				for: method modelClass
+				using: replacer]
+]
+
+{ #category : #preconditions }
+RBCopyPackageRefactoring >> reparent: classes  with: copyClasses [
+	| subclasses dict |
+	dict := Dictionary newFromKeys: classes andValues: copyClasses.
+	subclasses := copyClasses 
+		collect: [ :cls | self model classNamed: cls] 
+		thenSelect: [ :rb | classes includes: rb superclass name ].
+	subclasses do: [ :cls |
+		self model reparentClasses: { cls } to: (self model classNamed: (dict at: cls superclass name))
+	]
+	
+]
+
+{ #category : #printing }
+RBCopyPackageRefactoring >> storeOn: aStream [ 
+	aStream nextPut: $(.
+	self class storeOn: aStream.
+	aStream nextPutAll: ' copyPackage: '.
+	aStream nextPutAll: package name.
+	aStream
+		nextPutAll: ' in: #';
+		nextPutAll: newName;
+		nextPut: $)
+]
+
+{ #category : #preconditions }
+RBCopyPackageRefactoring >> transform [ 
+	| classes copyClasses |
+	self model addPackageNamed: newName.
+	classes := (package realPackage definedClasses collect: #name) asArray.
+	copyClasses := self copyAllClasses: classes.
+	self changeReferencesOf: classes with: copyClasses.
+	self reparent: classes  with: copyClasses.
+]

--- a/src/Refactoring-Core/RBMethod.class.st
+++ b/src/Refactoring-Core/RBMethod.class.st
@@ -109,6 +109,12 @@ RBMethod >> modelClass: aRBClass [
 ]
 
 { #category : #accessing }
+RBMethod >> package [
+	compiledMethod ifNotNil: [ ^ compiledMethod package name ].
+	^ class category
+]
+
+{ #category : #accessing }
 RBMethod >> parseTree [
 	^ self parserClass parseMethod: self source onError: [:str :pos | ^nil]
 ]

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -46,6 +46,7 @@ Class {
 		'rootClasses',
 		'implementorsCache',
 		'sendersCache',
+		'newPackages',
 		'changedPackages',
 		'removedPackages'
 	],
@@ -77,6 +78,18 @@ RBNamespace >> addClassVariable: aString to: aRBClass [
 { #category : #'private-changes' }
 RBNamespace >> addInstanceVariable: aString to: aRBClass [ 
 	^changes addInstanceVariable: aString to: aRBClass
+]
+
+{ #category : #'private-changes' }
+RBNamespace >> addPackageNamed: aSymbol [
+	| change pkg |
+	change := changes addPackageNamed: aSymbol.
+	self performChange: change around: [].
+	self flushCaches.
+	pkg := self packageNamed: aSymbol.
+	self unmarkPackageAsRemoved: aSymbol.
+	newPackages at: aSymbol put: pkg.
+	^change
 ]
 
 { #category : #'private-changes' }
@@ -193,6 +206,16 @@ RBNamespace >> allReferencesTo: aSymbol inPackages: aColl do: aBlock [
 { #category : #accessing }
 RBNamespace >> allReferencesToClass: aRBClass do: aBlock [ 
 	self allClassesDo: 
+			[:each |
+			(each whichSelectorsReferToClass: aRBClass) 
+				do: [:sel | aBlock value: (each methodFor: sel)].
+			(each classSide whichSelectorsReferToClass: aRBClass) 
+				do: [:sel | aBlock value: (each classSide methodFor: sel)]]
+]
+
+{ #category : #accessing }
+RBNamespace >> allReferencesToClass: aRBClass inPackages: aColl do: aBlock [ 
+	self allClassesInPackages: aColl do:
 			[:each |
 			(each whichSelectorsReferToClass: aRBClass) 
 				do: [:sel | aBlock value: (each methodFor: sel)].
@@ -385,6 +408,7 @@ RBNamespace >> initialize [
 	super initialize.
 	changes := changeFactory compositeRefactoryChange onSystemDictionary: self environment.
 	newClasses := IdentityDictionary new.
+	newPackages := IdentityDictionary new.
 	changedClasses := IdentityDictionary new.
 	changedPackages := IdentityDictionary new.
 	removedClasses := Set new.
@@ -441,6 +465,7 @@ RBNamespace >> name: aString [
 RBNamespace >> packageNamed: aSymbol [
 	aSymbol ifNil: [ ^ nil ].
 	(self hasPackageRemoved: aSymbol) ifTrue: [ ^ nil ].
+	(newPackages includesKey: aSymbol) ifTrue: [ ^ newPackages at: aSymbol ].
 	(changedPackages includesKey: aSymbol) ifTrue: [ ^ (changedPackages at: aSymbol) first ].
 	^ (self createNewPackageFor: aSymbol) first
 ]
@@ -569,6 +594,13 @@ RBNamespace >> removeMethod: aSelector from: aRBClass [
 	^changes removeMethod: aSelector from: aRBClass
 ]
 
+{ #category : #'private-changes' }
+RBNamespace >> removePackageNamed: aString [
+
+	self flushCaches.
+	^ changes removePackageNamed: aString.
+]
+
 { #category : #changes }
 RBNamespace >> renameClass: aRBClass to: aSymbol around: aBlock [
 	| change value dict |
@@ -617,8 +649,6 @@ RBNamespace >> renamePackage: aRBPackage to: aSymbol [
 	dict := changedPackages.
 	self markPackageAsRemoved: aRBPackage name.
 	self unmarkPackageAsRemoved: aSymbol.
-	"self markAsRemoved: aRBClass name.
-	self unmarkAsRemoved: aSymbol."
 	value := dict at: aRBPackage name.
 	dict removeKey: aRBPackage name.
 	dict at: aSymbol put: value.

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -84,7 +84,6 @@ RBNamespace >> addInstanceVariable: aString to: aRBClass [
 RBNamespace >> addPackageNamed: aSymbol [
 	| change pkg |
 	change := changes addPackageNamed: aSymbol.
-	self performChange: change around: [].
 	self flushCaches.
 	pkg := self packageNamed: aSymbol.
 	self unmarkPackageAsRemoved: aSymbol.

--- a/src/Refactoring-Core/RBPackage.class.st
+++ b/src/Refactoring-Core/RBPackage.class.st
@@ -73,5 +73,5 @@ RBPackage >> realPackage: anObject [
 
 { #category : #accessing }
 RBPackage >> realPackageFor: aSymbol [ 
-	self realPackage: (self model environment packageAt: aSymbol)
+	self realPackage: ( self model environment packageAt: aSymbol ifAbsent: [nil] )
 ]

--- a/src/Refactoring-Core/RBPackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBPackageRefactoring.class.st
@@ -12,7 +12,7 @@ Class {
 	#category : #'Refactoring-Core-Refactorings'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 RBPackageRefactoring class >> model: aRBModel packageName: aName [ 
 	^ self new
 		model: aRBModel;
@@ -20,7 +20,7 @@ RBPackageRefactoring class >> model: aRBModel packageName: aName [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : #'instance creation' }
 RBPackageRefactoring class >> packageName: aName [
 	^self new packageName: aName
 ]
@@ -35,4 +35,12 @@ RBPackageRefactoring >> packageName [
 RBPackageRefactoring >> packageName: anObject [
 
 	packageName := anObject
+]
+
+{ #category : #preconditions }
+RBPackageRefactoring >> preconditions [ 
+	^ (RBCondition withBlock: [ [ RPackage organizer includesPackageNamed: packageName ]
+			on: Error 
+			do: [ :e | self refactoringError: e messageText ]
+		])
 ]

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -327,6 +327,15 @@ RBRefactoring >> performCompositeRefactoring: aRefactoring [
 	aRefactoring primitiveExecute
 ]
 
+{ #category : #transforming }
+RBRefactoring >> performCompositeRefactoringThroughWarning: aRefactoring [ 
+	[ aRefactoring copyOptionsFrom: self options.
+	aRefactoring primitiveExecute ]
+	on: RBRefactoringError do: [ :ex | ex resume ]
+
+	
+]
+
 { #category : #utilities }
 RBRefactoring >> poolVariableNamesFor: aClass [ 
 	| pools |

--- a/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
@@ -9,16 +9,16 @@ Class {
 }
 
 { #category : #'instance creation' }
-RBRenamePackageRefactoring class >> model: aRBSmalltalk rename: aPkg to: aNewName [ 
-	^(self new)
+RBRenamePackageRefactoring class >> model: aRBSmalltalk rename: aSymbol to: aNewName [ 
+	^ self new
 		model: aRBSmalltalk;
-		packageName: aPkg name newName: aNewName;
+		packageName: aSymbol newName: aNewName;
 		yourself
 ]
 
 { #category : #'instance creation' }
-RBRenamePackageRefactoring class >> rename: aClass to: aNewName [
-	^self new packageName: aClass name newName: aNewName
+RBRenamePackageRefactoring class >> rename: aString to: aNewName [
+	^self new packageName: aString newName: aNewName
 ]
 
 { #category : #transforming }
@@ -37,7 +37,7 @@ RBRenamePackageRefactoring >> packageName: aName newName: aNewName [
 
 { #category : #preconditions }
 RBRenamePackageRefactoring >> preconditions [ 
-	^ (RBCondition withBlock: [ newName = package name ifTrue: 
+	^ super preconditions & (RBCondition withBlock: [ newName = package name ifTrue: 
 		[ self refactoringError: 'Use a different name' ].
 		true ]) &
 	(RBCondition withBlock: [ [RPackage organizer validatePackageDoesNotExist: newName. true]

--- a/src/Refactoring-Tests-Core/RBCopyPackageTest.class.st
+++ b/src/Refactoring-Tests-Core/RBCopyPackageTest.class.st
@@ -1,0 +1,53 @@
+Class {
+	#name : #RBCopyPackageTest,
+	#superclass : #RBRefactoringTest,
+	#category : #'Refactoring-Tests-Core-Refactorings'
+}
+
+{ #category : #'failure tests' }
+RBCopyPackageTest >> testBadName [
+	self
+		shouldFail: (RBCopyPackageRefactoring 
+				copyPackage: #'Refactoring-Tests-Core'
+				in: #'Refactoring-Tests-Core').
+]
+
+{ #category : #tests }
+RBCopyPackageTest >> testCopyPackage [
+	| refactoring aModel |
+	refactoring := (RBCopyPackageRefactoring 
+				copyPackage: #'Refactoring-Tests-Changes'
+				in: #'Refactoring-Tests-Changes1').
+	aModel := refactoring model.
+	self executeRefactoring: refactoring.
+	self assert: (aModel packageNamed: #'Refactoring-Tests-Changes1') isNotNil.
+	self assert: (aModel classNamed: #RBRefactoringChangeTestCopy) category equals: #'Refactoring-Tests-Changes1'.
+	self assert: (aModel classNamed: #RBRefactoringChangeManagerTestCopy) category equals: #'Refactoring-Tests-Changes1'.
+	
+]
+
+{ #category : #tests }
+RBCopyPackageTest >> testCopyPackageAndChangesCopyReferences [
+	| refactoring aModel |
+	self timeLimit: 2 minutes.
+	refactoring := (RBCopyPackageRefactoring 
+				copyPackage: #'Refactoring-Help'
+				in: #'Refactoring-Help1').
+	aModel := refactoring model.
+	self executeRefactoring: refactoring.
+	self assert: (aModel classNamed: #RBRefactoringClassesHelpCopy) category 
+		equals: #'Refactoring-Help1'.
+	self assert: (aModel classNamed: #RBRefactoringClassesHelpCopy) superclass name 
+		equals: #RBClassesHelpCopy.
+	self assert: ((aModel classNamed: #RBCoreClassesHelpCopy) classSide parseTreeFor: #pages) 
+		equals: (self parseMethod: 'pages
+	^ #(RBASTClassesHelpCopy RBRefactoringClassesHelpCopy RBBrowserEnvironmentsClassesHelpCopy)')
+]
+
+{ #category : #'failure tests' }
+RBCopyPackageTest >> testExistingPackage [
+	self
+		shouldFail: (RBCopyPackageRefactoring 
+				copyPackage: #'Refactoring-Tests-Core'
+				in: #'Refactoring-Tests-Changes')
+]

--- a/src/Refactoring-Tests-Core/RBRenamePackageTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRenamePackageTest.class.st
@@ -4,16 +4,11 @@ Class {
 	#category : #'Refactoring-Tests-Core-Refactorings'
 }
 
-{ #category : #tests }
-RBRenamePackageTest >> getPackageNamed: aSymbol [
-	^ RBBrowserEnvironment default packageAt: aSymbol
-]
-
 { #category : #'failure tests' }
 RBRenamePackageTest >> testBadName [
 	self
 		shouldFail: (RBRenamePackageRefactoring 
-				rename: (self getPackageNamed: #'Refactoring-Tests-Core')
+				rename: #'Refactoring-Tests-Core'
 				to: #'Refactoring-Tests-Core')
 ]
 
@@ -21,7 +16,7 @@ RBRenamePackageTest >> testBadName [
 RBRenamePackageTest >> testExistingPackage [
 	self
 		shouldFail: (RBRenamePackageRefactoring 
-				rename: (self getPackageNamed: #'Refactoring-Tests-Core')
+				rename: #'Refactoring-Tests-Core'
 				to: #'Refactoring-Tests-Changes')
 ]
 
@@ -30,7 +25,7 @@ RBRenamePackageTest >> testRenamePackage [
 	| refactoring aModel |
 	
 	refactoring := (RBRenamePackageRefactoring 
-				rename: (self getPackageNamed: #'Refactoring-Tests-Core')
+				rename: #'Refactoring-Tests-Core'
 				to: #'Refactoring-Tests-Core1').
 	aModel := refactoring model.
 	self executeRefactoring: refactoring.

--- a/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
@@ -138,6 +138,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testRefactoring [
 	super initialize.
 	changes := changeFactory compositeRefactoryChange onSystemDictionary: self environment.
 	newClasses := IdentityDictionary new.
+	newPackages := IdentityDictionary new.
 	changedClasses := IdentityDictionary new.
 	changedPackages := IdentityDictionary new.
 	removedClasses := Set new.

--- a/src/SystemCommands-PackageCommands/SycCopyPackageCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycCopyPackageCommand.class.st
@@ -1,5 +1,5 @@
 "
-I am a command to rename given package.
+I am a command to copy given package.
  
 Internal Representation and Key Implementation Points.
 
@@ -8,7 +8,7 @@ Internal Representation and Key Implementation Points.
 	package:		<RPackage>
 "
 Class {
-	#name : #SycRenamePackageCommand,
+	#name : #SycCopyPackageCommand,
 	#superclass : #CmdCommand,
 	#instVars : [
 		'package',
@@ -18,28 +18,28 @@ Class {
 }
 
 { #category : #testing }
-SycRenamePackageCommand class >> canBeExecutedInContext: aToolContext [
+SycCopyPackageCommand class >> canBeExecutedInContext: aToolContext [
 	^aToolContext isPackageSelected
 ]
 
 { #category : #accessing }
-SycRenamePackageCommand >> defaultMenuIconName [ 
-	^ #edit
+SycCopyPackageCommand >> defaultMenuIconName [
+	^#smallCopy
 ]
 
 { #category : #accessing }
-SycRenamePackageCommand >> defaultMenuItemName [
-	^'Rename'
+SycCopyPackageCommand >> defaultMenuItemName [
+	^'Copy all package'
 ]
 
 { #category : #execution }
-SycRenamePackageCommand >> execute [
-	
-	(RBRenamePackageRefactoring rename: package name to: newName) execute
+SycCopyPackageCommand >> execute [
+
+	(RBCopyPackageRefactoring copyPackage: package name in: newName) execute
 ]
 
 { #category : #execution }
-SycRenamePackageCommand >> prepareFullExecutionInContext: aToolContext [
+SycCopyPackageCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 	
 	package := aToolContext lastSelectedPackage.	

--- a/src/SystemCommands-PackageCommands/SycCopyPackageCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycCopyPackageCommand.class.st
@@ -44,8 +44,8 @@ SycCopyPackageCommand >> prepareFullExecutionInContext: aToolContext [
 	
 	package := aToolContext lastSelectedPackage.	
 	newName := UIManager default 
-		request: 'New name of the package' 
+		request: 'New name of copied package' 
 		initialAnswer: package name 
-		title: 'Rename a package'.
+		title: 'Copy package'.
 	newName isEmptyOrNil | (newName = package name) ifTrue: [ ^ CmdCommandAborted signal ]
 ]

--- a/src/SystemCommands-PackageCommands/SycRenamePackageCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycRenamePackageCommand.class.st
@@ -30,7 +30,7 @@ SycRenamePackageCommand >> defaultMenuItemName [
 { #category : #execution }
 SycRenamePackageCommand >> execute [
 	
-	(RBRenamePackageRefactoring rename: package to: newName) execute
+	(RBRenamePackageRefactoring rename: package name to: newName) execute
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fixes #8568

This new refactoring consists in copy a complete package with all defined classes inside it, if the copy classes has references between them, these references are renamed also. For example:

The following package has these classes, 

<img width="361" alt="imagen" src="https://user-images.githubusercontent.com/15729309/110998587-6aab4480-8355-11eb-8fd5-c2dad579bbd4.png">

and these classes has these references between them:
```
MyClassA >> foo
	^ MyClassB

MyClassB >> example4 
	#MyClassA1
```

After copy #Example package we obtain this result:

<img width="430" alt="imagen" src="https://user-images.githubusercontent.com/15729309/110999148-4dc34100-8356-11eb-984b-ceed14a8777d.png">

and references were updated

```
MyClassACopy >> foo
	^ MyClassBCopy

MyClassBCopy >> example4 
	#MyClassA1Copy
```

It can also be noted that the hierarchy was correctly updated with the copied classes 