### PR TITLE
fixing-socket-availableData

### DIFF
--- a/src/Network-Kernel/Socket.class.st
+++ b/src/Network-Kernel/Socket.class.st
@@ -1143,7 +1143,14 @@ Socket >> primSocketLocalPort: socketID [
 
 { #category : #primitives }
 Socket >> primSocketReceiveDataAvailable: socketID [
-	"Return true if data may be available for reading from the current socket."
+	"Return true if data may be available for reading from the current socket.
+	This primitive should not be called directly.
+	We should use #dataAvailable because it checks if the handler is nil.
+	The primitive fails with a primitive failure if the handler is nil.
+	Pay attention that if we are using the primitive directly, 
+	the image can be saved in the middle of the method niling the value in the socket. 
+	This can produce a primitiveFailed error while it should be a ConnectionClosedError 
+	or something like that."
 
 	<primitive: 'primitiveSocketReceiveDataAvailable' module: 'SocketPlugin'>
 	self primitiveFailed

--- a/src/Network-Kernel/Socket.class.st
+++ b/src/Network-Kernel/Socket.class.st
@@ -1770,11 +1770,11 @@ Socket >> waitForDataFor: timeout ifClosed: closedBlock ifTimedOut: timedOutBloc
 	startTime := Time millisecondClockValue.
 	msecsDelta := (timeout * 1000) truncated.
 	[ (Time millisecondsSince: startTime) < msecsDelta ]
-		whileTrue: [ (self primSocketReceiveDataAvailable: socketHandle) ifTrue: [ ^ self ].
+		whileTrue: [ self dataAvailable ifTrue: [ ^ self ].
 			self isConnected ifFalse: [ ^ closedBlock value ].
 			self readSemaphore waitTimeoutMSecs: (msecsDelta - (Time millisecondsSince: startTime) max: 0) ].
 
-	(self primSocketReceiveDataAvailable: socketHandle)
+	self dataAvailable
 		ifFalse: [ ^ (self isConnected
 				ifTrue: [ timedOutBlock ]
 				ifFalse: [ closedBlock ]) value ]
@@ -1787,7 +1787,7 @@ Socket >> waitForDataIfClosed: closedBlock [
 
 	[true]
 		whileTrue: [
-			(self primSocketReceiveDataAvailable: socketHandle)
+			self dataAvailable
 				ifTrue: [^self].
 			self isConnected
 				ifFalse: [^closedBlock value].


### PR DESCRIPTION
The primSocketReceiveDataAvailable: should not be called directly, as it should handle the nil in the socketHandle.

This nil is introduced when the image is saved and the socket state is set to nil. 
If we don't handle it properly, the primitive fails with a PrimitveFailure, and it should fail with a ConnectionClosed error.