### PR TITLE
ZdcSecureSocketStreamTest>>#testPlain and ZnHTTPSTests>>#testRequestR…

### DIFF
--- a/src/Zinc-Zodiac/ZnHTTPSTest.class.st
+++ b/src/Zinc-Zodiac/ZnHTTPSTest.class.st
@@ -185,18 +185,18 @@ ZnHTTPSTest >> testRequestResponse [
 	self ensureSocketStreamFactory.
 	self isNativeSSLPluginPresent ifFalse: [ ^ self ].
 	query := 'Smalltalk'.
-	stream := ZdcSecureSocketStream openConnectionToHostNamed: 'www.google.com' port: 443.
-	[
-		request := ZnRequest get: 'https://www.google.com/search?q=', query.
+	stream := ZdcSecureSocketStream openConnectionToHostNamed: 'duckduckgo.com' port: 443.
+	request := nil.
+	response := [
+		request := ZnRequest get: 'https://duckduckgo.com?q=', query.
 		stream connect.
 		request writeOn: stream.
 		stream flush.
-		response := ZnResponse readFrom: stream.
+		ZnResponse readFrom: stream.
 	] ensure: [ stream close ].
 	self assert: response isSuccess.
-	self assert: (response contents includesSubstring: 'Google').   
-	self assert: (response contents includesSubstring: 'Smalltalk').   
-
+	self assert: (response contents includesSubstring: 'Duck').   
+	self assert: (response contents includesSubstring: query).
 ]
 
 { #category : #testing }

--- a/src/Zodiac-Tests/ZdcSecureSocketStreamTest.class.st
+++ b/src/Zodiac-Tests/ZdcSecureSocketStreamTest.class.st
@@ -30,19 +30,20 @@ ZdcSecureSocketStreamTest >> testPlain [
 	| query stream request response |
 	self isNativeSSLPluginPresent ifFalse: [ ^ self ].
 	query := 'Smalltalk'.
-	stream := ZdcSecureSocketStream openConnectionToHostNamed: 'www.google.com' port: 443.
-	[
+	stream := ZdcSecureSocketStream openConnectionToHostNamed: 'duckduckgo.com' port: 443.
+	request := nil.
+	response := [
 		request := String streamContents: [ :out |
-			out << 'GET /search?q=' << query << ' HTTP/1.1' << String crlf.
-			out << 'Host: www.google.com' << String crlf.
+			out << 'GET /?q=' << query << ' HTTP/1.1' << String crlf.
+			out << 'Host: duckduckgo.com' << String crlf.
 			out << 'Connection: close' << String crlf.
 			out << String crlf ].
 		stream connect.
 		stream nextPutAll: request asByteArray.
 		stream flush.
-		response := stream upToEnd asString.
+		stream upToEnd asString.
 	] ensure: [ stream close ].
 	self assert: (response includesSubstring: '200 OK').      
-	self assert: (response includesSubstring: 'Google').
-	self assert: (response includesSubstring: 'Smalltalk').      
+	self assert: (response includesSubstring: 'Duck').
+	self assert: (response includesSubstring: query).
 ]


### PR DESCRIPTION
…esponse cannot handle the redirect that Google recently added.

Switch to DuckDuckGo for this more primitive test, which does not redirect.

Copy change from the upstream repositories

Here is the first change

svenvc/zinc@75710f9

and the second

svenvc/zodiac@cd4c4ee

tests for Pharo 7, 8 and 9 are green

https://github.com/svenvc/zinc/actions/runs/725549812