### PR TITLE
testNoUnusedInstanceVariablesLeft-down-25 

### DIFF
--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -44,9 +44,9 @@ NoUnusedVariablesLeftTest >> testNoUnusedInstanceVariablesLeft [
 	
 	remaining := classes asOrderedCollection removeAll: validExceptions; yourself.
 	
-	"we have 28 left, there are issue tracker entries for those.
+	"we have 25 left, there are issue tracker entries for those.
  	By testing for these, we avoid that new cases are added"
- 	self assert: remaining size <= 27
+ 	self assert: remaining size <= 25
 ]
 
 { #category : #testing }


### PR DESCRIPTION
#testNoUnusedInstanceVariablesLeft can now check for 25 after we fixed two more cases


