### PR TITLE
9947-SycSourceCodeRefactoringCommand-is-shown-in-menu 

### DIFF
--- a/src/Commander-Core/CmdCommand.class.st
+++ b/src/Commander-Core/CmdCommand.class.st
@@ -99,7 +99,8 @@ Class {
 
 { #category : #testing }
 CmdCommand class >> canBeExecutedInContext: aToolContext [
-	^true
+
+	^ self isAbstract not
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
fixes #9947 by adding the abstract check

In another pass, we could now check all overrides of canBeExecutedInContext: and remove the isAbtract check there and do a super call instead (which they often already do)


