### PR TITLE
10144-SystemNavigationobsoleteClasses-should-use-isObsolete

### DIFF
--- a/src/Kernel-Tests/BehaviorTest.class.st
+++ b/src/Kernel-Tests/BehaviorTest.class.st
@@ -212,7 +212,16 @@ BehaviorTest >> testMethodsWritingSlot [
 { #category : #tests }
 BehaviorTest >> testNonObsoleteClass [
 	"Does it work on not-obsolete classes?"
-	self assert: Object nonObsoleteClass equals: Object
+	self assert: Object nonObsoleteClass equals: Object.
+	"The case for obsolete classes (obtaining the #originalName) is tested 
+	in ObsoleteTest>>#testClassObsolete"
+]
+
+{ #category : #tests }
+BehaviorTest >> testOriginalName [
+	"Does it work on not-obsolete classes?"
+	self assert: Object originalName equals: #Object.
+	"The case for obsolete classes is tested in ObsoleteTest>>#testClassObsolete"
 ]
 
 { #category : #'tests - properties' }

--- a/src/Kernel-Tests/BehaviorTest.class.st
+++ b/src/Kernel-Tests/BehaviorTest.class.st
@@ -209,6 +209,12 @@ BehaviorTest >> testMethodsWritingSlot [
 	self assert: numberViaSlot equals: numberViaIVar
 ]
 
+{ #category : #tests }
+BehaviorTest >> testNonObsoleteClass [
+	"Does it work on not-obsolete classes?"
+	self assert: Object nonObsoleteClass equals: Object
+]
+
 { #category : #'tests - properties' }
 BehaviorTest >> testPropertyValueAtPut [
 	| testValue |

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1268,11 +1268,7 @@ Behavior >> new: sizeRequested [
 Behavior >> nonObsoleteClass [
 	"Attempt to find and return the current version of this obsolete class"
 
-	| obsName |
-	obsName := self name.
-	[obsName beginsWith: 'AnObsolete']
-		whileTrue: [obsName := obsName copyFrom: 'AnObsolete' size + 1 to: obsName size].
-	^ self environment at: obsName asSymbol
+	^ self environment at: self originalName
 ]
 
 { #category : #initialization }
@@ -1286,6 +1282,13 @@ Behavior >> obsoleteSubclasses [
 	| obs |
 	obs := self basicObsoleteSubclasses at: self ifAbsent: [^ #()].
 	^ obs copyWithout: nil
+]
+
+{ #category : #initialization }
+Behavior >> originalName [
+	^ ((self isObsolete and: [ self name beginsWith: 'AnObsolete' ])
+		ifTrue: [ (self name copyFrom:   'AnObsolete' size + 1 to: self name size ) ]
+		ifFalse:  [ self name ]) asSymbol
 ]
 
 { #category : #copying }

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1286,9 +1286,13 @@ Behavior >> obsoleteSubclasses [
 
 { #category : #initialization }
 Behavior >> originalName [
-	^ ((self isObsolete and: [ self name beginsWith: 'AnObsolete' ])
-		ifTrue: [ (self name copyFrom:   'AnObsolete' size + 1 to: self name size ) ]
-		ifFalse:  [ self name ]) asSymbol
+	| obsName |
+	obsName := self name.
+	self isObsolete ifFalse: [ ^obsName asSymbol].
+ 	[obsName beginsWith: 'AnObsolete']
+ 		whileTrue: [obsName := obsName copyFrom: 'AnObsolete' size + 1 to: obsName size].
+	^obsName asSymbol
+
 ]
 
 { #category : #copying }

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -191,7 +191,7 @@ Metaclass >> isMetaclassOfClassOrNil [
 { #category : #testing }
 Metaclass >> isObsolete [
 	"Return true if the receiver is obsolete"
-	^self soleInstance == nil "Either no thisClass"
+	^self soleInstance isNil "Either no thisClass"
 		or:[self soleInstance classSide ~~ self "or I am not the class of thisClass"
 			or:[self soleInstance isObsolete]] "or my instance is obsolete"
 ]

--- a/src/RPackage-Core/Behavior.extension.st
+++ b/src/RPackage-Core/Behavior.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #Behavior }
-
-{ #category : #'*Rpackage-Core' }
-Behavior >> originalName [
-	^ ((self isObsolete and: [ self name beginsWith: 'AnObsolete' ])
-		ifTrue: [ (self name copyFrom:   'AnObsolete' size + 1 to: self name size ) ]
-		ifFalse:  [ self name ]) asSymbol
-]

--- a/src/ReleaseTests/ObsoleteTest.class.st
+++ b/src/ReleaseTests/ObsoleteTest.class.st
@@ -33,14 +33,14 @@ ObsoleteTest >> tearDown [
 { #category : #tests }
 ObsoleteTest >> testClassObsolete [
 	| aClass |
-	testingEnvironment at: #ClassForObsoleteTest ifPresent: [ :cls | cls removeFromSystem ].
 	aClass := classFactory newClass.
 	
 	self deny: aClass isObsolete.
 	self deny: aClass class isObsolete.
 	aClass removeFromSystem.
 	self assert: aClass isObsolete.
-	self assert: aClass class isObsolete
+	self assert: aClass class isObsolete.
+	self assert: (aClass originalName beginsWith: #ClassForTestToBeDeleted).
 ]
 
 { #category : #tests }
@@ -76,9 +76,6 @@ ObsoleteTest >> testFixObsoleteSharedPools [
 { #category : #tests }
 ObsoleteTest >> testTraitObsolete [
 	| aClass aTrait |
-	testingEnvironment at: #ClassForObsoleteTest ifPresent: [ :cls | cls removeFromSystem ].
-	testingEnvironment at: #TraitForObsoleteTest ifPresent: [ :tr | tr removeFromSystem ].
-	
 	aTrait := classFactory newTrait.
 	aClass := classFactory newClassUsing: aTrait.
  

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -368,22 +368,22 @@ SystemNavigation >> obsoleteClasses [
 		allInstancesDo: [ :m | 
 			| c |
 			c := m soleInstance.
-			(c notNil and: [ 'AnOb*' match: c name asString ])
+			(c notNil and: [ c isObsolete ])
 				ifTrue: [ obs add: c ] ].
 	^ obs asArray	
 		
 "Likely in a ClassDict or Pool...
-(Association allInstances select: [:a | (a value isKindOf: Class) and: ['AnOb*' match: a value name]]) asArray
+(Association allInstances select: [:a | (a value isKindOf: Class) and: [a value isObsolete]]) asArray
 "	
 	
 "Obsolete class refs or super pointer in last lit of a method...
 | n l found |
-Smalltalk browseAllSelect:
+SystemNavigation new browseAllSelect:
 	[:m | found := false.
 	1 to: m numLiterals do:
 		[:i | (((l := m literalAt: i) isMemberOf: Association)
 				and: [(l value isKindOf: Behavior)
-				and: ['AnOb*' match: l value name]])
+				and: [l value isObsolete]])
 			ifTrue: [found := true]].
 	found]
 "


### PR DESCRIPTION
- implement obsoleteClasses to use #isObsolete

and some other small cleanups:

- move #originalName from RPackage to kernel
- implement #nonObsoleteClass in terms of #originalName
- add a test


fixes #10144


