### PR TITLE
Modify Array storeString

### DIFF
--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -327,16 +327,18 @@ Array >> shouldBePrintedAsLiteral [
 ]
 
 { #category : #printing }
-Array >> storeOn: aStream [ 
+Array >> storeOn: aStream [
+
 	"Use the literal form if possible."
 
 	self shouldBePrintedAsLiteral
-		ifTrue: 
-			[aStream nextPut: $#; nextPut: $(.
-			self do: 
-				[:element | 
-				element storeOn: aStream.
-				aStream space].
-			aStream nextPut: $)]
-		ifFalse: [super storeOn: aStream]
+		ifTrue: [ 
+			aStream
+				nextPut: $#;
+				nextPut: $(.
+			self
+				do: [ :element | element storeOn: aStream ]
+				separatedBy: [ aStream space ].
+			aStream nextPut: $) ]
+		ifFalse: [ super storeOn: aStream ]
 ]


### PR DESCRIPTION
Hello

This PR introduces extremely few changes so I don't know if it's appropriate

Store strings of Arrays leave a space after the last element, I removed it by changing Array>>#storeOn:
`#(1 2) storeString` is now `'#(1 2)'` instead of `'#(1 2 )'`

This space causes a few test failures on code that is supposed to run on Gemstone/VisualWorks

