### PR TITLE
Improve #indexOfMonth: to not create symbols and compare without using #match

### DIFF
--- a/src/Kernel-Chronology-Extras/Month.class.st
+++ b/src/Kernel-Chronology-Extras/Month.class.st
@@ -46,7 +46,7 @@ Month class >> february [
 { #category : #accessing }
 Month class >> indexOfMonth: aMonthName [ 
 
-	1 to: 12 do: [ :i |  (aMonthName, '*' match: (MonthNames at: i)) ifTrue: [^i] ].
+	1 to: 12 do: [ :i | ((MonthNames at: i) beginsWith: aMonthName) ifTrue: [^i] ].
  	self error: aMonthName , ' is not a recognized month name'.
 ]
 

--- a/src/Kernel-Chronology-Extras/Month.class.st
+++ b/src/Kernel-Chronology-Extras/Month.class.st
@@ -45,8 +45,8 @@ Month class >> february [
 
 { #category : #accessing }
 Month class >> indexOfMonth: aMonthName [ 
-
-	1 to: 12 do: [ :i | ((MonthNames at: i) beginsWith: aMonthName) ifTrue: [^i] ].
+	1 to: 12 do: [ :i | 
+		((MonthNames at: i) beginsWith:  aMonthName caseSensitive: false) ifTrue: [^i] ].
  	self error: aMonthName , ' is not a recognized month name'.
 ]
 

--- a/src/Kernel-Tests-Extended/MonthTest.class.st
+++ b/src/Kernel-Tests-Extended/MonthTest.class.st
@@ -70,9 +70,27 @@ MonthTest >> testIndexOfMonth [
 ]
 
 { #category : #tests }
+MonthTest >> testIndexOfMonthCaseInsensitive [
+	self assert: (Month indexOfMonth: 'january') equals: 1.
+	self assert: (Month indexOfMonth: #january) equals: 1.
+	self assert: (Month indexOfMonth: 'jAnUaRy') equals: 1.
+	self assert: (Month indexOfMonth: #jAnUaRy) equals: 1.
+
+]
+
+{ #category : #tests }
+MonthTest >> testIndexOfMonthIncompleteMonths [
+	| m |
+	m := #(Jan Feb Mar Apr May Jun Jul Aug Sept Oct Nov Dec).
+
+	m withIndexDo: [ :item :index | self assert: (Month indexOfMonth: item) equals: index ].
+]
+
+{ #category : #tests }
 MonthTest >> testIndexOfMonthWithStrings [
 	| m |
-	m := #(#January #February #March #April #May #June #July #August #September #October #November #December) collect: [ :aMonth | aMonth asString ].
+	m := #(#January #February #March #April #May #June #July #August #September #October #November #December) 
+		collect: [ :aMonth | aMonth asString ].
 
 	m withIndexDo: [ :item :index | 
 		self assert: (Month indexOfMonth: item) equals: index ].

--- a/src/Kernel-Tests-Extended/MonthTest.class.st
+++ b/src/Kernel-Tests-Extended/MonthTest.class.st
@@ -70,6 +70,15 @@ MonthTest >> testIndexOfMonth [
 ]
 
 { #category : #tests }
+MonthTest >> testIndexOfMonthWithStrings [
+	| m |
+	m := #(#January #February #March #April #May #June #July #August #September #October #November #December) collect: [ :aMonth | aMonth asString ].
+
+	m withIndexDo: [ :item :index | 
+		self assert: (Month indexOfMonth: item) equals: index ].
+]
+
+{ #category : #tests }
 MonthTest >> testInquiries [
 	self
 		assert: month index equals: 7;


### PR DESCRIPTION
Possible fix for https://github.com/pharo-project/pharo/issues/10676.  Update`Month class >> indexOfMonth:` to not call `match:` and avoid creating symbols.