### PR TITLE
Rolling back to the old morphic behavior (but in OUPS) when opening debuggers

### DIFF
--- a/src/Debugger-Oups/OupsDebuggerSelectionStrategy.class.st
+++ b/src/Debugger-Oups/OupsDebuggerSelectionStrategy.class.st
@@ -44,7 +44,7 @@ OupsDebuggerSelectionStrategy class >> debuggerSelectionStrategySettingsOn: aBui
 
 { #category : #settings }
 OupsDebuggerSelectionStrategy class >> defaultDebuggerSelectionStrategy [
-	^OupsDebuggerSelector
+	^OupsSingleDebuggerSelector
 ]
 
 { #category : #instance }

--- a/src/Debugger-Oups/OupsSingleDebuggerSelector.class.st
+++ b/src/Debugger-Oups/OupsSingleDebuggerSelector.class.st
@@ -25,7 +25,7 @@ OupsSingleDebuggerSelector >> nextDebugger [
 OupsSingleDebuggerSelector >> openDebuggerForSession: aDebugSession [
 
 	[ self nextDebugger debugSession: aDebugSession ]
-		on: Error
+		on: Exception
 		do: [ :err | 
 			error := err.
 			handled := false.


### PR DESCRIPTION
This fixes in particular https://github.com/pharo-project/pharo/issues/8324 by avoiding locking the image because of infinite debugger openings.

This rollbacks from smart debugger opening (when a debugger fails, tries to open another one) to just open the default system debugger and log error if any.
There actually was a bug in that rollbacked version that is now fixed.

The smart version problems should be investigated (issue https://github.com/pharo-project/pharo/issues/8383).