### PR TITLE
9973-Different-behavior-in-Playground-for-deprecated-method-transformed-vs-nontransformed-deprecations

### DIFF
--- a/src/Kernel/Deprecation.class.st
+++ b/src/Kernel/Deprecation.class.st
@@ -232,7 +232,7 @@ Deprecation >> transform [
 	self shouldTransform ifFalse: [ ^ self signal].
 	self rewriterClass ifNil:[ ^ self signal ].
 	aMethod := self contextOfSender compiledCode method.
-	aMethod isDoIt ifTrue:[^ self]. "no need to transform doits"
+	aMethod isDoIt ifTrue:[ ^ self signal ]. "no need to transform doits"
 	node := self contextOfSender sourceNodeExecuted.
 	RecursionStopper during: [
 		rewriteRule := self rewriterClass new 


### PR DESCRIPTION
fixes #9973 as described in the issue tracker entry

