### PR TITLE
Cleanup-Spec-Deprecated 

### DIFF
--- a/src/BaselineOfSpec/BaselineOfSpec.class.st
+++ b/src/BaselineOfSpec/BaselineOfSpec.class.st
@@ -14,6 +14,5 @@ BaselineOfSpec >> baseline: spec [
 			spec package: 'Spec-Layout'.
 			spec package: 'Spec-MorphicAdapters'.
 			spec package: 'Spec-PolyWidgets'.
-			spec package: 'Spec-StubAdapter'.
-			spec package: 'Spec-Deprecated' ]
+			spec package: 'Spec-StubAdapter']
 ]

--- a/src/Spec-Deprecated/ComposablePresenter.extension.st
+++ b/src/Spec-Deprecated/ComposablePresenter.extension.st
@@ -1,9 +1,0 @@
-Extension { #name : #ComposablePresenter }
-
-{ #category : #'*Spec-Deprecated' }
-ComposablePresenter >> instantiateModels: aCollectionOfPairs [
-	
-	"instantiateModels: is legacy code in ComposablePresenter and must not be used. It will be deprecated and removed."
-
-	^ self instantiatePresenters: aCollectionOfPairs
-]


### PR DESCRIPTION
The method #instantiateModels: of ComposablePresenter is not needed as the only sender sends it to an overridden version (see DynamicComposablePresenter>>#instantiateModels:)

- remove ComposablePresenter>>#instantiateModels:
- remove the package Spec-Deprecated from the BaselineOfSpec

fixes  #9647


