### PR TITLE
Redo #9845 -- Fix 9798: Deprecated class TextConverter is still used

### DIFF
--- a/src/Compression/CompiledMethodTrailer.extension.st
+++ b/src/Compression/CompiledMethodTrailer.extension.st
@@ -16,7 +16,7 @@ CompiledMethodTrailer >> decodeZip [
 	bytes := ByteArray new: len.
 	1 to: len do: [ :i |
 		bytes at: i put: (method at: method size - size + i) ].
-	data := (ZipReadStream on: bytes) contents asString convertFromEncoding: 'utf8'
+	data := (ZipReadStream on: bytes) contents utf8Decoded
 ]
 
 { #category : #'*Compression-Streams' }
@@ -34,7 +34,7 @@ CompiledMethodTrailer >> encodeUsingZip [
 	| utf8str stream length encodedLength |
 
 	[data isString] assert.
-	utf8str := data convertToEncoding: 'utf8'.
+	utf8str := data utf8Encoded.
 	
 	stream := ((ZipWriteStream on: (ByteArray new: utf8str size))
 		nextPutAll: utf8str asByteArray;

--- a/src/Deprecated90/String.extension.st
+++ b/src/Deprecated90/String.extension.st
@@ -2,7 +2,13 @@ Extension { #name : #String }
 
 { #category : #'*Deprecated90' }
 String >> convertFromEncoding: encodingName [
-	^self convertFromWithConverter: (TextConverter newForEncoding: encodingName)
+
+	self 
+        deprecated: 'Use #utf8Decoded or #decodeWith: encoding on a byte array. Using a string is not valid. You should have a byte array as input'
+        on: '2021-08-27'
+        in: #Pharo10.
+
+	^ self asByteArray decodeWith: encodingName
 ]
 
 { #category : #'*Deprecated90' }
@@ -22,7 +28,13 @@ String >> convertFromWithConverter: converter [
 
 { #category : #'*Deprecated90' }
 String >> convertToEncoding: encodingName [
-	^self convertToWithConverter: (TextConverter newForEncoding: encodingName).
+
+	self
+        deprecated: 'Use #utf8Encoded or #encodeWith: .'
+        on: '2021-08-27'
+        in: #Pharo10.
+
+	^ self encodeWith: encodingName
 ]
 
 { #category : #'*Deprecated90' }

--- a/src/Kernel/CompiledMethodTrailer.class.st
+++ b/src/Kernel/CompiledMethodTrailer.class.st
@@ -285,7 +285,7 @@ CompiledMethodTrailer >> decodeEmbeddedSourceQCompress [
 						ifFalse:
 							[strm nextPut: (charTable at: (nibble-12) * 16 + nextNibble value)]]]].
 			
-	data := str convertFromEncoding: 'utf8'
+	data := str asByteArray utf8Decoded
 ]
 
 { #category : #decoding }
@@ -610,7 +610,7 @@ CompiledMethodTrailer >> qCompress: string [
 
 	string isEmpty ifTrue:
 		[^self qCompress: ' '].
-	utf8str := string convertToEncoding: 'utf8'.
+	utf8str := string utf8Encoded.
 
 	stream := WriteStream on: (ByteArray new: utf8str size).
 	oddNibble := nil.

--- a/src/Monticello/MCMczWriter.class.st
+++ b/src/Monticello/MCMczWriter.class.st
@@ -37,7 +37,7 @@ MCMczWriter >> addString: string at: path [
 { #category : #writing }
 MCMczWriter >> addString: string at: path encodedTo: encodingName [
 	| member |
-	member := zip addString: (string convertToEncoding: encodingName) as: path.
+	member := zip addString: (string encodeWith: encodingName) as: path.
 	member desiredCompressionMethod: ZipArchive compressionDeflated 
 	
 ]

--- a/src/Monticello/MCVersionInfoWriter.class.st
+++ b/src/Monticello/MCVersionInfoWriter.class.st
@@ -25,7 +25,7 @@ MCVersionInfoWriter >> writeVersionInfo: aVersionInfo [
 	#(name message id date time author) do: [:sel | 
 		stream 
 			nextPutAll: sel; space;
-			print: (((aVersionInfo perform: sel) ifNil: ['']) asString convertToEncoding: 'latin-1' ); space ].
+			print: (((aVersionInfo perform: sel) ifNil: ['']) asString encodeWith: 'latin-1' ); space ].
 	stream nextPutAll: 'ancestors ('.
 	aVersionInfo ancestors do: [:ea | self writeVersionInfo: ea].
 	stream nextPutAll: ') stepChildren ('.

--- a/src/Network-MIME/String.extension.st
+++ b/src/Network-MIME/String.extension.st
@@ -49,7 +49,7 @@ String >> decodeMimeHeader [
 				"Delete spaces if followed by ="
 				input peek = $= ifFalse: [ input position: pos ]. 
 					
-				charsetStream :=  String new writeStream.
+				charsetStream := String new writeStream.
 				mimeDecoder := mimeEncoding = 'B' 
 					ifTrue: [ Base64MimeConverter new ]
 					ifFalse: [ RFC2047MimeConverter new ].
@@ -57,7 +57,7 @@ String >> decodeMimeHeader [
 					mimeStream: temp readStream;
 					dataStream: charsetStream;
 					mimeDecode.
-				output nextPutAll: (charsetStream contents convertFromEncoding: charset).
+				output nextPutAll: (charsetStream contents asByteArray decodeWith: charset).
 				]
 			ifFalse: 
 				[ output

--- a/src/Network-Tests/Base64MimeConverterTest.class.st
+++ b/src/Network-Tests/Base64MimeConverterTest.class.st
@@ -33,11 +33,11 @@ Base64MimeConverterTest >> testBase64Encoded [
 Base64MimeConverterTest >> testDecodeMimeHeader [
 	"Test MIME decoding from single-byte encoding to Unicode"
 
-	| mimeHeader expected characters |
-	characters := #[ 16rBE 16rFD 16r5F 16rE1 16r2E 16rC8 ] asString.
+	| mimeHeader expected bytes |
+	bytes := #[ 16rBE 16rFD 16r5F 16rE1 16r2E 16rC8 ].
 	mimeHeader := '=?ISO-8859-2?Q?=BE=FD=5F=E1=2E=C8?=' decodeMimeHeader.
 
-	expected := characters convertFromEncoding: 'ISO-8859-2'.
+	expected := bytes decodeWith: 'ISO-8859-2'.
 
 	self assert: mimeHeader equals: expected
 ]


### PR DESCRIPTION
Replace convertFromEncoding:/convertToEncoding: with decodeWith:/encodeWith:
Replace users and implementation so deprecated encoder classes can be removed

Fix #9845
Fix #9798