### PR TITLE
Make the patcher more robust

### DIFF
--- a/src/Monticello/MCPatcher.class.st
+++ b/src/Monticello/MCPatcher.class.st
@@ -35,7 +35,14 @@ MCPatcher >> initializeWithSnapshot: aSnapshot [
 
 { #category : #operations }
 MCPatcher >> modifyDefinition: baseDefinition to: targetDefinition [
-	self addDefinition: targetDefinition
+	
+	"Only modify the definition if present"
+	self definitions
+		definitionLike: baseDefinition
+		ifPresent: [ :found |
+			found = baseDefinition
+				ifTrue: [ self addDefinition: targetDefinition ]]
+		ifAbsent: [ "nothing" ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Make the patcher more robust by not modifying definitions that are not present in a patcher.
Part of https://github.com/pharo-project/pharo/issues/10623.

Integrate before it's iceberg counterpart.