### PR TITLE
Remove add argument refactor option from menu for message

### DIFF
--- a/src/SystemCommands-MessageCommands/SycAddMessageArgumentCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycAddMessageArgumentCommand.class.st
@@ -17,6 +17,17 @@ Class {
 	#category : #'SystemCommands-MessageCommands'
 }
 
+{ #category : #testing }
+SycAddMessageArgumentCommand class >> canBeExecutedInContext: aToolContext [
+
+	"This method overrides the superclass definition to make appear this option only for methods.
+
+	Using the refactor from the method selection panel works fine.
+	Otherwise createValidNameArgument creates an argument name that is not already in use (for example: if anObject is used then it return anObject1).
+	Howerver when we ask this refactoring from a message we don't know the method and cannot do those checks. (If there is only one)"
+	^aToolContext isMethodSelected
+]
+
 { #category : #activation }
 SycAddMessageArgumentCommand class >> methodContextMenuActivation [
 	<classAnnotation>


### PR DESCRIPTION
Using the refactor from the method selection panel works fine.
Otherwise createValidNameArgument creates an argument name that is not already in use (for example: if anObject is used then it return anObject1).
However when we ask this refactoring from a message we don't know the method and cannot do those checks. (If there is only one)".

They need do be check in another place.

Fix issue #9194