### PR TITLE
Add TFProcessLocalWorker

### DIFF
--- a/src/ThreadedFFI/TFProcessLocalWorker.class.st
+++ b/src/ThreadedFFI/TFProcessLocalWorker.class.st
@@ -19,7 +19,7 @@ Then you can execute a function like this:
 worker := TFWorker named: 'QUEUE'.
 [
 	TFProcessLocalWorker worker: worker.
-	channel readLineFromStdoutInSeparatedWorker.
+	channel readLineFromSocketInSeparatedWorker.
 ]
 
 "

--- a/src/ThreadedFFI/TFProcessLocalWorker.class.st
+++ b/src/ThreadedFFI/TFProcessLocalWorker.class.st
@@ -30,7 +30,7 @@ Class {
 		'defaultWorker'
 	],
 	#classInstVars : [
-		'worker',
+		'worker'
 	],
 	#category : #'ThreadedFFI-Worker'
 }

--- a/src/ThreadedFFI/TFProcessLocalWorker.class.st
+++ b/src/ThreadedFFI/TFProcessLocalWorker.class.st
@@ -31,7 +31,6 @@ Class {
 	],
 	#classInstVars : [
 		'worker',
-		'defaultWorker'
 	],
 	#category : #'ThreadedFFI-Worker'
 }

--- a/src/ThreadedFFI/TFProcessLocalWorker.class.st
+++ b/src/ThreadedFFI/TFProcessLocalWorker.class.st
@@ -1,0 +1,90 @@
+"
+This worker executes the function within the worker defined in a `ProcessLocalVariable`, allowing the user to execute the same function in two different native threads (this is very useful for executing functions that wait for some signal to return, e.g. reading from a socket or a piped file descriptor).
+
+It is important to define a `TFProcessLocalWorker>>defaultWorker` (even if by default it will take the `TFSameThreadRunner`.
+
+Example: 
+
+You define it like this: 
+```
+MyLibrary>>runner 
+
+	^ TFProcessLocalWorker new
+		defaultWorker: super runner;
+		yourself
+```
+
+Then you can execute a function like this: 
+```
+worker := TFWorker named: 'QUEUE'.
+[
+	TFProcessLocalWorker worker: worker.
+	channel readLineFromStdoutInSeparatedWorker.
+]
+
+"
+Class {
+	#name : #TFProcessLocalWorker,
+	#superclass : #TFRunner,
+	#instVars : [
+		'defaultWorker'
+	],
+	#classInstVars : [
+		'worker',
+		'defaultWorker'
+	],
+	#category : #'ThreadedFFI-Worker'
+}
+
+{ #category : #initialization }
+TFProcessLocalWorker class >> initialize [
+	
+	worker := ProcessLocalVariable new
+]
+
+{ #category : #accessing }
+TFProcessLocalWorker class >> worker [
+
+	^ worker value
+]
+
+{ #category : #accessing }
+TFProcessLocalWorker class >> worker: aWorker [
+
+	worker value: aWorker
+]
+
+{ #category : #accessing }
+TFProcessLocalWorker >> defaultWorker [
+
+	^ defaultWorker ifNil: [ TFSameThreadRunner uniqueInstance ]
+]
+
+{ #category : #accessing }
+TFProcessLocalWorker >> defaultWorker: aWorker [
+
+	defaultWorker := aWorker
+]
+
+{ #category : #executing }
+TFProcessLocalWorker >> invokeFunction: aTFExternalFunction withArguments: aCollection [ 
+
+	^ self worker
+		invokeFunction: aTFExternalFunction 
+		withArguments: aCollection 
+]
+
+{ #category : #private }
+TFProcessLocalWorker >> primitivePerformWorkerCall: aTFExternalFunction
+		withArguments: argumentHolder
+		withReturnHolder: aReturnHolder
+		usingSemaphore: anInteger [
+		
+	self error: 'Should not arrive here'
+]
+
+{ #category : #executing }
+TFProcessLocalWorker >> worker [
+		
+	^ self class worker ifNil: [ self defaultWorker ]
+]


### PR DESCRIPTION
This worker executes the function within the worker defined in a `ProcessLocalVariable`, allowing the user to execute the same function in two different native threads (this is very useful for executing functions that wait for some signal to return, e.g. reading from a socket or a piped file descriptor).

It is important to define a `TFProcessLocalWorker>>defaultWorker` (even if by default it will take the `TFSameThreadRunner`.

Example: 

You define it like this: 
```Smalltalk
MyLibrary>>runner 

	^ TFProcessLocalWorker new
		defaultWorker: super runner;
		yourself
```

Then you can execute a function like this: 
```Smalltalk
worker := TFWorker named: 'QUEUE'.
[
	TFProcessLocalWorker worker: worker.
	channel readLineFromSocketInSeparatedWorker.
]
