### PR TITLE
Split baseline of threadedffi

### DIFF
--- a/src/BaselineOfThreadedFFI/BaselineOfThreadedFFI.class.st
+++ b/src/BaselineOfThreadedFFI/BaselineOfThreadedFFI.class.st
@@ -21,6 +21,7 @@ BaselineOfThreadedFFI >> baseline: spec [
 		spec
 			"core"
 			package: 'ThreadedFFI';
+			package: 'ThreadedFFI-Graphics-Extensions' with: [ spec requires: #('ThreadedFFI') ];
 			package: 'ThreadedFFI-UFFI' with: [ spec requires: #('ThreadedFFI') ];
 			package: 'ThreadedFFI-UFFI-Overrides' with: [ spec requires: #('ThreadedFFI-UFFI') ];
 			"tests"
@@ -29,8 +30,9 @@ BaselineOfThreadedFFI >> baseline: spec [
 	
 	spec 
 		group: 'Core' with: #('ThreadedFFI' 'ThreadedFFI-UFFI' 'ThreadedFFI-UFFI-Overrides');
+		group: 'Graphics' with: #('Core' 'ThreadedFFI-Graphics-Extensions');
 		group: 'Tests' with: #('ThreadedFFI-Tests' 'ThreadedFFI-UFFI-Tests');
-		group: 'default' with: #('Core' 'Tests')
+		group: 'default' with: #('Core' 'Graphics' 'Tests')
 ]
 
 { #category : #doits }

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -139,7 +139,7 @@ SystemDependenciesTest >> knownUFFIDependencies [
 
 	"ideally this list should be empty"	
 
-	^ #(#'Refactoring-Critics' #'Refactoring-Environment' 'Graphics-Primitives')
+	^ #(#'Refactoring-Critics' #'Refactoring-Environment')
 ]
 
 { #category : #'known dependencies' }

--- a/src/ThreadedFFI-Graphics-Extensions/Bitmap.extension.st
+++ b/src/ThreadedFFI-Graphics-Extensions/Bitmap.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #Bitmap }
+
+{ #category : #'*ThreadedFFI-Graphics-Extensions' }
+Bitmap >> tfPointerAddress [
+
+	self pinInMemory.
+	^ PointerUtils oopForObject: self
+]

--- a/src/ThreadedFFI-Graphics-Extensions/package.st
+++ b/src/ThreadedFFI-Graphics-Extensions/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'ThreadedFFI-Graphics-Extensions' }


### PR DESCRIPTION
the extensions of Bitmap moved to its own package because a minimal image of Pharo can not have it :)