### PR TITLE
adding NewTools-Spotter to knownIDEDependencies

### DIFF
--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -83,7 +83,7 @@ SystemDependenciesTest >> knownIDEDependencies [
 
 	"ideally this list should be empty"	
 	
-	^ #()
+	^ #('NewTools-Spotter')
 ]
 
 { #category : #'known dependencies' }


### PR DESCRIPTION
I wonder why this was not trigger when I moved those methods?