### PR TITLE
10059-cannot-save-method-when-it-contains-a-breakpoint

### DIFF
--- a/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
@@ -351,3 +351,23 @@ BreakpointTest >> testUninstallFromGarbageCollectedInstance [
 	
 	self shouldnt: [ bp remove ] raise: Error.
 ]
+
+{ #category : #tests }
+BreakpointTest >> testUpdateMethod [
+	| bp method |
+	"test that, if we install a breakpoint and edit the method, it is removed correctly"
+	
+	cls compile: 'dummy ^42'.
+	method := cls >> #dummy.
+	self assertEmpty: Breakpoint all.
+	bp := Breakpoint new.
+	bp	node: (cls >> #dummy) ast.
+	bp install.
+	self assertCollection: Breakpoint all includesAll: {bp}.
+	"no edit the method"
+	cls compile: 'dummy ^nil'.
+	"after the new method is installed, the method is different"
+	self deny: (cls >> #dummy) bytecode equals: method bytecode.
+	"and the breakpoint is not registered anymore"
+	self assertEmpty: Breakpoint all
+]

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -384,14 +384,14 @@ Breakpoint >> remove [
 
 { #category : #removing }
 Breakpoint >> removeFromClass: aClass [
-
+	"we just remove this breakpoint from the cache, overridden by VariableBreakpoint to do more"
 	self class removeBreakpoint: self
 ]
 
 { #category : #removing }
 Breakpoint >> removeFromMethod: aMethod [
-
-	self remove
+	"we just remove this breakpoint from the cache, overridden by VariableBreakpoint to do more"
+	self class removeBreakpoint: self
 ]
 
 { #category : #removing }


### PR DESCRIPTION
- add a test #testUpdateMethod, it fails in the current version to show the bug
- change #removeFromMethod: to not call #remove, which would re-install the old AST, instead just remove the breakpoint from the list of all breakpoints

fixes #10059

