### PR TITLE
Author in PoolDefiner and PoolDefiner2 is shadowing class

### DIFF
--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -455,11 +455,11 @@ ClassTest >> testSharedPoolOfVarNamed [
 	"a metaclass does not have shared pools since only classes have shared pools"
 	self assert: (Date class sharedPoolOfVarNamed: 'DayNames') isNil.
 	
-	self assert: (RootClassPoolUser sharedPoolOfVarNamed: 'Author') equals: PoolDefiner.
+	self assert: (RootClassPoolUser sharedPoolOfVarNamed: 'AnAuthor') equals: PoolDefiner.
 	self assert: (RootClassPoolUser sharedPoolOfVarNamed: 'Gloups') equals: PoolDefiner.
-	self assert: (SubclassPoolUser sharedPoolOfVarNamed: 'Author') equals: PoolDefiner.
+	self assert: (SubclassPoolUser sharedPoolOfVarNamed: 'AnAuthor') equals: PoolDefiner.
 	
-	self assert: (ClassMultiplePoolUser sharedPoolOfVarNamed: 'Author') equals: PoolDefiner.
+	self assert: (ClassMultiplePoolUser sharedPoolOfVarNamed: 'AnAuthor') equals: PoolDefiner.
 	self assert: (ClassMultiplePoolUser sharedPoolOfVarNamed: 'VariableInPoolDefiner2') equals: PoolDefiner2.
 	self assert: (ClassMultiplePoolUser sharedPoolOfVarNamed: 'Gloups') equals: PoolDefiner
 ]

--- a/src/Kernel-Tests/ClassMultiplePoolUser.class.st
+++ b/src/Kernel-Tests/ClassMultiplePoolUser.class.st
@@ -14,7 +14,7 @@ Class {
 { #category : #accessing }
 ClassMultiplePoolUser class >> author [
 
-	^ Author
+	^ AnAuthor
 ]
 
 { #category : #accessing }

--- a/src/Kernel-Tests/PoolDefiner.class.st
+++ b/src/Kernel-Tests/PoolDefiner.class.st
@@ -5,7 +5,7 @@ Class {
 	#name : #PoolDefiner,
 	#superclass : #SharedPool,
 	#classVars : [
-		'Author',
+		'AnAuthor',
 		'Gloups'
 	],
 	#category : #'Kernel-Tests-Classes'
@@ -16,5 +16,5 @@ PoolDefiner class >> initialize [
 	"self initialize"
 	
 	Gloups := 42.
-	Author := 'Ducasse'.
+	AnAuthor := 'Ducasse'.
 ]

--- a/src/Kernel-Tests/PoolDefiner2.class.st
+++ b/src/Kernel-Tests/PoolDefiner2.class.st
@@ -5,7 +5,7 @@ Class {
 	#name : #PoolDefiner2,
 	#superclass : #SharedPool,
 	#classVars : [
-		'Author',
+		'AnAuthor',
 		'VariableInPoolDefiner2'
 	],
 	#category : #'Kernel-Tests-Classes'
@@ -16,5 +16,5 @@ PoolDefiner2 class >> initialize [
 	"self initialize"
 	
 	VariableInPoolDefiner2 := 33.
-	Author := 'NotDucasse'.
+	AnAuthor := 'NotDucasse'.
 ]

--- a/src/Kernel-Tests/RootClassPoolUser.class.st
+++ b/src/Kernel-Tests/RootClassPoolUser.class.st
@@ -14,7 +14,7 @@ Class {
 { #category : #accessing }
 RootClassPoolUser class >> author [
 
-	^  Author
+	^  AnAuthor
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
rename to AnAuthor