### PR TITLE
Fix missing return in ClySystemEnvironment

### DIFF
--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -161,12 +161,12 @@ ClySystemEnvironment >> confirmToOverrideExistingClassNamed: newClassName [
 
 	"Attempting to define new class/trait over existing one when not looking at the original one in this browser..."
 
-	self confirm:
-		((newClassName , ' is an existing class/trait in this system.
+	^ self confirm:
+		  ((newClassName , ' is an existing class/trait in this system.
 Redefining it might cause serious problems.
 Is this really what you want to do?') asText
-			 makeBoldFrom: 1
-			 to: newClassName size)
+			   makeBoldFrom: 1
+			   to: newClassName size)
 ]
 
 { #category : #'package management' }


### PR DESCRIPTION
Hello

This PR fixes an issue mentioned in https://github.com/pharo-project/pharo/issues/8878 with the missing return in ClySystemEnvironment>>confirmToOverrideExistingClassNamed: