### PR TITLE
copyOldValuesToNewVariable-no-offset

### DIFF
--- a/src/Refactoring-Changes/RBRenameInstanceVariableChange.class.st
+++ b/src/Refactoring-Changes/RBRenameInstanceVariableChange.class.st
@@ -16,12 +16,9 @@ RBRenameInstanceVariableChange >> addNewVariable [
 
 { #category : #private }
 RBRenameInstanceVariableChange >> copyOldValuesToNewVariable [
-	| newIndex oldIndex |
-	oldIndex := self changeClass allInstVarNames indexOf: oldName asString.
-	newIndex := self changeClass allInstVarNames indexOf: newName asString.
 	self changeClass withAllSubclasses do: [ :class |
 		class allInstances 
-			do: [ :each | each instVarAt: newIndex put: (each instVarAt: oldIndex) ] ]
+			do: [ :each | each instVarNamed: newName asString put: (each instVarNamed: oldName asString) ] ]
 ]
 
 { #category : #printing }


### PR DESCRIPTION
RBRenameInstanceVariableChange>>#copyOldValuesToNewVariable was using #instVarAt: to copy over state. But with Slots, we can have "instanceVariables" that have no offset.

This PR changes the code to use #instVarNamed: instead

The code gets executed by the RB tests

