### PR TITLE
upgrading Pharo 9 with Roassal 0.9.8

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -209,7 +209,7 @@ BaselineOfIDE >> baseline: spec [
 		spec 
   			baseline: 'Roassal3' 
   			with: [ spec 
-				repository: 'github://ObjectProfile/Roassal3:v0.9.7b/src';
+				repository: 'github://ObjectProfile/Roassal3:v0.9.8/src';
     				loads: #( 'Core' 'Tests') ].
 
 		spec 


### PR DESCRIPTION
Moving from v0.9.7b to v0.9.8

for issue: https://github.com/pharo-project/pharo/issues/9270