### PR TITLE
9525-Moving-method-from-one-class-to-another-should-automatically-use-the-original-protocol

### DIFF
--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToClassCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToClassCommand.class.st
@@ -41,16 +41,10 @@ SycMoveMethodsToClassCommand >> defaultMenuItemName [
 
 { #category : #execution }
 SycMoveMethodsToClassCommand >> execute [
-	self fillProtocols.
 	methods 
 		collect: [ :each | RBMoveMethodToClassRefactoring model: model method: each class: targetClass ]
 		thenDo: [ :each | each execute ].
 	methods do: [ :each | each origin organization removeEmptyCategories ].
-]
-
-{ #category : #accessing }
-SycMoveMethodsToClassCommand >> fillProtocols [
-	methods do: [ :meth |  self tagMethod: meth ]
 ]
 
 { #category : #'drag and drop support' }


### PR DESCRIPTION
This PR removes the #fillProtocols send in SycMoveMethodsToClassCommand

The idea is that we want to just move the method, keeping the category.

fixes #9525
fixes #9516

