### PR TITLE
Fixed the Undo and Redo in the RubTextEditor

### DIFF
--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -260,6 +260,7 @@ RubTextEditor >> backWord: aKeyboardEvent [
 { #category : #'typing/selecting keys' }
 RubTextEditor >> backspace: aKeyboardEvent [
 	| result startIndex |
+	self closeTypeIn.
 	result := aKeyboardEvent shiftPressed
 		ifTrue: [ self backWord: aKeyboardEvent keyCharacter ]
 		ifFalse: [ 
@@ -276,7 +277,6 @@ RubTextEditor >> backspace: aKeyboardEvent [
 					startIndex := 1 max: startIndex - 1.
 					self backTo: startIndex ].
 			false ].
-	self closeTypeIn.
 	^ result
 ]
 

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -143,6 +143,8 @@ RubTextEditor >> addDeleteSelectionUndoRecord [
 { #category : #'typing support' }
 RubTextEditor >> addString: aString [
 	"Think of a better name"
+	self hasSelection 
+		ifTrue: [self addDeleteSelectionUndoRecord].
 	self openTypeIn.
 	self zapSelectionWith: (Text string: aString attributes: self emphasisHere)
 ]
@@ -1644,8 +1646,6 @@ RubTextEditor >> noop: aKeyboardEvent [
 RubTextEditor >> normalCharacter: aKeyboardEvent [ 
 	"A nonspecial character is to be added to the stream of characters."
 
-	self hasSelection 
-		ifTrue: [self addDeleteSelectionUndoRecord].
 	self addString: aKeyboardEvent keyCharacter asString.
 	^false
 ]

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -143,6 +143,7 @@ RubTextEditor >> addDeleteSelectionUndoRecord [
 { #category : #'typing support' }
 RubTextEditor >> addString: aString [
 	"Think of a better name"
+	self openTypeIn.
 	self zapSelectionWith: (Text string: aString attributes: self emphasisHere)
 ]
 
@@ -1459,7 +1460,6 @@ RubTextEditor >> keystroke: aKeyboardEvent [
 	textArea announce: ((RubKeystroke with: aKeyboardEvent) morph: self).
 	self normalCharacter: aKeyboardEvent.
 	"normal character"
-	self openTypeIn.
 	self hasSelection
 		ifTrue: [ 
 			"save highlighted characters"


### PR DESCRIPTION
This should fix at least some issues with the Undo and Redo operations described in #3903. The main problem was that new lines and tab characters are not added to the history. By moving the `openTypeIn` (and also the `addDeleteSelectionUndoRecord`) from being used only for normal keys to being used for all changes. This will then include the new line or tab in the history when `closeTypeIn` is called, the same way it works for normal characters.

Also connected to: #9291
