### PR TITLE
Cleanup-canBeExecutedInContext

### DIFF
--- a/src/Calypso-SystemPlugins-Critic-Browser/ClyFixCritiqueCommand.class.st
+++ b/src/Calypso-SystemPlugins-Critic-Browser/ClyFixCritiqueCommand.class.st
@@ -8,7 +8,7 @@ Class {
 	#category : #'Calypso-SystemPlugins-Critic-Browser'
 }
 
-{ #category : #execution }
+{ #category : #testing }
 ClyFixCritiqueCommand class >> canBeExecutedInContext: aCriticContext [
 	(super canBeExecutedInContext: aCriticContext) ifFalse: [ ^false ].
 	

--- a/src/Calypso-SystemPlugins-Critic-Browser/ClyShowDependencyCritiqueCommand.class.st
+++ b/src/Calypso-SystemPlugins-Critic-Browser/ClyShowDependencyCritiqueCommand.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'Calypso-SystemPlugins-Critic-Browser'
 }
 
-{ #category : #execution }
+{ #category : #testing }
 ClyShowDependencyCritiqueCommand class >> canBeExecutedInContext: aCriticContext [
 	(super canBeExecutedInContext: aCriticContext) ifFalse: [ ^false ].
 	

--- a/src/Calypso-SystemPlugins-Monticello-Browser/ClyIcebergShowMethodVersionCommand.class.st
+++ b/src/Calypso-SystemPlugins-Monticello-Browser/ClyIcebergShowMethodVersionCommand.class.st
@@ -19,10 +19,10 @@ Class {
 
 { #category : #testing }
 ClyIcebergShowMethodVersionCommand class >> canBeExecutedInContext: aToolContext [
-	self flag: #todo. "Check for IceLog is temporal, to let time to update iceberg on Pharo 7.0a"
-	^ aToolContext isMethodSelected 
-		and: [ (Smalltalk globals includesKey: #IceLog)
-		and: [ (IceRepository registeredRepositoryIncludingPackage: aToolContext lastSelectedMethod package) notNil ] ]
+
+	^ aToolContext isMethodSelected and: [ 
+		  (IceRepository registeredRepositoryIncludingPackage:
+			   aToolContext lastSelectedMethod package) notNil ]
 ]
 
 { #category : #accessing }

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddBreakpointCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddBreakpointCommand.class.st
@@ -11,7 +11,7 @@ Class {
 	#category : #'Calypso-SystemPlugins-Reflectivity-Browser-Breakpoints'
 }
 
-{ #category : #execution }
+{ #category : #testing }
 ClyAddBreakpointCommand class >> canBeExecutedInContext: aBrowserContext [
 
 	^aBrowserContext isSelectedItemHasBreakpoint not

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddExecutionCounterCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddExecutionCounterCommand.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'Calypso-SystemPlugins-Reflectivity-Browser-ExecutionCounters'
 }
 
-{ #category : #execution }
+{ #category : #testing }
 ClyAddExecutionCounterCommand class >> canBeExecutedInContext: aBrowserContext [
 
 	^aBrowserContext isSelectedItemHasExecutionCounter not

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddWatchCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddWatchCommand.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'Calypso-SystemPlugins-Reflectivity-Browser-Watchpoints'
 }
 
-{ #category : #execution }
+{ #category : #testing }
 ClyAddWatchCommand class >> canBeExecutedInContext: aBrowserContext [
 
 	^aBrowserContext isSelectedItemHasWatch not

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyBreakOnVariableCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyBreakOnVariableCommand.class.st
@@ -7,12 +7,6 @@ Class {
 	#category : #'Calypso-SystemPlugins-Reflectivity-Browser-VariableBreakpoints'
 }
 
-{ #category : #testing }
-ClyBreakOnVariableCommand class >> canBeExecutedInContext: aSourceCodeContext [
-	^ self isAbstract not
-		and: [ super canBeExecutedInContext: aSourceCodeContext ]
-]
-
 { #category : #activation }
 ClyBreakOnVariableCommand class >> fullBrowserMenuActivation [
 	<classAnnotation>

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyRemoveBreakpointCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyRemoveBreakpointCommand.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'Calypso-SystemPlugins-Reflectivity-Browser-Breakpoints'
 }
 
-{ #category : #execution }
+{ #category : #testing }
 ClyRemoveBreakpointCommand class >> canBeExecutedInContext: aBrowserContext [
 
 	^aBrowserContext isSelectedItemHasBreakpoint

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyRemoveExecutionCounterCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyRemoveExecutionCounterCommand.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'Calypso-SystemPlugins-Reflectivity-Browser-ExecutionCounters'
 }
 
-{ #category : #execution }
+{ #category : #testing }
 ClyRemoveExecutionCounterCommand class >> canBeExecutedInContext: aBrowserContext [
 
 	^aBrowserContext isSelectedItemHasExecutionCounter

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyRemoveWatchCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyRemoveWatchCommand.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'Calypso-SystemPlugins-Reflectivity-Browser-Watchpoints'
 }
 
-{ #category : #execution }
+{ #category : #testing }
 ClyRemoveWatchCommand class >> canBeExecutedInContext: aBrowserContext [
 
 	^aBrowserContext isSelectedItemHasWatch

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyVariableBreakpointCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyVariableBreakpointCommand.class.st
@@ -11,7 +11,7 @@ Class {
 
 { #category : #testing }
 ClyVariableBreakpointCommand class >> canBeExecutedInContext: aSourceCodeContext [
-	^ self isAbstract not
+	^ (super canBeExecutedInContext: aSourceCodeContext)
 		and: [ aSourceCodeContext lastSelectedSourceNode isVariable ]
 ]
 

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/SycVariableBreakpointCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/SycVariableBreakpointCommand.class.st
@@ -17,12 +17,6 @@ SycVariableBreakpointCommand class >> browserContextMenuActivation [
 ]
 
 { #category : #testing }
-SycVariableBreakpointCommand class >> canBeExecutedInContext: aToolContext [
-	^ self isAbstract not
-		and: [ super canBeExecutedInContext: aToolContext ]
-]
-
-{ #category : #testing }
 SycVariableBreakpointCommand class >> isAbstract [
 	^self == SycVariableBreakpointCommand
 ]

--- a/src/SystemCommands-ClassCommands/SycSingleClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycSingleClassCommand.class.st
@@ -17,7 +17,9 @@ Class {
 
 { #category : #testing }
 SycSingleClassCommand class >> canBeExecutedInContext: aToolContext [
-	^aToolContext isClassSelected 
+
+	^ (super canBeExecutedInContext: aToolContext) and: [ 
+		  aToolContext isClassSelected ]
 ]
 
 { #category : #testing }

--- a/src/SystemCommands-SourceCodeCommands/SycConvertTempToInstVarCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycConvertTempToInstVarCommand.class.st
@@ -9,9 +9,7 @@ Class {
 
 { #category : #testing }
 SycConvertTempToInstVarCommand class >> canBeExecutedInContext: aSourceCodeContext [
-	super canBeExecutedInContext: aSourceCodeContext.
-	
-	^aSourceCodeContext isTempVariableSelected  
+	^(super canBeExecutedInContext: aSourceCodeContext) and: [aSourceCodeContext isTempVariableSelected]  
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
@@ -12,11 +12,11 @@ Class {
 	#category : #'SystemCommands-SourceCodeCommands'
 }
 
-{ #category : #execution }
+{ #category : #testing }
 SycExtractMethodCommand class >> canBeExecutedInContext: aSourceCodeContext [
-	super canBeExecutedInContext: aSourceCodeContext.
-	
-	^aSourceCodeContext isMethodSelected not 
+
+	^ (super canBeExecutedInContext: aSourceCodeContext) and: [ 
+		  aSourceCodeContext isMethodSelected not ]
 ]
 
 { #category : #converting }

--- a/src/SystemCommands-SourceCodeCommands/SycExtractSetUpRefactoring.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractSetUpRefactoring.class.st
@@ -12,9 +12,10 @@ Class {
 
 { #category : #testing }
 SycExtractSetUpRefactoring class >> canBeExecutedInContext: aToolContext [
-	super canBeExecutedInContext: aToolContext.
-	
-	^aToolContext isMethodSelected not and: [aToolContext lastSelectedMethod selector isTestSelector]
+
+	^ (super canBeExecutedInContext: aToolContext) and: [ 
+		  aToolContext isMethodSelected not and: [ 
+			  aToolContext lastSelectedMethod selector isTestSelector ] ]
 ]
 
 { #category : #executing }

--- a/src/SystemCommands-SourceCodeCommands/SycExtractTempCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractTempCommand.class.st
@@ -16,11 +16,9 @@ Class {
 	#category : #'SystemCommands-SourceCodeCommands'
 }
 
-{ #category : #execution }
+{ #category : #testing }
 SycExtractTempCommand class >> canBeExecutedInContext: aSourceCodeContext [
-	super canBeExecutedInContext: aSourceCodeContext.
-	
-	^aSourceCodeContext isMethodSelected not 
+		^ (super canBeExecutedInContext: aSourceCodeContext) and: [ aSourceCodeContext isMethodSelected not ]
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-SourceCodeCommands/SycInlineMethodCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycInlineMethodCommand.class.st
@@ -7,11 +7,12 @@ Class {
 	#category : #'SystemCommands-SourceCodeCommands'
 }
 
-{ #category : #execution }
+{ #category : #testing }
 SycInlineMethodCommand class >> canBeExecutedInContext: aSourceCodeContext [
-	super canBeExecutedInContext: aSourceCodeContext.
-	
-	^aSourceCodeContext isMethodSelected not and: [ aSourceCodeContext isMessageSelected ]
+
+	^ (super canBeExecutedInContext: aSourceCodeContext) and: [ 
+		  aSourceCodeContext isMethodSelected not and: [ 
+			  aSourceCodeContext isMessageSelected ] ]
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-SourceCodeCommands/SycInlineTempCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycInlineTempCommand.class.st
@@ -7,11 +7,9 @@ Class {
 	#category : #'SystemCommands-SourceCodeCommands'
 }
 
-{ #category : #execution }
+{ #category : #testing }
 SycInlineTempCommand class >> canBeExecutedInContext: aSourceCodeContext [
-	super canBeExecutedInContext: aSourceCodeContext.
-	
-	^aSourceCodeContext isTempVariableSelected  
+	^ (super canBeExecutedInContext: aSourceCodeContext) and: [ aSourceCodeContext isTempVariableSelected]
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-SourceCodeCommands/SycRenameArgOrTempCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycRenameArgOrTempCommand.class.st
@@ -15,11 +15,11 @@ Class {
 	#category : #'SystemCommands-SourceCodeCommands'
 }
 
-{ #category : #execution }
+{ #category : #testing }
 SycRenameArgOrTempCommand class >> canBeExecutedInContext: aSourceCodeContext [
-	super canBeExecutedInContext: aSourceCodeContext.
-	
-	^ aSourceCodeContext isArgOrTempVariableSelected 
+
+	^ (super canBeExecutedInContext: aSourceCodeContext) and: [ 
+		  aSourceCodeContext isArgOrTempVariableSelected ]
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-VariableCommands/SycGenerateVariableAccessorsWithLazyInitializationCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycGenerateVariableAccessorsWithLazyInitializationCommand.class.st
@@ -10,7 +10,10 @@ Class {
 
 { #category : #testing }
 SycGenerateVariableAccessorsWithLazyInitializationCommand class >> canBeExecutedInContext: aToolContext [
-	^aToolContext isVariableSelected and: [ aToolContext isGlobalVariableSelected not ]
+
+	^ (super canBeExecutedInContext: aToolContext) and: [ 
+		  aToolContext isVariableSelected and: [ 
+			  aToolContext isGlobalVariableSelected not ] ]
 ]
 
 { #category : #activation }


### PR DESCRIPTION
after doing the isAbstract check in the superclass (see #10770), we can omit it from all the methods that override it if we make sure to do a super call.

In addition:
- fix some super calls that were not returning anything 
- make sure the methods are all categorized the same 
- remove some Pharo7 specific code in ClyIcebergShowMethodVersionCommand

