### PR TITLE
10889-equal-CompiledBlocks-in-the-literal-frame-stored-only-once

### DIFF
--- a/src/Kernel-Tests/BlockClosureTest.class.st
+++ b/src/Kernel-Tests/BlockClosureTest.class.st
@@ -168,6 +168,26 @@ BlockClosureTest >> testIsClean [
 ]
 
 { #category : #tests }
+BlockClosureTest >> testLiteralEqual [
+	"Check that if we have two clean blocks with the same code, they are not #literalEqual:"
+	| methodToTest compiledBlocks |
+	methodToTest := self class compiler 
+		options: #(+ optionCleanBlockClosure);
+		compile: 'twoCleanBlocks
+
+	| value |
+	[3].
+	"just two clean blocks"
+	[3].'.
+	
+	compiledBlocks := methodToTest literals select: [ :each | each isBlock ].
+	self assert: compiledBlocks size equals: 2.
+	self deny: (compiledBlocks first literalEqual: compiledBlocks second).
+	"Clean blocks are not equal as they have a different compiledBlock"
+	self deny: compiledBlocks first equals: compiledBlocks second
+]
+
+{ #category : #tests }
 BlockClosureTest >> testNew [
 	self	should: [Context new: 5] raise: Error.
 	[Context new: 5]

--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -170,6 +170,27 @@ CompiledCodeTest >> testHasSelectorSpecialSelectorIndex [
 ]
 
 { #category : #'tests - literals' }
+CompiledCodeTest >> testLiteralEqual [
+	"Check that if we have two compiledblocks that are equal, there are two in the literals
+	and that they are not #literalEqual:"
+	| methodToTest compiledBlocks |
+	methodToTest := self class compiler compile: 'testWrongHeightlightSingleValue
+
+	| value |
+	value := 0.
+	10 timesRepeat: [self assert: value equals: 0].
+	value := 1.
+	10 timesRepeat: [self assert: value equals: 0].'.
+	
+	compiledBlocks := methodToTest literals select: [ :each | each isCompiledBlock ].
+	self assert: compiledBlocks size equals: 2.
+	self deny: (compiledBlocks first literalEqual: compiledBlocks second).
+	self assert: compiledBlocks first equals: compiledBlocks second.
+	
+	
+]
+
+{ #category : #'tests - literals' }
 CompiledCodeTest >> testLiteralsDoNotConsiderTheInnerBlockLiterals [
 
 	| method block |

--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -185,9 +185,7 @@ CompiledCodeTest >> testLiteralEqual [
 	compiledBlocks := methodToTest literals select: [ :each | each isCompiledBlock ].
 	self assert: compiledBlocks size equals: 2.
 	self deny: (compiledBlocks first literalEqual: compiledBlocks second).
-	self assert: compiledBlocks first equals: compiledBlocks second.
-	
-	
+	self assert: compiledBlocks first equals: compiledBlocks second
 ]
 
 { #category : #'tests - literals' }

--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -92,7 +92,7 @@ CompiledBlock >> isTestMethod [
 
 { #category : #comparing }
 CompiledBlock >> literalEqual: other [
-	"when ther are two blocks with the same code, we want to still have both in the literal array"
+	"when there are two blocks with the same code, we want to still have both in the literal array"
 	^self == other
 ]
 

--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -90,6 +90,12 @@ CompiledBlock >> isTestMethod [
 	^ false
 ]
 
+{ #category : #comparing }
+CompiledBlock >> literalEqual: other [
+	"when ther are two blocks with the same code, we want to still have both in the literal array"
+	^self == other
+]
+
 { #category : #literals }
 CompiledBlock >> literalsToSkip [
 


### PR DESCRIPTION
- add literalEqual: for CompiledBlock
- add test testLiteralEqual

fixes #10889
