### PR TITLE
Rewrote and improved String >> skipAnySubstring:startingAt:

### DIFF
--- a/src/Collections-Abstract-Tests/TAsStringCommaAndDelimiterTest.trait.st
+++ b/src/Collections-Abstract-Tests/TAsStringCommaAndDelimiterTest.trait.st
@@ -95,18 +95,17 @@ TAsStringCommaAndDelimiterTest >> testAsStringOnDelimiterLastEmpty [
 { #category : #'tests - as string comma delimiter sequenceable' }
 TAsStringCommaAndDelimiterTest >> testAsStringOnDelimiterLastMore [
 
-	| delim multiItemStream result last allElementsAsString tmp |
+	| delim multiItemStream result last allElementsAsString |
 	
 	delim := ', '.
 	last := ' and '.
 	result:=''.
-	tmp := self nonEmpty collect: [:each | each asString].
 	multiItemStream := ReadWriteStream on:result.
-	self nonEmpty  asStringOn: multiItemStream delimiter: delim last: last.
+	self nonEmpty asStringOn: multiItemStream delimiter: delim last: last.
 	result := multiItemStream contents.
 	allElementsAsString:=(result findBetweenSubstrings: delim ).
-	tmp do:[:each |
-		self assert: (tmp occurrencesOf: each) = (allElementsAsString occurrencesOf: each)].
+	self nonEmpty do:[:each |
+		self assert: (self nonEmpty occurrencesOf: each) = (allElementsAsString occurrencesOf: each asString)].
 	self assert: ((allElementsAsString at: (allElementsAsString size - 1))=('and'))
 ]
 
@@ -131,19 +130,17 @@ TAsStringCommaAndDelimiterTest >> testAsStringOnDelimiterLastOne [
 { #category : #'tests - as string comma delimiter sequenceable' }
 TAsStringCommaAndDelimiterTest >> testAsStringOnDelimiterMore [
 
-	| delim multiItemStream result allElementsAsString tmp |
-	
-	
+	| delim multiItemStream result allElementsAsString |
+		
 	delim := ', '.
-	result:=''.
-	tmp:= self nonEmpty collect:[:each | each asString].
+	result:= ''.
 	multiItemStream := ReadWriteStream on:result.
-	self nonEmpty  asStringOn: multiItemStream delimiter: delim.
+	self nonEmpty asStringOn: multiItemStream delimiter: delim.
 	result := multiItemStream contents.
 	allElementsAsString := (result findBetweenSubstrings: delim ).
-	tmp do:
+	self nonEmpty do:
 		[:each |
-		self assert: (tmp occurrencesOf: each)=(allElementsAsString occurrencesOf: each).
+		self assert: (self nonEmpty occurrencesOf: each)=(allElementsAsString occurrencesOf: each asString).
 		].
 ]
 

--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -1780,6 +1780,34 @@ StringTest >> testRomanNumber [
 	self assert: '-MDCCCXCV' romanNumber equals: -1895.
 ]
 
+{ #category : #test }
+StringTest >> testSkipAnySubstringStartingAt [
+	
+	"Simple skip"
+	self assert: ('abcd' skipAnySubstring: #('a') startingAt: 1) equals: 2. 
+	"Test multiple substrings to skip"
+	self assert: ('abcd' skipAnySubstring: #('a' 'b' 'd') startingAt: 1) equals: 3.
+	"Test skip symbol"
+	self assert: ('abcd' skipAnySubstring: #(ab) startingAt: 1) equals: 3.
+	"Test string is full of substrings to skip"
+	self assert: ('abcd' skipAnySubstring: #('ab' 'cd') startingAt: 1) equals: 5. 
+	"Test first substring matches but second substring is larger than entire string"
+	self assert: ('abcd' skipAnySubstring: #('ab' 'abcdefg') startingAt: 1) equals: 3.
+	"Test first substring is larger than entire string, and second substring matches string"
+	self assert: ('abcd' skipAnySubstring: #('abcdefg' 'ab') startingAt: 1) equals: 3.
+	"Test string is empty, return length of string + 1"
+	self assert: ('' skipAnySubstring: #('ab') startingAt: 1) equals: 1.
+	"Test starting at index > 1"
+	self assert: ('abcde' skipAnySubstring: #('cd') startingAt: 3) equals: 5.
+	"Test substring appears multiple times in a row"
+	self assert: ('ababc' skipAnySubstring: #('ab') startingAt: 1) equals: 5.
+	"Test substring to skip is given directly as a string instead of in an array"
+	self assert: (',ab' skipAnySubstring: ',' startingAt: 1) equals: 2.
+	"Test how delimiters order can influence the result: substrings are skipped greedily with no backtracking."
+	self assert: ('abcdefg' skipAnySubstring: #('abcd' 'abc' 'def' 'g') startingAt: 1) equals: 5.
+	self assert: ('abcdefg' skipAnySubstring: #('abc' 'def' 'g' 'abcd') startingAt: 1) equals: 8.
+]
+
 { #category : #'tests - instance creation' }
 StringTest >> testSpace [
 		

--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -1260,24 +1260,6 @@ StringTest >> testFormatFailures [
 
 ]
 
-{ #category : #test }
-StringTest >> testHasSubstringAt [
-
-	"Test empty strings"
-	self assert: ('' hasSubstring: '' at: 1).
-	self assert: ('test' hasSubstring: '' at: 1).
-	self deny: ('' hasSubstring: 'test' at: 1).
-	"Test out of bounds indexes"
-	self deny: ('test' hasSubstring: 't' at: 0).
-	self deny: ('test' hasSubstring: 't' at: 10).
-	"Test matching substring"
-	self assert: ('test' hasSubstring: 'st' at: 3).
-	"Test partially matching substring"
-	self deny: ('test' hasSubstring: 'sty' at: 3).
-	
-	
-]
-
 { #category : #tests }
 StringTest >> testHasWideCharacterFromTo [
 
@@ -1300,10 +1282,29 @@ StringTest >> testIncludesSubstring [
 
 	self assert: ('testing this string' includesSubstring: 'ring'). 
 	self assert: ('éèàôüößäóñíá' includesSubstring: '').
+	self assert: ('' includesSubstring: '').
 	self deny: ('éèàôüößäóñíá' includesSubstring: 'a'). 
 	self assert: ('éèàôüößäóñíá' includesSubstring: 'ßä').
 	self deny: ('kjdsnlksjdf' includesSubstring: 'K') 
 
+]
+
+{ #category : #test }
+StringTest >> testIncludesSubstringAt [
+
+	"Test empty strings"
+	self assert: ('' includesSubstring: '' at: 1).
+	self assert: ('test' includesSubstring: '' at: 1).
+	self deny: ('' includesSubstring: 'test' at: 1).
+	"Test out of bounds indexes"
+	self deny: ('test' includesSubstring: 't' at: 0).
+	self deny: ('test' includesSubstring: 't' at: 10).
+	"Test matching substring"
+	self assert: ('test' includesSubstring: 'st' at: 3).
+	"Test partially matching substring"
+	self deny: ('test' includesSubstring: 'sty' at: 3).
+	
+	
 ]
 
 { #category : #tests }
@@ -1819,9 +1820,9 @@ StringTest >> testSkipAnySubstringStartingAt [
 	self assert: ('abcde' skipAnySubstring: #('cd') startingAt: 3) equals: 5.
 	"Test substring appears multiple times in a row"
 	self assert: ('ababc' skipAnySubstring: #('ab') startingAt: 1) equals: 5.
-	"Test substring to skip is given directly as a string instead of in an array"
-	self assert: (',ab' skipAnySubstring: ',' startingAt: 1) equals: 2.
-	"Test how delimiters order can influence the result: substrings are skipped greedily with no backtracking."
+	"Test if delimiters is a string it is treated as a collection of characters"
+	self assert: (', ab' skipAnySubstring: ' ,' startingAt: 1) equals: 3.
+	"Test how delimiters order matters: substrings are skipped greedily with no backtracking"
 	self assert: ('abcdefg' skipAnySubstring: #('abcd' 'abc' 'def' 'g') startingAt: 1) equals: 5.
 	self assert: ('abcdefg' skipAnySubstring: #('abc' 'def' 'g' 'abcd') startingAt: 1) equals: 8.
 ]

--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -1260,6 +1260,24 @@ StringTest >> testFormatFailures [
 
 ]
 
+{ #category : #test }
+StringTest >> testHasSubstringAt [
+
+	"Test empty strings"
+	self assert: ('' hasSubstring: '' at: 1).
+	self assert: ('test' hasSubstring: '' at: 1).
+	self deny: ('' hasSubstring: 'test' at: 1).
+	"Test out of bounds indexes"
+	self deny: ('test' hasSubstring: 't' at: 0).
+	self deny: ('test' hasSubstring: 't' at: 10).
+	"Test matching substring"
+	self assert: ('test' hasSubstring: 'st' at: 3).
+	"Test partially matching substring"
+	self deny: ('test' hasSubstring: 'sty' at: 3).
+	
+	
+]
+
 { #category : #tests }
 StringTest >> testHasWideCharacterFromTo [
 

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2131,30 +2131,6 @@ String >> occursInWithEmpty: prefix caseSensitive: aBoolean [
 		matchTable: matchTable) > 0
 ]
 
-{ #category : #accessing }
-String >> oldSkipAnySubstring: delimiters startingAt: start [ 
-	"Answer the index of the last character within the receiver, starting at start, that does NOT match one of the delimiters. delimiters is a Array of substrings (Characters also allowed).  If the receiver is all delimiters, answer size + 1."
-
-	| any this ind ii |
-	ii := start-1.
-	[(ii := ii + 1) <= self size] whileTrue: [ "look for char that does not match"
-		any := false.
-		delimiters do: [:delim |
-			delim isCharacter 
-				ifTrue: [(self at: ii) == delim ifTrue: [any := true]]
-				ifFalse: ["a substring"
-					delim size > (self size - ii + 1) ifFalse: "Here's where the one-off error was."
-						[ind := 0.
-						this := true.
-						delim do: [:dd | 
-							dd == (self at: ii+ind) ifFalse: [this := false].
-							ind := ind + 1].
-						this ifTrue: [ii := ii + delim size - 1.  any := true]]
-							ifTrue: [any := false] "if the delim is too big, it can't match"]].
-		any ifFalse: [^ ii]].
-	^ self size + 1
-]
-
 { #category : #converting }
 String >> onlyLetters [
 	"answer the receiver with only letters"

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1595,6 +1595,20 @@ String >> format: collection [
 								ifFalse: [ result nextPut: currentChar ] ] ] ]
 ]
 
+{ #category : #'finding/searching' }
+String >> hasSubstring: str at: index [
+
+	"Answer true if the receiver contains the substring str exactly at index, false otherwise."
+
+	| pos |
+	pos := index - 1.
+
+	^ str size <= (self size - pos) and:
+		[ str allSatisfy: [ :char | 
+		  pos := pos + 1.
+		  (self at: pos) = char ] ]
+]
+
 { #category : #testing }
 String >> hasWideCharacterFrom: start to: stop [
 	"Return true if one of my character in the range does not fit in a single byte"
@@ -2114,6 +2128,30 @@ String >> occursInWithEmpty: prefix caseSensitive: aBoolean [
 		matchTable: matchTable) > 0
 ]
 
+{ #category : #accessing }
+String >> oldSkipAnySubstring: delimiters startingAt: start [ 
+	"Answer the index of the last character within the receiver, starting at start, that does NOT match one of the delimiters. delimiters is a Array of substrings (Characters also allowed).  If the receiver is all delimiters, answer size + 1."
+
+	| any this ind ii |
+	ii := start-1.
+	[(ii := ii + 1) <= self size] whileTrue: [ "look for char that does not match"
+		any := false.
+		delimiters do: [:delim |
+			delim isCharacter 
+				ifTrue: [(self at: ii) == delim ifTrue: [any := true]]
+				ifFalse: ["a substring"
+					delim size > (self size - ii + 1) ifFalse: "Here's where the one-off error was."
+						[ind := 0.
+						this := true.
+						delim do: [:dd | 
+							dd == (self at: ii+ind) ifFalse: [this := false].
+							ind := ind + 1].
+						this ifTrue: [ii := ii + delim size - 1.  any := true]]
+							ifTrue: [any := false] "if the delim is too big, it can't match"]].
+		any ifFalse: [^ ii]].
+	^ self size + 1
+]
+
 { #category : #converting }
 String >> onlyLetters [
 	"answer the receiver with only letters"
@@ -2200,26 +2238,21 @@ String >> sameAs: aString [
 ]
 
 { #category : #accessing }
-String >> skipAnySubstring: delimiters startingAt: start [ 
-	"Answer the index of the last character within the receiver, starting at start, that does NOT match one of the delimiters. delimiters is a Array of substrings (Characters also allowed).  If the receiver is all delimiters, answer size + 1."
+String >> skipAnySubstring: delimiters startingAt: start [
 
-	| any this ind ii |
-	ii := start-1.
-	[(ii := ii + 1) <= self size] whileTrue: [ "look for char that does not match"
-		any := false.
-		delimiters do: [:delim |
-			delim isCharacter 
-				ifTrue: [(self at: ii) == delim ifTrue: [any := true]]
-				ifFalse: ["a substring"
-					delim size > (self size - ii + 1) ifFalse: "Here's where the one-off error was."
-						[ind := 0.
-						this := true.
-						delim do: [:dd | 
-							dd == (self at: ii+ind) ifFalse: [this := false].
-							ind := ind + 1].
-						this ifTrue: [ii := ii + delim size - 1.  any := true]]
-							ifTrue: [any := false] "if the delim is too big, it can't match"]].
-		any ifFalse: [^ ii]].
+	"Answer the index of the last character within the receiver, starting at start, that does NOT match one of the delimiters. delimiters is a Array of substrings (Characters also allowed); their ordering sets priority and can influence the result. If the receiver is all delimiters, answer size + 1."
+
+	| pos delimArray |
+	pos := start.
+	delimArray := delimiters asArray.
+	[ pos <= self size ] whileTrue: [ 
+		pos := delimArray
+			      detect: [ :delim | 
+				      delim isCharacter
+					      ifTrue: [ (self at: pos) = delim ]
+					      ifFalse: [ self hasSubstring: delim at: pos ] ]
+			      ifFound: [ :match | pos + match asString size ]
+			      ifNone: [ ^ pos ] ].
 	^ self size + 1
 ]
 

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1595,22 +1595,6 @@ String >> format: collection [
 								ifFalse: [ result nextPut: currentChar ] ] ] ]
 ]
 
-{ #category : #'finding/searching' }
-String >> hasSubstring: str at: index [
-
-	"Answer true if the receiver contains the substring str exactly at index, false otherwise."
-
-	| pos |
-	
-	(index < 1) ifTrue: [ ^ false ].
-	pos := index - 1.
-	
-	^ str size <= (self size - pos) and:
-		[ str noneSatisfy: [ :char |  
-		  pos := pos + 1.
-		  (self at: pos) ~= char ] ]
-]
-
 { #category : #testing }
 String >> hasWideCharacterFrom: start to: stop [
 	"Return true if one of my character in the range does not fit in a single byte"
@@ -1653,6 +1637,23 @@ String >> includesSubstring: substring [
 	"('abcdefgh' includesSubstring: 'de') >>> true"
 	
 	^ substring isEmpty or: [ (self findString: substring startingAt: 1) > 0 ]
+]
+
+{ #category : #'finding/searching' }
+String >> includesSubstring: substring at: index [
+
+	"Answer true if the receiver contains the substring str exactly at index, false otherwise."
+
+	"('abcdefgh' includesSubstring: 'de' at: 1) >>> false"
+	"('abcdefgh' includesSubstring: 'de' at: 4) >>> true"
+
+	| pos |
+	pos := index - 1.
+
+	^ index > 0 & (self size - pos >= substring size) and: [ 
+		  substring allSatisfy: [ :char | 
+			  pos := pos + 1.
+			  (self at: pos) = char ] ]
 ]
 
 { #category : #testing }
@@ -2242,29 +2243,32 @@ String >> sameAs: aString [
 { #category : #accessing }
 String >> skipAnySubstring: delimiters startingAt: start [
 
-	"Answer the index of the last character within the receiver, starting at start, that does NOT match one of the delimiters. delimiters is a Array of substrings (Characters also allowed); their ordering sets priority and can influence the result. If the receiver is all delimiters, answer size + 1."
+	"Skip any of the delimiters found in receiver, from start onwards, until no delimiter substring matches; answer the position reached. delimiters is an array of strings (characters are accepted, but skipDelimiters:startingAt: handles them better). A string coming earlier in the array is skipped with higher priority. If the end of the receiver is reached, answer size + 1."
 
-	| pos delimArray |
+	| pos |
+	delimiters isString ifTrue: [ 
+		^ self skipDelimiters: delimiters startingAt: start ].
+
 	pos := start.
-	delimArray := delimiters asArray.
 	[ pos <= self size ] whileTrue: [ 
-		pos := delimArray
-			      detect: [ :delim | 
-				      delim isCharacter
-					      ifTrue: [ (self at: pos) = delim ]
-					      ifFalse: [ self hasSubstring: delim at: pos ] ]
-			      ifFound: [ :match | pos + match asString size ]
-			      ifNone: [ ^ pos ] ].
+		pos := delimiters
+			       detect: [ :delim | 
+				       delim isCharacter
+					       ifTrue: [ (self at: pos) = delim ]
+					       ifFalse: [ self includesSubstring: delim at: pos ] ]
+			       ifFound: [ :match | pos + match asString size ]
+			       ifNone: [ ^ pos ] ].
 	^ self size + 1
 ]
 
 { #category : #accessing }
-String >> skipDelimiters: delimiters startingAt: start [ 
-	"Answer the index of the character within the receiver, starting at start, that does NOT match one of the delimiters. If the receiver does not contain any of the delimiters, answer size + 1.  Assumes the delimiters to be a non-empty string."
+String >> skipDelimiters: delimiters startingAt: start [
 
-	start to: self size do: [:i |
-		delimiters detect: [:delim | delim = (self at: i)]
-				ifNone: [^ i]].
+	"Answer the index of the first character within the receiver, starting at start, that does NOT match any element of delimiters (a collection of characters). If the end of the receiver is reached, answer size + 1."
+
+	start to: self size do: [ :i | 
+		(delimiters anySatisfy: [ :delim | delim = (self at: i) ]) 
+			ifFalse: [ ^ i ] ].
 	^ self size + 1
 ]
 

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1601,12 +1601,14 @@ String >> hasSubstring: str at: index [
 	"Answer true if the receiver contains the substring str exactly at index, false otherwise."
 
 	| pos |
+	
+	(index < 1) ifTrue: [ ^ false ].
 	pos := index - 1.
-
+	
 	^ str size <= (self size - pos) and:
-		[ str allSatisfy: [ :char | 
+		[ str noneSatisfy: [ :char |  
 		  pos := pos + 1.
-		  (self at: pos) = char ] ]
+		  (self at: pos) ~= char ] ]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
- Moved part of the code to new separate method String >> hasSubstring:At:
- Added tests 
- Temporarily renamed original method to String >> oldSkipAnySubstring:startingAt:

This should fix issue #6191. 

I tried my hand at this after studying @dupriezt previous pull request #6230 and the discussion. Most of the new tests come from there.

I used detect:ifFound:ifNone: and allSatisfy: for a tighter control of the loops. One difference compared to the orginal method is that every time a delimiter is found, the iteration of the delimiters array restarts from the first element instead of continuing to the end.

I mentioned in the documentation that the order of the delimiters array can have an effect on the result. I don't think it could be otherwise.

I noticed an increase in performance for more complex/longer input, and worse but still comparable performance in other cases, but I haven't really profiled this for the time being.