### PR TITLE
Fixes #10037. Now it only register world menu entries if the class "marked with pra…

### DIFF
--- a/src/MenuRegistration/PragmaMenuBuilder.class.st
+++ b/src/MenuRegistration/PragmaMenuBuilder.class.st
@@ -144,19 +144,19 @@ PragmaMenuBuilder >> builder [
 
 { #category : #'registrations handling' }
 PragmaMenuBuilder >> collectRegistrations [
+
 	"Retrieve all pragma methods and evaluate them by passing the 
 	MenuRegistration class as argument. The result is a list of trees
 	stored in my itemList inst var"
 
 	| menu |
 	menu := PragmaMenuAndShortcutRegistration model: self model.
-	self pragmas
-		do: [ :prg | 
-			self
-				currentRoot: self
-				while: [ prg methodClass instanceSide
-						perform: prg methodSelector
-						with: menu ] ].
+	self pragmas do: [ :prg | 
+		self currentRoot: self while: [ 
+			prg methodClass instanceSide isDeprecated ifFalse: [ 
+				prg methodClass instanceSide
+					perform: prg methodSelector
+					with: menu ] ] ].
 	self interpretRegistration: menu
 ]
 


### PR DESCRIPTION
Fixes #10037.
Fix #10037
Closes #10037.
Prevent deprecated classes to register world menu entries.
Note that the changes won't trigger an UI update. I can't test if this will fix the problem in new images.
