### PR TITLE
Reflectivity-Fix-Reify-Node-DynamicArray

### DIFF
--- a/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
+++ b/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
@@ -152,6 +152,32 @@ ReflectiveMethodTest >> testSetLinkOnClassVariableAndUninstall [
 
 ]
 
+{ #category : #'tests - links' }
+ReflectiveMethodTest >> testSetLinkOnDynamicArrayArgument [
+	
+ 	| link |
+ 	link := MetaLink new
+ 		        metaObject: #node;
+ 		        selector: #tagExecuted;
+ 		        yourself.
+ 	(ReflectivityExamples >> #exampleDynamicArrayArgument)
+ 		compiledMethod recompile.
+ 	ReflectivityExamples new exampleDynamicArrayArgument. 
+ 	(ReflectivityExamples >> #exampleDynamicArrayArgument) ast 
+ 		nodesDo: [ :n | 
+ 			n removeProperty: #tagExecuted ifAbsent: [  ].
+ 			n isDynamicArray ifTrue: [ 
+ 				n
+ 					propertyAt: #tagExecuted put: false;
+ 					link: link ] ].
+ 	ReflectivityExamples new exampleDynamicArrayArgument.
+ 	link uninstall.
+ 	(ReflectivityExamples >> #exampleDynamicArrayArgument) ast 
+ 		nodesDo: [ :n | 
+ 			n isDynamicArray ifTrue: [ 
+ 				self assert: (n propertyAt: #tagExecuted) ]]
+]
+
 { #category : #'tests - variables' }
 ReflectiveMethodTest >> testSetLinkOnGlobalVariable [
 	| globalVar link |

--- a/src/Reflectivity-Tests/ReflectivityExamples.class.st
+++ b/src/Reflectivity-Tests/ReflectivityExamples.class.st
@@ -103,6 +103,12 @@ ReflectivityExamples >> exampleClassVarRead [
 ]
 
 { #category : #examples }
+ReflectivityExamples >> exampleDynamicArrayArgument [
+
+	^ OrderedCollection new , { self }
+]
+
+{ #category : #examples }
 ReflectivityExamples >> exampleGlobalRead [
 	^GlobalForTesting
 ]

--- a/src/Reflectivity/RFReification.class.st
+++ b/src/Reflectivity/RFReification.class.st
@@ -81,6 +81,12 @@ RFReification >> genForRBArgumentNode [
 ]
 
 { #category : #generate }
+RFReification >> genForRBArrayNode [
+
+	^ self genForRBProgramNode
+]
+
+{ #category : #generate }
 RFReification >> genForRBAssignmentNode [
 	^self genForRBProgramNode
 ]


### PR DESCRIPTION
This PR fixes one of the bugs shown by the tests from #8374

- Fix reifications for {} dynamic arrays
- add test testSetLinkOnDynamicArrayArgument

