### PR TITLE
Refactoring2-Cleanup-parentSuchAs 

### DIFF
--- a/src/Refactoring2-Transformations/RBAddSubtreeTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBAddSubtreeTransformation.class.st
@@ -59,7 +59,7 @@ RBAddSubtreeTransformation >> addNode: aRBNode toSequence: aSequenceNode [
 						node isBlock "special case when a block is empty"
 							ifTrue: [ node body addNode: aRBNode ]
 							ifFalse: [ aSequenceNode addNode: aRBNode before: node ]].
-	^ aSequenceNode parentSuchAs: #isMethod
+	^ aSequenceNode methodNode
 ]
 
 { #category : #api }

--- a/src/Refactoring2-Transformations/RBProgramNode.extension.st
+++ b/src/Refactoring2-Transformations/RBProgramNode.extension.st
@@ -1,9 +1,0 @@
-Extension { #name : #RBProgramNode }
-
-{ #category : #'*Refactoring2-Transformations' }
-RBProgramNode >> parentSuchAs: aPredicateSelector [
-	self flag: #pharoFixMe. "either there is a precondition stating that there is a parent matching or we need to check and return something when there is no parent matching."
-	^ (self parent perform: aPredicateSelector)
-		ifTrue: [ self parent ]
-		ifFalse: [ ^ self parent parentSuchAs: aPredicateSelector ]
-]


### PR DESCRIPTION
Refactoring2 adds a private method parentSuchAs: to RBProgramNode and uses it just once to get the method node of an AST node.

But for that we have #methodNode

- remove #parentSuchAs: (which had a "self flag: #pharoFixMe")
- use #methodNode in RBAddSubtreeTransformation>>#addNode:toSequence:

