### PR TITLE
8761-Add-a-release-test-for-unclassified-methods

### DIFF
--- a/src/ReleaseTests/ProperMethodCategorizationTest.class.st
+++ b/src/ReleaseTests/ProperMethodCategorizationTest.class.st
@@ -119,6 +119,19 @@ ProperMethodCategorizationTest >> testNoEmptyProtocols [
 	self assertEmpty: violating
 ]
 
+{ #category : #tests }
+ProperMethodCategorizationTest >> testNoUncategorizedMethods [
+
+	"Check that we have no #'as yet unclassified' protocols left"
+
+	| violating |
+	violating := Smalltalk globals allBehaviors select: [ :class | 
+		             class protocols includes: #'as yet unclassified' ].
+
+	"we lock in the number of problematic classes, this way it can only improve"
+	self assert: violating size <= 269
+]
+
 { #category : #'tests - object' }
 ProperMethodCategorizationTest >> testPostCopyMethodNeedsToBeInCopyingProtocol [
 	"The #postCopy methods should be in method protocol 'copying'"


### PR DESCRIPTION
add #testNoUncategorizedMethods testing for the number we have now. Cleaning up will take a while, but this way it does not get worse

fixes #8761

