### PR TITLE
9466-Sindarin-sends-unimplemented-message-keepAlive

### DIFF
--- a/src/Sindarin/SindarinUILessDebugger.class.st
+++ b/src/Sindarin/SindarinUILessDebugger.class.st
@@ -6,12 +6,7 @@ Class {
 
 { #category : #'debugger declaration' }
 SindarinUILessDebugger class >> openOn: aDebugSession withFullView: aBool andNotification: aString [
-	"This method will be called to open this debugger on a given debug session (i.e. execution to debug). If this debugger wants to keep the debug session (and its process) alive (for example because it is a graphical debugger that would break if the debug session is terminated while its window is open), it should call #keepAlive: on @aDebugSession, passing itself as argument.
-	The contract is that if a debugger calls #keepAlive:, it should also call #stopKeepingAlive: on @aDebugSession when it closes (passing itself as argument again).
-	The debug session will automatically not be kept alive by this debugger anymore if this debugger gets garbage collected (and DebugSession will only hold a weak reference to this debugger, so it will not prevent its garbage collection)"
-	aDebugSession keepAlive: self.
-	Smalltalk tools inspector openOn: (SindarinDebugger attachTo: aDebugSession).
-	"BAD: this debugger should call #stopKeepingAlive: on aDebugSession when it is close. Unfortunately, since it's just an inspector, I do not know how to make something happen when the inspector window closes"
+	Smalltalk tools inspector openOn: (SindarinDebugger attachTo: aDebugSession)
 ]
 
 { #category : #'debugger declaration' }


### PR DESCRIPTION
as all the other debuggers do not do anything special anymore in that methods, I guess the easiest is to remove the message send and the outdated comments.

fixes #9466


