### PR TITLE
[Enhancement] Smoother drag and drop in calypso

### DIFF
--- a/src/Calypso-Browser/ClyDataSource.class.st
+++ b/src/Calypso-Browser/ClyDataSource.class.st
@@ -530,6 +530,7 @@ ClyDataSource >> wantsDropElements: aPassanger type: type index: rowIndex [
 	self dragTransferType == type ifFalse: [ ^false ].
 	dropTargetItem := self elementAt: rowIndex.		
 	result := queryView wantsDropPassenger: aPassanger at: dropTargetItem.
+	queryView expandForDrag: dropTargetItem.
 	
 	result & dropTargetItem hasChildren ifTrue: [ dropTargetItem expand ].
 	

--- a/src/Calypso-Browser/ClyQueryViewMorph.class.st
+++ b/src/Calypso-Browser/ClyQueryViewMorph.class.st
@@ -115,7 +115,7 @@ Class {
 		'changesWasInitiatedByUser',
 		'navigationSelector',
 		'dataSourceClass',
-		'expandedItem'
+		'expandedItemByDrag'
 	],
 	#category : #'Calypso-Browser-Table'
 }
@@ -361,12 +361,12 @@ ClyQueryViewMorph >> ensureVisibleSelection [
 
 { #category : #drag }
 ClyQueryViewMorph >> expandForDrag: dropTargetItem [
-	(expandedItem isNotNil 
-		and: [ expandedItem ~= dropTargetItem
-		and: [ expandedItem hasChildren 
-		and: [ expandedItem isExpanded ]]])
-			ifTrue: [ expandedItem collapse ].
-	^ expandedItem := dropTargetItem hasChildren 
+	(expandedItemByDrag isNotNil 
+		and: [ expandedItemByDrag ~= dropTargetItem
+		and: [ expandedItemByDrag hasChildren 
+		and: [ expandedItemByDrag isExpanded ]]])
+			ifTrue: [ expandedItemByDrag collapse ].
+	^ expandedItemByDrag := dropTargetItem hasChildren 
 		ifFalse: [ nil ]
 		ifTrue: [
 			dropTargetItem expand.

--- a/src/Calypso-Browser/ClyQueryViewMorph.class.st
+++ b/src/Calypso-Browser/ClyQueryViewMorph.class.st
@@ -114,7 +114,8 @@ Class {
 		'highlighting',
 		'changesWasInitiatedByUser',
 		'navigationSelector',
-		'dataSourceClass'
+		'dataSourceClass',
+		'expandedItem'
 	],
 	#category : #'Calypso-Browser-Table'
 }
@@ -356,6 +357,21 @@ ClyQueryViewMorph >> ensureVisibleSelection [
 	where browser is just opened and automatic item visibility 
 	can be wrongly computed"
 	UIManager default defer: [self selection ensureVisibleLastItem]
+]
+
+{ #category : #drag }
+ClyQueryViewMorph >> expandForDrag: dropTargetItem [
+	(expandedItem isNotNil 
+		and: [ expandedItem ~= dropTargetItem
+		and: [ expandedItem hasChildren 
+		and: [ expandedItem isExpanded ]]])
+			ifTrue: [ expandedItem collapse ].
+	^ expandedItem := dropTargetItem hasChildren 
+		ifFalse: [ nil ]
+		ifTrue: [
+			dropTargetItem expand.
+			dropTargetItem.
+			]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
I know we're in a freeze, but this might still be relevant for p10.

When drag and dropping something in a package, the current behavior is to open the package and display the tags for that package.
However, it never closes it.
Drag n dropping a class in a package can be quite tedious to do.
If we do not hover directly on the right package, tags opened for other packages.
The opened tags are preventing access to the package that we want.

With this small fix, it collapses whichever package was opened, allowing for significantly smoother drag and drop operations.

However, I do not know how to test this without passing the rest of the day doing it..
Suggestions welcome :)

Pierre