### PR TITLE
P9 backport - Fix #10029 - ProfStef P9/10 updates

### DIFF
--- a/src/ProfStef-Core/LessonView.class.st
+++ b/src/ProfStef-Core/LessonView.class.st
@@ -36,6 +36,14 @@ LessonView class >> menuOn: aBuilder [
 
 ]
 
+{ #category : #accessing }
+LessonView >> bindings [
+
+	"dynamic variable binding not needed for Lessons"
+
+	^ Dictionary new
+]
+
 { #category : #gui }
 LessonView >> buildText [
 	| scrolledText |
@@ -75,6 +83,7 @@ LessonView >> initialize [
 	window := self buildWindow.
 	shoutMorph := self buildText.
 	window addMorph: shoutMorph frame: (0 @ 0 corner: 1 @ 1).
+	window extent: 600 @ 450.
 ]
 
 { #category : #testing }

--- a/src/ProfStef-Core/PharoSyntaxTutorial.class.st
+++ b/src/ProfStef-Core/PharoSyntaxTutorial.class.st
@@ -160,7 +160,7 @@ Blocks are anonymous methods that can be stored into variables and executed on d
 
 Blocks are delimited by square brackets: []"
 
-[GTPlayground open].
+[StPlayground open].
 
 "does not open a Browser because the block is not executed.
 
@@ -172,7 +172,7 @@ Here is a block that adds 2 to its argument (its argument is named x):"
 
 [:x | x+2] value: 5.
 
-[GTPlayground open] value.
+[StPlayground open] value.
 
 [:x | x+2] value: 10.
 
@@ -257,12 +257,11 @@ lesson:
 Note you can run this tutorial again by evaluating: ''ProfStef go''. 
 ''ProfStef previous'' returns to the previous lesson.
 
-You can also Do it using the keyboard shortcut ''Ctrl + D''
-(this varies according to your operating system/computer: it can be ''Cmd + D'' or ''Alt + D''). 
+You can also Do it using the keyboard shortcut ''Ctrl + D'' (or ''Cmd + D'' on MacOS). 
 
 Try to evaluate these expressions:"
 
-GTPlayground open.
+StPlayground open.
 
 SmalltalkImage current aboutThisSystem.
 
@@ -283,9 +282,9 @@ For example, select the text below, open the menu and click on ''Inspect it'':"
 
 1 / 2.
 
-"You''ve seen the keyboard keys next to the ''Inspect it''? It indicates the Ctrl- (or Cmd- or Alt-) shortcut to execute this command.
+"You''ve seen the keyboard keys next to the ''Inspect it''? It indicates the Ctrl- (or Cmd-) shortcut to execute this command.
 
-Try ''Ctrl + I'' (or ''Cmd + I'' or ''Alt + I'') on the following expressions:"
+Try ''Ctrl + I'' (or ''Cmd + I'') on the following expressions:"
 
 DateAndTime today.
 
@@ -615,9 +614,9 @@ For example, select the text below, open the menu and click on ''Print it'':"
 
 1 + 2.
 
-"You''ve seen the keyboard keys next to the ''Print it''? It indicates the Ctrl- (or Cmd- or Alt-) shortcut to execute this command.
+"You''ve seen the keyboard keys next to the ''Print it''? It indicates the Ctrl- (or Cmd-) shortcut to execute this command.
 
-Try ''Ctrl + P'' (or ''Cmd + P'' or ''Alt + P'') on the following expressions:"
+Try ''Ctrl + P'' (or ''Cmd + P'') on the following expressions:"
 
 Date today.
 
@@ -639,7 +638,7 @@ lesson:
 
 Take a look at method #ifFalse:ifTrue: source code of class True:"
 
-(True>>#ifFalse:ifTrue:) definition.
+(True>>#ifFalse:ifTrue:) sourceCode.
 
 "Or just its comment:"
 

--- a/src/ProfStef-Core/ProfStef.class.st
+++ b/src/ProfStef-Core/ProfStef.class.st
@@ -117,12 +117,6 @@ ProfStef class >> goOn: aTutorialClass [
 ]
 
 { #category : #navigating }
-ProfStef class >> goToNextLesson [
-
-  self next
-]
-
-{ #category : #navigating }
 ProfStef class >> last [
 
 	^ self default last


### PR DESCRIPTION
Fixes #10029. Pharo 9 backport of #10030.

ProfStef tutorial contains multiple uses of deprecated or already removed classes and methods (GTPlayground, CompiledCode>>#definition) in Pharo 9 and 10. There are also errors showing up when code is being written into ProfStef windows (that is required in multiple lessons) and multiple minor issues like window being very small by default or mentions of alt- meta modifier that is no longer used on any platform.