### PR TITLE
Fix Zinc extensions should use correct casing (package name)

### DIFF
--- a/src/Zinc-HTTP/ZnUrl.extension.st
+++ b/src/Zinc-HTTP/ZnUrl.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #ZnUrl }
 
-{ #category : #'*zinc-http' }
+{ #category : #'*Zinc-HTTP' }
 ZnUrl >> retrieveContents [
 	"Download and return the resource that I refer to.
 	This will typically return a String or a ByteArray.
@@ -11,7 +11,7 @@ ZnUrl >> retrieveContents [
 	^ self performOperation: #retrieveContents
 ]
 
-{ #category : #'*zinc-http' }
+{ #category : #'*Zinc-HTTP' }
 ZnUrl >> saveContentsToFile: aFilename [
 	"Download and return a fileReference to the resource that I refer to.
 

--- a/src/Zinc-Resource-Meta-Core/Collection.extension.st
+++ b/src/Zinc-Resource-Meta-Core/Collection.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #Collection }
 
-{ #category : #'*zinc-resource-meta-core' }
+{ #category : #'*Zinc-Resource-Meta-Core' }
 Collection >> addedToZnUrl: url [ 
 	^ url withPathSegments: self
 ]

--- a/src/Zinc-Resource-Meta-Core/String.extension.st
+++ b/src/Zinc-Resource-Meta-Core/String.extension.st
@@ -1,23 +1,23 @@
 Extension { #name : #String }
 
-{ #category : #'*zinc-resource-meta-core' }
+{ #category : #'*Zinc-Resource-Meta-Core' }
 String >> addedToZnUrl: url [
 	| segments |
 	segments := self findTokens: '/'.
 	^ url withPathSegments: segments
 ]
 
-{ #category : #'*zinc-resource-meta-core' }
+{ #category : #'*Zinc-Resource-Meta-Core' }
 String >> asUrl [
 	^ self asZnUrl 
 ]
 
-{ #category : #'*zinc-resource-meta-core' }
+{ #category : #'*Zinc-Resource-Meta-Core' }
 String >> asZnMimeType [
 	^ ZnMimeType fromString: self
 ]
 
-{ #category : #'*zinc-resource-meta-core' }
+{ #category : #'*Zinc-Resource-Meta-Core' }
 String >> asZnUrl [
 	^ ZnUrl fromString: self
 ]

--- a/src/Zinc-Resource-Meta-FileSystem/AbsolutePath.extension.st
+++ b/src/Zinc-Resource-Meta-FileSystem/AbsolutePath.extension.st
@@ -1,13 +1,13 @@
 Extension { #name : #AbsolutePath }
 
-{ #category : #'*zinc-resource-meta-filesystem' }
+{ #category : #'*Zinc-Resource-Meta-FileSystem' }
 AbsolutePath >> asUrl [
 	"Convert the receiver in a file:// ZnUrl"
 
 	^ self asZnUrl
 ]
 
-{ #category : #'*zinc-resource-meta-filesystem' }
+{ #category : #'*Zinc-Resource-Meta-FileSystem' }
 AbsolutePath >> asZnUrl [
 	"Convert the receiver in a file:// ZnUrl"
 

--- a/src/Zinc-Resource-Meta-FileSystem/AbstractFileReference.extension.st
+++ b/src/Zinc-Resource-Meta-FileSystem/AbstractFileReference.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #AbstractFileReference }
 
-{ #category : #'*zinc-resource-meta-filesystem' }
+{ #category : #'*Zinc-Resource-Meta-FileSystem' }
 AbstractFileReference >> asUrl [
 	"Convert the receiver in a file:// ZnUrl.
 	Only an absolute path can be represented as a file:// URL"
@@ -8,7 +8,7 @@ AbstractFileReference >> asUrl [
 	^ self asZnUrl
 ]
 
-{ #category : #'*zinc-resource-meta-filesystem' }
+{ #category : #'*Zinc-Resource-Meta-FileSystem' }
 AbstractFileReference >> asZnUrl [
 	"Convert the receiver in a file:// ZnUrl.
 	Only an absolute path can be represented as a file:// URL"

--- a/src/Zinc-Resource-Meta-FileSystem/ZnUrl.extension.st
+++ b/src/Zinc-Resource-Meta-FileSystem/ZnUrl.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #ZnUrl }
 
-{ #category : #'*zinc-resource-meta-filesystem' }
+{ #category : #'*Zinc-Resource-Meta-FileSystem' }
 ZnUrl >> asFileReference [
 	"Convert the receiver into a new FileReference object.
 	Note that for a FileReference a trailing slash is not relevant"

--- a/src/Zinc-Tests/ZnUrlTest.extension.st
+++ b/src/Zinc-Tests/ZnUrlTest.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #ZnUrlTest }
 
-{ #category : #'*zinc-tests' }
+{ #category : #'*Zinc-Tests' }
 ZnUrlTest >> testRetrieveContents [
 	| numbers |
 	numbers := 'http://zn.stfx.eu/zn/numbers.txt' asZnUrl retrieveContents.
@@ -9,7 +9,7 @@ ZnUrlTest >> testRetrieveContents [
 	self should: [ 'http://zn.stfx.eu/zn/numbers-wrong.txt' asZnUrl retrieveContents ] raise: Error
 ]
 
-{ #category : #'*zinc-tests' }
+{ #category : #'*Zinc-Tests' }
 ZnUrlTest >> testSaveContentsToFile [
 	| url target result numbers |
 	url := 'http://zn.stfx.eu/zn/numbers.txt' asZnUrl.


### PR DESCRIPTION
Fix #10360 

Something that possibly @svenvc can also merge back into https://github.com/svenvc/zinc
