### PR TITLE
add SystemDictionary>>#resetReservedVariables

### DIFF
--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -115,7 +115,7 @@ SystemDictionary >> at: aKey put: anObject [
 	^ anObject
 ]
 
-{ #category : #accessing }
+{ #category : #'variable lookup' }
 SystemDictionary >> bindingOf: varName [
 	"SystemDictionaries includes symbols only"
 	
@@ -278,7 +278,7 @@ SystemDictionary >> hasClassOrTraitNamed: aString [
 	^ false
 ]
 
-{ #category : #'dictionary access' }
+{ #category : #'variable lookup' }
 SystemDictionary >> lookupVar: name [
 	"Return a var with this name.  Return nil if none found"
 	^self reservedVariables at: name ifAbsent: [self bindingOf: name]
@@ -414,9 +414,16 @@ SystemDictionary >> renameClassNamed: oldName as: newName [
 	oldClass rename: newName
 ]
 
-{ #category : #removing }
+{ #category : #'variable lookup' }
 SystemDictionary >> reservedVariables [
+	"we cache the variables for speed"
 	^reservedVariables ifNil: [ reservedVariables := ReservedVariable lookupDictionary]
+]
+
+{ #category : #'variable lookup' }
+SystemDictionary >> resetReservedVariables [
+	"lazy init in the accessor, resetting it will take new subclasses on ReserverdVariable into account"
+	^reservedVariables := nil
 ]
 
 { #category : #'class and trait names' }


### PR DESCRIPTION
The reason is that we want to be able to add new kinds of Variables like self, thisContext as experiments.

For this we can easily add a subclass to ReserverdVariable, but we do need to make "Smalltalk globals reservedVariables" take them into account.
This can now be done by calling #resetReservedVariables. We could call this even in the name analyis by default once (need to benchmark).