### PR TITLE
Expand the class comment for Bag

### DIFF
--- a/src/Collections-Unordered/Bag.class.st
+++ b/src/Collections-Unordered/Bag.class.st
@@ -2,6 +2,39 @@
 I represent an unordered collection of possibly duplicate elements.
 	
 I store these elements in a dictionary, tallying up occurrences of equal objects. Because I store an occurrence only once, my clients should beware that objects they store will not necessarily be retrieved such that == is true. If the client cares, a subclass of me should be created.
+
+## Creating 
+Bags can be created from other collections or built up progressively using the `Bag>>#add:` message. The example below shows four different ways to create a `Bag` with 3 occurrences of 1.
+```
+b := #(1 1 1) asBag.
+""or""
+b:= Bag newFrom: #(1 1 1).
+""or""
+b := Bag new add: 1; add: 1; add: 1.
+""or"" 
+b add: 1 withOccurrences: 3.
+
+b valuesAndCounts.  ""Dictionary(1->3)""
+```
+
+## Enumerating
+
+It is possible to iterate over each individual occurrance of an object using the `Bag>>#do:` message, or pairs of objects and their occurances using `Bag>>#doWithOccurrences:` or the synonymous messages `Bag>>#associationsDo:` and `Bag>>#keysAndValuesDo:`.
+
+```
+b := #(1 1 1 1) asBag.
+b do: [:obj | obj].  ""will be 1. 1. 1. 1."" 
+b doWithOccurences: [:obj :count | ...].  ""will be 1->4""
+```
+
+## Accessing 
+As well as enumerating the contents it is possible to get a dictionary of all object counts using the `Bag>>#valuesAndCounts` message or get the counts of a single object using `Bag>>#occurrencesOf:`.
+
+```
+b := #(1 1 1 2 2 3) asBag.
+b valuesAndCounts.  ""Dictionary(1->3 2->2 3->1)""
+b occurrencesOf: 1  ""3""
+```
 "
 Class {
 	#name : #Bag,
@@ -104,7 +137,11 @@ Bag >> cumulativeCounts [
 
 { #category : #enumerating }
 Bag >> do: aBlock [ 
-	"Evaluate aBlock with each of the receiver's elements as the argument."
+	"Evaluate aBlock with each of the receiver's elements as the argument.
+	
+	This will print all of the occurrences of the value. Use doWithOccurrences: 
+	to gets pairs of values and their count.
+	"
 
 	contents associationsDo: [:assoc | assoc value timesRepeat: [aBlock value: assoc key]]
 ]

--- a/src/Collections-Unordered/Bag.class.st
+++ b/src/Collections-Unordered/Bag.class.st
@@ -23,8 +23,15 @@ It is possible to iterate over each individual occurrance of an object using the
 
 ```
 b := #(1 1 1 1) asBag.
-b do: [:obj | obj].  ""will be 1. 1. 1. 1."" 
-b doWithOccurences: [:obj :count | ...].  ""will be 1->4""
+
+""The block will receive each occurrence. obj = 1 and there will be 4 iterations""
+|counter|
+counter := 0
+b do: [:obj | counter := counter + 1].
+counter = 4  
+
+""The block will receive the obj and it's count. obj = 1 count = 4""
+b doWithOccurences: [:obj :count | ...].
 ```
 
 ## Accessing 
@@ -139,8 +146,8 @@ Bag >> cumulativeCounts [
 Bag >> do: aBlock [ 
 	"Evaluate aBlock with each of the receiver's elements as the argument.
 	
-	This will print all of the occurrences of the value. Use doWithOccurrences: 
-	to gets pairs of values and their count.
+	This will enumerate all of the occurrences of the object. Use doWithOccurrences: 
+	to gets pairs of objects and their count.
 	"
 
 	contents associationsDo: [:assoc | assoc value timesRepeat: [aBlock value: assoc key]]


### PR DESCRIPTION
- give some examples of constructing, enumerating, and accessing for Bag objects
- clarify that the `do:` message will return all occurrences of a stored object