### PR TITLE
10935-senders-of-in-playground-shows-senders-of-noMethod

### DIFF
--- a/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
+++ b/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
@@ -83,8 +83,9 @@ CNSelectorExtractor >> extractSelectorFromNode: aNode [
 	
 	"In the case of doIt methods"
 	(node selector = #noMethod and: [ aNode isVariable ])
-		ifTrue: [  ^ aNode name ].
-
+		ifTrue: [  ^ aNode name ].		
+	(node selector = #noMethod and: [ aNode isParseError ])
+		ifTrue: [ ^ aNode value asSymbol ifEmpty: [ nil ] ].
 
 	^ node selector
 ]


### PR DESCRIPTION
add another check for the DoIt case,  besides variables, add some simple fallback for error nodes.

This makes the common case work that you have a selector in the playground like "to:do:" and do "senders of" for it.

A test would be nice, the existing case for the variable is not tested, either

fixes #10935