### PR TITLE
Full block cleanup:  #sourceNodeForPC: RBBlockNode

### DIFF
--- a/src/OpalCompiler-Core/RBBlockNode.extension.st
+++ b/src/OpalCompiler-Core/RBBlockNode.extension.st
@@ -60,9 +60,6 @@ RBBlockNode >> owningScope [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-RBBlockNode >> sourceNodeForPC: anInteger [ 
-	self methodNode ir.
-	(self hasProperty: #ir) ifTrue: [ "FullBlockClosure"
-		^ self bcToASTCache nodeForPC: anInteger].
-	^ self methodNode sourceNodeForPC: anInteger
+RBBlockNode >> sourceNodeForPC: anInteger [
+	^ self bcToASTCache nodeForPC: anInteger
 ]

--- a/src/OpalCompiler-Core/RBBlockNode.extension.st
+++ b/src/OpalCompiler-Core/RBBlockNode.extension.st
@@ -7,8 +7,9 @@ RBBlockNode >> bcToASTCache [
 
 { #category : #'*OpalCompiler-Core' }
 RBBlockNode >> ir [
-
-	^ self propertyAt: #ir ifAbsent: [ self parent methodOrBlockNode ir ]
+	"if the ir is not yet set, generate the IR for the whole method, it fills the property here"
+	self propertyAt: #ir ifAbsent: [ self methodNode generateIR  ].
+	^self propertyAt: #ir
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
@@ -101,7 +101,8 @@ OCBytecodeToASTCacheTest >> testNodeForBCOffsetTestFull [
 	blockNode := compiledMethod ast statements last value.
 	pc := 27.
 	mappedNode := (blockNode sourceNodeForPC: pc).
-	expectedNode := blockNode body.
+	"the message node"
+	expectedNode := blockNode body statements first value.
 	self assert: mappedNode sourceCode equals: expectedNode sourceCode.	
 	self assert: mappedNode start equals: expectedNode start.
 	self assert: mappedNode stop equals: expectedNode stop


### PR DESCRIPTION
RBBlockNode #sourceNodeForPC: and #ir had some workaround still to make it work for Embedded Blocks and Fullblocks.

 Every RBBlockNode now has its own debugger map bc-offset to AST, the #ir property is always set.

- RBBlockNode #sourceNodeForPC: can now be simplified and look the  same as RBMethodNode
- Bugfix: when asking the #ir and the property #ir is not set: regenerate via calling it generation on the *method*, but return the ir of the *block*.

In pharo11, we should simplify even more and remove the need for storing the #ir property. 


This is tested via OCBytecodeToASTCacheTest