### PR TITLE
Modify UnixResolver>>xdgParseUserDirLine: to handle the home directory

### DIFF
--- a/src/FileSystem-Core/UnixResolver.class.st
+++ b/src/FileSystem-Core/UnixResolver.class.st
@@ -66,7 +66,7 @@ UnixResolver >> xdgParseUserDirLine: aStream [
 	(#($$ $/) includes: firstChar) ifFalse: [ ^ nil ].
 	path := firstChar = $$
 				ifTrue: [ (aStream next: 5) = 'HOME/' ifFalse: [ ^ nil ].
-					       self home / (aStream upTo: $") ]
+					       self home / ((aStream upTo: $") ifEmpty: [ '.' ]) ]
 				ifFalse: [ self resolveString: '/', (aStream upTo: $") ].
 	^ path
 ]

--- a/src/FileSystem-Tests-Core/UnixResolverTest.class.st
+++ b/src/FileSystem-Tests-Core/UnixResolverTest.class.st
@@ -1,0 +1,37 @@
+"
+SUnit tests for PlatformResolver
+"
+Class {
+	#name : #UnixResolverTest,
+	#superclass : #FileSystemResolverTest,
+	#category : #'FileSystem-Tests-Core-Resolver'
+}
+
+{ #category : #running }
+UnixResolverTest >> createResolver [
+
+	^ UnixResolver new
+]
+
+{ #category : #tests }
+UnixResolverTest >> testXdgParseUserDirLineDocuments [
+	"Ensure that a path of the form '$HOME/Documents' answers the expected value.
+	Note that this test can be run on any platform."
+	| stream path relativePath |
+
+	stream := '"$HOME/Documents"' readStream.
+	path := resolver xdgParseUserDirLine: stream.
+	relativePath := path relativeTo: resolver home.
+	self assert: relativePath pathString equals: 'Documents'.
+]
+
+{ #category : #tests }
+UnixResolverTest >> testXdgParseUserDirLineNotRoot [
+	"Ensure that a path of the form '$HOME/' doesn't resolve to the root directory.
+	Note that this test can be run on any platform."
+	| stream path |
+
+	stream := '"$HOME/"' readStream.
+	path := resolver xdgParseUserDirLine: stream.
+	self deny: path isRoot.
+]


### PR DESCRIPTION
Currently a line of the form:

XDG_DOCUMENTS_DIR="$HOME/"

in `~/.config/user-dirs.dirs` will answer the root directory, when the user's home directory is obviously intended.

Fixes: pharo-project/pharo#9410