### PR TITLE
Fix #8443 Crash on step over

### DIFF
--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1642,7 +1642,8 @@ Context >> resume: value through: firstUnwindContext [
 	| context unwindBlock |
 	self isDead 
 		ifTrue: [ self cannotReturn: value to: self ].
-	context := firstUnwindContext.
+	context := firstUnwindContext ifNil: [thisContext findNextUnwindContextUpTo: self].
+	"note: nil value of firstUnwindContext is sent by #return:from: to invoke fresh search for first unwind context"
 	[ context isNil ] whileFalse: [	
 		context unwindComplete ifNil:[
 			context unwindComplete: true.
@@ -1697,13 +1698,13 @@ Context >> return: value [
 Context >> return: value from: aSender [ 
 	"For simulation.  Roll back self to aSender and return value from it.  Execute any unwind blocks on the way.  ASSUMES aSender is a sender of self"
 
-	| newTop context |
+	| newTop |
 	aSender isDead ifTrue: [
 		^ self send: #cannotReturn: to: self with: {value} super: false ].
 	newTop := aSender sender.
-	context := self findNextUnwindContextUpTo: newTop.
-	context ifNotNil: [
-		^ self send: #aboutToReturn:through: to: self with: {value. context} super: false] .
+	(self findNextUnwindContextUpTo: newTop) ifNotNil: [
+		^ self send: #aboutToReturn:through: to: self with: {value. nil} super: false]. 
+		"note: nil is sent to #resume:through via #aboutToReturn:through: to invoke fresh search for next unwind context there"
 	self releaseTo: newTop.
 	newTop ifNotNil: [ newTop push: value ].
 	^ newTop


### PR DESCRIPTION
When debugging things like this (and similar, described in the Issue #8443):
```
[^2] ensure: [Transcript cr; show: 'done']
```
if we step into the protected block [^2] and then step over ^2, we crash the image or get an infinite recursion etc.
This behavior happens because #return:from: supplies firstUnwindContext to #resume:through: (via #aboutToReturn:through:) but by the time this argument can be used in #resume:through: the #runUntilErrorOrReturnFrom: method inserts another unwind context before this supplied firstUnwindContext! As a result firstUnwindContext is no longer the first unwind context and the computation derails because it misses the new unwind context inserted during simulation.

The proposed fix communicates the fact the computation is in simulation by sending nil instead of the firstUnwindContext (from #return:from: to #resume:through: via #aboutToReturn:through:) causing a fresh search for the actual first unwind context is invoked at the right time - before executing #resume:through:

This creates a close link between a simulation environment and the execution environment which is not ideal so I've included a note explicitly pointing at the relationship. In theory though even VM could send nil as firstUnwindContext value and the code would still work so I guess the little hack is justifiable.

Best regards,
Jaromir