### PR TITLE
10695-CmdBrowse-raise-a-DNU

### DIFF
--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -196,8 +196,7 @@ OCUndeclaredVariableWarning >> openMenuIn: aBlock [
 			labels add: each.
 			actions
 				add: [ 
-					self substituteVariable: each atInterval: interval.
-					(ReparseAfterSourceEditing new newSource: self requestor text) signal ] ].
+					^self substituteVariable: each atInterval: interval ] ].
 	lines add: labels size.
 	labels add: 'Cancel'.
 	caption := 'Unknown variable: ' , name , ' please correct, or cancel:'.
@@ -226,6 +225,7 @@ OCUndeclaredVariableWarning >> substituteVariable: varName atInterval: anInterva
 		offset: 0.
 	self methodNode source: self requestor text.
 	node replaceWith:((RBVariableNode named: varName) binding: (node owningScope lookupVar: varName)).
+	(ReparseAfterSourceEditing new newSource: self requestor text) signal.
 	^ (node owningScope lookupVar: varName)
 		ifNil: [self error: 'should be found'].
 ]


### PR DESCRIPTION
This fixes the #analyzeRead:by: DNU that we see when using "Browse it…"  (this happned for "Print it", too, though).

This fixes the base problem, but it is only working in the Code Browser for now.

For the Playground, it will work after we integrate a missing method (see https://github.com/pharo-spec/NewTools/pull/334)

fixes #10695


