### PR TITLE
RB - Add variables when we copy a class

### DIFF
--- a/src/Refactoring-Core/RBCopyClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBCopyClassRefactoring.class.st
@@ -98,6 +98,21 @@ RBCopyClassRefactoring >> copyMethodsOf: rbClass1 in: rbClass2 [
 	]
 ]
 
+{ #category : #transforming }
+RBCopyClassRefactoring >> copyVariables [
+	aClass instanceVariableNames do: [ :varName |
+		self performCompositeRefactoring: (RBAddInstanceVariableRefactoring
+		model: self model
+		variable: varName
+		class: className) ].
+
+	aClass classVariableNames do: [ :varName |
+		self performCompositeRefactoring: (RBAddClassVariableRefactoring
+		model: self model
+		variable: varName
+		class: className) ]
+]
+
 { #category : #preconditions }
 RBCopyClassRefactoring >> preconditions [ 
 	^ (RBCondition isValidClassName: className) 
@@ -107,5 +122,6 @@ RBCopyClassRefactoring >> preconditions [
 { #category : #transforming }
 RBCopyClassRefactoring >> transform [
 	self copyClass.
+	self copyVariables.
 	self copyMethods.
 ]

--- a/src/Refactoring-Tests-Core/RBCopyPackageTest.class.st
+++ b/src/Refactoring-Tests-Core/RBCopyPackageTest.class.st
@@ -22,6 +22,8 @@ RBCopyPackageTest >> testCopyPackage [
 	self executeRefactoring: refactoring.
 	self assert: (aModel packageNamed: #'Refactoring-Tests-Changes1') isNotNil.
 	self assert: (aModel classNamed: #RBRefactoringChangeTestCopy) category equals: #'Refactoring-Tests-Changes1'.
+	self assert: (aModel classNamed: #RBRefactoringChangeTestCopy) instanceVariableNames asArray
+		equals: #( 'changes' 'workingEnvironment' 'changeFactory').
 	self assert: (aModel classNamed: #RBRefactoringChangeManagerTestCopy) category equals: #'Refactoring-Tests-Changes1'.
 	
 ]
@@ -37,6 +39,8 @@ RBCopyPackageTest >> testCopyPackageAndChangesCopyReferences [
 	self executeRefactoring: refactoring.
 	self assert: (aModel classNamed: #RBRefactoringClassesHelpCopy) category 
 		equals: #'Refactoring-Help1'.
+	self assert: (aModel classNamed: #RBRefactoringClassesHelpCopy) superclass name 
+		equals: #RBClassesHelpCopy.
 	self assert: (aModel classNamed: #RBRefactoringClassesHelpCopy) superclass name 
 		equals: #RBClassesHelpCopy.
 	self assert: ((aModel classNamed: #RBCoreClassesHelpCopy) classSide parseTreeFor: #pages) 

--- a/src/SystemCommands-PackageCommands/SycCopyPackageCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycCopyPackageCommand.class.st
@@ -19,7 +19,8 @@ Class {
 
 { #category : #testing }
 SycCopyPackageCommand class >> canBeExecutedInContext: aToolContext [
-	^aToolContext isPackageSelected
+	"^aToolContext isPackageSelected"
+	^ false
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fixes #9335

- Fix copy of variables when we create a copy of a class, however it still doesn't work well when we a class uses traits or has slots.
- For the moment this refactoring's command was deactivated
- Create issue to support traits and slots when we copy a class [(#9440)](https://github.com/pharo-project/pharo/issues/9440)