### PR TITLE
10800-Broken-FT2-library-setting

### DIFF
--- a/src/Graphics-Fonts/StandardFonts.class.st
+++ b/src/Graphics-Fonts/StandardFonts.class.st
@@ -289,6 +289,24 @@ StandardFonts class >> setFontsToVeryLarge [
 ]
 
 { #category : #styles }
+StandardFonts class >> setSmallBitmapFonts [
+
+	| sans fixed |
+	
+	sans := 'Bitmap Source Sans Pro'.
+	fixed := 'Bitmap Source Code Pro'.
+	
+	self defaultFont: (LogicalFont familyName: sans pointSize: 10).
+	self codeFont: (LogicalFont familyName: fixed pointSize: 10).
+	self listFont: (LogicalFont familyName: sans pointSize: 10).
+	self menuFont: (LogicalFont familyName: sans pointSize: 10).
+	self buttonFont: (LogicalFont familyName: sans pointSize: 10).
+ 	self windowTitleFont: (LogicalFont familyName: sans pointSize: 11).
+	self balloonFont: (LogicalFont familyName: sans pointSize: 9).
+ 	self haloFont: (LogicalFont familyName: sans pointSize: 9).
+]
+
+{ #category : #styles }
 StandardFonts class >> smallPointSizeForStyleNamed: aSymbol [
 	| all s idx |
 	StrikeFont defaultFontKey.


### PR DESCRIPTION
This PR adds the missing method #setSmallBitmapFonts back as the minimal fix.

Fixes #10800


