### PR TITLE
Provide Autofix for ReProperMethodProtocolNameRule

### DIFF
--- a/src/Renraku/ReProperMethodProtocolNameForAccessingRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameForAccessingRule.class.st
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #idioms }
-ReProperMethodProtocolNameForAccessingRule >> protocolIdiom [ 
+ReProperMethodProtocolNameForAccessingRule class >> protocolIdiom [ 
 
 	^self use: 'accessing' insteadOf: #('accessor' 'accessors' 'acessing' 'acccessing' 'accesing' 'acesing')
 ]

--- a/src/Renraku/ReProperMethodProtocolNameForConvertingRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameForConvertingRule.class.st
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #idioms }
-ReProperMethodProtocolNameForConvertingRule >> protocolIdiom [ 
+ReProperMethodProtocolNameForConvertingRule class >> protocolIdiom [ 
 
 	^self use: 'converting' insteadOf: #('conversion' 'conversions')
 ]

--- a/src/Renraku/ReProperMethodProtocolNameForInstanceCreationRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameForInstanceCreationRule.class.st
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #idioms }
-ReProperMethodProtocolNameForInstanceCreationRule >> protocolIdiom [ 
+ReProperMethodProtocolNameForInstanceCreationRule class >> protocolIdiom [ 
 
 	^self use: 'instance creation' insteadOf: #('instance-creation' 'instances-creation' 'instances creation')
 ]

--- a/src/Renraku/ReProperMethodProtocolNameForTestsRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameForTestsRule.class.st
@@ -7,15 +7,15 @@ Class {
 	#category : #'Renraku-Rules'
 }
 
+{ #category : #idioms }
+ReProperMethodProtocolNameForTestsRule class >> protocolIdiom [ 
+
+	^self use: 'tests' insteadOf: #('test')
+]
+
 { #category : #running }
 ReProperMethodProtocolNameForTestsRule >> basicCheck: aMethod [
 	"We only check for SUnit test methods"
 	
-	^ aMethod isTestMethod and: [ self badMethodProtocolNames includes: aMethod category ]
-]
-
-{ #category : #idioms }
-ReProperMethodProtocolNameForTestsRule >> protocolIdiom [ 
-
-	^self use: 'tests' insteadOf: #('test')
+	^ aMethod isTestMethod and: [ self class badMethodProtocolNames includes: aMethod category ]
 ]

--- a/src/Renraku/ReProperMethodProtocolNameForUtilitiesRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameForUtilitiesRule.class.st
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #idioms }
-ReProperMethodProtocolNameForUtilitiesRule >> protocolIdiom [ 
+ReProperMethodProtocolNameForUtilitiesRule class >> protocolIdiom [ 
 
 	^self use: 'utilities' insteadOf: #('utils' 'utility')
 ]

--- a/src/Renraku/ReProperMethodProtocolNameRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameRule.class.st
@@ -7,8 +7,17 @@ Subclasses should override #protocolIdiom to return an association of a good pro
 Class {
 	#name : #ReProperMethodProtocolNameRule,
 	#superclass : #ReAbstractRule,
+	#instVars : [
+		'methodProtocolName'
+	],
 	#category : #'Renraku-Rules'
 }
+
+{ #category : #'private - accessing' }
+ReProperMethodProtocolNameRule class >> badMethodProtocolNames [
+
+	^self protocolIdiom value collect: [:each | each asSymbol]
+]
 
 { #category : #'testing - interest' }
 ReProperMethodProtocolNameRule class >> checksMethod [
@@ -17,10 +26,24 @@ ReProperMethodProtocolNameRule class >> checksMethod [
 	^ self name ~= #ReProperMethodProtocolNameRule
 ]
 
+{ #category : #'private - accessing' }
+ReProperMethodProtocolNameRule class >> goodMethodProtocolName [
+
+	^self protocolIdiom key printString
+]
+
 { #category : #testing }
 ReProperMethodProtocolNameRule class >> isAbstract [
 
 	^ self == ReProperMethodProtocolNameRule
+]
+
+{ #category : #idioms }
+ReProperMethodProtocolNameRule class >> protocolIdiom [
+	"Subclasses should override to return an association between a
+	 wished category and an array of category names that are not so good."
+ 
+	^self subclassResponsibility
 ]
 
 { #category : #'private - utilities' }
@@ -31,21 +54,23 @@ ReProperMethodProtocolNameRule class >> use: valid insteadOf: arrayOfInvalid [
 	^valid -> arrayOfInvalid 
 ]
 
-{ #category : #'private - accessing' }
-ReProperMethodProtocolNameRule >> badMethodProtocolNames [
-
-	^self protocolIdiom value collect: [:each | each asSymbol]
-]
-
 { #category : #running }
 ReProperMethodProtocolNameRule >> basicCheck: aMethod [
-	^ self badMethodProtocolNames includes: aMethod category
+	self methodProtocolName: aMethod category.
+	^ self class badMethodProtocolNames includes: aMethod category
 ]
 
-{ #category : #'private - accessing' }
-ReProperMethodProtocolNameRule >> goodMethodProtocolName [
-
-	^self protocolIdiom key printString
+{ #category : #helpers }
+ReProperMethodProtocolNameRule >> critiqueFor: aMethod [
+	| proposedCategory |
+	proposedCategory := self class goodMethodProtocolName.
+		
+	^ (ReRefactoringCritique
+		   withAnchor: (self anchorFor: aMethod)
+		   by: self) refactoring: (RBMethodProtocolTransformation
+			   protocol: { proposedCategory }
+			   inMethod: aMethod selector
+			   inClass: aMethod methodClass name) asRefactoring
 ]
 
 { #category : #accessing }
@@ -55,28 +80,30 @@ ReProperMethodProtocolNameRule >> group [
 ]
 
 { #category : #accessing }
-ReProperMethodProtocolNameRule >> name [
-	
-	^ 'Method categorization: use ', self goodMethodProtocolName, ' as protocol name' 
+ReProperMethodProtocolNameRule >> methodProtocolName [
+
+	^ methodProtocolName
 ]
 
-{ #category : #idioms }
-ReProperMethodProtocolNameRule >> protocolIdiom [
-	"Subclasses should override to return an association between a
-	 wished category and an array of category names that are not so good."
- 
-	^self subclassResponsibility
+{ #category : #accessing }
+ReProperMethodProtocolNameRule >> methodProtocolName: anObject [
+
+	methodProtocolName := anObject
+]
+
+{ #category : #accessing }
+ReProperMethodProtocolNameRule >> name [
+
+	^ 'Method categorization: use ' 
+		  	, self class goodMethodProtocolName
+  	  		, ' as protocol name instead of '''
+	  		, self methodProtocolName asString , ''''
 ]
 
 { #category : #accessing }
 ReProperMethodProtocolNameRule >> rationale [
+
 	^ 'Check if the method protocol name is appropriate and fulfils common expectations.'
-]
-
-{ #category : #accessing }
-ReProperMethodProtocolNameRule >> severity [
-
-	^ #information
 ]
 
 { #category : #'private - utilities' }

--- a/src/Renraku/ReProperMethodProtocolNameRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameRule.class.st
@@ -16,7 +16,7 @@ Class {
 { #category : #'private - accessing' }
 ReProperMethodProtocolNameRule class >> badMethodProtocolNames [
 
-	^self protocolIdiom value collect: [:each | each asSymbol]
+	^self protocolIdiom value collect: [:each | each asSymbol ]
 ]
 
 { #category : #'testing - interest' }
@@ -29,7 +29,7 @@ ReProperMethodProtocolNameRule class >> checksMethod [
 { #category : #'private - accessing' }
 ReProperMethodProtocolNameRule class >> goodMethodProtocolName [
 
-	^self protocolIdiom key printString
+	^self protocolIdiom key
 ]
 
 { #category : #testing }
@@ -63,7 +63,7 @@ ReProperMethodProtocolNameRule >> basicCheck: aMethod [
 { #category : #helpers }
 ReProperMethodProtocolNameRule >> critiqueFor: aMethod [
 	| proposedCategory |
-	proposedCategory := self class goodMethodProtocolName.
+	proposedCategory := self class goodMethodProtocolName asSymbol.
 		
 	^ (ReRefactoringCritique
 		   withAnchor: (self anchorFor: aMethod)
@@ -94,9 +94,9 @@ ReProperMethodProtocolNameRule >> methodProtocolName: anObject [
 { #category : #accessing }
 ReProperMethodProtocolNameRule >> name [
 
-	^ 'Method categorization: use ' 
+	^ 'Method categorization: use ''' 
 		  	, self class goodMethodProtocolName
-  	  		, ' as protocol name instead of '''
+  	  		, ''' as protocol name instead of '''
 	  		, self methodProtocolName asString , ''''
 ]
 


### PR DESCRIPTION
Fix #10139 
- remove "information" severity (so that the default "warning" is used)
- improve the lint message by shown current and suggested protocol name
- provide an autofix so code can easily repaired to follow lint rul
- move all #protocolIdioms to the class side (so we can later better reuse them in the release tests)