### PR TITLE
Fixes #10702 Printing method selector in windows title only if the selector is not nil

### DIFF
--- a/src/SystemCommands-RefactoringSupport/SycMethodNameEditorPresenter.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycMethodNameEditorPresenter.class.st
@@ -307,7 +307,9 @@ SycMethodNameEditorPresenter >> initializeDialogWindow: aModalPresenter [
 		addButton: 'Rename' do: [ :presenter | self renameMethodAndClose: presenter ];
 		addButton: 'Cancel' do: [ :presenter | presenter beCancel; close ];
 		initialExtent: 600 @ 300 ;
-		title: 'Method name editor : "', methodName selector ,'"'
+		title: 'Method name editor', (methodName selector 
+					ifNil: [ '' ] 
+					ifNotNil: [ :selector | ' : "', selector, '"' ]) 
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
In this fix we print the selector in the window title only if the selector exists (e.g. when renaming a method).
(note: In Pharo 9 the window title did not include the method's selector)