### PR TITLE
10678-Step-Over-fails-for-leaving-simple-accessors 

### DIFF
--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -564,7 +564,7 @@ DebugSession >> stepToFirstInterestingBytecodeIn: aProcess [
 	make sure that we step correctly over the first primitive bytecode"
 	| suspendedContext |
 	suspendedContext := aProcess suspendedContext.
-	suspendedContext method isQuick
+	(suspendedContext method isQuick and: [ suspendedContext pc == suspendedContext method initialPC ])
 		ifTrue: [ ^ suspendedContext updatePCForQuickPrimitiveRestart ].
 	
 	^ aProcess stepToSendOrReturn


### PR DESCRIPTION
This is a workaround to fix #10678

For a real fix we need to check if we really need to do the check and call to updatePCForQuickPrimitiveRestart for every step... this should only be done when starting (or restarting) to debug a method.

I will open a new issue tracker for that.

