### PR TITLE
9548-Menus-shortcut-rendering-broken

### DIFF
--- a/src/Morphic-Base/ShortcutReminder.class.st
+++ b/src/Morphic-Base/ShortcutReminder.class.st
@@ -78,9 +78,9 @@ ShortcutReminder >> createKeyTextMorph: aString [
 
 	| font |
 	font := ToggleWithSymbolMenuItemShortcut canBeUsed
-		ifTrue: [ ToggleWithSymbolMenuItemShortcut createSymbolFont 
-						pointSize: self pointSize * 2;
-						yourself ]
+		ifTrue: [ LogicalFont 
+						familyName: 'Lucida Grande' 
+						pointSize: self pointSize * 2 ]
 		ifFalse: [ self keyTextFont ].
 
 	^(self fixKeyText: aString) asStringMorph 


### PR DESCRIPTION
Creating a new font when using shortcut reminder, as it was reusing the same font.