### PR TITLE
speedup-specialSelectorIndexOrNil 

### DIFF
--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1811,12 +1811,11 @@ SmalltalkImage >> specialSelectorAt: anInteger [
 
 { #category : #'special objects' }
 SmalltalkImage >> specialSelectorIndexOrNil: selector [
-	| specialIndex |
 	1 to: Smalltalk specialSelectorSize do:
 		[:index | 
 		(Smalltalk specialSelectorAt: index) == selector
-			ifTrue: [specialIndex := index ]].	
-	^ specialIndex
+			ifTrue: [^index ]].	
+	^ nil
 ]
 
 { #category : #'special objects' }


### PR DESCRIPTION
This is a small speedup for #specialSelectorIndexOrNil: to stop iterating when it finds a hit.

For a trivial test, this made senders of for #+ a little bit faster.

There are a lot more potentials for optimizing (e.g. check BytecodeEncoder>>specialSelectors instead of iterating slowly using specialSelectorAt:), but that is for later.


The method is tested by CompiledCodeTest>>#testHasSelectorSpecialSelectorIndex


