### PR TITLE
10273-RBSmalllintContextprimitiveComputeLiterals-can-just-use-EncoderspecialSelectors

### DIFF
--- a/src/HeuristicCompletion-Model/SystemNavigation.extension.st
+++ b/src/HeuristicCompletion-Model/SystemNavigation.extension.st
@@ -19,9 +19,7 @@ SystemNavigation >> allSentMessagesInClass: aClass do: aBlock [
 			(literal isMemberOf: Array) ifTrue: ["might be performed"
 				literal do: [:x | (x isSymbol) ifTrue: [ x == method selector ifFalse: [ aBlock value: x ]]]]]].
 	"The following may be sent without being in any literal frame"
-	1
-		to: Smalltalk specialSelectorSize
-		do: [:index | aBlock value: (Smalltalk specialSelectorAt: index)].
+	BytecodeEncoder specialSelectors do: [:selector | aBlock value: selector].
 ]
 
 { #category : #'*HeuristicCompletion-Model' }

--- a/src/Refactoring-Critics/RBSmalllintContext.class.st
+++ b/src/Refactoring-Critics/RBSmalllintContext.class.st
@@ -137,7 +137,7 @@ RBSmalllintContext >> parseTree [
 RBSmalllintContext >> primitiveComputeLiterals [
 	| semaphore |
 	literals := IdentitySet new: 25000.
-	literals addAll: self specialSelectors keys.
+	literals addAll: BytecodeEncoder specialSelectors.
 	selectors := IdentitySet new.
 	RBBrowserEnvironment new
 		classesDo: [ :each | self computeLiteralsForClass: each ].
@@ -230,15 +230,6 @@ RBSmalllintContext >> signalProcesses: aSemaphore [
 { #category : #accessing }
 RBSmalllintContext >> sourceCode [
 	^self selectedClass sourceCodeAt: self selector ifAbsent: [ '' ].
-]
-
-{ #category : #private }
-RBSmalllintContext >> specialSelectors [
-	| answer |
-	answer := IdentityDictionary new.
-	(Smalltalk specialSelectors select: [:sel | sel isSymbol]) do:
-		[:sel | answer at: sel put: nil.].
-	^answer.
 ]
 
 { #category : #accessing }

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -206,11 +206,8 @@ SystemNavigation >> allSentMessages [
 										m == sel ifFalse: [sent add: m]].
 								(m isMemberOf: Array) ifTrue: ["might be performed"
 										m do: [:x | (x isSymbol) ifTrue: [x == sel ifFalse: [sent add: x]]]]]]].
-		"The following may be sent without being in any literal frame"
-		1
-			to: Smalltalk specialSelectorSize
-			do: [:index | sent
-					add: (Smalltalk specialSelectorAt: index)].
+	"The following may be sent without being in any literal frame"
+	sent addAll: BytecodeEncoder specialSelectors.
 	^ sent
 ]
 


### PR DESCRIPTION
use "BytecodeEncoder specialSelectors" as a simpler way to get all special selectors.

(later we need to unify  #specialSelectors on BytecodeEncoder and SmalltalkImage)

fixes #10273


