### PR TITLE
fixing-shortcut-reminder-in-osx

### DIFF
--- a/src/Morphic-Base/ShortcutReminder.class.st
+++ b/src/Morphic-Base/ShortcutReminder.class.st
@@ -76,8 +76,15 @@ ShortcutReminder >> backgroundColor: aColor [
 { #category : #'private - utilities' }
 ShortcutReminder >> createKeyTextMorph: aString [
 
+	| font |
+	font := ToggleWithSymbolMenuItemShortcut canBeUsed
+		ifTrue: [ ToggleWithSymbolMenuItemShortcut createSymbolFont 
+						pointSize: self pointSize * 2;
+						yourself ]
+		ifFalse: [ self keyTextFont ].
+
 	^(self fixKeyText: aString) asStringMorph 
-		font: self keyTextFont emphasis: 2;
+		font: font emphasis: 2;
 		color: textColor;
 		yourself. 
 ]
@@ -185,7 +192,8 @@ ShortcutReminder >> defaultTextColor [
 { #category : #'private - utilities' }
 ShortcutReminder >> fixKeyText: aString [
 
-	^ToggleMenuItemShortcut normalize: aString
+	^ (ToggleMenuItemShortcut owner: nil keyText: aString) text
+
 ]
 
 { #category : #'private - utilities' }


### PR DESCRIPTION
Fixing the shortcut reminder to use the same formatting than the menu Item