### PR TITLE
Macro expand expects a string and not a smallInteger (fixes  #10859: Removing a game controler opens a debugger in Pharo)

### DIFF
--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -74,14 +74,14 @@ OSSDL2Driver >> closeRemovedController: index [
 	"TODO: What should I do here?"
 
 	self
-		traceCr: ('Game controller <1s> removed' expandMacrosWith: index)
+		traceCr: ('Game controller <1s> removed' expandMacrosWith: index asString)
 ]
 
 { #category : #private }
 OSSDL2Driver >> closeRemovedJoystick: index [
 	"TODO: What should I do here?"
 
-	self traceCr: ('Joystick <1s> removed' expandMacrosWith: index)
+	self traceCr: ('Joystick <1s> removed' expandMacrosWith: index asString)
 ]
 
 { #category : #'window creation and deletion' }


### PR DESCRIPTION
Fix issue #10859.
A smallinteger was pass as argument instead of a string.