### PR TITLE
10123-Failing-test-Pharo9-ReleaseTesttestWorldMenuHasHelpForAllEntries 

### DIFF
--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -157,9 +157,6 @@ WorldState class >> helpOn: aBuilder [
 			(aBuilder group: #PharoHelp)
 				order: 2;
 				withSeparatorAfter.
-			(aBuilder group: #SpecHelp)
-				order: 3;
-				withSeparatorAfter.
 			(aBuilder item: #'About...')
 				order: 99;
 				iconName: #smallInfo;


### PR DESCRIPTION
Fixes #10123

By omitting all menu entries for deprecated classes, we remove the spec1 Help. After, the group is empty leading to the test failing.

This PR fixes the problem as we fixed it in Pharo10 after removing the deprecated class.

