### PR TITLE
10294-undefinedIdentifier-is-missing-in-SHRBTextStyler

### DIFF
--- a/src/Shout-Tests/SHRBTextStylerTest.class.st
+++ b/src/Shout-Tests/SHRBTextStylerTest.class.st
@@ -211,6 +211,19 @@ SHRBTextStylerTest >> testSettingFalseTheIncompleteMessageShouldNotFormatIt [
 ]
 
 { #category : #tests }
+SHRBTextStylerTest >> testSettingFalseTheIncompleteVariableShouldFormatUndefinedIdentifier [
+	
+	| aText ast |
+
+	SHRBTextStyler formatIncompleteIdentifiers: false.
+	aText := 'm1
+		^ sel' asText.
+	
+	ast := self style: aText.
+	self assert: (styler resolveStyleFor: ast variableNodes first) equals: #undefinedIdentifier
+]
+
+{ #category : #tests }
 SHRBTextStylerTest >> testSettingTrueTheIncompleteIdentifiersShouldFormatIt [
 	
 	| aText index attributes |
@@ -250,4 +263,25 @@ SHRBTextStylerTest >> testSettingTrueTheIncompleteMessageShouldFormatIt [
 	self assertCollection: attributes hasSameElements: { 
 		TextMethodLink sourceNode: node. 
 		TextEmphasis italic }.
+]
+
+{ #category : #tests }
+SHRBTextStylerTest >> testSettingTrueTheIncompleteVariableShouldFormatUndefinedIdentifier [
+	
+	| aText ast |
+
+	SHRBTextStyler formatIncompleteIdentifiers: true.
+	aText := 'm1
+		^ sel' asText.
+	
+	ast := self style: aText.
+	"here the identifier is incomplete"
+	self assert: (styler resolveStyleFor: ast variableNodes first) equals: #incompleteIdentifier.
+	
+	aText := 'm1
+		^ asdfasf' asText.
+	
+	ast := self style: aText.
+	"But for a name that does not exist at all, it is #undefinedIdentifier"
+	self assert: (styler resolveStyleFor: ast variableNodes first) equals: #undefinedIdentifier
 ]

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1033,6 +1033,8 @@ SHRBTextStyler >> resolveStyleFor: aVariableNode [
 	
 	(self class formatIncompleteIdentifiers and: [ aVariableNode hasIncompleteIdentifier ]) 
 		ifTrue:[ ^#incompleteIdentifier] .
+	"Note: if formatIncompleteIdentifiers is true, a non-exisiting variable might be incomplete"
+	aVariableNode isUndeclaredVariable ifTrue: [ ^#undefinedIdentifier ].
 
 	^#invalid.
 ]


### PR DESCRIPTION
This PR add the code as described in the Issue tracker entry.

The, somewhat odd, semantics of #incompleteIdentifier vs #undefinedIdentifier are explained in a comment and shown in the test.

fixes #10294


