### PR TITLE
9795-Failing-on-CI-ReleaseTesttestNoEquivalentSuperclassMethods 

### DIFF
--- a/src/Collections-Unordered-Tests/SmallDictionaryTest.class.st
+++ b/src/Collections-Unordered-Tests/SmallDictionaryTest.class.st
@@ -42,19 +42,6 @@ SmallDictionaryTest >> testAtUpdateInitial [
 	
 ]
 
-{ #category : #'tests - new' }
-SmallDictionaryTest >> testNewFromKeysAndValues2 [
- 
-	| dict newDict |
-	dict := self classToBeTested new
-		at: #a put: 1;
-		at: #b put: 2;
-		at: #c put: 3; yourself.
-	newDict := self classToBeTested newFromKeys: dict keys andValues: dict values.
-	dict keysAndValuesDo: [:k :v|
-		self assert: (newDict at: k) equals: v ]. 
-]
-
 { #category : #'tests - printing' }
 SmallDictionaryTest >> testStoreOn [
 	self

--- a/src/EnlumineurFormatter-Tests/EFBlockExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFBlockExpressionTest.class.st
@@ -333,11 +333,6 @@ EFBlockExpressionTest >> openBracket [
 	^ '['
 ]
 
-{ #category : #helpers }
-EFBlockExpressionTest >> parserClass [
-	^ RBParser
-]
-
 { #category : #configurations }
 EFBlockExpressionTest >> periodAtEndConfiguration [
 	"Here we can control explicitely the configuration we want."

--- a/src/Epicea/EpUnknownRefactoring.class.st
+++ b/src/Epicea/EpUnknownRefactoring.class.st
@@ -24,11 +24,6 @@ EpUnknownRefactoring >> asRBRefactoring [
 	^ self shouldNotImplement
 ]
 
-{ #category : #testing }
-EpUnknownRefactoring >> canBuildRBRefactoring [
-	^ false
-]
-
 { #category : #initialization }
 EpUnknownRefactoring >> initializeWith: aRBRefactoring [
 	self initialize.

--- a/src/Metacello-Core/MetacelloVersionNumber.class.st
+++ b/src/Metacello-Core/MetacelloVersionNumber.class.st
@@ -117,13 +117,6 @@ MetacelloVersionNumber >> asMetacelloVersionNumber [
 	^self
 ]
 
-{ #category : #printing }
-MetacelloVersionNumber >> asString [
-	"Answer a string that represents the receiver."
-
-	^ self printString
-]
-
 { #category : #private }
 MetacelloVersionNumber >> collapseZeros [
 	"the rule must be that zeros can be collapsed as long as the series of zeros ends in a string term"

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -274,7 +274,7 @@ ReleaseTest >> testNoEquivalentSuperclassMethods [
 			ifNil: [ false ] ]
 		ifNil: [ false ]
 	].
-	self assert: methods size <= 474.
+	self assert: methods size <= 470.
 	ASTCache reset.
 
 

--- a/src/System-Model/DisplayableObject.class.st
+++ b/src/System-Model/DisplayableObject.class.st
@@ -11,12 +11,6 @@ Class {
 }
 
 { #category : #accessing }
-DisplayableObject >> iconNamed: aSymbol [
-	"May be this method should not be managed by a presenter and not DisplayableObject"
-	^ Smalltalk ui icons iconNamed: aSymbol
-]
-
-{ #category : #accessing }
 DisplayableObject >> theme [
 	
 	^ Smalltalk ui theme

--- a/src/Tool-Finder-Tests/MethodFinderBottomClass.class.st
+++ b/src/Tool-Finder-Tests/MethodFinderBottomClass.class.st
@@ -76,15 +76,3 @@ MethodFinderBottomClass >> otherOneArgumentMethod: s [
 
 	^ s, ''
 ]
-
-{ #category : #accessing }
-MethodFinderBottomClass >> topApprovedButBottomDisapprovedMethod [
-
-	^self
-]
-
-{ #category : #accessing }
-MethodFinderBottomClass >> topDisapprovedButBottomApprovedMethod [
-
-	^self
-]


### PR DESCRIPTION

fixes #9795 by removing more useless methods