### PR TITLE
[P9] 10085-Pharo-does-not-work-on-network-drive-on-Windows

### DIFF
--- a/src/FileSystem-Disk/WindowsStore.class.st
+++ b/src/FileSystem-Disk/WindowsStore.class.st
@@ -237,7 +237,7 @@ WindowsStore >> pathFromString: aString [
 	
 	
 	pathClass := (normalized beginsWith: '\\')
-		ifTrue: [ NetworkPath ]
+		ifTrue: [ UNCNetworkPath ]
 		ifFalse: [  
 			(Path isAbsoluteWindowsPath: normalized)
 				ifTrue: [ (normalized = self delimiter asString) ifTrue: [ pathElements := { ':' } ].

--- a/src/FileSystem-Disk/WindowsStore.class.st
+++ b/src/FileSystem-Disk/WindowsStore.class.st
@@ -234,11 +234,17 @@ WindowsStore >> pathFromString: aString [
 	| normalized pathClass pathElements |
 	normalized := aString copy replaceAll: UnixStore delimiter with: self delimiter.
 	pathElements := self delimiter split: normalized.
-	pathClass := (Path isAbsoluteWindowsPath: normalized)
-		ifTrue: [ (normalized = self delimiter asString) ifTrue: [ pathElements := { ':' } ].
-			AbsolutePath ]
-		ifFalse: [ self stripDrive: pathElements.
-			RelativePath ].
+	
+	
+	pathClass := (normalized beginsWith: '\\')
+		ifTrue: [ NetworkPath ]
+		ifFalse: [  
+			(Path isAbsoluteWindowsPath: normalized)
+				ifTrue: [ (normalized = self delimiter asString) ifTrue: [ pathElements := { ':' } ].
+					AbsolutePath ]
+				ifFalse: [ self stripDrive: pathElements.
+					RelativePath ]].
+			
 	^pathClass withAll: pathElements
 ]
 
@@ -253,8 +259,13 @@ WindowsStore >> permissions: aPath [
 { #category : #converting }
 WindowsStore >> printPath: aPath on: aStream [
 	| hasDrive |
+
+	aPath isNetworkPath
+		ifTrue: [ ^ aPath printOn: aStream delimiter: self delimiter ].
+
 	aPath isRoot
 		ifTrue: [ ^ self ].	"effectively Windows root is empty string"
+
 	aPath isWorkingDirectory
 		ifTrue: [ ^ aPath printOn: aStream delimiter: self delimiter ].
 	aPath isRelative

--- a/src/FileSystem-Path/NetworkPath.class.st
+++ b/src/FileSystem-Path/NetworkPath.class.st
@@ -1,0 +1,68 @@
+"
+I am a path to express UNC paths e.g.,	
+	#( '\\MachineName.x.y.z\directory\file' '\\MachineName.x.y.z\directory' '\\MachineName.x.y.z' ) .
+
+This is useful to represent files in SMB shares as used by Windows or Samba.
+
+A NetworkPath acts as an absolute path but with a different translation to string.
+"
+Class {
+	#name : #NetworkPath,
+	#superclass : #Path,
+	#type : #variable,
+	#category : #'FileSystem-Path-Base'
+}
+
+{ #category : #testing }
+NetworkPath >> isAbsolute [
+	
+	^ true
+]
+
+{ #category : #testing }
+NetworkPath >> isNetworkPath [
+
+	^ true
+]
+
+{ #category : #testing }
+NetworkPath >> isRoot [
+	
+	"A network path is a root if it only has the machine name, it is of the form \\machine"
+	^ self size = 1.
+]
+
+{ #category : #printing }
+NetworkPath >> printOn: aStream [
+	aStream nextPutAll: 'Path ''//'. 
+	
+	self segments do: [ :e | aStream nextPutAll: e ]
+		separatedBy: [ aStream nextPutAll: '/' ].
+
+	aStream nextPut: $'.
+	
+]
+
+{ #category : #printing }
+NetworkPath >> printOn: aStream delimiter: aCharacter [
+
+	aStream nextPut: aCharacter.
+	aStream nextPut: aCharacter.
+	super printOn: aStream delimiter: aCharacter
+]
+
+{ #category : #printing }
+NetworkPath >> printPathOn: aStream delimiter: aCharacter [
+	"Print the path elements of the receiver, without the 'Path *' part"
+
+	aStream nextPut: aCharacter.
+	aStream nextPut: aCharacter.
+	super printPathOn: aStream delimiter: aCharacter
+
+]
+
+{ #category : #enumerating }
+NetworkPath >> withParents [
+
+	^ super withParents
+]

--- a/src/FileSystem-Path/Path.class.st
+++ b/src/FileSystem-Path/Path.class.st
@@ -117,7 +117,10 @@ Path class >> from: aString delimiter: aDelimiterCharacter [
 	
 	pathClass :=  ((self isAbsolutePath: aString delimiter: aDelimiterCharacter) or: 
 							[self isAbsoluteWindowsPath: aString]) 
-		ifTrue: [ AbsolutePath ]
+		ifTrue: [ 
+			((aString size >= 2) and: [ aString second = aDelimiterCharacter ])
+				ifTrue: [ NetworkPath ]
+				ifFalse: [AbsolutePath] ]
 		ifFalse:[ RelativePath ].
 	
 	^ pathClass withAll: (aDelimiterCharacter split: aString)
@@ -127,7 +130,7 @@ Path class >> from: aString delimiter: aDelimiterCharacter [
 Path class >> isAbsolutePath: aString delimiter: aCharacter [
 	"Answer a boolean indicating whether the supplied path is considered absolute"
 
-	^aString first = aCharacter
+	^ aString first = aCharacter
 ]
 
 { #category : #private }
@@ -137,12 +140,15 @@ Path class >> isAbsoluteUnixPath: aString [
 
 { #category : #private }
 Path class >> isAbsoluteWindowsPath: aString [
-	aString ifEmpty: [ ^ false ].
-	(aString first = $\) ifTrue: [ ^ true ]. "e.g. \file"
-	^ ((aString size > 2) and: [ aString first isLetter ])
-		ifTrue: [ (aString second = $:) and: [aString third = $\] ] "e.g. C:\..."
-		ifFalse: [ false ]
 
+	aString ifEmpty: [ ^ false ].
+	(aString first = $\ and: [ 
+		 aString size = 1 or: [ aString second ~= $\ ] ]) ifTrue: [ ^ true ]. "e.g. \file"
+
+	^ (aString size > 2 and: [ aString first isLetter ])
+		  ifTrue: [ "e.g. C:\..." 
+		  aString second = $: and: [ aString third = $\ ] ]
+		  ifFalse: [ false ]
 ]
 
 { #category : #'instance creation' }
@@ -415,6 +421,12 @@ Path >> isContainedBy: anObject [
 { #category : #testing }
 Path >> isEmpty [
 	^ self size = 0
+]
+
+{ #category : #testing }
+Path >> isNetworkPath [
+
+	^ false
 ]
 
 { #category : #testing }

--- a/src/FileSystem-Path/Path.class.st
+++ b/src/FileSystem-Path/Path.class.st
@@ -119,7 +119,7 @@ Path class >> from: aString delimiter: aDelimiterCharacter [
 							[self isAbsoluteWindowsPath: aString]) 
 		ifTrue: [ 
 			((aString size >= 2) and: [ aString second = aDelimiterCharacter ])
-				ifTrue: [ NetworkPath ]
+				ifTrue: [ UNCNetworkPath ]
 				ifFalse: [AbsolutePath] ]
 		ifFalse:[ RelativePath ].
 	

--- a/src/FileSystem-Path/UNCNetworkPath.class.st
+++ b/src/FileSystem-Path/UNCNetworkPath.class.st
@@ -7,33 +7,33 @@ This is useful to represent files in SMB shares as used by Windows or Samba.
 A NetworkPath acts as an absolute path but with a different translation to string.
 "
 Class {
-	#name : #NetworkPath,
+	#name : #UNCNetworkPath,
 	#superclass : #Path,
 	#type : #variable,
 	#category : #'FileSystem-Path-Base'
 }
 
 { #category : #testing }
-NetworkPath >> isAbsolute [
+UNCNetworkPath >> isAbsolute [
 	
 	^ true
 ]
 
 { #category : #testing }
-NetworkPath >> isNetworkPath [
+UNCNetworkPath >> isNetworkPath [
 
 	^ true
 ]
 
 { #category : #testing }
-NetworkPath >> isRoot [
+UNCNetworkPath >> isRoot [
 	
 	"A network path is a root if it only has the machine name, it is of the form \\machine"
 	^ self size = 1.
 ]
 
 { #category : #printing }
-NetworkPath >> printOn: aStream [
+UNCNetworkPath >> printOn: aStream [
 	aStream nextPutAll: 'Path ''//'. 
 	
 	self segments do: [ :e | aStream nextPutAll: e ]
@@ -44,7 +44,7 @@ NetworkPath >> printOn: aStream [
 ]
 
 { #category : #printing }
-NetworkPath >> printOn: aStream delimiter: aCharacter [
+UNCNetworkPath >> printOn: aStream delimiter: aCharacter [
 
 	aStream nextPut: aCharacter.
 	aStream nextPut: aCharacter.
@@ -52,7 +52,7 @@ NetworkPath >> printOn: aStream delimiter: aCharacter [
 ]
 
 { #category : #printing }
-NetworkPath >> printPathOn: aStream delimiter: aCharacter [
+UNCNetworkPath >> printPathOn: aStream delimiter: aCharacter [
 	"Print the path elements of the receiver, without the 'Path *' part"
 
 	aStream nextPut: aCharacter.
@@ -62,7 +62,7 @@ NetworkPath >> printPathOn: aStream delimiter: aCharacter [
 ]
 
 { #category : #enumerating }
-NetworkPath >> withParents [
+UNCNetworkPath >> withParents [
 
 	^ super withParents
 ]

--- a/src/FileSystem-Tests-Core/PathTest.class.st
+++ b/src/FileSystem-Tests-Core/PathTest.class.st
@@ -363,7 +363,7 @@ PathTest >> testMakeRelativeFrom2RelativePaths [
 { #category : #tests }
 PathTest >> testNetworkPathWithParents [
 	| path allPaths |
-	path := NetworkPath withAll: #('machine' 'plonk' 'griffle' 'nurb').
+	path := UNCNetworkPath withAll: #('machine' 'plonk' 'griffle' 'nurb').
 	allPaths := path withParents.
 	
 	self assert: allPaths size equals: 4.

--- a/src/FileSystem-Tests-Core/PathTest.class.st
+++ b/src/FileSystem-Tests-Core/PathTest.class.st
@@ -361,6 +361,28 @@ PathTest >> testMakeRelativeFrom2RelativePaths [
 ]
 
 { #category : #tests }
+PathTest >> testNetworkPathWithParents [
+	| path allPaths |
+	path := NetworkPath withAll: #('machine' 'plonk' 'griffle' 'nurb').
+	allPaths := path withParents.
+	
+	self assert: allPaths size equals: 4.
+	self assert: allPaths first isRoot.
+	self assert: allPaths second basename equals: 'plonk'.
+	self assert: allPaths second size equals: 2.
+	self assert: (allPaths second isChildOf: allPaths first).
+	self assert: allPaths third basename equals: 'griffle'.
+	self assert: allPaths third size equals: 3.
+	self assert: (allPaths third isChildOf: allPaths second).
+	self assert: allPaths fourth basename equals: 'nurb'.
+	self assert: allPaths fourth size equals: 4.
+	self assert: (allPaths fourth isChildOf: allPaths third).
+	
+	self assert: allPaths fourth equals: path.
+	self assert: allPaths fourth identicalTo: path
+]
+
+{ #category : #tests }
 PathTest >> testParent [
 	| path parent |
 	path := (Path * 'plonk') / 'griffle'.
@@ -422,6 +444,19 @@ PathTest >> testParseBogus [
 	self assert: path size equals: 2.
 	self assert: (path at: 1) equals: 'parent?<>~ \child'.
 	self assert: (path at: 2) equals: 'grandChild'
+	
+
+]
+
+{ #category : #tests }
+PathTest >> testParseNetworkPath [
+
+	| path |
+	path := Path from: '//parent/child/grandChild' delimiter: $/.
+	self assert: path size equals: 3.
+	self assert: (path at: 1) equals: 'parent'.
+	self assert: (path at: 2) equals: 'child'.
+	self assert: (path at: 3) equals: 'grandChild'
 	
 
 ]
@@ -494,6 +529,19 @@ PathTest >> testPrintPathOnDelimiter [
 	"Test an Absolute path"
 	"Use an unusal delimiter to check that the default isn't hardcoded anywhere"
 	pathSrc := '|one|two|three'.
+	path := Path from: pathSrc delimiter: $|.
+	self assert: path isAbsolute.
+	pathString := String streamContents: [ :stream | path printPathOn: stream delimiter: $| ].
+	self assert: pathSrc equals: pathString
+]
+
+{ #category : #tests }
+PathTest >> testPrintPathOnDelimiterOnNetworkDrive [
+
+
+	"Use an unusal delimiter to check that the default isn't hardcoded anywhere"
+	| pathSrc path pathString |
+	pathSrc := '||one|two|three'.
 	path := Path from: pathSrc delimiter: $|.
 	self assert: path isAbsolute.
 	pathString := String streamContents: [ :stream | path printPathOn: stream delimiter: $| ].

--- a/src/FileSystem-Tests-Disk/WindowsStoreTest.class.st
+++ b/src/FileSystem-Tests-Disk/WindowsStoreTest.class.st
@@ -51,7 +51,7 @@ WindowsStoreTest >> testNetworkPathFullName [
 WindowsStoreTest >> testNetworkPathIsAbsolute [
 
 		#( '\\MachineName.x.y.z\directory\file' '\\MachineName.x.y.z\directory' '\\MachineName.x.y.z' )  do: [:each |
-		self assert: (WindowsStore current pathFromString: each) isAbsolute ] 
+		self assert: (WindowsStore new pathFromString: each) isAbsolute ] 
 	
 ]
 

--- a/src/FileSystem-Tests-Disk/WindowsStoreTest.class.st
+++ b/src/FileSystem-Tests-Disk/WindowsStoreTest.class.st
@@ -32,6 +32,30 @@ WindowsStoreTest >> testAbsolutePath [
 ]
 
 { #category : #testing }
+WindowsStoreTest >> testNetworkPathFullName [
+	| filesystem |
+	filesystem := FileSystem store: WindowsStore new.
+
+	"Check dropping trailing slash."	
+	self assert: (filesystem referenceTo: '\\MachineName.x.y.z\directory\file') fullName equals: '\\MachineName.x.y.z\directory\file'.
+
+	"Check round-trip conversion from String to FileReference back to String again."
+	#( '\\MachineName.x.y.z\directory\file' '\\MachineName.x.y.z\directory' '\\MachineName.x.y.z' ) 
+		do: [ :pathString | self assert: (filesystem referenceTo: pathString) fullName equals: pathString ].
+	
+	
+
+]
+
+{ #category : #testing }
+WindowsStoreTest >> testNetworkPathIsAbsolute [
+
+		#( '\\MachineName.x.y.z\directory\file' '\\MachineName.x.y.z\directory' '\\MachineName.x.y.z' )  do: [:each |
+		self assert: (WindowsStore current pathFromString: each) isAbsolute ] 
+	
+]
+
+{ #category : #testing }
 WindowsStoreTest >> testPrintString [
 	| filesystem |
 	filesystem := FileSystem store: WindowsStore new.

--- a/src/MonticelloFileTree-Core/MCFileTreeRepository.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeRepository.class.st
@@ -110,6 +110,9 @@ MCFileTreeRepository class >> urlAsFileReference: aZnUrl [
 			aZnUrl pathSegments copyWithFirst: aZnUrl host ]
 		ifNil: [ aZnUrl pathSegments].
 
+	(path ifNotEmpty: [ path first = #'.' or: [ path first = #'..' ] ])
+		ifTrue: [ ^ (RelativePath withAll: path) asFileReference ].
+
 	^ (AbsolutePath withAll: path) asFileReference 
 ]
 

--- a/src/MonticelloFileTree-Core/MCFileTreeRepository.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeRepository.class.st
@@ -108,13 +108,9 @@ MCFileTreeRepository class >> urlAsFileReference: aZnUrl [
 			((aZnUrl host = #/) and: [ aZnUrl pathSegments isEmpty ])
 				ifTrue: [ ^ FileSystem root ].
 			aZnUrl pathSegments copyWithFirst: aZnUrl host ]
-		ifNil: [ aZnUrl pathSegments copyWithFirst: FileSystem disk delimiter asString ].
-	^ (String streamContents: 
-			[ :stream | 
-			path 
-				asStringOn: stream 
-				delimiter: FileSystem disk delimiter asString ])
-		asFileReference
+		ifNil: [ aZnUrl pathSegments].
+
+	^ (AbsolutePath withAll: path) asFileReference 
 ]
 
 { #category : #accessing }

--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -13,6 +13,12 @@ NoUnusedVariablesLeftTest class >> defaultTimeLimit [
 	^ 2 minute
 ]
 
+{ #category : #accessing }
+NoUnusedVariablesLeftTest >> defaultTimeLimit [ 
+
+	^ 30 seconds
+]
+
 { #category : #testing }
 NoUnusedVariablesLeftTest >> testNoUnusedClassVariablesLeft [
 	| variables classes validExceptions remaining |


### PR DESCRIPTION
Adding support for UNC Network paths.
They are required to correctly support window shares (SMB).