### PR TITLE
9560-Does-not-understand-while-using-a-non-defined-variable-starting-with-uppercase 

### DIFF
--- a/src/GeneralRules/ReConsistencyCheckRule.class.st
+++ b/src/GeneralRules/ReConsistencyCheckRule.class.st
@@ -32,5 +32,5 @@ ReConsistencyCheckRule >> initialize [
 
 { #category : #accessing }
 ReConsistencyCheckRule >> name [
-	^ 'Uses "size = 0" instead of "isEmpty"'
+	^ 'Checks for empty collection using #size instead of #isEmpty" or #isNotEmpty'
 ]

--- a/src/GeneralRules/ReConsistencyCheckRule.class.st
+++ b/src/GeneralRules/ReConsistencyCheckRule.class.st
@@ -26,7 +26,7 @@ ReConsistencyCheckRule >> initialize [
 		'`@object size == 0'
 		'`@object size = 0'
 		'`@object size > 0'
-		'`@object size >= 1')
+		'`@object size >= 0')
 		
 ]
 

--- a/src/GeneralRules/ReConsistencyCheckRule.class.st
+++ b/src/GeneralRules/ReConsistencyCheckRule.class.st
@@ -26,7 +26,7 @@ ReConsistencyCheckRule >> initialize [
 		'`@object size == 0'
 		'`@object size = 0'
 		'`@object size > 0'
-		'`@object size >= 0')
+		'`@object size >= 1')
 		
 ]
 

--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -149,10 +149,14 @@ OCUndeclaredVariableWarning >> node: aVariableNode [
 
 { #category : #correcting }
 OCUndeclaredVariableWarning >> openMenuIn: aBlock [
-	| alternatives labels actions lines caption choice name interval |
+	| alternatives labels actions lines caption choice name interval requestor |
 	
-	"Turn off suggestions when in RubSmalltalkCommentMode" 
-	(compilationContext requestor editingMode class name == #RubSmalltalkCommentMode) ifTrue: [ ^UndeclaredVariable named: node name ].
+	"Turn off suggestions when in RubSmalltalkCommentMode
+	This is a workaround, the plan is to not do this as part of the exception"
+	requestor := compilationContext requestor.
+	((requestor class name = #RubEditingArea) and: [
+		requestor editingMode class name = #RubSmalltalkCommentMode])
+					ifTrue: [ ^UndeclaredVariable named: node name ].
 	
 	interval := node sourceInterval.
 	name := node name.


### PR DESCRIPTION
Improve the workaround to turn off variable suggestions for class comments.

(the idea is to do the minimal workaround, a major cleanup is planned for Pharo10)