### PR TITLE
Fix for Issue #10269 Replaced RBExtractToTemporaryRefactoring with RBExtractToTemporaryTra…

### DIFF
--- a/src/Refactoring-Help/RBBrowserSourceRefactoringHelp.class.st
+++ b/src/Refactoring-Help/RBBrowserSourceRefactoringHelp.class.st
@@ -40,7 +40,7 @@ RBBrowserSourceRefactoringHelp class >> extractMethodToComponentRefactoring [
 RBBrowserSourceRefactoringHelp class >> extractToTemporaryRefactoring [
 	^HelpTopic
 		title: 'Extract to temporary'
-		contents: RBExtractToTemporaryRefactoring comment
+		contents: RBExtractToTemporaryTransformation comment
 
 ]
 

--- a/src/Refactoring2-Transformations/RBExtractToTemporaryTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBExtractToTemporaryTransformation.class.st
@@ -1,3 +1,9 @@
+"
+Add a new temporary variable for the value of the selected code. Every place in this method using the same piece of code is replaced by accessing this new temporary variable instead.
+As the code is now only evaluated once for initializing the variable value, this refactoring may modify the behavior if the code statements didn't evaluate to the same value on every call.
+
+My preconditions verify that the new temporary name is a valid name and isn't already used (neither a temporary, an instance variable or a class variable).
+"
 Class {
 	#name : #RBExtractToTemporaryTransformation,
 	#superclass : #RBCompositeMethodTransformation,

--- a/src/SystemCommands-SourceCodeCommands/SycExtractTempCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractTempCommand.class.st
@@ -33,7 +33,7 @@ SycExtractTempCommand >> applyResultInContext: aSourceCodeContext [
 { #category : #execution }
 SycExtractTempCommand >> asRefactorings [
 
-	^ {RBExtractToTemporaryRefactoring
+	^ {RBExtractToTemporaryTransformation
 		  extract: sourceNode sourceInterval
 		  to: tempName
 		  from: method selector


### PR DESCRIPTION
Replaced RBExtractToTemporaryRefactoring with RBExtractToTemporaryTransformation and added class comment. This should fix an error with a DNU when selecting a portion of a series of cascades