### PR TITLE
10854-Cmd-t-stopped-working

### DIFF
--- a/src/Calypso-SystemTools-Core/SycOpenReflectivityMenuCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycOpenReflectivityMenuCommand.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #SycOpenReflectivityMenuCommand }
+
+{ #category : #'*Calypso-SystemTools-Core' }
+SycOpenReflectivityMenuCommand class >> methodEditorShortcutActivation [
+	<classAnnotation>
+	
+	^CmdShortcutActivation by: $r meta shift for: ClySourceCodeContext
+]
+
+{ #category : #'*Calypso-SystemTools-Core' }
+SycOpenReflectivityMenuCommand class >> sourceCodeMenuActivation [
+	<classAnnotation>
+	
+	^CmdContextMenuActivation byRootGroupItemOrder: 8 for: ClySourceCodeContext
+]

--- a/src/SystemCommands-SourceCodeCommands/SycOpenReflectivityMenuCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycOpenReflectivityMenuCommand.class.st
@@ -8,13 +8,6 @@ Class {
 	#category : #'SystemCommands-SourceCodeCommands'
 }
 
-{ #category : #activation }
-SycOpenReflectivityMenuCommand class >> sourceCodeMenuActivation [
-	<classAnnotation>
-	
-	^CmdContextMenuActivation byRootGroupItemOrder: 8 for: ClySourceCodeContext
-]
-
 { #category : #execution }
 SycOpenReflectivityMenuCommand >> activationStrategy [
 	^SycReflectivityMenuActivation 


### PR DESCRIPTION
Fixes #10854 by adding a missing #methodEditorShortcutActivation to one of the subclasses
