### PR TITLE
9129-RubTextEditorunescapeCharacterinString-should-be-implemented-in-String

### DIFF
--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2554,6 +2554,23 @@ String >> uncapitalized [
 ]
 
 { #category : #converting }
+String >> unescapeCharacter: aCharacter [
+	"Unescape an escaped string. Assume the string has all occurrences of aCharacter are escaped. That is, they are in pairs.
+	This method returns a copy of the string replacing all pairs of aCharacter by a single appearance of it."
+	
+	"('''''' unescapeCharacter: $') >>> ''''"
+	"('''' unescapeCharacter: $') >>> ''"
+	
+	| result stream |
+	result := WriteStream with: ''.
+	stream := ReadStream on: self.
+	[ stream atEnd ] whileFalse: 
+			[ result nextPutAll: (stream upTo: aCharacter).
+			  stream peek ifNotNil: [result nextPut: stream next]].
+	^result contents
+]
+
+{ #category : #converting }
 String >> withBlanksCondensed [
 	"Return a copy of the receiver with leading/trailing blanks (separators) removed
 	 and consecutive white spaces (separators) condensed to the first one."

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -449,8 +449,8 @@ RubSmalltalkEditor >> copySelection [
 		"The node, if a comment or a string, should entirely contain the selection.
 		We convert the node source interval to an open interval to ignore the node delimiters."
 		node sourceInterval asOpenInterval includesAll: self selectionInterval ])
-		ifTrue: [ self unescapeCharacter: escapingCharacter inString:  self selection ]
-		ifFalse: [ self selection ].
+			ifTrue: [ self selection unescapeCharacter: escapingCharacter ]
+			ifFalse: [ self selection ].
 	self clipboardTextPut: selection.
 	self editingState previousInterval: self selectionInterval.
 

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -917,7 +917,7 @@ RubTextEditor >> encloseWith: aMatchingPair [
 		ifTrue: [
 			"already enclosed; strip off brackets"
 			newString := (self shouldEscapeCharacter: left)
-						 ifTrue: [ self unescapeCharacter: left inString: oldSelection ] 
+						 ifTrue: [ oldSelection unescapeCharacter: left ] 
 						 ifFalse: [ oldSelection ].
 			self selectFrom: startIndex-1 to: stopIndex.
 			self replaceSelectionWith: newString ]
@@ -2533,26 +2533,6 @@ RubTextEditor >> undoTypeIn: aText interval: anInterval [
 	self replace: anInterval with: aText and:
 		[self selectInterval: (anInterval first to: anInterval first - 1)].
 
-]
-
-{ #category : #nesting }
-RubTextEditor >> unescapeCharacter: aCharacter inString: aString [
-	"Unescape an escaped string.
-	Assume the string has all occurrences of aCharacter are escaped.
-	That is, they are in pairs.
-	
-	This method returns a copy of the string replacing all pairs of aCharacter by a single appearance of it."
-	
-	"(self unescapeCharacter: $' inString: '''''') >>> ''''"
-	"(self unescapeCharacter: $' inString: '''') >>> ''''"
-	
-	| result stream |
-	result := WriteStream with: ''.
-	stream := ReadStream on: aString.
-	[ stream atEnd ] whileFalse: 
-			[ result nextPutAll: (stream upTo: aCharacter).
-			  stream peek ifNotNil: [result nextPut: stream next]].
-	^result contents.
 ]
 
 { #category : #private }


### PR DESCRIPTION
- add #unescapeCharacter:
- fix runnable example
- change users to use unescapeCharacter:
- remove #unescapeCharacter: inString: 

No test as it is tested by the completion tests and there is a runnable example that serves as a test.

fixes #9129


