### PR TITLE
Parse comments at the end of methods without statements

### DIFF
--- a/src/AST-Core-Tests/RBMethodNodeTest.class.st
+++ b/src/AST-Core-Tests/RBMethodNodeTest.class.st
@@ -188,6 +188,18 @@ RBMethodNodeTest >> testMethodClass [
 	self assert: ast methodClass equals: nil
 ]
 
+{ #category : #'testing-comments' }
+RBMethodNodeTest >> testMethodWithCommentsAndEmptyStatements [
+
+	| tree |
+	tree := self parseMethod: 'foo: abd bar: cde  
+		"this is comment".
+		"this is another comment"'.
+
+	self assert: tree comments first contents equals: 'this is comment'.
+	self assert: tree body comments first contents equals: 'this is another comment'
+]
+
 { #category : #tests }
 RBMethodNodeTest >> testMethodsHasTemporaries [
 

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -1114,7 +1114,9 @@ RBParser >> parseStatementList: pragmaBoolean into: sequenceNode untilAnyCloserO
 					periodList: periods
 					withAcceptedStatementClosers: aCollectionOfClosers ].
 
-	statements notEmpty ifTrue: [ self addCommentsTo: statements last ].
+	statements
+		ifEmpty: [ self addCommentsTo: sequenceNode ]
+		ifNotEmpty: [ self addCommentsTo: statements last ].
 	sequenceNode
 		statements: statements;
 		periods: periods.


### PR DESCRIPTION
Fix issue #9063
- add comments to AST even with empty statement lists when parsing
- add test