### PR TITLE
9093--in-floatArray-changes-the-second-array- 

### DIFF
--- a/src/Collections-Native/FloatArray.class.st
+++ b/src/Collections-Native/FloatArray.class.st
@@ -24,7 +24,8 @@ FloatArray >> = aFloatArray [
 
 { #category : #adding }
 FloatArray >> addAssignToFloatArray: aFloatArray [
-	^ self primAddArray: aFloatArray
+
+	^ aFloatArray primAddArray: self
 ]
 
 { #category : #converting }

--- a/src/Collections-Tests/FloatArrayTest.class.st
+++ b/src/Collections-Tests/FloatArrayTest.class.st
@@ -362,6 +362,18 @@ FloatArrayTest >> subCollectionNotIn [
 ]
 
 { #category : #'tests - arithmetic' }
+FloatArrayTest >> testAddNoMutation [
+	"this test checks that addition does not impact the orginal arrays"
+
+	| a b c |
+	a := { 1.2. 2.3 } asFloatArray.
+	b := { 1.2. 2.3 } asFloatArray.
+	c := a + b.
+	self assert: a equals: { 1.2. 2.3 } asFloatArray.
+	self assert: b equals: { 1.2. 2.3 } asFloatArray
+]
+
+{ #category : #'tests - arithmetic' }
 FloatArrayTest >> testArithmeticCoercion [
 	"This test is related to http://bugs.squeak.org/view.php?id=6782"
 	


### PR DESCRIPTION
- add #testAddNoMutation
- Fix problem. #addAssignToFloatArray: had the arg and self in the wrong order

fixes #9093


