### PR TITLE
this change enables click + control, and click + alt in morphic

### DIFF
--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -3039,14 +3039,6 @@ Morph >> handlerForBlueButtonDown: anEvent [
 		ifTrue: [ "let me have it" self ]
 ]
 
-{ #category : #'meta-actions' }
-Morph >> handlerForMetaMenu: evt [
-	"Return the prospective handler for invoking the meta menu. By default, the top-most morph in the innermost world gets this menu"
-	self isWorldMorph ifTrue:[^self].
-	evt handler ifNotNil:[evt handler isWorldMorph ifTrue:[^self]].
-	^nil
-]
-
 { #category : #'event handling' }
 Morph >> handlerForMouseDown: anEvent [ 
 	"Return the (prospective) handler for a mouse down event. The handler is temporarily 
@@ -3057,8 +3049,6 @@ Morph >> handlerForMouseDown: anEvent [
 		ifTrue: [^ self handlerForBlueButtonDown: anEvent].
 	anEvent yellowButtonPressed
 		ifTrue: [^ self handlerForYellowButtonDown: anEvent].
-	anEvent controlKeyPressed
-		ifTrue: [^ self handlerForMetaMenu: anEvent].
 	(self handlesMouseDown: anEvent)
 		ifFalse: [^ nil].	"not interested"
 

--- a/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
+++ b/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
@@ -99,9 +99,6 @@ OSWindowMorphicEventHandler >> activeHand [
 { #category : #converting }
 OSWindowMorphicEventHandler >> convertButtonFromEvent: anEvent [
 
-	(self class simulateMiddleClick and: [anEvent button = 1 and: [ anEvent modifiers alt ]])
-		ifTrue: [ ^ MouseButtonEvent blueButton ].
-
 	anEvent button = 1 ifTrue: [ ^ MouseButtonEvent redButton ].
 	anEvent button = 2 ifTrue: [ ^ MouseButtonEvent blueButton ].
 	anEvent button = 3 ifTrue: [ ^ MouseButtonEvent yellowButton ].
@@ -112,14 +109,7 @@ OSWindowMorphicEventHandler >> convertModifiers: modifiers [
 	| buttons |
 	buttons := 0.
 	
-	"Alt/Option key"
-	modifiers alt ifTrue: [
-		"On windows and unix, treat alt key as command key"
-		buttons := Smalltalk os isWin32 | Smalltalk os isUnix
-			ifTrue: [ buttons | 2r01000000 ]
-			ifFalse: [ buttons | 2r00100000 ]
-	]. 
-	
+	modifiers alt ifTrue: [ buttons := buttons | 2r00100000 ]. "Alt key"
 	modifiers ctrl ifTrue: [ buttons := buttons | 2r00010000 ]. "Control key"
 	modifiers shift ifTrue: [ buttons := buttons | 8 ]. "Shift key"
 	modifiers cmd ifTrue: [ buttons := buttons | 2r01000000 ]. "Cmd key"


### PR DESCRIPTION
handlerForMeta not used anymore then is removed
this pull request is for
- https://github.com/pharo-project/pharo/issues/11031