### PR TITLE
7827-oldDefinition-should-use-the-associated-class-definition-printer

### DIFF
--- a/src/Calypso-Ring/RGBehavior.extension.st
+++ b/src/Calypso-Ring/RGBehavior.extension.st
@@ -95,44 +95,6 @@ RGBehavior >> methodDict [
 ]
 
 { #category : #'*Calypso-Ring' }
-RGBehavior >> oldDefinition [
-	"Answer a String that defines the receiver in the old format using poolDictionaries and category.
-	e.g,  
-	'Object subclass: #Point
-		instanceVariableNames: ''x y''
-		classVariableNames: ''''
-		poolDictionaries: ''''
-		category: ''Kernel-BasicObjects'''
-	"
-
-	| aStream |
-	aStream := (String new: 800) writeStream.
-	superclass 
-		ifNil: [aStream nextPutAll: 'ProtoObject']
-		ifNotNil: [aStream nextPutAll: superclass name].
-	aStream nextPutAll: self kindOfSubclass;
-			store: self name.
-	(self hasTraitComposition) ifTrue: [
-		aStream cr; tab; nextPutAll: 'uses: ';
-			nextPutAll: self traitCompositionString].
-	aStream cr; tab; nextPutAll: 'instanceVariableNames: ';
-			store: self instanceVariablesString.
-	aStream cr; tab; nextPutAll: 'classVariableNames: ';
-			store: self classVariablesString.
-	aStream cr; tab; nextPutAll: 'poolDictionaries: ';
-			store: self sharedPoolsString.
-	aStream cr; tab; nextPutAll: 'category: ';
-			store: self category asString.
-
-	superclass ifNil: [ 
-		aStream nextPutAll: '.'; cr.
-		aStream nextPutAll: self name.
-		aStream space; nextPutAll: 'superclass: nil'. ].
-
-	^ aStream contents
-]
-
-{ #category : #'*Calypso-Ring' }
 RGBehavior >> organization [
 
 	^ self

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -432,6 +432,12 @@ RGBehavior >> defaultTraitComposition [
 	^ self defaultTraitCompositionStubIn: self.
 ]
 
+{ #category : #fileout }
+RGBehavior >> definitionStringFor: aConfiguredPrinter [
+
+	^ aConfiguredPrinter classDefinitionString 
+]
+
 { #category : #'queries - methods' }
 RGBehavior >> ensureLocalMethodNamed: aSymbol [
 
@@ -761,6 +767,14 @@ RGBehavior >> name: aString [
 		self announcer behaviorDefinitionChangedFrom: assoc value to: assoc key.
 		self announcer behaviorModificationAppliedTo: assoc key.
 		self announcer behaviorParentRenamed: assoc key from: oldName ].
+]
+
+{ #category : #fileout }
+RGBehavior >> oldDefinition [
+	
+	^ ClassDefinitionPrinter legacy
+		for: self;
+		definitionString
 ]
 
 { #category : #printing }

--- a/src/Ring-Tests-Core/RGBehaviorTest.class.st
+++ b/src/Ring-Tests-Core/RGBehaviorTest.class.st
@@ -57,6 +57,17 @@ RGBehaviorTest >> testBehaviorWithProtocols [
 ]
 
 { #category : #tests }
+RGBehaviorTest >> testOldDefinition [
+	| newBehavior |
+	newBehavior := self behaviorClass named: #SomeClass.
+	self assert: newBehavior oldDefinition equals: 'unresolved subclass: #SomeClass
+	instanceVariableNames: ''''
+	classVariableNames: ''''
+	poolDictionaries: ''''
+	category: ''unresolved'''
+]
+
+{ #category : #tests }
 RGBehaviorTest >> testResolvingConsistency [
 
 	| anObject |


### PR DESCRIPTION
I checked them: RGBehavior was not using the ClassDefinitionPrinter.
This PR  implements a tests an makes it work with "ClassDefinitionPrinter legacy"

fixes #7827

