### PR TITLE
Remove class of the RBSelectorEnvirionment if there is no more selectors associated to the class

### DIFF
--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -158,37 +158,6 @@ RBBrowserEnvironment >> categories [
 ]
 
 { #category : #'accessing - classes' }
-RBBrowserEnvironment >> classNames [
-	| names |
-	names := IdentitySet new: 4096.
-	self classesDo: [ :each | names add: each instanceSide name ].
-	^ names
-]
-
-{ #category : #accessing }
-RBBrowserEnvironment >> classNamesFor: aCategoryName [
-	^ (self systemDictionary organization listAtCategoryNamed: aCategoryName) select: [ :each |
-		| class |
-		class := self systemDictionary at: each ifAbsent: [ nil ].
-		class notNil 
-			and: [ (self includesClass: class)
-			or: [ self includesClass: class class ] ] ]
-]
-
-{ #category : #environments }
-RBBrowserEnvironment >> classVarRefsTo: instVarName in: aClass [ 
-	^ RBVariableEnvironment 
-		on: self
-		referencesToClassVariable: instVarName
-		in: aClass
-]
-
-{ #category : #accessing }
-RBBrowserEnvironment >> classVariablesFor: aClass [ 
-	^aClass classVarNames
-]
-
-{ #category : #'accessing - classes' }
 RBBrowserEnvironment >> classes [
 	| classes |
 	classes := IdentitySet new: 4096.
@@ -225,6 +194,37 @@ RBBrowserEnvironment >> classesDo: aBlock [
 	self systemDictionaryClassesDo: [ :each |
 		(self includesClass: each)
 			ifTrue: [aBlock value: each ] ]
+]
+
+{ #category : #'accessing - classes' }
+RBBrowserEnvironment >> classNames [
+	| names |
+	names := IdentitySet new: 4096.
+	self classesDo: [ :each | names add: each instanceSide name ].
+	^ names
+]
+
+{ #category : #accessing }
+RBBrowserEnvironment >> classNamesFor: aCategoryName [
+	^ (self systemDictionary organization listAtCategoryNamed: aCategoryName) select: [ :each |
+		| class |
+		class := self systemDictionary at: each ifAbsent: [ nil ].
+		class notNil 
+			and: [ (self includesClass: class)
+			or: [ self includesClass: class class ] ] ]
+]
+
+{ #category : #accessing }
+RBBrowserEnvironment >> classVariablesFor: aClass [ 
+	^aClass classVarNames
+]
+
+{ #category : #environments }
+RBBrowserEnvironment >> classVarRefsTo: instVarName in: aClass [ 
+	^ RBVariableEnvironment 
+		on: self
+		referencesToClassVariable: instVarName
+		in: aClass
 ]
 
 { #category : #copying }
@@ -337,6 +337,11 @@ RBBrowserEnvironment >> includesSelector: aSelector in: aClass [
 	^ true
 ]
 
+{ #category : #accessing }
+RBBrowserEnvironment >> instanceVariablesFor: aClass [ 
+	^aClass instVarNames
+]
+
 { #category : #environments }
 RBBrowserEnvironment >> instVarReadersTo: instVarName in: aClass [ 
 	^RBVariableEnvironment 
@@ -359,11 +364,6 @@ RBBrowserEnvironment >> instVarWritersTo: instVarName in: aClass [
 		on: self
 		writersOfInstanceVariable: instVarName
 		in: aClass
-]
-
-{ #category : #accessing }
-RBBrowserEnvironment >> instanceVariablesFor: aClass [ 
-	^aClass instVarNames
 ]
 
 { #category : #testing }
@@ -548,17 +548,6 @@ RBBrowserEnvironment >> searchStrings: aCollection [
 	searchStrings := aCollection
 ]
 
-{ #category : #environments }
-RBBrowserEnvironment >> selectMethods: aBlock [ 
-	| env |
-	env := RBSelectorEnvironment onEnvironment: self.
-	self classesAndSelectorsDo: 
-			[:each :sel | 
-			(aBlock value: (each compiledMethodAt: sel)) 
-				ifTrue: [env addClass: each selector: sel]].
-	^env
-]
-
 { #category : #accessing }
 RBBrowserEnvironment >> selectionIntervalFor: aString [ 
 	| interval |
@@ -596,6 +585,17 @@ RBBrowserEnvironment >> selectionParseTreeIntervalFor: aString [
 					matchesArgumentTree: tree do: answerBlock ].
 		matcher executeTree: parseTree ].
 	^ nil
+]
+
+{ #category : #environments }
+RBBrowserEnvironment >> selectMethods: aBlock [ 
+	| env |
+	env := RBSelectorEnvironment onEnvironment: self.
+	self classesAndSelectorsDo: 
+			[:each :sel | 
+			(aBlock value: (each compiledMethodAt: sel)) 
+				ifTrue: [env addClass: each selector: sel]].
+	^env
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Environment/RBClassEnvironment.class.st
+++ b/src/Refactoring-Environment/RBClassEnvironment.class.st
@@ -58,24 +58,6 @@ RBClassEnvironment >> asSelectorEnvironment [
 		yourself.
 ]
 
-{ #category : #'accessing - classes' }
-RBClassEnvironment >> classNames [
-	^ IdentitySet new
-		addAll: classes;
-		addAll: metaClasses;
-		yourself
-]
-
-{ #category : #printing }
-RBClassEnvironment >> classSelectorDictionary [
-	^ classes 
-		inject: (IdentityDictionary new: classes size)
-		into: [ :answer :class |
-			answer
-				at: class put: (self systemDictionary at: class) selectors;
-				yourself ]
-]
-
 { #category : #initialization }
 RBClassEnvironment >> classes: aCollection [ 
 	aCollection do: [ :each | self addClass: each ]
@@ -93,6 +75,24 @@ RBClassEnvironment >> classesDo: aBlock [
 		class := self systemDictionary at: each ifAbsent: [ nil ].
 		(class notNil and: [ environment includesClass: class classSide ])
 			ifTrue: [ aBlock value: class classSide ] ]
+]
+
+{ #category : #'accessing - classes' }
+RBClassEnvironment >> classNames [
+	^ IdentitySet new
+		addAll: classes;
+		addAll: metaClasses;
+		yourself
+]
+
+{ #category : #printing }
+RBClassEnvironment >> classSelectorDictionary [
+	^ classes 
+		inject: (IdentityDictionary new: classes size)
+		into: [ :answer :class |
+			answer
+				at: class put: (self systemDictionary at: class) selectors;
+				yourself ]
 ]
 
 { #category : #private }

--- a/src/Refactoring-Environment/RBSelectorEnvironment.class.st
+++ b/src/Refactoring-Environment/RBSelectorEnvironment.class.st
@@ -162,20 +162,6 @@ RBSelectorEnvironment >> asSelectorEnvironment [
 	^ self
 ]
 
-{ #category : #'accessing - classes' }
-RBSelectorEnvironment >> classNames [
-	^ IdentitySet new
-		addAll: classSelectors keys;
-		addAll: metaClassSelectors keys;
-		yourself
-]
-
-{ #category : #'initialize-release' }
-RBSelectorEnvironment >> classSelectors: classSelectorDictionary metaClassSelectors: metaClassSelectorDictionary [ 
-	classSelectors := classSelectorDictionary.
-	metaClassSelectors := metaClassSelectorDictionary
-]
-
 { #category : #initialization }
 RBSelectorEnvironment >> classes: classArray metaClasses: metaArray [ 
 	"Used to recreate an environment from its storeString"
@@ -200,6 +186,20 @@ RBSelectorEnvironment >> classesDo: aBlock [
 		class := self systemDictionary at: each ifAbsent: [ nil ].
 		(class notNil and: [ environment includesClass: class class ])
 			ifTrue: [ aBlock value: class class ] ]
+]
+
+{ #category : #'accessing - classes' }
+RBSelectorEnvironment >> classNames [
+	^ IdentitySet new
+		addAll: classSelectors keys;
+		addAll: metaClassSelectors keys;
+		yourself
+]
+
+{ #category : #'initialize-release' }
+RBSelectorEnvironment >> classSelectors: classSelectorDictionary metaClassSelectors: metaClassSelectorDictionary [ 
+	classSelectors := classSelectorDictionary.
+	metaClassSelectors := metaClassSelectorDictionary
 ]
 
 { #category : #private }
@@ -310,12 +310,13 @@ RBSelectorEnvironment >> removeClass: aClass [
 ]
 
 { #category : #removing }
-RBSelectorEnvironment >> removeClass: aClass selector: aSelector [ 
-	(aClass isMeta 
-		ifTrue: [metaClassSelectors at: aClass soleInstance name ifAbsent: [^self]]
-		ifFalse: [classSelectors at: aClass name ifAbsent: [^self]]) 
-			remove: aSelector
-			ifAbsent: []
+RBSelectorEnvironment >> removeClass: aClass selector: aSelector [
+	| class |
+	class := aClass isMeta
+				ifTrue: [metaClassSelectors at: aClass soleInstance name ifAbsent: [^self]]
+				ifFalse: [classSelectors at: aClass name ifAbsent: [^self]].
+	class remove: aSelector ifAbsent: [].
+	class ifEmpty: [self removeClass: aClass]
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Environment/RBVariableEnvironment.class.st
+++ b/src/Refactoring-Environment/RBVariableEnvironment.class.st
@@ -192,6 +192,16 @@ RBVariableEnvironment >> classNamesWithVariables [
 ]
 
 { #category : #private }
+RBVariableEnvironment >> classVariables [
+	^classVariables
+]
+
+{ #category : #private }
+RBVariableEnvironment >> classVariables: anObject [
+	classVariables := anObject
+]
+
+{ #category : #private }
 RBVariableEnvironment >> classVariableSelectorsFor: aClass [ 
 	| selectors classVars |
 	selectors := Set new.
@@ -208,16 +218,6 @@ RBVariableEnvironment >> classVariableSelectorsFor: aClass [
 			binding := aClass bindingOf: each.
 			binding ifNotNil: [selectors addAll: (aClass whichSelectorsReferTo: binding)]].
 	^selectors
-]
-
-{ #category : #private }
-RBVariableEnvironment >> classVariables [
-	^classVariables
-]
-
-{ #category : #private }
-RBVariableEnvironment >> classVariables: anObject [
-	classVariables := anObject
 ]
 
 { #category : #accessing }
@@ -344,6 +344,16 @@ RBVariableEnvironment >> instanceVariableReaders: anObject [
 ]
 
 { #category : #private }
+RBVariableEnvironment >> instanceVariables [
+	^instanceVariables
+]
+
+{ #category : #private }
+RBVariableEnvironment >> instanceVariables: anObject [
+	instanceVariables := anObject
+]
+
+{ #category : #private }
 RBVariableEnvironment >> instanceVariableSelectorsFor: aClass [ 
 	| selectors |
 	selectors := Set new.
@@ -362,26 +372,6 @@ RBVariableEnvironment >> instanceVariableSelectorsFor: aClass [
 	^selectors
 ]
 
-{ #category : #private }
-RBVariableEnvironment >> instanceVariableWriters [
-	^instanceVariableWriters
-]
-
-{ #category : #private }
-RBVariableEnvironment >> instanceVariableWriters: anObject [
-	instanceVariableWriters := anObject
-]
-
-{ #category : #private }
-RBVariableEnvironment >> instanceVariables [
-	^instanceVariables
-]
-
-{ #category : #private }
-RBVariableEnvironment >> instanceVariables: anObject [
-	instanceVariables := anObject
-]
-
 { #category : #accessing }
 RBVariableEnvironment >> instanceVariablesFor: aClass [ 
 	| vars name |
@@ -392,6 +382,16 @@ RBVariableEnvironment >> instanceVariablesFor: aClass [
 		addAll: (instanceVariableReaders at: name ifAbsent: [#()]);
 		addAll: (instanceVariableWriters at: name ifAbsent: [#()]).
 	^vars
+]
+
+{ #category : #private }
+RBVariableEnvironment >> instanceVariableWriters [
+	^instanceVariableWriters
+]
+
+{ #category : #private }
+RBVariableEnvironment >> instanceVariableWriters: anObject [
+	instanceVariableWriters := anObject
 ]
 
 { #category : #testing }

--- a/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
+++ b/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
@@ -41,6 +41,15 @@ RBBrowserEnvironmentTest >> categoriesFor: anEnvironment [
 ]
 
 { #category : #private }
+RBBrowserEnvironmentTest >> classesFor: aBrowserEnvironment [
+	| allClasses |
+	allClasses := aBrowserEnvironment classes asSet.
+	allClasses addAll: aBrowserEnvironment not classes.
+	RBBrowserEnvironment new allClassesDo: [ :each | allClasses remove: each ].
+	self assertEmpty: allClasses
+]
+
+{ #category : #private }
 RBBrowserEnvironmentTest >> classNamesFor: anEnvironment [
 	| classNames allClassNames |
 	classNames := IdentitySet new
@@ -61,15 +70,6 @@ RBBrowserEnvironmentTest >> classVariableReader [
 { #category : #mockup }
 RBBrowserEnvironmentTest >> classVariableWriter [
 	AClassVariable := nil
-]
-
-{ #category : #private }
-RBBrowserEnvironmentTest >> classesFor: aBrowserEnvironment [
-	| allClasses |
-	allClasses := aBrowserEnvironment classes asSet.
-	allClasses addAll: aBrowserEnvironment not classes.
-	RBBrowserEnvironment new allClassesDo: [ :each | allClasses remove: each ].
-	self assertEmpty: allClasses
 ]
 
 { #category : #private }
@@ -415,6 +415,20 @@ RBBrowserEnvironmentTest >> testSelectorEnvironment [
 	self assert: printString isSelectorEnvironment.
 	self assert: printString numberSelectors equals: (printString referencesTo: #printString) numberSelectors.
 	self assert: printString numberClasses equals: (printString referencesTo: #printString) numberClasses
+]
+
+{ #category : #tests }
+RBBrowserEnvironmentTest >> testSelectorEnvironmentRemoveClassSelectorShouldRemoveTheClassIfThereIsNoMoreSelectors [
+	| environment |
+	environment := RBSelectorEnvironment new.
+	environment addClass: Object selector: #printString.
+	self assert: (environment includesClass: Object).
+	self assert: (environment includesSelector: #printString in: Object).
+	self assert: (environment classes includes: Object).
+	environment removeClass: Object selector: #printString.
+	self deny: (environment includesClass: Object).
+	self deny: (environment classes includes: Object).
+	self deny: (environment includesSelector: #printString in: Object)
 ]
 
 { #category : #tests }


### PR DESCRIPTION
For a RBSelectorEnvironment, #classes should not contains the class anymore