### PR TITLE
Fixing shortcuts for Debugging, Reflective and Breakpoint commands

### DIFF
--- a/src/Calypso-SystemTools-Core/SycOpenReflectivityMenuCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycOpenReflectivityMenuCommand.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #SycOpenReflectivityMenuCommand }
 
 { #category : #'*Calypso-SystemTools-Core' }
+SycOpenReflectivityMenuCommand class >> methodEditorShortcutActivation [
+	<classAnnotation>
+	
+	^CmdShortcutActivation by: $r meta shift for: ClySourceCodeContext
+]
+
+{ #category : #'*Calypso-SystemTools-Core' }
 SycOpenReflectivityMenuCommand class >> sourceCodeMenuActivation [
 	<classAnnotation>
 	

--- a/src/Calypso-SystemTools-Core/SycOpenReflectivityMenuCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycOpenReflectivityMenuCommand.extension.st
@@ -1,13 +1,6 @@
 Extension { #name : #SycOpenReflectivityMenuCommand }
 
 { #category : #'*Calypso-SystemTools-Core' }
-SycOpenReflectivityMenuCommand class >> methodEditorShortcutActivation [
-	<classAnnotation>
-	
-	^CmdShortcutActivation by: $r meta shift for: ClySourceCodeContext
-]
-
-{ #category : #'*Calypso-SystemTools-Core' }
 SycOpenReflectivityMenuCommand class >> sourceCodeMenuActivation [
 	<classAnnotation>
 	

--- a/src/SystemCommands-MethodCommands/SycOpenAdvancedDebuggingInMethodMenuCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycOpenAdvancedDebuggingInMethodMenuCommand.class.st
@@ -19,7 +19,7 @@ SycOpenAdvancedDebuggingInMethodMenuCommand class >> methodContextMenuActivation
 SycOpenAdvancedDebuggingInMethodMenuCommand class >> methodEditorShortcutActivation [
 	<classAnnotation>
 	
-	^CmdShortcutActivation by: $h meta for: ClyMethod asCalypsoItemContext
+	^CmdShortcutActivation by: $h meta shift for: ClyMethod asCalypsoItemContext
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-MethodCommands/SycOpenDebuggingInMethodMenuCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycOpenDebuggingInMethodMenuCommand.class.st
@@ -19,7 +19,7 @@ SycOpenDebuggingInMethodMenuCommand class >> methodContextMenuActivation [
 SycOpenDebuggingInMethodMenuCommand class >> methodEditorShortcutActivation [
 	<classAnnotation>
 	
-	^CmdShortcutActivation by: $g meta for: ClyMethod asCalypsoItemContext
+	^CmdShortcutActivation by: $g meta shift for: ClyMethod asCalypsoItemContext
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-MethodCommands/SycOpenMethodMenuCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycOpenMethodMenuCommand.class.st
@@ -22,12 +22,3 @@ SycOpenMethodMenuCommand >> cmCommandClass [
 SycOpenMethodMenuCommand >> defaultMenuItemName [
 	^'Refactorings'
 ]
-
-{ #category : #execution }
-SycOpenMethodMenuCommand >> execute [
-
-	context selectedTextInterval ifEmpty: [ 
-		context showSourceNode].
-	
-	super execute
-]

--- a/src/SystemCommands-MethodCommands/SycOpenReflectivityInMethodMenuCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycOpenReflectivityInMethodMenuCommand.class.st
@@ -19,7 +19,7 @@ SycOpenReflectivityInMethodMenuCommand class >> methodContextMenuActivation [
 SycOpenReflectivityInMethodMenuCommand class >> methodEditorShortcutActivation [
 	<classAnnotation>
 	
-	^CmdShortcutActivation by: $r meta for: ClyMethod asCalypsoItemContext
+	^CmdShortcutActivation by: $r meta shift for: ClyMethod asCalypsoItemContext
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-MethodCommands/SycOpenReflectivityInMethodMenuCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycOpenReflectivityInMethodMenuCommand.class.st
@@ -15,13 +15,6 @@ SycOpenReflectivityInMethodMenuCommand class >> methodContextMenuActivation [
 	^CmdContextMenuActivation byRootGroupItemOrder: 1.5 for: ClyMethod asCalypsoItemContext
 ]
 
-{ #category : #activation }
-SycOpenReflectivityInMethodMenuCommand class >> methodEditorShortcutActivation [
-	<classAnnotation>
-	
-	^CmdShortcutActivation by: $r meta shift for: ClyMethod asCalypsoItemContext
-]
-
 { #category : #execution }
 SycOpenReflectivityInMethodMenuCommand >> activationStrategy [
 	^SycReflectivityMenuActivation


### PR DESCRIPTION
Fixes #10956 by adding 'shift' to the shortcuts of Debugging, Reflective and Breakpoint commands