### PR TITLE
Allow the user to delete a class even if the class has references.

### DIFF
--- a/src/SystemCommands-ClassCommands-Tests/SycRemoveClassStrategyTest.class.st
+++ b/src/SystemCommands-ClassCommands-Tests/SycRemoveClassStrategyTest.class.st
@@ -52,8 +52,10 @@ SycRemoveClassStrategyTest >> testCreateStrategiesForReferencedClass [
 		              createForBrowser: browser
 		              classes: { ClyFullBrowser }.
 	self
-		assert: strategies size equals: 2;
+		assert: strategies size equals: 3;
 		assert: strategies first userRequestString
+		equals: SycSilentlyRemoveClassStrategy new userRequestString;
+		assert: strategies second userRequestString
 		equals:
 			ClyNotRemoveAndShowReferencesClassStrategy new userRequestString;
 		assert: strategies last userRequestString

--- a/src/SystemCommands-ClassCommands/SycSilentlyRemoveClassStrategy.class.st
+++ b/src/SystemCommands-ClassCommands/SycSilentlyRemoveClassStrategy.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #testing }
 SycSilentlyRemoveClassStrategy class >> canExecuteWithReferences: hasReferences subclasses: hasSubclasses users: hasUsers [
-	^(hasReferences | hasSubclasses | hasUsers) not 
+	^(hasSubclasses | hasUsers) not 
 ]
 
 { #category : #execution }


### PR DESCRIPTION
Allow a user to delete a class even if the class has references.

Fixes #9048