### PR TITLE
Bugfix in RBSelectorEnvironment

### DIFF
--- a/src/Refactoring-Environment/RBSelectorEnvironment.class.st
+++ b/src/Refactoring-Environment/RBSelectorEnvironment.class.st
@@ -316,18 +316,25 @@ RBSelectorEnvironment >> removeClass: aClass [
 ]
 
 { #category : #removing }
-RBSelectorEnvironment >> removeClass: aClass selector: aSelector [ 
-	(aClass isMeta 
-		ifTrue: [metaClassSelectors at: aClass soleInstance name ifAbsent: [^self]]
-		ifFalse: [classSelectors at: aClass name ifAbsent: [^self]]) 
-			remove: aSelector
-			ifAbsent: []
+RBSelectorEnvironment >> removeClass: aClass selector: aSelector [
+
+	| class |
+	class := aClass isMeta
+		         ifTrue: [ 
+			         metaClassSelectors
+				         at: aClass soleInstance name
+				         ifAbsent: [ ^ self ] ]
+		         ifFalse: [ 
+		         classSelectors at: aClass name ifAbsent: [ ^ self ] ].
+	class remove: aSelector ifAbsent: [  ].
+	class ifEmpty: [ self removeClass: aClass ]
 ]
 
 { #category : #accessing }
-RBSelectorEnvironment >> selectorsForClass: aClass do: aBlock [ 
-	^(self privateSelectorsForClass: aClass) 
-		do: [:each | (aClass includesSelector: each) ifTrue: [aBlock value: each]]
+RBSelectorEnvironment >> selectorsForClass: aClass do: aBlock [
+
+	^ (self privateSelectorsForClass: aClass) copy do: [ :each | 
+		  (aClass includesSelector: each) ifTrue: [ aBlock value: each ] ]
 ]
 
 { #category : #printing }

--- a/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
+++ b/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
@@ -416,6 +416,17 @@ RBBrowserEnvironmentTest >> testSelectorEnvironment [
 	self assert: printString numberClasses equals: (printString referencesTo: #printString) numberClasses
 ]
 
+{ #category : #'tests - environments' }
+RBBrowserEnvironmentTest >> testSelectorEnvironmentRemovesEmptyClasses [
+
+	| printString class |
+	printString := RBBrowserEnvironment new referencesTo: #printString.
+	class := printString classes anyOne.
+	printString selectorsForClass: class do: [ :eachSelector | 
+		printString removeClass: class selector: eachSelector ].
+	self deny: (printString classes includes: class)
+]
+
 { #category : #tests }
 RBBrowserEnvironmentTest >> testSystemIntegrity [
 	| classes environment |


### PR DESCRIPTION
Hello there

This PR ports to Pharo 10 https://github.com/pharo-project/pharo/pull/10209

While writing the test I found a bug in `RBSelectorEnvironment >> selectorsForClass: aClass do: aBlock` : this method should iterate on a copy of the selectors collection, in case aBlock modifies the environment