### PR TITLE
6526-RGTraitDescriptionStrategy-invoke-methods-that-do-not-exist-announcer

### DIFF
--- a/src/Ring-Core/RGTraitDescriptionStrategy.class.st
+++ b/src/Ring-Core/RGTraitDescriptionStrategy.class.st
@@ -46,8 +46,8 @@ RGTraitDescriptionStrategy >> name: aString [
 	super name: aString.
 	
 	usersWithOldDefinition do: [ :assoc |
-		self announcer behaviorDefinitionChangedFrom: assoc value to: assoc key.
-		self announcer behaviorModificationAppliedTo: assoc key. ].		
+		self trait announcer behaviorDefinitionChangedFrom: assoc value to: assoc key.
+		self trait announcer behaviorModificationAppliedTo: assoc key. ].		
 ]
 
 { #category : #variables }


### PR DESCRIPTION
announcer is defined on the trait (an RGObject). Yes... test should be done but I have no idea how

fixes #6526

