### PR TITLE
Fix for #9096 string >>> as time is very permissive

### DIFF
--- a/src/Fuel-Tests-Core/FLBasicSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLBasicSerializationTest.class.st
@@ -264,20 +264,22 @@ FLBasicSerializationTest >> testDate [
 
 { #category : #tests }
 FLBasicSerializationTest >> testDateAndTime [
-	
+
 	| initialTime initialDate |
 	initialTime := Time fromSeconds: 76020.
 	initialDate := Date fromSeconds: 3492288000.
-	self assertSerializationEqualityOf: (DateAndTime date: initialDate time: initialTime).
-	
-	initialTime := (Time hour: 24 minute: 60 second: 60).
+	self assertSerializationEqualityOf:
+		(DateAndTime date: initialDate time: initialTime).
+
+	initialTime := Time hour: 0 minute: 0 second: 0.
 	initialDate := Date year: 3050 month: 12 day: 31.
-	self assertSerializationEqualityOf: (DateAndTime date: initialDate time: initialTime).
-	
-	initialTime := (Time hour: 24 minute: 60 second: 60).
+	self assertSerializationEqualityOf:
+		(DateAndTime date: initialDate time: initialTime).
+
+	initialTime := Time hour: 0 minute: 0 second: 0.
 	initialDate := Date year: 1600 month: 12 day: 31.
-	self assertSerializationEqualityOf: (DateAndTime date: initialDate time: initialTime).
-	
+	self assertSerializationEqualityOf:
+		(DateAndTime date: initialDate time: initialTime)
 ]
 
 { #category : #tests }
@@ -790,14 +792,19 @@ FLBasicSerializationTest >> testSystemDictionary [
 FLBasicSerializationTest >> testTime [
 
 	self assertSerializationEqualityOf: (Time fromSeconds: 84072).
-	self assertSerializationEqualityOf: (Time hour: 24 minute: 60 second: 60).
-	self assertSerializationEqualityOf: (Time hour: 23 minute: 59 second: 59).
-	self assertSerializationEqualityOf: (Time hour: 0 minute: 0 second: 0).
+	self assertSerializationEqualityOf:
+		(Time hour: 0 minute: 0 second: 0).
+	self assertSerializationEqualityOf:
+		(Time hour: 23 minute: 59 second: 59).
+	self assertSerializationEqualityOf:
+		(Time hour: 0 minute: 0 second: 0).
 	self assertSerializationEqualityOf: (Time seconds: 0 nanoSeconds: 5).
-	self assertSerializationEqualityOf: (Time allInstances sort:  [:a :b | a asSeconds > b asSeconds]) first.
-	self assertSerializationEqualityOf: (Time allInstances sort:  [:a :b | a nanoSecond > b nanoSecond]) first
-		
-
+	self assertSerializationEqualityOf:
+		(Time allInstances sort: [ :a :b | a asSeconds > b asSeconds ])
+			first.
+	self assertSerializationEqualityOf:
+		(Time allInstances sort: [ :a :b | a nanoSecond > b nanoSecond ])
+			first
 ]
 
 { #category : #tests }

--- a/src/Kernel-Chronology-Extras/Time.extension.st
+++ b/src/Kernel-Chronology-Extras/Time.extension.st
@@ -203,6 +203,7 @@ Time class >> noon [
 
 { #category : #'*Kernel-Chronology-Extras' }
 Time class >> readFrom: aStream [
+
 	"Read a Time from the stream in the form:
 		<hour>:<minute>:<second>.<nseconds> <am/pm>
 	<minute>, <second> or <am/pm> may be omitted.  e.g. 1:59:30 pm; 8AM; 15:30"
@@ -210,34 +211,38 @@ Time class >> readFrom: aStream [
 	| hour minute second ampm nanos power |
 	hour := Integer readFrom: aStream.
 	minute := second := nanos := 0.
-	(aStream peekFor: $:) 
-		ifTrue: [
-			minute := Integer readFrom: aStream.
-			(aStream peekFor: $:) 
-				ifTrue: [
-					second := Integer readFrom: aStream.
-					(aStream peekFor: $.)
-						ifTrue: [ 
-							power := 1.
-							[ aStream atEnd not and: [ aStream peek isDigit ] ]
-								whileTrue: [  
-									nanos := nanos * 10 + aStream next digitValue.
-									power := power * 10 ].
-							nanos := nanos / power * 1000000000 ] ] ].
+	(aStream peekFor: $:) ifTrue: [ 
+		minute := Integer readFrom: aStream.
+		(aStream peekFor: $:) ifTrue: [ 
+			second := Integer readFrom: aStream.
+			(aStream peekFor: $.) ifTrue: [ 
+				power := 1.
+				[ aStream atEnd not and: [ aStream peek isDigit ] ] whileTrue: [ 
+					nanos := nanos * 10 + aStream next digitValue.
+					power := power * 10 ].
+				nanos := nanos / power * 1000000000 ] ] ].
 	aStream skipSeparators.
-	(aStream atEnd not and: [ 'APap' includes: aStream peek ]) 
-		ifTrue: [
-			ampm := aStream next asLowercase.
-			(ampm = $p and: [ hour < 12 ]) ifTrue: [ hour := hour + 12 ].
-			(ampm = $a and: [ hour = 12 ]) ifTrue: [ hour := 0 ].
-			(aStream peekFor: $m) ifFalse: [ aStream peekFor: $M ] ].
+	aStream atEnd ifFalse: [ 
+		('APap' includes: aStream peek)
+			ifTrue: [ 
+				ampm := aStream next asLowercase.
+				(ampm = $p and: [ hour < 12 ]) ifTrue: [ hour := hour + 12 ].
+				(ampm = $a and: [ hour = 12 ]) ifTrue: [ hour := 0 ].
+				(aStream peekFor: $m) ifFalse: [ aStream peekFor: $M ] ]
+			ifFalse: [ 
+				('Z+-' includes: aStream peek) ifFalse: [ 
+					Error new signal: 'Trailing characters after time' ] ] ].
+
 	aStream skipSeparators.
-	aStream atEnd ifFalse: [ Error new signal: 'Trailing characters after time' ].
-	^ self 
-		hour: hour 
-		minute: minute 
-		second: second 
-		nanoSecond: nanos
+	aStream atEnd ifFalse: [  
+	    ('Z+-' includes: aStream peek) ifFalse: [ 
+					Error new signal: 'Trailing characters after time' ]].
+	
+	^ self
+		  hour: hour
+		  minute: minute
+		  second: second
+		  nanoSecond: nanos
 ]
 
 { #category : #'*Kernel-Chronology-Extras' }

--- a/src/Kernel-Chronology-Extras/Time.extension.st
+++ b/src/Kernel-Chronology-Extras/Time.extension.st
@@ -150,8 +150,8 @@ Time class >> hour: hour minute: minute second: second  nano: nano [
 Time class >> hour: hour minute: minute second: second  nanoSecond: nanoCount [
 	"Answer a Time - only second precision for now"
 	
-	hour >= 24 ifTrue: [ Error new signal: 'An hour must be 24 or less' ].
-	minute >= 60 ifTrue: [ Error new signal: 'A minute must be 60 or less' ].
+	hour >= HoursInDay ifTrue: [ Error new signal: ('An hour must be {1} or less' format: {HoursInDay})].
+	minute >= MinutesInHour ifTrue: [ Error new signal: ('A minute must be {1} or less' format: {MinutesInHour}) ].
 	second > SecondsInMinute ifTrue: [ Error new signal: ('A second must be {1} or less' format: {SecondsInMinute}) ].
 	
  	^ self 

--- a/src/Kernel-Chronology-Extras/Time.extension.st
+++ b/src/Kernel-Chronology-Extras/Time.extension.st
@@ -149,7 +149,11 @@ Time class >> hour: hour minute: minute second: second  nano: nano [
 { #category : #'*Kernel-Chronology-Extras' }
 Time class >> hour: hour minute: minute second: second  nanoSecond: nanoCount [
 	"Answer a Time - only second precision for now"
- 
+	
+	hour >= 24 ifTrue: [ Error new signal: 'An hour must be 24 or less' ].
+	minute >= 60 ifTrue: [ Error new signal: 'A minute must be 60 or less' ].
+	second > SecondsInMinute ifTrue: [ Error new signal: ('A second must be {1} or less' format: {SecondsInMinute}) ].
+	
  	^ self 
 		seconds: (hour * SecondsInHour) + (minute * SecondsInMinute) + second 
 		nanoSeconds: nanoCount
@@ -226,7 +230,10 @@ Time class >> readFrom: aStream [
 			ampm := aStream next asLowercase.
 			(ampm = $p and: [ hour < 12 ]) ifTrue: [ hour := hour + 12 ].
 			(ampm = $a and: [ hour = 12 ]) ifTrue: [ hour := 0 ].
-			(aStream peekFor: $m) ifFalse: [ aStream peekFor: $M ] ].
+			(aStream peekFor: $m) ifFalse: [ aStream peekFor: $M ] ]
+		ifFalse: [Error new signal: 'Invalid Time format.'].
+	aStream skipSeparators.
+	aStream atEnd ifFalse: [ Error new signal: 'Trailing characters after time' ].
 	^ self 
 		hour: hour 
 		minute: minute 

--- a/src/Kernel-Chronology-Extras/Time.extension.st
+++ b/src/Kernel-Chronology-Extras/Time.extension.st
@@ -230,8 +230,7 @@ Time class >> readFrom: aStream [
 			ampm := aStream next asLowercase.
 			(ampm = $p and: [ hour < 12 ]) ifTrue: [ hour := hour + 12 ].
 			(ampm = $a and: [ hour = 12 ]) ifTrue: [ hour := 0 ].
-			(aStream peekFor: $m) ifFalse: [ aStream peekFor: $M ] ]
-		ifFalse: [Error new signal: 'Invalid Time format.'].
+			(aStream peekFor: $m) ifFalse: [ aStream peekFor: $M ] ].
 	aStream skipSeparators.
 	aStream atEnd ifFalse: [ Error new signal: 'Trailing characters after time' ].
 	^ self 

--- a/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
@@ -61,7 +61,7 @@ FluidClassDefinitionPrinterTest >> testChronologyConstants [
 	self
 		assert: (self forClass: ChronologyConstants)
 		equals: 'SharedPool << #ChronologyConstants
-	sharedVariables: { #NanosInSecond . #MonthNames . #SecondsInHour . #SecondsInDay . #DayNames . #DaysInMonth . #NanosInMillisecond . #SecondsInMinute . #HoursInDay . #MinutesInHour . #MicrosecondsInDay };
+	sharedVariables: { #NanosInSecond . #MonthNames . #SecondsInHour . #SqueakEpoch . #SecondsInDay . #DayNames . #NanosInMillisecond . #DaysInMonth . #SecondsInMinute . #HoursInDay . #MinutesInHour . #MicrosecondsInDay };
 	tag: ''Chronology'';
 	package: ''Kernel'''
 ]

--- a/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
@@ -61,7 +61,7 @@ FluidClassDefinitionPrinterTest >> testChronologyConstants [
 	self
 		assert: (self forClass: ChronologyConstants)
 		equals: 'SharedPool << #ChronologyConstants
-	sharedVariables: { #NanosInSecond . #MonthNames . #SecondsInHour . #SqueakEpoch . #SecondsInDay . #DayNames . #NanosInMillisecond . #DaysInMonth . #SecondsInMinute . #HoursInDay . #MinutesInHour . #MicrosecondsInDay };
+	sharedVariables: { #NanosInSecond . #MonthNames . #SecondsInHour . #SecondsInDay . #DayNames . #DaysInMonth . #HoursInDay . #NanosInMillisecond . #SecondsInMinute . #SqueakEpoch . #MinutesInHour . #MicrosecondsInDay };
 	tag: ''Chronology'';
 	package: ''Kernel'''
 ]

--- a/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
@@ -57,9 +57,11 @@ FluidClassDefinitionPrinterTest >> testByteString [
 
 { #category : #'tests - classes' }
 FluidClassDefinitionPrinterTest >> testChronologyConstants [
-	
-	self assert: (self forClass: ChronologyConstants) equals: 'SharedPool << #ChronologyConstants
-	sharedVariables: { #NanosInSecond . #MonthNames . #SecondsInHour . #SecondsInDay . #SqueakEpoch . #NanosInMillisecond . #DayNames . #DaysInMonth . #SecondsInMinute . #MicrosecondsInDay };
+
+	self
+		assert: (self forClass: ChronologyConstants)
+		equals: 'SharedPool << #ChronologyConstants
+	sharedVariables: { #NanosInSecond . #MonthNames . #SecondsInHour . #SecondsInDay . #DayNames . #DaysInMonth . #NanosInMillisecond . #SecondsInMinute . #HoursInDay . #MinutesInHour . #MicrosecondsInDay };
 	tag: ''Chronology'';
 	package: ''Kernel'''
 ]

--- a/src/Kernel-Tests/LegacyClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/LegacyClassDefinitionPrinterTest.class.st
@@ -48,12 +48,12 @@ LegacyClassDefinitionPrinterTest >> testByteString [
 
 { #category : #'tests - classes' }
 LegacyClassDefinitionPrinterTest >> testChronologyConstants [
-	
-	self 
-		assert: (self forClass: ChronologyConstants) 
+
+	self
+		assert: (self forClass: ChronologyConstants)
 		equals: 'SharedPool subclass: #ChronologyConstants
 	instanceVariableNames: ''''
-	classVariableNames: ''DayNames DaysInMonth MicrosecondsInDay MonthNames NanosInMillisecond NanosInSecond SecondsInDay SecondsInHour SecondsInMinute SqueakEpoch''
+	classVariableNames: ''DayNames DaysInMonth HoursInDay MicrosecondsInDay MinutesInHour MonthNames NanosInMillisecond NanosInSecond SecondsInDay SecondsInHour SecondsInMinute SqueakEpoch''
 	poolDictionaries: ''''
 	category: ''Kernel-Chronology'''
 ]

--- a/src/Kernel-Tests/OldClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/OldClassDefinitionPrinterTest.class.st
@@ -52,12 +52,12 @@ OldClassDefinitionPrinterTest >> testByteString [
 
 { #category : #'tests - classes' }
 OldClassDefinitionPrinterTest >> testChronologyConstants [
-	
-	self 
-		assert: (self forClass: ChronologyConstants) 
+
+	self
+		assert: (self forClass: ChronologyConstants)
 		equals: 'SharedPool subclass: #ChronologyConstants
 	instanceVariableNames: ''''
-	classVariableNames: ''DayNames DaysInMonth MicrosecondsInDay MonthNames NanosInMillisecond NanosInSecond SecondsInDay SecondsInHour SecondsInMinute SqueakEpoch''
+	classVariableNames: ''DayNames DaysInMonth HoursInDay MicrosecondsInDay MinutesInHour MonthNames NanosInMillisecond NanosInSecond SecondsInDay SecondsInHour SecondsInMinute SqueakEpoch''
 	package: ''Kernel-Chronology'''
 ]
 

--- a/src/Kernel-Tests/TimeTest.class.st
+++ b/src/Kernel-Tests/TimeTest.class.st
@@ -302,11 +302,10 @@ TimeTest >> testReadFrom [
 { #category : #'tests - input' }
 TimeTest >> testReadFromWithError [
 		
-	| string |
-	string := 'invalid'.
-	self should: [self timeClass readFrom: string readStream] raise: Error.
-	string := '0:invalid'.
-	self should: [self timeClass readFrom: string readStream] raise: Error
+	#('invalid' '0:invalid' '1 invalid' '1 pm is the afternoon' '1250 Fake St, New York, USA 12345' '13000 AM' '25:69:1239' '1,3,6') do: [ :each | 
+	self should: [self timeClass readFrom: each readStream] raise: Error.]
+
+	
 
 ]
 

--- a/src/Kernel/ChronologyConstants.class.st
+++ b/src/Kernel/ChronologyConstants.class.st
@@ -7,7 +7,9 @@ Class {
 	#classVars : [
 		'DayNames',
 		'DaysInMonth',
+		'HoursInDay',
 		'MicrosecondsInDay',
+		'MinutesInHour',
 		'MonthNames',
 		'NanosInMillisecond',
 		'NanosInSecond',

--- a/src/Kernel/ChronologyConstants.class.st
+++ b/src/Kernel/ChronologyConstants.class.st
@@ -29,6 +29,8 @@ ChronologyConstants class >> initialize [
 	MicrosecondsInDay := SecondsInDay * 1e6.
 	SecondsInHour := 3600.
 	SecondsInMinute := 60.
+	MinutesInHour := 60.
+	HoursInDay := 24.
 	NanosInSecond := 10 raisedTo: 9.
 	NanosInMillisecond := 10 raisedTo: 6.
 	DayNames := #(Sunday Monday Tuesday Wednesday Thursday Friday Saturday).


### PR DESCRIPTION
Hi,

This change adds in additional checks to `Time class >>> hour:minute:second:nanoSecond:` and `Time class >>> readFrom:` to make sure that the given string is a valid time. I also extended `TimeTest >>> testReadFromWithError` to include a number of strings that (I think) not should be a time or are otherwise invalid times.

However, one of the existing tests `TimeTest >>> testSeconds` fails with these new changes. In this test, the string `20:33:14.321-05:00` is used and the final part `-05:00` causes the test to error. I believe that this is supposed to be a timezone designation however I don't see any mention of timezones being recognized by the `Time` object (neither the class comment or the `readFrom` comment mention timezone parsing). If this format is required to be valid, I'll change my code so that it does not error for this instance.