### PR TITLE
9392-ProtocolRemovalException-when-removing-a-method-implemented-in-a-trait

### DIFF
--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -73,7 +73,9 @@ ClassOrganizationTest >> testListAtCategoryNamed [
 { #category : #tests }
 ClassOrganizationTest >> testRemoveCategory [
 	self assert: self organization categories size equals: 2.
-	self should: [ self organization removeCategory: 'one' ] raise: Error.
+	"just ignore removing of non empty categories" 
+	self organization removeCategory: 'one'.
+	self assert: self organization categories size equals: 2.
 	self organization removeCategory: 'empty'.
 	self assert: self organization categories size equals: 1.
 	self assert: self organization categories first equals: 'one'

--- a/src/Kernel/ProtocolOrganizer.class.st
+++ b/src/Kernel/ProtocolOrganizer.class.st
@@ -190,13 +190,7 @@ ProtocolOrganizer >> removeMethod: aSymbol [
 { #category : #'protocol - removing' }
 ProtocolOrganizer >> removeProtocol: aProtocol [
 	
-	aProtocol canBeRemoved
-		ifFalse: [ 
-			"Virtual protocols who cannot be removed should not raise an error"
-			aProtocol isVirtualProtocol 
-				ifTrue: [ ^ self ].
-			ProtocolRemovalException signal ].
-	
+	aProtocol canBeRemoved ifFalse:  [ ^ self ].
 	^ protocols 
 		remove: aProtocol
 		ifAbsent: [ ]


### PR DESCRIPTION
#removeProtocol: was raising an exception if #canBeRemoved was false to me this makes no sense.

(there are no users of ProtocolRemovalException)

#removeCategory is already silently failing when the category does not exist. I should fail silently, too, if we can not remove the category (e.g. because it is virtual, or because it is not empty yet).

fixes #9392

( we really need to cleanup categories/tags/protocols in Pharo10... this fix should be seen more of a workaround than a real fix)


