### PR TITLE
Epicea-deprecation-rewrites 

### DIFF
--- a/src/EpiceaBrowsers/EpLogBrowserPresenter.class.st
+++ b/src/EpiceaBrowsers/EpLogBrowserPresenter.class.st
@@ -32,15 +32,21 @@ EpLogBrowserPresenter class >> defaultLog [
 
 { #category : #specs }
 EpLogBrowserPresenter class >> defaultSpec [
+
 	^ SpPanedLayout newVertical
-		position: 0.6;
-		add: #itemsPresenter;
-		add:
-			(SpBoxLayout newVertical
-				add: #toolbarPresenter expand: false fill: false padding: 2;
-				add: #entryContentPresenter expand: true fill: true padding: 2;
-				yourself);
-		yourself
+		  positionOfSlider: 0.6;
+		  add: #itemsPresenter;
+		  add: (SpBoxLayout newVertical
+				   add: #toolbarPresenter
+				   expand: false
+				   fill: false
+				   padding: 2;
+				   add: #entryContentPresenter
+				   expand: true
+				   fill: true
+				   padding: 2;
+				   yourself);
+		  yourself
 ]
 
 { #category : #'instance creation' }

--- a/src/EpiceaBrowsers/EpUnifiedBrowserPresenter.class.st
+++ b/src/EpiceaBrowsers/EpUnifiedBrowserPresenter.class.st
@@ -17,11 +17,12 @@ Class {
 
 { #category : #specs }
 EpUnifiedBrowserPresenter class >> defaultSpec [
+
 	^ SpPanedLayout newHorizontal
-		position: 40 percent;
-		add: #logNodesPresenter;
-		add: #logPresenter;
-		yourself
+		  positionOfSlider: 40 percent;
+		  add: #logNodesPresenter;
+		  add: #logPresenter;
+		  yourself
 ]
 
 { #category : #'instance creation' }


### PR DESCRIPTION
When opening the code changes browser, two #defaultSpec methods get rewritten due to deprecations.

This PR commits the changed methods


