### PR TITLE
10035 text anchors with morphs do not render in rubric

### DIFF
--- a/src/Rubric-Tests/RubEditingAreaTest.class.st
+++ b/src/Rubric-Tests/RubEditingAreaTest.class.st
@@ -59,26 +59,29 @@ RubEditingAreaTest >> setUp [
 	area setTextWith: 'one two three four'.
 ]
 
-{ #category : #tests }
+{ #category : #'tests - accessing selection' }
+RubEditingAreaTest >> tearDown [
+
+	area delete.
+	super tearDown.
+]
+
+{ #category : #'tests - accessing selection' }
 RubEditingAreaTest >> testEmbeddedAnchorInTextAreDrawn [
-	| circle text renderedText|
+	| circle text |
 	circle := CircleMorph new extent: 50 @ 50;color: Color blue.
-	
+
 	self assert: circle owner isNil.
 	self assert: circle position equals: 0@0.
 	"add the circle to a text string"
 	text := ('aaaaa',(String value: 1),'bbbbbbb') asText 
 			addAttribute: (TextAnchor new anchoredMorph: circle).
 	"render the text in a RubEditingArea to place the circle in a layout"
-	renderedText := RubEditingArea new updateTextWith: text.
-	renderedText openInWorld.
-	
-	[	self assert: circle owner notNil.
-		self deny: circle position equals: 0@0]
-	ensure: [renderedText owner removeMorph: renderedText]
-	
-	
-	
+	area updateTextWith: text.
+	area openInWorld.
+
+	self assert: circle owner notNil.
+	self deny: circle position equals: 0@0
 ]
 
 { #category : #'tests - accessing selection' }

--- a/src/Rubric-Tests/RubEditingAreaTest.class.st
+++ b/src/Rubric-Tests/RubEditingAreaTest.class.st
@@ -59,6 +59,28 @@ RubEditingAreaTest >> setUp [
 	area setTextWith: 'one two three four'.
 ]
 
+{ #category : #tests }
+RubEditingAreaTest >> testEmbeddedAnchorInTextAreDrawn [
+	| circle text renderedText|
+	circle := CircleMorph new extent: 50 @ 50;color: Color blue.
+	
+	self assert: circle owner isNil.
+	self assert: circle position equals: 0@0.
+	"add the circle to a text string"
+	text := ('aaaaa',(String value: 1),'bbbbbbb') asText 
+			addAttribute: (TextAnchor new anchoredMorph: circle).
+	"render the text in a RubEditingArea to place the circle in a layout"
+	renderedText := RubEditingArea new updateTextWith: text.
+	renderedText openInWorld.
+	
+	self assert: circle owner notNil.
+	self deny: circle position equals: 0@0.
+	renderedText owner removeMorph: renderedText
+	
+	
+	
+]
+
 { #category : #'tests - accessing selection' }
 RubEditingAreaTest >> testMarkBlockPointBlock [
 	self setSelectionFrom: 3 to: 6 text: area text.

--- a/src/Rubric-Tests/RubEditingAreaTest.class.st
+++ b/src/Rubric-Tests/RubEditingAreaTest.class.st
@@ -73,9 +73,9 @@ RubEditingAreaTest >> testEmbeddedAnchorInTextAreDrawn [
 	renderedText := RubEditingArea new updateTextWith: text.
 	renderedText openInWorld.
 	
-	self assert: circle owner notNil.
-	self deny: circle position equals: 0@0.
-	renderedText owner removeMorph: renderedText
+	[	self assert: circle owner notNil.
+		self deny: circle position equals: 0@0]
+	ensure: [renderedText owner removeMorph: renderedText]
 	
 	
 	

--- a/src/Rubric-Tests/RubEditingAreaTest.class.st
+++ b/src/Rubric-Tests/RubEditingAreaTest.class.st
@@ -63,7 +63,7 @@ RubEditingAreaTest >> setUp [
 RubEditingAreaTest >> tearDown [
 
 	area delete.
-	super tearDown.
+	super tearDown
 ]
 
 { #category : #'tests - accessing selection' }

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -702,6 +702,8 @@ RubAbstractTextArea >> doubleClick: anEvent [
 
 { #category : #composing }
 RubAbstractTextArea >> drawEmbeddedMorphs [
+	"Scan through text to find spans of TextBackgroundColor, and mark them using TextBackgroundColorSegmentMorph."
+
 	"Scan through text to find spans containing submorphs (Background color and TextAnchor)"
 
 	self text runs
@@ -714,7 +716,7 @@ RubAbstractTextArea >> drawEmbeddedMorphs [
 								from: start
 								to: stop+1) ].
 					((v isKindOf: TextAnchor) and:[v anchoredMorph isMorph ])
-						ifTrue: [ self addMorphBack: v anchoredMorph  ] ] ] 
+						ifTrue: [ self addMorphBack: v anchoredMorph  ] ] ]
 ]
 
 { #category : #drawing }
@@ -1474,7 +1476,7 @@ RubAbstractTextArea >> paragraphReplacedTextFrom: start to: stop with: aText [
 				ifFalse: [ self updateExtentFromParagraph ] ].
 	self scrollPane ifNotNil: [ :sp | sp textChanged ].
 	self announce: (RubTextChanged from: start to: stop with: aText).
-	self drawEmbeddedMorphs .
+	self drawEmbeddedMorphs.
 
 ]
 

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -579,7 +579,7 @@ RubAbstractTextArea >> compose [
 
 	self prepareParagraphToCompose.
 	self paragraph compose.
-	self markBackgroundColors
+	self drawEmbeddedMorphs
 ]
 
 { #category : #composing }
@@ -698,6 +698,23 @@ RubAbstractTextArea >> deselect [
 { #category : #'event handling' }
 RubAbstractTextArea >> doubleClick: anEvent [
 	^ self handleEdit: [ self editor doubleClick: anEvent ]
+]
+
+{ #category : #composing }
+RubAbstractTextArea >> drawEmbeddedMorphs [
+	"Scan through text to find spans containing submorphs (Background color and TextAnchor)"
+
+	self text runs
+		withStartStopAndValueDo: [ :start :stop :value | 
+			value do: [ :v | 
+					(v isKindOf: TextBackgroundColor)
+						ifTrue: [ self addSegment: 
+							(RubTextBackgroundColorSegmentMorph
+								color: v color
+								from: start
+								to: stop+1) ].
+					((v isKindOf: TextAnchor) and:[v anchoredMorph isMorph ])
+						ifTrue: [ self addMorphBack: v anchoredMorph  ] ] ] 
 ]
 
 { #category : #drawing }
@@ -1196,21 +1213,6 @@ RubAbstractTextArea >> margins: aMargin [
 	margins := m
 ]
 
-{ #category : #composing }
-RubAbstractTextArea >> markBackgroundColors [
-	"Scan through text to find spans of TextBackgroundColor, and mark them using TextBackgroundColorSegmentMorph."
-
-	self text runs
-		withStartStopAndValueDo: [ :start :stop :value | 
-			value do: [ :v | 
-					(v isKindOf: TextBackgroundColor)
-						ifTrue: [ self addSegment: 
-							(RubTextBackgroundColorSegmentMorph
-								color: v color
-								from: start
-								to: stop+1) ] ] ] 
-]
-
 { #category : #'accessing - selection' }
 RubAbstractTextArea >> markBlock [
 	^ self editingState markBlock
@@ -1472,7 +1474,7 @@ RubAbstractTextArea >> paragraphReplacedTextFrom: start to: stop with: aText [
 				ifFalse: [ self updateExtentFromParagraph ] ].
 	self scrollPane ifNotNil: [ :sp | sp textChanged ].
 	self announce: (RubTextChanged from: start to: stop with: aText).
-	self markBackgroundColors .
+	self drawEmbeddedMorphs .
 
 ]
 

--- a/src/Rubric/RubDisplayScanner.class.st
+++ b/src/Rubric/RubDisplayScanner.class.st
@@ -177,27 +177,27 @@ RubDisplayScanner >> paddedSpace [
 
 { #category : #scanning }
 RubDisplayScanner >> placeEmbeddedObject: anchoredMorph [
-	"It seemed like the placement of morphs did not work. I am left here for the case someone will find out how to fix me"
-	anchoredMorph relativeTextAnchorPosition ifNotNil: [ 
-		anchoredMorph position: anchoredMorph relativeTextAnchorPosition
-			+ (anchoredMorph owner bounds origin x @ 0) - (0 @ morphicOffset y)
-			+ (0 @ lineY).
-		^ true ].
-	(super placeEmbeddedObject: anchoredMorph) ifFalse: [ ^ false ].
-	anchoredMorph isMorph
-		ifTrue: [ 
-			anchoredMorph position:
-				destX - anchoredMorph width @ lineY - morphicOffset ]
-		ifFalse: [ 
-			destY := lineY.
-			baselineY := lineY + anchoredMorph height.
-			runX := destX.
-			anchoredMorph
-				displayOn: bitBlt destForm
-				at: destX - anchoredMorph width @ destY
-				clippingBox: bitBlt clipRect
-				rule: Form blend
-				fillColor: Color white ].
+	anchoredMorph relativeTextAnchorPosition ifNotNil:[
+		anchoredMorph position: 
+			anchoredMorph relativeTextAnchorPosition +
+			(anchoredMorph owner bounds origin x @ 0)
+			- (0@morphicOffset y) + (0@lineY).
+		^true
+	].
+	(super placeEmbeddedObject: anchoredMorph) ifFalse: [^ false].
+	anchoredMorph isMorph ifTrue: [
+		anchoredMorph position: ((destX - anchoredMorph width)@lineY) - morphicOffset
+	] ifFalse: [
+		destY := lineY.
+		baselineY := lineY + anchoredMorph height..
+		runX := destX.
+		anchoredMorph 
+			displayOn: bitBlt destForm 
+			at: destX - anchoredMorph width @ destY
+			clippingBox: bitBlt clipRect
+			rule: Form blend
+			fillColor: Color white 
+	].
 	^ true
 ]
 

--- a/src/Rubric/RubDisplayScanner.class.st
+++ b/src/Rubric/RubDisplayScanner.class.st
@@ -177,27 +177,46 @@ RubDisplayScanner >> paddedSpace [
 
 { #category : #scanning }
 RubDisplayScanner >> placeEmbeddedObject: anchoredMorph [
-	anchoredMorph relativeTextAnchorPosition ifNotNil:[
-		anchoredMorph position: 
-			anchoredMorph relativeTextAnchorPosition +
-			(anchoredMorph owner bounds origin x @ 0)
-			- (0@morphicOffset y) + (0@lineY).
-		^true
-	].
-	(super placeEmbeddedObject: anchoredMorph) ifFalse: [^ false].
-	anchoredMorph isMorph ifTrue: [
-		anchoredMorph position: ((destX - anchoredMorph width)@lineY) - morphicOffset
-	] ifFalse: [
-		destY := lineY.
-		baselineY := lineY + anchoredMorph height..
-		runX := destX.
-		anchoredMorph 
-			displayOn: bitBlt destForm 
-			at: destX - anchoredMorph width @ destY
-			clippingBox: bitBlt clipRect
-			rule: Form blend
-			fillColor: Color white 
-	].
+	"I am a simplified version of placeEmbeddedObjectOld: as the rendering of morphs did not work"
+
+	| form |
+	form := anchoredMorph asForm. "make morph into form, or keep form"
+	(super placeEmbeddedObject: form) ifFalse: [ ^ false ].
+	destY := lineY.
+	baselineY := lineY + form height.
+	runX := destX.
+	form
+		displayOn: bitBlt destForm
+		at: destX - form width @ destY
+		clippingBox: bitBlt clipRect
+		rule: Form blend
+		fillColor: Color white.
+	^ true
+]
+
+{ #category : #scanning }
+RubDisplayScanner >> placeEmbeddedObjectOld: anchoredMorph [
+	"It seemed like the placement of morphs did not work. I am left here for the case someone will find out how to fix me"
+	anchoredMorph relativeTextAnchorPosition ifNotNil: [ 
+		anchoredMorph position: anchoredMorph relativeTextAnchorPosition
+			+ (anchoredMorph owner bounds origin x @ 0) - (0 @ morphicOffset y)
+			+ (0 @ lineY).
+		^ true ].
+	(super placeEmbeddedObject: anchoredMorph) ifFalse: [ ^ false ].
+	anchoredMorph isMorph
+		ifTrue: [ 
+			anchoredMorph position:
+				destX - anchoredMorph width @ lineY - morphicOffset ]
+		ifFalse: [ 
+			destY := lineY.
+			baselineY := lineY + anchoredMorph height.
+			runX := destX.
+			anchoredMorph
+				displayOn: bitBlt destForm
+				at: destX - anchoredMorph width @ destY
+				clippingBox: bitBlt clipRect
+				rule: Form blend
+				fillColor: Color white ].
 	^ true
 ]
 

--- a/src/Rubric/RubDisplayScanner.class.st
+++ b/src/Rubric/RubDisplayScanner.class.st
@@ -177,25 +177,6 @@ RubDisplayScanner >> paddedSpace [
 
 { #category : #scanning }
 RubDisplayScanner >> placeEmbeddedObject: anchoredMorph [
-	"I am a simplified version of placeEmbeddedObjectOld: as the rendering of morphs did not work"
-
-	| form |
-	form := anchoredMorph asForm. "make morph into form, or keep form"
-	(super placeEmbeddedObject: form) ifFalse: [ ^ false ].
-	destY := lineY.
-	baselineY := lineY + form height.
-	runX := destX.
-	form
-		displayOn: bitBlt destForm
-		at: destX - form width @ destY
-		clippingBox: bitBlt clipRect
-		rule: Form blend
-		fillColor: Color white.
-	^ true
-]
-
-{ #category : #scanning }
-RubDisplayScanner >> placeEmbeddedObjectOld: anchoredMorph [
 	"It seemed like the placement of morphs did not work. I am left here for the case someone will find out how to fix me"
 	anchoredMorph relativeTextAnchorPosition ifNotNil: [ 
 		anchoredMorph position: anchoredMorph relativeTextAnchorPosition


### PR DESCRIPTION
After a lot of poking around, the problem was that `RubAbstractTextArea` simply did not render TextAnchors if they contained a morph. This PR fixes it (within my understanding of Rubrics).