### PR TITLE
9495-Color-selection-dialog-broken

### DIFF
--- a/src/FormCanvas-Core/FormCanvas.class.st
+++ b/src/FormCanvas-Core/FormCanvas.class.st
@@ -266,14 +266,13 @@ FormCanvas >> drawString: aString from: firstIndex to: lastIndex in: bounds font
 
 { #category : #'private - balloon engine' }
 FormCanvas >> ensuredEngine [
-	engine ifNil:[
-		engine := BalloonEngine new.
-		engine aaLevel: 1.
-		engine bitBlt: port.
-		engine destOffset: origin.
-		engine clipRect: clipRect.
-		engine deferred: false.
-		engine].
+	engine := BalloonEngine new.
+	engine aaLevel: 1.
+	engine bitBlt: port.
+	engine destOffset: origin.
+	engine clipRect: clipRect.
+	engine deferred: false.
+
 	engine colorTransform: colorTransform.
 	engine edgeTransform: self transform.
 	^engine


### PR DESCRIPTION
We cannot reuse the engine, it is not possible to ensure the state of it in the programming model we have.