### PR TITLE
Fix Cmd-t again 

### DIFF
--- a/src/SystemCommands-SourceCodeCommands/SycOpenAdvancedDebuggingMenuCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycOpenAdvancedDebuggingMenuCommand.class.st
@@ -4,13 +4,19 @@ I show in the menu all commands annotated by SycAdvancedDebuggingMenuActivation
 "
 Class {
 	#name : #SycOpenAdvancedDebuggingMenuCommand,
-	#superclass : #SycOpenSourceCodeMenuCommand,
+	#superclass : #SycOpenContextMenuCommand,
 	#category : #'SystemCommands-SourceCodeCommands'
 }
 
 { #category : #execution }
 SycOpenAdvancedDebuggingMenuCommand >> activationStrategy [
 	^SycAdvancedDebuggingMenuActivation
+]
+
+{ #category : #'context menu' }
+SycOpenAdvancedDebuggingMenuCommand >> cmCommandClass [
+
+	^ SycSourceCodeCmCommand
 ]
 
 { #category : #accessing }

--- a/src/SystemCommands-SourceCodeCommands/SycOpenDebuggingMenuCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycOpenDebuggingMenuCommand.class.st
@@ -4,13 +4,19 @@ I show in the menu all commands annotated by SycDebuggingMenuActivation
 "
 Class {
 	#name : #SycOpenDebuggingMenuCommand,
-	#superclass : #SycOpenSourceCodeMenuCommand,
+	#superclass : #SycOpenContextMenuCommand,
 	#category : #'SystemCommands-SourceCodeCommands'
 }
 
 { #category : #execution }
 SycOpenDebuggingMenuCommand >> activationStrategy [
 	^SycDebuggingMenuActivation
+]
+
+{ #category : #'context menu' }
+SycOpenDebuggingMenuCommand >> cmCommandClass [
+
+	^ SycSourceCodeCmCommand
 ]
 
 { #category : #accessing }

--- a/src/SystemCommands-SourceCodeCommands/SycOpenReflectivityMenuCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycOpenReflectivityMenuCommand.class.st
@@ -4,13 +4,19 @@ I show in the menu all commands annotated by SycReflectiveActivation
 "
 Class {
 	#name : #SycOpenReflectivityMenuCommand,
-	#superclass : #SycOpenSourceCodeMenuCommand,
+	#superclass : #SycOpenContextMenuCommand,
 	#category : #'SystemCommands-SourceCodeCommands'
 }
 
 { #category : #execution }
 SycOpenReflectivityMenuCommand >> activationStrategy [
 	^SycReflectivityMenuActivation
+]
+
+{ #category : #'context menu' }
+SycOpenReflectivityMenuCommand >> cmCommandClass [
+
+	^ SycSourceCodeCmCommand
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This PR fixes cmd-t by making sure that SycOpenSourceCodeMenuCommand has no subclasses, as they interfere

fixes  #10854 (again)