### PR TITLE
10651-Resuming-a-exception-that-has-been-signalled-twice-does-not-return-correctly

### DIFF
--- a/src/Kernel-Tests/ExceptionTest.class.st
+++ b/src/Kernel-Tests/ExceptionTest.class.st
@@ -30,6 +30,14 @@ ExceptionTest >> assertSuccess: anExceptionTester [
 	self should: [ ( anExceptionTester suiteLog first) endsWith:  'succeeded'].
 ]
 
+{ #category : #utilities }
+ExceptionTest >> methodSignallingZeroDivide [
+
+	^ [ 1 / 0 ]
+		  on: ZeroDivide
+		  do: [ :e | e signal ]
+]
+
 { #category : #private }
 ExceptionTest >> runCaseManaged [
 	"We should disable TestEnvironment to avoid any logic for unhandled errors from background processes.
@@ -312,6 +320,19 @@ ExceptionTest >> testResignalAsUnwinds [
 			on: ZeroDivide do: [:ex | self assert: unwound.  ex return: 5]
 	] on: Error do: [:ex | [ex resignalAs: ZeroDivide] ifCurtailed: [unwound := true]].
 	self assert: answer == 5
+]
+
+{ #category : #'tests - resignal' }
+ExceptionTest >> testResignalExceptionThatHasBeenSignaledTwice [
+
+	| shouldBe17 |
+	shouldBe17 := nil.
+
+	[ shouldBe17 := self methodSignallingZeroDivide ]
+		on: ZeroDivide
+		do: [ :e | e resume: 17 ].
+
+	self assert: shouldBe17 notNil
 ]
 
 { #category : #'tests - exceptiontester' }

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -732,8 +732,8 @@ Context >> evaluateSignal: exception [
 	| value |
 	exception privHandlerContext: self contextTag.
 	value := self exceptionHandlerBlock cull: exception.	
-	"default return if not otherwise directed in handle block"
-	exception return: value
+	"return from self if not otherwise directed in handle block"
+	self return: value
 ]
 
 { #category : #'special context access' }


### PR DESCRIPTION
There has been a regression as the same exception is not returning to the correct signalling context when resuming.

- Returning to the previous change introduced in #10429
- Fix #10651
- Adding Tests