### PR TITLE
10860-Debugger-hightlights-the-wrong-line-in-test-for-asserts-inside-two-identical-blocks

### DIFF
--- a/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
+++ b/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
@@ -476,7 +476,7 @@ EncoderForSistaV1 class >> isCreateFullBlock: compiledBlock code: code at: pc [
 	^self extensionsAt: pc in: code into:
 		[:extA :extB :nExtBytes| 
 			(code at: pc + nExtBytes) = 16rF9 and: [ 
-				compiledBlock = (code literalAt: (code at: pc + nExtBytes + 1) + (extA bitShift: 8) + 1)] ]
+				compiledBlock == (code literalAt: (code at: pc + nExtBytes + 1) + (extA bitShift: 8) + 1)] ]
 ]
 
 { #category : #'instruction stream support' }

--- a/src/Kernel-Tests/CompiledBlockTest.class.st
+++ b/src/Kernel-Tests/CompiledBlockTest.class.st
@@ -1,0 +1,42 @@
+Class {
+	#name : #CompiledBlockTest,
+	#superclass : #TestCase,
+	#category : #'Kernel-Tests-Classes'
+}
+
+{ #category : #tests }
+CompiledBlockTest >> testLiteralEqual [
+	"Check that if we have two compiledblocks that are equal, there are two in the literals
+	and that they are not #literalEqual:"
+	| methodToTest compiledBlocks |
+	methodToTest := self class compiler compile: 'testWrongHeightlightSingleValue
+
+	| value |
+	value := 0.
+	10 timesRepeat: [self assert: value equals: 0].
+	value := 1.
+	10 timesRepeat: [self assert: value equals: 0].'.
+	
+	compiledBlocks := methodToTest literals select: [ :each | each isCompiledBlock ].
+	self assert: compiledBlocks size equals: 2.
+	self deny: (compiledBlocks first literalEqual: compiledBlocks second).
+	self assert: compiledBlocks first equals: compiledBlocks second
+]
+
+{ #category : #tests }
+CompiledBlockTest >> testPcInOuter [
+	| methodToTest compiledBlocks |
+	methodToTest := self class compiler compile: 'testWrongHeightlightSingleValue
+
+	| value |
+	value := 0.
+	10 timesRepeat: [self assert: value equals: 0].
+	value := 1.
+	10 timesRepeat: [self assert: value equals: 0].'.
+	
+	compiledBlocks := methodToTest literals select: [ :each | each isCompiledBlock ].
+	self assert: compiledBlocks size equals: 2.
+	"we should find different pcs for the blocks in the outer method"
+	self deny: compiledBlocks first pcInOuter equals: compiledBlocks second pcInOuter
+
+]

--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -170,25 +170,6 @@ CompiledCodeTest >> testHasSelectorSpecialSelectorIndex [
 ]
 
 { #category : #'tests - literals' }
-CompiledCodeTest >> testLiteralEqual [
-	"Check that if we have two compiledblocks that are equal, there are two in the literals
-	and that they are not #literalEqual:"
-	| methodToTest compiledBlocks |
-	methodToTest := self class compiler compile: 'testWrongHeightlightSingleValue
-
-	| value |
-	value := 0.
-	10 timesRepeat: [self assert: value equals: 0].
-	value := 1.
-	10 timesRepeat: [self assert: value equals: 0].'.
-	
-	compiledBlocks := methodToTest literals select: [ :each | each isCompiledBlock ].
-	self assert: compiledBlocks size equals: 2.
-	self deny: (compiledBlocks first literalEqual: compiledBlocks second).
-	self assert: compiledBlocks first equals: compiledBlocks second
-]
-
-{ #category : #'tests - literals' }
 CompiledCodeTest >> testLiteralsDoNotConsiderTheInnerBlockLiterals [
 
 	| method block |


### PR DESCRIPTION
- fix #isCreateFullBlock:code:at: to search for blocks in the literals using #==

- add test #testPcInOuter for CompiledBlock
- move tests to CompiledBlockTest

fixes #10860 