### PR TITLE
Fix-deprecated-hostWindowTitle

### DIFF
--- a/src/Spec-MorphicAdapters/WorldPresenter.class.st
+++ b/src/Spec-MorphicAdapters/WorldPresenter.class.st
@@ -94,14 +94,7 @@ WorldPresenter >> openWithSpecLayout: aSpec [
 { #category : #private }
 WorldPresenter >> title: aString [
 
-	^ DisplayScreen hostWindowTitle: aString
-]
-
-{ #category : #private }
-WorldPresenter >> updateTitle [
-	"Update the window title"
-
-	DisplayScreen hostWindowTitle: self title
+	^ self currentWorld worldState worldRenderer windowTitle: aString
 ]
 
 { #category : #api }


### PR DESCRIPTION
fix two senders of deprecated #hostWindowTitle:

- fix WorldPresenter>>#title:
- remove #updateTitle, as the superclass method does the right thing ("self title: self title").

For Spec2, I did a PR here: https://github.com/pharo-spec/Spec/pull/1224


