### PR TITLE
Enable-SharedLiterals

### DIFF
--- a/src/Kernel-Tests-Extended/WriteBarrierTest.class.st
+++ b/src/Kernel-Tests-Extended/WriteBarrierTest.class.st
@@ -174,14 +174,11 @@ WriteBarrierTest >> testMutateByteStringyUsingByteAtPut [
 { #category : #'tests - object' }
 WriteBarrierTest >> testMutateByteSymbolUsingPrivateAtPut [
 	| guineaPig |
-	[ guineaPig := #hello.
-	guineaPig beReadOnlyObject.
-	
+	guineaPig := #hello.
+	"symbol literals are read-only already, no need to call #beReadOnlyObject"
 	self 
 		should: [ guineaPig privateAt: 1 put: $q  ]
-		raise: ModificationForbidden ]
-	ensure: [  
-		guineaPig beWritableObject ].
+		raise: ModificationForbidden.
 	
 	self assert: guineaPig first equals: $h
 ]
@@ -322,7 +319,7 @@ WriteBarrierTest >> testMutateObjectLastInstVarWithManyVars [
 { #category : #'tests - object' }
 WriteBarrierTest >> testMutateVariableObject [
 	| guineaPigs |
-	guineaPigs := {#[1 2 3] . #(1 2 3)}.
+	guineaPigs := {#[1 2 3] copy . #(1 2 3) copy}.
 	guineaPigs
 		do: [ :guineaPig | 
 			guineaPig beReadOnlyObject.

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -152,7 +152,12 @@ ImageCleaner >> cleanUpProcesses [
 { #category : #'literal sharing' }
 ImageCleaner >> createLiteralTable [
 	literalTable := OCLiteralSet new.
-	self literalsDo: [ :literal :method | literalTable add: literal].
+	self literalsDo: [ :literal :method | literalTable add: literal.
+		"we add all the contentents of the arrays recursively, too"
+		literal isArray ifTrue: [ 
+			literal recursiveDo: [ :each | 
+				(each isSymbol not and: [ each isImmediateObject not and: [each isNotNil]]) 
+					ifTrue: [ literalTable add: each ] ] ] ].
 	"TODO: For now we do not go over nested arrays to use the shared version"
 ]
 

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -112,6 +112,7 @@ ImageCleaner >> cleanUpForRelease [
 	FreeTypeFontProvider current prepareForRelease.	
 	
 	HashedCollection rehashAll.		
+	self shareLiterals.
 	Author reset
 ]
 
@@ -150,7 +151,7 @@ ImageCleaner >> cleanUpProcesses [
 
 { #category : #'literal sharing' }
 ImageCleaner >> createLiteralTable [
-	| allLiterals arrays |
+	| allLiterals |
 	literalTable := Dictionary new.
 	allLiterals := Set new.
 	self literalsDo: [ :literal :method | 
@@ -160,19 +161,7 @@ ImageCleaner >> createLiteralTable [
 			literal recursiveDo: [ :each | 
 				(each isSymbol not and: [ each isImmediateObject not]) 
 					ifTrue: [ allLiterals add: each ] ] ] ].
-		
-
-	"we need to go over all array and unify. as we have all flattend versions already once, we need to do that only for the top level"
-	arrays := allLiterals select: [ :each | each isArray ].
-	arrays do: [ :array |
-			array beWritableObject.
-			array copy do: [ :arrayValue | 
-				(arrayValue  isSymbol not and:  [ arrayValue isImmediateObject not ]) ifTrue:
-				[array
-					at: (array indexOf: arrayValue)
-					put: (allLiterals like: arrayValue)]].
-			array beReadOnlyObject ].
-		
+	"TODO: For now we do not go over nested arrays to use the shared version"
 	allLiterals do: [:each | literalTable at: each put: each]
 ]
 
@@ -236,7 +225,7 @@ ImageCleaner >> removeEmptyPackages [
 
 { #category : #'literal sharing' }
 ImageCleaner >> shareLiterals [
-	"Experimental Image Shrinker: We go over all methods and replace all the literals that are equal by one copy"
+	"We go over all methods and replace all the literals that are equal by one copy"
 	self createLiteralTable.
 	self literalsDo: [ :literal :cm |
 			cm literalAt: (cm indexOfLiteral: literal) put: (literalTable at: literal)  ].

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -151,18 +151,15 @@ ImageCleaner >> cleanUpProcesses [
 
 { #category : #'literal sharing' }
 ImageCleaner >> createLiteralTable [
-	| allLiterals |
-	literalTable := Dictionary new.
-	allLiterals := Set new.
+	literalTable := OCLiteralSet new.
 	self literalsDo: [ :literal :method | 
-		allLiterals add: literal.
+		literal ifNotNil: [literalTable add: literal].
 		"we add all the contentents of the arrays recursively, too"
 		literal isArray ifTrue: [ 
 			literal recursiveDo: [ :each | 
-				(each isSymbol not and: [ each isImmediateObject not]) 
-					ifTrue: [ allLiterals add: each ] ] ] ].
+				(each isSymbol not and: [ each isImmediateObject not and: [each isNotNil]]) 
+					ifTrue: [ literalTable add: each ] ] ] ].
 	"TODO: For now we do not go over nested arrays to use the shared version"
-	allLiterals do: [:each | literalTable at: each put: each]
 ]
 
 { #category : #'literal sharing' }
@@ -228,7 +225,7 @@ ImageCleaner >> shareLiterals [
 	"We go over all methods and replace all the literals that are equal by one copy"
 	self createLiteralTable.
 	self literalsDo: [ :literal :cm |
-			cm literalAt: (cm indexOfLiteral: literal) put: (literalTable at: literal)  ].
+			cm literalAt: (cm indexOfLiteral: literal) put: (literalTable like: literal)  ].
 	self detroyLiteralTable
 		
 

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -152,13 +152,7 @@ ImageCleaner >> cleanUpProcesses [
 { #category : #'literal sharing' }
 ImageCleaner >> createLiteralTable [
 	literalTable := OCLiteralSet new.
-	self literalsDo: [ :literal :method | 
-		literal ifNotNil: [literalTable add: literal].
-		"we add all the contentents of the arrays recursively, too"
-		literal isArray ifTrue: [ 
-			literal recursiveDo: [ :each | 
-				(each isSymbol not and: [ each isImmediateObject not and: [each isNotNil]]) 
-					ifTrue: [ literalTable add: each ] ] ] ].
+	self literalsDo: [ :literal :method | literalTable add: literal].
 	"TODO: For now we do not go over nested arrays to use the shared version"
 ]
 
@@ -184,7 +178,7 @@ ImageCleaner >> literalsDo: aBlock [
 	CompiledCode allSubInstancesDo: [ :cm | 
 		cm literals do: [ :literal | 
 			"Symbols are already shared, we can skip them here"
-			(literal isLiteral and: [literal isSymbol not and: [literal isImmediateObject not]]) 
+			(literal isLiteral and: [literal isSymbol not and: [literal isImmediateObject not and: [literal isNotNil]]]) 
 				ifTrue: [ aBlock value: literal value: cm ] ] ]
 ]
 


### PR DESCRIPTION
This PR enables literal sharing. As part of #cleanUpForRelease:
 -  we create a table with all the literals (even recursing into literal arrays). 
 -  then we make sure that we use this one literal in all methods.

For now, the last step does not recurse into arrays (TBD).


