### PR TITLE
8762-Compiler-Evaluating-an-expression-with-error-with-a-requestor-leads-to-primitive-fail

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -322,9 +322,19 @@ OpalCompiler >> compilationContextClass: aClass [
 
 { #category : #'public access' }
 OpalCompiler >> compile [
-	^compilationContext noPattern 
+	^[compilationContext noPattern 
 		ifTrue: [ self compileDoit ]
-		ifFalse: [ self compileMethod ]
+		ifFalse: [ self compileMethod ]]
+		on: SyntaxErrorNotification 
+		do: [ :exception | 
+			self compilationContext requestor
+                ifNotNil: [
+						self compilationContext requestor 
+							notify: exception errorMessage , ' ->'
+							at: exception location
+							in: exception errorCode.
+                    ^ self compilationContext failBlock value ]
+                ifNil: [ exception pass ]].
 ]
 
 { #category : #'public access' }
@@ -338,23 +348,12 @@ OpalCompiler >> compile: textOrString [
 { #category : #private }
 OpalCompiler >> compileDoit [
 	| cm |
-	["We need to first compile with the AST having the text 
+	"We need to first compile with the AST having the text 
 	offset of the original selected code. This way the #location 
 	will be correct regarding the requestor"
 	self parseDoIt.
 	self callPlugins.
-	cm := ast generateWithSource ]
-		on: SyntaxErrorNotification
-		do: [ :exception | 
-			self compilationContext requestor
-				ifNotNil: [ 
-					self compilationContext requestor
-						notify: exception errorMessage , ' ->'
-						at: exception location
-						in: exception errorCode.
-					^ self compilationContext failBlock value ]
-				ifNil: [ exception pass ] ].
-
+	cm := ast generateWithSource.
 	"We need to re-parse so that the AST is in sync with the 
 	bytecode to be able to debug the doit. Recompile not needed"
 	ast := RBParser parseMethod: ast formattedCode.
@@ -368,7 +367,7 @@ OpalCompiler >> compileDoit [
 { #category : #'public access' }
 OpalCompiler >> compileMethod [
 	| cm |
-	[ 	[	self parse.
+	[	self parse.
 			self callPlugins.  
 		] 	on: ReparseAfterSourceEditing 
 			do: 
@@ -378,18 +377,7 @@ OpalCompiler >> compileMethod [
 			]. 
 		cm := compilationContext optionEmbeddSources
 			ifTrue: [ ast generateWithSource ]
-			ifFalse: [ast generate: self compilationContext compiledMethodTrailer   ]
-		
-	]	on: SyntaxErrorNotification 
-		do: [ :exception | 
-			self compilationContext requestor
-                ifNotNil: [
-						self compilationContext requestor 
-							notify: exception errorMessage , ' ->'
-							at: exception location
-							in: exception errorCode.
-                    ^ self compilationContext failBlock value ]
-                ifNil: [ exception pass ]].
+			ifFalse: [ast generate: self compilationContext compiledMethodTrailer   ].
 	^cm
 ]
 
@@ -446,7 +434,17 @@ OpalCompiler >> evaluate [
 	self noPattern: true.
 	self getSourceFromRequestorSelection.
 	self class: (context ifNil: [ receiver class ] ifNotNil: [ context compiledCode methodClass ]).
-	value := receiver withArgs: (context ifNil: [ #() ] ifNotNil: [ {context} ]) executeMethod: self compileDoit.
+	value := [ receiver withArgs: (context ifNil: [ #() ] ifNotNil: [ {context} ]) executeMethod: self compileDoit]
+		on: SyntaxErrorNotification 
+		do: [ :exception | 
+			self compilationContext requestor
+                ifNotNil: [
+						self compilationContext requestor 
+							notify: exception errorMessage , ' ->'
+							at: exception location
+							in: exception errorCode.
+                    self compilationContext failBlock value ]
+                ifNil: [ exception pass ]].
 	self logDoIt.
 	^ value
 ]

--- a/src/OpalCompiler-Tests/OCDoitTest.class.st
+++ b/src/OpalCompiler-Tests/OCDoitTest.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'OpalCompiler-Tests-Misc'
 }
 
+{ #category : #'interactive error protocol' }
+OCDoitTest >> notify: aString at: anInteger in: aString3 [ 
+	"we ignore"
+]
+
 { #category : #tests }
 OCDoitTest >> testDoItContextReadGlobal [
 	"we can read a global from a doit when executing against a context"
@@ -49,6 +54,16 @@ OCDoitTest >> testDoItContextReadTemp [
 		evaluate.
 		
 	self assert: value equals: #someValue
+]
+
+{ #category : #tests }
+OCDoitTest >> testDoItRequestorEvalError [
+	| value |
+	value  := OpalCompiler new 
+	requestor: self;
+	evaluate: '1('.
+
+	self assert: value isNil.
 ]
 
 { #category : #tests }

--- a/src/OpalCompiler-Tests/OCDoitTest.class.st
+++ b/src/OpalCompiler-Tests/OCDoitTest.class.st
@@ -7,6 +7,18 @@ Class {
 	#category : #'OpalCompiler-Tests-Misc'
 }
 
+{ #category : #binding }
+OCDoitTest >> bindingOf: aSelector [
+	^(aSelector == #requestorVarForTesting) 
+		ifTrue: [WorkspaceVariable key: aSelector value: 5 ]
+		ifFalse:  [nil]
+]
+
+{ #category : #binding }
+OCDoitTest >> hasBindingOf: aSelector [
+	^aSelector == #requestorVarForTesting
+]
+
 { #category : #'interactive error protocol' }
 OCDoitTest >> notify: aString at: anInteger in: aString3 [ 
 	"we ignore"
@@ -64,6 +76,20 @@ OCDoitTest >> testDoItRequestorEvalError [
 	evaluate: '1('.
 
 	self assert: value isNil.
+]
+
+{ #category : #tests }
+OCDoitTest >> testDoItRequestorReadRequestorVar [
+
+	| value  |
+	"we can read a variable from a requestor"
+	value := OpalCompiler new
+		          source: 'requestorVarForTesting';
+		          noPattern: true;
+		          requestor: self;
+		          evaluate.
+		
+	self assert: value equals: 5
 ]
 
 { #category : #tests }


### PR DESCRIPTION
This adds a test #testDoItRequestorEvalError and a fix.

The fix tries to be minimal, in the sense of not doing the big cleanup (which we should do..) to have minimal impact.
It moves the exception handler to the caller of the compile methods.

Fixes: #8762


