### PR TITLE
5879-Printing-an-exception-should-not-rely-on-the-AST

### DIFF
--- a/src/Kernel/BlockClosure.class.st
+++ b/src/Kernel/BlockClosure.class.st
@@ -174,7 +174,13 @@ BlockClosure >> cull: firstArg cull: secondArg cull: thirdArg cull: fourthArg [
 
 { #category : #printing }
 BlockClosure >> doPrintOn: aStream [
-	aStream nextPutAll: self sourceNode sourceCode
+
+	| code |
+	"If the compiler is available, we can print the code nicely"
+	code := Smalltalk hasCompiler
+		        ifTrue: [ self sourceNode value sourceCode ]
+		        ifFalse: [ '[]' ].
+	aStream nextPutAll: code
 ]
 
 { #category : #controlling }


### PR DESCRIPTION
Allow block printing if the compiler is not available.

(the error handler already kind of solved it in practice (as it would catch the case of a missing compiler, too), but this improves it: printing a block without the compiler should not be an error).

fixes #5879