### PR TITLE
Updating bootstrap image to v1.7.8

### DIFF
--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -15,7 +15,7 @@ mkdir -p "${BOOTSTRAP_CACHE}" #required to generate hermes files
 
 ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/getPharoVM.sh 90 vm 64
 
-wget --progress=dot:mega https://github.com/guillep/PharoBootstrap/releases/download/v1.7.6/bootstrapImage.zip
+wget --progress=dot:mega https://github.com/guillep/PharoBootstrap/releases/download/v1.7.8/bootstrapImage.zip
 
 unzip bootstrapImage.zip
 


### PR DESCRIPTION
Updating to a latest image of Pharo10.
Mostly to allow the use of newer versions of libgit2.