### PR TITLE
9777-SystemNavigation-default-allUnimplementedCalls-size---DNU 

### DIFF
--- a/src/Debugging-Core/InstructionStream.extension.st
+++ b/src/Debugging-Core/InstructionStream.extension.st
@@ -5,8 +5,8 @@ InstructionStream >> addSelectorTo: set [
 	"If this instruction is a send, add its selector to set."
 
 	| selectorOrSelf |
-	(selectorOrSelf := self selectorToSendOrSelf) == self ifFalse:
-		[set add: selectorOrSelf]
+	(selectorOrSelf := self selectorToSendOrSelf) isSymbol ifTrue:
+		[ set add: selectorOrSelf ]
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/Graphics-Canvas/InterpolatedGradientFillStyle.class.st
+++ b/src/Graphics-Canvas/InterpolatedGradientFillStyle.class.st
@@ -20,7 +20,7 @@ InterpolatedGradientFillStyle >> computePixelRampOfSize: length [
 	ramp do:[:assoc| | distance nextColor theta nextWord nextIndex step |
 		nextIndex := (assoc key * length) rounded.
 		nextColor := assoc value.
-		nextWord := nextColor pixelWord32.
+		nextWord := self pixelWord32Of: nextColor.
 		distance := nextIndex - lastIndex.
 		distance = 0 ifTrue: [distance := 1].
 		step := 1.0 / distance.

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -240,18 +240,18 @@ SystemNavigation >> allUnimplementedCalls [
 	"Answer an Array of each message that is sent by an expression in a  
 	method but is not implemented by any object in the system."
 
-	| all |
+	| all badMethods |
 	all := self allImplementedMessages.
-	^ Array streamContents: [ :aStream | 
-		  self allBehaviorsDo: [ :cl | 
-			  cl selectorsAndMethodsDo: [ :sel :meth | 
-				  | ignored |
-				  ignored := (meth pragmaAt: #ignoreUnimplementedCalls:)
-					             ifNotNil: [ :pragma | pragma argumentAt: 1 ]
-					             ifNil: [ #(  ) ].
-				  meth messages do: [ :m | 
-					  ((all includes: m) not and: [ (ignored includes: m) not ]) 
-						  ifTrue: [ aStream nextPut: meth ] ] ] ] ]
+	badMethods := Set new.
+	self allMethods do: [ :meth | 
+		| ignored |
+		ignored := (meth pragmaAt: #ignoreUnimplementedCalls:)
+			           ifNotNil: [ :pragma | pragma argumentAt: 1 ]
+			           ifNil: [ #(  ) ].
+		meth messages do: [ :m | 
+			((all includes: m) not and: [ (ignored includes: m) not ]) ifTrue: [ 
+				badMethods add: meth ] ] ].
+	^ badMethods
 ]
 
 { #category : #query }

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -236,25 +236,22 @@ SystemNavigation >> allSentMessages [
 
 { #category : #query }
 SystemNavigation >> allUnimplementedCalls [
+
 	"Answer an Array of each message that is sent by an expression in a  
 	method but is not implemented by any object in the system."
-	| aStream all |
+
+	| all |
 	all := self allImplementedMessages.
-	aStream := (Array new: 50) writeStream.
-	self
-		allBehaviorsDo: [:cl | cl
-				selectorsAndMethodsDo: [:sel :meth |
-					| secondStream ignored | 
-					secondStream := (String new: 5) writeStream.
-					ignored := (meth pragmaAt: #ignoreUnimplementedCalls:) 
-						ifNotNil: [ :pragma | (pragma argumentAt: 1)  ] 
-						ifNil: [ #() ].
-					meth messages
-						do: [:m | ((all includes: m) not and: [ (ignored includes: m) not])
-								ifTrue: [ secondStream nextPutAll: m; space ]].
-					secondStream position = 0
-						ifFalse: [aStream nextPut: cl name , ' ' , sel , ' calls: ' , secondStream contents]]].
-	^ aStream contents
+	^ Array streamContents: [ :aStream | 
+		  self allBehaviorsDo: [ :cl | 
+			  cl selectorsAndMethodsDo: [ :sel :meth | 
+				  | ignored |
+				  ignored := (meth pragmaAt: #ignoreUnimplementedCalls:)
+					             ifNotNil: [ :pragma | pragma argumentAt: 1 ]
+					             ifNil: [ #(  ) ].
+				  meth messages do: [ :m | 
+					  ((all includes: m) not and: [ (ignored includes: m) not ]) 
+						  ifTrue: [ aStream nextPut: meth ] ] ] ] ]
 ]
 
 { #category : #query }


### PR DESCRIPTION
- This PR implements the workaround as described in the issue.
- simplify #allUnimplementedCalls to return the methods so you can look at the code in the inspector

There is #9778 for fixing the problem with the extended bytecode parsing.

fixes #9777


