### PR TITLE
8978-Selector-extraction-for-browsing-sendersimplementors-does-not-work-for-for-multi-line-calls

### DIFF
--- a/src/Calypso-SystemTools-QueryBrowser/ClyTextEditor.extension.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyTextEditor.extension.st
@@ -30,11 +30,10 @@ ClyTextEditor >> implementorsOf: selectedSelector [
 
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
 ClyTextEditor >> implementorsOfIt [
-	| selector |
 
-	self lineSelectAndEmptyCheck: [^ self].
-	(selector := self selectedSelector) == nil ifTrue: [^ textArea flash].
-	selector 	isCharacter ifTrue: [ ^ textArea flash ].
+	| selector |
+	(selector := self selectedSelector) ifNil: [ ^ textArea flash ].
+	selector isCharacter ifTrue: [ ^ textArea flash ].
 	self browser browseImplementorsOf: selector
 ]
 
@@ -81,9 +80,8 @@ ClyTextEditor >> sendersOf: selectedSelector [
 
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
 ClyTextEditor >> sendersOfIt [
+
 	| selector |
-	self lineSelectAndEmptyCheck: [^ self].
-	(selector := self selectedSelector) == nil ifTrue: [^ textArea flash].
-	
-	self sendersOf: selector 
+	(selector := self selectedSelector) ifNil: [ ^ textArea flash ].
+	self sendersOf: selector
 ]

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -760,7 +760,6 @@ RubSmalltalkEditor >> implementorsOfIt [
 	"Open an implementors browser on the selected selector"
 
 	| aSelector |
-	"self lineSelectAndEmptyCheck: [^ self]."
 	(aSelector := self selectedSelector) ifNil: [^ textArea flash].
 	aSelector isCharacter ifTrue: [^ textArea flash].
 	self implementorsOf: aSelector
@@ -1165,7 +1164,6 @@ RubSmalltalkEditor >> sendersOfIt [
 	"Open a senders browser on the selected selector"
 
 	| selectedSelector syst |
-	"self lineSelectAndEmptyCheck: [ ^ self ]."
 	(selectedSelector := self selectedSelector) ifNil: [ ^ textArea flash ].
 	syst := self model interactionModel systemNavigation.
 	syst browseAllSendersOrUsersOf: selectedSelector


### PR DESCRIPTION
fix #8978 by removing the call to #lineSelectAndEmptyCheck:. The overridden method in the superclass had that already commented.

fixes #8978

