### PR TITLE
10331-No-need-to-refer-to-transcript-in-executable-comments 

### DIFF
--- a/src/Collections-Abstract/SequenceableCollection.class.st
+++ b/src/Collections-Abstract/SequenceableCollection.class.st
@@ -1694,7 +1694,7 @@ SequenceableCollection >> pairsCollect: aBlock [
 SequenceableCollection >> pairsDo: aBlock [
 	"Evaluate aBlock with my elements taken two at a time.  If there's an odd number of items, ignore the last one.  Allows use of a flattened array for things that naturally group into pairs.  See also pairsCollect:"
 
-	"(Array streamContents: [:s | #(1 'fred' 2 'charlie' 3 'elmer') pairsDo: [:a :b | s nextPut: b; nextPut: a]])  >>> #(1 'fred' 2 'charlie' 3 'elmer')"
+	"(Array streamContents: [:s | #(1 'fred' 2 'charlie' 3 'elmer') pairsDo: [:a :b | s nextPut: b; nextPut: a]]) >>> #('fred' 1 'charlie' 2 'elmer' 3)"
 
 	1 to: self size // 2 do: [ :index | aBlock value: (self at: 2 * index - 1) value: (self at: 2 * index) ]
 ]

--- a/src/Collections-Abstract/SequenceableCollection.class.st
+++ b/src/Collections-Abstract/SequenceableCollection.class.st
@@ -1694,7 +1694,7 @@ SequenceableCollection >> pairsCollect: aBlock [
 SequenceableCollection >> pairsDo: aBlock [
 	"Evaluate aBlock with my elements taken two at a time.  If there's an odd number of items, ignore the last one.  Allows use of a flattened array for things that naturally group into pairs.  See also pairsCollect:"
 
-	"(#(1 'fred' 2 'charlie' 3 'elmer') pairsDo: [:a :b | Transcript cr; show: b, ' is number ', a printString]) >>> #(1 'fred' 2 'charlie' 3 'elmer')"
+	"(Array streamContents: [:s | #(1 'fred' 2 'charlie' 3 'elmer') pairsDo: [:a :b | s nextPut: b; nextPut: a]])  >>> #(1 'fred' 2 'charlie' 3 'elmer')"
 
 	1 to: self size // 2 do: [ :index | aBlock value: (self at: 2 * index - 1) value: (self at: 2 * index) ]
 ]

--- a/src/DrTests/DrTests.class.st
+++ b/src/DrTests/DrTests.class.st
@@ -142,8 +142,9 @@ DrTests >> initializePluginsDropList [
 		help: 'Select the plugin used by Dr Tests UI.';
 		items: self plugins;
 		display: [ :pluginClass | pluginClass pluginName ];
-		iconBlock: [ :pluginClass | pluginClass pluginIcon ];
-		whenSelectedItemChangedDo: [ :pluginClass | self currentPlugin: pluginClass new ]
+		displayIcon: [ :pluginClass | pluginClass pluginIcon ];
+		whenSelectedItemChangedDo: [ :pluginClass | 
+			self currentPlugin: pluginClass new ]
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
- fix executable comment as described in the issue
- commit a #iconBlock: deprecation rewrite

fixes #10331


