### PR TITLE
8695-FTSizeRec-declares-class-variables-without-referencing

### DIFF
--- a/src/FreeType/FTSizeRec.class.st
+++ b/src/FreeType/FTSizeRec.class.st
@@ -4,6 +4,12 @@ I map the FT_SizeRec type.
 Class {
 	#name : #FTSizeRec,
 	#superclass : #FFIExternalStructure,
+	#classVars : [
+		'OFFSET_FACE',
+		'OFFSET_GENERIC',
+		'OFFSET_INTERNAL',
+		'OFFSET_METRICS'
+	],
 	#pools : [
 		'FT2Types'
 	],
@@ -21,4 +27,52 @@ FTSizeRec class >> fieldsDesc [
     FT_Size_Metrics   metrics;
     FT_Size_Internal  internal;	
 )
+]
+
+{ #category : #'accessing structure variables' }
+FTSizeRec >> face [
+	"This method was automatically generated"
+	^FTFaceRec fromHandle: (handle pointerAt: OFFSET_FACE)
+]
+
+{ #category : #'accessing structure variables' }
+FTSizeRec >> face: anObject [
+	"This method was automatically generated"
+	handle pointerAt: OFFSET_FACE put: anObject getHandle.
+]
+
+{ #category : #'accessing structure variables' }
+FTSizeRec >> generic [
+	"This method was automatically generated"
+	^ FTGeneric fromHandle: (handle referenceStructAt: OFFSET_GENERIC length: FTGeneric byteSize)
+]
+
+{ #category : #'accessing structure variables' }
+FTSizeRec >> generic: anObject [
+	"This method was automatically generated"
+	handle structAt: OFFSET_GENERIC put: anObject getHandle length: FTGeneric byteSize
+]
+
+{ #category : #'accessing structure variables' }
+FTSizeRec >> internal [
+	"This method was automatically generated"
+	^ExternalData fromHandle: (handle pointerAt: OFFSET_INTERNAL) type: ExternalType void asPointerType
+]
+
+{ #category : #'accessing structure variables' }
+FTSizeRec >> internal: anObject [
+	"This method was automatically generated"
+	handle pointerAt: OFFSET_INTERNAL put: anObject getHandle.
+]
+
+{ #category : #'accessing structure variables' }
+FTSizeRec >> metrics [
+	"This method was automatically generated"
+	^ FTSizeMetrics fromHandle: (handle referenceStructAt: OFFSET_METRICS length: FTSizeMetrics byteSize)
+]
+
+{ #category : #'accessing structure variables' }
+FTSizeRec >> metrics: anObject [
+	"This method was automatically generated"
+	handle structAt: OFFSET_METRICS put: anObject getHandle length: FTSizeMetrics byteSize
 ]

--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -26,9 +26,9 @@ NoUnusedVariablesLeftTest >> testNoUnusedClassVariablesLeft [
 	
 	remaining := classes asOrderedCollection reject: [ :each  | validExceptions includes: each name].
 	
-	"we have three left, there are issue tracker entries for those.
-	By testing for 3, we avoid that new cases are added"
-	self assert: remaining size <= 3
+	"we have 2 left, there are issue tracker entries for those.
+	By testing for 2, we avoid that new cases are added"
+	self assert: remaining size <= 2
 ]
 
 { #category : #testing }


### PR DESCRIPTION
executed "self rebuildFieldAccessors"

fixes #8695


