### PR TITLE
9256-Failing-on-CI-ProperMethodCategorizationTesttestSetUpMethodInSUnitTestsNeedsToBeInRunningProtocol

### DIFF
--- a/src/Kernel-Tests/OutOfMemoryTest.class.st
+++ b/src/Kernel-Tests/OutOfMemoryTest.class.st
@@ -7,14 +7,14 @@ Class {
 	#category : #'Kernel-Tests-Exception'
 }
 
-{ #category : #tests }
+{ #category : #running }
 OutOfMemoryTest >> setUp [ 
 
 	super setUp.
 	oldValue := Smalltalk vm maxOldSpaceSize: 2 * 1024 *1024 * 1024.
 ]
 
-{ #category : #tests }
+{ #category : #running }
 OutOfMemoryTest >> tearDown [ 
 
 	Smalltalk vm maxOldSpaceSize: oldValue.


### PR DESCRIPTION
fixes #9256 by changing the category

