### PR TITLE
Microoptimization-MethodDictionary-scanFor

### DIFF
--- a/src/Kernel/MethodDictionary.class.st
+++ b/src/Kernel/MethodDictionary.class.st
@@ -305,12 +305,12 @@ MethodDictionary >> scanFor: anObject [
 
 	"Search from (hash mod size) to the end."
 	start to: finish do:
-		[:index | ((element := self basicAt: index) isNil or: [element == anObject])
+		[:index | ((element := self basicAt: index) == nil or: [element == anObject])
 			ifTrue: [^ index ]].
 
 	"Search from 1 to where we started."
 	1 to: start-1 do:
-		[:index | ((element := self basicAt: index) isNil or: [element == anObject])
+		[:index | ((element := self basicAt: index) == nil or: [element == anObject])
 			ifTrue: [^ index ]].
 
 	^ 0  "No match AND no empty slot"

--- a/src/OpalCompiler-Core/OCLiteralSet.class.st
+++ b/src/OpalCompiler-Core/OCLiteralSet.class.st
@@ -33,13 +33,13 @@ OCLiteralSet >> scanFor: anObject [
 
 	"Search from (hash mod size) to the end."
 	start to: finish do:
-		[:index | ((element := array at: index) isNil
+		[:index | ((element := array at: index) == nil
 					or: [element literalEqual: anObject])
 					ifTrue: [^ index ]].
 
 	"Search from 1 to where we started."
 	1 to: start-1 do:
-		[:index | ((element := array at: index) isNil
+		[:index | ((element := array at: index) == nil
 					or: [element literalEqual: anObject])
 					ifTrue: [^ index ]].
 


### PR DESCRIPTION
All #scanFor: methods use == nil instead of #isNil to avoid one message send.

This PR unifies the situation and does this for MethodDictionary and the OCLiteralSet, too.

"implementors of" got 2% faster for me with this change.


