### PR TITLE
Compiler-Improve-lookupVar

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -33,6 +33,11 @@ Context >> lookupVar: aSymbol [
 ]
 
 { #category : #'*Debugging-Core' }
+Context >> lookupVar: aSymbol declare: aBoolean [
+	^ self astScope lookupVar: aSymbol declare: aBoolean
+]
+
+{ #category : #'*Debugging-Core' }
 Context >> methodReturnConstant: value [
 	"Simulate the action of a 'return constant' bytecode whose value is the
 	 argument, value. This corresponds to a source expression like '^0'."

--- a/src/Deprecated90/OCEnvironmentScope.class.st
+++ b/src/Deprecated90/OCEnvironmentScope.class.st
@@ -32,11 +32,3 @@ OCEnvironmentScope >> hasBindingThatBeginsWith: aString [
 	^environment hasBindingThatBeginsWith: aString
 
 ]
-
-{ #category : #lookup }
-OCEnvironmentScope >> lookupVar: name [
-	"Return a var with this name.  Return nil if none found"
-	name isString ifFalse: [ ^nil ].
-	
-	^environment bindingOf: name
-]

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -80,6 +80,11 @@ Behavior >> lookupVar: aName [
 ]
 
 { #category : #'*OpalCompiler-Core' }
+Behavior >> lookupVar: aName declare: aBoolean [
+	^ self lookupVar: aName 
+]
+
+{ #category : #'*OpalCompiler-Core' }
 Behavior >> lookupVarForDeclaration: name [
 	"This is a version of #lookupVar: that skips the OCRequestorScope, from here on it is the same as lookupVar:"
 	^ self lookupVar: name

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -142,21 +142,14 @@ OCAbstractMethodScope >> lookupDefiningContextForVariable: var startingFrom: aCo
 ]
 
 { #category : #lookup }
-OCAbstractMethodScope >> lookupVar: name [
+OCAbstractMethodScope >> lookupVar: name declare: aBoolean [
 
 	copiedVars at: name ifPresent: [:v | ^ v].
 	tempVector at: name ifPresent: [:v | ^ v].
 	tempVars at: name ifPresent: [:v | ^ v].
 	name = self tempVectorName ifTrue: [ ^ self tempVectorVar ].
-	^self outerScope lookupVar: name
+	^self outerScope lookupVar: name declare: aBoolean
 	
-]
-
-{ #category : #lookup }
-OCAbstractMethodScope >> lookupVarForDeclaration: name [
-	"This is a version of #lookupVar: that skips the OCRequestorScope"
-	tempVars at: name ifPresent: [:v | ^ v].
-	^self outerScope lookupVarForDeclaration: name
 ]
 
 { #category : #scope }

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -43,6 +43,12 @@ OCAbstractScope >> isMethodScope [
 { #category : #lookup }
 OCAbstractScope >> lookupVar: name [
 	"search the scope (and the outer scopes) for a variable 'name' and return it"
+	^ self lookupVar: name declare: true
+]
+
+{ #category : #lookup }
+OCAbstractScope >> lookupVar: name declare: aBoolean [
+	"search the scope (and the outer scopes) for a variable 'name' and return it"
 	^self subclassResponsibility
 ]
 
@@ -52,7 +58,7 @@ OCAbstractScope >> lookupVarForDeclaration: name [
 	When looking temp var declarations, we do not want the Requestor scope to automatically
 	create that variable. Subclasses override if they do not skip but do a lookup"
 
-	^ self outerScope lookupVarForDeclaration: name
+	^ self lookupVar: name declare: false
 ]
 
 { #category : #lookup }

--- a/src/OpalCompiler-Core/OCExtraBindingScope.class.st
+++ b/src/OpalCompiler-Core/OCExtraBindingScope.class.st
@@ -35,11 +35,11 @@ OCExtraBindingScope >> bindings: anObject [
 ]
 
 { #category : #lookup }
-OCExtraBindingScope >> lookupVar: name [
+OCExtraBindingScope >> lookupVar: name declare: aBoolean [
 	"reserved Variables are defined by the instance scope"
-	(ReservedVariable nameIsReserved: name) ifTrue: [ ^ outerScope lookupVar: name ].
+	(ReservedVariable nameIsReserved: name) ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
 	
 	^(bindings bindingOf: name asSymbol)
 		ifNotNil: [ :var | var ]
-		ifNil: [ outerScope lookupVar: name ]
+		ifNil: [ outerScope lookupVar: name declare: aBoolean]
 ]

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -31,26 +31,24 @@ OCRequestorScope >> compilationContext: anObject [
 ]
 
 { #category : #lookup }
-OCRequestorScope >> lookupVar: name [
+OCRequestorScope >> lookupVar: name declare: aBoolean [
 
 	"reserved Variables are defined by the instance scope"
-	(ReservedVariable nameIsReserved: name) ifTrue: [ ^ outerScope lookupVar: name ].
+	(ReservedVariable nameIsReserved: name) ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
 	
 	"generated temps (e.g. for limits in to:do: should not create bindings"
-	name first = $0 ifTrue: [ ^ outerScope lookupVar: name ].
-	
+	name first = $0 ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
 	"We do not want to auto define bindings for unknown Globals"
-	(name isString and: [name first isUppercase]) ifTrue: [ ^ outerScope lookupVar: name].
-	
+	(name isString and: [name first isUppercase]) ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean].
 	"do not 'create bindings' in requestor scope if we just want to style a possible unknown variable"
-	(compilationContext optionSkipSemanticWarnings
+	((compilationContext optionSkipSemanticWarnings or: [aBoolean not])
 		and: [ (requestor hasBindingOf: name) not ])
-		ifTrue: [ ^ outerScope lookupVar: name ].
+		ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
 
 	"the requestors #bindingOf may create a binding for not yet existing variables"
 	^(requestor bindingOf: name)
 		ifNotNil: [ :var | var ]
-		ifNil: [ outerScope lookupVar: name ]
+		ifNil: [ outerScope lookupVar: name declare: aBoolean ]
 ]
 
 { #category : #accessing }

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -683,6 +683,11 @@ RGBehavior >> lookupVar: aName [
 ]
 
 { #category : #lookup }
+RGBehavior >> lookupVar: aName declare: aBoolean [
+	^ self lookupVar: aName 
+]
+
+{ #category : #lookup }
 RGBehavior >> lookupVarForDeclaration: aName [
 
 	"This is a version of #lookupVar: that skips the OCRequestorScope, from here on it is the same as lookupVar:"


### PR DESCRIPTION
This is a first step for #8803

Instead of a dedicated #lookupVarForDeclaration:, we now have #lookupVar:declare: and two methods #lookupVar: and #lookupVarForDeclaration: which use it either allowing declaration or not.

Next steps:

- use #lookupVar:declare: in Newtools
- make sure to hand over the AST that has the right scopes to the code highlighter (right now it creates a completely new AST that knows nothing about the Requestor scope of the Playground)


