### PR TITLE
Fix: preserve pinning between ffi calls.

### DIFF
--- a/src/ThreadedFFI-Graphics-Extensions/Bitmap.extension.st
+++ b/src/ThreadedFFI-Graphics-Extensions/Bitmap.extension.st
@@ -3,6 +3,5 @@ Extension { #name : #Bitmap }
 { #category : #'*ThreadedFFI-Graphics-Extensions' }
 Bitmap >> tfPointerAddress [
 
-	self pinInMemory.
 	^ PointerUtils oopForObject: self
 ]

--- a/src/ThreadedFFI-UFFI-Tests/TFUFFIDerivedTypeMarshallingTest.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFUFFIDerivedTypeMarshallingTest.class.st
@@ -86,19 +86,6 @@ TFUFFIDerivedTypeMarshallingTest >> testMarshallingByteArrayAsStringArgument [
 ]
 
 { #category : #tests }
-TFUFFIDerivedTypeMarshallingTest >> testMarshallingByteArrayWillPinTheObject [
-	| aByteArray |
-	
-	aByteArray := ByteArray new: 10.
-	
-	self fillByteArray: aByteArray size: aByteArray size.
-	
-	self assert: aByteArray equals: #[1 2 3 4 5 6 7 8 9 10].
-	
-	self assert: aByteArray isPinnedInMemory
-]
-
-{ #category : #tests }
 TFUFFIDerivedTypeMarshallingTest >> testMarshallingFalseArgument [
 
 	self assert: (self booleanToInt: false) equals: 0

--- a/src/ThreadedFFI-UFFI/TFCalloutMethodBuilder.class.st
+++ b/src/ThreadedFFI-UFFI/TFCalloutMethodBuilder.class.st
@@ -99,47 +99,54 @@ TFCalloutMethodBuilder >> createFFICalloutLiteralFromSpec: functionSpec [
 TFCalloutMethodBuilder >> generateFFICallout: builder spec: functionSpec ffiLibrary: ffiLibrary [
 
 	TFCalloutAPI isTracing ifTrue: [ 
-		TFCalloutAPI trace: sender. 
-		builder 
+		TFCalloutAPI trace: sender.
+		builder
 			pushLiteral: TFCalloutAPI;
 			pushLiteral: sender;
 			send: #trace: ].
-	
-	builder 
-		pushLiteral: (ffiLibrary uniqueInstance runner).
-			
+
+	builder pushLiteral: ffiLibrary uniqueInstance runner.
+
 	"save ffi call as literal"
-	builder pushLiteral: (self createFFICalloutLiteralFromSpec: functionSpec).
+	builder pushLiteral:
+		(self createFFICalloutLiteralFromSpec: functionSpec).
 	"iterate arguments in order (in the function) to create the function call"
-	
-	functionSpec arguments 
-		do: [ :each | 
-			each emitArgument: builder context: sender inCallout: self requestor.
-			each resolvedType tfExternalTypeWithArity emitMarshallToPrimitive: builder ].
-	
+
+	functionSpec arguments doWithIndex: [ :each :index | 
+		each emitArgument: builder context: sender inCallout: self requestor.
+		each resolvedType tfExternalTypeWithArity
+			emitSavePinnedStateIn: builder index: index;
+			emitMarshallToPrimitive: builder ].
+
 	"create the array"
 	builder pushConsArray: functionSpec arguments size.
 	builder addTemp: #argumentsArray.
 	builder storeTemp: #argumentsArray.
-	
+
 	"send call and store into result"
 	builder send: #invokeFunction:withArguments:.
 
-	functionSpec arguments withIndexDo: [ :each :index| 
+	functionSpec arguments withIndexDo: [ :each :index | 
 		each emitReturnArgument: builder context: sender.
-		each resolvedType tfExternalTypeWithArity 
+		each resolvedType tfExternalTypeWithArity
+			emitRestorePinnedStateIn: builder
+			of: each
+			context: sender
+			index: index
+			callout: self requestor;
 			emitFreeIfNeededOfIndex: index
 			argumentsArrayTempName: #argumentsArray
-			withBuilder: builder  ].
-	
-	"Additional marshall in the case of TFFI"	
-	functionSpec returnType resolvedType tfExternalTypeWithArity emitMarshallFromPrimitive: builder.
+			withBuilder: builder ].
 
-	"convert in case return type needs it. And return reseult"	
-	
+	"Additional marshall in the case of TFFI"
+	functionSpec returnType resolvedType tfExternalTypeWithArity 
+		emitMarshallFromPrimitive: builder.
+
+	"convert in case return type needs it. And return reseult"
+
 	^ functionSpec returnType
-		emitReturn: builder
-		resultTempVar: #result
-		context: sender
-		inCallout: self requestor
+		  emitReturn: builder
+		  resultTempVar: #result
+		  context: sender
+		  inCallout: self requestor
 ]

--- a/src/ThreadedFFI/ByteString.extension.st
+++ b/src/ThreadedFFI/ByteString.extension.st
@@ -3,7 +3,6 @@ Extension { #name : #ByteString }
 { #category : #'*ThreadedFFI' }
 ByteString >> tfPointerAddress [
 
-	self pinInMemory.
 	^ PointerUtils oopForObject: self
 
 ]

--- a/src/ThreadedFFI/DoubleByteArray.extension.st
+++ b/src/ThreadedFFI/DoubleByteArray.extension.st
@@ -3,7 +3,6 @@ Extension { #name : #DoubleByteArray }
 { #category : #'*ThreadedFFI' }
 DoubleByteArray >> tfPointerAddress [
 
-	self pinInMemory.
 	^ PointerUtils oopForObject: self
 
 ]

--- a/src/ThreadedFFI/DoubleWordArray.extension.st
+++ b/src/ThreadedFFI/DoubleWordArray.extension.st
@@ -3,7 +3,6 @@ Extension { #name : #DoubleWordArray }
 { #category : #'*ThreadedFFI' }
 DoubleWordArray >> tfPointerAddress [
 
-	self pinInMemory.
 	^ PointerUtils oopForObject: self
 
 ]

--- a/src/ThreadedFFI/FloatArray.extension.st
+++ b/src/ThreadedFFI/FloatArray.extension.st
@@ -3,7 +3,6 @@ Extension { #name : #FloatArray }
 { #category : #'*ThreadedFFI' }
 FloatArray >> tfPointerAddress [
 
-	self pinInMemory.
 	^ PointerUtils oopForObject: self
 
 ]

--- a/src/ThreadedFFI/IntegerArray.extension.st
+++ b/src/ThreadedFFI/IntegerArray.extension.st
@@ -3,7 +3,6 @@ Extension { #name : #IntegerArray }
 { #category : #'*ThreadedFFI' }
 IntegerArray >> tfPointerAddress [
 
-	self pinInMemory.
 	^ PointerUtils oopForObject: self
 
 ]

--- a/src/ThreadedFFI/PointerUtils.class.st
+++ b/src/ThreadedFFI/PointerUtils.class.st
@@ -24,13 +24,6 @@ PointerUtils class >> oopForObject: anObject [
 ]
 
 { #category : #private }
-PointerUtils class >> oopForObjectForcePinInMemory: anObject [
-
-	anObject pinInMemory.
-	^ self oopForObject: anObject
-]
-
-{ #category : #private }
 PointerUtils class >> primObjectForOop: anObject [
 
 	"This primitive fails if the object is not pinned"

--- a/src/ThreadedFFI/TFBasicType.class.st
+++ b/src/ThreadedFFI/TFBasicType.class.st
@@ -311,6 +311,18 @@ TFBasicType >> emitMarshallToPrimitive: builder [
 	"Nothing to do in this case"
 ]
 
+{ #category : #marshalling }
+TFBasicType >> emitRestorePinnedStateIn: builder of: argument context: sender index: index callout: anObject [
+	
+	"Nothing to do in this case"
+]
+
+{ #category : #marshalling }
+TFBasicType >> emitSavePinnedStateIn: builder index: index [
+	
+	"Nothing to do in this case"
+]
+
 { #category : #writing }
 TFBasicType >> freeValueIfNeeded: aValue [ 
 	

--- a/src/ThreadedFFI/TFDerivedType.class.st
+++ b/src/ThreadedFFI/TFDerivedType.class.st
@@ -66,6 +66,23 @@ TFDerivedType >> emitFreeIfNeededOfIndex: argIndex argumentsArrayTempName: argum
 
 ]
 
+{ #category : #marshalling }
+TFDerivedType >> emitRestorePinnedStateIn: builder of: argument context: sender index: index callout: aCallout [
+
+	self basicType
+		emitRestorePinnedStateIn: builder
+		of: argument
+		context: sender
+		index: index
+		callout: aCallout
+]
+
+{ #category : #marshalling }
+TFDerivedType >> emitSavePinnedStateIn: anIRBuilder index: anInteger [
+	
+	self basicType emitSavePinnedStateIn: anIRBuilder index: anInteger
+]
+
 { #category : #freeing }
 TFDerivedType >> freeValueIfNeeded: aCHeapValueHolder [ 
 	

--- a/src/ThreadedFFI/TFOOPType.class.st
+++ b/src/ThreadedFFI/TFOOPType.class.st
@@ -27,7 +27,7 @@ TFOOPType >> emitMarshallToPrimitive: anIRBuilder [
 	anIRBuilder popTop.
 	anIRBuilder pushLiteral: PointerUtils.
 	anIRBuilder pushTemp: #__marshall_temp.
-	anIRBuilder send: #oopForObjectForcePinInMemory:
+	anIRBuilder send: #oopForObject:
 	
 ]
 

--- a/src/ThreadedFFI/TFPointerToStructType.class.st
+++ b/src/ThreadedFFI/TFPointerToStructType.class.st
@@ -35,6 +35,41 @@ TFPointerToStructType >> emitMarshallToPrimitive: anIRBuilder [
 	self basicType emitMarshallToPrimitive: anIRBuilder.
 ]
 
+{ #category : #marshalling }
+TFPointerToStructType >> emitRestorePinnedStateIn: builder of: argument context: sender index: index callout: aCallout [
+	
+	| tempName |
+	tempName := '__pinState', index asString.
+	
+	argument emitArgument: builder context: sender inCallout: aCallout.
+	builder pushDup.
+	builder send: #isNil.
+	builder jumpAheadTo: #notStruct if: true.
+	
+	"We should pin the handle, not the struct"
+	builder send: #getHandle.
+	builder pushTemp: tempName.
+	builder send: #setPinnedInMemory:.
+	
+	builder jumpAheadTarget: #notStruct.
+	builder popTop.
+]
+
+{ #category : #marshalling }
+TFPointerToStructType >> emitSavePinnedStateIn: anIRBuilder index: anInteger [
+	
+	"We should pin the handle, not the struct, only if the handle is not nil"
+	anIRBuilder pushDup.
+	anIRBuilder send: #isNil.
+	anIRBuilder jumpAheadTo: #notStruct if: true.
+	
+	anIRBuilder send: #getHandle.
+	self basicType emitSavePinnedStateIn: anIRBuilder index: anInteger.
+	
+	anIRBuilder jumpAheadTarget: #notStruct.
+
+]
+
 { #category : #'reading-writing' }
 TFPointerToStructType >> readValue: anExternalAddress [
 	

--- a/src/ThreadedFFI/TFPointerType.class.st
+++ b/src/ThreadedFFI/TFPointerType.class.st
@@ -16,6 +16,34 @@ TFPointerType >> emitMarshallToPrimitive: builder [
 	builder send: #tfPointerAddress
 ]
 
+{ #category : #marshalling }
+TFPointerType >> emitRestorePinnedStateIn: builder of: argument context: sender index: index callout: aCallout [
+	
+	| tempName |
+	tempName := '__pinState', index asString.
+	
+	argument emitArgument: builder context: sender inCallout: aCallout.
+	builder pushTemp: tempName.
+	builder send: #setPinnedInMemory:.
+	builder popTop.
+]
+
+{ #category : #marshalling }
+TFPointerType >> emitSavePinnedStateIn: builder index: index [
+	
+	| tempName |
+	tempName := '__pinState', index asString.
+	builder addTemp: tempName.
+	
+	"Finally pin it.
+	Pinning returns the previous state.
+	Store it to restore it later"
+	builder pushDup.
+	builder send: #pinInMemory.
+	builder storeTemp: tempName.
+	builder popTop
+]
+
 { #category : #reading }
 TFPointerType >> readValue: anExternalAddress offset: offset [
 

--- a/src/ThreadedFFI/TFStructType.class.st
+++ b/src/ThreadedFFI/TFStructType.class.st
@@ -90,6 +90,18 @@ TFStructType >> emitMarshallToPrimitive: anIRBuilder [
 	anIRBuilder send: #getHandle
 ]
 
+{ #category : #marshalling }
+TFStructType >> emitRestorePinnedStateIn: builder of: argument context: sender index: index callout: anObject [
+
+	"Nothing"
+]
+
+{ #category : #marshalling }
+TFStructType >> emitSavePinnedStateIn: builder index: index [
+
+	"Nothing"
+]
+
 { #category : #primitives }
 TFStructType >> free [
 	<primitive: 'primitiveFreeStruct'>

--- a/src/ThreadedFFI/UndefinedObject.extension.st
+++ b/src/ThreadedFFI/UndefinedObject.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #UndefinedObject }
 
 { #category : #'*ThreadedFFI' }
+UndefinedObject >> pinStructHandleInMemory [
+
+	"Do not change pinning of nil. Return its current pinned state"
+	^ self isPinnedInMemory
+]
+
+{ #category : #'*ThreadedFFI' }
 UndefinedObject >> tfPointerAddress [
 
 	^ ExternalAddress null

--- a/src/ThreadedFFI/WordArray.extension.st
+++ b/src/ThreadedFFI/WordArray.extension.st
@@ -3,7 +3,6 @@ Extension { #name : #WordArray }
 { #category : #'*ThreadedFFI' }
 WordArray >> tfPointerAddress [
 
-	self pinInMemory.
 	^ PointerUtils oopForObject: self
 
 ]

--- a/src/UnifiedFFI-Tests/FFICalloutAPITest.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutAPITest.class.st
@@ -242,6 +242,35 @@ FFICalloutAPITest >> testCallWithSelfParameter [
 	self assert: object handle asString equals: ('Hello, World' copyWith: (Character value: 0))
 ]
 
+{ #category : #'tests pointer' }
+FFICalloutAPITest >> testCalloutRestoresSetPinValue [
+	| dest argument |
+	
+	argument := 'Hello, World' asByteArray.
+	argument pinInMemory.
+
+	self 
+		primFromByteArray: argument
+		toExternalAddress: (dest := ExternalAddress allocate: 12) autoRelease 
+		size: 12.
+		
+	self assert: argument isPinnedInMemory
+]
+
+{ #category : #'tests pointer' }
+FFICalloutAPITest >> testCalloutRestoresUnsetPinValue [
+	| dest argument |
+	
+	argument := 'Hello, World' asByteArray.
+	self deny: argument isPinnedInMemory.
+	self 
+		primFromByteArray: argument
+		toExternalAddress: (dest := ExternalAddress allocate: 12) autoRelease 
+		size: 12.
+		
+	self deny: argument isPinnedInMemory
+]
+
 { #category : #'tests atomic' }
 FFICalloutAPITest >> testCharCall [
 	"Test using generic FFI spec"


### PR DESCRIPTION
Some ffi calls require that arguments are pinned to work correctly.
Pin arguments before calls, save the previous state and restore pinning after call.

The main objective of this PR is to avoid having large snapshots with big holes due to pinned objects.