### PR TITLE
add knownPaths for openbsd

### DIFF
--- a/src/UnifiedFFI/FFIUnix64LibraryFinder.class.st
+++ b/src/UnifiedFFI/FFIUnix64LibraryFinder.class.st
@@ -15,6 +15,5 @@ FFIUnix64LibraryFinder >> knownPaths [
 	'/lib64'
 	'/usr/lib64'	
 	'/usr/lib'
-	'/usr/local/lib'
-	'/usr/X11R6/lib')
+	'/usr/local/lib')
 ]

--- a/src/UnifiedFFI/FFIUnix64LibraryFinder.class.st
+++ b/src/UnifiedFFI/FFIUnix64LibraryFinder.class.st
@@ -14,5 +14,7 @@ FFIUnix64LibraryFinder >> knownPaths [
 	'/lib/x86_64-linux-gnu'
 	'/lib64'
 	'/usr/lib64'	
-	'/usr/lib')
+	'/usr/lib'
+	'/usr/local/lib'
+	'/usr/X11R6/lib')
 ]


### PR DESCRIPTION
OpenBSD ports installs things into `/usr/local`, also X11 libraries live in `/usr/X11R6/lib`, not 100% sure if X11 stuff is needed.