### PR TITLE
AbstractFileReference>>canonicalize should not resolve the receiver

### DIFF
--- a/src/FileSystem-Core/AbstractFileReference.class.st
+++ b/src/FileSystem-Core/AbstractFileReference.class.st
@@ -198,7 +198,7 @@ AbstractFileReference >> binaryWriteStreamDo: doBlock ifPresent: presentBlock [
 AbstractFileReference >> canonicalize [
 	"Answer the receiver with references to the current folder (.) and parent folder (..) removed"
 
-	^ self withPath: self resolve path canonicalize
+	^ self withPath: self path canonicalize
 ]
 
 { #category : #accessing }

--- a/src/FileSystem-Tests-Core/FileLocatorTest.class.st
+++ b/src/FileSystem-Tests-Core/FileLocatorTest.class.st
@@ -75,6 +75,19 @@ FileLocatorTest >> testCanCreateLocatorFromStringWhenSamePath [
 		equals: path.
 ]
 
+{ #category : #'creation tests' }
+FileLocatorTest >> testCananonicalize [
+	| fl canonicalized |
+
+	fl := FileLocator home / 'foo' / 'bar'.
+	self assert: fl path isRelative.
+	self assert: fl path size equals: 2.
+
+	canonicalized := fl canonicalize.
+	self assert: canonicalized path isRelative.
+	self assert: canonicalized path size equals: 2.
+]
+
 { #category : #'compatibility tests' }
 FileLocatorTest >> testCommaAddsExtension [
 
@@ -219,7 +232,7 @@ FileLocatorTest >> testIsRelative [
 FileLocatorTest >> testIsRoot [
 	locator := FileLocator image.
 	(locator resolve path size) timesRepeat: [ locator := locator / '..' ].
-	self assert: locator canonicalize isRoot
+	self assert: locator resolve canonicalize isRoot
 ]
 
 { #category : #'resolution tests' }


### PR DESCRIPTION
FileLocator's path's should always be relative to the origin.  Resolving the FileLocator results in a FileLocator being answered with an absolute path, which is invalid.

Fixes: pharo-project/pharo#9469