### PR TITLE
8932-CI-failure-ArrayTestClassTestCasetestMethodsOfTheClassShouldNotBeRepeatedInItsSuperclasses

### DIFF
--- a/src/GT-Spotter-Processors/SptEntry.class.st
+++ b/src/GT-Spotter-Processors/SptEntry.class.st
@@ -63,12 +63,6 @@ SptEntry >> evaluateFor: aGTSpotterStep [
 	aGTSpotterStep exit.
 ]
 
-{ #category : #'spotter-extensions' }
-SptEntry >> gtDisplayString [
-	self deprecated: 'Use displayString' transformWith: '`@receiver gtDisplayString' -> '`@receiver displayString'.
-	^ self displayString
-]
-
 { #category : #comparing }
 SptEntry >> hash [
 

--- a/src/NewTools-Inspector-Extensions/Array.extension.st
+++ b/src/NewTools-Inspector-Extensions/Array.extension.st
@@ -5,9 +5,3 @@ Array >> displayString [
 
 	^ super displayString contractTo: 200
 ]
-
-{ #category : #'*NewTools-Inspector-Extensions' }
-Array >> gtDisplayString [
-	self deprecated: 'Use displayString' transformWith: '`@receiver gtDisplayString' -> '`@receiver displayString'.
-	^ self displayString
-]

--- a/src/NewTools-Spotter-Processors/StEntry.class.st
+++ b/src/NewTools-Spotter-Processors/StEntry.class.st
@@ -63,12 +63,6 @@ StEntry >> evaluateFor: aGTSpotterStep [
 	aGTSpotterStep exit.
 ]
 
-{ #category : #'spotter-extensions' }
-StEntry >> gtDisplayString [
-	self deprecated: 'Use displayString' transformWith: '`@receiver gtDisplayString' -> '`@receiver displayString'.
-	^ self displayString
-]
-
 { #category : #comparing }
 StEntry >> hash [
 


### PR DESCRIPTION
remove the duplicated methods
fixes #8932

