### PR TITLE
Breakpoint-timeSpamp-unchanged-test

### DIFF
--- a/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
@@ -66,23 +66,25 @@ BreakpointTest >> testAddRemoveBreakpoint [
 
 { #category : #tests }
 BreakpointTest >> testAddRemoveBreakpointKeepTimeStamp [
+
 	| bp timeStamp |
 	"adding an removing a breakpoint does not change the timestamp of the method"
-	
-	cls compile: 'dummy ^42'.
-	
+	Author
+		useAuthor: thisContext method selector
+		during: [ cls compile: 'dummy ^42' ].
+
 	timeStamp := (cls >> #dummy) timeStamp.
-	
+
 	bp := Breakpoint new.
-	bp	node: (cls >> #dummy) ast.
+	bp node: (cls >> #dummy) ast.
 	bp install.
-	
+
 	self assert: (cls >> #dummy) timeStamp equals: timeStamp.
-	
+
 	bp remove.
 	self assertEmpty: Breakpoint all.
-	
-	self assert: (cls >> #dummy) timeStamp equals: timeStamp.
+
+	self assert: (cls >> #dummy) timeStamp equals: timeStamp
 ]
 
 { #category : #tests }

--- a/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
@@ -58,6 +58,27 @@ BreakpointTest >> testAddRemoveBreakpoint [
 ]
 
 { #category : #tests }
+BreakpointTest >> testAddRemoveBreakpointKeepTimeStamp [
+	| bp timeStamp |
+	"adding an removing a breakpoint does not change the timestamp of the method"
+	
+	cls compile: 'dummy ^42'.
+	
+	timeStamp := (cls >> #dummy) timeStamp.
+	
+	bp := Breakpoint new.
+	bp	node: (cls >> #dummy) ast.
+	Breakpoint addBreakpoint: bp.
+	
+	self assert: (cls >> #dummy) timeStamp equals: timeStamp.
+	
+	Breakpoint removeBreakpoint: bp.
+	self assertEmpty: Breakpoint all.
+	
+	self assert: (cls >> #dummy) timeStamp equals: timeStamp.
+]
+
+{ #category : #tests }
 BreakpointTest >> testBreakInContextNode [
 
 	|observer breakpoint|

--- a/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
@@ -46,15 +46,22 @@ BreakpointTest >> tearDown [
 
 { #category : #tests }
 BreakpointTest >> testAddRemoveBreakpoint [
-	|bp|
+	| bp method |
 	cls compile: 'dummy ^42'.
+	method := cls >> #dummy.
 	self assertEmpty: Breakpoint all.
 	bp := Breakpoint new.
 	bp	node: (cls >> #dummy) ast.
-	Breakpoint addBreakpoint: bp.
+	bp install.
+	"after the breakpoint is installed, the method is different"
+	self deny: (cls >> #dummy) bytecode equals: method bytecode.
+	
 	self assertCollection: Breakpoint all includesAll: {bp}.
-	Breakpoint removeBreakpoint: bp.
+	bp remove.
 	self assertEmpty: Breakpoint all.
+	
+	"Check that the method is correcty reverted"
+	self assert: (cls >> #dummy) bytecode equals: method bytecode
 ]
 
 { #category : #tests }
@@ -68,11 +75,11 @@ BreakpointTest >> testAddRemoveBreakpointKeepTimeStamp [
 	
 	bp := Breakpoint new.
 	bp	node: (cls >> #dummy) ast.
-	Breakpoint addBreakpoint: bp.
+	bp install.
 	
 	self assert: (cls >> #dummy) timeStamp equals: timeStamp.
 	
-	Breakpoint removeBreakpoint: bp.
+	bp remove.
 	self assertEmpty: Breakpoint all.
 	
 	self assert: (cls >> #dummy) timeStamp equals: timeStamp.


### PR DESCRIPTION
This adds a test that checks that the timestamp is not changed when installing and removing a breakpoint from a method


