### PR TITLE
Fix #7952: Decompiler raises Error For methods from Traits on class side

### DIFF
--- a/src/Flashback-Decompiler/FBDASTBuilder.class.st
+++ b/src/Flashback-Decompiler/FBDASTBuilder.class.st
@@ -88,7 +88,7 @@ FBDASTBuilder >> codeEmptySequence [
 
 { #category : #building }
 FBDASTBuilder >> codeInstanceVariable: offset [
-	^ RBVariableNode named: (methodClass allInstVarNames at: offset)
+	^ RBVariableNode named: (methodClass allSlots at: offset) name
 ]
 
 { #category : #building }


### PR DESCRIPTION
For Traits with State: #allInstVarNames not in sync with #allSlots, there is an issue for that already: #8630

A side effect is that this breaks the decompiler, but we can just use #allSlots here.

fixes #7952

The code shown in the issue (regression test to run the decompiler on all the image) is too slow to the added
to the tests of the image. Instead we should add a dedicated regression test CI for these kind of tests.

