### PR TITLE
9955-add-comments-to-mcType-subclassDefiningSymbol-kindOfSubclass

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1151,7 +1151,8 @@ Behavior >> isWords [
 
 { #category : #'testing - class hierarchy' }
 Behavior >> kindOfSubclass [
-	"Answer a String that is the keyword that describes the receiver's kind of subclass"
+	"Answer a String that is the keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
 	^ self classLayout kindOfSubclass
 ]
 
@@ -1177,12 +1178,6 @@ Behavior >> lookupSelector: selector [
 				ifPresent: [ :method | ^ method ].
 			lookupClass := lookupClass superclass].
 	^ nil
-]
-
-{ #category : #accessing }
-Behavior >> mcType [
-	"Answer the symbol that Monticello uses internally to encode layouts"
-	^self classLayout class mcTypeSymbol
 ]
 
 { #category : #accessing }

--- a/src/Kernel/ByteLayout.class.st
+++ b/src/Kernel/ByteLayout.class.st
@@ -15,12 +15,10 @@ ByteLayout class >> extending: superLayout scope: aScope host: aClass [
 ]
 
 { #category : #description }
-ByteLayout class >> mcTypeSymbol [ 
-	^ #bytes
-]
-
-{ #category : #description }
 ByteLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
 	^#variableByteSubclass:
 ]
 

--- a/src/Kernel/CompiledMethodLayout.class.st
+++ b/src/Kernel/CompiledMethodLayout.class.st
@@ -18,13 +18,11 @@ CompiledMethodLayout class >> extending: superLayout scope: aScope host: aClass 
 ]
 
 { #category : #description }
-CompiledMethodLayout class >> mcTypeSymbol [ 
-	^ #compiledMethod 
-]
-
-{ #category : #description }
 CompiledMethodLayout class >> subclassDefiningSymbol [
-	"there is no way to define classes of this layoyt, the system shows them as variable classes"
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
+	"there is no way to define classes of this Layput, the system shows them as variable classes"
 	^#variableByteSubclass:
 ]
 

--- a/src/Kernel/DoubleByteLayout.class.st
+++ b/src/Kernel/DoubleByteLayout.class.st
@@ -16,6 +16,9 @@ DoubleByteLayout class >> extending: superLayout scope: aScope host: aClass [
 
 { #category : #description }
 DoubleByteLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
 	^#variableDoubleByteSubclass:
 ]
 

--- a/src/Kernel/DoubleWordLayout.class.st
+++ b/src/Kernel/DoubleWordLayout.class.st
@@ -16,6 +16,9 @@ DoubleWordLayout class >> extending: superLayout scope: aScope host: aClass [
 
 { #category : #description }
 DoubleWordLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
 	^#variableDoubleWordSubclass:
 ]
 

--- a/src/Kernel/EphemeronLayout.class.st
+++ b/src/Kernel/EphemeronLayout.class.st
@@ -16,12 +16,10 @@ EphemeronLayout class >> extending: superLayout scope: aScope host: aClass [
 ]
 
 { #category : #description }
-EphemeronLayout class >> mcTypeSymbol [ 
-	^ #ephemeron
-]
-
-{ #category : #description }
 EphemeronLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
 	^#ephemeronSubclass:
 ]
 

--- a/src/Kernel/FixedLayout.class.st
+++ b/src/Kernel/FixedLayout.class.st
@@ -17,11 +17,6 @@ FixedLayout class >> extending: superLayout scope: aScope host: aClass [
 		yourself
 ]
 
-{ #category : #description }
-FixedLayout class >> mcTypeSymbol [ 
-	^ #normal
-]
-
 { #category : #format }
 FixedLayout >> instanceSpecification [
 	^ self hasFields

--- a/src/Kernel/ImmediateLayout.class.st
+++ b/src/Kernel/ImmediateLayout.class.st
@@ -17,12 +17,10 @@ ImmediateLayout class >> extending: superLayout scope: aScope host: aClass [
 ]
 
 { #category : #description }
-ImmediateLayout class >> mcTypeSymbol [ 	
-	^ #immediate
-]
-
-{ #category : #description }
 ImmediateLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
 	^#immediateSubclass:
 ]
 

--- a/src/Kernel/ObjectLayout.class.st
+++ b/src/Kernel/ObjectLayout.class.st
@@ -25,14 +25,11 @@ ObjectLayout class >> layoutForType: typeSymbol [
 		ifNone: [ Error signal: 'Invalid layout type: ', typeSymbol asString ]
 ]
 
-{ #category : #monticello }
-ObjectLayout class >> mcTypeSymbol [
-	"return the symbol that Monticello uses to encode the layout"
-	^self name asSymbol
-]
-
 { #category : #description }
 ObjectLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
 	"As a fallback we just return a standard class creation symbol. This will be called for user 	
 	defined Layouts, for old style class definitions that can not support user defined Layouts"
 	^#subclass:
@@ -144,10 +141,16 @@ ObjectLayout >> instanceSpecification [
 
 { #category : #'testing - class hierarchy' }
 ObjectLayout >> kindOfSubclass [
+	"Answer a String that is the keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
 	^' ',self class subclassDefiningSymbol, ' '.
 ]
 
 { #category : #'testing - class hierarchy' }
 ObjectLayout >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else as CompiledMethodLayout answers the same as ByteLayout and user defined Layouts are not 
+	supported"
 	^self class subclassDefiningSymbol
 ]

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -215,13 +215,6 @@ UndefinedObject >> isNotNil [
 	^false
 ]
 
-{ #category : #'class hierarchy' }
-UndefinedObject >> mcType [
-	"Answer the symbol that Monticello uses internally to encode layouts"
-	"Implemented here  to support disjoint class hierarchies"
-	^#normal
-]
-
 { #category : #testing }
 UndefinedObject >> notNil [ 
 	"Refer to the comment in Object|notNil."

--- a/src/Kernel/VariableLayout.class.st
+++ b/src/Kernel/VariableLayout.class.st
@@ -18,12 +18,10 @@ VariableLayout class >> extending: superLayout scope: aScope host: aClass [
 ]
 
 { #category : #description }
-VariableLayout class >> mcTypeSymbol [ 
-	^ #variable
-]
-
-{ #category : #description }
 VariableLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
 	^#variableSubclass:
 ]
 

--- a/src/Kernel/WeakLayout.class.st
+++ b/src/Kernel/WeakLayout.class.st
@@ -20,12 +20,10 @@ WeakLayout class >> extending: superLayout scope: aScope host: aClass [
 ]
 
 { #category : #description }
-WeakLayout class >> mcTypeSymbol [ 
-	^ #weak
-]
-
-{ #category : #description }
 WeakLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
 	^#weakSubclass:
 ]
 

--- a/src/Kernel/WordLayout.class.st
+++ b/src/Kernel/WordLayout.class.st
@@ -15,12 +15,10 @@ WordLayout class >> extending: superLayout scope: aScope host: aClass [
 ]
 
 { #category : #description }
-WordLayout class >> mcTypeSymbol [ 
-	^ #words
-]
-
-{ #category : #description }
 WordLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
 	^#variableWordSubclass:
 ]
 

--- a/src/Monticello/Behavior.extension.st
+++ b/src/Monticello/Behavior.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Behavior }
+
+{ #category : #'*Monticello' }
+Behavior >> mcType [
+	"Answer the symbol that Monticello uses internally to encode layouts"
+	^self classLayout class mcTypeSymbol
+]

--- a/src/Monticello/ByteLayout.extension.st
+++ b/src/Monticello/ByteLayout.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #ByteLayout }
+
+{ #category : #'*Monticello' }
+ByteLayout class >> mcTypeSymbol [ 
+	^ #bytes
+]

--- a/src/Monticello/CompiledMethodLayout.extension.st
+++ b/src/Monticello/CompiledMethodLayout.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #CompiledMethodLayout }
+
+{ #category : #'*Monticello' }
+CompiledMethodLayout class >> mcTypeSymbol [ 
+	^ #compiledMethod 
+]

--- a/src/Monticello/EphemeronLayout.extension.st
+++ b/src/Monticello/EphemeronLayout.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #EphemeronLayout }
+
+{ #category : #'*Monticello' }
+EphemeronLayout class >> mcTypeSymbol [ 
+	^ #ephemeron
+]

--- a/src/Monticello/FixedLayout.extension.st
+++ b/src/Monticello/FixedLayout.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FixedLayout }
+
+{ #category : #'*Monticello' }
+FixedLayout class >> mcTypeSymbol [ 
+	^ #normal
+]

--- a/src/Monticello/ImmediateLayout.extension.st
+++ b/src/Monticello/ImmediateLayout.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #ImmediateLayout }
+
+{ #category : #'*Monticello' }
+ImmediateLayout class >> mcTypeSymbol [ 	
+	^ #immediate
+]

--- a/src/Monticello/ObjectLayout.extension.st
+++ b/src/Monticello/ObjectLayout.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #ObjectLayout }
+
+{ #category : #'*Monticello' }
+ObjectLayout class >> mcTypeSymbol [
+	"return the symbol that Monticello uses to encode the layout"
+	^self name asSymbol
+]

--- a/src/Monticello/UndefinedObject.extension.st
+++ b/src/Monticello/UndefinedObject.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #UndefinedObject }
+
+{ #category : #'*Monticello' }
+UndefinedObject >> mcType [
+	"Answer the symbol that Monticello uses internally to encode layouts"
+	"Implemented here  to support disjoint class hierarchies"
+	^#normal
+]

--- a/src/Monticello/VariableLayout.extension.st
+++ b/src/Monticello/VariableLayout.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #VariableLayout }
+
+{ #category : #'*Monticello' }
+VariableLayout class >> mcTypeSymbol [ 
+	^ #variable
+]

--- a/src/Monticello/WeakLayout.extension.st
+++ b/src/Monticello/WeakLayout.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #WeakLayout }
+
+{ #category : #'*Monticello' }
+WeakLayout class >> mcTypeSymbol [ 
+	^ #weak
+]

--- a/src/Monticello/WordLayout.extension.st
+++ b/src/Monticello/WordLayout.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #WordLayout }
+
+{ #category : #'*Monticello' }
+WordLayout class >> mcTypeSymbol [ 
+	^ #words
+]

--- a/src/Ring-Core/RGBehaviorStrategy.class.st
+++ b/src/Ring-Core/RGBehaviorStrategy.class.st
@@ -313,7 +313,8 @@ RGBehaviorStrategy >> isTraitStrategy [
 
 { #category : #'private - backend access' }
 RGBehaviorStrategy >> kindOfSubclass [
-
+	"Answer a String that is the keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
 	self incompatibleBehaviorType
 ]
 

--- a/src/Ring-Core/RGBehaviorStrategyUser.class.st
+++ b/src/Ring-Core/RGBehaviorStrategyUser.class.st
@@ -265,7 +265,8 @@ RGBehaviorStrategyUser >> isTrait [
 
 { #category : #'testing - class hierarchy' }
 RGBehaviorStrategyUser >> kindOfSubclass [
-
+	"Answer a String that is the keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
 	^ self behaviorStrategy kindOfSubclass
 ]
 

--- a/src/Ring-Core/RGClassDescriptionStrategy.class.st
+++ b/src/Ring-Core/RGClassDescriptionStrategy.class.st
@@ -101,10 +101,8 @@ RGClassDescriptionStrategy >> instanceVariablesString [
 
 { #category : #'testing - class hierarchy' }
 RGClassDescriptionStrategy >> kindOfSubclass [
-	"Answer a String that is the keyword that describes the receiver's kind of subclass,
-	 either a regular subclass, a variableSubclass, a variableByteSubclass,
-	 a variableWordSubclass, a weakSubclass, an ephemeronSubclass or an immediateSubclass.
-	 c.f. typeOfClass"
+	"Answer a String that is the keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
 	^self owner isVariable
 		ifTrue:
 			[self layout isBitsLayout

--- a/src/Ring-Core/RGTraitV2DescriptionStrategy.class.st
+++ b/src/Ring-Core/RGTraitV2DescriptionStrategy.class.st
@@ -107,10 +107,8 @@ RGTraitV2DescriptionStrategy >> isTrait [
 
 { #category : #'testing - class hierarchy' }
 RGTraitV2DescriptionStrategy >> kindOfSubclass [
-	"Answer a String that is the keyword that describes the receiver's kind of subclass,
-	 either a regular subclass, a variableSubclass, a variableByteSubclass,
-	 a variableWordSubclass, a weakSubclass, an ephemeronSubclass or an immediateSubclass.
-	 c.f. typeOfClass"
+	"Answer a String that is the keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
 	^self owner isVariable
 		ifTrue:
 			[self layout isBitsLayout


### PR DESCRIPTION
- move mcType and mcTypeSymbol to Monticello package
- add documentation to #kindOfSubclass and #subclassDefiningSymbol so it is not used for anything where it makes no sense

fixes #9955


