### PR TITLE
9971 cleanup ring deprecate the meta class the non meta class base class 

### DIFF
--- a/src/Ring-Core/RGBehaviorStrategy.class.st
+++ b/src/Ring-Core/RGBehaviorStrategy.class.st
@@ -412,14 +412,24 @@ RGBehaviorStrategy >> storeName [
 
 { #category : #'accessing - deprecated parallel hierarchy' }
 RGBehaviorStrategy >> theMetaClass [
-
-	^ self owner
+	"This method is deprecated so consider to migrate."
+	
+	self
+		deprecated: 'Please use #classSide instead'
+		transformWith: '`@receiver theMetaClass' -> '`@receiver classSide'.
+	
+	^ self classSide
 ]
 
 { #category : #'accessing - deprecated parallel hierarchy' }
 RGBehaviorStrategy >> theNonMetaClass [
-
-	^ self owner
+	"This method is deprecated so consider to migrate."
+	
+	self
+		deprecated: 'Please use #instanceSide instead'
+		transformWith: '`@receiver theNonMetaClass' -> '`@receiver instanceSide'.
+	
+	^ self instanceSide
 ]
 
 { #category : #variables }

--- a/src/Ring-Core/RGBehaviorStrategy.class.st
+++ b/src/Ring-Core/RGBehaviorStrategy.class.st
@@ -309,7 +309,22 @@ RGBehaviorStrategy >> isTraitStrategy [
 RGBehaviorStrategy >> kindOfSubclass [
 	"Answer a String that is the keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
-	self incompatibleBehaviorType
+	
+	^ ' ', self layout class subclassDefiningSymbol, ' '
+]
+
+{ #category : #accessing }
+RGBehaviorStrategy >> layout [
+
+	^ self backend forBehavior layoutFor: self owner
+]
+
+{ #category : #accessing }
+RGBehaviorStrategy >> layout: anRGLayout [
+
+	self owner announceDefinitionChangeDuring: [ 
+		self backend forBehavior setLayoutFor: self owner to: anRGLayout ].
+
 ]
 
 { #category : #'private - backend access' }

--- a/src/Ring-Core/RGBehaviorStrategyUser.class.st
+++ b/src/Ring-Core/RGBehaviorStrategyUser.class.st
@@ -365,8 +365,13 @@ RGBehaviorStrategyUser >> storeOn: aStream [
 
 { #category : #accessing }
 RGBehaviorStrategyUser >> theMetaClass [
-
-	^ self behaviorStrategy theMetaClass
+	"This method is deprecated so consider to migrate."
+	
+	self
+		deprecated: 'Please use #classSide instead'
+		transformWith: '`@receiver theMetaClass' -> '`@receiver classSide'.
+	
+	^ self classSide
 ]
 
 { #category : #accessing }

--- a/src/Ring-Core/RGBitsLayout.class.st
+++ b/src/Ring-Core/RGBitsLayout.class.st
@@ -4,6 +4,14 @@ Class {
 	#category : #'Ring-Core-Kernel'
 }
 
+{ #category : #description }
+RGBitsLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton."
+	
+	^ #variableWordSubclass:
+]
+
 { #category : #'testing - types' }
 RGBitsLayout >> isBitsLayout [
 

--- a/src/Ring-Core/RGByteLayout.class.st
+++ b/src/Ring-Core/RGByteLayout.class.st
@@ -4,6 +4,14 @@ Class {
 	#category : #'Ring-Core-Kernel'
 }
 
+{ #category : #description }
+RGByteLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton."
+	
+	^ #variableByteSubclass:
+]
+
 { #category : #'testing - types' }
 RGByteLayout >> isByteLayout [
 

--- a/src/Ring-Core/RGClassDescriptionStrategy.class.st
+++ b/src/Ring-Core/RGClassDescriptionStrategy.class.st
@@ -99,44 +99,6 @@ RGClassDescriptionStrategy >> instanceVariablesString [
 			separatedBy: [ stream space ] ]
 ]
 
-{ #category : #'testing - class hierarchy' }
-RGClassDescriptionStrategy >> kindOfSubclass [
-	"Answer a String that is the keyword that describes the receiver's kind of subclass
-	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
-	^self owner isVariable
-		ifTrue:
-			[self layout isBitsLayout
-				ifTrue:
-					[self layout isByteLayout
-						ifTrue: [' variableByteSubclass: ']
-						ifFalse: [' variableWordSubclass: ']]
-				ifFalse:
-					[self layout isWeakLayout
-						ifTrue: [' weakSubclass: ']
-						ifFalse: [' variableSubclass: ']]]
-		ifFalse:
-			[self layout isImmediateLayout 
-				ifTrue: [' immediateSubclass: ']
-				ifFalse:
-					[self layout isEphemeronLayout 
-						ifTrue: [' ephemeronSubclass: ']
-						ifFalse: [' subclass: ']]]
-]
-
-{ #category : #'accessing - backend' }
-RGClassDescriptionStrategy >> layout [
-
-	^ self backend forBehavior layoutFor: self owner
-]
-
-{ #category : #'accessing - backend' }
-RGClassDescriptionStrategy >> layout: anRGLayout [
-
-	self owner announceDefinitionChangeDuring: [ 
-		self backend forBehavior setLayoutFor: self owner to: anRGLayout ].
-
-]
-
 { #category : #'private - backend interface' }
 RGClassDescriptionStrategy >> makeResolved [
 

--- a/src/Ring-Core/RGClassStrategy.class.st
+++ b/src/Ring-Core/RGClassStrategy.class.st
@@ -595,9 +595,3 @@ RGClassStrategy >> storeName [
 
 	^ 'RGClass'
 ]
-
-{ #category : #'accessing - deprecated parallel hierarchy' }
-RGClassStrategy >> theMetaClass [
-
-	^ self owner metaclass
-]

--- a/src/Ring-Core/RGEphemeronLayout.class.st
+++ b/src/Ring-Core/RGEphemeronLayout.class.st
@@ -4,6 +4,14 @@ Class {
 	#category : #'Ring-Core-Kernel'
 }
 
+{ #category : #description }
+RGEphemeronLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton."
+	
+	^ #ephemeronSubclass:
+]
+
 { #category : #'testing - types' }
 RGEphemeronLayout >> isEphemeronLayout [
 

--- a/src/Ring-Core/RGImmediateLayout.class.st
+++ b/src/Ring-Core/RGImmediateLayout.class.st
@@ -4,6 +4,14 @@ Class {
 	#category : #'Ring-Core-Kernel'
 }
 
+{ #category : #description }
+RGImmediateLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton."
+	
+	^ #immediateSubclass:
+]
+
 { #category : #'testing - types' }
 RGImmediateLayout >> isImmediateLayout [
 

--- a/src/Ring-Core/RGLayout.class.st
+++ b/src/Ring-Core/RGLayout.class.st
@@ -4,6 +4,14 @@ Class {
 	#category : #'Ring-Core-Kernel'
 }
 
+{ #category : #description }
+RGLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton."
+	
+	^ #subclass:
+]
+
 { #category : #'managing container' }
 RGLayout >> addoptToParentStub [
 

--- a/src/Ring-Core/RGMetaclassStrategy.class.st
+++ b/src/Ring-Core/RGMetaclassStrategy.class.st
@@ -221,8 +221,3 @@ RGMetaclassStrategy >> storeName [
 
 	^ 'RGMetaclass'
 ]
-
-{ #category : #'private - backend access' }
-RGMetaclassStrategy >> theNonMetaClass [
-	^self baseClass
-]

--- a/src/Ring-Core/RGMetaclassTraitStrategy.class.st
+++ b/src/Ring-Core/RGMetaclassTraitStrategy.class.st
@@ -141,11 +141,6 @@ RGMetaclassTraitStrategy >> storeName [
 ]
 
 { #category : #'private - backend access' }
-RGMetaclassTraitStrategy >> theNonMetaClass [
-	^self baseTrait
-]
-
-{ #category : #'private - backend access' }
 RGMetaclassTraitStrategy >> traitTransformationString [		
 		
 	^ self owner name 

--- a/src/Ring-Core/RGMetaclassTraitV2Strategy.class.st
+++ b/src/Ring-Core/RGMetaclassTraitV2Strategy.class.st
@@ -200,8 +200,3 @@ RGMetaclassTraitV2Strategy >> storeName [
 
 	^ 'RGMetaclass'
 ]
-
-{ #category : #'private - backend access' }
-RGMetaclassTraitV2Strategy >> theNonMetaClass [
-	^self baseClass
-]

--- a/src/Ring-Core/RGTraitDescriptionStrategy.class.st
+++ b/src/Ring-Core/RGTraitDescriptionStrategy.class.st
@@ -31,6 +31,18 @@ RGTraitDescriptionStrategy >> isTrait [
 	^true
 ]
 
+{ #category : #accessing }
+RGTraitDescriptionStrategy >> layout [
+
+	self incompatibleBehaviorType
+]
+
+{ #category : #accessing }
+RGTraitDescriptionStrategy >> layout: anRGLayout [
+
+	self incompatibleBehaviorType
+]
+
 { #category : #variables }
 RGTraitDescriptionStrategy >> methods [
 

--- a/src/Ring-Core/RGTraitStrategy.class.st
+++ b/src/Ring-Core/RGTraitStrategy.class.st
@@ -269,11 +269,6 @@ RGTraitStrategy >> storeName [
 ]
 
 { #category : #accessing }
-RGTraitStrategy >> theMetaClass [
-	^ self classTrait
-]
-
-{ #category : #accessing }
 RGTraitStrategy >> traitTransformationString [
 
 	^ self owner name

--- a/src/Ring-Core/RGTraitV2DescriptionStrategy.class.st
+++ b/src/Ring-Core/RGTraitV2DescriptionStrategy.class.st
@@ -105,44 +105,6 @@ RGTraitV2DescriptionStrategy >> isTrait [
 	^true
 ]
 
-{ #category : #'testing - class hierarchy' }
-RGTraitV2DescriptionStrategy >> kindOfSubclass [
-	"Answer a String that is the keyword that describes the receiver's kind of subclass
-	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
-	^self owner isVariable
-		ifTrue:
-			[self layout isBitsLayout
-				ifTrue:
-					[self layout isByteLayout
-						ifTrue: [' variableByteSubclass: ']
-						ifFalse: [' variableWordSubclass: ']]
-				ifFalse:
-					[self layout isWeakLayout
-						ifTrue: [' weakSubclass: ']
-						ifFalse: [' variableSubclass: ']]]
-		ifFalse:
-			[self layout isImmediateLayout 
-				ifTrue: [' immediateSubclass: ']
-				ifFalse:
-					[self layout isEphemeronLayout 
-						ifTrue: [' ephemeronSubclass: ']
-						ifFalse: [' subclass: ']]]
-]
-
-{ #category : #'accessing - backend' }
-RGTraitV2DescriptionStrategy >> layout [
-
-	^ self backend forBehavior layoutFor: self owner
-]
-
-{ #category : #'accessing - backend' }
-RGTraitV2DescriptionStrategy >> layout: anRGLayout [
-
-	self owner announceDefinitionChangeDuring: [ 
-		self backend forBehavior setLayoutFor: self owner to: anRGLayout ].
-
-]
-
 { #category : #'private - backend interface' }
 RGTraitV2DescriptionStrategy >> makeResolved [
 

--- a/src/Ring-Core/RGTraitV2Strategy.class.st
+++ b/src/Ring-Core/RGTraitV2Strategy.class.st
@@ -578,9 +578,3 @@ RGTraitV2Strategy >> storeName [
 
 	^ 'RGClass'
 ]
-
-{ #category : #'accessing - deprecated parallel hierarchy' }
-RGTraitV2Strategy >> theMetaClass [
-
-	^ self owner metaclass
-]

--- a/src/Ring-Core/RGVariableLayout.class.st
+++ b/src/Ring-Core/RGVariableLayout.class.st
@@ -4,6 +4,14 @@ Class {
 	#category : #'Ring-Core-Kernel'
 }
 
+{ #category : #description }
+RGVariableLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton."
+	
+	^ #variableSubclass:
+]
+
 { #category : #'testing - types' }
 RGVariableLayout >> isVariableLayout [
 

--- a/src/Ring-Core/RGWeakLayout.class.st
+++ b/src/Ring-Core/RGWeakLayout.class.st
@@ -4,6 +4,14 @@ Class {
 	#category : #'Ring-Core-Kernel'
 }
 
+{ #category : #description }
+RGWeakLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton."
+	
+	^ #weakSubclass:
+]
+
 { #category : #'testing - types' }
 RGWeakLayout >> isVariableLayout [
 

--- a/src/Ring-Definitions-Core/RGBehaviorDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGBehaviorDefinition.class.st
@@ -521,14 +521,24 @@ RGBehaviorDefinition >> superclassName: aSymbol [
 
 { #category : #'accessing - deprecated parallel hierarchy' }
 RGBehaviorDefinition >> theMetaClass [
-
-	self subclassResponsibility
+	"This method is deprecated so consider to migrate."
+	
+	self
+		deprecated: 'Please use #classSide instead'
+		transformWith: '`@receiver theMetaClass' -> '`@receiver classSide'.
+		
+	^ self classSide
 ]
 
 { #category : #'accessing - deprecated parallel hierarchy' }
 RGBehaviorDefinition >> theNonMetaClass [
-
-	self subclassResponsibility
+	"This method is deprecated so consider to migrate."
+	
+	self
+		deprecated: 'Please use #instanceSide instead'
+		transformWith: '`@receiver theNonMetaClass' -> '`@receiver instanceSide'.
+	
+	^ self instanceSide
 ]
 
 { #category : #annotations }

--- a/src/Ring-Definitions-Core/RGClassDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGClassDefinition.class.st
@@ -341,18 +341,6 @@ RGClassDefinition >> stamp: aString [
 						 stamp: aString ]
 ]
 
-{ #category : #'accessing - deprecated parallel hierarchy ' }
-RGClassDefinition >> theMetaClass [
-	
-	^metaClass
-]
-
-{ #category : #'accessing - deprecated parallel hierarchy ' }
-RGClassDefinition >> theNonMetaClass [
-
-	^self
-]
-
 { #category : #'managing pool users' }
 RGClassDefinition >> users [
 	"If the reciever is a SharedPool then retrieves its users"

--- a/src/Ring-Definitions-Core/RGMetaclassDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGMetaclassDefinition.class.st
@@ -103,15 +103,3 @@ RGMetaclassDefinition >> storeOn: aStream [
 	
 
 ]
-
-{ #category : #'accessing - deprecated parallel hierarchy' }
-RGMetaclassDefinition >> theMetaClass [
-
-	^self
-]
-
-{ #category : #'accessing - deprecated parallel hierarchy' }
-RGMetaclassDefinition >> theNonMetaClass [
-
-	^baseClass
-]

--- a/src/Ring-Definitions-Core/RGMetatraitDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGMetatraitDefinition.class.st
@@ -73,15 +73,3 @@ RGMetatraitDefinition >> realClass [
 
 	^baseClass realClass classSide
 ]
-
-{ #category : #'accessing - deprecated parallel hierarchy' }
-RGMetatraitDefinition >> theMetaClass [
-
-	^self
-]
-
-{ #category : #'accessing - deprecated parallel hierarchy' }
-RGMetatraitDefinition >> theNonMetaClass [
-
-	^baseClass
-]

--- a/src/Ring-Definitions-Core/RGTraitDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGTraitDefinition.class.st
@@ -142,18 +142,6 @@ RGTraitDefinition >> stamp: aString [
 						 stamp: aString ]
 ]
 
-{ #category : #'accessing - deprecated parallel hierarchy' }
-RGTraitDefinition >> theMetaClass [
-
-	^metaClass
-]
-
-{ #category : #'accessing - deprecated parallel hierarchy' }
-RGTraitDefinition >> theNonMetaClass [
-
-	^self
-]
-
 { #category : #behavior }
 RGTraitDefinition >> withMetaclass [
 	"Registers explicitly the metaclass of a trait"


### PR DESCRIPTION
Fixed #9971. Deprecated #theMetaClass and #theNonMetaClass in Ring in favor of #classSide and #instanceSide. #baseClass also needs to be deprecated and rewritten with #instanceSide but I did not understand if it is safe or not