### PR TITLE
ReleaseTest-Dot-end-of-Signature

### DIFF
--- a/src/OSWindow-Core/OSWindowDriver.class.st
+++ b/src/OSWindow-Core/OSWindowDriver.class.st
@@ -109,8 +109,7 @@ OSWindowDriver class >> shutDown: quitting [
 ]
 
 { #category : #events }
-OSWindowDriver >> afterSetWindowTitle: windowTitle onWindow: osWindow [.	
-
+OSWindowDriver >> afterSetWindowTitle: windowTitle onWindow: osWindow [
 ]
 
 { #category : #'window creation' }

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -213,24 +213,6 @@ ReleaseTest >> testManifestNamesAccordingToPackageNames [
 		 self assert: (expectedManifestNames includes: each)] 
 ]
 
-{ #category : #'tests - source' }
-ReleaseTest >> testMethodSignaturePeriod [
-	| methods |
-	methods := SystemNavigation new allMethods select: [ :method | 
- 		method sourceCode lines first trimRight last == $..].
-	
-	"there are 11 problematic methods"
-	self assert: methods size <=11.
-	
-	"there should be no method left"
-	"self assert: methods isEmpty description: [ 
-		String streamContents: [ :stream | 
-			stream
-				nextPutAll: 'Found methods with period in signature:';
-				print: methods ] ]"
-	
-]
-
 { #category : #tests }
 ReleaseTest >> testMethodsContainNoHalt [
 
@@ -281,6 +263,24 @@ ReleaseTest >> testNoEmptyPackages [
 ReleaseTest >> testNoNilAssignmentInInitializeMethod [
 	
 	self assertValidLintRule: ReNoNilAssignationInInitializeRule new
+	
+]
+
+{ #category : #'tests - source' }
+ReleaseTest >> testNoPeriodInMethodSignature [
+	| methods |
+	methods := SystemNavigation new allMethods select: [ :method | 
+ 		method sourceCode lines first trimRight last == $..].
+	
+	"there are 11 problematic methods"
+	self assert: methods size <=11.
+	
+	"there should be no method left"
+	"self assert: methods isEmpty description: [ 
+		String streamContents: [ :stream | 
+			stream
+				nextPutAll: 'Found methods with period in signature:';
+				print: methods ] ]"
 	
 ]
 

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -213,6 +213,24 @@ ReleaseTest >> testManifestNamesAccordingToPackageNames [
 		 self assert: (expectedManifestNames includes: each)] 
 ]
 
+{ #category : #'tests - source' }
+ReleaseTest >> testMethodSignaturePeriod [
+	| methods |
+	methods := SystemNavigation new allMethods select: [ :method | 
+ 		method sourceCode lines first trimRight last == $..].
+	
+	"there are 11 problematic methods"
+	self assert: methods size <=11.
+	
+	"there should be no method left"
+	"self assert: methods isEmpty description: [ 
+		String streamContents: [ :stream | 
+			stream
+				nextPutAll: 'Found methods with period in signature:';
+				print: methods ] ]"
+	
+]
+
 { #category : #tests }
 ReleaseTest >> testMethodsContainNoHalt [
 


### PR DESCRIPTION
- add release teset #testMethodSignaturePeriod
- fix one problematic case

The other 11 cases are all in Roassal and Iceberg, we need to fix them there.


