### PR TITLE
cleaning-up-workaround in copyTo: 

### DIFF
--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -502,7 +502,6 @@ Context >> copyTo: aContext [
 
 	| copy |
 	self == aContext ifTrue: [^ nil].
-	self pc. "this is a workaround, see https://github.com/pharo-project/pharo/issues/2949"
 	copy := self copy.
 	self sender ifNotNil: [
 		copy privSender: (self sender copyTo: aContext)].


### PR DESCRIPTION
Removing workaround that has been fixed in the VM