### PR TITLE
Merge NewTools 0.6

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -200,7 +200,8 @@ BaselineOfIDE >> baseline: spec [
 					'Debugger' 
 					'SystemReporter'
 					'ChangeSorter'
-					'Methods') ].
+					'Methods'
+					'Spotter') ].
 			
 		spec baseline: 'Microdown' with: [ spec 
 				repository: self packageRepositoryURL ].

--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -15,6 +15,7 @@ BaselineOfNewTools >> baseline: spec [
 		spec preLoadDoIt: #'preload:package:'.
 		spec postLoadDoIt: #'postload:package:'.
 
+		"self spec: spec."
 		self sindarin: spec.
 
 		spec
@@ -35,10 +36,19 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-Debugger-Tests' with: [ spec requires: #('NewTools-Debugger') ];
 			"playground"
 			package: 'NewTools-Playground' with: [ spec requires: #('NewTools-Inspector') ];
+			"spotter"
+			package: 'NewTools-Spotter' with: [ spec requires: #('NewTools-Core') ];
+			package: 'NewTools-Morphic-Spotter' with: [ spec requires: #('NewTools-Morphic') ];
 			"browser"
 			package: 'NewTools-SystemBrowser' with: [ spec requires: #('NewTools-Inspector') ];
 			"system reporter"
 			package: 'NewTools-SystemReporter' with: [ spec requires: #('NewTools-Core') ];
+			"spotter"
+			package: 'NewTools-Spotter-Processors';
+			package: 'NewTools-Spotter' with: [ spec requires: #('NewTools-Core' 'NewTools-Spotter-Processors') ];
+			package: 'NewTools-Spotter-Extensions' with: [ spec requires: #('NewTools-Spotter') ];
+			package: 'NewTools-Spotter-Processors-Tests' with: [ spec requires: #('NewTools-Spotter-Processors') ];
+			package: 'NewTools-Morphic-Spotter' with: [ spec requires: #('NewTools-Morphic') ];
 			"extras"
 			package: 'HelpCenter' with: [ spec requires: #('NewTools-Core') ];
 			package: 'NewTools-FlagBrowser' with: [ spec requires: #('NewTools-Core') ];
@@ -78,6 +88,12 @@ BaselineOfNewTools >> baseline: spec [
 				'NewTools-Debugger-Breakpoints-Tools'
 				'NewTools-Debugger-Tests'
 				'NewTools-Debugger-Fuel');
+			group: 'Spotter' with: #(
+				'NewTools-Morphic-Spotter' 
+				'NewTools-Spotter-Processors' 
+				'NewTools-Spotter' 
+				'NewTools-Spotter-Extensions'
+				'NewTools-Spotter-Processors-Tests');
 			group: 'SystemReporter' with: #('Core' 'NewTools-SystemReporter');
 			group: 'Methods' with: #('Core' 'NewTools-MethodBrowsers');
 			"Not in the image for the moment, we need a pass on them"
@@ -99,11 +115,12 @@ BaselineOfNewTools >> baseline: spec [
 				'Inspector'
 				'Debugger'
 				'Methods'
+				'Spotter'
 				"'ChangeSorter'"
 				"'KeymapBrowser'"
-				"'FlagBrowser'");
+				"'FlagBrowser'").
 			"A group for running CI"
-			group: 'CI' with: #('Spec2' 'default') ]
+			"spec group: 'CI' with: #('Spec2' 'default')" ]
 ]
 
 { #category : #dependencies }

--- a/src/GT-Spotter-Processors/SptSpotterProcessor.class.st
+++ b/src/GT-Spotter-Processors/SptSpotterProcessor.class.st
@@ -86,7 +86,7 @@ SptSpotterProcessor class >> settingsDescription [
 
 { #category : #settings }
 SptSpotterProcessor class >> settingsOn: aBuilder [
-	<systemsettings>
+	"<systemsettings>
 
 	(aBuilder group: #spotterProcessors)
 		parent: #spotter;
@@ -102,7 +102,7 @@ SptSpotterProcessor class >> settingsOn: aBuilder [
 			target: aProcessorClass;
 			description: aProcessorClass settingsDescription;
 			label: aProcessorClass settingsTitle
-	].
+	]."
 ]
 
 { #category : #settings }

--- a/src/GT-Spotter-UI/GTSpotterGlobalShortcut.class.st
+++ b/src/GT-Spotter-UI/GTSpotterGlobalShortcut.class.st
@@ -14,20 +14,8 @@ GTSpotterGlobalShortcut class >> isGlobalCategory [
 
 { #category : #accessing }
 GTSpotterGlobalShortcut class >> openGlobalSpotter [
-	| spotterModel |
-		
-	self reset.
-	spotterModel := GTSpotter new.
-		
-	GTSpotterMorph new
-		extent: (self currentWorld width / 2.4 @ (self currentWorld height / 1.6)) asIntegerPoint;
-		spotterModel: spotterModel;
-		doLayout;
-		openCenteredInWorld;
-		initializeListeners;
-		takeKeyboardFocus.
-		
-	spotterModel class markOpened.
+
+	Smalltalk tools spotter open
 ]
 
 { #category : #accessing }

--- a/src/GT-Spotter/GTSpotter.class.st
+++ b/src/GT-Spotter/GTSpotter.class.st
@@ -138,7 +138,7 @@ GTSpotter class >> resetHistory [
 
 { #category : #testing }
 GTSpotter class >> settingsOn: aBuilder [
-	<systemsettings>
+	"<systemsettings>
 	(aBuilder group: #spotter)
 		parent: #tools;
 		label: 'Spotter';
@@ -149,7 +149,7 @@ GTSpotter class >> settingsOn: aBuilder [
 		default: false;
 		target: self;
 		description: 'If Spotter will show the preview panel on the right of spotter';
-		label: 'Show Preview Panel'.
+		label: 'Show Preview Panel'."
 ]
 
 { #category : #accessing }

--- a/src/GT-Spotter/GTSpotter.class.st
+++ b/src/GT-Spotter/GTSpotter.class.st
@@ -91,6 +91,24 @@ GTSpotter class >> on: anObject [
 	^ self new foundationOrigin: anObject
 ]
 
+{ #category : #'instance creation' }
+GTSpotter class >> open [
+	| spotterModel |
+		
+	GTSpotterGlobalShortcut reset.
+	spotterModel := self new.
+		
+	GTSpotterMorph new
+		extent: (self currentWorld width / 2.4 @ (self currentWorld height / 1.6)) asIntegerPoint;
+		spotterModel: spotterModel;
+		doLayout;
+		openCenteredInWorld;
+		initializeListeners;
+		takeKeyboardFocus.
+		
+	spotterModel class markOpened
+]
+
 { #category : #accessing }
 GTSpotter class >> previewVisible [
 
@@ -101,6 +119,13 @@ GTSpotter class >> previewVisible [
 GTSpotter class >> previewVisible: aValue [
 
 	isPreviewVisible := aValue
+]
+
+{ #category : #'instance creation' }
+GTSpotter class >> registerToolsOn: registry [
+	"self registerToolsOn: Smalltalk tools"
+
+	"registry register: self as: #spotter"
 ]
 
 { #category : #accessing }

--- a/src/GT-Spotter/GTSpotterPragmaBasedProcessor.class.st
+++ b/src/GT-Spotter/GTSpotterPragmaBasedProcessor.class.st
@@ -29,7 +29,7 @@ GTSpotterPragmaBasedProcessor class >> defaultItemsLimit: aValue [
 
 { #category : #'accessing-defaults' }
 GTSpotterPragmaBasedProcessor class >> settingsOn: aBuilder [
-	<systemsettings>
+	"<systemsettings>
 
 	(aBuilder setting: #defaultItemsLimit)
 		target: self;
@@ -38,7 +38,7 @@ GTSpotterPragmaBasedProcessor class >> settingsOn: aBuilder [
 		default: 25;
 		order: 100;
 		description:
-			'Number of results per category to show in Spotter'
+			'Number of results per category to show in Spotter'"
 ]
 
 { #category : #public }

--- a/src/NewTools-Core/StPharoApplication.class.st
+++ b/src/NewTools-Core/StPharoApplication.class.st
@@ -4,9 +4,6 @@ The application for the Pharo IDE.
 Class {
 	#name : #StPharoApplication,
 	#superclass : #SpApplication,
-	#instVars : [
-		'tools'
-	],
 	#classVars : [
 		'Current'
 	],
@@ -89,14 +86,8 @@ StPharoApplication >> start [
 
 { #category : #'system startup' }
 StPharoApplication >> startUp: resuming [
-]
 
-{ #category : #'accessing resources' }
-StPharoApplication >> styleSheet [
-
-	^ StPharoStyleContributor allSubclasses 
-			inject: super styleSheet 
-			into: [ :accum :each | accum , (each new styleSheetContribution) ]
+	self resetConfiguration
 ]
 
 { #category : #settings }

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -5,7 +5,6 @@ Class {
 	#name : #StDebuggerActionModel,
 	#superclass : #Object,
 	#instVars : [
-		'debugger',
 		'session',
 		'contextPredicate',
 		'topContext',

--- a/src/NewTools-Debugger/StDebuggerErrorContextPredicate.class.st
+++ b/src/NewTools-Debugger/StDebuggerErrorContextPredicate.class.st
@@ -32,6 +32,15 @@ StDebuggerErrorContextPredicate >> exception: anObject [
 	exception := anObject
 ]
 
+{ #category : #accessing }
+StDebuggerErrorContextPredicate >> exceptionWhiteList [
+
+	^ { 
+		  Warning.
+		  OupsNullException.
+		  Halt }
+]
+
 { #category : #predicates }
 StDebuggerErrorContextPredicate >> isContextDoesNotUnderstand [
 

--- a/src/NewTools-Debugger/StDebuggerInspector.class.st
+++ b/src/NewTools-Debugger/StDebuggerInspector.class.st
@@ -14,7 +14,6 @@ Class {
 		'label',
 		'rawInspectionSelectionCache',
 		'assertionFailure',
-		'currentLayout',
 		'currentLayoutSpec',
 		'lateralToolbar'
 	],

--- a/src/NewTools-Inspector-Extensions/OrderedDictionary.extension.st
+++ b/src/NewTools-Inspector-Extensions/OrderedDictionary.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : #Dictionary }
+Extension { #name : #OrderedDictionary }
 
 { #category : #'*NewTools-Inspector-Extensions' }
-Dictionary >> inspectionItems: aBuilder [
+OrderedDictionary >> inspectionItems: aBuilder [
 	<inspectorPresentationOrder: 0 title: 'Items'> 
 	
 	^ aBuilder newTable 

--- a/src/NewTools-Inspector-Extensions/SmallDictionary.extension.st
+++ b/src/NewTools-Inspector-Extensions/SmallDictionary.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : #Dictionary }
+Extension { #name : #SmallDictionary }
 
 { #category : #'*NewTools-Inspector-Extensions' }
-Dictionary >> inspectionItems: aBuilder [
+SmallDictionary >> inspectionItems: aBuilder [
 	<inspectorPresentationOrder: 0 title: 'Items'> 
 	
 	^ aBuilder newTable 

--- a/src/NewTools-Inspector/StInspector.class.st
+++ b/src/NewTools-Inspector/StInspector.class.st
@@ -18,8 +18,7 @@ Class {
 		'millerList',
 		'model',
 		'lastPageSelectedTabName',
-		'withHeaderBar',
-		'paginator'
+		'withHeaderBar'
 	],
 	#classVars : [
 		'IndexableDisplayLimit'

--- a/src/NewTools-Inspector/StMetaBrowser.class.st
+++ b/src/NewTools-Inspector/StMetaBrowser.class.st
@@ -4,8 +4,7 @@ Class {
 	#instVars : [
 		'classes',
 		'methods',
-		'source',
-		'methodFilter'
+		'source'
 	],
 	#category : #'NewTools-Inspector-View'
 }

--- a/src/NewTools-Inspector/StNodeCollector.class.st
+++ b/src/NewTools-Inspector/StNodeCollector.class.st
@@ -83,10 +83,3 @@ StNodeCollector >> slotNodes [
 				hostObject: self object 
 				slot: each ]
 ]
-
-{ #category : #building }
-StNodeCollector >> tempNodesForContext: aContext [
-
-	^ aContext astScope allTemps collect: [ :temp | 
-		  (StInspectorTempNode hostObject: aContext) tempVariable: temp ]
-]

--- a/src/NewTools-Inspector/StRawInspection.class.st
+++ b/src/NewTools-Inspector/StRawInspection.class.st
@@ -172,7 +172,7 @@ StRawInspection >> valuesColumn [
 	^ SpStringTableColumn new
 		title: 'Value';
 		evaluated: #stringValue;
-		beEditable;
+		"beEditable;"
 		onAcceptEdition: [ :node :value | 
 			self inform: node label , '=' , value asString	"node value: value" ];
 		sortFunction: #stringValue ascending;

--- a/src/NewTools-Morphic-Spotter/StSpotterStyleContributor.class.st
+++ b/src/NewTools-Morphic-Spotter/StSpotterStyleContributor.class.st
@@ -1,0 +1,32 @@
+Class {
+	#name : #StSpotterStyleContributor,
+	#superclass : #StPharoStyleContributor,
+	#category : #'NewTools-Morphic-Spotter'
+}
+
+{ #category : #styles }
+StSpotterStyleContributor >> styleSheetContribution [
+	
+	^ SpStyle newApplication 
+		addClass: 'presenter' with: [ :class |	class 
+			addClass: 'stSpotter' with: [ :spotterClass | spotterClass 
+				addPropertyDrawWith: [ :draw | draw backgroundColor: Color red ] ];
+			addClass: 'stSpotterLink' with: [ :spotterLinkClass | spotterLinkClass 
+				addPropertyGeometryWith: [ :geometry | geometry height: 22; vResizing: false ] ] ]; 
+		addClass: 'componentList' with: [ :componentList | componentList 
+			addClass: 'stSpotterList' with: [ :spotter | spotter 
+				addPropertyDrawWith: [ :draw | draw color: Color transparent ] ] ];
+		addClass: 'searchInputField' with: [ :class | class 
+			addClass: 'stSpotterSearch' with: [ :spotterClass | spotterClass
+				addPropertyDrawWith: [ :draw | draw color: Color transparent ];
+				addPropertyTextWith: [ :text | text drawKeyboardFocus: false ];
+				addPropertyGeometryWith: [ :geometry | geometry minHeight: 35; vResizing: false ];
+				addPropertyFontWith: [ :font | font size: 12 ] ] ];
+		addClass: 'text' with: [ :class | class 
+			addClass: 'stSpotterPreview' with: [ :spotter | spotter
+				addPropertyDrawWith: [ :draw | draw color: Color transparent ] ] ];
+		addClass: 'code' with: [ :class | class 
+			addClass: 'stSpotterPreview' with: [ :spotterClass | spotterClass
+				addPropertyDrawWith: [ :draw | draw color: Color transparent ] ] ];
+		yourself
+]

--- a/src/NewTools-Morphic-Spotter/package.st
+++ b/src/NewTools-Morphic-Spotter/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'NewTools-Morphic-Spotter' }

--- a/src/NewTools-Morphic/StPharoMorphicConfiguration.class.st
+++ b/src/NewTools-Morphic/StPharoMorphicConfiguration.class.st
@@ -38,28 +38,9 @@ StPharoMorphicConfiguration >> configureWindows: anApplication [
 { #category : #private }
 StPharoMorphicConfiguration >> styleSheet [
 
-	^ SpStyle defaultStyleSheet, self styleSheetCommon
-]
-
-{ #category : #private }
-StPharoMorphicConfiguration >> styleSheetCommon [
-	"Just an example on how to build styles programatically ;)"
-
-	^ SpStyle newApplication 
-		addClass: 'presenter' with: [ :presenter |	presenter 
-			addClass: 'stSpotter' with: [ :spotter | spotter 
-				addPropertyDrawWith: [ :draw | draw color: Color transparent ] ];
-			addClass: 'stSpotterLink' with: [ :spotter | spotter 
-				addPropertyGeometryWith: [ :geometry | geometry height: 22; vResizing: false ] ] ]; 
-		addClass: 'componentList' with: [ :componentList | componentList 
-			addClass: 'stSpotterList' with: [ :spotter | spotter 
-				addPropertyDrawWith: [ :draw | draw color: Color transparent ] ] ];
-		addClass: 'searchInputField' with: [ :searchInputField | searchInputField 
-			addClass: 'stSpotterSearch' with: [ :spotter | spotter
-				addPropertyDrawWith: [ :draw | draw color: Color transparent ];
-				addPropertyGeometryWith: [ :geometry | geometry minHeight: 30; vResizing: false ];
-				addPropertyFontWith: [ :font | font size: 12 ] ] ];
-		yourself
+	^ StPharoStyleContributor availableContributors 
+		inject: SpStyle defaultStyleSheet 
+		into: [ :accum :each | accum, (each styleSheetContribution) ]
 ]
 
 { #category : #private }

--- a/src/NewTools-Morphic/StPharoStyleContributor.class.st
+++ b/src/NewTools-Morphic/StPharoStyleContributor.class.st
@@ -7,8 +7,16 @@ Also subclasses are able to extend the #isApplicable method in the class side an
 Class {
 	#name : #StPharoStyleContributor,
 	#superclass : #Object,
-	#category : #'NewTools-Core-Application'
+	#category : #'NewTools-Morphic'
 }
+
+{ #category : #'as yet unclassified' }
+StPharoStyleContributor class >> availableContributors [
+
+	^ self allSubclasses
+		select: [ :each | each isApplicable ]
+		thenCollect: [ :each | each new ]
+]
 
 { #category : #testing }
 StPharoStyleContributor class >> isApplicable [ 

--- a/src/NewTools-ObjectCentricBreakpoints/StObjectBreakpointInspection.extension.st
+++ b/src/NewTools-ObjectCentricBreakpoints/StObjectBreakpointInspection.extension.st
@@ -24,7 +24,7 @@ StObjectBreakpointInspection class >> removeBreakpointCommandFor: presenter [
 	| cmd |
 	cmd := StRemoveBreakpointCommand forSpecContext: presenter.
 	cmd iconName: #smallDelete.
-	cmd decoratedCommand
+	cmd innerCommand
 		transform: [ :ctx | ctx methodsWithBreakpoints selection selectedItem ].
 	^ cmd
 ]

--- a/src/NewTools-ObjectCentricBreakpoints/StObjectInspectorPresenter.extension.st
+++ b/src/NewTools-ObjectCentricBreakpoints/StObjectInspectorPresenter.extension.st
@@ -16,7 +16,7 @@ StObjectInspectorPresenter >> haltInspectedObjectOnWriteAccess [
 ]
 
 { #category : #'*NewTools-ObjectCentricBreakpoints' }
-StObjectInspectorPresenter classSide >> objectCentricBreakpointCommandsWith: aPresenter forRootGroup: aRootCommandsGroup [
+StObjectInspectorPresenter class >> objectCentricBreakpointCommandsWith: aPresenter forRootGroup: aRootCommandsGroup [
 	<extensionCommands>
 	
 	aRootCommandsGroup 

--- a/src/NewTools-Playground/StPlayground.class.st
+++ b/src/NewTools-Playground/StPlayground.class.st
@@ -47,9 +47,6 @@ See *class:StPlaygroundPagesPresenter*
 Class {
 	#name : #StPlayground,
 	#superclass : #StInspector,
-	#instVars : [
-		'page'
-	],
 	#classVars : [
 		'CacheDirectory'
 	],
@@ -124,6 +121,12 @@ StPlayground class >> registerToolsOn: registry [
 
 	registry register: self as: #workspace
 
+]
+
+{ #category : #accessing }
+StPlayground >> contents: aString [ 
+
+	self firstPage contents: aString
 ]
 
 { #category : #'api-focus' }

--- a/src/NewTools-Playground/StPlaygroundPagePresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPagePresenter.class.st
@@ -9,7 +9,6 @@ Class {
 		'text',
 		'toolbar',
 		'statusbar',
-		'bindings',
 		'lineLabel',
 		'toggleLineNumberButton',
 		'page',

--- a/src/NewTools-Playground/StPlaygroundPagesPresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPagesPresenter.class.st
@@ -11,8 +11,6 @@ Class {
 		'parent',
 		'pageList',
 		'pagePreview',
-		'pageListHeader',
-		'pagePreviewHeader',
 		'pageListPanel',
 		'pagePreviewPanel'
 	],

--- a/src/NewTools-Sindarin-Tools/StSindarinBytecodeContextInspectorModel.class.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinBytecodeContextInspectorModel.class.st
@@ -28,7 +28,9 @@ StSindarinBytecodeContextInspectorModel >> contextReceiverSlotNodes [
 
 { #category : #'*NewTools-Sindarin-Tools' }
 StSindarinBytecodeContextInspectorModel >> contextTempNodes [
-	^ StNodeCollector new tempNodesForContext: self inspectedObject
+	^ self inspectedObject astScope allTemps collect: [ :temp | 
+		  (StInspectorTempNode hostObject: self inspectedObject) tempVariable: temp ]
+
 ]
 
 { #category : #accessing }

--- a/src/NewTools-Sindarin-Tools/StSindarinBytecodeContextInspectorModel.extension.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinBytecodeContextInspectorModel.extension.st
@@ -11,5 +11,7 @@ StSindarinBytecodeContextInspectorModel >> contextReceiverSlotNodes [
 
 { #category : #'*NewTools-Sindarin-Tools' }
 StSindarinBytecodeContextInspectorModel >> contextTempNodes [
-	^ StNodeCollector new tempNodesForContext: self inspectedObject
+	^ self inspectedObject astScope allTemps collect: [ :temp | 
+		  (StInspectorTempNode hostObject: self inspectedObject) tempVariable: temp ]
+
 ]

--- a/src/NewTools-Sindarin-Tools/StSindarinDebuggerPresenter.class.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinDebuggerPresenter.class.st
@@ -2,13 +2,9 @@ Class {
 	#name : #StSindarinDebuggerPresenter,
 	#superclass : #StInspection,
 	#instVars : [
-		'currentNodeInspector',
 		'currentNodeSource',
-		'contextStack',
-		'sindarinDebuggingToolbar',
 		'stack',
 		'inspector',
-		'election',
 		'toolbar'
 	],
 	#category : #'NewTools-Sindarin-Tools'

--- a/src/NewTools-Spotter-Extensions/AbstractFileReference.extension.st
+++ b/src/NewTools-Spotter-Extensions/AbstractFileReference.extension.st
@@ -1,0 +1,60 @@
+Extension { #name : #AbstractFileReference }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+AbstractFileReference >> spotterForDirectoriesFor: aStep [
+	<stSpotterOrder: 10>
+	^ self isDirectory ifTrue: [
+		aStep listProcessor
+			allCandidates: [ self directories ];
+			title: 'Directories';
+			candidatesLimit: Float infinity;
+			itemName: #basename;
+			itemIcon: [ GLMUIThemeExtraIcons glamorousFolder ];
+			filter: GTFilterSubstring ]
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+AbstractFileReference >> spotterForFilesFor: aStep [
+	<stSpotterOrder: 20>
+	^ self isDirectory ifTrue: [
+		aStep listProcessor
+			allCandidates: [ self files ];
+			title: 'Files';
+			candidatesLimit: Float infinity;
+			itemName: #basename;
+			itemIcon: [ GLMUIThemeExtraIcons glamorousBrowse ];
+			filter: GTFilterSubstring ]
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+AbstractFileReference >> spotterForZipDirectoriesFor: aStep [
+	<stSpotterOrder: 10>
+	| zipFileSystem |
+	self isZipFile ifFalse: [ ^ self ].
+	aStep listProcessor
+			allCandidates: [ 
+				zipFileSystem := (FileSystem zip: self) open.
+				zipFileSystem workingDirectory directories ];
+			title: 'Directories';
+			candidatesLimit: Float infinity;
+			itemName: #basename;
+			itemIcon: [ GLMUIThemeExtraIcons glamorousFolder ];
+			filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+AbstractFileReference >> spotterForZipFilesFor: aStep [
+	<stSpotterOrder: 10>
+	| zipFileSystem |
+	self isZipFile ifFalse: [ ^ self ].
+	aStep listProcessor
+			allCandidates: [ 
+				zipFileSystem := (FileSystem zip: self) open.
+				zipFileSystem workingDirectory files ];
+			title: 'Files';
+			candidatesLimit: Float infinity;
+			itemName: #basename;
+			itemIcon: [ GLMUIThemeExtraIcons glamorousBrowse ];
+			filter: GTFilterSubstring
+	
+]

--- a/src/NewTools-Spotter-Extensions/Behavior.extension.st
+++ b/src/NewTools-Spotter-Extensions/Behavior.extension.st
@@ -1,0 +1,86 @@
+Extension { #name : #Behavior }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Behavior >> spotterClassInstanceVariablesFor: aStep [
+	<stSpotterOrder: 25>
+	self isTrait
+		ifTrue: [ ^ self ].
+	aStep listProcessor
+		title: 'Class instance variables';
+		allCandidates: [ self class classLayout allSlots ];
+		itemName: [ :each | each name asString ];
+		filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Behavior >> spotterCompositionFor: aStep [
+	<stSpotterOrder: 25>
+	aStep listProcessor
+			title: 'Composing traits';
+			allCandidates: [ self allTraits ];
+			itemIcon: #systemIcon;
+			filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Behavior >> spotterInstanceVariablesFor: aStep [
+	<stSpotterOrder: 20>
+	self isTrait
+		ifTrue: [ ^ self ].
+	aStep listProcessor
+		title: 'Instance variables';
+		allCandidates: [ self classLayout allSlots ];
+		itemName: [ :each | each name asString ];
+		filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Behavior >> spotterSubclassesFor: aStep [
+	<stSpotterOrder: 50>
+	aStep listProcessor
+			title: 'All subclasses';
+			allCandidates: [ self allSubclasses ];
+			itemIcon: #systemIcon;
+			filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Behavior >> spotterSuperclassesFor: aStep [
+	<stSpotterOrder: 40>
+	aStep listProcessor
+			title: 'All superclasses';
+			allCandidates: [ self allSuperclasses ];
+			itemIcon: #systemIcon;
+			filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Behavior >> spotterTraitUsersFor: aStep [
+	<stSpotterOrder: 20>
+	self isTrait ifFalse: [ ^ self ].
+	aStep listProcessor
+			title: 'Users';
+			allCandidates: [ self traitUsers asArray ];
+			itemIcon: #systemIcon;
+			filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Behavior >> spotterUsedSlotsFor: aStep [
+	<stSpotterOrder: 70>
+	aStep listProcessor
+			title: 'Full Definition Slots';
+			allCandidates: [ self slots select: [ :slot | slot needsFullDefinition ] ];
+			itemName: [ :item | item definitionString ];
+			filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Behavior >> spotterUsedTraitsFor: aStep [
+	<stSpotterOrder: 60>
+	aStep listProcessor
+			title: 'Uses Traits';
+			allCandidates: [ self traits asArray ];
+			itemIcon: #systemIcon;
+			filter: GTFilterSubstring
+]

--- a/src/NewTools-Spotter-Extensions/Class.extension.st
+++ b/src/NewTools-Spotter-Extensions/Class.extension.st
@@ -1,0 +1,51 @@
+Extension { #name : #Class }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Class >> spotterClassMethodsFor: aStep [
+	<stSpotterOrder: 15>
+	aStep listProcessor
+			title: 'Class methods';
+			allCandidates: [ self classSide methods ];
+			itemName: [ :method | method selector ];
+			filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Class >> spotterMethodsFor: aStep [
+	<stSpotterOrder: 10>
+	aStep listProcessor
+			title: 'Instance methods';
+			allCandidates: [ self methods ];
+			itemName: [ :method | method selector ];
+			filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Class >> spotterReferenceFor: aStep [
+	<stSpotterOrder: 30>
+	aStep listProcessor
+			title: 'References';
+			allCandidates: [ (SystemNavigation default allReferencesTo: self binding) collect: [:each | each compiledMethod ] ];
+			itemName: [ :method | method gtDisplayString ];
+			filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Class >> spotterSuperClassMethodsFor: aStep [
+	<stSpotterOrder: 16>
+	|superclasses|
+	superclasses := self class withAllSuperclasses select: #isMeta.
+	aStep listProcessor
+			title: 'Super class methods';
+			allCandidates: [ self classSide allMethods select: [ :each |(each methodClass = self classSide) not & (superclasses includes: each methodClass) ] ];
+			filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Class >> spotterSuperMethodsFor: aStep [
+	<stSpotterOrder: 11>
+	aStep listProcessor
+			title: 'Super instance methods';
+			allCandidates: [ self allMethods reject: [ :each | each methodClass = self ] ];
+			filter: GTFilterSubstring
+]

--- a/src/NewTools-Spotter-Extensions/ClassDescription.extension.st
+++ b/src/NewTools-Spotter-Extensions/ClassDescription.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #ClassDescription }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+ClassDescription >> spotterPackageFor: aStep [
+	<stSpotterOrder: 50>
+	aStep listProcessor
+			title: 'Package';
+			allCandidates: [ {self package} ];
+			itemName: [ :item | item packageName ];
+			itemIcon: #systemIcon;
+			filter: GTFilterSubstring
+]

--- a/src/NewTools-Spotter-Extensions/ClySpotterModel.extension.st
+++ b/src/NewTools-Spotter-Extensions/ClySpotterModel.extension.st
@@ -1,0 +1,25 @@
+Extension { #name : #ClySpotterModel }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+ClySpotterModel >> spotterForCommandsFor: aStep [
+	<stSpotterOrder: 20>
+
+	browser allContextsDo: [ :each | 
+		self commandListProcessorForContext: each step: aStep]
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+ClySpotterModel >> spotterForGoToFor: aStep [
+	<stSpotterOrder: 10>
+
+	aStep listProcessor
+		title: 'Go to';
+		allCandidates: [ self collectGoToCandidates ];
+		itemName: #name;
+		itemIcon: #icon;
+		candidatesLimit: 10;
+		filter: GTFilterSubstring;
+		actLogic: [ :assoc :step | 
+			step exit. 
+			assoc activate ]
+]

--- a/src/NewTools-Spotter-Extensions/Collection.extension.st
+++ b/src/NewTools-Spotter-Extensions/Collection.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : #Collection }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Collection >> spotterItemsFor: aStep [
+	<stSpotterOrder: 10>
+	| processor |
+
+	(self isEmpty or: [ self size > self gtCollectionSizeThreshold ]) ifTrue: [ ^ self ].
+	processor := aStep previousProcessorFrom: self.
+	^ aStep listProcessor
+		title: processor title;
+		candidatesLimit: 100;
+		items: [ self collect: [ :each | each asStSpotterCandidateLink value ] as: OrderedCollection ];
+		itemName: processor itemName;
+		itemIcon: processor itemIcon;
+		actLogic: processor actLogic; 
+		filter: processor filter gtListFilter;
+		wantsToDisplayOnEmptyQuery: true
+]

--- a/src/NewTools-Spotter-Extensions/CompiledMethod.extension.st
+++ b/src/NewTools-Spotter-Extensions/CompiledMethod.extension.st
@@ -1,0 +1,60 @@
+Extension { #name : #CompiledMethod }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+CompiledMethod >> spotterForBytecodesFor: aStep [
+	<stSpotterOrder: 15>
+	aStep listProcessor
+		title: 'Bytecode';
+		allCandidates: [ self symbolicBytecodes ];
+		itemName: #printString;
+		filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+CompiledMethod >> spotterForImplementorsFor: aStep [
+	<stSpotterOrder: 10>
+	aStep listProcessor
+			title: 'Implementors';
+			allCandidates: [ self implementors collect: [:each | each compiledMethod] ];
+			filter: GTFilterSubstring;
+			keyBinding: $m command
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+CompiledMethod >> spotterForMessagesFor: aStep [
+	<stSpotterOrder: 12>
+	aStep listProcessor
+			title: 'Messages';
+			allCandidates: [ self messages asSortedCollection collect: [:each | GTSelector new name: each ] ];
+			filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+CompiledMethod >> spotterForSendersFor: aStep [
+	<stSpotterOrder: 11>
+	aStep listProcessor
+			title: 'Senders';
+			allCandidates: [ self senders collect: [:each | each compiledMethod] ];
+			filter: GTFilterSubstring;
+			keyBinding: $n command
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+CompiledMethod >> spotterMethodClassFor: aStep [
+	<stSpotterOrder: 50>
+	aStep listProcessor
+			allCandidates: [  {self methodClass }];
+			title: 'Class';
+			filter: GTFilterSubstring;
+			itemIcon: #systemIcon
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+CompiledMethod >> spotterPreview: aBuilder [
+
+	^ aBuilder newCode
+		beForMethod: self;
+		beNotEditable;
+		text: self sourceCode;
+		yourself
+]

--- a/src/NewTools-Spotter-Extensions/Dictionary.extension.st
+++ b/src/NewTools-Spotter-Extensions/Dictionary.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #Dictionary }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Dictionary >> spotterForKeysFor: aStep [
+	<stSpotterOrder: 15>
+	aStep listProcessor
+			title: 'Keys';
+			allCandidates: [ self keys ];
+			candidatesLimit: 5;
+			filter: GTFilterSubstring
+]

--- a/src/NewTools-Spotter-Extensions/GTInspector.extension.st
+++ b/src/NewTools-Spotter-Extensions/GTInspector.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #GTInspector }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+GTInspector class >> spotterExtensionsFor: aStep [
+	<stSpotterOrder: 50>
+	aStep listProcessor
+			allCandidates: [ self inspectorExtendingMethods ];
+			title: 'Extensions';
+			itemName:[ :each | each gtDisplayString ];
+			filter: GTFilterSubstring;
+			wantsToDisplayOnEmptyQuery: true
+]

--- a/src/NewTools-Spotter-Extensions/GTSelector.extension.st
+++ b/src/NewTools-Spotter-Extensions/GTSelector.extension.st
@@ -1,0 +1,21 @@
+Extension { #name : #GTSelector }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+GTSelector >> spotterImplementorsFor: aStep [
+	<stSpotterOrder: 40>
+	^ aStep listProcessor
+		title: 'Implementors';
+		filter: GTFilterSubstring item: [ :filter :context | self implementors do: filter ];
+		keyBinding: $m meta
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+GTSelector >> spotterUsersFor: aStep [
+	<stSpotterOrder: 50>
+	^ aStep listProcessor
+		title: 'Senders';
+		filter: GTFilterSubstring item: [ :filter :context | 
+			self senders do: [ :sender | 
+				filter value: sender compiledMethod ] ];
+		keyBinding: $n meta
+]

--- a/src/NewTools-Spotter-Extensions/GTSpotter.extension.st
+++ b/src/NewTools-Spotter-Extensions/GTSpotter.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #GTSpotter }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+GTSpotter class >> spotterExtensionsFor: aStep [
+	<stSpotterOrder: 50>
+	aStep listProcessor
+			allCandidates: [ self spotterExtendingMethods ];
+			title: 'Extensions';
+			itemName:[ :each | each gtDisplayString ];
+			filter: GTFilterSubstring;
+			wantsToDisplayOnEmptyQuery: true
+]

--- a/src/NewTools-Spotter-Extensions/GlobalVariable.extension.st
+++ b/src/NewTools-Spotter-Extensions/GlobalVariable.extension.st
@@ -1,0 +1,21 @@
+Extension { #name : #GlobalVariable }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+GlobalVariable >> spotterClassFor: aStep [
+	<stSpotterOrder: 50>
+	aStep listProcessor
+			title: 'Class';
+			allCandidates: [ { self value class }];
+			itemIcon: #systemIcon;
+			filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+GlobalVariable >> spotterForReferencesFor: aStep [
+	<stSpotterOrder: 130>
+	aStep listProcessor
+			title: 'References';
+			allCandidates: [ (SystemNavigation default allReferencesTo: self) collect: [:each | each compiledMethod] ];
+			itemName: [ :method | method gtDisplayString ];
+			filter: GTFilterSubstring
+]

--- a/src/NewTools-Spotter-Extensions/HelpTopic.extension.st
+++ b/src/NewTools-Spotter-Extensions/HelpTopic.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #HelpTopic }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+HelpTopic >> spotterForHelpTopicFor: aStep [
+	<stSpotterOrder: 200>
+	self flag: 'filter for multiple items like #title + #contents (combined by OR)'.
+	self flag: #specialFilter.
+	aStep listProcessor 
+		title: 'Help contents';
+		items: [ self subtopics ];
+		itemName: [ :helpTopic | helpTopic title ];
+		itemIcon: [ :helpTopic | helpTopic gtTopicIcon ];
+		filter: GTFilterSubstrings;
+		wantsToDisplayOnEmptyQuery: true
+]

--- a/src/NewTools-Spotter-Extensions/KMDispatcher.extension.st
+++ b/src/NewTools-Spotter-Extensions/KMDispatcher.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #KMDispatcher }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+KMDispatcher >> spotterForKeysFor: aStep [
+	<stSpotterOrder: 15>
+		
+	aStep listProcessor
+			title: 'Keys';
+			allCandidates: [ (self gtAllKeyCategoryPairs collect: [:each | each key]) asOrderedCollection ];
+			itemName: [ :aKeymap | 
+				aKeymap shortcut gtDisplayString, 
+				(aKeymap name ifNil: [ '' ] ifNotNil: [ ' [', aKeymap name,']' ]) ];
+			candidatesLimit: 5;
+			filter: GTFilterSubstrings
+]

--- a/src/NewTools-Spotter-Extensions/MCPackage.extension.st
+++ b/src/NewTools-Spotter-Extensions/MCPackage.extension.st
@@ -1,0 +1,22 @@
+Extension { #name : #MCPackage }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+MCPackage >> spotterForPackageFor: aStep [
+	<stSpotterOrder: 2>
+	aStep listProcessor
+		title: 'Packages';
+		allCandidates: [ Array with: self correspondingRPackage ];
+		itemName: [ :package | package name ];
+		itemIcon: [ Smalltalk ui icons iconNamed: #packageIcon ];
+		filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+MCPackage >> spotterMonticelloWorkingCopyFor: aStep [
+	<stSpotterOrder: 1>
+	aStep listProcessor
+		title: 'Monticello Working Copy';
+		allCandidates: [ Array with: self workingCopy ];
+		itemIcon: [ Smalltalk ui icons iconNamed: #versionControlIcon ];
+		filter: GTFilterSubstring
+]

--- a/src/NewTools-Spotter-Extensions/MCVersionInfo.extension.st
+++ b/src/NewTools-Spotter-Extensions/MCVersionInfo.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #MCVersionInfo }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+MCVersionInfo >> spotterAncestorsFor: aStep [
+	<stSpotterOrder: 1>
+	self flag: 'rewrite for direct streaming - get rid of recursion'.
+	aStep listProcessor
+		title: 'Ancestors';
+		allCandidates: [ self allAncestors ];
+		filter: GTFilterSubstring
+]

--- a/src/NewTools-Spotter-Extensions/MCWorkingCopy.extension.st
+++ b/src/NewTools-Spotter-Extensions/MCWorkingCopy.extension.st
@@ -1,0 +1,61 @@
+Extension { #name : #MCWorkingCopy }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+MCWorkingCopy >> spotterAllRepositoriesFor: aStep [
+	<stSpotterOrder: 20>
+	aStep listProcessor
+		title: 'All other repositories';
+		allCandidates: [ MCRepositoryGroup default repositories \ self repositoryGroup repositories ];
+		itemName: [ :item | item description ];
+		actLogic: [ :item :step | 
+			step exit.
+			self spotterCommit: self in: item ];
+		filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+MCWorkingCopy >> spotterAncestorsFor: aStep [
+	<stSpotterOrder: 2>
+	self flag: #maybeRewriteForDirectStreaming.
+	aStep listProcessor
+		title: 'Ancestors';
+		allCandidates: [ self allAncestors ];
+		filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+MCWorkingCopy >> spotterMonticelloPackageFor: aStep [
+	<stSpotterOrder: 21>
+	aStep listProcessor
+		title: 'Monticello Package';
+		allCandidates: [ Array with: self package ];
+		itemIcon: [ Smalltalk ui icons iconNamed: #monticelloPackageIcon ];
+		filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+MCWorkingCopy >> spotterPackageFor: aStep [
+	<stSpotterOrder: 21>
+	self flag: #maybeRewriteForDirectStreaming.
+	aStep listProcessor
+		title: 'Packages';
+		allCandidates: [ self package correspondingRPackage 
+			ifNotNil: [ :rpackage | { rpackage } ] 
+			ifNil: [ { } ] ];
+		itemName: [ :item | item name ];
+		itemIcon: [ Smalltalk ui icons iconNamed: #packageIcon ];
+		filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+MCWorkingCopy >> spotterPackageRepositoriesFor: aStep [
+	<stSpotterOrder: 10>
+	aStep listProcessor
+		title: 'Package repositories';
+		allCandidates: [ self repositoryGroup repositories ];
+		itemName: [ :item | item description ];
+		actLogic: [ :item :step |
+			step exit.
+			self spotterCommit: self in: item ];
+		filter: GTFilterSubstring
+]

--- a/src/NewTools-Spotter-Extensions/MenuItemMorph.extension.st
+++ b/src/NewTools-Spotter-Extensions/MenuItemMorph.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #MenuItemMorph }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+MenuItemMorph >> spotterPreview: aBuilder [
+
+	^ self balloonText spotterPreview: aBuilder
+]

--- a/src/NewTools-Spotter-Extensions/MetacelloAbstractPackageSpec.extension.st
+++ b/src/NewTools-Spotter-Extensions/MetacelloAbstractPackageSpec.extension.st
@@ -1,0 +1,23 @@
+Extension { #name : #MetacelloAbstractPackageSpec }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+MetacelloAbstractPackageSpec >> spotterForIncludesFor: aStep [
+	<stSpotterOrder: 1>
+	aStep listProcessor
+		title: 'Includes';
+		allCandidates: [ self includes ];
+		itemName: [ :item | item name ];
+		filter: GTFilterSubstring;
+		wantsToDisplayOnEmptyQuery: true
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+MetacelloAbstractPackageSpec >> spotterForRequiresFor: aStep [
+	<stSpotterOrder: 2>
+	aStep listProcessor
+		title: 'Requires';
+		allCandidates: [ self requires ];
+		itemName: [ :item | item name ];
+		filter: GTFilterSubstring;
+		wantsToDisplayOnEmptyQuery: true
+]

--- a/src/NewTools-Spotter-Extensions/MetacelloProject.extension.st
+++ b/src/NewTools-Spotter-Extensions/MetacelloProject.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : #MetacelloProject }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+MetacelloProject >> spotterForVersionsFor: aStep [
+	<stSpotterOrder: 1>
+	self flag: #maybeRewriteForDirectStreaming.
+	aStep listProcessor
+		title: 'Versions';
+		allCandidates: [
+			(#( stableVersion currentVersion bleedingEdge development ) 
+				collect: [ :each | [ self perform: each ] on: Error do: [  nil ] ]) 
+				reject: [ :each | each isNil ] ];
+		itemName: [ :version | version versionString ];
+		filter: GTFilterSubstring;
+		wantsToDisplayOnEmptyQuery: true
+]

--- a/src/NewTools-Spotter-Extensions/MetacelloVersion.extension.st
+++ b/src/NewTools-Spotter-Extensions/MetacelloVersion.extension.st
@@ -1,0 +1,23 @@
+Extension { #name : #MetacelloVersion }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+MetacelloVersion >> spotterForGroupsFor: aStep [
+	<stSpotterOrder: 2>
+	aStep listProcessor
+		title: 'Groups';
+		allCandidates: [ self groups ];
+		itemName: [ :item | item name ];
+		filter: GTFilterSubstring;
+		wantsToDisplayOnEmptyQuery: true
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+MetacelloVersion >> spotterForPackagesFor: aStep [
+	<stSpotterOrder: 3>
+	aStep listProcessor
+		title: 'Packages';
+		allCandidates: [ self packages ];
+		itemName: [ :item | item file ];
+		filter: GTFilterSubstring;
+		wantsToDisplayOnEmptyQuery: true
+]

--- a/src/NewTools-Spotter-Extensions/Morph.extension.st
+++ b/src/NewTools-Spotter-Extensions/Morph.extension.st
@@ -1,0 +1,28 @@
+Extension { #name : #Morph }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Morph >> spotterForKeysFor: aStep [
+	<stSpotterOrder: 15>
+	(self hasProperty: #kmDispatcher) ifFalse: [^self].
+	self kmDispatcher spotterForKeysFor: aStep
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Morph >> spotterForSubmorphsFor: aStep [
+	<stSpotterOrder: 10>
+	self submorphs ifNil: [ ^ self ].
+	
+	aStep listProcessor
+			title: 'Submorphs';
+			allCandidates: [ self submorphs ];
+			candidatesLimit: 5;
+			filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Morph >> spotterPreview: aBuilder [
+
+	^ aBuilder newImage 
+		image: (self asFormOfSize: 300@300);
+		yourself
+]

--- a/src/NewTools-Spotter-Extensions/Pragma.extension.st
+++ b/src/NewTools-Spotter-Extensions/Pragma.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : #Pragma }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Pragma >> spotterForBytecodesFor: aStep [
+	<stSpotterOrder: 15>
+	self method spotterForBytecodesFor: aStep
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Pragma >> spotterForImplementorsFor: aStep [
+	<stSpotterOrder: 10>
+	self method spotterForImplementorsFor: aStep
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Pragma >> spotterForSendersFor: aStep [
+	<stSpotterOrder: 10>
+	self method spotterForSendersFor: aStep
+]

--- a/src/NewTools-Spotter-Extensions/RPackage.extension.st
+++ b/src/NewTools-Spotter-Extensions/RPackage.extension.st
@@ -1,0 +1,54 @@
+Extension { #name : #RPackage }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+RPackage >> spotterClassesFor: aStep [
+	<stSpotterOrder: 20>
+	aStep listProcessor
+			allCandidates: [ self definedClasses sorted: [ :a :b | a name < b name ] ];
+			title: 'Classes';
+			filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+RPackage >> spotterExtensionMethodsFor: aStep [
+	<stSpotterOrder: 30>
+	aStep listProcessor
+			allCandidates: [ self extensionMethods ];
+			title: 'Extension Methods';
+			filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+RPackage >> spotterMonticelloPackageFor: aStep [
+	<stSpotterOrder: 41>
+	aStep listProcessor
+		title: 'Monticello Package';
+		allCandidates: [ self mcPackage 
+			ifNotNil: [ :mcPackage | Array with: mcPackage ] 
+			ifNil: [ #() ] ];
+		itemIcon: [ Smalltalk ui icons iconNamed: #monticelloPackageIcon ];
+		filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+RPackage >> spotterMonticelloWorkingCopyFor: aStep [
+	<stSpotterOrder: 42>
+	aStep listProcessor
+		title: 'Monticello Working Copy';
+		allCandidates: [ self mcPackage 
+			ifNotNil: [ :mcPackage | Array with: mcPackage workingCopy ] 
+			ifNil: [ #() ] ];
+		itemIcon: [ Smalltalk ui icons iconNamed: #versionControlIcon ];
+		filter: GTFilterSubstring
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+RPackage >> spotterTagsFor: aStep [
+	<stSpotterOrder: 20>
+	self classTags size <= 1 ifTrue: [ ^ self ].
+	aStep listProcessor
+			allCandidates: [ self classTags sorted: [ :a :b | a name < b name ] ];
+			title: 'Tags';
+			itemName: [ :item | item name ];
+			filter: GTFilterSubstring
+]

--- a/src/NewTools-Spotter-Extensions/RPackageTag.extension.st
+++ b/src/NewTools-Spotter-Extensions/RPackageTag.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #RPackageTag }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+RPackageTag >> spotterClassesFor: aStep [
+	<stSpotterOrder: 20>
+	aStep listProcessor
+			allCandidates: [ self classes sorted: [ :a :b | a name < b name ] ];
+			title: 'Classes';
+			filter: GTFilterSubstring
+]

--- a/src/NewTools-Spotter-Extensions/ReflectiveMethod.extension.st
+++ b/src/NewTools-Spotter-Extensions/ReflectiveMethod.extension.st
@@ -1,0 +1,31 @@
+Extension { #name : #ReflectiveMethod }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+ReflectiveMethod >> spotterForBytecodesFor: aStep [
+	<stSpotterOrder: 15>
+	compiledMethod spotterForBytecodesFor: aStep
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+ReflectiveMethod >> spotterForImplementorsFor: aStep [
+	<stSpotterOrder: 10>
+	self compiledMethod spotterForImplementorsFor: aStep
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+ReflectiveMethod >> spotterForMessagesFor: aStep [
+	<stSpotterOrder: 12>
+	self compiledMethod spotterForMessagesFor: aStep
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+ReflectiveMethod >> spotterForSendersFor: aStep [
+	<stSpotterOrder: 11>
+	self compiledMethod spotterForSendersFor: aStep
+]
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+ReflectiveMethod >> spotterMethodClassFor: aStep [
+	<stSpotterOrder: 50>
+	self compiledMethod spotterMethodClassFor: aStep
+]

--- a/src/NewTools-Spotter-Extensions/SettingNode.extension.st
+++ b/src/NewTools-Spotter-Extensions/SettingNode.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #SettingNode }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+SettingNode >> spotterForSettingsFor: aStep [
+	<stSpotterOrder: 0>
+	self allChildren isEmpty ifTrue: [ ^ self ].
+	aStep listProcessor
+		title: 'Children';
+		allCandidates: [ self allChildren ];
+		itemName: [ :each | each spotterLabel ];
+		filter: GTFilterSubstring
+]

--- a/src/NewTools-Spotter-Extensions/SettingTree.extension.st
+++ b/src/NewTools-Spotter-Extensions/SettingTree.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #SettingTree }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+SettingTree >> spotterForSettingsFor: aStep [
+	<stSpotterOrder: 0>
+	aStep listProcessor
+		title: 'Settings';
+		allCandidates: [ self nodeList ];
+		itemName: [ :each | each spotterLabel ];
+		filter: GTFilterSubstring
+]

--- a/src/NewTools-Spotter-Extensions/Slot.extension.st
+++ b/src/NewTools-Spotter-Extensions/Slot.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #Slot }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Slot >> spotterAccessesFor: aStep [
+	<stSpotterOrder: 10>
+	(aStep hasPreviousStep and: [
+		(aStep previousStep origin isKindOf: Class) or: [
+			aStep origin isKindOf: Class]]) ifTrue: [
+		aStep listProcessor
+				title: 'Accesses';
+				allCandidates: [  
+						(aStep previousStep origin slotNamed: self name) usingMethods ];
+				itemName: [:each | each asString];
+				filter: GTFilterSubstring ]
+]

--- a/src/NewTools-Spotter-Extensions/StFilterImplementor.class.st
+++ b/src/NewTools-Spotter-Extensions/StFilterImplementor.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : #StFilterImplementor,
+	#superclass : #StFilterSubstring,
+	#category : #'NewTools-Spotter-Extensions'
+}
+
+{ #category : #public }
+StFilterImplementor class >> gtListFilter [
+	^ GTFilterSubstring new
+]
+
+{ #category : #private }
+StFilterImplementor >> applyFilterWithQuery [
+
+	super applyFilterWithQuery.
+	self filteredItems: (self filteredItems reject: [ :each | each isFromTrait ])
+]
+
+{ #category : #'private-model' }
+StFilterImplementor >> itemFilterNameFor: each [
+
+	self flag: 'this filter wants to filter items by #selector (speed 10x), but dive-in-category wants to filter by #printString. Most filters in dive-in-category wants to filter by #printString, but not all. Others: files, topics, help, ... ?'.
+	^ each selector
+]
+
+{ #category : #public }
+StFilterImplementor >> stListFilter [
+
+	^ StFilterSubstring new
+]

--- a/src/NewTools-Spotter-Extensions/SystemWindow.extension.st
+++ b/src/NewTools-Spotter-Extensions/SystemWindow.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #SystemWindow }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+SystemWindow >> spotterWindowsFor: aStep [
+	<stSpotterOrder: 100>
+
+	aStep listProcessor
+			title: 'Windows';
+			allCandidates: [ self class allSubInstances ];
+			itemName: [ :window | '**', window label, '**' ];
+			filter: GTFilterSubstring
+]

--- a/src/NewTools-Spotter-Extensions/package.st
+++ b/src/NewTools-Spotter-Extensions/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'NewTools-Spotter-Extensions' }

--- a/src/NewTools-Spotter-Processors-Tests/StAbstractProcessorTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StAbstractProcessorTest.class.st
@@ -1,0 +1,94 @@
+Class {
+	#name : #StAbstractProcessorTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'text',
+		'candidates',
+		'context',
+		'processor',
+		'stream'
+	],
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #testing }
+StAbstractProcessorTest class >> isAbstract [ 
+
+	^ self == StAbstractProcessorTest
+]
+
+{ #category : #asserting }
+StAbstractProcessorTest >> assertQuantityOfResults: anInteger [ 
+	
+	self assert: candidates results size equals: anInteger
+]
+
+{ #category : #asserting }
+StAbstractProcessorTest >> assertResultsIncludes: anElement [ 
+	
+	self assert: ((candidates results collect: [:each | each content]) includes: anElement)
+]
+
+{ #category : #asserting }
+StAbstractProcessorTest >> denyResultsIncludes: anElement [ 
+
+	self deny: ((candidates results collect: [:each | each content]) includes: anElement )
+]
+
+{ #category : #tests }
+StAbstractProcessorTest >> processor [
+
+	^ self subclassResponsibility 
+]
+
+{ #category : #testing }
+StAbstractProcessorTest >> rerunWithText: aText [ 
+	
+	text := aText.
+	context search: aText.
+	context text: aText.
+	candidates reset.
+	processor filterInContext: context
+]
+
+{ #category : #tests }
+StAbstractProcessorTest >> runForText: aText [
+
+	candidates := StMockCandidatesList new.
+	text := aText.
+	stream := StMockSpotterStream new
+		receiver: candidates;
+		yourself.
+
+	context:= StSpotterContext new 
+		step: self;
+		stream: stream;
+		text: text;
+		search: text;
+		yourself.
+
+	processor := self processor.
+			
+	processor filterInContext: context.
+]
+
+{ #category : #running }
+StAbstractProcessorTest >> setUp [ 
+	
+	super setUp.
+	SptDefaultSourceFactory forTest.
+]
+
+{ #category : #running }
+StAbstractProcessorTest >> tearDown [ 
+
+	SptSourceFactory reset.
+	super tearDown.
+]
+
+{ #category : #tests }
+StAbstractProcessorTest >> testSearchingInvalidTextDoesNotReturnResult [
+
+	self runForText: 'assdsadasdsada'.
+	self assert: candidates results isEmpty
+]

--- a/src/NewTools-Spotter-Processors-Tests/StBenchProcessors.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StBenchProcessors.class.st
@@ -1,0 +1,138 @@
+"
+I am a test class to measure the impact of the new implementation of spotter processors.
+"
+Class {
+	#name : #StBenchProcessors,
+	#superclass : #Object,
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #benchmarking }
+StBenchProcessors >> benchClassFinding [
+	<script: 'self new benchClassFinding'>
+
+	| numberOfClasses |
+	
+	numberOfClasses := SystemNavigation default allBehaviors size.
+
+	(String streamContents: [ :aStream |
+		aStream 
+			<< 'Classes'; cr;
+			<< '-------'; cr;
+			cr;
+			<< 'Total Classes:';
+			print: numberOfClasses;
+			cr;cr.
+
+		self runClassBenchMarksFor: 'znu' resultsInto: aStream for: #ClassProcessor.	
+		self runClassBenchMarksFor: 'ast' resultsInto: aStream for: #ClassProcessor.	
+		self runClassBenchMarksFor: 'gtspotter' resultsInto: aStream for: #ClassProcessor.	
+		self runClassBenchMarksFor: 'test' resultsInto: aStream for: #ClassProcessor.	
+	]) inspect.
+
+]
+
+{ #category : #benchmarking }
+StBenchProcessors >> benchImplementors [
+	<script: 'self new benchImplementors'>
+
+	| numberOfMethods |
+	
+	numberOfMethods := SystemNavigation default allBehaviors sum: [:c | c localMethods size].
+
+	(String streamContents: [ :aStream |
+		aStream 
+			<< 'Methods'; cr;
+			<< '-------'; cr;
+			cr;
+			<< 'Total Methods:';
+			print: numberOfMethods;
+			cr;cr.
+
+		self runClassBenchMarksFor: 'asString' resultsInto: aStream for: #ImplementorsProcessor.	
+		self runClassBenchMarksFor: 'printOn:' resultsInto: aStream for: #ImplementorsProcessor.	
+		self runClassBenchMarksFor: 'asUrl' resultsInto: aStream for: #ImplementorsProcessor.	
+		self runClassBenchMarksFor: 'test' resultsInto: aStream for: #ImplementorsProcessor.	
+	]) inspect.
+
+]
+
+{ #category : #benchmarking }
+StBenchProcessors >> contextForText: aString [
+
+	| candidates stream |
+
+	candidates := StMockCandidatesList new.
+	stream := StMockSpotterStream new
+		receiver: candidates;
+		onAddedSelector: #addObject:inProcessor:;
+		yourself.
+
+	^ StSpotterContext new 
+		step: self;
+		stream: stream;
+		text: aString;
+		search: aString;
+		yourself.
+
+	
+]
+
+{ #category : #benchmarking }
+StBenchProcessors >> newClassProcessor [
+
+	^ StClassProcessor new
+]
+
+{ #category : #benching }
+StBenchProcessors >> newImplementorsProcessor [
+	
+	^ StImplementorsProcessor new
+]
+
+{ #category : #benchmarking }
+StBenchProcessors >> oldClassProcessor [
+
+	^ StSpotterCandidatesListProcessor new
+		allCandidates: [ Smalltalk allClassesAndTraits ];
+		title: 'Classes';
+		filter: StFilterFuzzy;
+		itemIcon: #systemIcon;
+		keyBinding: $b meta;
+		wantsToDisplayOnEmptyQuery: false;
+		yourself
+]
+
+{ #category : #benching }
+StBenchProcessors >> oldImplementorsProcessor [
+
+	^ StSpotterCandidatesListProcessor new
+		title: 'Implementors';
+		filter: StFilterImplementor item: [ :filter :context | 
+			SystemNavigation default allBehaviorsDo: [ :class | class methodsDo: filter ] ];
+		keyBinding: $m meta;
+		wantsToDisplayOnEmptyQuery: false
+]
+
+{ #category : #benching }
+StBenchProcessors >> runClassBenchMarksFor: aString resultsInto: aWriteStream for: processorName [
+	| context oldProcessor newProcessor oldBench newBench |
+	
+	oldBench := [
+		context := self contextForText: aString.
+		oldProcessor := self perform: ('old' , processorName) asSymbol.
+		oldProcessor filterInContext: context ] bench.
+
+	newBench := [
+		context := self contextForText: aString.
+		newProcessor := self perform: ('new' , processorName) asSymbol.
+		newProcessor filterInContext: context ] bench.
+
+	aWriteStream
+			<< 'Searching:';
+			print: aString; tab; tab; tab;
+			<< 'Old Implementation:'; 
+			<< oldBench; tab;	
+			<< 'new Implementation:'; 
+			<< newBench; cr.
+]

--- a/src/NewTools-Spotter-Processors-Tests/StCamelCaseSplitTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StCamelCaseSplitTest.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : #StCamelCaseSplitTest,
+	#superclass : #TestCase,
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #tests }
+StCamelCaseSplitTest >> testSingleLowercaseLetter [
+
+	self 
+		assertCollection: 'a' splitCamelCase 
+		hasSameElements: {'a'}
+]
+
+{ #category : #tests }
+StCamelCaseSplitTest >> testSingleUppercaseLetter [
+
+	self 
+		assertCollection: 'A' splitCamelCase 
+		hasSameElements: { 'A' }
+]
+
+{ #category : #tests }
+StCamelCaseSplitTest >> testSplittingShouldNotLosePrefix [
+
+	self 
+		assertCollection: 'GTSpotter' splitCamelCase 
+		hasSameElements: {'GTSpotter'}
+]
+
+{ #category : #tests }
+StCamelCaseSplitTest >> testTwoDifferentWordsStartingWithLowerCase [
+
+	self 
+		assertCollection: 'anObject' splitCamelCase 
+		hasSameElements: {'an'. 'Object'}
+]
+
+{ #category : #tests }
+StCamelCaseSplitTest >> testTwoDifferentWordsStartingWithUpperCase [
+
+	self 
+		assertCollection: 'AnObject' splitCamelCase 
+		hasSameElements: {'An'. 'Object'}
+]

--- a/src/NewTools-Spotter-Processors-Tests/StCatalogProjectsProcessorTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StCatalogProjectsProcessorTest.class.st
@@ -1,0 +1,57 @@
+Class {
+	#name : #StCatalogProjectsProcessorTest,
+	#superclass : #StAbstractProcessorTest,
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #tests }
+StCatalogProjectsProcessorTest >> processor [
+
+	^ StCatalogProjectsProcessor new
+]
+
+{ #category : #running }
+StCatalogProjectsProcessorTest >> setUp [ 
+	
+	super setUp.
+	StMockCatalogProvider forTest
+]
+
+{ #category : #running }
+StCatalogProjectsProcessorTest >> tearDown [ 
+
+	StMockCatalogProvider reset.
+	super tearDown
+]
+
+{ #category : #tests }
+StCatalogProjectsProcessorTest >> testBeginsWithQueryShowsResults [
+
+	| jsonProject |
+	jsonProject := CatalogProvider default projects detect: [:e | e name = 'JSON'].
+
+	self runForText: 'JSON'.
+	self assertResultsIncludes: jsonProject.
+
+]
+
+{ #category : #tests }
+StCatalogProjectsProcessorTest >> testEmptyQueryNotShowResults [
+
+	self runForText: ''.
+	self assert: candidates results isEmpty
+
+]
+
+{ #category : #tests }
+StCatalogProjectsProcessorTest >> testLookingSubstringShowsResults [
+
+	| jsonProject artefactProject |
+	jsonProject := CatalogProvider default projects detect: [:e | e name = 'JSON'].
+	artefactProject := CatalogProvider default projects detect: [:e | e name = 'Artefact'].
+
+	self runForText: 'son'.
+	self denyResultsIncludes: artefactProject.
+	self assertResultsIncludes: jsonProject.
+
+]

--- a/src/NewTools-Spotter-Processors-Tests/StClassProcessorTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StClassProcessorTest.class.st
@@ -1,0 +1,50 @@
+Class {
+	#name : #StClassProcessorTest,
+	#superclass : #StAbstractProcessorTest,
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #tests }
+StClassProcessorTest >> processor [
+
+	^ StClassProcessor new
+]
+
+{ #category : #tests }
+StClassProcessorTest >> testFindGTClassProcessorTest [
+
+	self runForText: 'stclassprocessortest'.
+	self assertResultsIncludes: StClassProcessorTest
+]
+
+{ #category : #tests }
+StClassProcessorTest >> testFindGTClassProcessorTestAfterAddingTest [
+
+	self runForText: 'stclass'.
+	self rerunWithText: 'stclassprocess'.
+	
+	self assertResultsIncludes: StClassProcessorTest 
+]
+
+{ #category : #tests }
+StClassProcessorTest >> testFindGTClassProcessorTestWithPartialText [
+
+	self runForText: 'stclass'.
+	self assertResultsIncludes: StClassProcessorTest
+]
+
+{ #category : #tests }
+StClassProcessorTest >> testGTClassProcessorIsRemovedAfterUpdatingText [
+
+	self runForText: 'gtclass'.
+	self rerunWithText: 'gtclassprocesst'.
+	
+	self denyResultsIncludes: SptClassProcessor
+]
+
+{ #category : #tests }
+StClassProcessorTest >> testPopularStringDoesReturnOnlyTenResults [
+
+	self runForText: 'test'.
+	self assertQuantityOfResults: 25.
+]

--- a/src/NewTools-Spotter-Processors-Tests/StGeneratorBlockIteratorTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StGeneratorBlockIteratorTest.class.st
@@ -1,0 +1,55 @@
+Class {
+	#name : #StGeneratorBlockIteratorTest,
+	#superclass : #TestCase,
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #tests }
+StGeneratorBlockIteratorTest >> testIteratorOnACalculatedCollectionReturnsOnlyFirst [
+
+	| it m |
+	 
+	it := StGeneratorBlockIterator on: [ :aBlock | 
+		SystemNavigation default allBehaviorsDo: [ :e | e methodsDo: aBlock ] ].	
+	
+	m := it next.
+	
+	self assert: m isNotNil.
+	self assert: m isCompiledMethod.	
+]
+
+{ #category : #tests }
+StGeneratorBlockIteratorTest >> testIteratorWithEmptyBlockIsAtEnd [
+	| it |
+	
+	it := StGeneratorBlockIterator on: [ :aBlock |  ].
+	self assert: it atEnd.
+]
+
+{ #category : #tests }
+StGeneratorBlockIteratorTest >> testIteratorWithInfiniteBlockNotCallIfNotUsed [
+	| it count |
+	
+	count := 0. 
+	it := StGeneratorBlockIterator on: [ :aBlock | [aBlock value: count. count := count + 1] repeat ].	
+	self assert: count equals: 0.
+]
+
+{ #category : #tests }
+StGeneratorBlockIteratorTest >> testIteratorWithInfiniteBlockOnlyCallFirstTimes [
+	| it count |
+	
+	count := 1. 
+	it := StGeneratorBlockIterator on: [ :aBlock | [aBlock value: count. count := count + 1] repeat ].
+	it next: 4.
+	self assert: count equals: 5.
+]
+
+{ #category : #tests }
+StGeneratorBlockIteratorTest >> testIteratorWithSingleElementIsAtEndAfterNext [
+	| it |
+	 
+	it := StGeneratorBlockIterator on: [ :aBlock | aBlock value: 1 ].	
+	it next.
+	self assert: it atEnd.
+]

--- a/src/NewTools-Spotter-Processors-Tests/StGeneratorIteratorTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StGeneratorIteratorTest.class.st
@@ -1,0 +1,62 @@
+Class {
+	#name : #StGeneratorIteratorTest,
+	#superclass : #TestCase,
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #tests }
+StGeneratorIteratorTest >> testCollectionWithSingleElementReturnsIt [
+	| gen |
+	
+	gen := StCollectionIterator on: #(1).
+	self assert: gen next equals: 1
+]
+
+{ #category : #tests }
+StGeneratorIteratorTest >> testCollectionWithSingleManyElementsReturnsTheRequested [
+	| gen |
+	
+	gen := StCollectionIterator on: #(1 2 3 4 5 6 7 8 9 10).
+	
+	self assert: gen next equals: 1.
+	self assert: gen next equals: 2.
+	self assert: gen next equals: 3.
+]
+
+{ #category : #tests }
+StGeneratorIteratorTest >> testCollectionWithSingleManyElementsReturnsTheRequestedInCollection [
+	| gen |
+	
+	gen := StCollectionIterator on: #(1 2 3 4 5 6 7 8 9 10).
+	self assertCollection: (gen next:3) hasSameElements: #(1 2 3).
+
+]
+
+{ #category : #tests }
+StGeneratorIteratorTest >> testCollectionWithSingleWithALotOfElementsReturnsTheRequestedInCollection [
+	| gen |
+	
+	gen := StCollectionIterator on: (1 to: 10**99).
+	self assertCollection: (gen next:3) hasSameElements: #(1 2 3).
+
+]
+
+{ #category : #tests }
+StGeneratorIteratorTest >> testEmptyCollectionIsAtEnd [
+	| gen |
+	
+	gen := StCollectionIterator on: #().
+	self assert: gen atEnd
+]
+
+{ #category : #tests }
+StGeneratorIteratorTest >> testResetRestartsIterationOnTheCollection [
+	| gen |
+	
+	gen := StCollectionIterator on: #(1 2 3 4 5 6 7 8 9 10).
+	
+	self assertCollection: (gen next:3) hasSameElements: #(1 2 3).
+	gen reset.
+	self assertCollection: (gen next:3) hasSameElements: #(1 2 3).
+	
+]

--- a/src/NewTools-Spotter-Processors-Tests/StHelpProcessorTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StHelpProcessorTest.class.st
@@ -1,0 +1,50 @@
+Class {
+	#name : #StHelpProcessorTest,
+	#superclass : #StAbstractProcessorTest,
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #tests }
+StHelpProcessorTest >> assertResultsIncludesHelpTopic: aHelpTopic [
+
+	^ self assert: (candidates results
+				anySatisfy: [ :each | each content title = aHelpTopic title ])
+]
+
+{ #category : #tests }
+StHelpProcessorTest >> denyResultsIncludesHelpTopic: aHelpTopic [
+
+	^ self assert: (candidates results
+				noneSatisfy: [ :each | each content title = aHelpTopic title ])
+]
+
+{ #category : #tests }
+StHelpProcessorTest >> processor [
+
+	^ StHelpProcessor new
+]
+
+{ #category : #tests }
+StHelpProcessorTest >> testBeginsWithQueryShowsResults [
+
+	self runForText: 'Contr'.
+	self assertResultsIncludesHelpTopic: HowToContributeHelp asHelpTopic.
+
+]
+
+{ #category : #tests }
+StHelpProcessorTest >> testEmptyQueryShowsResults [
+
+	self runForText: ''.
+	self assertResultsIncludesHelpTopic: WelcomeHelp asHelpTopic.
+
+]
+
+{ #category : #tests }
+StHelpProcessorTest >> testLookingSubstringShowsResults [
+
+	self runForText: 'menu'.
+	self denyResultsIncludesHelpTopic: HowToContributeHelp asHelpTopic.
+	self assertResultsIncludesHelpTopic: WorldMenuHelp asHelpTopic.
+
+]

--- a/src/NewTools-Spotter-Processors-Tests/StHistoryProcessorTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StHistoryProcessorTest.class.st
@@ -1,0 +1,58 @@
+Class {
+	#name : #StHistoryProcessorTest,
+	#superclass : #StAbstractProcessorTest,
+	#instVars : [
+		'firstValue',
+		'secondValue'
+	],
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #tests }
+StHistoryProcessorTest >> processor [
+
+	^ StHistoryProcessor new
+]
+
+{ #category : #running }
+StHistoryProcessorTest >> setUp [
+	super setUp. 
+	
+	firstValue := StClassEntry on: self class.
+	secondValue := StClassEntry on: StUnifiedProcessorTest.
+	
+	StSpotter new historize: firstValue.
+	StSpotter new historize: secondValue.
+]
+
+{ #category : #running }
+StHistoryProcessorTest >> tearDown [
+
+	StSpotter resetHistory.
+	super tearDown
+]
+
+{ #category : #tests }
+StHistoryProcessorTest >> testEmptyQueryShowsResults [
+
+	self runForText: ''.
+	self assertResultsIncludes: self class.
+
+]
+
+{ #category : #tests }
+StHistoryProcessorTest >> testLookingHistoryQueryShowsResults [
+
+	self runForText: 'sthistory'.
+	self assertResultsIncludes: self class.
+
+]
+
+{ #category : #tests }
+StHistoryProcessorTest >> testLookingSubstringShowsResults [
+
+	self runForText: 'unifi'.
+	self denyResultsIncludes: self class.
+	self assertResultsIncludes: StUnifiedProcessorTest.
+
+]

--- a/src/NewTools-Spotter-Processors-Tests/StImplementorsProcessorTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StImplementorsProcessorTest.class.st
@@ -1,0 +1,41 @@
+Class {
+	#name : #StImplementorsProcessorTest,
+	#superclass : #StAbstractProcessorTest,
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #tests }
+StImplementorsProcessorTest >> processor [
+
+	^ StImplementorsProcessor new
+]
+
+{ #category : #tests }
+StImplementorsProcessorTest >> testFindThisMethod [
+
+	self runForText: 'testFindThisMethod'.
+	self assertResultsIncludes: thisContext method
+]
+
+{ #category : #tests }
+StImplementorsProcessorTest >> testFindThisMethodAfterAddingText [
+
+	self runForText: 'test'.
+	self runForText: 'testFindThisMethod'.
+	
+	self assertResultsIncludes: thisContext method
+]
+
+{ #category : #tests }
+StImplementorsProcessorTest >> testPopularStringDoesReturnOnlyTenResults [
+
+	self runForText: 'test'.
+	self assertQuantityOfResults: 25.
+]
+
+{ #category : #tests }
+StImplementorsProcessorTest >> testPopularStringDoesReturnOnlyTenResultsWithUppercase [
+
+	self runForText: 'Test'.
+	self assertQuantityOfResults: 25.
+]

--- a/src/NewTools-Spotter-Processors-Tests/StIteratorsTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StIteratorsTest.class.st
@@ -1,0 +1,322 @@
+Class {
+	#name : #StIteratorsTest,
+	#superclass : #TestCase,
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #tests }
+StIteratorsTest >> testBeginsWithFilterDoesNotFetchTwiceIfTheFilterIsARefinementOfPreviousText [
+
+	| it |
+	it := (SptGeneratorBlockIterator on: [ :x | x value: 'bbb'; value:'bbb1'; error ]) beginsWithFilter: 'b'.
+	it next.
+	it beginsWithFilter: 'bb'.
+	
+	self assert: it next equals: 'bbb'
+]
+
+{ #category : #tests }
+StIteratorsTest >> testBeginsWithFilterReturnsValidResults [
+
+	| it |
+	it := (SptCollectionIterator on: { 'aaa'. 'bbb'. 'ccc' }) beginsWithFilter: 'b'.
+	self assert: it next equals: 'bbb'
+]
+
+{ #category : #tests }
+StIteratorsTest >> testBeginsWithFilterReturnsValidResultsWithTheSameFilter [
+
+	| it |
+	it := (SptCollectionIterator on: { 'aaa'. 'bbb'. 'ccc' }) beginsWithFilter: 'b'.
+	it beginsWithFilter: 'b'.
+	
+	self assert: it next equals: 'bbb'
+]
+
+{ #category : #tests }
+StIteratorsTest >> testIteratorOnACollectedCollectionIsFiltered [
+
+	| it |
+	it := ((SptCollectionIterator on: #(1 2 3)) 
+		collect: [ :e | e * 2 ])
+		select: [:e | e even].
+	self assertCollection: (it next: 3) hasSameElements: #(2 4 6).
+
+]
+
+{ #category : #tests }
+StIteratorsTest >> testIteratorOnACollectionIsFiltered [
+
+	| it |
+
+	it := (SptCollectionIterator on: #(1 2 3)) select: [:e | e even].
+
+	self assertCollection: (it next: 3) hasSameElements: #(2).
+
+]
+
+{ #category : #tests }
+StIteratorsTest >> testIteratorOnACollectionReturnsTheCollection [
+
+	| it |
+	it := SptCollectionIterator on: #(1 2 3).
+	self assertCollection: (it next:3) hasSameElements: #(1 2 3)
+]
+
+{ #category : #tests }
+StIteratorsTest >> testIteratorOnACollectionReturnsTheFirstValue [
+
+	| it |
+
+	it := SptCollectionIterator on: #(1 2 3).
+	self assert: (it next) equals: 1
+]
+
+{ #category : #tests }
+StIteratorsTest >> testIteratorOnACollectionReturnsTheFirstValueAndSecondValue [
+
+	| it |
+
+	it := SptCollectionIterator on: #(1 2 3).
+	self assert: (it next) equals: 1.
+	self assert: (it next) equals: 2	
+]
+
+{ #category : #tests }
+StIteratorsTest >> testIteratorOnACollectionWithCollectReturnsCorrectFirstValue [
+
+	| it |
+	it := (SptCollectionIterator on: #(1 2 3)) collect: [:e | e * 3].
+	self assert: (it next) equals: 3.
+
+]
+
+{ #category : #tests }
+StIteratorsTest >> testIteratorOnACollectionWithCollectReturnsCorrectValues [
+
+	| it |
+	it := (SptCollectionIterator on: #(1 2 3)) collect: [:e | e * 3].
+	self assertCollection: (it next: 3) hasSameElements: #(3 6 9).
+
+]
+
+{ #category : #tests }
+StIteratorsTest >> testIteratorOnACollectionWithTwoCollectReturnsCorrectFirstValue [
+
+	| it |
+	it := ((SptCollectionIterator on: #(1 2 3)) collect: [:e | e * 3]) collect: [:e | e * 2].
+	self assert: it next equals: 6.
+
+]
+
+{ #category : #tests }
+StIteratorsTest >> testIteratorOnACollectionWithTwoCollectReturnsCorrectValues [
+	| it |
+	
+	it := ((StCollectionIterator on: #(1 2 3)) collect: [:e | e * 3]) collect: [:e | e * 2].
+	self assertCollection: (it next: 3) hasSameElements: #(6 12 18).
+
+]
+
+{ #category : #tests }
+StIteratorsTest >> testNonDuplicatesRemoveDuplicates [
+
+	| it |
+	
+	it := (StCollectionIterator on: #(1 1)) asWithoutDuplicates.
+	self assert: (it next:1) equals: #(1) asOrderedCollection
+]
+
+{ #category : #tests }
+StIteratorsTest >> testNonDuplicatesRemoveDuplicatesResetReturnsWithoutDuplicates [
+
+	| it |
+	
+	it := (StCollectionIterator on: #(1 1 2 2 3 3)) asWithoutDuplicates.
+	self assert: (it next:3) equals: #(1 2 3) asOrderedCollection.
+	
+	it reset. 
+	
+	self assert: (it next:3) equals: #(1 2 3) asOrderedCollection 
+]
+
+{ #category : #tests }
+StIteratorsTest >> testNonDuplicatesRemoveDuplicatesWithThree [
+	| it |
+	
+	it := (StCollectionIterator on: #(1 1 2 2 3 3)) asWithoutDuplicates.
+	self assert: (it next:3) equals: #(1 2 3) asOrderedCollection 
+]
+
+{ #category : #tests }
+StIteratorsTest >> testSequenceDetectsAtEnd [
+
+	| it |
+	it := (StCollectionIterator on: #(1 2 3)) , (StCollectionIterator on: #(4 5 6)).
+	it next: 3.
+	self deny: it atEnd.
+	it next: 3.
+	self assert: it atEnd.
+		
+
+	
+]
+
+{ #category : #tests }
+StIteratorsTest >> testSequenceReturnsTheSequenceOfAllResults [
+	| it |
+	
+	it := (StCollectionIterator on: #(1 2 3)) , (StCollectionIterator on: #(4 5 6)).
+	self assertCollection: (it next: 6) hasSameElements: #(1 2 3 4 5 6)
+]
+
+{ #category : #tests }
+StIteratorsTest >> testSequenceReturnsTheSequenceOfAllResultsInParts [
+	| it |
+	
+	it := (StCollectionIterator on: #(1 2 3)) , (StCollectionIterator on: #(4 5 6)).
+	
+	self assertCollection: (it next: 3) hasSameElements: #(1 2 3).
+	self assertCollection: (it next: 3) hasSameElements: #(4 5 6)	
+]
+
+{ #category : #tests }
+StIteratorsTest >> testSubstringFilterDoesNotFetchTwiceIfTheFilterIsARefinementOfPreviousText [
+
+	| it |
+	it := (StGeneratorBlockIterator on: [ :x | x value: '1bbb'; value:'11bbb1'; error ]) substringFilter: 'b'.
+	it next.
+	it substringFilter: 'bb'.
+	
+	self assert: it next equals: '1bbb'
+]
+
+{ #category : #tests }
+StIteratorsTest >> testSubstringFilterReturnsValidResults [
+
+	| it |
+	it := (StCollectionIterator on: { 'xxxaaa'. 'xxxbbb'. 'xxxccc' }) substringFilter: 'b'.
+	self assert: it next equals: 'xxxbbb'
+]
+
+{ #category : #tests }
+StIteratorsTest >> testSubstringFilterReturnsValidResultsWithTheSameFilter [
+	| it |
+
+	it := (StCollectionIterator on: { 'aaa'. 'xxxbbb'. 'ccc' }) substringFilter: 'b'.
+	it substringFilter: 'b'.
+	
+	self assert: it next equals: 'xxxbbb'
+]
+
+{ #category : #tests }
+StIteratorsTest >> testWordsAwareIteratorFiltersByASequenceOfCamelCase [
+
+	| inner it |
+	
+	inner := (StCollectionIterator on: { 'aaa'. 'xxxyyybbb'. 'xxxcccbbb' }) asSubstringFilter.
+	it := StWordsAwareFilter new
+		inner: inner;
+		yourself.
+		
+	it filteringText: 'xxxBbb'.
+	
+	self assert: it next equals: 'xxxyyybbb'.
+	self assert: it next equals: 'xxxcccbbb'	
+]
+
+{ #category : #tests }
+StIteratorsTest >> testWordsAwareIteratorFiltersByASequenceOfCamelCaseMixingCase [
+
+	| inner it |
+	
+	inner := (StCollectionIterator on: { 'aaa'. 'xxxyyyBBB'. 'XXXcccbbb'. 'xxxcccbbb' }) asSubstringFilter.
+	it := StWordsAwareFilter new
+		inner: inner;
+		yourself.
+		
+	it filteringText: 'xxxBbb'.
+	
+	self assert: it next equals: 'xxxyyyBBB'.
+	self assert: it next equals: 'XXXcccbbb'.
+	self assert: it next equals: 'xxxcccbbb'	
+]
+
+{ #category : #tests }
+StIteratorsTest >> testWordsAwareIteratorFiltersByASequenceOfCamelCaseWithUppercase [
+
+	| inner it |
+	
+	inner := (StCollectionIterator on: { 'aaa'. 'xxxyyybbb'. 'xxxcccbbb' }) asSubstringFilter.
+	it := StWordsAwareFilter new
+		inner: inner;
+		yourself.
+		
+	it filteringText: 'XxxBbb'.
+	
+	self assert: it next equals: 'xxxyyybbb'.
+	self assert: it next equals: 'xxxcccbbb'	
+]
+
+{ #category : #tests }
+StIteratorsTest >> testWordsAwareIteratorFiltersByASequenceOfWords [
+
+	| inner it |
+	
+	inner := (StCollectionIterator on: { 'aaa'. 'xxxyyybbb'. 'xxxcccbbb' }) asSubstringFilter.
+	it := StWordsAwareFilter new
+		inner: inner;
+		yourself.
+		
+	it filteringText: 'xxx bbb'.
+	
+	self assert: it next equals: 'xxxyyybbb'.
+	self assert: it next equals: 'xxxcccbbb'	
+]
+
+{ #category : #tests }
+StIteratorsTest >> testWordsAwareIteratorFiltersByASingleWord [
+
+	| inner it |
+	
+	inner := (StCollectionIterator on: { 'aaa'. 'xxxyyybbb'. 'xxxcccbbb' }) asSubstringFilter.
+	it := StWordsAwareFilter new
+		inner: inner;
+		yourself.
+		
+	it filteringText: 'xxx'.
+	
+	self assert: it next equals: 'xxxyyybbb'.
+	self assert: it next equals: 'xxxcccbbb'	
+]
+
+{ #category : #tests }
+StIteratorsTest >> testWordsAwareIteratorFiltersByASingleWordFindingNothing [
+
+	| inner it |
+	
+	inner := (StCollectionIterator on: { 'aaa'. 'xxxyyybbb'. 'xxxcccbbb' }) asSubstringFilter.
+	it := StWordsAwareFilter new
+		inner: inner;
+		yourself.
+		
+	it filteringText: 'zzz'.
+	
+	self assert: it next equals: nil
+]
+
+{ #category : #tests }
+StIteratorsTest >> testWordsAwareIteratorFiltersLeftOutBecauseSecondWord [
+
+	| inner it |
+	
+	inner := (StCollectionIterator on: { 'aaa'. 'xxxyyybbb'. 'xxxcccbbb' }) asSubstringFilter.
+	it := StWordsAwareFilter new
+		inner: inner;
+		yourself.
+		
+	it filteringText: 'xxx aaa'.
+	
+	self assert: it next equals: nil.
+
+]

--- a/src/NewTools-Spotter-Processors-Tests/StMockCandidatesList.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StMockCandidatesList.class.st
@@ -1,0 +1,73 @@
+Class {
+	#name : #StMockCandidatesList,
+	#superclass : #Object,
+	#instVars : [
+		'results',
+		'totalResults'
+	],
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #adding }
+StMockCandidatesList >> addAllCandidates: aCollection in: aProcessor [
+
+	results removeAll.
+	results addAll: aCollection
+]
+
+{ #category : #adding }
+StMockCandidatesList >> addCandidate: anEntry in: aProcessor [
+
+	results add: anEntry 
+	
+	
+]
+
+{ #category : #adding }
+StMockCandidatesList >> addObject: anObject inProcessor: aProcessor [
+
+	results add: anObject
+]
+
+{ #category : #adding }
+StMockCandidatesList >> addObjects: aCollection inProcessor: aProcessor [
+
+	results addAll: aCollection
+]
+
+{ #category : #adding }
+StMockCandidatesList >> initialize [ 
+	
+	super initialize.
+	results := OrderedCollection new
+]
+
+{ #category : #adding }
+StMockCandidatesList >> onAmountChanged: aQuantity in: processor [
+
+	totalResults := aQuantity
+]
+
+{ #category : #events }
+StMockCandidatesList >> processorEnded: aSptClassProcessor [ 
+
+	
+]
+
+{ #category : #events }
+StMockCandidatesList >> processorStarted: aSptClassProcessor [ 
+	
+	
+]
+
+{ #category : #accessing }
+StMockCandidatesList >> reset [
+	
+	results removeAll.
+	totalResults := 0.
+]
+
+{ #category : #accessing }
+StMockCandidatesList >> results [
+	^ results
+]

--- a/src/NewTools-Spotter-Processors-Tests/StMockCatalogProvider.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StMockCatalogProvider.class.st
@@ -1,0 +1,38 @@
+"
+I am a mock version of the CatalogProvider. 
+As the catalog provider goes to the network it produces flaky tests!!
+So I will return the projects required for the tests
+"
+Class {
+	#name : #StMockCatalogProvider,
+	#superclass : #CatalogProvider,
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #accessing }
+StMockCatalogProvider class >> forTest [
+
+	Default := self new
+]
+
+{ #category : #accessing }
+StMockCatalogProvider class >> reset [
+
+	Default := nil
+]
+
+{ #category : #private }
+StMockCatalogProvider >> loadProjects [
+	"I am a mock version I do not go to the network"
+
+	^ { self projectNamed: 'JSON'.
+	    self projectNamed: 'Artefact'.
+		 self projectNamed: 'ThirdProject'}
+]
+
+{ #category : #private }
+StMockCatalogProvider >> projectNamed: aName [
+
+	^ CatalogProject fromDictionary: { #name -> aName. #packageName -> aName.
+	#repositoryUrl -> ('http://github.com/lala/' , aName) } asDictionary 
+]

--- a/src/NewTools-Spotter-Processors-Tests/StMockSpotterStream.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StMockSpotterStream.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #StMockSpotterStream,
+	#superclass : #StSpotterStream,
+	#category : #'NewTools-Spotter-Processors-Tests-Scripting-Mocks'
+}
+
+{ #category : #performing }
+StMockSpotterStream >> performSymbol: aSymbol withArguments: aCollection [
+	self receiver perform: aSymbol withEnoughArguments: aCollection
+]

--- a/src/NewTools-Spotter-Processors-Tests/StPackageProcessorTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StPackageProcessorTest.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : #StPackageProcessorTest,
+	#superclass : #StAbstractProcessorTest,
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #tests }
+StPackageProcessorTest >> processor [
+
+	^ StPackageProcessor new
+]
+
+{ #category : #tests }
+StPackageProcessorTest >> testFindThisPackage [
+
+	self runForText: 'newtools-spotter-processors-tests'.
+	self assertResultsIncludes: self class package
+]
+
+{ #category : #tests }
+StPackageProcessorTest >> testFindThisPackageAfterAddingText [
+
+	self runForText: 'newtools-spo'.
+	self runForText: 'newtools-spotter-processors-tests'.
+
+	self assertResultsIncludes: self class package
+	
+	
+]
+
+{ #category : #tests }
+StPackageProcessorTest >> testGTSpotterNewIsRemovedAfterAddingText [
+
+	self runForText: 'gt-spotter'.
+	self rerunWithText: 'gt-spotter-new-te'.
+	
+	self denyResultsIncludes: SptClassProcessor package
+]
+
+{ #category : #tests }
+StPackageProcessorTest >> testPopularStringDoesReturnOnlyTenResults [
+
+	self runForText: 'test'.
+	self assertQuantityOfResults: 25.
+]

--- a/src/NewTools-Spotter-Processors-Tests/StUnifiedProcessorTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StUnifiedProcessorTest.class.st
@@ -1,0 +1,180 @@
+Class {
+	#name : #StUnifiedProcessorTest,
+	#superclass : #StAbstractProcessorTest,
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #tests }
+StUnifiedProcessorTest >> processor [
+
+	^ StUnifiedProcessor new
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testFindGTClassProcessorTest [
+
+	self runForText: 'stunifiedprocessortest'.
+	self assertResultsIncludes: StUnifiedProcessorTest
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testFindGTClassProcessorTestAfterAddingTest [
+
+	self runForText: 'stun'.
+	self rerunWithText: 'stunifiedprocess'.
+	
+	self assertResultsIncludes: self class
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testFindGTClassProcessorTestWithPartialText [
+
+	self runForText: 'stunifi'.
+	self assertResultsIncludes: self class
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testFindThisMethod [
+
+	self runForText: 'testFindThisMethod'.
+	self assertResultsIncludes: thisContext method
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testFindThisMethodAfterAddingText [
+
+	self runForText: 'test'.
+	self runForText: 'testFindThisMethod'.
+	
+	self assertResultsIncludes: thisContext method
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testFindThisMethodWithFullClass [
+
+	self runForText: 'StUnifiedProcessorTest >> #testFindThisMethod'.
+	self assertResultsIncludes: thisContext method
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testFindThisMethodWithFullClassDoesNotIncludeOtherClassMethod [
+
+	self runForText: 'StUnifiedProcessorTest >> #testFindThisMethod'.
+	self denyResultsIncludes: StImplementorsProcessorTest >> #testFindThisMethod
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testFindThisMethodWithFullClassIsTheCorrectclass [
+
+	self runForText: 'StUnifiedProcessorTest >> #testFindThisMethod'.
+	self
+		assert:
+			((candidates results collect: [:each | each content])
+				allSatisfy: [ :aMethod | aMethod methodClass = self class ])
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testFindThisPackage [
+
+	self runForText: 'newtools-spotter-processors'.
+	self assertResultsIncludes: StUnifiedProcessorTest package
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testFindThisPackageAfterAddingText [
+
+	self runForText: 'newtools-spo'.
+	self runForText: 'newtools-spotter-processors'.
+
+	self assertResultsIncludes: StUnifiedProcessorTest package
+	
+	
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testFindThisPackageWithCategory [
+
+	self runForText: '#Packages newtools-spotter-processors'.
+	self assertResultsIncludes: StUnifiedProcessorTest package
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testFindThisPackageWithOtherCategory [
+
+	self runForText: '#Classes newtools-spotter-processors'.
+	self denyResultsIncludes: self class package
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testGTClassProcessorIsRemovedAfterUpdatingText [
+
+	self runForText: 'stclass'.
+	self rerunWithText: 'stclassprocesst'.
+	
+	self denyResultsIncludes: StClassProcessor
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testGTSpotterNewIsRemovedAfterAddingText [
+
+	self runForText: 'newtools-spotter'.
+	self rerunWithText: 'newtools-spotter-other'.
+	
+	self denyResultsIncludes: StClassProcessor package
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testLookingForDiskStoreWithSpaceReturnsDiskStore [
+
+	self runForText: 'Disk Store'.
+	self assertResultsIncludes: DiskStore
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testLookingForStoreDiskLowercaseReturnsThisMethod [
+
+	self runForText: 'store disk'.
+	self assertResultsIncludes: StUnifiedProcessorTest >> #testLookingForStoreDiskLowercaseReturnsThisMethod
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testLookingForStoreDiskReturnsDiskStore [
+
+	self runForText: 'StoreDisk'.
+	self assertResultsIncludes: DiskStore
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testLookingForStoreDiskWithSpaceReturnsDiskStore [
+
+	self runForText: 'Store Disk'.
+	self assertResultsIncludes: DiskStore
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testLookingForStoreLowercaseReturnsDiskStore [
+
+	self runForText: 'store disk'.
+	self assertResultsIncludes: DiskStore
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testPopularStringDoesReturnOnlyTwentyResults [
+
+	self runForText: 'test'.
+	self assertQuantityOfResults: 25.
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testPopularStringDoesReturnOnlyTwentyResultsForPackage [
+
+	self runForText: '-Test'.
+	self assertQuantityOfResults: 25.
+]
+
+{ #category : #tests }
+StUnifiedProcessorTest >> testPopularStringDoesReturnOnlyTwentyResultsWithCapital [
+
+	self runForText: 'Test'.
+	self assertQuantityOfResults: 25.
+]

--- a/src/NewTools-Spotter-Processors-Tests/StWindowsProcessorTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StWindowsProcessorTest.class.st
@@ -1,0 +1,73 @@
+Class {
+	#name : #StWindowsProcessorTest,
+	#superclass : #StAbstractProcessorTest,
+	#instVars : [
+		'backWindow1',
+		'backWindow2',
+		'topMostWindow'
+	],
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #tests }
+StWindowsProcessorTest >> processor [
+
+	^ StWindowsProcessor new
+]
+
+{ #category : #running }
+StWindowsProcessorTest >> setUp [
+
+	super setUp.
+	backWindow1 := StandardWindow new title: 'backWindow1'; openInWorld; yourself.
+	backWindow2 := StandardWindow new title: 'backWindow2'; openInWorld; yourself.
+	topMostWindow := StandardWindow new title: 'topMostWindow'; openInWorld; yourself.		
+	
+]
+
+{ #category : #running }
+StWindowsProcessorTest >> tearDown [
+
+	{backWindow1. backWindow2. topMostWindow} 
+		do:[:e | e ifNotNil: [ e close ]].
+
+	super tearDown.	
+]
+
+{ #category : #tests }
+StWindowsProcessorTest >> testBackWindowsAreFind [
+
+	self runForText: 'back'.
+	self assertResultsIncludes: backWindow1.
+	self assertResultsIncludes: backWindow2.	
+]
+
+{ #category : #tests }
+StWindowsProcessorTest >> testBackWindowsAreFindWhenUsingSubstring [
+
+	self runForText: 'wind'.
+	self assertResultsIncludes: backWindow1.
+	self assertResultsIncludes: backWindow2.	
+]
+
+{ #category : #tests }
+StWindowsProcessorTest >> testBackWindowsAreShown [
+
+	self runForText: ''.
+	self assertResultsIncludes: backWindow1.
+	self assertResultsIncludes: backWindow2.	
+]
+
+{ #category : #tests }
+StWindowsProcessorTest >> testEmptyQueryShowsResults [
+
+	self runForText: ''.
+	self assertResultsIncludes: backWindow1
+]
+
+{ #category : #tests }
+StWindowsProcessorTest >> testTopMostWindowIsNotShown [
+
+	self runForText: ''.
+	self denyResultsIncludes: topMostWindow
+]

--- a/src/NewTools-Spotter-Processors-Tests/StWorldMenuProcessorTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StWorldMenuProcessorTest.class.st
@@ -1,0 +1,70 @@
+Class {
+	#name : #StWorldMenuProcessorTest,
+	#superclass : #StAbstractProcessorTest,
+	#category : #'NewTools-Spotter-Processors-Tests'
+}
+
+{ #category : #asserting }
+StWorldMenuProcessorTest >> assertResultsIncludesMenuEntry: aString [ 
+	
+	self assert: (candidates results anySatisfy: [:each | each content contents = aString ])
+]
+
+{ #category : #asserting }
+StWorldMenuProcessorTest >> denyResultsIncludesMenuEntry: aString [ 
+	
+	self assert: (candidates results noneSatisfy: [:each | each content contents = aString ])
+]
+
+{ #category : #tests }
+StWorldMenuProcessorTest >> processor [
+
+	^ StWorldMenuProcessor new
+]
+
+{ #category : #tests }
+StWorldMenuProcessorTest >> testEmptyQueryShowsResults [
+
+	self runForText: ''.
+	self assertResultsIncludesMenuEntry: 'Iceberg'.
+
+]
+
+{ #category : #tests }
+StWorldMenuProcessorTest >> testSearchingSaDoesNotIncludeIceberg [
+
+	self runForText: 'sa'.
+	self denyResultsIncludesMenuEntry: 'Iceberg'.
+
+]
+
+{ #category : #tests }
+StWorldMenuProcessorTest >> testSearchingSaIncludesSaveAndSaveAs [
+
+	self runForText: 'sa'.
+	self assertResultsIncludesMenuEntry: 'Save'.
+	self assertResultsIncludesMenuEntry: 'Save as...'	
+]
+
+{ #category : #tests }
+StWorldMenuProcessorTest >> testSearchingSettingsFindsTheCorrectEntry [
+
+	self runForText: 'settings'.
+	self assertResultsIncludesMenuEntry: 'Settings'
+]
+
+{ #category : #tests }
+StWorldMenuProcessorTest >> testSearchingVeDoesNotIncludeIceberg [
+
+	self runForText: 've'.
+	self denyResultsIncludesMenuEntry: 'Iceberg'.
+
+]
+
+{ #category : #tests }
+StWorldMenuProcessorTest >> testSearchingVeIncludesSaveAndSaveAs [
+
+	self runForText: 'Ve'.
+	self assertResultsIncludesMenuEntry: 'Save'.
+	self assertResultsIncludesMenuEntry: 'Save as...'	
+]

--- a/src/NewTools-Spotter-Processors-Tests/package.st
+++ b/src/NewTools-Spotter-Processors-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'NewTools-Spotter-Processors-Tests' }

--- a/src/NewTools-Spotter-Processors/ManifestNewToolsSpotterProcessors.class.st
+++ b/src/NewTools-Spotter-Processors/ManifestNewToolsSpotterProcessors.class.st
@@ -1,0 +1,13 @@
+"
+I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestNewToolsSpotterProcessors,
+	#superclass : #PackageManifest,
+	#category : #'NewTools-Spotter-Processors-Manifest'
+}
+
+{ #category : #'code-critics' }
+ManifestNewToolsSpotterProcessors class >> ruleReClassNotReferencedRuleV1FalsePositive [
+	^ #(#(#(#RGPackageDefinition #(#'NewTools-Spotter-Processors')) #'2020-03-26T18:37:51.234976+01:00') )
+]

--- a/src/NewTools-Spotter-Processors/MenuItemMorph.extension.st
+++ b/src/NewTools-Spotter-Processors/MenuItemMorph.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #MenuItemMorph }
+
+{ #category : #'*NewTools-Spotter-Processors' }
+MenuItemMorph >> withAllLeafItemsDo: aBlockClosure [
+
+	self subMenu ifNil: [ ^ aBlockClosure cull: self ].
+	self subMenu items do: [ :anItem | anItem withAllLeafItemsDo: aBlockClosure ]
+]

--- a/src/NewTools-Spotter-Processors/MenuMorph.extension.st
+++ b/src/NewTools-Spotter-Processors/MenuMorph.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #MenuMorph }
+
+{ #category : #'*NewTools-Spotter-Processors' }
+MenuMorph >> withAllLeafItemsDo: aBlockClosure [ 
+	
+	self items do: [:anItem | anItem withAllLeafItemsDo: aBlockClosure]
+]

--- a/src/NewTools-Spotter-Processors/StAbstractStringFilter.class.st
+++ b/src/NewTools-Spotter-Processors/StAbstractStringFilter.class.st
@@ -1,0 +1,103 @@
+"
+I implement an abstract string based filter.
+My users can update the filteringText using the message #filteringText:
+When a new filtering is done I can handle the update of the filtering strategy and also I keep a list of already returned values so on a reset the filter is reapply to them, without reseting the inner iterator.
+If the filter requires a full reset, I reset myself and the inner one.
+
+My subclasses implements #criterium: to change how the strings are compared.
+"
+Class {
+	#name : #StAbstractStringFilter,
+	#superclass : #StIteratorDecorator,
+	#instVars : [
+		'returnedIndex',
+		'originalUnwrapped',
+		'results',
+		'filteringText'
+	],
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #'instance creation' }
+StAbstractStringFilter class >> on: aStCombinator with: aString [
+
+	^ self new
+		originalUnwrapped: aStCombinator;
+		filteringText: aString
+]
+
+{ #category : #testing }
+StAbstractStringFilter >> atEnd [
+
+	^ (returnedIndex = results size) and: [ inner atEnd ]
+]
+
+{ #category : #protected }
+StAbstractStringFilter >> criterium: aString [
+
+	self subclassResponsibility 
+
+]
+
+{ #category : #protected }
+StAbstractStringFilter >> doReset [
+
+	originalUnwrapped reset.
+	returnedIndex := 0.
+	results := OrderedCollection new
+]
+
+{ #category : #accessing }
+StAbstractStringFilter >> filteringText: aString [
+
+	inner := originalUnwrapped select: [ :e | self criterium: e].
+
+	(aString asLowercase beginsWith: filteringText asLowercase) 
+		ifFalse: [ 
+			self reset ].
+
+	filteringText := aString.
+	results := results select: [ :e | self criterium: e].
+	returnedIndex := 0.
+
+
+]
+
+{ #category : #initialization }
+StAbstractStringFilter >> initialize [
+
+	filteringText := ''.
+	results := OrderedCollection new.
+	returnedIndex := ''.
+]
+
+{ #category : #accessing }
+StAbstractStringFilter >> next [
+
+	| nextOne |
+
+	(returnedIndex < results size) ifTrue: [  
+		returnedIndex := returnedIndex + 1.
+		^ results at: returnedIndex.	
+	].
+
+	nextOne := super next.
+	
+	nextOne 
+		ifNil: [ ^ nil ].
+	
+	results add: nextOne.
+	returnedIndex := results size.
+	
+	^ nextOne
+]
+
+{ #category : #accessing }
+StAbstractStringFilter >> originalUnwrapped [
+	^ originalUnwrapped
+]
+
+{ #category : #accessing }
+StAbstractStringFilter >> originalUnwrapped: anObject [
+	originalUnwrapped := anObject
+]

--- a/src/NewTools-Spotter-Processors/StBeginsWithFilter.class.st
+++ b/src/NewTools-Spotter-Processors/StBeginsWithFilter.class.st
@@ -1,0 +1,22 @@
+"
+I implement a simple beginsWith: string filter.
+"
+Class {
+	#name : #StBeginsWithFilter,
+	#superclass : #StAbstractStringFilter,
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #filtering }
+StBeginsWithFilter >> beginsWithFilter: aString [
+
+	self filteringText: aString
+]
+
+{ #category : #protected }
+StBeginsWithFilter >> criterium: aValue [
+
+	^ aValue asString asLowercase beginsWith: filteringText asLowercase
+
+
+]

--- a/src/NewTools-Spotter-Processors/StCaseSelectorIterator.class.st
+++ b/src/NewTools-Spotter-Processors/StCaseSelectorIterator.class.st
@@ -1,0 +1,56 @@
+"
+I implement a decorator that is useful with the string comparison.
+I implement a selection based in the first letter of the filteringText.
+I have two iterators inside, one for lowercase and other for uppercase text.
+
+If the text starts with a lowercase letter, I will iterate the values first from the lowercase, and the from the uppercase.
+If the text starts with an uppercase letter, I will iterate the values first from the uppercase, and the from the lowercase.
+
+"
+Class {
+	#name : #StCaseSelectorIterator,
+	#superclass : #StIteratorDecorator,
+	#instVars : [
+		'lowercaseIterator',
+		'uppercaseIterator'
+	],
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #protected }
+StCaseSelectorIterator >> doReset [
+
+	lowercaseIterator reset.
+	uppercaseIterator reset.
+]
+
+{ #category : #filtering }
+StCaseSelectorIterator >> filteringText: aString [
+	aString
+		ifEmpty: [ inner := lowercaseIterator.
+			^ self ].
+
+	inner := aString first isLowercase
+		ifTrue: [ lowercaseIterator , uppercaseIterator ]
+		ifFalse: [ uppercaseIterator , lowercaseIterator ].
+]
+
+{ #category : #accessing }
+StCaseSelectorIterator >> lowercaseIterator [
+	^ lowercaseIterator
+]
+
+{ #category : #accessing }
+StCaseSelectorIterator >> lowercaseIterator: anObject [
+	lowercaseIterator := anObject
+]
+
+{ #category : #accessing }
+StCaseSelectorIterator >> uppercaseIterator [
+	^ uppercaseIterator
+]
+
+{ #category : #accessing }
+StCaseSelectorIterator >> uppercaseIterator: anObject [
+	uppercaseIterator := anObject
+]

--- a/src/NewTools-Spotter-Processors/StCatalogProjectEntry.class.st
+++ b/src/NewTools-Spotter-Processors/StCatalogProjectEntry.class.st
@@ -1,0 +1,30 @@
+"
+I wrap a CatalogProject entry, to modify its behavior if required for the spotter
+"
+Class {
+	#name : #StCatalogProjectEntry,
+	#superclass : #StEntry,
+	#category : #'NewTools-Spotter-Processors-Entries'
+}
+
+{ #category : #converting }
+StCatalogProjectEntry >> asString [ 
+
+	^ content name
+]
+
+{ #category : #evaluating }
+StCatalogProjectEntry >> doEvaluate [
+	(UIManager default
+		confirm: 'Would you like to install ' , content name , '?')
+		ifFalse: [ ^ self ].
+
+	content installStableVersion.
+	UIManager inform: content name , ' installed'
+]
+
+{ #category : #accessing }
+StCatalogProjectEntry >> icon [
+
+	^ self iconNamed: #catalog
+]

--- a/src/NewTools-Spotter-Processors/StCatalogProjectsProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StCatalogProjectsProcessor.class.st
@@ -1,0 +1,39 @@
+"
+I am processor that gets all the projects from the Catalog.
+However, this operation is quite expensive so this is not enabled by default.
+"
+Class {
+	#name : #StCatalogProjectsProcessor,
+	#superclass : #StCollectionBasedProcessor,
+	#category : #'NewTools-Spotter-Processors-Processors'
+}
+
+{ #category : #'default-settings' }
+StCatalogProjectsProcessor class >> defaultEnabled [
+
+	^ false
+]
+
+{ #category : #accessing }
+StCatalogProjectsProcessor class >> order [
+	
+	^ 900
+]
+
+{ #category : #accessing }
+StCatalogProjectsProcessor class >> title [
+
+	^ 'Catalog Projects'
+]
+
+{ #category : #filtering }
+StCatalogProjectsProcessor >> collection [
+
+	^ CatalogProvider default projects
+]
+
+{ #category : #filtering }
+StCatalogProjectsProcessor >> newEntryOn: anElement [
+
+	^ StCatalogProjectEntry on: anElement
+]

--- a/src/NewTools-Spotter-Processors/StClassEntry.class.st
+++ b/src/NewTools-Spotter-Processors/StClassEntry.class.st
@@ -1,0 +1,25 @@
+"
+I wrap a Class or Trait entry, to modify its behavior if required for the class
+"
+Class {
+	#name : #StClassEntry,
+	#superclass : #StEntry,
+	#category : #'NewTools-Spotter-Processors-Entries'
+}
+
+{ #category : #converting }
+StClassEntry >> asString [
+
+	^ content name
+]
+
+{ #category : #evaluating }
+StClassEntry >> doEvaluate [
+	content browse
+]
+
+{ #category : #accessing }
+StClassEntry >> icon [
+
+	^ content systemIcon
+]

--- a/src/NewTools-Spotter-Processors/StClassIterator.class.st
+++ b/src/NewTools-Spotter-Processors/StClassIterator.class.st
@@ -1,0 +1,15 @@
+"
+I implement an iteration over all the classes in the system.
+
+"
+Class {
+	#name : #StClassIterator,
+	#superclass : #StGenericGenerator,
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #enumerating }
+StClassIterator >> elementsDo: aValuable [
+
+	SystemNavigation default allBehaviorsDo: aValuable
+]

--- a/src/NewTools-Spotter-Processors/StClassProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StClassProcessor.class.st
@@ -1,0 +1,39 @@
+"
+I am simple processor that iterates on the classes
+"
+Class {
+	#name : #StClassProcessor,
+	#superclass : #StSpotterProcessor,
+	#category : #'NewTools-Spotter-Processors-Processors'
+}
+
+{ #category : #'default-settings' }
+StClassProcessor class >> defaultEnabled [
+
+	^ false
+]
+
+{ #category : #settings }
+StClassProcessor class >> hideInSettings [
+
+	"I am hidden because the implementation in the unified processor is richer"
+	^ true
+]
+
+{ #category : #accessing }
+StClassProcessor class >> order [
+	
+	^ 100
+]
+
+{ #category : #accessing }
+StClassProcessor class >> title [
+
+	^ 'Classes'
+]
+
+{ #category : #filtering }
+StClassProcessor >> newTextFilteringSource [
+
+	^ StSourceFactory current classesSubstringSource
+]

--- a/src/NewTools-Spotter-Processors/StClassWithSelectorWordFilter.class.st
+++ b/src/NewTools-Spotter-Processors/StClassWithSelectorWordFilter.class.st
@@ -1,0 +1,35 @@
+Class {
+	#name : #StClassWithSelectorWordFilter,
+	#superclass : #StWordsAwareFilter,
+	#instVars : [
+		'className'
+	],
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #filtering }
+StClassWithSelectorWordFilter >> additionalFilter: aString firstWord: firstWord otherWords: otherWords on: anEntry [
+
+	^ anEntry content methodClass name = className
+		and: [ otherWords
+				allSatisfy: [ :otherW | anEntry asString asLowercase includesSubstring: otherW ] ]
+]
+
+{ #category : #filtering }
+StClassWithSelectorWordFilter >> splitWords: aString [
+
+	| splitted message |
+
+	splitted := aString splitOn: '>>'.
+	splitted size = 1 ifTrue: [ ^ super splitWords: aString ].
+	
+	className := splitted first trimBoth.
+	message := (splitted second copyWithout: $#) trimBoth.
+	
+	className isEmpty 
+		ifTrue: [ ^ super splitWords: aString ].
+	
+	^ super splitWords: message
+		
+	
+]

--- a/src/NewTools-Spotter-Processors/StCollectionBasedProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StCollectionBasedProcessor.class.st
@@ -1,0 +1,33 @@
+"
+I am an abstract processor that is used when the results collection already exists or this is really cheap to calculate.
+"
+Class {
+	#name : #StCollectionBasedProcessor,
+	#superclass : #StSpotterProcessor,
+	#category : #'NewTools-Spotter-Processors-Processors'
+}
+
+{ #category : #testing }
+StCollectionBasedProcessor class >> isAbstract [ 
+
+	^ self = StCollectionBasedProcessor 
+]
+
+{ #category : #filtering }
+StCollectionBasedProcessor >> collection [
+
+	^ self subclassResponsibility 
+]
+
+{ #category : #filtering }
+StCollectionBasedProcessor >> newEntryOn: anElement [
+
+	^ self subclassResponsibility 
+]
+
+{ #category : #filtering }
+StCollectionBasedProcessor >> newTextFilteringSource [
+
+	^ ((StCollectionIterator on: self collection) 
+			collect: [ :e | self newEntryOn: e ]) asSubstringFilter
+]

--- a/src/NewTools-Spotter-Processors/StCollectionIterator.class.st
+++ b/src/NewTools-Spotter-Processors/StCollectionIterator.class.st
@@ -1,0 +1,36 @@
+"
+I wrap an existing collection and expose it as a iterator
+"
+Class {
+	#name : #StCollectionIterator,
+	#superclass : #StGenericGenerator,
+	#instVars : [
+		'collection'
+	],
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #'instance creation' }
+StCollectionIterator class >> on: aSequenceableCollection [
+
+	^ self basicNew
+		collection: aSequenceableCollection;
+		initialize;
+		yourself
+]
+
+{ #category : #accessing }
+StCollectionIterator >> collection [
+	^ collection
+]
+
+{ #category : #accessing }
+StCollectionIterator >> collection: anObject [
+	collection := anObject
+]
+
+{ #category : #enumerating }
+StCollectionIterator >> elementsDo: aValuable [
+
+	collection do: aValuable 
+]

--- a/src/NewTools-Spotter-Processors/StDefaultSourceFactory.class.st
+++ b/src/NewTools-Spotter-Processors/StDefaultSourceFactory.class.st
@@ -1,0 +1,49 @@
+"
+I represent the creation of sources without indexes. 
+
+"
+Class {
+	#name : #StDefaultSourceFactory,
+	#superclass : #StSourceFactory,
+	#category : #'NewTools-Spotter-Processors-Processors'
+}
+
+{ #category : #'detecting implementations' }
+StDefaultSourceFactory class >> isAvailable [ 
+
+	"I am always available, I am the default implementation"
+	^ true
+]
+
+{ #category : #'detecting implementations' }
+StDefaultSourceFactory class >> priority [ 
+	
+	"I have a lower priority, because I don't use any fancy scheme"
+	^ 0 
+]
+
+{ #category : #'sources - classes' }
+StDefaultSourceFactory >> classesBeginsWithSource [
+
+	^ ((StClassIterator new select: [ :e | e isMeta not ])
+		collect: [ :e | StClassEntry on: e ]) asBeginsWithFilter
+]
+
+{ #category : #'sources - classes' }
+StDefaultSourceFactory >> classesSubstringSource [
+
+	^ ((StClassIterator new select: [ :e | e isMeta not ])
+		collect: [ :e | StClassEntry on: e ]) asSubstringFilter
+]
+
+{ #category : #'sources - implementors' }
+StDefaultSourceFactory >> implementorsBeginsWithSource [
+
+	^ (StImplementorsIterator new collect: [ :e | StMethodEntry on: e ]) asBeginsWithFilter
+]
+
+{ #category : #'sources - implementors' }
+StDefaultSourceFactory >> implementorsSubstringSource [
+
+	^ (StImplementorsIterator new collect: [ :e | StMethodEntry on: e ]) asSubstringFilter
+]

--- a/src/NewTools-Spotter-Processors/StEntry.class.st
+++ b/src/NewTools-Spotter-Processors/StEntry.class.st
@@ -1,0 +1,111 @@
+"
+I wrap the return elements from the spotter processor. 
+As the processor returns different elements I add the behaviour required to show the element. 
+
+Also, I redirect the messages that should be answer by my content
+"
+Class {
+	#name : #StEntry,
+	#superclass : #DisplayableObject,
+	#instVars : [
+		'content'
+	],
+	#category : #'NewTools-Spotter-Processors-Entries'
+}
+
+{ #category : #wrapping }
+StEntry class >> on: aValue [
+	
+	^ self new
+		content: aValue;
+		yourself
+]
+
+{ #category : #comparing }
+StEntry >> = anEntry [
+
+	^ self species = anEntry species
+		and: [ anEntry content = self content ]
+]
+
+{ #category : #converting }
+StEntry >> asString [ 
+
+	^ self subclassResponsibility 
+]
+
+{ #category : #accessing }
+StEntry >> content [
+	^ content
+]
+
+{ #category : #accessing }
+StEntry >> content: anObject [
+	content := anObject
+]
+
+{ #category : #evaluating }
+StEntry >> doEvaluate [ 
+
+	self subclassResponsibility 
+]
+
+{ #category : #evaluating }
+StEntry >> evaluateFor: aGTSpotterStep [ 
+
+	self doEvaluate.
+	aGTSpotterStep exit.
+]
+
+{ #category : #'spotter-extensions' }
+StEntry >> gtDisplayString [
+
+	^ self asString
+]
+
+{ #category : #comparing }
+StEntry >> hash [
+
+	^ content hash
+]
+
+{ #category : #accessing }
+StEntry >> icon [
+	
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+StEntry >> label [
+
+	^ self asString
+]
+
+{ #category : #printing }
+StEntry >> printOn: aStream [
+
+	super printOn: aStream.	
+	aStream
+		<< '( ';
+		print: content;
+		<< ' )'
+]
+
+{ #category : #'spotter-extensions' }
+StEntry >> spotterActDefault [
+	^ content spotterActDefault 
+]
+
+{ #category : #accessing }
+StEntry >> spotterPreview [
+
+	^ (content spotterPreview: SpPresenterBuilder new)
+		addStyle: 'stSpotterPreview';
+		yourself
+]
+
+{ #category : #'spotter-extensions' }
+StEntry >> stSpotterProcessorsFor: aSpotterStep [
+
+	^ content stSpotterProcessorsFor: aSpotterStep
+]

--- a/src/NewTools-Spotter-Processors/StFilter.class.st
+++ b/src/NewTools-Spotter-Processors/StFilter.class.st
@@ -1,0 +1,28 @@
+"
+I implement the select: operation on the iterator.
+I apply the block and filter the elements returned by myself.
+
+"
+Class {
+	#name : #StFilter,
+	#superclass : #StIteratorBlockDecorator,
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #initialization }
+StFilter >> filter: aValue [
+
+	^ aBlock value: aValue
+]
+
+{ #category : #accessing }
+StFilter >> next [
+
+	| value |
+
+	[ inner atEnd ]
+		whileFalse: [ value := inner next.
+			(self filter: value)
+				ifTrue: [ ^ value ] ].
+	^ nil
+]

--- a/src/NewTools-Spotter-Processors/StGeneratorBlockIterator.class.st
+++ b/src/NewTools-Spotter-Processors/StGeneratorBlockIterator.class.st
@@ -1,0 +1,36 @@
+"
+I wrap a block and expose it as an iterator
+"
+Class {
+	#name : #StGeneratorBlockIterator,
+	#superclass : #StGenericGenerator,
+	#instVars : [
+		'block'
+	],
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #'instance creation' }
+StGeneratorBlockIterator class >> on: aBlock [
+
+	^ self basicNew
+		block: aBlock;
+		initialize;
+		yourself
+]
+
+{ #category : #accessing }
+StGeneratorBlockIterator >> block [
+	^ block
+]
+
+{ #category : #accessing }
+StGeneratorBlockIterator >> block: anObject [
+	block := anObject
+]
+
+{ #category : #enumerating }
+StGeneratorBlockIterator >> elementsDo: aValuable [
+
+	block value: aValuable
+]

--- a/src/NewTools-Spotter-Processors/StGenericGenerator.class.st
+++ b/src/NewTools-Spotter-Processors/StGenericGenerator.class.st
@@ -1,0 +1,63 @@
+"
+I wrap a generator to provide the same API than the iterators.
+My subclasses should implement #elementsDo: to iterate the collection or implement the values.
+In this method, each of the generated values should be used with the valuable pased.
+
+
+Ex:
+elementsDo: aValuable
+	[ true ] whileTrue: [ aValuable value: 42  ].
+	
+This example generates an infinite iterator always returning 42.
+Using the generator will produce that the method is only executed on demand.
+
+This Iterator can also wrap collections, iterating one element at the time.
+
+Ex:
+elementsDo: aValuable
+	SystemNavigation default allBehaviorsDo: aValuable
+"
+Class {
+	#name : #StGenericGenerator,
+	#superclass : #StIterator,
+	#instVars : [
+		'generator'
+	],
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #testing }
+StGenericGenerator >> atEnd [ 
+
+	^ generator atEnd
+]
+
+{ #category : #protected }
+StGenericGenerator >> doReset [
+	generator := Generator on: [ :aGenerator | 
+		self elementsDo: [ :each | aGenerator yield: each ] ]
+]
+
+{ #category : #enumerating }
+StGenericGenerator >> elementsDo: aValuable [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #initialization }
+StGenericGenerator >> initialize [
+	super initialize.
+	self reset
+]
+
+{ #category : #accessing }
+StGenericGenerator >> next [
+
+	^ generator next
+]
+
+{ #category : #initialization }
+StGenericGenerator >> next: aQuantity [
+
+	^ generator next: aQuantity
+]

--- a/src/NewTools-Spotter-Processors/StHelpEntry.class.st
+++ b/src/NewTools-Spotter-Processors/StHelpEntry.class.st
@@ -1,0 +1,26 @@
+"
+I wrap a HelpTopic entry, to modify its behavior if required for the spotter
+"
+Class {
+	#name : #StHelpEntry,
+	#superclass : #StEntry,
+	#category : #'NewTools-Spotter-Processors-Entries'
+}
+
+{ #category : #converting }
+StHelpEntry >> asString [ 
+
+	^ content title
+]
+
+{ #category : #evaluating }
+StHelpEntry >> doEvaluate [ 
+
+	content spotterActDefault 
+]
+
+{ #category : #accessing }
+StHelpEntry >> icon [
+	
+	^ content gtTopicIcon
+]

--- a/src/NewTools-Spotter-Processors/StHelpProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StHelpProcessor.class.st
@@ -1,0 +1,52 @@
+"
+I am a processor that gets all the help topics in the system.
+"
+Class {
+	#name : #StHelpProcessor,
+	#superclass : #StCollectionBasedProcessor,
+	#category : #'NewTools-Spotter-Processors-Processors'
+}
+
+{ #category : #'default-settings' }
+StHelpProcessor class >> defaultEnabled [
+
+	^ true
+]
+
+{ #category : #accessing }
+StHelpProcessor class >> order [
+	
+	^ 2000
+]
+
+{ #category : #accessing }
+StHelpProcessor class >> title [
+
+	^ 'Help topics'
+]
+
+{ #category : #filtering }
+StHelpProcessor >> collection [
+
+	^ SystemHelp asHelpTopic gtAllSubtopics
+]
+
+{ #category : #'key-bindings' }
+StHelpProcessor >> installKeymappingsOn: aPresenter [
+
+	aPresenter
+		bindKeyCombination: $h meta
+		toAction: [ aPresenter onKeyProcessor: self ]
+]
+
+{ #category : #filtering }
+StHelpProcessor >> newEntryOn: anElement [
+
+	^ StHelpEntry on: anElement
+]
+
+{ #category : #configuration }
+StHelpProcessor >> showForEmptyQuery [ 
+
+	^ true
+]

--- a/src/NewTools-Spotter-Processors/StHistoryProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StHistoryProcessor.class.st
@@ -1,0 +1,44 @@
+"
+I am a processor that shows all the entries in the spotter history.
+"
+Class {
+	#name : #StHistoryProcessor,
+	#superclass : #StCollectionBasedProcessor,
+	#category : #'NewTools-Spotter-Processors-Processors'
+}
+
+{ #category : #'default-settings' }
+StHistoryProcessor class >> defaultEnabled [
+
+	^ true
+]
+
+{ #category : #accessing }
+StHistoryProcessor class >> order [
+	
+	^ 80
+]
+
+{ #category : #accessing }
+StHistoryProcessor class >> title [
+
+	^ 'History'
+]
+
+{ #category : #filtering }
+StHistoryProcessor >> collection [
+
+	^ StSpotter history
+]
+
+{ #category : #filtering }
+StHistoryProcessor >> newEntryOn: anElement [
+
+	^ anElement
+]
+
+{ #category : #configuration }
+StHistoryProcessor >> showForEmptyQuery [
+
+	^ true
+]

--- a/src/NewTools-Spotter-Processors/StImplementorsIterator.class.st
+++ b/src/NewTools-Spotter-Processors/StImplementorsIterator.class.st
@@ -1,0 +1,15 @@
+"
+I implement an iterator over all the implementors in the system
+"
+Class {
+	#name : #StImplementorsIterator,
+	#superclass : #StGenericGenerator,
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #enumerating }
+StImplementorsIterator >> elementsDo: aValuable [
+
+	SystemNavigation default
+		allBehaviorsDo: [ :aClass | aClass methodsDo: aValuable ]
+]

--- a/src/NewTools-Spotter-Processors/StImplementorsProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StImplementorsProcessor.class.st
@@ -1,0 +1,39 @@
+"
+I am simple processor that iterates on the implementors
+"
+Class {
+	#name : #StImplementorsProcessor,
+	#superclass : #StSpotterProcessor,
+	#category : #'NewTools-Spotter-Processors-Processors'
+}
+
+{ #category : #'default-settings' }
+StImplementorsProcessor class >> defaultEnabled [
+
+	^ false
+]
+
+{ #category : #settings }
+StImplementorsProcessor class >> hideInSettings [
+
+	"I am hidden because the implementation in the unified processor is richer"
+	^ true
+]
+
+{ #category : #accessing }
+StImplementorsProcessor class >> order [
+	
+	^ 100
+]
+
+{ #category : #accessing }
+StImplementorsProcessor class >> title [
+
+	^ 'Implementors'
+]
+
+{ #category : #filtering }
+StImplementorsProcessor >> newTextFilteringSource [
+
+	^ StSourceFactory current implementorsSubstringSource
+]

--- a/src/NewTools-Spotter-Processors/StIterator.class.st
+++ b/src/NewTools-Spotter-Processors/StIterator.class.st
@@ -1,0 +1,129 @@
+"
+I represent an abstract Iterator.
+My subclasses should implement #next, #doReset, and #atEnd.
+
+I implement some construction messages to ease the construction of chains of iterators.
+
+#, allows to create sequence of iterators, the results are from the first one, then from the second one and so on. 
+
+#asBeginsWithFilter
+Creates an iterator that allows to filter by a string, comparing with beginsWith:, with an starting filter of ''.
+#beginsWithFilter: aString
+Create an iterator that allows to filter by a string, comparing with beginsWith:, with an starting filter of aString.
+
+#asSubStringFilter
+Creates an iterator that allows to filter by a string, comparing with substring:, with an starting filter of ''.
+
+#substringFilter: aString
+Create an iterator that allows to filter by a string, comparing with substring:, with an starting filter of aString.
+
+#asWithoutDuplicates 
+Creates an itearator that returns no duplicates.
+"
+Class {
+	#name : #StIterator,
+	#superclass : #Object,
+	#instVars : [
+		'onReset'
+	],
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #sequencing }
+StIterator >> , aStGeneratorIterator [ 
+	
+	^ StSequenceIterator with: { self. aStGeneratorIterator }
+]
+
+{ #category : #filtering }
+StIterator >> asBeginsWithFilter [
+	
+	^ self beginsWithFilter: ''
+]
+
+{ #category : #filtering }
+StIterator >> asSubstringFilter [
+	
+	^ self substringFilter: ''
+]
+
+{ #category : #filtering }
+StIterator >> asWithoutDuplicates [
+	
+	^ StWithoutDuplicatesDecorator on: self
+]
+
+{ #category : #testing }
+StIterator >> atEnd [ 
+
+	^ self subclassResponsibility 
+]
+
+{ #category : #filtering }
+StIterator >> beginsWithFilter: aString [ 
+	
+	^ StBeginsWithFilter on: self with: aString
+]
+
+{ #category : #transforming }
+StIterator >> collect: aBlockClosure [ 
+	
+	^ StTransformation on: self with: aBlockClosure
+]
+
+{ #category : #protected }
+StIterator >> doReset [
+	
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+StIterator >> next [
+
+	self subclassResponsibility 
+]
+
+{ #category : #initialization }
+StIterator >> next: aQuantity [
+
+	^ OrderedCollection streamContents: [ :stream | | total last |
+			total := 0.
+			[ (last := self next).
+				last ifNotNil: [  
+					stream nextPut: last.
+					total := total + 1 ] ]
+				doWhileTrue: [ total < aQuantity and: [ last notNil ] ] ]
+]
+
+{ #category : #events }
+StIterator >> onReset: aValuable [
+
+	onReset := aValuable
+]
+
+{ #category : #reseting }
+StIterator >> reset [
+
+	self doReset.
+	onReset ifNotNil: [ onReset value ]
+]
+
+{ #category : #filtering }
+StIterator >> select: aBlockClosure [ 
+	
+	^ StFilter on: self with: aBlockClosure 
+]
+
+{ #category : #filtering }
+StIterator >> substringFilter: aString [ 
+	
+	^ StSubStringFilter on: self with: aString
+]
+
+{ #category : #accessing }
+StIterator >> upToEnd [
+
+	^ OrderedCollection
+		streamContents:
+			[ :stream | [ self atEnd ] whileFalse: [ stream nextPut: self next ] ]
+]

--- a/src/NewTools-Spotter-Processors/StIteratorBlockDecorator.class.st
+++ b/src/NewTools-Spotter-Processors/StIteratorBlockDecorator.class.st
@@ -1,0 +1,26 @@
+"
+I implement a simple block decorator, I am a abstract class that have a block.
+"
+Class {
+	#name : #StIteratorBlockDecorator,
+	#superclass : #StIteratorDecorator,
+	#instVars : [
+		'aBlock'
+	],
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #'instance creation' }
+StIteratorBlockDecorator class >> on: aStGeneratorIterator with: aBlockClosure [ 
+	
+	^ self new
+		inner: aStGeneratorIterator;
+		block: aBlockClosure;
+		yourself
+]
+
+{ #category : #accessing }
+StIteratorBlockDecorator >> block: aBlockClosure [
+
+	aBlock := aBlockClosure
+]

--- a/src/NewTools-Spotter-Processors/StIteratorDecorator.class.st
+++ b/src/NewTools-Spotter-Processors/StIteratorDecorator.class.st
@@ -1,0 +1,36 @@
+"
+I implement an abstract decorator for the implementors.
+I have an iterator in the inner instance variable and all the messages are redirected to it. 
+My subclasses can override the required behaviour.
+"
+Class {
+	#name : #StIteratorDecorator,
+	#superclass : #StIterator,
+	#instVars : [
+		'inner'
+	],
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #testing }
+StIteratorDecorator >> atEnd [ 
+
+	^ inner atEnd
+]
+
+{ #category : #protected }
+StIteratorDecorator >> doReset [ 
+	
+	inner reset
+]
+
+{ #category : #accessing }
+StIteratorDecorator >> inner: anObject [
+	inner := anObject
+]
+
+{ #category : #accessing }
+StIteratorDecorator >> next [
+
+	^ inner next
+]

--- a/src/NewTools-Spotter-Processors/StMethodEntry.class.st
+++ b/src/NewTools-Spotter-Processors/StMethodEntry.class.st
@@ -1,0 +1,32 @@
+"
+I wrap a CompiledMethod, to modify its behavior if required for the class
+"
+Class {
+	#name : #StMethodEntry,
+	#superclass : #StEntry,
+	#category : #'NewTools-Spotter-Processors-Entries'
+}
+
+{ #category : #converting }
+StMethodEntry >> asString [
+
+	^ content selector
+]
+
+{ #category : #evaluating }
+StMethodEntry >> doEvaluate [
+
+	^ content browse
+]
+
+{ #category : #accessing }
+StMethodEntry >> icon [
+
+	^ content systemIcon
+]
+
+{ #category : #accessing }
+StMethodEntry >> label [
+
+	^ content printString
+]

--- a/src/NewTools-Spotter-Processors/StPackageEntry.class.st
+++ b/src/NewTools-Spotter-Processors/StPackageEntry.class.st
@@ -1,0 +1,25 @@
+"
+I wrap a RPackage entry, to modify its behavior if required for the class
+"
+Class {
+	#name : #StPackageEntry,
+	#superclass : #StEntry,
+	#category : #'NewTools-Spotter-Processors-Entries'
+}
+
+{ #category : #converting }
+StPackageEntry >> asString [
+
+	^ content name
+]
+
+{ #category : #evaluating }
+StPackageEntry >> doEvaluate [
+
+	content browse
+]
+
+{ #category : #accessing }
+StPackageEntry >> icon [
+	^ self iconNamed: #package
+]

--- a/src/NewTools-Spotter-Processors/StPackageIterator.class.st
+++ b/src/NewTools-Spotter-Processors/StPackageIterator.class.st
@@ -1,0 +1,14 @@
+"
+I implement an iterator over all the packages in the system
+"
+Class {
+	#name : #StPackageIterator,
+	#superclass : #StGenericGenerator,
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #enumerating }
+StPackageIterator >> elementsDo: aValuable [
+
+	RPackageOrganizer default packagesDo: aValuable
+]

--- a/src/NewTools-Spotter-Processors/StPackageProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StPackageProcessor.class.st
@@ -1,0 +1,38 @@
+"
+I am simple processor that iterates on the packages in the system
+"
+Class {
+	#name : #StPackageProcessor,
+	#superclass : #StSpotterProcessor,
+	#category : #'NewTools-Spotter-Processors-Processors'
+}
+
+{ #category : #'default-settings' }
+StPackageProcessor class >> defaultEnabled [
+
+	^ false
+]
+
+{ #category : #settings }
+StPackageProcessor class >> hideInSettings [
+
+	"I am hidden because the implementation in the unified processor is richer"
+	^ true
+]
+
+{ #category : #accessing }
+StPackageProcessor class >> order [
+	
+	^ 100
+]
+
+{ #category : #accessing }
+StPackageProcessor class >> title [
+	^ 'Packages'
+]
+
+{ #category : #filtering }
+StPackageProcessor >> newTextFilteringSource [
+
+	^ (StPackageIterator new collect: [ :e | StClassEntry on: e ]) asSubstringFilter
+]

--- a/src/NewTools-Spotter-Processors/StQuery.class.st
+++ b/src/NewTools-Spotter-Processors/StQuery.class.st
@@ -1,0 +1,121 @@
+"
+I am the reification of a Spotter query.
+I know how to parse the search string and returns the categories selected (#Classes, #Implementors, etc) and the look up string.
+I also handle how to return the results to spotter and how to update the searching morph when a category change.
+
+I am updated from a Spotter context (updateFromContext:), and I update the search bar with #updateSearchingMorph.
+
+The processors talk with me to add results to the query, and later show them (#addResult: #informAllResultAmount:).
+
+I am also configurable to filter classes, implementors or add another modified.
+"
+Class {
+	#name : #StQuery,
+	#superclass : #Object,
+	#instVars : [
+		'query',
+		'spotterContext',
+		'processor',
+		'modifiers'
+	],
+	#category : #'NewTools-Spotter-Processors-Query'
+}
+
+{ #category : #results }
+StQuery >> addResult: anEntry [
+
+	spotterContext stream
+		performSymbol: #addCandidate:in:
+		withArguments: { anEntry. processor }
+]
+
+{ #category : #accessing }
+StQuery >> categoriesSelected [
+
+	^ modifiers copy
+]
+
+{ #category : #configuring }
+StQuery >> filterClasses [
+
+	modifiers add: #Classes
+]
+
+{ #category : #configuring }
+StQuery >> filterImplementors [
+
+	modifiers add: #Implementors
+]
+
+{ #category : #configuring }
+StQuery >> filterSenders [
+
+	modifiers add: #Senders
+]
+
+{ #category : #results }
+StQuery >> informAllResultAmount: anInteger [ 
+
+	spotterContext stream
+		performSymbol: #onAmountChanged:in:
+		withArguments: { anInteger. processor }.
+	
+]
+
+{ #category : #initialization }
+StQuery >> initialize [
+
+	super initialize.
+	modifiers := OrderedCollection new.
+	query:= ''.
+]
+
+{ #category : #testing }
+StQuery >> isSearchEmpty [
+
+	^ query isEmpty
+]
+
+{ #category : #accessing }
+StQuery >> processor [
+
+	^ processor
+]
+
+{ #category : #accessing }
+StQuery >> processor: aProcessor [
+
+	processor := aProcessor
+]
+
+{ #category : #accessing }
+StQuery >> searchingText [
+	
+	^ query
+]
+
+{ #category : #accessing }
+StQuery >> textInSearchBar [
+
+	^ String streamContents: [ :stream | 
+		modifiers do: [ :each | stream print:each; space ].
+		stream nextPutAll: query ]
+]
+
+{ #category : #updating }
+StQuery >> updateFromContext: aSpotterContext [
+	| textParts texts |
+
+	modifiers removeAll.
+	texts := (aSpotterContext search ifNil:[ '' ]) trimBoth.
+	textParts := texts substrings: { Character space. Character tab }.
+	query := ''.
+	
+	textParts do: [ :aPart | 
+		((aPart beginsWith: '#') 
+			and: [ ((texts copyWithout: Character space) includesSubstring: '>>#') not ])
+			ifTrue: [ modifiers add: aPart allButFirst asSymbol ]
+			ifFalse: [ query := (query, ' ', aPart) trimBoth ] ].
+
+	spotterContext := aSpotterContext
+]

--- a/src/NewTools-Spotter-Processors/StSendersIterator.class.st
+++ b/src/NewTools-Spotter-Processors/StSendersIterator.class.st
@@ -1,0 +1,27 @@
+"
+I am an iterator to find the senders of a message.
+I always receive a filteringText because it does not have any sense to show senders of an empty string.
+Also, I lookup all the senders of the complete symbol.
+"
+Class {
+	#name : #StSendersIterator,
+	#superclass : #StGenericGenerator,
+	#instVars : [
+		'selector'
+	],
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #enumerating }
+StSendersIterator >> elementsDo: aValuable [
+
+	selector ifNil: [ ^ self ].
+	^ selector senders do: [ :aMethod | aValuable value: (StMethodEntry on: aMethod )]
+]
+
+{ #category : #filtering }
+StSendersIterator >> filteringText: aString [
+
+	selector := aString ifEmpty: [ nil] ifNotEmpty: [aString asSymbol].
+	self reset.
+]

--- a/src/NewTools-Spotter-Processors/StSendersProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StSendersProcessor.class.st
@@ -1,0 +1,78 @@
+"
+I implement the lookup of #Senders and the Meta + n binding.
+
+"
+Class {
+	#name : #StSendersProcessor,
+	#superclass : #StSpotterProcessor,
+	#category : #'NewTools-Spotter-Processors-Processors'
+}
+
+{ #category : #'default-settings' }
+StSendersProcessor class >> defaultEnabled [
+
+	^ true
+]
+
+{ #category : #accessing }
+StSendersProcessor class >> order [
+	
+	^ 150
+]
+
+{ #category : #accessing }
+StSendersProcessor class >> title [
+	
+	^ 'Senders'
+]
+
+{ #category : #testing }
+StSendersProcessor >> askingForSenders [
+
+	^ query categoriesSelected 
+		anySatisfy: [ :each | each asLowercase beginsWith: #s ]
+]
+
+{ #category : #testing }
+StSendersProcessor >> categoriesIncludes: aCategory [
+
+	^ aCategory asLowercase beginsWith: #s
+]
+
+{ #category : #filtering }
+StSendersProcessor >> executeQuery [
+
+	self askingForSenders
+		ifFalse: [ ^ self ].
+
+	^ super executeQuery 
+]
+
+{ #category : #'key-bindings' }
+StSendersProcessor >> installKeymappingsOn: aPresenter onExecution: aBlock [
+
+	aPresenter
+		bindKeyCombination: self keyBinding
+		toAction: [ 
+			self query filterSenders.
+			aBlock cull: self ]
+]
+
+{ #category : #'spotter-api' }
+StSendersProcessor >> isRelevantForQuery: aString [ 
+	
+	"I will handle... I am old enough"
+	^ true
+]
+
+{ #category : #'key-bindings' }
+StSendersProcessor >> keyBinding [
+
+	^ $n meta
+]
+
+{ #category : #filtering }
+StSendersProcessor >> newTextFilteringSource [
+
+	^ StSendersIterator new 
+]

--- a/src/NewTools-Spotter-Processors/StSequenceIterator.class.st
+++ b/src/NewTools-Spotter-Processors/StSequenceIterator.class.st
@@ -1,0 +1,45 @@
+"
+I am sequence iterator, I will take all the iterators I have in myself and then I will go over the elements of them.
+I iterate first all elements from the first one, and then the elements of the second one, and so on.
+"
+Class {
+	#name : #StSequenceIterator,
+	#superclass : #StIterator,
+	#instVars : [
+		'iterators'
+	],
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #'instance creation' }
+StSequenceIterator class >> with: aCollection [ 
+	
+	^ self new
+		iterators: aCollection;
+		yourself
+]
+
+{ #category : #testing }
+StSequenceIterator >> atEnd [ 
+
+	^ iterators allSatisfy: [ :e | e atEnd ]
+]
+
+{ #category : #protected }
+StSequenceIterator >> doReset [
+
+	^ iterators do: [ :e | e reset ]
+]
+
+{ #category : #accessing }
+StSequenceIterator >> iterators: aCollection [ 
+
+	iterators := aCollection 
+]
+
+{ #category : #accessing }
+StSequenceIterator >> next [
+
+	iterators do: [ :e | e next ifNotNil: [ :aValue | ^ aValue ] ].
+	^ nil
+]

--- a/src/NewTools-Spotter-Processors/StSourceFactory.class.st
+++ b/src/NewTools-Spotter-Processors/StSourceFactory.class.st
@@ -1,0 +1,77 @@
+"
+I represent the responsibility to create the sources, 
+so there could be different strategies to generate the sources, for example with or without indexes.
+"
+Class {
+	#name : #StSourceFactory,
+	#superclass : #Object,
+	#classVars : [
+		'Current'
+	],
+	#category : #'NewTools-Spotter-Processors-Processors'
+}
+
+{ #category : #accessing }
+StSourceFactory class >> current [
+
+	^ Current ifNil: [ self defaultSourceFactory ]
+]
+
+{ #category : #'detecting implementations' }
+StSourceFactory class >> defaultSourceFactory [
+
+	| sourceFactoryClass |
+	sourceFactoryClass := (self subclasses
+		sorted: [ :a :b | a priority > b priority ])
+		detect: [ :each | each isAvailable ].
+		
+	^ sourceFactoryClass new
+]
+
+{ #category : #accessing }
+StSourceFactory class >> forTest [
+
+	Current := self new
+]
+
+{ #category : #'detecting implementations' }
+StSourceFactory class >> isAvailable [ 
+
+	^ self subclassResponsibility
+]
+
+{ #category : #'detecting implementations' }
+StSourceFactory class >> priority [ 
+
+	^ self subclassResponsibility 
+]
+
+{ #category : #accessing }
+StSourceFactory class >> reset [
+
+	Current := nil
+]
+
+{ #category : #'sources - classes' }
+StSourceFactory >> classesBeginsWithSource [
+
+	 ^ self subclassResponsibility 
+]
+
+{ #category : #'sources - classes' }
+StSourceFactory >> classesSubstringSource [
+
+	 ^ self subclassResponsibility 
+]
+
+{ #category : #'sources - implementors' }
+StSourceFactory >> implementorsBeginsWithSource [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #'sources - implementors' }
+StSourceFactory >> implementorsSubstringSource [
+
+	^ self subclassResponsibility
+]

--- a/src/NewTools-Spotter-Processors/StSpotterCandidatesListProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StSpotterCandidatesListProcessor.class.st
@@ -1,0 +1,230 @@
+Class {
+	#name : #StSpotterCandidatesListProcessor,
+	#superclass : #StSpotterCandidatesProcessor,
+	#instVars : [
+		'allCandidatesBlock',
+		'candidatesLimit',
+		'title',
+		'itemNameBlock',
+		'itemIconBlock',
+		'actBlock',
+		'wantsToDisplayOnEmptyQuery',
+		'filterBlock',
+		'keyBinding',
+		'sortBlock'
+	],
+	#category : #'NewTools-Spotter-Processors'
+}
+
+{ #category : #accessing }
+StSpotterCandidatesListProcessor >> actLogic [
+	^ actBlock
+]
+
+{ #category : #scripting }
+StSpotterCandidatesListProcessor >> actLogic: aBlockWithTwoArguments [
+
+	actBlock := aBlockWithTwoArguments
+]
+
+{ #category : #private }
+StSpotterCandidatesListProcessor >> actOn: anObject for: aStep [
+	
+	actBlock
+		ifNil: [ super actOn: anObject for: aStep ]
+		ifNotNil: [ actBlock cull: anObject cull: aStep ]
+]
+
+{ #category : #compatibility }
+StSpotterCandidatesListProcessor >> allCandidates: aBlockWithOneArgument [
+	self items: aBlockWithOneArgument
+]
+
+{ #category : #compatibility }
+StSpotterCandidatesListProcessor >> candidatesLimit: anInteger [
+	self itemsLimit: anInteger
+]
+
+{ #category : #private }
+StSpotterCandidatesListProcessor >> computeAllItemsIn: aContext [
+	^ allCandidatesBlock cull: aContext
+]
+
+{ #category : #compatibility }
+StSpotterCandidatesListProcessor >> defaultCandidatesLimit [
+	^ self defaultItemsLimit
+]
+
+{ #category : #'accessing-defaults' }
+StSpotterCandidatesListProcessor >> defaultContinueItemsLimit [
+	" Spotter becomes extraordenary slow when rendering too many results. So we set the maximum limit to 100. This is only a temporary solution until we have fixed the problem. Until then no spotter processor will ever generate more then 100 results. "
+	^ 100
+]
+
+{ #category : #'accessing-defaults' }
+StSpotterCandidatesListProcessor >> defaultItemsLimit [
+	^ self class defaultItemsLimit
+]
+
+{ #category : #private }
+StSpotterCandidatesListProcessor >> doFilterInContext: aSpotterContext [
+
+	^ aSpotterContext 
+		doFilter: filterBlock stFilter 
+		forProcessor: self
+]
+
+{ #category : #accessing }
+StSpotterCandidatesListProcessor >> filter [
+	^ filterBlock
+]
+
+{ #category : #scripting }
+StSpotterCandidatesListProcessor >> filter: aGTFilterOrBlockWithOneArgument [
+	filterBlock := aGTFilterOrBlockWithOneArgument 
+]
+
+{ #category : #scripting }
+StSpotterCandidatesListProcessor >> filter: aGTFilter item: aGTSpotterIterator [ 
+	self filter: aGTFilter.
+	self items: aGTSpotterIterator gtIterator.
+	
+]
+
+{ #category : #compatibility }
+StSpotterCandidatesListProcessor >> filterUsing: aFilter [
+	self filter: aFilter
+]
+
+{ #category : #testing }
+StSpotterCandidatesListProcessor >> hasDynamicItems [
+	^ allCandidatesBlock hasDynamicItems
+]
+
+{ #category : #accessing }
+StSpotterCandidatesListProcessor >> itemIcon [
+	^ itemIconBlock
+]
+
+{ #category : #scripting }
+StSpotterCandidatesListProcessor >> itemIcon: aBlockWithOneArgument [
+	itemIconBlock := aBlockWithOneArgument
+]
+
+{ #category : #private }
+StSpotterCandidatesListProcessor >> itemIconFor: anObject [
+
+	^ itemIconBlock ifNil: [ super itemIconFor: anObject ] ifNotNil: [ itemIconBlock cull: anObject ]
+]
+
+{ #category : #accessing }
+StSpotterCandidatesListProcessor >> itemName [
+	^ itemNameBlock
+]
+
+{ #category : #scripting }
+StSpotterCandidatesListProcessor >> itemName: aBlockWithOneArgument [
+	itemNameBlock := aBlockWithOneArgument
+]
+
+{ #category : #private }
+StSpotterCandidatesListProcessor >> itemNameFor: anObject [
+
+	^ itemNameBlock ifNil: [ super itemNameFor: anObject ] ifNotNil: [ itemNameBlock cull: anObject ]
+]
+
+{ #category : #scripting }
+StSpotterCandidatesListProcessor >> items: aBlock [
+	allCandidatesBlock := aBlock
+]
+
+{ #category : #accessing }
+StSpotterCandidatesListProcessor >> itemsLimit [
+	^ candidatesLimit ifNil: [ self defaultItemsLimit ]
+]
+
+{ #category : #scripting }
+StSpotterCandidatesListProcessor >> itemsLimit: anInteger [
+	candidatesLimit := anInteger
+]
+
+{ #category : #accessing }
+StSpotterCandidatesListProcessor >> keyBinding [
+	^ keyBinding
+]
+
+{ #category : #accessing }
+StSpotterCandidatesListProcessor >> keyBinding: anObject [
+	keyBinding := anObject
+]
+
+{ #category : #'scripting-convenience' }
+StSpotterCandidatesListProcessor >> match: aBlockWithTwoArguments [
+
+	self filter: (StFilterBlock new 
+		matcher: aBlockWithTwoArguments;
+		yourself)
+]
+
+{ #category : #'scripting-convenience' }
+StSpotterCandidatesListProcessor >> matchAlike [
+	self filter: StFilterAlike
+]
+
+{ #category : #'scripting-convenience' }
+StSpotterCandidatesListProcessor >> matchRegex [
+	self filter: StFilterRegex
+]
+
+{ #category : #'scripting-convenience' }
+StSpotterCandidatesListProcessor >> matchString [
+	self filter: StFilterStringMatch
+]
+
+{ #category : #'scripting-convenience' }
+StSpotterCandidatesListProcessor >> matchSubstring [
+	self filter: StFilterSubstring
+]
+
+{ #category : #'scripting-convenience' }
+StSpotterCandidatesListProcessor >> matchSubstrings [
+	self filter: StFilterSubstrings
+]
+
+{ #category : #accessing }
+StSpotterCandidatesListProcessor >> sort [
+	^ sortBlock
+]
+
+{ #category : #scripting }
+StSpotterCandidatesListProcessor >> sort: aBlockWithTwoArguments [
+	sortBlock := aBlockWithTwoArguments
+]
+
+{ #category : #accessing }
+StSpotterCandidatesListProcessor >> title [
+	^ title ifNil: [ super title ]
+]
+
+{ #category : #scripting }
+StSpotterCandidatesListProcessor >> title: aString [
+	title := aString
+]
+
+{ #category : #accessing }
+StSpotterCandidatesListProcessor >> wantsToDisplayOnEmptyQuery [
+	^ wantsToDisplayOnEmptyQuery ifNil: [ super wantsToDisplayOnEmptyQuery ]
+]
+
+{ #category : #scripting }
+StSpotterCandidatesListProcessor >> wantsToDisplayOnEmptyQuery: anObject [
+	wantsToDisplayOnEmptyQuery := anObject
+]
+
+{ #category : #private }
+StSpotterCandidatesListProcessor >> withItemsLimit: aLimit do: aBlock [
+	| previousCandidatesLimit |
+	previousCandidatesLimit := candidatesLimit.
+	^ [ candidatesLimit := aLimit. aBlock value ] 
+		ensure: [ candidatesLimit := previousCandidatesLimit ]
+]

--- a/src/NewTools-Spotter-Processors/StSpotterCandidatesProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StSpotterCandidatesProcessor.class.st
@@ -1,0 +1,103 @@
+Class {
+	#name : #StSpotterCandidatesProcessor,
+	#superclass : #StSpotterPragmaBasedProcessor,
+	#instVars : [
+		'origin',
+		'allCandidates'
+	],
+	#category : #'NewTools-Spotter-Processors'
+}
+
+{ #category : #'instance creation' }
+StSpotterCandidatesProcessor class >> on: anObject [
+
+	^ self new origin: anObject
+]
+
+{ #category : #compatibility }
+StSpotterCandidatesProcessor >> allCandidatesIn: aContext [
+	^ self allItemsIn: aContext
+]
+
+{ #category : #public }
+StSpotterCandidatesProcessor >> allItemsIn: aContext [
+
+	^ allCandidates ifNil: [ allCandidates := (self computeAllItemsIn: aContext) copy ].
+]
+
+{ #category : #compatibility }
+StSpotterCandidatesProcessor >> candidatesLimit [
+	^ self itemsLimit
+]
+
+{ #category : #private }
+StSpotterCandidatesProcessor >> computeAllItemsIn: aContext [
+
+	^ OrderedCollection new
+	
+]
+
+{ #category : #compatibility }
+StSpotterCandidatesProcessor >> computeCandidatesIn: aContext [
+
+	^ self computeAllItemsIn: aContext
+]
+
+{ #category : #private }
+StSpotterCandidatesProcessor >> continueItemsLimit [
+	^ (self defaultContinueItemsLimit - self itemsLimit) max: 0
+]
+
+{ #category : #private }
+StSpotterCandidatesProcessor >> doFilterInContext: aSpotterContext [
+
+	^ aSpotterContext 
+		doFilter: StFilterBlock stFilter 
+		forProcessor: self
+]
+
+{ #category : #private }
+StSpotterCandidatesProcessor >> itemFilterNameFor: anObject [
+	^ self itemNameFor: anObject
+]
+
+{ #category : #private }
+StSpotterCandidatesProcessor >> itemIconFor: anObject [
+	^ nil
+]
+
+{ #category : #private }
+StSpotterCandidatesProcessor >> itemNameFor: anObject [
+	^ anObject gtDisplayString
+]
+
+{ #category : #accessing }
+StSpotterCandidatesProcessor >> itemsLimit [
+	"Return the maximal number of elements that can be found during search.
+	Default implementation returns infinity, so the number of element is not limited."
+	^ Float infinity
+]
+
+{ #category : #accessing }
+StSpotterCandidatesProcessor >> origin [
+
+	^ origin
+]
+
+{ #category : #accessing }
+StSpotterCandidatesProcessor >> origin: anObject [
+
+	origin := anObject
+]
+
+{ #category : #private }
+StSpotterCandidatesProcessor >> prepareProcessorInContext: aContext [
+	super prepareProcessorInContext: aContext.
+	
+	self hasDynamicItems ifTrue: [ allCandidates := nil ]
+]
+
+{ #category : #accessing }
+StSpotterCandidatesProcessor >> title [
+	^ 'undefined'
+]

--- a/src/NewTools-Spotter-Processors/StSpotterPragmaBasedProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StSpotterPragmaBasedProcessor.class.st
@@ -34,8 +34,7 @@ StSpotterPragmaBasedProcessor class >> settingsOn: aBuilder [
 		label: 'Number of results per category';
 		default: 25;
 		order: 100;
-		description:
-			'Number of results per category to show in Spotter'
+		description: 'Number of results per category to show in Spotter'
 ]
 
 { #category : #public }

--- a/src/NewTools-Spotter-Processors/StSpotterPragmaBasedProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StSpotterPragmaBasedProcessor.class.st
@@ -1,0 +1,189 @@
+Class {
+	#name : #StSpotterPragmaBasedProcessor,
+	#superclass : #Object,
+	#instVars : [
+		'allFilteredCandidates',
+		'order',
+		'running'
+	],
+	#classVars : [
+		'DefaultItemsLimit'
+	],
+	#category : #'NewTools-Spotter-Processors'
+}
+
+{ #category : #'accessing-defaults' }
+StSpotterPragmaBasedProcessor class >> defaultItemsLimit [
+
+	^ DefaultItemsLimit ifNil: [ DefaultItemsLimit := 25 ]
+]
+
+{ #category : #'accessing-defaults' }
+StSpotterPragmaBasedProcessor class >> defaultItemsLimit: aValue [
+
+	DefaultItemsLimit := aValue
+]
+
+{ #category : #'accessing-defaults' }
+StSpotterPragmaBasedProcessor class >> settingsOn: aBuilder [
+	<systemsettings>
+
+	(aBuilder setting: #defaultItemsLimit)
+		target: self;
+		parent: #spotter;
+		label: 'Number of results per category';
+		default: 25;
+		order: 100;
+		description:
+			'Number of results per category to show in Spotter'
+]
+
+{ #category : #public }
+StSpotterPragmaBasedProcessor >> actOn: anObject for: aStep [
+	anObject spotterActDefault: aStep
+]
+
+{ #category : #public }
+StSpotterPragmaBasedProcessor >> allFilteredCandidates [
+	^ allFilteredCandidates ifNil: [ allFilteredCandidates := OrderedCollection new ]
+]
+
+{ #category : #private }
+StSpotterPragmaBasedProcessor >> continueFilterInContext: aSpotterContext [
+
+	" We DO NOT prepare the context since we could no longer continue producing filtered candidates. "
+	(self shouldFilterInContext: aSpotterContext) ifTrue: [
+		" The continue-filter only puts more items on the stream but doesn't do any filtering at all. Therefore the original collection (=result/candidates) and its size remains the same and can be reused after the continue-filter has added more items. So we do not ressign the result to #allFilteredCandidates as it is done for the regular filter-loop. #allFilteredCandidates must never be modified more than once because the next #diveIntoCategory would render an invalid set of items !!! "
+		self doContinueFilterInContext: aSpotterContext ].
+	aSpotterContext stream 
+		performSymbol: #onAmountChanged:in:
+		withArguments: { self allFilteredCandidates size . self }
+]
+
+{ #category : #private }
+StSpotterPragmaBasedProcessor >> doContinueFilterInContext: aSpotterContext [
+	^ aSpotterContext doContinueFilterForProcessor: self
+]
+
+{ #category : #private }
+StSpotterPragmaBasedProcessor >> doFilterInContext: aSpotterContext [
+	"override this method to:
+	- add items to the stream
+	- return all found items at the end"
+	self subclassResponsibility
+]
+
+{ #category : #private }
+StSpotterPragmaBasedProcessor >> filterInContext: aSpotterContext [
+
+	running := true.
+	aSpotterContext stream 
+		performSymbol: #processorStarted: 
+		withArguments: { self }.
+	
+	self prepareProcessorInContext: aSpotterContext.
+	(self shouldFilterInContext: aSpotterContext) ifTrue: [
+		allFilteredCandidates := self doFilterInContext: aSpotterContext ].
+	aSpotterContext stream 
+		performSymbol: #onAmountChanged:in: 
+		withArguments: { self allFilteredCandidates size . self }.
+		
+	running := false.
+	aSpotterContext stream 
+		performSymbol: #processorEnded: 
+		withArguments: { self }.
+
+]
+
+{ #category : #printing }
+StSpotterPragmaBasedProcessor >> gtDisplayOn: stream [
+	stream 
+		nextPutAll: 'Processor: ';
+		nextPutAll: self title asString
+]
+
+{ #category : #testing }
+StSpotterPragmaBasedProcessor >> hasFilteredCandidates [
+	^ self allFilteredCandidates notEmpty
+]
+
+{ #category : #initialization }
+StSpotterPragmaBasedProcessor >> initialize [ 
+
+	super initialize.
+	running := false
+]
+
+{ #category : #'key-bindings' }
+StSpotterPragmaBasedProcessor >> installKeymappingsOn: aGTSpotterMorph [
+
+	self keyBinding
+		ifNotNil: [ | keyCombination |
+			keyCombination := self keyBinding asKeyCombination.
+			aGTSpotterMorph 
+				bindKeyCombination: keyCombination 
+				ofProcessor: self 
+				toAction: [ aGTSpotterMorph onKeyProcessor: self ] ]
+]
+
+{ #category : #testing }
+StSpotterPragmaBasedProcessor >> isRelevantForQuery: categoryQueryPrefix [
+	| trimmedProcessorTitle |
+	trimmedProcessorTitle := self title asLowercase 
+										copyReplaceAll: String space
+										with: ''.
+	^ trimmedProcessorTitle beginsWith: categoryQueryPrefix
+]
+
+{ #category : #testing }
+StSpotterPragmaBasedProcessor >> isRunning [ 
+	
+	^ running
+]
+
+{ #category : #'key-bindings' }
+StSpotterPragmaBasedProcessor >> keyBinding [
+
+	^ nil
+]
+
+{ #category : #accessing }
+StSpotterPragmaBasedProcessor >> order [
+	"Return assigned spotter order used to arrange categories in spotter UI"
+	<return: #Number>
+	
+	^ order
+]
+
+{ #category : #accessing }
+StSpotterPragmaBasedProcessor >> order: aNumber [
+	"Assign to processor its spotter order to arrange categories
+	within spotter ui"
+	order := aNumber
+]
+
+{ #category : #private }
+StSpotterPragmaBasedProcessor >> prepareProcessorInContext: aContext [
+	allFilteredCandidates := nil
+]
+
+{ #category : #testing }
+StSpotterPragmaBasedProcessor >> shouldFilterInContext: aSpotterContext [
+	^ aSpotterContext notEmpty 
+		or: [ self wantsToDisplayOnEmptyQuery ]
+]
+
+{ #category : #accessing }
+StSpotterPragmaBasedProcessor >> title [
+	self subclassResponsibility
+]
+
+{ #category : #accessing }
+StSpotterPragmaBasedProcessor >> wantsToDisplayOnEmptyQuery [
+	^ true
+]
+
+{ #category : #private }
+StSpotterPragmaBasedProcessor >> withItemsLimit: aLimit do: aBlock [
+	^ aBlock value
+]

--- a/src/NewTools-Spotter-Processors/StSpotterProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StSpotterProcessor.class.st
@@ -1,0 +1,326 @@
+"
+I am a extensible spotter processor. 
+I perform the integration with Spotter, but also I handle the lifecycle of the query, creating it from the spotter context; storing the results and the filter. 
+
+The filter is divided in two instance variables. The #filter contains the whole iterator that will be used. As some of the parts of the decorator requires to be notified when the filtering text is changed there is a collection of filters that require this.
+
+My subclasses should implement #newTextFilteringSource to return the filtering iterator to use or newSource if the iterator building is more complex (see StUnifiedProcessor).
+
+My subclasses can override #installKeymappingsOn: to install keybindings in Spotter.
+Also, there is #configureFilter to extend the configuration of the source when there is a change in the query.
+
+I also handled the notifications when the query finish, so Spotter UI can show it correctly.
+"
+Class {
+	#name : #StSpotterProcessor,
+	#superclass : #Object,
+	#instVars : [
+		'order',
+		'filter',
+		'results',
+		'query',
+		'running',
+		'textFilteringIterators'
+	],
+	#classInstVars : [
+		'enabled'
+	],
+	#category : #'NewTools-Spotter-Processors-Processors'
+}
+
+{ #category : #accessing }
+StSpotterProcessor class >> allConcreteSubclasses [
+	
+	^ self allSubclasses reject: [ :e | e isAbstract ]
+]
+
+{ #category : #accessing }
+StSpotterProcessor class >> allEnabledSubclasses [
+	
+	^ self allConcreteSubclasses select: [ :e | e isEnabled ]
+]
+
+{ #category : #'default-settings' }
+StSpotterProcessor class >> defaultEnabled [
+
+	^ self subclassResponsibility 
+]
+
+{ #category : #settings }
+StSpotterProcessor class >> enabled [ 
+
+	^ enabled ifNil: [ self defaultEnabled ]
+]
+
+{ #category : #settings }
+StSpotterProcessor class >> enabled: aValue [
+
+	enabled := aValue
+]
+
+{ #category : #settings }
+StSpotterProcessor class >> hideInSettings [
+
+	^ false
+]
+
+{ #category : #testing }
+StSpotterProcessor class >> isAbstract [ 
+
+	^ self == StSpotterProcessor 
+]
+
+{ #category : #testing }
+StSpotterProcessor class >> isEnabled [
+
+	self isAbstract
+		ifTrue: [ ^ false ].
+	^ enabled ifNil: [ self defaultEnabled ] ifNotNil: [ enabled ]
+]
+
+{ #category : #accessing }
+StSpotterProcessor class >> order [
+	
+	^ self subclassResponsibility 
+]
+
+{ #category : #settings }
+StSpotterProcessor class >> settingsDescription [
+
+	^ self title
+]
+
+{ #category : #settings }
+StSpotterProcessor class >> settingsOn: aBuilder [
+	<systemsettings>
+
+	(aBuilder group: #spotterProcessors)
+		parent: #spotter;
+		label: 'Sources';
+		description: 'It configures the sources that are queried when using spotter'.
+
+	self allConcreteSubclasses reject: [:e | e hideInSettings ] thenDo: [ :aProcessorClass | 
+		(aBuilder setting: aProcessorClass name , '_enabled')
+			parent: #spotterProcessors;
+			default: aProcessorClass defaultEnabled;
+			getSelector: #enabled;
+			setSelector: #enabled:;
+			target: aProcessorClass;
+			description: aProcessorClass settingsDescription;
+			label: aProcessorClass settingsTitle
+	].
+]
+
+{ #category : #settings }
+StSpotterProcessor class >> settingsTitle [
+
+	^ self title
+]
+
+{ #category : #accessing }
+StSpotterProcessor class >> title [
+	
+	^ self subclassResponsibility 
+]
+
+{ #category : #accessing }
+StSpotterProcessor >> actLogic [
+
+	^ [ :anItem :aStep | anItem evaluateFor: aStep ]
+]
+
+{ #category : #'spotter-api' }
+StSpotterProcessor >> allFilteredCandidates [
+
+	self configureFilter.		
+	^ self filter upToEnd
+]
+
+{ #category : #filtering }
+StSpotterProcessor >> configureFilter [
+
+	self ensureFilter.
+	textFilteringIterators do: [ :each | 
+		each filteringText: self query searchingText ]
+]
+
+{ #category : #filtering }
+StSpotterProcessor >> ensureFilter [
+
+	^ filter ifNil: [
+		filter := self newSource ]
+]
+
+{ #category : #filtering }
+StSpotterProcessor >> executeQuery [
+
+	(self query isSearchEmpty and: [ self showForEmptyQuery not ]) 
+		ifTrue: [ ^ self ].
+	
+	self configureFilter.
+		
+	results := OrderedCollection new.
+	[ self filter atEnd or: [ results size = self maxResults ] ] 
+		whileFalse: [
+			self filter next ifNotNil: [ :aResult | 
+				self query addResult: aResult.
+				results add: aResult ] ].
+
+	(results size = self maxResults)
+		ifTrue: [ ^ self ].
+
+	self query informAllResultAmount: results size
+]
+
+{ #category : #filtering }
+StSpotterProcessor >> filter [ 
+	
+	^ filter ifNil: [ self ensureFilter ]
+]
+
+{ #category : #'spotter-api' }
+StSpotterProcessor >> filterInContext: aSpotterContext [ 
+
+	self notifyStarted: aSpotterContext.
+	self query updateFromContext: aSpotterContext.
+	self executeQuery.
+	self notifyEnded: aSpotterContext.
+]
+
+{ #category : #initialization }
+StSpotterProcessor >> initialize [
+
+	super initialize.
+	running := false.
+]
+
+{ #category : #'key-bindings' }
+StSpotterProcessor >> installKeymappingsOn: aPresenter [ 
+	"Nothing to do"
+]
+
+{ #category : #'key-bindings' }
+StSpotterProcessor >> installKeymappingsOn: aPresenter onExecution: aBlock [
+
+	self installKeymappingsOn: aPresenter
+]
+
+{ #category : #'spotter-api' }
+StSpotterProcessor >> isRelevantForQuery: categoryQueryPrefix [
+
+	^ (self title asLowercase copyReplaceAll: String space with: '')
+			beginsWith: categoryQueryPrefix
+]
+
+{ #category : #'spotter-api' }
+StSpotterProcessor >> isRunning [ 
+
+	^ running
+]
+
+{ #category : #accessing }
+StSpotterProcessor >> itemIcon [
+
+	^ [ :anItem | anItem icon ]
+]
+
+{ #category : #accessing }
+StSpotterProcessor >> itemName [
+
+	^ [ :anItem | anItem asString ]
+]
+
+{ #category : #'key-bindings' }
+StSpotterProcessor >> keyBinding [ 
+	^ nil
+]
+
+{ #category : #configuration }
+StSpotterProcessor >> maxResults [
+
+	^ StSpotterPragmaBasedProcessor defaultItemsLimit
+]
+
+{ #category : #filtering }
+StSpotterProcessor >> newSource [
+
+	| source |
+	source := self newTextFilteringSource.
+
+	textFilteringIterators := OrderedCollection new.
+	textFilteringIterators add: source.
+	
+	^ source
+	
+]
+
+{ #category : #filtering }
+StSpotterProcessor >> newTextFilteringSource [
+
+	self subclassResponsibility 
+]
+
+{ #category : #events }
+StSpotterProcessor >> notifyEnded: aSpotterContext [
+
+	running := false.
+	aSpotterContext stream 
+		performSymbol: #processorEnded: 
+		withArguments: { self }.
+
+]
+
+{ #category : #events }
+StSpotterProcessor >> notifyStarted: aSpotterContext [
+
+	running := true.
+	aSpotterContext stream 
+		performSymbol: #processorStarted: 
+		withArguments: { self }.
+
+]
+
+{ #category : #accessing }
+StSpotterProcessor >> order [
+
+	^ order ifNil: [ self class order ]
+]
+
+{ #category : #accessing }
+StSpotterProcessor >> order: aNumber [
+
+	^ order
+]
+
+{ #category : #accessing }
+StSpotterProcessor >> query [
+
+	^ query ifNil: [ 
+		query := StQuery new 
+			processor: self; 
+			yourself ]
+]
+
+{ #category : #accessing }
+StSpotterProcessor >> query: aQuery [
+
+	query := aQuery
+]
+
+{ #category : #filtering }
+StSpotterProcessor >> render: anEntry [
+		
+	^ anEntry render
+]
+
+{ #category : #configuration }
+StSpotterProcessor >> showForEmptyQuery [
+
+	^ false
+]
+
+{ #category : #accessing }
+StSpotterProcessor >> title [
+
+	^ self class title
+]

--- a/src/NewTools-Spotter-Processors/StSpotterProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StSpotterProcessor.class.st
@@ -99,16 +99,17 @@ StSpotterProcessor class >> settingsOn: aBuilder [
 		label: 'Sources';
 		description: 'It configures the sources that are queried when using spotter'.
 
-	self allConcreteSubclasses reject: [:e | e hideInSettings ] thenDo: [ :aProcessorClass | 
-		(aBuilder setting: aProcessorClass name , '_enabled')
-			parent: #spotterProcessors;
-			default: aProcessorClass defaultEnabled;
-			getSelector: #enabled;
-			setSelector: #enabled:;
-			target: aProcessorClass;
-			description: aProcessorClass settingsDescription;
-			label: aProcessorClass settingsTitle
-	].
+	self allConcreteSubclasses 
+		reject: [ :each | each hideInSettings ] 
+		thenDo: [ :aProcessorClass | 
+			(aBuilder setting: aProcessorClass name , '_enabled')
+				parent: #spotterProcessors;
+				default: aProcessorClass defaultEnabled;
+				getSelector: #enabled;
+				setSelector: #enabled:;
+				target: aProcessorClass;
+				description: aProcessorClass settingsDescription;
+				label: aProcessorClass settingsTitle ]
 ]
 
 { #category : #settings }

--- a/src/NewTools-Spotter-Processors/StSubStringFilter.class.st
+++ b/src/NewTools-Spotter-Processors/StSubStringFilter.class.st
@@ -1,0 +1,22 @@
+"
+I implement a simple substring string filter using includesSubstring:.
+"
+Class {
+	#name : #StSubStringFilter,
+	#superclass : #StAbstractStringFilter,
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #protected }
+StSubStringFilter >> criterium: aValue [
+
+	^ aValue asString asLowercase includesSubstring: filteringText asLowercase
+
+
+]
+
+{ #category : #filtering }
+StSubStringFilter >> substringFilter: aString [
+	
+	self filteringText: aString
+]

--- a/src/NewTools-Spotter-Processors/StTransformation.class.st
+++ b/src/NewTools-Spotter-Processors/StTransformation.class.st
@@ -1,0 +1,21 @@
+"
+I implement the collect: operation on the iterator.
+I apply the block and transform the elements returned by myself.
+
+"
+Class {
+	#name : #StTransformation,
+	#superclass : #StIteratorBlockDecorator,
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #accessing }
+StTransformation >> next [
+	^ inner next ifNotNil: [ :aValue | self transform: aValue ]
+]
+
+{ #category : #tranforming }
+StTransformation >> transform: anElement [
+
+	^ aBlock value: anElement
+]

--- a/src/NewTools-Spotter-Processors/StUnifiedProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StUnifiedProcessor.class.st
@@ -1,0 +1,206 @@
+"
+I am a complex processor that unifies queries from: Classes, Implementors and Packages.
+I can handle filtering by categories, so to have different behavior when the query includes #Classes, #Packages, #Implementors.
+I configure the keymapping for the categories in spotter.
+
+My source is a complex one: 
+ 
+ - I will filter the duplicates out.
+ - I will configure it using the categories in the query.
+ - I have two behaviors, depending of the case of query. If it is uppercase, I will search first in implementors, then in classes and then in packages. If it is lowercase I will search in classes, packages and then implementors.
+ - I first search for matches starting with the query and then for matches with the query in any place of the entry.
+"
+Class {
+	#name : #StUnifiedProcessor,
+	#superclass : #StSpotterProcessor,
+	#instVars : [
+		'categories'
+	],
+	#category : #'NewTools-Spotter-Processors-Processors'
+}
+
+{ #category : #'default-settings' }
+StUnifiedProcessor class >> defaultEnabled [
+
+	^ true
+]
+
+{ #category : #accessing }
+StUnifiedProcessor class >> order [
+	
+	^ 100
+]
+
+{ #category : #settings }
+StUnifiedProcessor class >> settingsDescription [
+
+	^ 'I am the main processor: I show classes, packages and implementors'
+]
+
+{ #category : #settings }
+StUnifiedProcessor class >> settingsTitle [
+
+	^ 'Classes, Implementors & Packages'
+]
+
+{ #category : #accessing }
+StUnifiedProcessor class >> title [
+
+	^ 'Results'
+]
+
+{ #category : #sources }
+StUnifiedProcessor >> calculateLowercaseSourcesOn: anStream [
+
+	| implementorsBeginsWith implementorsSubstring wordsAwareImplementors |
+
+	(self categoriesIncludes: #Implementors) 
+		ifFalse: [ ^ self ].
+
+	implementorsBeginsWith := StSourceFactory current implementorsBeginsWithSource.
+	implementorsSubstring := StSourceFactory current implementorsSubstringSource.
+	wordsAwareImplementors := StWordsAwareFilter new 
+		inner: (StSourceFactory current implementorsSubstringSource); 
+		yourself.
+	
+	textFilteringIterators add: implementorsBeginsWith.
+	textFilteringIterators add: implementorsSubstring.
+	textFilteringIterators add: wordsAwareImplementors.
+	
+	anStream nextPut: implementorsBeginsWith.
+	anStream nextPut: implementorsSubstring.
+	anStream nextPut: wordsAwareImplementors 
+
+]
+
+{ #category : #sources }
+StUnifiedProcessor >> calculateUppercaseSourcesOn: anStream [
+	| classesBeginsWith classesIncludesString packagesBeginsWith packagesIncludesString wordsAwareClassesSource wordsAwarePackageSource classAndSelectorImplementors |
+	
+	(self categoriesIncludes: #Classes) 
+		ifTrue: [
+			classesBeginsWith := StSourceFactory current classesBeginsWithSource.			
+			textFilteringIterators add: classesBeginsWith.
+			anStream nextPut: classesBeginsWith ].
+
+	(self categoriesIncludes: #Packages) 
+		ifTrue: [
+			packagesBeginsWith := (StPackageIterator new 
+				collect: [ :each | StPackageEntry on: each ]) 
+				asBeginsWithFilter.			
+			textFilteringIterators add: packagesBeginsWith.
+			anStream nextPut: packagesBeginsWith ].
+
+	(self categoriesIncludes: #Classes) 
+		ifTrue: [
+			classesIncludesString := StSourceFactory current classesSubstringSource.
+			textFilteringIterators add: classesIncludesString.
+			anStream nextPut: classesIncludesString ].
+		
+	(self categoriesIncludes: #Packages) 
+		ifTrue: [
+			packagesIncludesString := (StPackageIterator new 
+				collect: [ :each | StPackageEntry on: each ]) 
+				asSubstringFilter.		
+			textFilteringIterators add: packagesIncludesString.
+			anStream nextPut: packagesIncludesString ].
+		
+	(self categoriesIncludes: #Classes) 
+		ifTrue: [
+			wordsAwareClassesSource := StWordsAwareFilter new 
+				inner: (StSourceFactory current classesSubstringSource); 
+				yourself.
+			textFilteringIterators add: wordsAwareClassesSource.
+			anStream nextPut: wordsAwareClassesSource ].
+
+	(self categoriesIncludes: #Implementors) 
+		ifTrue: 	[ 	
+			classAndSelectorImplementors := StClassWithSelectorWordFilter new 
+				inner: (StSourceFactory current implementorsSubstringSource); 
+				yourself.
+			textFilteringIterators add: classAndSelectorImplementors.
+			anStream nextPut: classAndSelectorImplementors ].
+
+	(self categoriesIncludes: #Packages) 
+		ifTrue: [
+			wordsAwarePackageSource := StWordsAwareFilter new 
+				inner: ((StPackageIterator new 
+					collect: [ :each | StPackageEntry on: each ]) 
+					asSubstringFilter); 
+				yourself.
+			textFilteringIterators add: wordsAwarePackageSource.
+			anStream nextPut: wordsAwarePackageSource ]
+]
+
+{ #category : #sources }
+StUnifiedProcessor >> categoriesIncludes: aCategory [
+
+	^ categories isNil 
+		or: [ categories isEmpty 
+		or: [ (categories includes: aCategory)
+		or: [ categories anySatisfy: [ :each | aCategory asLowercase beginsWith: each asLowercase ] ] ] ]
+]
+
+{ #category : #filtering }
+StUnifiedProcessor >> configureFilter [
+
+	(categories ~= self query categoriesSelected)
+		ifTrue: [
+			categories := self query categoriesSelected.
+			filter := nil ].
+
+	super configureFilter.
+	
+	"I will clear the duplicates, as a new query have done"
+	filter clearDuplicates
+]
+
+{ #category : #'key-bindings' }
+StUnifiedProcessor >> installKeymappingsOn: aPresenter onExecution: aBlock [
+
+	aPresenter
+		bindKeyCombination: $b meta
+		toAction: [
+			self query filterClasses.
+			aBlock cull: self ].
+
+	aPresenter
+		bindKeyCombination: $m meta
+		toAction: [ 
+			self query filterImplementors.
+			aBlock cull: self ]
+]
+
+{ #category : #'spotter-api' }
+StUnifiedProcessor >> isRelevantForQuery: aString [ 
+	
+	"I will handle... I am old enough"
+	^ true
+]
+
+{ #category : #filtering }
+StUnifiedProcessor >> newSource [
+	| uppercaseIterators lowercaseIterators caseSelectorIterator root |
+	
+	textFilteringIterators := OrderedCollection new.
+	lowercaseIterators := OrderedCollection streamContents: [ :stream | 
+		self calculateLowercaseSourcesOn: stream ].
+	uppercaseIterators := OrderedCollection streamContents: [ :stream | 
+		self calculateUppercaseSourcesOn: stream ].
+
+	caseSelectorIterator := StCaseSelectorIterator new 
+		lowercaseIterator: (StSequenceIterator with: lowercaseIterators);
+		uppercaseIterator: (StSequenceIterator with: uppercaseIterators).
+		
+	textFilteringIterators add: caseSelectorIterator.
+	
+	root := caseSelectorIterator asWithoutDuplicates.
+		
+	^ root
+]
+
+{ #category : #filtering }
+StUnifiedProcessor >> newTextFilteringSource [
+	"It should not arrive here"
+	^ nil
+]

--- a/src/NewTools-Spotter-Processors/StWindowEntry.class.st
+++ b/src/NewTools-Spotter-Processors/StWindowEntry.class.st
@@ -1,0 +1,25 @@
+"
+I wrap a Window, to modify its behavior if required for the spotter
+"
+Class {
+	#name : #StWindowEntry,
+	#superclass : #StEntry,
+	#category : #'NewTools-Spotter-Processors-Entries'
+}
+
+{ #category : #converting }
+StWindowEntry >> asString [ 
+
+	^ '{1} [{2}]' format: { content label. content className }
+]
+
+{ #category : #evaluating }
+StWindowEntry >> doEvaluate [
+	content spotterActDefault
+]
+
+{ #category : #accessing }
+StWindowEntry >> icon [
+	
+	^ content taskbarIcon
+]

--- a/src/NewTools-Spotter-Processors/StWindowsProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StWindowsProcessor.class.st
@@ -1,0 +1,46 @@
+"
+I am a processor to get all the windows open in the world. It filters out the top most window
+"
+Class {
+	#name : #StWindowsProcessor,
+	#superclass : #StCollectionBasedProcessor,
+	#category : #'NewTools-Spotter-Processors-Processors'
+}
+
+{ #category : #'default-settings' }
+StWindowsProcessor class >> defaultEnabled [
+
+	^ true
+]
+
+{ #category : #accessing }
+StWindowsProcessor class >> order [
+	
+	^ 50
+]
+
+{ #category : #accessing }
+StWindowsProcessor class >> title [
+
+	^ 'Windows'
+]
+
+{ #category : #filtering }
+StWindowsProcessor >> collection [
+
+	^ (self currentWorld submorphs
+		select: [ :window | window isKindOf: SystemWindow ])
+		ifNotEmpty: [ :aCollection | aCollection allButFirst ]
+]
+
+{ #category : #filtering }
+StWindowsProcessor >> newEntryOn: anElement [
+
+	^ StWindowEntry on: anElement
+]
+
+{ #category : #configuration }
+StWindowsProcessor >> showForEmptyQuery [
+
+	^ true
+]

--- a/src/NewTools-Spotter-Processors/StWithoutDuplicatesDecorator.class.st
+++ b/src/NewTools-Spotter-Processors/StWithoutDuplicatesDecorator.class.st
@@ -1,0 +1,54 @@
+"
+I implement a decorator for the iterators. 
+I don't allow duplicates to be returned. For doing so, I have a collection of the already returned values, so I can filter duplicates.
+"
+Class {
+	#name : #StWithoutDuplicatesDecorator,
+	#superclass : #StIteratorDecorator,
+	#instVars : [
+		'uniqueResults'
+	],
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #'instance creation' }
+StWithoutDuplicatesDecorator class >> on: anInner [
+
+	^ self new 
+		inner: anInner;
+		yourself
+]
+
+{ #category : #resetting }
+StWithoutDuplicatesDecorator >> clearDuplicates [
+	
+	uniqueResults removeAll
+]
+
+{ #category : #protected }
+StWithoutDuplicatesDecorator >> doReset [ 
+
+	inner reset.
+	self clearDuplicates
+]
+
+{ #category : #initialization }
+StWithoutDuplicatesDecorator >> initialize [ 
+
+	super initialize.
+	uniqueResults := Set new.
+]
+
+{ #category : #accessing }
+StWithoutDuplicatesDecorator >> next [
+
+	| aValue |
+	aValue := inner next.
+	
+	[aValue isNotNil and: [ uniqueResults includes: aValue ]]
+		whileTrue: [ aValue := inner next ].
+		
+	uniqueResults add: aValue.
+	^ aValue
+	
+]

--- a/src/NewTools-Spotter-Processors/StWordsAwareFilter.class.st
+++ b/src/NewTools-Spotter-Processors/StWordsAwareFilter.class.st
@@ -1,0 +1,54 @@
+"
+I implement a complex filter on top of my inner iterator.
+I will take the filtering text and split it on the spaces, $: and camel case syntax to try to detect all the elements that have those words.
+
+My iterator is query with the first word of the filtering text and the filtering the elements that have all the words in any part. 
+For example, doing the query StoreDisk will answer also DiskStore 
+"
+Class {
+	#name : #StWordsAwareFilter,
+	#superclass : #StIteratorDecorator,
+	#instVars : [
+		'words',
+		'realFilter'
+	],
+	#category : #'NewTools-Spotter-Processors-Iterators'
+}
+
+{ #category : #filtering }
+StWordsAwareFilter >> additionalFilter: aString firstWord: firstWord otherWords: otherWords on: anEntry [
+
+	^ otherWords allSatisfy: [ :otherW | anEntry asString asLowercase includesSubstring: otherW ]
+
+]
+
+{ #category : #filtering }
+StWordsAwareFilter >> filteringText: aString [
+
+	| firstWord otherWords |
+	words := self splitWords: aString.
+	words ifEmpty: [ ^ self ].
+	
+	firstWord := words first.
+	otherWords := words allButFirst collect: [:each | each asLowercase].
+		
+	realFilter filteringText: firstWord.
+	inner := realFilter select: [ :anEntry | 
+		anEntry isNotNil and: 
+		[self additionalFilter: aString firstWord: firstWord otherWords: otherWords on: anEntry ]].
+
+]
+
+{ #category : #accessing }
+StWordsAwareFilter >> inner: anIterator [
+
+	inner := anIterator.
+	realFilter := anIterator
+]
+
+{ #category : #filtering }
+StWordsAwareFilter >> splitWords: aString [
+
+	^ (aString substrings: ' :-')
+		flatCollect: [ :each | each splitCamelCase  ]
+]

--- a/src/NewTools-Spotter-Processors/StWorldMenuEntry.class.st
+++ b/src/NewTools-Spotter-Processors/StWorldMenuEntry.class.st
@@ -1,0 +1,26 @@
+"
+I wrap a World menu entry, to modify its behavior if required for the spotter
+"
+Class {
+	#name : #StWorldMenuEntry,
+	#superclass : #StEntry,
+	#category : #'NewTools-Spotter-Processors-Entries'
+}
+
+{ #category : #converting }
+StWorldMenuEntry >> asString [ 
+
+	^ content contents
+]
+
+{ #category : #evaluating }
+StWorldMenuEntry >> doEvaluate [ 
+
+	content spotterActDefault
+]
+
+{ #category : #accessing }
+StWorldMenuEntry >> icon [
+
+	^ content icon
+]

--- a/src/NewTools-Spotter-Processors/StWorldMenuProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StWorldMenuProcessor.class.st
@@ -1,0 +1,40 @@
+"
+I am a simple processor that returns all the world menu entries. 
+"
+Class {
+	#name : #StWorldMenuProcessor,
+	#superclass : #StSpotterProcessor,
+	#category : #'NewTools-Spotter-Processors-Processors'
+}
+
+{ #category : #'default-settings' }
+StWorldMenuProcessor class >> defaultEnabled [
+
+	^ true
+]
+
+{ #category : #accessing }
+StWorldMenuProcessor class >> order [
+	
+	^ 90
+]
+
+{ #category : #accessing }
+StWorldMenuProcessor class >> title [
+
+	^ 'Menu'
+]
+
+{ #category : #filtering }
+StWorldMenuProcessor >> newTextFilteringSource [
+
+	^ ((StGeneratorBlockIterator
+		on: [ :aValuable | self currentWorld worldMenu withAllLeafItemsDo: aValuable ])
+		collect: [ :e | StWorldMenuEntry on: e ]) asSubstringFilter
+]
+
+{ #category : #configuration }
+StWorldMenuProcessor >> showForEmptyQuery [
+
+	^ true
+]

--- a/src/NewTools-Spotter-Processors/String.extension.st
+++ b/src/NewTools-Spotter-Processors/String.extension.st
@@ -1,0 +1,24 @@
+Extension { #name : #String }
+
+{ #category : #'*NewTools-Spotter-Processors' }
+String >> splitCamelCase [
+	
+	| results accum previousIsLower |
+	
+	results := OrderedCollection new.
+	accum := 	self first asString.
+	previousIsLower := self first isLowercase.
+	
+	2 to: self size do: [ :index | | currentCharacter |
+		currentCharacter := self at: index.
+		(currentCharacter isUppercase and: [ previousIsLower ])
+			ifTrue: [ results add: accum. accum := '' ].
+			
+		accum := accum copyWith: currentCharacter.
+		previousIsLower := currentCharacter isLowercase.
+	].	
+	
+	results add: accum.
+	
+	^ results.
+]

--- a/src/NewTools-Spotter-Processors/package.st
+++ b/src/NewTools-Spotter-Processors/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'NewTools-Spotter-Processors' }

--- a/src/NewTools-Spotter/Class.extension.st
+++ b/src/NewTools-Spotter/Class.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #Class }
+
+{ #category : #'*NewTools-Spotter-Extensions' }
+Class >> spotterPreview: aBuilder [
+
+	^ aBuilder newCode
+		beForScripting;
+		beNotEditable;
+		text: self definitionString;
+		yourself
+]

--- a/src/NewTools-Spotter/Object.extension.st
+++ b/src/NewTools-Spotter/Object.extension.st
@@ -1,0 +1,45 @@
+Extension { #name : #Object }
+
+{ #category : #'*NewTools-Spotter' }
+Object >> asStSpotterCandidateLink [
+
+	^ StSpotterCandidateLink value: self
+]
+
+{ #category : #'*NewTools-Spotter' }
+Object >> asStSpotterProcessorLink [
+
+	^ StSpotterProcessorLink value: self
+]
+
+{ #category : #'*NewTools-Spotter' }
+Object >> spotterPreview: aBuilder [
+
+	^ self asString spotterPreview: aBuilder
+]
+
+{ #category : #'*NewTools-Spotter' }
+Object >> stFilter [
+
+	^ StFilterBlock stFilter
+		
+]
+
+{ #category : #'*NewTools-Spotter' }
+Object >> stListFilter [
+
+	^ StFilterSubstring new
+]
+
+{ #category : #'*NewTools-Spotter' }
+Object >> stSpotterProcessorsFor: aSpotterStep [
+	"This is a utility method that collects all extensions (processors) for the current object.
+	By default, it simply looks for the #spotterOrder: pragma.
+	The step can decice whether or not an extension should be enabled.
+	The step can also configure each extension (e.g. override any property)"
+	
+	(Pragma allNamed: #stSpotterOrder: from: self class to: Object) 
+		do: [ :aPragma |  
+			self perform: aPragma methodSelector with: aSpotterStep.
+			aSpotterStep processors last order: (aPragma argumentAt: 1) ]
+]

--- a/src/NewTools-Spotter/StBaseFilter.class.st
+++ b/src/NewTools-Spotter/StBaseFilter.class.st
@@ -1,0 +1,170 @@
+Class {
+	#name : #StBaseFilter,
+	#superclass : #Object,
+	#instVars : [
+		'context',
+		'filteredItems',
+		'streamed'
+	],
+	#category : #'NewTools-Spotter-Filters'
+}
+
+{ #category : #public }
+StBaseFilter class >> stFilter [
+
+	^ self new
+]
+
+{ #category : #public }
+StBaseFilter class >> stListFilter [
+
+	^ self new
+]
+
+{ #category : #'private-model' }
+StBaseFilter >> addItem: anItem [
+	self context streamed add: anItem.
+	self context addItem: anItem
+]
+
+{ #category : #'private-model' }
+StBaseFilter >> addItems: aCollection [
+	self context streamed addAll: aCollection.
+	self context addItems: aCollection
+]
+
+{ #category : #'private-model' }
+StBaseFilter >> allItems [
+	" WARNING: #allItems might be a list, block or iterator. we have to evaluate it in order to calculate the remaining/unstreamed items. #allItems are/were designed to be polymorphic to collections and streams. so this should be safe "
+	| allItems |
+	allItems := self processor allItemsIn: self context.
+	^ self context isContinuing
+		ifTrue: [ allItems value fasterDifferencePreservingOrder: self context streamed ]
+		ifFalse: [ allItems ]
+]
+
+{ #category : #'private-model' }
+StBaseFilter >> allItemsDo: aBlock [
+	self allItems do: aBlock
+]
+
+{ #category : #private }
+StBaseFilter >> applyFilter [
+	^ self filteredItems
+]
+
+{ #category : #private }
+StBaseFilter >> applyFilterInContext: aSpotterContext [
+	self prepareFilterInContext: aSpotterContext.
+	^ self applyFilter
+]
+
+{ #category : #private }
+StBaseFilter >> applyFilterInContext: aSpotterContext error: anException [
+	('[Spotter] Exception in filter <' , self class name , '>: '
+		, anException asString) traceCr.
+	^ self defaultFilteredItems
+]
+
+{ #category : #accessing }
+StBaseFilter >> context [
+	^ context
+]
+
+{ #category : #accessing }
+StBaseFilter >> context: anObject [
+	context := anObject
+]
+
+{ #category : #'accessing-defaults' }
+StBaseFilter >> defaultFilteredItems [
+	^ OrderedCollection new: 100 " not a limitation, just a reasonable start size "
+]
+
+{ #category : #'accessing-defaults' }
+StBaseFilter >> defaultStreamed [
+	^ true
+]
+
+{ #category : #accessing }
+StBaseFilter >> filteredItems [
+	^ filteredItems
+]
+
+{ #category : #accessing }
+StBaseFilter >> filteredItems: aCollection [
+	filteredItems := aCollection
+]
+
+{ #category : #testing }
+StBaseFilter >> hasFilteredItems [
+	^ self filteredItems isEmptyOrNil not
+]
+
+{ #category : #initialization }
+StBaseFilter >> initialize [
+	super initialize.
+	
+	self filteredItems: self defaultFilteredItems
+]
+
+{ #category : #'private-model' }
+StBaseFilter >> itemFilterNameFor: anItem [
+	"I return the string/text representation of an item used by the filter."
+	
+	^ self processor itemFilterNameFor: anItem
+]
+
+{ #category : #'private-model' }
+StBaseFilter >> itemsLimit [
+	^ self context itemsLimit
+]
+
+{ #category : #private }
+StBaseFilter >> prepareFilterInContext: aSpotterContext [
+	"I provide a hook for preprocessing the query once before performing a search."
+	
+	self context: aSpotterContext.
+]
+
+{ #category : #'private-model' }
+StBaseFilter >> processor [
+	^ self context processor
+]
+
+{ #category : #public }
+StBaseFilter >> stFilter [
+
+	^ self
+]
+
+{ #category : #public }
+StBaseFilter >> stListFilter [
+
+	^ self
+]
+
+{ #category : #'private-model' }
+StBaseFilter >> step [
+	^ self context step
+]
+
+{ #category : #accessing }
+StBaseFilter >> streamed [
+	^ streamed ifNil: [ streamed := self defaultStreamed ]
+]
+
+{ #category : #accessing }
+StBaseFilter >> streamed: anObject [
+	streamed := anObject
+]
+
+{ #category : #public }
+StBaseFilter >> value: aSpotterContext [
+	"I provide an entry point for performing a search that is 
+	polymorphic with BlockClosure>>value:. I return the list of
+	filtered items."
+	
+	^ [ self applyFilterInContext: aSpotterContext ]
+		ensure: [ context := nil " release the context after search is completed " ] 
+]

--- a/src/NewTools-Spotter/StClassEntry.extension.st
+++ b/src/NewTools-Spotter/StClassEntry.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #StClassEntry }
+
+{ #category : #'*NewTools-Spotter' }
+StClassEntry >> headerCategoryForUnifiedProcessor: aLink on: aSpotterPresenter [
+
+	^ aSpotterPresenter headerCategoryUnifiedFor: aLink
+]
+
+{ #category : #'*NewTools-Spotter' }
+StClassEntry class >> prepareUnifiedHeaderDescriptionFor: aHeaderPresenter [
+
+	^ aHeaderPresenter prepareAsClasses
+]

--- a/src/NewTools-Spotter/StEntry.extension.st
+++ b/src/NewTools-Spotter/StEntry.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #StEntry }
+
+{ #category : #'*NewTools-Spotter' }
+StEntry >> headerCategoryForUnifiedProcessor: aLink on: aSpotterPresenter [
+
+	^ aSpotterPresenter headerCategoryFor: aLink 			
+
+]
+
+{ #category : #'*NewTools-Spotter' }
+StEntry class >> prepareUnifiedHeaderDescriptionFor: aHeaderPresenter [
+	"do nothing"
+]

--- a/src/NewTools-Spotter/StFilterAlike.class.st
+++ b/src/NewTools-Spotter/StFilterAlike.class.st
@@ -1,0 +1,82 @@
+Class {
+	#name : #StFilterAlike,
+	#superclass : #StOrderedFilter,
+	#instVars : [
+		'lowerThreshold',
+		'upperThreshold'
+	],
+	#category : #'NewTools-Spotter-Filters'
+}
+
+{ #category : #private }
+StFilterAlike >> applyFilterWithQuery [
+	| allItemsPrepocessed allItemsPrepocessedAndSorted alikeMatches otherMatches upper lower |
+	alikeMatches := OrderedCollection  new.
+	otherMatches := OrderedCollection new.	
+	" calculate the <similarity> of all items and throw away everything that is below the lower threshold (irrelevant) "			
+	allItemsPrepocessed := OrderedCollection streamContents: [ :allItems | 
+		lower := lowerThreshold * query size.
+		self allItemsDo: [ :each | 
+			| weight |
+			(weight :=  (self itemFilterNameFor: each) alike: query) > lower ifTrue: [
+				allItems nextPut: (Array with: weight with: each) ] ] ].
+	" sort all items using <similarity> "
+	allItemsPrepocessedAndSorted := allItemsPrepocessed asSortedCollection: [ :a :b | a first > b first ].
+	" calculate the upper threshold "
+	upper := allItemsPrepocessed isEmpty 
+		ifTrue: [ upperThreshold ]
+		ifFalse: [ (allItemsPrepocessedAndSorted collect: [ :each | each first ]) median " try an adaptive threshold (slow if not presorted) " ].
+	" stream all items based on upper and lower threshold "
+	allItemsPrepocessedAndSorted do: [ :each | 
+		each first >= upper 
+			ifTrue: [
+				alikeMatches add: each last.
+				alikeMatches size > self itemsLimit ifFalse: [ 
+					self addItem: each ] ]
+			ifFalse:[ otherMatches add: each last ] ].
+	" push less relevant matches onto the result "
+	(alikeMatches size < self itemsLimit) ifTrue: [ 
+		(otherMatches first: ((self itemsLimit - alikeMatches size) min: otherMatches size)) do: [ :each |
+			self addItem: each ] ].
+	self filteredItems: alikeMatches , otherMatches 
+]
+
+{ #category : #'accessing-defaults' }
+StFilterAlike >> defaultLowerThreshold [
+	" lower threshold: to cut off the large irrelevent chunk before sorting/filtering is appplied "
+	^ 0.33
+]
+
+{ #category : #'accessing-defaults' }
+StFilterAlike >> defaultUpperThreshold [
+	" upper threshold: to keep a reasonably sized set of interesting matches "
+	^ 0.45
+]
+
+{ #category : #accessing }
+StFilterAlike >> lowerThreshold [
+	^ lowerThreshold
+]
+
+{ #category : #accessing }
+StFilterAlike >> lowerThreshold: anObject [
+	lowerThreshold := anObject
+]
+
+{ #category : #private }
+StFilterAlike >> prepareFilterInContext: aSpotterContext [
+	super prepareFilterInContext: aSpotterContext.
+	
+	lowerThreshold ifNil: [ lowerThreshold := self defaultLowerThreshold ]. " performance optimization "
+	upperThreshold ifNil: [ upperThreshold := self defaultUpperThreshold ]. " performance optimization "
+]
+
+{ #category : #accessing }
+StFilterAlike >> upperThreshold [
+	^ upperThreshold
+]
+
+{ #category : #accessing }
+StFilterAlike >> upperThreshold: anObject [
+	upperThreshold := anObject
+]

--- a/src/NewTools-Spotter/StFilterBlock.class.st
+++ b/src/NewTools-Spotter/StFilterBlock.class.st
@@ -1,0 +1,27 @@
+Class {
+	#name : #StFilterBlock,
+	#superclass : #StUnorderedFilter,
+	#instVars : [
+		'matcher'
+	],
+	#category : #'NewTools-Spotter-Filters'
+}
+
+{ #category : #private }
+StFilterBlock >> isMatchedItem: anItem [
+
+	^ self matcher 
+		ifNotNil: [ self matcher value: anItem value: self context ]
+		ifNil: [ (self itemFilterNameFor: anItem) includesSubstring: query caseSensitive: caseSensitive ]
+		
+]
+
+{ #category : #accessing }
+StFilterBlock >> matcher [
+	^ matcher
+]
+
+{ #category : #accessing }
+StFilterBlock >> matcher: anObject [
+	matcher := anObject
+]

--- a/src/NewTools-Spotter/StFilterFuzzy.class.st
+++ b/src/NewTools-Spotter/StFilterFuzzy.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #StFilterFuzzy,
+	#superclass : #StOrderedFilter,
+	#category : #'NewTools-Spotter-Filters'
+}
+
+{ #category : #private }
+StFilterFuzzy >> applyFilterWithQuery [
+	
+	| result |
+
+	result := FuzzyMatcher allSortedByScoreMatching: query 
+		in: self allItems
+		by: [ :each | self itemFilterNameFor: each ].
+	
+	self 
+		addItems: (result takeFirst: self itemsLimit);
+		filteredItems: result
+
+]

--- a/src/NewTools-Spotter/StFilterRegex.class.st
+++ b/src/NewTools-Spotter/StFilterRegex.class.st
@@ -1,0 +1,41 @@
+Class {
+	#name : #StFilterRegex,
+	#superclass : #StUnorderedFilter,
+	#instVars : [
+		'regex'
+	],
+	#category : #'NewTools-Spotter-Filters'
+}
+
+{ #category : #private }
+StFilterRegex >> applyFilterInContext: aSpotterContext error: exception [
+	
+	super applyFilterInContext: aSpotterContext error: exception.
+	^ (StFilterSubstrings new
+		caseSensitive: self caseSensitive;
+		yourself) value: aSpotterContext
+]
+
+{ #category : #private }
+StFilterRegex >> isMatchedItem: anItem [
+	^ self regex matches: (self itemFilterNameFor: anItem)
+]
+
+{ #category : #private }
+StFilterRegex >> prepareFilterInContext: aSpotterContext [
+	super prepareFilterInContext: aSpotterContext.
+	
+	self regex: (caseSensitive " performance optimization "
+		ifTrue: [ self query asRegex ] 
+		ifFalse: [ self query asRegexIgnoringCase ])
+]
+
+{ #category : #accessing }
+StFilterRegex >> regex [
+	^ regex
+]
+
+{ #category : #accessing }
+StFilterRegex >> regex: anObject [
+	regex := anObject
+]

--- a/src/NewTools-Spotter/StFilterStringMatch.class.st
+++ b/src/NewTools-Spotter/StFilterStringMatch.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #StFilterStringMatch,
+	#superclass : #StUnorderedFilter,
+	#category : #'NewTools-Spotter-Filters'
+}
+
+{ #category : #private }
+StFilterStringMatch >> isMatchedItem: anItem [
+	^ query match: (self itemFilterNameFor: anItem)
+]

--- a/src/NewTools-Spotter/StFilterSubstring.class.st
+++ b/src/NewTools-Spotter/StFilterSubstring.class.st
@@ -1,0 +1,54 @@
+Class {
+	#name : #StFilterSubstring,
+	#superclass : #StOrderedFilter,
+	#category : #'NewTools-Spotter-Filters'
+}
+
+{ #category : #private }
+StFilterSubstring >> doApplyFilterWithQuery [
+	| exactMatches prefixMatches otherMatches nonExactMatches |
+	"we want to distinguish between exact matches"
+	exactMatches := OrderedCollection new.
+	"... results for which the query matches the prefix"
+	prefixMatches := OrderedCollection new.	
+	"... and the rest of the results"
+	otherMatches := OrderedCollection new.
+
+	self allItemsDo: [ :each | 
+		| index queryString itemName |
+		itemName := self itemFilterNameFor: each.
+		queryString := self queryForItem: each.
+		index := self indexForItemName: itemName andQuery: queryString.
+		index >= 1 ifTrue: [
+			index = 1 
+				ifTrue: [ 
+					itemName size = queryString size 
+						ifTrue: [ 
+							exactMatches add: each.
+							self addItem: each.
+														
+							exactMatches size = self itemsLimit ifTrue: [ 
+								self filteredItems: exactMatches.
+								StLimitArrived signal	] ]							
+						ifFalse: [ prefixMatches add: each ] ]
+				ifFalse: [ otherMatches add: each ] ] ].
+	nonExactMatches := prefixMatches, otherMatches.
+	(exactMatches size < self itemsLimit) ifTrue: [ 
+		| restVisibleItems |
+		restVisibleItems := nonExactMatches first: ((self itemsLimit - exactMatches size) min: nonExactMatches size).
+		self addItems: restVisibleItems ].
+	self filteredItems: exactMatches, nonExactMatches
+]
+
+{ #category : #private }
+StFilterSubstring >> indexForItemName: aString andQuery: aQueryString [
+	^ aString 
+		findString: aQueryString
+		startingAt: 1 
+		caseSensitive: self caseSensitive
+]
+
+{ #category : #private }
+StFilterSubstring >> queryForItem: each [
+	^ query " performance optimization "
+]

--- a/src/NewTools-Spotter/StFilterSubstrings.class.st
+++ b/src/NewTools-Spotter/StFilterSubstrings.class.st
@@ -1,0 +1,39 @@
+Class {
+	#name : #StFilterSubstrings,
+	#superclass : #StUnorderedFilter,
+	#instVars : [
+		'separators'
+	],
+	#category : #'NewTools-Spotter-Filters'
+}
+
+{ #category : #'accessing-defaults' }
+StFilterSubstrings >> defaultSeparators [
+	^ ' '
+]
+
+{ #category : #private }
+StFilterSubstrings >> isMatchedItem: anItem [
+	| itemName |
+	itemName := self itemFilterNameFor: anItem.
+	^ query allSatisfy: [ :fragment | 
+		itemName includesSubstring: fragment caseSensitive: self caseSensitive ]
+]
+
+{ #category : #private }
+StFilterSubstrings >> prepareFilterInContext: aSpotterContext [
+	super prepareFilterInContext: aSpotterContext.
+	
+	separators ifNil: [  separators := self defaultSeparators  ]. " performance optimization "
+	self query: (self query substrings: self separators) asSet asArray
+]
+
+{ #category : #accessing }
+StFilterSubstrings >> separators [
+	^ separators
+]
+
+{ #category : #accessing }
+StFilterSubstrings >> separators: anObject [
+	separators := anObject
+]

--- a/src/NewTools-Spotter/StLimitArrived.class.st
+++ b/src/NewTools-Spotter/StLimitArrived.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #StLimitArrived,
+	#superclass : #Warning,
+	#category : #'NewTools-Spotter-Filters'
+}

--- a/src/NewTools-Spotter/StMethodEntry.extension.st
+++ b/src/NewTools-Spotter/StMethodEntry.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #StMethodEntry }
+
+{ #category : #'*NewTools-Spotter' }
+StMethodEntry >> headerCategoryForUnifiedProcessor: aLink on: aSpotterPresenter [
+
+	^ aSpotterPresenter headerCategoryUnifiedFor: aLink
+]
+
+{ #category : #'*NewTools-Spotter' }
+StMethodEntry class >> prepareUnifiedHeaderDescriptionFor: aHeaderPresenter [
+
+	^ aHeaderPresenter prepareAsImplementors
+]

--- a/src/NewTools-Spotter/StNullFilter.class.st
+++ b/src/NewTools-Spotter/StNullFilter.class.st
@@ -1,0 +1,35 @@
+Class {
+	#name : #StNullFilter,
+	#superclass : #StStringFilter,
+	#category : #'NewTools-Spotter-Filters'
+}
+
+{ #category : #public }
+StNullFilter class >> stListFilter [
+
+	^ StFilterSubstring new
+]
+
+{ #category : #private }
+StNullFilter >> doApplyFilterWithQuery [
+
+	self streamed 
+		ifTrue: [
+			" this will be more responsive (faster) for very large collections and/or expensive filters "
+			| allItems |
+			self filteredItems: (allItems := OrderedCollection new).
+			self allItems withIndexDo: [ :each :index |				
+				allItems add: each.
+				self addItem: each.
+				index = self itemsLimit ifTrue: [ StLimitArrived signal ] ] ]
+		ifFalse: [
+			" this will be much much faster for small collections and/or very quick filters " 
+			self filteredItems: self allItems.
+			self addItems: (self allItems first: (self itemsLimit min: self allItems size)) ]
+]
+
+{ #category : #public }
+StNullFilter >> stListFilter [
+
+	^ StFilterSubstring new
+]

--- a/src/NewTools-Spotter/StOrderedFilter.class.st
+++ b/src/NewTools-Spotter/StOrderedFilter.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #StOrderedFilter,
+	#superclass : #StStringFilter,
+	#category : #'NewTools-Spotter-Filters'
+}

--- a/src/NewTools-Spotter/StPackageEntry.extension.st
+++ b/src/NewTools-Spotter/StPackageEntry.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #StPackageEntry }
+
+{ #category : #'*NewTools-Spotter' }
+StPackageEntry >> headerCategoryForUnifiedProcessor: aLink on: aSpotterPresenter [
+
+	^ aSpotterPresenter headerCategoryUnifiedFor: aLink
+]
+
+{ #category : #'*NewTools-Spotter' }
+StPackageEntry class >> prepareUnifiedHeaderDescriptionFor: aHeaderPresenter [
+
+	^ aHeaderPresenter prepareAsPackages
+]

--- a/src/NewTools-Spotter/StSpotter.class.st
+++ b/src/NewTools-Spotter/StSpotter.class.st
@@ -1,0 +1,561 @@
+"
+When exploring the system, is useful to have a single entry point that will allow users to search for different component of the system. 
+Spotter provides such entry point and is usually available by pressing <meta+enter>.
+
+Spotter is just a front-end to show the result of different processors (see *StSpotterProcessor*) that provide results. Those processors can be configured in different ways and will provide different access options. 
+
+Some known processors and options are: 
+
+## Classes processor: 
+- Type #classes in the search bar
+- Press <meta+b>
+
+## Implementors processor: 
+- Type #implementors in the search bar
+- Press <meta+m>
+
+## Senders processor: 
+- Type #senders in the search bar
+- Press <meta+n>
+"
+Class {
+	#name : #StSpotter,
+	#superclass : #StPresenter,
+	#instVars : [
+		'searchText',
+		'resultList',
+		'model',
+		'previewContainer',
+		'categories',
+		'mutex',
+		'spinner',
+		'tip'
+	],
+	#classVars : [
+		'History',
+		'Preview',
+		'Tips'
+	],
+	#classInstVars : [
+		'spotterWindow'
+	],
+	#category : #'NewTools-Spotter-View'
+}
+
+{ #category : #private }
+StSpotter class >> basicHistory [
+
+	^ History ifNil: [ History := WeakOrderedCollection new ]
+]
+
+{ #category : #private }
+StSpotter class >> createTips [
+
+	^ {
+		'<meta+n> filters for Classes'.
+		'<meta+m> filters for Implementros'.
+		'<meta+h> filters for Help topics'.
+		'Adding #Classes in the query filters for Classes'.
+		'Adding #Implementors in the query filters for Implementros'.
+		'Adding #Help in the query filters for Help Topics'.
+		'Adding #Packages in the query filters for Packages'.
+		'Adding #Menu in the query filters for System Menu entries'.
+		'Using words separated with spaces looks up for all of them'.
+		'Using camel case looks up for all of the parts'.
+		'Clicking in the question mark shows another tip'.
+		'Clicking in this tip shows another tip'.
+	}
+]
+
+{ #category : #accessing }
+StSpotter class >> hidePreview [
+	<script>
+
+	Preview := false
+]
+
+{ #category : #private }
+StSpotter class >> historize: aCandidateLink [
+
+	self basicHistory 
+		removeAllSuchThat: [ :each | each value = aCandidateLink value ];
+		addFirst: aCandidateLink
+]
+
+{ #category : #accessing }
+StSpotter class >> history [
+
+	^ self basicHistory reject: [ :each | each isNil ]
+]
+
+{ #category : #'class initialization' }
+StSpotter class >> initialize [
+
+	self showPreview
+]
+
+{ #category : #testing }
+StSpotter class >> isShowingPreview [
+
+	^ Preview
+]
+
+{ #category : #'instance creation' }
+StSpotter class >> open [
+
+	self reset.
+	^ spotterWindow := self new openModalWithSpec
+]
+
+{ #category : #'tools registry' }
+StSpotter class >> registerToolsOn: registry [
+	"self registerToolsOn: Smalltalk tools"
+
+	registry register: self as: #spotter
+]
+
+{ #category : #private }
+StSpotter class >> reset [
+	
+	spotterWindow ifNotNil: [ spotterWindow close ]
+]
+
+{ #category : #accessing }
+StSpotter class >> resetHistory [
+	<script>
+	"
+	self resetHistory
+	"
+	History := nil
+]
+
+{ #category : #accessing }
+StSpotter class >> showPreview [
+	<script>
+	
+	Preview := true
+]
+
+{ #category : #private }
+StSpotter class >> tips [ 
+
+	^ Tips ifNil: [ Tips := self createTips ]
+]
+
+{ #category : #private }
+StSpotter class >> windowClosed [
+
+	spotterWindow := nil
+]
+
+{ #category : #'private actions' }
+StSpotter >> activate: aPresenter [
+
+	aPresenter activateOn: self
+]
+
+{ #category : #'private actions' }
+StSpotter >> activateLink: aCandidateLink [
+
+	self window close.
+	self historize: aCandidateLink.
+	aCandidateLink value doEvaluate.
+
+]
+
+{ #category : #private }
+StSpotter >> allowUIToDraw [
+
+	"5 is a magic number we tested is enough to allow the UI to display the spotter"
+	5 timesRepeat: [ Processor yield ].
+
+]
+
+{ #category : #private }
+StSpotter >> configureModel: aModel [ 
+
+	aModel 
+		whenSearchUpdatedDo: [ :aCandidateLink | 
+			self updateResultList: aCandidateLink ];
+		whenAmountChangedDo: [ :processor :amount | 
+			self updateResultProcessor: processor amount: amount ];
+		whenQueryStartedDo: [ self showSpinner ];
+		whenQueryEndedDo: [ self hideSpinner ]
+]
+
+{ #category : #private }
+StSpotter >> defaultModel [
+
+	^ StSpotterModel new
+		in: [ :this | self configureModel: this ];
+		yourself
+]
+
+{ #category : #'private updating' }
+StSpotter >> deferredUpdateResultList: aCandidateLink [
+	| categoryPresenter presenters |
+
+	categoryPresenter := aCandidateLink processor 
+		headerCategoryFor: aCandidateLink
+		on: self.
+		
+	(categoryPresenter includesLink: aCandidateLink) ifTrue: [ ^ self ].
+	
+	categoryPresenter addCandidate: aCandidateLink inSpotter: self.
+	
+	presenters := (categories values 
+		sorted: [ :each | each order ] ascending)
+		flatCollect: [ :each | each withCandidates ]. 
+	
+	resultList disableActivationDuring: [ 
+		| index |
+		index := resultList selection selectedIndex.
+		resultList items: presenters.
+		resultList selectIndex: index ]
+]
+
+{ #category : #'private actions' }
+StSpotter >> diveInProcessor: aProcessor [
+
+	[
+		self showSpinner.
+		resultList presenters: #().
+		self removeAll.
+		self model pushStepForProcessor: aProcessor.
+		searchText text: '' 
+	] schedule
+]
+
+{ #category : #'private actions' }
+StSpotter >> diveOut [
+
+	self removeAll.
+	self model popStep
+]
+
+{ #category : #'private actions' }
+StSpotter >> feedTip [
+	
+	"tip label: self class tips atRandom"
+]
+
+{ #category : #private }
+StSpotter >> handleKeyEvent: anEvent [
+	
+	(#( 30 "arrow up" 31 "arrow down" 13 "cr") includes: anEvent keyCharacter asInteger)
+		ifFalse: [ searchText takeKeyboardFocus ]
+]
+
+{ #category : #'private updating' }
+StSpotter >> headerCategoryFor: aLink [
+
+	^ categories 
+		at: aLink processor
+		ifAbsentPut: [ self newSpotterHeaderPresenter: aLink processor ]
+]
+
+{ #category : #'private updating' }
+StSpotter >> headerCategoryUnifiedFor: aLink [
+
+	^ categories 
+		at: aLink value class
+		ifAbsentPut: [ 
+			(self newSpotterHeaderPresenter: aLink processor)
+				type: aLink value class;
+				yourself ]
+]
+
+{ #category : #'private actions' }
+StSpotter >> hideSpinner [
+
+	[
+		self application defer: [ spinner hide ]
+	] schedule
+]
+
+{ #category : #'private actions' }
+StSpotter >> historize: aCandidateLink [
+
+	self class historize: aCandidateLink
+]
+
+{ #category : #initialization }
+StSpotter >> initialExtent [
+
+	self flag: #TODO. "Maybe calculate coordinates?"
+	^ self isShowingPreview 
+		ifTrue: [ 750@450 ]
+		ifFalse: [ 500@450 ]
+]
+
+{ #category : #initialization }
+StSpotter >> initialize [
+
+	mutex ifNil: [ mutex := Mutex new ].
+	categories := Dictionary new.
+	super initialize
+]
+
+{ #category : #initialization }
+StSpotter >> initializeDialogWindow: aDialogWindowPresenter [
+
+	aDialogWindowPresenter closeOnBackdropClick: true
+]
+
+{ #category : #initialization }
+StSpotter >> initializePresenters [
+	| contentsLayout |
+
+	self layout: (SpBoxLayout newVertical
+		borderWidth: 10;
+		spacing: 5;
+		add: (searchText := self newSearchInput) expand: false;
+		add: (SpOverlayLayout new
+			child: ((contentsLayout := SpBoxLayout newHorizontal)
+				beHomogeneous;
+				spacing: 5;
+				add: (resultList := self newComponentList);
+				yourself);
+			addOverlay: (spinner := self newSpinner) 
+				withConstraints: [ :c | c vAlignCenter; hAlignCenter ];
+			yourself);
+		"add: (SpBoxLayout newHorizontal
+				vAlignCenter;
+				add: (tip := self newLabel);
+				addLast: (self newButton 
+					label: 'More...';
+					action: [ self feedTip ];
+					yourself);
+				yourself)
+			expand: false;"
+		yourself).
+
+	spinner hide.
+
+	resultList
+		bindKeyCombination: Character arrowUp asKeyCombination 
+			toAction: [ :target :widget :event |
+				self transferFocusToSearchText.
+				event wasHandled: false ];
+		bindKeyCombination: Character arrowRight asKeyCombination 
+			toAction: [ self tryDiveIn ];
+		bindKeyCombination: Character arrowLeft asKeyCombination 
+			toAction: [ self tryDiveOut ];
+		whenActivatedDo: [ :selection | 
+			self activate: selection selectedItem ].
+	resultList eventHandler 
+		whenKeyDownDo: [ :anEvent | self handleKeyEvent: anEvent ].
+		
+	self isShowingPreview ifTrue: [ 
+		contentsLayout 	add: (previewContainer := SpBoxLayout newVertical).
+		resultList whenSelectionChangedDo: [ :selection | 
+			self showPreview: selection selectedItem ] ].
+
+	self addStyle: 'stSpotter'.
+	searchText 
+		placeholder: 'Search...';
+		addStyle: 'stSpotterSearch';
+		whenTextChangedDo: [ :aString | self updateSearch: aString ];
+		bindKeyCombination: Character arrowDown asKeyCombination 
+			toAction: [ self transferFocusToResultList ];
+		bindKeyCombination: Character arrowUp asKeyCombination 
+			toAction: [ self transferFocusToResultListAtLast ].
+	resultList addStyle: 'stSpotterList'.
+]
+
+{ #category : #initialization }
+StSpotter >> initializeWindow: aWindowPresenter [
+
+	super initializeWindow: aWindowPresenter.
+	aWindowPresenter 
+		title: 'Spotter';
+		withoutDecorations;
+		initialExtent: self initialExtent;
+		whenOpenedDo: [ self startProcessing ];
+		whenClosedDo: [ 
+			self stopProcessing.
+			self class windowClosed ];
+		centered.
+
+	self flag: #TODO. "This is more or less hacky, since I am using the processors that are
+	relevant to the first level of spotter as the only ones, but for now it is working"
+	self model activeProcessors do: [ :each | 
+		each 
+			installKeymappingsOn: aWindowPresenter
+			onExecution: [ :aProcessor | self updateSearchFromProcessor: aProcessor ] ]
+]
+
+{ #category : #testing }
+StSpotter >> isShowingPreview [
+
+	^ self class isShowingPreview
+]
+
+{ #category : #'accessing model' }
+StSpotter >> model [
+
+	^ model ifNil: [ model := self defaultModel ]
+]
+
+{ #category : #'private factory' }
+StSpotter >> newSpotterCandidateLinkPresenter: aLink [
+
+	^ self instantiate: StSpotterCandidateLinkPresenter on: aLink
+]
+
+{ #category : #'private factory' }
+StSpotter >> newSpotterHeaderPresenter: aProcessor [
+
+	^ (self instantiate: StSpotterHeaderPresenter on: aProcessor)
+		nested: self model isNested;
+		whenDiveInDo: [ :processor | self diveInProcessor: processor ];
+		whenDiveOutDo: [ self diveOut ];
+		yourself
+]
+
+{ #category : #private }
+StSpotter >> removeAll [
+
+	"resultList presenters: #()."
+	self allowUIToDraw.
+	categories removeAll
+]
+
+{ #category : #'accessing model' }
+StSpotter >> setModelBeforeInitialization: aSpotterModel [
+
+	model := aSpotterModel.
+	self configureModel: model
+]
+
+{ #category : #'private actions' }
+StSpotter >> showPreview: aPresenter [
+
+	previewContainer removeAll.	
+	(aPresenter isNil or: [ aPresenter isHeader ]) 
+		ifTrue: [ ^ self ].
+
+	aPresenter model value spotterPreview 
+		ifNotNil: [ :previewPresenter | 
+			previewContainer add: (previewPresenter 
+				owner: self; 
+				yourself) ]
+]
+
+{ #category : #'private actions' }
+StSpotter >> showSpinner [
+
+	spinner isVisible ifTrue: [ ^ self ].
+	[
+		self application defer: [ spinner show ]
+	] schedule
+]
+
+{ #category : #private }
+StSpotter >> startProcessing [
+	"Start the process."
+
+	[ 
+		self allowUIToDraw.
+		self model startProcessing 
+	] schedule
+]
+
+{ #category : #private }
+StSpotter >> stopProcessing [
+	"Start the process."
+
+	self model stopProcessing
+]
+
+{ #category : #private }
+StSpotter >> transferFocusToResultList [
+
+	self transferFocusToResultListAt: 1
+]
+
+{ #category : #private }
+StSpotter >> transferFocusToResultListAt: index [
+
+	resultList items isEmptyOrNil ifTrue: [ ^ self ].
+	
+	resultList 
+		selectIndex: index;
+		takeKeyboardFocus
+]
+
+{ #category : #private }
+StSpotter >> transferFocusToResultListAtLast [ 
+
+	self transferFocusToResultListAt: (resultList presenters size)
+]
+
+{ #category : #private }
+StSpotter >> transferFocusToSearchText [
+
+	(resultList items notEmpty and: [ resultList selection selectedIndex = 1 ])
+		ifTrue: [ searchText takeKeyboardFocus ].
+		
+	
+]
+
+{ #category : #'private actions' }
+StSpotter >> tryDiveIn [
+	| item |
+	
+	self model isNested ifTrue: [ ^ self ].
+	item := resultList selectedItem.
+	item ifNil: [ ^ self ].
+	item isHeader ifFalse: [ ^ self ].
+	item diveIn
+]
+
+{ #category : #'private actions' }
+StSpotter >> tryDiveOut [
+	| item |
+	
+	self model isNested ifFalse: [ ^ self ].
+	item := resultList selectedItem.
+	item ifNil: [ ^ self ].
+	item isHeader ifFalse: [ ^ self ].
+	item diveOut
+]
+
+{ #category : #initialization }
+StSpotter >> updatePresenter [
+
+	self feedTip
+]
+
+{ #category : #'private updating' }
+StSpotter >> updateResultList: aCandidateLink [
+
+	[
+		self application defer: [
+			mutex critical: [
+				self deferredUpdateResultList: aCandidateLink ] ]
+	] schedule
+]
+
+{ #category : #'private updating' }
+StSpotter >> updateResultProcessor: processor amount: amount [
+
+	self application defer: [ 
+		categories 
+			at: processor 
+			ifPresent: [ :aPresenter | aPresenter finalAmount: amount ] ]
+]
+
+{ #category : #'private updating' }
+StSpotter >> updateSearch: aString [
+	
+	self removeAll.
+	self model asyncProcess: aString
+]
+
+{ #category : #'private updating' }
+StSpotter >> updateSearchFromProcessor: aProcessor [
+
+	searchText text: aProcessor query textInSearchBar.
+	searchText cursorPositionIndex: searchText text size + 1.
+]

--- a/src/NewTools-Spotter/StSpotter.class.st
+++ b/src/NewTools-Spotter/StSpotter.class.st
@@ -91,7 +91,7 @@ StSpotter class >> history [
 { #category : #'class initialization' }
 StSpotter class >> initialize [
 
-	self showPreview: true
+	self showPreview
 ]
 
 { #category : #testing }

--- a/src/NewTools-Spotter/StSpotter.class.st
+++ b/src/NewTools-Spotter/StSpotter.class.st
@@ -91,7 +91,7 @@ StSpotter class >> history [
 { #category : #'class initialization' }
 StSpotter class >> initialize [
 
-	self showPreview
+	self showPreview: true
 ]
 
 { #category : #testing }
@@ -105,6 +105,18 @@ StSpotter class >> open [
 
 	self reset.
 	^ spotterWindow := self new openModalWithSpec
+]
+
+{ #category : #settings }
+StSpotter class >> previewVisible [
+		
+	^ Preview
+]
+
+{ #category : #settings }
+StSpotter class >> previewVisible: aBoolean [
+	
+	Preview := aBoolean
 ]
 
 { #category : #'tools registry' }
@@ -127,6 +139,23 @@ StSpotter class >> resetHistory [
 	self resetHistory
 	"
 	History := nil
+]
+
+{ #category : #settings }
+StSpotter class >> settingsOn: aBuilder [
+	<systemsettings>
+
+	(aBuilder group: #spotter)
+		parent: #tools;
+		label: 'Spotter';
+		description: 'Spotter configuration'.
+
+	(aBuilder setting: #previewVisible)
+		parent: #spotter;
+		default: self isShowingPreview;
+		target: self;
+		description: 'If Spotter will show the preview panel on the right of spotter';
+		label: 'Show Preview Panel'.
 ]
 
 { #category : #accessing }

--- a/src/NewTools-Spotter/StSpotterAllCandidatesAdded.class.st
+++ b/src/NewTools-Spotter/StSpotterAllCandidatesAdded.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #StSpotterAllCandidatesAdded,
+	#superclass : #StSpotterAnnouncement,
+	#instVars : [
+		'candidateLinks'
+	],
+	#category : #'NewTools-Spotter-Announcements'
+}
+
+{ #category : #accessing }
+StSpotterAllCandidatesAdded >> candidateLinks [
+	^ candidateLinks
+]
+
+{ #category : #accessing }
+StSpotterAllCandidatesAdded >> candidateLinks: anObject [
+	candidateLinks := anObject
+]

--- a/src/NewTools-Spotter/StSpotterAnnouncement.class.st
+++ b/src/NewTools-Spotter/StSpotterAnnouncement.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #StSpotterAnnouncement,
+	#superclass : #Announcement,
+	#instVars : [
+		'category'
+	],
+	#category : #'NewTools-Spotter-Announcements'
+}
+
+{ #category : #accessing }
+StSpotterAnnouncement >> category [
+	"Return the category (ie the kind of group of elements). This has nothing to do with class category."
+	^ category
+]
+
+{ #category : #accessing }
+StSpotterAnnouncement >> category: anObject [
+	"Set the category (ie the kind of group of elements). This has nothing to do with class category."
+	category := anObject
+]

--- a/src/NewTools-Spotter/StSpotterBasePresenter.class.st
+++ b/src/NewTools-Spotter/StSpotterBasePresenter.class.st
@@ -1,0 +1,20 @@
+"
+A base for presenters to be displayed as part of the spotter results list.
+"
+Class {
+	#name : #StSpotterBasePresenter,
+	#superclass : #SpPresenter,
+	#category : #'NewTools-Spotter-View'
+}
+
+{ #category : #actions }
+StSpotterBasePresenter >> activateOn: spotterPresenter [
+
+	self subclassResponsibility
+]
+
+{ #category : #testing }
+StSpotterBasePresenter >> isHeader [
+
+	^ false
+]

--- a/src/NewTools-Spotter/StSpotterCandidateAdded.class.st
+++ b/src/NewTools-Spotter/StSpotterCandidateAdded.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : #StSpotterCandidateAdded,
+	#superclass : #StSpotterAnnouncement,
+	#instVars : [
+		'candidateLink'
+	],
+	#category : #'NewTools-Spotter-Announcements'
+}
+
+{ #category : #accessing }
+StSpotterCandidateAdded >> candidate [
+	^ candidateLink value
+]
+
+{ #category : #accessing }
+StSpotterCandidateAdded >> candidateLink [
+
+	^ candidateLink
+]
+
+{ #category : #accessing }
+StSpotterCandidateAdded >> candidateLink: anObject [
+	candidateLink := anObject
+]

--- a/src/NewTools-Spotter/StSpotterCandidateLink.class.st
+++ b/src/NewTools-Spotter/StSpotterCandidateLink.class.st
@@ -1,0 +1,129 @@
+Class {
+	#name : #StSpotterCandidateLink,
+	#superclass : #DoubleLink,
+	#instVars : [
+		'processorLink',
+		'weight',
+		'renderingProcessorLink'
+	],
+	#category : #'NewTools-Spotter-Model'
+}
+
+{ #category : #comparing }
+StSpotterCandidateLink >> < anotherCandidateLink [
+
+	^ self weight < anotherCandidateLink weight
+]
+
+{ #category : #comparing }
+StSpotterCandidateLink >> > anotherCandidateLink [
+
+	^ self weight > anotherCandidateLink weight
+]
+
+{ #category : #converting }
+StSpotterCandidateLink >> asStSpotterCandidateLink [
+
+	^ self
+]
+
+{ #category : #accessing }
+StSpotterCandidateLink >> candidate [
+	^ self value
+]
+
+{ #category : #copying }
+StSpotterCandidateLink >> copy [
+	| link |
+	
+	link := self class value: self value.
+	link privateProcessorLink: processorLink.
+	link privateRenderingProcessorLink: renderingProcessorLink.
+	link weight: weight.
+	
+	^ link
+]
+
+{ #category : #printing }
+StSpotterCandidateLink >> gtDisplayOn: stream [
+
+	stream nextPutAll: 'Candidate link: '.
+	self value gtDisplayOn: stream 
+]
+
+{ #category : #testing }
+StSpotterCandidateLink >> isFirst [
+
+	^ self previousLink processorLink ~= self processorLink
+]
+
+{ #category : #accessing }
+StSpotterCandidateLink >> next [
+	^ self nextLink
+]
+
+{ #category : #accessing }
+StSpotterCandidateLink >> previous [
+	^ self previousLink
+]
+
+{ #category : #private }
+StSpotterCandidateLink >> privateProcessorLink: aLink [
+
+	processorLink := aLink
+]
+
+{ #category : #private }
+StSpotterCandidateLink >> privateRenderingProcessorLink: aLink [
+
+	renderingProcessorLink := aLink
+]
+
+{ #category : #accessing }
+StSpotterCandidateLink >> processor [
+
+	^ self processorLink value
+]
+
+{ #category : #accessing }
+StSpotterCandidateLink >> processorLink [
+	^ processorLink
+]
+
+{ #category : #accessing }
+StSpotterCandidateLink >> processorLink: anObject [
+
+	"we set rendering processor only if one is not set. it allows to have a collection of items,
+	that have different rendering processors"
+	
+	processorLink ifNil: [ self renderingProcessor: anObject ].
+	processorLink := anObject.
+	
+]
+
+{ #category : #accessing }
+StSpotterCandidateLink >> renderingProcessor [
+
+	renderingProcessorLink ifNil: [ self renderingProcessor: processorLink ].
+	^ renderingProcessorLink value
+]
+
+{ #category : #accessing }
+StSpotterCandidateLink >> renderingProcessor: aProcessorLink [
+
+	renderingProcessorLink ifNil: [ 
+		renderingProcessorLink := aProcessorLink processor asStSpotterProcessorLink ].
+	processorLink ifNil: [ processorLink := aProcessorLink ]
+]
+
+{ #category : #accessing }
+StSpotterCandidateLink >> weight [
+
+	^ weight
+]
+
+{ #category : #accessing }
+StSpotterCandidateLink >> weight: anObject [ 
+
+	weight := anObject
+]

--- a/src/NewTools-Spotter/StSpotterCandidateLinkPresenter.class.st
+++ b/src/NewTools-Spotter/StSpotterCandidateLinkPresenter.class.st
@@ -1,0 +1,54 @@
+"
+A presenter to show a candidate (an option that can be choosen). 
+
+"
+Class {
+	#name : #StSpotterCandidateLinkPresenter,
+	#superclass : #StSpotterBasePresenter,
+	#instVars : [
+		'iconPresenter',
+		'labelPresenter',
+		'model'
+	],
+	#category : #'NewTools-Spotter-View'
+}
+
+{ #category : #actions }
+StSpotterCandidateLinkPresenter >> activateOn: spotterPresenter [
+
+	spotterPresenter activateLink: self model
+]
+
+{ #category : #accessing }
+StSpotterCandidateLinkPresenter >> entry [
+
+	^ self model value
+]
+
+{ #category : #initialization }
+StSpotterCandidateLinkPresenter >> initializePresenters [
+
+	self layout: (SpBoxLayout newHorizontal
+		borderWidth: 2;
+		spacing: 5;
+		vAlignCenter;
+		add: (iconPresenter := self newImage) expand: false;
+		add: (labelPresenter := self newLabel);
+		yourself).
+		
+	self addStyle: 'stSpotterLink'.
+	iconPresenter image: self entry icon.
+	labelPresenter label: self entry label
+]
+
+{ #category : #'accessing model' }
+StSpotterCandidateLinkPresenter >> model [
+
+	^ model
+]
+
+{ #category : #'accessing model' }
+StSpotterCandidateLinkPresenter >> setModelBeforeInitialization: anEntry [
+
+	model := anEntry
+]

--- a/src/NewTools-Spotter/StSpotterCandidatesAmountChanged.class.st
+++ b/src/NewTools-Spotter/StSpotterCandidatesAmountChanged.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #StSpotterCandidatesAmountChanged,
+	#superclass : #StSpotterAnnouncement,
+	#instVars : [
+		'amount'
+	],
+	#category : #'NewTools-Spotter-Announcements'
+}
+
+{ #category : #accessing }
+StSpotterCandidatesAmountChanged >> amount [
+
+	^ amount
+]
+
+{ #category : #accessing }
+StSpotterCandidatesAmountChanged >> amount: anObject [
+
+	amount := anObject
+]

--- a/src/NewTools-Spotter/StSpotterCandidatesList.class.st
+++ b/src/NewTools-Spotter/StSpotterCandidatesList.class.st
@@ -1,0 +1,361 @@
+Class {
+	#name : #StSpotterCandidatesList,
+	#superclass : #Object,
+	#instVars : [
+		'categories',
+		'candidates',
+		'announcer',
+		'processorLinksMap'
+	],
+	#category : #'NewTools-Spotter-Model'
+}
+
+{ #category : #'adding/removing' }
+StSpotterCandidatesList >> addAllCandidates: aCollection in: aProcessor [
+	| allLinks |
+	
+	allLinks := aCollection collect: [ :each | 
+		| processorLink candidateLink |
+		processorLink := self getProcessorLink: aProcessor.
+		candidateLink := each asStSpotterCandidateLink processorLink: processorLink.	"if head is nil, it means there are no candidates yet"
+		candidateLink := processorLink isEmpty
+			ifTrue: [ self privateAddCandidate: candidateLink inEmpty: processorLink ]
+			ifFalse: [ self privateAddCandidate: candidateLink inNotEmpty: processorLink ].
+		self updateCycleConnectionFor: candidateLink.
+		candidateLink ].
+
+	self announcer announce: (StSpotterAllCandidatesAdded new
+		candidateLinks: allLinks;
+		category: aProcessor;
+		yourself)
+]
+
+{ #category : #'adding/removing' }
+StSpotterCandidatesList >> addCandidate: anObjectOrLink in: aProcessor [
+	"before adding candidates we need to define all categories, because their order is important"
+	| processorLink candidateLink |
+	
+	"processorLink is DoubleLink"
+	processorLink := self getProcessorLink: aProcessor.
+	candidateLink := anObjectOrLink asStSpotterCandidateLink processorLink: processorLink.
+	
+	"if head is nil, it means there are no candidates yet"
+	candidateLink := processorLink isEmpty
+		ifTrue: [ self privateAddCandidate: candidateLink inEmpty: processorLink ]
+		ifFalse: [ self privateAddCandidate: candidateLink inNotEmpty: processorLink ].
+		
+	self updateCycleConnectionFor: candidateLink.
+	
+	self notifyCandidateAdded: candidateLink in: aProcessor.
+	
+	^ candidateLink
+]
+
+{ #category : #'adding/removing' }
+StSpotterCandidatesList >> addProcessor: aProcessor [
+	| processorLink |
+	
+	processorLink := aProcessor asSpotterProcessorLink.
+	"linking processor with it's link"
+	self processorLinksMap add: (aProcessor -> processorLink).
+	self processors addLast: processorLink.
+	
+	^ processorLink
+]
+
+{ #category : #accessing }
+StSpotterCandidatesList >> announcer [
+	^ announcer ifNil: [ announcer := Announcer new ]
+]
+
+{ #category : #accessing }
+StSpotterCandidatesList >> candidates [
+
+	^ candidates ifNil: [ candidates := DoubleLinkedList new ]
+]
+
+{ #category : #candidates }
+StSpotterCandidatesList >> getCandidateLink: aCandiate in: aProcessor [
+	"returns a corresponding candidateLink, that belongs to a processor"
+	(self getCandidateLinks: (self getProcessorLink: aProcessor))
+		do: [ :each | each value = aCandiate ifTrue: [ ^ each ] ].
+	
+	^ nil
+	
+]
+
+{ #category : #candidates }
+StSpotterCandidatesList >> getCandidateLinks: aProcessorLink [
+	"returns all candidate links that belongs to a processor link"
+	| list head tail current |
+	
+	head := aProcessorLink headLink.
+	tail := aProcessorLink tailLink.
+	
+	list := OrderedCollection new.
+	head ifNil: [ ^ list ].
+	(head = tail) ifTrue: [ list add: head. ^ list ].
+	
+	current := head.
+	
+	[ current = tail ] whileFalse: [
+		list add: current.
+		current := current nextLink ].
+	"adding last one"
+	list add: current.
+	
+	^ list
+]
+
+{ #category : #processors }
+StSpotterCandidatesList >> getProcessorLink: aProcessor [
+
+	^ self processorLinksMap at: aProcessor ifAbsentPut: [ self addProcessor: aProcessor ]
+]
+
+{ #category : #processors }
+StSpotterCandidatesList >> getProcessorLinkByCandidateLink: aCandidateLink [
+
+	^ aCandidateLink processorLink
+]
+
+{ #category : #candidates }
+StSpotterCandidatesList >> head [
+
+	^ self candidates head
+]
+
+{ #category : #testing }
+StSpotterCandidatesList >> isEmpty [
+	"Return true if there are no candidates in the list, false otherwise"
+	<return: #Boolean>
+
+	^ self candidates isEmpty
+]
+
+{ #category : #testing }
+StSpotterCandidatesList >> isNotEmpty [
+	"Return true if there is at least one candidate in the list, false otherwise"
+	<return: #Boolean>
+
+	^ self isEmpty not
+]
+
+{ #category : #processors }
+StSpotterCandidatesList >> nextProcessorLinkOf: aProcessorLink [
+	"returns next processor link, that has more than zero candidates.
+	if passed processor is the last one, will continue searching from the beginning"
+	| current |
+	
+	aProcessorLink ifNil: [ ^ aProcessorLink ].
+	
+	current := aProcessorLink nextLink.
+	current ifNil: [ current := self processors head ].
+	
+	[ current = aProcessorLink ] whileFalse: [
+		(current isEmpty) ifFalse: [ ^ current ].
+		current := current nextLink.
+		current ifNil: [ current := self processors head ] ].
+
+	^ aProcessorLink
+]
+
+{ #category : #notifying }
+StSpotterCandidatesList >> notifyAllCandidatesRemoved [
+
+	"self announcer announce: (GTSpotterAllCandidatesRemoved new)"
+]
+
+{ #category : #notifying }
+StSpotterCandidatesList >> notifyCandidateAdded: aCandidateLink in: aProcessor [
+
+	self announcer announce: (StSpotterCandidateAdded new 
+		candidateLink: aCandidateLink; 
+		category: aProcessor; 
+		yourself).
+]
+
+{ #category : #'stream handling' }
+StSpotterCandidatesList >> onAmountChanged: anInteger in: aProcessor [
+	"Amount must be non-negative"
+	"If amount is not positive there is no need to do anything"
+	
+	anInteger <= 0 ifTrue: [ ^ self ].
+	self announcer announce: (StSpotterCandidatesAmountChanged new 
+		amount: anInteger; 
+		category: aProcessor; 
+		yourself)
+]
+
+{ #category : #processors }
+StSpotterCandidatesList >> previousProcessorLinkOf: aProcessorLink [
+	"returns previous processor link, that has more than zero candidates.
+	if passed processor is the first one, will continue searching from the end"
+	| current |
+	
+	aProcessorLink ifNil: [ ^ aProcessorLink ].
+	
+	current := aProcessorLink previousLink.
+	current ifNil: [ current := self processors tail ].
+	
+	[ current = aProcessorLink ] whileFalse: [
+		(current isEmpty) ifFalse: [ ^ current ].
+		current := current previousLink.
+		current ifNil: [ current := self processors tail ] ].
+
+	^ aProcessorLink
+	
+]
+
+{ #category : #private }
+StSpotterCandidatesList >> privateAddCandidate: aCandidateLink inEmpty: aProcessorLink [
+	| head current |
+	current := aProcessorLink.	"not nil"
+	head := nil.	"nil"
+	[ head isNil and: [ current isNotNil ] ]
+		whileTrue: [ current := current nextLink.	"next category"
+			"head of next category if not nil break loop"
+			current ifNotNil: [ head := current headLink ] ].
+
+	"means all next categories are empty, just add to the end"
+	current
+		ifNil: [ self candidates addLast: aCandidateLink ]
+		ifNotNil: [ self candidates add: aCandidateLink beforeLink: head ].
+	aProcessorLink
+		headLink: aCandidateLink;
+		tailLink: aCandidateLink.
+
+	aProcessorLink incrementSize.
+
+	^ aCandidateLink
+]
+
+{ #category : #private }
+StSpotterCandidatesList >> privateAddCandidate: aCandidateLink inNotEmpty: aProcessorLink [
+	
+	"aCandidateLink weight
+		ifNotNil: [ ^ self privateAddCandidate: aCandidateLink weightedIn: aProcessorLink ]."
+	
+	self candidates add: aCandidateLink afterLink: (aProcessorLink tailLink).
+	aProcessorLink incrementSize.
+	"updating category tail"
+	aProcessorLink tailLink: aCandidateLink.
+	^ aCandidateLink
+]
+
+{ #category : #private }
+StSpotterCandidatesList >> privateAddCandidate: aCandidateLink weightedIn: aProcessorLink [
+
+	^ aProcessorLink isFull
+		ifTrue: [ self privateAddCandidate: aCandidateLink weightedInFull: aProcessorLink ]
+		ifFalse: [ self privateAddCandidate: aCandidateLink weightedInNotFull: aProcessorLink ]
+]
+
+{ #category : #private }
+StSpotterCandidatesList >> privateAddCandidate: aCandidateLink weightedInFull: aProcessorLink [
+
+	
+]
+
+{ #category : #private }
+StSpotterCandidatesList >> privateAddCandidate: aCandidateLink weightedInNotFull: aProcessorLink [
+	| head tail |
+	
+	head := aProcessorLink headLink.
+	tail := aProcessorLink tailLink.
+
+	"fast check if we need to add it before first"
+	(aCandidateLink weight > head weight)
+		ifTrue: [ head := self candidates add: aCandidateLink beforeLink: head ]
+		ifFalse: [
+			"fast check if we need to add it after the last"
+			(aCandidateLink weight > tail weight)
+				ifFalse: [ tail := self candidates add: aCandidateLink afterLink: tail ]
+				ifTrue: [  ] ]
+]
+
+{ #category : #notifying }
+StSpotterCandidatesList >> processorEnded: aProcessor [
+
+	(self processors noneSatisfy: [ :each | each isRunning ])
+		ifTrue: [ self announcer announce: StSpotterQueryEnded new ] 
+	
+]
+
+{ #category : #accessing }
+StSpotterCandidatesList >> processorLinksMap [
+
+	^ processorLinksMap ifNil: [ processorLinksMap := Dictionary new ]
+	
+]
+
+{ #category : #notifying }
+StSpotterCandidatesList >> processorStarted: aProcessor [
+	
+	self announcer announce: StSpotterQueryStarted new.
+]
+
+{ #category : #accessing }
+StSpotterCandidatesList >> processors [
+
+	^ categories ifNil: [ categories := DoubleLinkedList new ].
+]
+
+{ #category : #'adding/removing' }
+StSpotterCandidatesList >> removeAllCandidates [
+
+	self processors linksDo: [ :each | each clear ].
+	self candidates removeAll.
+	self notifyAllCandidatesRemoved
+]
+
+{ #category : #'adding/removing' }
+StSpotterCandidatesList >> removeAllCandidatesOf: aProcessor [
+	| processorLink head tail current |
+	
+	processorLink := self getProcessorLink: aProcessor.
+	processorLink isEmpty ifTrue: [ ^ self ].
+	
+	head := processorLink headLink.
+	tail := processorLink tailLink.
+		
+	(head = tail) ifTrue: [
+		self candidates removeCycledLink: head.
+		processorLink clear. ].
+	
+	current := head.
+	[ current = tail ] whileFalse: [ | nextCurrent |
+		nextCurrent := current nextLink.
+		self candidates removeCycledLink: current.
+		current := nextCurrent ].
+	
+	self candidates removeCycledLink: current.
+	
+	processorLink clear.
+	
+	
+	
+	
+	
+	
+]
+
+{ #category : #candidates }
+StSpotterCandidatesList >> tail [
+
+	^ self candidates tail
+]
+
+{ #category : #candidates }
+StSpotterCandidatesList >> updateCycleConnectionFor: aCandidateLink [
+
+	"if link is the last setting nextLink to head"
+	(self candidates tail = aCandidateLink) ifTrue: [
+		aCandidateLink nextLink: self candidates head.
+		self candidates head previousLink: aCandidateLink ].
+	
+	"if link is the first setting previousLink to tail"
+	(self candidates head = aCandidateLink) ifTrue: [
+		aCandidateLink previousLink: self candidates tail.
+		self candidates tail nextLink: aCandidateLink ].
+]

--- a/src/NewTools-Spotter/StSpotterContext.class.st
+++ b/src/NewTools-Spotter/StSpotterContext.class.st
@@ -1,0 +1,287 @@
+Class {
+	#name : #StSpotterContext,
+	#superclass : #Object,
+	#instVars : [
+		'step',
+		'stream',
+		'search',
+		'text',
+		'textTrimmed',
+		'textLowercase',
+		'processor',
+		'filter',
+		'streamed',
+		'cache',
+		'continuing'
+	],
+	#category : #'NewTools-Spotter-Model'
+}
+
+{ #category : #public }
+StSpotterContext >> addItem: anObject [
+
+	self stream 
+		addObject: anObject 
+		inProcessor: self processor
+]
+
+{ #category : #public }
+StSpotterContext >> addItems: aCollection [
+
+	self stream 
+		addObjects: aCollection 
+		inProcessor: self processor
+]
+
+{ #category : #accessing }
+StSpotterContext >> cache [
+	^ cache
+]
+
+{ #category : #accessing }
+StSpotterContext >> cache: anObject [
+	cache := anObject
+]
+
+{ #category : #public }
+StSpotterContext >> cacheAt: aSymbol [
+	^ self cacheAt: aSymbol ifAbsent: [ nil ]
+]
+
+{ #category : #public }
+StSpotterContext >> cacheAt: aSymbol ifAbsent: aBlock [
+	^ self cache at: aSymbol ifAbsent: aBlock
+]
+
+{ #category : #public }
+StSpotterContext >> cacheAt: aSymbol ifAbsentPut: aBlock [
+	^ self cache at: aSymbol ifAbsentPut: aBlock
+]
+
+{ #category : #public }
+StSpotterContext >> cacheAt: aSymbol put: anObject [
+	^ self cache at: aSymbol put: anObject
+]
+
+{ #category : #testing }
+StSpotterContext >> canContinue [
+	 " divein / really ugly, spotter-step does not really know why it was created or where it comes from :( "
+	" another hack: diveIncategory must never continue because it just streams all items from the previous step. continuing in diveInCategory would duplicate all items! " 
+	^ self step event == #diveIn
+		or: [ self step event isNil ]
+]
+
+{ #category : #private }
+StSpotterContext >> continueFilter [
+	| processors nonEmptyProcessors |
+	processors := self cache at: #processorsAndFilters ifAbsent: [ ^ self ].
+	nonEmptyProcessors := processors associations select: [ :assoc | assoc key hasFilteredCandidates ].
+	nonEmptyProcessors size = 1 ifFalse: [ ^ self ].
+	self canContinue ifFalse: [ ^ self ].
+	
+	self withContinue: true do: [ 
+		nonEmptyProcessors do: [ :assoc | 
+			assoc key continueFilterInContext: self ] ]
+]
+
+{ #category : #accessing }
+StSpotterContext >> continuing [
+	^ continuing
+]
+
+{ #category : #accessing }
+StSpotterContext >> continuing: anObject [
+	continuing := anObject
+]
+
+{ #category : #'accessing-defaults' }
+StSpotterContext >> defaultCache [
+	^ IdentityDictionary new 
+		at: #processorsAndFilters put: (IdentityDictionary new: 100); " not a limitation, just a reasonable start size "
+		at: #processorsAndStreamed put: (IdentityDictionary new: 100); " not a limitation, just a reasonable start size "
+		yourself
+]
+
+{ #category : #'accessing-defaults' }
+StSpotterContext >> defaultContinuing [
+	^ false
+]
+
+{ #category : #'accessing-defaults' }
+StSpotterContext >> defaultText [
+	^ ''
+]
+
+{ #category : #'accessing-defaults' }
+StSpotterContext >> defaultTextLowercase [
+	^ self textTrimmed asLowercase
+]
+
+{ #category : #'accessing-defaults' }
+StSpotterContext >> defaultTextTrimmed [
+	^ self text trimBoth
+]
+
+{ #category : #private }
+StSpotterContext >> doContinueFilterForProcessor: aGTProcessor [
+	self processor: aGTProcessor.
+	self filter: ((self cache at: #processorsAndFilters) at: aGTProcessor).
+	self streamed: ((self cache at: #processorsAndStreamed) at: aGTProcessor).
+
+	^ aGTProcessor withItemsLimit: aGTProcessor continueItemsLimit do: [ filter value: self ]
+]
+
+{ #category : #private }
+StSpotterContext >> doFilter: aFilter forProcessor: aProcessor [
+
+	self processor: aProcessor.
+	self filter: aFilter.
+	self streamed: (OrderedCollection new: 100). " not a limitation, just a reasonable start size "
+	(self cache at: #processorsAndFilters) at: aProcessor put: aFilter.
+	(self cache at: #processorsAndStreamed) at: aProcessor put: streamed.
+
+	^ aFilter value: self
+]
+
+{ #category : #comparing }
+StSpotterContext >> equals: aContext [
+	aContext ifNil: [ ^ false ].
+   ^ self matches: aContext search
+]
+
+{ #category : #accessing }
+StSpotterContext >> filter [
+	^ filter
+]
+
+{ #category : #accessing }
+StSpotterContext >> filter: anObject [
+	filter := anObject
+]
+
+{ #category : #initialization }
+StSpotterContext >> initialize [
+	super initialize.
+	
+	cache := self defaultCache.
+	text := self defaultText.
+	continuing := self defaultContinuing.
+]
+
+{ #category : #testing }
+StSpotterContext >> isContinuing [
+	^ self continuing 
+		and: [ self streamed isEmptyOrNil not 
+			and: [ self canContinue ] ]
+]
+
+{ #category : #testing }
+StSpotterContext >> isEmpty [
+	^ self text isNil
+		or: [ self textTrimmed isEmpty ]
+]
+
+{ #category : #public }
+StSpotterContext >> itemsLimit [
+	^ self processor itemsLimit
+]
+
+{ #category : #testing }
+StSpotterContext >> matches: aString [
+	^ self isEmpty not
+		and: [ self search = aString ]
+]
+
+{ #category : #testing }
+StSpotterContext >> notEmpty [
+	^ self isEmpty not
+]
+
+{ #category : #accessing }
+StSpotterContext >> processor [
+	^ processor
+]
+
+{ #category : #accessing }
+StSpotterContext >> processor: anObject [
+	processor := anObject
+]
+
+{ #category : #public }
+StSpotterContext >> removeCacheAt: aSymbol [
+	^ self cache removeKey: aSymbol ifAbsent: [ nil ]
+]
+
+{ #category : #initializing }
+StSpotterContext >> search [
+	^ search
+]
+
+{ #category : #initializing }
+StSpotterContext >> search: anObject [
+	" search stores the fully entered text (including categories) "
+	search := anObject
+]
+
+{ #category : #'accessing-dynamic' }
+StSpotterContext >> spotter [
+	^ self step spotter
+]
+
+{ #category : #accessing }
+StSpotterContext >> step [
+	^ step
+]
+
+{ #category : #accessing }
+StSpotterContext >> step: anObject [
+	step := anObject
+]
+
+{ #category : #accessing }
+StSpotterContext >> stream [
+	^ stream
+]
+
+{ #category : #accessing }
+StSpotterContext >> stream: anObject [
+	stream := anObject
+]
+
+{ #category : #accessing }
+StSpotterContext >> streamed [
+	^ streamed
+]
+
+{ #category : #accessing }
+StSpotterContext >> streamed: anObject [
+	streamed := anObject
+]
+
+{ #category : #accessing }
+StSpotterContext >> text [
+	^ text
+]
+
+{ #category : #accessing }
+StSpotterContext >> text: anObject [
+	text := anObject ifNil: [ self defaultText ]
+]
+
+{ #category : #public }
+StSpotterContext >> textLowercase [
+	^ textLowercase ifNil: [ textLowercase := self defaultTextLowercase ]
+]
+
+{ #category : #public }
+StSpotterContext >> textTrimmed [
+	^ textTrimmed ifNil: [ textTrimmed := self defaultTextTrimmed ]
+]
+
+{ #category : #private }
+StSpotterContext >> withContinue: aBoolean do: aBlock [
+	| previousContinuing |
+	previousContinuing := continuing.
+	^ [ continuing := aBoolean. aBlock value ]
+		ensure: [ continuing := previousContinuing ]
+]

--- a/src/NewTools-Spotter/StSpotterHeaderPresenter.class.st
+++ b/src/NewTools-Spotter/StSpotterHeaderPresenter.class.st
@@ -1,0 +1,206 @@
+"
+A presenter to display a group of results.
+Each processor define a group. 
+Each group has a list of children (instances of *StSpotterCandidateListPresenter). 
+
+"
+Class {
+	#name : #StSpotterHeaderPresenter,
+	#superclass : #StSpotterBasePresenter,
+	#instVars : [
+		'model',
+		'candidatePresentersList',
+		'labelPresenter',
+		'diveButtonPresenter',
+		'diveInAction',
+		'finalAmount',
+		'amountLabelPresenter',
+		'entryClass',
+		'helpLabelPresenter',
+		'order',
+		'diveOutAction',
+		'nested'
+	],
+	#category : #'NewTools-Spotter-View'
+}
+
+{ #category : #actions }
+StSpotterHeaderPresenter >> activateOn: spotterPresenter [
+
+	self doDive
+]
+
+{ #category : #accessing }
+StSpotterHeaderPresenter >> addCandidate: aCandidateLink inSpotter: spotterPresenter [
+
+	candidatePresentersList add: (spotterPresenter newSpotterCandidateLinkPresenter: aCandidateLink).
+	self updateAmount
+]
+
+{ #category : #'private actions' }
+StSpotterHeaderPresenter >> diveIn [
+
+	diveInAction ifNil: [ ^ self ].
+	diveInAction cull: self model
+]
+
+{ #category : #'private actions' }
+StSpotterHeaderPresenter >> diveOut [
+
+	diveOutAction ifNil: [ ^ self ].
+	diveOutAction cull: self model
+]
+
+{ #category : #actions }
+StSpotterHeaderPresenter >> doDive [
+
+	nested 
+		ifTrue: [ self diveOut ]
+		ifFalse: [ self diveIn ]
+]
+
+{ #category : #accessing }
+StSpotterHeaderPresenter >> finalAmount [
+
+	^ finalAmount
+]
+
+{ #category : #accessing }
+StSpotterHeaderPresenter >> finalAmount: aNumber [
+
+	finalAmount := aNumber
+]
+
+{ #category : #testing }
+StSpotterHeaderPresenter >> includesLink: aLink [
+
+	^ candidatePresentersList anySatisfy: [ :each | each entry = aLink value ]
+]
+
+{ #category : #initialization }
+StSpotterHeaderPresenter >> initialize [
+
+	candidatePresentersList := OrderedCollection new.
+	nested := false.
+	super initialize
+]
+
+{ #category : #initialization }
+StSpotterHeaderPresenter >> initializePresenters [
+
+	self layout: (SpBoxLayout newHorizontal
+		borderWidth: 5;
+		spacing: 5;
+		vAlignCenter;
+		add: (labelPresenter := self newLabel) expand: false;
+		add: (amountLabelPresenter := self newLabel) expand: false;
+		add: (helpLabelPresenter := self newLabel) expand: false;
+		addLast: (diveButtonPresenter := self newImage) expand: false; 
+		yourself).
+
+	self addStyle: 'stSpotterHeader'.
+	amountLabelPresenter addStyle: 'dim'.
+	helpLabelPresenter addStyle: 'dim'.
+	diveButtonPresenter image: (self application iconNamed: #smallForward).
+	diveButtonPresenter eventHandler
+		whenMouseDownDo: [ :event | 
+			event isPrimaryButton ifTrue: [ self doDive ] ].
+]
+
+{ #category : #testing }
+StSpotterHeaderPresenter >> isHeader [
+
+	^ true
+]
+
+{ #category : #'accessing model' }
+StSpotterHeaderPresenter >> model [
+
+	^ model
+]
+
+{ #category : #accessing }
+StSpotterHeaderPresenter >> nested: aBoolean [
+
+	nested = aBoolean ifTrue: [ ^ self ].
+
+	nested := aBoolean.
+	diveButtonPresenter image: (self application iconNamed: (nested 
+		ifTrue: [ #smallBack ]
+		ifFalse: [ #smallForward ]))
+]
+
+{ #category : #accessing }
+StSpotterHeaderPresenter >> order [
+
+	^ order ifNil: [ self model order ]
+]
+
+{ #category : #accessing }
+StSpotterHeaderPresenter >> prepareAsClasses [
+
+	labelPresenter label: '#Classes'.
+	helpLabelPresenter label: (KMShortcutPrinter toString: self model keyBindingForClasses).
+]
+
+{ #category : #accessing }
+StSpotterHeaderPresenter >> prepareAsImplementors [
+
+	order := self model order + 1.
+	labelPresenter label: '#Implementors'.
+	helpLabelPresenter label: (KMShortcutPrinter toString: self model keyBindingForImplementors).
+]
+
+{ #category : #accessing }
+StSpotterHeaderPresenter >> prepareAsPackages [
+
+	order := self model order - 1.
+	labelPresenter label: '#Packages'
+]
+
+{ #category : #'accessing model' }
+StSpotterHeaderPresenter >> setModelBeforeInitialization: aProcessor [
+
+	model := aProcessor
+]
+
+{ #category : #accessing }
+StSpotterHeaderPresenter >> type: aClass [
+
+	 aClass prepareUnifiedHeaderDescriptionFor: self
+]
+
+{ #category : #'private updating' }
+StSpotterHeaderPresenter >> updateAmount [
+
+	amountLabelPresenter label: ('{1}/{2}' format: { 
+		candidatePresentersList size. 
+		self finalAmount ifNil: [ '...' ] })
+]
+
+{ #category : #initialization }
+StSpotterHeaderPresenter >> updatePresenter [
+
+	labelPresenter label: '#', self model title.
+	helpLabelPresenter label: (self model keyBinding 
+		ifNotNil: [ :binding | binding asString ]
+		ifNil: [ '' ])
+]
+
+{ #category : #events }
+StSpotterHeaderPresenter >> whenDiveInDo: aBlock [
+
+	diveInAction := aBlock
+]
+
+{ #category : #events }
+StSpotterHeaderPresenter >> whenDiveOutDo: aBlock [
+
+	diveOutAction := aBlock
+]
+
+{ #category : #accessing }
+StSpotterHeaderPresenter >> withCandidates [
+
+	^ { self }, candidatePresentersList
+]

--- a/src/NewTools-Spotter/StSpotterModel.class.st
+++ b/src/NewTools-Spotter/StSpotterModel.class.st
@@ -1,0 +1,203 @@
+Class {
+	#name : #StSpotterModel,
+	#superclass : #Object,
+	#instVars : [
+		'steps',
+		'candidateAddedAction',
+		'searchUpdatedAction',
+		'amountChangedAction',
+		'mutex',
+		'queryStartedAction',
+		'queryEndedAction'
+	],
+	#category : #'NewTools-Spotter-Model'
+}
+
+{ #category : #accessing }
+StSpotterModel >> activeProcessors [
+
+	^ self activeStep processors
+]
+
+{ #category : #accessing }
+StSpotterModel >> activeStep [
+
+	^ steps last
+]
+
+{ #category : #'private announcing' }
+StSpotterModel >> announceAllCandidatesAdded: ann [
+
+	searchUpdatedAction ifNil: [ ^ self ].
+	ann candidateLinks 
+		do: [ :each | searchUpdatedAction value: each ]
+]
+
+{ #category : #'private announcing' }
+StSpotterModel >> announceAmountChanged: ann [
+
+	amountChangedAction ifNil: [ ^ self ].
+	amountChangedAction 
+		value: ann category 
+		value: ann amount
+]
+
+{ #category : #'private announcing' }
+StSpotterModel >> announceCandidateAdded: ann [
+
+	searchUpdatedAction ifNil: [ ^ self ].
+	searchUpdatedAction value: ann candidateLink
+]
+
+{ #category : #'private announcing' }
+StSpotterModel >> announceQueryEnded: ann [
+
+	queryEndedAction ifNil: [ ^ self ].
+	queryEndedAction value
+]
+
+{ #category : #'private announcing' }
+StSpotterModel >> announceQueryStarted: ann [
+
+	queryStartedAction ifNil: [ ^ self ].
+	queryStartedAction value
+]
+
+{ #category : #processing }
+StSpotterModel >> asyncProcess: aString [
+
+	[
+		mutex critical: [
+			self process: aString ]
+	] schedule
+]
+
+{ #category : #private }
+StSpotterModel >> defaultProcessors [
+
+	^ (StSpotterProcessor allEnabledSubclasses 
+		collect: [ :each | each new ])
+		sort: #order ascending
+]
+
+{ #category : #initialization }
+StSpotterModel >> initialize [
+
+	super initialize.
+	mutex := Mutex new.
+	steps := OrderedCollection with: self newDefaultStep
+]
+
+{ #category : #testing }
+StSpotterModel >> isNested [
+
+	^ steps size > 1
+]
+
+{ #category : #accessing }
+StSpotterModel >> links [
+
+	^ self activeStep links
+]
+
+{ #category : #'private factory' }
+StSpotterModel >> newDefaultStep [
+
+	^ self newStep
+		origin: self;
+		yourself
+]
+
+{ #category : #'private factory' }
+StSpotterModel >> newStep [
+
+	^ StSpotterStep newModel: self
+]
+
+{ #category : #accessing }
+StSpotterModel >> popStep [
+	| lastQuery |
+
+	"Do not pop first"
+	steps size > 1 ifFalse: [ ^ self ]. 
+
+	lastQuery := self activeStep activeQuery.
+	self activeStep deactivate.
+	steps removeLast.
+	self activeStep activate.
+	self asyncProcess: ''
+]
+
+{ #category : #'private processing' }
+StSpotterModel >> process: aString [
+	
+	self activeStep process: aString
+]
+
+{ #category : #accessing }
+StSpotterModel >> pushStep: aStep [
+	| lastQuery |
+
+	lastQuery := self activeStep activeQuery.
+	self activeStep deactivate.
+	steps addLast: aStep
+]
+
+{ #category : #accessing }
+StSpotterModel >> pushStepForProcessor: aProcessor [
+	| step allCandidates processorLink |
+
+	step := self newStep.
+	processorLink := aProcessor asStSpotterProcessorLink.
+	allCandidates := aProcessor allFilteredCandidates collect: [ :each | 
+		each asStSpotterCandidateLink renderingProcessor: processorLink ].
+	step origin: allCandidates.
+	self pushStep: step
+]
+
+{ #category : #accessing }
+StSpotterModel >> results [
+
+	^ self activeStep results
+]
+
+{ #category : #accessing }
+StSpotterModel >> stSpotterProcessorsFor: aStep [
+
+	self defaultProcessors 
+		do: [ :each | aStep addProcessor: each ]
+]
+
+{ #category : #processing }
+StSpotterModel >> startProcessing [
+
+	self asyncProcess: ''
+]
+
+{ #category : #processing }
+StSpotterModel >> stopProcessing [
+]
+
+{ #category : #events }
+StSpotterModel >> whenAmountChangedDo: aBlock [
+
+	amountChangedAction := aBlock
+]
+
+{ #category : #events }
+StSpotterModel >> whenQueryEndedDo: aBlock [
+
+	queryEndedAction := aBlock
+]
+
+{ #category : #events }
+StSpotterModel >> whenQueryStartedDo: aBlock [
+
+	queryStartedAction := aBlock
+]
+
+{ #category : #events }
+StSpotterModel >> whenSearchUpdatedDo: aBlock [
+
+	searchUpdatedAction := aBlock
+]

--- a/src/NewTools-Spotter/StSpotterPragmaBasedProcessor.extension.st
+++ b/src/NewTools-Spotter/StSpotterPragmaBasedProcessor.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #StSpotterPragmaBasedProcessor }
+
+{ #category : #'*NewTools-Spotter' }
+StSpotterPragmaBasedProcessor >> headerCategoryFor: aLink on: aSpotterPresenter [
+
+	^ aSpotterPresenter headerCategoryFor: aLink
+]

--- a/src/NewTools-Spotter/StSpotterProcessor.extension.st
+++ b/src/NewTools-Spotter/StSpotterProcessor.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #StSpotterProcessor }
+
+{ #category : #'*NewTools-Spotter' }
+StSpotterProcessor >> headerCategoryFor: aLink on: aSpotterPresenter [
+
+	^ aSpotterPresenter headerCategoryFor: aLink
+]

--- a/src/NewTools-Spotter/StSpotterProcessorLink.class.st
+++ b/src/NewTools-Spotter/StSpotterProcessorLink.class.st
@@ -1,0 +1,89 @@
+Class {
+	#name : #StSpotterProcessorLink,
+	#superclass : #DoubleLink,
+	#instVars : [
+		'headLink',
+		'tailLink',
+		'size'
+	],
+	#category : #'NewTools-Spotter-Model'
+}
+
+{ #category : #accessing }
+StSpotterProcessorLink class >> from: aDoubleLink [
+
+	
+]
+
+{ #category : #accessing }
+StSpotterProcessorLink >> asStSpotterProcessorLink [
+
+	^ self
+]
+
+{ #category : #actions }
+StSpotterProcessorLink >> clear [
+
+	self
+		headLink: nil;
+		tailLink: nil.
+		
+	size := 0.
+]
+
+{ #category : #printing }
+StSpotterProcessorLink >> gtDisplayOn: stream [
+	stream 
+		nextPutAll: 'Processor link: ';
+		nextPutAll: self processor title asString
+]
+
+{ #category : #accessing }
+StSpotterProcessorLink >> headLink [
+	^ headLink
+]
+
+{ #category : #accessing }
+StSpotterProcessorLink >> headLink: anObject [
+	headLink := anObject
+]
+
+{ #category : #actions }
+StSpotterProcessorLink >> incrementSize [
+
+	size := self size + 1
+]
+
+{ #category : #testing }
+StSpotterProcessorLink >> isEmpty [
+
+	^ self headLink isNil
+]
+
+{ #category : #testing }
+StSpotterProcessorLink >> isFull [
+
+	^ self size = self processor itemsLimit
+]
+
+{ #category : #accessing }
+StSpotterProcessorLink >> processor [
+
+	^ self value
+]
+
+{ #category : #accessing }
+StSpotterProcessorLink >> size [
+
+	^ size ifNil: [ size := 0 ]
+]
+
+{ #category : #accessing }
+StSpotterProcessorLink >> tailLink [
+	^ tailLink
+]
+
+{ #category : #accessing }
+StSpotterProcessorLink >> tailLink: anObject [
+	tailLink := anObject
+]

--- a/src/NewTools-Spotter/StSpotterQuery.class.st
+++ b/src/NewTools-Spotter/StSpotterQuery.class.st
@@ -1,0 +1,171 @@
+Class {
+	#name : #StSpotterQuery,
+	#superclass : #Object,
+	#instVars : [
+		'candidatesList',
+		'processors',
+		'candidateLinks',
+		'searchText',
+		'finished'
+	],
+	#category : #'NewTools-Spotter-Model'
+}
+
+{ #category : #'instance creation' }
+StSpotterQuery class >> new [
+
+	self error: 'Use #on:'
+]
+
+{ #category : #'instance creation' }
+StSpotterQuery class >> on: aString [
+
+	^ self basicNew 
+		initializeText: aString; 
+		yourself
+]
+
+{ #category : #private }
+StSpotterQuery >> allCandidatesAdded: ann [
+	
+	ann candidateLinks ifEmpty: [ ^ self ].
+	candidateLinks addAll: ann candidateLinks
+]
+
+{ #category : #accessing }
+StSpotterQuery >> announcer [
+
+	^ self candidatesList announcer
+]
+
+{ #category : #private }
+StSpotterQuery >> candidateAdded: ann [
+
+	candidateLinks add: ann candidateLink
+]
+
+{ #category : #accessing }
+StSpotterQuery >> candidatesList [
+
+	^ candidatesList
+]
+
+{ #category : #private }
+StSpotterQuery >> filteringText [
+		
+	^ self searchText substrings 
+		detect: [ :each | each beginsWith: '#' ]
+		ifFound: [ :categoryQuery | categoryQuery ]
+		ifNone: [ nil ]
+]
+
+{ #category : #initialization }
+StSpotterQuery >> initialize [
+
+	super initialize.
+	self initializeCandidatesList.
+	finished := false.	
+	candidateLinks := Set new
+]
+
+{ #category : #initialization }
+StSpotterQuery >> initializeCandidatesList [
+
+	candidatesList := StSpotterCandidatesList new.
+	candidatesList announcer 
+		when: StSpotterCandidateAdded send: #candidateAdded: to: self;
+		when: StSpotterAllCandidatesAdded send: #allCandidatesAdded: to: self.
+		"when: GTSpotterAllCandidatesRemoved do: [ self deselect ];
+		when: StSpotterQueryStarted send: #queryStarted: to: self;
+		when: StSpotterQueryEnded send: #queryEnded: to: self."
+]
+
+{ #category : #initialization }
+StSpotterQuery >> initializeText: aString [ 
+
+	searchText := aString.
+	self initialize
+]
+
+{ #category : #testing }
+StSpotterQuery >> isFinished [
+
+	^ finished
+]
+
+{ #category : #accessing }
+StSpotterQuery >> links [
+
+	^ candidateLinks
+]
+
+{ #category : #'private factory' }
+StSpotterQuery >> newContextFor: aStream text: aString [
+
+	^ StSpotterContext new 
+		step: self;
+		stream: aStream;
+		text: aString;
+		search: aString;
+		yourself
+]
+
+{ #category : #'private factory' }
+StSpotterQuery >> newStreamFor: candidates [
+
+	^ StSpotterStream new
+		onAddedSelector: #addCandidate:in:;
+		onRemoveSelector: #removeAllCandidatesOf:;
+		receiver: candidates;
+		yourself
+]
+
+{ #category : #processing }
+StSpotterQuery >> process [
+	| stream context |
+
+	finished := false.
+	stream := self newStreamFor: candidatesList.
+	context := self newContextFor: stream text: self searchText.
+	self relevantProcessors
+		do: [ :each | each filterInContext: context ].
+	finished := true
+]
+
+{ #category : #accessing }
+StSpotterQuery >> processors [
+
+	^ processors
+]
+
+{ #category : #accessing }
+StSpotterQuery >> processors: aCollection [
+
+	processors := aCollection
+]
+
+{ #category : #private }
+StSpotterQuery >> relevantProcessors [
+
+	^ self filteringText
+		ifNotNil: [ :aString | self relevantProcessorsFor: aString ]
+		ifNil: [ self processors ]
+]
+
+{ #category : #private }
+StSpotterQuery >> relevantProcessorsFor: aString [
+		
+	^ (self processors select: [ :each | each isRelevantForQuery: aString ])
+]
+
+{ #category : #accessing }
+StSpotterQuery >> results [
+
+	^ self links collect: [ :each | each value ]
+]
+
+{ #category : #accessing }
+StSpotterQuery >> searchText [
+
+	^ searchText
+]

--- a/src/NewTools-Spotter/StSpotterQueryEnded.class.st
+++ b/src/NewTools-Spotter/StSpotterQueryEnded.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #StSpotterQueryEnded,
+	#superclass : #Announcement,
+	#category : #'NewTools-Spotter-Announcements'
+}

--- a/src/NewTools-Spotter/StSpotterQueryStarted.class.st
+++ b/src/NewTools-Spotter/StSpotterQueryStarted.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #StSpotterQueryStarted,
+	#superclass : #Announcement,
+	#category : #'NewTools-Spotter-Announcements'
+}

--- a/src/NewTools-Spotter/StSpotterStep.class.st
+++ b/src/NewTools-Spotter/StSpotterStep.class.st
@@ -1,0 +1,186 @@
+"
+A ""step"" in spotter is part of the nested structure created by diving into a category.
+""Diving"" means enter to a particular category (or ""processor"" in spotter definition) to show more in detail its results.
+The old spotter allowed also other kinds of diving, but current implementation removed that (since it was not really used).
+"
+Class {
+	#name : #StSpotterStep,
+	#superclass : #Object,
+	#instVars : [
+		'model',
+		'origin',
+		'activeQuery',
+		'processors'
+	],
+	#category : #'NewTools-Spotter-Model'
+}
+
+{ #category : #'instance creation' }
+StSpotterStep class >> newModel: aSpotterModel [
+
+	^ self new 
+		model: aSpotterModel;
+		yourself
+]
+
+{ #category : #accessing }
+StSpotterStep >> activate [
+
+	activeQuery ifNil: [ ^ self ].
+	self activateQuery: activeQuery
+]
+
+{ #category : #private }
+StSpotterStep >> activateQuery: aQuery [
+
+	activeQuery ifNotNil: [ self disconnectQuery: aQuery ].
+	activeQuery := aQuery.
+	self connectQuery: aQuery.
+	self refreshQueryStatus: aQuery
+]
+
+{ #category : #accessing }
+StSpotterStep >> activeQuery [
+
+	^ activeQuery
+]
+
+{ #category : #accessing }
+StSpotterStep >> addProcessor: processor [
+	
+	processors add: processor
+]
+
+{ #category : #accessing }
+StSpotterStep >> candidatesList [
+
+	^ activeQuery 
+		ifNotNil: [ :aQuery | aQuery candidatesList ]
+		ifNil: [ #() ]
+]
+
+{ #category : #private }
+StSpotterStep >> connectQuery: aQuery [
+
+	aQuery announcer
+		when: StSpotterCandidateAdded send: #announceCandidateAdded: to: self model;
+		when: StSpotterAllCandidatesAdded send: #announceAllCandidatesAdded: to: self model;
+		when: StSpotterCandidatesAmountChanged send: #announceAmountChanged: to: self model;
+		when: StSpotterQueryStarted send: #announceQueryStarted: to: self model;
+		when: StSpotterQueryEnded send: #announceQueryEnded: to: self model.
+]
+
+{ #category : #accessing }
+StSpotterStep >> deactivate [
+
+	self disconnectQuery: activeQuery
+]
+
+{ #category : #private }
+StSpotterStep >> disconnectQuery: aQuery [
+
+	aQuery announcer unsubscribe: self model
+]
+
+{ #category : #accessing }
+StSpotterStep >> links [
+
+	^ activeQuery 
+		ifNotNil: [ :aQuery | aQuery links ]
+		ifNil: [ #() ]
+]
+
+{ #category : #factory }
+StSpotterStep >> listProcessor [
+	| processor |
+	
+	processor := StSpotterCandidatesListProcessor new.
+	self addProcessor: processor.
+	
+	^ processor
+]
+
+{ #category : #accessing }
+StSpotterStep >> model [
+
+	^ model
+]
+
+{ #category : #accessing }
+StSpotterStep >> model: aSpotterModel [
+
+	model := aSpotterModel
+]
+
+{ #category : #accessing }
+StSpotterStep >> origin [
+
+	^ origin
+]
+
+{ #category : #accessing }
+StSpotterStep >> origin: anObject [
+
+	origin := anObject
+]
+
+{ #category : #accessing }
+StSpotterStep >> previousProcessorFrom: aCollection [
+
+	aCollection do: [ :each | 
+		" we assume they are all identical "
+		each asStSpotterCandidateLink processor ifNotNil: [ ^ each processor ] ]. 
+	
+	^ StSpotterCandidatesListProcessor new
+		title: 'Items';
+		filter: StFilterSubstring;
+		yourself
+]
+
+{ #category : #processing }
+StSpotterStep >> process: aString [
+	| query |
+
+	query := StSpotterQuery on: aString.
+	query processors: (self processors sort: #order ascending).
+	self activateQuery: query.
+	query process
+]
+
+{ #category : #accessing }
+StSpotterStep >> processors [
+
+	^ processors ifNil: [ 
+		processors := OrderedCollection new.
+		self origin stSpotterProcessorsFor: self.
+		processors ]
+]
+
+{ #category : #accessing }
+StSpotterStep >> processors: aCollection [
+
+	processors := aCollection
+]
+
+{ #category : #private }
+StSpotterStep >> refreshQueryStatus: aQuery [
+
+	aQuery links ifEmpty: [ ^ self ].
+
+	self model announceAllCandidatesAdded: (StSpotterAllCandidatesAdded new
+		candidateLinks: aQuery links;
+		yourself).
+
+	aQuery isFinished ifTrue: [ 
+		self model announceAmountChanged: (StSpotterCandidatesAmountChanged new 
+			amount: aQuery links size;
+			yourself) ]
+]
+
+{ #category : #accessing }
+StSpotterStep >> results [
+
+	^ activeQuery 
+		ifNotNil: [ :aQuery | aQuery results ]
+		ifNil: [ #() ]
+]

--- a/src/NewTools-Spotter/StSpotterStream.class.st
+++ b/src/NewTools-Spotter/StSpotterStream.class.st
@@ -1,0 +1,101 @@
+Class {
+	#name : #StSpotterStream,
+	#superclass : #Object,
+	#instVars : [
+		'onAddedSelector',
+		'onRemoveSelector',
+		'receiver',
+		'timestamp'
+	],
+	#category : #'NewTools-Spotter-Model'
+}
+
+{ #category : #'adding/removing' }
+StSpotterStream >> addObject: firstObject inProcessor: secondObject [
+
+	self 
+		performSymbol: self onAddedSelector 
+		withArguments: { firstObject. secondObject }.
+	Processor yield
+]
+
+{ #category : #'adding/removing' }
+StSpotterStream >> addObjects: aCollection inProcessor: aProcessor [
+
+	self 
+		performSymbol: #addAllCandidates:in: 
+		withArguments: { aCollection . aProcessor }.
+	Processor yield
+]
+
+{ #category : #accessing }
+StSpotterStream >> onAddedSelector [
+
+	^ onAddedSelector
+]
+
+{ #category : #accessing }
+StSpotterStream >> onAddedSelector: anObject [
+
+	onAddedSelector := anObject
+]
+
+{ #category : #accessing }
+StSpotterStream >> onRemoveSelector [
+
+	^ onRemoveSelector
+]
+
+{ #category : #accessing }
+StSpotterStream >> onRemoveSelector: anObject [
+
+	onRemoveSelector := anObject
+]
+
+{ #category : #performing }
+StSpotterStream >> performSymbol: aSymbol withArguments: aCollection [
+	| time |
+
+	"we save current timestamp here, so that defer block can check if it belongs to the correct task"
+	time := self timestamp.
+	"UI manages commands for us"
+	Processor yield.
+	"if timestamp is wrong just skip command"
+	time = self timestamp ifTrue: [ 
+		self receiver perform: aSymbol withEnoughArguments: aCollection ]
+]
+
+{ #category : #accessing }
+StSpotterStream >> receiver [
+	^ receiver
+]
+
+{ #category : #accessing }
+StSpotterStream >> receiver: anObject [
+	receiver := anObject
+]
+
+{ #category : #'adding/removing' }
+StSpotterStream >> removeAllCandidates [
+
+	self 
+		performSymbol: #removeAllCandidates 
+		withArguments: { }.
+	Processor yield
+]
+
+{ #category : #accessing }
+StSpotterStream >> timestamp [
+	^ timestamp
+]
+
+{ #category : #accessing }
+StSpotterStream >> timestamp: anObject [
+	timestamp := anObject
+]
+
+{ #category : #updating }
+StSpotterStream >> updateTimestamp [
+
+	self timestamp: Time microsecondClockValue
+]

--- a/src/NewTools-Spotter/StStringFilter.class.st
+++ b/src/NewTools-Spotter/StStringFilter.class.st
@@ -1,0 +1,90 @@
+Class {
+	#name : #StStringFilter,
+	#superclass : #StBaseFilter,
+	#instVars : [
+		'caseSensitive',
+		'query'
+	],
+	#category : #'NewTools-Spotter-Filters'
+}
+
+{ #category : #private }
+StStringFilter >> applyFilter [
+	self hasQuery ifFalse: [ 
+		self applyFilterWithoutQuery.
+		^ self allItems. " return the unfiltered items (all) - used for divein (no filtering appied) "  ].
+	self applyFilterWithQuery.
+	^ self filteredItems " return the filtered items only "
+]
+
+{ #category : #private }
+StStringFilter >> applyFilterWithQuery [
+
+	[ self doApplyFilterWithQuery ]
+		on: StLimitArrived do: [ ^ self ]
+]
+
+{ #category : #private }
+StStringFilter >> applyFilterWithoutQuery [
+	" WARNING: this is not a copy of GTNullFilter>>#applyFilterWithoutQuery !!! "
+
+	[self streamed 
+		ifTrue: [
+			" this will be more responsive (faster) for very large collections and/or expensive filters "
+			| reducedItems |
+			self filteredItems: (reducedItems := OrderedCollection new).
+			self allItems withIndexDo: [ :each :index |
+				reducedItems add: each.
+				self addItem: each.
+				index = self itemsLimit ifTrue: [ StLimitArrived signal ] ] ]
+		ifFalse: [
+			" this will be much much faster for small collections and/or very quick filters " 
+			self filteredItems: (self allItems first: (self itemsLimit min: self allItems size)).
+			self addItems: self filteredItems ]] on: StLimitArrived do: [ ^ self ]
+]
+
+{ #category : #accessing }
+StStringFilter >> caseSensitive [
+	^ caseSensitive
+]
+
+{ #category : #accessing }
+StStringFilter >> caseSensitive: anObject [
+	caseSensitive := anObject
+]
+
+{ #category : #'accessing-defaults' }
+StStringFilter >> defaultCaseSensitive [
+	^ false
+]
+
+{ #category : #private }
+StStringFilter >> doApplyFilterWithQuery [
+
+	self subclassResponsibility 
+]
+
+{ #category : #testing }
+StStringFilter >> hasQuery [
+	^ self query isEmptyOrNil not
+]
+
+{ #category : #private }
+StStringFilter >> prepareFilterInContext: aSpotterContext [
+	super prepareFilterInContext: aSpotterContext.
+	
+	caseSensitive ifNil: [ caseSensitive := self defaultCaseSensitive ]. " performance optimization "
+	self query: (caseSensitive " performance optimization "
+		ifTrue: [ self context textTrimmed ]
+		ifFalse: [ self context textLowercase ])
+]
+
+{ #category : #accessing }
+StStringFilter >> query [
+	^ query
+]
+
+{ #category : #accessing }
+StStringFilter >> query: anObject [
+	query := anObject
+]

--- a/src/NewTools-Spotter/StUnifiedProcessor.extension.st
+++ b/src/NewTools-Spotter/StUnifiedProcessor.extension.st
@@ -1,0 +1,21 @@
+Extension { #name : #StUnifiedProcessor }
+
+{ #category : #'*NewTools-Spotter' }
+StUnifiedProcessor >> headerCategoryFor: aLink on: aSpotterPresenter [
+
+	^ aLink value 
+		headerCategoryForUnifiedProcessor: aLink 
+		on: aSpotterPresenter
+]
+
+{ #category : #'*NewTools-Spotter' }
+StUnifiedProcessor >> keyBindingForClasses [
+
+	^ $b meta
+]
+
+{ #category : #'*NewTools-Spotter' }
+StUnifiedProcessor >> keyBindingForImplementors [
+
+	^ $m meta
+]

--- a/src/NewTools-Spotter/StUnorderedFilter.class.st
+++ b/src/NewTools-Spotter/StUnorderedFilter.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #StUnorderedFilter,
+	#superclass : #StStringFilter,
+	#category : #'NewTools-Spotter-Filters'
+}
+
+{ #category : #private }
+StUnorderedFilter >> doApplyFilterWithQuery [
+
+	| unorderedMatchedItems |
+
+	unorderedMatchedItems := OrderedCollection new.
+	self allItemsDo: [ :each | 
+		(self isMatchedItem: each)
+				ifTrue: [
+					unorderedMatchedItems add: each.
+					self addItem: each.
+					unorderedMatchedItems size = self itemsLimit ifTrue: [ StLimitArrived signal ] ] ].
+	self filteredItems: unorderedMatchedItems
+]
+
+{ #category : #private }
+StUnorderedFilter >> isMatchedItem: anItem [
+	^ false
+]

--- a/src/NewTools-Spotter/String.extension.st
+++ b/src/NewTools-Spotter/String.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #String }
+
+{ #category : #'*NewTools-Spotter' }
+String >> spotterPreview: aBuilder [
+
+	^ aBuilder newText
+		beNotEditable;
+		text: self;
+		yourself
+]

--- a/src/NewTools-Spotter/package.st
+++ b/src/NewTools-Spotter/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'NewTools-Spotter' }

--- a/src/Spec2-Adapters-Morphic/SpAbstractMorphicWindowAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpAbstractMorphicWindowAdapter.class.st
@@ -50,8 +50,8 @@ SpAbstractMorphicWindowAdapter >> addContent: aMorph toWindow: aSpecWindow [
 
 { #category : #private }
 SpAbstractMorphicWindowAdapter >> addMenuTo: aMorph [
-
 	| menuMorph |
+	
 	menuMorph := self model menu buildWithSpec.
 	aMorph addMorphBack: menuMorph.	
 	menuMorph
@@ -84,24 +84,25 @@ SpAbstractMorphicWindowAdapter >> newContainerMorph [
 
 { #category : #private }
 SpAbstractMorphicWindowAdapter >> setToolbarTo: aMorph [
-
-	| newToolbarMorph |
+	| newToolbarMorph toolbarPresenter |
 	
 	self model hasToolbar 
-		ifFalse: [ 
+		ifFalse: [
 			toolbarMorph ifNotNil: [ 
 				aMorph removeMorph: toolbarMorph.
 				toolbarMorph := nil.  ].
 			^ self. ].
 	
-	newToolbarMorph := self presenter toolbar buildWithSpec.
+	toolbarPresenter := self presenter toolbar.
+	newToolbarMorph := toolbarPresenter buildWithSpec.
+	toolbarPresenter adapter applyStyle.
 	newToolbarMorph
 		hResizing: #spaceFill;
 		vResizing: #rigid.
 	
 	"If we have a toolbar morph, we replace with the new one"
 	toolbarMorph 
-		ifNil: [	aMorph addMorph: newToolbarMorph ]
+		ifNil: [	aMorph addMorphBack: newToolbarMorph ]
 		ifNotNil: [ aMorph replaceSubmorph: toolbarMorph by: newToolbarMorph ].
 		
 	toolbarMorph := newToolbarMorph

--- a/src/Spec2-Adapters-Morphic/SpAbstractMorphicWindowAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpAbstractMorphicWindowAdapter.class.st
@@ -5,7 +5,8 @@ Class {
 	#name : #SpAbstractMorphicWindowAdapter,
 	#superclass : #SpAbstractMorphicAdapter,
 	#instVars : [
-		'toolbarMorph'
+		'toolbarMorph',
+		'menuMorph'
 	],
 	#category : #'Spec2-Adapters-Morphic-Base'
 }
@@ -50,7 +51,6 @@ SpAbstractMorphicWindowAdapter >> addContent: aMorph toWindow: aSpecWindow [
 
 { #category : #private }
 SpAbstractMorphicWindowAdapter >> addMenuTo: aMorph [
-	| menuMorph |
 	
 	menuMorph := self model menu buildWithSpec.
 	aMorph addMorphBack: menuMorph.	
@@ -102,8 +102,11 @@ SpAbstractMorphicWindowAdapter >> setToolbarTo: aMorph [
 	
 	"If we have a toolbar morph, we replace with the new one"
 	toolbarMorph 
-		ifNil: [	aMorph addMorphBack: newToolbarMorph ]
-		ifNotNil: [ aMorph replaceSubmorph: toolbarMorph by: newToolbarMorph ].
+		ifNotNil: [ aMorph replaceSubmorph: toolbarMorph by: newToolbarMorph ]
+		ifNil: [	
+			menuMorph 
+				ifNotNil: [ aMorph addMorph: newToolbarMorph after: menuMorph ]
+				ifNil: [ aMorph addMorph: newToolbarMorph ] ].
 		
 	toolbarMorph := newToolbarMorph
 

--- a/src/Spec2-Adapters-Morphic/SpMorphicBaseTextAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicBaseTextAdapter.class.st
@@ -107,6 +107,12 @@ SpMorphicBaseTextAdapter >> cursorPositionIndex [
 ]
 
 { #category : #'widget API' }
+SpMorphicBaseTextAdapter >> cursorPositionIndex: index [ 
+
+	self subclassResponsibility
+]
+
+{ #category : #'widget API' }
 SpMorphicBaseTextAdapter >> font: aFont [
 
 	self widgetDo: [ :w | w font: aFont ]

--- a/src/Spec2-Adapters-Morphic/SpMorphicTextInputFieldAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTextInputFieldAdapter.class.st
@@ -50,6 +50,8 @@ SpMorphicTextInputFieldAdapter >> buildWidget [
 		newWidget encrypted: isPassword ].
 	self presenter whenMaxLengthChangedDo: [ :length | 
 		newWidget maxLength: length ].
+	self presenter whenEditableChangedDo: [ :value | 
+		self setEditable: value to: newWidget ].
 
 	^ newWidget
 ]
@@ -96,6 +98,12 @@ SpMorphicTextInputFieldAdapter >> getPlaceholderText [
 SpMorphicTextInputFieldAdapter >> isPassword [
 	
 	^ self widget font isKindOf: FixedFaceFont
+]
+
+{ #category : #private }
+SpMorphicTextInputFieldAdapter >> setEditable: aBoolean to: aWidget [
+
+	aWidget textArea readOnly: aBoolean not
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Adapters-Morphic/SpMorphicTextInputFieldAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTextInputFieldAdapter.class.st
@@ -55,6 +55,12 @@ SpMorphicTextInputFieldAdapter >> buildWidget [
 ]
 
 { #category : #'widget API' }
+SpMorphicTextInputFieldAdapter >> cursorPositionIndex: index [ 
+
+	self widgetDo: [ :w | ^ w textArea editor selectAt: index ]
+]
+
+{ #category : #'widget API' }
 SpMorphicTextInputFieldAdapter >> encrypted [
 	^ self model isPassword
 ]

--- a/src/Spec2-Adapters-Morphic/SpMorphicWindowAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicWindowAdapter.class.st
@@ -48,7 +48,7 @@ SpMorphicWindowAdapter >> addPresenterIn: aWindow withSpecLayout: aSpec [
 			ifTrue: [ aWindow initializeLabelArea ]
 			ifFalse: [ aWindow removeLabelArea ] ].
 	
-self 
+	self 
 		addContent: (self presenter presenter buildWithSpecLayout: aSpec) 
 		toWindow: aWindow
 ]

--- a/src/Spec2-Core/SpAbstractTextPresenter.class.st
+++ b/src/Spec2-Core/SpAbstractTextPresenter.class.st
@@ -75,6 +75,14 @@ SpAbstractTextPresenter >> cursorPositionIndex [
 ]
 
 { #category : #api }
+SpAbstractTextPresenter >> cursorPositionIndex: index [
+	"Set cursor position index. 
+	 This method will place the cursor in the text index position requested."
+
+ 	^ self withAdapterDo: [ :anAdapter | anAdapter cursorPositionIndex: index ]
+]
+
+{ #category : #api }
 SpAbstractTextPresenter >> enabled: aBoolean [
 	"Set if the widget is enabled (clickable or focusable)"
 

--- a/src/Spec2-Core/SpAbstractTreePresenter.class.st
+++ b/src/Spec2-Core/SpAbstractTreePresenter.class.st
@@ -282,8 +282,7 @@ SpAbstractTreePresenter >> selectPath: aPath [
 	`aPath` is the path to select. A path is an array of node indexes (e.g. #(1 2 3)).
 	 It does not scrolls to selected element."
 
-	self withAdapterPerformOrDefer: [ :anAdapter | 
-		self selection selectPath: aPath ]
+	self selection selectPath: aPath
 ]
 
 { #category : #'api-selection' }

--- a/src/Spec2-Core/SpAbstractTreePresenter.class.st
+++ b/src/Spec2-Core/SpAbstractTreePresenter.class.st
@@ -327,8 +327,7 @@ SpAbstractTreePresenter >> selectPaths: pathArray [
 	"Selects all elements in `pathsArray``
 	`pathsArray` is an array of paths. A path is an array of node indexes (e.g. #(1 2 3))"
 
-	self withAdapterPerformOrDefer: [ :anAdapter | 
-		self selection selectPaths: pathArray ]
+	self selection selectPaths: pathArray
 ]
 
 { #category : #'api-selection' }

--- a/src/Spec2-Core/SpAbstractTreePresenter.class.st
+++ b/src/Spec2-Core/SpAbstractTreePresenter.class.st
@@ -200,6 +200,27 @@ SpAbstractTreePresenter >> items: aCollection [
 	self roots: aCollection
 ]
 
+{ #category : #private }
+SpAbstractTreePresenter >> pathIndexOf: anArrayOfElements [
+
+	^ self 
+		pathIndexOf: anArrayOfElements 
+		in: self roots
+]
+
+{ #category : #private }
+SpAbstractTreePresenter >> pathIndexOf: pathArray in: aCollection [ 
+	| pathElement |
+	
+	pathElement := { aCollection indexOf: pathArray first }.
+	pathArray size = 1 ifTrue: [ ^ pathElement ].
+	
+	^ pathElement, (self 
+		pathIndexOf: pathArray allButFirst
+		in: (self childrenFor: pathArray first))
+
+]
+
 { #category : #api }
 SpAbstractTreePresenter >> refresh [
 	"Forces a refresh of the tree. 
@@ -261,17 +282,45 @@ SpAbstractTreePresenter >> selectPath: aPath [
 	`aPath` is the path to select. A path is an array of node indexes (e.g. #(1 2 3)).
 	 It does not scrolls to selected element."
 
-	self selection selectPath: aPath
+	self withAdapterPerformOrDefer: [ :anAdapter | 
+		self selection selectPath: aPath ]
 ]
 
 { #category : #'api-selection' }
 SpAbstractTreePresenter >> selectPath: aPath scrollToSelection: shouldScrollToSelection [
 	"Selects element in `aPath`
 	`aPath` is the path to select. A path is an array of node indexes (e.g. #(1 2 3)).
-	 If `shouldScrollToSelection` is true, it will scroll to selected element."
+	 If `shouldScrollToSelection` is true, it will scroll to selected element.
+	 IMPORTANT: Scrolling to selection just has sense when the widget is already shown, because before it 
+	 is displayed it does not has real bounds. In morphic (and gtk) it has a minimal extent assigned, 
+	 but that will change as soon as the widget is inserted in a container and the container applies its 
+	 layout."
 
-	self selectPath: aPath.
-	shouldScrollToSelection ifTrue: [ adapter scrollToSelection ]
+	self withAdapterPerformOrDefer: [ :anAdapter |
+		self selectPath: aPath.
+		shouldScrollToSelection ifTrue: [ adapter scrollToSelection ] ]
+]
+
+{ #category : #'api-selection' }
+SpAbstractTreePresenter >> selectPathByItems: pathArray [
+
+	self selectPathByItems: pathArray scrollToSelection: false
+]
+
+{ #category : #'api-selection' }
+SpAbstractTreePresenter >> selectPathByItems: pathArray scrollToSelection: aBoolean [
+	"IMPORTANT: Scrolling to selection just has sense when the widget is already shown, because before it 
+	 is displayed it does not has real bounds. In morphic (and gtk) it has a minimal extent assigned, 
+	 but that will change as soon as the widget is inserted in a container and the container applies its 
+	 layout."
+	| pathIndexes |
+
+	pathIndexes := self pathIndexOf: pathArray.
+	pathIndexes size > 1 ifTrue: [ 
+		self expandPath: pathIndexes allButLast ].
+	self 
+		selectPath: pathIndexes
+		scrollToSelection: aBoolean
 ]
 
 { #category : #'api-selection' }
@@ -279,7 +328,8 @@ SpAbstractTreePresenter >> selectPaths: pathArray [
 	"Selects all elements in `pathsArray``
 	`pathsArray` is an array of paths. A path is an array of node indexes (e.g. #(1 2 3))"
 
-	self selection selectPaths: pathArray
+	self withAdapterPerformOrDefer: [ :anAdapter | 
+		self selection selectPaths: pathArray ]
 ]
 
 { #category : #'api-selection' }

--- a/src/Spec2-Core/SpFilteringSelectableListPresenter.class.st
+++ b/src/Spec2-Core/SpFilteringSelectableListPresenter.class.st
@@ -60,7 +60,12 @@ SpFilteringSelectableListPresenter >> initializePresenters [
 					selectFrom: previousSelectedIndex
 					to: listPresenter selection selectedIndex ]
 			ifFalse: [ 
-				self toggleSelection ] ]
+				self toggleSelection ] ].
+		
+	"listPresenter
+  		bindKeyCombination: $a meta toAction: [
+    		self selectItems: self items ]"
+
 ]
 
 { #category : #private }

--- a/src/Spec2-Core/SpTextInputFieldPresenter.class.st
+++ b/src/Spec2-Core/SpTextInputFieldPresenter.class.st
@@ -8,6 +8,7 @@ Class {
 	#instVars : [
 		'#entryCompletion => SpObservableSlot',
 		'#isPassword => SpObservableSlot',
+		'#editable => SpObservableSlot',
 		'#maxLength => SpObservableSlot'
 	],
 	#category : #'Spec2-Core-Widgets'
@@ -17,6 +18,20 @@ Class {
 SpTextInputFieldPresenter class >> adapterName [
 
 	^ #TextInputFieldAdapter
+]
+
+{ #category : #api }
+SpTextInputFieldPresenter >> beEditable [
+	"Allow edition (deny readonly)."
+
+	self editable: true
+]
+
+{ #category : #api }
+SpTextInputFieldPresenter >> beNotEditable [
+	"Set content text as not editable (readonly)"
+
+	self editable: false
 ]
 
 { #category : #api }
@@ -37,6 +52,12 @@ SpTextInputFieldPresenter >> beText [
 	"Set this input text as a text editor."
 
 	self bePassword: false
+]
+
+{ #category : #private }
+SpTextInputFieldPresenter >> editable: aBoolean [
+
+	editable := aBoolean
 ]
 
 { #category : #api }
@@ -72,7 +93,16 @@ SpTextInputFieldPresenter >> initialize [
 	super initialize.
 
 	maxLength := 0.
-	isPassword := false
+	isPassword := false.
+	self beEditable.
+
+]
+
+{ #category : #testing }
+SpTextInputFieldPresenter >> isEditable [
+	"Answer true if edition is allowed (component is NOT readonly)"
+
+	^ editable
 ]
 
 { #category : #testing }
@@ -120,6 +150,17 @@ SpTextInputFieldPresenter >> updateText [
 	"Update text but applying lenght constraints"
 	
 	self text: self text.
+]
+
+{ #category : #'api-events' }
+SpTextInputFieldPresenter >> whenEditableChangedDo: aBlock [
+	"Inform when editable property has changed. 
+	 `aBlock` has three optional arguments: 
+	 - new value
+	 - old value
+	 - the announcement triggering this action"
+
+	self property: #editable whenChangedDo: aBlock
 ]
 
 { #category : #'api-events' }

--- a/src/Spec2-Core/SpTextPresenter.class.st
+++ b/src/Spec2-Core/SpTextPresenter.class.st
@@ -120,14 +120,6 @@ SpTextPresenter >> cursorPosition [
 	^ self withAdapterDo: [ :anAdapter | anAdapter cursorPosition ]
 ]
 
-{ #category : #api }
-SpTextPresenter >> cursorPositionIndex: index [
-	"Set cursor position index. 
-	 This method will place the cursor in the text index position requested."
-
-	^ self withAdapterDo: [ :anAdapter | anAdapter cursorPositionIndex: index ]
-]
-
 { #category : #commands }
 SpTextPresenter >> doTextCopy [
 


### PR DESCRIPTION
NewTools 0.6
===

https://github.com/pharo-spec/NewTools/releases/tag/v0.6

- This version introduces new `Spotter` tool!
- uses style contributor (thanks @tesonep) to add styles for each tool (using it in spotter) 
- fixes cmd+p, and cmd+i, etc on playground.
- fixes https://github.com/pharo-spec/NewTools/issues/171 
- fixes https://github.com/pharo-project/pharo/issues/8765
- fixes https://github.com/pharo-spec/NewTools/issues/161
- fixes https://github.com/pharo-spec/NewTools/issues/176
- several debugger fixes
- cleanups 

Spec 0.8.6
===

https://github.com/pharo-spec/Spec/releases/tag/v0.8.6

- add cursorPositionIndex: to input fields
- add beEditable property to input fields

