### PR TITLE
LiteralSharing-NestedArrays

### DIFF
--- a/src/Collections-Sequenceable-Tests/ArrayTest.class.st
+++ b/src/Collections-Sequenceable-Tests/ArrayTest.class.st
@@ -604,9 +604,9 @@ ArrayTest >> testAtWrap2 [
 
 { #category : #tests }
 ArrayTest >> testBeReadOnlyLiteral [
-	self assert: (Array new) beReadOnlyLiteral isReadOnlyObject.
-	self assert: (Array with: (String new)) beReadOnlyLiteral first isReadOnlyObject.
-	self deny: (Array with: (Object new)) first isReadOnlyObject
+	self assert: Array new beReadOnlyLiteral isReadOnlyObject.
+	self assert: (Array with: String new) beReadOnlyLiteral first isReadOnlyObject.
+	self deny: (Array with: Object new) first isReadOnlyObject
 ]
 
 { #category : #tests }

--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -314,6 +314,16 @@ Array >> printOn: aStream [
 	super printOn: aStream
 ]
 
+{ #category : #enumerating }
+Array >> recursiveDo: aBlock [
+
+	"execute the block for my content like do, but then recurse into nested arrays"
+
+	self do: [ :each | 
+		aBlock value: each.
+		each isArray ifTrue: [ each recursiveDo: aBlock ] ]
+]
+
 { #category : #'literal testing' }
 Array >> refersToLiteral: literal [
 	^ (self literalEqual: literal) 

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -150,8 +150,30 @@ ImageCleaner >> cleanUpProcesses [
 
 { #category : #'literal sharing' }
 ImageCleaner >> createLiteralTable [
+	| allLiterals arrays |
 	literalTable := Dictionary new.
-	self literalsDo: [ :literal : method | literalTable at: literal put: literal]
+	allLiterals := Set new.
+	self literalsDo: [ :literal :method | 
+		allLiterals add: literal.
+		"we add all the contentents of the arrays recursively, too"
+		literal isArray ifTrue: [ 
+			literal recursiveDo: [ :each | 
+				(each isSymbol not and: [ each isImmediateObject not]) 
+					ifTrue: [ allLiterals add: each ] ] ] ].
+		
+
+	"we need to go over all array and unify. as we have all flattend versions already once, we need to do that only for the top level"
+	arrays := allLiterals select: [ :each | each isArray ].
+	arrays do: [ :array |
+			array beWritableObject.
+			array copy do: [ :arrayValue | 
+				(arrayValue  isSymbol not and:  [ arrayValue isImmediateObject not ]) ifTrue:
+				[array
+					at: (array indexOf: arrayValue)
+					put: (allLiterals like: arrayValue)]].
+			array beReadOnlyObject ].
+		
+	allLiterals do: [:each | literalTable at: each put: each]
 ]
 
 { #category : #'literal sharing' }
@@ -215,19 +237,12 @@ ImageCleaner >> removeEmptyPackages [
 { #category : #'literal sharing' }
 ImageCleaner >> shareLiterals [
 	"Experimental Image Shrinker: We go over all methods and replace all the literals that are equal by one copy"
-	"Note: as thse literals can be changed, it is adviced to set #optionReadOnlyLiterals to true and recompile the system before using this in production"
 	self createLiteralTable.
 	self literalsDo: [ :literal :cm |
 			cm literalAt: (cm indexOfLiteral: literal) put: (literalTable at: literal)  ].
 	self detroyLiteralTable
 		
 
-]
-
-{ #category : #'literal sharing' }
-ImageCleaner >> statistics [
-	"run this before and after, this is just there while testing, will be removed"
-	^(CompiledCode allSubInstances flatCollect: #literals) asIdentitySet size
 ]
 
 { #category : #cleaning }


### PR DESCRIPTION
This PR improves literal sharing (note: not yet active)

- take into account the content of nested arrays when building the table
- unify the nested arrays to use the one version from the table
- formatting test fix

