### PR TITLE
8195-Moving-message-refactoring-is-broken-in-the-implementors-browser

### DIFF
--- a/src/Calypso-Browser/ClyBrowserContext.class.st
+++ b/src/Calypso-Browser/ClyBrowserContext.class.st
@@ -72,6 +72,12 @@ ClyBrowserContext >> copyForBrowserStateSnapshot [
 		yourself
 ]
 
+{ #category : #'accessing context' }
+ClyBrowserContext >> currentMetaLevelOf: aClass [
+	"we do not model class side vs instance side"
+	^aClass
+]
+
 { #category : #helpers }
 ClyBrowserContext >> firstSelectedObjectIn: selectedObjects [
 	^selectedObjects last


### PR DESCRIPTION
This change fixes #8195. Somewhat

The problem is that we can not model "class side" vs. "instance side" on this model. Thus, if you are on the class side, use "move to other class", it will move the method to the instance side. But then, this is what you selected in the dialog... 

