### PR TITLE
Exposing the ABI of a function to the image.

### DIFF
--- a/src/ThreadedFFI-Tests/TFFunctionCallTest.class.st
+++ b/src/ThreadedFFI-Tests/TFFunctionCallTest.class.st
@@ -85,7 +85,7 @@ TFFunctionCallTest >> testCallingFunctionWithW64CallingConvention [
 	| fun returnValue |
 	
 	"This test is only valid in OSX and X86_64, as calling conventions constants are heavily dependant on the OS & Architecture"
-	(OSPlatform current isMacOS and: [ (Smalltalk vm getSystemAttribute: 1003) = 'x86_64']) 
+	(OSPlatform current isMacOS and: [ Smalltalk vm architectureName = 'x86_64']) 
 		ifFalse: [ self skip ].
 
 	fun := TFExternalFunction

--- a/src/ThreadedFFI-Tests/TFFunctionCallTest.class.st
+++ b/src/ThreadedFFI-Tests/TFFunctionCallTest.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #TFFunctionCallTest,
 	#superclass : #TFTestCase,
+	#pools : [
+		'TFAbiTypes'
+	],
 	#category : #'ThreadedFFI-Tests'
 }
 
@@ -73,6 +76,29 @@ TFFunctionCallTest >> testCallbackInSingleFunction [
 	returnValue := runner invokeFunction: fun withArguments: {callback getHandle. 3}.
 
 	self assert: returnValue equals: 5
+
+]
+
+{ #category : #tests }
+TFFunctionCallTest >> testCallingFunctionWithW64CallingConvention [
+
+	| fun returnValue |
+	
+	"This test is only valid in OSX and X86_64, as calling conventions constants are heavily dependant on the OS & Architecture"
+	(OSPlatform current isMacOS and: [ (Smalltalk vm getSystemAttribute: 1003) = 'x86_64']) 
+		ifFalse: [ self skip ].
+
+	fun := TFExternalFunction
+		name: 'w64Convention'
+		moduleName: self libraryPath
+		definition: (TFFunctionDefinition
+			parameterTypes: {TFBasicType sint. TFBasicType sint. TFBasicType sint. TFBasicType sint. TFBasicType sint. TFBasicType sint. TFBasicType sint. TFBasicType sint. TFBasicType sint. TFBasicType sint}
+			returnType: TFBasicType sint
+			abi: DARWIN_X86_64_WIN64).
+			
+	returnValue := runner invokeFunction: fun withArguments: (1 to: 10) asArray.
+
+	self assert: returnValue equals: 55
 
 ]
 

--- a/src/ThreadedFFI-UFFI-Tests/TFUFFIDifferentCallingConventionFunctionCallTest.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFUFFIDifferentCallingConventionFunctionCallTest.class.st
@@ -1,0 +1,42 @@
+Class {
+	#name : #TFUFFIDifferentCallingConventionFunctionCallTest,
+	#superclass : #TFUFFITestCase,
+	#category : #'ThreadedFFI-UFFI-Tests'
+}
+
+{ #category : #tests }
+TFUFFIDifferentCallingConventionFunctionCallTest >> calloutWithManyArguments: arg1 and: arg2 and: arg3 and: arg4 and: arg5 and: arg6 and: arg7 and: arg8 and: arg9 and: arg10 [
+	^ self
+		ffiCall:
+			#(int w64Convention #(int arg1 , int arg2 , int arg3 , int arg4 , int arg5 , int arg6 , int arg7 , int arg8 , int arg9 , int arg10))
+]
+
+{ #category : #private }
+TFUFFIDifferentCallingConventionFunctionCallTest >> ffiCallingConvention [ 
+
+	^ #win64
+]
+
+{ #category : #tests }
+TFUFFIDifferentCallingConventionFunctionCallTest >> testCallingFunctionWithW64CallingConvention [
+
+	| result |
+	
+	"This test is only valid in OSX and X86_64, as calling conventions constants are heavily dependant on the OS & Architecture"
+	(OSPlatform current isMacOS and: [ Smalltalk vm architectureName = 'x86_64']) 
+		ifFalse: [ self skip ].
+			
+	result := self
+			calloutWithManyArguments: 1
+			and: 2
+			and: 3
+			and: 4
+			and: 5
+			and: 6
+			and: 7
+			and: 8
+			and: 9
+			and: 10.
+			
+	self assert: result equals: 55
+]

--- a/src/ThreadedFFI-UFFI/TFCalloutMethodBuilder.class.st
+++ b/src/ThreadedFFI-UFFI/TFCalloutMethodBuilder.class.st
@@ -4,18 +4,92 @@ I override some methods to correctly generate TFFI methods when using UFFI.
 Class {
 	#name : #TFCalloutMethodBuilder,
 	#superclass : #FFICalloutMethodBuilder,
+	#classVars : [
+		'ABI_MAPPING'
+	],
+	#pools : [
+		'TFAbiTypes'
+	],
 	#category : #'ThreadedFFI-UFFI'
 }
 
+{ #category : #'calling conventions' }
+TFCalloutMethodBuilder class >> abiConstantFor: aString [
+
+	| key |
+	aString = OSPlatform current ffiCallingConvention ifTrue: [ 
+		^ DEFAULT_ABI ].
+	key := { 
+		       Smalltalk vm operatingSystemName asSymbol.
+		       Smalltalk vm architectureName asSymbol.
+		       aString asSymbol }.
+
+	^ self abiConstantMapping at: key ifAbsent: [ 
+		  self error: 'The requested ABI is not available for this architecture:'
+		  , key printString ]
+]
+
+{ #category : #'calling convention' }
+TFCalloutMethodBuilder class >> abiConstantMapping [
+	
+	^ ABI_MAPPING ifNil: [ self initializeABIMapping ]
+]
+
+{ #category : #'initialization - private' }
+TFCalloutMethodBuilder class >> initializeABIMapping [
+
+	"self initializeABIMapping"
+
+	^ ABI_MAPPING := { 
+		  ({ #Win32. #x86_64. #win64 } -> WIN_X86_64_WIN64).
+		  ({ #Win32. #x86_64. #gnuw64 } -> WIN_X86_64_GNUW64).
+
+		  ({ #'Mac OS'. #x86_64. #unix64 } -> DARWIN_X86_64_UNIX64).
+		  ({ #'Mac OS'. #x86_64. #win64 } -> DARWIN_X86_64_WIN64).
+		  ({ #'Mac OS'. #x86_64. #gnuw64 } -> DARWIN_X86_64_GNUW64).
+
+		  ({ #unix. #x86_64. #unix64 } -> UNIX_X86_64_UNIX64).
+		  ({ #unix. #x86_64. #win64 } -> UNIX_X86_64_WIN64).
+		  ({ #unix. #x86_64. #gnuw64 } -> UNIX_X86_64_GNUW64).
+
+		  ({ #Win32. #i686. #sysv } -> WIN_X86_32_SYSV).
+		  ({ #Win32. #i686. #stdcall } -> WIN_X86_32_STDCALL).
+		  ({ #Win32. #i686. #thisCall } -> WIN_X86_32_THISCALL).
+		  ({ #Win32. #i686. #fastCall } -> WIN_X86_32_FASTCALL).
+		  ({ #Win32. #i686. #ms_cdecl } -> WIN_X86_32_MS_CDECL).
+		  ({ #Win32. #i686. #pascal } -> WIN_X86_32_PASCAL).
+		  ({ #Win32. #i686. #register } -> WIN_X86_32_REGISTER).
+
+		  ({ #unix. #i686. #sysv } -> UNIX_X86_32_SYSV).
+		  ({ #unix. #i686. #thisCall } -> UNIX_X86_32_THISCALL).
+		  ({ #unix. #i686. #fastCall } -> UNIX_X86_32_FASTCALL).
+		  ({ #unix. #i686. #stdcall } -> UNIX_X86_32_STDCALL).
+		  ({ #unix. #i686. #ms_cdecl } -> UNIX_X86_32_MS_CDECL).
+		  ({ #unix. #i686. #pascal } -> UNIX_X86_32_PASCAL).
+		  ({ #unix. #i686. #register } -> UNIX_X86_32_REGISTER).
+		
+		} asDictionary
+]
+
+{ #category : #'calling convention' }
+TFCalloutMethodBuilder >> abiConstantFor: aSelector [
+
+	^ self class abiConstantFor: aSelector
+	
+	
+]
+
 { #category : #private }
 TFCalloutMethodBuilder >> createFFICalloutLiteralFromSpec: functionSpec [
-	
-	^ 	TFExternalFunction
-			name: functionSpec functionName
-			moduleName: self libraryName
-			parameterTypes: (functionSpec arguments collect: #tfExternalTypeWithArity)
-			returnType: functionSpec returnType tfExternalTypeWithArity
-			fixedArgumentCount: fixedArgumentCount 
+
+	^ TFExternalFunction
+		  name: functionSpec functionName
+		  moduleName: self libraryName
+		  parameterTypes:
+		  (functionSpec arguments collect: #tfExternalTypeWithArity)
+		  returnType: functionSpec returnType tfExternalTypeWithArity
+		  fixedArgumentCount: fixedArgumentCount
+		  abi: (self abiConstantFor: calloutAPI callingConvention)
 ]
 
 { #category : #private }

--- a/src/ThreadedFFI-UFFI/TFCalloutMethodBuilder.class.st
+++ b/src/ThreadedFFI-UFFI/TFCalloutMethodBuilder.class.st
@@ -43,6 +43,7 @@ TFCalloutMethodBuilder class >> initializeABIMapping [
 	^ ABI_MAPPING := { 
 		  ({ #Win32. #x86_64. #win64 } -> WIN_X86_64_WIN64).
 		  ({ #Win32. #x86_64. #gnuw64 } -> WIN_X86_64_GNUW64).
+		  ({ #Win32. #x86_64. #cdecl } -> WIN_X86_64_GNUW64).
 
 		  ({ #'Mac OS'. #x86_64. #unix64 } -> DARWIN_X86_64_UNIX64).
 		  ({ #'Mac OS'. #x86_64. #win64 } -> DARWIN_X86_64_WIN64).
@@ -52,6 +53,7 @@ TFCalloutMethodBuilder class >> initializeABIMapping [
 		  ({ #unix. #x86_64. #win64 } -> UNIX_X86_64_WIN64).
 		  ({ #unix. #x86_64. #gnuw64 } -> UNIX_X86_64_GNUW64).
 
+		  ({ #Win32. #i686. #cdecl } -> WIN_X86_32_SYSV).
 		  ({ #Win32. #i686. #sysv } -> WIN_X86_32_SYSV).
 		  ({ #Win32. #i686. #stdcall } -> WIN_X86_32_STDCALL).
 		  ({ #Win32. #i686. #thisCall } -> WIN_X86_32_THISCALL).
@@ -60,6 +62,7 @@ TFCalloutMethodBuilder class >> initializeABIMapping [
 		  ({ #Win32. #i686. #pascal } -> WIN_X86_32_PASCAL).
 		  ({ #Win32. #i686. #register } -> WIN_X86_32_REGISTER).
 
+		  ({ #unix. #i686. #cdecl } -> UNIX_X86_32_SYSV).
 		  ({ #unix. #i686. #sysv } -> UNIX_X86_32_SYSV).
 		  ({ #unix. #i686. #thisCall } -> UNIX_X86_32_THISCALL).
 		  ({ #unix. #i686. #fastCall } -> UNIX_X86_32_FASTCALL).

--- a/src/ThreadedFFI/TFAbiTypes.class.st
+++ b/src/ThreadedFFI/TFAbiTypes.class.st
@@ -1,3 +1,6 @@
+"
+I represent all possible ABI Types
+"
 Class {
 	#name : #TFAbiTypes,
 	#superclass : #SharedPool,
@@ -26,7 +29,7 @@ Class {
 		'WIN_X86_64_GNUW64',
 		'WIN_X86_64_WIN64'
 	],
-	#category : #ThreadedFFI
+	#category : #'ThreadedFFI-Base'
 }
 
 { #category : #initialization }

--- a/src/ThreadedFFI/TFAbiTypes.class.st
+++ b/src/ThreadedFFI/TFAbiTypes.class.st
@@ -1,0 +1,67 @@
+Class {
+	#name : #TFAbiTypes,
+	#superclass : #SharedPool,
+	#classVars : [
+		'DARWIN_X86_64_GNUW64',
+		'DARWIN_X86_64_UNIX64',
+		'DARWIN_X86_64_WIN64',
+		'DEFAULT_ABI',
+		'UNIX_X86_32_FASTCALL',
+		'UNIX_X86_32_MS_CDECL',
+		'UNIX_X86_32_PASCAL',
+		'UNIX_X86_32_REGISTER',
+		'UNIX_X86_32_STDCALL',
+		'UNIX_X86_32_SYSV',
+		'UNIX_X86_32_THISCALL',
+		'UNIX_X86_64_GNUW64',
+		'UNIX_X86_64_UNIX64',
+		'UNIX_X86_64_WIN64',
+		'WIN_X86_32_FASTCALL',
+		'WIN_X86_32_MS_CDECL',
+		'WIN_X86_32_PASCAL',
+		'WIN_X86_32_REGISTER',
+		'WIN_X86_32_STDCALL',
+		'WIN_X86_32_SYSV',
+		'WIN_X86_32_THISCALL',
+		'WIN_X86_64_GNUW64',
+		'WIN_X86_64_WIN64'
+	],
+	#category : #ThreadedFFI
+}
+
+{ #category : #initialization }
+TFAbiTypes class >> initialize [
+
+	"The default ABI is marked with a nil. The primitive will use the correct ABI depending on the platform"
+	DEFAULT_ABI := nil.
+
+	WIN_X86_64_WIN64 := 1.
+	WIN_X86_64_GNUW64 := 2.
+
+	DARWIN_X86_64_UNIX64 := 2.
+	DARWIN_X86_64_WIN64 := 3.
+	DARWIN_X86_64_GNUW64 := 4.
+
+	UNIX_X86_64_UNIX64 := 2.
+	UNIX_X86_64_WIN64 := 3.
+	UNIX_X86_64_GNUW64 := 4.
+
+
+	WIN_X86_32_SYSV      := 1.
+	WIN_X86_32_STDCALL   := 2.
+	WIN_X86_32_THISCALL  := 3.
+	WIN_X86_32_FASTCALL  := 4.
+	WIN_X86_32_MS_CDECL  := 5.
+	WIN_X86_32_PASCAL   := 6.
+	WIN_X86_32_REGISTER  := 7.
+
+	UNIX_X86_32_SYSV      := 1.
+	UNIX_X86_32_THISCALL  := 3.
+	UNIX_X86_32_FASTCALL  := 4.
+	UNIX_X86_32_STDCALL   := 5.
+	UNIX_X86_32_PASCAL    := 6.
+	UNIX_X86_32_REGISTER  := 7.
+	UNIX_X86_32_MS_CDECL  := 8.
+	
+
+]

--- a/src/ThreadedFFI/TFExternalFunction.class.st
+++ b/src/ThreadedFFI/TFExternalFunction.class.st
@@ -56,11 +56,17 @@ TFExternalFunction class >> name: aName moduleName: aModuleName definition: aFun
 { #category : #'instance creation' }
 TFExternalFunction class >> name: aName moduleName: aModuleName parameterTypes: parameterTypes returnType: returnType [
 
-	^ self name: aName moduleName: aModuleName parameterTypes: parameterTypes returnType: returnType fixedArgumentCount: 0
+	^ self
+		  name: aName
+		  moduleName: aModuleName
+		  parameterTypes: parameterTypes
+		  returnType: returnType
+		  fixedArgumentCount: 0
+		  abi: nil
 ]
 
 { #category : #'instance creation' }
-TFExternalFunction class >> name: aName moduleName: aModuleName parameterTypes: parameterTypes returnType: returnType fixedArgumentCount: fixedArgumentCount [
+TFExternalFunction class >> name: aName moduleName: aModuleName parameterTypes: parameterTypes returnType: returnType fixedArgumentCount: fixedArgumentCount abi: abiType [
 
 	| definition |
 
@@ -68,12 +74,14 @@ TFExternalFunction class >> name: aName moduleName: aModuleName parameterTypes: 
 		ifTrue:[	
 			TFFunctionDefinition 
 				parameterTypes: parameterTypes
-				returnType: returnType]
+				returnType: returnType
+				abi: abiType]
 		ifFalse:[	
 			TFVariadicFunctionDefinition 
 				parameterTypes: parameterTypes
 				returnType: returnType
-				fixedArgumentCount: fixedArgumentCount].
+				fixedArgumentCount: fixedArgumentCount
+				abi: abiType].
 
 	^ self
 		name: aName

--- a/src/ThreadedFFI/TFFunctionDefinition.class.st
+++ b/src/ThreadedFFI/TFFunctionDefinition.class.st
@@ -7,13 +7,18 @@ TFFunctionDefinition
 	returnType: TFBasicType float.
 	
 I am not meant to be used from outside of this plugin, so my main users are TFCallback and TFExternalFunction
+
+As we maybe keep the function definition when we are saving the image, we cannot put a default value to the ABI, as the default value changes from platform to platform.
+That is why the ABI is initialized to nil and then different primitives are used.
+
 "
 Class {
 	#name : #TFFunctionDefinition,
 	#superclass : #FFIExternalReference,
 	#instVars : [
 		'parameterTypes',
-		'returnType'
+		'returnType',
+		'abi'
 	],
 	#category : #'ThreadedFFI-Base'
 }
@@ -37,17 +42,47 @@ TFFunctionDefinition class >> fromHandle: aHandle [
 { #category : #'instance creation' }
 TFFunctionDefinition class >> parameterTypes: someParameters returnType: returnType [
 
+	^ self parameterTypes: someParameters returnType: returnType abi: nil
+]
+
+{ #category : #'instance creation' }
+TFFunctionDefinition class >> parameterTypes: someParameters returnType: returnType abi: abi [
+
 	^ self new
 		parameterTypes: someParameters;
 		returnType: returnType;
+		abi: abi;
 		autoRelease;
 		yourself
+]
+
+{ #category : #accessing }
+TFFunctionDefinition >> abi [
+
+	^ abi
+]
+
+{ #category : #accessing }
+TFFunctionDefinition >> abi: anObject [
+
+	abi := anObject
 ]
 
 { #category : #private }
 TFFunctionDefinition >> doValidate: parameterHandlers [
 
-	self primDefineFunctionWith: parameterHandlers returnType: returnType getHandle
+	"As we maybe keep the function definition when we are saving the image, we cannot put a default value to the ABI, as the default value changes from platform to platform"
+	
+	abi
+		ifNil: [ 
+			self
+				primDefineFunctionWith: parameterHandlers
+				returnType: returnType getHandle ]
+		ifNotNil: [ 
+			self
+				primDefineFunctionWith: parameterHandlers
+				returnType: returnType getHandle
+				abi: abi asInteger ]
 ]
 
 { #category : #accessing }
@@ -62,6 +97,14 @@ TFFunctionDefinition >> parameterTypes: anObject [
 
 { #category : #primitives }
 TFFunctionDefinition >> primDefineFunctionWith: parameterHandlers returnType: returnTypeHandler [ 
+	
+	<primitive: 'primitiveDefineFunction' error: ec>
+
+	^ self primitiveFailed	
+]
+
+{ #category : #primitives }
+TFFunctionDefinition >> primDefineFunctionWith: parameterHandlers returnType: returnTypeHandler abi: abiType [
 	
 	<primitive: 'primitiveDefineFunction' error: ec>
 

--- a/src/ThreadedFFI/TFVariadicFunctionDefinition.class.st
+++ b/src/ThreadedFFI/TFVariadicFunctionDefinition.class.st
@@ -21,12 +21,29 @@ TFVariadicFunctionDefinition class >> parameterTypes: someParameters returnType:
 ]
 
 { #category : #'instance creation' }
+TFVariadicFunctionDefinition class >> parameterTypes: someParameters returnType: returnType abi: abiType [
+
+	^ self error: 'You should use #parameterTypes:returnType:fixedArgumentCount:abi:'
+]
+
+{ #category : #'instance creation' }
 TFVariadicFunctionDefinition class >> parameterTypes: someParameters returnType: returnType fixedArgumentCount: fixedArgumentCount [
+
+	^ self
+		  parameterTypes: someParameters
+		  returnType: returnType
+		  fixedArgumentCount: fixedArgumentCount
+		  abi: nil
+]
+
+{ #category : #'instance creation' }
+TFVariadicFunctionDefinition class >> parameterTypes: someParameters returnType: returnType fixedArgumentCount: fixedArgumentCount abi: abiType [
 
 	^ self new
 		parameterTypes: someParameters;
 		returnType: returnType;
 		fixedArgumentCount: fixedArgumentCount;
+		abi: abiType;
 		autoRelease;
 		yourself
 ]

--- a/src/ThreadedFFI/TFVariadicFunctionDefinition.class.st
+++ b/src/ThreadedFFI/TFVariadicFunctionDefinition.class.st
@@ -34,10 +34,18 @@ TFVariadicFunctionDefinition class >> parameterTypes: someParameters returnType:
 { #category : #private }
 TFVariadicFunctionDefinition >> doValidate: parameterHandlers [
 
-	self
-		primDefineFunctionWith: parameterHandlers
-		returnType: returnType getHandle
-		fixedArgumentsCount: fixedArgumentCount
+	abi
+		ifNil: [ 
+			self
+				primDefineFunctionWith: parameterHandlers
+				returnType: returnType getHandle
+				fixedArgumentsCount: fixedArgumentCount ]
+		ifNotNil: [ 
+			self
+				primDefineFunctionWith: parameterHandlers
+				returnType: returnType getHandle
+				fixedArgumentsCount: fixedArgumentCount
+				abi: abi ]
 ]
 
 { #category : #accessing }
@@ -61,6 +69,15 @@ TFVariadicFunctionDefinition >> initialize [
 
 { #category : #primitives }
 TFVariadicFunctionDefinition >> primDefineFunctionWith: parameterHandlers returnType: returnTypeHandler fixedArgumentsCount: aFixedArgumentCount [
+	
+	<primitive: 'primitiveDefineVariadicFunction' error: ec>
+
+	"If the VM does not have an implementation of this primitive, we try with the non variadic version"
+	^ self primDefineFunctionWith: parameterHandlers returnType: returnTypeHandler
+]
+
+{ #category : #primitives }
+TFVariadicFunctionDefinition >> primDefineFunctionWith: parameterHandlers returnType: returnTypeHandler fixedArgumentsCount: aFixedArgumentCount abi: abiType [
 	
 	<primitive: 'primitiveDefineVariadicFunction' error: ec>
 


### PR DESCRIPTION
The image can pass the ABI type so LibFFI uses the correct one