### PR TITLE
[P10] 10264-Text-Wrapping-is-not-working

### DIFF
--- a/src/Rubric/RubCharacterScanner.class.st
+++ b/src/Rubric/RubCharacterScanner.class.st
@@ -105,6 +105,10 @@ RubCharacterScanner >> basicScanCharactersFrom: startIndex to: stopIndex in: sou
 			"Note: The following is querying the font about the width
 			since the primitive may have failed due to a non-trivial
 			mapping of characters to glyphs or a non-existing xTable."
+			
+			(self isBreakableAt: lastIndex in: text) 
+				ifTrue: [ self registerBreakableIndex ].
+			
 			nextChar := (lastIndex + 1 <= stopIndex) 
 				ifTrue:[sourceString at: lastIndex + 1]
 				ifFalse:[
@@ -181,6 +185,19 @@ RubCharacterScanner >> initialize [
 	destX := destY := leftMargin := 0.
 ]
 
+{ #category : #'scanner methods' }
+RubCharacterScanner >> isBreakableAt: index in: sourceString [ 
+
+	| char |
+	
+	char := sourceString at: index.
+	char = Character space ifTrue: [^ true].
+	char = Character cr ifTrue: [^ true].
+
+	^ false.
+
+]
+
 { #category : #'text constants' }
 RubCharacterScanner >> justified [
 	^ 3
@@ -250,6 +267,16 @@ RubCharacterScanner >> plainTab [
 ]
 
 { #category : #scanning }
+RubCharacterScanner >> registerBreakableIndex [
+
+	"Record left x and character index of the line-wrappable point. 
+	The default implementation here does nothing."
+
+	^ false.
+
+]
+
+{ #category : #scanning }
 RubCharacterScanner >> scanCharactersFrom: startIndex to: stopIndex in: sourceString rightX: rightX stopConditions: stops kern: kernDelta [
 
 	sourceString isByteString
@@ -304,6 +331,10 @@ RubCharacterScanner >> scanMultiCharactersFrom: startIndex to: stopIndex in: sou
 		ascii > maxAscii ifTrue: [ascii := maxAscii].
 		(ascii < stops size and: [(stops at: ascii + 1) ~~ nil])
 			ifTrue: [^ stops at: ascii + 1].
+		
+		(self isBreakableAt: lastIndex in: sourceString) ifTrue: [
+			self registerBreakableIndex ].
+		
 		nextChar := (lastIndex + 1 <= stopIndex) 
 			ifTrue:[sourceString at: lastIndex + 1]
 			ifFalse:[

--- a/src/Rubric/RubCompositionScanner.class.st
+++ b/src/Rubric/RubCompositionScanner.class.st
@@ -158,6 +158,31 @@ RubCompositionScanner >> placeEmbeddedObject: anchoredMorph [
 	^ true
 ]
 
+{ #category : #scanning }
+RubCompositionScanner >> registerBreakableIndex [
+
+	"Record left x and character index of the line-wrappable point. 
+	Used for wrap-around. Answer whether the character has crossed the 
+	right edge of the composition rectangle of the paragraph."
+
+	(text at: lastIndex) = Character space ifTrue: [
+		breakAtSpace := true.
+		spaceX := destX.
+		spaceCount := spaceCount + 1.
+		lineHeightAtBreak := lineHeight.
+		baselineAtBreak := baseline.
+		breakableIndex := lastIndex.
+		destX > rightMargin ifTrue: 	[^self crossedX].
+	] ifFalse: [
+		breakAtSpace := false.
+		lineHeightAtBreak := lineHeight.
+		baselineAtBreak := baseline.
+		breakableIndex := lastIndex - 1.
+	].
+	^ false.
+
+]
+
 { #category : #accessing }
 RubCompositionScanner >> rightX [
 	"Meaningful only when a line has just been composed -- refers to the 

--- a/src/Rubric/RubDisplayScanner.class.st
+++ b/src/Rubric/RubDisplayScanner.class.st
@@ -155,7 +155,7 @@ RubDisplayScanner >> fillTextBackground [
 ]
 
 { #category : #'multilingual scanning' }
-RubDisplayScanner >> isBreakableAt: index in: sourceString in: encodingClass [
+RubDisplayScanner >> isBreakableAt: index in: sourceString [
 
 	^ false.
 


### PR DESCRIPTION
Recovering the wordwrap implementation that was lost when Latin1Encoder was removed.

Fix #10264