### PR TITLE
Fixes the issue #9250: The context menu now opens correctly

### DIFF
--- a/src/SystemCommands-ClassCommands/SycDeprecateClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycDeprecateClassCommand.class.st
@@ -24,8 +24,9 @@ SycDeprecateClassCommand class >> browserContextMenuActivation [
 
 { #category : #testing }
 SycDeprecateClassCommand class >> canBeExecutedInContext: aToolContext [
-	^ (super canBeExecutedInContext: aToolContext) &
-		aToolContext lastSelectedClass isDeprecated not
+
+	^ (super canBeExecutedInContext: aToolContext) and: [ 
+		  aToolContext lastSelectedClass isDeprecated not ]
 ]
 
 { #category : #activation }


### PR DESCRIPTION
This fixes issue #9250.
The only change here is replacing the `&` with a `and: [...]` to avoid calling `lastSelectedClass` if no class is selected.