### PR TITLE
9780-ARM32-64bits-values-in-structs-should-be-aligned-to-8-bytes

### DIFF
--- a/src/Deprecated10/OSPlatform.extension.st
+++ b/src/Deprecated10/OSPlatform.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #OSPlatform }
+
+{ #category : #'*Deprecated10' }
+OSPlatform class >> currentPlatformName [
+	"Return the name of the platform we're running on"
+
+	<deprecated: 'Use ''Smalltalk vm operatingSystemName'' instead'>
+
+	^ Smalltalk vm operatingSystemName
+]

--- a/src/System-Platforms/MacOSPlatform.class.st
+++ b/src/System-Platforms/MacOSPlatform.class.st
@@ -16,7 +16,7 @@ MacOSPlatform class >> isActivePlatform [
 { #category : #testing }
 MacOSPlatform class >> isMacOS [
 
-	^ self currentPlatformName = 'Mac OS'
+	^ Smalltalk vm operatingSystemName = 'Mac OS'
 ]
 
 { #category : #visiting }

--- a/src/System-Platforms/OSPlatform.class.st
+++ b/src/System-Platforms/OSPlatform.class.st
@@ -24,13 +24,6 @@ OSPlatform class >> current [
 ]
 
 { #category : #'system attributes' }
-OSPlatform class >> currentPlatformName [
-	"Return the name of the platform we're running on"
-
-	^ Smalltalk vm getSystemAttribute: 1001
-]
-
-{ #category : #'system attributes' }
 OSPlatform class >> currentVersion [
 	"Return the version number string of the platform we're running on"
 
@@ -218,7 +211,7 @@ OSPlatform >> menuShortcutString [
 OSPlatform >> name [
 	"Return the name of the platform we're running on"
 
-	^ self class currentPlatformName
+	^ Smalltalk vm operatingSystemName
 ]
 
 { #category : #compatbility }

--- a/src/System-Platforms/Unix32Platform.class.st
+++ b/src/System-Platforms/Unix32Platform.class.st
@@ -9,7 +9,10 @@ Class {
 
 { #category : #testing }
 Unix32Platform class >> isActivePlatform [
-	^ (self currentPlatformName = 'unix') and: [ Smalltalk vm wordSize = 4 ]
+
+	^ (Smalltalk vm operatingSystemName = 'unix') 
+		and: [ Smalltalk vm wordSize = 4 
+			and: [ Smalltalk vm architectureName ~= 'armv7l' ] ] 
 ]
 
 { #category : #visiting }

--- a/src/System-Platforms/Unix64Platform.class.st
+++ b/src/System-Platforms/Unix64Platform.class.st
@@ -15,7 +15,7 @@ Class {
 
 { #category : #testing }
 Unix64Platform class >> isActivePlatform [
-	^ (self currentPlatformName = 'unix') and: [ Smalltalk vm wordSize = 8 ]
+	^ (Smalltalk vm operatingSystemName = 'unix') and: [ Smalltalk vm wordSize = 8 ]
 ]
 
 { #category : #visiting }

--- a/src/System-Platforms/UnixARM32Platform.class.st
+++ b/src/System-Platforms/UnixARM32Platform.class.st
@@ -1,0 +1,16 @@
+"
+I represent the specifics of running Unix in a ARM32 processor
+"
+Class {
+	#name : #UnixARM32Platform,
+	#superclass : #Unix32Platform,
+	#category : #'System-Platforms-Unix'
+}
+
+{ #category : #testing }
+UnixARM32Platform class >> isActivePlatform [
+
+	^ (Smalltalk vm operatingSystemName = 'unix') 
+		and: [ Smalltalk vm wordSize = 4 
+			and: [ Smalltalk vm architectureName = 'armv7l' ] ] 
+]

--- a/src/System-Platforms/Win32Platform.class.st
+++ b/src/System-Platforms/Win32Platform.class.st
@@ -17,7 +17,7 @@ Class {
 { #category : #testing }
 Win32Platform class >> isActivePlatform [
 	"Answer whether the receiver is the active platform"
-	^ self currentPlatformName = 'Win32'
+	^ Smalltalk vm operatingSystemName = 'Win32'
 ]
 
 { #category : #visiting }

--- a/src/System-Platforms/Win64Platform.class.st
+++ b/src/System-Platforms/Win64Platform.class.st
@@ -17,7 +17,7 @@ Class {
 { #category : #testing }
 Win64Platform class >> isActivePlatform [
 	"Answer whether the receiver is the active platform"
-	^ self currentPlatformName = 'Win64'
+	^ Smalltalk vm operatingSystemName = 'Win64'
 ]
 
 { #category : #visiting }

--- a/src/System-Support/VirtualMachine.class.st
+++ b/src/System-Support/VirtualMachine.class.st
@@ -37,6 +37,12 @@ VirtualMachine >> allocationsBetweenGC: anInteger [
 ]
 
 { #category : #accessing }
+VirtualMachine >> architectureName [
+	
+	^ Smalltalk vm getSystemAttribute: 1003
+]
+
+{ #category : #accessing }
 VirtualMachine >> buildDate [			
 	"Return a String reflecting the build date of the VM"
 	"Smalltalk buildDate"
@@ -617,6 +623,12 @@ VirtualMachine >> oldSpaceEnd [
 
 	^ self parameterAt: 1
 
+]
+
+{ #category : #accessing }
+VirtualMachine >> operatingSystemName [
+	
+	^ Smalltalk vm getSystemAttribute: 1001
 ]
 
 { #category : #accessing }

--- a/src/UnifiedFFI/UnixARM32Platform.extension.st
+++ b/src/UnifiedFFI/UnixARM32Platform.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #UnixARM32Platform }
+
+{ #category : #'*UnifiedFFI' }
+UnixARM32Platform >> ffiFloat64Alignment [
+	
+	"64 bits value are aligned to 8 bytes"
+	^ 8
+]
+
+{ #category : #'*UnifiedFFI' }
+UnixARM32Platform >> ffiInt64Alignment [
+	
+	"64 bits value are aligned to 8 bytes"
+	^ 8
+]


### PR DESCRIPTION
Fix #9780
64 bits struct values should be aligned to 8 bytes in ARM32