### PR TITLE
9963-MCStReadertypeOfSubclass-hard-codes-mcType-and-subclassDefiningSymbol

### DIFF
--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -135,13 +135,10 @@ MCStReader >> systemOrganizationFromRecords: changeRecords [
 
 { #category : #reading }
 MCStReader >> typeOfSubclass: aSymbol [
-	#(
-		(subclass: normal)
-		(named: normal)
-		(variableSubclass: variable)
-		(variableByteSubclass: bytes)
-		(variableWordSubclass: words)
-		(weakSubclass: weak)
-		) do: [:ea | ea first = aSymbol ifTrue: [^ ea second]].
-	self error: 'Unrecognized class definition'
+	| layoutClass |
+	layoutClass := ObjectLayout layoutForSubclassDefiningSymbol: aSymbol.
+	"if we get back CompiledMethodLayout, we put ByteLayout as CompiledMethodLayout.
+	The actual class creation methods have a hack to create the right format in this case"
+	layoutClass = CompiledMethodLayout ifTrue: [ layoutClass := ByteLayout ].
+	^layoutClass mcTypeSymbol
 ]


### PR DESCRIPTION
This PR changes the hard-coded table in #typeOfSubclass: to delegate the class layout.

- this way we support ephemeron, immediate and doubleWord/Byte
- Instead of raising an error, we load FixedLayout by default

Fixes #9963