### PR TITLE
9877-SmalltalkImagepackages-should-not-sort 

### DIFF
--- a/src/RPackage-Core/SmalltalkImage.extension.st
+++ b/src/RPackage-Core/SmalltalkImage.extension.st
@@ -3,5 +3,5 @@ Extension { #name : #SmalltalkImage }
 { #category : #'*RPackage-Core' }
 SmalltalkImage >> packages [
 
-	^ (RPackageOrganizer default packages) sorted
+	^ RPackageOrganizer default packages
 ]


### PR DESCRIPTION
do not sort queries of all packages (the same as we do not sort queries for all methods, all classes...)

fixes #9877


