### PR TITLE
Add test for ZnBufferedReadStream>>setToEnd

### DIFF
--- a/src/Zinc-Character-Encoding-Tests/ZnBufferedReadStreamTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnBufferedReadStreamTest.class.st
@@ -79,3 +79,22 @@ ZnBufferedReadStreamTest >> testReadUpToEnd [
 	self assert: stream upToEnd equals: '23456789'.
 	self assert: stream atEnd
 ]
+
+{ #category : #tests }
+ZnBufferedReadStreamTest >> testSetToEnd [
+	| stream source |
+	source := '0123456789'.
+	stream := ZnBufferedReadStream on: source readStream.
+	stream sizeBuffer: source size.
+	
+	"Call setToEnd on new stream"
+	self assert: stream position equals: 0.
+	stream setToEnd.
+	self assert: stream position equals: source size.
+
+	"Call setToEnd without after reading some elements"
+	stream position: 2.
+	self assert: (stream next: 4) equals: '2345'.
+	stream setToEnd.
+	self assert: stream position equals: source size.
+]


### PR DESCRIPTION
Fixes #10010 
Test is failing before #8658 

Wrote the test in Pharo9 because I cannot get Iceberg to work on Pharo10 win64 (using PharoLauncher)