### PR TITLE
Renamed protocol name from `accesing` to `accessing`

### DIFF
--- a/src/Zinc-HTTP-Examples/ZnStaticFileDecoratorDelegate.class.st
+++ b/src/Zinc-HTTP-Examples/ZnStaticFileDecoratorDelegate.class.st
@@ -44,7 +44,7 @@ ZnStaticFileDecoratorDelegate >> handleRequest: znRequest [
 	^ delegate handleRequest: znRequest
 ]
 
-{ #category : #accesing }
+{ #category : #accessing }
 ZnStaticFileDecoratorDelegate >> path: aString [ 
 	staticDelegate := ZnStaticFileServerDelegate new
 		directory: aString asFileReference 


### PR DESCRIPTION
Fixed typo in the protocol name of the method `ZnStaticFileDecoratorDelegate >> path:`.

Renamed from "accesing" to "accessing"