### PR TITLE
5090-SystemSettingLauncher-should-be-moved-to-System-Settings-Browser

### DIFF
--- a/src/System-Settings-Browser/SystemSettingLauncher.class.st
+++ b/src/System-Settings-Browser/SystemSettingLauncher.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'script'
 	],
-	#category : #'System-Settings-Core-Utilities'
+	#category : #'System-Settings-Browser'
 }
 
 { #category : #accessing }


### PR DESCRIPTION


Fixes #5090