### PR TITLE
Cleanup newlines and blanks in "CodeExport" and "CodeImport" packages

### DIFF
--- a/src/CodeExport/Class.extension.st
+++ b/src/CodeExport/Class.extension.st
@@ -70,7 +70,6 @@ Class >> fileOutSharedPoolsOn: aFileStream [
 	poolsToFileOut := self sharedPools select: 
 		[:aPool | (self shouldFileOutPool: (self environment keyAtIdentityValue: aPool))].
 	poolsToFileOut do: [:aPool | self fileOutPool: aPool onFileStream: aFileStream].
-	
 ]
 
 { #category : #'*CodeExport' }

--- a/src/CodeExport/ClassDescription.extension.st
+++ b/src/CodeExport/ClassDescription.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #ClassDescription }
 { #category : #'*CodeExport' }
 ClassDescription >> fileOutCategory: catName [ 
 
-	self organization fileOutCategory: catName 
+	self organization fileOutCategory: catName
 ]
 
 { #category : #'*CodeExport' }
@@ -103,7 +103,6 @@ ClassDescription >> printCategoryChunk: category on: aFileStream withStamp: chan
 			[strm nextPutAll: ' stamp: '; print: changeStamp].
 		priorMethod ~~ nil ifTrue:
 			[strm nextPutAll: ' prior: '; print: priorMethod sourcePointer]]).
-	
 ]
 
 { #category : #'*CodeExport' }

--- a/src/CodeExport/SystemOrganizer.extension.st
+++ b/src/CodeExport/SystemOrganizer.extension.st
@@ -14,7 +14,6 @@ SystemOrganizer >> fileOut [
 		writeSourceCodeFrom: internalStream 
 		baseName: 'SystemOrganization.st' asFileReference nextVersion basenameWithoutExtension 
 		isSt: true
-
 ]
 
 { #category : #'*CodeExport' }
@@ -25,7 +24,7 @@ SystemOrganizer >> fileOutCategory: category [
 	| internalStream |
 	internalStream := (String new: 1000) writeStream.
 	self fileOutCategory: category on: internalStream.
-	^ CodeExporter writeSourceCodeFrom: internalStream baseName: category isSt: true 
+	^ CodeExporter writeSourceCodeFrom: internalStream baseName: category isSt: true
 ]
 
 { #category : #'*CodeExport' }

--- a/src/CodeImport/ChunkFileFormatParser.class.st
+++ b/src/CodeImport/ChunkFileFormatParser.class.st
@@ -25,7 +25,7 @@ ChunkFileFormatParser class >> for: aReadStream [
 
 { #category : #accessing }
 ChunkFileFormatParser >> addDeclaration: aDeclaration [
-	parsedDeclarations	 add: aDeclaration 
+	parsedDeclarations	 add: aDeclaration
 ]
 
 { #category : #'class factory' }
@@ -127,7 +127,7 @@ ChunkFileFormatParser >> methodsForSelector: anObject [
 { #category : #parsing }
 ChunkFileFormatParser >> parseChunks [
 	[ readStream atEnd ] whileFalse: [ self parseNextDeclaration ].
-	^ parsedDeclarations 
+	^ parsedDeclarations
 ]
 
 { #category : #parsing }

--- a/src/CodeImport/CodeImporter.class.st
+++ b/src/CodeImport/CodeImporter.class.st
@@ -57,7 +57,6 @@ CodeImporter class >> chunksFromFileNamed: aFileName [
 	^ (self fileNamed: aFileName)
 			parseChunks;
 			codeDeclarations.
-
 ]
 
 { #category : #'instance creation' }
@@ -65,7 +64,6 @@ CodeImporter class >> chunksFromStream: aStream [
 	^ (self fileStream: aStream)
 			parseChunks;
 			codeDeclarations.
-
 ]
 
 { #category : #evaluating }
@@ -91,7 +89,6 @@ CodeImporter class >> evaluateString: aString [
 { #category : #'instance creation' }
 CodeImporter class >> fileNamed: aFileName [
 	^ self new file: (aFileName asFileReference readStream).
-
 ]
 
 { #category : #'instance creation' }

--- a/src/CodeImport/MissingClassError.class.st
+++ b/src/CodeImport/MissingClassError.class.st
@@ -66,12 +66,10 @@ MissingClassError >> isResumable [
 MissingClassError >> superclassName [
 
 	^ superclassName ifNil: [ superclassName := 'Object' ]
-
 ]
 
 { #category : #accessing }
 MissingClassError >> superclassName: aString [
 
 	superclassName := aString
-
 ]

--- a/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
+++ b/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
@@ -181,7 +181,6 @@ STCommandLineHandler >> installSourceFiles [
 	[ sourceFiles do: [ :reference | 
 		self installSourceFile: reference ]
 	] ensure: [ sourceFiles := nil ].
-	
 ]
 
 { #category : #loading }
@@ -189,7 +188,6 @@ STCommandLineHandler >> loadSourceFiles: anArray [
 	"Load all the source files in the given array."
 
 	sourceFiles := anArray collect: [ :each | File named: each ].
-
 ]
 
 { #category : #activation }
@@ -211,5 +209,4 @@ STCommandLineHandler >> skipShebangFrom: readStream [
 	
 	"here we found the shebang, so skip the first line"
 	^ readStream nextLine.
-	
 ]


### PR DESCRIPTION
Fix #10412