### PR TITLE
Change UserInterrupt detection to use character codes rather than sca…

### DIFF
--- a/src/OSWindow-SDL2/SDL_KeyDownEvent.class.st
+++ b/src/OSWindow-SDL2/SDL_KeyDownEvent.class.st
@@ -28,7 +28,7 @@ SDL_KeyDownEvent >> isUserInterrupt [
 
 	^ ((self keysym mod bitAnd: 16r200) = 0) "ignore all if AltGr is pressed" 
 		and: [(self keysym mod anyMask: 1344) "This mask is for meta/cmd"
-			and: [ self keysym scancode = SDL_SCANCODE_PERIOD ] ] "This is the dot scancode"
+			and: [ self keysym sym = $. asInteger ] ]
 ]
 
 { #category : #testing }
@@ -36,7 +36,7 @@ SDL_KeyDownEvent >> isUserInterruptKillAll [
 
 	^ ((self keysym mod bitAnd: 16r200) = 0) "ignore all if AltGr is pressed" 
 		and: [(self keysym mod anyMask: 1344) 
-			and: [ self keysym scancode = SDL_SCANCODE_COMMA ] ]
+			and: [ self keysym sym = $, asInteger ] ]
 ]
 
 { #category : #'accessing - structure variables' }


### PR DESCRIPTION
…ncodes

Direct reference to key scancodes is discouraged because it bypasses O/S translation, nixing regional & language settings and also risks defeating accessibility settings possibly other nice things like kb macros.