### PR TITLE
FIX issue #10933: Scaled decimals comparison result depends on the number creation method

### DIFF
--- a/src/Kernel-Tests/ScaledDecimalTest.class.st
+++ b/src/Kernel-Tests/ScaledDecimalTest.class.st
@@ -298,6 +298,46 @@ ScaledDecimalTest >> testScaleExtension [
 ]
 
 { #category : #tests }
+ScaledDecimalTest >> testScaledDecimalsEquality [
+
+	
+	self assert: 1.234s2 = 1.23s2. "1.23 = 1.23"
+	
+	self deny: 1.023s3 = 1.23s2. "1.023 != 1.23 "
+	
+	self assert: 1.230s3 = 1.23s2.  " 1.230 = 1.23"
+]
+
+{ #category : #tests }
+ScaledDecimalTest >> testScaledDecimalsInequality [
+
+	
+	self deny: 1.234s2 < 1.23s2. 
+	self assert: 1.023s3 < 1.23s2. 
+	self deny: 1.230s3 < 1.23s2.  
+	self deny: 1.234s2 < 1.111s2.
+	self assert: 1.111s2 < 1.234s2.
+	
+	self deny: 1.234s2 > 1.23s2. 
+	self deny: 1.023s3 > 1.23s2. 
+	self deny: 1.230s3 > 1.23s2.
+	self assert: 1.234s2 > 1.111s2.
+	self deny: 1.111s2 > 1.234s2.
+	
+	self assert: 1.234s2 >= 1.23s2. 
+	self deny: 1.023s3 >= 1.23s2. 
+	self assert: 1.230s3 >= 1.23s2.
+	self assert: 1.234s2 >= 1.111s2.
+	self deny: 1.111s2 >= 1.234s2.
+	
+	self assert: 1.234s2 <= 1.23s2. 
+	self assert: 1.023s3 <= 1.23s2. 
+	self assert: 1.230s3 <= 1.23s2.
+	self deny: 1.234s2 <= 1.111s2.
+	self assert: 1.111s2 <= 1.234s2.
+]
+
+{ #category : #tests }
 ScaledDecimalTest >> testZeroRaisedToInteger [
 	"Zero might be handle specially"
 	

--- a/src/Kernel-Tests/ScaledDecimalTest.class.st
+++ b/src/Kernel-Tests/ScaledDecimalTest.class.st
@@ -287,6 +287,20 @@ ScaledDecimalTest >> testRounded [
 ]
 
 { #category : #tests }
+ScaledDecimalTest >> testScaleDecimalsHash [
+
+	| firstScaleDecimals secondScaleDecimals |
+	firstScaleDecimals := ScaledDecimal new.
+	firstScaleDecimals setNumerator: 8617 denominator: 500 scale: 2.
+
+	secondScaleDecimals := ScaledDecimal new.
+	secondScaleDecimals setNumerator: 2425469874315723 denominator: 140737488355328 scale: 2.
+
+	self assert: firstScaleDecimals equals: secondScaleDecimals.
+	self assert: firstScaleDecimals hash equals: secondScaleDecimals hash
+]
+
+{ #category : #tests }
 ScaledDecimalTest >> testScaleExtension [
 
 	#( #+ #- #/ ) do: [ :op | "The scale is extended to the larger one in case of arithmetic operation"

--- a/src/Kernel-Tests/ScaledDecimalTest.class.st
+++ b/src/Kernel-Tests/ScaledDecimalTest.class.st
@@ -290,6 +290,8 @@ ScaledDecimalTest >> testRounded [
 ScaledDecimalTest >> testScaleDecimalsHash [
 
 	| firstScaleDecimals secondScaleDecimals |
+	"Creating 2 equivalent scaled decimals by hands, the magic literals are just examples taken from the issue"
+	
 	firstScaleDecimals := ScaledDecimal new.
 	firstScaleDecimals setNumerator: 8617 denominator: 500 scale: 2.
 

--- a/src/Kernel-Tests/ScaledDecimalTest.class.st
+++ b/src/Kernel-Tests/ScaledDecimalTest.class.st
@@ -186,14 +186,13 @@ ScaledDecimalTest >> testConvertFromIntegerWithScale [
 { #category : #tests }
 ScaledDecimalTest >> testConvertFromNonDecimalFraction [
 	"Converting a Fraction with asScaledDecimal use default number of decimals when the series of decimals is infinite."
+	
 	| defaultNumberOfDecimals |
 	defaultNumberOfDecimals := (1/3) asScaledDecimal scale.
 	#(6 7 9 11 12 13 14 17 18 19 21 22 23 24) do: [:den |
-		| sd sd2 |
+		| sd |
 		sd := (1/den) asScaledDecimal.
 		self assert: sd scale equals: defaultNumberOfDecimals.
-		sd2 := ScaledDecimal readFrom: sd printString.
-		self deny: sd equals: sd2
 		]
 ]
 

--- a/src/Kernel-Tests/ScaledDecimalTest.class.st
+++ b/src/Kernel-Tests/ScaledDecimalTest.class.st
@@ -317,24 +317,28 @@ ScaledDecimalTest >> testScaledDecimalsInequality [
 	self deny: 1.230s3 < 1.23s2.  
 	self deny: 1.234s2 < 1.111s2.
 	self assert: 1.111s2 < 1.234s2.
+	self deny: 2.111s2 < 1.222s2.
 	
 	self deny: 1.234s2 > 1.23s2. 
 	self deny: 1.023s3 > 1.23s2. 
 	self deny: 1.230s3 > 1.23s2.
 	self assert: 1.234s2 > 1.111s2.
 	self deny: 1.111s2 > 1.234s2.
+	self assert: 2.111s2 > 1.222s2.
 	
 	self assert: 1.234s2 >= 1.23s2. 
 	self deny: 1.023s3 >= 1.23s2. 
 	self assert: 1.230s3 >= 1.23s2.
 	self assert: 1.234s2 >= 1.111s2.
 	self deny: 1.111s2 >= 1.234s2.
+	self assert: 2.111s2 >= 1.222s2.
 	
 	self assert: 1.234s2 <= 1.23s2. 
 	self assert: 1.023s3 <= 1.23s2. 
 	self assert: 1.230s3 <= 1.23s2.
 	self deny: 1.234s2 <= 1.111s2.
 	self assert: 1.111s2 <= 1.234s2.
+	self deny: 2.111s2 <= 1.222s2.
 ]
 
 { #category : #tests }

--- a/src/Kernel/ScaledDecimal.class.st
+++ b/src/Kernel/ScaledDecimal.class.st
@@ -55,9 +55,8 @@ ScaledDecimal >> < aNumber [
 
 	aNumber class = self class ifTrue: [ 
 		aNumber integerPart = self integerPart ifTrue: [ 
-			^ self roundedFractionPart < aNumber roundedFractionPart ] ].
-	aNumber integerPart < self integerPart ifTrue: [ ^ false ].
-	aNumber integerPart > self integerPart ifTrue: [ ^ true ].
+			^ self roundedFractionPart < aNumber roundedFractionPart ].
+		^ self integerPart < aNumber integerPart ].
 
 	^ self asFraction < aNumber
 ]
@@ -68,8 +67,7 @@ ScaledDecimal >> <= aNumber [
 	aNumber class = self class ifTrue: [ 
 		aNumber integerPart = self integerPart ifTrue: [ 
 			^ self roundedFractionPart <= aNumber roundedFractionPart ].
-		aNumber integerPart < self integerPart ifTrue: [ ^ false ].
-		aNumber integerPart > self integerPart ifTrue: [ ^ true ] ].
+		^self integerPart < aNumber integerPart ].
 	^ self asFraction < aNumber
 ]
 
@@ -89,8 +87,8 @@ ScaledDecimal >> > aNumber [
 	aNumber class = self class ifTrue: [ 
 		aNumber integerPart = self integerPart ifTrue: [ 
 			^ self roundedFractionPart > aNumber roundedFractionPart ].
-		self integerPart > aNumber integerPart ifTrue: [ ^ true ].
-		self integerPart < aNumber integerPart ifTrue: [ ^ false ] ].
+		^ self integerPart > aNumber integerPart ].
+	
 	^ self asFraction < aNumber
 ]
 
@@ -100,8 +98,8 @@ ScaledDecimal >> >= aNumber [
 	aNumber class = self class ifTrue: [ 
 		aNumber integerPart = self integerPart ifTrue: [ 
 			^ self roundedFractionPart >= aNumber roundedFractionPart ].
-		self integerPart > aNumber integerPart ifTrue: [ ^ true ].
-		self integerPart < aNumber integerPart ifTrue: [ ^ false ] ].
+		^self integerPart > aNumber integerPart ].
+	
 	^ self asFraction < aNumber
 ]
 

--- a/src/Kernel/ScaledDecimal.class.st
+++ b/src/Kernel/ScaledDecimal.class.st
@@ -52,32 +52,50 @@ ScaledDecimal >> / aNumber [
 
 { #category : #comparing }
 ScaledDecimal >> < aNumber [
-	aNumber class = self class ifTrue: [^self asFraction < aNumber asFraction].
-	^self asFraction < aNumber
+
+	aNumber class = self class ifTrue: [ 
+		aNumber integerPart = self integerPart
+			ifTrue: [ ^ self roundedFractionPart < aNumber roundedFractionPart ]
+			ifFalse: [ ^ false ] ].
+	^ self asFraction < aNumber
 ]
 
 { #category : #comparing }
 ScaledDecimal >> <= aNumber [
-	aNumber class = self class ifTrue: [^self asFraction <= aNumber asFraction].
-	^self asFraction <= aNumber
+		aNumber class = self class ifTrue: [ 
+		aNumber integerPart = self integerPart
+			ifTrue: [ ^ self roundedFractionPart <= aNumber roundedFractionPart ]
+			ifFalse: [ ^ false ] ].
+	^ self asFraction < aNumber
 ]
 
 { #category : #comparing }
 ScaledDecimal >> = aNumber [
-	aNumber class = self class ifTrue: [^self asFraction = aNumber asFraction].
-	^self asFraction = aNumber
+
+	aNumber class = self class ifTrue: [ 
+		aNumber integerPart = self integerPart ifTrue: [ 
+			^ aNumber roundedFractionPart = self roundedFractionPart ]
+		ifFalse: [ ^false ] ].
+	^ self asFraction = aNumber
 ]
 
 { #category : #comparing }
 ScaledDecimal >> > aNumber [
-	aNumber class = self class ifTrue: [^self asFraction > aNumber asFraction].
-	^self asFraction > aNumber
+
+	aNumber class = self class ifTrue: [ 
+		aNumber integerPart = self integerPart
+			ifTrue: [ ^ self roundedFractionPart > aNumber roundedFractionPart ]
+			ifFalse: [ ^ false ] ].
+	^ self asFraction < aNumber
 ]
 
 { #category : #comparing }
 ScaledDecimal >> >= aNumber [
-	aNumber class = self class ifTrue: [^self asFraction >= aNumber asFraction].
-	^self asFraction >= aNumber
+		aNumber class = self class ifTrue: [ 
+		aNumber integerPart = self integerPart
+			ifTrue: [ ^ self roundedFractionPart >= aNumber roundedFractionPart ]
+			ifFalse: [ ^ false ] ].
+	^ self asFraction < aNumber
 ]
 
 { #category : #converting }

--- a/src/Kernel/ScaledDecimal.class.st
+++ b/src/Kernel/ScaledDecimal.class.st
@@ -138,6 +138,12 @@ ScaledDecimal >> coerce: aNumber [
 	^aNumber
 ]
 
+{ #category : #comparing }
+ScaledDecimal >> hash [
+
+	^self integerPart hash bitXor: self roundedFractionPart hash
+]
+
 { #category : #testing }
 ScaledDecimal >> isFraction [
 	"Though kind of Fraction, pretend we are not a Fraction to let coercion works correctly"

--- a/src/Kernel/ScaledDecimal.class.st
+++ b/src/Kernel/ScaledDecimal.class.st
@@ -68,7 +68,8 @@ ScaledDecimal >> <= aNumber [
 		aNumber integerPart = self integerPart ifTrue: [ 
 			^ self roundedFractionPart <= aNumber roundedFractionPart ].
 		^self integerPart < aNumber integerPart ].
-	^ self asFraction < aNumber
+	
+	^ self asFraction <= aNumber
 ]
 
 { #category : #comparing }
@@ -89,7 +90,7 @@ ScaledDecimal >> > aNumber [
 			^ self roundedFractionPart > aNumber roundedFractionPart ].
 		^ self integerPart > aNumber integerPart ].
 	
-	^ self asFraction < aNumber
+	^ self asFraction > aNumber
 ]
 
 { #category : #comparing }
@@ -100,7 +101,7 @@ ScaledDecimal >> >= aNumber [
 			^ self roundedFractionPart >= aNumber roundedFractionPart ].
 		^self integerPart > aNumber integerPart ].
 	
-	^ self asFraction < aNumber
+	^ self asFraction >= aNumber
 ]
 
 { #category : #converting }

--- a/src/Kernel/ScaledDecimal.class.st
+++ b/src/Kernel/ScaledDecimal.class.st
@@ -54,11 +54,11 @@ ScaledDecimal >> / aNumber [
 ScaledDecimal >> < aNumber [
 
 	aNumber class = self class ifTrue: [ 
-		aNumber integerPart < self integerPart ifTrue:[^true].
-		aNumber integerPart > self integerPart ifTrue:[^false].
-		aNumber integerPart = self integerPart 	
-			ifTrue: [ ^ self roundedFractionPart < aNumber roundedFractionPart ]
-			 ].
+		aNumber integerPart = self integerPart ifTrue: [ 
+			^ self roundedFractionPart < aNumber roundedFractionPart ] ].
+	aNumber integerPart < self integerPart ifTrue: [ ^ false ].
+	aNumber integerPart > self integerPart ifTrue: [ ^ true ].
+
 	^ self asFraction < aNumber
 ]
 
@@ -66,10 +66,10 @@ ScaledDecimal >> < aNumber [
 ScaledDecimal >> <= aNumber [
 
 	aNumber class = self class ifTrue: [ 
-		aNumber integerPart < self integerPart ifTrue: [ ^ true ].
-		aNumber integerPart > self integerPart ifTrue: [ ^ false ].
 		aNumber integerPart = self integerPart ifTrue: [ 
-			^ self roundedFractionPart <= aNumber roundedFractionPart ] ].
+			^ self roundedFractionPart <= aNumber roundedFractionPart ].
+		aNumber integerPart < self integerPart ifTrue: [ ^ false ].
+		aNumber integerPart > self integerPart ifTrue: [ ^ true ] ].
 	^ self asFraction < aNumber
 ]
 
@@ -87,11 +87,10 @@ ScaledDecimal >> = aNumber [
 ScaledDecimal >> > aNumber [
 
 	aNumber class = self class ifTrue: [ 
-		aNumber integerPart < self integerPart ifTrue: [ ^ true ].
-		aNumber integerPart > self integerPart ifTrue: [ ^ false ].
-		aNumber integerPart = self integerPart
-			ifTrue: [ ^ self roundedFractionPart > aNumber roundedFractionPart ]
-		 ].
+		aNumber integerPart = self integerPart ifTrue: [ 
+			^ self roundedFractionPart > aNumber roundedFractionPart ].
+		self integerPart > aNumber integerPart ifTrue: [ ^ true ].
+		self integerPart < aNumber integerPart ifTrue: [ ^ false ] ].
 	^ self asFraction < aNumber
 ]
 
@@ -99,10 +98,10 @@ ScaledDecimal >> > aNumber [
 ScaledDecimal >> >= aNumber [
 
 	aNumber class = self class ifTrue: [ 
-		aNumber integerPart < self integerPart ifTrue: [ ^ true ].
-		aNumber integerPart > self integerPart ifTrue: [ ^ false ].
 		aNumber integerPart = self integerPart ifTrue: [ 
-			^ self roundedFractionPart >= aNumber roundedFractionPart ] ].
+			^ self roundedFractionPart >= aNumber roundedFractionPart ].
+		self integerPart > aNumber integerPart ifTrue: [ ^ true ].
+		self integerPart < aNumber integerPart ifTrue: [ ^ false ] ].
 	^ self asFraction < aNumber
 ]
 

--- a/src/Kernel/ScaledDecimal.class.st
+++ b/src/Kernel/ScaledDecimal.class.st
@@ -54,18 +54,22 @@ ScaledDecimal >> / aNumber [
 ScaledDecimal >> < aNumber [
 
 	aNumber class = self class ifTrue: [ 
-		aNumber integerPart = self integerPart
+		aNumber integerPart < self integerPart ifTrue:[^true].
+		aNumber integerPart > self integerPart ifTrue:[^false].
+		aNumber integerPart = self integerPart 	
 			ifTrue: [ ^ self roundedFractionPart < aNumber roundedFractionPart ]
-			ifFalse: [ ^ false ] ].
+			 ].
 	^ self asFraction < aNumber
 ]
 
 { #category : #comparing }
 ScaledDecimal >> <= aNumber [
-		aNumber class = self class ifTrue: [ 
-		aNumber integerPart = self integerPart
-			ifTrue: [ ^ self roundedFractionPart <= aNumber roundedFractionPart ]
-			ifFalse: [ ^ false ] ].
+
+	aNumber class = self class ifTrue: [ 
+		aNumber integerPart < self integerPart ifTrue: [ ^ true ].
+		aNumber integerPart > self integerPart ifTrue: [ ^ false ].
+		aNumber integerPart = self integerPart ifTrue: [ 
+			^ self roundedFractionPart <= aNumber roundedFractionPart ] ].
 	^ self asFraction < aNumber
 ]
 
@@ -83,18 +87,22 @@ ScaledDecimal >> = aNumber [
 ScaledDecimal >> > aNumber [
 
 	aNumber class = self class ifTrue: [ 
+		aNumber integerPart < self integerPart ifTrue: [ ^ true ].
+		aNumber integerPart > self integerPart ifTrue: [ ^ false ].
 		aNumber integerPart = self integerPart
 			ifTrue: [ ^ self roundedFractionPart > aNumber roundedFractionPart ]
-			ifFalse: [ ^ false ] ].
+		 ].
 	^ self asFraction < aNumber
 ]
 
 { #category : #comparing }
 ScaledDecimal >> >= aNumber [
-		aNumber class = self class ifTrue: [ 
-		aNumber integerPart = self integerPart
-			ifTrue: [ ^ self roundedFractionPart >= aNumber roundedFractionPart ]
-			ifFalse: [ ^ false ] ].
+
+	aNumber class = self class ifTrue: [ 
+		aNumber integerPart < self integerPart ifTrue: [ ^ true ].
+		aNumber integerPart > self integerPart ifTrue: [ ^ false ].
+		aNumber integerPart = self integerPart ifTrue: [ 
+			^ self roundedFractionPart >= aNumber roundedFractionPart ] ].
 	^ self asFraction < aNumber
 ]
 

--- a/src/Kernel/ScaledDecimal.class.st
+++ b/src/Kernel/ScaledDecimal.class.st
@@ -215,6 +215,21 @@ ScaledDecimal >> reciprocal [
 ]
 
 { #category : #accessing }
+ScaledDecimal >> roundedFractionPart [
+
+	| scaling integerPart roundedFractionPart |
+	scaling:= 10 raisedToInteger: scale.
+			integerPart := numerator abs quo: denominator.
+			roundedFractionPart := (numerator abs - (integerPart * denominator)) * scaling * 2 + denominator quo: denominator * 2.
+			roundedFractionPart = scaling
+				ifTrue:
+					[integerPart := integerPart + 1.
+					roundedFractionPart := 0].
+	
+			^roundedFractionPart/scaling
+]
+
+{ #category : #accessing }
 ScaledDecimal >> scale [
 	^scale
 ]


### PR DESCRIPTION
AS title says 'fix issue #10933'.
Added tests for equality and inequality fro scaled decimals.
Fix by comparing integer part then rounded part of the fraction.
Added rounded part calculation.