### PR TITLE
Fix #7634: Use "Smalltalk vm wordSize" to determine the version of the VM: 32 or 64

### DIFF
--- a/src/System-Platforms/Win32Platform.class.st
+++ b/src/System-Platforms/Win32Platform.class.st
@@ -17,7 +17,8 @@ Class {
 { #category : #testing }
 Win32Platform class >> isActivePlatform [
 	"Answer whether the receiver is the active platform"
-	^ Smalltalk vm operatingSystemName = 'Win32'
+	^ self currentPlatformName = 'Win32' and: [ 
+		  Smalltalk vm is32bit ]
 ]
 
 { #category : #visiting }

--- a/src/System-Platforms/Win64Platform.class.st
+++ b/src/System-Platforms/Win64Platform.class.st
@@ -17,7 +17,8 @@ Class {
 { #category : #testing }
 Win64Platform class >> isActivePlatform [
 	"Answer whether the receiver is the active platform"
-	^ Smalltalk vm operatingSystemName = 'Win64'
+	^ self currentPlatformName = 'Win32' and: [ 
+		  Smalltalk vm is64bit ]
 ]
 
 { #category : #visiting }

--- a/src/Tests/OSPlatformTest.class.st
+++ b/src/Tests/OSPlatformTest.class.st
@@ -11,6 +11,7 @@ OSPlatformTest >> testAPI [
 		isMacOS;
 		isMacOSX;
 		isWin32;
+		isWin64;
 		isWindows;
 		isUnix;
 		isLinux;


### PR DESCRIPTION
Redo https://github.com/pharo-project/pharo/pull/7634/files

Correctly ask if the vm is 32 or 64 bits and if we are in windows platform.

Fixes:
#6709
#2246
#5968