### PR TITLE
fixes #9244: NullWorldRenderer did not understand #convertWindowMouseEventPosition

### DIFF
--- a/src/Morphic-Core/AbstractWorldRenderer.class.st
+++ b/src/Morphic-Core/AbstractWorldRenderer.class.st
@@ -165,6 +165,12 @@ AbstractWorldRenderer >> actualScreenSize [
 	self subclassResponsibility 
 ]
 
+{ #category : #initialization }
+AbstractWorldRenderer >> convertWindowMouseEventPosition: aPosition [
+
+	self subclassResponsibility
+]
+
 { #category : #activation }
 AbstractWorldRenderer >> deactivate [
 

--- a/src/Morphic-Core/NullWorldRenderer.class.st
+++ b/src/Morphic-Core/NullWorldRenderer.class.st
@@ -44,6 +44,12 @@ NullWorldRenderer >> checkForNewScreenSize [
 
 ]
 
+{ #category : #initialization }
+NullWorldRenderer >> convertWindowMouseEventPosition: aPosition [
+
+	^ aPosition
+]
+
 { #category : #activation }
 NullWorldRenderer >> deactivate [
 ]

--- a/src/Morphic-Tests/NullWorldRendererTest.class.st
+++ b/src/Morphic-Tests/NullWorldRendererTest.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : #NullWorldRendererTest,
+	#superclass : #TestCase,
+	#category : #'Morphic-Tests'
+}
+
+{ #category : #tests }
+NullWorldRendererTest >> testConvertWindowMouseEventPosition [
+	| renderer |
+	
+
+	renderer := NullWorldRenderer new.
+	self 
+		assert: (renderer convertWindowMouseEventPosition: 0@0)
+		equals: 0@0
+]

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -64,6 +64,7 @@ OSWorldRenderer >> clipboardText: aString [
 
 { #category : #initialization }
 OSWorldRenderer >> convertWindowMouseEventPosition: aPosition [
+
 	^ (aPosition / self screenScaleFactor) rounded
 ]
 


### PR DESCRIPTION
add a dummy convertWindowMouseEventPosition: