### PR TITLE
Fix KMShortcutPrinter when single key is pressed

### DIFF
--- a/src/Keymapping-Core/KMOSXShortcutPrinter.class.st
+++ b/src/Keymapping-Core/KMOSXShortcutPrinter.class.st
@@ -1,3 +1,7 @@
+"
+I'm an util to convert a shortcut into the representation used in OSX
+
+"
 Class {
 	#name : #KMOSXShortcutPrinter,
 	#superclass : #KMShortcutPrinter,

--- a/src/Keymapping-Core/KMShortcutPrinter.class.st
+++ b/src/Keymapping-Core/KMShortcutPrinter.class.st
@@ -84,9 +84,10 @@ KMShortcutPrinter >> visitSingleShortcut: aShortcut [
 	| char |
 	char := self mapSpecialCharacter: aShortcut platformCharacter.
 	^ String streamContents: [ :stream | 
-		  (self shortcutModifiersOf: aShortcut)
+		(self shortcutModifiersOf: aShortcut) ifNotEmpty: [ :modifiers |  
+			modifiers
 			  do: [ :each | stream << each ]
 			  separatedBy: [ stream << '+' ].
-		  stream << '+'.
-		  stream << char ]
+			stream << '+' ].
+		stream << char ]
 ]

--- a/src/Keymapping-Tests/KMShortcutPrinterTest.class.st
+++ b/src/Keymapping-Tests/KMShortcutPrinterTest.class.st
@@ -107,3 +107,14 @@ KMShortcutPrinterTest >> testPrintShortcut [
 	printed := shortcut acceptVisitor: platform shortcutPrinter.
 	self assert: printed equals: result
 ]
+
+{ #category : #tests }
+KMShortcutPrinterTest >> testSingleKeyCombinationIsPrintedWithoutSeparators [
+	| printed |
+
+	printed := Character arrowLeft asKeyCombination acceptVisitor: platform shortcutPrinter.
+	self assert: printed equals: 'LEFT'.
+	
+	printed := Character arrowRight asKeyCombination acceptVisitor: platform shortcutPrinter.
+	self assert: printed equals: 'RIGHT'
+]


### PR DESCRIPTION
shortcut printer was expecting always at least one modifier, hence if we send a shortcut that is only "left" or "right" (or any "single key") it was printing +LEFT and +RIGHT, which is obviously wrong :)