### PR TITLE
Use LibraryFinder in CairoLibrary>>macLibraryName

### DIFF
--- a/src/Athens-Cairo/CairoLibrary.class.st
+++ b/src/Athens-Cairo/CairoLibrary.class.st
@@ -10,7 +10,8 @@ Class {
 
 { #category : #'accessing platform' }
 CairoLibrary >> macLibraryName [
-	^ 'libcairo.2.dylib'
+
+	^ FFIMacLibraryFinder findLibrary: 'libcairo.2.dylib'
 ]
 
 { #category : #'accessing platform' }


### PR DESCRIPTION
LibraryFinder are used for unix and windows but was missing for mac.

The change is not motivated by an error. Mostly to be consistent with all platforms.

@tesonep 