### PR TITLE
10238-Cleanup-Deprecated90-CharacterleadingChar-has-still-users

### DIFF
--- a/src/Deprecated90/Character.extension.st
+++ b/src/Deprecated90/Character.extension.st
@@ -1,11 +1,6 @@
 Extension { #name : #Character }
 
 { #category : #'*Deprecated90' }
-Character >> leadingChar [
-	^ (self asInteger bitAnd: 1069547520) bitShift: -22
-]
-
-{ #category : #'*Deprecated90' }
 Character class >> leadingChar: leadChar code: code [
 
 	code >= 16r400000 ifTrue: [

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -799,6 +799,11 @@ Character >> isVowel [
 	^'AEIOU' includes: self asUppercase
 ]
 
+{ #category : #testing }
+Character >> leadingChar [
+	^ (self asInteger bitAnd: 1069547520) bitShift: -22
+]
+
 { #category : #converting }
 Character >> lowercase [
 	^ self asLowercase


### PR DESCRIPTION
as we have still users both in Deprecated10 and the main image, and it was never changed to warn users, we un-deprecate for now

