### PR TITLE
ImageCleaner: call #shareLiterals in #cleanUpForRelease

### DIFF
--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -112,6 +112,7 @@ ImageCleaner >> cleanUpForRelease [
 	FreeTypeFontProvider current prepareForRelease.	
 	
 	HashedCollection rehashAll.		
+	self shareLiterals.
 	Author reset
 ]
 


### PR DESCRIPTION
This PR adds a step to the release cleaning script: call #shareLiterals

This means that it post-processes all methods to use the same object for all literals. This should save (a little bit) of memory.

This is save as:

- all these literals are read-only 
- recompile creates new instances, thus identity can never be assumed to stay the same