### PR TITLE
P9-10384-Performance-Regression-in-SmallInteger-/

### DIFF
--- a/src/Kernel/SmallInteger.class.st
+++ b/src/Kernel/SmallInteger.class.st
@@ -107,7 +107,16 @@ SmallInteger >> / aNumber [
 
 	<primitive: 10>
 	aNumber = 0 ifTrue: [^(ZeroDivide dividend: self) signal].
-	^super / aNumber
+
+	"This ugly type checking is needed because the implementation in the superclass assumes that the argument is a LargeInteger.
+	So, it is using a primitive message that is only in LargeInteger. 
+	Using the implementation in the superclass when we have a SmallInteger will fail the primitive and use the slow code.
+	At the end it is creating the same Fraction that is done here.
+	These duplication has to be avoided by correctly implementing the decision by using double dispatch."
+
+	^(aNumber isMemberOf: SmallInteger)
+		ifTrue: [(Fraction numerator: self denominator: aNumber) reduced]
+		ifFalse: [super / aNumber]
 ]
 
 { #category : #arithmetic }


### PR DESCRIPTION
In Pharo 9, we have introduced a performance regression.
We have modified the implementation to use the implementation in Integer >> #/ when the primitive fails.
However, this implementation is intended to be used with a parameter of type LargeInteger.
The implementation in Integer uses a primitive implemented for LargeIntegers.
Passing a SmallInteger force the execution of the fallback code in the primitive.

Simple Benchmark:

results := (1 to: 50) collect: [:x | [ 1000000 timesRepeat: [65 / 64 ]] timeToRun asMilliSeconds].
{results average asFloat. results stdev asFloat}.

Before the Fix: 668.2 ms +/- 15
After the Fix: 187.68 ms +/- 3

Fix #10384