### PR TITLE
9000-MethodFinder-class-works-as-expected-but-not-in-the-Finder-tool--error-in-Finder-documentation 

### DIFF
--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -81,8 +81,8 @@ Finder >> computeListOfClasses: aString [
 Finder >> computeWithMethodFinder: aString [
 	"Compute the selectors for the single example of receiver and args, in the very top pane"
 
-	| data result resultArray dataObjects |
-(aString includes: $.)
+	| data result dataObjects |
+	(aString includes: $.)
 		ifFalse: [ ^ #() ].	"delete trailing period. This should be fixed in the Parser!"
 	data := aString trimRight: [ :char | char isSeparator or: [ char = $. ] ].
 
@@ -102,9 +102,7 @@ Finder >> computeWithMethodFinder: aString [
 		
 	result := MethodFinder new findMethodsByExampleInput: dataObjects allButLast andExpectedResult: dataObjects last.
 	result isEmpty ifTrue: [ self inform: 'no single method'. ^ #()].
-	
-	resultArray := result collect: [ :send | send asString , ' --> ', dataObjects last asString. ].
-	^ resultArray.
+	^ result.
 ]
 
 { #category : #'private-class' }
@@ -159,17 +157,17 @@ Finder >> constructDictionaryWithMessagesNameSearch: aString [
 Finder >> constructDictionaryWithMethodFinder: aString [
 	"construct dictionary when searching patterns"
 
-	| result listOfStrings listOfSelectors |
+	| result listOfResults listOfSelectors |
 	result := Dictionary new.
-	listOfStrings := self computeWithMethodFinder: aString.
-	listOfSelectors := listOfStrings collect: [ :each | self findSelector: each ].
+	listOfResults := self computeWithMethodFinder: aString.
+	listOfSelectors := listOfResults collect: [ :each | each selector ].
 	self packagesSelection classesDo:[ :class | 
 			class methodsDo:  [ :method | 
 					| index |
 					(index := listOfSelectors indexOf: method selector) = 0
 						ifFalse: [ 
 							| key value |
-							key := listOfStrings at: index.
+							key := listOfResults at: index.
 							value := method methodClass.
 							(result includesKey: key)
 								ifTrue: [ (result at: key) add: value ]
@@ -279,20 +277,6 @@ Finder >> environment [
 Finder >> environment: aCollection [
 
 	 environment := aCollection
-]
-
-{ #category : #private }
-Finder >> findSelector: aString [
-	"Answer the selector of aString."
-
-	| example tokens |
-	example := aString.
-	tokens := example parseLiterals.
-	tokens size = 1 ifTrue: [^ tokens first].
-	tokens first == #'^' ifTrue: [^ nil].
-	(tokens second includes: $:) ifTrue: [^ example findSelector].
-	Symbol hasInterned: tokens second ifTrue: [:aSymbol | ^ aSymbol].
-	^ nil
 ]
 
 { #category : #initialization }

--- a/src/Tool-Finder/FinderExampleMethodNode.class.st
+++ b/src/Tool-Finder/FinderExampleMethodNode.class.st
@@ -15,13 +15,19 @@ FinderExampleMethodNode >> childNodeClassFromItem: anItem [
 	^ FinderExampleClassNode
 ]
 
+{ #category : #displaying }
+FinderExampleMethodNode >> displayString [
+	
+	^ self selector asString
+]
+
 { #category : #private }
 FinderExampleMethodNode >> receiver [
 	"return the receiver of my item."
-	^(RBParser parseExpression: self item) receiver evaluate
+	^self item receiver
 ]
 
 { #category : #private }
 FinderExampleMethodNode >> selector [
-	^ self model finder findSelector: self item
+	^ self item selector
 ]

--- a/src/Tool-Finder/FinderExampleMethodNode.class.st
+++ b/src/Tool-Finder/FinderExampleMethodNode.class.st
@@ -17,8 +17,12 @@ FinderExampleMethodNode >> childNodeClassFromItem: anItem [
 
 { #category : #displaying }
 FinderExampleMethodNode >> displayString [
-	
-	^ self selector asString
+
+	^ String streamContents: [ :str | 
+		  str
+			  print: self item;
+			  nextPutAll: ' -> ';
+			  print: self item evaluate ]
 ]
 
 { #category : #private }

--- a/src/Tool-Finder/FinderUI.class.st
+++ b/src/Tool-Finder/FinderUI.class.st
@@ -975,11 +975,11 @@ FinderUI >> sourceCode [
 				ifNil: [
 					self buildDescriptionOf: self selectedClass]
 				ifNotNil:[
-					| method |
-					method := self isExamplesSymbol
-								ifTrue: [self finder findSelector: self selectedMethod]
+					| selector |
+					selector := self isExamplesSymbol
+								ifTrue: [self selectedMethod selector]
 								ifFalse: [self selectedMethod].
-					(self selectedClass >> method) sourceCode]]
+					(self selectedClass >> selector) sourceCode]]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
The Finder has lots of code that is strange...

This PR removed the parsing of the string (#findSelector:) and just delegates to the MethodFinderSend object which knows the string.

Fixes #9000

