### PR TITLE
Fix #9471: roundDownTo: Turn comments into executable comments

### DIFF
--- a/src/Kernel/Number.class.st
+++ b/src/Kernel/Number.class.st
@@ -704,12 +704,12 @@ Number >> round: numberOfWishedDecimal [
 { #category : #'truncation and round off' }
 Number >> roundDownTo: aNumber [
 	"Answer the next multiple of aNumber toward negative infinity that is nearest the receiver. 
-	Examples:
-               3.1479 roundDownTo: 0.01 -> 3.14
-               3.1479 roundDownTo: 0.1 -> 3.1
-               1923 roundDownTo: 10 -> 1920
-               3.1479 roundDownTo: 0.005 -> 3.145
-               -3.1479 roundDownTo: 0.01 -> -3.15"
+	Examples:"
+               "(3.1479 roundDownTo: 0.01) >>> 3.14"
+               "(3.1479 roundDownTo: 0.1) >>> 3.1"
+               "(1923 roundDownTo: 10) >>> 1920"
+               "(3.1479 roundDownTo: 0.005) >>> 3.145"
+               "(-3.1479 roundDownTo: 0.01) >>> -3.15"
 	
 	^(self / aNumber) floor * aNumber
 ]


### PR DESCRIPTION
Changed comments into executable comments in Number>>roundDownTo: