### PR TITLE
Cleanup-Deprecated-DisplayMedium

### DIFF
--- a/src/Graphics-Display Objects/DisplayMedium.class.st
+++ b/src/Graphics-Display Objects/DisplayMedium.class.st
@@ -45,28 +45,6 @@ DisplayMedium >> border: aRectangle width: borderWidth rule: combinationRule fil
 		fillColor: aHalfTone
 ]
 
-{ #category : #bordering }
-DisplayMedium >> border: aRectangle widthRectangle: insets rule: combinationRule fillColor: aHalfTone [
-	"Paint a border whose rectangular area is defined by aRectangle. The 
-	width of each edge of the border is determined by the four coordinates 
-	of insets. Uses aHalfTone and combinationRule for drawing the border."
-
-	| deprecationMessage |
-	deprecationMessage := 'Use #border:margins:rule:fillColor: instead'.
-	insets class = Rectangle
-		ifTrue:
-			[ deprecationMessage := deprecationMessage
-				,
-					'\Change sender to use Margin instead of Rectangle. \ Rectangles are now normalized, and can no longer interchangeably be used as margins'
-						withCRs ].
-	self deprecated: deprecationMessage on: '10 December 2017' in: 'Pharo70'.
-	^ self
-		border: aRectangle
-		margins: insets asMargin
-		rule: combinationRule
-		fillColor: aHalfTone
-]
-
 { #category : #displaying }
 DisplayMedium >> copyBits: sourceRect from: sourceForm at: destOrigin clippingBox: clipRect rule: rule fillColor: aForm [ 
 	"Make up a BitBlt table and copy the bits."

--- a/src/Graphics-Display Objects/Form.class.st
+++ b/src/Graphics-Display Objects/Form.class.st
@@ -1735,59 +1735,6 @@ Form >> orderedDither32To16 [
 	^out
 ]
 
-{ #category : #transitions }
-Form >> pageWarp: otherImage at: topLeft forward: forward [
-	"Produce a page-turning illusion that gradually reveals otherImage
-	located at topLeft in this form.
-	forward == true means turn pages toward you, else away. [ignored for now]"
-	| pageRect oldPage nSteps buffer p leafRect sourceQuad warp oldBottom d |
-	pageRect := otherImage boundingBox.
-	oldPage := self copy: (pageRect translateBy: topLeft).
-	(forward ifTrue: [oldPage] ifFalse: [otherImage])
-		border: pageRect
-		margins: (Rectangle
-				left: 0
-				right: 2
-				top: 1
-				bottom: 1) asMargin
-		rule: Form over
-		fillColor: Color black.
-	oldBottom := self copy: ((pageRect bottomLeft + topLeft) extent: (pageRect width@(pageRect height//4))).
-	nSteps := 8.
-	buffer := Form extent: otherImage extent + (0@(pageRect height//4)) depth: self depth.
-	d := pageRect topLeft + (0@(pageRect height//4)) - pageRect topRight.
-	1 to: nSteps-1 do:
-		[:i | forward
-			ifTrue: [buffer copy: pageRect from: otherImage to: 0@0 rule: Form over.
-					p := pageRect topRight + (d * i // nSteps)]
-			ifFalse: [buffer copy: pageRect from: oldPage to: 0@0 rule: Form over.
-					p := pageRect topRight + (d * (nSteps-i) // nSteps)].
-		buffer copy: oldBottom boundingBox from: oldBottom to: pageRect bottomLeft rule: Form over.
-		leafRect := pageRect topLeft corner: p x @ (pageRect bottom + p y).
-		sourceQuad := Array with: pageRect topLeft
-			with: pageRect bottomLeft + (0@p y)
-			with: pageRect bottomRight
-			with: pageRect topRight - (0@p y).
-		warp := (WarpBlt toForm: buffer)
-				clipRect: leafRect;
-				sourceForm: (forward ifTrue: [oldPage] ifFalse: [otherImage]);
-				combinationRule: Form paint.
-		warp copyQuad: sourceQuad toRect: leafRect.
-		self copy: buffer boundingBox from: buffer to: topLeft rule: Form over.
-		Display forceDisplayUpdate].
-
-	buffer copy: pageRect from: otherImage to: 0@0 rule: Form over.
-	buffer copy: oldBottom boundingBox from: oldBottom to: pageRect bottomLeft rule: Form over.
-	self copy: buffer boundingBox from: buffer to: topLeft rule: Form over.
-	Display forceDisplayUpdate.
-"
-1 to: 4 do: [:corner | Display pageWarp:
-				(Form fromDisplay: (10@10 extent: 200@300)) reverse
-			at: 10@10 forward: false]
-"
-
-]
-
 { #category : #displaying }
 Form >> paintBits: sourceForm at: destOrigin translucent: factor [
 	"Make up a BitBlt table and copy the bits with the given colorMap."

--- a/src/Graphics-Display Objects/Form.class.st
+++ b/src/Graphics-Display Objects/Form.class.st
@@ -1745,11 +1745,11 @@ Form >> pageWarp: otherImage at: topLeft forward: forward [
 	oldPage := self copy: (pageRect translateBy: topLeft).
 	(forward ifTrue: [oldPage] ifFalse: [otherImage])
 		border: pageRect
-		widthRectangle: (Rectangle
+		margins: (Rectangle
 				left: 0
 				right: 2
 				top: 1
-				bottom: 1)
+				bottom: 1) asMargin
 		rule: Form over
 		fillColor: Color black.
 	oldBottom := self copy: ((pageRect bottomLeft + topLeft) extent: (pageRect width@(pageRect height//4))).


### PR DESCRIPTION
The (very old) deprecated method in DisplayMedium still had a sender.

This PR fixes the sender and removed the method. But as the #pageWarp:at:forward: was broken for so long, maybe we should remove it, too?


