### PR TITLE
6970-win32ModuleName-not-implemented

### DIFF
--- a/src/UnifiedFFI/FFILibrary.class.st
+++ b/src/UnifiedFFI/FFILibrary.class.st
@@ -73,6 +73,8 @@ FFILibrary >> libraryName [
 { #category : #'accessing platform' }
 FFILibrary >> macLibraryName [
 	"Calling by default #macModuleName for backwards compatibility.
+	The system complains that this method is not implemented as it will only exist
+	in subclasses that use the old API.
 	Please redefine #macLibraryName"
 	^ self macModuleName
 ]
@@ -112,11 +114,17 @@ FFILibrary >> unix64LibraryName [
 { #category : #'accessing platform' }
 FFILibrary >> unixLibraryName [
 	"Kept for backward compatibility. 
+	The system complains that this method is not implemented as it will only exist
+	in subclasses that use the old API.
 	 Users should use unix32* or unix64*"
 	^ self unixModuleName
 ]
 
 { #category : #'accessing platform' }
 FFILibrary >> win32LibraryName [
-	^self subclassResponsibility
+	"Calling by default #win32ModuleName for backwards compatibility.
+	The system complains that this method is not implemented as it will only exist
+	in subclasses that use the old API.
+	Please redefine #win32LibraryName"
+	^ self win32ModuleName
 ]

--- a/src/UnifiedFFI/FFILibrary.class.st
+++ b/src/UnifiedFFI/FFILibrary.class.st
@@ -118,7 +118,5 @@ FFILibrary >> unixLibraryName [
 
 { #category : #'accessing platform' }
 FFILibrary >> win32LibraryName [
-	"Calling by default #win32ModuleName for backwards compatibility.
-	Please redefine #win32LibraryName"
-	^ self win32ModuleName
+	^self subclassResponsibility
 ]


### PR DESCRIPTION
I think this is a leftover from the transition. We can just make turn it into a subclass-responsability now

fixes #6970

