### PR TITLE
9901-Fluid-Class-Parser-gets-wrong-symbols-from-the-layout-kind

### DIFF
--- a/src/ClassParser-Tests/CDExistingClassDefinitionTest.class.st
+++ b/src/ClassParser-Tests/CDExistingClassDefinitionTest.class.st
@@ -58,7 +58,6 @@ CDExistingClassDefinitionTest >> testGettingExistingClassNameBinding [
 CDExistingClassDefinitionTest >> testSharedSlotNodeArePolymorphicToRBVariableNodes [
 	
 	| classVarNode |
-		self skip.
 	classVarNode := classDefinition sharedSlotNodes first.
 	
 	self assert: classVarNode isVariable.

--- a/src/ClassParser-Tests/CDFluidClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDFluidClassParserTest.class.st
@@ -92,7 +92,7 @@ CDFluidClassParserTest >> testEphemeronSubclass [
 		layout: EphemeronLayout;
 		package: #MyPackage'.
 	def := parser parse: defString.
-	self assert: def classKind equals: #ephemeron
+	self assert: def classKind equals: #ephemeronSubclass:
 ]
 
 { #category : #'tests - (r) simple class definition' }
@@ -115,7 +115,7 @@ CDFluidClassParserTest >> testNormalSubclass [
 		layout: FixedLayout;
 		package: #MyPackage'.
 	def := parser parse: defString.
-	self assert: def classKind equals: #normal
+	self assert: def classKind equals: #subclass:
 ]
 
 { #category : #'tests - (r) sharedPools' }
@@ -301,10 +301,10 @@ CDFluidClassParserTest >> testVariableByteSubclass [
 	parser := self classDefinitionParserClass new.
 	
 	defString := 'Object << #MyObject
-		layout: VariableLayout;
+		layout: ByteLayout;
 		package: #MyPackage'.
 	def := parser parse: defString.
-	self assert: def classKind equals: #variable
+	self assert: def classKind equals: #variableByteSubclass:
 ]
 
 { #category : #'tests - (r) kinds' }
@@ -317,7 +317,7 @@ CDFluidClassParserTest >> testVariableSubclass [
 		layout: VariableLayout;
 		package: #MyPackage'.
 	def := parser parse: defString.
-	self assert: def classKind equals: #variable
+	self assert: def classKind equals: #variableSubclass:
 ]
 
 { #category : #'tests - (r) kinds' }
@@ -330,7 +330,7 @@ CDFluidClassParserTest >> testVariableWordSubclass [
 		layout: WordLayout;
 		package: #MyPackage'.
 	def := parser parse: defString.
-	self assert: def classKind equals: #words
+	self assert: def classKind equals: #variableWordSubclass:
 ]
 
 { #category : #'tests - (r) kinds' }
@@ -343,5 +343,5 @@ CDFluidClassParserTest >> testWeakSubclass [
 		layout: WeakLayout;
 		package: #MyPackage'.
 	def := parser parse: defString.
-	self assert: def classKind equals: #weak
+	self assert: def classKind equals: #weakSubclass:
 ]

--- a/src/ClassParser/CDFluidClassDefinitionParser.class.st
+++ b/src/ClassParser/CDFluidClassDefinitionParser.class.st
@@ -62,8 +62,7 @@ CDFluidClassDefinitionParser >> handleClassAndSuperclassOf: aNode [
 
 { #category : #'handling  nodes' }
 CDFluidClassDefinitionParser >> handleLayout: aNode [
-
-	classDefinition classKind: aNode binding value kind
+	classDefinition classKind: aNode binding value subclassDefiningSymbol
 ]
 
 { #category : #'handling  nodes' }

--- a/src/Kernel/AbstractLayout.class.st
+++ b/src/Kernel/AbstractLayout.class.st
@@ -160,12 +160,6 @@ AbstractLayout >> isWeak [
 ]
 
 { #category : #accessing }
-AbstractLayout >> kindOfSubclass [
-	"As a fallback we just return a standard class creation substring. This will be called for user 	defined Layouts, for old style class definitions that can not support user defined Layouts"
-	^' subclass: '
-]
-
-{ #category : #accessing }
 AbstractLayout >> resolveSlot: aName [
 	^SlotNotFound signalForName: aName
 ]

--- a/src/Kernel/ByteLayout.class.st
+++ b/src/Kernel/ByteLayout.class.st
@@ -19,6 +19,11 @@ ByteLayout class >> kind [
 	^ #bytes
 ]
 
+{ #category : #description }
+ByteLayout class >> subclassDefiningSymbol [
+	^#variableByteSubclass:
+]
+
 { #category : #accessing }
 ByteLayout >> bytesPerSlot [
 	
@@ -38,9 +43,4 @@ ByteLayout >> instanceSpecification [
 { #category : #testing }
 ByteLayout >> isBytes [
 	^ true
-]
-
-{ #category : #accessing }
-ByteLayout >> kindOfSubclass [
-	^' variableByteSubclass: '
 ]

--- a/src/Kernel/CompiledMethodLayout.class.st
+++ b/src/Kernel/CompiledMethodLayout.class.st
@@ -22,6 +22,12 @@ CompiledMethodLayout class >> kind [
 	^ #compiledMethod 
 ]
 
+{ #category : #description }
+CompiledMethodLayout class >> subclassDefiningSymbol [
+	"there is no way to define classes of this layoyt, the system shows them as variable classes"
+	^#variableByteSubclass:
+]
+
 { #category : #extending }
 CompiledMethodLayout >> extend [
 	self error: 'CompiledMethodLayout can not be extendend'
@@ -30,10 +36,4 @@ CompiledMethodLayout >> extend [
 { #category : #format }
 CompiledMethodLayout >> instanceSpecification [
 	 ^ 24
-]
-
-{ #category : #accessing }
-CompiledMethodLayout >> kindOfSubclass [
-	"not really true but this is what is shows now"
-	^' variableByteSubclass: '
 ]

--- a/src/Kernel/DoubleByteLayout.class.st
+++ b/src/Kernel/DoubleByteLayout.class.st
@@ -7,11 +7,16 @@ Class {
 	#category : #'Kernel-Layout'
 }
 
-{ #category : #'methodsFor:' }
+{ #category : #'instance creation' }
 DoubleByteLayout class >> extending: superLayout scope: aScope host: aClass [
 	^ superLayout extendDoubleByte
 		host: aClass;
 		yourself
+]
+
+{ #category : #description }
+DoubleByteLayout class >> subclassDefiningSymbol [
+	^#variableDoubleByteSubclass:
 ]
 
 { #category : #accessing }
@@ -33,9 +38,4 @@ DoubleByteLayout >> instanceSpecification [
 { #category : #testing }
 DoubleByteLayout >> isDoubleBytes [
 	^ true
-]
-
-{ #category : #accessing }
-DoubleByteLayout >> kindOfSubclass [
-	^' variableDoubleByteSubclass: '
 ]

--- a/src/Kernel/DoubleWordLayout.class.st
+++ b/src/Kernel/DoubleWordLayout.class.st
@@ -14,6 +14,11 @@ DoubleWordLayout class >> extending: superLayout scope: aScope host: aClass [
 		yourself
 ]
 
+{ #category : #description }
+DoubleWordLayout class >> subclassDefiningSymbol [
+	^#variableDoubleWordSubclass:
+]
+
 { #category : #extending }
 DoubleWordLayout >> extendDoubleWord [
 	^ DoubleWordLayout new
@@ -27,9 +32,4 @@ DoubleWordLayout >> instanceSpecification [
 { #category : #testing }
 DoubleWordLayout >> isDoubleWords [
 	^ true
-]
-
-{ #category : #accessing }
-DoubleWordLayout >> kindOfSubclass [
-	^' variableDoubleWordSubclass: '
 ]

--- a/src/Kernel/EmptyLayout.class.st
+++ b/src/Kernel/EmptyLayout.class.st
@@ -51,8 +51,3 @@ EmptyLayout >> extendWeak [
 EmptyLayout >> extendWord [
 	^ WordLayout new
 ]
-
-{ #category : #accessing }
-EmptyLayout >> kindOfSubclass [
-	^self shouldNotImplement
-]

--- a/src/Kernel/EphemeronLayout.class.st
+++ b/src/Kernel/EphemeronLayout.class.st
@@ -20,12 +20,12 @@ EphemeronLayout class >> kind [
 	^ #ephemeron
 ]
 
+{ #category : #description }
+EphemeronLayout class >> subclassDefiningSymbol [
+	^#ephemeronSubclass:
+]
+
 { #category : #format }
 EphemeronLayout >> instanceSpecification [
 	^ 5
-]
-
-{ #category : #accessing }
-EphemeronLayout >> kindOfSubclass [
-	^' ephemeronSubclass: '
 ]

--- a/src/Kernel/FixedLayout.class.st
+++ b/src/Kernel/FixedLayout.class.st
@@ -33,8 +33,3 @@ FixedLayout >> instanceSpecification [
 FixedLayout >> isFixedLayout [
 	^true
 ]
-
-{ #category : #accessing }
-FixedLayout >> kindOfSubclass [
-	^' subclass: '
-]

--- a/src/Kernel/ImmediateLayout.class.st
+++ b/src/Kernel/ImmediateLayout.class.st
@@ -21,6 +21,11 @@ ImmediateLayout class >> kind [
 	^ #immediate
 ]
 
+{ #category : #description }
+ImmediateLayout class >> subclassDefiningSymbol [
+	^#immediateSubclass:
+]
+
 { #category : #extending }
 ImmediateLayout >> extend [
 	self error: 'ImmediateLayout can not be extendend'
@@ -40,9 +45,4 @@ ImmediateLayout >> initialize [
 { #category : #format }
 ImmediateLayout >> instanceSpecification [
 	^ 7
-]
-
-{ #category : #accessing }
-ImmediateLayout >> kindOfSubclass [
-	^' immediateSubclass: '
 ]

--- a/src/Kernel/ObjectLayout.class.st
+++ b/src/Kernel/ObjectLayout.class.st
@@ -31,6 +31,13 @@ ObjectLayout class >> layoutForType: typeSymbol [
 		ifNone: [ Error signal: 'Invalid layout type: ', typeSymbol asString ]
 ]
 
+{ #category : #description }
+ObjectLayout class >> subclassDefiningSymbol [
+	"As a fallback we just return a standard class creation symbol. This will be called for user 	
+	defined Layouts, for old style class definitions that can not support user defined Layouts"
+	^#subclass:
+]
+
 { #category : #extending }
 ObjectLayout >> extend [
 	"Answer a default extension of me."
@@ -133,4 +140,14 @@ ObjectLayout >> initializeInstance: anInstance [
 { #category : #format }
 ObjectLayout >> instanceSpecification [
 	self subclassResponsibility
+]
+
+{ #category : #'testing - class hierarchy' }
+ObjectLayout >> kindOfSubclass [
+	^' ',self class subclassDefiningSymbol, ' '.
+]
+
+{ #category : #'testing - class hierarchy' }
+ObjectLayout >> subclassDefiningSymbol [
+	^self class subclassDefiningSymbol
 ]

--- a/src/Kernel/VariableLayout.class.st
+++ b/src/Kernel/VariableLayout.class.st
@@ -22,6 +22,11 @@ VariableLayout class >> kind [
 	^ #variable
 ]
 
+{ #category : #description }
+VariableLayout class >> subclassDefiningSymbol [
+	^#variableSubclass:
+]
+
 { #category : #format }
 VariableLayout >> instanceSpecification [
 	^ self hasFields
@@ -32,9 +37,4 @@ VariableLayout >> instanceSpecification [
 { #category : #testing }
 VariableLayout >> isVariable [
 	^ true
-]
-
-{ #category : #accessing }
-VariableLayout >> kindOfSubclass [
-	^' variableSubclass: '
 ]

--- a/src/Kernel/WeakLayout.class.st
+++ b/src/Kernel/WeakLayout.class.st
@@ -24,6 +24,11 @@ WeakLayout class >> kind [
 	^ #weak
 ]
 
+{ #category : #description }
+WeakLayout class >> subclassDefiningSymbol [
+	^#weakSubclass:
+]
+
 { #category : #format }
 WeakLayout >> instanceSpecification [
 	^ 4
@@ -37,9 +42,4 @@ WeakLayout >> isVariable [
 { #category : #testing }
 WeakLayout >> isWeak [
 	^ true
-]
-
-{ #category : #accessing }
-WeakLayout >> kindOfSubclass [
-	^' weakSubclass: '
 ]

--- a/src/Kernel/WordLayout.class.st
+++ b/src/Kernel/WordLayout.class.st
@@ -19,6 +19,11 @@ WordLayout class >> kind [
 	^ #words
 ]
 
+{ #category : #description }
+WordLayout class >> subclassDefiningSymbol [
+	^#variableWordSubclass:
+]
+
 { #category : #accessing }
 WordLayout >> bytesPerSlot [
 	
@@ -38,9 +43,4 @@ WordLayout >> instanceSpecification [
 { #category : #testing }
 WordLayout >> isWords [
 	^ true
-]
-
-{ #category : #accessing }
-WordLayout >> kindOfSubclass [
-	^' variableWordSubclass: '
 ]


### PR DESCRIPTION
This pr fixes #9901:
- add a method #subclassDefiningSymbol to the class side of the layout classes
- implement one #kindOfSubclass that uses this method
- change  ClassParser #handleLayout: to use this method
- fix the now failing tests

After this PR, the class parser now uses consistently the subclass defining symbols (and not a mix of these and the Monticello symbols).

A problem now is that these symbols are not useful for the purpose of the ClassParser:
- there are layouts that use the same (e.g. CompiledMethodLayout uses the same symbol as a byte layout)
- We can not support user defined layouts this way.

Fixing that is the next step


