### PR TITLE
Add faster ByteString comparison primitive.

### DIFF
--- a/src/Collections-Strings/ByteString.class.st
+++ b/src/Collections-Strings/ByteString.class.st
@@ -185,6 +185,37 @@ ByteString >> byteSize [
 ]
 
 { #category : #comparing }
+ByteString >> compareWith: anotherString [
+
+	"Return a negative Smi, 0 or a positive Smi if self is anotherString, with the collating order of characters given optionnally by the order array."
+
+	<primitive: 158>
+	^ self compareWith: anotherString collated: AsciiOrder
+]
+
+{ #category : #comparing }
+ByteString >> compareWith: anotherString collated: order [
+
+	"Return a negative Smi, 0 or a positive Smi if self is anotherString, with the collating order of characters given optionnally by the order array."
+
+	<primitive: 158>
+	| len1 len2 c1 c2 |
+	len1 := self size.
+	len2 := anotherString size.
+	1 to: (len1 min: len2) do: [ :i | 
+		c1 := order at: (self basicAt: i) + 1.
+		c2 := order at: (anotherString basicAt: i) + 1.
+		c1 = c2 ifFalse: [ 
+			^ c1 < c2
+				  ifTrue: [ -1 ]
+				  ifFalse: [ 1 ] ] ].
+	len1 = len2 ifTrue: [ ^ 0 ].
+	^ len1 < len2
+		  ifTrue: [ -1 ]
+		  ifFalse: [ 1 ]
+]
+
+{ #category : #comparing }
 ByteString >> findSubstring: key in: body startingAt: start matchTable: matchTable [
 	
 	^ key findIn: body startingAt: start matchTable: matchTable.


### PR DESCRIPTION
/!\ This just adds the methods but it does not use them in the actual default implementation of String comparison. This is just a first step.

See: https://github.com/pharo-project/pharo/issues/3156