### PR TITLE
9565 pharo 9  seaside  process dying on cloud instance

### DIFF
--- a/src/UIManager/CommandLineUIManager.class.st
+++ b/src/UIManager/CommandLineUIManager.class.st
@@ -188,8 +188,13 @@ CommandLineUIManager >> exitFailure [
 
 { #category : #'handle debug requests' }
 CommandLineUIManager >> handleDebugRequest: aDebugRequest [
-	
-	self unhandledErrorDefaultAction: aDebugRequest exception
+
+	self
+		debugProcess: aDebugRequest process
+		context: aDebugRequest exception signalerContext
+		label: aDebugRequest exception description
+		fullView: false
+		notification: aDebugRequest exception description
 ]
 
 { #category : #'error handling' }


### PR DESCRIPTION
Fixes #9565 (see that issue for a detailed analysis) and #9919.

Basically we changed P9 to kill the image when an error occured in command line.
In P8, it handled the error without quitting, we fixed it so that it worked again.