### PR TITLE
 Fix #10026: Cannot use Iceberg - Pharo 10 Windows 64bits FFI

### DIFF
--- a/src/System-OSEnvironments/Win32Environment.class.st
+++ b/src/System-OSEnvironments/Win32Environment.class.st
@@ -20,7 +20,7 @@ Class {
 
 { #category : #testing }
 Win32Environment class >> isDefaultFor: aPlatform [ 
-	^ aPlatform isWin32
+	^ aPlatform isWindows
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fix #10026 

Adapt platform recognition for Windows 64 bits.