### PR TITLE
9453 Path>>parent answers wrong value if '..' is the last segment

### DIFF
--- a/src/FileSystem-Path/Path.class.st
+++ b/src/FileSystem-Path/Path.class.st
@@ -457,7 +457,7 @@ Path >> makeRelative: anObject [
 Path >> parent [
 	| size parent |
 	self isRoot ifTrue: [^ self].
-	self isAllParents ifTrue: [^ self / '..'].
+	(self isEmpty or: [ (self at: self size) = '..' ]) ifTrue: [^ self / '..'].
 	
 	size := self size - 1.
 	parent := self class new: size.

--- a/src/FileSystem-Path/Path.class.st
+++ b/src/FileSystem-Path/Path.class.st
@@ -401,12 +401,6 @@ Path >> isAbsolute [
 	self subclassResponsibility 
 ]
 
-{ #category : #private }
-Path >> isAllParents [
-	1 to: self size do: [:i | (self at: i) = '..' ifFalse: [^ false]].
-	^ true
-]
-
 { #category : #comparing }
 Path >> isChildOf: anObject [
 	^ self parent = anObject

--- a/src/FileSystem-Tests-Core/PathTest.class.st
+++ b/src/FileSystem-Tests-Core/PathTest.class.st
@@ -173,6 +173,24 @@ PathTest >> testContainsLocator [
 ]
 
 { #category : #tests }
+PathTest >> testDotDotParent [
+	| path parent |
+	path := (Path * 'plonk') / 'griffle' / '..'.
+	parent := path parent.
+	self assert: parent isRelative.
+	self assert: parent segments equals: #(plonk griffle '..' '..').
+]
+
+{ #category : #tests }
+PathTest >> testDotParent [
+	| path parent |
+	path := (Path * 'plonk') / 'griffle' / '.'.
+	parent := path parent.
+	self assert: parent isRelative.
+	self assert: parent segments equals: #(plonk).
+]
+
+{ #category : #tests }
 PathTest >> testEqual [
 	| a b |
 	a := Path * 'plonk'.


### PR DESCRIPTION
See https://github.com/pharo-project/pharo/issues/9453 for the issue description.

There are two new tests:

- Path>>testDotDotParent
- Path>>testDotParent