### PR TITLE
Add possibility to wrap text in the text comparator

### DIFF
--- a/src/Spec2-Adapters-Morphic/SpMorphicDiffAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicDiffAdapter.class.st
@@ -7,6 +7,18 @@ Class {
 	#category : #'Spec2-Adapters-Morphic-Base'
 }
 
+{ #category : #'widget API' }
+SpMorphicDiffAdapter >> beWrapped [
+
+	^ self model beWrapped
+]
+
+{ #category : #'spec protocol' }
+SpMorphicDiffAdapter >> beWrapped: aBoolean [
+
+	self widgetDo: [ :w | w beWrapped: aBoolean ]
+]
+
 { #category : #factory }
 SpMorphicDiffAdapter >> buildWidget [
 

--- a/src/Spec2-Core/SpDiffPresenter.class.st
+++ b/src/Spec2-Core/SpDiffPresenter.class.st
@@ -19,7 +19,8 @@ Class {
 		'#leftLabel => SpObservableSlot',
 		'#leftText => SpObservableSlot',
 		'#rightLabel => SpObservableSlot',
-		'#rightText => SpObservableSlot'
+		'#rightText => SpObservableSlot',
+		'#beWrapped => SpObservableSlot'
 	],
 	#category : #'Spec2-Core-Widgets'
 }
@@ -28,6 +29,18 @@ Class {
 SpDiffPresenter class >> adapterName [
 
 	^ #DiffAdapter
+]
+
+{ #category : #api }
+SpDiffPresenter >> beWrapped [
+
+	^ beWrapped
+]
+
+{ #category : #api }
+SpDiffPresenter >> beWrapped: aBoolean [
+
+	beWrapped := aBoolean
 ]
 
 { #category : #'undo-redo' }
@@ -54,7 +67,9 @@ SpDiffPresenter >> initialize [
 	showOptions := true.
 	showOnlyDestination := false.
 	showOnlySource := false.
+	beWrapped := true.
 
+	self property: #beWrapped whenChangedDo: [ :aBoolean | self changed: #beWrapped: with: {aBoolean} ].
 	self property: #leftText whenChangedDo: [ :newText | self changed: #leftText: with: {newText} ].
 	self property: #rightText whenChangedDo: [ :newText | self changed: #rightText: with: {newText} ].
 	self property: #contextClass whenChangedDo: [ :newClass | self changed: #contextClass: with: {newClass} ].

--- a/src/Tool-Diff/DiffMorph.class.st
+++ b/src/Tool-Diff/DiffMorph.class.st
@@ -23,7 +23,8 @@ Class {
 		'sourceTextModel',
 		'destTextModel',
 		'leftCaption',
-		'rightCaption'
+		'rightCaption',
+		'beWrapped'
 	],
 	#category : #'Tool-Diff-Morphs'
 }
@@ -240,6 +241,22 @@ DiffMorph >> applyPrettyPrinter [
 				ifFalse: [ self sourceTextModel formatSourceCodeInView ].
 			self destTextModel getString isEmpty
 				ifFalse: [ self destTextModel formatSourceCodeInView ] ]
+]
+
+{ #category : #accessing }
+DiffMorph >> beWrapped [
+
+	^ beWrapped
+]
+
+{ #category : #accessing }
+DiffMorph >> beWrapped: aBoolean [
+
+	beWrapped = aBoolean ifTrue: [ ^ self ].
+	beWrapped := aBoolean.
+	aBoolean
+		ifTrue: [ self dstMorph beWrapped. self srcMorph beWrapped ]
+		ifFalse: [ self dstMorph beNotWrapped. self srcMorph beNotWrapped ]
 ]
 
 { #category : #actions }
@@ -536,6 +553,7 @@ DiffMorph >> initialize [
 	showOnlyDestination := false.
 	showOnlySource := false.
 	showOptions := true.
+	beWrapped := false.
 	self
 		srcMorph: self newSrcMorph;
 		joinMorph: self newJoinMorph;


### PR DESCRIPTION
Hello there

I implemented the possibility to wrap texts in SpDiffPresenter (default behavior is unchanged, i.e horizontal scrollbars)

![wrapped-example](https://user-images.githubusercontent.com/49032546/116376546-a7050800-a810-11eb-8063-fafcabdad345.png)

Example from screenshot:
```
SpDiffPresenter exampleWithOptions presenter beWrapped: true
```