### PR TITLE
Cleanup-CDAbstractClassDefinitionParser

### DIFF
--- a/src/ClassParser/CDAbstractClassDefinitionParser.class.st
+++ b/src/ClassParser/CDAbstractClassDefinitionParser.class.st
@@ -11,6 +11,18 @@ Class {
 	#category : #'ClassParser-Parser'
 }
 
+{ #category : #parsing }
+CDAbstractClassDefinitionParser class >> fromASTNode: aNode [ 
+	
+	^ self new parseRootNode: aNode
+]
+
+{ #category : #testing }
+CDAbstractClassDefinitionParser class >> isAbstract [
+		
+	^ self == CDAbstractClassDefinitionParser
+]
+
 { #category : #'instance creation' }
 CDAbstractClassDefinitionParser class >> parse: aString [ 
 	
@@ -81,8 +93,9 @@ CDAbstractClassDefinitionParser >> handleInstanceVariablesFromNode: aNode [
 CDAbstractClassDefinitionParser >> handleMetaclassName: aNode [
 	"we are in situation ClassX class << ClassZ class
 				slots: {xxxx} so grab the class"
-	
+				
 	aNode handleMetaclassName: self		
+	
 	"| className classNode node |
 	node := aNode receiver arguments first. 
 	className := node receiver binding value class name.
@@ -93,13 +106,18 @@ CDAbstractClassDefinitionParser >> handleMetaclassName: aNode [
 	"
 ]
 
-{ #category : #accessing }
+{ #category : #parsing }
 CDAbstractClassDefinitionParser >> handlePackage: aNode [ 
 	
 	classDefinition packageNameNode: aNode astNode: aNode
 ]
 
-{ #category : #accessing }
+{ #category : #parsing }
+CDAbstractClassDefinitionParser >> handleSharedPoolsFromNode: aNode [ 
+	^ self subclassResponsibility
+]
+
+{ #category : #parsing }
 CDAbstractClassDefinitionParser >> handleSharedVariableNames: aNode [ 
 	
 	| slots slotNodes classVariablesString |
@@ -182,6 +200,11 @@ CDAbstractClassDefinitionParser >> handleSlotsNodesFromArrayNode: aRBArrayNode [
 ]
 
 { #category : #parsing }
+CDAbstractClassDefinitionParser >> handleSuperclassNode: aNode [ 
+	^ self subclassResponsibility
+]
+
+{ #category : #parsing }
 CDAbstractClassDefinitionParser >> handleTraitUsesFromNode: aNode [
 	
 	| traitComposition |
@@ -200,7 +223,17 @@ CDAbstractClassDefinitionParser >> parse: aString [
 	^ self parseRootNode: expressionTree
 ]
 
-{ #category : #hooks }
+{ #category : #parsing }
+CDAbstractClassDefinitionParser >> parseRootNode: aNode [ 
+	^ self subclassResponsibility
+]
+
+{ #category : #parsing }
+CDAbstractClassDefinitionParser >> parseSelectorPart: aString withArgument: aNode [ 
+	^ self subclassResponsibility
+]
+
+{ #category : #'private - class factory' }
 CDAbstractClassDefinitionParser >> parserClass [
 	^ RBParser
 ]
@@ -219,4 +252,9 @@ CDAbstractClassDefinitionParser >> slotInitializationNodeClass [
 { #category : #'private - class factory' }
 CDAbstractClassDefinitionParser >> slotNodeClass [
 	^ CDSlotNode
+]
+
+{ #category : #parsing }
+CDAbstractClassDefinitionParser >> visitMessageNode: aNode [ 
+	^ self subclassResponsibility
 ]

--- a/src/ClassParser/CDClassDefinitionParser.class.st
+++ b/src/ClassParser/CDClassDefinitionParser.class.st
@@ -13,12 +13,6 @@ Class {
 }
 
 { #category : #parsing }
-CDClassDefinitionParser class >> fromASTNode: aNode [ 
-	
-	^ self new parseRootNode: aNode
-]
-
-{ #category : #parsing }
 CDClassDefinitionParser >> handleClassName: aNode withType: aSymbol [
 	| layoutClass |
 	self handleClassName: aNode.

--- a/src/ClassParser/CDFluidClassDefinitionParser.class.st
+++ b/src/ClassParser/CDFluidClassDefinitionParser.class.st
@@ -43,24 +43,18 @@ Class {
 }
 
 { #category : #parsing }
-CDFluidClassDefinitionParser class >> fromASTNode: aNode [ 
-	
-	^ self new parseRootNode: aNode
-]
-
-{ #category : #'handling  nodes' }
 CDFluidClassDefinitionParser >> handleClassAndSuperclassOf: aNode [
 
 	superclassNode ifNotNil: [ self handleSuperclassNode: superclassNode ].
 	self handleClassName: classNameNode.
 ]
 
-{ #category : #'handling  nodes' }
+{ #category : #parsing }
 CDFluidClassDefinitionParser >> handleLayout: aNode [
 	classDefinition layoutClass: aNode binding value
 ]
 
-{ #category : #metaclass }
+{ #category : #parsing }
 CDFluidClassDefinitionParser >> handleMetaclassNameFromCascade: aRBCascadeNode [ 
 
 	| className classNode node |
@@ -72,7 +66,7 @@ CDFluidClassDefinitionParser >> handleMetaclassNameFromCascade: aRBCascadeNode [
 	classDefinition className: node astNode: classNode
 ]
 
-{ #category : #metaclass }
+{ #category : #parsing }
 CDFluidClassDefinitionParser >> handleMetaclassNameFromMessage: aNode [ 
 
 	| className classNode node |
@@ -84,7 +78,7 @@ CDFluidClassDefinitionParser >> handleMetaclassNameFromMessage: aNode [
 	classDefinition className: node astNode: classNode
 ]
 
-{ #category : #'handling  nodes' }
+{ #category : #parsing }
 CDFluidClassDefinitionParser >> handleSharedPoolsFromNode: aNode [
 	| sharedPoolNodes |
 	sharedPoolNodes := aNode children
@@ -98,7 +92,7 @@ CDFluidClassDefinitionParser >> handleSharedPoolsFromNode: aNode [
 	classDefinition sharedPools: sharedPoolNodes
 ]
 
-{ #category : #'handling  nodes' }
+{ #category : #parsing }
 CDFluidClassDefinitionParser >> handleSharedVariableNames: aNode [ 
 	
 	| slotNodes classVariablesString |
@@ -117,7 +111,7 @@ CDFluidClassDefinitionParser >> handleSharedVariableNames: aNode [
 	classDefinition sharedSlots: slotNodes
 ]
 
-{ #category : #'handling  nodes' }
+{ #category : #parsing }
 CDFluidClassDefinitionParser >> handleSuperclassNode: aSuperclassNode [
 	| aSuperclassName newSuperclassNode |
 
@@ -132,13 +126,13 @@ CDFluidClassDefinitionParser >> handleSuperclassNode: aSuperclassNode [
 		astNode: newSuperclassNode
 ]
 
-{ #category : #'handling  nodes' }
+{ #category : #parsing }
 CDFluidClassDefinitionParser >> handleTag: aNode [
 
 	classDefinition tag: (CDClassTagNode new name: aNode value)
 ]
 
-{ #category : #'parsing-internal' }
+{ #category : #parsing }
 CDFluidClassDefinitionParser >> parseRootNode: expressionTree [
 	
 	| searcher |
@@ -165,7 +159,7 @@ CDFluidClassDefinitionParser >> parseRootNode: expressionTree [
 	^ classDefinition
 ]
 
-{ #category : #'parsing-internal' }
+{ #category : #parsing }
 CDFluidClassDefinitionParser >> parseSelectorPart: aString withArgument: aNode [ 
 	"We could do this with reflection, or with a dictionary and closures.
 	I chose to use a series of if for readability only."
@@ -191,7 +185,7 @@ CDFluidClassDefinitionParser >> parseSelectorPart: aString withArgument: aNode [
 		signal
 ]
 
-{ #category : #'parsing-internal' }
+{ #category : #parsing }
 CDFluidClassDefinitionParser >> visitCascadeNode: aRBCascadeNode [ 
 	"See class comment. Here we handle the cascade version of the class definition."
 	" 
@@ -209,7 +203,7 @@ CDFluidClassDefinitionParser >> visitCascadeNode: aRBCascadeNode [
 			self parseSelectorPart: selectorPart withArgument: argument ] ]
 ]
 
-{ #category : #'parsing-internal' }
+{ #category : #parsing }
 CDFluidClassDefinitionParser >> visitMessageNode: aRBMessageNode [
 	"See class comment. Here we handle the cascade version of the class definition."
 	"


### PR DESCRIPTION
This PR cleans a bit the CDAbstractClassDefinitionParser hierarchy

- add subclassResponsibility
- make sure that the categories are in sync in the hierarchy
- push up #fromASTNode:
