### PR TITLE
8955-failing-test-on-CI-ReleaseTesttestUndeclared 

### DIFF
--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -379,18 +379,33 @@ ReleaseTest >> testThatAllMethodsArePackaged [
 
 { #category : #'tests - variables' }
 ReleaseTest >> testUndeclared [
-	| undeclaredBindings |
+	| undeclaredVariables validExceptions remaining description |
 	
 	Smalltalk cleanOutUndeclared. 
-	undeclaredBindings := Undeclared keys reject: [:each |
-			each includesSubstring: 'undeclaredStub' caseSensitive: false].
+	undeclaredVariables := Undeclared associations select: [:each |
+			each isUndeclaredVariable].
 	
+	validExceptions := { #undeclaredStubInstVar1 . #undeclaredStubInstVar2 }.
+	
+	"for now we filter by name"
+	remaining := undeclaredVariables reject: [ :each | validExceptions includes: each name  ].
+	
+	"we look for one of the undeclared var and report that, this should be enough to fix it quickly"							
+	description := String streamContents: [ :stream |
+			stream nextPutAll: 'Found undeclared references: '.
+			remaining do: [ :variable  |
+				| methodAST |
+				methodAST := variable accessingNodes first methodNode.
+				stream 
+					nextPutAll: variable name;
+					nextPutAll: ' in: ';
+					print: methodAST methodClass;
+					nextPutAll: '>>';
+					print: methodAST selector ]].
+
 	self 
-		assert: undeclaredBindings isEmpty 
-		description: (String streamContents: [ :s|
-			s 
-				nextPutAll: 'Found undeclared references: ';
-				print: undeclaredBindings ])
+		assert: remaining isEmpty 
+		description: description
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Improve #testUndeclared to report the method of one of its uses (there is at least one).

Reporting one in the logs should make it easy to fix it. It is interesting that this is very simple to do with Undeclared variables now being Variables... 

fixes #8955

On the CI this will fail as we have right now one case... with this being merged, it will be easier to fix

