### PR TITLE
Fix 8855: Paste shortcut (cmd/ctrl+V) conflicts with new calypso shortcut

### DIFF
--- a/src/Calypso-SystemTools-Core/SycMergeVariableCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycMergeVariableCommand.extension.st
@@ -6,10 +6,3 @@ SycMergeVariableCommand class >> fullBrowserMenuActivation [
 	
 	^CmdContextMenuActivation byRootGroupItemOrder: 1.1 for: ClyFullBrowserVariableContext 
 ]
-
-{ #category : #'*Calypso-SystemTools-Core' }
-SycMergeVariableCommand class >> sourceCodeMenuActivation [
-	<classAnnotation>
-	
-	^SycSourceCodeMenuActivation byRootGroupItemOrder: 1.1 for: ClySourceCodeContext
-]

--- a/src/Calypso-SystemTools-FullBrowser/SycMergeVariableCommand.extension.st
+++ b/src/Calypso-SystemTools-FullBrowser/SycMergeVariableCommand.extension.st
@@ -6,10 +6,3 @@ SycMergeVariableCommand class >> fullBrowserShortcutActivation [
 	
 	^CmdShortcutActivation by: $v meta, $m meta for: ClyFullBrowserVariableContext
 ]
-
-{ #category : #'*Calypso-SystemTools-FullBrowser' }
-SycMergeVariableCommand class >> sourceCodeShortcutActivation [
-	<classAnnotation>
-	
-	^CmdShortcutActivation by: $v meta, $m meta for: ClySourceCodeContext 
-]

--- a/src/Keymapping-KeyCombinations/KMKeyCombination.class.st
+++ b/src/Keymapping-KeyCombinations/KMKeyCombination.class.st
@@ -95,7 +95,9 @@ KMKeyCombination >> mac [
 
 { #category : #matching }
 KMKeyCombination >> matches: anEventBuffer [
-	^ self matchesCompletely: anEventBuffer first
+
+	^ anEventBuffer size = 1 and:
+		[self matchesCompletely: anEventBuffer first]
 ]
 
 { #category : #matching }

--- a/src/Keymapping-Tests/KMShortcutTest.class.st
+++ b/src/Keymapping-Tests/KMShortcutTest.class.st
@@ -127,7 +127,9 @@ KMShortcutTest >> testSimpleChainMatches [
 	eCtrl := self eventKey: $e ctrl: true.
 	
 	self assert: (($e ctrl, $e) matches: {eCtrl}).
-	self assert: ($e ctrl matches: {eCtrl. e}).
+	
+	"A full shortcut should not match a bigger buffer ever"
+	self deny: ($e ctrl matches: {eCtrl. e}).
 	
 	self deny: (($e ctrl, $e) matches: {eCtrl. self eventKey: $a}).
 	self deny: ($e ctrl matches: {e})


### PR DESCRIPTION
Two related fixes:
 - make keymappings more robust
 - fix shortcut conflicting with "paste"

* Fix keymapping to correctly cancel on key "buffer overrun".
* Remove conflicting shortcut from text pane