### PR TITLE
testNoUnusedInstanceVariablesLeft-set-to-zero

### DIFF
--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -37,13 +37,10 @@ NoUnusedVariablesLeftTest >> testNoUnusedInstanceVariablesLeft [
 	
 	classes := variables collect: [ :each | each definingClass ] as: Set.
 	
-	validExceptions := { RBFooLintRuleTestData . RBLintRuleTestData .RBFooDummyLintRuleTest . RBDummyLintRuleTest}.	
+	validExceptions := { RBFooLintRuleTestData . RBLintRuleTestData .RBFooDummyLintRuleTest . RBDummyLintRuleTest. MockWithComplexSlot}.	
 	
 	remaining := classes asOrderedCollection removeAll: validExceptions; yourself.
-	
-	"we have 6 left, there are issue tracker entries for those.
- 	By testing for these, we avoid that new cases are added"
- 	self assert: remaining size <= 6
+	self assert: remaining isEmpty description: ('the following classes have unused instance variables and should be cleaned: ', remaining asString)
 ]
 
 { #category : #testing }


### PR DESCRIPTION
We can now check for isEmpty in testNoUnusedInstanceVariablesLeft, MockWithComplexSlot is for now in valid exceptions.


