### PR TITLE
Fix a rare case where the primitiveRegisterSurface fails without setting true or false.

### DIFF
--- a/src/Athens-Cairo/AthensCairoSurface.class.st
+++ b/src/Athens-Cairo/AthensCairoSurface.class.st
@@ -308,6 +308,7 @@ AthensCairoSurface class >> primRegisterSurface: aCairoSurfaceHandle dispatch: s
 	otherwise."
 
 	<primitive: 'primitiveRegisterSurface' module: 'SurfacePlugin'>
+	^false
 ]
 
 { #category : #private }


### PR DESCRIPTION
Fix #10433.
Add a ^false in fallback code.