### PR TITLE
Variable-model-Shadowing

### DIFF
--- a/src/GeneralRules/ReTempVarOverridesInstVarRule.class.st
+++ b/src/GeneralRules/ReTempVarOverridesInstVarRule.class.st
@@ -21,16 +21,13 @@ ReTempVarOverridesInstVarRule class >> uniqueIdentifierName [
 
 { #category : #running }
 ReTempVarOverridesInstVarRule >> check: aMethod forCritiquesDo: aCriticBlock [
-	| ivarNames problemTemps|
-	ivarNames := aMethod methodClass instVarNames.
-	ivarNames ifEmpty: [ ^ self ].
-	
-	problemTemps := ((aMethod ast arguments, aMethod ast temporaries)
-		select: [ :node |ivarNames includes: node name]).
-	problemTemps do: [ :node |
-		aCriticBlock cull: (self critiqueFor: aMethod about: node) ] 
-		
 
+	| problemTemps |
+	problemTemps := aMethod temporaryVariables select: [ :var | 
+		                var isShadowing ].
+	problemTemps do: [ :var | 
+		aCriticBlock cull:
+			(self critiqueFor: aMethod about: var definingNode) ]
 ]
 
 { #category : #'running-helpers' }
@@ -51,5 +48,5 @@ ReTempVarOverridesInstVarRule >> group [
 
 { #category : #accessing }
 ReTempVarOverridesInstVarRule >> name [
-	^ 'Instance variable overridden by temporary variable'
+	^ 'Instance variable shadowed by temporary variable'
 ]

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -601,6 +601,13 @@ Character >> isDigit [
 
 ]
 
+{ #category : #testing }
+Character >> isDoubleQuote [
+	"Returns whether the receiver is a Double Quote"
+
+	^ self = $"
+]
+
 { #category : #'testing unicode' }
 Character >> isEnclosingMark [
 	"Return whether the receiver is ... one of these https://www.compart.com/en/unicode/category/Me"
@@ -795,13 +802,6 @@ Character >> isUppercase [
 
 	^ self characterSet isUppercase: self
 
-]
-
-{ #category : #testing }
-Character >> isDoubleQuote [
-	"Returns whether the receiver is a Double Quote"
-
-	^ self = $"
 ]
 
 { #category : #testing }

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -192,6 +192,11 @@ Variable >> isSelfVariable [
 ]
 
 { #category : #testing }
+Variable >> isShadowing [
+	^self hasProperty: #shadows
+]
+
+{ #category : #testing }
 Variable >> isSuperVariable [
 	^false
 ]
@@ -324,6 +329,11 @@ Variable >> removeProperty: propName ifAbsent: aBlock [
 { #category : #accessing }
 Variable >> scope [
 	^self subclassResponsibility
+]
+
+{ #category : #accessing }
+Variable >> shadowing: anotherVariable [
+	self propertyAt: #shadows put: anotherVariable
 ]
 
 { #category : #queries }

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -69,15 +69,16 @@ OCASTSemanticAnalyzer >> declareTemporaryNode: aVariableNode [
 
 { #category : #variables }
 OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode as: anOCTempVariable [
-	| name var |
-	name := aVariableNode name.
+	| name var shadowed |
+	name := aVariableNode name. 
 	var := scope lookupVarForDeclaration: name.
 	var ifNotNil: [ 
-		"Another variable with same name is visible from current scope.
-		Warn about the name clash and if proceed add new temp to shadow existing var" 
-		self variable: aVariableNode shadows: var ].
+		"Another variable with same name is visible from current scope"
+		shadowed := var.
+		].
 	var := scope addTemp: anOCTempVariable.
 	aVariableNode binding: var.
+	shadowed ifNotNil: [self variable: var shadows: shadowed inNode: aVariableNode].
 	^ var
 ]
 
@@ -155,11 +156,12 @@ OCASTSemanticAnalyzer >> unusedVariable: variableNode [
 ]
 
 { #category : #'error handling' }
-OCASTSemanticAnalyzer >> variable: variableNode shadows: semVar [
-	compilationContext optionSkipSemanticWarnings ifTrue: [ ^semVar ].
+OCASTSemanticAnalyzer >> variable: aVariable shadows: shadowedVariable inNode: variableNode [
+	aVariable shadowing: shadowedVariable. 
+	compilationContext optionSkipSemanticWarnings ifTrue: [ ^aVariable ].
 	^ OCShadowVariableWarning new
 		node: variableNode;
-		shadowedVar: semVar;
+		shadowedVar: aVariable;
 		compilationContext: compilationContext;
 		signal
 ]

--- a/src/OpalCompiler-Core/OCShadowVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCShadowVariableWarning.class.st
@@ -11,10 +11,11 @@ Class {
 }
 
 { #category : #correcting }
-OCShadowVariableWarning >> defaultAction [ 
+OCShadowVariableWarning >> defaultAction [
 
-	^ self resume: (self variable: self node shadows: self shadowedVar)
-	
+	^ self resume: (compilationContext interactive
+			   ifTrue: [ self raiseSemanticError ]
+			   ifFalse: [ self showWarningOnTranscript ])
 ]
 
 { #category : #accessing }
@@ -28,6 +29,16 @@ OCShadowVariableWarning >> node: aVariableNode [
 { #category : #correcting }
 OCShadowVariableWarning >> openMenuIn: aBlock [
 	self error: 'should not be called'
+]
+
+{ #category : #correcting }
+OCShadowVariableWarning >> raiseSemanticError [
+
+	^OCSemanticError new
+		node: node;
+		compilationContext: compilationContext;
+		messageText: self stringMessage;
+		signal
 ]
 
 { #category : #accessing }
@@ -50,19 +61,6 @@ OCShadowVariableWarning >> showWarningOnTranscript [
 { #category : #accessing }
 OCShadowVariableWarning >> stringMessage [
 	^ 'Name already defined'
-]
-
-{ #category : #correcting }
-OCShadowVariableWarning >> variable: varNode shadows: semVar [
-	compilationContext interactive
-		ifTrue: [ 
-			OCSemanticError new
-				node: node;
-				compilationContext: compilationContext;
-				messageText: self stringMessage;
-				signal ]
-		ifFalse: [ self showWarningOnTranscript ].
-
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
as a prepation for #8009, this PR adds a better model for shadowed variables.

-  add #isShadowing and #shadowing: to Variable
- improve OCASTSemanticAnalyzer to set the shadowing infomation
- simplify code in OCShadowVariableWarning
- Simplfy ReTempVarOverridesInstVarRule by using #isShadowing

This does not yet enhance the rule to cover block args, but that will be very easy after we merge it.

The tagging is tested by the test for ReTempVarOverridesInstVarRule, more tests will come in a second PR.