### PR TITLE
10062-Cleanup-Ring-RGElementDefinitiontheNonMetaParentName

### DIFF
--- a/src/EmergencyDebugger-Tests/EDDebuggingAPITest.class.st
+++ b/src/EmergencyDebugger-Tests/EDDebuggingAPITest.class.st
@@ -51,7 +51,7 @@ EDDebuggingAPITest >> testChangeRecordsForMethod [
 	| changes |
 	self prepareMethodVersionTest.
 	changes := debugAPI
-		changeRecordsForMethod: (EDMockObjectForTests >> #mWithVersion) asHistoricalRingDefinition.
+		changeRecordsForMethod: (EDMockObjectForTests >> #mWithVersion).
 	self assert: changes size equals: 2.
 	self assert: changes first sourceCode equals: self sampleMethodSourceCodeVersion2.
 	self assert: changes second sourceCode equals: self sampleMethodSourceCodeVersion1

--- a/src/EmergencyDebugger/EDDebuggingAPI.class.st
+++ b/src/EmergencyDebugger/EDDebuggingAPI.class.st
@@ -63,8 +63,8 @@ EDDebuggingAPI class >> terminateProcesses: processes [
 EDDebuggingAPI >> changeRecordsForMethod: aCompiledMethod [
 	^ SourceFiles
 		changeRecordsFrom: aCompiledMethod sourcePointer
-		className: aCompiledMethod realClass name
-		isMeta: aCompiledMethod realClass isMeta
+		className: aCompiledMethod methodClass name
+		isMeta: aCompiledMethod methodClass isMeta
 ]
 
 { #category : #accessing }

--- a/src/EmergencyDebugger/EDDebuggingAPI.class.st
+++ b/src/EmergencyDebugger/EDDebuggingAPI.class.st
@@ -63,8 +63,8 @@ EDDebuggingAPI class >> terminateProcesses: processes [
 EDDebuggingAPI >> changeRecordsForMethod: aCompiledMethod [
 	^ SourceFiles
 		changeRecordsFrom: aCompiledMethod sourcePointer
-		className: aCompiledMethod methodClass name
-		isMeta: aCompiledMethod methodClass isMeta
+		className: aCompiledMethod realClass name
+		isMeta: aCompiledMethod realClass isMeta
 ]
 
 { #category : #accessing }

--- a/src/Monticello/RGMethodDefinition.extension.st
+++ b/src/Monticello/RGMethodDefinition.extension.st
@@ -44,7 +44,7 @@ RGMethodDefinition >> basicAsMCMethodDefinition [
 		ifTrue: [ self asMCMethodDefinitionFromActiveDefinition ]
 		ifFalse: [
 		   ^ MCMethodDefinition
-				className: self theNonMetaParentName
+				className: self methodClass instanceSide name
 		 	   	classIsMeta: self isMetaSide
 				selector: self selector
 				category: self protocol

--- a/src/Ring-ChunkImporter/RGChunkImporter.class.st
+++ b/src/Ring-ChunkImporter/RGChunkImporter.class.st
@@ -503,18 +503,16 @@ RGChunkImporter >> visitDoItChunk: aChunk [
 RGChunkImporter >> visitMethodChunk: aChunk [
 
 	| theClass theMethod theProtocol |
+	theClass := self classNamed: aChunk behaviorName.
+	aChunk isMeta ifTrue: [ theClass := theClass classSide makeResolved ].
 
-	theClass := self classNamed: aChunk behaviorName. 
-	aChunk isMeta ifTrue: [ 
-		theClass := theClass theMetaClass makeResolved].
-	
-	theMethod := theClass ensureLocalMethodNamed: aChunk methodSelector asSymbol.
+	theMethod := theClass ensureLocalMethodNamed:
+		             aChunk methodSelector asSymbol.
 	theProtocol := theClass ensureProtocolNamed: aChunk category asSymbol.
 	theMethod protocol: theProtocol.
 	theMethod sourceCode: aChunk contents.
 	theMethod author: (RGStampParser authorForStamp: aChunk stamp).
-	theMethod time: (RGStampParser timeForStamp: aChunk stamp).
-
+	theMethod time: (RGStampParser timeForStamp: aChunk stamp)
 ]
 
 { #category : #visitor }

--- a/src/Ring-Core/RGBehaviorStrategyUser.class.st
+++ b/src/Ring-Core/RGBehaviorStrategyUser.class.st
@@ -376,8 +376,8 @@ RGBehaviorStrategyUser >> theMetaClass [
 
 { #category : #accessing }
 RGBehaviorStrategyUser >> theNonMetaClass [
-	
-	^ self behaviorStrategy theNonMetaClass
+
+	^ self behaviorStrategy instanceSide
 ]
 
 { #category : #variables }

--- a/src/Ring-Definitions-Core/RGElementDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGElementDefinition.class.st
@@ -359,18 +359,3 @@ RGElementDefinition >> setParentInfo: anObject [
 	self parentName: anObject name. 
 	self isMetaSide: anObject isMeta
 ]
-
-{ #category : #deprecated }
-RGElementDefinition >> theNonMetaParentName [
-	"Rejects the prefix ' class' or ' classTrait' of the parentName"
-	| index |
-	
-	index := self parentName
-				indexOfSubCollection: ' class'
-				startingAt: 1
-				ifAbsent: [ ^self parentName ].
-
-	^(self parentName 
-		copyFrom: 1
-		to: index - 1) asSymbol
-]

--- a/src/Ring-Definitions-Core/RGMethodDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGMethodDefinition.class.st
@@ -478,7 +478,7 @@ RGMethodDefinition >> method [
 RGMethodDefinition >> methodClass [
 	"Return the class to which the receiver belongs to."
 	
-	^ self realClass
+	^ self parent
 ]
 
 { #category : #accessing }

--- a/src/Ring-Definitions-Tests-Core/RGMethodDefinitionTest.class.st
+++ b/src/Ring-Definitions-Tests-Core/RGMethodDefinitionTest.class.st
@@ -383,6 +383,26 @@ RGMethodDefinitionTest >> testMessagesNonExistingMethodWithSource [
 ]
 
 { #category : #testing }
+RGMethodDefinitionTest >> testMethodClass [
+	| newMethod newClass |
+	
+	"When asking a Ring Method for it's methodClass, we need to not escape the model and return
+	the Ring parent. Use #realClass to escape and get the class in the Smalltalk globals"
+	
+	newClass := RGClassDefinition named: #OrderedCollection.
+	newMethod := (RGMethodDefinition named: #add:)
+		parent: newClass;
+		protocol: 'adding';
+		sourceCode:
+			'add: newObject
+									^self addLast: newObject'.
+
+	self assert: newMethod methodClass equals: newClass.
+	self assert: newMethod realClass equals: OrderedCollection.
+	
+]
+
+{ #category : #testing }
 RGMethodDefinitionTest >> testMethodEquality [
 	| newMethod newClass |
 	self assert: (OrderedCollection >> #size) asRingDefinition equals: (OrderedCollection >> #size) asRingDefinition.

--- a/src/Ring-Tests-Core/RGMetaclassStrategyTest.class.st
+++ b/src/Ring-Tests-Core/RGMetaclassStrategyTest.class.st
@@ -5,6 +5,14 @@ Class {
 }
 
 { #category : #tests }
+RGMetaclassStrategyTest >> testClassSide [
+
+	| anRGBehavior |
+	anRGBehavior := RGBehavior newMetaclass.
+	self assert: anRGBehavior classSide equals: anRGBehavior
+]
+
+{ #category : #tests }
 RGMetaclassStrategyTest >> testCreationByMethod [
 
 	| anRGBehavior |
@@ -117,13 +125,4 @@ RGMetaclassStrategyTest >> testStoreString [
 
 	anRGBehavior := RGMetaclass named: #SomeMetaclass.
 	self assert: anRGBehavior storeString equals: '(RGMetaclass named: #SomeMetaclass)'.	
-]
-
-{ #category : #tests }
-RGMetaclassStrategyTest >> testTheMetaclass [
-
-	| anRGBehavior |
-	
-	anRGBehavior := RGBehavior newMetaclass.
-	self assert: (anRGBehavior theMetaClass) equals: anRGBehavior.
 ]

--- a/src/Ring-Tests-Core/RGTraitTest.class.st
+++ b/src/Ring-Tests-Core/RGTraitTest.class.st
@@ -34,10 +34,12 @@ RGTraitTest >> testEnsureProtocol [
 
 { #category : #tests }
 RGTraitTest >> testNewTrait [
+
 	| trait metaclassTrait comment category package |
 	trait := RGTrait unnamed.
 	self assert: trait isRingResolved.
-	self assert: (trait hasUnresolvedAll: #(classTrait comment category package)).
+	self assert:
+		(trait hasUnresolvedAll: #( classTrait comment category package )).
 	self assert: trait isTrait.
 	self assert: trait trait identicalTo: trait.
 
@@ -45,14 +47,14 @@ RGTraitTest >> testNewTrait [
 	trait classTrait: metaclassTrait.
 	self assert: (trait hasResolved: #classTrait).
 	self assert: trait classTrait identicalTo: metaclassTrait.
-	self assert: trait theMetaClass identicalTo: metaclassTrait.
+	self assert: trait classSide identicalTo: metaclassTrait.
 
 	comment := RGComment parent: metaclassTrait.
 	self deny: trait hasComment.
 	trait comment: comment.
 	self assert: (trait hasResolved: #comment).
 	self assert: trait comment identicalTo: comment.
-	self deny: trait hasComment.	"the comment has no content"
+	self deny: trait hasComment. "the comment has no content"
 	comment content: 'some comment'.
 	self assert: trait hasComment.
 


### PR DESCRIPTION
This PR fixes RGMethodDefinition>>#basicAsMCMethodDefinition to not use theNonMetaParentName. As this was the only user and it was already in a deprecated category, the method was removed.

I addition, from running all Ring tests, we commit some transformations #theMetaClass to #classSide  (form a prior change that, too, brings the Ring API closer to the main model API again)


