### PR TITLE
Cleanup-hasLinks 

### DIFF
--- a/src/Calypso-SystemPlugins-Reflectivity-Browser-Tests/ClyInstallMetaLinkPresenterTest.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser-Tests/ClyInstallMetaLinkPresenterTest.class.st
@@ -59,9 +59,9 @@ ClyInstallMetaLinkPresenterTest >> testInstallSelectedMetalink [
 	presenter := ClyMetaLinkInstallationPresenter onNode: self nodeInRealMethod forInstallation:  true.
 	list := presenter metalinkListPresenter.
 	list clickItem: 1.
-	self deny: self nodeInRealMethod hasLinks.
+	self deny: self nodeInRealMethod hasMetaLinks.
 	presenter installSelectedMetalink.
-	self assert: self nodeInRealMethod hasLinks.
+	self assert: self nodeInRealMethod hasMetaLinks.
 	self assert: self nodeInRealMethod links asArray first identicalTo: list items first 
 ]
 
@@ -71,9 +71,9 @@ ClyInstallMetaLinkPresenterTest >> testInstallSelectedMetalinkActionButton [
 	presenter := ClyMetaLinkInstallationPresenter onNode: self nodeInRealMethod forInstallation:  true.
 	list := presenter metalinkListPresenter.
 	list clickItem: 1.	
-	self deny: self nodeInRealMethod hasLinks.
+	self deny: self nodeInRealMethod hasMetaLinks.
 	presenter toolbarButtons first click.
-	self assert: self nodeInRealMethod hasLinks.
+	self assert: self nodeInRealMethod hasMetaLinks.
 	self assert: self nodeInRealMethod links asArray first identicalTo: list items first 
 ]
 
