### PR TITLE
Fix so that Rename Method refactoring does not start with a disabled text input

### DIFF
--- a/src/SystemCommands-MessageCommands/SycAddMessageArgumentCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycAddMessageArgumentCommand.class.st
@@ -27,6 +27,11 @@ SycAddMessageArgumentCommand class >> canBeExecutedInContext: aToolContext [
 	^aToolContext isMethodSelected
 ]
 
+{ #category : #testing }
+SycAddMessageArgumentCommand >> canEditName [
+	^ false
+]
+
 { #category : #requesting }
 SycAddMessageArgumentCommand >> canRemoveArgs [ 
 	^ false

--- a/src/SystemCommands-MessageCommands/SycChangeMessageSignatureCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycChangeMessageSignatureCommand.class.st
@@ -52,6 +52,11 @@ SycChangeMessageSignatureCommand >> canAddArgs [
 	^ true
 ]
 
+{ #category : #testing }
+SycChangeMessageSignatureCommand >> canEditName [
+	^ true
+]
+
 { #category : #requesting }
 SycChangeMessageSignatureCommand >> canRemoveArgs [
 	^ true
@@ -103,7 +108,8 @@ SycChangeMessageSignatureCommand >> requestNewMessageIn: aToolContext [
 	dialog := SycMethodNameEditorPresenter openOn: methodName withInvalidArgs: invalidArgNames
 		canRenameArgs: self canRenameArgs
 		canRemoveArgs: self canRemoveArgs
-		canAddArgs: self canAddArgs.
+		canAddArgs: self canAddArgs
+		canEditName: self canEditName .
 	dialog cancelled ifTrue: [  CmdCommandAborted signal ].
 	
 	originalMessage selector = methodName selector & (originalMessage argumentNames = methodName arguments)

--- a/src/SystemCommands-RefactoringSupport/SycMethodNameEditorPresenter.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycMethodNameEditorPresenter.class.st
@@ -109,7 +109,6 @@ SycMethodNameEditorPresenter class >> openOn: aMethod [
 	"I take a RBMethodName as parameter and open the refactoring UI in a modal to rename it."
 	|temp|
 	temp := self on: aMethod.
-	self selectorInput beNotEditable.
 	^ temp openBlockedDialogWithSpec
 ]
 
@@ -133,6 +132,19 @@ SycMethodNameEditorPresenter class >> openOn: aMethod withInvalidArgs: aSet canR
 	temp canRenameArgs: aBoolean1.
 	temp canRemoveArgs: aBoolean2.
 	temp canAddArgs: aBoolean3.
+	^ temp openBlockedDialogWithSpec
+]
+
+{ #category : #specs }
+SycMethodNameEditorPresenter class >> openOn: aMethod withInvalidArgs: aSet canRenameArgs: aBoolean1 canRemoveArgs: aBoolean2 canAddArgs: aBoolean3 canEditName: aBoolean4 [
+	"I take a RBMethodName as parameter and open the refactoring UI in a modal to rename it."
+	|temp|
+	temp := self on: aMethod.
+	temp invalidArgNames: aSet. 
+	temp canRenameArgs: aBoolean1.
+	temp canRemoveArgs: aBoolean2.
+	temp canAddArgs: aBoolean3.
+	temp canEditName: aBoolean4.
 	^ temp openBlockedDialogWithSpec
 ]
 
@@ -231,7 +243,7 @@ SycMethodNameEditorPresenter >> canAddArgs: aBoolean [
 
 { #category : #accessing }
 SycMethodNameEditorPresenter >> canEditName [
-	^canEditName  ifNil: [ canEditName := false ]
+	^canEditName  ifNil: [ canEditName := true ]
 ]
 
 { #category : #accessing }
@@ -311,7 +323,7 @@ SycMethodNameEditorPresenter >> initializeDialogWindow: aModalPresenter [
 { #category : #initialization }
 SycMethodNameEditorPresenter >> initializePresenter [
 	selectorInput whenTextChangedDo: [ :text | self updateLabel ].
-	self canEditName:false.
+	selectorInput editable: self canEditName.
 	upButton action: [ self pushUpSelectedArgument ].
 	downButton action: [ self pushDownSelectedArgument ].
 	addButton action: [ argumentsList items 
@@ -333,7 +345,7 @@ SycMethodNameEditorPresenter >> initializePresenter [
 { #category : #initialization }
 SycMethodNameEditorPresenter >> initializeWidgets [
 	selectorInput := self newTextInput.
-	selectorInput editable: false.
+	selectorInput editable: self canEditName.
 	argumentsList := self newList.
 	previewResult := self newLabel.
 	upButton := self newButton.
@@ -346,7 +358,7 @@ SycMethodNameEditorPresenter >> initializeWidgets [
 	addButton label: '+'.
 	selectorInput text: methodName selector.
 	previewResult label: methodName methodName.
-	selectorInput beNotEditable.
+	"selectorInput beNotEditable."
 	
 	self setFocus
 ]


### PR DESCRIPTION
Fix for issue #10332 