### PR TITLE
10067-CDClassDefinitionParserparseSelectorPartwithArgument-misses-subclass-definition-symbols

### DIFF
--- a/src/ClassParser-Tests/CDDoubleByteClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDDoubleByteClassParserTest.class.st
@@ -1,0 +1,27 @@
+Class {
+	#name : #CDDoubleByteClassParserTest,
+	#superclass : #CDClassDefinitionParserTest,
+	#category : #'ClassParser-Tests'
+}
+
+{ #category : #helpers }
+CDDoubleByteClassParserTest >> classDefinitionString [
+
+	^ '{superclassName} variableDoubleByteSubclass: #{classname}
+		instanceVariableNames: ''{instvar1} {instvar2}''
+		classVariableNames: ''{classvar1} {classvar2}''
+		package: #MyPackage'
+			format: { 
+				'classname' -> self className.
+				'superclassName' -> self superclassName.
+				'instvar1' -> self firstInstanceVariableName.
+				'instvar2' -> self secondInstanceVariableName.
+				'classvar1' -> self firstClassVariableName.
+				'classvar2' -> self secondClassVariableName. } asDictionary
+]
+
+{ #category : #helpers }
+CDDoubleByteClassParserTest >> testDoubleByteClass [
+
+	self assert: classDefinition layoutClass equals: DoubleByteLayout 
+]

--- a/src/ClassParser-Tests/CDDoubleWordClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDDoubleWordClassParserTest.class.st
@@ -1,0 +1,27 @@
+Class {
+	#name : #CDDoubleWordClassParserTest,
+	#superclass : #CDClassDefinitionParserTest,
+	#category : #'ClassParser-Tests'
+}
+
+{ #category : #helpers }
+CDDoubleWordClassParserTest >> classDefinitionString [
+
+	^ '{superclassName} variableDoubleWordSubclass: #{classname}
+		instanceVariableNames: ''{instvar1} {instvar2}''
+		classVariableNames: ''{classvar1} {classvar2}''
+		package: #MyPackage'
+			format: { 
+				'classname' -> self className.
+				'superclassName' -> self superclassName.
+				'instvar1' -> self firstInstanceVariableName.
+				'instvar2' -> self secondInstanceVariableName.
+				'classvar1' -> self firstClassVariableName.
+				'classvar2' -> self secondClassVariableName. } asDictionary
+]
+
+{ #category : #helpers }
+CDDoubleWordClassParserTest >> testDoubleWordClass [
+
+	self assert: classDefinition layoutClass equals: DoubleWordLayout 
+]

--- a/src/ClassParser/CDClassDefinitionParser.class.st
+++ b/src/ClassParser/CDClassDefinitionParser.class.st
@@ -83,7 +83,7 @@ CDClassDefinitionParser >> parseSelectorPart: aString withArgument: aNode [
 	"We could do this with reflection, or with a dictionary and closures.
 	I chose to use a series of if for readability only."
 	
-	(#(variableWordSubclass: ephemeronSubclass: weakSubclass: variableByteSubclass: variableSubclass: immediateSubclass: #subclass:) includes: aString)
+	(ObjectLayout allSubclassDefiningSymbols includes: aString)
 		ifTrue: [ ^ self handleClassName: aNode withType: aString  ].
 	aString =	 #instanceVariableNames:
 		ifTrue: [ ^ self handleInstanceVariablesFromNode: aNode ].

--- a/src/Kernel/ObjectLayout.class.st
+++ b/src/Kernel/ObjectLayout.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Kernel-Layout'
 }
 
+{ #category : #description }
+ObjectLayout class >> allSubclassDefiningSymbols [
+	^self allSubclasses collect: [ :class | class subclassDefiningSymbol ] as: Set
+]
+
 { #category : #'instance creation' }
 ObjectLayout class >> extending: superLayout scope: aScope host: aClass [
 	self subclassResponsibility


### PR DESCRIPTION
This PR fixes #10067

The problem was that CDAbstractClassDefinitionParser did not know all subclass definition symbols. variableDoubleByteSubclass: and variableDoubleWordSubclass: were missing.

- we add tests for the two cases (which fail)
- we add #allSubclassDefiningSymbols that gets all the defined symbols from the layout classes

Now we can just use #allSubclassDefiningSymbols instead of hard coding the symbols and the tests are now green!


