### PR TITLE
Fix  #10698: Misleading Calypso warning when defining new instance variables

### DIFF
--- a/src/Calypso-SystemPlugins-Traits-Queries/ClySystemEnvironment.extension.st
+++ b/src/Calypso-SystemPlugins-Traits-Queries/ClySystemEnvironment.extension.st
@@ -13,8 +13,8 @@ ClySystemEnvironment >> defineTrait: defString notifying: aController startingFr
 		and: [self includesClassNamed: newTraitName asSymbol]) ifTrue:
 			["Attempting to define new class/trait over existing one when
 				not looking at the original one in this browser..."
-			(self confirm: ((newTraitName , ' is an existing class/trait in this system.
-Redefining it might cause serious problems.
+			(self confirm: ((newTraitName , ' might have been edited from another editor.
+Redefining it might override these changes.
 Is this really what you want to do?') asText makeBoldFrom: 1 to: newTraitName size))
 				ifFalse: [^ nil ]].
 

--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -165,8 +165,8 @@ ClySystemEnvironment >> confirmToOverrideExistingClassNamed: newClassName [
 	"Attempting to define new class/trait over existing one when not looking at the original one in this browser..."
 
 	^ self confirm:
-		((newClassName , ' is an existing class/trait in this system.
-Redefining it might cause serious problems.
+		((newClassName , ' might have been edited from another editor.
+Redefining it might override these changes.
 Is this really what you want to do?') asText
 			 makeBoldFrom: 1
 			 to: newClassName size)


### PR DESCRIPTION
This PR changes the message to be in line with what the code says.

XX  might have been edited from another editor.
Redefining it might override these changes.
Is this really what you want to do?


fixes #10698
