### PR TITLE
Typo: method category "visting" should be "visiting"

### DIFF
--- a/src/Deprecated90/RBInstanceVariableNode.class.st
+++ b/src/Deprecated90/RBInstanceVariableNode.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'Deprecated90-AST'
 }
 
-{ #category : #visting }
+{ #category : #visiting }
 RBInstanceVariableNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitInstanceVariableNode: self
 ]


### PR DESCRIPTION
Fix #9367 for RBInstanceVariableNode

Note: IceMergeToChangeTreeVisitor need to be fixed in Iceberg repo, not Pharo repo