### PR TITLE
Inserting variable breakpoint when the selected node is variable and the user double clicks left panel

### DIFF
--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddBreakpointCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyAddBreakpointCommand.class.st
@@ -15,8 +15,7 @@ Class {
 ClyAddBreakpointCommand class >> canBeExecutedInContext: aBrowserContext [
 
 	^ (super canBeExecutedInContext: aBrowserContext) and: [ 
-		  aBrowserContext lastSelectedSourceNode isVariable not and: [ 
-			  aBrowserContext isSelectedItemHasBreakpoint not ] ]
+		  aBrowserContext isSelectedItemHasBreakpoint not ]
 ]
 
 { #category : #activation }

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyBreakOnVarAccessCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyBreakOnVarAccessCommand.class.st
@@ -13,13 +13,6 @@ ClyBreakOnVarAccessCommand class >> canBeExecutedInContext: aSourceCodeContext [
 		and: [ aSourceCodeContext selectedSourceNode isArgumentVariable not ]
 ]
 
-{ #category : #testing }
-ClyBreakOnVarAccessCommand class >> methodEditorLeftBarClickActivation [
-	<classAnnotation>
-
-	^CmdTextLeftBarDoubleClickActivation for: ClyMethodSourceCodeContext
-]
-
 { #category : #accessing }
 ClyBreakOnVarAccessCommand >> defaultMenuItemName [
 	sourceNode isVariable ifFalse:[^'(unvalid node)'].

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyBreakOnVarAccessCommand.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClyBreakOnVarAccessCommand.class.st
@@ -13,6 +13,13 @@ ClyBreakOnVarAccessCommand class >> canBeExecutedInContext: aSourceCodeContext [
 		and: [ aSourceCodeContext selectedSourceNode isArgumentVariable not ]
 ]
 
+{ #category : #testing }
+ClyBreakOnVarAccessCommand class >> methodEditorLeftBarClickActivation [
+	<classAnnotation>
+
+	^CmdTextLeftBarDoubleClickActivation for: ClyMethodSourceCodeContext
+]
+
 { #category : #accessing }
 ClyBreakOnVarAccessCommand >> defaultMenuItemName [
 	sourceNode isVariable ifFalse:[^'(unvalid node)'].


### PR DESCRIPTION
Insert a VariableBreakpoint that breaks when the variable is accessed.
The problem of inserting breakpoints in pseudo-variables is not solved yet.