### PR TITLE
Test no period in method signature downto 2

### DIFF
--- a/src/OpalCompiler-Core/OCExtraBindingScope.class.st
+++ b/src/OpalCompiler-Core/OCExtraBindingScope.class.st
@@ -36,9 +36,6 @@ OCExtraBindingScope >> bindings: anObject [
 
 { #category : #lookup }
 OCExtraBindingScope >> lookupVar: name declare: aBoolean [
-	"reserved Variables are defined by the instance scope"
-	(ReservedVariable nameIsReserved: name) ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
-	
 	^(bindings bindingOf: name asSymbol)
 		ifNotNil: [ :var | var ]
 		ifNil: [ outerScope lookupVar: name declare: aBoolean]

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -32,9 +32,6 @@ OCRequestorScope >> compilationContext: anObject [
 
 { #category : #lookup }
 OCRequestorScope >> lookupVar: name declare: aBoolean [
-
-	"reserved Variables are defined by the instance scope"
-	(ReservedVariable nameIsReserved: name) ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
 	
 	"generated temps (e.g. for limits in to:do: should not create bindings"
 	name first = $0 ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -135,6 +135,27 @@ OpalCompilerTest >> testEvaluateWithBindings [
 ]
 
 { #category : #'tests - bindings' }
+OpalCompilerTest >> testEvaluateWithBindingsSelfSuperThisContext [
+	| result |
+
+	"via #bindings: we can overwrite even self, super and thisContext"
+	result := Smalltalk compiler
+		bindings: {(#self -> 3)} asDictionary;
+		evaluate: '1+self'.
+	self assert: result equals: 4.
+	
+	result := Smalltalk compiler
+		bindings: {(#super -> 3)} asDictionary;
+		evaluate: '1+super'.
+	self assert: result equals: 4.
+	
+	result := Smalltalk compiler
+		bindings: {(#thisContext -> 3)} asDictionary;
+		evaluate: '1+thisContext'.
+	self assert: result equals: 4
+]
+
+{ #category : #'tests - bindings' }
 OpalCompilerTest >> testEvaluateWithBindingsWithUppercaseName [
 	| result |
 	result := Smalltalk compiler

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -272,8 +272,8 @@ ReleaseTest >> testNoPeriodInMethodSignature [
 	methods := SystemNavigation new allMethods select: [ :method | 
  		method sourceCode lines first trimRight last == $..].
 	
-	"there are 11 problematic methods"
-	self assert: methods size <=11.
+	"there are 2 problematic methods in Roassal, issue tracker entry has been added"
+	self assert: methods size <=2.
 	
 	"there should be no method left"
 	"self assert: methods isEmpty description: [ 


### PR DESCRIPTION
With Iceberg merges, we have just 2 methods with periods in the first line of a method left.

To not add new cases, this PR makes sure we test for 2. The two cases are in Roassal, an issue tracker entry has been added tot he issue tracker and the next merge for sure will fix this.