### PR TITLE
9620-changes-in-pharo-10-in-welcome-window-points-to-version-8-instead-of-10

### DIFF
--- a/src/Pharo-WelcomeHelp/WelcomeHelp.class.st
+++ b/src/Pharo-WelcomeHelp/WelcomeHelp.class.st
@@ -212,7 +212,7 @@ A new VM with
 		
 You can see the Pharo 10.0 changelog at: 
 
-', (self url: 'https://github.com/pharo-project/pharo-changelogs/blob/master/Pharo10ChangeLogs.md')
+', (self url: 'https://github.com/pharo-project/pharo-changelogs/blob/master/Pharo100ChangeLogs.md')
 
 ]
 

--- a/src/Pharo-WelcomeHelp/WelcomeHelp.class.st
+++ b/src/Pharo-WelcomeHelp/WelcomeHelp.class.st
@@ -210,9 +210,9 @@ A new VM with
 (self heading: 'New threaded architecture'),
 'Pharo 9 comes also with a new Threaded FFI support. In fact Threaded FFI is not a single architecture but a set of alternatives that can be choosen depending on the constraints of the OS. TFFI offers adaptability to the different constraints imposed by Cocoa or GTK.	
 		
-You can see the Pharo 9.0 changelog at: 
+You can see the Pharo 10.0 changelog at: 
 
-', (self url: 'https://github.com/pharo-project/pharo-changelogs/blob/master/Pharo90ChangeLogs.md')
+', (self url: 'https://github.com/pharo-project/pharo-changelogs/blob/master/Pharo10ChangeLogs.md')
 
 ]
 


### PR DESCRIPTION
This PR just updates the end of the method #changLog so we know that the 10 changelog link is already there.

I do not think that we should now do anything else.


fixes #9620


