### PR TITLE
CompiledCode-hasTemporaries

### DIFF
--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -169,6 +169,17 @@ CompiledCodeTest >> testHasSelectorSpecialSelectorIndex [
 	self deny: (method hasSelector: #method specialSelectorIndex: specialIndex).
 ]
 
+{ #category : #'tests - testing' }
+CompiledCodeTest >> testHasTemporaries [
+	| method block |
+	method := self class >> #testHasTemporaries.
+	self assert: method hasTemporaries.
+	block := [ | b | b := 2  ].
+	self assert: block method hasTemporaries.
+	block := [  2  ].
+	self deny: block method hasTemporaries
+]
+
 { #category : #'tests - literals' }
 CompiledCodeTest >> testLiteralEqual [
 	"Check that if we have two compiledblocks that are equal, there are two in the literals

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -291,6 +291,12 @@ CompiledCode >> hasSourceCode [
 	^ self subclassResponsibility
 ]
 
+{ #category : #testing }
+CompiledCode >> hasTemporaries [
+	"Fast check that does not scan the bytecode, nor reifies the AST"
+	^ (self numTemps - self numArgs) > 0
+]
+
 { #category : #comparing }
 CompiledCode >> hash [
 	"CompiledMethod>>#= compares code, i.e. same literals and same bytecode.

--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -46,17 +46,13 @@ NoUnusedVariablesLeftTest >> testNoUnusedInstanceVariablesLeft [
 { #category : #testing }
 NoUnusedVariablesLeftTest >> testNoUnusedTemporaryVariablesLeft [
 	"Fail if there are methods who have unused temporary variables"
-	| found validExceptions remaining |
+	| found validExceptions |
 	found := SystemNavigation default allMethodsSelect: [ :m | 
-		((m numTemps - m numArgs) > 0) and: [  
-		m ast temporaries anySatisfy: [ :x | x binding isUsed not] ] ].
+		m hasTemporaries and: [m ast temporaries anySatisfy: [ :x | x binding isUsed not] ] ].
 	
 	"No other exceptions beside the ones mentioned here should be allowed"	
 	validExceptions := { MFClassA>>#method. MFClassB>>#method3. MFClassB>>#method2 . TemporaryVariableTest>>#testIsReferenced }.	
-	
-	remaining := found asOrderedCollection 
-								removeAll: validExceptions;
-								yourself.
+	found removeAll: validExceptions.
 								
-	self assert: remaining isEmpty description: ('the following methods have unused temporary variables and should be cleaned: ', remaining asString)
+	self assert: found isEmpty description: ('the following methods have unused temporary variables and should be cleaned: ', found asString)
 ]


### PR DESCRIPTION
in #testNoUnusedTemporaryVariablesLeft we used a clever trick to check *fast* if a method defines temporary variables.

(without having to scan the bytecode or look at the AST).

This PR makes this available as a method on CompiledCode. The name, even though not perfect, follows the API of the AST,
where we have #hasTemporaries already.

- add CompiledCode #hasTemporaries
- add a test showing that it works on blocks, too
- simplify testNoUnusedTemporaryVariablesLeft