### PR TITLE
9107-Syntax-highlighter-does-not-refresh-when-a-method-is-saved

### DIFF
--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -12,21 +12,21 @@ OCUndeclaredVariableWarning >> declareClassVar [
 
 	self methodClass instanceSide
 		addClassVarNamed: node name asSymbol.
-	^ self lookUpVariable
+	(ReparseAfterSourceEditing new newSource: self requestor text) signal
 ]
 
 { #category : #correcting }
 OCUndeclaredVariableWarning >> declareGlobal [
 
 	Smalltalk at: node name asSymbol put: nil.
-	^self lookUpVariable
+	(ReparseAfterSourceEditing new newSource: self requestor text) signal
 ]
 
 { #category : #correcting }
 OCUndeclaredVariableWarning >> declareInstVar: name [
 	"Declare an instance variable."
 	self methodClass addInstVarNamed: name.
-	^ self lookUpVariable
+	(ReparseAfterSourceEditing new newSource: self requestor text) signal
 ]
 
 { #category : #correcting }
@@ -135,12 +135,6 @@ OCUndeclaredVariableWarning >> defineTrait: traitName [
 		evaluate.
 	^ (node owningScope lookupVar: traitSymbol)
 		ifNil: [self error: 'should be not happen']
-]
-
-{ #category : #correcting }
-OCUndeclaredVariableWarning >> lookUpVariable [
-	^ (node owningScope lookupVar: node name)
-		ifNil: [self error: 'should be found']
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -367,14 +367,8 @@ OpalCompiler >> compileDoit [
 { #category : #'public access' }
 OpalCompiler >> compileMethod [
 	| cm |
-	[	self parse.
-			self callPlugins.  
-		] 	on: ReparseAfterSourceEditing 
-			do: 
-			[  	:notification | 
-				self source: notification newSource. 
-				notification retry. 
-			]. 
+	self parse.
+	self callPlugins.  
 		cm := compilationContext optionEmbeddSources
 			ifTrue: [ ast generateWithSource ]
 			ifFalse: [ast generate: self compilationContext compiledMethodTrailer   ].
@@ -530,11 +524,17 @@ OpalCompiler >> options: anOptionsArray [
 
 { #category : #'public access' }
 OpalCompiler >> parse [
-	ast := self compilationContext noPattern 
+	[ast := self compilationContext noPattern 
 		ifTrue: [ self parseExpression ]
 		ifFalse: [ self parseMethod ].
 	ast methodNode compilationContext: self compilationContext.
-	self doSemanticAnalysis.
+	self doSemanticAnalysis]
+	on: ReparseAfterSourceEditing 
+			do: 
+			[  	:notification | 
+				self source: notification newSource. 
+				notification retry.  
+			]. 
 	^ast
 ]
 


### PR DESCRIPTION
This PR fixes #9107. We need to do some changes as the browser now keeps the AST in some cases where it used to re-parse.

- move the ReparseAfterSourceEditing handler from #compiledMethod to #parse
- make sure to raise ReparseAfterSourceEditing not only for the case we add a temp but for global, class, and Ivars, too
- remove the now unused (private) method  #lookUpVariable

Doing this change it got clear that we should re-evaluate if it would not be better to remove the whole #ReparseAfterSourceEditing concept.

But that will have to wait for Pharo10 as it would be a large change.


