### PR TITLE
CairoLibrary in windows: don't look for cairo.dll

### DIFF
--- a/src/Athens-Cairo/CairoLibrary.class.st
+++ b/src/Athens-Cairo/CairoLibrary.class.st
@@ -54,5 +54,5 @@ CairoLibrary >> versionString [
 { #category : #'accessing platform' }
 CairoLibrary >> win32LibraryName [ 
 	
-	^ FFIWindowsLibraryFinder findAnyLibrary: #('cairo.dll' 'libcairo-2.dll')	
+	^ FFIWindowsLibraryFinder findAnyLibrary: #('libcairo-2.dll')	
 ]


### PR DESCRIPTION
Fixes #8985

Change suggested by @lopezca 
Thanks