### PR TITLE
9517 modifying method with variable breakpoints in the debugger sliently remove the breakpoint but leaves metalinks behind in other methods

### DIFF
--- a/src/Reflectivity-Tests/LinkInstallerTest.class.st
+++ b/src/Reflectivity-Tests/LinkInstallerTest.class.st
@@ -923,7 +923,7 @@ LinkInstallerTest >> testUninstallLinkOnSlotOrVar [
 		
 	"After installing, registry must be correct"	
 	permalink := (linkRegistry permaLinksFor:link) asArray first.
-	self assert: (linkRegistry registeredClassesAt: ReflectivityExamples2) asArray first 
+	self assert: (linkRegistry slotSourcesAt: ReflectivityExamples2) asArray first asArray first
 		identicalTo: permalink slotOrVariable.
 	self assert: (linkRegistry registeredTargetsAt: permalink slotOrVariable) asArray first 
 		identicalTo: permalink.
@@ -932,7 +932,7 @@ LinkInstallerTest >> testUninstallLinkOnSlotOrVar [
 	link uninstall.
 	self assertEmpty: link nodes.
 	self assertEmpty: (linkRegistry permaLinksFor:link).
-	self assertEmpty: (linkRegistry registeredClassesAt: ReflectivityExamples2).
+	self assertEmpty: (linkRegistry slotSourcesAt: ReflectivityExamples2) flattened.
 	self assertEmpty: (linkRegistry registeredTargetsAt: permalink slotOrVariable).
 	
 	link installOnVariableNamed: #classVar
@@ -942,16 +942,16 @@ LinkInstallerTest >> testUninstallLinkOnSlotOrVar [
 	
 	"After installing, registry must be correct"	
 	permalink := (linkRegistry permaLinksFor:link) asArray first.
-	self assert: (linkRegistry registeredClassesAt: ReflectivityExamples2) asArray first 
+	self assert: (linkRegistry slotSourcesAt: ReflectivityExamples2) flattened first 
 		identicalTo: permalink slotOrVariable.
-	self assert: (linkRegistry registeredTargetsAt: permalink slotOrVariable) asArray first 
+	self assert: (linkRegistry registeredTargetsAt: permalink slotOrVariable) flattened first 
 		identicalTo: permalink.
 	
 	"After uninstalling, registry must be cleared"
 	link uninstall.
 	self assertEmpty: link nodes.
 	self assertEmpty: (linkRegistry permaLinksFor:link).
-	self assertEmpty: (linkRegistry registeredClassesAt: ReflectivityExamples2).
+	self assertEmpty: (linkRegistry slotSourcesAt: ReflectivityExamples2) flattened.
 	self assertEmpty: (linkRegistry registeredTargetsAt: permalink slotOrVariable)
 ]
 

--- a/src/Reflectivity-Tests/MetaLinkRegistryTest.class.st
+++ b/src/Reflectivity-Tests/MetaLinkRegistryTest.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : #MetaLinkRegistryTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'registry',
+		'permalink'
+	],
+	#category : #'Reflectivity-Tests-Base'
+}
+
+{ #category : #running }
+MetaLinkRegistryTest >> setUp [
+
+	super setUp.
+
+	registry := MetaLinkRegistry new.
+	permalink := PermaLink new.
+	permalink slotOrVarClass: ReflectivityExamples2.
+	permalink slotOrVariable: (ReflectivityExamples2 lookupVar: #instVar2).
+	registry registerPermaLink: permalink.
+	registry slotSourcesAt: ReflectivityExamples2 ifAbsentPut: [ 
+		Set new
+			add: permalink slotOrVariable;
+			yourself ]
+]
+
+{ #category : #tests }
+MetaLinkRegistryTest >> testPermaLinksForMethod [
+	|plinks|
+	plinks := registry permaLinksForMethod: ReflectivityExamples2Subclass>>#useInstVarInSubclass.
+	self assert: plinks size equals: 1.
+	self assert: plinks first identicalTo: permalink 
+]
+
+{ #category : #tests }
+MetaLinkRegistryTest >> testSlotSourcesConsiderClassesHierarchy [
+
+	| slotSources |
+	slotSources := (registry
+		                slotSourcesAt: ReflectivityExamples2Subclass
+		                ifAbsent: [ nil ]) flattened.
+	self assert: slotSources size equals: 1.
+	self
+		assert: slotSources asArray first
+		identicalTo: permalink slotOrVariable 
+]

--- a/src/Reflectivity-Tests/ReflectivityExamples2.class.st
+++ b/src/Reflectivity-Tests/ReflectivityExamples2.class.st
@@ -5,7 +5,8 @@ Class {
 	#name : #ReflectivityExamples2,
 	#superclass : #Object,
 	#instVars : [
-		'instVar'
+		'instVar',
+		'instVar2'
 	],
 	#classVars : [
 		'classVar'
@@ -34,6 +35,12 @@ ReflectivityExamples2 >> generateNewMethodWithInstVarAccess [
 	instVar := 6.
 	instVar > 5 ifTrue:[^ instVar raisedTo: 2]'
 		classified: 'example'
+]
+
+{ #category : #accessing }
+ReflectivityExamples2 >> instVar2: anObject [
+
+	instVar2 := anObject
 ]
 
 { #category : #examples }
@@ -82,7 +89,7 @@ ReflectivityExamples2 >> modifyMethodWithInstVarAccess [
 
 ]
 
-{ #category : #examples }
+{ #category : #example }
 ReflectivityExamples2 >> newMethodWithInstVarAccess [
 	instVar := 5.
 	instVar := 6.

--- a/src/Reflectivity-Tests/ReflectivityExamples2Subclass.class.st
+++ b/src/Reflectivity-Tests/ReflectivityExamples2Subclass.class.st
@@ -13,3 +13,8 @@ ReflectivityExamples2Subclass >> methodWithOverrides [
 ReflectivityExamples2Subclass >> methodWithOverrides: str1 with: str2 [
 	^(super methodWithOverrides: str1 with: str2), str1, str2
 ]
+
+{ #category : #'as yet unclassified' }
+ReflectivityExamples2Subclass >> useInstVarInSubclass [
+	^instVar2
+]

--- a/src/Reflectivity-Tests/ReflectivityExamples2Subclass.class.st
+++ b/src/Reflectivity-Tests/ReflectivityExamples2Subclass.class.st
@@ -1,3 +1,6 @@
+"
+Subclass for testing premalink spanning class hierarchies.
+"
 Class {
 	#name : #ReflectivityExamples2Subclass,
 	#superclass : #ReflectivityExamples2,

--- a/src/Reflectivity-Tests/VariableBreakpointTest.class.st
+++ b/src/Reflectivity-Tests/VariableBreakpointTest.class.st
@@ -615,9 +615,14 @@ VariableBreakpointTest >> testRemoveAfterSuperclassRemoved [
 
 { #category : #'tests - removing' }
 VariableBreakpointTest >> testRemoveFromMethod [
+	
+	|ast|
+	"We get the variable node one which the variable breakpoint will be installed"
+	ast := (VariableBreakpointMockClass >> #v1) ast allChildren last. 
+	
 	"Removing a variable breakpoint should not uninstall the breakpoint"
 	wp := VariableBreakpoint watchVariable: #v1 inClass: VariableBreakpointMockSubclass. 
-	wp install.	
+	wp install.		
 		
 	"Let us recompile a method touching v1 in the super class of our test class.
 	This is meant so simulate, e.g., a modification in the debugger after a break in that method."
@@ -629,7 +634,7 @@ VariableBreakpointTest >> testRemoveFromMethod [
 	self should: [ VariableBreakpointMockSubclass basicNew v1 ] raise: Break.
 	
 	"Second, the old method ast's is not referenced by the breakpoint's link anymore"
-	
+	self assert: (wp link nodes noneSatisfy: [ :n| n == ast ])
 	
 ]
 

--- a/src/Reflectivity-Tests/VariableBreakpointTest.class.st
+++ b/src/Reflectivity-Tests/VariableBreakpointTest.class.st
@@ -7,7 +7,9 @@ Class {
 		'wp',
 		'obj3',
 		'obj4',
-		'observer'
+		'observer',
+		'testClass',
+		'testSubclass'
 	],
 	#category : #'Reflectivity-Tests-Breakpoints'
 }
@@ -49,6 +51,29 @@ VariableBreakpointTest >> argNodes [
 	nodes := OrderedCollection new.
 	nodes add: (VariableBreakpointMockClass>>#methodWithTempsAndArg:) ast statements first value.
 	^nodes
+]
+
+{ #category : #helpers }
+VariableBreakpointTest >> compileTestClass [
+
+	testClass := VariableBreakpointMockClass
+		             subclass: #VariableBreakpointTestSubclass
+		             instanceVariableNames: 'v3'
+		             classVariableNames: ''
+		             package: 'Reflectivity-Tests-Breakpoints'.
+	testClass compile: 'accessingV1 ^v1'.
+	testClass compile: 'accessingtemp |temp| temp := 0'.
+]
+
+{ #category : #helpers }
+VariableBreakpointTest >> compileTestClass2 [
+
+	testSubclass := testClass
+		                subclass: #VariableBreakpointTestSubclass2
+		                instanceVariableNames: ''
+		                classVariableNames: ''
+		                package: 'Reflectivity-Tests-Breakpoints'.
+	testSubclass compile: 'accessingV1 ^v1'
 ]
 
 { #category : #helpers }
@@ -99,6 +124,8 @@ VariableBreakpointTest >> tearDown [
 		ifNotNil: [ wp isInstalled
 				ifTrue: [ wp remove ] ].
 	Breakpoint unregisterObserver: observer.
+	testSubclass ifNotNil:[testSubclass removeFromSystem].
+	testClass ifNotNil:[testClass removeFromSystem].
 	super tearDown
 ]
 
@@ -420,6 +447,29 @@ VariableBreakpointTest >> testNewForClass [
 	self assert: wp targetClassOrMethod equals: VariableBreakpointMockSubclass
 ]
 
+{ #category : #'tests - removing' }
+VariableBreakpointTest >> testNoRemoveAfterSubclassRemoved [
+	"Removing the class where the target variable of a variable breakpoint is defined should uninstall the variable breakpoint"
+	|testClassNode testSubclassNode|
+	self compileTestClass.
+	self compileTestClass2.
+	testClassNode := (testClass >> #accessingV1) ast allChildren detect:[:n| n isVariable].
+	testSubclassNode := (testSubclass >> #accessingV1) ast allChildren detect:[:n| n isVariable].
+	
+	wp := VariableBreakpoint watchVariable: #v1 inClass: testClass. 
+	wp install.	
+	
+	self should: [testClass basicNew accessingV1] raise: Break.
+	
+	testSubclass removeFromSystem.	
+
+	self deny: (wp link nodes anySatisfy:[:n| n == testSubclassNode]).
+	self assert: (wp link nodes anySatisfy:[:n| n == testClassNode]).
+	self assert: wp isInstalled.
+	self should: [ testClass basicNew accessingV1 ] raise: Break
+
+]
+
 { #category : #'tests - notifications' }
 VariableBreakpointTest >> testNotifyArgumentBreakpointHit [
 	|method notification|
@@ -485,7 +535,7 @@ VariableBreakpointTest >> testNotifyTempBreakpointHit [
 	self assert: notification valueOrNil equals: 42
 ]
 
-{ #category : #'tests - installation' }
+{ #category : #'tests - removing' }
 VariableBreakpointTest >> testRemove [
 
 	wp := VariableBreakpoint watchVariablesInClass: VariableBreakpointMockSubclass.
@@ -506,6 +556,61 @@ VariableBreakpointTest >> testRemove [
 	self shouldnt: [obj2 v1] raise: Break.	
 	self shouldnt: [obj2 v1: 0] raise: Break.
 	
+]
+
+{ #category : #'tests - removing' }
+VariableBreakpointTest >> testRemoveAfterClassRemoved [
+	"Removing the class where the target variable of a variable breakpoint is defined should uninstall the variable breakpoint"
+	|testClassNodes|
+	self compileTestClass.
+	testClassNodes := (testClass >> #accessingV1) ast allChildren.
+	
+	wp := VariableBreakpoint watchVariable: #v1 inClass: testClass. 
+	wp install.	
+		
+	testClass removeFromSystem.	
+	self denyCollection: wp link nodes includesAny: testClassNodes.
+	self deny: wp isInstalled.
+	self shouldnt: [ VariableBreakpointMockClass new v1 ] raise: Break
+
+]
+
+{ #category : #'tests - removing' }
+VariableBreakpointTest >> testRemoveAfterClassWithTempVarRemoved [
+	"Removing the class where the target temporary variable of a variable breakpoint is defined should uninstall the variable breakpoint"
+	|testClassNodes|
+	self compileTestClass.
+	testClassNodes := (testClass >> #accessingtemp) ast allChildren.
+	
+	wp := (testClass >> #accessingtemp)  newBreakpointForVariable: #temp.
+	wp install.	
+	self should: [ testClass basicNew accessingtemp ] raise: Break.
+		
+	testClass removeFromSystem.	
+	self denyCollection: wp link nodes includesAny: testClassNodes.
+	self deny: wp isInstalled.
+	self shouldnt: [ testClass basicNew accessingtemp ] raise: Break
+
+]
+
+{ #category : #'tests - removing' }
+VariableBreakpointTest >> testRemoveAfterSuperclassRemoved [
+	"Removing the class where the target variable of a variable breakpoint is defined should uninstall the variable breakpoint"
+	|testClassNodes|
+	self compileTestClass.
+	self compileTestClass2.
+	testClassNodes := (testClass >> #accessingV1) ast allChildren.
+	
+	wp := VariableBreakpoint watchVariable: #v1 inClass: testClass. 
+	wp install.	
+	
+	self should: [testSubclass basicNew accessingV1] raise: Break.
+	
+	testClass removeFromSystem.	
+	self denyCollection: wp link nodes includesAny: testClassNodes.
+	self deny: wp isInstalled.
+	self shouldnt: [ testSubclass basicNew accessingV1 ] raise: Break
+
 ]
 
 { #category : #'tests - installation' }

--- a/src/Reflectivity-Tests/VariableBreakpointTest.class.st
+++ b/src/Reflectivity-Tests/VariableBreakpointTest.class.st
@@ -613,6 +613,26 @@ VariableBreakpointTest >> testRemoveAfterSuperclassRemoved [
 
 ]
 
+{ #category : #'tests - removing' }
+VariableBreakpointTest >> testRemoveFromMethod [
+	"Removing a variable breakpoint should not uninstall the breakpoint"
+	wp := VariableBreakpoint watchVariable: #v1 inClass: VariableBreakpointMockSubclass. 
+	wp install.	
+		
+	"Let us recompile a method touching v1 in the super class of our test class.
+	This is meant so simulate, e.g., a modification in the debugger after a break in that method."
+	VariableBreakpointMockClass compile: 'v1 ^v1'.
+	
+	"First, the breakpoint should still be installed in that method"
+	self assert: wp isInstalled.
+	self should: [ VariableBreakpointMockClass basicNew v1 ] raise: Break.
+	self should: [ VariableBreakpointMockSubclass basicNew v1 ] raise: Break.
+	
+	"Second, the old method ast's is not referenced by the breakpoint's link anymore"
+	
+	
+]
+
 { #category : #'tests - installation' }
 VariableBreakpointTest >> testScopeTo [
 	| instance testContext |

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -91,10 +91,11 @@ Breakpoint class >> debugWorldMenuOn: aBuilder [
 
 { #category : #'system announcements' }
 Breakpoint class >> handleClassRemoved: anAnnouncement [
-	self all copy do: [ :breakpoint |
+
+	self all copy do: [ :breakpoint | 
 		breakpoint link methods
 			detect: [ :m | m methodClass = anAnnouncement classRemoved ]
-			ifFound: [ self removeBreakpoint: breakpoint ] ]
+			ifFound: [ breakpoint removeFromClass: anAnnouncement classRemoved ] ]
 ]
 
 { #category : #'system announcements' }
@@ -337,14 +338,19 @@ Breakpoint >> options: anArray [
 	options := anArray
 ]
 
-{ #category : #install }
+{ #category : #removing }
 Breakpoint >> remove [
 	self removeFromNodeProperty.
 	self class removeBreakpoint: self.
 	link uninstall
 ]
 
-{ #category : #install }
+{ #category : #removing }
+Breakpoint >> removeFromClass: aClass [
+	self class removeBreakpoint: self
+]
+
+{ #category : #removing }
 Breakpoint >> removeFromNodeProperty [
 	self node removeBreakpoint: self
 	

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -193,11 +193,12 @@ Breakpoint class >> removeFrom: aNode [
 ]
 
 { #category : #cleanup }
-Breakpoint class >> removeFromMethod: aMethod [ 
-	self all copy do: [ :breakpoint |
+Breakpoint class >> removeFromMethod: aMethod [
+
+	self all copy do: [ :breakpoint | 
 		breakpoint link methods
 			detect: [ :m | m == aMethod ]
-			ifFound: [ self removeBreakpoint: breakpoint  ] ]
+			ifFound: [ breakpoint removeFromMethod: aMethod ] ]
 ]
 
 { #category : #'observers - experimental' }
@@ -348,6 +349,11 @@ Breakpoint >> remove [
 { #category : #removing }
 Breakpoint >> removeFromClass: aClass [
 	self class removeBreakpoint: self
+]
+
+{ #category : #removing }
+Breakpoint >> removeFromMethod: aMethod [
+	self remove
 ]
 
 { #category : #removing }

--- a/src/Reflectivity/Class.extension.st
+++ b/src/Reflectivity/Class.extension.st
@@ -6,6 +6,13 @@ Class >> intanceSpecificMetaLinksAvailable [
 ]
 
 { #category : #'*Reflectivity' }
+Class >> isInClassHierarchyOf: aClass [
+
+	^ (self includesBehavior: aClass) or: [ 
+		  aClass includesBehavior: self ]
+]
+
+{ #category : #'*Reflectivity' }
 Class >> link: aMetaLink toAST: aNode [
 	aNode link: aMetaLink
 ]

--- a/src/Reflectivity/MetaLinkRegistry.class.st
+++ b/src/Reflectivity/MetaLinkRegistry.class.st
@@ -107,9 +107,7 @@ MetaLinkRegistry >> permaLinksForMethod: method [
 	targets := (self slotSourcesAt: class) flattened.
 	^ (permanentTargets associationsSelect: [ :assoc | 
 		   targets includes: assoc key ]) values flattened select: [ 
-		  :permalink | 
-		  permalink slotOrVarClass == class or: [ 
-			  class allSuperclasses includes: permalink slotOrVarClass ] ] 
+		  :permalink | permalink slotOrVarClass isInClassHierarchyOf: class ]
 ]
 
 { #category : #permalinks }
@@ -162,11 +160,9 @@ MetaLinkRegistry >> slotSourcesAt: aClass ifAbsent: aBlock [
 
 	| registeredClasses |
 	registeredClasses := slotSources keys select: [ :c | 
-		                     c == aClass or: [ 
-			                     (aClass allSuperclasses includes: c) or: [ 
-				                     c allSubclasses includes: aClass ] ] ].
+		                     c isInClassHierarchyOf: aClass ].
 	registeredClasses isEmpty ifTrue: [ ^ aBlock value ].
-	^ (registeredClasses collect: [ :c | slotSources at: c ])
+	^ registeredClasses collect: [ :c | slotSources at: c ]
 ]
 
 { #category : #'registry access' }

--- a/src/Reflectivity/MetaLinkRegistry.class.st
+++ b/src/Reflectivity/MetaLinkRegistry.class.st
@@ -34,8 +34,8 @@ Class {
 	#instVars : [
 		'links',
 		'permalinks',
-		'classes',
-		'permanentTargets'
+		'permanentTargets',
+		'slotSources'
 	],
 	#category : #'Reflectivity-Installer'
 }
@@ -49,8 +49,8 @@ MetaLinkRegistry >> addMetaLink: aLink forObject: anObject [
 MetaLinkRegistry >> canReinstallPermaLink: permalink [
 	^ (self hasPermaLinks: permalink link) not
 		or: [ | slotsOrVarsWithPermalink |
-			slotsOrVarsWithPermalink := self registeredClassesAt: permalink slotOrVarClass.
-			slotsOrVarsWithPermalink noneSatisfy: [ :slotOrVar | permalink slotOrVariable == slotOrVar ] ]
+			slotsOrVarsWithPermalink := self slotSourcesAt: permalink slotOrVarClass.
+			slotsOrVarsWithPermalink flattened noneSatisfy: [ :slotOrVar | permalink slotOrVariable == slotOrVar ] ]
 ]
 
 { #category : #'registry access' }
@@ -68,7 +68,7 @@ MetaLinkRegistry >> hasPermaLinks: aLink [
 MetaLinkRegistry >> initialize [
 	links := WeakKeyDictionary new.
 	permalinks := WeakKeyDictionary new.
-	classes := WeakKeyDictionary new.
+	slotSources := WeakKeyDictionary new.
 	permanentTargets := WeakKeyDictionary new
 ]
 
@@ -101,11 +101,15 @@ MetaLinkRegistry >> permaLinksForClasses: targetClasses [
 
 { #category : #permalinks }
 MetaLinkRegistry >> permaLinksForMethod: method [
+
 	| class targets |
 	class := method methodClass.
-	targets := self registeredClassesAt: class.
-	^ (permanentTargets associationsSelect: [ :assoc | targets includes: assoc key ]) values
-		flattened select: [ :permalink | permalink slotOrVarClass == class ]
+	targets := (self slotSourcesAt: class) flattened.
+	^ (permanentTargets associationsSelect: [ :assoc | 
+		   targets includes: assoc key ]) values flattened select: [ 
+		  :permalink | 
+		  permalink slotOrVarClass == class or: [ 
+			  class allSuperclasses includes: permalink slotOrVarClass ] ] 
 ]
 
 { #category : #permalinks }
@@ -117,23 +121,8 @@ MetaLinkRegistry >> registerPermaLink: aPermaLink [
 	registeredLinks := permalinks at: aPermaLink link ifAbsentPut: [ Set new ].
 	registeredLinks add: aPermaLink.
 	
-	registeredSlots := self registeredClassesAt: aPermaLink slotOrVarClass ifAbsentPut: [ Set new ].
+	registeredSlots := self slotSourcesAt: aPermaLink slotOrVarClass ifAbsentPut: [ Set new ].
 	registeredSlots add: aPermaLink slotOrVariable
-]
-
-{ #category : #'registry access' }
-MetaLinkRegistry >> registeredClassesAt: aClass [
-	^ self registeredClassesAt:  aClass ifAbsent: [Set new ]
-]
-
-{ #category : #'registry access' }
-MetaLinkRegistry >> registeredClassesAt: aClass ifAbsent: aBlock [
-	^ classes at: aClass ifAbsent: aBlock
-]
-
-{ #category : #'registry access' }
-MetaLinkRegistry >> registeredClassesAt: aClass ifAbsentPut: aBlock [
-	^ classes at: aClass ifAbsentPut: aBlock
 ]
 
 { #category : #'registry access' }
@@ -158,9 +147,31 @@ MetaLinkRegistry >> removePermaLinkFromPermanentTarget: permaLink [
 
 { #category : #permalinks }
 MetaLinkRegistry >> removePermalinkSlotOrVarFromClassRegistry: permaLink [
-	(self registeredClassesAt: permaLink slotOrVarClass)
-		remove: permaLink slotOrVariable
-		ifAbsent: [  ]
+
+	(self slotSourcesAt: permaLink slotOrVarClass) do: [ :set | 
+		set remove: permaLink slotOrVariable ifAbsent: [  ] ]
+]
+
+{ #category : #'registry access' }
+MetaLinkRegistry >> slotSourcesAt: aClass [
+	^ self slotSourcesAt:  aClass ifAbsent: [Array with: Set new ]
+]
+
+{ #category : #'registry access' }
+MetaLinkRegistry >> slotSourcesAt: aClass ifAbsent: aBlock [
+
+	| registeredClasses |
+	registeredClasses := slotSources keys select: [ :c | 
+		                     c == aClass or: [ 
+			                     (aClass allSuperclasses includes: c) or: [ 
+				                     c allSubclasses includes: aClass ] ] ].
+	registeredClasses isEmpty ifTrue: [ ^ aBlock value ].
+	^ (registeredClasses collect: [ :c | slotSources at: c ])
+]
+
+{ #category : #'registry access' }
+MetaLinkRegistry >> slotSourcesAt: aClass ifAbsentPut: aBlock [
+	^ slotSources at: aClass ifAbsentPut: aBlock
 ]
 
 { #category : #'registry access' }

--- a/src/Reflectivity/VariableBreakpoint.class.st
+++ b/src/Reflectivity/VariableBreakpoint.class.st
@@ -219,6 +219,12 @@ VariableBreakpoint >> removeFromClass: aClass [
 ]
 
 { #category : #removing }
+VariableBreakpoint >> removeFromMethod: aMethod [
+	(self link nodes select: [ :n | n methodNode method == aMethod ]) 
+		do: [ :n | self link removeNode: n ]
+]
+
+{ #category : #removing }
 VariableBreakpoint >> removeFromNodeProperty [
 	 self link nodes do: [ :n | n removeBreakpoint: self ]
 ]

--- a/src/Reflectivity/VariableBreakpoint.class.st
+++ b/src/Reflectivity/VariableBreakpoint.class.st
@@ -185,14 +185,40 @@ VariableBreakpoint >> isVariableBreakpoint [
 	^true
 ]
 
-{ #category : #install }
+{ #category : #removing }
 VariableBreakpoint >> remove [
 	super remove.
 	targetInstance := nil.
 	isInstalled := false
 ]
 
-{ #category : #install }
+{ #category : #removing }
+VariableBreakpoint >> removeFromClass: aClass [
+
+	"If we're targeting a temp var in a method,
+	then we got here because we detected that method belong to the class
+	passed as parameter. We need to uninstall."
+	self targetClassOrMethod isCompiledMethod ifTrue: [ 
+		self remove.
+		^ self ].
+
+	"If the removed class is the class we target or one of its superclasses,
+	then after that class is removed we have no reason to exist. We need to uninstall."
+	(self targetClassOrMethod = aClass or: [ 
+		 self targetClassOrMethod allSuperclasses includes: aClass ]) 
+		ifTrue: [ 
+			self remove.
+			^ self ].
+
+	"We removed a aClass, but it is not our target class nor one of its superclasses.
+	It is then one of its subclasses, we can continue to exist since the variable
+	we target still exist in the target class.
+	However, we need to remove the nodes of the removed class from our metalink"
+	(self link nodes select: [ :n | n methodNode methodClass == aClass ]) 
+		do: [ :n | self link removeNode: n ]
+]
+
+{ #category : #removing }
 VariableBreakpoint >> removeFromNodeProperty [
 	 self link nodes do: [ :n | n removeBreakpoint: self ]
 ]


### PR DESCRIPTION
Fixes #9517 

The bug prevented that we modify methods in the debugger that popped because of a variable breakpoint.
It required a fix in the Reflectivity core, and one in the Reflectivity tools.

The code around seems overly complicated, so a general redesign will be later required for some parts of Reflectivity (basically the object-centric and the permalink part).
