### PR TITLE
P9-Backport-PR10099: Added two missing methods #tfPointerAddress

### DIFF
--- a/src/ThreadedFFI/FFIExternalArray.extension.st
+++ b/src/ThreadedFFI/FFIExternalArray.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #FFIExternalArray }
+
+{ #category : #'*ThreadedFFI' }
+FFIExternalArray >> tfPointerAddress [ 
+
+	^ handle tfPointerAddress
+]

--- a/src/ThreadedFFI/FFIExternalValueHolder.extension.st
+++ b/src/ThreadedFFI/FFIExternalValueHolder.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #FFIExternalValueHolder }
+
+{ #category : #'*ThreadedFFI' }
+FFIExternalValueHolder >> tfPointerAddress [ 
+
+	^ data tfPointerAddress
+]


### PR DESCRIPTION
Backporting missing methods added in PR 10099