### PR TITLE
NoSymbolCreation-hasPackageMatchingExtensionName 

### DIFF
--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -453,7 +453,7 @@ RPackageOrganizer >> hasPackageMatchingExtensionName: anExtensionName [
 		ifTrue: [ ^true ].
 		
 	packages keysDo: [ :aSymbol | 
-		(anExtensionName beginsWithEmpty: aSymbol, '-' caseSensitive: false)
+		(anExtensionName beginsWithEmpty: aSymbol asString, '-' caseSensitive: false)
 			ifTrue: [ ^ true]].
 	^ false
 	


### PR DESCRIPTION
as described in #8242, this PR avoids a symbol creation in RPackageOrganizer>>#hasPackageMatchingExtensionName:

The issue tracker entry has another idea to speed this up even more which we should try afterward (the issue tracker entry thus stays open even after merging this)


