### PR TITLE
Simplify-CommentTestCase

### DIFF
--- a/src/DrTests-CommentsToTests-Tests/CommentsToTestsTest.class.st
+++ b/src/DrTests-CommentsToTests-Tests/CommentsToTestsTest.class.st
@@ -8,6 +8,30 @@ Class {
 }
 
 { #category : #tests }
+CommentsToTestsTest >> testCommentWithFailure [
+	"(1+3)>>>5"
+	
+	| docComment commentTestCase |
+
+	docComment := thisContext method ast pharoDocCommentNodes first.
+	commentTestCase := CommentTestCase for: docComment.
+		
+	self should: [commentTestCase testIt] raise: TestFailure
+]
+
+{ #category : #tests }
+CommentsToTestsTest >> testCommentWithSyntaxError [
+	"(1+)>>>5"
+	
+	| docComment commentTestCase |
+
+	docComment := thisContext method ast pharoDocCommentNodes first.
+	commentTestCase := CommentTestCase for: docComment.
+	
+	self should: [commentTestCase testIt] raise: SyntaxErrorNotification
+]
+
+{ #category : #tests }
 CommentsToTestsTest >> testErrorComment [
 	"(1+3)+6/0>>>4"
 	
@@ -15,7 +39,8 @@ CommentsToTestsTest >> testErrorComment [
 
 	docComment := thisContext method ast pharoDocCommentNodes first.
 	commentTestCase := CommentTestCase for: docComment.	
-	self assert: commentTestCase hasError
+	
+	self should: [commentTestCase testIt] raise: Error
 ]
 
 { #category : #tests }
@@ -27,7 +52,6 @@ CommentsToTestsTest >> testSimpleComment [
 	docComment := thisContext method ast pharoDocCommentNodes first.
 	commentTestCase := CommentTestCase for: docComment.
 		
-	self deny: commentTestCase hasError.	
 	self
 		assert: commentTestCase currentValue
 		equals: commentTestCase expectedValue

--- a/src/DrTests-CommentsToTests/CommentTestCase.class.st
+++ b/src/DrTests-CommentsToTests/CommentTestCase.class.st
@@ -7,9 +7,6 @@ Class {
 	#name : #CommentTestCase,
 	#superclass : #TestCase,
 	#instVars : [
-		'currentValue',
-		'expectedValue',
-		'expression',
 		'docCommentNode'
 	],
 	#category : #'DrTests-CommentsToTests-Model'
@@ -24,64 +21,33 @@ CommentTestCase class >> for: aDocComment [
 { #category : #accessing }
 CommentTestCase class >> testSelectors [
 	"we remove the selectors to add back later one of them, depending if is is error or not"
-	^ super testSelectors \ { #testError. #testIt }
+	^ super testSelectors \ { #testIt }
 ]
 
-{ #category : #accessing }
-CommentTestCase >> classExample [ 
-	^  docCommentNode sourceNode methodNode methodClass
-]
-
-{ #category : #accessing }
+{ #category : #private }
 CommentTestCase >> cleanUpInstanceVariables [
 	self class allInstVarNames
 		do: [ :name | 
-			(#('testSelector' 'currentValue' 'expression' 'classExample' 'selectorExample')
+			(#('docCommentNode')
 				includes: name)
 				ifFalse: [ self instVarNamed: name put: nil ] ]
 ]
 
 { #category : #accessing }
 CommentTestCase >> currentValue [
-	^ currentValue
-]
-
-{ #category : #accessing }
-CommentTestCase >> currentValue: anObject [
-	currentValue := anObject
-]
-
-{ #category : #accessing }
-CommentTestCase >> docCommentNode [
-
-	^ docCommentNode
+	^ docCommentNode expression evaluate
 ]
 
 { #category : #accessing }
 CommentTestCase >> docCommentNode: aDocComment [
 
-	| result |
 	docCommentNode := aDocComment.
-	self expression: aDocComment sourceNode contents.
-
-	result := [ Smalltalk compiler evaluate: expression ]
-		          on: Exception
-		          do: [ ^ self setTestSelector: #testError ].
-
-	(result isKindOf: Association)
-		ifFalse: [ self setTestSelector: #testError ]
-		ifTrue: [ 
-			self
-				expectedValue: result key;
-				currentValue: result value;
-				setTestSelector: #testIt ]
+	testSelector := #testIt.
 ]
 
 { #category : #accessing }
 CommentTestCase >> drTestsBrowse [
-	self flag: #todo.
-	"this should be done via the presenter application and not using a global variable."
-	Smalltalk tools browser openOnClass: self classExample  selector: self selectorExample
+ 	docCommentNode browse
 ]
 
 { #category : #accessing }
@@ -91,45 +57,20 @@ CommentTestCase >> drTestsName [
 
 { #category : #accessing }
 CommentTestCase >> expectedValue [
-	^ expectedValue
-]
-
-{ #category : #accessing }
-CommentTestCase >> expectedValue: anObject [
-	expectedValue := anObject
+	^ docCommentNode result evaluate
 ]
 
 { #category : #accessing }
 CommentTestCase >> expression [
-	^ expression
-]
-
-{ #category : #accessing }
-CommentTestCase >> expression: anObject [
-	expression := anObject
-]
-
-{ #category : #tests }
-CommentTestCase >> hasError [
-	^ testSelector == #testError
+	^ docCommentNode sourceNode contents
 ]
 
 { #category : #printing }
 CommentTestCase >> printString [
-	^ expression
-]
-
-{ #category : #accessing }
-CommentTestCase >> selectorExample [
-	^docCommentNode sourceNode methodNode methodClass
-]
-
-{ #category : #tests }
-CommentTestCase >> testError [
-	self error: 'syntax error on the comment'
+	^ docCommentNode sourceNode contents 
 ]
 
 { #category : #tests }
 CommentTestCase >> testIt [
-	self assert: expectedValue equals: currentValue
+	self assert: self expectedValue equals: self currentValue
 ]

--- a/src/Kernel/BlockClosure.class.st
+++ b/src/Kernel/BlockClosure.class.st
@@ -144,12 +144,8 @@ BlockClosure >> copyForSaving [
 { #category : #evaluating }
 BlockClosure >> cull: anArg [
 	"Execute the receiver with one or zero arguments depending on the receiver"
-	"([ 12 ] cull: 13)
-	>>> 12 
-	"
-	"([:x | x + 12] cull: 3)
-	>>> 15
-	"
+	"([ 12 ] cull: 13)>>> 12 "
+	"([:x | x + 12] cull: 3)>>> 15"
 	^numArgs = 0 
 		ifTrue: [self value]
 		ifFalse: [self value: anArg]
@@ -159,11 +155,9 @@ BlockClosure >> cull: anArg [
 { #category : #evaluating }
 BlockClosure >> cull: firstArg cull: secondArg [
 	"Execute the receiver with one or two arguments depending on the receiver"
-	"([:x | x + 1] cull: 13 cull: 12)
-	>>> 14
+	"([:x | x + 1] cull: 13 cull: 12) >>> 14
 	"
-	"([:x :y | x + y] cull: 3 cull: 2)
-	>>> 5
+	"([:x :y | x + y] cull: 3 cull: 2) >>> 5
 	"
 	^numArgs < 2 
 		ifTrue: [self cull: firstArg]

--- a/src/PharoDocComment/PharoDocCommentNode.class.st
+++ b/src/PharoDocComment/PharoDocCommentNode.class.st
@@ -88,6 +88,13 @@ PharoDocCommentNode >> asTriplet [
 		 self result expressionCode formattedCode }
 ]
 
+{ #category : #private }
+PharoDocCommentNode >> browse [
+	| methodNode |
+	methodNode := self sourceNode methodNode.
+	(methodNode methodClass>>methodNode selector) browse
+]
+
 { #category : #accessing }
 PharoDocCommentNode >> expression [
 	^ expression


### PR DESCRIPTION
- simplify CommentTestCase further to hold onto just the DocComment node
- improve tests in CommentsToTestsTest

This now means that we use the doc node infrastructure to run tests: fixes #5226


