### PR TITLE
RB - Fix namespace with aliased methods, and inline refactoring errors

### DIFF
--- a/src/Refactoring-Core/RBAbstractClass.class.st
+++ b/src/Refactoring-Core/RBAbstractClass.class.st
@@ -429,6 +429,18 @@ RBAbstractClass >> isTrait [
 ]
 
 { #category : #'method accessing' }
+RBAbstractClass >> localSelectors [
+	| selectors |
+	selectors := Set new.
+	selectors addAll: self newMethods keys.
+	self isDefined 
+		ifTrue: 
+			[selectors addAll: self realClass localSelectors.
+			removedMethods ifNotNil: [removedMethods do: [:each | selectors remove: each ifAbsent: []]]].
+	^selectors
+]
+
+{ #category : #'method accessing' }
 RBAbstractClass >> methodFor: aSelector [
 	^ self newMethods
 		at: aSelector

--- a/src/Refactoring-Core/RBAbstractClass.class.st
+++ b/src/Refactoring-Core/RBAbstractClass.class.st
@@ -432,7 +432,8 @@ RBAbstractClass >> methodFor: aSelector [
 			compiledMethod := class compiledMethodAt: aSelector ifAbsent: [ nil ].
 			compiledMethod ifNotNil: [ 
 				compiledMethod isFromTrait 
-					ifTrue: [ (model classNamed: compiledMethod origin name) methodFor: aSelector ]
+					ifTrue: [ (compiledMethod traitSource hasMethod: aSelector) ifTrue: [
+						(model classNamed: compiledMethod origin name) methodFor: aSelector ] ]
 					ifFalse: [modelFactory rbMethod for: self fromMethod: compiledMethod andSelector: aSelector ]] ]
 ]
 
@@ -465,11 +466,13 @@ RBAbstractClass >> newMethods [
 { #category : #'method accessing' }
 RBAbstractClass >> parseTreeFor: aSelector [
 
-	| class |
+	| class method |
 
 	class := self whoDefinesMethod: aSelector.
 	class ifNil: [ ^ nil ].
-	^ ( class methodFor: aSelector ) parseTree
+	method := class methodFor: aSelector.
+	method ifNil: [ ^ nil ].
+	^ method parseTree
 ]
 
 { #category : #printing }

--- a/src/Refactoring-Core/RBAbstractClass.class.st
+++ b/src/Refactoring-Core/RBAbstractClass.class.st
@@ -319,6 +319,13 @@ RBAbstractClass >> existingMethodsThatReferToInstanceVariable: aString [
 		reject: [ :each | (self hasRemoved: each) or: [ self newMethods includesKey: each ] ]
 ]
 
+{ #category : #'method accessing' }
+RBAbstractClass >> firstSuperclassRedefines: aSelector [
+	"Return rbClass, if one of your superclasses redefines the method with name, aMethod"
+	self allSuperclasses do: [:each |
+		(each directlyDefinesMethod: aSelector) ifTrue: [^ each]].
+]
+
 { #category : #testing }
 RBAbstractClass >> hasRemoved: aSelector [ 
 	^removedMethods notNil and: [removedMethods includes: aSelector]
@@ -629,6 +636,13 @@ RBAbstractClass >> superclass: aRBClass [
 	self superclass ifNotNil: [self superclass removeSubclass: self].
 	superclass := aRBClass.
 	superclass ifNotNil: [superclass addSubclass: self].
+]
+
+{ #category : #testing }
+RBAbstractClass >> superclassRedefines: aSelector [
+	"Return true, if one of your superclasses redefines the method with name, aMethod"
+	
+	^ self allSuperclasses anySatisfy: [ :each | each directlyDefinesMethod: aSelector ]
 ]
 
 { #category : #'accessing - deprecated' }

--- a/src/Refactoring-Core/RBInlineAllSendersRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineAllSendersRefactoring.class.st
@@ -33,7 +33,9 @@ Class {
 	#instVars : [
 		'selector',
 		'numberReplaced',
-		'numberNotReplaced'
+		'numberNotReplaced',
+		'pattern',
+		'selectorString'
 	],
 	#category : #'Refactoring-Core-Refactorings'
 }
@@ -54,7 +56,18 @@ RBInlineAllSendersRefactoring class >> sendersOf: aSelector in: aClass [
 { #category : #transforming }
 RBInlineAllSendersRefactoring >> checkInlinedMethods [
 	numberReplaced = 0 
-		ifTrue: [self refactoringFailure: 'Could not find any senders to inline into']
+		ifTrue: [self inform:  'Could not find any senders to inline into']
+]
+
+{ #category : #transforming }
+RBInlineAllSendersRefactoring >> initializePatternFor: aClass [
+	pattern := nil.
+	(aClass = class or: [(aClass directlyDefinesMethod: selector) not]) ifTrue: [
+		pattern := 'self ' , self selectorString.
+		^ self].
+	((aClass directlyDefinesMethod: selector) and: 
+		[ (aClass firstSuperclassRedefines: selector) = class]) ifTrue: [ 
+		pattern := 'super ' , self selectorString ].
 ]
 
 { #category : #transforming }
@@ -63,31 +76,34 @@ RBInlineAllSendersRefactoring >> inlineMessagesInClass: aClass andSelector: aSel
 	previousCountOfMessages := 4294967295.	"Some really large number > # of initial self sends."
 	rbMethod := aClass parseTreeFor: aSelector.
 	rbMethod ifNil: [ ^ self ].
-	[messagesToInline := self numberOfSelfSendsIn: rbMethod.
+	[ messagesToInline := self numberOfSelfSendsIn: (aClass parseTreeFor: aSelector).
 	messagesToInline > 0 and: [previousCountOfMessages > messagesToInline]] 
 			whileTrue: 
 				[| node |
 				previousCountOfMessages := messagesToInline.
 				node := self selfSendIn: (aClass parseTreeFor: aSelector).
 				self onError: 
-						[self performCompositeRefactoring: (RBInlineMethodRefactoring 
+						[self performCompositeRefactoring: (RBInlineMethodRefactoring1 
 									model: self model
 									inline: node sourceInterval
 									inMethod: aSelector
 									forClass: aClass).
 						numberReplaced := numberReplaced + 1]
-					do: []].
+					do: [ :e | ]].
 	numberNotReplaced := numberNotReplaced + messagesToInline
 ]
 
 { #category : #transforming }
 RBInlineAllSendersRefactoring >> inlineSelfSends [
 	class withAllSubclasses do: 
-			[:each | 
+		[:each | 
 			| selectors |
+			self initializePatternFor: each.
+			pattern ifNotNil: [
 			selectors := each selectors.
-			selectors remove: selector ifAbsent: [].
-			selectors do: [:sel | self inlineMessagesInClass: each andSelector: sel]]
+			class = each ifTrue: [ selectors remove: selector ifAbsent: []].
+			selectors do: [:sel | self inlineMessagesInClass: each andSelector: sel]]]
+	
 ]
 
 { #category : #transforming }
@@ -100,7 +116,7 @@ RBInlineAllSendersRefactoring >> numberOfSelfSendsIn: aParseTree [
 	| search |
 	search := self parseTreeSearcher.
 	search
-		matches: self messagePattern
+		matches: pattern
 		do: [ :aNode :answer | answer + 1 ].
 	^ search executeTree: aParseTree initialAnswer: 0
 ]
@@ -121,11 +137,16 @@ RBInlineAllSendersRefactoring >> removeMethod [
 ]
 
 { #category : #transforming }
+RBInlineAllSendersRefactoring >> selectorString [
+	^selectorString ifNil: [ selectorString := self buildSelectorString: selector ]
+]
+
+{ #category : #transforming }
 RBInlineAllSendersRefactoring >> selfSendIn: aTree [
 	| searcher |
 	searcher := self parseTreeSearcher.
 	searcher
-		matches: self messagePattern
+		matches: pattern
 		do: [ :aNode :answer | ^ aNode ].
 	^ searcher executeTree: aTree initialAnswer: nil
 ]

--- a/src/Refactoring-Core/RBInlineAllSendersRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineAllSendersRefactoring.class.st
@@ -59,11 +59,11 @@ RBInlineAllSendersRefactoring >> checkInlinedMethods [
 
 { #category : #transforming }
 RBInlineAllSendersRefactoring >> inlineMessagesInClass: aClass andSelector: aSelector [ 
-	| messagesToInline previousCountOfMessages |
+	| messagesToInline previousCountOfMessages rbMethod |
 	previousCountOfMessages := 4294967295.	"Some really large number > # of initial self sends."
-	
-	[messagesToInline := self 
-				numberOfSelfSendsIn: (aClass parseTreeFor: aSelector).
+	rbMethod := aClass parseTreeFor: aSelector.
+	rbMethod ifNil: [ ^ self ].
+	[messagesToInline := self numberOfSelfSendsIn: rbMethod.
 	messagesToInline > 0 and: [previousCountOfMessages > messagesToInline]] 
 			whileTrue: 
 				[| node |

--- a/src/Refactoring-Core/RBInlineAllSendersRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineAllSendersRefactoring.class.st
@@ -35,7 +35,8 @@ Class {
 		'numberReplaced',
 		'numberNotReplaced',
 		'pattern',
-		'selectorString'
+		'selectorString',
+		'removeMethod'
 	],
 	#category : #'Refactoring-Core-Refactorings'
 }
@@ -100,7 +101,7 @@ RBInlineAllSendersRefactoring >> inlineSelfSends [
 			| selectors |
 			self initializePatternFor: each.
 			pattern ifNotNil: [
-			selectors := each selectors.
+			selectors := each localSelectors.
 			class = each ifTrue: [ selectors remove: selector ifAbsent: []].
 			selectors do: [:sel | self inlineMessagesInClass: each andSelector: sel]]]
 	

--- a/src/Refactoring-Core/RBInlineMethodRefactoring1.class.st
+++ b/src/Refactoring-Core/RBInlineMethodRefactoring1.class.st
@@ -1,0 +1,22 @@
+Class {
+	#name : #RBInlineMethodRefactoring1,
+	#superclass : #RBInlineMethodRefactoring,
+	#category : #'Refactoring-Core-Refactorings'
+}
+
+{ #category : #preconditions }
+RBInlineMethodRefactoring1 >> preconditions [
+	^(RBCondition definesSelector: sourceSelector in: class) 
+		& (RBCondition withBlock: 
+					[self findSelectedMessage.
+					self parseInlineMethod.
+					self isPrimitive 
+						ifTrue: [self refactoringError: 'Cannot inline primitives'].
+					self checkSuperMessages.
+					self rewriteInlinedTree.
+					(sourceMessage parent isReturn or: [self hasMultipleReturns not]) 
+						ifFalse: 
+							[self 
+								refactoringError: 'Cannot inline method since it contains multiple returns that cannot be rewritten'].
+					true])
+]

--- a/src/Refactoring-Tests-Core/RBClassTest.class.st
+++ b/src/Refactoring-Tests-Core/RBClassTest.class.st
@@ -2,6 +2,7 @@ Class {
 	#name : #RBClassTest,
 	#superclass : #RBRefactoringBrowserTest,
 	#instVars : [
+		'rbNamespace',
 		'objectClass',
 		'newClass',
 		'messageNodeClass'
@@ -11,17 +12,16 @@ Class {
 
 { #category : #running }
 RBClassTest >> setUp [
-	| st |
 	super setUp.
-	st := RBClassModelFactory rbNamespace new.
-	objectClass := st classNamed: #Object.
-	messageNodeClass := st classNamed: #RBMessageNode.
-	st defineClass: 'Object subclass: #SomeClassName
+	rbNamespace := RBClassModelFactory rbNamespace new.
+	objectClass := rbNamespace classNamed: #Object.
+	messageNodeClass := rbNamespace classNamed: #RBMessageNode.
+	rbNamespace defineClass: 'Object subclass: #SomeClassName
 	instanceVariableNames: ''instanceVariable1 instanceVariable2''
 	classVariableNames: ''ClassVariable1''
 	poolDictionaries: ''TextConstants''
 	category: #''Refactory-Testing'''.
-	newClass := st classNamed: #SomeClassName
+	newClass := rbNamespace classNamed: #SomeClassName
 ]
 
 { #category : #'method tests' }
@@ -57,6 +57,22 @@ RBClassTest >> testDefinesPoolDictionary [
 	self deny: (messageNodeClass definesPoolDictionary: #OpcodePool).
 	self assert: ((RBClassModelFactory rbNamespace new classNamed: #Text) 
 				definesPoolDictionary: #TextConstants)
+]
+
+{ #category : #'method tests' }
+RBClassTest >> testDefinesTraitMethod [
+	| user trait |
+	user := rbNamespace classNamed: #MOPTestClassD.
+	self assert: (user definesMethod: #c3).
+	self assert: (user definesMethod: #c).
+	self assert: (user definesMethod: #c2).
+	self assert: (user methodFor: #c2) modelClass ~= user.
+	self assert: (user methodFor: #c) modelClass ~= user.
+	self assert: (user methodFor: #c3) isNil. "we use nil to represent alias"
+	trait := rbNamespace classNamed: #Trait2.
+	self assert: (user methodFor: #c2) modelClass equals: trait.
+	self assert: (user methodFor: #c) modelClass equals: trait.
+	
 ]
 
 { #category : #'method tests' }

--- a/src/Refactoring-Tests-Core/RBInlineAllMethodTest.class.st
+++ b/src/Refactoring-Tests-Core/RBInlineAllMethodTest.class.st
@@ -4,6 +4,22 @@ Class {
 	#category : #'Refactoring-Tests-Core-Refactorings'
 }
 
+{ #category : #tests }
+RBInlineAllMethodTest >> testInlineMethodCalledAsSuper [
+	| class superclass |
+	model := RBClassModelFactory rbNamespace new.
+	superclass := model classNamed: self class superclass name.
+	superclass compile: 'foo: arg1 bar: arg2 ^ arg1 + arg2' classified: #(#accessing).
+	class := model classNamed: self class name.
+	class compile: 'foo: arg1 bar: arg2 ^ (super foo: arg1 bar: arg2) - arg1' classified: #(#accessing).
+	self executeRefactoring: (RBInlineAllSendersRefactoring 
+				model: model
+				sendersOf: #foo:bar:
+				in: superclass).
+	self assert: (class parseTreeFor: #foo:bar:) 
+			equals: (self parseMethod: 'foo: arg1 bar: arg2 ^ (arg1 + arg2) - arg1')
+]
+
 { #category : #'failure tests' }
 RBInlineAllMethodTest >> testInlineMethodCanNotUnderstandSelectorInClass [
 	| refactoring |


### PR DESCRIPTION
Fixes  #9041
Fixes #6218
Fixes #9042

You can watch the new behavior in: https://youtu.be/H9S3nmEHL9s

<img width="994" alt="imagen" src="https://user-images.githubusercontent.com/15729309/116035755-8764b880-a633-11eb-8e93-7b92b1d7a199.png">

This refactoring only changes the methods called with SELF and SUPER as receiver, this because if the subclasses override the method, the calls to this method, even from other classes, remain intact. 
