### PR TITLE
Fix  #9222: Cannot disable word wrap from Rubric

### DIFF
--- a/src/Rubric/RubTextScrollPane.class.st
+++ b/src/Rubric/RubTextScrollPane.class.st
@@ -35,7 +35,7 @@ RubTextScrollPane >> appendText: stringOrText [
 
 { #category : #'text area protocol' }
 RubTextScrollPane >> beNotWrapped [
-	self handleWrappingPolicyChange: [ self textArea wrapped: false]
+	self handleWrappingPolicyChange: [ self textArea beNotWrapped ]
 ]
 
 { #category : #'text area protocol' }


### PR DESCRIPTION
#wrapped: is private to the text area, we should use beNotWrapped and be symetric with beWrapped