@@ -124,9 +124,9 @@ ClyInstallMetaLinkPresenterTest >> testUninstallSelectedMetalink [
 	presenter := ClyMetaLinkInstallationPresenter onNode: self nodeInRealMethod forInstallation:  false.
 	list := presenter metalinkListPresenter.
 	list clickItem: 1.
-	self assert: self nodeInRealMethod hasLinks.
+	self assert: self nodeInRealMethod hasMetaLinks.
 	presenter uninstallSelectedMetalink.
-	self deny: self nodeInRealMethod hasLinks
+	self deny: self nodeInRealMethod hasMetaLinks
 ]
 
 { #category : #tests }
@@ -136,7 +136,7 @@ ClyInstallMetaLinkPresenterTest >> testUninstallSelectedMetalinkActionButton [
 	presenter := ClyMetaLinkInstallationPresenter onNode: self nodeInRealMethod forInstallation:  false.
 	list := presenter metalinkListPresenter.
 	list clickItem: 1.	
-	self assert: self nodeInRealMethod hasLinks.
+	self assert: self nodeInRealMethod hasMetaLinks.
 	presenter toolbarButtons first click.
-	self deny: self nodeInRealMethod hasLinks
+	self deny: self nodeInRealMethod hasMetaLinks
 ]

--- a/src/Reflectivity-Tools/MetaLinkIconStyler.class.st
+++ b/src/Reflectivity-Tools/MetaLinkIconStyler.class.st
@@ -29,6 +29,7 @@ MetaLinkIconStyler >> iconLabel: aNode [
 
 { #category : #testing }
 MetaLinkIconStyler >> shouldStyleNode: aNode [
-	 ^ aNode hasLinks and: [ 
-		   aNode links anySatisfy: [ :link | link hasOption: #optionStyler]]
+
+	^ aNode hasMetaLinks and: [ 
+		  aNode links anySatisfy: [ :link | link hasOption: #optionStyler ] ]
 ]

--- a/src/Reflectivity/MetaLinkInstaller.class.st
+++ b/src/Reflectivity/MetaLinkInstaller.class.st
@@ -73,8 +73,8 @@ MetaLinkInstaller >> astFromNode: aNode forObject: anObject inClass: anonClass [
 MetaLinkInstaller >> canRemoveMethodNodeContaining: aNode [
 	| methodNode allNodes |
 	methodNode := aNode methodNode.
-	allNodes := methodNode allChildren select: [ :c | c hasLinks ].
-	methodNode hasLinks
+	allNodes := methodNode allChildren select: [ :c | c hasMetaLinks ].
+	methodNode hasMetaLinks
 		ifTrue: [ allNodes add: methodNode ].
 	^ allNodes allSatisfy: [ :node | (linksRegistry isNodeWithInstanceSpecificLinks: node) not ]
 ]
@@ -187,12 +187,12 @@ MetaLinkInstaller >> linkAllFromNode: aNode into: copyNode [
 	"If aNode is the original ast node from which a copy was made - namely copyNode,
 	and if this node has links, we need to add them to copyNode."
 	
-	aNode hasLinks
+	aNode hasMetaLinks
 		ifTrue: [	aNode links do: [ :link | copyNode linkIfAbsent: link ] ].
 		
 	aNode allChildren
 		do: [ :c | 
-			c hasLinks
+			c hasMetaLinks
 				ifTrue: [ | node |
 					node := self findSubNode: c in: copyNode.
 					c links do: [ :link | node linkIfAbsent: link ] ] ]
@@ -248,7 +248,7 @@ MetaLinkInstaller >> nodesForPermaLink: permalink toBeInstalledIn: method [
 	persistenceType := permalink persistenceType.
 	nodes := (slotOrVar accessingNodesFor: persistenceType) asIdentitySet 
 					select: [ :node | node methodNode method = method ].
-	^ nodes select: [ :node | node hasLinks not or: [ (node links includes: permalink link) not ] ]
+	^ nodes select: [ :node | node hasMetaLinks not or: [ (node links includes: permalink link) not ] ]
 ]
 
 { #category : #links }
@@ -333,13 +333,13 @@ MetaLinkInstaller >> removeAllAnonymousNodesIn: methodNode fromAnonSubclassesOf:
 			"Getting all nodes in the method with links,
 			they are instance specific because located 
 			in the sole instance of a anonymous class"
-			anonNodes := anonMethodNode allChildren select: [ :n | n hasLinks ].
+			anonNodes := anonMethodNode allChildren select: [ :n | n hasMetaLinks ].
 
 			"We remove the existing links"
 			anonNodes do: [ :node | node links do: [ :link | self uninstall: link fromNode: node forObject: object ]].
 
 			"We remove links from the anonymous method node if any"
-			anonMethodNode hasLinks
+			anonMethodNode hasMetaLinks
 				ifTrue: [ anonMethodNode links do: [ :link | self uninstall: link fromNode: anonMethodNode forObject: object ]. anonMethodNode links removeAll ] ].
 	
 	"Method nodes are implicetely removed from anonymous subclasses,
@@ -379,7 +379,7 @@ MetaLinkInstaller >> removePermaLinksNodesReferencesFor: aMethodNode [
 { #category : #lookup }
 MetaLinkInstaller >> removeSuperJumpsFor: methodNode [
 	| nodesWithLinks |
-	nodesWithLinks := methodNode allChildren select: [ :c | c hasLinks ].
+	nodesWithLinks := methodNode allChildren select: [ :c | c hasMetaLinks ].
 	superJumpLinks
 		do: [ :link | 
 			(nodesWithLinks anySatisfy: [ :node | node links includes: link ])

--- a/src/Reflectivity/RBProgramNode.extension.st
+++ b/src/Reflectivity/RBProgramNode.extension.st
@@ -79,6 +79,14 @@ RBProgramNode >> hasExecutionCounter [
 
 { #category : #'*Reflectivity' }
 RBProgramNode >> hasLinks [
+	self 
+		deprecated: 'use #hasMetaLinks'
+		transformWith:  '`@receiver hasLinks' -> '`@receiver hasMetaLinks'.
+	^self hasMetaLinks
+]
+
+{ #category : #'*Reflectivity' }
+RBProgramNode >> hasMetaLinks [
 	^ self links notNil and: [ self links notEmpty ]
 ]
 
@@ -161,7 +169,7 @@ RBProgramNode >> linkIfAbsent: metalink [
 	"Per-object check only.
 	Links and nodes are stored in IdentitySet so there is already a guarantee that there will be no duplicates. However putting a link already existing for a given node will retrigger method compilation.
 	This check is used by MetaLinkInstaller only to avoid multiple and recursive reinstallation of links on nodes." 
-	(self hasLinks and: [ self links includes: metalink ])
+	(self hasMetaLinks and: [ self links includes: metalink ])
 		ifTrue: [ ^ self ].
 	self link: metalink
 ]


### PR DESCRIPTION
In Pharo9 we renamed hasLinks to hasMetaLinks but forgot one case.

This PR makes sure it is uniform


