### PR TITLE
use fixed spec version (for release)

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -18,7 +18,7 @@ BaselineOfPharo class >> declareExternalProjects [
 
 	^ { 
 	PharoExternalProject newName: 'Iceberg' owner: 'pharo-vcs' project: 'iceberg' version: 'dev-2.0' sourceDir: nil.
-	PharoExternalProject newName: 'Spec2' owner: 'pharo-spec' project:'Spec' version: 'Pharo10'.
+	PharoExternalProject newName: 'Spec2' owner: 'pharo-spec' project:'Spec' version: 'v1.1.0'.
 	PharoExternalProject newName: 'NewTools' owner: 'pharo-spec' project: 'NewTools' version: 'Pharo10'.	
 	PharoExternalProject newName: 'Microdown' owner: 'pillar-markup' project: 'Microdown' version: 'integration'.	
 	PharoExternalProject newName: 'BeautifulComments' owner: 'pillar-markup' project: 'BeautifulComments' version: 'integration'.	


### PR DESCRIPTION
use fixed spec version for release.

https://github.com/pharo-spec/Spec/releases/tag/v1.1.0

# Changes overview

- deprecation of class side defaultSpec, now all layouts can be defined in instance side (but defaultLayout can still be defined in class side, in case of need)
- deprecation of all WithSpec suffixes. Now to open a presenter window you just use #open/#openModal, etc. (this was a lot more work as you may think).
- added #asWindow, #asModalWindow to allow user to modify the window presenter (adding extent, ot title, for example) without needingto override `initializeWindow:` and before the window is opened.
- all layouts are dynamic and can be modified on runtime (API depending the layout). 
- enhancement SpApplication with notion of iconProvider
- added some standard dialogs (inform, request, confirm) to SpApplication
- added a progress bar standard dialog/processor (SpJobListPresenter) 
- enhanced Common-Widgets: SpFilteringListPresenter, etc.
- many improvements to SpCodePresenter, including syntax highlight, better code operations, text search, etc. 
- implemented drag&drop (not all widget, but required).
- enhanced styleSheets usage
- box, grid and scrollable layouts implement SpTAlignable (to better place its contents).
- enhanced API for building grid layouts.
- fix any remaining memory leak (some may remain, as always... but we removed all we found ;)

... and many, many tweaks and bugfixes!