### PR TITLE
9697-FTExamplesexampleTree1-menu-item-Expand-All-freezes-image 

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTExamples.class.st
+++ b/src/Morphic-Widgets-FastTable/FTExamples.class.st
@@ -846,7 +846,7 @@ FTExamples class >> exampleTree1 [
 	| ds |
 	ds := FTTreeDataSource
 		roots:
-			((ProtoObject allSubclasses reject: [ :e | e name endsWith: 'class' ])
+			((Collection allSubclasses reject: [ :e | e name endsWith: 'class' ])
 				sort: [ :a :b | a name < b name ])
 		children: [ :data | data subclasses sort: [ :a :b | a name < b name ] ].
 	FTTableMorph new


### PR DESCRIPTION
fixes #9697 by using less less data

