### PR TITLE
10113-speedup-isReferenced-for-ClassVariables-from-a-Pool 

### DIFF
--- a/src/Kernel/ClassVariable.class.st
+++ b/src/Kernel/ClassVariable.class.st
@@ -100,13 +100,12 @@ ClassVariable >> possiblyUsingClasses [
 
 	| classes |
 	classes := self definingClass withAllSubclasses.
-	
+
 	"For pool variables we need to add the poolUsers and it's subclasses"
-	self definingClass isPool ifTrue: [ 
+	self isPoolVariable ifTrue: [ 
 		classes addAll:
-			(self definingClass poolUsers flatCollect: [ :each | 
-				 each withAllSubclasses ]) ].
-	
+			(self definingClass poolUsers flatCollect: [ :each | each withAllSubclasses ]) ].
+
 	"we can access from both the class and the metaclass"
 	classes addAll: (classes collect: [ :class | class class ]).
 	^ classes

--- a/src/Kernel/ClassVariable.class.st
+++ b/src/Kernel/ClassVariable.class.st
@@ -75,11 +75,7 @@ ClassVariable >> isPoolVariable [
 
 { #category : #testing }
 ClassVariable >> isReferenced [
-	"For pools, fall back to the slow full search of all methods"
-	self definingClass isPool ifTrue: [ ^ super isReferenced ].
-	"A class variable can only be accessed in the defintionClass and its subclasses (both class and instance side)"
-	^ self definingClass withAllSubclasses anySatisfy: [ :behavior | 
-		  (behavior class hasMethodAccessingVariable: self) or: [ behavior hasMethodAccessingVariable: self ] ]
+	^ self possiblyUsingClasses anySatisfy: [ :behavior | behavior hasMethodAccessingVariable: self]
 ]
 
 { #category : #testing }
@@ -100,10 +96,23 @@ ClassVariable >> owningClass: anObject [
 ]
 
 { #category : #queries }
+ClassVariable >> possiblyUsingClasses [
+
+	| classes |
+	classes := self definingClass withAllSubclasses.
+	
+	"For pool variables we need to add the poolUsers and it's subclasses"
+	self definingClass isPool ifTrue: [ 
+		classes addAll:
+			(self definingClass poolUsers flatCollect: [ :each | 
+				 each withAllSubclasses ]) ].
+	
+	"we can access from both the class and the metaclass"
+	classes addAll: (classes collect: [ :class | class class ]).
+	^ classes
+]
+
+{ #category : #queries }
 ClassVariable >> usingMethods [
-	"For pools, fall back to the slow full search of all methods"
-	self definingClass isPool ifTrue: [ ^ super usingMethods ].
-	"if we are a class variable, we only need to search the sublasses and metaclasses"
-	^ self definingClass withAllSubclasses flatCollect: [ :class | 
-			(class whichMethodsReferTo: self), (class class whichMethodsReferTo: self) ]
+	^self possiblyUsingClasses flatCollect: [ :class | class whichMethodsReferTo: self ]
 ]

--- a/src/Slot-Tests/ClassVariableTest.class.st
+++ b/src/Slot-Tests/ClassVariableTest.class.st
@@ -87,10 +87,7 @@ ClassVariableTest >> testPossiblyUsingClasses [
 	self assert: (variable possiblyUsingClasses includes: CharacterScanner class).
 	"and subclasses"
 	self assert: (variable possiblyUsingClasses includes: CompositionScanner).
-	self assert: (variable possiblyUsingClasses includes: CompositionScanner class).
-		
-	
-	
+	self assert: (variable possiblyUsingClasses includes: CompositionScanner class)
 ]
 
 { #category : #'tests - properties' }
@@ -152,7 +149,7 @@ ClassVariableTest >> testScope [
 { #category : #tests }
 ClassVariableTest >> testUsingMethods [
 	| variable |
-	"The semantics of where to search is tested as part of #tesPossiblyUsingClasses"
+	"The semantics of where to search is tested as part of #testPossiblyUsingClasses"
 	
 	variable := CharacterScanner classVariableNamed: #CompositionStopConditions.
 	self assert: (variable usingMethods includes: CompositionScanner>>#setStopConditions).
@@ -161,7 +158,6 @@ ClassVariableTest >> testUsingMethods [
 	self assert: variable isPoolVariable.
 	self assert: (variable usingMethods includes: TextConstants class>>#DefaultMarginTabsArray).
 	self assert: (variable usingMethods includes: TextStyle>>#newFontArray:)
-	
 ]
 
 { #category : #'tests - properties' }

--- a/src/Slot-Tests/ClassVariableTest.class.st
+++ b/src/Slot-Tests/ClassVariableTest.class.st
@@ -62,6 +62,37 @@ ClassVariableTest >> testNotWrittenInMethodWhenItIsOnlyRead [
 	self deny: ((TestCase classVariableNamed: #DefaultTimeLimit) isWrittenIn: self class >> testSelector)
 ]
 
+{ #category : #tests }
+ClassVariableTest >> testPossiblyUsingClasses [
+	| variable |
+
+	"this is a normal class var"
+	variable := CharacterScanner classVariableNamed: #CompositionStopConditions.
+
+	"it can be accessed from the class and the meta class"
+	self assert: (variable possiblyUsingClasses includes: CharacterScanner).
+	self assert: (variable possiblyUsingClasses includes: CharacterScanner class).
+	"and subclasses"
+	self assert: (variable possiblyUsingClasses includes: CompositionScanner).
+	self assert: (variable possiblyUsingClasses includes: CompositionScanner class).
+
+	"Pools are more complex"
+	variable := TextConstants classVariableNamed: #Basal.
+	self assert: variable isPoolVariable.
+	"same for pool var: class and meta class of the defining class"
+	self assert: (variable possiblyUsingClasses includes: TextConstants).
+	self assert: (variable possiblyUsingClasses includes: TextConstants class).
+	"but in addition the all the users"
+	self assert: (variable possiblyUsingClasses includes: CharacterScanner).
+	self assert: (variable possiblyUsingClasses includes: CharacterScanner class).
+	"and subclasses"
+	self assert: (variable possiblyUsingClasses includes: CompositionScanner).
+	self assert: (variable possiblyUsingClasses includes: CompositionScanner class).
+		
+	
+	
+]
+
 { #category : #'tests - properties' }
 ClassVariableTest >> testPropertyAtPut [
 
@@ -116,6 +147,21 @@ ClassVariableTest >> testScope [
 	variable := SmalltalkImage classVariableNamed: #CompilerClass.
 	self assert: variable scope equals: SmalltalkImage.
 	self assert: (variable scope lookupVar: variable name) equals: variable
+]
+
+{ #category : #tests }
+ClassVariableTest >> testUsingMethods [
+	| variable |
+	"The semantics of where to search is tested as part of #tesPossiblyUsingClasses"
+	
+	variable := CharacterScanner classVariableNamed: #CompositionStopConditions.
+	self assert: (variable usingMethods includes: CompositionScanner>>#setStopConditions).
+	 
+	variable := TextConstants classVariableNamed: #DefaultMarginTabsArray.
+	self assert: variable isPoolVariable.
+	self assert: (variable usingMethods includes: TextConstants class>>#DefaultMarginTabsArray).
+	self assert: (variable usingMethods includes: TextStyle>>#newFontArray:)
+	
 ]
 
 { #category : #'tests - properties' }


### PR DESCRIPTION
- implement #possiblyUsingClasses for ClassVariable. This returns all classes that the var could be referenced from

- #testPossiblyUsingClasses tests all the possible cases with examples from the image
- #isReferenced and #usingMethods are now using #possiblyUsingClasses to search
- add a dedicated test for #usingMethods

fixes #10113


