### PR TITLE
9430-Playground-Define-Global-lead-to-DNU 

### DIFF
--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -17,9 +17,9 @@ OCUndeclaredVariableWarning >> declareClassVar [
 
 { #category : #correcting }
 OCUndeclaredVariableWarning >> declareGlobal [
-
-	Smalltalk at: node name asSymbol put: nil.
-	(ReparseAfterSourceEditing new newSource: self requestor text) signal
+	Smalltalk globals at: node name asSymbol put: nil.
+	(ReparseAfterSourceEditing new newSource: self requestor text) signal.
+	^Smalltalk globals bindingOf: node name asSymbol
 ]
 
 { #category : #correcting }


### PR DESCRIPTION
this fixes #9430

I have two tests 

- StPlaygroundPagePresenterTest>>#testDoEvaluateDeclareGlobal
- StObjectContextPresenterTest>>#testDoEvaluateDeclareGlobal

That I will commit to the Newtools repo later after this is merged.

I have added to the backlog:
- remove the possibility to select "add class var" when in the playground
- check #declareInstVar: and #declareClassVar for the case when this is not the playground

All this will be *much* simpler in Pharo10 when we remove this code from the exception.


