### PR TITLE
Cleanup newlines and blanks in "JenkinsTools" packages

### DIFF
--- a/src/JenkinsTools-Core/Exception.extension.st
+++ b/src/JenkinsTools-Core/Exception.extension.st
@@ -19,5 +19,5 @@ Exception >> recordResultOf: aTestCase inHDTestReport: aHDTestReport [
 
 	This default logic is in SUnit for a long time 
 	but in past it was in senders of this method which handles a predefined set of known exceptions"	
-	self pass 
+	self pass
 ]

--- a/src/JenkinsTools-Core/HDTestReport.class.st
+++ b/src/JenkinsTools-Core/HDTestReport.class.st
@@ -129,7 +129,6 @@ HDTestReport >> newLogDuring: aBlock [
 	stream := tempStream := String new writeStream.
 	aBlock ensure: [ stream := currentStream ].
 	^tempStream contents
-	 
 ]
 
 { #category : #initialization }
@@ -178,8 +177,7 @@ HDTestReport >> recordPassOf: aTestCase [
 ]
 
 { #category : #running }
-HDTestReport >> recordSkip: aTestSkip duringTest: aTestCase [ 
-
+HDTestReport >> recordSkip: aTestSkip duringTest: aTestCase [
 ]
 
 { #category : #running }

--- a/src/JenkinsTools-Core/TestCommandLineHandler.class.st
+++ b/src/JenkinsTools-Core/TestCommandLineHandler.class.st
@@ -136,5 +136,4 @@ TestCommandLineHandler >> testRunner [
 		(self hasOption: 'no-xterm') ifTrue: [ ^ commandLineTestRunner ].
 		^ self class environment at: #VTermTestRunner
 	] ifAbsent: [ self error: 'no tests output available, try to use the option --junit-xml-output' ]
-
 ]


### PR DESCRIPTION
Fix #10530