### PR TITLE
8814-Is-registerBreakableIndex-still-needed

### DIFF
--- a/src/Deprecated90/CompositionScanner.extension.st
+++ b/src/Deprecated90/CompositionScanner.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #CompositionScanner }
+
+{ #category : #'*Deprecated90' }
+CompositionScanner >> registerBreakableIndex [
+	"Record left x and character index of the line-wrappable point. 
+	Used for wrap-around in eastern Asian languages."
+	
+	self deprecated: 'only sender was deprecated in Pharo9'.
+	spaceX := destX.
+	lineHeightAtSpace := lineHeight.
+	baselineAtSpace := baseline.
+	spaceIndex := lastIndex.
+	lastBreakIsNotASpace := true.
+]

--- a/src/Deprecated90/RubCharacterScanner.extension.st
+++ b/src/Deprecated90/RubCharacterScanner.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #RubCharacterScanner }
+
+{ #category : #'*Deprecated90' }
+RubCharacterScanner >> registerBreakableIndex [
+
+	"Record left x and character index of the line-wrappable point. 
+	The default implementation here does nothing."
+	self deprecated: 'only sender was deprecated in Pharo9'.
+
+	^ false.
+
+]

--- a/src/Deprecated90/RubCompositionScanner.extension.st
+++ b/src/Deprecated90/RubCompositionScanner.extension.st
@@ -1,0 +1,28 @@
+Extension { #name : #RubCompositionScanner }
+
+{ #category : #'*Deprecated90' }
+RubCompositionScanner >> registerBreakableIndex [
+
+	"Record left x and character index of the line-wrappable point. 
+	Used for wrap-around. Answer whether the character has crossed the 
+	right edge of the composition rectangle of the paragraph."
+
+	self deprecated: 'only sender was deprecated in Pharo9'.
+
+	(text at: lastIndex) = Character space ifTrue: [
+		breakAtSpace := true.
+		spaceX := destX.
+		spaceCount := spaceCount + 1.
+		lineHeightAtBreak := lineHeight.
+		baselineAtBreak := baseline.
+		breakableIndex := lastIndex.
+		destX > rightMargin ifTrue: 	[^self crossedX].
+	] ifFalse: [
+		breakAtSpace := false.
+		lineHeightAtBreak := lineHeight.
+		baselineAtBreak := baseline.
+		breakableIndex := lastIndex - 1.
+	].
+	^ false.
+
+]

--- a/src/Rubric/RubCharacterScanner.class.st
+++ b/src/Rubric/RubCharacterScanner.class.st
@@ -256,16 +256,6 @@ RubCharacterScanner >> plainTab [
 	firstDestX  := destX.
 ]
 
-{ #category : #'multilingual scanning' }
-RubCharacterScanner >> registerBreakableIndex [
-
-	"Record left x and character index of the line-wrappable point. 
-	The default implementation here does nothing."
-
-	^ false.
-
-]
-
 { #category : #scanning }
 RubCharacterScanner >> scanCharactersFrom: startIndex to: stopIndex in: sourceString rightX: rightX stopConditions: stops kern: kernDelta [
 

--- a/src/Rubric/RubCompositionScanner.class.st
+++ b/src/Rubric/RubCompositionScanner.class.st
@@ -158,31 +158,6 @@ RubCompositionScanner >> placeEmbeddedObject: anchoredMorph [
 	^ true
 ]
 
-{ #category : #'multilingual scanning' }
-RubCompositionScanner >> registerBreakableIndex [
-
-	"Record left x and character index of the line-wrappable point. 
-	Used for wrap-around. Answer whether the character has crossed the 
-	right edge of the composition rectangle of the paragraph."
-
-	(text at: lastIndex) = Character space ifTrue: [
-		breakAtSpace := true.
-		spaceX := destX.
-		spaceCount := spaceCount + 1.
-		lineHeightAtBreak := lineHeight.
-		baselineAtBreak := baseline.
-		breakableIndex := lastIndex.
-		destX > rightMargin ifTrue: 	[^self crossedX].
-	] ifFalse: [
-		breakAtSpace := false.
-		lineHeightAtBreak := lineHeight.
-		baselineAtBreak := baseline.
-		breakableIndex := lastIndex - 1.
-	].
-	^ false.
-
-]
-
 { #category : #accessing }
 RubCompositionScanner >> rightX [
 	"Meaningful only when a line has just been composed -- refers to the 

--- a/src/Text-Scanning/CompositionScanner.class.st
+++ b/src/Text-Scanning/CompositionScanner.class.st
@@ -212,18 +212,6 @@ CompositionScanner >> placeEmbeddedObject: anchoredMorph [
 	^ true
 ]
 
-{ #category : #'multilingual scanning' }
-CompositionScanner >> registerBreakableIndex [
-	"Record left x and character index of the line-wrappable point. 
-	Used for wrap-around in eastern Asian languages."
-
-	spaceX := destX.
-	lineHeightAtSpace := lineHeight.
-	baselineAtSpace := baseline.
-	spaceIndex := lastIndex.
-	lastBreakIsNotASpace := true.
-]
-
 { #category : #accessing }
 CompositionScanner >> rightX [
 	"Meaningful only when a line has just been composed -- refers to the 


### PR DESCRIPTION
deprecate registerBreakableIndex as the only sender was deprecated. It is in the repo fi we need it in the future

fixes #8814

