### PR TITLE
Adding missing check for pool contained in superclasses

### DIFF
--- a/src/Calypso-SystemQueries/ClyClassVariable.class.st
+++ b/src/Calypso-SystemQueries/ClyClassVariable.class.st
@@ -50,9 +50,12 @@ ClyClassVariable >> detectDefiningClassFrom: anUserClass ifAbsent: aBlock [
 
 { #category : #testing }
 ClyClassVariable >> isAccessibleFrom: aClass [
-	(aClass instanceSide includesSharedPoolNamed: definingClass name) ifTrue: [ ^true ].
-		
-	^aClass instanceSide = definingClass or: [ aClass instanceSide inheritsFrom: definingClass ]
+
+	(aClass instanceSide withAllSuperclasses anySatisfy: [ :c | 
+		 c includesSharedPoolNamed: definingClass name ]) ifTrue: [ ^ true ].
+
+	^ aClass instanceSide = definingClass or: [ 
+		  aClass instanceSide inheritsFrom: definingClass ]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Fix on the writers query of pool vars. 
Now it consider pools being defined in super classes.