### PR TITLE
10205-LiteralVariable-classcheckValidName-has-commented-out-code

### DIFF
--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -23,9 +23,11 @@ Class {
 
 { #category : #validating }
 LiteralVariable class >> checkValidName: aString [
-	self flag: #fixme
-	"aString first canBeGlobalVarInitial
-		ifFalse: [InvalidGlobalName signal: 'Class name does not start with a valid Global Var Initial' for: aString]"
+
+	aString first canBeGlobalVarInitial ifFalse: [ 
+		InvalidGlobalName
+			signal: 'Class name does not start with a valid Global Var Initial'
+			for: aString ]
 ]
 
 { #category : #'gt-inspector-extension' }

--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -21,15 +21,6 @@ Class {
 	#category : #'Kernel-Variables'
 }
 
-{ #category : #validating }
-LiteralVariable class >> checkValidName: aString [
-
-	aString first canBeGlobalVarInitial ifFalse: [ 
-		InvalidGlobalName
-			signal: 'Class name does not start with a valid Global Var Initial'
-			for: aString ]
-]
-
 { #category : #'gt-inspector-extension' }
 LiteralVariable class >> gtInspectorAllVariablesIn: composite [
  	"This provides a list of all defined Class or Global Variables"


### PR DESCRIPTION
fixes #10205 by un-commenting the code

(maybe there was a reason for the change... I did run compiler and class builder tests and they are green, but there could be other places, the tests will show us)