### PR TITLE
8525-Errors--Insufficient-buffer-size-to-read-current-working-directory-at-the-launch-of-a-new-image-with-not-supported-yet-and-ever-StrikeFont-error

### DIFF
--- a/src/System-Platforms/WinPlatform.class.st
+++ b/src/System-Platforms/WinPlatform.class.st
@@ -26,32 +26,10 @@ WinPlatform >> accept: aVisitor [
 ]
 
 { #category : #accessing }
-WinPlatform >> currentWorkingDirectoryPath [
-	^ self currentWorkingDirectoryPathWithBufferSize: self defaultMaximumPathLength
-]
-
-{ #category : #'working-directory' }
-WinPlatform >> currentWorkingDirectoryPathWithBufferSize: aBufferSize [
-	| buffer |
-	<primitive: 'primitiveGetCurrentWorkingDirectory' module: '' error: ec>
-
-	buffer := Win32WideString new: aBufferSize.
-	self currentWorkingDirectoryPathWithBuffer: buffer.
-	^ buffer asString
-]
-
-{ #category : #accessing }
-WinPlatform >> defaultEncoding [
-
-	"Windows encoding is managed directly by Win32WideString class.
-	See Win32WideString class comment for more details."
-	self shouldNotImplement 
-]
-
-{ #category : #accessing }
 WinPlatform >> defaultMaximumPathLength [
-		"This method returns the default maximum path length for the getCurrentWorkingDirectory implementation. Windows default PATH_MAX is 260.  PATH_MAX is needed to avoid buffer overflow.  In case PATH_MAX is not sufficient the method currentWorkingDirectoryWithBufferSize: can be used to give desired buffer size."
-	 ^260
+		"This method returns the default maximum path length for the getCurrentWorkingDirectory implementation. Windows default PATH_MAX is 260.  PATH_MAX is needed to avoid buffer overflow.  In case PATH_MAX is not sufficient the method currentWorkingDirectoryWithBufferSize: can be used to give desired buffer size. The path can include unicode characters, so it can be longer than 260, doubling it should be enough"
+		
+	 ^ 260 * 2 
 
 ]
 
@@ -79,7 +57,12 @@ WinPlatform >> getPwdViaFFI: buffer size: bufferSize [
 	This method should be removed, as we should delegate to the VM
 	
 	We use FFI-OldFFIBackend for this because this is required for bootstrapping, and we ensure minimal dependencies."
-	^ (ExternalLibraryFunction 
+	
+	| wideString return |
+	
+	wideString := Win32WideString new: bufferSize.
+	
+	return := (ExternalLibraryFunction 
 			name: '_wgetcwd'
 			module: 'msvcrt.dll'
 			callType: 0
@@ -87,8 +70,12 @@ WinPlatform >> getPwdViaFFI: buffer size: bufferSize [
 			argumentTypes: {
 				ExternalType char asPointerType.
 				ExternalType long })
-					invokeWith: buffer getHandle with: bufferSize.
+					invokeWith: wideString getHandle with: bufferSize.
 
+	return ifNil: [ ^ nil ].
+	
+	"The primitive is returning an string that is encoded in UTF8. We need to emulate the same behavior"
+	^ wideString asString utf8Encoded asString
 ]
 
 { #category : #testing }

--- a/src/ThreadedFFI/TFFIBackend.class.st
+++ b/src/ThreadedFFI/TFFIBackend.class.st
@@ -69,10 +69,12 @@ TFFIBackend >> isAvailable [
 
 { #category : #'instance creation' }
 TFFIBackend >> loadSymbol: moduleSymbol module: module [ 
-
-	<primitive: 'primitiveLoadSymbolFromModule'>
-
-	^ self primitiveFailed
+	
+	| encodedString |
+	encodedString := module ifNotNil: [ module utf8Encoded asString ].
+	
+	"The primitive is expected the module to be a utf8Encoded String."
+	^ self primLoadSymbol: moduleSymbol module: encodedString
 ]
 
 { #category : #accessing }
@@ -114,5 +116,13 @@ TFFIBackend >> on: anObject float64At: offset put: value [
 			  index: offset
 			  value: value ].
 		
+	^ self primitiveFailed
+]
+
+{ #category : #'instance creation' }
+TFFIBackend >> primLoadSymbol: moduleSymbol module: module [ 
+
+	<primitive: 'primitiveLoadSymbolFromModule'>
+
 	^ self primitiveFailed
 ]


### PR DESCRIPTION
I cannot reproduce exactly #8525, but I have found issues with the handling of the current working directory and vm directory when executing with a path with utf8 characters.

This is affecting not only the resolution of the working directory, but the resolution of FFI calls as the libraries are next to the VM.``