### PR TITLE
3234-CDNode-got-polluted-with-extension-methods-that-are-on-reflectivity-for-nodes

### DIFF
--- a/src/ClassParser/CDAbstractTraitCompositionNode.class.st
+++ b/src/ClassParser/CDAbstractTraitCompositionNode.class.st
@@ -8,6 +8,12 @@ Class {
 	#category : #'ClassParser-Model'
 }
 
+{ #category : #testing }
+CDAbstractTraitCompositionNode class >> isAbstract [
+		
+	^ self == CDAbstractTraitCompositionNode
+]
+
 { #category : #composing }
 CDAbstractTraitCompositionNode >> + aNode [
 	

--- a/src/ClassParser/CDNode.class.st
+++ b/src/ClassParser/CDNode.class.st
@@ -18,6 +18,12 @@ Class {
 	#category : #'ClassParser-Model'
 }
 
+{ #category : #testing }
+CDNode class >> isAbstract [
+		
+	^ self == CDNode
+]
+
 { #category : #'instance creation' }
 CDNode class >> on: aRBMessageNode [ 
 	
@@ -71,24 +77,6 @@ CDNode >> classDefinitionNode [
 { #category : #selection }
 CDNode >> containedBy: anInterval [ 
 	^anInterval first <= self start and: [anInterval last >= self stop]
-]
-
-{ #category : #compatibility }
-CDNode >> hasBreakpoint [
-	
-	^ false
-]
-
-{ #category : #compatibility }
-CDNode >> hasExecutionCounter [
-	
-	^ false
-]
-
-{ #category : #compatibility }
-CDNode >> hasWatch [
-	
-	^ false
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
- remove breakpoint related methods on CDNode
- tag two abstract classes

fixes #3234