### PR TITLE
10172-Fix-typo-in-comment-of-ExternalDatafromCStrings

### DIFF
--- a/src/FFI-Kernel/ExternalData.class.st
+++ b/src/FFI-Kernel/ExternalData.class.st
@@ -56,7 +56,7 @@ ExternalData >> fromCString [
 
 { #category : #converting }
 ExternalData >> fromCStrings [
-	"Assume that the receiver represents a set of C strings and is teerminated by a empty string and convert it to a Smalltalk ordered collection of strings"
+	"Assume that the receiver represents a set of C strings and is terminated by a empty string and convert it to a Smalltalk ordered collection of strings"
 
 	| stream index char strings str |
 	type isPointerType ifFalse: [self error: 'External object is not a pointer type.'].
@@ -71,7 +71,7 @@ ExternalData >> fromCStrings [
 			].
 		str := stream contents.
 		strings addLast: str.
-		str size = 0
+		str isEmpty
 	] whileFalse.
 	^strings
 ]


### PR DESCRIPTION
- fix typo
- change a "size = 0" into a #isEmpty driven by the code critique

fixes #10172


