### PR TITLE
Cleanup-defaultTimeLimit

### DIFF
--- a/src/FileSystem-Tests-Core/FileSystemTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemTest.class.st
@@ -14,11 +14,6 @@ Class {
 	#category : #'FileSystem-Tests-Core-Base'
 }
 
-{ #category : #accessing }
-FileSystemTest class >> defaultTimeLimit [
-	^10 seconds
-]
-
 { #category : #testing }
 FileSystemTest class >> isAbstract [
 	^ self name = #FileSystemTest

--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -13,12 +13,6 @@ NoUnusedVariablesLeftTest class >> defaultTimeLimit [
 	^ 2 minute
 ]
 
-{ #category : #accessing }
-NoUnusedVariablesLeftTest >> defaultTimeLimit [ 
-
-	^ 30 seconds
-]
-
 { #category : #testing }
 NoUnusedVariablesLeftTest >> testNoUnusedClassVariablesLeft [
 	| variables classes validExceptions remaining |

--- a/src/ReleaseTests/ObsoleteTest.class.st
+++ b/src/ReleaseTests/ObsoleteTest.class.st
@@ -11,7 +11,7 @@ Class {
 }
 
 { #category : #accessing }
-ObsoleteTest >> defaultTimeLimit [ 
+ObsoleteTest class >> defaultTimeLimit [ 
 
 	^ 30 seconds
 ]

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -10,11 +10,6 @@ Class {
 	#category : #'SUnit-Tests-Core'
 }
 
-{ #category : #accessing }
-ClassFactoryForTestCaseTest class >> defaultTimeLimit [
-	^10 seconds
-]
-
 { #category : #history }
 ClassFactoryForTestCaseTest class >> lastStoredRun [
 	^ ((Dictionary new) add: (#passed->((Set new) add: #testDefaultCategoryCleanUp; add: #testPackageCleanUp; add: #testSingleClassCreation; add: #testClassCreationInDifferentCategories; add: #testClassFastCreationInDifferentCategories; add: #testMultipleClassCreation; add: #testSingleClassFastCreation; yourself)); add: (#timeStamp->'22 November 2008 10:11:35 pm'); add: (#failures->((Set new))); add: (#errors->((Set new))); yourself)

--- a/src/SUnit-Tests/ClassFactoryWithOrganizationTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryWithOrganizationTest.class.st
@@ -10,11 +10,6 @@ Class {
 	#category : #'SUnit-Tests-Core'
 }
 
-{ #category : #accessing }
-ClassFactoryWithOrganizationTest class >> defaultTimeLimit [ 
-	^10 seconds
-]
-
 { #category : #testing }
 ClassFactoryWithOrganizationTest >> assertEnvironmentOf: aBehavior [
 	self assert: aBehavior environment equals: self testedEnvironment

--- a/src/Slot-Tests/SlotLayoutEqualityTest.class.st
+++ b/src/Slot-Tests/SlotLayoutEqualityTest.class.st
@@ -4,11 +4,6 @@ Class {
 	#category : #'Slot-Tests-ClassBuilder'
 }
 
-{ #category : #accessing }
-SlotLayoutEqualityTest class >> defaultTimeLimit [
-	^10 seconds
-]
-
 { #category : #helpers }
 SlotLayoutEqualityTest >> assertClassBuiltWith: blockToBuildAClass isEqualToClassBuiltWith: blockToBuildAnotherClass [
 	

--- a/src/Zinc-Zodiac/ZnHTTPSTest.class.st
+++ b/src/Zinc-Zodiac/ZnHTTPSTest.class.st
@@ -13,11 +13,6 @@ Class {
 	#category : #'Zinc-Zodiac'
 }
 
-{ #category : #accessing }
-ZnHTTPSTest class >> defaultTimeLimit [
-	^10 seconds
-]
-
 { #category : #testing }
 ZnHTTPSTest class >> generateTestData: size [
 	"self generateTestData: 1111"


### PR DESCRIPTION
- #defaultTimeLimit is 10 seconds, so we can remove all the methods that set it to 10 seconds.

- unify to override on the class side (just two tests where overriding instance side)
- This fixes a timeout for NoUnusedVariablesLeftTest, which has 2 minutes on the class side but 30 seconds on the instance side.

