### PR TITLE
SycOpenReflectivityMenuCommand-remove-shortcut

### DIFF
--- a/src/Calypso-SystemTools-Core/SycOpenReflectivityMenuCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycOpenReflectivityMenuCommand.extension.st
@@ -1,13 +1,6 @@
 Extension { #name : #SycOpenReflectivityMenuCommand }
 
 { #category : #'*Calypso-SystemTools-Core' }
-SycOpenReflectivityMenuCommand class >> methodEditorShortcutActivation [
-	<classAnnotation>
-	
-	^CmdShortcutActivation by: $r meta shift for: ClySourceCodeContext
-]
-
-{ #category : #'*Calypso-SystemTools-Core' }
 SycOpenReflectivityMenuCommand class >> sourceCodeMenuActivation [
 	<classAnnotation>
 	


### PR DESCRIPTION
This OR removes the shortcut from SycOpenReflectivityMenuCommand which is overlapping

(trying to see if this is fix for https://github.com/pharo-project/pharo/issues/10984 )