### PR TITLE
Playground-Define-ClassVars-Check

### DIFF
--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -174,8 +174,9 @@ OCUndeclaredVariableWarning >> openMenuIn: aBlock [
 						do: [ self openMenuIn: aBlock ] ].
 			labels add: 'Declare new global'.
 			actions add: [ self declareGlobal ].
-			labels add: 'Declare new class variable'.
-			actions add: [ self declareClassVar ] .
+			compilationContext requestor isForScripting ifFalse: 
+				[labels add: 'Declare new class variable'.
+				actions add: [ self declareClassVar ]].
 			labels add: 'Define new trait'.
 			actions
 				add: [ 

--- a/src/Rubric/RubScrolledTextMorph.class.st
+++ b/src/Rubric/RubScrolledTextMorph.class.st
@@ -690,6 +690,11 @@ RubScrolledTextMorph >> initialize [
 ]
 
 { #category : #testing }
+RubScrolledTextMorph >> isForScripting [
+	^ self textArea isForScripting
+]
+
+{ #category : #testing }
 RubScrolledTextMorph >> isReadOnly [
 	^ self textArea isReadOnly 
 ]


### PR DESCRIPTION
OCUndeclaredVariableWarning should not present the possibility to define class variables if this is a playground

- check the requestor using isForScripting
- implement isForScripting in RubScrolledTextMorph to forward to the editor

There is no test as this is not easy to test. The whole idea to correct this in the Exception is wrong, we will radically simplify this in Pharo10.


