### PR TITLE
RubParagraphDecorator-class-isUsed 

### DIFF
--- a/src/Rubric/RubParagraphDecorator.class.st
+++ b/src/Rubric/RubParagraphDecorator.class.st
@@ -15,6 +15,14 @@ RubParagraphDecorator class >> classOfDecoratorNamed: aKey [
 	^ self allSubclasses detect: [ :cls | cls key = aKey ] ifNone: [  ]
 ]
 
+{ #category : #testing }
+RubParagraphDecorator class >> isUsed [
+	"all my subclasses might be used via #classOfDecoratorNamed:"
+	^self name = 'RubParagraphDecorator'
+		ifTrue: [ super isUsed ]
+		ifFalse: [ true ]
+]
+
 { #category : #querying }
 RubParagraphDecorator class >> key [
 	^ self subclassResponsibility 


### PR DESCRIPTION
subclasses of RubParagraphDecorator might be used reflectively via #classOfDecoratorNamed:

This PR adds a #isUsed method so that the code critique does not show the "class is not used" critique for subclasses

