### PR TITLE
Simpler-VariableName-ReservedVariable

### DIFF
--- a/src/Kernel/ReservedVariable.class.st
+++ b/src/Kernel/ReservedVariable.class.st
@@ -32,7 +32,12 @@ ReservedVariable class >> lookupDictionary [
 
 { #category : #testing }
 ReservedVariable class >> nameIsReserved: aName [
-	^self subclasses anySatisfy: [ :class | class instance name = aName ]
+	^self subclasses anySatisfy: [ :class | class variableName = aName ]
+]
+
+{ #category : #accessing }
+ReservedVariable class >> variableName [
+	^self subclassResponsibility
 ]
 
 { #category : #converting }
@@ -49,7 +54,8 @@ ReservedVariable >> emitStore: methodBuilder [
 
 { #category : #initialization }
 ReservedVariable >> initialize [
-	environment := Smalltalk globals
+	environment := Smalltalk globals.
+	name := self class variableName
 ]
 
 { #category : #testing }

--- a/src/Kernel/SelfVariable.class.st
+++ b/src/Kernel/SelfVariable.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Kernel-Variables'
 }
 
+{ #category : #accessing }
+SelfVariable class >> variableName [
+	^'self'
+]
+
 { #category : #visiting }
 SelfVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 
@@ -17,13 +22,6 @@ SelfVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 SelfVariable >> emitValue: methodBuilder [
 
 	methodBuilder pushReceiver
-]
-
-{ #category : #initialization }
-SelfVariable >> initialize [
-	super initialize.
-	
-	name := 'self'
 ]
 
 { #category : #testing }

--- a/src/Kernel/SuperVariable.class.st
+++ b/src/Kernel/SuperVariable.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Kernel-Variables'
 }
 
+{ #category : #accessing }
+SuperVariable class >> variableName [
+	^'super'
+]
+
 { #category : #visiting }
 SuperVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitSuperNode: aNode
@@ -16,13 +21,6 @@ SuperVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 SuperVariable >> emitValue: methodBuilder [
 	"super references the receiver, send that follows is a super send (the message lookup starts in the superclass)"
 	methodBuilder pushReceiver
-]
-
-{ #category : #initialization }
-SuperVariable >> initialize [
-	super initialize.
-	
-	name := 'super'
 ]
 
 { #category : #testing }

--- a/src/Kernel/ThisContextVariable.class.st
+++ b/src/Kernel/ThisContextVariable.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Kernel-Variables'
 }
 
+{ #category : #accessing }
+ThisContextVariable class >> variableName [
+	^'thisContext'
+]
+
 { #category : #visiting }
 ThisContextVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitThisContextNode: aNode
@@ -16,13 +21,6 @@ ThisContextVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 ThisContextVariable >> emitValue: methodBuilder [
 
 	methodBuilder pushThisContext
-]
-
-{ #category : #initialization }
-ThisContextVariable >> initialize [
-	super initialize.
-	
-	name := 'thisContext'
 ]
 
 { #category : #testing }


### PR DESCRIPTION
This moves how the name of self/super/thisContext is set in the variables. It used to be done in initialize methods.

- move it to #variableName on the class side
- we just need one #initialize
- #nameIsReserved: does not need an instance 

This makes it much easier to define your own subclass (e.g. for thisProcess) without breaking the compiler

