### PR TITLE
Small changes to make flow clearer.

### DIFF
--- a/src/SystemCommands-RefactoringSupport/SycMethodNameEditorPresenter.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycMethodNameEditorPresenter.class.st
@@ -41,7 +41,8 @@ Class {
 		'methodName',
 		'args',
 		'invalidArgNames',
-		'canAddArgs'
+		'canAddArgs',
+		'canEditName'
 	],
 	#category : #'SystemCommands-RefactoringSupport'
 }
@@ -93,11 +94,22 @@ SycMethodNameEditorPresenter class >> example2 [
 		canAddArgs: true
 ]
 
+{ #category : #'instance creation' }
+SycMethodNameEditorPresenter class >> newApplication: anApplication model: aModel [
+
+	^ self basicNew
+		application: anApplication;
+		setModelBeforeInitialization: aModel;
+		initialize;
+		yourself
+]
+
 { #category : #specs }
 SycMethodNameEditorPresenter class >> openOn: aMethod [
 	"I take a RBMethodName as parameter and open the refactoring UI in a modal to rename it."
 	|temp|
 	temp := self on: aMethod.
+	self selectorInput beNotEditable.
 	^ temp openBlockedDialogWithSpec
 ]
 
@@ -127,21 +139,26 @@ SycMethodNameEditorPresenter class >> openOn: aMethod withInvalidArgs: aSet canR
 { #category : #action }
 SycMethodNameEditorPresenter >> addArgument [
 
-	| newArg argValue |
+	| newArg argValue newKeyword |
+	newKeyword := self getNewKeywordName.
+	newKeyword isEmptyOrNil ifTrue: [ CmdCommandAborted signal ].
 	newArg := self newArgName asSymbol.
 	argValue := self getDefaultValue.
 	argValue isEmptyOrNil ifTrue: [ CmdCommandAborted signal ].
 	newArg := RBArgumentName name: newArg value: argValue.
 	argumentsList items: { newArg }.
-	self selectorInput text: self selectorInput text , 'arg:'.
+	self selectorInput text: self selectorInput text , newKeyword ,':' .
 	argumentsList selectIndex: 1.
+	self canEditName: true.
 	self updateLabel
 ]
 
 { #category : #action }
 SycMethodNameEditorPresenter >> addArgumentAfter: anItem [
 
-	| newArg argValue selectedIndex |
+	| newArg argValue selectedIndex newKeyword |
+	newKeyword := self getNewKeywordName.
+	newKeyword isEmptyOrNil ifTrue: [ CmdCommandAborted signal ].
 	selectedIndex := argumentsList selection selectedIndex.
 	newArg := self newArgName asSymbol.
 	argValue := self getDefaultValue.
@@ -150,8 +167,9 @@ SycMethodNameEditorPresenter >> addArgumentAfter: anItem [
 	argumentsList items:
 		(argumentsList items copyUpThrough: anItem) , { newArg }
 		, (argumentsList items copyAfter: anItem).
-	self selectorInput text: self selectorInput text , 'arg:'.
+	self selectorInput text: self selectorInput text , newKeyword, ':'.
 	argumentsList selectIndex: selectedIndex + 1.
+	self canEditName: true.
 	self updateLabel
 ]
 
@@ -212,6 +230,17 @@ SycMethodNameEditorPresenter >> canAddArgs: aBoolean [
 ]
 
 { #category : #accessing }
+SycMethodNameEditorPresenter >> canEditName [
+	^canEditName  ifNil: [ canEditName := false ]
+]
+
+{ #category : #accessing }
+SycMethodNameEditorPresenter >> canEditName: aBoolean [
+	canEditName := aBoolean.
+	selectorInput enabled: canEditName .
+]
+
+{ #category : #accessing }
 SycMethodNameEditorPresenter >> canRemoveArgs: anObject [
 
 	argumentsList items do: [ :arg | arg canBeRemoved: anObject ]
@@ -256,6 +285,14 @@ SycMethodNameEditorPresenter >> getDefaultValue [
 		  initialAnswer: 'nil'
 ]
 
+{ #category : #action }
+SycMethodNameEditorPresenter >> getNewKeywordName [
+
+	^ self uiManager
+		  request: 'Enter name for new keyword'
+		  initialAnswer: 'arg'
+]
+
 { #category : #services }
 SycMethodNameEditorPresenter >> getParametersOrder [
 	^ argumentsList items collect: [ :arg | arg newName ]
@@ -268,12 +305,13 @@ SycMethodNameEditorPresenter >> initializeDialogWindow: aModalPresenter [
 		addButton: 'Rename' do: [ :presenter | self renameMethodAndClose: presenter ];
 		addButton: 'Cancel' do: [ :presenter | presenter beCancel; close ];
 		initialExtent: 600 @ 300 ;
-		title: 'Method name editor'
+		title: 'Method name editor : "', methodName selector ,'"'
 ]
 
 { #category : #initialization }
 SycMethodNameEditorPresenter >> initializePresenter [
 	selectorInput whenTextChangedDo: [ :text | self updateLabel ].
+	self canEditName:false.
 	upButton action: [ self pushUpSelectedArgument ].
 	downButton action: [ self pushDownSelectedArgument ].
 	addButton action: [ argumentsList items 
@@ -295,6 +333,7 @@ SycMethodNameEditorPresenter >> initializePresenter [
 { #category : #initialization }
 SycMethodNameEditorPresenter >> initializeWidgets [
 	selectorInput := self newTextInput.
+	selectorInput editable: false.
 	argumentsList := self newList.
 	previewResult := self newLabel.
 	upButton := self newButton.
@@ -307,6 +346,7 @@ SycMethodNameEditorPresenter >> initializeWidgets [
 	addButton label: '+'.
 	selectorInput text: methodName selector.
 	previewResult label: methodName methodName.
+	selectorInput beNotEditable.
 	
 	self setFocus
 ]


### PR DESCRIPTION
Changed SycMethodNameEditorPresenter to change the UI for the Add Argument refactoring
![image](https://user-images.githubusercontent.com/45406261/139329064-9b06b3f5-a3b0-4aaa-83ec-99528d8eecf1.png)
Title now includes method name. Selector input is not editable until an argument has been added, to prevent the user from changing it too soon and getting an invalid selector name.
![image](https://user-images.githubusercontent.com/45406261/139328783-8f0deef6-e089-43a6-9d22-ca2182d60d02.png)
![image](https://user-images.githubusercontent.com/45406261/139328502-3ced9209-362e-48a9-beeb-b7809929f499.png)

User can now enter the keyword name before the default value.
![image](https://user-images.githubusercontent.com/45406261/139328310-ee8311f8-885e-43fa-8a73-a968fec4e9f0.png)

