### PR TITLE
9188-Text-does-understand-unescapeCharacter

### DIFF
--- a/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
+++ b/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
@@ -583,6 +583,22 @@ RubSmalltalkEditorTest >> testBestNodeWithValidValueMidSource [
 
 ]
 
+{ #category : #'tests-copy' }
+RubSmalltalkEditorTest >> testCopySelection [
+
+	| textArea editor |
+	textArea := RubEditingArea new.
+	textArea editingMode: RubSmalltalkCodeMode new.
+
+	editor := RubSmalltalkEditor new
+		          textArea: textArea;
+		          addString: 'aa "asdfasdf"';
+		          selectInterval: (5 to: 12). 
+	self assert: editor selection equals: 'asdfasdf'.
+	self assert: editor selection class equals: Text.
+	editor copySelection.
+]
+
 { #category : #'tests-completion' }
 RubSmalltalkEditorTest >> testDefaultCompletionEngineUsesGlobalClass [
 

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -449,8 +449,8 @@ RubSmalltalkEditor >> copySelection [
 		"The node, if a comment or a string, should entirely contain the selection.
 		We convert the node source interval to an open interval to ignore the node delimiters."
 		node sourceInterval asOpenInterval includesAll: self selectionInterval ])
-			ifTrue: [ self selection unescapeCharacter: escapingCharacter ]
-			ifFalse: [ self selection ].
+			ifTrue: [ self selection asString unescapeCharacter: escapingCharacter ]
+			ifFalse: [ self selection asString ].
 	self clipboardTextPut: selection.
 	self editingState previousInterval: self selectionInterval.
 


### PR DESCRIPTION
- add test #testCopySelection
- add asString. The clipboard converts text to strings anyway, so we do not need to hand a text to it.

fixes #9188


