### PR TITLE
adding-variadic-TF-functions

### DIFF
--- a/src/ThreadedFFI-Tests/TFFunctionCallTest.class.st
+++ b/src/ThreadedFFI-Tests/TFFunctionCallTest.class.st
@@ -77,6 +77,30 @@ TFFunctionCallTest >> testCallbackInSingleFunction [
 ]
 
 { #category : #tests }
+TFFunctionCallTest >> testVariadicFunctionWithOneFixedAndTwoOptional [
+
+	| fun return buffer aString |
+
+	fun := TFExternalFunction
+		name: 'sprintf'
+		moduleName: LibC uniqueInstance ffiLibraryName
+		definition: (TFVariadicFunctionDefinition
+			parameterTypes: { TFBasicType pointer. TFBasicType pointer.  TFBasicType sint. TFBasicType sint }
+			returnType: TFBasicType sint
+			fixedArgumentCount: 2).
+	
+	buffer := ByteArray new: 50.
+	buffer pinInMemory.
+
+	aString := '%d %d' utf8Encoded.
+	aString pinInMemory.
+	
+	return := runner invokeFunction: fun withArguments: {PointerUtils oopForObject: buffer. PointerUtils oopForObject: aString . 5 . 5}.
+	
+	self assert: return equals: 3
+]
+
+{ #category : #tests }
 TFFunctionCallTest >> testWithFloatAndDouble [
 	| fun return |
 

--- a/src/ThreadedFFI-UFFI/TFCalloutMethodBuilder.class.st
+++ b/src/ThreadedFFI-UFFI/TFCalloutMethodBuilder.class.st
@@ -9,15 +9,13 @@ Class {
 
 { #category : #private }
 TFCalloutMethodBuilder >> createFFICalloutLiteralFromSpec: functionSpec [
-	| function |
 	
-	function := TFExternalFunction
-		name: functionSpec functionName
-		moduleName: self libraryName
-		parameterTypes: (functionSpec arguments collect: #tfExternalTypeWithArity)
-		returnType: functionSpec returnType tfExternalTypeWithArity.
-				
-	^ function
+	^ 	TFExternalFunction
+			name: functionSpec functionName
+			moduleName: self libraryName
+			parameterTypes: (functionSpec arguments collect: #tfExternalTypeWithArity)
+			returnType: functionSpec returnType tfExternalTypeWithArity
+			fixedArgumentCount: fixedArgumentCount 
 ]
 
 { #category : #private }

--- a/src/ThreadedFFI/TFExternalFunction.class.st
+++ b/src/ThreadedFFI/TFExternalFunction.class.st
@@ -56,24 +56,35 @@ TFExternalFunction class >> name: aName moduleName: aModuleName definition: aFun
 { #category : #'instance creation' }
 TFExternalFunction class >> name: aName moduleName: aModuleName parameterTypes: parameterTypes returnType: returnType [
 
+	^ self name: aName moduleName: aModuleName parameterTypes: parameterTypes returnType: returnType fixedArgumentCount: 0
+]
+
+{ #category : #'instance creation' }
+TFExternalFunction class >> name: aName moduleName: aModuleName parameterTypes: parameterTypes returnType: returnType fixedArgumentCount: fixedArgumentCount [
+
+	| definition |
+
+	definition := fixedArgumentCount = 0 
+		ifTrue:[	
+			TFFunctionDefinition 
+				parameterTypes: parameterTypes
+				returnType: returnType]
+		ifFalse:[	
+			TFVariadicFunctionDefinition 
+				parameterTypes: parameterTypes
+				returnType: returnType
+				fixedArgumentCount: fixedArgumentCount].
+
 	^ self
 		name: aName
 		moduleName: aModuleName
-		definition: (TFFunctionDefinition 
-			parameterTypes: parameterTypes
-			returnType: returnType)
-
+		definition: definition
 ]
 
 { #category : #'instance creation' }
 TFExternalFunction class >> name: aName moduleName: aModuleName parameterTypes: parameterTypes returnType: returnType type: aFunctionCallType [
 
-	^ (self
-		name: aName
-		moduleName: aModuleName
-		definition: (TFFunctionDefinition 
-			parameterTypes: parameterTypes
-			returnType: returnType))
+	^ (self name: aName moduleName: aModuleName parameterTypes: parameterTypes returnType: returnType)
 		type: aFunctionCallType;
 		yourself
 

--- a/src/ThreadedFFI/TFFunctionDefinition.class.st
+++ b/src/ThreadedFFI/TFFunctionDefinition.class.st
@@ -44,6 +44,12 @@ TFFunctionDefinition class >> parameterTypes: someParameters returnType: returnT
 		yourself
 ]
 
+{ #category : #private }
+TFFunctionDefinition >> doValidate: parameterHandlers [
+
+	self primDefineFunctionWith: parameterHandlers returnType: returnType getHandle
+]
+
 { #category : #accessing }
 TFFunctionDefinition >> parameterTypes [
 	^ parameterTypes
@@ -91,5 +97,7 @@ TFFunctionDefinition >> validate [
 	returnType validate.
 	
 	parameterHandlers := parameterTypes collect: [ :e | e getHandle ] as: Array.
-	self primDefineFunctionWith: parameterHandlers returnType: returnType getHandle
+	
+	self doValidate: parameterHandlers.
+
 ]

--- a/src/ThreadedFFI/TFVariadicFunctionDefinition.class.st
+++ b/src/ThreadedFFI/TFVariadicFunctionDefinition.class.st
@@ -1,0 +1,69 @@
+"
+I represent Variadic Argument Functions.
+I work the same as my superclass, with the difference that I use a different primitive. 
+This primitive uses the libFFI API for variadic functions.
+
+For compatibility reason with older VMs, If the new primitive fails, the old primitive is used instead.
+"
+Class {
+	#name : #TFVariadicFunctionDefinition,
+	#superclass : #TFFunctionDefinition,
+	#instVars : [
+		'fixedArgumentCount'
+	],
+	#category : #'ThreadedFFI-Base'
+}
+
+{ #category : #'instance creation' }
+TFVariadicFunctionDefinition class >> parameterTypes: someParameters returnType: returnType [
+
+	^ self error: 'You should use #parameterTypes:returnType:fixedArgumentCount:'
+]
+
+{ #category : #'instance creation' }
+TFVariadicFunctionDefinition class >> parameterTypes: someParameters returnType: returnType fixedArgumentCount: fixedArgumentCount [
+
+	^ self new
+		parameterTypes: someParameters;
+		returnType: returnType;
+		fixedArgumentCount: fixedArgumentCount;
+		autoRelease;
+		yourself
+]
+
+{ #category : #private }
+TFVariadicFunctionDefinition >> doValidate: parameterHandlers [
+
+	self
+		primDefineFunctionWith: parameterHandlers
+		returnType: returnType getHandle
+		fixedArgumentsCount: fixedArgumentCount
+]
+
+{ #category : #accessing }
+TFVariadicFunctionDefinition >> fixedArgumentCount [
+
+	^ fixedArgumentCount
+]
+
+{ #category : #accessing }
+TFVariadicFunctionDefinition >> fixedArgumentCount: anObject [
+
+	fixedArgumentCount := anObject
+]
+
+{ #category : #private }
+TFVariadicFunctionDefinition >> initialize [ 
+	
+	super initialize.
+	fixedArgumentCount := 0
+]
+
+{ #category : #primitives }
+TFVariadicFunctionDefinition >> primDefineFunctionWith: parameterHandlers returnType: returnTypeHandler fixedArgumentsCount: aFixedArgumentCount [
+	
+	<primitive: 'primitiveDefineVariadicFunction' error: ec>
+
+	"If the VM does not have an implementation of this primitive, we try with the non variadic version"
+	^ self primDefineFunctionWith: parameterHandlers returnType: returnTypeHandler
+]

--- a/src/UnifiedFFI-Tests/FFICalloutAPITest.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutAPITest.class.st
@@ -49,12 +49,12 @@ FFICalloutAPITest >> ffiLongLongAbs: number [
 
 { #category : #'primitives constant' }
 FFICalloutAPITest >> ffiTestConstantFormat: format to: buffer [
-	^ self ffiCall: #( int sprintf ( ByteArray buffer, String format, 65, 65, 1 ) )
+	^ self ffiCall: #( int sprintf ( ByteArray buffer, String format, 65, 65, 1 ) ) fixedArgumentCount: 2
 ]
 
 { #category : #'primitives constant' }
 FFICalloutAPITest >> ffiTestContantFormat: format value: aNumber to: buffer [
-	^ self ffiCall: #( int sprintf ( ByteArray buffer, String format, 65, 65, long aNumber ) )
+	^ self ffiCall: #( int sprintf ( ByteArray buffer, String format, 65, 65, long aNumber ) ) fixedArgumentCount: 2
 ]
 
 { #category : #'primitives atomic' }

--- a/src/UnifiedFFI-Tests/FFIExternalEnumerationTest.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalEnumerationTest.class.st
@@ -16,14 +16,16 @@ FFIExternalEnumerationTest >> enumClass [
 FFIExternalEnumerationTest >> ffiTestCall: enumValue format: format to: buffer [
 	^ self 
 		ffiCall: #( int sprintf ( void* buffer, String format, FFITestEnumeration enumValue ) )
-		module: LibC
+		library: LibC
+		fixedArgumentCount: 2
 ]
 
 { #category : #primitives }
 FFIExternalEnumerationTest >> ffiTestReturn: aNumber format: format to: buffer [
 	^ self 
 		ffiCall: #( FFITestEnumeration sprintf ( void* buffer, String format, int aNumber ) )
-		module: LibC
+		library: LibC
+		fixedArgumentCount: 2
 ]
 
 { #category : #tests }

--- a/src/UnifiedFFI/FFICalloutAPI.class.st
+++ b/src/UnifiedFFI/FFICalloutAPI.class.st
@@ -8,7 +8,8 @@ Class {
 		'options',
 		'callingConvention',
 		'senderContext',
-		'uFFIEntryPointContext'
+		'uFFIEntryPointContext',
+		'fixedArgumentCount'
 	],
 	#classVars : [
 		'CalloutAPIClass'
@@ -96,6 +97,18 @@ FFICalloutAPI >> findUffiEnterContext [
 	^ uffiEnterContext
 ]
 
+{ #category : #accessing }
+FFICalloutAPI >> fixedArgumentCount [
+
+	^ fixedArgumentCount
+]
+
+{ #category : #accessing }
+FFICalloutAPI >> fixedArgumentCount: anObject [
+
+	fixedArgumentCount := anObject
+]
+
 { #category : #action }
 FFICalloutAPI >> function: functionSignature library: moduleNameOrLibrary [
 	| sender ffiMethod ffiMethodSelector |
@@ -106,6 +119,7 @@ FFICalloutAPI >> function: functionSignature library: moduleNameOrLibrary [
 			builder
 				signature: functionSignature;
 				sender: sender;
+				fixedArgumentCount: fixedArgumentCount;
 				library: moduleNameOrLibrary ].
 	ffiMethod
 		selector: sender selector;
@@ -129,8 +143,11 @@ FFICalloutAPI >> function: aCollection module: aClass [
 
 { #category : #initialization }
 FFICalloutAPI >> initialize [
+
 	callingConvention := #cdecl.
 	options := #().
+	fixedArgumentCount := 0.
+
 	super initialize
 ]
 

--- a/src/UnifiedFFI/FFICalloutMethodBuilder.class.st
+++ b/src/UnifiedFFI/FFICalloutMethodBuilder.class.st
@@ -11,7 +11,8 @@ Class {
 		'sender',
 		'signature',
 		'functionResolutionStrategies',
-		'library'
+		'library',
+		'fixedArgumentCount'
 	],
 	#category : #'UnifiedFFI-Callouts'
 }
@@ -97,6 +98,18 @@ FFICalloutMethodBuilder >> extractLibrary [
 	^ ffiLibrary
 ]
 
+{ #category : #accessing }
+FFICalloutMethodBuilder >> fixedArgumentCount [
+
+	^ fixedArgumentCount
+]
+
+{ #category : #accessing }
+FFICalloutMethodBuilder >> fixedArgumentCount: anObject [
+
+	fixedArgumentCount := anObject
+]
+
 { #category : #private }
 FFICalloutMethodBuilder >> generate [
 	^ self generateMethodFromSpec: (self parseSignature: self signature)
@@ -152,7 +165,8 @@ FFICalloutMethodBuilder >> generateMethodFromSpec: functionSpec [
 { #category : #initialization }
 FFICalloutMethodBuilder >> initialize [
 	super initialize.
-	functionResolutionStrategies := FFIFunctionResolutionStrategy allSubclasses collect: [:aClass | aClass new]
+	functionResolutionStrategies := FFIFunctionResolutionStrategy allSubclasses collect: [:aClass | aClass new].
+	fixedArgumentCount := 0.
 		
 ]
 

--- a/src/UnifiedFFI/Object.extension.st
+++ b/src/UnifiedFFI/Object.extension.st
@@ -14,7 +14,26 @@ Object >> ffiCall: fnSpec [
 	Please refer to the booklet about more configuration details
 	or some of the examples on the image LibC / FreeTypeFont / Athens / SDL."
 	
-	self ffiCall: fnSpec library: self ffiLibrary
+	self ffiCall: fnSpec library: self ffiLibrary options: #()	
+]
+
+{ #category : #'*UnifiedFFI' }
+Object >> ffiCall: fnSpec fixedArgumentCount: fixedArgumentsCount [
+	<ffiCalloutTranslator>
+	
+	"All the ffiCall: messages are used to perform Foreign-Function calls (FFI calls).
+	FFI calls allows Pharo code to interact with external dynamic linked libraries.
+	Please refer to the booklet about more configuration details
+	or some of the examples on the image LibC / FreeTypeFont / Athens / SDL.
+	
+	This message allows to call variadic functions.
+	It is required to set the number of fixed arguments in the call as different calling conventions handle them differently"
+	
+	self 
+		ffiCall: fnSpec 
+		library: self ffiLibrary 
+		options: #()	
+		fixedArgumentCount: fixedArgumentsCount
 ]
 
 { #category : #'*UnifiedFFI' }
@@ -25,7 +44,29 @@ Object >> ffiCall: fnSpec library: aLibrary [
 ]
 
 { #category : #'*UnifiedFFI' }
+Object >> ffiCall: fnSpec library: aLibrary fixedArgumentCount: fixedArgumentsCount [
+	<ffiCalloutTranslator>
+	
+	"This message allows to call variadic functions.
+	It is required to set the number of fixed arguments in the call as different calling conventions handle them differently"
+	
+	self 
+		ffiCall: fnSpec 
+		library: aLibrary
+		options: #()	
+		fixedArgumentCount: fixedArgumentsCount
+]
+
+{ #category : #'*UnifiedFFI' }
 Object >> ffiCall: fnSpec library: aLibrary options: callOptions [
+	<ffiCalloutTranslator>
+	
+	"Zero argument count tells it is a not variadic function"
+	^ self ffiCall: fnSpec library: aLibrary options: callOptions fixedArgumentCount: 0
+]
+
+{ #category : #'*UnifiedFFI' }
+Object >> ffiCall: fnSpec library: aLibrary options: callOptions fixedArgumentCount: fixedArgumentsCount [
 	<ffiCalloutTranslator>
 	
 	| ffiLibrary |
@@ -33,6 +74,7 @@ Object >> ffiCall: fnSpec library: aLibrary options: callOptions [
 	^ (ffiLibrary calloutAPIClass inUFFIContext: thisContext)
 		convention: self ffiCallingConvention;
 		options: (ffiLibrary options), callOptions;
+		fixedArgumentCount: fixedArgumentsCount;
 		function: fnSpec library: ffiLibrary
 ]
 
@@ -40,7 +82,8 @@ Object >> ffiCall: fnSpec library: aLibrary options: callOptions [
 Object >> ffiCall: fnSpec module: aModuleName [
 	<ffiCalloutTranslator>
 	
-	self ffiCall: fnSpec library: aModuleName
+	self ffiCall: fnSpec library: aModuleName options: #()	
+
 ]
 
 { #category : #'*UnifiedFFI' }


### PR DESCRIPTION
Adding a difference for calling variadic and non-variadic functions in TFFI.

Adding a new primitive that handles it.
If the primitive is not present, use the old implementation