### PR TITLE
p9 duplicate new tools world menu items (Edit: this is a wrong PR)

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -40,8 +40,8 @@ BaselineOfPharo class >> newToolsVersion [
 BaselineOfPharo class >> specReleaseCommit [
 	"The commit corresponding to current release (to be used on bootstrap process)"
 
-	"v1.0.2"
-	^ '88cc5234fcbcc8a8cc8da085c5e23f74db1c349b'
+	"v1.0.3"
+	^ '093d57d83f1554b69ca019c21b1f955ec71f8f0d'
 ]
 
 { #category : #'repository urls' }
@@ -53,7 +53,7 @@ BaselineOfPharo class >> specRepository [
 { #category : #versions }
 BaselineOfPharo class >> specVersion [
 
-	^ 'v1.0.2'
+	^ 'v1.0.3'
 ]
 
 { #category : #baseline }

--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -20,8 +20,8 @@ BaselineOfPharo class >> icebergVersion [
 BaselineOfPharo class >> newToolsReleaseCommit [
 	"The commit corresponding to current release (to be used on bootstrap process)"
 
-	"v0.6.9"
-	^ '3f9dfd73609fa14254fedbab70c69842bfde8a76'
+	"v0.6.10"
+	^ '526c39f7511ecf24308b36d044ebb6647ffa226c'
 ]
 
 { #category : #'repository urls' }
@@ -33,7 +33,7 @@ BaselineOfPharo class >> newToolsRepository [
 { #category : #versions }
 BaselineOfPharo class >> newToolsVersion [
 
-	^ 'v0.6.9'
+	^ 'v0.6.10'
 ]
 
 { #category : #versions }

--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -21,7 +21,7 @@ BaselineOfPharo class >> newToolsReleaseCommit [
 	"The commit corresponding to current release (to be used on bootstrap process)"
 	
 	"v0.6.10"
-	^ '526c39f7511ecf24308b36d044ebb6647ffa226c'
+	^ '53f0f8ba1c81edd16b994bb80f8568e2693d5faf'
 ]
 
 { #category : #'repository urls' }

--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -19,7 +19,7 @@ BaselineOfPharo class >> icebergVersion [
 { #category : #versions }
 BaselineOfPharo class >> newToolsReleaseCommit [
 	"The commit corresponding to current release (to be used on bootstrap process)"
-
+	
 	"v0.6.10"
 	^ '526c39f7511ecf24308b36d044ebb6647ffa226c'
 ]
@@ -41,7 +41,7 @@ BaselineOfPharo class >> specReleaseCommit [
 	"The commit corresponding to current release (to be used on bootstrap process)"
 
 	"v1.0.3"
-	^ '093d57d83f1554b69ca019c21b1f955ec71f8f0d'
+	^ '64d914cd5c621f00b551306ee2fbd1e3540af6a1'
 ]
 
 { #category : #'repository urls' }

--- a/src/Collections-Abstract-Tests/TAsStringCommaAndDelimiterTest.trait.st
+++ b/src/Collections-Abstract-Tests/TAsStringCommaAndDelimiterTest.trait.st
@@ -95,18 +95,17 @@ TAsStringCommaAndDelimiterTest >> testAsStringOnDelimiterLastEmpty [
 { #category : #'tests - as string comma delimiter sequenceable' }
 TAsStringCommaAndDelimiterTest >> testAsStringOnDelimiterLastMore [
 
-	| delim multiItemStream result last allElementsAsString tmp |
+	| delim multiItemStream result last allElementsAsString |
 	
 	delim := ', '.
 	last := ' and '.
 	result:=''.
-	tmp := self nonEmpty collect: [:each | each asString].
 	multiItemStream := ReadWriteStream on:result.
-	self nonEmpty  asStringOn: multiItemStream delimiter: delim last: last.
+	self nonEmpty asStringOn: multiItemStream delimiter: delim last: last.
 	result := multiItemStream contents.
 	allElementsAsString:=(result findBetweenSubstrings: delim ).
-	tmp do:[:each |
-		self assert: (tmp occurrencesOf: each) = (allElementsAsString occurrencesOf: each)].
+	self nonEmpty do:[:each |
+		self assert: (self nonEmpty occurrencesOf: each) = (allElementsAsString occurrencesOf: each asString)].
 	self assert: ((allElementsAsString at: (allElementsAsString size - 1))=('and'))
 ]
 
@@ -131,19 +130,17 @@ TAsStringCommaAndDelimiterTest >> testAsStringOnDelimiterLastOne [
 { #category : #'tests - as string comma delimiter sequenceable' }
 TAsStringCommaAndDelimiterTest >> testAsStringOnDelimiterMore [
 
-	| delim multiItemStream result allElementsAsString tmp |
-	
-	
+	| delim multiItemStream result allElementsAsString |
+		
 	delim := ', '.
-	result:=''.
-	tmp:= self nonEmpty collect:[:each | each asString].
+	result:= ''.
 	multiItemStream := ReadWriteStream on:result.
-	self nonEmpty  asStringOn: multiItemStream delimiter: delim.
+	self nonEmpty asStringOn: multiItemStream delimiter: delim.
 	result := multiItemStream contents.
 	allElementsAsString := (result findBetweenSubstrings: delim ).
-	tmp do:
+	self nonEmpty do:
 		[:each |
-		self assert: (tmp occurrencesOf: each)=(allElementsAsString occurrencesOf: each).
+		self assert: (self nonEmpty occurrencesOf: each)=(allElementsAsString occurrencesOf: each asString).
 		].
 ]
 

--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -1780,6 +1780,34 @@ StringTest >> testRomanNumber [
 	self assert: '-MDCCCXCV' romanNumber equals: -1895.
 ]
 
+{ #category : #test }
+StringTest >> testSkipAnySubstringStartingAt [
+	
+	"Simple skip"
+	self assert: ('abcd' skipAnySubstring: #('a') startingAt: 1) equals: 2. 
+	"Test multiple substrings to skip"
+	self assert: ('abcd' skipAnySubstring: #('a' 'b' 'd') startingAt: 1) equals: 3.
+	"Test skip symbol"
+	self assert: ('abcd' skipAnySubstring: #(ab) startingAt: 1) equals: 3.
+	"Test string is full of substrings to skip"
+	self assert: ('abcd' skipAnySubstring: #('ab' 'cd') startingAt: 1) equals: 5. 
+	"Test first substring matches but second substring is larger than entire string"
+	self assert: ('abcd' skipAnySubstring: #('ab' 'abcdefg') startingAt: 1) equals: 3.
+	"Test first substring is larger than entire string, and second substring matches string"
+	self assert: ('abcd' skipAnySubstring: #('abcdefg' 'ab') startingAt: 1) equals: 3.
+	"Test string is empty, return length of string + 1"
+	self assert: ('' skipAnySubstring: #('ab') startingAt: 1) equals: 1.
+	"Test starting at index > 1"
+	self assert: ('abcde' skipAnySubstring: #('cd') startingAt: 3) equals: 5.
+	"Test substring appears multiple times in a row"
+	self assert: ('ababc' skipAnySubstring: #('ab') startingAt: 1) equals: 5.
+	"Test substring to skip is given directly as a string instead of in an array"
+	self assert: (',ab' skipAnySubstring: ',' startingAt: 1) equals: 2.
+	"Test how delimiters order can influence the result: substrings are skipped greedily with no backtracking."
+	self assert: ('abcdefg' skipAnySubstring: #('abcd' 'abc' 'def' 'g') startingAt: 1) equals: 5.
+	self assert: ('abcdefg' skipAnySubstring: #('abc' 'def' 'g' 'abcd') startingAt: 1) equals: 8.
+]
+
 { #category : #'tests - instance creation' }
 StringTest >> testSpace [
 		

--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -1260,24 +1260,6 @@ StringTest >> testFormatFailures [
 
 ]
 
-{ #category : #test }
-StringTest >> testHasSubstringAt [
-
-	"Test empty strings"
-	self assert: ('' hasSubstring: '' at: 1).
-	self assert: ('test' hasSubstring: '' at: 1).
-	self deny: ('' hasSubstring: 'test' at: 1).
-	"Test out of bounds indexes"
-	self deny: ('test' hasSubstring: 't' at: 0).
-	self deny: ('test' hasSubstring: 't' at: 10).
-	"Test matching substring"
-	self assert: ('test' hasSubstring: 'st' at: 3).
-	"Test partially matching substring"
-	self deny: ('test' hasSubstring: 'sty' at: 3).
-	
-	
-]
-
 { #category : #tests }
 StringTest >> testHasWideCharacterFromTo [
 
@@ -1300,10 +1282,29 @@ StringTest >> testIncludesSubstring [
 
 	self assert: ('testing this string' includesSubstring: 'ring'). 
 	self assert: ('éèàôüößäóñíá' includesSubstring: '').
+	self assert: ('' includesSubstring: '').
 	self deny: ('éèàôüößäóñíá' includesSubstring: 'a'). 
 	self assert: ('éèàôüößäóñíá' includesSubstring: 'ßä').
 	self deny: ('kjdsnlksjdf' includesSubstring: 'K') 
 
+]
+
+{ #category : #test }
+StringTest >> testIncludesSubstringAt [
+
+	"Test empty strings"
+	self assert: ('' includesSubstring: '' at: 1).
+	self assert: ('test' includesSubstring: '' at: 1).
+	self deny: ('' includesSubstring: 'test' at: 1).
+	"Test out of bounds indexes"
+	self deny: ('test' includesSubstring: 't' at: 0).
+	self deny: ('test' includesSubstring: 't' at: 10).
+	"Test matching substring"
+	self assert: ('test' includesSubstring: 'st' at: 3).
+	"Test partially matching substring"
+	self deny: ('test' includesSubstring: 'sty' at: 3).
+	
+	
 ]
 
 { #category : #tests }
@@ -1819,9 +1820,9 @@ StringTest >> testSkipAnySubstringStartingAt [
 	self assert: ('abcde' skipAnySubstring: #('cd') startingAt: 3) equals: 5.
 	"Test substring appears multiple times in a row"
 	self assert: ('ababc' skipAnySubstring: #('ab') startingAt: 1) equals: 5.
-	"Test substring to skip is given directly as a string instead of in an array"
-	self assert: (',ab' skipAnySubstring: ',' startingAt: 1) equals: 2.
-	"Test how delimiters order can influence the result: substrings are skipped greedily with no backtracking."
+	"Test if delimiters is a string it is treated as a collection of characters"
+	self assert: (', ab' skipAnySubstring: ' ,' startingAt: 1) equals: 3.
+	"Test how delimiters order matters: substrings are skipped greedily with no backtracking"
 	self assert: ('abcdefg' skipAnySubstring: #('abcd' 'abc' 'def' 'g') startingAt: 1) equals: 5.
 	self assert: ('abcdefg' skipAnySubstring: #('abc' 'def' 'g' 'abcd') startingAt: 1) equals: 8.
 ]

--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -1260,6 +1260,24 @@ StringTest >> testFormatFailures [
 
 ]
 
+{ #category : #test }
+StringTest >> testHasSubstringAt [
+
+	"Test empty strings"
+	self assert: ('' hasSubstring: '' at: 1).
+	self assert: ('test' hasSubstring: '' at: 1).
+	self deny: ('' hasSubstring: 'test' at: 1).
+	"Test out of bounds indexes"
+	self deny: ('test' hasSubstring: 't' at: 0).
+	self deny: ('test' hasSubstring: 't' at: 10).
+	"Test matching substring"
+	self assert: ('test' hasSubstring: 'st' at: 3).
+	"Test partially matching substring"
+	self deny: ('test' hasSubstring: 'sty' at: 3).
+	
+	
+]
+
 { #category : #tests }
 StringTest >> testHasWideCharacterFromTo [
 

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2131,30 +2131,6 @@ String >> occursInWithEmpty: prefix caseSensitive: aBoolean [
 		matchTable: matchTable) > 0
 ]
 
-{ #category : #accessing }
-String >> oldSkipAnySubstring: delimiters startingAt: start [ 
-	"Answer the index of the last character within the receiver, starting at start, that does NOT match one of the delimiters. delimiters is a Array of substrings (Characters also allowed).  If the receiver is all delimiters, answer size + 1."
-
-	| any this ind ii |
-	ii := start-1.
-	[(ii := ii + 1) <= self size] whileTrue: [ "look for char that does not match"
-		any := false.
-		delimiters do: [:delim |
-			delim isCharacter 
-				ifTrue: [(self at: ii) == delim ifTrue: [any := true]]
-				ifFalse: ["a substring"
-					delim size > (self size - ii + 1) ifFalse: "Here's where the one-off error was."
-						[ind := 0.
-						this := true.
-						delim do: [:dd | 
-							dd == (self at: ii+ind) ifFalse: [this := false].
-							ind := ind + 1].
-						this ifTrue: [ii := ii + delim size - 1.  any := true]]
-							ifTrue: [any := false] "if the delim is too big, it can't match"]].
-		any ifFalse: [^ ii]].
-	^ self size + 1
-]
-
 { #category : #converting }
 String >> onlyLetters [
 	"answer the receiver with only letters"

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1595,6 +1595,20 @@ String >> format: collection [
 								ifFalse: [ result nextPut: currentChar ] ] ] ]
 ]
 
+{ #category : #'finding/searching' }
+String >> hasSubstring: str at: index [
+
+	"Answer true if the receiver contains the substring str exactly at index, false otherwise."
+
+	| pos |
+	pos := index - 1.
+
+	^ str size <= (self size - pos) and:
+		[ str allSatisfy: [ :char | 
+		  pos := pos + 1.
+		  (self at: pos) = char ] ]
+]
+
 { #category : #testing }
 String >> hasWideCharacterFrom: start to: stop [
 	"Return true if one of my character in the range does not fit in a single byte"
@@ -2114,6 +2128,30 @@ String >> occursInWithEmpty: prefix caseSensitive: aBoolean [
 		matchTable: matchTable) > 0
 ]
 
+{ #category : #accessing }
+String >> oldSkipAnySubstring: delimiters startingAt: start [ 
+	"Answer the index of the last character within the receiver, starting at start, that does NOT match one of the delimiters. delimiters is a Array of substrings (Characters also allowed).  If the receiver is all delimiters, answer size + 1."
+
+	| any this ind ii |
+	ii := start-1.
+	[(ii := ii + 1) <= self size] whileTrue: [ "look for char that does not match"
+		any := false.
+		delimiters do: [:delim |
+			delim isCharacter 
+				ifTrue: [(self at: ii) == delim ifTrue: [any := true]]
+				ifFalse: ["a substring"
+					delim size > (self size - ii + 1) ifFalse: "Here's where the one-off error was."
+						[ind := 0.
+						this := true.
+						delim do: [:dd | 
+							dd == (self at: ii+ind) ifFalse: [this := false].
+							ind := ind + 1].
+						this ifTrue: [ii := ii + delim size - 1.  any := true]]
+							ifTrue: [any := false] "if the delim is too big, it can't match"]].
+		any ifFalse: [^ ii]].
+	^ self size + 1
+]
+
 { #category : #converting }
 String >> onlyLetters [
 	"answer the receiver with only letters"
@@ -2200,26 +2238,21 @@ String >> sameAs: aString [
 ]
 
 { #category : #accessing }
-String >> skipAnySubstring: delimiters startingAt: start [ 
-	"Answer the index of the last character within the receiver, starting at start, that does NOT match one of the delimiters. delimiters is a Array of substrings (Characters also allowed).  If the receiver is all delimiters, answer size + 1."
+String >> skipAnySubstring: delimiters startingAt: start [
 
-	| any this ind ii |
-	ii := start-1.
-	[(ii := ii + 1) <= self size] whileTrue: [ "look for char that does not match"
-		any := false.
-		delimiters do: [:delim |
-			delim isCharacter 
-				ifTrue: [(self at: ii) == delim ifTrue: [any := true]]
-				ifFalse: ["a substring"
-					delim size > (self size - ii + 1) ifFalse: "Here's where the one-off error was."
-						[ind := 0.
-						this := true.
-						delim do: [:dd | 
-							dd == (self at: ii+ind) ifFalse: [this := false].
-							ind := ind + 1].
-						this ifTrue: [ii := ii + delim size - 1.  any := true]]
-							ifTrue: [any := false] "if the delim is too big, it can't match"]].
-		any ifFalse: [^ ii]].
+	"Answer the index of the last character within the receiver, starting at start, that does NOT match one of the delimiters. delimiters is a Array of substrings (Characters also allowed); their ordering sets priority and can influence the result. If the receiver is all delimiters, answer size + 1."
+
+	| pos delimArray |
+	pos := start.
+	delimArray := delimiters asArray.
+	[ pos <= self size ] whileTrue: [ 
+		pos := delimArray
+			      detect: [ :delim | 
+				      delim isCharacter
+					      ifTrue: [ (self at: pos) = delim ]
+					      ifFalse: [ self hasSubstring: delim at: pos ] ]
+			      ifFound: [ :match | pos + match asString size ]
+			      ifNone: [ ^ pos ] ].
 	^ self size + 1
 ]
 

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1595,22 +1595,6 @@ String >> format: collection [
 								ifFalse: [ result nextPut: currentChar ] ] ] ]
 ]
 
-{ #category : #'finding/searching' }
-String >> hasSubstring: str at: index [
-
-	"Answer true if the receiver contains the substring str exactly at index, false otherwise."
-
-	| pos |
-	
-	(index < 1) ifTrue: [ ^ false ].
-	pos := index - 1.
-	
-	^ str size <= (self size - pos) and:
-		[ str noneSatisfy: [ :char |  
-		  pos := pos + 1.
-		  (self at: pos) ~= char ] ]
-]
-
 { #category : #testing }
 String >> hasWideCharacterFrom: start to: stop [
 	"Return true if one of my character in the range does not fit in a single byte"
@@ -1653,6 +1637,23 @@ String >> includesSubstring: substring [
 	"('abcdefgh' includesSubstring: 'de') >>> true"
 	
 	^ substring isEmpty or: [ (self findString: substring startingAt: 1) > 0 ]
+]
+
+{ #category : #'finding/searching' }
+String >> includesSubstring: substring at: index [
+
+	"Answer true if the receiver contains the substring str exactly at index, false otherwise."
+
+	"('abcdefgh' includesSubstring: 'de' at: 1) >>> false"
+	"('abcdefgh' includesSubstring: 'de' at: 4) >>> true"
+
+	| pos |
+	pos := index - 1.
+
+	^ index > 0 & (self size - pos >= substring size) and: [ 
+		  substring allSatisfy: [ :char | 
+			  pos := pos + 1.
+			  (self at: pos) = char ] ]
 ]
 
 { #category : #testing }
@@ -2242,29 +2243,32 @@ String >> sameAs: aString [
 { #category : #accessing }
 String >> skipAnySubstring: delimiters startingAt: start [
 
-	"Answer the index of the last character within the receiver, starting at start, that does NOT match one of the delimiters. delimiters is a Array of substrings (Characters also allowed); their ordering sets priority and can influence the result. If the receiver is all delimiters, answer size + 1."
+	"Skip any of the delimiters found in receiver, from start onwards, until no delimiter substring matches; answer the position reached. delimiters is an array of strings (characters are accepted, but skipDelimiters:startingAt: handles them better). A string coming earlier in the array is skipped with higher priority. If the end of the receiver is reached, answer size + 1."
 
-	| pos delimArray |
+	| pos |
+	delimiters isString ifTrue: [ 
+		^ self skipDelimiters: delimiters startingAt: start ].
+
 	pos := start.
-	delimArray := delimiters asArray.
 	[ pos <= self size ] whileTrue: [ 
-		pos := delimArray
-			      detect: [ :delim | 
-				      delim isCharacter
-					      ifTrue: [ (self at: pos) = delim ]
-					      ifFalse: [ self hasSubstring: delim at: pos ] ]
-			      ifFound: [ :match | pos + match asString size ]
-			      ifNone: [ ^ pos ] ].
+		pos := delimiters
+			       detect: [ :delim | 
+				       delim isCharacter
+					       ifTrue: [ (self at: pos) = delim ]
+					       ifFalse: [ self includesSubstring: delim at: pos ] ]
+			       ifFound: [ :match | pos + match asString size ]
+			       ifNone: [ ^ pos ] ].
 	^ self size + 1
 ]
 
 { #category : #accessing }
-String >> skipDelimiters: delimiters startingAt: start [ 
-	"Answer the index of the character within the receiver, starting at start, that does NOT match one of the delimiters. If the receiver does not contain any of the delimiters, answer size + 1.  Assumes the delimiters to be a non-empty string."
+String >> skipDelimiters: delimiters startingAt: start [
 
-	start to: self size do: [:i |
-		delimiters detect: [:delim | delim = (self at: i)]
-				ifNone: [^ i]].
+	"Answer the index of the first character within the receiver, starting at start, that does NOT match any element of delimiters (a collection of characters). If the end of the receiver is reached, answer size + 1."
+
+	start to: self size do: [ :i | 
+		(delimiters anySatisfy: [ :delim | delim = (self at: i) ]) 
+			ifFalse: [ ^ i ] ].
 	^ self size + 1
 ]
 

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -3,13 +3,89 @@ A String is an indexed collection of Characters. Class String provides the abstr
 
 Strings support a vast array of useful methods, which can best be learned by browsing and trying out examples as you find them in the code.
 
-Here are a few useful methods to look at...
-	String match:
-	String contractTo:
+## Substrings and slicing
 
-String also inherits many useful methods from its hierarchy, such as
-	SequenceableCollection ,
-	SequenceableCollection copyReplaceAll:with:
+A number of selectors can be used to get substrings. `String>>#lines` will return a colection containing substrings separated by `\\n`, `\\r`, or `\\r\\n`; `String>>#trim` will return a substring with whitespace removed from the beginning and end. 
+
+Obtaining parts of a string can also be achieved using numbered indices, also known as slicing. There are shortcut methods for some common operations that are often inherited from `SequenceableCollection` inclusing `allButFirst`, `allButLast`, `first`, or `last`.
+
+```
+s := 'abcdefg'.
+
+s first. ""$a""
+s allButFirst.  ""bcdefg""
+
+s last.  ""$g""
+s allButLast.  ""abcdef""
+
+""pass a number argument to change the number of characters removed/kept""
+
+s first: 2.  ""ab""  
+s allButFirst: 2.  ""cdefg""
+
+s last: 2.  ""fg""
+s allButLast: 2.  ""abcde""
+```
+
+To get the middle of a string use `SequenceableCollection>>#copyFrom:to:`
+
+```
+s := 'abcdefg'.
+s copyFrom: 2 to: 6. ""bcdef""
+```
+
+To count back from the end of the string use the `size` selector
+```
+s := 'abcdefg'
+s copyFrom: 2 to: s size - 1 
+```
+
+## Formatting
+
+Strings have a `String>>#format:` selector that can be used for interpolating other objects.
+The ""string template"" can either have numbers between curly bracket characters (`{` and `}`)
+where the argument to format is a collection where values are indexed by number. Or pass in
+a `HashedCollection` where the placeholders are the keys of the collection
+```
+'ab {1} ef {2}' format: {'cd'. 'gh'}.  ""ab cd ef gh""
+
+'ab {one} ef {two}' format: 
+    (Dictionary with: #one -> 'cd' with: #two -> 'gh').
+```
+
+`String>>#contractTo:` is also useful for shortening strings to a particular length by replacing 
+middle characters.
+
+## Copying and Streaming
+As well as the `format:` selector it is possible to build up a string using contatenation with
+`SequenceableCollection>>#,` 
+
+```
+a := 'abc'.
+b := ' easy as '.
+c := '123'.
+a , b , c.  ""abc easy as 123""
+```
+Or alternatively, construct a string from a stream using `SequenceableCollection class>>#streamContents:`.
+
+```
+s := String streamContents: [ :stream |
+	  stream nextPutAll: 'abcdefg';
+	  space;
+	  nextPutAll: '123456';
+	  space.
+	  '7890' putOn: stream. ].  ""abcdefg 123456 7890""
+```
+
+## Finding/Searching
+
+Simple reqular expression type searching can be performed using `String>>#match:`, which has similar
+symantics as ""globbing"" in a shell. The reciever is a template string where the `#` character matches any single character and the `*` character matches any number of characters. A `Boolean` object is returned. 
+```
+'#abb*cdch' match: '4abbadskfakjdfadiadfnvcdch'  ""true""
+```
+
+For more complex matching use `String>>#matchesRegex:` which is an extension method implmented by `RxMatcher`. See the help documentation on regular expressions `HelpBrowser openOn: RegexHelp.`
 
 "
 Class {

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1601,12 +1601,14 @@ String >> hasSubstring: str at: index [
 	"Answer true if the receiver contains the substring str exactly at index, false otherwise."
 
 	| pos |
+	
+	(index < 1) ifTrue: [ ^ false ].
 	pos := index - 1.
-
+	
 	^ str size <= (self size - pos) and:
-		[ str allSatisfy: [ :char | 
+		[ str noneSatisfy: [ :char |  
 		  pos := pos + 1.
-		  (self at: pos) = char ] ]
+		  (self at: pos) ~= char ] ]
 ]
 
 { #category : #testing }

--- a/src/GT-SpotterExtensions-Core/HelpTopic.extension.st
+++ b/src/GT-SpotterExtensions-Core/HelpTopic.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #HelpTopic }
 
 { #category : #'*GT-SpotterExtensions-Core' }
+HelpTopic >> gtAllSubtopics [
+
+	 ^ self subtopics flatCollect: [:aTopic |
+		aTopic asOrderedCollection, aTopic gtAllSubtopics ]
+]
+
+{ #category : #'*GT-SpotterExtensions-Core' }
 HelpTopic >> gtBreadcrumbTitle [
 	|breadcrumbTitle currentHelpTopic|
 	

--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -55,7 +55,7 @@ CoASTResultSetBuilder >> configureFetcherForNode: aNode usingHeuristicAvoidingRe
 	| fetcher |
 	fetcher := heuristic fetcherFor: aNode inContext: completionContext.
 	^ self
-		configureFetcher: fetcher withoutRepetition
+		configureFetcher: fetcher withoutRepetition withNarrowHistory
 		forNode: aNode
 ]
 

--- a/src/HeuristicCompletion-Model/CoFetcher.class.st
+++ b/src/HeuristicCompletion-Model/CoFetcher.class.st
@@ -90,7 +90,7 @@ CoFetcher >> isEmptyCompletionFetcher [
 ]
 
 { #category : #composing }
-CoFetcher >> narrowFilterBlock: aBlockClosure [ 
+CoFetcher >> narrowFilterBlock: aBlockClosure narrowKey: aKey [
 	
 	^ self select: aBlockClosure
 ]
@@ -127,10 +127,26 @@ CoFetcher >> select: aBlockClosure [
 		yourself
 ]
 
+{ #category : #composing }
+CoFetcher >> unnarrowFilterBlock: aBlockClosure narrowKey: aKey [
+
+	self reset.
+	
+	^ self select: aBlockClosure
+]
+
 { #category : #enumerating }
 CoFetcher >> upToEnd [
 	
 	^ self generator upToEnd
+]
+
+{ #category : #composing }
+CoFetcher >> withNarrowHistory [
+
+	^ CoNarrowHistoryFetcher new
+		decoree: self;
+		yourself
 ]
 
 { #category : #composing }

--- a/src/HeuristicCompletion-Model/CoNarrowHistoryFetcher.class.st
+++ b/src/HeuristicCompletion-Model/CoNarrowHistoryFetcher.class.st
@@ -1,0 +1,88 @@
+"
+I am a decorator that allows the narrowing and unnarrowing without needing to reset the decoree.
+I store the intermediate state of the query and perform the subsequent query taking care of the results already handled.
+"
+Class {
+	#name : #CoNarrowHistoryFetcher,
+	#superclass : #CoFetcherDecorator,
+	#instVars : [
+		'currentResults',
+		'history',
+		'currentKey',
+		'currentFinished'
+	],
+	#category : #'HeuristicCompletion-Model-Core'
+}
+
+{ #category : #enumerating }
+CoNarrowHistoryFetcher >> entriesDo: aBlock [
+
+	currentResults do: aBlock.
+
+	"If previously I have detected that the decoree has not found entries, we need to avoid getting them again"
+	currentFinished ifTrue: [ ^ self ].
+
+	decoree entriesDo: [ :elem | 
+		currentResults add: elem.
+		aBlock value: elem ].
+	
+	currentFinished := true.
+]
+
+{ #category : #enumerating }
+CoNarrowHistoryFetcher >> initialize [
+
+	super initialize.
+	currentResults := OrderedCollection new.
+	currentKey := ''.
+	currentFinished := false.
+	history := Dictionary new.
+]
+
+{ #category : #composing }
+CoNarrowHistoryFetcher >> narrowFilterBlock: aBlock narrowKey: aKey [
+
+	history at: currentKey put: (CoNarrowHistoryItem forFetcher: decoree results: currentResults hasFinished: currentFinished).
+
+	currentResults := currentResults select: aBlock.
+
+	decoree := decoree narrowFilterBlock: aBlock narrowKey: currentKey.
+	generator := nil.
+	currentFinished := false.
+	
+	currentKey := aKey.
+	
+	^ self
+]
+
+{ #category : #initialization }
+CoNarrowHistoryFetcher >> reset [
+
+	super reset.
+	currentResults := OrderedCollection new.
+	currentFinished := false.
+	history := Dictionary new.
+]
+
+{ #category : #composing }
+CoNarrowHistoryFetcher >> unnarrowFilterBlock: aBlock narrowKey: aKey [
+
+	history at: aKey 
+		ifPresent: [ :historyItem |
+			decoree := historyItem fetcher.
+			currentResults := historyItem results.
+			currentFinished := historyItem hasFinished ] 
+		ifAbsent: [ 
+			currentResults := OrderedCollection new.
+			decoree := decoree unnarrowFilterBlock: aBlock narrowKey: aKey.
+			currentFinished := false ].
+	
+	generator := nil.
+	currentKey := aKey.
+]
+
+{ #category : #composing }
+CoNarrowHistoryFetcher >> withNarrowHistory [
+
+	^ self
+]

--- a/src/HeuristicCompletion-Model/CoNarrowHistoryItem.class.st
+++ b/src/HeuristicCompletion-Model/CoNarrowHistoryItem.class.st
@@ -1,0 +1,60 @@
+"
+I am an item in the history when using the CoNarrowHistoryFetcher.
+I represent the intermediate results of a query, allowing to narrowing and unnarrowing without needing to reset the decoree fetcher.
+"
+Class {
+	#name : #CoNarrowHistoryItem,
+	#superclass : #Object,
+	#instVars : [
+		'fetcher',
+		'results',
+		'hasFinished'
+	],
+	#category : #'HeuristicCompletion-Model-Core'
+}
+
+{ #category : #'instance creation' }
+CoNarrowHistoryItem class >> forFetcher: fetcher results: results hasFinished: hasFinished [
+
+	^ self new
+		fetcher: fetcher;
+		results: results;
+		hasFinished: hasFinished;
+		yourself
+]
+
+{ #category : #accessing }
+CoNarrowHistoryItem >> fetcher [
+
+	^ fetcher
+]
+
+{ #category : #accessing }
+CoNarrowHistoryItem >> fetcher: anObject [
+
+	fetcher := anObject
+]
+
+{ #category : #accessing }
+CoNarrowHistoryItem >> hasFinished [
+
+	^ hasFinished
+]
+
+{ #category : #accessing }
+CoNarrowHistoryItem >> hasFinished: anObject [
+
+	hasFinished := anObject
+]
+
+{ #category : #accessing }
+CoNarrowHistoryItem >> results [
+
+	^ results
+]
+
+{ #category : #accessing }
+CoNarrowHistoryItem >> results: anObject [
+
+	results := anObject
+]

--- a/src/HeuristicCompletion-Model/CoResultSet.class.st
+++ b/src/HeuristicCompletion-Model/CoResultSet.class.st
@@ -108,16 +108,23 @@ CoResultSet >> filterWithString: aString [
 
 	"Narrow results"
 
+	aString = completionString ifTrue: [ ^ self ].
+
 	aString size >= completionString size
 		ifTrue: [ "Filter existing results"
 			fetcher := fetcher narrowFilterBlock: [ :e | 
-				 self does: e matches: aString ].
-			results := results select: [ :e | 
-				self does: e matches: aString ] ]
+				           self does: e matches: aString ] narrowKey: aString.
+			results := results select: [ :e | self does: e matches: aString ] ]
 		ifFalse: [ "Smaller filter, reset results and filter"
-			results := OrderedCollection new.
-			fetcher reset.
-			fetcher := fetcher select: [ :e | self does: e matches: aString ] ].
+			fetcher := fetcher
+				         unnarrowFilterBlock: [ :e | 
+				         self does: e matches: aString ]
+				         narrowKey: aString.
+
+			results := OrderedCollection new ].
+		
+	results := OrderedCollection new.	
+		
 	completionString := aString
 ]
 

--- a/src/HeuristicCompletion-Tests/CoNarrowHistoryFetcherTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoNarrowHistoryFetcherTest.class.st
@@ -1,0 +1,98 @@
+Class {
+	#name : #CoNarrowHistoryFetcherTest,
+	#superclass : #CoBasicFetcherWithElementsTest,
+	#category : #'HeuristicCompletion-Tests-Core'
+}
+
+{ #category : #initialization }
+CoNarrowHistoryFetcherTest >> setUp [
+
+	super setUp.
+	fetcher := CoNarrowHistoryFetcher new
+		decoree: (CoCollectionFetcher onCollection: #( a b c )).
+	expectedElements := #(a b c).
+]
+
+{ #category : #tests }
+CoNarrowHistoryFetcherTest >> testNarrowingAndUnnarrowingReturnsSameResult [
+
+	| f1Result f2Result f3Result |
+
+	fetcher := (CoCollectionFetcher onCollection: Symbol selectorTable)
+		           withNarrowHistory.
+	fetcher := fetcher
+		           narrowFilterBlock: [ :e | e beginsWith: 'as' ]
+		           narrowKey: 'as'.
+	f1Result := fetcher next: 10.
+
+	fetcher := fetcher
+		           narrowFilterBlock: [ :e | e beginsWith: 'asC' ]
+		           narrowKey: 'asC'.
+	f2Result := fetcher next: 10.
+
+	fetcher := fetcher
+		      unnarrowFilterBlock: [ :e | e beginsWith: 'as' ]
+		      narrowKey: 'as'.
+	f3Result := fetcher next: 10.
+
+	self assertCollection: f1Result equals: f3Result 
+]
+
+{ #category : #tests }
+CoNarrowHistoryFetcherTest >> testNarrowingReturnsSameElementsThatCallingDirectly [
+
+	| originalSearch narrowedResults |
+	
+	"First execution with complete query"
+	fetcher := (CoCollectionFetcher onCollection: Symbol selectorTable)
+		           withNarrowHistory.
+	fetcher := fetcher
+		           narrowFilterBlock: [ :e | e beginsWith: 'asL' ]
+		           narrowKey: 'as'.
+	originalSearch := fetcher next: 10.
+
+	"Second execution with query using narrowing"
+	fetcher := (CoCollectionFetcher onCollection: Symbol selectorTable)
+		           withNarrowHistory.
+	fetcher := fetcher
+		           narrowFilterBlock: [ :e | e beginsWith: 'as' ]
+		           narrowKey: 'as'.
+	fetcher next: 10.
+	fetcher := fetcher
+		           narrowFilterBlock: [ :e | e beginsWith: 'asL' ]
+		           narrowKey: 'asL'.
+
+	narrowedResults := fetcher next: 10.
+	
+	self assertCollection: originalSearch equals: narrowedResults
+]
+
+{ #category : #tests }
+CoNarrowHistoryFetcherTest >> testUnnarrowingAndThenNarrowingReturnsSameResult [
+
+
+	| originalResults newResults |
+	fetcher := (CoCollectionFetcher onCollection: Symbol selectorTable)
+		           withNarrowHistory.
+	fetcher := fetcher
+		           narrowFilterBlock: [ :e | e beginsWith: 'as' ]
+		           narrowKey: 'as'.
+	fetcher upToEnd.
+
+	fetcher := fetcher
+		           narrowFilterBlock: [ :e | e beginsWith: 'asL' ]
+		           narrowKey: 'asC'.
+	originalResults := fetcher upToEnd.
+
+	fetcher := fetcher
+		      unnarrowFilterBlock: [ :e | e beginsWith: 'as' ]
+		      narrowKey: 'as'.
+	fetcher upToEnd.
+
+	fetcher := fetcher
+		           narrowFilterBlock: [ :e | e beginsWith: 'asL' ]
+		           narrowKey: 'asC'.
+	newResults := fetcher upToEnd.
+
+	self assertCollection: originalResults equals: newResults 
+]

--- a/src/HeuristicCompletion-Tests/CoNarrowHistoryFetcherTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoNarrowHistoryFetcherTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'HeuristicCompletion-Tests-Core'
 }
 
-{ #category : #initialization }
+{ #category : #running }
 CoNarrowHistoryFetcherTest >> setUp [
 
 	super setUp.

--- a/src/HeuristicCompletion-Tests/CoRepeatedHierarchyImplementedSelectorsFetcherTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoRepeatedHierarchyImplementedSelectorsFetcherTest.class.st
@@ -11,7 +11,7 @@ CoRepeatedHierarchyImplementedSelectorsFetcherTest >> setUp [
 	fetcher := (CoClassImplementedMessagesFetcher new
 		completionClass: self completionClass;
 		forHierarchy)
-		withoutRepetition.
+		withoutRepetition withNarrowHistory.
 	self completionClass superclass
 		selectors: (self completionClass superclass selectors copyWith: 'ma').
 	expectedElements := { 

--- a/src/MenuRegistration/PragmaMenuBuilder.class.st
+++ b/src/MenuRegistration/PragmaMenuBuilder.class.st
@@ -144,19 +144,19 @@ PragmaMenuBuilder >> builder [
 
 { #category : #'registrations handling' }
 PragmaMenuBuilder >> collectRegistrations [
+
 	"Retrieve all pragma methods and evaluate them by passing the 
 	MenuRegistration class as argument. The result is a list of trees
 	stored in my itemList inst var"
 
 	| menu |
 	menu := PragmaMenuAndShortcutRegistration model: self model.
-	self pragmas
-		do: [ :prg | 
-			self
-				currentRoot: self
-				while: [ prg methodClass instanceSide
-						perform: prg methodSelector
-						with: menu ] ].
+	self pragmas do: [ :prg | 
+		self currentRoot: self while: [ 
+			prg methodClass instanceSide isDeprecated ifFalse: [ 
+				prg methodClass instanceSide
+					perform: prg methodSelector
+					with: menu ] ] ].
 	self interpretRegistration: menu
 ]
 

--- a/src/Morphic-Base/HaloMorph.class.st
+++ b/src/Morphic-Base/HaloMorph.class.st
@@ -1172,7 +1172,6 @@ HaloMorph >> prepareToTrackCenterOfRotation: evt with: rotationHandle [
 		rotationHandle setProperty: #dragByCenterOfRotation toValue: true.
 		self startDrag: evt with: rotationHandle
 	].
-	evt hand showTemporaryCursor: Cursor blank
 ]
 
 { #category : #'events - processing' }

--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -310,7 +310,6 @@ HandMorph >> drawOn: aCanvas [
 	"Draw the hand itself (i.e., the cursor)."
 
 	temporaryCursor 
-		ifNil: [aCanvas paintImage: NormalCursor at: bounds topLeft]
 		ifNotNil: [aCanvas paintImage: temporaryCursor at: bounds topLeft].
 	
 ]
@@ -889,10 +888,7 @@ HandMorph >> needsToBeDrawn [
 		or: [ (submorphs anySatisfy: [ :ea | ea visible ])
 			or: [ (temporaryCursor notNil and: [hardwareCursor isNil])
 				]])
-		ifTrue: [
-			"using the software cursor; hide the hardware one"
-			self currentCursor == Cursor blank ifFalse: [Cursor blank show].
-			^ true].
+		ifTrue: [ ^ true ].
 	"Switch from one hardware cursor to another, if needed."
 	cursor := hardwareCursor ifNil: [Cursor normal].
 	self currentCursor == cursor ifFalse: [cursor show].

--- a/src/NECompletion/NECEntry.class.st
+++ b/src/NECompletion/NECEntry.class.st
@@ -93,7 +93,9 @@ NECEntry >> printOn: aStream [
 		nextPutAll: self class name;
 		nextPut: $(;
 		nextPutAll: contents;
-		nextPut: $,;
-		nextPutAll: self hightlightSymbol;
-		nextPut: $)
+		nextPut: $,.
+
+	self hightlightSymbol ifNotNil: [ aStream nextPutAll: self hightlightSymbol ].
+	
+	aStream nextPut: $)
 ]

--- a/src/OSWindow-SDL2/SDLWindowsPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLWindowsPlatform.class.st
@@ -1,0 +1,45 @@
+"
+Specific SDL initialization for Windows
+"
+Class {
+	#name : #SDLWindowsPlatform,
+	#superclass : #SDLAbstractPlatform,
+	#category : #'OSWindow-SDL2-Bindings'
+}
+
+{ #category : #operations }
+SDLWindowsPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
+]
+
+{ #category : #initialization }
+SDLWindowsPlatform >> initPlatformSpecific [
+
+	"For windows and Unix, we activate linearization.
+	This does not work properly on OSX with retina display, blurrying the rendering"
+	
+	SDL2 setHint: SDL_HINT_RENDER_SCALE_QUALITY value: '1'
+]
+
+{ #category : #initialization }
+SDLWindowsPlatform >> systemCursorConversionTable [
+
+	^ {
+		 #normal -> #SDL_SYSTEM_CURSOR_ARROW.
+       #overEditableText -> #SDL_SYSTEM_CURSOR_IBEAM.
+       #wait -> #SDL_SYSTEM_CURSOR_WAIT.
+       #crossHair -> #SDL_SYSTEM_CURSOR_CROSSHAIR.
+       "#SDL_SYSTEM_CURSOR_WAITARROW."
+        #resizeTopLeft -> #SDL_SYSTEM_CURSOR_SIZENWSE.    
+		  #resizeBottomRight -> #SDL_SYSTEM_CURSOR_SIZENWSE.
+        #resizeBottomLeft -> #SDL_SYSTEM_CURSOR_SIZENESW.
+        #resizeTopRight -> #SDL_SYSTEM_CURSOR_SIZENESW.
+        #resizeLeft -> #SDL_SYSTEM_CURSOR_SIZEWE.
+        #resizeRight -> #SDL_SYSTEM_CURSOR_SIZEWE.
+        #resizeBottom -> #SDL_SYSTEM_CURSOR_SIZENS.
+        #resizeTop -> #SDL_SYSTEM_CURSOR_SIZENS.
+        #move -> #SDL_SYSTEM_CURSOR_SIZEALL.
+       "SDL_SYSTEM_CURSOR_NO."
+       #webLink -> #SDL_SYSTEM_CURSOR_HAND.	
+		
+		}
+]

--- a/src/OSWindow-SDL2/WinPlatform.extension.st
+++ b/src/OSWindow-SDL2/WinPlatform.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #WinPlatform }
+
+{ #category : #'*OSWindow-SDL2' }
+WinPlatform >> sdlPlatform [
+
+	^ SDLWindowsPlatform new
+]

--- a/src/ProfStef-Core/LessonView.class.st
+++ b/src/ProfStef-Core/LessonView.class.st
@@ -36,6 +36,14 @@ LessonView class >> menuOn: aBuilder [
 
 ]
 
+{ #category : #accessing }
+LessonView >> bindings [
+
+	"dynamic variable binding not needed for Lessons"
+
+	^ Dictionary new
+]
+
 { #category : #gui }
 LessonView >> buildText [
 	| scrolledText |
@@ -75,6 +83,7 @@ LessonView >> initialize [
 	window := self buildWindow.
 	shoutMorph := self buildText.
 	window addMorph: shoutMorph frame: (0 @ 0 corner: 1 @ 1).
+	window extent: 600 @ 450.
 ]
 
 { #category : #testing }

--- a/src/ProfStef-Core/PharoSyntaxTutorial.class.st
+++ b/src/ProfStef-Core/PharoSyntaxTutorial.class.st
@@ -160,7 +160,7 @@ Blocks are anonymous methods that can be stored into variables and executed on d
 
 Blocks are delimited by square brackets: []"
 
-[GTPlayground open].
+[StPlayground open].
 
 "does not open a Browser because the block is not executed.
 
@@ -172,7 +172,7 @@ Here is a block that adds 2 to its argument (its argument is named x):"
 
 [:x | x+2] value: 5.
 
-[GTPlayground open] value.
+[StPlayground open] value.
 
 [:x | x+2] value: 10.
 
@@ -257,12 +257,11 @@ lesson:
 Note you can run this tutorial again by evaluating: ''ProfStef go''. 
 ''ProfStef previous'' returns to the previous lesson.
 
-You can also Do it using the keyboard shortcut ''Ctrl + D''
-(this varies according to your operating system/computer: it can be ''Cmd + D'' or ''Alt + D''). 
+You can also Do it using the keyboard shortcut ''Ctrl + D'' (or ''Cmd + D'' on MacOS). 
 
 Try to evaluate these expressions:"
 
-GTPlayground open.
+StPlayground open.
 
 SmalltalkImage current aboutThisSystem.
 
@@ -283,9 +282,9 @@ For example, select the text below, open the menu and click on ''Inspect it'':"
 
 1 / 2.
 
-"You''ve seen the keyboard keys next to the ''Inspect it''? It indicates the Ctrl- (or Cmd- or Alt-) shortcut to execute this command.
+"You''ve seen the keyboard keys next to the ''Inspect it''? It indicates the Ctrl- (or Cmd-) shortcut to execute this command.
 
-Try ''Ctrl + I'' (or ''Cmd + I'' or ''Alt + I'') on the following expressions:"
+Try ''Ctrl + I'' (or ''Cmd + I'') on the following expressions:"
 
 DateAndTime today.
 
@@ -615,9 +614,9 @@ For example, select the text below, open the menu and click on ''Print it'':"
 
 1 + 2.
 
-"You''ve seen the keyboard keys next to the ''Print it''? It indicates the Ctrl- (or Cmd- or Alt-) shortcut to execute this command.
+"You''ve seen the keyboard keys next to the ''Print it''? It indicates the Ctrl- (or Cmd-) shortcut to execute this command.
 
-Try ''Ctrl + P'' (or ''Cmd + P'' or ''Alt + P'') on the following expressions:"
+Try ''Ctrl + P'' (or ''Cmd + P'') on the following expressions:"
 
 Date today.
 
@@ -639,7 +638,7 @@ lesson:
 
 Take a look at method #ifFalse:ifTrue: source code of class True:"
 
-(True>>#ifFalse:ifTrue:) definition.
+(True>>#ifFalse:ifTrue:) sourceCode.
 
 "Or just its comment:"
 

--- a/src/ProfStef-Core/ProfStef.class.st
+++ b/src/ProfStef-Core/ProfStef.class.st
@@ -117,12 +117,6 @@ ProfStef class >> goOn: aTutorialClass [
 ]
 
 { #category : #navigating }
-ProfStef class >> goToNextLesson [
-
-  self next
-]
-
-{ #category : #navigating }
 ProfStef class >> last [
 
 	^ self default last

--- a/src/Settings-Graphics/GraphicFontSettings.class.st
+++ b/src/Settings-Graphics/GraphicFontSettings.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #fonts }
 GraphicFontSettings class >> displayScaleFactorForStyleNamed: aSymbol [
 
-	^ (#(#(#superTiny 0.6) #(#tiny 0.8) #(#small 1) #(#medium 1.3) #(#large 1.6) #(veryLarge 2) #(huge 2.7)) 
+	^ (#(#(#superTiny 0.6) #(#tiny 0.8) #(#small 1) #(#medium 1.4) #(#large 1.6) #(veryLarge 2) #(huge 2.7))
 		detect: [:info | info first asUppercase = aSymbol asUppercase] ifNone: []) 
 			ifNotNil: [:info | info second]
 

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -131,7 +131,6 @@ SystemDependenciesTest >> knownSpec2Dependencies [
 	
 	^ #(
 		'WebBrowser-Core' "Spec's Link adapter"
-		'Spec2-CommonWidgets'
 		)
 ]
 

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -59,7 +59,7 @@ SystemDependenciesTest >> knownBasicToolsDependencies [
 
 	"ideally this list should be empty"	
 	^ #('AST-Core-Tests' 'Athens-Cairo' 'Athens-Core' 
-	#'Athens-Morphic' #'Refactoring-Critics' #'Reflectivity' #'Reflectivity-Tools' #Shout 'ParametrizedTests' 'HeuristicCompletion-Model' #VariablesLibrary)
+	#'Athens-Morphic' #'Refactoring-Critics' #'Reflectivity' #'Reflectivity-Tools' #Shout 'ParametrizedTests' 'HeuristicCompletion-Model' #VariablesLibrary 'Spec2-CommonWidgets')
 ]
 
 { #category : #'known dependencies' }
@@ -83,7 +83,7 @@ SystemDependenciesTest >> knownIDEDependencies [
 
 	"ideally this list should be empty"	
 	
-	^ #('NewTools-Spotter')
+	^ #('NewTools-Spotter' 'Spec2-CommonWidgets')
 ]
 
 { #category : #'known dependencies' }
@@ -131,6 +131,7 @@ SystemDependenciesTest >> knownSpec2Dependencies [
 	
 	^ #(
 		'WebBrowser-Core' "Spec's Link adapter"
+		'Spec2-CommonWidgets'
 		)
 ]
 
@@ -148,7 +149,7 @@ SystemDependenciesTest >> knownUIDependencies [
 	"ideally this list should be empty"	
 
 	^ #('AST-Core-Tests'  'Athens-Cairo' 'Athens-Core' 
-	#'Athens-Morphic' #'Refactoring-Critics' #'Refactoring-Environment' 'Reflectivity-Tools' #Shout #'Tool-Diff' #'Tool-FileList' #'Tool-Profilers' #'HeuristicCompletion-Model' 'NECompletion-Morphic' #VariablesLibrary #'Tools-CodeNavigation')
+	#'Athens-Morphic' #'Refactoring-Critics' #'Refactoring-Environment' 'Reflectivity-Tools' #Shout #'Tool-Diff' #'Tool-FileList' #'Tool-Profilers' #'HeuristicCompletion-Model' 'NECompletion-Morphic' #VariablesLibrary #'Tools-CodeNavigation' 'Spec2-CommonWidgets')
 ]
 
 { #category : #utilities }

--- a/src/System-Platforms/Unix32Platform.class.st
+++ b/src/System-Platforms/Unix32Platform.class.st
@@ -9,7 +9,10 @@ Class {
 
 { #category : #testing }
 Unix32Platform class >> isActivePlatform [
-	^ (self currentPlatformName = 'unix') and: [ Smalltalk vm wordSize = 4 ]
+
+	^ (self currentPlatformName = 'unix') 
+		and: [ Smalltalk vm wordSize = 4 
+			and: [ (Smalltalk vm getSystemAttribute: 1003) ~= 'armv7l' ] ] 
 ]
 
 { #category : #visiting }

--- a/src/System-Platforms/UnixARM32Platform.class.st
+++ b/src/System-Platforms/UnixARM32Platform.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : #UnixARM32Platform,
+	#superclass : #Unix32Platform,
+	#category : #'System-Platforms-Unix'
+}
+
+{ #category : #testing }
+UnixARM32Platform class >> isActivePlatform [
+
+	^ (self currentPlatformName = 'unix') 
+		and: [ Smalltalk vm wordSize = 4 
+			and: [ (Smalltalk vm getSystemAttribute: 1003) = 'armv7l' ] ] 
+]

--- a/src/UIManager/CommandLineUIManager.class.st
+++ b/src/UIManager/CommandLineUIManager.class.st
@@ -188,8 +188,13 @@ CommandLineUIManager >> exitFailure [
 
 { #category : #'handle debug requests' }
 CommandLineUIManager >> handleDebugRequest: aDebugRequest [
-	
-	self unhandledErrorDefaultAction: aDebugRequest exception
+
+	self
+		debugProcess: aDebugRequest process
+		context: aDebugRequest exception signalerContext
+		label: aDebugRequest exception description
+		fullView: false
+		notification: aDebugRequest exception description
 ]
 
 { #category : #'error handling' }

--- a/src/UnifiedFFI/UnixARM32Platform.extension.st
+++ b/src/UnifiedFFI/UnixARM32Platform.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #UnixARM32Platform }
+
+{ #category : #'*UnifiedFFI' }
+UnixARM32Platform >> ffiFloat64Alignment [
+	
+	"64 bits value are aligned to 8 bytes"
+	^ 8
+]
+
+{ #category : #'*UnifiedFFI' }
+UnixARM32Platform >> ffiInt64Alignment [
+	
+	"64 bits value are aligned to 8 bytes"
+	^ 8
+]


### PR DESCRIPTION
(Edit: I did a mistake in this PR and selected Pharo 10. It should be Pharo 9.0).
Removes duplicated entries from the world menu.
They were duplicated because the menus were built ignoring if the classes were deprecated or not. Now, the world menu only adds entries coming from non deprecated classes.
Before:
![Screen Shot 2021-09-27 at 14 52 54](https://user-images.githubusercontent.com/1684221/134913606-3797e4be-5510-42ab-b59e-e924c35cfe04.png)

After: 
![Screen Shot 2021-09-27 at 15 01 52](https://user-images.githubusercontent.com/1684221/134913631-e2e54dd9-b26a-4232-befc-53ee787fb2ef.png)

Please check first if this is the expected behavior.
Also, I don't know how to test this myself: The menu update is made when changes are performed on classes with the pragma <worldMenu>. Note that, the change proposed in this code won't trigger an update in the UI, so I'm not sure if just pulling these changes will remove the duplicated entries.