### PR TITLE
Deprecated-message-testCreateClassWithFullExpandedDefinitionKeepsTheMinimum 

### DIFF
--- a/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
@@ -301,7 +301,7 @@ FluidClassBuilderTest >> testCreateClassWithFullExpandedDefinitionKeepsTheMinimu
 	builder := self class compilerClass new
 		           evaluate: 'Object << #MyClass
 	layout: FixedLayout;
-	trait: {};
+	traits: {};
 	slots: {};
 	sharedVariables: {};
 	tag: '''' ;

--- a/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
@@ -485,7 +485,7 @@ FluidClassBuilderTest >> testInstallMinimalMockClass [
 	builder := self class compilerClass new
 		           evaluate: 'Object << #MyClass
 	layout: FixedLayout;
-	trait: {};
+	traits: {};
 	slots: {};
 	sharedVariables: {};
 	tag: '''' ;


### PR DESCRIPTION
testCreateClassWithFullExpandedDefinitionKeepsTheMinimum sends a deprecated method #trait: instead of #traits. As the code is a string, the rewrite does not change it.

