### PR TITLE
Make Athens not coupled with FT2

### DIFF
--- a/src/Athens-Cairo/AthensCairoText.class.st
+++ b/src/Athens-Cairo/AthensCairoText.class.st
@@ -118,14 +118,16 @@ AthensCairoText >> initialize [
 
 { #category : #drawing }
 AthensCairoText >> loadOn: aCanvas [
-	fontFamily notNil ifTrue:[
-		self
+	
+	fontFamily ifNotNil:[
+		self 
 			primSelectFont:  fontFamily
-				slant:  fontSlant
-				weight:  fontWeight 
-				on: aCanvas] .
-	fontSize notNil ifTrue:[		
-		self primSetFontSize:  (TextStyle pointsToPixels: fontSize) on: aCanvas ]
+			slant:  fontSlant
+			weight:  fontWeight 
+			on: aCanvas ].
+	
+	fontSize ifNotNil: [
+		self primSetFontSize: (CairoScaledFont pointsToPixels: fontSize) on: aCanvas ]
 ]
 
 { #category : #private }

--- a/src/Athens-Cairo/AthensFT2Constants.class.st
+++ b/src/Athens-Cairo/AthensFT2Constants.class.st
@@ -1,0 +1,240 @@
+"
+The various flags from the Freetype/2 header.
+
+The LoadXXXX flags can be used with `primitiveLoadGlyph:flags:` or with the Cairo `primCairoFtFontCreateForFtFace:flags:scale:` primitives.
+
+#### `FT_LOAD_DEFAULT`
+  Corresponding to 0, this value is used a default glyph load.  In this
+  case, the following will happen:
+                                                                        
+1. FreeType looks for a bitmap for the glyph corresponding to the
+   face's current size.  If one is found, the function returns.  The
+   bitmap data can be accessed from the glyph slot (see note below).
+                                                                        
+2. If no embedded bitmap is searched or found, FreeType looks for a
+   scalable outline.  If one is found, it is loaded from the font
+   file, scaled to device pixels, then ""hinted"" to the pixel grid in
+   order to optimize it.  The outline data can be accessed from the
+   glyph slot (see note below).
+                                                                        
+Note that by default, the glyph loader doesn't render outlines into
+bitmaps. The following flags are used to modify this default
+behaviour to more specific and useful cases.
+                                                                        
+#### `FT_LOAD_NO_SCALE`
+  Don't scale the vector outline being loaded to 26.6 fractional
+  pixels, but kept in font units.  Note that this also disables
+  hinting and the loading of embedded bitmaps.  You should only use it
+  when you want to retrieve the original glyph outlines in font units.
+                                                                        
+#### `FT_LOAD_NO_HINTING`
+  Don't hint glyph outlines after their scaling to device pixels.
+  This generally generates ""blurrier"" glyphs in anti-aliased modes.
+                                                                        
+  This flag is ignored if `FT_LOAD_NO_SCALE` is set.
+                                                                        
+#### `FT_LOAD_RENDER` 
+  Render the glyph outline immediately into a bitmap before the glyph
+  loader returns.  By default, the glyph is rendered for the
+  `FT_RENDER_MODE_NORMAL` mode, which corresponds to 8-bit anti-aliased
+  bitmaps using 256 opacity levels.  You can use either
+  `FT_LOAD_TARGET_MONO` or `FT_LOAD_MONOCHROME` to render 1-bit
+  monochrome bitmaps.
+                                                                        
+  This flag is ignored if `FT_LOAD_NO_SCALE` is set.
+                                                                        
+####`FT_LOAD_NO_BITMAP`
+  Don't look for bitmaps when loading the glyph.  Only scalable
+  outlines will be loaded when available, and scaled, hinted, or
+  rendered depending on other bit flags.
+                                                                        
+  This does not prevent you from rendering outlines to bitmaps
+  with `FT_LOAD_RENDER`, however.
+                                                                        
+####`FT_LOAD_VERTICAL_LAYOUT`
+  Prepare the glyph image for vertical text layout.  This basically
+  means that `face.glyph.advance` will correspond to the vertical
+  advance height (instead of the default horizontal advance width),
+  and that the glyph image will be translated to match the vertical
+  bearings positions.
+                                                                        
+####`FT_LOAD_FORCE_AUTOHINT`
+  Force the use of the FreeType auto-hinter when a glyph outline is
+  loaded.  You shouldn't need this in a typical application, since it
+  is mostly used to experiment with its algorithm.
+                                                                        
+####`FT_LOAD_CROP_BITMAP`
+  Indicates that the glyph loader should try to crop the bitmap (i.e.,
+  remove all space around its black bits) when loading it.  This is
+  only useful when loading embedded bitmaps in certain fonts, since
+  bitmaps rendered with `FT_LOAD_RENDER` are always cropped by default.
+                                                                        
+####`FT_LOAD_PEDANTIC`
+  Indicates that the glyph loader should perform pedantic
+  verifications during glyph loading, rejecting invalid fonts.  This
+  is mostly used to detect broken glyphs in fonts.  By default,
+  FreeType tries to handle broken fonts also.
+                                                                        
+#### `FT_LOAD_IGNORE_GLOBAL_ADVANCE_WIDTH`
+  Indicates that the glyph loader should ignore the global advance
+  width defined in the font.  As far as we know, this is only used by
+  the X-TrueType font server, in order to deal correctly with the
+  incorrect metrics contained in DynaLab's TrueType CJK fonts.
+                                                                        
+####`FT_LOAD_NO_RECURSE`
+  This flag is only used internally.  It merely indicates that the
+  glyph loader should not load composite glyphs recursively.  Instead,
+  it should set the `num_subglyph` and `subglyphs` values of the glyph
+  slot accordingly, and set ""glyph->format"" to `FT_GLYPH_FORMAT_COMPOSITE`.
+                                                                        
+  The description of sub-glyphs is not available to client
+  applications for now.
+                                                                        
+####`FT_LOAD_IGNORE_TRANSFORM`
+  Indicates that the glyph loader should not try to transform the
+  loaded glyph image.  This doesn't prevent scaling, hinting, or
+  rendering.
+                                                                        
+####`FT_LOAD_MONOCHROME`
+  This flag is used with `FT_LOAD_RENDER` to indicate that you want
+  to render a 1-bit monochrome glyph bitmap from a vectorial outline.
+                                                                        
+  Note that this has no effect on the hinting algorithm used by the
+  glyph loader.  You should better use `FT_LOAD_TARGET_MONO` if you
+  want to render monochrome-optimized glyph images instead.
+                                                                        
+####`FT_LOAD_LINEAR_DESIGN`
+  Return the linearly scaled metrics expressed in original font units
+  instead of the default 16.16 pixel values.
+                                                                        
+####`FT_LOAD_NO_AUTOHINT`
+  Indicates that the auto-hinter should never be used to hint glyph
+  outlines.  This doesn't prevent native format-specific hinters from
+  being used.  This can be important for certain fonts where unhinted
+  output is better than auto-hinted one.
+
+One of following flags (as LoadTargetXXX) can be used to further specify the result.
+
+####`FT_RENDER_MODE_NORMAL`                                          
+     This is the default render mode; it corresponds to 8-bit        
+     anti-aliased bitmaps, using 256 levels of opacity.              
+                                                                     
+####`FT_RENDER_MODE_LIGHT`                                           
+     This is similar to `FT_RENDER_MODE_NORMAL`, except that this     
+     changes the hinting to prevent stem width quantization.  This   
+     results in glyph shapes that are more similar to the original,  
+     while being a bit more fuzzy (""better shapes"", instead of       
+     ""better contrast"" if you want :-).                              
+                                                                     
+####`FT_RENDER_MODE_MONO`                                            
+     This mode corresponds to 1-bit bitmaps.                         
+                                                                     
+####`FT_RENDER_MODE_LCD`                                             
+     This mode corresponds to horizontal RGB/BGR sub-pixel displays, 
+     like LCD-screens.  It produces 8-bit bitmaps that are 3 times   
+     the width of the original glyph outline in pixels, and which use
+     the `FT_PIXEL_MODE_LCD` mode.                                    
+                                                                     
+####`FT_RENDER_MODE_LCD_V`                                         
+     This mode corresponds to vertical RGB/BGR sub-pixel displays    
+     (like PDA screens, rotated LCD displays, etc.).  It produces    
+     8-bit bitmaps that are 3 times the height of the original       
+     glyph outline in pixels and use the `FT_PIXEL_MODE_LCD_V` mode.  
+                                                                     
+####Note                                                              
+  The LCD-optimized glyph bitmaps produced by `FT_Render_Glyph` are    
+  _not filtered_ to reduce color-fringes.  It is up to the caller to 
+  perform this pass.                                                 
+
+
+"
+Class {
+	#name : #AthensFT2Constants,
+	#superclass : #SharedPool,
+	#classVars : [
+		'LoadCropBitmap',
+		'LoadDefault',
+		'LoadForceAutohint',
+		'LoadIgnoreGlobalAdvanceWidth',
+		'LoadIgnoreTransform',
+		'LoadLinearDesign',
+		'LoadMonochrome',
+		'LoadNoAutohint',
+		'LoadNoBitmap',
+		'LoadNoHinting',
+		'LoadNoRecurse',
+		'LoadNoScale',
+		'LoadPedantic',
+		'LoadRender',
+		'LoadSbitsOnly',
+		'LoadTargetLCD',
+		'LoadTargetLCDV',
+		'LoadTargetLight',
+		'LoadTargetMono',
+		'LoadTargetNormal',
+		'LoadVerticalLayout',
+		'PixelModeGray',
+		'PixelModeGray2',
+		'PixelModeGray4',
+		'PixelModeLCD',
+		'PixelModeLCDV',
+		'PixelModeMono',
+		'PixelModeNone',
+		'RenderModeLCD',
+		'RenderModeLCDV',
+		'RenderModeLight',
+		'RenderModeMono',
+		'RenderModeNormal',
+		'StyleFlagBold',
+		'StyleFlagItalic'
+	],
+	#category : #'Athens-Cairo-Text'
+}
+
+{ #category : #'class initialization' }
+AthensFT2Constants class >> initialize [
+	"FT2Constants initialize"
+
+	LoadDefault := 0.
+	LoadNoScale := 1.
+	LoadNoHinting := 2.
+	LoadRender := 4.
+	LoadNoBitmap := 8.
+	LoadVerticalLayout := 16.
+	LoadForceAutohint := 32.
+	LoadCropBitmap := 64.
+	LoadPedantic := 128.
+	LoadIgnoreGlobalAdvanceWidth := 512.
+	LoadNoRecurse := 1024.
+	LoadIgnoreTransform := 2048.
+	LoadMonochrome := 4096.
+	LoadLinearDesign := 8192.
+	LoadSbitsOnly := 16384.
+	LoadNoAutohint := 32768.
+
+	"One of these flags may be OR'd with the above."
+	LoadTargetNormal := 0.
+	LoadTargetLight := 1 bitShift: 16.
+	LoadTargetMono := 2 bitShift: 16.
+	LoadTargetLCD := 3 bitShift: 16.
+	LoadTargetLCDV  := 4 bitShift: 16.
+
+	"rendering mode constants"
+	RenderModeNormal := 0.
+	RenderModeLight := 1.
+	RenderModeMono := 2.
+	RenderModeLCD := 3.	
+	RenderModeLCDV := 4.
+
+	"pixel mode constants"
+	PixelModeNone := 0.
+	PixelModeMono := 1.
+	PixelModeGray := 2.
+	PixelModeGray2 := 3.
+	PixelModeGray4 := 4.
+	PixelModeLCD := 5.
+	PixelModeLCDV := 6.
+	
+	StyleFlagItalic := 1.
+	StyleFlagBold := 2.
+]

--- a/src/Athens-Cairo/CairoFontFace.class.st
+++ b/src/Athens-Cairo/CairoFontFace.class.st
@@ -14,10 +14,16 @@ Class {
 	#classTraits : 'TCairoLibrary classTrait',
 	#pools : [
 		'AthensCairoDefinitions',
-		'FT2Constants'
+		'AthensFT2Constants'
 	],
 	#category : #'Athens-Cairo-Text'
 }
+
+{ #category : #private }
+CairoFontFace class >> boldEmphasisCode [
+
+	^ 1
+]
 
 { #category : #finalizing }
 CairoFontFace class >> countReferences: handle [
@@ -49,6 +55,12 @@ CairoFontFace class >> fromFreetypeFace: aFace [
 CairoFontFace class >> hasSharedResourceData: handle [
 	"Answer wether the external cairo_font_face resource is shared (referenced) by other external objects."
 	^(self countReferences: handle) > 1
+]
+
+{ #category : #private }
+CairoFontFace class >> italicEmphasisCode [
+
+	^ 2
 ]
 
 { #category : #'instance creation' }
@@ -111,11 +123,12 @@ CairoFontFace >> synthesizeBoldAndOblique [
 
 { #category : #accessing }
 CairoFontFace >> synthesizeEmphasis: emphasisCode [
-	emphasisCode = (TextEmphasis bold emphasisCode | TextEmphasis italic emphasisCode)
+
+	emphasisCode = (self class boldEmphasisCode | self class italicEmphasisCode)
 		ifTrue: [ ^ self synthesizeBoldAndOblique ].
-	emphasisCode = TextEmphasis bold emphasisCode
+	emphasisCode = self class boldEmphasisCode
 		ifTrue: [ ^ self synthesizeBold ].
-	emphasisCode = TextEmphasis italic emphasisCode
+	emphasisCode = self class italicEmphasisCode
 		ifTrue: [ ^ self synthesizeOblique ]
 ]
 

--- a/src/Athens-Cairo/CairoScaledFont.class.st
+++ b/src/Athens-Cairo/CairoScaledFont.class.st
@@ -47,7 +47,7 @@ CairoScaledFont class >> fromFreetypeFont: aFont cairoFace: face [
 	fontMatrix := AthensCairoMatrix new.
 	deviceMatrix := AthensCairoMatrix new.
 
-	fontMatrix scaleBy: (TextStyle pointsToPixels: aFont pointSize).
+	fontMatrix scaleBy: (self pointsToPixels: aFont pointSize).
 	
 	font := self primCreate: face fontMatrix: fontMatrix  userToDeviceMatrix: deviceMatrix options: options. 
 	
@@ -55,6 +55,20 @@ CairoScaledFont class >> fromFreetypeFont: aFont cairoFace: face [
 	^ (font initWithFace: face)
 			freeTypeFont: aFont;
 			yourself.
+]
+
+{ #category : #private }
+CairoScaledFont class >> pixelsPerInch [
+
+	self flag: #TODO. "Hardcoded, but it need to come from the right place (which varies depending on 
+	the graphics backend)"
+	^ 96.0 
+]
+
+{ #category : #accessing }
+CairoScaledFont class >> pointsToPixels: points [
+
+	^ points * self pixelsPerInch / 72.0
 ]
 
 { #category : #private }

--- a/src/Athens-Cairo/StrikeFont.extension.st
+++ b/src/Athens-Cairo/StrikeFont.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #StrikeFont }
-
-{ #category : #'*Athens-Cairo' }
-StrikeFont >> asAthensFontDescription [
-	^ AthensFontDescription new family: self familyName; fontSize: self pointSize.
-]

--- a/src/Athens-Text/StrikeFont.extension.st
+++ b/src/Athens-Text/StrikeFont.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : #StrikeFont }
 
 { #category : #'*Athens-Text' }
+StrikeFont >> asAthensFontDescription [
+	^ AthensFontDescription new family: self familyName; fontSize: self pointSize.
+]
+
+{ #category : #'*Athens-Text' }
 StrikeFont >> asFreetypeFont [
 
 		self error: 'not supported yet. and ever'

--- a/src/BaselineOfFreeType/BaselineOfFreeType.class.st
+++ b/src/BaselineOfFreeType/BaselineOfFreeType.class.st
@@ -10,12 +10,13 @@ BaselineOfFreeType >> baseline: spec [
 	
 	spec for: #common do: [ 
 		spec package: 'FreeType'.
-		spec package: 'FreeType-Morphic'.
-		spec package: 'FreeType-Tests'.
-		spec package: 'FreeType-Help'.
+		spec package: 'FreeType-Graphics' with: [ spec requires: #('FreeType') ].		
+		spec package: 'FreeType-Morphic' with: [ spec requires: #('FreeType-Graphics') ].
+		spec package: 'FreeType-Tests' with: [ spec requires: #('FreeType') ].
+		spec package: 'FreeType-Help' with: [ spec requires: #('FreeType') ].
 
 		spec group: 'core' with: #('FreeType').
-		spec group: 'morphic' with: #('core' 'FreeType-Morphic').
+		spec group: 'ui' with: #('core' 'FreeType-Graphics' 'FreeType-Morphic').
 		spec group: 'tests' with: #('core' 'FreeType-Tests') ]
 ]
 

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -55,7 +55,7 @@ BaselineOfMorphic >> baseline: spec [
 		spec baseline: 'FreeType' with: [ 
 			spec 
 				repository: repository; 
-				loads: 'morphic' ].
+				loads: 'ui' ].
 
 		spec package: 'Graphics-Files'.
 		spec package: 'Graphics-Fonts'.

--- a/src/FreeType-Graphics/BitBlt.extension.st
+++ b/src/FreeType-Graphics/BitBlt.extension.st
@@ -1,13 +1,13 @@
 Extension { #name : #BitBlt }
 
-{ #category : #'*FreeType-Addition' }
+{ #category : #'*FreeType-Graphics' }
 BitBlt >> combinationRule [
 	"Answer the receiver's combinationRule"
 	
 	^combinationRule
 ]
 
-{ #category : #'*FreeType-Addition' }
+{ #category : #'*FreeType-Graphics' }
 BitBlt >> copyBitsColor: argbColorSmallInteger alpha: argbAlphaSmallInteger gammaTable: gammaByteArray ungammaTable: ungammaByteArray [
 	"This entry point to BitBlt supplies an extra argument to specify the fore color
 	argb value for operation 41. This is split into an alpha value and an rgb value,
@@ -28,7 +28,7 @@ BitBlt >> copyBitsColor: argbColorSmallInteger alpha: argbAlphaSmallInteger gamm
 	self primitiveFailed  "Later do nicer error recovery -- share copyBits recovery"
 ]
 
-{ #category : #'*FreeType-Addition' }
+{ #category : #'*FreeType-Graphics' }
 BitBlt >> installFreeTypeFont: aFreeTypeFont foregroundColor: foregroundColor backgroundColor: backgroundColor [
 	"Set up the parameters.  Since the glyphs in a TTCFont is 32bit depth form, it tries to use rule=34 to get better AA result if possible."
 
@@ -53,7 +53,7 @@ BitBlt >> installFreeTypeFont: aFreeTypeFont foregroundColor: foregroundColor ba
 	height := aFreeTypeFont height.
 ]
 
-{ #category : #'*FreeType-Addition' }
+{ #category : #'*FreeType-Graphics' }
 BitBlt >> lastFontForegroundColor [
 	^ nil
 ]

--- a/src/FreeType-Graphics/Form.extension.st
+++ b/src/FreeType-Graphics/Form.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Form }
+
+{ #category : #'*FreeType-Graphics' }
+Form >> ftSize [
+
+	^ (self bitsSize * 4) + 32
+]

--- a/src/FreeType-Graphics/FreeTypeCache.extension.st
+++ b/src/FreeType-Graphics/FreeTypeCache.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #FreeTypeCache }
-
-{ #category : #'*FreeType-Graphics' }
-FreeTypeCache >> sizeOf: anObject [
-	^(anObject isKindOf: Form)
-		ifTrue:[(anObject bitsSize * 4) + 32]
-		ifFalse:[4]
-]

--- a/src/FreeType-Graphics/FreeTypeCache.extension.st
+++ b/src/FreeType-Graphics/FreeTypeCache.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #FreeTypeCache }
+
+{ #category : #'*FreeType-Graphics' }
+FreeTypeCache >> sizeOf: anObject [
+	^(anObject isKindOf: Form)
+		ifTrue:[(anObject bitsSize * 4) + 32]
+		ifFalse:[4]
+]

--- a/src/FreeType-Graphics/FreeTypeFont.extension.st
+++ b/src/FreeType-Graphics/FreeTypeFont.extension.st
@@ -1,0 +1,51 @@
+Extension { #name : #FreeTypeFont }
+
+{ #category : #'*FreeType-Graphics' }
+FreeTypeFont >> displayLineGlyphOn: aDisplayContext from: startPoint to: endPoint [
+	|  oldCombinationRule oldHalftoneForm originalColorMap clr depth foreColorVal foreColorAlpha glyph width height
+	startPointX startPointY endPointX endPointY foreColor |
+	oldCombinationRule := aDisplayContext combinationRule .
+	oldHalftoneForm := aDisplayContext halftoneForm .
+	originalColorMap := aDisplayContext colorMap.
+	clr := (foreColor := aDisplayContext lastFontForegroundColor ifNil:[Color black asNontranslucentColor]) 
+		pixelValueForDepth: 32.
+	depth := aDisplayContext destForm depth.
+	foreColorVal := clr bitAnd: 16rFFFFFF.
+	foreColorAlpha := (clr bitAnd: 16rFF000000) >> 24.
+	depth <= 8
+		ifTrue:[
+			aDisplayContext colorMap: (aDisplayContext cachedFontColormapFrom:32 to: depth)]
+		ifFalse:[
+			aDisplayContext colorMap: nil].
+	startPointX := startPoint x truncated.
+	startPointY := startPoint y.
+	endPointX := endPoint x ceiling.
+	endPointY := endPoint y.
+	width := endPointX - startPointX.
+	height := endPointY - startPointY.
+	glyph := (Form extent: width@height depth: 32) fillWhite. "we could cache a big white glyph somewhere to save having to create this. Clipping will make only a part of it display"
+	aDisplayContext sourceForm: glyph.
+	aDisplayContext destOrigin: startPointX@startPointY.
+	aDisplayContext width: width.
+	aDisplayContext height: height.
+	aDisplayContext 
+		sourceOrigin: 0@0;
+		halftoneForm: nil.
+	(FreeTypeSettings current useSubPixelAntiAliasing and: [depth >= 8])
+		ifTrue:[
+			aDisplayContext 
+				combinationRule: 41.
+			aDisplayContext 
+				copyBitsColor: foreColorVal 
+				alpha: foreColorAlpha 
+				gammaTable: FreeTypeSettings current gammaTable
+				ungammaTable: FreeTypeSettings current gammaInverseTable]
+		ifFalse:[
+			glyph fillWithColor: foreColor.
+			aDisplayContext combinationRule: (depth <= 8 ifTrue: [Form paint] ifFalse: [34]).
+			aDisplayContext copyBits].		
+	aDisplayContext 
+		colorMap: originalColorMap;
+		combinationRule: oldCombinationRule;
+		halftoneForm: oldHalftoneForm.
+]

--- a/src/FreeType-Graphics/FreeTypeGlyphRenderer.class.st
+++ b/src/FreeType-Graphics/FreeTypeGlyphRenderer.class.st
@@ -11,7 +11,7 @@ Class {
 	#classInstVars : [
 		'current'
 	],
-	#category : #'FreeType-GlyphRendering'
+	#category : #'FreeType-Graphics-GlyphRendering'
 }
 
 { #category : #'instance creation' }

--- a/src/FreeType-Graphics/FreeTypeSettings.extension.st
+++ b/src/FreeType-Graphics/FreeTypeSettings.extension.st
@@ -1,0 +1,43 @@
+Extension { #name : #FreeTypeSettings }
+
+{ #category : #'*FreeType-Graphics' }
+FreeTypeSettings >> bitBltSubPixelAvailable [	
+	"Answer true if the the subPixel combination rule is available, false otherwise.
+	to test :-
+	bitBltSubPixelAvailable := false. 
+	FreeTypeCache current removeAll.
+	World restoreMorphicDisplay
+	"
+	
+	| form bitBlt color |
+	bitBltSubPixelAvailable == nil ifFalse:[^bitBltSubPixelAvailable].
+	form := Form extent: 10@10 depth: 32.
+	bitBlt := GrafPort toForm: form.
+	bitBlt combinationRule: 41.
+	bitBlt sourceForm: (Form extent: 5@5 depth: 32).
+	bitBlt destOrigin: 1@1.
+	bitBlt width: 5; height: 5.
+	color := Color black asNontranslucentColor pixelValueForDepth: 32.
+	[bitBlt 
+		copyBitsColor: (color bitAnd: 16rFFFFFF)
+		alpha: (color bitAnd: 16rFF000000) >> 24 
+		gammaTable: nil
+		ungammaTable: nil]
+	on: Error do:[:e | ^bitBltSubPixelAvailable := false].
+	#toDo. "need to check that rule 41 has done the right thing, and isn't someone elses new BitBlt rule"
+	^bitBltSubPixelAvailable := true
+]
+
+{ #category : #'*FreeType-Graphics' }
+FreeTypeSettings >> glyphContrast: aContrastValue [
+	" value between 1 and 100.
+	100 is highest contrast and maps to gamma 0.25
+	1 is lowest contrast and maps to gamma 2.22"
+	Cursor wait showWhile: [
+		| v g |
+		v := (((aContrastValue asNumber) min: 100) max: 1) asFloat.
+		(v closeTo: 50.0) 
+			ifTrue: [g := 1.0]
+			ifFalse: [g := ((100 - v) + 50 / 100.0) raisedTo: 2].
+		self setGamma: g].
+]

--- a/src/FreeType-Graphics/FreeTypeSubPixelAntiAliasedGlyphRenderer.class.st
+++ b/src/FreeType-Graphics/FreeTypeSubPixelAntiAliasedGlyphRenderer.class.st
@@ -7,7 +7,7 @@ Class {
 	#pools : [
 		'FT2Constants'
 	],
-	#category : #'FreeType-GlyphRendering'
+	#category : #'FreeType-Graphics-GlyphRendering'
 }
 
 { #category : #'class initialization' }

--- a/src/FreeType-Graphics/FreeTypeSystemSettings.extension.st
+++ b/src/FreeType-Graphics/FreeTypeSystemSettings.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #FreeTypeSystemSettings }
+
+{ #category : #'*FreeType-Graphics' }
+FreeTypeSystemSettings class >> loadFt2Library: aBoolean [
+	(LoadFT2Library = aBoolean) 
+		ifTrue: [ ^ self ].
+	LoadFT2Library := aBoolean.
+	aBoolean 
+		ifTrue: [ 
+			FreeTypeFontProvider current updateFromSystem ]
+		ifFalse: [
+			StandardFonts setSmallBitmapFonts.
+			FreeTypeFontProvider unload ]
+]

--- a/src/FreeType-Graphics/GlyphForm.class.st
+++ b/src/FreeType-Graphics/GlyphForm.class.st
@@ -8,7 +8,7 @@ Class {
 		'advance',
 		'linearAdvance'
 	],
-	#category : #'FreeType-Fonts'
+	#category : #'FreeType-Graphics-Fonts'
 }
 
 { #category : #accessing }

--- a/src/FreeType-Graphics/GrafPort.extension.st
+++ b/src/FreeType-Graphics/GrafPort.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #GrafPort }
 
-{ #category : #'*FreeType-addition' }
+{ #category : #'*FreeType-Graphics' }
 GrafPort >> installFreeTypeFont: aFreeTypeFont foregroundColor: foregroundColor backgroundColor: backgroundColor [
 
 	super installFreeTypeFont: aFreeTypeFont foregroundColor: foregroundColor backgroundColor: backgroundColor.

--- a/src/FreeType-Graphics/package.st
+++ b/src/FreeType-Graphics/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'FreeType-Graphics' }

--- a/src/FreeType-Morphic/TextStyle.extension.st
+++ b/src/FreeType-Morphic/TextStyle.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #TextStyle }
 
-{ #category : #'*FreeType-override' }
+{ #category : #'*FreeType-Morphic' }
 TextStyle class >> emphasisMenuForFont: font target: target selector: selector highlight: currentEmphasis [
 	"Offer a font emphasis menu for the given style. If one is selected, pass that font to target with a call to selector. The fonts will be displayed in that font. Answer nil if no derivatives exist"
 

--- a/src/FreeType/FreeTypeCache.class.st
+++ b/src/FreeType/FreeTypeCache.class.st
@@ -247,3 +247,9 @@ FreeTypeCache >> shrinkTo: newSize [
 	
 	used > newSize ifTrue:[self removeAll]
 ]
+
+{ #category : #'private - accessing' }
+FreeTypeCache >> sizeOf: anObject [
+
+	^ anObject ftSize
+]

--- a/src/FreeType/FreeTypeCache.class.st
+++ b/src/FreeType/FreeTypeCache.class.st
@@ -247,10 +247,3 @@ FreeTypeCache >> shrinkTo: newSize [
 	
 	used > newSize ifTrue:[self removeAll]
 ]
-
-{ #category : #'private - accessing' }
-FreeTypeCache >> sizeOf: anObject [
-	^(anObject isKindOf: Form)
-		ifTrue:[(anObject bitsSize * 4) + 32]
-		ifFalse:[4]
-]

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -135,56 +135,6 @@ FreeTypeFont >> descentKern [
 ]
 
 { #category : #displaying }
-FreeTypeFont >> displayLineGlyphOn: aDisplayContext from: startPoint to: endPoint [
-	|  oldCombinationRule oldHalftoneForm originalColorMap clr depth foreColorVal foreColorAlpha glyph width height
-	startPointX startPointY endPointX endPointY foreColor |
-	oldCombinationRule := aDisplayContext combinationRule .
-	oldHalftoneForm := aDisplayContext halftoneForm .
-	originalColorMap := aDisplayContext colorMap.
-	clr := (foreColor := aDisplayContext lastFontForegroundColor ifNil:[Color black asNontranslucentColor]) 
-		pixelValueForDepth: 32.
-	depth := aDisplayContext destForm depth.
-	foreColorVal := clr bitAnd: 16rFFFFFF.
-	foreColorAlpha := (clr bitAnd: 16rFF000000) >> 24.
-	depth <= 8
-		ifTrue:[
-			aDisplayContext colorMap: (aDisplayContext cachedFontColormapFrom:32 to: depth)]
-		ifFalse:[
-			aDisplayContext colorMap: nil].
-	startPointX := startPoint x truncated.
-	startPointY := startPoint y.
-	endPointX := endPoint x ceiling.
-	endPointY := endPoint y.
-	width := endPointX - startPointX.
-	height := endPointY - startPointY.
-	glyph := (Form extent: width@height depth: 32) fillWhite. "we could cache a big white glyph somewhere to save having to create this. Clipping will make only a part of it display"
-	aDisplayContext sourceForm: glyph.
-	aDisplayContext destOrigin: startPointX@startPointY.
-	aDisplayContext width: width.
-	aDisplayContext height: height.
-	aDisplayContext 
-		sourceOrigin: 0@0;
-		halftoneForm: nil.
-	(FreeTypeSettings current useSubPixelAntiAliasing and: [depth >= 8])
-		ifTrue:[
-			aDisplayContext 
-				combinationRule: 41.
-			aDisplayContext 
-				copyBitsColor: foreColorVal 
-				alpha: foreColorAlpha 
-				gammaTable: FreeTypeSettings current gammaTable
-				ungammaTable: FreeTypeSettings current gammaInverseTable]
-		ifFalse:[
-			glyph fillWithColor: foreColor.
-			aDisplayContext combinationRule: (depth <= 8 ifTrue: [Form paint] ifFalse: [34]).
-			aDisplayContext copyBits].		
-	aDisplayContext 
-		colorMap: originalColorMap;
-		combinationRule: oldCombinationRule;
-		halftoneForm: oldHalftoneForm.
-]
-
-{ #category : #displaying }
 FreeTypeFont >> displayStrikeoutOn: aDisplayContext from: baselineStartPoint to: baselineEndPoint [
 	| top bottom strikeoutThickness s e |
 	

--- a/src/FreeType/FreeTypeSettings.class.st
+++ b/src/FreeType/FreeTypeSettings.class.st
@@ -86,34 +86,6 @@ FreeTypeSettings class >> updateFreeType [
 ]
 
 { #category : #accessing }
-FreeTypeSettings >> bitBltSubPixelAvailable [	
-	"Answer true if the the subPixel combination rule is available, false otherwise.
-	to test :-
-	bitBltSubPixelAvailable := false. 
-	FreeTypeCache current removeAll.
-	World restoreMorphicDisplay
-	"
-	
-	| form bitBlt color |
-	bitBltSubPixelAvailable == nil ifFalse:[^bitBltSubPixelAvailable].
-	form := Form extent: 10@10 depth: 32.
-	bitBlt := GrafPort toForm: form.
-	bitBlt combinationRule: 41.
-	bitBlt sourceForm: (Form extent: 5@5 depth: 32).
-	bitBlt destOrigin: 1@1.
-	bitBlt width: 5; height: 5.
-	color := Color black asNontranslucentColor pixelValueForDepth: 32.
-	[bitBlt 
-		copyBitsColor: (color bitAnd: 16rFFFFFF)
-		alpha: (color bitAnd: 16rFF000000) >> 24 
-		gammaTable: nil
-		ungammaTable: nil]
-	on: Error do:[:e | ^bitBltSubPixelAvailable := false].
-	#toDo. "need to check that rule 41 has done the right thing, and isn't someone elses new BitBlt rule"
-	^bitBltSubPixelAvailable := true
-]
-
-{ #category : #accessing }
 FreeTypeSettings >> clearBitBltSubPixelAvailable [	
 	
 	bitBltSubPixelAvailable := nil.
@@ -165,20 +137,6 @@ FreeTypeSettings >> gammaTable [
 { #category : #accessing }
 FreeTypeSettings >> glyphContrast [
 	^ 100 - ((self gamma  sqrt * 100) - 50)
-]
-
-{ #category : #accessing }
-FreeTypeSettings >> glyphContrast: aContrastValue [
-	" value between 1 and 100.
-	100 is highest contrast and maps to gamma 0.25
-	1 is lowest contrast and maps to gamma 2.22"
-	Cursor wait showWhile: [
-		| v g |
-		v := (((aContrastValue asNumber) min: 100) max: 1) asFloat.
-		(v closeTo: 50.0) 
-			ifTrue: [g := 1.0]
-			ifFalse: [g := ((100 - v) + 50 / 100.0) raisedTo: 2].
-		self setGamma: g].
 ]
 
 { #category : #accessing }

--- a/src/FreeType/FreeTypeSystemSettings.class.st
+++ b/src/FreeType/FreeTypeSystemSettings.class.st
@@ -109,19 +109,6 @@ FreeTypeSystemSettings class >> loadFt2Library [
 ]
 
 { #category : #settings }
-FreeTypeSystemSettings class >> loadFt2Library: aBoolean [
-	(LoadFT2Library = aBoolean) 
-		ifTrue: [ ^ self ].
-	LoadFT2Library := aBoolean.
-	aBoolean 
-		ifTrue: [ 
-			FreeTypeFontProvider current updateFromSystem ]
-		ifFalse: [
-			StandardFonts setSmallBitmapFonts.
-			FreeTypeFontProvider unload ]
-]
-
-{ #category : #settings }
 FreeTypeSystemSettings class >> noFt2Library [
 	^ 'Free type fonts are not available'
 ]

--- a/src/FreeType/Object.extension.st
+++ b/src/FreeType/Object.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Object }
+
+{ #category : #'*FreeType' }
+Object >> ftSize [
+
+	^ 4
+]

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -191,7 +191,7 @@ SystemDependenciesTest >> testExternalBasicToolsDependencies [
 	| dependencies | 
 	
 	self longTestCase.
-	
+
 	dependencies := self externalDependendiesOf: (
 		self metacelloPackageNames,
 		self tonelCorePackageNames,
@@ -199,7 +199,7 @@ SystemDependenciesTest >> testExternalBasicToolsDependencies [
 		{ BaselineOfSUnit name }, BaselineOfSUnit allPackageNames, "ALL"
 		{ BaselineOfDisplay name }, BaselineOfDisplay allPackageNames,
 		{ BaselineOfUnifiedFFI name }, BaselineOfUnifiedFFI allPackageNames,
-		{ BaselineOfKeymapping name }, (BaselineOfFreeType deepPackagesOfGroupNamed: #core),
+		{ BaselineOfFreeType name }, (BaselineOfFreeType deepPackagesOfGroupNamed: #ui),
 		{ BaselineOfKeymapping name }, (BaselineOfKeymapping deepPackagesOfGroupNamed: #ui),
 		{ BaselineOfMorphicCore name }, BaselineOfMorphicCore allPackageNames,
 		{ BaselineOfMorphic name }, BaselineOfMorphic allPackageNames,
@@ -313,7 +313,7 @@ SystemDependenciesTest >> testExternalIDEDependencies [
 	BaselineOfHeuristicCompletion.
 	 } do: [ :baseline | packages := packages , {baseline name} , baseline allPackageNames ].
 
-	packages := packages ,  { BaselineOfFreeType name }, (self packagesOfGroupNamed: 'core' on: BaselineOfFreeType ).
+	packages := packages ,  { BaselineOfFreeType name }, (self packagesOfGroupNamed: 'ui' on: BaselineOfFreeType ).
 	packages := packages ,  { BaselineOfKeymapping name }, (self packagesOfGroupNamed: 'ui' on: BaselineOfKeymapping ).
 	packages := packages ,  { BaselineOfSpecCore name }, (self packagesOfGroupNamed: 'default' on: BaselineOfSpecCore ).
 	packages := packages ,  { BaselineOfSpec2 name }, (self packagesOfGroupNamed: 'default' on: BaselineOfSpec2 ).
@@ -446,7 +446,7 @@ SystemDependenciesTest >> testExternalMorphicDependencies [
 		BaselineOfDisplay allPackageNames,
 		BaselineOfUnifiedFFI allPackageNames,
 		(BaselineOfKeymapping deepPackagesOfGroupNamed: #morphic),
-		(BaselineOfFreeType deepPackagesOfGroupNamed: #core),
+		(BaselineOfFreeType deepPackagesOfGroupNamed: #ui),
 		BaselineOfMorphicCore allPackageNames,
 		BaselineOfMorphic allPackageNames,
 		BaselineOfMenuRegistration allPackageNames,
@@ -508,7 +508,7 @@ SystemDependenciesTest >> testExternalSpec2Dependencies [
 		"Morphic - for Morphic backend"
 		BaselineOfDisplay allPackageNames,
 		(BaselineOfKeymapping deepPackagesOfGroupNamed: #ui),
-		(BaselineOfFreeType deepPackagesOfGroupNamed: #morphic),
+		(BaselineOfFreeType deepPackagesOfGroupNamed: #ui),
 		BaselineOfMorphicCore allPackageNames,
 		BaselineOfMorphic allPackageNames,
 		BaselineOfMenuRegistration allPackageNames,
@@ -563,7 +563,7 @@ SystemDependenciesTest >> testExternalUIDependencies [
 		BaselineOfDisplay allPackageNames,
 		BaselineOfUnifiedFFI allPackageNames,
 		(BaselineOfKeymapping deepPackagesOfGroupNamed: #ui),
-		(BaselineOfFreeType deepPackagesOfGroupNamed: #morphic),
+		(BaselineOfFreeType deepPackagesOfGroupNamed: #ui),
 		BaselineOfMorphicCore allPackageNames,
 		BaselineOfMorphic allPackageNames,
 		BaselineOfSpec allPackageNames,


### PR DESCRIPTION
because we need to be able to load Athens without FreeType fonts (most of the times, when using Athens, you want to use the Athens primitives for that).