### PR TITLE
Links in class comments crash instead of opening a browser

### DIFF
--- a/src/WebBrowser-Core/WebBrowser.class.st
+++ b/src/WebBrowser-Core/WebBrowser.class.st
@@ -29,17 +29,17 @@ WebBrowser class >> isUsed [
 ]
 
 { #category : #private }
-WebBrowser class >> openNativeWebBrowserOn: aURL [
+WebBrowser class >> openNativeWebBrowserOn: aURLString [
 
 	self subclassResponsibility
 ]
 
 { #category : #'instance creation' }
-WebBrowser class >> openOn: aURLString [
-	"Open the webbrowser on the given URL"
+WebBrowser class >> openOn: anURLOrString [
+	"Open the webbrowser on the given URL or String"
 	
 	^self webbrowserClassForPlatform 
-				openNativeWebBrowserOn: aURLString	
+				openNativeWebBrowserOn: anURLOrString asString
 
 ]
 


### PR DESCRIPTION
Fix #9064 by making WebBrowser more flexible and let also accept ZnURLs (or other objects who can convert themself into a URL string via #asString)