### PR TITLE
Fix/9056: The 'meta' keyboard shortcut modifier should not be used in the UI

### DIFF
--- a/src/Commander-Activators-ContextMenu/CmdCommandActivator.extension.st
+++ b/src/Commander-Activators-ContextMenu/CmdCommandActivator.extension.st
@@ -22,5 +22,5 @@ CmdCommandActivator >> setUpShortcutTipForMenuItem: aMenuItemMorph [
 	CmdShortcutActivation 
 		activeInstancesFor: command class inContext: context
 		do: [ :shortcut |  	
-			aMenuItemMorph keyText: (shortcut keyCombination acceptVisitorForGenericPlatform: OSPlatform current shortcutPrinter)]
+			aMenuItemMorph keyText: (shortcut keyCombination acceptVisitor: OSPlatform current shortcutPrinter)]
 ]

--- a/src/Commander-Activators-ContextMenu/CmdCommandActivator.extension.st
+++ b/src/Commander-Activators-ContextMenu/CmdCommandActivator.extension.st
@@ -22,5 +22,5 @@ CmdCommandActivator >> setUpShortcutTipForMenuItem: aMenuItemMorph [
 	CmdShortcutActivation 
 		activeInstancesFor: command class inContext: context
 		do: [ :shortcut |  	
-			aMenuItemMorph keyText: (KMShortcutPrinter toString: shortcut keyCombination)]
+			aMenuItemMorph keyText: (shortcut keyCombination acceptVisitorForGenericPlatform: OSPlatform current shortcutPrinter)]
 ]

