### PR TITLE
Float numbers are only immediates if the VM/Image has SmallFloats.

### DIFF
--- a/src/Kernel-Tests/ProtoObjectTest.class.st
+++ b/src/Kernel-Tests/ProtoObjectTest.class.st
@@ -200,9 +200,12 @@ ProtoObjectTest >> testNextObject [
 	self assert: (nil nextObject notNil).
 	self assert: ('test' nextObject notNil).
 	
-	self should: [42 nextObject notNil] raise: ShouldNotImplement .
-	self should: [$x nextObject notNil] raise: ShouldNotImplement .
-	self should: [3.14 nextObject notNil] raise: ShouldNotImplement .
+	self should: [42 nextObject notNil] raise: ShouldNotImplement.
+	self should: [$x nextObject notNil] raise: ShouldNotImplement.
+
+	"Boxed Floats are only available in 64 bits VMs"	
+	Smalltalk vm hasSmallFloats 
+		ifTrue: [self should: [3.14 nextObject notNil] raise: ShouldNotImplement].
 
 ]
 

--- a/src/Kernel-Tests/ProtoObjectTest.class.st
+++ b/src/Kernel-Tests/ProtoObjectTest.class.st
@@ -203,7 +203,7 @@ ProtoObjectTest >> testNextObject [
 	self should: [42 nextObject notNil] raise: ShouldNotImplement.
 	self should: [$x nextObject notNil] raise: ShouldNotImplement.
 
-	"Boxed Floats are only available in 64 bits VMs"	
+	"Small Floats are only available in 64 bits VMs"	
 	Smalltalk vm hasSmallFloats 
 		ifTrue: [self should: [3.14 nextObject notNil] raise: ShouldNotImplement].
 

--- a/src/System-Support/VirtualMachine.class.st
+++ b/src/System-Support/VirtualMachine.class.st
@@ -250,6 +250,12 @@ VirtualMachine >> getSystemAttribute: attributeID [
 	^ nil
 ]
 
+{ #category : #testing }
+VirtualMachine >> hasSmallFloats [
+	"SmallFloats are available in 64 bits machines"
+	^ self wordSize = 8
+]
+
 { #category : #accessing }
 VirtualMachine >> headlessOption [
 	"Return the default name for the headless option for this VM"


### PR DESCRIPTION
We need to test if the VM/Image has SmallFloats. 32bits VM does not have them