### PR TITLE
10190-Literal-Sharing-unify-nested-arrays

### DIFF
--- a/src/Kernel-Tests/ObjectTest.class.st
+++ b/src/Kernel-Tests/ObjectTest.class.st
@@ -42,7 +42,7 @@ ObjectTest >> testBeRecursivelyReadOnlyObject [
 	self should: [ assoc key: 2 ] raise: ModificationForbidden.
 	self should: [ assoc value key: 2 ] raise: ModificationForbidden.
 	
-	array := #(1 #(1 2)).
+	array := Array with: 1 with: (Array with:1 with: 2).
 	array beRecursivelyReadOnlyObject.
 	self should: [ array at: 1 put: 2 ] raise: ModificationForbidden.
 	self should: [ array second  at: 1 put: 2 ] raise: ModificationForbidden.
@@ -63,7 +63,7 @@ ObjectTest >> testBeRecursivelyWritableObject [
 	self assert: assoc key equals: 2.
 	self assert: assoc value key equals: 2.
 	
-	array := #(1 #(1 2)).
+	array := Array with: 1 with: (Array with:1 with: 2).
 	array beRecursivelyReadOnlyObject.
 	self should: [ array at: 1 put: 2 ] raise: ModificationForbidden.
 	self should: [ array second  at: 1 put: 2 ] raise: ModificationForbidden.

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -151,6 +151,7 @@ ImageCleaner >> cleanUpProcesses [
 
 { #category : #'literal sharing' }
 ImageCleaner >> createLiteralTable [
+	| arrays |
 	literalTable := OCLiteralSet new.
 	self literalsDo: [ :literal :method | literalTable add: literal.
 		"we add all the contentents of the arrays recursively, too"
@@ -158,7 +159,17 @@ ImageCleaner >> createLiteralTable [
 			literal recursiveDo: [ :each | 
 				(each isSymbol not and: [ each isImmediateObject not and: [each isNotNil]]) 
 					ifTrue: [ literalTable add: each ] ] ] ].
-	"TODO: For now we do not go over nested arrays to use the shared version"
+
+	"we need to go over all array and unify. As we have all flattend arrays in the literalTable, we need to only have to iterate it"
+	arrays := literalTable select: [ :each | each isArray ].
+	arrays do: [ :array |
+			array beWritableObject.
+			array copy do: [ :arrayValue | 
+				(arrayValue  isSymbol not and:  [ arrayValue isImmediateObject not ]) ifTrue:
+				[array
+					at: (array indexOf: arrayValue)
+					put: (literalTable like: arrayValue)]].
+			array beReadOnlyObject ].
 ]
 
 { #category : #'literal sharing' }


### PR DESCRIPTION
This impoves literal sharing: unify all the nested arrays using the table that we created.

fixes #10190


