### PR TITLE
10847-Deprecate-canBeGlobalVarInitial-and-canBeNonGlobalVarInitial

### DIFF
--- a/src/Deprecated10/AsciiCharset.extension.st
+++ b/src/Deprecated10/AsciiCharset.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #AsciiCharset }
+
+{ #category : #'*Deprecated10' }
+AsciiCharset class >> canBeGlobalVarInitial: aCharacter [ 
+	self deprecated: 'Please use #isValidGlobalName on the name of the variable'.
+	^ self isUppercase: aCharacter
+]

--- a/src/Deprecated10/Character.extension.st
+++ b/src/Deprecated10/Character.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #Character }
+
+{ #category : #'*Deprecated10' }
+Character >> canBeGlobalVarInitial [
+	self deprecated: 'Please use #isValidGlobalName on the name of the variable'.
+	^ self characterSet canBeGlobalVarInitial: self
+]
+
+{ #category : #'*Deprecated10' }
+Character >> canBeNonGlobalVarInitial [
+	self deprecated: 'Please use #isValidGlobalName on the name of the variable'.
+	^ self characterSet canBeNonGlobalVarInitial: self
+]

--- a/src/Deprecated10/EncodedCharSet.extension.st
+++ b/src/Deprecated10/EncodedCharSet.extension.st
@@ -1,0 +1,23 @@
+Extension { #name : #EncodedCharSet }
+
+{ #category : #'*Deprecated10' }
+EncodedCharSet class >> canBeGlobalVarInitial: char [
+
+	| leadingChar |
+	self deprecated: 'Please use #isValidGlobalName on the name of the variable'.
+	leadingChar := char leadingChar.
+
+	leadingChar = 0 ifTrue: [^ self isUppercase: char].
+	^ self isLetter: char.
+]
+
+{ #category : #'*Deprecated10' }
+EncodedCharSet class >> canBeNonGlobalVarInitial: char [
+
+	| leadingChar |
+	self deprecated: 'Please use #isValidGlobalName on the name of the variable'.
+	leadingChar := char leadingChar.
+
+	leadingChar = 0 ifTrue: [^ self isLowercase: char].
+	^ self isLetter: char.
+]

--- a/src/Kernel/AsciiCharset.class.st
+++ b/src/Kernel/AsciiCharset.class.st
@@ -9,12 +9,6 @@ Class {
 	#category : #'Kernel-BasicObjects'
 }
 
-{ #category : #testing }
-AsciiCharset class >> canBeGlobalVarInitial: aCharacter [ 
-	
-	^ self isUppercase: aCharacter
-]
-
 { #category : #'character classification' }
 AsciiCharset class >> isCasedLetter: char [
 	"There are no ASCII Characters in this Category"

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -404,16 +404,6 @@ Character >> basicPharoToIso [
 	^ Character value: tmp1
 ]
 
-{ #category : #testing }
-Character >> canBeGlobalVarInitial [
-	^ self characterSet canBeGlobalVarInitial: self
-]
-
-{ #category : #testing }
-Character >> canBeNonGlobalVarInitial [
-  ^ self characterSet canBeNonGlobalVarInitial: self
-]
-
 { #category : #accessing }
 Character >> charCode [
 	^ self asInteger bitAnd: 4194303

--- a/src/Multilingual-Encodings/EncodedCharSet.class.st
+++ b/src/Multilingual-Encodings/EncodedCharSet.class.st
@@ -17,26 +17,6 @@ Class {
 	#category : #'Multilingual-Encodings-CharSets'
 }
 
-{ #category : #'character classification' }
-EncodedCharSet class >> canBeGlobalVarInitial: char [
-
-	| leadingChar |
-	leadingChar := char leadingChar.
-
-	leadingChar = 0 ifTrue: [^ self isUppercase: char].
-	^ self isLetter: char.
-]
-
-{ #category : #'character classification' }
-EncodedCharSet class >> canBeNonGlobalVarInitial: char [
-
-	| leadingChar |
-	leadingChar := char leadingChar.
-
-	leadingChar = 0 ifTrue: [^ self isLowercase: char].
-	^ self isLetter: char.
-]
-
 { #category : #'class methods' }
 EncodedCharSet class >> charsetAt: encoding [
 


### PR DESCRIPTION
This deprecates the method so we can remove #leadingChar eventually

fixes #10847