### PR TITLE
Add the trace operation to Array2D class

### DIFF
--- a/src/Collections-Sequenceable/Array2D.class.st
+++ b/src/Collections-Sequenceable/Array2D.class.st
@@ -179,6 +179,17 @@ Array2D >> = aMatrix [
 					and: [ aMatrix privateContents = contents ] ] ]
 ]
 
+{ #category : #'row/column operations' }
+Array2D >> Trace [
+	"returns the trace, the sum of diagonal elements of the matrix"
+	
+	| result |
+	result := 0.
+	[numberOfRows = numberOfColumns] assert.
+	1 to: self numberOfRows do: [ :n | result := result + (self at: n at: n) ].
+	^ result
+]
+
 { #category : #adding }
 Array2D >> add: newObject [
 	self shouldNotImplement

--- a/src/Collections-Sequenceable/Array2D.class.st
+++ b/src/Collections-Sequenceable/Array2D.class.st
@@ -180,7 +180,7 @@ Array2D >> = aMatrix [
 ]
 
 { #category : #'row/column operations' }
-Array2D >> Trace [
+Array2D >> tr [
 	"returns the trace, the sum of diagonal elements of the matrix"
 	
 	| result |


### PR DESCRIPTION
The operation to find the trace (sum of the diagonal elements of the matrix) of a matrix has been added in this PR.