### PR TITLE
Fix typos in documentation and source comments within src/S* directories

### DIFF
--- a/src/STON-Core/STON.class.st
+++ b/src/STON-Core/STON.class.st
@@ -30,7 +30,7 @@ STON is more or less a superset of JSON and is backwards compatible with JSON wh
 
   - class information (except for lists (Array) and maps (Dictionary))
   - proper handling of shared and circular references
-  - more Smalltalk like syntax (Symbols with #, single qouted Strings, nil instead of null)
+  - more Smalltalk like syntax (Symbols with #, single quoted Strings, nil instead of null)
   - more defined special types (Date, Time, DataAndTime, ByteArray, Point)
 
 Parsing JSON is done using #fromString: or #fromStream: with the results being composed of Arrays and Dictionaries.
@@ -46,7 +46,7 @@ For a much more sophisticated JSON parser/writer implementation, have a look at 
 
 Like JSON, STON does not allow for comments. However, a preprocessor option can skip C style comments before parsing.
 
-I also define some contants used in the implementation: the class used as list, map and association, as well as the optional class name key (used when reading objects using an unknown class).
+I also define some constants used in the implementation: the class used as list, map and association, as well as the optional class name key (used when reading objects using an unknown class).
 
 
 I m p l e m e n t a t i o n

--- a/src/STON-Core/STONJSON.class.st
+++ b/src/STON-Core/STONJSON.class.st
@@ -5,7 +5,7 @@ STON is more or less a superset of JSON and is backwards compatible with JSON wh
 
   - class information (except for lists (Array) and maps (Dictionary))
   - proper handling of shared and circular references
-  - more Smalltalk like syntax (Symbols with #, single qouted Strings, nil instead of null)
+  - more Smalltalk like syntax (Symbols with #, single quoted Strings, nil instead of null)
   - more defined special types (Date, Time, DataAndTime, ByteArray, Point)
 
 Parsing JSON is done using

--- a/src/STON-Core/STONReader.class.st
+++ b/src/STON-Core/STONReader.class.st
@@ -71,7 +71,7 @@ STONReader >> consumeWhitespace [
 STONReader >> convertNewLines: boolean [
 	"When true, any newline CR, LF or CRLF read unescaped inside strings or symbols 
 	will be converted to the newline convention chosen, see #newLine:
-	The default is false, not doing any convertions."
+	The default is false, not doing any conversions."
 	
 	convertNewLines := boolean
 ]

--- a/src/STON-Tests/STONTestKnownObject.class.st
+++ b/src/STON-Tests/STONTestKnownObject.class.st
@@ -33,7 +33,7 @@ STONTestKnownObject class >> addKnownObject: object [
 
 { #category : #'instance creation' }
 STONTestKnownObject class >> fromId: idString [
-	"Given id, return a matching instance of me, either by returning an existing known instance or by creating a new one (that is automtically added to the known instances)"
+	"Given id, return a matching instance of me, either by returning an existing known instance or by creating a new one (that is automatically added to the known instances)"
 	
 	| uuid |
 	uuid := UUID fromString: idString.

--- a/src/SUnit-Core/ProcessMonitorTestService.class.st
+++ b/src/SUnit-Core/ProcessMonitorTestService.class.st
@@ -40,7 +40,7 @@ And to disable it use:
 
 	self executionProcessMonitor allowTestToLeaveProcesses.
 
-3) I can be completelly disabled globaly in settings (System/SUnit) or in test and setUp:
+3) I can be completely disabled globaly in settings (System/SUnit) or in test and setUp:
 
 	self executionProcessMonitor disable 
 	 
@@ -258,7 +258,7 @@ ProcessMonitorTestService >> ensureNoRunningProcesses [
 	"COMMENT FOR DEBUGGER STOPPED HERE:
 	TestLeftRunningProcess notifies that forked processes are still running when test completes.
 	Test failed because test left the system in dirty state.
-	Left runnning processes can affect the result of other tests 
+	Left running processes can affect the result of other tests 
 	and even the general system behavior after test run.
 	This protection can be disabled globaly in settings or in test method and setUp:
 		self executionProcessMonitor allowTestToLeaveProcesses

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -102,7 +102,7 @@ TestAsserter >> assert: aBooleanOrBlock description: aStringOrBlock [
 TestAsserter >> assert: aBooleanOrBlock description: aStringOrBlock resumable: resumableBoolean [
 	"Checks if aBooleanOrBlock evaluates to true (by sending #value message to it).
 	 The message text of the assertion failure exception thrown in case aBooleanOrBlock
-	 evaluates to false is determinated by the evaluation of aStringOrBlock (again by
+	 evaluates to false is determined by the evaluation of aStringOrBlock (again by
 	 sending #value message to it).
 	 The resumableBoolean flag is used to decide if the assertion failure signalled by
 	 the source code below should be resumable or not.
@@ -226,7 +226,7 @@ TestAsserter >> classForTestSuite [
 
 { #category : #private }
 TestAsserter >> comparingCollectionBetween: left and: right [
-	"Returns a string that shows the size if they are diferent and the aditional items for each left and right"
+	"Returns a string that shows the size if they are different and the additional items for each left and right"
 
 	| additionalLeft additionalRight sortBlock |
 	"use a very slow sort block"

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -464,7 +464,7 @@ TestCase class >> localCoverageForClass: cls [
 		self methods inject: Set new into: 
 							[:sums :cm | sums union: cm messages].
 					
-	"testedMethods contains all the methods send in test methods, which probably contains methods that have nothign to do with collection"
+	"testedMethods contains all the methods send in test methods, which probably contains methods that have nothing to do with collection"
 	testedMethods := testedMethods reject: [:sel | (definedMethods includes: sel) not].
 
 	untestedMethods := definedMethods select: [:selector | (testedMethods includes: selector) not].
@@ -629,7 +629,7 @@ TestCase class >> whichClassIncludesTestSelector: aSymbol [
 
 { #category : #dependencies }
 TestCase >> addDependentToHierachy: anObject [ 
-	"an empty method. for Composite compability with TestSuite"
+	"an empty method. for Composite compatibility with TestSuite"
 ]
 
 { #category : #events }
@@ -817,7 +817,7 @@ TestCase >> printTestSelectorOn: aStream [
 
 { #category : #dependencies }
 TestCase >> removeDependentFromHierachy: anObject [ 
-	"an empty method. for Composite compability with TestSuite"
+	"an empty method. for Composite compatibility with TestSuite"
 ]
 
 { #category : #accessing }

--- a/src/SUnit-Core/TestExecutionEnvironment.class.st
+++ b/src/SUnit-Core/TestExecutionEnvironment.class.st
@@ -47,7 +47,7 @@ Or with configuration block:
 	self executionEnvironment enableService: TestServiceExample using: [:service | ]
 	
 I lookup given service class in my registered services and use the found one if it exists. Otherwise I create and register new service instance with enabled state. 	
-At the end of test I disable services which were registered manually registed and which are disabled by default. So no other tests are affected by them.
+At the end of test I disable services which were registered manually registered and which are disabled by default. So no other tests are affected by them.
 	
 I provide handy method to access well known service ProcessMonitorTestService:
 

--- a/src/SUnit-Core/TestExecutionService.class.st
+++ b/src/SUnit-Core/TestExecutionService.class.st
@@ -16,7 +16,7 @@ All services must recover own default state in this method.
 For example every service can be enabled or disabled for concrete test: 
 
 	- enable 
-	- disble
+	- disable
 
 During #cleanUpAfterTest I restore the activeness according to my default configuration (class side #isEnabled). Subclasses should do the same with their own configurations.
 

--- a/src/SUnit-Core/TestLeftRunningProcess.class.st
+++ b/src/SUnit-Core/TestLeftRunningProcess.class.st
@@ -1,6 +1,6 @@
 "
 I notify users about dirty system state when test left running background processes. 
-The process left running after the test could affect the execution of other tests and generaly it could break the system when test suite is complete
+The process left running after the test could affect the execution of other tests and generally it could break the system when test suite is complete
 
 "
 Class {

--- a/src/SUnit-Core/TestSuiteEnded.class.st
+++ b/src/SUnit-Core/TestSuiteEnded.class.st
@@ -1,5 +1,5 @@
 "
-This announcment is thrown when a test suite just finished (more precisly when hisoties are updated)
+This announcement is thrown when a test suite just finished (more precisely when hisoties are updated)
 "
 Class {
 	#name : #TestSuiteEnded,

--- a/src/SUnit-Help/SUnitHelp.class.st
+++ b/src/SUnit-Help/SUnitHelp.class.st
@@ -33,7 +33,7 @@ SUnitHelp class >> links [
 	^HelpTopic
 		title: 'Links'
 		contents: 
-'Visit the following sites to get more informations on SUnit
+'Visit the following sites to get more information on SUnit
 
 - http://sunit.sourceforge.net/
 - http://www.iam.unibe.ch/~ducasse/Programmez/OnTheWeb/Eng-Art8-SUnit-V1.pdf

--- a/src/SUnit-Help/SUnitTutorial.class.st
+++ b/src/SUnit-Help/SUnitTutorial.class.st
@@ -37,7 +37,7 @@ So to create a test for the Person class we subclass TestCase with a custom "Per
 		poolDictionaries: ''''
 		category: ''MyApp-Tests-Model''
 
-Note that we havent created the class Person yet - so one idea of ExtremeProgramming (XP) is to write the test first as a way to describe a use case that your application has to cover. After that you write the code and the test will show you if the scenario is fullfilled. You dont have to follow this programming style and can also write tests to cover existing code.
+Note that we have not created the class Person yet - so one idea of ExtremeProgramming (XP) is to write the test first as a way to describe a use case that your application has to cover. After that you write the code and the test will show you if the scenario is fulfilled. You dont have to follow this programming style and can also write tests to cover existing code.
 	!' readStream nextChunkText
 ]
 
@@ -82,9 +82,9 @@ If you print the result then the following will appear:
 
       1 run, 0 passes, 0 skipped, 0 expected failures, 0 failures, 1 errors, 0 unexpected passes
 
-This tells us that one test has been run and one error occured while testing. Currently we dont have all messages implemented - so the test has to fail. 
+This tells us that one test has been run and one error occurred while testing. Currently we dont have all messages implemented - so the test has to fail. 
 
-If you want to debug the test to see whats happened you can evaluate:
+If you want to debug the test to see what has happened you can evaluate:
 
      PersonTest debug: #testInstanceCreation
 

--- a/src/SUnit-Tests/SimpleTestResource.class.st
+++ b/src/SUnit-Tests/SimpleTestResource.class.st
@@ -1,5 +1,5 @@
 "
-I'm a simple test ressource for test purposes
+I'm a simple test resource for test purposes
 "
 Class {
 	#name : #SimpleTestResource,

--- a/src/SUnit-Tests/SimpleTestResourceA.class.st
+++ b/src/SUnit-Tests/SimpleTestResourceA.class.st
@@ -1,5 +1,5 @@
 "
-I'm a simple test ressource for test purposes
+I'm a simple test resource for test purposes
 "
 Class {
 	#name : #SimpleTestResourceA,

--- a/src/SUnit-Tests/SimpleTestResourceA1.class.st
+++ b/src/SUnit-Tests/SimpleTestResourceA1.class.st
@@ -1,5 +1,5 @@
 "
-I'm a simple test ressource for test purposes
+I'm a simple test resource for test purposes
 "
 Class {
 	#name : #SimpleTestResourceA1,

--- a/src/SUnit-Tests/SimpleTestResourceA2.class.st
+++ b/src/SUnit-Tests/SimpleTestResourceA2.class.st
@@ -1,5 +1,5 @@
 "
-I'm a simple test ressource for test purposes
+I'm a simple test resource for test purposes
 "
 Class {
 	#name : #SimpleTestResourceA2,

--- a/src/SUnit-Tests/SimpleTestResourceB.class.st
+++ b/src/SUnit-Tests/SimpleTestResourceB.class.st
@@ -1,5 +1,5 @@
 "
-I'm a simple test ressource for test purposes
+I'm a simple test resource for test purposes
 "
 Class {
 	#name : #SimpleTestResourceB,

--- a/src/SUnit-Tests/SimpleTestResourceB1.class.st
+++ b/src/SUnit-Tests/SimpleTestResourceB1.class.st
@@ -1,5 +1,5 @@
 "
-I'm a simple test ressource for test purposes
+I'm a simple test resource for test purposes
 "
 Class {
 	#name : #SimpleTestResourceB1,

--- a/src/SUnit-Tests/SimpleTestResourceCircular.class.st
+++ b/src/SUnit-Tests/SimpleTestResourceCircular.class.st
@@ -1,5 +1,5 @@
 "
-I'm a simple test ressource for test purposes
+I'm a simple test resource for test purposes
 "
 Class {
 	#name : #SimpleTestResourceCircular,

--- a/src/SUnit-Tests/SimpleTestResourceCircular1.class.st
+++ b/src/SUnit-Tests/SimpleTestResourceCircular1.class.st
@@ -1,5 +1,5 @@
 "
-I'm a simple test ressource for test purposes
+I'm a simple test resource for test purposes
 "
 Class {
 	#name : #SimpleTestResourceCircular1,

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -5,7 +5,7 @@ The classes are nor installed or modifies other objects. That is part of the job
 I can be extended by using a different builder enhancer. 
 See ShDefaultBuilderEnhancer for a default implementation. 
 
-I can be used directly to create anonymous classes, but it is better if you use the annonymous class installer.
+I can be used directly to create anonymous classes, but it is better if you use the anonymous class installer.
 
 I also can compare the old class with the configured new class to calculate the required changes.
 "

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -11,7 +11,7 @@ Smalltalk classInstaller make: [ :aBuilder |
 			slots: #(varA varB);
 			category: 'My-Category' ].
 		
-See that I should never be referenced directly, only through the accesor 
+See that I should never be referenced directly, only through the accessor 
 in Smalltalk or in any class in the system. 
 
 The block passed is used to configure the builder. Check ShiftClassBuilder to see the available messages.
@@ -80,14 +80,14 @@ ShiftClassInstaller >> copyObject: oldObject to: newClass [
 		ifTrue: [ newClass basicNew: oldObject size ]
 		ifFalse: [ newClass basicNew ].
 
-	"first initalize all hidden slots"
+	"first initialize all hidden slots"
 	hiddenSlots := newClass classLayout allSlots reject: [:each | each isVisible].
 	hiddenSlots do: [ :newSlot | 
 			newSlot initialize: newObject.
 			oldObject class slotNamed: newSlot name ifFound: [ :oldSlot | 
 				newSlot write: (oldSlot read: oldObject) to: newObject ]  ].
 
-	"the initalize all visible slots"
+	"the initialize all visible slots"
 	newClass allSlots do: [ :newSlot | oldObject class slotNamed: newSlot name ifFound: [ :oldSlot | 
 			newSlot initialize: newObject.
 		   newSlot write: (oldSlot read: oldObject) to: newObject ] ].

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -402,7 +402,7 @@ SHRBTextStyler class >> settingsOn: aBuilder [
 		order: 1;
 		label: 'Format Incomplete Identifiers';
 		parentName: #'Syntax Highlighting';
-		description: 'If the code highlighter tryies to format incomplete identifiers and selectors or not. This is not recomended for big images, as it traverse all the image to get the information'
+		description: 'If the code highlighter tryies to format incomplete identifiers and selectors or not. This is not recommended for big images, as it traverse all the image to get the information'
 
 ]
 

--- a/src/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/src/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -695,7 +695,7 @@ SindarinDebuggerTest >> testStepOver [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod14 ].
 	scdbg step. "Enters the call of helperMethod14. Current node should be: a:=5"
-	scdbg stepOver. "After this, current node shoud be: '3' asInteger"
+	scdbg stepOver. "After this, current node should be: '3' asInteger"
 	scdbg stepOver. "After this, current node should be: Point x:5 y:'3' asInteger"
 	self assert: scdbg node isMessage.
 	self assert: scdbg node selector equals: #x:y:

--- a/src/Slot-Examples/AccessorInstanceVariableSlot.class.st
+++ b/src/Slot-Examples/AccessorInstanceVariableSlot.class.st
@@ -1,7 +1,7 @@
 "
 NOTE: this is an example of what can be done with Slots. It is *not* an example of what *should* be done with Slots.
 
-I am a slot that compiles accessor methods in the Class that it is installes in.
+I am a slot that compiles accessor methods in the Class that it is installed in.
 
 This example shows how Slots can change the class that they are part of.
 "

--- a/src/Slot-Examples/ExampleSlotWithState.class.st
+++ b/src/Slot-Examples/ExampleSlotWithState.class.st
@@ -4,7 +4,7 @@ I am a simple example for a Slot.
 Instead of mapping to a field, I store the value myself. This means that all instances share the
 slot, similar to a class variable.
 
-I just overide the methods for reflective read and write (#read and #write:to:), I do not bother to emit bytecode myself but rely on the fallback that the compiler will generate code for reflective read and write (see the emit* method of my superclass).
+I just override the methods for reflective read and write (#read and #write:to:), I do not bother to emit bytecode myself but rely on the fallback that the compiler will generate code for reflective read and write (see the emit* method of my superclass).
 
 Smalltalk classInstaller make: [ :builder |
 	builder name: #A;

--- a/src/Slot-Examples/WriteOnceSlot.class.st
+++ b/src/Slot-Examples/WriteOnceSlot.class.st
@@ -33,5 +33,5 @@ WriteOnceSlot >> write: aValue to: anObject [
 
 	^(self isWritten: anObject)
 		ifTrue: [ (super read: anObject) key: aValue value: false. aValue ]
-		ifFalse: [ self error: 'only one assigment allowed' ]
+		ifFalse: [ self error: 'only one assignment allowed' ]
 ]

--- a/src/Slot-Tests/SlotErrorsTest.class.st
+++ b/src/Slot-Tests/SlotErrorsTest.class.st
@@ -132,7 +132,7 @@ SlotErrorsTest >> testDangerousClassesEnabling [
 
 { #category : #tests }
 SlotErrorsTest >> testDirectCircularHierarchyError [
-	"Tests an error is raised when trying to create a heirarchy A<-A"
+	"Tests an error is raised when trying to create a hierarchy A<-A"
 	
 	| classA |
 	classA := self make: [ :builder |
@@ -150,7 +150,7 @@ SlotErrorsTest >> testDirectCircularHierarchyError [
 
 { #category : #tests }
 SlotErrorsTest >> testIndirectCircularHierarchyError [
-	"Tests an error is raised when trying to create a heirarchy A<-B<-A"
+	"Tests an error is raised when trying to create a hierarchy A<-B<-A"
 	
 	| classA classB |
 	classA := self make: [ :builder |

--- a/src/Slot-Tests/SlotIntegrationTest.class.st
+++ b/src/Slot-Tests/SlotIntegrationTest.class.st
@@ -1,5 +1,5 @@
 "
-I'm a test case of SlotClassBuilder integration in the system. Tipically, my tests assert over Class API.
+I'm a test case of SlotClassBuilder integration in the system. Typically, my tests assert over Class API.
 "
 Class {
 	#name : #SlotIntegrationTest,

--- a/src/Slot-Tests/SlotTraitsTest.class.st
+++ b/src/Slot-Tests/SlotTraitsTest.class.st
@@ -36,7 +36,7 @@ SlotTraitsTest >> testClassWithTrait [
 
 { #category : #tests }
 SlotTraitsTest >> testModifyClassTraitComposition [
-	"Tests that when modifing the trait composition on class-side, the old methods are removed from the method dictionary, and the new ones are added."
+	"Tests that when modifying the trait composition on class-side, the old methods are removed from the method dictionary, and the new ones are added."
 
 	self make: [ :builder | builder classTraitComposition: TOne ].
 

--- a/src/SortFunctions-Core/BlockClosure.extension.st
+++ b/src/SortFunctions-Core/BlockClosure.extension.st
@@ -7,7 +7,7 @@ BlockClosure >> asSortFunction [
 	self numArgs = 1 ifTrue: [^PropertySortFunction property: self].
 	self numArgs = 2 ifTrue: [^CollatorBlockFunction usingBlock: self].
 
-	self error: 'Cant be converted to sort function. It should has one or two args'	
+	self error: 'Can not be converted to sort function. It should have one or two args'	
 ]
 
 { #category : #'*SortFunctions-Core-converting' }
@@ -22,7 +22,7 @@ BlockClosure >> collatedBy: aSortFunction [
 	"Return a SortFunction around the receiver. If the receiver is a 2 arg block, it is assumed it will do the collation directly itself, returning -1, 0, or 1. If the receiver is a one arg block, it will be evaluated for each a and b and of the sort input, and the result of using aSortFunction on those will be used"
 	
 	self numArgs = 1 ifTrue: [^PropertySortFunction property: self collatedWith: aSortFunction asSortFunction].
-	self error: 'Cant be converted to sort function. It should hava one arg'	
+	self error: 'Can not be converted to sort function. It should have one arg'	
 ]
 
 { #category : #'*SortFunctions-Core-converting' }

--- a/src/SortFunctions-Core/DefaultSortFunction.class.st
+++ b/src/SortFunctions-Core/DefaultSortFunction.class.st
@@ -2,7 +2,7 @@
 A DefaultSortFunction is a collator using the default threeWayCompareTo: operator.
 It is known to work on String and Magnitude.
 
-It is generally not usefull to create a new instance, and the recommended pattern is to use the single instance available by sending the message  SortFunction default .
+It is generally not useful to create a new instance, and the recommended pattern is to use the single instance available by sending the message  SortFunction default .
 
 For other objects  that don't understand threeWayCompareTo: it is necessary to use a custom SortFunction rather than the default one.
 "

--- a/src/SortFunctions-Core/UndefinedSortFunction.class.st
+++ b/src/SortFunctions-Core/UndefinedSortFunction.class.st
@@ -1,5 +1,5 @@
 "
-An  UndefinedSortFunction is a specialization usefull for sorting undefined objects (nil), either first or last according to direction.
+An  UndefinedSortFunction is a specialization useful for sorting undefined objects (nil), either first or last according to direction.
 The non nil objects are sorted according to the baseSortFunction defined in superclass.
 
 instance variables:

--- a/src/SortFunctions-Tests/ThreeWayComparisonTest.class.st
+++ b/src/SortFunctions-Tests/ThreeWayComparisonTest.class.st
@@ -1,5 +1,5 @@
 "
-Unit test for three way comparision
+Unit test for three way comparison
 "
 Class {
 	#name : #ThreeWayComparisonTest,

--- a/src/Spec-Core/AbstractFormButtonPresenter.class.st
+++ b/src/Spec-Core/AbstractFormButtonPresenter.class.st
@@ -5,7 +5,7 @@ See AbstractWidgetPresenter
 self example
 
 I provide the following variables and their accessors
-- activationAction and desactivationAction are actions to perform when I am activeted / desactivated.
+- activationAction and desactivationAction are actions to perform when I am activated / deactivated.
 - label is the text displayed near the box.
 - state is a boolean representing if I am activated, it is false by default
 
@@ -127,7 +127,7 @@ AbstractFormButtonPresenter >> state: aBoolean [
 { #category : #api }
 AbstractFormButtonPresenter >> toggleState [
 	"<api: #do>"
-	"Toogle the current state of the checkbox"
+	"Toggle the current state of the checkbox"
 
 	self state: self state not
 ]

--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -59,7 +59,7 @@ Instantiation
 
 The instantiation of a subwidget should use one of that way
 - instantiate: take a class in parameter and return the created instance.
-- methods named 'new' followed by a widget name are shortcut working with instatiate:
+- methods named 'new' followed by a widget name are shortcut working with instantiate:
 
 Usually, the subwidgets must be added in the focusOrder using something like 'self focusOrder add: accessor of  the  subwidget'
 
@@ -72,7 +72,7 @@ Methods named 'when' followed by an event provide hook to perform the action in 
 Note
 -------
 Be careful about code order if you are overriding initialize method.
-Normally in Spec initializing instance variables should be done BEFORE calling super initialize (so the opposite of the normal approach), because super initialize calls initalizeWidgets and initializePresenter that normally would make use of those variables.
+Normally in Spec initializing instance variables should be done BEFORE calling super initialize (so the opposite of the normal approach), because super initialize calls initializeWidgets and initializePresenter that normally would make use of those variables.
 
 Layout
 ======
@@ -80,7 +80,7 @@ Layout
 See SpecLayout
 
 defaultSpec or a method containing the pragma <spec: #default> must be defined in the class side of my subclasses.
-It contains informations about how place its elements.
+It contains information about how place its elements.
 It possible to define more than one method to give the possibility to use another layout, by default the one containing the pragma will be used if it exists, if not defaultSpec will be used.
 "
 Class {
@@ -346,7 +346,7 @@ ComposablePresenter >> centeredRelativeTo: aModel [
 
 { #category : #'instance creation' }
 ComposablePresenter >> createInstanceFor: aClassSymbol [
-	"Retrieve the class corresponding to aClassSymbol using the bindings, then create a new instance of theis class"
+	"Retrieve the class corresponding to aClassSymbol using the bindings, then create a new instance of this class"
 	| class |
 	
 	class := self resolveSymbol: aClassSymbol.

--- a/src/Spec-Core/DiffPresenter.class.st
+++ b/src/Spec-Core/DiffPresenter.class.st
@@ -1,7 +1,7 @@
 "
 I am a Spec widget useful for visualising differences between two strings.
 
-When a classContext: is setted, the strings are highlighted using such contextual information.
+When a classContext: is set, the strings are highlighted using such contextual information.
 
 Examples:
 

--- a/src/Spec-Core/FTArrayIndexColumn.class.st
+++ b/src/Spec-Core/FTArrayIndexColumn.class.st
@@ -42,7 +42,7 @@ FTArrayIndexColumn class >> index: aNumber width: aNumber2 [
 
 { #category : #accessing }
 FTArrayIndexColumn class >> undefinedColumnWidth [
-	"This is a contant that defines a column width is undefined, then the layout will try to arrange 
+	"This is a constant that defines a column width is undefined, then the layout will try to arrange 
 	 it by itself."
 	^ 0
 ]

--- a/src/Spec-Core/SliderPresenter.class.st
+++ b/src/Spec-Core/SliderPresenter.class.st
@@ -135,7 +135,7 @@ SliderPresenter >> label: aString [
 { #category : #api }
 SliderPresenter >> max [
 	"<api: #inspect>"
-	"Return the maximun value"
+	"Return the maximum value"
 	
 	^ max value
 ]
@@ -143,7 +143,7 @@ SliderPresenter >> max [
 { #category : #api }
 SliderPresenter >> max: anObject [
 	"<api: #integer min: 1 max: 100 getter:#max registration: #whenMaxChanged:>"
-	"Set the maximun value"
+	"Set the maximum value"
 
 	max value: anObject
 ]
@@ -167,7 +167,7 @@ SliderPresenter >> min: anObject [
 { #category : #api }
 SliderPresenter >> quantum [
 	"<api: #inspect>"
-	"Return the quantum betwen values"
+	"Return the quantum between values"
 
 	^ quantum value
 ]
@@ -175,7 +175,7 @@ SliderPresenter >> quantum [
 { #category : #api }
 SliderPresenter >> quantum: aNumber [
 	"<api: #integer min: #min max: #max getter:#quantum registration: #whenQuantumChanged:>"
-	"Set the quantum betwen values"
+	"Set the quantum between values"
 
 	quantum value: aNumber
 ]

--- a/src/Spec-Core/SpecFTColumn.class.st
+++ b/src/Spec-Core/SpecFTColumn.class.st
@@ -20,7 +20,7 @@ SpecFTColumn class >> id: anObject [
 
 { #category : #accessing }
 SpecFTColumn class >> undefinedColumnWidth [
-	"This is a contant that defines a column width is undefined, then the layout will try to arrange 
+	"This is a constant that defines a column width is undefined, then the layout will try to arrange 
 	 it by itself."
 	^ 0
 ]

--- a/src/Spec-Core/TreePresenter.class.st
+++ b/src/Spec-Core/TreePresenter.class.st
@@ -307,7 +307,7 @@ TreePresenter >> deselectAll [
 TreePresenter >> displayBlock [
 	"< api: #inspect>"
 	"Return the block used to generate the display of the items.
-	The optioanl block arguments are:
+	The optional block arguments are:
 		- the item
 		- the tree"
 
@@ -318,7 +318,7 @@ TreePresenter >> displayBlock [
 TreePresenter >> displayBlock: aBlock [
 	"<api: #block getter: #displayBlock registration: #whenDisplayBlockChanged:>"
 	"Set the block used to generate the display of the items.
-	The optioanl block arguments are:
+	The optional block arguments are:
 		- the item
 		- the tree"
 

--- a/src/Spec-Examples/OpenOnNilExample.class.st
+++ b/src/Spec-Examples/OpenOnNilExample.class.st
@@ -3,7 +3,7 @@ I am the component of DynamycSpecExample used for nil.
 
 self example
 
-I display simply an TextInputFieldPresenter, disable to don't be edditable by the user.
+I display simply an TextInputFieldPresenter, disable to not be editable by the user.
 "
 Class {
 	#name : #OpenOnNilExample,

--- a/src/Spec-MorphicAdapters/AbstractMorphicAdapter.class.st
+++ b/src/Spec-MorphicAdapters/AbstractMorphicAdapter.class.st
@@ -1,5 +1,5 @@
 "
-I am an abstract class providing all the properties shared amongs all the morphic specific adapters
+I am an abstract class providing all the properties shared amongst all the morphic specific adapters
 "
 Class {
 	#name : #AbstractMorphicAdapter,

--- a/src/Spec-MorphicAdapters/MorphicDiffAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicDiffAdapter.class.st
@@ -1,5 +1,5 @@
 "
-I am an adpater to bridge a DiffPresenter and a DiffMorph
+I am an adapter to bridge a DiffPresenter and a DiffMorph
 "
 Class {
 	#name : #MorphicDiffAdapter,

--- a/src/Spec-MorphicAdapters/MorphicMenuGroupAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicMenuGroupAdapter.class.st
@@ -1,6 +1,6 @@
 "
 I am used to compute a MenuGroupPresenter.
-There is not Morphic represenation of a MenuGroup, that is why I do not have a coresponding morph.
+There is not Morphic representation of a MenuGroup, that is why I do not have a coresponding morph.
 "
 Class {
 	#name : #MorphicMenuGroupAdapter,

--- a/src/Spec-MorphicAdapters/MorphicTabManagerAdapter.class.st
+++ b/src/Spec-MorphicAdapters/MorphicTabManagerAdapter.class.st
@@ -1,5 +1,5 @@
 "
-I am the adpater used to bridge a TabManagerPresenter and a TabManager
+I am the adapter used to bridge a TabManagerPresenter and a TabManager
 "
 Class {
 	#name : #MorphicTabManagerAdapter,

--- a/src/Spec-PolyWidgets/DatePresenter.class.st
+++ b/src/Spec-PolyWidgets/DatePresenter.class.st
@@ -106,7 +106,7 @@ DatePresenter >> displayBlock [
 { #category : #api }
 DatePresenter >> displayBlock: aBlock [
 	"<api: #block getter:#displayBlock registration: #whenDisplayBlockChanged:>"
-	"Set the one argument block used to transfrom your date into a string"
+	"Set the one argument block used to transform your date into a string"
 	
 	displayBlockHolder value: aBlock
 ]

--- a/src/Spec-PolyWidgets/EditableList.class.st
+++ b/src/Spec-PolyWidgets/EditableList.class.st
@@ -3,7 +3,7 @@ This widget allows you to edit a list of items :
 - add / remove an item to/from the list 
 - order the list by moving elements up/down/top/bottom.
 
-The default behavior is to do a copy of the list. The widget works with its internal copy. It allows the user to accept / reject changes (for example by opening the widget in a DialogWindow) before affecting the original list. It is your responsability to copy EditableList items back to the original list.
+The default behavior is to do a copy of the list. The widget works with its internal copy. It allows the user to accept / reject changes (for example by opening the widget in a DialogWindow) before affecting the original list. It is your responsibility to copy EditableList items back to the original list.
 
 The addItemBlock is used to provide a way to give the item to add (e.g. a UIManager default chooseFrom: values:).
 

--- a/src/Spec-StubAdapter/SpecStubAbstractAdapter.class.st
+++ b/src/Spec-StubAdapter/SpecStubAbstractAdapter.class.st
@@ -1,5 +1,5 @@
 "
-I am an abstract class providing all the properties shared amongs all the stub adapters. They do not produce real views, only stub objects.
+I am an abstract class providing all the properties shared amongst all the stub adapters. They do not produce real views, only stub objects.
 
 "
 Class {

--- a/src/Spec-StubAdapter/SpecStubAdapterBindings.class.st
+++ b/src/Spec-StubAdapter/SpecStubAdapterBindings.class.st
@@ -1,7 +1,7 @@
 "
 I am used to link the Spec presenter names to the stub adapters that generate no real views.
 
-Usefull  for images or UI managers without possible real UI output or  for tests. Can serve as template for real Spec adapters
+Useful  for images or UI managers without possible real UI output or  for tests. Can serve as template for real Spec adapters
 
 Usage:
 

--- a/src/StartupPreferences/StartupPreferencesHandler.class.st
+++ b/src/StartupPreferences/StartupPreferencesHandler.class.st
@@ -1,5 +1,5 @@
 "
-I manage the links of the chain of responsibilites to retrieve the good preference file.
+I manage the links of the chain of responsibilities to retrieve the good preference file.
 "
 Class {
 	#name : #StartupPreferencesHandler,

--- a/src/System-Announcements/CategoryAdded.class.st
+++ b/src/System-Announcements/CategoryAdded.class.st
@@ -1,5 +1,5 @@
 "
-This announcement will be emited when adding a category using:
+This announcement will be emitted when adding a category using:
 => SystemOrganizer >> addCategory:
 "
 Class {

--- a/src/System-Announcements/CategoryRemoved.class.st
+++ b/src/System-Announcements/CategoryRemoved.class.st
@@ -1,5 +1,5 @@
 "
-This announcement will be emited when removing a category using:
+This announcement will be emitted when removing a category using:
 => SystemOrganizer >> removeCategory:
 "
 Class {

--- a/src/System-Announcements/CategoryRenamed.class.st
+++ b/src/System-Announcements/CategoryRenamed.class.st
@@ -1,5 +1,5 @@
 "
-This announcement will be emited when renaming a category using:
+This announcement will be emitted when renaming a category using:
 => SystemOrganizer >> renameCategory:toBe:
 "
 Class {

--- a/src/System-Announcements/ClassRemoved.class.st
+++ b/src/System-Announcements/ClassRemoved.class.st
@@ -1,5 +1,5 @@
 "
-the annoucement will be emitted when removing a class or a trait using:  
+the announcement will be emitted when removing a class or a trait using:  
 	=> removeFromSystem
 "
 Class {

--- a/src/System-Announcements/ClassRenamed.class.st
+++ b/src/System-Announcements/ClassRenamed.class.st
@@ -1,5 +1,5 @@
 "
-the annoucement will be emitted when renaming a class or a trait using:  
+the announcement will be emitted when renaming a class or a trait using:  
 	=> RenameClassRefactoring >> rename:to:
 	=> class>>rename:
 The corresponding event is raised in: SystemDictionary>>renameClass:from:to:

--- a/src/System-Announcements/MethodAdded.class.st
+++ b/src/System-Announcements/MethodAdded.class.st
@@ -1,5 +1,5 @@
 "
-This announcement is emited when we add a method to a class or a trait using:
+This announcement is emitted when we add a method to a class or a trait using:
 	=> Behavior >> compile: or TraitBehavior >> compile:
 "
 Class {

--- a/src/System-Announcements/MethodModified.class.st
+++ b/src/System-Announcements/MethodModified.class.st
@@ -1,5 +1,5 @@
 "
-This announcement is emited when we RE-compile a method in a class or a trait, with: ClassDescription >> compile: or TraitDescription >> compile:. If the method is not yet registered in the class or the trait, the announcement will not be emitted.
+This announcement is emitted when we RE-compile a method in a class or a trait, with: ClassDescription >> compile: or TraitDescription >> compile:. If the method is not yet registered in the class or the trait, the announcement will not be emitted.
 
 The action of renaming a method will be handled by SystemMethodRemovedAnnouncement and SystemMethodAddedAnnouncement, since this refactoring is concretely composed by removing the old method and add a new with the new name  
 "

--- a/src/System-BasicCommandLineHandler-Tests/STCommandLineHandlerTest.class.st
+++ b/src/System-BasicCommandLineHandler-Tests/STCommandLineHandlerTest.class.st
@@ -15,7 +15,7 @@ STCommandLineHandlerTest >> testCommandLineHandlerCondition [
 	| commandLine reference |
 	
 	commandLine := CommandLineArguments withArguments: {'/non/existing/file.st'}. 
-	"the reponsibility is transfered tot the BasicCodeLoader as soon as there is a .st file in the arguments"
+	"the responsibility is transferred to the BasicCodeLoader as soon as there is a .st file in the arguments"
 	self assert: (STCommandLineHandler isResponsibleFor: commandLine).
 		
 	[ reference := FileSystem disk workingDirectory / 'codeLoad1.st'.

--- a/src/System-BasicCommandLineHandler/BasicCommandLineHandler.class.st
+++ b/src/System-BasicCommandLineHandler/BasicCommandLineHandler.class.st
@@ -8,7 +8,7 @@ I also implement a way to password-protect command lines.
 
 The password will not be saved as in clear. It will be hash using pepper and iterations.
 
-The pepper of a hash is a fix string happened to a password to increase the difficulty of finding the password. Also, we hash multiple times (iterations) to increase the strenght of the protection.
+The pepper of a hash is a fix string happened to a password to increase the difficulty of finding the password. Also, we hash multiple times (iterations) to increase the strength of the protection.
 
 If you wish to define ""application"" command lines who do not need a password protection, implement the method #requirePasswordInDeployment on the class side to return false.
 
@@ -74,7 +74,7 @@ BasicCommandLineHandler class >> priority [
 
 { #category : #'system startup' }
 BasicCommandLineHandler class >> startUp: isImageStarting [
-	"only handle when lauching a new image"
+	"only handle when launching a new image"
 	isImageStarting ifFalse: [ ^ self ].
 
 	Smalltalk session 
@@ -100,7 +100,7 @@ BasicCommandLineHandler >> activate [
 BasicCommandLineHandler >> activateSubCommand: aCommandLinehandler [
 	[ aCommandLinehandler activateWith: commandLine ] on: Exit do: [ :exit |
 		^ self handleExit: exit for: aCommandLinehandler ].
-	"the return value of this method is used to check if the subcommand was successfull"
+	"the return value of this method is used to check if the subcommand was successful"
 	^ aCommandLinehandler
 ]
 

--- a/src/System-BasicCommandLineHandler/CommandLineHandler.class.st
+++ b/src/System-BasicCommandLineHandler/CommandLineHandler.class.st
@@ -13,7 +13,7 @@ A handler may provide a short name with the class-side #commandName method. If t
 	
 For more sophisticated handler selection the CommandLineHandler should implement the #isResponsibleFor: class-side method. An instance of the current command line options is passed to this method which should then return a boolean.
 
-Between all the responsible handlers the one with the highes #priority is chosen. To change the priority overwrite the class-side accessor.
+Between all the responsible handlers the one with the highest #priority is chosen. To change the priority overwrite the class-side accessor.
 
 "
 Class {

--- a/src/System-BasicCommandLineHandler/CommandLinePasswordManager.class.st
+++ b/src/System-BasicCommandLineHandler/CommandLinePasswordManager.class.st
@@ -65,14 +65,14 @@ CommandLinePasswordManager class >> exampleRemovePasswordProtection [
 
 { #category : #public }
 CommandLinePasswordManager class >> protectCommandLinesByPasswordWith: aString [
-	"This method enables the password protection of command line. All command lines returning true to #requireDeploymentPassword ask a password to be executed. This is usefull in deployment mode of private applications."
+	"This method enables the password protection of command line. All command lines returning true to #requireDeploymentPassword ask a password to be executed. This is useful in deployment mode of private applications."
 	
 	self protectCommandLinesByPasswordWith: aString pepper: nil numberOfHashIterations: nil
 ]
 
 { #category : #public }
 CommandLinePasswordManager class >> protectCommandLinesByPasswordWith: aString pepper: anotherString [
-	"This method enables the password protection of command line. All command lines returning true to #requireDeploymentPassword ask a password to be executed. This is usefull in deployment mode of private applications.
+	"This method enables the password protection of command line. All command lines returning true to #requireDeploymentPassword ask a password to be executed. This is useful in deployment mode of private applications.
 		This method accepts a custom pepper for the password hashing. See https://en.wikipedia.org/wiki/Pepper_(cryptography) for more information."
 
 	self protectCommandLinesByPasswordWith: aString pepper: anotherString numberOfHashIterations: nil
@@ -80,7 +80,7 @@ CommandLinePasswordManager class >> protectCommandLinesByPasswordWith: aString p
 
 { #category : #public }
 CommandLinePasswordManager class >> protectCommandLinesByPasswordWith: aString pepper: anotherString numberOfHashIterations: aNumber [
-	"This method enables the password protection of command line. All command lines returning true to #requireDeploymentPassword ask a password to be executed. This is usefull in deployment mode of private applications.
+	"This method enables the password protection of command line. All command lines returning true to #requireDeploymentPassword ask a password to be executed. This is useful in deployment mode of private applications.
 	This method accepts a custom pepper for the password hashing. See https://en.wikipedia.org/wiki/Pepper_(cryptography) for more information.
 	This method also allows to specify a custom number of hash iterations."
 
@@ -155,7 +155,7 @@ CommandLinePasswordManager >> passwordHash: aString [
 
 { #category : #public }
 CommandLinePasswordManager >> protectCommandLinesByPasswordWith: aString pepper: anotherString numberOfHashIterations: aNumber [
-	"This method enables the password protection of command line. All command lines returning true to #requireDeploymentPassword ask a password to be executed. This is usefull in deployment mode of private applications.
+	"This method enables the password protection of command line. All command lines returning true to #requireDeploymentPassword ask a password to be executed. This is useful in deployment mode of private applications.
 	This method accepts a custom pepper for the password hashing. See https://en.wikipedia.org/wiki/Pepper_(cryptography) for more information.
 	This method also allows to specify a custom number of hash iterations."
 	

--- a/src/System-BasicCommandLineHandler/PrintVersionCommandLineHandler.class.st
+++ b/src/System-BasicCommandLineHandler/PrintVersionCommandLineHandler.class.st
@@ -1,7 +1,7 @@
 "
 Usage: printVersion [ --numeric | --release ]
 	--numeric   Print the full version number only (e.g. 12345)
-	--release   Print the major relase number only (e.g. 1.2)
+	--release   Print the major release number only (e.g. 1.2)
 	
 Documentation:
 Prints the version number in an easy to parse format. This can be used in Jenkins with the ""Description Setter"" Plugin. Configure it like this:

--- a/src/System-Caching/AbstractCache.class.st
+++ b/src/System-Caching/AbstractCache.class.st
@@ -12,7 +12,7 @@ The default #computeWeight returns 1 for each value, effectively counting the nu
 
 I count hits and misses and can return my #hitRatio.
 
-Optionally, but not by default, I can be configured so that it is safe to access me from different threads/processess during my important operations. See #beThreadSafe.
+Optionally, but not by default, I can be configured so that it is safe to access me from different threads/processes during my important operations. See #beThreadSafe.
 "
 Class {
 	#name : #AbstractCache,

--- a/src/System-Clipboard/Clipboard.class.st
+++ b/src/System-Clipboard/Clipboard.class.st
@@ -52,7 +52,7 @@ Clipboard class >> shutDown: isImageQuitting [
 
 { #category : #'system startup' }
 Clipboard class >> startUp: isImageStarting [
-	"Pharo is starting up. If this platform requires specific intialization, this is a great place to put it."
+	"Pharo is starting up. If this platform requires specific initialization, this is a great place to put it."
 	isImageStarting
 		ifTrue: [Default := nil]
 ]

--- a/src/System-CommandLine/TermInfoCharacter.class.st
+++ b/src/System-CommandLine/TermInfoCharacter.class.st
@@ -1,6 +1,6 @@
 "
 I'm a TermCap which define the styles with the printing of characters, used when OSSubProcess is not installed in the image.
-Not really powerfull, better install OSSubProcess and use TermCapTput
+Not really powerful, better install OSSubProcess and use TermCapTput
 "
 Class {
 	#name : #TermInfoCharacter,
@@ -13,7 +13,7 @@ Class {
 
 { #category : #'term style' }
 TermInfoCharacter >> on: aStream [
-	"Define the stream where termcap will change the style, normaly it's used on a terminal"
+	"Define the stream where termcap will change the style, normally it's used on a terminal"
 
 	out := aStream
 ]

--- a/src/System-CommandLine/VTermOutputDriver2.class.st
+++ b/src/System-CommandLine/VTermOutputDriver2.class.st
@@ -639,7 +639,7 @@ VTermOutputDriver2 >> reset [
 
 { #category : #reset }
 VTermOutputDriver2 >> resetStyle [
-	"Reset the style by creating a new VTermOutputStyle and reseting the terminal to default config"
+	"Reset the style by creating a new VTermOutputStyle and resetting the terminal to default config"
 
 	style := VTermOutputStyle new.
 	installedStyle := style copy.

--- a/src/System-FileRegistry/SimpleServiceEntry.class.st
+++ b/src/System-FileRegistry/SimpleServiceEntry.class.st
@@ -7,7 +7,7 @@ selector : to do the service
 useLineAfter
 stateSelector : a secondary selector (to be able to query state of the provider for example)
 description : a description for balloon for example
-argumentGetter : a selector to get additional arguments with (if selector requres them)
+argumentGetter : a selector to get additional arguments with (if selector requires them)
 buttonLabel : a short label
 
 The entire client interface (provided by FileList and other users of the registry)

--- a/src/System-Finalization/EphemeronRegistry.class.st
+++ b/src/System-Finalization/EphemeronRegistry.class.st
@@ -11,7 +11,7 @@ An ephemeron registry can be simply used by instantiating it and putting objects
 registry := EphemeronRegistry new.
 registry at: objectThatMayBeCollected put: somePropertyThatWouldBeHoldWeaklyDependingOnTheKey.
 
-Notice that the key is the object that is important from the finalization point of view. As soon as the key is only rechable by the ephemeron registry, two things will happen:
+Notice that the key is the object that is important from the finalization point of view. As soon as the key is only reachable by the ephemeron registry, two things will happen:
 
 - The key will be sent #finalize, giving the user the opportunity to override the hook and provide an application specific finalization
 - They registry will forget the ephemeron. If the value of the ephemeron is only referenced by this ephemeron it will then be collected.

--- a/src/System-Finalization/WeakArray.extension.st
+++ b/src/System-Finalization/WeakArray.extension.st
@@ -15,12 +15,12 @@ WeakArray class >> finalizationProcess [
 	"The finalization process arranges to send mourn to each element of the VM's finalization queue,
 	 which is accessed via primitiveFetchMourner.  The VM signals FinalizationSemaphore whenever
 	 the queue is non-empty.  This process loops, waiting on the semaphore, fetches the first element
-	 of the queue and then spawns a process at a higher priority to acually send the mourn messages.
+	 of the queue and then spawns a process at a higher priority to actually send the mourn messages.
 	 If an error occurs in the higher priority mourn loop process then this process will simply spawn
 	 another process, hence ensuring that errors in finalization methods don't break finalization.
 
 	 In addition this process also runs the old finalization scheme, supporting clients of the older,
-	 WeakRegistry based scheme.  Hopefully this will go away when all cleints have moved over."
+	 WeakRegistry based scheme.  Hopefully this will go away when all clients have moved over."
 	| throttle firstMourner |
 	throttle := Semaphore new.
 	[true] whileTrue: [FinalizationSemaphore wait; initSignals.
@@ -36,7 +36,7 @@ WeakArray class >> finalizationProcess [
 { #category : #'*System-Finalization' }
 WeakArray class >> mournLoopWith: firstMourner [
 	"Send mourn to all the objects available in the mourn queue, starting
-	 with firstMourner which the sender has already extraced for us.  If
+	 with firstMourner which the sender has already extracted for us.  If
 	 an error occurs here, it will break this loop but the sender will spawn
 	 another mournLoopWith: so that finalization is not broken by errors in
 	 individual cases."

--- a/src/System-Hashing/Checksum.class.st
+++ b/src/System-Hashing/Checksum.class.st
@@ -1,5 +1,5 @@
 "
-I represent the abstact superclass of all checksum algorithms.
+I represent the abstract superclass of all checksum algorithms.
 "
 Class {
 	#name : #Checksum,

--- a/src/System-Hashing/DigitalSignatureAlgorithm.class.st
+++ b/src/System-Hashing/DigitalSignatureAlgorithm.class.st
@@ -482,7 +482,7 @@ DigitalSignatureAlgorithm >> stringToSignature: aString [
 
 		 '[DSA digital signature <r> <s>]'
 
-	where <r> and <s> are large positive integers represented by strings of hexidecimal digits."
+	where <r> and <s> are large positive integers represented by strings of hexadecimal digits."
 	| prefix stream r s |
 	prefix := '[DSA digital signature '.
 	(aString beginsWith: prefix) ifFalse: [ self error: 'bad signature prefix' ].

--- a/src/System-Hashing/SHA256.class.st
+++ b/src/System-Hashing/SHA256.class.st
@@ -19,7 +19,7 @@ Copied from CFSHA256 (Cloudfront)
 
 Please direct questions or comments about this implementation to Ron Teitelbaum: Ron@USMedRec.com
 
-This code was extensively coppied from SHA1 by Luciano Notarfrancesco lnotarfrancesco@yahoo.com
+This code was extensively copied from SHA1 by Luciano Notarfrancesco lnotarfrancesco@yahoo.com
 "
 Class {
 	#name : #SHA256,

--- a/src/System-Identification-Tests/GlobalIdentifierPersistenceMockChecker.class.st
+++ b/src/System-Identification-Tests/GlobalIdentifierPersistenceMockChecker.class.st
@@ -1,5 +1,5 @@
 "
-I am a MOCK equivalent for GlobalIdentifierPersistenceChecker, userful for testing behavior.
+I am a MOCK equivalent for GlobalIdentifierPersistenceChecker, useful for testing behavior.
 "
 Class {
 	#name : #GlobalIdentifierPersistenceMockChecker,

--- a/src/System-Identification-Tests/GlobalIdentifierTest.class.st
+++ b/src/System-Identification-Tests/GlobalIdentifierTest.class.st
@@ -81,7 +81,7 @@ GlobalIdentifierTest >> testBackwardCompatibility [
 { #category : #tests }
 GlobalIdentifierTest >> testBackwardCompatibility2 [
 	"Let's say that we have information stored using both FUEL and STON, and we use STON.
-	We will ingnore FUEL file and load STON."
+	We will ignore FUEL file and load STON."
 
 	| fuelPersistence fuelPrefereces fuelDictionary stonDictionary |
 	fuelPersistence := GlobalIdentifierPersistence fuel.

--- a/src/System-OSEnvironments/OSEnvironment.class.st
+++ b/src/System-OSEnvironments/OSEnvironment.class.st
@@ -11,7 +11,7 @@ In other words, methods
 - #at:
 - #at:put:
 
-and its variants receive normal strings and decide wether they have to encode those strings to platform bytes or not depending on the platform.
+and its variants receive normal strings and decide whether they have to encode those strings to platform bytes or not depending on the platform.
 
 My subclasses may or may not provide additional APIs to have more control on the particular encoding used.
 "
@@ -107,7 +107,7 @@ OSEnvironment >> associationsDo: aBlock [
 OSEnvironment >> at: aKey [
 	"Gets the value of an environment variable called `aKey`.
 	Throws a KeyNotFound exception if not found.
-	It is the system reponsibility to manage the encodings of the argument and return values.
+	It is the system responsibility to manage the encodings of the argument and return values.
 	
 	This is the common denominator API for all platforms.
 	Rationale: Windows does not (compared to *nix systems) provide a encoded byte representation of the value. Windows has instead its own wide string representation."
@@ -119,7 +119,7 @@ OSEnvironment >> at: aKey [
 OSEnvironment >> at: aKey ifAbsent: aBlock [
 	"Gets the value of an environment variable called `aKey`.
 	Execute aBlock if absent.
-	It is the system reponsibility to manage the encodings of the argument and return values.
+	It is the system responsibility to manage the encodings of the argument and return values.
 	
 	This is the common denominator API for all platforms.
 	Rationale: Windows does not (compared to *nix systems) provide a encoded byte representation of the value. Windows has instead its own wide string representation."
@@ -131,7 +131,7 @@ OSEnvironment >> at: aKey ifAbsent: aBlock [
 OSEnvironment >> at: aKey ifAbsentPut: aBlock [ 
 	"Gets the value of an environment variable called `aKey`.
 	If absent, insert the value given by aBlock.
-	It is the system reponsibility to manage the encodings of the argument and return values.
+	It is the system responsibility to manage the encodings of the argument and return values.
 	
 	This is the common denominator API for all platforms.
 	Rationale: Windows does not (compared to *nix systems) provide a encoded byte representation of the value. Windows has instead its own wide string representation."
@@ -143,7 +143,7 @@ OSEnvironment >> at: aKey ifAbsentPut: aBlock [
 OSEnvironment >> at: aKey ifPresent: aBlock [
 	"Gets the value of an environment variable called `aKey` and invoke aBlock with it.
 	Return nil if absent.
-	It is the system reponsibility to manage the encodings of the argument and return values.
+	It is the system responsibility to manage the encodings of the argument and return values.
 	
 	This is the common denominator API for all platforms.
 	Rationale: Windows does not (compared to *nix systems) provide a encoded byte representation of the value. Windows has instead its own wide string representation."
@@ -156,7 +156,7 @@ OSEnvironment >> at: aKey ifPresent: presentBlock ifAbsent: absentBlock [
 	"Gets the value of an environment variable called `aKey`.
 	Call presentBlock with it if present.
 	Execute absentBlock if absent.
-	It is the system reponsibility to manage the encodings of the argument and return values.
+	It is the system responsibility to manage the encodings of the argument and return values.
 	
 	This is the common denominator API for all platforms.
 	Rationale: Windows does not (compared to *nix systems) provide a encoded byte representation of the value. Windows has instead its own wide string representation."
@@ -168,7 +168,7 @@ OSEnvironment >> at: aKey ifPresent: presentBlock ifAbsent: absentBlock [
 { #category : #accessing }
 OSEnvironment >> at: aKey put: aValue [
 	"Sets the value of an environment variable called `aKey` to `aValue`.
-	It is the system reponsibility to manage the encodings of both arguments.
+	It is the system responsibility to manage the encodings of both arguments.
 	
 	This is the common denominator API for all platforms.
 	Rationale: Windows does not (compared to *nix systems) provide a encoded byte representation of the value. Windows has instead its own wide string representation."
@@ -236,7 +236,7 @@ OSEnvironment >> platform [
 { #category : #accessing }
 OSEnvironment >> removeKey: aKey [
 	"Removes the entry `aKey` from the environment variables.
-	It is the system reponsibility to manage the encoding of the argument.
+	It is the system responsibility to manage the encoding of the argument.
 	
 	This is the common denominator API for all platforms.
 	Rationale: Windows does not (compared to *nix systems) provide a encoded byte representation of the value. Windows has instead its own wide string representation."

--- a/src/System-OSEnvironments/UnixEnvironment.class.st
+++ b/src/System-OSEnvironments/UnixEnvironment.class.st
@@ -100,7 +100,7 @@ UnixEnvironment >> at: aKey encoding: anEncoding ifPresent: presentBlock ifAbsen
 { #category : #accessing }
 UnixEnvironment >> at: aKey ifAbsent: aBlock [
 	"See super>>at:ifAbsent:.
-	Uses a single encoding determined dinamically"
+	Uses a single encoding determined dynamically"
 
 	^ self at: aKey encoding: self defaultEncoding ifAbsent: aBlock
 ]
@@ -108,7 +108,7 @@ UnixEnvironment >> at: aKey ifAbsent: aBlock [
 { #category : #accessing }
 UnixEnvironment >> at: aKey put: aValue [
 	"See super>>at:put:.
-	Uses a single encoding determined dinamically"
+	Uses a single encoding determined dynamically"
 
 	^ self at: aKey put: aValue encoding: self defaultEncoding
 ]
@@ -267,7 +267,7 @@ UnixEnvironment >> rawRemoveKey: anEncodedKey [
 { #category : #accessing }
 UnixEnvironment >> removeKey: key [
 	"See super>>removeKey:.
-	Uses a single encoding determined dinamically"
+	Uses a single encoding determined dynamically"
 	
 	^ self removeKey: key encoded: self defaultEncoding
 ]

--- a/src/System-OSEnvironments/Win32Environment.class.st
+++ b/src/System-OSEnvironments/Win32Environment.class.st
@@ -53,9 +53,9 @@ Win32Environment >> doGetEnvVariable: aVariableName bufferSize: aSize ifAbsent: 
 	name := aVariableName asWin32WideString.
 	buffer := Win32WideString new: aSize.
 
-	"This Windows API to get the environment variable has ambigous behavior when handling environment variables with empty values.
+	"This Windows API to get the environment variable has ambiguous behavior when handling environment variables with empty values.
 	In the case of a empty string, the API call to get the environment variable returns 0. 
-	We need to differenciate the 0 in the case of an empty string and when there is an error.
+	We need to differentiate the 0 in the case of an empty string and when there is an error.
 	To do so, we are clearing the last error variable, and also we are retrying.
 	The retrying is needed because we can have a race condition between different API calls."
 

--- a/src/System-Object Events/EventManager.class.st
+++ b/src/System-Object Events/EventManager.class.st
@@ -1,9 +1,9 @@
 "
-An EventManager is used to registers a 'observer' object's interest in in changes to an 'observed' object.  Then when the observered object is changed,  EventManager broadcasts the an update message to all objects with a registered interest.  Finally, the Event manager can be used to remove an object from the list of observer object.
+An EventManager is used to registers a 'observer' object's interest in in changes to an 'observed' object.  Then when the observed object is changed,  EventManager broadcasts an update message to all objects with a registered interest.  Finally, the EventManager can be used to remove an object from the list of observer object.
 
-An interested object is said to be a dependant on the target object.  Registering an interest in an event is called adding a dependant. Deregistering is called removing  a dependant.  The EventManager's action map is a WeakIdentityDictionary that maps events (selectors) to dependants (objects & selectors) in a way that ensures the mapping is to specific objects (hence identity) and in a way that allows the object to be garbage collected if not other used (hence weak.)  EventManager class has ActionMaps which has one actionMap for each object.
+An interested object is said to be a dependant on the target object.  Registering an interest in an event is called adding a dependant. Deregistering is called removing a dependant.  The EventManager's action map is a WeakIdentityDictionary that maps events (selectors) to dependants (objects & selectors) in a way that ensures the mapping is to specific objects (hence identity) and in a way that allows the object to be garbage collected if not other used (hence weak.)  EventManager class has ActionMaps which has one actionMap for each object.
 
-Classic uses of an EventManager are to implement the Observer Pattern, see ChangeNotification or the MorphicModle as examples.
+Classic uses of an EventManager are to implement the Observer Pattern, see ChangeNotification or the MorphicModel as examples.
 "
 Class {
 	#name : #EventManager,

--- a/src/System-Platforms/KeyboardKey.class.st
+++ b/src/System-Platforms/KeyboardKey.class.st
@@ -1,6 +1,6 @@
 "
 I represent a keyboard Key, I am independent from the text issued from myself.
-That is, when you press e.g., the combination Alt + A, you get the Character å (as in ""an instance of Character"") in a text event, but in the KeyDown/Up events you get an instance of the myself, the KeyboardKey A (see section Keys vs Characters below).
+That is, when you press e.g., the combination Alt + A, you get the Character å (as in ""an instance of Character"") in a text event, but in the KeyDown/Up events you get an instance of myself, the KeyboardKey A (see section Keys vs Characters below).
 
 # Implementation details
 

--- a/src/System-Platforms/MacOSPlatform.class.st
+++ b/src/System-Platforms/MacOSPlatform.class.st
@@ -39,7 +39,7 @@ MacOSPlatform >> family [
 
 { #category : #accessing }
 MacOSPlatform >> getPwdViaFFI: buffer size: bufferSize [
-	"This method calls the Standard C Library getcwd() function. The name of the argument (arg1) should fit decompiled version. This method is used in getting the current working directory. This uses the inbuilt libC function getcwd(). getcwd is preferred over pwd because getcwd takes care of re-initialization of environment variables, whereas pwd needs implict re- initialization.
+	"This method calls the Standard C Library getcwd() function. The name of the argument (arg1) should fit decompiled version. This method is used in getting the current working directory. This uses the inbuilt libC function getcwd(). getcwd is preferred over pwd because getcwd takes care of re-initialization of environment variables, whereas pwd needs implicit re- initialization.
 	
 	This method should be removed, as we should delegate to the VM
 	

--- a/src/System-Platforms/OSPlatform.class.st
+++ b/src/System-Platforms/OSPlatform.class.st
@@ -239,7 +239,7 @@ OSPlatform >> shutDown: quitting [
 
 { #category : #initialize }
 OSPlatform >> startUp: resuming [
-	"Pharo is starting up. If this platform requires specific intialization, this is a great place to put it."
+	"Pharo is starting up. If this platform requires specific initialization, this is a great place to put it."
 
 ]
 

--- a/src/System-Platforms/UnixPlatform.class.st
+++ b/src/System-Platforms/UnixPlatform.class.st
@@ -39,7 +39,7 @@ UnixPlatform >> family [
 
 { #category : #accessing }
 UnixPlatform >> getPwdViaFFI: buffer size: bufferSize [
-	"This method calls the Standard C Library getcwd() function. The name of the argument (arg1) should fit decompiled version.This method is used in getting the current working directory. getcwd is preffered over pwd because getcwd takes care of re-initialization of environment variables, whereas pwd needs implict re- initialization.
+	"This method calls the Standard C Library getcwd() function. The name of the argument (arg1) should fit decompiled version.This method is used in getting the current working directory. getcwd is preferred over pwd because getcwd takes care of re-initialization of environment variables, whereas pwd needs implicit re- initialization.
 	
 	This method should be removed, as we should delegate to the VM
 	

--- a/src/System-Platforms/WinPlatform.class.st
+++ b/src/System-Platforms/WinPlatform.class.st
@@ -52,7 +52,7 @@ WinPlatform >> getEnvironmentVariable: lpName into: lpBuffer size: nSize [
 
 { #category : #accessing }
 WinPlatform >> getPwdViaFFI: buffer size: bufferSize [
-	"This method calls the Standard C Library getcwd() function. The name of the argument (arg1) should fit decompiled version. This method is used in getting the current working directory. getcwd is preffered over pwd because getcwd takes care of re-initialization of environment variables, whereas pwd needs implict re- initialization.
+	"This method calls the Standard C Library getcwd() function. The name of the argument (arg1) should fit decompiled version. This method is used in getting the current working directory. getcwd is preferred over pwd because getcwd takes care of re-initialization of environment variables, whereas pwd needs implicit re- initialization.
 	
 	This method should be removed, as we should delegate to the VM
 	

--- a/src/System-SessionManager-Tests/SessionErrorHandlingTest.class.st
+++ b/src/System-SessionManager-Tests/SessionErrorHandlingTest.class.st
@@ -53,7 +53,7 @@ SessionErrorHandlingTest >> testErrorCaughtIfExceptionSignaledAtShutdownWhenDefa
 	self shouldnt: [ session stop: false ] raise: Halt.
 	self assert: session errorHandler errors size equals: 1.
 
-	"ensure no defered actions"
+	"ensure no deferred actions"
 	self assertEmpty: (session instVarNamed: 'deferredStartupActions')
 ]
 
@@ -85,6 +85,6 @@ SessionErrorHandlingTest >> testErrorHandledIfExceptionSignaledAtStartupWhenDefa
 	self shouldnt: [ session start: false ] raise: Halt.
 	self assert: session errorHandler errors size equals: 1.
 
-	"ensure no defered actions"
+	"ensure no deferred actions"
 	self assertEmpty: (session instVarNamed: 'deferredStartupActions')
 ]

--- a/src/System-SessionManager/AbstractSessionHandler.class.st
+++ b/src/System-SessionManager/AbstractSessionHandler.class.st
@@ -1,6 +1,6 @@
 "
 API  to manage startup and shutdown of a session.
-On startup, isImageStarting indicates wheter the image is starting or just resuming from a save.
+On startup, isImageStarting indicates whether the image is starting or just resuming from a save.
 On shutdown, isQuitting indicates if we save and quit the image  or if we just save  the image.  
 "
 Class {

--- a/src/System-SessionManager/SessionManager.class.st
+++ b/src/System-SessionManager/SessionManager.class.st
@@ -30,7 +30,7 @@ The startup and shutdown lists can be accessed through the messages:
 
 In general terms, the shutdown list is the startup list reversed.
 
-Upon a startup [shutdown], all elements in the startup list are sent the message #startup: [#shutdown:] with a boolean as argument that indicates wether the image is being saved [closed].
+Upon a startup [shutdown], all elements in the startup list are sent the message #startup: [#shutdown:] with a boolean as argument that indicates whether the image is being saved [closed].
 
 Internally, startup and shutdown lists are prioritised. Priorities are managed by startup categories. By default the session manager includes the following categories in decreasing priority order:
 

--- a/src/System-SessionManager/UIManagerSessionHandler.class.st
+++ b/src/System-SessionManager/UIManagerSessionHandler.class.st
@@ -3,7 +3,7 @@ I am a session handler that will initialize the UIManager during startup.
 
 This session handler makes the assumption that the current UIManager is a startup UI manager when its #startup: method gets called. Then, during startup he will install a Morphic UI manager.
 
-During shutdown we put back a startup ui manager, so we can handle startup actions during next startup without depending in the UI. (However, we shouldnt need a UI manager during the first startup actions).
+During shutdown we put back a startup ui manager, so we can handle startup actions during next startup without depending in the UI. (However, we shouldn't need a UI manager during the first startup actions).
 "
 Class {
 	#name : #UIManagerSessionHandler,

--- a/src/System-Settings-Browser/SettingBrowser.class.st
+++ b/src/System-Settings-Browser/SettingBrowser.class.st
@@ -57,7 +57,7 @@ CodeHolderSystemSettings class>>caseSensitiveFindsSettingsOn: aBuilder
 		target: TextEditor;
 		parent: #codeEditing.
 
-For this setting to be declared, we make the asumption that we have TextEditor class>>caseSensitiveFinds and TextEditor class>>caseSensitiveFinds: methods in order to change the preference value. 
+For this setting to be declared, we make the assumption that we have TextEditor class>>caseSensitiveFinds and TextEditor class>>caseSensitiveFinds: methods in order to change the preference value. 
 To declare a setting, just send #setting: to the builder with its identifier, a Symbol passed as argument. It creates a setting node. Then you can set the label, the description with #label: and #description sent to the newly created setting node. You also have to set the selectors for setting and getting the preference value as well as the target to which these accessors are sent  (often a class). This is done by sending respectively, #setSelector:, #getSelector: and #target: to the setting node.
 Because all settings are organized in trees we need a way to indicate what is the position of the setting node in the overall setting trees list. In fact it can be done two ways. The first way is to use the #parent: message (A second possibility is to declare a subtree in one method, it is explained later in this documentation).The #parent: message is send for non root settings. #parent takes the identifier of the parent setting as argument.
 
@@ -131,7 +131,7 @@ windowPositionStrategySettingsOn: aBuilder
 			'Standard' translated -> #standardFor:initialExtent:world:};
 
 !!Launcher
-A launcher is a particular setting. It allows to launch a script directly from the setting browser. Imagine that you have changed some settings and that you need to evaluate a script in order to update some other objets. It can be used also to configurate globally a package of the entire image.
+A launcher is a particular setting. It allows to launch a script directly from the setting browser. Imagine that you have changed some settings and that you need to evaluate a script in order to update some other objects. It can be used also to configurate globally a package of the entire image.
 As an example, in order to use True Type Fonts, the system must be updated by collecting all the available TT fonts. This can be done by evaluating the following expression:
 -------------
 FreeTypeFontProvider current updateFromSystem
@@ -812,7 +812,7 @@ SettingBrowser >> toolBarIn: aMorph [
 				arguments: {aMorph}
 				getEnabled: nil
 				label: 'Choose packages' translated 
-				help: 'Per default, SettingBrowser shows all the setting of the system. You can restrict what is displayed to some packages that contains setting defintions.' translated).
+				help: 'Per default, SettingBrowser shows all the setting of the system. You can restrict what is displayed to some packages that contains setting definitions.' translated).
 	(aMorph
 				newButtonFor: self
 				getState: nil

--- a/src/System-Settings-Core/SettingFilter.class.st
+++ b/src/System-Settings-Core/SettingFilter.class.st
@@ -1,5 +1,5 @@
 "
-A SettingFilter is a filter wich is used by a SettingBrowser in order to select which nodes of the setting trees are to be shown. A SettingFilter subclass must redefine the #keepHandler: method which return true if the argument handler is to be kept.
+A SettingFilter is a filter which is used by a SettingBrowser in order to select which nodes of the setting trees are to be shown. A SettingFilter subclass must redefine the #keepHandler: method which return true if the argument handler is to be kept.
 
 Instance Variables
 

--- a/src/System-Settings-Core/SystemSettingsPersistence.class.st
+++ b/src/System-Settings-Core/SystemSettingsPersistence.class.st
@@ -58,7 +58,7 @@ SystemSettingsPersistence class >> deleteSettingNode: aSettingNode [
 { #category : #'class initialization' }
 SystemSettingsPersistence class >> initialize [
 	"in order to update settings at startup.
-	shoudl be register at the end of standard classes but before user classes"
+	should be registered at the end of standard classes but before user classes"
 	
 	"IMPORTANT: do not uncomment the registration to the session manager!
 	For now, SystemSettingsPersistence is handled directly by the command line handler startup.

--- a/src/System-Sources/RemoteString.class.st
+++ b/src/System-Sources/RemoteString.class.st
@@ -9,7 +9,7 @@ max: aNumber
 	^ self > aNumber ifTrue: [self] ifFalse: [aNumber]!
  
 Some chunks are styled (they have parts in bold, or font color...).
-When a chunk is styled, it is followed by a second chunk (prefixed with something like ]sytle[), and specifying the style.
+When a chunk is styled, it is followed by a second chunk (prefixed with something like ]style[), and specifying the style.
 The encoding is as follows:
 
 max: aNumber

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -102,7 +102,7 @@ SourceFileArray >> createReadOnlyFiles [
 { #category : #'public - string writing' }
 SourceFileArray >> deferFlushDuring: aBlock [
 
-	"defer flusing the filestream until a block has been executed"
+	"defer flushing the filestream until a block has been executed"
 	
 	flushChanges ifFalse: [ ^ aBlock value ].
 	

--- a/src/System-Support/EndianDetector.class.st
+++ b/src/System-Support/EndianDetector.class.st
@@ -61,7 +61,7 @@ EndianDetector class >> isLittleEndian [
 { #category : #'system startup' }
 EndianDetector class >> startUp: isImageStarting [
 
-	"only handle when lauching a new image"
+	"only handle when launching a new image"
 	isImageStarting ifFalse: [ ^ self ].
 	EndianCache := nil.
 ]

--- a/src/System-Support/ExternalSemaphoreTable.class.st
+++ b/src/System-Support/ExternalSemaphoreTable.class.st
@@ -1,6 +1,6 @@
 "
 By John M McIntosh johnmci@smalltalkconsulting.com
-This class was written to mange the external semaphore table. When I was writing a Socket test server I discovered various race conditions on the access to the externalSemaphore table. This new class uses class side methods to restrict access using two mutex semaphores, one for removal and one for additions to the table. It seemed cleaner to deligate the reponsibility here versus adding more code and another class variable to SystemDictionary 
+This class was written to mange the external semaphore table. When I was writing a Socket test server I discovered various race conditions on the access to the externalSemaphore table. This new class uses class side methods to restrict access using two mutex semaphores, one for removal and one for additions to the table. It seemed cleaner to delegate the responsibility here versus adding more code and another class variable to SystemDictionary 
 
 Note that in Smalltalk recreateSpecialObjectsArray we still directly play with the table.
 

--- a/src/System-Support/PrimitiveError.class.st
+++ b/src/System-Support/PrimitiveError.class.st
@@ -11,7 +11,7 @@ errorName
 errorCode
 	- the value of the error, a signed 64-bit value, a representation imposed by the VM; specific clients must map this error value into an unsigned value as appropriate if required
 
-Typical usage is shown in the ficticious method below:
+Typical usage is shown in the fictitious method below:
 
 primitiveOperation
 	<primitive: 'primitiveOperation' module: 'APlugin' error: error>

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -295,7 +295,7 @@ SmalltalkImage >> bytesLeft [
 
 { #category : #'memory space' }
 SmalltalkImage >> bytesLeft: aBool [
-	"Return the amount of available space. If aBool is true, include possibly available swap space. If aBool is false, include possibly available physical memory. For a report on the largest free block currently availabe within Pharo memory but not counting extra memory use #primBytesLeft."
+	"Return the amount of available space. If aBool is true, include possibly available swap space. If aBool is false, include possibly available physical memory. For a report on the largest free block currently available within Pharo memory but not counting extra memory use #primBytesLeft."
 	<primitive: 112>
 	^self primBytesLeft
 ]
@@ -529,7 +529,7 @@ SmalltalkImage >> exitToDebugger [
 
 { #category : #'special objects' }
 SmalltalkImage >> externalObjects [
-	"Return an array of objects that have been registered for use in non-Smalltalk code. Smalltalk objects should be referrenced by external code only via indirection through this array, thus allowing the objects to move during compaction. This array can be cleared when the VM re-starts, since variables in external code do not survive snapshots. Note that external code should not attempt to access a Smalltalk object, even via this mechanism, while garbage collection is in progress."
+	"Return an array of objects that have been registered for use in non-Smalltalk code. Smalltalk objects should be referenced by external code only via indirection through this array, thus allowing the objects to move during compaction. This array can be cleared when the VM re-starts, since variables in external code do not survive snapshots. Note that external code should not attempt to access a Smalltalk object, even via this mechanism, while garbage collection is in progress."
 	"Smalltalk externalObjects"
 
 	^ ExternalSemaphoreTable externalObjects
@@ -750,7 +750,7 @@ SmalltalkImage >> growMemoryByAtLeast: numBytes [
 
 { #category : #'class and trait names' }
 SmalltalkImage >> hasClassNamed: aString [
-	"Answer whether there is a class of the given name, but don't intern aString if it's not alrady interned."
+	"Answer whether there is a class of the given name, but don't intern aString if it's not already interned."
 
 	^ globals hasClassNamed: aString
 ]

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -260,7 +260,7 @@ SystemDictionary >> hasBindingThatBeginsWith: aString [
 
 { #category : #'classes and traits' }
 SystemDictionary >> hasClassNamed: aString [
-	"Answer whether there is a class of the given name, but don't intern aString if it's not alrady interned."
+	"Answer whether there is a class of the given name, but don't intern aString if it's not already interned."
 
 	Symbol 
 		hasInterned: aString 
@@ -270,7 +270,7 @@ SystemDictionary >> hasClassNamed: aString [
 
 { #category : #'classes and traits' }
 SystemDictionary >> hasClassOrTraitNamed: aString [
-	"Answer whether there is a class of the given name, but don't intern aString if it's not alrady interned."
+	"Answer whether there is a class of the given name, but don't intern aString if it's not already interned."
 
 	Symbol 
 		hasInterned: aString 

--- a/src/System-Support/SystemVersion.class.st
+++ b/src/System-Support/SystemVersion.class.st
@@ -197,7 +197,7 @@ SystemVersion >> highestUpdate: anInteger [
 
 { #category : #'accessing - version strings' }
 SystemVersion >> imageVersionString [
-	"Print the version compatibile with naming the image."
+	"Print the version compatible with naming the image."
 	
 	^String streamContents: [:str |
 		str nextPutAll: self type;

--- a/src/System-Support/VirtualMachine.class.st
+++ b/src/System-Support/VirtualMachine.class.st
@@ -52,7 +52,7 @@ VirtualMachine >> cogitClass [
 
 { #category : #accessing }
 VirtualMachine >> command [
-	"return a bash-like lauch command for the vm including all arguments up to the image name "
+	"return a bash-like launch command for the vm including all arguments up to the image name "
 	^ String streamContents: [ :s|
 		s nextPutAll: (self optionAt: 0).
 		Smalltalk commandLine options 
@@ -86,7 +86,7 @@ VirtualMachine >> directory [
 { #category : #modules }
 VirtualMachine >> disableModuleLoading [
 	"Primitive. Disable a new module loading mechanism for the rest of current session.
-	This operation is not reversable.
+	This operation is not reversible.
 	Any subsequent attempts to load either external or internal module(s) will fail"
 
 	<primitive: 'primitiveDisableModuleLoading' module: ''>
@@ -354,7 +354,7 @@ VirtualMachine >> is64bit [
 
 { #category : #testing }
 VirtualMachine >> isAIOInterrupt [
-	"Answer true, if the vm is capable of being interupted until there is an AIO event. 
+	"Answer true, if the vm is capable of being interrupted until there is an AIO event. 
 	 (This means we are going idle until we have something real to process)"
 
 	^ (self getSystemAttribute: 1010) = 'AIO'
@@ -615,7 +615,7 @@ To speed-up execution, the cog uses internally a JIT compiler which translates t
 
 The default size should be between 1Mb and 2Mb for standard applications. If memory is a constraint, it can be lowered down to 750kb, under that you should use the stack VM else the performance starts to drastically decrease.
 
-This setting is useful to tune your application performance. For example, on compilation-intensive benchs, 750kb is the optimal machine code zone size. On large benchmarks, 2 Mb, maybe more, is better, but then one may see machine code garbage collection pauses. On small benchs all the methods fit into this zone so it doesn't really matter.
+This setting is useful to tune your application performance. For example, on compilation-intensive benches, 750kb is the optimal machine code zone size. On large benchmarks, 2 Mb, maybe more, is better, but then one may see machine code garbage collection pauses. On small benches all the methods fit into this zone so it doesn't really matter.
 
 Growing the machine code zone:
 - increase the number of methods that can be present there, hence decreasing machine code zone garbage collection frequency and method jit compilation.

--- a/src/System-VMEvents/InputEventSensor.class.st
+++ b/src/System-VMEvents/InputEventSensor.class.st
@@ -1,6 +1,6 @@
 "
 An InputEventSensor is a replacement for the old Morphic EventSensor framework.
-It updates its state when events are received so that all state based users of Sensor (e.g., Sensor keyboard, Sensor leftShiftDown, Sensor mouseButtons) will work exactly as before. The usage of these funtions is discouraged. 
+It updates its state when events are received so that all state based users of Sensor (e.g., Sensor keyboard, Sensor leftShiftDown, Sensor mouseButtons) will work exactly as before. The usage of these functions is discouraged. 
 
 Instance variables:
 	mouseButtons <Integer>	- mouse button state as replacement for primMouseButtons
@@ -371,8 +371,8 @@ InputEventSensor >> primTabletGetParameters: cursorIndex [
 	3. number of tablet units per inch
 	4. number of cursors (pens, pucks, etc; some tablets have more than one)
 	5. this cursor index
-	6. and 7. x scale and x offset for scaling tablet coordintes (e.g., to fit the screen)
-	8. and 9. y scale and y offset for scaling tablet coordintes  (e.g., to fit the screen)
+	6. and 7. x scale and x offset for scaling tablet coordinates (e.g., to fit the screen)
+	8. and 9. y scale and y offset for scaling tablet coordinates  (e.g., to fit the screen)
 	10. number of pressure levels
 	11. presure threshold needed close pen tip switch 
 	12. number of pen tilt angles"
@@ -421,7 +421,7 @@ InputEventSensor >> processEvent: evt [
 	type = EventTypeKeyboard
 		ifTrue: [ ^ self processKeyboardEvent: evt ].
 
-	"Handle all events other than Keyborad or Mouse."
+	"Handle all events other than Keyboard or Mouse."
 	^ evt
 ]
 
@@ -547,7 +547,7 @@ InputEventSensor >> waitButton [
 { #category : #mouse }
 InputEventSensor >> waitButtonOrKeyboard [
 	"Wait for the user to press either any mouse button or any key. 
-	Answer the current cursor location or nil if a keypress occured."
+	Answer the current cursor location or nil if a keypress occurred."
 
 	| delay |
 	delay := Delay forMilliseconds: 50.

--- a/src/SystemCommands-ClassCommands/SycRemoveClassStrategy.class.st
+++ b/src/SystemCommands-ClassCommands/SycRemoveClassStrategy.class.st
@@ -1,7 +1,7 @@
 "
 I am the abstract strategy used to remove classes from the system.
 
-My concrete subclasses handle the possible actions when a user attemps to remove a class:
+My concrete subclasses handle the possible actions when a user attempts to remove a class:
 	- remove the class
 	- remove the class, keeping the subclasses
 	- Don't remove the class, but browse references/subclasses/users

--- a/src/SystemCommands-MessageCommands/SycAddMessageArgumentCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycAddMessageArgumentCommand.class.st
@@ -23,7 +23,7 @@ SycAddMessageArgumentCommand class >> canBeExecutedInContext: aToolContext [
 
 	Using the refactor from the method selection panel works fine.
 	Otherwise createValidNameArgument creates an argument name that is not already in use (for example: if anObject is used then it return anObject1).
-	Howerver when we ask this refactoring from a message we don't know the method and cannot do those checks. (If there is only one)"
+	However when we ask this refactoring from a message we don't know the method and cannot do those checks. (If there is only one)"
 	^aToolContext isMethodSelected
 ]
 

--- a/src/SystemCommands-MessageCommands/SycMessageDescription.class.st
+++ b/src/SystemCommands-MessageCommands/SycMessageDescription.class.st
@@ -13,7 +13,7 @@ I implement suitable method for commands to request new signature:
 
 	aMessage requestNewSignature
 
-It returnes new message instance.
+It returns new message instance.
 
 Also I provide a method to compute argument permutations comparing to another message: 
 

--- a/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
@@ -5,7 +5,7 @@ I provide suitable methods for subclasses to move methods to package:
 
 - moveMethod: aMethod toPackage: aPackage
 
-Subclasses should just deside what package it should be. 
+Subclasses should just decide what package it should be. 
 "
 Class {
 	#name : #SycMethodRepackagingCommand,

--- a/src/SystemCommands-MethodCommands/SycRemoveMethodStrategy.class.st
+++ b/src/SystemCommands-MethodCommands/SycRemoveMethodStrategy.class.st
@@ -1,13 +1,13 @@
 "
 I am a strategy on how remove methods.
 You can see my subclasses when you try remove method in the browser which is still in use.
-Usualy you see four options what to do:
+Usually you see four options what to do:
 - just remove 
 - remove and show senders
 - do not remove and show senders
 - cancel  
 
-My subclasses reprsent this choices using following method: 
+My subclasses represent this choices using following method: 
 
 - removeMethods: methods 
 

--- a/src/SystemCommands-MethodCommands/SycSilentlyRemoveMethodStrategy.class.st
+++ b/src/SystemCommands-MethodCommands/SycSilentlyRemoveMethodStrategy.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #removing }
 SycSilentlyRemoveMethodStrategy >> collectMethodTagsFrom: methods [
-	"It will return map class->tags where tags are releated to given methods"
+	"It will return map class->tags where tags are related to given methods"
 	| result tags |
 	result := IdentityDictionary new.
 	methods do: [ :each | 

--- a/src/SystemCommands-RefactoringSupport-Tests/MockSycRefactoringPreviewPresenter.class.st
+++ b/src/SystemCommands-RefactoringSupport-Tests/MockSycRefactoringPreviewPresenter.class.st
@@ -11,7 +11,7 @@ MockSycRefactoringPreviewPresenter >> activeRBEnvironment [
 
 { #category : #private }
 MockSycRefactoringPreviewPresenter >> buildDiffFor: aChange [
-	"i override this method bacause i just want to test if the transmission use this method"
+	"i override this method because i just want to test if the transmission use this method"
 	^ 'useForTest'
 ]
 

--- a/src/SystemCommands-RefactoringSupport/RBFindAndReplacePreviewPresenter.class.st
+++ b/src/SystemCommands-RefactoringSupport/RBFindAndReplacePreviewPresenter.class.st
@@ -1,5 +1,5 @@
 "
-I am a preview of find and replace refactoring (tool). I can select the methods of class (or subclasses) to find ocurrences in them. 
+I am a preview of find and replace refactoring (tool). I can select the methods of class (or subclasses) to find occurrences in them. 
 
 EXAMPLES
 -------------------------------------------------
@@ -13,7 +13,7 @@ changeList:           <TablePresenter> A table to display the possible methods t
 label:                <LabelPresenter> Title of table
 dropList:             <DropListPresenter> A selector to select the search type
 selectedRefactorings: <OrderedCollection> A list with elements to search
-method:               <CompiledMethod> A method to find ocurrences
+method:               <CompiledMethod> A method to find occurrences
 refactoring:          <RBRefactoring> A subclass of RBRefactoring 
 
 

--- a/src/SystemCommands-RefactoringSupport/SycRefactoringPreviewPresenter.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycRefactoringPreviewPresenter.class.st
@@ -258,7 +258,7 @@ SycRefactoringPreviewPresenter >> title [
 
 { #category : #private }
 SycRefactoringPreviewPresenter >> toggleSelectionOf: aRefactoring [
-	"it's normal it's impossible that anItem dosn't store in dictionary because at initialize i fill the dictionary and at each scope change"
+	"it's normal it's impossible that anItem doesn't store in dictionary because at initialize I fill the dictionary and at each scope change"
 
 	selectedRefactorings at: aRefactoring put: (selectedRefactorings at: aRefactoring) not.
 	self rebuild 


### PR DESCRIPTION
Found via `codespell -q 3 -S ./resources/unicode -L aline,anumber,atleast,ba,doubleclick,shouldnt,upto`