### PR TITLE
Speedup-reflective-read-IndexedSlot

### DIFF
--- a/src/Kernel/IndexedSlot.class.st
+++ b/src/Kernel/IndexedSlot.class.st
@@ -49,11 +49,38 @@ IndexedSlot >> isVirtual [
 ]
 
 { #category : #'meta-object-protocol' }
+IndexedSlot >> object: anObject instVarAt: anIndex [
+	"Primitive. Answer a fixed variable in an object. The numbering of the 
+	 variables corresponds to the named instance variables. Fail if the index 
+	 is not an Integer or is not the index of a fixed variable. Essential for the
+	 debugger. See  Object documentation whatIsAPrimitive."
+
+	<primitive: 73>
+	"instead of copying the fail code here, just call the method that has it"
+	^thisContext object: anObject instVarAt: anIndex
+]
+
+{ #category : #'meta-object-protocol' }
+IndexedSlot >> object: anObject instVarAt: anIndex put: aValue [ 
+	"Primitive. Store a value into a fixed variable in the argument anObject.
+	 The numbering of the variables corresponds to the named instance
+	 variables.  Fail if the index is not an Integer or is not the index of a
+	 fixed variable.  Answer the value stored as the result. Using this
+	 message violates the  principle that each object has sovereign control
+	 over the storing of values into its instance variables. Essential for the
+	 debugger. See Object documentation whatIsAPrimitive."
+
+	<primitive: 74>
+	"instead of copying the fail code here, just call the method that has it"
+	^thisContext object: anObject instVarAt: anIndex put: aValue 
+]
+
+{ #category : #'meta-object-protocol' }
 IndexedSlot >> read: anObject [
-	^ thisContext object: anObject instVarAt: index
+	^ self object: anObject instVarAt: index
 ]
 
 { #category : #'meta-object-protocol' }
 IndexedSlot >> write: aValue to: anObject [
-	^ thisContext object: anObject instVarAt: index put: aValue
+	^ self object: anObject instVarAt: index put: aValue
 ]


### PR DESCRIPTION
Read and Write of indexed instance variables via the variable (IndexedSlot or a subclass) is using the mirror method on thisContext.


(thus we can read ivars from objects without sending a message to them, Variables thus can be understood to be special kinds of Mirror objects)

```Smalltalk
read: anObject
	^ thisContext object: anObject instVarAt: index
```

But this means that we have to reference thisContext... which the VM does not like (it is slow).

The actual primitives do not care about the receiver, we can just copy them and implement them in IndexSlot:

```Smalltalk
read: anObject
	^ self object: anObject instVarAt: index
```

A simple naive benchmark:

```
slot := Point slotNamed: #x.
[slot read: 4@4 ] bench  

before: "'12863984.406 per second'"
after: "'28472842.495 per second'"
```

Which means this is indeed faster, with not changing the complexity too much.