### PR TITLE
fix 9213 DNU when browsing implementors

### DIFF
--- a/src/Spec2-Code/SpCodePresenter.class.st
+++ b/src/Spec2-Code/SpCodePresenter.class.st
@@ -197,7 +197,8 @@ SpCodePresenter >> browseSelectedSelectorIfGlobal: globalBlock ifNotGlobal: nonG
 	| variableOrClassName env |
 
 	variableOrClassName := self selectedSelector.
-
+	variableOrClassName ifNil: [ ^ self inform: 'No string could be parsed to answer your query.' ].
+	
 	env := self environment.
 	
 	self flag: #bug.

--- a/src/Spec2-Tests/SpCodePresenterTest.class.st
+++ b/src/Spec2-Tests/SpCodePresenterTest.class.st
@@ -83,36 +83,13 @@ SpCodePresenterTest >> testFindClassFrom [
 ]
 
 { #category : #tests }
-SpCodePresenterTest >> testSelectedSelector [
-
-	"Testing border cases to avoid breaking execution. The selector extraction logic should be tested in the extractor class"
-
+SpCodePresenterTest >> testNilTestSelectedSelectorDoesNotBreakExecution [
 	"Code presenter has nil text for some reason"
 
 	| selector |
 	presenter text: nil.
 	selector := presenter selectedSelector.
 	self assert: selector isNil.
-
-	"Code presenter is empty"
-	presenter text: ''.
-	selector := presenter selectedSelector.
-	self assert: selector isNil.
-
-	"Code has valid code"
-	selector := presenter text: 'anObject do: 1 with: 2'.
-	selector := presenter selectedSelector.
-	self assert: selector equals: #do:with:.
-
-	"Code has faulty code"
-	selector := presenter text: 'anObject do : 1 with: 2'.
-	selector := presenter selectedSelector.
-	self assert: selector equals: #do.
-
-	"Code has invalid code (no selectors at all)"
-	selector := presenter text: 'anObjectdo : 2'.
-	selector := presenter selectedSelector.
-	self assert: selector equals: #noMethod
 ]
 
 { #category : #tests }

--- a/src/Tools-CodeNavigation-Tests/CNSelectorExtractionOnPositionTest.class.st
+++ b/src/Tools-CodeNavigation-Tests/CNSelectorExtractionOnPositionTest.class.st
@@ -114,6 +114,17 @@ CNSelectorExtractionOnPositionTest >> testCaretAfterFirstMessageInBlock [
 	self assert: self selectedSelector equals: messageInsideBlock selector
 ]
 
+{ #category : #'tests - no selection - variable' }
+CNSelectorExtractionOnPositionTest >> testCaretAfterInVariable [
+
+	| selector |
+	selector := #even.
+	sourceCode := selector.
+	ast := (RBParser parseFaultyExpression: selector).
+	self caretAfter: ast.
+	self assert: self selectedSelector equals: selector
+]
+
 { #category : #'tests - no selection - blocks' }
 CNSelectorExtractionOnPositionTest >> testCaretAfterLastMessageInBlock [
 

--- a/src/Tools-CodeNavigation-Tests/CNSelectorExtractionOnPositionTest.class.st
+++ b/src/Tools-CodeNavigation-Tests/CNSelectorExtractionOnPositionTest.class.st
@@ -102,6 +102,66 @@ CNSelectorExtractionOnPositionTest >> sourceCodeOf: aMethod [
 	ast := aMethod ast
 ]
 
+{ #category : #'tests - no selection - withOutMessage' }
+CNSelectorExtractionOnPositionTest >> testCaretAfterABlock [
+	| selector |
+	selector := '[]'.
+	sourceCode := selector.
+	ast := (RBParser parseFaultyExpression: selector).
+	self caretAfter: ast.
+	self assert: self selectedSelector equals: #noMethod
+]
+
+{ #category : #'tests - no selection - withOutMessage' }
+CNSelectorExtractionOnPositionTest >> testCaretAfterABlockWithArgument [
+	| selector |
+	selector := '[:even| ]'.
+	sourceCode := selector.
+	ast := (RBParser parseFaultyExpression: selector).
+	self caretAfter: ast.
+	self assert: self selectedSelector equals: #noMethod
+]
+
+{ #category : #'tests - no selection - withOutMessage' }
+CNSelectorExtractionOnPositionTest >> testCaretAfterADynamicArray [
+	| selector |
+	selector := '{}'.
+	sourceCode := selector.
+	ast := (RBParser parseFaultyExpression: selector).
+	self caretAfter: ast.
+	self assert: self selectedSelector equals: #noMethod
+]
+
+{ #category : #'tests - no selection - withOutMessage' }
+CNSelectorExtractionOnPositionTest >> testCaretAfterADynamicArrayWithAnElement [
+	| selector |
+	selector := '{even}'.
+	sourceCode := selector.
+	ast := (RBParser parseFaultyExpression: selector).
+	self caretAfter: ast.
+	self assert: self selectedSelector equals: #noMethod
+]
+
+{ #category : #'tests - no selection - withOutMessage' }
+CNSelectorExtractionOnPositionTest >> testCaretAfterALiteralArray [
+	| selector |
+	selector := '#()'.
+	sourceCode := selector.
+	ast := (RBParser parseFaultyExpression: selector).
+	self caretAfter: ast.
+	self assert: self selectedSelector equals: #noMethod
+]
+
+{ #category : #'tests - no selection - withOutMessage' }
+CNSelectorExtractionOnPositionTest >> testCaretAfterALiteralArrayWithAnElement [
+	| selector |
+	selector := '#(even)'.
+	sourceCode := selector.
+	ast := (RBParser parseFaultyExpression: selector).
+	self caretAfter: ast.
+	self assert: self selectedSelector equals: #noMethod
+]
+
 { #category : #'tests - no selection - blocks' }
 CNSelectorExtractionOnPositionTest >> testCaretAfterFirstMessageInBlock [
 
@@ -112,17 +172,6 @@ CNSelectorExtractionOnPositionTest >> testCaretAfterFirstMessageInBlock [
 	self caretAfter: messageInsideBlock.
 	
 	self assert: self selectedSelector equals: messageInsideBlock selector
-]
-
-{ #category : #'tests - no selection - variable' }
-CNSelectorExtractionOnPositionTest >> testCaretAfterInVariable [
-
-	| selector |
-	selector := #even.
-	sourceCode := selector.
-	ast := (RBParser parseFaultyExpression: selector).
-	self caretAfter: ast.
-	self assert: self selectedSelector equals: selector
 ]
 
 { #category : #'tests - no selection - blocks' }
@@ -182,6 +231,17 @@ CNSelectorExtractionOnPositionTest >> testCaretAfterReturnShouldMatchChildCascad
 	
 	cascade := self returnNodeToTest value.
 	self assert: self selectedSelector equals: cascade messages first selector
+]
+
+{ #category : #'tests - no selection - variable' }
+CNSelectorExtractionOnPositionTest >> testCaretAfterVariableNode [
+
+	| selector |
+	selector := #even.
+	sourceCode := selector.
+	ast := (RBParser parseFaultyExpression: selector).
+	self caretAfter: ast.
+	self assert: self selectedSelector equals: selector
 ]
 
 { #category : #'tests - no selection - return' }
@@ -390,6 +450,27 @@ CNSelectorExtractionOnPositionTest >> testCaretInTheMiddleOfNestedMessageReceive
 	self caretInMiddleOf: self messageNodeToTest receiver.
 	
 	self assert: self selectedSelector equals: self messageNodeToTest receiver selector
+]
+
+{ #category : #'tests - no selection - withOutMessage' }
+CNSelectorExtractionOnPositionTest >> testCaretOnNonValidCode [
+	"Code has invalid code (no selectors at all)"
+
+	
+	sourceCode := 'anObjectdo : 2'.
+	ast := (RBParser parseFaultyExpression: sourceCode).
+	self caretAfter: ast.
+	self assert: self selectedSelector equals: #noMethod.
+]
+
+{ #category : #'tests - no selection - withOutMessage' }
+CNSelectorExtractionOnPositionTest >> testCaretWithEmptyString [
+	| selector |
+	selector := ''.
+	sourceCode := selector.
+	ast := (RBParser parseFaultyExpression: selector).
+	self caretAfter: ast.
+	self assert: self selectedSelector equals: nil
 ]
 
 { #category : #'tests - no selection - blocks' }

--- a/src/Tools-CodeNavigation-Tests/CNSelectorExtractionOnSelectionTest.class.st
+++ b/src/Tools-CodeNavigation-Tests/CNSelectorExtractionOnSelectionTest.class.st
@@ -105,3 +105,11 @@ CNSelectorExtractionOnSelectionTest >> testSelectReturnShouldMatchToken [
 	
 	self assert: self selectedSelector equals: #foo
 ]
+
+{ #category : #'tests - selection' }
+CNSelectorExtractionOnSelectionTest >> testSelectTokenShouldMatchToken [
+
+	self select: 'foo'.
+	
+	self assert: self selectedSelector equals: #foo
+]

--- a/src/Tools-CodeNavigation-Tests/CNSelectorExtractionOnSelectionTest.class.st
+++ b/src/Tools-CodeNavigation-Tests/CNSelectorExtractionOnSelectionTest.class.st
@@ -94,7 +94,7 @@ CNSelectorExtractionOnSelectionTest >> testSelectReturnShouldMatchToken [
 { #category : #'tests - selection' }
 CNSelectorExtractionOnSelectionTest >> testSelectTokenShouldMatchToken [
 
-	self select: 'foo'.
+	self select: 'even : 2'.
 	
-	self assert: self selectedSelector equals: #foo
+	self assert: self selectedSelector equals: #noMethod
 ]

--- a/src/Tools-CodeNavigation-Tests/CNSelectorExtractionOnSelectionTest.class.st
+++ b/src/Tools-CodeNavigation-Tests/CNSelectorExtractionOnSelectionTest.class.st
@@ -36,6 +36,21 @@ CNSelectorExtractionOnSelectionTest >> testSelectCascadeFirstMessageWithoutRecei
 ]
 
 { #category : #'tests - selection' }
+CNSelectorExtractionOnSelectionTest >> testSelectInvalidCode [
+
+	self select: 'even : 2'.
+	
+	self assert: self selectedSelector equals: #even
+]
+
+{ #category : #'tests - selection' }
+CNSelectorExtractionOnSelectionTest >> testSelectInvalidCodeWithPossibleSelector [
+	"Code has faulty code"
+	self select: 'anObject do : 1 with: 2'.
+	self assert: self selectedSelector equals: #do
+]
+
+{ #category : #'tests - selection' }
 CNSelectorExtractionOnSelectionTest >> testSelectKeywordMessageShouldMatchKeywordSelector [
 
 	self select: 'a foo: 17 bar: (some message: #toto) fum: [ :will | it break ]'.
@@ -89,12 +104,4 @@ CNSelectorExtractionOnSelectionTest >> testSelectReturnShouldMatchToken [
 	self select: '^ foo'.
 	
 	self assert: self selectedSelector equals: #foo
-]
-
-{ #category : #'tests - selection' }
-CNSelectorExtractionOnSelectionTest >> testSelectTokenShouldMatchToken [
-
-	self select: 'even : 2'.
-	
-	self assert: self selectedSelector equals: #noMethod
 ]

--- a/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
+++ b/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
@@ -82,7 +82,7 @@ CNSelectorExtractor >> extractSelectorFromNode: aNode [
 			node := node parent messages first ] ].
 	
 	"In the case of doIt methods"
-	node selector = #noMethod & aNode isVariable
+	(node selector = #noMethod and: [ aNode isVariable ])
 		ifTrue: [  ^ aNode name ].
 
 

--- a/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
+++ b/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
@@ -82,7 +82,8 @@ CNSelectorExtractor >> extractSelectorFromNode: aNode [
 			node := node parent messages first ] ].
 	
 	"In the case of doIt methods"
-	node selector = #noMethod ifTrue: [  ^ aNode name ].
+	node selector = #noMethod & aNode isVariable
+		ifTrue: [  ^ aNode name ].
 
 
 	^ node selector

--- a/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
+++ b/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
@@ -80,6 +80,10 @@ CNSelectorExtractor >> extractSelectorFromNode: aNode [
 		(node ~= originalNode and: [ 
 			 node parent notNil and: [ node parent isCascade ] ]) ifTrue: [ 
 			node := node parent messages first ] ].
+	
+	"In the case of doIt methods"
+	node selector = #noMethod ifTrue: [  ^ aNode name ].
+
 
 	^ node selector
 ]
@@ -108,10 +112,14 @@ CNSelectorExtractor >> extractSelectorFromSelection: aString [
 CNSelectorExtractor >> extractSelectorFromSource: aString atPosition: aPosition [
 
 	"Receives a string with the source code, and a number which indicates the position (of the caret) where the selectors will be extracted."
-
+	| position |
 	aString ifNil: [ ^ nil ].
 	aString ifEmpty: [ ^ nil ].
-	((aPosition < 0) or: (aPosition > aString size)) ifTrue: [ ^nil ].
+	position := (aPosition < 0 or: [ aPosition > aString size ]) 
+		ifTrue: [
+			(aString size + 1) = aPosition 
+				ifTrue: [ aPosition -1 ]
+				ifFalse: [ ^ nil ]].
 	^ self
 		  extractSelectorFromAST: (RBParser parseFaultyExpression: aString)
 		  atPosition: aPosition


### PR DESCRIPTION
fixes #9213.

This breaks (at least) the test SPCodePresenterTest >>  #testSelectedSelector.
I left it as is for now and I'm awaiting for some feedback / opinion on this.
The breaking assert in the test is not relevant IMO in this test.
I'll see if the CI finds more breaking tests and their relevance.

The problem is two fold.
First, when reproducing the issue, the string is parse (rightfully) as a Variable (an unresolved one), which is put in a doIt (#noMethod).
The selector extraction is looking for a selector and only encounters a variable.
Therefore, the first selector it's actually encountering is the doIt selector #noMethod.
There is a test showing it in the selector extraction &  the fix only in the doIt case.
I am unsure whether this can happen some other way.

The second problem is that when putting the caret at the end of a selector, it's too big for the string
'isTest' size = 6
Position of cursor when at the end = 7.
Therefore it was never extracted as a selector.
Fix without test. 
Unsure where this should go if anywhere.

Thanks for reading, awaiting for CI & feedbacks :)