### PR TITLE
moving-fuel-platform-to-our-control

### DIFF
--- a/src/BaselineOfFuel/BaselineOfFuel.class.st
+++ b/src/BaselineOfFuel/BaselineOfFuel.class.st
@@ -56,7 +56,7 @@ BaselineOfFuel >> fuelPlatform: spec [
 		baseline: 'FuelPlatform' 
 		with: [ 
 			spec
-				repository: 'github://theseion/FuelPlatform:stable/repository';
+				repository: 'github://pharo-project/FuelPlatform:master/repository';
   				loads: 'default' ]
 ]
 


### PR DESCRIPTION
Moving FuelPlatform to pharo-project, we need to move because Max changed the repository and broken our build.

Also, we need to see what we do with the repository, because it is just a package for us.