### PR TITLE
8082-Code-import-does-not-with-fluid-class-definition 

### DIFF
--- a/src/CodeExport/ClassDescription.extension.st
+++ b/src/CodeExport/ClassDescription.extension.st
@@ -72,7 +72,7 @@ ClassDescription >> fileOutOn: aFileStream [
 	"File a description of the receiver on aFileStream."
 	
 	"we for now file out old style class definitions"
-	aFileStream nextChunkPut: self oldDefinition.
+	aFileStream nextChunkPut: self oldPharoDefinition.
 	self organization putCommentOnFile: aFileStream forClass: self.
 	self organization categories 
 		do: [ :heading | self fileOutLocalMethodsInCategory: heading on: aFileStream ]

--- a/src/CodeExport/ClassDescription.extension.st
+++ b/src/CodeExport/ClassDescription.extension.st
@@ -70,8 +70,9 @@ ClassDescription >> fileOutMethod: selector on: aStream [
 { #category : #'*CodeExport' }
 ClassDescription >> fileOutOn: aFileStream [
 	"File a description of the receiver on aFileStream."
-
-	aFileStream nextChunkPut: self definitionString.
+	
+	"we for now file out old style class definitions"
+	aFileStream nextChunkPut: self oldDefinition.
 	self organization putCommentOnFile: aFileStream forClass: self.
 	self organization categories 
 		do: [ :heading | self fileOutLocalMethodsInCategory: heading on: aFileStream ]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -944,6 +944,14 @@ ClassDescription >> oldDefinition [
 		definitionString
 ]
 
+{ #category : #'file in/out' }
+ClassDescription >> oldPharoDefinition [
+	
+	^ ClassDefinitionPrinter oldPharo
+		for: self;
+		definitionString
+]
+
 { #category : #organization }
 ClassDescription >> organization [
 	"Answer the instance of ClassOrganizer that represents the organization 


### PR DESCRIPTION
This PR fixes #8082 by not writing fluid class definitions when filing out code.