### PR TITLE
Ring2-Layouts-simpler-layoutName 

### DIFF
--- a/src/Ring-Core/RGBitsLayout.class.st
+++ b/src/Ring-Core/RGBitsLayout.class.st
@@ -15,9 +15,3 @@ RGBitsLayout >> isVariableLayout [
 
 	^ true
 ]
-
-{ #category : #accessing }
-RGBitsLayout >> layoutName [
-
-	^ #BitsLayout
-]

--- a/src/Ring-Core/RGByteLayout.class.st
+++ b/src/Ring-Core/RGByteLayout.class.st
@@ -9,9 +9,3 @@ RGByteLayout >> isByteLayout [
 
 	^ true
 ]
-
-{ #category : #accessing }
-RGByteLayout >> layoutName [
-
-	^ #ByteLayout
-]

--- a/src/Ring-Core/RGCompiledMethodLayout.class.st
+++ b/src/Ring-Core/RGCompiledMethodLayout.class.st
@@ -27,9 +27,3 @@ RGCompiledMethodLayout >> isVariableLayout [
 
 	^ true
 ]
-
-{ #category : #accessing }
-RGCompiledMethodLayout >> layoutName [
-
-	^ #CompiledMethodLayout
-]

--- a/src/Ring-Core/RGDoubleByteLayout.class.st
+++ b/src/Ring-Core/RGDoubleByteLayout.class.st
@@ -12,9 +12,3 @@ RGDoubleByteLayout >> isByteLayout [
 
 	^ true
 ]
-
-{ #category : #accessing }
-RGDoubleByteLayout >> layoutName [
-
-	^ #DoubleByteLayout
-]

--- a/src/Ring-Core/RGDoubleWordLayout.class.st
+++ b/src/Ring-Core/RGDoubleWordLayout.class.st
@@ -11,9 +11,3 @@ Class {
 RGDoubleWordLayout >> isWordLayout [
 	^ true
 ]
-
-{ #category : #accessing }
-RGDoubleWordLayout >> layoutName [
-
-	^ #DoubleWordLayout
-]

--- a/src/Ring-Core/RGEmptyLayout.class.st
+++ b/src/Ring-Core/RGEmptyLayout.class.st
@@ -9,9 +9,3 @@ RGEmptyLayout >> isEmptyLayout [
 
 	^ true
 ]
-
-{ #category : #accessing }
-RGEmptyLayout >> layoutName [
-
-	^ #EmptyLayout
-]

--- a/src/Ring-Core/RGEphemeronLayout.class.st
+++ b/src/Ring-Core/RGEphemeronLayout.class.st
@@ -9,9 +9,3 @@ RGEphemeronLayout >> isEphemeronLayout [
 
 	^ true
 ]
-
-{ #category : #accessing }
-RGEphemeronLayout >> layoutName [
-
-	^ #EphemeronLayout
-]

--- a/src/Ring-Core/RGFixedLayout.class.st
+++ b/src/Ring-Core/RGFixedLayout.class.st
@@ -9,9 +9,3 @@ RGFixedLayout >> isFixedLayout [
 
 	^ true
 ]
-
-{ #category : #accessing }
-RGFixedLayout >> layoutName [
-
-	^ #FixedLayout
-]

--- a/src/Ring-Core/RGImmediateLayout.class.st
+++ b/src/Ring-Core/RGImmediateLayout.class.st
@@ -9,9 +9,3 @@ RGImmediateLayout >> isImmediateLayout [
 
 	^ true
 ]
-
-{ #category : #accessing }
-RGImmediateLayout >> layoutName [
-
-	^ #ImmediateLayout
-]

--- a/src/Ring-Core/RGLayout.class.st
+++ b/src/Ring-Core/RGLayout.class.st
@@ -108,6 +108,11 @@ RGLayout >> isWordLayout [
 ]
 
 { #category : #accessing }
+RGLayout >> layoutName [
+	^ (self class name allButFirst: 2) asSymbol
+]
+
+{ #category : #accessing }
 RGLayout >> resolveSlot: aName ifFound: foundBlock ifNone: exceptionBlock [
 	^exceptionBlock value
 ]

--- a/src/Ring-Core/RGObjectLayout.class.st
+++ b/src/Ring-Core/RGObjectLayout.class.st
@@ -11,12 +11,6 @@ RGObjectLayout >> isObjectLayout [
 ]
 
 { #category : #accessing }
-RGObjectLayout >> layoutName [
-
-	^ #ObjectLayout
-]
-
-{ #category : #accessing }
 RGObjectLayout >> slots [ 
 
 	"only for API compatibility purposes"

--- a/src/Ring-Core/RGPointerLayout.class.st
+++ b/src/Ring-Core/RGPointerLayout.class.st
@@ -64,12 +64,6 @@ RGPointerLayout >> isPointerLayout [
 	^ true
 ]
 
-{ #category : #accessing }
-RGPointerLayout >> layoutName [
-
-	^ #PointerLayout
-]
-
 { #category : #resolving }
 RGPointerLayout >> makeResolved [
 

--- a/src/Ring-Core/RGVariableLayout.class.st
+++ b/src/Ring-Core/RGVariableLayout.class.st
@@ -9,9 +9,3 @@ RGVariableLayout >> isVariableLayout [
 
 	^ true
 ]
-
-{ #category : #accessing }
-RGVariableLayout >> layoutName [
-
-	^ #VariableLayout
-]

--- a/src/Ring-Core/RGWeakLayout.class.st
+++ b/src/Ring-Core/RGWeakLayout.class.st
@@ -15,9 +15,3 @@ RGWeakLayout >> isWeakLayout [
 
 	^ true
 ]
-
-{ #category : #accessing }
-RGWeakLayout >> layoutName [
-
-	^ #EphemeronLayout
-]

--- a/src/Ring-Core/RGWordLayout.class.st
+++ b/src/Ring-Core/RGWordLayout.class.st
@@ -9,9 +9,3 @@ RGWordLayout >> isWordLayout [
 
 	^ true
 ]
-
-{ #category : #accessing }
-RGWordLayout >> layoutName [
-
-	^ #WordLayout
-]


### PR DESCRIPTION
instead of re-implementing #layoutName, we can just use the class name minus the prefix.