### PR TITLE
9299-Method-classification-in-the-list-of-implementors-causes-DNU

### DIFF
--- a/src/Calypso-Browser/ClyBrowserContext.class.st
+++ b/src/Calypso-Browser/ClyBrowserContext.class.st
@@ -174,6 +174,12 @@ ClyBrowserContext >> selectedObjects [
 	^self actualSelectionFrom: selectedItems
 ]
 
+{ #category : #'tool controlling' }
+ClyBrowserContext >> showMethodTag: aString [
+	"Default is to do nothing"
+	
+]
+
 { #category : #accessing }
 ClyBrowserContext >> system [
 	^tool system


### PR DESCRIPTION
Method classification in the list of implementors causes DNU

To Reproduce
Steps to reproduce the behavior:

display implementors of yourself
from the context menu for the first (and only) method perform classsify methods
select new protocol, e.g. access
DNU: Instance of ClyQueryBrowserContext did not understand #showMethodTag:
Richard's solution would be to provide an empty implementation of #showMethodTag: in the common superclass ClyBrowserContext.


fixes #9299


