### PR TITLE
fixes #8918 the SpLabelledContainer examples are over engineered

### DIFF
--- a/src/Spec2-Core/SpLabelledDropList.class.st
+++ b/src/Spec2-Core/SpLabelledDropList.class.st
@@ -64,20 +64,20 @@ SpLabelledDropList >> selectedItem [
 
 { #category : #'api-shortcuts' }
 SpLabelledDropList >> setIndex: anIndex [
-	^self dropList setIndex: anIndex
+	^self dropList selectIndex: anIndex
 ]
 
 { #category : #'events-shortcuts' }
 SpLabelledDropList >> whenSelectedItemChanged: aBlock [
-	self dropList whenSelectedItemChanged: aBlock
+	self dropList whenSelectedItemChangedDo: aBlock
 ]
 
 { #category : #'events-shortcuts' }
 SpLabelledDropList >> whenSelectionChanged: aBlock [
-	self dropList whenSelectionChanged: aBlock
+	self dropList whenSelectionChangedDo: aBlock
 ]
 
 { #category : #'events-shortcuts' }
 SpLabelledDropList >> whenSelectionIndexChanged: aBlock [
-	self dropList whenSelectionIndexChanged: aBlock
+	self dropList whenSelectionChangedDo: [:selectionMode | aBlock value: selectionMode selectedIndex]
 ]

--- a/src/Spec2-Core/SpLabelledList.class.st
+++ b/src/Spec2-Core/SpLabelledList.class.st
@@ -76,15 +76,16 @@ SpLabelledList >> sortingBlock: aBlock [
 
 { #category : #'events-shortcuts' }
 SpLabelledList >> whenSelectedItemChanged: aBlock [
-self list whenSelectedItemChanged: aBlock
+self list whenSelectionChangedDo: [:selectionMode | aBlock value: (selectionMode selectedItem)]
 ]
 
 { #category : #'events-shortcuts' }
 SpLabelledList >> whenSelectionChanged: aBlock [
-	self list whenSelectionChanged: aBlock
+	"aBlock is passed the instance of SpSingleSelectionMode from list"
+	self list whenSelectionChangedDo: aBlock
 ]
 
 { #category : #'events-shortcuts' }
 SpLabelledList >> whenSelectionIndexChanged: aBlock [
-	self list whenSelectionIndexChanged: aBlock
+	self list whenSelectionChangedDo: [:selectionMode | aBlock value: (selectionMode selectedIndex)]
 ]

--- a/src/Spec2-Core/SpLabelledTextInput.class.st
+++ b/src/Spec2-Core/SpLabelledTextInput.class.st
@@ -72,14 +72,14 @@ SpLabelledTextInput >> text: aText [
 
 { #category : #'api-events' }
 SpLabelledTextInput >> whenSubmitDo: aBlock [
-
-	self input whenSubmitDo: aBlock
+	"aBlock is executed on meta-s or CR. It is passed the final string value of the field as parameter"
+	self input whenSubmitDo: [:morph | aBlock value: (morph text asString)]
 ]
 
 { #category : #'api-events' }
 SpLabelledTextInput >> whenTextChanged: aBlock [
 
-	self input whenTextChanged: aBlock
+	self input whenTextChangedDo: aBlock
 ]
 
 { #category : #'api-events' }

--- a/src/Spec2-Examples/SpLabelledDropList.extension.st
+++ b/src/Spec2-Examples/SpLabelledDropList.extension.st
@@ -13,3 +13,20 @@ SpLabelledDropList class >> setUpExample: example [
 		display: [ :item | item asString ];
 		extent: 400 @ 50
 ]
+
+{ #category : #'*Spec2-Examples' }
+SpLabelledDropList class >> simpleExample [
+	<example>
+	^ (self new
+		label: 'droplist label';
+		items:#('stef' 'marcus' 'sven' 'norbert' 'guille' 'esteban');
+		display: [ :item | item capitalized  ];
+		setIndex: 5;
+		whenSelectedItemChanged:  
+			[ :item | Transcript nextPutAll: item asString;cr;endEntry  ];
+		whenSelectionChanged: 
+			[ :selection | Transcript nextPutAll: selection isEmpty asString;cr;endEntry ];
+		whenSelectionIndexChanged: 
+			[ :index | Transcript nextPutAll: index asString;cr;endEntry ]	)
+	openWithSpec
+]

--- a/src/Spec2-Examples/SpLabelledDropList.extension.st
+++ b/src/Spec2-Examples/SpLabelledDropList.extension.st
@@ -18,6 +18,7 @@ SpLabelledDropList class >> setUpExample: example [
 SpLabelledDropList class >> simpleExample [
 	<example>
 	^ (self new
+		layout: self labelRight ;
 		label: 'droplist label';
 		items:#('stef' 'marcus' 'sven' 'norbert' 'guille' 'esteban');
 		display: [ :item | item capitalized  ];

--- a/src/Spec2-Examples/SpLabelledList.extension.st
+++ b/src/Spec2-Examples/SpLabelledList.extension.st
@@ -10,3 +10,20 @@ SpLabelledList class >> example [
 SpLabelledList class >> setUpExample: example [
 	example items: {'item 1' . 'item 2'}
 ]
+
+{ #category : #'*Spec2-Examples' }
+SpLabelledList class >> simpleExample [
+	<example>
+	^ (self new
+		label: 'list label';
+		items:#('stef' 'marcus' 'sven' 'norbert' 'guille' 'esteban');
+		display: [ :item | item capitalized  ];
+		sortingBlock: [ :n1 :n2 | n1 last < n2 last ];
+		whenSelectedItemChanged:  
+			[ :item | Transcript nextPutAll: item asString;cr;endEntry  ];
+		whenSelectionChanged: 
+			[ :selection | Transcript nextPutAll: selection isEmpty asString;cr;endEntry ];
+		whenSelectionIndexChanged: 
+			[ :index | Transcript nextPutAll: index asString;cr;endEntry ])
+	openWithSpec
+]

--- a/src/Spec2-Examples/SpLabelledList.extension.st
+++ b/src/Spec2-Examples/SpLabelledList.extension.st
@@ -15,6 +15,7 @@ SpLabelledList class >> setUpExample: example [
 SpLabelledList class >> simpleExample [
 	<example>
 	^ (self new
+		layout: self labelTop ;
 		label: 'list label';
 		items:#('stef' 'marcus' 'sven' 'norbert' 'guille' 'esteban');
 		display: [ :item | item capitalized  ];

--- a/src/Spec2-Examples/SpLabelledSliderInput.extension.st
+++ b/src/Spec2-Examples/SpLabelledSliderInput.extension.st
@@ -20,6 +20,7 @@ SpLabelledSliderInput class >> setUpExample: example [
 SpLabelledSliderInput class >> simpleExample [
 	<example>
 	^ (self new
+		layout: self labelLeft ;
 		label: 'slider label';
 		min: 10;
 		max: 90;

--- a/src/Spec2-Examples/SpLabelledSliderInput.extension.st
+++ b/src/Spec2-Examples/SpLabelledSliderInput.extension.st
@@ -15,3 +15,16 @@ SpLabelledSliderInput class >> setUpExample: example [
 		value: 120;
 		extent: 400 @ 50
 ]
+
+{ #category : #'*Spec2-Examples' }
+SpLabelledSliderInput class >> simpleExample [
+	<example>
+	^ (self new
+		label: 'slider label';
+		min: 10;
+		max: 90;
+		value: 25;
+		whenValueChangedDo:  
+			[ :new :old| Transcript nextPutAll: new asString;cr;endEntry  ] )
+	openWithSpec
+]

--- a/src/Spec2-Examples/SpLabelledTextInput.extension.st
+++ b/src/Spec2-Examples/SpLabelledTextInput.extension.st
@@ -16,6 +16,7 @@ SpLabelledTextInput class >> setUpExample: example [
 SpLabelledTextInput class >> simpleExample [
 	<example>
 	^ (self new
+		layout: self labelTop ;
 		label: 'simple text field'; 
 		text: 'text to be edited';
 		whenTextChanged:  

--- a/src/Spec2-Examples/SpLabelledTextInput.extension.st
+++ b/src/Spec2-Examples/SpLabelledTextInput.extension.st
@@ -11,3 +11,16 @@ SpLabelledTextInput class >> setUpExample: example [
 	example input placeholder: 'Tilt'.
 	example extent: 400 @ 50
 ]
+
+{ #category : #'*Spec2-Examples' }
+SpLabelledTextInput class >> simpleExample [
+	<example>
+	^ (self new
+		label: 'simple text field'; 
+		text: 'text to be edited';
+		whenTextChanged:  
+			[ :newText| Transcript nextPutAll: newText;cr;endEntry  ];
+		whenSubmitDo: 
+			[ :finalText |  Transcript nextPutAll: 'Done: ', finalText;cr;endEntry] )
+	openWithSpec
+]


### PR DESCRIPTION
Added simpler examples to the four concrete subclasses.