### PR TITLE
Fix testIgnoreLongTestWhenItIsSuspendedAsUnderDebug

### DIFF
--- a/src/SUnit-Tests/TestExecutionEnvironmentTest.class.st
+++ b/src/SUnit-Tests/TestExecutionEnvironmentTest.class.st
@@ -241,9 +241,8 @@ TestExecutionEnvironmentTest >> testIgnoreLongTestWhenItIsSuspendedAsUnderDebug 
 				executionEnvironment maxTimeForTest: 10 milliSeconds.
 				Processor activeProcess suspend "it simulates the under debugger condition"]
 		] on: TestTookTooMuchTime do: [ :err | timeOutSignaled := true ]		
-	] newProcess.
-	testProcess priority: Processor activePriority + 1.
-	testProcess resume.
+	] forkAt: Processor activePriority + 1.
+
 	self deny: timeOutSignaled
 ]
 

--- a/src/SUnit-Tests/TestExecutionEnvironmentTest.class.st
+++ b/src/SUnit-Tests/TestExecutionEnvironmentTest.class.st
@@ -241,9 +241,8 @@ TestExecutionEnvironmentTest >> testIgnoreLongTestWhenItIsSuspendedAsUnderDebug 
 				executionEnvironment maxTimeForTest: 10 milliSeconds.
 				Processor activeProcess suspend "it simulates the under debugger condition"]
 		] on: TestTookTooMuchTime do: [ :err | timeOutSignaled := true ]		
-	] forkAt: Processor activePriority + 1.
-
-	200 milliSeconds wait.
+	] newProcess.
+	testProcess priority: Processor activePriority + 1.
 	testProcess resume.
 	self deny: timeOutSignaled
 ]


### PR DESCRIPTION
It fixes #10459 : testProcess in the test was incidentally forked twice