### PR TITLE
Fix Calypso toolbar layout to prevent buttons in browser from hiding

### DIFF
--- a/src/Calypso-Browser/ClyBrowserMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserMorph.class.st
@@ -500,7 +500,7 @@ ClyBrowserMorph >> open [
 	window := self openInWindow.
 	window model: self.
 	self updateWindowTitle.
-	window minimumExtent: 860@500.0 
+	window minimumExtent: 650@500.0
 ]
 
 { #category : #'opening/closing' }

--- a/src/Calypso-Browser/ClyToolbarMorph.class.st
+++ b/src/Calypso-Browser/ClyToolbarMorph.class.st
@@ -36,7 +36,17 @@ ClyToolbarMorph class >> of: aBrowser [
 
 { #category : #accessing }
 ClyToolbarMorph >> addNewItem: aMorph [
-	self addMorphBack: aMorph
+
+	| offsetX offsetY |
+	offsetX := self submorphs
+		           inject: 0
+		           into: [ :sum :each | sum + each extent x ].
+	offsetY := 5.
+	self addMorphBack: aMorph.
+	self computeFullBounds.
+	self minHeight: self defaultHeight.
+	aMorph bounds: (offsetX @ offsetY corner:
+			 aMorph extent x + offsetX @ (aMorph extent y + offsetY))
 ]
 
 { #category : #accessing }
@@ -57,15 +67,16 @@ ClyToolbarMorph >> defaultHeight [
 { #category : #initialization }
 ClyToolbarMorph >> initialize [
 	super initialize.
-	self 
-		color: self theme windowColor;
-		changeTableLayout;
-		height: self defaultHeight;	
-		layoutInset: 2@0; 
-		listDirection: #leftToRight;
-		wrapCentering: #center;
+	"setting layoutPolicy to nil because existing layouts fix my owner's minimum width, hiding other widgets when the windows shrinks"
+	self layoutPolicy: nil.
+	self
+		listDirection: #rightToLeft;
 		hResizing: #spaceFill;
-		vResizing: #rigid
+		vResizing: #shrinkWrap;
+		wrapCentering: #left;
+		color: self defaultColor;
+		extent: 0 @ 0.
+	self layoutChanged
 ]
 
 { #category : #updating }
@@ -77,5 +88,6 @@ ClyToolbarMorph >> updateItems [
 	
 	self hide.
 	self removeAllMorphs.
+	self initialize.
 	[menu buildBrowserToolbar: self] ensure: [self show]
 ]


### PR DESCRIPTION
Handling toolbar layout by hand to prevent buttons in the browser from hiding when windows width is less than toolbar's width.
Fixes #10894 