### PR TITLE
9077-SpValueHolder-did-not-untderstand-asTest-in-new-playground-About-menu

### DIFF
--- a/src/Spec2-ObservableSlot/SpObservableSlot.class.st
+++ b/src/Spec2-ObservableSlot/SpObservableSlot.class.st
@@ -6,20 +6,19 @@ Class {
 
 { #category : #'code generation' }
 SpObservableSlot >> emitStore: aMethodBuilder [
-	"generate bytecode for 'varName value: <stackTop>', make sure to preserve the stackTop"
+	"generate bytecode for 'varName value: <stackTop>'"
 
 	| temp |
 	temp := '0slotTempForStackManipulation'.	
 	"We pop the value from the stack into a temp to push it back in the right order"
 	aMethodBuilder addTemp: temp.
 	aMethodBuilder storeTemp: temp.
+	aMethodBuilder popTop.
 
 	"Push the value holder into the stack, then the value again, then send"
 	aMethodBuilder pushInstVar: index.
 	aMethodBuilder pushTemp: temp.
-	aMethodBuilder send: #value:.
-	"we have to return the value, not the valueHolder"
-	aMethodBuilder popTop
+	aMethodBuilder send: #value:
 ]
 
 { #category : #'code generation' }

--- a/src/Spec2-ObservableSlot/SpObservableSlot.class.st
+++ b/src/Spec2-ObservableSlot/SpObservableSlot.class.st
@@ -6,19 +6,20 @@ Class {
 
 { #category : #'code generation' }
 SpObservableSlot >> emitStore: aMethodBuilder [
-	"generate bytecode for 'varName value: <stackTop>'"
+	"generate bytecode for 'varName value: <stackTop>', make sure to preserve the stackTop"
 
 	| temp |
 	temp := '0slotTempForStackManipulation'.	
 	"We pop the value from the stack into a temp to push it back in the right order"
 	aMethodBuilder addTemp: temp.
 	aMethodBuilder storeTemp: temp.
-	aMethodBuilder popTop.
 
 	"Push the value holder into the stack, then the value again, then send"
 	aMethodBuilder pushInstVar: index.
 	aMethodBuilder pushTemp: temp.
-	aMethodBuilder send: #value:
+	aMethodBuilder send: #value:.
+	"we have to return the value, not the valueHolder"
+	aMethodBuilder popTop
 ]
 
 { #category : #'code generation' }

--- a/src/VariablesLibrary-Tests/ObservablePoint.class.st
+++ b/src/VariablesLibrary-Tests/ObservablePoint.class.st
@@ -32,6 +32,11 @@ ObservablePoint >> x: anInteger [
 ]
 
 { #category : #accessing }
+ObservablePoint >> xReturn: anInteger [ 
+	^x := anInteger
+]
+
+{ #category : #accessing }
 ObservablePoint >> y [
 	^ y
 ]

--- a/src/VariablesLibrary-Tests/ObservableSlotTest.class.st
+++ b/src/VariablesLibrary-Tests/ObservableSlotTest.class.st
@@ -52,6 +52,13 @@ ObservableSlotTest >> testExplicitNotifyUnexistentPropertyChangedRaisesError [
 ]
 
 { #category : #tests }
+ObservableSlotTest >> testObservableSlotAssignReturnsValue [
+	"When assigning to a Observable Slot, the return value should be the value"
+	self assert: (point xReturn: 299) equals: 299
+
+]
+
+{ #category : #tests }
 ObservableSlotTest >> testObservableSlotWorksAsNormalSlot [
 	point x: 17.
 	point y: 299.

--- a/src/VariablesLibrary/ObservableSlot.class.st
+++ b/src/VariablesLibrary/ObservableSlot.class.st
@@ -33,19 +33,20 @@ Class {
 
 { #category : #'code generation' }
 ObservableSlot >> emitStore: aMethodBuilder [
-	"generate bytecode for 'varName value: <stackTop>'"
+	"generate bytecode for 'varName value: <stackTop>', make sure to preserve the stackTop"
 
 	| temp |
-	temp := '0slotTempForStackManipulation'.
+	temp := '0slotTempForStackManipulation'.	
 	"We pop the value from the stack into a temp to push it back in the right order"
 	aMethodBuilder addTemp: temp.
 	aMethodBuilder storeTemp: temp.
-	aMethodBuilder popTop.
 
 	"Push the value holder into the stack, then the value again, then send"
 	aMethodBuilder pushInstVar: index.
 	aMethodBuilder pushTemp: temp.
-	aMethodBuilder send: #value:
+	aMethodBuilder send: #value:.
+	"we have to return the value, not the valueHolder"
+	aMethodBuilder popTop
 ]
 
 { #category : #'code generation' }


### PR DESCRIPTION
- fix emitStore: in both SpObservableSlot and ObservableSlot
- add test: #testObservableSlotAssignReturnsValue

fixes 9077


