### PR TITLE
Improve the workaround to not show the  undeclared fix menu when in c…

### DIFF
--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -149,10 +149,14 @@ OCUndeclaredVariableWarning >> node: aVariableNode [
 
 { #category : #correcting }
 OCUndeclaredVariableWarning >> openMenuIn: aBlock [
-	| alternatives labels actions lines caption choice name interval |
+	| alternatives labels actions lines caption choice name interval requestor |
 	
-	"Turn off suggestions when in RubSmalltalkCommentMode" 
-	(compilationContext requestor editingMode class name == #RubSmalltalkCommentMode) ifTrue: [ ^UndeclaredVariable named: node name ].
+	"Turn off suggestions when in RubSmalltalkCommentMode
+ 	This is a workaround, the plan is to not do this as part of the exception"
+ 	requestor := compilationContext requestor.
+ 	((requestor class name = #RubEditingArea) and: [
+ 		requestor editingMode class name = #RubSmalltalkCommentMode])
+ 					ifTrue: [ ^UndeclaredVariable named: node name ].
 	
 	interval := node sourceInterval.
 	name := node name.


### PR DESCRIPTION
…omment mode.

This PR is a workaround: as many classes can be used a requestor, adding a test method might lead to more problems, therefore the idea
is to detect that case when it is happening in comment mode.

Pharo10 will clean this up and not do the variable suggestion as part of the exception.

fixes #9560