### PR TITLE
CDSlotNode-NoIndex 

### DIFF
--- a/src/ClassParser/CDSlotNode.class.st
+++ b/src/ClassParser/CDSlotNode.class.st
@@ -3,7 +3,6 @@ Class {
 	#superclass : #CDNode,
 	#instVars : [
 		'node',
-		'index',
 		'start',
 		'stop',
 		'name',
@@ -49,12 +48,6 @@ CDSlotNode >> asSlot [
 CDSlotNode >> binding [
 	"To be polymorphic to RB method nodes"
 	^self
-]
-
-{ #category : #accessing }
-CDSlotNode >> index: anInteger [ 
-	
-	index := anInteger
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
CDSlotNode should not have an "index" ivar: Only indexedSlots have an index and that information is just needed for compilation

fixes #9938


