### PR TITLE
9145-Cursor-is-too-small-when-using-display-scaling

### DIFF
--- a/src/Deprecated90/OSSDL2BackendWindow.extension.st
+++ b/src/Deprecated90/OSSDL2BackendWindow.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #OSSDL2BackendWindow }
+
+{ #category : #'*Deprecated90' }
+OSSDL2BackendWindow >> convertCursor: cursor withMask: mask [
+
+	self deprecated: 'Use #convertCursor:withMask:andScale:'.
+
+	^ self convertCursor: cursor withMask: mask andScale: 1
+]

--- a/src/Graphics-Display Objects/Cursor.class.st
+++ b/src/Graphics-Display Objects/Cursor.class.st
@@ -1079,6 +1079,17 @@ Cursor >> printOn: aStream [
 	self storeOn: aStream base: 2
 ]
 
+{ #category : #primitives }
+Cursor >> scaledToSize: newExtent [
+
+	"We need to override, so we can scale also the offset."
+
+	| newOne |
+	newOne := super scaledToSize: newExtent.
+	newOne offset: offset * (newExtent / self extent).
+	^ newOne
+]
+
 { #category : #displaying }
 Cursor >> show [
 	"Make the hardware's mouse cursor look like the receiver"

--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -81,14 +81,14 @@ WorldMorph class >> displayScaleFactor: aNumber [
 WorldMorph class >> displayScaleFactorSettingsOn: aBuilder [ 
 	<systemsettings>
 	
-	(aBuilder range: #displayScaleFactor)
+	(aBuilder range: #scaleFactor)
 		parent: #appearance;
 		order: 3;
 		default: 1;
 		label: 'Display scale factor';
 		description: 'Specify scale factor for UI elements. This setting does not affect defined font sizes.';
 		target: self;
-		range: (0.3 to: 8 by: 0.1)
+		range: (0.5 to: 5 by: 0.5)
 	
 ]
 
@@ -125,6 +125,18 @@ WorldMorph class >> removeExtraWorld: aWorld [
 		ExtraWorldList := self extraWorldList copyWithout: aWorld.
 	].
 	CursorOwnerWorld == aWorld ifTrue: [ CursorOwnerWorld := nil ].	
+]
+
+{ #category : #setting }
+WorldMorph class >> scaleFactor [
+	
+	^ World scaleFactor 
+]
+
+{ #category : #setting }
+WorldMorph class >> scaleFactor: aValue [
+	
+	World scaleFactor: aValue
 ]
 
 { #category : #cursor }

--- a/src/OSWindow-Core/OSBackendWindow.class.st
+++ b/src/OSWindow-Core/OSBackendWindow.class.st
@@ -175,8 +175,14 @@ OSBackendWindow >> setMouseCursor: cursorWithMask [
 	self setMouseCursor: cursorWithMask mask: cursorWithMask maskForm
 ]
 
-{ #category : #accessing }
+{ #category : #cursor }
 OSBackendWindow >> setMouseCursor: cursor mask: mask [
+
+	self setMouseCursor: cursor mask: mask andScale: 1
+]
+
+{ #category : #accessing }
+OSBackendWindow >> setMouseCursor: cursor mask: mask andScale: scale [
 ]
 
 { #category : #accessing }

--- a/src/OSWindow-Core/OSWindow.class.st
+++ b/src/OSWindow-Core/OSWindow.class.st
@@ -387,10 +387,16 @@ OSWindow >> setMouseCursor: cursorWithMask [
 
 { #category : #accessing }
 OSWindow >> setMouseCursor: cursor mask: mask [
+
+	self setMouseCursor: cursor mask: mask andScale: 1
+]
+
+{ #category : #accessing }
+OSWindow >> setMouseCursor: cursor mask: mask andScale: scale [
 	currentCursor == cursor ifTrue: [ ^ self ].
 	currentCursor := cursor.
 
-	self validHandle setMouseCursor: cursor mask: mask
+	self validHandle setMouseCursor: cursor mask: mask andScale: scale
 ]
 
 { #category : #visibility }

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -29,7 +29,7 @@ OSWorldRenderer class >> priority [
 { #category : #initialization }
 OSWorldRenderer >> activateCursor: aCursor withMask: maskForm [
 
-	osWindow ifNotNil: [ osWindow setMouseCursor: aCursor mask: maskForm ]
+	osWindow ifNotNil: [ osWindow setMouseCursor: aCursor mask: maskForm andScale: world worldState worldRenderer screenScaleFactor ]
 ]
 
 { #category : #initialization }

--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -127,13 +127,15 @@ OSSDL2BackendWindow >> convertCursor: aCursor [
 { #category : #cursor }
 OSSDL2BackendWindow >> convertCursor: cursor withMask: mask andScale: scale [
 
-	| maskBits extent cursorBits offset sdlCursor scaledCursor scaledMask |
+	| maskBits extent cursorBits offset sdlCursor scaledCursor scaledMask scaleToUse |
+
+	scaleToUse := scale ceiling.
 
 	^ self 
 		lookupSystemCursor: cursor 
 		ifNotFound: [ 
-			scaledCursor := cursor scaledToSize: (cursor extent * scale).
-			scaledMask := mask scaledToSize: (mask extent * scale).
+			scaledCursor := cursor scaledToSize: (cursor extent * scaleToUse).
+			scaledMask := mask scaledToSize: (mask extent * scaleToUse).
 
 			cursorBits := self convertCursor: scaledCursor.
 			maskBits := self convertCursor: scaledMask.

--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -83,15 +83,70 @@ OSSDL2BackendWindow >> convertButtonState: mouseState modState: modState modifie
 
 { #category : #private }
 OSSDL2BackendWindow >> convertCursor: aCursor [
-	| result bits|
+	| bits size result bytesPerLineInResult bytesPerLineInBitMap lineBitmapPosition lineResultPosition |
+
+	"This method converts the bits in a Pharo Cursor to the bitmap expected by SDL.
+	SDL expects a bitmap of 1bit depth. The cursor passed as parameter should be 1 bit depth.	
+		
+	This conversion handles cursors of any size. SDL requires that the resulting width is multiple of 8.
+	"
 	aCursor unhibernate.
+	
 	bits := aCursor bits.
-	result := ByteArray new: 32.
-	0 to: 15 do: [ :i |
-		result at: i*2 + 1 put: (bits at: i + 1) >> 24 & 255.
-		result at: i*2 + 2 put: (bits at: i + 1) >> 16 & 255.
-	].
-	^ result
+	size := aCursor extent.
+
+	"The resulting byte array has the size of the cursor (e.g., 32x32), but as each pixel is one byte 
+	we need to divide it by 8"
+	result := ByteArray new: (size x * size y) // 8.
+
+	"We are going to traverse the whole Pharo bitmap and generate the byteArray.
+	As the bitmap is organized line by line, we need to calculate how many bytes there is in a line."
+	bytesPerLineInResult := size x // 8.
+	"The amount of bytes in a line in the bitmap is not the same as the result.
+	Bitmaps contain 32-bit numbers. So each line is padded to 32 bits elements (4 bytes). 
+	If the line has 48 pixels, in the byteArray it will take 6 bytes, but in the bitmap this is round up to 8 bytes.
+	The padding is always zero and we can discard it in the transformation (as it has not image information)"
+	bytesPerLineInBitMap := bytesPerLineInResult roundUpTo: 4.
+
+	"We are going to traverse the cursor line by line.
+	As the positions in the bitmap and the byte array are not the same (the bitmap has padding, the bytearray no)
+	we need to have different starts for each line.
+	Once the offset is adjusted we can copy byte-per-byte"	
+	1 to: size y do: [ :line |
+		lineBitmapPosition := (line - 1) * bytesPerLineInBitMap.
+		lineResultPosition := (line - 1) * bytesPerLineInResult.
+		
+		1 to: bytesPerLineInResult do: [ :i |
+			result at: lineResultPosition + i put: (bits byteAt: lineBitmapPosition + i)]].
+	
+
+	^ result 
+	
+]
+
+{ #category : #cursor }
+OSSDL2BackendWindow >> convertCursor: cursor withMask: mask andScale: scale [
+
+	| maskBits extent cursorBits offset sdlCursor scaledCursor scaledMask |
+
+	^ self 
+		lookupSystemCursor: cursor 
+		ifNotFound: [ 
+			scaledCursor := cursor scaledToSize: (cursor extent * scale).
+			scaledMask := mask scaledToSize: (mask extent * scale).
+
+			cursorBits := self convertCursor: scaledCursor.
+			maskBits := self convertCursor: scaledMask.
+			extent := scaledCursor extent.
+			offset := scaledCursor offset.
+			sdlCursor := SDL2
+				             createCursor: cursorBits
+				             mask: maskBits
+				             w: extent x
+				             h: extent y
+				             hotX: offset x negated
+				             hotY: offset y negated ].
+	
 ]
 
 { #category : #'event handling' }
@@ -269,6 +324,15 @@ OSSDL2BackendWindow >> isVisible [
 	^ (self getFlags bitAnd: SDL_WINDOW_SHOWN) = SDL_WINDOW_SHOWN
 ]
 
+{ #category : #cursor }
+OSSDL2BackendWindow >> lookupSystemCursor: cursor ifNotFound: aBlock [
+	
+	^ self systemCursorConversionTable
+		  detect: [ :aMapping | (Cursor perform: aMapping key) = cursor ]
+		  ifFound: [ :aMapping | SDL2 createSystemCursor: (SDL_SystemCursorType perform: aMapping value) ]
+		  ifNone: [ aBlock value  ]
+]
+
 { #category : #'event handling' }
 OSSDL2BackendWindow >> mapSpecialCharacter: symbol [
 	^ SDL2SpecialCharacterMapping mapKeySymbol: symbol ifAbsent: [ ^ nil ]
@@ -415,13 +479,11 @@ OSSDL2BackendWindow >> setDraggableArea: aRectangle [
 ]
 
 { #category : #cursor }
-OSSDL2BackendWindow >> setMouseCursor: cursor mask: mask [
-	| cursorBits maskBits extent offset sdlCursor |
-	cursorBits := self convertCursor: cursor.
-	maskBits := self convertCursor: mask.
-	extent := cursor extent.
-	offset := cursor offset.
-	sdlCursor := SDL2 createCursor: cursorBits mask: maskBits w: extent x h: extent y hotX: offset x negated hotY: offset y negated.
+OSSDL2BackendWindow >> setMouseCursor: cursor mask: mask andScale: scale [
+
+	| sdlCursor |
+	sdlCursor := self convertCursor: cursor withMask: mask andScale: scale.
+
 	sdlCursor ifNotNil: [ sdlCursor setCursor ].
 	currentCursor ifNotNil: [ currentCursor freeCursor ].
 	currentCursor := sdlCursor
@@ -449,6 +511,12 @@ OSSDL2BackendWindow >> stopTextInput [
 	"See https://wiki.libsdl.org/SDL_StopTextInput"
 
 	sdl2Window stopTextInput
+]
+
+{ #category : #cursor }
+OSSDL2BackendWindow >> systemCursorConversionTable [
+
+	^ OSPlatform current sdlPlatform systemCursorConversionTable
 ]
 
 { #category : #accessing }

--- a/src/OSWindow-SDL2/SDL2.class.st
+++ b/src/OSWindow-SDL2/SDL2.class.st
@@ -89,6 +89,11 @@ SDL2 class >> createRGBSurfaceFromPixels: pixels width: width height: height dep
 						  Uint32 rmask , Uint32 gmask , Uint32 bmask , Uint32 amask ) )
 ]
 
+{ #category : #cursor }
+SDL2 class >> createSystemCursor: cursorId [
+	^ self ffiCall: #( SDL_Cursor SDL_CreateSystemCursor (SDL_SystemCursorType cursorId) )
+]
+
 { #category : #video }
 SDL2 class >> createWindow: title x: x y: y width: w height: h flags: flags [
 	^ self ffiCall: #( SDL_Window SDL_CreateWindow ( String title, int x, int y, int w, int h, Uint32 flags ) )

--- a/src/OSWindow-SDL2/SDLAbstractPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLAbstractPlatform.class.st
@@ -24,3 +24,9 @@ SDLAbstractPlatform >> initPlatformSpecific [
 
 	self subclassResponsibility
 ]
+
+{ #category : #initialization }
+SDLAbstractPlatform >> systemCursorConversionTable [
+
+	^ #()
+]

--- a/src/OSWindow-SDL2/SDL_SystemCursorType.class.st
+++ b/src/OSWindow-SDL2/SDL_SystemCursorType.class.st
@@ -1,0 +1,144 @@
+"
+I am the FFIEnumeration used to get the system cursors. I am defined as following C Enum
+
+```
+typedef enum {
+        SDL_SYSTEM_CURSOR_ARROW,     
+        SDL_SYSTEM_CURSOR_IBEAM,     
+        SDL_SYSTEM_CURSOR_WAIT,      
+        SDL_SYSTEM_CURSOR_CROSSHAIR, 
+        SDL_SYSTEM_CURSOR_WAITARROW, 
+        SDL_SYSTEM_CURSOR_SIZENWSE,  
+        SDL_SYSTEM_CURSOR_SIZENESW,  
+        SDL_SYSTEM_CURSOR_SIZEWE,    
+        SDL_SYSTEM_CURSOR_SIZENS,    
+        SDL_SYSTEM_CURSOR_SIZEALL,   
+        SDL_SYSTEM_CURSOR_NO,        
+        SDL_SYSTEM_CURSOR_HAND,      
+        SDL_NUM_SYSTEM_CURSORS
+} SDL_SystemCursor; 
+```
+"
+Class {
+	#name : #'SDL_SystemCursorType',
+	#superclass : #FFIEnumeration,
+	#classVars : [
+		'SDL_NUM_SYSTEM_CURSORS',
+		'SDL_SYSTEM_CURSOR_ARROW',
+		'SDL_SYSTEM_CURSOR_CROSSHAIR',
+		'SDL_SYSTEM_CURSOR_HAND',
+		'SDL_SYSTEM_CURSOR_IBEAM',
+		'SDL_SYSTEM_CURSOR_NO',
+		'SDL_SYSTEM_CURSOR_SIZEALL',
+		'SDL_SYSTEM_CURSOR_SIZENESW',
+		'SDL_SYSTEM_CURSOR_SIZENS',
+		'SDL_SYSTEM_CURSOR_SIZENWSE',
+		'SDL_SYSTEM_CURSOR_SIZEWE',
+		'SDL_SYSTEM_CURSOR_WAIT',
+		'SDL_SYSTEM_CURSOR_WAITARROW'
+	],
+	#category : #'OSWindow-SDL2-Bindings'
+}
+
+{ #category : #accessing }
+SDL_SystemCursorType class >> SDL_NUM_SYSTEM_CURSORS [
+	^ SDL_NUM_SYSTEM_CURSORS
+]
+
+{ #category : #accessing }
+SDL_SystemCursorType class >> SDL_SYSTEM_CURSOR_ARROW [
+	^ SDL_SYSTEM_CURSOR_ARROW
+]
+
+{ #category : #accessing }
+SDL_SystemCursorType class >> SDL_SYSTEM_CURSOR_CROSSHAIR [
+	^ SDL_SYSTEM_CURSOR_CROSSHAIR
+]
+
+{ #category : #accessing }
+SDL_SystemCursorType class >> SDL_SYSTEM_CURSOR_HAND [
+	^ SDL_SYSTEM_CURSOR_HAND
+]
+
+{ #category : #accessing }
+SDL_SystemCursorType class >> SDL_SYSTEM_CURSOR_IBEAM [
+	^ SDL_SYSTEM_CURSOR_IBEAM
+]
+
+{ #category : #accessing }
+SDL_SystemCursorType class >> SDL_SYSTEM_CURSOR_NO [
+	^ SDL_SYSTEM_CURSOR_NO
+]
+
+{ #category : #accessing }
+SDL_SystemCursorType class >> SDL_SYSTEM_CURSOR_SIZEALL [
+	^ SDL_SYSTEM_CURSOR_SIZEALL
+]
+
+{ #category : #accessing }
+SDL_SystemCursorType class >> SDL_SYSTEM_CURSOR_SIZENESW [
+	^ SDL_SYSTEM_CURSOR_SIZENESW
+]
+
+{ #category : #accessing }
+SDL_SystemCursorType class >> SDL_SYSTEM_CURSOR_SIZENS [
+	^ SDL_SYSTEM_CURSOR_SIZENS
+]
+
+{ #category : #accessing }
+SDL_SystemCursorType class >> SDL_SYSTEM_CURSOR_SIZENWSE [
+	^ SDL_SYSTEM_CURSOR_SIZENWSE
+]
+
+{ #category : #accessing }
+SDL_SystemCursorType class >> SDL_SYSTEM_CURSOR_SIZEWE [
+	^ SDL_SYSTEM_CURSOR_SIZEWE
+]
+
+{ #category : #accessing }
+SDL_SystemCursorType class >> SDL_SYSTEM_CURSOR_WAIT [
+	^ SDL_SYSTEM_CURSOR_WAIT
+]
+
+{ #category : #accessing }
+SDL_SystemCursorType class >> SDL_SYSTEM_CURSOR_WAITARROW [
+	^ SDL_SYSTEM_CURSOR_WAITARROW
+]
+
+{ #category : #'enum declaration' }
+SDL_SystemCursorType class >> enumDecl [ 
+
+	^ #( SDL_SYSTEM_CURSOR_ARROW 			0     
+        SDL_SYSTEM_CURSOR_IBEAM 			1     
+        SDL_SYSTEM_CURSOR_WAIT 			2     
+        SDL_SYSTEM_CURSOR_CROSSHAIR 		3 
+        SDL_SYSTEM_CURSOR_WAITARROW 		4 
+        SDL_SYSTEM_CURSOR_SIZENWSE 		5  
+        SDL_SYSTEM_CURSOR_SIZENESW 		6  
+        SDL_SYSTEM_CURSOR_SIZEWE 			7    
+        SDL_SYSTEM_CURSOR_SIZENS 			8    
+        SDL_SYSTEM_CURSOR_SIZEALL 		9   
+        SDL_SYSTEM_CURSOR_NO 				10        
+        SDL_SYSTEM_CURSOR_HAND 			11      
+        SDL_NUM_SYSTEM_CURSORS				12)
+]
+
+{ #category : #'class initialization' }
+SDL_SystemCursorType class >> initialize [
+	self initializeEnumeration.
+	
+	self classPool keysDo: [ :e |
+		self class compile: ('{1}
+	^ {1}' format: {e asString}) classified: #accessing	] 
+
+]
+
+{ #category : #printing }
+SDL_SystemCursorType >> printOn: stream [
+	super printOn: stream.
+	stream nextPut: $(;
+		 print: self item ;
+		 space;
+		 print: self value;
+		 nextPut: $)
+]


### PR DESCRIPTION
- Adding support for system cursors
- Adding support for overriding cursors of Pharo with System Cursors
- Adding support for changing the mapping per platform
- Fixing the scaling of cursors 
- Fixing the conversion to SDL cursors to handle different sizes (required for scalling)
- Using the scaling of the World in the setting

Fix #9145