### PR TITLE
Fix-Compiler-bindings-self-super-thisContext

### DIFF
--- a/src/OpalCompiler-Core/OCExtraBindingScope.class.st
+++ b/src/OpalCompiler-Core/OCExtraBindingScope.class.st
@@ -36,9 +36,6 @@ OCExtraBindingScope >> bindings: anObject [
 
 { #category : #lookup }
 OCExtraBindingScope >> lookupVar: name declare: aBoolean [
-	"reserved Variables are defined by the instance scope"
-	(ReservedVariable nameIsReserved: name) ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
-	
 	^(bindings bindingOf: name asSymbol)
 		ifNotNil: [ :var | var ]
 		ifNil: [ outerScope lookupVar: name declare: aBoolean]

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -32,9 +32,6 @@ OCRequestorScope >> compilationContext: anObject [
 
 { #category : #lookup }
 OCRequestorScope >> lookupVar: name declare: aBoolean [
-
-	"reserved Variables are defined by the instance scope"
-	(ReservedVariable nameIsReserved: name) ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
 	
 	"generated temps (e.g. for limits in to:do: should not create bindings"
 	name first = $0 ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -135,6 +135,27 @@ OpalCompilerTest >> testEvaluateWithBindings [
 ]
 
 { #category : #'tests - bindings' }
+OpalCompilerTest >> testEvaluateWithBindingsSelfSuperThisContext [
+	| result |
+
+	"via #bindings: we can overwrite even self, super and thisContext"
+	result := Smalltalk compiler
+		bindings: {(#self -> 3)} asDictionary;
+		evaluate: '1+self'.
+	self assert: result equals: 4.
+	
+	result := Smalltalk compiler
+		bindings: {(#super -> 3)} asDictionary;
+		evaluate: '1+super'.
+	self assert: result equals: 4.
+	
+	result := Smalltalk compiler
+		bindings: {(#thisContext -> 3)} asDictionary;
+		evaluate: '1+thisContext'.
+	self assert: result equals: 4
+]
+
+{ #category : #'tests - bindings' }
 OpalCompilerTest >> testEvaluateWithBindingsWithUppercaseName [
 	| result |
 	result := Smalltalk compiler


### PR DESCRIPTION
When defining new variable names via #bindings, we should be able to override even 'self' 'super' and 'thisContext'.

This PR: 
- adds a test #testEvaluateWithBindingsSelfSuperThisContext
- removes the check for #nameIsReserved: from the variable lookup for OCExtraBindingScope to enable overriding
- remove it from OCRequestorScope, as the requestor will not allow defining bindings as these already exist in the parent scope