### PR TITLE
9948-OCRequestorScope-does-not-like-empty-variable-names

### DIFF
--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -33,14 +33,20 @@ OCRequestorScope >> compilationContext: anObject [
 { #category : #lookup }
 OCRequestorScope >> lookupVar: name declare: aBoolean [
 
-	"reserved Variables are defined by the instance scope"
+	"the system normally allows any object as the name, but the requestor uses some 
+	heuristics based on names of variables"
+	
+	name isString ifFalse: [ ^ outerScope lookupVar: name declare: aBoolean ].
+	name isEmpty ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
+
+	"reserved Variables are defined by the global scope, thus we look up in the outer scope"
 	(ReservedVariable nameIsReserved: name) ifTrue: [ 
 		^ outerScope lookupVar: name declare: aBoolean ].
 	
 	"generated temps (e.g. for limits in to:do: should not create bindings"
 	name first = $0 ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
 	"We do not want to auto define bindings for unknown Globals"
-	(name isString and: [name first isUppercase]) ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean].
+	name first isUppercase ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean].
 	"do not 'create bindings' in requestor scope if we just want to style a possible unknown variable"
 	((compilationContext optionSkipSemanticWarnings or: [aBoolean not])
 		and: [ (requestor hasBindingOf: name) not ])

--- a/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
@@ -11,6 +11,24 @@ Class {
 	#category : #'OpalCompiler-Tests-Source'
 }
 
+{ #category : #'interactive error protocol' }
+OCCompileWithFailureTest >> notify: aMessage at: positon in: object [
+	"ingnore, for testEmptyBlockArg"
+]
+
+{ #category : #tests }
+OCCompileWithFailureTest >> testEmptyBlockArg [
+	| result | 
+	"parse [:] in parse error mode, this results in arg vars with an empty string as a name"
+	result := UndefinedObject compiler
+    source: '^[ :]';
+    noPattern: true;
+    options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
+    requestor: self;
+    parse. 
+	self assert: result isReturn
+]
+
 { #category : #tests }
 OCCompileWithFailureTest >> testEvalSimpleMethodWithError [
 	| ast cm |


### PR DESCRIPTION
fixes #9948 and add a test
This is just a workaround, I will open another issue describing the real solution.


