### PR TITLE
Fix invalid (non-Boolean) return when CPU watcher is enabled

### DIFF
--- a/src/Tool-ProcessBrowser/ProcessBrowser.class.st
+++ b/src/Tool-ProcessBrowser/ProcessBrowser.class.st
@@ -56,9 +56,9 @@ Class {
 		'autoUpdateProcess',
 		'deferredMessageRecipient',
 		'lastUpdate',
-		'startedCPUWatcher',
 		'keyEventsDict',
-		'textModel'
+		'textModel',
+		'cpuWatcherMonitoring'
 	],
 	#classVars : [
 		'SuspendedProcesses',
@@ -585,6 +585,13 @@ ProcessBrowser >> doItReceiver [
 	^selectedContext ifNil: [ selectedProcess ] ifNotNil: [ selectedContext receiver ]
 ]
 
+{ #category : #initialization }
+ProcessBrowser >> ensureCPUWatcherMonitoring [
+
+	self startCPUWatcher.
+	^ true
+]
+
 { #category : #'stack list' }
 ProcessBrowser >> exploreContext [
 	selectedContext inspect
@@ -645,7 +652,7 @@ ProcessBrowser >> initialize [
 	searchString := ''.
 	lastUpdate := 0.
 	textModel :=  RubScrolledTextModel new interactionModel: self; yourself.
-	startedCPUWatcher := CPUWatcher cpuWatcherEnabled and: [ self startCPUWatcher ].
+	cpuWatcherMonitoring := CPUWatcher cpuWatcherEnabled and: [ self ensureCPUWatcherMonitoring ].
 	self updateProcessList; processListIndex: 1
 ]
 
@@ -713,7 +720,7 @@ ProcessBrowser >> keyEventsDict [
 
 { #category : #initialization }
 ProcessBrowser >> mayBeStartCPUWatcher [
-	startedCPUWatcher ifTrue: [ self setUpdateCallbackAfter: 7 ].
+	cpuWatcherMonitoring ifTrue: [ self setUpdateCallbackAfter: 7 ].
 
 ]
 
@@ -1007,13 +1014,11 @@ ProcessBrowser >> startAutoUpdate [
 
 { #category : #initialization }
 ProcessBrowser >> startCPUWatcher [
-	"Answers whether I started the CPUWatcher"
 
-	CPUWatcher isMonitoring
-		ifFalse: [ 
-					CPUWatcher startMonitoringPeriod: 5 rate: 100 threshold: 0.85.
-					self setUpdateCallbackAfter: 7.
-					^ true ]
+	CPUWatcher isMonitoring ifTrue: [ ^ self ].
+
+	CPUWatcher startMonitoringPeriod: 5 rate: 100 threshold: 0.85.
+	self setUpdateCallbackAfter: 7
 ]
 
 { #category : #updating }
@@ -1029,7 +1034,7 @@ ProcessBrowser >> stopCPUWatcher [
 
 	CPUWatcher stopMonitoring.
 	self updateProcessList.
-	startedCPUWatcher := false	"so a manual restart won't be killed later" 
+	cpuWatcherMonitoring := false	"so a manual restart won't be killed later" 
 ]
 
 { #category : #'process actions' }
@@ -1127,5 +1132,5 @@ ProcessBrowser >> wasProcessSuspendedByProcessBrowser: aProcess [
 
 { #category : #initialization }
 ProcessBrowser >> windowIsClosing [
-	startedCPUWatcher ifTrue: [ CPUWatcher stopMonitoring ]
+	cpuWatcherMonitoring ifTrue: [ CPUWatcher stopMonitoring ]
 ]


### PR DESCRIPTION
Hi lovely Pharo people!

Upon discovering and enabling the CPU watcher system setting, I encountered an error where the ProcessBrowser instance variable #startedCPUWatcher was an instance of self instead of a Boolean.

The cause was the code in the process browser initialization logic. Considering that the variable and method names were somewhat confusing, I decided to rename the variable and refactor the method, to make the names more consistent with the behavior.

This is for Pharo 8.0, since we still actively use that for development. However, the Pharo 9/10 code seems to be identical, so this can be ported forward.

Best,
Jonathan