### PR TITLE
8009-Rule-required-for-shadowed-variables 

### DIFF
--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -1069,9 +1069,16 @@ RBProgramNode >> uses: aNode [
 ]
 
 { #category : #querying }
+RBProgramNode >> variableDefinitionNodes [
+	^ self allChildren select: [ :each | 
+		  each isVariable and: [ each isDefinition ] ]
+]
+
+{ #category : #querying }
 RBProgramNode >> variableNodes [
-		^self allChildren select: [:each | 
-			each isVariable and: [each isDefinition not]].
+
+	^ self allChildren select: [ :each | 
+		  each isVariable and: [ each isDefinition not ] ]
 ]
 
 { #category : #querying }

--- a/src/GeneralRules-Tests/ReTempVarOverridesInstVarRuleTest.class.st
+++ b/src/GeneralRules-Tests/ReTempVarOverridesInstVarRuleTest.class.st
@@ -47,7 +47,8 @@ ReTempVarOverridesInstVarRuleTest >> testRule [
 	| critiques |
 	critiques := self myCritiquesOnMethod: self class >> #sampleMethod:.
 	
-	self assert: critiques size equals: 2.
+	self assert: critiques size equals: 3.
+	self assert: (self sourceAtChritique:  critiques first) equals: 'dummy1'.
 	self assert: (self sourceAtChritique:  critiques second) equals: 'dummy2'.
-	
+	self assert: (self sourceAtChritique:  critiques third) equals: 'dummy3'.
 ]

--- a/src/GeneralRules/ReTempVarOverridesInstVarRule.class.st
+++ b/src/GeneralRules/ReTempVarOverridesInstVarRule.class.st
@@ -23,8 +23,9 @@ ReTempVarOverridesInstVarRule class >> uniqueIdentifierName [
 ReTempVarOverridesInstVarRule >> check: aMethod forCritiquesDo: aCriticBlock [
 
 	| problemTemps |
-	problemTemps := aMethod temporaryVariables select: [ :var | 
-		                var isShadowing ].
+	problemTemps := aMethod ast variableDefinitionNodes 
+		 collect: [ :node | node variable ]
+		 thenSelect: [ :var | var isShadowing ].
 	problemTemps do: [ :var | 
 		aCriticBlock cull:
 			(self critiqueFor: aMethod about: var definingNode) ]
@@ -48,5 +49,5 @@ ReTempVarOverridesInstVarRule >> group [
 
 { #category : #accessing }
 ReTempVarOverridesInstVarRule >> name [
-	^ 'Instance variable shadowed by temporary variable'
+	^ 'Outer variable shadowed by temporary variable or argument'
 ]


### PR DESCRIPTION
This now fixes #8009 by changing ReTempVarOverridesInstVarRule to check *all* defined variables in a method.


Interestingly, the existing test data already has a case for this, we just need to fix the test to test for the case of block args shadowing instance variables.

- The rule of course can now be further improved to exactly tell the user what is shadowed
- We should add a release test to make sure we have no shadowed vars in the system
- We should add a rule that checks of instance or class vars shadow globals (which needs further refinement on the shadow model) 

 but that is for the  future 

Fixes #8009