### PR TITLE
Answer the new instance in OSWindowGestureHandler

### DIFF
--- a/src/OSWindow-Core/OSWindowGestureHandler.class.st
+++ b/src/OSWindow-Core/OSWindowGestureHandler.class.st
@@ -81,6 +81,8 @@ OSWindowGestureHandler >> trackFinger: anEvent [
 	"Registering it in the right places"
 	fingers at: anEvent fingerId put: newFingerTracker.
 	(devicesFingers at: anEvent deviceId ifAbsentPut: [ OrderedCollection new ]) add: newFingerTracker.
+	
+	^ newFingerTracker
 ]
 
 { #category : #'detector registering' }


### PR DESCRIPTION
The selector trackFinger: has only 2 senders in P9: One ignores the result, the other expects this result. Then, this change should be inoffensive.

Fixes #9057