### PR TITLE
6319-SmallInteger-as31BitInteger-wrong-on-64-bit-systems 

### DIFF
--- a/src/Kernel/Integer.class.st
+++ b/src/Kernel/Integer.class.st
@@ -289,11 +289,6 @@ Integer >> anyMask: mask [
 	^0 ~= (self bitAnd: mask)
 ]
 
-{ #category : #accessing }
-Integer >> as31BitSmallInt [
-	^ self subclassResponsibility
-]
-
 { #category : #'converting-arrays' }
 Integer >> asByteArray [
 

--- a/src/Kernel/LargeInteger.class.st
+++ b/src/Kernel/LargeInteger.class.st
@@ -142,15 +142,6 @@ LargeInteger >> \\\ anInteger [
 ]
 
 { #category : #converting }
-LargeInteger >> as31BitSmallInt [
-	"This is only for 31 bit numbers.  Keep my 31 bits the same, but put them in a small int.  The small int will be negative since my 31st bit is 1.  We know my 31st bit is 1 because otherwise I would already be a positive small int."
-
-	self highBit = 31 ifFalse: [self error: 'more than 31 bits can not fit in a SmallInteger'].
-
-	^ self - 16r80000000
-]
-
-{ #category : #converting }
 LargeInteger >> asFloat [
 	"Answer a Float that best approximates the value of the receiver.
 	This algorithm is optimized to process only the significant digits of a LargeInteger.

--- a/src/Kernel/SmallInteger.class.st
+++ b/src/Kernel/SmallInteger.class.st
@@ -188,14 +188,6 @@ SmallInteger >> \\ aNumber [
 ]
 
 { #category : #converting }
-SmallInteger >> as31BitSmallInt [
-	"Polymorphic with LargePositiveInteger (see comment there).
-	 Return self since all SmallIntegers are 31 bits"
-
-	^ self
-]
-
-{ #category : #converting }
 SmallInteger >> asCharacter [
 	<primitive: 170>
 	^self primitiveFailed

--- a/src/NECompletion-Tests/CompletionContextTest.class.st
+++ b/src/NECompletion-Tests/CompletionContextTest.class.st
@@ -50,12 +50,7 @@ CompletionContextTest >> testReceiverClassVar [
 
 { #category : #tests }
 CompletionContextTest >> testReceiverConstant [
-	| text context |
-	text := 'testIt
-	15r16 as'.
-	context := self createContextFor: text at: text size.
-	self assert: ((context entries collect: [:each | each contents]) includes: #as31BitSmallInt).
-	
+	| text context |	
 	text := 'testIt
 	''test'' pre'.
 	context := self createContextFor: text at: text size.


### PR DESCRIPTION
as the method is not used (other than in a test), I propose to remove it

fixes #6319


