### PR TITLE
10078-To-check-CompiledMethodlocalReadsSelf-does-isFFIMethod-check

### DIFF
--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -284,6 +284,11 @@ CompiledCodeTest >> testReadsSelf [
 	self assert: method readsSelf.
 	method := self class compiler compile: 'method ^thisContext'.
 	self deny: method readsSelf.
+	"take care! FFI methods have a self send, but they do not have self bytecode after the first call
+	Here we test just the case of a FFI method that was not yet called to not make this test depend on FFI
+	calls"
+	method := self class compiler compile: 'status ^ self ffiCall: #(int cairo_scaled_font_status (self))'.
+	self assert: method readsSelf.
 ]
 
 { #category : #'tests - scanning' }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -703,12 +703,6 @@ CompiledMethod >> literalsToSkip [
 	^ 2
 ]
 
-{ #category : #scanning }
-CompiledMethod >> localReadsSelf [
-	"methods that are compiled with FFI have a self in the source but not in the bytecode"
-	^self isFFIMethod or: [ super localReadsSelf ]
-]
-
 { #category : #lookup }
 CompiledMethod >> lookupVar: aString [ 
 	^self ast scope lookupVar: aString

--- a/src/Kernel/SelfVariable.class.st
+++ b/src/Kernel/SelfVariable.class.st
@@ -36,11 +36,13 @@ SelfVariable >> readInContext: aContext [
 
 { #category : #queries }
 SelfVariable >> usingMethods [
-	"as super sends are doing a pushSelf, too, we need to still check the AST level sometimes"
+	"Super sends are doing a pushSelf, too, we need to still check the AST level sometimes.
+	FFI methods after a first call do not have a self send in the bytecode, but one in the code"
 
 	^ environment allMethods select: [ :method | 
+		method isFFIMethod or: [  
 		  method readsSelf and: [ 
 			  method sendsToSuper not or: [ 
 				  method ast variableNodes anySatisfy: [ :varNode | 
-					  varNode variable == self ] ] ] ]
+					  varNode variable == self ] ] ] ] ]
 ]

--- a/src/Slot-Tests/SelfVariableTest.class.st
+++ b/src/Slot-Tests/SelfVariableTest.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : #SelfVariableTest,
 	#superclass : #TestCase,
-	#instVars : [
-		'instVarForTest'
-	],
 	#category : #'Slot-Tests-VariablesAndSlots'
 }
 

--- a/src/Slot-Tests/SelfVariableTest.class.st
+++ b/src/Slot-Tests/SelfVariableTest.class.st
@@ -1,0 +1,35 @@
+Class {
+	#name : #SelfVariableTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'instVarForTest'
+	],
+	#category : #'Slot-Tests-VariablesAndSlots'
+}
+
+{ #category : #tests }
+SelfVariableTest >> testUsingMethods [
+
+	|  var |
+	var := self class lookupVar: #self.
+	self assert: (var usingMethods includes: thisContext method)
+]
+
+{ #category : #tests }
+SelfVariableTest >> testUsingMethodsFFI [
+
+	|  var |
+	var := self class lookupVar: #self.
+	
+	"We find an ffi method that was run and thus does not contain any push self, yet has self send in the code"
+	self assert: (var usingMethods anySatisfy: [:method | method isFFIMethod and: [ method readsSelf not ]])
+]
+
+{ #category : #tests }
+SelfVariableTest >> testUsingMethodsSuper [
+
+	|  var |
+	"we use super instead of self to check that super sends are not understood as self sends"
+	var := super class lookupVar: #self.
+	super deny: (var usingMethods includes: thisContext method)
+]


### PR DESCRIPTION
This PR fixes #10078:

- Move the FFI check from #localReadSelf to #usingMethods of SelfVariable
- add a test and comment to  testReadsSelf. I do not execute an FFI method here to not add a dependency / make this test platform specific
- add tests for #usingMethods for self:
	- check that we can find the test method itself (with the self assert)
	- check that if we use super, we do not find it
	- add test to check for a #isFFIMethod that does not read self, but we find it still by #usingMethods of SelfVariable

