### PR TITLE
8669 aFloat asScaledDecimal loses precision

### DIFF
--- a/src/Kernel-Tests/FloatTest.class.st
+++ b/src/Kernel-Tests/FloatTest.class.st
@@ -13,6 +13,23 @@ FloatTest >> classToBeTested [
 	^ Float
 ]
 
+{ #category : #test }
+FloatTest >> testAsScaledDecimal [
+
+	self
+		assert: 0.00000000000006 asScaledDecimal asString
+		equals: '0.00000000000006s14'.
+	self
+		assert: 9.99999999999999 asScaledDecimal asString
+		equals: '9.99999999999999s14'.
+	self
+		assert:
+		(ScaledDecimal newFromNumber: 9.999999999999999 scale: 15) asString
+		equals: '9.999999999999998s15'.
+		self assert: (ScaledDecimal  newFromNumber: 9.999999999999994 scale: 15) asString 
+		equals: '9.999999999999995s15'
+]
+
 { #category : #'tests - conversion' }
 FloatTest >> testCeiling [
 

--- a/src/Kernel/Float.class.st
+++ b/src/Kernel/Float.class.st
@@ -719,6 +719,12 @@ Float >> asMinimalDecimalFraction [
 ]
 
 { #category : #converting }
+Float >> asScaledDecimal [
+
+	^ self asScaledDecimal: 15
+]
+
+{ #category : #converting }
 Float >> asTrueFraction [
 	" Answer a fraction that EXACTLY represents self,
 	  a double precision IEEE floating point number.

--- a/src/Kernel/Float.class.st
+++ b/src/Kernel/Float.class.st
@@ -721,7 +721,15 @@ Float >> asMinimalDecimalFraction [
 { #category : #converting }
 Float >> asScaledDecimal [
 
-	^ self asScaledDecimal: 15
+	"Answer a scaled decimal number approximating the receiver.
+	
+	IEEE 754 double precision numbers use 53 bits to encode mantissa. This means
+	that the maximum amount of decimal digits that can be represented is log10(2^53).
+	
+	Due to the fact that at least one of the decimal digits has to be placed to 
+	the left of the decimal point, the scale was set to 15 - 1 = 14."
+
+	^ self asScaledDecimal: 14
 ]
 
 { #category : #converting }


### PR DESCRIPTION
In class Float, the method asScaledDecimal was overriden to set a custom scale (14) for floats.

The reasons for this number are:
1) IEEE 754 double precision numbers use 53 bits to encode mantissa. This means that the maximum amount of decimal digits that can be represented is log10(2^53) = 15,xx.
2) At least one of the decimal digits has to be placed to the left of the decimal point.

Therefore, if we round down the max amount of digits and we remove the digit that will not be to the right of the decimal point, we obtain a scale of 14.