### PR TITLE
Use-equivalentTo-ReEquivalentSuperclassMethodsRule 

### DIFF
--- a/src/GeneralRules/ReEquivalentSuperclassMethodsRule.class.st
+++ b/src/GeneralRules/ReEquivalentSuperclassMethodsRule.class.st
@@ -27,7 +27,7 @@ ReEquivalentSuperclassMethodsRule >> basicCheck: aMethod [
 
 	^ aMethod methodClass superclass
 		ifNotNil: [ :superclass | (superclass lookupSelector: aMethod selector)
-			ifNotNil: [ :overridenMethod | aMethod ast = overridenMethod ast ]
+			ifNotNil: [ :overridenMethod | aMethod equivalentTo: overridenMethod ]
 			ifNil: [ false ] ]
 		ifNil: [ false ]
 ]

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -269,12 +269,11 @@ ReleaseTest >> testNoEquivalentSuperclassMethods [
 	methods := methods select: [:method |
 	method methodClass superclass
 		ifNotNil: [ :superclass | (superclass lookupSelector: method selector)
-			ifNotNil: [ :overridenMethod | method ast = overridenMethod ast ]
+			ifNotNil: [ :overridenMethod | method equivalentTo: overridenMethod ]
 			ifNil: [ false ] ]
 		ifNil: [ false ]
 	].
-	self assert: methods size <= 470.
-	ASTCache reset.
+	self assert: methods size <= 369.
 
 
 	"there should be no method left"


### PR DESCRIPTION
This PR changes ReEquivalentSuperclassMethodsRule and testNoEquivalentSuperclassMethods to use #equivalentTo:

 #equivalentTo: in the end compares the AST, too, but it first does some quick checks to avoid that in most
 cases (numArgs and numLiterals).


