### PR TITLE
5388-Improving-RBNode-API: add #hasArguments

### DIFF
--- a/src/AST-Core-Tests/RBMethodNodeTest.class.st
+++ b/src/AST-Core-Tests/RBMethodNodeTest.class.st
@@ -136,6 +136,14 @@ RBMethodNodeTest >> testCommentsParent [
 		equals: #testCommentsParent.
 ]
 
+{ #category : #tests }
+RBMethodNodeTest >> testHasArguments [
+
+	| ast |
+	ast := self parseMethod: 'foo: arg'.
+	self assert: ast hasArguments
+]
+
 { #category : #'testing-comments' }
 RBMethodNodeTest >> testHasComments [
 

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -346,6 +346,12 @@ RBMethodNode >> hasArgumentNamed: aString [
 ]
 
 { #category : #testing }
+RBMethodNode >> hasArguments [
+
+	^ arguments isNotEmpty
+]
+
+{ #category : #testing }
 RBMethodNode >> hasPragmaNamed: aSymbol [	
 	self pragmaNamed: aSymbol ifAbsent: [ ^ false ].
 	^ true


### PR DESCRIPTION
#hasTemporaries was already added to RBMethodNode

This PR adds a test and #hasArguments to RBMethodNode

fixes #5388

