### PR TITLE
9590-asRingMinimalDefinitionIn-not-defined-in-AbstractLayout-hierarchy 

### DIFF
--- a/src/Kernel/AbstractLayout.class.st
+++ b/src/Kernel/AbstractLayout.class.st
@@ -11,6 +11,11 @@ Class {
 	#category : #'Kernel-Layout'
 }
 
+{ #category : #testing }
+AbstractLayout class >> isAbstract [
+	^self == AbstractLayout
+]
+
 { #category : #description }
 AbstractLayout class >> kind [
 	"Return an identifier describing uniquely the layout"
@@ -52,9 +57,39 @@ AbstractLayout >> definesSlot: aSlot [
 	^self slots identityIncludes: aSlot 
 ]
 
+{ #category : #accessing }
+AbstractLayout >> extend: arg1 [ 
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+AbstractLayout >> extendByte [
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+AbstractLayout >> extendDoubleByte [
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+AbstractLayout >> extendDoubleWord [
+	^ self subclassResponsibility
+]
+
 { #category : #extending }
 AbstractLayout >> extendImmediate [
 	^ ImmediateLayout new
+]
+
+{ #category : #accessing }
+AbstractLayout >> extendVariable: arg1 [ 
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+AbstractLayout >> extendWord [
+	^ self subclassResponsibility
 ]
 
 { #category : #accessing }

--- a/src/Kernel/BitsLayout.class.st
+++ b/src/Kernel/BitsLayout.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Kernel-Layout'
 }
 
+{ #category : #testing }
+BitsLayout class >> isAbstract [
+	^self == BitsLayout
+]
+
 { #category : #accessing }
 BitsLayout >> bytesPerSlot [
 

--- a/src/Kernel/CompiledMethodLayout.class.st
+++ b/src/Kernel/CompiledMethodLayout.class.st
@@ -22,6 +22,11 @@ CompiledMethodLayout class >> kind [
 	^ #compiledMethod 
 ]
 
+{ #category : #extending }
+CompiledMethodLayout >> extend [
+	self error: 'CompiledMethodLayout can not be extendend'
+]
+
 { #category : #format }
 CompiledMethodLayout >> instanceSpecification [
 	 ^ 24

--- a/src/Kernel/ImmediateLayout.class.st
+++ b/src/Kernel/ImmediateLayout.class.st
@@ -23,6 +23,11 @@ ImmediateLayout class >> kind [
 ]
 
 { #category : #extending }
+ImmediateLayout >> extend [
+	self error: 'ImmediateLayout can not be extendend'
+]
+
+{ #category : #extending }
 ImmediateLayout >> extend: newScope [
 	^ FixedLayout new slotScope: newScope
 ]

--- a/src/Kernel/LayoutAbstractScope.class.st
+++ b/src/Kernel/LayoutAbstractScope.class.st
@@ -17,6 +17,11 @@ LayoutAbstractScope >> allSlotsDo: aBlock [
 	self subclassResponsibility
 ]
 
+{ #category : #accessing }
+LayoutAbstractScope >> allVisibleSlots [
+	^ self subclassResponsibility
+]
+
 { #category : #extending }
 LayoutAbstractScope >> extend [
 	^ self extend: { }
@@ -56,6 +61,11 @@ LayoutAbstractScope >> firstFieldIndex [
 { #category : #flattening }
 LayoutAbstractScope >> flatten [
 	self subclassResponsibility
+]
+
+{ #category : #accessing }
+LayoutAbstractScope >> hasBindingThatBeginsWith: arg1 [ 
+	^ self subclassResponsibility
 ]
 
 { #category : #testing }

--- a/src/Kernel/ObjectLayout.class.st
+++ b/src/Kernel/ObjectLayout.class.st
@@ -12,6 +12,11 @@ ObjectLayout class >> extending: superLayout scope: aScope host: aClass [
 	self subclassResponsibility
 ]
 
+{ #category : #testing }
+ObjectLayout class >> isAbstract [
+	^self == ObjectLayout
+]
+
 { #category : #accessing }
 ObjectLayout class >> layoutForType: typeSymbol [
 	typeSymbol = #compiledMethod 

--- a/src/Kernel/PointerLayout.class.st
+++ b/src/Kernel/PointerLayout.class.st
@@ -10,6 +10,11 @@ Class {
 	#category : #'Kernel-Layout'
 }
 
+{ #category : #testing }
+PointerLayout class >> isAbstract [
+	^self == PointerLayout
+]
+
 { #category : #comparing }
 PointerLayout >> = other [
 	^ super = other

--- a/src/Ring-Core/BitsLayout.extension.st
+++ b/src/Ring-Core/BitsLayout.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #BitsLayout }
-
-{ #category : #'*Ring-Core' }
-BitsLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
-
-	self subclassResponsibility 
-]

--- a/src/Ring-Core/DoubleByteLayout.extension.st
+++ b/src/Ring-Core/DoubleByteLayout.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #DoubleByteLayout }
+
+{ #category : #'*Ring-Core' }
+DoubleByteLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
+
+	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [
+		RGDoubleByteLayout parent: (self host asRingMinimalDefinitionIn: anRGEnvironment)]
+]

--- a/src/Ring-Core/DoubleWordLayout.extension.st
+++ b/src/Ring-Core/DoubleWordLayout.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #DoubleWordLayout }
+
+{ #category : #'*Ring-Core' }
+DoubleWordLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
+
+	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [
+		RGDoubleWordLayout parent: (self host asRingMinimalDefinitionIn: anRGEnvironment)]
+]

--- a/src/Ring-Core/ObjectLayout.extension.st
+++ b/src/Ring-Core/ObjectLayout.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #ObjectLayout }
-
-{ #category : #'*Ring-Core' }
-ObjectLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
-
-	self subclassResponsibility 
-
-]

--- a/src/Ring-Core/PointerLayout.extension.st
+++ b/src/Ring-Core/PointerLayout.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #PointerLayout }
-
-{ #category : #'*Ring-Core' }
-PointerLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
-
-	self subclassResponsibility 
-]

--- a/src/Ring-Core/RGDoubleByteLayout.class.st
+++ b/src/Ring-Core/RGDoubleByteLayout.class.st
@@ -1,0 +1,20 @@
+"
+Ring2 model of DoubleByteLayout
+"
+Class {
+	#name : #RGDoubleByteLayout,
+	#superclass : #RGBitsLayout,
+	#category : #'Ring-Core-Kernel'
+}
+
+{ #category : #'testing - types' }
+RGDoubleByteLayout >> isByteLayout [
+
+	^ true
+]
+
+{ #category : #accessing }
+RGDoubleByteLayout >> layoutName [
+
+	^ #DoubleByteLayout
+]

--- a/src/Ring-Core/RGDoubleWordLayout.class.st
+++ b/src/Ring-Core/RGDoubleWordLayout.class.st
@@ -1,0 +1,19 @@
+"
+Ring2 model of DoubleWordLayout
+"
+Class {
+	#name : #RGDoubleWordLayout,
+	#superclass : #RGBitsLayout,
+	#category : #'Ring-Core-Kernel'
+}
+
+{ #category : #testing }
+RGDoubleWordLayout >> isWordLayout [
+	^ true
+]
+
+{ #category : #accessing }
+RGDoubleWordLayout >> layoutName [
+
+	^ #DoubleWordLayout
+]

--- a/src/Ring-Monticello/RGDoubleByteLayout.extension.st
+++ b/src/Ring-Monticello/RGDoubleByteLayout.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #RGDoubleByteLayout }
+
+{ #category : #'*Ring-Monticello' }
+RGDoubleByteLayout >> mcType [
+
+	^ #DoubleByteLayout 
+]

--- a/src/Ring-Monticello/RGDoubleWordLayout.extension.st
+++ b/src/Ring-Monticello/RGDoubleWordLayout.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #RGDoubleWordLayout }
+
+{ #category : #'*Ring-Monticello' }
+RGDoubleWordLayout >> mcType [
+
+	^ #DoubleWordLayout 
+]


### PR DESCRIPTION
this PR fixes the problems with abstract classes in the layout hierarchy

- tag abstract classes. This allows removing some copies of #subclassResponsability methods
- add all missing #subclassResponsibility (guided by code critique)
- add all missing subclassResponsability methods

This needed an improvement in Ring2:

- add RGDoubleByteLayout and RGDoubleWordLayout which were missing

fixes #9590 

 