### PR TITLE
9888-FFI-remove-gcpointer

### DIFF
--- a/src/UnifiedFFI/ExternalAddress.extension.st
+++ b/src/UnifiedFFI/ExternalAddress.extension.st
@@ -165,15 +165,6 @@ ExternalAddress class >> fromString: aString [
 	^ result
 ]
 
-{ #category : #'*UnifiedFFI-Deprecated50' }
-ExternalAddress >> gcpointer [
-	"Same as #pointer (see its comment for detals), but contents are garbage collected automatically"
-	self deprecated: 'Use "pointer autoRelease" instead.' on: '2016-01-22' in: #Pharo5.  
-	^ (ExternalAddress gcallocate: self size)
-		pointerAt: 1 put: self;
-		yourself
-]
-
 { #category : #'*UnifiedFFI' }
 ExternalAddress >> getHandle [
 	

--- a/src/UnifiedFFI/FFIExternalArray.class.st
+++ b/src/UnifiedFFI/FFIExternalArray.class.st
@@ -129,21 +129,6 @@ FFIExternalArray >> free [
 		ifFalse: [ handle := nil ]
 ]
 
-{ #category : #converting }
-FFIExternalArray >> gcpointer [
-	"Answers a pointer to the this array. 
-	 This is useful when translating an array pointer to a function (FFI requires to be passed as a
-	 pointer, otherwise will be interpreted as a direct array and it will not work fine)
-	
-	 For an example, see FFICallback class>>#exampleCqsort
-	
-	 WARNING: Only valid for external address (you cannot have a pointer to an image side object)"
-	self deprecated: 'Use "pointer autoRelease" instead.' on: '2016-01-22' in: #Pharo5.  		
-	self getHandle isExternalAddress ifFalse: [ 
-		self error: 'Arrays need to be moved to external memory space before passing them as pointers.' ].
-	^ self getHandle gcpointer	
-]
-
 { #category : #accessing }
 FFIExternalArray >> getHandle [
 	self flag: #pharoTodo. "I do not like the name 'getHandle' but I'm looking to unify the 


### PR DESCRIPTION
remove the two deprecated methods (they have no senders)
fixes #9888


