### PR TITLE
Fixes pharo-spec/Spec#1219: Ticking list should scroll to the next ticked items instead of scrolling up

### DIFF
--- a/src/SystemCommands-RefactoringSupport/SycRefactoringPreviewPresenter.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycRefactoringPreviewPresenter.class.st
@@ -216,12 +216,6 @@ SycRefactoringPreviewPresenter >> pickedChanges [
 	^ table items select: [ :item | selectedRefactorings at: item ]
 ]
 
-{ #category : #update }
-SycRefactoringPreviewPresenter >> rebuild [
-	self needRebuild: false.
-	self buildWithSpec
-]
-
 { #category : #accessing }
 SycRefactoringPreviewPresenter >> scopeDropList [
 	^ scopeDropList
@@ -230,6 +224,14 @@ SycRefactoringPreviewPresenter >> scopeDropList [
 { #category : #accessing }
 SycRefactoringPreviewPresenter >> scopes: aCollectionOfScopes [
 	scopeDropList items: aCollectionOfScopes "It also sets up first item as selection"
+]
+
+{ #category : #private }
+SycRefactoringPreviewPresenter >> selectItemBelow: aRefactoring [ 
+
+	| nextIndex |
+	nextIndex := (self table items indexOf: aRefactoring) + 1.
+	self table selectIndex: nextIndex scrollToSelection: true
 ]
 
 { #category : #update }
@@ -259,9 +261,8 @@ SycRefactoringPreviewPresenter >> title [
 { #category : #private }
 SycRefactoringPreviewPresenter >> toggleSelectionOf: aRefactoring [
 	"it's normal it's impossible that anItem doesn't store in dictionary because at initialize I fill the dictionary and at each scope change"
-
 	selectedRefactorings at: aRefactoring put: (selectedRefactorings at: aRefactoring) not.
-	self rebuild 
+	self selectItemBelow: aRefactoring 
 ]
 
 { #category : #update }


### PR DESCRIPTION
Cleaning old rebuild implementation. Automatically selecting the next item.
New behavior is:
![Alt Text](https://media.giphy.com/media/gT1cvbpNkx6boGvmR8/giphy.gif)
