### PR TITLE
10204-RBMoveMethodRefactoring-incorrectly-computes-types-when-using-a-class-name-for-the-variable-to-move-into

### DIFF
--- a/src/Refactoring-Core/RBMoveMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodRefactoring.class.st
@@ -186,8 +186,9 @@ RBMoveMethodRefactoring >> getClassForGlobalOrClassVariable [
 	| definingClass type |
 	definingClass := class whoDefinesClassVariable: (variable ifNil: ['']).
 	definingClass ifNil: [ 
-			type := self model classNamed: variable.
-			type ifNil: [ type := self model classNamed: #Object ] ]
+			type := (self model classNamed: variable) 
+				ifNotNil: [ :cls | cls classSide ]
+				ifNil: [ self model classNamed: #Object ] ]
 		ifNotNil: [ type := definingClass typeOfClassVariable: variable ].
 	moveToClasses := self selectVariableTypesFrom: (Array with: type) selected: (Array with: type).
 	moveToClasses ifNil: [ self refactoringFailure: 'Method not moved' ]

--- a/src/Refactoring2-Transformations-Tests/RBMoveMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveMethodParametrizedTest.class.st
@@ -53,6 +53,30 @@ RBMoveMethodParametrizedTest >> testMoveMethodIntoArgument [
 ]
 
 { #category : #test }
+RBMoveMethodParametrizedTest >> testMoveMethodIntoClass [
+	| refactoring class |
+	(model classFor: Object) compile: 'aTestMethodName ^ OrderedCollection new addAll: (1 to: 100); yourself' classified: #test.
+	
+	refactoring := self createRefactoringWithArguments:  
+				{ #aTestMethodName . model classFor: Object . 'OrderedCollection'}.
+	
+	self
+		setupMethodNameFor: refactoring
+		toReturn: #oneToOneHundred
+		withArguments: #().
+	refactoring setOption: #variableTypes toUse: [ :ref :initialTypes :selectedTypes | selectedTypes ].
+	self executeRefactoring: refactoring.
+	class := refactoring model classNamed: #Object.
+	self
+		assert: ((model classFor: Object) parseTreeFor: #aTestMethodName)
+		equals: (self parseMethod: 'aTestMethodName ^ OrderedCollection oneToOneHundred ').
+	self
+		assert: ((refactoring model classNamed: #OrderedCollection) classSide parseTreeFor: #oneToOneHundred)
+		equals: (self parseMethod: 'oneToOneHundred ^ self new addAll: (1 to: 100); yourself')
+
+]
+
+{ #category : #test }
 RBMoveMethodParametrizedTest >> testMoveMethodIntoClassVariable [
 	| refactoring class |
 	self proceedThroughWarning: 


### PR DESCRIPTION
- do the change in getClassForGlobalOrClassVariable as described in the issue
- add testMoveMethodIntoClass 

fixes #10204


