### PR TITLE
10667-Installed-breakpoints-not-shown-in-UI-after-AST-cache-reset-during-image-saving 

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -70,7 +70,8 @@ ClyMethodCodeEditorToolMorph >> attachToSystem [
 	browser system 
 		when: (ClyMethodChange of: self editingMethod)
 		send: #triggerUpdate
-		to: self
+		to: self.
+	SystemAnnouncer uniqueInstance when: ASTCacheReset send: #resetASTCache to: self
 ]
 
 { #category : #testing }
@@ -258,6 +259,12 @@ ClyMethodCodeEditorToolMorph >> modifiesExtension [
 { #category : #printing }
 ClyMethodCodeEditorToolMorph >> printContext [
 	^self editingMethod printSystemPath
+]
+
+{ #category : #initialization }
+ClyMethodCodeEditorToolMorph >> resetASTCache [
+	"when the AST cache is cleared, we have to rescue the AST we are looking at"
+	ASTCache default at: ast compiledMethod ifAbsentPut: ast
 ]
 
 { #category : #'selecting text' }

--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -71,7 +71,7 @@ ClyMethodCodeEditorToolMorph >> attachToSystem [
 		when: (ClyMethodChange of: self editingMethod)
 		send: #triggerUpdate
 		to: self.
-	SystemAnnouncer uniqueInstance when: ASTCacheReset send: #resetASTCache to: self
+	SystemAnnouncer uniqueInstance weak when: ASTCacheReset send: #resetASTCache to: self
 ]
 
 { #category : #testing }


### PR DESCRIPTION
fixes #10667