### PR TITLE
9965-CI-ZipArchiveTesttestArchiveWithThousandFilesShouldWork-sometimes-times-out 

### DIFF
--- a/src/Compression-Tests/ZipArchiveTest.class.st
+++ b/src/Compression-Tests/ZipArchiveTest.class.st
@@ -14,6 +14,11 @@ Class {
 	#category : #'Compression-Tests-Archives'
 }
 
+{ #category : #accessing }
+ZipArchiveTest class >> defaultTimeLimit [
+	^30 seconds
+]
+
 { #category : #tests }
 ZipArchiveTest >> assertLastModificationTimeFrom: endianStream expected: fileModified [
 	| lastModificationTime |


### PR DESCRIPTION
increase the time limit for ZipArchiveTest
fixes #9965

Just increased from 10 to 30 seconds, (just made that up). I think we should improve the print of TestTookTooMuchTime to print the time (I will add an issue for that)