### PR TITLE
Use a Mutex instead of a Semaphore to prevent trouble in concurrent s…

### DIFF
--- a/src/Network-UUID/UUIDGenerator.class.st
+++ b/src/Network-UUID/UUIDGenerator.class.st
@@ -122,7 +122,7 @@ UUIDGenerator >> computeNodeIdentifier [
 UUIDGenerator >> initialize [
 	super initialize.
 	random := Random new.
-	lock := Semaphore forMutualExclusion.
+	lock := Mutex new.
 	node := self computeNodeIdentifier.
 	counter := self nextRandom16
 ]

--- a/src/Network-UUID/UUIDGenerator.class.st
+++ b/src/Network-UUID/UUIDGenerator.class.st
@@ -122,9 +122,13 @@ UUIDGenerator >> computeNodeIdentifier [
 UUIDGenerator >> initialize [
 	super initialize.
 	random := Random new.
+	"This prior usage of a Semaphore has been exchanged because there are reports that
+	the Semaphore did not work in concurrent situations. So the Mutex adds some extra 
+	bits here for usage in multi threaded environments"
 	lock := Mutex new.
 	node := self computeNodeIdentifier.
 	counter := self nextRandom16
+	
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
…cenarios. The generator is accessed as singleton so this should add some more bits of safety.

Although Semaphore should be thread safe there is the notion it doesn't work in some cases but a Mutex will do.