### PR TITLE
update Spec version to v1.0.3 and NewTools to v0.6.10

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -40,8 +40,8 @@ BaselineOfPharo class >> newToolsVersion [
 BaselineOfPharo class >> specReleaseCommit [
 	"The commit corresponding to current release (to be used on bootstrap process)"
 
-	"v1.0.2"
-	^ '88cc5234fcbcc8a8cc8da085c5e23f74db1c349b'
+	"v1.0.3"
+	^ '093d57d83f1554b69ca019c21b1f955ec71f8f0d'
 ]
 
 { #category : #'repository urls' }
@@ -53,7 +53,7 @@ BaselineOfPharo class >> specRepository [
 { #category : #versions }
 BaselineOfPharo class >> specVersion [
 
-	^ 'v1.0.2'
+	^ 'v1.0.3'
 ]
 
 { #category : #baseline }

--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -20,8 +20,8 @@ BaselineOfPharo class >> icebergVersion [
 BaselineOfPharo class >> newToolsReleaseCommit [
 	"The commit corresponding to current release (to be used on bootstrap process)"
 
-	"v0.6.9"
-	^ '3f9dfd73609fa14254fedbab70c69842bfde8a76'
+	"v0.6.10"
+	^ '526c39f7511ecf24308b36d044ebb6647ffa226c'
 ]
 
 { #category : #'repository urls' }
@@ -33,7 +33,7 @@ BaselineOfPharo class >> newToolsRepository [
 { #category : #versions }
 BaselineOfPharo class >> newToolsVersion [
 
-	^ 'v0.6.9'
+	^ 'v0.6.10'
 ]
 
 { #category : #versions }

--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -21,7 +21,7 @@ BaselineOfPharo class >> newToolsReleaseCommit [
 	"The commit corresponding to current release (to be used on bootstrap process)"
 	
 	"v0.6.10"
-	^ '526c39f7511ecf24308b36d044ebb6647ffa226c'
+	^ '53f0f8ba1c81edd16b994bb80f8568e2693d5faf'
 ]
 
 { #category : #'repository urls' }

--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -19,7 +19,7 @@ BaselineOfPharo class >> icebergVersion [
 { #category : #versions }
 BaselineOfPharo class >> newToolsReleaseCommit [
 	"The commit corresponding to current release (to be used on bootstrap process)"
-
+	
 	"v0.6.10"
 	^ '526c39f7511ecf24308b36d044ebb6647ffa226c'
 ]
@@ -41,7 +41,7 @@ BaselineOfPharo class >> specReleaseCommit [
 	"The commit corresponding to current release (to be used on bootstrap process)"
 
 	"v1.0.3"
-	^ '093d57d83f1554b69ca019c21b1f955ec71f8f0d'
+	^ '64d914cd5c621f00b551306ee2fbd1e3540af6a1'
 ]
 
 { #category : #'repository urls' }

--- a/src/GT-SpotterExtensions-Core/HelpTopic.extension.st
+++ b/src/GT-SpotterExtensions-Core/HelpTopic.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #HelpTopic }
 
 { #category : #'*GT-SpotterExtensions-Core' }
+HelpTopic >> gtAllSubtopics [
+
+	 ^ self subtopics flatCollect: [:aTopic |
+		aTopic asOrderedCollection, aTopic gtAllSubtopics ]
+]
+
+{ #category : #'*GT-SpotterExtensions-Core' }
 HelpTopic >> gtBreadcrumbTitle [
 	|breadcrumbTitle currentHelpTopic|
 	

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -131,7 +131,6 @@ SystemDependenciesTest >> knownSpec2Dependencies [
 	
 	^ #(
 		'WebBrowser-Core' "Spec's Link adapter"
-		'Spec2-CommonWidgets'
 		)
 ]
 

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -59,7 +59,7 @@ SystemDependenciesTest >> knownBasicToolsDependencies [
 
 	"ideally this list should be empty"	
 	^ #('AST-Core-Tests' 'Athens-Cairo' 'Athens-Core' 
-	#'Athens-Morphic' #'Refactoring-Critics' #'Reflectivity' #'Reflectivity-Tools' #Shout 'ParametrizedTests' 'HeuristicCompletion-Model' #VariablesLibrary)
+	#'Athens-Morphic' #'Refactoring-Critics' #'Reflectivity' #'Reflectivity-Tools' #Shout 'ParametrizedTests' 'HeuristicCompletion-Model' #VariablesLibrary 'Spec2-CommonWidgets')
 ]
 
 { #category : #'known dependencies' }
@@ -83,7 +83,7 @@ SystemDependenciesTest >> knownIDEDependencies [
 
 	"ideally this list should be empty"	
 	
-	^ #('NewTools-Spotter')
+	^ #('NewTools-Spotter' 'Spec2-CommonWidgets')
 ]
 
 { #category : #'known dependencies' }
@@ -131,6 +131,7 @@ SystemDependenciesTest >> knownSpec2Dependencies [
 	
 	^ #(
 		'WebBrowser-Core' "Spec's Link adapter"
+		'Spec2-CommonWidgets'
 		)
 ]
 
@@ -148,7 +149,7 @@ SystemDependenciesTest >> knownUIDependencies [
 	"ideally this list should be empty"	
 
 	^ #('AST-Core-Tests'  'Athens-Cairo' 'Athens-Core' 
-	#'Athens-Morphic' #'Refactoring-Critics' #'Refactoring-Environment' 'Reflectivity-Tools' #Shout #'Tool-Diff' #'Tool-FileList' #'Tool-Profilers' #'HeuristicCompletion-Model' 'NECompletion-Morphic' #VariablesLibrary #'Tools-CodeNavigation')
+	#'Athens-Morphic' #'Refactoring-Critics' #'Refactoring-Environment' 'Reflectivity-Tools' #Shout #'Tool-Diff' #'Tool-FileList' #'Tool-Profilers' #'HeuristicCompletion-Model' 'NECompletion-Morphic' #VariablesLibrary #'Tools-CodeNavigation' 'Spec2-CommonWidgets')
 ]
 
 { #category : #utilities }


### PR DESCRIPTION
# Spec 1.0.3
https://github.com/pharo-spec/Spec/releases/tag/v1.0.3

- fix a leak happening when using an announcer in presenters and rebuilding the widget (something that may happen when manipulating layouts dynamically and in certain presenters that act as containers, like `SpNotebookPresenter`.
- some fixes in `SpCodePresenter` to enhance visibility of pool variables
- Common widgets extracted to its own package (Spec2-CommonWidgets)
- fixed a problem with the navigator and drag&drop
- improved delegation on ports (now we can delegate to other ports, not just to other presenters)

#NewTools 0.6.10
https://github.com/pharo-spec/NewTools/releases/tag/v0.6.10

- fixes to spotter performance
- remove remaining dependencies with GT
- improve inspector on halt on sensible methods
- make the inspector more robust by handling better the internal errors 
- some fixes on debugger bahavior
- add better inspections for compiled methods
- fixes on meta+g on playground
- fixes on visualization of variables while debugging