### PR TITLE
align commit of external projects with its merged version

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -244,10 +244,10 @@ BaselineOfIDE >> loadIceberg [
 	pharoPluginClass := Smalltalk classNamed: #IcePharoPlugin.
 	pharoPluginClass  addPharoProjectToIceberg.
 	
-	(Smalltalk classNamed: #BaselineOfSpec2) ifNotNil: [ :aClass | 
+	(Smalltalk classNamed: #BaselineOfSpec2) ifNotNil: [ :aClass |.
 		pharoPluginClass
 			addProjectNamed: 'pharo-spec2' 
-			commit: (Smalltalk classNamed: #BaselineOfPharo) specReleaseCommit 
+			commit: (pharoPluginClass commitOfExternalProject: 'Spec2') 
 			baselines: #(BaselineOfSpec2).
 		"Register baselines"
 		Metacello new baseline: 'Spec2'; register.
@@ -256,7 +256,7 @@ BaselineOfIDE >> loadIceberg [
 	(Smalltalk classNamed: #BaselineOfNewTools) ifNotNil: [ :aClass | 
 		pharoPluginClass 
 			addProjectNamed: 'pharo-newtools' 
-			commit: (Smalltalk classNamed: #BaselineOfPharo) newToolsReleaseCommit 
+			commit: (pharoPluginClass commitOfExternalProject: 'NewTools') 
 			baselines: #(BaselineOfNewTools).
 		"Register baselines"
 		Metacello new baseline: 'NewTools'; register ].

--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -1,13 +1,45 @@
 Class {
 	#name : #BaselineOfPharo,
 	#superclass : #BaselineOf,
+	#classVars : [
+		'ExternalProjects'
+	],
 	#category : #BaselineOfPharo
 }
+
+{ #category : #'external projects' }
+BaselineOfPharo class >> declareExternalProjects [
+
+	^ { 
+	PharoExternalProject 
+		newName: 'Iceberg' 
+			owner: 'pharo-vcs' 
+			project: 'iceberg' 
+			version: 'dev-2.0' 
+			sourceDir: nil.
+	PharoExternalProject newName: 'Spec2' owner: 'pharo-spec' project:'Spec' version: 'Pharo10'.
+	PharoExternalProject newName: 'NewTools' owner: 'pharo-spec' project: 'NewTools' version: 'Pharo10'.	
+	 }
+]
+
+{ #category : #'external projects' }
+BaselineOfPharo class >> externalProjectNamed: aName [
+
+	^ self externalProjects 
+		detect: [ :each | each name = aName ]
+]
+
+{ #category : #'external projects' }
+BaselineOfPharo class >> externalProjects [
+
+	^ ExternalProjects ifNil: [ 
+		ExternalProjects := self declareExternalProjects ]
+]
 
 { #category : #'repository urls' }
 BaselineOfPharo class >> icebergRepository [
 
-	^ 'github://pharo-vcs/iceberg:{1}' format: { self icebergVersion }
+	^ (self externalProjectNamed: 'Iceberg') repository
 ]
 
 { #category : #versions }
@@ -16,18 +48,10 @@ BaselineOfPharo class >> icebergVersion [
 	^ 'dev-2.0'
 ]
 
-{ #category : #versions }
-BaselineOfPharo class >> newToolsReleaseCommit [
-	"The commit corresponding to current release (to be used on bootstrap process)"
-
-	"Pharo10"
-	^ '0a30d62222168b54ba9c12608bd10a7c1cfed6a1'
-]
-
 { #category : #'repository urls' }
 BaselineOfPharo class >> newToolsRepository [
 
-	^ 'github://pharo-spec/NewTools:{1}/src' format: { self newToolsVersion }
+	^ (self externalProjectNamed: 'NewTools') repository
 ]
 
 { #category : #versions }
@@ -36,18 +60,10 @@ BaselineOfPharo class >> newToolsVersion [
 	^ 'Pharo10'
 ]
 
-{ #category : #versions }
-BaselineOfPharo class >> specReleaseCommit [
-	"The commit corresponding to current release (to be used on bootstrap process)"
-
-	"Pharo10- fix paginator in presence of fast dragging"
-	^ '8fe65f1d49f090bb739ae6ef5113a05b4e89109f'
-]
-
 { #category : #'repository urls' }
 BaselineOfPharo class >> specRepository [
 
-	^ 'github://pharo-spec/Spec:{1}/src' format: { self specVersion }
+	^ (self externalProjectNamed: 'Spec2') repository
 ]
 
 { #category : #versions }

--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -11,12 +11,7 @@ Class {
 BaselineOfPharo class >> declareExternalProjects [
 
 	^ { 
-	PharoExternalProject 
-		newName: 'Iceberg' 
-			owner: 'pharo-vcs' 
-			project: 'iceberg' 
-			version: 'dev-2.0' 
-			sourceDir: nil.
+	PharoExternalProject newName: 'Iceberg' owner: 'pharo-vcs' project: 'iceberg' version: 'dev-2.0' sourceDir: nil.
 	PharoExternalProject newName: 'Spec2' owner: 'pharo-spec' project:'Spec' version: 'Pharo10'.
 	PharoExternalProject newName: 'NewTools' owner: 'pharo-spec' project: 'NewTools' version: 'Pharo10'.	
 	 }

--- a/src/BaselineOfPharo/PharoExternalProject.class.st
+++ b/src/BaselineOfPharo/PharoExternalProject.class.st
@@ -87,7 +87,8 @@ PharoExternalProject >> project [
 { #category : #accessing }
 PharoExternalProject >> repository [
 
-	^ 'github://{1}:{2}{3}' format: { 
+	^ 'github://{1}{2}:{3}{4}' format: { 
+		self owner.
 		self project.
 		self version.
 		self sourceDirWithSlash }

--- a/src/BaselineOfPharo/PharoExternalProject.class.st
+++ b/src/BaselineOfPharo/PharoExternalProject.class.st
@@ -87,7 +87,7 @@ PharoExternalProject >> project [
 { #category : #accessing }
 PharoExternalProject >> repository [
 
-	^ 'github://{1}{2}:{3}{4}' format: { 
+	^ 'github://{1}/{2}:{3}{4}' format: { 
 		self owner.
 		self project.
 		self version.

--- a/src/BaselineOfPharo/PharoExternalProject.class.st
+++ b/src/BaselineOfPharo/PharoExternalProject.class.st
@@ -1,0 +1,114 @@
+"
+A definition of an external projects. 
+External projects are kept at `BaselineOfPharo` but instead keeping a lot of strings on it, this class is the reification of the information needed.
+Is used to point to the place to download them (`PharoExternalProject>>repository`), but also to calculate the correct commit of the project (See `IcePharoPlugin class>>#commitOfExternalProject:`).
+"
+Class {
+	#name : #PharoExternalProject,
+	#superclass : #Object,
+	#instVars : [
+		'name',
+		'version',
+		'sourceDir',
+		'project',
+		'owner'
+	],
+	#category : #BaselineOfPharo
+}
+
+{ #category : #defaults }
+PharoExternalProject class >> defaultSourceDir [
+
+	^ 'src'
+]
+
+{ #category : #'instance creation' }
+PharoExternalProject class >> newName: aName owner: owner project: aProject version: aVersion [
+
+	^ self 
+		newName: aName 
+		owner: owner
+		project: aProject 
+		version: aVersion
+		sourceDir: self defaultSourceDir
+]
+
+{ #category : #'instance creation' }
+PharoExternalProject class >> newName: aName owner: anOwner project: aProject version: aVersion sourceDir: aSourceDir [
+
+	^ self basicNew
+		initializeName: aName 
+			owner: anOwner
+			project: aProject 
+			version: aVersion 
+			sourceDir: aSourceDir;
+		yourself
+]
+
+{ #category : #initialization }
+PharoExternalProject >> initializeName: aName owner: anOwner project: aProject version: aVersion sourceDir: aSourceDir [
+
+	self initialize.
+	name := aName.
+	owner := anOwner.
+	project := aProject.
+	version := aVersion.
+	sourceDir := aSourceDir
+]
+
+{ #category : #initialization }
+PharoExternalProject >> initializeName: aName project: aRepository version: aVersion sourceDir: aSourceDir [
+
+	self initialize.
+	name := aName.
+	project := aRepository.
+	version := aVersion.
+	sourceDir := aSourceDir
+]
+
+{ #category : #accessing }
+PharoExternalProject >> name [
+
+	^ name
+]
+
+{ #category : #accessing }
+PharoExternalProject >> owner [
+
+	^ owner
+]
+
+{ #category : #accessing }
+PharoExternalProject >> project [
+
+	^ project
+]
+
+{ #category : #accessing }
+PharoExternalProject >> repository [
+
+	^ 'github://{1}:{2}{3}' format: { 
+		self project.
+		self version.
+		self sourceDirWithSlash }
+]
+
+{ #category : #accessing }
+PharoExternalProject >> sourceDir [
+
+	^ sourceDir
+]
+
+{ #category : #private }
+PharoExternalProject >> sourceDirWithSlash [
+
+	^ self sourceDir isEmptyOrNil
+		ifTrue: [ '' ]
+		ifFalse: [ '/', self sourceDir ]
+]
+
+{ #category : #accessing }
+PharoExternalProject >> version [
+
+	^ version
+]


### PR DESCRIPTION
this pull request changes the way external projects are declared when included in the image.
before, this was a hard coded commit making the number to be out of sync in development phase (when external projects are pointing to a branch and not a tag) making the development process more cumbersome than needed. 

With this change, we search and add the commit as part of the bootstrap, making the build be always pointing to the exact merged commitish.