### PR TITLE
Putting back the expectedFailure to test of write barrier

### DIFF
--- a/src/Kernel-Tests-Extended/WriteBarrierTest.class.st
+++ b/src/Kernel-Tests-Extended/WriteBarrierTest.class.st
@@ -92,6 +92,7 @@ WriteBarrierTest >> testMutateByteArrayUsingByteAtPut [
 { #category : #'tests - object' }
 WriteBarrierTest >> testMutateByteArrayUsingDoubleAtPut [
 	| guineaPig |
+	<expectedFailure>
 	guineaPig := ByteArray new: 8.
 	guineaPig beReadOnlyObject.
 	


### PR DESCRIPTION
Putting back the expectedFailure to test of write barrier
Related with #10053