### PR TITLE
9925-Defining-variables-in-the-debugger-DNU-isForScripting 

### DIFF
--- a/src/Rubric/RubAbstractSmalltalkMode.class.st
+++ b/src/Rubric/RubAbstractSmalltalkMode.class.st
@@ -19,6 +19,12 @@ RubAbstractSmalltalkMode >> isCompletionEnabled [
 ]
 
 { #category : #testing }
+RubAbstractSmalltalkMode >> isForScripting [
+	"needs to be unified is #isScripting"
+	self isScripting
+]
+
+{ #category : #testing }
 RubAbstractSmalltalkMode >> isScripting [
 	^ false
 ]


### PR DESCRIPTION
Workaround, fixes #9925