--- a/src/Keymapping-Core/KMOSXShortcutPrinter.class.st
+++ b/src/Keymapping-Core/KMOSXShortcutPrinter.class.st
@@ -1,0 +1,36 @@
+Class {
+	#name : #KMOSXShortcutPrinter,
+	#superclass : #KMShortcutPrinter,
+	#category : #'Keymapping-Core-Base'
+}
+
+{ #category : #visiting }
+KMOSXShortcutPrinter >> basicModifierStringsOf: aShortcut [
+
+	| list |
+	list := super basicModifierStringsOf: aShortcut.
+	list replaceAll: 'Meta' with: 'Cmd'.
+	^ list
+]
+
+{ #category : #visiting }
+KMOSXShortcutPrinter >> mapSpecialCharacter: char [ 
+
+	char = KeyboardKey enter ifTrue: [ ^ self class symbolTableAt: #Enter ifAbsent: [ 'Enter' ] ].	
+	(char = (KeyboardKey fromCharacter: Character space))
+		ifTrue: [ ^ self class symbolTableAt: #Space ifAbsent: [ 'Space' ] ].	
+	^ char name asUppercase
+]
+
+{ #category : #visiting }
+KMOSXShortcutPrinter >> visitSingleShortcut: aShortcut [
+
+	| keyParts symbols char |
+	keyParts := self shortcutModifiersOf: aShortcut.
+	symbols := keyParts inject: '' into: [ :s :each | 
+		           s , (self class
+			            symbolTableAt: each
+			            ifAbsent: [ each capitalized ]) ].
+	char := self mapSpecialCharacter: aShortcut platformCharacter.
+	^ symbols , char asString
+]

--- a/src/Keymapping-Core/KMShortcutPrinter.class.st
+++ b/src/Keymapping-Core/KMShortcutPrinter.class.st
@@ -5,9 +5,6 @@ I'm an util to convert a shortcut into the representation used in a platform (th
 Class {
 	#name : #KMShortcutPrinter,
 	#superclass : #OSPlatformVisitor,
-	#instVars : [
-		'shortcut'
-	],
 	#classVars : [
 		'SymbolTable'
 	],
@@ -49,62 +46,26 @@ KMShortcutPrinter class >> toString: aShortcut [
 ]
 
 { #category : #private }
-KMShortcutPrinter >> genericShortcutFor: aShortcut [
-
-	| char |
-	char := self genericSpecialCharacter: aShortcut platformCharacter.	
-	^ String streamContents: [ :stream |
-		(self shortcutModifiersOf: aShortcut)
-			do: [ :each | stream << each ]
-			separatedBy: [ stream << '+' ].
-		stream << '+'.
-		stream << char ]
-	
+KMShortcutPrinter >> basicModifierStringsOf: aShortcut [
+		
+	^ (aShortcut platformModifier asString substrings: '+') collect: [:each | each trimBoth]
 ]
 
 { #category : #visiting }
-KMShortcutPrinter >> genericSpecialCharacter: char [ 
+KMShortcutPrinter >> mapSpecialCharacter: char [ 
 
 	char = KeyboardKey enter ifTrue: [ ^ 'Enter' ].
 	char = (KeyboardKey fromCharacter: Character space) ifTrue: [ ^ 'Space' ].
 	^ char	 name
 ]
 
-{ #category : #visiting }
-KMShortcutPrinter >> macSpecialCharacter: char [ 
-
-	char = KeyboardKey enter ifTrue: [ ^ self class symbolTableAt: #Enter ifAbsent: [ 'Enter' ] ].	
-	(char = (KeyboardKey fromCharacter: Character space))
-		ifTrue: [ ^ self class symbolTableAt: #Space ifAbsent: [ 'Space' ] ].	
-	^ char name asUppercase
-]
-
-{ #category : #private }
-KMShortcutPrinter >> osxShortcutFor: aShortcut [
-
-	| keyParts symbols char |
-
-	keyParts := self shortcutModifiersOf: aShortcut.
-	symbols := keyParts 
-		inject: ''
-		into: [ :s :each | 
-			s, (self class symbolTableAt: each ifAbsent: [ each capitalized ]) ].
-	
-	char := self macSpecialCharacter: aShortcut platformCharacter.
-	^ symbols, char asString
-]
-
-{ #category : #accessing }
-KMShortcutPrinter >> shortcut: aShortcut [
-
-	shortcut := aShortcut
-]
-
 { #category : #private }
 KMShortcutPrinter >> shortcutModifiersOf: aShortcut [
 	| modifiers |
 	
-	modifiers := (aShortcut platformModifier asString substrings: '+') collect: [:each | each trimBoth].
+	modifiers := self basicModifierStringsOf: aShortcut.
+	modifiers replaceAll: 'Meta' with: 'Ctrl'.
+	
 	"Ensure shift is first"
 	((modifiers includes: 'Shift') 
 		and: [ modifiers first ~= 'Shift' ])
@@ -114,37 +75,20 @@ KMShortcutPrinter >> shortcutModifiersOf: aShortcut [
 ]
 
 { #category : #visiting }
-KMShortcutPrinter >> visitCombinationShortcutOnGeneric: aShortcut [
+KMShortcutPrinter >> visitCombinationShortcut: aShortcut [
 
-	^ (shortcut sequence collect: [ :e | self genericShortcutFor: e ]) joinUsing: ','
+	^ (aShortcut sequence collect: [ :e | self visitSingleShortcut: e ]) joinUsing: ','
 ]
 
 { #category : #visiting }
-KMShortcutPrinter >> visitCombinationShortcutOnOSX: aShortcut [
+KMShortcutPrinter >> visitSingleShortcut: aShortcut [
 
-	^ (shortcut sequence collect: [ :e | self osxShortcutFor: e ]) joinUsing: ','
-]
-
-{ #category : #visiting }
-KMShortcutPrinter >> visitGeneric: aPlatform [
-	
-	^ shortcut acceptVisitorForGenericPlatform: self
-]
-
-{ #category : #visiting }
-KMShortcutPrinter >> visitMacOS: aPlatform [
-	
-	^ shortcut acceptVisitorForOSXPlatform: self
-]
-
-{ #category : #visiting }
-KMShortcutPrinter >> visitSingleShortcutOnGeneric: aShortcut [
-
-	^ self genericShortcutFor: shortcut
-]
-
-{ #category : #visiting }
-KMShortcutPrinter >> visitSingleShortcutOnOSX: aShortcut [
-
-	^ self osxShortcutFor: shortcut
+	| char |
+	char := self mapSpecialCharacter: aShortcut platformCharacter.
+	^ String streamContents: [ :stream | 
+		  (self shortcutModifiersOf: aShortcut)
+			  do: [ :each | stream << each ]
+			  separatedBy: [ stream << '+' ].
+		  stream << '+'.
+		  stream << char ]
 ]

--- a/src/Keymapping-Core/MacOSPlatform.extension.st
+++ b/src/Keymapping-Core/MacOSPlatform.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #MacOSPlatform }
+
+{ #category : #'*Keymapping-Core' }
+MacOSPlatform >> shortcutPrinter [
+	
+	^ KMOSXShortcutPrinter new
+]

--- a/src/Keymapping-Core/OSPlatform.extension.st
+++ b/src/Keymapping-Core/OSPlatform.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #OSPlatform }
+
+{ #category : #'*Keymapping-Core' }
+OSPlatform >> shortcutPrinter [
+	"Return a generic shortcut printer"
+	^ KMShortcutPrinter new
+]

--- a/src/Keymapping-KeyCombinations/KMKeyCombination.class.st
+++ b/src/Keymapping-KeyCombinations/KMKeyCombination.class.st
@@ -51,7 +51,7 @@ KMKeyCombination >> = aShortcut [
 ]
 
 { #category : #printing }
-KMKeyCombination >> acceptVisitorForGenericPlatform: aKMShortcutPrinter [ 
+KMKeyCombination >> acceptVisitor: aKMShortcutPrinter [ 
 
 	^ aKMShortcutPrinter visitSingleShortcut: self
 ]

--- a/src/Keymapping-KeyCombinations/KMKeyCombination.class.st
+++ b/src/Keymapping-KeyCombinations/KMKeyCombination.class.st
@@ -53,14 +53,7 @@ KMKeyCombination >> = aShortcut [
 { #category : #printing }
 KMKeyCombination >> acceptVisitorForGenericPlatform: aKMShortcutPrinter [ 
 
-	^ aKMShortcutPrinter visitSingleShortcutOnGeneric: self
-]
-
-{ #category : #printing }
-KMKeyCombination >> acceptVisitorForOSXPlatform: aKMShortcutPrinter [ 
-	
-	^ aKMShortcutPrinter visitSingleShortcutOnOSX: self
-
+	^ aKMShortcutPrinter visitSingleShortcut: self
 ]
 
 { #category : #converting }

--- a/src/Keymapping-KeyCombinations/KMKeyCombinationSequence.class.st
+++ b/src/Keymapping-KeyCombinations/KMKeyCombinationSequence.class.st
@@ -45,13 +45,7 @@ KMKeyCombinationSequence >> = aShortcut [
 { #category : #printing }
 KMKeyCombinationSequence >> acceptVisitorForGenericPlatform: aKMShortcutPrinter [ 
 	
-	^ aKMShortcutPrinter visitCombinationShortcutOnGeneric: self
-]
-
-{ #category : #printing }
-KMKeyCombinationSequence >> acceptVisitorForOSXPlatform: aKMShortcutPrinter [ 
-	
-	^ aKMShortcutPrinter visitCombinationShortcutOnOSX: self
+	^ aKMShortcutPrinter visitCombinationShortcut: self
 ]
 
 { #category : #accessing }

--- a/src/Keymapping-KeyCombinations/KMKeyCombinationSequence.class.st
+++ b/src/Keymapping-KeyCombinations/KMKeyCombinationSequence.class.st
@@ -43,7 +43,7 @@ KMKeyCombinationSequence >> = aShortcut [
 ]
 
 { #category : #printing }
-KMKeyCombinationSequence >> acceptVisitorForGenericPlatform: aKMShortcutPrinter [ 
+KMKeyCombinationSequence >> acceptVisitor: aKMShortcutPrinter [ 
 	
 	^ aKMShortcutPrinter visitCombinationShortcut: self
 ]

--- a/src/Keymapping-Tests/KMShortcutPrinterTest.class.st
+++ b/src/Keymapping-Tests/KMShortcutPrinterTest.class.st
@@ -104,6 +104,6 @@ KMShortcutPrinterTest >> shortcut: anObject [
 KMShortcutPrinterTest >> testPrintShortcut [
 	| printed |
 
-	printed := shortcut acceptVisitorForGenericPlatform: platform shortcutPrinter.
+	printed := shortcut acceptVisitor: platform shortcutPrinter.
 	self assert: printed equals: result
 ]

--- a/src/Keymapping-Tests/KMShortcutPrinterTest.class.st
+++ b/src/Keymapping-Tests/KMShortcutPrinterTest.class.st
@@ -21,6 +21,7 @@ KMShortcutPrinterTest class >> testParameters [
 
 	^ super testParameters
 		"linux"
+		addCase: { #platform -> UnixPlatform new. #shortcut -> $n meta. #result -> 'Ctrl+N' };
 		addCase: { #platform -> UnixPlatform new. #shortcut -> $n command. #result -> 'Cmd+N' };
 		addCase: { #platform -> UnixPlatform new. #shortcut -> $n control. #result -> 'Ctrl+N' };
 		addCase: { #platform -> UnixPlatform new. #shortcut -> $n alt. #result -> 'Alt+N' };
@@ -34,6 +35,7 @@ KMShortcutPrinterTest class >> testParameters [
 			#shortcut -> Character cr shift. 
 			#result -> 'Shift+Enter' };
 		"windows"
+		addCase: { #platform -> WinPlatform new. #shortcut -> $n meta. #result -> 'Ctrl+N' };
 		addCase: { #platform -> WinPlatform new. #shortcut -> $n command. #result -> 'Cmd+N' };
 		addCase: { #platform -> WinPlatform new. #shortcut -> $n control. #result -> 'Ctrl+N' };
 		addCase: { #platform -> WinPlatform new. #shortcut -> $n alt. #result -> 'Alt+N' };
@@ -102,9 +104,6 @@ KMShortcutPrinterTest >> shortcut: anObject [
 KMShortcutPrinterTest >> testPrintShortcut [
 	| printed |
 
-	printed := platform accept: (KMShortcutPrinter new
-		shortcut: shortcut;
-		yourself).
-
+	printed := shortcut acceptVisitorForGenericPlatform: platform shortcutPrinter.
 	self assert: printed equals: result
 ]

--- a/src/NewTools-Core/StHeaderBar.class.st
+++ b/src/NewTools-Core/StHeaderBar.class.st
@@ -88,7 +88,7 @@ StHeaderBar >> label: aString [
 { #category : #accessing }
 StHeaderBar >> shortcut: aShortcut [ 
 
-	self shortcutLabel: (KMShortcutPrinter toString: aShortcut)
+	self shortcutLabel: (aShortcut asKeyCombination acceptVisitor: OSPlatform current shortcutPrinter	)
 ]
 
 { #category : #private }

--- a/src/NewTools-Spotter/StSpotterHeaderPresenter.class.st
+++ b/src/NewTools-Spotter/StSpotterHeaderPresenter.class.st
@@ -140,7 +140,7 @@ StSpotterHeaderPresenter >> order [
 StSpotterHeaderPresenter >> prepareAsClasses [
 
 	labelPresenter label: '#Classes'.
-	helpLabelPresenter label: (KMShortcutPrinter toString: self model keyBindingForClasses).
+	helpLabelPresenter label: (self model keyBindingForClasses acceptVisitor: OSPlatform current shortcutPrinter).
 ]
 
 { #category : #accessing }
@@ -148,7 +148,7 @@ StSpotterHeaderPresenter >> prepareAsImplementors [
 
 	order := self model order + 1.
 	labelPresenter label: '#Implementors'.
-	helpLabelPresenter label: (KMShortcutPrinter toString: self model keyBindingForImplementors).
+	helpLabelPresenter label: (self model keyBindingForImplementors acceptVisitor: OSPlatform current shortcutPrinter).
 ]
 
 { #category : #accessing }
@@ -156,7 +156,7 @@ StSpotterHeaderPresenter >> prepareAsPackages [
 
 	order := self model order + 2.
 	labelPresenter label: '#Packages'.
-	helpLabelPresenter label: (KMShortcutPrinter toString: self model keyBindingForPackages).
+	helpLabelPresenter label: (self model keyBindingForPackages acceptVisitor: OSPlatform current shortcutPrinter).
 ]
 
 { #category : #'accessing model' }

--- a/src/Spec2-Adapters-Morphic/SpMorphicMenuItemAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicMenuItemAdapter.class.st
@@ -163,8 +163,7 @@ SpMorphicMenuItemAdapter >> shortcutText [
 
 	"We can use the KMShortcutPrinter. ToggleMenuItemMorph handles when it has been already normalized or not"
 		
-	^ KMShortcutPrinter toString: shortcut asKeyCombination
-	
+	^ shortcut asKeyCombination acceptVisitor: OSPlatform current shortcutPrinter	
 ]
 
 { #category : #'widget API' }


### PR DESCRIPTION
Fix #9056

- Refactor a bit KMShortcut printer
- Add tests about Meta mapping