### PR TITLE
ReVariableAssignedLiteralRule-Skip-PoolVars

### DIFF
--- a/src/GeneralRules/ReVariableAssignedLiteralRule.class.st
+++ b/src/GeneralRules/ReVariableAssignedLiteralRule.class.st
@@ -17,11 +17,13 @@ ReVariableAssignedLiteralRule class >> checksClass [
 ReVariableAssignedLiteralRule >> check: aClass forCritiquesDo: aCriticBlock [
 
 	aClass definedVariables do: [ :variable | 
-		|  assignmentNodes |
-		assignmentNodes := variable  assignmentNodes.
+		| assignmentNodes |
+		"Pools are often used to define constants and can read without an accessor"
+		variable isPoolVariable ifTrue: [ ^ self ].
+		assignmentNodes := variable assignmentNodes.
 		assignmentNodes size = 1 ifFalse: [ ^ self ].
 		assignmentNodes first value isLiteralNode ifTrue: [ 
-		aCriticBlock cull: (self critiqueFor: aClass about: variable  name) ]]
+			aCriticBlock cull: (self critiqueFor: aClass about: variable name) ] ]
 ]
 
 { #category : #'running-helpers' }

--- a/src/Kernel/ClassVariable.class.st
+++ b/src/Kernel/ClassVariable.class.st
@@ -69,6 +69,11 @@ ClassVariable >> isDefinedByOwningClass [
 ]
 
 { #category : #testing }
+ClassVariable >> isPoolVariable [
+	^ self definingClass isPool 
+]
+
+{ #category : #testing }
 ClassVariable >> isReferenced [
 	"A class variable can only be accessed in the defintionClass and its subclasses (both class and instance side)"
 

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -160,6 +160,11 @@ Variable >> isLocalVariable [
 ]
 
 { #category : #testing }
+Variable >> isPoolVariable [
+	^ false
+]
+
+{ #category : #testing }
 Variable >> isReadIn: aCompiledCode [
 	^aCompiledCode ast readNodes
 		 anySatisfy: [ :node | node binding == self ]

--- a/src/Slot-Tests/ClassVariableTest.class.st
+++ b/src/Slot-Tests/ClassVariableTest.class.st
@@ -105,3 +105,12 @@ ClassVariableTest >> testWritingToContext [
 	
 	self assert: TestVariable equals: #testValue
 ]
+
+{ #category : #tests }
+ClassVariableTest >> testisPoolVariable [
+	| variable |
+	variable := SmalltalkImage classVariableNamed: #CompilerClass.
+	self deny: variable isPoolVariable.
+	variable := TextConstants classVariableNamed: #Basal.
+	self assert: variable isPoolVariable.
+]


### PR DESCRIPTION
ReVariableAssignedLiteralRule is complaining a lot for Class Variables defined in subclasses of SharedPool.

This PR disabled the warning for that case: We use SharedPools to define Constants, these are often written to once but
read via referencing the Pool Var from some other class.

- add #isPoolVariable so we can easily check if a class variable is a pool variable
- add test #testisPoolVariable
