### PR TITLE
enabling-debug-window-in-windows-P10

### DIFF
--- a/src/OSWindow-Core/OSWindowDriver.class.st
+++ b/src/OSWindow-Core/OSWindowDriver.class.st
@@ -109,6 +109,10 @@ OSWindowDriver class >> shutDown: quitting [
 ]
 
 { #category : #events }
+OSWindowDriver >> afterMainPharoWindowCreated: aWindow [
+]
+
+{ #category : #events }
 OSWindowDriver >> afterSetWindowTitle: windowTitle onWindow: osWindow [
 ]
 

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -106,6 +106,7 @@ OSWorldRenderer >> doActivate [
 	attributes preferableDriver: driver.
 	osWindow := OSWindow createWithAttributes: attributes eventHandler: (OSWindowMorphicEventHandler for: world).
 	
+	driver afterMainPharoWindowCreated: osWindow.
 	driver afterSetWindowTitle: Smalltalk image imageFile fullName onWindow: osWindow.
 		
 	osWindow focus. 

--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -44,6 +44,14 @@ OSSDL2Driver class >> isVMDisplayUsingSDL2 [
 ]
 
 { #category : #events }
+OSSDL2Driver >> afterMainPharoWindowCreated: osWindow [
+	
+	OSPlatform current sdlPlatform 
+		afterMainPharoWindowCreated: osWindow
+
+]
+
+{ #category : #events }
 OSSDL2Driver >> afterSetWindowTitle: windowTitle onWindow: osWindow [
 	
 	OSPlatform current sdlPlatform 

--- a/src/OSWindow-SDL2/SDLAbstractPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLAbstractPlatform.class.st
@@ -14,6 +14,12 @@ Class {
 }
 
 { #category : #operations }
+SDLAbstractPlatform >> afterMainPharoWindowCreated: aOSSDLWindow [
+
+	self subclassResponsibility 
+]
+
+{ #category : #operations }
 SDLAbstractPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
 
 	self subclassResponsibility

--- a/src/OSWindow-SDL2/SDLNullPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLNullPlatform.class.st
@@ -8,6 +8,12 @@ Class {
 }
 
 { #category : #operations }
+SDLNullPlatform >> afterMainPharoWindowCreated: aOSSDLWindow [
+
+
+]
+
+{ #category : #operations }
 SDLNullPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
 ]
 

--- a/src/OSWindow-SDL2/SDLOSXPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPlatform.class.st
@@ -8,6 +8,11 @@ Class {
 }
 
 { #category : #operations }
+SDLOSXPlatform >> afterMainPharoWindowCreated: aOSSDLWindow [
+
+]
+
+{ #category : #operations }
 SDLOSXPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
 
 	| aParam cocoaWindow wmInfo selector |

--- a/src/OSWindow-SDL2/SDLWindowsPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLWindowsPlatform.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'OSWindow-SDL2-Bindings'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #operations }
 SDLWindowsPlatform class >> enableDebugWindowMenu: hwnd [
 
 	self ffiCall: #(int enableDebugWindowMenu(void* hwnd)) module: 'PharoVMCore.dll'

--- a/src/OSWindow-SDL2/SDLWindowsPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLWindowsPlatform.class.st
@@ -7,6 +7,24 @@ Class {
 	#category : #'OSWindow-SDL2-Bindings'
 }
 
+{ #category : #'as yet unclassified' }
+SDLWindowsPlatform class >> enableDebugWindowMenu: hwnd [
+
+	self ffiCall: #(int enableDebugWindowMenu(void* hwnd)) module: 'PharoVMCore.dll'
+]
+
+{ #category : #operations }
+SDLWindowsPlatform >> afterMainPharoWindowCreated: aOSSDLWindow [
+
+	| sdlWindowInfo handle |
+	[	sdlWindowInfo := aOSSDLWindow backendWindow getWMInfo.
+		handle := sdlWindowInfo info win window.
+
+		self class enableDebugWindowMenu: handle ] 
+	onErrorDo: [ 
+		"There was an error installing the support for debug Window, the VM is not new enough." ].
+]
+
 { #category : #operations }
 SDLWindowsPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
 ]


### PR DESCRIPTION
Adding hook to configure additional options in Windows.
This might fail if the VM is not prepared, so it is handling that scenario.
Part of pharo-project/opensmalltalk-vm#125