### PR TITLE
Deprecate #beginsWithEmpty:caseSensitive. Users should use beginsWith…

### DIFF
--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -577,20 +577,6 @@ StringTest >> testBeginsWithCaseSensitive [
 	self assert: (w1 beginsWith: w2 asUppercase caseSensitive: false).
 ]
 
-{ #category : #tests }
-StringTest >> testBeginsWithEmptyCaseSensitive [
-
-	self deny: ('éèàôüößäóñíá' beginsWithEmpty: 'ß' caseSensitive: true).
-	self assert: ('éèàôüößäóñíá' beginsWithEmpty: 'éèàô' caseSensitive: true).
-	self assert: ('éèàôüö' beginsWithEmpty: '' caseSensitive: true).
-	self deny: ('éèàôüö' beginsWithEmpty: 'ÉÈÀ' caseSensitive: true).
-	self assert: ('ÉÈÀÔÜÖ' beginsWithEmpty: 'ÉÈÀ' caseSensitive: true).
-	self assert: ('123test' beginsWithEmpty: '123' caseSensitive: true).
-	self should: ('aaee' beginsWithEmpty: 'AA' caseSensitive: false).
-	self should: ('???' beginsWithEmpty: '??' caseSensitive: false)
-	"self assert: ('ÉÈÀÔÜÖ' beginsWithEmpty: 'éèà' caseSensitive: false)."
-]
-
 { #category : #'tests - converting' }
 StringTest >> testCapitalized [
 	| uc lc empty |

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -820,23 +820,6 @@ String >> beginsWith: prefix caseSensitive: aBoolean [
 	^true
 ]
 
-{ #category : #testing }
-String >> beginsWithEmpty: prefix caseSensitive: aBoolean [ 
-	"Answer whether the receiver begins with the given prefix string. 
-	The comparison is case-sensitive." 
-	| matchTable |
-	prefix isEmpty ifTrue: [ ^ true ].
-	self size < prefix size ifTrue: [ ^ false ].
-	matchTable := aBoolean 
-		ifTrue: [ CaseSensitiveOrder ]
-		ifFalse: [ CaseInsensitiveOrder ].
-	^ (self 
-		findSubstring: prefix
-		in: self
-		startingAt: 1
-		matchTable: matchTable) = 1
-]
-
 { #category : #accessing }
 String >> byteAt: index [
 	^self subclassResponsibility

--- a/src/Deprecated10/String.extension.st
+++ b/src/Deprecated10/String.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #String }
+
+{ #category : #'*Deprecated10' }
+String >> beginsWithEmpty: prefix caseSensitive: aBoolean [ 
+	self 
+		deprecated:  'Please use #beginsWith:caseSensitive: and check for empty prefix explicitly' 
+		transformWith:  '`@receiver beginsWithEmpty: `@args1 caseSensitive: `@args2' 
+						-> ' `@args1 
+									ifEmpty: [ true ] 
+									ifNotEmpty: [ `@receiver beginsWith: `@args1 caseSensitive: `@args2 ]'.
+	^prefix 
+		ifEmpty: [ true ]
+		ifNotEmpty: [ self beginsWith: prefix caseSensitive: aBoolean ]
+]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -453,7 +453,7 @@ RPackageOrganizer >> hasPackageMatchingExtensionName: anExtensionName [
 		ifTrue: [ ^true ].
 		
 	packages keysDo: [ :aSymbol | 
-		(anExtensionName beginsWithEmpty: aSymbol asString, '-' caseSensitive: false)
+		(anExtensionName beginsWith: aSymbol asString, '-' caseSensitive: false)
 			ifTrue: [ ^ true]].
 	^ false
 	
@@ -660,7 +660,7 @@ RPackageOrganizer >> packageMatchingExtensionName: anExtensionName [
 	"if no package was found, we try to find one matching the begining of the name specified"
 	tmpPackageName := ''.
 	packages keysDo: [:aSymbol |
-		(anExtensionName beginsWithEmpty: (aSymbol asString, '-') caseSensitive: false)
+		(anExtensionName beginsWith: (aSymbol asString, '-') caseSensitive: false)
 			ifTrue: [
 				"we keep the longest package name found"
 				(aSymbol size > tmpPackageName size) 


### PR DESCRIPTION
It deprecates String method #beginsWithEmpty:caseSensitive. It was oddly named and it was inconsistent to a simple #beginsWith: analog in case of empty prefix.
Now users should use #beginsWith:caseSensitive and take care about empty prefix on their own side when needed.
The image users are adopted accordingly