### PR TITLE
Cleanup DoItVariable from locals related methods (markRead and etc.)

### DIFF
--- a/src/Kernel/DoItVariable.class.st
+++ b/src/Kernel/DoItVariable.class.st
@@ -174,31 +174,6 @@ DoItVariable >> key [
 	^self name
 ]
 
-{ #category : #'read/write usage' }
-DoItVariable >> markEscapingRead [
-	"ignored, the escape status of the actualVariable does not change"
-]
-
-{ #category : #'read/write usage' }
-DoItVariable >> markEscapingWrite [
-	"ignored, the escape status of the actualVariable does not change"
-]
-
-{ #category : #'read/write usage' }
-DoItVariable >> markRead [
-	"ignored, the escape status of the actualVariable does not change"
-]
-
-{ #category : #'read/write usage' }
-DoItVariable >> markRepeatedWrite [
-	"ignored, the escape status of the actualVariable does not change"
-]
-
-{ #category : #'read/write usage' }
-DoItVariable >> markWrite [
-	"ignored, the escape status of the actualVariable does not change"
-]
-
 { #category : #printing }
 DoItVariable >> printOn: aStream [ 
 	super printOn: aStream.


### PR DESCRIPTION
There are several methods in DoItVariable related to the logic of locals variable compilation:
- markRead
- markEscapingRead
- etc

They are now not needed anymore with regards to #9113 refactoring.