### PR TITLE
9909-Deprecate-typeOfClass-and-kind-and-add-mcType-instead

### DIFF
--- a/src/Deprecated10/Behavior.extension.st
+++ b/src/Deprecated10/Behavior.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #Behavior }
+
+{ #category : #'*Deprecated10' }
+Behavior >> typeOfClass [
+
+	self
+		deprecated: 'Should use mcType instead'
+		on: '08 September 2021'
+		in: #Pharo10
+		transformWith: '`@rec typeOfClass' -> '`@rec mcType'.
+	^ self mcType
+]

--- a/src/Deprecated10/ObjectLayout.extension.st
+++ b/src/Deprecated10/ObjectLayout.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #ObjectLayout }
+
+{ #category : #'*Deprecated10' }
+ObjectLayout class >> kind [
+
+	self
+		deprecated: 'Should use mcTypeSymbol instead'
+		on: '08 September 2021'
+		in: #Pharo10
+		transformWith: '`@rec kind' -> '`@rec mcTypeSymbol'.
+	^ self mcType
+]

--- a/src/Deprecated10/UndefinedObject.extension.st
+++ b/src/Deprecated10/UndefinedObject.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #UndefinedObject }
+
+{ #category : #'*Deprecated10' }
+UndefinedObject >> typeOfClass [
+	self
+		deprecated: 'Should use mcType instead'
+		on: '08 September 2021'
+		in: #Pharo10
+		transformWith: '`@rec typeOfClass' -> '`@rec mcType'.
+	^ self mcType
+]

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1180,6 +1180,12 @@ Behavior >> lookupSelector: selector [
 ]
 
 { #category : #accessing }
+Behavior >> mcType [
+	"Answer the symbol that Monticello uses internally to encode layouts"
+	^self classLayout class mcTypeSymbol
+]
+
+{ #category : #accessing }
 Behavior >> methodDict [
        "The method dictionary of a class can be nil when we want to use the #cannotInterpret: hook. Indeed when a class dictionary is nil, the VM sends the message cannotInterpret: to the receiver but starting the look up in the superclass of the class whose method dictionary was nil.
 	 Now the system relies that when the message methodDict is sent to a class a method dictionary is returned. In order to prevent the complaints of tools and IDE unaware of this feature, we fool them by providing an empty MethodDictionary. This will hopefully work in most cases, but the tools will loose the ability to modify the behaviour of this behavior. The user of #cannotInterpret: should be aware of this."
@@ -1668,12 +1674,6 @@ Behavior >> thoroughWhichMethodsReferTo: literal [
 { #category : #'testing - method dictionary' }
 Behavior >> thoroughWhichSelectorsReferTo: literal [
 	^ (self thoroughWhichMethodsReferTo: literal) collect: [ :method | method selector ]
-]
-
-{ #category : #accessing }
-Behavior >> typeOfClass [
-	"Answer the symbol that Monticello uses internally to encode layouts"
-	^self classLayout class kind
 ]
 
 { #category : #'user interface' }

--- a/src/Kernel/ByteLayout.class.st
+++ b/src/Kernel/ByteLayout.class.st
@@ -15,7 +15,7 @@ ByteLayout class >> extending: superLayout scope: aScope host: aClass [
 ]
 
 { #category : #description }
-ByteLayout class >> kind [ 
+ByteLayout class >> mcTypeSymbol [ 
 	^ #bytes
 ]
 

--- a/src/Kernel/CompiledMethodLayout.class.st
+++ b/src/Kernel/CompiledMethodLayout.class.st
@@ -18,7 +18,7 @@ CompiledMethodLayout class >> extending: superLayout scope: aScope host: aClass 
 ]
 
 { #category : #description }
-CompiledMethodLayout class >> kind [ 
+CompiledMethodLayout class >> mcTypeSymbol [ 
 	^ #compiledMethod 
 ]
 

--- a/src/Kernel/EphemeronLayout.class.st
+++ b/src/Kernel/EphemeronLayout.class.st
@@ -16,7 +16,7 @@ EphemeronLayout class >> extending: superLayout scope: aScope host: aClass [
 ]
 
 { #category : #description }
-EphemeronLayout class >> kind [ 
+EphemeronLayout class >> mcTypeSymbol [ 
 	^ #ephemeron
 ]
 

--- a/src/Kernel/FixedLayout.class.st
+++ b/src/Kernel/FixedLayout.class.st
@@ -18,7 +18,7 @@ FixedLayout class >> extending: superLayout scope: aScope host: aClass [
 ]
 
 { #category : #description }
-FixedLayout class >> kind [ 
+FixedLayout class >> mcTypeSymbol [ 
 	^ #normal
 ]
 

--- a/src/Kernel/ImmediateLayout.class.st
+++ b/src/Kernel/ImmediateLayout.class.st
@@ -17,7 +17,7 @@ ImmediateLayout class >> extending: superLayout scope: aScope host: aClass [
 ]
 
 { #category : #description }
-ImmediateLayout class >> kind [ 	
+ImmediateLayout class >> mcTypeSymbol [ 	
 	^ #immediate
 ]
 

--- a/src/Kernel/ObjectLayout.class.st
+++ b/src/Kernel/ObjectLayout.class.st
@@ -17,18 +17,18 @@ ObjectLayout class >> isAbstract [
 	^self == ObjectLayout
 ]
 
-{ #category : #description }
-ObjectLayout class >> kind [
-	"return the symbol that Monticello uses to encode the layout"
-	^self name asSymbol
-]
-
 { #category : #monticello }
 ObjectLayout class >> layoutForType: typeSymbol [
 	"used to get the layout for a Monticello internal layout symbol"
 	^self allSubclasses 
-		detect: [ :class | class kind = typeSymbol ] 
+		detect: [ :class | class mcTypeSymbol = typeSymbol ] 
 		ifNone: [ Error signal: 'Invalid layout type: ', typeSymbol asString ]
+]
+
+{ #category : #monticello }
+ObjectLayout class >> mcTypeSymbol [
+	"return the symbol that Monticello uses to encode the layout"
+	^self name asSymbol
 ]
 
 { #category : #description }

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -215,6 +215,13 @@ UndefinedObject >> isNotNil [
 	^false
 ]
 
+{ #category : #'class hierarchy' }
+UndefinedObject >> mcType [
+	"Answer the symbol that Monticello uses internally to encode layouts"
+	"Implemented here  to support disjoint class hierarchies"
+	^#normal
+]
+
 { #category : #testing }
 UndefinedObject >> notNil [ 
 	"Refer to the comment in Object|notNil."
@@ -285,13 +292,6 @@ UndefinedObject >> subclassesDo: aBlock [
 
 	^ Class subclassesDo: [:cl | 
 			cl isMeta ifTrue: [aBlock value: cl soleInstance]].
-]
-
-{ #category : #'class hierarchy' }
-UndefinedObject >> typeOfClass [
-	"Answer the symbol that Monticello uses internally to encode layouts"
-	"Implemented here  to support disjoint class hierarchies"
-	^#normal
 ]
 
 { #category : #copying }

--- a/src/Kernel/VariableLayout.class.st
+++ b/src/Kernel/VariableLayout.class.st
@@ -18,7 +18,7 @@ VariableLayout class >> extending: superLayout scope: aScope host: aClass [
 ]
 
 { #category : #description }
-VariableLayout class >> kind [ 
+VariableLayout class >> mcTypeSymbol [ 
 	^ #variable
 ]
 

--- a/src/Kernel/WeakLayout.class.st
+++ b/src/Kernel/WeakLayout.class.st
@@ -20,7 +20,7 @@ WeakLayout class >> extending: superLayout scope: aScope host: aClass [
 ]
 
 { #category : #description }
-WeakLayout class >> kind [ 
+WeakLayout class >> mcTypeSymbol [ 
 	^ #weak
 ]
 

--- a/src/Kernel/WordLayout.class.st
+++ b/src/Kernel/WordLayout.class.st
@@ -15,7 +15,7 @@ WordLayout class >> extending: superLayout scope: aScope host: aClass [
 ]
 
 { #category : #description }
-WordLayout class >> kind [ 
+WordLayout class >> mcTypeSymbol [ 
 	^ #words
 ]
 

--- a/src/Monticello/Class.extension.st
+++ b/src/Monticello/Class.extension.st
@@ -20,7 +20,7 @@ Class >> asClassDefinition [
 						classVarNames: (self classVariables collect: [:each | each definitionString])
 						poolDictionaryNames: self sharedPoolNames
 						classInstVarNames: (self class localSlots collect: [:each | each definitionString])
-						type: self typeOfClass
+						type: self mcType
 						comment: self organization classComment	asString
 						commentStamp: self organization commentStamp ]
 	
@@ -35,7 +35,7 @@ Class >> asClassDefinition [
 						classVarNames: self classVarNames
 						poolDictionaryNames: self sharedPoolNames
 						classInstVarNames: (self class localSlots collect: [ :each | each name ])
-						type: self typeOfClass
+						type: self mcType
 						comment: self organization classComment	asString
 						commentStamp: self organization commentStamp ]
 	


### PR DESCRIPTION
- deprecate #typeOfClass
- deprecate #kind
- add #mcType and #mcTypeSymbol (can not be mcType as all classes need to return their correct #mcType, including the Layout Classes)

fixes #9909


