### PR TITLE
RecurseReadOnly-LiteralArray

### DIFF
--- a/src/Collections-Sequenceable-Tests/ArrayTest.class.st
+++ b/src/Collections-Sequenceable-Tests/ArrayTest.class.st
@@ -603,6 +603,13 @@ ArrayTest >> testAtWrap2 [
 ]
 
 { #category : #tests }
+ArrayTest >> testBeReadOnlyLiteral [
+	self assert: (Array new) beReadOnlyLiteral isReadOnlyObject.
+	self assert: (Array with: (String new)) beReadOnlyLiteral first isReadOnlyObject.
+	self deny: (Array with: (Object new)) first isReadOnlyObject
+]
+
+{ #category : #tests }
 ArrayTest >> testCombinations [
 	self assert: #(1 2 3) combinations equals: #(#(1) #(2) #(3) #(1 2) #(1 3) #(2 3) #(1 2 3)).
 	self assert: (1 to: 3) combinations equals: #(#(1) #(2) #(3) #(1 2) #(1 3) #(2 3) #(1 2 3))

--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -168,6 +168,13 @@ Array >> atWrap: index put: anObject [
 	^ self at: index - 1 \\ self size + 1 put: anObject
 ]
 
+{ #category : #'write barrier' }
+Array >> beReadOnlyLiteral [
+	self isLiteral ifFalse: [ ^ self ].
+	self beReadOnlyObject.
+	self do: [ :each | each beReadOnlyLiteral ]
+]
+
 { #category : #copying }
 Array >> copyWithDependent: newElement [
 	self size = 0 ifTrue:[^DependentsArray with: newElement].

--- a/src/Kernel-Tests/ObjectTest.class.st
+++ b/src/Kernel-Tests/ObjectTest.class.st
@@ -28,6 +28,12 @@ ObjectTest >> testAs [
 ]
 
 { #category : #'tests - write barrier' }
+ObjectTest >> testBeReadOnlyLiteral [
+	self assert: String new beReadOnlyLiteral isReadOnlyObject.
+	self deny: Object new beReadOnlyLiteral isReadOnlyObject
+]
+
+{ #category : #'tests - write barrier' }
 ObjectTest >> testBeRecursivelyReadOnlyObject [
 
 	| assoc array |

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -460,6 +460,13 @@ Object >> basicSize [
 ]
 
 { #category : #'write barrier' }
+Object >> beReadOnlyLiteral [
+	"This is used by the compiler, it recurses into Arrays (see the override there)"
+	self isLiteral ifFalse: [ ^ self ].
+	self beReadOnlyObject
+]
+
+{ #category : #'write barrier' }
 Object >> beReadOnlyObject [
 	"If the VM supports read-only objects it will not write to read-only objects.
 	 An attempt to write to an instance variable of a read-only object will

--- a/src/OpalCompiler-Core/IRTranslator.class.st
+++ b/src/OpalCompiler-Core/IRTranslator.class.st
@@ -248,12 +248,7 @@ IRTranslator >> visitPushInstVar: instVar [
 
 { #category : #visiting }
 IRTranslator >> visitPushLiteral: lit [
-	| literal |
-	literal := lit literal.
-	"all objects that are not literals we keep writable"
-	literal isLiteral ifTrue: [ literal beReadOnlyObject ].
-	^ gen pushLiteral: literal
-	
+	^ gen pushLiteral: lit literal beReadOnlyLiteral
 ]
 
 { #category : #visiting }


### PR DESCRIPTION
Since Pharo9. literals are immutable.
But we did not recurse into the Literal Arrays.

This PR:
- add #beReadOnlyLiteral and test
- use it in the compiler

