### PR TITLE
ClassDefinitionPrinter-Comments

### DIFF
--- a/src/Kernel/ClassDefinitionPrinter.class.st
+++ b/src/Kernel/ClassDefinitionPrinter.class.st
@@ -101,7 +101,8 @@ ClassDefinitionPrinter class >> for: aClass [
 
 { #category : #testing }
 ClassDefinitionPrinter class >> isAbstract [
-	^true
+		
+	^ self == ClassDefinitionPrinter
 ]
 
 { #category : #'instance creation' }

--- a/src/Kernel/ClassDefinitionPrinter.class.st
+++ b/src/Kernel/ClassDefinitionPrinter.class.st
@@ -99,6 +99,11 @@ ClassDefinitionPrinter class >> for: aClass [
 		yourself
 ]
 
+{ #category : #testing }
+ClassDefinitionPrinter class >> isAbstract [
+	^true
+]
+
 { #category : #'instance creation' }
 ClassDefinitionPrinter class >> legacy [
 	^ LegacyClassDefinitionPrinter basicNew initialize
@@ -170,6 +175,16 @@ ClassDefinitionPrinter class >> toggleShowFluidClassDefinition [
 	self showFluidClassDefinition: self showFluidClassDefinition not
 ]
 
+{ #category : #'public api' }
+ClassDefinitionPrinter >> classDefinitionString [
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+ClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName [ 
+	^ self subclassResponsibility
+]
+
 { #category : #printing }
 ClassDefinitionPrinter >> definitionString [
 	"The method is part of the double dispatch. It is an extra starting point. 
@@ -191,4 +206,24 @@ ClassDefinitionPrinter >> expandedDefinitionString [
 { #category : #accessing }
 ClassDefinitionPrinter >> for: aClass [ 
 	forClass := aClass
+]
+
+{ #category : #'public api' }
+ClassDefinitionPrinter >> metaclassDefinitionString [
+	^ self subclassResponsibility
+]
+
+{ #category : #template }
+ClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aString [ 
+	^ self subclassResponsibility
+]
+
+{ #category : #'public api' }
+ClassDefinitionPrinter >> traitDefinitionString [
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+ClassDefinitionPrinter >> traitedMetaclassDefinitionString [
+	^ self subclassResponsibility
 ]

--- a/src/Kernel/FluidClassDefinitionPrinter.class.st
+++ b/src/Kernel/FluidClassDefinitionPrinter.class.st
@@ -121,29 +121,35 @@ FluidClassDefinitionPrinter >> compactTraitDefinitionTemplateInPackage: aPackage
 { #category : #'expanded double dispatch API' }
 FluidClassDefinitionPrinter >> expandedDefinitionString [
 
-	^ String streamContents: [ :s | 
-		"in case of ProtoObject"
-		forClass superclass isNil 
-			ifTrue: [ s nextPutAll: 'nil' ]
-			ifFalse: [ s nextPutAll: forClass superclass name ].
-		self msgAndClassNameOn: s.
-		self layoutOn: s.
-		s crtab.
-		s nextPutAll: 'traits: '.
-		forClass hasTraitComposition
-			ifTrue: [ s nextPutAll: '{'; nextPutAll: forClass traitCompositionString; nextPutAll: '};' ]
-			ifFalse: [ s nextPutAll: '{};' ].
-		self slotsOn: s.
-		self sharedVariablesOn: s.
-		self sharedPoolsOn: s.
-		
-		(forClass package classTagForClass: forClass) ifNotNil: [ :t |
-			| tag | 
-			tag := t name.
-			tag = forClass package name 
-				ifTrue: [ s crtab; nextPutAll: 'tag: '''';' ]
-				ifFalse: [ self tagOn: s]].
-			self packageOn: s ]
+	^ String streamContents: [ :s | "in case of ProtoObject"
+		  forClass superclass
+			  ifNil: [ s nextPutAll: 'nil' ]
+			  ifNotNil: [ s nextPutAll: forClass superclass name ].
+		  self msgAndClassNameOn: s.
+		  self layoutOn: s.
+		  s crtab.
+		  s nextPutAll: 'traits: '.
+		  forClass hasTraitComposition
+			  ifTrue: [ 
+				  s
+					  nextPutAll: '{';
+					  nextPutAll: forClass traitCompositionString;
+					  nextPutAll: '};' ]
+			  ifFalse: [ s nextPutAll: '{};' ].
+		  self slotsOn: s.
+		  self sharedVariablesOn: s.
+		  self sharedPoolsOn: s.
+
+		  (forClass package classTagForClass: forClass) ifNotNil: [ :t | 
+			  | tag |
+			  tag := t name.
+			  tag = forClass package name
+				  ifTrue: [ 
+					  s
+						  crtab;
+						  nextPutAll: 'tag: '''';' ]
+				  ifFalse: [ self tagOn: s ] ].
+		  self packageOn: s ]
 ]
 
 { #category : #'expanded double dispatch API' }

--- a/src/Kernel/LegacyClassDefinitionPrinter.class.st
+++ b/src/Kernel/LegacyClassDefinitionPrinter.class.st
@@ -1,3 +1,10 @@
+"
+This is a printer that generates the ST80 class defintion syntax (that is, including pool defintion and category:).
+
+The reason we still need this is that there are still parts of the system that use this in Monticello and the Refactoring engine.
+
+When the last users have been fixed, we can remove this class
+"
 Class {
 	#name : #LegacyClassDefinitionPrinter,
 	#superclass : #ClassDefinitionPrinter,

--- a/src/Kernel/OldPharoClassDefinitionPrinter.class.st
+++ b/src/Kernel/OldPharoClassDefinitionPrinter.class.st
@@ -1,3 +1,9 @@
+"
+This prints the class definition as it was till Pharo9: ST80 style, but with extensions/changes:
+- package: instead of category:
+- if no pool is imported, the pool import is not printed
+- support for traits
+"
 Class {
 	#name : #OldPharoClassDefinitionPrinter,
 	#superclass : #ClassDefinitionPrinter,


### PR DESCRIPTION
- add Class Comments to LegacyClassDefinitionPrinter OldPharoClassDefinitionPrinter

- unify categories a bit
- add #isAbstract
- add subclass responsibility methods
-  a isNil refactoring