### PR TITLE
cleanup: rewrite users of leadingChar

### DIFF
--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1497,36 +1497,33 @@ String >> findString: key startingAt: start caseSensitive: caseSensitive [
 
 { #category : #comparing }
 String >> findSubstring: key in: body startingAt: start matchTable: matchTable [
-	"Answer the index in the string body at which the substring key first occurs, at or beyond start.  The match is determined using matchTable, which can be used to effect, eg, case-insensitive matches.  If no match is found, zero will be returned."
-	| index c1 c2 |
-	matchTable == nil ifTrue: [
-		key size = 0 ifTrue: [^ 0].
-		start to: body size - key size + 1 do:
-			[:startIndex |
-			index := 1.
-				[(body at: startIndex+index-1)
-					= (key at: index)]
-					whileTrue:
-					[index = key size ifTrue: [^ startIndex].
-					index := index+1]].
-		^ 0
-	].
 
-	key size = 0 ifTrue: [^ 0].
-	start to: body size - key size + 1 do:
-		[:startIndex |
+	"Answer the index in the string body at which the substring key first occurs, at or beyond start.  The match is determined using matchTable, which can be used to effect, eg, case-insensitive matches.  If no match is found, zero will be returned."
+
+	| index c1 c2 |
+	matchTable == nil ifTrue: [ 
+		key size = 0 ifTrue: [ ^ 0 ].
+		start to: body size - key size + 1 do: [ :startIndex | 
+			index := 1.
+			[ (body at: startIndex + index - 1) = (key at: index) ] whileTrue: [ 
+				index = key size ifTrue: [ ^ startIndex ].
+				index := index + 1 ] ].
+		^ 0 ].
+
+	key size = 0 ifTrue: [ ^ 0 ].
+	start to: body size - key size + 1 do: [ :startIndex | 
 		index := 1.
-		[c1 := body at: startIndex+index-1.
+		[ 
+		c1 := body at: startIndex + index - 1.
 		c2 := key at: index.
-		((c1 leadingChar = 0 and: [ c1 asciiValue < matchTable size ]) 
-			ifTrue: [ matchTable at: c1 asciiValue + 1 ]
-			ifFalse: [ c1 asciiValue + 1 ]) = 
-			((c2 leadingChar = 0 and: [ c2 asciiValue < matchTable size ])
-				ifTrue: [ matchTable at: c2 asciiValue + 1 ]
-				ifFalse: [c2 asciiValue + 1 ]) ]
-			whileTrue:
-				[index = key size ifTrue: [^ startIndex].
-				index := index+1]].
+		(c1 asciiValue < matchTable size
+			 ifTrue: [ matchTable at: c1 asciiValue + 1 ]
+			 ifFalse: [ c1 asciiValue + 1 ])
+		= (c2 asciiValue < matchTable size
+				 ifTrue: [ matchTable at: c2 asciiValue + 1 ]
+				 ifFalse: [ c2 asciiValue + 1 ]) ] whileTrue: [ 
+			index = key size ifTrue: [ ^ startIndex ].
+			index := index + 1 ] ].
 	^ 0
 ]
 

--- a/src/Deprecated10/EncodedCharSet.extension.st
+++ b/src/Deprecated10/EncodedCharSet.extension.st
@@ -3,21 +3,13 @@ Extension { #name : #EncodedCharSet }
 { #category : #'*Deprecated10' }
 EncodedCharSet class >> canBeGlobalVarInitial: char [
 
-	| leadingChar |
 	self deprecated: 'Please use #isValidGlobalName on the name of the variable'.
-	leadingChar := char leadingChar.
-
-	leadingChar = 0 ifTrue: [^ self isUppercase: char].
-	^ self isLetter: char.
+	^ self isUppercase: char
 ]
 
 { #category : #'*Deprecated10' }
 EncodedCharSet class >> canBeNonGlobalVarInitial: char [
 
-	| leadingChar |
 	self deprecated: 'Please use #isValidGlobalName on the name of the variable'.
-	leadingChar := char leadingChar.
-
-	leadingChar = 0 ifTrue: [^ self isLowercase: char].
-	^ self isLetter: char.
+	^ self isLowercase: char
 ]

--- a/src/Deprecated10/GB2312.class.st
+++ b/src/Deprecated10/GB2312.class.st
@@ -58,16 +58,7 @@ GB2312 class >> initializeUcsTable [
 { #category : #'class methods' }
 GB2312 class >> isLetter: char [
 
-	| value leading |
-
-	leading := char leadingChar.
-	value := char charCode.
-
-	leading = 0 ifTrue: [^ super isLetter: char].
-
-	value := value // 94 + 1.
-	^ 1 <= value and: [value < 84].
-
+	^ super isLetter: char
 ]
 
 { #category : #'class methods' }
@@ -80,11 +71,6 @@ GB2312 class >> leadingChar [
 { #category : #'class methods' }
 GB2312 class >> nextPutValue: ascii toStream: aStream withShiftSequenceIfNeededForTextConverterState: state [ 
 	| c1 c2 |
-	state charSize: 2.
-	state g0Leading ~= self leadingChar ifTrue: 
-		[ state g0Leading: self leadingChar.
-		state g0Size: 2.
-		aStream basicNextPutAll: compoundTextSequence ].
 	c1 := ascii // 94 + 33.
 	c2 := ascii \\ 94 + 33.
 	^ aStream

--- a/src/System-Changes/PositionableStream.extension.st
+++ b/src/System-Changes/PositionableStream.extension.st
@@ -39,7 +39,7 @@ PositionableStream >> decodeString: string andRuns: runsRaw [
 	runLength
 		with: runValues
 		do: [ :length :leadingChar | 
-			index to: index + length - 1 do: [ :pos | newString at: pos put: (Character leadingChar: leadingChar code: (string at: pos) charCode) ].
+			index to: index + length - 1 do: [ :pos | newString at: pos put: (string at: pos) ].
 			index := index + length ].
 	^ newString
 ]

--- a/src/System-Sources/ChunkReadStream.class.st
+++ b/src/System-Sources/ChunkReadStream.class.st
@@ -60,7 +60,7 @@ ChunkReadStream >> decodeString: string andRuns: runsRaw [
 	runLength
 		with: runValues
 		do: [ :length :leadingChar | 
-			index to: index + length - 1 do: [ :pos | newString at: pos put: (Character leadingChar: leadingChar code: (string at: pos) charCode) ].
+			index to: index + length - 1 do: [ :pos | newString at: pos put: (string at: pos) ].
 			index := index + length ].
 	^ newString
 ]


### PR DESCRIPTION
Assume all characters return 0: Characters in Pharo are internally unicode code points and the concept of leading char is obsolete and wrong.

Fix part of https://github.com/pharo-project/pharo/pull/10871