### PR TITLE
RBSequenceNode-children-no-accessor 

### DIFF
--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -235,8 +235,8 @@ RBSequenceNode >> bestNodeFor: anInterval [
 { #category : #accessing }
 RBSequenceNode >> children [
 	^(OrderedCollection new)
-		addAll: self temporaries;
-		addAll: self statements;
+		addAll: temporaries;
+		addAll: statements;
 		yourself
 ]
 


### PR DESCRIPTION
RBSequenceNode>>#children does not need to use accessors but can access the vars directly (forgot that in an earlier PR where I did that for all #children method on the AST).

This is part of an experiment I am doing... but makes a lot of sense to be done anyway. (I will write about it when it is done)


