### PR TITLE
Reflectivity-AddPragmaSupport 

### DIFF
--- a/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
+++ b/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
@@ -211,6 +211,29 @@ ReflectiveMethodTest >> testSetLinkOnInstanceVariableAndUninstall [
 ]
 
 { #category : #'tests - links' }
+ReflectiveMethodTest >> testSetLinkOnPragma [ 
+
+ 	| link a b |
+ 	link := MetaLink new
+ 		        metaObject: #node;
+ 		        selector: #tagExecuted;
+ 		        yourself.
+ 	(ReflectivityExamples >> #examplePragma) compiledMethod recompile.
+ 	a := ReflectivityExamples new examplePragma. 
+ 	(ReflectivityExamples >> #examplePragma) ast nodesDo: [ :n | 
+ 		n removeProperty: #tagExecuted ifAbsent: [  ].
+ 		n isPragma ifTrue: [ 
+ 			n
+ 				propertyAt: #tagExecuted put: false;
+ 				link: link ] ].
+ 	b := ReflectivityExamples new examplePragma.
+ 	link uninstall.
+ 	self assert: a equals: b.
+ 	(ReflectivityExamples >> #examplePragma) ast nodesDo: [ :n | 
+ 		n isPragma ifTrue: [ self assert: (n propertyAt: #tagExecuted) ] ]
+]
+
+{ #category : #'tests - links' }
 ReflectiveMethodTest >> testSetLinkOnPrimitive [
 	| methodNode link |
 	selector := #examplePrimitiveMethod.

--- a/src/Reflectivity-Tests/ReflectivityExamples.class.st
+++ b/src/Reflectivity-Tests/ReflectivityExamples.class.st
@@ -166,6 +166,12 @@ ReflectivityExamples >> exampleMethodWithMetaLinkOptions [
 ]
 
 { #category : #examples }
+ReflectivityExamples >> examplePragma [
+ 	<tudelu>
+ 	^ 4
+]
+
+{ #category : #examples }
 ReflectivityExamples >> examplePrimitiveMethod [
 	"returns image path"
 	<primitive: 121>

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -258,6 +258,17 @@ RFASTTranslator >> visitMethodNode: aMethodNode [
 ]
 
 { #category : #'visitor - double dispatching' }
+RFASTTranslator >> visitPragmaNode: aPragmaNode [  
+
+	self emitPreamble: aPragmaNode.
+	self emitMetaLinkBefore: aPragmaNode.
+	aPragmaNode hasMetalinkInstead
+		ifTrue: [ self emitMetaLinkInstead: aPragmaNode ]
+		ifFalse: [super visitPragmaNode: aPragmaNode  ].
+	self emitMetaLinkAfterNoEnsure: aPragmaNode
+]
+
+{ #category : #'visitor - double dispatching' }
 RFASTTranslator >> visitReturnNode: aReturnNode [ 
 
 	valueTranslator visitNode: aReturnNode value.

--- a/src/Reflectivity/RFReification.class.st
+++ b/src/Reflectivity/RFReification.class.st
@@ -131,6 +131,11 @@ RFReification >> genForRBMethodNode [
 ]
 
 { #category : #generate }
+RFReification >> genForRBPragmaNode [
+	^ self genForRBProgramNode 
+]
+
+{ #category : #generate }
 RFReification >> genForRBProgramNode [
 	"overriden in subclass if needed"
 ]


### PR DESCRIPTION
This PR adds support (and a test) for metalinks on Pragmas. (Test was from #8374)

- add testSetLinkOnPragma
- adds support in the compiler (see #visitPragmaNode:)
- adds support to ask for reifications on RBPragmaNode

