### PR TITLE
10714 new file without different extensions

### DIFF
--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -603,6 +603,13 @@ FileReference >> versionNumberFor: basename extension: extension [
 		ifFalse: [ maxVersion ]
 ]
 
+{ #category : #utilities }
+FileReference >> withDifferentExtension: aString [ 
+	"Return a new file reference having the same path than the receiver but with a new extension replacing the previous one."
+	^ self parent / (self basenameWithoutExtension: self extension), aString
+	
+]
+
 { #category : #streams }
 FileReference >> writeStream [
 	

--- a/src/FileSystem-Tests-Core/FileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/FileReferenceTest.class.st
@@ -1186,6 +1186,21 @@ FileReferenceTest >> testVersionNumberForExtension [
 		ensure: [ (filesystem / 'dir') ensureDeleteAll ].
 ]
 
+{ #category : #'tests - handy utils' }
+FileReferenceTest >> testWithExtension [
+	
+	| dir origin newFileRef |
+	filesystem createDirectory: 'dir'.
+	dir := filesystem / 'dir'.
+	origin := dir / 'games.html'.
+	
+	newFileRef := (dir / 'games.html') withDifferentExtension: 'md'.
+	self assert: newFileRef basenameWithoutExtension equals: origin basenameWithoutExtension.
+	self assert: newFileRef extension equals: 'md'.
+	self assert: newFileRef withoutExtension printString size equals: origin withoutExtension printString size
+	
+]
+
 { #category : #tests }
 FileReferenceTest >> testWithExtentionAddsExtension [
 	| ref result |


### PR DESCRIPTION
Please have a look this is a simple enh of fileReference 

```
(dir / 'games.html') withDifferentExtension: 'md'.
>>> dir/ 'grames.md'
```
```
testWithExtension
	
	| dir origin newFileRef |
	filesystem createDirectory: 'dir'.
	dir := filesystem / 'dir'.
	origin := dir / 'games.html'.
	
	newFileRef := (dir / 'games.html') withDifferentExtension: 'md'.
	self assert: newFileRef basenameWithoutExtension equals: origin basenameWithoutExtension.
	self assert: newFileRef extension equals: 'md'.
	self assert: newFileRef withoutExtension printString size equals: origin withoutExtension printString size
```