### PR TITLE
Shadowing-Better-Implementation

### DIFF
--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -193,7 +193,10 @@ Variable >> isSelfVariable [
 
 { #category : #testing }
 Variable >> isShadowing [
-	^self hasProperty: #shadows
+	| outer |
+	outer := self scope outerScope.
+	
+	^(outer ifNotNil: [self scope outerScope lookupVar: self name]) notNil
 ]
 
 { #category : #testing }
@@ -329,11 +332,6 @@ Variable >> removeProperty: propName ifAbsent: aBlock [
 { #category : #accessing }
 Variable >> scope [
 	^self subclassResponsibility
-]
-
-{ #category : #accessing }
-Variable >> shadowing: anotherVariable [
-	self propertyAt: #shadows put: anotherVariable
 ]
 
 { #category : #queries }

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -193,10 +193,8 @@ Variable >> isSelfVariable [
 
 { #category : #testing }
 Variable >> isShadowing [
-	| outer |
-	outer := self scope outerScope.
-	
-	^(outer ifNotNil: [self scope outerScope lookupVar: self name]) notNil
+	"I shadow a variable if looking up my name in the outer scope returns a variable"
+	^(self scope outerScope ifNotNil: [:outer | outer lookupVar: self name]) notNil
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -86,6 +86,11 @@ Behavior >> lookupVarForDeclaration: name [
 ]
 
 { #category : #'*OpalCompiler-Core' }
+Behavior >> outerScope [
+	^self environment
+]
+
+{ #category : #'*OpalCompiler-Core' }
 Behavior >> recompile [
 	self compileAll
 ]

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -157,7 +157,6 @@ OCASTSemanticAnalyzer >> unusedVariable: variableNode [
 
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> variable: aVariable shadows: shadowedVariable inNode: variableNode [
-	aVariable shadowing: shadowedVariable. 
 	compilationContext optionSkipSemanticWarnings ifTrue: [ ^aVariable ].
 	^ OCShadowVariableWarning new
 		node: variableNode;

--- a/src/Slot-Tests/ClassVariableTest.class.st
+++ b/src/Slot-Tests/ClassVariableTest.class.st
@@ -18,6 +18,14 @@ ClassVariableTest >> testIsReadInMethod [
 	self assert: ((TestCase classVariableNamed: #DefaultTimeLimit) isReadIn: self class >> testSelector)
 ]
 
+{ #category : #tests }
+ClassVariableTest >> testIsShadowing [
+	| variable |
+	variable := SmalltalkImage classVariableNamed: #CompilerClass.
+	self deny: variable isShadowing
+
+]
+
 { #category : #'tests  - properties' }
 ClassVariableTest >> testIsWrittenInMethod [
 

--- a/src/Slot-Tests/GlobalVariableTest.class.st
+++ b/src/Slot-Tests/GlobalVariableTest.class.st
@@ -15,6 +15,11 @@ GlobalVariableTest >> testIsReadInMethod [
 							isReadIn: self class >> testSelector).
 ]
 
+{ #category : #tests }
+GlobalVariableTest >> testIsShadowing [
+	self deny: Object binding isShadowing
+]
+
 { #category : #'tests  - properties' }
 GlobalVariableTest >> testNotWrittenInMethod [
 

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -313,6 +313,11 @@ SystemDictionary >> organization: anOrganization [
 	^self at: #SystemOrganization put: anOrganization
 ]
 
+{ #category : #'variable lookup' }
+SystemDictionary >> outerScope [
+	^nil
+]
+
 { #category : #accessing }
 SystemDictionary >> poolUsers [
 	"Answer a dictionary of pool name -> classes that refer to it.


### PR DESCRIPTION
We should think about Shadowed Variables on the level of the class

Classes define instance variables (modeled by subclasses of Slot) and Class Variables. They can shadow Variables from the environment that the class is in (normally this is Smalltalk Globals).

We should extend the concept of Shadowed variables to over these cases, too. 

Imagine we have a class that has a class variable "Person". Then we add a class named "Person": The class variable is now shadowing the class. #isShadowing is just checking for the property. But here we run into a problem: who could set the property? The classbuilder could do it. But adding a class then would mean that we would need to check all existing classes if the new global is shadowed somewhere.

And we would not just have to check the classes: nothing forbids us to use a block argument "Person"... thus we would need to re-analyse all code globally. Not a good idea in a system where current users might have >100K classes...

Thus: we need to rethink our solution. It was not wrong: we were concened with just modeling shadowing for methods, the solution to tag the variables was a good one for that use. But now we need to step back. What is shadowing again? It means that the outer scope of a variable has  already a variable of the same name. 

Interestingly, the Variable model is already modeling all the needed information. We can just change  #isShadowing to do that:

```Smalltalk
isShadowing
	"I shadow a variable if looking up my name in the outer scope returns a variable"
	^(self scope outerScope ifNotNil: [:outer | outer lookupVar: self name]) notNil
```

We just have to add a missing #outerScope method to Behavior (as the outer scope is called the environment here). And it works! The tests we did for shadowing are still green.