### PR TITLE
add upperbound on seed in random

### DIFF
--- a/src/Random-Core/Random.class.st
+++ b/src/Random-Core/Random.class.st
@@ -184,11 +184,13 @@ Random >> seed [
 
 { #category : #initialization }
 Random >> seed: aNumber [
-	"Refer #privateNextSeed and [1], seed should be positive"
+	"Refer #privateNextSeed and [1], seed should be positive and less than m"
 	| newSeed |
 	newSeed := aNumber.
 	[ newSeed > 0 ] whileFalse: 
 		[ newSeed := newSeed + m ].
+	[ newSeed < m ] whileFalse:
+		[ newSeed := newSeed - m ].
 	seed := newSeed.
 
 ]


### PR DESCRIPTION
Aims to solve #6231

When a large seed is given to Random, it starts giving negative values.
Every seed greater than 1e12 seems to be producing negative values.

This PR adds an upper bound( m = 2^31 - 1) to the value that a seed can take.

