### PR TITLE
9612-CleanBlockChecker-looks-to-be-used-before-it-is-loaded

### DIFF
--- a/src/Kernel/CleanBlockChecker.class.st
+++ b/src/Kernel/CleanBlockChecker.class.st
@@ -9,7 +9,7 @@ Class {
 	#instVars : [
 		'isClean'
 	],
-	#category : #'Debugging-Core'
+	#category : #'Kernel-Methods'
 }
 
 { #category : #validation }

--- a/src/Kernel/InstructionClient.class.st
+++ b/src/Kernel/InstructionClient.class.st
@@ -5,7 +5,7 @@ as an example.
 Class {
 	#name : #InstructionClient,
 	#superclass : #Object,
-	#category : #'Debugging-Core'
+	#category : #'Kernel-Methods'
 }
 
 { #category : #'instruction decoding' }


### PR DESCRIPTION
this PR fixes #9612 by moving InstructionClient and CleanBlockChecker to Kernel-Methods
