### PR TITLE
Fixes #10673 by adding missing method method to display a MessageTally identified

### DIFF
--- a/src/Tool-Profilers/MessageTally.class.st
+++ b/src/Tool-Profilers/MessageTally.class.st
@@ -544,11 +544,10 @@ MessageTally >> into: leafDict fromSender: senderTally [
 { #category : #testing }
 MessageTally >> isClosed [
 
-	^ Timer isNil 
-		and: [ class isNil 
+	^ class isNil 
 		and: [ method isNil 
 		and: [ tally isNil 
-		and: [ receivers isNil ] ] ] ]
+		and: [ receivers isNil ] ] ] 
 ]
 
 { #category : #comparing }

--- a/src/Tool-Profilers/MessageTally.class.st
+++ b/src/Tool-Profilers/MessageTally.class.st
@@ -453,6 +453,21 @@ MessageTally >> copyWithTally: hitCount [
 ]
 
 { #category : #printing }
+MessageTally >> displayIdentifierOn: aStream [
+	self isClosed ifTrue: [ ^ self ].
+	
+	class displayStringOn: aStream.
+	self method methodClass ~~ class ifTrue: [ 
+		aStream
+			nextPut: $(;
+			print: self method methodClass;
+			nextPut: $) ].
+	aStream
+		nextPutAll: '>>';
+		store: self method selector
+]
+
+{ #category : #printing }
 MessageTally >> displayStringOn: aStream [
 	self displayIdentifierOn: aStream.
 	aStream 
@@ -524,6 +539,16 @@ MessageTally >> into: leafDict fromSender: senderTally [
 						reportOtherProcesses: reportOtherProcesses ].
 					
 	leafNode bump: tally fromSender: senderTally
+]
+
+{ #category : #testing }
+MessageTally >> isClosed [
+
+	^ Timer isNil 
+		and: [ class isNil 
+		and: [ method isNil 
+		and: [ tally isNil 
+		and: [ receivers isNil ] ] ] ]
 ]
 
 { #category : #comparing }


### PR DESCRIPTION
Test solution executing
```
mt := MessageTally  
	spyOn: [ self notNil ]
	reportOtherProcesses: false 
	cutoff: 1 
	openResultWindow: true 
	closeAfter: false. "if true, the instance will be closed immediately and its identifier will not be displayed"
mt inspect.
mt close
```