### PR TITLE
[P9] 10208-Cannot-inline-method-if-the-code-to-inline-is-not-an-immediate-node

### DIFF
--- a/src/SystemCommands-SourceCodeCommands/SycInlineMethodCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycInlineMethodCommand.class.st
@@ -17,10 +17,15 @@ SycInlineMethodCommand class >> canBeExecutedInContext: aSourceCodeContext [
 { #category : #execution }
 SycInlineMethodCommand >> asRefactorings [
 
-	^ {RBInlineMethodRefactoring
-		  inline: sourceNode sourceInterval
-		  inMethod: method selector
-		  forClass: method origin}
+	^ { ((RBInlineMethodRefactoring
+		    inline: sourceNode sourceInterval
+		    inMethod: method selector
+		    forClass: method origin)
+		   setOption: #inlineExpression toUse: [ :ref :aString | 
+			   self confirm:
+					   ('Do you want to inline the expression ''<1s>'' in the current method?' 
+						    expandMacrosWith: aString) ];
+		   yourself) }
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fix #10208