### PR TITLE
Allow-Shadowing-RequestorVars

### DIFF
--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -72,6 +72,11 @@ Variable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitVariableNode: aNode
 ]
 
+{ #category : #testing }
+Variable >> allowShadowing [
+	^false
+]
+
 { #category : #converting }
 Variable >> asDoItVariableFrom: aContext [
 	"Specific kind of variables may require special logic to be visible in DoIt expressions.

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -73,7 +73,7 @@ Variable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 ]
 
 { #category : #testing }
-Variable >> allowShadowing [
+Variable >> allowsShadowing [
 	^false
 ]
 

--- a/src/Kernel/WorkspaceVariable.class.st
+++ b/src/Kernel/WorkspaceVariable.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Kernel-Variables'
 }
 
+{ #category : #testing }
+WorkspaceVariable >> allowShadowing [
+	^true
+]
+
 { #category : #'code generation' }
 WorkspaceVariable >> emitStore: methodBuilder [
 

--- a/src/Kernel/WorkspaceVariable.class.st
+++ b/src/Kernel/WorkspaceVariable.class.st
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #testing }
-WorkspaceVariable >> allowShadowing [
+WorkspaceVariable >> allowsShadowing [
 	^true
 ]
 

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -76,7 +76,7 @@ OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode as: anOCTempVariable
 	var ifNotNil: [ shadowing := var].
 	var := scope addTemp: anOCTempVariable.
 	aVariableNode binding: var.
-	shadowing ifNotNil: [self shadowingVariable: aVariableNode].
+	(shadowing notNil and: [ shadowing allowShadowing not]) ifTrue: [self shadowingVariable: aVariableNode].
 	^ var
 ]
 

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -76,7 +76,7 @@ OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode as: anOCTempVariable
 	var ifNotNil: [ shadowing := var].
 	var := scope addTemp: anOCTempVariable.
 	aVariableNode binding: var.
-	(shadowing notNil and: [ shadowing allowShadowing not]) ifTrue: [self shadowingVariable: aVariableNode].
+	(shadowing notNil and: [ shadowing allowsShadowing not]) ifTrue: [self shadowingVariable: aVariableNode].
 	^ var
 ]
 

--- a/src/OpalCompiler-Tests/OCDoitTest.class.st
+++ b/src/OpalCompiler-Tests/OCDoitTest.class.st
@@ -93,6 +93,20 @@ OCDoitTest >> testDoItRequestorReadRequestorVar [
 ]
 
 { #category : #tests }
+OCDoitTest >> testDoItRequestorShadow [
+
+	| value  |
+	"we can shadow a var defined in the requestor without error"
+	value := OpalCompiler new
+		          source: '|requestorVarForTesting| requestorVarForTesting';
+		          noPattern: true;
+		          requestor: self;
+		          evaluate.
+		
+	self assert: value equals: nil
+]
+
+{ #category : #tests }
 OCDoitTest >> testDoitContextCheckClass [
 	"if we create a parse tree for a doit in a context, the class should be correctly set"
 	


### PR DESCRIPTION
This is a fix for https://github.com/pharo-spec/NewTools/issues/221

- introduce the concept of #allowShadowing for Variables. These variables can be shadowed and will not raise and error
- OCASTSemanticAnalyzer>>#declareVariableNode:as: now checks for allowShadowing

Add a test testDoItRequestorShadow that tests that we can indeed declare a temp if we evaluate aganst a requestor.


