### PR TITLE
reset the ASTCache in #testNoShadowedVariablesInMethods

### DIFF
--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -262,7 +262,8 @@ ReleaseTest >> testNoShadowedVariablesInMethods [
 	| found validExceptions remaining |
 	found := SystemNavigation default allMethodsSelect: [ :m | 
 		m ast variableDefinitionNodes anySatisfy: [ :node | node variable isShadowing ] ].
-	
+	"Make sure to not waste memory with all the ASTs"
+	ASTCache reset.
 	"No other exceptions beside the ones mentioned here should be allowed"	
 	validExceptions := { 
 		RBDummyRefactoryTestDataApp>>#tempVarOverridesInstVar.


### PR DESCRIPTION
This is a workaround for #8984, that is, it should fix the problems if running the tests on the CI but we need to rethink the mechanism behind the ASTCache