### PR TITLE
Skip-testModifiedReturn

### DIFF
--- a/src/OpalCompiler-Tests/OCTargetCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCTargetCompilerTest.class.st
@@ -13,6 +13,7 @@ OCTargetCompilerTest >> expectedFailures [
 OCTargetCompilerTest >> testModifiedReturn [
 	" I test that the compilerClass method works for instance-side "
 	" if something has failed to recompile using compilerClass, then you may need to go to OCTargetCompilerSample and force recompile of the method returnExpected (by e.g. adding/deleting a space and saving) "
+	self skipOnPharoCITestingEnvironment.
 	self assert: OCTargetCompilerSample new returnExpected equals: #expectedReturn.
 
 ]


### PR DESCRIPTION
add a #skipOnPharoCITestingEnvironment for now for  testModifiedRetuurn while we analyze the problem


