### PR TITLE
5818-SHRBTextStyler-doesnt-format-comments-on-root-AST-node

### DIFF
--- a/src/Shout-Tests/SHRBTextStylerTest.class.st
+++ b/src/Shout-Tests/SHRBTextStylerTest.class.st
@@ -32,6 +32,22 @@ SHRBTextStylerTest >> style: aText [
 	^ ast
 ]
 
+{ #category : #'private - utilities' }
+SHRBTextStylerTest >> styleExpression: aText [
+
+	| ast |
+	
+	ast := self class compiler
+		source: aText asString;
+		noPattern: true ;
+		options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
+		requestor: nil;
+		parse.				
+	styler style: aText ast: ast.
+	
+	^ ast
+]
+
 { #category : #running }
 SHRBTextStylerTest >> tearDown [ 
 
@@ -55,6 +71,40 @@ SHRBTextStylerTest >> testArgumentStylingBlock [
 	index2 := 22. "second each"
 	attribute := aText attributesAt: index2.
 	self assert: attribute equals: (SHRBTextStyler  attributesFor: #blockArg pixelHeight: 10)
+]
+
+{ #category : #tests }
+SHRBTextStylerTest >> testArgumentStylingExpressionWithComment [
+	
+	| aText index1 index2 attribute |
+
+	aText := '"comment"3+4.' asText.
+	self styleExpression: aText.
+	
+	index1 := 5. "inside comment"
+	attribute := aText attributesAt: index1.
+	self assert: attribute equals: (SHRBTextStyler  attributesFor: #comment pixelHeight: 10).
+	
+	index2 := 11. "outside the +"
+	attribute := (aText attributesAt: index2) first.
+	self assert: attribute equals: (SHRBTextStyler  attributesFor: #unary pixelHeight: 10) first
+]
+
+{ #category : #tests }
+SHRBTextStylerTest >> testArgumentStylingExpressionWithComment2 [
+	
+	| aText index1 index2 attribute |
+
+	aText := '"comment"3.' asText.
+	self styleExpression: aText.
+	
+	index1 := 5. "inside comment"
+	attribute := aText attributesAt: index1.
+	self assert: attribute equals: (SHRBTextStyler  attributesFor: #comment pixelHeight: 10).
+	
+	index2 := 10. "outside the 3"
+	attribute := (aText attributesAt: index2) first.
+	self assert: attribute equals: (SHRBTextStyler  attributesFor: #integer pixelHeight: 10) first
 ]
 
 { #category : #tests }

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1063,7 +1063,7 @@ SHRBTextStyler >> style: aText ast: ast [
 	charAttr := Array new: aText size withAll: (self attributesFor: #default).
 	bracketLevel := 0.
 	parentheseLevel:=0.
-	ast acceptVisitor: self.
+	self visitNode: ast.
 	^aText runs: (RunArray newFrom: charAttr)	
 
 ]


### PR DESCRIPTION
This PR implements the fix described in the issue tracker entry.

I added the two examples as tests, the testArgumentStylingExpressionWithComment2 was failing without the fix and is now green.

fixes #5818
fixes #7075