### PR TITLE
[Pharo 10] Reactivating debugger opening strategies by default.

### DIFF
--- a/src/Debugger-Oups/OupsDebuggerSelectionStrategy.class.st
+++ b/src/Debugger-Oups/OupsDebuggerSelectionStrategy.class.st
@@ -44,7 +44,7 @@ OupsDebuggerSelectionStrategy class >> debuggerSelectionStrategySettingsOn: aBui
 
 { #category : #settings }
 OupsDebuggerSelectionStrategy class >> defaultDebuggerSelectionStrategy [
-	^OupsSingleDebuggerSelector
+	^OupsDebuggerSelector
 ]
 
 { #category : #instance }


### PR DESCRIPTION
When a debugger fails because of an error:

- tries to open the next available debugger (depending on the settings priorities)
- P9: opens GT, if GT fails it opens the emergency debugger
- P10: opens the emergency debugger (ED) immediately

If ED fails, this means the error is too critical to be handled (at least, in the current state of the system)