### PR TITLE
Context>>printDetails trimmed the last character

### DIFF
--- a/src/Kernel-Tests/ContextTest.class.st
+++ b/src/Kernel-Tests/ContextTest.class.st
@@ -19,7 +19,8 @@ Class {
 		'aMethodContext',
 		'aSender',
 		'instVarForTestLookupSymbol',
-		'nonActiveBlockContext'
+		'nonActiveBlockContext',
+		'anArgument'
 	],
 	#classVars : [
 		'Block',
@@ -111,11 +112,17 @@ ContextTest >> privRestartBlockTest [
 
 { #category : #running }
 ContextTest >> setUp [
+
 	super setUp.
-	aCompiledMethod := Rectangle methodDict at: #rightCenter.
-	aReceiver := 100@100 corner: 200@200.
+	aCompiledMethod := Rectangle methodDict at: #areasOutside:.
+	aReceiver := 100 @ 100 corner: 200 @ 200.
 	aSender := thisContext.
-	aMethodContext := Context sender: aSender receiver: aReceiver method: aCompiledMethod arguments: #(). 
+	anArgument := 420 @ 420 corner: 200 @ 200.
+	aMethodContext := Context
+		                  sender: aSender
+		                  receiver: aReceiver
+		                  method: aCompiledMethod
+		                  arguments: { anArgument }
 ]
 
 { #category : #running }
@@ -154,6 +161,23 @@ ContextTest >> testMethodContext [
 	self assert: aMethodContext home notNil.
 	self assert: aMethodContext receiver notNil.
 	self assert: (aMethodContext method isKindOf: CompiledMethod).
+]
+
+{ #category : #tests }
+ContextTest >> testMethodContextPrintDetails [
+
+	self
+		assert: (String streamContents: [ :stream | 
+				 aMethodContext printDetails: stream ])
+		equals: 'Rectangle>>areasOutside:
+	Receiver: (100@100) corner: (200@200)
+	Arguments and temporary variables: 
+		aRectangle: 	(200@200) corner: (420@420)
+	Receiver''s instance variables: 
+		origin: 	(100@100)
+		corner: 	(200@200)
+
+'
 ]
 
 { #category : #tests }

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1351,26 +1351,42 @@ Context >> printDebugOn: aStream [
 
 { #category : #printing }
 Context >> printDetails: stream [
+
 	"Put my class>>selector and instance variables and arguments and temporaries on the stream.  Protect against errors during printing."
 
 	| errorMessage string |
 	self printOn: stream.
 	stream cr.
-	stream tab; nextPutAll: 'Receiver: '.
+	stream
+		tab;
+		nextPutAll: 'Receiver: '.
 	errorMessage := '<<error during printing>>'.
-	stream nextPutAll: ([receiver printStringLimitedTo: 90] onErrorDo: [errorMessage]).
+	stream nextPutAll:
+		([ receiver printStringLimitedTo: 90 ] onErrorDo: [ errorMessage ]).
 
-	stream cr; tab; nextPutAll: 'Arguments and temporary variables: '; cr.
-	string := [(self tempsAndValuesLimitedTo: 80 indent: 2) 
-				padRightTo:1 with: $x] onErrorDo: [errorMessage].
-	stream nextPutAll: (string allButLast).
+	stream
+		cr;
+		tab;
+		nextPutAll: 'Arguments and temporary variables: ';
+		cr.
+	string := [ 
+	          (self tempsAndValuesLimitedTo: 80 indent: 2)
+		          padRightTo: 1
+		          with: $x ] onErrorDo: [ errorMessage ].
+	stream nextPutAll: string.
 
-	stream cr; tab; nextPutAll: 'Receiver''s instance variables: '; cr.
-	receiver class allInstVarNames isEmpty ifTrue: [ 
-		stream nextPutAll: ([receiver printStringLimitedTo: 90] onErrorDo: [ errorMessage ]).
-	] ifFalse: [
-		[receiver longPrintOn: stream limitedTo: 80 indent: 2] onErrorDo: [ stream nextPutAll: errorMessage ].
-	].
+	stream
+		cr;
+		tab;
+		nextPutAll: 'Receiver''s instance variables: ';
+		cr.
+	receiver class allInstVarNames isEmpty
+		ifTrue: [ 
+			stream nextPutAll:
+				([ receiver printStringLimitedTo: 90 ] onErrorDo: [ errorMessage ]) ]
+		ifFalse: [ 
+			[ receiver longPrintOn: stream limitedTo: 80 indent: 2 ] 
+				onErrorDo: [ stream nextPutAll: errorMessage ] ].
 	stream cr
 ]
 


### PR DESCRIPTION
Hello there

There was a small issue in Context>>#printDetails:, the list of arguments and temporaries didn't include the last letter
Example from a PharoDebug.log file:
```
Arguments and temporary variables: 
	aBlock: 	[ 
	updating := false ]
	complete: 	nil
	returnValue: 	ni
```

I modified a little bit ContextTest to cover this case: now the context generated in the setUp uses a method with an argument and temporary variables

This PR fixes the second issue mentionned in https://github.com/pharo-project/pharo/issues/8700