### PR TITLE
Fix completion of keyword selectors

### DIFF
--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -121,6 +121,67 @@ CompletionEngineTest >> tearDown [
 ]
 
 { #category : #'tests - interaction' }
+CompletionEngineTest >> testReplaceKeywordTokenWithCaretInTheEndOfWordAfterCaretWithFollowingWordsReplacesEntireWord [
+
+	"If the caret is at the end of a word, replace the entire word"
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist: something that follows'.
+	
+	"Select just after the colon"
+	self
+		setEditorText: text;
+		selectAt: 'self mEthOdThatDoesNotExist:' size + 1.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+
+	controller context replaceTokenInEditorWith: 'mEthOdThatDoesNotExist:'.
+	
+	self assert: editor text asString equals: 'self mEthOdThatDoesNotExist: something that follows'
+]
+
+{ #category : #'tests - interaction' }
+CompletionEngineTest >> testReplaceKeywordTokenWithCaretInTheEndOfWordWithFollowingWordsReplacesEntireWord [
+
+	"If the caret is at the end of a word, replace the entire word"
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist: something that follows'.
+	
+	self
+		setEditorText: text;
+		selectAt: 'self mEthOdThatDoesNotExist' size + 1.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+
+	controller context replaceTokenInEditorWith: 'mEthOdThatDoesNotExist:'.
+	
+	self assert: editor text asString equals: 'self mEthOdThatDoesNotExist: something that follows'
+]
+
+{ #category : #'tests - interaction' }
+CompletionEngineTest >> testReplaceKeywordTokenWithCaretInTheMiddleOfWordWithFollowingWordsReplacesEntireWord [
+
+	"If the caret is at the end of a word, replace the entire word"
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist: something that follows'.
+	
+	self
+		setEditorText: text;
+		selectAt: 'self mEthOdThatDoes' size.
+
+	editor textArea openInWorld.
+	controller openMenu.
+
+	controller context replaceTokenInEditorWith: 'mEthOdThatDoesNotExist:'.
+	
+	self assert: editor text asString equals: 'self mEthOdThatDoesNotExist: something that follows'
+]
+
+{ #category : #'tests - interaction' }
 CompletionEngineTest >> testReplaceTokenAfterMovingCaretToMiddleOfWordWithFollowingWordsReplacesEntireWord [
 
 	"If the caret is at the end of a word, replace the entire word"

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -121,6 +121,67 @@ CompletionEngineTest >> tearDown [
 ]
 
 { #category : #'tests - interaction' }
+CompletionEngineTest >> testReplaceKeywordTokenFollowedByAssignmentWithCaretInTheEndOfWordAfterCaretWithFollowingWordsReplacesEntireWord [
+
+	"If the caret is at the end of a word, replace the entire word"
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist:= something that follows'.
+	
+	"Select just after the colon"
+	self
+		setEditorText: text;
+		selectAt: 'self mEthOdThatDoesNotExist:' size.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+
+	controller context replaceTokenInEditorWith: 'mEthOdThatDoesNotExist:'.
+	
+	self assert: editor text asString equals: 'self mEthOdThatDoesNotExist::= something that follows'
+]
+
+{ #category : #'tests - interaction' }
+CompletionEngineTest >> testReplaceKeywordTokenFollowedByAssignmentWithCaretInTheEndOfWordWithFollowingWordsReplacesEntireWord [
+
+	"If the caret is at the end of a word, replace the entire word"
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist:= something that follows'.
+	
+	self
+		setEditorText: text;
+		selectAt: 'self mEthOdThatDoesNotExist' size.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+
+	controller context replaceTokenInEditorWith: 'mEthOdThatDoesNotExist'.
+	
+	self assert: editor text asString equals: 'self mEthOdThatDoesNotExist:= something that follows'
+]
+
+{ #category : #'tests - interaction' }
+CompletionEngineTest >> testReplaceKeywordTokenFollowedByAssignmentWithCaretInTheMiddleOfWordWithFollowingWordsReplacesEntireWord [
+
+	"If the caret is at the end of a word, replace the entire word"
+	
+	| text |
+	text := 'self mEthOdThatDoesNotExist:= something that follows'.
+	
+	self
+		setEditorText: text;
+		selectAt: 'self mEthOdThatDoes' size.
+
+	editor textArea openInWorld.
+	controller openMenu.
+
+	controller context replaceTokenInEditorWith: 'mEthOdThatDoesNotExist'.
+	
+	self assert: editor text asString equals: 'self mEthOdThatDoesNotExist:= something that follows'
+]
+
+{ #category : #'tests - interaction' }
 CompletionEngineTest >> testReplaceKeywordTokenWithCaretInTheEndOfWordAfterCaretWithFollowingWordsReplacesEntireWord [
 
 	"If the caret is at the end of a word, replace the entire word"

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -818,6 +818,12 @@ RubSmalltalkEditor >> isSmalltalkEditor [
 	^ true 
 ]
 
+{ #category : #private }
+RubSmalltalkEditor >> isWordCharacter: aCharacter [
+	"In smalltalk code, colons make part of selectors too and are part of a word"
+	^ aCharacter isAlphaNumeric or: [aCharacter = $:]
+]
+
 { #category : #'menu messages' }
 RubSmalltalkEditor >> jumpToNextKeywordOfIt [
 	"Jump to the next keyword after the cursor - this is for legacy support"

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -819,9 +819,18 @@ RubSmalltalkEditor >> isSmalltalkEditor [
 ]
 
 { #category : #private }
-RubSmalltalkEditor >> isWordCharacter: aCharacter [
+RubSmalltalkEditor >> isWordCharacterAt: index in: aString [
+	"By default, group alphanumeric and non-alphanumeric separately"
+	| character |
+	character := aString at: index.
 	"In smalltalk code, colons make part of selectors too and are part of a word"
-	^ aCharacter isAlphaNumeric or: [aCharacter = $:]
+	^ character isAlphaNumeric or: [
+		"Check that it is a keyword selector.
+		 - followed by a colon
+		 - but not by an assignment "
+		character = $: and: [ 
+			aString size > index
+				and: [  (aString at: index + 1) ~= $= ] ] ]
 ]
 
 { #category : #'menu messages' }

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -1438,6 +1438,12 @@ RubTextEditor >> isTextEditor [
 	^ true 
 ]
 
+{ #category : #private }
+RubTextEditor >> isWordCharacter: aCharacter [
+	"By default, group alphanumeric and non-alphanumeric separately"
+	^ aCharacter isAlphaNumeric
+]
+
 { #category : #'typing support' }
 RubTextEditor >> keyDown: aKeyboardEvent [
 	textArea announce: ((RubKeystroke with: aKeyboardEvent) morph: self).
@@ -1617,10 +1623,10 @@ RubTextEditor >> nextWord: position [
 	string := self string.
 	index := position.
 	position >= string size ifTrue: [ ^ position ].
-	initialIsAlphaNumeric := (string at: index - 1) isAlphaNumeric.
+	initialIsAlphaNumeric := self isWordCharacter: (string at: index - 1).
 
 	[(index <= string size) 
-		and: [(string at: index) isAlphaNumeric = initialIsAlphaNumeric]]
+		and: [ (self isWordCharacter: (string at: index)) = initialIsAlphaNumeric]]
 			whileTrue: [index := index + 1].
 	^ index
 ]
@@ -1765,9 +1771,9 @@ RubTextEditor >> previousWord: position [
 	string := self string.
 	index := position.
 	position <= 1 ifTrue: [ ^ position ].
-	initialIsAlphaNumeric := (string at: index) isAlphaNumeric.
+	initialIsAlphaNumeric := self isWordCharacter: (string at: index).
 	[index := index - 1] doWhileTrue:
-		[(index > 0) and: [(string at: index) isAlphaNumeric = initialIsAlphaNumeric]].
+		[(index > 0) and: [ (self isWordCharacter: (string at: index)) = initialIsAlphaNumeric]].
 	^ index + 1
 ]
 

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -1439,9 +1439,9 @@ RubTextEditor >> isTextEditor [
 ]
 
 { #category : #private }
-RubTextEditor >> isWordCharacter: aCharacter [
+RubTextEditor >> isWordCharacterAt: index in: aString [
 	"By default, group alphanumeric and non-alphanumeric separately"
-	^ aCharacter isAlphaNumeric
+	^ (aString at: index) isAlphaNumeric
 ]
 
 { #category : #'typing support' }
@@ -1623,10 +1623,10 @@ RubTextEditor >> nextWord: position [
 	string := self string.
 	index := position.
 	position >= string size ifTrue: [ ^ position ].
-	initialIsAlphaNumeric := self isWordCharacter: (string at: index - 1).
+	initialIsAlphaNumeric := self isWordCharacterAt: index -1 in: string.
 
 	[(index <= string size) 
-		and: [ (self isWordCharacter: (string at: index)) = initialIsAlphaNumeric]]
+		and: [ (self isWordCharacterAt: index in: string) = initialIsAlphaNumeric]]
 			whileTrue: [index := index + 1].
 	^ index
 ]
@@ -1771,9 +1771,9 @@ RubTextEditor >> previousWord: position [
 	string := self string.
 	index := position.
 	position <= 1 ifTrue: [ ^ position ].
-	initialIsAlphaNumeric := self isWordCharacter: (string at: index).
+	initialIsAlphaNumeric := self isWordCharacterAt: index in: string.
 	[index := index - 1] doWhileTrue:
-		[(index > 0) and: [ (self isWordCharacter: (string at: index)) = initialIsAlphaNumeric]].
+		[(index > 0) and: [ (self isWordCharacterAt: index in: string) = initialIsAlphaNumeric]].
 	^ index + 1
 ]
 


### PR DESCRIPTION
- Extend rubric iterate words backward and forward by selector when in smalltalk mode.
- Added completion tests for #10437

As a nice side effect, navigating code with ctrl+arrow now takes into account colons in keyword selectors too!