### PR TITLE
10191-MCClassDefinitionring2LayoutType-misses-Double-layouts

### DIFF
--- a/src/Ring-Monticello/MCClassDefinition.extension.st
+++ b/src/Ring-Monticello/MCClassDefinition.extension.st
@@ -71,6 +71,8 @@ MCClassDefinition >> ring2LayoutType [
 		#ephemeron -> RGEphemeronLayout.
 		#normal -> RGFixedLayout.
 		#weak -> RGWeakLayout.
+		#DoubleByteLayout -> RGDoubleByteLayout.
+		#DoubleWordLayout -> RGDoubleWordLayout
 	}) at: type.		
 
 ]


### PR DESCRIPTION
fixes #1091 by adding the two cases.

