### PR TITLE
9543-Executing-an-expression-with-an-unknow-class-raises-an-error-on-rub

### DIFF
--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -152,7 +152,7 @@ OCUndeclaredVariableWarning >> openMenuIn: aBlock [
 	| alternatives labels actions lines caption choice name interval |
 	
 	"Turn off suggestions when in RubSmalltalkCommentMode" 
-	(compilationContext requestor editingMode class == RubSmalltalkCommentMode) ifTrue: [ ^UndeclaredVariable named: node name ].
+	(compilationContext requestor editingMode class name == #RubSmalltalkCommentMode) ifTrue: [ ^UndeclaredVariable named: node name ].
 	
 	interval := node sourceInterval.
 	name := node name.

--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -150,6 +150,10 @@ OCUndeclaredVariableWarning >> node: aVariableNode [
 { #category : #correcting }
 OCUndeclaredVariableWarning >> openMenuIn: aBlock [
 	| alternatives labels actions lines caption choice name interval |
+	
+	"Turn off suggestions when in RubSmalltalkCommentMode" 
+	(compilationContext requestor editingMode class == RubSmalltalkCommentMode) ifTrue: [ ^UndeclaredVariable named: node name ].
+	
 	interval := node sourceInterval.
 	name := node name.
 	alternatives := self possibleVariablesFor: name.


### PR DESCRIPTION
Workaround. When in RubSmalltalkCommentMode, we do not want to get any variables suggested.

This is a workaround: in Pharo10 we will remove this mechanism that fixes Undeclareds within the Exception and let the editor drive it instead, which will be much cleaner.

fixes #9543 

