### PR TITLE
9493-Compiler-error-when-using-whileTrue

### DIFF
--- a/src/OpalCompiler-Core/RBMessageNode.extension.st
+++ b/src/OpalCompiler-Core/RBMessageNode.extension.st
@@ -127,7 +127,7 @@ RBMessageNode >> isInlineWhile [
 	self isCascaded ifTrue: [^ false].
 	(#(whileFalse: whileTrue: whileFalse whileTrue) includes: self selector) ifFalse: [^ false].
 	self receiver isBlock ifFalse: [^ false].
-	self receiver arguments isEmpty ifFalse: [self notify: 'while receiver block must have no arguments'. ^ false].
+	self receiver arguments isEmpty ifFalse: [^ false].
 	self arguments isEmpty ifFalse: [
 		self arguments first isBlock ifFalse: [^ false].
 		self arguments first arguments isEmpty ifFalse: [^ false].

--- a/src/OpalCompiler-Tests/OCASTSemanticAnalyzerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTSemanticAnalyzerTest.class.st
@@ -1,0 +1,14 @@
+Class {
+	#name : #OCASTSemanticAnalyzerTest,
+	#superclass : #TestCase,
+	#category : #'OpalCompiler-Tests-Semantic'
+}
+
+{ #category : #tests }
+OCASTSemanticAnalyzerTest >> testWhileWithArg [
+	"If we analyse #whileTrue with a block that has an argument, answer false for #isInlineWhile.
+	executing this code would lead to a runtime error, which is what we expect"
+	| ast |
+	ast := RBParser parseExpression: '[:test | ] whileTrue'.
+	self deny: ast sendNodes first isInlineWhile.
+]


### PR DESCRIPTION
If we  have a #whileTrue with a block that has an argument, answer false for #isInlineWhile.

There was a call to #notify:. which makes no sense.
Executing this code will lead to a runtime error, which is what we expect. 

 If we want to give a hint to the programmer, we could add a rule, but it should not be hard-coded in the #isInlineWhile check.

fixes #9493

