### PR TITLE
Increasing minimum size for Calypso browser

### DIFF
--- a/src/Calypso-Browser/ClyBrowserMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserMorph.class.st
@@ -123,9 +123,7 @@ Class {
 		'navigationStarted',
 		'plugins',
 		'navigationEnvironment',
-		'systemScope',
-		'toolbars',
-		'toolbarPanels'
+		'systemScope'
 	],
 	#category : #'Calypso-Browser-UI'
 }

--- a/src/Calypso-Browser/ClyBrowserMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserMorph.class.st
@@ -123,7 +123,9 @@ Class {
 		'navigationStarted',
 		'plugins',
 		'navigationEnvironment',
-		'systemScope'
+		'systemScope',
+		'toolbars',
+		'toolbarPanels'
 	],
 	#category : #'Calypso-Browser-UI'
 }
@@ -500,7 +502,7 @@ ClyBrowserMorph >> open [
 	window := self openInWindow.
 	window model: self.
 	self updateWindowTitle.
-	window minimumExtent: 675@500.0 
+	window minimumExtent: 860@500.0 
 ]
 
 { #category : #'opening/closing' }


### PR DESCRIPTION
New minimum size prevents widgets from hiding.

Note: In Calypso Browser, the middle toolbar (the one between the navigation views and the source code editor) constraints the minimum size of its container (which also contains the widgets). 

To allow the browser to have a smaller size, the middle toolbar must be split into smaller toolbars, which are able to resize together with their container