### PR TITLE
8887-Rename-variable-takes-wrong-selection

### DIFF
--- a/src/AST-Core-Tests/RBProgramNodeTest.class.st
+++ b/src/AST-Core-Tests/RBProgramNodeTest.class.st
@@ -441,6 +441,84 @@ RBProgramNodeTest >> testBestNodeWithMethodSelectorGivesCommentNode [
 	self assert: ast isCommentNode.
 ]
 
+{ #category : #'testing-adding' }
+RBProgramNodeTest >> testCursorAfterArgumentReturnsVariableNode [
+
+	| sourceCode ast bestNode |
+	sourceCode := 'toto: m1
+	               m1 aMessage'.
+	
+	ast := RBParser parseMethod: sourceCode.
+	bestNode := ast bestNodeForPosition: 9.
+	
+	self assert: bestNode isVariable 
+]
+
+{ #category : #'testing-adding' }
+RBProgramNodeTest >> testCursorAfterVariableReturnsVariableNode [
+
+	| sourceCode ast bestNode |
+	sourceCode := 'toto: m1
+	               m1 aMessage'.
+	
+	ast := RBParser parseMethod: sourceCode.
+	bestNode := ast bestNodeForPosition: 28.
+	
+	self assert: bestNode isVariable 
+]
+
+{ #category : #'testing-adding' }
+RBProgramNodeTest >> testCursorBeforeArgumentNextToSelectorReturnsMethodNode [
+
+	| sourceCode ast bestNode |
+	sourceCode := 'toto:m1
+	               m1 aMessage'.
+	
+	ast := RBParser parseMethod: sourceCode.
+	bestNode := ast bestNodeForPosition: 6.
+	
+	self assert: bestNode isMethod 
+]
+
+{ #category : #'testing-adding' }
+RBProgramNodeTest >> testCursorBeforeArgumentReturnsVariableNode [
+
+	| sourceCode ast bestNode |
+	sourceCode := 'toto: m1
+	               m1 aMessage'.
+	
+	ast := RBParser parseMethod: sourceCode.
+	bestNode := ast bestNodeForPosition: 7.
+	
+	self assert: bestNode isVariable 
+]
+
+{ #category : #'testing-adding' }
+RBProgramNodeTest >> testCursorBeforeVariableReturnsVariableNode [
+
+	| sourceCode ast bestNode |
+	sourceCode := 'toto: m1
+	               m1 aMessage'.
+	
+	ast := RBParser parseMethod: sourceCode.
+	bestNode := ast bestNodeForPosition: 26.
+	
+	self assert: bestNode isVariable 
+]
+
+{ #category : #'testing-adding' }
+RBProgramNodeTest >> testCursorInMiddleOfVariableReturnsVariableNode [
+
+	| sourceCode ast bestNode |
+	sourceCode := 'toto: m1
+	               m1 aMessage'.
+	
+	ast := RBParser parseMethod: sourceCode.
+	bestNode := ast bestNodeForPosition: 27.
+	
+	self assert: bestNode isVariable 
+]
+
 { #category : #'testing-properties' }
 RBProgramNodeTest >> testHasProperty [
 	self deny: (self node hasProperty: #foo).

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -201,6 +201,33 @@ RBProgramNode >> bestNodeFor: anInterval [
 ]
 
 { #category : #querying }
+RBProgramNode >> bestNodeForPosition: aPosition [
+
+	"aPosition is an integer that represents the position of the caret. 
+	A value of N represents that the caret is between the characters N-1 and N.
+	The position 1 is at beginning of the text.
+	
+	Position Heuristic: If the previous character is not a separator, take selection one position before.
+		This heuristic is for the cases where the caret (|) is:
+		   |self foo  => the caret is before self, do not move
+		   self foo|  => the caret is before foo, interpret is as if we are in foo.
+			self foo | => the caret is before a space, interpret is as if we are in foo.
+
+		This heuristic introduces although an ambiguity when code is not nicely formatted:
+		   self foo:|#bar => Here a user may want foo: or bar.
+		For now we decided to favor foo: to motivate people to indent code correctly	"
+ 
+	| offset position |
+	offset := (aPosition = 1 or: [ (self methodNode sourceCode at: aPosition - 1) isSeparator ])
+		ifTrue: [ 0 ]
+		ifFalse: [ -1 ].
+
+	position := (aPosition + offset) min: self stop.
+
+	^ self bestNodeFor: (position to: position)
+]
+
+{ #category : #querying }
 RBProgramNode >> blockNodes [
 	^self allChildren select: [:each | each isBlock].
 ]

--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -286,9 +286,14 @@ ClyMethodCodeEditorToolMorph >> selectVariableNamed: varName [
 { #category : #accessing }
 ClyMethodCodeEditorToolMorph >> selectedSourceNode [
 
-	| selectedInterval |
+	| selectedInterval ast |
 	selectedInterval := self selectedTextInterval.
-	^(editingMethod astForStylingInCalypso bestNodeFor: selectedInterval)
+	
+	ast := selectedInterval isEmpty 
+		ifTrue: [ editingMethod astForStylingInCalypso bestNodeForPosition: selectedInterval first ]
+		ifFalse: [ editingMethod astForStylingInCalypso bestNodeFor: selectedInterval ].
+	
+	^ ast
 		ifNil: [ editingMethod astForStylingInCalypso ]
 ]
 

--- a/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
+++ b/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
@@ -41,24 +41,8 @@ Class {
 { #category : #'public - extraction' }
 CNSelectorExtractor >> extractSelectorFromAST: ast atPosition: aPosition [
 
-	"Obtain the the best node matching the position and extracts a selector from it."
-
-	"Position Heuristic: If the previous character is not a separator, take selection one position before.
-	This heuristic is for the cases where the caret (|) is:
-	   |self foo  => the caret is before self, do not move
-	   self foo|  => the caret is before foo, interpret is as if we are in foo.
-		self foo | => the caret is before a space, interpret is as if we are in foo.
-
-	This heuristic introduces although an ambiguity when code is not nicely formatted:
-	   self foo:|#bar => Here a user may want foo: or bar.
-	For now we decided to favor foo: to motivate people to indent code correctly"
-	| offset position bestNodeAtPosition |
-	offset := (aPosition = 1 or: [ (ast sourceCode at: aPosition - 1) isSeparator ])
-		ifTrue: [ 0 ]
-		ifFalse: [ -1 ].
-
-	position := (aPosition + offset) min: ast stop.
-	bestNodeAtPosition := ast bestNodeFor: (position to: position).
+	| bestNodeAtPosition |
+	bestNodeAtPosition := ast bestNodeForPosition: aPosition.
 	^ self extractSelectorFromNode: bestNodeAtPosition
 ]
 


### PR DESCRIPTION
Adding a better way of getting the best matching node when we are working with a position of the caret and not a selection interval.

Just changing the users to fix the issue
Fix #8887