### PR TITLE
10147-Fix-invalid-non-Boolean-return-when-CPU-watcher-is-enabled-For-P9--P10

### DIFF
--- a/src/Tool-ProcessBrowser/ProcessBrowser.class.st
+++ b/src/Tool-ProcessBrowser/ProcessBrowser.class.st
@@ -56,9 +56,9 @@ Class {
 		'autoUpdateProcess',
 		'deferredMessageRecipient',
 		'lastUpdate',
-		'startedCPUWatcher',
 		'keyEventsDict',
-		'textModel'
+		'textModel',
+		'cpuWatcherMonitoring'
 	],
 	#classVars : [
 		'SuspendedProcesses',
@@ -478,6 +478,13 @@ ProcessBrowser >> doItReceiver [
 	^selectedContext ifNil: [ selectedProcess ] ifNotNil: [ selectedContext receiver ]
 ]
 
+{ #category : #initialization }
+ProcessBrowser >> ensureCPUWatcherMonitoring [
+
+	self startCPUWatcher.
+	^ true
+]
+
 { #category : #'stack list' }
 ProcessBrowser >> exploreContext [
 	selectedContext inspect
@@ -538,7 +545,7 @@ ProcessBrowser >> initialize [
 	searchString := ''.
 	lastUpdate := 0.
 	textModel :=  RubScrolledTextModel new interactionModel: self; yourself.
-	startedCPUWatcher := CPUWatcher cpuWatcherEnabled and: [ self startCPUWatcher ].
+	cpuWatcherMonitoring := CPUWatcher cpuWatcherEnabled and: [ self ensureCPUWatcherMonitoring ].
 	self updateProcessList; processListIndex: 1
 ]
 
@@ -606,7 +613,7 @@ ProcessBrowser >> keyEventsDict [
 
 { #category : #initialization }
 ProcessBrowser >> mayBeStartCPUWatcher [
-	startedCPUWatcher ifTrue: [ self setUpdateCallbackAfter: 7 ].
+	cpuWatcherMonitoring ifTrue: [ self setUpdateCallbackAfter: 7 ]
 
 ]
 
@@ -1068,13 +1075,11 @@ ProcessBrowser >> startAutoUpdate [
 
 { #category : #initialization }
 ProcessBrowser >> startCPUWatcher [
-	"Answers whether I started the CPUWatcher"
 
-	CPUWatcher isMonitoring
-		ifFalse: [ 
-					CPUWatcher startMonitoringPeriod: 5 rate: 100 threshold: 0.85.
-					self setUpdateCallbackAfter: 7.
-					^ true ]
+	CPUWatcher isMonitoring ifTrue: [ ^ self ].
+
+	CPUWatcher startMonitoringPeriod: 5 rate: 100 threshold: 0.85.
+	self setUpdateCallbackAfter: 7
 ]
 
 { #category : #updating }
@@ -1090,7 +1095,7 @@ ProcessBrowser >> stopCPUWatcher [
 
 	CPUWatcher stopMonitoring.
 	self updateProcessList.
-	startedCPUWatcher := false	"so a manual restart won't be killed later" 
+	cpuWatcherMonitoring := false	"so a manual restart won't be killed later" 
 ]
 
 { #category : #'process actions' }
@@ -1188,5 +1193,6 @@ ProcessBrowser >> wasProcessSuspendedByProcessBrowser: aProcess [
 
 { #category : #initialization }
 ProcessBrowser >> windowIsClosing [
-	startedCPUWatcher ifTrue: [ CPUWatcher stopMonitoring ]
+
+	cpuWatcherMonitoring ifTrue: [ CPUWatcher stopMonitoring ]
 ]


### PR DESCRIPTION
Fix #10147