### PR TITLE
10050-Failing-in-CI-CompiledMethodTrailerTesttestEmbeddingCompressedSourceCode

### DIFF
--- a/src/Kernel-Tests-Extended/CompiledMethodTrailerTest.extension.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTrailerTest.extension.st
@@ -36,6 +36,17 @@ CompiledMethodTrailerTest >> testEmbeddingCompressedSourceCode [
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
+CompiledMethodTrailerTest >> testEmbeddingCompressedSourceCodeWithQCompress [
+	| trailer code |
+	trailer := CompiledMethodTrailer new.
+
+	code := 'foo'.
+	trailer compressSourceCode: code.
+	
+	self assert: (trailer instVarNamed: #encodedData) equals: #[207 102 2 24]
+]
+
+{ #category : #'*Kernel-Tests-Extended' }
 CompiledMethodTrailerTest >> testEmbeddingSourceCode [
 	
 	self testEmbeddingSourceCode: 'testEmbeddingSourceCode

--- a/src/Kernel/CompiledMethodTrailer.class.st
+++ b/src/Kernel/CompiledMethodTrailer.class.st
@@ -615,12 +615,12 @@ CompiledMethodTrailer >> qCompress: string [
 	stream := WriteStream on: (ByteArray new: utf8str size).
 	oddNibble := nil.
 
-	utf8str do:	[:char | | ix |
+	utf8str do:	[:byte | | ix |
 		ix := 'ear tonsilcmbdfghjkpquvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345[]()'
-			indexOf: char ifAbsent: 0.
+			indexOf: byte asCharacter ifAbsent: 0.
 		(ix = 0
 			ifTrue:
-				[{ 0. char asInteger // 16. char asInteger \\ 16 }]
+				[{ 0. byte // 16. byte \\ 16 }]
 			ifFalse:
 				[ix <= 11
 					ifTrue: [{ ix }]


### PR DESCRIPTION
When encoding a string in any encoding, it returns a byteArray.
We need to change the code to handle bytes instead of characters.
Fix #10050