### PR TITLE
Cleaning up `ValueLink` objects

### DIFF
--- a/src/Collections-Sequenceable-Tests/LinkedListTest.class.st
+++ b/src/Collections-Sequenceable-Tests/LinkedListTest.class.st
@@ -14,7 +14,6 @@ Class {
 		'link2',
 		'link3',
 		'link4',
-		'link5',
 		'nonEmpty',
 		'otherList',
 		'link',
@@ -275,7 +274,6 @@ LinkedListTest >> setUp [
 	link2 := 'test'.
 	link3 := $h.
 	link4 := Set new.
-	link5 := nil.
 	elementNotIn := Link new.
 	collectionWithoutNil := LinkedList new add: link1; add: link2 ; add: link3; yourself.
 	elementIn := 'thisElementIsIncluded'.
@@ -328,6 +326,7 @@ LinkedListTest >> tearDown [
 
 { #category : #tests }
 LinkedListTest >> test01add [
+
 	self assertEmpty: list.
 	list add: link1.
 	self assert: list size equals: 1.
@@ -350,14 +349,14 @@ LinkedListTest >> test01add [
 	self assert: list second equals: link2.
 	self assert: list third equals: link3.
 	self assert: list fourth equals: link4.
-	
-	list add: link5.
+
+	list add: nil.
 	self assert: list size equals: 5.
 	self assert: list first equals: link1.
 	self assert: list second equals: link2.
 	self assert: list third equals: link3.
 	self assert: list fourth equals: link4.
-	self assert: list fifth equals: link5.
+	self assert: list fifth equals: nil
 ]
 
 { #category : #tests }

--- a/src/Collections-Sequenceable-Tests/LinkedListTest.class.st
+++ b/src/Collections-Sequenceable-Tests/LinkedListTest.class.st
@@ -14,6 +14,7 @@ Class {
 		'link2',
 		'link3',
 		'link4',
+		'link5',
 		'nonEmpty',
 		'otherList',
 		'link',
@@ -274,6 +275,7 @@ LinkedListTest >> setUp [
 	link2 := 'test'.
 	link3 := $h.
 	link4 := Set new.
+	link5 := nil.
 	elementNotIn := Link new.
 	collectionWithoutNil := LinkedList new add: link1; add: link2 ; add: link3; yourself.
 	elementIn := 'thisElementIsIncluded'.
@@ -347,7 +349,15 @@ LinkedListTest >> test01add [
 	self assert: list first equals: link1.
 	self assert: list second equals: link2.
 	self assert: list third equals: link3.
-	self assert: list fourth equals: link4
+	self assert: list fourth equals: link4.
+	
+	list add: link5.
+	self assert: list size equals: 5.
+	self assert: list first equals: link1.
+	self assert: list second equals: link2.
+	self assert: list third equals: link3.
+	self assert: list fourth equals: link4.
+	self assert: list fifth equals: link5.
 ]
 
 { #category : #tests }

--- a/src/Collections-Support-Tests/ValueLinkForTesting.class.st
+++ b/src/Collections-Support-Tests/ValueLinkForTesting.class.st
@@ -1,5 +1,10 @@
 "
 I am a variant of `ValueLink` to show the behavior of `Object>>#~~>`.
+
+In particular, I will be used to test expressions of the form `a ~~> b` 
+that create a link (with `a` as value) of the same class of the link `b`, 
+so I don't introduce any new methods but provide myself to check that newly 
+created links keep the class of the chain we are pushing on.
 "
 Class {
 	#name : #ValueLinkForTesting,

--- a/src/Collections-Support-Tests/ValueLinkForTesting.class.st
+++ b/src/Collections-Support-Tests/ValueLinkForTesting.class.st
@@ -1,0 +1,8 @@
+"
+I am a variant of `ValueLink` to show the behavior of `Object>>#~~>`.
+"
+Class {
+	#name : #ValueLinkForTesting,
+	#superclass : #ValueLink,
+	#category : #'Collections-Support-Tests-Links'
+}

--- a/src/Collections-Support-Tests/ValueLinkTest.class.st
+++ b/src/Collections-Support-Tests/ValueLinkTest.class.st
@@ -1,0 +1,29 @@
+"
+A ValueLinkTest is a test class for testing the behavior of ValueLink
+"
+Class {
+	#name : #ValueLinkTest,
+	#superclass : #TestCase,
+	#category : #'Collections-Support-Tests-Links'
+}
+
+{ #category : #tests }
+ValueLinkTest >> testNilAsLink [
+
+	self assert: nil asLink equals: (ValueLink value: nil)
+]
+
+{ #category : #tests }
+ValueLinkTest >> testPushingOnValueLink [
+
+	| link link1 link2 link3 |
+	link := 3 ~~> nil.
+	link1 := 5 ~~> link.
+	link2 := ValueLinkForTesting value: 8.
+	link3 := link1 value + link2 value ~~> link2.
+
+	self
+		assert: link1 class equals: ValueLink;
+		assert: link3 class equals: ValueLinkForTesting;
+		assert: link3 value equals: 13
+]

--- a/src/Collections-Support-Tests/ValueLinkTest.class.st
+++ b/src/Collections-Support-Tests/ValueLinkTest.class.st
@@ -19,11 +19,20 @@ ValueLinkTest >> testPushingOnValueLink [
 	| link link1 link2 link3 |
 	link := 3 ~~> nil.
 	link1 := 5 ~~> link.
-	link2 := ValueLinkForTesting value: 8.
+	link2 := ValueLinkForTesting new
+		         value: 8;
+		         nextLink: link1;
+		         yourself.
 	link3 := link1 value + link2 value ~~> link2.
 
 	self
-		assert: link1 class equals: ValueLink;
+		assert: link3 value equals: 13;
 		assert: link3 class equals: ValueLinkForTesting;
-		assert: link3 value equals: 13
+		assert: link3 nextLink value equals: 8;
+		assert: link3 nextLink class equals: ValueLinkForTesting;
+		assert: link3 nextLink nextLink value equals: 5;
+		assert: link3 nextLink nextLink class equals: ValueLink;
+		assert: link3 nextLink nextLink nextLink value equals: 3;
+		assert: link3 nextLink nextLink nextLink class equals: ValueLink;
+		assert: link3 nextLink nextLink nextLink nextLink equals: nil
 ]

--- a/src/Collections-Support-Tests/ValueLinkTest.class.st
+++ b/src/Collections-Support-Tests/ValueLinkTest.class.st
@@ -14,7 +14,21 @@ ValueLinkTest >> testNilAsLink [
 ]
 
 { #category : #tests }
-ValueLinkTest >> testPushingOnValueLink [
+ValueLinkTest >> testPushingOnObjects [
+
+	| link o |
+	o := Object new.
+	link := 3 ~~> (#aSymbol ~~> o).
+
+	self
+		assert: link value equals: 3;
+		assert: link nextLink value equals: #aSymbol;
+		assert: link nextLink nextLink value equals: o;
+		assert: link nextLink nextLink nextLink equals: nil
+]
+
+{ #category : #tests }
+ValueLinkTest >> testPushingOnValueLinks [
 
 	| link link1 link2 link3 |
 	link := 3 ~~> nil.

--- a/src/Collections-Support/Link.class.st
+++ b/src/Collections-Support/Link.class.st
@@ -22,6 +22,12 @@ Link >> asLink [
 	^self
 ]
 
+{ #category : #dispatched }
+Link >> asLinkPrepend: anObject [
+
+	^ self class nextLink: self
+]
+
 { #category : #accessing }
 Link >> nextLink [
 	"Answer the link to which the receiver points."

--- a/src/Collections-Support/ValueLink.class.st
+++ b/src/Collections-Support/ValueLink.class.st
@@ -26,6 +26,14 @@ ValueLink >> = anotherObject [
 				and: [self nextLink == anotherObject nextLink]]
 ]
 
+{ #category : #dispatched }
+ValueLink >> asLinkPrepend: anObject [
+
+	^ (super asLinkPrepend: anObject)
+		  value: anObject;
+		  yourself
+]
+
 { #category : #comparing }
 ValueLink >> hash [
 	^self value hash bitXor: nextLink identityHash 

--- a/src/Kernel-Tests/ContinuationTest.class.st
+++ b/src/Kernel-Tests/ContinuationTest.class.st
@@ -266,15 +266,16 @@ ContinuationTest >> remove: anObj uptoLastValueLink: aValueLink continuation: sk
 
 { #category : #tests }
 ContinuationTest >> testBlockEscape [
-
 	| x |
+	self flag: #flakyTest.
+	self skip.
 	tmp := 0.
-	x := [ 
-	     tmp := tmp + 1.
-	     tmp2 value ].
-	self callcc: [ :cc | 
-		tmp2 := cc.
-		x value ].
+	x := [ tmp := tmp + 1.
+	tmp2 value ].
+	self
+		callcc: [ :cc | 
+			tmp2 := cc.
+			x value ].
 	tmp2 := [  ].
 	x value.
 	self assert: tmp equals: 2

--- a/src/Kernel-Tests/ContinuationTest.class.st
+++ b/src/Kernel-Tests/ContinuationTest.class.st
@@ -266,16 +266,15 @@ ContinuationTest >> remove: anObj uptoLastValueLink: aValueLink continuation: sk
 
 { #category : #tests }
 ContinuationTest >> testBlockEscape [
+
 	| x |
-	self flag: #flakyTest.
-	self skip.
 	tmp := 0.
-	x := [ tmp := tmp + 1.
-	tmp2 value ].
-	self
-		callcc: [ :cc | 
-			tmp2 := cc.
-			x value ].
+	x := [ 
+	     tmp := tmp + 1.
+	     tmp2 value ].
+	self callcc: [ :cc | 
+		tmp2 := cc.
+		x value ].
 	tmp2 := [  ].
 	x value.
 	self assert: tmp equals: 2

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -337,6 +337,12 @@ Object >> asLink [
 ]
 
 { #category : #converting }
+Object >> asLinkPrepend: anObject [
+
+	^ self asLink asLinkPrepend: anObject
+]
+
+{ #category : #converting }
 Object >> asOrderedCollection [
 	"Answer an OrderedCollection with the receiver as its only element."
 
@@ -2188,17 +2194,11 @@ Object >> ~= anObject [
 
 { #category : #associating }
 Object >> ~~> aValueLinkOrNil [
-	"Answer a ValueLink between self and aValueLinkOrNil.
-	This message allows the receiver to be inserted in a chain of objects, terminated by nil."
 
-	"Code of ValueLink>>#nextLink: and ValueLink>>#value: are inline here for speed."
-
-	"(1 ~~> nil) = ValueLink new value: 1"
-	"(1 ~~> 'one') value >>> 1"
-	"(1 ~~> nil) nextLink >>> nil"
-
-	"Note that `value` can be ANY object; on the other hand, `nextLink` should be either another 
-	ValueLink object or nil."
+	"Answer a link of the same class of `aValueLinkOrNil`; if that argument is nil,
+	 then the Link hierarchy is used as fallback. Moreover, `aValueLinkOrNil` can be
+	 any object, in that case by dispatching of #asLinkPrepend:, that object is enclosed
+	 in a Link and then used to chain `self`. "
 
 	^ aValueLinkOrNil asLinkPrepend: self
 ]

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -2200,8 +2200,5 @@ Object >> ~~> aValueLinkOrNil [
 	"Note that `value` can be ANY object; on the other hand, `nextLink` should be either another 
 	ValueLink object or nil."
 
-	^ ValueLink basicNew
-		value: self;
-		nextLink: aValueLinkOrNil;
-		yourself
+	^ aValueLinkOrNil asLinkPrepend: self
 ]

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -53,7 +53,7 @@ UndefinedObject >> asCollectionElement [
 { #category : #dispatched }
 UndefinedObject >> asLinkPrepend: anObject [
 
-	^ ValueLink value: anObject
+	^ anObject asLink
 ]
 
 { #category : #accessing }

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -50,6 +50,12 @@ UndefinedObject >> asCollectionElement [
 	^ CollectionElement withNil
 ]
 
+{ #category : #dispatched }
+UndefinedObject >> asLinkPrepend: anObject [
+
+	^ ValueLink value: anObject
+]
+
 { #category : #accessing }
 UndefinedObject >> at: index put: anObject [ 
 	self shouldNotImplement 

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -53,7 +53,7 @@ UndefinedObject >> asCollectionElement [
 { #category : #dispatched }
 UndefinedObject >> asLinkPrepend: anObject [
 
-	^ anObject asLink
+	^ ValueLink value: anObject
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This PR primarily fixes the creation of `Link` objects as happen in the message `Object>>#~~>`. 

The current implementation sends `#basicNew` then sets some properties and, finally, returns the newly created link without a send of `#initialize`. The proposed change dispatches over the argument of the binary message in order to maintain the class of the links the sender is pushing on. Moreover, also the following points changes:
- A refinement of the test case about `#add:` for `LinkedList` objects when a sender wants to add `nil` to it.
- A new test class for `ValueLink` objects and two test cases:
  - `#testPushingOnValueLink` that records the subject of this PR as explained above;
  - `#testNilAsLink` that shows how `nil` is related to links creation.