### PR TITLE
Making inline refactoring's confirmation message more clear

### DIFF
--- a/src/NautilusRefactoring/NautilusRefactoring.class.st
+++ b/src/NautilusRefactoring/NautilusRefactoring.class.st
@@ -154,7 +154,10 @@ NautilusRefactoring >> shouldExtractAssignmentTo: aString [
 
 { #category : #option }
 NautilusRefactoring >> shouldInlineExpression: aString [
-	^ self confirm: ('Do you want to inline the expression ''<1s>'' in the current method?' expandMacrosWith: aString)
+
+	^ (self confirm:
+		   ('Do you want to extract the expression ''<1s>'' into a variable in the current method?' 
+			    expandMacrosWith: aString)) not
 ]
 
 { #category : #option }

--- a/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
@@ -420,6 +420,11 @@ RBInlineMethodRefactoring >> rewriteInlinedTree [
 				addSelfReturn]
 ]
 
+{ #category : #accessing }
+RBInlineMethodRefactoring >> sourceSelector [
+	^ sourceSelector
+]
+
 { #category : #printing }
 RBInlineMethodRefactoring >> storeOn: aStream [ 
 	aStream nextPut: $(.

--- a/src/SystemCommands-MessageCommands/SycInlineAllSendersMessageCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycInlineAllSendersMessageCommand.class.st
@@ -27,8 +27,7 @@ SycInlineAllSendersMessageCommand >> createRefactoring [
 		sendersOf: originalMessage selector 
 		in: methodOrigin.
 	refactoring setOption: #inlineExpression toUse: [ :ref :aString | 
-		(self confirm: ('Do you want to extract the expression ''<1s>'' into a variable in method ''',
-			ref sourceSelector,''' ?' expandMacrosWith: aString)) not ] .
+		(self confirm: ('Do you want to extract the expression ''<1s>'' into a variable in method ''<2s>''?' expandMacrosWith: aString with: ref sourceSelector)) not ] .
 	^ refactoring
 ]
 

--- a/src/SystemCommands-MessageCommands/SycInlineAllSendersMessageCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycInlineAllSendersMessageCommand.class.st
@@ -26,7 +26,9 @@ SycInlineAllSendersMessageCommand >> createRefactoring [
 		model: model
 		sendersOf: originalMessage selector 
 		in: methodOrigin.
-	refactoring setOption: #inlineExpression toUse: [ :ref :aString | self confirm: ('Do you want to inline the expression ''<1s>'' in the current method?' expandMacrosWith: aString) ] .
+	refactoring setOption: #inlineExpression toUse: [ :ref :aString | 
+		(self confirm: ('Do you want to extract the expression ''<1s>'' into a variable in method ''',
+			ref sourceSelector,''' ?' expandMacrosWith: aString)) not ] .
 	^ refactoring
 ]
 

--- a/src/SystemCommands-SourceCodeCommands/SycInlineMethodCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycInlineMethodCommand.class.st
@@ -23,9 +23,9 @@ SycInlineMethodCommand >> asRefactorings [
 		    inMethod: method selector
 		    forClass: method origin)
 		   setOption: #inlineExpression toUse: [ :ref :aString | 
-			   self confirm:
-					   ('Do you want to inline the expression ''<1s>'' in the current method?' 
-						    expandMacrosWith: aString) ];
+			   (self confirm: 
+					('Do you want to extract the expression ''<1s>'' into a variable in the current method?'
+					 	expandMacrosWith: aString)) not ];
 		   yourself) }
 ]
 


### PR DESCRIPTION
Fixes #10994 .
This solution improves the confirmation message for user's clarity.
The refactoring is working well and the buttons 'yes' and 'no' do their job, but this is hard to see because the inline refactoring formats the code, making it hard for the user to see the difference between the two options 
