### PR TITLE
Fix #8630: fix allInstVarNames for Traits with State

### DIFF
--- a/src/Kernel-Tests/BehaviorTest.class.st
+++ b/src/Kernel-Tests/BehaviorTest.class.st
@@ -25,6 +25,20 @@ BehaviorTest >> sampleMessageWithFirstArgument: firstArgument "This is a comment
 ]
 
 { #category : #tests }
+BehaviorTest >> testAllInstVarNames [
+
+	self assert: Point allInstVarNames asArray equals: #( x y ).
+	"superclass ivars are first"
+	self assert: Association allInstVarNames asArray equals: #( key value ).
+	"For now, allInstVarNames is implemented by returning all slot names. This has the be improved 
+	later: for ST80 compatibilty, we should have allInstVarNames just returning the indexed slots, 
+	while allInstanceVariableNames should return all"
+	self assert:
+		(SystemNavigation new allBehaviors allSatisfy: [ :behavior | 
+			 behavior allInstVarNames size = behavior allSlots size ])
+]
+
+{ #category : #tests }
 BehaviorTest >> testAllMethods [
 	| allMethods nonOverridenMethods |
 	allMethods := IdentitySet new

--- a/src/Kernel-Tests/BehaviorTest.class.st
+++ b/src/Kernel-Tests/BehaviorTest.class.st
@@ -27,9 +27,9 @@ BehaviorTest >> sampleMessageWithFirstArgument: firstArgument "This is a comment
 { #category : #tests }
 BehaviorTest >> testAllInstVarNames [
 
-	self assert: Point allInstVarNames asArray equals: #( x y ).
+	self assert: Point allInstVarNames equals: #( x y ).
 	"superclass ivars are first"
-	self assert: Association allInstVarNames asArray equals: #( key value ).
+	self assert: Association allInstVarNames equals: #( key value ).
 	"For now, allInstVarNames is implemented by returning all slot names. This has the be improved 
 	later: for ST80 compatibilty, we should have allInstVarNames just returning the indexed slots, 
 	while allInstanceVariableNames should return all"

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -106,6 +106,13 @@ ClassDescription >> addSlot: aSlot [
 	^self subclassResponsibility
 ]
 
+{ #category : #'accessing - instances and variables' }
+ClassDescription >> allInstVarNames [
+	"Answer an Array of the receiver's instance variable names."
+
+	^self allSlots collect: [ :each | each name ]
+]
+
 { #category : #'instance variables' }
 ClassDescription >> allInstVarNamesEverywhere [
 	"Answer the set of inst var names used by the receiver, all superclasses, and all subclasses"

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -110,7 +110,7 @@ ClassDescription >> addSlot: aSlot [
 ClassDescription >> allInstVarNames [
 	"Answer an Array of the receiver's instance variable names."
 
-	^self allSlots collect: [ :each | each name ]
+	^self allSlots collect: [ :each | each name ] as: Array
 ]
 
 { #category : #'instance variables' }

--- a/src/Spec-Core/AbstractFormButtonPresenter.class.st
+++ b/src/Spec-Core/AbstractFormButtonPresenter.class.st
@@ -120,7 +120,6 @@ AbstractFormButtonPresenter >> state [
 { #category : #api }
 AbstractFormButtonPresenter >> state: aBoolean [
 	"Set if the checkbox is activated or not"
-	"<api: #boolean getter: #state>"
 	stateHolder value: aBoolean
 ]
 

--- a/src/Spec-Core/RadioButtonPresenter.class.st
+++ b/src/Spec-Core/RadioButtonPresenter.class.st
@@ -98,11 +98,10 @@ RadioButtonPresenter >> privateSetState: aBoolean [
 	self changed: #state
 ]
 
-{ #category : #protocol }
+{ #category : #api }
 RadioButtonPresenter >> state: aBoolean [
 	"Set if the radio is activated or not"
 
-	<api: #boolean getter: #state>
 	self canDeselectByClick
 		ifTrue: [ stateHolder value: aBoolean ]
 		ifFalse: [ self state


### PR DESCRIPTION
- add #testAllInstVarNames
- Implement allInstVarNames in terms of #allSlots in ClassDescription

We should make sure later that #allInstVarNames is in sync with #instVarAt: for the ST80 offset API (as soon as we use non-offset-based Slots for real).

For that, we have another issue tracker entry: https://github.com/pharo-project/pharo/issues/8631

This PR cleans some unused Pragma from Spec in addition (not really needed as that code will be removed anyway)

