### PR TITLE
Unify #layoutForType: with the #kind methods.

### DIFF
--- a/src/ClassParser-Tests/CDFluidClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDFluidClassParserTest.class.st
@@ -330,7 +330,7 @@ CDFluidClassParserTest >> testVariableWordSubclass [
 		layout: WordLayout;
 		package: #MyPackage'.
 	def := parser parse: defString.
-	self assert: def classKind equals: #variableWord
+	self assert: def classKind equals: #words
 ]
 
 { #category : #'tests - (r) kinds' }

--- a/src/Kernel/AbstractLayout.class.st
+++ b/src/Kernel/AbstractLayout.class.st
@@ -16,12 +16,6 @@ AbstractLayout class >> isAbstract [
 	^self == AbstractLayout
 ]
 
-{ #category : #description }
-AbstractLayout class >> kind [
-	"Return an identifier describing uniquely the layout"
-	^ self subclassResponsibility
-]
-
 { #category : #comparing }
 AbstractLayout >> = other [
 	^ self class = other class

--- a/src/Kernel/ByteLayout.class.st
+++ b/src/Kernel/ByteLayout.class.st
@@ -16,7 +16,7 @@ ByteLayout class >> extending: superLayout scope: aScope host: aClass [
 
 { #category : #description }
 ByteLayout class >> kind [ 
-	^ #variableByte
+	^ #bytes
 ]
 
 { #category : #accessing }

--- a/src/Kernel/DoubleByteLayout.class.st
+++ b/src/Kernel/DoubleByteLayout.class.st
@@ -14,11 +14,6 @@ DoubleByteLayout class >> extending: superLayout scope: aScope host: aClass [
 		yourself
 ]
 
-{ #category : #description }
-DoubleByteLayout class >> kind [ 
-	^ #variableDoubleByte
-]
-
 { #category : #accessing }
 DoubleByteLayout >> bytesPerSlot [
 

--- a/src/Kernel/DoubleWordLayout.class.st
+++ b/src/Kernel/DoubleWordLayout.class.st
@@ -14,11 +14,6 @@ DoubleWordLayout class >> extending: superLayout scope: aScope host: aClass [
 		yourself
 ]
 
-{ #category : #description }
-DoubleWordLayout class >> kind [ 
-	^ #variableDoubleWord
-]
-
 { #category : #extending }
 DoubleWordLayout >> extendDoubleWord [
 	^ DoubleWordLayout new

--- a/src/Kernel/EmptyLayout.class.st
+++ b/src/Kernel/EmptyLayout.class.st
@@ -15,12 +15,6 @@ EmptyLayout class >> instance [
 	^ instance ifNil: [ instance := self new ]
 ]
 
-{ #category : #description }
-EmptyLayout class >> kind [ 	
-
-	^ #empty
-]
-
 { #category : #extending }
 EmptyLayout >> extend: someSlots [
 	^ FixedLayout new

--- a/src/Kernel/ImmediateLayout.class.st
+++ b/src/Kernel/ImmediateLayout.class.st
@@ -18,7 +18,6 @@ ImmediateLayout class >> extending: superLayout scope: aScope host: aClass [
 
 { #category : #description }
 ImmediateLayout class >> kind [ 	
-
 	^ #immediate
 ]
 

--- a/src/Kernel/ObjectLayout.class.st
+++ b/src/Kernel/ObjectLayout.class.st
@@ -17,27 +17,18 @@ ObjectLayout class >> isAbstract [
 	^self == ObjectLayout
 ]
 
-{ #category : #accessing }
+{ #category : #description }
+ObjectLayout class >> kind [
+	"return the symbol that Monticello uses to encode the layout"
+	^self name asSymbol
+]
+
+{ #category : #monticello }
 ObjectLayout class >> layoutForType: typeSymbol [
-	typeSymbol = #compiledMethod 
-		ifTrue: [ ^ CompiledMethodLayout ].
-	typeSymbol = #bytes 
-		ifTrue: [ ^ ByteLayout ].
-	typeSymbol = #words 
-		ifTrue: [ ^ WordLayout ].
-	typeSymbol = #weak 
-		ifTrue: [ ^ WeakLayout ].
-	typeSymbol = #variable 
-		ifTrue: [ ^ VariableLayout ].
-	typeSymbol = #normal 
-		ifTrue: [ ^ FixedLayout ].
-	typeSymbol = #immediate 
-		ifTrue: [ ^ ImmediateLayout ].
-	typeSymbol = #ephemeron
-		ifTrue: [ ^ EphemeronLayout ].
-	"hack to support user defined layouts"
-	(Smalltalk hasClassNamed: typeSymbol) ifTrue: [ ^Smalltalk globals at: typeSymbol ].
-	Error signal: 'Invalid layout type: ', typeSymbol asString.
+	"used to get the layout for a Monticello internal layout symbol"
+	^self allSubclasses 
+		detect: [ :class | class kind = typeSymbol ] 
+		ifNone: [ Error signal: 'Invalid layout type: ', typeSymbol asString ]
 ]
 
 { #category : #extending }

--- a/src/Kernel/WordLayout.class.st
+++ b/src/Kernel/WordLayout.class.st
@@ -16,7 +16,7 @@ WordLayout class >> extending: superLayout scope: aScope host: aClass [
 
 { #category : #description }
 WordLayout class >> kind [ 
-	^ #variableWord
+	^ #words
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- make sure to use the right symbols in #kind, implement a fall back on ObjectLayout that returns the name of the layout
- instead of hard-Coding the symbols in #layoutForType:, iterate over the subclasses instead.

This is all just internal to Monticello, maybe we should rename #kind to #mcType (as it is in Ring2) later to make this clearer.