### PR TITLE
Ring2: simplify #mcType and unify with #kind

### DIFF
--- a/src/Ring-Monticello/RGDoubleByteLayout.extension.st
+++ b/src/Ring-Monticello/RGDoubleByteLayout.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #RGDoubleByteLayout }
-
-{ #category : #'*Ring-Monticello' }
-RGDoubleByteLayout >> mcType [
-
-	^ #DoubleByteLayout 
-]

--- a/src/Ring-Monticello/RGDoubleWordLayout.extension.st
+++ b/src/Ring-Monticello/RGDoubleWordLayout.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #RGDoubleWordLayout }
-
-{ #category : #'*Ring-Monticello' }
-RGDoubleWordLayout >> mcType [
-
-	^ #DoubleWordLayout 
-]

--- a/src/Ring-Monticello/RGLayout.extension.st
+++ b/src/Ring-Monticello/RGLayout.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #RGLayout }
+
+{ #category : #'*Ring-Monticello' }
+RGLayout >> mcType [
+	^ self layoutName
+]


### PR DESCRIPTION
#mcType should have a fallback on  RGLayout returning the layoutName.

This makes it extensible and allows to remove the hardcoded cases for #DoubleByteLayout and  #DoubleWordLayout
(and follows the implementation of #kind on the layout classes, see #9819)