### PR TITLE
Use double click on the left bar to install a breakpoint in the browser

### DIFF
--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddStaticBreakpointCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddStaticBreakpointCommand.class.st
@@ -11,7 +11,7 @@ Class {
 ClyAddStaticBreakpointCommand class >> methodEditorLeftBarClickActivation [
 	<classAnnotation>
 	
-	^CmdTextLeftBarClickActivation for: ClyMethodSourceCodeContext
+	^CmdTextLeftBarDoubleClickActivation for: ClyMethodSourceCodeContext
 ]
 
 { #category : #execution }

--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -96,7 +96,8 @@ ClyMethodCodeEditorToolMorph >> belongsToRemovedBrowserContext [
 ClyMethodCodeEditorToolMorph >> buildLeftSideBar [
 	super buildLeftSideBar.
 
-	self leftSideBar enableMouseCommands: CmdTextLeftBarClickActivation withContextFrom: self
+	self leftSideBar enableMouseCommands: CmdTextLeftBarClickActivation withContextFrom: self.	
+	self leftSideBar enableMouseCommands: CmdTextLeftBarDoubleClickActivation withContextFrom: self
 ]
 
 { #category : #operations }

--- a/src/Commander-Activators-TextView/CmdOpenTextLeftBarMenuCommand.class.st
+++ b/src/Commander-Activators-TextView/CmdOpenTextLeftBarMenuCommand.class.st
@@ -19,3 +19,12 @@ CmdOpenTextLeftBarMenuCommand class >> contextClickActivation [
 CmdOpenTextLeftBarMenuCommand >> activationStrategy [
 	^CmdTextLeftBarMenuActivation
 ]
+
+{ #category : #execution }
+CmdOpenTextLeftBarMenuCommand >> execute [
+
+	context selectedTextInterval ifEmpty: [ 
+		context showSourceNode].
+	
+	super execute
+]

--- a/src/Commander-Activators-TextView/CmdTextLeftBarDoubleClickActivation.class.st
+++ b/src/Commander-Activators-TextView/CmdTextLeftBarDoubleClickActivation.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #CmdTextLeftBarDoubleClickActivation,
+	#superclass : #CmdDoubleClickActivation,
+	#category : #'Commander-Activators-TextView'
+}


### PR DESCRIPTION
It switches the breakpoint installation to the double click instead of single click according to proposal from #10265 . 
And the highlighting of ast node is added for breakpoint menu activation.

The breakpoint menu is still activated with right click on the left side bar. The single click  does not work properly because it conflicts with double click event. To see the problem you can play with this code:
```Smalltalk
CmdOpenTextLeftBarMenuCommand>>contextClickActivation
	<classAnnotation>
	^CmdTextLeftBarClickActivation for: CmdToolContext "it was byYellowButtonFor: "
``` 