### PR TITLE
6337-Ensure-test-classes-are-named-in-singular 

### DIFF
--- a/src/ReleaseTests/ProperlyImplementedSUnitClassesTest.class.st
+++ b/src/ReleaseTests/ProperlyImplementedSUnitClassesTest.class.st
@@ -39,3 +39,13 @@ ProperlyImplementedSUnitClassesTest >> testAndMakeSureSuperTearDownIsCalledAsLas
 						ifTrue: [ violating add: method ] ] ].
 	self assertEmpty: violating
 ]
+
+{ #category : #tests }
+ProperlyImplementedSUnitClassesTest >> testTestClassesShouldBeSingular [
+
+	| violations |
+	"Ensure test class names are consistent"
+	violations := Object allSubclasses select: [ :each | 
+		              (each inheritsFrom: TestCase) and: [ each name endsWith: 'Tests' ] ].
+	self assert: violations isEmpty
+]


### PR DESCRIPTION
add #testTestClassesShouldBeSingular as a release test to ProperlyImplementedSUnitClassesTest

fixes #6337


