### PR TITLE
Fixes #8668: Scaled Decimal multiplication loses precision

### DIFF
--- a/src/Kernel-Tests/ScaledDecimalTest.class.st
+++ b/src/Kernel-Tests/ScaledDecimalTest.class.st
@@ -281,11 +281,13 @@ ScaledDecimalTest >> testRounded [
 
 { #category : #tests }
 ScaledDecimalTest >> testScaleExtension [
-	"The scale is extended to the larger one in case of arithmetic operation"
-	
-	#( #* #+ #- #/) do: [:op |
+
+	#( #+ #- #/ ) do: [ :op | "The scale is extended to the larger one in case of arithmetic operation"
 		self assert: (2.5s1 perform: op with: 1.000s3) scale equals: 3.
-		self assert: (3.5000s4 perform: op with: 1.0s1) scale equals: 4.]
+		self assert: (3.5000s4 perform: op with: 1.0s1) scale equals: 4 ].
+	"The scale for multiplication is the sum of the operand scales"
+	self assert: (2.5s1 * 1.000s3) scale equals: 4.
+	self assert: (3.5000s4 * 1.0s1) scale equals: 5
 ]
 
 { #category : #tests }

--- a/src/Kernel/ScaledDecimal.class.st
+++ b/src/Kernel/ScaledDecimal.class.st
@@ -25,8 +25,11 @@ ScaledDecimal class >> newFromNumber: aNumber scale: anInteger [
 
 { #category : #arithmetic }
 ScaledDecimal >> * aNumber [
-	aNumber class = self class ifTrue: [^self asFraction * aNumber asFraction asScaledDecimal: (scale max: aNumber scale)].
-	^self coerce: self asFraction * aNumber
+
+	aNumber class = self class ifTrue: [ 
+		^ self asFraction * aNumber asFraction asScaledDecimal:
+			  scale + aNumber scale ].
+	^ self coerce: self asFraction * aNumber
 ]
 
 { #category : #arithmetic }


### PR DESCRIPTION
For multiplication of 2 scaled decimals we answer a scaled decimal with a scale equal to the sum of the operand scales