### PR TITLE
Pharo 9 looks bad on Windows HiDPI Devices (Microsoft Surface)

### DIFF
--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -210,7 +210,11 @@ OSSDL2BackendWindow >> fetchDPI [
 	hdpi := ByteArray new: 4.
 	vdpi := ByteArray new: 4.
 	(SDL2 getDisplay: displayIndex ddpi: ddpi hdpi: hdpi vdpi: vdpi) = 0 ifFalse: [ ^ false ].
-	
+		
+ 	ddpi floatAt: 1 put: 96.0.
+	ddpi floatAt: 1 put: 96.0.
+	ddpi floatAt: 1 put: 96.0.
+		
 	newDiagonalDPI := ddpi floatAt: 1.
 	"Allow automatic scale of factor increments of 5%. We need to
 	round due to precision issues which may result in an almost 1 scale factor, but not exactly one.


### PR DESCRIPTION
Fix #9715