### PR TITLE
9928-Do-not-use-optionFullBlockClosure-in-OCASTTranslatorvisitBlockNode

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -56,9 +56,6 @@ CompilationContext class >> bytecodeBackend [
 
 { #category : #accessing }
 CompilationContext class >> bytecodeBackend: bytecodeSet [
-	((self defaultOptions includes: #optionFullBlockClosure)
-		and: [ bytecodeSet ~= EncoderForSistaV1 ]) ifTrue: [ 
-			^ self notify: 'Operation aborted. Bytecode set incompatible with FullBlockClosure option.' ].
 	BytecodeBackend := bytecodeSet
 ]
 

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -501,29 +501,14 @@ OCASTTranslator >> visitAssignmentNode: anAssignmentNode [
 
 { #category : #'visitor - double dispatching' }
 OCASTTranslator >> visitBlockNode: aBlockNode [
+	| compiledBlock |
 	aBlockNode arguments size >15 ifTrue: [self backendError: 'Too many arguments' forNode: aBlockNode ].
-	
 	aBlockNode isInlined ifTrue: [^ self visitInlinedBlockNode: aBlockNode ].
 	
-	self compilationContext optionFullBlockClosure ifTrue: [ ^ self visitFullBlockNode: aBlockNode ].
-		
-	methodBuilder
-			pushClosureCopyCopiedValues: aBlockNode scope inComingCopiedVarNames
-			args: aBlockNode argumentNames
-			jumpTo:  #block.
-	 
-	aBlockNode scope tempVector ifNotEmpty: [
-		methodBuilder 
-			createTempVectorNamed: aBlockNode scope tempVectorName 
-			withVars: aBlockNode scope tempVectorVarNames.
-	].
-	methodBuilder addTemps: aBlockNode scope tempVarNamesWithoutArguments.
-	valueTranslator visitNode: aBlockNode body.
-	methodBuilder addBlockReturnTopIfRequired.
-	self flag: 'why dont we just add a blockReturnTop here... it could be removed or ignored in IRTranslator'.
-	methodBuilder jumpAheadTarget: #block.		
-
-
+	compiledBlock := self compilationContext astTranslatorClass new translateFullBlock: aBlockNode.
+	(self compilationContext optionCleanBlockClosure and: [ aBlockNode isClean ])
+		ifTrue: [ methodBuilder pushLiteral: ((CleanBlockClosure new: 0) numArgs: compiledBlock numArgs; compiledBlock: compiledBlock)]
+		ifFalse: [methodBuilder pushFullClosureCompiledBlock: compiledBlock copiedValues: aBlockNode scope inComingCopiedVarNames  ]
 ]
 
 { #category : #'visitor - double dispatching' }
@@ -536,15 +521,6 @@ OCASTTranslator >> visitCascadeNode: aCascadeNode [
 	].
 	self visitNode: aCascadeNode messages last.
 
-]
-
-{ #category : #'visitor - double dispatching' }
-OCASTTranslator >> visitFullBlockNode: aBlockNode [
-	| compiledBlock |
-	compiledBlock := self compilationContext astTranslatorClass new translateFullBlock: aBlockNode.
-	(self compilationContext optionCleanBlockClosure and: [ aBlockNode isClean ])
-		ifTrue: [ methodBuilder pushLiteral: ((CleanBlockClosure new: 0) numArgs: compiledBlock numArgs; compiledBlock: compiledBlock)]
-		ifFalse: [methodBuilder pushFullClosureCompiledBlock: compiledBlock copiedValues: aBlockNode scope inComingCopiedVarNames  ]
 ]
 
 { #category : #'visitor - double dispatching' }


### PR DESCRIPTION
This PR removes the check for #optionFullBlockClosure in #visitBlockNode: and inlines #visitFullBlockNode: there.

In addition, remove check when setting the backend. After this the #optionFullBlockClosure option still exists but it is never checked (this we can deprecate or remove it)

fixes #9928


