### PR TITLE
9252-Adding-a-breakpoint-throws-an-exception-in-the-latest-build

### DIFF
--- a/src/SystemCommands-SourceCodeCommands/SycSourceCodeCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycSourceCodeCommand.class.st
@@ -51,11 +51,6 @@ SycSourceCodeCommand >> executeRefactoring: refactoring [
 		do: [ :e | UIManager default alert: e messageText ]
 ]
 
-{ #category : #testing }
-SycSourceCodeCommand >> isComplexRefactoring [
-	^ true
-]
-
 { #category : #accessing }
 SycSourceCodeCommand >> method [
 	^ method


### PR DESCRIPTION
#isComplexRefactoring should not return true for all... it is already overridden in two subclasses that implement refactorings.

if it returns false by default (see superclass), this fixes #9252


