### PR TITLE
ReClassVariablesShadowingRule-Improve

### DIFF
--- a/src/GeneralRules/ReClassVariableNeitherReadNorWrittenRule.class.st
+++ b/src/GeneralRules/ReClassVariableNeitherReadNorWrittenRule.class.st
@@ -12,25 +12,11 @@ ReClassVariableNeitherReadNorWrittenRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #enumerating }
+{ #category : #running }
 ReClassVariableNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 	aClass classVariables
 		select: [ :variable | variable isReferenced not ]
-		thenDo: [ :variable | aCriticBlock cull: (self critiqueFor: aClass about: variable) ]
-]
-
-{ #category : #enumerating }
-ReClassVariableNeitherReadNorWrittenRule >> critiqueFor: aClass about: aVariable [
-
-	| crit |
-	crit := ReTrivialCritique
-		withAnchor: (ReVarSearchSourceAnchor
-			entity: aClass
-			string: aVariable name)
-		by: self.
-	
-	crit tinyHint: aVariable name.
-	^ crit
+		thenDo: [ :variable | aCriticBlock cull: (self critiqueFor: aClass about: variable name) ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/ReClassVariablesShadowingRule.class.st
+++ b/src/GeneralRules/ReClassVariablesShadowingRule.class.st
@@ -16,24 +16,9 @@ ReClassVariablesShadowingRule class >> checksClass [
 { #category : #running }
 ReClassVariablesShadowingRule >> check: aClass forCritiquesDo: aCriticBlock [
 
-	aClass definedVariables do: [ :variable | 
-		variable isShadowing  ifTrue: [ 
-			aCriticBlock cull: (self critiqueFor: aClass about: variable name) ] ]
-]
-
-{ #category : #'running-helpers' }
-ReClassVariablesShadowingRule >> critiqueFor: aClass about: aVarName [
-
-	| crit |
-	crit := ReTrivialCritique
-		withAnchor: (ReVarSearchSourceAnchor
-			entity: aClass
-			string: aVarName)
-		by: self.
-	
-	crit tinyHint: aVarName.
-				
-	^ crit
+	aClass definedVariables
+		select: [ :variable | variable isShadowing ]
+		thenDo: [ :variable | aCriticBlock cull: (self critiqueFor: aClass about: variable name) ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/ReInstanceVariableCapitalizationRule.class.st
+++ b/src/GeneralRules/ReInstanceVariableCapitalizationRule.class.st
@@ -14,12 +14,10 @@ ReInstanceVariableCapitalizationRule class >> checksClass [
 
 { #category : #running }
 ReInstanceVariableCapitalizationRule >> check: aClass forCritiquesDo: aCriticBlock [
-	
+
 	aClass instVarNames
 		select: [ :each | each first isUppercase ]
-		thenDo: [ :each |
-			aCriticBlock cull: (
-				self critiqueFor: aClass about: each) ]
+		thenDo: [ :each | aCriticBlock cull: (self critiqueFor: aClass about: each) ]
 ]
 
 { #category : #'running-helpers' }

--- a/src/GeneralRules/ReIvarNeitherReadNorWrittenRule.class.st
+++ b/src/GeneralRules/ReIvarNeitherReadNorWrittenRule.class.st
@@ -4,9 +4,6 @@ This smell arises when an instance variable is not both read and written. If an 
 Class {
 	#name : #ReIvarNeitherReadNorWrittenRule,
 	#superclass : #ReAbstractRule,
-	#instVars : [
-		't'
-	],
 	#category : #'GeneralRules-Migrated'
 }
 

--- a/src/GeneralRules/ReIvarNeitherReadNorWrittenRule.class.st
+++ b/src/GeneralRules/ReIvarNeitherReadNorWrittenRule.class.st
@@ -4,6 +4,9 @@ This smell arises when an instance variable is not both read and written. If an 
 Class {
 	#name : #ReIvarNeitherReadNorWrittenRule,
 	#superclass : #ReAbstractRule,
+	#instVars : [
+		't'
+	],
 	#category : #'GeneralRules-Migrated'
 }
 
@@ -12,25 +15,11 @@ ReIvarNeitherReadNorWrittenRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #enumerating }
+{ #category : #running }
 ReIvarNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 	aClass slots
 		select: [ :slot | slot isReferenced not ]
-		thenDo: [ :slot | aCriticBlock cull: (self critiqueFor: aClass about: slot) ]
-]
-
-{ #category : #enumerating }
-ReIvarNeitherReadNorWrittenRule >> critiqueFor: aClass about: aSlot [
-
-	| crit |
-	crit := ReTrivialCritique
-		withAnchor: (ReVarSearchSourceAnchor
-			entity: aClass
-			string: aSlot name)
-		by: self.
-	
-	crit tinyHint: aSlot name.
-	^ crit
+		thenDo: [ :slot | aCriticBlock cull: (self critiqueFor: aClass about: slot name) ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/ReVariableAssignedLiteralRule.class.st
+++ b/src/GeneralRules/ReVariableAssignedLiteralRule.class.st
@@ -26,21 +26,6 @@ ReVariableAssignedLiteralRule >> check: aClass forCritiquesDo: aCriticBlock [
 			aCriticBlock cull: (self critiqueFor: aClass about: variable name) ] ]
 ]
 
-{ #category : #'running-helpers' }
-ReVariableAssignedLiteralRule >> critiqueFor: aClass about: aVarName [
-
-	| crit |
-	crit := ReTrivialCritique
-		withAnchor: (ReVarSearchSourceAnchor
-			entity: aClass
-			string: aVarName)
-		by: self.
-	
-	crit tinyHint: aVarName.
-				
-	^ crit
-]
-
 { #category : #accessing }
 ReVariableAssignedLiteralRule >> group [
 	^ 'Design Flaws'

--- a/src/GeneralRules/ReVariableReferencedOnceRule.class.st
+++ b/src/GeneralRules/ReVariableReferencedOnceRule.class.st
@@ -32,19 +32,6 @@ ReVariableReferencedOnceRule >> check: aClass forCritiquesDo: aCriticBlock [
 
 ]
 
-{ #category : #running }
-ReVariableReferencedOnceRule >> critiqueFor: aClass about: aVarName [
-
-	| crit |
-	crit := ReTrivialCritique
-		withAnchor: (ReVarSearchSourceAnchor
-			entity: aClass
-			string: aVarName)
-		by: self.
-	crit tinyHint: aVarName.
-	^ crit
-]
-
 { #category : #accessing }
 ReVariableReferencedOnceRule >> group [
 	^ 'Design Flaws'

--- a/src/Renraku/ReAbstractRule.class.st
+++ b/src/Renraku/ReAbstractRule.class.st
@@ -224,6 +224,19 @@ ReAbstractRule >> critiqueFor: anEntity [
 		by: self
 ]
 
+{ #category : #'running-helpers' }
+ReAbstractRule >> critiqueFor: aClass about: aVarName [
+
+	| crit |
+	crit := ReTrivialCritique
+		withAnchor: (ReVarSearchSourceAnchor
+			entity: aClass
+			string: aVarName)
+		by: self.
+	crit tinyHint: aVarName.	
+	^ crit
+]
+
 { #category : #accessing }
 ReAbstractRule >> group [
 


### PR DESCRIPTION
Cleanup from the backlog while doing the first version of ReClassVariablesShadowingRule:

-  ReClassVariablesShadowingRule should use #select:thenDo:
- We had a lot of copies of #critiqueFor:about:, this PR moves it as a helper method to the superclass and removed all the duplicates
- recategorize some methods 

Just a small step

