### PR TITLE
add missing methods needed for spotter

### DIFF
--- a/src/Calypso-SystemPlugins-Spotter/ClyGoToSpotterCandidate.class.st
+++ b/src/Calypso-SystemPlugins-Spotter/ClyGoToSpotterCandidate.class.st
@@ -72,6 +72,12 @@ ClyGoToSpotterCandidate >> label [
 	^ self name
 ]
 
+{ #category : #spotter }
+ClyGoToSpotterCandidate >> matchesText: aString [ 
+
+	^ self name = aString
+]
+
 { #category : #accessing }
 ClyGoToSpotterCandidate >> name [
 	^ name

--- a/src/Calypso-SystemPlugins-Spotter/CmdCommandActivator.extension.st
+++ b/src/Calypso-SystemPlugins-Spotter/CmdCommandActivator.extension.st
@@ -19,6 +19,12 @@ CmdCommandActivator >> label [
 ]
 
 { #category : #'*Calypso-SystemPlugins-Spotter' }
+CmdCommandActivator >> matchesText: aString [ 
+
+	^ self label = aString
+]
+
+{ #category : #'*Calypso-SystemPlugins-Spotter' }
 CmdCommandActivator >> spotterPreview [
 
 	^ self spotterPreview: SpPresenterBuilder new


### PR DESCRIPTION
I moved this from NewTools-Spotter because otherwise there would be a NewTools-Spotter -> Calypso dependence and this is incorrect (it has to be Calypso -> NewTools-Spotter)