### PR TITLE
8701-Class-references-show-incorrect-results-when-there-are-super-sends-in-blocks

### DIFF
--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -261,6 +261,21 @@ CompiledCodeTest >> testLiteralsEvenTheOnesInTheInnerCleanBlocks [
 ]
 
 { #category : #'tests - scanning' }
+CompiledCodeTest >> testReadsRef [
+	| readMethod writeMethod classVar |
+	readMethod := SmalltalkImage class>>#compilerClass.
+	writeMethod := SmalltalkImage class>>#compilerClass:.
+	classVar := SmalltalkImage classVariableNamed: #CompilerClass.
+	
+	self assert: (readMethod readsRef: classVar).
+	self deny: (writeMethod readsRef: classVar).
+	
+	"Special test for a method with super in a full block. 
+	We push a binding for this class but make sure that it is not the same"
+	self deny: ((DelayMutexScheduler>>#unschedule:) readsRef: DelayMutexScheduler binding)
+]
+
+{ #category : #'tests - scanning' }
 CompiledCodeTest >> testReadsSelf [
 	| method |
 	method := self class compiler compile: 'method self doit'.

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -715,13 +715,13 @@ IRBytecodeGenerator >> send: selector toSuperOf: behavior [
 	index := self literalIndexOf: selector.
 
 	(encoder class = EncoderForSistaV1 and: [ inBlock ])
-		ifTrue: [ 
-			encoder genPushLiteralVar: (self literalIndexOf: behavior binding).
+		ifTrue: [
+			"we need to use a copy of the binding as else 'references to' will find this method" 
+			encoder genPushLiteralVar: (self literalIndexOf: behavior binding copy).
 			encoder genSendDirectedSuper: index numArgs: nArgs ]
 		ifFalse: [ 
 			self addLastLiteral: behavior binding.  
 			encoder genSendSuper: index numArgs: nArgs ]
-
 ]
 
 { #category : #results }


### PR DESCRIPTION
Class references show incorrect results when there are super sends in blocks.

An example can be seen in DelayMutexScheduler>>#unschedule:, if you lool for references to DelayMutexScheduler, it shows this method.

The reason is that "super" in full block is compiled as a push of a binding to the class and then a directed send. We push just "theClass binding".
This will create a normal literal for that binding, while in a method it will find the last literal that is ignored for literals as it is always the class binding.

Solution: push a copy.

Fixes #8701