### PR TITLE
10021 - Fixing the export of Monticello.

### DIFF
--- a/src/Deprecated90/String.extension.st
+++ b/src/Deprecated90/String.extension.st
@@ -30,11 +30,11 @@ String >> convertFromWithConverter: converter [
 String >> convertToEncoding: encodingName [
 
 	self
-        deprecated: 'Use #utf8Encoded or #encodeWith: .'
+        deprecated: 'Use #utf8Encoded or #encodeWith:. Pay attention the new API returns byteArray instead of Strings. Do not use Strings to represent encoded Strings, they should be ByteArrays'
         on: '2021-08-27'
         in: #Pharo10.
 
-	^ self encodeWith: encodingName
+	^ (self encodeWith: encodingName) asString
 ]
 
 { #category : #'*Deprecated90' }

--- a/src/Monticello/MCVersionInfoWriter.class.st
+++ b/src/Monticello/MCVersionInfoWriter.class.st
@@ -25,7 +25,7 @@ MCVersionInfoWriter >> writeVersionInfo: aVersionInfo [
 	#(name message id date time author) do: [:sel | 
 		stream 
 			nextPutAll: sel; space;
-			print: (((aVersionInfo perform: sel) ifNil: ['']) asString encodeWith: 'latin-1' ); space ].
+			print: (((aVersionInfo perform: sel) ifNil: ['']) asString encodeWith: 'latin-1' ) asString; space ].
 	stream nextPutAll: 'ancestors ('.
 	aVersionInfo ancestors do: [:ea | self writeVersionInfo: ea].
 	stream nextPutAll: ') stepChildren ('.


### PR DESCRIPTION
The problem is that is using strings and saving them to the zip file.
Keeping that behavior, because if not we are not able to generate valid MCZ files.
Also, this code has a ticket to go away.