### PR TITLE
8935-add-release-test-for-shadowed-ivar--class-vars 

### DIFF
--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -106,6 +106,20 @@ ReleaseTest >> testAllGlobalBindingAreGlobalVariables [
 	self assertEmpty: wrong
 ]
 
+{ #category : #'tests - variables' }
+ReleaseTest >> testClassesShadow [
+	|  classes validExceptions remaining |
+
+	classes := Smalltalk globals allBehaviors select: [ :class | 
+		class definedVariables anySatisfy: [:var | var isShadowing]].
+
+	validExceptions := #().	
+	
+	remaining := classes asOrderedCollection reject: [ :each  | validExceptions includes: each name].
+	"6 left that we need to fix"
+	self assert: remaining size <= 6.
+]
+
 { #category : #tests }
 ReleaseTest >> testExplicitRequirementMethodsShouldBeImplementedInTheirUsers [
 	"If a class is using a trait with an explicit requirement method, this class should implement the method"


### PR DESCRIPTION
add release test for testClassesShadow that checks for shadowed class and instances variables

fixes #8935

