### PR TITLE
rescue testForTiltedStickyness 

### DIFF
--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -3746,11 +3746,11 @@ Morph >> isSteppingSelector: aSelector [
 		ifNotNil:	[aWorld isStepping: self selector: aSelector]
 ]
 
-{ #category : #accessing }
+{ #category : #testing }
 Morph >> isSticky [
 	"answer whether the receiver is Sticky"
-	extension ifNil: [^ false].
-	^ extension sticky
+
+	^ extension ifNil: [ false ] ifNotNil: [ :ext | ext sticky ]
 ]
 
 { #category : #classification }

--- a/src/Morphic-Tests/MorphTest.class.st
+++ b/src/Morphic-Tests/MorphTest.class.st
@@ -58,6 +58,22 @@ MorphTest >> testExtent [
 	self assert: b2 equals: b1
 ]
 
+{ #category : #'testing - testing' }
+MorphTest >> testForTiltedStickyness [
+
+	| m |
+	m := Morph new openCenteredInWorld.
+	self assert: m topRendererOrSelf isSticky not.
+	m beSticky.
+	self assert: m topRendererOrSelf isSticky.
+	m addFlexShell.
+	m topRendererOrSelf rotationDegrees: 45.0.
+	self assert: m topRendererOrSelf isSticky.
+	m beUnsticky.
+	self assert: m topRendererOrSelf isSticky not.
+	m topRendererOrSelf delete
+]
+
 { #category : #'testing - halo' }
 MorphTest >> testHaloIsDisable [
 	| isHaloEnable |


### PR DESCRIPTION
The removed code in #10218 contains one useful test. This PR adds it to MorphTest

- add testForTiltedStickyness
- categorize isSticky as "testing" and use ifNotNil