### PR TITLE
9114-Locale-seem-to-use-two-class-vars-for-the-same-thing

### DIFF
--- a/src/Deprecated90/Locale.extension.st
+++ b/src/Deprecated90/Locale.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #Locale }
+
+{ #category : #'*Deprecated90' }
+Locale class >> currentPlatform [
+	self deprecated: 'Use #current instead.' transformWith: '`@receiver currentPlatform' -> '`@receiver current'.
+	^ self current
+]
+
+{ #category : #'*Deprecated90' }
+Locale class >> currentPlatform: locale [
+
+		self deprecated: 'Use #switchTo: instead.' transformWith: '`@receiver currentPlatform: `@arg' -> '`@receiver switchTo: `@arg'.
+		self switchTo: locale
+]

--- a/src/System-Localization/Locale.class.st
+++ b/src/System-Localization/Locale.class.st
@@ -22,7 +22,6 @@ Class {
 	#classVars : [
 		'Activated',
 		'Current',
-		'CurrentPlatform',
 		'KnownLocales',
 		'LanguageSymbols',
 		'PlatformEncodings'
@@ -45,35 +44,18 @@ Locale class >> activated: aBoolean [
 
 { #category : #accessing }
 Locale class >> current [
-	"Current := nil"
-	Current ifNil: [
-		Current := self determineCurrentLocale.
-		"Transcript show: 'Current locale: ' , Current localeID asString; cr"].
-	^Current
-]
 
-{ #category : #accessing }
-Locale class >> currentPlatform [
-	"CurrentPlatform := nil"
-	CurrentPlatform ifNil: [CurrentPlatform := self determineCurrentLocale].
-	^CurrentPlatform
-]
-
-{ #category : #accessing }
-Locale class >> currentPlatform: locale [
-
-	CurrentPlatform := locale
-
+	^ Current ifNil: [ Current := self determineCurrentLocale ]
 ]
 
 { #category : #accessing }
 Locale class >> currentPlatform: locale during: aBlock [ 
-	"Alter current language platform during a block"
-	| backupPlatform |
-	backupPlatform := self currentPlatform.
-	[self currentPlatform: locale.
+	"Alter current locale during a block"
+	| savedLocale |
+	savedLocale := self current.
+	[self switchTo: locale.
 	aBlock value]
-		ensure: [self currentPlatform: backupPlatform]
+		ensure: [self switchTo: savedLocale]
 ]
 
 { #category : #'platform specific' }
@@ -222,15 +204,13 @@ Locale class >> stringForLanguageNameIs: localeID [
 ]
 
 { #category : #accessing }
-Locale class >> switchTo: locale [ 
-	"Locale switchTo: Locale isoLanguage: 'de'"
-	Current localeID = locale localeID
-		ifFalse: [
-			|announcement|
-			announcement := LocaleChanged from: Current to: locale.
-			Current := locale.
-			CurrentPlatform := locale.
-			self localeAnnouncer announce: announcement ]
+Locale class >> switchTo: locale [
+
+	| announcement |
+	Current localeID = locale localeID ifTrue: [ ^ self ].
+	announcement := LocaleChanged from: Current to: locale.
+	Current := locale.
+	self localeAnnouncer announce: announcement
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
CurrentPlatform seems to be just used by currentPlatform:during: , which then has no effect as there are no users of the ivar or the accessors of CurrentPlatform.

- simplify #current and #switchTo:
- deprecate #currentPlatform and #currentPlatform:
- rewrite #currentPlatform:during: to use #current and switchTo: (it has not senders, I wonder if it is needed)
- remvove class variable CurrentPlatform

fixes #9114


