### PR TITLE
AllProtocol should not initialize unused ivar

### DIFF
--- a/src/Kernel/AllProtocol.class.st
+++ b/src/Kernel/AllProtocol.class.st
@@ -34,6 +34,12 @@ AllProtocol >> canBeRenamed [
 	^ false
 ]
 
+{ #category : #initialization }
+AllProtocol >> initialize [
+	"overridden to not itialize unsused methodSelectors, more cleanup needed"
+	name := self class defaultName.
+]
+
 { #category : #testing }
 AllProtocol >> isVirtualProtocol [ 
 	^ true


### PR DESCRIPTION
AllProtocol has to be refactored (see https://github.com/pharo-project/pharo/issues/10963). This should not be done in Pharo10.

This is a minimal change that we could do in Pharo10 to avoid allocating 20.000 unused empty IdentitiSets, which already would save some memory.


