### PR TITLE
[P9] backporting-new-iceberg

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -13,7 +13,7 @@ BaselineOfPharo class >> icebergRepository [
 { #category : #versions }
 BaselineOfPharo class >> icebergVersion [
 
-	^ 'v2.0.4'
+	^ 'v2.0.5'
 ]
 
 { #category : #versions }


### PR DESCRIPTION
Updating Iceberg version to 2.0.5, because it has the new version of libgit