### PR TITLE
Pr new user interrupt

### DIFF
--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -136,7 +136,10 @@ OSSDL2Driver >> dispatchEvent: mappedEvent [
 OSSDL2Driver >> evaluateUserInterrupt: anSDLEvent [
 
 	anSDLEvent isUserInterrupt
-		ifTrue: [ UserInterruptHandler new handleUserInterrupt ]
+		ifTrue: [ UserInterruptHandler new handleUserInterrupt ].
+		
+	anSDLEvent isUserInterruptKillAll 
+	 	ifTrue: [ UserInterruptHandler new handleUserInterruptKillAll ].
 ]
 
 { #category : #accessing }

--- a/src/OSWindow-SDL2/SDL2MappedEvent.class.st
+++ b/src/OSWindow-SDL2/SDL2MappedEvent.class.st
@@ -52,6 +52,12 @@ SDL2MappedEvent >> isUserInterrupt [
 	^ false
 ]
 
+{ #category : #testing }
+SDL2MappedEvent >> isUserInterruptKillAll [
+
+	^ false
+]
+
 { #category : #accessing }
 SDL2MappedEvent >> windowID [
 	^ nil

--- a/src/OSWindow-SDL2/SDL2ScanCodeConstants.class.st
+++ b/src/OSWindow-SDL2/SDL2ScanCodeConstants.class.st
@@ -1,0 +1,22 @@
+Class {
+	#name : #SDL2ScanCodeConstants,
+	#superclass : #SharedPool,
+	#classVars : [
+		'SDL_SCANCODE_COMMA',
+		'SDL_SCANCODE_PERIOD'
+	],
+	#category : #'OSWindow-SDL2-Bindings'
+}
+
+{ #category : #initialization }
+SDL2ScanCodeConstants class >> initialize [
+
+	self initializeScanCodes 
+]
+
+{ #category : #initialization }
+SDL2ScanCodeConstants class >> initializeScanCodes [
+
+	SDL_SCANCODE_COMMA := 54.
+	SDL_SCANCODE_PERIOD := 55.
+]

--- a/src/OSWindow-SDL2/SDL2Structure.class.st
+++ b/src/OSWindow-SDL2/SDL2Structure.class.st
@@ -5,7 +5,9 @@ Class {
 	#name : #SDL2Structure,
 	#superclass : #FFIExternalStructure,
 	#pools : [
+		'SDL2',
 		'SDL2Constants',
+		'SDL2ScanCodeConstants',
 		'SDL2Types'
 	],
 	#category : #'OSWindow-SDL2-Bindings'

--- a/src/OSWindow-SDL2/SDL_KeyDownEvent.class.st
+++ b/src/OSWindow-SDL2/SDL_KeyDownEvent.class.st
@@ -27,8 +27,17 @@ SDL_KeyDownEvent >> isKeyDownEvent [
 SDL_KeyDownEvent >> isUserInterrupt [
 
 	^ ((self keysym mod bitAnd: 16r200) = 0) "ignore all if AltGr is pressed" 
+		and: [(self keysym mod anyMask: 1344) "This mask is for meta/cmd"
+			and: [ self keysym scancode = SDL_SCANCODE_PERIOD ] ] "This is the dot scancode"
+	
+]
+
+{ #category : #testing }
+SDL_KeyDownEvent >> isUserInterruptKillAll [
+
+	^ ((self keysym mod bitAnd: 16r200) = 0) "ignore all if AltGr is pressed" 
 		and: [(self keysym mod anyMask: 1344) 
-			and: [ self keysym scancode = 55 ] ]
+			and: [ self keysym scancode = SDL_SCANCODE_COMMA ] ]
 	
 ]
 

--- a/src/System-VMEvents/UserInterruptHandler.class.st
+++ b/src/System-VMEvents/UserInterruptHandler.class.st
@@ -76,6 +76,43 @@ UserInterruptHandler >> handleUserInterrupt [
 ]
 
 { #category : #private }
+UserInterruptHandler >> handleUserInterruptKillAll [
+	"This will be called from the event-fetcher process. 
+	Assume no system-vital processes have a lower priority than this, and are thus ok to interrupt"
+	| killedProcesses |
+	UserInterruptHandler cmdDotEnabled ifFalse: [ ^ self ]. 
+
+	[
+		killedProcesses := self killAllProcess.
+		UIManager default spawnNewProcess.
+		UIManager default inform: 'All processes killed'.
+		killedProcesses inspect.
+	"fork exceptions, we don't want interrupt handler to die"
+	] on: Error fork: [:ex | ex pass].
+]
+
+{ #category : #private }
+UserInterruptHandler >> killAllProcess [
+	"Look for best candidate to interrupt: 
+		- any scheduled non-finalization process of lower priority 
+		- the weak-finalization process, if scheduled 
+		- the UI process 
+	Never interrupt the idle process, since killing it is fatal" 
+
+	|  myself killedProcesses | 
+	killedProcesses := OrderedCollection new.
+	myself := Processor activeProcess.
+	Processor 
+		scanSchedule: [:p | 
+		 "suspendedContext sender == nil usually means that process is only scheduled but had no chance to run" 
+			(p ~~ Processor backgroundProcess and: [p suspendedContext sender notNil and: [p ~~ myself "fallback"]] ) ifTrue: [
+				killedProcesses add: p.
+				p terminate ]]
+		startingAt: Processor highestPriority. 
+	^killedProcesses
+]
+
+{ #category : #private }
 UserInterruptHandler >> processToInterrupt [ 
 	"Look for best candidate to interrupt: 
 		- any scheduled non-finalization process of lower priority 


### PR DESCRIPTION
Adding a new command 'cmd+,' user interrupt that kill all processes.
It respawns an UI process and answer a collection of the killed processes.
The SDL changes are used for adding the shortcut.
Resolve #9762 