### PR TITLE
Fix 10741: Adding an unknown SharedPool and canceling the proposed choice brings a debugger

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -1038,7 +1038,7 @@ Class >> sharing: poolString [
 							builder superclass: SharedPool;
 							name: poolName;
 							category: self category ]]
-				ifFalse:[^self error: poolName,' does not exist']])].
+				ifFalse:[^self inform: poolName,' does not exist']])].
 	self sharedPools isEmpty ifTrue: [self sharedPools: nil].
 	oldPools do: [:pool |
 				| found |


### PR DESCRIPTION
This PR changes the #error: to an inform:, which allows the programmer to continue editing

fixes #10741