### PR TITLE
Cleanup-FullBlocks: remove dead code

### DIFF
--- a/src/Debugging-Core/BlockLocalTempCounter.class.st
+++ b/src/Debugging-Core/BlockLocalTempCounter.class.st
@@ -127,17 +127,6 @@ BlockLocalTempCounter >> pushActiveContext [
 ]
 
 { #category : #'instruction decoding' }
-BlockLocalTempCounter >> pushClosureCopyNumCopiedValues: numCopied numArgs: numArgs blockSize: blockSize [
-	"Push Closure bytecode.  Either compute the end of the block if this is
-	 the block we're analysing, or skip it, adjusting the stack as appropriate."
-	blockEnd
-		ifNil: [blockEnd := scanner pc + blockSize]
-		ifNotNil:
-			[stackPointer := stackPointer - numCopied + 1.
-			 scanner pc: scanner pc + blockSize]
-]
-
-{ #category : #'instruction decoding' }
 BlockLocalTempCounter >> pushConsArrayWithElements: numElements [
 	"Push Cons Array of size numElements popping numElements items from the stack into the array bytecode."
 	stackPointer := stackPointer - numElements + 1

--- a/src/Debugging-Core/SymbolicBytecodeBuilder.class.st
+++ b/src/Debugging-Core/SymbolicBytecodeBuilder.class.st
@@ -191,15 +191,6 @@ SymbolicBytecodeBuilder >> pushActiveProcess [
 ]
 
 { #category : #'instruction decoding' }
-SymbolicBytecodeBuilder >> pushClosureCopyNumCopiedValues: numCopied numArgs: numArgs blockSize: blockSize [
-
-	self addBytecode: 'closureNumCopied: ', numCopied printString
-			, ' numArgs: ', numArgs printString
-			, ' bytes ', scanner pc printString
-			, ' to ', (scanner pc + blockSize - 1) printString
-]
-
-{ #category : #'instruction decoding' }
 SymbolicBytecodeBuilder >> pushClosureTemps: numTemps [
 	"Push on stack nil numTemps times for the closure temps."
 	

--- a/src/Flashback-Decompiler/FBDDecompiler.class.st
+++ b/src/Flashback-Decompiler/FBDDecompiler.class.st
@@ -215,21 +215,6 @@ FBDDecompiler >> errorCodeNameFor: cm [
 	^ primitivePragma argumentAt: (selectorParts indexOf: 'error:')
 ]
 
-{ #category : #'data flow instructions' }
-FBDDecompiler >> extractBlockWith: copied numArgs: numArgs blockSize: blockSize [
-	| startPC numTemps |
-	numTemps := instructionStream method encoderClass 
-		numLocalTempsForBlockAt: self pc 
-		in: instructionStream method.
-	self initializeStackNumArgs: numArgs copied: copied numTemps: numTemps.
-	startPC := self pc.
-	self skipTemps: numTemps.
-	self interpret: startPC + blockSize - 1.
-	^ builder 
-		codeBlock: currentSequence 
-		arguments: (simulatedStack first: numArgs)
-]
-
 { #category : #'closure support' }
 FBDDecompiler >> extractFullBlock: aCompiledBlock numCopied: numCopied [
 
@@ -513,19 +498,6 @@ FBDDecompiler >> pushCleanClosure: aCompiledBlock [
 	simulatedStack := savedSimStack.
 	currentSequence := savedSequence.
 
-]
-
-{ #category : #'data flow instructions' }
-FBDDecompiler >> pushClosureCopyNumCopiedValues: numCopied numArgs: numArgs blockSize: blockSize [
-	| savedSimStack savedSequence |
-	savedSimStack := simulatedStack.
-	savedSequence := currentSequence.
-	savedSimStack addLast: (self
-		extractBlockWith: (self popFromStack: numCopied)
-		numArgs: numArgs
-		blockSize: blockSize).
-	simulatedStack := savedSimStack.
-	currentSequence := savedSequence.
 ]
 
 { #category : #'data flow instructions' }

--- a/src/Kernel/BlockClosure.class.st
+++ b/src/Kernel/BlockClosure.class.st
@@ -45,15 +45,6 @@ Class {
 	#category : #'Kernel-Methods'
 }
 
-{ #category : #'instance creation' }
-BlockClosure class >> outerContext: aContext startpc: aStartpc numArgs: argCount copiedValues: anArrayOrNil [
-	^(self new: anArrayOrNil basicSize)
-		outerContext: aContext
-		startpc: aStartpc
-		numArgs: argCount
-		copiedValues: anArrayOrNil
-]
-
 { #category : #accessing }
 BlockClosure >> argumentCount [
 	"Answer the number of arguments that must be used to evaluate this block"

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -446,24 +446,6 @@ Context >> closure [
 	^closureOrNil
 ]
 
-{ #category : #controlling }
-Context >> closureCopy: numArgs copiedValues: anArray [
-	"Distinguish a block of code from its enclosing method by 
-	creating a BlockClosure for that block. The compiler inserts into all 
-	methods that contain blocks the bytecodes to send the message 
-	closureCopy:copiedValues:. Do not use closureCopy:copiedValues: in code that you write! Only the 
-	compiler can decide to send the message closureCopy:copiedValues:. Fail if numArgs is 
-	not a SmallInteger. Optional. No Lookup. See Object documentation 
-	whatIsAPrimitive."
-
-	<primitive: 200>
-	^BlockClosure 
-		outerContext: self
-		startpc: pc + 2
-		numArgs: numArgs
-		copiedValues: anArray
-]
-
 { #category : #accessing }
 Context >> compiledCode [
 
@@ -663,12 +645,7 @@ Context >> doPrimitive: primitiveIndex method: meth receiver: aReceiver args: ar
 		].
 	"Closure primitives"
 	(primitiveIndex = 200 and: [self == aReceiver]) ifTrue:
-		"ContextPart>>closureCopy:copiedValues:; simulated to get startpc right"
-		[^self push: (BlockClosure
-						outerContext: aReceiver
-						startpc: pc + 2
-						numArgs: arguments first
-						copiedValues: arguments last)].
+		[^self error: 'embedded block not supported'].
 
 	primitiveIndex = 118 ifTrue: "tryPrimitive:withArgs:; avoid recursing in the VM"
 		[(arguments size = 2
@@ -1505,25 +1482,6 @@ Context >> pushArgs: arguments from: senderContext [
 	1 to: closureOrNil numArgs do: [:i |
 		self at: i put: (arguments at: i)].
 	sender := senderContext
-]
-
-{ #category : #'instruction decoding' }
-Context >> pushClosureCopyNumCopiedValues: numCopied numArgs: numArgs blockSize: blockSize withInterpreter: anInterpreter [
-	"Simulate the action of a 'closure copy' bytecode whose result is the
-	 new BlockClosure for the following code"
-	| copiedValues |
-	numCopied > 0
-		ifTrue: [
-			copiedValues := Array new: numCopied.
-			numCopied to: 1 by: -1 do: [ :i |
-				copiedValues at: i put: self pop ]]
-		ifFalse: [ copiedValues := nil ].
-	self push: (BlockClosure
-				outerContext: self
-				startpc: pc
-				numArgs: numArgs
-				copiedValues: copiedValues).
-	self jump: blockSize withInterpreter: anInterpreter
 ]
 
 { #category : #'instruction decoding' }

--- a/src/Kernel/InstructionClient.class.st
+++ b/src/Kernel/InstructionClient.class.st
@@ -141,12 +141,6 @@ InstructionClient >> pushActiveProcess [
 ]
 
 { #category : #'instruction decoding' }
-InstructionClient >> pushClosureCopyNumCopiedValues: numCopied numArgs: numArgs blockSize: blockSize [
-	"Push Closure bytecode."
-
-]
-
-{ #category : #'instruction decoding' }
 InstructionClient >> pushClosureTemps: numTemps [
 	"push on stack nil numTemps times for the closure temps"
 ]


### PR DESCRIPTION
This PR removes more dead code that was used by the old closure model

This does not yet merge the BlockClosure and FullBlockClosure classes.

