### PR TITLE
Remove Spec1 Critic Browser

### DIFF
--- a/src/BaselineOfQualityAssistant/BaselineOfQualityAssistant.class.st
+++ b/src/BaselineOfQualityAssistant/BaselineOfQualityAssistant.class.st
@@ -11,12 +11,11 @@ BaselineOfQualityAssistant >> baseline: spec [
 	spec for: #'common' do: [
 			
 		spec 
-			package: 'Tool-CriticBrowser';
 			package: 'Renraku';
 			package: 'Renraku-Tests';
 			package: 'Renraku-Help'.
 		spec 
-			group: 'Core' with: #('Renraku' 'Tool-CriticBrowser');
+			group: 'Core' with: #('Renraku');
 			group: 'Tests' with: #('Renraku-Tests');
 			group: 'Help' with: #('Renraku-Help');
 			group: 'default' with: #('Core' 'Help' 'Tests') ]

--- a/src/Calypso-SystemPlugins-Critic-Browser/ClyOpenCriticBrowserCommand.class.st
+++ b/src/Calypso-SystemPlugins-Critic-Browser/ClyOpenCriticBrowserCommand.class.st
@@ -22,8 +22,8 @@ ClyOpenCriticBrowserCommand >> defaultMenuItemName [
 
 { #category : #execution }
 ClyOpenCriticBrowserCommand >> execute [
-
-	CriticBrowser
-		openOnRule: (ReRuleManager uniqueInstance allRules) 
-		onEnvironment: (RBPackageEnvironment packages: packages)
+	| env |
+	
+	env := RBPackageEnvironment new packages: packages.
+	StCritiqueRuleSelectorPresenter openWithEnvironment: env removeTestCase: false
 ]

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -339,6 +339,7 @@ SystemDependenciesTest >> testExternalIDEDependencies [
 	packages := packages ,  #('TaskIt').
 	packages := packages , { BaselineOfFuel name } , (BaselineOfFuel packagesOfGroupNamed: #Core).
 	packages := packages , {BaselineOfFuelPlatform name } , BaselineOfFuelPlatform allPackageNames.
+	packages := packages ,  { BaselineOfNewTools name }, (self packagesOfGroupNamed: 'CritiqueBrowser' on: BaselineOfNewTools ).
 
 	dependencies := self externalDependendiesOf: packages.
 	self assertCollection: dependencies hasSameElements: self knownIDEDependencies


### PR DESCRIPTION
Spec2 rewrite is already loaded.
See NewTools-CodeCritiques package.