### PR TITLE
9924-CDBehaviorDefinitionNode-uses-subclassDefiningSymbol-not-unique

### DIFF
--- a/src/ClassParser-Tests/ASTClassBuilderTest.class.st
+++ b/src/ClassParser-Tests/ASTClassBuilderTest.class.st
@@ -361,7 +361,8 @@ ASTClassBuilderTest >> testCreateVariableWordClassWithAll [
 		         build.
 	self assert: class name equals: #TestSubClass.
 	self assert: class instanceVariablesString equals: ''.
-	self assert: class classVarNames equals: #( #classVar #pouet #var )
+	self assert: class classVarNames equals: #( #classVar #pouet #var ).
+	self assert: class classLayout class equals: WordLayout.
 ]
 
 { #category : #running }

--- a/src/ClassParser-Tests/CDFluidClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDFluidClassParserTest.class.st
@@ -92,7 +92,7 @@ CDFluidClassParserTest >> testEphemeronSubclass [
 		layout: EphemeronLayout;
 		package: #MyPackage'.
 	def := parser parse: defString.
-	self assert: def classKind equals: #ephemeronSubclass:
+	self assert: def layoutClass equals: EphemeronLayout
 ]
 
 { #category : #'tests - (r) simple class definition' }
@@ -115,7 +115,7 @@ CDFluidClassParserTest >> testNormalSubclass [
 		layout: FixedLayout;
 		package: #MyPackage'.
 	def := parser parse: defString.
-	self assert: def classKind equals: #subclass:
+	self assert: def layoutClass equals: FixedLayout
 ]
 
 { #category : #'tests - (r) sharedPools' }
@@ -304,7 +304,7 @@ CDFluidClassParserTest >> testVariableByteSubclass [
 		layout: ByteLayout;
 		package: #MyPackage'.
 	def := parser parse: defString.
-	self assert: def classKind equals: #variableByteSubclass:
+	self assert: def layoutClass equals: ByteLayout
 ]
 
 { #category : #'tests - (r) kinds' }
@@ -317,7 +317,7 @@ CDFluidClassParserTest >> testVariableSubclass [
 		layout: VariableLayout;
 		package: #MyPackage'.
 	def := parser parse: defString.
-	self assert: def classKind equals: #variableSubclass:
+	self assert: def layoutClass equals: VariableLayout
 ]
 
 { #category : #'tests - (r) kinds' }
@@ -330,7 +330,7 @@ CDFluidClassParserTest >> testVariableWordSubclass [
 		layout: WordLayout;
 		package: #MyPackage'.
 	def := parser parse: defString.
-	self assert: def classKind equals: #variableWordSubclass:
+	self assert: def layoutClass equals: WordLayout
 ]
 
 { #category : #'tests - (r) kinds' }
@@ -343,5 +343,5 @@ CDFluidClassParserTest >> testWeakSubclass [
 		layout: WeakLayout;
 		package: #MyPackage'.
 	def := parser parse: defString.
-	self assert: def classKind equals: #weakSubclass:
+	self assert: def layoutClass equals: WeakLayout
 ]

--- a/src/ClassParser/CDBehaviorDefinitionNode.class.st
+++ b/src/ClassParser/CDBehaviorDefinitionNode.class.st
@@ -9,7 +9,7 @@ Class {
 		'slotNodes',
 		'traitDefinition',
 		'className',
-		'classKind'
+		'layoutClass'
 	],
 	#category : #'ClassParser-Model'
 }
@@ -24,17 +24,6 @@ CDBehaviorDefinitionNode >> addSlot: aCDSlotNode [
 { #category : #accessing }
 CDBehaviorDefinitionNode >> classDefinitionNode [
 	^self
-]
-
-{ #category : #testing }
-CDBehaviorDefinitionNode >> classKind [
-
-	^ classKind
-]
-
-{ #category : #accessing }
-CDBehaviorDefinitionNode >> classKind: aString [ 
-	classKind := aString
 ]
 
 { #category : #accessing }
@@ -95,43 +84,54 @@ CDBehaviorDefinitionNode >> initialize [
 { #category : #testing }
 CDBehaviorDefinitionNode >> isBytes [
 	
-	^ classKind = #variableByteSubclass:
+	^ layoutClass = ByteLayout
 ]
 
 { #category : #testing }
 CDBehaviorDefinitionNode >> isEphemeron [
 	
-	^ classKind = #ephemeronSubclass:
+	^ layoutClass = EphemeronLayout
 ]
 
 { #category : #testing }
 CDBehaviorDefinitionNode >> isImmediate [
 	
-	^ classKind = #immediateSubclass:
+	^ layoutClass = ImmediateLayout
 ]
 
 { #category : #testing }
 CDBehaviorDefinitionNode >> isNormal [
 	
-	^ classKind = #subclass:
+	^ layoutClass = FixedLayout
 ]
 
 { #category : #testing }
 CDBehaviorDefinitionNode >> isVariableClass [
 	
-	^ classKind = #variableSubclass:
+	^ layoutClass = VariableLayout
 ]
 
 { #category : #testing }
 CDBehaviorDefinitionNode >> isWeak [
 	
-	^ classKind = #weakSubclass:
+	^ layoutClass = WeakLayout
 ]
 
 { #category : #testing }
 CDBehaviorDefinitionNode >> isWords [
 	
-	^ classKind = #variableWordSubclass:
+	^ layoutClass = WordLayout
+]
+
+{ #category : #testing }
+CDBehaviorDefinitionNode >> layoutClass [
+
+	^ layoutClass
+]
+
+{ #category : #accessing }
+CDBehaviorDefinitionNode >> layoutClass: aClass [ 
+	layoutClass := aClass
 ]
 
 { #category : #accessing }

--- a/src/ClassParser/CDClassDefinitionParser.class.st
+++ b/src/ClassParser/CDClassDefinitionParser.class.st
@@ -20,9 +20,19 @@ CDClassDefinitionParser class >> fromASTNode: aNode [
 
 { #category : #parsing }
 CDClassDefinitionParser >> handleClassName: aNode withType: aSymbol [
+	| layout |
 	
 	self handleClassName: aNode.
-	classDefinition classKind: aSymbol
+	layout := FixedLayout.
+	aSymbol = #variableWordSubclass: ifTrue: [ layout := WordLayout ].
+	aSymbol = #ephemeronSubclass: ifTrue: [ layout := EphemeronLayout ].
+	aSymbol = #weakSubclass: ifTrue: [ layout := WeakLayout ].
+	aSymbol = #variableByteSubclass: ifTrue: [ layout := ByteLayout  ].
+	aSymbol = #variableSubclass: ifTrue: [ layout := VariableLayout ].
+	aSymbol = #immediateSubclass: ifTrue: [ layout := ImmediateLayout ].
+	aSymbol = #subclass: ifTrue: [ layout := FixedLayout ].
+	
+	classDefinition layoutClass: layout
 ]
 
 { #category : #parsing }

--- a/src/ClassParser/CDFluidClassDefinitionParser.class.st
+++ b/src/ClassParser/CDFluidClassDefinitionParser.class.st
@@ -62,7 +62,7 @@ CDFluidClassDefinitionParser >> handleClassAndSuperclassOf: aNode [
 
 { #category : #'handling  nodes' }
 CDFluidClassDefinitionParser >> handleLayout: aNode [
-	classDefinition classKind: aNode binding value subclassDefiningSymbol
+	classDefinition layoutClass: aNode binding value
 ]
 
 { #category : #'handling  nodes' }

--- a/src/ClassParser/ShiftClassBuilder.extension.st
+++ b/src/ClassParser/ShiftClassBuilder.extension.st
@@ -15,19 +15,7 @@ ShiftClassBuilder >> buildFromAST: aCDClassDefinitionNode [
 						inEnv: buildEnvironment) ]
 		ifTrue: [ self superclass: nil ].
 		
-	self layoutClass: FixedLayout.
-	aCDClassDefinitionNode isEphemeron
-		ifTrue: [ self layoutClass: EphemeronLayout ].
-	aCDClassDefinitionNode isWeak
-		ifTrue: [ self layoutClass: WeakLayout ].
-	aCDClassDefinitionNode isImmediate
-		ifTrue: [ self layoutClass: ImmediateLayout ].
-	aCDClassDefinitionNode isVariableClass
-		ifTrue: [ self layoutClass: VariableLayout ].
-	aCDClassDefinitionNode isWords
-		ifTrue: [ self layoutClass: WordLayout ].
-	aCDClassDefinitionNode isBytes
-		ifTrue: [ self layoutClass: ByteLayout ].
+	self layoutClass: aCDClassDefinitionNode layoutClass.
 		
 	self slots: (aCDClassDefinitionNode slots collect: [ :e | e asSlot ]).
 	


### PR DESCRIPTION
- store the layoutClass in CDBehaviorDefinitionNode, not a symbol
- fix all tests to check for that
- fix CDClassDefinitionParser to do the right thing
- simplify #buildFromAST: which can now just take the layout from the CDBehaviorDefinitionNode

fixes #9924


