### PR TITLE
11001-Stateful-Traits-Adding-One-Corrupts-Existing-Instances

### DIFF
--- a/src/Shift-Changes/ShSlotChangeDetector.class.st
+++ b/src/Shift-Changes/ShSlotChangeDetector.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #initialization }
 ShSlotChangeDetector >> initialize [
 	super initialize.
-	builderAccessor := [ :e | e layoutDefinition allSlots asArray ].
+	builderAccessor := [ :e | e allSlots asArray ].
 	classAccessor := [ :e | e allSlots asArray].
-	comparer := [ :a :b |  self compareSlotCollection: a with: b ]
+	comparer := [ :a :b | self compareSlotCollection: a with: b ]
 ]

--- a/src/Shift-ClassBuilder/ShDefaultBuilderEnhancer.class.st
+++ b/src/Shift-ClassBuilder/ShDefaultBuilderEnhancer.class.st
@@ -23,6 +23,12 @@ ShDefaultBuilderEnhancer >> afterMethodsCompiled: builder [
 ShDefaultBuilderEnhancer >> afterMigratingClass: aBuilder installer: anInstaller [
 ]
 
+{ #category : #accessing }
+ShDefaultBuilderEnhancer >> allSlotsForBuilder: aBuilder [
+
+	^ aBuilder layoutDefinition allSlots
+]
+
 { #category : #migrating }
 ShDefaultBuilderEnhancer >> beforeMigratingClass: aBuilder installer: anInstaller [
 ]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -60,6 +60,12 @@ ShiftClassBuilder >> addChangeComparer: aChangeComparer [
 	changeComparers add: aChangeComparer.
 ]
 
+{ #category : #accessing }
+ShiftClassBuilder >> allSlots [ 
+	
+	^ self builderEnhancer allSlotsForBuilder: self
+]
+
 { #category : #building }
 ShiftClassBuilder >> build [	
 	self tryToFillOldClass.

--- a/src/TraitsV2-Tests/T2TraitWithSlotsTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithSlotsTest.class.st
@@ -27,6 +27,22 @@ T2TraitWithSlotsTest >> createT1 [
 ]
 
 { #category : #tests }
+T2TraitWithSlotsTest >> testAddingStatefulTraitToClassAddsInstanceVariable [
+
+	| t1 c1 obj |
+	t1 := self newTrait: #T1 with: #(aSlot).
+	c1 := self newClass: #C1 superclass: Object with: #(anotherSlot) uses: {}. 
+
+	obj := c1 new.
+
+	self should: [ obj instVarAt: 2 ] raise: PrimitiveFailed.	
+
+	c1 := self newClass: #C1 superclass: Object with: #(anotherSlot) uses: {t1}.	
+
+	self assert: (obj instVarAt: 2) isNil. 
+]
+
+{ #category : #tests }
 T2TraitWithSlotsTest >> testClassUsingStatefulTraits [
 
 	| t1 c1 |

--- a/src/TraitsV2/TraitBuilderEnhancer.class.st
+++ b/src/TraitsV2/TraitBuilderEnhancer.class.st
@@ -63,6 +63,18 @@ TraitBuilderEnhancer >> afterMigratingClass: aBuilder installer: anInstaller [
 	aBuilder newClass traitUsers do: [:e | e rebuildMethodDictionary].
 ]
 
+{ #category : #accessing }
+TraitBuilderEnhancer >> allSlotsForBuilder: aBuilder [
+
+	| resultingSlots |
+	
+	resultingSlots := self
+		eliminateDuplicates: aBuilder layoutDefinition slots , aBuilder traitComposition asTraitComposition slotsCopy
+		withSuperclassSlots: (aBuilder superclass ifNil: [#()] ifNotNil:[ :x | x allSlots]).
+
+	^ resultingSlots
+]
+
 { #category : #migrating }
 TraitBuilderEnhancer >> beforeMigratingClass: aBuilder installer: anInstaller [
 	aBuilder oldClass ifNil: [ ^ self ].
@@ -114,9 +126,7 @@ TraitBuilderEnhancer >> configureClass: newClass superclass: superclass withLayo
 	| resultingSlots |
 	self validateTraitComposition: self traitComposition ofClass: builder oldClass.
 
-	resultingSlots := self
-		eliminateDuplicates: slots , self traitComposition slotsCopy
-		withSuperclassSlots: (superclass ifNil: [#()] ifNotNil:[ :x | x allSlots]).
+	resultingSlots := self allSlotsForBuilder: builder.
 
 	newClass superclass: superclass withLayoutType: layoutType slots: resultingSlots
 ]


### PR DESCRIPTION
Correctly calculating when a class should migrate the instances.
Fix #11001