### PR TITLE
Add SDL2 class >> version

### DIFF
--- a/src/OSWindow-SDL2/SDL2.class.st
+++ b/src/OSWindow-SDL2/SDL2.class.st
@@ -170,6 +170,11 @@ SDL2 class >> getQueuedAudioSize: dev [
 
 { #category : #common }
 SDL2 class >> getVersion: ver [
+	"Get the version of SDL.
+
+	See: https://wiki.libsdl.org/SDL_GetVersion
+	"
+
 	^ self ffiCall: #( void SDL_GetVersion(SDL_Version* ver) )
 ]
 
@@ -392,6 +397,17 @@ SDL2 class >> showCursor: toggle [
 SDL2 class >> ticks [
 	"Gets the number of milliseconds since the SDL library was initialized"
 	^ self ffiCall: #( Uint32 SDL_GetTicks ( ) )
+]
+
+{ #category : #common }
+SDL2 class >> version [
+	"Answer the SDL version. For example, a SDL_Version(2.0.7)."
+
+	| version |
+	version := SDL_Version new.
+	self getVersion: version.
+	version autoRelease.
+	^ version
 ]
 
 { #category : #common }

--- a/src/OSWindow-SDL2/SDL_Version.class.st
+++ b/src/OSWindow-SDL2/SDL_Version.class.st
@@ -1,5 +1,8 @@
 "
-A structure that contains information about the version of SDL in use. 
+A structure that contains information about the version of SDL in use.
+
+See:
+https://wiki.libsdl.org/SDL_version
 "
 Class {
 	#name : #'SDL_Version',
@@ -63,4 +66,27 @@ SDL_Version >> patch [
 SDL_Version >> patch: anObject [
 	"This method was automatically generated"
 	handle unsignedByteAt: OFFSET_PATCH put: anObject
+]
+
+{ #category : #printing }
+SDL_Version >> printAsSemanticVersioningOn: aStream [
+	"Print in format MAJOR.MINOR.PATCH."
+
+	aStream
+		print: self major;
+		nextPut: $.;
+		print: self minor;
+		nextPut: $.;
+		print: self patch
+
+]
+
+{ #category : #printing }
+SDL_Version >> printOn: aStream [
+	"Append a sequence of characters to aStream that identify the receiver."
+
+	super printOn: aStream.
+	aStream nextPut: $(.
+	self printAsSemanticVersioningOn: aStream.
+	aStream nextPut: $)
 ]


### PR DESCRIPTION
The FFI call was already present but it is not direct to obtain
the result from the workspace. Now it only printing 
`SDL2 version`.

Added in class-side in coincidence with other similar methods
in that class.

Also added a printOn: to ease reading.