### PR TITLE
Consistently categorize #startUp: and shutDown: methods

### DIFF
--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -313,7 +313,7 @@ Symbol class >> selectorsContaining: aString [
 "Symbol selectorsContaining: 'scon'"
 ]
 
-{ #category : #private }
+{ #category : #'system startup' }
 Symbol class >> shutDown: aboutToQuit [
 
 	SymbolTable addAll: NewSymbols.

--- a/src/FFI-Kernel/ExternalAddress.class.st
+++ b/src/FFI-Kernel/ExternalAddress.class.st
@@ -57,7 +57,7 @@ ExternalAddress class >> new: n [
 		ifFalse: [self shouldNotImplement]
 ]
 
-{ #category : #'class initialization' }
+{ #category : #'system startup' }
 ExternalAddress class >> startUp: resuming [
 	"If starting the image afresh all external addresses should be zero.
 	 In addition, if the word size has changed then external addresses shoiuld be resized.

--- a/src/FFI-Kernel/FFIBackend.class.st
+++ b/src/FFI-Kernel/FFIBackend.class.st
@@ -45,12 +45,12 @@ FFIBackend class >> reset [
 	Current := nil.
 ]
 
-{ #category : #accessing }
+{ #category : #'system startup' }
 FFIBackend class >> startUp: isImageStarting [
 	
 	isImageStarting ifFalse: [ ^ self ].
 	
-	Current := nil.
+	Current := nil
 ]
 
 { #category : #'instance creation' }

--- a/src/FileSystem-Core/FileSystem.class.st
+++ b/src/FileSystem-Core/FileSystem.class.st
@@ -23,7 +23,7 @@ Class {
 	#category : #'FileSystem-Core-Public'
 }
 
-{ #category : #initializing }
+{ #category : #'system startup' }
 FileSystem class >> startUp: aBoolean [
 	"This is only here to deal with migration from older versions of
 	FileSystem that wanted to receive startup notifcations."

--- a/src/FileSystem-Disk/FileHandle.class.st
+++ b/src/FileSystem-Disk/FileHandle.class.st
@@ -27,7 +27,7 @@ FileHandle class >> registry [
 
 ]
 
-{ #category : #'class initialization' }
+{ #category : #'system startup' }
 FileHandle class >> startUp: resuming [
 	"This functionality is disabled for now, to avoid doing a lot of processing at
 	image start up. To reenable, add this class to the start up list."

--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -1325,7 +1325,7 @@ File class >> sizeOrNil: id [
 	^ nil
 ]
 
-{ #category : #'class initialization' }
+{ #category : #'system startup' }
 File class >> startUp: isImageStarting [
 	"Update VM constants on startup"
 

--- a/src/Files/Stdio.class.st
+++ b/src/Files/Stdio.class.st
@@ -91,7 +91,7 @@ Stdio class >> standardIOStreamNamed: moniker forWrite: forWrite [
 	^ StdioStream handle: handle file: (File named: moniker) forWrite: forWrite
 ]
 
-{ #category : #'startup - shutdown' }
+{ #category : #'system startup' }
 Stdio class >> startUp: resuming [
 
 	resuming ifTrue: [ self cleanStdioHandles ].

--- a/src/Fonts-Infrastructure/LogicalFont.class.st
+++ b/src/Fonts-Infrastructure/LogicalFont.class.st
@@ -105,7 +105,7 @@ LogicalFont class >> new [
 	^ self all add: super new
 ]
 
-{ #category : #shutdown }
+{ #category : #'system startup' }
 LogicalFont class >> shutDown: quitting [
 
 	self allSubInstances do: [ :i | i clearRealFont ]

--- a/src/System-Platforms/OSPlatform.class.st
+++ b/src/System-Platforms/OSPlatform.class.st
@@ -216,13 +216,13 @@ OSPlatform >> platformName [
 	^ self name
 ]
 
-{ #category : #initialize }
+{ #category : #'system startup' }
 OSPlatform >> shutDown: quitting [
 	"Pharo is shutting down. If this platform requires specific shutdown code, this is a great place to put it."
 
 ]
 
-{ #category : #initialize }
+{ #category : #'system startup' }
 OSPlatform >> startUp: resuming [
 	"Pharo is starting up. If this platform requires specific initialization, this is a great place to put it."
 

--- a/src/System-SessionManager/SessionAccessModeResolver.class.st
+++ b/src/System-SessionManager/SessionAccessModeResolver.class.st
@@ -41,7 +41,7 @@ SessionAccessModeResolver class >> resolve [
 	SessionManager default currentSession accessMode: mode.
 ]
 
-{ #category : #'class initialization' }
+{ #category : #'system startup' }
 SessionAccessModeResolver class >> startUp: resuming [
 
 	resuming ifTrue: [

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -25,7 +25,7 @@ SourceFileArray class >> initialize [
 	SessionManager default registerSystemClassNamed: self name.
 ]
 
-{ #category : #'class initialization' }
+{ #category : #'system startup' }
 SourceFileArray class >> startUp: resuming [
 
 	resuming ifTrue: [ Smalltalk openSourceFiles ]

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -77,13 +77,13 @@ SmalltalkImage class >> new [
 	self error: 'Use current'.
 ]
 
-{ #category : #initialization }
+{ #category : #'system startup' }
 SmalltalkImage class >> shutDown: isImageClosing [
 
 	isImageClosing ifTrue: [ SourceFiles close ].
 ]
 
-{ #category : #initialization }
+{ #category : #'system startup' }
 SmalltalkImage class >> startUp: isImageStarting [
 	
 	ChangesLog default

--- a/src/ThreadedFFI/TFCallbackQueue.class.st
+++ b/src/ThreadedFFI/TFCallbackQueue.class.st
@@ -28,7 +28,7 @@ TFCallbackQueue class >> initialize [
 	self startUp: true
 ]
 
-{ #category : #'startup - shutdown' }
+{ #category : #'system startup' }
 TFCallbackQueue class >> shutDown: inANewImageSession [
 
 	inANewImageSession ifFalse: [ ^ self ].
@@ -36,7 +36,7 @@ TFCallbackQueue class >> shutDown: inANewImageSession [
 	UniqueInstance := nil
 ]
 
-{ #category : #'startup - shutdown' }
+{ #category : #'system startup' }
 TFCallbackQueue class >> startUp: inANewImageSession [
 
 	inANewImageSession ifFalse: [ ^ self ].


### PR DESCRIPTION
Fix #10300