### PR TITLE
9681-AbstractLayout-hierarchy-unify-typeOfClass-and-kind

### DIFF
--- a/src/Kernel/AbstractLayout.class.st
+++ b/src/Kernel/AbstractLayout.class.st
@@ -186,12 +186,6 @@ AbstractLayout >> slots [
 ]
 
 { #category : #accessing }
-AbstractLayout >> typeOfClass [
-	"The type is the class name of the layout. But for ST80 layouts, we define some special symbols to stay backward compatible"
-	^self class name asSymbol
-]
-
-{ #category : #accessing }
 AbstractLayout >> visibleSlots [
 	^self slots select: [:slot | slot isVisible]
 ]

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1672,8 +1672,8 @@ Behavior >> thoroughWhichSelectorsReferTo: literal [
 
 { #category : #accessing }
 Behavior >> typeOfClass [
-	"Answer a symbol uniquely describing the type of the receiver. c.f. kindOfSubclass"
-	^self classLayout typeOfClass
+	"Answer the symbol that Monticello uses internally to encode layouts"
+	^self classLayout class kind
 ]
 
 { #category : #'user interface' }

--- a/src/Kernel/ByteLayout.class.st
+++ b/src/Kernel/ByteLayout.class.st
@@ -44,8 +44,3 @@ ByteLayout >> isBytes [
 ByteLayout >> kindOfSubclass [
 	^' variableByteSubclass: '
 ]
-
-{ #category : #accessing }
-ByteLayout >> typeOfClass [
-	^#bytes
-]

--- a/src/Kernel/CompiledMethodLayout.class.st
+++ b/src/Kernel/CompiledMethodLayout.class.st
@@ -37,8 +37,3 @@ CompiledMethodLayout >> kindOfSubclass [
 	"not really true but this is what is shows now"
 	^' variableByteSubclass: '
 ]
-
-{ #category : #accessing }
-CompiledMethodLayout >> typeOfClass [
-	^#compiledMethod
-]

--- a/src/Kernel/EphemeronLayout.class.st
+++ b/src/Kernel/EphemeronLayout.class.st
@@ -29,8 +29,3 @@ EphemeronLayout >> instanceSpecification [
 EphemeronLayout >> kindOfSubclass [
 	^' ephemeronSubclass: '
 ]
-
-{ #category : #accessing }
-EphemeronLayout >> typeOfClass [
-	^#ephemeron
-]

--- a/src/Kernel/FixedLayout.class.st
+++ b/src/Kernel/FixedLayout.class.st
@@ -38,8 +38,3 @@ FixedLayout >> isFixedLayout [
 FixedLayout >> kindOfSubclass [
 	^' subclass: '
 ]
-
-{ #category : #accessing }
-FixedLayout >> typeOfClass [
-	^#normal
-]

--- a/src/Kernel/ImmediateLayout.class.st
+++ b/src/Kernel/ImmediateLayout.class.st
@@ -46,8 +46,3 @@ ImmediateLayout >> instanceSpecification [
 ImmediateLayout >> kindOfSubclass [
 	^' immediateSubclass: '
 ]
-
-{ #category : #accessing }
-ImmediateLayout >> typeOfClass [
-	^#immediate
-]

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -283,7 +283,8 @@ UndefinedObject >> subclassesDo: aBlock [
 
 { #category : #'class hierarchy' }
 UndefinedObject >> typeOfClass [
-	"Necessary to support disjoint class hierarchies."
+	"Answer the symbol that Monticello uses internally to encode layouts"
+	"Implemented here  to support disjoint class hierarchies"
 	^#normal
 ]
 

--- a/src/Kernel/VariableLayout.class.st
+++ b/src/Kernel/VariableLayout.class.st
@@ -38,8 +38,3 @@ VariableLayout >> isVariable [
 VariableLayout >> kindOfSubclass [
 	^' variableSubclass: '
 ]
-
-{ #category : #accessing }
-VariableLayout >> typeOfClass [
-	^#variable
-]

--- a/src/Kernel/WeakLayout.class.st
+++ b/src/Kernel/WeakLayout.class.st
@@ -43,8 +43,3 @@ WeakLayout >> isWeak [
 WeakLayout >> kindOfSubclass [
 	^' weakSubclass: '
 ]
-
-{ #category : #accessing }
-WeakLayout >> typeOfClass [
-	^#weak
-]

--- a/src/Kernel/WordLayout.class.st
+++ b/src/Kernel/WordLayout.class.st
@@ -44,8 +44,3 @@ WordLayout >> isWords [
 WordLayout >> kindOfSubclass [
 	^' variableWordSubclass: '
 ]
-
-{ #category : #accessing }
-WordLayout >> typeOfClass [
-	^#words
-]


### PR DESCRIPTION
#typeOfClass can now delegate to the class side (#kind).

maybe we should deprecate both #kind and #typeOfClass and call it #mcType, as this is really an internal method of Monticello, but that is for later (even if we decide against that, this cleanup is still important to do)