### PR TITLE
Cleanup-DuplicatedMethods-ClassParser

### DIFF
--- a/src/ClassParser-Tests/CDPointClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDPointClassParserTest.class.st
@@ -54,13 +54,6 @@ CDPointClassParserTest >> superclassName [
 	^ #Object 
 ]
 
-{ #category : #tests }
-CDPointClassParserTest >> testClassDefFromLegacyStringHasSlots [
-	
-	self assert: classDefinition slotNodes first name equals: self firstInstanceVariableName.
-	self assert: classDefinition slotNodes second name equals: self secondInstanceVariableName.
-]
-
 { #category : #helpers }
 CDPointClassParserTest >> testProperties [
 

--- a/src/ClassParser/CDAbstractTraitCompositionNode.class.st
+++ b/src/ClassParser/CDAbstractTraitCompositionNode.class.st
@@ -57,15 +57,3 @@ CDAbstractTraitCompositionNode >> isTraitComposition [
 CDAbstractTraitCompositionNode >> isTraitNode [
 	^false
 ]
-
-{ #category : #selection }
-CDAbstractTraitCompositionNode >> start [
-	
-	^ originalNode start
-]
-
-{ #category : #selection }
-CDAbstractTraitCompositionNode >> stop [
-	
-	^ originalNode stop
-]

--- a/src/ClassParser/CDBehaviorDefinitionNode.class.st
+++ b/src/ClassParser/CDBehaviorDefinitionNode.class.st
@@ -154,16 +154,6 @@ CDBehaviorDefinitionNode >> slots: aCollection [
 	
 ]
 
-{ #category : #testing }
-CDBehaviorDefinitionNode >> tokens [
-	^ tokens
-]
-
-{ #category : #testing }
-CDBehaviorDefinitionNode >> tokens: aCollection [ 
-	tokens := aCollection
-]
-
 { #category : #accessing }
 CDBehaviorDefinitionNode >> traitDefinition [
 

--- a/src/ClassParser/CDClassDefinitionNode.class.st
+++ b/src/ClassParser/CDClassDefinitionNode.class.st
@@ -12,14 +12,6 @@ Class {
 	#category : #'ClassParser-Model'
 }
 
-{ #category : #'instance creation' }
-CDClassDefinitionNode class >> on: aRBMessageNode [ 
-	
-	^ self new
-		originalNode: aRBMessageNode;
-		yourself
-]
-
 { #category : #accessing }
 CDClassDefinitionNode >> binding [ 
 	self trace: '.'.

--- a/src/ClassParser/CDClassDefinitionParser.class.st
+++ b/src/ClassParser/CDClassDefinitionParser.class.st
@@ -19,12 +19,6 @@ CDClassDefinitionParser class >> fromASTNode: aNode [
 ]
 
 { #category : #parsing }
-CDClassDefinitionParser class >> parse: aString [ 
-	
-	^ self new parse: aString
-]
-
-{ #category : #parsing }
 CDClassDefinitionParser >> handleClassName: aNode withType: aSymbol [
 	
 	self handleClassName: aNode.

--- a/src/ClassParser/CDFluidClassDefinitionParser.class.st
+++ b/src/ClassParser/CDFluidClassDefinitionParser.class.st
@@ -44,12 +44,6 @@ CDFluidClassDefinitionParser class >> fromASTNode: aNode [
 	^ self new parseRootNode: aNode
 ]
 
-{ #category : #parsing }
-CDFluidClassDefinitionParser class >> parse: aString [ 
-	
-	^ self new parse: aString
-]
-
 { #category : #'handling  nodes' }
 CDFluidClassDefinitionParser >> handleClassAndSuperclassOf: aNode [
 


### PR DESCRIPTION
Small cleanup for ClassParser package: remove all  duplicated methods in the hierarchy (the ones that have an equal superclass method)


