### PR TITLE
CmdCommand-isAbstract-check

### DIFF
--- a/src/Commander-Core/CmdCommand.class.st
+++ b/src/Commander-Core/CmdCommand.class.st
@@ -99,7 +99,7 @@ Class {
 
 { #category : #testing }
 CmdCommand class >> canBeExecutedInContext: aToolContext [
-	^true
+	^self isAbstract not
 ]
 
 { #category : #accessing }

--- a/src/Tool-Registry/PharoCommonTools.class.st
+++ b/src/Tool-Registry/PharoCommonTools.class.st
@@ -97,6 +97,7 @@ PharoCommonTools class >> shutDown: aboutToQuit [
 
 { #category : #'world menu' }
 PharoCommonTools class >> worldMenuOn: aBuilder [
+
 	<worldMenu>
 	(aBuilder item: #'System Browser')
 		parent: #Browsing;
@@ -105,13 +106,14 @@ PharoCommonTools class >> worldMenuOn: aBuilder [
 		keyText: 'o, b';
 		help: 'System browser to browse and edit code.';
 		iconName: #smallSystemBrowser.
-	(aBuilder item: #'Iceberg')
-		order: 1; 
-		icon: (self iconNamed: #komitterSmalltalkhubRemote);  
-		parent: #'Browsing';
+	(aBuilder item: #Iceberg)
+		order: 1;
+		icon: (self iconNamed: #komitterSmalltalkhubRemote);
+		parent: #Browsing;
 		keyText: 'o, i';
-		help: 'Iceberg is a set of tools that allow one to handle git repositories directly from a Pharo image.';
-		action: [ (Smalltalk at: #IceTipRepositoriesBrowser) new openWithSpec ]
+		help:
+			'Iceberg is a set of tools that allow one to handle git repositories directly from a Pharo image.';
+		action: [ (Smalltalk at: #IceTipRepositoriesBrowser) new open ]
 ]
 
 { #category : #'registry access' }


### PR DESCRIPTION
This PR adds a check for Abstract classes in #canBeExecutedInContext:

in addition, commit a change to worldMenuOn: that was  in the downloaded image but not in git


This should fix #9947