### PR TITLE
10025-ObjectLayout-classlayoutForType-should-be-moved-to-the-Monticello-package

### DIFF
--- a/src/Kernel/ObjectLayout.class.st
+++ b/src/Kernel/ObjectLayout.class.st
@@ -25,14 +25,6 @@ ObjectLayout class >> layoutForSubclassDefiningSymbol: aSymbol [
 		ifNone: [ FixedLayout ]
 ]
 
-{ #category : #monticello }
-ObjectLayout class >> layoutForType: typeSymbol [
-	"used to get the layout for a Monticello internal layout symbol"
-	^self allSubclasses 
-		detect: [ :class | class mcTypeSymbol = typeSymbol ] 
-		ifNone: [ Error signal: 'Invalid layout type: ', typeSymbol asString ]
-]
-
 { #category : #description }
 ObjectLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass

--- a/src/Monticello/ObjectLayout.extension.st
+++ b/src/Monticello/ObjectLayout.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : #ObjectLayout }
 
 { #category : #'*Monticello' }
+ObjectLayout class >> layoutForType: typeSymbol [
+	"used to get the layout for a Monticello internal layout symbol"
+	^self allSubclasses 
+		detect: [ :class | class mcTypeSymbol = typeSymbol ] 
+		ifNone: [ Error signal: 'Invalid layout type: ', typeSymbol asString ]
+]
+
+{ #category : #'*Monticello' }
 ObjectLayout class >> mcTypeSymbol [
 	"return the symbol that Monticello uses to encode the layout"
 	^self name asSymbol


### PR DESCRIPTION
fixes #10025

- move monticello internal method layoutForType: to the monticello package.

It is only used in MCClassDefinition>>#createClass


