### PR TITLE
Fix #9397 - collect:as: behavior on dictionaries

### DIFF
--- a/src/Collections-Unordered-Tests/DictionaryTest.class.st
+++ b/src/Collections-Unordered-Tests/DictionaryTest.class.st
@@ -410,6 +410,33 @@ DictionaryTest >> testAtUpdateInitial [
 ]
 
 { #category : #tests }
+DictionaryTest >> testCollectAsWithParenthesis [
+
+	| array dict |
+	array := { 1. 2. 3 }.
+	dict := (array collect: [ :each | each -> each asString ]) as:
+		        Dictionary.
+	self assert: dict equals: { 
+			(1 -> '1').
+			(2 -> '2').
+			(3 -> '3') } asDictionary
+]
+
+{ #category : #tests }
+DictionaryTest >> testCollectAsWithoutParenthesis [
+
+	| array dict |
+	array := { 1. 2. 3 }.
+	dict := array
+		        collect: [ :each | each -> each asString ]
+		        as: Dictionary.
+	self assert: dict equals: { 
+			(1 -> '1').
+			(2 -> '2').
+			(3 -> '3') } asDictionary
+]
+
+{ #category : #tests }
 DictionaryTest >> testDictionaryPublicProtocolCompatibility [
 	"Tests that other dictionaries and their classes respond to the messages
 	in the public protocols (ignoring extensions, private, printing, copying,

--- a/src/Collections-Unordered/Dictionary.class.st
+++ b/src/Collections-Unordered/Dictionary.class.st
@@ -429,15 +429,6 @@ Dictionary >> errorValueNotFound: value [
 ]
 
 { #category : #private }
-Dictionary >> fillFrom: aCollection with: aBlock [
-	"Evaluate aBlock with each of aCollections's elements as the argument.  
-	Collect the resulting values into self. Answer self."
-
-	aCollection keysAndValuesDo: [ :key :value |
-		self at: key put: (aBlock value: value) ]
-]
-
-{ #category : #private }
 Dictionary >> fixCollisionsFrom: start [
 	"The element at start has been removed and replaced by nil.
 	This method moves forward from there, relocating any entries


### PR DESCRIPTION
Now Dictionary have the expected behavior

I had to remove `Dictionary>>#fillFrom:with:`, but removing this method didn't make any Dictionary test go red or yellow, it's weird

Anyway, I added tests to ensure https://github.com/pharo-project/pharo/issues/9397 is fixed