### PR TITLE
Enable display empty slots by default

### DIFF
--- a/src/Kernel-Tests/CommonClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/CommonClassDefinitionPrinterTest.class.st
@@ -17,7 +17,7 @@ CommonClassDefinitionPrinterTest >> setUp [
 	super setUp.
 	slotUse := ClassDefinitionPrinter showFluidClassDefinition.
 	slotDisplay := ClassDefinitionPrinter displayEmptySlots.
-	
+	ClassDefinitionPrinter displayEmptySlots: false
 ]
 
 { #category : #running }

--- a/src/Kernel/ClassDefinitionPrinter.class.st
+++ b/src/Kernel/ClassDefinitionPrinter.class.st
@@ -68,7 +68,7 @@ Class {
 { #category : #configure }
 ClassDefinitionPrinter class >> displayEmptySlots [
 
-	^ DisplayEmptySlots ifNil: [ DisplayEmptySlots := false ]
+	^ DisplayEmptySlots ifNil: [ DisplayEmptySlots := true ]
 ]
 
 { #category : #configure }

--- a/src/Kernel/ClassDefinitionPrinter.class.st
+++ b/src/Kernel/ClassDefinitionPrinter.class.st
@@ -127,7 +127,7 @@ ClassDefinitionPrinter class >> settingsOn: aBuilder [
 	<systemsettings>
 	(aBuilder setting: #showFluidClassDefinition)
 		parent: #codeBrowsing;
-		default: true;
+		default: false;
 		label: 'Use fluid class definition';
 		description: 'If true, the system will display the class definition using a fluid interface e.g., 
 
@@ -142,7 +142,7 @@ In addition, as soon as you will use slots such as ObservableSlot and more this 
 		
 	(aBuilder setting: #displayEmptySlots)
 		parent: #codeBrowsing;
-		default: false;
+		default: true;
 		label: 'Display empty slots';
 		description: 'If true, the system will display the slots even if they are empty e.g., 
 

--- a/src/Kernel/ClassDefinitionPrinter.class.st
+++ b/src/Kernel/ClassDefinitionPrinter.class.st
@@ -127,7 +127,7 @@ ClassDefinitionPrinter class >> settingsOn: aBuilder [
 	<systemsettings>
 	(aBuilder setting: #showFluidClassDefinition)
 		parent: #codeBrowsing;
-		default: false;
+		default: true;
 		label: 'Use fluid class definition';
 		description: 'If true, the system will display the class definition using a fluid interface e.g., 
 

--- a/src/TraitsV2-Tests/T2CommonClassDefinitionPrinterTest.class.st
+++ b/src/TraitsV2-Tests/T2CommonClassDefinitionPrinterTest.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : #T2CommonClassDefinitionPrinterTest,
 	#superclass : #T2AbstractTest,
 	#instVars : [
-		'slotuse'
+		'slotuse',
+		'emptySlots'
 	],
 	#category : #'TraitsV2-Tests'
 }
@@ -11,12 +12,14 @@ Class {
 T2CommonClassDefinitionPrinterTest >> setUp [ 
 	super setUp.
 	slotuse := ClassDefinitionPrinter showFluidClassDefinition.
-	
+	emptySlots := ClassDefinitionPrinter displayEmptySlots.
+	ClassDefinitionPrinter displayEmptySlots: false
 ]
 
 { #category : #running }
 T2CommonClassDefinitionPrinterTest >> tearDown [
 
+	ClassDefinitionPrinter displayEmptySlots: emptySlots.
 	ClassDefinitionPrinter showFluidClassDefinition: slotuse.
 	super tearDown
 ]


### PR DESCRIPTION
I am changing this setting because "first impression counts", and this is what users expect. 
I know this is not the ideal solution, but changing the setting will solve the problem now, while we can fix the more general problem that prevents the expand keybinding to work.