### PR TITLE
Updating the commit of NewTools

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -20,8 +20,8 @@ BaselineOfPharo class >> icebergVersion [
 BaselineOfPharo class >> newToolsReleaseCommit [
 	"The commit corresponding to current release (to be used on bootstrap process)"
 
-	"v0.6.9"
-	^ '3f9dfd73609fa14254fedbab70c69842bfde8a76'
+	"Pharo10"
+	^ '0a30d62222168b54ba9c12608bd10a7c1cfed6a1'
 ]
 
 { #category : #'repository urls' }


### PR DESCRIPTION
This fixes:

- Fixes the commitish of Newtools so Create branch from image works better.
- Missing menu entries for Spotter and Playground (#9749)
- Missing Shortcut for Spotter