### PR TITLE
String #beginsWith:caseSensitive and #endsWith:caseSensitive: 

### DIFF
--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -554,6 +554,30 @@ StringTest >> testAt [
 ]
 
 { #category : #tests }
+StringTest >> testBeginsWithCaseSensitive [
+	| w1 w2 |
+	self deny: ('abc' beginsWith: '' caseSensitive: true). "consistent to #beginsWith:"
+	self deny: ('abc' beginsWith: '' caseSensitive: false). "consistent to #beginsWith:"
+	self deny: ('abc' beginsWith: 'abcd' caseSensitive: true).
+	self deny: ('abc' beginsWith: 'abcd' caseSensitive: false).
+	self deny: ('abc' beginsWith: 'c' caseSensitive: true).
+	self deny: ('abc' beginsWith: 'c' caseSensitive: false).
+	
+	self assert: ('abc' beginsWith: 'ab' caseSensitive: true).
+	self assert: ('abc' beginsWith: 'ab' caseSensitive: false).
+	self assert: ('abc' beginsWith: 'Ab' caseSensitive: false).
+	self assert: ('abc' beginsWith: 'aB' caseSensitive: false).
+	self deny: ('abc' beginsWith: 'aB' caseSensitive: true).
+	self assert: ('abcd' asWideString beginsWith: 'abC' caseSensitive: false).
+
+	w1 := WideString with: (Unicode value: 402) with: $a with: (Unicode value: 400) with: $b.
+	w2 := WideString with: (Unicode value: 402).
+	self assert: (w1 beginsWith: w2 caseSensitive: true).
+	self deny: (w1 beginsWith: w2 asUppercase caseSensitive: true).
+	self assert: (w1 beginsWith: w2 asUppercase caseSensitive: false).
+]
+
+{ #category : #tests }
 StringTest >> testBeginsWithEmptyCaseSensitive [
 
 	self deny: ('éèàôüößäóñíá' beginsWithEmpty: 'ß' caseSensitive: true).
@@ -765,6 +789,30 @@ StringTest >> testEndsWithAnyOf [
 	self assert: ('éèàôüößäóñíá' endsWithAnyOf: #('test' 'ÉÈÀ' 'äóñíá')).
 	self assert: ('test' endsWithAnyOf: #('tests' 'tester' 'testing' 't')).
 
+]
+
+{ #category : #tests }
+StringTest >> testEndsWithCaseSensitive [
+	| w1 w2 |
+	self deny: ('abc' endsWith: '' caseSensitive: true). "consistent to #beginsWith:"
+	self deny: ('abc' endsWith: '' caseSensitive: false). "consistent to #beginsWith:"
+	self deny: ('abc' endsWith: 'qabc' caseSensitive: false).
+	self deny: ('abc' endsWith: 'qabc' caseSensitive: true).
+	self deny: ('abc' endsWith: 'a' caseSensitive: true).
+	self deny: ('abc' endsWith: 'a' caseSensitive: false).
+	
+	self assert: ('abc' endsWith: 'bc' caseSensitive: true).
+	self assert: ('abc' endsWith: 'bc' caseSensitive: false).
+	self assert: ('abc' endsWith: 'bC' caseSensitive: false).
+	self assert: ('abc' endsWith: 'Bc' caseSensitive: false). 
+	self deny: ('abc' endsWith: 'Bc' caseSensitive: true).
+	self assert: ('abcd' asWideString endsWith: 'Bcd' caseSensitive: false). 
+
+	w1 := WideString with: (Unicode value: 400) with: $a with: $b with: (Unicode value: 402).
+	w2 := WideString with: (Unicode value: 402).
+	self assert: (w1 endsWith: w2 caseSensitive: true).
+	self deny: (w1 endsWith: w2 asUppercase caseSensitive: true).
+	self assert: (w1 endsWith: w2 asUppercase caseSensitive: false).
 ]
 
 { #category : #tests }

--- a/src/Collections-Strings/ByteString.class.st
+++ b/src/Collections-Strings/ByteString.class.st
@@ -166,29 +166,6 @@ ByteString >> at: index put: aCharacter [
 
 ]
 
-{ #category : #comparing }
-ByteString >> beginsWith: prefix [
-	"Answer whether the receiver begins with the given prefix string.
-	The comparison is case-sensitive."
-
-	"IMPLEMENTATION NOTE:
-	following algorithm is optimized in primitive only in case self and prefix are bytes like.
-	Otherwise, if self is wide, then super outperforms,
-	Otherwise, if prefix is wide, primitive is not correct"
-	
-	"('pharo' beginsWith: '') >>> false"
-	"('pharo' beginsWith: 'pharo-project') >>> false"
-	"('pharo' beginsWith: 'phuro') >>> false"
-	"('pharo' beginsWith: 'pha') >>> true"
-	
-	prefix class isBytes ifFalse: [^super beginsWith: prefix].
-	
-	self size < prefix size ifTrue: [^ false].
-	^ (self findSubstring: prefix in: self startingAt: 1
-			matchTable: CaseSensitiveOrder) = 1
-
-]
-
 { #category : #accessing }
 ByteString >> byteAt: index [
 	<primitive: 60>

--- a/src/Collections-Strings/ByteSymbol.class.st
+++ b/src/Collections-Strings/ByteSymbol.class.st
@@ -52,27 +52,6 @@ ByteSymbol >> at: index [
 	^ Character value: (super at: index)
 ]
 
-{ #category : #testing }
-ByteSymbol >> beginsWith: prefix [
-	"Answer whether the receiver begins with the given prefix string.
-	The comparison is case-sensitive."
-
-	"IMPLEMENTATION NOTE:
-	following algorithm is optimized in primitive only in case self and prefix are bytes like.
-	Otherwise, if self is wide, then super outperforms,
-	Otherwise, if prefix is wide, primitive is not correct"
-
-	"(#pharo beginsWith: #pharoProject) >>> false"
-	"(#pharo beginsWith: #phuro) >>> false"
-	"(#pharo beginsWith: #pha) >>> true"
-	
-	prefix class isBytes ifFalse: [^super beginsWith: prefix].
-	
-	self size < prefix size ifTrue: [^ false].
-	^ (self findSubstring: prefix in: self startingAt: 1
-			matchTable: CaseSensitiveOrder) = 1
-]
-
 { #category : #accessing }
 ByteSymbol >> byteAt: index [
 	<primitive: 60>

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1105,7 +1105,7 @@ String >> displayStringOn: aStream [
 
 { #category : #testing }
 String >> endsWith: suffix [
-	"Answer whether the receiver begins with the given prefix string.
+	"Answer whether the receiver ends with the given prefix string.
 	The comparison is case-sensitive."
 
 	"IMPLEMENTATION NOTE:

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -774,6 +774,53 @@ String >> asWideString [
 ]
 
 { #category : #testing }
+String >> beginsWith: prefix [
+	"Answer whether the receiver begins with the given prefix string.
+	The comparison is case-sensitive."
+
+	"IMPLEMENTATION NOTE:
+	following algorithm is optimized in primitive only in case self and prefix are bytes like.
+	Otherwise, if self is wide, then super outperforms,
+	Otherwise, if prefix is wide, primitive is not correct"
+	
+	"('pharo' beginsWith: '') >>> false"
+	"('pharo' beginsWith: 'pharo-project') >>> false"
+	"('pharo' beginsWith: 'phuro') >>> false"
+	"('pharo' beginsWith: 'pha') >>> true"
+	
+	(self class isBytes and: [ prefix class isBytes ]) ifFalse: [^super beginsWith: prefix].
+	
+	self size < prefix size ifTrue: [^ false].
+	^ (self findSubstring: prefix in: self startingAt: 1 
+			  matchTable: CaseSensitiveOrder) = 1
+]
+
+{ #category : #testing }
+String >> beginsWith: prefix caseSensitive: aBoolean [ 
+	"Answer whether the receiver begins with the given prefix string"
+
+	"IMPLEMENTATION NOTE:
+	following algorithm is optimized in primitive only in case self and prefix are bytes like.
+	Otherwise, if self or prefix are wide strings, then slow version with asLowercase convertation,
+	(primitive is not correct for wide strings)"
+	
+	"('pharo' beginsWith: '' caseSensitive: false) >>> false"
+	"('pharo' beginsWith: 'pharo-project' caseSensitive: false) >>> false"
+	"('pharo' beginsWith: 'phuro' caseSensitive: false) >>> false"
+	"('pharo' beginsWith: 'Pha' caseSensitive: false) >>> true"
+
+	aBoolean ifTrue: [ ^self beginsWith: prefix ].
+	self size < prefix size ifTrue: [^ false].
+	(self class isBytes and: [prefix class isBytes]) ifTrue: [
+		"Optimized version based on primitive"
+		^ (self findSubstring: prefix in: self startingAt: 1 matchTable: CaseInsensitiveOrder) = 1 ].
+	prefix withIndexDo: [ :each :index | 
+		(self at: index) asLowercase = each asLowercase ifFalse: [ ^false ]
+	].
+	^true
+]
+
+{ #category : #testing }
 String >> beginsWithEmpty: prefix caseSensitive: aBoolean [ 
 	"Answer whether the receiver begins with the given prefix string. 
 	The comparison is case-sensitive." 
@@ -1058,16 +1105,52 @@ String >> displayStringOn: aStream [
 
 { #category : #testing }
 String >> endsWith: suffix [
-	"Answer whether the tail end of the receiver is the same as suffix.
+	"Answer whether the receiver begins with the given prefix string.
 	The comparison is case-sensitive."
- 
-	"('Elvis' endsWith: 'vis') >>> true"
+
+	"IMPLEMENTATION NOTE:
+	following algorithm is optimized in primitive only in case self and prefix are bytes like.
+	Otherwise, if self is wide, then super outperforms,
+	Otherwise, if prefix is wide, primitive is not correct"
 	
-	| extra |
-	extra := self size - suffix size.
-	^extra < 0 
-		ifTrue: [ false]
-	   ifFalse: [ (self findString: suffix startingAt: extra + 1) > 0 ]
+	"('pharo' endsWith: '') >>> false"
+	"('pharo' endsWith: 'project-pharo') >>> false"
+	"('pharo' endsWith: 'phuro') >>> false"
+	"('pharo' endsWith: 'aro') >>> true"
+	"('pharo' endsWith: 'aRo') >>> false"
+	
+	| requiredStart |
+	(self class isBytes and: [ suffix class isBytes ]) ifFalse: [^super endsWith: suffix].	
+	requiredStart := self size - suffix size + 1.
+	requiredStart <= 0 ifTrue: [  ^false ].
+	
+	^ (self findSubstring: suffix in: self startingAt: requiredStart
+			  matchTable: CaseSensitiveOrder) = requiredStart
+]
+
+{ #category : #testing }
+String >> endsWith: suffix caseSensitive: aBoolean [ 
+	"Answer whether the tail end of the receiver is the same as suffix"
+
+	"IMPLEMENTATION NOTE:
+	following algorithm is optimized in primitive only in case self and suffix are bytes like.
+	Otherwise, if self or suffix are wide strings, then slow version with asLowercase convertation,
+	(primitive is not correct for wide strings)"
+	
+	"('pharo' endsWith: '' caseSensitive: false) >>> false"
+	"('pharo' endsWith: 'project-pharo' caseSensitive: false) >>> false"
+	"('pharo' endsWith: 'phuro' caseSensitive: false) >>> false"
+	"('pharo' endsWith: 'aRo' caseSensitive: false) >>> true"
+	aBoolean ifTrue: [ ^self endsWith: suffix ].
+	self size < suffix size ifTrue: [^ false].
+	(self class isBytes and: [suffix class isBytes]) ifTrue: [
+		"Optimized version based on primitive"
+		^ (self findSubstring: suffix in: self startingAt: self size - suffix size + 1
+				  matchTable: CaseInsensitiveOrder) = (self size - suffix size + 1) ].
+	suffix withIndexDo: [ :each :index | 
+		(self at: self size - suffix size + index) asLowercase = each asLowercase ifFalse: [ ^false ]
+	].
+	^true
 ]
 
 { #category : #testing }


### PR DESCRIPTION
1. Introduce #beginsWith:caseSensitive and #endsWith:caseSensitive: String methods using existing primitive approach for substring search (see current beginsWith:) 
The new #begins method should replace quite strangely named #beginsWithEmpty:caseSensitive (in another PR). The old method actually does not work properly for wide strings (covered by tests for new methods).

2. Remove duplicated #beginWith:  in String subclasses. Simply check the bytes  type of string in the base class to decide if super implementation is required (the type check was already there but only for the argument). 
The logic of those  methods is not that simple actually due to the optimization parts. And therefore I believe it is a better  to not spread it over classes.

3. Optimize endsWith: using same logic as #beginsWith: