### PR TITLE
IRBuilderTest-testLiteralVariableClassVariable-cleanup

### DIFF
--- a/src/OpalCompiler-Tests/IRBuilderTest.class.st
+++ b/src/OpalCompiler-Tests/IRBuilderTest.class.st
@@ -275,14 +275,16 @@ IRBuilderTest >> testLiteralVariableClass [
 IRBuilderTest >> testLiteralVariableClassVariable [
 	| iRMethod aCompiledMethod |
 	iRMethod := IRBuilder new
-		pushLiteralVariable: (DateAndTime bindingOf: #LocalTimeZoneCache);
+		pushLiteralVariable: (OCOpalExamples classVariableNamed: #ExampleClassVariable);
 		returnTop;
 		ir.
 
 	aCompiledMethod := iRMethod compiledMethod.
 
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: DateAndTime localTimeZone.
+	OCOpalExamples new classVariable: #tag.
+	self assert: (aCompiledMethod valueWithReceiver: nil arguments: #()) equals: #tag.
+	OCOpalExamples reset.
 	^ iRMethod
 ]
 

--- a/src/OpalCompiler-Tests/OCOpalExamples.class.st
+++ b/src/OpalCompiler-Tests/OCOpalExamples.class.st
@@ -12,7 +12,7 @@ Class {
 	#classVars : [
 		'ExampleClassVariable'
 	],
-	#category : #'OpalCompiler-Tests-AST'
+	#category : #'OpalCompiler-Tests-Data'
 }
 
 { #category : #compiler }


### PR DESCRIPTION
IRBuilderTest-#testLiteralVariableClassVariable was using a class var from Date for testing

- This PR changes it to use OCOpalExamples instead
- tag OCOpalExamples as "Data" so it can be found quickly
