### PR TITLE
Fixes pharo-spec/Spec#1219

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -1111,6 +1111,11 @@ FTTableMorph >> showIndex [
 	^ showIndex
 ]
 
+{ #category : #private }
+FTTableMorph >> showIndex: anInteger [
+	showIndex := anInteger
+]
+
 { #category : #menu }
 FTTableMorph >> showMenuForIndex: aTuple [
 	| menu rowIndex columnIndex |

--- a/src/SystemCommands-RefactoringSupport/SycRefactoringPreviewPresenter.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycRefactoringPreviewPresenter.class.st
@@ -218,8 +218,14 @@ SycRefactoringPreviewPresenter >> pickedChanges [
 
 { #category : #update }
 SycRefactoringPreviewPresenter >> rebuild [
+
+	| indx |
 	self needRebuild: false.
-	self buildWithSpec
+	indx := table adapter widget showIndex.
+	self buildWithSpec.
+	table adapter widget showIndex: indx.
+	table refresh.
+	
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fixing the refactoring preview visualization by remembering the scrollbar position and setting it again after UI rebuild. 

@Ducasse you have more examples of lists scrolling up after ticking an item?

This solution breaks encapsulation of FTTableMorph by writing a private variable from outside, but it is simpler than fixing the calculations used to get the first shown item from the scroll bar position
