### PR TITLE
[Redo #8894] Introduce bestNodeForAtPosition: by moving selector extractor heuristic.

### DIFF
--- a/src/AST-Core-Tests/RBProgramNodeTest.class.st
+++ b/src/AST-Core-Tests/RBProgramNodeTest.class.st
@@ -441,6 +441,84 @@ RBProgramNodeTest >> testBestNodeWithMethodSelectorGivesCommentNode [
 	self assert: ast isCommentNode.
 ]
 
+{ #category : #'testing-adding' }
+RBProgramNodeTest >> testCursorAfterArgumentReturnsVariableNode [
+
+	| sourceCode ast bestNode |
+	sourceCode := 'toto: m1
+	               m1 aMessage'.
+	
+	ast := RBParser parseMethod: sourceCode.
+	bestNode := ast bestNodeForPosition: 9.
+	
+	self assert: bestNode isVariable 
+]
+
+{ #category : #'testing-adding' }
+RBProgramNodeTest >> testCursorAfterVariableReturnsVariableNode [
+
+	| sourceCode ast bestNode |
+	sourceCode := 'toto: m1
+	               m1 aMessage'.
+	
+	ast := RBParser parseMethod: sourceCode.
+	bestNode := ast bestNodeForPosition: 28.
+	
+	self assert: bestNode isVariable 
+]
+
+{ #category : #'testing-adding' }
+RBProgramNodeTest >> testCursorBeforeArgumentNextToSelectorReturnsMethodNode [
+
+	| sourceCode ast bestNode |
+	sourceCode := 'toto:m1
+	               m1 aMessage'.
+	
+	ast := RBParser parseMethod: sourceCode.
+	bestNode := ast bestNodeForPosition: 6.
+	
+	self assert: bestNode isMethod 
+]
+
+{ #category : #'testing-adding' }
+RBProgramNodeTest >> testCursorBeforeArgumentReturnsVariableNode [
+
+	| sourceCode ast bestNode |
+	sourceCode := 'toto: m1
+	               m1 aMessage'.
+	
+	ast := RBParser parseMethod: sourceCode.
+	bestNode := ast bestNodeForPosition: 7.
+	
+	self assert: bestNode isVariable 
+]
+
+{ #category : #'testing-adding' }
+RBProgramNodeTest >> testCursorBeforeVariableReturnsVariableNode [
+
+	| sourceCode ast bestNode |
+	sourceCode := 'toto: m1
+	               m1 aMessage'.
+	
+	ast := RBParser parseMethod: sourceCode.
+	bestNode := ast bestNodeForPosition: 26.
+	
+	self assert: bestNode isVariable 
+]
+
+{ #category : #'testing-adding' }
+RBProgramNodeTest >> testCursorInMiddleOfVariableReturnsVariableNode [
+
+	| sourceCode ast bestNode |
+	sourceCode := 'toto: m1
+	               m1 aMessage'.
+	
+	ast := RBParser parseMethod: sourceCode.
+	bestNode := ast bestNodeForPosition: 27.
+	
+	self assert: bestNode isVariable 
+]
+
 { #category : #'testing-properties' }
 RBProgramNodeTest >> testHasProperty [
 	self deny: (self node hasProperty: #foo).

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -201,6 +201,33 @@ RBProgramNode >> bestNodeFor: anInterval [
 ]
 
 { #category : #querying }
+RBProgramNode >> bestNodeForPosition: aPosition [
+
+	"aPosition is an integer that represents the position of the caret. 
+	A value of N represents that the caret is between the characters N-1 and N.
+	The position 1 is at beginning of the text.
+	
+	Position Heuristic: If the previous character is not a separator, take selection one position before.
+		This heuristic is for the cases where the caret (|) is:
+		   |self foo  => the caret is before self, do not move
+		   self foo|  => the caret is before foo, interpret is as if we are in foo.
+			self foo | => the caret is before a space, interpret is as if we are in foo.
+
+		This heuristic introduces although an ambiguity when code is not nicely formatted:
+		   self foo:|#bar => Here a user may want foo: or bar.
+		For now we decided to favor foo: to motivate people to indent code correctly	"
+ 
+	| offset position |
+	offset := (aPosition = 1 or: [ (self methodNode sourceCode at: aPosition - 1) isSeparator ])
+		ifTrue: [ 0 ]
+		ifFalse: [ -1 ].
+
+	position := (aPosition + offset) min: self stop.
+
+	^ self bestNodeFor: (position to: position)
+]
+
+{ #category : #querying }
 RBProgramNode >> blockNodes [
 	^self allChildren select: [:each | each isBlock].
 ]

--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -54,7 +54,7 @@ ClyMethodCodeEditorToolMorph >> applyDecorations [
 	 a lot of time, we will skip it when it is the case"
 	editingMethod isLiteralMethod ifFalse: [ 
 		IconStyler withStaticStylers  
-			styleText: textModel withAst: editingMethod astForStylingInCalypso ].	
+			styleText: textModel withAst: self currentEditedAST ].	
 	textMorph hasUnacceptedEdits: hasEdits.
 	
 	super applyDecorations.
@@ -169,7 +169,7 @@ ClyMethodCodeEditorToolMorph >> extendingPackage: aPackage [
 ClyMethodCodeEditorToolMorph >> findAnySelectorInSourceCode: selectors [
 
 	| foundSelector foundNode positions ast |
-	ast := editingMethod astForStylingInCalypso.
+	ast := self currentEditedAST.
 	foundNode := ast sendNodes 
 		detect: [:each | selectors includes: (foundSelector := each selector) ] 
 		ifNone: [ 
@@ -180,13 +180,6 @@ ClyMethodCodeEditorToolMorph >> findAnySelectorInSourceCode: selectors [
 		
 	positions := foundNode keywordsPositions.
 	^positions first to: positions last + foundSelector keywords last size - 1.
-]
-
-{ #category : #'selecting text' }
-ClyMethodCodeEditorToolMorph >> findAnySelectorOrString: selectors inSourceCode: aText [
-
-	^(self findAnySelectorInSourceCode: selectors) 
-		ifEmpty: [ self findAnyString: selectors in: aText ]
 ]
 
 { #category : #'selecting text' }
@@ -201,7 +194,7 @@ ClyMethodCodeEditorToolMorph >> findAnyVariableInSourceCode: varNames [
 
 { #category : #contexts }
 ClyMethodCodeEditorToolMorph >> findSourceNodeAt: aCursorPoint [
-	| startPosition endPosition line lineIndex  selection ast |
+	| startPosition endPosition line lineIndex  selection |
 	lineIndex := self leftSideBar lineIndexForPoint: aCursorPoint. "strangely we can't ask text morph about it"
 	line := textMorph paragraph lines at: lineIndex.	
 	startPosition := line first.
@@ -212,9 +205,9 @@ ClyMethodCodeEditorToolMorph >> findSourceNodeAt: aCursorPoint [
 		selection first >= startPosition & (selection last <= endPosition) ifTrue: [ 
 			startPosition := selection first max: 1.
 			endPosition := selection last min: self editingText size]].
-	
-	ast := self editingMethod astForStylingInCalypso.	
-	^(ast bestNodeFor: (startPosition to: endPosition)) ifNil: [ ast ]
+
+	^(self currentEditedAST bestNodeFor: (startPosition to: endPosition))
+		ifNil: [ self currentEditedAST ]
 ]
 
 { #category : #testing }
@@ -286,10 +279,14 @@ ClyMethodCodeEditorToolMorph >> selectVariableNamed: varName [
 { #category : #accessing }
 ClyMethodCodeEditorToolMorph >> selectedSourceNode [
 
-	| selectedInterval |
+	| selectedInterval ast |
 	selectedInterval := self selectedTextInterval.
-	^(editingMethod astForStylingInCalypso bestNodeFor: selectedInterval)
-		ifNil: [ editingMethod astForStylingInCalypso ]
+	
+	ast := selectedInterval isEmpty 
+		ifTrue: [ self currentEditedAST bestNodeForPosition: selectedInterval first ]
+		ifFalse: [ self currentEditedAST bestNodeFor: selectedInterval ].
+	
+	^ ast ifNil: [ self currentEditedAST ]
 ]
 
 { #category : #initialization }
@@ -326,6 +323,14 @@ ClyMethodCodeEditorToolMorph >> toggleExtendingPackage [
 	super toggleExtendingPackage.
 	
 	self hasUnacceptedEdits ifFalse: [self packageEditingMethod: editingMethod]
+]
+
+{ #category : #'as yet unclassified' }
+ClyMethodCodeEditorToolMorph >> toto [
+
+	self halt.
+	
+
 ]
 
 { #category : #updating }

--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -325,14 +325,6 @@ ClyMethodCodeEditorToolMorph >> toggleExtendingPackage [
 	self hasUnacceptedEdits ifFalse: [self packageEditingMethod: editingMethod]
 ]
 
-{ #category : #'as yet unclassified' }
-ClyMethodCodeEditorToolMorph >> toto [
-
-	self halt.
-	
-
-]
-
 { #category : #updating }
 ClyMethodCodeEditorToolMorph >> update [
 

--- a/src/Calypso-SystemTools-OldToolCompatibillity/ClyOldMessageBrowserQuery.class.st
+++ b/src/Calypso-SystemTools-OldToolCompatibillity/ClyOldMessageBrowserQuery.class.st
@@ -50,7 +50,6 @@ ClyOldMessageBrowserQuery >> decorateResultMethodEditor: aMethodEditor [
 
 	criteriaString ifNil: [ ^self ].
 	
-	"aMethodEditor selectAnyString: {criteriaString}"
 	aMethodEditor selectStringAsInMessageBrowser: criteriaString
 ]
 

--- a/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
+++ b/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
@@ -38,27 +38,11 @@ Class {
 	#category : #'Tools-CodeNavigation'
 }
 
-{ #category : #'public - extraction' }
+{ #category : #private }
 CNSelectorExtractor >> extractSelectorFromAST: ast atPosition: aPosition [
 
-	"Obtain the the best node matching the position and extracts a selector from it."
-
-	"Position Heuristic: If the previous character is not a separator, take selection one position before.
-	This heuristic is for the cases where the caret (|) is:
-	   |self foo  => the caret is before self, do not move
-	   self foo|  => the caret is before foo, interpret is as if we are in foo.
-		self foo | => the caret is before a space, interpret is as if we are in foo.
-
-	This heuristic introduces although an ambiguity when code is not nicely formatted:
-	   self foo:|#bar => Here a user may want foo: or bar.
-	For now we decided to favor foo: to motivate people to indent code correctly"
-	| offset position bestNodeAtPosition |
-	offset := (aPosition = 1 or: [ (ast sourceCode at: aPosition - 1) isSeparator ])
-		ifTrue: [ 0 ]
-		ifFalse: [ -1 ].
-
-	position := (aPosition + offset) min: ast stop.
-	bestNodeAtPosition := ast bestNodeFor: (position to: position).
+	| bestNodeAtPosition |
+	bestNodeAtPosition := ast bestNodeForPosition: aPosition.
 	^ self extractSelectorFromNode: bestNodeAtPosition
 ]
 


### PR DESCRIPTION
Introduce bestNodeForAtPosition: by moving selector extractor heuristic.

Fixes #8887

Use `self currentEditedAST` instead of `self editingMethod astForStylingInCalypso`
astForStylingInCalypso yields the AST of the original method, but does not take into account editions