### PR TITLE
Use Pharo10 branches for Spec and Newtools

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -20,8 +20,8 @@ BaselineOfPharo class >> icebergVersion [
 BaselineOfPharo class >> newToolsReleaseCommit [
 	"The commit corresponding to current release (to be used on bootstrap process)"
 
-	"v0.6.8"
-	^ '5d8b80ed8a8ff01666447d1f8f085296c152b8ab'
+	"v0.6.9"
+	^ '3f9dfd73609fa14254fedbab70c69842bfde8a76'
 ]
 
 { #category : #'repository urls' }
@@ -33,7 +33,7 @@ BaselineOfPharo class >> newToolsRepository [
 { #category : #versions }
 BaselineOfPharo class >> newToolsVersion [
 
-	^ 'v0.6.8'
+	^ 'dev-1.0'
 ]
 
 { #category : #versions }

--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -33,7 +33,7 @@ BaselineOfPharo class >> newToolsRepository [
 { #category : #versions }
 BaselineOfPharo class >> newToolsVersion [
 
-	^ 'dev-1.0'
+	^ 'Pharo10'
 ]
 
 { #category : #versions }
@@ -53,7 +53,7 @@ BaselineOfPharo class >> specRepository [
 { #category : #versions }
 BaselineOfPharo class >> specVersion [
 
-	^ 'dev-1.0'
+	^ 'Pharo10'
 ]
 
 { #category : #baseline }


### PR DESCRIPTION
use Pharo10 branch of Spec and NewTools (to keep development branches aligned).
in fact, I made a mistake when I pushed "dev-1.0" :(