### PR TITLE
RB - Fix move method with empty protocols

### DIFF
--- a/src/Calypso-SystemTools-Core/ClySystemBrowserContext.class.st
+++ b/src/Calypso-SystemTools-Core/ClySystemBrowserContext.class.st
@@ -217,34 +217,6 @@ ClySystemBrowserContext >> requestSingleClass: queryTitle from: classCollection 
 ]
 
 { #category : #'user requests' }
-ClySystemBrowserContext >> requestSingleMethodTag: queryTitle [
-	^self requestSingleMethodTag: queryTitle suggesting: ''
-]
-
-{ #category : #'user requests' }
-ClySystemBrowserContext >> requestSingleMethodTag: queryTitle suggesting: suggestedTag [
-	| knownTags ui selectedTag |
-	knownTags := (SystemNavigation default allExistingProtocolsFor: true)
-		reject: [ :each | each beginsWith: '*' ].
-	knownTags := knownTags asSortedCollection: [ :a :b | a asLowercase < b asLowercase ].	
-	ui := ListDialogWindow new
-		getList: [ :r | knownTags select: [ :e | r search: e ] ];
-		displayBlock: [ :e | e ];
-		initialAnswer: suggestedTag;
-		acceptNewEntry: true;
-		title: queryTitle;
-		yourself.
-	ui defaultFocusMorph contentMorph selectAll.
-	selectedTag := ui chooseFromOwner: tool.
-	selectedTag isEmptyOrNil ifTrue: [ CmdCommandAborted signal].
-	(selectedTag beginsWith: '*') ifTrue: [ 
-		self inform: 'Star is forbidden for protocol name. You can specify package in method editor using status bar checkbox'.
-		^CmdCommandAborted signal].
-	
-	^selectedTag asSymbol
-]
-
-{ #category : #'user requests' }
 ClySystemBrowserContext >> requestSinglePackage: queryTitle [
 	^tool searchDialog requestSingleObject: queryTitle from: ClyAllPackagesQuery sorted
 ]

--- a/src/Commander-Core/CmdToolContext.class.st
+++ b/src/Commander-Core/CmdToolContext.class.st
@@ -87,6 +87,34 @@ CmdToolContext >> processFailure: anException of: aCommand [
 	anException notifyUserOfCommand: aCommand
 ]
 
+{ #category : #'user requests' }
+CmdToolContext >> requestSingleMethodTag: queryTitle [
+	^self requestSingleMethodTag: queryTitle suggesting: ''
+]
+
+{ #category : #'user requests' }
+CmdToolContext >> requestSingleMethodTag: queryTitle suggesting: suggestedTag [
+	| knownTags ui selectedTag |
+	knownTags := (SystemNavigation default allExistingProtocolsFor: true)
+		reject: [ :each | each beginsWith: '*' ].
+	knownTags := knownTags asSortedCollection: [ :a :b | a asLowercase < b asLowercase ].	
+	ui := ListDialogWindow new
+		getList: [ :r | knownTags select: [ :e | r search: e ] ];
+		displayBlock: [ :e | e ];
+		initialAnswer: suggestedTag;
+		acceptNewEntry: true;
+		title: queryTitle;
+		yourself.
+	ui defaultFocusMorph contentMorph selectAll.
+	selectedTag := ui chooseFromOwner: tool.
+	selectedTag isEmptyOrNil ifTrue: [ CmdCommandAborted signal].
+	(selectedTag beginsWith: '*') ifTrue: [ 
+		self inform: 'Star is forbidden for protocol name. You can specify package in method editor using status bar checkbox'.
+		^CmdCommandAborted signal].
+	
+	^selectedTag asSymbol
+]
+
 { #category : #accessing }
 CmdToolContext >> tool [
 	^ tool

--- a/src/SystemCommands-MethodCommands/SycMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMethodCommand.class.st
@@ -43,6 +43,11 @@ SycMethodCommand >> methods: anObject [
 	methods := anObject
 ]
 
+{ #category : #execution }
+SycMethodCommand >> newTagFor: aMethod [
+	^ self asCommandActivator context requestSingleMethodTag: 'New protocol name for: ', aMethod name
+]
+
 { #category : #'activation-drag and drop' }
 SycMethodCommand >> prepareExecutionInDragContext: aToolContext [
 	super prepareExecutionInDragContext: aToolContext.
@@ -54,4 +59,9 @@ SycMethodCommand >> prepareExecutionInDragContext: aToolContext [
 SycMethodCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 	methods := aToolContext selectedMethods
+]
+
+{ #category : #execution }
+SycMethodCommand >> tagMethod: aMethod [
+	aMethod tagWith: (self newTagFor: aMethod) asSymbol
 ]

--- a/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
@@ -20,15 +20,16 @@ SycMethodRepackagingCommand class >> isAbstract [
 
 { #category : #execution }
 SycMethodRepackagingCommand >> moveMethod: aMethod toPackage: aPackage [
-	| existingPackage wasExtension willBeExtension |
 
+	| existingPackage wasExtension willBeExtension |
 	existingPackage := aMethod package.
-	existingPackage == aPackage ifTrue: [ ^self ].
-	wasExtension := aMethod isExtension.	
-	willBeExtension := aPackage ~~ aMethod origin package. 
-	
-	aPackage addMethod: aMethod.	
-	
-	willBeExtension ifTrue: [ aMethod tagWith: ('*', aPackage name) asSymbol].
-	wasExtension ifTrue: [aMethod untagFrom: ('*', existingPackage name) asSymbol]
+	existingPackage == aPackage ifTrue: [ ^ self ].
+	wasExtension := aMethod isExtension.
+	willBeExtension := aPackage ~~ aMethod origin package.
+	aPackage addMethod: aMethod.
+	willBeExtension ifTrue: [ 
+		aMethod tagWith: ('*' , aPackage name) asSymbol ].
+	wasExtension ifFalse: [ ^ self ].
+	aMethod untagFrom: ('*' , existingPackage name) asSymbol.
+	aMethod tags ifEmpty: [ self tagMethod: aMethod ]
 ]

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToClassCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToClassCommand.class.st
@@ -41,14 +41,14 @@ SycMoveMethodsToClassCommand >> defaultMenuItemName [
 
 { #category : #execution }
 SycMoveMethodsToClassCommand >> execute [
-	self fillNonExistenProtocol.
+	self fillNonExistingProtocol.
 	methods 
 		collect: [ :each | RBMoveMethodToClassRefactoring model: model method: each class: targetClass ]
 		thenDo: [ :each | each execute ]
 ]
 
 { #category : #filling }
-SycMoveMethodsToClassCommand >> fillNonExistenProtocol [
+SycMoveMethodsToClassCommand >> fillNonExistingProtocol [
 	methods do: [ :meth | meth tags ifEmpty: 
 		[ self tagMethod: meth ] ].
 ]

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToClassCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToClassCommand.class.st
@@ -41,10 +41,16 @@ SycMoveMethodsToClassCommand >> defaultMenuItemName [
 
 { #category : #execution }
 SycMoveMethodsToClassCommand >> execute [
-	
+	self fillNonExistenProtocol.
 	methods 
 		collect: [ :each | RBMoveMethodToClassRefactoring model: model method: each class: targetClass ]
 		thenDo: [ :each | each execute ]
+]
+
+{ #category : #filling }
+SycMoveMethodsToClassCommand >> fillNonExistenProtocol [
+	methods do: [ :meth | meth tags ifEmpty: 
+		[ self tagMethod: meth ] ].
 ]
 
 { #category : #'drag and drop support' }
@@ -57,9 +63,8 @@ SycMoveMethodsToClassCommand >> prepareExecutionInDropContext: aToolContext [
 { #category : #execution }
 SycMoveMethodsToClassCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
-	
 	targetClass := aToolContext requestSingleClass: 'Choose class'.
-	targetClass := aToolContext currentMetaLevelOf: targetClass
+	targetClass := aToolContext currentMetaLevelOf: targetClass.
 ]
 
 { #category : #accessing }

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToPackageCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToPackageCommand.class.st
@@ -45,7 +45,6 @@ SycMoveMethodsToPackageCommand >> execute [
 	
 	methods do: [ :each | 
 		self moveMethod: each toPackage: package]
-
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fixes #8929

# 1. Move methods to another package
## 1.1. Method that is extension
- Move to another package, there isn't problem because it has the extension protocol by default and the name of the package where it is extended.
- Move to the package where its proprietary class is defined, here there is a problem because in the previous version it was moved with the "as yet unclassified" protocol, **now you have the option to change the protocol so that the moved method is not declassified .**
## 1.2. Method that is not extension,
- Move to another package, the protocol is changed to "extension" and the name of the extension package
# 2. Move methods to another class
## 2.1. The method has protocol
When moving to another class the same protocol is used
## 2.2. The method doesn't have protocol
It was moved to the other class declassified, **now you have the option to change the name of the protocol when moving the method .**