### PR TITLE
Fix #9577: Typing in the help browser DNU

### DIFF
--- a/src/HelpSystem-Core/HelpBrowser.class.st
+++ b/src/HelpSystem-Core/HelpBrowser.class.st
@@ -109,6 +109,13 @@ HelpBrowser class >> taskbarIconName [
 ]
 
 { #category : #ui }
+HelpBrowser >> bindings [
+	"I'm used as an interaction model for the Help Browser text editors.
+	Return an empty collection of bindings, since no compilation or code completion happen on myself"
+	^ Dictionary new
+]
+
+{ #category : #ui }
 HelpBrowser >> close [
 	window notNil ifTrue: [window delete]
 ]


### PR DESCRIPTION
Fix #9577.
Make the help browser a valid interaction model, so it does not fail with a DNU on typing.