### PR TITLE
Remove Class>>isAbstract as it actually call the super class method 

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -698,13 +698,6 @@ Class >> instanceSide [
 ]
 
 { #category : #testing }
-Class >> isAbstract [
-	"Tells whether the receiver locally defines an abstract method, i.e., a method sending subclassResponsibility"
-
-	^ super isAbstract or: [ self classSide isAbstract ]
-]
-
-{ #category : #testing }
 Class >> isAnonymous [
 	^self getName isNil
 ]


### PR DESCRIPTION
Behavior>>isAbstract. Calls are now going dorectly to behavior class.
fixes #10810 