### PR TITLE
9936-MCClassDefinitionkindOfSubclass-wrong-for-user-defined-layouts 

### DIFF
--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -121,7 +121,7 @@ MCClassDefinitionTest >> testEqualsSensitivity [
 { #category : #tests }
 MCClassDefinitionTest >> testKindOfSubclass [
 	| classes |
-	classes := {self mockClassA. String. Context. WeakArray. Float}.
+	classes := {self mockClassA. String. Context. WeakArray. Float. CompiledMethod. DoubleByteArray . DoubleWordArray }.
 	classes do: [:c | | d |
 		d :=  c asClassDefinition.
 		self assert: d kindOfSubclass equals: c kindOfSubclass.

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -355,9 +355,8 @@ MCClassDefinition >> kindOfSubclass [
 	type = #ephemeron ifTrue: [ ^ ' ephemeronSubclass: ' ].
 	type = #DoubleByteLayout ifTrue: [ ^' variableDoubleByteSubclass: ' ].
 	type = #DoubleWordLayout ifTrue: [ ^' variableDoubleWordSubclass: ' ].
-	"hack to support user defined layouts"
-	(Smalltalk hasClassNamed: type) ifTrue: [ ^type asString].
-	self error: 'Unrecognized class type', type asString
+	"To support user defined layouts (load them as normal classes), we just return the default"
+	^ ' subclass: '
 ]
 
 { #category : #installing }


### PR DESCRIPTION
- return the "subclass:" string for all non-known cases
- improve testKindOfSubclass to test CompiledMethod and the  DoubleByteLayout / DoubleWordLayout cases

does not really test the fallback case as we have no user-defined layouts in the system for now

fixes #9936

