### PR TITLE
Ring-Cleanup-theNonMetaClass

### DIFF
--- a/src/Ring-Core/RGBehaviorStrategyUser.class.st
+++ b/src/Ring-Core/RGBehaviorStrategyUser.class.st
@@ -365,8 +365,6 @@ RGBehaviorStrategyUser >> storeOn: aStream [
 
 { #category : #accessing }
 RGBehaviorStrategyUser >> theMetaClass [
-	"This method is deprecated so consider to migrate."
-	
 	self
 		deprecated: 'Please use #classSide instead'
 		transformWith: '`@receiver theMetaClass' -> '`@receiver classSide'.
@@ -377,7 +375,10 @@ RGBehaviorStrategyUser >> theMetaClass [
 { #category : #accessing }
 RGBehaviorStrategyUser >> theNonMetaClass [
 
-	^ self behaviorStrategy instanceSide
+	self
+		deprecated: 'Please use #instanceSide instead'
+		transformWith: '`@receiver theNonMetaClass' -> '`@receiver instanceSide'.
+	^self instanceSide
 ]
 
 { #category : #variables }

--- a/src/Ring-Core/RGMetaclassStrategy.class.st
+++ b/src/Ring-Core/RGMetaclassStrategy.class.st
@@ -52,7 +52,7 @@ RGMetaclassStrategy >> category [
 { #category : #'private - backend access' }
 RGMetaclassStrategy >> classVarNames [
 
-	^ self theNonMetaClass classVarNames
+	^ self instanceSide classVarNames
 ]
 
 { #category : #'private - backend access' }

--- a/src/Ring-Core/RGMetaclassTraitV2Strategy.class.st
+++ b/src/Ring-Core/RGMetaclassTraitV2Strategy.class.st
@@ -40,7 +40,7 @@ RGMetaclassTraitV2Strategy >> category [
 { #category : #'private - backend access' }
 RGMetaclassTraitV2Strategy >> classVarNames [
 
-	^ self theNonMetaClass classVarNames
+	^ self instanceSide classVarNames
 ]
 
 { #category : #'private - backend access' }

--- a/src/Ring-Monticello/RGMethod.extension.st
+++ b/src/Ring-Monticello/RGMethod.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #RGMethod }
 RGMethod >> asMCDefinition [
 
 	^ MCMethodDefinition 
-		className: self parent theNonMetaClass name
+		className: self parent instanceSide name
 		classIsMeta: self parent isMeta
 		selector: self name
 		category: self protocol

--- a/src/Ring-Tests-Core/RGBehaviorTest.class.st
+++ b/src/Ring-Tests-Core/RGBehaviorTest.class.st
@@ -77,33 +77,31 @@ RGBehaviorTest >> testResolvingConsistency [
 
 { #category : #tests }
 RGBehaviorTest >> testSiblings [
+
 	| newBehavior |
-	
 	newBehavior := RGClass named: #SomeBehaivor.
 	self assert: newBehavior sibling equals: newBehavior metaclass.
 	self assert: newBehavior baseBehavior equals: newBehavior.
 	self assert: newBehavior instanceSide equals: newBehavior.
-	self assert: newBehavior theNonMetaClass equals: newBehavior.
-	
+	self assert: newBehavior instanceSide equals: newBehavior.
+
 	newBehavior := RGMetaclass named: #SomeBehaivor.
 	self assert: newBehavior sibling equals: newBehavior baseClass.
 	self assert: newBehavior baseBehavior equals: newBehavior baseClass.
 	self assert: newBehavior instanceSide equals: newBehavior baseClass.
-	self assert: newBehavior theNonMetaClass equals: newBehavior baseClass.
+	self assert: newBehavior instanceSide equals: newBehavior baseClass.
 
 	newBehavior := RGTrait named: #SomeBehaivor.
 	self assert: newBehavior sibling equals: newBehavior classTrait.
 	self assert: newBehavior baseBehavior equals: newBehavior.
 	self assert: newBehavior instanceSide equals: newBehavior.
-	self assert: newBehavior theNonMetaClass equals: newBehavior.
+	self assert: newBehavior instanceSide equals: newBehavior.
 
 	newBehavior := RGMetaclassTrait named: #SomeBehaivor.
 	self assert: newBehavior sibling equals: newBehavior baseTrait.
 	self assert: newBehavior baseBehavior equals: newBehavior baseTrait.
 	self assert: newBehavior instanceSide equals: newBehavior baseTrait.
-	self assert: newBehavior theNonMetaClass equals: newBehavior baseTrait.
-
-
+	self assert: newBehavior instanceSide equals: newBehavior baseTrait
 ]
 
 { #category : #tests }

--- a/src/Ring-TraitsV2Support/MetaclassForTraits.extension.st
+++ b/src/Ring-TraitsV2Support/MetaclassForTraits.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #MetaclassForTraits }
 { #category : #'*Ring-TraitsV2Support' }
 MetaclassForTraits >> asRGDefinition [
 
-	^ self theNonMetaClass asRGDefinition theMetaClass
+	^ self instanceSide asRGDefinition theMetaClass
 ]
 
 { #category : #'*Ring-TraitsV2Support' }


### PR DESCRIPTION
This PR deprecates #theNonMetaClass (theMetaClass was already deprecated) and fixes all users

(the only users of theNonMetaClass are now from the Refactoring meta model, see issue #10089 for that)


