### PR TITLE
Rename "Hier" to "Hierarchy" in scopes of refactoring #10778

### DIFF
--- a/src/Calypso-SystemQueries/ClyAbstractClassScope.class.st
+++ b/src/Calypso-SystemQueries/ClyAbstractClassScope.class.st
@@ -95,7 +95,7 @@ ClyAbstractClassScope class >> defaultName [
 
 { #category : #'scope names' }
 ClyAbstractClassScope class >> hierarchyScopeName [
-	^'hier'
+	^ 'hierarchy'
 ]
 
 { #category : #'scope names' }


### PR DESCRIPTION
Fixes #10778