### PR TITLE
AST-Tag-ErrorNodes

### DIFF
--- a/src/AST-Core/RBArrayErrorNode.class.st
+++ b/src/AST-Core/RBArrayErrorNode.class.st
@@ -9,7 +9,7 @@ or the closure : { array node .
 Class {
 	#name : #RBArrayErrorNode,
 	#superclass : #RBEnglobingErrorNode,
-	#category : #'AST-Core-Nodes'
+	#category : #'AST-Core-Nodes - ErrorNodes'
 }
 
 { #category : #construction }

--- a/src/AST-Core/RBBlockErrorNode.class.st
+++ b/src/AST-Core/RBBlockErrorNode.class.st
@@ -9,7 +9,7 @@ or the closure : [ block node .
 Class {
 	#name : #RBBlockErrorNode,
 	#superclass : #RBEnglobingErrorNode,
-	#category : #'AST-Core-Nodes'
+	#category : #'AST-Core-Nodes - ErrorNodes'
 }
 
 { #category : #construction }

--- a/src/AST-Core/RBEnglobingErrorNode.class.st
+++ b/src/AST-Core/RBEnglobingErrorNode.class.st
@@ -17,7 +17,7 @@ Class {
 	#instVars : [
 		'content'
 	],
-	#category : #'AST-Core-Nodes'
+	#category : #'AST-Core-Nodes - ErrorNodes'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/AST-Core/RBInvalidCascadeErrorNode.class.st
+++ b/src/AST-Core/RBInvalidCascadeErrorNode.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #RBInvalidCascadeErrorNode,
 	#superclass : #RBEnglobingErrorNode,
-	#category : #'AST-Core-Nodes'
+	#category : #'AST-Core-Nodes - ErrorNodes'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/AST-Core/RBLiteralArrayErrorNode.class.st
+++ b/src/AST-Core/RBLiteralArrayErrorNode.class.st
@@ -8,7 +8,7 @@ Forgetting the opening will be assumed to be a parentheses node.
 Class {
 	#name : #RBLiteralArrayErrorNode,
 	#superclass : #RBEnglobingErrorNode,
-	#category : #'AST-Core-Nodes'
+	#category : #'AST-Core-Nodes - ErrorNodes'
 }
 
 { #category : #construction }

--- a/src/AST-Core/RBLiteralByteArrayErrorNode.class.st
+++ b/src/AST-Core/RBLiteralByteArrayErrorNode.class.st
@@ -8,7 +8,7 @@ Forgetting the opening will be assumed to be a block node.
 Class {
 	#name : #RBLiteralByteArrayErrorNode,
 	#superclass : #RBEnglobingErrorNode,
-	#category : #'AST-Core-Nodes'
+	#category : #'AST-Core-Nodes - ErrorNodes'
 }
 
 { #category : #construction }

--- a/src/AST-Core/RBMissingOpenerErrorNode.class.st
+++ b/src/AST-Core/RBMissingOpenerErrorNode.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #RBMissingOpenerErrorNode,
 	#superclass : #RBEnglobingErrorNode,
-	#category : #'AST-Core-Nodes'
+	#category : #'AST-Core-Nodes - ErrorNodes'
 }

--- a/src/AST-Core/RBParenthesesErrorNode.class.st
+++ b/src/AST-Core/RBParenthesesErrorNode.class.st
@@ -9,7 +9,7 @@ or the closure : ( parentheses node .
 Class {
 	#name : #RBParenthesesErrorNode,
 	#superclass : #RBEnglobingErrorNode,
-	#category : #'AST-Core-Nodes'
+	#category : #'AST-Core-Nodes - ErrorNodes'
 }
 
 { #category : #construction }

--- a/src/AST-Core/RBParseErrorNode.class.st
+++ b/src/AST-Core/RBParseErrorNode.class.st
@@ -19,7 +19,7 @@ Class {
 		'start',
 		'stop'
 	],
-	#category : #'AST-Core-Nodes'
+	#category : #'AST-Core-Nodes - ErrorNodes'
 }
 
 { #category : #'instance creation' }

--- a/src/AST-Core/RBPragmaErrorNode.class.st
+++ b/src/AST-Core/RBPragmaErrorNode.class.st
@@ -8,7 +8,7 @@ Forgetting the opening will be assumed to be a binary selector.
 Class {
 	#name : #RBPragmaErrorNode,
 	#superclass : #RBEnglobingErrorNode,
-	#category : #'AST-Core-Nodes'
+	#category : #'AST-Core-Nodes - ErrorNodes'
 }
 
 { #category : #construction }

--- a/src/AST-Core/RBTemporariesErrorNode.class.st
+++ b/src/AST-Core/RBTemporariesErrorNode.class.st
@@ -8,7 +8,7 @@ Forgetting the opening will be assumed to be a binary selector.
 Class {
 	#name : #RBTemporariesErrorNode,
 	#superclass : #RBEnglobingErrorNode,
-	#category : #'AST-Core-Nodes'
+	#category : #'AST-Core-Nodes - ErrorNodes'
 }
 
 { #category : #construction }

--- a/src/AST-Core/RBUnfinishedStatementErrorNode.class.st
+++ b/src/AST-Core/RBUnfinishedStatementErrorNode.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #RBUnfinishedStatementErrorNode,
 	#superclass : #RBEnglobingErrorNode,
-	#category : #'AST-Core-Nodes'
+	#category : #'AST-Core-Nodes - ErrorNodes'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/AST-Core/RBUnreachableStatementErrorNode.class.st
+++ b/src/AST-Core/RBUnreachableStatementErrorNode.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #RBUnreachableStatementErrorNode,
 	#superclass : #RBEnglobingErrorNode,
-	#category : #'AST-Core-Nodes'
+	#category : #'AST-Core-Nodes - ErrorNodes'
 }
 
 { #category : #visiting }


### PR DESCRIPTION
When showing the AST to students, I always say that it is nice to have not many node classes.

This PR moves all the nodes related to errors to it's own tag. This way the main AST nodes can be seen without having yet to care about Error Nodes.

