### PR TITLE
DrTest-Simplify-Docomment-detection

### DIFF
--- a/src/DrTests-CommentsToTests/CommentTestCase.class.st
+++ b/src/DrTests-CommentsToTests/CommentTestCase.class.st
@@ -50,17 +50,10 @@ CommentTestCase class >> errorComment: stringComment class: aClass selector: aSy
 		yourself
 ]
 
-{ #category : #example }
-CommentTestCase class >> example [
-	"1 + 1 >>> 2"
-	^ CommentTestCase comment: '1 + 1 >>> 2' class: CommentTestCase class selector: #example
-]
-
 { #category : #accessing }
 CommentTestCase class >> testSelectors [
-	self flag: #todo.
-	"missing comments. I have no ide what this method is doing."
-	^ super testSelectors \ {#testError . #testIt}
+	"we remove the selectors to add back later one of them, depending if is is error or not"
+	^ super testSelectors \ { #testError. #testIt }
 ]
 
 { #category : #accessing }
@@ -124,7 +117,7 @@ CommentTestCase >> expression: anObject [
 	expression := anObject
 ]
 
-{ #category : #accessing }
+{ #category : #printing }
 CommentTestCase >> printString [
 	^ expression
 ]
@@ -139,12 +132,12 @@ CommentTestCase >> selectorExample: anObject [
 	selectorExample := anObject
 ]
 
-{ #category : #accessing }
+{ #category : #tests }
 CommentTestCase >> testError [
 	self error: 'syntax error on the comment'
 ]
 
-{ #category : #accessing }
+{ #category : #tests }
 CommentTestCase >> testIt [
 	self assert: expectedValue equals: currentValue
 ]

--- a/src/DrTests-CommentsToTests/DTCommentTestConfiguration.class.st
+++ b/src/DrTests-CommentsToTests/DTCommentTestConfiguration.class.st
@@ -14,9 +14,8 @@ DTCommentTestConfiguration >> asTestSuite [
 	suite := TestSuite named: 'Test Generated From Comments'.
 	methods := (self items reject: [ :each | each isAbstract ]) flatCollect: [ :each | each methods ].
 	methods := methods select: [:each | each sourceCode includesSubstring: '>>>' ].
-	methods do: [ :m | m comments do: [ :com | 
-					(com includesSubstring: '>>>')
-						ifTrue: [ suite addTest: 
-							(CommentTestCase comment: com class: m methodClass selector: m selector) ] ] ].
+	methods do: [ :m | m pharoDocCommentNodes do: [ :docComment | 
+			 suite addTest: 
+				(CommentTestCase comment: docComment sourceNode contents class: m methodClass selector: m selector) ] ].
 	^ suite
 ]

--- a/src/DrTests-CommentsToTests/DTCommentToTestPlugin.class.st
+++ b/src/DrTests-CommentsToTests/DTCommentToTestPlugin.class.st
@@ -37,14 +37,9 @@ DTCommentToTestPlugin >> firstListLabel [
 
 { #category : #api }
 DTCommentToTestPlugin >> itemsToBeAnalysedFor: packagesSelected [
-	^ packagesSelected
-		flatCollect: [ :p | 
-			p definedClasses
-				select: [ :c | 
-					c methods
-						anySatisfy: [ :m | 
-							( m sourceCode includesSubstring: '>>>') and: [
-								m comments anySatisfy: [ :com | com includesSubstring: '>>>' ] ] ] ]]
+
+	^ packagesSelected flatCollect: [ :package | 
+		  package definedClasses select: [ :class | class hasDocComment ] ]
 ]
 
 { #category : #api }

--- a/src/PharoDocComment/Behavior.extension.st
+++ b/src/PharoDocComment/Behavior.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Behavior }
+
+{ #category : #'*PharoDocComment' }
+Behavior >> hasDocComment [
+	^ self methods anySatisfy: [:method | method hasDocComment ]
+]

--- a/src/PharoDocComment/CompiledMethod.extension.st
+++ b/src/PharoDocComment/CompiledMethod.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : #CompiledMethod }
 
 { #category : #'*PharoDocComment' }
+CompiledMethod >> hasDocComment [
+	^ self pharoDocCommentNodes notEmpty
+]
+
+{ #category : #'*PharoDocComment' }
 CompiledMethod >> pharoDocCommentNodes [
 	"we try to avoid to have to create the AST if we are sure that we do not need it"
 	^ (self sourceCode includesSubstring: '>>>')


### PR DESCRIPTION
DrTests does all the doc comment detecting, parsing and running all manually, not relying on the PharoDocComment package at all.

This is the first step to change that: we use PharoDocComment abstraction to find the methods. NOTE: the actually execution is still does not use PharoDocComment, this will be another step

- remove not needed example method
- improve comment and categorization in CommentTestCase
- add a #hasDocComment test for method and class
-  use this to simplify DrTest

