### PR TITLE
Fix-isSuperSend-Not-Hardcode-String 

### DIFF
--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -199,7 +199,7 @@ RBMessageNode >> isSelfSend [
 
 { #category : #testing }
 RBMessageNode >> isSuperSend [
-	^ self receiver isVariable and: [ self receiver name = 'super' ]
+	^ self receiver isSuperVariable
 ]
 
 { #category : #testing }


### PR DESCRIPTION
This PR fixes RBMessageNode>> #isSuperSend to not hard-code the string.

#isSelfSend was already just doing a #isSelfVariable check on the receiver,  we can do the same for #isSuperSend and use #isSuperVariable


