### PR TITLE
10065-Cleanup-ClassBuilder-remove-uses

### DIFF
--- a/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
@@ -161,7 +161,7 @@ FluidClassBuilderTest >> testCreateClassWithFullExpandedDefinitionKeepsTheMinimu
 	builder := self class compilerClass new
 		           evaluate: 'Object << #MyClass
 	layout: FixedLayout;
-	uses: {};
+	trait: {};
 	slots: {};
 	sharedVariables: {};
 	tag: '''' ;
@@ -210,7 +210,7 @@ FluidClassBuilderTest >> testInstallMinimalMockClass [
 	builder := self class compilerClass new
 		           evaluate: 'Object << #MyClass
 	layout: FixedLayout;
-	uses: {};
+	trait: {};
 	slots: {};
 	sharedVariables: {};
 	tag: '''' ;

--- a/src/FluidClassBuilder-Tests/FluidTraitBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidTraitBuilderTest.class.st
@@ -64,7 +64,7 @@ FluidTraitBuilderTest >> testInstallMinimalMockClass [
 	[ 
 	builder := self class compilerClass new
 		           evaluate: 'Trait << #TMyClass
-	uses: {};
+	trait: {};
 	slots: {};
 	tag: '''' ;
 	package: ''MyPackage'''.

--- a/src/FluidClassBuilder/FluidClassBuilder.class.st
+++ b/src/FluidClassBuilder/FluidClassBuilder.class.st
@@ -210,9 +210,3 @@ FluidClassBuilder >> traitsToBuild [
 
 	^ traitComposition
 ]
-
-{ #category : #deprecated }
-FluidClassBuilder >> uses: aTraitComposition [
-
-	traitComposition := aTraitComposition
-]

--- a/src/FluidClassBuilder/FluidTraitBuilder.class.st
+++ b/src/FluidClassBuilder/FluidTraitBuilder.class.st
@@ -104,9 +104,3 @@ FluidTraitBuilder >> trait: anArray [
 	"To replace the uses: which will be deprecated"
 	uses := anArray
 ]
-
-{ #category : #deprecated }
-FluidTraitBuilder >> uses: anArray [
-
-	uses := anArray
-]


### PR DESCRIPTION
This PR removes the #uses: method that were in a "deprecated" category.
We can remove them as the builder just needs to support what the *printer* emits. 

fixes #10065


