### PR TITLE
9731-Ph9-Spec2-List-items-cannot-be-selected-when-medium-font-is-used

### DIFF
--- a/src/Settings-Graphics/GraphicFontSettings.class.st
+++ b/src/Settings-Graphics/GraphicFontSettings.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #fonts }
 GraphicFontSettings class >> displayScaleFactorForStyleNamed: aSymbol [
 
-	^ (#(#(#superTiny 0.6) #(#tiny 0.8) #(#small 1) #(#medium 1.3) #(#large 1.6) #(veryLarge 2) #(huge 2.7)) 
+	^ (#(#(#superTiny 0.6) #(#tiny 0.8) #(#small 1) #(#medium 1.4) #(#large 1.6) #(veryLarge 2) #(huge 2.7))
 		detect: [:info | info first asUppercase = aSymbol asUppercase] ifNone: []) 
 			ifNotNil: [:info | info second]
 


### PR DESCRIPTION
This value is used as a factor to resize all widgets. Changing the 1.3 so we don't have rounding issues.

We need to review this behavior, as size should be calculated relative to the selected default font.