### PR TITLE
Merge newtools 0.6.5

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -11,8 +11,8 @@ Class {
 BaselineOfNewTools class >> releaseCommit [
 	"The commit corresponding to current release (to be used on bootstrap process)"
 	
-	"v0.6.4"
-	^ 'ad4ad933695435588b063d710cbc1a71bbbc41f2'
+	"v0.6.5"
+	^ '2aaa7f6731479e4a7b942252f20a5b807d802912'
 ]
 
 { #category : #baselines }

--- a/src/BaselineOfSpec2/BaselineOfSpec2.class.st
+++ b/src/BaselineOfSpec2/BaselineOfSpec2.class.st
@@ -7,9 +7,9 @@ Class {
 { #category : #accessing }
 BaselineOfSpec2 class >> releaseCommit [
 	"The commit corresponding to current release (to be used on bootstrap process)"
-  
-	"v0.8.11"
-	^ '69ad69af2dbecf2ce225eda5277147a9a40ac450'
+
+	"v0.8.12"
+	^ '37f3e01b42c22615d20b791655c4b411ed2bad10'
 ]
 
 { #category : #baseline }

--- a/src/Calypso-Browser/ClyBrowserToolMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserToolMorph.class.st
@@ -532,8 +532,7 @@ ClyBrowserToolMorph >> selectAsExtraTab [
 { #category : #controlling }
 ClyBrowserToolMorph >> selectAsMainTab [
 
-	containerTab selected: true
-
+	containerTab addToSelection
 ]
 
 { #category : #initialization }

--- a/src/Calypso-SystemPlugins-Spotter/ClyGoToSpotterCandidate.class.st
+++ b/src/Calypso-SystemPlugins-Spotter/ClyGoToSpotterCandidate.class.st
@@ -50,6 +50,12 @@ ClyGoToSpotterCandidate >> activate [
 	actionBlock value
 ]
 
+{ #category : #evaluating }
+ClyGoToSpotterCandidate >> doEvaluate [
+
+	self activate
+]
+
 { #category : #accessing }
 ClyGoToSpotterCandidate >> icon [
 	^ icon
@@ -61,6 +67,12 @@ ClyGoToSpotterCandidate >> icon: anObject [
 ]
 
 { #category : #accessing }
+ClyGoToSpotterCandidate >> label [
+
+	^ self name
+]
+
+{ #category : #accessing }
 ClyGoToSpotterCandidate >> name [
 	^ name
 ]
@@ -68,6 +80,12 @@ ClyGoToSpotterCandidate >> name [
 { #category : #accessing }
 ClyGoToSpotterCandidate >> name: anObject [
 	name := anObject
+]
+
+{ #category : #accessing }
+ClyGoToSpotterCandidate >> spotterPreview [
+
+	^ nil
 ]
 
 { #category : #spotter }

--- a/src/Calypso-SystemPlugins-Spotter/ClyOpenSpotterMenuCommand.class.st
+++ b/src/Calypso-SystemPlugins-Spotter/ClyOpenSpotterMenuCommand.class.st
@@ -50,11 +50,5 @@ ClyOpenSpotterMenuCommand class >> textToolShortcutActivation [
 { #category : #execution }
 ClyOpenSpotterMenuCommand >> execute [
 
-	GTSpotterMorph new
-		extent: (self currentWorld width / 2.4 @ (self currentWorld height / 1.6)) asIntegerPoint;
-		spotterModel: (GTSpotter on: (ClySpotterModel on: browser));
-		doLayout;
-		openCenteredInWorld;	
-		initializeListeners;
-		takeKeyboardFocus
+	Smalltalk tools spotter openOnOrigin: (ClySpotterModel on: browser)
 ]

--- a/src/Calypso-SystemPlugins-Spotter/ClySpotterModel.class.st
+++ b/src/Calypso-SystemPlugins-Spotter/ClySpotterModel.class.st
@@ -85,27 +85,3 @@ ClySpotterModel >> initializeOn: aBrowser [
 	browser := aBrowser.
 	self initialize	
 ]
-
-{ #category : #private }
-ClySpotterModel >> spotterForCommandsFor: aStep [
-	<spotterOrder: 20>
-
-	browser allContextsDo: [ :each | 
-		self commandListProcessorForContext: each step: aStep]
-]
-
-{ #category : #'accessing spotter' }
-ClySpotterModel >> spotterForGoToFor: aStep [
-	<spotterOrder: 10>
-
-	aStep listProcessor
-		title: 'Go to';
-		allCandidates: [ self collectGoToCandidates ];
-		itemName: #name;
-		itemIcon: #icon;
-		candidatesLimit: 10;
-		filter: GTFilterSubstring;
-		actLogic: [ :assoc :step | 
-			step exit. 
-			assoc activate ]
-]

--- a/src/Calypso-SystemPlugins-Spotter/CmdCommandActivator.extension.st
+++ b/src/Calypso-SystemPlugins-Spotter/CmdCommandActivator.extension.st
@@ -1,11 +1,34 @@
 Extension { #name : #CmdCommandActivator }
 
 { #category : #'*Calypso-SystemPlugins-Spotter' }
-CmdCommandActivator >> spotterPreviewIn: aComposite [
-	<spotterPreview: 10>
+CmdCommandActivator >> doEvaluate [
 	
-	^aComposite text
-		title: [self command class name]; 
-		display: [self command class comment];
-		entity: [ self ]
+	self executeCommand
+]
+
+{ #category : #'*Calypso-SystemPlugins-Spotter' }
+CmdCommandActivator >> icon [
+
+	^ self menuItemIcon
+]
+
+{ #category : #'*Calypso-SystemPlugins-Spotter' }
+CmdCommandActivator >> label [
+
+	^ self menuItemName
+]
+
+{ #category : #'*Calypso-SystemPlugins-Spotter' }
+CmdCommandActivator >> spotterPreview [
+
+	^ self spotterPreview: SpPresenterBuilder new
+]
+
+{ #category : #'*Calypso-SystemPlugins-Spotter' }
+CmdCommandActivator >> spotterPreview: aBuilder [
+
+	^ aBuilder newText
+		beNotEditable;
+		text: self command class comment;
+		yourself
 ]

--- a/src/Morphic-Widgets-FastTable/FTBasicItem.class.st
+++ b/src/Morphic-Widgets-FastTable/FTBasicItem.class.st
@@ -87,6 +87,8 @@ FTBasicItem >> collapse [
 	If any selected elements are within the childrens of the collapsed element,
 	I select the collapsed element."
 
+	self isExpanded ifFalse: [ ^ self ].
+	
 	recentlyChanged := true.
 	self dataSource
 		updateSelectionWithCollectBlock:

--- a/src/NewTools-Spotter-Processors/StSpotterPragmaBasedProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StSpotterPragmaBasedProcessor.class.st
@@ -132,6 +132,11 @@ StSpotterPragmaBasedProcessor >> installKeymappingsOn: aGTSpotterMorph [
 				toAction: [ aGTSpotterMorph onKeyProcessor: self ] ]
 ]
 
+{ #category : #'key-bindings' }
+StSpotterPragmaBasedProcessor >> installKeymappingsOn: aPresenter onExecution: aBlock [
+
+]
+
 { #category : #testing }
 StSpotterPragmaBasedProcessor >> isRelevantForQuery: categoryQueryPrefix [
 	| trimmedProcessorTitle |

--- a/src/NewTools-Spotter/StSpotter.class.st
+++ b/src/NewTools-Spotter/StSpotter.class.st
@@ -411,7 +411,7 @@ StSpotter >> initialize [
 
 { #category : #initialization }
 StSpotter >> initializeDialogWindow: aDialogWindowPresenter [
-
+ 
 	aDialogWindowPresenter closeOnBackdropClick: true
 ]
 

--- a/src/NewTools-Spotter/StSpotter.class.st
+++ b/src/NewTools-Spotter/StSpotter.class.st
@@ -128,6 +128,20 @@ StSpotter class >> open [
 	^ spotter openModalWithSpec
 ]
 
+{ #category : #'instance creation' }
+StSpotter class >> openOn: aModel [
+
+	self reset.
+	spotter := self on: aModel.
+	^ spotter openModalWithSpec
+]
+
+{ #category : #'instance creation' }
+StSpotter class >> openOnOrigin: anObject [
+
+	^ self openOn: (StSpotterModel newOrigin: anObject)
+]
+
 { #category : #settings }
 StSpotter class >> previewVisible [
 		

--- a/src/NewTools-Spotter/StSpotterModel.class.st
+++ b/src/NewTools-Spotter/StSpotterModel.class.st
@@ -14,6 +14,14 @@ Class {
 	#category : #'NewTools-Spotter-Model'
 }
 
+{ #category : #'instance creation' }
+StSpotterModel class >> newOrigin: anObject [ 
+
+	^ self basicNew 
+		initializeOrigin: anObject;
+		yourself
+]
+
 { #category : #accessing }
 StSpotterModel >> activeProcessors [
 
@@ -23,7 +31,14 @@ StSpotterModel >> activeProcessors [
 { #category : #accessing }
 StSpotterModel >> activeStep [
 
-	^ steps last
+	^ self steps last
+]
+
+{ #category : #private }
+StSpotterModel >> addStep: aStep [ 
+
+	steps ifNil: [ steps := OrderedCollection new ].
+	steps addLast: aStep
 ]
 
 { #category : #'private announcing' }
@@ -88,14 +103,22 @@ StSpotterModel >> initialize [
 	scheduler poolMaxSize: 10.
 	scheduler start.
 	
-	mutex := Mutex new.
-	steps := OrderedCollection with: self newDefaultStep
+	mutex := Mutex new
+]
+
+{ #category : #initialization }
+StSpotterModel >> initializeOrigin: anObject [
+	
+	self initialize.
+	self addStep: (self newStep
+		origin: anObject;
+		yourself)
 ]
 
 { #category : #testing }
 StSpotterModel >> isNested [
 
-	^ steps size > 1
+	^ self steps size > 1
 ]
 
 { #category : #accessing }
@@ -129,11 +152,11 @@ StSpotterModel >> popStep [
 	| lastQuery |
 
 	"Do not pop first"
-	steps size > 1 ifFalse: [ ^ self ]. 
+	self steps size > 1 ifFalse: [ ^ self ]. 
 
 	lastQuery := self activeStep activeQuery.
 	self activeStep deactivate.
-	steps removeLast.
+	self steps removeLast.
 	self activeStep activate
 ]
 
@@ -167,7 +190,7 @@ StSpotterModel >> pushStepForProcessor: aProcessor [
 	allCandidates := aProcessor allFilteredCandidates collect: [ :each | 
 		each asStSpotterCandidateLink renderingProcessor: processorLink ].
 	step origin: allCandidates.
-	steps addLast: step
+	self addStep: step
 ]
 
 { #category : #accessing }
@@ -196,6 +219,14 @@ StSpotterModel >> stSpotterProcessorsFor: aStep [
 StSpotterModel >> startProcessingOn: spotter [
 
 	self processSearch: '' on: spotter
+]
+
+{ #category : #private }
+StSpotterModel >> steps [
+
+	^ steps ifNil: [ 
+		self addStep: self newDefaultStep.
+		steps ]
 ]
 
 { #category : #'accessing query' }

--- a/src/Spec2-Adapters-Morphic/SpMorphicTreeTableAdapter.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTreeTableAdapter.class.st
@@ -144,6 +144,18 @@ SpMorphicTreeTableAdapter >> buildWidget [
 	^ tableMorph
 ]
 
+{ #category : #accessing }
+SpMorphicTreeTableAdapter >> collapseAll [
+
+	widget dataSource collapseAll
+]
+
+{ #category : #accessing }
+SpMorphicTreeTableAdapter >> collapsePath: anArray [  
+
+	widget dataSource collapsePath: anArray
+]
+
 { #category : #testing }
 SpMorphicTreeTableAdapter >> columnCount [
 	
@@ -210,7 +222,9 @@ SpMorphicTreeTableAdapter >> isExpanded: anItem [
 	path := widget dataSource 
 		pathOfItem: anItem 
 		root: widget dataSource rootItem.
-	^ (widget dataSource itemAtPath: path) isExpanded
+	^ (widget dataSource itemAtPath: path) 
+		ifNotNil: [ :node | node isExpanded ]
+		ifNil: [ false ]
 ]
 
 { #category : #testing }

--- a/src/Spec2-Adapters-Morphic/SpMorphicTreeTableDataSource.class.st
+++ b/src/Spec2-Adapters-Morphic/SpMorphicTreeTableDataSource.class.st
@@ -68,10 +68,19 @@ SpMorphicTreeTableDataSource >> cellIndentFor: item [
 	^ item depth * 16
 ]
 
+{ #category : #private }
+SpMorphicTreeTableDataSource >> collapsePath: aPath [
+
+	(self itemAtPath: aPath) ifNotNil:[ :aNode | 
+		aNode collapseAll.
+		self tableRefresh ]
+]
+
 { #category : #accessing }
 SpMorphicTreeTableDataSource >> expandPath: anArray [
 
-	self expandPath: anArray root: self rootItem children
+	self expandPath: anArray root: self rootItem children.
+	self tableRefresh
 ]
 
 { #category : #accessing }

--- a/src/Spec2-Backend-Tests/SpTreePresenterExpandTest.class.st
+++ b/src/Spec2-Backend-Tests/SpTreePresenterExpandTest.class.st
@@ -15,7 +15,32 @@ SpTreePresenterExpandTest >> initializeTestedInstance [
 
 	presenter 
 		roots: #(1);
-		children: [ :aNumber | (aNumber * 10 to: (aNumber * 10) + 10) asOrderedCollection ].
+		children: [ :aNumber | 
+			aNumber < 1000
+				ifTrue: [ (aNumber * 10 to: (aNumber * 10) + 10) asOrderedCollection ]
+				ifFalse: [ #() ] ].
+]
+
+{ #category : #tests }
+SpTreePresenterExpandTest >> testCollapseAll [
+
+	presenter expandAll.
+	self openInstance.
+	self deny: presenter roots isEmpty.
+	self assert: (presenter adapter isExpanded: (presenter itemAtPath: #(1 2 3))).	
+	presenter collapseAll.
+	self deny: (presenter adapter isExpanded: (presenter itemAtPath: #(1 2 3)))
+]
+
+{ #category : #tests }
+SpTreePresenterExpandTest >> testCollapsePath [
+
+	presenter expandAll.
+	self openInstance.
+	self deny: presenter roots isEmpty.
+	self assert: (presenter adapter isExpanded: (presenter itemAtPath: #(1 2 3))).	
+	presenter collapsePath: #(1 2 3).
+	self deny: (presenter adapter isExpanded: (presenter itemAtPath: #(1 2 3)))
 ]
 
 { #category : #tests }

--- a/src/Spec2-Core/SpAbstractTreePresenter.class.st
+++ b/src/Spec2-Core/SpAbstractTreePresenter.class.st
@@ -96,6 +96,23 @@ SpAbstractTreePresenter >> clickAtPath: aPath [
 	self doActivateAtPath: aPath
 ]
 
+{ #category : #api }
+SpAbstractTreePresenter >> collapseAll [
+	"Collapse all nodes of the tree. "
+
+	self withAdapterPerformOrDefer: [ :anAdapter | 
+		anAdapter collapseAll ]
+]
+
+{ #category : #api }
+SpAbstractTreePresenter >> collapsePath: aPath [
+	"Collapse the tree path.
+	`aPath` is the path to collapse. A path is an array of node indexes (e.g. #(1 2 3))"
+
+	self withAdapterPerformOrDefer: [ :anAdapter |
+		anAdapter collapsePath: aPath ]
+]
+
 { #category : #private }
 SpAbstractTreePresenter >> disableActivationDuring: aBlock [
 	| oldActivate |


### PR DESCRIPTION
NewTools 0.6.5
===
https://github.com/pharo-spec/NewTools/releases/tag/v0.6.5

- spotter handles correctly scoping it by an origin (it will be used in calypso <meta+h> command, and probably others).

Spec 0.8.12
===
https://github.com/pharo-spec/Spec/releases/tag/v0.8.12

- trees now can collapse paths
