### PR TITLE
9196-Enter-key-in-the-numpad-does-not-work

### DIFF
--- a/src/Morphic-Base/Form.extension.st
+++ b/src/Morphic-Base/Form.extension.st
@@ -12,13 +12,13 @@ Form >> asMorph [
 ]
 
 { #category : #'*Morphic-Base' }
-Form >> floodFillTolerance [
-	^ self class floodFillTolerance
+Form class >> floodFillTolerance [
+	^ FloodFillTolerance ifNil: [FloodFillTolerance := 0.0]
 ]
 
 { #category : #'*Morphic-Base' }
-Form class >> floodFillTolerance [
-	^ FloodFillTolerance ifNil: [FloodFillTolerance := 0.0]
+Form >> floodFillTolerance [
+	^ self class floodFillTolerance
 ]
 
 { #category : #'*Morphic-Base' }

--- a/src/Morphic-Base/MenuMorph.class.st
+++ b/src/Morphic-Base/MenuMorph.class.st
@@ -948,7 +948,7 @@ MenuMorph >> keyDown: evt [
 
 	| matchString key selectable |
 	key := evt key.
-	key = KeyboardKey enter
+	(key = KeyboardKey enter or: [key = KeyboardKey keypadEnter])
 		ifTrue: [ selectedItem
 				ifNotNil: [ ^ selectedItem hasSubMenu
 						ifTrue: [ evt hand newMouseFocus: selectedItem subMenu.

--- a/src/Morphic-Widgets-Windows/DialogWindow.class.st
+++ b/src/Morphic-Widgets-Windows/DialogWindow.class.st
@@ -225,7 +225,9 @@ DialogWindow >> keyDown: evt [
 	"Check for return and escape keys."
 
 	super keyDown: evt.
-	(self defaultButton notNil and: [evt key = KeyboardKey enter]) ifTrue: [self returnPressed. ^true].
+	(self defaultButton notNil and: [evt key = KeyboardKey enter or: [evt key = KeyboardKey keypadEnter]]) 
+		ifTrue: [self returnPressed. ^true].
+	
 	evt key = KeyboardKey escape ifTrue: [self escapePressed. ^true].
 	^false
 ]

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -151,7 +151,7 @@ CompletionEngine >> handleKeyDownBefore: aKeyboardEvent editor: anEditor [
 		ifTrue: [ 
 			menuMorph pageDown.
 			^ true ].
-	(key = KeyboardKey enter and: [ NECPreferences useEnterToAccept ])
+	((key = KeyboardKey enter or:[key = KeyboardKey keypadEnter]) and: [ NECPreferences useEnterToAccept ])
 		ifTrue: [ 
 			menuMorph insertSelected
 				ifTrue: [ ^ true ] ].

--- a/src/OSWindow-SDL2/SDL2SpecialCharacterMapping.class.st
+++ b/src/OSWindow-SDL2/SDL2SpecialCharacterMapping.class.st
@@ -21,6 +21,7 @@ SDL2SpecialCharacterMapping class >> initialize [
 	Mapping := Dictionary new.
 	{
 	 SDLK_RETURN . Character cr.
+	 SDLK_KP_ENTER. Character cr.
 	 SDLK_BACKSPACE . Character backspace.
 	 SDLK_TAB . Character tab.
 	 SDLK_HOME . Character home.

--- a/src/Polymorph-Widgets/PopupChoiceDialogWindow.class.st
+++ b/src/Polymorph-Widgets/PopupChoiceDialogWindow.class.st
@@ -181,7 +181,7 @@ PopupChoiceDialogWindow >> keyDown: anEvent [
 	(super keyDown: anEvent)
 		ifTrue: [ ^ true ].
 	
-	(anEvent key = KeyboardKey enter) 
+	(anEvent key = KeyboardKey enter or: [anEvent key = KeyboardKey keypadEnter]) 
 		ifTrue: [ ^self processEnter: anEvent ].
 	anEvent key = KeyboardKey backspace
 		ifTrue: [

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -1109,7 +1109,7 @@ RubAbstractTextArea >> isReadOnly [
 { #category : #'event handling' }
 RubAbstractTextArea >> keyDown: anEvent [
 	"Handle a keystroke event."
-	anEvent key = KeyboardKey enter
+	(anEvent key = KeyboardKey enter or: [ anEvent key = KeyboardKey keypadEnter ])
 		ifTrue: [ self handleReturnKey
 				ifTrue: [ ^ self ] ].
 

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -800,6 +800,7 @@ RubTextEditor >> defaultCommandKeymapping [
 	(KeyboardKey keypadRight -> #cursorRight:).
 	(KeyboardKey keypadUp -> #cursorUp:).
 	(KeyboardKey keypadDown -> #cursorDown:).
+	(KeyboardKey keypadEnter -> #crWithIndent:).
 	(KeyboardKey tab -> #tab:).
 	(KeyboardKey delete -> #forwardDelete:) } do: [ :assoc | 
 		cmdMap at: assoc key  put: assoc value ].


### PR DESCRIPTION
Adding the numpad enter as an enter in rubric and other text editors.
Fix #9196