### PR TITLE
Added #combinations: method

### DIFF
--- a/src/Collections-Abstract/SequenceableCollection.class.st
+++ b/src/Collections-Abstract/SequenceableCollection.class.st
@@ -569,6 +569,17 @@ SequenceableCollection >> combinations [
 ]
 
 { #category : #enumerating }
+SequenceableCollection >> combinations: aNumber [
+
+	"Take the items in the receiver, aNumber at a time, return all the combinations"
+
+	^ Array streamContents: [ :stream | 
+		  self
+			  combinations: aNumber
+			  atATimeDo: [ :combination | stream nextPut: combination copy ] ]
+]
+
+{ #category : #enumerating }
 SequenceableCollection >> combinations: kk atATimeDo: aBlock [
 	"Take the items in the receiver, kk at a time, and evaluate the block for each combination.  Hand in an array of elements of self as the block argument.  Each combination only occurs once, and order of the elements does not matter.  There are (self size take: kk) combinations."
 

--- a/src/Collections-Sequenceable-Tests/ArrayTest.class.st
+++ b/src/Collections-Sequenceable-Tests/ArrayTest.class.st
@@ -609,6 +609,17 @@ ArrayTest >> testCombinations [
 ]
 
 { #category : #tests }
+ArrayTest >> testCombinationsTaken [
+
+	self
+		assertCollection: (#( 1 2 3 ) combinations: 2)
+		hasSameElements: #( #( 1 2 ) #( 1 3 ) #( 2 3 ) ).
+	self
+		assertCollection: ((1 to: 4) combinations: 3)
+		hasSameElements: #( #( 1 2 3 ) #( 1 2 4 ) #( 1 3 4 ) #( 2 3 4 ) )
+]
+
+{ #category : #tests }
 ArrayTest >> testComplexIsSelfEvaluating [
 	| complexArray restoredArray |
 	complexArray := {1 . true . false . nil . #a . 'a' . $a . Float pi . Float halfPi . (4 / 5) . Float infinity negated . (1 @ 2) . (0 @ 0 extent: 1 @ 1).


### PR DESCRIPTION
Added the `#combinations: aNumber` method that return the combination taking only `aNumber`. This is useful when you want to obtain only the combination for a `k` number as shown in the formula: 

![equation](https://i0.wp.com/www.fairlynerdy.com/wp-content/uploads/2016/02/combinations.png?resize=625%2C242)