### PR TITLE
Update-ReleaseTests

### DIFF
--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -22,13 +22,10 @@ NoUnusedVariablesLeftTest >> testNoUnusedClassVariablesLeft [
 	
 	classes := variables collect: [ :each | each definingClass ] as: Set.
 	
-	validExceptions := #(OSKeySymbols FooSharedPool SDL2Constants AthensCairoDefinitions BalloonEngineConstants ShTestSharedPool RBLintRuleTestData RBDummyLintRuleTest MCMockClassF Unicode).	
+	validExceptions := #(OSKeySymbols FooSharedPool SDL2Constants AthensCairoDefinitions BalloonEngineConstants ShTestSharedPool RBLintRuleTestData RBDummyLintRuleTest MCMockClassF Unicode Character).	
 	
 	remaining := classes asOrderedCollection reject: [ :each  | validExceptions includes: each name].
-	
-	"we have 2 left, there are issue tracker entries for those.
-	By testing for 2, we avoid that new cases are added"
-	self assert: remaining size <= 2
+	self assert: remaining isEmpty
 ]
 
 { #category : #testing }

--- a/src/ReleaseTests/ProperMethodCategorizationTest.class.st
+++ b/src/ReleaseTests/ProperMethodCategorizationTest.class.st
@@ -129,7 +129,7 @@ ProperMethodCategorizationTest >> testNoUncategorizedMethods [
 		             class protocols includes: #'as yet unclassified' ].
 
 	"we lock in the number of problematic classes, this way it can only improve"
-	self assert: violating size <= 269
+	self assert: violating size <= 151
 ]
 
 { #category : #'tests - object' }


### PR DESCRIPTION
- we fixed more than 100 classes for #testNoUncategorizedMethods --> update number to 151
- testNoUnusedClassVariablesLeft: there is just Character left, I added it to the validExceptions for now as it requires a boostrap change.
