### PR TITLE
do not re-parse in ReShouldSendSuperSetUpAsFirstMessage and ReShouldSendSuperTearDownAsLastMessage

### DIFF
--- a/src/SUnit-Rules/ReShouldSendSuperSetUpAsFirstMessage.class.st
+++ b/src/SUnit-Rules/ReShouldSendSuperSetUpAsFirstMessage.class.st
@@ -31,7 +31,7 @@ ReShouldSendSuperSetUpAsFirstMessage class >> superSetUpNotCalledFirstIn: aCompi
 			do: [ :node :answer | true ];
 		yourself.
 	^ (searcher
-		executeTree: aCompiledMethod parseTree
+		executeTree: aCompiledMethod ast
 		initialAnswer: false) not
 ]
 

--- a/src/SUnit-Rules/ReShouldSendSuperTearDownAsLastMessage.class.st
+++ b/src/SUnit-Rules/ReShouldSendSuperTearDownAsLastMessage.class.st
@@ -31,7 +31,7 @@ ReShouldSendSuperTearDownAsLastMessage class >> superTearDownNotCalledLastIn: aC
 			do: [ :node :answer | true ];
 		yourself.
 	^ (searcher
-		executeTree: aCompiledMethod parseTree
+		executeTree: aCompiledMethod ast
 		initialAnswer: false) not
 ]
 


### PR DESCRIPTION
Use the cached #ast instead of parseTree for two Critique Rules: ReShouldSendSuperSetUpAsFirstMessage and ReShouldSendSuperTearDownAsLastMessage

This reduces the need of re-compiling from source when e.g. browsing through classes.