### PR TITLE
8941-Cleanup-shadowing-class-Variables

### DIFF
--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -108,16 +108,13 @@ ReleaseTest >> testAllGlobalBindingAreGlobalVariables [
 
 { #category : #'tests - variables' }
 ReleaseTest >> testClassesShadow [
-	|  classes validExceptions remaining |
 
+	| classes |
 	classes := Smalltalk globals allBehaviors select: [ :class | 
-		class definedVariables anySatisfy: [:var | var isShadowing]].
+		           class definedVariables anySatisfy: [ :var | 
+			           var isShadowing ] ].
 
-	validExceptions := #().	
-	
-	remaining := classes asOrderedCollection reject: [ :each  | validExceptions includes: each name].
-	"6 left that we need to fix"
-	self assert: remaining size <= 6.
+	self assert: classes isEmpty description: classes asArray asString
 ]
 
 { #category : #tests }


### PR DESCRIPTION
#testClassesShadow can now check that there are no shadowing cases in the classes.

fixes #8941
