### PR TITLE
10991-AbstractBinaryFileStream-has-no-write-equivalent-to-readIntostartingAtcount

### DIFF
--- a/src/Files-Tests/BinaryFileStreamTest.class.st
+++ b/src/Files-Tests/BinaryFileStreamTest.class.st
@@ -170,6 +170,19 @@ BinaryFileStreamTest >> testSkipLecture [
 ]
 
 { #category : #testing }
+BinaryFileStreamTest >> testWriteFromStartingAtCount [
+	
+	| file |
+	file := self fileStreamForFileNamed: 'testFile'.
+	file writeFrom: #[1 2 3] startingAt: 2 count: 2.
+	file close.
+
+	file := self fileStreamForFileNamed: 'testFile'.
+	self assert: file next equals: 2.
+	self assert: file next equals: 3.
+]
+
+{ #category : #testing }
 BinaryFileStreamTest >> testWriteMultipleBytes [
 	
 	| file |

--- a/src/Files/AbstractBinaryFileStream.class.st
+++ b/src/Files/AbstractBinaryFileStream.class.st
@@ -353,3 +353,13 @@ AbstractBinaryFileStream >> waitForData [
 	File primitiveWaitForDataOn: handle signalling: semaphoreIndex.
 	semaphore wait.
 ]
+
+{ #category : #writing }
+AbstractBinaryFileStream >> writeFrom: writeBuffer startingAt: aNumber count: length [
+
+	^ File 
+		write: handle 
+		from: writeBuffer 
+		startingAt: aNumber 
+		count: length
+]


### PR DESCRIPTION
- add writeFrom: startingAt: count:
- add testWriteFromStartingAtCount

fixes #10991