### PR TITLE
8972-Class-instance-variable-menu-error

### DIFF
--- a/src/SystemCommands-SourceCodeCommands/SycExtractSetUpRefactoring.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractSetUpRefactoring.class.st
@@ -27,8 +27,7 @@ SycExtractSetUpRefactoring >> executeRefactoring [
 
 { #category : #testing }
 SycExtractSetUpRefactoring >> isApplicable [
-	
-	^ context lastSelectedMethod selector isTestSelector 
+	^context isMethodSelected and: [ context lastSelectedMethod selector isTestSelector  ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
SycExtractSetUpRefactoring needs to check if we are browsing a method.

fixes #8972
fixes #8967


