### PR TITLE
fix-testNoUnusedInstanceVariablesLeft

### DIFF
--- a/src/Refactoring-Core/RBInlineAllSendersRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineAllSendersRefactoring.class.st
@@ -35,8 +35,7 @@ Class {
 		'numberReplaced',
 		'numberNotReplaced',
 		'pattern',
-		'selectorString',
-		'removeMethod'
+		'selectorString'
 	],
 	#category : #'Refactoring-Core-Refactorings'
 }


### PR DESCRIPTION
due to merging a PR from before testNoUnusedInstanceVariablesLeft was improved to check for 6 unused ivars, we got

a new unused ivar in RBInlineAllSendersRefactoring

This PR just removed this unused ivar

