### PR TITLE
9961-cleanup-and-support-CompiledMethodLayout-in-CDClassDefinitionParserhandleClassNamewithType 

### DIFF
--- a/src/ClassParser/CDClassDefinitionParser.class.st
+++ b/src/ClassParser/CDClassDefinitionParser.class.st
@@ -20,19 +20,16 @@ CDClassDefinitionParser class >> fromASTNode: aNode [
 
 { #category : #parsing }
 CDClassDefinitionParser >> handleClassName: aNode withType: aSymbol [
-	| layout |
-	
+	| layoutClass |
 	self handleClassName: aNode.
-	layout := FixedLayout.
-	aSymbol = #variableWordSubclass: ifTrue: [ layout := WordLayout ].
-	aSymbol = #ephemeronSubclass: ifTrue: [ layout := EphemeronLayout ].
-	aSymbol = #weakSubclass: ifTrue: [ layout := WeakLayout ].
-	aSymbol = #variableByteSubclass: ifTrue: [ layout := ByteLayout  ].
-	aSymbol = #variableSubclass: ifTrue: [ layout := VariableLayout ].
-	aSymbol = #immediateSubclass: ifTrue: [ layout := ImmediateLayout ].
-	aSymbol = #subclass: ifTrue: [ layout := FixedLayout ].
+	layoutClass := ObjectLayout layoutForSubclassDefiningSymbol: aSymbol.
 	
-	classDefinition layoutClass: layout
+	"if we get back CompiledMethodLayout or ByteLayout, we need to check the class name"
+	(layoutClass = CompiledMethodLayout or: [ layoutClass = ByteLayout ]) ifTrue: [ 
+		layoutClass := (classDefinition className = 'CompiledMethod') 
+					ifTrue:  [  CompiledMethodLayout ]
+					ifFalse: [  ByteLayout ]].
+	classDefinition layoutClass: (layoutClass)
 ]
 
 { #category : #parsing }

--- a/src/Kernel-Tests/ObjectLayoutTest.class.st
+++ b/src/Kernel-Tests/ObjectLayoutTest.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #ObjectLayoutTest,
+	#superclass : #TestCase,
+	#category : #'Kernel-Tests-Classes'
+}
+
+{ #category : #tests }
+ObjectLayoutTest >> testLayoutForSubclassDefiningSymbol [
+
+	self assert: (ObjectLayout layoutForSubclassDefiningSymbol: #variableWordSubclass:) equals: WordLayout.
+	self assert: (ObjectLayout layoutForSubclassDefiningSymbol: #ephemeronSubclass:) equals: EphemeronLayout.
+	self assert: (ObjectLayout layoutForSubclassDefiningSymbol: #weakSubclass:) equals: WeakLayout.
+	self assert: (ObjectLayout layoutForSubclassDefiningSymbol: #variableSubclass: ) equals: VariableLayout.
+	self assert: (ObjectLayout layoutForSubclassDefiningSymbol: #immediateSubclass: ) equals: ImmediateLayout.
+	self assert: (ObjectLayout layoutForSubclassDefiningSymbol: #subclass: ) equals: FixedLayout.
+	"here we can get back ByteLayout or CompiledMethodLayout, clients have to take that into account and check the class name"
+	self assert: ({ByteLayout. CompiledMethodLayout} includes: (ObjectLayout layoutForSubclassDefiningSymbol: #variableByteSubclass:))
+]

--- a/src/Kernel/ObjectLayout.class.st
+++ b/src/Kernel/ObjectLayout.class.st
@@ -18,6 +18,14 @@ ObjectLayout class >> isAbstract [
 ]
 
 { #category : #monticello }
+ObjectLayout class >> layoutForSubclassDefiningSymbol: aSymbol [
+	"used to get the layout for a subclass definition symbol"
+	^self allSubclasses 
+		detect: [ :class | class isAbstract not and: [class subclassDefiningSymbol == aSymbol ]] 
+		ifNone: [ FixedLayout ]
+]
+
+{ #category : #monticello }
 ObjectLayout class >> layoutForType: typeSymbol [
 	"used to get the layout for a Monticello internal layout symbol"
 	^self allSubclasses 


### PR DESCRIPTION
- add #layoutForSubclassDefiningSymbol:
- add testLayoutForSubclassDefiningSymbol
- use it in classParser

This way, the class parser now supports parsing the old-style class definition for CompiledMethod and the Double* layouts.

fixes #9961


