### PR TITLE
9970-ReConsistencyCheckRule-is-a-very-bad-name 

### DIFF
--- a/src/GeneralRules/ReUseIsEmptyNotSizeRule.class.st
+++ b/src/GeneralRules/ReUseIsEmptyNotSizeRule.class.st
@@ -2,25 +2,25 @@
 Checks for code using equality tests instead of the message sends. Since the code ""aCollection size = 0"" works for all objects, it is more difficult for someone reading such code to determine that ""aCollection"" is a collection. Whereas, if you say ""aCollection isEmpty"" then aCollection must be a collection since isEmpty is only defined for collections.
 "
 Class {
-	#name : #ReConsistencyCheckRule,
+	#name : #ReUseIsEmptyNotSizeRule,
 	#superclass : #ReNodeMatchRule,
 	#category : #'GeneralRules-Migrated'
 }
 
 { #category : #accessing }
-ReConsistencyCheckRule class >> uniqueIdentifierName [
+ReUseIsEmptyNotSizeRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 	
 	^'ConsistencyCheckRule'
 ]
 
 { #category : #accessing }
-ReConsistencyCheckRule >> group [
+ReUseIsEmptyNotSizeRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
 { #category : #initialization }
-ReConsistencyCheckRule >> initialize [
+ReUseIsEmptyNotSizeRule >> initialize [
 	super initialize.
 	self  matchesAny: #(
 		'`@object size == 0'
@@ -31,6 +31,6 @@ ReConsistencyCheckRule >> initialize [
 ]
 
 { #category : #accessing }
-ReConsistencyCheckRule >> name [
+ReUseIsEmptyNotSizeRule >> name [
 	^ 'Checks for empty collection using #size instead of #isEmpty" or #isNotEmpty'
 ]


### PR DESCRIPTION
Change the name to ReUseIsEmptyNotSizeRule, we keep the uniqueIdentifierName as before so all bans e.g. are not affected

fixes #9970

