### PR TITLE
10110-isReferenced-is-not-working-for-PoolVariables

### DIFF
--- a/src/Kernel/ClassVariable.class.st
+++ b/src/Kernel/ClassVariable.class.st
@@ -75,8 +75,9 @@ ClassVariable >> isPoolVariable [
 
 { #category : #testing }
 ClassVariable >> isReferenced [
+	"For pools, fall back to the slow full search of all methods"
+	self definingClass isPool ifTrue: [ ^ super isReferenced ].
 	"A class variable can only be accessed in the defintionClass and its subclasses (both class and instance side)"
-
 	^ self definingClass withAllSubclasses anySatisfy: [ :behavior | 
 		  (behavior class hasMethodAccessingVariable: self) or: [ behavior hasMethodAccessingVariable: self ] ]
 ]
@@ -100,6 +101,7 @@ ClassVariable >> owningClass: anObject [
 
 { #category : #queries }
 ClassVariable >> usingMethods [
+	"For pools, fall back to the slow full search of all methods"
 	self definingClass isPool ifTrue: [ ^ super usingMethods ].
 	"if we are a class variable, we only need to search the sublasses and metaclasses"
 	^ self definingClass withAllSubclasses flatCollect: [ :class | 

--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -25,7 +25,7 @@ NoUnusedVariablesLeftTest >> testNoUnusedClassVariablesLeft [
 	validExceptions := #(OSKeySymbols FooSharedPool SDL2Constants AthensCairoDefinitions BalloonEngineConstants ShTestSharedPool RBLintRuleTestData RBDummyLintRuleTest MCMockClassF Unicode Character STONAlternativeRepresentationTestObject).	
 	
 	remaining := classes asOrderedCollection reject: [ :each  | validExceptions includes: each name].
-	self assert: remaining isEmpty
+	self assert: remaining isEmpty description: ('the following classes have unused class variables and should be cleaned: ', remaining asString)
 ]
 
 { #category : #testing }

--- a/src/Slot-Tests/ClassVariableTest.class.st
+++ b/src/Slot-Tests/ClassVariableTest.class.st
@@ -7,6 +7,9 @@ Class {
 	#classVars : [
 		'TestVariable'
 	],
+	#pools : [
+		'TestSharedPool'
+	],
 	#category : #'Slot-Tests-VariablesAndSlots'
 }
 
@@ -16,6 +19,17 @@ ClassVariableTest >> testIsReadInMethod [
 	DefaultTimeLimit printString. "reading class variable".
 	
 	self assert: ((TestCase classVariableNamed: #DefaultTimeLimit) isReadIn: self class >> testSelector)
+]
+
+{ #category : #tests }
+ClassVariableTest >> testIsReferenced [
+	self assert: (SmalltalkImage classVariableNamed: #CompilerClass) isReferenced.
+	TestVariable.
+	self assert: (self class classVariableNamed: #TestVariable) isReferenced.
+	"Check that it works for references to pool vars in the pool defining class"
+	self assert: (TestSharedPool classVariableNamed: #One) isReferenced.
+	ReferencedInTest.
+	self assert: (TestSharedPool classVariableNamed: #ReferencedInTest) isReferenced
 ]
 
 { #category : #tests }

--- a/src/Slot-Tests/LiteralVariableTest.class.st
+++ b/src/Slot-Tests/LiteralVariableTest.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : #LiteralVariableTest,
 	#superclass : #TestCase,
-	#classVars : [
-		'TestVariable'
-	],
 	#category : #'Slot-Tests-VariablesAndSlots'
 }
 

--- a/src/Slot-Tests/LiteralVariableTest.class.st
+++ b/src/Slot-Tests/LiteralVariableTest.class.st
@@ -23,13 +23,6 @@ LiteralVariableTest >> testComparison [
 ]
 
 { #category : #tests }
-LiteralVariableTest >> testIsReferenced [
-	self assert: (SmalltalkImage classVariableNamed: #CompilerClass) isReferenced.
-	TestVariable.
-	self assert: (self class classVariableNamed: #TestVariable) isReferenced
-]
-
-{ #category : #tests }
 LiteralVariableTest >> testIsVariableBinding [
 
 	| var1 |

--- a/src/Slot-Tests/TestSharedPool.class.st
+++ b/src/Slot-Tests/TestSharedPool.class.st
@@ -5,7 +5,8 @@ Class {
 	#name : #TestSharedPool,
 	#superclass : #SharedPool,
 	#classVars : [
-		'One'
+		'One',
+		'ReferencedInTest'
 	],
 	#category : #'Slot-Tests-Data'
 }


### PR DESCRIPTION
fixes #10110

- add a test for IsReferenced for the case of Pool variables
- add a comment to both usingMethods and isReferenced explaining why we treat pools specially

We could speed up the search for pools to look in the pool users in addition to the definer if we see that it is too slow.


