### PR TITLE
8974-Adding-a-breakpoint-using-the-context-menu-does-not-work-in-the-latest-build

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -41,6 +41,8 @@ ClyMethodCodeEditorToolMorph >> applyChanges [
 	currentMethod := methodClass >> selector.
 	self tagAndPackageEditingMethod: currentMethod.
 	self switchToMethod: currentMethod.
+	"update the AST to the just compiled method. This clears breakpoints. To be improved"
+	ast := self initializeAST.
 	^true
 ]
 

--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -97,14 +97,6 @@ ClyMethodCodeEditorToolMorph >> buildLeftSideBar [
 	self leftSideBar enableMouseCommands: CmdTextLeftBarClickActivation withContextFrom: self
 ]
 
-{ #category : #building }
-ClyMethodCodeEditorToolMorph >> buildTextMorph [
-	super buildTextMorph.
-	"we start with the AST from the cache"
-	ast := editingMethod ast.
-	self formatTextIfNeeded.
-]
-
 { #category : #operations }
 ClyMethodCodeEditorToolMorph >> cancelChanges [
 	self updateMethodTagsAndPackage.
@@ -215,6 +207,12 @@ ClyMethodCodeEditorToolMorph >> findSourceNodeAt: aCursorPoint [
 
 	^(ast bestNodeFor: (startPosition to: endPosition))
 		ifNil: [ ast ]
+]
+
+{ #category : #initialization }
+ClyMethodCodeEditorToolMorph >> initializeAST [
+	"When the editor is created, we get the AST from the method"
+	^ editingMethod ast
 ]
 
 { #category : #testing }

--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -54,7 +54,7 @@ ClyMethodCodeEditorToolMorph >> applyDecorations [
 	 a lot of time, we will skip it when it is the case"
 	editingMethod isLiteralMethod ifFalse: [ 
 		IconStyler withStaticStylers  
-			styleText: textModel withAst: self currentEditedAST ].	
+			styleText: textModel withAst: ast ].	
 	textMorph hasUnacceptedEdits: hasEdits.
 	
 	super applyDecorations.
@@ -95,6 +95,14 @@ ClyMethodCodeEditorToolMorph >> buildLeftSideBar [
 	super buildLeftSideBar.
 
 	self leftSideBar enableMouseCommands: CmdTextLeftBarClickActivation withContextFrom: self
+]
+
+{ #category : #building }
+ClyMethodCodeEditorToolMorph >> buildTextMorph [
+	super buildTextMorph.
+	"we start with the AST from the cache"
+	ast := editingMethod ast.
+	self formatTextIfNeeded.
 ]
 
 { #category : #operations }
@@ -168,8 +176,7 @@ ClyMethodCodeEditorToolMorph >> extendingPackage: aPackage [
 { #category : #'selecting text' }
 ClyMethodCodeEditorToolMorph >> findAnySelectorInSourceCode: selectors [
 
-	| foundSelector foundNode positions ast |
-	ast := self currentEditedAST.
+	| foundSelector foundNode positions |
 	foundNode := ast sendNodes 
 		detect: [:each | selectors includes: (foundSelector := each selector) ] 
 		ifNone: [ 
@@ -206,8 +213,8 @@ ClyMethodCodeEditorToolMorph >> findSourceNodeAt: aCursorPoint [
 			startPosition := selection first max: 1.
 			endPosition := selection last min: self editingText size]].
 
-	^(self currentEditedAST bestNodeFor: (startPosition to: endPosition))
-		ifNil: [ self currentEditedAST ]
+	^(ast bestNodeFor: (startPosition to: endPosition))
+		ifNil: [ ast ]
 ]
 
 { #category : #testing }
@@ -279,14 +286,14 @@ ClyMethodCodeEditorToolMorph >> selectVariableNamed: varName [
 { #category : #accessing }
 ClyMethodCodeEditorToolMorph >> selectedSourceNode [
 
-	| selectedInterval ast |
+	| selectedInterval selectedNode |
 	selectedInterval := self selectedTextInterval.
 	
-	ast := selectedInterval isEmpty 
-		ifTrue: [ self currentEditedAST bestNodeForPosition: selectedInterval first ]
-		ifFalse: [ self currentEditedAST bestNodeFor: selectedInterval ].
+	selectedNode := selectedInterval isEmpty 
+		ifTrue: [ ast bestNodeForPosition: selectedInterval first ]
+		ifFalse: [ ast bestNodeFor: selectedInterval ].
 	
-	^ ast ifNil: [ self currentEditedAST ]
+	^ selectedNode ifNil: [ ast ]
 ]
 
 { #category : #initialization }

--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -26,6 +26,7 @@ Class {
 	#name : #ClyMethodEditorToolMorph,
 	#superclass : #ClyTextEditorToolMorph,
 	#instVars : [
+		'ast',
 		'methodTags',
 		'extendingPackage',
 		'targetClasses'
@@ -58,8 +59,8 @@ ClyMethodEditorToolMorph >> belongsToRemovedBrowserContext [
 { #category : #building }
 ClyMethodEditorToolMorph >> buildTextMorph [
 	super buildTextMorph.
-	
-	self formatTextIfNeeded 
+	ast := self currentEditedAST.
+	self formatTextIfNeeded.
 ]
 
 { #category : #'events handling' }
@@ -246,7 +247,6 @@ ClyMethodEditorToolMorph >> tagsAndPackageEditor [
 
 { #category : #'events handling' }
 ClyMethodEditorToolMorph >> textChanged: aTextChanged [
-	| ast |
 	super textChanged: aTextChanged.
 	ast := self currentEditedAST.
 	textMorph segments copy do: #delete.

--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -59,7 +59,7 @@ ClyMethodEditorToolMorph >> belongsToRemovedBrowserContext [
 { #category : #building }
 ClyMethodEditorToolMorph >> buildTextMorph [
 	super buildTextMorph.
-	ast := self currentEditedAST.
+	ast := self initializeAST.
 	self formatTextIfNeeded.
 ]
 
@@ -89,7 +89,10 @@ ClyMethodEditorToolMorph >> chooseClassForNewMethodIfNone: aBlock [
 { #category : #'events handling' }
 ClyMethodEditorToolMorph >> currentEditedAST [
 
-	^ self getASTFor: self pendingText
+	^ self methodClass compiler
+		  source: self pendingText;
+		  options: #( + optionParseErrors + optionSkipSemanticWarnings );
+		  parse
 ]
 
 { #category : #accessing }
@@ -137,19 +140,17 @@ ClyMethodEditorToolMorph >> formatTextIfNeeded [
 	textModel clearUserEdits
 ]
 
-{ #category : #'events handling' }
-ClyMethodEditorToolMorph >> getASTFor: aString [
-	^ self methodClass compiler
-		source: aString;
-		options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
-		parse
-]
-
 { #category : #initialization }
 ClyMethodEditorToolMorph >> initialize [
 	super initialize.
 	
 	methodTags := #()
+]
+
+{ #category : #initialization }
+ClyMethodEditorToolMorph >> initializeAST [
+	"subclasses might get it from the method"
+	^ self currentEditedAST
 ]
 
 { #category : #testing }


### PR DESCRIPTION
This PR changes ClyMethodCodeEditorToolMorph/ClyMethodEditorToolMorph to store the ast.

- #buildTextMorph, when the view is created, gets the ast from the unchanged method
- every keystroke (see #textChanged:) parses a new AST from the text buffer
- #findSourceNodeAt: and selectedSourceNode now do not create new ASTs

This makes breakpoints work again for *non edited* methods. This should get us back very close to the old behavior
and makes breakpoints usable for not edited methods.

I think we can even improve it to not clear the breakpoints on accept (if no edit was done between setting the Break and accepting):

- We need to make sure that if we accept a method with a set breakpoint that we compile the method not from the text buffer but from the AST (and make sure the reflective method is correctly setup)
- Not re-initialize the ast in the #applyChanges method


