### PR TITLE
9069-Typing-in-Transcript-gives-a-DNU-doItContext-CompletionEngine

### DIFF
--- a/src/Transcript-Core/ThreadSafeTranscript.class.st
+++ b/src/Transcript-Core/ThreadSafeTranscript.class.st
@@ -117,6 +117,11 @@ ThreadSafeTranscript >> critical: block [
 	^ accessSemaphore critical: block 
 ]
 
+{ #category : #accessing }
+ThreadSafeTranscript >> doItContext [
+	^nil
+]
+
 { #category : #streaming }
 ThreadSafeTranscript >> endEntry [
 "	
@@ -264,7 +269,7 @@ ThreadSafeTranscript >> title [
 	^ 'Transcript'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 ThreadSafeTranscript >> variableBindings [
 
 	^ Dictionary new


### PR DESCRIPTION
- fixes #9069 by implementing #doItContext returning nil
- categorize a method


