### PR TITLE
testNoUnusedInstanceVariablesLeft-down-to-19

### DIFF
--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -43,7 +43,7 @@ NoUnusedVariablesLeftTest >> testNoUnusedInstanceVariablesLeft [
 	
 	"we have 25 left, there are issue tracker entries for those.
  	By testing for these, we avoid that new cases are added"
- 	self assert: remaining size <= 25
+ 	self assert: remaining size <= 19
 ]
 
 { #category : #testing }


### PR DESCRIPTION
After merging newtools/spec, we are down to 19 classes with ivars defined that are not used

