### PR TITLE
10334-Metaclass-should-be-able-to-answer-hasClassVarNamed 

### DIFF
--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -272,6 +272,13 @@ ClassTest >> testHasBindingThatBeginsWith [
 
 ]
 
+{ #category : #'tests - class variables' }
+ClassTest >> testHasClassVarNamed [
+
+	self assert: (Object hasClassVarNamed: #DependentsFields).
+	self deny: (Object hasClassVarNamed: #CompilerClass)
+]
+
 { #category : #'tests - access' }
 ClassTest >> testHasPoolVarNamed [	
 

--- a/src/Kernel-Tests/MetaClassTest.class.st
+++ b/src/Kernel-Tests/MetaClassTest.class.st
@@ -12,3 +12,19 @@ MetaClassTest >> testHasBindingThatBeginsWith [
 	"Pools are looked up, too"
 	self assert: (TimeZone class hasBindingThatBeginsWith: 'DaysInMo')
 ]
+
+{ #category : #tests }
+MetaClassTest >> testHasClassVarNamed [
+
+	self assert: (Object class hasClassVarNamed: #DependentsFields).
+	self deny: (Object class hasClassVarNamed: #CompilerClass)
+]
+
+{ #category : #tests }
+MetaClassTest >> testclassVarNames [
+
+	self assert: (Object class classVarNames includes: #DependentsFields).
+	
+	"A class and it's meta-class share the class variables"
+	self assert: Object class classVarNames equals: Object classVarNames
+]

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -149,6 +149,14 @@ Metaclass >> hasClassSide [
 	^ false
 ]
 
+{ #category : #'accessing - instances and variables' }
+Metaclass >> hasClassVarNamed: aString [
+
+	^self instanceSide 
+		ifNil: [ false ]
+		ifNotNil: [ :class | class hasClassVarNamed: aString ]
+]
+
 { #category : #compiling }
 Metaclass >> innerBindingOf: varName [
 


### PR DESCRIPTION
- add Metaclass>>#hasClassVarNamed:
- add test for testHasClassVarNamed for both MetaClass and Class
- add testclassVarNames for MetaClassTest

fixes #10334


