### PR TITLE
10353-Backport-Pharo9-CI-ZnHTTPSTesttestGmailEncrypted-started-failing-on-the-CI- 

### DIFF
--- a/src/Zinc-HTTP/ZnClient.class.st
+++ b/src/Zinc-HTTP/ZnClient.class.st
@@ -915,9 +915,9 @@ ZnClient >> maxNumberOfRedirects [
 	"Return the maximum number of HTTP redirect that will be followed.
 	Note that when the #followsRedirect option is false, 
 	no redirects will ever be followed regardless of the value of this option.
-	Defaults to 3. A ZnTooManyRedirects will be signalled when the count reaches zero."
+	Defaults to 5. A ZnTooManyRedirects will be signalled when the count reaches zero."
 
-	^ self optionAt: #maxNumberOfRedirects ifAbsent: [ 3 ]
+	^ self optionAt: #maxNumberOfRedirects ifAbsent: [ 5 ]
 ]
 
 { #category : #options }


### PR DESCRIPTION

backport #10290