### PR TITLE
ReadOnlyLiterals-Remove-Preference

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -290,16 +290,6 @@ CompilationContext class >> optionParseErrorsNonInteractiveOnly: aBoolean [
 ]
 
 { #category : #'options - settings API' }
-CompilationContext class >> optionReadOnlyLiterals [
-	^ self readDefaultOption: #optionReadOnlyLiterals
-]
-
-{ #category : #'options - settings API' }
-CompilationContext class >> optionReadOnlyLiterals: aBoolean [
-	^ self writeDefaultOption: #optionReadOnlyLiterals value: aBoolean
-]
-
-{ #category : #'options - settings API' }
 CompilationContext class >> optionSkipSemanticWarnings [
 	^ self readDefaultOption: #optionSkipSemanticWarnings
 ]
@@ -328,8 +318,6 @@ CompilationContext class >> optionsDescription [
 	(- optionInlineNone 				'To turn off all inlining options. Overrides the others')
 	
 	(- optionEmbeddSources         'Embedd sources into CompiledMethod instead of storing in .changes')
-	
-	(+ optionReadOnlyLiterals 			'Compiler sets some literals as read-only')
 	(+ optionFullBlockClosure 			'Compiler compiles closure creation to use FullBlockClosure instead of BlockClosure')
 	(- optionCleanBlockClosure 			'Compiler compiles closure creation to use CleanBlockClosure instead of FullBlockClosure for clean blocks. Experimental')
 	(- optionLongIvarAccessBytecodes 	'Specific inst var accesses to Maybe context objects')
@@ -610,12 +598,6 @@ CompilationContext >> optionParseErrors [
 { #category : #options }
 CompilationContext >> optionParseErrorsNonInteractiveOnly [
 	^ options includes: #optionParseErrorsNonInteractiveOnly
-]
-
-{ #category : #options }
-CompilationContext >> optionReadOnlyLiterals [
-	^ options includes: #optionReadOnlyLiterals
-
 ]
 
 { #category : #options }

--- a/src/OpalCompiler-Core/IRTranslator.class.st
+++ b/src/OpalCompiler-Core/IRTranslator.class.st
@@ -251,13 +251,7 @@ IRTranslator >> visitPushLiteral: lit [
 	| literal |
 	literal := lit literal.
 	"all objects that are not literals we keep writable"
-	literal isLiteral ifFalse: [ ^ gen pushLiteral: literal ].
-	"For symbol we need to set explicitly to writable or read-only. 
-	 Compilation to read-only then back to writable keep the object 
-	 read-only if we don't set it back to writable."
-	compilationContext optionReadOnlyLiterals
-		ifTrue: [ literal beReadOnlyObject ]
-		ifFalse: [ literal beWritableObject ].
+	literal isLiteral ifTrue: [ literal beReadOnlyObject ].
 	^ gen pushLiteral: literal
 	
 ]


### PR DESCRIPTION
In Pharo9 we changed the compiler to compile all literals (that is, where #isLiteral returns true) as read-only.

For testing, we added a compiler preference. Now that this is the default, we can remove the preference as it never makes sense to turn it off

(and even if someone would need to, they can just post-process the literals and send #beWritableObject themselves)


